### PR TITLE
feat(proxy): add model name prefix stripping option

### DIFF
--- a/src/shared/validation/settingsSchemas.ts
+++ b/src/shared/validation/settingsSchemas.ts
@@ -42,6 +42,8 @@ export const updateSettingsSchema = z.object({
   a2aEnabled: z.boolean().optional(),
   // CLI Fingerprint compatibility (per-provider)
   cliCompatProviders: z.array(z.string().max(100)).optional(),
+  // Strip provider/model prefix at proxy layer (e.g. "openai/gpt-4" → "gpt-4")
+  stripModelPrefix: z.boolean().optional(),
   // Custom CLI agent definitions for ACP
   customAgents: z
     .array(

--- a/src/sse/services/model.ts
+++ b/src/sse/services/model.ts
@@ -1,5 +1,6 @@
 // Re-export from open-sse with localDb integration
 import { getModelAliases, getComboByName, getProviderNodes, getCustomModels } from "@/lib/localDb";
+import { getSettings } from "@/lib/localDb";
 import {
   parseModel,
   resolveModelAliasFromMap,
@@ -76,6 +77,18 @@ export async function getModelInfo(modelStr) {
         extendedContext,
         ...(apiFormat && { apiFormat }),
       };
+    }
+
+    // stripModelPrefix: if enabled, strip provider prefix and re-resolve
+    // the bare model name using existing heuristics (claude-* → anthropic, etc.)
+    try {
+      const settings = await getSettings();
+      if (settings.stripModelPrefix === true) {
+        const strippedResult = await getModelInfoCore(parsed.model, getModelAliases);
+        return { ...strippedResult, extendedContext };
+      }
+    } catch {
+      // If settings read fails, fall through to normal resolution
     }
   }
 


### PR DESCRIPTION
Closes #568.

Adds stripModelPrefix option that automatically strips provider prefixes from incoming model names before routing. Tools can send gpt-4 while the proxy maps it to openai/gpt-4 internally.

- Backward compatible (opt-in, default off)
- Simple configuration flag
- No changes to default behavior