### PR TITLE
fix: improve light mode contrast for log detail page

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -36,10 +36,13 @@
   /* Light theme */
   --color-bg: #f9f9fb;
   --color-bg-alt: #f0f0f5;
+  --color-bg-primary: #f9f9fb;
+  --color-bg-subtle: #f0f0f5;
   --color-surface: #ffffff;
   --color-sidebar: rgba(245, 245, 250, 0.8);
   --color-border: rgba(0, 0, 0, 0.08);
   --color-text-main: #1a1a2e;
+  --color-text-primary: #1a1a2e;
   --color-text-muted: #71717a;
 
   /* Shadows */
@@ -52,10 +55,13 @@
   /* Dark theme (ClawHub deep) */
   --color-bg: #0b0e14;
   --color-bg-alt: #111520;
+  --color-bg-primary: #0b0e14;
+  --color-bg-subtle: #111520;
   --color-surface: #161b22;
   --color-sidebar: rgba(16, 20, 30, 0.8);
   --color-border: rgba(255, 255, 255, 0.08);
   --color-text-main: #e6e6ef;
+  --color-text-primary: #e6e6ef;
   --color-text-muted: #a1a1aa;
 
   /* Dark shadows */
@@ -81,10 +87,13 @@
 
   /* Auto-switch colors (use CSS variables from :root/.dark) */
   --color-bg: var(--color-bg);
+  --color-bg-primary: var(--color-bg-primary);
+  --color-bg-subtle: var(--color-bg-subtle);
   --color-surface: var(--color-surface);
   --color-sidebar: var(--color-sidebar);
   --color-border: var(--color-border);
   --color-text-main: var(--color-text-main);
+  --color-text-primary: var(--color-text-primary);
   --color-text-muted: var(--color-text-muted);
 
   /* Static colors (for explicit light/dark usage) */

--- a/src/shared/components/RequestLoggerDetail.tsx
+++ b/src/shared/components/RequestLoggerDetail.tsx
@@ -36,7 +36,7 @@ function PayloadSection({ title, json, onCopy }) {
           {copied ? "Copied!" : "Copy"}
         </button>
       </div>
-      <pre className="p-4 rounded-xl bg-black/30 border border-border overflow-x-auto text-xs font-mono text-text-primary max-h-[600px] overflow-y-auto leading-relaxed whitespace-pre-wrap break-words">
+      <pre className="p-4 rounded-xl bg-black/5 dark:bg-black/30 border border-border overflow-x-auto text-xs font-mono text-text-main max-h-[600px] overflow-y-auto leading-relaxed whitespace-pre-wrap break-words">
         {json}
       </pre>
     </div>
@@ -138,7 +138,7 @@ export default function RequestLoggerDetail({ log, detail, loading, onClose, onC
                 <span className="px-2 py-0.5 rounded bg-primary/20 text-primary text-xs font-bold">
                   In: {(detail?.tokens?.in || log.tokens?.in || 0).toLocaleString()}
                 </span>
-                <span className="px-2 py-0.5 rounded bg-emerald-500/20 text-emerald-400 text-xs font-bold">
+                <span className="px-2 py-0.5 rounded bg-emerald-500/20 text-emerald-700 dark:text-emerald-400 text-xs font-bold">
                   Out: {(detail?.tokens?.out || log.tokens?.out || 0).toLocaleString()}
                 </span>
               </div>
@@ -198,7 +198,7 @@ export default function RequestLoggerDetail({ log, detail, loading, onClose, onC
             <div>
               <div className="text-[10px] text-text-muted uppercase tracking-wider mb-1">Combo</div>
               {detail?.comboName || log.comboName ? (
-                <span className="inline-block px-2.5 py-1 rounded-full text-[10px] font-bold bg-violet-500/20 text-violet-300 border border-violet-500/30">
+                <span className="inline-block px-2.5 py-1 rounded-full text-[10px] font-bold bg-violet-500/20 text-violet-700 dark:text-violet-300 border border-violet-500/30">
                   {detail?.comboName || log.comboName}
                 </span>
               ) : (
@@ -210,10 +210,12 @@ export default function RequestLoggerDetail({ log, detail, loading, onClose, onC
           {/* Error Message */}
           {(detail?.error || log.error) && (
             <div className="p-4 rounded-xl bg-red-500/10 border border-red-500/30">
-              <div className="text-[10px] text-red-400 uppercase tracking-wider mb-1 font-bold">
+              <div className="text-[10px] text-red-600 dark:text-red-400 uppercase tracking-wider mb-1 font-bold">
                 Error
               </div>
-              <div className="text-sm text-red-300 font-mono">{detail?.error || log.error}</div>
+              <div className="text-sm text-red-600 dark:text-red-300 font-mono">
+                {detail?.error || log.error}
+              </div>
             </div>
           )}
 


### PR DESCRIPTION
## Summary
- Add missing CSS theme variables (`bg-primary`, `bg-subtle`, `text-primary`) that were referenced by 21+ components but never defined — causing styles to silently resolve to nothing in both light and dark modes.
- Fix hardcoded dark-mode-only colors in `RequestLoggerDetail.tsx` (`emerald-400`, `violet-300`, `red-300/400`) with proper `dark:` variants so text is readable in light mode.
- Change payload code block background from `bg-black/30` to `bg-black/5 dark:bg-black/30` for proper contrast in light theme.

## Test plan
- [ ] Open the log detail modal in **light mode** and verify all text (tokens, combo badge, error message, payload) is readable
- [ ] Verify **dark mode** appearance is unchanged
- [ ] Check other pages that use `bg-bg-primary`, `bg-bg-subtle`, `text-text-primary` for correct rendering in both themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)