### PR TITLE
fix(pricing): add missing Codex 5.3/5.4 and Anthropic model ID entries

### DIFF
--- a/src/shared/constants/pricing.ts
+++ b/src/shared/constants/pricing.ts
@@ -2,6 +2,47 @@
 // All rates are in dollars per million tokens ($/1M tokens)
 // Based on user-provided pricing for Antigravity models and industry standards for others
 
+// Shared pricing constants to reduce duplication
+const GPT_5_3_CODEX_PRICING = {
+  input: 5.0,
+  output: 20.0,
+  cached: 2.5,
+  reasoning: 30.0,
+  cache_creation: 5.0,
+};
+
+const CLAUDE_OPUS_4_PRICING = {
+  input: 15.0,
+  output: 75.0,
+  cached: 7.5,
+  reasoning: 112.5,
+  cache_creation: 15.0,
+};
+
+const CLAUDE_SONNET_4_PRICING = {
+  input: 3.0,
+  output: 15.0,
+  cached: 1.5,
+  reasoning: 15.0,
+  cache_creation: 3.0,
+};
+
+const CLAUDE_OPUS_46_PRICING = {
+  input: 5.0,
+  output: 25.0,
+  cached: 2.5,
+  reasoning: 37.5,
+  cache_creation: 5.0,
+};
+
+const CLAUDE_SONNET_46_PRICING = {
+  input: 3.0,
+  output: 15.0,
+  cached: 1.5,
+  reasoning: 22.5,
+  cache_creation: 3.0,
+};
+
 export const DEFAULT_PRICING = {
   // OAuth Providers (using aliases)
 
@@ -61,42 +102,12 @@ export const DEFAULT_PRICING = {
       reasoning: 30.0,
       cache_creation: 5.0,
     },
-    // GPT 5.3 Codex family
-    "gpt-5.3-codex": {
-      input: 5.0,
-      output: 20.0,
-      cached: 2.5,
-      reasoning: 30.0,
-      cache_creation: 5.0,
-    },
-    "gpt-5.3-codex-xhigh": {
-      input: 5.0,
-      output: 20.0,
-      cached: 2.5,
-      reasoning: 30.0,
-      cache_creation: 5.0,
-    },
-    "gpt-5.3-codex-high": {
-      input: 5.0,
-      output: 20.0,
-      cached: 2.5,
-      reasoning: 30.0,
-      cache_creation: 5.0,
-    },
-    "gpt-5.3-codex-low": {
-      input: 5.0,
-      output: 20.0,
-      cached: 2.5,
-      reasoning: 30.0,
-      cache_creation: 5.0,
-    },
-    "gpt-5.3-codex-none": {
-      input: 5.0,
-      output: 20.0,
-      cached: 2.5,
-      reasoning: 30.0,
-      cache_creation: 5.0,
-    },
+    // GPT 5.3 Codex family (all same pricing tier)
+    "gpt-5.3-codex": GPT_5_3_CODEX_PRICING,
+    "gpt-5.3-codex-xhigh": GPT_5_3_CODEX_PRICING,
+    "gpt-5.3-codex-high": GPT_5_3_CODEX_PRICING,
+    "gpt-5.3-codex-low": GPT_5_3_CODEX_PRICING,
+    "gpt-5.3-codex-none": GPT_5_3_CODEX_PRICING,
     "gpt-5.1-codex-mini-high": {
       input: 1.5,
       output: 6.0,
@@ -576,48 +587,14 @@ export const DEFAULT_PRICING = {
       cache_creation: 5.0,
     },
     // Common model IDs (without dates) used across providers
-    "claude-opus-4-6": {
-      input: 5.0,
-      output: 25.0,
-      cached: 2.5,
-      reasoning: 37.5,
-      cache_creation: 5.0,
-    },
-    "claude-sonnet-4-6": {
-      input: 3.0,
-      output: 15.0,
-      cached: 1.5,
-      reasoning: 22.5,
-      cache_creation: 3.0,
-    },
-    "claude-opus-4-5-20251101": {
-      input: 15.0,
-      output: 75.0,
-      cached: 7.5,
-      reasoning: 112.5,
-      cache_creation: 15.0,
-    },
-    "claude-sonnet-4-5-20250929": {
-      input: 3.0,
-      output: 15.0,
-      cached: 1.5,
-      reasoning: 15.0,
-      cache_creation: 3.0,
-    },
-    "claude-sonnet-4": {
-      input: 3.0,
-      output: 15.0,
-      cached: 1.5,
-      reasoning: 15.0,
-      cache_creation: 3.0,
-    },
-    "claude-opus-4": {
-      input: 15.0,
-      output: 75.0,
-      cached: 7.5,
-      reasoning: 112.5,
-      cache_creation: 15.0,
-    },
+    // Intentional duplicates of dot-notation variants (e.g. claude-opus-4.6)
+    // to cover hyphen-notation IDs (claude-opus-4-6) used by some clients
+    "claude-opus-4-6": CLAUDE_OPUS_46_PRICING,
+    "claude-sonnet-4-6": CLAUDE_SONNET_46_PRICING,
+    "claude-opus-4-5-20251101": CLAUDE_OPUS_4_PRICING,
+    "claude-sonnet-4-5-20250929": CLAUDE_SONNET_4_PRICING,
+    "claude-sonnet-4": CLAUDE_SONNET_4_PRICING,
+    "claude-opus-4": CLAUDE_OPUS_4_PRICING,
   },
 
   // Gemini


### PR DESCRIPTION
## Summary
Missing pricing entries cause $0.00 cost display for common models:
- **Codex**: `gpt-5.3-codex-*` family (high, xhigh, low, none) and `gpt-5.4` — these are current default Codex models
- **Anthropic**: `claude-opus-4-6`, `claude-sonnet-4-6`, `claude-opus-4`, `claude-sonnet-4` — common short model IDs used by various clients
- **Claude Code**: `claude-opus-4-5-20251101`, `claude-sonnet-4-5-20250929` — dated IDs used by Claude Code OAuth

## Test plan
- [ ] Cost for `gpt-5.3-codex-high` requests shows non-zero in analytics
- [ ] Cost for `claude-opus-4-6` model shows correct Opus 4.6 pricing ($5/$25)