### PR TITLE
fix: keep cc-compatible cache ttl ordering valid

### DIFF
--- a/open-sse/services/claudeCodeCompatible.ts
+++ b/open-sse/services/claudeCodeCompatible.ts
@@ -397,8 +397,14 @@ function buildClaudeCodeCompatibleSystemBlocks({
 }) {
   const customSystemBlocks =
     Array.isArray(systemBlocks) && systemBlocks.length > 0
-      ? systemBlocks
+      ? systemBlocks.map((block) => ({ ...block }))
       : extractCustomSystemBlocks(messages);
+  const useLongSystemTtl =
+    !preserveCacheControl ||
+    customSystemBlocks.some((block) => readCacheControlTtl(block) === "1h");
+  const systemCacheControl = useLongSystemTtl
+    ? { type: "ephemeral", ttl: "1h" }
+    : { type: "ephemeral" };
 
   const dateText = formatDate(now);
   const blocks: Array<Record<string, unknown>> = [
@@ -409,17 +415,21 @@ function buildClaudeCodeCompatibleSystemBlocks({
     {
       type: "text",
       text: "You are a Claude agent, built on Anthropic's Claude Agent SDK.",
-      cache_control: { type: "ephemeral" },
+      cache_control: { ...systemCacheControl },
     },
     {
       type: "text",
       text: `You are Claude Code, Anthropic's official CLI for Claude.\n\nCWD: ${cwd}\nDate: ${dateText}`,
-      cache_control: { type: "ephemeral" },
+      cache_control: { ...systemCacheControl },
     },
   ];
 
   for (const systemBlock of customSystemBlocks) {
-    blocks.push(systemBlock);
+    const preparedBlock = { ...systemBlock };
+    if (!preserveCacheControl || useLongSystemTtl) {
+      preparedBlock.cache_control = { ...systemCacheControl };
+    }
+    blocks.push(preparedBlock);
   }
 
   if (
@@ -427,8 +437,8 @@ function buildClaudeCodeCompatibleSystemBlocks({
     customSystemBlocks.length > 0 &&
     !customSystemBlocks.some((block) => hasCacheControl(block))
   ) {
-    const lastCustomSystemBlock = customSystemBlocks[customSystemBlocks.length - 1];
-    lastCustomSystemBlock.cache_control = { type: "ephemeral", ttl: "1h" };
+    const lastCustomSystemBlock = blocks[blocks.length - 1];
+    lastCustomSystemBlock.cache_control = { ...systemCacheControl };
   }
 
   return blocks;
@@ -650,7 +660,7 @@ function convertClaudeCodeCompatibleClaudeMessage(
 function extractCustomSystemBlocks(messages: MessageLike[] | undefined) {
   if (!Array.isArray(messages)) return [];
 
-  const blocks = messages
+  return messages
     .filter((message) => {
       const role = String(message?.role || "").toLowerCase();
       return role === "system" || role === "developer";
@@ -660,14 +670,7 @@ function extractCustomSystemBlocks(messages: MessageLike[] | undefined) {
     .map((text) => ({
       type: "text",
       text,
-      cache_control: { type: "ephemeral" },
     }));
-
-  if (blocks.length > 0) {
-    blocks[blocks.length - 1].cache_control = { type: "ephemeral", ttl: "1h" };
-  }
-
-  return blocks;
 }
 
 function applyClaudeCodeCompatibleMessageCacheStrategy(
@@ -760,6 +763,10 @@ function markLastContentCacheControl(
 
 function hasCacheControl(value: unknown) {
   return !!readRecord(value)?.cache_control && typeof readRecord(value)?.cache_control === "object";
+}
+
+function readCacheControlTtl(value: unknown) {
+  return toNonEmptyString(readRecord(readRecord(value)?.cache_control)?.ttl);
 }
 
 function findLastCacheableToolIndex(tools: Array<Record<string, unknown>>) {

--- a/tests/unit/cc-compatible-provider.test.mjs
+++ b/tests/unit/cc-compatible-provider.test.mjs
@@ -109,6 +109,9 @@ test("buildClaudeCodeCompatibleRequest keeps prior role history while dropping t
   assert.deepEqual(payload.messages[2].content.at(-1).cache_control, { type: "ephemeral" });
   assert.equal(payload.system.length, 4);
   assert.equal(payload.system.at(-1).text, "sys");
+  assert.deepEqual(payload.system[1].cache_control, { type: "ephemeral", ttl: "1h" });
+  assert.deepEqual(payload.system[2].cache_control, { type: "ephemeral", ttl: "1h" });
+  assert.deepEqual(payload.system[3].cache_control, { type: "ephemeral", ttl: "1h" });
   assert.equal(payload.tools.length, 1);
   const { cache_control, ...toolWithoutCacheControl } = payload.tools[0];
   assert.deepEqual(toolWithoutCacheControl, {
@@ -230,7 +233,36 @@ test("buildClaudeCodeCompatibleRequest supplements missing Claude cache markers 
   assert.deepEqual(payload.messages[0].content[0].cache_control, { type: "ephemeral" });
   assert.deepEqual(payload.messages[1].content[0].cache_control, { type: "ephemeral" });
   assert.deepEqual(payload.messages[2].content[0].cache_control, { type: "ephemeral" });
+  assert.deepEqual(payload.system.at(-1).cache_control, { type: "ephemeral" });
   assert.deepEqual(payload.tools[0].cache_control, { type: "ephemeral", ttl: "1h" });
+});
+
+test("buildClaudeCodeCompatibleRequest upgrades built-in system cache markers when preserved system uses 1h", () => {
+  const payload = buildClaudeCodeCompatibleRequest({
+    sourceBody: {
+      max_tokens: 64,
+    },
+    normalizedBody: {
+      max_tokens: 64,
+      messages: [{ role: "user", content: "fallback" }],
+    },
+    claudeBody: {
+      system: [
+        { type: "text", text: "prefix", cache_control: { type: "ephemeral" } },
+        { type: "text", text: "stable", cache_control: { type: "ephemeral", ttl: "1h" } },
+      ],
+      messages: [{ role: "user", content: [{ type: "text", text: "u1" }] }],
+      tools: [],
+    },
+    model: "claude-sonnet-4-6",
+    sessionId: "session-preserve-system-upgrade",
+    preserveCacheControl: true,
+  });
+
+  assert.deepEqual(payload.system[1].cache_control, { type: "ephemeral", ttl: "1h" });
+  assert.deepEqual(payload.system[2].cache_control, { type: "ephemeral", ttl: "1h" });
+  assert.deepEqual(payload.system[3].cache_control, { type: "ephemeral", ttl: "1h" });
+  assert.deepEqual(payload.system[4].cache_control, { type: "ephemeral", ttl: "1h" });
 });
 
 test("buildClaudeCodeCompatibleRequest marks final user turn and 1h system cache in non-preserve mode", () => {
@@ -257,10 +289,9 @@ test("buildClaudeCodeCompatibleRequest marks final user turn and 1h system cache
     preserveCacheControl: false,
   });
 
-  assert.deepEqual(payload.system.at(-1).cache_control, {
-    type: "ephemeral",
-    ttl: "1h",
-  });
+  assert.deepEqual(payload.system[1].cache_control, { type: "ephemeral", ttl: "1h" });
+  assert.deepEqual(payload.system[2].cache_control, { type: "ephemeral", ttl: "1h" });
+  assert.deepEqual(payload.system[3].cache_control, { type: "ephemeral", ttl: "1h" });
   assert.deepEqual(payload.messages[0].content[0].cache_control, { type: "ephemeral" });
   assert.deepEqual(payload.messages[1].content[0].cache_control, { type: "ephemeral" });
   assert.deepEqual(payload.messages[2].content[0].cache_control, { type: "ephemeral" });


### PR DESCRIPTION
## Summary

This PR fixes invalid prompt-cache TTL ordering for Claude Code compatible providers.

## Root Cause

CC-compatible requests could mix cache markers so that a `ttl: "1h"` system block appeared after `ephemeral` (`5m`) cache markers in Anthropic's processing order. Anthropic validates cache TTLs across `tools -> system -> messages`, so that mixed ordering caused upstream request failures.

## What Changed

- Normalize CC-compatible system cache markers so the cacheable system block set uses a compatible TTL ordering.
- In OmniRoute-managed mode, apply `1h` consistently across the cacheable system group instead of mixing short-lived and long-lived system markers.
- In preserve mode, upgrade built-in system markers when preserved system blocks already use `1h`, and avoid injecting an incompatible late `1h` marker when the preserved system set does not.
- Add regression tests covering both OmniRoute-managed and preserve-mode TTL ordering.

## Validation

- `node --import tsx/esm --test tests/unit/cc-compatible-provider.test.mjs`
- `npx eslint open-sse/services/claudeCodeCompatible.ts tests/unit/cc-compatible-provider.test.mjs`
- `npx prettier --check open-sse/services/claudeCodeCompatible.ts tests/unit/cc-compatible-provider.test.mjs`

## Repro Covered

This specifically addresses real upstream failures like:

- `system.2.cache_control.ttl: a ttl='1h' cache_control block must not come after a ttl='5m' cache_control block`
