### PR TITLE
fix: allow combo fallback on context overflow 400 errors

### DIFF
--- a/open-sse/services/accountFallback.ts
+++ b/open-sse/services/accountFallback.ts
@@ -61,6 +61,31 @@ export const OAUTH_INVALID_TOKEN_SIGNALS = [
   "invalid credentials",
 ];
 
+// Context overflow patterns — the prompt exceeds the model's maximum context length.
+// Different providers phrase this differently. Used to decide whether a 400 error
+// should trigger combo fallback (a different model may have a larger context window).
+const CONTEXT_OVERFLOW_PATTERNS = [
+  /\binput is too long\b/i,
+  /\binput too long\b/i,
+  /\bcontext.*(too long|exceeded|overflow|limit)/i,
+  /\btoo many tokens\b/i,
+  /\bprompt is too long\b/i,
+  /\bcontext window/i,
+  /\bmaximum context/i,
+  /\bmax.*token/i,
+  /\btoken limit/i,
+  /\brequest too large\b/i,
+];
+
+// Malformed request patterns — the model rejected the message format but a different
+// provider/model in the combo may accept it.
+const MALFORMED_REQUEST_PATTERNS = [
+  /\bimproperly formed request\b/i,
+  /\binvalid.*message.*format/i,
+  /\bmessages must alternate/i,
+  /\bempty (message|content)/i,
+];
+
 /**
  * T06: Returns true if response body indicates the account is permanently deactivated.
  */
@@ -860,37 +885,8 @@ export function checkFallbackError(
     };
   }
 
-  // 400 Bad Request — check for context overflow / malformed request before blanket rejection.
-  // When using combos (multiple models), a 400 caused by context length exceeding one model's
-  // limit should trigger fallback so the next model (potentially with a larger context window)
-  // can be tried instead of failing immediately.
+  // 400 — context overflow / malformed request may succeed on another model in the combo
   if (status === HTTP_STATUS.BAD_REQUEST) {
-    const lowerError = errorStr.toLowerCase();
-
-    // Context overflow: the prompt exceeds the model's maximum context length.
-    // Different providers phrase this differently.
-    const CONTEXT_OVERFLOW_PATTERNS = [
-      /\binput is too long\b/i,
-      /\binput too long\b/i,
-      /\bcontext.*(too long|exceeded|overflow|limit)/i,
-      /\btoo many tokens\b/i,
-      /\bprompt is too long\b/i,
-      /\bcontext window/i,
-      /\bmaximum context/i,
-      /\bmax.*token/i,
-      /\btoken limit/i,
-      /\brequest too large\b/i,
-    ];
-
-    // Malformed request: the model rejected the message format but a different
-    // provider/model in the combo may accept it.
-    const MALFORMED_REQUEST_PATTERNS = [
-      /\bimproperly formed request\b/i,
-      /\binvalid.*message.*format/i,
-      /\bmessages must alternate/i,
-      /\bempty (message|content)/i,
-    ];
-
     const isOverflow = CONTEXT_OVERFLOW_PATTERNS.some((p) => p.test(errorStr));
     const isMalformed = MALFORMED_REQUEST_PATTERNS.some((p) => p.test(errorStr));
 

--- a/open-sse/services/accountFallback.ts
+++ b/open-sse/services/accountFallback.ts
@@ -860,8 +860,49 @@ export function checkFallbackError(
     };
   }
 
-  // 400 Bad Request - don't fallback (same request will fail on all accounts)
+  // 400 Bad Request — check for context overflow / malformed request before blanket rejection.
+  // When using combos (multiple models), a 400 caused by context length exceeding one model's
+  // limit should trigger fallback so the next model (potentially with a larger context window)
+  // can be tried instead of failing immediately.
   if (status === HTTP_STATUS.BAD_REQUEST) {
+    const lowerError = errorStr.toLowerCase();
+
+    // Context overflow: the prompt exceeds the model's maximum context length.
+    // Different providers phrase this differently.
+    const CONTEXT_OVERFLOW_PATTERNS = [
+      /\binput is too long\b/i,
+      /\binput too long\b/i,
+      /\bcontext.*(too long|exceeded|overflow|limit)/i,
+      /\btoo many tokens\b/i,
+      /\bprompt is too long\b/i,
+      /\bcontext window/i,
+      /\bmaximum context/i,
+      /\bmax.*token/i,
+      /\btoken limit/i,
+      /\brequest too large\b/i,
+    ];
+
+    // Malformed request: the model rejected the message format but a different
+    // provider/model in the combo may accept it.
+    const MALFORMED_REQUEST_PATTERNS = [
+      /\bimproperly formed request\b/i,
+      /\binvalid.*message.*format/i,
+      /\bmessages must alternate/i,
+      /\bempty (message|content)/i,
+    ];
+
+    const isOverflow = CONTEXT_OVERFLOW_PATTERNS.some((p) => p.test(errorStr));
+    const isMalformed = MALFORMED_REQUEST_PATTERNS.some((p) => p.test(errorStr));
+
+    if (isOverflow || isMalformed) {
+      return {
+        shouldFallback: true,
+        cooldownMs: 0,
+        reason: RateLimitReason.MODEL_CAPACITY,
+      };
+    }
+
+    // Generic 400 — same request will likely fail on all accounts; don't fallback.
     return { shouldFallback: false, cooldownMs: 0, reason: RateLimitReason.UNKNOWN };
   }
 


### PR DESCRIPTION
## Summary

Fixes combo routing fallback behavior for HTTP 400 context overflow errors. When a combo routes through models with different context limits, a 400 "input is too long" or "improperly formed request" from one model should trigger fallback to the next model rather than failing immediately.

Closes #1329

## Problem

`checkFallbackError()` in `open-sse/services/accountFallback.ts` returns `shouldFallback: false` for **all** HTTP 400 responses. This means when a combo's first model rejects a request due to context length (e.g., a 128K model getting a request that exceeds its window), the entire combo fails — even if subsequent models in the combo have larger context windows (200K, 1M, etc.).

This commonly manifests during OpenCode compaction cycles where accumulated context grows large and hits the limit of the first model in a combo chain.

## Root Cause

Line 863-866 (before this PR):
```ts
if (status === HTTP_STATUS.BAD_REQUEST) {
  return { shouldFallback: false, cooldownMs: 0, reason: RateLimitReason.UNKNOWN };
}
```

The blanket `shouldFallback: false` for all 400s assumes the same request will always fail identically on any account. This is correct for malformed API requests but **incorrect** for context overflow — different models have different context limits.

## Fix

Adds pattern-based detection for two categories of 400 errors that should trigger fallback:

1. **Context overflow patterns** — `"input is too long"`, `"too many tokens"`, `"prompt is too long"`, `"context window"`, `"token limit"`, etc.
2. **Malformed request patterns** — `"improperly formed request"`, `"invalid message format"`, `"messages must alternate"`, `"empty message/content"`

When detected, returns `shouldFallback: true` with `MODEL_CAPACITY` reason (zero cooldown — the model's context limit won't change by waiting).

Unmatched 400 errors continue to return `shouldFallback: false` as before.

## Testing

- Local patch has been running in production for 48+ hours on our instance
- Confirmed combos now successfully fallback from smaller-context models to larger ones
- No false positives observed — unrelated 400 errors still fail fast as expected

## Changes

- `open-sse/services/accountFallback.ts` — Added context overflow and malformed request pattern detection before the blanket 400 rejection in `checkFallbackError()`