### PR TITLE
fix: forward client x-initiator header to GitHub Copilot upstream

### DIFF
--- a/open-sse/executors/base.ts
+++ b/open-sse/executors/base.ts
@@ -61,6 +61,8 @@ export type ExecuteInput = {
   extendedContext?: boolean;
   /** Merged after auth + CLI fingerprint headers (values override same-named defaults). */
   upstreamExtraHeaders?: Record<string, string> | null;
+  /** Original client request headers (read-only). Executors may forward select headers upstream. */
+  clientHeaders?: Record<string, string> | null;
 };
 
 /** Apply model-level extra upstream headers (e.g. Authentication, X-Custom-Auth). */

--- a/open-sse/executors/github.ts
+++ b/open-sse/executors/github.ts
@@ -3,6 +3,9 @@ import { PROVIDERS, OAUTH_ENDPOINTS } from "../config/constants.ts";
 import { getModelTargetFormat } from "../config/providerModels.ts";
 
 export class GithubExecutor extends BaseExecutor {
+  /** Stashed per-request so buildHeaders() can read the client's x-initiator value. */
+  private _clientHeaders: Record<string, string> | null = null;
+
   constructor() {
     super("github", PROVIDERS.github);
   }
@@ -84,54 +87,72 @@ export class GithubExecutor extends BaseExecutor {
   }
 
   async execute(input: ExecuteInput) {
-    const result = await super.execute(input);
-    if (!result || !result.response) return result;
+    this._clientHeaders = input.clientHeaders ?? null;
+    try {
+      const result = await super.execute(input);
+      if (!result || !result.response) return result;
 
-    if (!input.stream) {
-      // wreq-js clone/text semantics consume the original response body. Materialize
-      // non-streaming responses immediately so downstream code always sees a native
-      // fetch Response with a readable body.
-      const status = result.response.status;
-      const statusText = result.response.statusText;
-      const headers = new Headers(result.response.headers);
-      const payload = await result.response.text();
-      result.response = new Response(payload, { status, statusText, headers });
+      if (!input.stream) {
+        // wreq-js clone/text semantics consume the original response body. Materialize
+        // non-streaming responses immediately so downstream code always sees a native
+        // fetch Response with a readable body.
+        const status = result.response.status;
+        const statusText = result.response.statusText;
+        const headers = new Headers(result.response.headers);
+        const payload = await result.response.text();
+        result.response = new Response(payload, { status, statusText, headers });
+        return result;
+      }
+
+      if (!result.response.body) return result;
+
+      const isStreaming = input.stream === true;
+      const contentType = (result.response.headers.get("content-type") || "").toLowerCase();
+      if (isStreaming && result.response.ok && contentType.includes("text/event-stream")) {
+        // Preserve the original response body for downstream error handling.
+        const sourceResponse = result.response.clone();
+        if (!sourceResponse.body) return result;
+
+        const decoder = new TextDecoder();
+        const transformStream = new TransformStream({
+          transform(chunk, controller) {
+            const text = decoder.decode(chunk, { stream: true });
+            if (text.includes("data: [DONE]")) {
+              return;
+            }
+            controller.enqueue(chunk);
+          },
+        });
+
+        const newResponse = new Response(sourceResponse.body.pipeThrough(transformStream), {
+          status: sourceResponse.status,
+          statusText: sourceResponse.statusText,
+          headers: new Headers(sourceResponse.headers),
+        });
+        result.response = newResponse;
+      }
+
       return result;
+    } finally {
+      this._clientHeaders = null;
     }
-
-    if (!result.response.body) return result;
-
-    const isStreaming = input.stream === true;
-    const contentType = (result.response.headers.get("content-type") || "").toLowerCase();
-    if (isStreaming && result.response.ok && contentType.includes("text/event-stream")) {
-      // Preserve the original response body for downstream error handling.
-      const sourceResponse = result.response.clone();
-      if (!sourceResponse.body) return result;
-
-      const decoder = new TextDecoder();
-      const transformStream = new TransformStream({
-        transform(chunk, controller) {
-          const text = decoder.decode(chunk, { stream: true });
-          if (text.includes("data: [DONE]")) {
-            return;
-          }
-          controller.enqueue(chunk);
-        },
-      });
-
-      const newResponse = new Response(sourceResponse.body.pipeThrough(transformStream), {
-        status: sourceResponse.status,
-        statusText: sourceResponse.statusText,
-        headers: new Headers(sourceResponse.headers),
-      });
-      result.response = newResponse;
-    }
-
-    return result;
   }
 
   buildHeaders(credentials, stream = true) {
     const token = this.getCopilotToken(credentials) || credentials.accessToken;
+
+    // Forward the client's x-initiator header when present. OpenCode and other
+    // Copilot-aware clients use this to distinguish user-initiated turns
+    // (x-initiator: user) from autonomous tool-call continuations
+    // (x-initiator: agent). GitHub Copilot's billing treats "agent" turns as
+    // free, so forwarding the value avoids burning a premium request on every
+    // tool-call round-trip.  Fall back to "user" when the header is absent to
+    // preserve the existing default behaviour.
+    const ch = this._clientHeaders;
+    const clientInitiator = ch?.["x-initiator"] || ch?.["X-Initiator"];
+    const initiator =
+      clientInitiator === "agent" || clientInitiator === "user" ? clientInitiator : "user";
+
     return {
       Authorization: `Bearer ${token}`,
       "Content-Type": "application/json",
@@ -144,7 +165,7 @@ export class GithubExecutor extends BaseExecutor {
       "x-request-id":
         crypto.randomUUID?.() || `${Date.now()}-${Math.random().toString(36).slice(2)}`,
       "x-vscode-user-agent-library-version": "electron-fetch",
-      "X-Initiator": "user",
+      "X-Initiator": initiator,
       Accept: stream ? "text/event-stream" : "application/json",
     };
   }

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -1301,6 +1301,7 @@ export async function handleChatCore({
       signal?: AbortSignal | null;
       log?: unknown;
       upstreamExtraHeaders?: Record<string, string> | null;
+      clientHeaders?: Record<string, string> | null;
     }) => {
       let result;
       try {
@@ -1396,6 +1397,7 @@ export async function handleChatCore({
             log,
             extendedContext,
             upstreamExtraHeaders: buildUpstreamHeadersForExecute(modelToCall),
+            clientHeaders: clientRawRequest?.headers ?? null,
           });
 
           // Qwen 429 strict quota backoff (wait 1.5s, 3s and retry)
@@ -1595,6 +1597,7 @@ export async function handleChatCore({
           log,
           extendedContext,
           upstreamExtraHeaders: buildUpstreamHeadersForExecute(retryModelId),
+          clientHeaders: clientRawRequest?.headers ?? null,
         });
 
         if (retryResult.response.ok) {
@@ -1953,6 +1956,7 @@ export async function handleChatCore({
               signal: streamController.signal,
               log,
               extendedContext,
+              clientHeaders: clientRawRequest?.headers ?? null,
             });
             if (fbResult.response.ok) {
               provider = fbDecision.provider;


### PR DESCRIPTION
- feat: add optional clientHeaders field to ExecuteInput type
- feat: thread clientRawRequest.headers through all executor.execute() callsites in chatCore
- fix: GithubExecutor reads client x-initiator and forwards "agent" or "user" to Copilot
- chore: clean up _clientHeaders in finally block to prevent cross-request leakage

## Summary

- OmniRoute currently hardcodes X-Initiator: "user" on every request to GitHub Copilot. This causes all tool-call continuation turns to be billed as premium requests, when GitHub Copilot's billing treats x-initiator: "agent" turns as free.
- This PR threads the client's original request headers through the executor pipeline and forwards the x-initiator value ("agent" or "user") to Copilot upstream, falling back to "user" when absent.
- For an agentic coding session triggering 10 tool calls on Claude Opus (3x multiplier), this reduces premium request consumption from ~30 per user message to ~3.

## Related Issues

- Related to BerriAI/litellm#12859 (https://github.com/BerriAI/litellm/issues/12859) - Same issue reported for litellm's Copilot proxy
- Related to anomalyco/opencode#595 (https://github.com/anomalyco/opencode/pull/595) - OpenCode's native fix (merged Jul 2025) that this PR mirrors for OmniRoute
- Related to olimorris/codecompanion.nvim#1738 (https://github.com/olimorris/codecompanion.nvim/pull/1738) - codecompanion.nvim's equivalent fix (merged Jun 2025)

## Validation

- [x] `npm run lint`
- [x] `npm run test:unit`
- [x] `npm run test:coverage`
- [x] Coverage is still `>= 60%` for statements, lines, functions, and branches
- [x] SonarQube PR analysis is green or any remaining issues are explicitly documented below

## Tests Added Or Updated

- No new test files added. The change is a header-forwarding fix in the existing `GithubExecutor` pipeline. The existing 2719 unit tests all pass and cover the executor and chatCore paths exercised by this change.

## Coverage Notes

- This PR changes `open-sse/executors/base.ts`, `open-sse/executors/github.ts`, and `open-sse/handlers/chatCore.ts`.
- `github.ts` changes are covered by existing GitHub executor unit tests (buildHeaders, execute flow, streaming transform). The `_clientHeaders` stash/cleanup pattern follows the same try/finally structure already tested in retry and fallback paths.
- `chatCore.ts` changes are additive (passing one extra field to `executor.execute()`), covered by existing chat handler integration tests.
- `base.ts` adds an optional field to a type — no runtime change, no coverage impact.
- No coverage regression expected.

## Reviewer Notes

- **Whitelist approach**: Only `"agent"` and `"user"` are forwarded — any other value from the client is silently replaced with `"user"`. This prevents clients from injecting unexpected initiator values.
- **Stash pattern**: `_clientHeaders` is set at the top of `execute()` and cleared in a `finally` block to prevent cross-request header leakage in case of errors or retries.
- **No new dependencies** added.
- **Backward compatible**: When clients don't send `x-initiator` (e.g., non-Copilot-aware clients), behaviour is identical to before — `"user"` is sent.
- **Manual validation**: Tested with OpenCode + OmniRoute against GitHub Copilot. Tool-call turns sent with `x-initiator: "agent"` are confirmed free in the Copilot usage dashboard.
