### PR TITLE
Makes text visible in dark-mode

### DIFF
--- a/src/app/(dashboard)/dashboard/combos/page.tsx
+++ b/src/app/(dashboard)/dashboard/combos/page.tsx
@@ -2742,7 +2742,7 @@ function ComboFormModal({ isOpen, combo, onClose, onSave, activeProviders }) {
                       value={builderProviderId}
                       onChange={handleBuilderProviderChange}
                       data-testid="combo-builder-provider"
-                      className="w-full text-xs py-2 px-2 rounded border border-black/10 dark:border-white/10 bg-transparent focus:border-primary focus:outline-none"
+                      className="w-full text-xs py-2 px-2 rounded border border-black/10 dark:border-white/10 bg-white dark:bg-bg-main text-text-main focus:border-primary focus:outline-none"
                     >
                       <option value="">
                         {builderLoading
@@ -2767,7 +2767,7 @@ function ComboFormModal({ isOpen, combo, onClose, onSave, activeProviders }) {
                       onChange={handleBuilderModelChange}
                       disabled={!selectedBuilderProvider}
                       data-testid="combo-builder-model"
-                      className="w-full text-xs py-2 px-2 rounded border border-black/10 dark:border-white/10 bg-transparent focus:border-primary focus:outline-none disabled:opacity-50"
+                      className="w-full text-xs py-2 px-2 rounded border border-black/10 dark:border-white/10 bg-white dark:bg-bg-main text-text-main focus:border-primary focus:outline-none disabled:opacity-50"
                     >
                       <option value="">
                         {selectedBuilderProvider
@@ -2792,7 +2792,7 @@ function ComboFormModal({ isOpen, combo, onClose, onSave, activeProviders }) {
                       onChange={handleBuilderConnectionChange}
                       disabled={!selectedBuilderModel}
                       data-testid="combo-builder-account"
-                      className="w-full text-xs py-2 px-2 rounded border border-black/10 dark:border-white/10 bg-transparent focus:border-primary focus:outline-none disabled:opacity-50"
+                      className="w-full text-xs py-2 px-2 rounded border border-black/10 dark:border-white/10 bg-white dark:bg-bg-main text-text-main focus:border-primary focus:outline-none disabled:opacity-50"
                     >
                       <option value={COMBO_BUILDER_AUTO_CONNECTION}>
                         {getI18nOrFallback(
@@ -2853,7 +2853,7 @@ function ComboFormModal({ isOpen, combo, onClose, onSave, activeProviders }) {
                     <select
                       value={builderComboRefName}
                       onChange={(e) => setBuilderComboRefName(e.target.value)}
-                      className="flex-1 text-xs py-2 px-2 rounded border border-black/10 dark:border-white/10 bg-transparent focus:border-primary focus:outline-none"
+                      className="flex-1 text-xs py-2 px-2 rounded border border-black/10 dark:border-white/10 bg-white dark:bg-bg-main text-text-main focus:border-primary focus:outline-none"
                     >
                       <option value="">
                         {getI18nOrFallback(


### PR DESCRIPTION
## Summary

- Text white on white in dark mode, can not see easily.

<img width="958" height="361" alt="Screenshot from 2026-04-19 13-49-42" src="https://github.com/user-attachments/assets/2d27eb3b-94c9-489d-9013-8595def95683" />


## Related Issues

- Closes N/A
- Related to visibility of text in dark mode

## Tests Added Or Updated

- UI change only

## Coverage Notes

- N/A.

## Reviewer Notes

- Dropdown text not visible in dark mode.
