### PR TITLE
chore(ui): rebrand to OmniRoute

### DIFF
--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -9,9 +9,9 @@ const inter = Inter({
 });
 
 export const metadata = {
-  title: "OmniRoute - AI Infrastructure Management",
+  title: "OmniRoute — AI Gateway for Multi-Provider LLMs",
   description:
-    "One endpoint for all your AI providers. Manage keys, monitor usage, and scale effortlessly.",
+    "OmniRoute is an AI gateway for multi-provider LLMs. One endpoint for all your AI providers.",
   icons: {
     icon: "/favicon.svg",
   },

--- a/src/shared/constants/config.js
+++ b/src/shared/constants/config.js
@@ -2,8 +2,8 @@ import pkg from "../../../package.json" with { type: "json" };
 
 // App configuration
 export const APP_CONFIG = {
-  name: "Endpoint Proxy",
-  description: "AI Infrastructure Management",
+  name: "OmniRoute",
+  description: "AI Gateway for Multi-Provider LLMs",
   version: pkg.version,
 };
 


### PR DESCRIPTION
Sidebar, page title, footer all now show 'OmniRoute' instead of 'Endpoint Proxy'.