### PR TITLE
fix(build): update all import paths from .js to .ts

### DIFF
--- a/open-sse/config/constants.ts
+++ b/open-sse/config/constants.ts
@@ -1,4 +1,4 @@
-import { loadProviderCredentials } from "./credentialLoader.js";
+import { loadProviderCredentials } from "./credentialLoader.ts";
 
 // Timeout for non-streaming fetch requests (ms). Prevents stalled connections.
 export const FETCH_TIMEOUT_MS = parseInt(process.env.FETCH_TIMEOUT_MS || "120000", 10);
@@ -9,7 +9,7 @@ export const STREAM_IDLE_TIMEOUT_MS = parseInt(process.env.STREAM_IDLE_TIMEOUT_M
 // Provider configurations
 // OAuth credentials read from env vars with hardcoded fallbacks for backward compatibility.
 // Use provider-credentials.json or env vars to override in production.
-import { generateLegacyProviders } from "./providerRegistry.js";
+import { generateLegacyProviders } from "./providerRegistry.ts";
 
 export const PROVIDERS = generateLegacyProviders();
 

--- a/open-sse/config/providerModels.ts
+++ b/open-sse/config/providerModels.ts
@@ -1,4 +1,4 @@
-import { generateModels, generateAliasMap } from "./providerRegistry.js";
+import { generateModels, generateAliasMap } from "./providerRegistry.ts";
 
 // Provider models - Generated from providerRegistry.js (single source of truth)
 export const PROVIDER_MODELS = generateModels();

--- a/open-sse/executors/antigravity.ts
+++ b/open-sse/executors/antigravity.ts
@@ -1,6 +1,6 @@
 import crypto from "crypto";
-import { BaseExecutor } from "./base.js";
-import { PROVIDERS, OAUTH_ENDPOINTS, HTTP_STATUS } from "../config/constants.js";
+import { BaseExecutor } from "./base.ts";
+import { PROVIDERS, OAUTH_ENDPOINTS, HTTP_STATUS } from "../config/constants.ts";
 
 const MAX_RETRY_AFTER_MS = 10000;
 

--- a/open-sse/executors/base.ts
+++ b/open-sse/executors/base.ts
@@ -1,4 +1,4 @@
-import { HTTP_STATUS, FETCH_TIMEOUT_MS } from "../config/constants.js";
+import { HTTP_STATUS, FETCH_TIMEOUT_MS } from "../config/constants.ts";
 
 /**
  * BaseExecutor - Base class for provider executors.

--- a/open-sse/executors/codex.ts
+++ b/open-sse/executors/codex.ts
@@ -1,6 +1,6 @@
-import { BaseExecutor } from "./base.js";
-import { CODEX_DEFAULT_INSTRUCTIONS } from "../config/codexInstructions.js";
-import { PROVIDERS } from "../config/constants.js";
+import { BaseExecutor } from "./base.ts";
+import { CODEX_DEFAULT_INSTRUCTIONS } from "../config/codexInstructions.ts";
+import { PROVIDERS } from "../config/constants.ts";
 
 /**
  * Codex Executor - handles OpenAI Codex API (Responses API format)

--- a/open-sse/executors/cursor.ts
+++ b/open-sse/executors/cursor.ts
@@ -20,16 +20,16 @@ declare var EdgeRuntime: any;
  * @see cursorProtobuf.js for Protobuf encoding/decoding utilities
  */
 
-import { BaseExecutor } from "./base.js";
-import { PROVIDERS, HTTP_STATUS } from "../config/constants.js";
+import { BaseExecutor } from "./base.ts";
+import { PROVIDERS, HTTP_STATUS } from "../config/constants.ts";
 import {
   generateCursorBody,
   parseConnectRPCFrame,
   extractTextFromResponse,
-} from "../utils/cursorProtobuf.js";
-import { estimateUsage } from "../utils/usageTracking.js";
-import { FORMATS } from "../translator/formats.js";
-import { buildCursorRequest } from "../translator/request/openai-to-cursor.js";
+} from "../utils/cursorProtobuf.ts";
+import { estimateUsage } from "../utils/usageTracking.ts";
+import { FORMATS } from "../translator/formats.ts";
+import { buildCursorRequest } from "../translator/request/openai-to-cursor.ts";
 import crypto from "crypto";
 import { v5 as uuidv5 } from "uuid";
 import zlib from "zlib";

--- a/open-sse/executors/default.ts
+++ b/open-sse/executors/default.ts
@@ -1,6 +1,6 @@
-import { BaseExecutor } from "./base.js";
-import { PROVIDERS, OAUTH_ENDPOINTS } from "../config/constants.js";
-import { getAccessToken } from "../services/tokenRefresh.js";
+import { BaseExecutor } from "./base.ts";
+import { PROVIDERS, OAUTH_ENDPOINTS } from "../config/constants.ts";
+import { getAccessToken } from "../services/tokenRefresh.ts";
 
 export class DefaultExecutor extends BaseExecutor {
   constructor(provider) {

--- a/open-sse/executors/gemini-cli.ts
+++ b/open-sse/executors/gemini-cli.ts
@@ -1,5 +1,5 @@
-import { BaseExecutor } from "./base.js";
-import { PROVIDERS, OAUTH_ENDPOINTS } from "../config/constants.js";
+import { BaseExecutor } from "./base.ts";
+import { PROVIDERS, OAUTH_ENDPOINTS } from "../config/constants.ts";
 
 export class GeminiCLIExecutor extends BaseExecutor {
   constructor() {

--- a/open-sse/executors/github.ts
+++ b/open-sse/executors/github.ts
@@ -1,6 +1,6 @@
-import { BaseExecutor } from "./base.js";
-import { PROVIDERS, OAUTH_ENDPOINTS } from "../config/constants.js";
-import { getModelTargetFormat } from "../config/providerModels.js";
+import { BaseExecutor } from "./base.ts";
+import { PROVIDERS, OAUTH_ENDPOINTS } from "../config/constants.ts";
+import { getModelTargetFormat } from "../config/providerModels.ts";
 
 export class GithubExecutor extends BaseExecutor {
   constructor() {

--- a/open-sse/executors/index.ts
+++ b/open-sse/executors/index.ts
@@ -1,10 +1,10 @@
-import { AntigravityExecutor } from "./antigravity.js";
-import { GeminiCLIExecutor } from "./gemini-cli.js";
-import { GithubExecutor } from "./github.js";
-import { KiroExecutor } from "./kiro.js";
-import { CodexExecutor } from "./codex.js";
-import { CursorExecutor } from "./cursor.js";
-import { DefaultExecutor } from "./default.js";
+import { AntigravityExecutor } from "./antigravity.ts";
+import { GeminiCLIExecutor } from "./gemini-cli.ts";
+import { GithubExecutor } from "./github.ts";
+import { KiroExecutor } from "./kiro.ts";
+import { CodexExecutor } from "./codex.ts";
+import { CursorExecutor } from "./cursor.ts";
+import { DefaultExecutor } from "./default.ts";
 
 const executors = {
   antigravity: new AntigravityExecutor(),
@@ -28,11 +28,11 @@ export function hasSpecializedExecutor(provider) {
   return !!executors[provider];
 }
 
-export { BaseExecutor } from "./base.js";
-export { AntigravityExecutor } from "./antigravity.js";
-export { GeminiCLIExecutor } from "./gemini-cli.js";
-export { GithubExecutor } from "./github.js";
-export { KiroExecutor } from "./kiro.js";
-export { CodexExecutor } from "./codex.js";
-export { CursorExecutor } from "./cursor.js";
-export { DefaultExecutor } from "./default.js";
+export { BaseExecutor } from "./base.ts";
+export { AntigravityExecutor } from "./antigravity.ts";
+export { GeminiCLIExecutor } from "./gemini-cli.ts";
+export { GithubExecutor } from "./github.ts";
+export { KiroExecutor } from "./kiro.ts";
+export { CodexExecutor } from "./codex.ts";
+export { CursorExecutor } from "./cursor.ts";
+export { DefaultExecutor } from "./default.ts";

--- a/open-sse/executors/kiro.ts
+++ b/open-sse/executors/kiro.ts
@@ -1,7 +1,7 @@
-import { BaseExecutor } from "./base.js";
-import { PROVIDERS } from "../config/constants.js";
+import { BaseExecutor } from "./base.ts";
+import { PROVIDERS } from "../config/constants.ts";
 import { v4 as uuidv4 } from "uuid";
-import { refreshKiroToken } from "../services/tokenRefresh.js";
+import { refreshKiroToken } from "../services/tokenRefresh.ts";
 
 // ── CRC32 lookup table (IEEE polynomial, no dependency) ──
 const CRC32_TABLE = new Uint32Array(256);

--- a/open-sse/handlers/audioSpeech.ts
+++ b/open-sse/handlers/audioSpeech.ts
@@ -10,8 +10,8 @@
  * - Deepgram: POST { text } with model via query param, Token auth
  */
 
-import { getSpeechProvider, parseSpeechModel } from "../config/audioRegistry.js";
-import { errorResponse } from "../utils/error.js";
+import { getSpeechProvider, parseSpeechModel } from "../config/audioRegistry.ts";
+import { errorResponse } from "../utils/error.ts";
 
 /**
  * Build auth header for a speech provider

--- a/open-sse/handlers/audioTranscription.ts
+++ b/open-sse/handlers/audioTranscription.ts
@@ -10,8 +10,8 @@
  * - AssemblyAI: async workflow (upload → submit → poll)
  */
 
-import { getTranscriptionProvider, parseTranscriptionModel } from "../config/audioRegistry.js";
-import { errorResponse } from "../utils/error.js";
+import { getTranscriptionProvider, parseTranscriptionModel } from "../config/audioRegistry.ts";
+import { errorResponse } from "../utils/error.ts";
 
 /**
  * Build auth header for a transcription provider

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -1,34 +1,34 @@
-import { detectFormat, getTargetFormat } from "../services/provider.js";
-import { translateRequest, needsTranslation } from "../translator/index.js";
-import { FORMATS } from "../translator/formats.js";
+import { detectFormat, getTargetFormat } from "../services/provider.ts";
+import { translateRequest, needsTranslation } from "../translator/index.ts";
+import { FORMATS } from "../translator/formats.ts";
 import {
   createSSETransformStreamWithLogger,
   createPassthroughStreamWithLogger,
   COLORS,
-} from "../utils/stream.js";
-import { createStreamController, pipeWithDisconnect } from "../utils/streamHandler.js";
-import { addBufferToUsage, filterUsageForFormat, estimateUsage } from "../utils/usageTracking.js";
-import { refreshWithRetry } from "../services/tokenRefresh.js";
-import { createRequestLogger } from "../utils/requestLogger.js";
-import { getModelTargetFormat, PROVIDER_ID_TO_ALIAS } from "../config/providerModels.js";
-import { createErrorResult, parseUpstreamError, formatProviderError } from "../utils/error.js";
-import { HTTP_STATUS } from "../config/constants.js";
-import { handleBypassRequest } from "../utils/bypassHandler.js";
+} from "../utils/stream.ts";
+import { createStreamController, pipeWithDisconnect } from "../utils/streamHandler.ts";
+import { addBufferToUsage, filterUsageForFormat, estimateUsage } from "../utils/usageTracking.ts";
+import { refreshWithRetry } from "../services/tokenRefresh.ts";
+import { createRequestLogger } from "../utils/requestLogger.ts";
+import { getModelTargetFormat, PROVIDER_ID_TO_ALIAS } from "../config/providerModels.ts";
+import { createErrorResult, parseUpstreamError, formatProviderError } from "../utils/error.ts";
+import { HTTP_STATUS } from "../config/constants.ts";
+import { handleBypassRequest } from "../utils/bypassHandler.ts";
 import {
   saveRequestUsage,
   trackPendingRequest,
   appendRequestLog,
   saveCallLog,
 } from "@/lib/usageDb";
-import { getExecutor } from "../executors/index.js";
-import { translateNonStreamingResponse } from "./responseTranslator.js";
-import { extractUsageFromResponse } from "./usageExtractor.js";
-import { parseSSEToOpenAIResponse, parseSSEToResponsesOutput } from "./sseParser.js";
+import { getExecutor } from "../executors/index.ts";
+import { translateNonStreamingResponse } from "./responseTranslator.ts";
+import { extractUsageFromResponse } from "./usageExtractor.ts";
+import { parseSSEToOpenAIResponse, parseSSEToResponsesOutput } from "./sseParser.ts";
 import {
   withRateLimit,
   updateFromHeaders,
   initializeRateLimits,
-} from "../services/rateLimitManager.js";
+} from "../services/rateLimitManager.ts";
 import {
   generateSignature,
   getCachedResponse,
@@ -36,7 +36,7 @@ import {
   isCacheable,
 } from "@/lib/semanticCache";
 import { getIdempotencyKey, checkIdempotency, saveIdempotency } from "@/lib/idempotencyLayer";
-import { createProgressTransform, wantsProgress } from "../utils/progressTracker.js";
+import { createProgressTransform, wantsProgress } from "../utils/progressTracker.ts";
 
 /**
  * Core chat handler - shared between SSE and Worker

--- a/open-sse/handlers/embeddings.ts
+++ b/open-sse/handlers/embeddings.ts
@@ -13,7 +13,7 @@
  * }
  */
 
-import { getEmbeddingProvider, parseEmbeddingModel } from "../config/embeddingRegistry.js";
+import { getEmbeddingProvider, parseEmbeddingModel } from "../config/embeddingRegistry.ts";
 import { saveCallLog } from "@/lib/usageDb";
 
 /**

--- a/open-sse/handlers/imageGeneration.ts
+++ b/open-sse/handlers/imageGeneration.ts
@@ -15,7 +15,7 @@
  * }
  */
 
-import { getImageProvider, parseImageModel } from "../config/imageRegistry.js";
+import { getImageProvider, parseImageModel } from "../config/imageRegistry.ts";
 import { saveCallLog } from "@/lib/usageDb";
 
 /**

--- a/open-sse/handlers/moderations.ts
+++ b/open-sse/handlers/moderations.ts
@@ -4,8 +4,8 @@
  * Handles POST /v1/moderations (OpenAI Moderations API format).
  */
 
-import { getModerationProvider, parseModerationModel } from "../config/moderationRegistry.js";
-import { errorResponse } from "../utils/error.js";
+import { getModerationProvider, parseModerationModel } from "../config/moderationRegistry.ts";
+import { errorResponse } from "../utils/error.ts";
 
 /**
  * Handle moderation request

--- a/open-sse/handlers/rerank.ts
+++ b/open-sse/handlers/rerank.ts
@@ -5,8 +5,8 @@
  * Routes to the appropriate provider based on the model prefix or lookup.
  */
 
-import { getRerankProvider, parseRerankModel } from "../config/rerankRegistry.js";
-import { errorResponse } from "../utils/error.js";
+import { getRerankProvider, parseRerankModel } from "../config/rerankRegistry.ts";
+import { errorResponse } from "../utils/error.ts";
 
 /**
  * Build authorization header for a rerank provider

--- a/open-sse/handlers/responseTranslator.ts
+++ b/open-sse/handlers/responseTranslator.ts
@@ -1,4 +1,4 @@
-import { FORMATS } from "../translator/formats.js";
+import { FORMATS } from "../translator/formats.ts";
 
 /**
  * Translate non-streaming response to OpenAI format

--- a/open-sse/handlers/responsesHandler.ts
+++ b/open-sse/handlers/responsesHandler.ts
@@ -3,9 +3,9 @@
  * Converts Chat Completions to Codex Responses API format
  */
 
-import { handleChatCore } from "./chatCore.js";
-import { convertResponsesApiFormat } from "../translator/helpers/responsesApiHelper.js";
-import { createResponsesApiTransformStream } from "../transformer/responsesTransformer.js";
+import { handleChatCore } from "./chatCore.ts";
+import { convertResponsesApiFormat } from "../translator/helpers/responsesApiHelper.ts";
+import { createResponsesApiTransformStream } from "../transformer/responsesTransformer.ts";
 
 /**
  * Handle /v1/responses request

--- a/open-sse/index.ts
+++ b/open-sse/index.ts
@@ -1,5 +1,5 @@
 // Patch global fetch with proxy support (must be first)
-import "./utils/proxyFetch.js";
+import "./utils/proxyFetch.ts";
 
 // Config
 export {
@@ -10,7 +10,7 @@ export {
   CLAUDE_SYSTEM_PROMPT,
   COOLDOWN_MS,
   BACKOFF_CONFIG,
-} from "./config/constants.js";
+} from "./config/constants.ts";
 export {
   PROVIDER_MODELS,
   getProviderModels,
@@ -20,10 +20,10 @@ export {
   getModelTargetFormat,
   PROVIDER_ID_TO_ALIAS,
   getModelsByProviderId,
-} from "./config/providerModels.js";
+} from "./config/providerModels.ts";
 
 // Translator
-export { FORMATS } from "./translator/formats.js";
+export { FORMATS } from "./translator/formats.ts";
 export {
   register,
   translateRequest,
@@ -31,7 +31,7 @@ export {
   needsTranslation,
   initState,
   initTranslators,
-} from "./translator/index.js";
+} from "./translator/index.ts";
 
 // Services
 export {
@@ -40,16 +40,16 @@ export {
   buildProviderUrl,
   buildProviderHeaders,
   getTargetFormat,
-} from "./services/provider.js";
+} from "./services/provider.ts";
 
-export { parseModel, resolveModelAliasFromMap, getModelInfoCore } from "./services/model.js";
+export { parseModel, resolveModelAliasFromMap, getModelInfoCore } from "./services/model.ts";
 
 export {
   checkFallbackError,
   isAccountUnavailable,
   getUnavailableUntil,
   filterAvailableAccounts,
-} from "./services/accountFallback.js";
+} from "./services/accountFallback.ts";
 
 export {
   TOKEN_EXPIRY_BUFFER_MS,
@@ -63,43 +63,43 @@ export {
   refreshCopilotToken,
   getAccessToken,
   refreshTokenByProvider,
-} from "./services/tokenRefresh.js";
+} from "./services/tokenRefresh.ts";
 
 // Handlers
-export { handleChatCore, isTokenExpiringSoon } from "./handlers/chatCore.js";
+export { handleChatCore, isTokenExpiringSoon } from "./handlers/chatCore.ts";
 export {
   createStreamController,
   pipeWithDisconnect,
   createDisconnectAwareStream,
-} from "./utils/streamHandler.js";
+} from "./utils/streamHandler.ts";
 
 // Executors
-export { getExecutor, hasSpecializedExecutor } from "./executors/index.js";
+export { getExecutor, hasSpecializedExecutor } from "./executors/index.ts";
 
 // Utils
-export { errorResponse, formatProviderError } from "./utils/error.js";
+export { errorResponse, formatProviderError } from "./utils/error.ts";
 export {
   createSSETransformStreamWithLogger,
   createPassthroughStreamWithLogger,
-} from "./utils/stream.js";
+} from "./utils/stream.ts";
 
 // Embeddings
-export { handleEmbedding } from "./handlers/embeddings.js";
+export { handleEmbedding } from "./handlers/embeddings.ts";
 export {
   EMBEDDING_PROVIDERS,
   getEmbeddingProvider,
   parseEmbeddingModel,
   getAllEmbeddingModels,
-} from "./config/embeddingRegistry.js";
+} from "./config/embeddingRegistry.ts";
 
 // Image Generation
-export { handleImageGeneration } from "./handlers/imageGeneration.js";
+export { handleImageGeneration } from "./handlers/imageGeneration.ts";
 export {
   IMAGE_PROVIDERS,
   getImageProvider,
   parseImageModel,
   getAllImageModels,
-} from "./config/imageRegistry.js";
+} from "./config/imageRegistry.ts";
 
 // Think Tag Parser
 export {
@@ -107,20 +107,20 @@ export {
   extractThinkTags,
   processStreamingThinkDelta,
   flushThinkBuffer,
-} from "./utils/thinkTagParser.js";
+} from "./utils/thinkTagParser.ts";
 
 // Rerank
-export { handleRerank } from "./handlers/rerank.js";
+export { handleRerank } from "./handlers/rerank.ts";
 export {
   RERANK_PROVIDERS,
   getRerankProvider,
   parseRerankModel,
   getAllRerankModels,
-} from "./config/rerankRegistry.js";
+} from "./config/rerankRegistry.ts";
 
 // Audio (Transcription + Speech)
-export { handleAudioTranscription } from "./handlers/audioTranscription.js";
-export { handleAudioSpeech } from "./handlers/audioSpeech.js";
+export { handleAudioTranscription } from "./handlers/audioTranscription.ts";
+export { handleAudioSpeech } from "./handlers/audioSpeech.ts";
 export {
   AUDIO_TRANSCRIPTION_PROVIDERS,
   AUDIO_SPEECH_PROVIDERS,
@@ -129,13 +129,13 @@ export {
   parseTranscriptionModel,
   parseSpeechModel,
   getAllAudioModels,
-} from "./config/audioRegistry.js";
+} from "./config/audioRegistry.ts";
 
 // Moderations
-export { handleModeration } from "./handlers/moderations.js";
+export { handleModeration } from "./handlers/moderations.ts";
 export {
   MODERATION_PROVIDERS,
   getModerationProvider,
   parseModerationModel,
   getAllModerationModels,
-} from "./config/moderationRegistry.js";
+} from "./config/moderationRegistry.ts";

--- a/open-sse/services/accountFallback.ts
+++ b/open-sse/services/accountFallback.ts
@@ -5,8 +5,8 @@ import {
   RateLimitReason,
   HTTP_STATUS,
   PROVIDER_PROFILES,
-} from "../config/constants.js";
-import { getProviderCategory } from "../config/providerRegistry.js";
+} from "../config/constants.ts";
+import { getProviderCategory } from "../config/providerRegistry.ts";
 
 // ─── Provider Profile Helper ────────────────────────────────────────────────
 

--- a/open-sse/services/accountSelector.ts
+++ b/open-sse/services/accountSelector.ts
@@ -5,7 +5,7 @@
  * Uses account health scores from accountFallback.js.
  */
 
-import { getAccountHealth } from "./accountFallback.js";
+import { getAccountHealth } from "./accountFallback.ts";
 
 /**
  * P2C selection: pick 2 random candidates, return the healthier one.

--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -3,13 +3,13 @@
  * Supports: priority, weighted, round-robin, random, least-used, and cost-optimized strategies
  */
 
-import { checkFallbackError, formatRetryAfter, getProviderProfile } from "./accountFallback.js";
-import { unavailableResponse } from "../utils/error.js";
-import { recordComboRequest, getComboMetrics } from "./comboMetrics.js";
-import { resolveComboConfig, getDefaultComboConfig } from "./comboConfig.js";
-import * as semaphore from "./rateLimitSemaphore.js";
+import { checkFallbackError, formatRetryAfter, getProviderProfile } from "./accountFallback.ts";
+import { unavailableResponse } from "../utils/error.ts";
+import { recordComboRequest, getComboMetrics } from "./comboMetrics.ts";
+import { resolveComboConfig, getDefaultComboConfig } from "./comboConfig.ts";
+import * as semaphore from "./rateLimitSemaphore.ts";
 import { getCircuitBreaker } from "../../src/shared/utils/circuitBreaker";
-import { parseModel } from "./model.js";
+import { parseModel } from "./model.ts";
 
 // Status codes that should mark semaphore + record circuit breaker failures
 const TRANSIENT_FOR_BREAKER = [429, 502, 503, 504];

--- a/open-sse/services/model.ts
+++ b/open-sse/services/model.ts
@@ -1,4 +1,4 @@
-import { PROVIDER_ID_TO_ALIAS, PROVIDER_MODELS } from "../config/providerModels.js";
+import { PROVIDER_ID_TO_ALIAS, PROVIDER_MODELS } from "../config/providerModels.ts";
 
 // Derive alias→provider mapping from the single source of truth (PROVIDER_ID_TO_ALIAS)
 // This prevents the two maps from drifting out of sync

--- a/open-sse/services/provider.ts
+++ b/open-sse/services/provider.ts
@@ -1,5 +1,5 @@
-import { PROVIDERS } from "../config/constants.js";
-import { getRegistryEntry } from "../config/providerRegistry.js";
+import { PROVIDERS } from "../config/constants.ts";
+import { getRegistryEntry } from "../config/providerRegistry.ts";
 
 const OPENAI_COMPATIBLE_PREFIX = "openai-compatible-";
 const OPENAI_COMPATIBLE_DEFAULTS = {

--- a/open-sse/services/rateLimitManager.ts
+++ b/open-sse/services/rateLimitManager.ts
@@ -9,9 +9,9 @@
  */
 
 import Bottleneck from "bottleneck";
-import { parseRetryAfterFromBody, lockModel } from "./accountFallback.js";
-import { getProviderCategory } from "../config/providerRegistry.js";
-import { DEFAULT_API_LIMITS } from "../config/constants.js";
+import { parseRetryAfterFromBody, lockModel } from "./accountFallback.ts";
+import { getProviderCategory } from "../config/providerRegistry.ts";
+import { DEFAULT_API_LIMITS } from "../config/constants.ts";
 
 // Store limiters keyed by "provider:connectionId" (and optionally ":model")
 const limiters = new Map();

--- a/open-sse/services/tokenRefresh.ts
+++ b/open-sse/services/tokenRefresh.ts
@@ -1,4 +1,4 @@
-import { PROVIDERS, OAUTH_ENDPOINTS } from "../config/constants.js";
+import { PROVIDERS, OAUTH_ENDPOINTS } from "../config/constants.ts";
 import { createHash } from "node:crypto";
 
 // Token expiry buffer (refresh if expires within 5 minutes)

--- a/open-sse/services/usage.ts
+++ b/open-sse/services/usage.ts
@@ -2,7 +2,7 @@
  * Usage Fetcher - Get usage data from provider APIs
  */
 
-import { PROVIDERS } from "../config/constants.js";
+import { PROVIDERS } from "../config/constants.ts";
 
 // GitHub API config
 const GITHUB_CONFIG = {

--- a/open-sse/translator/helpers/claudeHelper.ts
+++ b/open-sse/translator/helpers/claudeHelper.ts
@@ -1,5 +1,5 @@
 // Claude helper functions for translator
-import { DEFAULT_THINKING_CLAUDE_SIGNATURE } from "../../config/defaultThinkingSignature.js";
+import { DEFAULT_THINKING_CLAUDE_SIGNATURE } from "../../config/defaultThinkingSignature.ts";
 
 // Check if message has valid non-empty content
 export function hasValidContent(msg) {

--- a/open-sse/translator/helpers/maxTokensHelper.ts
+++ b/open-sse/translator/helpers/maxTokensHelper.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_MAX_TOKENS, DEFAULT_MIN_TOKENS } from "../../config/constants.js";
+import { DEFAULT_MAX_TOKENS, DEFAULT_MIN_TOKENS } from "../../config/constants.ts";
 
 /**
  * Adjust max_tokens based on request context

--- a/open-sse/translator/index.ts
+++ b/open-sse/translator/index.ts
@@ -1,9 +1,9 @@
-import { FORMATS } from "./formats.js";
-import { ensureToolCallIds, fixMissingToolResponses } from "./helpers/toolCallHelper.js";
-import { prepareClaudeRequest } from "./helpers/claudeHelper.js";
-import { filterToOpenAIFormat } from "./helpers/openaiHelper.js";
-import { normalizeThinkingConfig } from "../services/provider.js";
-import { applyThinkingBudget } from "../services/thinkingBudget.js";
+import { FORMATS } from "./formats.ts";
+import { ensureToolCallIds, fixMissingToolResponses } from "./helpers/toolCallHelper.ts";
+import { prepareClaudeRequest } from "./helpers/claudeHelper.ts";
+import { filterToOpenAIFormat } from "./helpers/openaiHelper.ts";
+import { normalizeThinkingConfig } from "../services/provider.ts";
+import { applyThinkingBudget } from "../services/thinkingBudget.ts";
 
 // Registry for translators.
 // NOTE: translator modules import this file and call register() at module-load time.
@@ -88,24 +88,24 @@ export function register(from, to, requestFn, responseFn) {
 }
 
 // Translator modules self-register via register() on import
-import "./request/claude-to-openai.js";
-import "./request/openai-to-claude.js";
-import "./request/gemini-to-openai.js";
-import "./request/openai-to-gemini.js";
-import "./request/antigravity-to-openai.js";
-import "./request/openai-responses.js";
-import "./request/openai-to-kiro.js";
-import "./request/openai-to-cursor.js";
-import "./request/claude-to-gemini.js";
+import "./request/claude-to-openai.ts";
+import "./request/openai-to-claude.ts";
+import "./request/gemini-to-openai.ts";
+import "./request/openai-to-gemini.ts";
+import "./request/antigravity-to-openai.ts";
+import "./request/openai-responses.ts";
+import "./request/openai-to-kiro.ts";
+import "./request/openai-to-cursor.ts";
+import "./request/claude-to-gemini.ts";
 
-import "./response/claude-to-openai.js";
-import "./response/openai-to-claude.js";
-import "./response/gemini-to-openai.js";
-import "./response/gemini-to-claude.js";
-import "./response/openai-to-antigravity.js";
-import "./response/openai-responses.js";
-import "./response/kiro-to-openai.js";
-import "./response/cursor-to-openai.js";
+import "./response/claude-to-openai.ts";
+import "./response/openai-to-claude.ts";
+import "./response/gemini-to-openai.ts";
+import "./response/gemini-to-claude.ts";
+import "./response/openai-to-antigravity.ts";
+import "./response/openai-responses.ts";
+import "./response/kiro-to-openai.ts";
+import "./response/cursor-to-openai.ts";
 
 // Translate request: source -> openai -> target
 export function translateRequest(

--- a/open-sse/translator/request/antigravity-to-openai.ts
+++ b/open-sse/translator/request/antigravity-to-openai.ts
@@ -1,6 +1,6 @@
-import { register } from "../index.js";
-import { FORMATS } from "../formats.js";
-import { adjustMaxTokens } from "../helpers/maxTokensHelper.js";
+import { register } from "../index.ts";
+import { FORMATS } from "../formats.ts";
+import { adjustMaxTokens } from "../helpers/maxTokensHelper.ts";
 
 // Convert Antigravity request to OpenAI format
 // Antigravity body: { project, model, userAgent, requestType, requestId, request: { contents, systemInstruction, tools, toolConfig, generationConfig, sessionId } }

--- a/open-sse/translator/request/claude-to-gemini.ts
+++ b/open-sse/translator/request/claude-to-gemini.ts
@@ -1,7 +1,7 @@
-import { register } from "../index.js";
-import { FORMATS } from "../formats.js";
-import { DEFAULT_SAFETY_SETTINGS, tryParseJSON } from "../helpers/geminiHelper.js";
-import { DEFAULT_THINKING_GEMINI_SIGNATURE } from "../../config/defaultThinkingSignature.js";
+import { register } from "../index.ts";
+import { FORMATS } from "../formats.ts";
+import { DEFAULT_SAFETY_SETTINGS, tryParseJSON } from "../helpers/geminiHelper.ts";
+import { DEFAULT_THINKING_GEMINI_SIGNATURE } from "../../config/defaultThinkingSignature.ts";
 
 /**
  * Direct Claude → Gemini request translator.

--- a/open-sse/translator/request/claude-to-openai.ts
+++ b/open-sse/translator/request/claude-to-openai.ts
@@ -1,6 +1,6 @@
-import { register } from "../index.js";
-import { FORMATS } from "../formats.js";
-import { adjustMaxTokens } from "../helpers/maxTokensHelper.js";
+import { register } from "../index.ts";
+import { FORMATS } from "../formats.ts";
+import { adjustMaxTokens } from "../helpers/maxTokensHelper.ts";
 
 // Convert Claude request to OpenAI format
 export function claudeToOpenAIRequest(model, body, stream) {

--- a/open-sse/translator/request/gemini-to-openai.ts
+++ b/open-sse/translator/request/gemini-to-openai.ts
@@ -1,6 +1,6 @@
-import { register } from "../index.js";
-import { FORMATS } from "../formats.js";
-import { adjustMaxTokens } from "../helpers/maxTokensHelper.js";
+import { register } from "../index.ts";
+import { FORMATS } from "../formats.ts";
+import { adjustMaxTokens } from "../helpers/maxTokensHelper.ts";
 
 // Convert Gemini request to OpenAI format
 export function geminiToOpenAIRequest(model, body, stream) {

--- a/open-sse/translator/request/openai-responses.ts
+++ b/open-sse/translator/request/openai-responses.ts
@@ -4,8 +4,8 @@
  * Responses API uses: { input: [...], instructions: "..." }
  * Chat API uses: { messages: [...] }
  */
-import { register } from "../index.js";
-import { FORMATS } from "../formats.js";
+import { register } from "../index.ts";
+import { FORMATS } from "../formats.ts";
 
 /**
  * Convert OpenAI Responses API request to OpenAI Chat Completions format

--- a/open-sse/translator/request/openai-to-claude.ts
+++ b/open-sse/translator/request/openai-to-claude.ts
@@ -1,8 +1,8 @@
-import { register } from "../index.js";
-import { FORMATS } from "../formats.js";
-import { CLAUDE_SYSTEM_PROMPT } from "../../config/constants.js";
-import { adjustMaxTokens } from "../helpers/maxTokensHelper.js";
-import { DEFAULT_THINKING_CLAUDE_SIGNATURE } from "../../config/defaultThinkingSignature.js";
+import { register } from "../index.ts";
+import { FORMATS } from "../formats.ts";
+import { CLAUDE_SYSTEM_PROMPT } from "../../config/constants.ts";
+import { adjustMaxTokens } from "../helpers/maxTokensHelper.ts";
+import { DEFAULT_THINKING_CLAUDE_SIGNATURE } from "../../config/defaultThinkingSignature.ts";
 
 // Prefix for Claude OAuth tool names to avoid conflicts
 const CLAUDE_OAUTH_TOOL_PREFIX = "proxy_";

--- a/open-sse/translator/request/openai-to-cursor.ts
+++ b/open-sse/translator/request/openai-to-cursor.ts
@@ -2,8 +2,8 @@
  * OpenAI to Cursor Request Translator
  * Converts OpenAI messages to Cursor simple format
  */
-import { register } from "../index.js";
-import { FORMATS } from "../formats.js";
+import { register } from "../index.ts";
+import { FORMATS } from "../formats.ts";
 
 /**
  * Convert OpenAI messages to Cursor format with native tool_results support

--- a/open-sse/translator/request/openai-to-gemini.ts
+++ b/open-sse/translator/request/openai-to-gemini.ts
@@ -1,8 +1,8 @@
-import { register } from "../index.js";
-import { FORMATS } from "../formats.js";
-import { DEFAULT_THINKING_GEMINI_SIGNATURE } from "../../config/defaultThinkingSignature.js";
-import { ANTIGRAVITY_DEFAULT_SYSTEM } from "../../config/constants.js";
-import { openaiToClaudeRequestForAntigravity } from "./openai-to-claude.js";
+import { register } from "../index.ts";
+import { FORMATS } from "../formats.ts";
+import { DEFAULT_THINKING_GEMINI_SIGNATURE } from "../../config/defaultThinkingSignature.ts";
+import { ANTIGRAVITY_DEFAULT_SYSTEM } from "../../config/constants.ts";
+import { openaiToClaudeRequestForAntigravity } from "./openai-to-claude.ts";
 
 function generateUUID() {
   return crypto.randomUUID();
@@ -17,7 +17,7 @@ import {
   generateSessionId,
   generateProjectId,
   cleanJSONSchemaForAntigravity,
-} from "../helpers/geminiHelper.js";
+} from "../helpers/geminiHelper.ts";
 
 // Core: Convert OpenAI request to Gemini format (base for all variants)
 function openaiToGeminiBase(model, body, stream) {

--- a/open-sse/translator/request/openai-to-kiro.ts
+++ b/open-sse/translator/request/openai-to-kiro.ts
@@ -2,8 +2,8 @@
  * OpenAI to Kiro Request Translator
  * Converts OpenAI Chat Completions format to Kiro/AWS CodeWhisperer format
  */
-import { register } from "../index.js";
-import { FORMATS } from "../formats.js";
+import { register } from "../index.ts";
+import { FORMATS } from "../formats.ts";
 import { v4 as uuidv4 } from "uuid";
 
 /**

--- a/open-sse/translator/response/claude-to-openai.ts
+++ b/open-sse/translator/response/claude-to-openai.ts
@@ -1,5 +1,5 @@
-import { register } from "../index.js";
-import { FORMATS } from "../formats.js";
+import { register } from "../index.ts";
+import { FORMATS } from "../formats.ts";
 
 // Create OpenAI chunk helper
 function createChunk(state, delta, finishReason = null) {

--- a/open-sse/translator/response/cursor-to-openai.ts
+++ b/open-sse/translator/response/cursor-to-openai.ts
@@ -2,8 +2,8 @@
  * Cursor to OpenAI Response Translator
  * CursorExecutor already emits OpenAI format - this is a passthrough
  */
-import { register } from "../index.js";
-import { FORMATS } from "../formats.js";
+import { register } from "../index.ts";
+import { FORMATS } from "../formats.ts";
 
 /**
  * Convert Cursor response to OpenAI format

--- a/open-sse/translator/response/gemini-to-claude.ts
+++ b/open-sse/translator/response/gemini-to-claude.ts
@@ -1,5 +1,5 @@
-import { register } from "../index.js";
-import { FORMATS } from "../formats.js";
+import { register } from "../index.ts";
+import { FORMATS } from "../formats.ts";
 
 /**
  * Direct Gemini → Claude response translator.

--- a/open-sse/translator/response/gemini-to-openai.ts
+++ b/open-sse/translator/response/gemini-to-openai.ts
@@ -1,5 +1,5 @@
-import { register } from "../index.js";
-import { FORMATS } from "../formats.js";
+import { register } from "../index.ts";
+import { FORMATS } from "../formats.ts";
 
 // Convert Gemini response chunk to OpenAI format
 export function geminiToOpenAIResponse(chunk, state) {

--- a/open-sse/translator/response/kiro-to-openai.ts
+++ b/open-sse/translator/response/kiro-to-openai.ts
@@ -2,8 +2,8 @@
  * Kiro to OpenAI Response Translator
  * Converts Kiro/AWS CodeWhisperer streaming events to OpenAI SSE format
  */
-import { register } from "../index.js";
-import { FORMATS } from "../formats.js";
+import { register } from "../index.ts";
+import { FORMATS } from "../formats.ts";
 
 /**
  * Parse Kiro SSE event and convert to OpenAI format

--- a/open-sse/translator/response/openai-responses.ts
+++ b/open-sse/translator/response/openai-responses.ts
@@ -2,8 +2,8 @@
  * Translator: OpenAI Chat Completions → OpenAI Responses API (response)
  * Converts streaming chunks from Chat Completions to Responses API events
  */
-import { register } from "../index.js";
-import { FORMATS } from "../formats.js";
+import { register } from "../index.ts";
+import { FORMATS } from "../formats.ts";
 
 /**
  * Translate OpenAI chunk to Responses API events

--- a/open-sse/translator/response/openai-to-antigravity.ts
+++ b/open-sse/translator/response/openai-to-antigravity.ts
@@ -1,5 +1,5 @@
-import { register } from "../index.js";
-import { FORMATS } from "../formats.js";
+import { register } from "../index.ts";
+import { FORMATS } from "../formats.ts";
 
 // Convert OpenAI SSE chunk to Antigravity SSE format
 // Real Antigravity format:

--- a/open-sse/translator/response/openai-to-claude.ts
+++ b/open-sse/translator/response/openai-to-claude.ts
@@ -1,5 +1,5 @@
-import { register } from "../index.js";
-import { FORMATS } from "../formats.js";
+import { register } from "../index.ts";
+import { FORMATS } from "../formats.ts";
 
 // Prefix for Claude OAuth tool names (must match request translator)
 const CLAUDE_OAUTH_TOOL_PREFIX = "proxy_";

--- a/open-sse/utils/bypassHandler.ts
+++ b/open-sse/utils/bypassHandler.ts
@@ -1,8 +1,8 @@
-import { detectFormat } from "../services/provider.js";
-import { translateResponse, initState } from "../translator/index.js";
-import { FORMATS } from "../translator/formats.js";
-import { SKIP_PATTERNS } from "../config/constants.js";
-import { formatSSE } from "./stream.js";
+import { detectFormat } from "../services/provider.ts";
+import { translateResponse, initState } from "../translator/index.ts";
+import { FORMATS } from "../translator/formats.ts";
+import { SKIP_PATTERNS } from "../config/constants.ts";
+import { formatSSE } from "./stream.ts";
 
 /**
  * Check for bypass patterns — return fake response without calling provider.

--- a/open-sse/utils/error.ts
+++ b/open-sse/utils/error.ts
@@ -1,4 +1,4 @@
-import { ERROR_TYPES, DEFAULT_ERROR_MESSAGES } from "../config/constants.js";
+import { ERROR_TYPES, DEFAULT_ERROR_MESSAGES } from "../config/constants.ts";
 
 /**
  * Build OpenAI-compatible error response body

--- a/open-sse/utils/logger.ts
+++ b/open-sse/utils/logger.ts
@@ -7,7 +7,7 @@
  *   - "json": Single-line JSON objects for log aggregators
  *
  * Usage:
- *   import { logger, createLogger, generateRequestId } from "../utils/logger.js";
+ *   import { logger, createLogger, generateRequestId } from "../utils/logger.ts";
  *
  *   // Tag-based (simple — for services/utilities):
  *   const log = logger("CHAT");

--- a/open-sse/utils/proxyFetch.ts
+++ b/open-sse/utils/proxyFetch.ts
@@ -4,8 +4,8 @@ import {
   normalizeProxyUrl,
   proxyConfigToUrl,
   proxyUrlForLogs,
-} from "./proxyDispatcher.js";
-import tlsClient from "./tlsClient.js";
+} from "./proxyDispatcher.ts";
+import tlsClient from "./tlsClient.ts";
 
 function isTlsFingerprintEnabled() {
   return process.env.ENABLE_TLS_FINGERPRINT === "true";

--- a/open-sse/utils/stream.ts
+++ b/open-sse/utils/stream.ts
@@ -1,5 +1,5 @@
-import { translateResponse, initState } from "../translator/index.js";
-import { FORMATS } from "../translator/formats.js";
+import { translateResponse, initState } from "../translator/index.ts";
+import { FORMATS } from "../translator/formats.ts";
 import { trackPendingRequest, appendRequestLog } from "@/lib/usageDb";
 import {
   extractUsage,
@@ -9,9 +9,9 @@ import {
   addBufferToUsage,
   filterUsageForFormat,
   COLORS,
-} from "./usageTracking.js";
-import { parseSSELine, hasValuableContent, fixInvalidId, formatSSE } from "./streamHelpers.js";
-import { STREAM_IDLE_TIMEOUT_MS, HTTP_STATUS } from "../config/constants.js";
+} from "./usageTracking.ts";
+import { parseSSELine, hasValuableContent, fixInvalidId, formatSSE } from "./streamHelpers.ts";
+import { STREAM_IDLE_TIMEOUT_MS, HTTP_STATUS } from "../config/constants.ts";
 
 export { COLORS, formatSSE };
 

--- a/open-sse/utils/streamHelpers.ts
+++ b/open-sse/utils/streamHelpers.ts
@@ -11,7 +11,7 @@
  * expects its native format and normalization would lose format-specific metadata.
  */
 
-import { FORMATS } from "../translator/formats.js";
+import { FORMATS } from "../translator/formats.ts";
 
 // Parse SSE data line
 export function parseSSELine(line) {

--- a/open-sse/utils/thinkTagParser.ts
+++ b/open-sse/utils/thinkTagParser.ts
@@ -8,7 +8,7 @@
  * chain-of-thought reasoning inside <think> tags.
  *
  * Usage:
- *   import { extractThinkTags, hasThinkTags } from "./thinkTagParser.js";
+ *   import { extractThinkTags, hasThinkTags } from "./thinkTagParser.ts";
  *
  *   const { reasoning, content } = extractThinkTags(rawOutput);
  *   // reasoning = "step-by-step thinking..."

--- a/open-sse/utils/usageTracking.ts
+++ b/open-sse/utils/usageTracking.ts
@@ -3,7 +3,7 @@
  */
 
 import { saveRequestUsage, appendRequestLog } from "@/lib/usageDb";
-import { FORMATS } from "../translator/formats.js";
+import { FORMATS } from "../translator/formats.ts";
 
 // ANSI color codes
 export const COLORS = {

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.tsx
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.tsx
@@ -1,4 +1,4 @@
-import { getModelsByProviderId } from "@omniroute/open-sse/config/providerModels.js";
+import { getModelsByProviderId } from "@omniroute/open-sse/config/providerModels.ts";
 
 /**
  * Format ISO date string to countdown format (inspired by vscode-antigravity-cockpit)

--- a/src/app/api/combos/[id]/route.ts
+++ b/src/app/api/combos/[id]/route.ts
@@ -9,7 +9,7 @@ import {
 } from "@/lib/localDb";
 import { getConsistentMachineId } from "@/shared/utils/machineId";
 import { syncToCloud } from "@/lib/cloudSync";
-import { validateComboDAG } from "@omniroute/open-sse/services/combo.js";
+import { validateComboDAG } from "@omniroute/open-sse/services/combo.ts";
 
 // Validate combo name: only a-z, A-Z, 0-9, -, _
 const VALID_NAME_REGEX = /^[a-zA-Z0-9_/.-]+$/;

--- a/src/app/api/combos/metrics/route.ts
+++ b/src/app/api/combos/metrics/route.ts
@@ -4,7 +4,7 @@ import {
   getComboMetrics,
   resetComboMetrics,
   resetAllComboMetrics,
-} from "@omniroute/open-sse/services/comboMetrics.js";
+} from "@omniroute/open-sse/services/comboMetrics.ts";
 
 // GET /api/combos/metrics - Get per-combo metrics
 export async function GET(request) {

--- a/src/app/api/combos/route.ts
+++ b/src/app/api/combos/route.ts
@@ -3,7 +3,7 @@ import { getCombos, createCombo, getComboByName, isCloudEnabled } from "@/lib/lo
 import { getConsistentMachineId } from "@/shared/utils/machineId";
 import { syncToCloud } from "@/lib/cloudSync";
 import { createComboSchema, validateBody } from "@/shared/validation/schemas";
-import { validateComboDAG } from "@omniroute/open-sse/services/combo.js";
+import { validateComboDAG } from "@omniroute/open-sse/services/combo.ts";
 
 // GET /api/combos - Get all combos
 export async function GET() {

--- a/src/app/api/models/catalog/route.ts
+++ b/src/app/api/models/catalog/route.ts
@@ -1,7 +1,7 @@
 import { getProviderConnections, getAllCustomModels } from "@/lib/localDb";
 import { PROVIDER_MODELS, PROVIDER_ID_TO_ALIAS } from "@/shared/constants/models";
-import { getAllEmbeddingModels } from "@omniroute/open-sse/config/embeddingRegistry.js";
-import { getAllImageModels } from "@omniroute/open-sse/config/imageRegistry.js";
+import { getAllEmbeddingModels } from "@omniroute/open-sse/config/embeddingRegistry.ts";
+import { getAllImageModels } from "@omniroute/open-sse/config/imageRegistry.ts";
 import { AI_PROVIDERS, ALIAS_TO_ID } from "@/shared/constants/providers";
 
 /**

--- a/src/app/api/pricing/models/route.ts
+++ b/src/app/api/pricing/models/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { REGISTRY } from "@omniroute/open-sse/config/providerRegistry.js";
+import { REGISTRY } from "@omniroute/open-sse/config/providerRegistry.ts";
 import { getAllCustomModels, getPricing } from "@/lib/localDb";
 
 /**

--- a/src/app/api/providers/[id]/test/route.ts
+++ b/src/app/api/providers/[id]/test/route.ts
@@ -5,7 +5,7 @@ import { syncToCloud } from "@/lib/cloudSync";
 import { validateProviderApiKey } from "@/lib/providers/validation";
 import { getCliRuntimeStatus } from "@/shared/services/cliRuntime";
 // Use the shared open-sse token refresh with built-in dedup/race-condition cache
-import { getAccessToken } from "@omniroute/open-sse/services/tokenRefresh.js";
+import { getAccessToken } from "@omniroute/open-sse/services/tokenRefresh.ts";
 import { saveCallLog } from "@/lib/usageDb";
 import { logProxyEvent } from "@/lib/proxyLogger";
 

--- a/src/app/api/rate-limits/route.ts
+++ b/src/app/api/rate-limits/route.ts
@@ -1,13 +1,13 @@
 import { NextResponse } from "next/server";
-import { getAllModelLockouts } from "@omniroute/open-sse/services/accountFallback.js";
-import { getCacheStats } from "@omniroute/open-sse/services/signatureCache.js";
+import { getAllModelLockouts } from "@omniroute/open-sse/services/accountFallback.ts";
+import { getCacheStats } from "@omniroute/open-sse/services/signatureCache.ts";
 import { getProviderConnections, updateProviderConnection } from "@/lib/localDb";
 import {
   enableRateLimitProtection,
   disableRateLimitProtection,
   getRateLimitStatus,
   getAllRateLimitStatus,
-} from "@omniroute/open-sse/services/rateLimitManager.js";
+} from "@omniroute/open-sse/services/rateLimitManager.ts";
 
 /**
  * GET /api/rate-limits — Consolidated rate-limit status

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import {
   getActiveSessions,
   getActiveSessionCount,
-} from "@omniroute/open-sse/services/sessionManager.js";
+} from "@omniroute/open-sse/services/sessionManager.ts";
 
 export async function GET() {
   try {

--- a/src/app/api/settings/ip-filter/route.ts
+++ b/src/app/api/settings/ip-filter/route.ts
@@ -8,7 +8,7 @@ import {
   removeFromWhitelist,
   tempBanIP,
   removeTempBan,
-} from "@omniroute/open-sse/services/ipFilter.js";
+} from "@omniroute/open-sse/services/ipFilter.ts";
 
 export async function GET() {
   try {

--- a/src/app/api/settings/proxy/test/route.ts
+++ b/src/app/api/settings/proxy/test/route.ts
@@ -4,7 +4,7 @@ import {
   isSocks5ProxyEnabled,
   proxyConfigToUrl,
   proxyUrlForLogs,
-} from "@omniroute/open-sse/utils/proxyDispatcher.js";
+} from "@omniroute/open-sse/utils/proxyDispatcher.ts";
 
 const BASE_SUPPORTED_PROXY_TYPES = new Set(["http", "https"]);
 

--- a/src/app/api/settings/system-prompt/route.ts
+++ b/src/app/api/settings/system-prompt/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import {
   setSystemPromptConfig,
   getSystemPromptConfig,
-} from "@omniroute/open-sse/services/systemPrompt.js";
+} from "@omniroute/open-sse/services/systemPrompt.ts";
 import { updateSettings } from "@/lib/localDb";
 
 export async function GET() {

--- a/src/app/api/settings/thinking-budget/route.ts
+++ b/src/app/api/settings/thinking-budget/route.ts
@@ -4,7 +4,7 @@ import {
   setThinkingBudgetConfig,
   getThinkingBudgetConfig,
   ThinkingMode,
-} from "@omniroute/open-sse/services/thinkingBudget.js";
+} from "@omniroute/open-sse/services/thinkingBudget.ts";
 
 export async function GET() {
   try {

--- a/src/app/api/tags/route.ts
+++ b/src/app/api/tags/route.ts
@@ -1,4 +1,4 @@
-import { ollamaModels } from "@omniroute/open-sse/config/ollamaModels.js";
+import { ollamaModels } from "@omniroute/open-sse/config/ollamaModels.ts";
 
 const CORS_HEADERS = {
   "Access-Control-Allow-Origin": "*",

--- a/src/app/api/translator/detect/route.ts
+++ b/src/app/api/translator/detect/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { detectFormat } from "@omniroute/open-sse/services/provider.js";
+import { detectFormat } from "@omniroute/open-sse/services/provider.ts";
 
 /**
  * POST /api/translator/detect

--- a/src/app/api/translator/send/route.ts
+++ b/src/app/api/translator/send/route.ts
@@ -4,7 +4,7 @@ import {
   buildProviderHeaders,
   detectFormat,
   getTargetFormat,
-} from "@omniroute/open-sse/services/provider.js";
+} from "@omniroute/open-sse/services/provider.ts";
 import { getProviderConnections } from "@/lib/localDb";
 import { toJsonErrorPayload } from "@/shared/utils/upstreamError";
 import { logTranslationEvent } from "@/lib/translatorEvents";

--- a/src/app/api/translator/translate/route.ts
+++ b/src/app/api/translator/translate/route.ts
@@ -4,9 +4,9 @@ import {
   getTargetFormat,
   buildProviderUrl,
   buildProviderHeaders,
-} from "@omniroute/open-sse/services/provider.js";
-import { translateRequest } from "@omniroute/open-sse/translator/index.js";
-import { FORMATS } from "@omniroute/open-sse/translator/formats.js";
+} from "@omniroute/open-sse/services/provider.ts";
+import { translateRequest } from "@omniroute/open-sse/translator/index.ts";
+import { FORMATS } from "@omniroute/open-sse/translator/formats.ts";
 import { getProviderConnections } from "@/lib/localDb";
 
 export async function POST(request) {

--- a/src/app/api/usage/[connectionId]/route.ts
+++ b/src/app/api/usage/[connectionId]/route.ts
@@ -1,7 +1,7 @@
 import { getProviderConnectionById, updateProviderConnection } from "@/lib/localDb";
 import { getMachineId } from "@/shared/utils/machine";
-import { getUsageForProvider } from "@omniroute/open-sse/services/usage.js";
-import { getExecutor } from "@omniroute/open-sse/executors/index.js";
+import { getUsageForProvider } from "@omniroute/open-sse/services/usage.ts";
+import { getExecutor } from "@omniroute/open-sse/executors/index.ts";
 import { syncToCloud } from "@/lib/cloudSync";
 
 /**

--- a/src/app/api/v1/api/chat/route.ts
+++ b/src/app/api/v1/api/chat/route.ts
@@ -1,6 +1,6 @@
 import { handleChat } from "@/sse/handlers/chat";
-import { initTranslators } from "@omniroute/open-sse/translator/index.js";
-import { transformToOllama } from "@omniroute/open-sse/utils/ollamaTransform.js";
+import { initTranslators } from "@omniroute/open-sse/translator/index.ts";
+import { transformToOllama } from "@omniroute/open-sse/utils/ollamaTransform.ts";
 
 let initialized = false;
 

--- a/src/app/api/v1/audio/speech/route.ts
+++ b/src/app/api/v1/audio/speech/route.ts
@@ -1,8 +1,8 @@
-import { handleAudioSpeech } from "@omniroute/open-sse/handlers/audioSpeech.js";
+import { handleAudioSpeech } from "@omniroute/open-sse/handlers/audioSpeech.ts";
 import { getProviderCredentials, extractApiKey, isValidApiKey } from "@/sse/services/auth";
-import { parseSpeechModel } from "@omniroute/open-sse/config/audioRegistry.js";
-import { errorResponse } from "@omniroute/open-sse/utils/error.js";
-import { HTTP_STATUS } from "@omniroute/open-sse/config/constants.js";
+import { parseSpeechModel } from "@omniroute/open-sse/config/audioRegistry.ts";
+import { errorResponse } from "@omniroute/open-sse/utils/error.ts";
+import { HTTP_STATUS } from "@omniroute/open-sse/config/constants.ts";
 
 /**
  * Handle CORS preflight

--- a/src/app/api/v1/audio/transcriptions/route.ts
+++ b/src/app/api/v1/audio/transcriptions/route.ts
@@ -1,8 +1,8 @@
-import { handleAudioTranscription } from "@omniroute/open-sse/handlers/audioTranscription.js";
+import { handleAudioTranscription } from "@omniroute/open-sse/handlers/audioTranscription.ts";
 import { getProviderCredentials, extractApiKey, isValidApiKey } from "@/sse/services/auth";
-import { parseTranscriptionModel } from "@omniroute/open-sse/config/audioRegistry.js";
-import { errorResponse } from "@omniroute/open-sse/utils/error.js";
-import { HTTP_STATUS } from "@omniroute/open-sse/config/constants.js";
+import { parseTranscriptionModel } from "@omniroute/open-sse/config/audioRegistry.ts";
+import { errorResponse } from "@omniroute/open-sse/utils/error.ts";
+import { HTTP_STATUS } from "@omniroute/open-sse/config/constants.ts";
 
 /**
  * Handle CORS preflight

--- a/src/app/api/v1/chat/completions/route.ts
+++ b/src/app/api/v1/chat/completions/route.ts
@@ -1,6 +1,6 @@
 import { callCloudWithMachineId } from "@/shared/utils/cloud";
 import { handleChat } from "@/sse/handlers/chat";
-import { initTranslators } from "@omniroute/open-sse/translator/index.js";
+import { initTranslators } from "@omniroute/open-sse/translator/index.ts";
 
 let initPromise = null;
 

--- a/src/app/api/v1/embeddings/route.ts
+++ b/src/app/api/v1/embeddings/route.ts
@@ -1,11 +1,11 @@
-import { handleEmbedding } from "@omniroute/open-sse/handlers/embeddings.js";
+import { handleEmbedding } from "@omniroute/open-sse/handlers/embeddings.ts";
 import { getProviderCredentials, extractApiKey, isValidApiKey } from "@/sse/services/auth";
 import {
   parseEmbeddingModel,
   getAllEmbeddingModels,
-} from "@omniroute/open-sse/config/embeddingRegistry.js";
-import { errorResponse } from "@omniroute/open-sse/utils/error.js";
-import { HTTP_STATUS } from "@omniroute/open-sse/config/constants.js";
+} from "@omniroute/open-sse/config/embeddingRegistry.ts";
+import { errorResponse } from "@omniroute/open-sse/utils/error.ts";
+import { HTTP_STATUS } from "@omniroute/open-sse/config/constants.ts";
 import * as log from "@/sse/utils/logger";
 import { toJsonErrorPayload } from "@/shared/utils/upstreamError";
 

--- a/src/app/api/v1/images/generations/route.ts
+++ b/src/app/api/v1/images/generations/route.ts
@@ -1,8 +1,8 @@
-import { handleImageGeneration } from "@omniroute/open-sse/handlers/imageGeneration.js";
+import { handleImageGeneration } from "@omniroute/open-sse/handlers/imageGeneration.ts";
 import { getProviderCredentials, extractApiKey, isValidApiKey } from "@/sse/services/auth";
-import { parseImageModel, getAllImageModels } from "@omniroute/open-sse/config/imageRegistry.js";
-import { errorResponse } from "@omniroute/open-sse/utils/error.js";
-import { HTTP_STATUS } from "@omniroute/open-sse/config/constants.js";
+import { parseImageModel, getAllImageModels } from "@omniroute/open-sse/config/imageRegistry.ts";
+import { errorResponse } from "@omniroute/open-sse/utils/error.ts";
+import { HTTP_STATUS } from "@omniroute/open-sse/config/constants.ts";
 import * as log from "@/sse/utils/logger";
 import { toJsonErrorPayload } from "@/shared/utils/upstreamError";
 

--- a/src/app/api/v1/messages/route.ts
+++ b/src/app/api/v1/messages/route.ts
@@ -1,5 +1,5 @@
 import { handleChat } from "@/sse/handlers/chat";
-import { initTranslators } from "@omniroute/open-sse/translator/index.js";
+import { initTranslators } from "@omniroute/open-sse/translator/index.ts";
 
 let initialized = false;
 

--- a/src/app/api/v1/models/route.ts
+++ b/src/app/api/v1/models/route.ts
@@ -1,11 +1,11 @@
 import { PROVIDER_MODELS, PROVIDER_ID_TO_ALIAS } from "@/shared/constants/models";
 import { AI_PROVIDERS } from "@/shared/constants/providers";
 import { getProviderConnections, getCombos, getAllCustomModels } from "@/lib/localDb";
-import { getAllEmbeddingModels } from "@omniroute/open-sse/config/embeddingRegistry.js";
-import { getAllImageModels } from "@omniroute/open-sse/config/imageRegistry.js";
-import { getAllRerankModels } from "@omniroute/open-sse/config/rerankRegistry.js";
-import { getAllAudioModels } from "@omniroute/open-sse/config/audioRegistry.js";
-import { getAllModerationModels } from "@omniroute/open-sse/config/moderationRegistry.js";
+import { getAllEmbeddingModels } from "@omniroute/open-sse/config/embeddingRegistry.ts";
+import { getAllImageModels } from "@omniroute/open-sse/config/imageRegistry.ts";
+import { getAllRerankModels } from "@omniroute/open-sse/config/rerankRegistry.ts";
+import { getAllAudioModels } from "@omniroute/open-sse/config/audioRegistry.ts";
+import { getAllModerationModels } from "@omniroute/open-sse/config/moderationRegistry.ts";
 
 const FALLBACK_ALIAS_TO_PROVIDER = {
   ag: "antigravity",

--- a/src/app/api/v1/moderations/route.ts
+++ b/src/app/api/v1/moderations/route.ts
@@ -1,8 +1,8 @@
-import { handleModeration } from "@omniroute/open-sse/handlers/moderations.js";
+import { handleModeration } from "@omniroute/open-sse/handlers/moderations.ts";
 import { getProviderCredentials, extractApiKey, isValidApiKey } from "@/sse/services/auth";
-import { parseModerationModel } from "@omniroute/open-sse/config/moderationRegistry.js";
-import { errorResponse } from "@omniroute/open-sse/utils/error.js";
-import { HTTP_STATUS } from "@omniroute/open-sse/config/constants.js";
+import { parseModerationModel } from "@omniroute/open-sse/config/moderationRegistry.ts";
+import { errorResponse } from "@omniroute/open-sse/utils/error.ts";
+import { HTTP_STATUS } from "@omniroute/open-sse/config/constants.ts";
 
 /**
  * Handle CORS preflight

--- a/src/app/api/v1/providers/[provider]/chat/completions/route.ts
+++ b/src/app/api/v1/providers/[provider]/chat/completions/route.ts
@@ -1,8 +1,8 @@
 import { handleChat } from "@/sse/handlers/chat";
-import { initTranslators } from "@omniroute/open-sse/translator/index.js";
-import { errorResponse } from "@omniroute/open-sse/utils/error.js";
-import { HTTP_STATUS } from "@omniroute/open-sse/config/constants.js";
-import { getRegistryEntry } from "@omniroute/open-sse/config/providerRegistry.js";
+import { initTranslators } from "@omniroute/open-sse/translator/index.ts";
+import { errorResponse } from "@omniroute/open-sse/utils/error.ts";
+import { HTTP_STATUS } from "@omniroute/open-sse/config/constants.ts";
+import { getRegistryEntry } from "@omniroute/open-sse/config/providerRegistry.ts";
 
 let initialized = false;
 

--- a/src/app/api/v1/providers/[provider]/embeddings/route.ts
+++ b/src/app/api/v1/providers/[provider]/embeddings/route.ts
@@ -1,8 +1,8 @@
-import { errorResponse } from "@omniroute/open-sse/utils/error.js";
-import { HTTP_STATUS } from "@omniroute/open-sse/config/constants.js";
-import { getRegistryEntry } from "@omniroute/open-sse/config/providerRegistry.js";
+import { errorResponse } from "@omniroute/open-sse/utils/error.ts";
+import { HTTP_STATUS } from "@omniroute/open-sse/config/constants.ts";
+import { getRegistryEntry } from "@omniroute/open-sse/config/providerRegistry.ts";
 import { getProviderCredentials, extractApiKey, isValidApiKey } from "@/sse/services/auth";
-import { handleEmbedding } from "@omniroute/open-sse/handlers/embeddings.js";
+import { handleEmbedding } from "@omniroute/open-sse/handlers/embeddings.ts";
 import * as log from "@/sse/utils/logger";
 
 /**

--- a/src/app/api/v1/providers/[provider]/images/generations/route.ts
+++ b/src/app/api/v1/providers/[provider]/images/generations/route.ts
@@ -1,8 +1,8 @@
-import { handleImageGeneration } from "@omniroute/open-sse/handlers/imageGeneration.js";
-import { errorResponse } from "@omniroute/open-sse/utils/error.js";
-import { HTTP_STATUS } from "@omniroute/open-sse/config/constants.js";
+import { handleImageGeneration } from "@omniroute/open-sse/handlers/imageGeneration.ts";
+import { errorResponse } from "@omniroute/open-sse/utils/error.ts";
+import { HTTP_STATUS } from "@omniroute/open-sse/config/constants.ts";
 import { getProviderCredentials, extractApiKey, isValidApiKey } from "@/sse/services/auth";
-import { getImageProvider } from "@omniroute/open-sse/config/imageRegistry.js";
+import { getImageProvider } from "@omniroute/open-sse/config/imageRegistry.ts";
 import * as log from "@/sse/utils/logger";
 import { toJsonErrorPayload } from "@/shared/utils/upstreamError";
 

--- a/src/app/api/v1/rerank/route.ts
+++ b/src/app/api/v1/rerank/route.ts
@@ -1,8 +1,8 @@
-import { handleRerank } from "@omniroute/open-sse/handlers/rerank.js";
+import { handleRerank } from "@omniroute/open-sse/handlers/rerank.ts";
 import { getProviderCredentials, extractApiKey, isValidApiKey } from "@/sse/services/auth";
-import { parseRerankModel } from "@omniroute/open-sse/config/rerankRegistry.js";
-import { errorResponse } from "@omniroute/open-sse/utils/error.js";
-import { HTTP_STATUS } from "@omniroute/open-sse/config/constants.js";
+import { parseRerankModel } from "@omniroute/open-sse/config/rerankRegistry.ts";
+import { errorResponse } from "@omniroute/open-sse/utils/error.ts";
+import { HTTP_STATUS } from "@omniroute/open-sse/config/constants.ts";
 
 /**
  * Handle CORS preflight

--- a/src/app/api/v1/responses/route.ts
+++ b/src/app/api/v1/responses/route.ts
@@ -1,5 +1,5 @@
 import { handleChat } from "@/sse/handlers/chat";
-import { initTranslators } from "@omniroute/open-sse/translator/index.js";
+import { initTranslators } from "@omniroute/open-sse/translator/index.ts";
 
 let initialized = false;
 

--- a/src/app/api/v1beta/models/[...path]/route.ts
+++ b/src/app/api/v1beta/models/[...path]/route.ts
@@ -1,5 +1,5 @@
 import { handleChat } from "@/sse/handlers/chat";
-import { initTranslators } from "@omniroute/open-sse/translator/index.js";
+import { initTranslators } from "@omniroute/open-sse/translator/index.ts";
 
 let initialized = false;
 

--- a/src/lib/db/settings.ts
+++ b/src/lib/db/settings.ts
@@ -4,7 +4,7 @@
 
 import { getDbInstance } from "./core";
 import { backupDbFile } from "./backup";
-import { PROVIDER_ID_TO_ALIAS } from "@omniroute/open-sse/config/providerModels.js";
+import { PROVIDER_ID_TO_ALIAS } from "@omniroute/open-sse/config/providerModels.ts";
 
 // ──────────────── Settings ────────────────
 

--- a/src/lib/providers/validation.ts
+++ b/src/lib/providers/validation.ts
@@ -1,4 +1,4 @@
-import { getRegistryEntry } from "@omniroute/open-sse/config/providerRegistry.js";
+import { getRegistryEntry } from "@omniroute/open-sse/config/providerRegistry.ts";
 import {
   isAnthropicCompatibleProvider,
   isOpenAICompatibleProvider,

--- a/src/lib/tokenHealthCheck.ts
+++ b/src/lib/tokenHealthCheck.ts
@@ -15,7 +15,7 @@ import {
   getAccessToken,
   supportsTokenRefresh,
   isUnrecoverableRefreshError,
-} from "@omniroute/open-sse/services/tokenRefresh.js";
+} from "@omniroute/open-sse/services/tokenRefresh.ts";
 
 // ── Constants ────────────────────────────────────────────────────────────────
 const TICK_MS = 60 * 1000; // sweep interval: every 60 seconds

--- a/src/shared/constants/models.ts
+++ b/src/shared/constants/models.ts
@@ -8,10 +8,10 @@ export {
   getModelTargetFormat,
   PROVIDER_ID_TO_ALIAS,
   getModelsByProviderId,
-} from "@omniroute/open-sse/config/providerModels.js";
+} from "@omniroute/open-sse/config/providerModels.ts";
 
 import { AI_PROVIDERS, isOpenAICompatibleProvider } from "./providers";
-import { PROVIDER_MODELS as MODELS } from "@omniroute/open-sse/config/providerModels.js";
+import { PROVIDER_MODELS as MODELS } from "@omniroute/open-sse/config/providerModels.ts";
 
 // Providers that accept any model (passthrough)
 const PASSTHROUGH_PROVIDERS = new Set(

--- a/src/sse/handlers/chat.ts
+++ b/src/sse/handlers/chat.ts
@@ -6,21 +6,21 @@ import {
   isValidApiKey,
 } from "../services/auth";
 import { getModelInfo, getCombo } from "../services/model";
-import { parseModel } from "@omniroute/open-sse/services/model.js";
-import { detectFormat, getTargetFormat } from "@omniroute/open-sse/services/provider.js";
-import { handleChatCore } from "@omniroute/open-sse/handlers/chatCore.js";
-import { errorResponse, unavailableResponse } from "@omniroute/open-sse/utils/error.js";
-import { handleComboChat } from "@omniroute/open-sse/services/combo.js";
-import { HTTP_STATUS } from "@omniroute/open-sse/config/constants.js";
+import { parseModel } from "@omniroute/open-sse/services/model.ts";
+import { detectFormat, getTargetFormat } from "@omniroute/open-sse/services/provider.ts";
+import { handleChatCore } from "@omniroute/open-sse/handlers/chatCore.ts";
+import { errorResponse, unavailableResponse } from "@omniroute/open-sse/utils/error.ts";
+import { handleComboChat } from "@omniroute/open-sse/services/combo.ts";
+import { HTTP_STATUS } from "@omniroute/open-sse/config/constants.ts";
 import {
   getModelTargetFormat,
   PROVIDER_ID_TO_ALIAS,
-} from "@omniroute/open-sse/config/providerModels.js";
+} from "@omniroute/open-sse/config/providerModels.ts";
 import {
   runWithProxyContext,
   runWithTlsTracking,
   isTlsFingerprintActive,
-} from "@omniroute/open-sse/utils/proxyFetch.js";
+} from "@omniroute/open-sse/utils/proxyFetch.ts";
 import * as log from "../utils/logger";
 import { updateProviderCredentials, checkAndRefreshToken } from "../services/tokenRefresh";
 import { getSettings, getCombos, getApiKeyMetadata } from "@/lib/localDb";

--- a/src/sse/handlers/chatHelpers.ts
+++ b/src/sse/handlers/chatHelpers.ts
@@ -12,11 +12,11 @@
  */
 
 import { getModelInfo } from "../services/model";
-import { detectFormat, getTargetFormat } from "@omniroute/open-sse/services/provider.js";
+import { detectFormat, getTargetFormat } from "@omniroute/open-sse/services/provider.ts";
 import {
   getModelTargetFormat,
   PROVIDER_ID_TO_ALIAS,
-} from "@omniroute/open-sse/config/providerModels.js";
+} from "@omniroute/open-sse/config/providerModels.ts";
 import { logProxyEvent } from "../../lib/proxyLogger";
 import { logTranslationEvent } from "../../lib/translatorEvents";
 // updateProviderCredentials is dynamically imported from ../services/auth when needed

--- a/src/sse/services/auth.ts
+++ b/src/sse/services/auth.ts
@@ -12,7 +12,7 @@ import {
   checkFallbackError,
   isModelLocked,
   lockModel,
-} from "@omniroute/open-sse/services/accountFallback.js";
+} from "@omniroute/open-sse/services/accountFallback.ts";
 import * as log from "../utils/logger";
 
 // Mutex to prevent race conditions during account selection

--- a/src/sse/services/model.ts
+++ b/src/sse/services/model.ts
@@ -4,7 +4,7 @@ import {
   parseModel,
   resolveModelAliasFromMap,
   getModelInfoCore,
-} from "@omniroute/open-sse/services/model.js";
+} from "@omniroute/open-sse/services/model.ts";
 
 export { parseModel };
 

--- a/src/sse/services/tokenRefresh.ts
+++ b/src/sse/services/tokenRefresh.ts
@@ -15,7 +15,7 @@ import {
   refreshTokenByProvider as _refreshTokenByProvider,
   formatProviderCredentials as _formatProviderCredentials,
   getAllAccessTokens as _getAllAccessTokens,
-} from "@omniroute/open-sse/services/tokenRefresh.js";
+} from "@omniroute/open-sse/services/tokenRefresh.ts";
 
 export const TOKEN_EXPIRY_BUFFER_MS = BUFFER_MS;
 


### PR DESCRIPTION
## Root Cause

After the TypeScript migration (PR #62), all files were renamed from `.js` to `.ts` but **294 import paths** were not updated. This caused `npm run build` to fail with:

```
Module not found: Can't resolve '@omniroute/open-sse/config/providerModels.js'
Module not found: Can't resolve './providerRegistry.js'
Module not found: Can't resolve './credentialLoader.js'
```

## Fix

Updated all 294 import paths across 99 files:
- `from ".../.js"` → `from ".../.ts"`
- `import ".../.js"` → `import ".../.ts"`  
- `@omniroute/open-sse/*.js` → `@omniroute/open-sse/*.ts`

## Verification

```bash
npm run build  # ✅ Exit code 0
```