### PR TITLE
fix: normalize Anthropic header keys to lowercase in provider registry

### DIFF
--- a/open-sse/config/providerRegistry.ts
+++ b/open-sse/config/providerRegistry.ts
@@ -126,8 +126,8 @@ const KIMI_CODING_SHARED = {
   baseUrl: "https://api.kimi.com/coding/v1/messages",
   authHeader: "x-api-key",
   headers: {
-    "Anthropic-Version": ANTHROPIC_VERSION_HEADER,
-    "Anthropic-Beta": ANTHROPIC_BETA_API_KEY,
+    "anthropic-version": ANTHROPIC_VERSION_HEADER,
+    "anthropic-beta": ANTHROPIC_BETA_API_KEY,
   },
   models: [
     { id: "kimi-k2.5", name: "Kimi K2.5" },
@@ -273,11 +273,11 @@ export const REGISTRY: Record<string, RegistryEntry> = {
     authHeader: "x-api-key",
     defaultContextLength: 200000,
     headers: {
-      "Anthropic-Version": ANTHROPIC_VERSION_HEADER,
-      "Anthropic-Beta": ANTHROPIC_BETA_CLAUDE_OAUTH,
-      "Anthropic-Dangerous-Direct-Browser-Access": "true",
+      "anthropic-version": ANTHROPIC_VERSION_HEADER,
+      "anthropic-beta": ANTHROPIC_BETA_CLAUDE_OAUTH,
+      "anthropic-dangerous-direct-browser-access": "true",
       "User-Agent": CLAUDE_CLI_USER_AGENT,
-      "X-App": "cli",
+      "x-app": "cli",
       "X-Stainless-Helper-Method": "stream",
       "X-Stainless-Retry-Count": "0",
       "X-Stainless-Runtime-Version": CLAUDE_CLI_STAINLESS_RUNTIME_VERSION,
@@ -607,8 +607,8 @@ export const REGISTRY: Record<string, RegistryEntry> = {
     authHeader: "x-api-key",
     defaultContextLength: 200000,
     headers: {
-      "Anthropic-Version": ANTHROPIC_VERSION_HEADER,
-      "Anthropic-Beta": ANTHROPIC_BETA_API_KEY,
+      "anthropic-version": ANTHROPIC_VERSION_HEADER,
+      "anthropic-beta": ANTHROPIC_BETA_API_KEY,
     },
     models: [
       { id: "claude-haiku-4.5", name: "Claude Haiku 4.5" },
@@ -721,8 +721,8 @@ export const REGISTRY: Record<string, RegistryEntry> = {
     authType: "apikey",
     authHeader: "x-api-key",
     headers: {
-      "Anthropic-Version": ANTHROPIC_VERSION_HEADER,
-      "Anthropic-Beta": ANTHROPIC_BETA_API_KEY,
+      "anthropic-version": ANTHROPIC_VERSION_HEADER,
+      "anthropic-beta": ANTHROPIC_BETA_API_KEY,
     },
     models: [
       { id: "qwen3.5-plus", name: "Qwen3.5 Plus" },
@@ -746,8 +746,8 @@ export const REGISTRY: Record<string, RegistryEntry> = {
     authType: "apikey",
     authHeader: "x-api-key",
     headers: {
-      "Anthropic-Version": ANTHROPIC_VERSION_HEADER,
-      "Anthropic-Beta": ANTHROPIC_BETA_API_KEY,
+      "anthropic-version": ANTHROPIC_VERSION_HEADER,
+      "anthropic-beta": ANTHROPIC_BETA_API_KEY,
     },
     models: [
       { id: "glm-5", name: "GLM 5" },
@@ -878,8 +878,8 @@ export const REGISTRY: Record<string, RegistryEntry> = {
     authType: "apikey",
     authHeader: "bearer",
     headers: {
-      "Anthropic-Version": ANTHROPIC_VERSION_HEADER,
-      "Anthropic-Beta": ANTHROPIC_BETA_API_KEY,
+      "anthropic-version": ANTHROPIC_VERSION_HEADER,
+      "anthropic-beta": ANTHROPIC_BETA_API_KEY,
     },
     models: [
       // T12/T28: MiniMax default upgraded from M2.5 to M2.7
@@ -902,8 +902,8 @@ export const REGISTRY: Record<string, RegistryEntry> = {
     authType: "apikey",
     authHeader: "bearer",
     headers: {
-      "Anthropic-Version": ANTHROPIC_VERSION_HEADER,
-      "Anthropic-Beta": ANTHROPIC_BETA_API_KEY,
+      "anthropic-version": ANTHROPIC_VERSION_HEADER,
+      "anthropic-beta": ANTHROPIC_BETA_API_KEY,
     },
     models: [
       // Keep parity with minimax to ensure model discovery works for minimax-cn connections.

--- a/tests/unit/search-provider-validation.test.ts
+++ b/tests/unit/search-provider-validation.test.ts
@@ -79,7 +79,7 @@ test("kimi-coding-apikey validation uses Kimi Coding messages endpoint", async (
     assert.equal(calls[0].url, "https://api.kimi.com/coding/v1/messages");
     assert.equal(calls[0].method, "POST");
     assert.equal(calls[0].headers["x-api-key"], "sk-kimi-test");
-    assert.equal(calls[0].headers["Anthropic-Version"], "2023-06-01");
+    assert.equal(calls[0].headers["anthropic-version"], "2023-06-01");
 
     for (const call of calls) {
       assert.equal(call.url.includes("?beta=true/messages"), false);

--- a/tests/unit/t20-t22-provider-headers.test.ts
+++ b/tests/unit/t20-t22-provider-headers.test.ts
@@ -15,10 +15,10 @@ test("T20: antigravity config has updated User-Agent and sandbox fallback URL", 
 
 test("T25: anthropic API-key config includes the full Anthropic beta header set", () => {
   const anthropic = REGISTRY.anthropic;
-  assert.equal(anthropic.headers["Anthropic-Version"], "2023-06-01");
-  assert.ok(anthropic.headers["Anthropic-Beta"]?.includes("advanced-tool-use-2025-11-20"));
-  assert.ok(anthropic.headers["Anthropic-Beta"]?.includes("structured-outputs-2025-12-15"));
-  assert.ok(anthropic.headers["Anthropic-Beta"]?.includes("token-efficient-tools-2026-03-28"));
+  assert.equal(anthropic.headers["anthropic-version"], "2023-06-01");
+  assert.ok(anthropic.headers["anthropic-beta"]?.includes("advanced-tool-use-2025-11-20"));
+  assert.ok(anthropic.headers["anthropic-beta"]?.includes("structured-outputs-2025-12-15"));
+  assert.ok(anthropic.headers["anthropic-beta"]?.includes("token-efficient-tools-2026-03-28"));
 });
 
 test("T22: github headers include updated editor/plugin versions and required fields", () => {


### PR DESCRIPTION
## Summary

- Normalize all Anthropic-specific header keys in `providerRegistry.ts` from PascalCase (`"Anthropic-Version"`, `"Anthropic-Beta"`, etc.) to lowercase (`"anthropic-version"`, `"anthropic-beta"`, etc.)
- Update test assertions to match the new lowercase keys

## Problem

The provider registry uses PascalCase header keys (e.g. `"Anthropic-Version"`) while the Claude Code client path in `base.ts` (added in v3.6.9) uses lowercase keys (`"anthropic-version"`). Since JavaScript object keys are case-sensitive, both keys coexist in the headers object. When `fetch()` sends them, HTTP treats them as duplicates and concatenates the values:

```
anthropic-version: "2023-06-01, 2023-06-01"
```

This causes Anthropic's API to reject the request with a 400 error:

```json
{"error":{"message":"[400]: anthropic-version: \"2023-06-01, 2023-06-01\" is not a valid version","type":"invalid_request_error","code":"bad_request"}}
```

## Root cause

Two independent code paths setting the same HTTP header with different JS key casing:
1. `providerRegistry.ts` (v1.0.0) — `"Anthropic-Version": ANTHROPIC_VERSION_HEADER` (PascalCase)
2. `base.ts` ccHeaders (v3.6.9) — `"anthropic-version": "2023-06-01"` (lowercase)

## Test plan

- [x] `t20-t22-provider-headers.test.ts` — passes with lowercase assertions
- [x] `search-provider-validation.test.ts` — passes with lowercase assertion
- [x] Full test suite (3238 tests) — all pass