### PR TITLE
fix(skills): follow-up review refinements for AUTO scoring and Responses context

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -1198,7 +1198,11 @@ export async function handleChatCore({
       sourceFormat,
       targetFormat,
       backgroundReason,
-      messages: Array.isArray(body.messages) ? body.messages : undefined,
+      messages: Array.isArray(body.messages)
+        ? body.messages
+        : Array.isArray(body.input)
+          ? body.input
+          : undefined,
     });
 
     if (mergedTools.length > existingTools.length) {

--- a/src/lib/skills/injection.ts
+++ b/src/lib/skills/injection.ts
@@ -132,17 +132,21 @@ function buildContextText(options: InjectionOptions): string {
   return parts.filter(Boolean).join(" ");
 }
 
-function scoreAutoSkill(skill: Skill, options: InjectionOptions, contextText: string): number {
+function scoreAutoSkill(
+  skill: Skill,
+  options: InjectionOptions,
+  contextText: string,
+  contextTokens: Set<string>,
+  backgroundTokens: Set<string>
+): number {
   const name = skill.name.toLowerCase();
   const tags = (Array.isArray(skill.tags) ? skill.tags : []).map((tag) =>
     String(tag).toLowerCase()
   );
   const description = toLowerText(skill.description);
 
-  const contextTokens = extractTokens(contextText);
   const nameTokens = splitNameTokens(skill.name);
   const descriptionTokens = extractTokens(description);
-  const backgroundTokens = extractTokens(toLowerText(options.backgroundReason));
 
   let score = 0;
 
@@ -196,6 +200,8 @@ function scoreAutoSkill(skill: Skill, options: InjectionOptions, contextText: st
 
 export function injectSkills(options: InjectionOptions): unknown[] {
   const contextText = buildContextText(options);
+  const contextTokens = extractTokens(contextText);
+  const backgroundTokens = extractTokens(toLowerText(options.backgroundReason));
   const selectedSkills = skillRegistry.list(options.apiKeyId).filter((s) => {
     const mode = s.mode || (s.enabled ? "on" : "off");
     if (mode === "off") return false;
@@ -215,7 +221,7 @@ export function injectSkills(options: InjectionOptions): unknown[] {
   const autoSkills = autoCandidates
     .map((skill) => ({
       skill,
-      score: scoreAutoSkill(skill, options, contextText),
+      score: scoreAutoSkill(skill, options, contextText, contextTokens, backgroundTokens),
     }))
     .filter((entry) => entry.score >= AUTO_MIN_SCORE)
     .sort((a, b) => {

--- a/tests/integration/skills-pipeline.test.ts
+++ b/tests/integration/skills-pipeline.test.ts
@@ -51,6 +51,9 @@ async function registerSkill({
   handler,
   enabled = true,
   description = "Test skill",
+  mode,
+  tags,
+  installCount,
 }) {
   return skillRegistry.register({
     apiKeyId,
@@ -71,6 +74,9 @@ async function registerSkill({
     },
     handler,
     enabled,
+    mode,
+    tags,
+    installCount,
   });
 }
 
@@ -381,6 +387,65 @@ test("injectSkills() merges with existing tools without duplicating", async () =
   const names = tools.map((t) => t.function?.name || t.name);
   assert.ok(names.includes("calcRoute@1.0.0"));
   assert.ok(names.includes("preExistingTool"));
+});
+
+test("responses input context participates in AUTO skill injection", async () => {
+  await seedConnection("openai", { apiKey: "sk-openai-skills-responses-input" });
+  const apiKey = await seedApiKey();
+  await enableSkills();
+
+  await registerSkill({
+    apiKeyId: apiKey.id,
+    name: "issueSearch",
+    handler: "issue-search-handler",
+    description: "search github issues and pull requests",
+    mode: "auto",
+    tags: ["github", "issues", "search"],
+    installCount: 40,
+  });
+
+  await registerSkill({
+    apiKeyId: apiKey.id,
+    name: "calendarPlanner",
+    handler: "calendar-handler",
+    description: "manage meetings and calendars",
+    mode: "auto",
+    tags: ["calendar", "meeting"],
+    installCount: 100,
+  });
+
+  const fetchBodies = [];
+  globalThis.fetch = async (_url, init = {}) => {
+    fetchBodies.push(init.body ? JSON.parse(String(init.body)) : null);
+    return buildOpenAIResponse("AUTO skill selection via responses input");
+  };
+
+  const response = await handleChat(
+    buildRequest({
+      url: "http://localhost/v1/responses",
+      authKey: apiKey.key,
+      body: {
+        model: "openai/gpt-4o-mini",
+        stream: false,
+        input: [
+          {
+            role: "user",
+            content: [{ type: "input_text", text: "Please search github issues for flaky tests" }],
+          },
+        ],
+      },
+    })
+  );
+
+  assert.equal(response.status, 200);
+  assert.ok(Array.isArray(fetchBodies[0].tools));
+
+  const names = fetchBodies[0].tools
+    .map((tool) => tool?.function?.name)
+    .filter((name) => typeof name === "string");
+
+  assert.ok(names.includes("issueSearch@1.0.0"));
+  assert.ok(!names.includes("calendarPlanner@1.0.0"));
 });
 
 test("handleToolCallExecution() processes a tool call correctly", async () => {


### PR DESCRIPTION
## Summary
- Follow-up to #1411 (which was merged/closed) to include the two remaining review refinements that were discussed after merge.
- Optimize AUTO skill injection scoring by precomputing token sets once per request instead of recomputing for each candidate skill.
- Include Responses API `input` as fallback context for skill injection when `messages` is absent so AUTO matching still receives request context.

## Why
The previous feature merge addressed provider-aware skill UX and memory hardening, but code review highlighted two concrete improvements:
1. Remove repeated token extraction per candidate to reduce scoring overhead.
2. Preserve AUTO-injection behavior for Responses-style payloads that carry context in `input`.

This PR applies those refinements in a minimal, focused follow-up.

## Changes
- `src/lib/skills/injection.ts`
  - Precompute `contextTokens` and `backgroundTokens` once inside `injectSkills(...)`.
  - Pass token sets into `scoreAutoSkill(...)` to avoid repeated extraction work.
- `open-sse/handlers/chatCore.ts`
  - Skill injection context now uses:
    - `body.messages` when present,
    - otherwise `body.input` (array) as fallback.
- `tests/integration/skills-pipeline.test.ts`
  - Add integration coverage: **responses input context participates in AUTO skill injection**.
  - Extend test helper registration to support metadata needed by this scenario.

## Verification
Executed on this branch:
- `node --import tsx/esm --test tests/unit/skills-injection.test.ts` ✅
- `node --import tsx/esm --test tests/integration/skills-pipeline.test.ts` ✅
- `npm run typecheck:core` ✅
- `npm run build` ✅

Also verified by remote pre-push hook during branch push:
- `npm run test:unit` (3229 passing, 0 failing) ✅