### PR TITLE
fix(electron): resolve release build workflow errors

### DIFF
--- a/.github/workflows/electron-release.yml
+++ b/.github/workflows/electron-release.yml
@@ -55,12 +55,12 @@ jobs:
             target: win
             ext: .exe
           - platform: macos-intel
-            runner: macos-latest
-            target: mac
+            runner: macos-13
+            target: mac-x64
             ext: .dmg
           - platform: macos-arm64
             runner: macos-latest
-            target: mac
+            target: mac-arm64
             ext: -arm64.dmg
           - platform: linux
             runner: ubuntu-latest

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omniroute-desktop",
-  "version": "1.6.9",
+  "version": "2.0.13",
   "description": "OmniRoute Desktop Application",
   "main": "main.js",
   "author": "OmniRoute Team",
@@ -12,6 +12,8 @@
     "build": "electron-builder",
     "build:win": "electron-builder --win",
     "build:mac": "electron-builder --mac",
+    "build:mac-x64": "electron-builder --mac --x64",
+    "build:mac-arm64": "electron-builder --mac --arm64",
     "build:linux": "electron-builder --linux",
     "pack": "electron-builder --dir"
   },
@@ -82,13 +84,7 @@
     },
     "mac": {
       "target": [
-        {
-          "target": "dmg",
-          "arch": [
-            "x64",
-            "arm64"
-          ]
-        }
+        "dmg"
       ],
       "icon": "assets/icon.icns",
       "category": "public.app-category.productivity"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "omniroute",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "omniroute",
-      "version": "2.0.12",
+      "version": "2.0.13",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [


### PR DESCRIPTION
## Summary
- Sync electron package.json version with root to fix artifact collection
- Separate mac x64 and arm64 targets into dedicated runner jobs
- Use macos-13 (Intel) runner for x64 build to prevent cross-compilation timeouts