### PR TITLE
fix: extract email from id_token for Codex OAuth to allow multiple ac…

### DIFF
--- a/src/lib/oauth/providers/codex.ts
+++ b/src/lib/oauth/providers/codex.ts
@@ -44,10 +44,24 @@ export const codex = {
 
     return await response.json();
   },
-  mapTokens: (tokens) => ({
-    accessToken: tokens.access_token,
-    refreshToken: tokens.refresh_token,
-    idToken: tokens.id_token,
-    expiresIn: tokens.expires_in,
-  }),
+  mapTokens: (tokens) => {
+    // Extract email from id_token JWT to distinguish between accounts
+    let email = null;
+    if (tokens.id_token) {
+      try {
+        const payload = tokens.id_token.split(".")[1];
+        const decoded = JSON.parse(Buffer.from(payload, "base64").toString());
+        email = decoded.email || null;
+      } catch {
+        // Ignore JWT parsing errors
+      }
+    }
+    return {
+      accessToken: tokens.access_token,
+      refreshToken: tokens.refresh_token,
+      idToken: tokens.id_token,
+      expiresIn: tokens.expires_in,
+      email,
+    };
+  },
 };


### PR DESCRIPTION
Adding multiple codex provider failed before fixed that in this update

- Parse JWT id_token to extract email in mapTokens function
- Allows database to distinguish between different Codex accounts
- Fixes issue where adding More than 1+ Codex account would update existing connection instead of creating new one