### PR TITLE
fix(cli): resolve --version returning 'unknown' on Windows

### DIFF
--- a/bin/omniroute.mjs
+++ b/bin/omniroute.mjs
@@ -116,10 +116,8 @@ if (args.includes("--help") || args.includes("-h")) {
 
 if (args.includes("--version") || args.includes("-v")) {
   try {
-    const pkg = await import(join(ROOT, "package.json"), {
-      with: { type: "json" },
-    });
-    console.log(pkg.default.version);
+    const { version } = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf8"));
+    console.log(version);
   } catch {
     console.log("unknown");
   }


### PR DESCRIPTION
Fixes diegosouzapw/OmniRoute#545 - omniroute --version returns "unknown" on Windows

`omniroute --version` returns `unknown` instead of the package version.

---

## Root Cause

ESM `import()` requires `file://` URLs for Windows absolute paths:

```javascript
// bin/omniroute.mjs, lines 119-123
const pkg = await import(join(ROOT, "package.json"), {
  with: { type: "json" },
});
```

Produces `C:\...\package.json` → throws `ERR_UNSUPPORTED_ESM_URL_SCHEME`.

---

## Fix

**File:** `bin/omniroute.mjs`, lines 119-123

```javascript
// Before
const pkg = await import(join(ROOT, "package.json"), {
  with: { type: "json" },
});
console.log(pkg.default.version);

// After
const { version } = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf8"));
console.log(version);
```

---

## Impact

- **Change:** 1 line (4 → 2 lines)
- **Dependencies:** None (`readFileSync` already imported)
- **Breaking:** None (identical output)
- **Cross-platform:** Works on all platforms

---

## Verification

```powershell
PS> omniroute --version
3.0.0-rc.5
```