### PR TITLE
fix: translate max_tokens/max_completion_tokens → max_output_tokens in Chat→Responses translator

### DIFF
--- a/open-sse/translator/request/openai-responses.ts
+++ b/open-sse/translator/request/openai-responses.ts
@@ -124,8 +124,7 @@ export function openaiResponsesToOpenAIRequest(
               if (contentItem.detail !== undefined) {
                 (imgResult.image_url as JsonRecord).detail = contentItem.detail;
               }
-
-return imgResult;
+              return imgResult;
             }
             if (contentItem.type === "input_file") {
               const fileObj: JsonRecord = {};
@@ -265,8 +264,7 @@ return imgResult;
     } else if (tcType && tcType !== "function" && tcType !== "allowed_tools") {
       // Built-in tool types (web_search_preview, file_search, etc.) have no Chat equivalent
       throw unsupportedFeature(
-
-`Unsupported Responses API feature: tool_choice type '${tcType}' is not supported by omniroute`
+        `Unsupported Responses API feature: tool_choice type '${tcType}' is not supported by omniroute`
       );
     }
   }
@@ -388,8 +386,7 @@ export function openaiToOpenAIResponsesRequest(
           const contentItem = toRecord(contentValue);
           if (contentItem.type === "text") {
             outputContent.push({ type: "output_text", text: toString(contentItem.text) });
-
-} else if (contentItem.type === "thinking" || contentItem.type === "redacted_thinking") {
+          } else if (contentItem.type === "thinking" || contentItem.type === "redacted_thinking") {
             // Reasoning already moved above
             continue;
           } else {
@@ -528,8 +525,7 @@ export function openaiToOpenAIResponsesRequest(
 
   // Pass through relevant fields
   if (root.previous_response_id !== undefined) {
-
-result.previous_response_id = root.previous_response_id;
+    result.previous_response_id = root.previous_response_id;
   }
   if (root.prompt_cache_key !== undefined) {
     result.prompt_cache_key = root.prompt_cache_key;

--- a/open-sse/translator/request/openai-responses.ts
+++ b/open-sse/translator/request/openai-responses.ts
@@ -124,7 +124,8 @@ export function openaiResponsesToOpenAIRequest(
               if (contentItem.detail !== undefined) {
                 (imgResult.image_url as JsonRecord).detail = contentItem.detail;
               }
-              return imgResult;
+
+return imgResult;
             }
             if (contentItem.type === "input_file") {
               const fileObj: JsonRecord = {};
@@ -264,7 +265,8 @@ export function openaiResponsesToOpenAIRequest(
     } else if (tcType && tcType !== "function" && tcType !== "allowed_tools") {
       // Built-in tool types (web_search_preview, file_search, etc.) have no Chat equivalent
       throw unsupportedFeature(
-        `Unsupported Responses API feature: tool_choice type '${tcType}' is not supported by omniroute`
+
+`Unsupported Responses API feature: tool_choice type '${tcType}' is not supported by omniroute`
       );
     }
   }
@@ -386,7 +388,8 @@ export function openaiToOpenAIResponsesRequest(
           const contentItem = toRecord(contentValue);
           if (contentItem.type === "text") {
             outputContent.push({ type: "output_text", text: toString(contentItem.text) });
-          } else if (contentItem.type === "thinking" || contentItem.type === "redacted_thinking") {
+
+} else if (contentItem.type === "thinking" || contentItem.type === "redacted_thinking") {
             // Reasoning already moved above
             continue;
           } else {
@@ -525,7 +528,8 @@ export function openaiToOpenAIResponsesRequest(
 
   // Pass through relevant fields
   if (root.previous_response_id !== undefined) {
-    result.previous_response_id = root.previous_response_id;
+
+result.previous_response_id = root.previous_response_id;
   }
   if (root.prompt_cache_key !== undefined) {
     result.prompt_cache_key = root.prompt_cache_key;
@@ -538,7 +542,14 @@ export function openaiToOpenAIResponsesRequest(
   }
   if (root.service_tier !== undefined) result.service_tier = root.service_tier;
   if (root.temperature !== undefined) result.temperature = root.temperature;
-  if (root.max_tokens !== undefined) result.max_tokens = root.max_tokens;
+  // Translate max_tokens / max_completion_tokens → max_output_tokens for Responses API.
+  // The Responses API does not accept max_tokens or max_completion_tokens; it requires
+  // max_output_tokens. max_completion_tokens takes priority as the newer Chat Completions field.
+  if (root.max_completion_tokens !== undefined) {
+    result.max_output_tokens = root.max_completion_tokens;
+  } else if (root.max_tokens !== undefined) {
+    result.max_output_tokens = root.max_tokens;
+  }
   if (root.top_p !== undefined) result.top_p = root.top_p;
   if (storeEnabled) {
     if (root[RESPONSES_STORE_MARKER] !== undefined) {

--- a/tests/unit/translator-openai-responses-req.test.mjs
+++ b/tests/unit/translator-openai-responses-req.test.mjs
@@ -230,7 +230,7 @@ test("Chat -> Responses converts messages, tool calls, tool outputs, tools and p
   ]);
   assert.deepEqual(result.tool_choice, { type: "function", name: "read_file" });
   assert.equal(result.temperature, 0.2);
-  assert.equal(result.max_tokens, 100);
+  assert.equal(result.max_output_tokens, 100);
   assert.equal(result.top_p, 0.9);
 });
 
@@ -310,4 +310,52 @@ test("Chat -> Responses filters orphan function_call_output items and leaves emp
   );
   assert.equal(result.input.filter((item) => item.type === "function_call_output").length, 1);
   assert.equal(result.input.find((item) => item.type === "function_call_output").call_id, "call_2");
+});
+
+test("Chat -> Responses maps max_completion_tokens to max_output_tokens", () => {
+  const result = openaiToOpenAIResponsesRequest(
+    "gpt-4o",
+    {
+      messages: [{ role: "user", content: "Hello" }],
+      max_completion_tokens: 2048,
+    },
+    false,
+    null
+  );
+
+  assert.equal(result.max_output_tokens, 2048);
+  assert.equal(result.max_tokens, undefined);
+  assert.equal(result.max_completion_tokens, undefined);
+});
+
+test("Chat -> Responses maps legacy max_tokens to max_output_tokens when max_completion_tokens is absent", () => {
+  const result = openaiToOpenAIResponsesRequest(
+    "gpt-4o",
+    {
+      messages: [{ role: "user", content: "Hello" }],
+      max_tokens: 512,
+    },
+    false,
+    null
+  );
+
+  assert.equal(result.max_output_tokens, 512);
+  assert.equal(result.max_tokens, undefined);
+});
+
+test("Chat -> Responses prefers max_completion_tokens over max_tokens when both are present", () => {
+  const result = openaiToOpenAIResponsesRequest(
+    "gpt-4o",
+    {
+      messages: [{ role: "user", content: "Hello" }],
+      max_tokens: 100,
+      max_completion_tokens: 4096,
+    },
+    false,
+    null
+  );
+
+  assert.equal(result.max_output_tokens, 4096);
+  assert.equal(result.max_tokens, undefined);
+  assert.equal(result.max_completion_tokens, undefined);
 });


### PR DESCRIPTION
## Problem

When translating from OpenAI Chat Completions format to OpenAI Responses API format (`openaiToOpenAIResponsesRequest`), the translator passes `max_tokens` through as-is:

```typescript
if (root.max_tokens !== undefined) result.max_tokens = root.max_tokens;
```

The OpenAI Responses API does **not** accept `max_tokens` — it requires `max_output_tokens`. This causes a **400 error** for every request routed through OmniRoute to a Responses API endpoint (e.g., Codex):

```
{"detail":"Unsupported parameter: max_tokens"}
```

Additionally, `max_completion_tokens` (the newer Chat Completions field introduced by OpenAI) was not handled at all, meaning clients using the modern field would lose their token limit during translation.

## Fix

Replace the direct passthrough with proper field mapping:

```diff
-  if (root.max_tokens !== undefined) result.max_tokens = root.max_tokens;
+  // Translate max_tokens / max_completion_tokens → max_output_tokens for Responses API.
+  // The Responses API does not accept max_tokens or max_completion_tokens; it requires
+  // max_output_tokens. max_completion_tokens takes priority as the newer Chat Completions field.
+  if (root.max_completion_tokens !== undefined) {
+    result.max_output_tokens = root.max_completion_tokens;
+  } else if (root.max_tokens !== undefined) {
+    result.max_output_tokens = root.max_tokens;
+  }
```

- `max_completion_tokens` → `max_output_tokens` (preferred, newer field)
- `max_tokens` → `max_output_tokens` (fallback for legacy clients)
- `max_completion_tokens` takes priority when both are present

## Reproduction

1. Configure a provider with `openai` source format targeting an `openai-responses` upstream (e.g., Codex)
2. Send a Chat Completions request with `max_tokens` or `max_completion_tokens`
3. OmniRoute translates and forwards with `max_tokens` intact → 400 error from upstream

## Testing

The existing `translator-openai-responses-req.test.mjs` test suite should be extended with cases for `max_tokens` and `max_completion_tokens` translation.