### PR TITLE
Restore Claude OAuth localhost callback handling

### DIFF
--- a/src/lib/oauth/providers/claude.ts
+++ b/src/lib/oauth/providers/claude.ts
@@ -3,12 +3,12 @@ import { CLAUDE_CONFIG } from "../constants/oauth";
 export const claude = {
   config: CLAUDE_CONFIG,
   flowType: "authorization_code_pkce",
-  buildAuthUrl: (config, redirectUri, state, codeChallenge) => {
+  buildAuthUrl: (config, _redirectUri, state, codeChallenge) => {
     const params = new URLSearchParams({
       code: "true",
       client_id: config.clientId,
       response_type: "code",
-      redirect_uri: redirectUri,
+      redirect_uri: config.redirectUri,
       scope: config.scopes.join(" "),
       code_challenge: codeChallenge,
       code_challenge_method: config.codeChallengeMethod,
@@ -16,7 +16,7 @@ export const claude = {
     });
     return `${config.authorizeUrl}?${params.toString()}`;
   },
-  exchangeToken: async (config, code, redirectUri, codeVerifier, state) => {
+  exchangeToken: async (config, code, _redirectUri, codeVerifier, state) => {
     let authCode = code;
     let codeState = "";
     if (authCode.includes("#")) {
@@ -36,7 +36,7 @@ export const claude = {
         state: codeState || state,
         grant_type: "authorization_code",
         client_id: config.clientId,
-        redirect_uri: redirectUri,
+        redirect_uri: config.redirectUri,
         code_verifier: codeVerifier,
       }),
     });

--- a/tests/unit/claude-oauth-provider.test.mjs
+++ b/tests/unit/claude-oauth-provider.test.mjs
@@ -10,17 +10,22 @@ test.afterEach(() => {
   globalThis.fetch = originalFetch;
 });
 
-test("Claude OAuth provider uses the runtime redirectUri when building the auth URL", () => {
-  const redirectUri = "http://localhost:43121/callback";
-  const authUrl = claude.buildAuthUrl(CLAUDE_CONFIG, redirectUri, "state-123", "challenge-456");
+test("Claude OAuth provider always uses the configured redirectUri when building the auth URL", () => {
+  const runtimeRedirectUri = "http://localhost:43121/callback";
+  const authUrl = claude.buildAuthUrl(
+    CLAUDE_CONFIG,
+    runtimeRedirectUri,
+    "state-123",
+    "challenge-456"
+  );
   const parsed = new URL(authUrl);
 
-  assert.equal(parsed.searchParams.get("redirect_uri"), redirectUri);
+  assert.equal(parsed.searchParams.get("redirect_uri"), CLAUDE_CONFIG.redirectUri);
   assert.equal(parsed.searchParams.get("state"), "state-123");
   assert.equal(parsed.searchParams.get("code_challenge"), "challenge-456");
 });
 
-test("Claude OAuth provider uses the runtime redirectUri during token exchange", async () => {
+test("Claude OAuth provider always uses the configured redirectUri during token exchange", async () => {
   let captured = null;
 
   globalThis.fetch = async (url, init = {}) => {
@@ -37,18 +42,18 @@ test("Claude OAuth provider uses the runtime redirectUri during token exchange",
     });
   };
 
-  const redirectUri = "http://localhost:43121/callback";
+  const runtimeRedirectUri = "http://localhost:43121/callback";
   await claude.exchangeToken(
     CLAUDE_CONFIG,
     "auth-code#state-from-fragment",
-    redirectUri,
+    runtimeRedirectUri,
     "verifier-123",
     "state-from-request"
   );
 
   assert.equal(captured.url, CLAUDE_CONFIG.tokenUrl);
   assert.equal(captured.method, "POST");
-  assert.equal(captured.body.redirect_uri, redirectUri);
+  assert.equal(captured.body.redirect_uri, CLAUDE_CONFIG.redirectUri);
   assert.equal(captured.body.code, "auth-code");
   assert.equal(captured.body.state, "state-from-fragment");
   assert.equal(captured.body.code_verifier, "verifier-123");


### PR DESCRIPTION
## Summary

This PR restores Claude OAuth to always use Anthropic's configured callback URL instead of the runtime callback passed in by OmniRoute.

## Root Cause

A recent change switched Claude OAuth to use the runtime `redirectUri` parameter in both the authorization URL and token exchange request. That behavior matches some other OAuth providers, but Claude's OAuth registration is tied to its configured callback and must not be overridden dynamically.

## What Changed

- make `src/lib/oauth/providers/claude.ts` always use `config.redirectUri` for both auth URL construction and token exchange
- update the Claude OAuth regression test to assert that runtime callback values cannot override the configured callback

## Validation

- `node --import tsx/esm --test tests/unit/claude-oauth-provider.test.mjs`
- `npx eslint src/lib/oauth/providers/claude.ts tests/unit/claude-oauth-provider.test.mjs`
- pre-commit hook ran the repository `test:unit` suite successfully during commit

## Impact

Claude OAuth flows keep using the expected configured callback URL, which restores compatibility with Claude's localhost-bound OAuth callback behavior.
