### PR TITLE
docs: add macOS better-sqlite3 rebuild fix to troubleshooting

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -15,6 +15,35 @@ Common problems and solutions for OmniRoute.
 | No request logs under `logs/` | Set `ENABLE_REQUEST_LOGS=true`                                     |
 | EACCES: permission denied     | Set `DATA_DIR=/path/to/writable/dir` to override `~/.omniroute`    |
 | Routing strategy not saving   | Update to v1.4.11+ (Zod schema fix for settings persistence)       |
+| `dlopen` / `slice is not valid mach-o file` (macOS) | Run `cd $(npm root -g)/omniroute/app && npm rebuild better-sqlite3` — see [macOS native module rebuild](#macos-native-module-rebuild) below |
+
+---
+
+## macOS: `dlopen` / "slice is not valid mach-o file"
+
+<a name="macos-native-module-rebuild"></a>
+
+**Cause:** After a global `npm install -g omniroute`, the `better-sqlite3` native binary inside the package may have been compiled for a different architecture or Node.js ABI than what is running locally. This is common on macOS (both Apple Silicon and Intel) when the pre-built binary does not match your environment.
+
+**Symptoms:**
+
+- Server fails immediately on startup with a `dlopen` error
+- Error contains `slice is not valid mach-o file`
+- Full example:
+
+```
+dlopen(/Users/<user>/.nvm/versions/node/v24.13.1/lib/node_modules/omniroute/app/node_modules/better-sqlite3/build/Release/better_sqlite3.node, 0x0001): tried: '...' (slice is not valid mach-o file)
+```
+
+**Fix — rebuild for your local environment (no Node.js downgrade required):**
+
+```bash
+cd $(npm root -g)/omniroute/app
+npm rebuild better-sqlite3
+omniroute
+```
+
+> **Note:** This compiles the native binding against your current Node.js version and CPU architecture. It works with Node.js 18, 20, 22, and 24 — you do not need to downgrade Node.js if the rebuild succeeds.
 
 ---
 

--- a/docs/i18n/pt-BR/TROUBLESHOOTING.md
+++ b/docs/i18n/pt-BR/TROUBLESHOOTING.md
@@ -19,6 +19,35 @@ Common problems and solutions for OmniRoute.
 | No request logs under `logs/` | Set `ENABLE_REQUEST_LOGS=true`                                     |
 | EACCES: permission denied     | Set `DATA_DIR=/path/to/writable/dir` to override `~/.omniroute`    |
 | Routing strategy not saving   | Update to v1.4.11+ (Zod schema fix for settings persistence)       |
+| `dlopen` / `slice is not valid mach-o file` (macOS) | Execute `cd $(npm root -g)/omniroute/app && npm rebuild better-sqlite3` — veja [Rebuild nativo no macOS](#macos-native-module-rebuild) abaixo |
+
+---
+
+## macOS: `dlopen` / "slice is not valid mach-o file"
+
+<a name="macos-native-module-rebuild"></a>
+
+**Causa:** Após `npm install -g omniroute`, o binário nativo do `better-sqlite3` incluído no pacote pode ter sido compilado para uma arquitetura ou versão ABI do Node.js diferente da que está sendo usada localmente. Isso é comum no macOS (Apple Silicon e Intel) quando o binário pré-compilado não corresponde ao ambiente.
+
+**Sintomas:**
+
+- O servidor falha imediatamente ao iniciar com um erro `dlopen`
+- A mensagem contém `slice is not valid mach-o file`
+- Exemplo completo:
+
+```
+dlopen(/Users/<usuario>/.nvm/versions/node/v24.13.1/lib/node_modules/omniroute/app/node_modules/better-sqlite3/build/Release/better_sqlite3.node, 0x0001): tried: '...' (slice is not valid mach-o file)
+```
+
+**Solução — recompilar para o ambiente local (sem precisar fazer downgrade do Node.js):**
+
+```bash
+cd $(npm root -g)/omniroute/app
+npm rebuild better-sqlite3
+omniroute
+```
+
+> **Nota:** Isso compila o binding nativo para a versão e arquitetura do Node.js em uso. Funciona com Node.js 18, 20, 22 e 24 — não é necessário fazer downgrade se o rebuild for bem-sucedido.
 
 ---
 


### PR DESCRIPTION
## Summary

- Documents the `dlopen` / `slice is not valid mach-o file` error that occurs on macOS after `npm install -g omniroute` when the pre-built `better-sqlite3` binary doesn't match the local Node.js ABI or CPU architecture (Apple Silicon and Intel affected)
- Adds a **Quick Fixes** table row pointing to the new section
- The fix is a one-liner `npm rebuild better-sqlite3` that works **without downgrading Node.js** (tested on Node.js 24 + Apple Silicon)
- Same content added to `docs/i18n/pt-BR/TROUBLESHOOTING.md` in Portuguese

## Motivation

After following the README quick start (`npm install -g omniroute`), the server crashes immediately on macOS with:

```
dlopen(.../better-sqlite3/build/Release/better_sqlite3.node, 0x0001):
tried: '...' (slice is not valid mach-o file)
```

The existing Node.js Compatibility section only covers the `Module did not self-register` variant and recommends downgrading to Node.js 22. This is a **different error** (mach-o architecture mismatch) with a simpler fix that doesn't require a downgrade.

## Test plan

- [x] Reproduced the `dlopen` / `slice is not valid mach-o file` error on macOS with Node.js 24 + Apple Silicon after `npm install -g omniroute`
- [x] Confirmed `cd $(npm root -g)/omniroute/app && npm rebuild better-sqlite3` resolves the error
- [x] OmniRoute starts and dashboard loads normally after rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)