### PR TITLE
feat(bailian-quota): add Alibaba Coding Plan quota monitoring

### DIFF
--- a/open-sse/services/bailianQuotaFetcher.ts
+++ b/open-sse/services/bailianQuotaFetcher.ts
@@ -1,0 +1,307 @@
+/**
+ * bailianQuotaFetcher.ts — Alibaba Coding Plan (Bailian) Triple-Window Quota Fetcher
+ *
+ * Implements QuotaFetcher for the bailian-coding-plan provider (quotaPreflight.ts + quotaMonitor.ts).
+ * This fetcher is specific to the Alibaba Coding Plan quota API.
+ *
+ * Bailian Coding Plan has THREE independent quota windows:
+ *   - 5h:       short-term rate limit, resets every 5 hours
+ *   - weekly:   weekly limit, resets every week
+ *   - monthly:  monthly billing limit
+ *
+ * We return percentUsed = max(5h%, weekly%, monthly%) so the system switches accounts when
+ * ANY window approaches exhaustion (95% threshold).
+ *
+ * [Oracle CONDITIONAL] consoleApiKey is bailian-coding-plan specific. Do NOT reuse for other providers.
+ *
+ * Cache: in-memory TTL (60s) to avoid hammering the usage API on every request.
+ *
+ * Registration: call registerBailianCodingPlanQuotaFetcher() once at server startup.
+ */
+
+import { registerQuotaFetcher, type QuotaInfo } from "./quotaPreflight.ts";
+import { registerMonitorFetcher } from "./quotaMonitor.ts";
+
+// Bailian quota hosts (international / china fallback)
+const BAILIAN_QUOTA_HOSTS = {
+  international: "https://modelstudio.console.alibabacloud.com",
+  china: "https://bailian.console.aliyun.com",
+} as const;
+
+const BAILIAN_QUOTA_PATH =
+  "/data/api.json?action=zeldaEasy.broadscope-bailian.codingPlan.queryCodingPlanInstanceInfoV2&product=broadscope-bailian&api=queryCodingPlanInstanceInfoV2";
+
+// Cache TTL — short enough to be reactive, long enough to avoid rate limits
+const CACHE_TTL_MS = 60_000; // 60 seconds
+
+// Triple-window quota info (richer than QuotaInfo — includes all 3 windows)
+// [Oracle CONDITIONAL] bailian-coding-plan only — do not reuse for other providers
+export interface BailianTripleWindowQuota extends QuotaInfo {
+  window5h: { percentUsed: number; resetAt: string | null };
+  windowWeekly: { percentUsed: number; resetAt: string | null };
+  windowMonthly: { percentUsed: number; resetAt: string | null };
+}
+
+interface CacheEntry {
+  quota: BailianTripleWindowQuota;
+  fetchedAt: number;
+}
+
+// In-memory cache: connectionId → { quota, fetchedAt }
+const quotaCache = new Map<string, CacheEntry>();
+
+// Auto-cleanup stale entries every 5 minutes
+const _cacheCleanup = setInterval(() => {
+  const now = Date.now();
+  for (const [key, entry] of quotaCache) {
+    if (now - entry.fetchedAt > CACHE_TTL_MS * 5) {
+      quotaCache.delete(key);
+    }
+  }
+}, 5 * 60_000);
+
+if (typeof _cacheCleanup === "object" && "unref" in _cacheCleanup) {
+  (_cacheCleanup as { unref?: () => void }).unref?.();
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function toNumber(value: unknown, fallback = 0): number {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const parsed = parseFloat(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return fallback;
+}
+
+function toRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function getAuthKey(
+  providerSpecificData: Record<string, unknown> | undefined,
+  apiKey: string
+): string {
+  // [Oracle CONDITIONAL] consoleApiKey is bailian-coding-plan specific only
+  const consoleKey = providerSpecificData?.consoleApiKey;
+  if (typeof consoleKey === "string" && consoleKey.trim().length > 0) {
+    return consoleKey;
+  }
+  return apiKey;
+}
+
+function getHost(): string {
+  return process.env.ALIBABA_CODING_PLAN_HOST || BAILIAN_QUOTA_HOSTS.international;
+}
+
+function getQuotaUrl(): string {
+  return process.env.ALIBABA_CODING_PLAN_QUOTA_URL || `${getHost()}${BAILIAN_QUOTA_PATH}`;
+}
+
+function buildHeaders(authKey: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${authKey}`,
+    "x-api-key": authKey,
+    "X-DashScope-API-Key": authKey,
+    "Content-Type": "application/json",
+    Accept: "application/json",
+  };
+}
+
+// ─── Response Parser ─────────────────────────────────────────────────────────
+
+function parseBailianQuotaResponse(data: unknown): BailianTripleWindowQuota | null {
+  const obj = toRecord(data);
+
+  if (obj["code"] === "ConsoleNeedLogin") {
+    // Caller will handle fallback — return null here to signal no usable data
+    return null;
+  }
+
+  if (obj["code"] !== "Success" && obj["code"] !== "200") {
+    return null;
+  }
+
+  const dataObj = toRecord(obj["data"]);
+  const instanceInfos = dataObj["codingPlanInstanceInfos"];
+
+  if (!Array.isArray(instanceInfos) || instanceInfos.length === 0) {
+    return null;
+  }
+
+  const instance = toRecord(instanceInfos[0]);
+  const quotaInfo = toRecord(instance["codingPlanQuotaInfo"]);
+
+  if (Object.keys(quotaInfo).length === 0) {
+    return null;
+  }
+
+  // Parse 5h window
+  const used5h = toNumber(quotaInfo["per5HourUsedQuota"]);
+  const total5h = toNumber(quotaInfo["per5HourTotalQuota"]);
+  const resetAt5h = toNumber(quotaInfo["per5HourQuotaNextRefreshTime"]);
+  const pct5h = total5h > 0 ? used5h / total5h : 0;
+
+  // Parse weekly window
+  const usedWeekly = toNumber(quotaInfo["perWeekUsedQuota"]);
+  const totalWeekly = toNumber(quotaInfo["perWeekTotalQuota"]);
+  const resetAtWeekly = toNumber(quotaInfo["perWeekQuotaNextRefreshTime"]);
+  const pctWeekly = totalWeekly > 0 ? usedWeekly / totalWeekly : 0;
+
+  // Parse monthly window
+  const usedMonthly = toNumber(quotaInfo["perBillMonthUsedQuota"]);
+  const totalMonthly = toNumber(quotaInfo["perBillMonthTotalQuota"]);
+  const resetAtMonthly = toNumber(quotaInfo["perBillMonthQuotaNextRefreshTime"]);
+  const pctMonthly = totalMonthly > 0 ? usedMonthly / totalMonthly : 0;
+
+  // Most restrictive window = highest percentUsed
+  const worstPercentUsed = Math.max(pct5h, pctWeekly, pctMonthly);
+
+  const window5h = {
+    percentUsed: pct5h,
+    resetAt: resetAt5h > 0 ? new Date(resetAt5h * 1000).toISOString() : null,
+  };
+  const windowWeekly = {
+    percentUsed: pctWeekly,
+    resetAt: resetAtWeekly > 0 ? new Date(resetAtWeekly * 1000).toISOString() : null,
+  };
+  const windowMonthly = {
+    percentUsed: pctMonthly,
+    resetAt: resetAtMonthly > 0 ? new Date(resetAtMonthly * 1000).toISOString() : null,
+  };
+
+  // Dominant reset = reset time of the most restrictive window
+  const dominantResetAt =
+    worstPercentUsed === pct5h
+      ? window5h.resetAt
+      : worstPercentUsed === pctWeekly
+        ? windowWeekly.resetAt
+        : windowMonthly.resetAt;
+
+  return {
+    used: Math.round(worstPercentUsed * 100),
+    total: 100,
+    percentUsed: worstPercentUsed,
+    resetAt: dominantResetAt,
+    window5h,
+    windowWeekly,
+    windowMonthly,
+  };
+}
+
+// ─── Core Fetcher ────────────────────────────────────────────────────────────
+
+/**
+ * Fetch current quota for a Bailian Coding Plan connection.
+ * Returns percentUsed = max(5h%, weekly%, monthly%) — worst-case across all 3 windows.
+ *
+ * @param connectionId - Connection ID from the DB (used to look up credentials)
+ * @param connection - Optional connection object with apiKey / providerSpecificData
+ * @returns BailianTripleWindowQuota or null if fetch fails
+ */
+export async function fetchBailianQuota(
+  connectionId: string,
+  connection?: Record<string, unknown>
+): Promise<QuotaInfo | null> {
+  // Check cache first
+  const cached = quotaCache.get(connectionId);
+  if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
+    return cached.quota;
+  }
+
+  // Extract credentials from connection snapshot
+  const providerSpecificData =
+    connection?.providerSpecificData &&
+    typeof connection.providerSpecificData === "object" &&
+    !Array.isArray(connection.providerSpecificData)
+      ? (connection.providerSpecificData as Record<string, unknown>)
+      : undefined;
+
+  const apiKey =
+    typeof connection?.apiKey === "string" && connection.apiKey.trim().length > 0
+      ? connection.apiKey
+      : "";
+
+  const authKey = getAuthKey(providerSpecificData, apiKey);
+
+  if (!authKey) {
+    return null;
+  }
+
+  const headers = buildHeaders(authKey);
+
+  try {
+    const url = getQuotaUrl();
+    const response = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({}),
+      signal: AbortSignal.timeout(8_000),
+    });
+
+    const rawData = await response.json();
+    const obj = toRecord(rawData);
+
+    // ConsoleNeedLogin → retry with China host exactly once
+    if (obj["code"] === "ConsoleNeedLogin") {
+      try {
+        const chinaUrl = process.env.ALIBABA_CODING_PLAN_QUOTA_URL
+          ? url
+          : `${BAILIAN_QUOTA_HOSTS.china}${BAILIAN_QUOTA_PATH}`;
+
+        const retryResponse = await fetch(chinaUrl, {
+          method: "POST",
+          headers,
+          body: JSON.stringify({}),
+          signal: AbortSignal.timeout(8_000),
+        });
+
+        const retryData = await retryResponse.json();
+        const quota = parseBailianQuotaResponse(retryData);
+
+        if (quota) {
+          quotaCache.set(connectionId, { quota, fetchedAt: Date.now() });
+          return quota;
+        }
+
+        return null;
+      } catch {
+        // China host also failed — fail open
+        return null;
+      }
+    }
+
+    const quota = parseBailianQuotaResponse(rawData);
+
+    if (!quota) return null;
+
+    quotaCache.set(connectionId, { quota, fetchedAt: Date.now() });
+    return quota;
+  } catch {
+    // Network error, timeout, etc. — fail open
+    return null;
+  }
+}
+
+// ─── Invalidation ────────────────────────────────────────────────────────────
+
+/**
+ * Force-invalidate the cache for a connection (e.g., after receiving quota headers).
+ */
+export function invalidateBailianQuotaCache(connectionId: string): void {
+  quotaCache.delete(connectionId);
+}
+
+// ─── Registration ─────────────────────────────────────────────────────────────
+
+/**
+ * Register the Bailian quota fetcher with the preflight and monitor systems.
+ * Call this once at server startup (in chat.ts or app entry point).
+ */
+export function registerBailianCodingPlanQuotaFetcher(): void {
+  registerQuotaFetcher("bailian-coding-plan", fetchBailianQuota);
+  registerMonitorFetcher("bailian-coding-plan", fetchBailianQuota);
+}

--- a/open-sse/services/usage.ts
+++ b/open-sse/services/usage.ts
@@ -4,6 +4,7 @@
 
 import { PROVIDERS } from "../config/constants.ts";
 import { safePercentage } from "@/shared/utils/formatting";
+import { fetchBailianQuota, type BailianTripleWindowQuota } from "./bailianQuotaFetcher.ts";
 
 // GitHub API config
 const GITHUB_CONFIG = {
@@ -157,12 +158,50 @@ async function getGlmUsage(apiKey: string, providerSpecificData?: Record<string,
 }
 
 /**
+ * Bailian (Alibaba Coding Plan) Usage
+ * Fetches triple-window quota (5h, weekly, monthly) and returns worst-case.
+ */
+async function getBailianCodingPlanUsage(
+  connectionId: string,
+  apiKey: string,
+  providerSpecificData?: Record<string, unknown>
+) {
+  try {
+    const connection = { apiKey, providerSpecificData };
+    const quota = await fetchBailianQuota(connectionId, connection);
+
+    if (!quota) {
+      return { message: "Bailian Coding Plan connected. Unable to fetch quota." };
+    }
+
+    const bailianQuota = quota as BailianTripleWindowQuota;
+    const used = bailianQuota.used;
+    const total = bailianQuota.total;
+    const remaining = Math.max(0, total - used);
+    const remainingPercentage = Math.round(remaining);
+
+    return {
+      plan: "Alibaba Coding Plan",
+      used,
+      total,
+      remaining,
+      remainingPercentage,
+      resetAt: bailianQuota.resetAt,
+      unlimited: false,
+      displayName: "Alibaba Coding Plan",
+    };
+  } catch (error) {
+    return { message: `Bailian Coding Plan error: ${(error as Error).message}` };
+  }
+}
+
+/**
  * Get usage data for a provider connection
  * @param {Object} connection - Provider connection with accessToken
  * @returns {Promise<unknown>} Usage data with quotas
  */
 export async function getUsageForProvider(connection) {
-  const { provider, accessToken, apiKey, providerSpecificData, projectId } = connection;
+  const { id, provider, accessToken, apiKey, providerSpecificData, projectId } = connection;
 
   switch (provider) {
     case "github":
@@ -185,6 +224,8 @@ export async function getUsageForProvider(connection) {
       return await getIflowUsage(accessToken);
     case "glm":
       return await getGlmUsage(apiKey, providerSpecificData);
+    case "bailian-coding-plan":
+      return await getBailianCodingPlanUsage(id, apiKey, providerSpecificData);
     default:
       return { message: `Usage API not implemented for ${provider}` };
   }

--- a/src/app/api/providers/[id]/route.ts
+++ b/src/app/api/providers/[id]/route.ts
@@ -50,6 +50,9 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
     delete result.accessToken;
     delete result.refreshToken;
     delete result.idToken;
+    if (result.providerSpecificData) {
+      delete result.providerSpecificData.consoleApiKey;
+    }
 
     return NextResponse.json({ connection: result });
   } catch (error) {
@@ -153,6 +156,9 @@ export async function PUT(request: Request, { params }: { params: Promise<{ id: 
     delete result.accessToken;
     delete result.refreshToken;
     delete result.idToken;
+    if (result.providerSpecificData) {
+      delete result.providerSpecificData.consoleApiKey;
+    }
 
     // Auto sync to Cloud if enabled
     await syncToCloudIfEnabled();

--- a/src/app/api/providers/route.ts
+++ b/src/app/api/providers/route.ts
@@ -29,6 +29,12 @@ export async function GET() {
       accessToken: undefined,
       refreshToken: undefined,
       idToken: undefined,
+      providerSpecificData: c.providerSpecificData
+        ? {
+            ...c.providerSpecificData,
+            consoleApiKey: undefined,
+          }
+        : undefined,
     }));
 
     return NextResponse.json({ connections: safeConnections });
@@ -150,6 +156,9 @@ export async function POST(request: Request) {
     // Hide sensitive fields
     const result: Record<string, any> = { ...newConnection };
     delete result.apiKey;
+    if (result.providerSpecificData) {
+      delete result.providerSpecificData.consoleApiKey;
+    }
 
     // Auto sync to Cloud if enabled
     await syncToCloudIfEnabled();

--- a/src/shared/validation/schemas.ts
+++ b/src/shared/validation/schemas.ts
@@ -51,6 +51,27 @@ export const createProviderSchema = z.object({
           path: ["customUserAgent"],
         });
       }
+      // [Oracle CONDITIONAL] consoleApiKey는 bailian-coding-plan 전용 필드.
+      // 다른 프로바이더 공통 규약으로 재사용하지 않는다.
+      const consoleApiKey = data.consoleApiKey;
+      if (
+        consoleApiKey !== undefined &&
+        consoleApiKey !== null &&
+        typeof consoleApiKey !== "string"
+      ) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "providerSpecificData.consoleApiKey must be a string",
+          path: ["consoleApiKey"],
+        });
+      }
+      if (typeof consoleApiKey === "string" && consoleApiKey.length > 10000) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "providerSpecificData.consoleApiKey must be at most 10000 characters",
+          path: ["consoleApiKey"],
+        });
+      }
     }),
 });
 
@@ -1120,6 +1141,27 @@ export const updateProviderConnectionSchema = z
             code: z.ZodIssueCode.custom,
             message: "providerSpecificData.customUserAgent must be a string up to 500 chars",
             path: ["customUserAgent"],
+          });
+        }
+        // [Oracle CONDITIONAL] consoleApiKey는 bailian-coding-plan 전용 필드.
+        // 다른 프로바이더 공통 규약으로 재사용하지 않는다.
+        const consoleApiKey = data.consoleApiKey;
+        if (
+          consoleApiKey !== undefined &&
+          consoleApiKey !== null &&
+          typeof consoleApiKey !== "string"
+        ) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: "providerSpecificData.consoleApiKey must be a string",
+            path: ["consoleApiKey"],
+          });
+        }
+        if (typeof consoleApiKey === "string" && consoleApiKey.length > 10000) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: "providerSpecificData.consoleApiKey must be at most 10000 characters",
+            path: ["consoleApiKey"],
           });
         }
       }),

--- a/src/sse/handlers/chat.ts
+++ b/src/sse/handlers/chat.ts
@@ -65,11 +65,14 @@ import {
   registerCodexConnection,
   registerCodexQuotaFetcher,
 } from "@omniroute/open-sse/services/codexQuotaFetcher.ts";
+import { registerBailianCodingPlanQuotaFetcher } from "@omniroute/open-sse/services/bailianQuotaFetcher.ts";
 
-// Register Codex quota fetcher at module load (once per server start).
-// This hooks into the quotaPreflight + quotaMonitor systems so that combos
-// can proactively switch accounts before the 5h or 7d quota is exhausted.
 registerCodexQuotaFetcher();
+
+// Register Bailian Coding Plan quota fetcher at module load (once per server start).
+// This hooks into the quotaPreflight + quotaMonitor systems so that combos
+// can proactively switch accounts before quota is exhausted.
+registerBailianCodingPlanQuotaFetcher();
 
 /**
  * Handle chat completion request

--- a/tests/unit/bailian-quota-fetcher.test.mjs
+++ b/tests/unit/bailian-quota-fetcher.test.mjs
@@ -1,0 +1,577 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  fetchBailianQuota,
+  invalidateBailianQuotaCache,
+  registerBailianCodingPlanQuotaFetcher,
+} from "../../open-sse/services/bailianQuotaFetcher.ts";
+import { preflightQuota } from "../../open-sse/services/quotaPreflight.ts";
+import {
+  clearQuotaMonitors,
+  getActiveMonitorCount,
+  startQuotaMonitor,
+  stopQuotaMonitor,
+} from "../../open-sse/services/quotaMonitor.ts";
+import { clearSessions, touchSession } from "../../open-sse/services/sessionManager.ts";
+
+const originalFetch = globalThis.fetch;
+
+test.afterEach(() => {
+  globalThis.fetch = originalFetch;
+  clearQuotaMonitors();
+  clearSessions();
+});
+
+test("fetchBailianQuota returns null when no registered credentials exist", async () => {
+  const quota = await fetchBailianQuota(`missing-${Date.now()}`);
+  assert.equal(quota, null);
+});
+
+test("fetchBailianQuota uses apiKey when consoleApiKey is absent", async () => {
+  const connectionId = `bailian-inline-${Date.now()}`;
+  const calls = [];
+
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url, init });
+    return new Response(
+      JSON.stringify({
+        code: "Success",
+        data: {
+          codingPlanInstanceInfos: [
+            {
+              planName: "Qwen3 Coder Next",
+              codingPlanQuotaInfo: {
+                per5HourUsedQuota: 50,
+                per5HourTotalQuota: 100,
+                per5HourQuotaNextRefreshTime: 1718304000,
+                perWeekUsedQuota: 30,
+                perWeekTotalQuota: 100,
+                perWeekQuotaNextRefreshTime: 1718563200,
+                perBillMonthUsedQuota: 20,
+                perBillMonthTotalQuota: 100,
+                perBillMonthQuotaNextRefreshTime: 1719772800,
+              },
+            },
+          ],
+        },
+      }),
+      {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }
+    );
+  };
+
+  const quota = await fetchBailianQuota(connectionId, {
+    apiKey: "test-api-key",
+  });
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].init.headers["Authorization"], "Bearer test-api-key");
+  assert.equal(quota?.percentUsed, 0.5);
+
+  invalidateBailianQuotaCache(connectionId);
+});
+
+test("fetchBailianQuota uses apiKey when consoleApiKey is empty string", async () => {
+  const connectionId = `bailian-empty-console-${Date.now()}`;
+  const calls = [];
+
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url, init });
+    return new Response(
+      JSON.stringify({
+        code: "Success",
+        data: {
+          codingPlanInstanceInfos: [
+            {
+              planName: "Qwen3 Coder Next",
+              codingPlanQuotaInfo: {
+                per5HourUsedQuota: 40,
+                per5HourTotalQuota: 100,
+                per5HourQuotaNextRefreshTime: 1718304000,
+                perWeekUsedQuota: 60,
+                perWeekTotalQuota: 100,
+                perWeekQuotaNextRefreshTime: 1718563200,
+                perBillMonthUsedQuota: 25,
+                perBillMonthTotalQuota: 100,
+                perBillMonthQuotaNextRefreshTime: 1719772800,
+              },
+            },
+          ],
+        },
+      }),
+      {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }
+    );
+  };
+
+  const quota = await fetchBailianQuota(connectionId, {
+    apiKey: "fallback-key",
+    providerSpecificData: {
+      consoleApiKey: "",
+    },
+  });
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].init.headers["Authorization"], "Bearer fallback-key");
+  assert.equal(quota?.percentUsed, 0.6);
+
+  invalidateBailianQuotaCache(connectionId);
+});
+
+test("fetchBailianQuota prefers consoleApiKey when present", async () => {
+  const connectionId = `bailian-console-key-${Date.now()}`;
+  const calls = [];
+
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url, init });
+    return new Response(
+      JSON.stringify({
+        code: "Success",
+        data: {
+          codingPlanInstanceInfos: [
+            {
+              planName: "Qwen3 Coder Next",
+              codingPlanQuotaInfo: {
+                per5HourUsedQuota: 70,
+                per5HourTotalQuota: 100,
+                per5HourQuotaNextRefreshTime: 1718304000,
+                perWeekUsedQuota: 50,
+                perWeekTotalQuota: 100,
+                perWeekQuotaNextRefreshTime: 1718563200,
+                perBillMonthUsedQuota: 30,
+                perBillMonthTotalQuota: 100,
+                perBillMonthQuotaNextRefreshTime: 1719772800,
+              },
+            },
+          ],
+        },
+      }),
+      {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }
+    );
+  };
+
+  const quota = await fetchBailianQuota(connectionId, {
+    apiKey: "regular-key",
+    providerSpecificData: {
+      consoleApiKey: "ck-test",
+    },
+  });
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].init.headers["Authorization"], "Bearer ck-test");
+  assert.equal(quota?.percentUsed, 0.7);
+
+  invalidateBailianQuotaCache(connectionId);
+});
+
+test("fetchBailianQuota parses triple-window and returns percentUsed = max(5h%, weekly%, monthly%)", async () => {
+  const connectionId = `bailian-triple-${Date.now()}`;
+  const calls = [];
+
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url, init });
+    return new Response(
+      JSON.stringify({
+        code: "Success",
+        data: {
+          codingPlanInstanceInfos: [
+            {
+              planName: "Qwen3 Coder Next",
+              codingPlanQuotaInfo: {
+                per5HourUsedQuota: 60,
+                per5HourTotalQuota: 100,
+                per5HourQuotaNextRefreshTime: 1718304000,
+                perWeekUsedQuota: 80,
+                perWeekTotalQuota: 100,
+                perWeekQuotaNextRefreshTime: 1718563200,
+                perBillMonthUsedQuota: 40,
+                perBillMonthTotalQuota: 100,
+                perBillMonthQuotaNextRefreshTime: 1719772800,
+              },
+            },
+          ],
+        },
+      }),
+      {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }
+    );
+  };
+
+  const quota = await fetchBailianQuota(connectionId, {
+    apiKey: "test-key",
+  });
+
+  assert.equal(calls.length, 1);
+  assert.equal(quota?.percentUsed, 0.8);
+  assert.equal(quota?.window5h?.percentUsed, 0.6);
+  assert.equal(quota?.windowWeekly?.percentUsed, 0.8);
+  assert.equal(quota?.windowMonthly?.percentUsed, 0.4);
+
+  invalidateBailianQuotaCache(connectionId);
+});
+
+test("fetchBailianQuota retries with China host on ConsoleNeedLogin", async () => {
+  const connectionId = `bailian-retry-${Date.now()}`;
+  const calls = [];
+
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url, init });
+
+    if (calls.length === 1) {
+      return new Response(
+        JSON.stringify({
+          code: "ConsoleNeedLogin",
+          message: "Login required",
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }
+      );
+    }
+
+    return new Response(
+      JSON.stringify({
+        code: "Success",
+        data: {
+          codingPlanInstanceInfos: [
+            {
+              planName: "Qwen3 Coder Next",
+              codingPlanQuotaInfo: {
+                per5HourUsedQuota: 30,
+                per5HourTotalQuota: 100,
+                per5HourQuotaNextRefreshTime: 1718304000,
+                perWeekUsedQuota: 45,
+                perWeekTotalQuota: 100,
+                perWeekQuotaNextRefreshTime: 1718563200,
+                perBillMonthUsedQuota: 15,
+                perBillMonthTotalQuota: 100,
+                perBillMonthQuotaNextRefreshTime: 1719772800,
+              },
+            },
+          ],
+        },
+      }),
+      {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }
+    );
+  };
+
+  const quota = await fetchBailianQuota(connectionId, {
+    apiKey: "test-key",
+  });
+
+  assert.equal(calls.length, 2);
+  assert.ok(calls[0].url.includes("modelstudio.console.alibabacloud.com"));
+  assert.ok(calls[1].url.includes("bailian.console.aliyun.com"));
+  assert.equal(quota?.percentUsed, 0.45);
+
+  invalidateBailianQuotaCache(connectionId);
+});
+
+test("fetchBailianQuota does not retry more than once on ConsoleNeedLogin", async () => {
+  const connectionId = `bailian-no-retry-${Date.now()}`;
+  const calls = [];
+
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url, init });
+    return new Response(
+      JSON.stringify({
+        code: "ConsoleNeedLogin",
+        message: "Login required",
+      }),
+      {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }
+    );
+  };
+
+  const quota = await fetchBailianQuota(connectionId, {
+    apiKey: "test-key",
+  });
+
+  assert.equal(calls.length, 2);
+  assert.equal(quota, null);
+
+  invalidateBailianQuotaCache(connectionId);
+});
+
+test("fetchBailianQuota returns null on network error", async () => {
+  const connectionId = `bailian-network-error-${Date.now()}`;
+
+  globalThis.fetch = async () => {
+    throw new Error("Network error");
+  };
+
+  const quota = await fetchBailianQuota(connectionId, {
+    apiKey: "test-key",
+  });
+
+  assert.equal(quota, null);
+});
+
+test("fetchBailianQuota returns null when response has no codingPlanQuotaInfo", async () => {
+  const connectionId = `bailian-empty-${Date.now()}`;
+
+  globalThis.fetch = async () => {
+    return new Response(
+      JSON.stringify({
+        code: "Success",
+        data: {
+          codingPlanInstanceInfos: [
+            {
+              planName: "Qwen3 Coder Next",
+            },
+          ],
+        },
+      }),
+      {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }
+    );
+  };
+
+  const quota = await fetchBailianQuota(connectionId, {
+    apiKey: "test-key",
+  });
+
+  assert.equal(quota, null);
+});
+test("fetchBailianQuota caches results within TTL", async () => {
+  const connectionId = `bailian-cache-${Date.now()}`;
+  const calls = [];
+
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url, init });
+    return new Response(
+      JSON.stringify({
+        code: "Success",
+        data: {
+          codingPlanInstanceInfos: [
+            {
+              planName: "Qwen3 Coder Next",
+              codingPlanQuotaInfo: {
+                per5HourUsedQuota: 25,
+                per5HourTotalQuota: 100,
+                per5HourQuotaNextRefreshTime: 1718304000,
+                perWeekUsedQuota: 35,
+                perWeekTotalQuota: 100,
+                perWeekQuotaNextRefreshTime: 1718563200,
+                perBillMonthUsedQuota: 10,
+                perBillMonthTotalQuota: 100,
+                perBillMonthQuotaNextRefreshTime: 1719772800,
+              },
+            },
+          ],
+        },
+      }),
+      {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }
+    );
+  };
+
+  const first = await fetchBailianQuota(connectionId, {
+    apiKey: "test-key",
+  });
+
+  const second = await fetchBailianQuota(connectionId, {
+    apiKey: "test-key",
+  });
+
+  assert.equal(calls.length, 1);
+  assert.deepEqual(first, second);
+
+  invalidateBailianQuotaCache(connectionId);
+
+  const third = await fetchBailianQuota(connectionId, {
+    apiKey: "test-key",
+  });
+
+  assert.equal(calls.length, 2);
+});
+
+test("ALIBABA_CODING_PLAN_HOST env var overrides default host", async () => {
+  const connectionId = `bailian-env-host-${Date.now()}`;
+  const calls = [];
+  const originalEnv = process.env.ALIBABA_CODING_PLAN_HOST;
+
+  process.env.ALIBABA_CODING_PLAN_HOST = "custom.bailian.aliyun.com";
+
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url, init });
+    return new Response(
+      JSON.stringify({
+        code: "Success",
+        data: {
+          codingPlanInstanceInfos: [
+            {
+              planName: "Qwen3 Coder Next",
+              codingPlanQuotaInfo: {
+                per5HourUsedQuota: 20,
+                per5HourTotalQuota: 100,
+                per5HourQuotaNextRefreshTime: 1718304000,
+                perWeekUsedQuota: 55,
+                perWeekTotalQuota: 100,
+                perWeekQuotaNextRefreshTime: 1718563200,
+                perBillMonthUsedQuota: 5,
+                perBillMonthTotalQuota: 100,
+                perBillMonthQuotaNextRefreshTime: 1719772800,
+              },
+            },
+          ],
+        },
+      }),
+      {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }
+    );
+  };
+
+  const quota = await fetchBailianQuota(connectionId, {
+    apiKey: "test-key",
+  });
+
+  assert.equal(calls.length, 1);
+  assert.ok(calls[0].url.includes("custom.bailian.aliyun.com"));
+  assert.equal(quota?.percentUsed, 0.55);
+
+  process.env.ALIBABA_CODING_PLAN_HOST = originalEnv;
+  invalidateBailianQuotaCache(connectionId);
+});
+
+test("ALIBABA_CODING_PLAN_QUOTA_URL env var overrides full URL", async () => {
+  const connectionId = `bailian-env-url-${Date.now()}`;
+  const calls = [];
+  const originalEnv = process.env.ALIBABA_CODING_PLAN_QUOTA_URL;
+
+  process.env.ALIBABA_CODING_PLAN_QUOTA_URL = "https://override.example.com/api/v1/quota";
+
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url, init });
+    return new Response(
+      JSON.stringify({
+        code: "Success",
+        data: {
+          codingPlanInstanceInfos: [
+            {
+              planName: "Qwen3 Coder Next",
+              codingPlanQuotaInfo: {
+                per5HourUsedQuota: 10,
+                per5HourTotalQuota: 100,
+                per5HourQuotaNextRefreshTime: 1718304000,
+                perWeekUsedQuota: 20,
+                perWeekTotalQuota: 100,
+                perWeekQuotaNextRefreshTime: 1718563200,
+                perBillMonthUsedQuota: 5,
+                perBillMonthTotalQuota: 100,
+                perBillMonthQuotaNextRefreshTime: 1719772800,
+              },
+            },
+          ],
+        },
+      }),
+      {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }
+    );
+  };
+
+  const quota = await fetchBailianQuota(connectionId, {
+    apiKey: "test-key",
+  });
+
+  assert.equal(calls.length, 1);
+  assert.ok(calls[0].url.includes("override.example.com"));
+  assert.equal(quota?.percentUsed, 0.2);
+
+  process.env.ALIBABA_CODING_PLAN_QUOTA_URL = originalEnv;
+  invalidateBailianQuotaCache(connectionId);
+});
+
+test("registerBailianCodingPlanQuotaFetcher exposes Bailian quota to preflight and monitor flows", async () => {
+  const connectionId = `bailian-preflight-${Date.now()}`;
+
+  registerBailianCodingPlanQuotaFetcher();
+
+  globalThis.fetch = async () =>
+    new Response(
+      JSON.stringify({
+        code: "Success",
+        data: {
+          codingPlanInstanceInfos: [
+            {
+              planName: "Qwen3 Coder Next",
+              codingPlanQuotaInfo: {
+                per5HourUsedQuota: 98,
+                per5HourTotalQuota: 100,
+                per5HourQuotaNextRefreshTime: 1718304000,
+                perWeekUsedQuota: 90,
+                perWeekTotalQuota: 100,
+                perWeekQuotaNextRefreshTime: 1718563200,
+                perBillMonthUsedQuota: 50,
+                perBillMonthTotalQuota: 100,
+                perBillMonthQuotaNextRefreshTime: 1719772800,
+              },
+            },
+          ],
+        },
+      }),
+      {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }
+    );
+
+  const preflight = await preflightQuota("bailian-coding-plan", connectionId, {
+    apiKey: "test-key",
+    providerSpecificData: { quotaPreflightEnabled: true },
+  });
+
+  touchSession("session-bailian", connectionId);
+  startQuotaMonitor("session-bailian", "bailian-coding-plan", connectionId, {
+    providerSpecificData: { quotaMonitorEnabled: true },
+  });
+
+  assert.equal(preflight.proceed, false);
+  assert.equal(preflight.reason, "quota_exhausted");
+  assert.equal(getActiveMonitorCount(), 1);
+
+  stopQuotaMonitor("session-bailian");
+  assert.equal(getActiveMonitorCount(), 0);
+});
+
+test("fetchBailianQuota returns null on malformed JSON response", async () => {
+  const connectionId = `bailian-malformed-json-${Date.now()}`;
+
+  globalThis.fetch = async () =>
+    new Response("not valid json{{{", {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+
+  const quota = await fetchBailianQuota(connectionId, {
+    apiKey: "test-key",
+  });
+
+  assert.equal(quota, null);
+
+  invalidateBailianQuotaCache(connectionId);
+});

--- a/tests/unit/bailian-schema-validation.test.mjs
+++ b/tests/unit/bailian-schema-validation.test.mjs
@@ -1,0 +1,120 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  createProviderSchema,
+  updateProviderConnectionSchema,
+} from "../../src/shared/validation/schemas.ts";
+
+test("createProviderSchema accepts valid provider without consoleApiKey", () => {
+  const result = createProviderSchema.safeParse({
+    provider: "bcp",
+    apiKey: "sk-test",
+    name: "test",
+  });
+  assert.equal(result.success, true, "Should accept valid provider without consoleApiKey");
+});
+
+test("createProviderSchema accepts valid provider with consoleApiKey", () => {
+  const result = createProviderSchema.safeParse({
+    provider: "bcp",
+    apiKey: "sk-test",
+    name: "test",
+    providerSpecificData: { consoleApiKey: "ck-valid" },
+  });
+  assert.equal(result.success, true, "Should accept valid provider with consoleApiKey");
+});
+
+test("createProviderSchema rejects non-string consoleApiKey", () => {
+  const result = createProviderSchema.safeParse({
+    provider: "bcp",
+    apiKey: "sk-test",
+    name: "test",
+    providerSpecificData: { consoleApiKey: 123 },
+  });
+  assert.equal(result.success, false, "Should reject non-string consoleApiKey");
+  if (!result.success) {
+    const hasConsoleApiKeyError = result.error.issues.some((issue) =>
+      issue.path.includes("consoleApiKey")
+    );
+    assert.equal(hasConsoleApiKeyError, true, "Error should target consoleApiKey path");
+  }
+});
+
+test("createProviderSchema accepts empty string consoleApiKey", () => {
+  const result = createProviderSchema.safeParse({
+    provider: "bcp",
+    apiKey: "sk-test",
+    name: "test",
+    providerSpecificData: { consoleApiKey: "" },
+  });
+  assert.equal(result.success, true, "Should accept empty string consoleApiKey");
+});
+
+test("createProviderSchema rejects consoleApiKey exceeding max length", () => {
+  const longConsoleApiKey = "x".repeat(10001);
+  const result = createProviderSchema.safeParse({
+    provider: "bcp",
+    apiKey: "sk-test",
+    name: "test",
+    providerSpecificData: { consoleApiKey: longConsoleApiKey },
+  });
+  assert.equal(result.success, false, "Should reject consoleApiKey exceeding max length");
+  if (!result.success) {
+    const hasConsoleApiKeyError = result.error.issues.some((issue) =>
+      issue.path.includes("consoleApiKey")
+    );
+    assert.equal(hasConsoleApiKeyError, true, "Error should target consoleApiKey path");
+  }
+});
+
+test("updateProviderConnectionSchema accepts valid provider without consoleApiKey", () => {
+  const result = updateProviderConnectionSchema.safeParse({
+    name: "test-provider",
+  });
+  assert.equal(result.success, true, "Should accept valid provider without consoleApiKey");
+});
+
+test("updateProviderConnectionSchema accepts valid provider with consoleApiKey", () => {
+  const result = updateProviderConnectionSchema.safeParse({
+    name: "test-provider",
+    providerSpecificData: { consoleApiKey: "ck-valid" },
+  });
+  assert.equal(result.success, true, "Should accept valid provider with consoleApiKey");
+});
+
+test("updateProviderConnectionSchema rejects non-string consoleApiKey", () => {
+  const result = updateProviderConnectionSchema.safeParse({
+    name: "test-provider",
+    providerSpecificData: { consoleApiKey: 123 },
+  });
+  assert.equal(result.success, false, "Should reject non-string consoleApiKey");
+  if (!result.success) {
+    const hasConsoleApiKeyError = result.error.issues.some((issue) =>
+      issue.path.includes("consoleApiKey")
+    );
+    assert.equal(hasConsoleApiKeyError, true, "Error should target consoleApiKey path");
+  }
+});
+
+test("updateProviderConnectionSchema accepts empty string consoleApiKey", () => {
+  const result = updateProviderConnectionSchema.safeParse({
+    name: "test-provider",
+    providerSpecificData: { consoleApiKey: "" },
+  });
+  assert.equal(result.success, true, "Should accept empty string consoleApiKey");
+});
+
+test("updateProviderConnectionSchema rejects consoleApiKey exceeding max length", () => {
+  const longConsoleApiKey = "x".repeat(10001);
+  const result = updateProviderConnectionSchema.safeParse({
+    name: "test-provider",
+    providerSpecificData: { consoleApiKey: longConsoleApiKey },
+  });
+  assert.equal(result.success, false, "Should reject consoleApiKey exceeding max length");
+  if (!result.success) {
+    const hasConsoleApiKeyError = result.error.issues.some((issue) =>
+      issue.path.includes("consoleApiKey")
+    );
+    assert.equal(hasConsoleApiKeyError, true, "Error should target consoleApiKey path");
+  }
+});

--- a/tests/unit/bailian-usage.test.mjs
+++ b/tests/unit/bailian-usage.test.mjs
@@ -1,0 +1,173 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { getUsageForProvider } from "../../open-sse/services/usage.ts";
+
+// Save original fetch
+const originalFetch = globalThis.fetch;
+
+test.afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+test("getUsageForProvider with bailian-coding-plan and consoleApiKey returns quota data", async () => {
+  // Mock Bailian API response
+  const mockBailianResponse = {
+    code: "Success",
+    data: {
+      codingPlanInstanceInfos: [
+        {
+          planName: "Qwen3 Coder Next",
+          codingPlanQuotaInfo: {
+            per5HourUsedQuota: 60,
+            per5HourTotalQuota: 100,
+            per5HourQuotaNextRefreshTime: 1718304000,
+            perWeekUsedQuota: 80,
+            perWeekTotalQuota: 100,
+            perWeekQuotaNextRefreshTime: 1718563200,
+            perBillMonthUsedQuota: 40,
+            perBillMonthTotalQuota: 100,
+            perBillMonthQuotaNextRefreshTime: 1719772800,
+          },
+        },
+      ],
+    },
+  };
+
+  globalThis.fetch = async (url, options) => {
+    return new Response(JSON.stringify(mockBailianResponse), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+
+  const result = await getUsageForProvider({
+    provider: "bailian-coding-plan",
+    apiKey: "sk-test",
+    providerSpecificData: { consoleApiKey: "ck-test" },
+  });
+
+  // Should NOT return "Usage API not implemented" message
+  assert.notStrictEqual(
+    result?.message,
+    "Usage API not implemented for bailian-coding-plan",
+    "Should have implemented bailian-coding-plan usage"
+  );
+
+  // Should return quota data with percentUsed
+  assert.ok(result, "Should return quota data");
+  assert.ok(result.used !== undefined, "Should have used property");
+  assert.ok(result.total !== undefined, "Should have total property");
+  assert.ok(result.remainingPercentage !== undefined, "Should have remainingPercentage");
+});
+
+test("getUsageForProvider with bailian-coding-plan and only apiKey falls back to apiKey", async () => {
+  // Mock Bailian API response
+  const mockBailianResponse = {
+    code: "Success",
+    data: {
+      codingPlanInstanceInfos: [
+        {
+          planName: "Qwen3 Coder Next",
+          codingPlanQuotaInfo: {
+            per5HourUsedQuota: 30,
+            per5HourTotalQuota: 100,
+            per5HourQuotaNextRefreshTime: 1718304000,
+            perWeekUsedQuota: 50,
+            perWeekTotalQuota: 100,
+            perWeekQuotaNextRefreshTime: 1718563200,
+            perBillMonthUsedQuota: 20,
+            perBillMonthTotalQuota: 100,
+            perBillMonthQuotaNextRefreshTime: 1719772800,
+          },
+        },
+      ],
+    },
+  };
+
+  let fetchCalledWith = null;
+  globalThis.fetch = async (url, options) => {
+    fetchCalledWith = options;
+    return new Response(JSON.stringify(mockBailianResponse), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+
+  const result = await getUsageForProvider({
+    provider: "bailian-coding-plan",
+    apiKey: "sk-test-fallback",
+    providerSpecificData: {},
+  });
+
+  // Should NOT return "Usage API not implemented" message
+  assert.notStrictEqual(
+    result?.message,
+    "Usage API not implemented for bailian-coding-plan",
+    "Should have implemented bailian-coding-plan usage with apiKey fallback"
+  );
+
+  assert.ok(result, "Should return quota data via apiKey fallback");
+
+  // Verify that apiKey was used as fallback (since no consoleApiKey provided)
+  if (fetchCalledWith) {
+    const authHeader = fetchCalledWith.headers?.Authorization || "";
+    assert.ok(
+      authHeader.includes("sk-test-fallback"),
+      "Should use apiKey when consoleApiKey is not provided"
+    );
+  }
+});
+
+test("getUsageForProvider with bailian-coding-plan returns quota with percentUsed from most restrictive window", async () => {
+  // Mock: 5h=60%, weekly=80%, monthly=40% → percentUsed should be 0.8 (80% = most restrictive)
+  const mockBailianResponse = {
+    code: "Success",
+    data: {
+      codingPlanInstanceInfos: [
+        {
+          planName: "Qwen3 Coder Next",
+          codingPlanQuotaInfo: {
+            per5HourUsedQuota: 60,
+            per5HourTotalQuota: 100,
+            per5HourQuotaNextRefreshTime: 1718304000,
+            perWeekUsedQuota: 80,
+            perWeekTotalQuota: 100,
+            perWeekQuotaNextRefreshTime: 1718563200,
+            perBillMonthUsedQuota: 40,
+            perBillMonthTotalQuota: 100,
+            perBillMonthQuotaNextRefreshTime: 1719772800,
+          },
+        },
+      ],
+    },
+  };
+
+  globalThis.fetch = async (url, options) => {
+    return new Response(JSON.stringify(mockBailianResponse), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+
+  const result = await getUsageForProvider({
+    provider: "bailian-coding-plan",
+    apiKey: "sk-test",
+    providerSpecificData: { consoleApiKey: "ck-test" },
+  });
+
+  // Should NOT return "Usage API not implemented" message
+  assert.notStrictEqual(
+    result?.message,
+    "Usage API not implemented for bailian-coding-plan",
+    "Should have implemented bailian-coding-plan usage"
+  );
+
+  // Should return percentUsed = 0.8 (80% from weekly, the most restrictive)
+  assert.ok(result, "Should return quota data");
+  const percentUsed = result.used / result.total;
+  assert.strictEqual(
+    percentUsed,
+    0.8,
+    "percentUsed should be 0.8 from most restrictive window (weekly 80%)"
+  );
+});


### PR DESCRIPTION
## Summary
- add a dedicated Bailian quota fetcher with triple-window parsing, ConsoleNeedLogin fallback, and quota monitor/preflight registration
- wire Alibaba Coding Plan quota usage into the existing usage flow and protect `consoleApiKey` by validating and redacting it from provider API responses
- add focused TDD coverage for fetcher behavior, usage integration, schema validation, malformed JSON handling, and cache behavior

## Verification
- node --import tsx/esm --test tests/unit/bailian-quota-fetcher.test.mjs
- node --import tsx/esm --test tests/unit/bailian-usage.test.mjs
- node --import tsx/esm --test tests/unit/bailian-schema-validation.test.mjs
- npm run typecheck:core
- npm run lint
- npm run test:all