### PR TITLE
fix: resolve Windows machine ID failure (undefined\REG.exe) caused by node-machine-id bundle-time platform detection

### DIFF
--- a/src/shared/utils/machineId.ts
+++ b/src/shared/utils/machineId.ts
@@ -1,25 +1,30 @@
-import { execSync } from "child_process";
+import { execSync, execFileSync } from "child_process";
 
 function getMachineIdRaw(): string {
   if (process.platform === "win32") {
     const sysRoot = process.env.SystemRoot || process.env.windir || "C:\\Windows";
-    const output = execSync(
-      `"${sysRoot}\\System32\\REG.exe" QUERY "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Cryptography" /v MachineGuid`,
+    const output = execFileSync(
+      `${sysRoot}\\System32\\REG.exe`,
+      ["QUERY", "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Cryptography", "/v", "MachineGuid"],
       { encoding: "utf8" }
     );
-    return output
-      .toString()
-      .split("REG_SZ")[1]
-      .replace(/\r+|\n+|\s+/gi, "")
-      .toLowerCase();
+    return (
+      output
+        .toString()
+        .split("REG_SZ")[1]
+        ?.replace(/\r+|\n+|\s+/gi, "")
+        ?.toLowerCase() ?? ""
+    );
   }
   if (process.platform === "darwin") {
     const output = execSync("ioreg -rd1 -c IOPlatformExpertDevice", { encoding: "utf8" });
-    return output
-      .split("IOPlatformUUID")[1]
-      .split("\n")[0]
-      .replace(/\=|\s+|\"/gi, "")
-      .toLowerCase();
+    return (
+      output
+        .split("IOPlatformUUID")[1]
+        ?.split("\n")[0]
+        ?.replace(/\=|\s+|\"/gi, "")
+        ?.toLowerCase() ?? ""
+    );
   }
   const output = execSync(
     "( cat /var/lib/dbus/machine-id /etc/machine-id 2> /dev/null || hostname ) | head -n 1 || :",


### PR DESCRIPTION
## Summary

- **Bug:** On Windows, calling `getConsistentMachineId()` logs `Error getting machine ID: Error: Command failed: undefined\REG.exe QUERY HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Cryptography /v MachineGuid — The system cannot find the path specified.`
- **Root cause:** `node-machine-id` builds its `REG.exe` command path at **module load time** using `process.platform`. When Next.js bundles the module, `process.platform` is `""` (not `"win32"`) in the webpack/build context, causing the path lookup to return `undefined` and permanently baking `"undefined\REG.exe ..."` into the compiled chunk.
- **Fix:** Remove the `node-machine-id` dependency from `machineId.ts` and replace it with a direct `execSync` call that resolves `process.env.SystemRoot` at **call time**, so the correct Windows path is always used regardless of when the module was bundled.

## Root cause in detail

```js
// node-machine-id/dist/index.js — evaluated ONCE at bundle/load time
var d = { native: "%windir%\System32" }

function o() {
  return "win32" !== process.platform
    ? ""        // <-- returns "" during Next.js webpack bundling
    : "native"
}

var y = {
  win32: d[o()] + "\REG.exe QUERY ..."  // d[""] = undefined → baked as "undefined\REG.exe ..."
}
```

At runtime on Windows, `process.platform === "win32"` correctly selects `y["win32"]`, but the string was already frozen with the wrong path at build time.

## Changes

**`src/shared/utils/machineId.ts`**
- Removed `import { machineIdSync } from "node-machine-id"`
- Added `getMachineIdRaw()` — a direct implementation using `execSync` with `process.env.SystemRoot` resolved at call time
- Platform support preserved for Windows (`REG.exe`), macOS (`ioreg`), and Linux/FreeBSD (`/etc/machine-id`)

## Test plan

- [ ] Run omniroute on Windows — confirm no `Error getting machine ID` log on startup
- [ ] Verify `getConsistentMachineId()` returns a consistent 16-char hex string across restarts
- [ ] Run on Linux — confirm machine ID still resolves correctly