### PR TITLE
fix(rate-limit): prevent endless queue with maxWait (#297)

### DIFF
--- a/open-sse/services/rateLimitManager.ts
+++ b/open-sse/services/rateLimitManager.ts
@@ -59,6 +59,11 @@ const PERSIST_DEBOUNCE_MS = 60_000; // Debounce persistence to every 60s max
 // Track initialization
 let initialized = false;
 
+// Max time (ms) a job can wait in queue before failing with a timeout error.
+// Prevents infinite queuing when all providers are exhausted after a 429.
+// Configurable via RATE_LIMIT_MAX_WAIT_MS env var (default: 2 minutes).
+const MAX_WAIT_MS = parseInt(process.env.RATE_LIMIT_MAX_WAIT_MS || "120000", 10);
+
 // Default conservative settings (before we learn from headers)
 const DEFAULT_SETTINGS = {
   maxConcurrent: 10,
@@ -66,6 +71,7 @@ const DEFAULT_SETTINGS = {
   reservoir: null, // No initial reservoir — unlimited until we learn
   reservoirRefreshAmount: null,
   reservoirRefreshInterval: null,
+  maxWait: MAX_WAIT_MS, // Fail-fast: don't queue forever on 429 exhaustion
 };
 
 /**
@@ -111,6 +117,7 @@ export async function initializeRateLimits() {
               reservoir: rpm,
               reservoirRefreshAmount: rpm,
               reservoirRefreshInterval: 60 * 1000,
+              maxWait: MAX_WAIT_MS,
               id: key,
             })
           );
@@ -135,6 +142,7 @@ export async function initializeRateLimits() {
               reservoir: DEFAULT_API_LIMITS.requestsPerMinute,
               reservoirRefreshAmount: DEFAULT_API_LIMITS.requestsPerMinute,
               reservoirRefreshInterval: 60 * 1000, // Refresh every minute
+              maxWait: MAX_WAIT_MS,
               id: key,
             })
           );


### PR DESCRIPTION
## Summary
Fixes #297 — requests hang indefinitely when all providers are rate-limited.

## Root Cause
Bottleneck was configured without `maxWait`, so when all providers returned 429 and `reservoir=0`, queued jobs waited forever. Clients (Cursor, Claude Code, VS Code) would show 'waiting...' indefinitely.

## Fix
Added `maxWait: MAX_WAIT_MS` (default 2 minutes, configurable via `RATE_LIMIT_MAX_WAIT_MS`) to:
- `DEFAULT_SETTINGS` (all ad-hoc limiters)
- Custom rpm/tpm Bottleneck constructor
- Auto-enabled API key Bottleneck constructor

When a job exceeds `maxWait`, Bottleneck throws a `BottleneckError`, which propagates as a clean 502/503 error to the client instead of hanging.