### PR TITLE
fix: Provider Limits table background in light mode

### DIFF
--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.tsx
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.tsx
@@ -511,7 +511,7 @@ export default function ProviderLimits() {
       </div>
 
       {/* Account rows */}
-      <div className="rounded-xl border border-border overflow-hidden bg-bg-subtle">
+      <div className="rounded-xl border border-border overflow-hidden bg-surface">
         {/* Table header */}
         <div
           className="items-center px-4 py-2.5 border-b border-border text-[11px] font-semibold uppercase tracking-wider text-text-muted"


### PR DESCRIPTION
## Summary
- Changed Provider Limits table container from `bg-bg-subtle` (#f0f0f5) to `bg-surface` (#ffffff) in light mode
- The gray background made the table look inconsistent with other Card-based sections (Active Sessions, Model Lockouts) which use `bg-surface`

## Test plan
- [ ] Open Limits & Quotas page with at least one OAuth/API key provider configured
- [ ] Switch to light mode and verify the Provider Limits table has a white background matching other cards
- [ ] Verify dark mode is unaffected (`bg-surface` maps to `#161b22` in dark)

🤖 Generated with [Claude Code](https://claude.com/claude-code)