### PR TITLE
fix(embeddings): forward provider-specific params to upstream API

### DIFF
--- a/open-sse/handlers/embeddings.ts
+++ b/open-sse/handlers/embeddings.ts
@@ -62,6 +62,7 @@ export async function handleEmbedding({
     model: body.model,
     input_count: Array.isArray(body.input) ? body.input.length : 1,
     dimensions: body.dimensions || undefined,
+    input_type: body.input_type || undefined,
   };
 
   if (!provider) {
@@ -86,9 +87,17 @@ export async function handleEmbedding({
     input: body.input,
   };
 
-  // Pass optional parameters
+  // Pass optional standard parameters
   if (body.dimensions !== undefined) upstreamBody.dimensions = body.dimensions;
   if (body.encoding_format !== undefined) upstreamBody.encoding_format = body.encoding_format;
+
+  // Forward any additional provider-specific parameters (e.g. input_type for NVIDIA NIM, user for OpenAI, truncate for Cohere)
+  const KNOWN_FIELDS = new Set(["model", "input", "dimensions", "encoding_format"]);
+  for (const [key, value] of Object.entries(body)) {
+    if (!KNOWN_FIELDS.has(key) && value !== undefined) {
+      upstreamBody[key] = value;
+    }
+  }
 
   // Build headers
   const headers = {


### PR DESCRIPTION
## Summary

The embedding proxy was dropping all non-standard request body parameters when building the upstream request. Only `model`, `input`, `dimensions`, and `encoding_format` were forwarded — everything else was silently discarded.

This caused **NVIDIA NIM asymmetric embedding models** (e.g. `nv-embedqa-e5-v5`) to fail with:
```
{"error":"'input_type' parameter is required for asymmetric models"}
```

## Changes

**`open-sse/handlers/embeddings.ts`** (single file, +10/-1):

- After copying standard fields, iterate remaining `body` entries and forward them to `upstreamBody` (excluded via `KNOWN_FIELDS` set: `model`, `input`, `dimensions`, `encoding_format`)
- Log `input_type` in `logRequestBody` for the Logger panel
- Consistent with `DefaultExecutor.transformRequest()` passthrough in the chat pipeline
- Safe because the Zod schema already accepts extra fields via `.catchall(z.unknown())`

## Affected providers

| Provider | Parameter | Status before | Status after |
|----------|-----------|--------------|--------------|
| NVIDIA NIM | `input_type` | HTTP 400 | Works |
| OpenAI | `user` | Dropped | Forwarded |
| Cohere | `truncate` | Dropped | Forwarded |
| Any future | Any extra field | Dropped | Forwarded |

## Test plan

- [x] `npm test` — 1070 pass, 0 fail
- [x] `npm run lint` — 0 errors
- [x] Docker rebuild + container healthy
- [x] Sent embedding request with `input_type: "query"` to `nvidia/nvidia/nv-embedqa-e5-v5` — received successful embedding vector (previously HTTP 400)

Made with [Cursor](https://cursor.com)