### PR TITLE
fix(resilience): prevent circuit breaker stuck OPEN in combo path

### DIFF
--- a/src/shared/utils/circuitBreaker.ts
+++ b/src/shared/utils/circuitBreaker.ts
@@ -203,6 +203,7 @@ export class CircuitBreaker {
       this._transition(STATE.CLOSED);
       this.failureCount = 0;
       this.successCount = 0;
+      this.lastFailureTime = null;
     } else if (this.state === STATE.HALF_OPEN) {
       this.successCount++;
       this._transition(STATE.CLOSED);


### PR DESCRIPTION
## Summary
- Fix circuit breakers becoming permanently stuck in `OPEN` state with 0 failures in combo handlers
- `_onSuccess()` now transitions `OPEN → CLOSED` when called directly (combo path bypasses `execute()`)
- `_onFailure()` skips redundant re-transition when already `OPEN`

## Problem
Combo handlers (`handleComboChat`, `handleRoundRobinCombo`) call `_onSuccess()`/`_onFailure()` directly instead of `execute()`. After `resetTimeout` elapses, `canExecute()` returns true and requests flow through, but `_onSuccess()` only reset `failureCount` without changing state — leaving the breaker permanently `OPEN` with 0 failures displayed on the health dashboard.

## Test plan
- [x] All pre-commit hooks pass (lint, typecheck, unit tests)
- [ ] Verify on live instance: trigger a combo provider circuit breaker OPEN, confirm it auto-recovers after `resetTimeout` + successful request
- [ ] Confirm health dashboard shows provider transitioning from "Down" back to "Healthy"

🤖 Generated with [Claude Code](https://claude.com/claude-code)