### PR TITLE
fix(deps): add @swc/helpers as explicit dependency (#306)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@monaco-editor/react": "^4.7.0",
+        "@swc/helpers": "0.5.19",
         "bcryptjs": "^3.0.3",
         "better-sqlite3": "^12.6.2",
         "bottleneck": "^2.19.5",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,8 @@
     "uuid": "^13.0.0",
     "wreq-js": "^2.0.1",
     "zod": "^4.3.6",
-    "zustand": "^5.0.10"
+    "zustand": "^5.0.10",
+    "@swc/helpers": "0.5.19"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",
@@ -142,6 +143,6 @@
     ]
   },
   "overrides": {
-    "@swc/helpers": "^0.5.19"
+    "@swc/helpers": "0.5.19"
   }
 }


### PR DESCRIPTION
## Summary
Fixes #306 — `@swc/helpers/esm/_interop_require_default.js` MODULE_NOT_FOUND on startup.

## Root Cause
`next@16` lists `@swc/helpers@0.5.15` in its own dependencies, but npm's deduplication algorithm during `npm install -g` fails to hoist it into the omniroute app's `node_modules` consistently — especially on Windows (Node 22) and in global install scenarios where the package tree structure differs from local installs.

## Fix
Explicitly pin `@swc/helpers@0.5.19` in omniroute's:
- `dependencies` — guarantees installation
- `overrides` — pins the version even if next tries to resolve a different one