### PR TITLE
fix(usage): include cache tokens in usage history input total

### DIFF
--- a/open-sse/utils/usageTracking.ts
+++ b/open-sse/utils/usageTracking.ts
@@ -400,8 +400,10 @@ export function logUsage(provider, usage, model = null, connectionId = null, api
   console.log(msg);
 
   // Save to usage DB
+  // input = total input tokens (non-cached + cache_read + cache_creation)
+  // This ensures analytics show correct totals for heavily-cached requests
   const tokens = {
-    input: inTokens,
+    input: inTokens + (cacheRead || 0) + (cacheCreation || 0),
     output: outTokens,
     cacheRead: cacheRead || 0,
     cacheCreation: cacheCreation || 0,


### PR DESCRIPTION
## Summary
`logUsage` stored only non-cached input tokens (`prompt_tokens`) in `usage_history.tokens_input`. For heavily-cached Claude requests (common with Claude Code), this shows near-zero input when the real total is 150K+.

## Fix
`tokens.input` now sums `prompt_tokens + cache_read + cache_creation` so analytics totals reflect actual token consumption.

## Test plan
- [ ] Send a cached Claude request and check `usage_history.tokens_input` includes cache tokens
- [ ] Analytics dashboard "Input" column shows correct totals