### PR TITLE
fix: auto-scroll ActivityHeatmap to show current date

### DIFF
--- a/src/shared/components/analytics/charts.tsx
+++ b/src/shared/components/analytics/charts.tsx
@@ -176,7 +176,6 @@ export function CompactStatGrid({ sections }: { sections: CompactStatSection[] }
 export function ActivityHeatmap({ activityMap }) {
   const scrollRef = useRef<HTMLDivElement>(null);
 
-
   const cells = useMemo(() => {
     const today = new Date();
     const days = [];
@@ -218,8 +217,6 @@ export function ActivityHeatmap({ activityMap }) {
       scrollRef.current.scrollLeft = scrollRef.current.scrollWidth;
     }
   }, [weeks]);
-
-
   const monthLabels = useMemo(() => {
     const labels = [];
     let lastMonth = -1;
@@ -270,47 +267,49 @@ export function ActivityHeatmap({ activityMap }) {
         </span>
       </div>
 
-      <div className="flex gap-[3px] mb-1 ml-6" style={{ fontSize: "10px" }}>
-        {monthLabels.map((m, i) => (
-          <span
-            key={i}
-            className="text-text-muted"
-            style={{
-              position: "relative",
-              left: `${m.weekIdx * 13}px`,
-              marginLeft: i === 0 ? 0 : "-20px",
-            }}
-          >
-            {m.label}
-          </span>
-        ))}
-      </div>
-
       <div
         ref={scrollRef}
-        className="flex gap-[3px] overflow-x-auto"
+        className="overflow-x-auto"
       >
-        <div className="flex flex-col gap-[3px] shrink-0 text-[10px] text-text-muted pr-1">
-          <span className="h-[10px]"></span>
-          <span className="h-[10px] leading-[10px]">Mon</span>
-          <span className="h-[10px]"></span>
-          <span className="h-[10px] leading-[10px]">Wed</span>
-          <span className="h-[10px]"></span>
-          <span className="h-[10px] leading-[10px]">Fri</span>
-          <span className="h-[10px]"></span>
+        <div className="flex gap-[3px] mb-1 ml-6" style={{ fontSize: "10px" }}>
+          {monthLabels.map((m, i) => (
+            <span
+              key={i}
+              className="text-text-muted"
+              style={{
+                position: "relative",
+                left: `${m.weekIdx * 13}px`,
+                marginLeft: i === 0 ? 0 : "-20px",
+              }}
+            >
+              {m.label}
+            </span>
+          ))}
         </div>
 
-        {weeks.map((week, wi) => (
-          <div key={wi} className="flex flex-col gap-[3px]">
-            {week.map((day, di) => (
-              <div
-                key={di}
-                title={day ? `${day.date}: ${fmtFull(day.value)} tokens` : ""}
-                className={`w-[10px] h-[10px] rounded-[2px] ${day ? getCellColor(day.value) : "bg-transparent"}`}
-              />
-            ))}
+        <div className="flex gap-[3px]">
+          <div className="flex flex-col gap-[3px] shrink-0 text-[10px] text-text-muted pr-1 sticky left-0 z-10 bg-surface">
+            <span className="h-[10px]"></span>
+            <span className="h-[10px] leading-[10px]">Mon</span>
+            <span className="h-[10px]"></span>
+            <span className="h-[10px] leading-[10px]">Wed</span>
+            <span className="h-[10px]"></span>
+            <span className="h-[10px] leading-[10px]">Fri</span>
+            <span className="h-[10px]"></span>
           </div>
-        ))}
+
+          {weeks.map((week, wi) => (
+            <div key={wi} className="flex flex-col gap-[3px]">
+              {week.map((day, di) => (
+                <div
+                  key={di}
+                  title={day ? `${day.date}: ${fmtFull(day.value)} tokens` : ""}
+                  className={`w-[10px] h-[10px] rounded-[2px] ${day ? getCellColor(day.value) : "bg-transparent"}`}
+                />
+              ))}
+            </div>
+          ))}
+        </div>
       </div>
 
       <div className="flex items-center gap-1 mt-2 ml-6 text-[10px] text-text-muted">

--- a/src/shared/components/analytics/charts.tsx
+++ b/src/shared/components/analytics/charts.tsx
@@ -271,34 +271,35 @@ export function ActivityHeatmap({ activityMap }) {
         ref={scrollRef}
         className="overflow-x-auto"
       >
-        <div className="flex gap-[3px] mb-1 ml-6" style={{ fontSize: "10px" }}>
-          {monthLabels.map((m, i) => (
-            <span
-              key={i}
-              className="text-text-muted"
-              style={{
-                position: "relative",
-                left: `${m.weekIdx * 13}px`,
-                marginLeft: i === 0 ? 0 : "-20px",
-              }}
-            >
-              {m.label}
-            </span>
-          ))}
-        </div>
-
-        <div className="flex gap-[3px]">
-          <div className="flex flex-col gap-[3px] shrink-0 text-[10px] text-text-muted pr-1 sticky left-0 z-10 bg-surface">
-            <span className="h-[10px]"></span>
-            <span className="h-[10px] leading-[10px]">Mon</span>
-            <span className="h-[10px]"></span>
-            <span className="h-[10px] leading-[10px]">Wed</span>
-            <span className="h-[10px]"></span>
-            <span className="h-[10px] leading-[10px]">Fri</span>
-            <span className="h-[10px]"></span>
+        <div className="w-max">
+          <div className="flex gap-[3px] mb-1 ml-6" style={{ fontSize: "10px" }}>
+            {monthLabels.map((m, i) => (
+              <span
+                key={i}
+                className="text-text-muted"
+                style={{
+                  position: "relative",
+                  left: `${m.weekIdx * 13}px`,
+                  marginLeft: i === 0 ? 0 : "-20px",
+                }}
+              >
+                {m.label}
+              </span>
+            ))}
           </div>
 
-          {weeks.map((week, wi) => (
+          <div className="flex gap-[3px]">
+            <div className="flex flex-col gap-[3px] shrink-0 text-[10px] text-text-muted pr-1 sticky left-0 z-10 bg-surface">
+              <span className="h-[10px]"></span>
+              <span className="h-[10px] leading-[10px]">Mon</span>
+              <span className="h-[10px]"></span>
+              <span className="h-[10px] leading-[10px]">Wed</span>
+              <span className="h-[10px]"></span>
+              <span className="h-[10px] leading-[10px]">Fri</span>
+              <span className="h-[10px]"></span>
+            </div>
+
+            {weeks.map((week, wi) => (
             <div key={wi} className="flex flex-col gap-[3px]">
               {week.map((day, di) => (
                 <div
@@ -310,6 +311,7 @@ export function ActivityHeatmap({ activityMap }) {
             </div>
           ))}
         </div>
+      </div>
       </div>
 
       <div className="flex items-center gap-1 mt-2 ml-6 text-[10px] text-text-muted">

--- a/src/shared/components/analytics/charts.tsx
+++ b/src/shared/components/analytics/charts.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo, useCallback } from "react";
+import { useState, useMemo, useCallback, useRef, useEffect } from "react";
 import { useLocale } from "next-intl";
 import Card from "../Card";
 import { getModelColor } from "@/shared/constants/colors";
@@ -174,6 +174,9 @@ export function CompactStatGrid({ sections }: { sections: CompactStatSection[] }
 // ── ActivityHeatmap ────────────────────────────────────────────────────────
 
 export function ActivityHeatmap({ activityMap }) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+
   const cells = useMemo(() => {
     const today = new Date();
     const days = [];
@@ -208,6 +211,14 @@ export function ActivityHeatmap({ activityMap }) {
     if (current.length > 0) w.push(current);
     return w;
   }, [cells]);
+
+  // Auto-scroll to the right edge so the current date is visible
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollLeft = scrollRef.current.scrollWidth;
+    }
+  }, [weeks]);
+
 
   const monthLabels = useMemo(() => {
     const labels = [];
@@ -275,7 +286,10 @@ export function ActivityHeatmap({ activityMap }) {
         ))}
       </div>
 
-      <div className="flex gap-[3px] overflow-x-auto">
+      <div
+        ref={scrollRef}
+        className="flex gap-[3px] overflow-x-auto"
+      >
         <div className="flex flex-col gap-[3px] shrink-0 text-[10px] text-text-muted pr-1">
           <span className="h-[10px]"></span>
           <span className="h-[10px] leading-[10px]">Mon</span>


### PR DESCRIPTION
## Problem

The 365-day Activity heatmap on the Analytics tab renders dates left-to-right (oldest → newest), but the container with `overflow-x: auto` starts scrolled to the **left edge**. This means users see dates from ~12 months ago instead of the current/recent activity, and must manually scroll right to view up-to-date statistics.

![Activity heatmap showing old dates instead of current ones](https://github.com/user-attachments/assets/placeholder)

## Root Cause

The `ActivityHeatmap` component in `charts.tsx` uses a horizontally-scrollable `div` to render all 52+ weeks, but never programmatically scrolls to the right edge after mounting.

## Fix

- Add a `useRef` on the scroll container  
- Add a `useEffect` that fires when `weeks` data is computed, setting `scrollLeft = scrollWidth` to auto-scroll to the right edge (current date)

## Changes

- `src/shared/components/analytics/charts.tsx`
  - Import `useRef` and `useEffect` from React
  - Add `scrollRef` + auto-scroll `useEffect` to `ActivityHeatmap`
  - Attach `ref={scrollRef}` to the grid container

## Testing

- Verified that on page load, the heatmap now shows the most recent weeks (rightmost edge)
- Horizontal scroll still works normally for viewing historical data
- No impact on other chart components in the same file