### PR TITLE
fix: GitHub Copilot token refresh failure and reasoning field stripping

### DIFF
--- a/open-sse/executors/github.ts
+++ b/open-sse/executors/github.ts
@@ -55,6 +55,19 @@ export class GithubExecutor extends BaseExecutor {
       );
       delete modifiedBody.response_format;
     }
+
+    // Strip reasoning_text / reasoning_content from assistant messages.
+    // GitHub Copilot converts these into Anthropic thinking blocks but cannot
+    // supply a valid `signature`, causing upstream 400 errors.
+    if (Array.isArray(modifiedBody.messages)) {
+      for (const msg of modifiedBody.messages) {
+        if (msg.role === "assistant") {
+          delete msg.reasoning_text;
+          delete msg.reasoning_content;
+        }
+      }
+    }
+
     return modifiedBody;
   }
 
@@ -167,6 +180,10 @@ export class GithubExecutor extends BaseExecutor {
             ...githubTokens,
             copilotToken: copilotResult.token,
             copilotTokenExpiresAt: copilotResult.expiresAt,
+            providerSpecificData: {
+              copilotToken: copilotResult.token,
+              copilotTokenExpiresAt: copilotResult.expiresAt,
+            },
           };
         }
         return githubTokens;
@@ -179,6 +196,10 @@ export class GithubExecutor extends BaseExecutor {
         refreshToken: credentials.refreshToken,
         copilotToken: copilotResult.token,
         copilotTokenExpiresAt: copilotResult.expiresAt,
+        providerSpecificData: {
+          copilotToken: copilotResult.token,
+          copilotTokenExpiresAt: copilotResult.expiresAt,
+        },
       };
     }
 

--- a/src/sse/services/tokenRefresh.ts
+++ b/src/sse/services/tokenRefresh.ts
@@ -141,6 +141,8 @@ export async function checkAndRefreshToken(provider: string, credentials: any) {
           copilotToken: copilotToken.token,
           copilotTokenExpiresAt: copilotToken.expiresAt,
         };
+        // Sync to top-level so buildHeaders() picks up the fresh token
+        updatedCredentials.copilotToken = copilotToken.token;
       }
     }
   }


### PR DESCRIPTION
## Summary

Fixes two bugs affecting GitHub Copilot provider reliability:

1. **400 "Invalid signature in thinking block"** — When multi-turn conversations include
   `reasoning_text`/`reasoning_content` on assistant messages (sent by AI coding clients),
   GitHub Copilot converts these into Anthropic `thinking` blocks but cannot supply a valid
   cryptographic `signature`, causing Claude to reject with HTTP 400.

2. **401 token refresh not persisted** — After the short-lived Copilot API token (~30 min)
   expires, the refresh logic had two issues:
   - `checkAndRefreshToken` refreshed the token into `providerSpecificData.copilotToken`
     but `buildHeaders()` reads from top-level `credentials.copilotToken`, so requests
     continued using the stale token.
   - `refreshCredentials` (401 retry path) returned credentials without
     `providerSpecificData`, so `onCredentialsRefreshed` could not persist the new token
     to the database.

## Changes

- **`open-sse/executors/github.ts`**:
  - Strip `reasoning_text` and `reasoning_content` from assistant messages in
    `transformRequest()` before forwarding to GitHub Copilot
  - Include `providerSpecificData` in both return branches of `refreshCredentials()`
    so the refreshed token is persisted to DB correctly

- **`src/sse/services/tokenRefresh.ts`**:
  - Sync refreshed `copilotToken` to top-level credentials so `buildHeaders()` picks
    up the fresh token instead of the stale one