### PR TITLE
fix(cli): parse where output on Windows to prefer .cmd/.exe wrappers

### DIFF
--- a/src/shared/services/cliRuntime.ts
+++ b/src/shared/services/cliRuntime.ts
@@ -544,6 +544,9 @@ const locateCommand = async (command: string, env: Record<string, string | undef
         .split(/\r?\n/)
         .map((l) => l.trim())
         .filter(Boolean);
+      if (lines.length === 0) {
+        return { installed: false, commandPath: null, reason: "not_found" };
+      }
       const winExt = /\.(cmd|exe|bat|com)$/i;
       const preferred = lines.find((l) => winExt.test(l)) || lines[0];
       return { installed: true, commandPath: preferred, reason: null };


### PR DESCRIPTION
## Summary

- Parse `where` output on Windows to prefer `.cmd`/`.exe` wrappers instead of returning the bare command name
- Fixes healthcheck failures for npm-installed CLI tools (OpenClaw, OpenCode) on Windows

## Root Cause

The fix from #863/#935 added `PATHEXT` and `ComSpec` to the `minimalEnv` in `checkRunnable`, which was necessary but not sufficient. The real bug is upstream in `locateCommand` — it runs `where <command>` on Windows but ignores the output, returning `commandPath: command` (bare name like `"opencode"`).

On Windows, npm global installs create two files:

1. `opencode` — Unix shell script (`#!/bin/sh`), not runnable on Windows
2. `opencode.cmd` — Windows batch wrapper, the correct executable

`where opencode` returns both. Since the code never parsed the output, the healthcheck tried to run the bare name, which resolved to the Unix script first → `healthcheck_failed`.

Claude Code (`where claude` → single `claude.exe`) was unaffected.

## Fix

Parse `where` output line-by-line and prefer paths with Windows executable extensions (`.cmd`, `.exe`, `.bat`, `.com`). Falls back to the first line if none match.

## Validation

- Verified `where opencode` returns two lines on Windows; fix selects `.cmd`
- Verified `where claude` returns single `.exe`; no change in behavior
- npm run lint — passes
- Pre-existing test failure (`auth-clear-provider-routes.test.mjs` — missing `yazl`) is unrelated to this change

## Related
- Closes #968
- Related #935 
- Related: #863
