### PR TITLE
feat(ui): export 6 shared components + notificationStore, wire into layout

### DIFF
--- a/src/shared/components/index.js
+++ b/src/shared/components/index.js
@@ -26,6 +26,12 @@ export { default as KiroOAuthWrapper } from "./KiroOAuthWrapper";
 export { default as KiroSocialOAuthModal } from "./KiroSocialOAuthModal";
 export { default as CursorAuthModal } from "./CursorAuthModal";
 export { default as SegmentedControl } from "./SegmentedControl";
+export { default as Breadcrumbs } from "./Breadcrumbs";
+export { default as EmptyState } from "./EmptyState";
+export { default as NotificationToast } from "./NotificationToast";
+export { default as FilterBar } from "./FilterBar";
+export { default as ColumnToggle } from "./ColumnToggle";
+export { default as DataTable } from "./DataTable";
 
 // Layouts
 export * from "./layouts";

--- a/src/shared/components/layouts/DashboardLayout.js
+++ b/src/shared/components/layouts/DashboardLayout.js
@@ -3,6 +3,8 @@
 import { useState } from "react";
 import Sidebar from "../Sidebar";
 import Header from "../Header";
+import Breadcrumbs from "../Breadcrumbs";
+import NotificationToast from "../NotificationToast";
 
 const SIDEBAR_COLLAPSED_KEY = "sidebar-collapsed";
 
@@ -54,9 +56,16 @@ export default function DashboardLayout({ children }) {
       >
         <Header onMenuClick={() => setSidebarOpen(true)} />
         <div className="flex-1 overflow-y-auto custom-scrollbar p-6 lg:p-10">
-          <div className="max-w-7xl mx-auto">{children}</div>
+          <div className="max-w-7xl mx-auto">
+            <Breadcrumbs />
+            {children}
+          </div>
         </div>
       </main>
+
+      {/* Global notification toast system */}
+      <NotificationToast />
     </div>
   );
 }
+

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -2,3 +2,4 @@
 export { default as useThemeStore } from "./themeStore";
 export { default as useUserStore } from "./userStore";
 export { default as useProviderStore } from "./providerStore";
+export { useNotificationStore } from "./notificationStore";


### PR DESCRIPTION
## Batch 3 — Barrel Exports + Layout

### Component Barrel (shared/components/index.js)
Added 6 exports: Breadcrumbs, EmptyState, NotificationToast, FilterBar, ColumnToggle, DataTable

### Store Barrel (store/index.js)
Added: useNotificationStore

### DashboardLayout
- Breadcrumbs rendered between Header and page content
- NotificationToast rendered as global fixed overlay

✅ Build succeeds (exit code 0)