### PR TITLE
[Urgent] fix: include npm config in Docker install layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,10 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 COPY package*.json ./
-COPY .npmrc ./
 COPY scripts/postinstall.mjs ./scripts/postinstall.mjs
 COPY scripts/postinstallSupport.mjs ./scripts/postinstallSupport.mjs
 COPY scripts/native-binary-compat.mjs ./scripts/native-binary-compat.mjs
+ENV NPM_CONFIG_LEGACY_PEER_DEPS=true
 RUN if [ -f package-lock.json ]; then npm ci --no-audit --no-fund; else npm install --no-audit --no-fund; fi
 
 COPY . ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,10 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 COPY package*.json ./
+COPY .npmrc ./
 COPY scripts/postinstall.mjs ./scripts/postinstall.mjs
 COPY scripts/postinstallSupport.mjs ./scripts/postinstallSupport.mjs
 COPY scripts/native-binary-compat.mjs ./scripts/native-binary-compat.mjs
-COPY scripts/postinstallSupport.mjs ./scripts/postinstallSupport.mjs
 RUN if [ -f package-lock.json ]; then npm ci --no-audit --no-fund; else npm install --no-audit --no-fund; fi
 
 COPY . ./


### PR DESCRIPTION
## Summary
- Set `NPM_CONFIG_LEGACY_PEER_DEPS=true` inside the Docker builder before `npm ci` runs.
- Remove the duplicate `postinstallSupport.mjs` copy in the dependency install layer.

## Impact
- The Docker install issue prevented the v3.7.0 container image from being built correctly.

## Root Cause
The release lockfile relies on npm legacy peer dependency resolution to avoid installing unused `@lobehub/icons` peer packages. The Docker build did not provide that npm config before `npm ci`, so npm attempted to resolve the peer dependency tree and failed with lockfile sync errors for `@lobehub/ui`, `antd`, `lucide-react`, and related packages.

## Validation
- `git diff --check`
- Reproduced the install failure in a clean temp directory without legacy peer dependency config.
- Confirmed `NPM_CONFIG_LEGACY_PEER_DEPS=true npm ci --ignore-scripts --dry-run --no-audit --no-fund` succeeds in a clean temp directory without copying `.npmrc`.
- Commit hook checks passed: docs sync and explicit-any budget.

Docker daemon was not available locally, so the full image build is left to CI.