### PR TITLE
fix(google-cli): remove random project fallback causing permission/verification errors

### DIFF
--- a/open-sse/executors/antigravity.ts
+++ b/open-sse/executors/antigravity.ts
@@ -38,14 +38,11 @@ export class AntigravityExecutor extends BaseExecutor {
   transformRequest(model, body, stream, credentials) {
     const bodyProjectId = body?.project;
     const credentialsProjectId = credentials?.projectId;
-    const hasExplicitProject = !!(bodyProjectId || credentialsProjectId);
-    const projectId = bodyProjectId || credentialsProjectId || this.generateProjectId();
+    const projectId = bodyProjectId || credentialsProjectId;
 
-    if (!hasExplicitProject) {
-      console.warn(
-        `[Antigravity] ⚠️ No projectId provided via body or credentials — using generated fallback "${projectId}". ` +
-          `This may cause 404 errors if the account has no active GCP project. ` +
-          `Ensure the OAuth token includes a valid project or the request includes a project field.`
+    if (!projectId) {
+      throw new Error(
+        "Missing Google projectId for Antigravity account. Please reconnect OAuth so OmniRoute can fetch your real Cloud Code project (loadCodeAssist)."
       );
     }
 
@@ -126,12 +123,6 @@ export class AntigravityExecutor extends BaseExecutor {
       log?.error?.("TOKEN", `Antigravity refresh error: ${error.message}`);
       return null;
     }
-  }
-
-  generateProjectId() {
-    const adj = ["useful", "bright", "swift", "calm", "bold"][Math.floor(Math.random() * 5)];
-    const noun = ["fuze", "wave", "spark", "flow", "core"][Math.floor(Math.random() * 5)];
-    return `${adj}-${noun}-${crypto.randomUUID().slice(0, 5)}`;
   }
 
   generateSessionId() {

--- a/open-sse/translator/helpers/geminiHelper.ts
+++ b/open-sse/translator/helpers/geminiHelper.ts
@@ -126,15 +126,6 @@ export function generateSessionId() {
   return `-${Math.floor(Math.random() * 9000000000000000000)}`;
 }
 
-// Generate project ID
-export function generateProjectId() {
-  const adjectives = ["useful", "bright", "swift", "calm", "bold"];
-  const nouns = ["fuze", "wave", "spark", "flow", "core"];
-  const adj = adjectives[Math.floor(Math.random() * adjectives.length)];
-  const noun = nouns[Math.floor(Math.random() * nouns.length)];
-  return `${adj}-${noun}-${crypto.randomUUID().slice(0, 5)}`;
-}
-
 // Helper: Remove unsupported keywords recursively from object/array
 function removeUnsupportedKeywords(obj, keywords) {
   if (!obj || typeof obj !== "object") return;

--- a/open-sse/translator/request/openai-to-gemini.ts
+++ b/open-sse/translator/request/openai-to-gemini.ts
@@ -15,7 +15,6 @@ import {
   tryParseJSON,
   generateRequestId,
   generateSessionId,
-  generateProjectId,
   cleanJSONSchemaForAntigravity,
 } from "../helpers/geminiHelper.ts";
 
@@ -321,13 +320,11 @@ export function openaiToGeminiCLIRequest(model, body, stream) {
 
 // Wrap Gemini CLI format in Cloud Code wrapper
 function wrapInCloudCodeEnvelope(model, geminiCLI, credentials = null, isAntigravity = false) {
-  const hasRealProject = !!credentials?.projectId;
-  const projectId = credentials?.projectId || generateProjectId();
+  const projectId = credentials?.projectId;
 
-  if (!hasRealProject) {
-    console.warn(
-      `[${isAntigravity ? "Antigravity" : "GeminiCLI"}] ⚠️ No projectId in credentials — using generated fallback "${projectId}". ` +
-        `This may cause 404 errors. Ensure the OAuth token includes a valid GCP project.`
+  if (!projectId) {
+    throw new Error(
+      `${isAntigravity ? "Antigravity" : "GeminiCLI"} account is missing projectId. Reconnect OAuth to load your real Cloud Code project before sending requests.`
     );
   }
 
@@ -374,13 +371,11 @@ function wrapInCloudCodeEnvelope(model, geminiCLI, credentials = null, isAntigra
 }
 
 function wrapInCloudCodeEnvelopeForClaude(model, claudeRequest, credentials = null) {
-  const hasRealProject = !!credentials?.projectId;
-  const projectId = credentials?.projectId || generateProjectId();
+  const projectId = credentials?.projectId;
 
-  if (!hasRealProject) {
-    console.warn(
-      `[Antigravity/Claude] ⚠️ No projectId in credentials — using generated fallback "${projectId}". ` +
-        `This may cause 404 errors. Ensure the OAuth token includes a valid GCP project.`
+  if (!projectId) {
+    throw new Error(
+      "Antigravity/Claude account is missing projectId. Reconnect OAuth to load your real Cloud Code project before sending requests."
     );
   }
 


### PR DESCRIPTION
## Summary
Removes synthetic Google project fallback IDs (e.g. `useful-fuze-a04c5`) for Antigravity/Gemini CLI requests and fails fast when `projectId` is missing.

## Problem
Users hit errors like:
- `Permission denied on resource project useful-fuze-a04c5`
- `Verify your account to continue`

Root cause: when OAuth credentials lacked `projectId`, OmniRoute generated a fake project id and still sent requests upstream. This produces confusing Google auth/permission errors that look like account issues.

## Changes
- `open-sse/executors/antigravity.ts`
  - remove fallback generation path in `transformRequest`
  - throw clear error when neither body nor credentials has `projectId`
  - remove unused `generateProjectId()` helper

- `open-sse/translator/request/openai-to-gemini.ts`
  - `wrapInCloudCodeEnvelope*` now require `credentials.projectId`
  - remove fallback `generateProjectId()` usage
  - throw actionable reconnect-OAuth error instead

- `open-sse/translator/helpers/geminiHelper.ts`
  - remove now-unused `generateProjectId()` export

## Impact
- Prevents opaque upstream Google errors caused by fake project IDs.
- Surfaces a deterministic local error telling users to reconnect OAuth so OmniRoute can load a real Cloud Code project (`loadCodeAssist`).
- Keeps successful paths unchanged when valid `projectId` is present.
