### PR TITLE
chore(release): v3.2.1 — context pinning fix + global fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@
 
 ---
 
+## [3.2.1] — 2026-03-29
+
+### ✨ New Features
+
+- **Global Fallback Provider (#689)** — When all combo models are exhausted (502/503), OmniRoute now attempts a configurable global fallback model before returning the error. Set `globalFallbackModel` in settings to enable.
+
+### 🐛 Bug Fixes
+
+- **Fix #721** — Fixed context pinning bypass during tool-call responses. Non-streaming tagging used wrong JSON path (`json.messages` → `json.choices[0].message`). Streaming injection now triggers on `finish_reason` chunks for tool-call-only streams. `injectModelTag()` now appends synthetic pin messages for non-string content.
+- **Fix #709** — Confirmed already fixed (v3.1.9) — `system-info.mjs` creates directories recursively. Closed.
+- **Fix #707** — Confirmed already fixed (v3.1.9) — empty tool name sanitization in `chatCore.ts`. Closed.
+
+### 🧪 Tests
+
+- Added 6 unit tests for context pinning with tool-call responses (null content, array content, roundtrip, re-injection)
+
 ## [3.2.0] — 2026-03-28
 
 ### ✨ New Features

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: OmniRoute API
-  version: 3.2.0
+  version: 3.2.1
   description: |
     OmniRoute is a local-first AI API proxy router. It provides an OpenAI-compatible
     endpoint that routes requests to multiple AI providers with load balancing,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "omniroute",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "omniroute",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omniroute",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Smart AI Router with auto fallback — route to FREE & cheap models, zero downtime. Works with Cursor, Cline, Claude Desktop, Codex, and any OpenAI-compatible tool.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## 🚀 Release v3.2.1

### Changes

#### 🐛 Bug Fixes
- **Fix #721** — Context pinning bypass during tool-call responses
  - Non-streaming: fixed `json.messages` → `json.choices[0].message` (OpenAI format)
  - Streaming: inject pin tag before `finish_reason` for tool-call-only streams
  - `injectModelTag()`: appends synthetic pin for non-string content (tool_calls)

- **Fix #709** — Confirmed fixed (v3.1.9). Closed.
- **Fix #707** — Confirmed fixed (v3.1.9). Closed.

#### ✨ Features
- **#689** — Global Fallback Provider: configurable last-resort model when combos exhaust

#### 🧪 Tests
- 6 new unit tests for context pinning (null content, array content, roundtrip, re-injection)

### Test Results
- **1046/1046 tests pass**, 0 failures

### Triage
- Closed 4 issues (#721, #709, #707, #689)
- Posted needs-info comments on #653, #606, #604

### ⚠️ After merging: run Phase 2 (tag, publish, deploy)