### PR TITLE
feat(oauth): support cursor-agent CLI as Cursor credential source

### DIFF
--- a/open-sse/executors/cursor.ts
+++ b/open-sse/executors/cursor.ts
@@ -240,12 +240,13 @@ export class CursorExecutor extends BaseExecutor {
 
   buildHeaders(credentials) {
     const accessToken = credentials.accessToken;
-    const machineId = credentials.providerSpecificData?.machineId;
     const ghostMode = credentials.providerSpecificData?.ghostMode !== false;
 
-    if (!machineId) {
-      throw new Error("Machine ID is required for Cursor API");
-    }
+    // Use stored machineId, or derive a stable one from the access token
+    // (cursor-agent imports don't provide a machineId)
+    const machineId =
+      credentials.providerSpecificData?.machineId ||
+      crypto.createHash("sha256").update(accessToken).digest("hex");
 
     const cleanToken = accessToken.includes("::") ? accessToken.split("::")[1] : accessToken;
 

--- a/src/app/api/oauth/cursor/auto-import/route.ts
+++ b/src/app/api/oauth/cursor/auto-import/route.ts
@@ -1,12 +1,100 @@
 import { NextResponse } from "next/server";
 import { homedir } from "os";
 import { join } from "path";
+import { readFile } from "fs/promises";
 import Database from "better-sqlite3";
 import { isAuthRequired, isAuthenticated } from "@/shared/utils/apiAuth";
 
 /**
+ * Try to read credentials from cursor-agent's auth.json
+ * (written by `cursor-agent` CLI after login).
+ */
+async function tryAgentAuth(): Promise<{
+  found: boolean;
+  accessToken?: string;
+  source?: string;
+  error?: string;
+}> {
+  try {
+    const authPath = join(homedir(), ".config", "cursor", "auth.json");
+    const raw = await readFile(authPath, "utf-8");
+    const auth = JSON.parse(raw);
+    if (auth.accessToken && typeof auth.accessToken === "string") {
+      return { found: true, accessToken: auth.accessToken, source: "cursor-agent" };
+    }
+    return { found: false, error: "cursor-agent auth.json has no accessToken" };
+  } catch {
+    return { found: false, error: "cursor-agent auth.json not found" };
+  }
+}
+
+/**
+ * Try to read credentials from Cursor IDE's state.vscdb
+ */
+function tryIdeAuth(): {
+  found: boolean;
+  accessToken?: string;
+  machineId?: string;
+  source?: string;
+  error?: string;
+} {
+  const platform = process.platform;
+  let dbPath;
+
+  if (platform === "darwin") {
+    dbPath = join(homedir(), "Library/Application Support/Cursor/User/globalStorage/state.vscdb");
+  } else if (platform === "linux") {
+    dbPath = join(homedir(), ".config/Cursor/User/globalStorage/state.vscdb");
+  } else if (platform === "win32") {
+    dbPath = join(process.env.APPDATA || "", "Cursor/User/globalStorage/state.vscdb");
+  } else {
+    return { found: false, error: "Unsupported platform" };
+  }
+
+  let db;
+  try {
+    db = new Database(dbPath, { readonly: true, fileMustExist: true });
+  } catch {
+    return { found: false, error: "Cursor IDE database not found" };
+  }
+
+  try {
+    const rows = db
+      .prepare("SELECT key, value FROM itemTable WHERE key IN (?, ?)")
+      .all("cursorAuth/accessToken", "storage.serviceMachineId") as {
+      key: string;
+      value: string;
+    }[];
+
+    const tokens: Record<string, string> = {};
+    for (const row of rows) {
+      if (row.key === "cursorAuth/accessToken") tokens.accessToken = row.value;
+      else if (row.key === "storage.serviceMachineId") tokens.machineId = row.value;
+    }
+
+    db.close();
+
+    if (!tokens.accessToken) {
+      return { found: false, error: "Tokens not found in database" };
+    }
+
+    return {
+      found: true,
+      accessToken: tokens.accessToken,
+      machineId: tokens.machineId,
+      source: "cursor-ide",
+    };
+  } catch (error) {
+    db?.close();
+    return { found: false, error: `Failed to read database: ${(error as any).message}` };
+  }
+}
+
+/**
  * GET /api/oauth/cursor/auto-import
- * Auto-detect and extract Cursor tokens from local SQLite database.
+ * Auto-detect and extract Cursor tokens from:
+ *   1. Cursor IDE's local SQLite database (state.vscdb) — includes machineId
+ *   2. cursor-agent CLI's auth.json — fallback, no machineId
  *
  * 🔒 Auth-guarded: requires JWT cookie or Bearer API key (finding #258-4).
  */
@@ -18,69 +106,31 @@ export async function GET(request: Request) {
   }
 
   try {
-    const platform = process.platform;
-    let dbPath;
-
-    // Determine database path based on platform
-    if (platform === "darwin") {
-      dbPath = join(homedir(), "Library/Application Support/Cursor/User/globalStorage/state.vscdb");
-    } else if (platform === "linux") {
-      dbPath = join(homedir(), ".config/Cursor/User/globalStorage/state.vscdb");
-    } else if (platform === "win32") {
-      dbPath = join(process.env.APPDATA || "", "Cursor/User/globalStorage/state.vscdb");
-    } else {
-      return NextResponse.json({ error: "Unsupported platform", found: false }, { status: 400 });
-    }
-
-    // Try to open database
-    let db;
-    try {
-      db = new Database(dbPath, { readonly: true, fileMustExist: true });
-    } catch (error) {
-      return NextResponse.json({
-        found: false,
-        error:
-          "Cursor database not found. Make sure Cursor IDE is installed and you are logged in.",
-      });
-    }
-
-    try {
-      // Extract tokens from database
-      const rows = db
-        .prepare("SELECT key, value FROM itemTable WHERE key IN (?, ?)")
-        .all("cursorAuth/accessToken", "storage.serviceMachineId");
-
-      const tokens: Record<string, any> = {};
-      for (const row of rows) {
-        if (row.key === "cursorAuth/accessToken") {
-          tokens.accessToken = row.value;
-        } else if (row.key === "storage.serviceMachineId") {
-          tokens.machineId = row.value;
-        }
-      }
-
-      db.close();
-
-      // Validate tokens exist
-      if (!tokens.accessToken || !tokens.machineId) {
-        return NextResponse.json({
-          found: false,
-          error: "Tokens not found in database. Please login to Cursor IDE first.",
-        });
-      }
-
+    // Try Cursor IDE first (has both accessToken and machineId)
+    const ideResult = tryIdeAuth();
+    if (ideResult.found) {
       return NextResponse.json({
         found: true,
-        accessToken: tokens.accessToken,
-        machineId: tokens.machineId,
-      });
-    } catch (error) {
-      db?.close();
-      return NextResponse.json({
-        found: false,
-        error: `Failed to read database: ${(error as any).message}`,
+        accessToken: ideResult.accessToken,
+        machineId: ideResult.machineId,
+        source: ideResult.source,
       });
     }
+
+    // Fall back to cursor-agent CLI auth (accessToken only, no machineId)
+    const agentResult = await tryAgentAuth();
+    if (agentResult.found) {
+      return NextResponse.json({
+        found: true,
+        accessToken: agentResult.accessToken,
+        source: agentResult.source,
+      });
+    }
+
+    return NextResponse.json({
+      found: false,
+      error: "No Cursor credentials found. Install Cursor IDE or login with cursor-agent.",
+    });
   } catch (error) {
     console.log("Cursor auto-import error:", error);
     return NextResponse.json({ found: false, error: (error as any).message }, { status: 500 });

--- a/src/app/api/oauth/cursor/import/route.ts
+++ b/src/app/api/oauth/cursor/import/route.ts
@@ -45,7 +45,7 @@ export async function POST(request: any) {
 
     // Validate token by making API call (through proxy if configured)
     const tokenData = await runWithProxyContext(proxy, () =>
-      cursorService.validateImportToken(accessToken.trim(), machineId.trim())
+      cursorService.validateImportToken(accessToken.trim(), machineId?.trim())
     );
 
     // Try to extract user info from token

--- a/src/lib/oauth/services/cursor.ts
+++ b/src/lib/oauth/services/cursor.ts
@@ -90,20 +90,16 @@ export class CursorService {
   }
 
   /**
-   * Validate and import token from Cursor IDE
+   * Validate and import token from Cursor IDE or cursor-agent CLI.
    * Note: We skip API validation because Cursor API uses complex protobuf format.
    * Token will be validated when actually used for requests.
-   * @param {string} accessToken - Access token from state.vscdb
-   * @param {string} machineId - Machine ID from state.vscdb
+   * @param {string} accessToken - Access token from state.vscdb or auth.json
+   * @param {string} [machineId] - Machine ID from state.vscdb (optional for cursor-agent imports)
    */
-  async validateImportToken(accessToken: string, machineId: string) {
+  async validateImportToken(accessToken: string, machineId?: string) {
     // Basic validation
     if (!accessToken || typeof accessToken !== "string") {
       throw new Error("Access token is required");
-    }
-
-    if (!machineId || typeof machineId !== "string") {
-      throw new Error("Machine ID is required");
     }
 
     // Token format validation (Cursor tokens are typically long strings)
@@ -111,10 +107,12 @@ export class CursorService {
       throw new Error("Invalid token format. Token appears too short.");
     }
 
-    // Machine ID format validation (should be UUID-like)
-    const uuidRegex = /^[a-f0-9-]{32,}$/i;
-    if (!uuidRegex.test(machineId.replace(/-/g, ""))) {
-      throw new Error("Invalid machine ID format. Expected UUID format.");
+    // Machine ID format validation (only if provided — cursor-agent imports don't have one)
+    if (machineId) {
+      const uuidRegex = /^[a-f0-9-]{32,}$/i;
+      if (!uuidRegex.test(machineId.replace(/-/g, ""))) {
+        throw new Error("Invalid machine ID format. Expected UUID format.");
+      }
     }
 
     // Note: We don't validate against API because Cursor uses complex protobuf.
@@ -122,9 +120,9 @@ export class CursorService {
 
     return {
       accessToken,
-      machineId,
+      machineId: machineId || null,
       expiresIn: 86400, // Cursor tokens typically last 24 hours
-      authMethod: "imported",
+      authMethod: machineId ? "imported" : "cursor-agent",
     };
   }
 

--- a/src/shared/components/CursorAuthModal.tsx
+++ b/src/shared/components/CursorAuthModal.tsx
@@ -33,7 +33,7 @@ export default function CursorAuthModal({ isOpen, onSuccess, onClose }) {
 
         if (data.found) {
           setAccessToken(data.accessToken);
-          setMachineId(data.machineId);
+          setMachineId(data.machineId || "");
           setAutoDetected(true);
         } else {
           setError(data.error || "Could not auto-detect tokens");
@@ -54,22 +54,17 @@ export default function CursorAuthModal({ isOpen, onSuccess, onClose }) {
       return;
     }
 
-    if (!machineId.trim()) {
-      setError("Please enter a machine ID");
-      return;
-    }
-
     setImporting(true);
     setError(null);
 
     try {
+      const body: Record<string, string> = { accessToken: accessToken.trim() };
+      if (machineId.trim()) body.machineId = machineId.trim();
+
       const res = await fetch("/api/oauth/cursor/import", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          accessToken: accessToken.trim(),
-          machineId: machineId.trim(),
-        }),
+        body: JSON.stringify(body),
       });
 
       const data = await res.json();
@@ -100,7 +95,7 @@ export default function CursorAuthModal({ isOpen, onSuccess, onClose }) {
               </span>
             </div>
             <h3 className="text-lg font-semibold mb-2">Auto-detecting tokens...</h3>
-            <p className="text-sm text-text-muted">Reading from Cursor IDE database</p>
+            <p className="text-sm text-text-muted">Reading from Cursor IDE or cursor-agent</p>
           </div>
         )}
 
@@ -149,10 +144,10 @@ export default function CursorAuthModal({ isOpen, onSuccess, onClose }) {
               />
             </div>
 
-            {/* Machine ID Input */}
+            {/* Machine ID Input (optional — not needed for cursor-agent imports) */}
             <div>
               <label className="block text-sm font-medium mb-2">
-                Machine ID <span className="text-red-500">*</span>
+                Machine ID <span className="text-text-muted text-xs">(optional)</span>
               </label>
               <Input
                 value={machineId}
@@ -174,7 +169,7 @@ export default function CursorAuthModal({ isOpen, onSuccess, onClose }) {
               <Button
                 onClick={handleImportToken}
                 fullWidth
-                disabled={importing || !accessToken.trim() || !machineId.trim()}
+                disabled={importing || !accessToken.trim()}
               >
                 {importing ? "Importing..." : "Import Token"}
               </Button>

--- a/src/shared/validation/schemas.ts
+++ b/src/shared/validation/schemas.ts
@@ -940,7 +940,7 @@ export const oauthPollSchema = z.object({
 
 export const cursorImportSchema = z.object({
   accessToken: z.string().trim().min(1, "Access token is required"),
-  machineId: z.string().trim().min(1, "Machine ID is required"),
+  machineId: z.string().trim().optional(),
 });
 
 export const kiroImportSchema = z.object({

--- a/tests/unit/executor-cursor-extended.test.mjs
+++ b/tests/unit/executor-cursor-extended.test.mjs
@@ -123,12 +123,11 @@ test("buildCursorHeaders utility stays aligned with Cursor Composer 2 versioned 
   assert.equal(headers["x-ghost-mode"], "false");
 });
 
-test("CursorExecutor.buildHeaders requires a machine ID", () => {
+test("CursorExecutor.buildHeaders derives machineId when not provided", () => {
   const executor = new CursorExecutor();
-  assert.throws(
-    () => executor.buildHeaders({ accessToken: "real-token", providerSpecificData: {} }),
-    /Machine ID is required/
-  );
+  const headers = executor.buildHeaders({ accessToken: "real-token", providerSpecificData: {} });
+  assert.ok(headers["x-cursor-checksum"], "should have a checksum header");
+  assert.ok(headers["x-client-key"], "should have a client key header");
 });
 
 test("CursorExecutor.transformRequest produces a framed protobuf payload", () => {


### PR DESCRIPTION
## Summary
- Adds `cursor-agent` CLI's `~/.config/cursor/auth.json` as a fallback credential source for Cursor auto-import (when Cursor IDE's `state.vscdb` is not available)
- Makes `machineId` optional throughout the import flow (cursor-agent doesn't provide one)
- Derives a stable `machineId` from the access token hash in the executor when none is stored
- Fixes `CursorAuthModal` crash when `machineId` is absent from auto-import response

## Test plan
- [x] Auto-import detects cursor-agent credentials (`source: "cursor-agent"`)
- [x] Import succeeds without `machineId`
- [x] CursorAuthModal renders correctly with optional machineId field
- [x] Cursor API requests work end-to-end with derived machineId
- [x] Existing IDE-based imports (with machineId) still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)