### PR TITLE
fix(sse): strip Claude-specific fields in OpenAI format cleanup

### DIFF
--- a/open-sse/translator/helpers/openaiHelper.ts
+++ b/open-sse/translator/helpers/openaiHelper.ts
@@ -91,6 +91,10 @@ export function filterToOpenAIFormat(body) {
     delete body.tools;
   }
 
+  // Strip Claude-specific fields that OpenAI-compatible providers reject
+  delete body.metadata;
+  delete body.anthropic_version;
+
   // Normalize tools to OpenAI format (from Claude, Gemini, etc.)
   if (body.tools && Array.isArray(body.tools) && body.tools.length > 0) {
     body.tools = body.tools


### PR DESCRIPTION
## Problem

When translating Claude-format requests to OpenAI format, Claude-specific fields
like `metadata` and `anthropic_version` are passed through to the translated
request body. OpenAI-compatible providers that perform strict schema validation
reject these unknown fields with "invalid params" or "Improperly formed request"
errors.

This affects any request path where a Claude-format client (such as Claude Code)
sends requests through OmniRoute to an OpenAI-compatible backend provider.

## Root Cause

The `filterToOpenAIFormat` helper in `openaiHelper.ts` normalizes translated
requests for OpenAI-compatible providers. It already strips empty tools arrays,
converts tool_choice formats, and filters non-OpenAI content types. However, it
does not remove top-level Claude API fields that have no equivalent in the OpenAI
API specification.

The `metadata` field is used by the Anthropic Messages API for request tracking.
The `anthropic_version` field specifies the Anthropic API version. Neither field
is recognized by OpenAI-compatible providers.

## Changes

| File | Change |
|------|--------|
| `open-sse/translator/helpers/openaiHelper.ts` | Delete `metadata` and `anthropic_version` fields in `filterToOpenAIFormat` |

## How It Works

After the existing empty-tools cleanup, the function now deletes `body.metadata`
and `body.anthropic_version` before returning the normalized body. These fields
are safe to remove because:

1. They carry no semantic meaning for OpenAI-compatible providers
2. The original untranslated request body is preserved in the request logger
3. If the target is a Claude-format provider, this function is not called
   (Claude targets use `prepareClaudeRequest` instead)

## Test Plan

- [ ] Unit tests pass: `npm run test:unit`
- [ ] Lint passes: `npm run lint`
- [ ] Send a Claude-format request with `metadata` field through an
      OpenAI-compatible provider -- verify the field is stripped and
      the provider does not return an error
- [ ] Verify Claude-to-Claude routing is unaffected (filterToOpenAIFormat
      is not called for Claude targets)