### PR TITLE
fix(callLogs): support Claude format usage and include cache tokens

### DIFF
--- a/src/lib/usage/callLogs.ts
+++ b/src/lib/usage/callLogs.ts
@@ -184,8 +184,11 @@ export async function saveCallLog(entry: any) {
       account,
       connectionId: entry.connectionId || null,
       duration: entry.duration || 0,
-      tokensIn: entry.tokens?.prompt_tokens || 0,
-      tokensOut: entry.tokens?.completion_tokens || 0,
+      tokensIn:
+        (entry.tokens?.prompt_tokens || entry.tokens?.input_tokens || 0) +
+        (entry.tokens?.cache_read_input_tokens || entry.tokens?.cached_tokens || 0) +
+        (entry.tokens?.cache_creation_input_tokens || 0),
+      tokensOut: entry.tokens?.completion_tokens || entry.tokens?.output_tokens || 0,
       requestType: entry.requestType || null,
       sourceFormat: entry.sourceFormat || null,
       targetFormat: entry.targetFormat || null,


### PR DESCRIPTION
## Summary
- `saveCallLog` only read `prompt_tokens`/`completion_tokens` (OpenAI format), but when `sourceFormat=claude`, the `openai-to-claude` translator writes `input_tokens`/`output_tokens` — causing **all cross-format requests** (Codex-via-Claude, Kiro-via-Claude, Gemini-via-Claude) to show `I: 0 | O: 0` in call_logs
- Also includes `cache_read_input_tokens` + `cache_creation_input_tokens` in `tokens_in` total so heavily-cached requests don't show misleadingly low input counts

## Root Cause
`openai-to-claude.ts` line 51 overwrites `state.usage` with `{ input_tokens, output_tokens }` (Claude format). `callLogs.ts` line 187 only reads `entry.tokens?.prompt_tokens` which is `undefined` → `0`.

## Fix
- Read `prompt_tokens || input_tokens` (supports both formats)
- Read `completion_tokens || output_tokens` (supports both formats)
- Sum cache tokens into `tokens_in` for accurate totals

## Test plan
- [ ] Send a request through Codex with `sourceFormat=claude` and verify `call_logs` shows non-zero tokens
- [ ] Send a cached Claude request and verify `tokens_in` includes cache_read + cache_creation
- [ ] Existing OpenAI-format requests continue to work unchanged