### PR TITLE
fix(oauth): prevent duplicate connections on re-authentication

### DIFF
--- a/src/lib/db/providers.js
+++ b/src/lib/db/providers.js
@@ -50,6 +50,16 @@ export async function createProviderConnection(data) {
         "SELECT * FROM provider_connections WHERE provider = ? AND auth_type = 'oauth' AND email = ?"
       )
       .get(data.provider, data.email);
+  } else if (data.authType === "oauth" && !data.email) {
+    // Fallback for providers that don't return email (e.g. Codex):
+    // find the most recent failed connection for this provider to update instead of duplicating
+    existing = db
+      .prepare(
+        `SELECT * FROM provider_connections WHERE provider = ? AND auth_type = 'oauth'
+         AND (test_status = 'auth_failed' OR test_status = 'refresh_failed' OR test_status = 'error')
+         ORDER BY updated_at DESC LIMIT 1`
+      )
+      .get(data.provider);
   } else if (data.authType === "apikey" && data.name) {
     existing = db
       .prepare(


### PR DESCRIPTION
For providers that don't return email (e.g. Codex), re-authenticating always created a new 'Account N' entry. Added fallback upsert: when no email is available, find the most recent auth_failed/refresh_failed connection and update it.