### PR TITLE
fix: deduplicate case-variant anthropic-version header in Claude Code patch

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,2 +1,8 @@
 #!/usr/bin/env sh
-exit 0
+if ! command -v npm >/dev/null 2>&1; then
+  echo "⚠️  npm not found in PATH — skipping pre-push hooks"
+  echo "   Run 'npm test' manually before pushing."
+  exit 0
+fi
+
+npm run test:unit

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,8 +1,2 @@
 #!/usr/bin/env sh
-if ! command -v npm >/dev/null 2>&1; then
-  echo "⚠️  npm not found in PATH — skipping pre-push hooks"
-  echo "   Run 'npm test' manually before pushing."
-  exit 0
-fi
-
-npm run test:unit
+exit 0

--- a/open-sse/executors/base.ts
+++ b/open-sse/executors/base.ts
@@ -531,6 +531,17 @@ export class BaseExecutor {
             "x-client-request-id": randomUUID(),
             "X-Claude-Code-Session-Id": randomUUID(),
           };
+          // Remove any existing case variants of ccHeaders keys before merging.
+          // The claude provider config sets "Anthropic-Version" (Title-Case) while
+          // ccHeaders uses all-lowercase keys.  Both JS keys normalise to the same
+          // HTTP header name, so undici would combine them into "2023-06-01, 2023-06-01"
+          // causing a 400 from Anthropic (see issue #1454).
+          const ccKeysLower = new Set(Object.keys(ccHeaders).map((k) => k.toLowerCase()));
+          for (const key of Object.keys(headers)) {
+            if (ccKeysLower.has(key.toLowerCase())) {
+              delete headers[key];
+            }
+          }
           Object.assign(headers, ccHeaders);
           delete headers["X-Stainless-Helper-Method"];
 

--- a/tests/unit/executor-default-base.test.ts
+++ b/tests/unit/executor-default-base.test.ts
@@ -802,11 +802,8 @@ test("DefaultExecutor.execute does not produce duplicate anthropic-version heade
   let capturedHeaders: Record<string, string> = {};
 
   globalThis.fetch = async (_url, init = {}) => {
-    const h = init.headers as Record<string, string>;
-    // Normalise to lowercase to mirror what undici/fetch does when sending.
-    capturedHeaders = Object.fromEntries(
-      Object.entries(h || {}).map(([k, v]) => [k.toLowerCase(), v])
-    );
+    // Capture raw headers without normalisation so case-variant duplicate keys are visible.
+    capturedHeaders = (init.headers as Record<string, string>) || {};
     return new Response(JSON.stringify({ ok: true }), {
       status: 200,
       headers: { "Content-Type": "application/json" },
@@ -833,6 +830,10 @@ test("DefaultExecutor.execute does not produce duplicate anthropic-version heade
     globalThis.fetch = originalFetch;
   }
 
-  // Must be exactly the canonical value — not "2023-06-01, 2023-06-01"
-  assert.equal(capturedHeaders["anthropic-version"], "2023-06-01");
+  // Must be exactly one key — not multiple case variants that undici would combine
+  const versionKeys = Object.keys(capturedHeaders).filter(
+    (k) => k.toLowerCase() === "anthropic-version"
+  );
+  assert.equal(versionKeys.length, 1, "Duplicate anthropic-version header keys found");
+  assert.equal(capturedHeaders[versionKeys[0]], "2023-06-01");
 });

--- a/tests/unit/executor-default-base.test.ts
+++ b/tests/unit/executor-default-base.test.ts
@@ -789,3 +789,50 @@ test("BaseExecutor.execute clears the startup timeout after headers arrive", asy
     globalThis.fetch = originalFetch;
   }
 });
+
+// Regression test for issue #1454: duplicate anthropic-version header when
+// Claude Code CLI headers are detected on the native `claude` provider.
+// The provider config seeds headers with Title-Case "Anthropic-Version" while
+// the Claude-Code patch injects lowercase "anthropic-version".  Before the fix,
+// both keys coexisted in the JS object and undici combined their values into
+// "2023-06-01, 2023-06-01", causing a 400 from Anthropic.
+test("DefaultExecutor.execute does not produce duplicate anthropic-version header when Claude Code CLI headers are present", async () => {
+  const executor = new DefaultExecutor("claude");
+  const originalFetch = globalThis.fetch;
+  let capturedHeaders: Record<string, string> = {};
+
+  globalThis.fetch = async (_url, init = {}) => {
+    const h = init.headers as Record<string, string>;
+    // Normalise to lowercase to mirror what undici/fetch does when sending.
+    capturedHeaders = Object.fromEntries(
+      Object.entries(h || {}).map(([k, v]) => [k.toLowerCase(), v])
+    );
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+
+  try {
+    await executor.execute({
+      model: "claude-sonnet-4-6",
+      body: {
+        model: "claude-sonnet-4-6",
+        messages: [{ role: "user", content: "hi" }],
+        max_tokens: 1,
+      },
+      stream: false,
+      credentials: { accessToken: "oauth-token" },
+      clientHeaders: {
+        "x-app": "cli",
+        "user-agent": "claude-cli/2.1.116 (external, cli)",
+        "anthropic-beta": "oauth-2025-04-20",
+      },
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  // Must be exactly the canonical value — not "2023-06-01, 2023-06-01"
+  assert.equal(capturedHeaders["anthropic-version"], "2023-06-01");
+});


### PR DESCRIPTION
Fixes https://github.com/diegosouzapw/OmniRoute/issues/1454

## Root Cause

The `claude` provider's config seeds outgoing headers with `"Anthropic-Version": "2023-06-01"` (Title-Case, from `providerRegistry.ts`). When a Claude Code CLI client is detected (`x-app: cli` / `claude-cli/*` User-Agent), `base.ts` builds `ccHeaders` with `"anthropic-version": "2023-06-01"` (all-lowercase) and merges it via `Object.assign(headers, ccHeaders)`.

Because JavaScript objects are case-sensitive, both keys coexisted in the same headers object:
```
{
  "Anthropic-Version": "2023-06-01",   // from config
  "anthropic-version": "2023-06-01",   // from CC patch
  ...
}
```
When undici/Node.js `fetch` serialised the request it treated the two keys as the same HTTP header name and combined their values with a comma, producing:
```
anthropic-version: 2023-06-01, 2023-06-01
```
Anthropic rejects this with `400 anthropic-version: "2023-06-01, 2023-06-01" is not a valid version`.

## Fix

**`open-sse/executors/base.ts`** — before `Object.assign(headers, ccHeaders)`, delete any existing entry in `headers` whose key normalises (case-insensitively) to the same name as a key in `ccHeaders`. This covers `anthropic-version`, `anthropic-beta`, `anthropic-dangerous-direct-browser-access`, `x-app`, and any other header that the CC patch owns.

## Test

**`tests/unit/executor-default-base.test.ts`** — new regression test executes the `claude` provider with Claude Code CLI `clientHeaders` (`x-app: cli`, `user-agent: claude-cli/*`) and asserts the outgoing `anthropic-version` header is exactly `"2023-06-01"`, not the duplicated `"2023-06-01, 2023-06-01"`.

## Test Results

```
✔ DefaultExecutor.execute does not produce duplicate anthropic-version header when Claude Code CLI headers are present
29/29 tests pass
Coverage: 88.86% statements / 76.7% branches / 91.65% functions (all above 60% gate)
```