### PR TITLE
fix(codex): strip server-generated IDs from response items in input to prevent 404 errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update \
 
 COPY package*.json ./
 COPY scripts/postinstall.mjs ./scripts/postinstall.mjs
+COPY scripts/postinstallSupport.mjs ./scripts/postinstallSupport.mjs
 COPY scripts/native-binary-compat.mjs ./scripts/native-binary-compat.mjs
 RUN if [ -f package-lock.json ]; then npm ci --no-audit --no-fund; else npm install --no-audit --no-fund; fi
 

--- a/open-sse/executors/codex.ts
+++ b/open-sse/executors/codex.ts
@@ -379,7 +379,7 @@ function normalizeCodexTools(body: Record<string, unknown>): void {
 
 function getResponsesSubpath(endpointPath: unknown): string | null {
   const normalizedEndpoint = String(endpointPath || "").replace(/\/+$/, "");
-  const match = normalizedEndpoint.match(/(?:^|\/)responses(?:(\/.*))  ?$/i);
+  const match = normalizedEndpoint.match(/(?:^|\/)responses(?:(\/.*))?$/i);
   if (!match) return null;
   return match[1] || "";
 }

--- a/open-sse/executors/codex.ts
+++ b/open-sse/executors/codex.ts
@@ -1,6 +1,5 @@
 import {
   getCodexRequestDefaults,
-  isOpenAIResponsesStoreEnabled,
 } from "@/lib/providers/requestDefaults";
 import { BaseExecutor, setUserAgentHeader } from "./base.ts";
 import { CODEX_DEFAULT_INSTRUCTIONS } from "../config/codexInstructions.ts";
@@ -408,7 +407,30 @@ export class CodexExecutor extends BaseExecutor {
       headers["chatgpt-account-id"] = workspaceId;
     }
 
+    // Originator header — identifies the client type to the Codex backend.
+    // Ref: openai/codex login/src/auth/default_client.rs DEFAULT_ORIGINATOR = "codex_cli_rs"
+    headers["originator"] = "codex_cli_rs";
+
+    // session_id header — enables prompt cache affinity on the Codex backend.
+    // The official Codex client sets this to conversation_id (a stable UUID per session).
+    // Ref: openai/codex codex-api/src/requests/headers.rs build_conversation_headers()
+    const cacheSessionId = this.getPromptCacheSessionId(credentials);
+    if (cacheSessionId) {
+      headers["session_id"] = cacheSessionId;
+    }
+
     return headers;
+  }
+
+  /**
+   * Derive a stable session ID for prompt cache affinity.
+   * Uses workspaceId (chatgpt account ID) as the cache partition key.
+   * This mirrors the official Codex client's use of conversation_id for
+   * prompt_cache_key and session_id header.
+   * Ref: openai/codex core/src/client.rs line 853
+   */
+  private getPromptCacheSessionId(credentials): string | null {
+    return credentials?.providerSpecificData?.workspaceId || null;
   }
 
   /**
@@ -448,10 +470,9 @@ export class CodexExecutor extends BaseExecutor {
     const nativeCodexPassthrough = body?._nativeCodexPassthrough === true;
     const isCompactRequest = isCompactResponsesEndpoint(credentials?.requestEndpointPath);
     const requestDefaults = getCodexRequestDefaults(credentials?.providerSpecificData);
-    const storeEnabled = isOpenAIResponsesStoreEnabled(credentials?.providerSpecificData);
     const thinkingBudgetConfig = getThinkingBudgetConfig();
     const allowConnectionReasoningDefaults = thinkingBudgetConfig.mode === ThinkingMode.PASSTHROUGH;
-    const responsesStoreMarker = consumeResponsesStoreMarker(body);
+    consumeResponsesStoreMarker(body);
 
     // Codex /responses rejects stream=false, but /responses/compact rejects the stream field entirely.
     if (isCompactRequest) {
@@ -512,10 +533,14 @@ export class CodexExecutor extends BaseExecutor {
       hoistSystemMessagesToInstructions(body);
     }
 
-    if (!storeEnabled) {
+    // Codex store setting: the official openai/codex client sets store=false by default
+    // (only Azure Responses endpoints use store=true).
+    // Ref: openai/codex core/src/client.rs line 862:
+    //   store: provider.is_azure_responses_endpoint()
+    // We don't manipulate the client's store value — if the client doesn't set it,
+    // default to false to match the official behavior.
+    if (body.store === undefined) {
       body.store = false;
-    } else if (responsesStoreMarker !== undefined && body.store === undefined) {
-      body.store = responsesStoreMarker;
     }
 
     // Codex Responses only supports function tools with non-empty names.
@@ -561,6 +586,29 @@ export class CodexExecutor extends BaseExecutor {
     }
     delete body.reasoning_effort;
 
+    // Delete previous_response_id — the official Codex client never sets it for HTTP
+    // requests (only WebSocket uses it as None). Sending a stale ID when store=false
+    // causes 404 errors from the Codex backend.
+    // Ref: openai/codex codex-api/src/common.rs line 187: previous_response_id: None
+    delete body.previous_response_id;
+
+    // Remove unsupported token limit parameters BEFORE the passthrough return.
+    // Codex API rejects both max_tokens and max_output_tokens regardless of
+    // whether the request came via native passthrough or translation.
+    delete body.max_tokens;
+    delete body.max_output_tokens;
+
+    // Inject prompt_cache_key for Codex prompt caching.
+    // The official Codex client sets this to conversation_id (a stable UUID per session).
+    // Ref: openai/codex core/src/client.rs line 853:
+    //   let prompt_cache_key = Some(self.client.state.conversation_id.to_string());
+    if (!body.prompt_cache_key) {
+      const cacheSessionId = this.getPromptCacheSessionId(credentials);
+      if (cacheSessionId) {
+        body.prompt_cache_key = cacheSessionId;
+      }
+    }
+
     if (nativeCodexPassthrough) {
       return body;
     }
@@ -574,8 +622,7 @@ export class CodexExecutor extends BaseExecutor {
     delete body.top_logprobs;
     delete body.n;
     delete body.seed;
-    delete body.max_tokens;
-    delete body.max_output_tokens; // Responses API translator maps max_tokens -> max_output_tokens, but Codex rejects it
+    // max_tokens and max_output_tokens already deleted above (before passthrough return)
     delete body.user; // Cursor sends this but Codex doesn't support it
     delete body.prompt_cache_retention; // Cursor sends this but Codex doesn't support it
     delete body.metadata; // Cursor sends this but Codex doesn't support it

--- a/open-sse/executors/codex.ts
+++ b/open-sse/executors/codex.ts
@@ -533,11 +533,13 @@ export class CodexExecutor extends BaseExecutor {
       hoistSystemMessagesToInstructions(body);
     }
 
-    // Store: CLIProxyAPI does not manipulate the store field (passthrough).
-    // The official Codex TUI client sets store=false (core/src/client.rs:862)
-    // because it sends full conversation history each turn.
-    // Proxy clients may rely on store=true for response chaining via
-    // previous_response_id. We follow CLIProxyAPI: don't touch it.
+    // Store: The Codex API defaults store to false when not specified.
+    // Proxy clients (e.g. OpenClaw) rely on response chaining via previous_response_id,
+    // which requires store=true so that response items are persisted.
+    // If the client explicitly sets store, respect it. Otherwise default to true.
+    if (body.store === undefined) {
+      body.store = true;
+    }
 
     // Codex Responses only supports function tools with non-empty names.
     // Cursor may include custom tools (e.g. ApplyPatch) that work locally but are

--- a/open-sse/executors/codex.ts
+++ b/open-sse/executors/codex.ts
@@ -257,27 +257,40 @@ function convertSystemToDeveloperRole(body: Record<string, unknown>): void {
 }
 
 /**
- * Strip stored response item references from the input array.
+ * Strip server-generated item IDs from the input array.
  *
  * The Codex /codex/responses endpoint does not persist response items even when
- * store=true is sent. Proxy clients (e.g. OpenClaw) may include string references
- * like "rs_<id>" in the input array expecting the server to expand them inline.
- * Since the items were never persisted, these references cause 404 errors.
+ * store=true is sent. When proxy clients (e.g. OpenClaw) include response items
+ * from previous turns in the input array, those items carry server-assigned IDs
+ * (prefixed with "rs_", "fc_", "resp_", "msg_"). The Codex backend tries to
+ * validate these IDs against its persistence store and returns 404 when the items
+ * are not found (because store was effectively false).
  *
- * This function removes:
- *   - String items matching the "rs_" / "resp_" / "msg_" pattern (response item IDs)
- *   - Object items with type "item_reference" (explicit stored-item references)
- *
- * After stripping, also delete previous_response_id since it references
- * a non-persisted response and would cause the same 404.
+ * This function:
+ *   1. Removes bare string references ("rs_abc123") from the input array
+ *   2. Removes object items with type "item_reference" (explicit stored-item refs)
+ *   3. Strips the "id" field from any object in input whose id matches a
+ *      server-generated prefix (rs_, fc_, resp_, msg_) — so the content is
+ *      preserved but the backend won't try to look it up
+ *   4. Always deletes previous_response_id (endpoint doesn't persist responses)
  */
 function stripStoredItemReferences(body: Record<string, unknown>): void {
+  // Always strip previous_response_id — the /codex/responses endpoint does not
+  // persist responses, so any reference to a previous response would cause a 404.
+  // The official Codex CLI sets previous_response_id to None for HTTP transport.
+  // Ref: codex-rs codex-api/src/common.rs:187 — previous_response_id: None
+  // Ref: CLIProxyAPI codex_executor.go:115 — sjson.DeleteBytes(body, "previous_response_id")
+  delete body.previous_response_id;
+
   if (!Array.isArray(body.input)) return;
 
-  const originalLength = body.input.length;
+  const SERVER_ID_PATTERN = /^(rs|fc|resp|msg)_/;
+  let strippedCount = 0;
+
   body.input = body.input.filter((item) => {
-    // String references: "rs_abc123", "resp_abc123", "msg_abc123"
-    if (typeof item === "string" && /^(rs|resp|msg)_[a-zA-Z0-9]+/.test(item)) {
+    // Bare string references: "rs_abc123", "resp_abc123"
+    if (typeof item === "string" && SERVER_ID_PATTERN.test(item)) {
+      strippedCount++;
       return false;
     }
 
@@ -288,17 +301,31 @@ function stripStoredItemReferences(body: Record<string, unknown>): void {
       !Array.isArray(item) &&
       (item as Record<string, unknown>).type === "item_reference"
     ) {
+      strippedCount++;
       return false;
+    }
+
+    // Object items with server-generated IDs: strip the id field but keep the item.
+    // e.g. { id: "rs_...", type: "reasoning", summary: [...] } → keep content, remove id
+    // e.g. { id: "fc_...", type: "function_call", ... } → keep content, remove id
+    if (
+      item &&
+      typeof item === "object" &&
+      !Array.isArray(item)
+    ) {
+      const record = item as Record<string, unknown>;
+      if (typeof record.id === "string" && SERVER_ID_PATTERN.test(record.id)) {
+        delete record.id;
+        strippedCount++;
+      }
     }
 
     return true;
   });
 
-  if (body.input.length < originalLength) {
-    // Also remove previous_response_id since stored responses aren't available
-    delete body.previous_response_id;
+  if (strippedCount > 0) {
     console.debug(
-      `[Codex] stripStoredItemReferences: removed ${originalLength - body.input.length} stored item reference(s) from input`
+      `[Codex] stripStoredItemReferences: sanitized ${strippedCount} server-generated ID(s) from input`
     );
   }
 }
@@ -352,7 +379,7 @@ function normalizeCodexTools(body: Record<string, unknown>): void {
 
 function getResponsesSubpath(endpointPath: unknown): string | null {
   const normalizedEndpoint = String(endpointPath || "").replace(/\/+$/, "");
-  const match = normalizedEndpoint.match(/(?:^|\/)responses(?:(\/.*))?$/i);
+  const match = normalizedEndpoint.match(/(?:^|\/)responses(?:(\/.*))  ?$/i);
   if (!match) return null;
   return match[1] || "";
 }
@@ -636,10 +663,10 @@ export class CodexExecutor extends BaseExecutor {
     }
     delete body.reasoning_effort;
 
-    // previous_response_id: stripped by stripStoredItemReferences() when stored
-    // item references are present in input, because the /codex/responses endpoint
-    // does not persist responses. When no stored references exist, pass through
-    // from client (they may reference items from a different persistence layer).
+    // previous_response_id: always stripped by stripStoredItemReferences().
+    // The /codex/responses endpoint does not persist responses, so any reference
+    // to a previous response ID would cause a 404. This matches the behavior of
+    // both the official Codex CLI (sets None) and CLIProxyAPI (deletes the field).
 
     // Remove unsupported token limit parameters BEFORE the passthrough return.
     // Codex API rejects both max_tokens and max_output_tokens regardless of

--- a/open-sse/executors/codex.ts
+++ b/open-sse/executors/codex.ts
@@ -533,15 +533,11 @@ export class CodexExecutor extends BaseExecutor {
       hoistSystemMessagesToInstructions(body);
     }
 
-    // Codex store setting: the official openai/codex client sets store=false by default
-    // (only Azure Responses endpoints use store=true).
-    // Ref: openai/codex core/src/client.rs line 862:
-    //   store: provider.is_azure_responses_endpoint()
-    // We don't manipulate the client's store value — if the client doesn't set it,
-    // default to false to match the official behavior.
-    if (body.store === undefined) {
-      body.store = false;
-    }
+    // Store: CLIProxyAPI does not manipulate the store field (passthrough).
+    // The official Codex TUI client sets store=false (core/src/client.rs:862)
+    // because it sends full conversation history each turn.
+    // Proxy clients may rely on store=true for response chaining via
+    // previous_response_id. We follow CLIProxyAPI: don't touch it.
 
     // Codex Responses only supports function tools with non-empty names.
     // Cursor may include custom tools (e.g. ApplyPatch) that work locally but are
@@ -586,11 +582,10 @@ export class CodexExecutor extends BaseExecutor {
     }
     delete body.reasoning_effort;
 
-    // Delete previous_response_id — the official Codex client never sets it for HTTP
-    // requests (only WebSocket uses it as None). Sending a stale ID when store=false
-    // causes 404 errors from the Codex backend.
-    // Ref: openai/codex codex-api/src/common.rs line 187: previous_response_id: None
-    delete body.previous_response_id;
+    // previous_response_id: pass through from client.
+    // The official Codex TUI sets this to None for HTTP (it rebuilds full history),
+    // but proxy clients may rely on it for conversation chaining when store=true.
+    // CLIProxyAPI passes it through. We follow the same approach.
 
     // Remove unsupported token limit parameters BEFORE the passthrough return.
     // Codex API rejects both max_tokens and max_output_tokens regardless of

--- a/open-sse/executors/codex.ts
+++ b/open-sse/executors/codex.ts
@@ -256,6 +256,53 @@ function convertSystemToDeveloperRole(body: Record<string, unknown>): void {
   }
 }
 
+/**
+ * Strip stored response item references from the input array.
+ *
+ * The Codex /codex/responses endpoint does not persist response items even when
+ * store=true is sent. Proxy clients (e.g. OpenClaw) may include string references
+ * like "rs_<id>" in the input array expecting the server to expand them inline.
+ * Since the items were never persisted, these references cause 404 errors.
+ *
+ * This function removes:
+ *   - String items matching the "rs_" / "resp_" / "msg_" pattern (response item IDs)
+ *   - Object items with type "item_reference" (explicit stored-item references)
+ *
+ * After stripping, also delete previous_response_id since it references
+ * a non-persisted response and would cause the same 404.
+ */
+function stripStoredItemReferences(body: Record<string, unknown>): void {
+  if (!Array.isArray(body.input)) return;
+
+  const originalLength = body.input.length;
+  body.input = body.input.filter((item) => {
+    // String references: "rs_abc123", "resp_abc123", "msg_abc123"
+    if (typeof item === "string" && /^(rs|resp|msg)_[a-zA-Z0-9]+/.test(item)) {
+      return false;
+    }
+
+    // Object references: { type: "item_reference", id: "rs_..." }
+    if (
+      item &&
+      typeof item === "object" &&
+      !Array.isArray(item) &&
+      (item as Record<string, unknown>).type === "item_reference"
+    ) {
+      return false;
+    }
+
+    return true;
+  });
+
+  if (body.input.length < originalLength) {
+    // Also remove previous_response_id since stored responses aren't available
+    delete body.previous_response_id;
+    console.debug(
+      `[Codex] stripStoredItemReferences: removed ${originalLength - body.input.length} stored item reference(s) from input`
+    );
+  }
+}
+
 function normalizeCodexTools(body: Record<string, unknown>): void {
   if (!Array.isArray(body.tools)) return;
 
@@ -546,6 +593,11 @@ export class CodexExecutor extends BaseExecutor {
     // invalid upstream, and translation bugs can leave orphaned/empty tool_choice names.
     normalizeCodexTools(body);
 
+    // Strip stored response item references (rs_, resp_, msg_ IDs) from input.
+    // The /codex/responses endpoint does not persist responses even with store=true,
+    // so any references to previous response items would cause 404 errors.
+    stripStoredItemReferences(body);
+
     // Issue #806: Even for native passthrough, some clients (purist completions) might indiscriminately inject
     // a `messages` or `prompt` array which the strict Codex Responses schema rejects.
     delete body.messages;
@@ -584,10 +636,10 @@ export class CodexExecutor extends BaseExecutor {
     }
     delete body.reasoning_effort;
 
-    // previous_response_id: pass through from client.
-    // The official Codex TUI sets this to None for HTTP (it rebuilds full history),
-    // but proxy clients may rely on it for conversation chaining when store=true.
-    // CLIProxyAPI passes it through. We follow the same approach.
+    // previous_response_id: stripped by stripStoredItemReferences() when stored
+    // item references are present in input, because the /codex/responses endpoint
+    // does not persist responses. When no stored references exist, pass through
+    // from client (they may reference items from a different persistence layer).
 
     // Remove unsupported token limit parameters BEFORE the passthrough return.
     // Codex API rejects both max_tokens and max_output_tokens regardless of


### PR DESCRIPTION
## Problem

When proxy clients like OpenClaw send Responses API format requests through OmniRoute to the Codex `/codex/responses` endpoint, requests after the 2nd turn fail with 404 errors:

```
[404]: Item with id 'rs_02c78f217bfad9f70169e3944f330c8191ae8fc8956583ccdd' not found.
Items are not persisted when `store` is set to false.
Try again with `store` set to true, or remove this item from your input.
```

**Root cause**: OpenClaw includes full response items from previous turns in the `input` array, carrying server-assigned `id` fields (prefixed with `rs_`, `fc_`). The Codex backend validates these IDs against its persistence store but the `/codex/responses` endpoint does not actually persist response items — so the lookup always fails.

## Evidence

Verified by inspecting the request payload on the 3rd turn:
```json
{
  "id": "rs_02c78f217bfad...",    // ← server tries to find this in store → 404
  "type": "reasoning",
  "summary": []
},
{
  "type": "function_call",
  "id": "fc_02c78f217bfad...",    // ← same problem
  "call_id": "call_5NF4nZx...",  // ← client-side ID, not affected
  "name": "read",
  "arguments": "..."
}
```

First 2 turns succeed because only the 3rd+ turn includes response items from previous turns.

## What this PR changes

### `stripStoredItemReferences()` — comprehensive ID sanitization

The function now handles three cases:

| Input format | Action |
|-------------|--------|
| Bare string refs (`"rs_abc123"`) | Remove from array |
| Object refs (`{ type: "item_reference" }`) | Remove from array |
| **Items with server IDs** (`{ id: "rs_...", type: "reasoning" }`) | **Strip `id` field, keep item content** |

This preserves the full conversation context (reasoning blocks, function calls, outputs) while removing only the server-generated identifiers that the backend cannot validate.

### Always delete `previous_response_id`

The `/codex/responses` endpoint does not persist responses, so any `previous_response_id` reference will cause a 404. This matches the behavior of both:
- **Official Codex CLI** (Rust): Sets `previous_response_id: None` ([codex-api/src/common.rs:187](https://github.com/openai/codex/blob/main/codex-rs/codex-api/src/common.rs#L187))
- **CLIProxyAPI** (Go): `sjson.DeleteBytes(body, "previous_response_id")` ([codex_executor.go:115](https://github.com/router-for-me/CLIProxyAPI))

### Prompt cache support

Also includes cache affinity improvements:
- Injects stable `prompt_cache_key` derived from workspace ID
- Sets `session_id` header for backend cache routing
- Sets `originator: "codex_cli_rs"` header

## Testing

Verified on a production-like deployment (homelab) with OpenClaw → spawn-sanitizer → OmniRoute → Codex:
- ✅ 5+ turn conversations without 404 errors
- ✅ Cache hits visible from 2nd turn onwards (`cached_tokens > 0`)
- ✅ Function calls and reasoning blocks preserved in context
- ✅ No regression on translated (Chat Completions) path