### PR TITLE
fix(docker): copy postinstallSupport.mjs before npm ci in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update \
 
 COPY package*.json ./
 COPY scripts/postinstall.mjs ./scripts/postinstall.mjs
+COPY scripts/postinstallSupport.mjs ./scripts/postinstallSupport.mjs
 COPY scripts/native-binary-compat.mjs ./scripts/native-binary-compat.mjs
 RUN if [ -f package-lock.json ]; then npm ci --no-audit --no-fund; else npm install --no-audit --no-fund; fi
 


### PR DESCRIPTION
## Summary

- Added `scripts/postinstallSupport.mjs` to the files copied into the Docker image, ensuring this script is available during the build.Agent-Logs-Url: https://github.com/uwuclxdy/OmniRoute/sessions/cb9cd4a9-4f1e-4201-8327-a26c0f2c87d0

## Related Issues

- Fixes #1382

## Validation

- [x] `npm run lint`
- [x] `npm run test:unit`
- [x] `npm run test:coverage`
- [x] Coverage is still `>= 60%` for statements, lines, functions, and branches
- [x] SonarQube PR analysis is green or any remaining issues are explicitly documented below
