### PR TITLE
fix(cli): avoid creating app router during postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "src/shared/utils/nodeRuntimeSupport.ts",
     ".env.example",
     "scripts/postinstall.mjs",
+    "scripts/postinstallSupport.mjs",
     "scripts/check-supported-node-runtime.ts",
     "scripts/sync-env.mjs",
     "scripts/native-binary-compat.mjs",

--- a/scripts/pack-artifact-policy.ts
+++ b/scripts/pack-artifact-policy.ts
@@ -72,6 +72,7 @@ export const PACK_ARTIFACT_ROOT_ALLOWED_EXACT_PATHS: string[] = [
   "scripts/check-supported-node-runtime.ts",
   "scripts/native-binary-compat.mjs",
   "scripts/postinstall.mjs",
+  "scripts/postinstallSupport.mjs",
   "scripts/sync-env.mjs",
   "src/shared/utils/nodeRuntimeSupport.ts",
 ];
@@ -89,6 +90,7 @@ export const PACK_ARTIFACT_REQUIRED_PATHS: string[] = [
   "package.json",
   "scripts/native-binary-compat.mjs",
   "scripts/postinstall.mjs",
+  "scripts/postinstallSupport.mjs",
   "src/shared/utils/nodeRuntimeSupport.ts",
 ];
 

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -22,6 +22,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { PUBLISHED_BUILD_ARCH, PUBLISHED_BUILD_PLATFORM } from "./native-binary-compat.mjs";
+import { hasStandaloneAppBundle } from "./postinstallSupport.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -174,6 +175,10 @@ async function fixBetterSqliteBinary() {
 }
 
 async function ensureSwcHelpers() {
+  if (!hasStandaloneAppBundle(ROOT)) {
+    return;
+  }
+
   const swcHelpersApp = join(ROOT, "app", "node_modules", "@swc", "helpers");
   const swcHelpersRoot = join(ROOT, "node_modules", "@swc", "helpers");
 

--- a/scripts/postinstallSupport.mjs
+++ b/scripts/postinstallSupport.mjs
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Detect whether the current install tree contains the published standalone app bundle.
+ * Source checkouts should not create `app/` during postinstall because Next.js would
+ * mis-detect it as a competing App Router root and serve 404s for the real `src/app` routes.
+ *
+ * @param {string} rootDir
+ * @returns {boolean}
+ */
+export function hasStandaloneAppBundle(rootDir) {
+  return existsSync(join(rootDir, "app", "server.js"));
+}

--- a/tests/unit/pack-artifact-policy.test.ts
+++ b/tests/unit/pack-artifact-policy.test.ts
@@ -45,7 +45,13 @@ test("findUnexpectedArtifactPaths flags app pack files outside the allowlist", (
 
 test("findMissingArtifactPaths flags missing root runtime files in the tarball", () => {
   const missingPaths = findMissingArtifactPaths(
-    ["app/server.js", "bin/omniroute.ts", "package.json", "scripts/postinstall.mjs"],
+    [
+      "app/server.js",
+      "bin/omniroute.ts",
+      "package.json",
+      "scripts/postinstall.mjs",
+      "scripts/postinstallSupport.mjs",
+    ],
     PACK_ARTIFACT_REQUIRED_PATHS
   );
 

--- a/tests/unit/postinstall-support.test.ts
+++ b/tests/unit/postinstall-support.test.ts
@@ -1,0 +1,30 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { hasStandaloneAppBundle } from "../../scripts/postinstallSupport.mjs";
+
+test("hasStandaloneAppBundle returns false for source checkout without standalone app", () => {
+  const root = mkdtempSync(join(tmpdir(), "omniroute-postinstall-src-"));
+
+  try {
+    mkdirSync(join(root, "src", "app"), { recursive: true });
+    assert.equal(hasStandaloneAppBundle(root), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("hasStandaloneAppBundle returns true for published standalone app bundle", () => {
+  const root = mkdtempSync(join(tmpdir(), "omniroute-postinstall-standalone-"));
+
+  try {
+    mkdirSync(join(root, "app"), { recursive: true });
+    writeFileSync(join(root, "app", "server.js"), "export {};\n");
+    assert.equal(hasStandaloneAppBundle(root), true);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- skip standalone-only postinstall helper sync when the published `app/server.js` bundle is absent
- prevent source checkouts from creating a fake root `app/` directory during `npm install`
- ship the new helper inside the npm artifact and cover the guard with targeted unit tests

## Problem

`3.6.6` introduced a startup regression in source checkouts:

1. `scripts/postinstall.mjs` can create `app/node_modules/...` at the repository root while trying to sync standalone-only runtime helpers.
2. `scripts/run-next.mjs` treats any root-level `app/` directory as a fatal App Router conflict because the real application lives under `src/app/`.
3. After a normal `npm install`, `npm start` may abort before the server boots, even though the checkout itself is otherwise healthy.

In practice this means a source checkout can fail to start only because `postinstall` materialized a standalone runtime directory that does not belong in development/source mode.

## Why this fix

The standalone helper sync is only valid for the published npm artifact, where `app/server.js` exists.
In a source checkout there is no standalone app bundle, so creating `app/` is both unnecessary and harmful.

This fix adds a small guard that only enables the standalone-specific postinstall behavior when the published standalone bundle is actually present.
That keeps npm package installs working while preventing source checkouts from poisoning themselves with a fake App Router root.

## Testing

- `node --import tsx/esm --test tests/unit/postinstall-support.test.ts tests/unit/pack-artifact-policy.test.ts`
- `npm run build`
- `rm -rf app && node scripts/postinstall.mjs && test ! -e app`

Changed or added test files:

- `tests/unit/postinstall-support.test.ts`
- `tests/unit/pack-artifact-policy.test.ts`