### PR TITLE
feat(account-fallback): add daily quota lockout for quota_exhausted errors

### DIFF
--- a/open-sse/services/accountFallback.ts
+++ b/open-sse/services/accountFallback.ts
@@ -345,6 +345,12 @@ export function recordModelLockoutFailure(
   const now = Date.now();
   cleanupModelLockKey(key, now);
 
+  // 对于日限额耗尽 (quota_exhausted),设置冷却到第二天 0 点
+  // 使用 exactCooldownMs 避免指数缩放，确保精确到明天 0 点
+  if (reason === "quota_exhausted" && typeof options.exactCooldownMs !== "number") {
+    options = { ...options, exactCooldownMs: getMsUntilTomorrow() };
+  }
+
   const resetAfterMs = getFailureWindowMs(profile);
   const previous = modelFailureState.get(key);
   const withinWindow = previous && now - previous.lastFailureAt <= previous.resetAfterMs;
@@ -770,11 +776,12 @@ export function classifyError(status, errorText) {
  * @returns {number} Milliseconds until tomorrow
  */
 export function getMsUntilTomorrow(): number {
-  const now = new Date();
-  const tomorrow = new Date(now);
+  const nowMs = Date.now();
+  const now = new Date(nowMs);
+  const tomorrow = new Date(nowMs);
   tomorrow.setDate(tomorrow.getDate() + 1);
   tomorrow.setHours(0, 0, 0, 0);
-  const ms = tomorrow.getTime() - now.getTime();
+  const ms = tomorrow.getTime() - nowMs;
   // Guard against DST edge cases: if ms is negative (shouldn't happen) or
   // unreasonably large (>25h due to spring-forward), cap at 24 hours.
   return ms > 0 && ms <= 25 * 60 * 60 * 1000 ? ms : 24 * 60 * 60 * 1000;

--- a/src/sse/handlers/chat.ts
+++ b/src/sse/handlers/chat.ts
@@ -9,6 +9,8 @@ import {
   getRuntimeProviderProfile,
   shouldMarkAccountExhaustedFrom429,
   clearModelLock,
+  lockModel,
+  recordModelLockoutFailure,
 } from "@omniroute/open-sse/services/accountFallback.ts";
 import { getModelInfo, getComboForModel } from "../services/model";
 import { errorResponse } from "@omniroute/open-sse/utils/error.ts";
@@ -827,18 +829,54 @@ async function handleSingleModelChat(
         }
       }
 
-      // 6. Mark account as quota-exhausted on 429 response
-      // For providers that route quota/cooldown at model scope, a 429 on one model
-      // does not mean the whole connection is exhausted.
-      const passthroughModels = credentials.providerSpecificData?.passthroughModels;
-      if (
-        result.status === 429 &&
-        shouldMarkAccountExhaustedFrom429(provider, model, passthroughModels)
-      ) {
-        markAccountExhaustedFrom429(credentials.connectionId, provider);
+      // 6. 日限额错误检查 - 必须在 markAccountUnavailable 之前执行
+      // 检查是否是日限额耗尽错误 (如 ModelScope/Kimi 的 "today's quota for model")
+      // 日限额锁定会覆盖后续的 rate_limited 锁定，确保锁定到第二天 0:00
+      let isDailyQuotaExhausted = false;
+      if (result.status === 429 && result.error?.includes("today's quota")) {
+        // 解析具体哪个模型限额了
+        const match = result.error.match(/today's quota for model ([^,]+)/);
+        const limitedModel = match ? match[1].trim() : model;
+
+        // 锁定该 connection 的该模型直到第二天 0 点
+        const lockResult = recordModelLockoutFailure(
+          provider,
+          credentials.connectionId,
+          limitedModel,
+          "quota_exhausted",
+          result.status,
+          0,
+          providerProfile
+        );
+
+        log.info(
+          "MODEL_DAILY_QUOTA",
+          JSON.stringify({
+            connection: credentials.connectionId.slice(0, 8),
+            model: limitedModel,
+            cooldownMs: lockResult.cooldownMs,
+            failureCount: lockResult.failureCount,
+          })
+        );
+
+        isDailyQuotaExhausted = true;
       }
 
-      // 7. Fallback to next account
+      // 7. Mark account as quota-exhausted on 429 response (非日限额错误)
+      // For providers that route quota/cooldown at model scope, a 429 on one model
+      // does not mean the whole connection is exhausted.
+      // 日限额错误已经单独处理，这里只处理普通 rate_limit
+      if (!isDailyQuotaExhausted) {
+        const passthroughModels = credentials.providerSpecificData?.passthroughModels;
+        if (
+          result.status === 429 &&
+          shouldMarkAccountExhaustedFrom429(provider, model, passthroughModels)
+        ) {
+          markAccountExhaustedFrom429(credentials.connectionId, provider);
+        }
+      }
+
+      // 8. Fallback to next account
       const { shouldFallback, cooldownMs } = await markAccountUnavailable(
         credentials.connectionId,
         result.status,

--- a/src/sse/handlers/chat.ts
+++ b/src/sse/handlers/chat.ts
@@ -840,7 +840,7 @@ async function handleSingleModelChat(
         const match = errorStr.match(/today's quota for model ([^,]+)/);
         const limitedModel = match ? match[1].trim() : model;
 
-        // 锁定该 connection 的该模型直到第二天 0 点
+        // Lock this model on this connection until tomorrow 00:00
         const lockResult = recordModelLockoutFailure(
           provider,
           credentials.connectionId,
@@ -864,10 +864,10 @@ async function handleSingleModelChat(
         dailyQuotaExhausted = true;
       }
 
-      // 7. Mark account as quota-exhausted on 429 response (非日限额错误)
+      // 7. Mark account as quota-exhausted on 429 response (non-daily-quota errors)
       // For providers that route quota/cooldown at model scope, a 429 on one model
       // does not mean the whole connection is exhausted.
-      // 日限额错误已经单独处理，这里只处理普通 rate_limit
+      // Daily quota errors are handled above; only process regular rate_limit here
       if (!dailyQuotaExhausted) {
         const passthroughModels = credentials.providerSpecificData?.passthroughModels;
         if (

--- a/src/sse/handlers/chat.ts
+++ b/src/sse/handlers/chat.ts
@@ -11,6 +11,7 @@ import {
   clearModelLock,
   lockModel,
   recordModelLockoutFailure,
+  isDailyQuotaExhausted,
 } from "@omniroute/open-sse/services/accountFallback.ts";
 import { getModelInfo, getComboForModel } from "../services/model";
 import { errorResponse } from "@omniroute/open-sse/utils/error.ts";
@@ -829,13 +830,14 @@ async function handleSingleModelChat(
         }
       }
 
-      // 6. 日限额错误检查 - 必须在 markAccountUnavailable 之前执行
-      // 检查是否是日限额耗尽错误 (如 ModelScope/Kimi 的 "today's quota for model")
-      // 日限额锁定会覆盖后续的 rate_limited 锁定，确保锁定到第二天 0:00
-      let isDailyQuotaExhausted = false;
-      if (result.status === 429 && result.error?.includes("today's quota")) {
-        // 解析具体哪个模型限额了
-        const match = result.error.match(/today's quota for model ([^,]+)/);
+      // 6. Daily quota error check - must be executed before markAccountUnavailable
+      // Check if it's a daily quota exhausted error (e.g., ModelScope/Kimi "today's quota for model")
+      // Daily quota lockout overrides subsequent rate_limited lockout, ensuring lockout until tomorrow 0:00
+      let dailyQuotaExhausted = false;
+      const errorStr = String(result.error || "");
+      if (result.status === 429 && isDailyQuotaExhausted(errorStr)) {
+        // Parse which model is quota-limited
+        const match = errorStr.match(/today's quota for model ([^,]+)/);
         const limitedModel = match ? match[1].trim() : model;
 
         // 锁定该 connection 的该模型直到第二天 0 点
@@ -859,14 +861,14 @@ async function handleSingleModelChat(
           })
         );
 
-        isDailyQuotaExhausted = true;
+        dailyQuotaExhausted = true;
       }
 
       // 7. Mark account as quota-exhausted on 429 response (非日限额错误)
       // For providers that route quota/cooldown at model scope, a 429 on one model
       // does not mean the whole connection is exhausted.
       // 日限额错误已经单独处理，这里只处理普通 rate_limit
-      if (!isDailyQuotaExhausted) {
+      if (!dailyQuotaExhausted) {
         const passthroughModels = credentials.providerSpecificData?.passthroughModels;
         if (
           result.status === 429 &&

--- a/tests/unit/account-fallback-service.test.ts
+++ b/tests/unit/account-fallback-service.test.ts
@@ -639,13 +639,13 @@ test("recordModelLockoutFailure sets cooldown until tomorrow 0:00 for quota_exha
       resetTimeoutMs: 5000,
     };
 
-    // 计算到本地时间第二天 0:00 的毫秒数
+    // Calculate milliseconds until tomorrow 00:00 local time
     const tomorrow = new Date(now);
     tomorrow.setDate(tomorrow.getDate() + 1);
     tomorrow.setHours(0, 0, 0, 0);
     const expectedMsUntilTomorrow = tomorrow.getTime() - now;
 
-    // 考虑时区偏移：函数使用本地时间，测试环境可能使用 UTC
+    // Account for timezone offset: function uses local time, test env may use UTC
     const timezoneOffset = new Date().getTimezoneOffset() * 60 * 1000;
 
     // Record failure with quota_exhausted reason
@@ -662,10 +662,10 @@ test("recordModelLockoutFailure sets cooldown until tomorrow 0:00 for quota_exha
     // Verify the cooldown is set to ms until tomorrow 0:00 (with tolerance)
     // The cooldown should be close to expectedMsUntilTomorrow
     const tolerance = 60 * 1000; // 1 minute tolerance
-    // 计算实际值与预期值的差异
+    // Calculate difference between actual and expected values
     const diff = Math.abs(result.cooldownMs - expectedMsUntilTomorrow);
 
-    // 允许 ±5 分钟的误差（300,000 ms）
+    // Allow ±5 minutes tolerance (300,000 ms)
     assert.ok(
       diff <= 300_000,
       `cooldown should be ms until tomorrow 0:00 (expected ${expectedMsUntilTomorrow}ms, got ${result.cooldownMs}ms, diff ${diff}ms)`

--- a/tests/unit/account-fallback-service.test.ts
+++ b/tests/unit/account-fallback-service.test.ts
@@ -613,3 +613,119 @@ test("checkFallbackError preserves OAuth 429 daily quota semantics", () => {
   assert.equal(result.dailyQuotaExhausted, true);
   assert.ok(result.cooldownMs > 0);
 });
+
+// ModelScope daily quota lockout tests (commit 0456a1f5)
+test("recordModelLockoutFailure sets cooldown until tomorrow 0:00 for quota_exhausted reason", () => {
+  const originalNow = Date.now;
+  // Use a fixed local time (noon) to ensure predictable results
+  const testDate = new Date();
+  testDate.setHours(12, 0, 0, 0); // Set to noon today
+  const now = testDate.getTime();
+  Date.now = () => now;
+
+  try {
+    const provider = "modelscope";
+    const connectionId = "test-conn-modelscope-1";
+    const model = "qwen/Qwen2.5-Coder-32B-Instruct";
+
+    // Clear any existing state
+    clearModelLock(provider, connectionId, model);
+
+    const profile = {
+      baseCooldownMs: 125,
+      useUpstreamRetryHints: false,
+      maxBackoffSteps: 3,
+      failureThreshold: 60,
+      resetTimeoutMs: 5000,
+    };
+
+    // 计算到本地时间第二天 0:00 的毫秒数
+    const tomorrow = new Date(now);
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    tomorrow.setHours(0, 0, 0, 0);
+    const expectedMsUntilTomorrow = tomorrow.getTime() - now;
+
+    // 考虑时区偏移：函数使用本地时间，测试环境可能使用 UTC
+    const timezoneOffset = new Date().getTimezoneOffset() * 60 * 1000;
+
+    // Record failure with quota_exhausted reason
+    const result = recordModelLockoutFailure(
+      provider,
+      connectionId,
+      model,
+      "quota_exhausted",
+      429,
+      0, // fallbackCooldownMs should be overridden to ms until tomorrow
+      profile
+    );
+
+    // Verify the cooldown is set to ms until tomorrow 0:00 (with tolerance)
+    // The cooldown should be close to expectedMsUntilTomorrow
+    const tolerance = 60 * 1000; // 1 minute tolerance
+    // 计算实际值与预期值的差异
+    const diff = Math.abs(result.cooldownMs - expectedMsUntilTomorrow);
+
+    // 允许 ±5 分钟的误差（300,000 ms）
+    assert.ok(
+      diff <= 300_000,
+      `cooldown should be ms until tomorrow 0:00 (expected ${expectedMsUntilTomorrow}ms, got ${result.cooldownMs}ms, diff ${diff}ms)`
+    );
+
+    // Verify model is locked
+    assert.equal(isModelLocked(provider, connectionId, model), true);
+
+    const lockInfo = getModelLockoutInfo(provider, connectionId, model);
+    assert.ok(lockInfo !== null, "lockInfo should not be null");
+    assert.ok(lockInfo.remainingMs > 0, "remaining time should be positive");
+
+    clearModelLock(provider, connectionId, model);
+  } finally {
+    Date.now = originalNow;
+    clearModelLock("modelscope", "test-conn-modelscope-1", "qwen/Qwen2.5-Coder-32B-Instruct");
+  }
+});
+
+test("recordModelLockoutFailure uses regular backoff for non-quota reasons", () => {
+  const originalNow = Date.now;
+  const now = 1_700_000_000_000;
+  Date.now = () => now;
+
+  try {
+    const provider = "modelscope";
+    const connectionId = "test-conn-modelscope-2";
+    const model = "qwen/Qwen2.5-Coder-32B-Instruct";
+
+    clearModelLock(provider, connectionId, model);
+
+    const profile = {
+      baseCooldownMs: 5000,
+      useUpstreamRetryHints: false,
+      maxBackoffSteps: 3,
+      failureThreshold: 60,
+      resetTimeoutMs: 5000,
+    };
+
+    // Record failure with rate_limited reason (not quota_exhausted)
+    const result = recordModelLockoutFailure(
+      provider,
+      connectionId,
+      model,
+      "rate_limited",
+      429,
+      0,
+      profile
+    );
+
+    // Verify the cooldown uses regular profile baseCooldownMs (5000ms)
+    assert.ok(
+      result.cooldownMs < 24 * 60 * 60 * 1000,
+      "cooldown should be less than 24h for non-quota reasons"
+    );
+    assert.equal(result.cooldownMs, 5000, "cooldown should use profile baseCooldownMs");
+
+    clearModelLock(provider, connectionId, model);
+  } finally {
+    Date.now = originalNow;
+    clearModelLock("modelscope", "test-conn-modelscope-2", "qwen/Qwen2.5-Coder-32B-Instruct");
+  }
+});


### PR DESCRIPTION
## Summary
- Add model-level daily quota lockout for any provider that signals daily quota exhaustion
- Complete zh-CN translations across costs, audit, providers, settings, evals, docs, and agents pages

## Changes
- open-sse/services/accountFallback.ts: when reason is quota_exhausted, set cooldown to tomorrow 0:00
- src/sse/handlers/chat.ts: detect daily quota errors via isDailyQuotaExhausted() helper and lock model
- tests/unit/account-fallback-service.test.ts: add unit tests for quota_exhausted cooldown
- src/i18n/messages/: complete 1500+ zh-CN translations with proper fullwidth punctuation

🤖 Generated with [Claude Code](https://claude.com/claude-code)