### PR TITLE
fix(sse): resolve ghost import in chatHelpers.js (Phase 6.6)

### DIFF
--- a/src/sse/handlers/chatHelpers.js
+++ b/src/sse/handlers/chatHelpers.js
@@ -12,8 +12,11 @@
  */
 
 import { getModelInfo } from "../services/model.js";
-import { detectFormat, getTargetFormat, getModelTargetFormat } from "../services/translator.js";
-import { PROVIDER_ID_TO_ALIAS } from "../services/model.js";
+import { detectFormat, getTargetFormat } from "@omniroute/open-sse/services/provider.js";
+import {
+  getModelTargetFormat,
+  PROVIDER_ID_TO_ALIAS,
+} from "@omniroute/open-sse/config/providerModels.js";
 import { logProxyEvent } from "../../lib/proxyLogger.js";
 import { logTranslationEvent } from "../../lib/translatorEvents.js";
 import { updateProviderCredentials } from "../services/auth.js";


### PR DESCRIPTION
## Phase 6.6 — SSE Deduplication Analysis & Fix

### Analysis
`src/sse/` (7 files) is an **intentional adapter layer** over `open-sse/` (92 files) — NOT duplication:
- `model.js`: re-exports + localDb queries
- `tokenRefresh.js`: re-exports + logger injection
- `auth.js`, `streamState.js`: local-only modules
- `chat.js`, `chatHelpers.js`: app-level orchestration

### Bug Fixed
`chatHelpers.js` imported from `../services/translator.js` — **this file does not exist**.

Fixed to import from canonical sources:
- `detectFormat`, `getTargetFormat` → `@omniroute/open-sse/services/provider.js`
- `getModelTargetFormat`, `PROVIDER_ID_TO_ALIAS` → `@omniroute/open-sse/config/providerModels.js`

### Tests
295 pass (unchanged)