### PR TITLE
fix(i18n): replace missing provider delete tooltip lookup

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/[id]/page.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.tsx
@@ -2540,7 +2540,7 @@ function ConnectionRow({
           <button
             onClick={onDelete}
             className="p-2 hover:bg-red-500/10 rounded text-red-500"
-            title={t("deleteConnection")}
+            title={t("delete")}
           >
             <span className="material-symbols-outlined text-[18px]">delete</span>
           </button>


### PR DESCRIPTION
## Summary
- replace the provider detail page's missing `providers.deleteConnection` lookup with the existing `providers.delete` label
- keep the fix to a single call site instead of adding a redundant translation key across all locales

## Problem
The provider detail page was requesting `t("deleteConnection")` from the `providers` namespace.

That key does not exist in the locale files. The namespace already defines:
- `delete`
- `deleteConnectionConfirm`

but not `deleteConnection`.

As a result, opening the provider detail page emitted a runtime i18n error instead of rendering a valid tooltip label for the delete button.

## Root Cause
This was a bad message-key lookup in the UI, not missing locale content.

The page needed the short button label for the delete icon tooltip, but it was asking for a non-existent key instead of reusing the existing `providers.delete` string that already matches the intended UI text.

## Why This Fix
Adding a new `deleteConnection` key to every locale would only duplicate an existing concept.

The tooltip is just the delete action label, so the smallest correct fix is to reuse `providers.delete` at the call site.

## Proof
I verified the bug directly on unpatched `origin/main`:
- `src/app/(dashboard)/dashboard/providers/[id]/page.tsx` requests `t("deleteConnection")`
- `src/i18n/messages/en.json` contains `providers.delete` and `providers.deleteConnectionConfirm`, but not `providers.deleteConnection`
- opening `/dashboard/providers/codex` on unpatched `origin/main` reproduced the exact runtime error:
  `MISSING_MESSAGE: providers.deleteConnection`

I also verified the patched branch:
- the page renders the delete buttons with `title="Delete"`
- the `MISSING_MESSAGE: providers.deleteConnection` error no longer appears in a fresh browser session

## Verification
- built the branch with `PORT=20131 npm run build`
- verified the provider detail page in a fresh browser session after login
- confirmed the delete button tooltip resolves to the existing `providers.delete` message
- confirmed the prior `MISSING_MESSAGE: providers.deleteConnection` error reproduces on unpatched `origin/main` and disappears with this patch
