### PR TITLE
fix(oauth): broaden upsert to match any existing connection

### DIFF
--- a/src/lib/db/providers.js
+++ b/src/lib/db/providers.js
@@ -51,12 +51,11 @@ export async function createProviderConnection(data) {
       )
       .get(data.provider, data.email);
   } else if (data.authType === "oauth" && !data.email) {
-    // Fallback for providers that don't return email (e.g. Codex):
-    // find the most recent failed connection for this provider to update instead of duplicating
+    // Fallback for providers that don't return email (e.g. Codex, Qwen):
+    // find the most recently updated connection for this provider to update instead of duplicating
     existing = db
       .prepare(
         `SELECT * FROM provider_connections WHERE provider = ? AND auth_type = 'oauth'
-         AND (test_status = 'auth_failed' OR test_status = 'refresh_failed' OR test_status = 'error')
          ORDER BY updated_at DESC LIMIT 1`
       )
       .get(data.provider);


### PR DESCRIPTION
Remove test_status restriction from the no-email upsert fallback. Now matches any existing OAuth connection for the same provider, preventing duplicates regardless of status.