### PR TITLE
fix: per-model rate limiting for GitHub Copilot provider

### DIFF
--- a/open-sse/services/accountFallback.ts
+++ b/open-sse/services/accountFallback.ts
@@ -407,7 +407,7 @@ export function hasPerModelQuota(
     return connectionPassthroughModels;
   }
   if (!provider) return false;
-  if (provider === "gemini") return true;
+  if (provider === "gemini" || provider === "github") return true;
   if (getPassthroughProviders().has(provider)) return true;
   if (isCompatibleProvider(provider)) return true;
   return false;

--- a/open-sse/services/rateLimitManager.ts
+++ b/open-sse/services/rateLimitManager.ts
@@ -236,9 +236,9 @@ function getLimiterKey(provider, connectionId, model = null) {
   if (provider === "codex" && model) {
     return `${provider}:${getCodexRateLimitKey(connectionId, model)}`;
   }
-  // Gemini AI Studio has per-model quotas — use model-scoped limiter keys
-  // so a 429 on one model doesn't pause requests for other models.
-  if (provider === "gemini" && model) {
+  // Gemini AI Studio and GitHub Copilot have per-model quotas — use model-scoped
+  // limiter keys so a 429 on one model doesn't pause requests for other models.
+  if ((provider === "gemini" || provider === "github") && model) {
     return `${provider}:${connectionId}:${model}`;
   }
   return `${provider}:${connectionId}`;


### PR DESCRIPTION
## Summary

GitHub Copilot multiplexes multiple models (Claude, GPT, Gemini, etc.) behind a single OAuth connection, each with their own PRU-based rate limits. When one model returns a 429, the **entire connection was being locked out**, blocking all other GitHub models unnecessarily — even ones with remaining quota (e.g., unlimited models like `gpt-5-mini`).

This is the same pattern already applied to the Gemini AI Studio provider.

## Changes

**`open-sse/services/accountFallback.ts`**
- Added `github` to `hasPerModelQuota()` so `shouldMarkAccountExhaustedFrom429()` returns `false` for GitHub, preventing connection-wide lockout when a single model hits its limit

**`open-sse/services/rateLimitManager.ts`**
- Added `github` to `getLimiterKey()` so the Bottleneck rate limiter uses model-scoped keys (`github:connectionId:model` instead of `github:connectionId`), ensuring a 429 on one model only pauses that model's limiter

## Before / After

| Scenario | Before | After |
|----------|--------|-------|
| `gpt-5.1-codex-max` (3x PRU) hits weekly limit | **All** GitHub models blocked | Only `gpt-5.1-codex-max` blocked |
| `gpt-5-mini` (0x PRU, unlimited) | Blocked if *any* model 429'd | Still works independently |
| `claude-haiku-4.5` (0.33x PRU) | Blocked if *any* model 429'd | Still works independently |

## Testing

Verified on a running OmniRoute instance with GitHub Copilot Student plan. After applying the patches, a 429 on a high-PRU model no longer blocks low-PRU/unlimited models on the same connection.