### PR TITLE
Refine pipeline logging and add count-based rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,21 +21,23 @@
 - **Provider Quota & Token Parsing:** Switched Antigravity limits to use `retrieveUserQuota` natively and correctly mapped Claude token refresh payloads to URL-encoded forms (#862)
 - **Rate-Limiting Stability:** Universalized the 429 Retry-After parsing architecture to cap provider-induced cooldowns at 24 hours max (#862)
 - **Dashboard Limit Rendering:** Re-architected `/dashboard/limits` quota mapping to render immediately inside chunks, fixing a major UI freezing delay on accounts exceeding 70 active connections (#784)
+- **Pipeline Log UX:** Renamed the dashboard toggle to Pipeline Logs, removed the redundant helper copy, and dropped the duplicated `SOURCE REQUEST` capture stage from request debug artifacts.
 
 ### ⚠️ Breaking Changes
 
 - **Request Log Layout:** Removed the old multi-file `DATA_DIR/logs/` request log sessions and the `DATA_DIR/log.txt` summary file. New requests are written as single JSON artifacts in `DATA_DIR/call_logs/YYYY-MM-DD/`.
-- **Logging Environment Variables:** Replaced `LOG_*`, `ENABLE_REQUEST_LOGS`, `CALL_LOGS_MAX`, `CALL_LOG_PAYLOAD_MODE`, and `PROXY_LOG_MAX_ENTRIES` with the new `APP_LOG_*` and `CALL_LOG_RETENTION_DAYS` configuration model.
+- **Logging Environment Variables:** Replaced `LOG_*`, `ENABLE_REQUEST_LOGS`, `CALL_LOGS_MAX`, `CALL_LOG_PAYLOAD_MODE`, and `PROXY_LOG_MAX_ENTRIES` with the new `APP_LOG_*`, `CALL_LOG_RETENTION_DAYS`, and `CALL_LOG_MAX_FILES` configuration model.
 - **Pipeline Toggle Setting:** Replaced the legacy `detailed_logs_enabled` setting with `call_log_pipeline_enabled`. New pipeline details are embedded inside the request artifact instead of being stored as separate `request_detail_logs` records.
 
 ### 🛠️ Maintenance
 
 - **Legacy Request Log Upgrade Backup:** Upgrades now archive old `data/logs/`, legacy `data/call_logs/`, and `data/log.txt` layouts into `DATA_DIR/log_archives/*.zip` before removing the deprecated structure.
+- **Log Rotation Controls:** Added archive-count rotation for app logs and file-count rotation for call log artifacts, both enforced alongside day-based retention.
 - **Streaming Usage Persistence:** Streaming requests now write a single `usage_history` row on completion instead of emitting a duplicate in-progress usage row with empty status metadata.
 
 ---
 
-## [3.3.11] - 2026-03-31
+## [3.4.0] - 2026-03-31
 
 ### 🚀 Features
 

--- a/README.md
+++ b/README.md
@@ -42,9 +42,11 @@ _Your universal API proxy — one endpoint, 67+ providers, zero downtime. Now wi
 >   - `APP_LOG_FILE_PATH`
 >   - `APP_LOG_MAX_FILE_SIZE`
 >   - `APP_LOG_RETENTION_DAYS`
+>   - `APP_LOG_MAX_FILES`
 >   - `APP_LOG_LEVEL`
 >   - `APP_LOG_FORMAT`
 >   - `CALL_LOG_RETENTION_DAYS`
+>   - `CALL_LOG_MAX_FILES`
 >
 > For release details and upgrade notes, see the [CHANGELOG](CHANGELOG.md).
 
@@ -415,7 +417,7 @@ When a call fails, the dev doesn't know if it was a rate limit, expired token, w
 - **SQLite Proxy Logs** — Persistent logs that survive server restarts
 - **Translator Playground** — 4 debugging modes: Playground (format translation), Chat Tester (round-trip), Test Bench (batch), Live Monitor (real-time)
 - **Request Telemetry** — p50/p95/p99 latency + X-Request-Id tracing
-- **File-Based Logging with Rotation** — Console interceptor captures everything to JSON log with size-based rotation
+- **File-Based Logging with Rotation** — App logs rotate by size, retention days, and archive count; call log artifacts rotate by retention days and file count
 - **System Info Report** — `npm run system-info` generates `system-info.txt` with your full environment (Node version, OmniRoute version, OS, CLI tools, Docker/PM2 status). Attach it when reporting issues for instant triage.
 
 </details>
@@ -1838,6 +1840,11 @@ opencode
 - Request artifacts are written to `DATA_DIR/call_logs/` as one JSON file per request
 - Enable pipeline capture from Dashboard → Logs → Request Logs if you need detailed per-stage payloads
 - Set `APP_LOG_TO_FILE=true` if you also want application console logs in `logs/application/app.log`
+
+**Console log file is empty**
+
+- Set `APP_LOG_TO_FILE=true` in `.env`
+- Adjust `APP_LOG_MAX_FILE_SIZE`, `APP_LOG_RETENTION_DAYS`, and `APP_LOG_MAX_FILES` as needed
 
 **Connection test shows "Invalid" for OpenAI-compatible providers**
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: OmniRoute API
-  version: 3.3.11
+  version: 3.4.0
   description: |
     OmniRoute is a local-first AI API proxy router. It provides an OpenAI-compatible
     endpoint that routes requests to multiple AI providers with load balancing,

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -646,9 +646,6 @@ export async function handleChatCore({
     );
   }
 
-  // 1. Log raw request from client
-  reqLogger.logRawRequest(body);
-
   log?.debug?.("FORMAT", `${sourceFormat} → ${targetFormat} | stream=${stream}`);
 
   // ── Common input sanitization (runs for ALL paths including passthrough) ──

--- a/open-sse/utils/requestLogger.ts
+++ b/open-sse/utils/requestLogger.ts
@@ -9,7 +9,6 @@ type HeaderInput =
 
 export type RequestPipelinePayloads = {
   clientRawRequest?: JsonRecord;
-  sourceRequest?: JsonRecord;
   openaiRequest?: JsonRecord;
   providerRequest?: JsonRecord;
   providerResponse?: JsonRecord;
@@ -25,7 +24,6 @@ export type RequestPipelinePayloads = {
 type RequestLogger = {
   sessionPath: null;
   logClientRawRequest: (endpoint: unknown, body: unknown, headers?: HeaderInput) => void;
-  logRawRequest: (body: unknown, headers?: HeaderInput) => void;
   logOpenAIRequest: (body: unknown) => void;
   logTargetRequest: (url: unknown, headers: HeaderInput, body: unknown) => void;
   logProviderResponse: (
@@ -115,7 +113,6 @@ function createNoOpLogger(): RequestLogger {
   return {
     sessionPath: null,
     logClientRawRequest() {},
-    logRawRequest() {},
     logOpenAIRequest() {},
     logTargetRequest() {},
     logProviderResponse() {},
@@ -147,14 +144,6 @@ export async function createRequestLogger(
       payloads.clientRawRequest = {
         timestamp: new Date().toISOString(),
         endpoint,
-        headers: maskSensitiveHeaders(headers),
-        body,
-      };
-    },
-
-    logRawRequest(body, headers = {}) {
-      payloads.sourceRequest = {
-        timestamp: new Date().toISOString(),
         headers: maskSensitiveHeaders(headers),
         body,
       };

--- a/src/app/api/logs/console/route.ts
+++ b/src/app/api/logs/console/route.ts
@@ -12,7 +12,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { readFileSync, existsSync } from "fs";
-import { getAppLogFilePath } from "@/lib/logEnv";
+import { getAppLogConfig } from "@/lib/logEnv";
 
 const LEVEL_ORDER: Record<string, number> = {
   trace: 5,
@@ -34,7 +34,7 @@ const NUMERIC_LEVEL_MAP: Record<number, string> = {
 };
 
 function getLogFilePath(): string {
-  return getAppLogFilePath();
+  return getAppLogConfig().logFilePath;
 }
 
 function parseLevel(raw: string | number): string {

--- a/src/app/api/translator/load/route.ts
+++ b/src/app/api/translator/load/route.ts
@@ -17,7 +17,6 @@ export async function GET(request) {
     // Security: only allow specific filenames
     const allowedFiles = [
       "1_req_client.json",
-      "2_req_source.json",
       "3_req_openai.json",
       "4_req_target.json",
       "5_res_provider.txt",

--- a/src/app/api/translator/save/route.ts
+++ b/src/app/api/translator/save/route.ts
@@ -31,7 +31,6 @@ export async function POST(request) {
     // Security: only allow specific filenames
     const allowedFiles = [
       "1_req_client.json",
-      "2_req_source.json",
       "3_req_openai.json",
       "4_req_target.json",
       "5_res_provider.txt",

--- a/src/lib/compliance/index.ts
+++ b/src/lib/compliance/index.ts
@@ -10,7 +10,7 @@
  */
 
 import { getDbInstance } from "../db/core";
-import { getAppLogRetentionDays, getCallLogRetentionDays } from "../logEnv";
+import { getAppLogConfig, getCallLogConfig } from "../logEnv";
 
 /** @returns {import("better-sqlite3").Database | null} */
 function getDb() {
@@ -215,8 +215,8 @@ export function isNoLog(apiKeyId: string) {
  */
 export function getRetentionDays() {
   return {
-    app: getAppLogRetentionDays(),
-    call: getCallLogRetentionDays(),
+    app: getAppLogConfig().retentionDays,
+    call: getCallLogConfig().retentionDays,
   };
 }
 
@@ -237,8 +237,8 @@ export function getRetentionDays() {
  */
 export function cleanupExpiredLogs() {
   const db = getDb();
-  const appRetentionDays = getAppLogRetentionDays();
-  const callRetentionDays = getCallLogRetentionDays();
+  const appRetentionDays = getAppLogConfig().retentionDays;
+  const callRetentionDays = getCallLogConfig().retentionDays;
 
   if (!db) {
     return {

--- a/src/lib/consoleInterceptor.ts
+++ b/src/lib/consoleInterceptor.ts
@@ -12,10 +12,11 @@
 
 import { appendFileSync, existsSync, mkdirSync } from "fs";
 import { dirname, resolve } from "path";
-import { getAppLogFilePath, getAppLogToFile } from "./logEnv";
+import { getAppLogConfig } from "./logEnv";
 
-const logToFile = getAppLogToFile();
-const logFilePath = resolve(getAppLogFilePath());
+const appLogConfig = getAppLogConfig();
+const logToFile = appLogConfig.logToFile;
+const logFilePath = resolve(appLogConfig.logFilePath);
 
 declare global {
   var __omnirouteConsoleInterceptorInit: boolean | undefined;

--- a/src/lib/logEnv.ts
+++ b/src/lib/logEnv.ts
@@ -1,9 +1,11 @@
 import path from "path";
 
-const DEFAULT_APP_LOG_RETENTION_DAYS = 7;
-const DEFAULT_CALL_LOG_RETENTION_DAYS = 7;
-const DEFAULT_APP_LOG_MAX_SIZE = 50 * 1024 * 1024;
 const DEFAULT_APP_LOG_PATH = path.join(process.cwd(), "logs", "application", "app.log");
+const DEFAULT_APP_LOG_MAX_SIZE = 50 * 1024 * 1024;
+const DEFAULT_APP_LOG_RETENTION_DAYS = 7;
+const DEFAULT_APP_LOG_MAX_FILES = 20;
+const DEFAULT_CALL_LOG_RETENTION_DAYS = 7;
+const DEFAULT_CALL_LOG_MAX_FILES = 10000;
 
 function parsePositiveInt(value: string | undefined, fallback: number): number {
   if (!value) return fallback;
@@ -15,8 +17,9 @@ export function parseFileSize(raw: string | undefined): number {
   if (!raw) return DEFAULT_APP_LOG_MAX_SIZE;
   const match = raw.match(/^(\d+)\s*(k|m|g|kb|mb|gb)?$/i);
   if (!match) return DEFAULT_APP_LOG_MAX_SIZE;
-  const num = parseInt(match[1], 10);
+  const num = Number.parseInt(match[1], 10);
   const unit = (match[2] || "").toLowerCase();
+
   switch (unit) {
     case "k":
     case "kb":
@@ -48,8 +51,16 @@ export function getAppLogRetentionDays(): number {
   return parsePositiveInt(process.env.APP_LOG_RETENTION_DAYS, DEFAULT_APP_LOG_RETENTION_DAYS);
 }
 
+export function getAppLogMaxFiles(): number {
+  return parsePositiveInt(process.env.APP_LOG_MAX_FILES, DEFAULT_APP_LOG_MAX_FILES);
+}
+
 export function getCallLogRetentionDays(): number {
   return parsePositiveInt(process.env.CALL_LOG_RETENTION_DAYS, DEFAULT_CALL_LOG_RETENTION_DAYS);
+}
+
+export function getCallLogMaxFiles(): number {
+  return parsePositiveInt(process.env.CALL_LOG_MAX_FILES, DEFAULT_CALL_LOG_MAX_FILES);
 }
 
 export function getAppLogLevel(defaultLevel: string): string {
@@ -58,4 +69,23 @@ export function getAppLogLevel(defaultLevel: string): string {
 
 export function getAppLogFormat(defaultFormat: string): string {
   return process.env.APP_LOG_FORMAT || defaultFormat;
+}
+
+export function getAppLogConfig() {
+  return {
+    level: process.env.APP_LOG_LEVEL,
+    format: getAppLogFormat("text"),
+    logToFile: getAppLogToFile(),
+    logFilePath: getAppLogFilePath(),
+    maxFileSize: getAppLogMaxFileSize(),
+    retentionDays: getAppLogRetentionDays(),
+    maxFiles: getAppLogMaxFiles(),
+  };
+}
+
+export function getCallLogConfig() {
+  return {
+    retentionDays: getCallLogRetentionDays(),
+    maxFiles: getCallLogMaxFiles(),
+  };
 }

--- a/src/lib/logRotation.ts
+++ b/src/lib/logRotation.ts
@@ -4,6 +4,7 @@
  * Handles:
  *   - Rotating log files when they exceed max size
  *   - Cleaning up old log files past retention period
+ *   - Capping the number of rotated log files kept on disk
  *   - Creating the log directory on startup
  *
  * Configuration via env vars:
@@ -11,24 +12,15 @@
  *   - APP_LOG_FILE_PATH: path to log file (default: logs/application/app.log)
  *   - APP_LOG_MAX_FILE_SIZE: max file size before rotation (default: 50MB)
  *   - APP_LOG_RETENTION_DAYS: days to keep old logs (default: 7)
+ *   - APP_LOG_MAX_FILES: max number of rotated log files to keep (default: 20)
  */
 
 import { existsSync, mkdirSync, statSync, renameSync, readdirSync, unlinkSync } from "fs";
-import { dirname, join, basename, extname } from "path";
-import {
-  getAppLogFilePath,
-  getAppLogMaxFileSize,
-  getAppLogRetentionDays,
-  getAppLogToFile,
-} from "./logEnv";
+import { dirname, basename, extname, join } from "path";
+import { getAppLogConfig } from "./logEnv";
 
 export function getLogConfig() {
-  const logToFile = getAppLogToFile();
-  const logFilePath = getAppLogFilePath() || join(process.cwd(), "logs/application/app.log");
-  const maxFileSize = getAppLogMaxFileSize();
-  const retentionDays = getAppLogRetentionDays();
-
-  return { logToFile, logFilePath, maxFileSize, retentionDays };
+  return getAppLogConfig();
 }
 
 /**
@@ -101,6 +93,44 @@ export function cleanupOldLogs(logFilePath: string, retentionDays: number): void
 }
 
 /**
+ * Keep only the newest rotated files up to the configured count limit.
+ */
+export function cleanupOverflowLogs(logFilePath: string, maxFiles: number): void {
+  try {
+    const dir = dirname(logFilePath);
+    if (!existsSync(dir) || maxFiles < 1) return;
+
+    const ext = extname(logFilePath);
+    const base = basename(logFilePath, ext);
+    const rotatedFiles = readdirSync(dir)
+      .filter(
+        (file) =>
+          file !== basename(logFilePath) && file.startsWith(base + ".") && file.endsWith(ext)
+      )
+      .map((file) => {
+        const filePath = join(dir, file);
+        try {
+          return { file, filePath, mtimeMs: statSync(filePath).mtimeMs };
+        } catch {
+          return null;
+        }
+      })
+      .filter((entry): entry is { file: string; filePath: string; mtimeMs: number } => !!entry)
+      .sort((a, b) => b.mtimeMs - a.mtimeMs);
+
+    for (const entry of rotatedFiles.slice(maxFiles)) {
+      try {
+        unlinkSync(entry.filePath);
+      } catch {
+        // Best effort only.
+      }
+    }
+  } catch {
+    // Cleanup is best-effort
+  }
+}
+
+/**
  * Initialize log rotation — call once at application startup.
  * Creates directories, rotates if needed, and cleans up old files.
  */
@@ -111,4 +141,5 @@ export function initLogRotation(): void {
   ensureLogDir(config.logFilePath);
   rotateIfNeeded(config.logFilePath, config.maxFileSize);
   cleanupOldLogs(config.logFilePath, config.retentionDays);
+  cleanupOverflowLogs(config.logFilePath, config.maxFiles);
 }

--- a/src/lib/usage/callLogs.ts
+++ b/src/lib/usage/callLogs.ts
@@ -21,7 +21,7 @@ import {
   parseStoredPayload,
   serializePayloadForStorage,
 } from "../logPayloads";
-import { getCallLogRetentionDays } from "../logEnv";
+import { getCallLogConfig } from "../logEnv";
 
 type JsonRecord = Record<string, unknown>;
 
@@ -230,6 +230,7 @@ function writeCallArtifact(artifact: CallLogArtifact): string | null {
   try {
     fs.mkdirSync(path.dirname(absPath), { recursive: true });
     fs.writeFileSync(absPath, JSON.stringify(artifact, null, 2));
+    rotateCallLogs();
     return relPath;
   } catch (error) {
     console.error("[callLogs] Failed to write request artifact:", (error as Error).message);
@@ -377,13 +378,77 @@ export async function saveCallLog(entry: any) {
   }
 }
 
+function cleanupEmptyCallLogDirs() {
+  if (!CALL_LOGS_DIR || !fs.existsSync(CALL_LOGS_DIR)) return;
+
+  try {
+    for (const entry of fs.readdirSync(CALL_LOGS_DIR)) {
+      const entryPath = path.join(CALL_LOGS_DIR, entry);
+      const stat = fs.statSync(entryPath);
+      if (!stat.isDirectory()) continue;
+      if (fs.readdirSync(entryPath).length === 0) {
+        fs.rmSync(entryPath, { recursive: true, force: true });
+      }
+    }
+  } catch {
+    // Best effort only.
+  }
+}
+
+export function cleanupOverflowCallLogFiles(baseDir = CALL_LOGS_DIR, maxFiles?: number) {
+  if (!baseDir || !fs.existsSync(baseDir)) return;
+
+  const limit = maxFiles ?? getCallLogConfig().maxFiles;
+  if (!Number.isInteger(limit) || limit < 1) return;
+
+  try {
+    const files = fs
+      .readdirSync(baseDir)
+      .flatMap((entry) => {
+        const entryPath = path.join(baseDir, entry);
+        try {
+          const stat = fs.statSync(entryPath);
+          if (!stat.isDirectory()) return [];
+
+          return fs
+            .readdirSync(entryPath)
+            .filter((file) => file.endsWith(".json"))
+            .map((file) => {
+              const filePath = path.join(entryPath, file);
+              const fileStat = fs.statSync(filePath);
+              return { filePath, mtimeMs: fileStat.mtimeMs };
+            });
+        } catch {
+          return [];
+        }
+      })
+      .sort((a, b) => b.mtimeMs - a.mtimeMs);
+
+    for (const file of files.slice(limit)) {
+      try {
+        fs.rmSync(file.filePath, { force: true });
+      } catch {
+        // Best effort only.
+      }
+    }
+
+    cleanupEmptyCallLogDirs();
+  } catch (err: any) {
+    console.error("[callLogs] Failed to prune overflow files:", err.message);
+  }
+}
+
+/**
+ * Rotate old call log directories and prune excess files.
+ */
 export function rotateCallLogs() {
   if (!CALL_LOGS_DIR || !fs.existsSync(CALL_LOGS_DIR)) return;
 
   try {
     const entries = fs.readdirSync(CALL_LOGS_DIR);
     const now = Date.now();
-    const retentionMs = getCallLogRetentionDays() * 24 * 60 * 60 * 1000;
+    const { retentionDays, maxFiles } = getCallLogConfig();
+    const retentionMs = retentionDays * 24 * 60 * 60 * 1000;
 
     for (const entry of entries) {
       const entryPath = path.join(CALL_LOGS_DIR, entry);
@@ -392,8 +457,10 @@ export function rotateCallLogs() {
         fs.rmSync(entryPath, { recursive: true, force: true });
       }
     }
-  } catch (error) {
-    console.error("[callLogs] Failed to rotate request artifacts:", (error as Error).message);
+
+    cleanupOverflowCallLogFiles(CALL_LOGS_DIR, maxFiles);
+  } catch (err: any) {
+    console.error("[callLogs] Failed to rotate logs:", err.message);
   }
 }
 

--- a/src/shared/components/RequestLoggerDetail.tsx
+++ b/src/shared/components/RequestLoggerDetail.tsx
@@ -94,7 +94,6 @@ export default function RequestLoggerDetail({ log, detail, loading, onClose, onC
     ? [
         ["clientRawRequest", "Client Raw Request"],
         ["clientRequest", "Client Request"],
-        ["sourceRequest", "Source Request"],
         ["openaiRequest", "OpenAI Request"],
         ["providerRequest", "Provider Request"],
         ["providerResponse", "Provider Response"],

--- a/src/shared/components/RequestLoggerV2.tsx
+++ b/src/shared/components/RequestLoggerV2.tsx
@@ -95,7 +95,6 @@ export default function RequestLoggerV2() {
   const [detailData, setDetailData] = useState(null);
   const [detailLoggingEnabled, setDetailLoggingEnabled] = useState(false);
   const [detailLoggingLoading, setDetailLoggingLoading] = useState(false);
-  const [detailLoggingReady, setDetailLoggingReady] = useState(false);
   const intervalRef = useRef(null);
   const hasLoadedRef = useRef(false);
   const [providerNodes, setProviderNodes] = useState([]);
@@ -173,7 +172,6 @@ export default function RequestLoggerV2() {
       .then((data) => {
         if (!data) return;
         setDetailLoggingEnabled(data.enabled === true);
-        setDetailLoggingReady(true);
       })
       .catch(() => {});
   }, []);
@@ -258,11 +256,10 @@ export default function RequestLoggerV2() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ enabled: nextEnabled }),
       });
-      if (!res.ok) throw new Error("Failed to update detailed logging");
+      if (!res.ok) throw new Error("Failed to update pipeline logging");
       setDetailLoggingEnabled(nextEnabled);
-      setDetailLoggingReady(true);
     } catch (error) {
-      console.error("Failed to toggle detailed logging:", error);
+      console.error("Failed to toggle pipeline logging:", error);
     } finally {
       setDetailLoggingLoading(false);
     }
@@ -315,24 +312,17 @@ export default function RequestLoggerV2() {
               ? "bg-amber-500/10 border-amber-500/30 text-amber-700 dark:text-amber-300"
               : "bg-bg-subtle border-border text-text-muted"
           }`}
-          title="Capture per-request pipeline payloads inside the unified call log artifact"
+          title="Capture pipeline payloads for new requests"
         >
           <span
             className={`w-2 h-2 rounded-full ${detailLoggingEnabled ? "bg-amber-500" : "bg-text-muted"}`}
           />
           {detailLoggingLoading
-            ? "Updating detailed logs..."
+            ? "Updating pipeline logs..."
             : detailLoggingEnabled
-              ? "Detailed Logs On"
-              : "Detailed Logs Off"}
+              ? "Pipeline Logs On"
+              : "Pipeline Logs Off"}
         </button>
-
-        {detailLoggingReady && (
-          <span className="text-[11px] text-text-muted">
-            New requests will {detailLoggingEnabled ? "" : "not "}capture client/provider pipeline
-            payloads.
-          </span>
-        )}
 
         {/* Search */}
         <div className="flex-1 min-w-[200px] relative">
@@ -769,8 +759,8 @@ export default function RequestLoggerV2() {
       </Card>
 
       <div className="text-[10px] text-text-muted italic">
-        Each request is also saved as a single JSON artifact in{" "}
-        <code>{`{DATA_DIR}/call_logs/`}</code>.
+        Call logs are also saved as JSON files to <code>{`{DATA_DIR}/call_logs/`}</code> and rotated
+        by <code>CALL_LOG_RETENTION_DAYS</code> and <code>CALL_LOG_MAX_FILES</code>.
       </div>
 
       {/* Detail Modal */}

--- a/src/shared/utils/logger.ts
+++ b/src/shared/utils/logger.ts
@@ -16,12 +16,13 @@
 import pino from "pino";
 import { resolve } from "path";
 import { getLogConfig, initLogRotation } from "@/lib/logRotation";
-import { getAppLogLevel } from "@/lib/logEnv";
+import { getAppLogConfig } from "@/lib/logEnv";
 
 const isDev = process.env.NODE_ENV !== "production";
+const appLogConfig = getAppLogConfig();
 
 const baseConfig: pino.LoggerOptions = {
-  level: getAppLogLevel(isDev ? "debug" : "info"),
+  level: appLogConfig.level || (isDev ? "debug" : "info"),
   base: { service: "omniroute" },
   timestamp: pino.stdTimeFunctions.isoTime,
   formatters: {

--- a/src/shared/utils/structuredLogger.ts
+++ b/src/shared/utils/structuredLogger.ts
@@ -14,7 +14,7 @@
 import { getCorrelationId } from "../middleware/correlationId";
 import { appendFileSync, existsSync, mkdirSync } from "fs";
 import { dirname, resolve } from "path";
-import { getAppLogFilePath, getAppLogLevel, getAppLogToFile } from "@/lib/logEnv";
+import { getAppLogConfig } from "@/lib/logEnv";
 
 const LOG_LEVELS: Record<string, number> = {
   debug: 10,
@@ -24,12 +24,13 @@ const LOG_LEVELS: Record<string, number> = {
   fatal: 50,
 };
 
-const currentLevel = LOG_LEVELS[getAppLogLevel("info").toLowerCase() || ""] || LOG_LEVELS.info;
+const appLogConfig = getAppLogConfig();
+const currentLevel = LOG_LEVELS[appLogConfig.level?.toLowerCase() || ""] || LOG_LEVELS.info;
 const isProduction = process.env.NODE_ENV === "production";
 
 // File logging configuration
-const logToFile = getAppLogToFile();
-const logFilePath = resolve(getAppLogFilePath());
+const logToFile = appLogConfig.logToFile;
+const logFilePath = resolve(appLogConfig.logFilePath);
 
 // Ensure log directory exists once at module load
 if (logToFile) {

--- a/src/shared/validation/schemas.ts
+++ b/src/shared/validation/schemas.ts
@@ -767,7 +767,6 @@ const nonEmptyJsonRecordSchema = jsonRecordSchema.refine(
 
 const translatorLogFileSchema = z.enum([
   "1_req_client.json",
-  "2_req_source.json",
   "3_req_openai.json",
   "4_req_target.json",
   "5_res_provider.txt",

--- a/tests/unit/call-log-file-rotation.test.mjs
+++ b/tests/unit/call-log-file-rotation.test.mjs
@@ -1,0 +1,74 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-call-log-files-"));
+const ORIGINAL_DATA_DIR = process.env.DATA_DIR;
+const ORIGINAL_RETENTION_DAYS = process.env.CALL_LOG_RETENTION_DAYS;
+const ORIGINAL_MAX_FILES = process.env.CALL_LOG_MAX_FILES;
+
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.CALL_LOG_RETENTION_DAYS = "7";
+process.env.CALL_LOG_MAX_FILES = "2";
+
+const { rotateCallLogs } = await import("../../src/lib/usage/callLogs.ts");
+const { CALL_LOGS_DIR } = await import("../../src/lib/usage/migrations.ts");
+
+test.after(() => {
+  if (ORIGINAL_DATA_DIR === undefined) {
+    delete process.env.DATA_DIR;
+  } else {
+    process.env.DATA_DIR = ORIGINAL_DATA_DIR;
+  }
+
+  if (ORIGINAL_RETENTION_DAYS === undefined) {
+    delete process.env.CALL_LOG_RETENTION_DAYS;
+  } else {
+    process.env.CALL_LOG_RETENTION_DAYS = ORIGINAL_RETENTION_DAYS;
+  }
+
+  if (ORIGINAL_MAX_FILES === undefined) {
+    delete process.env.CALL_LOG_MAX_FILES;
+  } else {
+    process.env.CALL_LOG_MAX_FILES = ORIGINAL_MAX_FILES;
+  }
+
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("call log file rotation honors both retention days and file count", () => {
+  assert.ok(CALL_LOGS_DIR, "CALL_LOGS_DIR should resolve for test data dir");
+  fs.rmSync(CALL_LOGS_DIR, { recursive: true, force: true });
+  fs.mkdirSync(CALL_LOGS_DIR, { recursive: true });
+
+  const oldDir = path.join(CALL_LOGS_DIR, "2026-03-01");
+  const activeDir = path.join(CALL_LOGS_DIR, "2026-03-31");
+  fs.mkdirSync(oldDir, { recursive: true });
+  fs.mkdirSync(activeDir, { recursive: true });
+
+  const oldFile = path.join(oldDir, "080000_old_200.json");
+  const keepA = path.join(activeDir, "090000_keep-a_200.json");
+  const keepB = path.join(activeDir, "091000_keep-b_200.json");
+  const keepC = path.join(activeDir, "092000_keep-c_200.json");
+
+  for (const file of [oldFile, keepA, keepB, keepC]) {
+    fs.writeFileSync(file, JSON.stringify({ file }), "utf8");
+  }
+
+  const now = Date.now();
+  const oneDay = 24 * 60 * 60 * 1000;
+  fs.utimesSync(oldFile, new Date(now - 10 * oneDay), new Date(now - 10 * oneDay));
+  fs.utimesSync(oldDir, new Date(now - 10 * oneDay), new Date(now - 10 * oneDay));
+  fs.utimesSync(keepA, new Date(now - 3 * oneDay), new Date(now - 3 * oneDay));
+  fs.utimesSync(keepB, new Date(now - 2 * oneDay), new Date(now - 2 * oneDay));
+  fs.utimesSync(keepC, new Date(now - oneDay), new Date(now - oneDay));
+
+  rotateCallLogs();
+
+  assert.equal(fs.existsSync(oldDir), false);
+  assert.equal(fs.existsSync(keepA), false);
+  assert.equal(fs.existsSync(keepB), true);
+  assert.equal(fs.existsSync(keepC), true);
+});

--- a/tests/unit/log-rotation.test.mjs
+++ b/tests/unit/log-rotation.test.mjs
@@ -1,0 +1,75 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const { cleanupOldLogs, cleanupOverflowLogs, getLogConfig } =
+  await import("../../src/lib/logRotation.ts");
+
+test("getLogConfig reads APP_LOG_* values", () => {
+  const originalEnv = {
+    APP_LOG_TO_FILE: process.env.APP_LOG_TO_FILE,
+    APP_LOG_FILE_PATH: process.env.APP_LOG_FILE_PATH,
+    APP_LOG_MAX_FILE_SIZE: process.env.APP_LOG_MAX_FILE_SIZE,
+    APP_LOG_RETENTION_DAYS: process.env.APP_LOG_RETENTION_DAYS,
+    APP_LOG_MAX_FILES: process.env.APP_LOG_MAX_FILES,
+  };
+
+  process.env.APP_LOG_TO_FILE = "false";
+  process.env.APP_LOG_FILE_PATH = "/tmp/omniroute-test-app.log";
+  process.env.APP_LOG_MAX_FILE_SIZE = "64M";
+  process.env.APP_LOG_RETENTION_DAYS = "14";
+  process.env.APP_LOG_MAX_FILES = "12";
+
+  try {
+    const config = getLogConfig();
+
+    assert.equal(config.logToFile, false);
+    assert.equal(config.logFilePath, "/tmp/omniroute-test-app.log");
+    assert.equal(config.maxFileSize, 64 * 1024 * 1024);
+    assert.equal(config.retentionDays, 14);
+    assert.equal(config.maxFiles, 12);
+  } finally {
+    for (const [key, value] of Object.entries(originalEnv)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+});
+
+test("app log cleanup honors both retention days and file count", () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-log-rotation-"));
+  const logFilePath = path.join(tmpDir, "app.log");
+
+  fs.writeFileSync(logFilePath, "", "utf8");
+
+  const oldFile = path.join(tmpDir, "app.2026-03-01_010101.log");
+  const keepA = path.join(tmpDir, "app.2026-03-02_010101.log");
+  const keepB = path.join(tmpDir, "app.2026-03-03_010101.log");
+  const dropByCount = path.join(tmpDir, "app.2026-03-04_010101.log");
+
+  for (const file of [oldFile, keepA, keepB, dropByCount]) {
+    fs.writeFileSync(file, file, "utf8");
+  }
+
+  const now = Date.now();
+  const oneDay = 24 * 60 * 60 * 1000;
+  fs.utimesSync(oldFile, new Date(now - 10 * oneDay), new Date(now - 10 * oneDay));
+  fs.utimesSync(keepA, new Date(now - 3 * oneDay), new Date(now - 3 * oneDay));
+  fs.utimesSync(keepB, new Date(now - 2 * oneDay), new Date(now - 2 * oneDay));
+  fs.utimesSync(dropByCount, new Date(now - oneDay), new Date(now - oneDay));
+
+  cleanupOldLogs(logFilePath, 7);
+  cleanupOverflowLogs(logFilePath, 2);
+
+  assert.equal(fs.existsSync(oldFile), false);
+  assert.equal(fs.existsSync(keepA), false);
+  assert.equal(fs.existsSync(keepB), true);
+  assert.equal(fs.existsSync(dropByCount), true);
+
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});


### PR DESCRIPTION
## Why this change

The old multi-file `DATA_DIR/logs/` layout had already been removed by the unified logging upgrade that is now on `main`, but there were still a few follow-up issues left on top of the new logging model:

- request and app logs still needed a single, predictable retention strategy on top of the new layout
- the old `DATA_DIR/logs/` request sessions were historically the worst offender because they had **no automatic rotation or retention at all**
- the old `DATA_DIR/log.txt` summary file only hard-truncated lines and was **not** a real rotation policy
- the per-request debug view still exposed a duplicated `SOURCE REQUEST` stage that made payload inspection harder than it needed to be

This PR is a follow-up cleanup on top of the already-merged unified logging upgrade, so the current logging path is easier to operate, easier to read, and less likely to fill disk unexpectedly.

## Breaking Change

This PR changes request pipeline artifacts and logging controls again:

- new request artifacts no longer capture or display `SOURCE REQUEST`
- application log archives are now capped by `APP_LOG_MAX_FILES`
- request artifact files are now capped by `CALL_LOG_MAX_FILES`
- both count-based caps apply **in addition to** the existing day-based retention windows

Upgrade notes:

- if you relied on `SOURCE REQUEST` in new request artifacts, that stage is no longer generated
- new log retention env vars to configure are:
  - `APP_LOG_MAX_FILES`
  - `CALL_LOG_MAX_FILES`
- the legacy request-log backup behavior introduced by the unified logging upgrade remains unchanged

## What changed

- added archive-count cleanup for application log rotation in `src/lib/logRotation.ts`
- added artifact-count cleanup for request JSON artifacts in `src/lib/usage/callLogs.ts`
- extended `src/lib/logEnv.ts` with `APP_LOG_MAX_FILES` and `CALL_LOG_MAX_FILES`
- removed `SOURCE REQUEST` capture from the request pipeline and removed the old translator whitelist entry for `2_req_source.json`
- simplified the dashboard request-log toggle to `Pipeline Logs` and removed the redundant helper copy
- removed `SOURCE REQUEST` from the request detail modal
- updated README / CHANGELOG / OpenAPI docs and aligned versioned docs to `3.4.0`

## Validation

- `npm run typecheck:core`
- `npm run test:unit` (`1194/1194` passing)

