### PR TITLE
feat(api): aceitar aliases explícitos para resposta sem stream

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -105,7 +105,7 @@ import {
   EMERGENCY_FALLBACK_CONFIG,
 } from "../services/emergencyFallback.ts";
 import {
-  hasExplicitNoStreamParam,
+  resolveExplicitStreamAlias,
   resolveStreamFlag,
   stripMarkdownCodeFence,
 } from "../utils/aiSdkCompat.ts";
@@ -684,17 +684,23 @@ export async function handleChatCore({
       ? clientRawRequest.headers.get("accept") || clientRawRequest.headers.get("Accept")
       : (clientRawRequest?.headers || {})["accept"] || (clientRawRequest?.headers || {})["Accept"];
 
-  const explicitNoStream = hasExplicitNoStreamParam(body);
-  const stream = explicitNoStream ? false : resolveStreamFlag(body?.stream, acceptHeader);
+  const explicitStreamAlias = resolveExplicitStreamAlias(body);
 
   // Remove non-standard non-stream aliases before provider translation/execution.
   // They are accepted for compatibility at the OmniRoute API boundary only.
   if (body && typeof body === "object") {
-    delete (body as Record<string, unknown>).non_stream;
-    delete (body as Record<string, unknown>).disable_stream;
-    delete (body as Record<string, unknown>).disable_streaming;
-    delete (body as Record<string, unknown>).streaming;
+    const b = body as Record<string, unknown>;
+    if (explicitStreamAlias !== undefined) {
+      b.stream = explicitStreamAlias;
+    }
+
+    delete b.non_stream;
+    delete b.disable_stream;
+    delete b.disable_streaming;
+    delete b.streaming;
   }
+
+  const stream = resolveStreamFlag(body?.stream, acceptHeader);
 
   // ── Phase 9.1: Semantic cache check (non-streaming, temp=0 only) ──
   if (isCacheable(body, clientRawRequest?.headers)) {

--- a/open-sse/utils/aiSdkCompat.ts
+++ b/open-sse/utils/aiSdkCompat.ts
@@ -27,19 +27,30 @@ export function resolveStreamFlag(bodyStream: unknown, acceptHeader: unknown): b
 }
 
 /**
- * Detects explicit aliases meaning "do not stream".
- * Useful for clients that do not send OpenAI's canonical `stream: false` field.
+ * Resolves explicit stream aliases used by non-standard clients.
+ * Returns:
+ * - `true`  -> explicit streaming intent
+ * - `false` -> explicit non-stream intent
+ * - `undefined` -> no explicit alias present
  */
-export function hasExplicitNoStreamParam(body: unknown): boolean {
-  if (!body || typeof body !== "object") return false;
+export function resolveExplicitStreamAlias(body: unknown): boolean | undefined {
+  if (!body || typeof body !== "object") return undefined;
   const b = body as Record<string, unknown>;
 
-  if (b.non_stream === true) return true;
-  if (b.disable_stream === true) return true;
-  if (b.disable_streaming === true) return true;
-  if (b.streaming === false) return true;
+  if (b.streaming === true) return true;
+  if (b.streaming === false) return false;
+  if (b.non_stream === true) return false;
+  if (b.disable_stream === true) return false;
+  if (b.disable_streaming === true) return false;
 
-  return false;
+  return undefined;
+}
+
+/**
+ * Backward-compatible helper used by tests/legacy call sites.
+ */
+export function hasExplicitNoStreamParam(body: unknown): boolean {
+  return resolveExplicitStreamAlias(body) === false;
 }
 
 /**

--- a/tests/unit/t26-ai-sdk-accept-header-compat.test.mjs
+++ b/tests/unit/t26-ai-sdk-accept-header-compat.test.mjs
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 const {
   clientWantsJsonResponse,
   resolveStreamFlag,
+  resolveExplicitStreamAlias,
   hasExplicitNoStreamParam,
   stripMarkdownCodeFence,
 } = await import("../../open-sse/utils/aiSdkCompat.ts");
@@ -52,6 +53,14 @@ test("T26: explicit non-stream aliases are detected", () => {
   assert.equal(hasExplicitNoStreamParam({ disable_stream: true }), true);
   assert.equal(hasExplicitNoStreamParam({ disable_streaming: true }), true);
   assert.equal(hasExplicitNoStreamParam({ streaming: false }), true);
+  assert.equal(hasExplicitNoStreamParam({ streaming: true }), false);
   assert.equal(hasExplicitNoStreamParam({ stream: false }), false);
   assert.equal(hasExplicitNoStreamParam({}), false);
+});
+
+test("T26: explicit stream aliases resolve true/false correctly", () => {
+  assert.equal(resolveExplicitStreamAlias({ streaming: true }), true);
+  assert.equal(resolveExplicitStreamAlias({ streaming: false }), false);
+  assert.equal(resolveExplicitStreamAlias({ disable_streaming: true }), false);
+  assert.equal(resolveExplicitStreamAlias({}), undefined);
 });


### PR DESCRIPTION
## Summary
- adiciona suporte na API de chat para aliases explícitos de não-stream (`non_stream`, `disable_stream`, `disable_streaming`, `streaming=false`), além do padrão `stream=false`
- força modo não-stream quando qualquer alias é enviado e remove esses campos não-padrão antes do envio ao provider
- inclui testes unitários cobrindo detecção dos aliases em `t26-ai-sdk-accept-header-compat.test.mjs`

## Why
Alguns clientes não enviam o campo OpenAI canônico `stream=false` e ainda assim precisam de resposta única (não SSE). A mudança amplia compatibilidade sem quebrar o comportamento existente.

## Validation
- `node --import tsx/esm --test tests/unit/t26-ai-sdk-accept-header-compat.test.mjs`