### PR TITLE
Fix cloudflared quick tunnel startup in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ ENV NODE_OPTIONS="--max-old-space-size=256"
 # Data directory inside Docker — must match the volume mount in docker-compose.yml
 ENV DATA_DIR=/app/data
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends libsecret-1-0 \
+  && apt-get install -y --no-install-recommends libsecret-1-0 ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /app/data
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:22-bookworm-slim AS builder
 WORKDIR /app
 
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends libsecret-1-0 \
+  && apt-get install -y --no-install-recommends libsecret-1-0 ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 
 COPY package*.json ./

--- a/README.md
+++ b/README.md
@@ -882,6 +882,7 @@ Notes:
 
 - Quick Tunnel URLs are temporary and change after every restart.
 - Managed install currently supports Linux, macOS, and Windows on `x64` / `arm64`.
+- Docker images bundle system CA roots and pass them to managed `cloudflared`, which avoids TLS trust failures when the tunnel bootstraps inside the container.
 - Set `CLOUDFLARED_BIN=/absolute/path/to/cloudflared` if you want OmniRoute to use an existing binary instead of downloading one.
 
 **Using Docker Compose with Caddy (HTTPS Auto-TLS):**

--- a/src/lib/cloudflaredTunnel.ts
+++ b/src/lib/cloudflaredTunnel.ts
@@ -13,6 +13,18 @@ const CLOUDFLARED_RELEASE_BASE =
   "https://github.com/cloudflare/cloudflared/releases/latest/download";
 const START_TIMEOUT_MS = 30000;
 const STOP_TIMEOUT_MS = 5000;
+const GENERIC_EXIT_ERROR_PREFIX = "cloudflared exited";
+const DEFAULT_CERT_FILE_CANDIDATES = [
+  "/etc/ssl/certs/ca-certificates.crt",
+  "/etc/pki/tls/certs/ca-bundle.crt",
+  "/etc/ssl/cert.pem",
+  "/private/etc/ssl/cert.pem",
+] as const;
+const DEFAULT_CERT_DIR_CANDIDATES = [
+  "/etc/ssl/certs",
+  "/etc/pki/tls/certs",
+  "/system/etc/security/cacerts",
+] as const;
 
 type CloudflaredInstallSource = "managed" | "path" | "env";
 type TunnelPhase = "unsupported" | "not_installed" | "stopped" | "starting" | "running" | "error";
@@ -238,9 +250,55 @@ export function extractTryCloudflareUrl(text: string) {
   return match ? match[0] : null;
 }
 
+function normalizeCloudflaredLogLine(line: string) {
+  return line
+    .trim()
+    .replace(/^\d{4}-\d{2}-\d{2}T\S+\s+(?:INF|WRN|ERR)\s+/i, "")
+    .trim();
+}
+
+export function extractCloudflaredErrorMessage(text: string) {
+  const lines = String(text || "")
+    .split(/\r?\n/)
+    .map(normalizeCloudflaredLogLine)
+    .filter(Boolean);
+
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (/(?:\berror\b|\bfailed\b|\btls:\b|\bx509\b|\bcertificate\b)/i.test(lines[i])) {
+      return lines[i];
+    }
+  }
+
+  return null;
+}
+
+function isSpecificCloudflaredError(error: string | null | undefined) {
+  return !!error && !error.startsWith(GENERIC_EXIT_ERROR_PREFIX);
+}
+
+function getGenericExitError(code: number | null, signal: NodeJS.Signals | null) {
+  return `cloudflared exited unexpectedly (${code ?? "signal"}${signal ? `/${signal}` : ""})`;
+}
+
+export function getDefaultCloudflaredCertEnv(
+  existsSync: (candidate: string) => boolean = fsSync.existsSync,
+  certFileCandidates: readonly string[] = DEFAULT_CERT_FILE_CANDIDATES,
+  certDirCandidates: readonly string[] = DEFAULT_CERT_DIR_CANDIDATES
+) {
+  const certEnv: NodeJS.ProcessEnv = {};
+  const certFile = certFileCandidates.find((candidate) => existsSync(candidate));
+  const certDir = certDirCandidates.find((candidate) => existsSync(candidate));
+
+  if (certFile) certEnv.SSL_CERT_FILE = certFile;
+  if (certDir) certEnv.SSL_CERT_DIR = certDir;
+
+  return certEnv;
+}
+
 export function buildCloudflaredChildEnv(
   sourceEnv: NodeJS.ProcessEnv = process.env,
-  runtimeDirs: CloudflaredRuntimeDirs = getCloudflaredRuntimeDirs()
+  runtimeDirs: CloudflaredRuntimeDirs = getCloudflaredRuntimeDirs(),
+  defaultCertEnv: NodeJS.ProcessEnv = getDefaultCloudflaredCertEnv()
 ): NodeJS.ProcessEnv {
   const childEnv: NodeJS.ProcessEnv = {};
 
@@ -262,6 +320,12 @@ export function buildCloudflaredChildEnv(
   if (!childEnv.TMPDIR) childEnv.TMPDIR = runtimeDirs.tempDir;
   if (!childEnv.TMP) childEnv.TMP = runtimeDirs.tempDir;
   if (!childEnv.TEMP) childEnv.TEMP = runtimeDirs.tempDir;
+  if (!childEnv.SSL_CERT_FILE && defaultCertEnv.SSL_CERT_FILE) {
+    childEnv.SSL_CERT_FILE = defaultCertEnv.SSL_CERT_FILE;
+  }
+  if (!childEnv.SSL_CERT_DIR && defaultCertEnv.SSL_CERT_DIR) {
+    childEnv.SSL_CERT_DIR = defaultCertEnv.SSL_CERT_DIR;
+  }
 
   return childEnv;
 }
@@ -447,7 +511,9 @@ async function finalizeProcessExit(code: number | null, signal: NodeJS.Signals |
   const lastError =
     code === 0 || signal === "SIGTERM" || signal === "SIGINT"
       ? null
-      : `cloudflared exited unexpectedly (${code ?? "signal"}${signal ? `/${signal}` : ""})`;
+      : isSpecificCloudflaredError(currentState.lastError)
+        ? currentState.lastError
+        : getGenericExitError(code, signal);
 
   tunnelProcess = null;
   tunnelPid = null;
@@ -562,14 +628,10 @@ export async function startCloudflaredTunnel(): Promise<CloudflaredTunnelStatus>
       startedAt: new Date().toISOString(),
     });
 
-    const child = spawn(
-      binary.binaryPath as string,
-      getCloudflaredStartArgs(targetUrl),
-      {
-        stdio: ["ignore", "pipe", "pipe"],
-        env: buildCloudflaredChildEnv(),
-      }
-    );
+    const child = spawn(binary.binaryPath as string, getCloudflaredStartArgs(targetUrl), {
+      stdio: ["ignore", "pipe", "pipe"],
+      env: buildCloudflaredChildEnv(),
+    });
 
     tunnelProcess = child;
     tunnelPid = child.pid ?? null;
@@ -597,6 +659,14 @@ export async function startCloudflaredTunnel(): Promise<CloudflaredTunnelStatus>
         if (!text) return;
 
         await appendTunnelLog(source, text);
+        const errorMessage = source === "stderr" ? extractCloudflaredErrorMessage(text) : null;
+        if (errorMessage) {
+          await updateStateFile({
+            pid: child.pid,
+            status: "error",
+            lastError: errorMessage,
+          });
+        }
         const url = extractTryCloudflareUrl(text);
         if (!url) return;
 
@@ -643,11 +713,18 @@ export async function startCloudflaredTunnel(): Promise<CloudflaredTunnelStatus>
   try {
     return await startPromise;
   } catch (error) {
+    const currentState = await readStateFile();
+    const message = isSpecificCloudflaredError(currentState.lastError)
+      ? currentState.lastError
+      : error instanceof Error
+        ? error.message
+        : "Failed to start cloudflared tunnel";
+
     await updateStateFile({
       status: "error",
-      lastError: error instanceof Error ? error.message : "Failed to start cloudflared tunnel",
+      lastError: message,
     });
-    throw error;
+    throw new Error(message);
   } finally {
     startPromise = null;
   }

--- a/tests/unit/cloudflaredTunnel.test.mjs
+++ b/tests/unit/cloudflaredTunnel.test.mjs
@@ -3,7 +3,9 @@ import assert from "node:assert/strict";
 
 import {
   buildCloudflaredChildEnv,
+  extractCloudflaredErrorMessage,
   extractTryCloudflareUrl,
+  getDefaultCloudflaredCertEnv,
   getCloudflaredStartArgs,
   getCloudflaredAssetSpec,
 } from "../../src/lib/cloudflaredTunnel.ts";
@@ -18,6 +20,17 @@ test("extractTryCloudflareUrl parses trycloudflare URL from log output", () => {
 
 test("extractTryCloudflareUrl returns null when no tunnel URL is present", () => {
   assert.equal(extractTryCloudflareUrl("cloudflared starting without assigned URL"), null);
+});
+
+test("extractCloudflaredErrorMessage keeps the actionable stderr line", () => {
+  const error = extractCloudflaredErrorMessage(
+    '2026-03-30T19:56:12Z INF Requesting new quick Tunnel on trycloudflare.com...\n2026-03-30T19:56:12Z ERR failed to request quick Tunnel: Post "https://api.trycloudflare.com/tunnel": tls: failed to verify certificate: x509: certificate signed by unknown authority'
+  );
+
+  assert.equal(
+    error,
+    'failed to request quick Tunnel: Post "https://api.trycloudflare.com/tunnel": tls: failed to verify certificate: x509: certificate signed by unknown authority'
+  );
 });
 
 test("getCloudflaredAssetSpec resolves linux amd64 binary", () => {
@@ -49,22 +62,26 @@ test("getCloudflaredAssetSpec returns null for unsupported platforms", () => {
 });
 
 test("buildCloudflaredChildEnv keeps runtime essentials, isolates runtime dirs, and drops secrets", () => {
-  const env = buildCloudflaredChildEnv({
-    PATH: "/usr/bin",
-    HTTPS_PROXY: "http://proxy.internal:8080",
-    JWT_SECRET: "top-secret",
-    API_KEY_SECRET: "another-secret",
-  }, {
-    runtimeRoot: "/managed/runtime",
-    homeDir: "/managed/runtime/home",
-    configDir: "/managed/runtime/config",
-    cacheDir: "/managed/runtime/cache",
-    dataDir: "/managed/runtime/data",
-    tempDir: "/managed/runtime/tmp",
-    userProfileDir: "/managed/runtime/userprofile",
-    appDataDir: "/managed/runtime/userprofile/AppData/Roaming",
-    localAppDataDir: "/managed/runtime/userprofile/AppData/Local",
-  });
+  const env = buildCloudflaredChildEnv(
+    {
+      PATH: "/usr/bin",
+      HTTPS_PROXY: "http://proxy.internal:8080",
+      JWT_SECRET: "top-secret",
+      API_KEY_SECRET: "another-secret",
+    },
+    {
+      runtimeRoot: "/managed/runtime",
+      homeDir: "/managed/runtime/home",
+      configDir: "/managed/runtime/config",
+      cacheDir: "/managed/runtime/cache",
+      dataDir: "/managed/runtime/data",
+      tempDir: "/managed/runtime/tmp",
+      userProfileDir: "/managed/runtime/userprofile",
+      appDataDir: "/managed/runtime/userprofile/AppData/Roaming",
+      localAppDataDir: "/managed/runtime/userprofile/AppData/Local",
+    },
+    {}
+  );
 
   assert.deepEqual(env, {
     PATH: "/usr/bin",
@@ -80,6 +97,41 @@ test("buildCloudflaredChildEnv keeps runtime essentials, isolates runtime dirs, 
     TMP: "/managed/runtime/tmp",
     TEMP: "/managed/runtime/tmp",
   });
+});
+
+test("getDefaultCloudflaredCertEnv detects common CA bundle paths", () => {
+  const env = getDefaultCloudflaredCertEnv((candidate) =>
+    ["/etc/ssl/certs/ca-certificates.crt", "/etc/ssl/certs"].includes(candidate)
+  );
+
+  assert.deepEqual(env, {
+    SSL_CERT_FILE: "/etc/ssl/certs/ca-certificates.crt",
+    SSL_CERT_DIR: "/etc/ssl/certs",
+  });
+});
+
+test("buildCloudflaredChildEnv injects discovered CA paths when the parent env omits them", () => {
+  const env = buildCloudflaredChildEnv(
+    { PATH: "/usr/bin" },
+    {
+      runtimeRoot: "/managed/runtime",
+      homeDir: "/managed/runtime/home",
+      configDir: "/managed/runtime/config",
+      cacheDir: "/managed/runtime/cache",
+      dataDir: "/managed/runtime/data",
+      tempDir: "/managed/runtime/tmp",
+      userProfileDir: "/managed/runtime/userprofile",
+      appDataDir: "/managed/runtime/userprofile/AppData/Roaming",
+      localAppDataDir: "/managed/runtime/userprofile/AppData/Local",
+    },
+    {
+      SSL_CERT_FILE: "/etc/ssl/certs/ca-certificates.crt",
+      SSL_CERT_DIR: "/etc/ssl/certs",
+    }
+  );
+
+  assert.equal(env.SSL_CERT_FILE, "/etc/ssl/certs/ca-certificates.crt");
+  assert.equal(env.SSL_CERT_DIR, "/etc/ssl/certs");
 });
 
 test("getCloudflaredStartArgs relies on cloudflared protocol auto-negotiation", () => {


### PR DESCRIPTION
## Summary
- keep the actionable cloudflared startup error instead of collapsing everything into a generic exit code message
- detect and pass common CA certificate bundle paths to the managed cloudflared process
- install `ca-certificates` in the Docker runtime image so quick tunnels can start inside `runner-base`

## Root Cause
The UI error surfaced only the generic process exit, which hid the real failure reason. In Docker, the runtime image also lacked system CA certificates, so cloudflared could not verify Cloudflare's TLS chain when requesting a Quick Tunnel.

## Validation
- `node --import tsx/esm --test tests/unit/cloudflaredTunnel.test.mjs`
- commit hook `npm run test:unit`
- Docker + Playwright browser click against `/dashboard/endpoint` using the repo `data/` directory
- browser-triggered `POST /api/tunnels/cloudflared` returned `200` and the response contained a live `https://*.trycloudflare.com/v1` URL
