### PR TITLE
fix: return real Retry-After values from pipeline gates to release/v3.6.6

### DIFF
--- a/src/domain/modelAvailability.ts
+++ b/src/domain/modelAvailability.ts
@@ -158,6 +158,33 @@ export function isModelAvailable(provider, model) {
 }
 
 /**
+ * Get remaining cooldown information for a model, if it is currently unavailable.
+ *
+ * @param {string} provider
+ * @param {string} model
+ * @returns {{ provider: string, model: string, reason: string, remainingMs: number, unavailableSince: string } | null}
+ */
+export function getModelCooldownInfo(provider, model) {
+  const key = makeKey(provider, model);
+  const entry = unavailable.get(key);
+  if (!entry) return null;
+
+  const elapsed = Date.now() - entry.unavailableSince;
+  if (elapsed >= entry.cooldownMs) {
+    unavailable.delete(key);
+    return null;
+  }
+
+  return {
+    provider: entry.provider,
+    model: entry.model,
+    reason: entry.reason || "unknown",
+    remainingMs: entry.cooldownMs - elapsed,
+    unavailableSince: new Date(entry.unavailableSince).toISOString(),
+  };
+}
+
+/**
  * Mark a model as temporarily unavailable.
  *
  * @param {string} provider

--- a/src/shared/utils/circuitBreaker.ts
+++ b/src/shared/utils/circuitBreaker.ts
@@ -184,6 +184,15 @@ export class CircuitBreaker {
   }
 
   /**
+   * Get remaining wait time before the breaker allows execution again.
+   * @returns {number}
+   */
+  getRetryAfterMs() {
+    if (this.state === STATE.CLOSED) return 0;
+    return this._timeUntilReset();
+  }
+
+  /**
    * Force reset the circuit breaker to CLOSED state.
    */
   reset() {

--- a/src/sse/handlers/chatHelpers.ts
+++ b/src/sse/handlers/chatHelpers.ts
@@ -24,7 +24,7 @@ import {
 } from "@omniroute/open-sse/utils/proxyFetch.ts";
 import { resolveProxyForConnection } from "@/lib/localDb";
 import { getCircuitBreaker, CircuitBreakerOpenError } from "../../shared/utils/circuitBreaker";
-import { isModelAvailable } from "../../domain/modelAvailability";
+import { getModelCooldownInfo, isModelAvailable } from "../../domain/modelAvailability";
 import { logProxyEvent } from "../../lib/proxyLogger";
 import { logTranslationEvent } from "../../lib/translatorEvents";
 import { getRuntimeProviderProfile } from "@omniroute/open-sse/services/accountFallback.ts";
@@ -84,11 +84,15 @@ export async function checkPipelineGates(
   if (!modelAvailable && options.ignoreModelCooldown) {
     log.info("AVAILABILITY", `${provider}/${model} cooldown bypassed (${bypassReason})`);
   } else if (!modelAvailable) {
+    const cooldownInfo = getModelCooldownInfo(provider, model);
+    const retryAfterSec = cooldownInfo
+      ? Math.max(Math.ceil(cooldownInfo.remainingMs / 1000), 1)
+      : 1;
     log.warn("AVAILABILITY", `${provider}/${model} is in cooldown, rejecting request`);
     return unavailableResponse(
       HTTP_STATUS.SERVICE_UNAVAILABLE,
       `Model ${provider}/${model} is temporarily unavailable (cooldown)`,
-      30
+      retryAfterSec
     );
   }
 
@@ -102,11 +106,13 @@ export async function checkPipelineGates(
   if (options.ignoreCircuitBreaker && !breaker.canExecute()) {
     log.info("CIRCUIT", `Bypassing OPEN circuit breaker for ${provider} (${bypassReason})`);
   } else if (!breaker.canExecute()) {
+    const retryAfterMs = breaker.getRetryAfterMs();
+    const retryAfterSec = Math.max(Math.ceil(retryAfterMs / 1000), 1);
     log.warn("CIRCUIT", `Circuit breaker OPEN for ${provider}, rejecting request`);
     return unavailableResponse(
       HTTP_STATUS.SERVICE_UNAVAILABLE,
       `Provider ${provider} circuit breaker is open`,
-      30
+      retryAfterSec
     );
   }
 

--- a/tests/unit/chat-helpers.test.ts
+++ b/tests/unit/chat-helpers.test.ts
@@ -18,7 +18,7 @@ const {
   safeLogEvents,
   withSessionHeader,
 } = await import("../../src/sse/handlers/chatHelpers.ts");
-const { setModelUnavailable, resetAllAvailability } =
+const { getModelCooldownInfo, setModelUnavailable, resetAllAvailability } =
   await import("../../src/domain/modelAvailability.ts");
 const { getCircuitBreaker, resetAllCircuitBreakers, CircuitBreakerOpenError, STATE } =
   await import("../../src/shared/utils/circuitBreaker.ts");
@@ -93,13 +93,18 @@ test("resolveModelOrError rejects malformed model strings", async () => {
 });
 
 test("checkPipelineGates blocks models in cooldown", async () => {
-  setModelUnavailable("openai", "gpt-4o-mini", 60_000, "cooldown");
+  setModelUnavailable("openai", "gpt-4o-mini", 12_000, "cooldown");
 
   const response = await checkPipelineGates("openai", "gpt-4o-mini");
   const json = await response.json();
+  const cooldownInfo = getModelCooldownInfo("openai", "gpt-4o-mini");
+  const retryAfter = Number(response.headers.get("Retry-After"));
 
   assert.equal(response.status, 503);
-  assert.equal(Number(response.headers.get("Retry-After")), 30);
+  assert.ok(cooldownInfo);
+  assert.ok(retryAfter >= 1);
+  assert.ok(retryAfter <= 12);
+  assert.ok(retryAfter >= Math.ceil((cooldownInfo?.remainingMs || 0) / 1000) - 1);
   assert.match(json.error.message, /temporarily unavailable/i);
 });
 
@@ -107,11 +112,20 @@ test("checkPipelineGates blocks providers with an open circuit breaker", async (
   const breaker = getCircuitBreaker("openai");
   breaker.state = STATE.OPEN;
   breaker.lastFailureTime = Date.now();
+  breaker.resetTimeout = 5_000;
 
-  const response = await checkPipelineGates("openai", "gpt-4o-mini");
+  const response = await checkPipelineGates("openai", "gpt-4o-mini", {
+    providerProfile: {
+      circuitBreakerThreshold: 5,
+      circuitBreakerReset: 5_000,
+    },
+  });
   const json = await response.json();
+  const retryAfter = Number(response.headers.get("Retry-After"));
 
   assert.equal(response.status, 503);
+  assert.ok(retryAfter >= 4);
+  assert.ok(retryAfter <= 5);
   assert.match(json.error.message, /circuit breaker is open/i);
 });
 


### PR DESCRIPTION
## Summary
- return the real remaining model cooldown in pipeline gate responses instead of a fixed 30s Retry-After
- return the real remaining circuit-breaker reset time in pipeline gate responses instead of a fixed 30s Retry-After
- add small helper APIs for querying model cooldown and breaker retry windows
- cover the new behavior in chat helper tests

## Root cause
- `checkPipelineGates()` hardcoded `Retry-After: 30` for both model cooldown rejections and circuit-breaker-open rejections
- the internal lock state already tracked the real remaining time, but the outward response did not surface it

## Validation
- `node --import tsx/esm --test --test-name-pattern 'checkPipelineGates blocks models in cooldown|checkPipelineGates blocks providers with an open circuit breaker|handleNoCredentials returns structured model_cooldown when every credential for the model is cooling down' tests/unit/chat-helpers.test.ts`
- `npm run typecheck:core`
- `npx eslint src/sse/handlers/chatHelpers.ts src/domain/modelAvailability.ts src/shared/utils/circuitBreaker.ts tests/unit/chat-helpers.test.ts`
- `pre-push hook: npm run test:unit` (`3022 passed / 0 failed`)
