### PR TITLE
fix: integrate compressContext() into chatCore.ts request pipeline

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -97,6 +97,7 @@ import {
   getModelFamily,
 } from "../services/modelFamilyFallback.ts";
 import { computeRequestHash, deduplicate, shouldDeduplicate } from "../services/requestDedup.ts";
+import { compressContext, estimateTokens, getTokenLimit } from "../services/contextManager.ts";
 import {
   getBackgroundTaskReason,
   getDegradedModel,
@@ -1285,6 +1286,53 @@ export async function handleChatCore({
           `Capping ${field} from ${translatedBody[field]} to ${providerCap} for ${provider}`
         );
         translatedBody[field] = providerCap;
+      }
+    }
+  }
+
+  if (translatedBody && translatedBody.messages && Array.isArray(translatedBody.messages)) {
+    const estimatedTokens = estimateTokens(JSON.stringify(translatedBody.messages));
+    const contextLimit = getTokenLimit(provider, effectiveModel);
+    const COMPRESSION_THRESHOLD = 0.85;
+    const threshold = Math.floor(contextLimit * COMPRESSION_THRESHOLD);
+
+    if (estimatedTokens > threshold) {
+      log?.info?.(
+        "CONTEXT",
+        `Proactive compression triggered: ${estimatedTokens} tokens > ${threshold} threshold (${contextLimit} limit)`
+      );
+
+      const compressionResult = compressContext(translatedBody, {
+        provider,
+        model: effectiveModel,
+        maxTokens: contextLimit,
+      });
+
+      if (compressionResult.compressed) {
+        translatedBody = compressionResult.body;
+        const stats = compressionResult.stats;
+        const layersInfo =
+          stats && "layers" in stats && Array.isArray(stats.layers)
+            ? ` (layers: ${stats.layers.map((l: { name: string }) => l.name).join(", ")})`
+            : "";
+
+        log?.info?.(
+          "CONTEXT",
+          `Context compressed: ${stats.original} → ${stats.final} tokens${layersInfo}`
+        );
+
+        logAuditEvent({
+          action: "context.proactive_compression",
+          actor: apiKeyInfo?.name || "system",
+          target: connectionId || provider || "chat",
+          details: {
+            provider,
+            model: effectiveModel,
+            original_tokens: stats.original,
+            final_tokens: stats.final,
+            layers: "layers" in stats ? stats.layers : undefined,
+          },
+        });
       }
     }
   }

--- a/tests/unit/chatcore-compression-integration.test.mjs
+++ b/tests/unit/chatcore-compression-integration.test.mjs
@@ -1,0 +1,135 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+test("chatCore integration: compressContext called proactively when context exceeds 85% threshold", async () => {
+  const { compressContext, estimateTokens, getTokenLimit } = await import(
+    "../../open-sse/services/contextManager.ts"
+  );
+
+  const provider = "openai";
+  const model = "gpt-4";
+  const contextLimit = getTokenLimit(provider, model);
+  const threshold = Math.floor(contextLimit * 0.85);
+
+  const largeMessage = "x".repeat(threshold * 4 + 1000);
+  const body = {
+    model,
+    messages: [
+      { role: "system", content: "You are helpful." },
+      { role: "user", content: largeMessage },
+    ],
+  };
+
+  const estimatedTokens = estimateTokens(JSON.stringify(body.messages));
+  assert.ok(
+    estimatedTokens > threshold,
+    `Expected ${estimatedTokens} to exceed threshold ${threshold}`
+  );
+
+  const result = compressContext(body, { provider, model, maxTokens: contextLimit });
+
+  assert.ok(result.compressed, "Context should be compressed");
+  assert.ok(result.stats.final < result.stats.original, "Final tokens should be less than original");
+  assert.ok(
+    result.stats.final <= contextLimit,
+    `Final tokens ${result.stats.final} should fit within limit ${contextLimit}`
+  );
+});
+
+test("chatCore integration: compressContext NOT called when context is below 85% threshold", async () => {
+  const { compressContext, estimateTokens, getTokenLimit } = await import(
+    "../../open-sse/services/contextManager.ts"
+  );
+
+  const provider = "openai";
+  const model = "gpt-4";
+  const contextLimit = getTokenLimit(provider, model);
+  const threshold = Math.floor(contextLimit * 0.85);
+
+  const smallMessage = "Hello, how are you?";
+  const body = {
+    model,
+    messages: [
+      { role: "system", content: "You are helpful." },
+      { role: "user", content: smallMessage },
+    ],
+  };
+
+  const estimatedTokens = estimateTokens(JSON.stringify(body.messages));
+  assert.ok(
+    estimatedTokens < threshold,
+    `Expected ${estimatedTokens} to be below threshold ${threshold}`
+  );
+
+  const result = compressContext(body, { provider, model, maxTokens: contextLimit });
+
+  assert.equal(result.compressed, false, "Context should NOT be compressed");
+});
+
+test("chatCore integration: compression preserves message structure", async () => {
+  const { compressContext, getTokenLimit } = await import(
+    "../../open-sse/services/contextManager.ts"
+  );
+
+  const provider = "claude";
+  const model = "claude-sonnet-4";
+  const contextLimit = getTokenLimit(provider, model);
+
+  const body = {
+    model,
+    messages: [
+      { role: "system", content: "You are helpful." },
+      { role: "user", content: "x".repeat(50000) },
+      { role: "assistant", content: "Response 1" },
+      { role: "user", content: "x".repeat(50000) },
+      { role: "assistant", content: "Response 2" },
+      { role: "user", content: "Final question" },
+    ],
+  };
+
+  const result = compressContext(body, { provider, model, maxTokens: contextLimit });
+
+  assert.ok(result.compressed, "Context should be compressed");
+  assert.ok(Array.isArray(result.body.messages), "Messages should remain an array");
+  assert.ok(result.body.messages.length > 0, "Messages should not be empty");
+
+  const hasSystem = result.body.messages.some((m) => m.role === "system");
+  assert.ok(hasSystem, "System message should be preserved");
+
+  const lastMessage = result.body.messages[result.body.messages.length - 1];
+  assert.equal(lastMessage.content, "Final question", "Last user message should be preserved");
+});
+
+test("chatCore integration: compression handles tool messages", async () => {
+  const { compressContext, getTokenLimit } = await import(
+    "../../open-sse/services/contextManager.ts"
+  );
+
+  const provider = "openai";
+  const model = "gpt-4";
+  const contextLimit = getTokenLimit(provider, model);
+
+  const longToolOutput = "x".repeat(10000);
+  const body = {
+    model,
+    messages: [
+      { role: "system", content: "You are helpful." },
+      { role: "user", content: "Run the tool" },
+      { role: "assistant", content: "Running tool", tool_calls: [{ id: "t1", type: "function" }] },
+      { role: "tool", content: longToolOutput, tool_call_id: "t1" },
+      { role: "user", content: "What's the result?" },
+    ],
+  };
+
+  const result = compressContext(body, { provider, model, maxTokens: 5000, reserveTokens: 1000 });
+
+  assert.ok(result.compressed, "Context should be compressed");
+
+  const toolMessage = result.body.messages.find((m) => m.role === "tool");
+  assert.ok(toolMessage, "Tool message should exist");
+  assert.ok(
+    toolMessage.content.length < longToolOutput.length,
+    "Tool message should be truncated"
+  );
+  assert.ok(toolMessage.content.includes("[truncated]"), "Tool message should have truncation marker");
+});


### PR DESCRIPTION
## Summary

- Integrates the existing (but unused) `compressContext()` from `open-sse/services/contextManager.ts` into the main request pipeline in `chatCore.ts`
- Proactively compresses oversized message contexts **before** sending to upstream providers, preventing `context_length_exceeded` errors
- Triggers compression when estimated tokens exceed 85% of the target model's context limit
- Adds audit logging for compression events

## Problem

Closes #1290

`compressContext()` has been fully implemented with 3 compression layers (trim tools, compress thinking, purify history) but was **never called** in the request pipeline. Context overflow was only handled **reactively** — after the upstream provider rejected the request, OmniRoute would try to find a larger model. If none existed, it returned the error to the client.

This wastes API calls, adds latency, and causes unnecessary failures for tool-heavy clients like OpenCode/Claude Code.

## Changes

### `open-sse/handlers/chatCore.ts`
- Imports `compressContext`, `estimateTokens`, `getTokenLimit` from `contextManager.ts`
- After request translation and before `executeProviderRequest()`, estimates token count
- If tokens exceed 85% of model's context limit, runs proactive compression
- Logs compression stats (original → final tokens, layers applied)
- Emits audit event for observability

### `tests/unit/chatcore-compression-integration.test.mjs` (new)
- Tests proactive compression triggers above 85% threshold
- Tests no compression below threshold
- Tests message structure preservation after compression
- Tests tool message truncation during compression

## Test Plan

```bash
node --import tsx/esm --test tests/unit/chatcore-compression-integration.test.mjs
node --import tsx/esm --test tests/unit/context-manager.test.mjs
```

Both should pass.

## Notes

- The insertion point is after translation (so memory/skills injection is preserved) and before the upstream request
- Compression threshold is 85% to leave headroom for translation overhead and response tokens
- This PR does NOT modify `contextManager.ts` itself — a separate PR (#1291) fixes the tool pair orphaning bug in `purifyHistory()`