### PR TITLE
fix(sse): strip empty text content blocks before translation

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -233,6 +233,19 @@ export async function handleChatCore({
         });
       }
 
+      // Strip empty text content blocks from messages.
+      // Anthropic API rejects {"type":"text","text":""} with 400 "text content blocks must be non-empty".
+      // Some clients (LiteLLM passthrough, @ai-sdk/anthropic) may forward these empty blocks as-is.
+      if (Array.isArray(translatedBody.messages)) {
+        for (const msg of translatedBody.messages) {
+          if (Array.isArray(msg.content)) {
+            msg.content = msg.content.filter((block: Record<string, unknown>) =>
+              block.type !== "text" || (typeof block.text === "string" && block.text.length > 0)
+            );
+          }
+        }
+      }
+
       translatedBody = translateRequest(
         sourceFormat,
         targetFormat,


### PR DESCRIPTION
## Problem

Anthropic API returns **400 Bad Request** with `"text content blocks must be non-empty"` when a request contains `{"type": "text", "text": ""}` content blocks.

This happens when upstream clients forward empty text blocks as-is. Known sources:
- **LiteLLM passthrough mode** — forwards messages without sanitizing content blocks
- **@ai-sdk/anthropic** (Vercel AI SDK) — may produce empty text blocks in multi-part content

## Solution

Strip empty text content blocks from `translatedBody.messages` before calling `translateRequest()` in `chatCore.ts`. This follows the same pattern already used for stripping empty-name tools (lines 228-234).

A text block is removed if `block.type === "text"` and `block.text` is either not a string or an empty string.

## Testing

- Sent requests with empty text blocks `{"type":"text","text":""}` through OmniRoute to Anthropic — previously returned 400, now succeeds
- Requests without empty text blocks are unaffected (filter is a no-op)