### PR TITLE
Fix Codex OAuth fallback and login runtime warning

### DIFF
--- a/src/app/api/settings/require-login/route.ts
+++ b/src/app/api/settings/require-login/route.ts
@@ -1,15 +1,9 @@
 import { NextResponse } from "next/server";
 import { getSettings, updateSettings } from "@/lib/localDb";
 import bcrypt from "bcryptjs";
+import { getNodeCompatibility } from "@/lib/runtime/nodeCompatibility";
 import { updateRequireLoginSchema } from "@/shared/validation/schemas";
 import { isValidationFailure, validateBody } from "@/shared/validation/helpers";
-
-// Node.js compatibility check — better-sqlite3 requires Node <24
-function getNodeCompatibility() {
-  const nodeVersion = process.version;
-  const major = parseInt(nodeVersion.replace("v", "").split(".")[0], 10);
-  return { nodeVersion, nodeCompatible: major >= 18 && major < 24 };
-}
 
 export async function GET() {
   const nodeInfo = getNodeCompatibility();

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -2814,10 +2814,10 @@
     "waitingForAntigravityAuthorization": "Waiting for Antigravity authorization...",
     "waitingForQoderAuthorization": "Waiting for Qoder authorization...",
     "exchangingCodeForTokens": "Exchanging code for tokens...",
-    "nodeIncompatibleTitle": "Incompatible Node.js Version",
-    "nodeIncompatibleDesc": "You are running Node.js {version}, which is not compatible with OmniRoute. The native SQLite module (better-sqlite3) requires Node.js 18–22 LTS.",
-    "nodeIncompatibleFixLabel": "Fix: install Node.js 22 LTS",
-    "nodeIncompatibleHint": "OmniRoute requires Node.js ≥18 and <24. Node 22 LTS is recommended for stability."
+    "nodeIncompatibleTitle": "Native SQLite Module Issue",
+    "nodeIncompatibleDesc": "OmniRoute could not load the native SQLite module (better-sqlite3) under Node.js {version}.",
+    "nodeIncompatibleFixLabel": "Fix: reinstall dependencies with Node.js 22 LTS",
+    "nodeIncompatibleHint": "If the app already starts and login works, you can ignore this warning. Otherwise switch to Node.js 22 LTS and rebuild native modules."
   },
   "landing": {
     "brandName": "OmniRoute",

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -2713,10 +2713,10 @@
     "waitingForAntigravityAuthorization": "正在等待 Antigravity 授权...",
     "waitingForQoderAuthorization": "正在等待 Qoder 授权...",
     "exchangingCodeForTokens": "正在用授权码换取 Tokens...",
-    "nodeIncompatibleTitle": "不兼容的 Node.js 版本",
-    "nodeIncompatibleDesc": "你当前运行的是 Node.js {version}，它与 OmniRoute 不兼容。原生 SQLite 模块（better-sqlite3）要求使用 Node.js 18–22 LTS。",
-    "nodeIncompatibleFixLabel": "修复：安装 Node.js 22 LTS",
-    "nodeIncompatibleHint": "OmniRoute 要求 Node.js ≥18 且 <24。为保证稳定性，建议使用 Node 22 LTS。"
+    "nodeIncompatibleTitle": "原生 SQLite 模块异常",
+    "nodeIncompatibleDesc": "OmniRoute 在 Node.js {version} 下未能加载原生 SQLite 模块（better-sqlite3）。",
+    "nodeIncompatibleFixLabel": "修复：用 Node.js 22 LTS 重新安装依赖",
+    "nodeIncompatibleHint": "如果应用已经能启动且登录正常，可以忽略这条提示；否则请切换到 Node.js 22 LTS 并重新构建原生模块。"
   },
   "landing": {
     "brandName": "OmniRoute",

--- a/src/lib/oauth/constants/oauth.ts
+++ b/src/lib/oauth/constants/oauth.ts
@@ -1,11 +1,11 @@
 /**
  * OAuth Configuration Constants
  *
- * All credentials are read exclusively from environment variables.
- * Default values are provided via .env.example and auto-populated by
- * scripts/sync-env.mjs on install. See .env.example for the built-in
- * credentials used for localhost setups.
+ * Non-secret public client IDs keep an in-code fallback so browser OAuth does
+ * not break when `.env` has not been synced yet. Secrets still rely on env.
  */
+
+const OPENAI_PUBLIC_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
 
 // Claude OAuth Configuration (Authorization Code Flow with PKCE)
 export const CLAUDE_CONFIG = {
@@ -26,7 +26,7 @@ export const CLAUDE_CONFIG = {
 
 // Codex (OpenAI) OAuth Configuration (Authorization Code Flow with PKCE)
 export const CODEX_CONFIG = {
-  clientId: process.env.CODEX_OAUTH_CLIENT_ID || "",
+  clientId: process.env.CODEX_OAUTH_CLIENT_ID || OPENAI_PUBLIC_OAUTH_CLIENT_ID,
   authorizeUrl: "https://auth.openai.com/oauth/authorize",
   tokenUrl: "https://auth.openai.com/oauth/token",
   scope: "openid profile email offline_access",
@@ -138,7 +138,7 @@ export const ANTIGRAVITY_CONFIG = {
 
 // OpenAI OAuth Configuration (Authorization Code Flow with PKCE)
 export const OPENAI_CONFIG = {
-  clientId: process.env.CODEX_OAUTH_CLIENT_ID || "",
+  clientId: process.env.CODEX_OAUTH_CLIENT_ID || OPENAI_PUBLIC_OAUTH_CLIENT_ID,
   authorizeUrl: "https://auth.openai.com/oauth/authorize",
   tokenUrl: "https://auth.openai.com/oauth/token",
   scope: "openid profile email offline_access",

--- a/src/lib/runtime/nodeCompatibility.ts
+++ b/src/lib/runtime/nodeCompatibility.ts
@@ -1,0 +1,19 @@
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+function loadBetterSqlite3() {
+  require("better-sqlite3");
+}
+
+export function getNodeCompatibility(
+  loadNativeModule: () => void = loadBetterSqlite3,
+  nodeVersion = process.version
+) {
+  try {
+    loadNativeModule();
+    return { nodeVersion, nodeCompatible: true };
+  } catch {
+    return { nodeVersion, nodeCompatible: false };
+  }
+}

--- a/tests/unit/login-bootstrap-route.test.mjs
+++ b/tests/unit/login-bootstrap-route.test.mjs
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import bcrypt from "bcryptjs";
+import { getNodeCompatibility } from "../../src/lib/runtime/nodeCompatibility.ts";
 
 const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-login-bootstrap-"));
 process.env.DATA_DIR = TEST_DATA_DIR;
@@ -34,6 +35,26 @@ test.after(() => {
 });
 
 const originalHash = bcrypt.hash;
+
+test("node compatibility depends on native SQLite availability instead of a hardcoded version range", () => {
+  assert.deepEqual(
+    getNodeCompatibility(() => {}, "v25.9.0"),
+    {
+      nodeVersion: "v25.9.0",
+      nodeCompatible: true,
+    }
+  );
+
+  assert.deepEqual(
+    getNodeCompatibility(() => {
+      throw new Error("native module missing");
+    }, "v22.17.0"),
+    {
+      nodeVersion: "v22.17.0",
+      nodeCompatible: false,
+    }
+  );
+});
 
 test("public login bootstrap route exposes the metadata the login page consumes", async () => {
   await settingsDb.updateSettings({

--- a/tests/unit/oauth-providers-config.test.mjs
+++ b/tests/unit/oauth-providers-config.test.mjs
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { pathToFileURL } from "node:url";
 
 const originalEnv = { ...process.env };
 Object.assign(process.env, {
@@ -187,6 +188,27 @@ test("OAuth constants include all provider ids and use a sane timeout", () => {
       constantIds.includes(providerId),
       `Expected oauth constants to include provider id ${providerId}`
     );
+  }
+});
+
+test("Codex and OpenAI OAuth configs keep a built-in client id fallback when env is missing", async () => {
+  const previous = process.env.CODEX_OAUTH_CLIENT_ID;
+  delete process.env.CODEX_OAUTH_CLIENT_ID;
+
+  try {
+    const moduleUrl = pathToFileURL(
+      new URL("../../src/lib/oauth/constants/oauth.ts", import.meta.url).pathname
+    ).href;
+    const freshModule = await import(`${moduleUrl}?fallback=${Date.now()}`);
+
+    assert.equal(freshModule.CODEX_CONFIG.clientId, "app_EMoamEEZ73f0CkXaXp7hrann");
+    assert.equal(freshModule.OPENAI_CONFIG.clientId, "app_EMoamEEZ73f0CkXaXp7hrann");
+  } finally {
+    if (previous === undefined) {
+      delete process.env.CODEX_OAUTH_CLIENT_ID;
+    } else {
+      process.env.CODEX_OAUTH_CLIENT_ID = previous;
+    }
   }
 });
 


### PR DESCRIPTION
## Summary
- restore a built-in public OAuth client id fallback for Codex/OpenAI browser auth when `.env` is missing `CODEX_OAUTH_CLIENT_ID`
- stop the login page from flagging working Node runtimes as incompatible by probing `better-sqlite3` directly instead of hardcoding a `<24` version gate
- update the login warning copy to describe the actual native-module failure condition

## Testing
- `node --import tsx/esm --test tests/unit/login-bootstrap-route.test.mjs tests/unit/oauth-providers-config.test.mjs`
- `npm run typecheck:core`
