### PR TITLE
fix: Improve Android/Termux ARM64 support for better-sqlite3

### DIFF
--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -128,10 +128,17 @@ async function fixBetterSqliteBinary() {
 
   try {
     const { execSync } = await import("node:child_process");
-    execSync("npm rebuild better-sqlite3", {
+    
+    // On Android/Termux, rebuild from source with --build-from-source flag
+    const isAndroid = process.platform === "android";
+    const rebuildCmd = isAndroid
+      ? "npm install better-sqlite3 --build-from-source --force"
+      : "npm rebuild better-sqlite3";
+    
+    execSync(rebuildCmd, {
       cwd: join(ROOT, "app"),
       stdio: "inherit",
-      timeout: 120_000,
+      timeout: 300_000, // 5 minutes for source builds
     });
 
     process.dlopen({ exports: {} }, appBinary);
@@ -140,7 +147,7 @@ async function fixBetterSqliteBinary() {
   } catch (err) {
     const isTimeout = err.killed || err.signal === "SIGTERM";
     if (isTimeout) {
-      console.warn("  ⚠️  npm rebuild timed out after 120s.");
+      console.warn("  ⚠️  npm rebuild timed out after 300s.");
     } else {
       console.warn(`  ⚠️  npm rebuild failed: ${err.message}`);
     }


### PR DESCRIPTION
## Summary

This PR improves support for Android/Termux devices with ARM64 architecture.

## Changes

- Add explicit `--build-from-source` flag for Android platform in postinstall script
- Increase timeout to 300s for source compilation (building from source takes longer than rebuild)
- Ensure proper native module compilation on ARM64 devices

## Problem

On Android/Termux, the prebuilt binaries for better-sqlite3 are not available for ARM64 architecture. The existing postinstall script attempts to rebuild, but doesn't use the correct flags for source builds.

## Solution

Detect Android platform and use `npm install better-sqlite3 --build-from-source --force` which properly compiles the native module from source code rather than trying to download prebuilt binaries.

## Testing

- ✅ Tested on Android/Termux (aarch64)
- ✅ Server starts successfully  
- ✅ SQLite database works correctly