### PR TITLE
fix(sse): use x-api-key for opencode-go minimax messages requests

### DIFF
--- a/open-sse/executors/opencode.ts
+++ b/open-sse/executors/opencode.ts
@@ -45,7 +45,11 @@ export class OpencodeExecutor extends BaseExecutor {
     const key = credentials?.apiKey || credentials?.accessToken;
 
     if (key) {
-      headers["Authorization"] = `Bearer ${key}`;
+      if (this._requestFormat === "claude") {
+        headers["x-api-key"] = key;
+      } else {
+        headers["Authorization"] = `Bearer ${key}`;
+      }
     }
 
     if (this._requestFormat === "claude") {

--- a/tests/unit/opencode-executor.test.mjs
+++ b/tests/unit/opencode-executor.test.mjs
@@ -158,7 +158,7 @@ describe("OpencodeExecutor", () => {
       );
 
       assert.deepEqual(result.headers, {
-        Authorization: "Bearer claude-key",
+        "x-api-key": "claude-key",
         "Content-Type": "application/json",
         "anthropic-version": "2023-06-01",
         Accept: "text/event-stream",


### PR DESCRIPTION
## Summary

Fix OpenCode Go MiniMax auth for Anthropic-style `/messages` requests.

## Root cause

OpenCode Go mixes protocol families by model:

- `glm-5` and `kimi-k2.5` use OpenAI-style `/chat/completions`
- `minimax-m2.5` and `minimax-m2.7` use Anthropic-style `/messages`

OmniRoute already routed the MiniMax Go models to `/messages`, but `OpencodeExecutor` still sent `Authorization: Bearer ...`, which caused upstream `401 Missing API key` errors.

For OpenCode Go MiniMax `/messages`, upstream expects:

- `x-api-key: <key>`
- `anthropic-version: 2023-06-01`

## Changes

- update `open-sse/executors/opencode.ts`
  - send `x-api-key` for Claude-targeted OpenCode Go requests
  - keep `Authorization: Bearer ...` for the remaining OpenCode Go request formats
- update `tests/unit/opencode-executor.test.mjs`
  - assert the correct MiniMax Go header behavior

## Validation

Validated with:

- direct `curl` repro against OpenCode Go endpoints
- `node --import tsx/esm --test tests/unit/opencode-executor.test.mjs`
- `npm run typecheck:core`
- `npm run build`

## Notes

This fix is intentionally narrow:

- it preserves current behavior for `glm-5` and `kimi-k2.5`
- it only changes auth header selection for OpenCode Go requests using Claude target format
