### PR TITLE
fix false Codex healthcheck refresh failures

### DIFF
--- a/src/lib/tokenHealthCheck.ts
+++ b/src/lib/tokenHealthCheck.ts
@@ -35,6 +35,19 @@ function getConnectionLogLabel(conn: { name?: string; email?: string; id?: strin
   return pickMaskedDisplayValue([conn.name, conn.email], conn.id || "-");
 }
 
+export function extractResolvedProxyConfig(resolvedProxy: unknown) {
+  if (
+    resolvedProxy &&
+    typeof resolvedProxy === "object" &&
+    !Array.isArray(resolvedProxy) &&
+    "proxy" in resolvedProxy
+  ) {
+    return (resolvedProxy as { proxy?: unknown }).proxy ?? null;
+  }
+
+  return resolvedProxy ?? null;
+}
+
 export function buildRefreshFailureUpdate(conn: any, now: string) {
   const wasExpired = conn.testStatus === "expired";
   const retryCount = (conn.expiredRetryCount ?? 0) + (wasExpired ? 1 : 0);
@@ -202,7 +215,7 @@ async function sweep() {
 /**
  * Check a single connection and refresh if due.
  */
-async function checkConnection(conn) {
+export async function checkConnection(conn) {
   // Determine interval (0 = disabled)
   const intervalMin = conn.healthCheckInterval ?? DEFAULT_HEALTH_CHECK_INTERVAL_MIN;
   if (intervalMin <= 0) return;
@@ -255,7 +268,8 @@ async function checkConnection(conn) {
   };
 
   const hideLogs = await shouldHideLogs();
-  const proxyConfig = await resolveProxyForConnection(conn.id);
+  const proxyResolution = await resolveProxyForConnection(conn.id);
+  const proxyConfig = extractResolvedProxyConfig(proxyResolution);
   const result = await getAccessToken(
     conn.provider,
     credentials,

--- a/tests/unit/token-health-check.test.mjs
+++ b/tests/unit/token-health-check.test.mjs
@@ -1,9 +1,168 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import http from "node:http";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
 
 process.env.NODE_ENV = "test";
 
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-token-healthcheck-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const providersDb = await import("../../src/lib/db/providers.ts");
+const settingsDb = await import("../../src/lib/db/settings.ts");
+const { PROVIDERS } = await import("../../open-sse/config/constants.ts");
 const tokenHealthCheck = await import("../../src/lib/tokenHealthCheck.ts");
+
+async function resetStorage() {
+  core.resetDbInstance();
+
+  for (let attempt = 0; attempt < 10; attempt++) {
+    try {
+      if (fs.existsSync(TEST_DATA_DIR)) {
+        fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+      }
+      break;
+    } catch (error) {
+      if ((error?.code === "EBUSY" || error?.code === "EPERM") && attempt < 9) {
+        await new Promise((resolve) => setTimeout(resolve, 50 * (attempt + 1)));
+      } else {
+        throw error;
+      }
+    }
+  }
+
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+async function withHttpServer(handler, fn) {
+  const server = http.createServer(handler);
+
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+
+  try {
+    return await fn({
+      host: "127.0.0.1",
+      port: address.port,
+      url: `http://127.0.0.1:${address.port}`,
+    });
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => {
+        if (error) reject(error);
+        else resolve();
+      });
+    });
+  }
+}
+
+async function withConnectProxyServer(fn) {
+  const server = http.createServer((_req, res) => {
+    res.writeHead(501);
+    res.end("CONNECT only");
+  });
+
+  server.on("connect", (req, clientSocket, head) => {
+    const [host, portText] = String(req.url || "").split(":");
+    const targetPort = Number(portText || 80);
+    const upstreamSocket = net.connect(targetPort, host, () => {
+      clientSocket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+      if (head && head.length > 0) {
+        upstreamSocket.write(head);
+      }
+      upstreamSocket.pipe(clientSocket);
+      clientSocket.pipe(upstreamSocket);
+    });
+
+    const closeSockets = () => {
+      upstreamSocket.destroy();
+      clientSocket.destroy();
+    };
+
+    upstreamSocket.on("error", closeSockets);
+    clientSocket.on("error", closeSockets);
+  });
+
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+
+  try {
+    return await fn({
+      host: "127.0.0.1",
+      port: address.port,
+      url: `http://127.0.0.1:${address.port}`,
+    });
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => {
+        if (error) reject(error);
+        else resolve();
+      });
+    });
+  }
+}
+
+async function withPatchedProvider(providerId, config, fn) {
+  const hadOwnConfig = Object.prototype.hasOwnProperty.call(PROVIDERS, providerId);
+  const previousConfig = hadOwnConfig ? PROVIDERS[providerId] : undefined;
+  PROVIDERS[providerId] = config;
+
+  try {
+    return await fn();
+  } finally {
+    if (hadOwnConfig) {
+      PROVIDERS[providerId] = previousConfig;
+    } else {
+      delete PROVIDERS[providerId];
+    }
+  }
+}
+
+test.after(async () => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("extractResolvedProxyConfig unwraps proxy resolution metadata", () => {
+  const proxy = {
+    type: "http",
+    host: "proxy.example.test",
+    port: 8080,
+  };
+
+  assert.deepEqual(
+    tokenHealthCheck.extractResolvedProxyConfig({
+      proxy,
+      level: "account",
+      levelId: "conn-123",
+      source: "registry",
+    }),
+    proxy
+  );
+  assert.deepEqual(tokenHealthCheck.extractResolvedProxyConfig(proxy), proxy);
+  assert.equal(
+    tokenHealthCheck.extractResolvedProxyConfig({
+      proxy: null,
+      level: "direct",
+    }),
+    null
+  );
+  assert.equal(tokenHealthCheck.extractResolvedProxyConfig(null), null);
+});
 
 test("buildRefreshFailureUpdate keeps active connections routable after refresh failure", () => {
   const now = "2026-04-09T04:40:00.000Z";
@@ -40,4 +199,81 @@ test("buildRefreshFailureUpdate preserves expired retry tracking", () => {
   assert.equal(update.testStatus, "expired");
   assert.equal(update.expiredRetryCount, 3);
   assert.equal(update.expiredRetryAt, now);
+});
+
+test("checkConnection uses the resolved proxy payload when refreshing tokens", async () => {
+  await resetStorage();
+
+  const providerId = "custom-oauth-healthcheck";
+  const refreshRequests = [];
+
+  await withHttpServer(
+    (req, res) => {
+      let body = "";
+      req.setEncoding("utf8");
+      req.on("data", (chunk) => {
+        body += chunk;
+      });
+      req.on("end", () => {
+        refreshRequests.push({
+          method: req.method,
+          url: req.url,
+          headers: req.headers,
+          body,
+        });
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            access_token: "new-access-token",
+            refresh_token: "new-refresh-token",
+            expires_in: 3600,
+          })
+        );
+      });
+    },
+    async (tokenServer) => {
+      await withConnectProxyServer(async (proxy) => {
+        await withPatchedProvider(
+          providerId,
+          {
+            tokenUrl: `${tokenServer.url}/token`,
+            clientId: "healthcheck-client-id",
+            clientSecret: "healthcheck-client-secret",
+          },
+          async () => {
+            const connection = await providersDb.createProviderConnection({
+              provider: providerId,
+              authType: "oauth",
+              name: "Healthcheck Proxy Account",
+              email: "healthcheck@example.com",
+              accessToken: "stale-access-token",
+              refreshToken: "refresh-token-123",
+              isActive: true,
+            });
+
+            await settingsDb.setProxyForLevel("key", connection.id, {
+              type: "http",
+              host: proxy.host,
+              port: proxy.port,
+            });
+
+            await tokenHealthCheck.checkConnection(connection);
+
+            const updated = await providersDb.getProviderConnectionById(connection.id);
+
+            assert.equal(refreshRequests.length, 1);
+            assert.equal(refreshRequests[0].method, "POST");
+            assert.equal(refreshRequests[0].url, "/token");
+            assert.match(refreshRequests[0].body, /grant_type=refresh_token/);
+            assert.match(refreshRequests[0].body, /refresh_token=refresh-token-123/);
+            assert.equal(updated?.accessToken, "new-access-token");
+            assert.equal(updated?.refreshToken, "new-refresh-token");
+            assert.equal(updated?.testStatus, "active");
+            assert.equal(updated?.lastError ?? null, null);
+            assert.ok(updated?.tokenExpiresAt);
+          }
+        );
+      });
+    }
+  );
 });


### PR DESCRIPTION
## Summary
- fix the background token healthcheck to pass the resolved proxy payload, not the proxy-resolution metadata wrapper, into token refresh
- add a regression test that exercises token refresh through a resolved account proxy during healthcheck execution
- keep the existing manual refresh and request-time refresh paths unchanged

## Problem
Users could see Codex accounts marked as refresh failed on the provider page even though the account still worked in practice.

The concrete failure pattern was:
- the background healthcheck logged `Refreshing codex/... (interval: 60min)`
- token refresh then failed with `[ProxyDispatcher] Context proxy host is required`
- the provider page showed a failed refresh state
- manual token refresh still succeeded
- direct Codex model calls also succeeded

That made the failure look like a broken Codex OAuth refresh flow, but the issue was isolated to the scheduled healthcheck path.

## Root Cause
`resolveProxyForConnection()` returns a structured object like `{ proxy, level, levelId, ... }`.

The healthcheck code forwarded that wrapper object directly into the token refresh pipeline. The proxy dispatcher expects the raw proxy config itself, so the background refresh path could fail before the upstream token request was even attempted.

Manual refresh and request-time execution did not hit this bug because they resolve and pass a plain provider proxy object.

## What Changed
- unwrap the resolved proxy result before calling `getAccessToken()` from token healthcheck
- export the minimal helper needed to verify that unwrapping behavior in tests
- add a regression test with a local CONNECT proxy and token endpoint to prove the healthcheck refresh path succeeds when a connection-level proxy is configured

## Impact
- background Codex healthchecks no longer report false refresh failures caused by proxy wrapper objects
- the provider page should stop showing a failed refresh state for accounts that are otherwise healthy
- other OAuth providers using the same healthcheck refresh path benefit from the same fix

## Validation
- `node --import tsx/esm --test tests/unit/token-health-check.test.mjs`
- `node --import tsx/esm --test tests/unit/token-refresh-service.test.mjs`
- `node --import tsx/esm --test tests/unit/token-refresh-route-service.test.mjs`
- `npx eslint src/lib/tokenHealthCheck.ts tests/unit/token-health-check.test.mjs`
- repository pre-push unit suite triggered by `git push`
