### PR TITLE
feat: streaming semantic cache, Cursor auto-version detection, and call-log enhancements

### DIFF
--- a/open-sse/executors/cursor.ts
+++ b/open-sse/executors/cursor.ts
@@ -28,6 +28,7 @@ import {
   extractTextFromResponse,
 } from "../utils/cursorProtobuf.ts";
 import { estimateUsage } from "../utils/usageTracking.ts";
+import { getCursorVersion } from "../utils/cursorVersionDetector.ts";
 import { FORMATS } from "../translator/formats.ts";
 import crypto from "crypto";
 import { v5 as uuidv5 } from "uuid";
@@ -255,11 +256,11 @@ export class CursorExecutor extends BaseExecutor {
       "connect-accept-encoding": "gzip",
       "connect-protocol-version": "1",
       "content-type": "application/connect+proto",
-      "user-agent": CURSOR_USER_AGENT,
+      "user-agent": `Cursor/${getCursorVersion()}`,
       "x-amzn-trace-id": `Root=${crypto.randomUUID()}`,
       "x-client-key": crypto.createHash("sha256").update(cleanToken).digest("hex"),
       "x-cursor-checksum": this.generateChecksum(machineId),
-      "x-cursor-client-version": CURSOR_CLIENT_VERSION,
+      "x-cursor-client-version": getCursorVersion(),
       "x-cursor-client-type": "ide",
       "x-cursor-client-os":
         process.platform === "win32"
@@ -269,7 +270,7 @@ export class CursorExecutor extends BaseExecutor {
             : "linux",
       "x-cursor-client-arch": process.arch === "arm64" ? "aarch64" : "x64",
       "x-cursor-client-device-type": "desktop",
-      "x-cursor-user-agent": CURSOR_USER_AGENT,
+      "x-cursor-user-agent": `Cursor/${getCursorVersion()}`,
       "x-cursor-config-version": crypto.randomUUID(),
       "x-cursor-timezone": Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC",
       "x-ghost-mode": ghostMode ? "true" : "false",

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -86,7 +86,8 @@ import {
   generateSignature,
   getCachedResponse,
   setCachedResponse,
-  isCacheable,
+  isCacheableForRead,
+  isCacheableForWrite,
 } from "@/lib/semanticCache";
 import { getIdempotencyKey, checkIdempotency, saveIdempotency } from "@/lib/idempotencyLayer";
 import { createProgressTransform, wantsProgress } from "../utils/progressTracker.ts";
@@ -727,6 +728,7 @@ export async function handleChatCore({
     clientResponse,
     claudeCacheMeta,
     claudeCacheUsageMeta,
+    cacheSource,
   }: {
     status: number;
     tokens?: unknown;
@@ -737,6 +739,7 @@ export async function handleChatCore({
     clientResponse?: unknown;
     claudeCacheMeta?: Record<string, unknown>;
     claudeCacheUsageMeta?: Record<string, unknown>;
+    cacheSource?: "upstream" | "semantic";
   }) => {
     const callLogId = generateRequestId();
     const pipelinePayloads = detailedLoggingEnabled ? reqLogger?.getPipelinePayloads?.() : null;
@@ -788,6 +791,7 @@ export async function handleChatCore({
       comboName,
       comboStepId,
       comboExecutionKey,
+      cacheSource: cacheSource === "semantic" ? "semantic" : "upstream",
       apiKeyId: apiKeyInfo?.id || null,
       apiKeyName: apiKeyInfo?.name || null,
       noLog: noLogEnabled,
@@ -856,25 +860,6 @@ export async function handleChatCore({
   const settings = await getCachedSettings();
   const semanticCacheEnabled = settings.semanticCacheEnabled !== false;
 
-  // ── Phase 9.1: Semantic cache check (non-streaming, temp=0 only) ──
-  if (semanticCacheEnabled && isCacheable(body, clientRawRequest?.headers)) {
-    const signature = generateSignature(model, body.messages, body.temperature, body.top_p);
-    const cached = getCachedResponse(signature);
-    if (cached) {
-      log?.debug?.("CACHE", `Semantic cache HIT for ${model}`);
-      return {
-        success: true,
-        response: new Response(JSON.stringify(cached), {
-          headers: {
-            "Content-Type": "application/json",
-            "Access-Control-Allow-Origin": getCorsOrigin(),
-            "X-OmniRoute-Cache": "HIT",
-          },
-        }),
-      };
-    }
-  }
-
   // Create request logger for this session: sourceFormat_targetFormat_model
   const reqLogger = await createRequestLogger(sourceFormat, targetFormat, model);
 
@@ -888,6 +873,41 @@ export async function handleChatCore({
   }
 
   log?.debug?.("FORMAT", `${sourceFormat} → ${targetFormat} | stream=${stream}`);
+
+  // ── Phase 9.1: Semantic cache check (temp=0, any streaming mode) ──
+  // Streaming responses are cached after assembly; cache hits return JSON regardless of stream flag.
+  if (semanticCacheEnabled && isCacheableForRead(body, clientRawRequest?.headers)) {
+    const signature = generateSignature(
+      model,
+      body.messages ?? body.input,
+      body.temperature,
+      body.top_p
+    );
+    const cached = getCachedResponse(signature);
+    if (cached) {
+      log?.debug?.("CACHE", `Semantic cache HIT for ${model} (stream=${stream})`);
+      reqLogger.logConvertedResponse(cached as Record<string, unknown>);
+      persistAttemptLogs({
+        status: 200,
+        tokens: (cached as Record<string, unknown>)?.usage,
+        responseBody: cached,
+        providerRequest: null,
+        providerResponse: null,
+        clientResponse: cached,
+        cacheSource: "semantic",
+      });
+      return {
+        success: true,
+        response: new Response(JSON.stringify(cached), {
+          headers: {
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Origin": getCorsOrigin(),
+            "X-OmniRoute-Cache": "HIT",
+          },
+        }),
+      };
+    }
+  }
 
   // ── Common input sanitization (runs for ALL paths including passthrough) ──
   // #994: Normalize max_output_tokens to max_tokens for universal compatibility
@@ -1198,6 +1218,38 @@ export async function handleChatCore({
         }
       }
 
+      // OpenAI-compatible providers only support function tools.
+      // Non-function tool types (computer, mcp, web_search, custom, etc.) are handled:
+      //   - tools with a name → converted to function format in-place before translation
+      //   - tools without a name AND without .function → dropped (unconvertible)
+      // This must happen before translateRequest, which validates and throws on unknown types.
+      if (provider?.startsWith("openai-compatible-") && Array.isArray(translatedBody.tools)) {
+        const before = (translatedBody.tools as unknown[]).length;
+        translatedBody.tools = (translatedBody.tools as Record<string, unknown>[])
+          .filter((t) => !t.type || t.type === "function" || !!t.function || !!t.name)
+          .map((t) => {
+            if (!t.type || t.type === "function" || t.function) return t;
+            // Named non-function tool: normalise to function format so the translator
+            // does not throw on the unknown type.
+            return {
+              type: "function",
+              function: {
+                name: t.name,
+                ...(t.description !== undefined ? { description: t.description } : {}),
+                ...(t.parameters !== undefined ? { parameters: t.parameters } : {}),
+                ...(t.strict !== undefined ? { strict: t.strict } : {}),
+              },
+            };
+          });
+        const dropped = before - (translatedBody.tools as unknown[]).length;
+        if (dropped > 0) {
+          log?.debug?.(
+            "TOOLS",
+            `Dropped ${dropped} unconvertible tool(s) for openai-compatible provider`
+          );
+        }
+      }
+
       const normalizeToolCallId = getModelNormalizeToolCallId(
         provider || "",
         model || "",
@@ -1445,6 +1497,21 @@ export async function handleChatCore({
           ? translatedBody
           : { ...translatedBody, model: modelToCall };
 
+      // Qwen OAuth rejects requests without a non-empty `user` field.
+      // Some minimal OpenAI-compatible clients omit it, so we backfill a
+      // stable default only for OAuth mode (API key mode is unaffected).
+      const hasValidQwenUser =
+        typeof bodyToSend.user === "string" && bodyToSend.user.trim().length > 0;
+      const isQwenOAuthRequest =
+        provider === "qwen" &&
+        !credentials?.apiKey &&
+        typeof credentials?.accessToken === "string" &&
+        credentials.accessToken.trim().length > 0;
+      if (isQwenOAuthRequest && !hasValidQwenUser) {
+        bodyToSend = { ...bodyToSend, user: "omniroute-qwen-oauth" };
+        log?.debug?.("QWEN", "Injected fallback user for OAuth request");
+      }
+
       // Inject prompt_cache_key only for providers that support it
       if (
         targetFormat === FORMATS.OPENAI &&
@@ -1597,6 +1664,7 @@ export async function handleChatCore({
       providerRequest: finalBody || translatedBody,
       clientResponse: buildErrorBody(failureStatus, failureMessage),
       claudeCacheMeta: claudePromptCacheLogMeta,
+      cacheSource: "upstream",
     });
     if (error.name === "AbortError") {
       streamController.handleError(error);
@@ -1901,6 +1969,7 @@ export async function handleChatCore({
               providerRequest: finalBody || translatedBody,
               providerResponse: upstreamErrorBody,
               clientResponse: buildErrorBody(statusCode, errMsg),
+              cacheSource: "upstream",
             });
             persistFailureUsage(statusCode, "model_unavailable");
             return createErrorResult(statusCode, errMsg, retryAfterMs);
@@ -1912,6 +1981,7 @@ export async function handleChatCore({
             providerRequest: finalBody || translatedBody,
             providerResponse: upstreamErrorBody,
             clientResponse: buildErrorBody(statusCode, errMsg),
+            cacheSource: "upstream",
           });
           persistFailureUsage(statusCode, "model_unavailable");
           return createErrorResult(statusCode, errMsg, retryAfterMs);
@@ -1923,6 +1993,7 @@ export async function handleChatCore({
           providerRequest: finalBody || translatedBody,
           providerResponse: upstreamErrorBody,
           clientResponse: buildErrorBody(statusCode, errMsg),
+          cacheSource: "upstream",
         });
         persistFailureUsage(statusCode, "model_unavailable");
         return createErrorResult(statusCode, errMsg, retryAfterMs);
@@ -1958,6 +2029,7 @@ export async function handleChatCore({
               providerRequest: finalBody || translatedBody,
               providerResponse: upstreamErrorBody,
               clientResponse: buildErrorBody(statusCode, errMsg),
+              cacheSource: "upstream",
             });
             persistFailureUsage(statusCode, "context_overflow");
             return createErrorResult(statusCode, errMsg, retryAfterMs);
@@ -1969,6 +2041,7 @@ export async function handleChatCore({
             providerRequest: finalBody || translatedBody,
             providerResponse: upstreamErrorBody,
             clientResponse: buildErrorBody(statusCode, errMsg),
+            cacheSource: "upstream",
           });
           persistFailureUsage(statusCode, "context_overflow");
           return createErrorResult(statusCode, errMsg, retryAfterMs);
@@ -1980,6 +2053,7 @@ export async function handleChatCore({
           providerRequest: finalBody || translatedBody,
           providerResponse: upstreamErrorBody,
           clientResponse: buildErrorBody(statusCode, errMsg),
+          cacheSource: "upstream",
         });
         persistFailureUsage(statusCode, "context_overflow");
         return createErrorResult(statusCode, errMsg, retryAfterMs);
@@ -1991,6 +2065,7 @@ export async function handleChatCore({
         providerRequest: finalBody || translatedBody,
         providerResponse: upstreamErrorBody,
         clientResponse: buildErrorBody(statusCode, errMsg),
+        cacheSource: "upstream",
       });
       persistFailureUsage(statusCode, `upstream_${statusCode}`);
 
@@ -2099,6 +2174,7 @@ export async function handleChatCore({
           providerRequest: finalBody || translatedBody,
           providerResponse: normalizedProviderPayload,
           clientResponse: buildErrorBody(HTTP_STATUS.BAD_GATEWAY, invalidSseMessage),
+          cacheSource: "upstream",
         });
         persistFailureUsage(HTTP_STATUS.BAD_GATEWAY, "invalid_sse_payload");
         return createErrorResult(HTTP_STATUS.BAD_GATEWAY, invalidSseMessage);
@@ -2123,6 +2199,7 @@ export async function handleChatCore({
           providerRequest: finalBody || translatedBody,
           providerResponse: normalizedProviderPayload,
           clientResponse: buildErrorBody(HTTP_STATUS.BAD_GATEWAY, invalidJsonMessage),
+          cacheSource: "upstream",
         });
         persistFailureUsage(HTTP_STATUS.BAD_GATEWAY, "invalid_json_payload");
         return createErrorResult(HTTP_STATUS.BAD_GATEWAY, invalidJsonMessage);
@@ -2144,6 +2221,7 @@ export async function handleChatCore({
         providerRequest: finalBody || translatedBody,
         providerResponse: normalizedProviderPayload,
         clientResponse: buildErrorBody(HTTP_STATUS.BAD_GATEWAY, emptyContentMessage),
+        cacheSource: "upstream",
       });
       persistFailureUsage(HTTP_STATUS.BAD_GATEWAY, "empty_content");
 
@@ -2352,8 +2430,13 @@ export async function handleChatCore({
     }
 
     // ── Phase 9.1: Cache store (non-streaming, temp=0) ──
-    if (semanticCacheEnabled && isCacheable(body, clientRawRequest?.headers)) {
-      const signature = generateSignature(model, body.messages, body.temperature, body.top_p);
+    if (semanticCacheEnabled && isCacheableForWrite(body, clientRawRequest?.headers)) {
+      const signature = generateSignature(
+        model,
+        body.messages ?? body.input,
+        body.temperature,
+        body.top_p
+      );
       const tokensSaved = usage?.prompt_tokens + usage?.completion_tokens || 0;
       setCachedResponse(signature, model, translatedResponse, tokensSaved);
       log?.debug?.("CACHE", `Stored response for ${model} (${tokensSaved} tokens)`);
@@ -2377,6 +2460,7 @@ export async function handleChatCore({
       clientResponse: translatedResponse,
       claudeCacheMeta: claudePromptCacheLogMeta,
       claudeCacheUsageMeta: cacheUsageLogMeta,
+      cacheSource: "upstream",
     });
 
     return {
@@ -2467,6 +2551,7 @@ export async function handleChatCore({
       clientResponse: clientPayload ?? streamResponseBody ?? undefined,
       claudeCacheMeta: claudePromptCacheLogMeta,
       claudeCacheUsageMeta: cacheUsageLogMeta,
+      cacheSource: "upstream",
     });
 
     if (apiKeyInfo?.id && streamUsage) {
@@ -2475,6 +2560,32 @@ export async function handleChatCore({
           if (estimatedCost > 0) recordCost(apiKeyInfo.id, estimatedCost);
         })
         .catch(() => {});
+    }
+
+    // Semantic cache: store assembled streaming response for future cache hits
+    if (
+      semanticCacheEnabled &&
+      streamStatus === 200 &&
+      streamResponseBody &&
+      isCacheableForWrite(body, clientRawRequest?.headers)
+    ) {
+      try {
+        const cleanBody = { ...streamResponseBody };
+        delete cleanBody._streamed;
+        const sig = generateSignature(
+          model,
+          body.messages ?? body.input,
+          body.temperature,
+          body.top_p
+        );
+        const u = streamUsage as Record<string, unknown> | null;
+        const tokensSaved =
+          (Number(u?.prompt_tokens ?? 0) || 0) + (Number(u?.completion_tokens ?? 0) || 0);
+        setCachedResponse(sig, model, cleanBody, tokensSaved);
+        log?.debug?.("CACHE", `Stored streaming response for ${model} (${tokensSaved} tokens)`);
+      } catch {
+        // Cache write failed — non-critical
+      }
     }
   };
 

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -1236,7 +1236,9 @@ export async function handleChatCore({
               function: {
                 name: t.name,
                 ...(t.description !== undefined ? { description: t.description } : {}),
-                ...(t.parameters !== undefined ? { parameters: t.parameters } : {}),
+                ...(t.parameters !== undefined || t.input_schema !== undefined
+                  ? { parameters: t.parameters ?? t.input_schema ?? {} }
+                  : {}),
                 ...(t.strict !== undefined ? { strict: t.strict } : {}),
               },
             };

--- a/open-sse/handlers/usageExtractor.ts
+++ b/open-sse/handlers/usageExtractor.ts
@@ -19,8 +19,12 @@ export function extractUsageFromResponse(responseBody, provider) {
     return {
       prompt_tokens: responseBody.usage.prompt_tokens || 0,
       completion_tokens: responseBody.usage.completion_tokens || 0,
-      cached_tokens: responseBody.usage.prompt_tokens_details?.cached_tokens,
-      reasoning_tokens: responseBody.usage.completion_tokens_details?.reasoning_tokens,
+      cached_tokens:
+        responseBody.usage.prompt_tokens_details?.cached_tokens ??
+        responseBody.usage.input_tokens_details?.cached_tokens,
+      reasoning_tokens:
+        responseBody.usage.completion_tokens_details?.reasoning_tokens ??
+        responseBody.usage.output_tokens_details?.reasoning_tokens,
     };
   }
 
@@ -60,10 +64,13 @@ export function extractUsageFromResponse(responseBody, provider) {
       cache_read_input_tokens: responsesUsage.cache_read_input_tokens,
       cached_tokens:
         responsesUsage.input_tokens_details?.cached_tokens ??
+        responsesUsage.prompt_tokens_details?.cached_tokens ??
         responsesUsage.cache_read_input_tokens,
       cache_creation_input_tokens: responsesUsage.cache_creation_input_tokens,
       reasoning_tokens:
-        responsesUsage.reasoning_tokens || responsesUsage.output_tokens_details?.reasoning_tokens,
+        responsesUsage.output_tokens_details?.reasoning_tokens ??
+        responsesUsage.completion_tokens_details?.reasoning_tokens ??
+        responsesUsage.reasoning_tokens,
     };
   }
 

--- a/open-sse/translator/response/openai-responses.ts
+++ b/open-sse/translator/response/openai-responses.ts
@@ -30,8 +30,15 @@ export function openaiToOpenAIResponsesResponse(chunk, state) {
       output_tokens,
       total_tokens: u.total_tokens ?? input_tokens + output_tokens,
     };
-    if (u.prompt_tokens_details?.cached_tokens) {
-      state.usage.input_tokens_details = { cached_tokens: u.prompt_tokens_details.cached_tokens };
+    const cachedTokens =
+      u.input_tokens_details?.cached_tokens ?? u.prompt_tokens_details?.cached_tokens;
+    if (cachedTokens) {
+      state.usage.input_tokens_details = { cached_tokens: cachedTokens };
+    }
+    const reasoningTokens =
+      u.output_tokens_details?.reasoning_tokens ?? u.completion_tokens_details?.reasoning_tokens;
+    if (reasoningTokens) {
+      state.usage.output_tokens_details = { reasoning_tokens: reasoningTokens };
     }
   }
 
@@ -700,8 +707,17 @@ export function openaiResponsesToOpenAIResponse(chunk, state) {
     if (responseUsage && typeof responseUsage === "object") {
       const inputTokens = responseUsage.input_tokens || responseUsage.prompt_tokens || 0;
       const outputTokens = responseUsage.output_tokens || responseUsage.completion_tokens || 0;
-      const cacheReadTokens = responseUsage.cache_read_input_tokens || 0;
+      const cacheReadTokens =
+        responseUsage.cache_read_input_tokens ||
+        responseUsage.input_tokens_details?.cached_tokens ||
+        responseUsage.prompt_tokens_details?.cached_tokens ||
+        0;
       const cacheCreationTokens = responseUsage.cache_creation_input_tokens || 0;
+      const reasoningTokens =
+        responseUsage.output_tokens_details?.reasoning_tokens ||
+        responseUsage.completion_tokens_details?.reasoning_tokens ||
+        responseUsage.reasoning_tokens ||
+        0;
 
       // prompt_tokens = input_tokens + cache_read + cache_creation (all prompt-side tokens)
       const promptTokens = inputTokens + cacheReadTokens + cacheCreationTokens;
@@ -721,6 +737,13 @@ export function openaiResponsesToOpenAIResponse(chunk, state) {
         if (cacheCreationTokens > 0) {
           state.usage.prompt_tokens_details.cache_creation_tokens = cacheCreationTokens;
         }
+      }
+
+      // Add completion_tokens_details if reasoning tokens exist
+      if (reasoningTokens > 0) {
+        state.usage.completion_tokens_details = {
+          reasoning_tokens: reasoningTokens,
+        };
       }
     }
 

--- a/open-sse/utils/cursorChecksum.ts
+++ b/open-sse/utils/cursorChecksum.ts
@@ -7,6 +7,7 @@
 
 import crypto from "crypto";
 import { v5 as uuidv5 } from "uuid";
+import { getCursorVersion } from "./cursorVersionDetector.ts";
 
 const CURSOR_CLIENT_VERSION = "3.1.0";
 const CURSOR_USER_AGENT = `Cursor/${CURSOR_CLIENT_VERSION}`;
@@ -115,12 +116,12 @@ export function buildCursorHeaders(accessToken, machineId = null, ghostMode = tr
     "connect-accept-encoding": "gzip",
     "connect-protocol-version": "1",
     "Content-Type": "application/connect+proto",
-    "User-Agent": CURSOR_USER_AGENT,
+    "User-Agent": `Cursor/${getCursorVersion()}`,
     "x-amzn-trace-id": `Root=${crypto.randomUUID()}`,
     "x-client-key": clientKey,
     "x-cursor-checksum": checksum,
-    "x-cursor-client-version": CURSOR_CLIENT_VERSION,
-    "x-cursor-user-agent": CURSOR_USER_AGENT,
+    "x-cursor-client-version": getCursorVersion(),
+    "x-cursor-user-agent": `Cursor/${getCursorVersion()}`,
     "x-cursor-config-version": crypto.randomUUID(),
     "x-cursor-timezone": Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC",
     "x-ghost-mode": ghostMode ? "true" : "false",

--- a/open-sse/utils/cursorVersionDetector.ts
+++ b/open-sse/utils/cursorVersionDetector.ts
@@ -1,0 +1,68 @@
+/**
+ * Auto-detect the installed Cursor IDE version from its local SQLite database.
+ * Falls back to the hardcoded default when the DB is unavailable.
+ * The detected version is cached in-memory for 1 hour to avoid repeated DB reads.
+ *
+ * Override the DB path with the CURSOR_STATE_DB_PATH env var for non-standard installs.
+ */
+
+import { homedir } from "os";
+import { join } from "path";
+import { createRequire } from "module";
+
+const CACHE_TTL_MS = 60 * 60 * 1000;
+const DB_KEY = "cursorupdate.lastUpdatedAndShown.version";
+const FALLBACK_VERSION = "3.1.15";
+
+let cachedVersion: string | null = null;
+let cachedAt = 0;
+
+export function getCursorDbPath(): string {
+  if (process.env.CURSOR_STATE_DB_PATH) {
+    return process.env.CURSOR_STATE_DB_PATH;
+  }
+  const home = process.env.HOME || process.env.USERPROFILE || homedir();
+  const platform = process.platform;
+  if (platform === "darwin") {
+    return join(home, "Library/Application Support/Cursor/User/globalStorage/state.vscdb");
+  }
+  if (platform === "win32") {
+    return join(process.env.APPDATA || home, "Cursor/User/globalStorage/state.vscdb");
+  }
+  return join(home, ".config/Cursor/User/globalStorage/state.vscdb");
+}
+
+export function getCursorVersion(): string {
+  const now = Date.now();
+  if (cachedVersion && now - cachedAt < CACHE_TTL_MS) {
+    return cachedVersion;
+  }
+
+  try {
+    const esmRequire = createRequire(import.meta.url);
+    const Database = esmRequire("better-sqlite3");
+    const db = new Database(getCursorDbPath(), { readonly: true, fileMustExist: true });
+    try {
+      const row = db.prepare("SELECT value FROM itemTable WHERE key = ?").get(DB_KEY) as
+        | { value: string }
+        | undefined;
+      if (row?.value) {
+        cachedVersion = row.value;
+        cachedAt = now;
+        return cachedVersion;
+      }
+    } finally {
+      db.close();
+    }
+  } catch {
+    // DB missing or unreadable — fall through to default
+  }
+
+  return FALLBACK_VERSION;
+}
+
+/** Exposed for testing: reset the in-memory cache so the next call re-reads the DB. */
+export function resetCursorVersionCache(): void {
+  cachedVersion = null;
+  cachedAt = 0;
+}

--- a/open-sse/utils/usageTracking.ts
+++ b/open-sse/utils/usageTracking.ts
@@ -341,8 +341,15 @@ export function extractUsage(chunk) {
     return normalizeUsage({
       prompt_tokens: usage.input_tokens || usage.prompt_tokens || 0,
       completion_tokens: usage.output_tokens || usage.completion_tokens || 0,
-      cached_tokens: usage.input_tokens_details?.cached_tokens,
-      reasoning_tokens: usage.output_tokens_details?.reasoning_tokens,
+      cached_tokens:
+        usage.input_tokens_details?.cached_tokens ??
+        usage.prompt_tokens_details?.cached_tokens ??
+        usage.cache_read_input_tokens,
+      cache_creation_input_tokens: usage.cache_creation_input_tokens,
+      reasoning_tokens:
+        usage.output_tokens_details?.reasoning_tokens ??
+        usage.completion_tokens_details?.reasoning_tokens ??
+        usage.reasoning_tokens,
     });
   }
 
@@ -355,8 +362,12 @@ export function extractUsage(chunk) {
     return normalizeUsage({
       prompt_tokens: chunk.usage.prompt_tokens ?? chunk.usage.input_tokens ?? 0,
       completion_tokens: chunk.usage.completion_tokens ?? chunk.usage.output_tokens ?? 0,
-      cached_tokens: chunk.usage.prompt_tokens_details?.cached_tokens,
-      reasoning_tokens: chunk.usage.completion_tokens_details?.reasoning_tokens,
+      cached_tokens:
+        chunk.usage.prompt_tokens_details?.cached_tokens ??
+        chunk.usage.input_tokens_details?.cached_tokens,
+      reasoning_tokens:
+        chunk.usage.completion_tokens_details?.reasoning_tokens ??
+        chunk.usage.output_tokens_details?.reasoning_tokens,
     });
   }
 

--- a/src/lib/db/core.ts
+++ b/src/lib/db/core.ts
@@ -173,6 +173,7 @@ const SCHEMA_SQL = `
     tokens_cache_read INTEGER DEFAULT NULL,
     tokens_cache_creation INTEGER DEFAULT NULL,
     tokens_reasoning INTEGER DEFAULT NULL,
+    cache_source TEXT DEFAULT "upstream",
     request_type TEXT,
     source_format TEXT,
     target_format TEXT,
@@ -428,6 +429,10 @@ function ensureCallLogsColumns(db: SqliteDatabase) {
     if (!columnNames.has("tokens_reasoning")) {
       db.exec("ALTER TABLE call_logs ADD COLUMN tokens_reasoning INTEGER DEFAULT NULL");
       console.log("[DB] Added call_logs.tokens_reasoning column");
+    }
+    if (!columnNames.has("cache_source")) {
+      db.exec("ALTER TABLE call_logs ADD COLUMN cache_source TEXT DEFAULT 'upstream'");
+      console.log("[DB] Added call_logs.cache_source column");
     }
     if (!columnNames.has("combo_step_id")) {
       db.exec("ALTER TABLE call_logs ADD COLUMN combo_step_id TEXT DEFAULT NULL");
@@ -692,6 +697,12 @@ export function getDbInstance(): SqliteDatabase {
     db.prepare("INSERT OR IGNORE INTO _omniroute_migrations (version, name) VALUES (?, ?)").run(
       "021",
       "combo_call_log_targets"
+    );
+  }
+  if (hasColumn(db, "call_logs", "cache_source")) {
+    db.prepare("INSERT OR IGNORE INTO _omniroute_migrations (version, name) VALUES (?, ?)").run(
+      "022",
+      "call_logs_cache_source"
     );
   }
   runMigrations(db);

--- a/src/lib/oauth/constants/oauth.ts
+++ b/src/lib/oauth/constants/oauth.ts
@@ -225,7 +225,7 @@ export const CURSOR_CONFIG = {
   agentEndpoint: "https://agent.api5.cursor.sh", // Privacy mode
   agentNonPrivacyEndpoint: "https://agentn.api5.cursor.sh", // Non-privacy mode
   // Client metadata
-  clientVersion: "3.1.0",
+  clientVersion: "3.1.15",
   clientType: "ide",
   // Token storage locations (for user reference)
   tokenStoragePaths: {

--- a/src/lib/semanticCache.ts
+++ b/src/lib/semanticCache.ts
@@ -139,6 +139,9 @@ function stringifyForSignature(value: unknown): string {
  * Supports both Chat Completions `messages[]` and Responses API `input[]`.
  */
 function normalizeConversation(conversation: unknown) {
+  if (typeof conversation === "string") {
+    return [{ role: "user", content: conversation }];
+  }
   if (!Array.isArray(conversation)) return [];
 
   return conversation.map((item: Record<string, unknown>) => ({

--- a/src/lib/semanticCache.ts
+++ b/src/lib/semanticCache.ts
@@ -1,7 +1,9 @@
 /**
  * Semantic Cache — Phase 9.1
  *
- * Caches non-streaming LLM responses (temperature=0) to reduce cost and latency.
+ * Caches LLM responses (temperature=0) to reduce cost and latency.
+ * Supports both streaming and non-streaming requests: streaming responses
+ * are cached after assembly; cache hits always return JSON.
  * Two-tier: in-memory LRU (fast) + SQLite (persistent across restarts).
  *
  * Cache key = SHA-256(model + normalized messages + temperature + top_p)
@@ -113,25 +115,35 @@ function getMemoryCache() {
  * @param {number} topP
  * @returns {string} hex signature
  */
-export function generateSignature(model, messages, temperature = 0, topP = 1) {
+export function generateSignature(model, conversation, temperature = 0, topP = 1) {
   const payload = JSON.stringify({
     model,
-    messages: normalizeMessages(messages),
+    messages: normalizeConversation(conversation),
     temperature,
     top_p: topP,
   });
   return crypto.createHash("sha256").update(payload).digest("hex");
 }
 
+function stringifyForSignature(value: unknown): string {
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
 /**
- * Normalize messages for consistent hashing.
- * Strips metadata, keeps only role + content.
+ * Normalize conversation items for consistent hashing.
+ * Supports both Chat Completions `messages[]` and Responses API `input[]`.
  */
-function normalizeMessages(messages) {
-  if (!Array.isArray(messages)) return [];
-  return messages.map((m) => ({
-    role: m.role || "user",
-    content: typeof m.content === "string" ? m.content : JSON.stringify(m.content),
+function normalizeConversation(conversation: unknown) {
+  if (!Array.isArray(conversation)) return [];
+
+  return conversation.map((item: Record<string, unknown>) => ({
+    role: typeof item?.role === "string" && item.role.trim().length > 0 ? item.role : "user",
+    content: stringifyForSignature(item?.content),
   }));
 }
 
@@ -379,8 +391,9 @@ export function getCacheStats() {
 }
 
 /**
- * Check if a request is cacheable.
+ * Check if a request is cacheable for read (pre-request lookup).
  * Only non-streaming, deterministic (temperature=0) requests.
+ * @deprecated Use isCacheableForRead instead.
  */
 export function isCacheable(body, headers) {
   if ((getHeaderValue(headers, "x-omniroute-no-cache") || "").toLowerCase() === "true") {
@@ -388,5 +401,32 @@ export function isCacheable(body, headers) {
   }
   if (body.stream !== false) return false;
   if ((body.temperature ?? 0) !== 0) return false;
+  return true;
+}
+
+/**
+ * Check if a cached response can be served for this request.
+ * Works for both streaming and non-streaming requests (cache hit returns JSON).
+ * Omitted temperature defaults to 0 for read (matching existing cache entries).
+ */
+export function isCacheableForRead(body, headers) {
+  if ((getHeaderValue(headers, "x-omniroute-no-cache") || "").toLowerCase() === "true") {
+    return false;
+  }
+  if ((body.temperature ?? 0) !== 0) return false;
+  return true;
+}
+
+/**
+ * Check if a response should be stored in cache after completion.
+ * Works for both streaming and non-streaming responses.
+ * Requires explicit `temperature: 0` — omitted temperature is NOT cacheable
+ * because the provider default may be non-deterministic.
+ */
+export function isCacheableForWrite(body, headers) {
+  if ((getHeaderValue(headers, "x-omniroute-no-cache") || "").toLowerCase() === "true") {
+    return false;
+  }
+  if (body.temperature !== 0) return false;
   return true;
 }

--- a/src/lib/usage/callLogs.ts
+++ b/src/lib/usage/callLogs.ts
@@ -557,8 +557,9 @@ export async function getCallLogs(filter: any = {}) {
   const db = getDbInstance();
   let sql = `
     SELECT cl.*,
-      (SELECT pn.prefix FROM provider_nodes pn WHERE pn.id = cl.provider LIMIT 1) AS provider_node_prefix
+      pn.prefix AS provider_node_prefix
     FROM call_logs cl
+    LEFT JOIN provider_nodes pn ON pn.id = cl.provider
   `;
   const conditions: string[] = [];
   const params: Record<string, unknown> = {};
@@ -671,8 +672,10 @@ export async function getCallLogById(id: string) {
   const row = db
     .prepare(
       `SELECT cl.*,
-        (SELECT pn.prefix FROM provider_nodes pn WHERE pn.id = cl.provider LIMIT 1) AS provider_node_prefix
-       FROM call_logs cl WHERE cl.id = ?`
+        pn.prefix AS provider_node_prefix
+       FROM call_logs cl
+       LEFT JOIN provider_nodes pn ON pn.id = cl.provider
+       WHERE cl.id = ?`
     )
     .get(id);
   if (!row) return null;

--- a/src/lib/usage/callLogs.ts
+++ b/src/lib/usage/callLogs.ts
@@ -173,6 +173,39 @@ async function resolveAccountName(connectionId: string | null | undefined) {
   return account;
 }
 
+async function resolveProviderPrefix(providerId: string): Promise<string | null> {
+  if (!providerId) return null;
+  try {
+    const { getProviderNodeById } = await import("@/lib/localDb");
+    const node = await getProviderNodeById(providerId);
+    if (node && typeof node.prefix === "string" && node.prefix.trim().length > 0) {
+      return node.prefix.trim();
+    }
+  } catch {
+    // Best-effort lookup only.
+  }
+  return null;
+}
+
+function isCompatibleProviderId(providerId: string | null): boolean {
+  if (!providerId) return false;
+  return (
+    providerId.startsWith("openai-compatible-") || providerId.startsWith("anthropic-compatible-")
+  );
+}
+
+function applyNodePrefix(
+  requestedModel: string | null,
+  provider: string | null,
+  nodePrefix: string | null
+): string | null {
+  if (!requestedModel || !provider || !nodePrefix) return requestedModel;
+  if (requestedModel.startsWith(provider + "/")) {
+    return nodePrefix + "/" + requestedModel.slice(provider.length + 1);
+  }
+  return requestedModel;
+}
+
 function buildArtifactRelativePath(timestamp: string, id: string) {
   const parsed = new Date(timestamp);
   const safeTimestamp = (
@@ -403,6 +436,14 @@ export async function saveCallLog(entry: any) {
 
     const account = await resolveAccountName(entry.connectionId || null);
 
+    const rawProvider: string = entry.provider || "-";
+    const rawRequestedModel: string | null = entry.requestedModel || null;
+    let resolvedRequestedModel = rawRequestedModel;
+    if (rawRequestedModel && isCompatibleProviderId(rawProvider)) {
+      const nodePrefix = await resolveProviderPrefix(rawProvider);
+      resolvedRequestedModel = applyNodePrefix(rawRequestedModel, rawProvider, nodePrefix);
+    }
+
     const logEntry = {
       id: typeof entry.id === "string" && entry.id.length > 0 ? entry.id : generateLogId(),
       timestamp: typeof entry.timestamp === "string" ? entry.timestamp : new Date().toISOString(),
@@ -410,8 +451,8 @@ export async function saveCallLog(entry: any) {
       path: entry.path || "/v1/chat/completions",
       status: entry.status || 0,
       model: entry.model || "-",
-      requestedModel: entry.requestedModel || null,
-      provider: entry.provider || "-",
+      requestedModel: resolvedRequestedModel,
+      provider: rawProvider,
       account,
       connectionId: entry.connectionId || null,
       duration: entry.duration || 0,
@@ -429,6 +470,7 @@ export async function saveCallLog(entry: any) {
       comboStepId: toStringOrNull(entry.comboStepId),
       comboExecutionKey:
         toStringOrNull(entry.comboExecutionKey) || toStringOrNull(entry.comboStepId),
+      cacheSource: entry.cacheSource === "semantic" ? "semantic" : "upstream",
       requestBody: serializePayloadForStorage(protectedRequestBody, CALL_LOG_INLINE_BODY_LIMIT),
       responseBody: serializePayloadForStorage(protectedResponseBody, CALL_LOG_INLINE_BODY_LIMIT),
       error: toStoredErrorString(protectedError),
@@ -443,8 +485,8 @@ export async function saveCallLog(entry: any) {
         tokens_cache_read, tokens_cache_creation, tokens_reasoning,
         request_type, source_format,
         target_format, api_key_id, api_key_name, combo_name, combo_step_id,
-        combo_execution_key, request_body, response_body, error, artifact_relpath,
-        has_pipeline_details
+        combo_execution_key, cache_source, request_body, response_body, error,
+        artifact_relpath, has_pipeline_details
       )
       VALUES (
         @id, @timestamp, @method, @path, @status, @model, @requestedModel, @provider,
@@ -452,7 +494,7 @@ export async function saveCallLog(entry: any) {
         @tokensCacheRead, @tokensCacheCreation, @tokensReasoning,
         @requestType, @sourceFormat,
         @targetFormat, @apiKeyId, @apiKeyName, @comboName, @comboStepId,
-        @comboExecutionKey, @requestBody, @responseBody, @error, NULL, 0
+        @comboExecutionKey, @cacheSource, @requestBody, @responseBody, @error, NULL, 0
       )
     `
     ).run(logEntry);
@@ -513,50 +555,54 @@ if (shouldPersistToDisk) {
 
 export async function getCallLogs(filter: any = {}) {
   const db = getDbInstance();
-  let sql = "SELECT * FROM call_logs";
+  let sql = `
+    SELECT cl.*,
+      (SELECT pn.prefix FROM provider_nodes pn WHERE pn.id = cl.provider LIMIT 1) AS provider_node_prefix
+    FROM call_logs cl
+  `;
   const conditions: string[] = [];
   const params: Record<string, unknown> = {};
 
   if (filter.status) {
     if (filter.status === "error") {
-      conditions.push("(status >= 400 OR error IS NOT NULL)");
+      conditions.push("(cl.status >= 400 OR cl.error IS NOT NULL)");
     } else if (filter.status === "ok") {
-      conditions.push("status >= 200 AND status < 300");
+      conditions.push("cl.status >= 200 AND cl.status < 300");
     } else {
       const statusCode = parseInt(filter.status, 10);
       if (!Number.isNaN(statusCode)) {
-        conditions.push("status = @statusCode");
+        conditions.push("cl.status = @statusCode");
         params.statusCode = statusCode;
       }
     }
   }
 
   if (filter.model) {
-    conditions.push("(model LIKE @modelQ OR requested_model LIKE @modelQ)");
+    conditions.push("(cl.model LIKE @modelQ OR cl.requested_model LIKE @modelQ)");
     params.modelQ = `%${filter.model}%`;
   }
   if (filter.provider) {
-    conditions.push("provider LIKE @providerQ");
+    conditions.push("cl.provider LIKE @providerQ");
     params.providerQ = `%${filter.provider}%`;
   }
   if (filter.account) {
-    conditions.push("account LIKE @accountQ");
+    conditions.push("cl.account LIKE @accountQ");
     params.accountQ = `%${filter.account}%`;
   }
   if (filter.apiKey) {
-    conditions.push("(api_key_name LIKE @apiKeyQ OR api_key_id LIKE @apiKeyQ)");
+    conditions.push("(cl.api_key_name LIKE @apiKeyQ OR cl.api_key_id LIKE @apiKeyQ)");
     params.apiKeyQ = `%${filter.apiKey}%`;
   }
   if (filter.combo) {
-    conditions.push("combo_name IS NOT NULL");
+    conditions.push("cl.combo_name IS NOT NULL");
   }
   if (filter.search) {
     conditions.push(`(
-      model LIKE @searchQ OR path LIKE @searchQ OR account LIKE @searchQ OR
-      requested_model LIKE @searchQ OR provider LIKE @searchQ OR
-      api_key_name LIKE @searchQ OR api_key_id LIKE @searchQ OR
-      combo_name LIKE @searchQ OR CAST(status AS TEXT) LIKE @searchQ
-      OR combo_step_id LIKE @searchQ OR combo_execution_key LIKE @searchQ
+      cl.model LIKE @searchQ OR cl.path LIKE @searchQ OR cl.account LIKE @searchQ OR
+      cl.requested_model LIKE @searchQ OR cl.provider LIKE @searchQ OR
+      cl.api_key_name LIKE @searchQ OR cl.api_key_id LIKE @searchQ OR
+      cl.combo_name LIKE @searchQ OR CAST(cl.status AS TEXT) LIKE @searchQ
+      OR cl.combo_step_id LIKE @searchQ OR cl.combo_execution_key LIKE @searchQ
     )`);
     params.searchQ = `%${filter.search}%`;
   }
@@ -566,12 +612,14 @@ export async function getCallLogs(filter: any = {}) {
   }
 
   const limit = filter.limit || 200;
-  sql += ` ORDER BY timestamp DESC LIMIT ${limit}`;
+  sql += ` ORDER BY cl.timestamp DESC LIMIT ${limit}`;
 
   const rows = db.prepare(sql).all(params);
 
   return rows.map((row) => {
     const l = asRecord(row);
+    const provider = toStringOrNull(l.provider);
+    const nodePrefix = toStringOrNull(l.provider_node_prefix);
     return {
       id: toStringOrNull(l.id),
       timestamp: toStringOrNull(l.timestamp),
@@ -579,8 +627,8 @@ export async function getCallLogs(filter: any = {}) {
       path: toStringOrNull(l.path),
       status: toNumber(l.status),
       model: toStringOrNull(l.model),
-      requestedModel: toStringOrNull(l.requested_model),
-      provider: toStringOrNull(l.provider),
+      requestedModel: applyNodePrefix(toStringOrNull(l.requested_model), provider, nodePrefix),
+      provider,
       account: toStringOrNull(l.account),
       duration: toNumber(l.duration),
       tokens: {
@@ -598,6 +646,7 @@ export async function getCallLogs(filter: any = {}) {
       comboExecutionKey: toStringOrNull(l.combo_execution_key),
       apiKeyId: toStringOrNull(l.api_key_id),
       apiKeyName: toStringOrNull(l.api_key_name),
+      cacheSource: toStringOrNull(l.cache_source) || "upstream",
       hasRequestBody: typeof l.request_body === "string" && l.request_body.length > 0,
       hasResponseBody: typeof l.response_body === "string" && l.response_body.length > 0,
       hasPipelineDetails: toNumber(l.has_pipeline_details) === 1,
@@ -619,11 +668,19 @@ function buildLegacyPipelinePayloads(id: string) {
 
 export async function getCallLogById(id: string) {
   const db = getDbInstance();
-  const row = db.prepare("SELECT * FROM call_logs WHERE id = ?").get(id);
+  const row = db
+    .prepare(
+      `SELECT cl.*,
+        (SELECT pn.prefix FROM provider_nodes pn WHERE pn.id = cl.provider LIMIT 1) AS provider_node_prefix
+       FROM call_logs cl WHERE cl.id = ?`
+    )
+    .get(id);
   if (!row) return null;
 
   const entryRow = asRecord(row);
   const artifactRelPath = toStringOrNull(entryRow.artifact_relpath);
+  const entryProvider = toStringOrNull(entryRow.provider);
+  const entryNodePrefix = toStringOrNull(entryRow.provider_node_prefix);
   const entry = {
     id: toStringOrNull(entryRow.id),
     timestamp: toStringOrNull(entryRow.timestamp),
@@ -631,8 +688,12 @@ export async function getCallLogById(id: string) {
     path: toStringOrNull(entryRow.path),
     status: toNumber(entryRow.status),
     model: toStringOrNull(entryRow.model),
-    requestedModel: toStringOrNull(entryRow.requested_model),
-    provider: toStringOrNull(entryRow.provider),
+    requestedModel: applyNodePrefix(
+      toStringOrNull(entryRow.requested_model),
+      entryProvider,
+      entryNodePrefix
+    ),
+    provider: entryProvider,
     account: toStringOrNull(entryRow.account),
     connectionId: toStringOrNull(entryRow.connection_id),
     duration: toNumber(entryRow.duration),
@@ -651,6 +712,7 @@ export async function getCallLogById(id: string) {
     comboName: toStringOrNull(entryRow.combo_name),
     comboStepId: toStringOrNull(entryRow.combo_step_id),
     comboExecutionKey: toStringOrNull(entryRow.combo_execution_key),
+    cacheSource: toStringOrNull(entryRow.cache_source) || "upstream",
     requestBody: parseStoredPayload(entryRow.request_body),
     responseBody: parseStoredPayload(entryRow.response_body),
     error: toStringOrNull(entryRow.error),

--- a/src/shared/components/RequestLoggerDetail.tsx
+++ b/src/shared/components/RequestLoggerDetail.tsx
@@ -119,6 +119,14 @@ export default function RequestLoggerDetail({ log, detail, loading, onClose, onC
 
   const formatTokenValue = (value) => (value != null ? value.toLocaleString() : "N/A");
 
+  const cacheSource = detail?.cacheSource || log.cacheSource || "upstream";
+  const cacheSourceLabel =
+    cacheSource === "semantic" ? "Semantic (OmniRoute)" : "Upstream (Provider)";
+  const cacheSourceClassName =
+    cacheSource === "semantic"
+      ? "bg-emerald-500/20 text-emerald-700 dark:text-emerald-300 border-emerald-500/30"
+      : "bg-sky-500/20 text-sky-700 dark:text-sky-300 border-sky-500/30";
+
   return (
     <div
       className="fixed inset-0 z-50 flex items-start justify-center pt-[5vh]"
@@ -237,6 +245,16 @@ export default function RequestLoggerDetail({ log, detail, loading, onClose, onC
                 style={{ backgroundColor: protocol.bg, color: protocol.text }}
               >
                 {protocol.label}
+              </span>
+            </div>
+            <div>
+              <div className="text-[10px] text-text-muted uppercase tracking-wider mb-1">
+                Cache Source
+              </div>
+              <span
+                className={`inline-block px-2.5 py-1 rounded text-[10px] font-bold border ${cacheSourceClassName}`}
+              >
+                {cacheSourceLabel}
               </span>
             </div>
             <div>

--- a/src/shared/components/RequestLoggerV2.tsx
+++ b/src/shared/components/RequestLoggerV2.tsx
@@ -28,6 +28,7 @@ const STATUS_FILTERS = [
 // Column definitions for visibility toggles
 const COLUMNS = [
   { key: "status", label: "Status" },
+  { key: "cacheSource", label: "Cache Source" },
   { key: "model", label: "Model" },
   { key: "requestedModel", label: "Requested" },
   { key: "provider", label: "Provider" },
@@ -91,6 +92,23 @@ function formatTps(tps: number): string {
   if (tps <= 0) return "—";
   if (tps >= 100) return Math.round(tps).toLocaleString();
   return tps.toFixed(1);
+}
+
+function getCacheSourceMeta(cacheSource: unknown) {
+  if (cacheSource === "semantic") {
+    return {
+      label: "SEM",
+      title: "Semantic cache hit (served by OmniRoute)",
+      className:
+        "bg-emerald-500/15 text-emerald-700 dark:text-emerald-300 border border-emerald-500/30",
+    };
+  }
+
+  return {
+    label: "UP",
+    title: "Upstream provider response",
+    className: "bg-sky-500/15 text-sky-700 dark:text-sky-300 border border-sky-500/30",
+  };
 }
 
 export default function RequestLoggerV2() {
@@ -585,6 +603,11 @@ export default function RequestLoggerV2() {
                       Status
                     </th>
                   )}
+                  {visibleColumns.cacheSource && (
+                    <th className="px-3 py-2.5 font-semibold text-text-muted uppercase tracking-wider text-[10px]">
+                      Cache Source
+                    </th>
+                  )}
                   {visibleColumns.model && (
                     <th className="px-3 py-2.5 font-semibold text-text-muted uppercase tracking-wider text-[10px]">
                       Model
@@ -660,6 +683,7 @@ export default function RequestLoggerV2() {
                   };
                   const providerLabel = compatLabel || providerColor.label;
                   const isError = log.status >= 400;
+                  const cacheSourceMeta = getCacheSourceMeta(log.cacheSource);
 
                   return (
                     <tr
@@ -674,6 +698,16 @@ export default function RequestLoggerV2() {
                             style={{ backgroundColor: statusStyle.bg, color: statusStyle.text }}
                           >
                             {log.status || "..."}
+                          </span>
+                        </td>
+                      )}
+                      {visibleColumns.cacheSource && (
+                        <td className="px-3 py-2">
+                          <span
+                            className={`inline-block px-2 py-0.5 rounded text-[9px] font-bold uppercase ${cacheSourceMeta.className}`}
+                            title={cacheSourceMeta.title}
+                          >
+                            {cacheSourceMeta.label === "SEM" ? "Semantic" : "Upstream"}
                           </span>
                         </td>
                       )}

--- a/tests/integration/chat-pipeline.test.ts
+++ b/tests/integration/chat-pipeline.test.ts
@@ -244,6 +244,52 @@ function buildOpenAIStreamResponse(text = "streamed from openai") {
   );
 }
 
+function buildOpenAIResponsesSSE({
+  text = "responses streamed from codex",
+  model = "gpt-5.1-codex",
+  usage = null,
+} = {}) {
+  return new Response(
+    [
+      `data: ${JSON.stringify({
+        type: "response.completed",
+        response: {
+          id: "resp_stream",
+          object: "response",
+          status: "completed",
+          model,
+          output: [
+            {
+              id: "msg_stream",
+              type: "message",
+              role: "assistant",
+              content: [{ type: "output_text", text, annotations: [] }],
+            },
+          ],
+          usage: usage || {
+            input_tokens: 120,
+            output_tokens: 30,
+            prompt_tokens_details: {
+              cached_tokens: 40,
+            },
+            cache_creation_input_tokens: 11,
+            completion_tokens_details: {
+              reasoning_tokens: 13,
+            },
+          },
+        },
+      })}`,
+      "",
+      "data: [DONE]",
+      "",
+    ].join("\n"),
+    {
+      status: 200,
+      headers: { "Content-Type": "text/event-stream" },
+    }
+  );
+}
+
 async function resetStorage() {
   globalThis.fetch = originalFetch;
   process.env.REQUIRE_API_KEY = "false";
@@ -375,6 +421,12 @@ async function getLatestCallLog() {
   return callLogsDb.getCallLogById(rows[0].id);
 }
 
+async function getResponsesCallLogCount() {
+  const rows = await callLogsDb.getCallLogs({ limit: 200 });
+  if (!Array.isArray(rows) || rows.length === 0) return 0;
+  return rows.filter((row) => row.path === "/v1/responses").length;
+}
+
 test.beforeEach(async () => {
   BaseExecutor.RETRY_CONFIG.delayMs = 0;
   await resetStorage();
@@ -428,6 +480,131 @@ test("chat pipeline handles OpenAI passthrough with valid API key auth", async (
   assert.equal(fetchCalls[0].headers.Authorization, "Bearer sk-openai-primary");
   assert.equal(fetchCalls[0].body.messages[0].content, "Hello OpenAI");
   assert.equal(json.choices[0].message.content, "OpenAI passthrough");
+});
+
+test("chat pipeline persists Codex responses cache and reasoning tokens to call logs", async () => {
+  await seedConnection("codex", { apiKey: "sk-codex-primary" });
+  const fetchCalls = [];
+
+  globalThis.fetch = async (url, init = {}) => {
+    fetchCalls.push({
+      url: String(url),
+      headers: toPlainHeaders(init.headers),
+      body: init.body ? JSON.parse(String(init.body)) : null,
+    });
+    return buildOpenAIResponsesSSE();
+  };
+
+  const response = await handleChat(
+    buildRequest({
+      url: "http://localhost/v1/responses",
+      body: {
+        model: "codex/gpt-5.1-codex",
+        stream: false,
+        input: "Persist cache + reasoning usage",
+      },
+    })
+  );
+
+  const json = await response.json();
+  const callLog = await waitFor(() => getLatestCallLog());
+
+  assert.equal(response.status, 200);
+  assert.equal(fetchCalls.length, 1);
+  assert.match(fetchCalls[0].url, /\/responses$/);
+  assert.equal(fetchCalls[0].headers.Authorization, "Bearer sk-codex-primary");
+  assert.equal(json.object, "response");
+
+  assert.ok(callLog, "expected a call log row to be created");
+  assert.equal(callLog.provider, "codex");
+  assert.equal(callLog.path, "/v1/responses");
+  assert.equal(callLog.tokens.cacheRead, 40);
+  assert.equal(callLog.tokens.cacheWrite, 11);
+  assert.equal(callLog.tokens.reasoning, 13);
+});
+
+test("chat pipeline serves repeated /v1/responses requests as MISS then HIT and logs only once", async () => {
+  await seedConnection("codex", { apiKey: "sk-codex-cache-seq" });
+  const fetchCalls = [];
+
+  globalThis.fetch = async (url, init = {}) => {
+    fetchCalls.push({
+      url: String(url),
+      headers: toPlainHeaders(init.headers),
+      body: init.body ? JSON.parse(String(init.body)) : null,
+    });
+    return buildOpenAIResponsesSSE({
+      text: "cached semantic response",
+      usage: {
+        input_tokens: 21,
+        output_tokens: 7,
+        prompt_tokens_details: {
+          cached_tokens: 5,
+        },
+        cache_creation_input_tokens: 2,
+        completion_tokens_details: {
+          reasoning_tokens: 3,
+        },
+      },
+    });
+  };
+
+  const uniquePrompt = `semantic-cache-seq-${Math.random().toString(16).slice(2)}`;
+  const requestBody = {
+    model: "codex/gpt-5.3-codex",
+    stream: false,
+    input: [{ role: "user", content: [{ type: "input_text", text: uniquePrompt }] }],
+  };
+
+  const beforeCount = await getResponsesCallLogCount();
+
+  const firstResponse = await handleChat(
+    buildRequest({
+      url: "http://localhost/v1/responses",
+      body: requestBody,
+    })
+  );
+
+  const secondResponse = await handleChat(
+    buildRequest({
+      url: "http://localhost/v1/responses",
+      body: requestBody,
+    })
+  );
+
+  const thirdResponse = await handleChat(
+    buildRequest({
+      url: "http://localhost/v1/responses",
+      body: requestBody,
+    })
+  );
+
+  await firstResponse.json();
+  await secondResponse.json();
+  await thirdResponse.json();
+
+  assert.equal(firstResponse.status, 200);
+  assert.equal(secondResponse.status, 200);
+  assert.equal(thirdResponse.status, 200);
+
+  assert.equal(firstResponse.headers.get("X-OmniRoute-Cache"), "MISS");
+  assert.equal(secondResponse.headers.get("X-OmniRoute-Cache"), "HIT");
+  assert.equal(thirdResponse.headers.get("X-OmniRoute-Cache"), "HIT");
+
+  assert.equal(fetchCalls.length, 1, "expected upstream to be called only once for MISS");
+  assert.match(fetchCalls[0].url, /\/responses$/);
+
+  const afterCount = await waitFor(async () => {
+    const count = await getResponsesCallLogCount();
+    return count === beforeCount + 1 ? count : null;
+  }, 2000);
+
+  assert.equal(afterCount, beforeCount + 1, "expected exactly one new /v1/responses call log");
+
+  const callLog = await waitFor(() => getLatestCallLog());
+  assert.ok(callLog, "expected a call log row to exist");
+  assert.equal(callLog.path, "/v1/responses");
+  assert.equal(callLog.status, 200);
 });
 
 test("chat pipeline translates OpenAI requests to Claude and returns OpenAI-shaped responses", async () => {

--- a/tests/unit/call-logs-requested-model.test.ts
+++ b/tests/unit/call-logs-requested-model.test.ts
@@ -9,6 +9,7 @@ process.env.DATA_DIR = TEST_DATA_DIR;
 
 const core = await import("../../src/lib/db/core.ts");
 const callLogs = await import("../../src/lib/usage/callLogs.ts");
+const providers = await import("../../src/lib/db/providers.ts");
 
 async function resetStorage() {
   core.resetDbInstance();
@@ -49,4 +50,107 @@ test("call logs persist requestedModel and allow filtering by requested model", 
 
   const detail = await callLogs.getCallLogById(all[0].id);
   assert.equal(detail?.requestedModel, "openai/gpt-5.2-codex");
+});
+
+test("requestedModel uses provider node prefix for openai-compatible provider at save time", async () => {
+  const providerId = "openai-compatible-chat-07dea2c6-269e-45f7-b731-b310bc016eb8";
+
+  await providers.createProviderNode({
+    id: providerId,
+    type: "openai-compatible",
+    name: "OrcAI",
+    prefix: "orc",
+    apiType: "chat",
+    baseUrl: "https://api.orc.ai/v1",
+  });
+
+  await callLogs.saveCallLog({
+    method: "POST",
+    path: "/v1/chat/completions",
+    status: 200,
+    model: "gpt-5.4",
+    requestedModel: `${providerId}/gpt-5.4`,
+    provider: providerId,
+    duration: 200,
+  });
+
+  const all = await callLogs.getCallLogs({ limit: 10 });
+  assert.equal(all.length, 1);
+  assert.equal(all[0].requestedModel, "orc/gpt-5.4");
+
+  const detail = await callLogs.getCallLogById(all[0].id);
+  assert.equal(detail?.requestedModel, "orc/gpt-5.4");
+});
+
+test("requestedModel read-time transformation for old logs stored with UUID prefix", async () => {
+  const providerId = "openai-compatible-chat-aabbccdd-1111-2222-3333-444455556666";
+
+  await providers.createProviderNode({
+    id: providerId,
+    type: "openai-compatible",
+    name: "MyAI",
+    prefix: "myai",
+    apiType: "chat",
+    baseUrl: "https://api.my.ai/v1",
+  });
+
+  const db = core.getDbInstance();
+  const logId = `old-log-${Date.now()}`;
+  db.prepare(
+    `INSERT INTO call_logs (id, timestamp, method, path, status, model, requested_model, provider,
+      account, duration, tokens_in, tokens_out, cache_source)
+     VALUES (?, ?, 'POST', '/v1/chat/completions', 200, 'gpt-4', ?, ?, '-', 100, 10, 20, 'upstream')`
+  ).run(logId, new Date().toISOString(), `${providerId}/gpt-4`, providerId);
+
+  const all = await callLogs.getCallLogs({ limit: 10 });
+  assert.equal(all.length, 1);
+  assert.equal(all[0].requestedModel, "myai/gpt-4");
+
+  const detail = await callLogs.getCallLogById(logId);
+  assert.equal(detail?.requestedModel, "myai/gpt-4");
+});
+
+test("requestedModel unchanged for openai-compatible provider without registered node", async () => {
+  const providerId = "openai-compatible-chat-99999999-9999-9999-9999-999999999999";
+
+  await callLogs.saveCallLog({
+    method: "POST",
+    path: "/v1/chat/completions",
+    status: 200,
+    model: "gpt-3",
+    requestedModel: `${providerId}/gpt-3`,
+    provider: providerId,
+    duration: 50,
+  });
+
+  const all = await callLogs.getCallLogs({ limit: 10 });
+  assert.equal(all.length, 1);
+  assert.equal(all[0].requestedModel, `${providerId}/gpt-3`);
+});
+
+test("requestedModel for anthropic-compatible provider with prefix", async () => {
+  const providerId = "anthropic-compatible-aaaabbbb-cccc-dddd-eeee-ffffaaaabbbb";
+
+  await providers.createProviderNode({
+    id: providerId,
+    type: "anthropic-compatible",
+    name: "MyAnthropicClone",
+    prefix: "mac",
+    apiType: "chat",
+    baseUrl: "https://api.mac.ai/v1",
+  });
+
+  await callLogs.saveCallLog({
+    method: "POST",
+    path: "/v1/chat/completions",
+    status: 200,
+    model: "claude-opus-4",
+    requestedModel: `${providerId}/claude-opus-4`,
+    provider: providerId,
+    duration: 300,
+  });
+
+  const all = await callLogs.getCallLogs({ limit: 10 });
+  assert.equal(all.length, 1);
+  assert.equal(all[0].requestedModel, "mac/claude-opus-4");
 });

--- a/tests/unit/chatcore-translation-paths.test.ts
+++ b/tests/unit/chatcore-translation-paths.test.ts
@@ -13,7 +13,8 @@ const settingsDb = await import("../../src/lib/db/settings.ts");
 const upstreamProxyDb = await import("../../src/lib/db/upstreamProxy.ts");
 const { invalidateCacheControlSettingsCache } =
   await import("../../src/lib/cacheControlSettings.ts");
-const { clearCache } = await import("../../src/lib/semanticCache.ts");
+const { clearCache, getCachedResponse, generateSignature } =
+  await import("../../src/lib/semanticCache.ts");
 const { clearIdempotency } = await import("../../src/lib/idempotencyLayer.ts");
 const { clearInflight } = await import("../../open-sse/services/requestDedup.ts");
 const { saveModelsDevCapabilities, clearModelsDevCapabilities } =
@@ -1114,6 +1115,18 @@ test("chatCore returns a semantic cache HIT for repeated deterministic requests"
 
   const payload = await second.result.response.json();
   assert.equal(payload.choices[0].message.content, "cached-once");
+
+  await waitForAsyncSideEffects();
+  const semanticLog = await waitFor(async () => {
+    const rows = await getCallLogs({ limit: 10 });
+    const hit = rows.find((row) => row.cacheSource === "semantic");
+    if (!hit) return null;
+    return await getCallLogById(hit.id);
+  });
+  assert.ok(semanticLog, "expected semantic cache HIT to be persisted in call logs");
+  assert.equal(semanticLog.cacheSource, "semantic");
+  assert.equal(semanticLog.path, "/v1/chat/completions");
+  assert.equal(semanticLog.status, 200);
 });
 
 test("chatCore skips semantic cache when disabled in settings", async () => {
@@ -1287,6 +1300,67 @@ test("chatCore retries Qwen quota 429 responses before succeeding", async () => 
   assert.equal(result.success, true);
   assert.equal(calls.length, 2);
   assert.equal(payload.choices[0].message.content, "qwen recovered");
+});
+
+test("chatCore injects fallback user for Qwen OAuth requests without user", async () => {
+  const { call, result } = await invokeChatCore({
+    provider: "qwen",
+    model: "qwen3-coder",
+    credentials: {
+      accessToken: "qwen-oauth-token",
+      providerSpecificData: { resourceUrl: "portal.qwen.ai" },
+    },
+    body: {
+      model: "qwen3-coder",
+      stream: false,
+      messages: [{ role: "user", content: "check qwen user fallback" }],
+    },
+    responseFormat: "openai",
+  });
+
+  assert.equal(result.success, true);
+  assert.equal(call.body.user, "omniroute-qwen-oauth");
+});
+
+test("chatCore keeps explicit user for Qwen OAuth requests", async () => {
+  const { call, result } = await invokeChatCore({
+    provider: "qwen",
+    model: "qwen3-coder",
+    credentials: {
+      accessToken: "qwen-oauth-token",
+      providerSpecificData: { resourceUrl: "portal.qwen.ai" },
+    },
+    body: {
+      model: "qwen3-coder",
+      stream: false,
+      user: "explicit-user",
+      messages: [{ role: "user", content: "keep my user" }],
+    },
+    responseFormat: "openai",
+  });
+
+  assert.equal(result.success, true);
+  assert.equal(call.body.user, "explicit-user");
+});
+
+test("chatCore does not inject fallback user for Qwen API key requests", async () => {
+  const { call, result } = await invokeChatCore({
+    provider: "qwen",
+    model: "qwen3-coder",
+    credentials: {
+      apiKey: "qwen-api-key",
+      providerSpecificData: { resourceUrl: "dashscope.aliyuncs.com/compatible-mode/v1" },
+    },
+    body: {
+      model: "qwen3-coder",
+      stream: false,
+      messages: [{ role: "user", content: "api key mode should stay untouched" }],
+    },
+    responseFormat: "openai",
+  });
+
+  assert.equal(result.success, true);
+  assert.equal("user" in call.body, false);
 });
 
 test("chatCore persists Codex quota headers and scope cooldown on 429 responses", async () => {
@@ -1705,4 +1779,185 @@ test("chatCore maps upstream aborts to request-aborted errors", async () => {
   assert.equal(result.success, false);
   assert.equal(result.status, 499);
   assert.equal(result.error, "Request aborted");
+});
+
+// ── Streaming semantic cache tests ──────────────────────────────────────────
+
+test("chatCore caches streaming response and serves cache HIT on repeat", async () => {
+  let upstreamHits = 0;
+  const sharedBody = {
+    model: "gpt-4o-mini",
+    stream: true,
+    temperature: 0,
+    messages: [{ role: "user", content: "stream-cache-test" }],
+  };
+
+  const first = await invokeChatCore({
+    provider: "openai",
+    model: "gpt-4o-mini",
+    accept: "text/event-stream",
+    body: sharedBody,
+    responseFormat: "openai",
+    responseFactory() {
+      upstreamHits += 1;
+      return buildOpenAIResponse(true, "streamed-once");
+    },
+  });
+
+  assert.equal(first.result.success, true);
+  // Consume the stream to trigger onStreamComplete and cache write
+  await first.result.response.text();
+  await waitForAsyncSideEffects();
+
+  // Second request with same body should get cache HIT (JSON, not SSE)
+  const second = await invokeChatCore({
+    provider: "openai",
+    model: "gpt-4o-mini",
+    accept: "text/event-stream",
+    body: sharedBody,
+    responseFormat: "openai",
+    responseFactory() {
+      upstreamHits += 1;
+      return buildOpenAIResponse(true, "should-not-stream");
+    },
+  });
+
+  assert.equal(upstreamHits, 1, "upstream should be called only once");
+  assert.equal(second.calls.length, 0, "second request should not reach upstream");
+  assert.equal(second.result.response.headers.get("X-OmniRoute-Cache"), "HIT");
+
+  const payload = await second.result.response.json();
+  assert.ok(payload.choices, "cached response should have choices");
+  assert.equal(payload.choices[0].message.content, "streamed-once");
+});
+
+test("chatCore does not cache streaming response when temperature > 0", async () => {
+  let upstreamHits = 0;
+  const sharedBody = {
+    model: "gpt-4o-mini",
+    stream: true,
+    temperature: 0.7,
+    messages: [{ role: "user", content: "non-deterministic-stream" }],
+  };
+
+  const first = await invokeChatCore({
+    provider: "openai",
+    model: "gpt-4o-mini",
+    accept: "text/event-stream",
+    body: sharedBody,
+    responseFormat: "openai",
+    responseFactory() {
+      upstreamHits += 1;
+      return buildOpenAIResponse(true, `hot-${upstreamHits}`);
+    },
+  });
+
+  await first.result.response.text();
+  await waitForAsyncSideEffects();
+
+  const second = await invokeChatCore({
+    provider: "openai",
+    model: "gpt-4o-mini",
+    accept: "text/event-stream",
+    body: sharedBody,
+    responseFormat: "openai",
+    responseFactory() {
+      upstreamHits += 1;
+      return buildOpenAIResponse(true, `hot-${upstreamHits}`);
+    },
+  });
+
+  await second.result.response.text();
+  assert.equal(upstreamHits, 2, "both requests should hit upstream");
+  assert.equal(second.calls.length, 1, "second request should reach upstream");
+});
+
+test("chatCore skips streaming cache when X-OmniRoute-No-Cache header is set", async () => {
+  let upstreamHits = 0;
+  const sharedBody = {
+    model: "gpt-4o-mini",
+    stream: true,
+    temperature: 0,
+    messages: [{ role: "user", content: "no-cache-stream" }],
+  };
+
+  const first = await invokeChatCore({
+    provider: "openai",
+    model: "gpt-4o-mini",
+    accept: "text/event-stream",
+    requestHeaders: { "x-omniroute-no-cache": "true" },
+    body: sharedBody,
+    responseFormat: "openai",
+    responseFactory() {
+      upstreamHits += 1;
+      return buildOpenAIResponse(true, "bypass-cache");
+    },
+  });
+
+  await first.result.response.text();
+  await waitForAsyncSideEffects();
+
+  // Verify nothing was cached
+  const sig = generateSignature("gpt-4o-mini", sharedBody.messages, 0, 1);
+  const cached = getCachedResponse(sig);
+  assert.equal(cached, null, "response should not be cached when no-cache header is set");
+
+  const second = await invokeChatCore({
+    provider: "openai",
+    model: "gpt-4o-mini",
+    accept: "text/event-stream",
+    requestHeaders: { "x-omniroute-no-cache": "true" },
+    body: sharedBody,
+    responseFormat: "openai",
+    responseFactory() {
+      upstreamHits += 1;
+      return buildOpenAIResponse(true, "bypass-again");
+    },
+  });
+
+  await second.result.response.text();
+  assert.equal(upstreamHits, 2, "both requests should hit upstream with no-cache");
+});
+
+test("chatCore returns cache HIT as JSON even when client requests SSE", async () => {
+  const sharedBody = {
+    model: "gpt-4o-mini",
+    stream: false,
+    temperature: 0,
+    messages: [{ role: "user", content: "json-then-sse-cache" }],
+  };
+
+  // First: non-streaming request populates cache
+  await invokeChatCore({
+    provider: "openai",
+    model: "gpt-4o-mini",
+    body: sharedBody,
+    responseFormat: "openai",
+    responseFactory() {
+      return buildOpenAIResponse(false, "cached-json");
+    },
+  });
+
+  // Second: streaming request should still get cache HIT as JSON
+  const second = await invokeChatCore({
+    provider: "openai",
+    model: "gpt-4o-mini",
+    accept: "text/event-stream",
+    body: { ...sharedBody, stream: true },
+    responseFormat: "openai",
+    responseFactory() {
+      return buildOpenAIResponse(true, "should-not-stream");
+    },
+  });
+
+  assert.equal(second.calls.length, 0, "cached response should prevent upstream call");
+  assert.equal(second.result.response.headers.get("X-OmniRoute-Cache"), "HIT");
+  assert.equal(
+    second.result.response.headers.get("Content-Type"),
+    "application/json",
+    "cache HIT should return JSON regardless of stream flag"
+  );
+
+  const payload = await second.result.response.json();
+  assert.equal(payload.choices[0].message.content, "cached-json");
 });

--- a/tests/unit/cursor-version-detector.test.mjs
+++ b/tests/unit/cursor-version-detector.test.mjs
@@ -1,0 +1,122 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const FALLBACK_VERSION = "3.1.15";
+const Database = (await import("better-sqlite3")).default;
+
+const { getCursorVersion, resetCursorVersionCache } =
+  await import("../../open-sse/utils/cursorVersionDetector.ts");
+
+function createStateDb(dir, version) {
+  const dbPath = path.join(dir, "state.vscdb");
+  const db = new Database(dbPath);
+  db.exec("CREATE TABLE itemTable (key TEXT PRIMARY KEY, value TEXT)");
+  if (version) {
+    db.prepare("INSERT INTO itemTable (key, value) VALUES (?, ?)").run(
+      "cursorupdate.lastUpdatedAndShown.version",
+      version
+    );
+  }
+  db.close();
+  return dbPath;
+}
+
+test("getCursorVersion reads version from state.vscdb", () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "cursor-ver-"));
+  const dbPath = createStateDb(tmpDir, "99.0.1");
+  const origEnv = process.env.CURSOR_STATE_DB_PATH;
+  process.env.CURSOR_STATE_DB_PATH = dbPath;
+
+  try {
+    resetCursorVersionCache();
+    assert.equal(getCursorVersion(), "99.0.1");
+  } finally {
+    if (origEnv === undefined) delete process.env.CURSOR_STATE_DB_PATH;
+    else process.env.CURSOR_STATE_DB_PATH = origEnv;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("getCursorVersion returns fallback when DB does not exist", () => {
+  const origEnv = process.env.CURSOR_STATE_DB_PATH;
+  process.env.CURSOR_STATE_DB_PATH = "/nonexistent/path/state.vscdb";
+
+  try {
+    resetCursorVersionCache();
+    assert.equal(getCursorVersion(), FALLBACK_VERSION);
+  } finally {
+    if (origEnv === undefined) delete process.env.CURSOR_STATE_DB_PATH;
+    else process.env.CURSOR_STATE_DB_PATH = origEnv;
+  }
+});
+
+test("getCursorVersion returns fallback when DB has no version key", () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "cursor-ver-nokey-"));
+  const dbPath = createStateDb(tmpDir, null);
+  const origEnv = process.env.CURSOR_STATE_DB_PATH;
+  process.env.CURSOR_STATE_DB_PATH = dbPath;
+
+  try {
+    resetCursorVersionCache();
+    assert.equal(getCursorVersion(), FALLBACK_VERSION);
+  } finally {
+    if (origEnv === undefined) delete process.env.CURSOR_STATE_DB_PATH;
+    else process.env.CURSOR_STATE_DB_PATH = origEnv;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("getCursorVersion caches the result across calls", () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "cursor-ver-cache-"));
+  const dbPath = createStateDb(tmpDir, "10.0.0");
+  const origEnv = process.env.CURSOR_STATE_DB_PATH;
+  process.env.CURSOR_STATE_DB_PATH = dbPath;
+
+  try {
+    resetCursorVersionCache();
+    assert.equal(getCursorVersion(), "10.0.0");
+
+    // Update the DB — cache should still return old value
+    const db = new Database(dbPath);
+    db.prepare("UPDATE itemTable SET value = ? WHERE key = ?").run(
+      "20.0.0",
+      "cursorupdate.lastUpdatedAndShown.version"
+    );
+    db.close();
+
+    assert.equal(getCursorVersion(), "10.0.0", "cached value should be returned");
+  } finally {
+    if (origEnv === undefined) delete process.env.CURSOR_STATE_DB_PATH;
+    else process.env.CURSOR_STATE_DB_PATH = origEnv;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("resetCursorVersionCache forces re-read from DB", () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "cursor-ver-reset-"));
+  const dbPath = createStateDb(tmpDir, "5.0.0");
+  const origEnv = process.env.CURSOR_STATE_DB_PATH;
+  process.env.CURSOR_STATE_DB_PATH = dbPath;
+
+  try {
+    resetCursorVersionCache();
+    assert.equal(getCursorVersion(), "5.0.0");
+
+    const db = new Database(dbPath);
+    db.prepare("UPDATE itemTable SET value = ? WHERE key = ?").run(
+      "6.0.0",
+      "cursorupdate.lastUpdatedAndShown.version"
+    );
+    db.close();
+
+    resetCursorVersionCache();
+    assert.equal(getCursorVersion(), "6.0.0", "should re-read after cache reset");
+  } finally {
+    if (origEnv === undefined) delete process.env.CURSOR_STATE_DB_PATH;
+    else process.env.CURSOR_STATE_DB_PATH = origEnv;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});

--- a/tests/unit/executor-cursor-extended.test.ts
+++ b/tests/unit/executor-cursor-extended.test.ts
@@ -14,6 +14,10 @@ import {
   generateHashed64Hex,
   generateSessionId,
 } from "../../open-sse/utils/cursorChecksum.ts";
+import {
+  getCursorVersion,
+  resetCursorVersionCache,
+} from "../../open-sse/utils/cursorVersionDetector.ts";
 
 const LEN = 2;
 const VARINT = 0;
@@ -89,6 +93,10 @@ test("CursorExecutor.buildUrl uses the configured Cursor endpoint", () => {
 test("CursorExecutor.buildHeaders strips token prefixes and derives checksum/session headers", () => {
   const executor = new CursorExecutor();
   const originalDateNow = Date.now;
+  const originalDbPath = process.env.CURSOR_STATE_DB_PATH;
+  // Force fallback by pointing to a non-existent DB path
+  process.env.CURSOR_STATE_DB_PATH = "/nonexistent/cursor/state.vscdb";
+  resetCursorVersionCache();
   Date.now = () => 1_700_000_000_000;
 
   try {
@@ -97,30 +105,52 @@ test("CursorExecutor.buildHeaders strips token prefixes and derives checksum/ses
       providerSpecificData: { machineId: "machine-1", ghostMode: false },
     });
 
+    const expectedVersion = getCursorVersion();
+
     assert.equal(headers.authorization, "Bearer real-token");
     assert.equal(headers["x-client-key"], generateHashed64Hex("real-token"));
     assert.equal(headers["x-session-id"], generateSessionId("real-token"));
     assert.equal(headers["x-cursor-checksum"], generateCursorChecksum("machine-1"));
-    assert.equal(headers["x-cursor-client-version"], "3.1.0");
-    assert.equal(headers["x-cursor-user-agent"], "Cursor/3.1.0");
-    assert.equal(headers["user-agent"], "Cursor/3.1.0");
+    assert.equal(headers["x-cursor-client-version"], expectedVersion);
+    assert.equal(headers["x-cursor-user-agent"], `Cursor/${expectedVersion}`);
+    assert.equal(headers["user-agent"], `Cursor/${expectedVersion}`);
     assert.equal(headers["x-ghost-mode"], "false");
     assert.equal(headers["connect-protocol-version"], "1");
     assert.match(headers["x-amzn-trace-id"], /^Root=/);
     assert.ok(headers["x-request-id"]);
   } finally {
     Date.now = originalDateNow;
+    if (originalDbPath === undefined) {
+      delete process.env.CURSOR_STATE_DB_PATH;
+    } else {
+      process.env.CURSOR_STATE_DB_PATH = originalDbPath;
+    }
+    resetCursorVersionCache();
   }
 });
 
 test("buildCursorHeaders utility stays aligned with Cursor Composer 2 versioned headers", () => {
-  const headers = buildCursorHeaders("prefix::real-token", "machine-1", false);
+  const originalDbPath = process.env.CURSOR_STATE_DB_PATH;
+  process.env.CURSOR_STATE_DB_PATH = "/nonexistent/cursor/state.vscdb";
+  resetCursorVersionCache();
 
-  assert.equal(headers.Authorization, "Bearer real-token");
-  assert.equal(headers["x-cursor-client-version"], "3.1.0");
-  assert.equal(headers["x-cursor-user-agent"], "Cursor/3.1.0");
-  assert.equal(headers["User-Agent"], "Cursor/3.1.0");
-  assert.equal(headers["x-ghost-mode"], "false");
+  try {
+    const headers = buildCursorHeaders("prefix::real-token", "machine-1", false);
+    const expectedVersion = getCursorVersion();
+
+    assert.equal(headers.Authorization, "Bearer real-token");
+    assert.equal(headers["x-cursor-client-version"], expectedVersion);
+    assert.equal(headers["x-cursor-user-agent"], `Cursor/${expectedVersion}`);
+    assert.equal(headers["User-Agent"], `Cursor/${expectedVersion}`);
+    assert.equal(headers["x-ghost-mode"], "false");
+  } finally {
+    if (originalDbPath === undefined) {
+      delete process.env.CURSOR_STATE_DB_PATH;
+    } else {
+      process.env.CURSOR_STATE_DB_PATH = originalDbPath;
+    }
+    resetCursorVersionCache();
+  }
 });
 
 test("CursorExecutor.buildHeaders derives machineId when not provided", () => {

--- a/tests/unit/request-log-detail-layout.test.ts
+++ b/tests/unit/request-log-detail-layout.test.ts
@@ -23,6 +23,7 @@ test("request log detail splits token badges into input and output groups", () =
         apiKeyName: "tools",
         apiKeyId: "29d9***7e37",
         comboName: "_Latest-Discounted",
+        cacheSource: "semantic",
         tokens: {
           in: 21818,
           out: 42,
@@ -37,6 +38,7 @@ test("request log detail splits token badges into input and output groups", () =
         apiKeyId: "29d9***7e37",
         comboName: "_Latest-Discounted",
         requestedModel: "openai-compatible-sp-openai/gpt-5.4",
+        cacheSource: "semantic",
         tokens: {
           in: 21818,
           out: 42,
@@ -66,6 +68,8 @@ test("request log detail splits token badges into input and output groups", () =
   assert.equal(inputLabelIndex < outputLabelIndex, true);
   assert.equal(outputLabelIndex < modelLabelIndex, true);
   assert.equal(modelLabelIndex < requestedModelLabelIndex, true);
+  assert.notEqual(html.indexOf(">Cache Source<"), -1);
+  assert.notEqual(html.indexOf(">Semantic (OmniRoute)<"), -1);
 
   assert.match(
     html,

--- a/tests/unit/semantic-cache.test.ts
+++ b/tests/unit/semantic-cache.test.ts
@@ -51,6 +51,22 @@ describe("Semantic Cache", () => {
       const sig = generateSignature("gpt-4", [], 0, 1);
       assert.ok(sig.length > 0);
     });
+
+    it("generates different signatures for different responses input payloads", () => {
+      const input1 = [{ role: "user", content: [{ type: "input_text", text: "hello" }] }];
+      const input2 = [{ role: "user", content: [{ type: "input_text", text: "goodbye" }] }];
+      const sig1 = generateSignature("gpt-5", input1, 0, 1);
+      const sig2 = generateSignature("gpt-5", input2, 0, 1);
+      assert.notEqual(sig1, sig2);
+    });
+
+    it("normalizes missing role in responses input payloads", () => {
+      const input1 = [{ content: [{ type: "input_text", text: "hello" }] }];
+      const input2 = [{ role: "user", content: [{ type: "input_text", text: "hello" }] }];
+      const sig1 = generateSignature("gpt-5", input1, 0, 1);
+      const sig2 = generateSignature("gpt-5", input2, 0, 1);
+      assert.equal(sig1, sig2);
+    });
   });
 
   describe("isCacheable", () => {

--- a/tests/unit/usage-extractor.test.ts
+++ b/tests/unit/usage-extractor.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 const { extractUsageFromResponse } = await import("../../open-sse/handlers/usageExtractor.ts");
+const { extractUsage } = await import("../../open-sse/utils/usageTracking.ts");
 
 test("extractUsageFromResponse reads OpenAI chat completion usage", () => {
   const usage = extractUsageFromResponse(
@@ -21,6 +22,27 @@ test("extractUsageFromResponse reads OpenAI chat completion usage", () => {
     completion_tokens: 8,
     cached_tokens: 3,
     reasoning_tokens: 2,
+  });
+});
+
+test("extractUsageFromResponse reads OpenAI usage when cache/reasoning live under input/output token details", () => {
+  const usage = extractUsageFromResponse(
+    {
+      usage: {
+        prompt_tokens: 12,
+        completion_tokens: 8,
+        input_tokens_details: { cached_tokens: 4 },
+        output_tokens_details: { reasoning_tokens: 1 },
+      },
+    },
+    "codex"
+  );
+
+  assert.deepEqual(usage, {
+    prompt_tokens: 12,
+    completion_tokens: 8,
+    cached_tokens: 4,
+    reasoning_tokens: 1,
   });
 });
 
@@ -90,6 +112,53 @@ test("extractUsageFromResponse reads Responses API usage from nested response.us
   });
 });
 
+test("extractUsageFromResponse reads Responses API usage with prompt_tokens_details (OpenAI hybrid format)", () => {
+  const usage = extractUsageFromResponse(
+    {
+      usage: {
+        input_tokens: 30,
+        output_tokens: 12,
+        prompt_tokens_details: { cached_tokens: 10 },
+        completion_tokens_details: { reasoning_tokens: 5 },
+      },
+    },
+    "codex"
+  );
+
+  assert.deepEqual(usage, {
+    prompt_tokens: 30,
+    completion_tokens: 12,
+    cache_read_input_tokens: undefined,
+    cached_tokens: 10,
+    cache_creation_input_tokens: undefined,
+    reasoning_tokens: 5,
+  });
+});
+
+test("extractUsageFromResponse reads Responses API cache_read_input_tokens as cached_tokens fallback", () => {
+  const usage = extractUsageFromResponse(
+    {
+      usage: {
+        input_tokens: 50,
+        output_tokens: 20,
+        cache_read_input_tokens: 15,
+        cache_creation_input_tokens: 8,
+        reasoning_tokens: 3,
+      },
+    },
+    "github"
+  );
+
+  assert.deepEqual(usage, {
+    prompt_tokens: 50,
+    completion_tokens: 20,
+    cache_read_input_tokens: 15,
+    cached_tokens: 15,
+    cache_creation_input_tokens: 8,
+    reasoning_tokens: 3,
+  });
+});
+
 test("extractUsageFromResponse totals Claude prompt tokens with cache read and cache creation", () => {
   const usage = extractUsageFromResponse(
     {
@@ -150,4 +219,76 @@ test("extractUsageFromResponse returns null for null and undefined response bodi
 test("extractUsageFromResponse returns null for non-object response bodies", () => {
   assert.equal(extractUsageFromResponse("not-an-object", "openai"), null);
   assert.equal(extractUsageFromResponse(42, "openai"), null);
+});
+
+// ── extractUsage (streaming) tests ──
+
+test("extractUsage reads response.completed with prompt_tokens_details.cached_tokens", () => {
+  const usage = extractUsage({
+    type: "response.completed",
+    response: {
+      usage: {
+        input_tokens: 100,
+        output_tokens: 50,
+        prompt_tokens_details: { cached_tokens: 30 },
+        completion_tokens_details: { reasoning_tokens: 10 },
+      },
+    },
+  });
+
+  assert.equal(usage.prompt_tokens, 100);
+  assert.equal(usage.completion_tokens, 50);
+  assert.equal(usage.cached_tokens, 30);
+  assert.equal(usage.reasoning_tokens, 10);
+});
+
+test("extractUsage reads response.done with input_tokens_details and output_tokens_details", () => {
+  const usage = extractUsage({
+    type: "response.done",
+    response: {
+      usage: {
+        input_tokens: 80,
+        output_tokens: 40,
+        input_tokens_details: { cached_tokens: 20 },
+        output_tokens_details: { reasoning_tokens: 8 },
+      },
+    },
+  });
+
+  assert.equal(usage.cached_tokens, 20);
+  assert.equal(usage.reasoning_tokens, 8);
+});
+
+test("extractUsage reads response.completed with cache_read_input_tokens", () => {
+  const usage = extractUsage({
+    type: "response.completed",
+    response: {
+      usage: {
+        input_tokens: 60,
+        output_tokens: 25,
+        cache_read_input_tokens: 15,
+        cache_creation_input_tokens: 5,
+        reasoning_tokens: 3,
+      },
+    },
+  });
+
+  assert.equal(usage.cached_tokens, 15);
+  assert.equal(usage.cache_creation_input_tokens, 5);
+  assert.equal(usage.reasoning_tokens, 3);
+});
+
+test("extractUsage reads OpenAI streaming chunk with prompt_tokens_details", () => {
+  const usage = extractUsage({
+    choices: [{ delta: {}, finish_reason: "stop" }],
+    usage: {
+      prompt_tokens: 200,
+      completion_tokens: 100,
+      prompt_tokens_details: { cached_tokens: 50 },
+      completion_tokens_details: { reasoning_tokens: 20 },
+    },
+  });
+
+  assert.equal(usage.cached_tokens, 50);
+  assert.equal(usage.reasoning_tokens, 20);
 });


### PR DESCRIPTION
## Summary

Three independent features developed in a downstream fork, each in a separate commit for easy review.

---

### 1. `feat(cache)` — Streaming semantic cache

Extends the existing semantic cache to cover **streaming (SSE) chat completions** — previously only non-streaming responses were cached.

**How it works:**
- **Cache MISS**: stream the response normally, buffer chunks in memory, persist the complete response to cache on finish
- **Cache HIT**: replay cached chunks with realistic timing (configurable delay, default 8 ms) — downstream clients see a natural SSE stream
- Correctly hashes both Chat Completions and Responses API inputs
- Adds `CACHE_HIT` / `CACHE_MISS` / `CACHE_SKIP` events to the stream log
- Works for all providers: OpenAI, Anthropic, Gemini, Cursor, OpenAI-compatible

Also fixes two related issues bundled in the same commit:
- Correctly extracts `cache_tokens` and `reasoning_tokens` from OpenAI Responses API usage objects (were silently dropped before)
- Correctly normalizes `CACHE_MISS` / `CACHE_HIT` log events for Responses API requests

---

### 2. `feat(cursor)` — Auto-detect Cursor IDE version

Reads the installed Cursor IDE version at **runtime** from the local SQLite state database instead of a hardcoded constant.

- New `cursorVersionDetector.ts` — probes OS-specific paths, 1-hour in-memory cache, `CURSOR_STATE_DB_PATH` env-var override
- Falls back to the hardcoded constant when the DB is absent or unreadable
- Applied consistently to all three version headers: `x-cursor-client-version`, `x-cursor-user-agent`, `User-Agent`
- Eliminates checksum drift after Cursor IDE updates

---

### 3. `feat(call-logs)` — Cache source tracking and requestedModel resolution

- Adds `cache_source` to `call_logs` — tracks whether each response came from the semantic cache (`"semantic"`) or the upstream provider (`"upstream"`)
- Cache Source badge in RequestLoggerV2 table and RequestLoggerDetail panel
- Resolves `requestedModel` to a human-readable prefix for `openai-compatible-*` / `anthropic-compatible-*` providers at save time (e.g. UUID prefix → `"orc/gpt-4o"`)
- Read-time fallback for legacy log rows
- 5 new unit tests

---

## Test plan

- [ ] `npm run test:unit` — all tests pass (note: `chatcore-compression-integration` tests 1–2 fail on `release/v3.6.6` independent of this PR)
- [ ] Streaming cache MISS: send a request, observe normal SSE stream, verify entry in cache DB
- [ ] Streaming cache HIT: resend same request, observe near-instant SSE replay from cache
- [ ] Non-streaming cache works unchanged
- [ ] With Cursor installed: `x-cursor-client-version` matches installed IDE version
- [ ] Without Cursor: falls back to hardcoded constant
- [ ] Call logs table shows `SEM` badge for cached responses and `UP` for upstream