### PR TITLE
fix(providers): navigate to node detail after creating compatible node

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/page.tsx
+++ b/src/app/(dashboard)/dashboard/providers/page.tsx
@@ -22,6 +22,7 @@ import {
   isOpenAICompatibleProvider,
 } from "@/shared/constants/providers";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { getErrorCode, getRelativeTime } from "@/shared/utils";
 import { pickDisplayValue } from "@/shared/utils/maskEmail";
 import useEmailPrivacyStore from "@/store/emailPrivacyStore";
@@ -106,6 +107,7 @@ function getConnectionErrorTag(connection) {
 }
 
 export default function ProvidersPage() {
+  const router = useRouter();
   const [connections, setConnections] = useState<any[]>([]);
   const [providerNodes, setProviderNodes] = useState<any[]>([]);
   const [ccCompatibleProviderEnabled, setCcCompatibleProviderEnabled] = useState(false);
@@ -803,6 +805,7 @@ export default function ProvidersPage() {
         onCreated={(node) => {
           setProviderNodes((prev) => [...prev, node]);
           setShowAddCompatibleModal(false);
+          router.push(`/dashboard/providers/${node.id}`);
         }}
       />
       <AddAnthropicCompatibleModal
@@ -811,6 +814,7 @@ export default function ProvidersPage() {
         onCreated={(node) => {
           setProviderNodes((prev) => [...prev, node]);
           setShowAddAnthropicCompatibleModal(false);
+          router.push(`/dashboard/providers/${node.id}`);
         }}
       />
       {ccCompatibleProviderEnabled && (
@@ -820,6 +824,7 @@ export default function ProvidersPage() {
           onCreated={(node) => {
             setProviderNodes((prev) => [...prev, node]);
             setShowAddCcCompatibleModal(false);
+            router.push(`/dashboard/providers/${node.id}`);
           }}
         />
       )}


### PR DESCRIPTION
## Summary

After clicking **Add OpenAI Compatible** / **Add Anthropic Compatible** / **Add Claude Code Compatible** and submitting the form, the modal closes but the user lands back on the providers list — where newly created nodes (with zero connections) are not rendered. The node exists in the database but is **invisible from the UI**, with no path to reach the connection-creation form.

## Symptoms reported by users

- "I added the provider and nothing happened."
- Accumulating orphan provider-nodes after multiple add attempts (I personally collected 6+ duplicate \"Crof AI\" rows in `/api/provider-nodes` while debugging).
- The dialog field labeled **\"API Key (for Check)\"** reinforces the confusion — users assume the key gets saved by the same form, when in fact it is only used by the inline `Check` button. The actual key/connection has to be added on the node detail page.

## Reproduction

1. Open `/dashboard/providers`.
2. Click **Add OpenAI Compatible**.
3. Fill Name / Prefix / Base URL / API Key, click **Add**.
4. Modal closes. List unchanged. Node exists at `/api/provider-nodes` but is hidden because it has 0 connections.
5. User has no UI path to reach `/dashboard/providers/<new-node-id>` to add the connection.

## Fix

After `onCreated` fires, push the user to `/dashboard/providers/<id>` where the empty-state CTA *\"Add your first connection to get started\"* is already rendered. No redesign of the dialog or list page; just close the loop on the create flow.

```tsx
onCreated={(node) => {
  setProviderNodes((prev) => [...prev, node]);
  setShowAddCompatibleModal(false);
  router.push(`/dashboard/providers/${node.id}`);
}}
```

Applied identically to all three Compatible modal handlers (OpenAI, Anthropic, Claude Code).

## Verification

Tested end-to-end against a locally rebuilt image:

- [x] Add OpenAI Compatible → redirected to `/dashboard/providers/openai-compatible-chat-<uuid>`, empty-state visible.
- [x] Add Anthropic Compatible → redirected to detail page.
- [x] Add Claude Code Compatible → redirected to detail page.
- [x] Connection added on detail page persists; node now appears in main list with `1 Connected`.
- [x] `npm run test:unit` clean.

## Related

Pairs well with #1601 (env-repair 500). Both surfaced in the same investigation around adding new providers.