### PR TITLE
feat(usageTracking): make usage token buffer configurable

### DIFF
--- a/open-sse/utils/usageTracking.ts
+++ b/open-sse/utils/usageTracking.ts
@@ -23,10 +23,74 @@ export const COLORS = {
 
 /**
  * Safety buffer added to reported token usage to prevent clients from hitting
- * context window limits. 2000 tokens accounts for overhead from system prompts,
+ * context window limits. Accounts for overhead from system prompts,
  * tool definitions, and format translation that may not be reflected in raw usage.
+ *
+ * Configurable via:
+ *   - Settings API / Dashboard: `usageTokenBuffer` (persisted in DB)
+ *   - Environment variable: `USAGE_TOKEN_BUFFER`
+ *   - Defaults to 2000 if neither is set
+ *
+ * Set to 0 to disable the buffer entirely (raw provider token counts).
  */
-const BUFFER_TOKENS = 2000;
+const DEFAULT_BUFFER_TOKENS = 2000;
+
+let _cachedBuffer: number | null = null;
+let _cacheTimestamp = 0;
+const CACHE_TTL_MS = 30_000; // Re-read from DB/env every 30s
+
+function getBufferTokens(): number {
+  const now = Date.now();
+  const isExpired = _cachedBuffer !== null && now - _cacheTimestamp >= CACHE_TTL_MS;
+
+  if (_cachedBuffer !== null && !isExpired) {
+    return _cachedBuffer;
+  }
+
+  // Priority: env var > cached DB value > default
+  const envVal = process.env.USAGE_TOKEN_BUFFER;
+  if (envVal !== undefined) {
+    const parsed = parseInt(envVal, 10);
+    if (!isNaN(parsed) && parsed >= 0) {
+      _cachedBuffer = parsed;
+      _cacheTimestamp = now;
+      return parsed;
+    }
+  }
+
+  // Return cached value or default; kick off async DB read to update cache.
+  // On first call (_cachedBuffer is null), use the default.
+  // On TTL expiry (_cachedBuffer is stale), continue returning the stale value
+  // while refreshing asynchronously — prevents blocking the hot path.
+  if (_cachedBuffer === null || isExpired) {
+    if (_cachedBuffer === null) {
+      _cachedBuffer = DEFAULT_BUFFER_TOKENS;
+    }
+    _cacheTimestamp = now;
+    _loadBufferFromDb();
+  }
+  return _cachedBuffer;
+}
+
+async function _loadBufferFromDb(): Promise<void> {
+  try {
+    const { getSettings } = await import("@/lib/db/settings");
+    const settings = await getSettings();
+    const val = settings.usageTokenBuffer;
+    if (typeof val === "number" && val >= 0) {
+      _cachedBuffer = val;
+      _cacheTimestamp = Date.now();
+    }
+  } catch {
+    // DB not ready yet or settings unavailable — keep current value
+  }
+}
+
+/** Force-refresh the buffer from settings (e.g. after a settings update). */
+export function invalidateBufferTokensCache(): void {
+  _cachedBuffer = null;
+  _cacheTimestamp = 0;
+}
 
 // Get HH:MM:SS timestamp
 function getTimeString() {
@@ -46,21 +110,24 @@ function getTimeString() {
 export function addBufferToUsage(usage) {
   if (!usage || typeof usage !== "object") return usage;
 
+  const buffer = getBufferTokens();
+  if (buffer === 0) return usage;
+
   const result = { ...usage };
 
   // Claude format
   if (result.input_tokens !== undefined) {
-    result.input_tokens += BUFFER_TOKENS;
+    result.input_tokens += buffer;
   }
 
   // OpenAI format
   if (result.prompt_tokens !== undefined) {
-    result.prompt_tokens += BUFFER_TOKENS;
+    result.prompt_tokens += buffer;
   }
 
   // Calculate or update total_tokens
   if (result.total_tokens !== undefined) {
-    result.total_tokens += BUFFER_TOKENS;
+    result.total_tokens += buffer;
   } else if (result.prompt_tokens !== undefined && result.completion_tokens !== undefined) {
     // Calculate total_tokens if not exists
     result.total_tokens = result.prompt_tokens + result.completion_tokens;

--- a/src/app/(dashboard)/dashboard/settings/components/ProxyTab.tsx
+++ b/src/app/(dashboard)/dashboard/settings/components/ProxyTab.tsx
@@ -12,6 +12,9 @@ export default function ProxyTab() {
   const t = useTranslations("settings");
   const tc = useTranslations("common");
   const [debugMode, setDebugMode] = useState(false);
+  const [usageTokenBuffer, setUsageTokenBuffer] = useState<number | null>(null);
+  const [bufferInput, setBufferInput] = useState("");
+  const [bufferSaving, setBufferSaving] = useState(false);
   const [loading, setLoading] = useState(true);
 
   const loadGlobalProxy = async () => {
@@ -36,6 +39,26 @@ export default function ProxyTab() {
       }
     } catch (err) {
       console.error("Failed to update debugMode:", err);
+    }
+  };
+
+  const updateUsageTokenBuffer = async () => {
+    const val = parseInt(bufferInput, 10);
+    if (isNaN(val) || val < 0 || val > 50000) return;
+    setBufferSaving(true);
+    try {
+      const res = await fetch("/api/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ usageTokenBuffer: val }),
+      });
+      if (res.ok) {
+        setUsageTokenBuffer(val);
+      }
+    } catch (err) {
+      console.error("Failed to update usageTokenBuffer:", err);
+    } finally {
+      setBufferSaving(false);
     }
   };
 
@@ -65,6 +88,9 @@ export default function ProxyTab() {
       })
       .then((data) => {
         setDebugMode(data.debugMode === true);
+        const buf = typeof data.usageTokenBuffer === "number" ? data.usageTokenBuffer : 2000;
+        setUsageTokenBuffer(buf);
+        setBufferInput(String(buf));
         setLoading(false);
       })
       .catch(() => setLoading(false));
@@ -118,6 +144,49 @@ export default function ProxyTab() {
               onChange={() => updateDebugMode(!debugMode)}
               disabled={loading}
             />
+          </div>
+        </Card>
+        <Card className="p-6 mt-4">
+          <div className="flex flex-col gap-3">
+            <div>
+              <p className="font-medium">Usage Token Buffer</p>
+              <p className="text-sm text-text-muted mt-1">
+                Extra tokens added to reported usage to account for system prompt overhead. Set to 0
+                to report raw provider token counts. Default: 2000. Changes take effect within 30
+                seconds.
+              </p>
+            </div>
+            <div className="flex items-center gap-3">
+              <input
+                type="number"
+                min={0}
+                max={50000}
+                value={bufferInput}
+                onChange={(e) => setBufferInput(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") updateUsageTokenBuffer();
+                }}
+                className="w-32 px-3 py-1.5 rounded bg-surface-2 border border-border text-sm text-text-primary"
+                disabled={loading}
+              />
+              <Button
+                size="sm"
+                variant="primary"
+                onClick={updateUsageTokenBuffer}
+                disabled={
+                  bufferSaving ||
+                  loading ||
+                  parseInt(bufferInput, 10) === usageTokenBuffer
+                }
+              >
+                {bufferSaving ? tc("saving") : tc("save")}
+              </Button>
+              {usageTokenBuffer !== null && parseInt(bufferInput, 10) !== usageTokenBuffer && (
+                <span className="text-xs text-text-muted">
+                  Current: {usageTokenBuffer}
+                </span>
+              )}
+            </div>
           </div>
         </Card>
       </div>

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -115,6 +115,13 @@ export async function PATCH(request) {
         );
       }
     }
+    // Sync usage token buffer to runtime cache
+    if ("usageTokenBuffer" in body) {
+      const { invalidateBufferTokensCache } =
+        await import("@omniroute/open-sse/utils/usageTracking.ts");
+      invalidateBufferTokensCache();
+    }
+
     if (cpaFallback !== undefined || cpaUrl !== undefined) {
       const enabled =
         cpaFallback ?? (settings as Record<string, unknown>).cliproxyapi_fallback_enabled;

--- a/src/shared/validation/settingsSchemas.ts
+++ b/src/shared/validation/settingsSchemas.ts
@@ -53,6 +53,9 @@ export const updateSettingsSchema = z.object({
   alwaysPreserveClientCache: z.enum(["auto", "always", "never"]).optional(),
   // Adaptive Volume Routing
   adaptiveVolumeRouting: z.boolean().optional(),
+  // Usage token buffer — safety margin added to reported prompt/input token counts.
+  // Prevents CLI tools from overrunning context windows. Set to 0 to disable.
+  usageTokenBuffer: z.number().int().min(0).max(50000).optional(),
   // Custom CLI agent definitions for ACP
   customAgents: z
     .array(


### PR DESCRIPTION
## Problem

Every API response from OmniRoute inflates `prompt_tokens` / `input_tokens` by **2 000** due to a hardcoded safety buffer in `addBufferToUsage()`:

```ts
const BUFFER_TOKENS = 2000; // open-sse/utils/usageTracking.ts
```

This constant is unconditionally added to every response in `chatCore.ts` and `stream.ts`.

### Why it matters

The buffer was introduced so that CLI tools (Claude Code, Codex, Cursor, etc.) underestimate remaining context and avoid hitting context-window limits. That is a valid safety measure — but it causes real problems for other users:

| Scenario | Impact |
|---|---|
| **Cost dashboards** | Token counts are inflated ≈ 20–200 × on short prompts, making spend tracking unreliable |
| **SDK integrations** | Applications comparing reported tokens across providers see 2 000 phantom tokens |
| **Pay-per-token billing** | Users auditing invoices find OmniRoute's numbers never match the upstream provider |
| **Context-window math** | Hard to reason about actual utilization when every count is offset by a silent constant |

### Reproduction

```bash
# Minimal "Hi" prompt via any provider → ~2008 prompt_tokens
curl -s http://localhost:20128/v1/chat/completions \
  -H "Authorization: Bearer $KEY" \
  -H "Content-Type: application/json" \
  -d '{"model":"provider/model","messages":[{"role":"user","content":"Hi"}]}' \
  | jq '.usage'
# → { "prompt_tokens": 2008, ... }   ← real count is ~8
```

## Solution

Make the buffer **configurable** with three layered sources (highest priority wins):

1. **Environment variable**: `USAGE_TOKEN_BUFFER=0`
2. **Settings API / Dashboard**: `PATCH /api/settings { "usageTokenBuffer": 0 }`
3. **Default**: `2000` (preserves existing behaviour — fully backward-compatible)

Setting the value to **0** disables the buffer entirely, returning raw provider token counts.

### Implementation details

- `getBufferTokens()` reads env → DB → default, with a **30-second in-process cache** so the hot path adds zero DB overhead.
- `invalidateBufferTokensCache()` is called from the settings API route when `usageTokenBuffer` is updated, ensuring changes take effect immediately.
- Zod schema validates the new field as `int, 0–50 000, optional`.

## Changes

| File | What changed |
|---|---|
| `open-sse/utils/usageTracking.ts` | Replaced `const BUFFER_TOKENS = 2000` with `getBufferTokens()` that reads env / DB settings with TTL cache |
| `src/shared/validation/settingsSchemas.ts` | Added `usageTokenBuffer` field to the Zod update schema |
| `src/app/api/settings/route.ts` | Invalidate buffer cache when `usageTokenBuffer` is updated |

## Testing

- Unit tests pass (6 assertions: default buffer, buffer = 0, buffer = 500, Claude format, null passthrough, total_tokens recalculation)
- ESLint and Prettier clean on all changed files
- TypeScript type-check passes
- Manual verification: setting `USAGE_TOKEN_BUFFER=0` returns raw provider token counts
