### PR TITLE
fix(api): add refreshable: true to claude OAuth test config

### DIFF
--- a/src/app/api/providers/[id]/test/route.ts
+++ b/src/app/api/providers/[id]/test/route.ts
@@ -20,6 +20,7 @@ const OAUTH_TEST_CONFIG = {
   claude: {
     // Claude doesn't have userinfo, we verify token exists and not expired
     checkExpiry: true,
+    refreshable: true,
   },
   codex: {
     // Codex OAuth tokens are ChatGPT session tokens, NOT standard OpenAI API keys.


### PR DESCRIPTION
## Problem

Claude OAuth tokens are short-lived (~10 minutes) and require periodic refresh via `refresh_token`. The open-sse runtime (HealthCheck) handles this correctly using `getAccessToken()` with built-in dedup/race-condition cache.

However, the **Dashboard test endpoint** (`/api/providers/[id]/test`) was missing `refreshable: true` in the `OAUTH_TEST_CONFIG` for the `claude` provider. This meant:

1. When a Claude token expired, the test endpoint did **not** attempt to refresh it
2. The Dashboard showed **"auth failed / Token expired"** even though the runtime was working fine
3. Users saw a misleading red status indicator for healthy Claude OAuth connections

The `codex` provider already had `refreshable: true` set correctly.

## Solution

Add `refreshable: true` to the `claude` entry in `OAUTH_TEST_CONFIG`, matching the behavior of `codex` and other refreshable providers.

## Testing

- Claude OAuth provider with expired access token now shows green status in Dashboard after automatic refresh
- No change in behavior for providers that already had `refreshable: true`