### PR TITLE
fix: use targetFormat in hasValuableContent filter for streaming chunks

### DIFF
--- a/open-sse/utils/stream.ts
+++ b/open-sse/utils/stream.ts
@@ -478,8 +478,8 @@ export function createSSEStream(options: StreamOptions = {}) {
               // Content for call log is accumulated only from parsed (above) to avoid double-counting;
               // do not add again from item here.
 
-              // Filter empty chunks
-              if (!hasValuableContent(item, sourceFormat)) {
+              // Filter empty chunks - use targetFormat since translated chunks are in provider's format
+              if (!hasValuableContent(item, targetFormat)) {
                 continue; // Skip this empty chunk
               }
 


### PR DESCRIPTION
## Summary

Streaming SSE responses were returning ONLY `data: [DONE]` with no actual content chunks, while non-streaming requests worked perfectly.

## Root Cause

In `open-sse/utils/stream.ts` line 482, the `hasValuableContent()` filter was using `sourceFormat` (client's format) instead of `targetFormat` (provider's format) when filtering translated chunks.

The `translateResponse()` function returns chunks in **targetFormat** (the provider's format, e.g., Claude), but `hasValuableContent()` was checking against **sourceFormat** (the client's format, e.g., OpenAI).

Claude chunks (`{type: "message_delta", delta: {...}}`) don't match OpenAI format expectations (`chunk.choices?.[0]?.delta`), so `hasValuableContent()` incorrectly returned `false` for ALL chunks, filtering them all out.

## Fix

```diff
- if (!hasValuableContent(item, sourceFormat)) {
+ if (!hasValuableContent(item, targetFormat)) {
```

## Impact

ALL streaming responses were affected - this was a bug in OmniRoute's SSE streaming pipeline, not specific to any provider.

## Testing

- Non-streaming (`stream: false`) - Works ✅
- Streaming (`stream: true`) - Now returns actual content chunks ✅