### PR TITLE
Clarify provider grouping and add a configured-only filter

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/page.tsx
+++ b/src/app/(dashboard)/dashboard/providers/page.tsx
@@ -26,6 +26,11 @@ import { getErrorCode, getRelativeTime } from "@/shared/utils";
 import { useNotificationStore } from "@/store/notificationStore";
 import ModelAvailabilityBadge from "./components/ModelAvailabilityBadge";
 import { useTranslations } from "next-intl";
+import {
+  buildMergedOAuthProviderEntries,
+  buildProviderEntries,
+  filterConfiguredProviderEntries,
+} from "./providerPageUtils";
 
 const CC_COMPATIBLE_LABEL = "CC Compatible";
 const ADD_CC_COMPATIBLE_LABEL = "Add CC Compatible";
@@ -109,6 +114,7 @@ export default function ProvidersPage() {
   const [testingMode, setTestingMode] = useState<string | null>(null);
   const [testResults, setTestResults] = useState<any>(null);
   const [importingZed, setImportingZed] = useState(false);
+  const [showConfiguredOnly, setShowConfiguredOnly] = useState(false);
   const notify = useNotificationStore();
   const t = useTranslations("providers");
   const tc = useTranslations("common");
@@ -320,6 +326,43 @@ export default function ProvidersPage() {
       textIcon: "CC",
     }));
 
+  const oauthProviderEntries = filterConfiguredProviderEntries(
+    buildMergedOAuthProviderEntries(OAUTH_PROVIDERS, FREE_PROVIDERS, getProviderStats),
+    showConfiguredOnly
+  );
+
+  const apiKeyProviderEntries = filterConfiguredProviderEntries(
+    buildProviderEntries(APIKEY_PROVIDERS, "apikey", "apikey", getProviderStats),
+    showConfiguredOnly
+  );
+
+  const compatibleProviderEntries = filterConfiguredProviderEntries(
+    [
+      ...compatibleProviders.map((provider) => ({
+        providerId: provider.id,
+        provider,
+        stats: getProviderStats(provider.id, "apikey"),
+        displayAuthType: "compatible" as const,
+        toggleAuthType: "apikey" as const,
+      })),
+      ...anthropicCompatibleProviders.map((provider) => ({
+        providerId: provider.id,
+        provider,
+        stats: getProviderStats(provider.id, "apikey"),
+        displayAuthType: "compatible" as const,
+        toggleAuthType: "apikey" as const,
+      })),
+      ...ccCompatibleProviders.map((provider) => ({
+        providerId: provider.id,
+        provider,
+        stats: getProviderStats(provider.id, "apikey"),
+        displayAuthType: "compatible" as const,
+        toggleAuthType: "apikey" as const,
+      })),
+    ],
+    showConfiguredOnly
+  );
+
   if (loading) {
     return (
       <div className="flex flex-col gap-8">
@@ -365,7 +408,7 @@ export default function ProvidersPage() {
           </div>
         )}
 
-      {/* OAuth Providers */}
+      {/* OAuth Providers (including providers that expose free tiers via OAuth) */}
       <div className="flex flex-col gap-4">
         <div className="flex flex-wrap items-center gap-2">
           <h2 className="text-xl font-semibold flex items-center gap-2 flex-1 min-w-0">
@@ -374,6 +417,13 @@ export default function ProvidersPage() {
           </h2>
           <div className="flex items-center gap-2">
             <ModelAvailabilityBadge />
+            <Toggle
+              size="sm"
+              checked={showConfiguredOnly}
+              onChange={setShowConfiguredOnly}
+              label={t("showConfiguredOnly")}
+              className="rounded-lg border border-border bg-bg-subtle px-3 py-1.5"
+            />
             <button
               onClick={handleZedImport}
               disabled={importingZed}
@@ -406,54 +456,18 @@ export default function ProvidersPage() {
           </div>
         </div>
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-          {Object.entries(OAUTH_PROVIDERS).map(([key, info]) => (
-            <ProviderCard
-              key={key}
-              providerId={key}
-              provider={info}
-              stats={getProviderStats(key, "oauth")}
-              authType="oauth"
-              onToggle={(active) => handleToggleProvider(key, "oauth", active)}
-            />
-          ))}
-        </div>
-      </div>
-
-      {/* Free Providers */}
-      <div className="flex flex-col gap-4">
-        <div className="flex flex-wrap items-center gap-2">
-          <h2 className="text-xl font-semibold flex items-center gap-2 flex-1 min-w-0">
-            {t("freeProviders")}{" "}
-            <span className="size-2.5 rounded-full bg-green-500" title={tc("free")} />
-          </h2>
-          <button
-            onClick={() => handleBatchTest("free")}
-            disabled={!!testingMode}
-            className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border transition-colors ${
-              testingMode === "free"
-                ? "bg-primary/20 border-primary/40 text-primary animate-pulse"
-                : "bg-bg-subtle border-border text-text-muted hover:text-text-primary hover:border-primary/40"
-            }`}
-            title={t("testAllFree")}
-            aria-label={t("testAllFree")}
-          >
-            <span className="material-symbols-outlined text-[14px]">
-              {testingMode === "free" ? "sync" : "play_arrow"}
-            </span>
-            {testingMode === "free" ? t("testing") : t("testAll")}
-          </button>
-        </div>
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-          {Object.entries(FREE_PROVIDERS).map(([key, info]) => (
-            <ProviderCard
-              key={key}
-              providerId={key}
-              provider={info}
-              stats={getProviderStats(key, "free")}
-              authType="free"
-              onToggle={(active) => handleToggleProvider(key, "free", active)}
-            />
-          ))}
+          {oauthProviderEntries.map(
+            ({ providerId, provider, stats, displayAuthType, toggleAuthType }) => (
+              <ProviderCard
+                key={providerId}
+                providerId={providerId}
+                provider={provider}
+                stats={stats}
+                authType={displayAuthType}
+                onToggle={(active) => handleToggleProvider(providerId, toggleAuthType, active)}
+              />
+            )
+          )}
         </div>
       </div>
 
@@ -482,16 +496,18 @@ export default function ProvidersPage() {
           </button>
         </div>
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-          {Object.entries(APIKEY_PROVIDERS).map(([key, info]) => (
-            <ApiKeyProviderCard
-              key={key}
-              providerId={key}
-              provider={info}
-              stats={getProviderStats(key, "apikey")}
-              authType="apikey"
-              onToggle={(active) => handleToggleProvider(key, "apikey", active)}
-            />
-          ))}
+          {apiKeyProviderEntries.map(
+            ({ providerId, provider, stats, displayAuthType, toggleAuthType }) => (
+              <ApiKeyProviderCard
+                key={providerId}
+                providerId={providerId}
+                provider={provider}
+                stats={stats}
+                authType={displayAuthType}
+                onToggle={(active) => handleToggleProvider(providerId, toggleAuthType, active)}
+              />
+            )
+          )}
         </div>
       </div>
 
@@ -547,20 +563,18 @@ export default function ProvidersPage() {
           </div>
         ) : (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-            {[
-              ...compatibleProviders,
-              ...anthropicCompatibleProviders,
-              ...ccCompatibleProviders,
-            ].map((info) => (
-              <ApiKeyProviderCard
-                key={info.id}
-                providerId={info.id}
-                provider={info}
-                stats={getProviderStats(info.id, "apikey")}
-                authType="compatible"
-                onToggle={(active) => handleToggleProvider(info.id, "apikey", active)}
-              />
-            ))}
+            {compatibleProviderEntries.map(
+              ({ providerId, provider, stats, displayAuthType, toggleAuthType }) => (
+                <ApiKeyProviderCard
+                  key={providerId}
+                  providerId={providerId}
+                  provider={provider}
+                  stats={stats}
+                  authType={displayAuthType}
+                  onToggle={(active) => handleToggleProvider(providerId, toggleAuthType, active)}
+                />
+              )
+            )}
           </div>
         )}
       </div>

--- a/src/app/(dashboard)/dashboard/providers/providerPageUtils.ts
+++ b/src/app/(dashboard)/dashboard/providers/providerPageUtils.ts
@@ -1,0 +1,54 @@
+export interface ProviderStatsSnapshot {
+  total?: number;
+  [key: string]: unknown;
+}
+
+export interface ProviderEntry<TProvider = Record<string, unknown>> {
+  providerId: string;
+  provider: TProvider;
+  stats: ProviderStatsSnapshot;
+  displayAuthType: "oauth" | "apikey" | "compatible";
+  toggleAuthType: "oauth" | "free" | "apikey";
+}
+
+type ProviderRecord<TProvider = Record<string, unknown>> = Record<string, TProvider>;
+
+type GetProviderStats = (
+  providerId: string,
+  authType: "oauth" | "free" | "apikey"
+) => ProviderStatsSnapshot;
+
+export function buildProviderEntries<TProvider = Record<string, unknown>>(
+  providers: ProviderRecord<TProvider>,
+  displayAuthType: ProviderEntry["displayAuthType"],
+  toggleAuthType: ProviderEntry["toggleAuthType"],
+  getProviderStats: GetProviderStats
+): ProviderEntry<TProvider>[] {
+  return Object.entries(providers).map(([providerId, provider]) => ({
+    providerId,
+    provider,
+    stats: getProviderStats(providerId, toggleAuthType),
+    displayAuthType,
+    toggleAuthType,
+  }));
+}
+
+export function buildMergedOAuthProviderEntries<TProvider = Record<string, unknown>>(
+  oauthProviders: ProviderRecord<TProvider>,
+  freeProviders: ProviderRecord<TProvider>,
+  getProviderStats: GetProviderStats
+): ProviderEntry<TProvider>[] {
+  return [
+    ...buildProviderEntries(oauthProviders, "oauth", "oauth", getProviderStats),
+    ...buildProviderEntries(freeProviders, "oauth", "free", getProviderStats),
+  ];
+}
+
+export function filterConfiguredProviderEntries<TProvider>(
+  entries: ProviderEntry<TProvider>[],
+  showConfiguredOnly: boolean
+): ProviderEntry<TProvider>[] {
+  if (!showConfiguredOnly) return entries;
+
+  return entries.filter((entry) => Number(entry.stats?.total || 0) > 0);
+}

--- a/src/app/api/providers/test-batch/route.ts
+++ b/src/app/api/providers/test-batch/route.ts
@@ -65,7 +65,10 @@ export async function POST(request) {
     if (mode === "provider" && providerId) {
       connectionsToTest = allConnections.filter((c) => c.provider === providerId);
     } else if (mode === "oauth") {
-      connectionsToTest = allConnections.filter((c) => getAuthGroup(c.provider) === "oauth");
+      connectionsToTest = allConnections.filter((c) => {
+        const authGroup = getAuthGroup(c.provider);
+        return authGroup === "oauth" || authGroup === "free";
+      });
     } else if (mode === "free") {
       connectionsToTest = allConnections.filter((c) => getAuthGroup(c.provider) === "free");
     } else if (mode === "apikey") {

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -1490,6 +1490,7 @@
     "failedCreate": "فشل في إنشاء الموفر",
     "errorOccurred": "حدث خطأ. يرجى المحاولة مرة أخرى.",
     "modelStatus": "حالة النموذج",
+    "showConfiguredOnly": "Configured only",
     "allModelsOperational": "جميع الموديلات شغالة",
     "modelsWithIssues": "{count} الطراز (النماذج) الذي به مشكلات",
     "allModelsNormal": "جميع النماذج تستجيب بشكل طبيعي.",

--- a/src/i18n/messages/bg.json
+++ b/src/i18n/messages/bg.json
@@ -1490,6 +1490,7 @@
     "failedCreate": "Неуспешно създаване на доставчик",
     "errorOccurred": "Възникна грешка. Моля, опитайте отново.",
     "modelStatus": "Статус на модела",
+    "showConfiguredOnly": "Configured only",
     "allModelsOperational": "Всички модели работещи",
     "modelsWithIssues": "{count} модел(а) с проблеми",
     "allModelsNormal": "Всички модели реагират нормално.",

--- a/src/i18n/messages/cs.json
+++ b/src/i18n/messages/cs.json
@@ -1490,6 +1490,7 @@
     "failedCreate": "Vytvoření poskytovatele selhalo",
     "errorOccurred": "Došlo k chybě. Zkuste to prosím znovu.",
     "modelStatus": "Status modelu",
+    "showConfiguredOnly": "Configured only",
     "allModelsOperational": "Všechny modely funkční",
     "modelsWithIssues": "{count} model(y) s problémy",
     "allModelsNormal": "Všechny modely reagují normálně.",

--- a/src/i18n/messages/da.json
+++ b/src/i18n/messages/da.json
@@ -1490,6 +1490,7 @@
     "failedCreate": "Kunne ikke oprette udbyder",
     "errorOccurred": "Der opstod en fejl. Prøv venligst igen.",
     "modelStatus": "Modelstatus",
+    "showConfiguredOnly": "Configured only",
     "allModelsOperational": "Alle modeller i drift",
     "modelsWithIssues": "{count} model(er) med problemer",
     "allModelsNormal": "Alle modeller reagerer normalt.",

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -1490,6 +1490,7 @@
     "failedCreate": "Anbieter konnte nicht erstellt werden",
     "errorOccurred": "Es ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut.",
     "modelStatus": "Modellstatus",
+    "showConfiguredOnly": "Configured only",
     "allModelsOperational": "Alle Modelle betriebsbereit",
     "modelsWithIssues": "{count} Modell(e) mit Problemen",
     "allModelsNormal": "Alle Modelle reagieren normal.",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1543,6 +1543,7 @@
     "failedCreate": "Failed to create provider",
     "errorOccurred": "An error occurred. Please try again.",
     "modelStatus": "Model Status",
+    "showConfiguredOnly": "Configured only",
     "allModelsOperational": "All models operational",
     "modelsWithIssues": "{count} model(s) with issues",
     "allModelsNormal": "All models are responding normally.",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -1490,6 +1490,7 @@
     "failedCreate": "No se pudo crear el proveedor",
     "errorOccurred": "Se produjo un error. Por favor inténtalo de nuevo.",
     "modelStatus": "Estado del modelo",
+    "showConfiguredOnly": "Configured only",
     "allModelsOperational": "Todos los modelos operativos.",
     "modelsWithIssues": "{count} modelo(s) con problemas",
     "allModelsNormal": "Todos los modelos están respondiendo normalmente.",

--- a/src/i18n/messages/fi.json
+++ b/src/i18n/messages/fi.json
@@ -1490,6 +1490,7 @@
     "failedCreate": "Palveluntarjoajan luominen epäonnistui",
     "errorOccurred": "Tapahtui virhe. Yritä uudelleen.",
     "modelStatus": "Mallin tila",
+    "showConfiguredOnly": "Configured only",
     "allModelsOperational": "Kaikki mallit toimivat",
     "modelsWithIssues": "{count} malli(t), joissa on ongelmia",
     "allModelsNormal": "Kaikki mallit reagoivat normaalisti.",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -1490,6 +1490,7 @@
     "failedCreate": "Échec de la création du fournisseur",
     "errorOccurred": "Une erreur s'est produite. Veuillez réessayer.",
     "modelStatus": "Statut du modèle",
+    "showConfiguredOnly": "Configured only",
     "allModelsOperational": "Tous les modèles opérationnels",
     "modelsWithIssues": "{count} modèle(s) présentant des problèmes",
     "allModelsNormal": "Tous les modèles répondent normalement.",

--- a/src/i18n/messages/he.json
+++ b/src/i18n/messages/he.json
@@ -1490,6 +1490,7 @@
     "failedCreate": "יצירת הספק נכשלה",
     "errorOccurred": "אירעה שגיאה. אנא נסה שוב.",
     "modelStatus": "סטטוס דגם",
+    "showConfiguredOnly": "Configured only",
     "allModelsOperational": "כל הדגמים מבצעיים",
     "modelsWithIssues": "{count} דגמים עם בעיות",
     "allModelsNormal": "כל הדגמים מגיבים כרגיל.",

--- a/src/i18n/messages/hi.json
+++ b/src/i18n/messages/hi.json
@@ -1490,6 +1490,7 @@
     "failedCreate": "प्रदाता बनाने में विफल",
     "errorOccurred": "एक त्रुटि हुई. कृपया पुन: प्रयास करें।",
     "modelStatus": "मॉडल स्थिति",
+    "showConfiguredOnly": "Configured only",
     "allModelsOperational": "सभी मॉडल क्रियाशील",
     "modelsWithIssues": "मुद्दों के साथ {count} मॉडल",
     "allModelsNormal": "सभी मॉडल सामान्य रूप से प्रतिक्रिया दे रहे हैं।",

--- a/src/i18n/messages/hu.json
+++ b/src/i18n/messages/hu.json
@@ -1490,6 +1490,7 @@
     "failedCreate": "Nem sikerült létrehozni a szolgáltatót",
     "errorOccurred": "Hiba történt. Kérjük, próbálja újra.",
     "modelStatus": "Modell állapota",
+    "showConfiguredOnly": "Configured only",
     "allModelsOperational": "Minden modell működőképes",
     "modelsWithIssues": "{count} problémákkal küzdő modell(ek).",
     "allModelsNormal": "Minden modell normálisan reagál.",

--- a/src/i18n/messages/id.json
+++ b/src/i18n/messages/id.json
@@ -1490,6 +1490,7 @@
     "failedCreate": "Gagal membuat penyedia",
     "errorOccurred": "Terjadi kesalahan. Silakan coba lagi.",
     "modelStatus": "Status Model",
+    "showConfiguredOnly": "Configured only",
     "allModelsOperational": "Semua model beroperasi",
     "modelsWithIssues": "{count} model yang bermasalah",
     "allModelsNormal": "Semua model merespons secara normal.",

--- a/src/i18n/messages/it.json
+++ b/src/i18n/messages/it.json
@@ -1490,6 +1490,7 @@
     "failedCreate": "Impossibile creare il fornitore",
     "errorOccurred": "Si è verificato un errore. Per favore riprova.",
     "modelStatus": "Stato del modello",
+    "showConfiguredOnly": "Configured only",
     "allModelsOperational": "Tutti i modelli operativi",
     "modelsWithIssues": "{count} modelli con problemi",
     "allModelsNormal": "Tutti i modelli rispondono normalmente.",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -1490,6 +1490,7 @@
     "failedCreate": "プロバイダーの作成に失敗しました",
     "errorOccurred": "エラーが発生しました。もう一度試してください。",
     "modelStatus": "モデルステータス",
+    "showConfiguredOnly": "Configured only",
     "allModelsOperational": "全モデル稼働中",
     "modelsWithIssues": "{count} モデルに問題があります",
     "allModelsNormal": "全機種正常に反応しております。",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -1490,6 +1490,7 @@
     "failedCreate": "공급자를 생성하지 못했습니다.",
     "errorOccurred": "오류가 발생했습니다. 다시 시도해 주세요.",
     "modelStatus": "모델현황",
+    "showConfiguredOnly": "Configured only",
     "allModelsOperational": "모든 모델 작동 가능",
     "modelsWithIssues": "문제가 있는 {count} 모델",
     "allModelsNormal": "모든 모델이 정상적으로 반응하고 있습니다.",

--- a/src/i18n/messages/ms.json
+++ b/src/i18n/messages/ms.json
@@ -1490,6 +1490,7 @@
     "failedCreate": "Gagal membuat pembekal",
     "errorOccurred": "Ralat berlaku. Sila cuba lagi.",
     "modelStatus": "Status Model",
+    "showConfiguredOnly": "Configured only",
     "allModelsOperational": "Semua model beroperasi",
     "modelsWithIssues": "{count} model dengan isu",
     "allModelsNormal": "Semua model bertindak balas secara normal.",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -1490,6 +1490,7 @@
     "failedCreate": "Kan provider niet maken",
     "errorOccurred": "Er is een fout opgetreden. Probeer het opnieuw.",
     "modelStatus": "Modelstatus",
+    "showConfiguredOnly": "Configured only",
     "allModelsOperational": "Alle modellen operationeel",
     "modelsWithIssues": "{count} model(len) met problemen",
     "allModelsNormal": "Alle modellen reageren normaal.",

--- a/src/i18n/messages/no.json
+++ b/src/i18n/messages/no.json
@@ -1490,6 +1490,7 @@
     "failedCreate": "Kunne ikke opprette leverandør",
     "errorOccurred": "Det oppsto en feil. Vennligst prøv igjen.",
     "modelStatus": "Modellstatus",
+    "showConfiguredOnly": "Configured only",
     "allModelsOperational": "Alle modeller i drift",
     "modelsWithIssues": "{count} modell(er) med problemer",
     "allModelsNormal": "Alle modellene reagerer normalt.",

--- a/src/i18n/messages/phi.json
+++ b/src/i18n/messages/phi.json
@@ -1490,6 +1490,7 @@
     "failedCreate": "Nabigong gumawa ng provider",
     "errorOccurred": "May naganap na error. Pakisubukang muli.",
     "modelStatus": "Katayuan ng Modelo",
+    "showConfiguredOnly": "Configured only",
     "allModelsOperational": "Ang lahat ng mga modelo ay gumagana",
     "modelsWithIssues": "{count} (mga) modelong may mga isyu",
     "allModelsNormal": "Ang lahat ng mga modelo ay tumutugon nang normal.",

--- a/src/i18n/messages/pl.json
+++ b/src/i18n/messages/pl.json
@@ -1490,6 +1490,7 @@
     "failedCreate": "Nie udało się utworzyć dostawcy",
     "errorOccurred": "Wystąpił błąd. Spróbuj ponownie.",
     "modelStatus": "Stan modelu",
+    "showConfiguredOnly": "Configured only",
     "allModelsOperational": "Wszystkie modele sprawne",
     "modelsWithIssues": "{count} modele z problemami",
     "allModelsNormal": "Wszystkie modele reagują normalnie.",

--- a/src/i18n/messages/pt-BR.json
+++ b/src/i18n/messages/pt-BR.json
@@ -1543,6 +1543,7 @@
     "failedCreate": "Falha ao criar provedor",
     "errorOccurred": "Ocorreu um erro. Tente novamente.",
     "modelStatus": "Status dos Modelos",
+    "showConfiguredOnly": "Configured only",
     "allModelsOperational": "Todos os modelos operacionais",
     "modelsWithIssues": "{count} modelo(s) com problemas",
     "allModelsNormal": "Todos os modelos estão respondendo normalmente.",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -1543,6 +1543,7 @@
     "failedCreate": "Falha ao criar provedor",
     "errorOccurred": "Ocorreu um erro. Por favor, tente novamente.",
     "modelStatus": "Status do modelo",
+    "showConfiguredOnly": "Configured only",
     "allModelsOperational": "Todos os modelos operacionais",
     "modelsWithIssues": "{count} modelo(s) com problemas",
     "allModelsNormal": "Todos os modelos estão respondendo normalmente.",

--- a/src/i18n/messages/ro.json
+++ b/src/i18n/messages/ro.json
@@ -1490,6 +1490,7 @@
     "failedCreate": "Nu s-a putut crea furnizorul",
     "errorOccurred": "A apărut o eroare. Vă rugăm să încercați din nou.",
     "modelStatus": "Stare model",
+    "showConfiguredOnly": "Configured only",
     "allModelsOperational": "Toate modelele sunt operaționale",
     "modelsWithIssues": "{count} model(e) cu probleme",
     "allModelsNormal": "Toate modelele răspund normal.",

--- a/src/i18n/messages/ru.json
+++ b/src/i18n/messages/ru.json
@@ -1490,6 +1490,7 @@
     "failedCreate": "Не удалось создать поставщика",
     "errorOccurred": "Произошла ошибка. Пожалуйста, попробуйте еще раз.",
     "modelStatus": "Статус модели",
+    "showConfiguredOnly": "Configured only",
     "allModelsOperational": "Все модели в рабочем состоянии",
     "modelsWithIssues": "{count} модели с проблемами",
     "allModelsNormal": "Все модели реагируют нормально.",

--- a/src/i18n/messages/sk.json
+++ b/src/i18n/messages/sk.json
@@ -1490,6 +1490,7 @@
     "failedCreate": "Poskytovateľa sa nepodarilo vytvoriť",
     "errorOccurred": "Vyskytla sa chyba. Skúste to znova.",
     "modelStatus": "Stav modelu",
+    "showConfiguredOnly": "Configured only",
     "allModelsOperational": "Všetky modely funkčné",
     "modelsWithIssues": "{count} modelov s problémami",
     "allModelsNormal": "Všetky modely reagujú normálne.",

--- a/src/i18n/messages/sv.json
+++ b/src/i18n/messages/sv.json
@@ -1490,6 +1490,7 @@
     "failedCreate": "Det gick inte att skapa leverantör",
     "errorOccurred": "Ett fel uppstod. Försök igen.",
     "modelStatus": "Modellstatus",
+    "showConfiguredOnly": "Configured only",
     "allModelsOperational": "Alla modeller i drift",
     "modelsWithIssues": "{count} modell(er) med problem",
     "allModelsNormal": "Alla modeller svarar normalt.",

--- a/src/i18n/messages/th.json
+++ b/src/i18n/messages/th.json
@@ -1490,6 +1490,7 @@
     "failedCreate": "ไม่สามารถสร้างผู้ให้บริการได้",
     "errorOccurred": "เกิดข้อผิดพลาด โปรดลองอีกครั้ง",
     "modelStatus": "สถานะโมเดล",
+    "showConfiguredOnly": "Configured only",
     "allModelsOperational": "ใช้งานได้ทุกรุ่น",
     "modelsWithIssues": "{count} โมเดลที่มีปัญหา",
     "allModelsNormal": "ทุกรุ่นตอบสนองได้ปกติ",

--- a/src/i18n/messages/tr.json
+++ b/src/i18n/messages/tr.json
@@ -1490,6 +1490,7 @@
     "failedCreate": "Sağlayıcı oluşturulamadı",
     "errorOccurred": "Bir hata oluştu. Lütfen tekrar deneyin.",
     "modelStatus": "Model Durumu",
+    "showConfiguredOnly": "Configured only",
     "allModelsOperational": "Tüm modeller çalışır durumda",
     "modelsWithIssues": "{count} modelde sorun var",
     "allModelsNormal": "Tüm modeller normal şekilde yanıt veriyor.",

--- a/src/i18n/messages/uk-UA.json
+++ b/src/i18n/messages/uk-UA.json
@@ -1490,6 +1490,7 @@
     "failedCreate": "Не вдалося створити постачальника",
     "errorOccurred": "Сталася помилка. Спробуйте ще раз.",
     "modelStatus": "Статус моделі",
+    "showConfiguredOnly": "Configured only",
     "allModelsOperational": "Всі моделі робочі",
     "modelsWithIssues": "{count} моделі з проблемами",
     "allModelsNormal": "Усі моделі реагують нормально.",

--- a/src/i18n/messages/vi.json
+++ b/src/i18n/messages/vi.json
@@ -1490,6 +1490,7 @@
     "failedCreate": "Không tạo được nhà cung cấp",
     "errorOccurred": "Đã xảy ra lỗi. Vui lòng thử lại.",
     "modelStatus": "Tình trạng mẫu",
+    "showConfiguredOnly": "Configured only",
     "allModelsOperational": "Tất cả các mô hình hoạt động",
     "modelsWithIssues": "{count} mô hình có vấn đề",
     "allModelsNormal": "Tất cả các model đều phản hồi bình thường.",

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -1490,6 +1490,7 @@
     "failedCreate": "创建提供商失败",
     "errorOccurred": "发生错误。请再试一次。",
     "modelStatus": "模型状态",
+    "showConfiguredOnly": "仅显示已配置",
     "allModelsOperational": "所有模型运行正常",
     "modelsWithIssues": "{count} 有问题的模型",
     "allModelsNormal": "所有模型当前响应正常。",

--- a/tests/unit/providers-page-utils.test.mjs
+++ b/tests/unit/providers-page-utils.test.mjs
@@ -1,0 +1,74 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const providerPageUtils =
+  await import("../../src/app/(dashboard)/dashboard/providers/providerPageUtils.ts");
+const providers = await import("../../src/shared/constants/providers.ts");
+
+test("merged OAuth providers keep free-tier providers in the OAuth section", () => {
+  const statsCalls = [];
+  const getProviderStats = (providerId, authType) => {
+    statsCalls.push({ providerId, authType });
+    return { total: authType === "free" ? 1 : 0 };
+  };
+
+  const entries = providerPageUtils.buildMergedOAuthProviderEntries(
+    providers.OAUTH_PROVIDERS,
+    providers.FREE_PROVIDERS,
+    getProviderStats
+  );
+
+  const oauthIds = Object.keys(providers.OAUTH_PROVIDERS);
+  const freeIds = Object.keys(providers.FREE_PROVIDERS);
+
+  assert.deepEqual(
+    entries.slice(0, oauthIds.length).map((entry) => entry.providerId),
+    oauthIds
+  );
+  assert.deepEqual(
+    entries.slice(oauthIds.length).map((entry) => entry.providerId),
+    freeIds
+  );
+
+  const freeEntry = entries.find((entry) => entry.providerId === freeIds[0]);
+  assert.equal(freeEntry.displayAuthType, "oauth");
+  assert.equal(freeEntry.toggleAuthType, "free");
+  assert.equal(
+    statsCalls.some((call) => call.providerId === freeIds[0] && call.authType === "free"),
+    true
+  );
+});
+
+test("configured-only filter keeps only providers with saved connections", () => {
+  const entries = [
+    {
+      providerId: "claude",
+      provider: { id: "claude" },
+      stats: { total: 2 },
+      displayAuthType: "oauth",
+      toggleAuthType: "oauth",
+    },
+    {
+      providerId: "codex",
+      provider: { id: "codex" },
+      stats: { total: 0 },
+      displayAuthType: "oauth",
+      toggleAuthType: "oauth",
+    },
+    {
+      providerId: "cursor",
+      provider: { id: "cursor" },
+      stats: { total: 1 },
+      displayAuthType: "oauth",
+      toggleAuthType: "oauth",
+    },
+  ];
+
+  const visible = providerPageUtils.filterConfiguredProviderEntries(entries, true);
+
+  assert.deepEqual(
+    visible.map((entry) => entry.providerId),
+    ["claude", "cursor"]
+  );
+  assert.equal(providerPageUtils.filterConfiguredProviderEntries(entries, false).length, 3);
+});


### PR DESCRIPTION
## Summary
- merge the old `Free Providers` cards into the `OAuth Providers` section on the Providers page
- add a `Configured only` toggle next to `Model Status` so the page can be filtered down to providers that already have saved connections
- make the OAuth batch test include free-tier OAuth providers so the section behavior stays consistent with the UI

## Why
The previous grouping mixed two different concepts into top-level categories:
- authentication method (`OAuth`, `API Key`, `API Key Compatible`)
- commercial tier / availability (`Free`)

That made the Providers page harder to understand because the old `Free Providers` group was not actually a separate authentication category. Those providers are still OAuth-based, and some of them expose free tiers rather than being universally or exclusively free. Surfacing them as a separate top-level bucket made the classification logic feel inconsistent.

## What Changed
- removed the separate `Free Providers` section from the page layout
- render those provider cards inside the OAuth section with the same OAuth category treatment
- added reusable provider list helpers and a focused unit test for the merged grouping/filtering behavior
- added a localized `Configured only` label for the new filter toggle

## Validation
- `npm run check`
- `npm run typecheck:core`
