### PR TITLE
fix(settings): align Codex fast-tier copy with the actual wire value

### DIFF
--- a/src/app/(dashboard)/dashboard/settings/components/CodexServiceTierTab.tsx
+++ b/src/app/(dashboard)/dashboard/settings/components/CodexServiceTierTab.tsx
@@ -57,7 +57,7 @@ export default function CodexServiceTierTab() {
         <div className="flex-1">
           <h3 className="text-lg font-semibold">Codex Fast Service Tier</h3>
           <p className="text-sm text-text-muted">
-            Inject `service_tier=fast` into Codex requests when the client leaves it unset.
+            Inject `service_tier=priority` into Codex requests when the client leaves it unset.
           </p>
         </div>
         {status === "saved" && (
@@ -79,6 +79,7 @@ export default function CodexServiceTierTab() {
           <p className="text-sm font-medium">Force fast tier for Codex</p>
           <p className="text-xs text-text-muted mt-0.5">
             Off by default. Applies only to Codex requests and does not override an explicit tier.
+            Codex fast mode is sent upstream as `service_tier=priority`.
           </p>
         </div>
         <button


### PR DESCRIPTION
This fixes the Codex fast-tier settings copy so it matches the actual Codex wire format.

What changed:
- update the dashboard settings text to say OmniRoute injects `service_tier=priority`
- clarify that Codex fast mode is sent upstream as `service_tier=priority`

Why:
- Codex CLI maps fast mode to `service_tier="priority"`
- OmniRoute already implements that normalization in `open-sse/executors/codex.ts`
- the settings copy still claimed `service_tier=fast`, which is misleading for operators and debugging

Verification:
- verified Codex CLI request builder maps fast -> `service_tier="priority"`
- verified OmniRoute Codex executor already normalizes `fast` to `priority`
- updated the dashboard copy to match the actual request behavior

Note:
- I did not change executor behavior; this is a narrow correctness fix for the settings UI copy.