### PR TITLE
feat(api): add Synthetic as a new API key provider

### DIFF
--- a/open-sse/config/providerRegistry.ts
+++ b/open-sse/config/providerRegistry.ts
@@ -919,6 +919,26 @@ export const REGISTRY: Record<string, RegistryEntry> = {
     ],
   },
 
+  synthetic: {
+    id: "synthetic",
+    alias: "synthetic",
+    format: "openai",
+    executor: "default",
+    baseUrl: "https://api.synthetic.new/openai/v1/chat/completions",
+    modelsUrl: "https://api.synthetic.new/openai/v1/models",
+    authType: "apikey",
+    authHeader: "bearer",
+    models: [
+      { id: "hf:nvidia/Kimi-K2.5-NVFP4", name: "Kimi K2.5 (NVFP4)" },
+      { id: "hf:MiniMaxAI/MiniMax-M2.5", name: "MiniMax M2.5" },
+      { id: "hf:zai-org/GLM-4.7-Flash", name: "GLM 4.7 Flash" },
+      { id: "hf:zai-org/GLM-4.7", name: "GLM 4.7" },
+      { id: "hf:moonshotai/Kimi-K2.5", name: "Kimi K2.5" },
+      { id: "hf:deepseek-ai/DeepSeek-V3.2", name: "DeepSeek V3.2" },
+    ],
+    passthroughModels: true,
+  },
+
   vertex: {
     id: "vertex",
     alias: "vertex",

--- a/src/app/api/providers/[id]/models/route.ts
+++ b/src/app/api/providers/[id]/models/route.ts
@@ -255,6 +255,14 @@ const PROVIDER_MODELS_CONFIG: Record<string, ProviderModelsConfigEntry> = {
     authPrefix: "Bearer ",
     parseResponse: (data) => data.models || data.data || [],
   },
+  synthetic: {
+    url: "https://api.synthetic.new/openai/v1/models",
+    method: "GET",
+    headers: { "Content-Type": "application/json" },
+    authHeader: "Authorization",
+    authPrefix: "Bearer ",
+    parseResponse: (data) => data.data || data.models || [],
+  },
 };
 
 /**

--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -360,6 +360,16 @@ export const APIKEY_PROVIDERS = {
     hasFree: true,
     freeNote: "Free Inference API for thousands of models (Whisper, VITS, SDXL…)",
   },
+  synthetic: {
+    id: "synthetic",
+    alias: "synthetic",
+    name: "Synthetic",
+    icon: "verified_user",
+    color: "#6366F1",
+    textIcon: "SY",
+    website: "https://synthetic.new",
+    passthroughModels: true,
+  },
   vertex: {
     id: "vertex",
     alias: "vertex",


### PR DESCRIPTION
## Summary

- Add [Synthetic](https://synthetic.new) as a new privacy-focused API key provider
- OpenAI-compatible format with dynamic model catalog via `/models` endpoint
- `passthroughModels` enabled for Synthetic's evolving model list

## Changes

| File | Change |
|------|--------|
| `open-sse/config/providerRegistry.ts` | Register `synthetic` provider with 6 initial models |
| `src/shared/constants/providers.ts` | Add APIKEY_PROVIDERS entry (`verified_user` icon, `#6366F1`) |
| `src/app/api/providers/[id]/models/route.ts` | Add models listing config for `/models` endpoint |

## Backward compatibility

- No breaking changes — new provider only
- No migration needed
- API keys configured via dashboard or API

## Test plan

- [x] `pnpm run lint` — 0 errors
- [x] `pnpm test` — 694/694 pass
- [x] `pnpm run test:vitest` — 52/52 pass
- [x] Synthetic API `/models` responds with 17 models across 3 sub-providers
- [x] Provider connection creation via API — `provider: "synthetic"` accepted
- [x] Routing `synthetic/hf:zai-org/GLM-4.7-Flash` — request reaches `api.synthetic.new`
- [x] Real chat with API key — GLM-4.7-Flash responds with reasoning content
- [x] Streaming — SSE thinking + content deltas received
- [x] Dashboard — provider listed in API Key Providers, icon and color correct
- [x] Models refresh from `/models` endpoint — fetches dynamic catalog
- [x] Model passthrough — any model ID forwarded as-is to upstream