### PR TITLE
fix(ui): use tokenExpiresAt for OAuth token expiry display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,6 @@ typescript
 
 # Superpowers plans/specs (internal tooling, not project code)
 docs/superpowers/
+
+# GitNexus local index
+.gitnexus

--- a/src/app/(dashboard)/dashboard/providers/[id]/page.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.tsx
@@ -390,6 +390,7 @@ interface ConnectionRowConnection {
   globalPriority?: number;
   providerSpecificData?: Record<string, unknown>;
   expiresAt?: string;
+  tokenExpiresAt?: string;
 }
 
 interface ConnectionRowProps {
@@ -4181,6 +4182,7 @@ function ConnectionRow({
       const expiresMs = new Date(effectiveExpiresAt).getTime();
       setTokenMinsLeft(Math.floor((expiresMs - Date.now()) / 60000));
     };
+    update();
     const iv = setInterval(update, 30000);
     return () => clearInterval(iv);
   }, [isOAuth, effectiveExpiresAt]);


### PR DESCRIPTION
## Summary

- OAuth connections (e.g. Qwen) were showing as **expired** in the providers dashboard even with valid tokens
- The UI was reading `connection.expiresAt` → DB column `expires_at`, which stores the **original grant date** and is never updated on refresh
- The live expiry lives in `token_expires_at` → `connection.tokenExpiresAt`, updated on every token refresh
- Fix: resolve `effectiveExpiresAt = connection.tokenExpiresAt || connection.expiresAt` and use that for the token minutes remaining calculation and tooltip — matching the existing fallback logic already in `src/app/api/providers/[id]/test/route.ts:281`

## Test plan

- [ ] Qwen (and other OAuth) connections show a time-remaining badge instead of "expired" after token refresh
- [ ] Connections with only `expiresAt` (no `tokenExpiresAt`) continue to work via fallback
- [ ] `npm run typecheck:core` passes
- [ ] Unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)