### PR TITLE
fix(docker): handle EXDEV in isolated build

### DIFF
--- a/scripts/build-next-isolated.mjs
+++ b/scripts/build-next-isolated.mjs
@@ -3,6 +3,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { spawn } from "node:child_process";
+import { pathToFileURL } from "node:url";
 
 /**
  * This repository contains a legacy `app/` snapshot (packaging/runtime artifacts)
@@ -21,6 +22,27 @@ async function exists(targetPath) {
     return true;
   } catch {
     return false;
+  }
+}
+
+export async function movePath(sourcePath, destinationPath, fsImpl = fs) {
+  try {
+    await fsImpl.rename(sourcePath, destinationPath);
+  } catch (error) {
+    if (error?.code !== "EXDEV") {
+      throw error;
+    }
+
+    console.warn(
+      `[build-next-isolated] EXDEV while moving ${sourcePath} -> ${destinationPath}; falling back to copy/remove`
+    );
+    await fsImpl.cp(sourcePath, destinationPath, {
+      recursive: true,
+      preserveTimestamps: true,
+      force: false,
+      errorOnExist: true,
+    });
+    await fsImpl.rm(sourcePath, { recursive: true, force: true });
   }
 }
 
@@ -52,12 +74,12 @@ function runNextBuild() {
   });
 }
 
-async function main() {
+export async function main() {
   let moved = false;
 
   try {
     if (await exists(legacyAppDir)) {
-      await fs.rename(legacyAppDir, backupDir);
+      await movePath(legacyAppDir, backupDir);
       moved = true;
     }
 
@@ -86,7 +108,7 @@ async function main() {
   } finally {
     if (moved) {
       try {
-        await fs.rename(backupDir, legacyAppDir);
+        await movePath(backupDir, legacyAppDir);
       } catch (restoreError) {
         console.error(
           `[build-next-isolated] Failed to restore legacy app dir from ${backupDir}:`,
@@ -98,4 +120,8 @@ async function main() {
   }
 }
 
-await main();
+const entryScript = process.argv[1] ? pathToFileURL(process.argv[1]).href : null;
+
+if (entryScript === import.meta.url) {
+  await main();
+}

--- a/src/shared/services/cliRuntime.ts
+++ b/src/shared/services/cliRuntime.ts
@@ -587,8 +587,26 @@ const checkKnownPath = async (commandPath: string) => {
     const realPath = await fs.realpath(commandPath);
 
     // Verify the resolved path is still within expected directories
-    // Use pre-computed expected parent paths (cached at module startup for performance)
-    const isWithinExpected = EXPECTED_PARENT_PATHS.some((parent) => isPathWithin(realPath, parent));
+    // Use pre-computed expected parent paths (cached at module startup for performance).
+    // On macOS temp directories often resolve from /var -> /private/var, so compare both
+    // the configured parent and its canonical realpath when available.
+    let isWithinExpected = false;
+    for (const parent of EXPECTED_PARENT_PATHS) {
+      if (isPathWithin(realPath, parent)) {
+        isWithinExpected = true;
+        break;
+      }
+
+      try {
+        const resolvedParent = await fs.realpath(parent);
+        if (isPathWithin(realPath, resolvedParent)) {
+          isWithinExpected = true;
+          break;
+        }
+      } catch {
+        // Ignore missing/unresolvable parents and continue checking the remaining ones.
+      }
+    }
 
     if (!isWithinExpected) {
       return { installed: false, commandPath: null, reason: "symlink_escape" };

--- a/tests/unit/auto-update.test.mjs
+++ b/tests/unit/auto-update.test.mjs
@@ -364,6 +364,8 @@ test("launchAutoUpdate returns validation failures and starts detached update sc
         },
       };
     },
+    existsImpl: async (targetPath) =>
+      targetPath === repoDir || targetPath === composeFile || targetPath === "/var/run/docker.sock",
   });
 
   try {

--- a/tests/unit/build-next-isolated.test.mjs
+++ b/tests/unit/build-next-isolated.test.mjs
@@ -1,0 +1,90 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import fsSync from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const { movePath } = await import("../../scripts/build-next-isolated.mjs");
+
+async function withTempDir(fn) {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omniroute-build-next-isolated-"));
+
+  try {
+    await fn(tempDir);
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+test("movePath falls back to copy/remove when rename raises EXDEV", async () => {
+  await withTempDir(async (tempDir) => {
+    const sourceDir = path.join(tempDir, "app");
+    const destinationDir = path.join(tempDir, ".app-build-backup");
+    const nestedFile = path.join(sourceDir, "nested", "file.txt");
+
+    await fs.mkdir(path.dirname(nestedFile), { recursive: true });
+    await fs.writeFile(nestedFile, "legacy payload");
+
+    let copyCalled = false;
+    let removeCalled = false;
+    const warnings = [];
+    const originalWarn = console.warn;
+    console.warn = (message) => warnings.push(String(message));
+
+    try {
+      await movePath(sourceDir, destinationDir, {
+        rename: async () => {
+          const error = new Error("cross-device link not permitted");
+          error.code = "EXDEV";
+          throw error;
+        },
+        cp: async (...args) => {
+          copyCalled = true;
+          return fs.cp(...args);
+        },
+        rm: async (...args) => {
+          removeCalled = true;
+          return fs.rm(...args);
+        },
+      });
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    assert.equal(copyCalled, true);
+    assert.equal(removeCalled, true);
+    assert.equal(fsSync.existsSync(sourceDir), false);
+    assert.equal(
+      await fs.readFile(path.join(destinationDir, "nested", "file.txt"), "utf8"),
+      "legacy payload"
+    );
+    assert.match(warnings[0] ?? "", /EXDEV while moving/);
+  });
+});
+
+test("movePath rethrows non-EXDEV rename failures", async () => {
+  await withTempDir(async (tempDir) => {
+    const sourceDir = path.join(tempDir, "app");
+    const destinationDir = path.join(tempDir, ".app-build-backup");
+
+    await fs.mkdir(sourceDir, { recursive: true });
+
+    await assert.rejects(
+      movePath(sourceDir, destinationDir, {
+        rename: async () => {
+          const error = new Error("permission denied");
+          error.code = "EACCES";
+          throw error;
+        },
+        cp: async () => {
+          throw new Error("copy fallback should not run");
+        },
+        rm: async () => {
+          throw new Error("remove fallback should not run");
+        },
+      }),
+      (error) => error?.code === "EACCES"
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- handle cross-device moves in `build-next-isolated` by falling back from `rename` to `copy/remove` when Docker buildx returns `EXDEV`
- add regression coverage for the isolated build path
- fix the current local pre-push blockers so the branch can be published cleanly:
  - align the auto-update test with the docker socket precondition
  - normalize known binary parent checks in `cliRuntime` for macOS real paths

## Root cause
`npm run build -- --webpack` failed inside the Docker publish workflow because `scripts/build-next-isolated.mjs` attempted to rename the legacy root `app/` directory across filesystems, which raises `EXDEV` under the buildx container filesystem. That stopped the Docker image publish job and caused the dependent VPS deploy workflow to be skipped.

## Validation
- `node --import tsx/esm --test tests/unit/build-next-isolated.test.mjs`
- `npm run build -- --webpack`
- `node --import tsx/esm --test tests/unit/auto-update.test.mjs tests/unit/cli-runtime-extended.test.mjs`
- local pre-push unit suite: `2602` tests passed
