### PR TITLE
docs: reference WFGY 16-problem RAG failure map in TROUBLESHOOTING

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -218,13 +218,13 @@ In practice these incidents usually come from the downstream RAG pipeline, not f
 
 If you want a shared vocabulary to describe those failures you can use the WFGY ProblemMap, an external MIT license text resource that defines sixteen recurring RAG / LLM failure patterns. At a high level it covers:
 
-- retrieval drift and broken context boundaries  
-- empty or stale indexes and vector stores  
-- embedding versus semantic mismatch  
-- prompt assembly and context window issues  
-- logic collapse and overconfident answers  
-- long chain and agent coordination failures  
-- multi agent memory and role drift  
+- retrieval drift and broken context boundaries
+- empty or stale indexes and vector stores
+- embedding versus semantic mismatch
+- prompt assembly and context window issues
+- logic collapse and overconfident answers
+- long chain and agent coordination failures
+- multi agent memory and role drift
 - deployment and bootstrap ordering problems
 
 The idea is simple:


### PR DESCRIPTION
This PR adds a small, docs-only section to `docs/TROUBLESHOOTING.md` that references the WFGY ProblemMap as an optional RAG / LLM failure taxonomy.

Details:

- Introduces an “Optional RAG / LLM failure taxonomy (16 problems)” section under Troubleshooting.
- Explains when it is useful: OmniRoute looks healthy, but answers are still wrong because the downstream RAG or agent stack is misbehaving.
- Describes how teams can tag incidents with `No.1` … `No.16` from the WFGY ProblemMap and keep those tags next to OmniRoute logs.
- Links to the external WFGY ProblemMap README (MIT license, text only) for full definitions and fix recipes.

Scope:

- English troubleshooting doc only.
- No code or API changes.
- Existing behavior of OmniRoute is unchanged; the section is optional and can be ignored by users who do not run RAG / agent pipelines behind the gateway.

Closes #157.