### PR TITLE
fix: budget warningThreshold + combo agent UI fields + omniModel tag strip

### DIFF
--- a/open-sse/services/comboAgentMiddleware.ts
+++ b/open-sse/services/comboAgentMiddleware.ts
@@ -123,6 +123,20 @@ export function applyToolFilter(
   });
 }
 
+/**
+ * Strip all <omniModel> tags from message content before forwarding to the provider.
+ * The tag is an internal OmniRoute marker; providers must never see it or their
+ * cache will treat every tagged request as a new session (#454).
+ */
+export function stripModelTags(messages: Message[]): Message[] {
+  return messages.map((msg) => {
+    if (typeof msg.content === "string" && CACHE_TAG_PATTERN.test(msg.content)) {
+      return { ...msg, content: msg.content.replace(CACHE_TAG_PATTERN, "").trimEnd() };
+    }
+    return msg;
+  });
+}
+
 // ── Main Middleware ──────────────────────────────────────────────────────────
 
 /**
@@ -157,6 +171,11 @@ export function applyComboAgentMiddleware(
     body.tools as unknown[] | undefined,
     comboConfig.tool_filter_regex
   );
+
+  // 4. Strip internal <omniModel> tags before forwarding to provider (#454)
+  //    These tags are OmniRoute-internal markers and must never reach the provider
+  //    since providers would treat each tagged request as a new cache session.
+  messages = stripModelTags(messages);
 
   return {
     body: {

--- a/src/app/(dashboard)/dashboard/combos/page.tsx
+++ b/src/app/(dashboard)/dashboard/combos/page.tsx
@@ -1181,6 +1181,12 @@ function ComboFormModal({ isOpen, combo, onClose, onSave, activeProviders }) {
   const [config, setConfig] = useState(combo?.config || {});
   const [showStrategyNudge, setShowStrategyNudge] = useState(false);
   const strategyChangeMountedRef = useRef(false);
+  // Agent features (#399 / #401 / #454)
+  const [agentSystemMessage, setAgentSystemMessage] = useState<string>(combo?.system_message || "");
+  const [agentToolFilter, setAgentToolFilter] = useState<string>(combo?.tool_filter_regex || "");
+  const [agentContextCache, setAgentContextCache] = useState<boolean>(
+    !!combo?.context_cache_protection
+  );
 
   // DnD state
   const hasPricingForModel = useCallback(
@@ -1531,6 +1537,14 @@ function ComboFormModal({ isOpen, combo, onClose, onSave, activeProviders }) {
     if (Object.keys(configToSave).length > 0) {
       saveData.config = configToSave;
     }
+
+    // Agent features (#399 / #401 / #454)
+    if (agentSystemMessage.trim()) saveData.system_message = agentSystemMessage.trim();
+    else delete saveData.system_message;
+    if (agentToolFilter.trim()) saveData.tool_filter_regex = agentToolFilter.trim();
+    else delete saveData.tool_filter_regex;
+    if (agentContextCache) saveData.context_cache_protection = true;
+    else delete saveData.context_cache_protection;
 
     await onSave(saveData);
     setSaving(false);
@@ -2051,6 +2065,72 @@ function ComboFormModal({ isOpen, combo, onClose, onSave, activeProviders }) {
               <p className="text-[10px] text-text-muted">{t("advancedHint")}</p>
             </div>
           )}
+
+          {/* Agent Features (#399 / #401 / #454) */}
+          <div className="flex flex-col gap-2 p-3 bg-black/[0.02] dark:bg-white/[0.02] rounded-lg border border-black/5 dark:border-white/5">
+            <div className="flex items-center gap-1.5 mb-1">
+              <span className="material-symbols-outlined text-[14px] text-primary">smart_toy</span>
+              <p className="text-xs font-medium">Agent Features</p>
+              <span className="text-[10px] text-text-muted">
+                — optional, for agent/tool workflows
+              </span>
+            </div>
+
+            {/* System Message Override */}
+            <div>
+              <label className="text-[11px] font-medium text-text-muted block mb-0.5">
+                System Message Override
+              </label>
+              <textarea
+                rows={2}
+                value={agentSystemMessage}
+                onChange={(e) => setAgentSystemMessage(e.target.value)}
+                placeholder="Override the system prompt for all requests routed through this combo…"
+                className="w-full text-xs py-1.5 px-2 rounded border border-black/10 dark:border-white/10 bg-transparent focus:border-primary focus:outline-none resize-none"
+              />
+              <p className="text-[10px] text-text-muted mt-0.5">
+                Replaces any system message sent by the client. Leave empty to pass through client
+                system messages.
+              </p>
+            </div>
+
+            {/* Tool Filter Regex */}
+            <div>
+              <label className="text-[11px] font-medium text-text-muted block mb-0.5">
+                Tool Filter Regex
+              </label>
+              <input
+                type="text"
+                value={agentToolFilter}
+                onChange={(e) => setAgentToolFilter(e.target.value)}
+                placeholder="e.g. ^(bash|computer)$"
+                className="w-full text-xs py-1.5 px-2 rounded border border-black/10 dark:border-white/10 bg-transparent focus:border-primary focus:outline-none font-mono"
+              />
+              <p className="text-[10px] text-text-muted mt-0.5">
+                Only tools whose name matches this regex are forwarded to the provider. Leave empty
+                to forward all tools.
+              </p>
+            </div>
+
+            {/* Context Cache Protection */}
+            <div className="flex items-center justify-between gap-2">
+              <div>
+                <label className="text-[11px] font-medium text-text-muted block">
+                  Context Cache Protection
+                </label>
+                <p className="text-[10px] text-text-muted">
+                  Pins the provider/model across turns to preserve cache sessions. Internal tags are
+                  stripped before forwarding to the provider.
+                </p>
+              </div>
+              <input
+                type="checkbox"
+                checked={agentContextCache}
+                onChange={(e) => setAgentContextCache(e.target.checked)}
+                className="accent-primary shrink-0"
+              />
+            </div>
+          </div>
 
           {/* Actions */}
           <div className="flex gap-2 pt-1">

--- a/src/app/(dashboard)/dashboard/usage/components/BudgetTab.tsx
+++ b/src/app/(dashboard)/dashboard/usage/components/BudgetTab.tsx
@@ -83,7 +83,11 @@ export default function BudgetTab() {
         if (data.monthlyLimitUsd)
           setForm((f) => ({ ...f, monthlyLimitUsd: String(data.monthlyLimitUsd) }));
         if (data.warningThreshold)
-          setForm((f) => ({ ...f, warningThreshold: String(data.warningThreshold) }));
+          // stored as fraction (0–1), display as percentage (0–100)
+          setForm((f) => ({
+            ...f,
+            warningThreshold: String(Math.round(data.warningThreshold * 100)),
+          }));
       }
     } catch {
       // silent
@@ -104,7 +108,8 @@ export default function BudgetTab() {
           apiKeyId: selectedKey,
           dailyLimitUsd: form.dailyLimitUsd ? parseFloat(form.dailyLimitUsd) : null,
           monthlyLimitUsd: form.monthlyLimitUsd ? parseFloat(form.monthlyLimitUsd) : null,
-          warningThreshold: parseInt(form.warningThreshold) || 80,
+          // schema expects a fraction (0–1); UI shows percentage (0–100)
+          warningThreshold: (parseInt(form.warningThreshold) || 80) / 100,
         }),
       });
       if (res.ok) {


### PR DESCRIPTION
## Summary

### fix(budget): warningThreshold fraction mismatch — Save Limits crashes (#451)

**Root cause:** `BudgetTab.tsx` sent an integer percentage (e.g. `80`) to `POST /api/usage/budget`, but `setBudgetSchema` validates `warningThreshold` as a fraction (`0–1`).

**Fix:**
- POST now divides by 100: `(parseInt(form.warningThreshold) || 80) / 100`
- GET now multiplies by 100: `Math.round(data.warningThreshold * 100)` for display

---

### fix(combos): Agent Features UI missing from Combo dashboard (#454)

Features implemented in #399 and #401 (`system_message`, `tool_filter_regex`, `context_cache_protection`) were wired up server-side but the dashboard had no UI to set them.

**Fix:** Added an "Agent Features" section to the combo create/edit modal. All three fields are now visible and included in the save payload.

---

### fix(combos): `<omniModel>` tag sent to provider — breaks cache sessions (#454)

The context cache protection feature injects an internal `<omniModel>provider/model</omniModel>` tag into assistant messages to pin the session. This tag was being forwarded to the provider, which caused cache misses — providers saw each tagged request as a new session.

**Fix:** Added `stripModelTags()` in `comboAgentMiddleware.ts`, called just before building the outgoing body. The tag is stripped from all messages before leaving OmniRoute.

## Tests
- 770/770 passing ✅

Closes #451
Closes #454