### PR TITLE
fix(sse): extract Claude SSE usage in passthrough stream mode

### DIFF
--- a/open-sse/utils/stream.ts
+++ b/open-sse/utils/stream.ts
@@ -184,6 +184,17 @@ export function createSSEStream(options: StreamOptions = {}) {
                   typeof parsed.type === "string" &&
                   parsed.type.startsWith("response.");
 
+                // Detect Claude SSE payloads. Includes "ping" and "error" to ensure
+                // they bypass the Chat Completions sanitization path which would
+                // incorrectly process or drop them.
+                const isClaudeSSE =
+                  parsed.type &&
+                  typeof parsed.type === "string" &&
+                  (parsed.type.startsWith("message") ||
+                    parsed.type.startsWith("content_block") ||
+                    parsed.type === "ping" ||
+                    parsed.type === "error");
+
                 if (isResponsesSSE) {
                   // Responses SSE: only extract usage, forward payload as-is
                   const extracted = extractUsage(parsed);
@@ -194,6 +205,22 @@ export function createSSEStream(options: StreamOptions = {}) {
                   if (parsed.delta && typeof parsed.delta === "string") {
                     totalContentLength += parsed.delta.length;
                   }
+                } else if (isClaudeSSE) {
+                  // Claude SSE: extract usage, track content, forward as-is
+                  const extracted = extractUsage(parsed);
+                  if (extracted) {
+                    // Non-destructive merge: never overwrite a positive value with 0
+                    // message_start carries input_tokens, message_delta carries output_tokens
+                    if (!usage) usage = {};
+                    if (extracted.prompt_tokens > 0) usage.prompt_tokens = extracted.prompt_tokens;
+                    if (extracted.completion_tokens > 0) usage.completion_tokens = extracted.completion_tokens;
+                    if (extracted.total_tokens > 0) usage.total_tokens = extracted.total_tokens;
+                    if (extracted.cache_read_input_tokens) usage.cache_read_input_tokens = extracted.cache_read_input_tokens;
+                    if (extracted.cache_creation_input_tokens) usage.cache_creation_input_tokens = extracted.cache_creation_input_tokens;
+                  }
+                  // Track content length from Claude format
+                  if (parsed.delta?.text) totalContentLength += parsed.delta.text.length;
+                  if (parsed.delta?.thinking) totalContentLength += parsed.delta.thinking.length;
                 } else {
                   // Chat Completions: full sanitization pipeline
                   parsed = sanitizeStreamingChunk(parsed);
@@ -372,9 +399,9 @@ export function createSSEStream(options: StreamOptions = {}) {
               controller.enqueue(encoder.encode(output));
             }
 
-            // Estimate usage if provider didn't return valid usage (PASSTHROUGH is always OpenAI format)
+            // Estimate usage if provider didn't return valid usage
             if (!hasValidUsage(usage) && totalContentLength > 0) {
-              usage = estimateUsage(body, totalContentLength, FORMATS.OPENAI);
+              usage = estimateUsage(body, totalContentLength, sourceFormat || FORMATS.OPENAI);
             }
 
             if (hasValidUsage(usage)) {


### PR DESCRIPTION
## Problem

When a Claude-format provider is used in passthrough mode (source and target
formats are both Claude), the streaming response handler does not extract usage
data from Claude SSE events. This causes token counts to show as 0 in call logs,
usage analytics, and cost calculations for all Claude-format passthrough
providers (e.g., anthropic-compatible nodes, MiniMax Anthropic endpoint).

The passthrough stream mode currently handles two event types:
1. OpenAI Responses SSE events (type: "response.*") -- usage extracted correctly
2. OpenAI Chat Completions events -- usage extracted correctly

Claude SSE events (type: "message_start", "content_block_delta", "message_delta")
fall through to the Chat Completions path, where sanitizeStreamingChunk and
hasValuableContent may drop them or fail to extract usage from the Claude-specific
event structure.

## Root Cause

The passthrough mode in `stream.ts` detects event types to decide how to process
each SSE line. Claude events have types like "message_start" and "message_delta"
which do not match the "response.*" prefix check for OpenAI Responses events.
They fall into the default Chat Completions processing path which:

1. Runs sanitizeStreamingChunk (designed for OpenAI format, may strip Claude fields)
2. Checks hasValuableContent using OpenAI format rules (may reject Claude events)
3. Does not call extractUsage for Claude event structures

Additionally, the usage merge logic must handle the fact that Claude splits usage
across two events: message_start provides input_tokens, and message_delta provides
output_tokens. A naive object spread would overwrite input_tokens with 0 when
processing message_delta.

## Changes

| File | Change |
|------|--------|
| `open-sse/utils/stream.ts` | Add Claude SSE event detection in passthrough mode |
| `open-sse/utils/stream.ts` | Extract usage with non-destructive merge (only overwrite when value > 0) |
| `open-sse/utils/stream.ts` | Track content length from Claude delta events |
| `open-sse/utils/stream.ts` | Use source format for usage estimation fallback instead of hardcoded OpenAI |

## How It Works

A new `isClaudeSSE` check detects Claude event types by matching the `type` field
against known prefixes: "message" (covers message_start, message_stop,
message_delta) and "content_block" (covers content_block_start, content_block_delta,
content_block_stop).

For Claude events, the handler:
1. Calls extractUsage (which already handles Claude event structures)
2. Merges the result non-destructively -- only overwrites a field if the new value
   is greater than 0, preventing message_delta from clobbering input_tokens
3. Tracks content length from delta.text and delta.thinking fields
4. Forwards the event as-is without modification

The response stream is never modified -- this change only observes events for
usage tracking purposes.

## Test Plan

- [ ] Unit tests pass: `npm run test:unit`
- [ ] Lint passes: `npm run lint`
- [ ] Send requests through a Claude-format passthrough provider and verify
      token counts appear in call logs (previously showed 0)
- [ ] Verify input_tokens and output_tokens are both captured correctly
      (input from message_start, output from message_delta)
- [ ] Verify OpenAI and Responses SSE passthrough continues to work
- [ ] Verify Claude SSE events are forwarded to the client unmodified