### PR TITLE
preserve reasoning when translating chat to responses

### DIFF
--- a/open-sse/translator/request/openai-responses.ts
+++ b/open-sse/translator/request/openai-responses.ts
@@ -553,6 +553,14 @@ export function openaiToOpenAIResponsesRequest(
     result.max_output_tokens = root.max_tokens;
   }
   if (root.top_p !== undefined) result.top_p = root.top_p;
+  if (root.reasoning !== undefined) {
+    result.reasoning = root.reasoning;
+  } else if (root.reasoning_effort !== undefined) {
+    const effort = toString(root.reasoning_effort);
+    if (effort) {
+      result.reasoning = { effort };
+    }
+  }
   if (storeEnabled) {
     if (root[RESPONSES_STORE_MARKER] !== undefined) {
       result.store = root[RESPONSES_STORE_MARKER];

--- a/tests/unit/translator-openai-responses-req.test.ts
+++ b/tests/unit/translator-openai-responses-req.test.ts
@@ -279,6 +279,37 @@ test("Chat -> Responses preserves prompt_cache_key and session affinity fields",
   assert.equal(result.store, undefined);
 });
 
+test("Chat -> Responses preserves explicit reasoning objects", () => {
+  const result = openaiToOpenAIResponsesRequest(
+    "gpt-5.3-codex-spark",
+    {
+      messages: [{ role: "user", content: "Hello" }],
+      reasoning: { effort: "low" },
+    },
+    false,
+    null
+  );
+
+  assert.deepEqual(result.reasoning, { effort: "low" });
+  assert.equal(result.store, false);
+});
+
+test("Chat -> Responses maps reasoning_effort into Responses reasoning", () => {
+  const result = openaiToOpenAIResponsesRequest(
+    "gpt-5.3-codex-spark",
+    {
+      messages: [{ role: "user", content: "Hello" }],
+      reasoning_effort: "low",
+    },
+    false,
+    null
+  );
+
+  assert.deepEqual(result.reasoning, { effort: "low" });
+  assert.equal(result.reasoning_effort, undefined);
+  assert.equal(result.store, false);
+});
+
 test("Chat -> Responses filters orphan function_call_output items and leaves empty instructions when absent", () => {
   const result = openaiToOpenAIResponsesRequest(
     "gpt-4o",


### PR DESCRIPTION
## Summary

This change preserves explicit reasoning configuration when Chat Completions requests are translated into OpenAI Responses payloads.

## Root Cause

The `openai -> openai-responses` translator forwarded fields such as `max_tokens`, `top_p`, and session affinity values, but it dropped explicit `reasoning` and `reasoning_effort` settings. On Codex routes, that meant the request reached the executor without the caller's requested effort, so the executor fell back to the connection-level default (for example `xhigh`).

## What Changed

- preserve `reasoning` objects during Chat -> Responses translation
- map legacy `reasoning_effort` into Responses `reasoning.effort`
- add regression tests for both input shapes

## Impact

- fixes Codex and other Responses-based routes where explicit reasoning settings should take precedence over connection defaults
- does not change connection default behavior when the request does not provide explicit reasoning

## Validation

- `npx --yes tsx --test tests/unit/translator-openai-responses-req.test.ts`
- attempted `npx --yes tsx --test tests/unit/executor-codex.test.ts` but the local environment is missing `xxhash-wasm`, so that suite could not run in this worktree
