### PR TITLE
fix: preserve built-in Responses API tool types in empty-name filter

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -741,6 +741,12 @@ export async function handleChatCore({
   // upstream providers to reject with 400 "Invalid 'tools[0].name': empty string."
   if (Array.isArray(body.tools)) {
     body.tools = body.tools.filter((tool: Record<string, unknown>) => {
+      // Built-in Responses API tool types (web_search, file_search, computer, etc.)
+      // are identified solely by their `type` field and carry no name — preserve them.
+      const toolType = typeof tool.type === "string" ? tool.type : "";
+      if (toolType && toolType !== "function" && !tool.function && tool.name === undefined) {
+        return true;
+      }
       const fn = tool.function as Record<string, unknown> | undefined;
       const name = fn?.name ?? tool.name;
       return name && String(name).trim().length > 0;

--- a/tests/unit/tools-filter-anthropic-format.test.mjs
+++ b/tests/unit/tools-filter-anthropic-format.test.mjs
@@ -10,9 +10,15 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
-// Inline the filter logic from chatCore.ts (lines 225-231 after #397 fix)
+// Inline the filter logic from chatCore.ts (after #397 fix + built-in tool type preservation)
 function filterEmptyNameTools(tools) {
   return tools.filter((tool) => {
+    // Built-in Responses API tool types (web_search, file_search, computer, etc.)
+    // are identified solely by their `type` field and carry no name — preserve them.
+    const toolType = typeof tool.type === "string" ? tool.type : "";
+    if (toolType && toolType !== "function" && !tool.function && tool.name === undefined) {
+      return true;
+    }
     const fn = tool.function;
     const name = fn?.name ?? tool.name;
     return name && String(name).trim().length > 0;
@@ -89,5 +95,43 @@ describe("tools empty-name filter — #346 / PR #397", () => {
       { name: null, input_schema: { type: "object" } },
     ];
     assert.equal(filterEmptyNameTools(tools).length, 0);
+  });
+
+  it("should preserve built-in Responses API web_search tool (no name field)", () => {
+    const tools = [{ type: "web_search", external_web_access: true }];
+    assert.equal(filterEmptyNameTools(tools).length, 1);
+  });
+
+  it("should preserve built-in Responses API tools without names (file_search, computer)", () => {
+    const tools = [
+      { type: "file_search" },
+      { type: "computer", display_width: 1024, display_height: 768 },
+      { type: "code_interpreter" },
+      { type: "image_generation", output_format: "png" },
+    ];
+    assert.equal(filterEmptyNameTools(tools).length, 4);
+  });
+
+  it("should preserve web_search alongside function tools and still drop empty-name functions", () => {
+    const tools = [
+      { type: "web_search", external_web_access: true },
+      { type: "function", function: { name: "exec_command", description: "Run a command" } },
+      { type: "function", function: { name: "" } },
+      { type: "custom", name: "apply_patch" },
+    ];
+    const result = filterEmptyNameTools(tools);
+    assert.equal(result.length, 3, "Should keep web_search, exec_command, and apply_patch");
+    assert.ok(
+      result.some((t) => t.type === "web_search"),
+      "web_search preserved"
+    );
+    assert.ok(
+      result.some((t) => t.function?.name === "exec_command"),
+      "exec_command preserved"
+    );
+    assert.ok(
+      result.some((t) => t.name === "apply_patch"),
+      "apply_patch preserved"
+    );
   });
 });


### PR DESCRIPTION
## Summary

The empty-name tool filter (#346/#637 in `chatCore.ts`) inadvertently drops **built-in Responses API tool types** (`web_search`, `file_search`, `computer`, `code_interpreter`, `image_generation`, etc.) because they carry no `name` field by design — their identity comes solely from the `type` field.

This caused Codex CLI's `web_search` tool (`{"type":"web_search","external_web_access":true}`) to be silently stripped from every request, removing the model's ability to perform web searches. The model was forced to fall back to `curl` via `exec_command`, which is unreliable (e.g. Cloudflare blocks).

### Root cause

The filter at `chatCore.ts:742-747` extracts `fn?.name ?? tool.name` and drops any tool where this is falsy. Built-in tool types have neither `.function.name` nor `.name`, so they always evaluate to `undefined` and get filtered out.

### Fix

Added an early-return check before the name extraction: if a tool has a non-`"function"` type, no `.function` wrapper, and no `.name` property, it is a built-in Responses API tool and is preserved unconditionally.

```typescript
const toolType = typeof tool.type === "string" ? tool.type : "";
if (toolType && toolType !== "function" && !tool.function && tool.name === undefined) {
  return true;
}
```

This preserves all existing behavior for function tools (OpenAI format), Anthropic-format tools, and custom tools — only built-in types that intentionally lack a name are exempted.

## Test plan

- [x] Existing 8 tests in `tools-filter-anthropic-format.test.mjs` still pass
- [x] Added 3 new test cases:
  - `web_search` tool with `external_web_access` is preserved
  - Multiple built-in types (`file_search`, `computer`, `code_interpreter`, `image_generation`) are preserved
  - Mixed array: `web_search` + valid function + empty-name function + custom — only the empty-name function is dropped
- [x] All 29 passing tests in `empty-tool-name-loop`, `responses-translation-fixes`, `tool-request-sanitization` are unaffected