### PR TITLE
fix(codex): keep system prompts in input for GPT-5 automatic prompt caching

### DIFF
--- a/open-sse/executors/codex.ts
+++ b/open-sse/executors/codex.ts
@@ -224,6 +224,39 @@ function hoistSystemMessagesToInstructions(body: Record<string, unknown>): void 
   body.input = filteredInput;
 }
 
+/**
+ * Convert role=system messages in `input` to role=developer.
+ *
+ * GPT-5 models support the `developer` role in input, but reject `system`.
+ * Unlike hoistSystemMessagesToInstructions(), this keeps the content inside
+ * the `input` array where it benefits from OpenAI's automatic prompt caching.
+ *
+ * OpenAI's prompt caching matches on the serialized prefix of the `input` array
+ * (+ tools). The `instructions` field is NOT included in the cache key for
+ * GPT-5 models. Moving system prompts from `input` to `instructions` therefore
+ * removes them from the cacheable prefix, resulting in 0% cache hit rates.
+ *
+ * Ref: https://community.openai.com/t/caching-is-borked-for-gpt-5-models/1359574
+ * Ref: https://community.openai.com/t/no-caching-with-model-responses/1338627
+ */
+function convertSystemToDeveloperRole(body: Record<string, unknown>): void {
+  if (!Array.isArray(body.input)) return;
+
+  for (const itemValue of body.input) {
+    if (!itemValue || typeof itemValue !== "object" || Array.isArray(itemValue)) {
+      continue;
+    }
+
+    const item = itemValue as Record<string, unknown>;
+    const role = typeof item.role === "string" ? item.role : "";
+    const type = typeof item.type === "string" ? item.type : "";
+    const isSystemMessage = role === "system" && (!type || type === "message");
+    if (isSystemMessage) {
+      item.role = "developer";
+    }
+  }
+}
+
 function normalizeCodexTools(body: Record<string, unknown>): void {
   if (!Array.isArray(body.tools)) return;
 
@@ -436,11 +469,41 @@ export class CodexExecutor extends BaseExecutor {
       body.service_tier = requestDefaults.serviceTier;
     }
 
-    // If no instructions provided, inject default Codex instructions
-    // NOTE: must run before the passthrough return — Codex upstream rejects
-    // requests without instructions even when the body is forwarded as-is.
-    if (!body.instructions || body.instructions.trim() === "") {
-      body.instructions = CODEX_DEFAULT_INSTRUCTIONS;
+    // ── System prompt handling: cache-aware strategy ──
+    //
+    // For GPT-5 models, OpenAI's automatic prompt caching only considers the
+    // `input` array content (+ tools). The `instructions` field is NOT included
+    // in the cache prefix computation. Moving system prompts from `input` into
+    // `instructions` therefore removes them from the cacheable prefix, causing
+    // 0% cache hit rates even with identical repeated requests.
+    //
+    // For native passthrough (client sends Responses API format directly):
+    //   - Convert system → developer role in-place (Codex accepts developer but rejects system)
+    //   - Only inject minimal instructions if the field is completely empty
+    //   - Do NOT inject CODEX_DEFAULT_INSTRUCTIONS (it would bloat the non-cached field)
+    //
+    // For translated requests (from Chat Completions format):
+    //   - Continue hoisting system messages to instructions (legacy behavior)
+    //   - Inject CODEX_DEFAULT_INSTRUCTIONS as fallback
+    //
+    // Ref: https://community.openai.com/t/caching-is-borked-for-gpt-5-models/1359574
+    // Ref: https://community.openai.com/t/no-caching-with-model-responses/1338627
+    if (nativeCodexPassthrough) {
+      // Passthrough path: keep system prompts in input for caching.
+      // Convert system → developer role since Codex rejects role=system in input.
+      convertSystemToDeveloperRole(body);
+
+      // Codex still requires a non-empty instructions field.
+      // Use a minimal placeholder if the client didn't provide one.
+      if (!body.instructions || (typeof body.instructions === "string" && body.instructions.trim() === "")) {
+        body.instructions = "Follow the developer instructions in the conversation.";
+      }
+    } else {
+      // Translated path: hoist system messages to instructions (legacy behavior).
+      if (!body.instructions || (typeof body.instructions === "string" && body.instructions.trim() === "")) {
+        body.instructions = CODEX_DEFAULT_INSTRUCTIONS;
+      }
+      hoistSystemMessagesToInstructions(body);
     }
 
     if (!storeEnabled) {
@@ -448,10 +511,6 @@ export class CodexExecutor extends BaseExecutor {
     } else if (responsesStoreMarker !== undefined && body.store === undefined) {
       body.store = responsesStoreMarker;
     }
-
-    // Cursor can send native Responses payloads with role=system items inside `input`.
-    // Codex rejects system messages there; they must be folded into `instructions`.
-    hoistSystemMessagesToInstructions(body);
 
     // Codex Responses only supports function tools with non-empty names.
     // Cursor may include custom tools (e.g. ApplyPatch) that work locally but are


### PR DESCRIPTION
## Problem

OpenAI's automatic prompt caching for GPT-5 models returns `cached_tokens: 0` on every request routed through OmniRoute, even with identical 53K-token prompts sent seconds apart.

**Root cause**: The `instructions` field in the Responses API is **not included** in the prompt cache key computation for GPT-5 models. OpenAI only caches based on the serialized `input` array + `tools`. The current code moves system messages from `input` (cacheable) into `instructions` (not cacheable) via `hoistSystemMessagesToInstructions()`, destroying the cache prefix entirely.

## Evidence

Diagnostic logging on a production deployment confirmed:

```
[cache-diag-resp] model=gpt-5.4 input=52889 output=370 cached=0 pct=0%   (request 1)
[cache-diag-resp] model=gpt-5.4 input=53421 output=29  cached=0 pct=0%   (request 2, 15s later)
[cache-diag-resp] model=gpt-5.4 input=53973 output=263 cached=0 pct=0%   (request 3, 50s later)
```

Three consecutive requests with identical `instructions + tools` prefix, same model, within 90 seconds — zero cache hits. Meanwhile, a MiniMax provider using the same proxy achieved cache hits immediately:

```
MiniMax request 1: cache_creation=10513, cache_read=0
MiniMax request 2: cache_creation=438,   cache_read=10513  ← cache hit!
```

This is consistent with community reports:
- [Caching is borked for GPT 5 models](https://community.openai.com/t/caching-is-borked-for-gpt-5-models/1359574)
- [No Caching with model Responses](https://community.openai.com/t/no-caching-with-model-responses/1338627)
- [Problem caching system prompt](https://community.openai.com/t/problem-caching-system-prompt/1346849)

## What this PR changes

For **native Responses API passthrough** requests (`_nativeCodexPassthrough === true`):

| Aspect | Before | After |
|--------|--------|-------|
| System messages | Hoisted from `input` to `instructions` | Converted `system` → `developer` role, kept in `input` |
| `instructions` field | `CODEX_DEFAULT_INSTRUCTIONS` (3000+ words) | Minimal placeholder |
| Cacheable prefix | `tools` only (system prompt removed from `input`) | `developer msg + tools + conversation prefix` |
| Expected cache rate | 0% | ~90%+ (matching direct connections) |

For **translated requests** (Chat Completions → Responses format): no change. The existing hoist + default instructions behavior is preserved.

### New function: `convertSystemToDeveloperRole()`

Converts `role: "system"` → `role: "developer"` in-place within the `input` array. This is necessary because:
1. Codex rejects `system` role in `input` (existing comment in code confirms this)
2. GPT-5 models support `developer` role as the replacement
3. Keeping the content in `input` preserves the cacheable prefix

### Impact

For a deployment routing ~7K daily Codex requests averaging 41K input tokens each:
- **Before**: 286.7M input tokens/day, 0.1% cache rate, ~8 cache hits total
- **After (projected)**: Same volume, ~90% cache rate → ~258M cached tokens/day
- **Cost reduction**: ~90% on input token costs for cached portions
- **Latency reduction**: Up to 80% TTFT for cache hits (per OpenAI docs)

## Testing

To verify the fix:
1. Deploy the updated executor
2. Monitor `cached_tokens` in `response.completed` SSE events
3. Second request with the same system prompt should show `cached_tokens > 0`

Example diagnostic (add to proxy/middleware):
```javascript
// In response handler, look for response.completed events:
const u = completed.response?.usage;
const cached = u?.input_tokens_details?.cached_tokens ?? 0;
console.log(`cached=${cached} pct=${Math.round(cached / u.input_tokens * 100)}%`);
```