### PR TITLE
v3.5.7 Hotfix: Turbopack Standalone Chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ---
 
+## [3.5.7] — 2026-04-09
+
+### 🐛 Bug Fixes & Security
+
+- **Turbopack Standalone Chunks:** Fixed a critical bug in `scripts/prepublish.mjs` where Turbopack chunks missing from the `.next/standalone` trace resulted in a `500 ChunkLoadError` (e.g., `_not-found` page crash) during production deployments via NPM or Docker. Standalone chunks are now explicitly copied and correctly stripped of Turbopack hashes.
+
+---
+
 ## [3.5.6] — 2026-04-09
 
 ### ✨ New Features

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omniroute-desktop",
-  "version": "3.5.6",
+  "version": "3.5.7",
   "description": "OmniRoute Desktop Application",
   "main": "main.js",
   "author": {

--- a/open-sse/package.json
+++ b/open-sse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omniroute/open-sse",
-  "version": "3.5.6",
+  "version": "3.5.7",
   "description": "Express SSE sidecar for OmniRoute — handles streaming, protocol translation, and provider orchestration",
   "type": "module",
   "main": "index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "omniroute",
-  "version": "3.5.6",
+  "version": "3.5.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "omniroute",
-      "version": "3.5.6",
+      "version": "3.5.7",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -20989,7 +20989,7 @@
     },
     "open-sse": {
       "name": "@omniroute/open-sse",
-      "version": "3.5.5"
+      "version": "3.5.6"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omniroute",
-  "version": "3.5.6",
+  "version": "3.5.7",
   "description": "Smart AI Router with auto fallback — route to FREE & cheap models, zero downtime. Works with Cursor, Cline, Claude Desktop, Codex, and any OpenAI-compatible tool.",
   "type": "module",
   "bin": {

--- a/scripts/prepublish.mjs
+++ b/scripts/prepublish.mjs
@@ -110,6 +110,15 @@ console.log("  📋 Copying standalone build to app/...");
 mkdirSync(APP_DIR, { recursive: true });
 cpSync(standaloneDir, APP_DIR, { recursive: true });
 
+// ── Next.js Turbopack Standalone Tracer Fix ───────────────
+// Workaround for Next.js 15+ standalone mode missing Turbopack chunks
+const staticChunksSrc = join(ROOT, ".next", "server", "chunks");
+const staticChunksDest = join(APP_DIR, ".next", "server", "chunks");
+if (existsSync(staticChunksSrc)) {
+  console.log("  📋 Patching standalone build with missing Turbopack chunks...");
+  cpSync(staticChunksSrc, staticChunksDest, { recursive: true, force: false });
+}
+
 // ── Step 5.5: Sanitize hardcoded build-machine paths ───────
 // Next.js standalone bakes absolute build-time paths into server.js and
 // required-server-files.json (outputFileTracingRoot, appDir, turbopack root).


### PR DESCRIPTION
Fixes a critical ChunkLoadError in 3.5.6 caused by Turbopack chunks missing in standalone output.