### PR TITLE
fix(chat): strip empty name from messages/input before upstream (#291)

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -158,6 +158,28 @@ export async function handleChatCore({
       translatedBody = { ...translatedBody, _disableToolPrefix: true };
     }
 
+    // ── #291: Strip empty name fields from messages/input items ──
+    // Upstream providers (OpenAI, Codex) reject name:"" with 400 errors.
+    // Clients like PocketPaw may forward empty name fields from assistant turns.
+    if (Array.isArray(body.messages)) {
+      body.messages = body.messages.map((msg: Record<string, unknown>) => {
+        if (msg.name === "") {
+          const { name: _n, ...rest } = msg;
+          return rest;
+        }
+        return msg;
+      });
+    }
+    if (Array.isArray(body.input)) {
+      body.input = body.input.map((item: Record<string, unknown>) => {
+        if (item.name === "") {
+          const { name: _n, ...rest } = item;
+          return rest;
+        }
+        return item;
+      });
+    }
+
     translatedBody = translateRequest(
       sourceFormat,
       targetFormat,


### PR DESCRIPTION
## Summary

Fixes #291 — OpenAI-compatible endpoint returns 400 for tool-calling / Responses API requests with empty `name` fields.

## Root Cause

Upstream providers (OpenAI, Codex) strictly reject `name: ""` on:
- `input[N].name` in the Responses API
- `messages[N].name` in chat completions

Clients like PocketPaw forward assistant turns with `name: ""` which causes upstream rejections.

## Fix

In `chatCore.ts`, before `translateRequest()`, strip `name` from messages and input items when the value is an empty string. Non-empty name values are preserved per spec.