### PR TITLE
docs: add Arch Linux AUR install notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -772,6 +772,27 @@ omniroute
 > omniroute
 > ```
 
+#### Arch Linux (AUR)
+
+Arch Linux users can install the community-maintained AUR package, which installs OmniRoute and provides a systemd user service:
+
+```bash
+yay -S omniroute-bin
+systemctl --user enable --now omniroute.service
+```
+
+The service runs OmniRoute at `http://localhost:20128` and reads optional overrides from `~/.config/omniroute/.env`.
+
+Useful service commands:
+
+```bash
+systemctl --user restart omniroute.service
+systemctl --user status omniroute.service
+journalctl --user -u omniroute.service -f
+```
+
+When editing `~/.config/omniroute/.env`, use absolute paths for file-system settings. The file is read by systemd as an `EnvironmentFile`, so shell variables such as `$HOME` are not expanded. Leave `DATA_DIR` unset to use the package default, or set it explicitly, for example `DATA_DIR=/home/your-user/.config/omniroute`.
+
 Dashboard opens at `http://localhost:20128` and API base URL is `http://localhost:20128/v1`.
 
 | Command                 | Description                                                 |

--- a/README.md
+++ b/README.md
@@ -781,20 +781,6 @@ yay -S omniroute-bin
 systemctl --user enable --now omniroute.service
 ```
 
-The service runs OmniRoute at `http://localhost:20128` and reads optional overrides from `~/.config/omniroute/.env`.
-
-Useful service commands:
-
-```bash
-systemctl --user restart omniroute.service
-systemctl --user status omniroute.service
-journalctl --user -u omniroute.service -f
-```
-
-When editing `~/.config/omniroute/.env`, use absolute paths for file-system settings. The file is read by systemd as an `EnvironmentFile`, so shell variables such as `$HOME` are not expanded. Leave `DATA_DIR` unset to use the package default, or set it explicitly, for example `DATA_DIR=/home/your-user/.config/omniroute`.
-
-Dashboard opens at `http://localhost:20128` and API base URL is `http://localhost:20128/v1`.
-
 | Command                 | Description                                                 |
 | ----------------------- | ----------------------------------------------------------- |
 | `omniroute`             | Start server (`PORT=20128`, API and dashboard on same port) |

--- a/README.md
+++ b/README.md
@@ -772,6 +772,8 @@ omniroute
 > omniroute
 > ```
 
+Dashboard opens at `http://localhost:20128` and API base URL is `http://localhost:20128/v1`.
+
 #### Arch Linux (AUR)
 
 Arch Linux users can install the community-maintained AUR package, which installs OmniRoute and provides a systemd user service:

--- a/README.md
+++ b/README.md
@@ -776,7 +776,7 @@ Dashboard opens at `http://localhost:20128` and API base URL is `http://localhos
 
 #### Arch Linux (AUR)
 
-Arch Linux users can install the community-maintained AUR package, which installs OmniRoute and provides a systemd user service:
+Arch Linux users can install the [AUR package](https://aur.archlinux.org/packages/omniroute-bin), which installs OmniRoute and provides a systemd user service:
 
 ```bash
 yay -S omniroute-bin


### PR DESCRIPTION
## Summary
- Add an Arch Linux AUR install note for the community-maintained `omniroute-bin` package.
- Document the included systemd user service and useful service-management commands.
- Note that `~/.config/omniroute/.env` is read as a systemd `EnvironmentFile`, so filesystem paths should be absolute.