### PR TITLE
fix: preserve max_output_tokens for Responses API targets in chatCore sanitization

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -910,8 +910,12 @@ export async function handleChatCore({
   }
 
   // ── Common input sanitization (runs for ALL paths including passthrough) ──
-  // #994: Normalize max_output_tokens to max_tokens for universal compatibility
-  if (body.max_output_tokens !== undefined) {
+  // #994: Normalize max_output_tokens to max_tokens for universal compatibility.
+  // Skip for Responses API targets where max_output_tokens is the canonical field;
+  // normalizing it to max_tokens there causes "Unsupported parameter: max_tokens"
+  // errors because Responses→Responses passthrough skips the translator that would
+  // convert it back (see openaiToOpenAIResponsesRequest).
+  if (body.max_output_tokens !== undefined && targetFormat !== FORMATS.OPENAI_RESPONSES) {
     if (body.max_tokens === undefined) {
       body.max_tokens = body.max_output_tokens;
     }

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -910,12 +910,21 @@ export async function handleChatCore({
   }
 
   // ── Common input sanitization (runs for ALL paths including passthrough) ──
-  // #994: Normalize max_output_tokens to max_tokens for universal compatibility.
-  // Skip for Responses API targets where max_output_tokens is the canonical field;
-  // normalizing it to max_tokens there causes "Unsupported parameter: max_tokens"
-  // errors because Responses→Responses passthrough skips the translator that would
-  // convert it back (see openaiToOpenAIResponsesRequest).
-  if (body.max_output_tokens !== undefined && targetFormat !== FORMATS.OPENAI_RESPONSES) {
+  // #994: Normalize between max_output_tokens and max_tokens for universal compatibility.
+  // For Responses API targets, max_output_tokens is the canonical field. For others,
+  // max_tokens is preferred. We handle normalization here to support passthrough
+  // paths where the translator is skipped.
+  if (targetFormat === FORMATS.OPENAI_RESPONSES) {
+    if (body.max_output_tokens === undefined) {
+      if (body.max_completion_tokens !== undefined) {
+        body.max_output_tokens = body.max_completion_tokens;
+        delete body.max_completion_tokens;
+      } else if (body.max_tokens !== undefined) {
+        body.max_output_tokens = body.max_tokens;
+        delete body.max_tokens;
+      }
+    }
+  } else if (body.max_output_tokens !== undefined) {
     if (body.max_tokens === undefined) {
       body.max_tokens = body.max_output_tokens;
     }

--- a/tests/unit/chatcore-sanitization.test.ts
+++ b/tests/unit/chatcore-sanitization.test.ts
@@ -179,6 +179,38 @@ test("chatCore sanitization normalizes max_output_tokens into max_tokens", async
   assert.equal("max_tokens" in untouched.call.body, false);
 });
 
+test("chatCore sanitization preserves max_output_tokens for openai-responses targets", async () => {
+  // When the target provider uses openai-responses format (e.g. Codex),
+  // max_output_tokens is the canonical field and must NOT be normalized to
+  // max_tokens. Normalizing it breaks Responses→Responses passthrough because
+  // the translator (which converts max_tokens back) is skipped for same-format.
+  const { call } = await invokeChatCore({
+    endpoint: "/v1/responses",
+    body: {
+      model: "gpt-5.4",
+      max_output_tokens: 4096,
+      input: [{ role: "user", content: "hello" }],
+    },
+    responseFactory: () =>
+      new Response(
+        JSON.stringify({
+          id: "resp_test",
+          object: "response",
+          status: "completed",
+          model: "gpt-5.4",
+          output: [
+            { type: "message", role: "assistant", content: [{ type: "output_text", text: "ok" }] },
+          ],
+          usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      ),
+  });
+
+  // max_output_tokens should survive sanitization for Responses targets
+  assert.equal("max_tokens" in call.body, false, "max_tokens must not be injected for Responses targets");
+});
+
 test("chatCore sanitization strips empty message names and filters empty tool names", async () => {
   // Note: `input` field is tested separately because its presence triggers
   // Responses format detection (PR #1002), which changes message handling.

--- a/tests/unit/chatcore-sanitization.test.ts
+++ b/tests/unit/chatcore-sanitization.test.ts
@@ -209,6 +209,58 @@ test("chatCore sanitization preserves max_output_tokens for openai-responses tar
 
   // max_output_tokens should survive sanitization for Responses targets
   assert.equal("max_tokens" in call.body, false, "max_tokens must not be injected for Responses targets");
+
+  // Reverse normalization: max_tokens → max_output_tokens for Responses targets
+  const fromMaxTokens = await invokeChatCore({
+    endpoint: "/v1/responses",
+    body: {
+      model: "gpt-5.4",
+      max_tokens: 2048,
+      input: [{ role: "user", content: "hello" }],
+    },
+    responseFactory: () =>
+      new Response(
+        JSON.stringify({
+          id: "resp_test2",
+          object: "response",
+          status: "completed",
+          model: "gpt-5.4",
+          output: [
+            { type: "message", role: "assistant", content: [{ type: "output_text", text: "ok" }] },
+          ],
+          usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      ),
+  });
+
+  assert.equal("max_tokens" in fromMaxTokens.call.body, false, "max_tokens should be converted to max_output_tokens");
+
+  // Reverse normalization: max_completion_tokens → max_output_tokens for Responses targets
+  const fromMaxCompletion = await invokeChatCore({
+    endpoint: "/v1/responses",
+    body: {
+      model: "gpt-5.4",
+      max_completion_tokens: 8192,
+      input: [{ role: "user", content: "hello" }],
+    },
+    responseFactory: () =>
+      new Response(
+        JSON.stringify({
+          id: "resp_test3",
+          object: "response",
+          status: "completed",
+          model: "gpt-5.4",
+          output: [
+            { type: "message", role: "assistant", content: [{ type: "output_text", text: "ok" }] },
+          ],
+          usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      ),
+  });
+
+  assert.equal("max_completion_tokens" in fromMaxCompletion.call.body, false, "max_completion_tokens should be converted to max_output_tokens");
 });
 
 test("chatCore sanitization strips empty message names and filters empty tool names", async () => {


### PR DESCRIPTION
## Problem

The common input sanitization in `chatCore.ts` unconditionally normalizes `max_output_tokens` to `max_tokens` ([#994](https://github.com/diegosouzapw/OmniRoute/issues/994)). While this works for Chat Completions targets, it breaks **OpenAI Responses API passthrough** when `sourceFormat === targetFormat === "openai-responses"`.

### Reproduction

1. Configure a client (e.g. Codex CLI, Claude Code) to use `openai-responses` API format
2. Send a request with `max_output_tokens` to an OmniRoute instance that routes to a Responses API provider (e.g. Codex)
3. The upstream rejects the request with: `400 Unsupported parameter: max_tokens`

### Root Cause

The flow is:

```
Client sends: { max_output_tokens: 4096, input: [...] }
  → chatCore.ts:914: max_output_tokens → max_tokens (normalization)
  → translateRequest(): sourceFormat === targetFormat → SKIP
  → Upstream receives: { max_tokens: 4096 } → ❌ "Unsupported parameter"
```

When source and target formats are both `openai-responses`, `translateRequest()` skips translation entirely (line 122-123 of `translator/index.ts`). The translator from [PR #1245](https://github.com/diegosouzapw/OmniRoute/pull/1245) — which correctly maps `max_tokens` back to `max_output_tokens` — is never invoked.

## Fix

Make the normalization conditional: **skip it when `targetFormat` is `openai-responses`**, where `max_output_tokens` is the canonical field.

```diff
- if (body.max_output_tokens !== undefined) {
+ if (body.max_output_tokens !== undefined && targetFormat !== FORMATS.OPENAI_RESPONSES) {
```

This preserves the existing behavior for all non-Responses paths (Chat Completions, Claude, Gemini etc.) while fixing the Responses→Responses passthrough.

### Why this is safe

- **Chat Completions targets**: Normalization still runs → `max_tokens` is used ✅
- **openai → openai-responses path**: The translator from PR #1245 handles `max_tokens → max_output_tokens` conversion ✅
- **openai-responses → openai-responses path (FIXED)**: `max_output_tokens` is preserved → upstream receives the correct field ✅
- **Codex executor**: Already deletes both `max_tokens` and `max_output_tokens` in `transformRequest` (lines 512-513), so no behavioral change ✅

## Test

Added a test that verifies `max_output_tokens` is not normalized to `max_tokens` when routing to a Responses API target via the `/v1/responses` endpoint.

## Related

- #994 — Original normalization PR
- #1245 — `max_tokens`/`max_completion_tokens` → `max_output_tokens` translator fix (openai → openai-responses path)