### PR TITLE
fix(aliases): resolve custom model aliases before routing + restore on startup (#315, #316)

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -12,6 +12,7 @@ import { addBufferToUsage, filterUsageForFormat, estimateUsage } from "../utils/
 import { refreshWithRetry } from "../services/tokenRefresh.ts";
 import { createRequestLogger } from "../utils/requestLogger.ts";
 import { getModelTargetFormat, PROVIDER_ID_TO_ALIAS } from "../config/providerModels.ts";
+import { resolveModelAlias } from "../services/modelDeprecation.ts";
 import { createErrorResult, parseUpstreamError, formatProviderError } from "../utils/error.ts";
 import { HTTP_STATUS } from "../config/constants.ts";
 import { handleBypassRequest } from "../utils/bypassHandler.ts";
@@ -105,8 +106,13 @@ export async function handleChatCore({
   // Detect source format and get target format
   // Model-specific targetFormat takes priority over provider default
 
+  // Apply custom model aliases (Settings → Model Aliases → Pattern→Target) before routing (#315)
+  // Custom aliases take priority over built-in and must be resolved here so the
+  // downstream getModelTargetFormat() lookup uses the correct, aliased model ID.
+  const resolvedModel = resolveModelAlias(model);
+
   const alias = PROVIDER_ID_TO_ALIAS[provider] || provider;
-  const modelTargetFormat = getModelTargetFormat(alias, model);
+  const modelTargetFormat = getModelTargetFormat(alias, resolvedModel);
   const targetFormat = modelTargetFormat || getTargetFormat(provider);
 
   // Default to false unless client explicitly sets stream: true (OpenAI spec compliant)

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -46,6 +46,30 @@ export async function register() {
     startBackgroundRefresh();
     console.log("[STARTUP] Quota cache background refresh started");
 
+    // Model aliases: restore persisted custom aliases into in-memory state (#316)
+    // Custom aliases are saved to settings.modelAliases on PUT /api/settings/model-aliases
+    // but the in-memory _customAliases resets to {} on every restart — load them here.
+    try {
+      const { getSettings } = await import("@/lib/db/settings");
+      const { setCustomAliases } = await import("@omniroute/open-sse/services/modelDeprecation.ts");
+      const settings = getSettings();
+      if (settings.modelAliases) {
+        const aliases =
+          typeof settings.modelAliases === "string"
+            ? JSON.parse(settings.modelAliases)
+            : settings.modelAliases;
+        if (aliases && typeof aliases === "object") {
+          setCustomAliases(aliases);
+          console.log(
+            `[STARTUP] Restored ${Object.keys(aliases).length} custom model alias(es) from settings`
+          );
+        }
+      }
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn("[STARTUP] Could not restore model aliases:", msg);
+    }
+
     // Compliance: Initialize audit_log table + cleanup expired logs
     try {
       const { initAuditLog, cleanupExpiredLogs } = await import("@/lib/compliance/index");


### PR DESCRIPTION
## Summary
Fixes #315 and #316 in a single PR — both bugs share the same root: the custom alias in-memory state.

## Fixes

### #315 — Model Alias (Pattern→Target) ignored during routing
**Root cause:** `chatCore.ts` called `getModelTargetFormat()` directly without consulting the custom aliases from `modelDeprecation.ts`.
**Fix:** Import and call `resolveModelAlias(model)` before routing so custom aliases apply.

### #316 — Model Aliases lost after server restart
**Root cause:** `_customAliases` is an in-memory variable that starts as empty `{}` on every restart. `setCustomAliases()` was only called from the PUT handler — not at startup.
**Fix:** In `src/instrumentation.ts` (Next.js server startup hook), load `settings.modelAliases` from the DB and call `setCustomAliases()`.

## Files Changed
- `open-sse/handlers/chatCore.ts` — add `resolveModelAlias(model)` before routing
- `src/instrumentation.ts` — restore aliases from DB at server startup