### PR TITLE
[codex] fix provider limits ui

### DIFF
--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.tsx
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.tsx
@@ -16,6 +16,8 @@ const LS_EXPANDED_GROUPS = "omniroute:limits:expandedGroups";
 
 const REFRESH_INTERVAL_MS = 120000;
 const MIN_FETCH_INTERVAL_MS = 30000; // Debounce per-connection fetches
+const QUOTA_BAR_GREEN_THRESHOLD = 50;
+const QUOTA_BAR_YELLOW_THRESHOLD = 20;
 
 // Provider display config
 const PROVIDER_CONFIG = {
@@ -65,10 +67,10 @@ function getShortModelName(name) {
 
 // Get bar color based on remaining percentage
 function getBarColor(remainingPercentage) {
-  if (remainingPercentage > 50) {
+  if (remainingPercentage > QUOTA_BAR_GREEN_THRESHOLD) {
     return { bar: "#22c55e", text: "#22c55e", bg: "rgba(34,197,94,0.12)" };
   }
-  if (remainingPercentage > 20) {
+  if (remainingPercentage > QUOTA_BAR_YELLOW_THRESHOLD) {
     return { bar: "#eab308", text: "#eab308", bg: "rgba(234,179,8,0.12)" };
   }
   return { bar: "#ef4444", text: "#ef4444", bg: "rgba(239,68,68,0.12)" };

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.tsx
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.tsx
@@ -4,12 +4,7 @@ import { useTranslations } from "next-intl";
 
 import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import Image from "next/image";
-import {
-  parseQuotaData,
-  calculateUsedPercentage,
-  normalizePlanTier,
-  resolvePlanValue,
-} from "./utils";
+import { parseQuotaData, calculatePercentage, normalizePlanTier, resolvePlanValue } from "./utils";
 import Card from "@/shared/components/Card";
 import Badge from "@/shared/components/Badge";
 import { CardSkeleton } from "@/shared/components/Loading";
@@ -68,10 +63,14 @@ function getShortModelName(name) {
   return map[name] || name;
 }
 
-// Get bar color based on used percentage
-function getBarColor(usedPercentage) {
-  if (usedPercentage < 50) return { bar: "#22c55e", text: "#22c55e", bg: "rgba(34,197,94,0.12)" };
-  if (usedPercentage < 80) return { bar: "#eab308", text: "#eab308", bg: "rgba(234,179,8,0.12)" };
+// Get bar color based on remaining percentage
+function getBarColor(remainingPercentage) {
+  if (remainingPercentage > 50) {
+    return { bar: "#22c55e", text: "#22c55e", bg: "rgba(34,197,94,0.12)" };
+  }
+  if (remainingPercentage > 20) {
+    return { bar: "#eab308", text: "#eab308", bg: "rgba(234,179,8,0.12)" };
+  }
   return { bar: "#ef4444", text: "#ef4444", bg: "rgba(239,68,68,0.12)" };
 }
 
@@ -620,8 +619,8 @@ export default function ProviderLimits() {
                     <div className="text-xs text-text-muted italic">{quota.message}</div>
                   ) : quota?.quotas?.length > 0 ? (
                     quota.quotas.map((q, i) => {
-                      const usedPercentage = calculateUsedPercentage(q.used, q.total);
-                      const colors = getBarColor(usedPercentage);
+                      const remainingPercentage = calculatePercentage(q.used, q.total);
+                      const colors = getBarColor(remainingPercentage);
                       const cd = formatCountdown(q.resetAt);
                       const shortName = getShortModelName(q.name);
                       const staleAfterReset = q.staleAfterReset === true;
@@ -657,7 +656,7 @@ export default function ProviderLimits() {
                             <div
                               className="h-full rounded-sm transition-[width] duration-300 ease-out"
                               style={{
-                                width: `${Math.min(usedPercentage, 100)}%`,
+                                width: `${Math.min(remainingPercentage, 100)}%`,
                                 background: colors.bar,
                               }}
                             />
@@ -668,7 +667,7 @@ export default function ProviderLimits() {
                             className="text-[11px] font-semibold min-w-[32px] text-right"
                             style={{ color: colors.text }}
                           >
-                            {usedPercentage}%
+                            {remainingPercentage}%
                           </span>
                         </div>
                       );

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.tsx
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.tsx
@@ -4,7 +4,12 @@ import { useTranslations } from "next-intl";
 
 import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import Image from "next/image";
-import { parseQuotaData, calculatePercentage, normalizePlanTier } from "./utils";
+import {
+  parseQuotaData,
+  calculateUsedPercentage,
+  normalizePlanTier,
+  resolvePlanValue,
+} from "./utils";
 import Card from "@/shared/components/Card";
 import Badge from "@/shared/components/Badge";
 import { CardSkeleton } from "@/shared/components/Loading";
@@ -63,10 +68,10 @@ function getShortModelName(name) {
   return map[name] || name;
 }
 
-// Get bar color based on remaining percentage
-function getBarColor(remaining) {
-  if (remaining > 70) return { bar: "#22c55e", text: "#22c55e", bg: "rgba(34,197,94,0.12)" };
-  if (remaining >= 30) return { bar: "#eab308", text: "#eab308", bg: "rgba(234,179,8,0.12)" };
+// Get bar color based on used percentage
+function getBarColor(usedPercentage) {
+  if (usedPercentage < 50) return { bar: "#22c55e", text: "#22c55e", bg: "rgba(34,197,94,0.12)" };
+  if (usedPercentage < 80) return { bar: "#eab308", text: "#eab308", bg: "rgba(234,179,8,0.12)" };
   return { bar: "#ef4444", text: "#ef4444", bg: "rgba(239,68,68,0.12)" };
 }
 
@@ -297,13 +302,21 @@ export default function ProviderLimits() {
     );
   }, [filteredConnections]);
 
-  const tierByConnection = useMemo(() => {
+  const resolvedPlanByConnection = useMemo(() => {
     const out = {};
     for (const conn of sortedConnections) {
-      out[conn.id] = normalizePlanTier(quotaData[conn.id]?.plan);
+      out[conn.id] = resolvePlanValue(quotaData[conn.id]?.plan, conn.providerSpecificData);
     }
     return out;
   }, [sortedConnections, quotaData]);
+
+  const tierByConnection = useMemo(() => {
+    const out = {};
+    for (const conn of sortedConnections) {
+      out[conn.id] = normalizePlanTier(resolvedPlanByConnection[conn.id]);
+    }
+    return out;
+  }, [sortedConnections, resolvedPlanByConnection]);
 
   const tierCounts = useMemo(() => {
     const counts = {
@@ -313,6 +326,7 @@ export default function ProviderLimits() {
       business: 0,
       ultra: 0,
       pro: 0,
+      plus: 0,
       free: 0,
       unknown: 0,
     };
@@ -533,6 +547,7 @@ export default function ProviderLimits() {
               color: "#666",
             };
             const tierMeta = tierByConnection[conn.id] || normalizePlanTier(null);
+            const resolvedPlan = resolvedPlanByConnection[conn.id];
 
             return (
               <div
@@ -558,21 +573,29 @@ export default function ProviderLimits() {
                   </div>
                   <div className="min-w-0">
                     <div className="text-[13px] font-semibold text-text-main truncate">
-                      {conn.name || config.label}
+                      {conn.name || conn.displayName || conn.email || config.label}
                     </div>
-                    <div className="flex items-center gap-1.5 mt-0.5">
+                    <div className="flex items-center gap-1.5 mt-1 min-h-5">
                       <span
                         title={
-                          quota?.plan
-                            ? t("rawPlanWithValue", { plan: quota.plan })
+                          resolvedPlan
+                            ? t("rawPlanWithValue", { plan: resolvedPlan })
                             : t("noPlanFromProvider")
                         }
+                        className="inline-flex items-center shrink-0"
                       >
-                        <Badge variant={tierMeta.variant} size="sm" dot>
+                        <Badge
+                          variant={tierMeta.variant}
+                          size="sm"
+                          dot
+                          className="h-5 leading-none"
+                        >
                           {tierMeta.label}
                         </Badge>
                       </span>
-                      <span className="text-[11px] text-text-muted">{config.label}</span>
+                      <span className="text-[11px] leading-none text-text-muted">
+                        {config.label}
+                      </span>
                     </div>
                   </div>
                 </div>
@@ -597,17 +620,19 @@ export default function ProviderLimits() {
                     <div className="text-xs text-text-muted italic">{quota.message}</div>
                   ) : quota?.quotas?.length > 0 ? (
                     quota.quotas.map((q, i) => {
-                      const remaining =
-                        q.remainingPercentage !== undefined
-                          ? Math.round(q.remainingPercentage)
-                          : calculatePercentage(q.used, q.total);
-                      const colors = getBarColor(remaining);
+                      const usedPercentage = calculateUsedPercentage(q.used, q.total);
+                      const colors = getBarColor(usedPercentage);
                       const cd = formatCountdown(q.resetAt);
                       const shortName = getShortModelName(q.name);
                       const staleAfterReset = q.staleAfterReset === true;
 
                       return (
-                        <div key={i} className="flex items-center gap-1.5 min-w-[200px] shrink-0">
+                        <div
+                          key={i}
+                          className={`flex items-center gap-1.5 min-w-[200px] shrink-0 ${
+                            i > 0 ? "border-l border-border/80 pl-3 ml-1" : ""
+                          }`}
+                        >
                           {/* Model label */}
                           <span
                             className="text-[11px] font-semibold py-0.5 px-2 rounded whitespace-nowrap min-w-[60px] text-center"
@@ -632,7 +657,7 @@ export default function ProviderLimits() {
                             <div
                               className="h-full rounded-sm transition-[width] duration-300 ease-out"
                               style={{
-                                width: `${Math.min(remaining, 100)}%`,
+                                width: `${Math.min(usedPercentage, 100)}%`,
                                 background: colors.bar,
                               }}
                             />
@@ -643,7 +668,7 @@ export default function ProviderLimits() {
                             className="text-[11px] font-semibold min-w-[32px] text-right"
                             style={{ color: colors.text }}
                           >
-                            {remaining}%
+                            {usedPercentage}%
                           </span>
                         </div>
                       );

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.tsx
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.tsx
@@ -1,6 +1,30 @@
 import { getModelsByProviderId } from "@omniroute/open-sse/config/providerModels.ts";
 import { safePercentage } from "@/shared/utils/formatting";
 
+const PROVIDER_PLAN_FALLBACKS = new Set([
+  "claude code",
+  "kimi coding",
+  "kiro",
+  "openai codex",
+  "codex",
+  "github copilot",
+]);
+
+function toRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function normalizePlanCandidate(value: unknown) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  if (trimmed.toLowerCase() === "unknown") return null;
+  if (PROVIDER_PLAN_FALLBACKS.has(trimmed.toLowerCase())) return null;
+  return trimmed;
+}
+
 /**
  * Format ISO date string to countdown format (inspired by vscode-antigravity-cockpit)
  * @param {string|Date} date - ISO date string or Date object
@@ -74,6 +98,20 @@ export function calculatePercentage(used, total) {
   if (used >= total) return 0;
 
   return Math.round(((total - used) / total) * 100);
+}
+
+/**
+ * Calculate used percentage
+ * @param {number} used - Used amount
+ * @param {number} total - Total amount
+ * @returns {number} Used percentage (0-100)
+ */
+export function calculateUsedPercentage(used, total) {
+  if (!total || total === 0) return 0;
+  if (!used || used < 0) return 0;
+  if (used >= total) return 100;
+
+  return Math.round((used / total) * 100);
 }
 
 function isPastResetWindow(resetAt) {
@@ -211,8 +249,31 @@ export function parseQuotaData(provider, data) {
 }
 
 /**
+ * Resolve the best available plan label using live usage first, then persisted
+ * provider-specific connection metadata.
+ */
+export function resolvePlanValue(plan, providerSpecificData) {
+  const psd = toRecord(providerSpecificData);
+  const candidates = [
+    plan,
+    psd.workspacePlanType,
+    psd.plan,
+    psd.subscription,
+    psd.tier,
+    psd.accountTier,
+  ];
+
+  for (const candidate of candidates) {
+    const normalized = normalizePlanCandidate(candidate);
+    if (normalized) return normalized;
+  }
+
+  return null;
+}
+
+/**
  * Normalize provider-specific plan labels into a shared tier taxonomy.
- * Supported tiers: enterprise, business, team, ultra, pro, free, unknown.
+ * Supported tiers: enterprise, business, team, ultra, pro, plus, free, unknown.
  */
 export function normalizePlanTier(plan) {
   const raw = typeof plan === "string" ? plan.trim() : "";
@@ -223,12 +284,12 @@ export function normalizePlanTier(plan) {
   const upper = raw.toUpperCase();
 
   // Provider names that are not real plan tiers — treat as unknown
-  if (upper === "CLAUDE CODE" || upper === "KIMI CODING" || upper === "KIRO") {
-    return { key: "unknown", label: raw, variant: "default", rank: 0, raw };
+  if (PROVIDER_PLAN_FALLBACKS.has(raw.toLowerCase())) {
+    return { key: "unknown", label: "Unknown", variant: "default", rank: 0, raw };
   }
 
   if (upper.includes("PRO+") || upper.includes("PRO PLUS") || upper.includes("PROPLUS")) {
-    return { key: "plus", label: "Pro+", variant: "secondary", rank: 4, raw };
+    return { key: "plus", label: "Pro+", variant: "success", rank: 4, raw };
   }
 
   if (upper.includes("ENTERPRISE") || upper.includes("CORP") || upper.includes("ORG")) {
@@ -245,7 +306,7 @@ export function normalizePlanTier(plan) {
   }
 
   if (upper.includes("STUDENT")) {
-    return { key: "pro", label: "Student", variant: "primary", rank: 3, raw };
+    return { key: "pro", label: "Student", variant: "success", rank: 3, raw };
   }
 
   if (upper.includes("ULTRA")) {
@@ -253,11 +314,11 @@ export function normalizePlanTier(plan) {
   }
 
   if (upper.includes("PRO") || upper.includes("PREMIUM")) {
-    return { key: "pro", label: "Pro", variant: "primary", rank: 3, raw };
+    return { key: "pro", label: "Pro", variant: "success", rank: 3, raw };
   }
 
   if (upper.includes("PLUS") || upper.includes("PAID")) {
-    return { key: "plus", label: "Plus", variant: "secondary", rank: 2, raw };
+    return { key: "plus", label: "Plus", variant: "success", rank: 2, raw };
   }
 
   if (

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.tsx
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.tsx
@@ -100,20 +100,6 @@ export function calculatePercentage(used, total) {
   return Math.round(((total - used) / total) * 100);
 }
 
-/**
- * Calculate used percentage
- * @param {number} used - Used amount
- * @param {number} total - Total amount
- * @returns {number} Used percentage (0-100)
- */
-export function calculateUsedPercentage(used, total) {
-  if (!total || total === 0) return 0;
-  if (!used || used < 0) return 0;
-  if (used >= total) return 100;
-
-  return Math.round((used / total) * 100);
-}
-
 function isPastResetWindow(resetAt) {
   if (!resetAt) return false;
   const resetTime =

--- a/src/shared/components/Badge.tsx
+++ b/src/shared/components/Badge.tsx
@@ -5,6 +5,7 @@ import { cn } from "@/shared/utils/cn";
 const variants = {
   default: "bg-black/5 dark:bg-white/10 text-text-muted",
   primary: "bg-primary/10 text-primary",
+  secondary: "bg-primary/10 border border-primary/20 text-primary",
   success: "bg-green-500/10 text-green-600 dark:text-green-400",
   warning: "bg-yellow-500/10 text-yellow-600 dark:text-yellow-400",
   error: "bg-red-500/10 text-red-600 dark:text-red-400",
@@ -53,6 +54,7 @@ export default function Badge({
             variant === "error" && "bg-red-500",
             variant === "info" && "bg-blue-500",
             variant === "primary" && "bg-primary",
+            variant === "secondary" && "bg-primary",
             variant === "default" && "bg-gray-500"
           )}
         />

--- a/src/shared/components/Badge.tsx
+++ b/src/shared/components/Badge.tsx
@@ -5,7 +5,6 @@ import { cn } from "@/shared/utils/cn";
 const variants = {
   default: "bg-black/5 dark:bg-white/10 text-text-muted",
   primary: "bg-primary/10 text-primary",
-  secondary: "bg-primary/10 border border-primary/20 text-primary",
   success: "bg-green-500/10 text-green-600 dark:text-green-400",
   warning: "bg-yellow-500/10 text-yellow-600 dark:text-yellow-400",
   error: "bg-red-500/10 text-red-600 dark:text-red-400",
@@ -54,7 +53,6 @@ export default function Badge({
             variant === "error" && "bg-red-500",
             variant === "info" && "bg-blue-500",
             variant === "primary" && "bg-primary",
-            variant === "secondary" && "bg-primary",
             variant === "default" && "bg-gray-500"
           )}
         />

--- a/tests/unit/provider-limits-ui.test.mjs
+++ b/tests/unit/provider-limits-ui.test.mjs
@@ -1,11 +1,8 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import React from "react";
-import { renderToStaticMarkup } from "react-dom/server";
 
 const providerLimitUtils =
   await import("../../src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.tsx");
-const { default: Badge } = await import("../../src/shared/components/Badge.tsx");
 
 test("provider plan fallbacks normalize to Unknown instead of repeating provider labels", () => {
   const tier = providerLimitUtils.normalizePlanTier("Claude Code");
@@ -46,15 +43,4 @@ test("remaining percentage helpers reflect remaining quota and stale resets refi
 
   assert.equal(parsed.length, 1);
   assert.equal(providerLimitUtils.calculatePercentage(parsed[0].used, parsed[0].total), 100);
-});
-
-test("Badge secondary variant renders bordered pill styles", () => {
-  const html = renderToStaticMarkup(
-    React.createElement(Badge, { variant: "secondary", size: "sm", dot: true }, "Plus")
-  );
-
-  assert.match(html, /bg-primary\/10/);
-  assert.match(html, /border/);
-  assert.match(html, /border-primary\/20/);
-  assert.match(html, />Plus</);
 });

--- a/tests/unit/provider-limits-ui.test.mjs
+++ b/tests/unit/provider-limits-ui.test.mjs
@@ -1,0 +1,60 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+const providerLimitUtils =
+  await import("../../src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.tsx");
+const { default: Badge } = await import("../../src/shared/components/Badge.tsx");
+
+test("provider plan fallbacks normalize to Unknown instead of repeating provider labels", () => {
+  const tier = providerLimitUtils.normalizePlanTier("Claude Code");
+
+  assert.equal(tier.key, "unknown");
+  assert.equal(tier.label, "Unknown");
+});
+
+test("paid individual tiers use non-gray badge variants", () => {
+  assert.equal(providerLimitUtils.normalizePlanTier("Plus").variant, "success");
+  assert.equal(providerLimitUtils.normalizePlanTier("Pro").variant, "success");
+  assert.equal(providerLimitUtils.normalizePlanTier("Student").variant, "success");
+  assert.equal(providerLimitUtils.normalizePlanTier("Free").variant, "default");
+});
+
+test("Codex workspacePlanType is used when live plan is missing or unknown", () => {
+  const resolvedPlan = providerLimitUtils.resolvePlanValue("unknown", {
+    workspacePlanType: "plus",
+  });
+
+  assert.equal(resolvedPlan, "plus");
+  const tier = providerLimitUtils.normalizePlanTier(resolvedPlan);
+  assert.equal(tier.key, "plus");
+  assert.equal(tier.variant, "success");
+});
+
+test("used percentage helpers reflect consumed quota and stale resets collapse to zero", () => {
+  assert.equal(providerLimitUtils.calculateUsedPercentage(0, 100), 0);
+  assert.equal(providerLimitUtils.calculateUsedPercentage(17, 100), 17);
+  assert.equal(providerLimitUtils.calculateUsedPercentage(60, 100), 60);
+
+  const past = new Date(Date.now() - 60_000).toISOString();
+  const parsed = providerLimitUtils.parseQuotaData("codex", {
+    quotas: {
+      session: { used: 83, total: 100, resetAt: past },
+    },
+  });
+
+  assert.equal(parsed.length, 1);
+  assert.equal(providerLimitUtils.calculateUsedPercentage(parsed[0].used, parsed[0].total), 0);
+});
+
+test("Badge secondary variant renders bordered pill styles", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(Badge, { variant: "secondary", size: "sm", dot: true }, "Plus")
+  );
+
+  assert.match(html, /bg-primary\/10/);
+  assert.match(html, /border/);
+  assert.match(html, /border-primary\/20/);
+  assert.match(html, />Plus</);
+});

--- a/tests/unit/provider-limits-ui.test.mjs
+++ b/tests/unit/provider-limits-ui.test.mjs
@@ -32,10 +32,10 @@ test("Codex workspacePlanType is used when live plan is missing or unknown", () 
   assert.equal(tier.variant, "success");
 });
 
-test("used percentage helpers reflect consumed quota and stale resets collapse to zero", () => {
-  assert.equal(providerLimitUtils.calculateUsedPercentage(0, 100), 0);
-  assert.equal(providerLimitUtils.calculateUsedPercentage(17, 100), 17);
-  assert.equal(providerLimitUtils.calculateUsedPercentage(60, 100), 60);
+test("remaining percentage helpers reflect remaining quota and stale resets refill to 100", () => {
+  assert.equal(providerLimitUtils.calculatePercentage(0, 100), 100);
+  assert.equal(providerLimitUtils.calculatePercentage(17, 100), 83);
+  assert.equal(providerLimitUtils.calculatePercentage(60, 100), 40);
 
   const past = new Date(Date.now() - 60_000).toISOString();
   const parsed = providerLimitUtils.parseQuotaData("codex", {
@@ -45,7 +45,7 @@ test("used percentage helpers reflect consumed quota and stale resets collapse t
   });
 
   assert.equal(parsed.length, 1);
-  assert.equal(providerLimitUtils.calculateUsedPercentage(parsed[0].used, parsed[0].total), 0);
+  assert.equal(providerLimitUtils.calculatePercentage(parsed[0].used, parsed[0].total), 100);
 });
 
 test("Badge secondary variant renders bordered pill styles", () => {


### PR DESCRIPTION
## Summary
- fix Provider Limits tier badge fallback and styling
- keep paid tiers visually distinct and avoid repeating provider names like `Claude Code` as a subscription badge
- improve account-row alignment and add clearer separators between quota windows
- keep quota bars in remaining-balance mode: a new window shows a full bar and `100%`, then the bar shrinks as quota is used
- keep unit coverage for tier normalization, plan fallback, and quota percentage display

## Why
The Limits page had several UI issues:
- `Plus` could render with missing or incorrect badge styling
- some providers could show the provider name twice instead of a real tier or `Unknown`
- the badge row alignment looked off
- different quota windows were crowded together visually
- the quota bar should represent remaining balance on the account

## Validation
- `node --import tsx/esm --test tests/unit/provider-limits-ui.test.mjs tests/unit/t13-stale-quota-display.test.mjs tests/unit/copilot-usage.test.mjs`
- `npx eslint src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.tsx src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.tsx tests/unit/provider-limits-ui.test.mjs`
- `npm run test:unit`
- `npm run build`
