### PR TITLE
feat(github): add Gemini 3.1 Pro Preview to GitHub Copilot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1635,7 +1635,7 @@ Dashboard → Providers → Connect GitHub
 Models:
   gh/gpt-5
   gh/claude-4.5-sonnet
-  gh/gemini-3-pro
+  gh/gemini-3.1-pro-preview
 ```
 
 </details>

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -164,7 +164,7 @@ Dashboard → Providers → Connect GitHub
 Models:
   gh/gpt-5
   gh/claude-4.5-sonnet
-  gh/gemini-3-pro
+  gh/gemini-3.1-pro-preview
 ```
 
 ### 💰 Cheap Providers

--- a/open-sse/config/providerRegistry.ts
+++ b/open-sse/config/providerRegistry.ts
@@ -439,6 +439,7 @@ export const REGISTRY: Record<string, RegistryEntry> = {
       { id: "claude-opus-4-5-20251101", name: "Claude Opus 4.5 (Full ID)" },
       { id: "claude-sonnet-4", name: "Claude Sonnet 4" },
       { id: "claude-sonnet-4.5", name: "Claude Sonnet 4.5" },
+      { id: "gemini-3.1-pro-preview", name: "Gemini 3.1 Pro Preview" },
       { id: "gemini-2.5-pro", name: "Gemini 2.5 Pro" },
       { id: "gemini-2.5-flash", name: "Gemini 2.5 Flash" },
       { id: "grok-code-fast-1", name: "Grok Code Fast 1" },
@@ -1556,7 +1557,9 @@ const _passthroughProviderIds: Set<string> | null = (() => {
       if (entry.passthroughModels) ids.add(entry.id);
     }
     return ids;
-  } catch { return null; }
+  } catch {
+    return null;
+  }
 })();
 
 export function getPassthroughProviders(): Set<string> {

--- a/open-sse/services/model.ts
+++ b/open-sse/services/model.ts
@@ -19,7 +19,8 @@ const PROVIDER_MODEL_ALIASES = {
   github: {
     "claude-4.5-opus": "claude-opus-4-5-20251101",
     "claude-opus-4.5": "claude-opus-4-5-20251101",
-    "gemini-3-pro": "gemini-3-pro-preview",
+    "gemini-3-pro": "gemini-3.1-pro-preview",
+    "gemini-3-pro-preview": "gemini-3.1-pro-preview",
     "gemini-3-flash": "gemini-3-flash-preview",
     "raptor-mini": "oswe-vscode-prime",
   },

--- a/tests/unit/t28-model-catalog-updates.test.mjs
+++ b/tests/unit/t28-model-catalog-updates.test.mjs
@@ -25,6 +25,20 @@ test("T28: antigravity static catalog exposes current Gemini 3.1 model IDs", () 
   assert.ok(!staticIds.includes("gemini-3-pro-low"));
 });
 
+test("T28: github registry exposes Gemini 3.1 Pro Preview and keeps legacy alias compatibility", async () => {
+  const githubIds = REGISTRY.github.models.map((m) => m.id);
+
+  assert.ok(githubIds.includes("gemini-3.1-pro-preview"));
+
+  const canonical = await getModelInfoCore("gh/gemini-3.1-pro-preview", {});
+  assert.equal(canonical.provider, "github");
+  assert.equal(canonical.model, "gemini-3.1-pro-preview");
+
+  const legacy = await getModelInfoCore("gh/gemini-3-pro", {});
+  assert.equal(legacy.provider, "github");
+  assert.equal(legacy.model, "gemini-3.1-pro-preview");
+});
+
 test("T28: qwen registry uses native chat.qwen.ai base URL", () => {
   assert.equal(
     REGISTRY.qwen.baseUrl,


### PR DESCRIPTION
## What changed
- add `gemini-3.1-pro-preview` to the GitHub Copilot model registry
- keep legacy GitHub Copilot Gemini aliases resolving to the new canonical model ID
- update user-facing docs to show the new explicit model ID
- add regression coverage for the GitHub registry entry and alias resolution

## Why
GitHub Copilot should expose `gemini-3.1-pro-preview` directly in the static catalog and model routing layer, while preserving compatibility for existing `gh/gemini-3-pro` usage.

## Validation
- `node --import tsx/esm --test tests/unit/t28-model-catalog-updates.test.mjs`
- `npx eslint open-sse/config/providerRegistry.ts open-sse/services/model.ts tests/unit/t28-model-catalog-updates.test.mjs`
- pre-commit hook ran `npm run test:unit`
