### PR TITLE
fix(codex): preserve namespace MCP tools forwarded to Codex Responses…

### DIFF
--- a/open-sse/executors/codex.ts
+++ b/open-sse/executors/codex.ts
@@ -334,6 +334,20 @@ function normalizeCodexTools(body: Record<string, unknown>): void {
     }
 
     const tool = toolValue as Record<string, unknown>;
+
+    // Preserve namespace tools (MCP tool groups used by Codex/OpenAI Responses API).
+    // Codex API supports them natively; register sub-tool names for tool_choice validation.
+    if (tool.type === "namespace" && Array.isArray(tool.tools)) {
+      for (const st of tool.tools as unknown[]) {
+        if (st && typeof st === "object" && !Array.isArray(st)) {
+          const subTool = st as Record<string, unknown>;
+          const name = typeof subTool.name === "string" ? subTool.name.trim() : "";
+          if (name) validToolNames.add(name);
+        }
+      }
+      return true;
+    }
+
     if (tool.type !== "function") {
       return false;
     }

--- a/open-sse/translator/request/openai-responses.ts
+++ b/open-sse/translator/request/openai-responses.ts
@@ -55,12 +55,14 @@ export function openaiResponsesToOpenAIRequest(
     for (const toolValue of tools) {
       const tool = toRecord(toolValue);
       const toolType = toString(tool.type);
-      // Allow: function tools, tools already in Chat format (have .function property), and CLI subagent tools
+      // Allow: function tools, tools already in Chat format (have .function property), CLI subagent tools,
+      // and namespace tools (MCP tool groups used by Codex/OpenAI Responses API).
       if (
         toolType &&
         toolType !== "function" &&
         toolType !== "custom" &&
         toolType !== "command" &&
+        toolType !== "namespace" &&
         !tool.function
       ) {
         throw unsupportedFeature(


### PR DESCRIPTION
… API

normalizeCodexTools() was dropping all tools with type !== "function", which stripped namespace-typed MCP tool groups (e.g. mcp__atlassian__) before the request reached the Codex API. Codex then saw an empty tools array and refused to call any MCP tools.

Fix: detect type === "namespace" entries, preserve them as-is (Codex API supports them natively), and register sub-tool names in validToolNames so tool_choice validation still works correctly. Also whitelist "namespace" in the openai-responses translator to prevent a throw on the same type when the translation path is invoked.

## Summary

- Describe the user-facing or operational change.

## Related Issues

- Closes #
- Related to #

## Validation

- [ ] `npm run lint`
- [ ] `npm run test:unit`
- [ ] `npm run test:coverage`
- [ ] Coverage is still `>= 60%` for statements, lines, functions, and branches
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below

## Tests Added Or Updated

- List every changed or added automated test file.
- If no production code changed, state that here.

## Coverage Notes

- If this PR changes `src/`, `open-sse/`, `electron/`, or `bin/`, explain which tests cover the change.
- If coverage moved down in any touched file, explain why and what follow-up task will recover it.

## Reviewer Notes

- Call out any risky areas, migrations, feature flags, or manual validation that reviewers should know about.
