### PR TITLE
fix: add Antigravity OAuth clientSecret fallback (#383)

### DIFF
--- a/src/lib/oauth/constants/oauth.ts
+++ b/src/lib/oauth/constants/oauth.ts
@@ -105,7 +105,8 @@ export const ANTIGRAVITY_CONFIG = {
   clientId:
     process.env.ANTIGRAVITY_OAUTH_CLIENT_ID ||
     "1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com",
-  clientSecret: process.env.ANTIGRAVITY_OAUTH_CLIENT_SECRET || "",
+  clientSecret:
+    process.env.ANTIGRAVITY_OAUTH_CLIENT_SECRET || "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",
   authorizeUrl: "https://accounts.google.com/o/oauth2/v2/auth",
   tokenUrl: "https://oauth2.googleapis.com/token",
   userInfoUrl: "https://www.googleapis.com/oauth2/v1/userinfo",


### PR DESCRIPTION
## Root Cause

`ANTIGRAVITY_CONFIG.clientSecret` in `src/lib/oauth/constants/oauth.ts` defaulted to an empty string `""`. Since JavaScript falsy check doesn't distinguish between `undefined` and `""`, the `client_secret` field was **never included** in the Google token exchange request.

This is the same bug that was fixed for iFlow in #339. The iFlow fix added the actual public credential as the fallback, but Antigravity was missed.

## Fix

```ts
// Before
clientSecret: process.env.ANTIGRAVITY_OAUTH_CLIENT_SECRET || "",

// After  
clientSecret: process.env.ANTIGRAVITY_OAUTH_CLIENT_SECRET || "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",
```

The credential is the built-in public OAuth client secret registered for OmniRoute with Google. Users can override it via `ANTIGRAVITY_OAUTH_CLIENT_SECRET` env var for custom deployments.

## Verification

686/686 unit tests pass. Closes #383