### PR TITLE
fix(cli): resolve Node 22 TS entrypoint incompatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,4 @@ docs/superpowers/
 # GitNexus local index
 .gitnexus
 .worktrees
+bin/omniroute.mjs

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Smart AI Router with auto fallback — route to FREE & cheap models, zero downtime. Works with Cursor, Cline, Claude Desktop, Codex, and any OpenAI-compatible tool.",
   "type": "module",
   "bin": {
-    "omniroute": "bin/omniroute.ts",
+    "omniroute": "bin/omniroute.mjs",
     "omniroute-reset-password": "bin/reset-password.mjs"
   },
   "files": [

--- a/scripts/prepublish.ts
+++ b/scripts/prepublish.ts
@@ -372,6 +372,24 @@ if (existsSync(mcpSrcFile)) {
   }
 }
 
+// ── Step 8.7: Bundle CLI Entrypoint ──────────────────────────
+const cliSrcFile = join(ROOT, "bin", "omniroute.ts");
+const cliDestFile = join(ROOT, "bin", "omniroute.mjs");
+
+if (existsSync(cliSrcFile)) {
+  console.log("  🔨 Bundling CLI Entrypoint (TypeScript → JavaScript)...");
+  try {
+    execSync(
+      `npx esbuild bin/omniroute.ts --bundle --platform=node --packages=external --format=esm --outfile=bin/omniroute.mjs`,
+      { cwd: ROOT, stdio: "inherit" }
+    );
+    execSync(`chmod +x bin/omniroute.mjs`, { cwd: ROOT });
+    console.log("  ✅ CLI Entrypoint bundled to bin/omniroute.mjs");
+  } catch (err: any) {
+    console.warn("  ⚠️  CLI bundle error:", err.message);
+  }
+}
+
 // ── Step 9: Copy shared utilities needed at runtime ────────
 const sharedApiKey = join(ROOT, "src", "shared", "utils", "apiKey.js");
 const sharedApiKeyDest = join(APP_DIR, "src", "shared", "utils");


### PR DESCRIPTION
This PR resolves the `[ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING]` error that prevents the `omniroute` CLI from correctly running under Node 22. It does this by compiling the CLI TS file into an executable `bin/omniroute.mjs` wrapper during build time.