### PR TITLE
fix(encryption): return null on decryption failure to prevent sending encrypted tokens to providers

### DIFF
--- a/src/lib/db/encryption.ts
+++ b/src/lib/db/encryption.ts
@@ -110,14 +110,16 @@ export function decrypt(ciphertext: string | null | undefined): string | null | 
     console.warn(
       "[Encryption] Found encrypted data but STORAGE_ENCRYPTION_KEY is not set. Cannot decrypt."
     );
-    return ciphertext;
+    // Return null instead of encrypted ciphertext to prevent sending encrypted tokens to providers
+    return null;
   }
 
   const body = ciphertext.slice(PREFIX.length);
   const parts = body.split(":");
   if (parts.length !== 3) {
     console.error("[Encryption] Malformed encrypted value");
-    return ciphertext;
+    // Return null instead of encrypted ciphertext to prevent sending malformed encrypted tokens to providers
+    return null;
   }
 
   const [ivHex, encryptedHex, authTagHex] = parts;
@@ -134,7 +136,8 @@ export function decrypt(ciphertext: string | null | undefined): string | null | 
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
     console.error("[Encryption] Decryption failed:", message);
-    return ciphertext;
+    // Return null instead of encrypted ciphertext to prevent sending encrypted tokens to providers
+    return null;
   }
 }
 

--- a/tests/unit/db-encryption.test.ts
+++ b/tests/unit/db-encryption.test.ts
@@ -66,7 +66,7 @@ test("connection field helpers encrypt and decrypt all supported credential fiel
   assert.deepEqual(decrypted, connection);
 });
 
-test("decrypt returns the original ciphertext when the value is malformed or the key is wrong", async () => {
+test("decrypt returns null when the value is malformed or the key is wrong", async () => {
   process.env.STORAGE_ENCRYPTION_KEY = "task-304-secret-c";
   const firstModule = await importFresh("src/lib/db/encryption.ts");
   const encrypted = firstModule.encrypt("top-secret");
@@ -74,6 +74,8 @@ test("decrypt returns the original ciphertext when the value is malformed or the
   process.env.STORAGE_ENCRYPTION_KEY = "task-304-secret-d";
   const secondModule = await importFresh("src/lib/db/encryption.ts");
 
-  assert.equal(secondModule.decrypt(encrypted), encrypted);
-  assert.equal(secondModule.decrypt("enc:v1:not-valid"), "enc:v1:not-valid");
+  // When decryption fails with wrong key, return null (not encrypted ciphertext)
+  // This prevents sending encrypted tokens to APIs
+  assert.equal(secondModule.decrypt(encrypted), null);
+  assert.equal(secondModule.decrypt("enc:v1:not-valid"), null);
 });


### PR DESCRIPTION
## Summary
Fix critical security issue where encrypted credential tokens were being sent to upstream APIs when decryption failed.

## Root Cause
The `decrypt()` function in `src/lib/db/encryption.ts` was returning the **encrypted ciphertext unchanged** when:
1. A malformed encrypted value was passed (invalid format)
2. Decryption failed due to wrong encryption key or corrupted auth tag

This caused encrypted tokens with `enc:v1:` prefix to reach upstream APIs like Kiro, which rejected them with `[400]: Improperly formed request`.

## Fix
- Line 120: Return `null` instead of `ciphertext` when encrypted value is malformed
- Line 138: Return `null` instead of `ciphertext` when decryption fails
- This allows the auth service to skip unavailable accounts and use fallback providers
- Prevents any encrypted tokens from reaching upstream APIs

## Testing
- All 4 encryption unit tests pass with updated expectations
- Build completes successfully with fix
- No type errors or linting issues

## Changes
- `src/lib/db/encryption.ts`: Return `null` on both malformed and decryption failure cases
- `tests/unit/db-encryption.test.ts`: Updated test expectations to verify `null` is returned on any decryption failure

## Security Impact
This fix prevents encrypted provider credentials from being leaked to external APIs when credentials are unavailable or corrupted.