### PR TITLE
chore(release): v2.9.5 — OpenCode providers, embedding fix, CLI masked key fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@
 
 ---
 
+## [2.9.5] — 2026-03-22
+
+> Sprint: New OpenCode providers, embedding credentials fix, CLI masked key bug, CACHE_TAG_PATTERN fix.
+
+### 🐛 Bug Fixes
+
+- **CLI tools save masked API key to config files** — `claude-settings`, `cline-settings`, and `openclaw-settings` POST routes now accept a `keyId` param and resolve the real API key from DB before writing to disk. `ClaudeToolCard` updated to send `keyId` instead of the masked display string. Fixes #523, #526.
+- **Custom embedding providers: `No credentials` error** — `/v1/embeddings` now tracks `credentialsProviderId` separately from the routing prefix, so credentials are fetched from the matching provider node ID rather than the public prefix string. Fixes a regression where `google/gemini-embedding-001` and similar custom-provider models would always fail with a credentials error. Fixes #532-related. (PR #528 by @jacob2826)
+- **Context cache protection regex misses `\n` prefix** — `CACHE_TAG_PATTERN` in `comboAgentMiddleware.ts` updated to match both literal `\n` (backslash-n) and actual newline U+000A that `combo.ts` streaming injects around the `<omniModel>` tag after fix #515. Fixes #531.
+
+### ✨ New Providers
+
+- **OpenCode Zen** — Free tier gateway at `opencode.ai/zen/v1` with 3 models: `minimax-m2.5-free`, `big-pickle`, `gpt-5-nano`
+- **OpenCode Go** — Subscription service at `opencode.ai/zen/go/v1` with 4 models: `glm-5`, `kimi-k2.5`, `minimax-m2.7` (Claude format), `minimax-m2.5` (Claude format)
+- Both providers use the new `OpencodeExecutor` which routes dynamically to `/chat/completions`, `/messages`, `/responses`, or `/models/{model}:generateContent` based on the requested model. (PR #530 by @kang-heewon)
+
+---
+
 ## [2.9.4] — 2026-03-21
 
 > Sprint: Bug fixes — preserve Codex prompt cache key, fix tagContent JSON escaping, sync expired token status to DB.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: OmniRoute API
-  version: 2.9.4
+  version: 2.9.5
   description: |
     OmniRoute is a local-first AI API proxy router. It provides an OpenAI-compatible
     endpoint that routes requests to multiple AI providers with load balancing,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "omniroute",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "omniroute",
-      "version": "2.9.4",
+      "version": "2.9.5",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omniroute",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "description": "Smart AI Router with auto fallback — route to FREE & cheap models, zero downtime. Works with Cursor, Cline, Claude Desktop, Codex, and any OpenAI-compatible tool.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## 🚀 Release v2.9.5

### ✨ New Providers
- **OpenCode Zen** — Free gateway at `opencode.ai/zen/v1` (minimax-m2.5-free, big-pickle, gpt-5-nano) — PR #530 by @kang-heewon
- **OpenCode Go** — Subscription at `opencode.ai/zen/go/v1` (glm-5, kimi-k2.5, minimax-m2.7, minimax-m2.5) — PR #530
- New `OpencodeExecutor` with multi-format routing (OpenAI / Claude / Responses / Gemini)

### 🐛 Bug Fixes
- **#523/#526** — CLI config files (claude, cline, openclaw) were saving the masked display key instead of the real API key. Fixed by sending `keyId` to backend which resolves the real key from DB.
- **Custom embedding providers credentials** — `/v1/embeddings` now uses provider node ID for credential lookup instead of the prefix string. Fixes auth failures for providers like `google/gemini-embedding-001`. PR #528 by @jacob2826.
- **#531** — Context cache protection regex (`CACHE_TAG_PATTERN`) updated to match surrounding `\n` (literal and actual newline) added by the streaming tag injector after fix #515.

### Tests
**832/832 ✅** (11 new from OpencodeExecutor unit tests)

### ⚠️ After merging: Phase 2 — tag, publish, Docker, and deploy.