### PR TITLE
Fix provider-profile-driven lockouts for compatible providers and model quarantine

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,8 +324,8 @@ AI providers can become unstable, return 5xx errors, or hit temporary rate limit
 
 **How OmniRoute solves it:**
 
-- **Circuit Breaker per-model** — Auto-open/close with configurable thresholds and cooldown (Closed/Open/Half-Open), scoped per-model to avoid cascading blocks
-- **Exponential Backoff** — Progressive retry delays
+- **Settings-Driven Lock Hierarchy** — Provider profiles control per-account model lockouts, global model quarantine, and provider circuit breakers from one control surface
+- **Exponential Backoff** — Progressive retry delays for both account/model lockouts and higher-level quarantine
 - **Anti-Thundering Herd** — Mutex + semaphore protection against concurrent retry storms
 - **Combo Fallback Chains** — If the primary provider fails, automatically falls through the chain with no intervention
 - **Combo Circuit Breaker** — Auto-disables failing providers within a combo chain

--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ AI providers can become unstable, return 5xx errors, or hit temporary rate limit
 
 **How OmniRoute solves it:**
 
-- **Settings-Driven Lock Hierarchy** — Provider profiles control per-account model lockouts, global model quarantine, and provider circuit breakers from one control surface
+- **Settings-Driven Lock Hierarchy** — Provider profiles control default account/model lockouts, global model quarantine, and provider circuit breakers from one control surface, while explicit upstream `Retry-After` windows still take priority
 - **Exponential Backoff** — Progressive retry delays for both account/model lockouts and higher-level quarantine
 - **Anti-Thundering Herd** — Mutex + semaphore protection against concurrent retry storms
 - **Combo Fallback Chains** — If the primary provider fails, automatically falls through the chain with no intervention

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -343,9 +343,9 @@ The CLI automatically loads `.env` from `~/.omniroute/.env` or `./.env`.
 
 When you no longer need OmniRoute, we provide two quick scripts for a clean removal:
 
-| Command | Action |
-| --- | --- |
-| `npm run uninstall` | Removes the system app but **keeps your DB and configurations** in `~/.omniroute`. |
+| Command                  | Action                                                                              |
+| ------------------------ | ----------------------------------------------------------------------------------- |
+| `npm run uninstall`      | Removes the system app but **keeps your DB and configurations** in `~/.omniroute`.  |
 | `npm run uninstall:full` | Removes the app AND permanently **erases all configurations, keys, and databases**. |
 
 > Note: To run these commands, navigate to the OmniRoute project folder (if you cloned it) and run them. Alternatively, if globally installed, you can simply run `npm uninstall -g omniroute`.
@@ -759,10 +759,11 @@ Configure via **Dashboard → Settings → Resilience**.
 OmniRoute implements provider-level resilience with four components:
 
 1. **Provider Profiles** — Per-provider configuration for:
-   - Failure threshold (how many failures before opening)
-   - Cooldown duration
-   - Rate limit detection sensitivity
-   - Exponential backoff parameters
+   - **Transient Cooldown** — Base cooldown for transient upstream failures
+   - **Rate Limit Cooldown** — Base cooldown for `429`-driven lockouts
+   - **Max Backoff Level** — Maximum exponential backoff level for repeated failures
+   - **CB Threshold** — Failure count before model quarantine / provider circuit breaker escalates
+   - **CB Reset Time** — Failure counting window and breaker reset timer
 
 2. **Editable Rate Limits** — System-level defaults configurable in the dashboard:
    - **Requests Per Minute (RPM)** — Maximum requests per minute per account
@@ -770,10 +771,14 @@ OmniRoute implements provider-level resilience with four components:
    - **Max Concurrent Requests** — Maximum simultaneous requests per account
    - Click **Edit** to modify, then **Save** or **Cancel**. Values persist via the resilience API.
 
-3. **Circuit Breaker** — Tracks failures per provider and automatically opens the circuit when a threshold is reached:
+3. **Circuit Breaker** — Tracks failures per provider and automatically opens the circuit when the configured threshold is reached:
    - **CLOSED** (Healthy) — Requests flow normally
    - **OPEN** — Provider is temporarily blocked after repeated failures
    - **HALF_OPEN** — Testing if provider has recovered
+
+   The same provider profile also drives model-scoped lockouts:
+   - Account/model lockouts react immediately to authoritative `429` / `404` signals and use the configured cooldown + backoff values
+   - Global provider/model quarantine only activates after repeated exhaustion hits the configured **CB Threshold** within **CB Reset Time**
 
 4. **Policies & Locked Identifiers** — Shows circuit breaker status and locked identifiers with force-unlock capability.
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -782,7 +782,7 @@ OmniRoute implements provider-level resilience with four components:
 
 4. **Policies & Locked Identifiers** — Shows circuit breaker status and locked identifiers with force-unlock capability.
 
-5. **Rate Limit Auto-Detection** — Monitors `429` and `Retry-After` headers to proactively avoid hitting provider rate limits.
+5. **Rate Limit Auto-Detection** — Monitors `429` and `Retry-After` headers to proactively avoid hitting provider rate limits. When an upstream provider returns an explicit wait window, that authoritative `Retry-After` value overrides the base cooldown from the provider profile.
 
 **Pro Tip:** Use **Reset All** button to clear all circuit breakers and cooldowns when a provider recovers from an outage.
 

--- a/open-sse/services/accountFallback.ts
+++ b/open-sse/services/accountFallback.ts
@@ -6,7 +6,23 @@ import {
   HTTP_STATUS,
   PROVIDER_PROFILES,
 } from "../config/constants.ts";
-import { getProviderCategory } from "../config/providerRegistry.ts";
+import { getPassthroughProviders, getProviderCategory } from "../config/providerRegistry.ts";
+
+type ProviderProfile = (typeof PROVIDER_PROFILES)["oauth"];
+type JsonRecord = Record<string, unknown>;
+type ModelLockoutEntry = {
+  reason: string;
+  until: number;
+  lockedAt: number;
+  failureCount: number;
+  lastFailureAt: number;
+  resetAfterMs: number;
+};
+type ModelFailureState = {
+  failureCount: number;
+  lastFailureAt: number;
+  resetAfterMs: number;
+};
 
 // T06 (sub2api PR #1037): Signals that indicate permanent account deactivation.
 // When a 401 body contains these strings, the account is permanently dead
@@ -82,9 +98,126 @@ export function getProviderProfile(provider) {
   return PROVIDER_PROFILES[category] ?? PROVIDER_PROFILES.apikey;
 }
 
+function asRecord(value: unknown): JsonRecord {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as JsonRecord) : {};
+}
+
+function isCompatibleProvider(provider: string | null | undefined): boolean {
+  return (
+    typeof provider === "string" &&
+    (provider.startsWith("openai-compatible-") || provider.startsWith("anthropic-compatible-"))
+  );
+}
+
+function isGeminiFamilyModel(model: string | null | undefined): boolean {
+  if (typeof model !== "string") return false;
+  const normalized = model.trim().toLowerCase();
+  return (
+    normalized.startsWith("gemini") ||
+    normalized.startsWith("models/gemini") ||
+    normalized.includes("/gemini")
+  );
+}
+
+function mergeProviderProfile(fallback: ProviderProfile, overrides: unknown): ProviderProfile {
+  const record = asRecord(overrides);
+  return {
+    transientCooldown:
+      typeof record.transientCooldown === "number"
+        ? record.transientCooldown
+        : fallback.transientCooldown,
+    rateLimitCooldown:
+      typeof record.rateLimitCooldown === "number"
+        ? record.rateLimitCooldown
+        : fallback.rateLimitCooldown,
+    maxBackoffLevel:
+      typeof record.maxBackoffLevel === "number"
+        ? record.maxBackoffLevel
+        : fallback.maxBackoffLevel,
+    circuitBreakerThreshold:
+      typeof record.circuitBreakerThreshold === "number"
+        ? record.circuitBreakerThreshold
+        : fallback.circuitBreakerThreshold,
+    circuitBreakerReset:
+      typeof record.circuitBreakerReset === "number"
+        ? record.circuitBreakerReset
+        : fallback.circuitBreakerReset,
+  };
+}
+
+export async function getRuntimeProviderProfile(provider: string | null | undefined) {
+  const fallback = getProviderProfile(provider);
+  try {
+    const { getCachedSettings } = await import("@/lib/db/readCache");
+    const settings = await getCachedSettings();
+    const profiles = asRecord(settings.providerProfiles);
+    const category = getProviderCategory(provider);
+    return mergeProviderProfile(fallback, profiles[category]);
+  } catch {
+    return fallback;
+  }
+}
+
 // ─── Per-Model Lockout Tracking ─────────────────────────────────────────────
 // In-memory map: "provider:connectionId:model" → { reason, until, lockedAt }
-const modelLockouts = new Map();
+const modelLockouts = new Map<string, ModelLockoutEntry>();
+const modelFailureState = new Map<string, ModelFailureState>();
+
+function getModelLockKey(provider: string, connectionId: string, model: string) {
+  return `${provider}:${connectionId}:${model}`;
+}
+
+function getFailureWindowMs(profile: ProviderProfile | null = null, fallbackMs = 30 * 60 * 1000) {
+  const configured = profile?.circuitBreakerReset;
+  return typeof configured === "number" && configured > 0 ? configured : fallbackMs;
+}
+
+function cleanupModelLockKey(key: string, now = Date.now()) {
+  const entry = modelLockouts.get(key);
+  if (entry && now > entry.until) {
+    modelLockouts.delete(key);
+  }
+
+  const failure = modelFailureState.get(key);
+  if (!failure) return;
+  if (now - failure.lastFailureAt <= failure.resetAfterMs) return;
+  if (modelLockouts.has(key)) return;
+  modelFailureState.delete(key);
+}
+
+function getModelLockBaseCooldown(
+  status: number,
+  fallbackCooldownMs: number,
+  profile: ProviderProfile | null = null
+) {
+  if (status === HTTP_STATUS.RATE_LIMITED) {
+    if (typeof profile?.rateLimitCooldown === "number" && profile.rateLimitCooldown > 0) {
+      return profile.rateLimitCooldown;
+    }
+    if (Number.isFinite(fallbackCooldownMs) && fallbackCooldownMs > 0) {
+      return fallbackCooldownMs;
+    }
+    return getQuotaCooldown(0);
+  }
+
+  if (typeof profile?.transientCooldown === "number" && profile.transientCooldown > 0) {
+    return profile.transientCooldown;
+  }
+  if (Number.isFinite(fallbackCooldownMs) && fallbackCooldownMs > 0) {
+    return fallbackCooldownMs;
+  }
+  return COOLDOWN_MS.transientInitial;
+}
+
+function getScaledCooldown(
+  baseCooldownMs: number,
+  failureCount: number,
+  maxBackoffLevel = BACKOFF_CONFIG.maxLevel
+) {
+  const safeBase = Number.isFinite(baseCooldownMs) && baseCooldownMs > 0 ? baseCooldownMs : 1000;
+  const exponent = Math.min(Math.max(0, failureCount - 1), Math.max(0, maxBackoffLevel));
+  return safeBase * Math.pow(2, exponent);
+}
 
 // Auto-cleanup expired lockouts every 15 seconds (lazy init for Cloudflare Workers compatibility)
 let _cleanupTimer: ReturnType<typeof setInterval> | null = null;
@@ -94,9 +227,8 @@ function ensureCleanupTimer() {
   try {
     _cleanupTimer = setInterval(() => {
       const now = Date.now();
-      for (const [key, entry] of modelLockouts) {
-        if (now > entry.until) modelLockouts.delete(key);
-      }
+      for (const key of modelLockouts.keys()) cleanupModelLockKey(key, now);
+      for (const key of modelFailureState.keys()) cleanupModelLockKey(key, now);
     }, 15_000);
     if (typeof _cleanupTimer === "object" && "unref" in _cleanupTimer) {
       (_cleanupTimer as { unref?: () => void }).unref?.(); // Don't prevent process exit (Node.js only)
@@ -114,35 +246,109 @@ function ensureCleanupTimer() {
  * @param {string} reason - from RateLimitReason
  * @param {number} cooldownMs
  */
-export function lockModel(provider, connectionId, model, reason, cooldownMs) {
+export function lockModel(
+  provider,
+  connectionId,
+  model,
+  reason,
+  cooldownMs,
+  metadata: Partial<ModelLockoutEntry> = {}
+) {
   if (!model) return; // No model → skip model-level locking
   ensureCleanupTimer();
-  const key = `${provider}:${connectionId}:${model}`;
+  const key = getModelLockKey(provider, connectionId, model);
+  cleanupModelLockKey(key);
   const newUntil = Date.now() + cooldownMs;
   // Preserve the longer cooldown if an existing lock has more time remaining.
   // Safe without a mutex: no await between get/set, so this runs atomically
   // within Node.js's single-threaded event loop.
   const existing = modelLockouts.get(key);
-  if (existing && existing.until > newUntil) return;
+  if (existing && existing.until > newUntil) {
+    if (metadata.failureCount && metadata.failureCount > existing.failureCount) {
+      existing.failureCount = metadata.failureCount;
+      existing.lastFailureAt = metadata.lastFailureAt ?? existing.lastFailureAt;
+      existing.resetAfterMs = metadata.resetAfterMs ?? existing.resetAfterMs;
+      modelLockouts.set(key, existing);
+    }
+    return;
+  }
+  const now = Date.now();
   modelLockouts.set(key, {
     reason,
     until: newUntil,
-    lockedAt: Date.now(),
+    lockedAt: now,
+    failureCount: metadata.failureCount ?? existing?.failureCount ?? 1,
+    lastFailureAt: metadata.lastFailureAt ?? now,
+    resetAfterMs: metadata.resetAfterMs ?? existing?.resetAfterMs ?? 0,
   });
+}
+
+export function recordModelLockoutFailure(
+  provider: string,
+  connectionId: string,
+  model: string,
+  reason: string,
+  status: number,
+  fallbackCooldownMs: number,
+  profile: ProviderProfile | null = null
+) {
+  ensureCleanupTimer();
+  const key = getModelLockKey(provider, connectionId, model);
+  const now = Date.now();
+  cleanupModelLockKey(key, now);
+
+  const resetAfterMs = getFailureWindowMs(profile);
+  const previous = modelFailureState.get(key);
+  const withinWindow = previous && now - previous.lastFailureAt <= previous.resetAfterMs;
+  const failureCount = withinWindow ? previous.failureCount + 1 : 1;
+  modelFailureState.set(key, {
+    failureCount,
+    lastFailureAt: now,
+    resetAfterMs,
+  });
+
+  const baseCooldownMs = getModelLockBaseCooldown(status, fallbackCooldownMs, profile);
+  const cooldownMs = getScaledCooldown(
+    baseCooldownMs,
+    failureCount,
+    profile?.maxBackoffLevel ?? BACKOFF_CONFIG.maxLevel
+  );
+
+  lockModel(provider, connectionId, model, reason, cooldownMs, {
+    failureCount,
+    lastFailureAt: now,
+    resetAfterMs,
+  });
+
+  return {
+    cooldownMs,
+    failureCount,
+    resetAfterMs,
+  };
+}
+
+export function clearModelLock(provider, connectionId, model) {
+  if (!model) return false;
+  const key = getModelLockKey(provider, connectionId, model);
+  const hadLock = modelLockouts.delete(key);
+  const hadFailureState = modelFailureState.delete(key);
+  return hadLock || hadFailureState;
 }
 
 /**
  * Whether a provider should use per-model lockouts instead of connection-wide cooldowns.
- * Gemini AI Studio has per-model quotas; passthrough providers have independent model limits.
+ * Gemini AI Studio, Gemini exposed through compatible providers, and passthrough providers
+ * should avoid connection-wide cooldowns when only one model is rate-limited.
  */
-export function hasPerModelQuota(provider: string): boolean {
+export function hasPerModelQuota(
+  provider: string | null | undefined,
+  model: string | null | undefined = null
+): boolean {
+  if (!provider) return false;
   if (provider === "gemini") return true;
-  try {
-    const { getPassthroughProviders } = require("../config/providerRegistry.ts");
-    return getPassthroughProviders().has(provider);
-  } catch {
-    return false;
-  }
+  if (getPassthroughProviders().has(provider)) return true;
+  if (isCompatibleProvider(provider) && isGeminiFamilyModel(model)) return true;
+  return false;
 }
 
 /**
@@ -156,9 +362,16 @@ export function lockModelIfPerModelQuota(
   reason: string,
   cooldownMs: number
 ): boolean {
-  if (!hasPerModelQuota(provider) || !model) return false;
+  if (!hasPerModelQuota(provider, model) || !model) return false;
   lockModel(provider, connectionId, model, reason, cooldownMs);
   return true;
+}
+
+export function shouldMarkAccountExhaustedFrom429(
+  provider: string | null | undefined,
+  model: string | null | undefined = null
+): boolean {
+  return !hasPerModelQuota(provider, model);
 }
 
 /**
@@ -167,14 +380,10 @@ export function lockModelIfPerModelQuota(
  */
 export function isModelLocked(provider, connectionId, model) {
   if (!model) return false;
-  const key = `${provider}:${connectionId}:${model}`;
+  const key = getModelLockKey(provider, connectionId, model);
+  cleanupModelLockKey(key);
   const entry = modelLockouts.get(key);
-  if (!entry) return false;
-  if (Date.now() > entry.until) {
-    modelLockouts.delete(key);
-    return false;
-  }
-  return true;
+  return Boolean(entry);
 }
 
 /**
@@ -182,13 +391,15 @@ export function isModelLocked(provider, connectionId, model) {
  */
 export function getModelLockoutInfo(provider, connectionId, model) {
   if (!model) return null;
-  const key = `${provider}:${connectionId}:${model}`;
+  const key = getModelLockKey(provider, connectionId, model);
+  cleanupModelLockKey(key);
   const entry = modelLockouts.get(key);
-  if (!entry || Date.now() > entry.until) return null;
+  if (!entry) return null;
   return {
     reason: entry.reason,
     remainingMs: entry.until - Date.now(),
     lockedAt: new Date(entry.lockedAt).toISOString(),
+    failureCount: entry.failureCount,
   };
 }
 
@@ -198,17 +409,19 @@ export function getModelLockoutInfo(provider, connectionId, model) {
 export function getAllModelLockouts() {
   const now = Date.now();
   const active = [];
+  for (const key of modelLockouts.keys()) {
+    cleanupModelLockKey(key, now);
+  }
   for (const [key, entry] of modelLockouts) {
-    if (now <= entry.until) {
-      const [provider, connectionId, model] = key.split(":");
-      active.push({
-        provider,
-        connectionId,
-        model,
-        reason: entry.reason,
-        remainingMs: entry.until - now,
-      });
-    }
+    const [provider, connectionId, model] = key.split(":");
+    active.push({
+      provider,
+      connectionId,
+      model,
+      reason: entry.reason,
+      remainingMs: entry.until - now,
+      failureCount: entry.failureCount,
+    });
   }
   return active;
 }
@@ -421,6 +634,16 @@ export function getQuotaCooldown(backoffLevel = 0) {
   return Math.min(cooldown, BACKOFF_CONFIG.max);
 }
 
+function getRateLimitCooldown(backoffLevel = 0, profile: ProviderProfile | null = null) {
+  const maxLevel = profile?.maxBackoffLevel ?? BACKOFF_CONFIG.maxLevel;
+  const cappedLevel = Math.min(Math.max(0, backoffLevel), maxLevel);
+  const configuredBase = profile?.rateLimitCooldown;
+  if (typeof configuredBase === "number" && configuredBase > 0) {
+    return configuredBase * Math.pow(2, cappedLevel);
+  }
+  return getQuotaCooldown(cappedLevel);
+}
+
 /**
  * Check if error should trigger account fallback (switch to next account)
  * @param {number} status - HTTP status code
@@ -436,9 +659,11 @@ export function checkFallbackError(
   backoffLevel = 0,
   model = null,
   provider = null,
-  headers = null
+  headers = null,
+  profileOverride: ProviderProfile | null = null
 ) {
   const errorStr = (errorText || "").toString();
+  const profile = profileOverride ?? (provider ? getProviderProfile(provider) : null);
 
   function parseResetFromHeaders(headers, errorStr = "") {
     if (!headers) return null;
@@ -544,11 +769,14 @@ export function checkFallbackError(
           reason: RateLimitReason.RATE_LIMIT_EXCEEDED,
         };
       }
-      const newLevel = Math.min(backoffLevel + 1, BACKOFF_CONFIG.maxLevel);
+      const newLevel = Math.min(
+        backoffLevel + 1,
+        profile?.maxBackoffLevel ?? BACKOFF_CONFIG.maxLevel
+      );
       const reason = classifyErrorText(errorStr);
       return {
         shouldFallback: true,
-        cooldownMs: getQuotaCooldown(backoffLevel),
+        cooldownMs: getRateLimitCooldown(backoffLevel, profile),
         newBackoffLevel: newLevel,
         reason,
       };
@@ -594,10 +822,13 @@ export function checkFallbackError(
       }
     }
 
-    const newLevel = Math.min(backoffLevel + 1, BACKOFF_CONFIG.maxLevel);
+    const newLevel = Math.min(
+      backoffLevel + 1,
+      profile?.maxBackoffLevel ?? BACKOFF_CONFIG.maxLevel
+    );
     return {
       shouldFallback: true,
-      cooldownMs: getQuotaCooldown(backoffLevel),
+      cooldownMs: getRateLimitCooldown(backoffLevel, profile),
       newBackoffLevel: newLevel,
       reason: RateLimitReason.RATE_LIMIT_EXCEEDED,
     };
@@ -626,7 +857,6 @@ export function checkFallbackError(
       }
     }
 
-    const profile = provider ? getProviderProfile(provider) : null;
     const baseCooldown = profile?.transientCooldown ?? COOLDOWN_MS.transientInitial;
     const maxLevel = profile?.maxBackoffLevel ?? BACKOFF_CONFIG.maxLevel;
     const cooldownMs = Math.min(baseCooldown * Math.pow(2, backoffLevel), COOLDOWN_MS.transientMax);

--- a/open-sse/services/accountFallback.ts
+++ b/open-sse/services/accountFallback.ts
@@ -109,16 +109,6 @@ function isCompatibleProvider(provider: string | null | undefined): boolean {
   );
 }
 
-function isGeminiFamilyModel(model: string | null | undefined): boolean {
-  if (typeof model !== "string") return false;
-  const normalized = model.trim().toLowerCase();
-  return (
-    normalized.startsWith("gemini") ||
-    normalized.startsWith("models/gemini") ||
-    normalized.includes("/gemini")
-  );
-}
-
 function mergeProviderProfile(fallback: ProviderProfile, overrides: unknown): ProviderProfile {
   const record = asRecord(overrides);
   return {
@@ -337,17 +327,18 @@ export function clearModelLock(provider, connectionId, model) {
 
 /**
  * Whether a provider should use per-model lockouts instead of connection-wide cooldowns.
- * Gemini AI Studio, Gemini exposed through compatible providers, and passthrough providers
- * should avoid connection-wide cooldowns when only one model is rate-limited.
+ * Compatible and passthrough providers multiplex multiple upstream models behind one
+ * connection, so transient 404/429 responses should stay model-scoped instead of
+ * poisoning the whole connection.
  */
 export function hasPerModelQuota(
   provider: string | null | undefined,
-  model: string | null | undefined = null
+  _model: string | null | undefined = null
 ): boolean {
   if (!provider) return false;
   if (provider === "gemini") return true;
   if (getPassthroughProviders().has(provider)) return true;
-  if (isCompatibleProvider(provider) && isGeminiFamilyModel(model)) return true;
+  if (isCompatibleProvider(provider)) return true;
   return false;
 }
 

--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -4,7 +4,11 @@
  * strict-random, auto, fill-first, p2c, lkgp, context-optimized, and context-relay strategies
  */
 
-import { checkFallbackError, formatRetryAfter, getProviderProfile } from "./accountFallback.ts";
+import {
+  checkFallbackError,
+  formatRetryAfter,
+  getRuntimeProviderProfile,
+} from "./accountFallback.ts";
 import { errorResponse, unavailableResponse } from "../utils/error.ts";
 import { recordComboIntent, recordComboRequest, getComboMetrics } from "./comboMetrics.ts";
 import { resolveComboConfig, getDefaultComboConfig } from "./comboConfig.ts";
@@ -1312,7 +1316,7 @@ export async function handleComboChat({
     const target = orderedTargets[i];
     const modelStr = target.modelStr;
     const provider = target.provider;
-    const profile = getProviderProfile(provider);
+    const profile = await getRuntimeProviderProfile(provider);
     const breakerKey = getComboBreakerKey(combo.name, target.executionKey);
     const breaker = getCircuitBreaker(breakerKey, {
       failureThreshold: profile.circuitBreakerThreshold,
@@ -1489,7 +1493,8 @@ export async function handleComboChat({
         0,
         null,
         provider,
-        result.headers
+        result.headers,
+        profile
       );
       const comboBadRequestFallback = shouldFallbackComboBadRequest(result.status, errorText);
 
@@ -1648,7 +1653,7 @@ async function handleRoundRobinCombo({
     const target = orderedTargets[modelIndex];
     const modelStr = target.modelStr;
     const provider = target.provider;
-    const profile = getProviderProfile(provider);
+    const profile = await getRuntimeProviderProfile(provider);
     const breakerKey = getComboBreakerKey(combo.name, target.executionKey);
     const semaphoreKey = `combo:${combo.name}:${target.executionKey}`;
     const breaker = getCircuitBreaker(breakerKey, {
@@ -1803,7 +1808,8 @@ async function handleRoundRobinCombo({
           0,
           null,
           provider,
-          result.headers
+          result.headers,
+          profile
         );
         const comboBadRequestFallback = shouldFallbackComboBadRequest(result.status, errorText);
 

--- a/src/domain/modelAvailability.ts
+++ b/src/domain/modelAvailability.ts
@@ -21,7 +21,23 @@
 /** @type {Map<string, UnavailableEntry>} */
 const unavailable = new Map();
 
-/** @type {Map<string, { failureCount: number, lastFailureAt: number }>} */
+/**
+ * @typedef {Object} FailureState
+ * @property {number} failureCount
+ * @property {number} lastFailureAt
+ * @property {number} resetAfterMs
+ */
+
+/**
+ * @typedef {Object} ProviderProfile
+ * @property {number} [transientCooldown]
+ * @property {number} [rateLimitCooldown]
+ * @property {number} [maxBackoffLevel]
+ * @property {number} [circuitBreakerThreshold]
+ * @property {number} [circuitBreakerReset]
+ */
+
+/** @type {Map<string, FailureState>} */
 const failureState = new Map();
 
 const FAILURE_WINDOW_MS = 30 * 60 * 1000;
@@ -37,6 +53,78 @@ const PROBLEMATIC_STATUS_COOLDOWNS = {
 
 const MIN_PROBLEMATIC_COOLDOWN_MS = 60 * 1000;
 const MAX_PROBLEMATIC_COOLDOWN_MS = 30 * 60 * 1000;
+
+function toPositiveNumber(value) {
+  return Number.isFinite(value) && Number(value) > 0 ? Number(value) : null;
+}
+
+function toNonNegativeNumber(value) {
+  return Number.isFinite(value) && Number(value) >= 0 ? Number(value) : null;
+}
+
+/**
+ * The first layer already reacts immediately to authoritative model/account failures.
+ * Global provider/model quarantine is the escalation layer, so its failure window and
+ * threshold are only customized when a runtime provider profile is supplied.
+ *
+ * @param {ProviderProfile | null | undefined} profile
+ * @returns {number}
+ */
+function getFailureWindowMs(profile) {
+  return toPositiveNumber(profile?.circuitBreakerReset) ?? FAILURE_WINDOW_MS;
+}
+
+/**
+ * Without a runtime profile we preserve legacy behavior: quarantine on the first failure.
+ *
+ * @param {ProviderProfile | null | undefined} profile
+ * @returns {number}
+ */
+function getFailureThreshold(profile) {
+  return toPositiveNumber(profile?.circuitBreakerThreshold) ?? 1;
+}
+
+function getLegacyStatusCooldown(status) {
+  return status && Object.prototype.hasOwnProperty.call(PROBLEMATIC_STATUS_COOLDOWNS, status)
+    ? PROBLEMATIC_STATUS_COOLDOWNS[status]
+    : 0;
+}
+
+/**
+ * @param {number | null} status
+ * @param {ProviderProfile | null | undefined} profile
+ * @returns {number}
+ */
+function getProfileStatusCooldown(status, profile) {
+  if (!profile) return 0;
+  if (status === 429) {
+    return toPositiveNumber(profile.rateLimitCooldown) ?? 0;
+  }
+  return toPositiveNumber(profile.transientCooldown) ?? 0;
+}
+
+/**
+ * @param {number} baseCooldownMs
+ * @param {number} failureCount
+ * @param {ProviderProfile | null | undefined} profile
+ * @returns {number}
+ */
+function getScaledCooldown(baseCooldownMs, failureCount, profile) {
+  const safeBase = toPositiveNumber(baseCooldownMs) ?? 1000;
+  if (!profile) {
+    return Math.min(
+      Math.max(safeBase, MIN_PROBLEMATIC_COOLDOWN_MS) * Math.pow(2, Math.max(0, failureCount - 1)),
+      MAX_PROBLEMATIC_COOLDOWN_MS
+    );
+  }
+
+  const maxBackoffLevel = Math.max(
+    0,
+    Math.trunc(toNonNegativeNumber(profile.maxBackoffLevel) ?? 0)
+  );
+  const exponent = Math.min(Math.max(0, failureCount - 1), maxBackoffLevel);
+  return safeBase * Math.pow(2, exponent);
+}
 
 /**
  * Build a composite key for provider+model.
@@ -104,35 +192,44 @@ export function setModelUnavailable(provider, model, cooldownMs = 60000, reason)
  *
  * @param {string} provider
  * @param {string} model
- * @param {{ status?: number, baseCooldownMs?: number, reason?: string }} [options]
- * @returns {{ cooldownMs: number, failureCount: number }}
+ * @param {{ status?: number, baseCooldownMs?: number, reason?: string, profile?: ProviderProfile | null }} [options]
+ * @returns {{ cooldownMs: number, failureCount: number, quarantined: boolean, threshold: number, resetAfterMs: number }}
  */
 export function markModelAsProblematic(provider, model, options = {}) {
   const key = makeKey(provider, model);
   const now = Date.now();
   const status = Number.isFinite(options.status) ? Number(options.status) : null;
-  const statusBaseCooldown =
-    status && Object.prototype.hasOwnProperty.call(PROBLEMATIC_STATUS_COOLDOWNS, status)
-      ? PROBLEMATIC_STATUS_COOLDOWNS[status]
-      : 0;
-  const baseCooldownMs =
+  const profile = options.profile || null;
+  const explicitBaseCooldownMs =
     Number.isFinite(options.baseCooldownMs) && Number(options.baseCooldownMs) > 0
       ? Number(options.baseCooldownMs)
       : 0;
+  const statusBaseCooldown = profile
+    ? getProfileStatusCooldown(status, profile)
+    : getLegacyStatusCooldown(status);
+  const baseCooldownMs = Math.max(explicitBaseCooldownMs, statusBaseCooldown);
 
   const prev = failureState.get(key);
-  const withinFailureWindow = prev && now - prev.lastFailureAt <= FAILURE_WINDOW_MS;
+  const resetAfterMs = getFailureWindowMs(profile);
+  const withinFailureWindow = prev && now - prev.lastFailureAt <= prev.resetAfterMs;
   const failureCount = withinFailureWindow ? prev.failureCount + 1 : 1;
-  failureState.set(key, { failureCount, lastFailureAt: now });
+  failureState.set(key, { failureCount, lastFailureAt: now, resetAfterMs });
 
-  const cooldownBase = Math.max(baseCooldownMs, statusBaseCooldown, MIN_PROBLEMATIC_COOLDOWN_MS);
-  const cooldownMs = Math.min(
-    cooldownBase * Math.pow(2, Math.max(0, failureCount - 1)),
-    MAX_PROBLEMATIC_COOLDOWN_MS
-  );
+  const threshold = getFailureThreshold(profile);
+  const cooldownMs = getScaledCooldown(baseCooldownMs, failureCount, profile);
+  const quarantined = failureCount >= threshold;
 
-  setModelUnavailable(provider, model, cooldownMs, options.reason || "problematic_model");
-  return { cooldownMs, failureCount };
+  if (quarantined) {
+    setModelUnavailable(provider, model, cooldownMs, options.reason || "problematic_model");
+  }
+
+  return {
+    cooldownMs,
+    failureCount,
+    quarantined,
+    threshold,
+    resetAfterMs,
+  };
 }
 
 /**

--- a/src/shared/utils/circuitBreaker.ts
+++ b/src/shared/utils/circuitBreaker.ts
@@ -274,7 +274,29 @@ export function getCircuitBreaker(name: string, options?: CircuitBreakerOptions)
   if (!registry.has(name)) {
     registry.set(name, new CircuitBreaker(name, options));
   }
-  return registry.get(name)!;
+  const breaker = registry.get(name)!;
+  if (options) {
+    if (typeof options.failureThreshold === "number") {
+      breaker.failureThreshold = options.failureThreshold;
+    }
+    if (typeof options.resetTimeout === "number") {
+      breaker.resetTimeout = options.resetTimeout;
+    }
+    if (typeof options.halfOpenRequests === "number") {
+      breaker.halfOpenRequests = options.halfOpenRequests;
+      if (breaker.state === STATE.HALF_OPEN) {
+        breaker.halfOpenAllowed = Math.min(breaker.halfOpenAllowed, breaker.halfOpenRequests);
+      }
+    }
+    if (typeof options.onStateChange === "function") {
+      breaker.onStateChange = options.onStateChange;
+    }
+    if (typeof options.isFailure === "function") {
+      breaker.isFailure = options.isFailure;
+    }
+    breaker._persistToDb();
+  }
+  return breaker;
 }
 
 /**

--- a/src/sse/handlers/chat.ts
+++ b/src/sse/handlers/chat.ts
@@ -722,8 +722,8 @@ async function handleSingleModelChat(
     }
 
     // 6. Mark account as quota-exhausted on 429 response
-    // For per-model quota providers (Gemini, compatible Gemini, passthrough model quotas),
-    // a 429 on one model does not mean the whole connection is exhausted.
+    // For providers that route quota/cooldown at model scope, a 429 on one model
+    // does not mean the whole connection is exhausted.
     if (result.status === 429 && shouldMarkAccountExhaustedFrom429(provider, model)) {
       markAccountExhaustedFrom429(credentials.connectionId, provider);
     }

--- a/src/sse/handlers/chat.ts
+++ b/src/sse/handlers/chat.ts
@@ -5,6 +5,11 @@ import {
   extractApiKey,
   isValidApiKey,
 } from "../services/auth";
+import {
+  getRuntimeProviderProfile,
+  shouldMarkAccountExhaustedFrom429,
+  clearModelLock,
+} from "@omniroute/open-sse/services/accountFallback.ts";
 import { getModelInfo, getComboForModel } from "../services/model";
 import { errorResponse } from "@omniroute/open-sse/utils/error.ts";
 import { handleComboChat } from "@omniroute/open-sse/services/combo.ts";
@@ -464,16 +469,18 @@ async function handleSingleModelChat(
       : undefined;
 
   // 2. Pipeline gates (availability + circuit breaker)
-  const gate = checkPipelineGates(provider, model, {
+  const providerProfile = await getRuntimeProviderProfile(provider);
+  const gate = await checkPipelineGates(provider, model, {
     ignoreCircuitBreaker: forceLiveComboTest || hasForcedConnection,
     ignoreModelCooldown: forceLiveComboTest || hasForcedConnection,
+    providerProfile,
     ...(bypassReason ? { bypassReason } : {}),
   });
   if (gate) return gate;
 
   const breaker = getCircuitBreaker(provider, {
-    failureThreshold: 5,
-    resetTimeout: 30000,
+    failureThreshold: providerProfile.circuitBreakerThreshold,
+    resetTimeout: providerProfile.circuitBreakerReset,
     onStateChange: (name: string, from: string, to: string) =>
       log.info("CIRCUIT", `${name}: ${from} → ${to}`),
   });
@@ -511,11 +518,19 @@ async function handleSingleModelChat(
           status: Number(lastStatus),
           baseCooldownMs: lastCooldownMs,
           reason: `HTTP ${lastStatus}`,
+          profile: providerProfile,
         });
-        log.info(
-          "AVAILABILITY",
-          `${provider}/${model} marked unavailable — all accounts exhausted (HTTP ${lastStatus}, cooldown ${Math.ceil(quarantine.cooldownMs / 1000)}s, failureCount ${quarantine.failureCount})`
-        );
+        if (quarantine.quarantined) {
+          log.info(
+            "AVAILABILITY",
+            `${provider}/${model} marked unavailable — all accounts exhausted (HTTP ${lastStatus}, cooldown ${Math.ceil(quarantine.cooldownMs / 1000)}s, failureCount ${quarantine.failureCount}/${quarantine.threshold})`
+          );
+        } else {
+          log.info(
+            "AVAILABILITY",
+            `${provider}/${model} recorded exhaustion failure ${quarantine.failureCount}/${quarantine.threshold} (HTTP ${lastStatus}, cooldown basis ${Math.ceil(quarantine.cooldownMs / 1000)}s)`
+          );
+        }
       }
       return handleNoCredentials(
         credentials,
@@ -632,6 +647,7 @@ async function handleSingleModelChat(
     });
 
     if (result.success) {
+      clearModelLock(provider, credentials.connectionId, model);
       clearModelUnavailability(provider, model);
       if (injectedHandoff && runtimeOptions.sessionId && comboName) {
         deleteHandoff(runtimeOptions.sessionId, comboName);
@@ -706,9 +722,9 @@ async function handleSingleModelChat(
     }
 
     // 6. Mark account as quota-exhausted on 429 response
-    // For per-model quota providers (Gemini), a 429 on one model doesn't mean
-    // the entire account is exhausted — skip connection-wide exhaustion marking.
-    if (result.status === 429 && provider !== "gemini") {
+    // For per-model quota providers (Gemini, compatible Gemini, passthrough model quotas),
+    // a 429 on one model does not mean the whole connection is exhausted.
+    if (result.status === 429 && shouldMarkAccountExhaustedFrom429(provider, model)) {
       markAccountExhaustedFrom429(credentials.connectionId, provider);
     }
 
@@ -718,7 +734,8 @@ async function handleSingleModelChat(
       result.status,
       result.error,
       provider,
-      model
+      model,
+      providerProfile
     );
 
     if (shouldFallback) {

--- a/src/sse/handlers/chatHelpers.ts
+++ b/src/sse/handlers/chatHelpers.ts
@@ -23,6 +23,7 @@ import { getCircuitBreaker, CircuitBreakerOpenError } from "../../shared/utils/c
 import { isModelAvailable } from "../../domain/modelAvailability";
 import { logProxyEvent } from "../../lib/proxyLogger";
 import { logTranslationEvent } from "../../lib/translatorEvents";
+import { getRuntimeProviderProfile } from "@omniroute/open-sse/services/accountFallback.ts";
 
 export async function resolveModelOrError(modelStr: string, body: any, endpointPath: string = "") {
   const modelInfo = await getModelInfo(modelStr);
@@ -61,13 +62,17 @@ export async function resolveModelOrError(modelStr: string, body: any, endpointP
   return { provider, model, sourceFormat, targetFormat, extendedContext };
 }
 
-export function checkPipelineGates(
+export async function checkPipelineGates(
   provider: string,
   model: string,
   options: {
     ignoreCircuitBreaker?: boolean;
     ignoreModelCooldown?: boolean;
     bypassReason?: string;
+    providerProfile?: {
+      circuitBreakerThreshold?: number;
+      circuitBreakerReset?: number;
+    } | null;
   } = {}
 ) {
   const bypassReason = options.bypassReason || "pipeline override";
@@ -83,9 +88,10 @@ export function checkPipelineGates(
     );
   }
 
+  const providerProfile = options.providerProfile ?? (await getRuntimeProviderProfile(provider));
   const breaker = getCircuitBreaker(provider, {
-    failureThreshold: 5,
-    resetTimeout: 30000,
+    failureThreshold: providerProfile.circuitBreakerThreshold,
+    resetTimeout: providerProfile.circuitBreakerReset,
     onStateChange: (name: string, from: string, to: string) =>
       log.info("CIRCUIT", `${name}: ${from} → ${to}`),
   });

--- a/src/sse/services/auth.ts
+++ b/src/sse/services/auth.ts
@@ -16,11 +16,10 @@ import {
   isModelLocked,
   lockModel,
   hasPerModelQuota,
+  getRuntimeProviderProfile,
+  recordModelLockoutFailure,
 } from "@omniroute/open-sse/services/accountFallback.ts";
-import {
-  isLocalProvider,
-  getPassthroughProviders,
-} from "@omniroute/open-sse/config/providerRegistry.ts";
+import { isLocalProvider } from "@omniroute/open-sse/config/providerRegistry.ts";
 import { COOLDOWN_MS } from "@omniroute/open-sse/config/constants.ts";
 import { preflightQuota } from "@omniroute/open-sse/services/quotaPreflight.ts";
 import { getCodexModelScope } from "@omniroute/open-sse/executors/codex.ts";
@@ -1037,7 +1036,8 @@ export async function markAccountUnavailable(
   status: number,
   errorText: string,
   provider: string | null = null,
-  model: string | null = null
+  model: string | null = null,
+  providerProfile = null
 ) {
   const currentMutex = markMutexes.get(connectionId) || Promise.resolve();
   let resolveMutex: (() => void) | undefined;
@@ -1050,27 +1050,6 @@ export async function markAccountUnavailable(
 
   try {
     await currentMutex;
-
-    // ── Per-model lockout for providers with independent model quotas ──
-    // Providers like Gemini AI Studio have per-model quotas. A 429/404 on one
-    // model must NOT lock out other models on the same API key.
-    if (hasPerModelQuota(provider) && model && (status === 429 || status === 404)) {
-      const reason = status === 404 ? "not_found" : "rate_limited";
-      const cooldown = status === 404 ? COOLDOWN_MS.notFoundLocal : COOLDOWN_MS.rateLimit;
-      lockModel(provider, connectionId, model, reason, cooldown);
-      // Update last error for observability (without changing terminal status)
-      updateProviderConnection(connectionId, {
-        lastErrorType: reason,
-        lastError: `Model ${model} ${reason}`,
-        lastErrorAt: new Date().toISOString(),
-        errorCode: status,
-      }).catch(() => {});
-      log.info(
-        "AUTH",
-        `Model-only lockout for ${provider}:${model} — ${status} ${reason} ${Math.ceil(cooldown / 1000)}s (connection stays active)`
-      );
-      return { shouldFallback: true, cooldownMs: cooldown };
-    }
 
     // Read current connection to get backoffLevel
     const connectionsRaw = await getProviderConnections({ provider });
@@ -1122,12 +1101,47 @@ export async function markAccountUnavailable(
       }
     }
 
+    const effectiveProviderProfile =
+      providerProfile || (provider ? await getRuntimeProviderProfile(provider) : null);
+
+    const isPerModelQuotaProvider = hasPerModelQuota(provider, model);
+    if (isPerModelQuotaProvider && provider && model && (status === 404 || status === 429)) {
+      const reason = status === 404 ? "not_found" : "rate_limited";
+      const fallbackCooldown =
+        status === 404
+          ? (effectiveProviderProfile?.transientCooldown ?? COOLDOWN_MS.notFoundLocal)
+          : 0;
+      const lockout = recordModelLockoutFailure(
+        provider,
+        connectionId,
+        model,
+        reason,
+        status,
+        fallbackCooldown,
+        effectiveProviderProfile
+      );
+      // Update last error for observability (without changing terminal status)
+      updateProviderConnection(connectionId, {
+        lastErrorType: reason,
+        lastError: `Model ${model} ${reason}`,
+        lastErrorAt: new Date().toISOString(),
+        errorCode: status,
+      }).catch(() => {});
+      log.info(
+        "AUTH",
+        `Model-only lockout for ${provider}:${model} — ${status} ${reason} ${Math.ceil(lockout.cooldownMs / 1000)}s (failureCount=${lockout.failureCount}, connection stays active)`
+      );
+      return { shouldFallback: true, cooldownMs: lockout.cooldownMs };
+    }
+
     const result = checkFallbackError(
       status,
       errorText,
       backoffLevel,
       model,
-      provider // ← Now passes provider for profile-aware cooldowns
+      provider,
+      null,
+      effectiveProviderProfile
     );
     const { shouldFallback, cooldownMs, newBackoffLevel, reason } = result;
     if (!shouldFallback) return { shouldFallback: false, cooldownMs: 0 };
@@ -1140,14 +1154,7 @@ export async function markAccountUnavailable(
       | string
       | undefined;
 
-    const isPassthroughProvider = provider && getPassthroughProviders().has(provider);
-    const isPerModelQuotaProvider = hasPerModelQuota(provider);
-    if (
-      (isLocalProvider(connBaseUrl) || isPerModelQuotaProvider) &&
-      status === 404 &&
-      provider &&
-      model
-    ) {
+    if (isLocalProvider(connBaseUrl) && status === 404 && provider && model) {
       const localCooldown = COOLDOWN_MS.notFoundLocal;
       lockModel(provider, connectionId, model, "not_found", localCooldown);
       log.info(
@@ -1155,21 +1162,6 @@ export async function markAccountUnavailable(
         `Model-only lockout for ${model} — 404 lockout ${localCooldown / 1000}s (connection stays active)`
       );
       return { shouldFallback: true, cooldownMs: localCooldown };
-    }
-
-    // ── 429 model-only lockout for per-model quota providers ──
-    // For providers where each model has independent quota (passthrough providers,
-    // Gemini AI Studio), a 429 on one model should NOT lock out the entire connection
-    // — other models may still have quota available. Use lockModel() instead of
-    // connection-wide rateLimitedUntil.
-    if (isPerModelQuotaProvider && status === 429 && provider && model) {
-      const modelCooldown = cooldownMs || COOLDOWN_MS.rateLimit;
-      lockModel(provider, connectionId, model, reason || "rate_limited", modelCooldown);
-      log.info(
-        "AUTH",
-        `Model-only lockout for ${model} — 429 rate limit ${Math.ceil(modelCooldown / 1000)}s (connection stays active)`
-      );
-      return { shouldFallback: true, cooldownMs: modelCooldown };
     }
 
     const rateLimitedUntil = getUnavailableUntil(cooldownMs);

--- a/src/sse/services/auth.ts
+++ b/src/sse/services/auth.ts
@@ -1147,21 +1147,34 @@ export async function markAccountUnavailable(
     if (!shouldFallback) return { shouldFallback: false, cooldownMs: 0 };
 
     // ── 404 model-only lockout: connection stays active ──
-    // For local providers (detected by URL) and cloud providers with passthrough models
-    // (like Antigravity), a 404 means the specific model doesn't exist or isn't available
-    // for this account — it should NOT lock out the entire connection.
+    // For local providers (detected by URL), a 404 means the specific model
+    // doesn't exist or isn't available for this account — it should NOT lock
+    // out the entire connection.
     const connBaseUrl = (conn?.providerSpecificData as Record<string, unknown>)?.baseUrl as
       | string
       | undefined;
 
     if (isLocalProvider(connBaseUrl) && status === 404 && provider && model) {
-      const localCooldown = COOLDOWN_MS.notFoundLocal;
-      lockModel(provider, connectionId, model, "not_found", localCooldown);
+      const lockout = recordModelLockoutFailure(
+        provider,
+        connectionId,
+        model,
+        "not_found",
+        status,
+        COOLDOWN_MS.notFoundLocal,
+        effectiveProviderProfile
+      );
+      updateProviderConnection(connectionId, {
+        lastErrorType: "not_found",
+        lastError: `Model ${model} not_found`,
+        lastErrorAt: new Date().toISOString(),
+        errorCode: status,
+      }).catch(() => {});
       log.info(
         "AUTH",
-        `Model-only lockout for ${model} — 404 lockout ${localCooldown / 1000}s (connection stays active)`
+        `Model-only lockout for ${provider}:${model} — 404 not_found ${Math.ceil(lockout.cooldownMs / 1000)}s (failureCount=${lockout.failureCount}, connection stays active)`
       );
-      return { shouldFallback: true, cooldownMs: localCooldown };
+      return { shouldFallback: true, cooldownMs: lockout.cooldownMs };
     }
 
     const rateLimitedUntil = getUnavailableUntil(cooldownMs);

--- a/tests/unit/account-fallback-service.test.mjs
+++ b/tests/unit/account-fallback-service.test.mjs
@@ -156,10 +156,12 @@ test("lockModelIfPerModelQuota only locks supported providers and real models", 
   const geminiConnectionId = `gemini-${Date.now()}`;
   const openAiConnectionId = `openai-${Date.now()}`;
   const compatibleConnectionId = `compatible-${Date.now()}`;
+  const compatibleProvider = "openai-compatible-custom-node";
+  const compatibleModel = "custom-model-a";
 
   assert.equal(hasPerModelQuota("gemini"), true);
   assert.equal(hasPerModelQuota("openai"), false);
-  assert.equal(hasPerModelQuota("openai-compatible-sp-google", "gemini-3.1-pro-preview"), true);
+  assert.equal(hasPerModelQuota(compatibleProvider, compatibleModel), true);
 
   assert.equal(
     lockModelIfPerModelQuota(
@@ -187,18 +189,15 @@ test("lockModelIfPerModelQuota only locks supported providers and real models", 
 
   assert.equal(
     lockModelIfPerModelQuota(
-      "openai-compatible-sp-google",
+      compatibleProvider,
       compatibleConnectionId,
-      "gemini-3.1-pro-preview",
+      compatibleModel,
       RateLimitReason.RATE_LIMIT_EXCEEDED,
       30_000
     ),
     true
   );
-  assert.equal(
-    isModelLocked("openai-compatible-sp-google", compatibleConnectionId, "gemini-3.1-pro-preview"),
-    true
-  );
+  assert.equal(isModelLocked(compatibleProvider, compatibleConnectionId, compatibleModel), true);
 });
 
 test("getProviderProfile differentiates oauth and api-key providers", () => {
@@ -206,10 +205,10 @@ test("getProviderProfile differentiates oauth and api-key providers", () => {
   assert.deepEqual(getProviderProfile("openai"), PROVIDER_PROFILES.apikey);
 });
 
-test("shouldMarkAccountExhaustedFrom429 skips compatible Gemini model cooldown poisoning", () => {
+test("shouldMarkAccountExhaustedFrom429 skips connection poisoning for compatible providers", () => {
   assert.equal(shouldMarkAccountExhaustedFrom429("gemini", "gemini-2.5-pro"), false);
   assert.equal(
-    shouldMarkAccountExhaustedFrom429("openai-compatible-sp-google", "gemini-3.1-pro-preview"),
+    shouldMarkAccountExhaustedFrom429("openai-compatible-custom-node", "any-model"),
     false
   );
   assert.equal(shouldMarkAccountExhaustedFrom429("openai", "gpt-4o-mini"), true);
@@ -221,6 +220,8 @@ test("recordModelLockoutFailure uses provider profile cooldowns, backoff, and re
   Date.now = () => now;
 
   try {
+    const compatibleProvider = "openai-compatible-custom-node";
+    const compatibleModel = "custom-model-a";
     const profile = {
       transientCooldown: 250,
       rateLimitCooldown: 125,
@@ -230,9 +231,9 @@ test("recordModelLockoutFailure uses provider profile cooldowns, backoff, and re
     };
 
     const first = recordModelLockoutFailure(
-      "openai-compatible-sp-google",
+      compatibleProvider,
       "conn-compatible",
-      "gemini-3.1-pro-preview",
+      compatibleModel,
       "rate_limited",
       429,
       0,
@@ -240,9 +241,9 @@ test("recordModelLockoutFailure uses provider profile cooldowns, backoff, and re
     );
     now += 50;
     const second = recordModelLockoutFailure(
-      "openai-compatible-sp-google",
+      compatibleProvider,
       "conn-compatible",
-      "gemini-3.1-pro-preview",
+      compatibleModel,
       "rate_limited",
       429,
       0,
@@ -250,20 +251,16 @@ test("recordModelLockoutFailure uses provider profile cooldowns, backoff, and re
     );
     now += 50;
     const third = recordModelLockoutFailure(
-      "openai-compatible-sp-google",
+      compatibleProvider,
       "conn-compatible",
-      "gemini-3.1-pro-preview",
+      compatibleModel,
       "rate_limited",
       429,
       0,
       profile
     );
 
-    const info = getModelLockoutInfo(
-      "openai-compatible-sp-google",
-      "conn-compatible",
-      "gemini-3.1-pro-preview"
-    );
+    const info = getModelLockoutInfo(compatibleProvider, "conn-compatible", compatibleModel);
 
     assert.equal(first.failureCount, 1);
     assert.equal(first.cooldownMs, 125);
@@ -273,13 +270,13 @@ test("recordModelLockoutFailure uses provider profile cooldowns, backoff, and re
     assert.equal(third.cooldownMs, 500);
     assert.equal(info.failureCount, 3);
 
-    clearModelLock("openai-compatible-sp-google", "conn-compatible", "gemini-3.1-pro-preview");
+    clearModelLock(compatibleProvider, "conn-compatible", compatibleModel);
     now += 600;
 
     const afterReset = recordModelLockoutFailure(
-      "openai-compatible-sp-google",
+      compatibleProvider,
       "conn-compatible",
-      "gemini-3.1-pro-preview",
+      compatibleModel,
       "rate_limited",
       429,
       0,
@@ -290,6 +287,6 @@ test("recordModelLockoutFailure uses provider profile cooldowns, backoff, and re
     assert.equal(afterReset.cooldownMs, 125);
   } finally {
     Date.now = originalNow;
-    clearModelLock("openai-compatible-sp-google", "conn-compatible", "gemini-3.1-pro-preview");
+    clearModelLock("openai-compatible-custom-node", "conn-compatible", "custom-model-a");
   }
 });

--- a/tests/unit/account-fallback-service.test.mjs
+++ b/tests/unit/account-fallback-service.test.mjs
@@ -16,8 +16,12 @@ const {
   applyErrorState,
   lockModelIfPerModelQuota,
   isModelLocked,
+  getModelLockoutInfo,
   hasPerModelQuota,
   getProviderProfile,
+  recordModelLockoutFailure,
+  clearModelLock,
+  shouldMarkAccountExhaustedFrom429,
 } = accountFallback;
 
 const { selectAccount } = accountSelector;
@@ -151,9 +155,11 @@ test("applyErrorState and selectAccount advance to the next account after an aut
 test("lockModelIfPerModelQuota only locks supported providers and real models", () => {
   const geminiConnectionId = `gemini-${Date.now()}`;
   const openAiConnectionId = `openai-${Date.now()}`;
+  const compatibleConnectionId = `compatible-${Date.now()}`;
 
   assert.equal(hasPerModelQuota("gemini"), true);
   assert.equal(hasPerModelQuota("openai"), false);
+  assert.equal(hasPerModelQuota("openai-compatible-sp-google", "gemini-3.1-pro-preview"), true);
 
   assert.equal(
     lockModelIfPerModelQuota(
@@ -178,9 +184,112 @@ test("lockModelIfPerModelQuota only locks supported providers and real models", 
     false
   );
   assert.equal(isModelLocked("openai", openAiConnectionId, "gpt-5-mini"), false);
+
+  assert.equal(
+    lockModelIfPerModelQuota(
+      "openai-compatible-sp-google",
+      compatibleConnectionId,
+      "gemini-3.1-pro-preview",
+      RateLimitReason.RATE_LIMIT_EXCEEDED,
+      30_000
+    ),
+    true
+  );
+  assert.equal(
+    isModelLocked("openai-compatible-sp-google", compatibleConnectionId, "gemini-3.1-pro-preview"),
+    true
+  );
 });
 
 test("getProviderProfile differentiates oauth and api-key providers", () => {
   assert.deepEqual(getProviderProfile("claude"), PROVIDER_PROFILES.oauth);
   assert.deepEqual(getProviderProfile("openai"), PROVIDER_PROFILES.apikey);
+});
+
+test("shouldMarkAccountExhaustedFrom429 skips compatible Gemini model cooldown poisoning", () => {
+  assert.equal(shouldMarkAccountExhaustedFrom429("gemini", "gemini-2.5-pro"), false);
+  assert.equal(
+    shouldMarkAccountExhaustedFrom429("openai-compatible-sp-google", "gemini-3.1-pro-preview"),
+    false
+  );
+  assert.equal(shouldMarkAccountExhaustedFrom429("openai", "gpt-4o-mini"), true);
+});
+
+test("recordModelLockoutFailure uses provider profile cooldowns, backoff, and reset window", () => {
+  const originalNow = Date.now;
+  let now = 1_700_000_000_000;
+  Date.now = () => now;
+
+  try {
+    const profile = {
+      transientCooldown: 250,
+      rateLimitCooldown: 125,
+      maxBackoffLevel: 2,
+      circuitBreakerThreshold: 60,
+      circuitBreakerReset: 500,
+    };
+
+    const first = recordModelLockoutFailure(
+      "openai-compatible-sp-google",
+      "conn-compatible",
+      "gemini-3.1-pro-preview",
+      "rate_limited",
+      429,
+      0,
+      profile
+    );
+    now += 50;
+    const second = recordModelLockoutFailure(
+      "openai-compatible-sp-google",
+      "conn-compatible",
+      "gemini-3.1-pro-preview",
+      "rate_limited",
+      429,
+      0,
+      profile
+    );
+    now += 50;
+    const third = recordModelLockoutFailure(
+      "openai-compatible-sp-google",
+      "conn-compatible",
+      "gemini-3.1-pro-preview",
+      "rate_limited",
+      429,
+      0,
+      profile
+    );
+
+    const info = getModelLockoutInfo(
+      "openai-compatible-sp-google",
+      "conn-compatible",
+      "gemini-3.1-pro-preview"
+    );
+
+    assert.equal(first.failureCount, 1);
+    assert.equal(first.cooldownMs, 125);
+    assert.equal(second.failureCount, 2);
+    assert.equal(second.cooldownMs, 250);
+    assert.equal(third.failureCount, 3);
+    assert.equal(third.cooldownMs, 500);
+    assert.equal(info.failureCount, 3);
+
+    clearModelLock("openai-compatible-sp-google", "conn-compatible", "gemini-3.1-pro-preview");
+    now += 600;
+
+    const afterReset = recordModelLockoutFailure(
+      "openai-compatible-sp-google",
+      "conn-compatible",
+      "gemini-3.1-pro-preview",
+      "rate_limited",
+      429,
+      0,
+      profile
+    );
+
+    assert.equal(afterReset.failureCount, 1);
+    assert.equal(afterReset.cooldownMs, 125);
+  } finally {
+    Date.now = originalNow;
+    clearModelLock("openai-compatible-sp-google", "conn-compatible", "gemini-3.1-pro-preview");
+  }
 });

--- a/tests/unit/batch-a-domain.test.mjs
+++ b/tests/unit/batch-a-domain.test.mjs
@@ -94,6 +94,71 @@ describe("modelAvailability", () => {
     assert.equal(afterReset.failureCount, 1);
     assert.equal(afterReset.cooldownMs, 120000);
   });
+
+  it("should use provider profile threshold, cooldowns, and reset window for global quarantine", () => {
+    const originalNow = Date.now;
+    let now = 10_000;
+    Date.now = () => now;
+
+    try {
+      const profile = {
+        transientCooldown: 200,
+        rateLimitCooldown: 100,
+        maxBackoffLevel: 2,
+        circuitBreakerThreshold: 3,
+        circuitBreakerReset: 500,
+      };
+
+      const first = markModelAsProblematic("openai", "gpt-4o-mini", {
+        status: 429,
+        reason: "HTTP 429",
+        profile,
+      });
+      const second = markModelAsProblematic("openai", "gpt-4o-mini", {
+        status: 429,
+        reason: "HTTP 429",
+        profile,
+      });
+
+      assert.equal(first.failureCount, 1);
+      assert.equal(first.cooldownMs, 100);
+      assert.equal(first.quarantined, false);
+      assert.equal(isModelAvailable("openai", "gpt-4o-mini"), true);
+
+      assert.equal(second.failureCount, 2);
+      assert.equal(second.cooldownMs, 200);
+      assert.equal(second.quarantined, false);
+      assert.equal(isModelAvailable("openai", "gpt-4o-mini"), true);
+
+      now += 10;
+      const third = markModelAsProblematic("openai", "gpt-4o-mini", {
+        status: 429,
+        reason: "HTTP 429",
+        profile,
+      });
+
+      assert.equal(third.failureCount, 3);
+      assert.equal(third.cooldownMs, 400);
+      assert.equal(third.quarantined, true);
+      assert.equal(isModelAvailable("openai", "gpt-4o-mini"), false);
+
+      now += 600;
+      assert.equal(isModelAvailable("openai", "gpt-4o-mini"), true);
+
+      const afterWindow = markModelAsProblematic("openai", "gpt-4o-mini", {
+        status: 429,
+        reason: "HTTP 429",
+        profile,
+      });
+
+      assert.equal(afterWindow.failureCount, 1);
+      assert.equal(afterWindow.cooldownMs, 100);
+      assert.equal(afterWindow.quarantined, false);
+    } finally {
+      Date.now = originalNow;
+      clearModelUnavailability("openai", "gpt-4o-mini");
+    }
+  });
 });
 
 // ──────────────── T-19: Cost Rules ────────────────

--- a/tests/unit/chat-helpers.test.mjs
+++ b/tests/unit/chat-helpers.test.mjs
@@ -81,7 +81,7 @@ test("resolveModelOrError rejects malformed model strings", async () => {
 test("checkPipelineGates blocks models in cooldown", async () => {
   setModelUnavailable("openai", "gpt-4o-mini", 60_000, "cooldown");
 
-  const response = checkPipelineGates("openai", "gpt-4o-mini");
+  const response = await checkPipelineGates("openai", "gpt-4o-mini");
   const json = await response.json();
 
   assert.equal(response.status, 503);
@@ -93,11 +93,31 @@ test("checkPipelineGates blocks providers with an open circuit breaker", async (
   breaker.state = STATE.OPEN;
   breaker.lastFailureTime = Date.now();
 
-  const response = checkPipelineGates("openai", "gpt-4o-mini");
+  const response = await checkPipelineGates("openai", "gpt-4o-mini");
   const json = await response.json();
 
   assert.equal(response.status, 503);
   assert.match(json.error.message, /circuit breaker is open/i);
+});
+
+test("checkPipelineGates reapplies runtime breaker settings to existing breakers", async () => {
+  const breaker = getCircuitBreaker("openai", {
+    failureThreshold: 5,
+    resetTimeout: 30_000,
+  });
+  breaker.state = STATE.OPEN;
+  breaker.lastFailureTime = Date.now() - 6_000;
+
+  const response = await checkPipelineGates("openai", "gpt-4o-mini", {
+    providerProfile: {
+      circuitBreakerThreshold: 60,
+      circuitBreakerReset: 5_000,
+    },
+  });
+
+  assert.equal(response, null);
+  assert.equal(breaker.resetTimeout, 5_000);
+  assert.equal(breaker.failureThreshold, 60);
 });
 
 test("handleNoCredentials reports missing provider credentials and exhausted accounts", async () => {

--- a/tests/unit/combo-circuit-breaker.test.mjs
+++ b/tests/unit/combo-circuit-breaker.test.mjs
@@ -60,15 +60,15 @@ test("handleComboChat: circuit breaker opens after repeated 502 errors", async (
   };
   const breakerKey = getComboTargetBreakerKey(combo);
   const breaker = getCircuitBreaker(breakerKey, {
-    failureThreshold: 3,
+    failureThreshold: PROVIDER_PROFILES.apikey.circuitBreakerThreshold,
     resetTimeout: 60000,
   });
   breaker.reset();
 
   const log = mockLog();
 
-  // Send 3 requests that all fail with 502 → breaker should open
-  for (let i = 0; i < 3; i++) {
+  // Send requests that all fail with 502 until the API-key profile threshold is reached.
+  for (let i = 0; i < PROVIDER_PROFILES.apikey.circuitBreakerThreshold; i++) {
     await handleComboChat({
       body: {},
       combo,
@@ -82,9 +82,17 @@ test("handleComboChat: circuit breaker opens after repeated 502 errors", async (
 
   // Breaker should now be OPEN
   const status = breaker.getStatus();
-  console.log("=== BREAKER STATUS AFTER 3 CALLS ===", status);
-  assert.equal(status.state, STATE.OPEN, "Breaker should be OPEN after 3 failures");
-  assert.equal(status.failureCount, 3, "Failure count should be 3");
+  console.log("=== BREAKER STATUS AFTER THRESHOLD CALLS ===", status);
+  assert.equal(
+    status.state,
+    STATE.OPEN,
+    "Breaker should be OPEN after the API-key failure threshold is reached"
+  );
+  assert.equal(
+    status.failureCount,
+    PROVIDER_PROFILES.apikey.circuitBreakerThreshold,
+    "Failure count should match the API-key profile threshold"
+  );
 });
 
 test("handleComboChat: skips models with open circuit breaker", async () => {

--- a/tests/unit/sse-auth.test.mjs
+++ b/tests/unit/sse-auth.test.mjs
@@ -715,7 +715,19 @@ test("getProviderCredentials exposes copilotToken when present in providerSpecif
   assert.equal(selected.copilotToken, "copilot-token-value");
 });
 
-test("markAccountUnavailable performs a model-only lockout for local 404 responses", async () => {
+test("markAccountUnavailable uses configured cooldowns for local 404 model lockouts", async () => {
+  await settingsDb.updateSettings({
+    providerProfiles: {
+      apikey: {
+        transientCooldown: 250,
+        rateLimitCooldown: 125,
+        maxBackoffLevel: 3,
+        circuitBreakerThreshold: 60,
+        circuitBreakerReset: 5000,
+      },
+    },
+  });
+
   const connection = await seedConnection("openai", {
     name: "local-openai",
     providerSpecificData: {
@@ -733,9 +745,11 @@ test("markAccountUnavailable performs a model-only lockout for local 404 respons
   const updated = await providersDb.getProviderConnectionById(connection.id);
 
   assert.equal(result.shouldFallback, true);
-  assert.ok(result.cooldownMs > 0);
+  assert.equal(result.cooldownMs, 250);
   assert.equal(updated.testStatus, "active");
   assert.equal(updated.rateLimitedUntil, undefined);
+  assert.equal(updated.lastErrorType, "not_found");
+  assert.equal(Number(updated.errorCode), 404);
 });
 
 test("markAccountUnavailable applies a model-only lockout for Gemini 429 responses", async () => {

--- a/tests/unit/sse-auth.test.mjs
+++ b/tests/unit/sse-auth.test.mjs
@@ -761,6 +761,58 @@ test("markAccountUnavailable applies a model-only lockout for Gemini 429 respons
   assert.equal(Number(updated.errorCode), 429);
 });
 
+test("markAccountUnavailable applies a model-only lockout for compatible Gemini 429 responses", async () => {
+  const connection = await seedConnection("openai-compatible-sp-google", {
+    name: "compatible-gemini-model-limit",
+  });
+
+  const result = await auth.markAccountUnavailable(
+    connection.id,
+    429,
+    "The upstream Google service exhausted its capacity",
+    "openai-compatible-sp-google",
+    "gemini-3.1-pro-preview"
+  );
+  await flushWrites();
+  const updated = await providersDb.getProviderConnectionById(connection.id);
+
+  assert.equal(result.shouldFallback, true);
+  assert.ok(result.cooldownMs > 0);
+  assert.equal(updated.testStatus, "active");
+  assert.equal(updated.rateLimitedUntil, undefined);
+  assert.equal(updated.lastErrorType, "rate_limited");
+  assert.equal(Number(updated.errorCode), 429);
+});
+
+test("markAccountUnavailable honors configured api-key rate-limit cooldowns", async () => {
+  await settingsDb.updateSettings({
+    providerProfiles: {
+      apikey: {
+        transientCooldown: 200,
+        rateLimitCooldown: 125,
+        maxBackoffLevel: 3,
+        circuitBreakerThreshold: 60,
+        circuitBreakerReset: 5000,
+      },
+    },
+  });
+
+  const connection = await seedConnection("openai", {
+    name: "configured-rate-limit-cooldown",
+  });
+
+  const result = await auth.markAccountUnavailable(
+    connection.id,
+    429,
+    "too many requests",
+    "openai",
+    "gpt-4o-mini"
+  );
+
+  assert.equal(result.shouldFallback, true);
+  assert.equal(result.cooldownMs, 125);
+});
+
 test("markAccountUnavailable stores Codex scope-specific cooldowns without a global rate limit", async () => {
   const connection = await seedConnection("codex", {
     authType: "oauth",

--- a/tests/unit/sse-auth.test.mjs
+++ b/tests/unit/sse-auth.test.mjs
@@ -761,17 +761,17 @@ test("markAccountUnavailable applies a model-only lockout for Gemini 429 respons
   assert.equal(Number(updated.errorCode), 429);
 });
 
-test("markAccountUnavailable applies a model-only lockout for compatible Gemini 429 responses", async () => {
-  const connection = await seedConnection("openai-compatible-sp-google", {
-    name: "compatible-gemini-model-limit",
+test("markAccountUnavailable applies a model-only lockout for compatible provider 429 responses", async () => {
+  const connection = await seedConnection("openai-compatible-custom-node", {
+    name: "compatible-model-limit",
   });
 
   const result = await auth.markAccountUnavailable(
     connection.id,
     429,
-    "The upstream Google service exhausted its capacity",
-    "openai-compatible-sp-google",
-    "gemini-3.1-pro-preview"
+    "The upstream compatible service exhausted its capacity",
+    "openai-compatible-custom-node",
+    "custom-model-a"
   );
   await flushWrites();
   const updated = await providersDb.getProviderConnectionById(connection.id);


### PR DESCRIPTION
## Summary
- keep compatible-provider 429/404 handling model-scoped instead of poisoning the whole connection
- drive account/model lockouts, global model quarantine, combo breakers, and request-path breakers from runtime provider profiles
- reload updated breaker thresholds/reset windows for existing circuit breaker instances
- align local-provider 404 model lockouts with the same settings-driven cooldown/backoff semantics
- document that explicit upstream Retry-After windows override the base provider-profile cooldowns

## Root cause
- parts of the resilience / circuit-breaker stack were still hardcoded in code instead of being fully driven by the Provider Profiles settings
- because of that, the settings page values did not fully take effect across all lockout layers: some model lockouts, cooldown paths, and existing circuit breaker instances continued using fixed defaults or stale in-memory thresholds
- once a compatible provider returned a model-local 429/404, that hardcoded behavior could escalate the failure into a broader connection-level lockout even when the configured settings were much less aggressive

## Validation
- node --import tsx/esm --test tests/unit/account-fallback-service.test.mjs
- node --import tsx/esm --test tests/unit/sse-auth.test.mjs
- node --import tsx/esm --test tests/unit/batch-a-domain.test.mjs
- node --import tsx/esm --test tests/unit/chat-helpers.test.mjs
- node --import tsx/esm --test tests/unit/combo-circuit-breaker.test.mjs
- node --import tsx/esm --test tests/unit/error-classification.test.mjs
- node --import tsx/esm --test tests/unit/chat-route-coverage.test.mjs
- npm run typecheck:core
- npx eslint open-sse/services/accountFallback.ts src/sse/services/auth.ts src/sse/handlers/chat.ts src/sse/handlers/chatHelpers.ts src/domain/modelAvailability.ts src/shared/utils/circuitBreaker.ts open-sse/services/combo.ts tests/unit/account-fallback-service.test.mjs tests/unit/sse-auth.test.mjs tests/unit/batch-a-domain.test.mjs tests/unit/chat-helpers.test.mjs tests/unit/combo-circuit-breaker.test.mjs
- git push (pre-push hook ran npm run test:unit successfully: 2831 passed, 0 failed)
