### PR TITLE
Allow custom User-Agent on third-party providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### ✨ New Features
+
+- **API Provider Advanced Settings:** Added per-connection custom `User-Agent` overrides for API-key provider connections. The override is stored in `providerSpecificData.customUserAgent` and now applies to validation probes and upstream execution requests.
+
 ---
 
 ## [3.5.0] — 2026-04-03

--- a/open-sse/executors/base.ts
+++ b/open-sse/executors/base.ts
@@ -70,8 +70,37 @@ export function mergeUpstreamExtraHeaders(
   if (!extra) return;
   for (const [k, v] of Object.entries(extra)) {
     if (typeof k === "string" && k.length > 0 && typeof v === "string") {
+      if (k.toLowerCase() === "user-agent") {
+        setUserAgentHeader(headers, v);
+        continue;
+      }
       headers[k] = v;
     }
+  }
+}
+
+export function getCustomUserAgent(providerSpecificData?: JsonRecord | null): string | null {
+  const customUserAgent =
+    typeof providerSpecificData?.customUserAgent === "string"
+      ? providerSpecificData.customUserAgent.trim()
+      : "";
+  return customUserAgent || null;
+}
+
+export function setUserAgentHeader(headers: Record<string, string>, userAgent: string): void {
+  headers["User-Agent"] = userAgent;
+  if ("user-agent" in headers) {
+    headers["user-agent"] = userAgent;
+  }
+}
+
+export function applyConfiguredUserAgent(
+  headers: Record<string, string>,
+  providerSpecificData?: JsonRecord | null
+): void {
+  const customUserAgent = getCustomUserAgent(providerSpecificData);
+  if (customUserAgent) {
+    setUserAgentHeader(headers, customUserAgent);
   }
 }
 
@@ -156,9 +185,7 @@ export class BaseExecutor {
       const envKey = `${providerId.toUpperCase().replace(/[^A-Z0-9]/g, "_")}_USER_AGENT`;
       const envUA = process.env[envKey]?.trim();
       if (envUA) {
-        // Override both common casing variants
-        headers["User-Agent"] = envUA;
-        if (headers["user-agent"]) headers["user-agent"] = envUA;
+        setUserAgentHeader(headers, envUA);
       }
     }
 
@@ -238,6 +265,7 @@ export class BaseExecutor {
     for (let urlIndex = 0; urlIndex < fallbackCount; urlIndex++) {
       const url = this.buildUrl(model, stream, urlIndex, credentials);
       const headers = this.buildHeaders(credentials, stream);
+      applyConfiguredUserAgent(headers, credentials?.providerSpecificData);
 
       // Append 1M context beta header when [1m] suffix was used
       // Only supported for specific Claude models per Anthropic docs

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -632,18 +632,36 @@ export async function handleChatCore({
   // Primary path: merge client model id + alias target so config on either key applies; resolved
   // id wins on same header name. T5 family fallback uses only (nextModel, resolveModelAlias(next))
   // so A-model headers are not sent to B — see buildUpstreamHeadersForExecute.
+  const connectionCustomUserAgent =
+    credentials?.providerSpecificData &&
+    typeof credentials.providerSpecificData === "object" &&
+    typeof credentials.providerSpecificData.customUserAgent === "string"
+      ? credentials.providerSpecificData.customUserAgent.trim()
+      : "";
+
   const buildUpstreamHeadersForExecute = (modelToCall: string): Record<string, string> => {
-    if (modelToCall === effectiveModel) {
-      return {
-        ...getModelUpstreamExtraHeaders(provider || "", model || "", sourceFormat),
-        ...getModelUpstreamExtraHeaders(provider || "", resolvedModel || "", sourceFormat),
-      };
+    const upstreamHeaders =
+      modelToCall === effectiveModel
+        ? {
+            ...getModelUpstreamExtraHeaders(provider || "", model || "", sourceFormat),
+            ...getModelUpstreamExtraHeaders(provider || "", resolvedModel || "", sourceFormat),
+          }
+        : (() => {
+            const r = resolveModelAlias(modelToCall);
+            return {
+              ...getModelUpstreamExtraHeaders(provider || "", modelToCall || "", sourceFormat),
+              ...getModelUpstreamExtraHeaders(provider || "", r || "", sourceFormat),
+            };
+          })();
+
+    if (connectionCustomUserAgent) {
+      upstreamHeaders["User-Agent"] = connectionCustomUserAgent;
+      if ("user-agent" in upstreamHeaders) {
+        upstreamHeaders["user-agent"] = connectionCustomUserAgent;
+      }
     }
-    const r = resolveModelAlias(modelToCall);
-    return {
-      ...getModelUpstreamExtraHeaders(provider || "", modelToCall || "", sourceFormat),
-      ...getModelUpstreamExtraHeaders(provider || "", r || "", sourceFormat),
-    };
+
+    return upstreamHeaders;
   };
 
   // Default to false unless client explicitly sets stream: true (OpenAI spec compliant)

--- a/src/app/(dashboard)/dashboard/providers/[id]/page.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.tsx
@@ -4523,11 +4523,13 @@ function AddApiKeyModal({
     region: isVertex ? defaultRegion : "",
     apiRegion: "international",
     validationModelId: "",
+    customUserAgent: "",
   });
   const [validating, setValidating] = useState(false);
   const [validationResult, setValidationResult] = useState(null);
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
+  const [showAdvanced, setShowAdvanced] = useState(false);
 
   const handleValidate = async () => {
     setValidating(true);
@@ -4540,6 +4542,7 @@ function AddApiKeyModal({
           provider,
           apiKey: formData.apiKey,
           validationModelId: formData.validationModelId || undefined,
+          customUserAgent: formData.customUserAgent.trim() || undefined,
         }),
       });
       const data = await res.json();
@@ -4578,6 +4581,7 @@ function AddApiKeyModal({
             provider,
             apiKey: formData.apiKey,
             validationModelId: formData.validationModelId || undefined,
+            customUserAgent: formData.customUserAgent.trim() || undefined,
           }),
         });
         const data = await res.json();
@@ -4594,28 +4598,26 @@ function AddApiKeyModal({
         return;
       }
 
+      const providerSpecificData: Record<string, unknown> = {};
+      if (formData.customUserAgent.trim()) {
+        providerSpecificData.customUserAgent = formData.customUserAgent.trim();
+      }
+      if (isBailian) {
+        providerSpecificData.baseUrl = validatedBailianBaseUrl;
+      } else if (isVertex) {
+        providerSpecificData.region = formData.region;
+      } else if (isGlm) {
+        providerSpecificData.apiRegion = formData.apiRegion;
+      }
+
       const payload = {
         name: formData.name,
         apiKey: formData.apiKey,
         priority: formData.priority,
         testStatus: "active",
-        providerSpecificData: undefined,
+        providerSpecificData:
+          Object.keys(providerSpecificData).length > 0 ? providerSpecificData : undefined,
       };
-
-      // Include baseUrl in providerSpecificData for bailian-coding-plan
-      if (isBailian) {
-        payload.providerSpecificData = {
-          baseUrl: validatedBailianBaseUrl,
-        };
-      } else if (isVertex) {
-        payload.providerSpecificData = {
-          region: formData.region,
-        };
-      } else if (isGlm) {
-        payload.providerSpecificData = {
-          apiRegion: formData.apiRegion,
-        };
-      }
 
       const error = await onSave(payload);
       if (error) {
@@ -4693,6 +4695,35 @@ function AddApiKeyModal({
                     provider: providerName || t("openaiCompatibleName"),
                   })}
           </p>
+        )}
+        <button
+          type="button"
+          className="text-sm text-text-muted hover:text-text-primary flex items-center gap-1"
+          onClick={() => setShowAdvanced(!showAdvanced)}
+          aria-expanded={showAdvanced}
+          aria-controls="add-api-key-advanced-settings"
+        >
+          <span
+            className={`transition-transform ${showAdvanced ? "rotate-90" : ""}`}
+            aria-hidden="true"
+          >
+            ▶
+          </span>
+          {t("advancedSettings")}
+        </button>
+        {showAdvanced && (
+          <div
+            id="add-api-key-advanced-settings"
+            className="flex flex-col gap-3 pl-2 border-l-2 border-border"
+          >
+            <Input
+              label="Custom User-Agent"
+              value={formData.customUserAgent}
+              onChange={(e) => setFormData({ ...formData, customUserAgent: e.target.value })}
+              placeholder="my-app/1.0"
+              hint="Optional override sent upstream as the User-Agent header for this connection"
+            />
+          </div>
         )}
         <Input
           label="Model ID (opcional)"
@@ -4796,6 +4827,7 @@ function EditConnectionModal({ isOpen, connection, onSave, onClose }: EditConnec
     apiRegion: "international",
     validationModelId: "",
     tag: "",
+    customUserAgent: "",
   });
   const [testing, setTesting] = useState(false);
   const [testResult, setTestResult] = useState(null);
@@ -4805,6 +4837,7 @@ function EditConnectionModal({ isOpen, connection, onSave, onClose }: EditConnec
   const [saveError, setSaveError] = useState<string | null>(null);
   const [extraApiKeys, setExtraApiKeys] = useState<string[]>([]);
   const [newExtraKey, setNewExtraKey] = useState("");
+  const [showAdvanced, setShowAdvanced] = useState(false);
 
   const isBailian = connection?.provider === "bailian-coding-plan";
   const defaultBailianUrl = "https://coding-intl.dashscope.aliyuncs.com/apps/anthropic/v1";
@@ -4818,6 +4851,9 @@ function EditConnectionModal({ isOpen, connection, onSave, onClose }: EditConnec
       const existingBaseUrl = typeof rawBaseUrl === "string" ? rawBaseUrl : "";
       const rawRegion = connection.providerSpecificData?.region;
       const existingRegion = typeof rawRegion === "string" ? rawRegion : "";
+      const rawCustomUserAgent = connection.providerSpecificData?.customUserAgent;
+      const existingCustomUserAgent =
+        typeof rawCustomUserAgent === "string" ? rawCustomUserAgent : "";
       setFormData({
         name: connection.name || "",
         priority: connection.priority || 1,
@@ -4828,11 +4864,13 @@ function EditConnectionModal({ isOpen, connection, onSave, onClose }: EditConnec
         apiRegion: (connection.providerSpecificData?.apiRegion as string) || "international",
         validationModelId: (connection.providerSpecificData?.validationModelId as string) || "",
         tag: (connection.providerSpecificData?.tag as string) || "",
+        customUserAgent: existingCustomUserAgent,
       });
       // Load existing extra keys from providerSpecificData
       const existing = connection.providerSpecificData?.extraApiKeys;
       setExtraApiKeys(Array.isArray(existing) ? existing : []);
       setNewExtraKey("");
+      setShowAdvanced(!!existingCustomUserAgent);
       setTestResult(null);
       setValidationResult(null);
       setSaveError(null);
@@ -4880,6 +4918,7 @@ function EditConnectionModal({ isOpen, connection, onSave, onClose }: EditConnec
           provider: connection.provider,
           apiKey: formData.apiKey,
           validationModelId: formData.validationModelId || undefined,
+          customUserAgent: formData.customUserAgent.trim() || undefined,
         }),
       });
       const data = await res.json();
@@ -4925,6 +4964,7 @@ function EditConnectionModal({ isOpen, connection, onSave, onClose }: EditConnec
                 provider: connection.provider,
                 apiKey: formData.apiKey,
                 validationModelId: formData.validationModelId || undefined,
+                customUserAgent: formData.customUserAgent.trim() || undefined,
               }),
             });
             const data = await res.json();
@@ -4952,6 +4992,7 @@ function EditConnectionModal({ isOpen, connection, onSave, onClose }: EditConnec
           ...(connection.providerSpecificData || {}),
           extraApiKeys: extraApiKeys.filter((k) => k.trim().length > 0),
           tag: formData.tag.trim() || undefined,
+          customUserAgent: formData.customUserAgent.trim(),
         };
         if (formData.validationModelId) {
           updates.providerSpecificData.validationModelId = formData.validationModelId;
@@ -5065,6 +5106,35 @@ function EditConnectionModal({ isOpen, connection, onSave, onClose }: EditConnec
             {saveError && (
               <div className="text-sm text-red-500 bg-red-500/10 border border-red-500/20 rounded-lg px-3 py-2">
                 {saveError}
+              </div>
+            )}
+            <button
+              type="button"
+              className="text-sm text-text-muted hover:text-text-primary flex items-center gap-1"
+              onClick={() => setShowAdvanced(!showAdvanced)}
+              aria-expanded={showAdvanced}
+              aria-controls="edit-connection-advanced-settings"
+            >
+              <span
+                className={`transition-transform ${showAdvanced ? "rotate-90" : ""}`}
+                aria-hidden="true"
+              >
+                ▶
+              </span>
+              {t("advancedSettings")}
+            </button>
+            {showAdvanced && (
+              <div
+                id="edit-connection-advanced-settings"
+                className="flex flex-col gap-3 pl-2 border-l-2 border-border"
+              >
+                <Input
+                  label="Custom User-Agent"
+                  value={formData.customUserAgent}
+                  onChange={(e) => setFormData({ ...formData, customUserAgent: e.target.value })}
+                  placeholder="my-app/1.0"
+                  hint="Optional override sent upstream as the User-Agent header for this connection"
+                />
               </div>
             )}
             <Input

--- a/src/app/api/providers/validate/route.ts
+++ b/src/app/api/providers/validate/route.ts
@@ -31,9 +31,12 @@ export async function POST(request) {
     if (isValidationFailure(validation)) {
       return NextResponse.json({ error: validation.error }, { status: 400 });
     }
-    const { provider, apiKey, validationModelId } = validation.data;
+    const { provider, apiKey, validationModelId, customUserAgent } = validation.data;
 
     let providerSpecificData: any = { validationModelId };
+    if (customUserAgent) {
+      providerSpecificData.customUserAgent = customUserAgent;
+    }
 
     if (isOpenAICompatibleProvider(provider) || isAnthropicCompatibleProvider(provider)) {
       const node: any = await getProviderNodeById(provider);

--- a/src/lib/providers/validation.ts
+++ b/src/lib/providers/validation.ts
@@ -80,11 +80,40 @@ function resolveChatUrl(provider: string, baseUrl: string, providerSpecificData:
   return normalized;
 }
 
-function buildBearerHeaders(apiKey: string) {
+function getCustomUserAgent(providerSpecificData: any = {}) {
+  if (typeof providerSpecificData?.customUserAgent !== "string") return null;
+  const customUserAgent = providerSpecificData.customUserAgent.trim();
+  return customUserAgent || null;
+}
+
+function applyCustomUserAgent(headers: Record<string, string>, providerSpecificData: any = {}) {
+  const customUserAgent = getCustomUserAgent(providerSpecificData);
+  if (!customUserAgent) return headers;
+  headers["User-Agent"] = customUserAgent;
+  if ("user-agent" in headers) {
+    headers["user-agent"] = customUserAgent;
+  }
+  return headers;
+}
+
+function withCustomUserAgent(init: RequestInit, providerSpecificData: any = {}) {
   return {
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${apiKey}`,
+    ...init,
+    headers: applyCustomUserAgent(
+      { ...((init.headers as Record<string, string> | undefined) || {}) },
+      providerSpecificData
+    ),
   };
+}
+
+function buildBearerHeaders(apiKey: string, providerSpecificData: any = {}) {
+  return applyCustomUserAgent(
+    {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    providerSpecificData
+  );
 }
 
 async function validateOpenAILikeProvider({
@@ -106,7 +135,7 @@ async function validateOpenAILikeProvider({
 
   const modelsRes = await fetch(modelsUrl, {
     method: "GET",
-    headers: buildBearerHeaders(apiKey),
+    headers: buildBearerHeaders(apiKey, providerSpecificData),
   });
 
   if (modelsRes.ok) {
@@ -132,7 +161,7 @@ async function validateOpenAILikeProvider({
 
   const chatRes = await fetch(chatUrl, {
     method: "POST",
-    headers: buildBearerHeaders(apiKey),
+    headers: buildBearerHeaders(apiKey, providerSpecificData),
     body: JSON.stringify(testBody),
   });
 
@@ -167,10 +196,13 @@ async function validateAnthropicLikeProvider({
     return { valid: false, error: "Missing base URL" };
   }
 
-  const requestHeaders = {
-    "Content-Type": "application/json",
-    ...headers,
-  };
+  const requestHeaders = applyCustomUserAgent(
+    {
+      "Content-Type": "application/json",
+      ...headers,
+    },
+    providerSpecificData
+  );
 
   if (!requestHeaders["x-api-key"] && !requestHeaders["X-API-Key"]) {
     requestHeaders["x-api-key"] = apiKey;
@@ -200,7 +232,7 @@ async function validateAnthropicLikeProvider({
   return { valid: true, error: null };
 }
 
-async function validateGeminiLikeProvider({ apiKey, baseUrl }: any) {
+async function validateGeminiLikeProvider({ apiKey, baseUrl, providerSpecificData = {} }: any) {
   if (!baseUrl) {
     return { valid: false, error: "Missing base URL" };
   }
@@ -208,7 +240,7 @@ async function validateGeminiLikeProvider({ apiKey, baseUrl }: any) {
   const separator = baseUrl.includes("?") ? "&" : "?";
   const response = await fetch(`${baseUrl}${separator}key=${encodeURIComponent(apiKey)}`, {
     method: "GET",
-    headers: { "Content-Type": "application/json" },
+    headers: applyCustomUserAgent({ "Content-Type": "application/json" }, providerSpecificData),
   });
 
   if (response.ok) {
@@ -224,11 +256,11 @@ async function validateGeminiLikeProvider({ apiKey, baseUrl }: any) {
 
 // ── Specialty providers (non-standard APIs) ──
 
-async function validateDeepgramProvider({ apiKey }: any) {
+async function validateDeepgramProvider({ apiKey, providerSpecificData = {} }: any) {
   try {
     const response = await fetch("https://api.deepgram.com/v1/auth/token", {
       method: "GET",
-      headers: { Authorization: `Token ${apiKey}` },
+      headers: applyCustomUserAgent({ Authorization: `Token ${apiKey}` }, providerSpecificData),
     });
     if (response.ok) return { valid: true, error: null };
     if (response.status === 401 || response.status === 403) {
@@ -240,14 +272,17 @@ async function validateDeepgramProvider({ apiKey }: any) {
   }
 }
 
-async function validateAssemblyAIProvider({ apiKey }: any) {
+async function validateAssemblyAIProvider({ apiKey, providerSpecificData = {} }: any) {
   try {
     const response = await fetch("https://api.assemblyai.com/v2/transcript?limit=1", {
       method: "GET",
-      headers: {
-        Authorization: apiKey,
-        "Content-Type": "application/json",
-      },
+      headers: applyCustomUserAgent(
+        {
+          Authorization: apiKey,
+          "Content-Type": "application/json",
+        },
+        providerSpecificData
+      ),
     });
     if (response.ok) return { valid: true, error: null };
     if (response.status === 401 || response.status === 403) {
@@ -259,16 +294,19 @@ async function validateAssemblyAIProvider({ apiKey }: any) {
   }
 }
 
-async function validateNanoBananaProvider({ apiKey }: any) {
+async function validateNanoBananaProvider({ apiKey, providerSpecificData = {} }: any) {
   try {
     // NanoBanana doesn't expose a lightweight validation endpoint,
     // so we send a minimal generate request that will succeed or fail on auth.
     const response = await fetch("https://api.nanobananaapi.ai/api/v1/nanobanana/generate", {
       method: "POST",
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-        "Content-Type": "application/json",
-      },
+      headers: applyCustomUserAgent(
+        {
+          Authorization: `Bearer ${apiKey}`,
+          "Content-Type": "application/json",
+        },
+        providerSpecificData
+      ),
       body: JSON.stringify({
         prompt: "test",
         model: "nanobanana-flash",
@@ -284,15 +322,18 @@ async function validateNanoBananaProvider({ apiKey }: any) {
   }
 }
 
-async function validateElevenLabsProvider({ apiKey }: any) {
+async function validateElevenLabsProvider({ apiKey, providerSpecificData = {} }: any) {
   try {
     // Lightweight auth check endpoint
     const response = await fetch("https://api.elevenlabs.io/v1/voices", {
       method: "GET",
-      headers: {
-        "xi-api-key": apiKey,
-        "Content-Type": "application/json",
-      },
+      headers: applyCustomUserAgent(
+        {
+          "xi-api-key": apiKey,
+          "Content-Type": "application/json",
+        },
+        providerSpecificData
+      ),
     });
 
     if (response.ok) return { valid: true, error: null };
@@ -306,16 +347,19 @@ async function validateElevenLabsProvider({ apiKey }: any) {
   }
 }
 
-async function validateInworldProvider({ apiKey }: any) {
+async function validateInworldProvider({ apiKey, providerSpecificData = {} }: any) {
   try {
     // Inworld TTS lacks a simple key-introspection endpoint.
     // Send a minimal synth request and treat non-auth 4xx as auth-pass.
     const response = await fetch("https://api.inworld.ai/tts/v1/voice", {
       method: "POST",
-      headers: {
-        Authorization: `Basic ${apiKey}`,
-        "Content-Type": "application/json",
-      },
+      headers: applyCustomUserAgent(
+        {
+          Authorization: `Basic ${apiKey}`,
+          "Content-Type": "application/json",
+        },
+        providerSpecificData
+      ),
       body: JSON.stringify({
         text: "test",
         modelId: "inworld-tts-1.5-mini",
@@ -348,11 +392,14 @@ async function validateBailianCodingPlanProvider({ apiKey, providerSpecificData 
 
     const response = await fetch(messagesUrl, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "x-api-key": apiKey,
-        "anthropic-version": "2023-06-01",
-      },
+      headers: applyCustomUserAgent(
+        {
+          "Content-Type": "application/json",
+          "x-api-key": apiKey,
+          "anthropic-version": "2023-06-01",
+        },
+        providerSpecificData
+      ),
       body: JSON.stringify({
         model: "qwen3-coder-plus",
         max_tokens: 1,
@@ -396,7 +443,7 @@ async function validateOpenAICompatibleProvider({ apiKey, providerSpecificData =
   try {
     const modelsRes = await fetch(`${baseUrl}/models`, {
       method: "GET",
-      headers: buildBearerHeaders(apiKey),
+      headers: buildBearerHeaders(apiKey, providerSpecificData),
     });
 
     modelsReachable = true;
@@ -441,7 +488,7 @@ async function validateOpenAICompatibleProvider({ apiKey, providerSpecificData =
   try {
     const chatRes = await fetch(chatUrl, {
       method: "POST",
-      headers: buildBearerHeaders(apiKey),
+      headers: buildBearerHeaders(apiKey, providerSpecificData),
       body: JSON.stringify({
         model: testModelId,
         messages: [{ role: "user", content: "test" }],
@@ -503,7 +550,7 @@ async function validateOpenAICompatibleProvider({ apiKey, providerSpecificData =
   try {
     const pingRes = await fetch(baseUrl, {
       method: "GET",
-      headers: buildBearerHeaders(apiKey),
+      headers: buildBearerHeaders(apiKey, providerSpecificData),
       signal: AbortSignal.timeout(5000),
     });
 
@@ -524,12 +571,15 @@ async function validateAnthropicCompatibleProvider({ apiKey, providerSpecificDat
     return { valid: false, error: "No base URL configured for Anthropic compatible provider" };
   }
 
-  const headers = {
-    "Content-Type": "application/json",
-    "x-api-key": apiKey,
-    "anthropic-version": "2023-06-01",
-    Authorization: `Bearer ${apiKey}`,
-  };
+  const headers = applyCustomUserAgent(
+    {
+      "Content-Type": "application/json",
+      "x-api-key": apiKey,
+      "anthropic-version": "2023-06-01",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    providerSpecificData
+  );
 
   // Step 1: Try GET /models
   try {
@@ -590,7 +640,10 @@ export async function validateClaudeCodeCompatibleProvider({
 
   const modelsPath = providerSpecificData?.modelsPath || CLAUDE_CODE_COMPATIBLE_DEFAULT_MODELS_PATH;
   const chatPath = providerSpecificData?.chatPath || CLAUDE_CODE_COMPATIBLE_DEFAULT_CHAT_PATH;
-  const defaultHeaders = buildClaudeCodeCompatibleHeaders(apiKey, false);
+  const defaultHeaders = applyCustomUserAgent(
+    buildClaudeCodeCompatibleHeaders(apiKey, false),
+    providerSpecificData
+  );
 
   try {
     const modelsRes = await fetch(joinClaudeCodeCompatibleUrl(baseUrl, modelsPath), {
@@ -617,7 +670,10 @@ export async function validateClaudeCodeCompatibleProvider({
   try {
     const messagesRes = await fetch(joinClaudeCodeCompatibleUrl(baseUrl, chatPath), {
       method: "POST",
-      headers: buildClaudeCodeCompatibleHeaders(apiKey, true, sessionId),
+      headers: applyCustomUserAgent(
+        buildClaudeCodeCompatibleHeaders(apiKey, true, sessionId),
+        providerSpecificData
+      ),
       body: JSON.stringify(payload),
     });
 
@@ -657,10 +713,11 @@ export async function validateClaudeCodeCompatibleProvider({
 
 async function validateSearchProvider(
   url: string,
-  init: RequestInit
+  init: RequestInit,
+  providerSpecificData: any = {}
 ): Promise<{ valid: boolean; error: string | null; unsupported: false }> {
   try {
-    const response = await fetch(url, init);
+    const response = await fetch(url, withCustomUserAgent(init, providerSpecificData));
     if (response.ok) return { valid: true, error: null, unsupported: false };
     if (response.status === 401 || response.status === 403) {
       return { valid: false, error: "Invalid API key", unsupported: false };
@@ -757,11 +814,11 @@ export async function validateProviderApiKey({ provider, apiKey, providerSpecifi
     inworld: validateInworldProvider,
     "bailian-coding-plan": validateBailianCodingPlanProvider,
     // LongCat AI — does not expose /v1/models; validate via chat completions directly (#592)
-    longcat: async ({ apiKey }: any) => {
+    longcat: async ({ apiKey, providerSpecificData }: any) => {
       try {
         const res = await fetch("https://api.longcat.chat/openai/v1/chat/completions", {
           method: "POST",
-          headers: buildBearerHeaders(apiKey),
+          headers: buildBearerHeaders(apiKey, providerSpecificData),
           body: JSON.stringify({
             model: "longcat",
             messages: [{ role: "user", content: "test" }],
@@ -781,9 +838,9 @@ export async function validateProviderApiKey({ provider, apiKey, providerSpecifi
     ...Object.fromEntries(
       Object.entries(SEARCH_VALIDATOR_CONFIGS).map(([id, configFn]) => [
         id,
-        ({ apiKey }: any) => {
+        ({ apiKey, providerSpecificData }: any) => {
           const { url, init } = configFn(apiKey);
-          return validateSearchProvider(url, init);
+          return validateSearchProvider(url, init, providerSpecificData);
         },
       ])
     ),
@@ -847,6 +904,7 @@ export async function validateProviderApiKey({ provider, apiKey, providerSpecifi
       return await validateGeminiLikeProvider({
         apiKey,
         baseUrl,
+        providerSpecificData,
       });
     }
 

--- a/src/shared/validation/schemas.ts
+++ b/src/shared/validation/schemas.ts
@@ -32,12 +32,23 @@ export const createProviderSchema = z.object({
     .superRefine((data, ctx) => {
       if (!data) return;
       const baseUrl = data.baseUrl;
-      if (baseUrl === undefined) return;
-      if (typeof baseUrl !== "string" || !isHttpUrl(baseUrl)) {
+      if (baseUrl !== undefined && (typeof baseUrl !== "string" || !isHttpUrl(baseUrl))) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message: "providerSpecificData.baseUrl must be a valid http(s) URL",
           path: ["baseUrl"],
+        });
+      }
+      const customUserAgent = data.customUserAgent;
+      if (
+        customUserAgent !== undefined &&
+        customUserAgent !== null &&
+        (typeof customUserAgent !== "string" || customUserAgent.length > 500)
+      ) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "providerSpecificData.customUserAgent must be a string up to 500 chars",
+          path: ["customUserAgent"],
         });
       }
     }),
@@ -1033,12 +1044,23 @@ export const updateProviderConnectionSchema = z
       .superRefine((data, ctx) => {
         if (!data) return;
         const baseUrl = data.baseUrl;
-        if (baseUrl === undefined) return;
-        if (typeof baseUrl !== "string" || !isHttpUrl(baseUrl)) {
+        if (baseUrl !== undefined && (typeof baseUrl !== "string" || !isHttpUrl(baseUrl))) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
             message: "providerSpecificData.baseUrl must be a valid http(s) URL",
             path: ["baseUrl"],
+          });
+        }
+        const customUserAgent = data.customUserAgent;
+        if (
+          customUserAgent !== undefined &&
+          customUserAgent !== null &&
+          (typeof customUserAgent !== "string" || customUserAgent.length > 500)
+        ) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: "providerSpecificData.customUserAgent must be a string up to 500 chars",
+            path: ["customUserAgent"],
           });
         }
       }),
@@ -1075,6 +1097,7 @@ export const validateProviderApiKeySchema = z.object({
   provider: z.string().trim().min(1, "Provider and API key required"),
   apiKey: z.string().trim().min(1, "Provider and API key required"),
   validationModelId: z.string().trim().optional(),
+  customUserAgent: z.string().trim().max(500).optional(),
 });
 
 const geminiPartSchema = z

--- a/tests/unit/plan3-p0.test.mjs
+++ b/tests/unit/plan3-p0.test.mjs
@@ -69,6 +69,40 @@ test("DefaultExecutor uses x-api-key for kimi-coding-apikey", () => {
   assert.equal(headers.Authorization, undefined);
 });
 
+test("DefaultExecutor execute honors connection-level custom User-Agent", async () => {
+  const executor = new DefaultExecutor("openai");
+  const originalFetch = globalThis.fetch;
+  let capturedHeaders = null;
+
+  globalThis.fetch = async (_url, init = {}) => {
+    capturedHeaders = init.headers || null;
+    return new Response(JSON.stringify({ id: "chatcmpl-test" }), { status: 200 });
+  };
+
+  try {
+    await executor.execute({
+      model: "gpt-4o",
+      body: {
+        model: "gpt-4o",
+        messages: [{ role: "user", content: "hello" }],
+      },
+      stream: false,
+      credentials: {
+        apiKey: "sk-openai-test",
+        providerSpecificData: {
+          customUserAgent: "OmniRouteCustomUA/2.0",
+        },
+      },
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  assert.ok(capturedHeaders);
+  assert.equal(capturedHeaders.Authorization, "Bearer sk-openai-test");
+  assert.equal(capturedHeaders["User-Agent"], "OmniRouteCustomUA/2.0");
+});
+
 test("CodexExecutor forces stream=true for upstream compatibility", () => {
   const executor = new CodexExecutor();
   const transformed = executor.transformRequest(

--- a/tests/unit/provider-validation-branches.test.mjs
+++ b/tests/unit/provider-validation-branches.test.mjs
@@ -41,8 +41,8 @@ test("openai-compatible validation reports missing base URL", async () => {
 
 test("openai-compatible validation accepts rate-limited /models responses", async () => {
   const calls = [];
-  globalThis.fetch = async (url) => {
-    calls.push(String(url));
+  globalThis.fetch = async (url, init = {}) => {
+    calls.push({ url: String(url), headers: init.headers || {} });
     return new Response(JSON.stringify({ error: "rate limited" }), { status: 429 });
   };
 
@@ -55,7 +55,33 @@ test("openai-compatible validation accepts rate-limited /models responses", asyn
   assert.equal(result.valid, true);
   assert.equal(result.method, "models_endpoint");
   assert.match(result.warning, /Rate limited/i);
-  assert.deepEqual(calls, ["https://api.example.com/v1/models"]);
+  assert.deepEqual(
+    calls.map((call) => call.url),
+    ["https://api.example.com/v1/models"]
+  );
+  assert.equal(calls[0].headers.Authorization, "Bearer sk-test");
+});
+
+test("openai-compatible validation forwards custom User-Agent", async () => {
+  const calls = [];
+  globalThis.fetch = async (url, init = {}) => {
+    calls.push({ url: String(url), headers: init.headers || {} });
+    return new Response(JSON.stringify({ error: "rate limited" }), { status: 429 });
+  };
+
+  const result = await validateProviderApiKey({
+    provider: "openai-compatible-custom-ua",
+    apiKey: "sk-test",
+    providerSpecificData: {
+      baseUrl: "https://api.example.com/v1",
+      customUserAgent: "MyRouteTester/1.0",
+    },
+  });
+
+  assert.equal(result.valid, true);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, "https://api.example.com/v1/models");
+  assert.equal(calls[0].headers["User-Agent"], "MyRouteTester/1.0");
 });
 
 test("openai-compatible validation treats chat 400 as authenticated fallback", async () => {


### PR DESCRIPTION
## What changed
- added a `Custom User-Agent` field under advanced settings for third-party provider connections
- persisted the value in `providerSpecificData.customUserAgent` during validation and connection updates
- applied the configured value to provider validation probes and runtime upstream requests across generic and compatible third-party providers
- added coverage for schema validation and provider validation branches, and updated the changelog

## Why
Some third-party API providers gate behavior, routing, or allowlisting based on `User-Agent`. OmniRoute previously always sent its default header, so users could not match provider-specific requirements without modifying code.

## Impact
Users can now set a per-connection `User-Agent` override from the dashboard advanced settings. The value is used consistently during credential validation and when forwarding actual model requests upstream.

## Validation
- `node --import tsx/esm --test tests/unit/plan3-p0.test.mjs tests/unit/provider-validation-branches.test.mjs tests/unit/search-provider-validation.test.mjs`
- `./node_modules/.bin/eslint 'open-sse/executors/base.ts' 'open-sse/handlers/chatCore.ts' 'src/app/(dashboard)/dashboard/providers/[id]/page.tsx' 'src/app/api/providers/validate/route.ts' 'src/lib/providers/validation.ts' 'src/shared/validation/schemas.ts'`
- end-to-end verification with a temporary app instance backed by a copied `data/storage.sqlite`: saved `Custom User-Agent` in the dashboard UI, then sent a real `/api/v1/chat/completions` request and confirmed the upstream mock received `User-Agent: PR2-Verify-UA/1.0`
