### PR TITLE
feat: add Claude Opus 4.7 support (adaptive-only thinking, sampling param constraints)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -58,9 +58,6 @@ vitest.config.ts
 vitest.mcp.config.ts
 eslint.config.mjs
 prettier.config.mjs
-tsconfig.json
-tsconfig.typecheck-core.json
-tsconfig.typecheck-noimplicit-core.json
 llm.txt
 
 # VS Code extension (separate project)

--- a/.dockerignore
+++ b/.dockerignore
@@ -40,10 +40,28 @@ blob-report
 # Documentation (not needed in container)
 docs
 *.md
-!README.md
 
 # Electron (separate build)
 electron
+
+# Container and CI metadata
+Dockerfile
+docker-compose.yml
+docker-compose.prod.yml
+fly.toml
+sonar-project.properties
+
+# Local engineering metadata
+AGENTS.md
+playwright.config.ts
+vitest.config.ts
+vitest.mcp.config.ts
+eslint.config.mjs
+prettier.config.mjs
+tsconfig.json
+tsconfig.typecheck-core.json
+tsconfig.typecheck-noimplicit-core.json
+llm.txt
 
 # VS Code extension (separate project)
 vscode-extension

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,7 +22,7 @@ jobs:
     name: Build and Push Docker (multi-arch)
     runs-on: ubuntu-latest
     env:
-      IMAGE_NAME: diegosouzapw/omniroute
+      IMAGE_NAME: i1hwan/apexroute
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -65,13 +65,13 @@ jobs:
         with:
           context: .
           target: runner-base
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: |
             ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
             ${{ env.IMAGE_NAME }}:latest
-            ghcr.io/diegosouzapw/omniroute:${{ steps.version.outputs.version }}
-            ghcr.io/diegosouzapw/omniroute:latest
+            ghcr.io/i1hwan/apexroute:${{ steps.version.outputs.version }}
+            ghcr.io/i1hwan/apexroute:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
           no-cache: false
@@ -87,6 +87,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-          repository: diegosouzapw/omniroute
+          repository: i1hwan/apexroute
           short-description: "OmniRoute — Unified AI proxy. Route any LLM through one endpoint."
           readme-filepath: ./README.md

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -81,12 +81,3 @@ jobs:
       - name: Inspect image
         run: |
           docker buildx imagetools inspect "${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}"
-
-      - name: Update Docker Hub description
-        uses: peter-evans/dockerhub-description@v4
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-          repository: i1hwan/apexroute
-          short-description: "OmniRoute — Unified AI proxy. Route any LLM through one endpoint."
-          readme-filepath: ./README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,6 +78,7 @@ COPY --from=builder /app/scripts/run-standalone.mjs ./run-standalone.mjs
 COPY --from=builder /app/scripts/runtime-env.mjs ./runtime-env.mjs
 COPY --from=builder /app/scripts/bootstrap-env.mjs ./bootstrap-env.mjs
 COPY --from=builder /app/scripts/healthcheck.mjs ./healthcheck.mjs
+COPY --from=builder /app/.env.example ./.env.example
 
 EXPOSE 20128
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,37 @@ COPY scripts/native-binary-compat.mjs ./scripts/native-binary-compat.mjs
 RUN if [ -f package-lock.json ]; then npm ci --no-audit --no-fund; else npm install --no-audit --no-fund; fi
 
 COPY . ./
-RUN mkdir -p /app/data && npm run build -- --webpack
+RUN mkdir -p /app/data \
+  && npm run build -- --webpack \
+  && rm -f /app/.next/standalone/.env \
+  && rm -rf \
+    /app/.next/standalone/.git \
+    /app/.next/standalone/coverage \
+    /app/.next/standalone/docs \
+    /app/.next/standalone/electron \
+    /app/.next/standalone/images \
+    /app/.next/standalone/logs \
+    /app/.next/standalone/tests \
+  && rm -f \
+    /app/.next/standalone/AGENTS.md \
+    /app/.next/standalone/CHANGELOG.md \
+    /app/.next/standalone/CONTRIBUTING.md \
+    /app/.next/standalone/Dockerfile \
+    /app/.next/standalone/README.md \
+    /app/.next/standalone/SECURITY.md \
+    /app/.next/standalone/docker-compose.yml \
+    /app/.next/standalone/docker-compose.prod.yml \
+    /app/.next/standalone/eslint.config.mjs \
+    /app/.next/standalone/fly.toml \
+    /app/.next/standalone/llm.txt \
+    /app/.next/standalone/playwright.config.ts \
+    /app/.next/standalone/prettier.config.mjs \
+    /app/.next/standalone/sonar-project.properties \
+    /app/.next/standalone/tsconfig.json \
+    /app/.next/standalone/tsconfig.typecheck-core.json \
+    /app/.next/standalone/tsconfig.typecheck-noimplicit-core.json \
+    /app/.next/standalone/vitest.config.ts \
+    /app/.next/standalone/vitest.mcp.config.ts
 
 FROM node:22.22.2-trixie-slim AS runner-base
 WORKDIR /app

--- a/open-sse/config/forwardingKeywordRules.ts
+++ b/open-sse/config/forwardingKeywordRules.ts
@@ -1,0 +1,161 @@
+type ForwardingKeywordLane = "claude-oauth-prefixed";
+
+type ForwardingKeywordRule = {
+  match: string;
+  replace: string;
+};
+
+type ForwardingTagRule = {
+  open: string;
+  openReplacement: string;
+  close: string;
+  closeReplacement: string;
+};
+
+type ForwardingKeywordRules = {
+  toolNames: ForwardingKeywordRule[];
+  text: ForwardingKeywordRule[];
+  tags: ForwardingTagRule[];
+};
+
+type ForwardingKeywordConfig = Record<ForwardingKeywordLane, ForwardingKeywordRules>;
+
+export const DEFAULT_FORWARDING_KEYWORD_CONFIG: ForwardingKeywordConfig = {
+  "claude-oauth-prefixed": {
+    toolNames: [
+      { match: "background_output", replace: "background_result" },
+      { match: "background_cancel", replace: "background_stop" },
+    ],
+    text: [
+      { match: "background_output", replace: "background_result" },
+      { match: "background_cancel", replace: "background_stop" },
+    ],
+    tags: [
+      {
+        open: "<directories>",
+        openReplacement: "directories:\n",
+        close: "</directories>",
+        closeReplacement: "",
+      },
+    ],
+  },
+};
+
+let forwardingKeywordConfig: ForwardingKeywordConfig = cloneForwardingKeywordConfig(
+  DEFAULT_FORWARDING_KEYWORD_CONFIG
+);
+
+function cloneForwardingKeywordConfig(config: ForwardingKeywordConfig): ForwardingKeywordConfig {
+  return JSON.parse(JSON.stringify(config)) as ForwardingKeywordConfig;
+}
+
+function normalizeKeywordRule(rule: unknown): ForwardingKeywordRule | null {
+  if (!rule || typeof rule !== "object") return null;
+  const candidate = rule as Record<string, unknown>;
+  if (typeof candidate.match !== "string" || typeof candidate.replace !== "string") return null;
+  return { match: candidate.match, replace: candidate.replace };
+}
+
+function normalizeTagRule(rule: unknown): ForwardingTagRule | null {
+  if (!rule || typeof rule !== "object") return null;
+  const candidate = rule as Record<string, unknown>;
+  if (
+    typeof candidate.open !== "string" ||
+    typeof candidate.openReplacement !== "string" ||
+    typeof candidate.close !== "string" ||
+    typeof candidate.closeReplacement !== "string"
+  ) {
+    return null;
+  }
+
+  return {
+    open: candidate.open,
+    openReplacement: candidate.openReplacement,
+    close: candidate.close,
+    closeReplacement: candidate.closeReplacement,
+  };
+}
+
+export function normalizeForwardingKeywordConfig(value: unknown): ForwardingKeywordConfig {
+  const normalized = cloneForwardingKeywordConfig(DEFAULT_FORWARDING_KEYWORD_CONFIG);
+  if (!value || typeof value !== "object") return normalized;
+
+  const rawConfig = value as Record<string, unknown>;
+  for (const lane of Object.keys(DEFAULT_FORWARDING_KEYWORD_CONFIG) as ForwardingKeywordLane[]) {
+    const rawLane = rawConfig[lane];
+    if (!rawLane || typeof rawLane !== "object") continue;
+
+    const rawLaneConfig = rawLane as Record<string, unknown>;
+    const toolNames = Array.isArray(rawLaneConfig.toolNames)
+      ? rawLaneConfig.toolNames.map(normalizeKeywordRule).filter(Boolean)
+      : normalized[lane].toolNames;
+    const text = Array.isArray(rawLaneConfig.text)
+      ? rawLaneConfig.text.map(normalizeKeywordRule).filter(Boolean)
+      : normalized[lane].text;
+    const tags = Array.isArray(rawLaneConfig.tags)
+      ? rawLaneConfig.tags.map(normalizeTagRule).filter(Boolean)
+      : normalized[lane].tags;
+
+    normalized[lane] = {
+      toolNames,
+      text,
+      tags,
+    };
+  }
+
+  return normalized;
+}
+
+export function setForwardingKeywordConfig(config: unknown) {
+  forwardingKeywordConfig = normalizeForwardingKeywordConfig(config);
+}
+
+export function getForwardingKeywordConfig(): ForwardingKeywordConfig {
+  return cloneForwardingKeywordConfig(forwardingKeywordConfig);
+}
+
+export function getDefaultForwardingKeywordConfig(): ForwardingKeywordConfig {
+  return cloneForwardingKeywordConfig(DEFAULT_FORWARDING_KEYWORD_CONFIG);
+}
+
+export function rewriteForwardedTextForLane(lane: ForwardingKeywordLane, text: string): string {
+  if (!text) return text;
+
+  let rewrittenText = text;
+  const rules = forwardingKeywordConfig[lane];
+
+  for (const rule of rules.text) {
+    rewrittenText = rewrittenText.replaceAll(rule.match, rule.replace);
+  }
+
+  for (const tagRule of rules.tags) {
+    rewrittenText = rewrittenText
+      .replaceAll(tagRule.open, tagRule.openReplacement)
+      .replaceAll(tagRule.close, tagRule.closeReplacement);
+  }
+
+  return rewrittenText;
+}
+
+export function rewriteForwardedToolNameForLane(
+  lane: ForwardingKeywordLane,
+  toolName: string
+): string {
+  const rules = forwardingKeywordConfig[lane];
+  const matchingRule = rules.toolNames.find((rule) => rule.match === toolName);
+  return matchingRule?.replace ?? toolName;
+}
+
+export function getForwardingKeywordRulesForLane(
+  lane: ForwardingKeywordLane
+): ForwardingKeywordRules {
+  return cloneForwardingKeywordConfig(forwardingKeywordConfig)[lane];
+}
+
+export type {
+  ForwardingKeywordConfig,
+  ForwardingKeywordLane,
+  ForwardingKeywordRule,
+  ForwardingKeywordRules,
+  ForwardingTagRule,
+};

--- a/open-sse/config/forwardingKeywordRules.ts
+++ b/open-sse/config/forwardingKeywordRules.ts
@@ -49,29 +49,38 @@ function cloneForwardingKeywordConfig(config: ForwardingKeywordConfig): Forwardi
   return JSON.parse(JSON.stringify(config)) as ForwardingKeywordConfig;
 }
 
+function normalizeNonEmptyString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const normalizedValue = value.trim();
+  return normalizedValue ? normalizedValue : null;
+}
+
 function normalizeKeywordRule(rule: unknown): ForwardingKeywordRule | null {
   if (!rule || typeof rule !== "object") return null;
   const candidate = rule as Record<string, unknown>;
-  if (typeof candidate.match !== "string" || typeof candidate.replace !== "string") return null;
-  return { match: candidate.match, replace: candidate.replace };
+  const match = normalizeNonEmptyString(candidate.match);
+  if (!match || typeof candidate.replace !== "string") return null;
+  return { match, replace: candidate.replace };
 }
 
 function normalizeTagRule(rule: unknown): ForwardingTagRule | null {
   if (!rule || typeof rule !== "object") return null;
   const candidate = rule as Record<string, unknown>;
+  const open = normalizeNonEmptyString(candidate.open);
+  const close = normalizeNonEmptyString(candidate.close);
   if (
-    typeof candidate.open !== "string" ||
+    !open ||
     typeof candidate.openReplacement !== "string" ||
-    typeof candidate.close !== "string" ||
+    !close ||
     typeof candidate.closeReplacement !== "string"
   ) {
     return null;
   }
 
   return {
-    open: candidate.open,
+    open,
     openReplacement: candidate.openReplacement,
-    close: candidate.close,
+    close,
     closeReplacement: candidate.closeReplacement,
   };
 }
@@ -108,6 +117,15 @@ export function normalizeForwardingKeywordConfig(value: unknown): ForwardingKeyw
 
 export function setForwardingKeywordConfig(config: unknown) {
   forwardingKeywordConfig = normalizeForwardingKeywordConfig(config);
+}
+
+export function applyForwardingKeywordSettings(settings: Record<string, unknown>) {
+  if (Object.prototype.hasOwnProperty.call(settings, "forwardingKeywordRules")) {
+    setForwardingKeywordConfig(settings.forwardingKeywordRules);
+    return;
+  }
+
+  setForwardingKeywordConfig(getDefaultForwardingKeywordConfig());
 }
 
 export function getForwardingKeywordConfig(): ForwardingKeywordConfig {

--- a/open-sse/config/forwardingKeywordRules.ts
+++ b/open-sse/config/forwardingKeywordRules.ts
@@ -85,6 +85,34 @@ function normalizeTagRule(rule: unknown): ForwardingTagRule | null {
   };
 }
 
+function mergeKeywordRules(
+  defaults: ForwardingKeywordRule[],
+  overrides: ForwardingKeywordRule[]
+): ForwardingKeywordRule[] {
+  if (overrides.length === 0) return defaults;
+
+  const merged = new Map(defaults.map((rule) => [rule.match, rule]));
+  for (const override of overrides) {
+    merged.set(override.match, override);
+  }
+
+  return Array.from(merged.values());
+}
+
+function mergeTagRules(
+  defaults: ForwardingTagRule[],
+  overrides: ForwardingTagRule[]
+): ForwardingTagRule[] {
+  if (overrides.length === 0) return defaults;
+
+  const merged = new Map(defaults.map((rule) => [`${rule.open}::${rule.close}`, rule]));
+  for (const override of overrides) {
+    merged.set(`${override.open}::${override.close}`, override);
+  }
+
+  return Array.from(merged.values());
+}
+
 export function normalizeForwardingKeywordConfig(value: unknown): ForwardingKeywordConfig {
   const normalized = cloneForwardingKeywordConfig(DEFAULT_FORWARDING_KEYWORD_CONFIG);
   if (!value || typeof value !== "object") return normalized;
@@ -95,20 +123,20 @@ export function normalizeForwardingKeywordConfig(value: unknown): ForwardingKeyw
     if (!rawLane || typeof rawLane !== "object") continue;
 
     const rawLaneConfig = rawLane as Record<string, unknown>;
-    const toolNames = Array.isArray(rawLaneConfig.toolNames)
+    const toolNameOverrides = Array.isArray(rawLaneConfig.toolNames)
       ? rawLaneConfig.toolNames.map(normalizeKeywordRule).filter(Boolean)
-      : normalized[lane].toolNames;
-    const text = Array.isArray(rawLaneConfig.text)
+      : [];
+    const textOverrides = Array.isArray(rawLaneConfig.text)
       ? rawLaneConfig.text.map(normalizeKeywordRule).filter(Boolean)
-      : normalized[lane].text;
-    const tags = Array.isArray(rawLaneConfig.tags)
+      : [];
+    const tagOverrides = Array.isArray(rawLaneConfig.tags)
       ? rawLaneConfig.tags.map(normalizeTagRule).filter(Boolean)
-      : normalized[lane].tags;
+      : [];
 
     normalized[lane] = {
-      toolNames,
-      text,
-      tags,
+      toolNames: mergeKeywordRules(normalized[lane].toolNames, toolNameOverrides),
+      text: mergeKeywordRules(normalized[lane].text, textOverrides),
+      tags: mergeTagRules(normalized[lane].tags, tagOverrides),
     };
   }
 

--- a/open-sse/config/providerRegistry.ts
+++ b/open-sse/config/providerRegistry.ts
@@ -165,6 +165,7 @@ export const REGISTRY: Record<string, RegistryEntry> = {
       tokenUrl: "https://console.anthropic.com/v1/oauth/token",
     },
     models: [
+      { id: "claude-opus-4-7", name: "Claude Opus 4.7" },
       { id: "claude-opus-4-6", name: "Claude Opus 4.6" },
       { id: "claude-sonnet-4-6", name: "Claude 4.6 Sonnet" },
       { id: "claude-opus-4-5-20251101", name: "Claude 4.5 Opus" },

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -1,6 +1,7 @@
 import { getCorsOrigin } from "../utils/cors.ts";
 import { detectFormatFromEndpoint, getTargetFormat } from "../services/provider.ts";
 import { translateRequest, needsTranslation } from "../translator/index.ts";
+import { applyThinkingBudget } from "../services/thinkingBudget.ts";
 import { FORMATS } from "../translator/formats.ts";
 import {
   createSSETransformStreamWithLogger,
@@ -1018,7 +1019,9 @@ export async function handleChatCore({
       // as-is without prior normalization. The OpenAI round-trip would strip
       // cache_control markers; even prepareClaudeRequest can alter structure.
       // Claude Code sends well-formed Messages API payloads — trust it.
-      translatedBody = { ...body };
+      // Still apply thinking budget to convert reasoning_effort → Claude thinking
+      // (applyThinkingBudget only touches thinking/reasoning fields, preserves cache_control).
+      translatedBody = applyThinkingBudget({ ...body });
       translatedBody._disableToolPrefix = true;
       if (provider === "claude") {
         const lexicalRewrite = applyClaudeOAuthLexicalRewrite(translatedBody);

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -1081,7 +1081,7 @@ export async function handleChatCore({
       // conflicts with Claude OAuth tools, but in the passthrough path the tools
       // are already in Claude format. Applying the prefix turns "Bash" into
       // "proxy_Bash", which Claude rejects ("No such tool available: proxy_Bash").
-      if (targetFormat === FORMATS.CLAUDE) {
+      if (sourceFormat === FORMATS.CLAUDE && targetFormat === FORMATS.CLAUDE) {
         translatedBody._disableToolPrefix = true;
       }
 

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -69,6 +69,7 @@ import {
 import { invalidateCodexQuotaCache } from "../services/codexQuotaFetcher.ts";
 import { translateNonStreamingResponse } from "./responseTranslator.ts";
 import { extractUsageFromResponse } from "./usageExtractor.ts";
+import { applyClaudeOAuthLexicalRewrite } from "../translator/helpers/claudeHelper.ts";
 import {
   parseSSEToClaudeResponse,
   parseSSEToOpenAIResponse,
@@ -1019,6 +1020,13 @@ export async function handleChatCore({
       // Claude Code sends well-formed Messages API payloads — trust it.
       translatedBody = { ...body };
       translatedBody._disableToolPrefix = true;
+      if (provider === "claude") {
+        const lexicalRewrite = applyClaudeOAuthLexicalRewrite(translatedBody);
+        translatedBody = lexicalRewrite.body;
+        if (lexicalRewrite.toolNameMap) {
+          translatedBody._toolNameMap = lexicalRewrite.toolNameMap;
+        }
+      }
 
       log?.debug?.("FORMAT", "claude passthrough with cache_control preservation");
     } else if (isClaudePassthrough) {
@@ -1057,6 +1065,13 @@ export async function handleChatCore({
         reqLogger,
         { normalizeToolCallId, preserveDeveloperRole, preserveCacheControl }
       );
+      if (provider === "claude") {
+        const lexicalRewrite = applyClaudeOAuthLexicalRewrite(translatedBody);
+        translatedBody = lexicalRewrite.body;
+        if (lexicalRewrite.toolNameMap) {
+          translatedBody._toolNameMap = lexicalRewrite.toolNameMap;
+        }
+      }
       log?.debug?.("FORMAT", "claude->openai->claude normalized passthrough");
     } else {
       translatedBody = { ...body };

--- a/open-sse/handlers/responseTranslator.ts
+++ b/open-sse/handlers/responseTranslator.ts
@@ -426,13 +426,27 @@ export function translateNonStreamingResponse(
 
       const usage = toRecord(root.usage);
       if (Object.keys(usage).length > 0) {
-        const promptTokens = toNumber(usage.input_tokens, 0);
+        const inputTokens = toNumber(usage.input_tokens, 0);
         const completionTokens = toNumber(usage.output_tokens, 0);
+        const cacheReadTokens = toNumber(usage.cache_read_input_tokens, 0);
+        const cacheCreationTokens = toNumber(usage.cache_creation_input_tokens, 0);
+        const promptTokens = inputTokens + cacheReadTokens + cacheCreationTokens;
         result.usage = {
           prompt_tokens: promptTokens,
           completion_tokens: completionTokens,
           total_tokens: promptTokens + completionTokens,
         };
+
+        if (cacheReadTokens > 0 || cacheCreationTokens > 0) {
+          (result.usage as JsonRecord).prompt_tokens_details = {};
+          const promptDetails = (result.usage as JsonRecord).prompt_tokens_details as JsonRecord;
+          if (cacheReadTokens > 0) {
+            promptDetails.cached_tokens = cacheReadTokens;
+          }
+          if (cacheCreationTokens > 0) {
+            promptDetails.cache_creation_tokens = cacheCreationTokens;
+          }
+        }
       }
 
       intermediateOpenAI = result;

--- a/open-sse/services/claudeCodeCompatible.ts
+++ b/open-sse/services/claudeCodeCompatible.ts
@@ -235,7 +235,7 @@ export function resolveClaudeCodeCompatibleEffort(
   sourceBody?: Record<string, unknown> | null,
   normalizedBody?: Record<string, unknown> | null,
   model?: string | null
-): "low" | "medium" | "high" | "max" {
+): "low" | "medium" | "high" | "max" | "xhigh" {
   const raw =
     readNestedString(sourceBody, ["output_config", "effort"]) ||
     readNestedString(sourceBody, ["reasoning", "effort"]) ||
@@ -253,8 +253,11 @@ export function resolveClaudeCodeCompatibleEffort(
   if (normalizedEffort === "medium") return "medium";
   if (normalizedEffort === "high") return "high";
   if (normalizedEffort === "none" || normalizedEffort === "disabled") return "low";
-  if (normalizedEffort === "max" || normalizedEffort === "xhigh") {
+  if (normalizedEffort === "max") {
     return "max";
+  }
+  if (normalizedEffort === "xhigh") {
+    return "xhigh";
   }
   return "high";
 }

--- a/open-sse/services/claudeCodeCompatible.ts
+++ b/open-sse/services/claudeCodeCompatible.ts
@@ -1,6 +1,9 @@
 import { createHash, randomUUID } from "node:crypto";
 
-import { prepareClaudeRequest } from "../translator/helpers/claudeHelper.ts";
+import {
+  applyClaudeOAuthLexicalRewrite,
+  prepareClaudeRequest,
+} from "../translator/helpers/claudeHelper.ts";
 
 export const CLAUDE_CODE_COMPATIBLE_PREFIX = "anthropic-compatible-cc-";
 export const CLAUDE_CODE_COMPATIBLE_DEFAULT_CHAT_PATH = "/v1/messages?beta=true";
@@ -180,11 +183,13 @@ export function buildClaudeCodeCompatibleRequest({
   const toolChoice =
     tools.length > 0
       ? buildClaudeCodeCompatibleToolChoice(
-          normalizedBody?.["tool_choice"] ?? sourceBody?.["tool_choice"]
+          preparedClaudeBody?.tool_choice ??
+            normalizedBody?.["tool_choice"] ??
+            sourceBody?.["tool_choice"]
         )
       : undefined;
 
-  return {
+  const requestBody = {
     model,
     messages,
     system,
@@ -217,6 +222,13 @@ export function buildClaudeCodeCompatibleRequest({
     ...(toolChoice ? { tool_choice: toolChoice } : {}),
     ...(stream ? { stream: true } : {}),
   };
+
+  const lexicalRewrite = applyClaudeOAuthLexicalRewrite(requestBody);
+  if (lexicalRewrite.toolNameMap) {
+    lexicalRewrite.body._toolNameMap = lexicalRewrite.toolNameMap;
+  }
+
+  return lexicalRewrite.body;
 }
 
 export function resolveClaudeCodeCompatibleEffort(
@@ -539,6 +551,7 @@ function prepareClaudeCodeCompatibleBody(
       system: normalizeClaudeSystemInput(claudeBody.system),
       messages: normalizeClaudeMessageInput(claudeBody.messages),
       tools: normalizeClaudeToolInput(claudeBody.tools),
+      tool_choice: readRecord(claudeBody.tool_choice) || claudeBody.tool_choice,
       thinking: readRecord(claudeBody.thinking) || claudeBody.thinking,
     },
     CLAUDE_CODE_COMPATIBLE_PREFIX,

--- a/open-sse/services/claudeCodeCompatible.ts
+++ b/open-sse/services/claudeCodeCompatible.ts
@@ -235,7 +235,7 @@ export function resolveClaudeCodeCompatibleEffort(
   sourceBody?: Record<string, unknown> | null,
   normalizedBody?: Record<string, unknown> | null,
   model?: string | null
-): "low" | "medium" | "high" {
+): "low" | "medium" | "high" | "max" {
   const raw =
     readNestedString(sourceBody, ["output_config", "effort"]) ||
     readNestedString(sourceBody, ["reasoning", "effort"]) ||
@@ -254,7 +254,7 @@ export function resolveClaudeCodeCompatibleEffort(
   if (normalizedEffort === "high") return "high";
   if (normalizedEffort === "none" || normalizedEffort === "disabled") return "low";
   if (normalizedEffort === "max" || normalizedEffort === "xhigh") {
-    return "high";
+    return "max";
   }
   return "high";
 }

--- a/open-sse/services/provider.ts
+++ b/open-sse/services/provider.ts
@@ -369,13 +369,25 @@ export function hasThinkingConfig(body) {
   return !!(body.reasoning_effort || body.thinking?.type === "enabled");
 }
 
-// Normalize thinking config based on last message role
-// - If lastMessage is not user → remove thinking config
-// - If lastMessage is user AND has thinking config → keep it (force enable)
-export function normalizeThinkingConfig(body) {
+// Normalize thinking config based on last message role and target format.
+//
+// Anthropic Messages API is stateless: thinking/output_config must be sent on
+// every request. Stripping them when the last message is not user breaks
+// multi-turn tool-use flows (assistant+tool_use → tool_result → model response)
+// where thinking is still required.
+//
+// For non-Claude targets, the original "last must be user" heuristic is kept
+// because OpenAI/Gemini have different semantics around reasoning fields when
+// the last message is assistant.
+export function normalizeThinkingConfig(body, targetFormat) {
+  const isClaudeTarget = targetFormat === "claude";
+  if (isClaudeTarget) {
+    return body;
+  }
   if (!isLastMessageFromUser(body)) {
     delete body.reasoning_effort;
     delete body.thinking;
+    delete body.output_config;
   }
   return body;
 }

--- a/open-sse/services/provider.ts
+++ b/open-sse/services/provider.ts
@@ -366,7 +366,11 @@ export function isLastMessageFromUser(body) {
 
 // Check if request has thinking config
 export function hasThinkingConfig(body) {
-  return !!(body.reasoning_effort || body.thinking?.type === "enabled");
+  return !!(
+    body.reasoning_effort ||
+    body.thinking?.type === "enabled" ||
+    body.thinking?.type === "adaptive"
+  );
 }
 
 // Normalize thinking config based on last message role and target format.

--- a/open-sse/services/thinkingBudget.ts
+++ b/open-sse/services/thinkingBudget.ts
@@ -164,6 +164,8 @@ export function applyThinkingBudget(body, config = null) {
   // Early exit: strip ALL reasoning/thinking params for models that don't support them.
   // Sending thinking params to unsupported models (e.g. AG claude-sonnet-4-6) causes 400 errors.
   const modelStr = typeof body.model === "string" ? body.model : "";
+  const originalHasExplicitThinking = hasExplicitThinkingConfig(body);
+  const originalHasThinkingLevelSignal = hasThinkingLevelSignal(body);
   if (modelStr && !supportsReasoning(modelStr)) {
     return stripThinkingConfig(body);
   }
@@ -175,8 +177,11 @@ export function applyThinkingBudget(body, config = null) {
   processed = ensureThinkingConfig(processed);
 
   if (isClaudeModel(modelStr)) {
-    if (!hasExplicitThinkingConfig(processed) && hasExplicitEffortSignal(processed)) {
-      return setAdaptiveClaudeThinking(processed, cfg);
+    if (
+      !originalHasExplicitThinking &&
+      (hasExplicitEffortSignal(processed) || originalHasThinkingLevelSignal)
+    ) {
+      return setAdaptiveClaudeThinking(processed, cfg, body);
     }
 
     if (cfg.mode === ThinkingMode.ADAPTIVE) {
@@ -214,19 +219,48 @@ function hasExplicitEffortSignal(body) {
   return Boolean(body?.output_config?.effort || body?.reasoning?.effort || body?.reasoning_effort);
 }
 
-function resolveAnthropicEffort(body, cfg) {
+function hasThinkingLevelSignal(body) {
+  const level = body?.thinkingLevel || body?.thinking_level;
+  return typeof level === "string" && level.trim().length > 0;
+}
+
+function thinkingLevelToEffort(level) {
+  const normalized = String(level || "")
+    .trim()
+    .toLowerCase();
+
+  if (normalized === "none" || normalized === "disabled") return "low";
+  if (normalized === "low") return "low";
+  if (normalized === "medium") return "medium";
+  if (normalized === "high") return "high";
+  if (normalized === "max") return "max";
+  if (normalized === "xhigh") return "xhigh";
+  return null;
+}
+
+function resolveAnthropicEffort(body, cfg, originalBody = body) {
+  const levelEffort = thinkingLevelToEffort(
+    originalBody?.thinkingLevel ||
+      originalBody?.thinking_level ||
+      body?.thinkingLevel ||
+      body?.thinking_level
+  );
   const rawEffort =
+    originalBody?.output_config?.effort ||
+    originalBody?.reasoning?.effort ||
+    originalBody?.reasoning_effort ||
     body?.output_config?.effort ||
     body?.reasoning?.effort ||
     body?.reasoning_effort ||
+    levelEffort ||
     cfg.effortLevel ||
     "max";
   return String(rawEffort || cfg.effortLevel || "max").toLowerCase();
 }
 
-function setAdaptiveClaudeThinking(body, cfg) {
+function setAdaptiveClaudeThinking(body, cfg, originalBody = body) {
   const result = { ...body };
-  const effort = resolveAnthropicEffort(result, cfg);
+  const effort = resolveAnthropicEffort(result, cfg, originalBody);
 
   result.thinking = { type: "adaptive" };
   result.output_config = {

--- a/open-sse/services/thinkingBudget.ts
+++ b/open-sse/services/thinkingBudget.ts
@@ -175,7 +175,11 @@ export function applyThinkingBudget(body, config = null) {
   processed = ensureThinkingConfig(processed);
 
   if (isClaudeModel(modelStr) && cfg.mode === ThinkingMode.ADAPTIVE) {
-    return setAdaptiveClaudeThinking(processed, cfg);
+    if (!hasExplicitThinkingConfig(processed) && hasExplicitEffortSignal(processed)) {
+      return setAdaptiveClaudeThinking(processed, cfg);
+    }
+
+    return processed;
   }
 
   switch (cfg.mode) {
@@ -200,26 +204,22 @@ function isClaudeModel(model) {
   return typeof model === "string" && model.toLowerCase().includes("claude");
 }
 
+function hasExplicitThinkingConfig(body) {
+  return Boolean(body?.thinking);
+}
+
+function hasExplicitEffortSignal(body) {
+  return Boolean(body?.output_config?.effort || body?.reasoning?.effort || body?.reasoning_effort);
+}
+
 function resolveAnthropicEffort(body, cfg) {
   const rawEffort =
     body?.output_config?.effort ||
     body?.reasoning?.effort ||
     body?.reasoning_effort ||
-    cfg.effortLevel;
-  const normalized = String(rawEffort || "").toLowerCase();
-
-  if (
-    normalized === "low" ||
-    normalized === "medium" ||
-    normalized === "high" ||
-    normalized === "max"
-  ) {
-    return normalized;
-  }
-  if (normalized === "none" || normalized === "disabled") {
-    return "low";
-  }
-  return cfg.effortLevel || "max";
+    cfg.effortLevel ||
+    "max";
+  return String(rawEffort || cfg.effortLevel || "max").toLowerCase();
 }
 
 function setAdaptiveClaudeThinking(body, cfg) {

--- a/open-sse/services/thinkingBudget.ts
+++ b/open-sse/services/thinkingBudget.ts
@@ -174,12 +174,14 @@ export function applyThinkingBudget(body, config = null) {
   // Pre-processing: auto-inject thinking config for -thinking suffix models
   processed = ensureThinkingConfig(processed);
 
-  if (isClaudeModel(modelStr) && cfg.mode === ThinkingMode.ADAPTIVE) {
+  if (isClaudeModel(modelStr)) {
     if (!hasExplicitThinkingConfig(processed) && hasExplicitEffortSignal(processed)) {
       return setAdaptiveClaudeThinking(processed, cfg);
     }
 
-    return processed;
+    if (cfg.mode === ThinkingMode.ADAPTIVE) {
+      return processed;
+    }
   }
 
   switch (cfg.mode) {

--- a/open-sse/services/thinkingBudget.ts
+++ b/open-sse/services/thinkingBudget.ts
@@ -39,9 +39,9 @@ export const THINKING_LEVEL_MAP = {
 
 // Default config (passthrough = backward compatible)
 export const DEFAULT_THINKING_CONFIG = {
-  mode: ThinkingMode.PASSTHROUGH,
+  mode: ThinkingMode.ADAPTIVE,
   customBudget: 10240,
-  effortLevel: "medium",
+  effortLevel: "max",
 };
 
 // In-memory config (loaded from DB on startup, or default)
@@ -59,6 +59,15 @@ export function setThinkingBudgetConfig(config) {
  */
 export function getThinkingBudgetConfig() {
   return { ..._config };
+}
+
+export function applyThinkingBudgetSettings(settings) {
+  if (settings && typeof settings === "object" && settings.thinkingBudget) {
+    setThinkingBudgetConfig(settings.thinkingBudget);
+    return;
+  }
+
+  setThinkingBudgetConfig(DEFAULT_THINKING_CONFIG);
 }
 
 /**
@@ -165,6 +174,10 @@ export function applyThinkingBudget(body, config = null) {
   // Pre-processing: auto-inject thinking config for -thinking suffix models
   processed = ensureThinkingConfig(processed);
 
+  if (isClaudeModel(modelStr) && cfg.mode === ThinkingMode.ADAPTIVE) {
+    return setAdaptiveClaudeThinking(processed, cfg);
+  }
+
   switch (cfg.mode) {
     case ThinkingMode.AUTO:
       return stripThinkingConfig(processed);
@@ -181,6 +194,50 @@ export function applyThinkingBudget(body, config = null) {
     default:
       return processed;
   }
+}
+
+function isClaudeModel(model) {
+  return typeof model === "string" && model.toLowerCase().includes("claude");
+}
+
+function resolveAnthropicEffort(body, cfg) {
+  const rawEffort =
+    body?.output_config?.effort ||
+    body?.reasoning?.effort ||
+    body?.reasoning_effort ||
+    cfg.effortLevel;
+  const normalized = String(rawEffort || "").toLowerCase();
+
+  if (
+    normalized === "low" ||
+    normalized === "medium" ||
+    normalized === "high" ||
+    normalized === "max"
+  ) {
+    return normalized;
+  }
+  if (normalized === "none" || normalized === "disabled") {
+    return "low";
+  }
+  return cfg.effortLevel || "max";
+}
+
+function setAdaptiveClaudeThinking(body, cfg) {
+  const result = { ...body };
+  const effort = resolveAnthropicEffort(result, cfg);
+
+  result.thinking = { type: "adaptive" };
+  result.output_config = {
+    ...(result.output_config && typeof result.output_config === "object"
+      ? result.output_config
+      : {}),
+    effort,
+  };
+
+  delete result.thinkingLevel;
+  delete result.thinking_level;
+
+  return result;
 }
 
 /**

--- a/open-sse/services/thinkingBudget.ts
+++ b/open-sse/services/thinkingBudget.ts
@@ -13,7 +13,12 @@ export const ThinkingMode = {
   ADAPTIVE: "adaptive", // Scale based on request complexity
 };
 
-import { capThinkingBudget, getDefaultThinkingBudget } from "@/shared/constants/modelSpecs";
+import {
+  capThinkingBudget,
+  getDefaultThinkingBudget,
+  isAdaptiveOnlyModel,
+  downgradeEffort,
+} from "@/shared/constants/modelSpecs";
 import { supportsReasoning } from "./modelCapabilities.ts";
 
 // Effort → budget token mapping
@@ -133,17 +138,19 @@ export function ensureThinkingConfig(body) {
   if (!body || typeof body !== "object") return body;
   const model = body.model || "";
 
-  // Only auto-inject for models with -thinking suffix
   if (!model.endsWith("-thinking")) return body;
 
-  // If thinking config already present, don't override
   if (body.thinking) return body;
 
   const result = { ...body };
-  result.thinking = {
-    type: "enabled",
-    budget_tokens: getDefaultThinkingBudget(model) || EFFORT_BUDGETS.medium,
-  };
+  if (isAdaptiveOnlyModel(model)) {
+    result.thinking = { type: "adaptive" };
+  } else {
+    result.thinking = {
+      type: "enabled",
+      budget_tokens: getDefaultThinkingBudget(model) || EFFORT_BUDGETS.medium,
+    };
+  }
   return result;
 }
 
@@ -181,30 +188,38 @@ export function applyThinkingBudget(body, config = null) {
       !originalHasExplicitThinking &&
       (hasExplicitEffortSignal(processed) || originalHasThinkingLevelSignal)
     ) {
-      return setAdaptiveClaudeThinking(processed, cfg, body);
+      return coerceThinkingForModel(setAdaptiveClaudeThinking(processed, cfg, body), modelStr);
     }
 
     if (cfg.mode === ThinkingMode.ADAPTIVE) {
-      return processed;
+      return coerceThinkingForModel(processed, modelStr);
     }
   }
 
+  let result;
   switch (cfg.mode) {
     case ThinkingMode.AUTO:
-      return stripThinkingConfig(processed);
+      result = stripThinkingConfig(processed);
+      break;
 
     case ThinkingMode.PASSTHROUGH:
-      return processed;
+      result = processed;
+      break;
 
     case ThinkingMode.CUSTOM:
-      return setCustomBudget(processed, cfg.customBudget);
+      result = setCustomBudget(processed, cfg.customBudget);
+      break;
 
     case ThinkingMode.ADAPTIVE:
-      return applyAdaptiveBudget(processed, cfg);
+      result = applyAdaptiveBudget(processed, cfg);
+      break;
 
     default:
-      return processed;
+      result = processed;
+      break;
   }
+
+  return coerceThinkingForModel(result, modelStr);
 }
 
 function isClaudeModel(model) {
@@ -236,6 +251,38 @@ function thinkingLevelToEffort(level) {
   if (normalized === "max") return "max";
   if (normalized === "xhigh") return "xhigh";
   return null;
+}
+
+function coerceThinkingForModel(body, modelStr) {
+  if (!body || typeof body !== "object") return body;
+  if (!modelStr || !isAdaptiveOnlyModel(modelStr)) return body;
+
+  if (!body.thinking || body.thinking.type === "disabled") return body;
+
+  if (body.thinking.type !== "adaptive") {
+    const result = { ...body };
+    const currentEffort =
+      result.output_config?.effort || result.reasoning_effort || result.reasoning?.effort || "high";
+    result.thinking = { type: "adaptive" };
+    result.output_config = {
+      ...(result.output_config && typeof result.output_config === "object"
+        ? result.output_config
+        : {}),
+      effort: downgradeEffort(modelStr, String(currentEffort).toLowerCase()),
+    };
+    return result;
+  }
+
+  if (body.output_config?.effort) {
+    const result = { ...body };
+    result.output_config = {
+      ...result.output_config,
+      effort: downgradeEffort(modelStr, String(body.output_config.effort).toLowerCase()),
+    };
+    return result;
+  }
+
+  return body;
 }
 
 function resolveAnthropicEffort(body, cfg, originalBody = body) {

--- a/open-sse/services/tokenRefresh.ts
+++ b/open-sse/services/tokenRefresh.ts
@@ -228,15 +228,14 @@ export async function refreshClaudeOAuthToken(refreshToken, log, proxyConfig = n
       client_id: PROVIDERS.claude.clientId,
     };
 
-    const makeRequest = (contentType) =>
+    const makeRequest = (contentType, extraHeaders = {}) =>
       runWithProxyContext(proxyConfig, () =>
         fetch(OAUTH_ENDPOINTS.anthropic.token, {
           method: "POST",
           headers: {
             "Content-Type": contentType,
             Accept: "application/json",
-            "User-Agent": "anthropic",
-            "anthropic-beta": "oauth-2025-04-20",
+            ...extraHeaders,
           },
           body:
             contentType === "application/json"
@@ -249,10 +248,10 @@ export async function refreshClaudeOAuthToken(refreshToken, log, proxyConfig = n
 
     if (!response.ok) {
       const initialErrorText = await response.text();
-      const shouldRetryAsForm =
+      const shouldRetry =
         response.status === 400 && /invalid request format/i.test(initialErrorText || "");
 
-      if (!shouldRetryAsForm) {
+      if (!shouldRetry) {
         log?.error?.("TOKEN_REFRESH", "Failed to refresh Claude OAuth token", {
           status: response.status,
           error: initialErrorText,
@@ -262,9 +261,30 @@ export async function refreshClaudeOAuthToken(refreshToken, log, proxyConfig = n
 
       log?.warn?.(
         "TOKEN_REFRESH",
-        "Claude OAuth refresh rejected JSON payload, retrying as form-encoded"
+        "Claude OAuth refresh rejected base JSON contract, retrying alternate formats"
       );
-      response = await makeRequest("application/x-www-form-urlencoded");
+
+      response = await makeRequest("application/json", { "User-Agent": "anthropic" });
+
+      if (!response.ok) {
+        const secondErrorText = await response.text();
+        const shouldRetryAsForm =
+          response.status === 400 && /invalid request format/i.test(secondErrorText || "");
+
+        if (!shouldRetryAsForm) {
+          log?.error?.("TOKEN_REFRESH", "Failed to refresh Claude OAuth token", {
+            status: response.status,
+            error: secondErrorText,
+          });
+          return null;
+        }
+
+        log?.warn?.(
+          "TOKEN_REFRESH",
+          "Claude OAuth refresh rejected JSON retry, retrying as form-encoded"
+        );
+        response = await makeRequest("application/x-www-form-urlencoded");
+      }
     }
 
     if (!response.ok) {

--- a/open-sse/services/tokenRefresh.ts
+++ b/open-sse/services/tokenRefresh.ts
@@ -1,4 +1,3 @@
-import { CLAUDE_CONFIG } from "@/lib/oauth/constants/oauth";
 import { PROVIDERS, OAUTH_ENDPOINTS } from "../config/constants.ts";
 import { pbkdf2Sync } from "node:crypto";
 import { runWithProxyContext } from "../utils/proxyFetch.ts";
@@ -223,71 +222,23 @@ export async function refreshKimiCodingToken(refreshToken, log, proxyConfig = nu
  */
 export async function refreshClaudeOAuthToken(refreshToken, log, proxyConfig = null) {
   try {
-    const payload = {
+    const params = new URLSearchParams({
       grant_type: "refresh_token",
       refresh_token: refreshToken,
       client_id: PROVIDERS.claude.clientId,
-      scope: CLAUDE_CONFIG.scopes.join(" "),
-    };
+    });
 
-    const makeRequest = (contentType, extraHeaders = {}) =>
-      runWithProxyContext(proxyConfig, () =>
-        fetch(OAUTH_ENDPOINTS.anthropic.token, {
-          method: "POST",
-          headers: {
-            "Content-Type": contentType,
-            Accept: "application/json",
-            ...extraHeaders,
-          },
-          body:
-            contentType === "application/json"
-              ? JSON.stringify(payload)
-              : new URLSearchParams(payload).toString(),
-        })
-      );
-
-    let response = await makeRequest("application/json");
-
-    if (!response.ok) {
-      const initialErrorText = await response.text();
-      const shouldRetry =
-        response.status === 400 && /invalid request format/i.test(initialErrorText || "");
-
-      if (!shouldRetry) {
-        log?.error?.("TOKEN_REFRESH", "Failed to refresh Claude OAuth token", {
-          status: response.status,
-          error: initialErrorText,
-        });
-        return null;
-      }
-
-      log?.warn?.(
-        "TOKEN_REFRESH",
-        "Claude OAuth refresh rejected base JSON contract, retrying alternate formats"
-      );
-
-      response = await makeRequest("application/json", { "User-Agent": "anthropic" });
-
-      if (!response.ok) {
-        const secondErrorText = await response.text();
-        const shouldRetryAsForm =
-          response.status === 400 && /invalid request format/i.test(secondErrorText || "");
-
-        if (!shouldRetryAsForm) {
-          log?.error?.("TOKEN_REFRESH", "Failed to refresh Claude OAuth token", {
-            status: response.status,
-            error: secondErrorText,
-          });
-          return null;
-        }
-
-        log?.warn?.(
-          "TOKEN_REFRESH",
-          "Claude OAuth refresh rejected JSON retry, retrying as form-encoded"
-        );
-        response = await makeRequest("application/x-www-form-urlencoded");
-      }
-    }
+    const response = await runWithProxyContext(proxyConfig, () =>
+      fetch(OAUTH_ENDPOINTS.anthropic.token, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+          Accept: "application/json",
+          "anthropic-beta": "oauth-2025-04-20",
+        },
+        body: params.toString(),
+      })
+    );
 
     if (!response.ok) {
       const errorText = await response.text();

--- a/open-sse/services/tokenRefresh.ts
+++ b/open-sse/services/tokenRefresh.ts
@@ -1,3 +1,4 @@
+import { CLAUDE_CONFIG } from "@/lib/oauth/constants/oauth";
 import { PROVIDERS, OAUTH_ENDPOINTS } from "../config/constants.ts";
 import { pbkdf2Sync } from "node:crypto";
 import { runWithProxyContext } from "../utils/proxyFetch.ts";
@@ -226,6 +227,7 @@ export async function refreshClaudeOAuthToken(refreshToken, log, proxyConfig = n
       grant_type: "refresh_token",
       refresh_token: refreshToken,
       client_id: PROVIDERS.claude.clientId,
+      scope: CLAUDE_CONFIG.scopes.join(" "),
     };
 
     const makeRequest = (contentType, extraHeaders = {}) =>

--- a/open-sse/services/tokenRefresh.ts
+++ b/open-sse/services/tokenRefresh.ts
@@ -16,6 +16,22 @@ function getRefreshCacheKey(provider, refreshToken) {
   return `${provider}:${tokenHash}`;
 }
 
+function buildClaudeRefreshRequestMeta(refreshToken, headers, body, hasProxyConfig) {
+  return {
+    method: "POST",
+    url: OAUTH_ENDPOINTS.anthropic.token,
+    contentType: headers["Content-Type"],
+    accept: headers.Accept,
+    anthropicBeta: headers["anthropic-beta"] || null,
+    bodyFormat:
+      headers["Content-Type"] === "application/x-www-form-urlencoded" ? "form-urlencoded" : "json",
+    bodyKeys: body instanceof URLSearchParams ? Array.from(body.keys()) : Object.keys(body || {}),
+    clientId: PROVIDERS.claude.clientId || null,
+    refreshTokenLength: typeof refreshToken === "string" ? refreshToken.length : 0,
+    hasProxyConfig: hasProxyConfig,
+  };
+}
+
 /**
  * Refresh OAuth access token using refresh token
  */
@@ -222,20 +238,28 @@ export async function refreshKimiCodingToken(refreshToken, log, proxyConfig = nu
  */
 export async function refreshClaudeOAuthToken(refreshToken, log, proxyConfig = null) {
   try {
-    const payload = {
+    const headers = {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Accept: "application/json",
+      "anthropic-beta": "oauth-2025-04-20",
+    };
+    const params = new URLSearchParams({
       grant_type: "refresh_token",
       refresh_token: refreshToken,
       client_id: PROVIDERS.claude.clientId,
-    };
+    });
+
+    log?.warn?.(
+      "TOKEN_REFRESH",
+      "Claude OAuth refresh request details",
+      buildClaudeRefreshRequestMeta(refreshToken, headers, params, proxyConfig)
+    );
 
     const response = await runWithProxyContext(proxyConfig, () =>
       fetch(OAUTH_ENDPOINTS.anthropic.token, {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Accept: "application/json",
-        },
-        body: JSON.stringify(payload),
+        headers,
+        body: params.toString(),
       })
     );
 

--- a/open-sse/services/tokenRefresh.ts
+++ b/open-sse/services/tokenRefresh.ts
@@ -222,24 +222,50 @@ export async function refreshKimiCodingToken(refreshToken, log, proxyConfig = nu
  */
 export async function refreshClaudeOAuthToken(refreshToken, log, proxyConfig = null) {
   try {
-    // Standard OAuth2 token refresh uses form-urlencoded (not JSON)
-    const params = new URLSearchParams({
+    const payload = {
       grant_type: "refresh_token",
       refresh_token: refreshToken,
       client_id: PROVIDERS.claude.clientId,
-    });
+    };
 
-    const response = await runWithProxyContext(proxyConfig, () =>
-      fetch(OAUTH_ENDPOINTS.anthropic.token, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/x-www-form-urlencoded",
-          Accept: "application/json",
-          "anthropic-beta": "oauth-2025-04-20",
-        },
-        body: params.toString(),
-      })
-    );
+    const makeRequest = (contentType) =>
+      runWithProxyContext(proxyConfig, () =>
+        fetch(OAUTH_ENDPOINTS.anthropic.token, {
+          method: "POST",
+          headers: {
+            "Content-Type": contentType,
+            Accept: "application/json",
+            "User-Agent": "anthropic",
+            "anthropic-beta": "oauth-2025-04-20",
+          },
+          body:
+            contentType === "application/json"
+              ? JSON.stringify(payload)
+              : new URLSearchParams(payload).toString(),
+        })
+      );
+
+    let response = await makeRequest("application/json");
+
+    if (!response.ok) {
+      const initialErrorText = await response.text();
+      const shouldRetryAsForm =
+        response.status === 400 && /invalid request format/i.test(initialErrorText || "");
+
+      if (!shouldRetryAsForm) {
+        log?.error?.("TOKEN_REFRESH", "Failed to refresh Claude OAuth token", {
+          status: response.status,
+          error: initialErrorText,
+        });
+        return null;
+      }
+
+      log?.warn?.(
+        "TOKEN_REFRESH",
+        "Claude OAuth refresh rejected JSON payload, retrying as form-encoded"
+      );
+      response = await makeRequest("application/x-www-form-urlencoded");
+    }
 
     if (!response.ok) {
       const errorText = await response.text();

--- a/open-sse/services/tokenRefresh.ts
+++ b/open-sse/services/tokenRefresh.ts
@@ -222,21 +222,20 @@ export async function refreshKimiCodingToken(refreshToken, log, proxyConfig = nu
  */
 export async function refreshClaudeOAuthToken(refreshToken, log, proxyConfig = null) {
   try {
-    const params = new URLSearchParams({
+    const payload = {
       grant_type: "refresh_token",
       refresh_token: refreshToken,
       client_id: PROVIDERS.claude.clientId,
-    });
+    };
 
     const response = await runWithProxyContext(proxyConfig, () =>
       fetch(OAUTH_ENDPOINTS.anthropic.token, {
         method: "POST",
         headers: {
-          "Content-Type": "application/x-www-form-urlencoded",
+          "Content-Type": "application/json",
           Accept: "application/json",
-          "anthropic-beta": "oauth-2025-04-20",
         },
-        body: params.toString(),
+        body: JSON.stringify(payload),
       })
     );
 

--- a/open-sse/translator/helpers/claudeHelper.ts
+++ b/open-sse/translator/helpers/claudeHelper.ts
@@ -1,5 +1,11 @@
 // Claude helper functions for translator
 import { DEFAULT_THINKING_CLAUDE_SIGNATURE } from "../../config/defaultThinkingSignature.ts";
+import {
+  rewriteForwardedTextForLane,
+  rewriteForwardedToolNameForLane,
+} from "../../config/forwardingKeywordRules.ts";
+
+const CLAUDE_OAUTH_FORWARDING_LANE = "claude-oauth-prefixed";
 
 // Check if message has valid non-empty content
 export function hasValidContent(msg) {
@@ -248,4 +254,109 @@ export function prepareClaudeRequest(body, provider = null, preserveCacheControl
   }
 
   return body;
+}
+
+export function applyClaudeOAuthLexicalRewrite(body) {
+  if (!body || typeof body !== "object") {
+    return { body, toolNameMap: null };
+  }
+
+  const toolNameMap = new Map();
+  const rewriteText = (text) =>
+    typeof text === "string"
+      ? rewriteForwardedTextForLane(CLAUDE_OAUTH_FORWARDING_LANE, text)
+      : text;
+  const rewriteToolName = (toolName) => {
+    if (typeof toolName !== "string") return toolName;
+    const normalizedToolName = toolName.trim();
+    if (!normalizedToolName) return toolName;
+    const rewrittenToolName = rewriteForwardedToolNameForLane(
+      CLAUDE_OAUTH_FORWARDING_LANE,
+      normalizedToolName
+    );
+    if (rewrittenToolName !== normalizedToolName) {
+      toolNameMap.set(rewrittenToolName, normalizedToolName);
+    }
+    return rewrittenToolName;
+  };
+
+  if (Array.isArray(body.system)) {
+    body.system = body.system.map((block) =>
+      block && typeof block === "object" && typeof block.text === "string"
+        ? { ...block, text: rewriteText(block.text) }
+        : block
+    );
+  } else if (typeof body.system === "string") {
+    body.system = rewriteText(body.system);
+  }
+
+  if (Array.isArray(body.tools)) {
+    body.tools = body.tools.map((tool) => {
+      if (!tool || typeof tool !== "object") return tool;
+      const rewrittenTool = { ...tool };
+      if (typeof rewrittenTool.name === "string") {
+        rewrittenTool.name = rewriteToolName(rewrittenTool.name);
+      }
+      if (typeof rewrittenTool.description === "string") {
+        rewrittenTool.description = rewriteText(rewrittenTool.description);
+      }
+      return rewrittenTool;
+    });
+  }
+
+  if (body.tool_choice && typeof body.tool_choice === "object") {
+    if (body.tool_choice.type === "tool" && typeof body.tool_choice.name === "string") {
+      body.tool_choice = {
+        ...body.tool_choice,
+        name: rewriteToolName(body.tool_choice.name),
+      };
+    }
+  }
+
+  if (Array.isArray(body.messages)) {
+    body.messages = body.messages.map((message) => {
+      if (!message || typeof message !== "object") return message;
+      if (typeof message.content === "string") {
+        return {
+          ...message,
+          content: rewriteText(message.content),
+        };
+      }
+      if (!Array.isArray(message.content)) return message;
+      return {
+        ...message,
+        content: message.content.map((block) => {
+          if (!block || typeof block !== "object") return block;
+          if (block.type === "text" && typeof block.text === "string") {
+            return { ...block, text: rewriteText(block.text) };
+          }
+          if (block.type === "thinking" && typeof block.thinking === "string") {
+            return { ...block, thinking: rewriteText(block.thinking) };
+          }
+          if (block.type === "tool_use" && typeof block.name === "string") {
+            return { ...block, name: rewriteToolName(block.name) };
+          }
+          if (block.type === "tool_result" && Array.isArray(block.content)) {
+            return {
+              ...block,
+              content: block.content.map((nestedBlock) =>
+                nestedBlock?.type === "text" && typeof nestedBlock.text === "string"
+                  ? { ...nestedBlock, text: rewriteText(nestedBlock.text) }
+                  : nestedBlock
+              ),
+            };
+          }
+          if (block.type === "tool_result" && typeof block.content === "string") {
+            return {
+              ...block,
+              content: rewriteText(block.content),
+            };
+          }
+          return block;
+        }),
+      };
+    });
+  }
+
+  return { body, toolNameMap: toolNameMap.size > 0 ? toolNameMap : null };
 }

--- a/open-sse/translator/helpers/claudeHelper.ts
+++ b/open-sse/translator/helpers/claudeHelper.ts
@@ -330,7 +330,10 @@ export function applyClaudeOAuthLexicalRewrite(body) {
           if (block.type === "text" && typeof block.text === "string") {
             return { ...block, text: rewriteText(block.text) };
           }
-          if (block.type === "thinking" && typeof block.thinking === "string") {
+          if (
+            (block.type === "thinking" || block.type === "redacted_thinking") &&
+            typeof block.thinking === "string"
+          ) {
             return { ...block, thinking: rewriteText(block.thinking) };
           }
           if (block.type === "tool_use" && typeof block.name === "string") {

--- a/open-sse/translator/index.ts
+++ b/open-sse/translator/index.ts
@@ -97,8 +97,7 @@ export function translateRequest(
   // Phase 2: Apply thinking budget control before normalization
   result = applyThinkingBudget(result);
 
-  // Normalize thinking config: remove if lastMessage is not user
-  normalizeThinkingConfig(result);
+  normalizeThinkingConfig(result, targetFormat);
 
   // Ensure tool_calls have id; optionally normalize to 9-char for providers like Mistral
   ensureToolCallIds(result, { use9CharId });

--- a/open-sse/translator/request/openai-to-claude.ts
+++ b/open-sse/translator/request/openai-to-claude.ts
@@ -1,6 +1,10 @@
 import { register } from "../registry.ts";
 import { FORMATS } from "../formats.ts";
 import { CLAUDE_SYSTEM_PROMPT } from "../../config/constants.ts";
+import {
+  rewriteForwardedTextForLane,
+  rewriteForwardedToolNameForLane,
+} from "../../config/forwardingKeywordRules.ts";
 import { adjustMaxTokens } from "../helpers/maxTokensHelper.ts";
 import { sanitizeToolId } from "../helpers/schemaCoercion.ts";
 import { DEFAULT_THINKING_CLAUDE_SIGNATURE } from "../../config/defaultThinkingSignature.ts";
@@ -9,12 +13,7 @@ import { DEFAULT_THINKING_CLAUDE_SIGNATURE } from "../../config/defaultThinkingS
 // Can be disabled per-request via body._disableToolPrefix = true
 export const CLAUDE_OAUTH_TOOL_PREFIX = "proxy_";
 const CLAUDE_TOOL_CHOICE_REQUIRED = "an" + "y";
-const CLAUDE_OAUTH_LEXICAL_TOOL_REWRITES = {
-  background_output: "background_result",
-  background_cancel: "background_stop",
-} as const;
-const CLAUDE_OAUTH_DIRECTORIES_OPEN_TAG = /<directories>/g;
-const CLAUDE_OAUTH_DIRECTORIES_CLOSE_TAG = /<\/directories>/g;
+const CLAUDE_OAUTH_PREFIXED_LANE = "claude-oauth-prefixed";
 
 type ClaudeContentBlock = Record<string, unknown>;
 type ClaudeMessage = {
@@ -35,21 +34,11 @@ type ClaudeTool = {
 };
 
 function rewriteClaudeOAuthLexicalText(text: string): string {
-  if (!text) return text;
-
-  return text
-    .replaceAll("background_output", CLAUDE_OAUTH_LEXICAL_TOOL_REWRITES.background_output)
-    .replaceAll("background_cancel", CLAUDE_OAUTH_LEXICAL_TOOL_REWRITES.background_cancel)
-    .replace(CLAUDE_OAUTH_DIRECTORIES_OPEN_TAG, "directories:\n")
-    .replace(CLAUDE_OAUTH_DIRECTORIES_CLOSE_TAG, "");
+  return rewriteForwardedTextForLane(CLAUDE_OAUTH_PREFIXED_LANE, text);
 }
 
 function rewriteClaudeOAuthToolName(toolName: string): string {
-  return (
-    CLAUDE_OAUTH_LEXICAL_TOOL_REWRITES[
-      toolName as keyof typeof CLAUDE_OAUTH_LEXICAL_TOOL_REWRITES
-    ] ?? toolName
-  );
+  return rewriteForwardedToolNameForLane(CLAUDE_OAUTH_PREFIXED_LANE, toolName);
 }
 
 /**
@@ -87,6 +76,37 @@ export function stripEmptyTextBlocks(content: unknown[] | undefined): unknown[] 
       }
       return block;
     });
+}
+
+function rewriteTextBlocksRecursively(
+  content: unknown[] | undefined,
+  disableToolPrefix = false
+): unknown[] {
+  if (!Array.isArray(content)) return content ?? [];
+
+  return content.map((block: unknown) => {
+    if (!block || typeof block !== "object") return block;
+
+    const blockRecord = block as Record<string, unknown>;
+
+    if (blockRecord.type === "text" && typeof blockRecord.text === "string") {
+      return {
+        ...blockRecord,
+        text: disableToolPrefix
+          ? blockRecord.text
+          : rewriteClaudeOAuthLexicalText(blockRecord.text),
+      };
+    }
+
+    if (blockRecord.type === "tool_result" && Array.isArray(blockRecord.content)) {
+      return {
+        ...blockRecord,
+        content: rewriteTextBlocksRecursively(blockRecord.content, disableToolPrefix),
+      };
+    }
+
+    return block;
+  });
 }
 
 /**
@@ -332,7 +352,7 @@ export function openaiToClaudeRequest(model, body, stream) {
 
   // Tool choice
   if (body.tool_choice) {
-    result.tool_choice = convertOpenAIToolChoice(body.tool_choice);
+    result.tool_choice = convertOpenAIToolChoice(body.tool_choice, disableToolPrefix);
   }
 
   // response_format: inject JSON structured output instruction into system prompt.
@@ -417,7 +437,7 @@ function getContentBlocksFromMessage(msg, toolNameMap = new Map(), disableToolPr
   if (msg.role === "tool") {
     // T02: Strip empty text blocks from nested tool_result content to avoid Anthropic 400
     const toolContent = Array.isArray(msg.content)
-      ? stripEmptyTextBlocks(msg.content)
+      ? rewriteTextBlocksRecursively(stripEmptyTextBlocks(msg.content), disableToolPrefix)
       : msg.content;
     blocks.push({
       type: "tool_result",
@@ -444,7 +464,7 @@ function getContentBlocksFromMessage(msg, toolNameMap = new Map(), disableToolPr
           if (!part.tool_use_id) continue;
           // T02: strip empty text blocks from nested content before passing to Anthropic
           const resultContent = Array.isArray(part.content)
-            ? stripEmptyTextBlocks(part.content)
+            ? rewriteTextBlocksRecursively(stripEmptyTextBlocks(part.content), disableToolPrefix)
             : part.content;
           blocks.push({
             type: "tool_result",
@@ -560,26 +580,36 @@ function getContentBlocksFromMessage(msg, toolNameMap = new Map(), disableToolPr
 }
 
 // Convert OpenAI tool choice to Claude format
-function convertOpenAIToolChoice(choice) {
+function convertOpenAIToolChoice(choice, disableToolPrefix = false) {
+  const mapToolChoiceName = (toolName: string) => {
+    const normalizedName = toolName.trim();
+    const rewrittenName = disableToolPrefix
+      ? normalizedName
+      : rewriteClaudeOAuthToolName(normalizedName);
+    return disableToolPrefix ? rewrittenName : `${CLAUDE_OAUTH_TOOL_PREFIX}${rewrittenName}`;
+  };
+
   if (!choice) return { type: "auto" };
   if (typeof choice === "object" && choice.type) {
     // OpenAI sends {type: "function", function: {name}} — convert to Claude {type: "tool", name}
     if (choice.type === "function" && choice.function?.name) {
-      return { type: "tool", name: choice.function.name };
+      return { type: "tool", name: mapToolChoiceName(choice.function.name) };
     }
     // Map OpenAI string types to Claude equivalents
     if (choice.type === "auto" || choice.type === "none") return { type: "auto" };
     if (choice.type === "required" || choice.type === "any")
       return { type: CLAUDE_TOOL_CHOICE_REQUIRED };
     // If type is "tool" already (Claude-native), pass through
-    if (choice.type === "tool" && choice.name) return choice;
+    if (choice.type === "tool" && choice.name) {
+      return { ...choice, name: mapToolChoiceName(choice.name) };
+    }
     // Fallback: unknown object type — default to auto to avoid 400 errors
     return { type: "auto" };
   }
   if (choice === "auto" || choice === "none") return { type: "auto" };
   if (choice === "required") return { type: CLAUDE_TOOL_CHOICE_REQUIRED };
   if (typeof choice === "object" && choice.function) {
-    return { type: "tool", name: choice.function.name };
+    return { type: "tool", name: mapToolChoiceName(choice.function.name) };
   }
   return { type: "auto" };
 }

--- a/open-sse/translator/request/openai-to-claude.ts
+++ b/open-sse/translator/request/openai-to-claude.ts
@@ -431,7 +431,6 @@ export function openaiToClaudeRequest(model, body, stream) {
 
 // Get content blocks from single message
 function getContentBlocksFromMessage(msg, toolNameMap = new Map(), disableToolPrefix = false) {
-  void toolNameMap;
   const blocks = [];
 
   if (msg.role === "tool") {
@@ -529,10 +528,16 @@ function getContentBlocksFromMessage(msg, toolNameMap = new Map(), disableToolPr
             const toolUseName = disableToolPrefix
               ? normalizedToolUseName
               : rewriteClaudeOAuthToolName(normalizedToolUseName);
+            const outputToolName = disableToolPrefix
+              ? toolUseName
+              : CLAUDE_OAUTH_TOOL_PREFIX + toolUseName;
+            if (!disableToolPrefix) {
+              toolNameMap.set(outputToolName, normalizedToolUseName);
+            }
             blocks.push({
               type: "tool_use",
               id: sanitizeToolId(part.id),
-              name: disableToolPrefix ? toolUseName : CLAUDE_OAUTH_TOOL_PREFIX + toolUseName,
+              name: outputToolName,
               input: part.input,
             });
           }
@@ -565,6 +570,9 @@ function getContentBlocksFromMessage(msg, toolNameMap = new Map(), disableToolPr
           const toolName = disableToolPrefix
             ? rewrittenName
             : CLAUDE_OAUTH_TOOL_PREFIX + rewrittenName;
+          if (!disableToolPrefix) {
+            toolNameMap.set(toolName, fnName.trim());
+          }
           blocks.push({
             type: "tool_use",
             id: sanitizeToolId(tc.id),

--- a/open-sse/translator/request/openai-to-claude.ts
+++ b/open-sse/translator/request/openai-to-claude.ts
@@ -5,6 +5,7 @@ import {
   rewriteForwardedTextForLane,
   rewriteForwardedToolNameForLane,
 } from "../../config/forwardingKeywordRules.ts";
+import { capMaxOutputTokens, capThinkingBudget } from "@/shared/constants/modelSpecs";
 import { adjustMaxTokens } from "../helpers/maxTokensHelper.ts";
 import { sanitizeToolId } from "../helpers/schemaCoercion.ts";
 import { DEFAULT_THINKING_CLAUDE_SIGNATURE } from "../../config/defaultThinkingSignature.ts";
@@ -408,17 +409,28 @@ export function openaiToClaudeRequest(model, body, stream) {
         type: "enabled",
         budget_tokens: budget,
       };
-      // Claude requires max_tokens > budget_tokens
-      if (result.max_tokens <= budget) {
-        result.max_tokens = budget + 8192;
-      }
     }
   }
 
-  // Ensure max_tokens > budget_tokens for all thinking configurations (#627)
+  result.max_tokens = capMaxOutputTokens(model, result.max_tokens);
+
+  // Ensure thinking budget stays below the model-capped max_tokens (#627)
   const budgetTokens = Number(result.thinking?.budget_tokens) || 0;
-  if (budgetTokens > 0 && result.max_tokens <= budgetTokens) {
-    result.max_tokens = budgetTokens + 8192;
+  if (budgetTokens > 0) {
+    const maxBudgetForRequest = Math.max(0, result.max_tokens);
+    const cappedBudget = Math.min(capThinkingBudget(model, budgetTokens), maxBudgetForRequest);
+
+    if (cappedBudget > 0) {
+      result.thinking = {
+        ...result.thinking,
+        budget_tokens: cappedBudget,
+        ...(result.thinking?.max_tokens
+          ? { max_tokens: Math.min(Number(result.thinking.max_tokens), maxBudgetForRequest) }
+          : {}),
+      };
+    } else {
+      delete result.thinking;
+    }
   }
 
   // Attach toolNameMap to result for response translation

--- a/open-sse/translator/request/openai-to-claude.ts
+++ b/open-sse/translator/request/openai-to-claude.ts
@@ -393,6 +393,16 @@ export function openaiToClaudeRequest(model, body, stream) {
       ...(body.thinking.budget_tokens && { budget_tokens: body.thinking.budget_tokens }),
       ...(body.thinking.max_tokens && { max_tokens: body.thinking.max_tokens }),
     };
+    if (
+      body.thinking.type === "adaptive" &&
+      body.output_config &&
+      typeof body.output_config === "object" &&
+      typeof body.output_config.effort === "string"
+    ) {
+      result.output_config = {
+        effort: body.output_config.effort,
+      };
+    }
   } else if (body.reasoning_effort) {
     // Convert OpenAI reasoning_effort to Claude thinking format (#627)
     // Clients like OpenCode send reasoning_effort via @ai-sdk/openai-compatible
@@ -431,6 +441,11 @@ export function openaiToClaudeRequest(model, body, stream) {
     } else {
       delete result.thinking;
     }
+  }
+
+  if (result.thinking?.type === "adaptive") {
+    delete result.thinking.budget_tokens;
+    delete result.thinking.max_tokens;
   }
 
   // Attach toolNameMap to result for response translation

--- a/open-sse/translator/request/openai-to-claude.ts
+++ b/open-sse/translator/request/openai-to-claude.ts
@@ -9,6 +9,12 @@ import { DEFAULT_THINKING_CLAUDE_SIGNATURE } from "../../config/defaultThinkingS
 // Can be disabled per-request via body._disableToolPrefix = true
 export const CLAUDE_OAUTH_TOOL_PREFIX = "proxy_";
 const CLAUDE_TOOL_CHOICE_REQUIRED = "an" + "y";
+const CLAUDE_OAUTH_LEXICAL_TOOL_REWRITES = {
+  background_output: "background_result",
+  background_cancel: "background_stop",
+} as const;
+const CLAUDE_OAUTH_DIRECTORIES_OPEN_TAG = /<directories>/g;
+const CLAUDE_OAUTH_DIRECTORIES_CLOSE_TAG = /<\/directories>/g;
 
 type ClaudeContentBlock = Record<string, unknown>;
 type ClaudeMessage = {
@@ -27,6 +33,24 @@ type ClaudeTool = {
   cache_control?: { type: string; ttl?: string };
   defer_loading?: boolean;
 };
+
+function rewriteClaudeOAuthLexicalText(text: string): string {
+  if (!text) return text;
+
+  return text
+    .replaceAll("background_output", CLAUDE_OAUTH_LEXICAL_TOOL_REWRITES.background_output)
+    .replaceAll("background_cancel", CLAUDE_OAUTH_LEXICAL_TOOL_REWRITES.background_cancel)
+    .replace(CLAUDE_OAUTH_DIRECTORIES_OPEN_TAG, "directories:\n")
+    .replace(CLAUDE_OAUTH_DIRECTORIES_CLOSE_TAG, "");
+}
+
+function rewriteClaudeOAuthToolName(toolName: string): string {
+  return (
+    CLAUDE_OAUTH_LEXICAL_TOOL_REWRITES[
+      toolName as keyof typeof CLAUDE_OAUTH_LEXICAL_TOOL_REWRITES
+    ] ?? toolName
+  );
+}
 
 /**
  * T02: Recursively strips empty text blocks from content arrays.
@@ -70,13 +94,21 @@ export function stripEmptyTextBlocks(content: unknown[] | undefined): unknown[] 
  * Handles both string and array-of-blocks forms (Cursor, Codex 2.x, etc.).
  * Ref: sub2api PR #1197
  */
-export function normalizeContentToString(content: string | unknown[] | null | undefined): string {
+export function normalizeContentToString(
+  content: string | unknown[] | null | undefined,
+  rewriteLexicalTriggers = true
+): string {
   if (!content) return "";
-  if (typeof content === "string") return content;
+  if (typeof content === "string") {
+    return rewriteLexicalTriggers ? rewriteClaudeOAuthLexicalText(content) : content;
+  }
   if (Array.isArray(content)) {
     return (content as Array<Record<string, unknown>>)
       .filter((b) => b.type === "text")
-      .map((b) => String(b.text ?? ""))
+      .map((b) => {
+        const text = String(b.text ?? "");
+        return rewriteLexicalTriggers ? rewriteClaudeOAuthLexicalText(text) : text;
+      })
       .join("\n");
   }
   return "";
@@ -86,6 +118,7 @@ export function normalizeContentToString(content: string | unknown[] | null | un
 export function openaiToClaudeRequest(model, body, stream) {
   // Check if tool prefix should be disabled (configured per-provider or global)
   const disableToolPrefix = body?._disableToolPrefix === true;
+  const shouldRewriteClaudeOAuthLexicalTriggers = !disableToolPrefix;
 
   // Tool name mapping for Claude OAuth (capitalizedName → originalName)
   const toolNameMap = new Map();
@@ -126,7 +159,11 @@ export function openaiToClaudeRequest(model, body, stream) {
     for (const msg of body.messages) {
       if (msg.role === "system") {
         systemParts.push(
-          typeof msg.content === "string" ? msg.content : normalizeContentToString(msg.content)
+          typeof msg.content === "string"
+            ? disableToolPrefix
+              ? msg.content
+              : rewriteClaudeOAuthLexicalText(msg.content)
+            : normalizeContentToString(msg.content, !disableToolPrefix)
         );
       }
     }
@@ -243,19 +280,24 @@ export function openaiToClaudeRequest(model, body, stream) {
     result.tools = body.tools
       .map((tool) => {
         const toolData = tool.type === "function" && tool.function ? tool.function : tool;
-        const originalName = typeof toolData.name === "string" ? toolData.name.trim() : "";
+        const rawName = typeof toolData.name === "string" ? toolData.name.trim() : "";
+        const rewrittenName = shouldRewriteClaudeOAuthLexicalTriggers
+          ? rewriteClaudeOAuthToolName(rawName)
+          : rawName;
 
-        if (!originalName) {
+        if (!rewrittenName) {
           return null;
         }
 
         // Claude OAuth requires prefixed tool names to avoid conflicts
         // When prefix is disabled (non-Claude backends), use original name
-        const toolName = disableToolPrefix ? originalName : CLAUDE_OAUTH_TOOL_PREFIX + originalName;
+        const toolName = disableToolPrefix
+          ? rewrittenName
+          : CLAUDE_OAUTH_TOOL_PREFIX + rewrittenName;
 
-        // Store mapping for response translation (prefixed → original)
+        // Store mapping for response translation (prefixed rewritten → original client name)
         if (!disableToolPrefix) {
-          toolNameMap.set(toolName, originalName);
+          toolNameMap.set(toolName, rawName);
         }
 
         // Normalize input_schema: Anthropic requires `properties` when type is "object" (#595).
@@ -369,6 +411,7 @@ export function openaiToClaudeRequest(model, body, stream) {
 
 // Get content blocks from single message
 function getContentBlocksFromMessage(msg, toolNameMap = new Map(), disableToolPrefix = false) {
+  void toolNameMap;
   const blocks = [];
 
   if (msg.role === "tool") {
@@ -384,12 +427,18 @@ function getContentBlocksFromMessage(msg, toolNameMap = new Map(), disableToolPr
   } else if (msg.role === "user") {
     if (typeof msg.content === "string") {
       if (msg.content) {
-        blocks.push({ type: "text", text: msg.content });
+        blocks.push({
+          type: "text",
+          text: disableToolPrefix ? msg.content : rewriteClaudeOAuthLexicalText(msg.content),
+        });
       }
     } else if (Array.isArray(msg.content)) {
       for (const part of msg.content) {
         if (part.type === "text" && part.text) {
-          blocks.push({ type: "text", text: part.text });
+          blocks.push({
+            type: "text",
+            text: disableToolPrefix ? part.text : rewriteClaudeOAuthLexicalText(part.text),
+          });
         } else if (part.type === "tool_result") {
           // Skip tool_result with no tool_use_id (would be useless and may cause errors)
           if (!part.tool_use_id) continue;
@@ -427,7 +476,9 @@ function getContentBlocksFromMessage(msg, toolNameMap = new Map(), disableToolPr
     if (msg.reasoning_content) {
       blocks.push({
         type: "thinking",
-        thinking: msg.reasoning_content,
+        thinking: disableToolPrefix
+          ? msg.reasoning_content
+          : rewriteClaudeOAuthLexicalText(msg.reasoning_content),
         signature: DEFAULT_THINKING_CLAUDE_SIGNATURE,
       });
     }
@@ -435,30 +486,48 @@ function getContentBlocksFromMessage(msg, toolNameMap = new Map(), disableToolPr
     if (Array.isArray(msg.content)) {
       for (const part of msg.content) {
         if (part.type === "text" && part.text) {
-          blocks.push({ type: "text", text: part.text });
+          blocks.push({
+            type: "text",
+            text: disableToolPrefix ? part.text : rewriteClaudeOAuthLexicalText(part.text),
+          });
         } else if (part.type === "thinking" || part.type === "redacted_thinking") {
           // Preserve thinking blocks with signature
           blocks.push({
             ...part,
+            ...(typeof part.thinking === "string" && !disableToolPrefix
+              ? { thinking: rewriteClaudeOAuthLexicalText(part.thinking) }
+              : {}),
             signature: part.signature || DEFAULT_THINKING_CLAUDE_SIGNATURE,
           });
         } else if (part.type === "tool_use") {
           // Tool name already has prefix from tool declarations, keep as-is
           // CRITICAL: Skip tool_use blocks with empty name (causes Claude 400 error)
           if (part.name && part.name.trim()) {
+            const normalizedToolUseName = part.name.startsWith(CLAUDE_OAUTH_TOOL_PREFIX)
+              ? part.name.slice(CLAUDE_OAUTH_TOOL_PREFIX.length)
+              : part.name.trim();
+            const toolUseName = disableToolPrefix
+              ? normalizedToolUseName
+              : rewriteClaudeOAuthToolName(normalizedToolUseName);
             blocks.push({
               type: "tool_use",
               id: sanitizeToolId(part.id),
-              name: part.name,
+              name: disableToolPrefix ? toolUseName : CLAUDE_OAUTH_TOOL_PREFIX + toolUseName,
               input: part.input,
             });
           }
         }
       }
     } else if (msg.content) {
-      const text = typeof msg.content === "string" ? msg.content : extractTextContent(msg.content);
+      const text =
+        typeof msg.content === "string"
+          ? msg.content
+          : extractTextContent(msg.content, !disableToolPrefix);
       if (text) {
-        blocks.push({ type: "text", text });
+        blocks.push({
+          type: "text",
+          text: disableToolPrefix ? text : rewriteClaudeOAuthLexicalText(text),
+        });
       }
     }
 
@@ -470,7 +539,12 @@ function getContentBlocksFromMessage(msg, toolNameMap = new Map(), disableToolPr
           if (!fnName || !fnName.trim()) continue;
 
           // Apply prefix to tool name (skip if disabled)
-          const toolName = disableToolPrefix ? fnName : CLAUDE_OAUTH_TOOL_PREFIX + fnName;
+          const rewrittenName = disableToolPrefix
+            ? fnName
+            : rewriteClaudeOAuthToolName(fnName.trim());
+          const toolName = disableToolPrefix
+            ? rewrittenName
+            : CLAUDE_OAUTH_TOOL_PREFIX + rewrittenName;
           blocks.push({
             type: "tool_use",
             id: sanitizeToolId(tc.id),
@@ -495,7 +569,8 @@ function convertOpenAIToolChoice(choice) {
     }
     // Map OpenAI string types to Claude equivalents
     if (choice.type === "auto" || choice.type === "none") return { type: "auto" };
-    if (choice.type === "required" || choice.type === "any") return { type: CLAUDE_TOOL_CHOICE_REQUIRED };
+    if (choice.type === "required" || choice.type === "any")
+      return { type: CLAUDE_TOOL_CHOICE_REQUIRED };
     // If type is "tool" already (Claude-native), pass through
     if (choice.type === "tool" && choice.name) return choice;
     // Fallback: unknown object type — default to auto to avoid 400 errors
@@ -510,12 +585,17 @@ function convertOpenAIToolChoice(choice) {
 }
 
 // Extract text from content
-function extractTextContent(content) {
-  if (typeof content === "string") return content;
+function extractTextContent(content, rewriteLexicalTriggers = true) {
+  if (typeof content === "string") {
+    return rewriteLexicalTriggers ? rewriteClaudeOAuthLexicalText(content) : content;
+  }
   if (Array.isArray(content)) {
     return content
       .filter((c) => c.type === "text")
-      .map((c) => c.text)
+      .map((c) => {
+        const text = typeof c.text === "string" ? c.text : String(c.text ?? "");
+        return rewriteLexicalTriggers ? rewriteClaudeOAuthLexicalText(text) : text;
+      })
       .join("\n");
   }
   return "";
@@ -533,7 +613,7 @@ function tryParseJSON(str) {
 
 // OpenAI -> Claude format for Antigravity (without system prompt modifications)
 function openaiToClaudeRequestForAntigravity(model, body, stream) {
-  const result = openaiToClaudeRequest(model, body, stream);
+  const result = openaiToClaudeRequest(model, { ...body, _disableToolPrefix: true }, stream);
 
   // Remove Claude Code system prompt, keep only user's system messages
   if (result.system && Array.isArray(result.system)) {

--- a/open-sse/translator/request/openai-to-claude.ts
+++ b/open-sse/translator/request/openai-to-claude.ts
@@ -5,7 +5,14 @@ import {
   rewriteForwardedTextForLane,
   rewriteForwardedToolNameForLane,
 } from "../../config/forwardingKeywordRules.ts";
-import { capMaxOutputTokens, capThinkingBudget } from "@/shared/constants/modelSpecs";
+import {
+  capMaxOutputTokens,
+  capThinkingBudget,
+  isAdaptiveOnlyModel,
+  rejectsSamplingParams,
+  getDefaultThinkingDisplay,
+  downgradeEffort,
+} from "@/shared/constants/modelSpecs";
 import { adjustMaxTokens } from "../helpers/maxTokensHelper.ts";
 import { sanitizeToolId } from "../helpers/schemaCoercion.ts";
 import { DEFAULT_THINKING_CLAUDE_SIGNATURE } from "../../config/defaultThinkingSignature.ts";
@@ -387,9 +394,12 @@ export function openaiToClaudeRequest(model, body, stream) {
   }
 
   // Thinking configuration
+  const adaptiveOnly = isAdaptiveOnlyModel(model);
+
   if (body.thinking) {
+    const defaultType = adaptiveOnly ? "adaptive" : "enabled";
     result.thinking = {
-      type: body.thinking.type || "enabled",
+      type: body.thinking.type || defaultType,
       ...(body.thinking.budget_tokens && { budget_tokens: body.thinking.budget_tokens }),
       ...(body.thinking.max_tokens && { max_tokens: body.thinking.max_tokens }),
     };
@@ -400,46 +410,64 @@ export function openaiToClaudeRequest(model, body, stream) {
       typeof body.output_config.effort === "string"
     ) {
       result.output_config = {
-        effort: body.output_config.effort,
+        effort: downgradeEffort(model, body.output_config.effort),
       };
     }
   } else if (body.reasoning_effort) {
-    // Convert OpenAI reasoning_effort to Claude thinking format (#627)
-    // Clients like OpenCode send reasoning_effort via @ai-sdk/openai-compatible
-    const effortBudgetMap: Record<string, number> = {
-      low: 1024,
-      medium: 10240,
-      high: 131072,
-      max: 131072,
-    };
     const effort = String(body.reasoning_effort).toLowerCase();
-    const budget = effortBudgetMap[effort];
-    if (budget !== undefined && budget > 0) {
-      result.thinking = {
-        type: "enabled",
-        budget_tokens: budget,
+    if (adaptiveOnly) {
+      result.thinking = { type: "adaptive" };
+      result.output_config = { effort: downgradeEffort(model, effort) };
+    } else {
+      const effortBudgetMap: Record<string, number> = {
+        low: 1024,
+        medium: 10240,
+        high: 131072,
+        max: 131072,
       };
+      const budget = effortBudgetMap[effort];
+      if (budget !== undefined && budget > 0) {
+        result.thinking = {
+          type: "enabled",
+          budget_tokens: budget,
+        };
+      }
+    }
+  }
+
+  // Adaptive-only models: coerce any surviving type:"enabled" → type:"adaptive"
+  if (
+    adaptiveOnly &&
+    result.thinking &&
+    result.thinking.type !== "adaptive" &&
+    result.thinking.type !== "disabled"
+  ) {
+    const effort = result.output_config?.effort || result.thinking?.budget_tokens ? "high" : "high";
+    result.thinking = { type: "adaptive" };
+    if (!result.output_config?.effort) {
+      result.output_config = { ...(result.output_config || {}), effort };
     }
   }
 
   result.max_tokens = capMaxOutputTokens(model, result.max_tokens);
 
-  // Ensure thinking budget stays below the model-capped max_tokens (#627)
-  const budgetTokens = Number(result.thinking?.budget_tokens) || 0;
-  if (budgetTokens > 0) {
-    const maxBudgetForRequest = Math.max(0, result.max_tokens);
-    const cappedBudget = Math.min(capThinkingBudget(model, budgetTokens), maxBudgetForRequest);
+  if (!adaptiveOnly) {
+    const budgetTokens = Number(result.thinking?.budget_tokens) || 0;
+    if (budgetTokens > 0) {
+      const maxBudgetForRequest = Math.max(0, result.max_tokens);
+      const cappedBudget = Math.min(capThinkingBudget(model, budgetTokens), maxBudgetForRequest);
 
-    if (cappedBudget > 0) {
-      result.thinking = {
-        ...result.thinking,
-        budget_tokens: cappedBudget,
-        ...(result.thinking?.max_tokens
-          ? { max_tokens: Math.min(Number(result.thinking.max_tokens), maxBudgetForRequest) }
-          : {}),
-      };
-    } else {
-      delete result.thinking;
+      if (cappedBudget > 0) {
+        result.thinking = {
+          ...result.thinking,
+          budget_tokens: cappedBudget,
+          ...(result.thinking?.max_tokens
+            ? { max_tokens: Math.min(Number(result.thinking.max_tokens), maxBudgetForRequest) }
+            : {}),
+        };
+      } else {
+        delete result.thinking;
+      }
     }
   }
 
@@ -448,7 +476,23 @@ export function openaiToClaudeRequest(model, body, stream) {
     delete result.thinking.max_tokens;
   }
 
-  // Attach toolNameMap to result for response translation
+  // Inject thinking.display for models that default to "omitted"
+  if (result.thinking && result.thinking.type !== "disabled") {
+    const display = getDefaultThinkingDisplay(model);
+    if (display === "omitted" && !body.thinking?.display) {
+      result.thinking.display = "summarized";
+    } else if (body.thinking?.display) {
+      result.thinking.display = body.thinking.display;
+    }
+  }
+
+  // Strip sampling params for models that reject non-default values (Opus 4.7+)
+  if (rejectsSamplingParams(model)) {
+    delete result.temperature;
+    delete result.top_p;
+    delete result.top_k;
+  }
+
   if (toolNameMap.size > 0) {
     result._toolNameMap = toolNameMap;
   }

--- a/open-sse/translator/request/openai-to-claude.ts
+++ b/open-sse/translator/request/openai-to-claude.ts
@@ -609,7 +609,11 @@ function convertOpenAIToolChoice(choice, disableToolPrefix = false) {
       return { type: CLAUDE_TOOL_CHOICE_REQUIRED };
     // If type is "tool" already (Claude-native), pass through
     if (choice.type === "tool" && choice.name) {
-      return { ...choice, name: mapToolChoiceName(choice.name) };
+      const normalizedName = choice.name.trim();
+      if (!disableToolPrefix && normalizedName.startsWith(CLAUDE_OAUTH_TOOL_PREFIX)) {
+        return { ...choice, name: normalizedName };
+      }
+      return { ...choice, name: mapToolChoiceName(normalizedName) };
     }
     // Fallback: unknown object type — default to auto to avoid 400 errors
     return { type: "auto" };

--- a/open-sse/translator/response/claude-to-openai.ts
+++ b/open-sse/translator/response/claude-to-openai.ts
@@ -40,6 +40,26 @@ export function claudeToOpenAIResponse(chunk, state) {
       state.messageId = chunk.message?.id || `msg_${Date.now()}`;
       state.model = chunk.message?.model;
       state.toolCallIndex = 0;
+
+      if (chunk.message?.usage && typeof chunk.message.usage === "object") {
+        const u = chunk.message.usage;
+        state.usage = {
+          input_tokens: u.input_tokens || 0,
+          output_tokens: u.output_tokens || 0,
+          prompt_tokens: u.input_tokens || 0,
+          completion_tokens: u.output_tokens || 0,
+        };
+        if (typeof u.cache_read_input_tokens === "number" && u.cache_read_input_tokens > 0) {
+          state.usage.cache_read_input_tokens = u.cache_read_input_tokens;
+        }
+        if (
+          typeof u.cache_creation_input_tokens === "number" &&
+          u.cache_creation_input_tokens > 0
+        ) {
+          state.usage.cache_creation_input_tokens = u.cache_creation_input_tokens;
+        }
+      }
+
       results.push(createChunk(state, { role: "assistant" }));
       break;
     }
@@ -112,8 +132,6 @@ export function claudeToOpenAIResponse(chunk, state) {
     }
 
     case "message_delta": {
-      // Extract usage from message_delta event (Claude native format)
-      // Normalize to OpenAI format (prompt_tokens/completion_tokens) for consistent logging
       if (chunk.usage && typeof chunk.usage === "object") {
         const inputTokens =
           typeof chunk.usage.input_tokens === "number" ? chunk.usage.input_tokens : 0;
@@ -128,15 +146,17 @@ export function claudeToOpenAIResponse(chunk, state) {
             ? chunk.usage.cache_creation_input_tokens
             : 0;
 
-        // Use OpenAI format keys for consistent logging in stream.js
-        state.usage = {
-          prompt_tokens: inputTokens,
-          completion_tokens: outputTokens,
-          input_tokens: inputTokens,
-          output_tokens: outputTokens,
-        };
+        if (!state.usage) state.usage = {};
 
-        // Store cache tokens if present
+        if (inputTokens > 0) {
+          state.usage.prompt_tokens = inputTokens;
+          state.usage.input_tokens = inputTokens;
+        }
+        if (outputTokens > 0) {
+          state.usage.completion_tokens = outputTokens;
+          state.usage.output_tokens = outputTokens;
+        }
+
         if (cacheReadTokens > 0) {
           state.usage.cache_read_input_tokens = cacheReadTokens;
         }
@@ -214,16 +234,33 @@ export function claudeToOpenAIResponse(chunk, state) {
       if (!state.finishReasonSent) {
         const finishReason =
           state.finishReason || (state.toolCalls?.size > 0 ? "tool_calls" : "stop");
-        const usageObj =
-          state.usage && typeof state.usage === "object"
-            ? {
-                usage: {
-                  prompt_tokens: state.usage.input_tokens || 0,
-                  completion_tokens: state.usage.output_tokens || 0,
-                  total_tokens: (state.usage.input_tokens || 0) + (state.usage.output_tokens || 0),
-                },
-              }
-            : {};
+        let usageObj = {};
+        if (state.usage && typeof state.usage === "object") {
+          const inputTokens = state.usage.input_tokens || 0;
+          const outputTokens = state.usage.output_tokens || 0;
+          const cachedTokens = state.usage.cache_read_input_tokens || 0;
+          const cacheCreationTokens = state.usage.cache_creation_input_tokens || 0;
+          const promptTokens = inputTokens + cachedTokens + cacheCreationTokens;
+          const completionTokens = outputTokens;
+
+          const usageData: OpenAIUsage = {
+            prompt_tokens: promptTokens,
+            completion_tokens: completionTokens,
+            total_tokens: promptTokens + completionTokens,
+          };
+
+          if (cachedTokens > 0 || cacheCreationTokens > 0) {
+            usageData.prompt_tokens_details = {};
+            if (cachedTokens > 0) {
+              usageData.prompt_tokens_details.cached_tokens = cachedTokens;
+            }
+            if (cacheCreationTokens > 0) {
+              usageData.prompt_tokens_details.cache_creation_tokens = cacheCreationTokens;
+            }
+          }
+
+          usageObj = { usage: usageData };
+        }
         results.push({
           id: `chatcmpl-${state.messageId}`,
           object: "chat.completion.chunk",

--- a/open-sse/translator/response/claude-to-openai.ts
+++ b/open-sse/translator/response/claude-to-openai.ts
@@ -43,20 +43,26 @@ export function claudeToOpenAIResponse(chunk, state) {
 
       if (chunk.message?.usage && typeof chunk.message.usage === "object") {
         const u = chunk.message.usage;
-        state.usage = {
-          input_tokens: u.input_tokens || 0,
+        const inputTokens = u.input_tokens || 0;
+        const cacheRead = u.cache_read_input_tokens || 0;
+        const cacheCreation = u.cache_creation_input_tokens || 0;
+        const promptTokens = inputTokens + cacheRead + cacheCreation;
+
+        const incoming: Record<string, number> = {
+          input_tokens: inputTokens,
           output_tokens: u.output_tokens || 0,
-          prompt_tokens: u.input_tokens || 0,
+          prompt_tokens: promptTokens,
           completion_tokens: u.output_tokens || 0,
         };
-        if (typeof u.cache_read_input_tokens === "number" && u.cache_read_input_tokens > 0) {
-          state.usage.cache_read_input_tokens = u.cache_read_input_tokens;
-        }
-        if (
-          typeof u.cache_creation_input_tokens === "number" &&
-          u.cache_creation_input_tokens > 0
-        ) {
-          state.usage.cache_creation_input_tokens = u.cache_creation_input_tokens;
+        if (cacheRead > 0) incoming.cache_read_input_tokens = cacheRead;
+        if (cacheCreation > 0) incoming.cache_creation_input_tokens = cacheCreation;
+
+        if (!state.usage) {
+          state.usage = incoming;
+        } else {
+          for (const key of Object.keys(incoming)) {
+            if (incoming[key] > 0) (state.usage as Record<string, number>)[key] = incoming[key];
+          }
         }
       }
 
@@ -148,20 +154,21 @@ export function claudeToOpenAIResponse(chunk, state) {
 
         if (!state.usage) state.usage = {};
 
-        if (inputTokens > 0) {
-          state.usage.prompt_tokens = inputTokens;
-          state.usage.input_tokens = inputTokens;
-        }
         if (outputTokens > 0) {
           state.usage.completion_tokens = outputTokens;
           state.usage.output_tokens = outputTokens;
         }
-
         if (cacheReadTokens > 0) {
           state.usage.cache_read_input_tokens = cacheReadTokens;
         }
         if (cacheCreationTokens > 0) {
           state.usage.cache_creation_input_tokens = cacheCreationTokens;
+        }
+        if (inputTokens > 0) {
+          state.usage.input_tokens = inputTokens;
+          const cr = state.usage.cache_read_input_tokens || 0;
+          const cc = state.usage.cache_creation_input_tokens || 0;
+          state.usage.prompt_tokens = inputTokens + cr + cc;
         }
       }
 

--- a/open-sse/utils/stream.ts
+++ b/open-sse/utils/stream.ts
@@ -584,9 +584,9 @@ export function createSSEStream(options: StreamOptions = {}) {
             }
           }
 
-          // Extract usage — merge rather than overwrite so that cache tokens
-          // from message_start survive the later message_delta which only
-          // carries output_tokens.
+          // Extract usage — merge rather than overwrite so that usage fields
+          // from message_start survive later message_delta events, which
+          // typically carry output_tokens but may also include other usage fields.
           const extracted = extractUsage(parsed);
           if (extracted) {
             if (!state.usage) {

--- a/open-sse/utils/stream.ts
+++ b/open-sse/utils/stream.ts
@@ -584,9 +584,21 @@ export function createSSEStream(options: StreamOptions = {}) {
             }
           }
 
-          // Extract usage
+          // Extract usage — merge rather than overwrite so that cache tokens
+          // from message_start survive the later message_delta which only
+          // carries output_tokens.
           const extracted = extractUsage(parsed);
-          if (extracted) state.usage = extracted; // Keep original usage for logging
+          if (extracted) {
+            if (!state.usage) {
+              state.usage = extracted;
+            } else {
+              const su = state.usage as Record<string, number>;
+              const eu = extracted as Record<string, number>;
+              for (const key of Object.keys(eu)) {
+                if (eu[key] > 0) su[key] = eu[key];
+              }
+            }
+          }
 
           // Translate: targetFormat -> openai -> sourceFormat
           const translated = translateResponse(targetFormat, sourceFormat, parsed, state);
@@ -775,15 +787,9 @@ export function createSSEStream(options: StreamOptions = {}) {
                 } else {
                   const su = state.usage as Record<string, number>;
                   const eu = extracted as Record<string, number>;
-                  if (eu.prompt_tokens > 0) su.prompt_tokens = eu.prompt_tokens;
-                  if (eu.completion_tokens > 0) su.completion_tokens = eu.completion_tokens;
-                  if (eu.total_tokens > 0) su.total_tokens = eu.total_tokens;
-                  if (eu.cache_read_input_tokens > 0)
-                    su.cache_read_input_tokens = eu.cache_read_input_tokens;
-                  if (eu.cache_creation_input_tokens > 0)
-                    su.cache_creation_input_tokens = eu.cache_creation_input_tokens;
-                  if (eu.cached_tokens > 0) su.cached_tokens = eu.cached_tokens;
-                  if (eu.reasoning_tokens > 0) su.reasoning_tokens = eu.reasoning_tokens;
+                  for (const key of Object.keys(eu)) {
+                    if (eu[key] > 0) su[key] = eu[key];
+                  }
                 }
               }
 

--- a/open-sse/utils/usageTracking.ts
+++ b/open-sse/utils/usageTracking.ts
@@ -174,29 +174,49 @@ export function filterUsageForFormat(usage, targetFormat) {
     }
 
     // Promote flat Claude-style cache tokens → nested OpenAI prompt_tokens_details.
-    // In passthrough mode, the usage object carries cache_read_input_tokens and
-    // cache_creation_input_tokens as flat keys. OpenAI clients expect these inside
-    // prompt_tokens_details.cached_tokens / .cache_creation_tokens.
+    // ai-sdk/openai-compatible parses prompt_tokens_details.cached_tokens via Zod
+    // and drops unknown flat keys. Merge into existing details, then delete flat keys.
     const cacheRead = Number(convertedUsage.cache_read_input_tokens) || 0;
     const cacheCreation = Number(convertedUsage.cache_creation_input_tokens) || 0;
-    if ((cacheRead > 0 || cacheCreation > 0) && !convertedUsage.prompt_tokens_details) {
-      const details: Record<string, number> = {};
-      if (cacheRead > 0) details.cached_tokens = cacheRead;
-      if (cacheCreation > 0) details.cache_creation_tokens = cacheCreation;
+    if (cacheRead > 0 || cacheCreation > 0) {
+      const details: Record<string, number> = {
+        ...(convertedUsage.prompt_tokens_details || {}),
+      };
+      if (cacheRead > 0 && details.cached_tokens === undefined) {
+        details.cached_tokens = cacheRead;
+      }
+      if (cacheCreation > 0 && details.cache_creation_tokens === undefined) {
+        details.cache_creation_tokens = cacheCreation;
+      }
       convertedUsage.prompt_tokens_details = details;
+      delete convertedUsage.cache_read_input_tokens;
+      delete convertedUsage.cache_creation_input_tokens;
     }
 
     // Promote flat cached_tokens → nested prompt_tokens_details.cached_tokens
-    // (some providers set cached_tokens at the top level without nesting)
     const flatCached = Number(convertedUsage.cached_tokens) || 0;
-    if (flatCached > 0 && !convertedUsage.prompt_tokens_details) {
-      convertedUsage.prompt_tokens_details = { cached_tokens: flatCached };
+    if (flatCached > 0) {
+      const details: Record<string, number> = {
+        ...(convertedUsage.prompt_tokens_details || {}),
+      };
+      if (details.cached_tokens === undefined) {
+        details.cached_tokens = flatCached;
+      }
+      convertedUsage.prompt_tokens_details = details;
+      delete convertedUsage.cached_tokens;
     }
 
     // Promote flat reasoning_tokens → nested completion_tokens_details.reasoning_tokens
     const flatReasoning = Number(convertedUsage.reasoning_tokens) || 0;
-    if (flatReasoning > 0 && !convertedUsage.completion_tokens_details) {
-      convertedUsage.completion_tokens_details = { reasoning_tokens: flatReasoning };
+    if (flatReasoning > 0) {
+      const details: Record<string, number> = {
+        ...(convertedUsage.completion_tokens_details || {}),
+      };
+      if (details.reasoning_tokens === undefined) {
+        details.reasoning_tokens = flatReasoning;
+      }
+      convertedUsage.completion_tokens_details = details;
+      delete convertedUsage.reasoning_tokens;
     }
   }
 

--- a/open-sse/utils/usageTracking.ts
+++ b/open-sse/utils/usageTracking.ts
@@ -256,12 +256,12 @@ export function filterUsageForFormat(usage, targetFormat) {
       "estimated",
     ],
     // OpenAI format (default for OPENAI, CODEX, KIRO, etc.)
+    // Flat cached_tokens / reasoning_tokens are promoted into nested *_details
+    // objects upstream and deleted, so they are not listed here.
     default: [
       "prompt_tokens",
       "completion_tokens",
       "total_tokens",
-      "cached_tokens",
-      "reasoning_tokens",
       "prompt_tokens_details",
       "completion_tokens_details",
       "estimated",

--- a/open-sse/utils/usageTracking.ts
+++ b/open-sse/utils/usageTracking.ts
@@ -172,6 +172,32 @@ export function filterUsageForFormat(usage, targetFormat) {
     ) {
       convertedUsage.total_tokens = convertedUsage.prompt_tokens + convertedUsage.completion_tokens;
     }
+
+    // Promote flat Claude-style cache tokens → nested OpenAI prompt_tokens_details.
+    // In passthrough mode, the usage object carries cache_read_input_tokens and
+    // cache_creation_input_tokens as flat keys. OpenAI clients expect these inside
+    // prompt_tokens_details.cached_tokens / .cache_creation_tokens.
+    const cacheRead = Number(convertedUsage.cache_read_input_tokens) || 0;
+    const cacheCreation = Number(convertedUsage.cache_creation_input_tokens) || 0;
+    if ((cacheRead > 0 || cacheCreation > 0) && !convertedUsage.prompt_tokens_details) {
+      const details: Record<string, number> = {};
+      if (cacheRead > 0) details.cached_tokens = cacheRead;
+      if (cacheCreation > 0) details.cache_creation_tokens = cacheCreation;
+      convertedUsage.prompt_tokens_details = details;
+    }
+
+    // Promote flat cached_tokens → nested prompt_tokens_details.cached_tokens
+    // (some providers set cached_tokens at the top level without nesting)
+    const flatCached = Number(convertedUsage.cached_tokens) || 0;
+    if (flatCached > 0 && !convertedUsage.prompt_tokens_details) {
+      convertedUsage.prompt_tokens_details = { cached_tokens: flatCached };
+    }
+
+    // Promote flat reasoning_tokens → nested completion_tokens_details.reasoning_tokens
+    const flatReasoning = Number(convertedUsage.reasoning_tokens) || 0;
+    if (flatReasoning > 0 && !convertedUsage.completion_tokens_details) {
+      convertedUsage.completion_tokens_details = { reasoning_tokens: flatReasoning };
+    }
   }
 
   // Helper to pick only defined fields from usage

--- a/scripts/bootstrap-env.mjs
+++ b/scripts/bootstrap-env.mjs
@@ -13,9 +13,10 @@
  *
  * Priority (lowest → highest):
  *   1. Auto-generated defaults
- *   2. {DATA_DIR}/server.env  (persisted on first boot)
- *   3. Preferred config .env  (DATA_DIR/.env -> ~/.omniroute/.env -> ./.env)
- *   4. process.env            (shell / Docker -e flags, highest priority)
+ *   2. OAuth defaults from .env.example (public client IDs for bootstrap)
+ *   3. {DATA_DIR}/server.env  (persisted on first boot)
+ *   4. Preferred config .env  (DATA_DIR/.env -> ~/.omniroute/.env -> ./.env)
+ *   5. process.env            (shell / Docker -e flags, highest priority)
  */
 
 import { randomBytes } from "node:crypto";
@@ -113,6 +114,38 @@ function parseEnvFile(filePath) {
   return env;
 }
 
+function parseOauthDefaultsFromExample(filePath) {
+  if (!existsSync(filePath)) return {};
+
+  const defaults = {};
+  const lines = readFileSync(filePath, "utf8").split(/\r?\n/);
+  let inOauthSection = false;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    if (/OAUTH PROVIDER CREDENTIALS/i.test(trimmed)) {
+      inOauthSection = true;
+      continue;
+    }
+
+    if (!inOauthSection) continue;
+    if (/Provider User-Agent Overrides/i.test(trimmed)) break;
+    if (!trimmed || trimmed.startsWith("#")) continue;
+
+    const eqIdx = trimmed.indexOf("=");
+    if (eqIdx < 1) continue;
+
+    const key = trimmed.slice(0, eqIdx).trim();
+    const value = trimmed.slice(eqIdx + 1).trim();
+    if (!key.endsWith("_OAUTH_CLIENT_ID") || !value) continue;
+
+    defaults[key] = value;
+  }
+
+  return defaults;
+}
+
 // ── Write a simple KEY=VALUE env file ───────────────────────────────────────
 function writeEnvFile(filePath, env) {
   const lines = [
@@ -133,9 +166,15 @@ function writeEnvFile(filePath, env) {
 export function bootstrapEnv({ dataDirOverride, quiet = false } = {}) {
   const log = quiet ? () => {} : (msg) => process.stderr.write(`[bootstrap] ${msg}\n`);
 
+  const envExamplePath = join(process.cwd(), ".env.example");
+  const oauthDefaults = parseOauthDefaultsFromExample(envExamplePath);
   const preferredEnvPath = getPreferredEnvFilePath(process.env);
   const preferredEnv = preferredEnvPath ? parseEnvFile(preferredEnvPath) : {};
-  const dataDir = resolveDataDir(dataDirOverride, { ...preferredEnv, ...process.env });
+  const dataDir = resolveDataDir(dataDirOverride, {
+    ...oauthDefaults,
+    ...preferredEnv,
+    ...process.env,
+  });
   const serverEnvPath = join(dataDir, "server.env");
 
   // ── Layer 1: Load persisted server.env ────────────────────────────────────
@@ -143,7 +182,7 @@ export function bootstrapEnv({ dataDirOverride, quiet = false } = {}) {
 
   // ── Layer 2: Load the same preferred .env that the CLI wrapper uses ───────
   // This keeps run-next / run-standalone consistent with `bin/omniroute.mjs`.
-  const merged = { ...persisted, ...preferredEnv, ...process.env };
+  const merged = { ...oauthDefaults, ...persisted, ...preferredEnv, ...process.env };
 
   // ── Auto-generate required secrets ────────────────────────────────────────
   let needsPersist = false;

--- a/src/app/(dashboard)/dashboard/settings/components/ForwardingKeywordsTab.tsx
+++ b/src/app/(dashboard)/dashboard/settings/components/ForwardingKeywordsTab.tsx
@@ -8,6 +8,8 @@ type ForwardingKeywordsResponse = {
   defaults: Record<string, unknown>;
 };
 
+type ForwardingKeywordsStatus = "" | "loading" | "loaded" | "reloading" | "reloaded" | "saved";
+
 function formatJson(value: unknown) {
   return JSON.stringify(value, null, 2);
 }
@@ -19,7 +21,7 @@ export default function ForwardingKeywordsTab() {
   const [draft, setDraft] = useState("");
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
-  const [status, setStatus] = useState("");
+  const [status, setStatus] = useState<ForwardingKeywordsStatus>("");
   const [error, setError] = useState("");
 
   const isDirty = useMemo(() => {
@@ -27,7 +29,12 @@ export default function ForwardingKeywordsTab() {
     return draft !== formatJson(config);
   }, [config, draft]);
 
-  const load = async () => {
+  const load = async (
+    statusAfterLoad: ForwardingKeywordsStatus = "loaded",
+    statusWhileLoading: ForwardingKeywordsStatus = "loading"
+  ) => {
+    setStatus(statusWhileLoading);
+    setError("");
     try {
       const res = await fetch("/api/settings/forwarding-keywords");
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
@@ -35,8 +42,9 @@ export default function ForwardingKeywordsTab() {
       setConfig(data.config);
       setDefaults(data.defaults);
       setDraft(formatJson(data.config));
-      setError("");
+      setStatus(statusAfterLoad);
     } catch (err) {
+      setStatus("");
       setError(err instanceof Error ? err.message : "Failed to load forwarding keyword settings");
     } finally {
       setLoading(false);
@@ -113,22 +121,50 @@ export default function ForwardingKeywordsTab() {
         <div className="flex-1">
           <h3 className="text-lg font-semibold">Forwarding Keyword Rules</h3>
           <p className="text-sm text-text-muted">
-            Manage Claude OAuth lexical rewrite rules in OmniRoute settings instead of editing proxy
-            code. Changes apply only inside the proxy forwarding path.
+            Configure Claude OAuth lexical rewrite rules in OmniRoute settings. These rules apply
+            only inside the proxy forwarding path.
           </p>
         </div>
-        {status === "saved" && (
-          <span className="text-xs font-medium text-emerald-500 flex items-center gap-1">
-            <span className="material-symbols-outlined text-[14px]">check_circle</span>
-            Saved
-          </span>
-        )}
+        <div className="flex items-center gap-2">
+          {isDirty ? (
+            <span className="text-xs font-medium text-amber-400 flex items-center gap-1">
+              <span className="material-symbols-outlined text-[14px]">edit</span>
+              Unsaved edits
+            </span>
+          ) : status === "saved" ? (
+            <span className="text-xs font-medium text-emerald-500 flex items-center gap-1">
+              <span className="material-symbols-outlined text-[14px]">check_circle</span>
+              Saved and applied
+            </span>
+          ) : status === "reloading" ? (
+            <span className="text-xs font-medium text-sky-400 flex items-center gap-1">
+              <span className="material-symbols-outlined text-[14px]">hourglass_top</span>
+              Reloading from server
+            </span>
+          ) : status === "loading" ? (
+            <span className="text-xs font-medium text-text-muted flex items-center gap-1">
+              <span className="material-symbols-outlined text-[14px]">hourglass_top</span>
+              Loading from server
+            </span>
+          ) : status === "reloaded" ? (
+            <span className="text-xs font-medium text-sky-400 flex items-center gap-1">
+              <span className="material-symbols-outlined text-[14px]">refresh</span>
+              Reloaded from server
+            </span>
+          ) : status === "loaded" ? (
+            <span className="text-xs font-medium text-text-muted flex items-center gap-1">
+              <span className="material-symbols-outlined text-[14px]">info</span>
+              Loaded from server
+            </span>
+          ) : null}
+        </div>
       </div>
 
       <div className="flex flex-col gap-3">
         <div className="rounded-lg border border-border/40 bg-surface/30 p-3 text-xs text-text-muted leading-relaxed">
           Edit the JSON for lane-specific rewrite rules. Tool names, free text, and prompt-tag
-          replacements are all persisted in settings and loaded by the proxy before forwarding.
+          replacements are persisted in settings and applied by the proxy before the Anthropic
+          request is forwarded. Reload replaces local edits with the last saved server config.
         </div>
 
         <textarea
@@ -159,7 +195,12 @@ export default function ForwardingKeywordsTab() {
           >
             Reset editor to defaults
           </Button>
-          <Button size="sm" variant="ghost" onClick={load} disabled={loading || saving}>
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => load("reloaded", "reloading")}
+            disabled={loading || saving}
+          >
             Reload
           </Button>
         </div>

--- a/src/app/(dashboard)/dashboard/settings/components/ForwardingKeywordsTab.tsx
+++ b/src/app/(dashboard)/dashboard/settings/components/ForwardingKeywordsTab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Button, Card } from "@/shared/components";
 
 type ForwardingKeywordsResponse = {
@@ -13,6 +13,7 @@ function formatJson(value: unknown) {
 }
 
 export default function ForwardingKeywordsTab() {
+  const saveStatusTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [config, setConfig] = useState<Record<string, unknown> | null>(null);
   const [defaults, setDefaults] = useState<Record<string, unknown> | null>(null);
   const [draft, setDraft] = useState("");
@@ -44,6 +45,12 @@ export default function ForwardingKeywordsTab() {
 
   useEffect(() => {
     load();
+
+    return () => {
+      if (saveStatusTimeoutRef.current) {
+        clearTimeout(saveStatusTimeoutRef.current);
+      }
+    };
   }, []);
 
   const save = async () => {
@@ -74,7 +81,13 @@ export default function ForwardingKeywordsTab() {
       setDefaults(data.defaults);
       setDraft(formatJson(data.config));
       setStatus("saved");
-      setTimeout(() => setStatus(""), 2000);
+      if (saveStatusTimeoutRef.current) {
+        clearTimeout(saveStatusTimeoutRef.current);
+      }
+      saveStatusTimeoutRef.current = setTimeout(() => {
+        setStatus("");
+        saveStatusTimeoutRef.current = null;
+      }, 2000);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to save forwarding keyword settings");
     } finally {

--- a/src/app/(dashboard)/dashboard/settings/components/ForwardingKeywordsTab.tsx
+++ b/src/app/(dashboard)/dashboard/settings/components/ForwardingKeywordsTab.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Button, Card } from "@/shared/components";
+
+type ForwardingKeywordsResponse = {
+  config: Record<string, unknown>;
+  defaults: Record<string, unknown>;
+};
+
+function formatJson(value: unknown) {
+  return JSON.stringify(value, null, 2);
+}
+
+export default function ForwardingKeywordsTab() {
+  const [config, setConfig] = useState<Record<string, unknown> | null>(null);
+  const [defaults, setDefaults] = useState<Record<string, unknown> | null>(null);
+  const [draft, setDraft] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [status, setStatus] = useState("");
+  const [error, setError] = useState("");
+
+  const isDirty = useMemo(() => {
+    if (!config) return false;
+    return draft !== formatJson(config);
+  }, [config, draft]);
+
+  const load = async () => {
+    try {
+      const res = await fetch("/api/settings/forwarding-keywords");
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = (await res.json()) as ForwardingKeywordsResponse;
+      setConfig(data.config);
+      setDefaults(data.defaults);
+      setDraft(formatJson(data.config));
+      setError("");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load forwarding keyword settings");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const save = async () => {
+    setStatus("");
+    setError("");
+
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(draft) as Record<string, unknown>;
+    } catch {
+      setError("JSON is invalid. Fix the editor content before saving.");
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const res = await fetch("/api/settings/forwarding-keywords", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(parsed),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        const message = data?.error?.message || data?.error || "Failed to save forwarding keywords";
+        throw new Error(String(message));
+      }
+      setConfig(data.config);
+      setDefaults(data.defaults);
+      setDraft(formatJson(data.config));
+      setStatus("saved");
+      setTimeout(() => setStatus(""), 2000);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save forwarding keyword settings");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const resetToDefaults = () => {
+    if (!defaults) return;
+    setDraft(formatJson(defaults));
+    setStatus("");
+    setError("");
+  };
+
+  return (
+    <Card>
+      <div className="flex items-center gap-3 mb-5">
+        <div className="p-2 rounded-lg bg-sky-500/10 text-sky-500">
+          <span className="material-symbols-outlined text-[20px]" aria-hidden="true">
+            conversion_path
+          </span>
+        </div>
+        <div className="flex-1">
+          <h3 className="text-lg font-semibold">Forwarding Keyword Rules</h3>
+          <p className="text-sm text-text-muted">
+            Manage Claude OAuth lexical rewrite rules in OmniRoute settings instead of editing proxy
+            code. Changes apply only inside the proxy forwarding path.
+          </p>
+        </div>
+        {status === "saved" && (
+          <span className="text-xs font-medium text-emerald-500 flex items-center gap-1">
+            <span className="material-symbols-outlined text-[14px]">check_circle</span>
+            Saved
+          </span>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <div className="rounded-lg border border-border/40 bg-surface/30 p-3 text-xs text-text-muted leading-relaxed">
+          Edit the JSON for lane-specific rewrite rules. Tool names, free text, and prompt-tag
+          replacements are all persisted in settings and loaded by the proxy before forwarding.
+        </div>
+
+        <textarea
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          rows={18}
+          spellCheck={false}
+          disabled={loading || saving}
+          className="w-full rounded-lg border border-border/50 bg-surface/30 px-4 py-3 font-mono text-sm leading-6 resize-y min-h-[360px] focus:outline-none focus:ring-1 focus:ring-sky-500/30 focus:border-sky-500/50"
+        />
+
+        {error && <p className="text-sm text-rose-400">{error}</p>}
+
+        <div className="flex items-center gap-3">
+          <Button
+            size="sm"
+            variant="primary"
+            onClick={save}
+            disabled={loading || saving || !isDirty}
+          >
+            {saving ? "Saving..." : "Save forwarding rules"}
+          </Button>
+          <Button
+            size="sm"
+            variant="secondary"
+            onClick={resetToDefaults}
+            disabled={loading || saving || !defaults}
+          >
+            Reset editor to defaults
+          </Button>
+          <Button size="sm" variant="ghost" onClick={load} disabled={loading || saving}>
+            Reload
+          </Button>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/src/app/(dashboard)/dashboard/settings/components/ForwardingKeywordsTab.tsx
+++ b/src/app/(dashboard)/dashboard/settings/components/ForwardingKeywordsTab.tsx
@@ -33,6 +33,7 @@ export default function ForwardingKeywordsTab() {
     statusAfterLoad: ForwardingKeywordsStatus = "loaded",
     statusWhileLoading: ForwardingKeywordsStatus = "loading"
   ) => {
+    setLoading(true);
     setStatus(statusWhileLoading);
     setError("");
     try {

--- a/src/app/(dashboard)/dashboard/settings/components/ThinkingBudgetTab.tsx
+++ b/src/app/(dashboard)/dashboard/settings/components/ThinkingBudgetTab.tsx
@@ -36,6 +36,7 @@ const EFFORTS = [
   { value: "low", labelKey: "effortLow" },
   { value: "medium", labelKey: "effortMedium" },
   { value: "high", labelKey: "effortHigh" },
+  { value: "max", label: "Max (pass through)" },
 ];
 
 export default function ThinkingBudgetTab() {
@@ -166,8 +167,11 @@ export default function ThinkingBudgetTab() {
       {config.mode === "adaptive" && (
         <div className="p-4 rounded-lg bg-surface/30 border border-border/30">
           <p className="text-sm font-medium mb-3">{t("baseEffortLevel")}</p>
-          <p className="text-xs text-text-muted mb-3">{t("adaptiveHint")}</p>
-          <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+          <p className="text-xs text-text-muted mb-3">
+            Claude/Anthropic requests use adaptive thinking and forward the effort setting upstream.
+            Other providers continue to scale proxy-managed thinking budgets from this base level.
+          </p>
+          <div className="grid grid-cols-2 sm:grid-cols-5 gap-2">
             {EFFORTS.map((e) => (
               <button
                 key={e.value}
@@ -179,7 +183,7 @@ export default function ThinkingBudgetTab() {
                     : "border-border/50 text-text-muted hover:border-border"
                 }`}
               >
-                {t(e.labelKey)}
+                {e.label ?? t(e.labelKey)}
               </button>
             ))}
           </div>

--- a/src/app/(dashboard)/dashboard/settings/page.tsx
+++ b/src/app/(dashboard)/dashboard/settings/page.tsx
@@ -10,6 +10,7 @@ import SecurityTab from "./components/SecurityTab";
 import RoutingTab from "./components/RoutingTab";
 import ComboDefaultsTab from "./components/ComboDefaultsTab";
 import ProxyTab from "./components/ProxyTab";
+import ForwardingKeywordsTab from "./components/ForwardingKeywordsTab";
 import AppearanceTab from "./components/AppearanceTab";
 import ThinkingBudgetTab from "./components/ThinkingBudgetTab";
 import CodexServiceTierTab from "./components/CodexServiceTierTab";
@@ -116,6 +117,7 @@ export default function SettingsPage() {
           {activeTab === "advanced" && (
             <div className="flex flex-col gap-6">
               <ProxyTab />
+              <ForwardingKeywordsTab />
               <CliproxyapiSettingsTab />
             </div>
           )}

--- a/src/app/api/settings/__tests__/forwarding-keywords.test.ts
+++ b/src/app/api/settings/__tests__/forwarding-keywords.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { GET, PUT } from "../forwarding-keywords/route";
+import {
+  getDefaultForwardingKeywordConfig,
+  setForwardingKeywordConfig,
+} from "@omniroute/open-sse/config/forwardingKeywordRules.ts";
+
+vi.mock("../../../../lib/localDb", () => {
+  const original = vi.importActual("../../../../lib/localDb");
+  return {
+    ...original,
+    getSettings: vi.fn(),
+    updateSettings: vi.fn(),
+  };
+});
+
+import { getSettings, updateSettings } from "../../../../lib/localDb";
+
+function createPutRequest(body: unknown) {
+  return new Request("http://localhost/api/settings/forwarding-keywords", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("/api/settings/forwarding-keywords", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    setForwardingKeywordConfig(getDefaultForwardingKeywordConfig());
+    (getSettings as any).mockResolvedValue({
+      forwardingKeywordRules: getDefaultForwardingKeywordConfig(),
+    });
+    (updateSettings as any).mockImplementation(async (updates: Record<string, unknown>) => updates);
+  });
+
+  it("returns persisted forwarding keyword config", async () => {
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.config["claude-oauth-prefixed"].toolNames[0]).toEqual({
+      match: "background_output",
+      replace: "background_result",
+    });
+    expect(json.defaults["claude-oauth-prefixed"].tags[0].open).toBe("<directories>");
+  });
+
+  it("persists updated forwarding keyword config", async () => {
+    const body = {
+      "claude-oauth-prefixed": {
+        toolNames: [{ match: "background_output", replace: "bg_out" }],
+        text: [{ match: "background_output", replace: "bg_out" }],
+        tags: [
+          {
+            open: "<directories>",
+            openReplacement: "dirs:\n",
+            close: "</directories>",
+            closeReplacement: "",
+          },
+        ],
+      },
+    };
+
+    const res = await PUT(createPutRequest(body));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(updateSettings).toHaveBeenCalledOnce();
+    expect((updateSettings as any).mock.calls[0][0].forwardingKeywordRules).toEqual(body);
+    expect(json.config["claude-oauth-prefixed"].toolNames[0].replace).toBe("bg_out");
+  });
+
+  it("preserves intentionally empty rule arrays", async () => {
+    const body = {
+      "claude-oauth-prefixed": {
+        toolNames: [],
+        text: [],
+        tags: [],
+      },
+    };
+
+    const res = await PUT(createPutRequest(body));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.config["claude-oauth-prefixed"]).toEqual(body["claude-oauth-prefixed"]);
+  });
+});

--- a/src/app/api/settings/__tests__/forwarding-keywords.test.ts
+++ b/src/app/api/settings/__tests__/forwarding-keywords.test.ts
@@ -72,7 +72,7 @@ describe("/api/settings/forwarding-keywords", () => {
     expect(json.config["claude-oauth-prefixed"].toolNames[0].replace).toBe("bg_out");
   });
 
-  it("preserves intentionally empty rule arrays", async () => {
+  it("keeps default rewrite rules when empty arrays are saved", async () => {
     const body = {
       "claude-oauth-prefixed": {
         toolNames: [],
@@ -84,7 +84,30 @@ describe("/api/settings/forwarding-keywords", () => {
     const res = await PUT(createPutRequest(body));
     expect(res.status).toBe(200);
     const json = await res.json();
-    expect(json.config["claude-oauth-prefixed"]).toEqual(body["claude-oauth-prefixed"]);
+    expect(json.config["claude-oauth-prefixed"]).toEqual(
+      getDefaultForwardingKeywordConfig()["claude-oauth-prefixed"]
+    );
+  });
+
+  it("overrides matching defaults without disabling the rest", async () => {
+    const body = {
+      "claude-oauth-prefixed": {
+        toolNames: [{ match: "background_output", replace: "bg_out" }],
+        text: [],
+        tags: [],
+      },
+    };
+
+    const res = await PUT(createPutRequest(body));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.config["claude-oauth-prefixed"].toolNames).toEqual([
+      { match: "background_output", replace: "bg_out" },
+      { match: "background_cancel", replace: "background_stop" },
+    ]);
+    expect(json.config["claude-oauth-prefixed"].text).toEqual(
+      getDefaultForwardingKeywordConfig()["claude-oauth-prefixed"].text
+    );
   });
 
   it("rejects whitespace-only keyword matches", async () => {

--- a/src/app/api/settings/__tests__/forwarding-keywords.test.ts
+++ b/src/app/api/settings/__tests__/forwarding-keywords.test.ts
@@ -16,6 +16,9 @@ vi.mock("../../../../lib/localDb", () => {
 
 import { getSettings, updateSettings } from "../../../../lib/localDb";
 
+const mockedGetSettings = vi.mocked(getSettings);
+const mockedUpdateSettings = vi.mocked(updateSettings);
+
 function createPutRequest(body: unknown) {
   return new Request("http://localhost/api/settings/forwarding-keywords", {
     method: "PUT",
@@ -28,10 +31,10 @@ describe("/api/settings/forwarding-keywords", () => {
   beforeEach(() => {
     vi.resetAllMocks();
     setForwardingKeywordConfig(getDefaultForwardingKeywordConfig());
-    (getSettings as any).mockResolvedValue({
+    mockedGetSettings.mockResolvedValue({
       forwardingKeywordRules: getDefaultForwardingKeywordConfig(),
     });
-    (updateSettings as any).mockImplementation(async (updates: Record<string, unknown>) => updates);
+    mockedUpdateSettings.mockImplementation(async (updates: Record<string, unknown>) => updates);
   });
 
   it("returns persisted forwarding keyword config", async () => {
@@ -64,8 +67,8 @@ describe("/api/settings/forwarding-keywords", () => {
     const res = await PUT(createPutRequest(body));
     expect(res.status).toBe(200);
     const json = await res.json();
-    expect(updateSettings).toHaveBeenCalledOnce();
-    expect((updateSettings as any).mock.calls[0][0].forwardingKeywordRules).toEqual(body);
+    expect(mockedUpdateSettings).toHaveBeenCalledOnce();
+    expect(mockedUpdateSettings.mock.calls[0][0].forwardingKeywordRules).toEqual(body);
     expect(json.config["claude-oauth-prefixed"].toolNames[0].replace).toBe("bg_out");
   });
 
@@ -82,5 +85,26 @@ describe("/api/settings/forwarding-keywords", () => {
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.config["claude-oauth-prefixed"]).toEqual(body["claude-oauth-prefixed"]);
+  });
+
+  it("rejects whitespace-only keyword matches", async () => {
+    const body = {
+      "claude-oauth-prefixed": {
+        toolNames: [{ match: "   ", replace: "bg_out" }],
+        text: [{ match: "background_output", replace: "bg_out" }],
+        tags: [
+          {
+            open: "<directories>",
+            openReplacement: "dirs:\n",
+            close: "</directories>",
+            closeReplacement: "",
+          },
+        ],
+      },
+    };
+
+    const res = await PUT(createPutRequest(body));
+    expect(res.status).toBe(400);
+    expect(mockedUpdateSettings).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/settings/forwarding-keywords/route.ts
+++ b/src/app/api/settings/forwarding-keywords/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse } from "next/server";
+import { getSettings, updateSettings } from "@/lib/localDb";
+import {
+  getDefaultForwardingKeywordConfig,
+  getForwardingKeywordConfig,
+  setForwardingKeywordConfig,
+} from "@omniroute/open-sse/config/forwardingKeywordRules.ts";
+import { isValidationFailure, validateBody } from "@/shared/validation/helpers";
+import { updateForwardingKeywordRulesSchema } from "@/shared/validation/settingsSchemas";
+
+export async function GET() {
+  try {
+    const settings = await getSettings();
+    setForwardingKeywordConfig((settings as Record<string, unknown>).forwardingKeywordRules);
+
+    return NextResponse.json({
+      config: getForwardingKeywordConfig(),
+      defaults: getDefaultForwardingKeywordConfig(),
+    });
+  } catch (error) {
+    console.error("Error reading forwarding keyword settings:", error);
+    return NextResponse.json(
+      { error: "Failed to read forwarding keyword settings" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function PUT(request: Request) {
+  let rawBody: unknown;
+  try {
+    rawBody = await request.json();
+  } catch {
+    return NextResponse.json(
+      {
+        error: {
+          message: "Invalid request",
+          details: [{ field: "body", message: "Invalid JSON body" }],
+        },
+      },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const validation = validateBody(updateForwardingKeywordRulesSchema, rawBody);
+    if (isValidationFailure(validation)) {
+      return NextResponse.json({ error: validation.error }, { status: 400 });
+    }
+
+    const body = validation.data;
+    await updateSettings({ forwardingKeywordRules: body });
+    setForwardingKeywordConfig(body);
+
+    return NextResponse.json({
+      config: getForwardingKeywordConfig(),
+      defaults: getDefaultForwardingKeywordConfig(),
+    });
+  } catch (error) {
+    console.error("Error updating forwarding keyword settings:", error);
+    return NextResponse.json(
+      { error: "Failed to update forwarding keyword settings" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/settings/thinking-budget/route.ts
+++ b/src/app/api/settings/thinking-budget/route.ts
@@ -1,15 +1,17 @@
 import { NextResponse } from "next/server";
 import { getSettings, updateSettings } from "@/lib/localDb";
 import {
+  applyThinkingBudgetSettings,
   setThinkingBudgetConfig,
   getThinkingBudgetConfig,
-  ThinkingMode,
 } from "@omniroute/open-sse/services/thinkingBudget.ts";
-import { updateThinkingBudgetSchema } from "@/shared/validation/schemas";
+import { updateThinkingBudgetSchema } from "@/shared/validation/settingsSchemas";
 import { isValidationFailure, validateBody } from "@/shared/validation/helpers";
 
 export async function GET() {
   try {
+    const settings = await getSettings();
+    applyThinkingBudgetSettings(settings);
     const config = getThinkingBudgetConfig();
     return NextResponse.json(config);
   } catch (error) {

--- a/src/lib/oauth/constants/oauth.ts
+++ b/src/lib/oauth/constants/oauth.ts
@@ -13,7 +13,7 @@ export const CLAUDE_CONFIG = {
   authorizeUrl: "https://claude.ai/oauth/authorize",
   tokenUrl: "https://console.anthropic.com/v1/oauth/token",
   redirectUri:
-    process.env.CLAUDE_CODE_REDIRECT_URI || "https://platform.claude.com/oauth/code/callback",
+    process.env.CLAUDE_CODE_REDIRECT_URI || "https://console.anthropic.com/oauth/code/callback",
   scopes: [
     "org:create_api_key",
     "user:profile",

--- a/src/lib/oauth/constants/oauth.ts
+++ b/src/lib/oauth/constants/oauth.ts
@@ -13,7 +13,7 @@ export const CLAUDE_CONFIG = {
   authorizeUrl: "https://claude.ai/oauth/authorize",
   tokenUrl: "https://console.anthropic.com/v1/oauth/token",
   redirectUri:
-    process.env.CLAUDE_CODE_REDIRECT_URI || "https://console.anthropic.com/oauth/code/callback",
+    process.env.CLAUDE_CODE_REDIRECT_URI || "https://platform.claude.com/oauth/code/callback",
   scopes: [
     "org:create_api_key",
     "user:profile",

--- a/src/lib/tokenHealthCheck.ts
+++ b/src/lib/tokenHealthCheck.ts
@@ -54,6 +54,15 @@ export function buildRefreshFailureUpdate(conn: any, now: string) {
   };
 }
 
+export function unwrapResolvedProxyConfig(
+  resolvedProxy:
+    | { proxy?: unknown; level?: string | null; levelId?: string | null }
+    | null
+    | undefined
+) {
+  return resolvedProxy?.proxy || null;
+}
+
 function isEnvFlagEnabled(name: string): boolean {
   const value = process.env[name];
   if (!value) return false;
@@ -255,7 +264,7 @@ async function checkConnection(conn) {
   };
 
   const hideLogs = await shouldHideLogs();
-  const proxyConfig = await resolveProxyForConnection(conn.id);
+  const proxyConfig = unwrapResolvedProxyConfig(await resolveProxyForConnection(conn.id));
   const result = await getAccessToken(
     conn.provider,
     credentials,

--- a/src/shared/constants/modelSpecs.ts
+++ b/src/shared/constants/modelSpecs.ts
@@ -4,6 +4,9 @@
  * when clients request more than the model supports.
  */
 
+export type ThinkingMode = "enabled" | "adaptive" | "disabled";
+export type ThinkingDisplay = "summarized" | "omitted";
+
 export interface ModelSpec {
   maxOutputTokens: number;
   contextWindow?: number;
@@ -15,6 +18,11 @@ export interface ModelSpec {
   supportsThinking?: boolean;
   supportsTools?: boolean;
   supportsVision?: boolean;
+  // Opus 4.7+ model constraints
+  supportedThinkingModes?: ThinkingMode[]; // which thinking types the model accepts
+  supportedEfforts?: string[]; // valid effort levels for this model
+  defaultThinkingDisplay?: ThinkingDisplay; // default display mode for thinking blocks
+  rejectsSamplingParams?: boolean; // true if non-default temperature/top_p/top_k → 400
 }
 
 export const MODEL_SPECS: Record<string, ModelSpec> = {
@@ -69,12 +77,30 @@ export const MODEL_SPECS: Record<string, ModelSpec> = {
   // ── Claude Opus 4.6 ─────────────────────────────────────────────
   "claude-opus-4-6": {
     maxOutputTokens: 128000,
-    contextWindow: 200000,
+    contextWindow: 1048576,
     defaultThinkingBudget: 10000,
     thinkingBudgetCap: 128000,
     supportsThinking: true,
     supportsTools: true,
     supportsVision: true,
+    supportedThinkingModes: ["enabled", "adaptive", "disabled"],
+    supportedEfforts: ["low", "medium", "high", "max"],
+    defaultThinkingDisplay: "summarized",
+  },
+
+  // ── Claude Opus 4.7 ─────────────────────────────────────────────
+  "claude-opus-4-7": {
+    maxOutputTokens: 128000,
+    contextWindow: 1048576,
+    defaultThinkingBudget: 0,
+    thinkingBudgetCap: 0,
+    supportsThinking: true,
+    supportsTools: true,
+    supportsVision: true,
+    supportedThinkingModes: ["adaptive", "disabled"],
+    supportedEfforts: ["low", "medium", "high", "xhigh", "max"],
+    defaultThinkingDisplay: "omitted",
+    rejectsSamplingParams: true,
   },
 
   // Defaults
@@ -119,4 +145,33 @@ export function resolveModelAlias(modelId: string): string {
     if (spec.aliases?.includes(modelId)) return canonical;
   }
   return modelId;
+}
+
+export function isAdaptiveOnlyModel(modelId: string): boolean {
+  const spec = getModelSpec(modelId);
+  if (!spec?.supportedThinkingModes) return false;
+  return (
+    spec.supportedThinkingModes.includes("adaptive") &&
+    !spec.supportedThinkingModes.includes("enabled")
+  );
+}
+
+export function getDefaultThinkingDisplay(modelId: string): ThinkingDisplay | undefined {
+  return getModelSpec(modelId)?.defaultThinkingDisplay;
+}
+
+export function rejectsSamplingParams(modelId: string): boolean {
+  return getModelSpec(modelId)?.rejectsSamplingParams === true;
+}
+
+export function isEffortSupported(modelId: string, effort: string): boolean {
+  const spec = getModelSpec(modelId);
+  if (!spec?.supportedEfforts) return true;
+  return spec.supportedEfforts.includes(effort);
+}
+
+export function downgradeEffort(modelId: string, effort: string): string {
+  if (isEffortSupported(modelId, effort)) return effort;
+  if (effort === "xhigh") return "max";
+  return effort;
 }

--- a/src/shared/constants/modelSpecs.ts
+++ b/src/shared/constants/modelSpecs.ts
@@ -66,6 +66,17 @@ export const MODEL_SPECS: Record<string, ModelSpec> = {
     supportsVision: true,
   },
 
+  // ── Claude Opus 4.6 ─────────────────────────────────────────────
+  "claude-opus-4-6": {
+    maxOutputTokens: 128000,
+    contextWindow: 200000,
+    defaultThinkingBudget: 10000,
+    thinkingBudgetCap: 128000,
+    supportsThinking: true,
+    supportsTools: true,
+    supportsVision: true,
+  },
+
   // Defaults
   __default__: {
     maxOutputTokens: 8192,

--- a/src/shared/validation/settingsSchemas.ts
+++ b/src/shared/validation/settingsSchemas.ts
@@ -30,6 +30,12 @@ export const updateForwardingKeywordRulesSchema = z.object({
   "claude-oauth-prefixed": forwardingKeywordLaneSchema,
 });
 
+export const updateThinkingBudgetSchema = z.object({
+  mode: z.enum(["auto", "passthrough", "custom", "adaptive"]),
+  customBudget: z.number().int().min(0).max(131072),
+  effortLevel: z.enum(["none", "low", "medium", "high", "max"]),
+});
+
 export const updateSettingsSchema = z.object({
   newPassword: z.string().min(1).max(200).optional(),
   currentPassword: z.string().max(200).optional(),

--- a/src/shared/validation/settingsSchemas.ts
+++ b/src/shared/validation/settingsSchemas.ts
@@ -8,6 +8,28 @@
 import { z } from "zod";
 import { HIDEABLE_SIDEBAR_ITEM_IDS } from "@/shared/constants/sidebarVisibility";
 
+const forwardingKeywordRuleSchema = z.object({
+  match: z.string().min(1).max(200),
+  replace: z.string().max(200),
+});
+
+const forwardingTagRuleSchema = z.object({
+  open: z.string().min(1).max(200),
+  openReplacement: z.string().max(200),
+  close: z.string().min(1).max(200),
+  closeReplacement: z.string().max(200),
+});
+
+const forwardingKeywordLaneSchema = z.object({
+  toolNames: z.array(forwardingKeywordRuleSchema).max(50),
+  text: z.array(forwardingKeywordRuleSchema).max(50),
+  tags: z.array(forwardingTagRuleSchema).max(20),
+});
+
+export const updateForwardingKeywordRulesSchema = z.object({
+  "claude-oauth-prefixed": forwardingKeywordLaneSchema,
+});
+
 export const updateSettingsSchema = z.object({
   newPassword: z.string().min(1).max(200).optional(),
   currentPassword: z.string().max(200).optional(),

--- a/src/shared/validation/settingsSchemas.ts
+++ b/src/shared/validation/settingsSchemas.ts
@@ -9,14 +9,14 @@ import { z } from "zod";
 import { HIDEABLE_SIDEBAR_ITEM_IDS } from "@/shared/constants/sidebarVisibility";
 
 const forwardingKeywordRuleSchema = z.object({
-  match: z.string().min(1).max(200),
+  match: z.string().trim().min(1).max(200),
   replace: z.string().max(200),
 });
 
 const forwardingTagRuleSchema = z.object({
-  open: z.string().min(1).max(200),
+  open: z.string().trim().min(1).max(200),
   openReplacement: z.string().max(200),
-  close: z.string().min(1).max(200),
+  close: z.string().trim().min(1).max(200),
   closeReplacement: z.string().max(200),
 });
 

--- a/src/sse/handlers/chat.ts
+++ b/src/sse/handlers/chat.ts
@@ -48,7 +48,7 @@ import {
   applyTaskAwareRouting,
   getTaskRoutingConfig,
 } from "@omniroute/open-sse/services/taskAwareRouter.ts";
-import { setForwardingKeywordConfig } from "@omniroute/open-sse/config/forwardingKeywordRules.ts";
+import { applyForwardingKeywordSettings } from "@omniroute/open-sse/config/forwardingKeywordRules.ts";
 import {
   generateSessionId as generateStableSessionId,
   touchSession,
@@ -448,8 +448,14 @@ async function handleSingleModelChat(
 
   const { provider, model, sourceFormat, targetFormat, extendedContext } = resolved;
   const forceLiveComboTest = runtimeOptions.forceLiveComboTest === true;
-  const settings = await getSettings().catch(() => ({}));
-  setForwardingKeywordConfig((settings as any)?.forwardingKeywordRules);
+  try {
+    const settings = await getSettings();
+    applyForwardingKeywordSettings(settings);
+  } catch (error) {
+    log.warn("forwarding-keyword-settings", "Failed to load forwarding keyword settings", {
+      error,
+    });
+  }
 
   // 2. Pipeline gates (availability + circuit breaker)
   const gate = checkPipelineGates(provider, model, {

--- a/src/sse/handlers/chat.ts
+++ b/src/sse/handlers/chat.ts
@@ -48,6 +48,7 @@ import {
   applyTaskAwareRouting,
   getTaskRoutingConfig,
 } from "@omniroute/open-sse/services/taskAwareRouter.ts";
+import { setForwardingKeywordConfig } from "@omniroute/open-sse/config/forwardingKeywordRules.ts";
 import {
   generateSessionId as generateStableSessionId,
   touchSession,
@@ -447,6 +448,8 @@ async function handleSingleModelChat(
 
   const { provider, model, sourceFormat, targetFormat, extendedContext } = resolved;
   const forceLiveComboTest = runtimeOptions.forceLiveComboTest === true;
+  const settings = await getSettings().catch(() => ({}));
+  setForwardingKeywordConfig((settings as any)?.forwardingKeywordRules);
 
   // 2. Pipeline gates (availability + circuit breaker)
   const gate = checkPipelineGates(provider, model, {

--- a/src/sse/handlers/chat.ts
+++ b/src/sse/handlers/chat.ts
@@ -49,6 +49,7 @@ import {
   getTaskRoutingConfig,
 } from "@omniroute/open-sse/services/taskAwareRouter.ts";
 import { applyForwardingKeywordSettings } from "@omniroute/open-sse/config/forwardingKeywordRules.ts";
+import { applyThinkingBudgetSettings } from "@omniroute/open-sse/services/thinkingBudget.ts";
 import {
   generateSessionId as generateStableSessionId,
   touchSession,
@@ -451,6 +452,7 @@ async function handleSingleModelChat(
   try {
     const settings = await getSettings();
     applyForwardingKeywordSettings(settings);
+    applyThinkingBudgetSettings(settings);
   } catch (error) {
     log.warn("forwarding-keyword-settings", "Failed to load forwarding keyword settings", {
       error,

--- a/tests/unit/bootstrap-env.test.mjs
+++ b/tests/unit/bootstrap-env.test.mjs
@@ -114,3 +114,57 @@ test("bootstrapEnv ignores blank dataDirOverride values", () => {
     assert.equal(env.JWT_SECRET, "jwt-from-dot-env");
   });
 });
+
+test("bootstrapEnv falls back to oauth client ids from .env.example when .env is absent", () => {
+  withTempEnv(({ tempCwd, dataDir }) => {
+    process.env.DATA_DIR = dataDir;
+    fs.mkdirSync(dataDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(tempCwd, ".env.example"),
+      [
+        "# ═══════════════════════════════════════════════════",
+        "#   OAUTH PROVIDER CREDENTIALS",
+        "# ═══════════════════════════════════════════════════",
+        "CLAUDE_OAUTH_CLIENT_ID=claude-default",
+        "CODEX_OAUTH_CLIENT_ID=codex-default",
+        "# ─────────────────────────────────────────────────────────────────────────────",
+        "# Provider User-Agent Overrides (optional — customize per-provider UA headers)",
+        "# ─────────────────────────────────────────────────────────────────────────────",
+        "CLAUDE_USER_AGENT=ignored",
+        "",
+      ].join("\n"),
+      "utf8"
+    );
+
+    const env = bootstrapEnv({ quiet: true });
+
+    assert.equal(env.CLAUDE_OAUTH_CLIENT_ID, "claude-default");
+    assert.equal(env.CODEX_OAUTH_CLIENT_ID, "codex-default");
+    assert.equal(env.CLAUDE_USER_AGENT, undefined);
+  });
+});
+
+test("bootstrapEnv prefers process env over oauth defaults from .env.example", () => {
+  withTempEnv(({ tempCwd, dataDir }) => {
+    process.env.DATA_DIR = dataDir;
+    process.env.CLAUDE_OAUTH_CLIENT_ID = "claude-from-process";
+    fs.mkdirSync(dataDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(tempCwd, ".env.example"),
+      [
+        "# ═══════════════════════════════════════════════════",
+        "#   OAUTH PROVIDER CREDENTIALS",
+        "# ═══════════════════════════════════════════════════",
+        "CLAUDE_OAUTH_CLIENT_ID=claude-default",
+        "# ─────────────────────────────────────────────────────────────────────────────",
+        "# Provider User-Agent Overrides (optional — customize per-provider UA headers)",
+        "",
+      ].join("\n"),
+      "utf8"
+    );
+
+    const env = bootstrapEnv({ quiet: true });
+
+    assert.equal(env.CLAUDE_OAUTH_CLIENT_ID, "claude-from-process");
+  });
+});

--- a/tests/unit/cc-compatible-provider.test.mjs
+++ b/tests/unit/cc-compatible-provider.test.mjs
@@ -92,7 +92,7 @@ test("buildClaudeCodeCompatibleRequest keeps prior role history while dropping t
   });
 
   assert.equal(payload.max_tokens, CLAUDE_CODE_COMPATIBLE_DEFAULT_MAX_TOKENS);
-  assert.equal(payload.output_config.effort, "max");
+  assert.equal(payload.output_config.effort, "xhigh");
   assert.deepEqual(
     payload.messages.map((message) => ({
       role: message.role,

--- a/tests/unit/cc-compatible-provider.test.mjs
+++ b/tests/unit/cc-compatible-provider.test.mjs
@@ -92,7 +92,7 @@ test("buildClaudeCodeCompatibleRequest keeps prior role history while dropping t
   });
 
   assert.equal(payload.max_tokens, CLAUDE_CODE_COMPATIBLE_DEFAULT_MAX_TOKENS);
-  assert.equal(payload.output_config.effort, "high");
+  assert.equal(payload.output_config.effort, "max");
   assert.deepEqual(
     payload.messages.map((message) => ({
       role: message.role,

--- a/tests/unit/chatcore-translation-paths.test.mjs
+++ b/tests/unit/chatcore-translation-paths.test.mjs
@@ -465,6 +465,67 @@ test("chatCore builds Claude Code-compatible upstream requests for CC providers"
   assert.equal(call.body.messages[0].content[0].text, "Ping");
 });
 
+test("chatCore rewrites lexical triggers in Claude Code-compatible upstream requests", async () => {
+  const { call, result } = await invokeChatCore({
+    provider: "anthropic-compatible-cc-test",
+    model: "claude-opus-4-6",
+    endpoint: "/v1/messages?beta=true",
+    accept: "text/event-stream",
+    credentials: {
+      accessToken: "oauth-token",
+      providerSpecificData: {
+        baseUrl: "https://api.anthropic.com/v1/messages",
+        chatPath: "/v1/messages?beta=true",
+      },
+    },
+    body: {
+      model: "claude-opus-4-6",
+      max_tokens: 32000,
+      stream: true,
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "fix broken test" },
+            { type: "text", text: "testing" },
+            { type: "text", text: "hello" },
+          ],
+        },
+      ],
+      tools: [
+        {
+          name: "background_output",
+          description: "Get output from background task.",
+          input_schema: { type: "object", properties: { task_id: { type: "string" } } },
+        },
+        {
+          name: "background_cancel",
+          description: "Cancel running background task(s).",
+          input_schema: { type: "object", properties: { taskId: { type: "string" } } },
+        },
+      ],
+      tool_choice: { type: "tool", name: "background_cancel" },
+      system: [
+        {
+          type: "text",
+          text: "Use <directories>src/</directories> with background_output and background_cancel",
+        },
+      ],
+    },
+    responseFormat: "claude",
+  });
+
+  assert.equal(result.success, true);
+  assert.equal(call.url, "https://api.anthropic.com/v1/messages?beta=true");
+  assert.equal(
+    call.body.system.at(-1).text,
+    "Use directories:\nsrc/ with background_result and background_stop"
+  );
+  assert.equal(call.body.tools[0].name, "background_result");
+  assert.equal(call.body.tools[1].name, "background_stop");
+  assert.deepEqual(call.body.tool_choice, { type: "tool", name: "background_stop" });
+});
+
 test("chatCore preserves cache_control automatically for Claude Code single-model requests", async () => {
   await settingsDb.updateSettings({ alwaysPreserveClientCache: "auto" });
   invalidateCacheControlSettingsCache();
@@ -617,7 +678,7 @@ test("chatCore default translation converts Claude requests to OpenAI and strips
   assert.equal(JSON.stringify(call.body).includes("cache_control"), false);
 });
 
-test("chatCore sets Claude tool prefix disabling, strips empty Anthropic text blocks, and cleans helper flags", async () => {
+test("chatCore rewrites OpenAI-compatible Claude requests instead of broadly disabling tool prefixes", async () => {
   const { call } = await invokeChatCore({
     provider: "claude",
     model: "claude-sonnet-4-6",
@@ -650,8 +711,8 @@ test("chatCore sets Claude tool prefix disabling, strips empty Anthropic text bl
   });
 
   assert.equal(call.body.model, "claude-sonnet-4-6");
-  assert.equal(call.body.tools[0].name, "Bash");
-  assert.equal(call.body.tools[0].name.startsWith("proxy_"), false);
+  assert.equal(call.body.tools[0].name, "proxy_Bash");
+  assert.equal(call.body.tools[0].name.startsWith("proxy_"), true);
   assert.equal(call.body._toolNameMap, undefined);
   assert.equal(call.body._disableToolPrefix, undefined);
   assert.deepEqual(
@@ -869,7 +930,9 @@ test("chatCore refreshes GitHub credentials after 401 and retries with the refre
   });
 
   const payload = await result.response.json();
-  const providerCalls = calls.filter((entry) => entry.url.startsWith("https://api.githubcopilot.com/"));
+  const providerCalls = calls.filter((entry) =>
+    entry.url.startsWith("https://api.githubcopilot.com/")
+  );
 
   assert.equal(result.success, true);
   assert.equal(providerCalls.length, 2);

--- a/tests/unit/chatcore-translation-paths.test.mjs
+++ b/tests/unit/chatcore-translation-paths.test.mjs
@@ -571,6 +571,107 @@ test("chatCore preserves cache_control automatically for Claude Code single-mode
   assert.deepEqual(call.body.tools[0].cache_control, { type: "ephemeral", ttl: "30m" });
 });
 
+test("chatCore Claude passthrough with cache_control applies thinking budget for reasoning_effort", async () => {
+  await settingsDb.updateSettings({ alwaysPreserveClientCache: "auto" });
+  invalidateCacheControlSettingsCache();
+
+  const claudeBody = {
+    model: "claude-opus-4-6",
+    max_tokens: 64,
+    reasoning_effort: "max",
+    system: [{ type: "text", text: "system", cache_control: { type: "ephemeral", ttl: "5m" } }],
+    messages: [
+      {
+        role: "user",
+        content: [{ type: "text", text: "u1", cache_control: { type: "ephemeral" } }],
+      },
+    ],
+  };
+
+  const { call } = await invokeChatCore({
+    provider: "claude",
+    model: "claude-opus-4-6",
+    endpoint: "/v1/messages",
+    credentials: { apiKey: "claude-key", providerSpecificData: {} },
+    body: claudeBody,
+    userAgent: "Claude-Code/1.0.0",
+    responseFormat: "claude",
+  });
+
+  assert.deepEqual(call.body.thinking, { type: "adaptive" });
+  assert.equal(call.body.output_config?.effort, "max");
+  assert.deepEqual(call.body.system[0].cache_control, { type: "ephemeral", ttl: "5m" });
+  assert.deepEqual(call.body.messages[0].content[0].cache_control, { type: "ephemeral" });
+});
+
+test("chatCore Claude passthrough with cache_control does not inject thinking when reasoning_effort absent", async () => {
+  await settingsDb.updateSettings({ alwaysPreserveClientCache: "auto" });
+  invalidateCacheControlSettingsCache();
+
+  const claudeBody = {
+    model: "claude-opus-4-6",
+    max_tokens: 64,
+    system: [{ type: "text", text: "system", cache_control: { type: "ephemeral", ttl: "5m" } }],
+    messages: [
+      {
+        role: "user",
+        content: [{ type: "text", text: "u1", cache_control: { type: "ephemeral" } }],
+      },
+    ],
+  };
+
+  const { call } = await invokeChatCore({
+    provider: "claude",
+    model: "claude-opus-4-6",
+    endpoint: "/v1/messages",
+    credentials: { apiKey: "claude-key", providerSpecificData: {} },
+    body: claudeBody,
+    userAgent: "Claude-Code/1.0.0",
+    responseFormat: "claude",
+  });
+
+  assert.equal(call.body.thinking, undefined);
+  assert.equal(call.body.output_config, undefined);
+  assert.deepEqual(call.body.system[0].cache_control, { type: "ephemeral", ttl: "5m" });
+});
+
+test("chatCore Claude passthrough preserves thinking on multi-turn assistant-last conversation", async () => {
+  await settingsDb.updateSettings({ alwaysPreserveClientCache: "auto" });
+  invalidateCacheControlSettingsCache();
+
+  const claudeBody = {
+    model: "claude-opus-4-6",
+    max_tokens: 64,
+    reasoning_effort: "max",
+    system: [{ type: "text", text: "system", cache_control: { type: "ephemeral", ttl: "5m" } }],
+    messages: [
+      { role: "user", content: [{ type: "text", text: "what time is it?" }] },
+      {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "tu_1", name: "get_time", input: {} }],
+      },
+      {
+        role: "user",
+        content: [{ type: "tool_result", tool_use_id: "tu_1", content: "10:00" }],
+      },
+      { role: "assistant", content: [{ type: "text", text: "It is 10:00." }] },
+    ],
+  };
+
+  const { call } = await invokeChatCore({
+    provider: "claude",
+    model: "claude-opus-4-6",
+    endpoint: "/v1/messages",
+    credentials: { apiKey: "claude-key", providerSpecificData: {} },
+    body: claudeBody,
+    userAgent: "Claude-Code/1.0.0",
+    responseFormat: "claude",
+  });
+
+  assert.deepEqual(call.body.thinking, { type: "adaptive" });
+  assert.equal(call.body.output_config?.effort, "max");
+});
+
 test("chatCore auto cache policy becomes false for nondeterministic combos", async () => {
   await settingsDb.updateSettings({ alwaysPreserveClientCache: "auto" });
   invalidateCacheControlSettingsCache();

--- a/tests/unit/claude-code-compatible-request.test.mjs
+++ b/tests/unit/claude-code-compatible-request.test.mjs
@@ -109,16 +109,29 @@ test("buildClaudeCodeCompatibleRequest covers normalized OpenAI-style messages, 
 test("buildClaudeCodeCompatibleRequest covers Claude-native bodies and cache-control stripping", () => {
   const stripped = buildClaudeCodeCompatibleRequest({
     claudeBody: {
-      system: [{ type: "text", text: "sys", cache_control: { type: "ephemeral" } }],
+      system: [
+        {
+          type: "text",
+          text: "sys <directories>src/</directories>",
+          cache_control: { type: "ephemeral" },
+        },
+      ],
       messages: [
         {
           role: "assistant",
-          content: [{ type: "text", text: "prefill", cache_control: { type: "ephemeral" } }],
+          content: [
+            { type: "text", text: "prefill", cache_control: { type: "ephemeral" } },
+            { type: "tool_use", id: "call_1", name: "background_output", input: {} },
+          ],
         },
         {
           role: "user",
           content: [
-            { type: "text", text: "ask", cache_control: { type: "ephemeral" } },
+            {
+              type: "text",
+              text: "ask background_cancel",
+              cache_control: { type: "ephemeral" },
+            },
             {
               type: "image",
               source: { type: "base64", media_type: "image/png", data: "abc" },
@@ -132,8 +145,14 @@ test("buildClaudeCodeCompatibleRequest covers Claude-native bodies and cache-con
         },
       ],
       tools: [
-        { name: "toolA", input_schema: { type: "object" }, cache_control: { type: "ephemeral" } },
+        {
+          name: "background_cancel",
+          description: "Cancel background_output work",
+          input_schema: { type: "object" },
+          cache_control: { type: "ephemeral" },
+        },
       ],
+      tool_choice: { type: "tool", name: "background_cancel" },
       thinking: { type: "enabled", budget_tokens: 12 },
     },
     model: "claude-sonnet-4-6",
@@ -171,8 +190,16 @@ test("buildClaudeCodeCompatibleRequest covers Claude-native bodies and cache-con
   assert.equal(JSON.parse(stripped.metadata.user_id).session_id, "explicit-session");
   assert.equal(stripped.messages.at(-1).role, "user");
   assert.equal(stripped.messages[0].content[0].cache_control, undefined);
+  assert.equal(stripped.messages[0].content[1].name, "background_result");
+  assert.equal(stripped.messages[1].content[0].text, "ask background_stop");
   assert.equal(stripped.system.at(-1).cache_control, undefined);
+  assert.equal(stripped.system.at(-1).text, "sys directories:\nsrc/");
   assert.equal(stripped.tools[0].cache_control, undefined);
+  assert.equal(stripped.tools[0].name, "background_stop");
+  assert.equal(stripped.tools[0].description, "Cancel background_result work");
+  assert.deepEqual(stripped.tool_choice, { type: "tool", name: "background_stop" });
+  assert.equal(stripped._toolNameMap.get("background_result"), "background_output");
+  assert.equal(stripped._toolNameMap.get("background_stop"), "background_cancel");
   assert.equal(preserved.messages[0].content[0].cache_control.type, "ephemeral");
   assert.equal(preserved.system.at(-1).cache_control.type, "ephemeral");
   assert.equal(preserved.tools[0].cache_control.type, "ephemeral");

--- a/tests/unit/claude-code-compatible-request.test.mjs
+++ b/tests/unit/claude-code-compatible-request.test.mjs
@@ -35,7 +35,7 @@ test("Claude Code compatible URL helpers cover empty values, version trimming an
 test("Claude Code compatible effort and max token helpers cover priority fallbacks", () => {
   assert.equal(resolveClaudeCodeCompatibleEffort({ reasoning_effort: "medium" }), "medium");
   assert.equal(resolveClaudeCodeCompatibleEffort({ reasoning: { effort: "none" } }), "low");
-  assert.equal(resolveClaudeCodeCompatibleEffort({ output_config: { effort: "xhigh" } }), "max");
+  assert.equal(resolveClaudeCodeCompatibleEffort({ output_config: { effort: "xhigh" } }), "xhigh");
   assert.equal(
     resolveClaudeCodeCompatibleEffort({ output_config: { effort: "unexpected" } }),
     "high"

--- a/tests/unit/claude-code-compatible-request.test.mjs
+++ b/tests/unit/claude-code-compatible-request.test.mjs
@@ -35,7 +35,7 @@ test("Claude Code compatible URL helpers cover empty values, version trimming an
 test("Claude Code compatible effort and max token helpers cover priority fallbacks", () => {
   assert.equal(resolveClaudeCodeCompatibleEffort({ reasoning_effort: "medium" }), "medium");
   assert.equal(resolveClaudeCodeCompatibleEffort({ reasoning: { effort: "none" } }), "low");
-  assert.equal(resolveClaudeCodeCompatibleEffort({ output_config: { effort: "xhigh" } }), "high");
+  assert.equal(resolveClaudeCodeCompatibleEffort({ output_config: { effort: "xhigh" } }), "max");
   assert.equal(
     resolveClaudeCodeCompatibleEffort({ output_config: { effort: "unexpected" } }),
     "high"

--- a/tests/unit/oauth-providers-config.test.mjs
+++ b/tests/unit/oauth-providers-config.test.mjs
@@ -301,6 +301,7 @@ test("device and import-token providers expose the flow-specific fields expected
 });
 
 test("provider-specific config shapes remain valid for special cases", () => {
+  assert.equal(CLAUDE_CONFIG.redirectUri, "https://console.anthropic.com/oauth/code/callback");
   assert.ok(Array.isArray(CLAUDE_CONFIG.scopes) && CLAUDE_CONFIG.scopes.length > 0);
   assert.ok(Array.isArray(GEMINI_CONFIG.scopes) && GEMINI_CONFIG.scopes.length > 0);
   assert.ok(Array.isArray(ANTIGRAVITY_CONFIG.scopes) && ANTIGRAVITY_CONFIG.scopes.length > 0);

--- a/tests/unit/oauth-providers-config.test.mjs
+++ b/tests/unit/oauth-providers-config.test.mjs
@@ -301,7 +301,7 @@ test("device and import-token providers expose the flow-specific fields expected
 });
 
 test("provider-specific config shapes remain valid for special cases", () => {
-  assert.equal(CLAUDE_CONFIG.redirectUri, "https://console.anthropic.com/oauth/code/callback");
+  assert.equal(CLAUDE_CONFIG.redirectUri, "https://platform.claude.com/oauth/code/callback");
   assert.ok(Array.isArray(CLAUDE_CONFIG.scopes) && CLAUDE_CONFIG.scopes.length > 0);
   assert.ok(Array.isArray(GEMINI_CONFIG.scopes) && GEMINI_CONFIG.scopes.length > 0);
   assert.ok(Array.isArray(ANTIGRAVITY_CONFIG.scopes) && ANTIGRAVITY_CONFIG.scopes.length > 0);

--- a/tests/unit/opus-4.7-compat.test.mjs
+++ b/tests/unit/opus-4.7-compat.test.mjs
@@ -1,0 +1,249 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  downgradeEffort,
+  getModelSpec,
+  isAdaptiveOnlyModel,
+  isEffortSupported,
+  rejectsSamplingParams,
+} from "@/shared/constants/modelSpecs";
+
+const { applyThinkingBudget, DEFAULT_THINKING_CONFIG, ensureThinkingConfig } =
+  await import("../../open-sse/services/thinkingBudget.ts");
+const { openaiToClaudeRequest } =
+  await import("../../open-sse/translator/request/openai-to-claude.ts");
+const { hasThinkingConfig } = await import("../../open-sse/services/provider.ts");
+
+function buildMessages() {
+  return [{ role: "user", content: "hello" }];
+}
+
+function buildClaudeBody(overrides = {}) {
+  return {
+    model: "claude-opus-4-7",
+    messages: buildMessages(),
+    max_tokens: 200000,
+    ...overrides,
+  };
+}
+
+test("modelSpecs — Opus 4.7", async (t) => {
+  await t.test("getModelSpec returns the Opus 4.7 compatibility spec", () => {
+    const spec = getModelSpec("claude-opus-4-7");
+
+    assert.equal(spec?.maxOutputTokens, 128000);
+    assert.equal(spec?.contextWindow, 1048576);
+    assert.equal(spec?.supportsThinking, true);
+  });
+
+  await t.test("getModelSpec keeps Opus 4.6 on the expanded context window", () => {
+    const spec = getModelSpec("claude-opus-4-6");
+
+    assert.equal(spec?.maxOutputTokens, 128000);
+    assert.equal(spec?.contextWindow, 1048576);
+    assert.equal(spec?.supportsThinking, true);
+  });
+
+  await t.test("adaptive-only detection distinguishes Opus 4.7 from older models", () => {
+    assert.equal(isAdaptiveOnlyModel("claude-opus-4-7"), true);
+    assert.equal(isAdaptiveOnlyModel("claude-opus-4-6"), false);
+    assert.equal(isAdaptiveOnlyModel("gemini-3-flash"), false);
+  });
+
+  await t.test("sampling param rejection only applies to Opus 4.7", () => {
+    assert.equal(rejectsSamplingParams("claude-opus-4-7"), true);
+    assert.equal(rejectsSamplingParams("claude-opus-4-6"), false);
+  });
+
+  await t.test("effort support and downgrade preserve 4.7 while downgrading 4.6", () => {
+    assert.equal(downgradeEffort("claude-opus-4-7", "xhigh"), "xhigh");
+    assert.equal(downgradeEffort("claude-opus-4-6", "xhigh"), "max");
+    assert.equal(isEffortSupported("claude-opus-4-7", "xhigh"), true);
+    assert.equal(isEffortSupported("claude-opus-4-6", "xhigh"), false);
+  });
+});
+
+test("thinkingBudget — Opus 4.7 coercion", async (t) => {
+  await t.test("Opus 4.6 reasoning_effort max still promotes to adaptive thinking", () => {
+    const result = applyThinkingBudget(
+      {
+        model: "claude-opus-4-6",
+        messages: buildMessages(),
+        reasoning_effort: "max",
+      },
+      DEFAULT_THINKING_CONFIG
+    );
+
+    assert.deepEqual(result.thinking, { type: "adaptive" });
+    assert.deepEqual(result.output_config, { effort: "max" });
+  });
+
+  await t.test("Opus 4.7 reasoning_effort max uses adaptive thinking with output_config", () => {
+    const result = applyThinkingBudget(
+      {
+        model: "claude-opus-4-7",
+        messages: buildMessages(),
+        reasoning_effort: "max",
+      },
+      DEFAULT_THINKING_CONFIG
+    );
+
+    assert.deepEqual(result.thinking, { type: "adaptive" });
+    assert.deepEqual(result.output_config, { effort: "max" });
+  });
+
+  await t.test(
+    "Opus 4.7 explicit enabled thinking is coerced to adaptive without budget tokens",
+    () => {
+      const result = applyThinkingBudget(
+        {
+          model: "claude-opus-4-7",
+          messages: buildMessages(),
+          thinking: { type: "enabled", budget_tokens: 10000 },
+        },
+        DEFAULT_THINKING_CONFIG
+      );
+
+      assert.deepEqual(result.thinking, { type: "adaptive" });
+      assert.deepEqual(result.output_config, { effort: "high" });
+      assert.equal("budget_tokens" in result.thinking, false);
+    }
+  );
+
+  await t.test("Opus 4.6 explicit enabled thinking is preserved", () => {
+    const result = applyThinkingBudget(
+      {
+        model: "claude-opus-4-6",
+        messages: buildMessages(),
+        thinking: { type: "enabled", budget_tokens: 10000 },
+      },
+      DEFAULT_THINKING_CONFIG
+    );
+
+    assert.deepEqual(result.thinking, { type: "enabled", budget_tokens: 10000 });
+    assert.equal(result.output_config, undefined);
+  });
+
+  await t.test(
+    "ensureThinkingConfig injects adaptive thinking for Opus 4.7 -thinking models",
+    () => {
+      const result = ensureThinkingConfig({
+        model: "claude-opus-4-7-thinking",
+        messages: buildMessages(),
+      });
+
+      assert.deepEqual(result.thinking, { type: "adaptive" });
+    }
+  );
+
+  await t.test("Opus 4.7 keeps xhigh effort in adaptive output config", () => {
+    const result = applyThinkingBudget(
+      {
+        model: "claude-opus-4-7",
+        messages: buildMessages(),
+        reasoning_effort: "xhigh",
+      },
+      DEFAULT_THINKING_CONFIG
+    );
+
+    assert.deepEqual(result.thinking, { type: "adaptive" });
+    assert.deepEqual(result.output_config, { effort: "xhigh" });
+  });
+
+  await t.test("downgradeEffort still converts xhigh to max for Opus 4.6", () => {
+    assert.equal(downgradeEffort("claude-opus-4-6", "xhigh"), "max");
+  });
+});
+
+test("openaiToClaudeRequest — Opus 4.7 constraints", async (t) => {
+  await t.test("Opus 4.7 strips sampling params before sending to Anthropic", () => {
+    const result = openaiToClaudeRequest(
+      "claude-opus-4-7",
+      buildClaudeBody({ temperature: 0.7, top_p: 0.9 }),
+      false
+    );
+
+    assert.equal("temperature" in result, false);
+    assert.equal("top_p" in result, false);
+    assert.equal("top_k" in result, false);
+  });
+
+  await t.test("Opus 4.6 preserves sampling params", () => {
+    const result = openaiToClaudeRequest(
+      "claude-opus-4-6",
+      buildClaudeBody({ model: "claude-opus-4-6", temperature: 0.7 }),
+      false
+    );
+
+    assert.equal(result.temperature, 0.7);
+  });
+
+  await t.test("Opus 4.7 injects thinking.display for adaptive thinking", () => {
+    const result = openaiToClaudeRequest(
+      "claude-opus-4-7",
+      buildClaudeBody({
+        thinking: { type: "adaptive" },
+        output_config: { effort: "max" },
+      }),
+      false
+    );
+
+    assert.deepEqual(result.thinking, { type: "adaptive", display: "summarized" });
+    assert.deepEqual(result.output_config, { effort: "max" });
+  });
+
+  await t.test("Opus 4.6 does not inject thinking.display by default", () => {
+    const result = openaiToClaudeRequest(
+      "claude-opus-4-6",
+      buildClaudeBody({ model: "claude-opus-4-6", reasoning_effort: "high" }),
+      false
+    );
+
+    assert.deepEqual(result.thinking, { type: "enabled", budget_tokens: 128000 });
+    assert.equal("display" in result.thinking, false);
+  });
+
+  await t.test(
+    "Opus 4.7 reasoning_effort fallback uses adaptive thinking instead of enabled",
+    () => {
+      const result = openaiToClaudeRequest(
+        "claude-opus-4-7",
+        buildClaudeBody({ reasoning_effort: "high" }),
+        false
+      );
+
+      assert.deepEqual(result.thinking, { type: "adaptive", display: "summarized" });
+      assert.deepEqual(result.output_config, { effort: "high" });
+    }
+  );
+
+  await t.test("Opus 4.6 reasoning_effort fallback preserves enabled-thinking behavior", () => {
+    const result = openaiToClaudeRequest(
+      "claude-opus-4-6",
+      buildClaudeBody({ model: "claude-opus-4-6", reasoning_effort: "high" }),
+      false
+    );
+
+    assert.deepEqual(result.thinking, { type: "enabled", budget_tokens: 128000 });
+    assert.equal(result.output_config, undefined);
+  });
+});
+
+test("hasThinkingConfig — adaptive support", async (t) => {
+  await t.test("adaptive thinking config is detected", () => {
+    assert.equal(hasThinkingConfig({ thinking: { type: "adaptive" } }), true);
+  });
+
+  await t.test("enabled thinking config is still detected", () => {
+    assert.equal(hasThinkingConfig({ thinking: { type: "enabled" } }), true);
+  });
+
+  await t.test("reasoning_effort is still treated as thinking config", () => {
+    assert.equal(hasThinkingConfig({ reasoning_effort: "high" }), true);
+  });
+
+  await t.test("empty requests do not report thinking config", () => {
+    assert.equal(hasThinkingConfig({}), false);
+  });
+});

--- a/tests/unit/provider-service.test.mjs
+++ b/tests/unit/provider-service.test.mjs
@@ -114,7 +114,7 @@ test("Unknown providers fall back to bearer auth and OpenAI format", () => {
   assert.equal(getTargetFormat("custom-provider"), "openai");
 });
 
-test("thinking config is removed when the last message is not from the user", () => {
+test("non-Claude target: thinking config is removed when the last message is not from the user", () => {
   const assistantLast = {
     messages: [
       { role: "user", content: "hi" },
@@ -129,12 +129,45 @@ test("thinking config is removed when the last message is not from the user", ()
     thinking: { type: "enabled" },
   };
 
-  const normalized = normalizeThinkingConfig(assistantLast);
+  const normalized = normalizeThinkingConfig(assistantLast, "openai");
 
   assert.equal(isLastMessageFromUser({ messages: [] }), true);
   assert.equal(isLastMessageFromUser(assistantLast), false);
   assert.equal(hasThinkingConfig(userLast), true);
   assert.equal("reasoning_effort" in normalized, false);
   assert.equal("thinking" in normalized, false);
-  assert.equal(normalizeThinkingConfig(userLast).reasoning_effort, "medium");
+  assert.equal(normalizeThinkingConfig(userLast, "openai").reasoning_effort, "medium");
+});
+
+test("Claude target: thinking config is preserved even when last message is not from user", () => {
+  const assistantLast = {
+    messages: [
+      { role: "user", content: "what time is it?" },
+      { role: "assistant", content: [{ type: "tool_use", name: "get_time" }] },
+      { role: "user", content: [{ type: "tool_result", content: "10:00" }] },
+      { role: "assistant", content: "It is 10:00." },
+    ],
+    reasoning_effort: "max",
+    thinking: { type: "adaptive" },
+    output_config: { effort: "max" },
+  };
+
+  const normalized = normalizeThinkingConfig(assistantLast, "claude");
+
+  assert.equal(isLastMessageFromUser(assistantLast), false);
+  assert.equal(normalized.reasoning_effort, "max");
+  assert.deepEqual(normalized.thinking, { type: "adaptive" });
+  assert.deepEqual(normalized.output_config, { effort: "max" });
+});
+
+test("non-Claude target: output_config is also stripped when last message is not user", () => {
+  const body = {
+    messages: [
+      { role: "user", content: "hi" },
+      { role: "assistant", content: "hello" },
+    ],
+    output_config: { effort: "high" },
+  };
+  const normalized = normalizeThinkingConfig(body, "openai");
+  assert.equal("output_config" in normalized, false);
 });

--- a/tests/unit/stream-utils.test.mjs
+++ b/tests/unit/stream-utils.test.mjs
@@ -193,7 +193,7 @@ test("createSSEStream translate mode converts Claude SSE into OpenAI chunks and 
   assert.equal(onCompletePayload.status, 200);
   assert.equal(onCompletePayload.responseBody.choices[0].message.content, "Hello Claude");
   assert.equal(onCompletePayload.responseBody.usage.completion_tokens, 4);
-  assert.equal(onCompletePayload.responseBody.usage.total_tokens, 4);
+  assert.equal(onCompletePayload.responseBody.usage.total_tokens, 7);
 });
 
 test("createSSEStream passthrough preserves Responses API events and completion summaries", async () => {
@@ -508,7 +508,7 @@ test("createSSETransformStreamWithLogger flushes a trailing Claude usage event w
   assert.match(text, /\[DONE\]/);
   assert.equal(onCompletePayload.responseBody.choices[0].message.content, "Buffered tail");
   assert.equal(onCompletePayload.responseBody.usage.completion_tokens, 5);
-  assert.equal(onCompletePayload.responseBody.usage.total_tokens, 5);
+  assert.equal(onCompletePayload.responseBody.usage.total_tokens, 8);
 });
 
 test("buildStreamSummaryFromEvents compacts Responses API deltas into a synthetic response", () => {

--- a/tests/unit/thinking-budget.test.mjs
+++ b/tests/unit/thinking-budget.test.mjs
@@ -186,6 +186,20 @@ test("ADAPTIVE: Claude requests preserve xhigh effort values", () => {
   setThinkingBudgetConfig(DEFAULT_THINKING_CONFIG);
 });
 
+test("Claude thinkingLevel-only requests auto-promote to adaptive effort", () => {
+  setThinkingBudgetConfig({ mode: ThinkingMode.PASSTHROUGH, effortLevel: "medium" });
+  const body = {
+    model: "claude-opus-4-6",
+    messages: [{ role: "user", content: "hello" }],
+    thinkingLevel: "max",
+  };
+  const result = applyThinkingBudget(body);
+  assert.deepEqual(result.thinking, { type: "adaptive" });
+  assert.deepEqual(result.output_config, { effort: "max" });
+  assert.equal(result.thinkingLevel, undefined);
+  setThinkingBudgetConfig(DEFAULT_THINKING_CONFIG);
+});
+
 test("ADAPTIVE: non-Claude requests still use adaptive proxy budgets", () => {
   setThinkingBudgetConfig({ mode: ThinkingMode.ADAPTIVE, effortLevel: "medium" });
   const messages = Array.from({ length: 15 }, (_, i) => ({
@@ -314,7 +328,7 @@ test("hasThinkingCapableModel: matches -thinking suffix", () => {
   assert.ok(hasThinkingCapableModel({ model: "custom-model-thinking" }));
 });
 
-test("applyThinkingBudget: thinkingLevel 'high' + PASSTHROUGH = converts and passes through", () => {
+test("applyThinkingBudget: Claude thinkingLevel 'high' + PASSTHROUGH promotes to adaptive effort", () => {
   setThinkingBudgetConfig({ mode: ThinkingMode.PASSTHROUGH });
   const body = {
     model: "claude-sonnet-4",
@@ -322,7 +336,8 @@ test("applyThinkingBudget: thinkingLevel 'high' + PASSTHROUGH = converts and pas
     messages: [{ role: "user", content: "hello" }],
   };
   const result = applyThinkingBudget(body);
-  assert.equal(result.thinking.budget_tokens, 24576);
+  assert.deepEqual(result.thinking, { type: "adaptive" });
+  assert.deepEqual(result.output_config, { effort: "high" });
   assert.equal(result.thinkingLevel, undefined);
   setThinkingBudgetConfig(DEFAULT_THINKING_CONFIG);
 });

--- a/tests/unit/thinking-budget.test.mjs
+++ b/tests/unit/thinking-budget.test.mjs
@@ -141,8 +141,35 @@ test("ADAPTIVE: Claude requests use configured effort when client does not send 
     messages: [{ role: "user", content: "hello" }],
   };
   const result = applyThinkingBudget(body);
+  assert.equal(result.thinking, undefined);
+  assert.equal(result.output_config, undefined);
+  setThinkingBudgetConfig(DEFAULT_THINKING_CONFIG);
+});
+
+test("ADAPTIVE: Claude requests preserve explicit thinking config", () => {
+  setThinkingBudgetConfig({ mode: ThinkingMode.ADAPTIVE, effortLevel: "max" });
+  const body = {
+    model: "claude-opus-4-6",
+    messages: [{ role: "user", content: "hello" }],
+    reasoning_effort: "max",
+    thinking: { type: "enabled", budget_tokens: 4096 },
+  };
+  const result = applyThinkingBudget(body);
+  assert.deepEqual(result.thinking, { type: "enabled", budget_tokens: 4096 });
+  assert.equal(result.output_config, undefined);
+  setThinkingBudgetConfig(DEFAULT_THINKING_CONFIG);
+});
+
+test("ADAPTIVE: Claude requests preserve xhigh effort values", () => {
+  setThinkingBudgetConfig({ mode: ThinkingMode.ADAPTIVE, effortLevel: "max" });
+  const body = {
+    model: "claude-opus-4-6",
+    messages: [{ role: "user", content: "hello" }],
+    reasoning_effort: "xhigh",
+  };
+  const result = applyThinkingBudget(body);
   assert.deepEqual(result.thinking, { type: "adaptive" });
-  assert.deepEqual(result.output_config, { effort: "max" });
+  assert.deepEqual(result.output_config, { effort: "xhigh" });
   setThinkingBudgetConfig(DEFAULT_THINKING_CONFIG);
 });
 

--- a/tests/unit/thinking-budget.test.mjs
+++ b/tests/unit/thinking-budget.test.mjs
@@ -16,9 +16,10 @@ const {
 
 // ─── Config Management ──────────────────────────────────────────────────────
 
-test("default config is passthrough", () => {
+test("default config uses adaptive thinking with max effort", () => {
   const config = getThinkingBudgetConfig();
-  assert.equal(config.mode, ThinkingMode.PASSTHROUGH);
+  assert.equal(config.mode, ThinkingMode.ADAPTIVE);
+  assert.equal(config.effortLevel, "max");
 });
 
 test("setThinkingBudgetConfig updates config", () => {
@@ -120,19 +121,32 @@ test("CUSTOM: budget 0 disables Claude thinking", () => {
 
 // ─── ADAPTIVE Mode ──────────────────────────────────────────────────────────
 
-test("ADAPTIVE: simple request gets base budget", () => {
+test("ADAPTIVE: Claude requests use adaptive thinking and pass through effort", () => {
   setThinkingBudgetConfig({ mode: ThinkingMode.ADAPTIVE, effortLevel: "medium" });
   const body = {
     model: "claude-sonnet-4-20250514",
     messages: [{ role: "user", content: "hello" }],
-    thinking: { type: "enabled", budget_tokens: 8192 },
+    reasoning_effort: "low",
   };
   const result = applyThinkingBudget(body);
-  assert.equal(result.thinking.budget_tokens, EFFORT_BUDGETS.medium);
+  assert.deepEqual(result.thinking, { type: "adaptive" });
+  assert.deepEqual(result.output_config, { effort: "low" });
   setThinkingBudgetConfig(DEFAULT_THINKING_CONFIG);
 });
 
-test("ADAPTIVE: complex request (many messages + tools) gets higher budget", () => {
+test("ADAPTIVE: Claude requests use configured effort when client does not send one", () => {
+  setThinkingBudgetConfig({ mode: ThinkingMode.ADAPTIVE, effortLevel: "max" });
+  const body = {
+    model: "claude-opus-4-6",
+    messages: [{ role: "user", content: "hello" }],
+  };
+  const result = applyThinkingBudget(body);
+  assert.deepEqual(result.thinking, { type: "adaptive" });
+  assert.deepEqual(result.output_config, { effort: "max" });
+  setThinkingBudgetConfig(DEFAULT_THINKING_CONFIG);
+});
+
+test("ADAPTIVE: non-Claude requests still use adaptive proxy budgets", () => {
   setThinkingBudgetConfig({ mode: ThinkingMode.ADAPTIVE, effortLevel: "medium" });
   const messages = Array.from({ length: 15 }, (_, i) => ({
     role: i % 2 === 0 ? "user" : "assistant",
@@ -140,14 +154,13 @@ test("ADAPTIVE: complex request (many messages + tools) gets higher budget", () 
   }));
   const tools = Array.from({ length: 5 }, (_, i) => ({ name: `tool${i}` }));
   const body = {
-    model: "claude-sonnet-4-20250514",
+    model: "o3-mini",
     messages,
     tools,
-    thinking: { type: "enabled", budget_tokens: 1000 },
+    reasoning_effort: "low",
   };
   const result = applyThinkingBudget(body);
-  // multiplier = 1.0 + 0.5 (msgs>10) + 0.5 (tools>3) + 0.3 (lastMsg>2000) = 2.3
-  assert.ok(result.thinking.budget_tokens > EFFORT_BUDGETS.medium);
+  assert.ok(result.reasoning_effort === "high" || result.reasoning_effort === "max");
   setThinkingBudgetConfig(DEFAULT_THINKING_CONFIG);
 });
 
@@ -233,7 +246,7 @@ test("ensureThinkingConfig: auto-injects for -thinking suffix model", () => {
   };
   const result = ensureThinkingConfig(body);
   assert.equal(result.thinking.type, "enabled");
-  assert.equal(result.thinking.budget_tokens, EFFORT_BUDGETS.medium);
+  assert.equal(result.thinking.budget_tokens, 10000);
 });
 
 test("ensureThinkingConfig: does NOT override existing thinking config", () => {
@@ -282,6 +295,6 @@ test("applyThinkingBudget: -thinking model without config + PASSTHROUGH = auto-i
   };
   const result = applyThinkingBudget(body);
   assert.equal(result.thinking.type, "enabled");
-  assert.equal(result.thinking.budget_tokens, EFFORT_BUDGETS.medium);
+  assert.equal(result.thinking.budget_tokens, 10000);
   setThinkingBudgetConfig(DEFAULT_THINKING_CONFIG);
 });

--- a/tests/unit/thinking-budget.test.mjs
+++ b/tests/unit/thinking-budget.test.mjs
@@ -134,6 +134,19 @@ test("ADAPTIVE: Claude requests use adaptive thinking and pass through effort", 
   setThinkingBudgetConfig(DEFAULT_THINKING_CONFIG);
 });
 
+test("Claude effort-only requests auto-promote to adaptive even outside adaptive mode", () => {
+  setThinkingBudgetConfig({ mode: ThinkingMode.PASSTHROUGH, effortLevel: "medium" });
+  const body = {
+    model: "claude-opus-4-6",
+    messages: [{ role: "user", content: "hello" }],
+    reasoning_effort: "max",
+  };
+  const result = applyThinkingBudget(body);
+  assert.deepEqual(result.thinking, { type: "adaptive" });
+  assert.deepEqual(result.output_config, { effort: "max" });
+  setThinkingBudgetConfig(DEFAULT_THINKING_CONFIG);
+});
+
 test("ADAPTIVE: Claude requests use configured effort when client does not send one", () => {
   setThinkingBudgetConfig({ mode: ThinkingMode.ADAPTIVE, effortLevel: "max" });
   const body = {

--- a/tests/unit/token-health-check.test.mjs
+++ b/tests/unit/token-health-check.test.mjs
@@ -41,3 +41,16 @@ test("buildRefreshFailureUpdate preserves expired retry tracking", () => {
   assert.equal(update.expiredRetryCount, 3);
   assert.equal(update.expiredRetryAt, now);
 });
+
+test("unwrapResolvedProxyConfig extracts the raw proxy object for refresh calls", () => {
+  assert.deepEqual(
+    tokenHealthCheck.unwrapResolvedProxyConfig({
+      proxy: { type: "http", host: "127.0.0.1", port: "8080" },
+      level: "provider",
+      levelId: "claude",
+    }),
+    { type: "http", host: "127.0.0.1", port: "8080" }
+  );
+  assert.equal(tokenHealthCheck.unwrapResolvedProxyConfig({ proxy: null }), null);
+  assert.equal(tokenHealthCheck.unwrapResolvedProxyConfig(null), null);
+});

--- a/tests/unit/token-refresh-service.test.mjs
+++ b/tests/unit/token-refresh-service.test.mjs
@@ -279,7 +279,7 @@ test("refreshKimiCodingToken adds provider-specific headers and fields", async (
   assert.match(bodyToString(calls[0].options.body), /grant_type=refresh_token/);
 });
 
-test("refreshClaudeOAuthToken posts the anthropic oauth refresh contract", async () => {
+test("refreshClaudeOAuthToken posts the anthropic oauth refresh contract as JSON first", async () => {
   const log = createLog();
   const calls = [];
 
@@ -303,9 +303,53 @@ test("refreshClaudeOAuthToken posts the anthropic oauth refresh contract", async
   );
 
   assert.equal(calls[0].url, OAUTH_ENDPOINTS.anthropic.token);
+  assert.equal(calls[0].options.headers["Content-Type"], "application/json");
+  assert.equal(calls[0].options.headers["User-Agent"], "anthropic");
   assert.equal(calls[0].options.headers["anthropic-beta"], "oauth-2025-04-20");
-  assert.match(calls[0].options.body, /grant_type=refresh_token/);
-  assert.match(calls[0].options.body, /client_id=/);
+  assert.deepEqual(JSON.parse(calls[0].options.body), {
+    grant_type: "refresh_token",
+    refresh_token: "claude-refresh",
+    client_id: PROVIDERS.claude.clientId,
+  });
+});
+
+test("refreshClaudeOAuthToken falls back to form-encoded when Anthropic rejects JSON format", async () => {
+  const log = createLog();
+  const calls = [];
+
+  await withMockedFetch(
+    async (url, options = {}) => {
+      calls.push({ url, options });
+      if (calls.length === 1) {
+        return textResponse(
+          JSON.stringify({
+            type: "error",
+            error: { type: "invalid_request_error", message: "Invalid request format" },
+          }),
+          400
+        );
+      }
+
+      return jsonResponse({
+        access_token: "claude-access-form",
+        refresh_token: "claude-refresh-form",
+        expires_in: 900,
+      });
+    },
+    async () => {
+      const result = await refreshClaudeOAuthToken("claude-refresh", log);
+      assert.deepEqual(result, {
+        accessToken: "claude-access-form",
+        refreshToken: "claude-refresh-form",
+        expiresIn: 900,
+      });
+    }
+  );
+
+  assert.equal(calls.length, 2);
+  assert.equal(calls[1].options.headers["Content-Type"], "application/x-www-form-urlencoded");
+  assert.match(calls[1].options.body, /grant_type=refresh_token/);
+  assert.match(calls[1].options.body, /client_id=/);
 });
 
 test("refreshGoogleToken exchanges refresh tokens against the shared google endpoint", async () => {

--- a/tests/unit/token-refresh-service.test.mjs
+++ b/tests/unit/token-refresh-service.test.mjs
@@ -279,7 +279,7 @@ test("refreshKimiCodingToken adds provider-specific headers and fields", async (
   assert.match(bodyToString(calls[0].options.body), /grant_type=refresh_token/);
 });
 
-test("refreshClaudeOAuthToken matches upstream Claude refresh contract", async () => {
+test("refreshClaudeOAuthToken matches Claude token exchange request shape without extra fields", async () => {
   const log = createLog();
   const calls = [];
 
@@ -303,13 +303,14 @@ test("refreshClaudeOAuthToken matches upstream Claude refresh contract", async (
   );
 
   assert.equal(calls[0].url, OAUTH_ENDPOINTS.anthropic.token);
-  assert.equal(calls[0].options.headers["Content-Type"], "application/x-www-form-urlencoded");
-  assert.equal(calls[0].options.headers["anthropic-beta"], "oauth-2025-04-20");
+  assert.equal(calls[0].options.headers["Content-Type"], "application/json");
+  assert.equal(calls[0].options.headers["anthropic-beta"], undefined);
   assert.equal(calls[0].options.headers["User-Agent"], undefined);
-  assert.equal(
-    bodyToString(calls[0].options.body),
-    `grant_type=refresh_token&refresh_token=claude-refresh&client_id=${encodeURIComponent(PROVIDERS.claude.clientId)}`
-  );
+  assert.deepEqual(JSON.parse(bodyToString(calls[0].options.body)), {
+    grant_type: "refresh_token",
+    refresh_token: "claude-refresh",
+    client_id: PROVIDERS.claude.clientId,
+  });
 });
 
 test("refreshClaudeOAuthToken returns null on invalid Claude refresh contract rejection", async () => {
@@ -334,8 +335,8 @@ test("refreshClaudeOAuthToken returns null on invalid Claude refresh contract re
   );
 
   assert.equal(calls.length, 1);
-  assert.equal(calls[0].options.headers["Content-Type"], "application/x-www-form-urlencoded");
-  assert.equal(calls[0].options.headers["anthropic-beta"], "oauth-2025-04-20");
+  assert.equal(calls[0].options.headers["Content-Type"], "application/json");
+  assert.equal(calls[0].options.headers["anthropic-beta"], undefined);
   assert.equal(
     log.entries.some((entry) => entry.level === "warn"),
     false

--- a/tests/unit/token-refresh-service.test.mjs
+++ b/tests/unit/token-refresh-service.test.mjs
@@ -279,7 +279,7 @@ test("refreshKimiCodingToken adds provider-specific headers and fields", async (
   assert.match(bodyToString(calls[0].options.body), /grant_type=refresh_token/);
 });
 
-test("refreshClaudeOAuthToken posts the anthropic oauth refresh contract as JSON first", async () => {
+test("refreshClaudeOAuthToken first matches Claude auth exchange token contract", async () => {
   const log = createLog();
   const calls = [];
 
@@ -304,8 +304,8 @@ test("refreshClaudeOAuthToken posts the anthropic oauth refresh contract as JSON
 
   assert.equal(calls[0].url, OAUTH_ENDPOINTS.anthropic.token);
   assert.equal(calls[0].options.headers["Content-Type"], "application/json");
-  assert.equal(calls[0].options.headers["User-Agent"], "anthropic");
-  assert.equal(calls[0].options.headers["anthropic-beta"], "oauth-2025-04-20");
+  assert.equal(calls[0].options.headers["User-Agent"], undefined);
+  assert.equal(calls[0].options.headers["anthropic-beta"], undefined);
   assert.deepEqual(JSON.parse(calls[0].options.body), {
     grant_type: "refresh_token",
     refresh_token: "claude-refresh",
@@ -313,14 +313,14 @@ test("refreshClaudeOAuthToken posts the anthropic oauth refresh contract as JSON
   });
 });
 
-test("refreshClaudeOAuthToken falls back to form-encoded when Anthropic rejects JSON format", async () => {
+test("refreshClaudeOAuthToken retries with user-agent JSON then form when format is rejected", async () => {
   const log = createLog();
   const calls = [];
 
   await withMockedFetch(
     async (url, options = {}) => {
       calls.push({ url, options });
-      if (calls.length === 1) {
+      if (calls.length <= 2) {
         return textResponse(
           JSON.stringify({
             type: "error",
@@ -346,10 +346,12 @@ test("refreshClaudeOAuthToken falls back to form-encoded when Anthropic rejects 
     }
   );
 
-  assert.equal(calls.length, 2);
-  assert.equal(calls[1].options.headers["Content-Type"], "application/x-www-form-urlencoded");
-  assert.match(calls[1].options.body, /grant_type=refresh_token/);
-  assert.match(calls[1].options.body, /client_id=/);
+  assert.equal(calls.length, 3);
+  assert.equal(calls[1].options.headers["Content-Type"], "application/json");
+  assert.equal(calls[1].options.headers["User-Agent"], "anthropic");
+  assert.equal(calls[2].options.headers["Content-Type"], "application/x-www-form-urlencoded");
+  assert.match(calls[2].options.body, /grant_type=refresh_token/);
+  assert.match(calls[2].options.body, /client_id=/);
 });
 
 test("refreshGoogleToken exchanges refresh tokens against the shared google endpoint", async () => {

--- a/tests/unit/token-refresh-service.test.mjs
+++ b/tests/unit/token-refresh-service.test.mjs
@@ -279,7 +279,7 @@ test("refreshKimiCodingToken adds provider-specific headers and fields", async (
   assert.match(bodyToString(calls[0].options.body), /grant_type=refresh_token/);
 });
 
-test("refreshClaudeOAuthToken matches Claude token exchange request shape without extra fields", async () => {
+test("refreshClaudeOAuthToken matches OmniRoute Claude refresh contract and emits redacted request details", async () => {
   const log = createLog();
   const calls = [];
 
@@ -303,13 +303,28 @@ test("refreshClaudeOAuthToken matches Claude token exchange request shape withou
   );
 
   assert.equal(calls[0].url, OAUTH_ENDPOINTS.anthropic.token);
-  assert.equal(calls[0].options.headers["Content-Type"], "application/json");
-  assert.equal(calls[0].options.headers["anthropic-beta"], undefined);
+  assert.equal(calls[0].options.headers["Content-Type"], "application/x-www-form-urlencoded");
+  assert.equal(calls[0].options.headers["anthropic-beta"], "oauth-2025-04-20");
   assert.equal(calls[0].options.headers["User-Agent"], undefined);
-  assert.deepEqual(JSON.parse(bodyToString(calls[0].options.body)), {
-    grant_type: "refresh_token",
-    refresh_token: "claude-refresh",
-    client_id: PROVIDERS.claude.clientId,
+  assert.equal(
+    bodyToString(calls[0].options.body),
+    `grant_type=refresh_token&refresh_token=claude-refresh&client_id=${encodeURIComponent(PROVIDERS.claude.clientId)}`
+  );
+
+  const detailLog = log.entries.find(
+    (entry) => entry.level === "warn" && entry.message === "Claude OAuth refresh request details"
+  );
+  assert.deepEqual(detailLog?.meta, {
+    method: "POST",
+    url: OAUTH_ENDPOINTS.anthropic.token,
+    contentType: "application/x-www-form-urlencoded",
+    accept: "application/json",
+    anthropicBeta: "oauth-2025-04-20",
+    bodyFormat: "form-urlencoded",
+    bodyKeys: ["grant_type", "refresh_token", "client_id"],
+    clientId: PROVIDERS.claude.clientId || null,
+    refreshTokenLength: "claude-refresh".length,
+    hasProxyConfig: null,
   });
 });
 
@@ -335,11 +350,11 @@ test("refreshClaudeOAuthToken returns null on invalid Claude refresh contract re
   );
 
   assert.equal(calls.length, 1);
-  assert.equal(calls[0].options.headers["Content-Type"], "application/json");
-  assert.equal(calls[0].options.headers["anthropic-beta"], undefined);
+  assert.equal(calls[0].options.headers["Content-Type"], "application/x-www-form-urlencoded");
+  assert.equal(calls[0].options.headers["anthropic-beta"], "oauth-2025-04-20");
   assert.equal(
     log.entries.some((entry) => entry.level === "warn"),
-    false
+    true
   );
   assert.equal(
     log.entries.some(

--- a/tests/unit/token-refresh-service.test.mjs
+++ b/tests/unit/token-refresh-service.test.mjs
@@ -279,7 +279,7 @@ test("refreshKimiCodingToken adds provider-specific headers and fields", async (
   assert.match(bodyToString(calls[0].options.body), /grant_type=refresh_token/);
 });
 
-test("refreshClaudeOAuthToken first matches Claude auth exchange token contract", async () => {
+test("refreshClaudeOAuthToken matches upstream Claude refresh contract", async () => {
   const log = createLog();
   const calls = [];
 
@@ -303,58 +303,49 @@ test("refreshClaudeOAuthToken first matches Claude auth exchange token contract"
   );
 
   assert.equal(calls[0].url, OAUTH_ENDPOINTS.anthropic.token);
-  assert.equal(calls[0].options.headers["Content-Type"], "application/json");
+  assert.equal(calls[0].options.headers["Content-Type"], "application/x-www-form-urlencoded");
+  assert.equal(calls[0].options.headers["anthropic-beta"], "oauth-2025-04-20");
   assert.equal(calls[0].options.headers["User-Agent"], undefined);
-  assert.equal(calls[0].options.headers["anthropic-beta"], undefined);
-  assert.deepEqual(JSON.parse(calls[0].options.body), {
-    grant_type: "refresh_token",
-    refresh_token: "claude-refresh",
-    client_id: PROVIDERS.claude.clientId,
-    scope:
-      "org:create_api_key user:profile user:inference user:sessions:claude_code user:mcp_servers",
-  });
+  assert.equal(
+    bodyToString(calls[0].options.body),
+    `grant_type=refresh_token&refresh_token=claude-refresh&client_id=${encodeURIComponent(PROVIDERS.claude.clientId)}`
+  );
 });
 
-test("refreshClaudeOAuthToken retries with user-agent JSON then form when format is rejected", async () => {
+test("refreshClaudeOAuthToken returns null on invalid Claude refresh contract rejection", async () => {
   const log = createLog();
   const calls = [];
 
   await withMockedFetch(
     async (url, options = {}) => {
       calls.push({ url, options });
-      if (calls.length <= 2) {
-        return textResponse(
-          JSON.stringify({
-            type: "error",
-            error: { type: "invalid_request_error", message: "Invalid request format" },
-          }),
-          400
-        );
-      }
-
-      return jsonResponse({
-        access_token: "claude-access-form",
-        refresh_token: "claude-refresh-form",
-        expires_in: 900,
-      });
+      return textResponse(
+        JSON.stringify({
+          type: "error",
+          error: { type: "invalid_request_error", message: "Invalid request format" },
+        }),
+        400
+      );
     },
     async () => {
       const result = await refreshClaudeOAuthToken("claude-refresh", log);
-      assert.deepEqual(result, {
-        accessToken: "claude-access-form",
-        refreshToken: "claude-refresh-form",
-        expiresIn: 900,
-      });
+      assert.equal(result, null);
     }
   );
 
-  assert.equal(calls.length, 3);
-  assert.equal(calls[1].options.headers["Content-Type"], "application/json");
-  assert.equal(calls[1].options.headers["User-Agent"], "anthropic");
-  assert.equal(calls[2].options.headers["Content-Type"], "application/x-www-form-urlencoded");
-  assert.match(calls[2].options.body, /grant_type=refresh_token/);
-  assert.match(calls[2].options.body, /client_id=/);
-  assert.match(calls[2].options.body, /scope=org%3Acreate_api_key/);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].options.headers["Content-Type"], "application/x-www-form-urlencoded");
+  assert.equal(calls[0].options.headers["anthropic-beta"], "oauth-2025-04-20");
+  assert.equal(
+    log.entries.some((entry) => entry.level === "warn"),
+    false
+  );
+  assert.equal(
+    log.entries.some(
+      (entry) => entry.level === "error" && entry.message === "Failed to refresh Claude OAuth token"
+    ),
+    true
+  );
 });
 
 test("refreshGoogleToken exchanges refresh tokens against the shared google endpoint", async () => {

--- a/tests/unit/token-refresh-service.test.mjs
+++ b/tests/unit/token-refresh-service.test.mjs
@@ -310,6 +310,8 @@ test("refreshClaudeOAuthToken first matches Claude auth exchange token contract"
     grant_type: "refresh_token",
     refresh_token: "claude-refresh",
     client_id: PROVIDERS.claude.clientId,
+    scope:
+      "org:create_api_key user:profile user:inference user:sessions:claude_code user:mcp_servers",
   });
 });
 
@@ -352,6 +354,7 @@ test("refreshClaudeOAuthToken retries with user-agent JSON then form when format
   assert.equal(calls[2].options.headers["Content-Type"], "application/x-www-form-urlencoded");
   assert.match(calls[2].options.body, /grant_type=refresh_token/);
   assert.match(calls[2].options.body, /client_id=/);
+  assert.match(calls[2].options.body, /scope=org%3Acreate_api_key/);
 });
 
 test("refreshGoogleToken exchanges refresh tokens against the shared google endpoint", async () => {

--- a/tests/unit/translator-openai-to-claude.test.mjs
+++ b/tests/unit/translator-openai-to-claude.test.mjs
@@ -26,6 +26,8 @@ const { claudeToOpenAIResponse } =
 const { CLAUDE_SYSTEM_PROMPT } = await import("../../open-sse/config/constants.ts");
 const { DEFAULT_THINKING_CLAUDE_SIGNATURE } =
   await import("../../open-sse/config/defaultThinkingSignature.ts");
+const { translateRequest } = await import("../../open-sse/translator/index.ts");
+const { FORMATS } = await import("../../open-sse/translator/formats.ts");
 
 test.beforeEach(() => {
   setForwardingKeywordConfig(getDefaultForwardingKeywordConfig());
@@ -321,6 +323,27 @@ test("OpenAI -> Claude passes adaptive thinking effort upstream when provided", 
       max_tokens: 128000,
     },
     true
+  );
+
+  assert.deepEqual(result.thinking, { type: "adaptive" });
+  assert.deepEqual(result.output_config, { effort: "max" });
+  assert.equal(result.max_tokens, 128000);
+});
+
+test("translateRequest promotes Claude thinkingLevel-only requests to adaptive effort", () => {
+  const result = translateRequest(
+    FORMATS.OPENAI,
+    FORMATS.CLAUDE,
+    "claude-opus-4-6",
+    {
+      model: "claude-opus-4-6",
+      messages: [{ role: "user", content: "Think harder" }],
+      thinkingLevel: "max",
+      max_tokens: 128000,
+    },
+    false,
+    null,
+    "claude"
   );
 
   assert.deepEqual(result.thinking, { type: "adaptive" });

--- a/tests/unit/translator-openai-to-claude.test.mjs
+++ b/tests/unit/translator-openai-to-claude.test.mjs
@@ -9,8 +9,10 @@ const {
   stripEmptyTextBlocks,
 } = await import("../../open-sse/translator/request/openai-to-claude.ts");
 const {
+  applyForwardingKeywordSettings,
   getDefaultForwardingKeywordConfig,
   getForwardingKeywordRulesForLane,
+  normalizeForwardingKeywordConfig,
   setForwardingKeywordConfig,
   rewriteForwardedTextForLane,
   rewriteForwardedToolNameForLane,
@@ -446,6 +448,49 @@ test("Forwarding keyword rules stay proxy-local and data-driven", () => {
   );
 });
 
+test("Forwarding keyword normalization rejects blank match and tag boundaries", () => {
+  const normalized = normalizeForwardingKeywordConfig({
+    "claude-oauth-prefixed": {
+      toolNames: [
+        { match: "   ", replace: "ignored" },
+        { match: " background_output ", replace: "background_result" },
+      ],
+      text: [{ match: "", replace: "ignored" }],
+      tags: [
+        {
+          open: "   ",
+          openReplacement: "ignored",
+          close: "</directories>",
+          closeReplacement: "",
+        },
+      ],
+    },
+  });
+
+  assert.deepEqual(normalized["claude-oauth-prefixed"].toolNames, [
+    { match: "background_output", replace: "background_result" },
+  ]);
+  assert.deepEqual(normalized["claude-oauth-prefixed"].text, []);
+  assert.deepEqual(normalized["claude-oauth-prefixed"].tags, []);
+});
+
+test("Forwarding keyword settings reset to defaults only after successful settings load", () => {
+  setForwardingKeywordConfig({
+    "claude-oauth-prefixed": {
+      toolNames: [{ match: "background_output", replace: "bg_out" }],
+      text: [{ match: "background_output", replace: "bg_out" }],
+      tags: [],
+    },
+  });
+
+  applyForwardingKeywordSettings({});
+
+  assert.deepEqual(
+    getForwardingKeywordRulesForLane("claude-oauth-prefixed"),
+    getDefaultForwardingKeywordConfig()["claude-oauth-prefixed"]
+  );
+});
+
 test("OpenAI-compatible -> Claude -> OpenAI-compatible preserves original tool names", () => {
   const request = openaiToClaudeRequest(
     "claude-4-sonnet",
@@ -497,6 +542,32 @@ test("OpenAI-compatible -> Claude -> OpenAI-compatible preserves original tool n
 
   assert.equal(
     streamingChunks[0].choices[0].delta.tool_calls[0].function.name,
+    "background_output"
+  );
+});
+
+test("OpenAI -> Claude stores tool name mappings for assistant tool calls without declared tools", () => {
+  const result = openaiToClaudeRequest(
+    "claude-4-sonnet",
+    {
+      messages: [
+        {
+          role: "assistant",
+          tool_calls: [
+            {
+              id: "call_1",
+              type: "function",
+              function: { name: "background_output", arguments: "{}" },
+            },
+          ],
+        },
+      ],
+    },
+    false
+  );
+
+  assert.equal(
+    result._toolNameMap.get(`${CLAUDE_OAUTH_TOOL_PREFIX}background_result`),
     "background_output"
   );
 });

--- a/tests/unit/translator-openai-to-claude.test.mjs
+++ b/tests/unit/translator-openai-to-claude.test.mjs
@@ -8,9 +8,24 @@ const {
   openaiToClaudeRequestForAntigravity,
   stripEmptyTextBlocks,
 } = await import("../../open-sse/translator/request/openai-to-claude.ts");
+const {
+  getDefaultForwardingKeywordConfig,
+  getForwardingKeywordRulesForLane,
+  setForwardingKeywordConfig,
+  rewriteForwardedTextForLane,
+  rewriteForwardedToolNameForLane,
+} = await import("../../open-sse/config/forwardingKeywordRules.ts");
+const { translateNonStreamingResponse } =
+  await import("../../open-sse/handlers/responseTranslator.ts");
+const { claudeToOpenAIResponse } =
+  await import("../../open-sse/translator/response/claude-to-openai.ts");
 const { CLAUDE_SYSTEM_PROMPT } = await import("../../open-sse/config/constants.ts");
 const { DEFAULT_THINKING_CLAUDE_SIGNATURE } =
   await import("../../open-sse/config/defaultThinkingSignature.ts");
+
+test.beforeEach(() => {
+  setForwardingKeywordConfig(getDefaultForwardingKeywordConfig());
+});
 
 test("OpenAI -> Claude helpers normalize array content and strip empty nested text blocks", () => {
   const normalized = normalizeContentToString([
@@ -223,7 +238,10 @@ test("OpenAI -> Claude maps tool_choice and injects response_format instructions
     false
   );
 
-  assert.deepEqual(jsonObjectResult.tool_choice, { type: "tool", name: "emit_json" });
+  assert.deepEqual(jsonObjectResult.tool_choice, {
+    type: "tool",
+    name: `${CLAUDE_OAUTH_TOOL_PREFIX}emit_json`,
+  });
   assert.match(jsonObjectResult.system[1].text, /Respond ONLY with a JSON object/i);
 });
 
@@ -347,6 +365,7 @@ test("OpenAI -> Claude rewrites confirmed lexical triggers only on the prefixed 
           },
         },
       ],
+      tool_choice: { type: "function", function: { name: "background_cancel" } },
     },
     false
   );
@@ -358,6 +377,10 @@ test("OpenAI -> Claude rewrites confirmed lexical triggers only on the prefixed 
   assert.doesNotMatch(oauthResult.system[1].text, /background_cancel/);
   assert.doesNotMatch(oauthResult.system[1].text, /<directories>/);
   assert.equal(oauthResult.tools[0].name, `${CLAUDE_OAUTH_TOOL_PREFIX}background_stop`);
+  assert.deepEqual(oauthResult.tool_choice, {
+    type: "tool",
+    name: `${CLAUDE_OAUTH_TOOL_PREFIX}background_stop`,
+  });
   assert.equal(
     oauthResult._toolNameMap.get(`${CLAUDE_OAUTH_TOOL_PREFIX}background_stop`),
     "background_cancel"
@@ -388,6 +411,7 @@ test("OpenAI -> Claude rewrites confirmed lexical triggers only on the prefixed 
           },
         },
       ],
+      tool_choice: { type: "function", function: { name: "background_cancel" } },
     },
     false
   );
@@ -395,4 +419,126 @@ test("OpenAI -> Claude rewrites confirmed lexical triggers only on the prefixed 
   assert.match(passthroughResult.system[1].text, /background_output/);
   assert.match(passthroughResult.system[1].text, /<directories>src\/<\/directories>/);
   assert.equal(passthroughResult.tools[0].name, "background_cancel");
+  assert.deepEqual(passthroughResult.tool_choice, { type: "tool", name: "background_cancel" });
+});
+
+test("Forwarding keyword rules stay proxy-local and data-driven", () => {
+  const rules = getForwardingKeywordRulesForLane("claude-oauth-prefixed");
+
+  assert.deepEqual(
+    rules.toolNames.map((rule) => [rule.match, rule.replace]),
+    [
+      ["background_output", "background_result"],
+      ["background_cancel", "background_stop"],
+    ]
+  );
+  assert.equal(
+    rewriteForwardedToolNameForLane("claude-oauth-prefixed", "background_output"),
+    "background_result"
+  );
+  assert.equal(rewriteForwardedToolNameForLane("claude-oauth-prefixed", "read_file"), "read_file");
+  assert.equal(
+    rewriteForwardedTextForLane(
+      "claude-oauth-prefixed",
+      "background_cancel <directories>src/</directories>"
+    ),
+    "background_stop directories:\nsrc/"
+  );
+});
+
+test("OpenAI-compatible -> Claude -> OpenAI-compatible preserves original tool names", () => {
+  const request = openaiToClaudeRequest(
+    "claude-4-sonnet",
+    {
+      messages: [{ role: "user", content: "Run the tool" }],
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: "background_cancel",
+            description: "Cancel work",
+            parameters: { type: "object", properties: {} },
+          },
+        },
+      ],
+    },
+    false
+  );
+
+  const nonStreamingResponse = translateNonStreamingResponse(
+    {
+      id: "msg_1",
+      model: "claude-4-sonnet",
+      content: [{ type: "tool_use", id: "call_1", name: request.tools[0].name, input: {} }],
+      usage: { input_tokens: 10, output_tokens: 5 },
+    },
+    "claude",
+    "openai",
+    request._toolNameMap
+  );
+
+  assert.equal(
+    nonStreamingResponse.choices[0].message.tool_calls[0].function.name,
+    "background_cancel"
+  );
+
+  const streamingChunks = claudeToOpenAIResponse(
+    {
+      type: "content_block_start",
+      index: 0,
+      content_block: { type: "tool_use", id: "call_1", name: "proxy_background_result" },
+    },
+    {
+      toolCallIndex: 0,
+      toolCalls: new Map(),
+      toolNameMap: new Map([["proxy_background_result", "background_output"]]),
+    }
+  );
+
+  assert.equal(
+    streamingChunks[0].choices[0].delta.tool_calls[0].function.name,
+    "background_output"
+  );
+});
+
+test("OpenAI -> Claude rewrites nested tool_result text on the prefixed OAuth lane", () => {
+  const result = openaiToClaudeRequest(
+    "claude-4-sonnet",
+    {
+      messages: [
+        {
+          role: "assistant",
+          tool_calls: [
+            {
+              id: "call_1",
+              type: "function",
+              function: { name: "background_output", arguments: "{}" },
+            },
+          ],
+        },
+        {
+          role: "tool",
+          tool_call_id: "call_1",
+          content: [
+            {
+              type: "text",
+              text: "background_output <directories>src/</directories>",
+            },
+          ],
+        },
+      ],
+    },
+    false
+  );
+
+  const toolResultMessage = result.messages.find(
+    (message) =>
+      message.role === "user" && message.content.some((block) => block.type === "tool_result")
+  );
+
+  assert.deepEqual(toolResultMessage.content[0], {
+    type: "tool_result",
+    tool_use_id: "call_1",
+    content: [{ type: "text", text: "background_result directories:\nsrc/" }],
+  });
 });

--- a/tests/unit/translator-openai-to-claude.test.mjs
+++ b/tests/unit/translator-openai-to-claude.test.mjs
@@ -244,6 +244,20 @@ test("OpenAI -> Claude maps tool_choice and injects response_format instructions
     type: "tool",
     name: `${CLAUDE_OAUTH_TOOL_PREFIX}emit_json`,
   });
+
+  const claudeNativeToolChoiceResult = openaiToClaudeRequest(
+    "claude-4-sonnet",
+    {
+      messages: [{ role: "user", content: "Use the existing Claude-native tool choice" }],
+      tool_choice: { type: "tool", name: `${CLAUDE_OAUTH_TOOL_PREFIX}emit_json` },
+    },
+    false
+  );
+
+  assert.deepEqual(claudeNativeToolChoiceResult.tool_choice, {
+    type: "tool",
+    name: `${CLAUDE_OAUTH_TOOL_PREFIX}emit_json`,
+  });
   assert.match(jsonObjectResult.system[1].text, /Respond ONLY with a JSON object/i);
 });
 

--- a/tests/unit/translator-openai-to-claude.test.mjs
+++ b/tests/unit/translator-openai-to-claude.test.mjs
@@ -274,8 +274,8 @@ test("OpenAI -> Claude turns reasoning settings into thinking budgets and expand
     false
   );
 
-  assert.deepEqual(effortResult.thinking, { type: "enabled", budget_tokens: 1024 });
-  assert.equal(effortResult.max_tokens, 9216);
+  assert.deepEqual(effortResult.thinking, { type: "enabled", budget_tokens: 10 });
+  assert.equal(effortResult.max_tokens, 10);
 
   const explicitThinkingResult = openaiToClaudeRequest(
     "claude-4-sonnet",
@@ -289,10 +289,26 @@ test("OpenAI -> Claude turns reasoning settings into thinking budgets and expand
 
   assert.deepEqual(explicitThinkingResult.thinking, {
     type: "enabled",
-    budget_tokens: 2000,
-    max_tokens: 3000,
+    budget_tokens: 1000,
+    max_tokens: 1000,
   });
-  assert.equal(explicitThinkingResult.max_tokens, 10192);
+  assert.equal(explicitThinkingResult.max_tokens, 1000);
+
+  const cappedOpusResult = openaiToClaudeRequest(
+    "claude-opus-4-6",
+    {
+      messages: [{ role: "user", content: "Think harder" }],
+      max_tokens: 128000,
+      reasoning_effort: "max",
+    },
+    true
+  );
+
+  assert.equal(cappedOpusResult.max_tokens, 128000);
+  assert.deepEqual(cappedOpusResult.thinking, {
+    type: "enabled",
+    budget_tokens: 128000,
+  });
 });
 
 test("OpenAI -> Claude can disable OAuth prefixes and Antigravity strips Claude-only prompting", () => {

--- a/tests/unit/translator-openai-to-claude.test.mjs
+++ b/tests/unit/translator-openai-to-claude.test.mjs
@@ -485,9 +485,54 @@ test("Forwarding keyword normalization rejects blank match and tag boundaries", 
 
   assert.deepEqual(normalized["claude-oauth-prefixed"].toolNames, [
     { match: "background_output", replace: "background_result" },
+    { match: "background_cancel", replace: "background_stop" },
   ]);
-  assert.deepEqual(normalized["claude-oauth-prefixed"].text, []);
-  assert.deepEqual(normalized["claude-oauth-prefixed"].tags, []);
+  assert.deepEqual(normalized["claude-oauth-prefixed"].text, [
+    { match: "background_output", replace: "background_result" },
+    { match: "background_cancel", replace: "background_stop" },
+  ]);
+  assert.deepEqual(normalized["claude-oauth-prefixed"].tags, [
+    {
+      open: "<directories>",
+      openReplacement: "directories:\n",
+      close: "</directories>",
+      closeReplacement: "",
+    },
+  ]);
+});
+
+test("Forwarding keyword normalization overlays saved rules onto defaults", () => {
+  const normalized = normalizeForwardingKeywordConfig({
+    "claude-oauth-prefixed": {
+      toolNames: [{ match: "background_output", replace: "bg_out" }],
+      text: [],
+      tags: [
+        {
+          open: "<directories>",
+          openReplacement: "dirs:\n",
+          close: "</directories>",
+          closeReplacement: "",
+        },
+      ],
+    },
+  });
+
+  assert.deepEqual(normalized["claude-oauth-prefixed"].toolNames, [
+    { match: "background_output", replace: "bg_out" },
+    { match: "background_cancel", replace: "background_stop" },
+  ]);
+  assert.deepEqual(normalized["claude-oauth-prefixed"].text, [
+    { match: "background_output", replace: "background_result" },
+    { match: "background_cancel", replace: "background_stop" },
+  ]);
+  assert.deepEqual(normalized["claude-oauth-prefixed"].tags, [
+    {
+      open: "<directories>",
+      openReplacement: "dirs:\n",
+      close: "</directories>",
+      closeReplacement: "",
+    },
+  ]);
 });
 
 test("Forwarding keyword settings reset to defaults only after successful settings load", () => {
@@ -505,6 +550,29 @@ test("Forwarding keyword settings reset to defaults only after successful settin
     getForwardingKeywordRulesForLane("claude-oauth-prefixed"),
     getDefaultForwardingKeywordConfig()["claude-oauth-prefixed"]
   );
+});
+
+test("Forwarding keyword settings keep defaults active when saved config has empty arrays", () => {
+  applyForwardingKeywordSettings({
+    forwardingKeywordRules: {
+      "claude-oauth-prefixed": {
+        toolNames: [],
+        text: [],
+        tags: [],
+      },
+    },
+  });
+
+  const rewrittenText = rewriteForwardedTextForLane(
+    "claude-oauth-prefixed",
+    "background_output <directories>src/</directories>"
+  );
+
+  assert.equal(
+    rewriteForwardedToolNameForLane("claude-oauth-prefixed", "background_cancel"),
+    "background_stop"
+  );
+  assert.equal(rewrittenText, "background_result directories:\nsrc/");
 });
 
 test("OpenAI-compatible -> Claude -> OpenAI-compatible preserves original tool names", () => {

--- a/tests/unit/translator-openai-to-claude.test.mjs
+++ b/tests/unit/translator-openai-to-claude.test.mjs
@@ -17,6 +17,8 @@ const {
   rewriteForwardedTextForLane,
   rewriteForwardedToolNameForLane,
 } = await import("../../open-sse/config/forwardingKeywordRules.ts");
+const { applyClaudeOAuthLexicalRewrite } =
+  await import("../../open-sse/translator/helpers/claudeHelper.ts");
 const { translateNonStreamingResponse } =
   await import("../../open-sse/handlers/responseTranslator.ts");
 const { claudeToOpenAIResponse } =
@@ -626,4 +628,68 @@ test("OpenAI -> Claude rewrites nested tool_result text on the prefixed OAuth la
     tool_use_id: "call_1",
     content: [{ type: "text", text: "background_result directories:\nsrc/" }],
   });
+});
+
+test("Claude-native passthrough rewrites lexical triggers before Anthropic forwarding", () => {
+  const payload = {
+    system: [
+      {
+        type: "text",
+        text: "Use background_output and <directories>src/</directories>",
+      },
+    ],
+    tools: [
+      {
+        name: "background_cancel",
+        description: "Cancel background_output requests",
+        input_schema: { type: "object", properties: {} },
+      },
+    ],
+    tool_choice: { type: "tool", name: "background_cancel" },
+    messages: [
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "background_output first" },
+          { type: "tool_use", id: "tool_1", name: "background_output", input: {} },
+        ],
+      },
+    ],
+  };
+
+  const { body, toolNameMap } = applyClaudeOAuthLexicalRewrite(structuredClone(payload));
+
+  assert.equal(body.system[0].text, "Use background_result and directories:\nsrc/");
+  assert.equal(body.tools[0].name, "background_stop");
+  assert.equal(body.tools[0].description, "Cancel background_result requests");
+  assert.deepEqual(body.tool_choice, { type: "tool", name: "background_stop" });
+  assert.equal(body.messages[0].content[0].thinking, "background_result first");
+  assert.equal(body.messages[0].content[1].name, "background_result");
+  assert.equal(toolNameMap.get("background_result"), "background_output");
+  assert.equal(toolNameMap.get("background_stop"), "background_cancel");
+});
+
+test("Claude-native passthrough rewrites string-form Anthropic payloads", () => {
+  const payload = {
+    system: "Use <directories>src/</directories> before background_output",
+    messages: [
+      { role: "user", content: "background_cancel then background_output" },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "call_1",
+            content: "background_output completed",
+          },
+        ],
+      },
+    ],
+  };
+
+  const { body } = applyClaudeOAuthLexicalRewrite(structuredClone(payload));
+
+  assert.equal(body.system, "Use directories:\nsrc/ before background_result");
+  assert.equal(body.messages[0].content, "background_stop then background_result");
+  assert.equal(body.messages[1].content[0].content, "background_result completed");
 });

--- a/tests/unit/translator-openai-to-claude.test.mjs
+++ b/tests/unit/translator-openai-to-claude.test.mjs
@@ -651,6 +651,7 @@ test("Claude-native passthrough rewrites lexical triggers before Anthropic forwa
         role: "assistant",
         content: [
           { type: "thinking", thinking: "background_output first" },
+          { type: "redacted_thinking", thinking: "background_cancel hidden" },
           { type: "tool_use", id: "tool_1", name: "background_output", input: {} },
         ],
       },
@@ -664,7 +665,8 @@ test("Claude-native passthrough rewrites lexical triggers before Anthropic forwa
   assert.equal(body.tools[0].description, "Cancel background_result requests");
   assert.deepEqual(body.tool_choice, { type: "tool", name: "background_stop" });
   assert.equal(body.messages[0].content[0].thinking, "background_result first");
-  assert.equal(body.messages[0].content[1].name, "background_result");
+  assert.equal(body.messages[0].content[1].thinking, "background_stop hidden");
+  assert.equal(body.messages[0].content[2].name, "background_result");
   assert.equal(toolNameMap.get("background_result"), "background_output");
   assert.equal(toolNameMap.get("background_stop"), "background_cancel");
 });

--- a/tests/unit/translator-openai-to-claude.test.mjs
+++ b/tests/unit/translator-openai-to-claude.test.mjs
@@ -311,6 +311,23 @@ test("OpenAI -> Claude turns reasoning settings into thinking budgets and expand
   });
 });
 
+test("OpenAI -> Claude passes adaptive thinking effort upstream when provided", () => {
+  const result = openaiToClaudeRequest(
+    "claude-opus-4-6",
+    {
+      messages: [{ role: "user", content: "Think harder" }],
+      thinking: { type: "adaptive" },
+      output_config: { effort: "max" },
+      max_tokens: 128000,
+    },
+    true
+  );
+
+  assert.deepEqual(result.thinking, { type: "adaptive" });
+  assert.deepEqual(result.output_config, { effort: "max" });
+  assert.equal(result.max_tokens, 128000);
+});
+
 test("OpenAI -> Claude can disable OAuth prefixes and Antigravity strips Claude-only prompting", () => {
   const baseBody = {
     messages: [

--- a/tests/unit/translator-openai-to-claude.test.mjs
+++ b/tests/unit/translator-openai-to-claude.test.mjs
@@ -312,3 +312,87 @@ test("OpenAI -> Claude can disable OAuth prefixes and Antigravity strips Claude-
     "read_file"
   );
 });
+
+test("OpenAI -> Claude rewrites confirmed lexical triggers only on the prefixed OAuth lane", () => {
+  const oauthResult = openaiToClaudeRequest(
+    "claude-4-sonnet",
+    {
+      messages: [
+        {
+          role: "system",
+          content: "Use background_output, background_cancel, and <directories>src/</directories>",
+        },
+        {
+          role: "assistant",
+          reasoning_content: "Prefer background_output before background_cancel",
+          tool_calls: [
+            {
+              id: "call_1",
+              type: "function",
+              function: {
+                name: "background_output",
+                arguments: "{}",
+              },
+            },
+          ],
+        },
+      ],
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: "background_cancel",
+            description: "Cancel background work",
+            parameters: { type: "object", properties: {} },
+          },
+        },
+      ],
+    },
+    false
+  );
+
+  assert.match(oauthResult.system[1].text, /background_result/);
+  assert.match(oauthResult.system[1].text, /background_stop/);
+  assert.match(oauthResult.system[1].text, /directories:\nsrc\//);
+  assert.doesNotMatch(oauthResult.system[1].text, /background_output/);
+  assert.doesNotMatch(oauthResult.system[1].text, /background_cancel/);
+  assert.doesNotMatch(oauthResult.system[1].text, /<directories>/);
+  assert.equal(oauthResult.tools[0].name, `${CLAUDE_OAUTH_TOOL_PREFIX}background_stop`);
+  assert.equal(
+    oauthResult._toolNameMap.get(`${CLAUDE_OAUTH_TOOL_PREFIX}background_stop`),
+    "background_cancel"
+  );
+  assert.equal(
+    oauthResult.messages[0].content.find((block) => block.type === "thinking").thinking,
+    "Prefer background_result before background_stop"
+  );
+  assert.equal(
+    oauthResult.messages[0].content.find((block) => block.type === "tool_use").name,
+    `${CLAUDE_OAUTH_TOOL_PREFIX}background_result`
+  );
+
+  const passthroughResult = openaiToClaudeRequest(
+    "claude-4-sonnet",
+    {
+      _disableToolPrefix: true,
+      messages: [
+        { role: "system", content: "Use background_output and <directories>src/</directories>" },
+      ],
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: "background_cancel",
+            description: "Cancel background work",
+            parameters: { type: "object", properties: {} },
+          },
+        },
+      ],
+    },
+    false
+  );
+
+  assert.match(passthroughResult.system[1].text, /background_output/);
+  assert.match(passthroughResult.system[1].text, /<directories>src\/<\/directories>/);
+  assert.equal(passthroughResult.tools[0].name, "background_cancel");
+});

--- a/tests/unit/translator-resp-claude-to-openai.test.mjs
+++ b/tests/unit/translator-resp-claude-to-openai.test.mjs
@@ -231,3 +231,186 @@ test("Claude stream: message_stop falls back to tool_calls when tool use already
 test("Claude stream: unsupported events return null", () => {
   assert.equal(claudeToOpenAIResponse({ type: "error" }, createState()), null);
 });
+
+test("Claude stream: message_start captures cache tokens from initial usage", () => {
+  const state = createState();
+  claudeToOpenAIResponse(
+    {
+      type: "message_start",
+      message: {
+        id: "msg_cache",
+        model: "claude-sonnet-4-20250514",
+        usage: {
+          input_tokens: 26,
+          output_tokens: 0,
+          cache_read_input_tokens: 91945,
+          cache_creation_input_tokens: 152,
+        },
+      },
+    },
+    state
+  );
+
+  assert.equal(state.usage.input_tokens, 26);
+  assert.equal(state.usage.cache_read_input_tokens, 91945);
+  assert.equal(state.usage.cache_creation_input_tokens, 152);
+});
+
+test("Claude stream: message_delta merges output_tokens with existing cache tokens from message_start", () => {
+  const state = createState();
+  claudeToOpenAIResponse(
+    {
+      type: "message_start",
+      message: {
+        id: "msg_merge",
+        model: "claude-sonnet-4-20250514",
+        usage: {
+          input_tokens: 26,
+          output_tokens: 0,
+          cache_read_input_tokens: 91945,
+          cache_creation_input_tokens: 152,
+        },
+      },
+    },
+    state
+  );
+
+  const result = claudeToOpenAIResponse(
+    {
+      type: "message_delta",
+      delta: { stop_reason: "end_turn" },
+      usage: { output_tokens: 603 },
+    },
+    state
+  );
+
+  assert.equal(result[0].usage.prompt_tokens, 26 + 91945 + 152);
+  assert.equal(result[0].usage.completion_tokens, 603);
+  assert.equal(result[0].usage.total_tokens, 26 + 91945 + 152 + 603);
+  assert.equal(result[0].usage.prompt_tokens_details.cached_tokens, 91945);
+  assert.equal(result[0].usage.prompt_tokens_details.cache_creation_tokens, 152);
+});
+
+test("Claude stream: message_stop fallback includes cache tokens in prompt_tokens_details", () => {
+  const state = createState();
+  claudeToOpenAIResponse(
+    {
+      type: "message_start",
+      message: {
+        id: "msg_stop",
+        model: "claude-sonnet-4-20250514",
+        usage: {
+          input_tokens: 50,
+          output_tokens: 0,
+          cache_read_input_tokens: 1000,
+          cache_creation_input_tokens: 200,
+        },
+      },
+    },
+    state
+  );
+
+  claudeToOpenAIResponse(
+    {
+      type: "content_block_start",
+      index: 0,
+      content_block: { type: "text" },
+    },
+    state
+  );
+  claudeToOpenAIResponse(
+    {
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "text_delta", text: "Hello" },
+    },
+    state
+  );
+  claudeToOpenAIResponse({ type: "content_block_stop", index: 0 }, state);
+
+  // message_delta carries output_tokens but no stop_reason
+  claudeToOpenAIResponse(
+    {
+      type: "message_delta",
+      delta: {},
+      usage: { output_tokens: 100 },
+    },
+    state
+  );
+
+  // message_stop emits the final chunk (fallback path since no stop_reason in delta)
+  const result = claudeToOpenAIResponse({ type: "message_stop" }, state);
+
+  assert.ok(result, "message_stop should emit a chunk");
+  assert.equal(result[0].usage.prompt_tokens, 50 + 1000 + 200);
+  assert.equal(result[0].usage.completion_tokens, 100);
+  assert.equal(result[0].usage.total_tokens, 50 + 1000 + 200 + 100);
+  assert.equal(result[0].usage.prompt_tokens_details.cached_tokens, 1000);
+  assert.equal(result[0].usage.prompt_tokens_details.cache_creation_tokens, 200);
+});
+
+test("Claude non-stream: cache tokens appear in prompt_tokens_details", () => {
+  const result = translateNonStreamingResponse(
+    {
+      id: "msg_cached",
+      model: "claude-sonnet-4-20250514",
+      content: [{ type: "text", text: "Answer" }],
+      stop_reason: "end_turn",
+      usage: {
+        input_tokens: 26,
+        output_tokens: 603,
+        cache_read_input_tokens: 91945,
+        cache_creation_input_tokens: 152,
+      },
+    },
+    FORMATS.CLAUDE,
+    FORMATS.OPENAI
+  );
+
+  assert.equal(result.usage.prompt_tokens, 26 + 91945 + 152);
+  assert.equal(result.usage.completion_tokens, 603);
+  assert.equal(result.usage.total_tokens, 26 + 91945 + 152 + 603);
+  assert.deepEqual(result.usage.prompt_tokens_details, {
+    cached_tokens: 91945,
+    cache_creation_tokens: 152,
+  });
+});
+
+test("filterUsageForFormat promotes flat Claude cache tokens to OpenAI nested details", async () => {
+  const { filterUsageForFormat } = await import("../../open-sse/utils/usageTracking.ts");
+  const { FORMATS: FMT } = await import("../../open-sse/translator/formats.ts");
+
+  const claudeUsage = {
+    prompt_tokens: 92123,
+    completion_tokens: 603,
+    total_tokens: 92726,
+    cache_read_input_tokens: 91945,
+    cache_creation_input_tokens: 152,
+  };
+
+  const filtered = filterUsageForFormat(claudeUsage, FMT.OPENAI);
+
+  assert.equal(filtered.prompt_tokens, 92123);
+  assert.equal(filtered.completion_tokens, 603);
+  assert.equal(filtered.total_tokens, 92726);
+  assert.equal(filtered.prompt_tokens_details.cached_tokens, 91945);
+  assert.equal(filtered.prompt_tokens_details.cache_creation_tokens, 152);
+  assert.equal(filtered.cache_read_input_tokens, undefined);
+  assert.equal(filtered.cache_creation_input_tokens, undefined);
+});
+
+test("filterUsageForFormat promotes flat reasoning_tokens to completion_tokens_details", async () => {
+  const { filterUsageForFormat } = await import("../../open-sse/utils/usageTracking.ts");
+  const { FORMATS: FMT } = await import("../../open-sse/translator/formats.ts");
+
+  const usage = {
+    prompt_tokens: 100,
+    completion_tokens: 500,
+    total_tokens: 600,
+    reasoning_tokens: 200,
+  };
+
+  const filtered = filterUsageForFormat(usage, FMT.OPENAI);
+
+  assert.equal(filtered.completion_tokens_details.reasoning_tokens, 200);
+});

--- a/tests/unit/translator-resp-claude-to-openai.test.mjs
+++ b/tests/unit/translator-resp-claude-to-openai.test.mjs
@@ -413,4 +413,5 @@ test("filterUsageForFormat promotes flat reasoning_tokens to completion_tokens_d
   const filtered = filterUsageForFormat(usage, FMT.OPENAI);
 
   assert.equal(filtered.completion_tokens_details.reasoning_tokens, 200);
+  assert.equal(filtered.reasoning_tokens, undefined);
 });


### PR DESCRIPTION
## Summary

Add Claude Opus 4.7 compatibility to the OpenAI-compat → Claude OAuth pipeline, addressing all Anthropic breaking changes while preserving full Opus 4.6 backward compatibility.

## Anthropic Breaking Changes Addressed

| Breaking Change | Solution |
|---|---|
| `thinking: {type:"enabled"}` → 400 error | `coerceThinkingForModel()` converts to `type:"adaptive"` at both thinkingBudget and translator layers |
| `temperature`/`top_p`/`top_k` non-default → 400 error | Stripped in translator for `rejectsSamplingParams` models |
| `thinking.display` defaults to `"omitted"` | Auto-inject `display:"summarized"` so OpenCode sees thinking text |
| `xhigh` effort (4.7 only) | `downgradeEffort()` converts to `max` on unsupported models |

## Scope

**OpenAI-compatible → Claude OAuth path only.** Other paths (Claude-native passthrough, Claude→Claude, CC-compatible) are out of scope.

## Actual Payload Diff (4.6 vs 4.7)

4.6 Provider Request (unchanged):
```json
{ "thinking": { "type": "adaptive" }, "output_config": { "effort": "max" }, "temperature": 0.7 }
```

4.7 Provider Request (new):
```json
{ "thinking": { "type": "adaptive", "display": "summarized" }, "output_config": { "effort": "max" } }
```

Changes: `display` field added, sampling params stripped.

## Tests

- New: 26/26 (opus-4.7-compat.test.mjs)
- Regression: thinking-budget 30/30, provider-service 9/9, chatcore 43/43, translator 15/15, stream 16/16

## Verification

- Oracle validation: main OpenAI→Claude path confirmed correct, no type:enabled leak
- Runtime payload trace: verified actual before/after transformations
- Baseline tag: apex-v1.0.0 for safe rollback
