### PR TITLE
fix(ci): add environment for npm token access

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: NPM_TOKEN
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -35,18 +36,7 @@ jobs:
           npm version "$VERSION" --no-git-tag-version --allow-same-version
           echo "Publishing version: $VERSION"
 
-      - name: Configure npm auth
-        run: |
-          TOKEN="${NPM_TOKEN_SECRET:-$NPM_TOKEN_VAR}"
-          if [ -z "$TOKEN" ]; then
-            echo "❌ NPM_TOKEN not found in secrets or vars"
-            exit 1
-          fi
-          echo "//registry.npmjs.org/:_authToken=${TOKEN}" > ~/.npmrc
-          echo "✅ npm auth configured"
-        env:
-          NPM_TOKEN_SECRET: ${{ secrets.NPM_TOKEN }}
-          NPM_TOKEN_VAR: ${{ vars.NPM_TOKEN }}
-
       - name: Publish to npm
         run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
The NPM_TOKEN is an environment-scoped secret. Add `environment: NPM_TOKEN` to the job.