### PR TITLE
fix(env-repair): replace dynamic import with static to fix prod build

### DIFF
--- a/src/app/api/system/env/repair/route.ts
+++ b/src/app/api/system/env/repair/route.ts
@@ -7,14 +7,13 @@
  */
 import { copyFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
-import { pathToFileURL } from "node:url";
 import { NextResponse } from "next/server";
 import { isAuthenticated } from "@/shared/utils/apiAuth";
-
-const SYNC_HELPER_PATH = join(process.cwd(), "scripts/sync-env.mjs");
+// @ts-expect-error - .mjs without types
+import { getEnvSyncPlan, syncEnv } from "../../../../../../scripts/sync-env.mjs";
 
 async function loadSyncHelpers() {
-  return import(pathToFileURL(SYNC_HELPER_PATH).href);
+  return { getEnvSyncPlan, syncEnv };
 }
 
 function createEnvBackup() {


### PR DESCRIPTION
## Summary

`/api/system/env/repair` returns **HTTP 500** on every request in production builds:

```json
{"error":"Cannot find module as expression is too dynamic"}
```

This breaks the OAuth env-repair flow shipped in #1116 and surfaces as a persistent error toast in the dashboard header (badge `1`) for every Docker user.

## Root cause

`src/app/api/system/env/repair/route.ts` loaded `scripts/sync-env.mjs` via:

```ts
const SYNC_HELPER_PATH = join(process.cwd(), "scripts/sync-env.mjs");
async function loadSyncHelpers() {
  return import(pathToFileURL(SYNC_HELPER_PATH).href);
}
```

Next.js's production bundler (both webpack and Turbopack) cannot trace dynamic `import()` expressions whose target is computed at runtime. The bundler emits a stub that throws the `"Cannot find module as expression is too dynamic"` error on first call. The route never reached `getEnvSyncPlan`.

## Fix

Replace the runtime dynamic import with a static relative import. The bundler now traces the dependency, includes `scripts/sync-env.mjs` in the route chunk, and behavior at runtime is identical.

```ts
// @ts-expect-error - .mjs without types
import { getEnvSyncPlan, syncEnv } from "../../../../../../scripts/sync-env.mjs";
```

`loadSyncHelpers()` is kept (returns the static bindings) so the call sites in `GET`/`POST` are untouched and the `try/catch` error path still wraps any helper failure.

## Reproduction

1. `docker run diegosouzapw/omniroute:3.6.6` (or 3.6.7+, all affected)
2. Open `/dashboard/providers`
3. Header shows `error 1` badge; `GET /api/system/env/repair` returns 500.

## Verification

Tested against a locally rebuilt image with the patch applied:

| Step | Before | After |
|------|--------|-------|
| `GET /api/system/env/repair` | 500 *"Cannot find module…"* | 200, `{ available, missingKeys: [9 keys], … }` |
| `POST /api/system/env/repair` | 500 | 200, populates `.env`, writes `.env.backup-<ts>` |
| Dashboard `error 1` badge | persistent | gone after restart |
| Bootstrap log `OAuth integrations are not configured` | warns on every start | gone post-repair |

Pre-push unit suite (`npm run test:unit`) — all suites pass.

## Test plan

- [x] `npm run test:unit` clean
- [x] Manual: GET returns OAuth missing-keys list
- [x] Manual: POST writes `.env`, `.env.backup-*` present, no warnings on restart
- [x] Manual: dashboard error badge clears

## Notes

The `// @ts-expect-error` is needed because `scripts/sync-env.mjs` ships without a `.d.ts`. Adding types is out of scope for this fix.