### PR TITLE
fix: remove id/type from tool_calls delta chunks in Responses API streaming

### DIFF
--- a/open-sse/translator/response/openai-responses.ts
+++ b/open-sse/translator/response/openai-responses.ts
@@ -464,6 +464,9 @@ export function openaiResponsesToOpenAIResponse(chunk, state) {
   }
 
   // Function call arguments delta
+  // NOTE: Do NOT include `id` or `type` here - only first chunk (response.output_item.added)
+  // should have them. Including `id` on every chunk causes openai-to-claude.ts to emit
+  // a new content_block_start for each delta, breaking Claude Code ACP sessions.
   if (eventType === "response.function_call_arguments.delta") {
     const argsDelta = data.delta || "";
     if (!argsDelta) return null;
@@ -480,8 +483,6 @@ export function openaiResponsesToOpenAIResponse(chunk, state) {
             tool_calls: [
               {
                 index: state.toolCallIndex,
-                id: state.currentToolCallId,
-                type: "function",
                 function: { arguments: argsDelta },
               },
             ],


### PR DESCRIPTION
## Summary

Fixes #682

When streaming tool calls from OpenAI Responses API, the delta chunks were incorrectly including `id` and `type` fields. This caused the Claude format translator to emit a new `content_block_start` for each delta chunk, breaking Claude Code ACP sessions.

## Root Cause

In `open-sse/translator/response/openai-responses.ts`, the `response.function_call_arguments.delta` handler was including the tool call ID on every streaming chunk:

```typescript
// Before (buggy)
tool_calls: [{
  index: state.toolCallIndex,
  id: state.currentToolCallId,  // ← Should NOT be here
  type: "function",              // ← Should NOT be here
  function: { arguments: argsDelta },
}]
```

The Claude format translator (`openai-to-claude.ts`) uses the presence of `tc.id` to detect a **new** tool call and emit a `content_block_start` event. Because every delta chunk had an `id`, it emitted a new `content_block_start` for each chunk.

## The Fix

Remove `id` and `type` from the delta handler. Only the `response.output_item.added` handler should emit the tool call ID:

```typescript
// After (fixed)
tool_calls: [{
  index: state.toolCallIndex,
  function: { arguments: argsDelta },
}]
```

## Observed Behavior

**Before fix:**
```
event: content_block_start  index:0  name:"Bash"
event: content_block_start  index:1  name:""        ← WRONG
event: content_block_delta  index:1  partial_json:"{"
event: content_block_start  index:2  name:""        ← WRONG
...
```

**After fix:**
```
event: content_block_start  index:0  name:"Bash"
event: content_block_delta  index:0  partial_json:"{"
event: content_block_delta  index:0  partial_json:"command"
...
```

## Testing

- Tested with `codex/gpt-5.4` (OpenAI Responses API)
- Validated via Claude Code ACP sessions through OpenClaw
- Confirmed correct streaming format in both OpenAI and Claude output formats

## Considerations

⚠️ This fix should be carefully evaluated for:
- Other OpenAI Responses API models (o1, o3, etc.)
- Non-Claude clients (OpenAI Chat Completions consumers)
- Edge cases with multiple concurrent tool calls

The fix aligns with the standard OpenAI Chat Completions streaming format where delta chunks should only include `index` and `function.arguments`.