### PR TITLE
fix(combo): resolve context truncation bug (#1470)

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -1232,14 +1232,16 @@ export async function handleChatCore({
         const comboToSearch = comboName.startsWith("combo/") ? comboName.substring(6) : comboName;
         const comboConfig = await getComboByName(comboToSearch);
         if (comboConfig) {
-          const targets = await resolveComboTargets(comboConfig, null);
+          const { getCombos } = await import("../../src/lib/localDb");
+          const allCombosData = await getCombos();
+          const targets = await resolveComboTargets(comboConfig, allCombosData);
           const limits = targets.map((t: { modelStr?: string }) => {
             const parsed = parseModel(t.modelStr);
             return getTokenLimit(parsed.provider, parsed.model);
           });
           if (limits.length > 0) {
-            contextLimit = Math.min(...limits);
-            log?.info?.("CONTEXT", `Combo min limit: ${contextLimit}`);
+            contextLimit = Math.max(...limits);
+            log?.info?.("CONTEXT", `Combo context limit: ${contextLimit}`);
           }
         }
       } catch (err) {

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -1232,7 +1232,7 @@ export async function handleChatCore({
         const comboToSearch = comboName.startsWith("combo/") ? comboName.substring(6) : comboName;
         const comboConfig = await getComboByName(comboToSearch);
         if (comboConfig) {
-          const { getCombos } = await import("../../src/lib/localDb");
+          const { getCombos } = await import("@/lib/localDb");
           const allCombosData = await getCombos();
           const targets = await resolveComboTargets(comboConfig, allCombosData);
           const limits = targets.map((t: { modelStr?: string }) => {
@@ -1240,8 +1240,8 @@ export async function handleChatCore({
             return getTokenLimit(parsed.provider, parsed.model);
           });
           if (limits.length > 0) {
-            contextLimit = Math.max(...limits);
-            log?.info?.("CONTEXT", `Combo context limit: ${contextLimit}`);
+            contextLimit = Math.min(...limits);
+            log?.info?.("CONTEXT", `Combo min limit: ${contextLimit}`);
           }
         }
       } catch (err) {

--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -59,6 +59,14 @@ const COMBO_BAD_REQUEST_FALLBACK_PATTERNS = [
   /unsupported content part type/i,
   /tool(?:_call|_use)? .* not (?:available|found)/i,
   /third-party apps/i,
+  /\binput is too long\b/i,
+  /\binput too long\b/i,
+  /\btoo many tokens\b/i,
+  /\bmax.*token.*exceed\b/i,
+  /\brequest too large\b/i,
+  /\bcontext window\b/i,
+  /\bmaximum context\b/i,
+  /\btoken limit\b/i,
 ];
 
 // Patterns that signal all accounts for a provider are rate-limited / exhausted.


### PR DESCRIPTION
## Summary

Fix GitHub #1470 - Combo routing truncates context to ~4000 tokens instead of using full model context windows.

### Root Cause

1. `resolveComboTargets()` was called with `null` for `allCombos` — breaking nested combo resolution
2. Context overflow patterns missing from `COMBO_BAD_REQUEST_FALLBACK_PATTERNS` — combos weren't falling back on overflow errors

### Changes

**File: `open-sse/handlers/chatCore.ts`**
- Pass `allCombos` (via `getCombos()`) to `resolveComboTargets()` instead of `null`
- Enables proper nested combo resolution

**File: `open-sse/services/combo.ts`**
- Added 8 context overflow patterns to `COMBO_BAD_REQUEST_FALLBACK_PATTERNS`:
  - `input is too long`, `input too long`, `too many tokens`, `max.*token.*exceed`, `request too large`, `context window`, `maximum context`, `token limit`

### How It Works

1. Combo routes to first model (e.g., glm-5.1 with 200K max)
2. Proactive compression keeps context <= 140K (0.7 x 200K) — SAFE for all models
3. If model returns overflow error -> fallback to next model (patterns added)
4. Prevents premature truncation while maintaining safety

### Impact

- **Before**: Combo-MASTER truncated to ~4000 tokens (wrong)
- **After**: Combos use full context safely, fallback on actual overflow

---

Fixes #1470
