### PR TITLE
fix(vision-bridge): force GPT-family image fallback

### DIFF
--- a/src/lib/guardrails/visionBridge.ts
+++ b/src/lib/guardrails/visionBridge.ts
@@ -15,6 +15,7 @@ import {
 import {
   VISION_BRIDGE_DEFAULTS,
   getVisionBridgeConfig,
+  isVisionBridgeForcedModel,
 } from "@/shared/constants/visionBridgeDefaults";
 
 export interface VisionBridgeDependencies {
@@ -55,9 +56,11 @@ export class VisionBridgeGuardrail extends BaseGuardrail {
       return { block: false };
     }
 
+    const forceVisionBridge = isVisionBridgeForcedModel(model);
+
     // 4. Check if model supports vision
     const capabilities = getResolvedModelCapabilities(model);
-    if (capabilities.supportsVision === true) {
+    if (capabilities.supportsVision === true && !forceVisionBridge) {
       return { block: false };
     }
 

--- a/src/shared/constants/visionBridgeDefaults.ts
+++ b/src/shared/constants/visionBridgeDefaults.ts
@@ -2,6 +2,14 @@
  * Vision Bridge default configuration values.
  */
 
+const NORMALIZED_GPT_MODEL_PATTERN = /^gpt-/i;
+
+export function isVisionBridgeForcedModel(model: string | null | undefined): boolean {
+  if (!model) return false;
+  const normalizedModel = model.includes("/") ? model.split("/").pop() || model : model;
+  return NORMALIZED_GPT_MODEL_PATTERN.test(normalizedModel);
+}
+
 export const VISION_BRIDGE_DEFAULTS = {
   enabled: true,
   model: "openai/gpt-4o-mini",

--- a/tests/unit/guardrails/visionBridge.test.ts
+++ b/tests/unit/guardrails/visionBridge.test.ts
@@ -164,6 +164,37 @@ test("VB-S02: passthroughs for vision-capable model (gpt-4o)", async () => {
   }
 });
 
+test("VB-S02b: forces Vision Bridge for GPT-family models even when model capabilities advertise vision", async () => {
+  const guardrail = createGuardrail();
+
+  for (const model of ["gpt-5.4", "gpt-5.4-mini", "gpt-4o", "openai/gpt-4o-mini"]) {
+    mockVisionResponse = `Forced bridge description for ${model}`;
+    visionCallCount = 0;
+
+    const payload = createPayload({
+      model,
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "What is this?" },
+            {
+              type: "image_url",
+              image_url: { url: "https://example.com/image.png" },
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = await guardrail.preCall(payload, createContext({ model }));
+
+    assert.strictEqual(result.block, false, `expected passthrough=false for ${model}`);
+    assert.ok(result.modifiedPayload, `expected modified payload for ${model}`);
+    assert.strictEqual(visionCallCount, 1, `expected one forced bridge call for ${model}`);
+  }
+});
+
 test("VB-S02: model capabilities returns supportsVision for known models", () => {
   const gpt4oCaps = getResolvedModelCapabilities("openai/gpt-4o");
   // supportsVision may be true (if sync data exists) or null (if not synced)


### PR DESCRIPTION
## Summary
- force Vision Bridge for GPT-family models even when synced capabilities advertise vision
- replace the hardcoded special case with a normalized GPT-family predicate
- add regression coverage for `gpt-5.4`, `gpt-5.4-mini`, `gpt-4o`, and `openai/gpt-4o-mini`

## Why
Some GPT-family models should still go through Vision Bridge in this release branch behavior, but the existing logic only bypassed the guardrail based on `supportsVision === true`. That prevented the intended forced-bridge behavior for newer GPT variants unless each one was hardcoded individually.

## Test Plan
```bash
node --import tsx/esm --test tests/unit/guardrails/visionBridge.test.ts
```
