### PR TITLE
feat(logging): unified Logger + Proxy logging for all test flows

### DIFF
--- a/src/app/api/combos/test/route.js
+++ b/src/app/api/combos/test/route.js
@@ -99,9 +99,12 @@ export async function POST(request) {
 }
 
 /**
- * Get the base URL for internal requests
+ * Get the base URL for internal requests (VPS-safe: respects reverse proxy headers)
  */
 function getBaseUrl(request) {
+  const fwdHost = request.headers.get("x-forwarded-host");
+  const fwdProto = request.headers.get("x-forwarded-proto") || "https";
+  if (fwdHost) return `${fwdProto}://${fwdHost}`;
   const url = new URL(request.url);
   return `${url.protocol}//${url.host}`;
 }


### PR DESCRIPTION
## Changes
- **Logger + Proxy logging** added to `testSingleConnection()` — all provider tests, API key tests, and batch tests now log to both tabs
- **VPS-safe combo test** — `getBaseUrl()` now respects `x-forwarded-host/proto` headers

## Coverage
| Flow | Logger | Proxy | Before | After |
|---|---|---|---|---|
| Provider test | ❌ | ❌ | bypass | ✅ ✅ |
| API key test | ❌ | ❌ | bypass | ✅ ✅ |
| Batch test | ❌ | ❌ | bypass | ✅ ✅ |
| Combo test | ✅ | ✅ | localhost bug | ✅ ✅ (VPS-safe) |
| Chat normal | ✅ | ✅ | - | ✅ ✅ |

## Verification
- ✅ Build passes
- ✅ Lint passes