### PR TITLE
fix(kiro): strip injected model field from request body

### DIFF
--- a/open-sse/executors/kiro.ts
+++ b/open-sse/executors/kiro.ts
@@ -77,10 +77,13 @@ export class KiroExecutor extends BaseExecutor {
   }
 
   transformRequest(model: string, body: unknown, stream: boolean, credentials: unknown): unknown {
-    void model;
     void stream;
     void credentials;
-    return body;
+    // Kiro uses conversationState.currentMessage.userInputMessage.modelId,
+    // not a top-level "model" field. chatCore injects translatedBody.model
+    // which Kiro API rejects as unknown top-level field.
+    const { model: _model, ...rest } = body as Record<string, unknown>;
+    return rest;
   }
 
   /**


### PR DESCRIPTION
## Summary
`chatCore.ts` injects `translatedBody.model` for all providers after translation. Kiro API (AWS CodeWhisperer) has strict schema validation — only `conversationState`, `profileArn`, and `inferenceConfig` are valid at top level. The injected `model` field causes **100% of Kiro requests to fail** with "Improperly formed request".

## Fix
Strip the injected `model` field in `KiroExecutor.transformRequest()` using destructuring.

## Test plan
- [ ] Kiro requests succeed without "Improperly formed request" errors
- [ ] Other providers unaffected (model field still injected for them)