### PR TITLE
fix(build): force better-sqlite3 webpack external to prevent hash-based module name in instrumentation hook (#394)

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -38,8 +38,31 @@ const nextConfig = {
     unoptimized: true,
   },
   webpack: (config, { isServer }) => {
-    // Ignore native Node.js modules in browser bundle
-    if (!isServer) {
+    if (isServer) {
+      // Force better-sqlite3 to always be required by its exact package name.
+      //
+      // Next.js 16 webpack compiles the instrumentation hook into a separate
+      // chunk ([root-of-the-server]__<hash>.js) and can emit a hashed require
+      // such as `require('better-sqlite3-90e2652d1716b047')` even when the
+      // package is listed in `serverExternalPackages`. That hashed name doesn't
+      // exist in node_modules, causing the 500 error reported in issue #394.
+      //
+      // Adding an explicit `externals` function overrides the bundler's default
+      // handling and always emits `require('better-sqlite3')`, which resolves
+      // correctly in the published standalone build.
+      const prev = config.externals ?? [];
+      const prevArr = Array.isArray(prev) ? prev : [prev];
+      config.externals = [
+        ...prevArr,
+        ({ request }, callback) => {
+          if (request === "better-sqlite3") {
+            return callback(null, `commonjs ${request}`);
+          }
+          callback();
+        },
+      ];
+    } else {
+      // Ignore native Node.js modules in browser bundle
       config.resolve.fallback = {
         ...config.resolve.fallback,
         fs: false,


### PR DESCRIPTION
## Summary

Fixes #394 — v2.6.0 fails at startup with `Cannot find module better-sqlite3-<hash>`

## Root Cause

Next.js 16 webpack compiles the instrumentation hook (`src/instrumentation.ts`) into its own chunk (`[root-of-the-server]__<hash>.js`) and emits a hashed require like `require('better-sqlite3-90e2652d1716b047')` — even when the package is listed in `serverExternalPackages`. That hashed name doesn't exist in the installed `node_modules/`, causing a 500 error on every request.

## Fix

Added an explicit webpack `externals` function to the server build configuration in `next.config.mjs` that intercepts any `require('better-sqlite3')` and forces it to be emitted as `require('better-sqlite3')` (exact package name), bypassing the bundler's hashing behavior.

The existing `serverExternalPackages` entry is preserved for Turbopack compatibility; the new `externals` entry handles the webpack path specifically.

## Files Changed

- `next.config.mjs` — server webpack config only (browser bundle unchanged)

## Testing

- All 694 unit tests pass locally