### PR TITLE
fix(sse): generate fallback call_id for tool calls with missing IDs

### DIFF
--- a/open-sse/translator/request/openai-responses.ts
+++ b/open-sse/translator/request/openai-responses.ts
@@ -6,6 +6,7 @@
  */
 import { register } from "../registry.ts";
 import { FORMATS } from "../formats.ts";
+import { generateToolCallId } from "../helpers/toolCallHelper.ts";
 
 type JsonRecord = Record<string, unknown>;
 
@@ -321,7 +322,7 @@ export function openaiToOpenAIResponsesRequest(
           const fn = toRecord(toolCall.function);
           input.push({
             type: "function_call",
-            call_id: toString(toolCall.id),
+            call_id: toString(toolCall.id).trim() || generateToolCallId(),
             name: toString(fn.name),
             arguments: toString(fn.arguments, "{}"),
           });


### PR DESCRIPTION
## Problem

When converting OpenAI Chat Completions format to OpenAI Responses API format
in `openaiToOpenAIResponsesRequest`, tool calls that lack a valid `id` field
produce function_call items with an empty `call_id`. The Responses API requires
non-empty call_id values for proper request/response correlation.

This causes errors when:
1. A provider returns tool calls without IDs (some providers omit or return null)
2. Claude Code compaction truncates message fields including tool call IDs
3. The translated request is sent to a Responses-compatible upstream that
   validates call_id presence

## Root Cause

The translator uses `toString(toolCall.id)` to extract the call_id, which
returns an empty string when the ID is undefined, null, or empty. The Responses
API specification requires each function_call to have a unique, non-empty
call_id that the client uses to match function_call_output responses.

## Changes

| File | Change |
|------|--------|
| `open-sse/translator/request/openai-responses.ts` | Generate unique fallback call_id when toolCall.id is empty or missing |

## How It Works

When `toString(toolCall.id)` returns an empty or whitespace-only string, a
unique fallback ID is generated using the pattern:

```
call_{timestamp}_{random_7_chars}
```

For example: `call_1710619200000_a3x7kf2`

This format:
- Starts with "call_" to match the OpenAI convention for tool call IDs
- Includes a millisecond timestamp for ordering
- Includes 7 random base-36 characters for uniqueness
- Is deterministic within a single request (each missing ID gets a unique value)

The fallback only activates when the original ID is missing. Valid IDs are
passed through unchanged.

## Test Plan

- [ ] Unit tests pass: `npm run test:unit`
- [ ] Lint passes: `npm run lint`
- [ ] Send a request with tool_calls that have missing/empty IDs through
      the Chat-to-Responses translator -- verify generated call_ids match
      the expected format
- [ ] Verify tool_calls with valid IDs are not modified
- [ ] Verify the generated call_id is used consistently for matching
      function_call_output items in the response