### PR TITLE
fix: preserve prompt_cache_key in Responses API, escape \n in tagContent (#517, #515)

### DIFF
--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -472,7 +472,7 @@ export async function handleComboChat({
         // SDKs close the connection on finish_reason, so anything sent after
         // that marker is silently dropped.
         if (!res.body) return res;
-        const tagContent = `\n<omniModel>${modelStr}</omniModel>\n`;
+        const tagContent = `\\n<omniModel>${modelStr}</omniModel>\\n`;
         const encoder = new TextEncoder();
         const decoder = new TextDecoder();
         let tagInjected = false;

--- a/open-sse/translator/helpers/responsesApiHelper.ts
+++ b/open-sse/translator/helpers/responsesApiHelper.ts
@@ -93,10 +93,11 @@ export function convertResponsesApiFormat(body) {
   }
 
   // Cleanup Responses API specific fields
+  // Note: prompt_cache_key is intentionally preserved — it is used by Codex and other
+  // providers as a cache-affinity signal. Stripping it breaks prompt caching (#517).
   delete result.input;
   delete result.instructions;
   delete result.include;
-  delete result.prompt_cache_key;
   delete result.store;
   delete result.reasoning;
 

--- a/open-sse/translator/request/openai-responses.ts
+++ b/open-sse/translator/request/openai-responses.ts
@@ -227,10 +227,11 @@ export function openaiResponsesToOpenAIRequest(
   });
 
   // Cleanup Responses API specific fields
+  // Note: prompt_cache_key is intentionally preserved — it is used by Codex and other
+  // providers as a cache-affinity signal. Stripping it breaks prompt caching (#517).
   delete result.input;
   delete result.instructions;
   delete result.include;
-  delete result.prompt_cache_key;
   delete result.store;
   delete result.reasoning;
 


### PR DESCRIPTION
## Fixes

Closes #517, #515

## Changes

### fix(translator): preserve `prompt_cache_key` (#517)
Codex uses `prompt_cache_key` as a cache-affinity signal — the same key routes the request to the same cached slot. OmniRoute was deleting it during Responses API → Chat Completions translation, which prevented caching from working.

**Files changed:**
- `open-sse/translator/request/openai-responses.ts` — removed `delete result.prompt_cache_key`
- `open-sse/translator/helpers/responsesApiHelper.ts` — removed `delete result.prompt_cache_key`

### fix(combo): escape `\n` in `tagContent` JSON injection (#515)
The `tagContent` variable used template literal newlines (U+000A character). When injected into a JSON string via regex replacement, these raw newlines produce invalid JSON (unescaped control characters). Replaced with literal `\n` escape sequences.

**File changed:**
- `open-sse/services/combo.ts` — `tagContent` now uses `\\n` instead of actual newlines

## Tests
- 821/821 pass ✅