### PR TITLE
fix(ci): fix npm publish auth — support vars.NPM_TOKEN

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -36,6 +36,6 @@ jobs:
           echo "Publishing version: $VERSION"
 
       - name: Publish to npm
-        run: npm publish --provenance --access public
+        run: npm publish --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN || vars.NPM_TOKEN }}


### PR DESCRIPTION
Fix ENEEDAUTH error by supporting NPM_TOKEN from both secrets and vars. Remove --provenance flag.