### PR TITLE
feat: add Qwen Code CLI tool with dedicated settings route and deprecate OAuth provider

### DIFF
--- a/open-sse/translator/request/openai-responses.ts
+++ b/open-sse/translator/request/openai-responses.ts
@@ -553,6 +553,14 @@ export function openaiToOpenAIResponsesRequest(
     result.max_output_tokens = root.max_tokens;
   }
   if (root.top_p !== undefined) result.top_p = root.top_p;
+  if (root.reasoning !== undefined) {
+    result.reasoning = root.reasoning;
+  } else if (root.reasoning_effort !== undefined) {
+    const effort = toString(root.reasoning_effort);
+    if (effort) {
+      result.reasoning = { effort };
+    }
+  }
   if (storeEnabled) {
     if (root[RESPONSES_STORE_MARKER] !== undefined) {
       result.store = root[RESPONSES_STORE_MARKER];

--- a/src/app/api/cli-tools/backups/route.ts
+++ b/src/app/api/cli-tools/backups/route.ts
@@ -6,7 +6,7 @@ import { ensureCliConfigWriteAllowed } from "@/shared/services/cliRuntime";
 import { cliBackupMutationSchema } from "@/shared/validation/schemas";
 import { isValidationFailure, validateBody } from "@/shared/validation/helpers";
 
-const VALID_TOOLS = ["claude", "codex", "droid", "openclaw", "cline", "kilo"];
+const VALID_TOOLS = ["claude", "codex", "droid", "openclaw", "cline", "kilo", "qwen"];
 
 // GET /api/cli-tools/backups?tool=claude — list backups
 export async function GET(request) {

--- a/src/app/api/cli-tools/guide-settings/[toolId]/route.ts
+++ b/src/app/api/cli-tools/guide-settings/[toolId]/route.ts
@@ -45,8 +45,6 @@ export async function POST(request, { params }) {
         // (#524) OpenCode config was never saved because only 'continue' was handled here.
         // opencode reads ~/.config/opencode/config.toml — write the OmniRoute settings there.
         return await saveOpenCodeConfig({ baseUrl, apiKey, model });
-      case "qwen":
-        return await saveQwenConfig({ baseUrl, apiKey, model });
       default:
         return NextResponse.json(
           { error: `Direct config save not supported for: ${toolId}` },
@@ -176,62 +174,3 @@ async function saveOpenCodeConfig({ baseUrl, apiKey, model }) {
   });
 }
 
-/**
- * Save Qwen Code config to ~/.qwen/settings.json
- * Writes the modelProviders.openai entry with OmniRoute as the provider.
- * Merges with existing config to preserve other providers.
- */
-async function saveQwenConfig({ baseUrl, apiKey, model }) {
-  const home = os.homedir();
-  const configPath = path.join(home, ".qwen", "settings.json");
-  const configDir = path.dirname(configPath);
-
-  await fs.mkdir(configDir, { recursive: true });
-
-  const normalizedBaseUrl = String(baseUrl || "").trim().replace(/\/+$/, "");
-
-  // Read existing config to preserve other provider entries
-  let existingConfig: Record<string, any> = {};
-  try {
-    const raw = await fs.readFile(configPath, "utf-8");
-    existingConfig = JSON.parse(raw);
-  } catch {
-    // File doesn't exist or invalid JSON
-  }
-
-  // Build OmniRoute openai provider entry
-  const omnirouteEntry = {
-    id: "omniroute",
-    name: "OmniRoute",
-    envKey: "OPENAI_API_KEY",
-    baseUrl: normalizedBaseUrl,
-    apiKey: apiKey || "sk_omniroute",
-    generationConfig: {
-      defaultModel: model || "auto",
-    },
-  };
-
-  // Ensure modelProviders.openai array exists
-  if (!existingConfig.modelProviders) existingConfig.modelProviders = {};
-  if (!existingConfig.modelProviders.openai) existingConfig.modelProviders.openai = [];
-
-  const providers = existingConfig.modelProviders.openai;
-
-  // Replace OmniRoute entry if already present, otherwise add it
-  const existingIdx = providers.findIndex(
-    (p: any) => p && (p.baseUrl === normalizedBaseUrl || p.id === "omniroute")
-  );
-  if (existingIdx >= 0) {
-    providers[existingIdx] = omnirouteEntry;
-  } else {
-    providers.push(omnirouteEntry);
-  }
-
-  await fs.writeFile(configPath, JSON.stringify(existingConfig, null, 2), "utf-8");
-
-  return NextResponse.json({
-    success: true,
-    message: `Qwen Code config saved to ${configPath}`,
-    configPath,
-  });
-}

--- a/src/app/api/cli-tools/qwen-settings/route.ts
+++ b/src/app/api/cli-tools/qwen-settings/route.ts
@@ -1,0 +1,352 @@
+"use server";
+
+import { NextResponse } from "next/server";
+import fs from "fs/promises";
+import path from "path";
+import os from "os";
+import {
+  ensureCliConfigWriteAllowed,
+  getCliPrimaryConfigPath,
+  getCliRuntimeStatus,
+} from "@/shared/services/cliRuntime";
+import { createBackup } from "@/shared/services/backupService";
+import { saveCliToolLastConfigured, deleteCliToolLastConfigured } from "@/lib/db/cliToolState";
+import { cliModelConfigSchema } from "@/shared/validation/schemas";
+import { isValidationFailure, validateBody } from "@/shared/validation/helpers";
+import { getApiKeyById } from "@/lib/localDb";
+
+const getQwenSettingsPath = () => getCliPrimaryConfigPath("qwen");
+const getQwenDir = () => path.dirname(getQwenSettingsPath());
+const getQwenEnvPath = () => path.join(getQwenDir(), ".env");
+
+// Read current settings.json
+const readSettings = async () => {
+  try {
+    const settingsPath = getQwenSettingsPath();
+    const content = await fs.readFile(settingsPath, "utf-8");
+    return JSON.parse(content);
+  } catch (error: any) {
+    if (error.code === "ENOENT") return null;
+    throw error;
+  }
+};
+
+// Read current .env file
+const readEnv = async () => {
+  try {
+    const envPath = getQwenEnvPath();
+    return await fs.readFile(envPath, "utf-8");
+  } catch (error: any) {
+    if (error.code === "ENOENT") return "";
+    throw error;
+  }
+};
+
+// Check if settings has OmniRoute config
+const hasOmniRouteConfig = (settings: any) => {
+  if (!settings || !settings.modelProviders) return false;
+  const openai = settings.modelProviders.openai;
+  if (!Array.isArray(openai)) return false;
+  return openai.some(
+    (p: any) =>
+      p.name?.includes("OmniRoute") ||
+      p.id === "omniroute" ||
+      (p.baseUrl && !p.baseUrl.includes("dashscope") && !p.baseUrl.includes("openai.com"))
+  );
+};
+
+// GET - Check Qwen CLI and read current settings
+export async function GET() {
+  try {
+    const runtime = await getCliRuntimeStatus("qwen");
+
+    if (!runtime.installed || !runtime.runnable) {
+      return NextResponse.json({
+        installed: runtime.installed,
+        runnable: runtime.runnable,
+        command: runtime.command,
+        commandPath: runtime.commandPath,
+        runtimeMode: runtime.runtimeMode,
+        reason: runtime.reason,
+        settings: null,
+        message:
+          runtime.installed && !runtime.runnable
+            ? "Qwen Code CLI is installed but not runnable"
+            : "Qwen Code CLI is not installed",
+      });
+    }
+
+    const settings = await readSettings();
+
+    return NextResponse.json({
+      installed: runtime.installed,
+      runnable: runtime.runnable,
+      command: runtime.command,
+      commandPath: runtime.commandPath,
+      runtimeMode: runtime.runtimeMode,
+      reason: runtime.reason,
+      settings,
+      hasOmniRoute: hasOmniRouteConfig(settings),
+      settingsPath: getQwenSettingsPath(),
+      envPath: getQwenEnvPath(),
+    });
+  } catch (error) {
+    console.log("Error checking qwen settings:", error);
+    return NextResponse.json({ error: "Failed to check qwen settings" }, { status: 500 });
+  }
+}
+
+// POST - Write OmniRoute config to settings.json + .env
+export async function POST(request: Request) {
+  let rawBody;
+  try {
+    rawBody = await request.json();
+  } catch {
+    return NextResponse.json(
+      {
+        error: {
+          message: "Invalid request",
+          details: [{ field: "body", message: "Invalid JSON body" }],
+        },
+      },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const writeGuard = ensureCliConfigWriteAllowed();
+    if (writeGuard) {
+      return NextResponse.json({ error: writeGuard }, { status: 403 });
+    }
+
+    // Extract keyId BEFORE validation — Zod strips unknown fields
+    const keyId = typeof rawBody?.keyId === "string" ? rawBody.keyId.trim() : null;
+
+    const validation = validateBody(cliModelConfigSchema, rawBody);
+    if (isValidationFailure(validation)) {
+      return NextResponse.json({ error: validation.error }, { status: 400 });
+    }
+    let { baseUrl, apiKey, model } = validation.data;
+
+    // Resolve real key from DB by ID
+    if (keyId) {
+      try {
+        const keyRecord = await getApiKeyById(keyId);
+        if (keyRecord?.key) apiKey = keyRecord.key as string;
+      } catch {
+        /* non-critical */
+      }
+    }
+
+    const resolvedApiKey = apiKey || "sk_omniroute";
+    const resolvedModel = model || "coder-model";
+    const normalizedBaseUrl = String(baseUrl || "").trim().replace(/\/+$/, "");
+    const qwenDir = getQwenDir();
+    const settingsPath = getQwenSettingsPath();
+    const envPath = getQwenEnvPath();
+
+    // Ensure directory exists
+    await fs.mkdir(qwenDir, { recursive: true });
+
+    // Backup current settings before modifying
+    await createBackup("qwen", settingsPath);
+
+    // --- Write API keys to ~/.qwen/.env ---
+    let envContent = await readEnv();
+    const envLines = envContent
+      .split("\n")
+      .filter((line) => {
+        // Remove old OmniRoute-related keys we're about to write
+        return (
+          !line.startsWith("OPENAI_API_KEY=") &&
+          !line.startsWith("ANTHROPIC_API_KEY=") &&
+          !line.startsWith("GEMINI_API_KEY=")
+        );
+      });
+
+    envLines.push(`OPENAI_API_KEY=${resolvedApiKey}`);
+    envLines.push(`ANTHROPIC_API_KEY=${resolvedApiKey}`);
+    envLines.push(`GEMINI_API_KEY=${resolvedApiKey}`);
+
+    await fs.writeFile(envPath, envLines.join("\n").trim() + "\n", "utf-8");
+
+    // --- Write modelProviders to settings.json ---
+    let existingConfig: Record<string, any> = {};
+    try {
+      const raw = await fs.readFile(settingsPath, "utf-8");
+      existingConfig = JSON.parse(raw);
+    } catch {
+      // File doesn't exist or invalid JSON
+    }
+
+    if (!existingConfig.modelProviders) existingConfig.modelProviders = {};
+
+    // openai provider — primary, supports all models via OmniRoute
+    const openaiEntry = {
+      id: resolvedModel,
+      name: `${resolvedModel} (OmniRoute)`,
+      envKey: "OPENAI_API_KEY",
+      baseUrl: normalizedBaseUrl,
+      generationConfig: {
+        contextWindowSize: 200000,
+      },
+    };
+
+    if (!existingConfig.modelProviders.openai) existingConfig.modelProviders.openai = [];
+    const openaiProviders = existingConfig.modelProviders.openai;
+    const openaiIdx = openaiProviders.findIndex(
+      (p: any) => p && (p.baseUrl === normalizedBaseUrl || p.id === "omniroute")
+    );
+    if (openaiIdx >= 0) {
+      openaiProviders[openaiIdx] = openaiEntry;
+    } else {
+      openaiProviders.push(openaiEntry);
+    }
+
+    // anthropic provider — for Claude models via OmniRoute
+    const anthropicEntry = {
+      id: "claude-sonnet-4-6",
+      name: "Claude Sonnet 4.6 (OmniRoute)",
+      envKey: "ANTHROPIC_API_KEY",
+      baseUrl: normalizedBaseUrl,
+      generationConfig: {
+        contextWindowSize: 200000,
+      },
+    };
+
+    if (!existingConfig.modelProviders.anthropic) existingConfig.modelProviders.anthropic = [];
+    const anthropicProviders = existingConfig.modelProviders.anthropic;
+    const anthropicIdx = anthropicProviders.findIndex(
+      (p: any) => p && p.baseUrl === normalizedBaseUrl
+    );
+    if (anthropicIdx >= 0) {
+      anthropicProviders[anthropicIdx] = anthropicEntry;
+    } else {
+      anthropicProviders.push(anthropicEntry);
+    }
+
+    // gemini provider — for Gemini models via OmniRoute
+    const geminiEntry = {
+      id: "gemini-3-flash",
+      name: "Gemini 3 Flash (OmniRoute)",
+      envKey: "GEMINI_API_KEY",
+      baseUrl: normalizedBaseUrl,
+    };
+
+    if (!existingConfig.modelProviders.gemini) existingConfig.modelProviders.gemini = [];
+    const geminiProviders = existingConfig.modelProviders.gemini;
+    const geminiIdx = geminiProviders.findIndex(
+      (p: any) => p && p.baseUrl === normalizedBaseUrl
+    );
+    if (geminiIdx >= 0) {
+      geminiProviders[geminiIdx] = geminiEntry;
+    } else {
+      geminiProviders.push(geminiEntry);
+    }
+
+    await fs.writeFile(settingsPath, JSON.stringify(existingConfig, null, 2), "utf-8");
+
+    // Persist last-configured timestamp
+    try {
+      saveCliToolLastConfigured("qwen");
+    } catch {
+      /* non-critical */
+    }
+
+    return NextResponse.json({
+      success: true,
+      message: "Qwen Code config saved successfully!",
+      settingsPath,
+      envPath,
+    });
+  } catch (error) {
+    console.log("Error updating qwen settings:", error);
+    return NextResponse.json({ error: "Failed to update qwen settings" }, { status: 500 });
+  }
+}
+
+// DELETE - Remove OmniRoute config from settings.json and .env
+export async function DELETE() {
+  try {
+    const writeGuard = ensureCliConfigWriteAllowed();
+    if (writeGuard) {
+      return NextResponse.json({ error: writeGuard }, { status: 403 });
+    }
+
+    const settingsPath = getQwenSettingsPath();
+    const envPath = getQwenEnvPath();
+
+    // Backup current settings before resetting
+    await createBackup("qwen", settingsPath);
+
+    // --- Clean settings.json ---
+    let existingConfig: Record<string, any> = {};
+    try {
+      const raw = await fs.readFile(settingsPath, "utf-8");
+      existingConfig = JSON.parse(raw);
+    } catch (error: any) {
+      if (error.code === "ENOENT") {
+        return NextResponse.json({
+          success: true,
+          message: "No settings file to reset",
+        });
+      }
+      throw error;
+    }
+
+    // Remove OmniRoute entries from each provider type
+    const providerTypes = ["openai", "anthropic", "gemini"];
+    for (const type of providerTypes) {
+      if (Array.isArray(existingConfig.modelProviders?.[type])) {
+        existingConfig.modelProviders[type] = existingConfig.modelProviders[type].filter(
+          (p: any) =>
+            !p.name?.includes("OmniRoute") &&
+            p.id !== "omniroute"
+        );
+        // Remove empty provider arrays
+        if (existingConfig.modelProviders[type].length === 0) {
+          delete existingConfig.modelProviders[type];
+        }
+      }
+    }
+
+    // Clean up empty modelProviders
+    if (
+      existingConfig.modelProviders &&
+      Object.keys(existingConfig.modelProviders).length === 0
+    ) {
+      delete existingConfig.modelProviders;
+    }
+
+    await fs.writeFile(settingsPath, JSON.stringify(existingConfig, null, 2), "utf-8");
+
+    // --- Clean .env ---
+    const RESET_ENV_KEYS = ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GEMINI_API_KEY"];
+
+    try {
+      let envContent = await fs.readFile(envPath, "utf-8");
+      const envLines = envContent
+        .split("\n")
+        .filter((line) => !RESET_ENV_KEYS.some((key) => line.startsWith(`${key}=`)));
+
+      await fs.writeFile(envPath, envLines.join("\n").trim() + "\n", "utf-8");
+    } catch {
+      // .env doesn't exist — nothing to clean
+    }
+
+    // Clear last-configured timestamp
+    try {
+      deleteCliToolLastConfigured("qwen");
+    } catch {
+      /* non-critical */
+    }
+
+    return NextResponse.json({
+      success: true,
+      message: "OmniRoute settings removed from Qwen Code",
+    });
+  } catch (error) {
+    console.log("Error resetting qwen settings:", error);
+    return NextResponse.json({ error: "Failed to reset qwen settings" }, { status: 500 });
+  }
+}

--- a/src/app/api/cli-tools/status/route.ts
+++ b/src/app/api/cli-tools/status/route.ts
@@ -52,6 +52,16 @@ async function checkToolConfigStatus(toolId: string): Promise<string> {
     switch (toolId) {
       case "claude":
         return config?.env?.ANTHROPIC_BASE_URL ? "configured" : "not_configured";
+      case "qwen":
+        // Check modelProviders for OmniRoute entries
+        const mp = config?.modelProviders;
+        if (!mp) return "not_configured";
+        const qwenConfigStr = JSON.stringify(mp).toLowerCase();
+        return qwenConfigStr.includes("omniroute") ||
+          qwenConfigStr.includes(`localhost:${apiPort}`) ||
+          qwenConfigStr.includes(`127.0.0.1:${apiPort}`)
+          ? "configured"
+          : "not_configured";
       case "droid":
       case "openclaw":
       case "cline":
@@ -128,7 +138,7 @@ export async function GET() {
     );
 
     // Check config status for installed+runnable tools via direct file reads
-    const settingsTools = ["claude", "codex", "droid", "openclaw", "cline", "kilo"];
+    const settingsTools = ["claude", "codex", "droid", "openclaw", "cline", "kilo", "qwen"];
 
     await Promise.all(
       settingsTools.map(async (toolId) => {

--- a/src/shared/constants/cliTools.ts
+++ b/src/shared/constants/cliTools.ts
@@ -356,28 +356,95 @@ amp --model "{{model}}"
     name: "Qwen Code",
     icon: "psychology",
     color: "#10B981",
-    description: "Alibaba Qwen Code CLI — OpenAI-compatible endpoint",
-    docsUrl: "https://qwenlm.github.io/qwen-code-docs/",
+    description: "Alibaba Qwen Code CLI — supports OpenAI, Anthropic & Gemini providers via OmniRoute",
+    docsUrl: "https://qwenlm.github.io/qwen-code-docs/en/users/configuration/model-providers/",
     configType: "guide",
     defaultCommand: "qwen",
     notes: [
       {
         type: "info",
-        text: "Qwen Code supports custom OpenAI-compatible API endpoints via modelProviders in settings.json.",
+        text: "Qwen Code supports multiple provider types (openai, anthropic, gemini) via modelProviders in settings.json. OmniRoute works as an OpenAI-compatible endpoint.",
+      },
+      {
+        type: "info",
+        text: "Any model available in OmniRoute can be used — not just Qwen models. Select from Qwen, Claude, Gemini, GPT, and more.",
       },
       {
         type: "warning",
         text: "Config path: Linux/macOS ~/.qwen/settings.json • Windows %USERPROFILE%\\.qwen\\settings.json",
       },
+      {
+        type: "error",
+        text: "Qwen OAuth free tier was discontinued on 2026-04-15. Use OmniRoute with alicode/openrouter/anthropic/gemini providers instead.",
+      },
     ],
-    modelAliases: ["default", "claude-sonnet", "claude-opus", "gemini-pro", "gemini-flash"],
+    modelAliases: [
+      "coder-model",
+      "qwen3-coder-plus",
+      "qwen3-coder-flash",
+      "vision-model",
+      "claude-sonnet-4-6",
+      "claude-opus-4-6-thinking",
+      "gemini-3-flash",
+      "gemini-3.1-pro-high",
+    ],
     defaultModels: [
       {
-        id: "default",
-        name: "Default Model",
-        alias: "default",
+        id: "coder-model",
+        name: "Coder Model (Qwen 3.6 Plus)",
+        alias: "coder-model",
         envKey: "OPENAI_MODEL",
-        defaultValue: "auto",
+        defaultValue: "coder-model",
+        isTopLevel: true,
+      },
+      {
+        id: "qwen3-coder-plus",
+        name: "Qwen 3 Coder Plus",
+        alias: "qwen3-coder-plus",
+        envKey: "OPENAI_MODEL",
+        defaultValue: "qwen3-coder-plus",
+      },
+      {
+        id: "qwen3-coder-flash",
+        name: "Qwen 3 Coder Flash",
+        alias: "qwen3-coder-flash",
+        envKey: "OPENAI_MODEL",
+        defaultValue: "qwen3-coder-flash",
+      },
+      {
+        id: "vision-model",
+        name: "Vision Model (Multimodal)",
+        alias: "vision-model",
+        envKey: "OPENAI_MODEL",
+        defaultValue: "vision-model",
+      },
+      {
+        id: "claude-sonnet-4-6",
+        name: "Claude Sonnet 4.6",
+        alias: "claude-sonnet-4-6",
+        envKey: "OPENAI_MODEL",
+        defaultValue: "claude-sonnet-4-6",
+      },
+      {
+        id: "claude-opus-4-6-thinking",
+        name: "Claude Opus 4.6 Thinking",
+        alias: "claude-opus-4-6-thinking",
+        envKey: "OPENAI_MODEL",
+        defaultValue: "claude-opus-4-6-thinking",
+      },
+      {
+        id: "gemini-3.1-pro-high",
+        name: "Gemini 3.1 Pro High",
+        alias: "gemini-3.1-pro-high",
+        envKey: "OPENAI_MODEL",
+        defaultValue: "gemini-3.1-pro-high",
+      },
+      {
+        id: "gemini-3-flash",
+        name: "Gemini 3 Flash",
+        alias: "gemini-3-flash",
+        envKey: "OPENAI_MODEL",
+        defaultValue: "gemini-3-flash",
       },
     ],
     guideSteps: [
@@ -393,17 +460,28 @@ amp --model "{{model}}"
     ],
     codeBlock: {
       language: "json",
-      code: `# ~/.qwen/settings.json
+      code: `# ~/.qwen/settings.json — OmniRoute as multi-provider
 {
   "modelProviders": {
     "openai": [{
-      "id": "omniroute",
+      "id": "{{model}}",
       "name": "OmniRoute",
       "envKey": "OPENAI_API_KEY",
       "baseUrl": "{{baseUrl}}",
-      "generationConfig": {
-        "defaultModel": "{{model}}"
-      }
+      "generationConfig": { "contextWindowSize": 200000 }
+    }],
+    "anthropic": [{
+      "id": "claude-sonnet-4-6",
+      "name": "Claude Sonnet 4.6",
+      "envKey": "ANTHROPIC_API_KEY",
+      "baseUrl": "{{baseUrl}}",
+      "generationConfig": { "contextWindowSize": 200000 }
+    }],
+    "gemini": [{
+      "id": "gemini-3-flash",
+      "name": "Gemini 3 Flash",
+      "envKey": "GEMINI_API_KEY",
+      "baseUrl": "{{baseUrl}}"
     }]
   }
 }`,

--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -3,7 +3,16 @@
 // Free Providers
 export const FREE_PROVIDERS = {
   qoder: { id: "qoder", alias: "if", name: "Qoder AI", icon: "water_drop", color: "#6366F1" },
-  qwen: { id: "qwen", alias: "qw", name: "Qwen Code", icon: "psychology", color: "#10B981" },
+  qwen: {
+    id: "qwen",
+    alias: "qw",
+    name: "Qwen Code",
+    icon: "psychology",
+    color: "#10B981",
+    deprecated: true,
+    deprecationReason:
+      "Qwen OAuth free tier was discontinued on 2026-04-15. Use 'alicode', 'alicode-intl', or 'openrouter' provider with API key instead.",
+  },
   "gemini-cli": {
     id: "gemini-cli",
     alias: "gemini-cli",

--- a/tests/unit/translator-openai-responses-req.test.ts
+++ b/tests/unit/translator-openai-responses-req.test.ts
@@ -279,6 +279,37 @@ test("Chat -> Responses preserves prompt_cache_key and session affinity fields",
   assert.equal(result.store, undefined);
 });
 
+test("Chat -> Responses preserves explicit reasoning objects", () => {
+  const result = openaiToOpenAIResponsesRequest(
+    "gpt-5.3-codex-spark",
+    {
+      messages: [{ role: "user", content: "Hello" }],
+      reasoning: { effort: "low" },
+    },
+    false,
+    null
+  );
+
+  assert.deepEqual(result.reasoning, { effort: "low" });
+  assert.equal(result.store, false);
+});
+
+test("Chat -> Responses maps reasoning_effort into Responses reasoning", () => {
+  const result = openaiToOpenAIResponsesRequest(
+    "gpt-5.3-codex-spark",
+    {
+      messages: [{ role: "user", content: "Hello" }],
+      reasoning_effort: "low",
+    },
+    false,
+    null
+  );
+
+  assert.deepEqual(result.reasoning, { effort: "low" });
+  assert.equal(result.reasoning_effort, undefined);
+  assert.equal(result.store, false);
+});
+
 test("Chat -> Responses filters orphan function_call_output items and leaves empty instructions when absent", () => {
   const result = openaiToOpenAIResponsesRequest(
     "gpt-4o",


### PR DESCRIPTION
## Summary

Qwen OAuth free tier was discontinued on 2026-04-15 (see [QwenLM/qwen-code#3203](https://github.com/QwenLM/qwen-code/issues/3203)). This PR adds full Qwen Code CLI integration and deprecates the broken OAuth provider.

### Changes (6 files)

**Provider deprecation**
- **`providers.ts`**: Mark `qwen` in `FREE_PROVIDERS` as `deprecated: true` with reason pointing to API key providers

**CLI Tool config**
- **`cliTools.ts`**: Add Qwen Code CLI tool entry with:
  - Multi-provider model support (`openai`, `anthropic`, `gemini` auth types per [official docs](https://qwenlm.github.io/qwen-code-docs/en/users/configuration/model-providers/))
  - Model list: Qwen models + Claude + Gemini (any OmniRoute model)
  - Error-type note about OAuth shutdown
  - CodeBlock showing all 3 auth types pointing to OmniRoute

**Dedicated settings route** (follows Claude/OpenClaw pattern)
- **`qwen-settings/route.ts`** (NEW): GET/POST/DELETE handlers
  - Writes API keys to `~/.qwen/.env` (per official docs, not hardcoded in settings.json)
  - Writes `openai`/`anthropic`/`gemini` providers to `~/.qwen/settings.json`
  - Backup support, keyId resolution from DB, last-configured tracking
- **`guide-settings/[toolId]/route.ts`**: Remove old `saveQwenConfig` (replaced by dedicated route)

**Integration**
- **`backups/route.ts`**: Add `qwen` to `VALID_TOOLS`
- **`status/route.ts`**: Add `qwen` to `settingsTools` + config status check for `modelProviders`