### PR TITLE
fix(oauth): persist providerSpecificData from token refresh in health check

### DIFF
--- a/src/lib/tokenHealthCheck.ts
+++ b/src/lib/tokenHealthCheck.ts
@@ -282,6 +282,13 @@ async function checkConnection(conn) {
       updateData.tokenExpiresAt = new Date(Date.now() + result.expiresIn * 1000).toISOString();
     }
 
+    if (result.providerSpecificData) {
+      updateData.providerSpecificData = {
+        ...(conn.providerSpecificData || {}),
+        ...result.providerSpecificData,
+      };
+    }
+
     await updateProviderConnection(conn.id, updateData);
     log(`${LOG_PREFIX} ✓ ${conn.provider}/${conn.name || conn.email || conn.id} refreshed`);
   } else {


### PR DESCRIPTION
## Summary

- The token health check refresh path was silently dropping `result.providerSpecificData` after a successful refresh
- This means Qwen's `resourceUrl` (returned in `providerSpecificData` by `refreshQwenToken`) was never persisted to the DB during health checks
- Fix deep-merges `result.providerSpecificData` into the existing connection's `providerSpecificData`, matching the same conditional pattern used for `refreshToken` and `expiresIn`

Identified via review comment on PR #900.

## Test plan

- [ ] Trigger a Qwen token health check refresh and verify `resourceUrl` is updated in the DB
- [ ] Verify no regression for providers that don't return `providerSpecificData` (field is only updated when present in result)
- [ ] Verify existing `providerSpecificData` fields are preserved (deep merge, not replace)

🤖 Generated with [Claude Code](https://claude.com/claude-code)