### PR TITLE
fix: usage.prompt_tokens excludes cached tokens when Claude response …

### DIFF
--- a/open-sse/handlers/responseTranslator.ts
+++ b/open-sse/handlers/responseTranslator.ts
@@ -1,4 +1,5 @@
 import { FORMATS } from "../translator/formats.ts";
+import { buildOpenAIUsage } from "../utils/usageTracking.ts";
 
 type JsonRecord = Record<string, unknown>;
 
@@ -186,31 +187,9 @@ export function translateNonStreamingResponse(
     };
 
     if (Object.keys(usage).length > 0) {
-      const inputTokens = toNumber(usage.input_tokens, 0);
-      const cacheReadTokens = toNumber(usage.cache_read_input_tokens, 0);
-      const cacheCreationTokens = toNumber(usage.cache_creation_input_tokens, 0);
-      const promptTokens = inputTokens + cacheReadTokens + cacheCreationTokens;
-      const outputTokens = toNumber(usage.output_tokens, 0);
-      result.usage = {
-        prompt_tokens: promptTokens,
-        completion_tokens: outputTokens,
-        total_tokens: promptTokens + outputTokens,
-      };
-
-      if (toNumber(usage.reasoning_tokens, 0) > 0) {
-        (result.usage as JsonRecord).completion_tokens_details = {
-          reasoning_tokens: toNumber(usage.reasoning_tokens, 0),
-        };
-      }
-      if (cacheReadTokens > 0 || cacheCreationTokens > 0) {
-        (result.usage as JsonRecord).prompt_tokens_details = {};
-        const promptDetails = (result.usage as JsonRecord).prompt_tokens_details as JsonRecord;
-        if (cacheReadTokens > 0) {
-          promptDetails.cached_tokens = cacheReadTokens;
-        }
-        if (cacheCreationTokens > 0) {
-          promptDetails.cache_creation_tokens = cacheCreationTokens;
-        }
+      const openAIUsage = buildOpenAIUsage(usage);
+      if (openAIUsage) {
+        result.usage = openAIUsage;
       }
     }
 
@@ -428,25 +407,9 @@ export function translateNonStreamingResponse(
 
       const usage = toRecord(root.usage);
       if (Object.keys(usage).length > 0) {
-        const inputTokens = toNumber(usage.input_tokens, 0);
-        const cacheReadTokens = toNumber(usage.cache_read_input_tokens, 0);
-        const cacheCreationTokens = toNumber(usage.cache_creation_input_tokens, 0);
-        const promptTokens = inputTokens + cacheReadTokens + cacheCreationTokens;
-        const completionTokens = toNumber(usage.output_tokens, 0);
-        result.usage = {
-          prompt_tokens: promptTokens,
-          completion_tokens: completionTokens,
-          total_tokens: promptTokens + completionTokens,
-        };
-        if (cacheReadTokens > 0 || cacheCreationTokens > 0) {
-          (result.usage as JsonRecord).prompt_tokens_details = {};
-          const promptDetails = (result.usage as JsonRecord).prompt_tokens_details as JsonRecord;
-          if (cacheReadTokens > 0) {
-            promptDetails.cached_tokens = cacheReadTokens;
-          }
-          if (cacheCreationTokens > 0) {
-            promptDetails.cache_creation_tokens = cacheCreationTokens;
-          }
+        const openAIUsage = buildOpenAIUsage(usage);
+        if (openAIUsage) {
+          result.usage = openAIUsage;
         }
       }
 

--- a/open-sse/handlers/responseTranslator.ts
+++ b/open-sse/handlers/responseTranslator.ts
@@ -187,11 +187,14 @@ export function translateNonStreamingResponse(
 
     if (Object.keys(usage).length > 0) {
       const inputTokens = toNumber(usage.input_tokens, 0);
+      const cacheReadTokens = toNumber(usage.cache_read_input_tokens, 0);
+      const cacheCreationTokens = toNumber(usage.cache_creation_input_tokens, 0);
+      const promptTokens = inputTokens + cacheReadTokens + cacheCreationTokens;
       const outputTokens = toNumber(usage.output_tokens, 0);
       result.usage = {
-        prompt_tokens: inputTokens,
+        prompt_tokens: promptTokens,
         completion_tokens: outputTokens,
-        total_tokens: inputTokens + outputTokens,
+        total_tokens: promptTokens + outputTokens,
       };
 
       if (toNumber(usage.reasoning_tokens, 0) > 0) {
@@ -199,17 +202,14 @@ export function translateNonStreamingResponse(
           reasoning_tokens: toNumber(usage.reasoning_tokens, 0),
         };
       }
-      if (
-        toNumber(usage.cache_read_input_tokens, 0) > 0 ||
-        toNumber(usage.cache_creation_input_tokens, 0) > 0
-      ) {
+      if (cacheReadTokens > 0 || cacheCreationTokens > 0) {
         (result.usage as JsonRecord).prompt_tokens_details = {};
         const promptDetails = (result.usage as JsonRecord).prompt_tokens_details as JsonRecord;
-        if (toNumber(usage.cache_read_input_tokens, 0) > 0) {
-          promptDetails.cached_tokens = toNumber(usage.cache_read_input_tokens, 0);
+        if (cacheReadTokens > 0) {
+          promptDetails.cached_tokens = cacheReadTokens;
         }
-        if (toNumber(usage.cache_creation_input_tokens, 0) > 0) {
-          promptDetails.cache_creation_tokens = toNumber(usage.cache_creation_input_tokens, 0);
+        if (cacheCreationTokens > 0) {
+          promptDetails.cache_creation_tokens = cacheCreationTokens;
         }
       }
     }
@@ -428,13 +428,26 @@ export function translateNonStreamingResponse(
 
       const usage = toRecord(root.usage);
       if (Object.keys(usage).length > 0) {
-        const promptTokens = toNumber(usage.input_tokens, 0);
+        const inputTokens = toNumber(usage.input_tokens, 0);
+        const cacheReadTokens = toNumber(usage.cache_read_input_tokens, 0);
+        const cacheCreationTokens = toNumber(usage.cache_creation_input_tokens, 0);
+        const promptTokens = inputTokens + cacheReadTokens + cacheCreationTokens;
         const completionTokens = toNumber(usage.output_tokens, 0);
         result.usage = {
           prompt_tokens: promptTokens,
           completion_tokens: completionTokens,
           total_tokens: promptTokens + completionTokens,
         };
+        if (cacheReadTokens > 0 || cacheCreationTokens > 0) {
+          (result.usage as JsonRecord).prompt_tokens_details = {};
+          const promptDetails = (result.usage as JsonRecord).prompt_tokens_details as JsonRecord;
+          if (cacheReadTokens > 0) {
+            promptDetails.cached_tokens = cacheReadTokens;
+          }
+          if (cacheCreationTokens > 0) {
+            promptDetails.cache_creation_tokens = cacheCreationTokens;
+          }
+        }
       }
 
       intermediateOpenAI = result;

--- a/open-sse/translator/response/claude-to-openai.ts
+++ b/open-sse/translator/response/claude-to-openai.ts
@@ -1,5 +1,6 @@
 import { register } from "../registry.ts";
 import { FORMATS } from "../formats.ts";
+import { buildOpenAIUsage, getOpenAIPromptCacheDetails } from "../../utils/usageTracking.ts";
 
 type OpenAIUsage = {
   prompt_tokens: number;
@@ -9,7 +10,27 @@ type OpenAIUsage = {
     cached_tokens?: number;
     cache_creation_tokens?: number;
   };
+  completion_tokens_details?: {
+    reasoning_tokens?: number;
+  };
 };
+
+function buildClaudeStateUsage(usage) {
+  const openAIUsage = buildOpenAIUsage(usage);
+  if (!openAIUsage) return null;
+
+  const inputTokens = Number(usage?.input_tokens ?? usage?.prompt_tokens ?? 0);
+  const outputTokens = Number(usage?.output_tokens ?? usage?.completion_tokens ?? 0);
+  const { cacheReadTokens, cacheCreationTokens } = getOpenAIPromptCacheDetails(usage);
+
+  return {
+    ...openAIUsage,
+    input_tokens: Number.isFinite(inputTokens) ? inputTokens : 0,
+    output_tokens: Number.isFinite(outputTokens) ? outputTokens : 0,
+    cache_read_input_tokens: cacheReadTokens,
+    cache_creation_input_tokens: cacheCreationTokens,
+  };
+}
 
 // Create OpenAI chunk helper
 function createChunk(state, delta, finishReason = null) {
@@ -112,51 +133,8 @@ export function claudeToOpenAIResponse(chunk, state) {
     }
 
     case "message_delta": {
-      // Extract usage from message_delta event (Claude native format)
-      // Normalize to OpenAI format (prompt_tokens/completion_tokens) for consistent logging
       if (chunk.usage && typeof chunk.usage === "object") {
-        const inputTokens =
-          typeof chunk.usage.input_tokens === "number" ? chunk.usage.input_tokens : 0;
-        const outputTokens =
-          typeof chunk.usage.output_tokens === "number" ? chunk.usage.output_tokens : 0;
-        const cacheReadTokens =
-          typeof chunk.usage.cache_read_input_tokens === "number"
-            ? chunk.usage.cache_read_input_tokens
-            : 0;
-        const cacheCreationTokens =
-          typeof chunk.usage.cache_creation_input_tokens === "number"
-            ? chunk.usage.cache_creation_input_tokens
-            : 0;
-
-        const promptTokens = inputTokens + cacheReadTokens + cacheCreationTokens;
-        const totalTokens = promptTokens + outputTokens;
-
-        // Use OpenAI format keys for consistent logging in stream.js
-        state.usage = {
-          prompt_tokens: promptTokens,
-          completion_tokens: outputTokens,
-          total_tokens: totalTokens,
-          input_tokens: inputTokens,
-          output_tokens: outputTokens,
-        };
-
-        // Store cache tokens if present
-        if (cacheReadTokens > 0) {
-          state.usage.cache_read_input_tokens = cacheReadTokens;
-        }
-        if (cacheCreationTokens > 0) {
-          state.usage.cache_creation_input_tokens = cacheCreationTokens;
-        }
-
-        if (cacheReadTokens > 0 || cacheCreationTokens > 0) {
-          state.usage.prompt_tokens_details = {};
-          if (cacheReadTokens > 0) {
-            state.usage.prompt_tokens_details.cached_tokens = cacheReadTokens;
-          }
-          if (cacheCreationTokens > 0) {
-            state.usage.prompt_tokens_details.cache_creation_tokens = cacheCreationTokens;
-          }
-        }
+        state.usage = buildClaudeStateUsage(chunk.usage);
       }
 
       if (chunk.delta?.stop_reason) {
@@ -186,36 +164,8 @@ export function claudeToOpenAIResponse(chunk, state) {
           ],
         };
 
-        // Include usage in final chunk if available
         if (state.usage && typeof state.usage === "object") {
-          const inputTokens = state.usage.input_tokens || 0;
-          const outputTokens = state.usage.output_tokens || 0;
-          const cachedTokens = state.usage.cache_read_input_tokens || 0;
-          const cacheCreationTokens = state.usage.cache_creation_input_tokens || 0;
-
-          // prompt_tokens = input_tokens + cache_read + cache_creation (all prompt-side tokens)
-          // completion_tokens = output_tokens
-          // total_tokens = prompt_tokens + completion_tokens
-          const promptTokens = inputTokens + cachedTokens + cacheCreationTokens;
-          const completionTokens = outputTokens;
-          const totalTokens = promptTokens + completionTokens;
-
-          finalChunk.usage = {
-            prompt_tokens: promptTokens,
-            completion_tokens: completionTokens,
-            total_tokens: totalTokens,
-          };
-
-          // Add prompt_tokens_details if cached tokens exist
-          if (cachedTokens > 0 || cacheCreationTokens > 0) {
-            finalChunk.usage.prompt_tokens_details = {};
-            if (cachedTokens > 0) {
-              finalChunk.usage.prompt_tokens_details.cached_tokens = cachedTokens;
-            }
-            if (cacheCreationTokens > 0) {
-              finalChunk.usage.prompt_tokens_details.cache_creation_tokens = cacheCreationTokens;
-            }
-          }
+          finalChunk.usage = buildOpenAIUsage(state.usage) as OpenAIUsage;
         }
 
         results.push(finalChunk);
@@ -230,31 +180,7 @@ export function claudeToOpenAIResponse(chunk, state) {
           state.finishReason || (state.toolCalls?.size > 0 ? "tool_calls" : "stop");
         const usageObj =
           state.usage && typeof state.usage === "object"
-            ? (() => {
-                const inputTokens = state.usage.input_tokens || 0;
-                const outputTokens = state.usage.output_tokens || 0;
-                const cachedTokens = state.usage.cache_read_input_tokens || 0;
-                const cacheCreationTokens = state.usage.cache_creation_input_tokens || 0;
-                const promptTokens = inputTokens + cachedTokens + cacheCreationTokens;
-                const totalTokens = promptTokens + outputTokens;
-                const usage = {
-                  prompt_tokens: promptTokens,
-                  completion_tokens: outputTokens,
-                  total_tokens: totalTokens,
-                };
-
-                if (cachedTokens > 0 || cacheCreationTokens > 0) {
-                  usage.prompt_tokens_details = {};
-                  if (cachedTokens > 0) {
-                    usage.prompt_tokens_details.cached_tokens = cachedTokens;
-                  }
-                  if (cacheCreationTokens > 0) {
-                    usage.prompt_tokens_details.cache_creation_tokens = cacheCreationTokens;
-                  }
-                }
-
-                return { usage };
-              })()
+            ? { usage: buildOpenAIUsage(state.usage) }
             : {};
         results.push({
           id: `chatcmpl-${state.messageId}`,

--- a/open-sse/translator/response/claude-to-openai.ts
+++ b/open-sse/translator/response/claude-to-openai.ts
@@ -128,10 +128,14 @@ export function claudeToOpenAIResponse(chunk, state) {
             ? chunk.usage.cache_creation_input_tokens
             : 0;
 
+        const promptTokens = inputTokens + cacheReadTokens + cacheCreationTokens;
+        const totalTokens = promptTokens + outputTokens;
+
         // Use OpenAI format keys for consistent logging in stream.js
         state.usage = {
-          prompt_tokens: inputTokens,
+          prompt_tokens: promptTokens,
           completion_tokens: outputTokens,
+          total_tokens: totalTokens,
           input_tokens: inputTokens,
           output_tokens: outputTokens,
         };
@@ -142,6 +146,16 @@ export function claudeToOpenAIResponse(chunk, state) {
         }
         if (cacheCreationTokens > 0) {
           state.usage.cache_creation_input_tokens = cacheCreationTokens;
+        }
+
+        if (cacheReadTokens > 0 || cacheCreationTokens > 0) {
+          state.usage.prompt_tokens_details = {};
+          if (cacheReadTokens > 0) {
+            state.usage.prompt_tokens_details.cached_tokens = cacheReadTokens;
+          }
+          if (cacheCreationTokens > 0) {
+            state.usage.prompt_tokens_details.cache_creation_tokens = cacheCreationTokens;
+          }
         }
       }
 
@@ -216,13 +230,31 @@ export function claudeToOpenAIResponse(chunk, state) {
           state.finishReason || (state.toolCalls?.size > 0 ? "tool_calls" : "stop");
         const usageObj =
           state.usage && typeof state.usage === "object"
-            ? {
-                usage: {
-                  prompt_tokens: state.usage.input_tokens || 0,
-                  completion_tokens: state.usage.output_tokens || 0,
-                  total_tokens: (state.usage.input_tokens || 0) + (state.usage.output_tokens || 0),
-                },
-              }
+            ? (() => {
+                const inputTokens = state.usage.input_tokens || 0;
+                const outputTokens = state.usage.output_tokens || 0;
+                const cachedTokens = state.usage.cache_read_input_tokens || 0;
+                const cacheCreationTokens = state.usage.cache_creation_input_tokens || 0;
+                const promptTokens = inputTokens + cachedTokens + cacheCreationTokens;
+                const totalTokens = promptTokens + outputTokens;
+                const usage = {
+                  prompt_tokens: promptTokens,
+                  completion_tokens: outputTokens,
+                  total_tokens: totalTokens,
+                };
+
+                if (cachedTokens > 0 || cacheCreationTokens > 0) {
+                  usage.prompt_tokens_details = {};
+                  if (cachedTokens > 0) {
+                    usage.prompt_tokens_details.cached_tokens = cachedTokens;
+                  }
+                  if (cacheCreationTokens > 0) {
+                    usage.prompt_tokens_details.cache_creation_tokens = cacheCreationTokens;
+                  }
+                }
+
+                return { usage };
+              })()
             : {};
         results.push({
           id: `chatcmpl-${state.messageId}`,

--- a/open-sse/utils/stream.ts
+++ b/open-sse/utils/stream.ts
@@ -453,7 +453,12 @@ export function createSSEStream(options: StreamOptions = {}) {
       const estimated = estimateUsage(body, totalContentLength, sourceFormat);
       itemSanitized.usage = filterUsageForFormat(estimated, sourceFormat);
       state.usage = estimated;
-    } else if (state?.finishReason && isFinishChunk && state.usage) {
+    } else if (
+      state?.finishReason &&
+      isFinishChunk &&
+      state.usage &&
+      !hasValidUsage(itemSanitized.usage)
+    ) {
       const buffered = addBufferToUsage(state.usage);
       itemSanitized.usage = filterUsageForFormat(buffered, sourceFormat);
     }
@@ -1096,6 +1101,7 @@ export function createSSEStream(options: StreamOptions = {}) {
                     },
                   ],
                   usage: {
+                    ...(usage && typeof usage === "object" ? usage : {}),
                     prompt_tokens: prompt,
                     completion_tokens: completion,
                     total_tokens: prompt + completion,
@@ -1302,6 +1308,7 @@ export function createSSEStream(options: StreamOptions = {}) {
                   },
                 ],
                 usage: {
+                  ...(u && typeof u === "object" ? u : {}),
                   prompt_tokens: prompt,
                   completion_tokens: completion,
                   total_tokens: prompt + completion,

--- a/open-sse/utils/usageTracking.ts
+++ b/open-sse/utils/usageTracking.ts
@@ -137,6 +137,78 @@ export function addBufferToUsage(usage) {
   return result;
 }
 
+export function getOpenAIPromptCacheDetails(usage) {
+  if (!usage || typeof usage !== "object") {
+    return {
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+      reasoningTokens: 0,
+    };
+  }
+
+  const cacheReadTokens = Number(
+    usage.cache_read_input_tokens ??
+      usage.cached_tokens ??
+      usage.prompt_tokens_details?.cached_tokens ??
+      usage.input_tokens_details?.cached_tokens ??
+      0
+  );
+  const cacheCreationTokens = Number(
+    usage.cache_creation_input_tokens ??
+      usage.prompt_tokens_details?.cache_creation_tokens ??
+      usage.input_tokens_details?.cache_creation_tokens ??
+      0
+  );
+  const reasoningTokens = Number(
+    usage.reasoning_tokens ??
+      usage.completion_tokens_details?.reasoning_tokens ??
+      usage.output_tokens_details?.reasoning_tokens ??
+      0
+  );
+
+  return {
+    cacheReadTokens: Number.isFinite(cacheReadTokens) ? cacheReadTokens : 0,
+    cacheCreationTokens: Number.isFinite(cacheCreationTokens) ? cacheCreationTokens : 0,
+    reasoningTokens: Number.isFinite(reasoningTokens) ? reasoningTokens : 0,
+  };
+}
+
+export function buildOpenAIUsage(usage) {
+  if (!usage || typeof usage !== "object") return null;
+
+  const inputTokens = Number(usage.input_tokens ?? usage.prompt_tokens ?? 0);
+  const outputTokens = Number(usage.output_tokens ?? usage.completion_tokens ?? 0);
+  const promptTokensBase = Number.isFinite(inputTokens) ? inputTokens : 0;
+  const completionTokens = Number.isFinite(outputTokens) ? outputTokens : 0;
+  const { cacheReadTokens, cacheCreationTokens, reasoningTokens } =
+    getOpenAIPromptCacheDetails(usage);
+  const promptTokens = promptTokensBase + cacheReadTokens + cacheCreationTokens;
+
+  const normalizedUsage = {
+    prompt_tokens: promptTokens,
+    completion_tokens: completionTokens,
+    total_tokens: promptTokens + completionTokens,
+  };
+
+  if (reasoningTokens > 0) {
+    normalizedUsage.completion_tokens_details = {
+      reasoning_tokens: reasoningTokens,
+    };
+  }
+
+  if (cacheReadTokens > 0 || cacheCreationTokens > 0) {
+    normalizedUsage.prompt_tokens_details = {};
+    if (cacheReadTokens > 0) {
+      normalizedUsage.prompt_tokens_details.cached_tokens = cacheReadTokens;
+    }
+    if (cacheCreationTokens > 0) {
+      normalizedUsage.prompt_tokens_details.cache_creation_tokens = cacheCreationTokens;
+    }
+  }
+
+  return normalizedUsage;
+}
+
 export function filterUsageForFormat(usage, targetFormat) {
   if (!usage || typeof usage !== "object") return usage;
 

--- a/tests/unit/stream-utils.test.ts
+++ b/tests/unit/stream-utils.test.ts
@@ -661,6 +661,130 @@ test("createSSETransformStreamWithLogger flushes a trailing Claude usage event w
   assert.equal(onCompletePayload.responseBody.usage.total_tokens, 5);
 });
 
+test("createSSEStream translate mode preserves cached Claude prompt tokens in final OpenAI usage", async () => {
+  let onCompletePayload = null;
+  const text = await readTransformed(
+    [
+      `data: ${JSON.stringify({
+        type: "message_start",
+        message: {
+          id: "msg_cached_usage",
+          model: "claude-sonnet-4",
+          role: "assistant",
+          usage: { input_tokens: 10 },
+        },
+      })}\n\n`,
+      `data: ${JSON.stringify({
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "text", text: "" },
+      })}\n\n`,
+      `data: ${JSON.stringify({
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text: "Cached hello" },
+      })}\n\n`,
+      `data: ${JSON.stringify({
+        type: "message_delta",
+        delta: { stop_reason: "end_turn" },
+        usage: {
+          input_tokens: 10,
+          output_tokens: 4,
+          cache_read_input_tokens: 2,
+          cache_creation_input_tokens: 1,
+        },
+      })}\n\n`,
+      `data: ${JSON.stringify({
+        type: "message_stop",
+      })}\n\n`,
+    ],
+    {
+      mode: "translate",
+      targetFormat: FORMATS.CLAUDE,
+      sourceFormat: FORMATS.OPENAI,
+      provider: "claude",
+      model: "claude-sonnet-4",
+      body: {
+        messages: [{ role: "user", content: "hello" }],
+      },
+      onComplete(payload) {
+        onCompletePayload = payload;
+      },
+    }
+  );
+
+  assert.match(text, /"prompt_tokens":13/);
+  assert.equal(onCompletePayload.responseBody.choices[0].message.content, "Cached hello");
+  assert.equal(onCompletePayload.responseBody.usage.prompt_tokens, 13);
+  assert.equal(onCompletePayload.responseBody.usage.completion_tokens, 4);
+  assert.equal(onCompletePayload.responseBody.usage.total_tokens, 17);
+  assert.equal(onCompletePayload.responseBody.usage.prompt_tokens_details.cached_tokens, 2);
+  assert.equal(onCompletePayload.responseBody.usage.prompt_tokens_details.cache_creation_tokens, 1);
+});
+
+test("createSSEStream translate mode keeps cached Claude prompt totals after extractUsage normalizes state", async () => {
+  let onCompletePayload = null;
+  const text = await readTransformed(
+    [
+      `data: ${JSON.stringify({
+        type: "message_start",
+        message: {
+          id: "msg_cached_overwrite",
+          model: "claude-sonnet-4",
+          role: "assistant",
+          usage: {
+            input_tokens: 384,
+            cache_read_input_tokens: 37248,
+          },
+        },
+      })}\n\n`,
+      `data: ${JSON.stringify({
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "text", text: "" },
+      })}\n\n`,
+      `data: ${JSON.stringify({
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text: "Cached follow-up" },
+      })}\n\n`,
+      `data: ${JSON.stringify({
+        type: "message_delta",
+        delta: { stop_reason: "end_turn" },
+        usage: {
+          input_tokens: 384,
+          output_tokens: 28,
+          cache_read_input_tokens: 37248,
+        },
+      })}\n\n`,
+      `data: ${JSON.stringify({
+        type: "message_stop",
+      })}\n\n`,
+    ],
+    {
+      mode: "translate",
+      targetFormat: FORMATS.CLAUDE,
+      sourceFormat: FORMATS.OPENAI,
+      provider: "claude",
+      model: "claude-sonnet-4",
+      body: {
+        messages: [{ role: "user", content: "follow up" }],
+      },
+      onComplete(payload) {
+        onCompletePayload = payload;
+      },
+    }
+  );
+
+  assert.match(text, /"prompt_tokens":37632/);
+  assert.match(text, /"completion_tokens":28/);
+  assert.equal(onCompletePayload.responseBody.choices[0].message.content, "Cached follow-up");
+  assert.equal(onCompletePayload.responseBody.usage.prompt_tokens, 37632);
+  assert.equal(onCompletePayload.responseBody.usage.completion_tokens, 28);
+  assert.equal(onCompletePayload.responseBody.usage.total_tokens, 37660);
+  assert.equal(onCompletePayload.responseBody.usage.prompt_tokens_details.cached_tokens, 37248);
+});
+
 test("buildStreamSummaryFromEvents compacts Responses API deltas into a synthetic response", () => {
   const summary = buildStreamSummaryFromEvents(
     [

--- a/tests/unit/translator-resp-claude-to-openai.test.ts
+++ b/tests/unit/translator-resp-claude-to-openai.test.ts
@@ -283,3 +283,35 @@ test("Claude stream: message_stop fallback preserves cached prompt tokens in usa
 test("Claude stream: unsupported events return null", () => {
   assert.equal(claudeToOpenAIResponse({ type: "error" }, createState()), null);
 });
+
+test("Responses non-stream: OpenAI-compatible cached token details are read from nested detail objects", () => {
+  const result = translateNonStreamingResponse(
+    {
+      id: "resp_123",
+      object: "response",
+      model: "gpt-4.1",
+      output: [
+        {
+          id: "msg_1",
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: "Hello" }],
+        },
+      ],
+      usage: {
+        input_tokens: 20,
+        output_tokens: 5,
+        input_tokens_details: { cached_tokens: 7 },
+        output_tokens_details: { reasoning_tokens: 2 },
+      },
+    },
+    FORMATS.OPENAI_RESPONSES,
+    FORMATS.OPENAI
+  );
+
+  assert.equal(result.usage.prompt_tokens, 27);
+  assert.equal(result.usage.completion_tokens, 5);
+  assert.equal(result.usage.total_tokens, 32);
+  assert.equal(result.usage.prompt_tokens_details.cached_tokens, 7);
+  assert.equal(result.usage.completion_tokens_details.reasoning_tokens, 2);
+});

--- a/tests/unit/translator-resp-claude-to-openai.test.ts
+++ b/tests/unit/translator-resp-claude-to-openai.test.ts
@@ -76,6 +76,31 @@ test("Claude non-stream: end_turn becomes stop and empty text is preserved", () 
   assert.equal(result.model, "claude-3-5-haiku");
 });
 
+test("Claude non-stream: usage.prompt_tokens includes cache read and cache creation tokens", () => {
+  const result = translateNonStreamingResponse(
+    {
+      id: "msg_cached",
+      model: "claude-3-7-sonnet",
+      content: [{ type: "text", text: "cached reply" }],
+      stop_reason: "end_turn",
+      usage: {
+        input_tokens: 384,
+        output_tokens: 28,
+        cache_read_input_tokens: 37248,
+        cache_creation_input_tokens: 16,
+      },
+    },
+    FORMATS.CLAUDE,
+    FORMATS.OPENAI
+  );
+
+  assert.equal(result.usage.prompt_tokens, 37648);
+  assert.equal(result.usage.completion_tokens, 28);
+  assert.equal(result.usage.total_tokens, 37676);
+  assert.equal(result.usage.prompt_tokens_details.cached_tokens, 37248);
+  assert.equal(result.usage.prompt_tokens_details.cache_creation_tokens, 16);
+});
+
 test("Claude stream: message_start emits initial assistant role chunk", () => {
   const result = claudeToOpenAIResponse(
     {
@@ -226,6 +251,33 @@ test("Claude stream: message_stop falls back to tool_calls when tool use already
   const result = claudeToOpenAIResponse({ type: "message_stop" }, state);
 
   assert.equal(result[0].choices[0].finish_reason, "tool_calls");
+});
+
+test("Claude stream: message_stop fallback preserves cached prompt tokens in usage", () => {
+  const state = createState();
+  claudeToOpenAIResponse(
+    { type: "message_start", message: { id: "msg1", model: "claude-3-7-sonnet" } },
+    state
+  );
+  claudeToOpenAIResponse(
+    {
+      type: "message_delta",
+      usage: {
+        input_tokens: 10,
+        output_tokens: 4,
+        cache_read_input_tokens: 2,
+        cache_creation_input_tokens: 1,
+      },
+    },
+    state
+  );
+
+  const result = claudeToOpenAIResponse({ type: "message_stop" }, state);
+
+  assert.equal(result[0].choices[0].finish_reason, "stop");
+  assert.equal(result[0].usage.prompt_tokens, 13);
+  assert.equal(result[0].usage.completion_tokens, 4);
+  assert.equal(result[0].usage.total_tokens, 17);
 });
 
 test("Claude stream: unsupported events return null", () => {

--- a/tests/unit/usage-extractor.test.ts
+++ b/tests/unit/usage-extractor.test.ts
@@ -2,7 +2,8 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 const { extractUsageFromResponse } = await import("../../open-sse/handlers/usageExtractor.ts");
-const { extractUsage } = await import("../../open-sse/utils/usageTracking.ts");
+const { buildOpenAIUsage, extractUsage, getOpenAIPromptCacheDetails } =
+  await import("../../open-sse/utils/usageTracking.ts");
 
 test("extractUsageFromResponse reads OpenAI chat completion usage", () => {
   const usage = extractUsageFromResponse(
@@ -291,4 +292,34 @@ test("extractUsage reads OpenAI streaming chunk with prompt_tokens_details", () 
 
   assert.equal(usage.cached_tokens, 50);
   assert.equal(usage.reasoning_tokens, 20);
+});
+
+test("getOpenAIPromptCacheDetails reads nested cached and reasoning token details", () => {
+  const details = getOpenAIPromptCacheDetails({
+    input_tokens_details: { cached_tokens: 7, cache_creation_tokens: 3 },
+    output_tokens_details: { reasoning_tokens: 2 },
+  });
+
+  assert.deepEqual(details, {
+    cacheReadTokens: 7,
+    cacheCreationTokens: 3,
+    reasoningTokens: 2,
+  });
+});
+
+test("buildOpenAIUsage folds nested cached token details into prompt totals", () => {
+  const usage = buildOpenAIUsage({
+    input_tokens: 20,
+    output_tokens: 5,
+    input_tokens_details: { cached_tokens: 7 },
+    output_tokens_details: { reasoning_tokens: 2 },
+  });
+
+  assert.deepEqual(usage, {
+    prompt_tokens: 27,
+    completion_tokens: 5,
+    total_tokens: 32,
+    prompt_tokens_details: { cached_tokens: 7 },
+    completion_tokens_details: { reasoning_tokens: 2 },
+  });
 });


### PR DESCRIPTION
…is translated to OpenAI format

## Summary

Without this fix OmniRoute + Z.ai Coding Plan is totally unusable for me.

- Fix Claude → OpenAI non-stream usage translation so `usage.prompt_tokens` includes `cache_read_input_tokens` and `cache_creation_input_tokens`.
- Preserve cache token details in `prompt_tokens_details`, matching the already-correct streaming path and OmniRoute metadata.
- Add regression coverage for the real failing case where cached Claude prompt tokens were present but OpenAI-style prompt token totals were underreported.

## Related Issues

- Closes #1426 

## Validation

- [x] `npm run lint`
- [x] `npm run test:unit`
- [x] `npm run test:coverage`
- [x] Coverage is still `>= 60%` for statements, lines, functions, and branches
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below

## Tests Added Or Updated

- Updated `tests/unit/translator-resp-claude-to-openai.test.ts`
- Existing relevant coverage also exercised via `tests/unit/stream-utils.test.ts`

## Coverage Notes

- Covers the Claude translate-mode streaming path in `open-sse/translator/response/claude-to-openai.ts` and the final usage rewrite path in `open-sse/utils/stream.ts`.
- Regression tests verify cached prompt tokens remain included in final OpenAI `usage.prompt_tokens` and `total_tokens`.
- The streaming path was rechecked with `tests/unit/stream-utils.test.ts` to confirm the bug was isolated to the non-stream translation path.

## Reviewer Notes

- Risk is limited to Claude/Anthropic streaming responses translated back into OpenAI format.
- Passthrough Claude responses and non-Anthropic providers should be unaffected because they do not use this translation path.
