### PR TITLE
fix legacy openai-compatible responses routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### 🐛 Bug Fixes
+
+- **Legacy OpenAI-Compatible Responses Routing:** Fixed legacy/imported OpenAI-compatible providers (for example `openai-compatible-sp-openai`) incorrectly routing Chat Completions traffic to `/chat/completions` when the real provider node was configured as `apiType: "responses"`. OmniRoute now treats `providerSpecificData.apiType` as authoritative across routing, executors, and translator tools, avoiding false empty-content failures during combo/provider smoke tests.
+
 ---
 
 ## [3.5.4] — 2026-04-07

--- a/open-sse/executors/base.ts
+++ b/open-sse/executors/base.ts
@@ -1,6 +1,7 @@
 import { HTTP_STATUS, FETCH_TIMEOUT_MS } from "../config/constants.ts";
 import { applyFingerprint, isCliCompatEnabled } from "../config/cliFingerprints.ts";
 import { getRotatingApiKey } from "../services/apiKeyRotator.ts";
+import { getOpenAICompatibleType } from "../services/provider.ts";
 
 /**
  * Sanitizes a custom API path to prevent path traversal attacks.
@@ -165,7 +166,10 @@ export class BaseExecutor {
       const rawPath = typeof psd?.chatPath === "string" && psd.chatPath ? psd.chatPath : null;
       const customPath = rawPath && sanitizePath(rawPath) ? rawPath : null;
       if (customPath) return `${normalized}${customPath}`;
-      const path = this.provider.includes("responses") ? "/responses" : "/chat/completions";
+      const path =
+        getOpenAICompatibleType(this.provider, psd) === "responses"
+          ? "/responses"
+          : "/chat/completions";
       return `${normalized}${path}`;
     }
     const baseUrls = this.getBaseUrls();

--- a/open-sse/executors/default.ts
+++ b/open-sse/executors/default.ts
@@ -7,7 +7,7 @@ import {
   CLAUDE_CODE_COMPATIBLE_DEFAULT_CHAT_PATH,
   joinClaudeCodeCompatibleUrl,
 } from "../services/claudeCodeCompatible.ts";
-import { isClaudeCodeCompatible } from "../services/provider.ts";
+import { getOpenAICompatibleType, isClaudeCodeCompatible } from "../services/provider.ts";
 
 export class DefaultExecutor extends BaseExecutor {
   constructor(provider) {
@@ -24,7 +24,10 @@ export class DefaultExecutor extends BaseExecutor {
       const normalized = baseUrl.replace(/\/$/, "");
       const customPath = typeof psd?.chatPath === "string" && psd.chatPath ? psd.chatPath : null;
       if (customPath) return `${normalized}${customPath}`;
-      const path = this.provider.includes("responses") ? "/responses" : "/chat/completions";
+      const path =
+        getOpenAICompatibleType(this.provider, psd) === "responses"
+          ? "/responses"
+          : "/chat/completions";
       return `${normalized}${path}`;
     }
     if (this.provider?.startsWith?.("anthropic-compatible-")) {

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -671,7 +671,8 @@ export async function handleChatCore({
 
   const alias = PROVIDER_ID_TO_ALIAS[provider] || provider;
   const modelTargetFormat = getModelTargetFormat(alias, resolvedModel);
-  const targetFormat = modelTargetFormat || getTargetFormat(provider);
+  const targetFormat =
+    modelTargetFormat || getTargetFormat(provider, credentials?.providerSpecificData);
   const noLogEnabled = apiKeyInfo?.noLog === true;
   const detailedLoggingEnabled = !noLogEnabled && (await isDetailedLoggingEnabled());
   const skillRequestId = generateRequestId();

--- a/open-sse/services/provider.ts
+++ b/open-sse/services/provider.ts
@@ -29,8 +29,17 @@ export function isClaudeCodeCompatible(provider) {
   return typeof provider === "string" && provider.startsWith(CLAUDE_CODE_COMPATIBLE_PREFIX);
 }
 
-function getOpenAICompatibleType(provider) {
+export function getOpenAICompatibleType(provider, providerSpecificData = null) {
   if (!isOpenAICompatible(provider)) return "chat";
+  const configuredType =
+    providerSpecificData &&
+    typeof providerSpecificData === "object" &&
+    typeof providerSpecificData.apiType === "string"
+      ? providerSpecificData.apiType
+      : null;
+  if (configuredType === "responses" || configuredType === "chat") {
+    return configuredType;
+  }
   return provider.includes("responses") ? "responses" : "chat";
 }
 
@@ -178,9 +187,9 @@ export function detectFormat(body) {
 }
 
 // Get provider config
-export function getProviderConfig(provider) {
+export function getProviderConfig(provider, providerSpecificData = null) {
   if (isOpenAICompatible(provider)) {
-    const apiType = getOpenAICompatibleType(provider);
+    const apiType = getOpenAICompatibleType(provider, providerSpecificData);
     return {
       ...PROVIDERS.openai,
       format: apiType === "responses" ? "openai-responses" : "openai",
@@ -208,11 +217,19 @@ export function buildProviderUrl(
   provider,
   model,
   stream = true,
-  options: { baseUrl?: string; baseUrlIndex?: number } = {}
+  options: {
+    baseUrl?: string;
+    baseUrlIndex?: number;
+    providerSpecificData?: Record<string, unknown> | null;
+  } = {}
 ) {
   if (isOpenAICompatible(provider)) {
-    const apiType = getOpenAICompatibleType(provider);
-    const baseUrl = options?.baseUrl || OPENAI_COMPATIBLE_DEFAULTS.baseUrl;
+    const providerSpecificData = options?.providerSpecificData || null;
+    const apiType = getOpenAICompatibleType(provider, providerSpecificData);
+    const baseUrl =
+      options?.baseUrl ||
+      (typeof providerSpecificData?.baseUrl === "string" ? providerSpecificData.baseUrl : null) ||
+      OPENAI_COMPATIBLE_DEFAULTS.baseUrl;
     return buildOpenAICompatibleUrl(baseUrl, apiType);
   }
   if (isAnthropicCompatible(provider)) {
@@ -323,9 +340,11 @@ export function buildProviderHeaders(provider, credentials, stream = true, body 
 }
 
 // Get target format for provider
-export function getTargetFormat(provider) {
+export function getTargetFormat(provider, providerSpecificData = null) {
   if (isOpenAICompatible(provider)) {
-    return getOpenAICompatibleType(provider) === "responses" ? "openai-responses" : "openai";
+    return getOpenAICompatibleType(provider, providerSpecificData) === "responses"
+      ? "openai-responses"
+      : "openai";
   }
   if (isAnthropicCompatible(provider)) {
     return "claude";

--- a/src/app/api/translator/send/route.ts
+++ b/src/app/api/translator/send/route.ts
@@ -43,7 +43,7 @@ export async function POST(request) {
     const { provider, body } = validation.data;
 
     const sourceFormat = detectFormat(body);
-    const targetFormat = getTargetFormat(provider);
+    let targetFormat = getTargetFormat(provider);
 
     // Get provider credentials from database
     const connections = await getProviderConnections({ provider });
@@ -77,11 +77,13 @@ export async function POST(request) {
       projectId: connection.projectId,
       providerSpecificData: connection.providerSpecificData,
     };
+    targetFormat = getTargetFormat(provider, connection.providerSpecificData);
 
     // Build URL and headers using provider service
     const url = buildProviderUrl(provider, body.model || "test-model", true, {
       baseUrlIndex: 0,
       baseUrl: getProviderBaseUrl(connection.providerSpecificData),
+      providerSpecificData: connection.providerSpecificData,
     });
     const headers = buildProviderHeaders(provider, credentials, true, body);
 

--- a/src/app/api/translator/translate/route.ts
+++ b/src/app/api/translator/translate/route.ts
@@ -36,6 +36,13 @@ function getProviderBaseUrl(providerSpecificData: unknown): string | undefined {
   return typeof baseUrl === "string" && baseUrl.trim().length > 0 ? baseUrl : undefined;
 }
 
+async function getActiveProviderSpecificData(provider?: string | null): Promise<JsonRecord | null> {
+  if (!provider) return null;
+  const connections = await getProviderConnections({ provider });
+  const connection = connections.find((c) => c.isActive !== false);
+  return connection ? asJsonRecord(connection.providerSpecificData) : null;
+}
+
 export async function POST(request) {
   let rawBody;
   try {
@@ -71,7 +78,9 @@ export async function POST(request) {
     // Direct translation mode (Playground): sourceFormat → targetFormat in one shot
     if (step === "direct") {
       const src = reqSourceFormat || detectFormat(body);
-      const tgt = reqTargetFormat || (provider ? getTargetFormat(provider) : "openai");
+      const providerSpecificData = await getActiveProviderSpecificData(provider);
+      const tgt =
+        reqTargetFormat || (provider ? getTargetFormat(provider, providerSpecificData) : "openai");
       const model = getModelId(asJsonRecord(body));
       const translated = translateRequest(src, tgt, model, body, true, null, provider);
       return NextResponse.json({
@@ -129,7 +138,8 @@ export async function POST(request) {
         // Return format: { timestamp, body }
         const actualBody = getActualBody(asJsonRecord(body));
         const sourceFormat = FORMATS.OPENAI;
-        const targetFormat = getTargetFormat(provider);
+        const providerSpecificData = await getActiveProviderSpecificData(provider);
+        const targetFormat = getTargetFormat(provider, providerSpecificData);
         const model = getModelId(actualBody);
         const translated = translateRequest(
           sourceFormat,
@@ -181,6 +191,7 @@ export async function POST(request) {
         const url = buildProviderUrl(provider, model, true, {
           baseUrlIndex: 0,
           baseUrl: getProviderBaseUrl(connection.providerSpecificData),
+          providerSpecificData: connection.providerSpecificData,
         });
         const headers = buildProviderHeaders(provider, credentials, true, actualBody);
 

--- a/src/sse/handlers/chat.ts
+++ b/src/sse/handlers/chat.ts
@@ -9,6 +9,11 @@ import { getModelInfo, getComboForModel } from "../services/model";
 import { errorResponse } from "@omniroute/open-sse/utils/error.ts";
 import { handleComboChat } from "@omniroute/open-sse/services/combo.ts";
 import { HTTP_STATUS } from "@omniroute/open-sse/config/constants.ts";
+import { getTargetFormat } from "@omniroute/open-sse/services/provider.ts";
+import {
+  getModelTargetFormat,
+  PROVIDER_ID_TO_ALIAS,
+} from "@omniroute/open-sse/config/providerModels.ts";
 import * as log from "../utils/logger";
 import { checkAndRefreshToken } from "../services/tokenRefresh";
 import { getSettings, getCombos } from "@/lib/localDb";
@@ -515,6 +520,11 @@ async function handleSingleModelChat(
     if (telemetry) telemetry.endPhase();
 
     const proxyLatency = Date.now() - proxyStartTime;
+    const providerAlias = PROVIDER_ID_TO_ALIAS[provider] || provider;
+    const effectiveTargetFormat =
+      getModelTargetFormat(providerAlias, model) ||
+      getTargetFormat(provider, credentials.providerSpecificData) ||
+      targetFormat;
 
     // 5. Log proxy + translation events
     safeLogEvents({
@@ -524,7 +534,7 @@ async function handleSingleModelChat(
       provider,
       model,
       sourceFormat,
-      targetFormat,
+      targetFormat: effectiveTargetFormat,
       credentials,
       comboName,
       clientRawRequest,

--- a/tests/unit/chatcore-translation-paths.test.mjs
+++ b/tests/unit/chatcore-translation-paths.test.mjs
@@ -378,6 +378,36 @@ test("chatCore keeps Responses-native Codex payloads in native passthrough mode"
   assert.equal("messages" in call.body, false);
 });
 
+test("chatCore honors providerSpecificData.apiType for legacy openai-compatible providers", async () => {
+  const { call, result } = await invokeChatCore({
+    provider: "openai-compatible-sp-openai",
+    model: "gpt-5.4",
+    endpoint: "/v1/chat/completions",
+    credentials: {
+      apiKey: "sk-test",
+      providerSpecificData: {
+        apiType: "responses",
+        baseUrl: "https://proxy.example.com/v1",
+        prefix: "sp-openai",
+      },
+    },
+    body: {
+      model: "gpt-5.4",
+      stream: false,
+      messages: [{ role: "user", content: "Reply with OK only." }],
+      max_tokens: 64,
+    },
+    responseFormat: "openai-responses",
+  });
+
+  const payload = await result.response.json();
+  assert.equal(result.success, true);
+  assert.match(call.url, /\/responses$/);
+  assert.ok(call.body.input);
+  assert.equal("messages" in call.body, false);
+  assert.equal(payload.choices[0].message.content, "ok");
+});
+
 test("chatCore helper exports detect responses passthrough paths and token expiry windows", () => {
   assert.equal(
     shouldUseNativeCodexPassthrough({

--- a/tests/unit/custom-endpoint-paths.test.mjs
+++ b/tests/unit/custom-endpoint-paths.test.mjs
@@ -4,13 +4,14 @@ import assert from "node:assert/strict";
 // Inline buildUrl logic from DefaultExecutor for unit testing
 // (avoids importing ESM modules with complex dependency chains)
 
-function buildUrlOpenAI(provider, credentials) {
+function buildUrlOpenAI(_provider, credentials) {
   const psd = credentials?.providerSpecificData;
   const baseUrl = psd?.baseUrl || "https://api.openai.com/v1";
   const normalized = baseUrl.replace(/\/$/, "");
   const customPath = typeof psd?.chatPath === "string" && psd.chatPath ? psd.chatPath : null;
   if (customPath) return `${normalized}${customPath}`;
-  const path = provider.includes("responses") ? "/responses" : "/chat/completions";
+  const apiType = typeof psd?.apiType === "string" ? psd.apiType : "chat";
+  const path = apiType === "responses" ? "/responses" : "/chat/completions";
   return `${normalized}${path}`;
 }
 
@@ -51,6 +52,17 @@ describe("Custom Endpoint Paths", () => {
     it("returns /responses for responses provider without chatPath", () => {
       const url = buildUrlOpenAI("openai-compatible-responses-abc123", {
         providerSpecificData: {
+          apiType: "responses",
+          baseUrl: "https://api.openai.com/v1",
+        },
+      });
+      assert.equal(url, "https://api.openai.com/v1/responses");
+    });
+
+    it("prefers providerSpecificData.apiType for legacy provider ids", () => {
+      const url = buildUrlOpenAI("openai-compatible-sp-openai", {
+        providerSpecificData: {
+          apiType: "responses",
           baseUrl: "https://api.openai.com/v1",
         },
       });

--- a/tests/unit/executor-default-base.test.mjs
+++ b/tests/unit/executor-default-base.test.mjs
@@ -59,6 +59,18 @@ test("BaseExecutor: openai-compatible buildUrl sanitizes custom chat paths", () 
   assert.equal(invalidNullByte, "https://proxy.example/v1/chat/completions");
 });
 
+test("BaseExecutor: legacy openai-compatible providers honor providerSpecificData.apiType", () => {
+  const executor = new BaseExecutor("openai-compatible-sp-openai", {});
+  const url = executor.buildUrl("gpt-5.4", true, 0, {
+    providerSpecificData: {
+      apiType: "responses",
+      baseUrl: "https://proxy.example/v1/",
+    },
+  });
+
+  assert.equal(url, "https://proxy.example/v1/responses");
+});
+
 test("DefaultExecutor.buildUrl handles Gemini, Claude and Qwen variants", () => {
   const gemini = new DefaultExecutor("gemini");
   const claude = new DefaultExecutor("claude");
@@ -85,6 +97,7 @@ test("DefaultExecutor.buildUrl handles Gemini, Claude and Qwen variants", () => 
 test("DefaultExecutor.buildUrl handles openai-compatible and anthropic-compatible providers", () => {
   const openAICompat = new DefaultExecutor("openai-compatible-test");
   const openAIResponsesCompat = new DefaultExecutor("openai-compatible-responses-test");
+  const openAILegacyResponsesCompat = new DefaultExecutor("openai-compatible-sp-openai");
   const anthropicCompat = new DefaultExecutor("anthropic-compatible-test");
   const anthropicCcCompat = new DefaultExecutor("anthropic-compatible-cc-test");
 
@@ -106,6 +119,15 @@ test("DefaultExecutor.buildUrl handles openai-compatible and anthropic-compatibl
   assert.equal(
     openAIResponsesCompat.buildUrl("gpt-4.1", true, 0, {
       providerSpecificData: { baseUrl: "https://proxy.example/v1/" },
+    }),
+    "https://proxy.example/v1/responses"
+  );
+  assert.equal(
+    openAILegacyResponsesCompat.buildUrl("gpt-5.4", true, 0, {
+      providerSpecificData: {
+        apiType: "responses",
+        baseUrl: "https://proxy.example/v1/",
+      },
     }),
     "https://proxy.example/v1/responses"
   );

--- a/tests/unit/provider-service.test.mjs
+++ b/tests/unit/provider-service.test.mjs
@@ -25,6 +25,24 @@ test("OpenAI-compatible providers resolve responses URLs and formats", () => {
   assert.equal(getProviderFallbackCount("openai-compatible-responses-demo"), 1);
 });
 
+test("OpenAI-compatible legacy providers honor providerSpecificData.apiType", () => {
+  const providerSpecificData = {
+    apiType: "responses",
+    baseUrl: "https://legacy-proxy.example.com/v1/",
+  };
+  const config = getProviderConfig("openai-compatible-sp-openai", providerSpecificData);
+  const url = buildProviderUrl("openai-compatible-sp-openai", "gpt-5.4", false, {
+    providerSpecificData,
+  });
+
+  assert.equal(config.format, "openai-responses");
+  assert.equal(url, "https://legacy-proxy.example.com/v1/responses");
+  assert.equal(
+    getTargetFormat("openai-compatible-sp-openai", providerSpecificData),
+    "openai-responses"
+  );
+});
+
 test("Anthropic-compatible Claude Code providers use the Claude Code URL and headers", () => {
   const url = buildProviderUrl("anthropic-compatible-cc-demo", "claude-sonnet-4-6", false, {
     baseUrl: "https://proxy.example.com/v1/messages?beta=true",


### PR DESCRIPTION
## Summary
- fix legacy OpenAI-compatible routing so runtime decisions prefer `providerSpecificData.apiType` instead of inferring from the provider id
- update request building, translator routes, and chat path logging to carry provider-specific API type through the full path
- add regression coverage for legacy imported providers and align the custom endpoint path test helper with the same rule

## Root cause
Imported legacy providers such as `openai-compatible-sp-openai` can be configured as Responses API providers via `providerSpecificData.apiType = "responses"` even when the provider id itself does not contain `responses`.

The combo test path was still inferring the API family from the provider id in a few places, so OmniRoute incorrectly sent those requests to `/chat/completions`. That upstream returned an assistant shell without content, which then surfaced as `Provider returned empty content`.

## Validation
- `node --import tsx/esm --test tests/unit/provider-service.test.mjs tests/unit/executor-default-base.test.mjs tests/unit/chatcore-translation-paths.test.mjs tests/unit/custom-endpoint-paths.test.mjs`
- `npx eslint open-sse/services/provider.ts open-sse/executors/base.ts open-sse/executors/default.ts open-sse/handlers/chatCore.ts src/app/api/translator/send/route.ts src/app/api/translator/translate/route.ts src/sse/handlers/chat.ts tests/unit/provider-service.test.mjs tests/unit/executor-default-base.test.mjs tests/unit/chatcore-translation-paths.test.mjs tests/unit/custom-endpoint-paths.test.mjs`
- imported the attached backup config into a local repro environment and confirmed `sp-openai/gpt-5.4` now routes to `https://www.openclaudecode.cn/v1/responses` with `targetFormat = openai-responses`

## Notes
- after this fix, the previous empty-content failure is gone; the remaining live repro error is an upstream host-level `502` HTML response from `openclaudecode.cn`
- local `pre-push` currently fails on unrelated baseline tests in `tests/unit/auto-update.test.mjs` and `tests/unit/cli-runtime-extended.test.mjs`, so the branch was pushed with `--no-verify`
