### PR TITLE
chore: add .tmp/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,7 @@ test-results/
 playwright-report/
 blob-report/
 cloud/
+.tmp/
 
 # Security Analysis (standalone project with own git)
 security-analysis/


### PR DESCRIPTION
## Summary

- Add `.tmp/` to `.gitignore` under the Playwright section
- Playwright E2E tests create browser user-data directories under `.tmp/playwright-data/` at runtime (numbered subdirs = browser process IDs)
- The folder was untracked but not ignored, causing it to appear as noise in `git status`

## Test plan

- [ ] Run `git status` after Playwright E2E tests — `.tmp/` should no longer appear as untracked
- [ ] Confirm no existing tracked files under `.tmp/` are affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)