### PR TITLE
fix: restore clientHeaders passthrough in chatCore (regression from #1227)

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -1563,6 +1563,7 @@ export async function handleChatCore({
             log,
             extendedContext,
             upstreamExtraHeaders: buildUpstreamHeadersForExecute(modelToCall),
+            clientHeaders: clientRawRequest?.headers ?? null,
           });
 
           // Qwen 429 strict quota backoff (wait 1.5s, 3s and retry)
@@ -1763,6 +1764,7 @@ export async function handleChatCore({
           log,
           extendedContext,
           upstreamExtraHeaders: buildUpstreamHeadersForExecute(retryModelId),
+          clientHeaders: clientRawRequest?.headers ?? null,
         });
 
         if (retryResult.response.ok) {


### PR DESCRIPTION
- fix: restore clientHeaders passthrough at both executor.execute() callsites in chatCore
- fix: re-enable x-initiator forwarding to GitHub Copilot that was lost during v3.6.5-v3.6.7 release merges

## Summary
- PR #1227 added the full x-initiator forwarding pipeline: `clientHeaders` field in `ExecuteInput` (base.ts), stash/read/cleanup in `GithubExecutor` (github.ts), and passthrough in `chatCore.ts`. All three parts were merged.
- During the v3.6.5-v3.6.7 release branch merges, the two `chatCore.ts` lines that pass `clientHeaders: clientRawRequest?.headers ?? null` to `executor.execute()` were lost. The base.ts and github.ts changes survived.
- This means the executor reads `clientHeaders` but never receives them - so `x-initiator` always falls back to `"user"`, burning premium requests on every turn instead of only user-initiated ones.
- This PR restores those two missing lines at the primary and retry `executor.execute()` callsites.
## Related Issues
- Regression from #1227
- Related to BerriAI/litellm#12859 (https://github.com/BerriAI/litellm/issues/12859) - same issue reported for litellm's Copilot proxy
- Related to anomalyco/opencode#595 (https://github.com/anomalyco/opencode/pull/595) - OpenCode's native fix (merged Jul 2025)
## Validation
- [x] `npm run lint` - 0 errors (78 pre-existing warnings, none from this change)
- [x] `npm run test:unit` - 3054/3061 pass, 3 pre-existing failures (chatcore-sanitization, proxy-fetch, xiaomi-mimo - all unrelated), 4 skipped
- [x] End-to-end verified on a production OmniRoute instance: server logs confirm correct agent/user classification matching the client-side x-initiator header
## Tests Added Or Updated
- No new tests. This is a 2-line regression fix restoring fields that were already passing through. The existing chatCore and GitHub executor tests cover these code paths.
## Reviewer Notes
- **2-line change**: only `open-sse/handlers/chatCore.ts` is modified - adding `clientHeaders: clientRawRequest?.headers ?? null` at lines ~1566 and ~1767
- **No new dependencies** added
- **Backward compatible**: when clients don't send x-initiator, behaviour is identical to before - "user" is sent