### PR TITLE
fix(desktop): stabilize packaged app startup on macOS

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -64,6 +64,25 @@ let serverPort = 20128;
 
 const getServerUrl = () => `http://localhost:${serverPort}`;
 
+function resolveNodeExecutable(env = process.env) {
+  const candidates = [
+    env.OMNIROUTE_NODE_PATH,
+    "/usr/local/bin/node",
+    "/opt/homebrew/bin/node",
+    "/opt/local/bin/node",
+  ].filter(Boolean);
+
+  for (const candidate of candidates) {
+    try {
+      if (fs.existsSync(candidate)) return candidate;
+    } catch {
+      /* continue */
+    }
+  }
+
+  return "node";
+}
+
 function resolveDataDir(overridePath, env = process.env) {
   if (overridePath && overridePath.trim()) return path.resolve(overridePath);
 
@@ -516,11 +535,14 @@ function startNextServer() {
     }
   }
 
+  const nodeExecutable = resolveNodeExecutable(serverEnv);
+
   console.log("[Electron] Starting Next.js server on port", serverPort);
+  console.log("[Electron] Using Node executable:", nodeExecutable);
   sendToRenderer("server-status", { status: "starting", port: serverPort });
 
   // Fix #10: Use pipe instead of inherit for logging & readiness detection
-  nextServer = spawn("node", [serverScript], {
+  nextServer = spawn(nodeExecutable, [serverScript], {
     cwd: NEXT_SERVER_PATH,
     env: {
       ...serverEnv,

--- a/scripts/prepare-electron-standalone.mjs
+++ b/scripts/prepare-electron-standalone.mjs
@@ -83,6 +83,16 @@ function ensurePackage(pkgPath, sourcePath) {
   cpSync(sourcePath, pkgPath, { recursive: true, dereference: true });
 }
 
+function removeGeneratedElectronArtifacts() {
+  const generatedDirs = [
+    join(ELECTRON_STANDALONE_DIR, "electron", "dist-electron"),
+  ];
+
+  for (const dir of generatedDirs) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
 function assertBundleIsPackagable(bundleDir) {
   const nodeModulesPath = join(bundleDir, "node_modules");
   if (!existsSync(nodeModulesPath)) return;
@@ -130,6 +140,8 @@ if (existsSync(STATIC_SRC)) {
 if (existsSync(PUBLIC_SRC)) {
   cpSync(PUBLIC_SRC, PUBLIC_DEST, { recursive: true, dereference: true });
 }
+
+removeGeneratedElectronArtifacts();
 
 ensurePackage(
   join(ELECTRON_STANDALONE_DIR, "node_modules", "@swc", "helpers"),


### PR DESCRIPTION
## Summary
- exclude packaged desktop artifacts from the standalone Electron bundle preparation step
- improve packaged desktop startup behavior by making the runtime launch path more reliable

## Why
This addresses packaged macOS app startup issues that can lead to:
- black screen on launch
- backend not starting even though the dock icon appears
- unstable launches after rebuilding and reinstalling the desktop app

## Reproduction
1. Build and install the packaged macOS app.
2. Launch from `/Applications`.
3. Before this patch, the app may show only a dock icon, hang on a black screen, or fail to bring up the local backend consistently.

## Test plan
- build the macOS desktop bundle
- install the packaged app and launch it from `/Applications`
- confirm the local backend starts and the app window renders normally