### PR TITLE
fix(reasoning): preserve OpenAI effort passthrough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### 🐛 Bug Fixes
+
+- **fix(providers):** Preserve OpenAI Chat Completions `reasoning_effort` through assistant-prefill requests, including OpenRouter and OpenAI-compatible providers, and keep OpenRouter `reasoning` requests displayed as `OPENAI-CHAT` protocol.
+
 ---
 
 ## [3.7.0] — 2026-04-23

--- a/open-sse/services/provider.ts
+++ b/open-sse/services/provider.ts
@@ -94,9 +94,7 @@ export function detectFormatFromEndpoint(body, endpointPath = "") {
   const hasResponsesSpecificFields =
     body &&
     typeof body === "object" &&
-    (body.max_output_tokens !== undefined ||
-      body.previous_response_id !== undefined ||
-      body.reasoning !== undefined);
+    (body.max_output_tokens !== undefined || body.previous_response_id !== undefined);
 
   if (/\/responses(?=\/|$)/i.test(path) || /^responses(?=\/|$)/i.test(path)) {
     return "openai-responses";
@@ -124,12 +122,14 @@ export function detectFormat(body) {
   // OpenAI Responses API:
   // - input can be string, array, or object (not only array)
   // - some clients send responses-specific fields even when input is omitted
+  // - reasoning alone is ambiguous: OpenRouter Chat Completions also uses a
+  //   reasoning object, so only treat it as Responses when messages are absent
   const hasInputField =
     Object.prototype.hasOwnProperty.call(body, "input") && body.input !== undefined;
   const hasResponsesSpecificFields =
     body.max_output_tokens !== undefined ||
     body.previous_response_id !== undefined ||
-    body.reasoning !== undefined;
+    (body.reasoning !== undefined && !Array.isArray(body.messages));
   if (hasInputField || hasResponsesSpecificFields) {
     return "openai-responses";
   }
@@ -155,6 +155,7 @@ export function detectFormat(body) {
     body.presence_penalty !== undefined || // Penalties
     body.frequency_penalty !== undefined ||
     body.logit_bias || // Token biasing
+    body.reasoning !== undefined || // OpenRouter/OpenAI-compatible reasoning config
     body.user // User identifier
   ) {
     return "openai";
@@ -396,15 +397,16 @@ export function isLastMessageFromUser(body) {
 
 // Check if request has thinking config
 export function hasThinkingConfig(body) {
-  return !!(body.reasoning_effort || body.thinking?.type === "enabled");
+  return !!(body.reasoning_effort || body.reasoning || body.thinking?.type === "enabled");
 }
 
 // Normalize thinking config based on last message role
-// - If lastMessage is not user → remove thinking config
-// - If lastMessage is user AND has thinking config → keep it (force enable)
+// - If lastMessage is not user → remove Claude/Gemini-style thinking config
+// - Keep OpenAI Chat Completions reasoning fields. Standard OpenAI-compatible
+//   providers and OpenRouter accept these as request-level options, including
+//   assistant-prefill continuation requests.
 export function normalizeThinkingConfig(body) {
   if (!isLastMessageFromUser(body)) {
-    delete body.reasoning_effort;
     delete body.thinking;
   }
   return body;

--- a/src/shared/components/RequestLoggerDetail.tsx
+++ b/src/shared/components/RequestLoggerDetail.tsx
@@ -2,9 +2,9 @@
 
 import { useState, useEffect } from "react";
 import {
-  PROTOCOL_COLORS,
   PROVIDER_COLORS,
   getHttpStatusStyle as getStatusStyle,
+  getProtocolColor,
 } from "@/shared/constants/colors";
 import { formatDuration, formatApiKeyLabel } from "@/shared/utils/formatting";
 
@@ -57,12 +57,7 @@ export default function RequestLoggerDetail({ log, detail, loading, onClose, onC
 
   const statusStyle = getStatusStyle(log.status);
   const protocolKey = log.sourceFormat || log.provider;
-  const protocol = PROTOCOL_COLORS[protocolKey] ||
-    PROTOCOL_COLORS[log.provider] || {
-      bg: "#6B7280",
-      text: "#fff",
-      label: (protocolKey || log.provider || "-").toUpperCase(),
-    };
+  const protocol = getProtocolColor(protocolKey, log.provider);
   const providerColor = PROVIDER_COLORS[log.provider] || {
     bg: "#374151",
     text: "#fff",

--- a/src/shared/components/RequestLoggerV2.tsx
+++ b/src/shared/components/RequestLoggerV2.tsx
@@ -6,9 +6,9 @@ import Card from "./Card";
 import RequestLoggerDetail from "./RequestLoggerDetail";
 import { copyToClipboard } from "@/shared/utils/clipboard";
 import {
-  PROTOCOL_COLORS,
   PROVIDER_COLORS,
   getHttpStatusStyle as getStatusStyle,
+  getProtocolColor,
 } from "@/shared/constants/colors";
 import {
   formatTime,
@@ -706,12 +706,7 @@ export default function RequestLoggerV2() {
                 {sortedLogs.map((log) => {
                   const statusStyle = getStatusStyle(log.status);
                   const protocolKey = log.sourceFormat || log.provider;
-                  const protocol = PROTOCOL_COLORS[protocolKey] ||
-                    PROTOCOL_COLORS[log.provider] || {
-                      bg: "#6B7280",
-                      text: "#fff",
-                      label: (protocolKey || log.provider || "-").toUpperCase(),
-                    };
+                  const protocol = getProtocolColor(protocolKey, log.provider);
                   const compatLabel = getProviderDisplayLabel(log.provider, providerNodes);
                   const providerColor = PROVIDER_COLORS[log.provider] || {
                     bg: "#374151",

--- a/src/shared/constants/colors.ts
+++ b/src/shared/constants/colors.ts
@@ -31,12 +31,19 @@ export const PROVIDER_COLORS = {
 
 export const PROTOCOL_COLORS = {
   openai: { bg: "#1A1A2E", text: "#fff", label: "OpenAI-Chat" },
+  "openai-chat": { bg: "#1A1A2E", text: "#fff", label: "OpenAI-Chat" },
   "openai-responses": { bg: "#1A1A2E", text: "#fff", label: "OpenAI-Responses" },
   claude: { bg: "#D97757", text: "#fff", label: "Claude" },
   gemini: { bg: "#4285F4", text: "#fff", label: "Gemini" },
   warmup: { bg: "#F59E0B", text: "#000", label: "Warmup" },
   bypass: { bg: "#6B7280", text: "#fff", label: "Bypass" },
 };
+
+function normalizeProtocolKey(protocol) {
+  if (protocol === "openai-chat") return "openai";
+  if (protocol === "openai-response") return "openai-responses";
+  return protocol;
+}
 
 // ═══════════════════════════════════════════
 // Proxy Type Colors (ProxyLogger)
@@ -131,6 +138,24 @@ export function getProviderColor(provider) {
       bg: "#374151",
       text: "#fff",
       label: (provider || "-").toUpperCase(),
+    }
+  );
+}
+
+/**
+ * Get default fallback for a protocol color lookup.
+ * @param {string} protocol - Protocol key
+ * @param {string} fallbackProvider - Provider key to use as a secondary protocol key
+ * @returns {{ bg: string, text: string, label: string }}
+ */
+export function getProtocolColor(protocol, fallbackProvider) {
+  const normalized = normalizeProtocolKey(protocol);
+  return (
+    PROTOCOL_COLORS[normalized] ||
+    PROTOCOL_COLORS[fallbackProvider] || {
+      bg: "#6B7280",
+      text: "#fff",
+      label: (protocol || fallbackProvider || "-").toUpperCase(),
     }
   );
 }

--- a/tests/unit/chatcore-translation-paths.test.ts
+++ b/tests/unit/chatcore-translation-paths.test.ts
@@ -797,6 +797,102 @@ test("chatCore strips unsupported reasoning params and caps provider token field
   assert.equal(call.body.max_completion_tokens, 16384);
 });
 
+test("chatCore passes through OpenAI reasoning_effort for OpenRouter", async () => {
+  const { call, result } = await invokeChatCore({
+    provider: "openrouter",
+    model: "deepseek/deepseek-v4-pro",
+    endpoint: "/v1/chat/completions",
+    body: {
+      model: "openrouter/deepseek/deepseek-v4-pro",
+      messages: [{ role: "user", content: "hello" }],
+      reasoning_effort: "xhigh",
+      stream: false,
+    },
+    responseFormat: "openai",
+  });
+
+  assert.equal(result.success, true);
+  assert.equal(call.body.model, "deepseek/deepseek-v4-pro");
+  assert.equal(call.body.reasoning_effort, "xhigh");
+  assert.equal(call.body.reasoning, undefined);
+});
+
+test("chatCore preserves reasoning_effort for assistant-prefill OpenAI-compatible requests", async () => {
+  const { call, result } = await invokeChatCore({
+    provider: "openai-compatible-aio",
+    model: "glm-5.1",
+    endpoint: "/v1/chat/completions",
+    body: {
+      model: "aio/glm-5.1",
+      messages: [
+        { role: "user", content: "draft the answer" },
+        { role: "assistant", content: "<thinking>" },
+      ],
+      reasoning_effort: "xhigh",
+      stream: true,
+    },
+    responseFormat: "openai",
+  });
+
+  assert.equal(result.success, true);
+  assert.equal(call.body.model, "glm-5.1");
+  assert.equal(call.body.reasoning_effort, "xhigh");
+});
+
+test("chatCore preserves standard effort for OpenRouter assistant-prefill", async () => {
+  const { call, result } = await invokeChatCore({
+    provider: "openrouter",
+    model: "deepseek/deepseek-v4-pro",
+    endpoint: "/v1/chat/completions",
+    body: {
+      model: "openrouter/deepseek/deepseek-v4-pro",
+      messages: [
+        { role: "user", content: "draft the answer" },
+        { role: "assistant", content: "<thinking>" },
+      ],
+      reasoning_effort: "xhigh",
+      stream: true,
+    },
+    responseFormat: "openai",
+  });
+
+  assert.equal(result.success, true);
+  assert.equal(call.body.model, "deepseek/deepseek-v4-pro");
+  assert.equal(call.body.reasoning_effort, "xhigh");
+  assert.equal(call.body.reasoning, undefined);
+});
+
+test("chatCore logs OpenRouter reasoning object chat requests as OpenAI protocol", async () => {
+  const { call, result } = await invokeChatCore({
+    provider: "openrouter",
+    model: "deepseek/deepseek-v4-pro",
+    endpoint: "/v1/chat/completions",
+    body: {
+      model: "openrouter/deepseek/deepseek-v4-pro",
+      messages: [{ role: "user", content: "Human: Hi" }],
+      temperature: 1,
+      max_tokens: 64000,
+      stream: false,
+      presence_penalty: 0,
+      frequency_penalty: 0,
+      top_p: 0.9,
+      reasoning: {
+        effort: "xhigh",
+      },
+    },
+    responseFormat: "openai",
+  });
+
+  assert.equal(result.success, true);
+  assert.equal(call.body.model, "deepseek/deepseek-v4-pro");
+  assert.deepEqual(call.body.reasoning, { effort: "xhigh" });
+
+  const logEntry = await waitFor(getLatestCallLog);
+  assert.ok(logEntry, "expected call log to be persisted");
+  assert.equal(logEntry.path, "/v1/chat/completions");
+  assert.equal(logEntry.sourceFormat, FORMATS.OPENAI);
+});
+
 test("chatCore surfaces translation errors with explicit status codes", async () => {
   register(
     FORMATS.OPENAI_RESPONSES,

--- a/tests/unit/executor-default-base.test.ts
+++ b/tests/unit/executor-default-base.test.ts
@@ -432,6 +432,47 @@ test("DefaultExecutor.transformRequest is a passthrough and preserves model ids 
   assert.equal(result.model, "zai-org/GLM-5-FP8");
 });
 
+test("DefaultExecutor.transformRequest passes through OpenAI reasoning_effort for OpenRouter", () => {
+  const executor = new DefaultExecutor("openrouter");
+  const body = {
+    model: "deepseek/deepseek-v4-pro",
+    messages: [{ role: "user", content: "hi" }],
+    reasoning_effort: "xhigh",
+  };
+  const result = executor.transformRequest("deepseek/deepseek-v4-pro", body, false, {});
+
+  assert.equal(result, body);
+  assert.equal((result as any).reasoning, undefined);
+  assert.equal((result as any).reasoning_effort, "xhigh");
+});
+
+test("DefaultExecutor.transformRequest preserves explicit OpenRouter reasoning config", () => {
+  const executor = new DefaultExecutor("openrouter");
+  const body = {
+    model: "anthropic/claude-sonnet-4.5",
+    messages: [{ role: "user", content: "hi" }],
+    reasoning_effort: "high",
+    reasoning: { max_tokens: 2000, exclude: true },
+  };
+  const result = executor.transformRequest("anthropic/claude-sonnet-4.5", body, false, {});
+
+  assert.deepEqual((result as any).reasoning, { max_tokens: 2000, exclude: true });
+  assert.equal((result as any).reasoning_effort, "high");
+});
+
+test("DefaultExecutor.transformRequest preserves OpenRouter none effort as standard field", () => {
+  const executor = new DefaultExecutor("openrouter");
+  const body = {
+    model: "deepseek/deepseek-v4-pro",
+    messages: [{ role: "user", content: "hi" }],
+    reasoning_effort: "none",
+  };
+  const result = executor.transformRequest("deepseek/deepseek-v4-pro", body, false, {});
+
+  assert.equal((result as any).reasoning, undefined);
+  assert.equal((result as any).reasoning_effort, "none");
+});
+
 test("DefaultExecutor.transformRequest neutralizes incompatible tool_choice for Qwen thinking", () => {
   const executor = new DefaultExecutor("qwen");
   const body = {

--- a/tests/unit/plan3-p0.test.ts
+++ b/tests/unit/plan3-p0.test.ts
@@ -396,6 +396,19 @@ test("detectFormat identifies OpenAI Responses by max_output_tokens without inpu
   assert.equal(format, FORMATS.OPENAI_RESPONSES);
 });
 
+test("detectFormat treats chat messages with reasoning as OpenAI chat", () => {
+  const format = detectFormat({
+    model: "openrouter/deepseek/deepseek-v4-pro",
+    messages: [{ role: "user", content: "Human: Hi" }],
+    max_tokens: 64000,
+    stream: false,
+    reasoning: {
+      effort: "xhigh",
+    },
+  });
+  assert.equal(format, FORMATS.OPENAI);
+});
+
 test("detectFormatFromEndpoint forces OpenAI for /v1/chat/completions", () => {
   const format = detectFormatFromEndpoint(
     {
@@ -403,6 +416,9 @@ test("detectFormatFromEndpoint forces OpenAI for /v1/chat/completions", () => {
       messages: [{ role: "user", content: "hi" }],
       max_tokens: 16,
       stream: false,
+      reasoning: {
+        effort: "xhigh",
+      },
     },
     "/v1/chat/completions"
   );

--- a/tests/unit/provider-service.test.ts
+++ b/tests/unit/provider-service.test.ts
@@ -114,13 +114,14 @@ test("Unknown providers fall back to bearer auth and OpenAI format", () => {
   assert.equal(getTargetFormat("custom-provider"), "openai");
 });
 
-test("thinking config is removed when the last message is not from the user", () => {
+test("native thinking config is removed when the last message is not from the user", () => {
   const assistantLast = {
     messages: [
       { role: "user", content: "hi" },
       { role: "assistant", content: "hello" },
     ],
     reasoning_effort: "high",
+    reasoning: { effort: "high" },
     thinking: { type: "enabled" },
   };
   const userLast = {
@@ -134,7 +135,8 @@ test("thinking config is removed when the last message is not from the user", ()
   assert.equal(isLastMessageFromUser({ messages: [] }), true);
   assert.equal(isLastMessageFromUser(assistantLast), false);
   assert.equal(hasThinkingConfig(userLast), true);
-  assert.equal("reasoning_effort" in normalized, false);
+  assert.equal(normalized.reasoning_effort, "high");
+  assert.deepEqual(normalized.reasoning, { effort: "high" });
   assert.equal("thinking" in normalized, false);
   assert.equal(normalizeThinkingConfig(userLast).reasoning_effort, "medium");
 });

--- a/tests/unit/request-log-detail-layout.test.ts
+++ b/tests/unit/request-log-detail-layout.test.ts
@@ -6,6 +6,46 @@ import { renderToStaticMarkup } from "react-dom/server";
 const { default: RequestLoggerDetail } =
   await import("../../src/shared/components/RequestLoggerDetail.tsx");
 
+function renderDetailWithSourceFormat(sourceFormat: string) {
+  return renderToStaticMarkup(
+    React.createElement(RequestLoggerDetail, {
+      log: {
+        status: 200,
+        method: "POST",
+        path: "/v1/chat/completions",
+        timestamp: "2026-04-09T21:27:08.000Z",
+        duration: 2500,
+        provider: "openrouter",
+        sourceFormat,
+        model: "deepseek/deepseek-v4-pro",
+        requestedModel: "openrouter/deepseek/deepseek-v4-pro",
+        cacheSource: "upstream",
+        tokens: {
+          in: 10,
+          out: 2,
+          cacheRead: null,
+          cacheWrite: null,
+          reasoning: null,
+        },
+      },
+      detail: {
+        requestedModel: "openrouter/deepseek/deepseek-v4-pro",
+        cacheSource: "upstream",
+        tokens: {
+          in: 10,
+          out: 2,
+          cacheRead: null,
+          cacheWrite: null,
+          reasoning: null,
+        },
+      },
+      loading: false,
+      onClose: () => {},
+      onCopy: async () => true,
+    })
+  );
+}
+
 test("request log detail splits token badges into input and output groups", () => {
   const html = renderToStaticMarkup(
     React.createElement(RequestLoggerDetail, {
@@ -70,10 +110,19 @@ test("request log detail splits token badges into input and output groups", () =
   assert.equal(modelLabelIndex < requestedModelLabelIndex, true);
   assert.notEqual(html.indexOf(">Cache Source<"), -1);
   assert.notEqual(html.indexOf(">Semantic (OmniRoute)<"), -1);
+  assert.notEqual(html.indexOf(">OpenAI-Chat<"), -1);
 
   assert.match(
     html,
     /data-testid="token-group-input"[\s\S]*Total In: 21[\s\S]*818[\s\S]*Cache Read: 21[\s\S]*632[\s\S]*Cache Write: N\/A/
   );
   assert.match(html, /data-testid="token-group-output"[\s\S]*Total Out: 42[\s\S]*Reasoning: N\/A/);
+});
+
+test("request log detail labels OpenAI protocol variants explicitly", () => {
+  const chatHtml = renderDetailWithSourceFormat("openai");
+  const responsesHtml = renderDetailWithSourceFormat("openai-responses");
+
+  assert.notEqual(chatHtml.indexOf(">OpenAI-Chat<"), -1);
+  assert.notEqual(responsesHtml.indexOf(">OpenAI-Responses<"), -1);
 });


### PR DESCRIPTION
## Summary
- Preserve standard OpenAI Chat Completions `reasoning_effort` through OpenAI-to-OpenAI translation, including assistant-prefill continuation requests.
- Keep OpenRouter as a standard OpenAI-compatible passthrough for `reasoning_effort`; do not synthesize `reasoning.effort` from the standard field.
- Classify `/v1/chat/completions` requests with a `reasoning` object as `OPENAI-CHAT`, not `OPENAI-RESPONSES`.
- Display request log protocols explicitly as `OPENAI-CHAT` and `OPENAI-RESPONSES` instead of the ambiguous `OPENAI`.

## Root Cause
- Successful AIO/OpenRouter logs showed inconsistent effort behavior only when the request ended with an assistant/model prefill shape such as `system > assistant > user > assistant`.
- Combo routing was not the root cause. Combo/context flows simply made assistant-prefill requests more common.
- The shared `normalizeThinkingConfig()` path deleted `reasoning_effort` whenever the last message was not from the user. That rule only makes sense for native Claude/Gemini-style `thinking` payloads, not for standard OpenAI Chat request options.
- OpenRouter live compatibility check confirmed that `/api/v1/chat/completions` accepts the standard OpenAI `reasoning_effort` field directly. `z-ai/glm-5.1` returned 200 with `reasoning_effort` only; `deepseek/deepseek-v4-pro` returned the same provider 429 with and without the field, so that was not a schema rejection.

## Validation
- `/Users/roger/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --import tsx/esm --test tests/unit/provider-service.test.ts`
- `/Users/roger/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --import tsx/esm --test tests/unit/executor-default-base.test.ts`
- `/Users/roger/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --import tsx/esm --test --test-force-exit --test-name-pattern "reasoning_effort|OpenRouter reasoning|assistant-prefill" tests/unit/chatcore-translation-paths.test.ts`
- `/Users/roger/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --import tsx/esm --test --test-force-exit --test-name-pattern "detectFormat|OpenRouter reasoning" tests/unit/plan3-p0.test.ts tests/unit/chatcore-translation-paths.test.ts`
- `/Users/roger/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --import tsx/esm --test tests/unit/request-log-detail-layout.test.ts`
- `/Users/roger/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node node_modules/typescript/bin/tsc --pretty false -p tsconfig.typecheck-core.json`
- `git diff --check`
- Pre-commit hooks passed: Prettier, ESLint, docs-sync, T11 any-budget.

Note: local pre-push hook was skipped because the machine default Node runtime loads a mismatched `better-sqlite3` native module. The targeted tests above were run with the bundled Node runtime used for this workspace.