### PR TITLE
Fix Gemini API error with integer enum in tool parameters

### DIFF
--- a/open-sse/translator/helpers/geminiHelper.ts
+++ b/open-sse/translator/helpers/geminiHelper.ts
@@ -167,13 +167,19 @@ function convertConstToEnum(obj) {
 }
 
 // Convert enum values to strings (Gemini requires string enum values)
+// For integer types, remove enum entirely as Gemini doesn't support it
 function convertEnumValuesToStrings(obj) {
   if (!obj || typeof obj !== "object") return;
 
   if (obj.enum && Array.isArray(obj.enum)) {
-    obj.enum = obj.enum.map((v) => String(v));
-    if (!obj.type) {
-      obj.type = "string";
+    // Gemini only supports enum for string types, not integer
+    if (obj.type === "integer" || obj.type === "number") {
+      delete obj.enum;
+    } else {
+      obj.enum = obj.enum.map((v) => String(v));
+      if (!obj.type) {
+        obj.type = "string";
+      }
     }
   }
 


### PR DESCRIPTION
Gemini API returns 400 error when tools have enum constraints on integer/number types: "enum: only allowed for STRING type"

This fix removes enum constraints for integer and number types in JSON schemas before sending to Gemini API, while keeping enum for string types.

Fixes tools like mcp__pointer__get-pointed-element that use integer enums for cssLevel and textDetail parameters.