### PR TITLE
fix: Correct LongCat API base URL path

### DIFF
--- a/open-sse/config/providerRegistry.ts
+++ b/open-sse/config/providerRegistry.ts
@@ -1275,10 +1275,7 @@ export const REGISTRY: Record<string, RegistryEntry> = {
     alias: "lc",
     format: "openai",
     executor: "default",
-    // (#536) Correct OpenAI-compatible base URL — was longcat.chat/api/v1/chat/completions
-    // which is the chat endpoint directly, not the base. Key validation and routing must
-    // use https://api.longcat.chat/openai which resolves /v1/models and /v1/chat/completions
-    baseUrl: "https://api.longcat.chat/openai",
+    baseUrl: "https://api.longcat.chat/openai/v1/chat/completions",
     authType: "apikey",
     authHeader: "Authorization",
     authPrefix: "Bearer",

--- a/src/lib/providers/validation.ts
+++ b/src/lib/providers/validation.ts
@@ -655,7 +655,7 @@ export async function validateProviderApiKey({ provider, apiKey, providerSpecifi
     // LongCat AI — does not expose /v1/models; validate via chat completions directly (#592)
     longcat: async ({ apiKey }: any) => {
       try {
-        const res = await fetch("https://longcat.chat/api/v1/chat/completions", {
+        const res = await fetch("https://api.longcat.chat/openai/v1/chat/completions", {
           method: "POST",
           headers: buildBearerHeaders(apiKey),
           body: JSON.stringify({


### PR DESCRIPTION
# Fix: Correct LongCat API base URL path

## Summary

LongCat provider requests were being sent to the wrong URL endpoint. The base URL was missing the required `/v1/chat/completions` path segment.

**Documentation:** https://longcat.chat/platform/docs/

## Root Cause

- **Documentation** specifies: `https://api.longcat.chat/openai/v1/chat/completions`
- **Previous code** used: `https://api.longcat.chat/openai` (missing path)

The executor's `DefaultExecutor.buildUrl()` returns `baseUrl` as-is for default providers, so requests were hitting the base URL without the required endpoint path.

## Changes

| File                                  | Change                                                                                                                      |
| ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
| `open-sse/config/providerRegistry.ts` | `baseUrl`: `https://api.longcat.chat/openai` → `https://api.longcat.chat/openai/v1/chat/completions`                        |
| `src/lib/providers/validation.ts`     | Validation endpoint: `https://longcat.chat/api/v1/chat/completions` → `https://api.longcat.chat/openai/v1/chat/completions` |

## Related

- Fixes issue with LongCat provider connectivity
- Closes #536 (referenced in original comment)

Fixes #622