### PR TITLE
feat: add skills.sh as external skill provider

### DIFF
--- a/src/app/(dashboard)/dashboard/skills/page.tsx
+++ b/src/app/(dashboard)/dashboard/skills/page.tsx
@@ -26,9 +26,9 @@ export default function SkillsPage() {
   const [skills, setSkills] = useState<Skill[]>([]);
   const [executions, setExecutions] = useState<Execution[]>([]);
   const [loading, setLoading] = useState(true);
-  const [activeTab, setActiveTab] = useState<"skills" | "executions" | "sandbox" | "marketplace">(
-    "skills"
-  );
+  const [activeTab, setActiveTab] = useState<
+    "skills" | "executions" | "sandbox" | "marketplace" | "skillssh"
+  >("skills");
   const [showInstallModal, setShowInstallModal] = useState(false);
   const [installJson, setInstallJson] = useState("");
   const [installStatus, setInstallStatus] = useState<{
@@ -50,6 +50,13 @@ export default function SkillsPage() {
   const [mpLoading, setMpLoading] = useState(false);
   const [mpError, setMpError] = useState("");
   const [mpInstallingId, setMpInstallingId] = useState<string | null>(null);
+  const [shQuery, setShQuery] = useState("");
+  const [shResults, setShResults] = useState<
+    { id: string; skillId: string; name: string; installs: number; source: string }[]
+  >([]);
+  const [shLoading, setShLoading] = useState(false);
+  const [shError, setShError] = useState("");
+  const [shInstallingId, setShInstallingId] = useState<string | null>(null);
   const t = useTranslations("skills");
 
   useEffect(() => {
@@ -180,6 +187,58 @@ export default function SkillsPage() {
     }
   };
 
+  const searchSkillsSh = async () => {
+    setShLoading(true);
+    setShError("");
+    setShResults([]);
+    try {
+      const res = await fetch(`/api/skills/skillssh?q=${encodeURIComponent(shQuery)}`);
+      const data = await res.json();
+      if (!res.ok) {
+        setShError(data.error || "Search failed");
+      } else {
+        setShResults(data.skills || []);
+      }
+    } catch (err) {
+      setShError(err instanceof Error ? err.message : "Search failed");
+    } finally {
+      setShLoading(false);
+    }
+  };
+
+  const installFromSkillsSh = async (skill: {
+    id: string;
+    skillId: string;
+    name: string;
+    installs: number;
+    source: string;
+  }) => {
+    setShInstallingId(skill.id);
+    try {
+      const res = await fetch("/api/skills/skillssh/install", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: skill.name,
+          description: `Installed from skills.sh (${skill.source})`,
+          source: skill.source,
+          skillId: skill.skillId,
+        }),
+      });
+      const data = await res.json();
+      if (res.ok && data.success) {
+        await refreshSkills();
+        setShInstallingId(null);
+      } else {
+        setShError(data.error || "Install failed");
+        setShInstallingId(null);
+      }
+    } catch (err) {
+      setShError(err instanceof Error ? err.message : "Install failed");
+      setShInstallingId(null);
+    }
+  };
+
   if (loading) {
     return (
       <div className="flex items-center justify-center min-h-[400px]">
@@ -243,6 +302,16 @@ export default function SkillsPage() {
           }`}
         >
           Marketplace
+        </button>
+        <button
+          onClick={() => setActiveTab("skillssh")}
+          className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+            activeTab === "skillssh"
+              ? "border-violet-500 text-violet-400"
+              : "border-transparent text-text-muted hover:text-text-main"
+          }`}
+        >
+          skills.sh
         </button>
       </div>
 
@@ -433,6 +502,66 @@ export default function SkillsPage() {
             <Card>
               <div className="text-center py-8 text-text-muted">
                 Configure your SkillsMP API key in Settings to browse the marketplace.
+              </div>
+            </Card>
+          )}
+        </div>
+      )}
+
+      {activeTab === "skillssh" && (
+        <div className="grid gap-4">
+          <Card>
+            <h3 className="font-semibold mb-4">skills.sh Directory</h3>
+            <div className="flex gap-2 mb-4">
+              <input
+                type="text"
+                value={shQuery}
+                onChange={(e) => setShQuery(e.target.value)}
+                onKeyDown={(e) => e.key === "Enter" && searchSkillsSh()}
+                placeholder="Search skills.sh..."
+                className="flex-1 px-3 py-2 rounded-lg bg-background border border-border text-sm focus:outline-none focus:ring-1 focus:ring-violet-500"
+              />
+              <button
+                onClick={searchSkillsSh}
+                disabled={shLoading}
+                className="px-4 py-2 text-sm font-medium rounded-lg bg-violet-500 text-white hover:bg-violet-600 disabled:opacity-50 transition-colors"
+              >
+                {shLoading ? "Searching..." : "Search skills.sh"}
+              </button>
+            </div>
+            {shError && (
+              <div className="p-3 rounded-lg bg-red-500/10 text-red-400 text-sm mb-4">
+                {shError}
+              </div>
+            )}
+          </Card>
+          {shResults.length > 0 && (
+            <div className="grid gap-3">
+              {shResults.map((skill) => (
+                <Card key={skill.id}>
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <h4 className="font-semibold">{skill.name}</h4>
+                      <p className="text-sm text-text-muted mt-1">
+                        {skill.source} · {skill.installs.toLocaleString()} installs
+                      </p>
+                    </div>
+                    <button
+                      onClick={() => installFromSkillsSh(skill)}
+                      disabled={shInstallingId === skill.id}
+                      className="px-4 py-1.5 text-sm font-medium rounded-lg bg-violet-500 text-white hover:bg-violet-600 disabled:opacity-50 transition-colors"
+                    >
+                      {shInstallingId === skill.id ? "Installing..." : "Install"}
+                    </button>
+                  </div>
+                </Card>
+              ))}
+            </div>
+          )}
+          {!shLoading && shResults.length === 0 && !shError && (
+            <Card>
+              <div className="text-center py-8 text-text-muted">
+                Search the skills.sh open directory to discover and install agent skills.
               </div>
             </Card>
           )}

--- a/src/app/api/skills/skillssh/install/route.ts
+++ b/src/app/api/skills/skillssh/install/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { validateBody, isValidationFailure } from "@/shared/validation/helpers";
+import { skillRegistry } from "@/lib/skills/registry";
+import { isAuthenticated } from "@/shared/utils/apiAuth";
+import { fetchSkillMd } from "@/lib/skills/skillssh";
+
+const skillsshInstallSchema = z.object({
+  name: z.string().min(1).max(64),
+  description: z.string().min(1).max(1024),
+  source: z.string().min(1),
+  skillId: z.string().min(1),
+  version: z.string().default("1.0.0"),
+});
+
+export async function POST(request: Request) {
+  if (!(await isAuthenticated(request))) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  try {
+    const rawBody = await request.json();
+    const validation = validateBody(skillsshInstallSchema, rawBody);
+    if (isValidationFailure(validation)) {
+      return NextResponse.json(validation.error, { status: 400 });
+    }
+    const { name, description, source, skillId, version } = validation.data;
+
+    const skillMdContent = await fetchSkillMd(source, skillId);
+
+    const skill = await skillRegistry.register({
+      name,
+      version,
+      description,
+      schema: { input: { content: "string" }, output: { result: "string" } },
+      handler: `// Installed from skills.sh\n// Source: ${source}/${skillId}\n// SKILL.md content:\n${skillMdContent}`,
+      apiKeyId: "skillssh",
+      enabled: true,
+    });
+
+    return NextResponse.json({ success: true, id: skill.id });
+  } catch (err: unknown) {
+    const error = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error }, { status: 500 });
+  }
+}

--- a/src/app/api/skills/skillssh/route.ts
+++ b/src/app/api/skills/skillssh/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+import { isAuthenticated } from "@/shared/utils/apiAuth";
+import { searchSkillsSh } from "@/lib/skills/skillssh";
+
+export async function GET(request: Request) {
+  if (!(await isAuthenticated(request))) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  try {
+    const { searchParams } = new URL(request.url);
+    const q = searchParams.get("q") || "";
+    const limit = Math.min(Math.max(Number(searchParams.get("limit")) || 20, 1), 100);
+
+    const data = await searchSkillsSh(q, limit);
+    return NextResponse.json({
+      skills: data.skills.map((s) => ({
+        id: s.id,
+        skillId: s.skillId,
+        name: s.name,
+        installs: s.installs,
+        source: s.source,
+      })),
+    });
+  } catch (err: unknown) {
+    const error = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error }, { status: 500 });
+  }
+}

--- a/src/lib/skills/skillssh.ts
+++ b/src/lib/skills/skillssh.ts
@@ -1,0 +1,74 @@
+import { z } from "zod";
+
+// ─── skills.sh API response schemas ───
+
+export const SkillsShSkillSchema = z.object({
+  id: z.string(),
+  skillId: z.string(),
+  name: z.string(),
+  installs: z.number().optional().default(0),
+  source: z.string(),
+});
+
+export const SkillsShSearchResponseSchema = z.object({
+  query: z.string().optional(),
+  searchType: z.string().optional(),
+  skills: z.array(SkillsShSkillSchema).default([]),
+  count: z.number().optional(),
+  duration_ms: z.number().optional(),
+});
+
+export type SkillsShSkill = z.infer<typeof SkillsShSkillSchema>;
+export type SkillsShSearchResponse = z.infer<typeof SkillsShSearchResponseSchema>;
+
+const SKILLSSH_BASE_URL = "https://skills.sh/api";
+const GITHUB_RAW_BASE = "https://raw.githubusercontent.com";
+const DEFAULT_SEARCH_LIMIT = 20;
+const REQUEST_TIMEOUT_MS = 15_000;
+
+/**
+ * Search the skills.sh public directory.
+ * No authentication required.
+ */
+export async function searchSkillsSh(
+  query: string,
+  limit: number = DEFAULT_SEARCH_LIMIT
+): Promise<SkillsShSearchResponse> {
+  const url = `${SKILLSSH_BASE_URL}/search?q=${encodeURIComponent(query)}&limit=${limit}`;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+  try {
+    const res = await fetch(url, { signal: controller.signal });
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(`skills.sh API error: ${res.status} ${body}`);
+    }
+    const data = await res.json();
+    return SkillsShSearchResponseSchema.parse(data);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/**
+ * Fetch SKILL.md content from GitHub for a skills.sh skill.
+ *
+ * @param source - GitHub "owner/repo" (e.g. "supabase/agent-skills")
+ * @param skillId - Skill name (last segment of the full id, e.g. "supabase-postgres-best-practices")
+ */
+export async function fetchSkillMd(source: string, skillId: string): Promise<string> {
+  const url = `${GITHUB_RAW_BASE}/${source}/main/skills/${skillId}/SKILL.md`;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+  try {
+    const res = await fetch(url, { signal: controller.signal });
+    if (!res.ok) {
+      throw new Error(`Failed to fetch SKILL.md: ${res.status} (${url})`);
+    }
+    return await res.text();
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/tests/unit/skills-skillssh.test.mjs
+++ b/tests/unit/skills-skillssh.test.mjs
@@ -1,0 +1,303 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-skillssh-"));
+const originalDataDir = process.env.DATA_DIR;
+process.env.DATA_DIR = tmpDir;
+
+const core = await import("../../src/lib/db/core.ts");
+const { skillRegistry } = await import("../../src/lib/skills/registry.ts");
+const { searchSkillsSh, fetchSkillMd, SkillsShSearchResponseSchema, SkillsShSkillSchema } =
+  await import("../../src/lib/skills/skillssh.ts");
+const searchRoute = await import("../../src/app/api/skills/skillssh/route.ts");
+const installRoute = await import("../../src/app/api/skills/skillssh/install/route.ts");
+
+function clearSkillRegistry() {
+  skillRegistry.registeredSkills?.clear?.();
+  skillRegistry.versionCache?.clear?.();
+}
+
+function resetStorage() {
+  core.resetDbInstance();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  fs.mkdirSync(tmpDir, { recursive: true });
+  clearSkillRegistry();
+  core.getDbInstance();
+}
+
+const originalFetch = globalThis.fetch;
+
+test.beforeEach(() => {
+  resetStorage();
+  globalThis.fetch = originalFetch;
+});
+
+test.after(() => {
+  core.resetDbInstance();
+  clearSkillRegistry();
+  globalThis.fetch = originalFetch;
+  process.env.DATA_DIR = originalDataDir;
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ── Zod schema validation tests ──
+
+test("SkillsShSkillSchema parses a valid skill object", () => {
+  const result = SkillsShSkillSchema.parse({
+    id: "supabase/agent-skills/supabase-postgres",
+    skillId: "supabase-postgres",
+    name: "Supabase Postgres",
+    installs: 42,
+    source: "supabase/agent-skills",
+  });
+  assert.equal(result.id, "supabase/agent-skills/supabase-postgres");
+  assert.equal(result.installs, 42);
+});
+
+test("SkillsShSkillSchema defaults installs to 0 when missing", () => {
+  const result = SkillsShSkillSchema.parse({
+    id: "x/y/z",
+    skillId: "z",
+    name: "Z Skill",
+    source: "x/y",
+  });
+  assert.equal(result.installs, 0);
+});
+
+test("SkillsShSearchResponseSchema parses a full response", () => {
+  const result = SkillsShSearchResponseSchema.parse({
+    query: "postgres",
+    searchType: "text",
+    skills: [{ id: "a/b/c", skillId: "c", name: "C", source: "a/b" }],
+    count: 1,
+    duration_ms: 50,
+  });
+  assert.equal(result.skills.length, 1);
+  assert.equal(result.count, 1);
+});
+
+test("SkillsShSearchResponseSchema defaults skills to empty array", () => {
+  const result = SkillsShSearchResponseSchema.parse({});
+  assert.deepEqual(result.skills, []);
+});
+
+// ── searchSkillsSh tests ──
+
+test("searchSkillsSh returns parsed results on success", async () => {
+  const mockPayload = {
+    query: "test",
+    searchType: "text",
+    skills: [
+      {
+        id: "owner/repo/skill-a",
+        skillId: "skill-a",
+        name: "Skill A",
+        installs: 10,
+        source: "owner/repo",
+      },
+    ],
+    count: 1,
+    duration_ms: 12,
+  };
+
+  globalThis.fetch = async (url) => {
+    assert.ok(url.includes("skills.sh/api/search"));
+    assert.ok(url.includes("q=test"));
+    return new Response(JSON.stringify(mockPayload), { status: 200 });
+  };
+
+  const result = await searchSkillsSh("test", 10);
+  assert.equal(result.skills.length, 1);
+  assert.equal(result.skills[0].skillId, "skill-a");
+});
+
+test("searchSkillsSh throws on non-ok response", async () => {
+  globalThis.fetch = async () => new Response("Server Error", { status: 500 });
+
+  await assert.rejects(
+    () => searchSkillsSh("fail"),
+    (err) => err.message.includes("skills.sh API error: 500")
+  );
+});
+
+// ── fetchSkillMd tests ──
+
+test("fetchSkillMd returns SKILL.md content on success", async () => {
+  const mdContent = "# My Skill\nDoes things.";
+  globalThis.fetch = async (url) => {
+    assert.ok(url.includes("raw.githubusercontent.com/owner/repo/main/skills/my-skill/SKILL.md"));
+    return new Response(mdContent, { status: 200 });
+  };
+
+  const result = await fetchSkillMd("owner/repo", "my-skill");
+  assert.equal(result, mdContent);
+});
+
+test("fetchSkillMd throws on 404", async () => {
+  globalThis.fetch = async () => new Response("Not Found", { status: 404 });
+
+  await assert.rejects(
+    () => fetchSkillMd("owner/repo", "missing-skill"),
+    (err) => err.message.includes("Failed to fetch SKILL.md: 404")
+  );
+});
+
+// ── GET /api/skills/skillssh route tests ──
+
+test("skillssh search route returns skills from the API", async () => {
+  const mockPayload = {
+    query: "docker",
+    searchType: "text",
+    skills: [
+      {
+        id: "o/r/docker-skill",
+        skillId: "docker-skill",
+        name: "Docker Skill",
+        installs: 5,
+        source: "o/r",
+      },
+      {
+        id: "o/r/compose-skill",
+        skillId: "compose-skill",
+        name: "Compose Skill",
+        installs: 3,
+        source: "o/r",
+      },
+    ],
+    count: 2,
+    duration_ms: 8,
+  };
+
+  globalThis.fetch = async () => new Response(JSON.stringify(mockPayload), { status: 200 });
+
+  const req = new Request("http://localhost/api/skills/skillssh?q=docker&limit=10");
+  const res = await searchRoute.GET(req);
+  const body = await res.json();
+
+  assert.equal(res.status, 200);
+  assert.equal(body.skills.length, 2);
+  assert.equal(body.skills[0].name, "Docker Skill");
+  assert.equal(body.skills[1].skillId, "compose-skill");
+});
+
+test("skillssh search route returns 500 when upstream fails", async () => {
+  globalThis.fetch = async () => new Response("Bad Gateway", { status: 502 });
+
+  const req = new Request("http://localhost/api/skills/skillssh?q=broken");
+  const res = await searchRoute.GET(req);
+  const body = await res.json();
+
+  assert.equal(res.status, 500);
+  assert.ok(body.error.includes("skills.sh API error"));
+});
+
+// ── POST /api/skills/skillssh/install route tests ──
+
+test("skillssh install route registers a skill from skills.sh", async () => {
+  const mdContent = "# Docker Best Practices\nContent here.";
+
+  globalThis.fetch = async (url) => {
+    if (url.includes("raw.githubusercontent.com")) {
+      return new Response(mdContent, { status: 200 });
+    }
+    return new Response("Not Found", { status: 404 });
+  };
+
+  const req = new Request("http://localhost/api/skills/skillssh/install", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      name: "docker-best-practices",
+      description: "Docker best practices skill",
+      source: "owner/repo",
+      skillId: "docker-best-practices",
+      version: "1.0.0",
+    }),
+  });
+
+  const res = await installRoute.POST(req);
+  const body = await res.json();
+
+  assert.equal(res.status, 200);
+  assert.equal(body.success, true);
+  assert.ok(body.id);
+
+  // Verify the skill was registered with correct metadata
+  const skills = skillRegistry.list();
+  const installed = skills.find((s) => s.name === "docker-best-practices");
+  assert.ok(installed);
+  assert.equal(installed.apiKeyId, "skillssh");
+  assert.ok(installed.handler.includes("Installed from skills.sh"));
+  assert.ok(installed.handler.includes(mdContent));
+});
+
+test("skillssh install route returns 400 for invalid payload", async () => {
+  const req = new Request("http://localhost/api/skills/skillssh/install", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      name: "",
+      description: "Missing name",
+      source: "owner/repo",
+      skillId: "something",
+    }),
+  });
+
+  const res = await installRoute.POST(req);
+  assert.equal(res.status, 400);
+});
+
+test("skillssh install route returns 500 when SKILL.md fetch fails", async () => {
+  globalThis.fetch = async () => new Response("Not Found", { status: 404 });
+
+  const req = new Request("http://localhost/api/skills/skillssh/install", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      name: "missing-skill",
+      description: "Skill that does not exist",
+      source: "owner/repo",
+      skillId: "nonexistent",
+    }),
+  });
+
+  const res = await installRoute.POST(req);
+  const body = await res.json();
+
+  assert.equal(res.status, 500);
+  assert.ok(body.error.includes("Failed to fetch SKILL.md"));
+});
+
+test("skillssh install route defaults version to 1.0.0 when omitted", async () => {
+  globalThis.fetch = async (url) => {
+    if (url.includes("raw.githubusercontent.com")) {
+      return new Response("# Skill Content", { status: 200 });
+    }
+    return new Response("Not Found", { status: 404 });
+  };
+
+  const req = new Request("http://localhost/api/skills/skillssh/install", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      name: "version-default-test",
+      description: "Test version default",
+      source: "owner/repo",
+      skillId: "vd-test",
+    }),
+  });
+
+  const res = await installRoute.POST(req);
+  const body = await res.json();
+
+  assert.equal(res.status, 200);
+  assert.equal(body.success, true);
+
+  const skills = skillRegistry.list();
+  const installed = skills.find((s) => s.name === "version-default-test");
+  assert.ok(installed);
+  assert.equal(installed.version, "1.0.0");
+});


### PR DESCRIPTION
## Summary

- Adds [skills.sh](https://skills.sh) (Vercel's open Agent Skills Directory, 13K+ stars) as a second external skill provider alongside the existing SkillsMP marketplace
- Follows the same integration pattern as SkillsMP: search API → fetch SKILL.md → register locally via `SkillRegistry`
- No authentication required — skills.sh has a public API

Closes #1222

## What Changed

### New Files

| File | Description |
|------|-------------|
| `src/lib/skills/skillssh.ts` | skills.sh client module — Zod-validated search + SKILL.md fetch with AbortController timeout |
| `src/app/api/skills/skillssh/route.ts` | `GET /api/skills/skillssh?q=&limit=` — search endpoint (auth-gated) |
| `src/app/api/skills/skillssh/install/route.ts` | `POST /api/skills/skillssh/install` — install endpoint with Zod body validation |
| `tests/unit/skills-skillssh.test.mjs` | 14 unit tests covering search, install, error handling, and edge cases |

### Modified Files

| File | Change |
|------|--------|
| `src/app/(dashboard)/dashboard/skills/page.tsx` | Added 5th "skills.sh" tab with search UI, result cards, and install flow (violet accent) |

## Implementation Details

- **Client module** (`skillssh.ts`): Zod schemas for API responses, `searchSkillsSh()` with configurable limit (1-100), `fetchSkillMd()` fetching raw SKILL.md from GitHub, 15s request timeout via AbortController
- **Search route**: Auth check → query param parsing → `searchSkillsSh()` → normalized response
- **Install route**: Auth check → Zod body validation (`validateBody`/`isValidationFailure`) → fetch SKILL.md → `skillRegistry.register()` with `apiKeyId: "skillssh"` and handler prefixed `// Installed from skills.sh`
- **Dashboard tab**: Search input, loading states, error display, result cards with install buttons, success feedback — matching the existing SkillsMP tab UX

## Testing

- **14 unit tests** — all pass ✅
- Full test suite: **2733 tests pass, 0 fail**
- Coverage gate: **91.06% statements, 78.18% branches, 92.21% functions, 91.06% lines** (requirement: 60%)

## How to Test Manually

1. Navigate to Dashboard → Skills → "skills.sh" tab
2. Search for a skill (e.g., "supabase", "nextjs")
3. Click "Install" on any result
4. Verify the skill appears in the main Skills tab with `apiKeyId: skillssh`

## API Examples

```bash
# Search skills.sh
GET /api/skills/skillssh?q=supabase&limit=10

# Install a skill
POST /api/skills/skillssh/install
{
  "name": "supabase-postgres-best-practices",
  "description": "Best practices for Supabase Postgres",
  "source": "supabase/agent-skills",
  "skillId": "supabase-postgres-best-practices",
  "version": "1.0.0"
}
```