### PR TITLE
[codex] Fix Electron server node path resolution

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -80,7 +80,11 @@ function resolveServerNodePath(env = process.env) {
     const trimmed = entry.trim();
     if (!trimmed) return;
     const normalized = path.normalize(trimmed);
-    if (seen.has(normalized) || !fs.existsSync(normalized)) return;
+    if (seen.has(normalized)) return; // already included
+    if (!fs.existsSync(normalized)) {
+      console.debug("[Electron] NODE_PATH candidate not found (skipped):", normalized);
+      return;
+    }
     seen.add(normalized);
     entries.push(normalized);
   };

--- a/electron/main.js
+++ b/electron/main.js
@@ -71,6 +71,33 @@ function resolveNodeExecutable(env = process.env) {
   return process.execPath;
 }
 
+function resolveServerNodePath(env = process.env) {
+  const seen = new Set();
+  const entries = [];
+
+  const addEntry = (entry) => {
+    if (!entry || typeof entry !== "string") return;
+    const trimmed = entry.trim();
+    if (!trimmed) return;
+    const normalized = path.normalize(trimmed);
+    if (seen.has(normalized) || !fs.existsSync(normalized)) return;
+    seen.add(normalized);
+    entries.push(normalized);
+  };
+
+  for (const existing of (env.NODE_PATH || "").split(path.delimiter)) {
+    addEntry(existing);
+  }
+
+  // Electron-builder installs native modules like better-sqlite3 under
+  // app.asar.unpacked, while the standalone bundle still carries helper deps
+  // such as bindings/file-uri-to-path inside resources/app/node_modules.
+  addEntry(path.join(process.resourcesPath, "app.asar.unpacked", "node_modules"));
+  addEntry(path.join(NEXT_SERVER_PATH, "node_modules"));
+
+  return entries.join(path.delimiter);
+}
+
 function resolveDataDir(overridePath, env = process.env) {
   if (overridePath && overridePath.trim()) return path.resolve(overridePath);
 
@@ -538,7 +565,7 @@ function startNextServer() {
       PORT: String(serverPort),
       NODE_ENV: "production",
       ELECTRON_RUN_AS_NODE: "1",
-      NODE_PATH: path.join(process.resourcesPath, "app.asar.unpacked", "node_modules"),
+      NODE_PATH: resolveServerNodePath(serverEnv),
     },
     stdio: "pipe",
   });


### PR DESCRIPTION
## What changed
- added a runtime helper to build `NODE_PATH` from all valid server module locations
- updated the Electron server spawn path to use the merged module search path instead of a single hardcoded directory

## Why
The Windows desktop package split native modules and their transitive helpers across two locations:
- `resources/app.asar.unpacked/node_modules`
- `resources/app/node_modules`

At runtime the server only searched the unpacked path, so `better-sqlite3` could load while helper modules like `bindings` and `file-uri-to-path` were missing. That broke SQLite initialization and caused desktop startup failures / internal server errors.

## Impact
- packaged Electron builds can resolve both the native sqlite module and its helper dependencies
- fixes desktop startup on Windows without changing the standalone bundle layout

## Validation
- `node --check electron/main.js`
- reproduced the missing-module failure locally and verified the merged module path resolves the sqlite dependency chain