### PR TITLE
fix: remove auto-opening OAuth modal on provider detail page

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/[id]/page.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.tsx
@@ -802,7 +802,6 @@ export default function ProviderDetailPage() {
   const { copied, copy } = useCopyToClipboard();
   const t = useTranslations("providers");
   const notify = useNotificationStore();
-  const userDismissed = useRef(false);
   const [proxyTarget, setProxyTarget] = useState(null);
   const [proxyConfig, setProxyConfig] = useState(null);
   const [connProxyMap, setConnProxyMap] = useState<
@@ -2408,7 +2407,6 @@ export default function ProviderDetailPage() {
           providerInfo={providerInfo}
           onSuccess={handleOAuthSuccess}
           onClose={() => {
-            userDismissed.current = true;
             setShowOAuthModal(false);
           }}
         />
@@ -2417,7 +2415,6 @@ export default function ProviderDetailPage() {
           isOpen={showOAuthModal}
           onSuccess={handleOAuthSuccess}
           onClose={() => {
-            userDismissed.current = true;
             setShowOAuthModal(false);
           }}
         />
@@ -2428,7 +2425,6 @@ export default function ProviderDetailPage() {
           providerInfo={providerInfo}
           onSuccess={handleOAuthSuccess}
           onClose={() => {
-            userDismissed.current = true;
             setShowOAuthModal(false);
           }}
         />


### PR DESCRIPTION
## Summary
- Removes the `useEffect` that auto-opens the "Add Connection" (OAuth/API key) modal when navigating to a provider detail page that has zero connections
- The page already displays a clear "No connections yet" empty state with an "Add Connection" button — users should click it when ready, not be ambushed by a modal on page load

## Why
Auto-opening the modal was a poor UX pattern that surprised users simply browsing provider details, especially when re-visiting a provider after deleting a connection or checking provider settings. Navigating to a page should never trigger a blocking modal without user intent.

## Test plan
- [x] All 1157 tests pass
- [x] Lint: 0 errors (57 pre-existing warnings)
- [ ] Navigate to a provider with no connections — verify the empty state renders without auto-opening a modal
- [ ] Click "Add Connection" button — verify the modal opens correctly
- [ ] Navigate to a provider with existing connections — verify no regression in behavior