### PR TITLE
fix: hide comfyui/sdwebui models when no provider configured

### DIFF
--- a/src/app/api/v1/models/catalog.ts
+++ b/src/app/api/v1/models/catalog.ts
@@ -14,8 +14,8 @@ import { getAllImageModels } from "@omniroute/open-sse/config/imageRegistry.ts";
 import { getAllRerankModels } from "@omniroute/open-sse/config/rerankRegistry.ts";
 import { getAllAudioModels } from "@omniroute/open-sse/config/audioRegistry.ts";
 import { getAllModerationModels } from "@omniroute/open-sse/config/moderationRegistry.ts";
-import { getAllVideoModels, getVideoProvider } from "@omniroute/open-sse/config/videoRegistry.ts";
-import { getAllMusicModels, getMusicProvider } from "@omniroute/open-sse/config/musicRegistry.ts";
+import { getAllVideoModels } from "@omniroute/open-sse/config/videoRegistry.ts";
+import { getAllMusicModels } from "@omniroute/open-sse/config/musicRegistry.ts";
 import { REGISTRY } from "@omniroute/open-sse/config/providerRegistry.ts";
 
 const FALLBACK_ALIAS_TO_PROVIDER = {
@@ -315,10 +315,9 @@ export async function getUnifiedModelsResponse(
       });
     }
 
-    // Add video models (local providers always listed, cloud filtered by active)
+    // Add video models (filtered by active providers)
     for (const videoModel of getAllVideoModels()) {
-      const vConfig = getVideoProvider(videoModel.provider);
-      if (vConfig?.authType !== "none" && !isProviderActive(videoModel.provider)) continue;
+      if (!isProviderActive(videoModel.provider)) continue;
       models.push({
         id: videoModel.id,
         object: "model",
@@ -328,10 +327,9 @@ export async function getUnifiedModelsResponse(
       });
     }
 
-    // Add music models (local providers always listed, cloud filtered by active)
+    // Add music models (filtered by active providers)
     for (const musicModel of getAllMusicModels()) {
-      const mConfig = getMusicProvider(musicModel.provider);
-      if (mConfig?.authType !== "none" && !isProviderActive(musicModel.provider)) continue;
+      if (!isProviderActive(musicModel.provider)) continue;
       models.push({
         id: musicModel.id,
         object: "model",


### PR DESCRIPTION
## Summary
- Video and music models had a special exemption for `authType="none"` providers (comfyui, sdwebui), causing them to appear in `/v1/models` even without any active provider connection configured
- Removed the exemption so all model types (chat, image, video, music) consistently use `isProviderActive()` filtering
- Cleaned up unused `getVideoProvider` and `getMusicProvider` imports

## Test plan
- [ ] Verify `/v1/models` does not include comfyui/sdwebui models when no provider connections are configured for them
- [ ] Verify comfyui/sdwebui models appear correctly after adding a provider connection
- [ ] Verify other providers' video/music models are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)