### PR TITLE
fix(codex): stop limits refresh from downgrading healthy accounts

### DIFF
--- a/open-sse/services/usage.ts
+++ b/open-sse/services/usage.ts
@@ -976,7 +976,7 @@ async function getCodexUsage(accessToken, providerSpecificData: Record<string, u
     if (!response.ok) {
       if (response.status === 401 || response.status === 403) {
         return {
-          message: `Codex token expired or access denied. Please re-authenticate the connection.`,
+          message: `Codex usage details are unavailable for this account.`,
         };
       }
       throw new Error(`Codex API error: ${response.status}`);

--- a/src/lib/tokenHealthCheck.ts
+++ b/src/lib/tokenHealthCheck.ts
@@ -180,7 +180,40 @@ async function checkConnection(conn) {
   if (!conn.isActive) return;
   if (!conn.refreshToken || typeof conn.refreshToken !== "string") return;
 
+  const nowMs = Date.now();
+
+  // Proactive pre-expiry check (#631): if token is about to expire, refresh immediately.
+  // When a connection still has a healthy access token, avoid forcing a refresh purely
+  // because the interval elapsed. Some providers may reject older refresh tokens while
+  // the current access token remains valid, and treating that as a hard auth failure
+  // produces false "re-authenticate" warnings.
+  const TOKEN_EXPIRY_BUFFER = 5 * 60 * 1000; // 5 minutes
+  const tokenExpiresAtMs = conn.tokenExpiresAt ? new Date(conn.tokenExpiresAt).getTime() : 0;
+  const hasHealthyAccessToken =
+    tokenExpiresAtMs > 0 && Number.isFinite(tokenExpiresAtMs) && tokenExpiresAtMs - nowMs > TOKEN_EXPIRY_BUFFER;
+  const isAboutToExpire =
+    tokenExpiresAtMs > 0 && Number.isFinite(tokenExpiresAtMs) && tokenExpiresAtMs - nowMs <= TOKEN_EXPIRY_BUFFER;
+
   // Retry expired connections with exponential backoff up to EXPIRED_RETRY_MAX times.
+  if (conn.testStatus === "expired" && hasHealthyAccessToken) {
+    const now = new Date().toISOString();
+    await updateProviderConnection(conn.id, {
+      lastHealthCheckAt: now,
+      testStatus: "active",
+      lastError: null,
+      lastErrorAt: null,
+      lastErrorType: null,
+      lastErrorSource: null,
+      errorCode: null,
+      expiredRetryCount: null,
+      expiredRetryAt: null,
+    });
+    log(
+      `${LOG_PREFIX} ✓ ${conn.provider}/${conn.name || conn.email || conn.id} marked active (access token still valid)`
+    );
+    return;
+  }
+
   if (conn.testStatus === "expired") {
     const retryCount = conn.expiredRetryCount ?? 0;
     if (retryCount >= EXPIRED_RETRY_MAX) return;
@@ -206,14 +239,28 @@ async function checkConnection(conn) {
   const intervalMs = intervalMin * 60 * 1000;
   const lastCheck = conn.lastHealthCheckAt ? new Date(conn.lastHealthCheckAt).getTime() : 0;
 
-  // Proactive pre-expiry check (#631): if token is about to expire, refresh immediately
-  // regardless of the health check interval — prevents request failures between checks
-  const TOKEN_EXPIRY_BUFFER = 5 * 60 * 1000; // 5 minutes
-  const tokenExpiresAt = conn.tokenExpiresAt ? new Date(conn.tokenExpiresAt).getTime() : 0;
-  const isAboutToExpire = tokenExpiresAt > 0 && tokenExpiresAt - Date.now() < TOKEN_EXPIRY_BUFFER;
+  // If the access token is still healthy, don't force a refresh merely because the
+  // periodic interval elapsed. Keep the status active and re-check later.
+  if (hasHealthyAccessToken) {
+    if (nowMs - lastCheck >= intervalMs) {
+      const now = new Date().toISOString();
+      await updateProviderConnection(conn.id, {
+        lastHealthCheckAt: now,
+        testStatus: "active",
+        lastError: null,
+        lastErrorAt: null,
+        lastErrorType: null,
+        lastErrorSource: null,
+        errorCode: null,
+        expiredRetryCount: null,
+        expiredRetryAt: null,
+      });
+    }
+    return;
+  }
 
-  // Not yet due: skip if (a) interval hasn't elapsed AND (b) token is not about to expire
-  if (Date.now() - lastCheck < intervalMs && !isAboutToExpire) return;
+  // Not yet due: skip if interval hasn't elapsed and the token isn't near expiry.
+  if (nowMs - lastCheck < intervalMs && !isAboutToExpire) return;
 
   const reason = isAboutToExpire ? "token expiring soon" : `interval: ${intervalMin}min`;
   log(

--- a/src/lib/usage/providerLimits.ts
+++ b/src/lib/usage/providerLimits.ts
@@ -2,6 +2,7 @@ import {
   getAllProviderLimitsCache,
   getProviderConnectionById,
   getProviderConnections,
+  getQuotaSnapshots,
   getSettings,
   resolveProxyForConnection,
   setProviderLimitsCache,
@@ -160,6 +161,70 @@ function isNetworkFailureMessage(message: unknown): boolean {
   );
 }
 
+function buildCodexQuotaFallback(connection: ProviderConnectionLike): JsonRecord | null {
+  if (connection.provider !== "codex") return null;
+
+  const since = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+  const snapshots = getQuotaSnapshots({ connectionId: connection.id, since });
+  if (!snapshots.length) return null;
+
+  const latestByWindow = new Map<string, (typeof snapshots)[number]>();
+  for (const snapshot of snapshots) {
+    const windowKey =
+      typeof (snapshot as { windowKey?: unknown }).windowKey === "string"
+        ? (snapshot as { windowKey: string }).windowKey
+        : "";
+    const createdAt =
+      typeof (snapshot as { createdAt?: unknown }).createdAt === "string"
+        ? (snapshot as { createdAt: string }).createdAt
+        : "";
+    if (!windowKey || !createdAt) continue;
+
+    const prev = latestByWindow.get(windowKey);
+    const prevCreatedAt =
+      prev && typeof (prev as { createdAt?: unknown }).createdAt === "string"
+        ? (prev as { createdAt: string }).createdAt
+        : "";
+
+    if (!prev || new Date(createdAt).getTime() > new Date(prevCreatedAt).getTime()) {
+      latestByWindow.set(windowKey, snapshot);
+    }
+  }
+
+  const quotas: Record<string, JsonRecord> = {};
+  for (const [windowKey, snapshot] of latestByWindow.entries()) {
+    const remaining =
+      typeof (snapshot as { remainingPercentage?: unknown }).remainingPercentage === "number"
+        ? (snapshot as { remainingPercentage: number }).remainingPercentage
+        : null;
+    if (remaining === null) continue;
+
+    quotas[windowKey] = {
+      used: Math.max(0, 100 - remaining),
+      total: 100,
+      remaining,
+      remainingPercentage: remaining,
+      resetAt:
+        typeof (snapshot as { nextResetAt?: unknown }).nextResetAt === "string"
+          ? (snapshot as { nextResetAt: string }).nextResetAt
+          : null,
+      unlimited: false,
+    };
+  }
+
+  if (Object.keys(quotas).length === 0) return null;
+
+  const providerSpecificData = (connection.providerSpecificData || {}) as JsonRecord;
+  const rawPlan = providerSpecificData.workspacePlanType;
+  const plan = typeof rawPlan === "string" && rawPlan.trim() ? rawPlan : null;
+
+  return {
+    quotas,
+    plan,
+    message: null,
+  };
+}
+
 async function syncExpiredStatusIfNeeded(connection: ProviderConnectionLike, usage: JsonRecord) {
   const errorMessage = typeof usage.message === "string" ? usage.message.toLowerCase() : "";
   const isAuthError =
@@ -169,6 +234,15 @@ async function syncExpiredStatusIfNeeded(connection: ProviderConnectionLike, usa
     errorMessage.includes("unauthorized");
 
   if (!isAuthError || connection.testStatus === "expired") {
+    return;
+  }
+
+  // Codex "provider limits" uses a ChatGPT backend usage endpoint, while the regular
+  // connection test for Codex is intentionally expiry-only and actual request traffic
+  // can still succeed with the current access token. Treat usage fetch auth failures as
+  // non-authoritative for connection status so "Refresh all" does not poison otherwise
+  // working Codex accounts.
+  if (connection.provider === "codex") {
     return;
   }
 
@@ -286,6 +360,20 @@ export async function fetchLiveProviderLimits(connectionId: string): Promise<{
   if (isRecord(result.usage.quotas)) {
     setQuotaCache(connectionId, connection.provider, result.usage.quotas);
   }
+
+  if (
+    connection.provider === "codex" &&
+    !isRecord(result.usage.quotas) &&
+    typeof result.usage.message === "string" &&
+    result.usage.message.toLowerCase().includes("usage details are unavailable")
+  ) {
+    const fallback = buildCodexQuotaFallback(connection);
+    if (fallback) {
+      result = { usage: fallback };
+      setQuotaCache(connectionId, connection.provider, fallback.quotas as JsonRecord);
+    }
+  }
+
   await syncExpiredStatusIfNeeded(connection, result.usage);
 
   return {


### PR DESCRIPTION
## Summary
This fixes false-negative Codex status updates in the Limits / Provider Limits flow.

Codex provider-limits refresh was using the ChatGPT usage endpoint as if it were an authoritative auth check. In practice, working Codex accounts could still succeed on real request traffic and manual connection tests, while background health checks and **Refresh All** downgraded them or surfaced re-auth wording.

## Reproduction
1. Restore Codex OAuth connections with valid access tokens
2. Open **Limits & Quotas**
3. Click **Refresh All**
4. Observe Codex accounts being treated as expired / re-auth-needed even though request traffic still works

## Fix
- do not force-refresh healthy Codex access tokens during background token health checks
- do not mark Codex connections expired from provider-limits usage fetch failures
- downgrade the message to usage-unavailable instead of re-auth-required
- fall back to stored Codex quota snapshots from real traffic when live usage details are unavailable

## Why this is correct
- Codex connection tests are expiry-only and do not validate the ChatGPT usage endpoint
- a denied usage read is weaker evidence than successful live traffic
- quota snapshots already exist in the DB and are better than showing no limits data at all

## Verification
- reproduced the false re-auth state via the live Limits page
- verified Codex provider rows remain `active` after refresh
- verified the Limits page renders Session / Weekly / Code Review quota bars from stored snapshots via Playwright

## Scope
Codex-only behavior in health-check + provider-limits paths.