### PR TITLE
Fix protocol, MCP, endpoint, and provider UX regressions

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -16,7 +16,7 @@ services:
     container_name: omniroute-prod
     build:
       context: .
-      target: runner-base
+      target: runner-cli
     image: omniroute:prod
     restart: unless-stopped
     env_file: .env

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -1,5 +1,5 @@
 import { getCorsOrigin } from "../utils/cors.ts";
-import { detectFormat, getTargetFormat } from "../services/provider.ts";
+import { detectFormatFromEndpoint, getTargetFormat } from "../services/provider.ts";
 import { translateRequest, needsTranslation } from "../translator/index.ts";
 import { FORMATS } from "../translator/formats.ts";
 import {
@@ -139,8 +139,8 @@ export async function handleChatCore({
     credentials.connectionId = connectionId;
   }
 
-  const sourceFormat = detectFormat(body);
   const endpointPath = String(clientRawRequest?.endpoint || "");
+  const sourceFormat = detectFormatFromEndpoint(body, endpointPath);
   const isResponsesEndpoint = /(?:^|\/)responses(?:\/.*)?$/i.test(endpointPath);
   const nativeCodexPassthrough = shouldUseNativeCodexPassthrough({
     provider,
@@ -219,11 +219,42 @@ export async function handleChatCore({
       translatedBody = { ...body, _nativeCodexPassthrough: true };
       log?.debug?.("FORMAT", "native codex passthrough enabled");
     } else if (isClaudePassthrough) {
-      // Claude-to-Claude passthrough: forward body completely untouched.
-      // No translation, no field stripping, no thinking normalization.
-      // We are just a gateway -- do not interfere with the request in the slightest.
-      translatedBody = { ...body };
-      log?.debug?.("FORMAT", "claude->claude passthrough -- forwarding untouched");
+      // Claude OAuth expects the same Claude Code prompt + structural normalization
+      // as the OpenAI-compatible chat path. Round-trip through OpenAI to reuse the
+      // working Claude translator instead of forwarding raw Messages payloads.
+      const normalizeToolCallId = getModelNormalizeToolCallId(
+        provider || "",
+        model || "",
+        sourceFormat
+      );
+      const preserveDeveloperRole = getModelPreserveOpenAIDeveloperRole(
+        provider || "",
+        model || "",
+        sourceFormat
+      );
+      translatedBody = translateRequest(
+        FORMATS.CLAUDE,
+        FORMATS.OPENAI,
+        model,
+        { ...body },
+        stream,
+        credentials,
+        provider,
+        reqLogger,
+        { normalizeToolCallId, preserveDeveloperRole }
+      );
+      translatedBody = translateRequest(
+        FORMATS.OPENAI,
+        FORMATS.CLAUDE,
+        model,
+        translatedBody,
+        stream,
+        credentials,
+        provider,
+        reqLogger,
+        { normalizeToolCallId, preserveDeveloperRole }
+      );
+      log?.debug?.("FORMAT", "claude->openai->claude normalized passthrough");
     } else {
       translatedBody = { ...body };
 

--- a/open-sse/index.ts
+++ b/open-sse/index.ts
@@ -36,6 +36,7 @@ export {
 // Services
 export {
   detectFormat,
+  detectFormatFromEndpoint,
   getProviderConfig,
   buildProviderUrl,
   buildProviderHeaders,

--- a/open-sse/mcp-server/httpTransport.ts
+++ b/open-sse/mcp-server/httpTransport.ts
@@ -1,5 +1,5 @@
 /**
- * MCP HTTP Transport Layer — Singleton server + SSE/Streamable HTTP handlers.
+ * MCP HTTP Transport Layer — session-aware handlers for SSE and Streamable HTTP.
  *
  * Runs the MCP server **inside** the Next.js process so it can be toggled
  * from the dashboard without requiring `omniroute --mcp`.
@@ -14,52 +14,174 @@ import { createMcpServer } from "./server.ts";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
-// ────── Singleton ──────────────────────────────────────────
+let _sseServer: McpServer | null = null;
+let _sseTransport: WebStandardStreamableHTTPServerTransport | null = null;
+let _sseStartedAt: number | null = null;
 
-let _server: McpServer | null = null;
-let _transport: WebStandardStreamableHTTPServerTransport | null = null;
-let _startedAt: number | null = null;
-let _activeTransportMode: "sse" | "streamable-http" | null = null;
+type StreamableSession = {
+  sessionId: string;
+  server: McpServer;
+  transport: WebStandardStreamableHTTPServerTransport;
+  startedAt: number;
+};
 
-function ensureServer(mode: "sse" | "streamable-http"): {
+const _streamableSessions = new Map<string, StreamableSession>();
+
+function closeSseTransport(): void {
+  if (_sseTransport) {
+    try {
+      _sseTransport.close();
+    } catch {
+      // ignore shutdown errors
+    }
+  }
+  _sseServer = null;
+  _sseTransport = null;
+  _sseStartedAt = null;
+}
+
+function closeStreamableSession(sessionId: string): void {
+  const session = _streamableSessions.get(sessionId);
+  if (!session) {
+    return;
+  }
+
+  try {
+    session.transport.close();
+  } catch {
+    // ignore shutdown errors
+  }
+  _streamableSessions.delete(sessionId);
+}
+
+function closeAllStreamableSessions(): void {
+  for (const sessionId of _streamableSessions.keys()) {
+    closeStreamableSession(sessionId);
+  }
+}
+
+function ensureSseServer(): {
   server: McpServer;
   transport: WebStandardStreamableHTTPServerTransport;
 } {
-  if (_server && _transport && _activeTransportMode === mode) {
-    return { server: _server, transport: _transport };
+  if (_sseServer && _sseTransport) {
+    return { server: _sseServer, transport: _sseTransport };
   }
 
-  // Shutdown previous if switching modes
-  if (_transport) {
-    try { _transport.close(); } catch { /* ignore */ }
-  }
+  closeAllStreamableSessions();
 
-  _server = createMcpServer();
-  _transport = new WebStandardStreamableHTTPServerTransport({
+  _sseServer = createMcpServer();
+  _sseTransport = new WebStandardStreamableHTTPServerTransport({
     sessionIdGenerator: () => randomUUID(),
   });
-  _activeTransportMode = mode;
-  _startedAt = Date.now();
+  _sseStartedAt = Date.now();
 
-  // Connect server to transport (fire-and-forget, will be ready by first request)
-  void _server.connect(_transport);
+  void _sseServer.connect(_sseTransport);
 
-  console.log(`[MCP] HTTP transport started (${mode})`);
-  return { server: _server, transport: _transport };
+  console.log("[MCP] HTTP transport started (sse)");
+  return { server: _sseServer, transport: _sseTransport };
 }
 
-// ────── Streamable HTTP Handler ────────────────────────────
+function createStreamableSession(): StreamableSession {
+  closeSseTransport();
 
-/**
- * Handle Streamable HTTP requests (POST / GET / DELETE).
- * Used by the Next.js route at /api/mcp/stream.
- */
-export async function handleMcpStreamableHTTP(request: Request): Promise<Response> {
-  const { transport } = ensureServer("streamable-http");
+  const sessionId = randomUUID();
+  const server = createMcpServer();
+  const transport = new WebStandardStreamableHTTPServerTransport({
+    sessionIdGenerator: () => sessionId,
+  });
+  const session = {
+    sessionId,
+    server,
+    transport,
+    startedAt: Date.now(),
+  };
+
+  void server.connect(transport);
+  _streamableSessions.set(sessionId, session);
+  console.log(`[MCP] HTTP transport started (streamable-http:${sessionId})`);
+  return session;
+}
+
+async function isInitializeRequest(request: Request): Promise<boolean> {
+  if (request.method !== "POST") {
+    return false;
+  }
 
   try {
-    return await transport.handleRequest(request);
+    const body = await request.clone().json() as { method?: unknown };
+    return body?.method === "initialize";
+  } catch {
+    return false;
+  }
+}
+
+function errorResponse(message: string, code: number, status = 400): Response {
+  return new Response(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      error: { code, message },
+      id: null,
+    }),
+    {
+      status,
+      headers: { "Content-Type": "application/json" },
+    }
+  );
+}
+
+function withSessionHeader(response: Response, sessionId: string): Response {
+  if (response.headers.get("mcp-session-id")) {
+    return response;
+  }
+
+  const headers = new Headers(response.headers);
+  headers.set("mcp-session-id", sessionId);
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+async function handleStreamableRequest(request: Request): Promise<Response> {
+  const sessionId = request.headers.get("mcp-session-id");
+
+  if (sessionId) {
+    const session = _streamableSessions.get(sessionId);
+    if (!session) {
+      return errorResponse("Bad Request: Unknown Mcp-Session-Id header", -32000);
+    }
+
+    try {
+      const response = await session.transport.handleRequest(request);
+      if (request.method === "DELETE") {
+        closeStreamableSession(sessionId);
+      }
+      return withSessionHeader(response, sessionId);
+    } catch (err) {
+      console.error("[MCP] Streamable HTTP error:", err);
+      if (request.method === "DELETE") {
+        closeStreamableSession(sessionId);
+      }
+      return new Response(
+        JSON.stringify({ error: "MCP transport error" }),
+        { status: 500, headers: { "Content-Type": "application/json" } },
+      );
+    }
+  }
+
+  if (!(await isInitializeRequest(request))) {
+    return errorResponse("Bad Request: Mcp-Session-Id header is required", -32000);
+  }
+
+  const session = createStreamableSession();
+
+  try {
+    const response = await session.transport.handleRequest(request);
+    return withSessionHeader(response, session.sessionId);
   } catch (err) {
+    closeStreamableSession(session.sessionId);
     console.error("[MCP] Streamable HTTP error:", err);
     return new Response(
       JSON.stringify({ error: "MCP transport error" }),
@@ -69,12 +191,20 @@ export async function handleMcpStreamableHTTP(request: Request): Promise<Respons
 }
 
 /**
+ * Handle Streamable HTTP requests (POST / GET / DELETE).
+ * Used by the Next.js route at /api/mcp/stream.
+ */
+export async function handleMcpStreamableHTTP(request: Request): Promise<Response> {
+  return handleStreamableRequest(request);
+}
+
+/**
  * Handle SSE requests.
  * SSE transport is implemented via Streamable HTTP transport with GET for SSE stream
  * and POST for messages (the Streamable HTTP transport supports both patterns).
  */
 export async function handleMcpSSE(request: Request): Promise<Response> {
-  const { transport } = ensureServer("sse");
+  const { transport } = ensureSseServer();
 
   try {
     return await transport.handleRequest(request);
@@ -87,34 +217,34 @@ export async function handleMcpSSE(request: Request): Promise<Response> {
   }
 }
 
-// ────── Status & Lifecycle ─────────────────────────────────
-
 export function getMcpHttpStatus(): {
   online: boolean;
   transport: string | null;
   startedAt: number | null;
   uptime: string | null;
 } {
-  const online = _transport !== null && _activeTransportMode !== null;
+  const streamableStartedAt =
+    _streamableSessions.size > 0
+      ? Math.min(...Array.from(_streamableSessions.values(), (session) => session.startedAt))
+      : null;
+  const startedAt = streamableStartedAt ?? _sseStartedAt;
+  const transport = _streamableSessions.size > 0 ? "streamable-http" : _sseTransport ? "sse" : null;
+  const online = transport !== null;
+
   return {
     online,
-    transport: _activeTransportMode,
-    startedAt: _startedAt,
-    uptime: _startedAt ? `${Math.floor((Date.now() - _startedAt) / 1000)}s` : null,
+    transport,
+    startedAt,
+    uptime: startedAt ? `${Math.floor((Date.now() - startedAt) / 1000)}s` : null,
   };
 }
 
 export function shutdownMcpHttp(): void {
-  if (_transport) {
-    try { _transport.close(); } catch { /* ignore */ }
-  }
-  _server = null;
-  _transport = null;
-  _activeTransportMode = null;
-  _startedAt = null;
+  closeSseTransport();
+  closeAllStreamableSessions();
   console.log("[MCP] HTTP transport shutdown");
 }
 
 export function isMcpHttpActive(): boolean {
-  return _transport !== null;
+  return _sseTransport !== null || _streamableSessions.size > 0;
 }

--- a/open-sse/services/provider.ts
+++ b/open-sse/services/provider.ts
@@ -35,6 +35,27 @@ function buildAnthropicCompatibleUrl(baseUrl) {
   return `${normalized}/messages`;
 }
 
+// Detect request format from endpoint first when the route is known.
+// This avoids ambiguous bodies like OpenAI /chat/completions requests that also
+// contain max_tokens or Claude model names.
+export function detectFormatFromEndpoint(body, endpointPath = "") {
+  const path = String(endpointPath || "");
+
+  if (/(?:^|\/)responses(?:\/.*)?$/i.test(path)) {
+    return "openai-responses";
+  }
+
+  if (/(?:^|\/)messages(?:\/.*)?$/i.test(path)) {
+    return "claude";
+  }
+
+  if (/(?:^|\/)(?:chat\/completions|completions)(?:\/.*)?$/i.test(path)) {
+    return "openai";
+  }
+
+  return detectFormat(body);
+}
+
 // Detect request format from body structure
 export function detectFormat(body) {
   // OpenAI Responses API:

--- a/open-sse/translator/index.ts
+++ b/open-sse/translator/index.ts
@@ -144,7 +144,7 @@ export function translateRequest(
   }
 
   // Final step: prepare request for Claude format endpoints
-  if (targetFormat === FORMATS.CLAUDE && sourceFormat !== FORMATS.CLAUDE) {
+  if (targetFormat === FORMATS.CLAUDE) {
     result = prepareClaudeRequest(result, provider);
   }
 

--- a/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.tsx
+++ b/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.tsx
@@ -8,10 +8,11 @@ import { useCopyToClipboard } from "@/shared/hooks/useCopyToClipboard";
 import { AI_PROVIDERS, getProviderByAlias } from "@/shared/constants/providers";
 import { useTranslations } from "next-intl";
 
-const CLOUD_URL = process.env.NEXT_PUBLIC_CLOUD_URL || null;
+const BUILD_TIME_CLOUD_URL = process.env.NEXT_PUBLIC_CLOUD_URL || null;
 const CLOUD_ACTION_TIMEOUT_MS = 15000;
 
 export default function APIPageClient({ machineId }) {
+  const [resolvedMachineId, setResolvedMachineId] = useState(machineId || "");
   const t = useTranslations("endpoint");
   const tc = useTranslations("common");
   const [loading, setLoading] = useState(true);
@@ -29,7 +30,8 @@ export default function APIPageClient({ machineId }) {
   const [syncStep, setSyncStep] = useState(""); // "syncing" | "verifying" | "disabling" | "done" | ""
   const [modalSuccess, setModalSuccess] = useState(false); // show success state in modal before closing
   const [selectedProvider, setSelectedProvider] = useState(null); // for provider models popup
-  const [cloudBaseUrl, setCloudBaseUrl] = useState(CLOUD_URL); // dynamic cloud URL from API response
+  const [cloudBaseUrl, setCloudBaseUrl] = useState(BUILD_TIME_CLOUD_URL); // dynamic cloud URL from API response
+  const [cloudConfigured, setCloudConfigured] = useState(Boolean(BUILD_TIME_CLOUD_URL));
   const [viewTab, setViewTab] = useState("api");
   const [mcpStatus, setMcpStatus] = useState<any>(null);
   const [a2aStatus, setA2aStatus] = useState<any>(null);
@@ -136,6 +138,15 @@ export default function APIPageClient({ machineId }) {
       if (res.ok) {
         const data = await res.json();
         setCloudEnabled(data.cloudEnabled || false);
+        if (typeof data.cloudConfigured === "boolean") {
+          setCloudConfigured(data.cloudConfigured);
+        }
+        if (data.cloudUrl) {
+          setCloudBaseUrl(data.cloudUrl);
+        }
+        if (data.machineId) {
+          setResolvedMachineId(data.machineId);
+        }
       }
     } catch (error) {
       console.log("Error loading cloud settings:", error);
@@ -144,6 +155,13 @@ export default function APIPageClient({ machineId }) {
 
   const handleCloudToggle = (checked) => {
     if (checked) {
+      if (!cloudConfigured) {
+        setCloudStatus({
+          type: "warning",
+          message: "Cloud sync is not configured on this instance.",
+        });
+        return;
+      }
       setShowCloudModal(true);
     } else {
       setShowDisableModal(true);
@@ -258,7 +276,12 @@ export default function APIPageClient({ machineId }) {
   };
 
   const [baseUrl, setBaseUrl] = useState("/v1");
-  const cloudEndpointNew = cloudBaseUrl ? `${cloudBaseUrl}/v1` : null;
+  const normalizedCloudBaseUrl = cloudBaseUrl
+    ? resolvedMachineId && !cloudBaseUrl.endsWith(`/${resolvedMachineId}`)
+      ? `${cloudBaseUrl}/${resolvedMachineId}`
+      : cloudBaseUrl
+    : null;
+  const cloudEndpointNew = normalizedCloudBaseUrl ? `${normalizedCloudBaseUrl}/v1` : null;
 
   // Hydration fix: Only access window on client side
   useEffect(() => {
@@ -290,12 +313,21 @@ export default function APIPageClient({ machineId }) {
         <div className="flex items-center justify-between mb-4">
           <div>
             <h2 className="text-lg font-semibold">{t("title")}</h2>
-            <p className="text-sm text-text-muted">
-              {cloudEnabled ? t("usingCloudProxy") : t("usingLocalServer")}
-            </p>
-            {machineId && (
-              <p className="text-xs text-text-muted mt-1">
-                {t("machineId", { id: machineId.slice(0, 8) })}
+            <div className="mt-2">
+              <Button
+                size="sm"
+                variant={cloudEnabled ? "primary" : "secondary"}
+                icon={cloudEnabled ? "cloud_done" : "dns"}
+                onClick={() => handleCloudToggle(!cloudEnabled)}
+                disabled={cloudSyncing || (!cloudEnabled && !cloudConfigured)}
+                className={cloudEnabled ? "" : "border-border/70! text-text-muted! hover:text-text!"}
+              >
+                {cloudEnabled ? t("usingCloudProxy") : t("usingLocalServer")}
+              </Button>
+            </div>
+            {resolvedMachineId && (
+              <p className="text-xs text-text-muted mt-2">
+                {t("machineId", { id: resolvedMachineId.slice(0, 8) })}
               </p>
             )}
           </div>
@@ -311,7 +343,7 @@ export default function APIPageClient({ machineId }) {
               >
                 {t("disableCloud")}
               </Button>
-            ) : (
+            ) : cloudConfigured ? (
               <Button
                 variant="primary"
                 icon="cloud_upload"
@@ -321,6 +353,10 @@ export default function APIPageClient({ machineId }) {
               >
                 {t("enableCloud")}
               </Button>
+            ) : (
+              <span className="text-xs px-2 py-1 rounded-full bg-surface text-text-muted border border-border/70">
+                Cloud not configured
+              </span>
             )}
           </div>
         </div>
@@ -354,16 +390,17 @@ export default function APIPageClient({ machineId }) {
         )}
 
         {/* Endpoint URL */}
-        <div className="flex gap-2 mb-3">
+        <div className="flex flex-col sm:flex-row gap-2 mb-3">
           <Input
             value={currentEndpoint}
             readOnly
-            className={`flex-1 font-mono text-sm ${cloudEnabled ? "animate-border-glow" : ""}`}
+            className={`flex-1 min-w-0 font-mono text-sm ${cloudEnabled ? "animate-border-glow" : ""}`}
           />
           <Button
             variant="secondary"
             icon={copied === "endpoint_url" ? "check" : "content_copy"}
             onClick={() => copy(currentEndpoint, "endpoint_url")}
+            className="shrink-0 self-start sm:self-auto"
           >
             {copied === "endpoint_url" ? tc("copied") : tc("copy")}
           </Button>
@@ -1245,3 +1282,4 @@ EndpointSection.propTypes = {
   copied: PropTypes.string,
   baseUrl: PropTypes.string.isRequired,
 };
+

--- a/src/app/api/providers/[id]/models/route.ts
+++ b/src/app/api/providers/[id]/models/route.ts
@@ -54,6 +54,21 @@ const STATIC_MODEL_PROVIDERS: Record<string, () => Array<{ id: string; name: str
     { id: "nanobanana-flash", name: "NanoBanana Flash (Gemini 2.5 Flash)" },
     { id: "nanobanana-pro", name: "NanoBanana Pro (Gemini 3 Pro)" },
   ],
+  antigravity: () => [
+    { id: "claude-opus-4-6-thinking", name: "Claude Opus 4.6 Thinking" },
+    { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
+    { id: "gemini-2.5-pro", name: "Gemini 2.5 Pro" },
+    { id: "gemini-2.5-flash", name: "Gemini 2.5 Flash" },
+    { id: "gemini-2.0-flash", name: "Gemini 2.0 Flash" },
+    { id: "gpt-oss-120b-medium", name: "GPT OSS 120B Medium" },
+  ],
+  claude: () => [
+    { id: "claude-opus-4-6", name: "Claude Opus 4.6" },
+    { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
+    { id: "claude-opus-4-5-20251101", name: "Claude Opus 4.5 (2025-11-01)" },
+    { id: "claude-sonnet-4-5-20250929", name: "Claude Sonnet 4.5 (2025-09-29)" },
+    { id: "claude-haiku-4-5-20251001", name: "Claude Haiku 4.5 (2025-10-01)" },
+  ],
   perplexity: () => [
     { id: "sonar", name: "Sonar (Fast Search)" },
     { id: "sonar-pro", name: "Sonar Pro (Advanced Search)" },
@@ -372,6 +387,14 @@ export async function GET(request, { params }) {
       });
     }
 
+    if (provider === "claude") {
+      return NextResponse.json({
+        provider,
+        connectionId,
+        models: STATIC_MODEL_PROVIDERS.claude(),
+      });
+    }
+
     if (isAnthropicCompatibleProvider(provider)) {
       let baseUrl = getProviderBaseUrl(connection.providerSpecificData);
       if (!baseUrl) {
@@ -387,13 +410,14 @@ export async function GET(request, { params }) {
       }
 
       const url = `${baseUrl}/models`;
+      const token = accessToken || apiKey;
       const response = await fetch(url, {
         method: "GET",
         headers: {
           "Content-Type": "application/json",
-          "x-api-key": apiKey,
+          ...(apiKey ? { "x-api-key": apiKey } : {}),
           "anthropic-version": "2023-06-01",
-          Authorization: `Bearer ${apiKey}`,
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
         },
       });
 

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -7,6 +7,7 @@ import { getRuntimePorts } from "@/lib/runtime/ports";
 import { updateSettingsSchema } from "@/shared/validation/settingsSchemas";
 import { isValidationFailure, validateBody } from "@/shared/validation/helpers";
 import { setCliCompatProviders } from "../../../../open-sse/config/cliFingerprints";
+import { getConsistentMachineId } from "@/shared/utils/machineId";
 
 export async function GET() {
   try {
@@ -20,6 +21,8 @@ export async function GET() {
 
     const enableRequestLogs = process.env.ENABLE_REQUEST_LOGS === "true";
     const runtimePorts = getRuntimePorts();
+    const cloudUrl = process.env.CLOUD_URL || process.env.NEXT_PUBLIC_CLOUD_URL || null;
+    const machineId = await getConsistentMachineId();
 
     return NextResponse.json({
       ...safeSettings,
@@ -28,6 +31,9 @@ export async function GET() {
       runtimePorts,
       apiPort: runtimePorts.apiPort,
       dashboardPort: runtimePorts.dashboardPort,
+      cloudConfigured: Boolean(cloudUrl),
+      cloudUrl,
+      machineId,
     });
   } catch (error) {
     console.log("Error getting settings:", error);

--- a/src/shared/components/OAuthModal.tsx
+++ b/src/shared/components/OAuthModal.tsx
@@ -482,17 +482,31 @@ export default function OAuthModal({
   const handleManualSubmit = async () => {
     try {
       setError(null);
-      const url = new URL(callbackUrl);
-      const code = url.searchParams.get("code");
-      const state = url.searchParams.get("state");
-      const errorParam = url.searchParams.get("error");
+      const input = callbackUrl.trim();
+      let code = null;
+      let state = authData?.state || null;
+      let errorParam = null;
+      let errorDescription = null;
+
+      try {
+        const url = new URL(input);
+        code = url.searchParams.get("code");
+        state = url.searchParams.get("state") || url.hash.replace(/^#/, "") || state;
+        errorParam = url.searchParams.get("error");
+        errorDescription = url.searchParams.get("error_description");
+      } catch {
+        // Claude Code remote auth may provide a raw "Authentication Code" like code#state.
+        const [rawCode, rawState] = input.split("#", 2);
+        code = rawCode || null;
+        state = rawState || state;
+      }
 
       if (errorParam) {
-        throw new Error(url.searchParams.get("error_description") || errorParam);
+        throw new Error(errorDescription || errorParam);
       }
 
       if (!code) {
-        throw new Error("No authorization code found in URL");
+        throw new Error("No authorization code found. Paste the callback URL or the Authentication Code.");
       }
 
       await exchangeTokens(code, state);
@@ -626,14 +640,17 @@ export default function OAuthModal({
               </div>
 
               <div>
-                <p className="text-sm font-medium mb-2">Step 2: Paste the callback URL here</p>
+                <p className="text-sm font-medium mb-2">
+                  Step 2: Paste the callback URL or auth code here
+                </p>
                 <p className="text-xs text-text-muted mb-2">
-                  After authorization, copy the full URL from your browser.
+                  After authorization, paste the full callback URL. For Claude Code, you can also
+                  paste the Authentication Code directly, for example <code>code#state</code>.
                 </p>
                 <Input
                   value={callbackUrl}
                   onChange={(e) => setCallbackUrl(e.target.value)}
-                  placeholder={placeholderUrl}
+                  placeholder={provider === "claude" ? "code#state or /callback?code=..." : placeholderUrl}
                   className="font-mono text-xs"
                 />
               </div>

--- a/src/sse/handlers/chat.ts
+++ b/src/sse/handlers/chat.ts
@@ -7,7 +7,7 @@ import {
 } from "../services/auth";
 import { getModelInfo, getCombo } from "../services/model";
 import { parseModel } from "@omniroute/open-sse/services/model.ts";
-import { detectFormat, getTargetFormat } from "@omniroute/open-sse/services/provider.ts";
+import { detectFormatFromEndpoint, getTargetFormat } from "@omniroute/open-sse/services/provider.ts";
 import { handleChatCore } from "@omniroute/open-sse/handlers/chatCore.ts";
 import { errorResponse, unavailableResponse } from "@omniroute/open-sse/utils/error.ts";
 import { handleComboChat } from "@omniroute/open-sse/services/combo.ts";
@@ -283,7 +283,7 @@ async function handleSingleModelChat(
   runtimeOptions: { emergencyFallbackTried?: boolean } = {}
 ) {
   // 1. Resolve model → provider/model
-  const resolved = await resolveModelOrError(modelStr, body);
+  const resolved = await resolveModelOrError(modelStr, body, clientRawRequest?.endpoint);
   if (resolved.error) return resolved.error;
 
   const { provider, model, sourceFormat, targetFormat, extendedContext } = resolved;
@@ -460,7 +460,7 @@ async function handleSingleModelChat(
 /**
  * Resolve model string to provider/model info, or return an error response.
  */
-async function resolveModelOrError(modelStr: string, body: any) {
+async function resolveModelOrError(modelStr: string, body: any, endpointPath: string = "") {
   const modelInfo = await getModelInfo(modelStr);
   if (!modelInfo.provider) {
     if ((modelInfo as any).errorType === "ambiguous_model") {
@@ -479,7 +479,7 @@ async function resolveModelOrError(modelStr: string, body: any) {
   }
 
   const { provider, model, extendedContext } = modelInfo;
-  const sourceFormat = detectFormat(body);
+  const sourceFormat = detectFormatFromEndpoint(body, endpointPath);
   const providerAlias = PROVIDER_ID_TO_ALIAS[provider] || provider;
 
   // If the custom model specifies apiFormat="responses", override targetFormat

--- a/tests/unit/plan3-p0.test.mjs
+++ b/tests/unit/plan3-p0.test.mjs
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 
 import { FORMATS } from "../../open-sse/translator/formats.ts";
 import { getModelInfoCore } from "../../open-sse/services/model.ts";
-import { detectFormat } from "../../open-sse/services/provider.ts";
+import { detectFormat, detectFormatFromEndpoint } from "../../open-sse/services/provider.ts";
 import { shouldUseNativeCodexPassthrough } from "../../open-sse/handlers/chatCore.ts";
 import { translateRequest } from "../../open-sse/translator/index.ts";
 import { GithubExecutor } from "../../open-sse/executors/github.ts";
@@ -74,6 +74,45 @@ test("CodexExecutor forces stream=true for upstream compatibility", () => {
     false
   );
   assert.equal(transformed.stream, true);
+});
+
+test("Claude native messages can be round-tripped through OpenAI into Claude OAuth format", () => {
+  const normalizeOptions = { normalizeToolCallId: false, preserveDeveloperRole: undefined };
+  const openaiBody = translateRequest(
+    FORMATS.CLAUDE,
+    FORMATS.OPENAI,
+    "claude-sonnet-4-6",
+    {
+      model: "claude-sonnet-4-6",
+      max_tokens: 32,
+      messages: [{ role: "user", content: "reply with OK only" }],
+    },
+    false,
+    null,
+    "claude",
+    null,
+    normalizeOptions
+  );
+  const translated = translateRequest(
+    FORMATS.OPENAI,
+    FORMATS.CLAUDE,
+    "claude-sonnet-4-6",
+    openaiBody,
+    false,
+    null,
+    "claude",
+    null,
+    normalizeOptions
+  );
+
+  assert.deepEqual(translated.messages, [
+    {
+      role: "user",
+      content: [{ type: "text", text: "reply with OK only" }],
+    },
+  ]);
+  assert.ok(Array.isArray(translated.system));
+  assert.equal(translated.system[0]?.text?.includes("You are Claude Code"), true);
 });
 
 test("CodexExecutor maps fast service tier to priority", () => {
@@ -315,6 +354,32 @@ test("detectFormat identifies OpenAI Responses by max_output_tokens without inpu
     stream: false,
   });
   assert.equal(format, FORMATS.OPENAI_RESPONSES);
+});
+
+test("detectFormatFromEndpoint forces OpenAI for /v1/chat/completions", () => {
+  const format = detectFormatFromEndpoint(
+    {
+      model: "cc/claude-opus-4-6",
+      messages: [{ role: "user", content: "hi" }],
+      max_tokens: 16,
+      stream: false,
+    },
+    "/v1/chat/completions"
+  );
+  assert.equal(format, FORMATS.OPENAI);
+});
+
+test("detectFormatFromEndpoint forces Claude for /v1/messages", () => {
+  const format = detectFormatFromEndpoint(
+    {
+      model: "claude-opus-4-6",
+      messages: [{ role: "user", content: "hi" }],
+      max_tokens: 16,
+      stream: false,
+    },
+    "/v1/messages"
+  );
+  assert.equal(format, FORMATS.CLAUDE);
 });
 
 test("translateRequest normalizes openai-responses input string into list payload", () => {


### PR DESCRIPTION
## Summary
- fix Claude/OpenAI/Anthropic protocol routing and native Messages handling
- fix MCP stream session isolation and endpoint/cloud UI regressions
- add provider model fallbacks and improve OAuth manual code input UX

## Verification
- verified /v1/chat/completions and /v1/messages against Claude models
- verified MCP initialize and tools/list over /api/mcp/stream
- rebuilt production container and confirmed dashboard endpoints load normally