### PR TITLE
fix(gemini): remove "optional" field from JSON schema — fixes #244

### DIFF
--- a/README.md
+++ b/README.md
@@ -1693,6 +1693,8 @@ gh release create v2.0.0 --title "v2.0.0" --generate-notes
  </picture>
 </a>
 
+> 📈 **[View live star history on star-history.com](https://star-history.com/#diegosouzapw/OmniRoute&Date)** — The embedded chart may be cached. Click the link for real-time data.
+
 ---
 
 ## 🙏 Acknowledgments

--- a/open-sse/translator/helpers/geminiHelper.ts
+++ b/open-sse/translator/helpers/geminiHelper.ts
@@ -41,6 +41,8 @@ export const UNSUPPORTED_SCHEMA_CONSTRAINTS = [
   "else",
   "contentMediaType",
   "contentEncoding",
+  // Non-standard schema fields (not recognized by Gemini API)
+  "optional",
   // UI/Styling properties (from Cursor tools - NOT JSON Schema standard)
   "cornerRadius",
   "fillColor",


### PR DESCRIPTION
## Problem
The Gemini API returns `400: Cannot find field: optional` when tool declarations contain an `optional` field in their JSON schema.

## Root Cause
The `UNSUPPORTED_SCHEMA_CONSTRAINTS` array in `open-sse/translator/helpers/geminiHelper.ts` was missing `"optional"`. The `cleanJSONSchemaForAntigravity` helper recursively strips unsupported fields, so adding it here fixes the issue globally.

## Changes
- `open-sse/translator/helpers/geminiHelper.ts` — Added `"optional"` to `UNSUPPORTED_SCHEMA_CONSTRAINTS`
- `README.md` — Updated star history section (api.star-history.com suspended since March 2025)

## Testing
- Non-breaking: only removes a field that was causing upstream rejection
- Existing tool call flows should work as before, now without the 400 error

Closes #244