### PR TITLE
fix: Clear All Models button now also removes aliases

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/[id]/page.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.tsx
@@ -1553,7 +1553,19 @@ export default function ProviderDetailPage() {
         { method: "DELETE" }
       );
       if (res.ok) {
+        // Also delete all aliases that belong to this provider
+        const aliasEntries = Object.entries(modelAliases).filter(([, model]) =>
+          (model as string).startsWith(`${providerStorageAlias}/`)
+        );
+        await Promise.all(
+          aliasEntries.map(([alias]) =>
+            fetch(`/api/models/alias?alias=${encodeURIComponent(alias)}`, {
+              method: "DELETE",
+            }).catch(() => {})
+          )
+        );
         await fetchProviderModelMeta();
+        await fetchAliases();
         notify.success(t("clearAllModelsSuccess"));
       } else {
         notify.error(t("clearAllModelsFailed"));


### PR DESCRIPTION
## Summary
- Fixed "Clear All Models" button only deleting custom models from the database but leaving their aliases intact
- The button now also deletes all aliases belonging to the provider and refreshes the alias state in the UI
- Without this fix, models appeared to persist in the UI after clearing because the rendering relies on aliases

## Test plan
- [ ] Navigate to a compatible provider with imported models
- [ ] Click "Clear All Models" and confirm
- [ ] Verify all models disappear from the UI immediately
- [ ] Verify the "Clear All Models" button disappears (no models left)
- [ ] Verify aliases are also removed (check `/api/models/alias`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)