### PR TITLE
fix: omit synthesized reasoning items in Chat→Responses translation (#224)

### DIFF
--- a/open-sse/translator/request/openai-responses.ts
+++ b/open-sse/translator/request/openai-responses.ts
@@ -275,30 +275,11 @@ export function openaiToOpenAIResponsesRequest(
 
     // Convert assistant messages
     if (role === "assistant") {
-      // Add reasoning content before assistant output
-      if (msg.reasoning_content) {
-        input.push({
-          type: "reasoning",
-          id: `reasoning_${input.length}`,
-          summary: [{ type: "summary_text", text: toString(msg.reasoning_content) }],
-        });
-      }
+      // Skip reasoning_content — OpenAI Responses API requires server-generated
+      // rs_* IDs for reasoning items. Synthesizing client-side IDs (e.g. reasoning_N)
+      // causes 400 errors from Responses-compatible upstreams. (#224)
 
-      // Handle thinking blocks in array content
-      if (Array.isArray(msg.content)) {
-        for (const blockValue of msg.content) {
-          const block = toRecord(blockValue);
-          if (block.type === "thinking" || block.type === "redacted_thinking") {
-            input.push({
-              type: "reasoning",
-              id: `reasoning_${input.length}`,
-              summary: [
-                { type: "summary_text", text: toString(block.thinking || block.data, "...") },
-              ],
-            });
-          }
-        }
-      }
+      // Skip thinking blocks in array content — same rs_* ID constraint applies
 
       // Build assistant output content
       const outputContent: unknown[] = [];


### PR DESCRIPTION
## Summary

When OmniRoute translates Chat Completions history to OpenAI Responses API input, it was generating synthetic reasoning items with IDs like `reasoning_15`. The Responses API requires server-generated `rs_*` IDs, causing `400 Invalid Request` errors.

## Fix

Removed reasoning item synthesis entirely from `openaiToOpenAIResponsesRequest()`. Since valid `rs_*` IDs can only be generated server-side, these items are now omitted during translation. Reasoning content is non-essential for the request flow.

## Changes

- **`open-sse/translator/request/openai-responses.ts`**: Removed `reasoning_content` and `thinking` block synthesis in Chat→Responses translation

Closes #224