### PR TITLE
feat: Add Perplexity Web (Session) provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,4 @@ docs/superpowers/
 
 # GitNexus local index
 .gitnexus
+.worktrees

--- a/open-sse/config/providerRegistry.ts
+++ b/open-sse/config/providerRegistry.ts
@@ -1066,6 +1066,25 @@ export const REGISTRY: Record<string, RegistryEntry> = {
     ],
   },
 
+  "perplexity-web": {
+    id: "perplexity-web",
+    alias: "pplx-web",
+    format: "openai",
+    executor: "perplexity-web",
+    baseUrl: "https://www.perplexity.ai/rest/sse/perplexity_ask",
+    authType: "apikey",
+    authHeader: "cookie",
+    models: [
+      { id: "pplx-auto", name: "Perplexity Auto (Free)" },
+      { id: "pplx-sonar", name: "Perplexity Sonar" },
+      { id: "pplx-gpt", name: "GPT-5.4 (via Perplexity)" },
+      { id: "pplx-gemini", name: "Gemini 3.1 Pro (via Perplexity)" },
+      { id: "pplx-sonnet", name: "Claude Sonnet 4.6 (via Perplexity)" },
+      { id: "pplx-opus", name: "Claude Opus 4.6 (via Perplexity)" },
+      { id: "pplx-nemotron", name: "Nemotron 3 Super (via Perplexity)" },
+    ],
+  },
+
   together: {
     id: "together",
     alias: "together",

--- a/open-sse/executors/index.ts
+++ b/open-sse/executors/index.ts
@@ -12,6 +12,7 @@ import { OpencodeExecutor } from "./opencode.ts";
 import { PuterExecutor } from "./puter.ts";
 import { VertexExecutor } from "./vertex.ts";
 import { CliproxyapiExecutor } from "./cliproxyapi.ts";
+import { PerplexityWebExecutor } from "./perplexity-web.ts";
 
 const executors = {
   antigravity: new AntigravityExecutor(),
@@ -33,6 +34,8 @@ const executors = {
   vertex: new VertexExecutor(),
   cliproxyapi: new CliproxyapiExecutor(),
   cpa: new CliproxyapiExecutor(), // Alias
+  "perplexity-web": new PerplexityWebExecutor(),
+  "pplx-web": new PerplexityWebExecutor(), // Alias
 };
 
 const defaultCache = new Map();
@@ -62,3 +65,4 @@ export { OpencodeExecutor } from "./opencode.ts";
 export { PuterExecutor } from "./puter.ts";
 export { CliproxyapiExecutor } from "./cliproxyapi.ts";
 export { VertexExecutor } from "./vertex.ts";
+export { PerplexityWebExecutor } from "./perplexity-web.ts";

--- a/open-sse/executors/perplexity-web.ts
+++ b/open-sse/executors/perplexity-web.ts
@@ -1,0 +1,831 @@
+/**
+ * PerplexityWebExecutor — Perplexity Web Session Provider
+ *
+ * Routes requests through Perplexity's internal SSE API using a Pro/Max
+ * subscription session cookie or JWT, translating between OpenAI chat
+ * completions format and Perplexity's internal protocol.
+ */
+
+import { BaseExecutor, type ExecuteInput } from "./base.ts";
+
+const PPLX_SSE_ENDPOINT = "https://www.perplexity.ai/rest/sse/perplexity_ask";
+const PPLX_API_VERSION = "2.18";
+const PPLX_USER_AGENT =
+  "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36";
+
+const MODEL_MAP: Record<string, [string, string]> = {
+  "pplx-auto": ["concise", "pplx_pro"],
+  "pplx-sonar": ["copilot", "experimental"],
+  "pplx-gpt": ["copilot", "gpt54"],
+  "pplx-gemini": ["copilot", "gemini31pro_high"],
+  "pplx-sonnet": ["copilot", "claude46sonnet"],
+  "pplx-opus": ["copilot", "claude46opus"],
+  "pplx-nemotron": ["copilot", "nv_nemotron_3_super"],
+};
+
+const THINKING_MAP: Record<string, string> = {
+  "pplx-gpt": "gpt54_thinking",
+  "pplx-sonnet": "claude46sonnetthinking",
+  "pplx-opus": "claude46opusthinking",
+};
+
+const CITATION_RE = /\[\d+\]/g;
+const GROK_TAG_RE = /<grok:[^>]*>.*?<\/grok:[^>]*>/gs;
+const GROK_SELF_RE = /<grok:[^>]*\/>/g;
+const XML_DECL_RE = /<[?]xml[^?]*[?]>/g;
+const SCRIPT_RE = /<script[^>]*>.*?<\/script>/gs;
+const SCRIPT_TAG_RE = /<\/?script[^>]*>/g;
+const RESPONSE_TAG_RE = /<\/?response[^>]*>/g;
+const MULTI_SPACE = / {2,}/g;
+const MULTI_NL = /\n{3,}/g;
+
+// ─── Session continuity ─────────────────────────────────────────────────────
+
+const SESSION_MAX_AGE_MS = 3600_000;
+const SESSION_MAX_ENTRIES = 200;
+
+interface SessionEntry {
+  backendUuid: string;
+  ts: number;
+}
+
+const sessionCache = new Map<string, SessionEntry>();
+
+function sessionKey(history: Array<{ role: string; content: string }>): string {
+  const parts = history.map((h) => `${h.role}:${h.content}`).join("\n");
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < parts.length; i++) {
+    hash ^= parts.charCodeAt(i);
+    hash = (hash * 0x01000193) >>> 0;
+  }
+  return hash.toString(16).padStart(8, "0");
+}
+
+function sessionLookup(history: Array<{ role: string; content: string }>): string | null {
+  if (history.length === 0) return null;
+  const key = sessionKey(history);
+  const entry = sessionCache.get(key);
+  if (!entry) return null;
+  if (Date.now() - entry.ts > SESSION_MAX_AGE_MS) {
+    sessionCache.delete(key);
+    return null;
+  }
+  return entry.backendUuid;
+}
+
+function sessionStore(
+  history: Array<{ role: string; content: string }>,
+  currentMsg: string,
+  responseText: string,
+  backendUuid: string | null,
+): void {
+  if (!backendUuid) return;
+  const full = [
+    ...history,
+    { role: "user", content: currentMsg },
+    { role: "assistant", content: responseText },
+  ];
+  const key = sessionKey(full);
+  sessionCache.set(key, { backendUuid, ts: Date.now() });
+  if (sessionCache.size > SESSION_MAX_ENTRIES) {
+    let oldestKey: string | null = null;
+    let oldestTs = Infinity;
+    for (const [k, v] of sessionCache) {
+      if (v.ts < oldestTs) {
+        oldestTs = v.ts;
+        oldestKey = k;
+      }
+    }
+    if (oldestKey) sessionCache.delete(oldestKey);
+  }
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function cleanResponse(text: string, strip = true): string {
+  let t = text;
+  t = t.replace(XML_DECL_RE, "");
+  t = t.replace(CITATION_RE, "");
+  t = t.replace(GROK_TAG_RE, "");
+  t = t.replace(GROK_SELF_RE, "");
+  t = t.replace(RESPONSE_TAG_RE, "");
+  t = t.replace(SCRIPT_RE, "");
+  t = t.replace(SCRIPT_TAG_RE, "");
+  if (strip) {
+    t = t.replace(MULTI_SPACE, " ");
+    t = t.replace(MULTI_NL, "\n\n");
+    t = t.trim();
+  }
+  return t;
+}
+
+// ─── SSE types ──────────────────────────────────────────────────────────────
+
+interface PplxBlock {
+  intended_usage?: string;
+  markdown_block?: {
+    answer?: string;
+    chunks?: string[];
+    progress?: string;
+    chunk_starting_offset?: number;
+  };
+  web_result_block?: {
+    web_results?: Array<{ url?: string; name?: string; snippet?: string }>;
+  };
+  plan_block?: {
+    steps?: Array<{
+      step_type?: string;
+      search_web_content?: { queries?: Array<{ query?: string }> };
+      read_results_content?: { urls?: string[] };
+    }>;
+    goals?: Array<{ description?: string }>;
+  };
+}
+
+interface PplxStreamEvent {
+  status?: string;
+  final?: boolean;
+  text?: string;
+  blocks?: PplxBlock[];
+  backend_uuid?: string;
+  web_results?: Array<{ url?: string; name?: string }>;
+  error_code?: string;
+  error_message?: string;
+  display_model?: string;
+}
+
+// ─── SSE parsing ────────────────────────────────────────────────────────────
+
+async function* readPplxSseEvents(
+  body: ReadableStream<Uint8Array>,
+  signal?: AbortSignal | null,
+): AsyncGenerator<PplxStreamEvent> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let dataLines: string[] = [];
+
+  function flush(): PplxStreamEvent | null | "done" {
+    if (dataLines.length === 0) return null;
+    const payload = dataLines.join("\n");
+    dataLines = [];
+    const trimmed = payload.trim();
+    if (!trimmed || trimmed === "[DONE]") return "done";
+    try {
+      return JSON.parse(trimmed) as PplxStreamEvent;
+    } catch {
+      return null;
+    }
+  }
+
+  try {
+    while (true) {
+      if (signal?.aborted) return;
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+
+      while (true) {
+        const idx = buffer.indexOf("\n");
+        if (idx < 0) break;
+        const rawLine = buffer.slice(0, idx);
+        buffer = buffer.slice(idx + 1);
+        const line = rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine;
+
+        if (line === "") {
+          const parsed = flush();
+          if (parsed === "done") return;
+          if (parsed) yield parsed;
+          continue;
+        }
+        if (line.startsWith("data:")) {
+          dataLines.push(line.slice(5).trimStart());
+        }
+        if (line === "event: end_of_stream") {
+          return;
+        }
+      }
+    }
+
+    buffer += decoder.decode();
+    if (buffer.trim().startsWith("data:")) {
+      dataLines.push(buffer.trim().slice(5).trimStart());
+    }
+    const tail = flush();
+    if (tail && tail !== "done") yield tail;
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+// ─── OpenAI → Perplexity translation ────────────────────────────────────────
+
+interface ParsedMessages {
+  systemMsg: string;
+  history: Array<{ role: string; content: string }>;
+  currentMsg: string;
+}
+
+function parseOpenAIMessages(messages: Array<Record<string, unknown>>): ParsedMessages {
+  let systemMsg = "";
+  const history: Array<{ role: string; content: string }> = [];
+
+  for (const msg of messages) {
+    let role = String(msg.role || "user");
+    if (role === "developer") role = "system";
+
+    let content = "";
+    if (typeof msg.content === "string") {
+      content = msg.content;
+    } else if (Array.isArray(msg.content)) {
+      content = (msg.content as Array<Record<string, unknown>>)
+        .filter((c) => c.type === "text")
+        .map((c) => String(c.text || ""))
+        .join(" ");
+    }
+    if (!content.trim()) continue;
+
+    if (role === "system") {
+      systemMsg += content + "\n";
+    } else if (role === "user" || role === "assistant") {
+      history.push({ role, content });
+    }
+  }
+
+  let currentMsg = "";
+  if (history.length > 0 && history[history.length - 1].role === "user") {
+    currentMsg = history.pop()!.content;
+  }
+
+  return { systemMsg, history, currentMsg };
+}
+
+function buildPplxRequestBody(
+  query: string,
+  mode: string,
+  modelPref: string,
+  followUpUuid: string | null,
+): Record<string, unknown> {
+  const tz =
+    typeof Intl !== "undefined"
+      ? Intl.DateTimeFormat().resolvedOptions().timeZone
+      : "UTC";
+
+  return {
+    query_str: query,
+    params: {
+      query_str: query,
+      search_focus: "internet",
+      mode,
+      model_preference: modelPref,
+      sources: ["web"],
+      attachments: [],
+      frontend_uuid: crypto.randomUUID(),
+      frontend_context_uuid: crypto.randomUUID(),
+      version: PPLX_API_VERSION,
+      language: "en-US",
+      timezone: tz,
+      search_recency_filter: null,
+      is_incognito: true,
+      use_schematized_api: true,
+      last_backend_uuid: followUpUuid,
+    },
+  };
+}
+
+function buildQuery(parsed: ParsedMessages, followUpUuid: string | null): string {
+  if (followUpUuid) return parsed.currentMsg;
+
+  const obj: Record<string, unknown> = {};
+  if (parsed.systemMsg.trim()) {
+    obj.instructions = [
+      parsed.systemMsg.trim(),
+      "You have built-in web search. Answer questions directly using search results.",
+    ];
+  }
+  if (parsed.history.length > 0) {
+    obj.history = parsed.history;
+  }
+  if (parsed.currentMsg) {
+    obj.query = parsed.currentMsg;
+  } else if (parsed.history.length === 0) {
+    obj.query = "";
+  }
+  const json = JSON.stringify(obj);
+  return json.length > 96000 ? json.slice(-96000) : json;
+}
+
+// ─── Content extraction ─────────────────────────────────────────────────────
+
+interface ContentChunk {
+  delta?: string;
+  answer?: string;
+  backendUuid?: string;
+  thinking?: string;
+  error?: string;
+  done?: boolean;
+}
+
+async function* extractContent(
+  eventStream: ReadableStream<Uint8Array>,
+  signal?: AbortSignal | null,
+): AsyncGenerator<ContentChunk> {
+  let fullAnswer = "";
+  let backendUuid: string | null = null;
+  let seenLen = 0;
+  const seenThinking = new Set<string>();
+
+  for await (const event of readPplxSseEvents(eventStream, signal)) {
+    if (event.error_code || event.error_message) {
+      yield {
+        error: event.error_message || `Perplexity error: ${event.error_code}`,
+        done: true,
+      };
+      return;
+    }
+
+    if (event.backend_uuid) backendUuid = event.backend_uuid;
+
+    const blocks = event.blocks ?? [];
+    for (const block of blocks) {
+      const usage = block.intended_usage ?? "";
+
+      // Thinking: search steps
+      if (usage === "pro_search_steps" && block.plan_block?.steps) {
+        for (const step of block.plan_block.steps) {
+          if (step.step_type === "SEARCH_WEB") {
+            for (const q of step.search_web_content?.queries ?? []) {
+              const qr = q.query ?? "";
+              if (qr && !seenThinking.has(qr)) {
+                seenThinking.add(qr);
+                yield { thinking: `Searching: ${qr}`, backendUuid: backendUuid ?? undefined };
+              }
+            }
+          } else if (step.step_type === "READ_RESULTS") {
+            for (const u of (step.read_results_content?.urls ?? []).slice(0, 3)) {
+              if (u && !seenThinking.has(u)) {
+                seenThinking.add(u);
+                yield { thinking: `Reading: ${u}`, backendUuid: backendUuid ?? undefined };
+              }
+            }
+          }
+        }
+      }
+
+      // Thinking: plan goals
+      if (usage === "plan" && block.plan_block?.goals) {
+        for (const goal of block.plan_block.goals) {
+          const desc = goal.description ?? "";
+          if (desc && !seenThinking.has(desc)) {
+            seenThinking.add(desc);
+            yield { thinking: desc, backendUuid: backendUuid ?? undefined };
+          }
+        }
+      }
+
+      // Content: markdown blocks
+      if (!usage.includes("markdown")) continue;
+      const mb = block.markdown_block;
+      if (!mb) continue;
+      const chunks = mb.chunks ?? [];
+      if (chunks.length === 0) continue;
+
+      if (mb.progress === "DONE") {
+        fullAnswer = chunks.join("");
+      } else {
+        const chunkText = chunks.join("");
+        const cumulative = fullAnswer + chunkText;
+        if (cumulative.length > seenLen) {
+          const delta = cumulative.slice(seenLen);
+          fullAnswer = cumulative;
+          seenLen = cumulative.length;
+          yield { delta, answer: fullAnswer, backendUuid: backendUuid ?? undefined };
+        }
+      }
+    }
+
+    // Fallback: text field
+    if (blocks.length === 0 && event.text) {
+      const t = event.text.trim();
+      if (t.length > seenLen) {
+        const delta = t.slice(seenLen);
+        fullAnswer = t;
+        seenLen = t.length;
+        yield { delta, answer: fullAnswer, backendUuid: backendUuid ?? undefined };
+      }
+    }
+
+    if (event.final || event.status === "COMPLETED") break;
+  }
+
+  yield { delta: "", answer: fullAnswer, backendUuid: backendUuid ?? undefined, done: true };
+}
+
+// ─── OpenAI SSE format ──────────────────────────────────────────────────────
+
+function sseChunk(data: unknown): string {
+  return `data: ${JSON.stringify(data)}\n\n`;
+}
+
+function buildStreamingResponse(
+  eventStream: ReadableStream<Uint8Array>,
+  model: string,
+  cid: string,
+  created: number,
+  history: Array<{ role: string; content: string }>,
+  currentMsg: string,
+  signal?: AbortSignal | null,
+): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+
+  return new ReadableStream({
+    async start(controller) {
+      try {
+        // Initial role chunk
+        controller.enqueue(
+          encoder.encode(
+            sseChunk({
+              id: cid,
+              object: "chat.completion.chunk",
+              created,
+              model,
+              system_fingerprint: null,
+              choices: [
+                { index: 0, delta: { role: "assistant" }, finish_reason: null, logprobs: null },
+              ],
+            }),
+          ),
+        );
+
+        let fullAnswer = "";
+        let respBackendUuid: string | null = null;
+
+        for await (const chunk of extractContent(eventStream, signal)) {
+          if (chunk.backendUuid) respBackendUuid = chunk.backendUuid;
+
+          if (chunk.error) {
+            controller.enqueue(
+              encoder.encode(
+                sseChunk({
+                  id: cid,
+                  object: "chat.completion.chunk",
+                  created,
+                  model,
+                  system_fingerprint: null,
+                  choices: [
+                    {
+                      index: 0,
+                      delta: { content: `[Error: ${chunk.error}]` },
+                      finish_reason: null,
+                      logprobs: null,
+                    },
+                  ],
+                }),
+              ),
+            );
+            break;
+          }
+
+          if (chunk.thinking) {
+            controller.enqueue(
+              encoder.encode(
+                sseChunk({
+                  id: cid,
+                  object: "chat.completion.chunk",
+                  created,
+                  model,
+                  system_fingerprint: null,
+                  choices: [
+                    {
+                      index: 0,
+                      delta: { reasoning_content: chunk.thinking + "\n" },
+                      finish_reason: null,
+                      logprobs: null,
+                    },
+                  ],
+                }),
+              ),
+            );
+            continue;
+          }
+
+          if (chunk.done) {
+            fullAnswer = chunk.answer || fullAnswer;
+            break;
+          }
+
+          let dt = chunk.delta || "";
+          if (dt) {
+            dt = cleanResponse(dt, false);
+            if (dt) {
+              controller.enqueue(
+                encoder.encode(
+                  sseChunk({
+                    id: cid,
+                    object: "chat.completion.chunk",
+                    created,
+                    model,
+                    system_fingerprint: null,
+                    choices: [
+                      { index: 0, delta: { content: dt }, finish_reason: null, logprobs: null },
+                    ],
+                  }),
+                ),
+              );
+            }
+          }
+          if (chunk.answer) fullAnswer = chunk.answer;
+        }
+
+        // Stop chunk
+        controller.enqueue(
+          encoder.encode(
+            sseChunk({
+              id: cid,
+              object: "chat.completion.chunk",
+              created,
+              model,
+              system_fingerprint: null,
+              choices: [{ index: 0, delta: {}, finish_reason: "stop", logprobs: null }],
+            }),
+          ),
+        );
+        controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+
+        sessionStore(history, currentMsg, cleanResponse(fullAnswer), respBackendUuid);
+      } catch (err) {
+        controller.enqueue(
+          encoder.encode(
+            sseChunk({
+              id: cid,
+              object: "chat.completion.chunk",
+              created,
+              model,
+              system_fingerprint: null,
+              choices: [
+                {
+                  index: 0,
+                  delta: {
+                    content: `[Stream error: ${err instanceof Error ? err.message : String(err)}]`,
+                  },
+                  finish_reason: "stop",
+                  logprobs: null,
+                },
+              ],
+            }),
+          ),
+        );
+        controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+      } finally {
+        controller.close();
+      }
+    },
+  });
+}
+
+async function buildNonStreamingResponse(
+  eventStream: ReadableStream<Uint8Array>,
+  model: string,
+  cid: string,
+  created: number,
+  history: Array<{ role: string; content: string }>,
+  currentMsg: string,
+  signal?: AbortSignal | null,
+): Promise<Response> {
+  let fullAnswer = "";
+  let respBackendUuid: string | null = null;
+  const thinkingParts: string[] = [];
+
+  for await (const chunk of extractContent(eventStream, signal)) {
+    if (chunk.backendUuid) respBackendUuid = chunk.backendUuid;
+    if (chunk.error) {
+      return new Response(
+        JSON.stringify({
+          error: { message: chunk.error, type: "upstream_error", code: "PPLX_ERROR" },
+        }),
+        { status: 502, headers: { "Content-Type": "application/json" } },
+      );
+    }
+    if (chunk.thinking) {
+      thinkingParts.push(chunk.thinking);
+      continue;
+    }
+    if (chunk.done) {
+      fullAnswer = chunk.answer || fullAnswer;
+      break;
+    }
+    if (chunk.answer) fullAnswer = chunk.answer;
+  }
+
+  fullAnswer = cleanResponse(fullAnswer);
+  sessionStore(history, currentMsg, fullAnswer, respBackendUuid);
+
+  const reasoningContent =
+    thinkingParts.length > 0 ? thinkingParts.join("\n") : undefined;
+  const msg: Record<string, unknown> = { role: "assistant", content: fullAnswer };
+  if (reasoningContent) msg.reasoning_content = reasoningContent;
+
+  const promptTokens = Math.ceil(currentMsg.length / 4);
+  const completionTokens = Math.ceil(fullAnswer.length / 4);
+
+  return new Response(
+    JSON.stringify({
+      id: cid,
+      object: "chat.completion",
+      created,
+      model,
+      system_fingerprint: null,
+      choices: [{ index: 0, message: msg, finish_reason: "stop", logprobs: null }],
+      usage: {
+        prompt_tokens: promptTokens,
+        completion_tokens: completionTokens,
+        total_tokens: promptTokens + completionTokens,
+      },
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+// ─── Executor ───────────────────────────────────────────────────────────────
+
+export class PerplexityWebExecutor extends BaseExecutor {
+  constructor() {
+    super("perplexity-web", { id: "perplexity-web", baseUrl: PPLX_SSE_ENDPOINT });
+  }
+
+  async execute({ model, body, stream, credentials, signal, log }: ExecuteInput) {
+    const messages = (body as Record<string, unknown>).messages as
+      | Array<Record<string, unknown>>
+      | undefined;
+    if (!messages || !Array.isArray(messages) || messages.length === 0) {
+      const errResp = new Response(
+        JSON.stringify({
+          error: { message: "Missing or empty messages array", type: "invalid_request" },
+        }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+      );
+      return { response: errResp, url: PPLX_SSE_ENDPOINT, headers: {}, transformedBody: body };
+    }
+
+    // Resolve thinking mode
+    const bodyObj = body as Record<string, unknown>;
+    const thinking =
+      bodyObj.thinking === true ||
+      (bodyObj.reasoning_effort != null && bodyObj.reasoning_effort !== "none");
+
+    let pplxMode: string;
+    let modelPref: string;
+    if (thinking && THINKING_MAP[model]) {
+      pplxMode = "copilot";
+      modelPref = THINKING_MAP[model];
+      log?.info?.("PPLX-WEB", `Thinking mode → ${model} using ${modelPref}`);
+    } else if (MODEL_MAP[model]) {
+      [pplxMode, modelPref] = MODEL_MAP[model];
+    } else {
+      pplxMode = "copilot";
+      modelPref = model;
+      log?.info?.("PPLX-WEB", `Unmapped model ${model}, using as raw preference`);
+    }
+
+    // Parse messages and check session continuity
+    const parsed = parseOpenAIMessages(messages);
+    const followUpUuid = sessionLookup(parsed.history);
+    if (followUpUuid) {
+      log?.info?.("PPLX-WEB", `Session continue: ${followUpUuid.slice(0, 12)}...`);
+    }
+
+    const query = buildQuery(parsed, followUpUuid);
+    if (!query.trim()) {
+      const errResp = new Response(
+        JSON.stringify({
+          error: { message: "Empty query after processing", type: "invalid_request" },
+        }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+      );
+      return { response: errResp, url: PPLX_SSE_ENDPOINT, headers: {}, transformedBody: body };
+    }
+
+    // Build Perplexity request
+    const pplxBody = buildPplxRequestBody(query, pplxMode, modelPref, followUpUuid);
+
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      Accept: "text/event-stream",
+      Origin: "https://www.perplexity.ai",
+      Referer: "https://www.perplexity.ai/",
+      "User-Agent": PPLX_USER_AGENT,
+      "X-App-ApiClient": "default",
+      "X-App-ApiVersion": PPLX_API_VERSION,
+    };
+
+    if (credentials.accessToken) {
+      headers["Authorization"] = `Bearer ${credentials.accessToken}`;
+    } else if (credentials.apiKey) {
+      headers["Cookie"] = `__Secure-next-auth.session-token=${credentials.apiKey}`;
+    }
+
+    log?.info?.(
+      "PPLX-WEB",
+      `Query to ${model} (pref=${modelPref}, mode=${pplxMode}), len=${query.length}`,
+    );
+
+    // Fetch from Perplexity
+    const fetchOptions: RequestInit = {
+      method: "POST",
+      headers,
+      body: JSON.stringify(pplxBody),
+    };
+    if (signal) fetchOptions.signal = signal;
+
+    let response: Response;
+    try {
+      response = await fetch(PPLX_SSE_ENDPOINT, fetchOptions);
+    } catch (err) {
+      log?.error?.(
+        "PPLX-WEB",
+        `Fetch failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      const errResp = new Response(
+        JSON.stringify({
+          error: {
+            message: `Perplexity connection failed: ${err instanceof Error ? err.message : String(err)}`,
+            type: "upstream_error",
+          },
+        }),
+        { status: 502, headers: { "Content-Type": "application/json" } },
+      );
+      return { response: errResp, url: PPLX_SSE_ENDPOINT, headers, transformedBody: pplxBody };
+    }
+
+    if (!response.ok) {
+      const status = response.status;
+      let errMsg = `Perplexity returned HTTP ${status}`;
+      if (status === 401 || status === 403) {
+        errMsg =
+          "Perplexity auth failed — session cookie may be expired. Re-paste your __Secure-next-auth.session-token.";
+      } else if (status === 429) {
+        errMsg = "Perplexity rate limited. Wait a moment and retry.";
+      }
+      log?.warn?.("PPLX-WEB", errMsg);
+      const errResp = new Response(
+        JSON.stringify({
+          error: { message: errMsg, type: "upstream_error", code: `HTTP_${status}` },
+        }),
+        { status, headers: { "Content-Type": "application/json" } },
+      );
+      return { response: errResp, url: PPLX_SSE_ENDPOINT, headers, transformedBody: pplxBody };
+    }
+
+    if (!response.body) {
+      const errResp = new Response(
+        JSON.stringify({
+          error: { message: "Perplexity returned empty response body", type: "upstream_error" },
+        }),
+        { status: 502, headers: { "Content-Type": "application/json" } },
+      );
+      return { response: errResp, url: PPLX_SSE_ENDPOINT, headers, transformedBody: pplxBody };
+    }
+
+    // Build OpenAI-compatible response
+    const cid = `chatcmpl-pplx-${crypto.randomUUID().slice(0, 12)}`;
+    const created = Math.floor(Date.now() / 1000);
+
+    let finalResponse: Response;
+    if (stream) {
+      const sseStream = buildStreamingResponse(
+        response.body,
+        model,
+        cid,
+        created,
+        parsed.history,
+        parsed.currentMsg,
+        signal,
+      );
+      finalResponse = new Response(sseStream, {
+        status: 200,
+        headers: {
+          "Content-Type": "text/event-stream",
+          "Cache-Control": "no-cache",
+          "X-Accel-Buffering": "no",
+        },
+      });
+    } else {
+      finalResponse = await buildNonStreamingResponse(
+        response.body,
+        model,
+        cid,
+        created,
+        parsed.history,
+        parsed.currentMsg,
+        signal,
+      );
+    }
+
+    return {
+      response: finalResponse,
+      url: PPLX_SSE_ENDPOINT,
+      headers,
+      transformedBody: pplxBody,
+    };
+  }
+}

--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -232,6 +232,16 @@ export const APIKEY_PROVIDERS = {
     textIcon: "PP",
     website: "https://www.perplexity.ai",
   },
+  "perplexity-web": {
+    id: "perplexity-web",
+    alias: "pplx-web",
+    name: "Perplexity Web (Session)",
+    icon: "search",
+    color: "#20808D",
+    textIcon: "PW",
+    website: "https://www.perplexity.ai",
+    authHint: "Paste your __Secure-next-auth.session-token cookie value from perplexity.ai",
+  },
   together: {
     id: "together",
     alias: "together",

--- a/tests/unit/perplexity-web.test.mjs
+++ b/tests/unit/perplexity-web.test.mjs
@@ -1,0 +1,754 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// ─── Import the executor and its dependencies ──────────────────────────────
+
+const { PerplexityWebExecutor } = await import(
+  "../../open-sse/executors/perplexity-web.ts"
+);
+const { getExecutor, hasSpecializedExecutor } = await import(
+  "../../open-sse/executors/index.ts"
+);
+
+// ─── Helper: Build a mock SSE stream from Perplexity events ─────────────────
+
+function mockPplxStream(events) {
+  const encoder = new TextEncoder();
+  const chunks = [];
+  for (const evt of events) {
+    chunks.push(`event: message\r\ndata: ${JSON.stringify(evt)}\r\n\r\n`);
+  }
+  chunks.push("event: end_of_stream\r\n\r\n");
+  const body = chunks.join("");
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(body));
+      controller.close();
+    },
+  });
+}
+
+// ─── Helper: Override global fetch for testing ──────────────────────────────
+
+function mockFetch(status, streamEvents) {
+  const original = globalThis.fetch;
+  globalThis.fetch = async (url, opts) => {
+    return new Response(mockPplxStream(streamEvents), {
+      status,
+      headers: { "Content-Type": "text/event-stream" },
+    });
+  };
+  return () => {
+    globalThis.fetch = original;
+  };
+}
+
+function mockFetchError(error) {
+  const original = globalThis.fetch;
+  globalThis.fetch = async () => {
+    throw error;
+  };
+  return () => {
+    globalThis.fetch = original;
+  };
+}
+
+// ─── Test: Executor registration ────────────────────────────────────────────
+
+test("PerplexityWebExecutor is registered in executor index", () => {
+  assert.ok(hasSpecializedExecutor("perplexity-web"));
+  assert.ok(hasSpecializedExecutor("pplx-web"));
+  const executor = getExecutor("perplexity-web");
+  assert.ok(executor instanceof PerplexityWebExecutor);
+});
+
+test("PerplexityWebExecutor alias resolves to same type", () => {
+  const a = getExecutor("perplexity-web");
+  const b = getExecutor("pplx-web");
+  assert.ok(a instanceof PerplexityWebExecutor);
+  assert.ok(b instanceof PerplexityWebExecutor);
+});
+
+// ─── Test: Constructor ──────────────────────────────────────────────────────
+
+test("PerplexityWebExecutor sets correct provider name", () => {
+  const executor = new PerplexityWebExecutor();
+  assert.equal(executor.getProvider(), "perplexity-web");
+});
+
+// ─── Test: Non-streaming response ───────────────────────────────────────────
+
+test("Non-streaming: simple text response", async () => {
+  const pplxEvents = [
+    {
+      backend_uuid: "test-uuid-123",
+      blocks: [
+        {
+          intended_usage: "markdown",
+          markdown_block: {
+            chunks: ["Hello, world!"],
+            progress: "DONE",
+          },
+        },
+      ],
+      status: "COMPLETED",
+    },
+  ];
+
+  const restore = mockFetch(200, pplxEvents);
+  try {
+    const executor = new PerplexityWebExecutor();
+    const result = await executor.execute({
+      model: "pplx-auto",
+      body: { messages: [{ role: "user", content: "hi" }], stream: false },
+      stream: false,
+      credentials: { apiKey: "test-cookie-value" },
+      signal: AbortSignal.timeout(10000),
+      log: null,
+    });
+
+    assert.equal(result.response.status, 200);
+    const json = await result.response.json();
+    assert.equal(json.object, "chat.completion");
+    assert.equal(json.choices[0].message.role, "assistant");
+    assert.equal(json.choices[0].message.content, "Hello, world!");
+    assert.equal(json.choices[0].finish_reason, "stop");
+    assert.ok(json.id.startsWith("chatcmpl-pplx-"));
+    assert.ok(json.usage.total_tokens > 0);
+  } finally {
+    restore();
+  }
+});
+
+test("Non-streaming: strips citations from response", async () => {
+  const pplxEvents = [
+    {
+      blocks: [
+        {
+          intended_usage: "markdown",
+          markdown_block: {
+            chunks: ["The answer is 42[1] according to sources[2][3]."],
+            progress: "DONE",
+          },
+        },
+      ],
+      status: "COMPLETED",
+    },
+  ];
+
+  const restore = mockFetch(200, pplxEvents);
+  try {
+    const executor = new PerplexityWebExecutor();
+    const result = await executor.execute({
+      model: "pplx-gpt",
+      body: { messages: [{ role: "user", content: "meaning of life" }], stream: false },
+      stream: false,
+      credentials: { apiKey: "test-cookie" },
+      signal: AbortSignal.timeout(10000),
+      log: null,
+    });
+
+    const json = await result.response.json();
+    assert.ok(!json.choices[0].message.content.includes("[1]"));
+    assert.ok(!json.choices[0].message.content.includes("[2]"));
+    assert.ok(!json.choices[0].message.content.includes("[3]"));
+    assert.ok(json.choices[0].message.content.includes("The answer is 42"));
+  } finally {
+    restore();
+  }
+});
+
+// ─── Test: Streaming response ───────────────────────────────────────────────
+
+test("Streaming: produces valid SSE chunks", async () => {
+  const pplxEvents = [
+    {
+      backend_uuid: "stream-uuid-456",
+      blocks: [
+        {
+          intended_usage: "markdown",
+          markdown_block: { chunks: ["Hello "], progress: "IN_PROGRESS" },
+        },
+      ],
+    },
+    {
+      blocks: [
+        {
+          intended_usage: "markdown",
+          markdown_block: { chunks: ["Hello world!"], progress: "DONE" },
+        },
+      ],
+      status: "COMPLETED",
+    },
+  ];
+
+  const restore = mockFetch(200, pplxEvents);
+  try {
+    const executor = new PerplexityWebExecutor();
+    const result = await executor.execute({
+      model: "pplx-sonnet",
+      body: { messages: [{ role: "user", content: "hello" }], stream: true },
+      stream: true,
+      credentials: { apiKey: "test-cookie" },
+      signal: AbortSignal.timeout(10000),
+      log: null,
+    });
+
+    assert.equal(result.response.status, 200);
+    assert.equal(
+      result.response.headers.get("Content-Type"),
+      "text/event-stream",
+    );
+
+    // Read all SSE chunks
+    const text = await result.response.text();
+    const lines = text.split("\n").filter((l) => l.startsWith("data: "));
+    assert.ok(lines.length >= 3, `Expected at least 3 SSE data lines, got ${lines.length}`);
+
+    // First chunk should have role
+    const first = JSON.parse(lines[0].slice(6));
+    assert.equal(first.object, "chat.completion.chunk");
+    assert.equal(first.choices[0].delta.role, "assistant");
+
+    // Last data line should be [DONE]
+    const lastLine = text.trim().split("\n").filter(Boolean).pop();
+    assert.equal(lastLine, "data: [DONE]");
+
+    // Second-to-last should have finish_reason: stop
+    const stopLine = lines[lines.length - 1];
+    if (stopLine !== "data: [DONE]") {
+      const stop = JSON.parse(stopLine.slice(6));
+      assert.equal(stop.choices[0].finish_reason, "stop");
+    }
+  } finally {
+    restore();
+  }
+});
+
+// ─── Test: Thinking/reasoning content ───────────────────────────────────────
+
+test("Streaming: thinking content emitted as reasoning_content", async () => {
+  const pplxEvents = [
+    {
+      blocks: [
+        {
+          intended_usage: "pro_search_steps",
+          plan_block: {
+            steps: [
+              {
+                step_type: "SEARCH_WEB",
+                search_web_content: { queries: [{ query: "test query" }] },
+              },
+            ],
+          },
+        },
+      ],
+    },
+    {
+      blocks: [
+        {
+          intended_usage: "markdown",
+          markdown_block: { chunks: ["The answer."], progress: "DONE" },
+        },
+      ],
+      status: "COMPLETED",
+    },
+  ];
+
+  const restore = mockFetch(200, pplxEvents);
+  try {
+    const executor = new PerplexityWebExecutor();
+    const result = await executor.execute({
+      model: "pplx-sonnet",
+      body: { messages: [{ role: "user", content: "search test" }], stream: true },
+      stream: true,
+      credentials: { apiKey: "test-cookie" },
+      signal: AbortSignal.timeout(10000),
+      log: null,
+    });
+
+    const text = await result.response.text();
+    const dataLines = text.split("\n").filter((l) => l.startsWith("data: ") && l !== "data: [DONE]");
+
+    // Should have a reasoning_content delta
+    const hasReasoning = dataLines.some((l) => {
+      const json = JSON.parse(l.slice(6));
+      return json.choices?.[0]?.delta?.reasoning_content != null;
+    });
+    assert.ok(hasReasoning, "Should have reasoning_content delta for thinking steps");
+  } finally {
+    restore();
+  }
+});
+
+// ─── Test: Error handling ───────────────────────────────────────────────────
+
+test("Error: 401 returns auth error message", async () => {
+  const restore = mockFetch(401, []);
+  try {
+    const executor = new PerplexityWebExecutor();
+    const result = await executor.execute({
+      model: "pplx-auto",
+      body: { messages: [{ role: "user", content: "hi" }] },
+      stream: false,
+      credentials: { apiKey: "expired-cookie" },
+      signal: AbortSignal.timeout(10000),
+      log: null,
+    });
+
+    assert.equal(result.response.status, 401);
+    const json = await result.response.json();
+    assert.ok(json.error.message.includes("auth failed"));
+    assert.ok(json.error.message.includes("session-token"));
+  } finally {
+    restore();
+  }
+});
+
+test("Error: 429 returns rate limit message", async () => {
+  const restore = mockFetch(429, []);
+  try {
+    const executor = new PerplexityWebExecutor();
+    const result = await executor.execute({
+      model: "pplx-gpt",
+      body: { messages: [{ role: "user", content: "hi" }] },
+      stream: false,
+      credentials: { apiKey: "test-cookie" },
+      signal: AbortSignal.timeout(10000),
+      log: null,
+    });
+
+    assert.equal(result.response.status, 429);
+    const json = await result.response.json();
+    assert.ok(json.error.message.includes("rate limited"));
+  } finally {
+    restore();
+  }
+});
+
+test("Error: fetch failure returns 502", async () => {
+  const restore = mockFetchError(new Error("ECONNREFUSED"));
+  try {
+    const executor = new PerplexityWebExecutor();
+    const result = await executor.execute({
+      model: "pplx-auto",
+      body: { messages: [{ role: "user", content: "hi" }] },
+      stream: false,
+      credentials: { apiKey: "test-cookie" },
+      signal: AbortSignal.timeout(10000),
+      log: null,
+    });
+
+    assert.equal(result.response.status, 502);
+    const json = await result.response.json();
+    assert.ok(json.error.message.includes("ECONNREFUSED"));
+  } finally {
+    restore();
+  }
+});
+
+test("Error: empty messages returns 400", async () => {
+  const executor = new PerplexityWebExecutor();
+  const result = await executor.execute({
+    model: "pplx-auto",
+    body: { messages: [] },
+    stream: false,
+    credentials: { apiKey: "test-cookie" },
+    signal: AbortSignal.timeout(10000),
+    log: null,
+  });
+
+  assert.equal(result.response.status, 400);
+  const json = await result.response.json();
+  assert.ok(json.error.message.includes("Missing or empty messages"));
+});
+
+test("Error: missing messages returns 400", async () => {
+  const executor = new PerplexityWebExecutor();
+  const result = await executor.execute({
+    model: "pplx-auto",
+    body: {},
+    stream: false,
+    credentials: { apiKey: "test-cookie" },
+    signal: AbortSignal.timeout(10000),
+    log: null,
+  });
+
+  assert.equal(result.response.status, 400);
+});
+
+// ─── Test: Perplexity SSE error in stream ───────────────────────────────────
+
+test("Non-streaming: Perplexity stream error returns 502", async () => {
+  const pplxEvents = [{ error_code: "RATE_LIMIT", error_message: "Too many requests" }];
+
+  const restore = mockFetch(200, pplxEvents);
+  try {
+    const executor = new PerplexityWebExecutor();
+    const result = await executor.execute({
+      model: "pplx-auto",
+      body: { messages: [{ role: "user", content: "test" }], stream: false },
+      stream: false,
+      credentials: { apiKey: "test-cookie" },
+      signal: AbortSignal.timeout(10000),
+      log: null,
+    });
+
+    assert.equal(result.response.status, 502);
+    const json = await result.response.json();
+    assert.ok(json.error.message.includes("Too many requests"));
+  } finally {
+    restore();
+  }
+});
+
+// ─── Test: Message parsing ──────────────────────────────────────────────────
+
+test("Message parsing: system + user + assistant history", async () => {
+  let capturedBody = null;
+  const original = globalThis.fetch;
+  globalThis.fetch = async (url, opts) => {
+    capturedBody = JSON.parse(opts.body);
+    return new Response(
+      mockPplxStream([
+        {
+          blocks: [
+            {
+              intended_usage: "markdown",
+              markdown_block: { chunks: ["response"], progress: "DONE" },
+            },
+          ],
+          status: "COMPLETED",
+        },
+      ]),
+      { status: 200, headers: { "Content-Type": "text/event-stream" } },
+    );
+  };
+
+  try {
+    const executor = new PerplexityWebExecutor();
+    await executor.execute({
+      model: "pplx-auto",
+      body: {
+        messages: [
+          { role: "system", content: "You are helpful" },
+          { role: "user", content: "First question" },
+          { role: "assistant", content: "First answer" },
+          { role: "user", content: "Follow up" },
+        ],
+        stream: false,
+      },
+      stream: false,
+      credentials: { apiKey: "test-cookie" },
+      signal: AbortSignal.timeout(10000),
+      log: null,
+    });
+
+    // The query should contain the current message
+    const query = capturedBody.query_str;
+    assert.ok(query.includes("Follow up"), "Query should contain current user message");
+    assert.ok(query.includes("You are helpful"), "Query should contain system message");
+    assert.equal(capturedBody.params.search_focus, "internet");
+    assert.equal(capturedBody.params.use_schematized_api, true);
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+test("Message parsing: developer role treated as system", async () => {
+  let capturedBody = null;
+  const original = globalThis.fetch;
+  globalThis.fetch = async (url, opts) => {
+    capturedBody = JSON.parse(opts.body);
+    return new Response(
+      mockPplxStream([
+        {
+          blocks: [
+            {
+              intended_usage: "markdown",
+              markdown_block: { chunks: ["ok"], progress: "DONE" },
+            },
+          ],
+          status: "COMPLETED",
+        },
+      ]),
+      { status: 200, headers: { "Content-Type": "text/event-stream" } },
+    );
+  };
+
+  try {
+    const executor = new PerplexityWebExecutor();
+    await executor.execute({
+      model: "pplx-sonnet",
+      body: {
+        messages: [
+          { role: "developer", content: "Be concise" },
+          { role: "user", content: "hello" },
+        ],
+        stream: false,
+      },
+      stream: false,
+      credentials: { apiKey: "test-cookie" },
+      signal: AbortSignal.timeout(10000),
+      log: null,
+    });
+
+    const query = capturedBody.query_str;
+    assert.ok(query.includes("Be concise"), "Developer message should be treated as system");
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+// ─── Test: Auth header construction ─────────────────────────────────────────
+
+test("Auth: cookie-based auth sends Cookie header", async () => {
+  let capturedHeaders = null;
+  const original = globalThis.fetch;
+  globalThis.fetch = async (url, opts) => {
+    capturedHeaders = opts.headers;
+    return new Response(
+      mockPplxStream([
+        {
+          blocks: [
+            {
+              intended_usage: "markdown",
+              markdown_block: { chunks: ["ok"], progress: "DONE" },
+            },
+          ],
+          status: "COMPLETED",
+        },
+      ]),
+      { status: 200, headers: { "Content-Type": "text/event-stream" } },
+    );
+  };
+
+  try {
+    const executor = new PerplexityWebExecutor();
+    await executor.execute({
+      model: "pplx-auto",
+      body: { messages: [{ role: "user", content: "test" }], stream: false },
+      stream: false,
+      credentials: { apiKey: "my-session-token-value" },
+      signal: AbortSignal.timeout(10000),
+      log: null,
+    });
+
+    assert.equal(
+      capturedHeaders["Cookie"],
+      "__Secure-next-auth.session-token=my-session-token-value",
+    );
+    assert.ok(!capturedHeaders["Authorization"], "Should not have Authorization header for cookie auth");
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+test("Auth: JWT auth sends Authorization Bearer header", async () => {
+  let capturedHeaders = null;
+  const original = globalThis.fetch;
+  globalThis.fetch = async (url, opts) => {
+    capturedHeaders = opts.headers;
+    return new Response(
+      mockPplxStream([
+        {
+          blocks: [
+            {
+              intended_usage: "markdown",
+              markdown_block: { chunks: ["ok"], progress: "DONE" },
+            },
+          ],
+          status: "COMPLETED",
+        },
+      ]),
+      { status: 200, headers: { "Content-Type": "text/event-stream" } },
+    );
+  };
+
+  try {
+    const executor = new PerplexityWebExecutor();
+    await executor.execute({
+      model: "pplx-auto",
+      body: { messages: [{ role: "user", content: "test" }], stream: false },
+      stream: false,
+      credentials: { accessToken: "jwt-token-value" },
+      signal: AbortSignal.timeout(10000),
+      log: null,
+    });
+
+    assert.equal(capturedHeaders["Authorization"], "Bearer jwt-token-value");
+    assert.ok(!capturedHeaders["Cookie"], "Should not have Cookie header for JWT auth");
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+// ─── Test: Model mapping ────────────────────────────────────────────────────
+
+test("Model mapping: pplx-gpt sends correct internal preference", async () => {
+  let capturedBody = null;
+  const original = globalThis.fetch;
+  globalThis.fetch = async (url, opts) => {
+    capturedBody = JSON.parse(opts.body);
+    return new Response(
+      mockPplxStream([
+        {
+          blocks: [
+            {
+              intended_usage: "markdown",
+              markdown_block: { chunks: ["ok"], progress: "DONE" },
+            },
+          ],
+          status: "COMPLETED",
+        },
+      ]),
+      { status: 200, headers: { "Content-Type": "text/event-stream" } },
+    );
+  };
+
+  try {
+    const executor = new PerplexityWebExecutor();
+    await executor.execute({
+      model: "pplx-gpt",
+      body: { messages: [{ role: "user", content: "test" }], stream: false },
+      stream: false,
+      credentials: { apiKey: "test" },
+      signal: AbortSignal.timeout(10000),
+      log: null,
+    });
+
+    assert.equal(capturedBody.params.model_preference, "gpt54");
+    assert.equal(capturedBody.params.mode, "copilot");
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+test("Model mapping: thinking mode uses thinking variant", async () => {
+  let capturedBody = null;
+  const original = globalThis.fetch;
+  globalThis.fetch = async (url, opts) => {
+    capturedBody = JSON.parse(opts.body);
+    return new Response(
+      mockPplxStream([
+        {
+          blocks: [
+            {
+              intended_usage: "markdown",
+              markdown_block: { chunks: ["ok"], progress: "DONE" },
+            },
+          ],
+          status: "COMPLETED",
+        },
+      ]),
+      { status: 200, headers: { "Content-Type": "text/event-stream" } },
+    );
+  };
+
+  try {
+    const executor = new PerplexityWebExecutor();
+    await executor.execute({
+      model: "pplx-sonnet",
+      body: {
+        messages: [{ role: "user", content: "test" }],
+        stream: false,
+        thinking: true,
+      },
+      stream: false,
+      credentials: { apiKey: "test" },
+      signal: AbortSignal.timeout(10000),
+      log: null,
+    });
+
+    assert.equal(capturedBody.params.model_preference, "claude46sonnetthinking");
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+// ─── Test: Provider registry ────────────────────────────────────────────────
+
+test("Provider registry: perplexity-web is registered with correct models", async () => {
+  const { PROVIDER_MODELS } = await import(
+    "../../open-sse/config/providerModels.ts"
+  );
+
+  const models = PROVIDER_MODELS["pplx-web"];
+  assert.ok(models, "pplx-web should be in PROVIDER_MODELS");
+  assert.ok(models.length === 7, `Expected 7 models, got ${models.length}`);
+
+  const modelIds = models.map((m) => m.id);
+  assert.ok(modelIds.includes("pplx-auto"));
+  assert.ok(modelIds.includes("pplx-gpt"));
+  assert.ok(modelIds.includes("pplx-sonnet"));
+  assert.ok(modelIds.includes("pplx-opus"));
+  assert.ok(modelIds.includes("pplx-gemini"));
+  assert.ok(modelIds.includes("pplx-nemotron"));
+  assert.ok(modelIds.includes("pplx-sonar"));
+});
+
+// ─── Test: Fallback text field ──────────────────────────────────────────────
+
+test("Non-streaming: falls back to text field when no blocks", async () => {
+  const pplxEvents = [
+    { text: "Fallback answer text", status: "COMPLETED", final: true },
+  ];
+
+  const restore = mockFetch(200, pplxEvents);
+  try {
+    const executor = new PerplexityWebExecutor();
+    const result = await executor.execute({
+      model: "pplx-auto",
+      body: { messages: [{ role: "user", content: "test" }], stream: false },
+      stream: false,
+      credentials: { apiKey: "test-cookie" },
+      signal: AbortSignal.timeout(10000),
+      log: null,
+    });
+
+    const json = await result.response.json();
+    assert.ok(json.choices[0].message.content.includes("Fallback answer text"));
+  } finally {
+    restore();
+  }
+});
+
+// ─── Test: Request URL and headers ──────────────────────────────────────────
+
+test("Request: posts to correct Perplexity SSE endpoint", async () => {
+  let capturedUrl = null;
+  let capturedHeaders = null;
+  const original = globalThis.fetch;
+  globalThis.fetch = async (url, opts) => {
+    capturedUrl = url;
+    capturedHeaders = opts.headers;
+    return new Response(
+      mockPplxStream([
+        {
+          blocks: [{ intended_usage: "markdown", markdown_block: { chunks: ["ok"], progress: "DONE" } }],
+          status: "COMPLETED",
+        },
+      ]),
+      { status: 200, headers: { "Content-Type": "text/event-stream" } },
+    );
+  };
+
+  try {
+    const executor = new PerplexityWebExecutor();
+    await executor.execute({
+      model: "pplx-auto",
+      body: { messages: [{ role: "user", content: "test" }], stream: false },
+      stream: false,
+      credentials: { apiKey: "test" },
+      signal: AbortSignal.timeout(10000),
+      log: null,
+    });
+
+    assert.equal(capturedUrl, "https://www.perplexity.ai/rest/sse/perplexity_ask");
+    assert.equal(capturedHeaders["Origin"], "https://www.perplexity.ai");
+    assert.equal(capturedHeaders["X-App-ApiVersion"], "2.18");
+    assert.equal(capturedHeaders["Accept"], "text/event-stream");
+  } finally {
+    globalThis.fetch = original;
+  }
+});


### PR DESCRIPTION
Closes #1288

## Summary

- Adds a new **Perplexity Web (Session)** provider that routes through Perplexity's internal SSE API using a Pro/Max subscription session cookie
- Enables access to GPT-5.4, Claude Sonnet/Opus 4.6, Gemini 3.1 Pro, Nemotron via Perplexity without separate API costs
- Full OpenAI chat completions format compliance with streaming, thinking/reasoning, and session continuity
- **22 unit tests, all passing**

## New executor: `open-sse/executors/perplexity-web.ts`

Complete `PerplexityWebExecutor` that:
- Translates OpenAI `messages[]` → Perplexity's internal `query_str` + `params` SSE format
- Parses Perplexity's blocks-based SSE events (markdown chunks, plan steps, web results)
- Translates back to OpenAI `chat.completion` / `chat.completion.chunk` format
- Tracks `backend_uuid` for multi-turn session continuity
- Strips citations `[1][2]`, grok tags, XML declarations, script tags from responses
- Handles auth errors (expired cookies), rate limits, and connection failures

## 7 models mapped to Perplexity internal preferences

| OmniRoute Model | Internal Preference | Mode |
|---|---|---|
| `pplx-auto` | `pplx_pro` | concise |
| `pplx-sonar` | `experimental` | copilot |
| `pplx-gpt` | `gpt54` | copilot |
| `pplx-gemini` | `gemini31pro_high` | copilot |
| `pplx-sonnet` | `claude46sonnet` | copilot |
| `pplx-opus` | `claude46opus` | copilot |
| `pplx-nemotron` | `nv_nemotron_3_super` | copilot |

## Thinking variants (via `thinking: true`)

| Model | Thinking Preference |
|---|---|
| `pplx-gpt` | `gpt54_thinking` |
| `pplx-sonnet` | `claude46sonnetthinking` |
| `pplx-opus` | `claude46opusthinking` |

## Auth

Users paste their `__Secure-next-auth.session-token` cookie value as the API key. JWT tokens from the macOS desktop app are also supported via the access token field.

## Files changed

- **Created**: `open-sse/executors/perplexity-web.ts` (832 lines)
- **Modified**: `open-sse/executors/index.ts` (+4 lines — import, register, export)
- **Modified**: `open-sse/config/providerRegistry.ts` (+19 lines — provider + models)
- **Modified**: `src/shared/constants/providers.ts` (+10 lines — UI metadata)
- **Created**: `tests/unit/perplexity-web.test.mjs` (22 tests — all passing)

## Test results

```
✔ PerplexityWebExecutor is registered in executor index
✔ PerplexityWebExecutor alias resolves to same type
✔ PerplexityWebExecutor sets correct provider name
✔ Non-streaming: simple text response
✔ Non-streaming: strips citations from response
✔ Streaming: produces valid SSE chunks
✔ Streaming: thinking content emitted as reasoning_content
✔ Error: 401 returns auth error message
✔ Error: 429 returns rate limit message
✔ Error: fetch failure returns 502
✔ Error: empty messages returns 400
✔ Error: missing messages returns 400
✔ Non-streaming: Perplexity stream error returns 502
✔ Message parsing: system + user + assistant history
✔ Message parsing: developer role treated as system
✔ Auth: cookie-based auth sends Cookie header
✔ Auth: JWT auth sends Authorization Bearer header
✔ Model mapping: pplx-gpt sends correct internal preference
✔ Model mapping: thinking mode uses thinking variant
✔ Provider registry: perplexity-web is registered with correct models
✔ Non-streaming: falls back to text field when no blocks
✔ Request: posts to correct Perplexity SSE endpoint
ℹ tests 22 | pass 22 | fail 0 | duration_ms 862
```

## References

Integrated best practices from:
- [pplx-proxy](https://github.com/jamie950315/pplx-proxy) — OpenAI format, model mappings, session continuity
- [pi-perplexity](https://github.com/ivanrvpereira/pi-perplexity) — TypeScript SSE client
- [perplexity-web-wrapper](https://github.com/balakumardev/perplexity-web-wrapper) — Cookie auth, search modes
- [plexcode](https://github.com/efekurucay/plexcode) — Perplexity TUI patterns