### PR TITLE
fix(chat): handle Anthropic-format tools in empty-name filter (#346)

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -217,14 +217,16 @@ export async function handleChatCore({
           return item;
         });
       }
-      // ── #346: Strip tools with empty function.name ──
+      // ── #346: Strip tools with empty name ──
       // Claude Code sometimes forwards tool definitions with empty names, causing
       // OpenAI-compatible upstream providers to reject with:
       // "Invalid 'input[N].name': empty string. Expected minimum length 1."
+      // Handles both OpenAI format ({ function: { name } }) and Anthropic format ({ name }).
       if (Array.isArray(translatedBody.tools)) {
         translatedBody.tools = translatedBody.tools.filter((tool: Record<string, unknown>) => {
           const fn = tool.function as Record<string, unknown> | undefined;
-          return fn?.name && String(fn.name).trim().length > 0;
+          const name = fn?.name ?? tool.name;
+          return name && String(name).trim().length > 0;
         });
       }
 


### PR DESCRIPTION
## Problem

The empty tool name filter introduced in #346 only checks OpenAI-format tool names (`tool.function.name`), silently dropping **all tools** when the request arrives in Anthropic Messages API format (`tool.name` without `.function`).

This happens when LiteLLM proxies requests with an `anthropic/` model prefix — it translates to Anthropic Messages API format before forwarding to OmniRoute. The filter drops all tools, leaving `tool_choice` set but `tools` empty, causing Anthropic API to return:

```
400: tool_choice.any may only be specified while providing tools
```

The request then silently falls back to an OpenRouter provider.

## Fix

Check both formats:

```typescript
// Before
const fn = tool.function as Record<string, unknown> | undefined;
return fn?.name && String(fn.name).trim().length > 0;

// After
const fn = tool.function as Record<string, unknown> | undefined;
const name = fn?.name ?? tool.name;
return name && String(name).trim().length > 0;
```

## Root cause

Introduced in commit `4fbe45f` (v2.5.0). Present through v2.6.1.