### PR TITLE
feat(codex): add built-in gpt-5.5 model

### DIFF
--- a/open-sse/config/providerRegistry.ts
+++ b/open-sse/config/providerRegistry.ts
@@ -386,6 +386,7 @@ export const REGISTRY: Record<string, RegistryEntry> = {
     models: [
       { id: "gpt-5.4", name: "GPT 5.4", targetFormat: "openai-responses" },
       { id: "gpt-5.4-mini", name: "GPT 5.4 Mini", targetFormat: "openai-responses" },
+      { id: "gpt-5.5", name: "GPT 5.5", targetFormat: "openai-responses" },
       { id: "gpt-5.3-codex", name: "GPT 5.3 Codex" },
       { id: "gpt-5.3-codex-xhigh", name: "GPT 5.3 Codex (xHigh)" },
       { id: "gpt-5.3-codex-high", name: "GPT 5.3 Codex (High)" },

--- a/tests/unit/provider-models-config.test.ts
+++ b/tests/unit/provider-models-config.test.ts
@@ -25,6 +25,7 @@ test("provider models helpers expose model lists and defaults", () => {
 test("provider models helpers validate and resolve model metadata", () => {
   const openaiModels = PROVIDER_MODELS.openai;
   const firstModel = openaiModels[0];
+  const codexModels = PROVIDER_MODELS.cx;
 
   assert.equal(isValidModel("openai", firstModel.id), true);
   assert.equal(isValidModel("openai", "missing-model"), false);
@@ -40,6 +41,9 @@ test("provider models helpers validate and resolve model metadata", () => {
   assert.equal(getModelTargetFormat("openai", firstModel.id), firstModel.targetFormat || null);
   assert.equal(getModelTargetFormat("openai", "missing-model"), null);
   assert.equal(getModelTargetFormat("missing-provider", "missing-model"), null);
+
+  assert.ok(codexModels.some((model) => model.id === "gpt-5.5"), "missing built-in cx/gpt-5.5");
+  assert.equal(getModelTargetFormat("cx", "gpt-5.5"), "openai-responses");
 });
 
 test("provider models helpers resolve provider IDs through aliases", () => {

--- a/tests/unit/t28-model-catalog-updates.test.ts
+++ b/tests/unit/t28-model-catalog-updates.test.ts
@@ -27,6 +27,14 @@ test("T28: antigravity static catalog exposes client-visible Gemini preview IDs"
   assert.ok(!staticIds.includes("gemini-3.1-pro-high"));
 });
 
+test("T28: codex registry exposes built-in gpt-5.5 via responses format", () => {
+  const codexIds = REGISTRY.codex.models.map((m) => m.id);
+  const gpt55 = REGISTRY.codex.models.find((m) => m.id === "gpt-5.5");
+
+  assert.ok(codexIds.includes("gpt-5.5"));
+  assert.equal(gpt55?.targetFormat, "openai-responses");
+});
+
 test("T28: github registry exposes Gemini 3.1 Pro Preview and keeps legacy alias compatibility", async () => {
   const githubIds = REGISTRY.github.models.map((m) => m.id);
 


### PR DESCRIPTION
## Summary
- add `gpt-5.5` as a built-in Codex model
- route `gpt-5.5` through the Responses API via `targetFormat: "openai-responses"`
- add focused regression coverage for Codex model metadata and registry exposure

## Why
`gpt-5.5` previously worked only as a manual custom model. This change makes it behave like the existing built-in GPT-5.4 Codex models, so users get first-class support without guessing the correct API format.

## Test Plan
```bash
node --import tsx/esm --test tests/unit/provider-models-config.test.ts tests/unit/t28-model-catalog-updates.test.ts tests/integration/v1-contracts-behavior.test.ts
```

Closes #1545