### PR TITLE
fix(ci): remove duplicate OmniRoute.exe entry in electron release workflow

### DIFF
--- a/.github/workflows/electron-release.yml
+++ b/.github/workflows/electron-release.yml
@@ -172,6 +172,5 @@ jobs:
             release-assets/*.blockmap
             release-assets/*.source.tar.gz
             release-assets/*.source.zip
-            release-assets/OmniRoute.exe
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- The `Create Release` step in the Electron workflow was failing with `404 Not Found` on the GitHub release asset update API
- Root cause: `release-assets/OmniRoute.exe` was listed explicitly **after** `release-assets/*.exe`, causing a duplicate upload attempt for the same asset
- Fix: remove the redundant explicit entry — `*.exe` already covers `OmniRoute.exe`

## Root cause

`softprops/action-gh-release` uploads `OmniRoute.exe` via the `*.exe` glob, then tries to upload it again from the explicit `release-assets/OmniRoute.exe` entry. The second call hits the update-asset API on an already-uploaded asset and returns 404, failing the job.