### PR TITLE
fix: strip reasoning/thinking params for models that don't support them

### DIFF
--- a/open-sse/services/modelCapabilities.ts
+++ b/open-sse/services/modelCapabilities.ts
@@ -48,3 +48,54 @@ export function supportsToolCalling(modelStr: string): boolean {
 
   return !blocked;
 }
+
+// Models that do NOT support reasoning/thinking parameters.
+// AG (Antigravity) claude-sonnet-4-6 routes through a Google internal API
+// that returns 400 if thinking params are included.
+const REASONING_UNSUPPORTED_PATTERNS = [
+  "antigravity/claude-sonnet-4-6",
+  "antigravity/claude-sonnet-4-5",
+  "antigravity/claude-sonnet-4",
+  "ag/claude-sonnet-4-6",
+  "ag/claude-sonnet-4-5",
+  "ag/claude-sonnet-4",
+];
+
+function getRegistryReasoningFlag(providerIdOrAlias: string, modelId: string): boolean | null {
+  const providerAlias = PROVIDER_ID_TO_ALIAS[providerIdOrAlias] || providerIdOrAlias;
+  const models = PROVIDER_MODELS[providerAlias];
+  if (!Array.isArray(models)) return null;
+  const found = models.find((m) => m?.id === modelId);
+  if (!found) return null;
+  return typeof found.supportsReasoning === "boolean" ? found.supportsReasoning : null;
+}
+
+/**
+ * Returns whether a model supports reasoning/thinking parameters.
+ *
+ * Decision order:
+ * 1) Provider registry metadata (supportsReasoning flag) when available.
+ * 2) Explicit denylist for known unsupported models (e.g. AG Claude Sonnet).
+ * 3) Default true (pass through — safe, provider will ignore if unsupported).
+ */
+export function supportsReasoning(modelStr: string): boolean {
+  const parsed = parseModel(modelStr);
+  const provider = parsed.provider || parsed.providerAlias || "";
+  const model = parsed.model || modelStr;
+
+  if (provider) {
+    const fromRegistry = getRegistryReasoningFlag(provider, model);
+    if (fromRegistry !== null) return fromRegistry;
+  }
+
+  const normalized = String(modelStr || "").toLowerCase();
+  if (!normalized) return true;
+
+  const blocked = REASONING_UNSUPPORTED_PATTERNS.some((pattern) =>
+    normalized === pattern ||
+    normalized.endsWith(`/${pattern}`) ||
+    normalized.includes(pattern)
+  );
+
+  return !blocked;
+}

--- a/open-sse/services/thinkingBudget.ts
+++ b/open-sse/services/thinkingBudget.ts
@@ -14,6 +14,7 @@ export const ThinkingMode = {
 };
 
 import { capThinkingBudget, getDefaultThinkingBudget } from "@/shared/constants/modelSpecs";
+import { supportsReasoning } from "./modelCapabilities.ts";
 
 // Effort → budget token mapping
 export const EFFORT_BUDGETS = {
@@ -150,6 +151,13 @@ export function ensureThinkingConfig(body) {
 export function applyThinkingBudget(body, config = null) {
   const cfg = config || _config;
   if (!body || typeof body !== "object") return body;
+
+  // Early exit: strip ALL reasoning/thinking params for models that don't support them.
+  // Sending thinking params to unsupported models (e.g. AG claude-sonnet-4-6) causes 400 errors.
+  const modelStr = typeof body.model === "string" ? body.model : "";
+  if (modelStr && !supportsReasoning(modelStr)) {
+    return stripThinkingConfig(body);
+  }
 
   // Pre-processing: convert string thinkingLevel to numeric budget
   let processed = normalizeThinkingLevel(body);


### PR DESCRIPTION
Closes #764

## Summary

Prevents HTTP 400 errors caused by sending `thinking`/`reasoning_effort`/`reasoning` parameters to provider models that don't support them (e.g. `antigravity/claude-sonnet-4-6`).

## Changes

### `open-sse/services/modelCapabilities.ts`
Added `supportsReasoning(modelStr: string): boolean`:
- Checks per-model `supportsReasoning` flag in the provider registry (if present)
- Falls back to an explicit denylist of known-unsupported patterns:
  - `antigravity/claude-sonnet-4-6`, `antigravity/claude-sonnet-4-5`, `antigravity/claude-sonnet-4`
  - `ag/claude-sonnet-*` (alias variants)
- Defaults to `true` for unknown models (safe pass-through)

### `open-sse/services/thinkingBudget.ts`
In `applyThinkingBudget()`: added early exit before the `ThinkingMode` switch —
if `body.model` is present and `!supportsReasoning(body.model)`, immediately calls
`stripThinkingConfig(body)` regardless of the configured mode.

## Behavior

| Model | Before | After |
|-------|--------|-------|
| `antigravity/claude-sonnet-4-6` | ❌ 400 (thinking params sent) | ✅ Stripped before forwarding |
| `anthropic/claude-opus-4-thinking` | ✅ Thinking applied | ✅ Unchanged |
| Any other model | ✅ Pass-through | ✅ Unchanged |

## Root Cause

The `applyThinkingBudget()` function had no model-capability check. Even in `PASSTHROUGH` mode, thinking parameters already in the request body were forwarded verbatim. The AG (Google Cloud Code) API returns 400 for any request containing `thinking` or `reasoning_effort`.

## Testing

```bash
# Should return 200, no 400 errors:
curl http://localhost:20128/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{"model": "antigravity/claude-sonnet-4-6", "messages": [{"role": "user", "content": "hi"}], "thinking": {"type": "enabled", "budget_tokens": 5000}}'
```