### PR TITLE
Fix CC compatible streaming and compatible provider UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🐛 Bug Fixes
 
-- **CC Compatible UX & Streaming:** Unified the Add CC/OpenAI/Anthropic compatible actions around the Anthropic UI treatment, forced CC-compatible upstream requests to use SSE while still returning streaming or non-streaming responses based on the client request, and removed CC model-list configuration/import support in favor of an explicit unsupported-model-listing error.
+- **CC Compatible UX & Streaming:** Unified the Add CC/OpenAI/Anthropic compatible actions around the Anthropic UI treatment, forced CC-compatible upstream requests to use SSE while still returning streaming or non-streaming responses based on the client request, removed CC model-list configuration/import support in favor of an explicit unsupported-model-listing error, and made CC-compatible Available Models mirror the OAuth Claude Code registry list.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🐛 Bug Fixes
 
-- **CC Compatible UX & Streaming:** Unified the Add CC/OpenAI/Anthropic compatible actions around the Anthropic UI treatment, and forced CC-compatible upstream requests to use SSE while still returning streaming or non-streaming responses based on the client request.
+- **CC Compatible UX & Streaming:** Unified the Add CC/OpenAI/Anthropic compatible actions around the Anthropic UI treatment, forced CC-compatible upstream requests to use SSE while still returning streaming or non-streaming responses based on the client request, and removed CC model-list configuration/import support in favor of an explicit unsupported-model-listing error.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### 🐛 Bug Fixes
+
+- **CC Compatible UX & Streaming:** Unified the Add CC/OpenAI/Anthropic compatible actions around the Anthropic UI treatment, and forced CC-compatible upstream requests to use SSE while still returning streaming or non-streaming responses based on the client request.
+
 ---
 
 ## [3.4.3] - 2026-04-02

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -60,7 +60,11 @@ import {
 } from "../executors/codex.ts";
 import { translateNonStreamingResponse } from "./responseTranslator.ts";
 import { extractUsageFromResponse } from "./usageExtractor.ts";
-import { parseSSEToOpenAIResponse, parseSSEToResponsesOutput } from "./sseParser.ts";
+import {
+  parseSSEToClaudeResponse,
+  parseSSEToOpenAIResponse,
+  parseSSEToResponsesOutput,
+} from "./sseParser.ts";
 import { sanitizeOpenAIResponse } from "./responseSanitizer.ts";
 import {
   withRateLimit,
@@ -711,6 +715,7 @@ export async function handleChatCore({
   let translatedBody = body;
   const isClaudePassthrough = sourceFormat === FORMATS.CLAUDE && targetFormat === FORMATS.CLAUDE;
   const isClaudeCodeCompatible = isClaudeCodeCompatibleProvider(provider);
+  const upstreamStream = stream || isClaudeCodeCompatible;
   let ccSessionId: string | null = null;
 
   // Determine if we should preserve client-side cache_control headers
@@ -770,7 +775,7 @@ export async function handleChatCore({
         sourceBody: body,
         normalizedBody: normalizedForCc,
         model,
-        stream,
+        stream: upstreamStream,
         sessionId: ccSessionId,
         cwd: process.cwd(),
         now: new Date(),
@@ -1031,7 +1036,7 @@ export async function handleChatCore({
   // Create stream controller for disconnect detection
   const streamController = createStreamController({ onDisconnect, log, provider, model });
 
-  const dedupRequestBody = { ...translatedBody, model: `${provider}/${model}` };
+  const dedupRequestBody = { ...translatedBody, model: `${provider}/${model}`, stream };
   const dedupEnabled = shouldDeduplicate(dedupRequestBody);
   const dedupHash = dedupEnabled ? computeRequestHash(dedupRequestBody) : null;
 
@@ -1065,7 +1070,7 @@ export async function handleChatCore({
           const res = await executor.execute({
             model: modelToCall,
             body: bodyToSend,
-            stream,
+            stream: upstreamStream,
             credentials: getExecutionCredentials(),
             signal: streamController.signal,
             log,
@@ -1228,7 +1233,7 @@ export async function handleChatCore({
         const retryResult = await executor.execute({
           model: retryModelId,
           body: translatedBody,
-          stream,
+          stream: upstreamStream,
           credentials: getExecutionCredentials(),
           signal: streamController.signal,
           log,
@@ -1532,7 +1537,9 @@ export async function handleChatCore({
       const parsedFromSSE =
         targetFormat === FORMATS.OPENAI_RESPONSES
           ? parseSSEToResponsesOutput(rawBody, model)
-          : parseSSEToOpenAIResponse(rawBody, model);
+          : targetFormat === FORMATS.CLAUDE
+            ? parseSSEToClaudeResponse(rawBody, model)
+            : parseSSEToOpenAIResponse(rawBody, model);
 
       if (!parsedFromSSE) {
         appendRequestLog({

--- a/open-sse/handlers/sseParser.ts
+++ b/open-sse/handlers/sseParser.ts
@@ -2,6 +2,75 @@
  * Convert OpenAI-style SSE chunks into a single non-streaming JSON response.
  * Used as a fallback when upstream returns text/event-stream for stream=false.
  */
+function readSSEEvents(rawSSE) {
+  const lines = String(rawSSE || "").split("\n");
+  const events = [];
+  let currentEvent = "";
+  let currentData = [];
+
+  const flush = () => {
+    if (currentData.length === 0) {
+      currentEvent = "";
+      return;
+    }
+
+    const payload = currentData.join("\n").trim();
+    currentData = [];
+    if (!payload || payload === "[DONE]") {
+      currentEvent = "";
+      return;
+    }
+
+    try {
+      events.push({
+        event: currentEvent || undefined,
+        data: JSON.parse(payload),
+      });
+    } catch {
+      // Ignore malformed SSE events and continue best-effort parsing.
+    }
+
+    currentEvent = "";
+  };
+
+  for (const rawLine of lines) {
+    const line = rawLine.replace(/\r$/, "");
+    if (line.trim() === "") {
+      flush();
+      continue;
+    }
+
+    if (line.startsWith("event:")) {
+      currentEvent = line.slice(6).trim();
+      continue;
+    }
+
+    if (line.startsWith("data:")) {
+      currentData.push(line.slice(5).trimStart());
+    }
+  }
+
+  flush();
+  return events;
+}
+
+function toRecord(value) {
+  return value && typeof value === "object" && !Array.isArray(value) ? value : {};
+}
+
+function toString(value, fallback = "") {
+  return typeof value === "string" ? value : fallback;
+}
+
+function toNumber(value, fallback = 0) {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : fallback;
+  }
+  return fallback;
+}
+
 export function parseSSEToOpenAIResponse(rawSSE, fallbackModel) {
   const lines = String(rawSSE || "").split("\n");
   const chunks = [];
@@ -141,6 +210,189 @@ export function parseSSEToOpenAIResponse(rawSSE, fallbackModel) {
   }
 
   return result;
+}
+
+/**
+ * Convert Claude-style SSE events into a single non-streaming message object.
+ * Used when Claude-compatible upstreams stream even for stream=false.
+ */
+export function parseSSEToClaudeResponse(rawSSE, fallbackModel) {
+  const payloads = readSSEEvents(rawSSE)
+    .map((event) => toRecord(event.data))
+    .filter((payload) => Object.keys(payload).length > 0);
+
+  if (payloads.length === 0) return null;
+
+  const blocks = new Map();
+  const usage = {};
+  let messageId = "";
+  let model = fallbackModel || "claude";
+  let role = "assistant";
+  let stopReason = "end_turn";
+  let stopSequence = null;
+
+  const mergeUsage = (incoming) => {
+    const usageRecord = toRecord(incoming);
+    for (const [key, value] of Object.entries(usageRecord)) {
+      if (typeof value === "number" && Number.isFinite(value)) {
+        usage[key] = value;
+      } else if (value && typeof value === "object" && !Array.isArray(value)) {
+        usage[key] = { ...toRecord(usage[key]), ...toRecord(value) };
+      } else if (typeof value === "string" && value.trim().length > 0) {
+        usage[key] = value;
+      }
+    }
+  };
+
+  const tryParseJson = (raw) => {
+    try {
+      return JSON.parse(raw);
+    } catch {
+      return raw;
+    }
+  };
+
+  for (const payload of payloads) {
+    const eventType = toString(payload.type);
+    if (eventType === "message_start") {
+      const message = toRecord(payload.message);
+      messageId = toString(message.id, messageId || `msg_${Date.now()}`);
+      model = toString(message.model, model);
+      role = toString(message.role, role);
+      mergeUsage(message.usage);
+      continue;
+    }
+
+    if (eventType === "content_block_start") {
+      const index = toNumber(payload.index, blocks.size);
+      const contentBlock = toRecord(payload.content_block);
+      const blockType = toString(contentBlock.type);
+
+      if (blockType === "thinking") {
+        blocks.set(index, {
+          type: "thinking",
+          index,
+          thinking: toString(contentBlock.thinking),
+          signature:
+            typeof contentBlock.signature === "string" ? contentBlock.signature : undefined,
+        });
+      } else if (blockType === "tool_use") {
+        blocks.set(index, {
+          type: "tool_use",
+          index,
+          id: toString(contentBlock.id, `toolu_${Date.now()}_${index}`),
+          name: toString(contentBlock.name),
+          input: contentBlock.input ?? {},
+          inputJson: "",
+        });
+      } else {
+        blocks.set(index, {
+          type: "text",
+          index,
+          text: toString(contentBlock.text),
+        });
+      }
+      continue;
+    }
+
+    if (eventType === "content_block_delta") {
+      const index = toNumber(payload.index, 0);
+      const delta = toRecord(payload.delta);
+      const deltaType = toString(delta.type);
+      const existing = blocks.get(index);
+
+      if (deltaType === "input_json_delta") {
+        const toolUse =
+          existing && existing.type === "tool_use"
+            ? existing
+            : {
+                type: "tool_use",
+                index,
+                id: `toolu_${Date.now()}_${index}`,
+                name: "",
+                input: {},
+                inputJson: "",
+              };
+        toolUse.inputJson += toString(delta.partial_json);
+        blocks.set(index, toolUse);
+        continue;
+      }
+
+      if (deltaType === "thinking_delta" || typeof delta.thinking === "string") {
+        const thinking =
+          existing && existing.type === "thinking"
+            ? existing
+            : { type: "thinking", index, thinking: "", signature: undefined };
+        thinking.thinking += toString(delta.thinking);
+        blocks.set(index, thinking);
+        continue;
+      }
+
+      const textBlock =
+        existing && existing.type === "text"
+          ? existing
+          : {
+              type: "text",
+              index,
+              text: "",
+            };
+      textBlock.text += toString(delta.text);
+      blocks.set(index, textBlock);
+      continue;
+    }
+
+    if (eventType === "message_delta") {
+      const delta = toRecord(payload.delta);
+      stopReason = toString(delta.stop_reason, stopReason);
+      stopSequence =
+        typeof delta.stop_sequence === "string" ? String(delta.stop_sequence) : stopSequence;
+      mergeUsage(payload.usage);
+      continue;
+    }
+
+    mergeUsage(payload.usage);
+  }
+
+  const content = [...blocks.values()]
+    .sort((a, b) => a.index - b.index)
+    .flatMap((block) => {
+      if (block.type === "text") {
+        return block.text ? [{ type: "text", text: block.text }] : [];
+      }
+      if (block.type === "thinking") {
+        return block.thinking
+          ? [
+              {
+                type: "thinking",
+                thinking: block.thinking,
+                ...(block.signature ? { signature: block.signature } : {}),
+              },
+            ]
+          : [];
+      }
+
+      const parsedInput =
+        block.inputJson.trim().length > 0 ? tryParseJson(block.inputJson) : block.input;
+      return [
+        {
+          type: "tool_use",
+          id: block.id,
+          name: block.name,
+          input: parsedInput,
+        },
+      ];
+    });
+
+  return {
+    id: messageId || `msg_${Date.now()}`,
+    type: "message",
+    role,
+    model,
+    content,
+    stop_reason: stopReason,
+    ...(stopSequence ? { stop_sequence: stopSequence } : {}),
+    ...(Object.keys(usage).length > 0 ? { usage } : {}),
+  };
 }
 
 /**

--- a/open-sse/services/claudeCodeCompatible.ts
+++ b/open-sse/services/claudeCodeCompatible.ts
@@ -116,7 +116,7 @@ export function buildClaudeCodeCompatibleValidationPayload(model = "claude-sonne
       max_tokens: 1,
     },
     model,
-    stream: false,
+    stream: true,
     sessionId,
     cwd: process.cwd(),
     now: new Date(),

--- a/src/app/(dashboard)/dashboard/providers/[id]/page.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.tsx
@@ -471,7 +471,6 @@ interface EditCompatibleNodeModalProps {
 const CC_COMPATIBLE_LABEL = "CC Compatible";
 const CC_COMPATIBLE_DETAILS_TITLE = "CC Compatible Details";
 const CC_COMPATIBLE_DEFAULT_CHAT_PATH = "/v1/messages?beta=true";
-const CC_COMPATIBLE_DEFAULT_MODELS_PATH = "/models";
 
 function normalizeCodexLimitPolicy(policy: unknown): { use5h: boolean; useWeekly: boolean } {
   const record =
@@ -5110,13 +5109,13 @@ function EditCompatibleNodeModal({
               ? "https://api.anthropic.com/v1"
               : "https://api.openai.com/v1"),
         chatPath: node.chatPath || (isCcCompatible ? CC_COMPATIBLE_DEFAULT_CHAT_PATH : ""),
-        modelsPath: node.modelsPath || (isCcCompatible ? CC_COMPATIBLE_DEFAULT_MODELS_PATH : ""),
+        modelsPath: isCcCompatible ? "" : node.modelsPath || "",
       });
       setShowAdvanced(
         !!(
           node.chatPath ||
-          node.modelsPath ||
-          (isCcCompatible && !node.chatPath && !node.modelsPath)
+          (!isCcCompatible && node.modelsPath) ||
+          (isCcCompatible && !node.chatPath)
         )
       );
     }
@@ -5136,8 +5135,7 @@ function EditCompatibleNodeModal({
         prefix: formData.prefix,
         baseUrl: formData.baseUrl,
         chatPath: formData.chatPath || (isCcCompatible ? CC_COMPATIBLE_DEFAULT_CHAT_PATH : ""),
-        modelsPath:
-          formData.modelsPath || (isCcCompatible ? CC_COMPATIBLE_DEFAULT_MODELS_PATH : ""),
+        modelsPath: isCcCompatible ? "" : formData.modelsPath,
       };
       if (!isAnthropic) {
         payload.apiType = formData.apiType;
@@ -5160,8 +5158,7 @@ function EditCompatibleNodeModal({
           type: isAnthropic ? "anthropic-compatible" : "openai-compatible",
           compatMode: isCcCompatible ? "cc" : undefined,
           chatPath: formData.chatPath || (isCcCompatible ? CC_COMPATIBLE_DEFAULT_CHAT_PATH : ""),
-          modelsPath:
-            formData.modelsPath || (isCcCompatible ? CC_COMPATIBLE_DEFAULT_MODELS_PATH : ""),
+          modelsPath: isCcCompatible ? "" : formData.modelsPath,
         }),
       });
       const data = await res.json();
@@ -5273,15 +5270,15 @@ function EditCompatibleNodeModal({
                   : t("chatPathHint")
               }
             />
-            <Input
-              label={isCcCompatible ? "Models Path" : t("modelsPathLabel")}
-              value={formData.modelsPath}
-              onChange={(e) => setFormData({ ...formData, modelsPath: e.target.value })}
-              placeholder={
-                isCcCompatible ? CC_COMPATIBLE_DEFAULT_MODELS_PATH : t("modelsPathPlaceholder")
-              }
-              hint={isCcCompatible ? "Defaults to /models" : t("modelsPathHint")}
-            />
+            {!isCcCompatible && (
+              <Input
+                label={t("modelsPathLabel")}
+                value={formData.modelsPath}
+                onChange={(e) => setFormData({ ...formData, modelsPath: e.target.value })}
+                placeholder={t("modelsPathPlaceholder")}
+                hint={t("modelsPathHint")}
+              />
+            )}
           </div>
         )}
         <div className="flex gap-2">

--- a/src/app/(dashboard)/dashboard/providers/[id]/page.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.tsx
@@ -32,6 +32,10 @@ import {
   isClaudeCodeCompatibleProvider,
 } from "@/shared/constants/providers";
 import { getModelsByProviderId } from "@/shared/constants/models";
+import {
+  compatibleProviderSupportsModelImport,
+  getCompatibleFallbackModels,
+} from "@/lib/providers/managedAvailableModels";
 import { useCopyToClipboard } from "@/shared/hooks/useCopyToClipboard";
 import {
   MODEL_COMPAT_PROTOCOL_KEYS,
@@ -334,6 +338,7 @@ interface CompatibleModelsSectionProps {
   providerDisplayAlias: string;
   modelAliases: Record<string, string>;
   fallbackModels?: CompatModelRow[];
+  allowImport: boolean;
   description: string;
   inputLabel: string;
   inputPlaceholder: string;
@@ -876,6 +881,7 @@ export default function ProviderDetailPage() {
   const providerAlias = getProviderAlias(providerId);
   const isManagedAvailableModelsProvider = isCompatible || providerId === "openrouter";
   const isSearchProvider = providerId.endsWith("-search");
+  const compatibleSupportsModelImport = compatibleProviderSupportsModelImport(providerId);
 
   const providerStorageAlias = isCompatible ? providerId : providerAlias;
   const providerDisplayAlias = isCompatible ? providerNode?.prefix || providerId : providerAlias;
@@ -1735,6 +1741,10 @@ export default function ProviderDetailPage() {
     () => buildCompatMap(modelMeta.modelCompatOverrides),
     [modelMeta.modelCompatOverrides]
   );
+  const compatibleFallbackModels = useMemo(
+    () => getCompatibleFallbackModels(providerId, modelMeta.customModels),
+    [providerId, modelMeta.customModels]
+  );
 
   const effectiveModelNormalize = (modelId: string, protocol = MODEL_COMPAT_PROTOCOL_KEYS[0]) =>
     effectiveNormalizeForProtocol(modelId, protocol, customMap, overrideMap);
@@ -1821,7 +1831,7 @@ export default function ProviderDetailPage() {
   };
 
   const renderModelsSection = () => {
-    const autoSyncToggle = canImportModels && (
+    const autoSyncToggle = compatibleSupportsModelImport && canImportModels && (
       <button
         onClick={handleToggleAutoSync}
         disabled={togglingAutoSync}
@@ -1856,7 +1866,7 @@ export default function ProviderDetailPage() {
         providerId === "openrouter"
           ? t("openRouterAnyModelHint")
           : isCcCompatible
-            ? "CC Compatible provider models are routed through the Claude Code-compatible bridge."
+            ? "CC Compatible available models mirror the OAuth Claude Code provider list."
             : t("compatibleModelsDescription", {
                 type: isAnthropicCompatible ? t("anthropic") : t("openai"),
               });
@@ -1880,7 +1890,7 @@ export default function ProviderDetailPage() {
             providerStorageAlias={providerStorageAlias}
             providerDisplayAlias={providerDisplayAlias}
             modelAliases={modelAliases}
-            fallbackModels={providerId === "openrouter" ? modelMeta.customModels : undefined}
+            fallbackModels={compatibleFallbackModels}
             description={description}
             inputLabel={inputLabel}
             inputPlaceholder={inputPlaceholder}
@@ -1898,6 +1908,7 @@ export default function ProviderDetailPage() {
             saveModelCompatFlags={saveModelCompatFlags}
             compatSavingModelId={compatSavingModelId}
             onModelsChanged={fetchProviderModelMeta}
+            allowImport={compatibleSupportsModelImport}
           />
         </div>
       );
@@ -3493,6 +3504,7 @@ function CompatibleModelsSection({
   saveModelCompatFlags,
   compatSavingModelId,
   onModelsChanged,
+  allowImport,
 }: CompatibleModelsSectionProps) {
   const [newModel, setNewModel] = useState("");
   const [adding, setAdding] = useState(false);
@@ -3581,7 +3593,7 @@ function CompatibleModelsSection({
   };
 
   const handleImport = async () => {
-    if (importing) return;
+    if (!allowImport || importing) return;
     const activeConnection = connections.find((conn) => conn.isActive !== false);
     if (!activeConnection) return;
 
@@ -3684,18 +3696,22 @@ function CompatibleModelsSection({
         <Button size="sm" icon="add" onClick={handleAdd} disabled={!newModel.trim() || adding}>
           {adding ? t("adding") : t("add")}
         </Button>
-        <Button
-          size="sm"
-          variant="secondary"
-          icon="download"
-          onClick={handleImport}
-          disabled={!canImport || importing}
-        >
-          {importing ? t("importingModels") : t("importFromModels")}
-        </Button>
+        {allowImport && (
+          <Button
+            size="sm"
+            variant="secondary"
+            icon="download"
+            onClick={handleImport}
+            disabled={!canImport || importing}
+          >
+            {importing ? t("importingModels") : t("importFromModels")}
+          </Button>
+        )}
       </div>
 
-      {!canImport && <p className="text-xs text-text-muted">{t("addConnectionToImport")}</p>}
+      {allowImport && !canImport && (
+        <p className="text-xs text-text-muted">{t("addConnectionToImport")}</p>
+      )}
 
       {allModels.length > 0 && (
         <div className="flex flex-col gap-3">
@@ -3749,6 +3765,7 @@ CompatibleModelsSection.propTypes = {
   saveModelCompatFlags: PropTypes.func.isRequired,
   compatSavingModelId: PropTypes.string,
   onModelsChanged: PropTypes.func,
+  allowImport: PropTypes.bool.isRequired,
 };
 
 function CooldownTimer({ until }: CooldownTimerProps) {

--- a/src/app/(dashboard)/dashboard/providers/page.tsx
+++ b/src/app/(dashboard)/dashboard/providers/page.tsx
@@ -30,7 +30,6 @@ import { useTranslations } from "next-intl";
 const CC_COMPATIBLE_LABEL = "CC Compatible";
 const ADD_CC_COMPATIBLE_LABEL = "Add CC Compatible";
 const CC_COMPATIBLE_DEFAULT_CHAT_PATH = "/v1/messages?beta=true";
-const CC_COMPATIBLE_DEFAULT_MODELS_PATH = "/models";
 
 // Shared helper function to avoid code duplication between ProviderCard and ApiKeyProviderCard
 function getStatusDisplay(connected, error, errorCode, t) {
@@ -1287,7 +1286,6 @@ function AddCcCompatibleModal({ isOpen, onClose, onCreated }) {
     prefix: "",
     baseUrl: "https://api.anthropic.com",
     chatPath: CC_COMPATIBLE_DEFAULT_CHAT_PATH,
-    modelsPath: CC_COMPATIBLE_DEFAULT_MODELS_PATH,
   });
   const [submitting, setSubmitting] = useState(false);
   const [checkKey, setCheckKey] = useState("");
@@ -1316,7 +1314,6 @@ function AddCcCompatibleModal({ isOpen, onClose, onCreated }) {
           type: "anthropic-compatible",
           compatMode: "cc",
           chatPath: formData.chatPath || CC_COMPATIBLE_DEFAULT_CHAT_PATH,
-          modelsPath: formData.modelsPath || CC_COMPATIBLE_DEFAULT_MODELS_PATH,
         }),
       });
       const data = await res.json();
@@ -1327,7 +1324,6 @@ function AddCcCompatibleModal({ isOpen, onClose, onCreated }) {
           prefix: "",
           baseUrl: "https://api.anthropic.com",
           chatPath: CC_COMPATIBLE_DEFAULT_CHAT_PATH,
-          modelsPath: CC_COMPATIBLE_DEFAULT_MODELS_PATH,
         });
         setCheckKey("");
         setValidationResult(null);
@@ -1352,7 +1348,6 @@ function AddCcCompatibleModal({ isOpen, onClose, onCreated }) {
           type: "anthropic-compatible",
           compatMode: "cc",
           chatPath: formData.chatPath || CC_COMPATIBLE_DEFAULT_CHAT_PATH,
-          modelsPath: formData.modelsPath || CC_COMPATIBLE_DEFAULT_MODELS_PATH,
         }),
       });
       const data = await res.json();
@@ -1414,13 +1409,6 @@ function AddCcCompatibleModal({ isOpen, onClose, onCreated }) {
               onChange={(e) => setFormData({ ...formData, chatPath: e.target.value })}
               placeholder={CC_COMPATIBLE_DEFAULT_CHAT_PATH}
               hint={t("chatPathHint")}
-            />
-            <Input
-              label={t("modelsPathLabel")}
-              value={formData.modelsPath}
-              onChange={(e) => setFormData({ ...formData, modelsPath: e.target.value })}
-              placeholder={CC_COMPATIBLE_DEFAULT_MODELS_PATH}
-              hint={t("modelsPathHint")}
             />
           </div>
         )}

--- a/src/app/(dashboard)/dashboard/providers/page.tsx
+++ b/src/app/(dashboard)/dashboard/providers/page.tsx
@@ -518,25 +518,14 @@ export default function ProvidersPage() {
               </button>
             )}
             {ccCompatibleProviderEnabled && (
-              <Button
-                size="sm"
-                variant="secondary"
-                icon="add"
-                onClick={() => setShowAddCcCompatibleModal(true)}
-              >
+              <Button size="sm" icon="add" onClick={() => setShowAddCcCompatibleModal(true)}>
                 {ADD_CC_COMPATIBLE_LABEL}
               </Button>
             )}
             <Button size="sm" icon="add" onClick={() => setShowAddAnthropicCompatibleModal(true)}>
               {t("addAnthropicCompatible")}
             </Button>
-            <Button
-              size="sm"
-              variant="secondary"
-              icon="add"
-              onClick={() => setShowAddCompatibleModal(true)}
-              className="!bg-white !text-black hover:!bg-gray-100"
-            >
+            <Button size="sm" icon="add" onClick={() => setShowAddCompatibleModal(true)}>
               {t("addOpenAICompatible")}
             </Button>
           </div>
@@ -1292,6 +1281,7 @@ AddAnthropicCompatibleModal.propTypes = {
 };
 
 function AddCcCompatibleModal({ isOpen, onClose, onCreated }) {
+  const t = useTranslations("providers");
   const [formData, setFormData] = useState({
     name: "",
     prefix: "",
@@ -1378,25 +1368,25 @@ function AddCcCompatibleModal({ isOpen, onClose, onCreated }) {
     <Modal isOpen={isOpen} title={ADD_CC_COMPATIBLE_LABEL} onClose={onClose}>
       <div className="flex flex-col gap-4">
         <Input
-          label="Name"
+          label={t("nameLabel")}
           value={formData.name}
           onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-          placeholder="CC Compatible Production"
-          hint="Display name for this Claude Code-compatible provider"
+          placeholder={t("compatibleProdPlaceholder", { type: CC_COMPATIBLE_LABEL })}
+          hint={t("nameHint")}
         />
         <Input
-          label="Prefix"
+          label={t("prefixLabel")}
           value={formData.prefix}
           onChange={(e) => setFormData({ ...formData, prefix: e.target.value })}
-          placeholder="cc"
-          hint="Used for model aliases such as prefix/model-id"
+          placeholder="cc-prod"
+          hint={t("prefixHint")}
         />
         <Input
-          label="Base URL"
+          label={t("baseUrlLabel")}
           value={formData.baseUrl}
           onChange={(e) => setFormData({ ...formData, baseUrl: e.target.value })}
-          placeholder="https://example.com/v1"
-          hint="Base URL for the CC-compatible site. Do not include /messages."
+          placeholder="https://api.anthropic.com"
+          hint={t("compatibleBaseUrlHint", { type: CC_COMPATIBLE_LABEL })}
         />
         <button
           type="button"
@@ -1411,7 +1401,7 @@ function AddCcCompatibleModal({ isOpen, onClose, onCreated }) {
           >
             ▶
           </span>
-          Advanced settings
+          {t("advancedSettings")}
         </button>
         {showAdvanced && (
           <div
@@ -1419,24 +1409,24 @@ function AddCcCompatibleModal({ isOpen, onClose, onCreated }) {
             className="flex flex-col gap-3 pl-2 border-l-2 border-border"
           >
             <Input
-              label="Chat Path"
+              label={t("chatPathLabel")}
               value={formData.chatPath}
               onChange={(e) => setFormData({ ...formData, chatPath: e.target.value })}
               placeholder={CC_COMPATIBLE_DEFAULT_CHAT_PATH}
-              hint="Defaults to the strict Claude Code-compatible messages path"
+              hint={t("chatPathHint")}
             />
             <Input
-              label="Models Path"
+              label={t("modelsPathLabel")}
               value={formData.modelsPath}
               onChange={(e) => setFormData({ ...formData, modelsPath: e.target.value })}
               placeholder={CC_COMPATIBLE_DEFAULT_MODELS_PATH}
-              hint="Defaults to /models"
+              hint={t("modelsPathHint")}
             />
           </div>
         )}
         <div className="flex gap-2">
           <Input
-            label="API Key for Check"
+            label={t("apiKeyForCheck")}
             type="password"
             value={checkKey}
             onChange={(e) => setCheckKey(e.target.value)}
@@ -1448,13 +1438,13 @@ function AddCcCompatibleModal({ isOpen, onClose, onCreated }) {
               disabled={!checkKey || validating || !formData.baseUrl.trim()}
               variant="secondary"
             >
-              {validating ? "Checking..." : "Check"}
+              {validating ? t("checking") : t("check")}
             </Button>
           </div>
         </div>
         {validationResult && (
           <Badge variant={validationResult === "success" ? "success" : "error"}>
-            {validationResult === "success" ? "Valid" : "Invalid"}
+            {validationResult === "success" ? t("valid") : t("invalid")}
           </Badge>
         )}
         <div className="flex gap-2">
@@ -1468,10 +1458,10 @@ function AddCcCompatibleModal({ isOpen, onClose, onCreated }) {
               submitting
             }
           >
-            {submitting ? "Creating..." : "Add"}
+            {submitting ? t("creating") : t("add")}
           </Button>
           <Button onClick={onClose} variant="ghost" fullWidth>
-            Cancel
+            {t("cancel")}
           </Button>
         </div>
       </div>

--- a/src/app/api/provider-nodes/[id]/route.ts
+++ b/src/app/api/provider-nodes/[id]/route.ts
@@ -83,7 +83,7 @@ export async function PUT(request: Request, { params }: { params: Promise<{ id: 
       prefix: prefix.trim(),
       baseUrl: sanitizedBaseUrl,
       chatPath: chatPath || null,
-      modelsPath: modelsPath || null,
+      modelsPath: isClaudeCodeCompatibleProvider(id) ? null : modelsPath || null,
     };
 
     if (node.type === "openai-compatible") {
@@ -105,8 +105,12 @@ export async function PUT(request: Request, { params }: { params: Promise<{ id: 
           baseUrl: sanitizedBaseUrl,
           nodeName: updated.name,
           chatPath: updated.chatPath || undefined,
-          modelsPath: updated.modelsPath || undefined,
         } as JsonRecord;
+        if (updated.modelsPath) {
+          providerSpecificData.modelsPath = updated.modelsPath;
+        } else {
+          delete providerSpecificData.modelsPath;
+        }
         if (node.type === "openai-compatible") {
           providerSpecificData.apiType = apiType;
         }

--- a/src/app/api/provider-nodes/route.ts
+++ b/src/app/api/provider-nodes/route.ts
@@ -109,7 +109,7 @@ export async function POST(request) {
         baseUrl: sanitizedBaseUrl,
         name: name.trim(),
         chatPath: chatPath || null,
-        modelsPath: modelsPath || null,
+        modelsPath: compatMode === "cc" ? null : modelsPath || null,
       });
       return NextResponse.json({ node }, { status: 201 });
     }

--- a/src/app/api/provider-nodes/validate/route.ts
+++ b/src/app/api/provider-nodes/validate/route.ts
@@ -57,7 +57,6 @@ export async function POST(request) {
           providerSpecificData: {
             baseUrl: sanitizeClaudeCodeCompatibleBaseUrl(baseUrl),
             chatPath: chatPath || undefined,
-            modelsPath: modelsPath || undefined,
           },
         });
 

--- a/src/app/api/providers/[id]/models/route.ts
+++ b/src/app/api/providers/[id]/models/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { getProviderConnectionById } from "@/models";
 import {
+  isClaudeCodeCompatibleProvider,
   isOpenAICompatibleProvider,
   isAnthropicCompatibleProvider,
 } from "@/shared/constants/providers";
@@ -555,6 +556,13 @@ export async function GET(
     }
 
     if (isAnthropicCompatibleProvider(provider)) {
+      if (isClaudeCodeCompatibleProvider(provider)) {
+        return NextResponse.json(
+          { error: `Provider ${provider} does not support models listing` },
+          { status: 400 }
+        );
+      }
+
       let baseUrl = getProviderBaseUrl(connection.providerSpecificData);
       if (!baseUrl) {
         return NextResponse.json(

--- a/src/lib/providers/managedAvailableModels.ts
+++ b/src/lib/providers/managedAvailableModels.ts
@@ -1,0 +1,20 @@
+import { getModelsByProviderId } from "@/shared/constants/models";
+import { isClaudeCodeCompatibleProvider } from "@/shared/constants/providers";
+
+type ManagedAvailableModel = {
+  id?: string;
+  name?: string;
+};
+
+export function getCompatibleFallbackModels(
+  providerId: string,
+  fallbackModels: ManagedAvailableModel[] = []
+): ManagedAvailableModel[] | undefined {
+  if (providerId === "openrouter") return fallbackModels;
+  if (isClaudeCodeCompatibleProvider(providerId)) return getModelsByProviderId("claude");
+  return undefined;
+}
+
+export function compatibleProviderSupportsModelImport(providerId: string): boolean {
+  return !isClaudeCodeCompatibleProvider(providerId);
+}

--- a/src/lib/providers/validation.ts
+++ b/src/lib/providers/validation.ts
@@ -616,7 +616,7 @@ export async function validateClaudeCodeCompatibleProvider({
   try {
     const messagesRes = await fetch(joinClaudeCodeCompatibleUrl(baseUrl, chatPath), {
       method: "POST",
-      headers: buildClaudeCodeCompatibleHeaders(apiKey, false, sessionId),
+      headers: buildClaudeCodeCompatibleHeaders(apiKey, true, sessionId),
       body: JSON.stringify(payload),
     });
 

--- a/tests/unit/cc-compatible-provider.test.mjs
+++ b/tests/unit/cc-compatible-provider.test.mjs
@@ -8,6 +8,7 @@ const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-cc-compat
 process.env.DATA_DIR = TEST_DATA_DIR;
 
 const core = await import("../../src/lib/db/core.ts");
+const providersDb = await import("../../src/lib/db/providers.ts");
 const { DefaultExecutor } = await import("../../open-sse/executors/default.ts");
 const {
   buildClaudeCodeCompatibleRequest,
@@ -21,6 +22,7 @@ const { validateProviderApiKey } = await import("../../src/lib/providers/validat
 const providerNodesRoute = await import("../../src/app/api/provider-nodes/route.ts");
 const providerNodesValidateRoute =
   await import("../../src/app/api/provider-nodes/validate/route.ts");
+const providerModelsRoute = await import("../../src/app/api/providers/[id]/models/route.ts");
 
 const originalFetch = globalThis.fetch;
 const originalFlag = process.env.ENABLE_CC_COMPATIBLE_PROVIDER;
@@ -398,7 +400,7 @@ test("provider-nodes create route creates CC node with dedicated prefix when ena
   assert.match(data.node.id, /^anthropic-compatible-cc-/);
   assert.equal(data.node.baseUrl, "https://proxy.example.com");
   assert.equal(data.node.chatPath, CLAUDE_CODE_COMPATIBLE_DEFAULT_CHAT_PATH);
-  assert.equal(data.node.modelsPath, CLAUDE_CODE_COMPATIBLE_DEFAULT_MODELS_PATH);
+  assert.equal(data.node.modelsPath, null);
 });
 
 test("provider-nodes validate route rejects CC mode when feature flag is disabled", async () => {
@@ -428,4 +430,29 @@ test("provider-nodes list route exposes CC flag state from server env", async ()
 
   const data = await response.json();
   assert.equal(data.ccCompatibleProviderEnabled, true);
+});
+
+test("provider models route reports CC compatible providers do not support models listing", async () => {
+  process.env.ENABLE_CC_COMPATIBLE_PROVIDER = "true";
+
+  const connection = await providersDb.createProviderConnection({
+    provider: "anthropic-compatible-cc-test",
+    authType: "apikey",
+    name: "cc-live",
+    apiKey: "sk-test",
+    providerSpecificData: {
+      baseUrl: "https://proxy.example.com",
+      chatPath: CLAUDE_CODE_COMPATIBLE_DEFAULT_CHAT_PATH,
+    },
+  });
+
+  const response = await providerModelsRoute.GET(
+    new Request(`http://localhost/api/providers/${connection.id}/models`),
+    { params: { id: connection.id } }
+  );
+
+  assert.equal(response.status, 400);
+  assert.deepEqual(await response.json(), {
+    error: "Provider anthropic-compatible-cc-test does not support models listing",
+  });
 });

--- a/tests/unit/cc-compatible-provider.test.mjs
+++ b/tests/unit/cc-compatible-provider.test.mjs
@@ -16,6 +16,7 @@ const {
   CLAUDE_CODE_COMPATIBLE_DEFAULT_MODELS_PATH,
   joinClaudeCodeCompatibleUrl,
 } = await import("../../open-sse/services/claudeCodeCompatible.ts");
+const { handleChatCore } = await import("../../open-sse/handlers/chatCore.ts");
 const { validateProviderApiKey } = await import("../../src/lib/providers/validation.ts");
 const providerNodesRoute = await import("../../src/app/api/provider-nodes/route.ts");
 const providerNodesValidateRoute =
@@ -263,7 +264,94 @@ test("validateProviderApiKey uses CC skeleton request after /models fallback", a
   );
   assert.equal(calls[1].body.model, "claude-sonnet-4-6");
   assert.equal(calls[1].body.messages[0].role, "user");
+  assert.equal(calls[1].body.stream, true);
   assert.equal(calls[1].headers["x-api-key"], "sk-test");
+  assert.equal(calls[1].headers.Accept, "text/event-stream");
+});
+
+test("handleChatCore forces upstream streaming for CC compatible while returning JSON to non-stream clients", async () => {
+  const calls = [];
+  globalThis.fetch = async (url, init = {}) => {
+    calls.push({
+      url: String(url),
+      method: init.method || "GET",
+      headers: init.headers,
+      body: init.body ? JSON.parse(String(init.body)) : null,
+    });
+
+    return new Response(
+      [
+        "event: message_start",
+        'data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-sonnet-4-6","usage":{"input_tokens":7,"output_tokens":0}}}',
+        "",
+        "event: content_block_start",
+        'data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}',
+        "",
+        "event: content_block_delta",
+        'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello from CC"}}',
+        "",
+        "event: message_delta",
+        'data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":5}}',
+        "",
+        "event: message_stop",
+        'data: {"type":"message_stop"}',
+        "",
+      ].join("\n"),
+      {
+        status: 200,
+        headers: {
+          "content-type": "text/event-stream",
+        },
+      }
+    );
+  };
+
+  const result = await handleChatCore({
+    body: {
+      model: "claude-sonnet-4-6",
+      messages: [{ role: "user", content: "Ping" }],
+      stream: false,
+    },
+    modelInfo: {
+      provider: "anthropic-compatible-cc-test",
+      model: "claude-sonnet-4-6",
+      extendedContext: false,
+    },
+    credentials: {
+      apiKey: "sk-test",
+      providerSpecificData: {
+        baseUrl: "https://proxy.example.com",
+        chatPath: CLAUDE_CODE_COMPATIBLE_DEFAULT_CHAT_PATH,
+      },
+    },
+    clientRawRequest: {
+      endpoint: "/v1/chat/completions",
+      body: {
+        model: "claude-sonnet-4-6",
+        messages: [{ role: "user", content: "Ping" }],
+        stream: false,
+      },
+      headers: new Headers({ accept: "application/json" }),
+    },
+    userAgent: "unit-test",
+    log: {
+      debug() {},
+      info() {},
+      warn() {},
+      error() {},
+    },
+  });
+
+  assert.equal(result.success, true);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].headers.Accept, "text/event-stream");
+  assert.equal(calls[0].body.stream, true);
+
+  const payload = await result.response.json();
+  assert.equal(payload.choices[0].message.content, "Hello from CC");
+  assert.equal(payload.choices[0].finish_reason, "stop");
+  assert.equal(payload.usage.prompt_tokens, 2007);
+  assert.equal(payload.usage.completion_tokens, 5);
 });
 
 test("provider-nodes create route rejects CC mode when feature flag is disabled", async () => {

--- a/tests/unit/managed-available-models.test.mjs
+++ b/tests/unit/managed-available-models.test.mjs
@@ -1,69 +1,22 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
 
-const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-managed-models-"));
-process.env.DATA_DIR = TEST_DATA_DIR;
+const { compatibleProviderSupportsModelImport, getCompatibleFallbackModels } =
+  await import("../../src/lib/providers/managedAvailableModels.ts");
+const { getModelsByProviderId } = await import("../../src/shared/constants/models.ts");
 
-const core = await import("../../src/lib/db/core.ts");
-const modelsDb = await import("../../src/lib/db/models.ts");
-const managedModels = await import("../../src/lib/providerModels/managedAvailableModels.ts");
-const aliasUtils = await import("../../src/shared/utils/providerModelAliases.ts");
-
-async function resetStorage() {
-  core.resetDbInstance();
-  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
-  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
-}
-
-test.beforeEach(async () => {
-  await resetStorage();
+test("CC compatible fallback models mirror the OAuth Claude Code registry list", () => {
+  assert.deepEqual(
+    getCompatibleFallbackModels("anthropic-compatible-cc-demo"),
+    getModelsByProviderId("claude")
+  );
 });
 
-test.after(() => {
-  core.resetDbInstance();
-  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+test("CC compatible providers disable remote model import", () => {
+  assert.equal(compatibleProviderSupportsModelImport("anthropic-compatible-cc-demo"), false);
 });
 
-test("resolveManagedModelAlias preserves existing aliases and falls back to provider-prefixed suffixes", () => {
-  const first = aliasUtils.resolveManagedModelAlias({
-    modelId: "anthropic/claude-3.7-sonnet",
-    fullModel: "openrouter/anthropic/claude-3.7-sonnet",
-    providerDisplayAlias: "openrouter",
-    existingAliases: {
-      "claude-3.7-sonnet": "other-provider/claude-3.7-sonnet",
-      "openrouter-claude-3.7-sonnet": "other-provider/claude-3.7-sonnet",
-    },
-  });
-  assert.equal(first, "openrouter-claude-3.7-sonnet-2");
-
-  const preserved = aliasUtils.resolveManagedModelAlias({
-    modelId: "openai/gpt-4.1",
-    fullModel: "openrouter/openai/gpt-4.1",
-    providerDisplayAlias: "openrouter",
-    existingAliases: {
-      kept: "openrouter/openai/gpt-4.1",
-      "gpt-4.1": "other-provider/gpt-4.1",
-    },
-  });
-  assert.equal(preserved, "kept");
-});
-
-test("syncManagedAvailableModelAliases backfills openrouter aliases and removes stale entries", async () => {
-  await modelsDb.setModelAlias("kept", "openrouter/openai/gpt-4.1");
-  await modelsDb.setModelAlias("claude-3.7-sonnet", "other-provider/claude-3.7-sonnet");
-  await modelsDb.setModelAlias("stale-model", "openrouter/legacy/stale-model");
-
-  const result = await managedModels.syncManagedAvailableModelAliases("openrouter", [
-    "openai/gpt-4.1",
-    "anthropic/claude-3.7-sonnet",
-  ]);
-  const aliases = await modelsDb.getModelAliases();
-
-  assert.deepEqual(result.removedAliases, ["stale-model"]);
-  assert.equal(aliases.kept, "openrouter/openai/gpt-4.1");
-  assert.equal(aliases["openrouter-claude-3.7-sonnet"], "openrouter/anthropic/claude-3.7-sonnet");
-  assert.equal(aliases["stale-model"], undefined);
+test("OpenRouter keeps imported fallback models as its managed list source", () => {
+  const fallbackModels = [{ id: "openai/gpt-5" }, { id: "anthropic/claude-sonnet-4-6" }];
+  assert.deepEqual(getCompatibleFallbackModels("openrouter", fallbackModels), fallbackModels);
 });


### PR DESCRIPTION
## Summary
- unify compatible provider CTA styling and align the CC modal with the current Anthropic-compatible UX
- force Claude Code compatible upstream requests to always stream, then translate back to streaming or non-streaming responses based on the client request
- remove CC compatible `Models Path` configuration entirely and surface an explicit unsupported-model-listing error when importing models
- mirror CC compatible `Available Models` from the OAuth Claude Code registry list and hide unsupported import/auto-sync actions in the CC models UI

## Why
- the CC-compatible bridge behaves like Claude Code rather than a generic provider with a discoverable `/models` endpoint
- keeping the managed model list aligned with the built-in Claude Code provider avoids UI drift and removes a dead-end import flow

## Validation
- npm run typecheck:core
- node --import tsx/esm --test tests/unit/cc-compatible-provider.test.mjs
- node --import tsx/esm --test tests/unit/managed-available-models.test.mjs tests/unit/cc-compatible-provider.test.mjs
- npm run test:unit
- live CC-compatible smoke test against https://api-cf.cubence.com (streaming and non-streaming client modes)