### PR TITLE
Restore Codex fast tier toggle visibility in light mode

### DIFF
--- a/src/app/(dashboard)/dashboard/settings/components/CodexServiceTierTab.tsx
+++ b/src/app/(dashboard)/dashboard/settings/components/CodexServiceTierTab.tsx
@@ -84,8 +84,10 @@ export default function CodexServiceTierTab() {
         <button
           onClick={() => save(!enabled)}
           disabled={loading || saving}
-          className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-            enabled ? "bg-sky-500" : "bg-white/10"
+          className={`relative inline-flex h-6 w-11 items-center rounded-full border transition-colors ${
+            enabled
+              ? "bg-sky-500 border-sky-500"
+              : "bg-black/10 border-black/10 dark:bg-white/10 dark:border-white/10"
           }`}
         >
           <span


### PR DESCRIPTION
## Summary
- restore a visible light-mode track for the Codex Fast Service Tier toggle in Settings
- add an explicit border to the control so the off state remains visible instead of blending into the page background
- preserve the existing enabled-state styling and behavior

## Why
The toggle's disabled track used a translucent white background without a corresponding light-theme border. In light mode, that made the control effectively disappear unless it was already enabled.

## Impact
The Codex Fast Service Tier control is now clearly visible in both light and dark themes, making the setting discoverable and usable in the default dashboard theme.

## Validation
- `npm run lint -- 'src/app/(dashboard)/dashboard/settings/components/CodexServiceTierTab.tsx'` (passes; existing repository warnings remain outside this change)
