### PR TITLE
fix(providers): show detail page for Web/Search/Audio providers

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/[id]/page.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.tsx
@@ -26,6 +26,9 @@ import {
   FREE_PROVIDERS,
   OAUTH_PROVIDERS,
   APIKEY_PROVIDERS,
+  WEB_COOKIE_PROVIDERS,
+  SEARCH_PROVIDERS,
+  AUDIO_ONLY_PROVIDERS,
   getProviderAlias,
   isOpenAICompatibleProvider,
   isAnthropicCompatibleProvider,
@@ -979,7 +982,10 @@ export default function ProviderDetailPage() {
       }
     : (FREE_PROVIDERS as any)[providerId] ||
       (OAUTH_PROVIDERS as any)[providerId] ||
-      (APIKEY_PROVIDERS as any)[providerId];
+      (APIKEY_PROVIDERS as any)[providerId] ||
+      (WEB_COOKIE_PROVIDERS as any)[providerId] ||
+      (SEARCH_PROVIDERS as any)[providerId] ||
+      (AUDIO_ONLY_PROVIDERS as any)[providerId];
   const providerSupportsOAuth =
     !!(FREE_PROVIDERS as any)[providerId] || !!(OAUTH_PROVIDERS as any)[providerId];
   const providerSupportsPat = supportsApiKeyOnFreeProvider(providerId);


### PR DESCRIPTION
## Summary

Clicking any card under **Search Providers** (Perplexity Search, Serper, Brave, Exa, Tavily), **Audio Providers** (Deepgram, AssemblyAI, ElevenLabs, Cartesia, PlayHT, Inworld), or web-cookie providers on the `/dashboard/providers` index currently lands on an empty detail page with **"Provider not found"**.

## Root cause

`src/app/(dashboard)/dashboard/providers/[id]/page.tsx` builds `providerInfo` from a fallback chain that only checks three catalogs:

```ts
const providerInfo = providerNode
  ? { ...derived from DB row... }
  : (FREE_PROVIDERS as any)[providerId] ||
    (OAUTH_PROVIDERS as any)[providerId] ||
    (APIKEY_PROVIDERS as any)[providerId];
```

But the index page `src/app/(dashboard)/dashboard/providers/page.tsx` already renders cards for three additional catalogs that point at `/dashboard/providers/<id>`:

- `WEB_COOKIE_PROVIDERS` (perplexity-web, grok-web, …)
- `SEARCH_PROVIDERS` (perplexity-search, serper-search, brave-search, exa-search, tavily-search)
- `AUDIO_ONLY_PROVIDERS` (deepgram, assemblyai, elevenlabs, cartesia, playht, inworld)

None of these IDs end up in `FREE_PROVIDERS / OAUTH_PROVIDERS / APIKEY_PROVIDERS`, and they do not have a row in `provider_nodes` (they are not compatible-provider nodes), so `providerInfo` is `undefined` and the page renders the `providerNotFound` empty state.

## Fix

Extend the fallback chain on the detail page to also look up the same three catalogs that the list page already imports. No other behaviour is touched — the existing branches (`providerNode`, compatible providers, FREE/OAUTH/APIKEY) take priority exactly as before.

\`\`\`ts
  : (FREE_PROVIDERS as any)[providerId] ||
    (OAUTH_PROVIDERS as any)[providerId] ||
    (APIKEY_PROVIDERS as any)[providerId] ||
    (WEB_COOKIE_PROVIDERS as any)[providerId] ||
    (SEARCH_PROVIDERS as any)[providerId] ||
    (AUDIO_ONLY_PROVIDERS as any)[providerId];
\`\`\`

## Test plan

- [x] Reproduce before patch: open \`/dashboard/providers\`, click **Perplexity Search** / **Brave Search** / **Deepgram** / **ElevenLabs** / etc. → "Provider not found".
- [x] With patch: the same clicks open the normal provider detail view with header, icon, name, website link, and the per-provider connection list (empty when no connections yet).
- [x] Existing FREE/OAUTH/APIKEY providers keep their current detail page (short-circuit eval — new branches only run when earlier ones return falsy).
- [x] OpenAI-/Anthropic-compatible providers unaffected (they go through the \`providerNode\` branch).