### PR TITLE
fix(antigravity): add image passthrough for Claude models

### DIFF
--- a/open-sse/translator/request/openai-to-gemini.ts
+++ b/open-sse/translator/request/openai-to-gemini.ts
@@ -435,7 +435,7 @@ function wrapInCloudCodeEnvelopeForClaude(model, claudeRequest, credentials = nu
           } else if (block.type === "image" && block.source) {
             parts.push({
               inlineData: {
-                mimeType: block.source.media_type,
+                mime_type: block.source.media_type,
                 data: block.source.data,
               },
             });


### PR DESCRIPTION
## Problem

`wrapInCloudCodeEnvelopeForClaude()` in `openai-to-gemini.ts` converts Claude message content blocks to Antigravity/Gemini `parts` format. It handles `text`, `tool_use`, and `tool_result` block types — but **silently drops `image` blocks**.

This means Claude models routed through the Antigravity provider never receive image content. The model responds with "I don't see any image" even though the image was correctly converted from OpenAI `image_url` format to Claude `image` format in the upstream translator.

### Affected path

```
OpenAI format (image_url) 
  → openaiToClaudeRequest (correctly converts to {type: "image", source: {base64}})
  → openaiToClaudeRequestForAntigravity (passes through)
  → wrapInCloudCodeEnvelopeForClaude (BUG: drops image blocks)
  → Antigravity API (never sees the image)
```

### Not affected

The **Gemini path** through Antigravity works correctly — `openaiToGeminiRequest()` properly converts `image_url` → `inlineData`, and `wrapInCloudCodeEnvelope()` preserves it.

## Fix

Add an `else if` branch for `block.type === "image"` that converts Claude's image format to Gemini's `inlineData` format (the same format the Gemini path already uses successfully):

```typescript
} else if (block.type === "image" && block.source) {
  parts.push({
    inlineData: {
      mimeType: block.source.media_type,
      data: block.source.data,
    },
  });
}
```

## Testing

Tested locally on v3.4.1:

- **Before patch**: `curl` with base64 image → Claude responds "I don't see any image"
- **After patch**: Claude correctly describes image content
- **Gemini models**: Unaffected (already working via separate path)
- **Text/tool requests**: Unaffected