### PR TITLE
fix: missing i18n keys and streaming fetch timeout (#748, #769)

### DIFF
--- a/open-sse/executors/base.ts
+++ b/open-sse/executors/base.ts
@@ -264,13 +264,12 @@ export class BaseExecutor {
       const transformedBody = this.transformRequest(model, body, stream, credentials);
 
       try {
-        // For non-streaming requests, apply a fetch timeout to prevent stalled connections.
-        // Streaming requests skip the timeout — they use stream idle detection instead.
-        const timeoutSignal = !stream ? AbortSignal.timeout(FETCH_TIMEOUT_MS) : null;
-        const combinedSignal =
-          signal && timeoutSignal
-            ? mergeAbortSignals(signal, timeoutSignal)
-            : signal || timeoutSignal;
+        // Apply timeout to all requests. Non-streaming requests need this to prevent
+        // stalled connections. Streaming requests also need it for the initial fetch() call
+        // to prevent hanging on unresponsive providers (e.g. 300s TCP default timeout — #769).
+        // Stream idle detection (STREAM_IDLE_TIMEOUT_MS) handles stalls after data starts flowing.
+        const timeoutSignal = AbortSignal.timeout(FETCH_TIMEOUT_MS);
+        const combinedSignal = signal ? mergeAbortSignals(signal, timeoutSignal) : timeoutSignal;
 
         // Apply CLI fingerprint ordering if enabled for this provider
         let finalHeaders = headers;

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -571,7 +571,9 @@
       "cursor": "محرر كود المؤشر AI",
       "continue": "تابع مساعد الذكاء الاصطناعي",
       "opencode": "OpenCode AI coding agent (Terminal)",
-      "kiro": "Amazon Kiro — AI-powered IDE"
+      "kiro": "Amazon Kiro — AI-powered IDE",
+      "windsurf": "Windsurf AI Code Editor",
+      "copilot": "GitHub Copilot AI Assistant"
     },
     "guides": {
       "cursor": {

--- a/src/i18n/messages/bg.json
+++ b/src/i18n/messages/bg.json
@@ -571,7 +571,9 @@
       "cursor": "Cursor AI Code Editor",
       "continue": "Продължете AI Assistant",
       "opencode": "OpenCode AI coding agent (Terminal)",
-      "kiro": "Amazon Kiro — AI-powered IDE"
+      "kiro": "Amazon Kiro — AI-powered IDE",
+      "windsurf": "Windsurf AI Code Editor",
+      "copilot": "GitHub Copilot AI Assistant"
     },
     "guides": {
       "cursor": {

--- a/src/i18n/messages/cs.json
+++ b/src/i18n/messages/cs.json
@@ -643,7 +643,9 @@
       "cursor": "Cursor AI Code Editor",
       "continue": "Continue AI asistent",
       "opencode": "OpenCode AI coding agent (Terminál)",
-      "kiro": "Amazon Kiro – AI poháněné IDE"
+      "kiro": "Amazon Kiro – AI poháněné IDE",
+      "windsurf": "Windsurf AI Code Editor",
+      "copilot": "GitHub Copilot AI Assistant"
     },
     "guides": {
       "cursor": {

--- a/src/i18n/messages/da.json
+++ b/src/i18n/messages/da.json
@@ -571,7 +571,9 @@
       "cursor": "Cursor AI Code Editor",
       "continue": "Fortsæt AI Assistant",
       "opencode": "OpenCode AI coding agent (Terminal)",
-      "kiro": "Amazon Kiro — AI-powered IDE"
+      "kiro": "Amazon Kiro — AI-powered IDE",
+      "windsurf": "Windsurf AI Code Editor",
+      "copilot": "GitHub Copilot AI Assistant"
     },
     "guides": {
       "cursor": {

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -571,7 +571,9 @@
       "cursor": "Cursor-KI-Code-Editor",
       "continue": "Weiter AI Assistant",
       "opencode": "OpenCode AI coding agent (Terminal)",
-      "kiro": "Amazon Kiro — AI-powered IDE"
+      "kiro": "Amazon Kiro — AI-powered IDE",
+      "windsurf": "Windsurf AI Code Editor",
+      "copilot": "GitHub Copilot AI Assistant"
     },
     "guides": {
       "cursor": {

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -648,7 +648,9 @@
       "cursor": "Cursor AI Code Editor",
       "continue": "Continue AI Assistant",
       "opencode": "OpenCode AI coding agent (Terminal)",
-      "kiro": "Amazon Kiro — AI-powered IDE"
+      "kiro": "Amazon Kiro — AI-powered IDE",
+      "windsurf": "Windsurf AI Code Editor",
+      "copilot": "GitHub Copilot AI Assistant"
     },
     "guides": {
       "cursor": {

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -571,7 +571,9 @@
       "cursor": "Editor de código AI del cursor",
       "continue": "Continuar Asistente de IA",
       "opencode": "OpenCode AI coding agent (Terminal)",
-      "kiro": "Amazon Kiro — AI-powered IDE"
+      "kiro": "Amazon Kiro — AI-powered IDE",
+      "windsurf": "Windsurf AI Code Editor",
+      "copilot": "GitHub Copilot AI Assistant"
     },
     "guides": {
       "cursor": {

--- a/src/i18n/messages/fi.json
+++ b/src/i18n/messages/fi.json
@@ -571,7 +571,9 @@
       "cursor": "Cursor AI Code Editor",
       "continue": "Jatka AI Assistantia",
       "opencode": "OpenCode AI coding agent (Terminal)",
-      "kiro": "Amazon Kiro — AI-powered IDE"
+      "kiro": "Amazon Kiro — AI-powered IDE",
+      "windsurf": "Windsurf AI Code Editor",
+      "copilot": "GitHub Copilot AI Assistant"
     },
     "guides": {
       "cursor": {

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -571,7 +571,9 @@
       "cursor": "Éditeur de code AI du curseur",
       "continue": "Continuer l'Assistant IA",
       "opencode": "OpenCode AI coding agent (Terminal)",
-      "kiro": "Amazon Kiro — AI-powered IDE"
+      "kiro": "Amazon Kiro — AI-powered IDE",
+      "windsurf": "Windsurf AI Code Editor",
+      "copilot": "GitHub Copilot AI Assistant"
     },
     "guides": {
       "cursor": {

--- a/src/i18n/messages/he.json
+++ b/src/i18n/messages/he.json
@@ -571,7 +571,9 @@
       "cursor": "עורך קוד AI של הסמן",
       "continue": "המשך עוזר AI",
       "opencode": "OpenCode AI coding agent (Terminal)",
-      "kiro": "Amazon Kiro — AI-powered IDE"
+      "kiro": "Amazon Kiro — AI-powered IDE",
+      "windsurf": "Windsurf AI Code Editor",
+      "copilot": "GitHub Copilot AI Assistant"
     },
     "guides": {
       "cursor": {

--- a/src/i18n/messages/hi.json
+++ b/src/i18n/messages/hi.json
@@ -489,7 +489,9 @@
       "cursor": "कर्सर एआई कोड संपादक",
       "continue": "एआई असिस्टेंट जारी रखें",
       "opencode": "OpenCode AI coding agent (Terminal)",
-      "kiro": "Amazon Kiro — AI-powered IDE"
+      "kiro": "Amazon Kiro — AI-powered IDE",
+      "windsurf": "Windsurf AI Code Editor",
+      "copilot": "GitHub Copilot AI Assistant"
     },
     "guides": {
       "cursor": {

--- a/src/i18n/messages/hu.json
+++ b/src/i18n/messages/hu.json
@@ -571,7 +571,9 @@
       "cursor": "Kurzor AI kódszerkesztő",
       "continue": "Az AI-asszisztens folytatása",
       "opencode": "OpenCode AI coding agent (Terminal)",
-      "kiro": "Amazon Kiro — AI-powered IDE"
+      "kiro": "Amazon Kiro — AI-powered IDE",
+      "windsurf": "Windsurf AI Code Editor",
+      "copilot": "GitHub Copilot AI Assistant"
     },
     "guides": {
       "cursor": {

--- a/src/i18n/messages/id.json
+++ b/src/i18n/messages/id.json
@@ -571,7 +571,9 @@
       "cursor": "Editor Kode AI Kursor",
       "continue": "Lanjutkan Asisten AI",
       "opencode": "OpenCode AI coding agent (Terminal)",
-      "kiro": "Amazon Kiro — AI-powered IDE"
+      "kiro": "Amazon Kiro — AI-powered IDE",
+      "windsurf": "Windsurf AI Code Editor",
+      "copilot": "GitHub Copilot AI Assistant"
     },
     "guides": {
       "cursor": {

--- a/src/i18n/messages/in.json
+++ b/src/i18n/messages/in.json
@@ -643,7 +643,9 @@
       "cursor": "कर्सर एआई कोड संपादक",
       "continue": "एआई असिस्टेंट जारी रखें",
       "opencode": "ओपनकोड एआई कोडिंग एजेंट (टर्मिनल)",
-      "kiro": "अमेज़ॅन किरो - एआई-संचालित आईडीई"
+      "kiro": "अमेज़ॅन किरो - एआई-संचालित आईडीई",
+      "windsurf": "Windsurf AI Code Editor",
+      "copilot": "GitHub Copilot AI Assistant"
     },
     "guides": {
       "cursor": {

--- a/src/i18n/messages/it.json
+++ b/src/i18n/messages/it.json
@@ -571,7 +571,9 @@
       "cursor": "Editor del codice AI del cursore",
       "continue": "Continua Assistente AI",
       "opencode": "OpenCode AI coding agent (Terminal)",
-      "kiro": "Amazon Kiro — AI-powered IDE"
+      "kiro": "Amazon Kiro — AI-powered IDE",
+      "windsurf": "Windsurf AI Code Editor",
+      "copilot": "GitHub Copilot AI Assistant"
     },
     "guides": {
       "cursor": {

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -571,7 +571,9 @@
       "cursor": "カーソルAIコードエディター",
       "continue": "AIアシスタントを続ける",
       "opencode": "OpenCode AI coding agent (Terminal)",
-      "kiro": "Amazon Kiro — AI-powered IDE"
+      "kiro": "Amazon Kiro — AI-powered IDE",
+      "windsurf": "Windsurf AI Code Editor",
+      "copilot": "GitHub Copilot AI Assistant"
     },
     "guides": {
       "cursor": {

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -571,7 +571,9 @@
       "cursor": "커서 AI 코드 편집기",
       "continue": "AI 어시스턴트 계속하기",
       "opencode": "OpenCode AI coding agent (Terminal)",
-      "kiro": "Amazon Kiro — AI-powered IDE"
+      "kiro": "Amazon Kiro — AI-powered IDE",
+      "windsurf": "Windsurf AI Code Editor",
+      "copilot": "GitHub Copilot AI Assistant"
     },
     "guides": {
       "cursor": {

--- a/src/i18n/messages/ms.json
+++ b/src/i18n/messages/ms.json
@@ -571,7 +571,9 @@
       "cursor": "Editor Kod AI Kursor",
       "continue": "Teruskan AI Assistant",
       "opencode": "OpenCode AI coding agent (Terminal)",
-      "kiro": "Amazon Kiro — AI-powered IDE"
+      "kiro": "Amazon Kiro — AI-powered IDE",
+      "windsurf": "Windsurf AI Code Editor",
+      "copilot": "GitHub Copilot AI Assistant"
     },
     "guides": {
       "cursor": {

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -571,7 +571,9 @@
       "cursor": "Cursor AI-code-editor",
       "continue": "Ga door met AI-assistent",
       "opencode": "OpenCode AI coding agent (Terminal)",
-      "kiro": "Amazon Kiro — AI-powered IDE"
+      "kiro": "Amazon Kiro — AI-powered IDE",
+      "windsurf": "Windsurf AI Code Editor",
+      "copilot": "GitHub Copilot AI Assistant"
     },
     "guides": {
       "cursor": {

--- a/src/i18n/messages/no.json
+++ b/src/i18n/messages/no.json
@@ -571,7 +571,9 @@
       "cursor": "Cursor AI Code Editor",
       "continue": "Fortsett AI Assistant",
       "opencode": "OpenCode AI coding agent (Terminal)",
-      "kiro": "Amazon Kiro — AI-powered IDE"
+      "kiro": "Amazon Kiro — AI-powered IDE",
+      "windsurf": "Windsurf AI Code Editor",
+      "copilot": "GitHub Copilot AI Assistant"
     },
     "guides": {
       "cursor": {

--- a/src/i18n/messages/phi.json
+++ b/src/i18n/messages/phi.json
@@ -571,7 +571,9 @@
       "cursor": "Cursor AI Code Editor",
       "continue": "Ipagpatuloy ang AI Assistant",
       "opencode": "OpenCode AI coding agent (Terminal)",
-      "kiro": "Amazon Kiro — AI-powered IDE"
+      "kiro": "Amazon Kiro — AI-powered IDE",
+      "windsurf": "Windsurf AI Code Editor",
+      "copilot": "GitHub Copilot AI Assistant"
     },
     "guides": {
       "cursor": {

--- a/src/i18n/messages/pl.json
+++ b/src/i18n/messages/pl.json
@@ -571,7 +571,9 @@
       "cursor": "Edytor kodu AI kursora",
       "continue": "Kontynuuj Asystenta AI",
       "opencode": "OpenCode AI coding agent (Terminal)",
-      "kiro": "Amazon Kiro — AI-powered IDE"
+      "kiro": "Amazon Kiro — AI-powered IDE",
+      "windsurf": "Windsurf AI Code Editor",
+      "copilot": "GitHub Copilot AI Assistant"
     },
     "guides": {
       "cursor": {

--- a/src/i18n/messages/pt-BR.json
+++ b/src/i18n/messages/pt-BR.json
@@ -571,7 +571,9 @@
       "cursor": "Editor de código com IA Cursor",
       "continue": "Assistente de IA Continue",
       "opencode": "OpenCode AI coding agent (Terminal)",
-      "kiro": "Amazon Kiro — AI-powered IDE"
+      "kiro": "Amazon Kiro — IDE com IA",
+      "windsurf": "Windsurf — Editor de Código com IA",
+      "copilot": "GitHub Copilot — Assistente de IA"
     },
     "guides": {
       "cursor": {

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -571,7 +571,9 @@
       "cursor": "Editor de código do cursor AI",
       "continue": "Continuar Assistente de IA",
       "opencode": "OpenCode AI coding agent (Terminal)",
-      "kiro": "Amazon Kiro — AI-powered IDE"
+      "kiro": "Amazon Kiro — AI-powered IDE",
+      "windsurf": "Windsurf AI Code Editor",
+      "copilot": "GitHub Copilot AI Assistant"
     },
     "guides": {
       "cursor": {

--- a/src/i18n/messages/ro.json
+++ b/src/i18n/messages/ro.json
@@ -571,7 +571,9 @@
       "cursor": "Cursor AI Code Editor",
       "continue": "Continuați Asistentul AI",
       "opencode": "OpenCode AI coding agent (Terminal)",
-      "kiro": "Amazon Kiro — AI-powered IDE"
+      "kiro": "Amazon Kiro — AI-powered IDE",
+      "windsurf": "Windsurf AI Code Editor",
+      "copilot": "GitHub Copilot AI Assistant"
     },
     "guides": {
       "cursor": {

--- a/src/i18n/messages/ru.json
+++ b/src/i18n/messages/ru.json
@@ -571,7 +571,9 @@
       "cursor": "Редактор кода курсора AI",
       "continue": "Продолжить AI-помощник",
       "opencode": "OpenCode AI coding agent (Terminal)",
-      "kiro": "Amazon Kiro — AI-powered IDE"
+      "kiro": "Amazon Kiro — AI-powered IDE",
+      "windsurf": "Windsurf AI Code Editor",
+      "copilot": "GitHub Copilot AI Assistant"
     },
     "guides": {
       "cursor": {

--- a/src/i18n/messages/sk.json
+++ b/src/i18n/messages/sk.json
@@ -571,7 +571,9 @@
       "cursor": "Editor kódu AI kurzora",
       "continue": "Pokračovať v Asistentovi AI",
       "opencode": "OpenCode AI coding agent (Terminal)",
-      "kiro": "Amazon Kiro — AI-powered IDE"
+      "kiro": "Amazon Kiro — AI-powered IDE",
+      "windsurf": "Windsurf AI Code Editor",
+      "copilot": "GitHub Copilot AI Assistant"
     },
     "guides": {
       "cursor": {

--- a/src/i18n/messages/sv.json
+++ b/src/i18n/messages/sv.json
@@ -571,7 +571,9 @@
       "cursor": "Cursor AI Code Editor",
       "continue": "Fortsätt AI Assistant",
       "opencode": "OpenCode AI coding agent (Terminal)",
-      "kiro": "Amazon Kiro — AI-powered IDE"
+      "kiro": "Amazon Kiro — AI-powered IDE",
+      "windsurf": "Windsurf AI Code Editor",
+      "copilot": "GitHub Copilot AI Assistant"
     },
     "guides": {
       "cursor": {

--- a/src/i18n/messages/th.json
+++ b/src/i18n/messages/th.json
@@ -571,7 +571,9 @@
       "cursor": "ตัวแก้ไขรหัสเคอร์เซอร์ AI",
       "continue": "ดำเนินการต่อผู้ช่วย AI",
       "opencode": "OpenCode AI coding agent (Terminal)",
-      "kiro": "Amazon Kiro — AI-powered IDE"
+      "kiro": "Amazon Kiro — AI-powered IDE",
+      "windsurf": "Windsurf AI Code Editor",
+      "copilot": "GitHub Copilot AI Assistant"
     },
     "guides": {
       "cursor": {

--- a/src/i18n/messages/tr.json
+++ b/src/i18n/messages/tr.json
@@ -641,7 +641,9 @@
       "cursor": "Cursor AI Kod Düzenleyici",
       "continue": "Continue AI Asistanı",
       "opencode": "OpenCode AI kodlama ajanı (Terminal)",
-      "kiro": "Amazon Kiro - AI destekli IDE"
+      "kiro": "Amazon Kiro - AI destekli IDE",
+      "windsurf": "Windsurf AI Code Editor",
+      "copilot": "GitHub Copilot AI Assistant"
     },
     "guides": {
       "cursor": {

--- a/src/i18n/messages/uk-UA.json
+++ b/src/i18n/messages/uk-UA.json
@@ -571,7 +571,9 @@
       "cursor": "Редактор коду Cursor AI",
       "continue": "Продовжити AI Assistant",
       "opencode": "OpenCode AI coding agent (Terminal)",
-      "kiro": "Amazon Kiro — AI-powered IDE"
+      "kiro": "Amazon Kiro — AI-powered IDE",
+      "windsurf": "Windsurf AI Code Editor",
+      "copilot": "GitHub Copilot AI Assistant"
     },
     "guides": {
       "cursor": {

--- a/src/i18n/messages/vi.json
+++ b/src/i18n/messages/vi.json
@@ -571,7 +571,9 @@
       "cursor": "Trình chỉnh sửa mã AI con trỏ",
       "continue": "Tiếp tục Trợ lý AI",
       "opencode": "OpenCode AI coding agent (Terminal)",
-      "kiro": "Amazon Kiro — AI-powered IDE"
+      "kiro": "Amazon Kiro — AI-powered IDE",
+      "windsurf": "Windsurf AI Code Editor",
+      "copilot": "GitHub Copilot AI Assistant"
     },
     "guides": {
       "cursor": {

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -627,7 +627,9 @@
       "cursor": "Cursor AI 代码编辑器",
       "continue": "继续AI助手",
       "opencode": "OpenCode AI 编码智能体（终端）",
-      "kiro": "Amazon Kiro - AI 驱动 IDE"
+      "kiro": "Amazon Kiro - AI 驱动 IDE",
+      "windsurf": "Windsurf AI Code Editor",
+      "copilot": "GitHub Copilot AI Assistant"
     },
     "guides": {
       "cursor": {


### PR DESCRIPTION
## Changes

### Fix #748 — Missing i18n keys (windsurf, copilot)
- Added `windsurf` and `copilot` entries to `toolDescriptions` in all 33 locale files
- These keys were already present in `toolUseCases` but missing from `toolDescriptions`, causing `MISSING_MESSAGE` console errors on the CLI Tools page

### Fix #769 — Streaming requests fail after 300s
- Applied `FETCH_TIMEOUT_MS` (default 10min) to streaming requests' initial `fetch()` call
- Previously only non-streaming requests had timeout protection via `AbortSignal.timeout()`
- Streaming requests relied solely on stream idle detection, which doesn't cover initial connection hangs
- Node.js `fetch` has a ~300s default TCP socket timeout, causing silent failures
- Users can override via `FETCH_TIMEOUT_MS` env var

### Tests
- 1156/1156 tests pass
- Build succeeds