### PR TITLE
Fix API provider error

### DIFF
--- a/src/app/api/providers/validate/route.ts
+++ b/src/app/api/providers/validate/route.ts
@@ -6,8 +6,10 @@ import {
   isAnthropicCompatibleProvider,
 } from "@/shared/constants/providers";
 import { validateProviderApiKey } from "@/lib/providers/validation";
+import { getProxyForLevel } from "@/lib/localDb";
 import { validateProviderApiKeySchema } from "@/shared/validation/schemas";
 import { isValidationFailure, validateBody } from "@/shared/validation/helpers";
+import { runWithProxyContext } from "@omniroute/open-sse/utils/proxyFetch.ts";
 
 // POST /api/providers/validate - Validate API key with provider
 export async function POST(request) {
@@ -57,11 +59,16 @@ export async function POST(request) {
       };
     }
 
-    const result = await validateProviderApiKey({
-      provider,
-      apiKey,
-      providerSpecificData,
-    });
+    const providerProxy = await getProxyForLevel("provider", provider);
+    const globalProxy = providerProxy ? null : await getProxyForLevel("global");
+
+    const result = await runWithProxyContext(providerProxy || globalProxy || null, () =>
+      validateProviderApiKey({
+        provider,
+        apiKey,
+        providerSpecificData,
+      })
+    );
 
     if (result.unsupported) {
       return NextResponse.json({ error: "Provider validation not supported" }, { status: 400 });


### PR DESCRIPTION
Fixed POST /api/providers/validate: API key validation is now performed within runWithProxyContext, rather than directly via fetch. This allows proxy settings to be taken into account when validating provider keys (OpenAI, Gemini, etc.).

Added proxy resolution with fallback logic: first the provider-level proxy, then the global proxy, otherwise the direct proxy. This eliminates scenarios where the endpoint returned "fetch failed" due to the lack of proxying of outgoing requests during the key validation stage.

Added the necessary imports for working with the proxy context and retrieving the proxy configuration in this route handler.