### PR TITLE
fix: auto-decay backoffLevel when rate limit window has passed

### DIFF
--- a/src/sse/services/auth.ts
+++ b/src/sse/services/auth.ts
@@ -368,6 +368,29 @@ export async function getProviderCredentials(
       return null;
     }
 
+    // Auto-decay backoffLevel for accounts whose rateLimitedUntil has passed.
+    // Without this, high backoffLevel permanently deprioritizes accounts even
+    // after the rate limit window expires, creating a deadlock where the account
+    // needs a successful request to reset but never gets selected.
+    for (const c of connections) {
+      if (
+        c.backoffLevel > 0 &&
+        !isTerminalConnectionStatus(c) &&
+        !isAccountUnavailable(c.rateLimitedUntil)
+      ) {
+        c.backoffLevel = 0;
+        updateProviderConnection(c.id, {
+          backoffLevel: 0,
+          testStatus: "active",
+          lastError: null,
+          lastErrorAt: null,
+          lastErrorType: null,
+          lastErrorSource: null,
+          errorCode: null,
+        }).catch(() => {});
+      }
+    }
+
     // Filter out unavailable accounts and excluded connection
     const availableConnections = connections.filter((c) => {
       if (excludeConnectionId && c.id === excludeConnectionId) return false;


### PR DESCRIPTION
## Summary

- Accounts stuck at high `backoffLevel` (up to 15) after a burst of 429s were permanently deprioritized by the account selector, even after the rate limit window expired
- Add auto-decay: during account selection, reset `backoffLevel` to 0 for any non-terminal connection whose `rateLimitedUntil` has passed

## Problem

When a provider returns repeated 429s, `backoffLevel` increments up to `maxLevel: 15` and `testStatus` is set to `unavailable`. Once `rateLimitedUntil` expires (max 2 min), the account becomes eligible for selection again — but `backoffLevel: 15` persists permanently in the DB.

The account health score is calculated as `100 - (backoffLevel * 10)`, so a level-15 account scores **-50**. The account selector always picks healthier accounts first, meaning this account is **never selected**. The only way to reset `backoffLevel` is via `clearAccountError`, which requires a **successful request** through that account — creating a deadlock:

```
429 burst → backoffLevel=15 → health score=-50 → never selected → never succeeds → never resets
```

This is what causes the "Quota exceeded" error in clients even when the upstream provider has plenty of quota available.

## Solution

During account selection in `getProviderCredentials`, before filtering available connections, check each connection:

- If `backoffLevel > 0` AND not a terminal status AND `rateLimitedUntil` has passed (or is null)
- → Reset `backoffLevel: 0`, `testStatus: "active"`, clear error fields

The DB update is fire-and-forget (`.catch(() => {})`) to avoid blocking the hot path. The in-memory `backoffLevel` is also set to 0 immediately so the current request benefits.

## Verification

- TypeScript diagnostics: ✅ no errors
- 938 unit tests: ✅ all pass, 0 failures
- Pre-commit hooks (prettier, eslint, docs-sync): ✅ all pass