### PR TITLE
fix: sanitizeUsage cross-maps input_tokens→prompt_tokens; update yaml vulnerability (#617)

### DIFF
--- a/open-sse/handlers/responseSanitizer.ts
+++ b/open-sse/handlers/responseSanitizer.ts
@@ -231,6 +231,17 @@ function sanitizeUsage(usage: unknown): unknown {
   if (!usageRecord) return usage;
 
   const sanitized: JsonRecord = {};
+
+  // Cross-map Claude-style → OpenAI-style field names.
+  // Some providers return input_tokens/output_tokens instead of prompt_tokens/completion_tokens.
+  // Without this mapping, the whitelist filter below strips them, resulting in NaN/0 tokens (#617).
+  if (usageRecord.input_tokens !== undefined && usageRecord.prompt_tokens === undefined) {
+    usageRecord.prompt_tokens = usageRecord.input_tokens;
+  }
+  if (usageRecord.output_tokens !== undefined && usageRecord.completion_tokens === undefined) {
+    usageRecord.completion_tokens = usageRecord.output_tokens;
+  }
+
   for (const key of ALLOWED_USAGE_FIELDS) {
     if (usageRecord[key] !== undefined) {
       sanitized[key] = usageRecord[key];

--- a/package-lock.json
+++ b/package-lock.json
@@ -19810,9 +19810,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "dev": true,
       "license": "ISC",
       "bin": {


### PR DESCRIPTION
## Bug Fix

### sanitizeUsage cross-mapping (#617)
The `sanitizeUsage()` function in `responseSanitizer.ts` filters usage fields through a whitelist (`ALLOWED_USAGE_FIELDS`). When providers return Claude-style field names (`input_tokens`/`output_tokens`) instead of OpenAI-style (`prompt_tokens`/`completion_tokens`), these fields were stripped and defaulted to 0 — causing **NaN token counts** in Claude Code and other clients.

**Fix:** Added cross-mapping before the whitelist filter, consistent with the v3.0.8 fix in `usageTracking.ts`.

### Security: yaml dependency update
Updated `yaml` package to fix GHSA-48c2-rrv3-qjmp (stack overflow via deeply nested YAML collections).

### Tests
- 936/936 tests pass
- `typecheck:noimplicit:core` passes
- `npm audit`: 0 vulnerabilities

### Issue Triage
- **#613** — Closed (workaround: Custom Provider for Codestral)
- **#615** — Commented with workaround + tracked as feature request
- **#618** — Commented with v3.0.8/v3.0.9 fix details, requesting v3.0.9 test
- **#627** — Commented (effort level already supported)
- **#617** — Root cause fixed in this PR