### PR TITLE
fix: ensure Codex passthrough path sets instructions and store=false

### DIFF
--- a/open-sse/executors/codex.ts
+++ b/open-sse/executors/codex.ts
@@ -260,17 +260,19 @@ export class CodexExecutor extends BaseExecutor {
       body.service_tier = CODEX_FAST_WIRE_VALUE;
     }
 
-    if (nativeCodexPassthrough) {
-      return body;
-    }
-
     // If no instructions provided, inject default Codex instructions
+    // NOTE: must run before the passthrough return — Codex upstream rejects
+    // requests without instructions even when the body is forwarded as-is.
     if (!body.instructions || body.instructions.trim() === "") {
       body.instructions = CODEX_DEFAULT_INSTRUCTIONS;
     }
 
     // Ensure store is false (Codex requirement)
     body.store = false;
+
+    if (nativeCodexPassthrough) {
+      return body;
+    }
 
     // Extract thinking level from model name suffix
     // e.g., gpt-5.3-codex-high → high, gpt-5.3-codex → medium (default)


### PR DESCRIPTION
The native Codex passthrough path returned early before injecting default instructions and enforcing store=false. Clients sending Responses API requests without instructions (e.g. opencode) got 400 "Instructions are required", and requests missing store=false got 400 "Store must be set to false" from the Codex upstream.

Move both assignments before the passthrough return so they apply to all code paths.