### PR TITLE
fix(codex): advertise gpt-5.4 models

### DIFF
--- a/open-sse/config/providerRegistry.ts
+++ b/open-sse/config/providerRegistry.ts
@@ -186,6 +186,7 @@ export const REGISTRY: Record<string, RegistryEntry> = {
       tokenUrl: "https://auth.openai.com/oauth/token",
     },
     models: [
+      { id: "gpt-5.4", name: "GPT 5.4" },
       { id: "gpt-5.3-codex", name: "GPT 5.3 Codex" },
       { id: "gpt-5.3-codex-xhigh", name: "GPT 5.3 Codex (xHigh)" },
       { id: "gpt-5.3-codex-high", name: "GPT 5.3 Codex (High)" },

--- a/tests/unit/plan3-p0.test.mjs
+++ b/tests/unit/plan3-p0.test.mjs
@@ -23,6 +23,12 @@ test("getModelInfoCore keeps openai fallback for gpt-4o", async () => {
   assert.equal(info.model, "gpt-4o");
 });
 
+test("getModelInfoCore resolves gpt-5.4 to codex", async () => {
+  const info = await getModelInfoCore("gpt-5.4", {});
+  assert.equal(info.provider, "codex");
+  assert.equal(info.model, "gpt-5.4");
+});
+
 test("getModelInfoCore returns explicit ambiguity metadata for ambiguous unprefixed model", async () => {
   const info = await getModelInfoCore("claude-haiku-4.5", {});
   assert.equal(info.provider, null);


### PR DESCRIPTION
## Summary
- add gpt-5.4 to the Codex model registry
- expose cx/gpt-5.4 and codex/gpt-5.4 in OmniRoute's model catalog
- add a focused regression test for Codex model resolution

## Testing
- npm run test:plan3