### PR TITLE
fix: auto-skip onboarding and enforce login on VM deployments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,5 @@ test-results/
 playwright-report/
 blob-report/
 cloud/
+omnirouteCloud/
+omnirouteSite/

--- a/src/app/api/settings/route.js
+++ b/src/app/api/settings/route.js
@@ -13,7 +13,7 @@ export async function GET() {
     return NextResponse.json({
       ...safeSettings,
       enableRequestLogs,
-      hasPassword: !!password,
+      hasPassword: !!password || !!process.env.INITIAL_PASSWORD,
     });
   } catch (error) {
     console.log("Error getting settings:", error);

--- a/src/app/login/page.js
+++ b/src/app/login/page.js
@@ -108,9 +108,11 @@ export default function LoginPage() {
               Login
             </Button>
 
-            <p className="text-xs text-center text-text-muted mt-2">
-              Default password is <code className="bg-sidebar px-1 rounded">123456</code>
-            </p>
+            {!hasPassword && (
+              <p className="text-xs text-center text-text-muted mt-2">
+                Default password is <code className="bg-sidebar px-1 rounded">123456</code>
+              </p>
+            )}
 
             <p className="text-xs text-center mt-1">
               <a href="/forgot-password" className="text-primary hover:underline">

--- a/src/lib/db/settings.js
+++ b/src/lib/db/settings.js
@@ -15,6 +15,20 @@ export async function getSettings() {
   for (const row of rows) {
     settings[row.key] = JSON.parse(row.value);
   }
+
+  // Auto-complete onboarding for pre-configured deployments (Docker/VM)
+  // If INITIAL_PASSWORD is set via env, this is a headless deploy — skip the wizard
+  if (!settings.setupComplete && process.env.INITIAL_PASSWORD) {
+    settings.setupComplete = true;
+    settings.requireLogin = true;
+    db.prepare(
+      "INSERT OR REPLACE INTO key_value (namespace, key, value) VALUES ('settings', 'setupComplete', 'true')"
+    ).run();
+    db.prepare(
+      "INSERT OR REPLACE INTO key_value (namespace, key, value) VALUES ('settings', 'requireLogin', 'true')"
+    ).run();
+  }
+
   return settings;
 }
 

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -49,9 +49,9 @@ export async function proxy(request) {
       if (settings.requireLogin === false) {
         return response;
       }
-      // Skip auth if no password has been set yet (fresh install)
+      // Skip auth if no password has been set yet (fresh install with no env override)
       // This prevents an unresolvable loop where requireLogin=true but no password exists
-      if (!settings.password) {
+      if (!settings.password && !process.env.INITIAL_PASSWORD) {
         return response;
       }
     } catch (err) {


### PR DESCRIPTION
## Summary

Fixes three issues with fresh Docker/VM deployments:

1. **Onboarding loop** — `getSettings()` now auto-sets `setupComplete=true` when `INITIAL_PASSWORD` env is set
2. **No auth enforcement** — `proxy.js` middleware enforces login when `INITIAL_PASSWORD` exists, even without stored bcrypt hash
3. **Misleading password hint** — Login page hides '123456' default hint when custom password is configured; Settings API reports `hasPassword: true` when `INITIAL_PASSWORD` is set

## Files Changed

- `src/lib/db/settings.js` — auto-complete onboarding for pre-configured deploys
- `src/proxy.js` — enforce login with INITIAL_PASSWORD
- `src/app/api/settings/route.js` — hasPassword includes env check
- `src/app/login/page.js` — conditional default password hint
- `.gitignore` — minor update

## Testing

Verified on VM (llms.omniroute.online):
- Fresh install → login page (no onboarding)
- Auth required → redirects to /login
- Password `OmniAdm1n!2026` accepted via INITIAL_PASSWORD
- No '123456' hint shown