### PR TITLE
fix(validation): support ElevenLabs and Inworld API key validation

### DIFF
--- a/src/lib/providers/validation.ts
+++ b/src/lib/providers/validation.ts
@@ -250,6 +250,56 @@ async function validateNanoBananaProvider({ apiKey }: any) {
   }
 }
 
+async function validateElevenLabsProvider({ apiKey }: any) {
+  try {
+    // Lightweight auth check endpoint
+    const response = await fetch("https://api.elevenlabs.io/v1/voices", {
+      method: "GET",
+      headers: {
+        "xi-api-key": apiKey,
+        "Content-Type": "application/json",
+      },
+    });
+
+    if (response.ok) return { valid: true, error: null };
+    if (response.status === 401 || response.status === 403) {
+      return { valid: false, error: "Invalid API key" };
+    }
+
+    return { valid: false, error: `Validation failed: ${response.status}` };
+  } catch (error: any) {
+    return { valid: false, error: error.message || "Validation failed" };
+  }
+}
+
+async function validateInworldProvider({ apiKey }: any) {
+  try {
+    // Inworld TTS lacks a simple key-introspection endpoint.
+    // Send a minimal synth request and treat non-auth 4xx as auth-pass.
+    const response = await fetch("https://api.inworld.ai/tts/v1/voice", {
+      method: "POST",
+      headers: {
+        Authorization: `Basic ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        text: "test",
+        modelId: "inworld-tts-1.5-mini",
+        audioConfig: { audioEncoding: "MP3" },
+      }),
+    });
+
+    if (response.status === 401 || response.status === 403) {
+      return { valid: false, error: "Invalid API key" };
+    }
+
+    // Any other response indicates auth is accepted (payload/model may still be wrong)
+    return { valid: true, error: null };
+  } catch (error: any) {
+    return { valid: false, error: error.message || "Validation failed" };
+  }
+}
+
 async function validateOpenAICompatibleProvider({ apiKey, providerSpecificData = {} }: any) {
   const baseUrl = normalizeBaseUrl(providerSpecificData.baseUrl);
   if (!baseUrl) {
@@ -416,6 +466,8 @@ export async function validateProviderApiKey({ provider, apiKey, providerSpecifi
     deepgram: validateDeepgramProvider,
     assemblyai: validateAssemblyAIProvider,
     nanobanana: validateNanoBananaProvider,
+    elevenlabs: validateElevenLabsProvider,
+    inworld: validateInworldProvider,
   };
 
   if (SPECIALTY_VALIDATORS[provider]) {


### PR DESCRIPTION
## Summary
- add provider API key validators for `elevenlabs` and `inworld`
- register both in `SPECIALTY_VALIDATORS` so `/api/providers/validate` no longer returns unsupported (400)

## Why
Currently, the Providers UI validates API keys before saving via `POST /api/providers/validate`.
`elevenlabs` and `inworld` are listed providers, but they were missing from validation handlers, causing false 400 failures (`Provider validation not supported`) even with valid keys.

## Validation behavior
- **ElevenLabs**: `GET https://api.elevenlabs.io/v1/voices` with `xi-api-key`
  - 200 => valid
  - 401/403 => invalid key
- **Inworld**: minimal `POST https://api.inworld.ai/tts/v1/voice` with `Authorization: Basic <apiKey>`
  - 401/403 => invalid key
  - other responses treated as auth pass (consistent with other providers where non-auth 4xx can still indicate valid auth)

## Impact
Fixes add/edit provider flows for ElevenLabs and Inworld in dashboard validation flow without changing runtime TTS request routing.
