### PR TITLE
fix(sse): revert resolveDataDir import in responsesTransformer for Workers compat

### DIFF
--- a/open-sse/config/credentialLoader.ts
+++ b/open-sse/config/credentialLoader.ts
@@ -33,8 +33,11 @@ function credGlobals(): CredGlobals {
 }
 
 /**
- * Resolve the path to provider-credentials.json
- * Priority: DATA_DIR env → ./data (project root)
+ * Resolves the path to provider-credentials.json using the application's
+ * data directory. Delegates to resolveDataDir() which handles DATA_DIR env,
+ * platform-specific defaults, and fallback logic.
+ *
+ * previous: Priority: DATA_DIR env → ./data (project root)
  */
 function resolveCredentialsPath() {
   return join(resolveDataDir(), "provider-credentials.json");

--- a/open-sse/transformer/responsesTransformer.ts
+++ b/open-sse/transformer/responsesTransformer.ts
@@ -40,6 +40,7 @@ export function createResponsesLogger(model, logsDir = null) {
   const timestamp = new Date().toISOString().replace(/[:.]/g, "").slice(0, 15);
   const uniqueId = Math.random().toString(36).slice(2, 8);
   const baseDir = logsDir || (typeof process !== "undefined" ? process.cwd() : ".");
+  // previous: const baseDir = logsDir || resolveDataDir(); — reverted in #555 for Workers compat
   const logDir = path.join(baseDir, "logs", `responses_${model}_${timestamp}_${uniqueId}`);
 
   try {


### PR DESCRIPTION
This PR addresses the comments from the previously merged one where an incorrect assumption lead to an incorrect change (that still needs to be fixed later)

Reverts the `responsesTransformer.ts` changes from `0fbabdc` (PR #555) which broke Cloudflare Workers execution.

### What Remains Still Broken (unchanged by PR)
_Potential credential break__ if users had credentials at the old `./data/` location_

**And static fs/path imports**

_The file still has import * as fs from "fs" and import * as path from "path" at the top level, which would also fail in Workers. These pre-date commit 0fbabdc and are a separate concern — addressing them would require refactoring createResponsesLogger to use the existing async dynamic import helpers (getFs()/getPath())._


### What broke (from PR #555)

Commit ` 0fbabdc ` added a static import of `resolveDataDir` from `src/lib/dataPaths`:

```typescript
import { resolveDataDir } from "../../src/lib/dataPaths";
```

This creates a transitive dependency chain that fails at module load time in Workers:

```
responsesTransformer.ts
  → import { resolveDataDir } from "../../src/lib/dataPaths"
    → dataPaths.ts
      → import path from "path"   ← unavailable in Workers
      → import os from "os"       ← unavailable in Workers
```

Module-level `import` statements are resolved before any code executes. Even though `createResponsesLogger` is never called in the Worker path (the `responsesHandler.ts` passes `null` for the logger), the mere act of importing `responsesTransformer.ts` triggers loading `dataPaths.ts`, which immediately fails because `os` and `path` are not available in the Workers runtime.

### What this PR changes

- Removes `import { resolveDataDir } from "../../src/lib/dataPaths"`
- Restores the original Worker-safe fallback: `typeof process !== "undefined" ? process.cwd() : "."`

No functional change in Node.js - `process.cwd()` returns the same value as `resolveDataDir()` in the non-configured case.

### Follow-up: credentialLoader JSDoc update

The JSDoc in `open-sse/config/credentialLoader.ts` (`resolveCredentialsPath`) was slightly outdated it said`Priority: DATA_DIR env → ./data (project root)` but `resolveDataDir()` has more complex resolution logic. 

Updated it to:

> _Resolves the path to provider-credentials.json using the application's data directory. Delegates to resolveDataDir() which handles DATA_DIR env, platform-specific defaults, and fallback logic._

also kept previous comment: 

> _previous: Priority: DATA_DIR env → ./data (project root)_

### Follow-up: static `fs`/`path` imports

The file still has `import * as fs from "fs"` and `import * as path from "path"` at the top level, which would also fail in Workers. These pre-date commit `0fbabdc` and are a separate concern — addressing them would require refactoring `createResponsesLogger` to use the existing async dynamic import helpers (`getFs()`/`getPath()`).
