### PR TITLE
feat(proxy): enable SOCKS5 proxy support by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,9 +37,9 @@ NEXT_PUBLIC_CLOUD_URL=https://omniroute.com
 
 # Optional outbound proxy variables for upstream provider calls
 # Lowercase variants are also supported: http_proxy, https_proxy, all_proxy, no_proxy
-# Enable socks5 support only when rollout is approved
-# ENABLE_SOCKS5_PROXY=false
-# NEXT_PUBLIC_ENABLE_SOCKS5_PROXY=false
+# SOCKS5 proxy support
+ENABLE_SOCKS5_PROXY=true
+NEXT_PUBLIC_ENABLE_SOCKS5_PROXY=true
 # HTTP_PROXY=http://127.0.0.1:7890
 # HTTPS_PROXY=http://127.0.0.1:7890
 # ALL_PROXY=socks5://127.0.0.1:7890


### PR DESCRIPTION
SOCKS5 was already fully implemented. Enable the feature flags to show SOCKS5 option in the settings UI.