### PR TITLE
fix(sse): enable tool calling for GPT OSS and DeepSeek Reasoner models

### DIFF
--- a/open-sse/config/providerRegistry.ts
+++ b/open-sse/config/providerRegistry.ts
@@ -1199,9 +1199,9 @@ export const REGISTRY: Record<string, RegistryEntry> = {
     authType: "apikey",
     authHeader: "bearer",
     models: [
-      { id: "gpt-oss-120b", name: "GPT OSS 120B", toolCalling: false },
-      { id: "openai/gpt-oss-120b", name: "GPT OSS 120B (OpenAI Prefix)", toolCalling: false },
-      { id: "openai/gpt-oss-20b", name: "GPT OSS 20B", toolCalling: false },
+      { id: "gpt-oss-120b", name: "GPT OSS 120B" },
+      { id: "openai/gpt-oss-120b", name: "GPT OSS 120B (OpenAI Prefix)" },
+      { id: "openai/gpt-oss-20b", name: "GPT OSS 20B" },
       { id: "meta/llama-3.3-70b-instruct", name: "Llama 3.3 70B" },
       { id: "nvidia/llama-3.3-70b-instruct", name: "Llama 3.3 70B (NVIDIA Prefix)" },
       { id: "meta/llama-4-maverick-17b-128e-instruct", name: "Llama 4 Maverick" },

--- a/src/lib/modelCapabilities.ts
+++ b/src/lib/modelCapabilities.ts
@@ -6,7 +6,7 @@ import { parseModel, resolveCanonicalProviderModel } from "@omniroute/open-sse/s
 import { MODEL_SPECS, getModelSpec, type ModelSpec } from "@/shared/constants/modelSpecs";
 import { getSyncedCapability } from "@/lib/modelsDevSync";
 
-const TOOL_CALLING_UNSUPPORTED_PATTERNS = ["gpt-oss-120b", "deepseek-reasoner"];
+const TOOL_CALLING_UNSUPPORTED_PATTERNS: string[] = [];
 const REASONING_UNSUPPORTED_PATTERNS = [
   "antigravity/claude-sonnet-4-6",
   "antigravity/claude-sonnet-4-5",

--- a/tests/unit/model-capabilities-registry.test.ts
+++ b/tests/unit/model-capabilities-registry.test.ts
@@ -103,3 +103,20 @@ test("canonical model capability resolver merges models.dev data and keeps stati
     32768
   );
 });
+
+test("GPT OSS and DeepSeek Reasoner models support tool calling", () => {
+  // GPT OSS models should not be blocked by the heuristic
+  assert.equal(modelCapabilities.supportsToolCalling("nvidia/gpt-oss-120b"), true);
+  assert.equal(modelCapabilities.supportsToolCalling("gpt-oss-120b"), true);
+  assert.equal(modelCapabilities.supportsToolCalling("openai/gpt-oss-20b"), true);
+
+  // DeepSeek Reasoner supports tool calling
+  assert.equal(modelCapabilities.supportsToolCalling("deepseek-reasoner"), true);
+  assert.equal(modelCapabilities.supportsToolCalling("deepseek/deepseek-r1"), true);
+
+  // Full capability resolution
+  const gptOss = modelCapabilities.getResolvedModelCapabilities("nvidia/gpt-oss-120b");
+  assert.equal(gptOss.toolCalling, true);
+  const deepseek = modelCapabilities.getResolvedModelCapabilities("deepseek/deepseek-reasoner");
+  assert.equal(deepseek.toolCalling, true);
+});

--- a/tests/unit/services-branch-hardening.test.ts
+++ b/tests/unit/services-branch-hardening.test.ts
@@ -79,8 +79,8 @@ test("model capability helpers cover denylist, empty input and default-safe path
   assert.equal(modelCapabilities.supportsReasoning("missing-provider/tool"), true);
 
   assert.equal(modelCapabilities.supportsToolCalling(""), false);
-  assert.equal(modelCapabilities.supportsToolCalling("openai/gpt-oss-120b"), false);
-  assert.equal(modelCapabilities.supportsToolCalling("deepseek-reasoner"), false);
+  assert.equal(modelCapabilities.supportsToolCalling("openai/gpt-oss-120b"), true);
+  assert.equal(modelCapabilities.supportsToolCalling("deepseek-reasoner"), true);
   assert.equal(
     modelCapabilities.supportsToolCalling("openai/nonexistent-default-safe-model"),
     true


### PR DESCRIPTION
## Summary

GPT OSS models (gpt-oss-120b, gpt-oss-20b) and DeepSeek Reasoner (deepseek-reasoner / deepseek-r1) all support tool calling, but OmniRoute incorrectly blocks them via `TOOL_CALLING_UNSUPPORTED_PATTERNS` in `src/lib/modelCapabilities.ts`.

The `heuristicToolCalling()` function is the fallback when no explicit `supportsTools` value exists in the static model spec, provider registry, or models.dev sync data. It returns `true` for any model not matched by `TOOL_CALLING_UNSUPPORTED_PATTERNS`. Both `gpt-oss-120b` and `deepseek-reasoner` are in this blocklist, but both models support tool calling -- confirmed by live API testing with tool-bearing requests.

The `.includes()` substring match also means `gpt-oss-120b` blocks any model ID containing that string across all providers, and the nvidia provider's GPT OSS entries carry a redundant explicit `toolCalling` field that no other provider uses for these models.

### What changed

- **`src/lib/modelCapabilities.ts`**: Emptied `TOOL_CALLING_UNSUPPORTED_PATTERNS` (removed `gpt-oss-120b` and `deepseek-reasoner`)
- **`open-sse/config/providerRegistry.ts`**: Removed the `toolCalling` field from 3 nvidia GPT OSS entries for consistency with other providers
- **`tests/unit/model-capabilities-registry.test.ts`**: Added test case verifying tool calling resolves correctly for GPT OSS and DeepSeek Reasoner models
- **`tests/unit/services-branch-hardening.test.ts`**: Updated existing denylist assertions to match the new behaviour

## Testing

- Added unit test covering `supportsToolCalling()` for GPT OSS (bare and provider-prefixed IDs), DeepSeek Reasoner, and full capability resolution via `getResolvedModelCapabilities()`
- Updated existing branch-hardening test assertions
- Validated end-to-end: `nvidia/gpt-oss-120b` and `openrouter/deepseek-r1` both return `tool_calls` in responses when given tool definitions

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this is a configuration-level change that unblocks already-supported model capabilities. The heuristic fallback is the same code path used by all other models without explicit tool calling overrides.