### PR TITLE
fix(auth): fix NVIDIA credential lookup failure (#922)

### DIFF
--- a/src/sse/services/auth.ts
+++ b/src/sse/services/auth.ts
@@ -15,7 +15,10 @@ import {
   isModelLocked,
   lockModel,
 } from "@omniroute/open-sse/services/accountFallback.ts";
-import { isLocalProvider, getPassthroughProviders } from "@omniroute/open-sse/config/providerRegistry.ts";
+import {
+  isLocalProvider,
+  getPassthroughProviders,
+} from "@omniroute/open-sse/config/providerRegistry.ts";
 import { COOLDOWN_MS } from "@omniroute/open-sse/config/constants.ts";
 import { getCodexModelScope } from "@omniroute/open-sse/executors/codex.ts";
 import * as log from "../utils/logger";
@@ -308,6 +311,16 @@ const markMutexes = new Map<string, Promise<void>>();
 export { fisherYatesShuffle, getNextFromDeckSync as getNextFromDeck };
 
 /**
+ * Resolve provider aliases (e.g., nvidia -> nvidia_nim) for DB lookup
+ */
+function getProviderSearchPool(provider: string): string[] {
+  const pool = [provider];
+  if (provider === "nvidia") pool.push("nvidia_nim");
+  if (provider === "nvidia_nim") pool.push("nvidia");
+  return [...new Set(pool)];
+}
+
+/**
  * Get provider credentials from localDb
  * Filters out unavailable accounts and returns the selected account based on strategy
  * @param {string} provider - Provider name
@@ -333,7 +346,14 @@ export async function getProviderCredentials(
     const allowSuppressedConnections = options.allowSuppressedConnections === true;
     const bypassQuotaPolicy = options.bypassQuotaPolicy === true;
 
-    const connectionsRaw = await getProviderConnections({ provider, isActive: true });
+    // Fix #922: Check for aliases (nvidia/nvidia_nim) to ensure credentials are found
+    const providersToSearch = getProviderSearchPool(provider);
+    let connectionsRaw: any[] = [];
+    for (const p of providersToSearch) {
+      const results = await getProviderConnections({ provider: p, isActive: true });
+      if (Array.isArray(results)) connectionsRaw.push(...results);
+    }
+
     let connections = (Array.isArray(connectionsRaw) ? connectionsRaw : [])
       .map(toProviderConnection)
       .filter((conn) => conn.id.length > 0);
@@ -348,7 +368,12 @@ export async function getProviderCredentials(
 
     if (connections.length === 0) {
       // Check all connections (including inactive) to see if rate limited
-      const allConnectionsRaw = await getProviderConnections({ provider });
+      // Fix #922: Also search aliases here
+      let allConnectionsRaw: any[] = [];
+      for (const p of providersToSearch) {
+        const results = await getProviderConnections({ provider: p });
+        if (Array.isArray(results)) allConnectionsRaw.push(...results);
+      }
       const allConnections = (Array.isArray(allConnectionsRaw) ? allConnectionsRaw : [])
         .map(toProviderConnection)
         .filter((conn) => conn.id.length > 0);
@@ -793,7 +818,12 @@ export async function markAccountUnavailable(
       | undefined;
 
     const isPassthroughProvider = provider && getPassthroughProviders().has(provider);
-    if ((isLocalProvider(connBaseUrl) || isPassthroughProvider) && status === 404 && provider && model) {
+    if (
+      (isLocalProvider(connBaseUrl) || isPassthroughProvider) &&
+      status === 404 &&
+      provider &&
+      model
+    ) {
       const localCooldown = COOLDOWN_MS.notFoundLocal;
       lockModel(provider, connectionId, model, "not_found", localCooldown);
       log.info(


### PR DESCRIPTION
## Summary
Fixes a bug where NVIDIA TTS credentials could not be found if they were stored under the `nvidia_nim` provider identifier in the database.

## Changes
- Added provider search pool logic to `getProviderCredentials` to search for both `nvidia` and `nvidia_nim` aliases.
- Updated the "no credentials found" check to also search across aliases before reporting failure.
- This ensures Media Playground TTS works correctly when valid NVIDIA credentials exist.