### PR TITLE
fix: OAuth login behind nginx/reverse proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,9 @@ REQUIRE_API_KEY=false
 BASE_URL=http://localhost:20128
 CLOUD_URL=
 # Backward-compatible/public variables:
+# NEXT_PUBLIC_BASE_URL is also used as the OAuth redirect_uri origin when running behind a
+# reverse proxy (e.g., nginx). Set this to your public-facing URL so OAuth callbacks work.
+# Example: NEXT_PUBLIC_BASE_URL=https://omniroute.example.com
 NEXT_PUBLIC_BASE_URL=http://localhost:20128
 NEXT_PUBLIC_CLOUD_URL=
 


### PR DESCRIPTION
## Problem

When OmniRoute is behind an nginx reverse proxy, OAuth login fails because the `redirect_uri` was hardcoded to `http://localhost:{port}/callback`. The OAuth provider would redirect to `localhost`, which is unreachable when accessing OmniRoute remotely.

## Root Cause

`OAuthModal.tsx` always constructed the redirect URI as `http://localhost:{port}/callback`, regardless of whether the user was accessing OmniRoute through a proxy or directly.

## Fix

**`OAuthModal.tsx`**: When **not on localhost** (i.e., behind a reverse proxy), use `window.location.origin + '/callback'` as the redirect URI. This ensures the OAuth provider redirects back to the actual proxied URL (e.g., `https://omniroute.example.com/callback`), where the existing callback page properly handles the code exchange via `postMessage`, `BroadcastChannel`, or `localStorage`.

- **Codex/OpenAI**: Keeps fixed port 1455 (registered redirect URI)
- **All other providers** (Claude, Gemini, GitHub, etc.): Uses actual origin when proxied
- Also supports `NEXT_PUBLIC_BASE_URL` env var as explicit override

**`.env.example`**: Added documentation about `NEXT_PUBLIC_BASE_URL` being used for OAuth callbacks behind reverse proxy.

## How to configure

Set `NEXT_PUBLIC_BASE_URL` in your `.env` to your public-facing URL:
```
NEXT_PUBLIC_BASE_URL=https://omniroute.example.com
```

Or, if not set, the app automatically uses `window.location.origin`.

Closes #82