### PR TITLE
fix(translator): map Claude thinking_delta to reasoning_content (#289)

### DIFF
--- a/open-sse/translator/response/claude-to-openai.ts
+++ b/open-sse/translator/response/claude-to-openai.ts
@@ -51,7 +51,9 @@ export function claudeToOpenAIResponse(chunk, state) {
       } else if (block?.type === "thinking") {
         state.inThinkingBlock = true;
         state.currentBlockIndex = chunk.index;
-        results.push(createChunk(state, { content: "<think>" }));
+        // Emit empty reasoning_content to signal thinking block start
+        // (clients like Claude Code look for reasoning_content, not <think> tags)
+        results.push(createChunk(state, { reasoning_content: "" }));
       } else if (block?.type === "tool_use") {
         const toolCallIndex = state.toolCallIndex++;
         // Restore original tool name from mapping (Claude OAuth)
@@ -76,7 +78,9 @@ export function claudeToOpenAIResponse(chunk, state) {
       if (delta?.type === "text_delta" && delta.text) {
         results.push(createChunk(state, { content: delta.text }));
       } else if (delta?.type === "thinking_delta" && delta.thinking) {
-        results.push(createChunk(state, { content: delta.thinking }));
+        // Map Claude thinking_delta → OpenAI reasoning_content
+        // Clients (Claude Code, Cursor, etc.) display reasoning_content as the thinking panel
+        results.push(createChunk(state, { reasoning_content: delta.thinking }));
       } else if (delta?.type === "input_json_delta" && delta.partial_json) {
         const toolCall = state.toolCalls.get(chunk.index);
         if (toolCall) {
@@ -99,7 +103,8 @@ export function claudeToOpenAIResponse(chunk, state) {
 
     case "content_block_stop": {
       if (state.inThinkingBlock && chunk.index === state.currentBlockIndex) {
-        results.push(createChunk(state, { content: "</think>" }));
+        // Thinking block closed — no additional content needed;
+        // reasoning_content chunks have already been streamed
         state.inThinkingBlock = false;
       }
       state.textBlockStarted = false;


### PR DESCRIPTION
## Summary

Fixes #289 — Claude thinking tokens invisible when using OmniRoute as a proxy to Claude (Antigravity OAuth or direct Claude provider).

## Root Cause

In `open-sse/translator/response/claude-to-openai.ts`, Claude's native `thinking_delta` SSE events were mistakenly mapped to the regular `content` field with `<think>/<\/think>` XML wrappers.

**Clients like Claude Code, Cursor, and Windsurf look for `delta.reasoning_content` — not `<think>` tags — to display the thinking panel.**

## Changes

| Event | Before | After |
|-------|--------|-------|
| `content_block_start` (type: thinking) | `{ content: '<think>' }` | `{ reasoning_content: '' }` |
| `content_block_delta` (thinking_delta) | `{ content: delta.thinking }` | `{ reasoning_content: delta.thinking }` |
| `content_block_stop` (thinking block) | `{ content: '</think>' }` | _(no chunk — already streamed)_ |

## Impact

This fix applies whenever a Claude-native API response is translated to OpenAI format (source: Anthropic API, target: OpenAI SDK/client). Thinking budget passthrough mode was already working correctly — the problem was only in the response translation layer.