### PR TITLE
fix(providers): eliminate HTTP self-calls in batch test for VPS

### DIFF
--- a/src/shared/services/cloudSyncScheduler.js
+++ b/src/shared/services/cloudSyncScheduler.js
@@ -2,7 +2,10 @@ import { getConsistentMachineId } from "@/shared/utils/machineId";
 import { isCloudEnabled } from "@/lib/localDb";
 
 const INTERNAL_BASE_URL =
-  process.env.BASE_URL || process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:20128";
+  process.env.BASE_URL ||
+  process.env.NEXT_PUBLIC_BASE_URL ||
+  process.env.NEXT_PUBLIC_APP_URL ||
+  "http://localhost:20128";
 
 /**
  * Cloud sync scheduler


### PR DESCRIPTION
## Problem
All 34 provider tests fail with NETWORK_ERROR when running on VPS (`llms.omniroute.online`).

**Root cause:** `test-batch/route.js` uses `request.nextUrl.origin` to build internal API URLs. Behind a reverse proxy, this resolves to `http://localhost:20128` instead of the domain, causing all self-referencing HTTP calls to fail.

## Fix
- **Extract `testSingleConnection()`** from `[id]/test/route.js` as a reusable export
- **Call it directly** from `test-batch/route.js` — eliminates HTTP self-calls entirely
- **Expand fallback chain** in `cloudSyncScheduler.js` to include `NEXT_PUBLIC_APP_URL`

## Verification
- ✅ Build passes
- ✅ Lint passes (eslint + prettier)