### PR TITLE
fix(sse): map Claude output_config/thinking to OpenAI reasoning_effort

### DIFF
--- a/.github/workflows/build-fork.yml
+++ b/.github/workflows/build-fork.yml
@@ -1,0 +1,41 @@
+name: Build Fork Image (ghcr.io)
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    name: Build and Push to ghcr.io
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: fix/claude-thinking-mapping
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: runner-base
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ghcr.io/inkorcloud/omniroute:fix-claude-thinking-mapping
+            ghcr.io/inkorcloud/omniroute:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/open-sse/translator/request/claude-to-gemini.ts
+++ b/open-sse/translator/request/claude-to-gemini.ts
@@ -176,11 +176,29 @@ export function claudeToGeminiRequest(model, body, stream) {
   }
 
   // ── Thinking config ────────────────────────────────────────────
+  // Priority: thinking.budget_tokens (Claude native) > output_config.effort (Claude Code).
   if (body.thinking?.type === "enabled" && body.thinking.budget_tokens) {
     result.generationConfig.thinkingConfig = {
       thinkingBudget: body.thinking.budget_tokens,
       includeThoughts: true,
     };
+  } else if (typeof body.output_config?.effort === "string") {
+    const effort = body.output_config.effort.toLowerCase();
+    const effortBudgetMap: Record<string, number> = {
+      none: 0,
+      low: 1024,
+      medium: 10240,
+      high: 32768,
+      max: 131072,
+      xhigh: 131072,
+    };
+    const budget = effortBudgetMap[effort];
+    if (budget !== undefined && budget > 0) {
+      result.generationConfig.thinkingConfig = {
+        thinkingBudget: budget,
+        includeThoughts: true,
+      };
+    }
   }
 
   const changedToolNameMap = new Map(

--- a/open-sse/translator/request/claude-to-openai.ts
+++ b/open-sse/translator/request/claude-to-openai.ts
@@ -102,6 +102,28 @@ export function claudeToOpenAIRequest(model, body, stream) {
     result.tool_choice = convertToolChoice(body.tool_choice);
   }
 
+  // Reasoning effort: map Claude-side thinking controls to OpenAI reasoning_effort.
+  // Priority: output_config.effort (Claude Code) > thinking.budget_tokens (Claude native).
+  // Budget buckets match the reverse mapping in thinkingBudget.ts::setCustomBudget.
+  const outputEffort =
+    typeof body.output_config?.effort === "string" ? body.output_config.effort.toLowerCase() : "";
+  if (outputEffort) {
+    result.reasoning_effort = outputEffort;
+  } else if (body.thinking?.type === "enabled" && typeof body.thinking.budget_tokens === "number") {
+    const budget = body.thinking.budget_tokens;
+    if (budget <= 0) {
+      // disabled — leave reasoning_effort unset
+    } else if (budget <= 1024) {
+      result.reasoning_effort = "low";
+    } else if (budget <= 10240) {
+      result.reasoning_effort = "medium";
+    } else if (budget < 131072) {
+      result.reasoning_effort = "high";
+    } else {
+      result.reasoning_effort = "max";
+    }
+  }
+
   return result;
 }
 

--- a/tests/unit/translator-claude-to-gemini.test.ts
+++ b/tests/unit/translator-claude-to-gemini.test.ts
@@ -208,3 +208,59 @@ test("Claude -> Gemini handles empty bodies without producing invalid content", 
   assert.deepEqual(result.generationConfig, {});
   assert.deepEqual(result.safetySettings, DEFAULT_SAFETY_SETTINGS);
 });
+
+test("Claude -> Gemini maps output_config.effort to thinkingConfig when thinking absent", () => {
+  const cases: Array<{ effort: string; expected: number }> = [
+    { effort: "low", expected: 1024 },
+    { effort: "medium", expected: 10240 },
+    { effort: "high", expected: 32768 },
+    { effort: "max", expected: 131072 },
+    { effort: "xhigh", expected: 131072 },
+  ];
+
+  for (const { effort, expected } of cases) {
+    const result = claudeToGeminiRequest(
+      "gemini-2.5-pro",
+      {
+        messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+        output_config: { effort },
+      },
+      false
+    );
+    assert.deepEqual(
+      result.generationConfig.thinkingConfig,
+      { thinkingBudget: expected, includeThoughts: true },
+      `effort ${effort} should map to budget ${expected}`
+    );
+  }
+});
+
+test("Claude -> Gemini prefers thinking.budget_tokens over output_config.effort", () => {
+  const result = claudeToGeminiRequest(
+    "gemini-2.5-pro",
+    {
+      messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      thinking: { type: "enabled", budget_tokens: 4096 },
+      output_config: { effort: "high" },
+    },
+    false
+  );
+
+  assert.deepEqual(result.generationConfig.thinkingConfig, {
+    thinkingBudget: 4096,
+    includeThoughts: true,
+  });
+});
+
+test("Claude -> Gemini skips thinkingConfig for output_config.effort=none", () => {
+  const result = claudeToGeminiRequest(
+    "gemini-2.5-pro",
+    {
+      messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      output_config: { effort: "none" },
+    },
+    false
+  );
+
+  assert.equal((result.generationConfig as any).thinkingConfig, undefined);
+});

--- a/tests/unit/translator-claude-to-openai.test.ts
+++ b/tests/unit/translator-claude-to-openai.test.ts
@@ -165,6 +165,92 @@ test("Claude -> OpenAI converts tool_result blocks into tool messages and preser
   });
 });
 
+test("Claude -> OpenAI maps output_config.effort to reasoning_effort", () => {
+  const result = claudeToOpenAIRequest(
+    "gpt-5",
+    {
+      messages: [{ role: "user", content: "hi" }],
+      output_config: { effort: "high" },
+    },
+    false
+  );
+
+  assert.equal(result.reasoning_effort, "high");
+});
+
+test("Claude -> OpenAI normalizes output_config.effort casing", () => {
+  const result = claudeToOpenAIRequest(
+    "gpt-5",
+    {
+      messages: [{ role: "user", content: "hi" }],
+      output_config: { effort: "MEDIUM" },
+    },
+    false
+  );
+
+  assert.equal(result.reasoning_effort, "medium");
+});
+
+test("Claude -> OpenAI prefers output_config.effort over thinking.budget_tokens", () => {
+  const result = claudeToOpenAIRequest(
+    "gpt-5",
+    {
+      messages: [{ role: "user", content: "hi" }],
+      output_config: { effort: "low" },
+      thinking: { type: "enabled", budget_tokens: 131072 },
+    },
+    false
+  );
+
+  assert.equal(result.reasoning_effort, "low");
+});
+
+test("Claude -> OpenAI maps thinking.budget_tokens to reasoning_effort buckets", () => {
+  const buckets: Array<{ budget: number; expected: string }> = [
+    { budget: 512, expected: "low" },
+    { budget: 1024, expected: "low" },
+    { budget: 8192, expected: "medium" },
+    { budget: 10240, expected: "medium" },
+    { budget: 65536, expected: "high" },
+    { budget: 131072, expected: "max" },
+  ];
+
+  for (const { budget, expected } of buckets) {
+    const result = claudeToOpenAIRequest(
+      "gpt-5",
+      {
+        messages: [{ role: "user", content: "hi" }],
+        thinking: { type: "enabled", budget_tokens: budget },
+      },
+      false
+    );
+    assert.equal(result.reasoning_effort, expected, `budget ${budget} should map to ${expected}`);
+  }
+});
+
+test("Claude -> OpenAI ignores disabled thinking and leaves reasoning_effort unset", () => {
+  const result = claudeToOpenAIRequest(
+    "gpt-5",
+    {
+      messages: [{ role: "user", content: "hi" }],
+      thinking: { type: "enabled", budget_tokens: 0 },
+    },
+    false
+  );
+
+  assert.equal(result.reasoning_effort, undefined);
+});
+
+test("Claude -> OpenAI leaves reasoning_effort unset when no thinking/output_config present", () => {
+  const result = claudeToOpenAIRequest(
+    "gpt-5",
+    { messages: [{ role: "user", content: "hi" }] },
+    false
+  );
+
+  assert.equal(result.reasoning_effort, undefined);
+});
+
 test("Claude -> OpenAI handles redacted thinking, empty arrays and unknown blocks defensively", () => {
   const result = claudeToOpenAIRequest(
     "gpt-4o",


### PR DESCRIPTION
Claude Code clients send reasoning controls via output_config.effort and native Claude clients via thinking.budget_tokens. The claude-to-openai request translator only extracted a subset of fields, causing both to be dropped before they could reach the OpenAI Responses API transformer.

- claude-to-openai: map output_config.effort (priority) or thinking.budget_tokens (bucketed into low/medium/high/max) to reasoning_effort, mirroring the reverse mapping in thinkingBudget.ts.
- claude-to-gemini: add output_config.effort fallback when thinking.budget_tokens is absent, using a budget bucket aligned with openai-to-gemini CLI (high=32768, max/xhigh=131072).
- Tests: cover priority, casing, bucket boundaries, disabled cases and absent-config for both translators.

## Summary

- Describe the user-facing or operational change.

## Related Issues

- Closes #
- Related to #

## Validation

- [ ] `npm run lint`
- [ ] `npm run test:unit`
- [ ] `npm run test:coverage`
- [ ] Coverage is still `>= 60%` for statements, lines, functions, and branches
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below

## Tests Added Or Updated

- List every changed or added automated test file.
- If no production code changed, state that here.

## Coverage Notes

- If this PR changes `src/`, `open-sse/`, `electron/`, or `bin/`, explain which tests cover the change.
- If coverage moved down in any touched file, explain why and what follow-up task will recover it.

## Reviewer Notes

- Call out any risky areas, migrations, feature flags, or manual validation that reviewers should know about.
