### PR TITLE
feat(pipeline): wire 7 backend modules into request pipeline

### DIFF
--- a/src/proxy.js
+++ b/src/proxy.js
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
 import { jwtVerify } from "jose";
+import { fetchWithTimeout } from "./shared/utils/fetchTimeout.js";
+import { generateRequestId } from "./shared/utils/requestId.js";
 
 // FASE-01: Fail-fast — no hardcoded fallback. Server must have JWT_SECRET configured.
 if (!process.env.JWT_SECRET) {
@@ -11,11 +13,16 @@ const SECRET = new TextEncoder().encode(process.env.JWT_SECRET);
 export async function proxy(request) {
   const { pathname } = request.nextUrl;
 
+  // Pipeline: Add request ID header for end-to-end tracing
+  const requestId = generateRequestId();
+  const response = NextResponse.next();
+  response.headers.set("X-Request-Id", requestId);
+
   // Protect all dashboard routes (except onboarding)
   if (pathname.startsWith("/dashboard")) {
     // Always allow onboarding — it has its own setupComplete guard
     if (pathname.startsWith("/dashboard/onboarding")) {
-      return NextResponse.next();
+      return response;
     }
 
     const token = request.cookies.get("auth_token")?.value;
@@ -23,12 +30,13 @@ export async function proxy(request) {
     if (token) {
       try {
         await jwtVerify(token, SECRET);
-        return NextResponse.next();
+        return response;
       } catch (err) {
         // FASE-01: Log auth errors instead of silently redirecting
         console.error("[Middleware] auth_error: JWT verification failed:", err.message, {
           path: pathname,
           tokenPresent: true,
+          requestId,
         });
         return NextResponse.redirect(new URL("/login", request.url));
       }
@@ -36,22 +44,24 @@ export async function proxy(request) {
 
     const origin = request.nextUrl.origin;
     try {
-      const res = await fetch(`${origin}/api/settings`);
+      // Pipeline: Use fetchWithTimeout instead of bare fetch
+      const res = await fetchWithTimeout(`${origin}/api/settings`, { timeoutMs: 5000 });
       const data = await res.json();
       // Skip auth if login is not required
       if (data.requireLogin === false) {
-        return NextResponse.next();
+        return response;
       }
       // Skip auth if no password has been set yet (fresh install)
       // This prevents an unresolvable loop where requireLogin=true but no password exists
       if (!data.hasPassword) {
-        return NextResponse.next();
+        return response;
       }
     } catch (err) {
       // FASE-01: Log settings fetch errors instead of silencing them
       console.error("[Middleware] settings_error: Settings fetch failed:", err.message, {
         path: pathname,
         origin,
+        requestId,
       });
       // On error, require login
     }
@@ -63,9 +73,10 @@ export async function proxy(request) {
     return NextResponse.redirect(new URL("/dashboard", request.url));
   }
 
-  return NextResponse.next();
+  return response;
 }
 
 export const config = {
   matcher: ["/", "/dashboard/:path*"],
 };
+

--- a/src/server-init.js
+++ b/src/server-init.js
@@ -1,10 +1,29 @@
 // Server startup script
 import initializeCloudSync from "./shared/services/initializeCloudSync.js";
 import { enforceSecrets } from "./shared/utils/secretsValidator.js";
+import { initAuditLog, cleanupExpiredLogs, logAuditEvent } from "./lib/compliance/index.js";
 
 async function startServer() {
   // FASE-01: Validate required secrets before anything else (fail-fast)
   enforceSecrets();
+
+  // Compliance: Initialize audit_log table
+  try {
+    initAuditLog();
+    console.log("[COMPLIANCE] Audit log table initialized");
+  } catch (err) {
+    console.warn("[COMPLIANCE] Could not initialize audit log:", err.message);
+  }
+
+  // Compliance: One-time cleanup of expired logs
+  try {
+    const cleanup = cleanupExpiredLogs();
+    if (cleanup.deletedUsage || cleanup.deletedCallLogs || cleanup.deletedAuditLogs) {
+      console.log("[COMPLIANCE] Expired log cleanup:", cleanup);
+    }
+  } catch (err) {
+    console.warn("[COMPLIANCE] Log cleanup failed:", err.message);
+  }
 
   console.log("Starting server with cloud sync...");
 
@@ -12,6 +31,9 @@ async function startServer() {
     // Initialize cloud sync
     await initializeCloudSync();
     console.log("Server started with cloud sync initialized");
+
+    // Log server start event to audit log
+    logAuditEvent({ action: "server.start", details: { timestamp: new Date().toISOString() } });
   } catch (error) {
     console.log("Error initializing cloud sync:", error);
     process.exit(1);
@@ -23,3 +45,4 @@ startServer().catch(console.log);
 
 // Export for use as module if needed
 export default startServer;
+


### PR DESCRIPTION
## Batch 1 — Pipeline Wiring

Wires 7 previously standalone backend modules into the live request flow:

### server-init.js
- Initialize compliance `audit_log` table on startup
- Run one-time expired log cleanup (`LOG_RETENTION_DAYS`)
- Log `server.start` audit event

### chat.js (SSE handler)
- **circuitBreaker**: Wraps provider calls — auto-opens after 5 failures, half-open after 30s
- **modelAvailability**: TTL cooldowns — marks models unavailable on 429/503 for 60s
- **requestTelemetry**: 7-phase lifecycle measurement (parse→validate→policy→resolve→connect→stream→finalize)
- **requestId**: Generates unique ID per request for tracing
- **costRules**: Budget check before request, cost recording after success
- **compliance**: Audit logging of server events

### proxy.js (middleware)
- Replace bare `fetch()` with `fetchWithTimeout` (5s timeout on /api/settings)
- Add `X-Request-Id` header for end-to-end tracing

### Verification
- ✅ 307/307 tests pass
- ✅ Build succeeds (exit code 0)
- ✅ All wiring is non-breaking (try/catch guards, best-effort)