### PR TITLE
fix(cc-compatible): restore upstream SSE and correct stream/combo timeout behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -792,10 +792,10 @@ When you no longer need OmniRoute, we provide two quick scripts for a clean remo
 
 For most deployments, you only need:
 
-| Variable                 | Default                       | Purpose                                                                                                                     |
-| ------------------------ | ----------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `REQUEST_TIMEOUT_MS`     | `600000`                      | Shared baseline for upstream fetch, hidden Undici timeouts, TLS fingerprint requests, and API bridge request/proxy timeouts |
-| `STREAM_IDLE_TIMEOUT_MS` | inherits `REQUEST_TIMEOUT_MS` | Maximum gap between streaming chunks before OmniRoute aborts the SSE stream                                                 |
+| Variable                 | Default                       | Purpose                                                                                                                                      |
+| ------------------------ | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `REQUEST_TIMEOUT_MS`     | `600000`                      | Shared baseline for upstream response-start timeout, hidden Undici timeouts, TLS fingerprint requests, and API bridge request/proxy timeouts |
+| `STREAM_IDLE_TIMEOUT_MS` | inherits `REQUEST_TIMEOUT_MS` | Maximum gap between streaming chunks before OmniRoute aborts the SSE stream                                                                  |
 
 Backward compatibility is preserved: existing `FETCH_TIMEOUT_MS`, `API_BRIDGE_PROXY_TIMEOUT_MS`, and other per-layer timeout vars still work and override the shared baseline.
 
@@ -803,19 +803,21 @@ For Claude Code-compatible upstreams (`anthropic-compatible-cc-*`), OmniRoute al
 
 Advanced overrides are available if you need finer control:
 
-| Variable                                 | Default                                    | Purpose                                                              |
-| ---------------------------------------- | ------------------------------------------ | -------------------------------------------------------------------- |
-| `FETCH_TIMEOUT_MS`                       | inherits `REQUEST_TIMEOUT_MS`              | Total upstream request timeout used by the main fetch abort signal   |
-| `FETCH_HEADERS_TIMEOUT_MS`               | inherits `FETCH_TIMEOUT_MS`                | Undici time limit for receiving upstream response headers            |
-| `FETCH_BODY_TIMEOUT_MS`                  | inherits `FETCH_TIMEOUT_MS`                | Undici time limit between upstream body chunks (`0` disables it)     |
-| `FETCH_CONNECT_TIMEOUT_MS`               | `30000`                                    | Undici TCP connect timeout                                           |
-| `FETCH_KEEPALIVE_TIMEOUT_MS`             | `4000`                                     | Undici idle keep-alive socket timeout                                |
-| `TLS_CLIENT_TIMEOUT_MS`                  | inherits `FETCH_TIMEOUT_MS`                | Timeout for TLS fingerprint requests made through `wreq-js`          |
-| `API_BRIDGE_PROXY_TIMEOUT_MS`            | inherits `REQUEST_TIMEOUT_MS` or `30000`   | Timeout for `/v1` proxy forwarding from API port to dashboard port   |
-| `API_BRIDGE_SERVER_REQUEST_TIMEOUT_MS`   | `max(API_BRIDGE_PROXY_TIMEOUT_MS, 300000)` | Incoming request timeout on the API bridge server                    |
-| `API_BRIDGE_SERVER_HEADERS_TIMEOUT_MS`   | `60000`                                    | Incoming header timeout on the API bridge server                     |
-| `API_BRIDGE_SERVER_KEEPALIVE_TIMEOUT_MS` | `5000`                                     | Keep-alive timeout on the API bridge server                          |
-| `API_BRIDGE_SERVER_SOCKET_TIMEOUT_MS`    | `0`                                        | Socket inactivity timeout on the API bridge server (`0` disables it) |
+| Variable                               | Default                                    | Purpose                                                            |
+| -------------------------------------- | ------------------------------------------ | ------------------------------------------------------------------ |
+| `FETCH_TIMEOUT_MS`                     | inherits `REQUEST_TIMEOUT_MS`              | Upstream response-start timeout used until response headers arrive |
+| `FETCH_HEADERS_TIMEOUT_MS`             | inherits `FETCH_TIMEOUT_MS`                | Undici time limit for receiving upstream response headers          |
+| `FETCH_BODY_TIMEOUT_MS`                | inherits `FETCH_TIMEOUT_MS`                | Undici time limit between upstream body chunks (`0` disables it)   |
+| `FETCH_CONNECT_TIMEOUT_MS`             | `30000`                                    | Undici TCP connect timeout                                         |
+| `FETCH_KEEPALIVE_TIMEOUT_MS`           | `4000`                                     | Undici idle keep-alive socket timeout                              |
+| `TLS_CLIENT_TIMEOUT_MS`                | inherits `FETCH_TIMEOUT_MS`                | Timeout for TLS fingerprint requests made through `wreq-js`        |
+| `API_BRIDGE_PROXY_TIMEOUT_MS`          | inherits `REQUEST_TIMEOUT_MS` or `30000`   | Timeout for `/v1` proxy forwarding from API port to dashboard port |
+| `API_BRIDGE_SERVER_REQUEST_TIMEOUT_MS` | `max(API_BRIDGE_PROXY_TIMEOUT_MS, 300000)` | Incoming request timeout on the API bridge server                  |
+
+For streaming requests, `FETCH_TIMEOUT_MS` only covers connection setup / waiting for the first upstream response. Once the stream is active, OmniRoute will only abort on an actual stall (`STREAM_IDLE_TIMEOUT_MS`) or Undici body inactivity (`FETCH_BODY_TIMEOUT_MS`).
+| `API_BRIDGE_SERVER_HEADERS_TIMEOUT_MS` | `60000` | Incoming header timeout on the API bridge server |
+| `API_BRIDGE_SERVER_KEEPALIVE_TIMEOUT_MS` | `5000` | Keep-alive timeout on the API bridge server |
+| `API_BRIDGE_SERVER_SOCKET_TIMEOUT_MS` | `0` | Socket inactivity timeout on the API bridge server (`0` disables it) |
 
 If you run OmniRoute behind Nginx, Caddy, Cloudflare, or another reverse proxy, make sure the proxy
 timeouts are also higher than your OmniRoute stream/fetch timeouts.

--- a/README.md
+++ b/README.md
@@ -813,11 +813,11 @@ Advanced overrides are available if you need finer control:
 | `TLS_CLIENT_TIMEOUT_MS`                | inherits `FETCH_TIMEOUT_MS`                | Timeout for TLS fingerprint requests made through `wreq-js`        |
 | `API_BRIDGE_PROXY_TIMEOUT_MS`          | inherits `REQUEST_TIMEOUT_MS` or `30000`   | Timeout for `/v1` proxy forwarding from API port to dashboard port |
 | `API_BRIDGE_SERVER_REQUEST_TIMEOUT_MS` | `max(API_BRIDGE_PROXY_TIMEOUT_MS, 300000)` | Incoming request timeout on the API bridge server                  |
+| `API_BRIDGE_SERVER_HEADERS_TIMEOUT_MS`   | `60000`                                    | Incoming header timeout on the API bridge server                   |
+| `API_BRIDGE_SERVER_KEEPALIVE_TIMEOUT_MS` | `5000`                                     | Keep-alive timeout on the API bridge server                        |
+| `API_BRIDGE_SERVER_SOCKET_TIMEOUT_MS`    | `0`                                        | Socket inactivity timeout on the API bridge server (`0` disables it) |
 
 For streaming requests, `FETCH_TIMEOUT_MS` only covers connection setup / waiting for the first upstream response. Once the stream is active, OmniRoute will only abort on an actual stall (`STREAM_IDLE_TIMEOUT_MS`) or Undici body inactivity (`FETCH_BODY_TIMEOUT_MS`).
-| `API_BRIDGE_SERVER_HEADERS_TIMEOUT_MS` | `60000` | Incoming header timeout on the API bridge server |
-| `API_BRIDGE_SERVER_KEEPALIVE_TIMEOUT_MS` | `5000` | Keep-alive timeout on the API bridge server |
-| `API_BRIDGE_SERVER_SOCKET_TIMEOUT_MS` | `0` | Socket inactivity timeout on the API bridge server (`0` disables it) |
 
 If you run OmniRoute behind Nginx, Caddy, Cloudflare, or another reverse proxy, make sure the proxy
 timeouts are also higher than your OmniRoute stream/fetch timeouts.

--- a/open-sse/config/constants.ts
+++ b/open-sse/config/constants.ts
@@ -6,7 +6,9 @@ const upstreamTimeouts = getUpstreamTimeoutConfig(process.env, (message) => {
   console.warn(`[open-sse] ${message}`);
 });
 
-// Timeout for non-streaming fetch requests (ms). Prevents stalled connections.
+// Timeout for receiving the initial upstream response (ms).
+// After headers arrive, active SSE streams are governed by STREAM_IDLE_TIMEOUT_MS
+// and Undici's bodyTimeout instead of this one-shot startup timer.
 export const FETCH_TIMEOUT_MS = upstreamTimeouts.fetchTimeoutMs;
 
 // Idle timeout for SSE streams (ms). Closes stream if no data for this duration.

--- a/open-sse/executors/base.ts
+++ b/open-sse/executors/base.ts
@@ -109,19 +109,23 @@ export function applyConfiguredUserAgent(
 export function mergeAbortSignals(primary: AbortSignal, secondary: AbortSignal): AbortSignal {
   const controller = new AbortController();
 
-  const abortBoth = () => {
+  const abortFrom = (source: AbortSignal) => {
     if (!controller.signal.aborted) {
-      controller.abort();
+      controller.abort(source.reason);
     }
   };
 
-  if (primary.aborted || secondary.aborted) {
-    abortBoth();
+  if (primary.aborted) {
+    abortFrom(primary);
+    return controller.signal;
+  }
+  if (secondary.aborted) {
+    abortFrom(secondary);
     return controller.signal;
   }
 
-  primary.addEventListener("abort", abortBoth, { once: true });
-  secondary.addEventListener("abort", abortBoth, { once: true });
+  primary.addEventListener("abort", () => abortFrom(primary), { once: true });
+  secondary.addEventListener("abort", () => abortFrom(secondary), { once: true });
   return controller.signal;
 }
 
@@ -231,6 +235,9 @@ export class BaseExecutor {
 
   // Intra-URL retry config: retry same URL before falling back to next node
   static readonly RETRY_CONFIG = { maxAttempts: 2, delayMs: 2000 };
+  // Timeout for receiving the initial upstream response headers. Once the response
+  // starts streaming, STREAM_IDLE_TIMEOUT_MS / Undici bodyTimeout handle stalls.
+  static FETCH_START_TIMEOUT_MS = FETCH_TIMEOUT_MS;
 
   // Override in subclass for provider-specific refresh
   async refreshCredentials(credentials: ProviderCredentials, log: ExecutorLog | null) {
@@ -313,12 +320,26 @@ export class BaseExecutor {
       const transformedBody = await this.transformRequest(model, body, stream, activeCredentials);
 
       try {
-        // Apply timeout to all requests. Non-streaming requests need this to prevent
-        // stalled connections. Streaming requests also need it for the initial fetch() call
-        // to prevent hanging on unresponsive providers (e.g. 300s TCP default timeout — #769).
-        // Stream idle detection (STREAM_IDLE_TIMEOUT_MS) handles stalls after data starts flowing.
-        const timeoutSignal = AbortSignal.timeout(FETCH_TIMEOUT_MS);
-        const combinedSignal = signal ? mergeAbortSignals(signal, timeoutSignal) : timeoutSignal;
+        // Only enforce the timeout while waiting for the initial fetch() response.
+        // Once headers arrive, active streams must not be cut off by total elapsed time;
+        // post-start stalls are handled separately by STREAM_IDLE_TIMEOUT_MS / bodyTimeout.
+        const fetchStartTimeoutMs = BaseExecutor.FETCH_START_TIMEOUT_MS;
+        const timeoutController = fetchStartTimeoutMs > 0 ? new AbortController() : null;
+        let timeoutId: ReturnType<typeof setTimeout> | null = null;
+        if (timeoutController) {
+          timeoutId = setTimeout(() => {
+            const timeoutError = new Error(
+              `Fetch timeout after ${fetchStartTimeoutMs}ms on ${url}`
+            );
+            timeoutError.name = "TimeoutError";
+            timeoutController.abort(timeoutError);
+          }, fetchStartTimeoutMs);
+        }
+        const timeoutSignal = timeoutController?.signal ?? null;
+        const combinedSignal =
+          signal && timeoutSignal
+            ? mergeAbortSignals(signal, timeoutSignal)
+            : signal || timeoutSignal;
 
         // Apply CLI fingerprint ordering if enabled for this provider
         let finalHeaders = headers;
@@ -346,7 +367,15 @@ export class BaseExecutor {
         };
         if (combinedSignal) fetchOptions.signal = combinedSignal;
 
-        const response = await fetch(url, fetchOptions);
+        let response;
+        try {
+          response = await fetch(url, fetchOptions);
+        } finally {
+          if (timeoutId) {
+            clearTimeout(timeoutId);
+            timeoutId = null;
+          }
+        }
 
         // Intra-URL retry: if 429 and we haven't exhausted per-URL retries, wait and retry the same URL
         if (
@@ -375,7 +404,10 @@ export class BaseExecutor {
         // Distinguish timeout errors from other abort errors
         const err = error instanceof Error ? error : new Error(String(error));
         if (err.name === "TimeoutError") {
-          log?.warn?.("TIMEOUT", `Fetch timeout after ${FETCH_TIMEOUT_MS}ms on ${url}`);
+          log?.warn?.(
+            "TIMEOUT",
+            `Fetch timeout after ${BaseExecutor.FETCH_START_TIMEOUT_MS}ms on ${url}`
+          );
         }
         lastError = err;
         if (urlIndex + 1 < fallbackCount) {

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -992,8 +992,10 @@ export async function handleChatCore({
     } else if (isClaudeCodeCompatible) {
       let normalizedForCc = { ...body };
 
-      // Claude Code-compatible providers expect Anthropic Messages-shaped payloads,
-      // but we extract only role/text/max_tokens/effort from an OpenAI-like view first.
+      // CC-compatible relays are optimized for gateway compatibility, not for
+      // lossless request preservation. Normalize through an OpenAI-like view,
+      // then rebuild a Claude Code-shaped payload that is more likely to pass
+      // upstream client fingerprint checks than a field-for-field passthrough.
       if (sourceFormat !== FORMATS.OPENAI) {
         const normalizeToolCallId = getModelNormalizeToolCallId(
           provider || "",

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -962,10 +962,10 @@ export async function handleChatCore({
   let translatedBody = body;
   const isClaudePassthrough = sourceFormat === FORMATS.CLAUDE && targetFormat === FORMATS.CLAUDE;
   const isClaudeCodeCompatible = isClaudeCodeCompatibleProvider(provider);
-  // Respect the client's explicit non-streaming intent for CC-compatible providers.
-  // Most upstreams can answer JSON directly; the SSE->JSON fallback remains as a
-  // compatibility path when an upstream still responds with event-stream.
-  const upstreamStream = stream;
+  // CC-compatible providers are most reliable when OmniRoute always requests SSE
+  // upstream. If the client asked for JSON, chatCore will still collect the SSE
+  // response and return a non-streaming payload after the stream finishes.
+  const upstreamStream = isClaudeCodeCompatible ? true : stream;
   let ccSessionId: string | null = null;
 
   // Determine if we should preserve client-side cache_control headers

--- a/open-sse/services/claudeCodeCompatible.ts
+++ b/open-sse/services/claudeCodeCompatible.ts
@@ -13,6 +13,16 @@ import {
 } from "./claudeCodeConstraints.ts";
 import { obfuscateInBody } from "./claudeCodeObfuscation.ts";
 
+/**
+ * `anthropic-compatible-cc-*` targets Anthropic relay gateways that only accept
+ * traffic which looks like the official Claude Code client, often because those
+ * gateways resell the same models at materially lower prices than the direct API.
+ *
+ * This bridge is intentionally compatibility-first, not lossless. We normalize
+ * requests into the smallest Claude Code-shaped surface that consistently passes
+ * provider-side client checks, instead of trying to preserve every original
+ * field one-to-one.
+ */
 export const CLAUDE_CODE_COMPATIBLE_PREFIX = "anthropic-compatible-cc-";
 export const CLAUDE_CODE_COMPATIBLE_DEFAULT_CHAT_PATH = "/v1/messages?beta=true";
 export const CLAUDE_CODE_COMPATIBLE_DEFAULT_MODELS_PATH = "/models";
@@ -112,6 +122,9 @@ export function buildClaudeCodeCompatibleHeaders(
   stream = false,
   sessionId?: string | null
 ): Record<string, string> {
+  // These headers intentionally mirror Claude Code's wire image closely.
+  // For CC-compatible relays, passing the upstream's client-gating checks is
+  // more important than forwarding arbitrary caller-specific header shapes.
   return {
     "Content-Type": "application/json",
     Accept: stream ? "text/event-stream" : "application/json",

--- a/src/app/(dashboard)/dashboard/combos/page.tsx
+++ b/src/app/(dashboard)/dashboard/combos/page.tsx
@@ -3195,7 +3195,7 @@ function ComboFormModal({ isOpen, combo, onClose, onSave, activeProviders }) {
                       <input
                         type="number"
                         min="1000"
-                        max="600000"
+                        max="1200000"
                         step="1000"
                         value={config.timeoutMs ?? ""}
                         placeholder="120000"

--- a/src/app/(dashboard)/dashboard/combos/page.tsx
+++ b/src/app/(dashboard)/dashboard/combos/page.tsx
@@ -3195,7 +3195,6 @@ function ComboFormModal({ isOpen, combo, onClose, onSave, activeProviders }) {
                       <input
                         type="number"
                         min="1000"
-                        max="1200000"
                         step="1000"
                         value={config.timeoutMs ?? ""}
                         placeholder="120000"

--- a/src/app/(dashboard)/dashboard/settings/components/ComboDefaultsTab.tsx
+++ b/src/app/(dashboard)/dashboard/settings/components/ComboDefaultsTab.tsx
@@ -54,7 +54,7 @@ export default function ComboDefaultsTab() {
   const numericSettings = [
     { key: "maxRetries", label: t("maxRetriesLabel"), min: 0, max: 5 },
     { key: "retryDelayMs", label: t("retryDelayLabel"), min: 500, max: 10000, step: 500 },
-    { key: "timeoutMs", label: t("timeoutLabel"), min: 5000, max: 300000, step: 5000 },
+    { key: "timeoutMs", label: t("timeoutLabel"), min: 5000, max: 1200000, step: 5000 },
     { key: "maxComboDepth", label: t("maxNestingDepth"), min: 1, max: 10 },
   ];
 
@@ -439,7 +439,7 @@ export default function ComboDefaultsTab() {
               <Input
                 type="number"
                 min="5000"
-                max="300000"
+                max="1200000"
                 step="5000"
                 value={config.timeoutMs ?? 120000}
                 onChange={(e) =>

--- a/src/app/(dashboard)/dashboard/settings/components/ComboDefaultsTab.tsx
+++ b/src/app/(dashboard)/dashboard/settings/components/ComboDefaultsTab.tsx
@@ -54,7 +54,7 @@ export default function ComboDefaultsTab() {
   const numericSettings = [
     { key: "maxRetries", label: t("maxRetriesLabel"), min: 0, max: 5 },
     { key: "retryDelayMs", label: t("retryDelayLabel"), min: 500, max: 10000, step: 500 },
-    { key: "timeoutMs", label: t("timeoutLabel"), min: 5000, max: 1200000, step: 5000 },
+    { key: "timeoutMs", label: t("timeoutLabel"), min: 5000, step: 5000 },
     { key: "maxComboDepth", label: t("maxNestingDepth"), min: 1, max: 10 },
   ];
 
@@ -439,7 +439,6 @@ export default function ComboDefaultsTab() {
               <Input
                 type="number"
                 min="5000"
-                max="1200000"
                 step="5000"
                 value={config.timeoutMs ?? 120000}
                 onChange={(e) =>

--- a/src/shared/validation/schemas.ts
+++ b/src/shared/validation/schemas.ts
@@ -204,7 +204,7 @@ const comboRuntimeConfigSchema = z
     strategy: comboStrategySchema.optional(),
     maxRetries: z.coerce.number().int().min(0).max(10).optional(),
     retryDelayMs: z.coerce.number().int().min(0).max(60000).optional(),
-    timeoutMs: z.coerce.number().int().min(1000).max(600000).optional(),
+    timeoutMs: z.coerce.number().int().min(1000).max(1200000).optional(),
     concurrencyPerModel: z.coerce.number().int().min(1).max(20).optional(),
     queueTimeoutMs: z.coerce.number().int().min(1000).max(120000).optional(),
     healthCheckEnabled: z.boolean().optional(),

--- a/src/shared/validation/schemas.ts
+++ b/src/shared/validation/schemas.ts
@@ -204,7 +204,7 @@ const comboRuntimeConfigSchema = z
     strategy: comboStrategySchema.optional(),
     maxRetries: z.coerce.number().int().min(0).max(10).optional(),
     retryDelayMs: z.coerce.number().int().min(0).max(60000).optional(),
-    timeoutMs: z.coerce.number().int().min(1000).max(1200000).optional(),
+    timeoutMs: z.coerce.number().int().min(1000).optional(),
     concurrencyPerModel: z.coerce.number().int().min(1).max(20).optional(),
     queueTimeoutMs: z.coerce.number().int().min(1000).max(120000).optional(),
     healthCheckEnabled: z.boolean().optional(),

--- a/tests/unit/cc-compatible-provider.test.mjs
+++ b/tests/unit/cc-compatible-provider.test.mjs
@@ -443,7 +443,7 @@ test("validateProviderApiKey uses CC skeleton request after /models fallback", a
   assert.equal(calls[1].headers.Accept, "text/event-stream");
 });
 
-test("handleChatCore respects non-streaming upstream requests for CC compatible providers", async () => {
+test("handleChatCore forces SSE upstream for CC compatible providers while returning JSON to non-stream clients", async () => {
   const calls = [];
   globalThis.fetch = async (url, init = {}) => {
     calls.push({
@@ -518,11 +518,8 @@ test("handleChatCore respects non-streaming upstream requests for CC compatible 
 
   assert.equal(result.success, true);
   assert.equal(calls.length, 1);
-  assert.equal(calls[0].headers.Accept, "application/json");
-  assert.equal(calls[0].body.stream, undefined);
-  // PR #1188: billing header system block carries cache_control: ephemeral for
-  // proper billing attribution. Only user-facing message blocks should be free of
-  // auto-injected cache markers (non-preserve mode).
+  assert.equal(calls[0].headers.Accept, "text/event-stream");
+  assert.equal(calls[0].body.stream, true);
   assert.equal(
     calls[0].body.messages.some((message) =>
       message.content.some((block) => block.cache_control !== undefined)

--- a/tests/unit/chatcore-translation-paths.test.mjs
+++ b/tests/unit/chatcore-translation-paths.test.mjs
@@ -457,8 +457,8 @@ test("chatCore builds Claude Code-compatible upstream requests for CC providers"
   });
 
   assert.equal(result.success, true);
-  assert.equal(call.headers.Accept ?? call.headers.accept, "application/json");
-  assert.equal(call.body.stream, undefined);
+  assert.equal(call.headers.Accept ?? call.headers.accept, "text/event-stream");
+  assert.equal(call.body.stream, true);
   assert.equal(call.body.context_management.edits[0].type, "clear_thinking_20251015");
   assert.equal(typeof call.body.metadata.user_id, "string");
   assert.equal(call.body.messages[0].role, "user");

--- a/tests/unit/combo-config.test.mjs
+++ b/tests/unit/combo-config.test.mjs
@@ -82,20 +82,20 @@ test("resolveComboConfig ignores null and undefined overrides", () => {
   assert.equal(result.strategy, "priority");
 });
 
-test("updateComboDefaultsSchema accepts 20 minute timeout defaults and provider overrides", () => {
+test("updateComboDefaultsSchema accepts arbitrarily large timeout defaults and provider overrides", () => {
   const parsed = updateComboDefaultsSchema.parse({
     comboDefaults: {
-      timeoutMs: 1200000,
+      timeoutMs: 3600000,
     },
     providerOverrides: {
       anthropic: {
-        timeoutMs: 1200000,
+        timeoutMs: 5400000,
       },
     },
   });
 
-  assert.equal(parsed.comboDefaults.timeoutMs, 1200000);
-  assert.equal(parsed.providerOverrides.anthropic.timeoutMs, 1200000);
+  assert.equal(parsed.comboDefaults.timeoutMs, 3600000);
+  assert.equal(parsed.providerOverrides.anthropic.timeoutMs, 5400000);
 });
 
 test("resolveComboConfig preserves explicit empty handoffProviders overrides", () => {

--- a/tests/unit/combo-config.test.mjs
+++ b/tests/unit/combo-config.test.mjs
@@ -82,6 +82,22 @@ test("resolveComboConfig ignores null and undefined overrides", () => {
   assert.equal(result.strategy, "priority");
 });
 
+test("updateComboDefaultsSchema accepts 20 minute timeout defaults and provider overrides", () => {
+  const parsed = updateComboDefaultsSchema.parse({
+    comboDefaults: {
+      timeoutMs: 1200000,
+    },
+    providerOverrides: {
+      anthropic: {
+        timeoutMs: 1200000,
+      },
+    },
+  });
+
+  assert.equal(parsed.comboDefaults.timeoutMs, 1200000);
+  assert.equal(parsed.providerOverrides.anthropic.timeoutMs, 1200000);
+});
+
 test("resolveComboConfig preserves explicit empty handoffProviders overrides", () => {
   const result = resolveComboConfig(
     {

--- a/tests/unit/executor-default-base.test.mjs
+++ b/tests/unit/executor-default-base.test.mjs
@@ -371,14 +371,19 @@ test("BaseExecutor.mergeAbortSignals aborts when either source signal aborts", (
   const merged = mergeAbortSignals(primary.signal, secondary.signal);
 
   assert.equal(merged.aborted, false);
-  primary.abort();
+  const primaryReason = new Error("primary timeout");
+  primaryReason.name = "TimeoutError";
+  primary.abort(primaryReason);
   assert.equal(merged.aborted, true);
+  assert.equal(merged.reason, primaryReason);
 
   const otherPrimary = new AbortController();
   const otherSecondary = new AbortController();
   const merged2 = mergeAbortSignals(otherPrimary.signal, otherSecondary.signal);
-  otherSecondary.abort();
+  const secondaryReason = new Error("client closed");
+  otherSecondary.abort(secondaryReason);
   assert.equal(merged2.aborted, true);
+  assert.equal(merged2.reason, secondaryReason);
 });
 
 test("BaseExecutor.needsRefresh returns true only when expiry is near", () => {
@@ -626,6 +631,38 @@ test("BaseExecutor.execute propagates aborted requests through the merged signal
       /aborted/
     );
   } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("BaseExecutor.execute clears the startup timeout after headers arrive", async () => {
+  const executor = new TestExecutor({ baseUrls: ["https://single.example/v1/chat/completions"] });
+  const originalFetch = globalThis.fetch;
+  const originalFetchStartTimeoutMs = BaseExecutor.FETCH_START_TIMEOUT_MS;
+  let capturedSignal;
+
+  BaseExecutor.FETCH_START_TIMEOUT_MS = 20;
+  globalThis.fetch = async (_url, options) => {
+    capturedSignal = options.signal;
+    return new Response("ok", {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+
+  try {
+    await executor.execute({
+      model: "gpt-4.1",
+      body: {},
+      stream: true,
+      credentials: {},
+    });
+
+    assert.equal(capturedSignal?.aborted, false);
+    await new Promise((resolve) => setTimeout(resolve, 40));
+    assert.equal(capturedSignal?.aborted, false);
+  } finally {
+    BaseExecutor.FETCH_START_TIMEOUT_MS = originalFetchStartTimeoutMs;
     globalThis.fetch = originalFetch;
   }
 });


### PR DESCRIPTION
## Summary
- restore forced upstream SSE for Claude Code-compatible providers while still returning JSON to non-stream clients after the upstream stream completes
- stop aborting active streams on total elapsed fetch time; only enforce the startup timeout before upstream headers arrive
- remove combo timeout caps from validation and settings UI so user-provided values are not artificially limited, while keeping the existing defaults unchanged

## Root cause
PR #1188 changed the CC-compatible path to respect client-side `stream: false` all the way upstream. That regressed third-party Claude Code reverse proxies that only behave correctly when the upstream request is sent as SSE.

Separately, the main fetch timeout was still attached to the full response body. Once a streaming response had started, that signal could still abort an otherwise healthy long-running stream after the configured duration, which conflicted with the intended `STREAM_IDLE_TIMEOUT_MS` semantics.

The combo timeout editor also had inconsistent hard caps in multiple places, and those caps blocked valid larger user-specified values even though the requested behavior was to preserve the default while not imposing a maximum.

## What changed
- `chatCore` now always sets `upstreamStream = true` for `anthropic-compatible-cc-*` providers
- non-stream clients still receive JSON through the existing SSE-to-JSON collection path after the upstream stream finishes
- `BaseExecutor` now uses the fetch timeout only while waiting for the initial upstream response; after headers arrive, active streams are governed by `STREAM_IDLE_TIMEOUT_MS` and Undici `FETCH_BODY_TIMEOUT_MS`
- merged abort signals now preserve the original abort `reason`, so timeout aborts stay classified as timeouts instead of degrading into generic aborts
- combo runtime timeout max caps were removed from schema validation and dashboard inputs; defaults remain unchanged
- README timeout docs were updated to reflect the corrected streaming semantics

## Validation
- `node --import tsx/esm --test tests/unit/cc-compatible-provider.test.mjs tests/unit/executor-default-base.test.mjs tests/unit/combo-config.test.mjs`
- `node --import tsx/esm --test tests/unit/runtime-timeouts.test.mjs tests/unit/chatcore-translation-paths.test.mjs tests/unit/claude-code-compatible-helpers.test.mjs`
- targeted follow-up after removing timeout caps: `node --import tsx/esm --test tests/unit/combo-config.test.mjs`
- push hook full unit suite: `2827 passed, 0 failed`
