### PR TITLE
fix(sync): disable cloud sync and truncate error logs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,10 +30,10 @@ REQUIRE_API_KEY=false
 # Must point to this running instance so internal sync jobs can call /api/sync/cloud.
 # Server-side preferred variables:
 BASE_URL=http://localhost:20128
-CLOUD_URL=https://omniroute.com
+CLOUD_URL=
 # Backward-compatible/public variables:
 NEXT_PUBLIC_BASE_URL=http://localhost:20128
-NEXT_PUBLIC_CLOUD_URL=https://omniroute.com
+NEXT_PUBLIC_CLOUD_URL=
 
 # Optional outbound proxy variables for upstream provider calls
 # Lowercase variants are also supported: http_proxy, https_proxy, all_proxy, no_proxy

--- a/src/lib/cloudSync.js
+++ b/src/lib/cloudSync.js
@@ -55,7 +55,8 @@ export async function syncToCloud(machineId, createdKey = null) {
 
   if (!response.ok) {
     const errorText = await response.text();
-    console.log("Cloud sync failed:", errorText);
+    const truncated = errorText.length > 200 ? errorText.slice(0, 200) + "…" : errorText;
+    console.log(`Cloud sync failed (${response.status}):`, truncated);
     return { error: "Cloud sync failed" };
   }
 


### PR DESCRIPTION
CLOUD_URL was pointing to omniroute.com which doesn't have a /sync/ endpoint, causing repeated 404 HTML dumps in console logs.