### PR TITLE
fix(api): resolve TypeError in chat/completions route

### DIFF
--- a/src/app/api/v1/chat/completions/route.js
+++ b/src/app/api/v1/chat/completions/route.js
@@ -9,7 +9,7 @@ let initPromise = null;
  */
 function ensureInitialized() {
   if (!initPromise) {
-    initPromise = initTranslators().then(() => {
+    initPromise = Promise.resolve(initTranslators()).then(() => {
       console.log("[SSE] Translators initialized");
     });
   }


### PR DESCRIPTION
**Bug:** `Cannot read properties of undefined (reading 'then')` in every chat completion request.

**Root cause:** `initTranslators()` in `open-sse/translator/index.js` is a no-op stub returning `undefined` (translators self-register via static imports). The route called `.then()` on it.

**Fix:** Wrapped with `Promise.resolve()` so `.then()` works regardless of return type.