### PR TITLE
Add Claude Opus 4.7 to Claude Code OAuth models

### DIFF
--- a/README.md
+++ b/README.md
@@ -695,7 +695,7 @@ During deep debugging, long histories with tool results quickly exceed provider 
 
 ```txt
 Combo: "maximize-claude"
-  1. cc/claude-opus-4-6
+  1. cc/claude-opus-4-7
   2. glm/glm-4.7
   3. if/kimi-k2-thinking
 
@@ -719,7 +719,7 @@ Outcome: stable free coding workflow
 
 ```txt
 Combo: "always-on"
-  1. cc/claude-opus-4-6
+  1. cc/claude-opus-4-7
   2. cx/gpt-5.2-codex
   3. glm/glm-4.7
   4. minimax/MiniMax-M2.1
@@ -1511,7 +1511,7 @@ OmniRoute v3.6 is built as an operational platform, not just a relay proxy.
 
 ```txt
 Combo: "my-coding-stack"
-  1. cc/claude-opus-4-6
+  1. cc/claude-opus-4-7
   2. nvidia/llama-3.3-70b
   3. glm/glm-4.7
   4. if/kimi-k2-thinking
@@ -1650,7 +1650,7 @@ Dashboard → Providers → Connect Claude Code
 → 5-hour + weekly quota tracking
 
 Models:
-  cc/claude-opus-4-6
+  cc/claude-opus-4-7
   cc/claude-sonnet-4-5-20250929
   cc/claude-haiku-4-5-20251001
 ```
@@ -1850,7 +1850,7 @@ Dashboard → Combos → Create New
 
 Name: premium-coding
 Models:
-  1. cc/claude-opus-4-6 (Subscription primary)
+  1. cc/claude-opus-4-7 (Subscription primary)
   2. glm/glm-4.7 (Cheap backup, $0.6/1M)
   3. minimax/MiniMax-M2.1 (Cheapest fallback, $0.20/1M)
 
@@ -1880,7 +1880,7 @@ Cost: $0 forever!
 Settings → Models → Advanced:
   OpenAI API Base URL: http://localhost:20128/v1
   OpenAI API Key: [from OmniRoute dashboard]
-  Model: cc/claude-opus-4-6
+  Model: cc/claude-opus-4-7
 ```
 
 ### Claude Code
@@ -1990,7 +1990,7 @@ opencode
 **Rate limiting**
 
 - Subscription quota out → Fallback to GLM/MiniMax
-- Add combo: `cc/claude-opus-4-6 → glm/glm-4.7 → if/kimi-k2-thinking`
+- Add combo: `cc/claude-opus-4-7 → glm/glm-4.7 → if/kimi-k2-thinking`
 
 **OAuth token expired**
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -55,7 +55,7 @@ Complete guide for configuring providers, creating combos, integrating CLI tools
 
 ```
 Combo: "maximize-claude"
-  1. cc/claude-opus-4-6        (use subscription fully)
+  1. cc/claude-opus-4-7        (use subscription fully)
   2. glm/glm-4.7               (cheap backup when quota out)
   3. if/kimi-k2-thinking       (free emergency fallback)
 
@@ -83,7 +83,7 @@ Quality: Production-ready models
 
 ```
 Combo: "always-on"
-  1. cc/claude-opus-4-6        (best quality)
+  1. cc/claude-opus-4-7        (best quality)
   2. cx/gpt-5.2-codex          (second subscription)
   3. glm/glm-4.7               (cheap, resets daily)
   4. minimax/MiniMax-M2.1      (cheapest, 5h reset)
@@ -121,7 +121,7 @@ Dashboard → Providers → Connect Claude Code
 → 5-hour + weekly quota tracking
 
 Models:
-  cc/claude-opus-4-6
+  cc/claude-opus-4-7
   cc/claude-sonnet-4-5-20250929
   cc/claude-haiku-4-5-20251001
 ```
@@ -230,7 +230,7 @@ Dashboard → Combos → Create New
 
 Name: premium-coding
 Models:
-  1. cc/claude-opus-4-6 (Subscription primary)
+  1. cc/claude-opus-4-7 (Subscription primary)
   2. glm/glm-4.7 (Cheap backup, $0.6/1M)
   3. minimax/MiniMax-M2.1 (Cheapest fallback, $0.20/1M)
 
@@ -259,7 +259,7 @@ Cost: $0 forever!
 Settings → Models → Advanced:
   OpenAI API Base URL: http://localhost:20128/v1
   OpenAI API Key: [from omniroute dashboard]
-  Model: cc/claude-opus-4-6
+  Model: cc/claude-opus-4-7
 ```
 
 ### Claude Code
@@ -313,7 +313,7 @@ Edit `~/.openclaw/openclaw.json`:
 Provider: OpenAI Compatible
 Base URL: http://localhost:20128/v1
 API Key: [from dashboard]
-Model: cc/claude-opus-4-6
+Model: cc/claude-opus-4-7
 ```
 
 ---
@@ -552,7 +552,7 @@ For the full environment variable reference, see the [README](../README.md).
 <details>
 <summary><b>View all available models</b></summary>
 
-**Claude Code (`cc/`)** — Pro/Max: `cc/claude-opus-4-6`, `cc/claude-sonnet-4-5-20250929`, `cc/claude-haiku-4-5-20251001`
+**Claude Code (`cc/`)** — Pro/Max: `cc/claude-opus-4-7`, `cc/claude-sonnet-4-5-20250929`, `cc/claude-haiku-4-5-20251001`
 
 **Codex (`cx/`)** — Plus/Pro: `cx/gpt-5.2-codex`, `cx/gpt-5.1-codex-max`
 
@@ -745,7 +745,7 @@ Define global fallback chains that apply across all requests:
 
 ```
 Chain: production-fallback
-  1. cc/claude-opus-4-6
+  1. cc/claude-opus-4-7
   2. gh/gpt-5.1-codex
   3. glm/glm-4.7
 ```

--- a/open-sse/config/providerRegistry.ts
+++ b/open-sse/config/providerRegistry.ts
@@ -277,6 +277,7 @@ export const REGISTRY: Record<string, RegistryEntry> = {
       tokenUrl: "https://console.anthropic.com/v1/oauth/token",
     },
     models: [
+      { id: "claude-opus-4-7", name: "Claude Opus 4.7" },
       { id: "claude-opus-4-6", name: "Claude Opus 4.6" },
       { id: "claude-sonnet-4-6", name: "Claude 4.6 Sonnet" },
       { id: "claude-opus-4-5-20251101", name: "Claude 4.5 Opus" },

--- a/open-sse/executors/base.ts
+++ b/open-sse/executors/base.ts
@@ -390,6 +390,7 @@ export class BaseExecutor {
       // Only supported for specific Claude models per Anthropic docs
       if (extendedContext) {
         const EXTENDED_CONTEXT_MODELS = [
+          "claude-opus-4-7",
           "claude-opus-4-6",
           "claude-sonnet-4-6",
           "claude-sonnet-4-5",

--- a/open-sse/services/modelFamilyFallback.ts
+++ b/open-sse/services/modelFamilyFallback.ts
@@ -73,6 +73,7 @@ const MODEL_FAMILIES: Record<string, string[]> = {
   "gemini-2.5-pro-preview-06-05": ["gemini-2.5-pro", "gemini-2.5-pro-exp-03-25"],
 
   // Claude Opus family
+  "claude-opus-4-7": ["claude-opus-4-6", "claude-opus-4-5-20251101", "claude-sonnet-4-6"],
   "claude-opus-4-6": ["claude-opus-4-6-thinking", "claude-opus-4-5-20251101", "claude-sonnet-4-6"],
   "claude-opus-4-6-thinking": ["claude-opus-4-6", "claude-opus-4-5-20251101"],
 

--- a/src/app/api/providers/[id]/models/route.ts
+++ b/src/app/api/providers/[id]/models/route.ts
@@ -124,6 +124,7 @@ const STATIC_MODEL_PROVIDERS: Record<string, () => Array<{ id: string; name: str
     { id: "gpt-oss-120b-medium", name: "GPT OSS 120B Medium" },
   ],
   claude: () => [
+    { id: "claude-opus-4-7", name: "Claude Opus 4.7" },
     { id: "claude-opus-4-6", name: "Claude Opus 4.6" },
     { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
     { id: "claude-opus-4-5-20251101", name: "Claude Opus 4.5 (2025-11-01)" },

--- a/src/shared/constants/modelSpecs.ts
+++ b/src/shared/constants/modelSpecs.ts
@@ -66,6 +66,16 @@ export const MODEL_SPECS: Record<string, ModelSpec> = {
     supportsVision: true,
   },
 
+  // ── Claude Opus 4.7 ─────────────────────────────────────────────
+  "claude-opus-4-7": {
+    maxOutputTokens: 128000,
+    contextWindow: 1000000,
+    supportsThinking: true,
+    supportsTools: true,
+    supportsVision: true,
+    aliases: ["claude-opus-4.7"],
+  },
+
   // Defaults
   __default__: {
     maxOutputTokens: 8192,

--- a/src/shared/constants/pricing.ts
+++ b/src/shared/constants/pricing.ts
@@ -121,6 +121,13 @@ export const DEFAULT_PRICING = {
 
   // Claude Code (cc)
   cc: {
+    "claude-opus-4-7": {
+      input: 5.0,
+      output: 25.0,
+      cached: 2.5,
+      reasoning: 25.0,
+      cache_creation: 5.0,
+    },
     "claude-opus-4-6": {
       input: 5.0,
       output: 25.0,

--- a/tests/unit/cc-compatible-model-catalog.test.ts
+++ b/tests/unit/cc-compatible-model-catalog.test.ts
@@ -58,6 +58,7 @@ test("v1 models exposes CC-compatible fallback models under the provider node pr
   const body = await response.json();
   const ids = new Set(body.data.map((item) => item.id));
 
+  assert.ok(ids.has("cm/claude-opus-4-7"));
   assert.ok(ids.has("cm/claude-opus-4-6"));
   assert.ok(ids.has("cm/claude-sonnet-4-6"));
   assert.equal(

--- a/tests/unit/models-catalog-route.test.ts
+++ b/tests/unit/models-catalog-route.test.ts
@@ -542,6 +542,7 @@ test("v1 models catalog adds managed fallback models for Claude-compatible provi
   const ids = new Set(body.data.map((item) => item.id));
 
   assert.equal(response.status, 200);
+  assert.ok(ids.has("ccdemo/claude-opus-4-7"));
   assert.ok(ids.has("ccdemo/claude-opus-4-6"));
   assert.equal(ids.has("ccdemo/claude-sonnet-4-6"), false);
 });

--- a/tests/unit/provider-models-route.test.ts
+++ b/tests/unit/provider-models-route.test.ts
@@ -356,6 +356,7 @@ test("provider models route filters hidden models from the static Claude catalog
 
   assert.equal(response.status, 200);
   assert.equal(body.provider, "claude");
+  assert.ok(body.models.some((model) => model.id === "claude-opus-4-7"));
   assert.equal(
     body.models.some((model) => model.id === "claude-sonnet-4-6"),
     false

--- a/tests/unit/t31-t33-t34-t38-model-specs.test.ts
+++ b/tests/unit/t31-t33-t34-t38-model-specs.test.ts
@@ -45,6 +45,7 @@ test("T34: max output tokens are capped by model spec", () => {
   assert.equal(capMaxOutputTokens("gemini-3-flash", 131072), 65536);
   assert.equal(capMaxOutputTokens("gemini-3-flash"), 65536);
   assert.equal(capMaxOutputTokens("gemini-3.1-pro-high", 131072), 65535);
+  assert.equal(capMaxOutputTokens("claude-opus-4-7", 200000), 128000);
 });
 
 test("T38: modelSpecs exposes centralized helpers with alias and prefix lookup", () => {
@@ -53,6 +54,8 @@ test("T38: modelSpecs exposes centralized helpers with alias and prefix lookup",
   assert.equal(getModelSpec("gemini-3-flash-preview").maxOutputTokens, 65536);
   assert.equal(getModelSpec("gemini-3.1-pro-preview").maxOutputTokens, 65535);
   assert.equal(getModelSpec("gemini-3.1-pro-preview-customtools").maxOutputTokens, 65535);
+  assert.equal(getModelSpec("claude-opus-4-7").contextWindow, 1000000);
+  assert.equal(getModelSpec("claude-opus-4.7").maxOutputTokens, 128000);
   assert.equal(resolveModelAlias("gemini-3-pro-low"), "gemini-3.1-pro-low");
   assert.equal(resolveModelAlias("gemini-3.1-pro-preview"), "gemini-3.1-pro-high");
   assert.equal(resolveModelAlias("gemini-3.1-pro-preview-customtools"), "gemini-3.1-pro-high");


### PR DESCRIPTION
## Summary
- add Claude Opus 4.7 to the Claude Code OAuth catalog and local static model list
- add Opus 4.7 specs, pricing metadata, extended-context handling, and family fallback coverage
- update tests and docs, and verify CC-compatible providers inherit the new model automatically

## Why
Claude Code now exposes Opus 4.7 as the current Opus model. OmniRoute should surface it consistently in the OAuth provider, the mirrored CC-compatible catalog, and the related capability metadata.

## Validation
- `node --import tsx/esm --test tests/unit/provider-models-route.test.ts tests/unit/cc-compatible-model-catalog.test.ts tests/unit/models-catalog-route.test.ts tests/unit/t31-t33-t34-t38-model-specs.test.ts`
