### PR TITLE
fix(analytics): redesign compact stat cards with sectioned layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "omniroute",
-  "version": "3.5.4",
+  "version": "3.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "omniroute",
-      "version": "3.5.4",
+      "version": "3.5.5",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -20977,7 +20977,7 @@
     },
     "open-sse": {
       "name": "@omniroute/open-sse",
-      "version": "3.5.4"
+      "version": "3.5.5"
     }
   }
 }

--- a/src/app/(dashboard)/dashboard/analytics/components/DiversityScoreCard.tsx
+++ b/src/app/(dashboard)/dashboard/analytics/components/DiversityScoreCard.tsx
@@ -72,33 +72,43 @@ export default function DiversityScoreCard() {
     riskLabel = "Moderate Distribution";
   }
 
+  const providerEntries = Object.entries(data.providers || {})
+    .sort(([, a], [, b]) => b.share - a.share)
+    .slice(0, 4);
+
   return (
-    <Card className="p-5 flex flex-col gap-5">
-      <div className="flex items-start justify-between gap-3">
-        <div>
-          <div className="flex items-center gap-2">
-            <span className="material-symbols-outlined text-[20px] text-primary">pie_chart</span>
-            <h3 className="font-semibold text-text-main">Provider Diversity</h3>
-          </div>
-          <p className="text-sm text-text-muted mt-1">
-            Provider concentration snapshot for the recent traffic window.
-          </p>
+    <Card className="p-5">
+      {/* Header */}
+      <div className="flex items-center justify-between gap-3 mb-4">
+        <div className="flex items-center gap-2">
+          <span className="material-symbols-outlined text-[20px] text-primary">pie_chart</span>
+          <h3 className="font-semibold text-text-main">Provider Diversity</h3>
+          <span className="text-xs text-text-muted hidden sm:inline">
+            — Provider concentration snapshot for the recent traffic window.
+          </span>
         </div>
-        <span
-          className={`shrink-0 rounded-full px-2.5 py-1 text-xs font-medium ${
-            scorePercentage < 40
-              ? "bg-red-500/10 text-red-500"
-              : scorePercentage < 70
-                ? "bg-amber-500/10 text-amber-500"
-                : "bg-green-500/10 text-green-500"
-          }`}
-        >
-          Shannon entropy
-        </span>
+        <div className="flex items-center gap-3">
+          <span className="text-xs text-text-muted hidden md:inline">
+            Window: {data.windowSize} reqs · Last {Math.round(data.ttlMs / 60000)} mins
+          </span>
+          <span
+            className={`shrink-0 rounded-full px-2.5 py-1 text-xs font-medium ${
+              scorePercentage < 40
+                ? "bg-red-500/10 text-red-500"
+                : scorePercentage < 70
+                  ? "bg-amber-500/10 text-amber-500"
+                  : "bg-green-500/10 text-green-500"
+            }`}
+          >
+            Shannon entropy
+          </span>
+        </div>
       </div>
 
-      <div className="grid gap-4 sm:grid-cols-[112px_minmax(0,1fr)] sm:items-center">
-        <div className="relative mx-auto h-28 w-28">
+      {/* Horizontal layout: gauge + risk label + provider bars */}
+      <div className="flex flex-col sm:flex-row items-center gap-5">
+        {/* Gauge */}
+        <div className="relative shrink-0 h-20 w-20">
           <svg className="h-full w-full -rotate-90" viewBox="0 0 36 36">
             <path
               className="text-border/70"
@@ -118,56 +128,52 @@ export default function DiversityScoreCard() {
             />
           </svg>
           <div className="absolute inset-0 flex flex-col items-center justify-center">
-            <span className={`text-2xl font-semibold tabular-nums ${riskColor}`}>
+            <span className={`text-lg font-semibold tabular-nums ${riskColor}`}>
               {scorePercentage}%
             </span>
-            <span className="text-[11px] uppercase tracking-[0.18em] text-text-muted">score</span>
+            <span className="text-[9px] uppercase tracking-[0.15em] text-text-muted">score</span>
           </div>
         </div>
 
-        <div className="space-y-4">
-          <div className="rounded-xl border border-border/30 bg-surface/20 px-4 py-3">
-            <div className={`text-sm font-medium ${riskColor}`}>{riskLabel}</div>
-            <div className="text-xs text-text-muted mt-1">
-              Higher values indicate traffic is spread across multiple providers instead of
-              clustering on one vendor.
-            </div>
+        {/* Risk label */}
+        <div className="shrink-0 text-center sm:text-left">
+          <div className={`text-sm font-medium ${riskColor}`}>{riskLabel}</div>
+          <div className="text-xs text-text-muted mt-0.5 max-w-[200px]">
+            Higher values mean traffic is spread across multiple providers.
           </div>
+        </div>
 
-          {Object.keys(data.providers || {}).length === 0 ? (
-            <div className="rounded-xl border border-dashed border-border/50 px-4 py-5 text-sm text-text-muted">
+        {/* Divider */}
+        <div className="hidden sm:block w-px h-14 bg-border/30 shrink-0" />
+
+        {/* Provider bars */}
+        <div className="flex-1 min-w-0 w-full">
+          {providerEntries.length === 0 ? (
+            <div className="text-sm text-text-muted text-center py-2">
               No recent usage data available.
             </div>
           ) : (
-            <div className="space-y-3">
-              {Object.entries(data.providers)
-                .sort(([, a], [, b]) => b.share - a.share)
-                .slice(0, 4)
-                .map(([provider, stat]) => (
-                  <div key={provider} className="space-y-1.5">
-                    <div className="flex items-center justify-between gap-3 text-sm">
-                      <span className="font-medium text-text-main capitalize">{provider}</span>
-                      <span className="tabular-nums text-text-muted">
-                        {Math.round(stat.share * 100)}%
-                      </span>
-                    </div>
-                    <div className="h-2 rounded-full bg-surface/50 overflow-hidden">
-                      <div
-                        className={`h-full rounded-full ${gaugeColor}`}
-                        style={{ width: `${Math.round(stat.share * 100)}%` }}
-                      />
-                    </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-2">
+              {providerEntries.map(([provider, stat]) => (
+                <div key={provider} className="space-y-1">
+                  <div className="flex items-center justify-between gap-3 text-sm">
+                    <span className="font-medium text-text-main capitalize truncate">
+                      {provider}
+                    </span>
+                    <span className="tabular-nums text-text-muted shrink-0">
+                      {Math.round(stat.share * 100)}%
+                    </span>
                   </div>
-                ))}
+                  <div className="h-1.5 rounded-full bg-surface/50 overflow-hidden">
+                    <div
+                      className={`h-full rounded-full ${gaugeColor}`}
+                      style={{ width: `${Math.round(stat.share * 100)}%` }}
+                    />
+                  </div>
+                </div>
+              ))}
             </div>
           )}
-        </div>
-      </div>
-
-      <div className="grid grid-cols-2 gap-3 border-t border-border/30 pt-4 text-xs text-text-muted">
-        <div className="rounded-lg bg-surface/20 px-3 py-2">Window: {data.windowSize} reqs</div>
-        <div className="rounded-lg bg-surface/20 px-3 py-2 text-right">
-          Based on last {Math.round(data.ttlMs / 60000)} mins
         </div>
       </div>
     </Card>

--- a/src/app/(dashboard)/dashboard/analytics/page.tsx
+++ b/src/app/(dashboard)/dashboard/analytics/page.tsx
@@ -45,12 +45,12 @@ export default function AnalyticsPage() {
       />
 
       {activeTab === "overview" && (
-        <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_340px] xl:items-start">
+        <>
           <Suspense fallback={<CardSkeleton />}>
             <UsageAnalytics />
           </Suspense>
           <DiversityScoreCard />
-        </div>
+        </>
       )}
       {activeTab === "evals" && <EvalsTab />}
       {activeTab === "search" && <SearchAnalyticsTab />}

--- a/src/shared/components/UsageAnalytics.tsx
+++ b/src/shared/components/UsageAnalytics.tsx
@@ -6,6 +6,7 @@ import { CardSkeleton } from "./Loading";
 import { fmtCompact as fmt, fmtFull, fmtCost } from "@/shared/utils/formatting";
 import {
   StatCard,
+  CompactStatGrid,
   ActivityHeatmap,
   DailyTrendChart,
   AccountDonut,
@@ -109,7 +110,7 @@ export default function UsageAnalytics() {
   const ioRatio = s.completionTokens > 0 ? (s.promptTokens / s.completionTokens).toFixed(1) : "—";
 
   return (
-    <div className="flex flex-col gap-5">
+    <div className="flex flex-col gap-5 min-w-0">
       {/* Header + Time Range */}
       <div className="flex items-center justify-between">
         <h2 className="text-xl font-semibold flex items-center gap-2">
@@ -133,8 +134,8 @@ export default function UsageAnalytics() {
         </div>
       </div>
 
-      {/* Summary Cards — Row 1: Core metrics */}
-      <div className="grid grid-cols-2 md:grid-cols-4 2xl:grid-cols-8 gap-3">
+      {/* Primary KPI Cards */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
         <StatCard
           icon="generating_tokens"
           label="Total Tokens"
@@ -159,56 +160,55 @@ export default function UsageAnalytics() {
           value={fmtCost(s.totalCost)}
           color="text-amber-500"
         />
-        <StatCard icon="group" label="Accounts" value={s.uniqueAccounts || 0} />
-        <StatCard icon="vpn_key" label="API Keys" value={s.uniqueApiKeys || 0} />
-        <StatCard icon="model_training" label="Models" value={s.uniqueModels || 0} />
-        <StatCard
-          icon="swap_horiz"
-          label="Fallback Rate"
-          value={`${Number(s.fallbackRatePct || 0).toFixed(1)}%`}
-          subValue={`${fmtFull(s.fallbackCount || 0)} fallbacks`}
-          color="text-amber-500"
-        />
       </div>
 
-      {/* Summary Cards — Row 2: Derived insights */}
-      <div className="grid grid-cols-2 md:grid-cols-4 2xl:grid-cols-8 gap-3">
-        <StatCard
-          icon="speed"
-          label="Avg Tokens/Req"
-          value={fmt(avgTokensPerReq)}
-          color="text-cyan-500"
-        />
-        <StatCard
-          icon="request_quote"
-          label="Cost/Request"
-          value={fmtCost(costPerReq)}
-          color="text-orange-500"
-        />
-        <StatCard
-          icon="compare_arrows"
-          label="I/O Ratio"
-          value={`${ioRatio}x`}
-          color="text-violet-500"
-        />
-        <StatCard icon="star" label="Top Model" value={topModel} color="text-pink-500" />
-        <StatCard icon="cloud" label="Top Provider" value={topProvider} color="text-teal-500" />
-        <StatCard icon="today" label="Busiest Day" value={busiestDay} color="text-rose-500" />
-        <StatCard icon="dns" label="Providers" value={providerCount} color="text-indigo-500" />
-        <StatCard
-          icon="network_node"
-          label="Diversity Score"
-          value={`${providerDiversity.toFixed(1)}%`}
-          color="text-sky-500"
-        />
-      </div>
+      {/* Secondary Metrics — compact grid */}
+      <CompactStatGrid
+        stats={[
+          { icon: "group", label: "Accounts", value: s.uniqueAccounts || 0 },
+          { icon: "vpn_key", label: "API Keys", value: s.uniqueApiKeys || 0 },
+          { icon: "model_training", label: "Models", value: s.uniqueModels || 0 },
+          {
+            icon: "swap_horiz",
+            label: "Fallback Rate",
+            value: `${Number(s.fallbackRatePct || 0).toFixed(1)}%`,
+            color: "text-amber-500",
+          },
+          {
+            icon: "speed",
+            label: "Avg Tokens/Req",
+            value: fmt(avgTokensPerReq),
+            color: "text-cyan-500",
+          },
+          {
+            icon: "request_quote",
+            label: "Cost/Req",
+            value: fmtCost(costPerReq),
+            color: "text-orange-500",
+          },
+          {
+            icon: "compare_arrows",
+            label: "I/O Ratio",
+            value: `${ioRatio}x`,
+            color: "text-violet-500",
+          },
+          { icon: "star", label: "Top Model", value: topModel, color: "text-pink-500" },
+          { icon: "cloud", label: "Top Provider", value: topProvider, color: "text-teal-500" },
+          { icon: "today", label: "Busiest Day", value: busiestDay, color: "text-rose-500" },
+          { icon: "dns", label: "Providers", value: providerCount, color: "text-indigo-500" },
+          {
+            icon: "network_node",
+            label: "Diversity Score",
+            value: `${providerDiversity.toFixed(1)}%`,
+            color: "text-sky-500",
+          },
+        ]}
+      />
 
       {/* Activity Heatmap + Weekly Widgets */}
-      <div
-        style={{ display: "grid", gridTemplateColumns: "2fr 1fr", gap: 16, alignItems: "stretch" }}
-      >
+      <div className="grid grid-cols-1 lg:grid-cols-[2fr_1fr] gap-4 items-stretch">
         <ActivityHeatmap activityMap={analytics?.activityMap} />
-        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+        <div className="flex flex-col gap-4">
           <MostActiveDay7d activityMap={analytics?.activityMap} />
           <WeeklySquares7d activityMap={analytics?.activityMap} />
         </div>

--- a/src/shared/components/UsageAnalytics.tsx
+++ b/src/shared/components/UsageAnalytics.tsx
@@ -165,15 +165,12 @@ export default function UsageAnalytics() {
       {/* Secondary Metrics — compact grid */}
       <CompactStatGrid
         stats={[
+          // Infrastructure
           { icon: "group", label: "Accounts", value: s.uniqueAccounts || 0 },
+          { icon: "dns", label: "Providers", value: providerCount, color: "text-indigo-500" },
           { icon: "vpn_key", label: "API Keys", value: s.uniqueApiKeys || 0 },
           { icon: "model_training", label: "Models", value: s.uniqueModels || 0 },
-          {
-            icon: "swap_horiz",
-            label: "Fallback Rate",
-            value: `${Number(s.fallbackRatePct || 0).toFixed(1)}%`,
-            color: "text-amber-500",
-          },
+          // Performance
           {
             icon: "speed",
             label: "Avg Tokens/Req",
@@ -192,10 +189,16 @@ export default function UsageAnalytics() {
             value: `${ioRatio}x`,
             color: "text-violet-500",
           },
+          {
+            icon: "swap_horiz",
+            label: "Fallback Rate",
+            value: `${Number(s.fallbackRatePct || 0).toFixed(1)}%`,
+            color: "text-amber-500",
+          },
+          // Highlights
           { icon: "star", label: "Top Model", value: topModel, color: "text-pink-500" },
           { icon: "cloud", label: "Top Provider", value: topProvider, color: "text-teal-500" },
           { icon: "today", label: "Busiest Day", value: busiestDay, color: "text-rose-500" },
-          { icon: "dns", label: "Providers", value: providerCount, color: "text-indigo-500" },
           {
             icon: "network_node",
             label: "Diversity Score",

--- a/src/shared/components/UsageAnalytics.tsx
+++ b/src/shared/components/UsageAnalytics.tsx
@@ -162,48 +162,61 @@ export default function UsageAnalytics() {
         />
       </div>
 
-      {/* Secondary Metrics — compact grid */}
+      {/* Secondary Metrics — compact grid with sections */}
       <CompactStatGrid
-        stats={[
-          // Infrastructure
-          { icon: "group", label: "Accounts", value: s.uniqueAccounts || 0 },
-          { icon: "dns", label: "Providers", value: providerCount, color: "text-indigo-500" },
-          { icon: "vpn_key", label: "API Keys", value: s.uniqueApiKeys || 0 },
-          { icon: "model_training", label: "Models", value: s.uniqueModels || 0 },
-          // Performance
+        sections={[
           {
-            icon: "speed",
-            label: "Avg Tokens/Req",
-            value: fmt(avgTokensPerReq),
-            color: "text-cyan-500",
+            title: "Infrastructure",
+            items: [
+              { icon: "group", label: "Accounts", value: s.uniqueAccounts || 0 },
+              { icon: "dns", label: "Providers", value: providerCount, color: "text-indigo-500" },
+              { icon: "vpn_key", label: "API Keys", value: s.uniqueApiKeys || 0 },
+              { icon: "model_training", label: "Models", value: s.uniqueModels || 0 },
+            ],
           },
           {
-            icon: "request_quote",
-            label: "Cost/Req",
-            value: fmtCost(costPerReq),
-            color: "text-orange-500",
+            title: "Performance",
+            items: [
+              {
+                icon: "speed",
+                label: "Avg Tokens/Req",
+                value: fmt(avgTokensPerReq),
+                color: "text-cyan-500",
+              },
+              {
+                icon: "request_quote",
+                label: "Cost/Req",
+                value: fmtCost(costPerReq),
+                color: "text-orange-500",
+              },
+              {
+                icon: "compare_arrows",
+                label: "I/O Ratio",
+                value: `${ioRatio}x`,
+                color: "text-violet-500",
+              },
+              {
+                icon: "swap_horiz",
+                label: "Fallback Rate",
+                value: `${Number(s.fallbackRatePct || 0).toFixed(1)}%`,
+                color: "text-amber-500",
+              },
+            ],
           },
           {
-            icon: "compare_arrows",
-            label: "I/O Ratio",
-            value: `${ioRatio}x`,
-            color: "text-violet-500",
-          },
-          {
-            icon: "swap_horiz",
-            label: "Fallback Rate",
-            value: `${Number(s.fallbackRatePct || 0).toFixed(1)}%`,
-            color: "text-amber-500",
-          },
-          // Highlights
-          { icon: "star", label: "Top Model", value: topModel, color: "text-pink-500" },
-          { icon: "cloud", label: "Top Provider", value: topProvider, color: "text-teal-500" },
-          { icon: "today", label: "Busiest Day", value: busiestDay, color: "text-rose-500" },
-          {
-            icon: "network_node",
-            label: "Diversity Score",
-            value: `${providerDiversity.toFixed(1)}%`,
-            color: "text-sky-500",
+            title: "Highlights",
+            wideValues: true,
+            items: [
+              { icon: "star", label: "Top Model", value: topModel, color: "text-pink-500" },
+              { icon: "cloud", label: "Top Provider", value: topProvider, color: "text-teal-500" },
+              { icon: "today", label: "Busiest Day", value: busiestDay, color: "text-rose-500" },
+              {
+                icon: "network_node",
+                label: "Diversity",
+                value: `${providerDiversity.toFixed(1)}%`,
+                color: "text-sky-500",
+              },
+            ],
           },
         ]}
       />

--- a/src/shared/components/UsageAnalytics.tsx
+++ b/src/shared/components/UsageAnalytics.tsx
@@ -134,7 +134,7 @@ export default function UsageAnalytics() {
       </div>
 
       {/* Summary Cards — Row 1: Core metrics */}
-      <div className="grid grid-cols-2 md:grid-cols-8 gap-3">
+      <div className="grid grid-cols-2 md:grid-cols-4 2xl:grid-cols-8 gap-3">
         <StatCard
           icon="generating_tokens"
           label="Total Tokens"
@@ -172,7 +172,7 @@ export default function UsageAnalytics() {
       </div>
 
       {/* Summary Cards — Row 2: Derived insights */}
-      <div className="grid grid-cols-2 md:grid-cols-8 gap-3">
+      <div className="grid grid-cols-2 md:grid-cols-4 2xl:grid-cols-8 gap-3">
         <StatCard
           icon="speed"
           label="Avg Tokens/Req"

--- a/src/shared/components/analytics/charts.tsx
+++ b/src/shared/components/analytics/charts.tsx
@@ -84,7 +84,7 @@ export function SortIndicator({ active, sortOrder }: { active: boolean; sortOrde
   );
 }
 
-// ── StatCard ───────────────────────────────────────────────────────────────
+// ── StatCard (primary KPI) ─────────────────────────────────────────────────
 
 export function StatCard({
   icon,
@@ -101,14 +101,52 @@ export function StatCard({
 }) {
   return (
     <Card className="px-4 py-3 flex flex-col gap-1 min-w-0">
-      <div className="flex items-center gap-2 text-text-muted text-xs uppercase font-semibold tracking-wider whitespace-nowrap overflow-hidden text-ellipsis">
-        <span className="material-symbols-outlined text-[16px] shrink-0">{icon}</span>
+      <div className="flex items-center gap-1.5 text-text-muted text-[11px] uppercase font-semibold tracking-wide min-w-0">
+        <span className="material-symbols-outlined text-[14px] shrink-0">{icon}</span>
         <span className="truncate">{label}</span>
       </div>
       <span className={`text-2xl font-bold ${color} truncate`} title={String(value)}>
         {value}
       </span>
       {subValue && <span className="text-xs text-text-muted truncate">{subValue}</span>}
+    </Card>
+  );
+}
+
+// ── CompactStatGrid (secondary metrics in a single card) ──────────────────
+
+export function CompactStatGrid({
+  stats,
+}: {
+  stats: Array<{
+    icon: string;
+    label: string;
+    value: any;
+    color?: string;
+  }>;
+}) {
+  return (
+    <Card className="px-4 py-3">
+      <div className="grid grid-cols-2 sm:grid-cols-3 2xl:grid-cols-4 gap-x-5 gap-y-2.5">
+        {stats.map((stat, i) => (
+          <div key={i} className="flex items-center justify-between gap-2 min-w-0 py-0.5">
+            <div className="flex items-center gap-1.5 min-w-0 shrink-0 max-w-[55%]">
+              <span className="material-symbols-outlined text-[14px] text-text-muted shrink-0">
+                {stat.icon}
+              </span>
+              <span className="text-[11px] uppercase font-semibold tracking-wide text-text-muted truncate">
+                {stat.label}
+              </span>
+            </div>
+            <span
+              className={`text-sm font-bold truncate min-w-0 ${stat.color || "text-text-main"}`}
+              title={String(stat.value)}
+            >
+              {stat.value}
+            </span>
+          </div>
+        ))}
+      </div>
     </Card>
   );
 }
@@ -191,7 +229,7 @@ export function ActivityHeatmap({ activityMap }) {
   }
 
   return (
-    <Card className="p-4 h-full">
+    <Card className="p-4 h-full min-w-0 overflow-hidden">
       <div className="flex items-center justify-between mb-3">
         <h3 className="text-sm font-semibold text-text-muted uppercase tracking-wider">Activity</h3>
         <span className="text-xs text-text-muted">

--- a/src/shared/components/analytics/charts.tsx
+++ b/src/shared/components/analytics/charts.tsx
@@ -113,37 +113,57 @@ export function StatCard({
   );
 }
 
-// ── CompactStatGrid (secondary metrics in a single card) ──────────────────
+// ── CompactStatGrid (secondary metrics in a single card, grouped) ─────────
 
-export function CompactStatGrid({
-  stats,
-}: {
-  stats: Array<{
-    icon: string;
-    label: string;
-    value: any;
-    color?: string;
-  }>;
-}) {
+export type CompactStatSection = {
+  title: string;
+  items: Array<{ icon: string; label: string; value: any; color?: string }>;
+  /** On mobile use 1 column instead of 2 — useful when values can be long (model names, etc.) */
+  wideValues?: boolean;
+};
+
+export function CompactStatGrid({ sections }: { sections: CompactStatSection[] }) {
   return (
-    <Card className="px-4 py-3">
-      <div className="grid grid-cols-2 sm:grid-cols-3 2xl:grid-cols-4 gap-x-5 gap-y-2.5">
-        {stats.map((stat, i) => (
-          <div key={i} className="flex items-center justify-between gap-2 min-w-0 py-0.5">
-            <div className="flex items-center gap-1.5 min-w-0 shrink-0 max-w-[55%]">
-              <span className="material-symbols-outlined text-[14px] text-text-muted shrink-0">
-                {stat.icon}
-              </span>
-              <span className="text-[11px] uppercase font-semibold tracking-wide text-text-muted truncate">
-                {stat.label}
-              </span>
+    <Card className="px-5 py-4">
+      <div className="flex flex-col gap-3">
+        {sections.map((section, si) => (
+          <div key={si}>
+            {si > 0 && (
+              <div className="border-t border-black/[0.06] dark:border-white/[0.06] mb-3" />
+            )}
+            <div className="text-[10px] uppercase font-semibold tracking-widest text-text-muted/50 mb-2">
+              {section.title}
             </div>
-            <span
-              className={`text-sm font-bold truncate min-w-0 ${stat.color || "text-text-main"}`}
-              title={String(stat.value)}
+            <div
+              className={
+                section.wideValues
+                  ? "grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-x-5 gap-y-2"
+                  : "grid grid-cols-2 md:grid-cols-4 gap-x-5 gap-y-2"
+              }
             >
-              {stat.value}
-            </span>
+              {section.items.map((stat, i) => (
+                <div key={i} className="flex items-center justify-between gap-2 min-w-0 py-0.5">
+                  <div
+                    className={`flex items-center gap-1.5 ${section.wideValues ? "shrink-0" : "min-w-0"}`}
+                  >
+                    <span className="material-symbols-outlined text-[14px] text-text-muted shrink-0">
+                      {stat.icon}
+                    </span>
+                    <span
+                      className={`text-[11px] uppercase font-semibold tracking-wide text-text-muted ${section.wideValues ? "whitespace-nowrap" : "truncate"}`}
+                    >
+                      {stat.label}
+                    </span>
+                  </div>
+                  <span
+                    className={`text-sm font-bold text-right ${section.wideValues ? "truncate min-w-0" : "shrink-0"} ${stat.color || "text-text-main"}`}
+                    title={String(stat.value)}
+                  >
+                    {stat.value}
+                  </span>
+                </div>
+              ))}
+            </div>
           </div>
         ))}
       </div>

--- a/src/shared/components/analytics/charts.tsx
+++ b/src/shared/components/analytics/charts.tsx
@@ -100,13 +100,15 @@ export function StatCard({
   color?: string;
 }) {
   return (
-    <Card className="px-4 py-3 flex flex-col gap-1">
-      <div className="flex items-center gap-2 text-text-muted text-xs uppercase font-semibold tracking-wider">
-        <span className="material-symbols-outlined text-[16px]">{icon}</span>
-        {label}
+    <Card className="px-4 py-3 flex flex-col gap-1 min-w-0">
+      <div className="flex items-center gap-2 text-text-muted text-xs uppercase font-semibold tracking-wider whitespace-nowrap overflow-hidden text-ellipsis">
+        <span className="material-symbols-outlined text-[16px] shrink-0">{icon}</span>
+        <span className="truncate">{label}</span>
       </div>
-      <span className={`text-2xl font-bold ${color}`}>{value}</span>
-      {subValue && <span className="text-xs text-text-muted">{subValue}</span>}
+      <span className={`text-2xl font-bold ${color} truncate`} title={String(value)}>
+        {value}
+      </span>
+      {subValue && <span className="text-xs text-text-muted truncate">{subValue}</span>}
     </Card>
   );
 }

--- a/src/shared/components/analytics/index.tsx
+++ b/src/shared/components/analytics/index.tsx
@@ -11,6 +11,7 @@
 export {
   SortIndicator,
   StatCard,
+  CompactStatGrid,
   ActivityHeatmap,
   DailyTrendChart,
   AccountDonut,


### PR DESCRIPTION
## Summary
- Redesign the analytics CompactStatGrid from a flat 3-column grid to a **sectioned 4-column layout** with labeled groups (Infrastructure, Performance, Highlights)
- Fix stat card overflow and responsive grid issues on both desktop and mobile
- Implement per-section responsive strategy: short-value sections use 2-col on mobile, wide-value sections (model/provider names) use 1-col to prevent truncation
- Move Provider Diversity score into the compact grid and reorder stats by logical category

## Changes
- `CompactStatGrid` now accepts `sections[]` with `title`, `items`, and optional `wideValues` flag
- Desktop: all sections display as 4 columns, aligned with the 4-items-per-category grouping
- Mobile: Infrastructure/Performance use 2-col (values are short numbers, labels can truncate); Highlights uses 1-col (values can be long model/provider names)
- Section dividers and subtle labels provide visual separation between groups

## Test plan
- [x] Verified desktop layout: 3 sections × 4 columns with section headers
- [x] Verified mobile (390px): short-value sections 2-col, wide-value section 1-col
- [x] Verified long field truncation with tooltip on hover
- [x] Lint and pre-commit hooks pass