### PR TITLE
fix(qwen): revert id_token bearer and use resource_url as API endpoint

### DIFF
--- a/open-sse/executors/default.ts
+++ b/open-sse/executors/default.ts
@@ -34,6 +34,10 @@ export class DefaultExecutor extends BaseExecutor {
         return `${this.config.baseUrl}?beta=true`;
       case "gemini":
         return `${this.config.baseUrl}/${model}:${stream ? "streamGenerateContent?alt=sse" : "generateContent"}`;
+      case "qwen": {
+        const resourceUrl = credentials?.providerSpecificData?.resourceUrl;
+        return `https://${resourceUrl || "portal.qwen.ai"}/v1/chat/completions`;
+      }
       default:
         return this.config.baseUrl;
     }

--- a/open-sse/services/tokenRefresh.ts
+++ b/open-sse/services/tokenRefresh.ts
@@ -324,9 +324,12 @@ export async function refreshQwenToken(refreshToken, log) {
       });
 
       return {
-        accessToken: tokens.id_token || tokens.access_token,
+        accessToken: tokens.access_token,
         refreshToken: tokens.refresh_token || refreshToken,
         expiresIn: tokens.expires_in,
+        providerSpecificData: tokens.resource_url
+          ? { resourceUrl: tokens.resource_url }
+          : undefined,
       };
     } else {
       const errorText = await response.text().catch(() => "");

--- a/src/lib/oauth/providers/qwen.ts
+++ b/src/lib/oauth/providers/qwen.ts
@@ -60,7 +60,7 @@ export const qwen = {
     }
 
     return {
-      accessToken: tokens.id_token || tokens.access_token,
+      accessToken: tokens.access_token,
       refreshToken: tokens.refresh_token,
       expiresIn: tokens.expires_in,
       idToken: tokens.id_token,


### PR DESCRIPTION
## Summary

- Reverts the 3.4.1 `id_token || access_token` change — `id_token` is a short-lived OIDC identity JWT (not an API credential), causing 401s within minutes of connecting
- Uses `access_token` as the bearer token, matching the [CLIProxyAPI reference implementation](https://github.com/diegosouzapw/CLIProxyAPI/blob/main/internal/runtime/executor/qwen_executor.go#L509)
- Uses `resource_url` from the token response to build the correct API endpoint (`https://{resource_url}/v1/chat/completions`) instead of the hardcoded `chat.qwen.ai` URL — falls back to `portal.qwen.ai` if absent
- Preserves `resource_url` through token refreshes via `providerSpecificData`

## Root cause

`chat.qwen.ai/api/v1/services/aigc/...` is a DashScope API key endpoint. Sending an OAuth `access_token` to it returns 401 with "session expired". The correct OAuth endpoint is `https://{resource_url}/v1/chat/completions` — confirmed via debug logging of the live token response.

## Test plan

- [x] Curl test against local dev server with prod DB — returns valid response
- [x] Confirmed `resource_url: "portal.qwen.ai"` present in both initial and refresh token responses
- [x] Token refresh still persists `resourceUrl` in `providerSpecificData`
- [ ] Deploy to prod and verify sustained requests work without re-auth

Closes #864

🤖 Generated with [Claude Code](https://claude.com/claude-code)