### PR TITLE
fix(cc-compatible): restore conservative beta flags and cache passthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -801,6 +801,11 @@ Backward compatibility is preserved: existing `FETCH_TIMEOUT_MS`, `API_BRIDGE_PR
 
 For Claude Code-compatible upstreams (`anthropic-compatible-cc-*`), OmniRoute also derives the outbound `X-Stainless-Timeout` header from the resolved fetch timeout so provider-side read timeouts stay aligned with your env configuration.
 
+For third-party Claude Code-compatible reverse proxies, OmniRoute keeps the default
+`anthropic-beta` set conservative and, when `Client Cache Control` is left on `Auto`,
+only forwards client-provided `cache_control` markers. If the request does not include
+`cache_control`, OmniRoute does not inject bridge-owned markers.
+
 Advanced overrides are available if you need finer control:
 
 | Variable                                 | Default                                    | Purpose                                                              |

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -1033,10 +1033,9 @@ export async function handleChatCore({
 
       // Apply PR #1188 parity pipeline (synchronous steps — CCH signing is async and
       // runs later in BaseExecutor over the serialized string).
-      // Only thinking constraints and tool remapping are applied here; cache-control
-      // limit enforcement (enforceCacheControlLimit) is intentionally omitted because
-      // the billing-header system block added by buildClaudeCodeCompatibleRequest counts
-      // toward the 4-block cap and would strip legitimate client cache markers.
+      // Only thinking constraints and tool remapping are applied here. Cache-control
+      // helpers stay out of the runtime bridge path so auto mode remains passthrough:
+      // if the client sends cache_control we preserve it, otherwise we do not inject it.
       remapToolNamesInRequest(translatedBody);
       enforceThinkingTemperature(translatedBody);
       disableThinkingIfToolChoiceForced(translatedBody);

--- a/open-sse/services/claudeCodeCompatible.ts
+++ b/open-sse/services/claudeCodeCompatible.ts
@@ -9,7 +9,6 @@ import {
   enforceThinkingTemperature,
   disableThinkingIfToolChoiceForced,
   enforceCacheControlLimit,
-  ensureCacheControlOnLastUserMessage,
 } from "./claudeCodeConstraints.ts";
 import { obfuscateInBody } from "./claudeCodeObfuscation.ts";
 
@@ -19,7 +18,7 @@ export const CLAUDE_CODE_COMPATIBLE_DEFAULT_MODELS_PATH = "/models";
 export const CLAUDE_CODE_COMPATIBLE_DEFAULT_MAX_TOKENS = 8092;
 export const CLAUDE_CODE_COMPATIBLE_ANTHROPIC_VERSION = "2023-06-01";
 export const CLAUDE_CODE_COMPATIBLE_ANTHROPIC_BETA =
-  "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,context-management-2025-06-27,prompt-caching-scope-2026-01-05,effort-2025-11-24,fast-mode-2025-04-01,redact-thinking-2025-06-20,token-efficient-tools-2025-02-19";
+  "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,context-management-2025-06-27,prompt-caching-scope-2026-01-05,effort-2025-11-24,token-efficient-tools-2025-02-19";
 export const CLAUDE_CODE_COMPATIBLE_VERSION = "2.1.87";
 export const CLAUDE_CODE_COMPATIBLE_USER_AGENT = `claude-cli/${CLAUDE_CODE_COMPATIBLE_VERSION} (external, cli)`;
 /**
@@ -259,11 +258,10 @@ export function buildClaudeCodeCompatibleRequest({
  * 2. Remap tool names to TitleCase
  * 3. Enforce thinking temperature constraint (temp=1)
  * 4. Disable thinking when tool_choice forces a specific tool
- * 5. Enforce 4-block cache_control limit
- * 6. Auto-inject cache_control on last user message
- * 7. Obfuscate sensitive words in user messages
- * 8. Serialize with CCH placeholder
- * 9. Sign body with xxHash64 CCH attestation
+ * 5. Enforce 4-block cache_control limit when markers are already present
+ * 6. Obfuscate sensitive words in user messages
+ * 7. Serialize with CCH placeholder
+ * 8. Sign body with xxHash64 CCH attestation
  *
  * Returns { bodyString, headers } ready to send upstream.
  */
@@ -282,19 +280,18 @@ export async function buildAndSignClaudeCodeRequest(
   enforceThinkingTemperature(body);
   disableThinkingIfToolChoiceForced(body);
 
-  // Step 5-6: Cache control
+  // Step 5: Cache control
   enforceCacheControlLimit(body);
-  ensureCacheControlOnLastUserMessage(body);
 
-  // Step 7: Obfuscation (optional, per-provider setting)
+  // Step 6: Obfuscation (optional, per-provider setting)
   if (enableObfuscation) {
     obfuscateInBody(body);
   }
 
-  // Step 8: Serialize with CCH placeholder
+  // Step 7: Serialize with CCH placeholder
   const serialized = JSON.stringify(body);
 
-  // Step 9: Sign with xxHash64
+  // Step 8: Sign with xxHash64
   const bodyString = await signRequestBody(serialized);
 
   // Build headers
@@ -498,7 +495,6 @@ function buildClaudeCodeCompatibleSystemBlocks({
     {
       type: "text",
       text: billingHeader,
-      cache_control: { type: "ephemeral" },
     },
     {
       type: "text",

--- a/src/app/(dashboard)/dashboard/settings/components/RoutingTab.tsx
+++ b/src/app/(dashboard)/dashboard/settings/components/RoutingTab.tsx
@@ -165,7 +165,7 @@ export default function RoutingTab() {
           <div>
             <h3 className="text-lg font-semibold">Client Cache Control</h3>
             <p className="text-sm text-text-muted">
-              Configure how client-side cache_control headers are handled
+              Configure whether OmniRoute preserves client-provided cache_control markers
             </p>
           </div>
         </div>
@@ -175,17 +175,17 @@ export default function RoutingTab() {
             {
               value: "auto",
               label: "Auto (Recommended)",
-              desc: "Preserve cache_control for native Claude-compatible flows with deterministic routing; CC-compatible bridges use OmniRoute-managed markers",
+              desc: "For deterministic Claude-compatible flows, preserve client-provided cache_control as-is. If the request has no cache_control, OmniRoute does not inject any bridge-owned markers for CC-compatible third-party proxy compatibility.",
             },
             {
               value: "always",
               label: "Always Preserve",
-              desc: "Always forward client cache_control headers to upstream providers",
+              desc: "Always forward client-provided cache_control headers to upstream providers as-is.",
             },
             {
               value: "never",
               label: "Never Preserve",
-              desc: "Always remove client cache_control headers, let OmniRoute manage caching",
+              desc: "Always remove client cache_control headers and let OmniRoute manage caching where native provider flows support it.",
             },
           ].map((option) => (
             <button

--- a/tests/unit/cc-compatible-provider.test.mjs
+++ b/tests/unit/cc-compatible-provider.test.mjs
@@ -109,6 +109,7 @@ test("buildClaudeCodeCompatibleRequest keeps prior role history while dropping t
   assert.equal(payload.messages[2].content.at(-1).cache_control, undefined);
   assert.equal(payload.system.length, 4);
   assert.equal(payload.system.at(-1).text, "sys");
+  assert.equal(payload.system[0].cache_control, undefined);
   assert.equal(payload.system[1].cache_control, undefined);
   assert.equal(payload.system[2].cache_control, undefined);
   assert.equal(payload.system[3].cache_control, undefined);
@@ -177,6 +178,7 @@ test("buildClaudeCodeCompatibleRequest preserves Claude cache markers when reque
     preserveCacheControl: true,
   });
 
+  assert.equal(payload.system[0].cache_control, undefined);
   assert.deepEqual(payload.system.at(-1).cache_control, { type: "ephemeral", ttl: "5m" });
   assert.deepEqual(payload.messages[0].content[0].cache_control, { type: "ephemeral" });
   assert.deepEqual(payload.messages[1].content[0].cache_control, {
@@ -228,6 +230,7 @@ test("buildClaudeCodeCompatibleRequest does not supplement missing Claude cache 
     preserveCacheControl: true,
   });
 
+  assert.equal(payload.system[0].cache_control, undefined);
   assert.equal(payload.messages[0].content[0].cache_control, undefined);
   assert.equal(payload.messages[1].content[0].cache_control, undefined);
   assert.equal(payload.messages[2].content[0].cache_control, undefined);
@@ -257,6 +260,7 @@ test("buildClaudeCodeCompatibleRequest keeps built-in system blocks untagged whe
     preserveCacheControl: true,
   });
 
+  assert.equal(payload.system[0].cache_control, undefined);
   assert.equal(payload.system[1].cache_control, undefined);
   assert.equal(payload.system[2].cache_control, undefined);
   assert.deepEqual(payload.system[3].cache_control, { type: "ephemeral" });
@@ -287,6 +291,7 @@ test("buildClaudeCodeCompatibleRequest does not add cache markers in non-preserv
     preserveCacheControl: false,
   });
 
+  assert.equal(payload.system[0].cache_control, undefined);
   assert.equal(payload.system[1].cache_control, undefined);
   assert.equal(payload.system[2].cache_control, undefined);
   assert.equal(payload.system[3].cache_control, undefined);
@@ -520,15 +525,7 @@ test("handleChatCore respects non-streaming upstream requests for CC compatible 
   assert.equal(calls.length, 1);
   assert.equal(calls[0].headers.Accept, "application/json");
   assert.equal(calls[0].body.stream, undefined);
-  // PR #1188: billing header system block carries cache_control: ephemeral for
-  // proper billing attribution. Only user-facing message blocks should be free of
-  // auto-injected cache markers (non-preserve mode).
-  assert.equal(
-    calls[0].body.messages.some((message) =>
-      message.content.some((block) => block.cache_control !== undefined)
-    ),
-    false
-  );
+  assert.equal(JSON.stringify(calls[0].body).includes('"cache_control"'), false);
 
   const payload = await result.response.json();
   assert.equal(payload.choices[0].message.content, "Hello from CC");
@@ -640,6 +637,7 @@ test("handleChatCore preserves client cache markers for Claude Code requests to 
 
   assert.equal(result.success, true);
   assert.equal(calls.length, 1);
+  assert.equal(calls[0].body.system[0].cache_control, undefined);
   assert.deepEqual(calls[0].body.system.at(-1).cache_control, {
     type: "ephemeral",
     ttl: "5m",

--- a/tests/unit/claude-code-compatible-helpers.test.mjs
+++ b/tests/unit/claude-code-compatible-helpers.test.mjs
@@ -5,6 +5,7 @@ const {
   CLAUDE_CODE_COMPATIBLE_DEFAULT_CHAT_PATH,
   CLAUDE_CODE_COMPATIBLE_DEFAULT_MODELS_PATH,
   CLAUDE_CODE_COMPATIBLE_DEFAULT_MAX_TOKENS,
+  CLAUDE_CODE_COMPATIBLE_ANTHROPIC_BETA,
   CLAUDE_CODE_COMPATIBLE_STAINLESS_TIMEOUT_SECONDS,
   isClaudeCodeCompatibleProvider,
   stripAnthropicMessagesSuffix,
@@ -55,6 +56,13 @@ test("buildClaudeCodeCompatibleHeaders emits stream-aware auth headers and sessi
   assert.equal(jsonHeaders["X-Claude-Code-Session-Id"], undefined);
 });
 
+test("Claude Code compatible beta set stays conservative for third-party proxies", () => {
+  assert.ok(CLAUDE_CODE_COMPATIBLE_ANTHROPIC_BETA.includes("oauth-2025-04-20"));
+  assert.ok(CLAUDE_CODE_COMPATIBLE_ANTHROPIC_BETA.includes("token-efficient-tools-2025-02-19"));
+  assert.equal(CLAUDE_CODE_COMPATIBLE_ANTHROPIC_BETA.includes("fast-mode-2025-04-01"), false);
+  assert.equal(CLAUDE_CODE_COMPATIBLE_ANTHROPIC_BETA.includes("redact-thinking-2025-06-20"), false);
+});
+
 test("resolveClaudeCodeCompatibleSessionId prefers explicit session headers and generates a fallback id", () => {
   const headers = new Headers({
     "x-session-id": "legacy-session",
@@ -81,6 +89,7 @@ test("buildClaudeCodeCompatibleValidationPayload produces the expected smoke-tes
     content: [{ type: "text", text: "ok" }],
   });
   assert.equal(payload.tools.length, 0);
+  assert.equal(payload.system[0].cache_control, undefined);
   assert.ok(JSON.parse(payload.metadata.user_id).session_id);
   assert.ok(payload.system.some((block) => String(block.text).includes(process.cwd())));
   assert.ok(CLAUDE_CODE_COMPATIBLE_DEFAULT_MAX_TOKENS > payload.max_tokens);

--- a/tests/unit/claude-code-compatible-request.test.mjs
+++ b/tests/unit/claude-code-compatible-request.test.mjs
@@ -170,9 +170,11 @@ test("buildClaudeCodeCompatibleRequest covers Claude-native bodies and cache-con
   assert.equal(stripped.stream, true);
   assert.equal(JSON.parse(stripped.metadata.user_id).session_id, "explicit-session");
   assert.equal(stripped.messages.at(-1).role, "user");
+  assert.equal(stripped.system[0].cache_control, undefined);
   assert.equal(stripped.messages[0].content[0].cache_control, undefined);
   assert.equal(stripped.system.at(-1).cache_control, undefined);
   assert.equal(stripped.tools[0].cache_control, undefined);
+  assert.equal(preserved.system[0].cache_control, undefined);
   assert.equal(preserved.messages[0].content[0].cache_control.type, "ephemeral");
   assert.equal(preserved.system.at(-1).cache_control.type, "ephemeral");
   assert.equal(preserved.tools[0].cache_control.type, "ephemeral");


### PR DESCRIPTION
## Summary

- trim the default `anthropic-beta` set used by `anthropic-compatible-cc-*` to a conservative subset that stays compatible with third-party Claude Code reverse proxies
- stop injecting bridge-owned `cache_control` markers into CC-compatible requests so `Client Cache Control = Auto` remains pure passthrough: preserve client markers when present, send none when absent
- update the settings copy and README to document the compatibility-focused behavior

## Root cause

A regression in the Claude Code parity work made the CC-compatible bridge advertise beta capabilities that some third-party Claude Code reverse proxies reject, specifically `fast-mode-2025-04-01` and `redact-thinking-2025-06-20`.

The same parity work also started tagging the billing-header system block with `cache_control`, which changed `Auto` from passthrough into marker injection for CC-compatible requests. That reduced compatibility with reverse proxies that expect Claude Code style cache markers to be client-owned only.

## What changed

- removed the incompatible beta flags from `CLAUDE_CODE_COMPATIBLE_ANTHROPIC_BETA` while keeping the stable Claude Code / OAuth / prompt-caching flags
- removed the auto-added billing-header `cache_control` marker from the CC-compatible request builder
- kept runtime cache-control helpers out of the CC-compatible bridge path so `Auto` does not synthesize new markers
- updated unit tests to lock the new beta set and the no-injection cache behavior
- clarified the dashboard and README wording around `Client Cache Control` and third-party CC-compatible proxy compatibility

## Validation

- `node --import tsx/esm --test tests/unit/claude-code-compatible-helpers.test.mjs tests/unit/claude-code-compatible-request.test.mjs tests/unit/cc-compatible-provider.test.mjs`
- `git push -u fork coder/fix-cc-compatible-beta-cache-control` (pre-push hook ran the full unit test suite: 2826 passing, 0 failing)
