### PR TITLE
align cc-compatible cache handling with client passthrough

### DIFF
--- a/open-sse/services/claudeCodeCompatible.ts
+++ b/open-sse/services/claudeCodeCompatible.ts
@@ -172,11 +172,9 @@ export function buildClaudeCodeCompatibleRequest({
   const effort = resolveClaudeCodeCompatibleEffort(sourceBody, normalizedBody, model);
   const maxTokens = resolveClaudeCodeCompatibleMaxTokens(sourceBody, normalizedBody);
   const tools = preparedClaudeBody?.tools
-    ? applyClaudeCodeCompatibleToolCacheStrategy(
+    ? buildClaudeCodeCompatibleToolsFromClaude(
         preparedClaudeBody.tools as Record<string, unknown>[],
-        {
-          preserveExisting: preserveCacheControl,
-        }
+        preserveCacheControl
       )
     : buildClaudeCodeCompatibleTools(normalizedBody, sourceBody);
   const toolChoice =
@@ -312,13 +310,11 @@ function buildClaudeCodeCompatibleMessages(messages: MessageLike[]) {
       return [
         {
           role: "user" as const,
-          content: [{ type: "text", text: fallbackText, cache_control: { type: "ephemeral" } }],
+          content: [{ type: "text", text: fallbackText }],
         },
       ];
     }
   }
-
-  applyClaudeCodeCompatibleMessageCacheStrategy(merged);
 
   return merged;
 }
@@ -358,9 +354,6 @@ function buildClaudeCodeCompatibleMessagesFromClaude(
       stripCacheControlFromContentBlocks(message.content);
     }
   }
-  applyClaudeCodeCompatibleMessageCacheStrategy(merged, {
-    preserveExisting: preserveCacheControl,
-  });
 
   if (merged.length === 0) {
     const fallbackText = converted
@@ -373,7 +366,7 @@ function buildClaudeCodeCompatibleMessagesFromClaude(
       return [
         {
           role: "user" as const,
-          content: [{ type: "text", text: fallbackText, cache_control: { type: "ephemeral" } }],
+          content: [{ type: "text", text: fallbackText }],
         },
       ];
     }
@@ -399,12 +392,6 @@ function buildClaudeCodeCompatibleSystemBlocks({
     Array.isArray(systemBlocks) && systemBlocks.length > 0
       ? systemBlocks.map((block) => ({ ...block }))
       : extractCustomSystemBlocks(messages);
-  const useLongSystemTtl =
-    !preserveCacheControl ||
-    customSystemBlocks.some((block) => readCacheControlTtl(block) === "1h");
-  const systemCacheControl = useLongSystemTtl
-    ? { type: "ephemeral", ttl: "1h" }
-    : { type: "ephemeral" };
 
   const dateText = formatDate(now);
   const blocks: Array<Record<string, unknown>> = [
@@ -415,30 +402,19 @@ function buildClaudeCodeCompatibleSystemBlocks({
     {
       type: "text",
       text: "You are a Claude agent, built on Anthropic's Claude Agent SDK.",
-      cache_control: { ...systemCacheControl },
     },
     {
       type: "text",
       text: `You are Claude Code, Anthropic's official CLI for Claude.\n\nCWD: ${cwd}\nDate: ${dateText}`,
-      cache_control: { ...systemCacheControl },
     },
   ];
 
   for (const systemBlock of customSystemBlocks) {
     const preparedBlock = { ...systemBlock };
-    if (!preserveCacheControl || useLongSystemTtl) {
-      preparedBlock.cache_control = { ...systemCacheControl };
+    if (!preserveCacheControl) {
+      delete preparedBlock.cache_control;
     }
     blocks.push(preparedBlock);
-  }
-
-  if (
-    preserveCacheControl &&
-    customSystemBlocks.length > 0 &&
-    !customSystemBlocks.some((block) => hasCacheControl(block))
-  ) {
-    const lastCustomSystemBlock = blocks[blocks.length - 1];
-    lastCustomSystemBlock.cache_control = { ...systemCacheControl };
   }
 
   return blocks;
@@ -477,11 +453,22 @@ function buildClaudeCodeCompatibleTools(
   return rawTools
     .map((tool) => convertClaudeCodeCompatibleTool(tool))
     .filter((tool): tool is Record<string, unknown> => !!tool)
-    .map((tool) => ({ ...tool }))
-    .map((tool, index, tools) => {
-      if (index !== findLastCacheableToolIndex(tools)) return tool;
-      return { ...tool, cache_control: { type: "ephemeral", ttl: "1h" } };
-    });
+    .map((tool) => ({ ...tool }));
+}
+
+function buildClaudeCodeCompatibleToolsFromClaude(
+  tools: Record<string, unknown>[] | undefined,
+  preserveCacheControl: boolean
+) {
+  if (!Array.isArray(tools)) return [];
+
+  return tools.map((tool) => {
+    const preparedTool = { ...tool };
+    if (!preserveCacheControl) {
+      delete preparedTool.cache_control;
+    }
+    return preparedTool;
+  });
 }
 
 function convertClaudeCodeCompatibleTool(tool: unknown) {
@@ -546,6 +533,7 @@ function prepareClaudeCodeCompatibleBody(
   claudeBody: Record<string, unknown>,
   preserveCacheControl: boolean
 ) {
+  void preserveCacheControl;
   const prepared = prepareClaudeRequest(
     {
       system: normalizeClaudeSystemInput(claudeBody.system),
@@ -554,7 +542,7 @@ function prepareClaudeCodeCompatibleBody(
       thinking: readRecord(claudeBody.thinking) || claudeBody.thinking,
     },
     CLAUDE_CODE_COMPATIBLE_PREFIX,
-    preserveCacheControl
+    true
   );
 
   return readRecord(prepared);
@@ -673,109 +661,10 @@ function extractCustomSystemBlocks(messages: MessageLike[] | undefined) {
     }));
 }
 
-function applyClaudeCodeCompatibleMessageCacheStrategy(
-  messages: Array<{ role: "user" | "assistant"; content: Array<Record<string, unknown>> }>,
-  options: {
-    preserveExisting?: boolean;
-  } = {}
-) {
-  const preserveExisting = options.preserveExisting === true;
-  const userIndexes = messages.reduce((indexes, message, index) => {
-    if (message.role === "user") indexes.push(index);
-    return indexes;
-  }, [] as number[]);
-  const hasAssistant = messages.some((message) => message.role === "assistant");
-  const secondToLastUserIndex = userIndexes.length >= 2 ? userIndexes[userIndexes.length - 2] : -1;
-
-  if (secondToLastUserIndex >= 0) {
-    markLastContentCacheControl(
-      messages[secondToLastUserIndex].content,
-      undefined,
-      preserveExisting
-    );
-  } else if (!hasAssistant && userIndexes.length > 0) {
-    markLastContentCacheControl(
-      messages[userIndexes[userIndexes.length - 1]].content,
-      undefined,
-      preserveExisting
-    );
-  }
-
-  const lastUserIndex = userIndexes.length > 0 ? userIndexes[userIndexes.length - 1] : -1;
-  const endsOnUser = lastUserIndex === messages.length - 1;
-  if (endsOnUser && lastUserIndex >= 0) {
-    markLastContentCacheControl(messages[lastUserIndex].content, undefined, preserveExisting);
-  }
-
-  for (let i = messages.length - 1; i >= 0; i--) {
-    if (messages[i].role !== "assistant") continue;
-    if (markLastContentCacheControl(messages[i].content, undefined, preserveExisting)) break;
-  }
-}
-
 function stripCacheControlFromContentBlocks(content: Array<Record<string, unknown>>) {
   for (const block of content) {
     delete block.cache_control;
   }
-}
-
-function applyClaudeCodeCompatibleToolCacheStrategy(
-  tools: Array<Record<string, unknown>>,
-  options: {
-    preserveExisting?: boolean;
-  } = {}
-) {
-  const preparedTools = tools.map((tool) => ({ ...tool }));
-  const lastCacheableToolIndex = findLastCacheableToolIndex(preparedTools);
-  if (lastCacheableToolIndex < 0) return preparedTools;
-
-  if (options.preserveExisting && preparedTools.some((tool) => hasCacheControl(tool))) {
-    return preparedTools;
-  }
-
-  preparedTools[lastCacheableToolIndex].cache_control = { type: "ephemeral", ttl: "1h" };
-  return preparedTools;
-}
-
-function markLastContentCacheControl(
-  content: Array<Record<string, unknown>>,
-  ttl?: string,
-  preserveExisting = false
-) {
-  if (!Array.isArray(content) || content.length === 0) return false;
-  const lastBlock = content[content.length - 1];
-  if (!lastBlock) return false;
-  if (
-    preserveExisting &&
-    content.some(
-      (block) =>
-        !!block &&
-        typeof block === "object" &&
-        !!readRecord(block)?.cache_control &&
-        typeof readRecord(block)?.cache_control === "object"
-    )
-  ) {
-    return true;
-  }
-  lastBlock.cache_control = ttl ? { type: "ephemeral", ttl } : { type: "ephemeral" };
-  return true;
-}
-
-function hasCacheControl(value: unknown) {
-  return !!readRecord(value)?.cache_control && typeof readRecord(value)?.cache_control === "object";
-}
-
-function readCacheControlTtl(value: unknown) {
-  return toNonEmptyString(readRecord(readRecord(value)?.cache_control)?.ttl);
-}
-
-function findLastCacheableToolIndex(tools: Array<Record<string, unknown>>) {
-  for (let i = tools.length - 1; i >= 0; i--) {
-    if (!tools[i].defer_loading) {
-      return i;
-    }
-  }
-  return -1;
 }
 
 function cloneValue<T>(value: T): T {

--- a/open-sse/utils/cacheControlPolicy.ts
+++ b/open-sse/utils/cacheControlPolicy.ts
@@ -148,13 +148,6 @@ export function shouldPreserveCacheControl({
     return false;
   }
 
-  // CC-compatible bridges should default to OmniRoute-managed cache markers.
-  // Their request shape differs from native Claude Messages payloads, so
-  // preserving client markers in auto mode weakens cache coverage.
-  if (typeof targetProvider === "string" && targetProvider.startsWith("anthropic-compatible-cc-")) {
-    return false;
-  }
-
   // Auto mode: use automatic detection (existing logic)
   // Must be a caching-aware client
   if (!isClaudeCodeClient(userAgent)) {

--- a/tests/unit/cache-control-claude-providers.test.mjs
+++ b/tests/unit/cache-control-claude-providers.test.mjs
@@ -139,7 +139,7 @@ describe("Cache Control Policy - Claude Protocol Providers", () => {
     );
   });
 
-  test("shouldPreserveCacheControl defaults CC-compatible providers to OmniRoute-managed cache in auto mode", () => {
+  test("shouldPreserveCacheControl treats CC-compatible providers like other Claude providers in auto mode", () => {
     const claudeCodeUA = "Claude-Code/1.0.0";
 
     assert.equal(
@@ -150,7 +150,7 @@ describe("Cache Control Policy - Claude Protocol Providers", () => {
         targetFormat: "claude",
         settings: { alwaysPreserveClientCache: "auto" },
       }),
-      false
+      true
     );
   });
 });

--- a/tests/unit/cc-compatible-provider.test.mjs
+++ b/tests/unit/cc-compatible-provider.test.mjs
@@ -104,17 +104,16 @@ test("buildClaudeCodeCompatibleRequest keeps prior role history while dropping t
       { role: "user", text: "u2" },
     ]
   );
-  assert.deepEqual(payload.messages[0].content.at(-1).cache_control, { type: "ephemeral" });
-  assert.deepEqual(payload.messages[1].content.at(-1).cache_control, { type: "ephemeral" });
-  assert.deepEqual(payload.messages[2].content.at(-1).cache_control, { type: "ephemeral" });
+  assert.equal(payload.messages[0].content.at(-1).cache_control, undefined);
+  assert.equal(payload.messages[1].content.at(-1).cache_control, undefined);
+  assert.equal(payload.messages[2].content.at(-1).cache_control, undefined);
   assert.equal(payload.system.length, 4);
   assert.equal(payload.system.at(-1).text, "sys");
-  assert.deepEqual(payload.system[1].cache_control, { type: "ephemeral", ttl: "1h" });
-  assert.deepEqual(payload.system[2].cache_control, { type: "ephemeral", ttl: "1h" });
-  assert.deepEqual(payload.system[3].cache_control, { type: "ephemeral", ttl: "1h" });
+  assert.equal(payload.system[1].cache_control, undefined);
+  assert.equal(payload.system[2].cache_control, undefined);
+  assert.equal(payload.system[3].cache_control, undefined);
   assert.equal(payload.tools.length, 1);
-  const { cache_control, ...toolWithoutCacheControl } = payload.tools[0];
-  assert.deepEqual(toolWithoutCacheControl, {
+  assert.deepEqual(payload.tools[0], {
     name: "lookup_weather",
     description: "Fetch weather",
     input_schema: {
@@ -125,7 +124,6 @@ test("buildClaudeCodeCompatibleRequest keeps prior role history while dropping t
       required: ["city"],
     },
   });
-  assert.deepEqual(payload.tools[0].cache_control, { type: "ephemeral", ttl: "1h" });
   assert.deepEqual(payload.tool_choice, { type: "any" });
   assert.equal(payload.context_management.edits[0].type, "clear_thinking_20251015");
   assert.equal(JSON.parse(payload.metadata.user_id).session_id, "session-1");
@@ -185,11 +183,11 @@ test("buildClaudeCodeCompatibleRequest preserves Claude cache markers when reque
     type: "ephemeral",
     ttl: "10m",
   });
-  assert.deepEqual(payload.messages[2].content[0].cache_control, { type: "ephemeral" });
+  assert.equal(payload.messages[2].content[0].cache_control, undefined);
   assert.deepEqual(payload.tools[0].cache_control, { type: "ephemeral", ttl: "30m" });
 });
 
-test("buildClaudeCodeCompatibleRequest supplements missing Claude cache markers in preserve mode", () => {
+test("buildClaudeCodeCompatibleRequest does not supplement missing Claude cache markers in preserve mode", () => {
   const payload = buildClaudeCodeCompatibleRequest({
     sourceBody: {
       max_tokens: 64,
@@ -230,14 +228,14 @@ test("buildClaudeCodeCompatibleRequest supplements missing Claude cache markers 
     preserveCacheControl: true,
   });
 
-  assert.deepEqual(payload.messages[0].content[0].cache_control, { type: "ephemeral" });
-  assert.deepEqual(payload.messages[1].content[0].cache_control, { type: "ephemeral" });
-  assert.deepEqual(payload.messages[2].content[0].cache_control, { type: "ephemeral" });
-  assert.deepEqual(payload.system.at(-1).cache_control, { type: "ephemeral" });
-  assert.deepEqual(payload.tools[0].cache_control, { type: "ephemeral", ttl: "1h" });
+  assert.equal(payload.messages[0].content[0].cache_control, undefined);
+  assert.equal(payload.messages[1].content[0].cache_control, undefined);
+  assert.equal(payload.messages[2].content[0].cache_control, undefined);
+  assert.equal(payload.system.at(-1).cache_control, undefined);
+  assert.equal(payload.tools[0].cache_control, undefined);
 });
 
-test("buildClaudeCodeCompatibleRequest upgrades built-in system cache markers when preserved system uses 1h", () => {
+test("buildClaudeCodeCompatibleRequest keeps built-in system blocks untagged when preserved system uses 1h", () => {
   const payload = buildClaudeCodeCompatibleRequest({
     sourceBody: {
       max_tokens: 64,
@@ -259,13 +257,13 @@ test("buildClaudeCodeCompatibleRequest upgrades built-in system cache markers wh
     preserveCacheControl: true,
   });
 
-  assert.deepEqual(payload.system[1].cache_control, { type: "ephemeral", ttl: "1h" });
-  assert.deepEqual(payload.system[2].cache_control, { type: "ephemeral", ttl: "1h" });
-  assert.deepEqual(payload.system[3].cache_control, { type: "ephemeral", ttl: "1h" });
+  assert.equal(payload.system[1].cache_control, undefined);
+  assert.equal(payload.system[2].cache_control, undefined);
+  assert.deepEqual(payload.system[3].cache_control, { type: "ephemeral" });
   assert.deepEqual(payload.system[4].cache_control, { type: "ephemeral", ttl: "1h" });
 });
 
-test("buildClaudeCodeCompatibleRequest marks final user turn and 1h system cache in non-preserve mode", () => {
+test("buildClaudeCodeCompatibleRequest does not add cache markers in non-preserve mode", () => {
   const largeUserPrompt = Array.from(
     { length: 200 },
     (_, index) => `Context line ${index + 1}: repeated stable context for cache testing.`
@@ -289,12 +287,12 @@ test("buildClaudeCodeCompatibleRequest marks final user turn and 1h system cache
     preserveCacheControl: false,
   });
 
-  assert.deepEqual(payload.system[1].cache_control, { type: "ephemeral", ttl: "1h" });
-  assert.deepEqual(payload.system[2].cache_control, { type: "ephemeral", ttl: "1h" });
-  assert.deepEqual(payload.system[3].cache_control, { type: "ephemeral", ttl: "1h" });
-  assert.deepEqual(payload.messages[0].content[0].cache_control, { type: "ephemeral" });
-  assert.deepEqual(payload.messages[1].content[0].cache_control, { type: "ephemeral" });
-  assert.deepEqual(payload.messages[2].content[0].cache_control, { type: "ephemeral" });
+  assert.equal(payload.system[1].cache_control, undefined);
+  assert.equal(payload.system[2].cache_control, undefined);
+  assert.equal(payload.system[3].cache_control, undefined);
+  assert.equal(payload.messages[0].content[0].cache_control, undefined);
+  assert.equal(payload.messages[1].content[0].cache_control, undefined);
+  assert.equal(payload.messages[2].content[0].cache_control, undefined);
 });
 
 test("buildClaudeCodeCompatibleRequest falls back to a user turn when the source only has assistant/model text", () => {
@@ -312,7 +310,7 @@ test("buildClaudeCodeCompatibleRequest falls back to a user turn when the source
   assert.deepEqual(payload.messages, [
     {
       role: "user",
-      content: [{ type: "text", text: "draft", cache_control: { type: "ephemeral" } }],
+      content: [{ type: "text", text: "draft" }],
     },
   ]);
 });
@@ -354,7 +352,7 @@ test("buildClaudeCodeCompatibleRequest omits auto tool_choice while preserving t
   });
 
   assert.equal(payload.tools.length, 1);
-  assert.deepEqual(payload.tools[0].cache_control, { type: "ephemeral", ttl: "1h" });
+  assert.equal(payload.tools[0].cache_control, undefined);
   assert.equal(payload.tool_choice, undefined);
 });
 
@@ -522,6 +520,16 @@ test("handleChatCore forces upstream streaming for CC compatible while returning
   assert.equal(calls.length, 1);
   assert.equal(calls[0].headers.Accept, "text/event-stream");
   assert.equal(calls[0].body.stream, true);
+  assert.equal(
+    calls[0].body.system.some((block) => block.cache_control !== undefined),
+    false
+  );
+  assert.equal(
+    calls[0].body.messages.some((message) =>
+      message.content.some((block) => block.cache_control !== undefined)
+    ),
+    false
+  );
 
   const payload = await result.response.json();
   assert.equal(payload.choices[0].message.content, "Hello from CC");
@@ -530,7 +538,7 @@ test("handleChatCore forces upstream streaming for CC compatible while returning
   assert.equal(payload.usage.completion_tokens, 5);
 });
 
-test("handleChatCore applies OmniRoute-managed cache strategy for CC-compatible requests in auto mode", async () => {
+test("handleChatCore preserves client cache markers for Claude Code requests to CC-compatible providers", async () => {
   const calls = [];
   globalThis.fetch = async (url, init = {}) => {
     calls.push({
@@ -635,20 +643,19 @@ test("handleChatCore applies OmniRoute-managed cache strategy for CC-compatible 
   assert.equal(calls.length, 1);
   assert.deepEqual(calls[0].body.system.at(-1).cache_control, {
     type: "ephemeral",
-    ttl: "1h",
+    ttl: "5m",
   });
   assert.deepEqual(calls[0].body.messages[0].content[0].cache_control, {
     type: "ephemeral",
   });
   assert.deepEqual(calls[0].body.messages[1].content[0].cache_control, {
     type: "ephemeral",
+    ttl: "10m",
   });
-  assert.deepEqual(calls[0].body.messages[2].content[0].cache_control, {
-    type: "ephemeral",
-  });
+  assert.equal(calls[0].body.messages[2].content[0].cache_control, undefined);
   assert.deepEqual(calls[0].body.tools[0].cache_control, {
     type: "ephemeral",
-    ttl: "1h",
+    ttl: "30m",
   });
 });
 


### PR DESCRIPTION
## What changed
- removed OmniRoute-managed cache_control injection from the CC-compatible bridge
- treated CC-compatible providers like other Claude providers for cache-control preservation decisions
- updated unit coverage so OpenAI-format requests to CC-compatible providers send no synthetic cache markers, while Claude Code-originated Claude requests keep their original markers

## Why
CC-compatible providers should behave like a transparent Claude Code bridge. The previous implementation added bridge-specific cache markers even when the source request did not carry any, which changed caching semantics for OpenAI-format callers.

## Impact
OpenAI-format requests sent to CC-compatible providers no longer receive bridge-generated `cache_control` fields. Claude-format requests that already include `cache_control` keep those markers when the request is treated as Claude Code-originated traffic.

## Validation
- `node --import tsx/esm --test tests/unit/cc-compatible-provider.test.mjs tests/unit/cache-control-claude-providers.test.mjs tests/unit/claude-cache-control-passthrough.test.mjs`
