### PR TITLE
fix: route usage API quota fetches through configured proxy (#194)

### DIFF
--- a/src/app/api/usage/[connectionId]/route.ts
+++ b/src/app/api/usage/[connectionId]/route.ts
@@ -1,8 +1,9 @@
-import { getProviderConnectionById, updateProviderConnection } from "@/lib/localDb";
+import { getProviderConnectionById, updateProviderConnection, resolveProxyForConnection } from "@/lib/localDb";
 import { getMachineId } from "@/shared/utils/machine";
 import { getUsageForProvider } from "@omniroute/open-sse/services/usage.ts";
 import { getExecutor } from "@omniroute/open-sse/executors/index.ts";
 import { syncToCloud } from "@/lib/cloudSync";
+import { runWithProxyContext } from "@omniroute/open-sse/utils/proxyFetch.ts";
 
 /**
  * Sync to cloud if enabled
@@ -139,8 +140,13 @@ export async function GET(request: Request, { params }: { params: Promise<{ conn
       );
     }
 
-    // Fetch usage from provider API
-    const usage = await getUsageForProvider(connection);
+    // Resolve proxy for this connection (key → combo → provider → global → direct)
+    const proxyInfo = await resolveProxyForConnection(connectionId);
+
+    // Fetch usage from provider API, wrapped in proxy context
+    const usage = await runWithProxyContext(proxyInfo?.proxy || null, () =>
+      getUsageForProvider(connection)
+    );
     return Response.json(usage);
   } catch (error) {
     console.error("[Usage API] Error fetching usage:", error);


### PR DESCRIPTION
## Summary

Fixes #194 — Usage API quota fetches fail in Docker deployments with Global Proxy configured.

### Root Cause
The `/api/usage/[connectionId]` endpoint calls provider quota APIs (chatgpt.com, googleapis.com, etc.) using bare `fetch()`. While OmniRoute patches `globalThis.fetch` to support proxies, it only resolves proxies from `AsyncLocalStorage` context or environment variables. The dashboard-configured Global Proxy (stored in SQLite) was never injected into the fetch context for usage calls, so quota fetches bypassed it while API calls worked fine.

### Fix
- Import `resolveProxyForConnection` and `runWithProxyContext`
- Wrap `getUsageForProvider()` in proxy context using the resolved proxy config
- Follows the same resolution chain as API calls: key → combo → provider → global → direct

### Test
- Build passes ✅