### PR TITLE
fix(stream): surface Responses failures and preserve upstream model

### DIFF
--- a/open-sse/translator/response/openai-responses.ts
+++ b/open-sse/translator/response/openai-responses.ts
@@ -425,6 +425,31 @@ function flushEvents(state) {
   return events;
 }
 
+function normalizeUpstreamFailure(data, fallbackType = "server_error") {
+  const response = data?.response && typeof data.response === "object" ? data.response : null;
+  const error =
+    response?.error && typeof response.error === "object"
+      ? response.error
+      : data?.error && typeof data.error === "object"
+        ? data.error
+        : null;
+
+  const code = typeof error?.code === "string" ? error.code : "";
+  const message =
+    typeof error?.message === "string"
+      ? error.message
+      : typeof data?.message === "string"
+        ? data.message
+        : "Upstream failure";
+
+  return {
+    status: code === "rate_limit_exceeded" ? 429 : 502,
+    type: code === "rate_limit_exceeded" ? "rate_limit_error" : fallbackType,
+    code: code || (fallbackType === "rate_limit_error" ? "rate_limit_exceeded" : "bad_gateway"),
+    message,
+  };
+}
+
 /**
  * Translate OpenAI Responses API chunk to OpenAI Chat Completions format
  * This is for when Codex returns data and we need to send it to an OpenAI-compatible client
@@ -455,6 +480,19 @@ export function openaiResponsesToOpenAIResponse(chunk, state) {
   // Handle different event types from Responses API
   const eventType = chunk.type || chunk.event;
   const data = chunk.data || chunk;
+
+  if (!state.model) {
+    const upstreamModel =
+      (data?.response && typeof data.response === "object" && data.response.model) ||
+      data?.model ||
+      data?.modelVersion ||
+      data?.model_version ||
+      null;
+
+    if (typeof upstreamModel === "string" && upstreamModel.trim().length > 0) {
+      state.model = upstreamModel.trim();
+    }
+  }
 
   // Initialize state
   if (!state.started) {
@@ -713,6 +751,16 @@ export function openaiResponsesToOpenAIResponse(chunk, state) {
 
       return finalChunk;
     }
+    return null;
+  }
+
+  if (eventType === "response.failed" || eventType === "error") {
+    state.upstreamError = normalizeUpstreamFailure(
+      data,
+      eventType === "error" ? "server_error" : "server_error"
+    );
+    state.finishReasonSent = true;
+    state.completedSent = true;
     return null;
   }
 

--- a/open-sse/translator/response/openai-responses.ts
+++ b/open-sse/translator/response/openai-responses.ts
@@ -755,12 +755,8 @@ export function openaiResponsesToOpenAIResponse(chunk, state) {
   }
 
   if (eventType === "response.failed" || eventType === "error") {
-    state.upstreamError = normalizeUpstreamFailure(
-      data,
-      eventType === "error" ? "server_error" : "server_error"
-    );
+    state.upstreamError = normalizeUpstreamFailure(data);
     state.finishReasonSent = true;
-    state.completedSent = true;
     return null;
   }
 

--- a/open-sse/utils/stream.ts
+++ b/open-sse/utils/stream.ts
@@ -26,6 +26,7 @@ import {
   sanitizeStreamingChunk,
   extractThinkingFromContent,
 } from "../handlers/responseSanitizer.ts";
+import { buildErrorBody } from "./error.ts";
 
 export { COLORS, formatSSE };
 
@@ -67,6 +68,12 @@ type TranslateState = ReturnType<typeof initState> & {
   finishReason?: unknown;
   /** Accumulated message content for call log response body */
   accumulatedContent?: string;
+  upstreamError?: {
+    status: number;
+    type: string;
+    code: string;
+    message: string;
+  } | null;
 };
 
 type ToolCall = {
@@ -468,6 +475,10 @@ export function createSSEStream(options: StreamOptions = {}) {
           // Translate mode
           if (!trimmed) continue;
 
+          if (state?.upstreamError) {
+            continue;
+          }
+
           const parsed = parseSSELine(trimmed);
           if (!parsed) continue;
           providerPayloadCollector.push(parsed);
@@ -793,6 +804,36 @@ export function createSSEStream(options: StreamOptions = {}) {
                 }
               }
             }
+          }
+
+          if (state?.upstreamError) {
+            const err = state.upstreamError;
+            trackPendingRequest(model, provider, connectionId, false);
+
+            const errorBody = buildErrorBody(err.status, err.message);
+            if (onComplete) {
+              try {
+                onComplete({
+                  status: err.status,
+                  usage: state?.usage,
+                  responseBody: errorBody,
+                  providerPayload: providerPayloadCollector.build(
+                    buildStreamSummaryFromEvents(
+                      providerPayloadCollector.getEvents(),
+                      targetFormat,
+                      model
+                    ),
+                    { includeEvents: false }
+                  ),
+                  clientPayload: clientPayloadCollector.build(errorBody, {
+                    includeEvents: false,
+                  }),
+                });
+              } catch {}
+            }
+
+            controller.error(new Error(err.message || "Upstream failure"));
+            return;
           }
 
           // Flush remaining events (only once at stream end)

--- a/tests/unit/stream-utils.test.mjs
+++ b/tests/unit/stream-utils.test.mjs
@@ -237,6 +237,59 @@ test("createSSEStream passthrough preserves Responses API events and completion 
   assert.equal(onCompletePayload.providerPayload.summary.object, "response");
 });
 
+test("createSSEStream translate mode aborts on Responses failure with rate limit error", async () => {
+  let onCompletePayload = null;
+
+  await assert.rejects(
+    readTransformed(
+      [
+        `data: ${JSON.stringify({
+          type: "response.created",
+          response: {
+            id: "resp_fail",
+            object: "response",
+            model: "gpt-5.4",
+            status: "in_progress",
+            output: [],
+          },
+        })}\n\n`,
+        `data: ${JSON.stringify({
+          type: "response.failed",
+          response: {
+            id: "resp_fail",
+            object: "response",
+            model: "gpt-5.4",
+            status: "failed",
+            error: {
+              message: "Rate limit reached for gpt-5.4",
+              code: "rate_limit_exceeded",
+            },
+          },
+        })}\n\n`,
+        `data: [DONE]\n\n`,
+      ],
+      {
+        mode: "translate",
+        targetFormat: FORMATS.OPENAI_RESPONSES,
+        sourceFormat: FORMATS.OPENAI,
+        provider: "codex",
+        model: "gpt-5.4",
+        body: { messages: [{ role: "user", content: "hello" }] },
+        onComplete(payload) {
+          onCompletePayload = payload;
+        },
+      }
+    ),
+    /Rate limit reached for gpt-5\.4|Upstream failure/
+  );
+
+  assert.ok(onCompletePayload, "should capture completion payload before aborting");
+  assert.equal(onCompletePayload.status, 429);
+  assert.equal(onCompletePayload.responseBody.error.type, "rate_limit_error");
+  assert.equal(onCompletePayload.responseBody.error.code, "rate_limit_exceeded");
+  assert.match(onCompletePayload.responseBody.error.message, /Rate limit reached/);
+});
+
 test("createSSEStream passthrough restores Claude tool names from the mapping table", async () => {
   const toolNameMap = new Map([["tool_alias", "read_file"]]);
   const text = await readTransformed(

--- a/tests/unit/translator-resp-openai-responses.test.mjs
+++ b/tests/unit/translator-resp-openai-responses.test.mjs
@@ -296,3 +296,60 @@ test("Responses -> OpenAI: tool-call delta, reasoning delta and completed usage 
   assert.equal(completed.usage.prompt_tokens_details.cached_tokens, 1);
   assert.equal(completed.usage.prompt_tokens_details.cache_creation_tokens, 2);
 });
+
+test("Responses -> OpenAI: preserves upstream model instead of defaulting to gpt-4", () => {
+  const state = {};
+  const created = openaiResponsesToOpenAIResponse(
+    {
+      type: "response.created",
+      response: {
+        id: "resp_1",
+        object: "response",
+        model: "gpt-5.4",
+        status: "in_progress",
+        output: [],
+      },
+    },
+    state
+  );
+  const text = openaiResponsesToOpenAIResponse(
+    { type: "response.output_text.delta", delta: "hello" },
+    state
+  );
+  const final = openaiResponsesToOpenAIResponse(
+    {
+      type: "response.completed",
+      response: {
+        model: "gpt-5.4",
+      },
+    },
+    state
+  );
+
+  assert.equal(text.model, "gpt-5.4");
+  assert.equal(final.model, "gpt-5.4");
+  assert.equal(created, null);
+});
+
+test("Responses -> OpenAI: response.failed records upstream error", () => {
+  const state = {};
+  const result = openaiResponsesToOpenAIResponse(
+    {
+      type: "response.failed",
+      response: {
+        error: {
+          message: "Rate limit reached for gpt-5.4",
+          code: "rate_limit_exceeded",
+        },
+      },
+    },
+    state
+  );
+
+  assert.equal(result, null);
+  assert.ok(state.upstreamError);
+  assert.equal(state.upstreamError.status, 429);
+  assert.equal(state.upstreamError.type, "rate_limit_error");
+  assert.equal(state.upstreamError.code, "rate_limit_exceeded");
+  assert.match(state.upstreamError.message, /Rate limit reached/);
+});


### PR DESCRIPTION
## Summary
- Surface upstream `response.failed` as an actual error instead of a fake empty 200 OK stream.
- Preserve the upstream model in Responses-to-OpenAI stream translation instead of falling back to `gpt-4`.
- Update unit coverage for failure handling and model propagation.

## Related Issues
- Closes #1093
- Closes #1094

## Validation
- `node --import tsx/esm --test tests/unit/translator-resp-openai-responses.test.mjs`
- `node --import tsx/esm --test tests/unit/stream-utils.test.mjs`
- Repo is on Node 22 per `.nvmrc` for this branch.

## Tests Added Or Updated
- `tests/unit/translator-resp-openai-responses.test.mjs`
- `tests/unit/stream-utils.test.mjs`

## Coverage Notes
- Added coverage for `response.failed(rate_limit_exceeded)` handling.
- Added coverage for preserving the upstream model through stream chunks.

## Reviewer Notes
- The branch was rebased onto `v3.5.8` before opening this PR.
- CI in the repository already shows unrelated failures in other workflows; the screenshots I checked include existing Docker / E2E / Sonar noise outside this change.