### PR TITLE
fix: add JWT_SECRET env to electron release build step

### DIFF
--- a/.github/workflows/electron-release.yml
+++ b/.github/workflows/electron-release.yml
@@ -89,6 +89,8 @@ jobs:
         run: npm ci
 
       - name: Build Next.js standalone
+        env:
+          JWT_SECRET: ci-build-secret-with-sufficient-length-for-validation
         run: npm run build
 
       - name: Install Electron dependencies


### PR DESCRIPTION
## Summary
- Adds `JWT_SECRET` environment variable to the "Build Next.js standalone" step in `electron-release.yml`
- Fixes the build failure caused by the secrets validator detecting a missing `JWT_SECRET` and exiting with code 1
- Matches the pattern already used in `ci.yml` for all build/test steps

## Test plan
- [ ] Trigger the electron release workflow (via tag push or workflow_dispatch) and verify the Next.js build step passes without the `[SECURITY] FATAL: JWT_SECRET is not set` error