### PR TITLE
fix(qwen): add x-request-id header to device code request

### DIFF
--- a/src/lib/oauth/services/qwen.ts
+++ b/src/lib/oauth/services/qwen.ts
@@ -1,5 +1,5 @@
 import open from "open";
-import { randomUUID } from "crypto";
+import { randomUUID } from "node:crypto";
 import { QWEN_CONFIG } from "../constants/oauth";
 import { getServerCredentials } from "../config/index";
 import { generatePKCE } from "../utils/pkce";

--- a/src/lib/oauth/services/qwen.ts
+++ b/src/lib/oauth/services/qwen.ts
@@ -1,4 +1,5 @@
 import open from "open";
+import { randomUUID } from "crypto";
 import { QWEN_CONFIG } from "../constants/oauth";
 import { getServerCredentials } from "../config/index";
 import { generatePKCE } from "../utils/pkce";
@@ -24,6 +25,7 @@ export class QwenService {
       headers: {
         "Content-Type": "application/x-www-form-urlencoded",
         Accept: "application/json",
+        "x-request-id": randomUUID(),
       },
       body: new URLSearchParams({
         client_id: this.config.clientId,


### PR DESCRIPTION
## Summary

- Adds `x-request-id` header with UUID to Qwen OAuth device code request
- Matches upstream qwen-code implementation (`qwenOAuth2.ts:306`)
- Fixes "invalid_client" error when connecting Qwen Code

## Root Cause

Qwen's OAuth server requires an `x-request-id` header on the device code endpoint. Without it, the server rejects requests with `{"error":"invalid_client","error_description":"Invalid client credentials"}`.

The official `qwen-code` client sends this header, but OmniRoute's `QwenService.requestDeviceCode` was missing it.

## Test Plan

- [x] Existing OAuth tests pass (2719 tests)
- [ ] Manual test: Connect Qwen Code from dashboard (user to verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)