### PR TITLE
fix: enforce API key model restrictions across all /v1/* endpoints

### DIFF
--- a/src/app/api/v1/rerank/route.ts
+++ b/src/app/api/v1/rerank/route.ts
@@ -4,6 +4,7 @@ import { getProviderCredentials, extractApiKey, isValidApiKey } from "@/sse/serv
 import { parseRerankModel } from "@omniroute/open-sse/config/rerankRegistry.ts";
 import { errorResponse } from "@omniroute/open-sse/utils/error.ts";
 import { HTTP_STATUS } from "@omniroute/open-sse/config/constants.ts";
+import { enforceApiKeyPolicy } from "@/shared/utils/apiKeyPolicy";
 
 /**
  * Handle CORS preflight
@@ -43,6 +44,10 @@ export async function POST(request) {
   if (!body.model) {
     return errorResponse(HTTP_STATUS.BAD_REQUEST, "Missing model");
   }
+
+  // Enforce API key policies (model restrictions + budget limits)
+  const policy = await enforceApiKeyPolicy(request, body.model);
+  if (policy.rejection) return policy.rejection;
 
   const { provider } = parseRerankModel(body.model);
   if (!provider) {

--- a/src/shared/utils/apiKeyPolicy.ts
+++ b/src/shared/utils/apiKeyPolicy.ts
@@ -1,0 +1,104 @@
+/**
+ * API Key Policy Enforcement — Shared middleware for all /v1/* endpoints.
+ *
+ * Enforces API key policies: model restrictions and budget limits.
+ * Should be called after API key authentication in every endpoint that
+ * accepts a model parameter.
+ *
+ * @module shared/utils/apiKeyPolicy
+ */
+
+import { extractApiKey } from "@/sse/services/auth";
+import { getApiKeyMetadata, isModelAllowedForKey } from "@/lib/localDb";
+import { checkBudget } from "@/domain/costRules";
+import { errorResponse } from "@omniroute/open-sse/utils/error.ts";
+import { HTTP_STATUS } from "@omniroute/open-sse/config/constants.ts";
+
+export interface ApiKeyPolicyResult {
+  /** API key string (null if no key provided) */
+  apiKey: string | null;
+  /** Metadata from DB (null if no key or key not found) */
+  apiKeyInfo: any | null;
+  /** If set, the request should be rejected with this Response */
+  rejection: Response | null;
+}
+
+/**
+ * Enforce API key policies for a request.
+ *
+ * Checks:
+ * 1. Model restriction — if the key has `allowedModels`, verify the requested model is permitted
+ * 2. Budget limit — if the key has a budget configured, verify it hasn't been exceeded
+ *
+ * @param request - The incoming HTTP request
+ * @param modelStr - The model ID from the request body
+ * @returns ApiKeyPolicyResult with apiKey, metadata, and optional rejection response
+ *
+ * @example
+ * ```ts
+ * const policy = await enforceApiKeyPolicy(request, body.model);
+ * if (policy.rejection) return policy.rejection;
+ * // proceed with request, optionally use policy.apiKeyInfo
+ * ```
+ */
+export async function enforceApiKeyPolicy(
+  request: Request,
+  modelStr: string | null
+): Promise<ApiKeyPolicyResult> {
+  const apiKey = extractApiKey(request);
+
+  // No API key = local mode, skip policy checks
+  if (!apiKey) {
+    return { apiKey: null, apiKeyInfo: null, rejection: null };
+  }
+
+  // Fetch key metadata (includes allowedModels)
+  let apiKeyInfo: any = null;
+  try {
+    apiKeyInfo = await getApiKeyMetadata(apiKey);
+  } catch {
+    // If metadata fetch fails, don't block — degrade gracefully
+    return { apiKey, apiKeyInfo: null, rejection: null };
+  }
+
+  // Key not found in DB — skip policy (auth layer handles validation)
+  if (!apiKeyInfo) {
+    return { apiKey, apiKeyInfo: null, rejection: null };
+  }
+
+  // ── Check 1: Model restriction ──
+  if (modelStr && apiKeyInfo.allowedModels && apiKeyInfo.allowedModels.length > 0) {
+    const allowed = await isModelAllowedForKey(apiKey, modelStr);
+    if (!allowed) {
+      return {
+        apiKey,
+        apiKeyInfo,
+        rejection: errorResponse(
+          HTTP_STATUS.FORBIDDEN,
+          `Model "${modelStr}" is not allowed for this API key`
+        ),
+      };
+    }
+  }
+
+  // ── Check 2: Budget limit ──
+  if (apiKeyInfo.id) {
+    try {
+      const budgetOk = checkBudget(apiKeyInfo.id);
+      if (!budgetOk.allowed) {
+        return {
+          apiKey,
+          apiKeyInfo,
+          rejection: errorResponse(
+            HTTP_STATUS.RATE_LIMITED,
+            budgetOk.reason || "Budget limit exceeded"
+          ),
+        };
+      }
+    } catch {
+      // Budget check is best-effort — don't block on errors
+    }
+  }
+
+  return { apiKey, apiKeyInfo, rejection: null };
+}

--- a/src/sse/handlers/chat.ts
+++ b/src/sse/handlers/chat.ts
@@ -23,7 +23,7 @@ import {
 } from "@omniroute/open-sse/utils/proxyFetch.ts";
 import * as log from "../utils/logger";
 import { updateProviderCredentials, checkAndRefreshToken } from "../services/tokenRefresh";
-import { getSettings, getCombos, getApiKeyMetadata } from "@/lib/localDb";
+import { getSettings, getCombos } from "@/lib/localDb";
 import { resolveProxyForConnection } from "@/lib/localDb";
 import { logProxyEvent } from "../../lib/proxyLogger";
 import { logTranslationEvent } from "../../lib/translatorEvents";
@@ -34,8 +34,9 @@ import { getCircuitBreaker, CircuitBreakerOpenError } from "../../shared/utils/c
 import { isModelAvailable, setModelUnavailable } from "../../domain/modelAvailability";
 import { RequestTelemetry, recordTelemetry } from "../../shared/utils/requestTelemetry";
 import { generateRequestId } from "../../shared/utils/requestId";
-import { checkBudget, recordCost } from "../../domain/costRules";
+import { recordCost } from "../../domain/costRules";
 import { logAuditEvent } from "../../lib/compliance/index";
+import { enforceApiKeyPolicy } from "../../shared/utils/apiKeyPolicy";
 
 /**
  * Handle chat completion request
@@ -97,15 +98,8 @@ export async function handleChat(request: any, clientRawRequest: any = null) {
   // Log API key (masked)
   const authHeader = request.headers.get("Authorization");
   const apiKey = extractApiKey(request);
-  let apiKeyInfo = null;
   if (authHeader && apiKey) {
-    const masked = log.maskKey(apiKey);
-    log.debug("AUTH", `API Key: ${masked}`);
-    try {
-      apiKeyInfo = await getApiKeyMetadata(apiKey);
-    } catch {
-      apiKeyInfo = null;
-    }
+    log.debug("AUTH", `API Key: ${log.maskKey(apiKey)}`);
   } else {
     log.debug("AUTH", "No API key provided (local mode)");
   }
@@ -129,19 +123,14 @@ export async function handleChat(request: any, clientRawRequest: any = null) {
     return errorResponse(HTTP_STATUS.BAD_REQUEST, "Missing model");
   }
 
-  // Pipeline: Budget check (if API key has budget limits)
+  // Pipeline: API key policy enforcement (model restrictions + budget limits)
   telemetry.startPhase("policy");
-  if (apiKeyInfo?.id) {
-    try {
-      const budgetOk = checkBudget(apiKeyInfo.id);
-      if (!budgetOk.allowed) {
-        log.warn("BUDGET", `API key ${apiKeyInfo.id} exceeded budget: ${budgetOk.reason}`);
-        return errorResponse(429, budgetOk.reason || "Budget limit exceeded");
-      }
-    } catch {
-      // Budget check is best-effort — don't block on errors
-    }
+  const policy = await enforceApiKeyPolicy(request, modelStr);
+  if (policy.rejection) {
+    log.warn("POLICY", `API key policy rejected: ${modelStr} (key=${policy.apiKeyInfo?.id || "unknown"})`);
+    return policy.rejection;
   }
+  const apiKeyInfo = policy.apiKeyInfo;
   telemetry.endPhase();
 
   // Check if model is a combo (has multiple models with fallback)


### PR DESCRIPTION
## Summary

Fixes #130 — `isModelAllowedForKey()` existed but was never called. API keys with `allowedModels` restrictions could access any model through any endpoint.

## Changes

### New: `src/shared/utils/apiKeyPolicy.ts`

Shared middleware that enforces two checks:

1. **Model restriction** — if the API key has `allowedModels` configured, verify the requested model is in the allowed list (supports exact match, prefix match like `openai/*`, and wildcard patterns)
2. **Budget limit** — if the API key has a budget configured, verify it hasn't been exceeded

Usage in any endpoint:
```typescript
import { enforceApiKeyPolicy } from "@/shared/utils/apiKeyPolicy";

const policy = await enforceApiKeyPolicy(request, body.model);
if (policy.rejection) return policy.rejection;
```

### Modified endpoints

| Endpoint | Change |
|---|---|
| `src/sse/handlers/chat.ts` | Replaced inline budget-only check with `enforceApiKeyPolicy()` |
| `src/app/api/v1/embeddings/route.ts` | Added `enforceApiKeyPolicy()` |
| `src/app/api/v1/images/generations/route.ts` | Added `enforceApiKeyPolicy()` |
| `src/app/api/v1/audio/speech/route.ts` | Added `enforceApiKeyPolicy()` |
| `src/app/api/v1/audio/transcriptions/route.ts` | Added `enforceApiKeyPolicy()` |
| `src/app/api/v1/moderations/route.ts` | Added `enforceApiKeyPolicy()` |
| `src/app/api/v1/rerank/route.ts` | Added `enforceApiKeyPolicy()` |
| `src/app/api/v1/providers/[provider]/embeddings/route.ts` | Added `enforceApiKeyPolicy()` |
| `src/app/api/v1/providers/[provider]/images/generations/route.ts` | Added `enforceApiKeyPolicy()` |

### Not modified (already covered)
- `/v1/responses` and `/v1/providers/[provider]/chat/completions` — these call `handleChat()` which now includes the policy check
- `/v1/chat/completions` — same as above

## Behavior

- **No API key** → skip policy checks (local mode, backward compatible)
- **API key with no `allowedModels`** → all models allowed (backward compatible)
- **API key with `allowedModels` set** → returns 403 if model not in list
- **API key over budget** → returns 429
- **Metadata fetch error** → degrades gracefully, doesn't block

## Testing

1. Create an API key with `allowedModels: ["gpt-4o-mini"]`
2. Request `claude-sonnet-4-20250514` via any endpoint → **403 Forbidden**
3. Request `gpt-4o-mini` → passes through normally
4. API key without `allowedModels` → all models work (no regression)