### PR TITLE
fix(resilience): route 429 cooldowns through settings

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -71,12 +71,7 @@ import {
 import { getCacheMetrics } from "@/lib/db/settings.ts";
 import { getCachedSettings } from "@/lib/db/readCache";
 
-import {
-  parseCodexQuotaHeaders,
-  getCodexResetTime,
-  getCodexModelScope,
-  getCodexDualWindowCooldownMs,
-} from "../executors/codex.ts";
+import { parseCodexQuotaHeaders, getCodexModelScope } from "../executors/codex.ts";
 import { invalidateCodexQuotaCache } from "../services/codexQuotaFetcher.ts";
 import { translateNonStreamingResponse } from "./responseTranslator.ts";
 import { extractUsageFromResponse } from "./usageExtractor.ts";
@@ -824,31 +819,7 @@ export async function handleChatCore({
         codexQuotaState: quotaState,
       };
 
-      // T03/T09: on 429, persist exact reset time per scope to avoid global over-blocking.
-      // Item 3: Use dual-window cooldown to distinguish 5h vs 7d exhaustion.
       if (status === 429) {
-        const { cooldownMs, window: exhaustedWindow } = getCodexDualWindowCooldownMs(quota);
-        if (cooldownMs > 0) {
-          const scopeUntil = new Date(Date.now() + cooldownMs).toISOString();
-          const scopeMapRaw =
-            existingProviderData &&
-            typeof existingProviderData === "object" &&
-            existingProviderData.codexScopeRateLimitedUntil &&
-            typeof existingProviderData.codexScopeRateLimitedUntil === "object"
-              ? existingProviderData.codexScopeRateLimitedUntil
-              : {};
-
-          nextProviderData.codexScopeRateLimitedUntil = {
-            ...(scopeMapRaw as Record<string, unknown>),
-            [scope]: scopeUntil,
-          };
-          nextProviderData.codexExhaustedWindow = exhaustedWindow;
-          log?.debug?.(
-            "CODEX",
-            `Quota exhaustion on ${exhaustedWindow} window, cooldown until ${scopeUntil}`
-          );
-        }
-
         // Invalidate the preflight cache for this connection so the next
         // isModelAvailable check fetches fresh quota data.
         if (connectionId) {
@@ -2306,46 +2277,11 @@ export async function handleChatCore({
             `[provider] Node ${connectionId} account deactivated (${statusCode}) — disabling permanently`
           );
         } else if (errorType === PROVIDER_ERROR_TYPES.RATE_LIMITED) {
-          // For providers with per-model quotas (passthrough providers, Gemini),
-          // each model has independent quota. A 429 on one model must NOT lock out
-          // the entire connection — other models may still have quota available.
-          const rateLimitCooldownMs = retryAfterMs || COOLDOWN_MS.rateLimit;
-          const accountSemaphoreKey = resolveAccountSemaphoreKey({
-            provider,
-            model: currentModel,
-            connectionId,
-            credentials,
+          await updateProviderConnection(connectionId, {
+            lastErrorType: errorType,
+            lastError: message,
+            errorCode: statusCode,
           });
-          if (accountSemaphoreKey) {
-            markAccountSemaphoreBlocked(accountSemaphoreKey, rateLimitCooldownMs);
-          }
-          if (
-            lockModelIfPerModelQuota(
-              provider,
-              connectionId,
-              model,
-              "rate_limited",
-              rateLimitCooldownMs
-            )
-          ) {
-            console.warn(
-              `[provider] Node ${connectionId} model-only rate limited (${statusCode}) for ${model} - ${Math.ceil(rateLimitCooldownMs / 1000)}s (connection stays active)`
-            );
-          } else {
-            const rateLimitedUntil = new Date(Date.now() + rateLimitCooldownMs).toISOString();
-            await updateProviderConnection(connectionId, {
-              rateLimitedUntil: rateLimitedUntil,
-              testStatus: "unavailable",
-              lastErrorType: errorType,
-              lastError: message,
-              errorCode: statusCode,
-              healthCheckInterval: null,
-              lastHealthCheckAt: null,
-            });
-            console.warn(
-              `[provider] Node ${connectionId} rate limited (${statusCode}) - Next available at ${rateLimitedUntil}`
-            );
-          }
         } else if (errorType === PROVIDER_ERROR_TYPES.QUOTA_EXHAUSTED) {
           // Providers with per-model quotas — lock the model only, not the connection
           const quotaCooldownMs = retryAfterMs || COOLDOWN_MS.rateLimit;

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -71,7 +71,11 @@ import {
 import { getCacheMetrics } from "@/lib/db/settings.ts";
 import { getCachedSettings } from "@/lib/db/readCache";
 
-import { parseCodexQuotaHeaders, getCodexModelScope } from "../executors/codex.ts";
+import {
+  parseCodexQuotaHeaders,
+  getCodexModelScope,
+  getCodexDualWindowCooldownMs,
+} from "../executors/codex.ts";
 import { invalidateCodexQuotaCache } from "../services/codexQuotaFetcher.ts";
 import { translateNonStreamingResponse } from "./responseTranslator.ts";
 import { extractUsageFromResponse } from "./usageExtractor.ts";
@@ -819,7 +823,31 @@ export async function handleChatCore({
         codexQuotaState: quotaState,
       };
 
+      // T03/T09: on 429, persist exact reset time per scope to avoid global over-blocking.
+      // Use dual-window cooldown to distinguish short-term and weekly Codex exhaustion.
       if (status === 429) {
+        const { cooldownMs, window: exhaustedWindow } = getCodexDualWindowCooldownMs(quota);
+        if (cooldownMs > 0) {
+          const scopeUntil = new Date(Date.now() + cooldownMs).toISOString();
+          const scopeMapRaw =
+            existingProviderData &&
+            typeof existingProviderData === "object" &&
+            existingProviderData.codexScopeRateLimitedUntil &&
+            typeof existingProviderData.codexScopeRateLimitedUntil === "object"
+              ? existingProviderData.codexScopeRateLimitedUntil
+              : {};
+
+          nextProviderData.codexScopeRateLimitedUntil = {
+            ...(scopeMapRaw as Record<string, unknown>),
+            [scope]: scopeUntil,
+          };
+          nextProviderData.codexExhaustedWindow = exhaustedWindow;
+          log?.debug?.(
+            "CODEX",
+            `Quota exhaustion on ${exhaustedWindow} window, cooldown until ${scopeUntil}`
+          );
+        }
+
         // Invalidate the preflight cache for this connection so the next
         // isModelAvailable check fetches fresh quota data.
         if (connectionId) {
@@ -2251,7 +2279,7 @@ export async function handleChatCore({
     }
 
     // T06/T10/T36: classify provider errors and persist terminal account states.
-    const errorType = classifyProviderError(statusCode, message);
+    const errorType = classifyProviderError(statusCode, message, provider);
     if (connectionId && errorType) {
       try {
         if (errorType === PROVIDER_ERROR_TYPES.FORBIDDEN) {
@@ -2276,12 +2304,6 @@ export async function handleChatCore({
           console.warn(
             `[provider] Node ${connectionId} account deactivated (${statusCode}) — disabling permanently`
           );
-        } else if (errorType === PROVIDER_ERROR_TYPES.RATE_LIMITED) {
-          await updateProviderConnection(connectionId, {
-            lastErrorType: errorType,
-            lastError: message,
-            errorCode: statusCode,
-          });
         } else if (errorType === PROVIDER_ERROR_TYPES.QUOTA_EXHAUSTED) {
           // Providers with per-model quotas — lock the model only, not the connection
           const quotaCooldownMs = retryAfterMs || COOLDOWN_MS.rateLimit;

--- a/open-sse/services/accountFallback.ts
+++ b/open-sse/services/accountFallback.ts
@@ -10,6 +10,7 @@ import {
   calculateBackoffCooldown,
   findMatchingErrorRule,
   matchErrorRuleByText,
+  matchErrorRuleByStatus,
 } from "../config/errorConfig.ts";
 import { getPassthroughProviders, getProviderCategory } from "../config/providerRegistry.ts";
 import {
@@ -196,6 +197,11 @@ function buildProviderProfile(
 export function getProviderProfile(provider) {
   const category = getProviderCategory(provider);
   return buildProviderProfile(category);
+}
+
+function shouldPreserveQuotaSignalsFor429(provider: string | null | undefined): boolean {
+  if (!provider) return true;
+  return getProviderCategory(provider) === "oauth";
 }
 
 export async function getRuntimeProviderProfile(provider: string | null | undefined) {
@@ -930,6 +936,8 @@ export function checkFallbackError(
   }
 
   const isRateLimitStatus = status === HTTP_STATUS.RATE_LIMITED;
+  const preserveQuota429 = shouldPreserveQuotaSignalsFor429(provider);
+  const shouldUseQuotaSignal = !isRateLimitStatus || preserveQuota429;
 
   // Check error message FIRST - specific patterns take priority over status codes
   if (errorText) {
@@ -944,7 +952,7 @@ export function checkFallbackError(
     }
 
     // T10 (sub2api #1169): Credits/quota exhausted — long cooldown, distinct from rate limit
-    if (!isRateLimitStatus && isCreditsExhausted(errorStr)) {
+    if (shouldUseQuotaSignal && isCreditsExhausted(errorStr)) {
       return {
         shouldFallback: true,
         cooldownMs: COOLDOWN_MS.paymentRequired ?? 3600 * 1000, // 1h cooldown
@@ -954,7 +962,7 @@ export function checkFallbackError(
     }
 
     // Daily quota exhausted — lock model until tomorrow
-    if (!isRateLimitStatus && isDailyQuotaExhausted(errorStr)) {
+    if (shouldUseQuotaSignal && isDailyQuotaExhausted(errorStr)) {
       const msUntilTomorrow = getMsUntilTomorrow();
       // Cap at 24 hours to handle timezone edge cases
       const cooldownMs = Math.min(msUntilTomorrow, 24 * 60 * 60 * 1000);
@@ -967,7 +975,10 @@ export function checkFallbackError(
     }
   }
 
-  const configuredRule = findMatchingErrorRule(status, errorStr);
+  const configuredRule =
+    isRateLimitStatus && !preserveQuota429
+      ? matchErrorRuleByStatus(status)
+      : findMatchingErrorRule(status, errorStr);
   if (configuredRule) {
     if (configuredRule.backoff) {
       return buildRetryableFallback(configuredRule.reason ?? classifyError(status, errorStr));

--- a/open-sse/services/accountFallback.ts
+++ b/open-sse/services/accountFallback.ts
@@ -929,6 +929,8 @@ export function checkFallbackError(
     };
   }
 
+  const isRateLimitStatus = status === HTTP_STATUS.RATE_LIMITED;
+
   // Check error message FIRST - specific patterns take priority over status codes
   if (errorText) {
     // T06 (sub2api #1037): Permanent account deactivation — do NOT retry, mark as permanent failure
@@ -942,7 +944,7 @@ export function checkFallbackError(
     }
 
     // T10 (sub2api #1169): Credits/quota exhausted — long cooldown, distinct from rate limit
-    if (isCreditsExhausted(errorStr)) {
+    if (!isRateLimitStatus && isCreditsExhausted(errorStr)) {
       return {
         shouldFallback: true,
         cooldownMs: COOLDOWN_MS.paymentRequired ?? 3600 * 1000, // 1h cooldown
@@ -952,7 +954,7 @@ export function checkFallbackError(
     }
 
     // Daily quota exhausted — lock model until tomorrow
-    if (isDailyQuotaExhausted(errorStr)) {
+    if (!isRateLimitStatus && isDailyQuotaExhausted(errorStr)) {
       const msUntilTomorrow = getMsUntilTomorrow();
       // Cap at 24 hours to handle timezone edge cases
       const cooldownMs = Math.min(msUntilTomorrow, 24 * 60 * 60 * 1000);

--- a/open-sse/services/errorClassifier.ts
+++ b/open-sse/services/errorClassifier.ts
@@ -4,6 +4,7 @@ import {
   isDailyQuotaExhausted,
   isOAuthInvalidToken,
 } from "./accountFallback.ts";
+import { getProviderCategory } from "../config/providerRegistry.ts";
 
 export function isEmptyContentResponse(responseBody: unknown): boolean {
   if (!responseBody || typeof responseBody !== "object") return false;
@@ -91,20 +92,38 @@ function responseBodyToString(responseBody: unknown): string {
   return "";
 }
 
-export function classifyProviderError(statusCode: number, responseBody: unknown): string | null {
+function shouldPreserveQuotaSignalsFor429(provider?: string | null): boolean {
+  if (!provider) return true;
+  return getProviderCategory(provider) === "oauth";
+}
+
+export function classifyProviderError(
+  statusCode: number,
+  responseBody: unknown,
+  provider?: string | null
+): string | null {
   const bodyStr = responseBodyToString(responseBody);
   const creditsExhausted = isCreditsExhausted(bodyStr);
   const accountDeactivated = isAccountDeactivated(bodyStr);
   const oauthInvalid = isOAuthInvalidToken(bodyStr);
-
-  // 429 is a retryable rate-limit signal. Cooldown duration and upstream retry hints are
-  // resolved by the resilience-aware fallback layer.
-  if (statusCode === 429) {
-    return PROVIDER_ERROR_TYPES.RATE_LIMITED;
-  }
+  const preserveQuota429 = shouldPreserveQuotaSignalsFor429(provider);
 
   if (creditsExhausted && [400, 402, 403].includes(statusCode)) {
     return PROVIDER_ERROR_TYPES.QUOTA_EXHAUSTED;
+  }
+
+  if (creditsExhausted && statusCode === 429 && preserveQuota429) {
+    return PROVIDER_ERROR_TYPES.QUOTA_EXHAUSTED;
+  }
+
+  // API-key providers route 429 cooldowns through the resilience-aware fallback layer.
+  // OAuth providers keep their existing quota semantics because some of them encode
+  // longer quota windows as 429 responses.
+  if (statusCode === 429) {
+    if (preserveQuota429 && isDailyQuotaExhausted(bodyStr)) {
+      return PROVIDER_ERROR_TYPES.QUOTA_EXHAUSTED;
+    }
+    return PROVIDER_ERROR_TYPES.RATE_LIMITED;
   }
 
   if (statusCode === 401) {

--- a/open-sse/services/errorClassifier.ts
+++ b/open-sse/services/errorClassifier.ts
@@ -97,16 +97,14 @@ export function classifyProviderError(statusCode: number, responseBody: unknown)
   const accountDeactivated = isAccountDeactivated(bodyStr);
   const oauthInvalid = isOAuthInvalidToken(bodyStr);
 
-  if (creditsExhausted && [400, 402, 403, 429].includes(statusCode)) {
-    return PROVIDER_ERROR_TYPES.QUOTA_EXHAUSTED;
+  // 429 is a retryable rate-limit signal. Cooldown duration and upstream retry hints are
+  // resolved by the resilience-aware fallback layer.
+  if (statusCode === 429) {
+    return PROVIDER_ERROR_TYPES.RATE_LIMITED;
   }
 
-  // 429: Check if it's a daily quota exhaustion (lock until tomorrow) vs regular rate limit
-  if (statusCode === 429) {
-    if (isDailyQuotaExhausted(bodyStr)) {
-      return PROVIDER_ERROR_TYPES.QUOTA_EXHAUSTED;
-    }
-    return PROVIDER_ERROR_TYPES.RATE_LIMITED;
+  if (creditsExhausted && [400, 402, 403].includes(statusCode)) {
+    return PROVIDER_ERROR_TYPES.QUOTA_EXHAUSTED;
   }
 
   if (statusCode === 401) {

--- a/src/sse/services/auth.ts
+++ b/src/sse/services/auth.ts
@@ -1267,7 +1267,7 @@ export async function markAccountUnavailable(
     const result = fallbackResult;
     const { shouldFallback, cooldownMs: rawCooldownMs, newBackoffLevel, reason } = result;
     if (!shouldFallback) return { shouldFallback: false, cooldownMs: 0 };
-    const providerErrorType = classifyProviderError(status, errorText);
+    const providerErrorType = classifyProviderError(status, errorText, provider);
     const terminalStatus = resolveTerminalConnectionStatus(status, result, providerErrorType);
     const cooldownMs = terminalStatus ? 0 : rawCooldownMs;
 

--- a/tests/unit/account-fallback-service.test.ts
+++ b/tests/unit/account-fallback-service.test.ts
@@ -73,7 +73,7 @@ test("checkFallbackError treats non-429 exhausted credits as long quota cooldown
   assert.equal(result.cooldownMs, COOLDOWN_MS.paymentRequired ?? 3600 * 1000);
 });
 
-test("checkFallbackError keeps 429 exhausted-credit text on the resilience cooldown path", () => {
+test("checkFallbackError keeps API-key 429 exhausted-credit text on the resilience cooldown path", () => {
   const result = checkFallbackError(429, "credit_balance_too_low", 0, null, "openai", null, {
     baseCooldownMs: 125,
     useUpstreamRetryHints: false,
@@ -85,6 +85,35 @@ test("checkFallbackError keeps 429 exhausted-credit text on the resilience coold
   assert.equal(result.shouldFallback, true);
   assert.equal(result.reason, RateLimitReason.RATE_LIMIT_EXCEEDED);
   assert.equal(result.creditsExhausted, undefined);
+  assert.equal(result.cooldownMs, 125);
+});
+
+test("checkFallbackError preserves OAuth 429 exhausted-credit semantics", () => {
+  const result = checkFallbackError(429, "credit_balance_too_low", 0, null, "codex", null, {
+    baseCooldownMs: 125,
+    useUpstreamRetryHints: false,
+    maxBackoffSteps: 3,
+    failureThreshold: 60,
+    resetTimeoutMs: 5000,
+  });
+
+  assert.equal(result.shouldFallback, true);
+  assert.equal(result.reason, RateLimitReason.QUOTA_EXHAUSTED);
+  assert.equal(result.creditsExhausted, true);
+  assert.equal(result.cooldownMs, COOLDOWN_MS.paymentRequired ?? 3600 * 1000);
+});
+
+test("checkFallbackError keeps API-key 429 quota text on the status-based resilience path", () => {
+  const result = checkFallbackError(429, "quota exceeded", 0, null, "openai", null, {
+    baseCooldownMs: 125,
+    useUpstreamRetryHints: false,
+    maxBackoffSteps: 3,
+    failureThreshold: 60,
+    resetTimeoutMs: 5000,
+  });
+
+  assert.equal(result.shouldFallback, true);
+  assert.equal(result.reason, RateLimitReason.RATE_LIMIT_EXCEEDED);
   assert.equal(result.cooldownMs, 125);
 });
 
@@ -495,7 +524,7 @@ test("checkFallbackError locks model until tomorrow for non-429 daily quota exha
   assert.ok(result.cooldownMs <= 24 * 60 * 60 * 1000, "cooldown should be <= 24 hours");
 });
 
-test("checkFallbackError routes 429 'try again tomorrow' through resilience cooldown", () => {
+test("checkFallbackError routes API-key 429 'try again tomorrow' through resilience cooldown", () => {
   const result = checkFallbackError(429, "Please try again tomorrow", 0, null, "openai", null, {
     baseCooldownMs: 125,
     useUpstreamRetryHints: false,
@@ -508,7 +537,7 @@ test("checkFallbackError routes 429 'try again tomorrow' through resilience cool
   assert.equal(result.cooldownMs, 125);
 });
 
-test("checkFallbackError routes 429 'daily quota' text through resilience cooldown", () => {
+test("checkFallbackError routes API-key 429 'daily quota' text through resilience cooldown", () => {
   const result = checkFallbackError(
     429,
     "You have exceeded your daily quota",
@@ -527,4 +556,27 @@ test("checkFallbackError routes 429 'daily quota' text through resilience cooldo
   assert.equal(result.shouldFallback, true);
   assert.equal(result.dailyQuotaExhausted, undefined);
   assert.equal(result.cooldownMs, 125);
+});
+
+test("checkFallbackError preserves OAuth 429 daily quota semantics", () => {
+  const result = checkFallbackError(
+    429,
+    "You have exceeded your daily quota",
+    0,
+    null,
+    "codex",
+    null,
+    {
+      baseCooldownMs: 125,
+      useUpstreamRetryHints: false,
+      maxBackoffSteps: 3,
+      failureThreshold: 60,
+      resetTimeoutMs: 5000,
+    }
+  );
+
+  assert.equal(result.shouldFallback, true);
+  assert.equal(result.reason, RateLimitReason.QUOTA_EXHAUSTED);
+  assert.equal(result.dailyQuotaExhausted, true);
+  assert.ok(result.cooldownMs > 0);
 });

--- a/tests/unit/account-fallback-service.test.ts
+++ b/tests/unit/account-fallback-service.test.ts
@@ -65,12 +65,27 @@ test("checkFallbackError marks deactivated accounts as permanent auth failures",
   assert.ok(result.cooldownMs >= 300 * 24 * 60 * 60 * 1000);
 });
 
-test("checkFallbackError treats exhausted credits as long quota cooldowns", () => {
-  const result = checkFallbackError(429, "credit_balance_too_low");
+test("checkFallbackError treats non-429 exhausted credits as long quota cooldowns", () => {
+  const result = checkFallbackError(402, "credit_balance_too_low");
   assert.equal(result.shouldFallback, true);
   assert.equal(result.reason, RateLimitReason.QUOTA_EXHAUSTED);
   assert.equal(result.creditsExhausted, true);
   assert.equal(result.cooldownMs, COOLDOWN_MS.paymentRequired ?? 3600 * 1000);
+});
+
+test("checkFallbackError keeps 429 exhausted-credit text on the resilience cooldown path", () => {
+  const result = checkFallbackError(429, "credit_balance_too_low", 0, null, "openai", null, {
+    baseCooldownMs: 125,
+    useUpstreamRetryHints: false,
+    maxBackoffSteps: 3,
+    failureThreshold: 60,
+    resetTimeoutMs: 5000,
+  });
+
+  assert.equal(result.shouldFallback, true);
+  assert.equal(result.reason, RateLimitReason.RATE_LIMIT_EXCEEDED);
+  assert.equal(result.creditsExhausted, undefined);
+  assert.equal(result.cooldownMs, 125);
 });
 
 test("checkFallbackError honors Retry-After header for rate limits", () => {
@@ -468,9 +483,9 @@ test("getMsUntilTomorrow returns positive value less than 24 hours", () => {
   assert.ok(ms <= 24 * 60 * 60 * 1000, "should be <= 24 hours");
 });
 
-test("checkFallbackError locks model until tomorrow for daily quota exhaustion", () => {
+test("checkFallbackError locks model until tomorrow for non-429 daily quota exhaustion", () => {
   const result = checkFallbackError(
-    429,
+    402,
     "You have exceeded today's quota for model moonshotai/Kimi-K2.5, please try again tomorrow"
   );
   assert.equal(result.shouldFallback, true);
@@ -480,14 +495,36 @@ test("checkFallbackError locks model until tomorrow for daily quota exhaustion",
   assert.ok(result.cooldownMs <= 24 * 60 * 60 * 1000, "cooldown should be <= 24 hours");
 });
 
-test("checkFallbackError detects daily quota with 'try again tomorrow'", () => {
-  const result = checkFallbackError(429, "Please try again tomorrow");
+test("checkFallbackError routes 429 'try again tomorrow' through resilience cooldown", () => {
+  const result = checkFallbackError(429, "Please try again tomorrow", 0, null, "openai", null, {
+    baseCooldownMs: 125,
+    useUpstreamRetryHints: false,
+    maxBackoffSteps: 3,
+    failureThreshold: 60,
+    resetTimeoutMs: 5000,
+  });
   assert.equal(result.shouldFallback, true);
-  assert.equal(result.dailyQuotaExhausted, true);
+  assert.equal(result.dailyQuotaExhausted, undefined);
+  assert.equal(result.cooldownMs, 125);
 });
 
-test("checkFallbackError detects daily quota with 'daily quota'", () => {
-  const result = checkFallbackError(429, "You have exceeded your daily quota");
+test("checkFallbackError routes 429 'daily quota' text through resilience cooldown", () => {
+  const result = checkFallbackError(
+    429,
+    "You have exceeded your daily quota",
+    0,
+    null,
+    "openai",
+    null,
+    {
+      baseCooldownMs: 125,
+      useUpstreamRetryHints: false,
+      maxBackoffSteps: 3,
+      failureThreshold: 60,
+      resetTimeoutMs: 5000,
+    }
+  );
   assert.equal(result.shouldFallback, true);
-  assert.equal(result.dailyQuotaExhausted, true);
+  assert.equal(result.dailyQuotaExhausted, undefined);
+  assert.equal(result.cooldownMs, 125);
 });

--- a/tests/unit/chatcore-translation-paths.test.ts
+++ b/tests/unit/chatcore-translation-paths.test.ts
@@ -10,6 +10,7 @@ process.env.DATA_DIR = TEST_DATA_DIR;
 const core = await import("../../src/lib/db/core.ts");
 const providersDb = await import("../../src/lib/db/providers.ts");
 const settingsDb = await import("../../src/lib/db/settings.ts");
+const auth = await import("../../src/sse/services/auth.ts");
 const upstreamProxyDb = await import("../../src/lib/db/upstreamProxy.ts");
 const { invalidateCacheControlSettingsCache } =
   await import("../../src/lib/cacheControlSettings.ts");
@@ -1447,7 +1448,7 @@ test("chatCore does not inject fallback user for Qwen API key requests", async (
   assert.equal("user" in call.body, false);
 });
 
-test("chatCore persists Codex quota headers and scope cooldown on 429 responses", async () => {
+test("chatCore persists Codex quota headers without pre-writing 429 scope cooldowns", async () => {
   const connection = await providersDb.createProviderConnection({
     provider: "codex",
     authType: "oauth",
@@ -1494,11 +1495,69 @@ test("chatCore persists Codex quota headers and scope cooldown on 429 responses"
   assert.equal(result.status, 429);
   assert.equal((updated as any).providerSpecificData.codexQuotaState.limit5h, 100);
   assert.equal((updated as any).providerSpecificData.codexQuotaState.scope, "codex");
-  assert.equal(
-    typeof (updated as any).providerSpecificData.codexScopeRateLimitedUntil.codex,
-    "string"
+  assert.equal((updated as any).providerSpecificData.codexScopeRateLimitedUntil, undefined);
+  assert.equal((updated as any).providerSpecificData.codexExhaustedWindow, undefined);
+});
+
+test("chatCore 429 lets account fallback apply the configured resilience cooldown", async () => {
+  await settingsDb.updateSettings({
+    resilienceSettings: {
+      connectionCooldown: {
+        apikey: {
+          baseCooldownMs: 125,
+          useUpstreamRetryHints: false,
+          maxBackoffSteps: 3,
+        },
+      },
+    },
+  });
+
+  const connection = await providersDb.createProviderConnection({
+    provider: "openai",
+    authType: "apikey",
+    name: "resilience-429",
+    apiKey: "sk-resilience-429",
+    isActive: true,
+    providerSpecificData: {},
+  });
+
+  const { result } = await invokeChatCore({
+    provider: "openai",
+    model: "gpt-4o-mini",
+    connectionId: connection.id,
+    body: {
+      model: "gpt-4o-mini",
+      stream: false,
+      messages: [{ role: "user", content: "rate limit me" }],
+    },
+    responseFactory() {
+      return new Response(JSON.stringify({ error: { message: "too many requests" } }), {
+        status: 429,
+        headers: { "Content-Type": "application/json" },
+      });
+    },
+  });
+
+  const afterCore = await providersDb.getProviderConnectionById((connection as any).id);
+  assert.equal(result.success, false);
+  assert.equal(result.status, 429);
+  assert.equal((afterCore as any).rateLimitedUntil, undefined);
+
+  const fallback = await auth.markAccountUnavailable(
+    (connection as any).id,
+    result.status,
+    result.error,
+    "openai",
+    "gpt-4o-mini"
   );
-  (assert as any).equal((updated.providerSpecificData as any).codexExhaustedWindow, "5h");
+  const afterFallback = await providersDb.getProviderConnectionById((connection as any).id);
+  const cooldownRemaining =
+    new Date((afterFallback as any).rateLimitedUntil).getTime() - Date.now();
+
+  assert.equal(fallback.shouldFallback, true);
+  assert.equal(fallback.cooldownMs, 125);
+  assert.equal((afterFallback as any).testStatus, "unavailable");
+  assert.ok(cooldownRemaining > 0 && cooldownRemaining < 2_000);
 });
 
 test("chatCore falls back to the next family model when the requested model is unavailable", async () => {

--- a/tests/unit/chatcore-translation-paths.test.ts
+++ b/tests/unit/chatcore-translation-paths.test.ts
@@ -1448,7 +1448,7 @@ test("chatCore does not inject fallback user for Qwen API key requests", async (
   assert.equal("user" in call.body, false);
 });
 
-test("chatCore persists Codex quota headers without pre-writing 429 scope cooldowns", async () => {
+test("chatCore preserves Codex dual-window scope cooldowns on 429 responses", async () => {
   const connection = await providersDb.createProviderConnection({
     provider: "codex",
     authType: "oauth",
@@ -1495,8 +1495,11 @@ test("chatCore persists Codex quota headers without pre-writing 429 scope cooldo
   assert.equal(result.status, 429);
   assert.equal((updated as any).providerSpecificData.codexQuotaState.limit5h, 100);
   assert.equal((updated as any).providerSpecificData.codexQuotaState.scope, "codex");
-  assert.equal((updated as any).providerSpecificData.codexScopeRateLimitedUntil, undefined);
-  assert.equal((updated as any).providerSpecificData.codexExhaustedWindow, undefined);
+  assert.equal(
+    typeof (updated as any).providerSpecificData.codexScopeRateLimitedUntil.codex,
+    "string"
+  );
+  assert.equal((updated as any).providerSpecificData.codexExhaustedWindow, "5h");
 });
 
 test("chatCore 429 lets account fallback apply the configured resilience cooldown", async () => {
@@ -1504,7 +1507,7 @@ test("chatCore 429 lets account fallback apply the configured resilience cooldow
     resilienceSettings: {
       connectionCooldown: {
         apikey: {
-          baseCooldownMs: 125,
+          baseCooldownMs: 1000,
           useUpstreamRetryHints: false,
           maxBackoffSteps: 3,
         },
@@ -1555,9 +1558,9 @@ test("chatCore 429 lets account fallback apply the configured resilience cooldow
     new Date((afterFallback as any).rateLimitedUntil).getTime() - Date.now();
 
   assert.equal(fallback.shouldFallback, true);
-  assert.equal(fallback.cooldownMs, 125);
+  assert.equal(fallback.cooldownMs, 1000);
   assert.equal((afterFallback as any).testStatus, "unavailable");
-  assert.ok(cooldownRemaining > 0 && cooldownRemaining < 2_000);
+  assert.ok(cooldownRemaining > 0 && cooldownRemaining <= 2_000);
 });
 
 test("chatCore falls back to the next family model when the requested model is unavailable", async () => {

--- a/tests/unit/error-classifier.test.ts
+++ b/tests/unit/error-classifier.test.ts
@@ -34,11 +34,33 @@ test("classifyProviderError: 429 without billing signal => RATE_LIMITED", () => 
   assert.equal(result, PROVIDER_ERROR_TYPES.RATE_LIMITED);
 });
 
-test("classifyProviderError: 429 with billing signal => RATE_LIMITED", () => {
+test("classifyProviderError: 429 with billing signal and no provider keeps legacy QUOTA_EXHAUSTED", () => {
   const result = classifyProviderError(429, {
     error: { message: "insufficient_quota: exceeded your current quota" },
   });
+  assert.equal(result, PROVIDER_ERROR_TYPES.QUOTA_EXHAUSTED);
+});
+
+test("classifyProviderError: API-key provider 429 with billing signal => RATE_LIMITED", () => {
+  const result = classifyProviderError(
+    429,
+    {
+      error: { message: "insufficient_quota: exceeded your current quota" },
+    },
+    "openai"
+  );
   assert.equal(result, PROVIDER_ERROR_TYPES.RATE_LIMITED);
+});
+
+test("classifyProviderError: OAuth provider 429 with billing signal => QUOTA_EXHAUSTED", () => {
+  const result = classifyProviderError(
+    429,
+    {
+      error: { message: "insufficient_quota: exceeded your current quota" },
+    },
+    "codex"
+  );
+  assert.equal(result, PROVIDER_ERROR_TYPES.QUOTA_EXHAUSTED);
 });
 
 test("classifyProviderError: 403 with 'has not been used in project' => PROJECT_ROUTE_ERROR (transient)", () => {
@@ -66,20 +88,24 @@ test("classifyProviderError: 403 with project string as plain string body => PRO
   assert.equal(result, PROVIDER_ERROR_TYPES.PROJECT_ROUTE_ERROR);
 });
 
-test("classifyProviderError: 429 with daily quota signal => RATE_LIMITED", () => {
+test("classifyProviderError: API-key provider 429 with daily quota signal => RATE_LIMITED", () => {
   const body = JSON.stringify({
     error: {
       message:
         "You have exceeded today's quota for model moonshotai/Kimi-K2.5, please try again tomorrow",
     },
   });
-  const result = classifyProviderError(429, body);
+  const result = classifyProviderError(429, body, "openai");
   assert.equal(result, PROVIDER_ERROR_TYPES.RATE_LIMITED);
 });
 
-test("classifyProviderError: 429 with 'daily quota' signal => RATE_LIMITED", () => {
-  const result = classifyProviderError(429, {
-    error: { message: "You have reached your daily quota limit" },
-  });
-  assert.equal(result, PROVIDER_ERROR_TYPES.RATE_LIMITED);
+test("classifyProviderError: OAuth provider 429 with daily quota signal => QUOTA_EXHAUSTED", () => {
+  const result = classifyProviderError(
+    429,
+    {
+      error: { message: "You have reached your daily quota limit" },
+    },
+    "codex"
+  );
+  assert.equal(result, PROVIDER_ERROR_TYPES.QUOTA_EXHAUSTED);
 });

--- a/tests/unit/error-classifier.test.ts
+++ b/tests/unit/error-classifier.test.ts
@@ -34,11 +34,11 @@ test("classifyProviderError: 429 without billing signal => RATE_LIMITED", () => 
   assert.equal(result, PROVIDER_ERROR_TYPES.RATE_LIMITED);
 });
 
-test("classifyProviderError: 429 with billing signal => QUOTA_EXHAUSTED", () => {
+test("classifyProviderError: 429 with billing signal => RATE_LIMITED", () => {
   const result = classifyProviderError(429, {
     error: { message: "insufficient_quota: exceeded your current quota" },
   });
-  assert.equal(result, PROVIDER_ERROR_TYPES.QUOTA_EXHAUSTED);
+  assert.equal(result, PROVIDER_ERROR_TYPES.RATE_LIMITED);
 });
 
 test("classifyProviderError: 403 with 'has not been used in project' => PROJECT_ROUTE_ERROR (transient)", () => {
@@ -66,7 +66,7 @@ test("classifyProviderError: 403 with project string as plain string body => PRO
   assert.equal(result, PROVIDER_ERROR_TYPES.PROJECT_ROUTE_ERROR);
 });
 
-test("classifyProviderError: 429 with daily quota signal => QUOTA_EXHAUSTED", () => {
+test("classifyProviderError: 429 with daily quota signal => RATE_LIMITED", () => {
   const body = JSON.stringify({
     error: {
       message:
@@ -74,12 +74,12 @@ test("classifyProviderError: 429 with daily quota signal => QUOTA_EXHAUSTED", ()
     },
   });
   const result = classifyProviderError(429, body);
-  assert.equal(result, PROVIDER_ERROR_TYPES.QUOTA_EXHAUSTED);
+  assert.equal(result, PROVIDER_ERROR_TYPES.RATE_LIMITED);
 });
 
-test("classifyProviderError: 429 with 'daily quota' signal => QUOTA_EXHAUSTED", () => {
+test("classifyProviderError: 429 with 'daily quota' signal => RATE_LIMITED", () => {
   const result = classifyProviderError(429, {
     error: { message: "You have reached your daily quota limit" },
   });
-  assert.equal(result, PROVIDER_ERROR_TYPES.QUOTA_EXHAUSTED);
+  assert.equal(result, PROVIDER_ERROR_TYPES.RATE_LIMITED);
 });


### PR DESCRIPTION
## Summary

- Route API-key provider HTTP 429 responses through the configured Resilience status rule, even when the upstream body contains quota, billing, or daily-limit wording.
- Preserve the existing OAuth 429 behavior, including Codex scope-specific dual-window cooldowns and OAuth quota/billing signals.
- Keep 429 out of the provider-level breaker path and let the account/model fallback layer own the cooldown state.

## Impact

Third-party/API-key providers now respect the Resilience page settings for 429 cooldowns instead of being promoted to hard quota exhaustion based on response text. OAuth providers keep their existing special handling so Codex and similar integrations can continue using provider-specific quota windows.

## Validation

- `npx prettier --write open-sse/services/errorClassifier.ts open-sse/services/accountFallback.ts open-sse/handlers/chatCore.ts src/sse/services/auth.ts tests/unit/error-classifier.test.ts tests/unit/account-fallback-service.test.ts tests/unit/chatcore-translation-paths.test.ts`
- `npx tsc --pretty false -p tsconfig.typecheck-core.json`
- `npx eslint open-sse/services/errorClassifier.ts open-sse/services/accountFallback.ts open-sse/handlers/chatCore.ts src/sse/services/auth.ts tests/unit/error-classifier.test.ts tests/unit/account-fallback-service.test.ts tests/unit/chatcore-translation-paths.test.ts`
- `npx -y node@24 --import tsx/esm --test --test-concurrency=1 --test-force-exit tests/unit/error-classifier.test.ts tests/unit/account-fallback-service.test.ts tests/unit/sse-auth.test.ts tests/unit/chatcore-translation-paths.test.ts` (140 passing)
- Full unit coverage was run with Node 24; coverage thresholds passed, while the full unit process still reported failures in tests outside this PR's changed files.