### PR TITLE
Support xhigh only on Claude models that expose it

### DIFF
--- a/open-sse/config/providerModels.ts
+++ b/open-sse/config/providerModels.ts
@@ -16,6 +16,12 @@ export function getDefaultModel(aliasOrId: string): string | null {
   return models?.[0]?.id || null;
 }
 
+export function getProviderModel(aliasOrId: string, modelId: string): RegistryModel | undefined {
+  const models = PROVIDER_MODELS[aliasOrId];
+  if (!models) return undefined;
+  return models.find((model) => model.id === modelId);
+}
+
 export function isValidModel(
   aliasOrId: string,
   modelId: string,
@@ -44,4 +50,9 @@ export function getModelTargetFormat(aliasOrId: string, modelId: string): string
 export function getModelsByProviderId(providerId: string): RegistryModel[] {
   const alias = PROVIDER_ID_TO_ALIAS[providerId] || providerId;
   return PROVIDER_MODELS[alias] || [];
+}
+
+export function supportsXHighEffort(aliasOrId: string, modelId: string): boolean {
+  const alias = PROVIDER_ID_TO_ALIAS[aliasOrId] || aliasOrId;
+  return getProviderModel(alias, modelId)?.supportsXHighEffort === true;
 }

--- a/open-sse/config/providerRegistry.ts
+++ b/open-sse/config/providerRegistry.ts
@@ -26,6 +26,7 @@ export interface RegistryModel {
   toolCalling?: boolean;
   supportsReasoning?: boolean;
   supportsVision?: boolean;
+  supportsXHighEffort?: boolean;
   targetFormat?: string;
   unsupportedParams?: readonly string[];
   /** Maximum context window in tokens */
@@ -277,12 +278,20 @@ export const REGISTRY: Record<string, RegistryEntry> = {
       tokenUrl: "https://console.anthropic.com/v1/oauth/token",
     },
     models: [
-      { id: "claude-opus-4-7", name: "Claude Opus 4.7" },
-      { id: "claude-opus-4-6", name: "Claude Opus 4.6" },
-      { id: "claude-sonnet-4-6", name: "Claude 4.6 Sonnet" },
-      { id: "claude-opus-4-5-20251101", name: "Claude 4.5 Opus" },
-      { id: "claude-sonnet-4-5-20250929", name: "Claude 4.5 Sonnet" },
-      { id: "claude-haiku-4-5-20251001", name: "Claude 4.5 Haiku" },
+      { id: "claude-opus-4-7", name: "Claude Opus 4.7", supportsXHighEffort: true },
+      { id: "claude-opus-4-6", name: "Claude Opus 4.6", supportsXHighEffort: false },
+      { id: "claude-sonnet-4-6", name: "Claude 4.6 Sonnet", supportsXHighEffort: false },
+      { id: "claude-opus-4-5-20251101", name: "Claude 4.5 Opus", supportsXHighEffort: false },
+      {
+        id: "claude-sonnet-4-5-20250929",
+        name: "Claude 4.5 Sonnet",
+        supportsXHighEffort: false,
+      },
+      {
+        id: "claude-haiku-4-5-20251001",
+        name: "Claude 4.5 Haiku",
+        supportsXHighEffort: false,
+      },
     ],
   },
 

--- a/open-sse/services/claudeCodeCompatible.ts
+++ b/open-sse/services/claudeCodeCompatible.ts
@@ -1,7 +1,7 @@
 import { createHash, randomUUID } from "node:crypto";
 
 import { getStainlessTimeoutSeconds } from "@/shared/utils/runtimeTimeouts";
-import { getModelsByProviderId } from "../config/providerModels.ts";
+import { supportsXHighEffort } from "../config/providerModels.ts";
 import { prepareClaudeRequest } from "../translator/helpers/claudeHelper.ts";
 import { signRequestBody } from "./claudeCodeCCH.ts";
 import { computeFingerprint, extractFirstUserMessageText } from "./claudeCodeFingerprint.ts";
@@ -47,11 +47,6 @@ export const CLAUDE_CODE_COMPATIBLE_BILLING_HEADER = `x-anthropic-billing-header
 export const CLAUDE_CODE_COMPATIBLE_STAINLESS_TIMEOUT_SECONDS = getStainlessTimeoutSeconds(
   process.env
 );
-const CLAUDE_XHIGH_SUPPORTED_MODELS = new Set(
-  getModelsByProviderId("claude")
-    .filter((model) => model.supportsXHighEffort)
-    .map((model) => model.id)
-);
 
 type HeaderLike =
   | Headers
@@ -78,7 +73,7 @@ type BuildRequestOptions = {
 };
 
 function supportsClaudeXHighEffort(model: string | null | undefined): boolean {
-  return typeof model === "string" && CLAUDE_XHIGH_SUPPORTED_MODELS.has(model);
+  return typeof model === "string" && supportsXHighEffort("claude", model);
 }
 
 export function isClaudeCodeCompatibleProvider(provider: string | null | undefined): boolean {

--- a/open-sse/services/claudeCodeCompatible.ts
+++ b/open-sse/services/claudeCodeCompatible.ts
@@ -1,6 +1,7 @@
 import { createHash, randomUUID } from "node:crypto";
 
 import { getStainlessTimeoutSeconds } from "@/shared/utils/runtimeTimeouts";
+import { getModelsByProviderId } from "../config/providerModels.ts";
 import { prepareClaudeRequest } from "../translator/helpers/claudeHelper.ts";
 import { signRequestBody } from "./claudeCodeCCH.ts";
 import { computeFingerprint, extractFirstUserMessageText } from "./claudeCodeFingerprint.ts";
@@ -46,6 +47,11 @@ export const CLAUDE_CODE_COMPATIBLE_BILLING_HEADER = `x-anthropic-billing-header
 export const CLAUDE_CODE_COMPATIBLE_STAINLESS_TIMEOUT_SECONDS = getStainlessTimeoutSeconds(
   process.env
 );
+const CLAUDE_XHIGH_SUPPORTED_MODELS = new Set(
+  getModelsByProviderId("claude")
+    .filter((model) => model.supportsXHighEffort)
+    .map((model) => model.id)
+);
 
 type HeaderLike =
   | Headers
@@ -70,6 +76,10 @@ type BuildRequestOptions = {
   sessionId?: string | null;
   preserveCacheControl?: boolean;
 };
+
+function supportsClaudeXHighEffort(model: string | null | undefined): boolean {
+  return typeof model === "string" && CLAUDE_XHIGH_SUPPORTED_MODELS.has(model);
+}
 
 export function isClaudeCodeCompatibleProvider(provider: string | null | undefined): boolean {
   return typeof provider === "string" && provider.startsWith(CLAUDE_CODE_COMPATIBLE_PREFIX);
@@ -331,7 +341,7 @@ export function resolveClaudeCodeCompatibleEffort(
   sourceBody?: Record<string, unknown> | null,
   normalizedBody?: Record<string, unknown> | null,
   model?: string | null
-): "low" | "medium" | "high" {
+): "low" | "medium" | "high" | "xhigh" {
   const raw =
     readNestedString(sourceBody, ["output_config", "effort"]) ||
     readNestedString(sourceBody, ["reasoning", "effort"]) ||
@@ -342,14 +352,16 @@ export function resolveClaudeCodeCompatibleEffort(
     "";
 
   const normalizedEffort = raw.toLowerCase();
-  void model;
 
   if (!normalizedEffort) return "high";
   if (normalizedEffort === "low") return "low";
   if (normalizedEffort === "medium") return "medium";
   if (normalizedEffort === "high") return "high";
   if (normalizedEffort === "none" || normalizedEffort === "disabled") return "low";
-  if (normalizedEffort === "max" || normalizedEffort === "xhigh") {
+  if (normalizedEffort === "xhigh") {
+    return supportsClaudeXHighEffort(model) ? "xhigh" : "high";
+  }
+  if (normalizedEffort === "max") {
     return "high";
   }
   return "high";

--- a/open-sse/translator/request/openai-to-claude.ts
+++ b/open-sse/translator/request/openai-to-claude.ts
@@ -1,6 +1,7 @@
 import { register } from "../registry.ts";
 import { FORMATS } from "../formats.ts";
 import { CLAUDE_SYSTEM_PROMPT } from "../../config/constants.ts";
+import { supportsXHighEffort } from "../../config/providerModels.ts";
 import { adjustMaxTokens } from "../helpers/maxTokensHelper.ts";
 import { sanitizeToolId } from "../helpers/schemaCoercion.ts";
 import { DEFAULT_THINKING_CLAUDE_SIGNATURE } from "../../config/defaultThinkingSignature.ts";
@@ -99,6 +100,7 @@ export function openaiToClaudeRequest(model, body, stream) {
     tools?: ClaudeTool[];
     tool_choice?: Record<string, unknown> | string;
     thinking?: Record<string, unknown>;
+    output_config?: Record<string, unknown>;
     _toolNameMap?: Map<string, string>;
   } = {
     model: model,
@@ -333,22 +335,36 @@ export function openaiToClaudeRequest(model, body, stream) {
   } else if (body.reasoning_effort) {
     // Convert OpenAI reasoning_effort to Claude thinking format (#627)
     // Clients like OpenCode send reasoning_effort via @ai-sdk/openai-compatible
-    const effortBudgetMap: Record<string, number> = {
-      low: 1024,
-      medium: 10240,
-      high: 131072,
-      max: 131072,
-    };
-    const effort = String(body.reasoning_effort).toLowerCase();
-    const budget = effortBudgetMap[effort];
-    if (budget !== undefined && budget > 0) {
+    const requestedEffort = String(body.reasoning_effort).toLowerCase();
+    const normalizedEffort =
+      requestedEffort === "xhigh" && !supportsXHighEffort("claude", model)
+        ? "high"
+        : requestedEffort;
+    if (normalizedEffort === "xhigh") {
       result.thinking = {
-        type: "enabled",
-        budget_tokens: budget,
+        type: "adaptive",
       };
-      // Claude requires max_tokens > budget_tokens
-      if (result.max_tokens <= budget) {
-        result.max_tokens = budget + 8192;
+      result.output_config = {
+        ...(result.output_config || {}),
+        effort: "xhigh",
+      };
+    } else {
+      const effortBudgetMap: Record<string, number> = {
+        low: 1024,
+        medium: 10240,
+        high: 131072,
+        max: 131072,
+      };
+      const budget = effortBudgetMap[normalizedEffort];
+      if (budget !== undefined && budget > 0) {
+        result.thinking = {
+          type: "enabled",
+          budget_tokens: budget,
+        };
+        // Claude requires max_tokens > budget_tokens
+        if (result.max_tokens <= budget) {
+          result.max_tokens = budget + 8192;
+        }
       }
     }
   }

--- a/tests/unit/cc-compatible-provider.test.ts
+++ b/tests/unit/cc-compatible-provider.test.ts
@@ -142,6 +142,23 @@ test("buildClaudeCodeCompatibleRequest keeps prior role history while dropping t
   assert.equal(JSON.parse(payload.metadata.user_id).session_id, "session-1");
 });
 
+test("buildClaudeCodeCompatibleRequest preserves xhigh for Claude models that support it", () => {
+  const payload = buildClaudeCodeCompatibleRequest({
+    sourceBody: {
+      reasoning_effort: "xhigh",
+    },
+    normalizedBody: {
+      messages: [{ role: "user", content: "u1" }],
+    },
+    model: "claude-opus-4-7",
+    cwd: "/tmp/work",
+    now: new Date("2026-04-01T12:00:00.000Z"),
+  });
+
+  assert.equal(payload.output_config.effort, "xhigh");
+  assert.equal(payload.thinking.type, "adaptive");
+});
+
 test("buildClaudeCodeCompatibleRequest preserves Claude cache markers when requested", () => {
   const payload = buildClaudeCodeCompatibleRequest({
     sourceBody: {

--- a/tests/unit/cc-compatible-provider.test.ts
+++ b/tests/unit/cc-compatible-provider.test.ts
@@ -18,6 +18,7 @@ const {
   CLAUDE_CODE_COMPATIBLE_DEFAULT_MODELS_PATH,
   joinClaudeCodeCompatibleUrl,
 } = await import("../../open-sse/services/claudeCodeCompatible.ts");
+const { getModelsByProviderId } = await import("../../open-sse/config/providerModels.ts");
 const { handleChatCore } = await import("../../open-sse/handlers/chatCore.ts");
 const { validateProviderApiKey } = await import("../../src/lib/providers/validation.ts");
 const providerNodesRoute = await import("../../src/app/api/provider-nodes/route.ts");
@@ -143,6 +144,10 @@ test("buildClaudeCodeCompatibleRequest keeps prior role history while dropping t
 });
 
 test("buildClaudeCodeCompatibleRequest preserves xhigh for Claude models that support it", () => {
+  const xhighModel = getModelsByProviderId("claude").find(
+    (model) => model.supportsXHighEffort === true
+  );
+  assert.ok(xhighModel, "expected at least one Claude model with xhigh support");
   const payload = buildClaudeCodeCompatibleRequest({
     sourceBody: {
       reasoning_effort: "xhigh",
@@ -150,7 +155,7 @@ test("buildClaudeCodeCompatibleRequest preserves xhigh for Claude models that su
     normalizedBody: {
       messages: [{ role: "user", content: "u1" }],
     },
-    model: "claude-opus-4-7",
+    model: xhighModel.id,
     cwd: "/tmp/work",
     now: new Date("2026-04-01T12:00:00.000Z"),
   });

--- a/tests/unit/claude-code-compatible-request.test.ts
+++ b/tests/unit/claude-code-compatible-request.test.ts
@@ -11,6 +11,7 @@ const {
   resolveClaudeCodeCompatibleMaxTokens,
   buildClaudeCodeCompatibleRequest,
 } = await import("../../open-sse/services/claudeCodeCompatible.ts");
+const { getModelsByProviderId } = await import("../../open-sse/config/providerModels.ts");
 
 test("Claude Code compatible URL helpers cover empty values, version trimming and legacy session headers", () => {
   assert.equal(stripClaudeCodeCompatibleEndpointSuffix(""), "");
@@ -33,9 +34,33 @@ test("Claude Code compatible URL helpers cover empty values, version trimming an
 });
 
 test("Claude Code compatible effort and max token helpers cover priority fallbacks", () => {
+  const claudeModels = getModelsByProviderId("claude");
+  assert.equal(
+    claudeModels.find((model) => model.id === "claude-opus-4-7")?.supportsXHighEffort,
+    true
+  );
+  assert.equal(
+    claudeModels.find((model) => model.id === "claude-opus-4-6")?.supportsXHighEffort,
+    false
+  );
   assert.equal(resolveClaudeCodeCompatibleEffort({ reasoning_effort: "medium" }), "medium");
   assert.equal(resolveClaudeCodeCompatibleEffort({ reasoning: { effort: "none" } }), "low");
-  assert.equal(resolveClaudeCodeCompatibleEffort({ output_config: { effort: "xhigh" } }), "high");
+  assert.equal(
+    resolveClaudeCodeCompatibleEffort(
+      { output_config: { effort: "xhigh" } },
+      null,
+      "claude-opus-4-7"
+    ),
+    "xhigh"
+  );
+  assert.equal(
+    resolveClaudeCodeCompatibleEffort(
+      { output_config: { effort: "xhigh" } },
+      null,
+      "claude-opus-4-6"
+    ),
+    "high"
+  );
   assert.equal(
     resolveClaudeCodeCompatibleEffort({ output_config: { effort: "unexpected" } }),
     "high"

--- a/tests/unit/claude-code-compatible-request.test.ts
+++ b/tests/unit/claude-code-compatible-request.test.ts
@@ -13,6 +13,15 @@ const {
 } = await import("../../open-sse/services/claudeCodeCompatible.ts");
 const { getModelsByProviderId } = await import("../../open-sse/config/providerModels.ts");
 
+function getClaudeEffortFixtures() {
+  const claudeModels = getModelsByProviderId("claude");
+  const xhighModel = claudeModels.find((model) => model.supportsXHighEffort === true);
+  const standardModel = claudeModels.find((model) => model.supportsXHighEffort === false);
+  assert.ok(xhighModel, "expected at least one Claude model with xhigh support");
+  assert.ok(standardModel, "expected at least one Claude model without xhigh support");
+  return { xhighModel, standardModel };
+}
+
 test("Claude Code compatible URL helpers cover empty values, version trimming and legacy session headers", () => {
   assert.equal(stripClaudeCodeCompatibleEndpointSuffix(""), "");
   assert.equal(
@@ -34,30 +43,18 @@ test("Claude Code compatible URL helpers cover empty values, version trimming an
 });
 
 test("Claude Code compatible effort and max token helpers cover priority fallbacks", () => {
-  const claudeModels = getModelsByProviderId("claude");
-  assert.equal(
-    claudeModels.find((model) => model.id === "claude-opus-4-7")?.supportsXHighEffort,
-    true
-  );
-  assert.equal(
-    claudeModels.find((model) => model.id === "claude-opus-4-6")?.supportsXHighEffort,
-    false
-  );
+  const { xhighModel, standardModel } = getClaudeEffortFixtures();
   assert.equal(resolveClaudeCodeCompatibleEffort({ reasoning_effort: "medium" }), "medium");
   assert.equal(resolveClaudeCodeCompatibleEffort({ reasoning: { effort: "none" } }), "low");
   assert.equal(
-    resolveClaudeCodeCompatibleEffort(
-      { output_config: { effort: "xhigh" } },
-      null,
-      "claude-opus-4-7"
-    ),
+    resolveClaudeCodeCompatibleEffort({ output_config: { effort: "xhigh" } }, null, xhighModel.id),
     "xhigh"
   );
   assert.equal(
     resolveClaudeCodeCompatibleEffort(
       { output_config: { effort: "xhigh" } },
       null,
-      "claude-opus-4-6"
+      standardModel.id
     ),
     "high"
   );

--- a/tests/unit/translator-openai-to-claude.test.ts
+++ b/tests/unit/translator-openai-to-claude.test.ts
@@ -11,6 +11,16 @@ const {
 const { CLAUDE_SYSTEM_PROMPT } = await import("../../open-sse/config/constants.ts");
 const { DEFAULT_THINKING_CLAUDE_SIGNATURE } =
   await import("../../open-sse/config/defaultThinkingSignature.ts");
+const { getModelsByProviderId } = await import("../../open-sse/config/providerModels.ts");
+
+function getClaudeEffortFixtures() {
+  const claudeModels = getModelsByProviderId("claude");
+  const xhighModel = claudeModels.find((model) => model.supportsXHighEffort === true);
+  const standardModel = claudeModels.find((model) => model.supportsXHighEffort === false);
+  assert.ok(xhighModel, "expected at least one Claude model with xhigh support");
+  assert.ok(standardModel, "expected at least one Claude model without xhigh support");
+  return { xhighModel, standardModel };
+}
 
 test("OpenAI -> Claude helpers normalize array content and strip empty nested text blocks", () => {
   const normalized = normalizeContentToString([
@@ -257,6 +267,33 @@ test("OpenAI -> Claude turns reasoning settings into thinking budgets and expand
     max_tokens: 3000,
   });
   assert.equal(explicitThinkingResult.max_tokens, 10192);
+});
+
+test("OpenAI -> Claude preserves xhigh only for Claude models that expose it", () => {
+  const { xhighModel, standardModel } = getClaudeEffortFixtures();
+  const preserved = openaiToClaudeRequest(
+    xhighModel.id,
+    {
+      messages: [{ role: "user", content: "Think harder" }],
+      reasoning_effort: "xhigh",
+    },
+    false
+  );
+  const downgraded = openaiToClaudeRequest(
+    standardModel.id,
+    {
+      messages: [{ role: "user", content: "Think harder" }],
+      max_tokens: 10,
+      reasoning_effort: "xhigh",
+    },
+    false
+  );
+
+  assert.deepEqual(preserved.thinking, { type: "adaptive" });
+  assert.deepEqual(preserved.output_config, { effort: "xhigh" });
+  assert.deepEqual(downgraded.thinking, { type: "enabled", budget_tokens: 131072 });
+  assert.equal(downgraded.output_config, undefined);
+  assert.equal(downgraded.max_tokens, 139264);
 });
 
 test("OpenAI -> Claude can disable OAuth prefixes and Antigravity strips Claude-only prompting", () => {


### PR DESCRIPTION
## Summary
- note that [Claude Opus 4.7 already supports `xhigh` effort](https://platform.claude.com/docs/en/build-with-claude/effort), so requests should preserve `xhigh` when the selected Claude model exposes that capability
- add a `supportsXHighEffort` flag to the shared Claude model registry and route both Claude OAuth and Claude Code compatible effort mapping through it
- keep the existing fallback to `high` for older Claude models and extend tests for both supported and unsupported branches

## Testing
- node --import tsx/esm --test tests/unit/claude-code-compatible-request.test.ts tests/unit/cc-compatible-provider.test.ts tests/unit/translator-openai-to-claude.test.ts