### PR TITLE
Bypass semantic cache in combo live tests

### DIFF
--- a/src/app/api/combos/test/route.ts
+++ b/src/app/api/combos/test/route.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { NextResponse } from "next/server";
 import { buildComboTestRequestBody, extractComboTestResponseText } from "@/lib/combos/testHealth";
 import { getComboByName } from "@/lib/localDb";
@@ -67,6 +68,10 @@ export async function POST(request) {
               // Internal dashboard tests still use the normal /v1 pipeline but
               // bypass REQUIRE_API_KEY so admins can test with local session auth.
               "X-Internal-Test": "combo-health-check",
+              // Force a fresh execution path so combo tests cannot be satisfied by
+              // OmniRoute's semantic cache or other request reuse layers.
+              "X-OmniRoute-No-Cache": "true",
+              "X-Request-Id": `combo-test-${randomUUID()}`,
             },
             body: JSON.stringify(testBody),
             signal: controller.signal,

--- a/src/lib/semanticCache.ts
+++ b/src/lib/semanticCache.ts
@@ -29,6 +29,25 @@ function toNumber(value: unknown, fallback = 0): number {
   return fallback;
 }
 
+function getHeaderValue(
+  headers: { get?: (name: string) => string | null } | Record<string, unknown> | null | undefined,
+  name: string
+): string | null {
+  if (!headers) return null;
+
+  if (typeof headers.get === "function") {
+    return headers.get(name);
+  }
+
+  const needle = name.toLowerCase();
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() !== needle) continue;
+    return typeof value === "string" ? value : null;
+  }
+
+  return null;
+}
+
 // ─── Singleton ─────────────────
 
 let memoryCache: LRUCache | null = null;
@@ -309,7 +328,9 @@ export function getCacheStats() {
  * Only non-streaming, deterministic (temperature=0) requests.
  */
 export function isCacheable(body, headers) {
-  if (headers?.get?.("x-omniroute-no-cache") === "true") return false;
+  if ((getHeaderValue(headers, "x-omniroute-no-cache") || "").toLowerCase() === "true") {
+    return false;
+  }
   if (body.stream !== false) return false;
   if ((body.temperature ?? 0) !== 0) return false;
   return true;

--- a/tests/unit/chat-combo-live-test.test.mjs
+++ b/tests/unit/chat-combo-live-test.test.mjs
@@ -11,6 +11,11 @@ const core = await import("../../src/lib/db/core.ts");
 const providersDb = await import("../../src/lib/db/providers.ts");
 const chatRoute = await import("../../src/app/api/v1/chat/completions/route.ts");
 const {
+  generateSignature,
+  invalidateBySignature,
+  setCachedResponse,
+} = await import("../../src/lib/semanticCache.ts");
+const {
   clearModelUnavailability,
   resetAllAvailability,
   setModelUnavailable,
@@ -40,6 +45,17 @@ async function seedSuppressedConnection() {
     isActive: true,
     testStatus: "credits_exhausted",
     rateLimitedUntil: new Date(Date.now() + 60_000).toISOString(),
+  });
+}
+
+async function seedHealthyConnection() {
+  return providersDb.createProviderConnection({
+    provider: "openai",
+    authType: "apikey",
+    name: "openai-cache-test",
+    apiKey: "sk-cache-test",
+    isActive: true,
+    testStatus: "active",
   });
 }
 
@@ -125,4 +141,68 @@ test("combo live test bypasses local cooldown and breaker state to perform a rea
 
   const updated = await providersDb.getProviderConnectionById(created.id);
   assert.equal(updated.testStatus, "active");
+});
+
+test("combo live test bypasses semantic cache and forces a fresh upstream request", async () => {
+  await seedHealthyConnection();
+
+  const signature = generateSignature(
+    "gpt-4o-mini",
+    [{ role: "user", content: "Reply with OK only." }],
+    0,
+    1
+  );
+
+  setCachedResponse(signature, "gpt-4o-mini", {
+    id: "chatcmpl-cached",
+    choices: [
+      {
+        message: {
+          role: "assistant",
+          content: "CACHED",
+        },
+      },
+    ],
+  });
+
+  const fetchCalls = [];
+  globalThis.fetch = async (url, init = {}) => {
+    fetchCalls.push({ url: String(url), init });
+    return Response.json({
+      id: "chatcmpl-live",
+      choices: [
+        {
+          message: {
+            role: "assistant",
+            content: "LIVE",
+          },
+        },
+      ],
+    });
+  };
+
+  try {
+    const cachedResponse = await chatRoute.POST(makeRequest());
+    const cachedBody = await cachedResponse.json();
+
+    assert.equal(cachedResponse.status, 200);
+    assert.equal(fetchCalls.length, 0);
+    assert.equal(cachedBody.choices[0].message.content, "CACHED");
+
+    const liveResponse = await chatRoute.POST(
+      makeRequest({
+        "X-Internal-Test": "combo-health-check",
+        "X-OmniRoute-No-Cache": "true",
+        "X-Request-Id": "combo-test-cache-bypass",
+      })
+    );
+    const liveBody = await liveResponse.json();
+
+    assert.equal(liveResponse.status, 200);
+    assert.equal(fetchCalls.length, 1);
+    assert.match(fetchCalls[0].url, /\/chat\/completions$/);
+    assert.equal(liveBody.choices[0].message.content, "LIVE");
+  } finally {
+    invalidateBySignature(signature);
+  }
 });

--- a/tests/unit/combo-test-route.test.mjs
+++ b/tests/unit/combo-test-route.test.mjs
@@ -82,6 +82,8 @@ test("combo test route marks a model healthy only when it returns assistant text
   assert.equal(fetchCalls.length, 1);
   assert.equal(fetchCalls[0].url, "http://localhost/v1/chat/completions");
   assert.equal(fetchCalls[0].init.headers["X-Internal-Test"], "combo-health-check");
+  assert.equal(fetchCalls[0].init.headers["X-OmniRoute-No-Cache"], "true");
+  assert.match(fetchCalls[0].init.headers["X-Request-Id"], /^combo-test-/);
   assert.equal(forwardedBody.model, "openrouter/openai/gpt-5.4");
   assert.equal(forwardedBody.messages[0].content, "Reply with OK only.");
   assert.equal(body.resolvedBy, "openrouter/openai/gpt-5.4");


### PR DESCRIPTION
## Summary

- force combo live tests to bypass OmniRoute semantic cache by sending `X-OmniRoute-No-Cache: true` on the internal `/v1/chat/completions` request
- attach a unique `X-Request-Id` to combo test requests so they are easier to trace and cannot accidentally reuse request-level dedup state
- fix semantic cache header handling so `X-OmniRoute-No-Cache` works for both `Headers` instances and plain header objects
- add regression coverage for the no-cache route headers and for the cached-response reproduction path

## Root Cause

After #759, combo tests no longer downgraded provider errors into reachability probes, but they could still return a fast cached `OK` without making any upstream call. The combo test prompt is fixed (`Reply with OK only.`), so repeated tests hit the semantic cache in `chatCore`. On top of that, the cache bypass flag only checked `headers.get(...)`, while the normal handler often forwarded headers as a plain object, so the no-cache signal was ignored in that path.

## What Changed

- send `X-OmniRoute-No-Cache: true` and a unique `X-Request-Id` from `/api/combos/test` to the internal chat route
- teach `isCacheable()` to read custom headers from either `Headers` or plain objects
- add a regression test that pre-populates semantic cache, reproduces the old instant-cache behavior, and verifies combo live tests now force a real upstream fetch instead

## Validation

- `node --import tsx/esm --test tests/unit/chat-combo-live-test.test.mjs tests/unit/combo-test-route.test.mjs`
- `npx eslint src/app/api/combos/test/route.ts src/lib/semanticCache.ts tests/unit/chat-combo-live-test.test.mjs tests/unit/combo-test-route.test.mjs`
