### PR TITLE
fix(providers): update Xiaomi MiMo token-plan endpoints

### DIFF
--- a/open-sse/config/providerRegistry.ts
+++ b/open-sse/config/providerRegistry.ts
@@ -185,7 +185,7 @@ const CHAT_OPENAI_COMPAT_MODELS: Record<string, RegistryModel[]> = {
   codestral: buildModels(["codestral-2405", "codestral-latest"]),
   upstage: buildModels(["solar-pro", "solar-mini", "solar-docvision", "solar-embedding-1-large"]),
   maritalk: buildModels(["sabia-3", "sabia-3-small"]),
-  "xiaomi-mimo": buildModels(["MiMo-7B-RL", "MiMo-7B-SFT"]),
+  "xiaomi-mimo": buildModels(["mimo-v2-pro", "mimo-v2-omni", "mimo-v2-tts"]),
   "inference-net": buildModels([
     "meta-llama/Llama-3.3-70B-Instruct",
     "deepseek-ai/DeepSeek-R1",
@@ -1804,7 +1804,7 @@ export const REGISTRY: Record<string, RegistryEntry> = {
     alias: "mimo",
     format: "openai",
     executor: "default",
-    baseUrl: "https://api.xiaomi.com/v1/chat/completions",
+    baseUrl: "https://token-plan-sgp.xiaomimimo.com/v1",
     authType: "apikey",
     authHeader: "bearer",
     models: CHAT_OPENAI_COMPAT_MODELS["xiaomi-mimo"],

--- a/open-sse/executors/default.ts
+++ b/open-sse/executors/default.ts
@@ -33,6 +33,11 @@ function normalizeDatabricksChatUrl(baseUrl) {
   return `${normalized}/chat/completions`;
 }
 
+function normalizeXiaomiMimoChatUrl(baseUrl) {
+  const normalized = normalizeBaseUrl(baseUrl).replace(/\/chat\/completions$/, "");
+  return `${normalized}/chat/completions`;
+}
+
 function normalizeSnowflakeChatUrl(baseUrl) {
   const normalized = normalizeBaseUrl(baseUrl)
     .replace(/\/cortex\/inference:complete$/, "")
@@ -91,6 +96,10 @@ export class DefaultExecutor extends BaseExecutor {
       case "databricks": {
         const baseUrl = credentials?.providerSpecificData?.baseUrl || this.config.baseUrl;
         return normalizeDatabricksChatUrl(baseUrl);
+      }
+      case "xiaomi-mimo": {
+        const baseUrl = credentials?.providerSpecificData?.baseUrl || this.config.baseUrl;
+        return normalizeXiaomiMimoChatUrl(baseUrl);
       }
       case "snowflake": {
         const baseUrl = credentials?.providerSpecificData?.baseUrl || this.config.baseUrl;

--- a/src/app/(dashboard)/dashboard/providers/[id]/page.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.tsx
@@ -5079,7 +5079,7 @@ function getProviderBaseUrlHint(providerId?: string | null) {
     case "bailian-coding-plan":
       return "Optional: Custom base URL for bailian-coding-plan provider";
     case "xiaomi-mimo":
-      return "Optional: Xiaomi MiMo token-plan base URL. Examples: https://token-plan-ams.xiaomimimo.com/v1, https://token-plan-sgp.xiaomimimo.com/v1, https://token-plan-cn.xiaomimimo.com/v1";
+      return "Optional: Xiaomi MiMo token-plan base URL. Examples: https://token-plan-ams.xiaomimimo.com/v1, https://token-plan-sgp.xiaomimimo.com/v1, https://token-plan-cn.xiaomimimo.com/v1. The app will append /chat/completions.";
     case "heroku":
       return "Required: paste the Heroku Inference base URL. The app will append /v1/chat/completions.";
     case "databricks":

--- a/src/app/(dashboard)/dashboard/providers/[id]/page.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.tsx
@@ -5059,6 +5059,7 @@ ConnectionRow.propTypes = {
 
 const CONFIGURABLE_BASE_URL_PROVIDERS = new Set([
   "bailian-coding-plan",
+  "xiaomi-mimo",
   "heroku",
   "databricks",
   "snowflake",
@@ -5066,6 +5067,7 @@ const CONFIGURABLE_BASE_URL_PROVIDERS = new Set([
 
 const DEFAULT_PROVIDER_BASE_URLS: Record<string, string> = {
   "bailian-coding-plan": "https://coding-intl.dashscope.aliyuncs.com/apps/anthropic/v1",
+  "xiaomi-mimo": "https://token-plan-ams.xiaomimimo.com/v1",
 };
 
 function getProviderBaseUrlDefault(providerId?: string | null) {
@@ -5076,6 +5078,8 @@ function getProviderBaseUrlHint(providerId?: string | null) {
   switch (providerId) {
     case "bailian-coding-plan":
       return "Optional: Custom base URL for bailian-coding-plan provider";
+    case "xiaomi-mimo":
+      return "Optional: Xiaomi MiMo token-plan base URL. Examples: https://token-plan-ams.xiaomimimo.com/v1, https://token-plan-sgp.xiaomimimo.com/v1, https://token-plan-cn.xiaomimimo.com/v1";
     case "heroku":
       return "Required: paste the Heroku Inference base URL. The app will append /v1/chat/completions.";
     case "databricks":
@@ -5090,6 +5094,7 @@ function getProviderBaseUrlHint(providerId?: string | null) {
 function getProviderBaseUrlPlaceholder(providerId?: string | null) {
   switch (providerId) {
     case "bailian-coding-plan":
+    case "xiaomi-mimo":
       return getProviderBaseUrlDefault(providerId);
     case "heroku":
       return "https://us.inference.heroku.com";

--- a/tests/unit/xiaomi-mimo-provider.test.mjs
+++ b/tests/unit/xiaomi-mimo-provider.test.mjs
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { REGISTRY } from "../../open-sse/config/providerRegistry.ts";
+import { DefaultExecutor } from "../../open-sse/executors/default.ts";
 import {
   createProviderSchema,
   updateProviderConnectionSchema,
@@ -16,6 +17,28 @@ test("xiaomi-mimo registry uses current token-plan base URL and current MiMo V2 
   assert.deepEqual(
     entry.models.map((model) => model.id),
     ["mimo-v2-pro", "mimo-v2-omni", "mimo-v2-tts"]
+  );
+});
+
+test("xiaomi-mimo executor appends /chat/completions for regional base URLs", () => {
+  const executor = new DefaultExecutor("xiaomi-mimo");
+
+  assert.equal(
+    executor.buildUrl("mimo-v2-pro", true, 0, {
+      providerSpecificData: {
+        baseUrl: "https://token-plan-ams.xiaomimimo.com/v1",
+      },
+    }),
+    "https://token-plan-ams.xiaomimimo.com/v1/chat/completions"
+  );
+
+  assert.equal(
+    executor.buildUrl("mimo-v2-pro", true, 0, {
+      providerSpecificData: {
+        baseUrl: "https://token-plan-cn.xiaomimimo.com/v1/chat/completions",
+      },
+    }),
+    "https://token-plan-cn.xiaomimimo.com/v1/chat/completions"
   );
 });
 

--- a/tests/unit/xiaomi-mimo-provider.test.mjs
+++ b/tests/unit/xiaomi-mimo-provider.test.mjs
@@ -1,0 +1,55 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { REGISTRY } from "../../open-sse/config/providerRegistry.ts";
+import {
+  createProviderSchema,
+  updateProviderConnectionSchema,
+} from "../../src/shared/validation/schemas.ts";
+import { validateBody } from "../../src/shared/validation/helpers.ts";
+
+test("xiaomi-mimo registry uses current token-plan base URL and current MiMo V2 models", () => {
+  const entry = REGISTRY["xiaomi-mimo"];
+
+  assert.ok(entry, "xiaomi-mimo should exist in registry");
+  assert.equal(entry.baseUrl, "https://token-plan-sgp.xiaomimimo.com/v1");
+  assert.deepEqual(
+    entry.models.map((model) => model.id),
+    ["mimo-v2-pro", "mimo-v2-omni", "mimo-v2-tts"]
+  );
+});
+
+test("xiaomi-mimo create schema accepts custom regional baseUrl", () => {
+  const validation = validateBody(createProviderSchema, {
+    provider: "xiaomi-mimo",
+    apiKey: "xm-placeholder-key",
+    name: "Xiaomi MiMo AMS",
+    providerSpecificData: {
+      baseUrl: "https://token-plan-ams.xiaomimimo.com/v1",
+    },
+  });
+
+  assert.equal(validation.success, true, "create schema should accept Xiaomi regional baseUrl");
+  if (validation.success) {
+    assert.equal(
+      validation.data.providerSpecificData?.baseUrl,
+      "https://token-plan-ams.xiaomimimo.com/v1"
+    );
+  }
+});
+
+test("xiaomi-mimo update schema accepts custom regional baseUrl", () => {
+  const validation = validateBody(updateProviderConnectionSchema, {
+    providerSpecificData: {
+      baseUrl: "https://token-plan-cn.xiaomimimo.com/v1",
+    },
+  });
+
+  assert.equal(validation.success, true, "update schema should accept Xiaomi regional baseUrl");
+  if (validation.success) {
+    assert.equal(
+      validation.data.providerSpecificData?.baseUrl,
+      "https://token-plan-cn.xiaomimimo.com/v1"
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- update Xiaomi MiMo provider to use the live token-plan endpoint instead of the dead `api.xiaomi.com` host
- refresh Xiaomi MiMo model IDs from legacy `MiMo-7B-*` names to current MiMo V2 models
- expose Xiaomi MiMo base URL as a configurable field in the dashboard so users can select regional endpoints like `-ams`, `-sgp`, or `-cn`
- add focused tests for Xiaomi MiMo registry config and regional `baseUrl` schema acceptance

## Problem
`xiaomi-mimo` was configured with:
- dead base URL: `https://api.xiaomi.com/v1/chat/completions`
- stale model IDs: `MiMo-7B-RL`, `MiMo-7B-SFT`
- no dashboard base URL field, so users could not switch to region-specific token-plan endpoints

That caused valid Xiaomi MiMo API keys to fail validation and made the provider effectively unusable.

## Changes
- `open-sse/config/providerRegistry.ts`
  - base URL -> `https://token-plan-sgp.xiaomimimo.com/v1`
  - models -> `mimo-v2-pro`, `mimo-v2-omni`, `mimo-v2-tts`
- `src/app/(dashboard)/dashboard/providers/[id]/page.tsx`
  - add `xiaomi-mimo` to configurable base URL providers
  - default placeholder -> `https://token-plan-ams.xiaomimimo.com/v1`
  - hint text now documents `-ams`, `-sgp`, and `-cn` regional endpoints
- `tests/unit/xiaomi-mimo-provider.test.mjs`
  - registry assertions
  - create/update schema coverage for regional custom base URLs

## Validation
Ran locally:
- `node --import tsx/esm --test tests/unit/xiaomi-mimo-provider.test.mjs`
- `node --import tsx/esm --test tests/unit/chat-openai-compat-providers.test.mjs`

Both passed.
