### PR TITLE
fix: close MCP audit SQLite connections on shutdown

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@
 
 x-common: &common
   restart: unless-stopped
+  stop_grace_period: 40s
   env_file: .env
   environment:
     - DATA_DIR=/app/data # Must match the volume mount below

--- a/open-sse/mcp-server/__tests__/audit.test.ts
+++ b/open-sse/mcp-server/__tests__/audit.test.ts
@@ -1,0 +1,87 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type MockAuditDb = {
+  prepare: ReturnType<typeof vi.fn>;
+  pragma: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+  open?: boolean;
+};
+
+function createStatementMock() {
+  return {
+    get: vi.fn(),
+    all: vi.fn(),
+    run: vi.fn(),
+  };
+}
+
+describe("MCP audit shutdown", () => {
+  let dataDir: string;
+  let dbFile: string;
+
+  beforeEach(() => {
+    vi.resetModules();
+    dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-mcp-audit-"));
+    dbFile = path.join(dataDir, "storage.sqlite");
+    fs.writeFileSync(dbFile, "");
+    process.env.DATA_DIR = dataDir;
+  });
+
+  afterEach(() => {
+    delete process.env.DATA_DIR;
+    vi.restoreAllMocks();
+  });
+
+  it("checkpoints and closes the audit database during shutdown", async () => {
+    const mockDb: MockAuditDb = {
+      prepare: vi.fn(() => createStatementMock()),
+      pragma: vi.fn(),
+      close: vi.fn(),
+      open: true,
+    };
+    const MockDatabase = vi.fn(function MockDatabase() {
+      return mockDb;
+    });
+
+    vi.doMock("better-sqlite3", () => ({
+      default: MockDatabase,
+    }));
+
+    const audit = await import("../audit.ts");
+
+    await audit.logToolCall("omniroute_get_health", { ok: true }, { ok: true }, 12, true);
+    expect(mockDb.prepare).toHaveBeenCalledTimes(1);
+
+    expect(audit.closeAuditDb()).toBe(true);
+    expect(mockDb.pragma).toHaveBeenCalledWith("wal_checkpoint(TRUNCATE)");
+    expect(mockDb.close).toHaveBeenCalledTimes(1);
+    expect(audit.closeAuditDb()).toBe(false);
+  });
+
+  it("still closes the audit database when checkpoint fails", async () => {
+    const mockDb: MockAuditDb = {
+      prepare: vi.fn(() => createStatementMock()),
+      pragma: vi.fn(() => {
+        throw new Error("database is busy");
+      }),
+      close: vi.fn(),
+      open: true,
+    };
+    const MockDatabase = vi.fn(function MockDatabase() {
+      return mockDb;
+    });
+
+    vi.doMock("better-sqlite3", () => ({
+      default: MockDatabase,
+    }));
+
+    const audit = await import("../audit.ts");
+
+    await audit.logToolCall("omniroute_get_health", {}, {}, 5, true);
+    expect(audit.closeAuditDb()).toBe(true);
+    expect(mockDb.close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/open-sse/mcp-server/audit.ts
+++ b/open-sse/mcp-server/audit.ts
@@ -18,6 +18,9 @@ interface StatementLike<TRow = unknown> {
 
 interface AuditDatabase {
   prepare: <TRow = unknown>(sql: string) => StatementLike<TRow>;
+  pragma: (sql: string) => unknown;
+  close: () => void;
+  open?: boolean;
 }
 
 interface AuditStatsRow {
@@ -169,6 +172,33 @@ async function getDb(): Promise<AuditDatabase | null> {
     console.error("[MCP Audit] Failed to connect to database:", message);
     return null;
   }
+}
+
+export function closeAuditDb(): boolean {
+  if (!db) return false;
+
+  const database = db;
+  db = null;
+
+  try {
+    try {
+      if (database.open !== false) {
+        database.pragma("wal_checkpoint(TRUNCATE)");
+      }
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn("[MCP Audit] WAL checkpoint failed during close:", message);
+    }
+  } finally {
+    try {
+      database.close();
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn("[MCP Audit] Failed to close database:", message);
+    }
+  }
+
+  return true;
 }
 
 // ============ Audit Logger ============

--- a/open-sse/mcp-server/server.ts
+++ b/open-sse/mcp-server/server.ts
@@ -43,7 +43,7 @@ import {
 } from "./schemas/tools.ts";
 import { startMcpHeartbeat } from "./runtimeHeartbeat.ts";
 
-import { logToolCall } from "./audit.ts";
+import { closeAuditDb, logToolCall } from "./audit.ts";
 import {
   evaluateToolScopes,
   resolveCallerScopeContext,
@@ -876,6 +876,9 @@ export async function startMcpStdio(): Promise<void> {
     await server.connect(transport);
     console.error("[MCP] OmniRoute MCP Server connected and ready.");
   } finally {
+    if (closeAuditDb()) {
+      console.error("[MCP] Audit database checkpointed and closed.");
+    }
     stopHeartbeatOnce();
     process.off("exit", stopHeartbeatOnce);
     process.off("SIGINT", stopHeartbeatOnce);

--- a/src/lib/gracefulShutdown.ts
+++ b/src/lib/gracefulShutdown.ts
@@ -96,7 +96,13 @@ async function waitForDrain(): Promise<void> {
  */
 async function cleanup(): Promise<void> {
   try {
-    const { closeDbInstance } = await import("@/lib/db/core");
+    const [{ closeAuditDb }, { closeDbInstance }] = await Promise.all([
+      import("@omniroute/open-sse/mcp-server/audit.ts"),
+      import("@/lib/db/core"),
+    ]);
+    if (closeAuditDb()) {
+      console.log("[Shutdown] MCP audit database checkpointed and closed.");
+    }
     if (closeDbInstance()) {
       console.log("[Shutdown] SQLite database checkpointed and closed.");
     }


### PR DESCRIPTION
## Summary
- close the MCP audit SQLite connection during shutdown and stdio server teardown
- checkpoint the audit connection before close so WAL changes are flushed back into `storage.sqlite`
- align the default Docker Compose stop grace period with the app shutdown window
- add regression coverage for audit database shutdown behavior

## Root Cause
OmniRoute already checkpoints and closes the main SQLite singleton during graceful shutdown, but the MCP audit logger kept a separate `better-sqlite3` connection open without a matching shutdown path. That extra connection could keep `storage.sqlite-wal` and `storage.sqlite-shm` on disk after an otherwise normal stop, especially in Docker when the container stop timeout was shorter than the app shutdown timeout.

## Impact
- normal shutdown now closes every known SQLite connection involved in the app process
- `docker stop` and `docker compose down` have enough time to finish WAL cleanup with the bundled Compose setup
- WAL sidecar files can still remain after hard kills or if another external process keeps the database open, which matches normal SQLite WAL behavior

## Validation
- `./node_modules/.bin/vitest run --config vitest.mcp.config.ts open-sse/mcp-server/__tests__/audit.test.ts open-sse/mcp-server/__tests__/essentialTools.test.ts`
- `./node_modules/.bin/eslint open-sse/mcp-server/audit.ts open-sse/mcp-server/server.ts src/lib/gracefulShutdown.ts open-sse/mcp-server/__tests__/audit.test.ts`
- `./node_modules/.bin/tsc --pretty false -p tsconfig.typecheck-core.json`
