### PR TITLE
feat(api): create 9 API routes for backend module access

### DIFF
--- a/src/app/api/cache/stats/route.js
+++ b/src/app/api/cache/stats/route.js
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import { getPromptCache } from "@/lib/cacheLayer";
+
+export async function GET() {
+  try {
+    const cache = getPromptCache();
+    const stats = cache.getStats();
+    return NextResponse.json(stats);
+  } catch (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}
+
+export async function DELETE() {
+  try {
+    const cache = getPromptCache();
+    cache.clear();
+    return NextResponse.json({ success: true, message: "Cache cleared" });
+  } catch (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}

--- a/src/app/api/compliance/audit-log/route.js
+++ b/src/app/api/compliance/audit-log/route.js
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+import { getAuditLog, logAuditEvent } from "@/lib/compliance/index";
+
+export async function GET(request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const action = searchParams.get("action") || undefined;
+    const actor = searchParams.get("actor") || undefined;
+    const limit = parseInt(searchParams.get("limit") || "50", 10);
+    const offset = parseInt(searchParams.get("offset") || "0", 10);
+
+    const logs = getAuditLog({ action, actor, limit, offset });
+    return NextResponse.json(logs);
+  } catch (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}

--- a/src/app/api/evals/[suiteId]/route.js
+++ b/src/app/api/evals/[suiteId]/route.js
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+import { getSuite } from "@/lib/evals/evalRunner";
+
+export async function GET(request, { params }) {
+  try {
+    const { suiteId } = await params;
+    const suite = getSuite(suiteId);
+    if (!suite) {
+      return NextResponse.json({ error: `Suite not found: ${suiteId}` }, { status: 404 });
+    }
+    return NextResponse.json(suite);
+  } catch (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}

--- a/src/app/api/evals/route.js
+++ b/src/app/api/evals/route.js
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+import { listSuites, runSuite } from "@/lib/evals/evalRunner";
+
+export async function GET() {
+  try {
+    const suites = listSuites();
+    return NextResponse.json(suites);
+  } catch (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}
+
+export async function POST(request) {
+  try {
+    const { suiteId, outputs } = await request.json();
+    if (!suiteId || !outputs) {
+      return NextResponse.json(
+        { error: "suiteId and outputs (Record<caseId, actualOutput>) are required" },
+        { status: 400 }
+      );
+    }
+    const result = runSuite(suiteId, outputs);
+    return NextResponse.json(result);
+  } catch (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}

--- a/src/app/api/fallback/chains/route.js
+++ b/src/app/api/fallback/chains/route.js
@@ -1,0 +1,44 @@
+import { NextResponse } from "next/server";
+import {
+  getAllFallbackChains,
+  registerFallback,
+  removeFallback,
+} from "@/domain/fallbackPolicy";
+
+export async function GET() {
+  try {
+    const chains = getAllFallbackChains();
+    return NextResponse.json(chains);
+  } catch (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}
+
+export async function POST(request) {
+  try {
+    const { model, chain } = await request.json();
+    if (!model || !Array.isArray(chain)) {
+      return NextResponse.json(
+        { error: "model (string) and chain (array of {provider, priority?, enabled?}) are required" },
+        { status: 400 }
+      );
+    }
+    registerFallback(model, chain);
+    return NextResponse.json({ success: true, model });
+  } catch (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}
+
+export async function DELETE(request) {
+  try {
+    const { model } = await request.json();
+    if (!model) {
+      return NextResponse.json({ error: "model is required" }, { status: 400 });
+    }
+    const removed = removeFallback(model);
+    return NextResponse.json({ success: true, removed });
+  } catch (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}

--- a/src/app/api/models/availability/route.js
+++ b/src/app/api/models/availability/route.js
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import {
+  getAvailabilityReport,
+  clearModelUnavailability,
+  getUnavailableCount,
+} from "@/domain/modelAvailability";
+
+export async function GET() {
+  try {
+    const report = getAvailabilityReport();
+    const count = getUnavailableCount();
+    return NextResponse.json({ unavailableCount: count, models: report });
+  } catch (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}
+
+export async function POST(request) {
+  try {
+    const { provider, model } = await request.json();
+    if (!provider || !model) {
+      return NextResponse.json({ error: "provider and model are required" }, { status: 400 });
+    }
+    const removed = clearModelUnavailability(provider, model);
+    return NextResponse.json({ success: true, removed });
+  } catch (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}

--- a/src/app/api/policies/route.js
+++ b/src/app/api/policies/route.js
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import {
+  getAllCircuitBreakerStatuses,
+} from "@/shared/utils/circuitBreaker";
+import {
+  getLockedIdentifiers,
+  forceUnlock,
+} from "@/domain/lockoutPolicy";
+
+export async function GET() {
+  try {
+    const circuitBreakers = getAllCircuitBreakerStatuses();
+    const lockedIdentifiers = getLockedIdentifiers();
+    return NextResponse.json({ circuitBreakers, lockedIdentifiers });
+  } catch (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}
+
+export async function POST(request) {
+  try {
+    const { action, identifier } = await request.json();
+
+    if (action === "unlock" && identifier) {
+      forceUnlock(identifier);
+      return NextResponse.json({ success: true, action: "unlocked", identifier });
+    }
+
+    return NextResponse.json({ error: "Unknown action. Supported: unlock" }, { status: 400 });
+  } catch (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}

--- a/src/app/api/telemetry/summary/route.js
+++ b/src/app/api/telemetry/summary/route.js
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server";
+import { getTelemetrySummary } from "@/shared/utils/requestTelemetry";
+
+export async function GET(request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const windowMs = parseInt(searchParams.get("windowMs") || "300000", 10);
+    const summary = getTelemetrySummary(windowMs);
+    return NextResponse.json(summary);
+  } catch (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}

--- a/src/app/api/usage/budget/route.js
+++ b/src/app/api/usage/budget/route.js
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+import { getCostSummary, setBudget, checkBudget } from "@/domain/costRules";
+
+export async function GET(request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const apiKeyId = searchParams.get("apiKeyId");
+    if (!apiKeyId) {
+      return NextResponse.json({ error: "apiKeyId query param is required" }, { status: 400 });
+    }
+    const summary = getCostSummary(apiKeyId);
+    const budgetCheck = checkBudget(apiKeyId);
+    return NextResponse.json({ ...summary, budgetCheck });
+  } catch (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}
+
+export async function POST(request) {
+  try {
+    const { apiKeyId, dailyLimitUsd, monthlyLimitUsd, warningThreshold } = await request.json();
+    if (!apiKeyId || !dailyLimitUsd) {
+      return NextResponse.json({ error: "apiKeyId and dailyLimitUsd are required" }, { status: 400 });
+    }
+    setBudget(apiKeyId, { dailyLimitUsd, monthlyLimitUsd, warningThreshold });
+    return NextResponse.json({ success: true, apiKeyId, dailyLimitUsd });
+  } catch (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Batch 2 — API Routes

Creates 9 new API endpoints that expose previously unreachable backend modules:

| Endpoint | Methods | Backend Module |
|----------|---------|---------------|
| `/api/cache/stats` | GET, DELETE | `cacheLayer` |
| `/api/models/availability` | GET, POST | `modelAvailability` |
| `/api/telemetry/summary` | GET | `requestTelemetry` |
| `/api/usage/budget` | GET, POST | `costRules` |
| `/api/fallback/chains` | GET, POST, DELETE | `fallbackPolicy` |
| `/api/compliance/audit-log` | GET | `compliance` |
| `/api/evals` | GET, POST | `evalRunner` |
| `/api/evals/[suiteId]` | GET | `evalRunner` |
| `/api/policies` | GET, POST | `circuitBreaker` + `lockoutPolicy` |

✅ Build succeeds (exit code 0)