### PR TITLE
fix: migration safety + 3 bug fixes (MCP timeout, kimi reasoning, GLM empty response)

### DIFF
--- a/open-sse/mcp-server/server.ts
+++ b/open-sse/mcp-server/server.ts
@@ -72,6 +72,7 @@ import { resolveOmniRouteBaseUrl } from "../../src/shared/utils/resolveOmniRoute
 
 const OMNIROUTE_BASE_URL = resolveOmniRouteBaseUrl();
 const OMNIROUTE_API_KEY = process.env.OMNIROUTE_API_KEY || "";
+const MCP_SEARCH_TIMEOUT_MS = Number(process.env.MCP_SEARCH_TIMEOUT_MS) || 20000;
 const MCP_ENFORCE_SCOPES = process.env.OMNIROUTE_MCP_ENFORCE_SCOPES === "true";
 const MCP_ALLOWED_SCOPES = new Set(
   (process.env.OMNIROUTE_MCP_SCOPES || "")
@@ -138,7 +139,11 @@ async function omniRouteFetch(path: string, options: RequestInit = {}): Promise<
     ...((options.headers as Record<string, string>) || {}),
   };
 
-  const response = await fetch(url, { ...options, headers, signal: AbortSignal.timeout(10000) });
+  const timeoutMs =
+    path.startsWith("/v1/search") || path.startsWith("/api/v1/search")
+      ? MCP_SEARCH_TIMEOUT_MS
+      : 10000;
+  const response = await fetch(url, { ...options, headers, signal: AbortSignal.timeout(timeoutMs) });
 
   if (!response.ok) {
     const errorText = await response.text().catch(() => "Unknown error");

--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -621,6 +621,22 @@ function sortTargetsByContextSize(targets: ResolvedComboTarget[]) {
     .filter((target): target is ResolvedComboTarget => target !== null);
 }
 
+function groupTargetsByProvider(targets: ResolvedComboTarget[]): ResolvedComboTarget[] {
+  const providerOrder: string[] = [];
+  const providerGroups = new Map<string, ResolvedComboTarget[]>();
+
+  for (const target of targets) {
+    const key = target.provider;
+    if (!providerGroups.has(key)) {
+      providerOrder.push(key);
+      providerGroups.set(key, []);
+    }
+    providerGroups.get(key)!.push(target);
+  }
+
+  return providerOrder.flatMap((provider) => providerGroups.get(provider) || []);
+}
+
 function toTextContent(content) {
   if (typeof content === "string") return content;
   if (!Array.isArray(content)) return "";
@@ -1295,6 +1311,11 @@ export async function handleComboChat({
   } else if (strategy === "context-optimized") {
     orderedTargets = sortTargetsByContextSize(orderedTargets);
     log.info("COMBO", `Context-optimized ordering: largest first (${orderedTargets[0]?.modelStr})`);
+  }
+
+  if (strategy === "priority" && orderedTargets.length > 1) {
+    orderedTargets = groupTargetsByProvider(orderedTargets);
+    log.info("COMBO", `Priority: grouped by provider (${orderedTargets.map((t) => t.executionKey).join(", ")})`);
   }
 
   if (orderedTargets.length === 0) {

--- a/open-sse/services/errorClassifier.ts
+++ b/open-sse/services/errorClassifier.ts
@@ -26,6 +26,20 @@ export function isEmptyContentResponse(responseBody: unknown): boolean {
     const hasReasoning =
       reasoningContent !== null && reasoningContent !== undefined && reasoningContent !== "";
 
+    if (hasContent || hasReasoning || hasToolCalls) return false;
+
+    // Detect quota-exhausted zero-token responses (e.g. GLM coding plan at limit):
+    // finish_reason="stop" with content=null and all usage fields 0.
+    // These are not real completions — the upstream silently returned empty.
+    const usage = body.usage as Record<string, unknown> | undefined;
+    if (
+      usage &&
+      (usage.prompt_tokens === 0 || usage.prompt_tokens === "0") &&
+      (usage.completion_tokens === 0 || usage.completion_tokens === "0")
+    ) {
+      return true;
+    }
+
     return !hasContent && !hasReasoning && !hasToolCalls;
   }
 

--- a/open-sse/translator/index.ts
+++ b/open-sse/translator/index.ts
@@ -207,7 +207,8 @@ export function translateRequest(
   // Inject reasoning_content = "" for DeepSeek/Reasoning models assistant messages with tool_calls
   // if omitted by the client, to avoid upstream 400 errors (e.g. "Messages with role 'assistant' that contain tool_calls must also include reasoning_content")
   const isReasoner =
-    provider === "deepseek" || (typeof model === "string" && /r1|reason/i.test(model));
+    provider === "deepseek" ||
+    (typeof model === "string" && /r1|reason|kimi/i.test(model));
   if (isReasoner && result.messages && Array.isArray(result.messages)) {
     for (const msg of result.messages) {
       if (

--- a/src/app/api/combos/test/route.ts
+++ b/src/app/api/combos/test/route.ts
@@ -1,6 +1,11 @@
 import { randomUUID } from "node:crypto";
 import { NextResponse } from "next/server";
-import { buildComboTestRequestBody, extractComboTestResponseText } from "@/lib/combos/testHealth";
+import {
+  buildComboTestRequestBody,
+  buildComboTestRequestBodyEmbedding,
+  extractComboTestResponseText,
+  isEmbeddingModel,
+} from "@/lib/combos/testHealth";
 import { getComboByName, getCombos } from "@/lib/localDb";
 import { resolveNestedComboTargets } from "@omniroute/open-sse/services/combo.ts";
 import { testComboSchema } from "@/shared/validation/schemas";
@@ -18,19 +23,21 @@ function buildComboTestResult(target, partial = {}) {
   };
 }
 
-async function testComboTarget(target, internalUrl) {
+async function testComboTarget(target, internalUrl, useEmbeddingsEndpoint = false) {
   const startTime = Date.now();
   try {
-    // Send a minimal but real chat request through the same internal
-    // endpoint an external OpenAI-compatible client would use.
-    const testBody = buildComboTestRequestBody(target.modelStr);
+    const testBody = useEmbeddingsEndpoint
+      ? buildComboTestRequestBodyEmbedding(target.modelStr)
+      : buildComboTestRequestBody(target.modelStr);
+
+    const endpoint = useEmbeddingsEndpoint ? "/v1/embeddings" : "/v1/chat/completions";
 
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 20000);
 
     let res;
     try {
-      res = await fetch(internalUrl, {
+      res = await fetch(`${internalUrl}${endpoint}`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -58,6 +65,24 @@ async function testComboTarget(target, internalUrl) {
         responseBody = await res.json();
       } catch {
         responseBody = null;
+      }
+
+      if (useEmbeddingsEndpoint) {
+        const embeddingData =
+          Array.isArray(responseBody?.data) && responseBody.data.length > 0;
+        if (embeddingData) {
+          return buildComboTestResult(target, {
+            status: "ok",
+            latencyMs,
+            responseText: `[embedding OK: ${responseBody.data.length} vector(s)]`,
+          });
+        }
+        return buildComboTestResult(target, {
+          status: "error",
+          statusCode: res.status,
+          error: "Provider returned HTTP 200 but no embedding data.",
+          latencyMs,
+        });
       }
 
       const responseText = extractComboTestResponseText(responseBody);
@@ -137,9 +162,12 @@ export async function POST(request) {
       return NextResponse.json({ error: "Combo has no models" }, { status: 400 });
     }
 
-    const internalUrl = `${getBaseUrl(request)}/v1/chat/completions`;
+    const useEmbeddings = targets.some((t) => isEmbeddingModel(t.modelStr));
+    const baseUrl = getBaseUrl(request);
     const results = await Promise.all(
-      targets.map((target) => testComboTarget(target, internalUrl))
+      targets.map((target) =>
+        testComboTarget(target, baseUrl, useEmbeddings)
+      )
     );
     const resolvedResult = results.find((result) => result.status === "ok") || null;
     const resolvedBy = resolvedResult?.model || null;

--- a/src/app/api/v1/embeddings/route.ts
+++ b/src/app/api/v1/embeddings/route.ts
@@ -22,7 +22,8 @@ import { enforceApiKeyPolicy } from "@/shared/utils/apiKeyPolicy";
 import { v1EmbeddingsSchema } from "@/shared/validation/schemas";
 import { isValidationFailure, validateBody } from "@/shared/validation/helpers";
 
-import { getAllCustomModels, getProviderNodes } from "@/lib/localDb";
+import { getAllCustomModels, getProviderNodes, getComboByName, getCombos } from "@/lib/localDb";
+import { resolveNestedComboTargets } from "@omniroute/open-sse/services/combo.ts";
 
 /**
  * Handle CORS preflight
@@ -148,8 +149,24 @@ export async function POST(request) {
     log.error("EMBED", `Failed to load provider_nodes for embeddings: ${err}`);
   }
 
+  // Resolve combo alias: if body.model is a combo name, expand to first target's provider/model
+  let effectiveModel = body.model;
+  try {
+    const combo = await getComboByName(body.model);
+    if (combo && Array.isArray(combo.models) && combo.models.length > 0) {
+      const allCombos = await getCombos();
+      const targets = resolveNestedComboTargets(combo, allCombos);
+      if (targets.length > 0) {
+        effectiveModel = targets[0].modelStr;
+        log.info("EMBED", `Resolved combo "${body.model}" → ${effectiveModel}`);
+      }
+    }
+  } catch {
+    // body.model is not a combo name — use as-is
+  }
+
   // Parse model to get provider
-  const { provider, model: resolvedModel } = parseEmbeddingModel(body.model, dynamicProviders);
+  const { provider, model: resolvedModel } = parseEmbeddingModel(effectiveModel, dynamicProviders);
   if (!provider) {
     return errorResponse(
       HTTP_STATUS.BAD_REQUEST,

--- a/src/lib/combos/testHealth.ts
+++ b/src/lib/combos/testHealth.ts
@@ -121,14 +121,30 @@ function buildComboTestPrompt() {
 export function buildComboTestRequestBody(modelStr: string) {
   return {
     model: modelStr,
-    // Randomize the arithmetic prompt so upstream providers are less likely to
-    // satisfy the smoke test with cached completions.
     messages: [{ role: "user", content: buildComboTestPrompt() }],
-    // Give reasoning-heavy models enough headroom to finish the request and
-    // still emit a visible answer without immediate truncation.
     max_tokens: COMBO_TEST_MAX_TOKENS,
     stream: false,
   };
+}
+
+export function buildComboTestRequestBodyEmbedding(modelStr: string) {
+  return {
+    model: modelStr,
+    input: "OmniRoute embedding combo health check",
+  };
+}
+
+const EMBEDDING_MODEL_PATTERNS = [
+  /embed/i,
+  /e5-/i,
+  /bge-/i,
+  /text-embedding/i,
+  /mistral-embed/i,
+  /nomic-embed/i,
+];
+
+export function isEmbeddingModel(modelStr: string): boolean {
+  return EMBEDDING_MODEL_PATTERNS.some((p) => p.test(modelStr));
 }
 
 export function extractComboTestResponseText(responseBody: unknown): string {

--- a/src/lib/db/migrationRunner.ts
+++ b/src/lib/db/migrationRunner.ts
@@ -2,11 +2,16 @@
  * Migration Runner — Versioned SQL Migrations for SQLite
  *
  * Reads numbered `.sql` files from the migrations directory and applies
- * them sequentially, tracking applied versions in a `schema_migrations` table.
+ * them sequentially, tracking applied versions in `_omniroute_migrations`.
  *
  * Naming convention: `NNN_description.sql` (e.g., `001_initial_schema.sql`)
  *
  * All migrations run within a single transaction — all-or-nothing per file.
+ *
+ * Safety features:
+ * - Pre-migration backup before applying any pending migrations
+ * - Mass-migration detection (abort if too many pending on existing DB)
+ * - Migration name mismatch warning (detects renumbering issues)
  */
 
 import fs from "fs";
@@ -34,6 +39,16 @@ function resolveMigrationsDir(): string {
 }
 
 const MIGRATIONS_DIR = resolveMigrationsDir();
+
+/**
+ * Maximum number of migrations allowed to run in a single startup on an
+ * existing database. If more migrations are pending than this threshold,
+ * it likely means the migration tracking table was accidentally wiped,
+ * and running all migrations from scratch could cause data loss.
+ *
+ * Set to 0 to disable this safety check.
+ */
+const MAX_PENDING_MIGRATIONS_ON_EXISTING_DB = 5;
 
 /**
  * Ensure the schema_migrations tracking table exists.
@@ -81,19 +96,171 @@ function getAppliedVersions(db: Database.Database): Set<string> {
 }
 
 /**
+ * Get applied migration records (version + name) for mismatch detection.
+ */
+function getAppliedRecords(
+  db: Database.Database
+): Array<{ version: string; name: string }> {
+  return db.prepare("SELECT version, name FROM _omniroute_migrations ORDER BY version").all() as Array<{
+    version: string;
+    name: string;
+  }>;
+}
+
+/**
+ * Detect migration name mismatches — when a migration version number
+ * has been reused/renumbered with a different name. This is a strong signal
+ * that the migration tracking is corrupted or migrations were renumbered.
+ */
+function detectNameMismatches(
+  appliedRecords: Array<{ version: string; name: string }>,
+  files: Array<{ version: string; name: string; path: string }>
+): Array<{ version: string; appliedName: string; diskName: string }> {
+  const appliedByName = new Map(appliedRecords.map((r) => [r.version, r.name]));
+  const mismatches: Array<{ version: string; appliedName: string; diskName: string }> = [];
+
+  for (const file of files) {
+    const appliedName = appliedByName.get(file.version);
+    if (appliedName && appliedName !== file.name) {
+      mismatches.push({
+        version: file.version,
+        appliedName,
+        diskName: file.name,
+      });
+    }
+  }
+
+  return mismatches;
+}
+
+/**
+ * Create a pre-migration backup of the SQLite database using VACUUM INTO.
+ * Returns the backup path on success, null on failure.
+ */
+function createPreMigrationBackup(db: Database.Database): string | null {
+  try {
+    const sqliteFile = db.name;
+    if (!sqliteFile || sqliteFile === ":memory:") return null;
+
+    const backupDir = path.join(path.dirname(sqliteFile), "db_backups");
+    if (!fs.existsSync(backupDir)) {
+      fs.mkdirSync(backupDir, { recursive: true });
+    }
+
+    const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const backupPath = path.join(backupDir, `db_${timestamp}_pre-migration.sqlite`);
+    const escapedBackupPath = backupPath.replace(/'/g, "''");
+
+    db.exec(`VACUUM INTO '${escapedBackupPath}'`);
+    console.log(`[Migration] Pre-migration backup created: ${backupPath}`);
+    return backupPath;
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn(`[Migration] Failed to create pre-migration backup: ${message}`);
+    return null;
+  }
+}
+
+/**
  * Run all pending migrations in order.
  * Returns the number of migrations applied.
+ *
+ * Includes safety checks:
+ * 1. Detects migration name mismatches (renumbering) and warns
+ * 2. Aborts if too many pending migrations on an existing DB (likely wipe)
+ * 3. Creates automatic backup before running any migrations
  */
 export function runMigrations(db: Database.Database): number {
   ensureMigrationsTable(db);
 
   const files = getMigrationFiles();
   const applied = getAppliedVersions(db);
+  const appliedRecords = getAppliedRecords(db);
+
+  // ── Safety Check 1: Detect migration name mismatches (renumbering) ──
+  const mismatches = detectNameMismatches(appliedRecords, files);
+  if (mismatches.length > 0) {
+    console.error(
+      `[Migration] ⚠️  CRITICAL: ${mismatches.length} migration version(s) have been renumbered!`
+    );
+    for (const m of mismatches) {
+      console.error(
+        `  Version ${m.version}: applied as "${m.appliedName}" but disk has "${m.diskName}"`
+      );
+    }
+    console.error(
+      `[Migration] This indicates migrations were renumbered between releases, ` +
+        `which can cause the migration runner to skip or re-run migrations incorrectly.`
+    );
+    console.error(
+      `[Migration] The version-only tracking will skip these (version already applied), ` +
+        `but please report this to the OmniRoute maintainers.`
+    );
+  }
+
+  // Collect pending migrations
+  const pending = files.filter((f) => !applied.has(f.version));
+  const pendingCount = pending.length;
+
+  if (pendingCount === 0) return 0;
+
+  // ── Safety Check 2: Mass-migration detection on existing DB ──
+  // If there are applied migrations already, but suddenly many are pending,
+  // the migration tracking table was likely wiped.
+  const hasAppliedMigrations = appliedRecords.length > 0;
+  const hasExistingData =
+    hasAppliedMigrations ||
+    (() => {
+      try {
+        const row = db
+          .prepare("SELECT COUNT(*) as c FROM provider_connections")
+          .get() as { c?: number } | undefined;
+        return Boolean(row && row.c > 0);
+      } catch {
+        return false;
+      }
+    })();
+
+  if (
+    hasExistingData &&
+    MAX_PENDING_MIGRATIONS_ON_EXISTING_DB > 0 &&
+    pendingCount > MAX_PENDING_MIGRATIONS_ON_EXISTING_DB
+  ) {
+    console.error(
+      `[Migration] 🚨 FATAL SAFETY ABORT: ${pendingCount} migrations are pending on a database ` +
+        `that already contains data, but only ${appliedRecords.length} migration(s) are recorded.`
+    );
+    console.error(
+      `[Migration] This likely means the _omniroute_migrations table was accidentally wiped, ` +
+        `which would cause all migrations to re-run from scratch.`
+    );
+    console.error(
+      `[Migration] To protect your data, migrations have been ABORTED. ` +
+        `The database will start with the existing schema.`
+    );
+    console.error(
+      `[Migration] To override this safety check, set environment variable: ` +
+        `OMNIROUTE_SKIP_MIGRATION_SAFETY=1`
+    );
+    console.error(
+      `[Migration] Pending migrations: ${pending.map((p) => `${p.version}_${p.name}`).join(", ")}`
+    );
+
+    if (process.env.OMNIROUTE_SKIP_MIGRATION_SAFETY !== "1") {
+      return 0;
+    }
+    console.warn(
+      `[Migration] Safety check bypassed via OMNIROUTE_SKIP_MIGRATION_SAFETY=1. Proceeding with caution.`
+    );
+  }
+
+  // ── Safety Check 3: Pre-migration backup ──
+  createPreMigrationBackup(db);
+
+  // ── Run pending migrations ──
   let count = 0;
 
-  for (const migration of files) {
-    if (applied.has(migration.version)) continue;
-
+  for (const migration of pending) {
     const sql = fs.readFileSync(migration.path, "utf-8");
 
     const applyMigration = db.transaction(() => {

--- a/src/lib/db/migrationRunner.ts
+++ b/src/lib/db/migrationRunner.ts
@@ -215,7 +215,7 @@ export function runMigrations(db: Database.Database): number {
         const row = db
           .prepare("SELECT COUNT(*) as c FROM provider_connections")
           .get() as { c?: number } | undefined;
-        return Boolean(row && row.c > 0);
+        return Boolean(row && (row.c ?? 0) > 0);
       } catch {
         return false;
       }


### PR DESCRIPTION
## Summary

Fixes for 6 open issues, all validated with clean CI (Lint ✅, Build ✅, E2E ✅, Security Tests ✅, i18n ✅).

### Fixes

| Fix | Issue | File(s) | Change |
|---|---|---|---|
| Migration safety | #1279 | `src/lib/db/migrationRunner.ts` | Pre-migration backup, mass-migration detection (abort if 5+ pending), name mismatch warning |
| MCP search timeout | #1278 | `open-sse/mcp-server/server.ts` | Endpoint-aware timeout: 20s for `/v1/search` (configurable via `MCP_SEARCH_TIMEOUT_MS`), 10s for others |
| kimi-k2.5 reasoning | #1273 | `open-sse/translator/index.ts` | Added `kimi` to `isReasoner` regex: `/r1|reason|kimi/i` |
| GLM empty response | #1282 | `open-sse/services/errorClassifier.ts` | Detect zero-token responses with null content as quota-exhausted |
| Embedding combo alias | #1260 | `src/app/api/v1/embeddings/route.ts`, `src/lib/combos/testHealth.ts`, `src/app/api/combos/test/route.ts` | `/v1/embeddings` resolves combo names; combo test detects embedding models and uses correct endpoint |
| Priority provider grouping | #1233 | `open-sse/services/combo.ts` | Priority strategy groups targets by provider so fallback iterates same-provider accounts together |
| TS type fix | — | `src/lib/db/migrationRunner.ts` | Fix `TS18048: 'row.c' is possibly 'undefined'` |

### CI Status (4 commits, clean branch)

- ✅ Build, ✅ Lint, ✅ E2E (all 4 shards), ✅ Security Tests, ✅ Kilo Code Review, ✅ i18n (30/30)
- ❌ 4 pre-existing failures also present on upstream `main` (Snyk auth expired, flaky integration/unit tests, PR test policy)