### PR TITLE
fix(sse): remove race condition in cache metrics tracking

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -43,13 +43,8 @@ import {
 } from "@/lib/localDb";
 import { getExecutor } from "../executors/index.ts";
 import { getCacheControlSettings } from "@/lib/cacheControlSettings";
-import {
-  shouldPreserveCacheControl,
-  trackCacheMetrics,
-  recordCacheHit,
-  type CacheControlMetrics,
-} from "../utils/cacheControlPolicy.ts";
-import { getCacheMetrics, updateCacheMetrics } from "@/lib/db/settings.ts";
+import { shouldPreserveCacheControl, recordCacheHit } from "../utils/cacheControlPolicy.ts";
+import { getCacheMetrics } from "@/lib/db/settings.ts";
 
 import {
   parseCodexQuotaHeaders,
@@ -699,27 +694,6 @@ export async function handleChatCore({
     comboStrategy,
     targetProvider: provider,
     settings: { alwaysPreserveClientCache: cacheControlMode },
-  });
-
-  // Track cache metrics for this request
-  let currentMetrics = await getCacheMetrics().catch(() => ({
-    totalRequests: 0,
-    requestsWithCacheControl: 0,
-    totalInputTokens: 0,
-    totalCachedTokens: 0,
-    totalCacheCreationTokens: 0,
-    tokensSaved: 0,
-    estimatedCostSaved: 0,
-    byProvider: {},
-    byStrategy: {},
-    lastUpdated: new Date().toISOString(),
-  }));
-
-  currentMetrics = trackCacheMetrics({
-    preserved: preserveCacheControl,
-    provider,
-    strategy: comboStrategy,
-    metrics: currentMetrics,
   });
 
   if (preserveCacheControl) {
@@ -1473,18 +1447,6 @@ export async function handleChatCore({
           (usage as any).prompt_tokens_details?.cache_creation_tokens
       );
 
-      if (cachedTokens > 0 || cacheCreationTokens > 0) {
-        currentMetrics = updateCacheTokenMetrics({
-          metrics: currentMetrics,
-          provider,
-          strategy: comboStrategy,
-          inputTokens,
-          cachedTokens,
-          cacheCreationTokens,
-          costSaved: 0, // Will be calculated based on pricing
-        });
-      }
-
       saveRequestUsage({
         provider: provider || "unknown",
         model: model || "unknown",
@@ -1649,17 +1611,22 @@ export async function handleChatCore({
           (streamUsage as any).prompt_tokens_details?.cache_creation_tokens
       );
 
-      if (cachedTokens > 0 || cacheCreationTokens > 0) {
-        currentMetrics = updateCacheTokenMetrics({
-          metrics: currentMetrics,
-          provider,
-          strategy: comboStrategy,
-          inputTokens,
-          cachedTokens,
-          cacheCreationTokens,
-          costSaved: 0,
-        });
-      }
+      saveRequestUsage({
+        provider: provider || "unknown",
+        model: model || "unknown",
+        tokens: streamUsage,
+        status: String(streamStatus || 200),
+        success: streamStatus === 200,
+        latencyMs: Date.now() - startTime,
+        timeToFirstTokenMs: ttft,
+        errorCode: null,
+        timestamp: new Date().toISOString(),
+        connectionId: connectionId || undefined,
+        apiKeyId: apiKeyInfo?.id || undefined,
+        apiKeyName: apiKeyInfo?.name || undefined,
+      }).catch((err) => {
+        console.error("Failed to save usage stats:", err.message);
+      });
     }
 
     persistAttemptLogs({
@@ -1671,11 +1638,6 @@ export async function handleChatCore({
       clientResponse: clientPayload ?? streamResponseBody ?? undefined,
       claudeCacheMeta: claudePromptCacheLogMeta,
       claudeCacheUsageMeta: cacheUsageLogMeta,
-    });
-
-    // Persist cache metrics to database
-    updateCacheMetrics(currentMetrics).catch((err) => {
-      log?.debug?.("CACHE", `Failed to persist cache metrics: ${err?.message || "unknown"}`);
     });
 
     if (apiKeyInfo?.id && streamUsage) {


### PR DESCRIPTION
## Summary

Follow-up fix for PR #752 which was merged before this critical fix was included.

## Changes

- Remove in-memory metrics tracking (, , )
- Cache metrics now computed on-the-fly from  table (single source of truth)
- Eliminates race condition where concurrent requests could overwrite each other's metrics
- Removes duplicate metric tracking logic in streaming/non-streaming paths

## Addresses Code Review Issues

From the original PR review bots:

1. **CRITICAL - Race condition in metrics updates**: Fixed by removing read-modify-write pattern entirely
2. **WARNING - Duplicate metric tracking logic**: Fixed by removing redundant tracking calls

## Testing

All cache-related unit tests pass. Two pre-existing test failures unrelated to this change:
-  - CodexExecutor test (pre-existing)
-  - Auto-update test (pre-existing)