### PR TITLE
refactor(dashboard): rename Usage to Request Logs and extract Limits & Quotas page

### DIFF
--- a/src/app/(dashboard)/dashboard/HomePageClient.tsx
+++ b/src/app/(dashboard)/dashboard/HomePageClient.tsx
@@ -204,7 +204,7 @@ export default function HomePageClient({ machineId }) {
                 <p className="text-text-muted mt-0.5">
                   Track tokens, cost and errors in{" "}
                   <Link href="/dashboard/usage" className="text-primary hover:underline">
-                    Usage
+                    Request Logs
                   </Link>{" "}
                   and{" "}
                   <Link href="/dashboard/analytics" className="text-primary hover:underline">

--- a/src/app/(dashboard)/dashboard/limits/page.tsx
+++ b/src/app/(dashboard)/dashboard/limits/page.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { Suspense } from "react";
+import { CardSkeleton } from "@/shared/components";
+import ProviderLimits from "../usage/components/ProviderLimits";
+import RateLimitStatus from "../usage/components/RateLimitStatus";
+import SessionsTab from "../usage/components/SessionsTab";
+
+export default function LimitsPage() {
+  return (
+    <div className="flex flex-col gap-6">
+      <Suspense fallback={<CardSkeleton />}>
+        <ProviderLimits />
+      </Suspense>
+      <RateLimitStatus />
+      <SessionsTab />
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/usage/page.tsx
+++ b/src/app/(dashboard)/dashboard/usage/page.tsx
@@ -1,10 +1,7 @@
 "use client";
 
-import { useState, Suspense } from "react";
-import { RequestLoggerV2, ProxyLogger, CardSkeleton, SegmentedControl } from "@/shared/components";
-import ProviderLimits from "./components/ProviderLimits";
-import SessionsTab from "./components/SessionsTab";
-import RateLimitStatus from "./components/RateLimitStatus";
+import { useState } from "react";
+import { RequestLoggerV2, ProxyLogger, SegmentedControl } from "@/shared/components";
 
 export default function UsagePage() {
   const [activeTab, setActiveTab] = useState("logs");
@@ -15,22 +12,12 @@ export default function UsagePage() {
         options={[
           { value: "logs", label: "Logger" },
           { value: "proxy-logs", label: "Proxy" },
-          { value: "limits", label: "Limits" },
         ]}
         value={activeTab}
         onChange={setActiveTab}
       />
 
       {/* Content */}
-      {activeTab === "limits" && (
-        <div className="flex flex-col gap-6">
-          <Suspense fallback={<CardSkeleton />}>
-            <ProviderLimits />
-          </Suspense>
-          <RateLimitStatus />
-          <SessionsTab />
-        </div>
-      )}
       {activeTab === "logs" && <RequestLoggerV2 />}
       {activeTab === "proxy-logs" && <ProxyLogger />}
     </div>

--- a/src/shared/components/Sidebar.tsx
+++ b/src/shared/components/Sidebar.tsx
@@ -16,9 +16,10 @@ const navItems = [
   { href: "/dashboard/endpoint", label: "Endpoint", icon: "api" },
   { href: "/dashboard/providers", label: "Providers", icon: "dns" },
   { href: "/dashboard/combos", label: "Combos", icon: "layers" },
-  { href: "/dashboard/usage", label: "Usage", icon: "bar_chart" },
+  { href: "/dashboard/usage", label: "Request Logs", icon: "receipt_long" },
   { href: "/dashboard/costs", label: "Costs", icon: "account_balance_wallet" },
   { href: "/dashboard/analytics", label: "Analytics", icon: "analytics" },
+  { href: "/dashboard/limits", label: "Limits & Quotas", icon: "tune" },
   { href: "/dashboard/health", label: "Health", icon: "health_and_safety" },
   { href: "/dashboard/cli-tools", label: "CLI Tools", icon: "terminal" },
 ];
@@ -38,7 +39,15 @@ const helpItems = [
   },
 ];
 
-export default function Sidebar({ onClose, collapsed = false, onToggleCollapse }: { onClose?: any; collapsed?: boolean; onToggleCollapse?: any }) {
+export default function Sidebar({
+  onClose,
+  collapsed = false,
+  onToggleCollapse,
+}: {
+  onClose?: any;
+  collapsed?: boolean;
+  onToggleCollapse?: any;
+}) {
   const pathname = usePathname();
   const [showShutdownModal, setShowShutdownModal] = useState(false);
   const [showRestartModal, setShowRestartModal] = useState(false);


### PR DESCRIPTION
## Changes
- Rename 'Usage' sidebar item to **Request Logs** with `receipt_long` icon
- Add new **Limits & Quotas** sidebar item with `tune` icon
- Extract ProviderLimits, RateLimitStatus, SessionsTab to dedicated `/dashboard/limits` page
- Simplify usage page to only Logger and Proxy tabs
- Update HomePageClient Quick Start cross-reference text

## Files Changed
- `src/shared/components/Sidebar.tsx` — nav items update
- `src/app/(dashboard)/dashboard/HomePageClient.tsx` — cross-ref text
- `src/app/(dashboard)/dashboard/usage/page.tsx` — removed Limits tab
- `src/app/(dashboard)/dashboard/limits/page.tsx` — NEW page