### PR TITLE
fix: login default password hint + Windows CLI healthcheck shell resolution

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -203,6 +203,7 @@ export default function LoginPage() {
                   {error}
                 </p>
               )}
+              <p className="text-xs text-text-muted/60 pt-0.5">{t("defaultPasswordHint")}</p>
             </div>
 
             <Button

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -2293,7 +2293,8 @@
     "orRemovePasswordHashField": "or remove the passwordHash field",
     "restartServerWithNewPassword": "Restart the server - it will use the new password",
     "backToLogin": "Back to Login",
-    "forgotPassword": "Forgot password?"
+    "forgotPassword": "Forgot password?",
+    "defaultPasswordHint": "Default password: 123456 (unless INITIAL_PASSWORD was set)"
   },
   "landing": {
     "brandName": "OmniRoute",

--- a/src/shared/services/cliRuntime.ts
+++ b/src/shared/services/cliRuntime.ts
@@ -121,7 +121,14 @@ const runProcess = (
     let timedOut = false;
     let settled = false;
 
-    const child = spawn(command, args, { env, stdio: ["ignore", "pipe", "pipe"] });
+    const child = spawn(command, args, {
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+      // On Windows, npm installs CLI wrappers as .cmd scripts (e.g. claude.cmd).
+      // Without shell:true, spawn cannot resolve them via PATHEXT and the
+      // healthcheck fails even when the CLI is correctly installed (#447).
+      ...(isWindows() ? { shell: true } : {}),
+    });
     const timer = setTimeout(() => {
       timedOut = true;
       child.kill("SIGKILL");


### PR DESCRIPTION
## Summary

Fixes two UX/bug issues reported by the community:

### fix(ux): Show default password hint on login page (#437)

First-time users on Windows were getting locked out not knowing the fallback password is `123456`. Added a small hint below the password input:
> *Default password: 123456 (unless INITIAL_PASSWORD was set)*

- File: `src/app/login/page.tsx`
- Uses i18n key `auth.defaultPasswordHint` (added to `en.json`)

### fix(cli): Windows CLI healthcheck resolves .cmd wrappers via shell (#447)

On Windows, npm installs CLI tools (Claude, opencode, etc.) as `.cmd` wrappers (e.g. `claude.cmd`). Without `shell: true` in `spawn()`, Node.js cannot find them via PATHEXT, causing the healthcheck to fail even when the CLI is correctly installed.

- File: `src/shared/services/cliRuntime.ts`
- Adds `...(isWindows() ? { shell: true } : {})` to spawn options
- Only applies on Windows — no behavior change on Linux/macOS

## Test Plan

- [x] 770/770 tests passing
- Windows: Claude CLI / opencode now show as ✅ installed
- Login page: hint visible on first-time login

Closes #437
Closes #447