### PR TITLE
fix: pino Docker crash + Codex /v1/responses worker exit + package-lock sync

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,10 @@ COPY --from=builder /app/.next/static ./.next/static
 COPY --from=builder /app/.next/standalone ./
 # Explicitly copy @swc/helpers — not always traced by standalone output but needed at runtime
 COPY --from=builder /app/node_modules/@swc/helpers ./node_modules/@swc/helpers
+# Explicitly copy pino transport dependencies — pino spawns a worker that requires
+# pino-abstract-transport at runtime; Next.js standalone trace does not capture it (#449)
+COPY --from=builder /app/node_modules/pino-abstract-transport ./node_modules/pino-abstract-transport
+COPY --from=builder /app/node_modules/pino-pretty ./node_modules/pino-pretty
 COPY --from=builder /app/scripts/run-standalone.mjs ./run-standalone.mjs
 COPY --from=builder /app/scripts/runtime-env.mjs ./runtime-env.mjs
 COPY --from=builder /app/scripts/bootstrap-env.mjs ./bootstrap-env.mjs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "omniroute",
-  "version": "2.7.0",
+  "version": "2.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "omniroute",
-      "version": "2.7.0",
+      "version": "2.7.2",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/src/app/api/v1/responses/route.ts
+++ b/src/app/api/v1/responses/route.ts
@@ -1,16 +1,14 @@
 import { CORS_ORIGIN } from "@/shared/utils/cors";
 import { handleChat } from "@/sse/handlers/chat";
-import { initTranslators } from "@omniroute/open-sse/translator/index.ts";
 
-let initialized = false;
-
-async function ensureInitialized() {
-  if (!initialized) {
-    await initTranslators();
-    initialized = true;
-    console.log("[SSE] Translators initialized for /v1/responses");
-  }
-}
+// NOTE: We do NOT call initTranslators() here — the translator registry is
+// bootstrapped at module level inside open-sse/translator/index.ts when it
+// is first imported. Calling it again from a Next.js Route Handler caused a
+// "the worker has exited" uncaughtException crash on Codex CLI requests (#450)
+// because the dynamic import runs in a Next.js server worker context where
+// certain Node APIs used by the translator bootstrap are not available.
+// The translators are always initialized via the open-sse side (chatCore),
+// so /v1/responses just delegates to handleChat which handles everything.
 
 export async function OPTIONS() {
   return new Response(null, {
@@ -24,9 +22,8 @@ export async function OPTIONS() {
 
 /**
  * POST /v1/responses - OpenAI Responses API format
- * Now handled by translator pattern (openai-responses format auto-detected)
+ * Handled by the unified chat handler (openai-responses format auto-detected).
  */
 export async function POST(request) {
-  await ensureInitialized();
   return await handleChat(request);
 }


### PR DESCRIPTION
## Summary

Fixes two bugs reported by @Aren1010 plus a housekeeping improvement:

### fix(docker): pino-abstract-transport missing in standalone image (#449)

pino spawns a worker thread () that dynamically requires `pino-abstract-transport` at startup. Next.js standalone trace does not capture dynamically-required peer dependencies — only static imports are traced.

Added explicit COPY statements for `pino-abstract-transport` and `pino-pretty` in the `runner-base` Dockerfile stage, identical to the existing `@swc/helpers` workaround.

### fix(responses): /v1/responses crashes Codex CLI with 'worker has exited' (#450)

`/v1/responses/route.ts` was calling `initTranslators()` which bootstrapped the open-sse translator registry from inside a Next.js Route Handler worker. This triggered dynamic imports that use Node APIs conflicting with the Next.js server worker context, causing `uncaughtException: Error: the worker has exited`.

**Fix:** Removed `initTranslators()` call entirely from the responses route. The translator registry is already bootstrapped at module level in the open-sse side (`chatCore`), so `/v1/responses` simply delegates to `handleChat()`.

### chore: include package-lock.json in commits

`package-lock.json` was being left behind on every version bump, causing `npm ci` in the Docker builder stage to install inconsistent dependency versions. Now committed alongside `package.json` on each release.

## Test Plan
- [x] 770/770 tests passing

Closes #449
Closes #450