### PR TITLE
fix: use bash shell for Collect installers step on Windows runner

### DIFF
--- a/.github/workflows/electron-release.yml
+++ b/.github/workflows/electron-release.yml
@@ -3,11 +3,11 @@ name: Build Electron Desktop App
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
   workflow_dispatch:
     inputs:
       version:
-        description: 'Release version (e.g., v1.6.8)'
+        description: "Release version (e.g., v1.6.8)"
         required: true
         type: string
 
@@ -100,6 +100,7 @@ jobs:
         run: npm run build:${{ matrix.target }}
 
       - name: Collect installers
+        shell: bash
         run: |
           mkdir -p release-assets
           cd electron/dist-electron
@@ -139,11 +140,11 @@ jobs:
           # Create source code archives (excluding dev dependencies and build artifacts)
           export TARBALL="OmniRoute-${{ needs.validate.outputs.version }}.source.tar.gz"
           export ZIPBALL="OmniRoute-${{ needs.validate.outputs.version }}.source.zip"
-          
+
           # Use git archive for clean source export
           git archive --format=tar.gz --prefix=OmniRoute-${{ needs.validate.outputs.version }}/ HEAD -o "release-assets/$TARBALL"
           git archive --format=zip --prefix=OmniRoute-${{ needs.validate.outputs.version }}/ HEAD -o "release-assets/$ZIPBALL"
-          
+
           echo "✓ Created source archives:"
           ls -lh "release-assets/$TARBALL" "release-assets/$ZIPBALL"
 


### PR DESCRIPTION
## Summary

- The `Collect installers` step in `electron-release.yml` uses bash syntax (`for file in ...; do`, `[ -f ]`, `if [ ]`) but GitHub Actions defaults to PowerShell (`pwsh`) on Windows runners
- Added `shell: bash` to the step so it runs correctly on all platforms (git-bash is always available on Windows runners)

## Root Cause

```
ParserError: Missing opening '(' after keyword 'for'.
  for file in *.exe; do
```

PowerShell's `for` syntax requires `for (...) { }` — not bash-style `for x in ...; do`. The fix explicitly declares `shell: bash` for that step.

## Test plan

- [ ] Trigger the workflow on a new tag and verify the Windows build completes successfully
- [ ] Confirm the `.exe` installer is correctly collected and uploaded as a release artifact