### PR TITLE
Fix: Remove leading/trailing newlines from omniModel tag injection (#531)

### DIFF
--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -951,7 +951,7 @@ export async function handleComboChat({
         // SDKs close the connection on finish_reason, so anything sent after
         // that marker is silently dropped.
         if (!res.body) return res;
-        const tagContent = `\\n<omniModel>${modelStr}</omniModel>\\n`;
+        const tagContent = `<omniModel>${modelStr}</omniModel>`;
         const encoder = new TextEncoder();
         const decoder = new TextDecoder();
         let tagInjected = false;

--- a/open-sse/services/comboAgentMiddleware.ts
+++ b/open-sse/services/comboAgentMiddleware.ts
@@ -62,7 +62,7 @@ export function injectModelTag(messages: Message[], providerModel: string): Mess
   if (lastAssistantIdx === -1) {
     return [
       ...cleaned,
-      { role: "assistant", content: `\n<omniModel>${providerModel}</omniModel>` },
+      { role: "assistant", content: `<omniModel>${providerModel}</omniModel>` },
     ];
   }
 
@@ -75,14 +75,14 @@ export function injectModelTag(messages: Message[], providerModel: string): Mess
     // message with the tag rather than silently failing.
     return [
       ...cleaned,
-      { role: "assistant", content: `\n<omniModel>${providerModel}</omniModel>` },
+      { role: "assistant", content: `<omniModel>${providerModel}</omniModel>` },
     ];
   }
 
   const tagged = [...cleaned];
   tagged[lastAssistantIdx] = {
     ...msg,
-    content: `${msg.content}\n<omniModel>${providerModel}</omniModel>`,
+    content: `${msg.content}<omniModel>${providerModel}</omniModel>`,
   };
   return tagged;
 }


### PR DESCRIPTION
## Problem

The `injectModelTag` function and `combo.ts` streaming handler were injecting `\n` before and after `<omniModel>` tags:

```typescript
// Was:
content: `\n<omniModel>${providerModel}</omniModel>`
// And in combo.ts:
const tagContent = `\n<omniModel>${modelStr}</omniModel>\n`
```

However, `stripOmniModelTags` (via `CACHE_TAG_PATTERN`) only removes the tag itself, leaving the newlines. On subsequent passes through the middleware, these newlines accumulate, resulting in `\n\n` at the start of every message when `context_cache_protection` is enabled.

## Fix

Removed `\n` prefix and suffix from all tag injection points:

1. **comboAgentMiddleware.ts** (3 locations):
   - Line 60: First turn synthetic assistant message
   - Line 74: Tool calls handling
   - Line 84: Appending to existing message content

2. **combo.ts** (1 location):
   - Line 954: Streaming response tag injection

## Testing

- Verified compiled output contains `<omniModel>${t}</omniModel>` without `\n`
- Tested both streaming and non-streaming responses
- Messages no longer have `\n\n` prefix with `context_cache_protection: true`

Fixes #531