### PR TITLE
fix(docker): include bootstrap-env.mjs in runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ COPY --from=builder /app/.next/standalone ./
 COPY --from=builder /app/node_modules/@swc/helpers ./node_modules/@swc/helpers
 COPY --from=builder /app/scripts/run-standalone.mjs ./run-standalone.mjs
 COPY --from=builder /app/scripts/runtime-env.mjs ./runtime-env.mjs
+COPY --from=builder /app/scripts/bootstrap-env.mjs ./bootstrap-env.mjs
 COPY --from=builder /app/scripts/healthcheck.mjs ./healthcheck.mjs
 
 EXPOSE 20128


### PR DESCRIPTION
## Summary
Fixes Docker startup regression where the runtime image fails with:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/app/bootstrap-env.mjs'
```

`run-standalone.mjs` imports `./bootstrap-env.mjs`, but the Docker runner stage was not copying that file from the builder image.

## Change
- Add missing copy in `Dockerfile` runner stage:
  - `COPY --from=builder /app/scripts/bootstrap-env.mjs ./bootstrap-env.mjs`

## Why this is safe
- No behavior change beyond restoring expected runtime file availability.
- Keeps current startup/import paths intact.

## Issue
Closes #292
