### PR TITLE
fix: improve API base URL handling and filter for chat models in CopilotToolCard

### DIFF
--- a/src/app/(dashboard)/dashboard/cli-tools/CLIToolsPageClient.tsx
+++ b/src/app/(dashboard)/dashboard/cli-tools/CLIToolsPageClient.tsx
@@ -33,7 +33,6 @@ export default function CLIToolsPageClient({ machineId }) {
   const [apiKeys, setApiKeys] = useState([]);
   const [toolStatuses, setToolStatuses] = useState({});
   const [statusesLoaded, setStatusesLoaded] = useState(false);
-  const [apiBaseUrl, setApiBaseUrl] = useState("");
 
   useEffect(() => {
     fetchConnections();
@@ -48,12 +47,6 @@ export default function CLIToolsPageClient({ machineId }) {
       if (res.ok) {
         const data = await res.json();
         setCloudEnabled(data.cloudEnabled || false);
-        if (typeof window !== "undefined") {
-          const protocol = window.location.protocol;
-          const hostname = window.location.hostname;
-          const apiPort = data?.apiPort || 20128;
-          setApiBaseUrl(`${protocol}//${hostname}:${apiPort}`);
-        }
       }
     } catch (error) {
       console.log("Error loading cloud settings:", error);
@@ -155,9 +148,8 @@ export default function CLIToolsPageClient({ machineId }) {
     if (cloudEnabled && CLOUD_URL) {
       return CLOUD_URL;
     }
-    if (apiBaseUrl) {
-      return apiBaseUrl;
-    }
+    // Use window.location.origin directly — works correctly in Docker/reverse-proxy
+    // Per @alpgul feedback: don't use baseUrl prop (has port duplication issues)
     if (typeof window !== "undefined") {
       return window.location.origin;
     }

--- a/src/app/(dashboard)/dashboard/cli-tools/components/CopilotToolCard.tsx
+++ b/src/app/(dashboard)/dashboard/cli-tools/components/CopilotToolCard.tsx
@@ -60,7 +60,7 @@ export default function CopilotToolCard({
       .then((data) => {
         if (cancelled) return;
         const modelList = (data.data || [])
-          .filter((m: any) => m.id) // Only models with valid IDs
+          .filter((m: any) => m && !m.type && !m.parent && m.id) // Only chat models with valid IDs
           .map((m: any) => ({
             value: m.id,
             label: m.id,
@@ -112,11 +112,8 @@ export default function CopilotToolCard({
   };
 
   const getBaseUrlForConfig = () => {
-    // Use window.location.origin directly — works correctly in Docker/reverse-proxy
-    // Per @alpgul feedback: don't use baseUrl prop (has port duplication issues)
-    const origin =
-      typeof window !== "undefined" ? window.location.origin : "http://localhost:20128";
-    return `${origin}/v1/chat/completions`;
+    const url = baseUrl;
+    return `${url}/v1/chat/completions`;
   };
 
   // Generate the Copilot chatLanguageModels.json config


### PR DESCRIPTION
- The baseURL adjustment has been applied to all CLI tools.
- Model filtering was malfunctioning due to an incorrect implementation. This has been resolved by applying the following method:

https://github.com/diegosouzapw/OmniRoute/blob/1de59bc75b4a349eb61f0b99511ba3bc3454add9/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.tsx#L43-L56