### PR TITLE
fix: add row count limits to prevent DB bloat and handle HTML error responses

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -1745,21 +1745,33 @@ export async function handleChatCore({
       try {
         responseBody = rawBody ? JSON.parse(rawBody) : {};
       } catch {
+        const isHtmlResponse =
+          rawBody &&
+          typeof rawBody === "string" &&
+          (rawBody.trim().startsWith("<!") || rawBody.trim().startsWith("<html"));
         appendRequestLog({
           model,
           provider,
           connectionId,
           status: `FAILED ${HTTP_STATUS.BAD_GATEWAY}`,
         }).catch(() => {});
-        const invalidJsonMessage = "Invalid JSON response from provider";
+
+        const invalidJsonMessage = isHtmlResponse
+          ? "Provider returned HTML error page instead of JSON - check credentials and endpoint"
+          : "Invalid JSON response from provider";
         persistAttemptLogs({
           status: HTTP_STATUS.BAD_GATEWAY,
           error: invalidJsonMessage,
           providerRequest: finalBody || translatedBody,
-          providerResponse: normalizedProviderPayload,
+          providerResponse: isHtmlResponse
+            ? { _raw: rawBody?.slice(0, 500) }
+            : normalizedProviderPayload,
           clientResponse: buildErrorBody(HTTP_STATUS.BAD_GATEWAY, invalidJsonMessage),
         });
-        persistFailureUsage(HTTP_STATUS.BAD_GATEWAY, "invalid_json_payload");
+        persistFailureUsage(
+          HTTP_STATUS.BAD_GATEWAY,
+          isHtmlResponse ? "html_error_response" : "invalid_json_payload"
+        );
         return createErrorResult(HTTP_STATUS.BAD_GATEWAY, invalidJsonMessage);
       }
     }

--- a/src/app/(dashboard)/dashboard/settings/components/SystemStorageTab.tsx
+++ b/src/app/(dashboard)/dashboard/settings/components/SystemStorageTab.tsx
@@ -34,6 +34,10 @@ export default function SystemStorageTab() {
       app: 7,
       call: 7,
     },
+    tableMaxRows: {
+      callLogs: 100000,
+      proxyLogs: 100000,
+    },
     lastBackupAt: null,
   });
 
@@ -291,8 +295,9 @@ export default function SystemStorageTab() {
           <div>
             <p className="text-sm font-medium text-text-main">Log retention policy</p>
             <p className="text-xs text-text-muted">
-              Request logs follow <code>CALL_LOG_RETENTION_DAYS</code>. Application and audit logs
-              follow <code>APP_LOG_RETENTION_DAYS</code>.
+              Request logs retain up to <code>CALL_LOGS_TABLE_MAX_ROWS</code> rows (default:
+              100,000). Proxy logs retain up to <code>PROXY_LOGS_TABLE_MAX_ROWS</code> rows. Older
+              entries auto-deleted.
             </p>
           </div>
           <div className="flex items-center gap-2">
@@ -301,6 +306,9 @@ export default function SystemStorageTab() {
             </Badge>
             <Badge variant="default" size="sm">
               App {storageHealth.retentionDays.app}d
+            </Badge>
+            <Badge variant="default" size="sm">
+              {storageHealth.tableMaxRows?.callLogs?.toLocaleString() || "100K"} rows
             </Badge>
           </div>
         </div>

--- a/src/app/api/storage/health/route.ts
+++ b/src/app/api/storage/health/route.ts
@@ -2,7 +2,12 @@ import { NextResponse } from "next/server";
 import path from "path";
 import fs from "fs";
 import { resolveDataDir } from "@/lib/dataPaths";
-import { getAppLogRetentionDays, getCallLogRetentionDays } from "@/lib/logEnv";
+import {
+  getAppLogRetentionDays,
+  getCallLogRetentionDays,
+  getCallLogsTableMaxRows,
+  getProxyLogsTableMaxRows,
+} from "@/lib/logEnv";
 
 /**
  * GET /api/storage/health — Return database storage information.
@@ -60,6 +65,10 @@ export async function GET() {
       retentionDays: {
         app: getAppLogRetentionDays(),
         call: getCallLogRetentionDays(),
+      },
+      tableMaxRows: {
+        callLogs: getCallLogsTableMaxRows(),
+        proxyLogs: getProxyLogsTableMaxRows(),
       },
       dataDir: dataDir.startsWith(homeDir) ? "~" + dataDir.slice(homeDir.length) : dataDir,
     });

--- a/src/lib/compliance/index.ts
+++ b/src/lib/compliance/index.ts
@@ -10,7 +10,12 @@
  */
 
 import { getDbInstance } from "../db/core";
-import { getAppLogRetentionDays, getCallLogRetentionDays } from "../logEnv";
+import {
+  getAppLogRetentionDays,
+  getCallLogRetentionDays,
+  getCallLogsTableMaxRows,
+  getProxyLogsTableMaxRows,
+} from "../logEnv";
 
 /** @returns {import("better-sqlite3").Database | null} */
 function getDb() {
@@ -231,14 +236,20 @@ export function getRetentionDays() {
  *   deletedRequestDetailLogs: number,
  *   deletedAuditLogs: number,
  *   deletedMcpAuditLogs: number,
+ *   trimmedCallLogs: number,
+ *   trimmedProxyLogs: number,
  *   appRetentionDays: number,
- *   callRetentionDays: number
+ *   callRetentionDays: number,
+ *   callLogsMaxRows: number,
+ *   proxyLogsMaxRows: number
  * }}
  */
 export function cleanupExpiredLogs() {
   const db = getDb();
   const appRetentionDays = getAppLogRetentionDays();
   const callRetentionDays = getCallLogRetentionDays();
+  const callLogsMaxRows = getCallLogsTableMaxRows();
+  const proxyLogsMaxRows = getProxyLogsTableMaxRows();
 
   if (!db) {
     return {
@@ -248,8 +259,12 @@ export function cleanupExpiredLogs() {
       deletedRequestDetailLogs: 0,
       deletedAuditLogs: 0,
       deletedMcpAuditLogs: 0,
+      trimmedCallLogs: 0,
+      trimmedProxyLogs: 0,
       appRetentionDays,
       callRetentionDays,
+      callLogsMaxRows,
+      proxyLogsMaxRows,
     };
   }
 
@@ -262,6 +277,8 @@ export function cleanupExpiredLogs() {
   let deletedRequestDetailLogs = 0;
   let deletedAuditLogs = 0;
   let deletedMcpAuditLogs = 0;
+  let trimmedCallLogs = 0;
+  let trimmedProxyLogs = 0;
 
   try {
     const r1 = db.prepare("DELETE FROM usage_history WHERE timestamp < ?").run(callCutoff);
@@ -305,6 +322,49 @@ export function cleanupExpiredLogs() {
     /* table may not exist */
   }
 
+  // Enforce row count limits to prevent unbounded DB growth
+  if (callLogsMaxRows > 0) {
+    try {
+      const callCount = db.prepare("SELECT COUNT(*) as cnt FROM call_logs").get() as {
+        cnt: number;
+      };
+      if (callCount.cnt > callLogsMaxRows) {
+        const excess = callCount.cnt - callLogsMaxRows;
+        const trimmed = db
+          .prepare(
+            `DELETE FROM call_logs WHERE id IN (
+            SELECT id FROM call_logs ORDER BY timestamp ASC LIMIT ?
+          )`
+          )
+          .run(excess);
+        trimmedCallLogs = trimmed.changes;
+      }
+    } catch {
+      /* best effort */
+    }
+  }
+
+  if (proxyLogsMaxRows > 0) {
+    try {
+      const proxyCount = db.prepare("SELECT COUNT(*) as cnt FROM proxy_logs").get() as {
+        cnt: number;
+      };
+      if (proxyCount.cnt > proxyLogsMaxRows) {
+        const excess = proxyCount.cnt - proxyLogsMaxRows;
+        const trimmed = db
+          .prepare(
+            `DELETE FROM proxy_logs WHERE id IN (
+            SELECT id FROM proxy_logs ORDER BY timestamp ASC LIMIT ?
+          )`
+          )
+          .run(excess);
+        trimmedProxyLogs = trimmed.changes;
+      }
+    } catch {
+      /* best effort */
+    }
+  }
+
   logAuditEvent({
     action: "compliance.cleanup",
     details: {
@@ -314,8 +374,12 @@ export function cleanupExpiredLogs() {
       deletedRequestDetailLogs,
       deletedAuditLogs,
       deletedMcpAuditLogs,
+      trimmedCallLogs,
+      trimmedProxyLogs,
       appRetentionDays,
       callRetentionDays,
+      callLogsMaxRows,
+      proxyLogsMaxRows,
     },
   });
 
@@ -326,7 +390,11 @@ export function cleanupExpiredLogs() {
     deletedRequestDetailLogs,
     deletedAuditLogs,
     deletedMcpAuditLogs,
+    trimmedCallLogs,
+    trimmedProxyLogs,
     appRetentionDays,
     callRetentionDays,
+    callLogsMaxRows,
+    proxyLogsMaxRows,
   };
 }

--- a/src/lib/logEnv.ts
+++ b/src/lib/logEnv.ts
@@ -5,6 +5,8 @@ const DEFAULT_CALL_LOG_RETENTION_DAYS = 7;
 const DEFAULT_APP_LOG_MAX_SIZE = 50 * 1024 * 1024;
 const DEFAULT_APP_LOG_MAX_FILES = 20;
 const DEFAULT_CALL_LOG_MAX_ENTRIES = 10000;
+const DEFAULT_CALL_LOGS_TABLE_MAX_ROWS = 100000;
+const DEFAULT_PROXY_LOGS_TABLE_MAX_ROWS = 100000;
 const DEFAULT_APP_LOG_PATH = path.join(process.cwd(), "logs", "application", "app.log");
 
 function parsePositiveInt(value: string | undefined, fallback: number): number {
@@ -60,6 +62,14 @@ export function getAppLogMaxFiles(): number {
 
 export function getCallLogMaxEntries(): number {
   return parsePositiveInt(process.env.CALL_LOG_MAX_ENTRIES, DEFAULT_CALL_LOG_MAX_ENTRIES);
+}
+
+export function getCallLogsTableMaxRows(): number {
+  return parsePositiveInt(process.env.CALL_LOGS_TABLE_MAX_ROWS, DEFAULT_CALL_LOGS_TABLE_MAX_ROWS);
+}
+
+export function getProxyLogsTableMaxRows(): number {
+  return parsePositiveInt(process.env.PROXY_LOGS_TABLE_MAX_ROWS, DEFAULT_PROXY_LOGS_TABLE_MAX_ROWS);
 }
 
 export function getAppLogLevel(defaultLevel: string): string {

--- a/tests/unit/log-retention.test.mjs
+++ b/tests/unit/log-retention.test.mjs
@@ -8,6 +8,8 @@ const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-log-reten
 process.env.DATA_DIR = TEST_DATA_DIR;
 process.env.APP_LOG_RETENTION_DAYS = "2";
 process.env.CALL_LOG_RETENTION_DAYS = "1";
+process.env.CALL_LOGS_TABLE_MAX_ROWS = "5";
+process.env.PROXY_LOGS_TABLE_MAX_ROWS = "5";
 
 const core = await import("../../src/lib/db/core.ts");
 const compliance = await import("../../src/lib/compliance/index.ts");
@@ -43,7 +45,7 @@ test("cleanupExpiredLogs uses separate APP and CALL retention windows", () => {
   ).run("openai", "fresh-usage", 1, 1, 1, 1, 1, freshCallTs);
 
   db.prepare(
-    "INSERT INTO call_logs (id, timestamp, method, path, status, model, provider, account, duration, tokens_in, tokens_out, has_pipeline_details) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+    "INSERT INTO call_logs (id, timestamp, method, path, status, model, provider, account, duration, tokens_in, tokens_out, has_pipeline_details) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
   ).run(
     "old-call",
     oldCallTs,
@@ -131,4 +133,57 @@ test("cleanupExpiredLogs uses separate APP and CALL retention windows", () => {
   assert.equal(db.prepare("SELECT COUNT(*) AS cnt FROM request_detail_logs").get().cnt, 1);
   assert.equal(db.prepare("SELECT COUNT(*) AS cnt FROM audit_log").get().cnt, 2);
   assert.equal(db.prepare("SELECT COUNT(*) AS cnt FROM mcp_tool_audit").get().cnt, 1);
+});
+
+test("cleanupExpiredLogs enforces row count limits", () => {
+  compliance.initAuditLog();
+  const db = core.getDbInstance();
+
+  const now = new Date().toISOString();
+
+  for (let i = 0; i < 10; i++) {
+    db.prepare(
+      "INSERT INTO call_logs (id, timestamp, method, path, status, model, provider, account, duration, tokens_in, tokens_out, has_pipeline_details) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+    ).run(
+      `call-${i}`,
+      now,
+      "POST",
+      "/v1/chat/completions",
+      200,
+      "model",
+      "provider",
+      "-",
+      1,
+      1,
+      1,
+      0
+    );
+  }
+
+  for (let i = 0; i < 10; i++) {
+    db.prepare(
+      "INSERT INTO proxy_logs (id, timestamp, status, level, latency_ms) VALUES (?, ?, ?, ?, ?)"
+    ).run(`proxy-${i}`, now, "success", "direct", 1);
+  }
+
+  assert.equal(db.prepare("SELECT COUNT(*) AS cnt FROM call_logs").get().cnt, 10);
+  assert.equal(db.prepare("SELECT COUNT(*) AS cnt FROM proxy_logs").get().cnt, 10);
+
+  const result = compliance.cleanupExpiredLogs();
+
+  assert.equal(result.trimmedCallLogs, 5);
+  assert.equal(result.trimmedProxyLogs, 5);
+  assert.equal(result.callLogsMaxRows, 5);
+  assert.equal(result.proxyLogsMaxRows, 5);
+
+  assert.equal(db.prepare("SELECT COUNT(*) AS cnt FROM call_logs").get().cnt, 5);
+  assert.equal(db.prepare("SELECT COUNT(*) AS cnt FROM proxy_logs").get().cnt, 5);
+});
+
+test("getCallLogsTableMaxRows returns configured value", async () => {
+  const { getCallLogsTableMaxRows, getProxyLogsTableMaxRows } =
+    await import("../../src/lib/logEnv.ts");
+
+  assert.equal(getCallLogsTableMaxRows(), 5);
+  assert.equal(getProxyLogsTableMaxRows(), 5);
 });


### PR DESCRIPTION
## Summary
- Add `CALL_LOGS_TABLE_MAX_ROWS` and `PROXY_LOGS_TABLE_MAX_ROWS` env vars (default: 100K) to prevent unbounded DB growth
- Modify `cleanupExpiredLogs()` to enforce row count limits to prevent DB growing to 10GB in 1 month  
- Handle HTML error responses from providers (e.g., GitHub Copilot) gracefully in chatCore
- Update storage health API to expose `tableMaxRows` settings
- Update SystemStorageTab UI to show row count limits
- Add unit tests for row count limit enforcement

## Fixes
- **Issue #1101**: DB bloat - SQLite DB grew to 10GB in 1 month with 300+ credentials
- **Issue #1066**: GitHub Copilot returning "Unexpected token '<'" and "fetch failed" error

## Test Results
- ✅ GitHub Copilot `/v1/chat/completions` tested on production - works
- ✅ GitHub Copilot models list - 10+ models available
- ✅ Row count limit unit test passes
- ✅ Build succeeds
- ✅ TypeScript passes