### PR TITLE
fix(db): migrate provider_connections.group for existing databases

### DIFF
--- a/src/lib/db/core.ts
+++ b/src/lib/db/core.ts
@@ -80,6 +80,7 @@ const SCHEMA_SQL = `
     consecutive_use_count INTEGER DEFAULT 0,
     rate_limit_protection INTEGER DEFAULT 0,
     last_used_at TEXT,
+    "group" TEXT,
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL
   );
@@ -315,6 +316,10 @@ function ensureProviderConnectionsColumns(db: SqliteDatabase) {
     if (!columnNames.has("last_used_at")) {
       db.exec("ALTER TABLE provider_connections ADD COLUMN last_used_at TEXT");
       console.log("[DB] Added provider_connections.last_used_at column");
+    }
+    if (!columnNames.has("group")) {
+      db.exec('ALTER TABLE provider_connections ADD COLUMN "group" TEXT');
+      console.log('[DB] Added provider_connections."group" column');
     }
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);

--- a/tests/unit/fixes-p1.test.mjs
+++ b/tests/unit/fixes-p1.test.mjs
@@ -141,6 +141,63 @@ test("provider connection persists rateLimitProtection across reopen", async () 
   assert.equal(secondRead.rateLimitProtection, true);
 });
 
+test('provider connection migration adds "group" column for existing databases', async () => {
+  await resetStorage();
+
+  const sqlitePath = core.SQLITE_FILE;
+  core.resetDbInstance();
+
+  const Database = (await import("better-sqlite3")).default;
+  const db = new Database(sqlitePath);
+  db.exec(`
+    CREATE TABLE provider_connections (
+      id TEXT PRIMARY KEY,
+      provider TEXT NOT NULL,
+      auth_type TEXT,
+      name TEXT,
+      email TEXT,
+      priority INTEGER DEFAULT 0,
+      is_active INTEGER DEFAULT 1,
+      access_token TEXT,
+      refresh_token TEXT,
+      expires_at TEXT,
+      token_expires_at TEXT,
+      scope TEXT,
+      project_id TEXT,
+      test_status TEXT,
+      error_code TEXT,
+      last_error TEXT,
+      last_error_at TEXT,
+      last_error_type TEXT,
+      last_error_source TEXT,
+      backoff_level INTEGER DEFAULT 0,
+      rate_limited_until TEXT,
+      health_check_interval INTEGER,
+      last_health_check_at TEXT,
+      last_tested TEXT,
+      api_key TEXT,
+      id_token TEXT,
+      provider_specific_data TEXT,
+      expires_in INTEGER,
+      display_name TEXT,
+      global_priority INTEGER,
+      default_model TEXT,
+      token_type TEXT,
+      consecutive_use_count INTEGER DEFAULT 0,
+      rate_limit_protection INTEGER DEFAULT 0,
+      last_used_at TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    )
+  `);
+  db.close();
+
+  const reopened = core.getDbInstance();
+  const columns = reopened.prepare("PRAGMA table_info(provider_connections)").all();
+  const names = new Set(columns.map((column) => column.name));
+  assert.equal(names.has("group"), true);
+});
+
 test("resolveProxyForConnection applies combo proxy for object/string model entries", async () => {
   await resetStorage();
 


### PR DESCRIPTION
## Summary
- add `provider_connections."group"` to the base schema definition
- add the same column to the runtime provider-connections column backfill for older databases
- add regression coverage for the upgrade path from an existing database that does not yet have the column

## Problem
`src/lib/db/providers.ts` already treats `provider_connections."group"` as part of the live schema:
- inserts it
- updates it
- reads it back into connection objects
- queries distinct group values

But the schema/bootstrap path did not create or migrate that column.

That left the code and the actual database schema out of sync.

## Root Cause
The application had already grown first-class support for connection groups in `providers.ts`, but `core.ts` never added the corresponding column to either:
- the base `provider_connections` table definition for new databases
- the column-backfill path for existing databases

So older databases could continue running with a `provider_connections` table that did not satisfy the assumptions already made by the live DB access layer.

## Why This Fix
This PR only brings the schema in line with behavior that already exists in the data-access layer.

It does not introduce new product behavior. It makes the database guarantee a column that the current code already depends on.

That is why both parts are required:
- base schema fix for fresh databases
- runtime migration fix for already-existing databases

## Proof
I verified the mismatch directly on unpatched `origin/main`.

On `origin/main`:
- `src/lib/db/providers.ts` already reads and writes `"group"`
- `src/lib/db/core.ts` did not create or migrate that column

I then reproduced the failure on an old-style temp database without `provider_connections."group"`:
- calling `createProviderConnection({ ..., group: "alpha" })` on unpatched `origin/main` fails with:
  `table provider_connections has no column named group`

I ran the same proof on the patched branch and confirmed:
- startup/backfill adds `provider_connections."group"`
- `createProviderConnection({ ..., group: "alpha" })` succeeds
- reading the row back returns `group: "alpha"`

## Verification
- ran:
  `node --import ./node_modules/tsx/dist/esm/index.mjs --test tests/unit/fixes-p1.test.mjs`
- built the branch successfully with `PORT=20133 npm run build`
- reproduced the failure on unpatched `origin/main` with an existing temp database missing the column
- reproduced the successful migrated behavior on the patched branch with the same old-schema setup
