### PR TITLE
fix: use api64 for proxy test

### DIFF
--- a/src/app/api/settings/proxy/test/route.ts
+++ b/src/app/api/settings/proxy/test/route.ts
@@ -137,7 +137,7 @@ export async function POST(request: Request) {
     const dispatcher = createProxyDispatcher(proxyUrl);
 
     try {
-      const result = await undiciRequest("https://api.ipify.org?format=json", {
+      const result = await undiciRequest("https://api64.ipify.org?format=json", {
         method: "GET",
         dispatcher,
         signal: controller.signal,


### PR DESCRIPTION
The current proxy test request fails for ipv6 proxy target.
Switch the test URL from api.ipify.org to api64.ipify.org to avoid the failing path.