### PR TITLE
Raise combo smoke test token budget and randomize probe prompt

### DIFF
--- a/src/lib/combos/testHealth.ts
+++ b/src/lib/combos/testHealth.ts
@@ -1,5 +1,9 @@
 type JsonRecord = Record<string, unknown>;
 
+const COMBO_TEST_MAX_TOKENS = 2048;
+const COMBO_TEST_OPERAND_MIN = 10000;
+const COMBO_TEST_OPERAND_RANGE = 90000;
+
 function asRecord(value: unknown): JsonRecord {
   return value && typeof value === "object" && !Array.isArray(value) ? (value as JsonRecord) : {};
 }
@@ -103,14 +107,26 @@ function hasReasoningOnlyCompletion(body: JsonRecord): boolean {
   });
 }
 
+function getRandomFiveDigitNumber() {
+  return COMBO_TEST_OPERAND_MIN + Math.floor(Math.random() * COMBO_TEST_OPERAND_RANGE);
+}
+
+function buildComboTestPrompt() {
+  const left = getRandomFiveDigitNumber();
+  const right = getRandomFiveDigitNumber();
+
+  return `Calculate ${left}+${right}, and reply with the result only.`;
+}
+
 export function buildComboTestRequestBody(modelStr: string) {
   return {
     model: modelStr,
-    messages: [{ role: "user", content: "Reply with OK only." }],
-    // Give reasoning-heavy models enough headroom to emit a tiny visible answer
-    // without turning the smoke test into a full-cost real request.
-    max_tokens: 64,
-    temperature: 0,
+    // Randomize the arithmetic prompt so upstream providers are less likely to
+    // satisfy the smoke test with cached completions.
+    messages: [{ role: "user", content: buildComboTestPrompt() }],
+    // Give reasoning-heavy models enough headroom to finish the request and
+    // still emit a visible answer without immediate truncation.
+    max_tokens: COMBO_TEST_MAX_TOKENS,
     stream: false,
   };
 }

--- a/tests/unit/combo-test-health.test.mjs
+++ b/tests/unit/combo-test-health.test.mjs
@@ -5,12 +5,24 @@ const { buildComboTestRequestBody, extractComboTestResponseText } =
   await import("../../src/lib/combos/testHealth.ts");
 
 test("combo test helper builds a realistic smoke payload", () => {
-  const body = buildComboTestRequestBody("openrouter/openai/gpt-5.4");
+  const originalRandom = Math.random;
+  let callCount = 0;
+  let body;
+  try {
+    Math.random = () => {
+      callCount += 1;
+      return callCount === 1 ? 0.4680222223 : 0.2677;
+    };
+
+    body = buildComboTestRequestBody("openrouter/openai/gpt-5.4");
+  } finally {
+    Math.random = originalRandom;
+  }
 
   assert.equal(body.model, "openrouter/openai/gpt-5.4");
-  assert.equal(body.messages[0].content, "Reply with OK only.");
-  assert.equal(body.max_tokens, 64);
-  assert.equal(body.temperature, 0);
+  assert.equal(body.messages[0].content, "Calculate 52122+34093, and reply with the result only.");
+  assert.equal(body.max_tokens, 2048);
+  assert.equal("temperature" in body, false);
   assert.equal(body.stream, false);
 });
 

--- a/tests/unit/combo-test-route.test.mjs
+++ b/tests/unit/combo-test-route.test.mjs
@@ -88,6 +88,8 @@ test("combo test route marks a model healthy only when it returns assistant text
   await createTestCombo();
 
   const fetchCalls = [];
+  const originalRandom = Math.random;
+  let callCount = 0;
   globalThis.fetch = async (url, init = {}) => {
     fetchCalls.push({ url: String(url), init });
     return new Response(
@@ -108,7 +110,16 @@ test("combo test route marks a model healthy only when it returns assistant text
     );
   };
 
-  const response = await route.POST(makeRequest());
+  let response;
+  try {
+    Math.random = () => {
+      callCount += 1;
+      return callCount === 1 ? 0.4680222223 : 0.2677;
+    };
+    response = await route.POST(makeRequest());
+  } finally {
+    Math.random = originalRandom;
+  }
   const body = await response.json();
   const forwardedBody = JSON.parse(fetchCalls[0].init.body);
 
@@ -119,9 +130,12 @@ test("combo test route marks a model healthy only when it returns assistant text
   assert.equal(fetchCalls[0].init.headers["X-OmniRoute-No-Cache"], "true");
   assert.match(fetchCalls[0].init.headers["X-Request-Id"], /^combo-test-/);
   assert.equal(forwardedBody.model, "openrouter/openai/gpt-5.4");
-  assert.equal(forwardedBody.messages[0].content, "Reply with OK only.");
-  assert.equal(forwardedBody.max_tokens, 64);
-  assert.equal(forwardedBody.temperature, 0);
+  assert.equal(
+    forwardedBody.messages[0].content,
+    "Calculate 52122+34093, and reply with the result only."
+  );
+  assert.equal(forwardedBody.max_tokens, 2048);
+  assert.equal("temperature" in forwardedBody, false);
   assert.equal(body.resolvedBy, "openrouter/openai/gpt-5.4");
   assert.equal(body.results[0].status, "ok");
   assert.equal(body.results[0].responseText, "OK");


### PR DESCRIPTION
## Summary
- raise the combo smoke-test `max_tokens` budget from `64` to `2048` so reasoning-heavy models are less likely to truncate before returning visible output
- remove the probe `temperature` field to reduce provider-specific request-shape failures during combo testing
- randomize the probe prompt with two 5-digit additions so upstream providers are less likely to satisfy the test from cached deterministic replies

## Root cause
The combo probe used a deterministic `Reply with OK only.` prompt together with a very small output budget. That made the smoke test fragile for thinking models and easier for upstream caches to shortcut.

I have also observed some upstream relay providers caching trivial test prompts so they can score better on model-availability checks. Randomizing the arithmetic prompt makes that behavior less useful.

## Validation
- `node --import tsx/esm --test tests/unit/combo-test-health.test.mjs tests/unit/combo-test-route.test.mjs`
- `node --import tsx/esm --test tests/unit/chat-combo-live-test.test.mjs`
- `git push -u fork coder/combo-test-randomized-payload` (pre-push hook ran the full unit suite: 2609 passing)
