### PR TITLE
fix: add opencode-zen to PROVIDER_MODELS_CONFIG (#667)

### DIFF
--- a/src/app/api/providers/[id]/models/route.ts
+++ b/src/app/api/providers/[id]/models/route.ts
@@ -318,6 +318,14 @@ const PROVIDER_MODELS_CONFIG: Record<string, ProviderModelsConfigEntry> = {
     authPrefix: "Bearer ",
     parseResponse: (data) => data.data || data.models || [],
   },
+  "opencode-zen": {
+    url: "https://opencode.ai/zen/v1/models",
+    method: "GET",
+    headers: { "Content-Type": "application/json" },
+    authHeader: "Authorization",
+    authPrefix: "Bearer ",
+    parseResponse: (data) => data.data || data.models || [],
+  },
 };
 
 /**


### PR DESCRIPTION
## Summary

Fixes #667

The 'Import from /models' button for OpenCode Zen provider was failing with:
```
Provider opencode-zen does not support models listing
```

**Root Cause:** `opencode-zen` was not registered in `PROVIDER_MODELS_CONFIG` in `src/app/api/providers/[id]/models/route.ts`, causing the code to fall through to the error handler. The provider's API at `https://opencode.ai/zen/v1/models` is fully functional and returns standard OpenAI-compatible format with 41 models.

## Changes
- Added `opencode-zen` entry to `PROVIDER_MODELS_CONFIG` with the correct API URL and authentication configuration

## Test plan
- [x] Verified the endpoint URL returns valid data
- [x] Code follows existing patterns for OpenAI-compatible provider configs