### PR TITLE
fix(docker): use /api/monitoring/health for Docker healthcheck (#296)

### DIFF
--- a/scripts/healthcheck.mjs
+++ b/scripts/healthcheck.mjs
@@ -2,12 +2,12 @@
 
 /**
  * Docker healthcheck script for OmniRoute.
- * Checks the /api/settings endpoint on the dashboard port.
+ * Checks the /api/monitoring/health endpoint on the dashboard port.
  * Used by Dockerfile and docker-compose files.
  */
 const port = process.env.DASHBOARD_PORT || process.env.PORT || "20128";
 
-fetch(`http://127.0.0.1:${port}/api/settings`)
+fetch(`http://127.0.0.1:${port}/api/monitoring/health`)
   .then((r) => {
     if (!r.ok) throw new Error(`HTTP ${r.status}`);
   })


### PR DESCRIPTION
## Summary
Fixes #296 — Docker healthcheck script uses incorrect endpoint.

## Root Cause
`scripts/healthcheck.mjs` queries `/api/settings` (config endpoint) instead of `/api/monitoring/health` (health endpoint).

`/api/settings` returns arbitrary config data and does not reflect system health. `/api/monitoring/health` is already used by SystemMonitor.tsx, MaintenanceBanner.tsx, E2E tests, Playwright config, and MCP tools.

## Change
```diff
- fetch(`http://127.0.0.1:${port}/api/settings`)
+ fetch(`http://127.0.0.1:${port}/api/monitoring/health`)
```