### PR TITLE
fix: custom image model routing + Codex OAuth workspace isolation (#232, #236)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "omniroute",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "omniroute",
-      "version": "2.0.5",
+      "version": "2.0.6",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/src/app/api/oauth/[provider]/[action]/route.ts
+++ b/src/app/api/oauth/[provider]/[action]/route.ts
@@ -221,9 +221,15 @@ export async function POST(
       let connection: any;
       if (tokenData.email) {
         const existing = await getProviderConnections({ provider });
-        const match = existing.find(
-          (c: any) => c.email === tokenData.email && c.authType === "oauth"
-        );
+        const match = existing.find((c: any) => {
+          if (c.email !== tokenData.email || c.authType !== "oauth") return false;
+          // For Codex, also check workspaceId to avoid overwriting different workspace connections
+          if (provider === "codex" && tokenData.providerSpecificData?.workspaceId) {
+            const existingWorkspace = c.providerSpecificData?.workspaceId;
+            return existingWorkspace === tokenData.providerSpecificData.workspaceId;
+          }
+          return true;
+        });
         const matchId = typeof match?.id === "string" ? match.id : null;
         if (matchId) {
           connection = await updateProviderConnection(matchId, {
@@ -285,9 +291,15 @@ export async function POST(
         let connection: any;
         if (result.tokens.email) {
           const existing = await getProviderConnections({ provider });
-          const match = existing.find(
-            (c: any) => c.email === result.tokens.email && c.authType === "oauth"
-          );
+          const match = existing.find((c: any) => {
+            if (c.email !== result.tokens.email || c.authType !== "oauth") return false;
+            // For Codex, also check workspaceId to avoid overwriting different workspace connections
+            if (provider === "codex" && result.tokens.providerSpecificData?.workspaceId) {
+              const existingWorkspace = c.providerSpecificData?.workspaceId;
+              return existingWorkspace === result.tokens.providerSpecificData.workspaceId;
+            }
+            return true;
+          });
           const matchId = typeof match?.id === "string" ? match.id : null;
           if (matchId) {
             connection = await updateProviderConnection(matchId, {
@@ -399,9 +411,15 @@ export async function POST(
         let connection: any;
         if (tokenData.email) {
           const existing = await getProviderConnections({ provider });
-          const match = existing.find(
-            (c: any) => c.email === tokenData.email && c.authType === "oauth"
-          );
+          const match = existing.find((c: any) => {
+            if (c.email !== tokenData.email || c.authType !== "oauth") return false;
+            // For Codex, also check workspaceId to avoid overwriting different workspace connections
+            if (provider === "codex" && tokenData.providerSpecificData?.workspaceId) {
+              const existingWorkspace = c.providerSpecificData?.workspaceId;
+              return existingWorkspace === tokenData.providerSpecificData.workspaceId;
+            }
+            return true;
+          });
           const matchId = typeof match?.id === "string" ? match.id : null;
           if (matchId) {
             connection = await updateProviderConnection(matchId, {

--- a/src/app/api/v1/images/generations/route.ts
+++ b/src/app/api/v1/images/generations/route.ts
@@ -107,7 +107,28 @@ export async function POST(request) {
   if (policy.rejection) return policy.rejection;
 
   // Parse model to get provider
-  const { provider } = parseImageModel(body.model);
+  let { provider } = parseImageModel(body.model);
+
+  // If not in built-in registry, check custom models tagged for images
+  if (!provider) {
+    try {
+      const customModelsMap = (await getAllCustomModels()) as Record<string, any>;
+      for (const [providerId, models] of Object.entries(customModelsMap)) {
+        if (!Array.isArray(models)) continue;
+        for (const model of models) {
+          if (!model?.id || !Array.isArray(model.supportedEndpoints)) continue;
+          if (!model.supportedEndpoints.includes("images")) continue;
+          const fullId = `${providerId}/${model.id}`;
+          if (fullId === body.model) {
+            provider = providerId;
+            break;
+          }
+        }
+        if (provider) break;
+      }
+    } catch {}
+  }
+
   if (!provider) {
     return errorResponse(
       HTTP_STATUS.BAD_REQUEST,


### PR DESCRIPTION
## Fixes

### #232 — Custom Gemini image models fail on /v1/images/generations

**Root Cause**: `parseImageModel()` only checks the built-in `IMAGE_PROVIDERS` registry. Custom models (like Gemini image models) that are visible in GET /v1/images/generations get rejected by the POST handler.

**Fix**: Added a custom model DB fallback — when `parseImageModel()` returns no provider, the handler now checks `customModels` in the DB for models tagged with `supportedEndpoints: ["images"]`.

### #236 — Codex OAuth overwrites existing connection when same email added to another workspace

**Root Cause**: The OAuth callback route has 3 upsert blocks (exchange, poll, poll-callback) that match connections by **email-only**, bypassing the workspace-aware upsert logic in `createProviderConnection()`. When the same email authenticates to a new workspace, the existing connection's `providerSpecificData.workspaceId` is overwritten.

**Fix**: For Codex connections, the match now also checks `providerSpecificData.workspaceId`, creating separate connections per workspace.

## Files Changed

| File | Change |
|------|--------|
| `src/app/api/v1/images/generations/route.ts` | Custom model DB fallback in POST handler |
| `src/app/api/oauth/[provider]/[action]/route.ts` | Workspace-aware Codex matching in 3 upsert locations |

Fixes #232, Fixes #236