### PR TITLE
fix(transport): cap streaming logs and parse fragmented responses

### DIFF
--- a/open-sse/executors/antigravity.ts
+++ b/open-sse/executors/antigravity.ts
@@ -27,6 +27,13 @@ const CREDITS_EXHAUSTED_TTL_MS = 5 * 60 * 60 * 1000; // 5 hours
 
 const BARE_PRO_IDS = new Set(["gemini-3.1-pro"]);
 
+type AntigravityCollectedStream = {
+  textContent: string;
+  finishReason: string;
+  usage: Record<string, unknown> | null;
+  remainingCredits: Array<{ creditType: string; creditAmount: string }> | null;
+};
+
 /**
  * Per-account GOOGLE_ONE_AI credits-exhausted tracker.
  * Key: accountId (OAuth subject / email). Value: expiry timestamp.
@@ -89,6 +96,72 @@ function isCreditsExhausted(accountId: string): boolean {
 
 function markCreditsExhausted(accountId: string): void {
   creditsExhaustedUntil.set(accountId, Date.now() + CREDITS_EXHAUSTED_TTL_MS);
+}
+
+function processAntigravitySSEPayload(
+  payload: string,
+  collected: AntigravityCollectedStream,
+  log?: { debug?: (scope: string, message: string) => void }
+) {
+  if (!payload || payload === "[DONE]") return;
+  try {
+    const parsed = JSON.parse(payload);
+    const candidate = parsed?.response?.candidates?.[0];
+    if (candidate?.content?.parts) {
+      for (const part of candidate.content.parts) {
+        if (typeof part.text === "string" && !part.thought && !part.thoughtSignature) {
+          collected.textContent += part.text;
+        }
+      }
+    }
+    if (candidate?.finishReason) {
+      collected.finishReason =
+        candidate.finishReason.toLowerCase() === "stop"
+          ? "stop"
+          : candidate.finishReason.toLowerCase();
+    }
+    if (parsed?.response?.usageMetadata) {
+      const um = parsed.response.usageMetadata;
+      collected.usage = {
+        prompt_tokens: um.promptTokenCount || 0,
+        completion_tokens: um.candidatesTokenCount || 0,
+        total_tokens: um.totalTokenCount || 0,
+      };
+    }
+    if (Array.isArray(parsed?.remainingCredits)) {
+      collected.remainingCredits = parsed.remainingCredits;
+    }
+  } catch {
+    log?.debug?.("SSE_PARSE", `Skipping malformed SSE line: ${payload.slice(0, 80)}`);
+  }
+}
+
+function processAntigravitySSEText(
+  text: string,
+  partialLine: { value: string },
+  collected: AntigravityCollectedStream,
+  log?: { debug?: (scope: string, message: string) => void }
+) {
+  partialLine.value += text;
+  const lines = partialLine.value.split("\n");
+  partialLine.value = lines.pop() || "";
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("data:")) continue;
+    processAntigravitySSEPayload(trimmed.slice(5).trim(), collected, log);
+  }
+}
+
+function flushAntigravitySSEText(
+  partialLine: { value: string },
+  collected: AntigravityCollectedStream,
+  log?: { debug?: (scope: string, message: string) => void }
+) {
+  const trimmed = partialLine.value.trim();
+  partialLine.value = "";
+  if (!trimmed.startsWith("data:")) return;
+  processAntigravitySSEPayload(trimmed.slice(5).trim(), collected, log);
 }
 
 /**
@@ -367,7 +440,13 @@ export class AntigravityExecutor extends BaseExecutor {
     const SSE_COLLECT_TIMEOUT_MS = 120_000;
 
     const collect = async () => {
-      const chunks: string[] = [];
+      const collected: AntigravityCollectedStream = {
+        textContent: "",
+        finishReason: "stop",
+        usage: null,
+        remainingCredits: null,
+      };
+      const partialLine = { value: "" };
       let timedOut = false;
       const timeout = AbortSignal.timeout(SSE_COLLECT_TIMEOUT_MS);
       try {
@@ -384,7 +463,12 @@ export class AntigravityExecutor extends BaseExecutor {
             ),
           ]);
           if (done) break;
-          chunks.push(decoder.decode(value, { stream: true }));
+          processAntigravitySSEText(
+            decoder.decode(value, { stream: true }),
+            partialLine,
+            collected,
+            log
+          );
         }
       } catch (err) {
         const msg = err?.message || String(err);
@@ -392,51 +476,8 @@ export class AntigravityExecutor extends BaseExecutor {
         log?.warn?.("SSE_COLLECT", `Error collecting SSE stream: ${msg}`);
         // Fall through — return whatever was collected so far
       }
-      const rawSSE = chunks.join("");
-
-      // Parse Gemini SSE: each line is "data: {json}"
-      let textContent = "";
-      let finishReason = "stop";
-      let usage: Record<string, unknown> | null = null;
-      let remainingCredits: Array<{ creditType: string; creditAmount: string }> | null = null;
-      const lines = rawSSE.split("\n");
-      for (const line of lines) {
-        const trimmed = line.trim();
-        if (!trimmed.startsWith("data:")) continue;
-        const payload = trimmed.slice(5).trim();
-        if (!payload || payload === "[DONE]") continue;
-        try {
-          const parsed = JSON.parse(payload);
-          const candidate = parsed?.response?.candidates?.[0];
-          if (candidate?.content?.parts) {
-            for (const part of candidate.content.parts) {
-              if (typeof part.text === "string" && !part.thought && !part.thoughtSignature) {
-                textContent += part.text;
-              }
-            }
-          }
-          if (candidate?.finishReason) {
-            finishReason =
-              candidate.finishReason.toLowerCase() === "stop"
-                ? "stop"
-                : candidate.finishReason.toLowerCase();
-          }
-          if (parsed?.response?.usageMetadata) {
-            const um = parsed.response.usageMetadata;
-            usage = {
-              prompt_tokens: um.promptTokenCount || 0,
-              completion_tokens: um.candidatesTokenCount || 0,
-              total_tokens: um.totalTokenCount || 0,
-            };
-          }
-          // Credit balance — arrives in the final chunk alongside consumedCredits
-          if (Array.isArray(parsed?.remainingCredits)) {
-            remainingCredits = parsed.remainingCredits;
-          }
-        } catch (e) {
-          log?.debug?.("SSE_PARSE", `Skipping malformed SSE line: ${payload.slice(0, 80)}`);
-        }
-      }
+      processAntigravitySSEText(decoder.decode(), partialLine, collected, log);
+      flushAntigravitySSEText(partialLine, collected, log);
 
       const result = {
         id: `chatcmpl-${Date.now()}-${crypto.randomUUID().slice(0, 8)}`,
@@ -446,13 +487,13 @@ export class AntigravityExecutor extends BaseExecutor {
         choices: [
           {
             index: 0,
-            message: { role: "assistant", content: textContent },
-            finish_reason: timedOut ? "length" : finishReason,
+            message: { role: "assistant", content: collected.textContent },
+            finish_reason: timedOut ? "length" : collected.finishReason,
           },
         ],
-        ...(usage && { usage }),
+        ...(collected.usage && { usage: collected.usage }),
         // Expose credit balance for upstream consumers (usage service, dashboard)
-        ...(remainingCredits && { _remainingCredits: remainingCredits }),
+        ...(collected.remainingCredits && { _remainingCredits: collected.remainingCredits }),
       };
 
       const syntheticStatus = timedOut ? 504 : response.status;

--- a/open-sse/executors/base.ts
+++ b/open-sse/executors/base.ts
@@ -221,7 +221,12 @@ export class BaseExecutor {
     return baseUrls[urlIndex] || baseUrls[0] || this.config.baseUrl;
   }
 
-  buildHeaders(credentials: ProviderCredentials, stream = true): Record<string, string> {
+  buildHeaders(
+    credentials: ProviderCredentials,
+    stream = true,
+    clientHeaders?: Record<string, string> | null
+  ): Record<string, string> {
+    void clientHeaders;
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
       ...this.config.headers,
@@ -408,7 +413,7 @@ export class BaseExecutor {
 
     for (let urlIndex = 0; urlIndex < fallbackCount; urlIndex++) {
       const url = this.buildUrl(model, stream, urlIndex, activeCredentials);
-      const headers = this.buildHeaders(activeCredentials, stream);
+      const headers = this.buildHeaders(activeCredentials, stream, clientHeaders);
       applyConfiguredUserAgent(headers, activeCredentials?.providerSpecificData);
 
       const ccRequestDefaults = isClaudeCodeCompatible(this.provider)

--- a/open-sse/executors/github.ts
+++ b/open-sse/executors/github.ts
@@ -1,4 +1,4 @@
-import { BaseExecutor, ExecuteInput } from "./base.ts";
+import { BaseExecutor, ExecuteInput, type ProviderCredentials } from "./base.ts";
 import { PROVIDERS, OAUTH_ENDPOINTS } from "../config/constants.ts";
 import { getModelTargetFormat } from "../config/providerModels.ts";
 import {
@@ -7,9 +7,6 @@ import {
 } from "../config/providerHeaderProfiles.ts";
 
 export class GithubExecutor extends BaseExecutor {
-  /** Stashed per-request so buildHeaders() can read the client's x-initiator value. */
-  private _clientHeaders: Record<string, string> | null = null;
-
   constructor() {
     super("github", PROVIDERS.github);
   }
@@ -66,83 +63,58 @@ export class GithubExecutor extends BaseExecutor {
   }
 
   transformRequest(model: string, body: any, stream: boolean, credentials: any): any {
-    const modifiedBody = JSON.parse(JSON.stringify(body));
+    void stream;
+    void credentials;
+
+    const sourceBody = body && typeof body === "object" ? body : {};
+    const modifiedBody = { ...sourceBody };
+
+    if (Array.isArray(sourceBody.messages)) {
+      modifiedBody.messages = sourceBody.messages.map((msg) => {
+        if (!msg || typeof msg !== "object" || msg.role !== "assistant") return msg;
+        if (msg.reasoning_text === undefined && msg.reasoning_content === undefined) return msg;
+        const next = { ...msg };
+        delete next.reasoning_text;
+        delete next.reasoning_content;
+        return next;
+      });
+    }
+
     if (modifiedBody.response_format && model.toLowerCase().includes("claude")) {
       modifiedBody.messages = this.injectResponseFormat(
-        modifiedBody.messages,
+        Array.isArray(modifiedBody.messages) ? modifiedBody.messages : [],
         modifiedBody.response_format
       );
       delete modifiedBody.response_format;
-    }
-
-    // Strip reasoning_text / reasoning_content from assistant messages.
-    // GitHub Copilot converts these into Anthropic thinking blocks but cannot
-    // supply a valid `signature`, causing upstream 400 errors.
-    if (Array.isArray(modifiedBody.messages)) {
-      for (const msg of modifiedBody.messages) {
-        if (msg.role === "assistant") {
-          delete msg.reasoning_text;
-          delete msg.reasoning_content;
-        }
-      }
     }
 
     return modifiedBody;
   }
 
   async execute(input: ExecuteInput) {
-    this._clientHeaders = input.clientHeaders ?? null;
-    try {
-      const result = await super.execute(input);
-      if (!result || !result.response) return result;
+    const result = await super.execute(input);
+    if (!result || !result.response) return result;
 
-      if (!input.stream) {
-        // wreq-js clone/text semantics consume the original response body. Materialize
-        // non-streaming responses immediately so downstream code always sees a native
-        // fetch Response with a readable body.
-        const status = result.response.status;
-        const statusText = result.response.statusText;
-        const headers = new Headers(result.response.headers);
-        const payload = await result.response.text();
-        result.response = new Response(payload, { status, statusText, headers });
-        return result;
-      }
-
-      if (!result.response.body) return result;
-
-      const isStreaming = input.stream === true;
-      const contentType = (result.response.headers.get("content-type") || "").toLowerCase();
-      if (isStreaming && result.response.ok && contentType.includes("text/event-stream")) {
-        // Preserve the original response body for downstream error handling.
-        const sourceResponse = result.response.clone();
-        if (!sourceResponse.body) return result;
-
-        const decoder = new TextDecoder();
-        const transformStream = new TransformStream({
-          transform(chunk, controller) {
-            const text = decoder.decode(chunk, { stream: true });
-            if (text.includes("data: [DONE]")) {
-              return;
-            }
-            controller.enqueue(chunk);
-          },
-        });
-
-        const newResponse = new Response(sourceResponse.body.pipeThrough(transformStream), {
-          status: sourceResponse.status,
-          statusText: sourceResponse.statusText,
-          headers: new Headers(sourceResponse.headers),
-        });
-        result.response = newResponse;
-      }
-
+    if (!input.stream) {
+      // wreq-js clone/text semantics consume the original response body. Materialize
+      // non-streaming responses immediately so downstream code always sees a native
+      // fetch Response with a readable body.
+      const status = result.response.status;
+      const statusText = result.response.statusText;
+      const headers = new Headers(result.response.headers);
+      const payload = await result.response.text();
+      result.response = new Response(payload, { status, statusText, headers });
       return result;
-    } finally {
-      this._clientHeaders = null;
     }
+
+    return result;
   }
 
-  buildHeaders(credentials, stream = true) {
+  buildHeaders(
+    credentials: ProviderCredentials,
+    stream = true,
+    clientHeaders?: Record<string, string> | null
+  ): Record<string, string> {
     const token = this.getCopilotToken(credentials) || credentials.accessToken;
 
     // Forward the client's x-initiator header when present. OpenCode and other
@@ -152,8 +124,9 @@ export class GithubExecutor extends BaseExecutor {
     // free, so forwarding the value avoids burning a premium request on every
     // tool-call round-trip.  Fall back to "user" when the header is absent to
     // preserve the existing default behaviour.
-    const ch = this._clientHeaders;
-    const clientInitiator = ch?.["x-initiator"] || ch?.["X-Initiator"];
+    const clientInitiator = Object.entries(clientHeaders || {}).find(
+      ([key]) => key.toLowerCase() === "x-initiator"
+    )?.[1];
     const initiator =
       clientInitiator === "agent" || clientInitiator === "user" ? clientInitiator : "user";
 

--- a/open-sse/executors/github.ts
+++ b/open-sse/executors/github.ts
@@ -71,7 +71,9 @@ export class GithubExecutor extends BaseExecutor {
 
     if (Array.isArray(sourceBody.messages)) {
       modifiedBody.messages = sourceBody.messages.map((msg) => {
-        if (!msg || typeof msg !== "object" || msg.role !== "assistant") return msg;
+        if (!msg || typeof msg !== "object") return msg;
+        const role = typeof msg.role === "string" ? msg.role.toLowerCase() : "";
+        if (role !== "assistant") return msg;
         if (msg.reasoning_text === undefined && msg.reasoning_content === undefined) return msg;
         const next = { ...msg };
         delete next.reasoning_text;
@@ -124,9 +126,15 @@ export class GithubExecutor extends BaseExecutor {
     // free, so forwarding the value avoids burning a premium request on every
     // tool-call round-trip.  Fall back to "user" when the header is absent to
     // preserve the existing default behaviour.
-    const clientInitiator = Object.entries(clientHeaders || {}).find(
-      ([key]) => key.toLowerCase() === "x-initiator"
-    )?.[1];
+    let clientInitiator = clientHeaders?.["x-initiator"] || clientHeaders?.["X-Initiator"];
+    if (!clientInitiator && clientHeaders) {
+      for (const key in clientHeaders) {
+        if (key.toLowerCase() === "x-initiator") {
+          clientInitiator = clientHeaders[key];
+          break;
+        }
+      }
+    }
     const initiator =
       clientInitiator === "agent" || clientInitiator === "user" ? clientInitiator : "user";
 

--- a/open-sse/executors/kiro.ts
+++ b/open-sse/executors/kiro.ts
@@ -15,11 +15,14 @@ type UsageSummary = {
   prompt_tokens: number;
   completion_tokens: number;
   total_tokens: number;
+  cache_read_input_tokens?: number;
+  cache_creation_input_tokens?: number;
 };
 
 type KiroStreamState = {
   endDetected: boolean;
   finishEmitted: boolean;
+  stopSeen: boolean;
   hasToolCalls: boolean;
   toolCallIndex: number;
   seenToolIds: Map<string, number>;
@@ -34,6 +37,66 @@ type EventFrame = {
   headers: Record<string, string>;
   payload: JsonRecord | null;
 };
+
+class ByteQueue {
+  private chunks: Uint8Array[] = [];
+  private headOffset = 0;
+  length = 0;
+
+  push(chunk: Uint8Array) {
+    if (!(chunk instanceof Uint8Array) || chunk.length === 0) return;
+    this.chunks.push(chunk);
+    this.length += chunk.length;
+  }
+
+  peekUint32BE(offset = 0): number | null {
+    if (this.length < offset + 4) return null;
+
+    let value = 0;
+    for (let i = 0; i < 4; i++) {
+      value = (value << 8) | this.byteAt(offset + i);
+    }
+    return value >>> 0;
+  }
+
+  read(length: number): Uint8Array | null {
+    if (length < 0 || this.length < length) return null;
+
+    const output = new Uint8Array(length);
+    let written = 0;
+
+    while (written < length) {
+      const head = this.chunks[0];
+      const available = head.length - this.headOffset;
+      const take = Math.min(available, length - written);
+      output.set(head.subarray(this.headOffset, this.headOffset + take), written);
+      written += take;
+      this.headOffset += take;
+      this.length -= take;
+
+      if (this.headOffset >= head.length) {
+        this.chunks.shift();
+        this.headOffset = 0;
+      }
+    }
+
+    return output;
+  }
+
+  private byteAt(offset: number): number {
+    let remaining = offset;
+    for (let i = 0; i < this.chunks.length; i++) {
+      const chunk = this.chunks[i];
+      const start = i === 0 ? this.headOffset : 0;
+      const available = chunk.length - start;
+      if (remaining < available) {
+        return chunk[start + remaining];
+      }
+      remaining -= available;
+    }
+    return 0;
+  }
+}
 
 // ── CRC32 lookup table (IEEE polynomial, no dependency) ──
 const CRC32_TABLE = new Uint32Array(256);
@@ -53,6 +116,56 @@ function crc32(buf: Uint8Array) {
     crc = CRC32_TABLE[(crc ^ buf[i]) & 0xff] ^ (crc >>> 8);
   }
   return (crc ^ 0xffffffff) >>> 0;
+}
+
+function buildKiroFinishChunk(
+  state: KiroStreamState,
+  responseId: string,
+  created: number,
+  model: string,
+  includeUsage: boolean
+): JsonRecord {
+  const finishChunk: JsonRecord = {
+    id: responseId,
+    object: "chat.completion.chunk",
+    created,
+    model,
+    choices: [
+      {
+        index: 0,
+        delta: {},
+        finish_reason: state.hasToolCalls ? "tool_calls" : "stop",
+      },
+    ],
+  };
+
+  if (includeUsage && state.usage) {
+    finishChunk.usage = state.usage;
+  }
+
+  return finishChunk;
+}
+
+function ensureKiroUsage(state: KiroStreamState) {
+  if (state.usage) return;
+
+  const estimatedOutputTokens =
+    state.totalContentLength && state.totalContentLength > 0
+      ? Math.max(1, Math.floor(state.totalContentLength / 4))
+      : 0;
+
+  const estimatedInputTokens =
+    state.contextUsagePercentage && state.contextUsagePercentage > 0
+      ? Math.floor((state.contextUsagePercentage * 200000) / 100)
+      : 0;
+
+  if (estimatedInputTokens <= 0 && estimatedOutputTokens <= 0) return;
+
+  state.usage = {
+    prompt_tokens: estimatedInputTokens,
+    completion_tokens: estimatedOutputTokens,
+    total_tokens: estimatedInputTokens + estimatedOutputTokens,
+  };
 }
 
 /**
@@ -131,13 +244,14 @@ export class KiroExecutor extends BaseExecutor {
    * Using TransformStream instead of ReadableStream.pull() to avoid Workers timeout
    */
   transformEventStreamToSSE(response: Response, model: string) {
-    let buffer = new Uint8Array(0);
+    const buffer = new ByteQueue();
     let chunkIndex = 0;
     const responseId = `chatcmpl-${Date.now()}`;
     const created = Math.floor(Date.now() / 1000);
     const state: KiroStreamState = {
       endDetected: false,
       finishEmitted: false,
+      stopSeen: false,
       hasToolCalls: false,
       toolCallIndex: 0,
       seenToolIds: new Map(),
@@ -145,24 +259,19 @@ export class KiroExecutor extends BaseExecutor {
 
     const transformStream = new TransformStream({
       async transform(chunk, controller) {
-        // Append to buffer
-        const newBuffer = new Uint8Array(buffer.length + chunk.length);
-        newBuffer.set(buffer);
-        newBuffer.set(chunk, buffer.length);
-        buffer = newBuffer;
+        buffer.push(chunk);
 
         // Parse events from buffer
         let iterations = 0;
         const maxIterations = 1000;
         while (buffer.length >= 16 && iterations < maxIterations) {
           iterations++;
-          const view = new DataView(buffer.buffer, buffer.byteOffset);
-          const totalLength = view.getUint32(0, false);
+          const totalLength = buffer.peekUint32BE(0);
 
-          if (totalLength < 16 || totalLength > buffer.length || buffer.length < totalLength) break;
+          if (!totalLength || totalLength < 16 || totalLength > buffer.length) break;
 
-          const eventData = buffer.slice(0, totalLength);
-          buffer = buffer.slice(totalLength);
+          const eventData = buffer.read(totalLength);
+          if (!eventData) break;
 
           const event = parseEventFrame(eventData);
           if (!event) continue;
@@ -308,21 +417,7 @@ export class KiroExecutor extends BaseExecutor {
 
           // Handle messageStopEvent
           if (eventType === "messageStopEvent") {
-            const chunk: JsonRecord = {
-              id: responseId,
-              object: "chat.completion.chunk",
-              created,
-              model,
-              choices: [
-                {
-                  index: 0,
-                  delta: {},
-                  finish_reason: state.hasToolCalls ? "tool_calls" : "stop",
-                },
-              ],
-            };
-            state.finishEmitted = true;
-            controller.enqueue(TEXT_ENCODER.encode(`data: ${JSON.stringify(chunk)}\n\n`));
+            state.stopSeen = true;
           }
 
           // Handle contextUsageEvent to extract contextUsagePercentage
@@ -381,54 +476,6 @@ export class KiroExecutor extends BaseExecutor {
               }
             }
           }
-
-          // Emit final chunk only after receiving BOTH meteringEvent AND contextUsageEvent
-          if (state.hasMeteringEvent && state.hasContextUsage && !state.finishEmitted) {
-            state.finishEmitted = true;
-
-            // Estimate tokens if not available from events
-            if (!state.usage) {
-              // Estimate output tokens from content length
-              const estimatedOutputTokens =
-                state.totalContentLength > 0
-                  ? Math.max(1, Math.floor(state.totalContentLength / 4))
-                  : 0;
-
-              // Estimate input tokens from contextUsagePercentage
-              // Kiro models typically have 200k context window
-              const estimatedInputTokens =
-                state.contextUsagePercentage > 0
-                  ? Math.floor((state.contextUsagePercentage * 200000) / 100)
-                  : 0;
-
-              state.usage = {
-                prompt_tokens: estimatedInputTokens,
-                completion_tokens: estimatedOutputTokens,
-                total_tokens: estimatedInputTokens + estimatedOutputTokens,
-              };
-            }
-
-            const finishChunk: JsonRecord = {
-              id: responseId,
-              object: "chat.completion.chunk",
-              created,
-              model,
-              choices: [
-                {
-                  index: 0,
-                  delta: {},
-                  finish_reason: state.hasToolCalls ? "tool_calls" : "stop",
-                },
-              ],
-            };
-
-            // Include usage in final chunk if available
-            if (state.usage) {
-              finishChunk.usage = state.usage;
-            }
-
-            controller.enqueue(TEXT_ENCODER.encode(`data: ${JSON.stringify(finishChunk)}\n\n`));
-          }
         }
 
         if (iterations >= maxIterations) {
@@ -440,19 +487,8 @@ export class KiroExecutor extends BaseExecutor {
         // Emit finish chunk if not already sent
         if (!state.finishEmitted) {
           state.finishEmitted = true;
-          const finishChunk = {
-            id: responseId,
-            object: "chat.completion.chunk",
-            created,
-            model,
-            choices: [
-              {
-                index: 0,
-                delta: {},
-                finish_reason: state.hasToolCalls ? "tool_calls" : "stop",
-              },
-            ],
-          };
+          ensureKiroUsage(state);
+          const finishChunk = buildKiroFinishChunk(state, responseId, created, model, true);
           controller.enqueue(TEXT_ENCODER.encode(`data: ${JSON.stringify(finishChunk)}\n\n`));
         }
 

--- a/open-sse/executors/kiro.ts
+++ b/open-sse/executors/kiro.ts
@@ -37,6 +37,8 @@ type EventFrame = {
 
 // ── CRC32 lookup table (IEEE polynomial, no dependency) ──
 const CRC32_TABLE = new Uint32Array(256);
+const TEXT_ENCODER = new TextEncoder();
+const TEXT_DECODER = new TextDecoder();
 for (let i = 0; i < 256; i++) {
   let c = i;
   for (let j = 0; j < 8; j++) {
@@ -193,7 +195,7 @@ export class KiroExecutor extends BaseExecutor {
               ],
             };
             chunkIndex++;
-            controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(chunk)}\n\n`));
+            controller.enqueue(TEXT_ENCODER.encode(`data: ${JSON.stringify(chunk)}\n\n`));
           }
 
           // Handle codeEvent
@@ -212,7 +214,7 @@ export class KiroExecutor extends BaseExecutor {
               ],
             };
             chunkIndex++;
-            controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(chunk)}\n\n`));
+            controller.enqueue(TEXT_ENCODER.encode(`data: ${JSON.stringify(chunk)}\n\n`));
           }
 
           // Handle toolUseEvent
@@ -260,9 +262,7 @@ export class KiroExecutor extends BaseExecutor {
                   ],
                 };
                 chunkIndex++;
-                controller.enqueue(
-                  new TextEncoder().encode(`data: ${JSON.stringify(startChunk)}\n\n`)
-                );
+                controller.enqueue(TEXT_ENCODER.encode(`data: ${JSON.stringify(startChunk)}\n\n`));
               } else {
                 toolIndex = state.seenToolIds.get(toolCallId);
               }
@@ -301,9 +301,7 @@ export class KiroExecutor extends BaseExecutor {
                   ],
                 };
                 chunkIndex++;
-                controller.enqueue(
-                  new TextEncoder().encode(`data: ${JSON.stringify(argsChunk)}\n\n`)
-                );
+                controller.enqueue(TEXT_ENCODER.encode(`data: ${JSON.stringify(argsChunk)}\n\n`));
               }
             }
           }
@@ -324,7 +322,7 @@ export class KiroExecutor extends BaseExecutor {
               ],
             };
             state.finishEmitted = true;
-            controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(chunk)}\n\n`));
+            controller.enqueue(TEXT_ENCODER.encode(`data: ${JSON.stringify(chunk)}\n\n`));
           }
 
           // Handle contextUsageEvent to extract contextUsagePercentage
@@ -429,9 +427,7 @@ export class KiroExecutor extends BaseExecutor {
               finishChunk.usage = state.usage;
             }
 
-            controller.enqueue(
-              new TextEncoder().encode(`data: ${JSON.stringify(finishChunk)}\n\n`)
-            );
+            controller.enqueue(TEXT_ENCODER.encode(`data: ${JSON.stringify(finishChunk)}\n\n`));
           }
         }
 
@@ -457,11 +453,11 @@ export class KiroExecutor extends BaseExecutor {
               },
             ],
           };
-          controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(finishChunk)}\n\n`));
+          controller.enqueue(TEXT_ENCODER.encode(`data: ${JSON.stringify(finishChunk)}\n\n`));
         }
 
         // Send final done message
-        controller.enqueue(new TextEncoder().encode("data: [DONE]\n\n"));
+        controller.enqueue(TEXT_ENCODER.encode("data: [DONE]\n\n"));
       },
     });
 
@@ -538,7 +534,7 @@ function parseEventFrame(data: Uint8Array): EventFrame | null {
       offset++;
       if (offset + nameLen > data.length) break;
 
-      const name = new TextDecoder().decode(data.slice(offset, offset + nameLen));
+      const name = TEXT_DECODER.decode(data.slice(offset, offset + nameLen));
       offset += nameLen;
 
       const headerType = data[offset];
@@ -550,7 +546,7 @@ function parseEventFrame(data: Uint8Array): EventFrame | null {
         offset += 2;
         if (offset + valueLen > data.length) break;
 
-        const value = new TextDecoder().decode(data.slice(offset, offset + valueLen));
+        const value = TEXT_DECODER.decode(data.slice(offset, offset + valueLen));
         offset += valueLen;
         headers[name] = value;
       } else {
@@ -564,7 +560,7 @@ function parseEventFrame(data: Uint8Array): EventFrame | null {
 
     let payload: JsonRecord | null = null;
     if (payloadEnd > payloadStart) {
-      const payloadStr = new TextDecoder().decode(data.slice(payloadStart, payloadEnd));
+      const payloadStr = TEXT_DECODER.decode(data.slice(payloadStart, payloadEnd));
 
       // Skip empty or whitespace-only payloads
       if (!payloadStr || !payloadStr.trim()) {

--- a/open-sse/executors/kiro.ts
+++ b/open-sse/executors/kiro.ts
@@ -534,7 +534,7 @@ function parseEventFrame(data: Uint8Array): EventFrame | null {
       offset++;
       if (offset + nameLen > data.length) break;
 
-      const name = TEXT_DECODER.decode(data.slice(offset, offset + nameLen));
+      const name = TEXT_DECODER.decode(data.subarray(offset, offset + nameLen));
       offset += nameLen;
 
       const headerType = data[offset];
@@ -546,7 +546,7 @@ function parseEventFrame(data: Uint8Array): EventFrame | null {
         offset += 2;
         if (offset + valueLen > data.length) break;
 
-        const value = TEXT_DECODER.decode(data.slice(offset, offset + valueLen));
+        const value = TEXT_DECODER.decode(data.subarray(offset, offset + valueLen));
         offset += valueLen;
         headers[name] = value;
       } else {
@@ -560,7 +560,7 @@ function parseEventFrame(data: Uint8Array): EventFrame | null {
 
     let payload: JsonRecord | null = null;
     if (payloadEnd > payloadStart) {
-      const payloadStr = TEXT_DECODER.decode(data.slice(payloadStart, payloadEnd));
+      const payloadStr = TEXT_DECODER.decode(data.subarray(payloadStart, payloadEnd));
 
       // Skip empty or whitespace-only payloads
       if (!payloadStr || !payloadStr.trim()) {

--- a/open-sse/executors/kiro.ts
+++ b/open-sse/executors/kiro.ts
@@ -22,12 +22,13 @@ type UsageSummary = {
 type KiroStreamState = {
   endDetected: boolean;
   finishEmitted: boolean;
+  doneEmitted: boolean;
   stopSeen: boolean;
   hasToolCalls: boolean;
   toolCallIndex: number;
   seenToolIds: Map<string, number>;
-  totalContentLength?: number;
-  contextUsagePercentage?: number;
+  totalContentLength: number;
+  contextUsagePercentage: number;
   hasContextUsage?: boolean;
   hasMeteringEvent?: boolean;
   usage?: UsageSummary;
@@ -102,6 +103,7 @@ class ByteQueue {
 const CRC32_TABLE = new Uint32Array(256);
 const TEXT_ENCODER = new TextEncoder();
 const TEXT_DECODER = new TextDecoder();
+const KIRO_POST_STOP_USAGE_WAIT_MS = 250;
 for (let i = 0; i < 256; i++) {
   let c = i;
   for (let j = 0; j < 8; j++) {
@@ -150,12 +152,10 @@ function ensureKiroUsage(state: KiroStreamState) {
   if (state.usage) return;
 
   const estimatedOutputTokens =
-    state.totalContentLength && state.totalContentLength > 0
-      ? Math.max(1, Math.floor(state.totalContentLength / 4))
-      : 0;
+    state.totalContentLength > 0 ? Math.max(1, Math.floor(state.totalContentLength / 4)) : 0;
 
   const estimatedInputTokens =
-    state.contextUsagePercentage && state.contextUsagePercentage > 0
+    state.contextUsagePercentage > 0
       ? Math.floor((state.contextUsagePercentage * 200000) / 100)
       : 0;
 
@@ -246,19 +246,57 @@ export class KiroExecutor extends BaseExecutor {
   transformEventStreamToSSE(response: Response, model: string) {
     const buffer = new ByteQueue();
     let chunkIndex = 0;
-    const responseId = `chatcmpl-${Date.now()}`;
+    let postStopTimer: ReturnType<typeof setTimeout> | null = null;
+    const responseId = `chatcmpl-${Date.now()}-${uuidv4().slice(0, 8)}`;
     const created = Math.floor(Date.now() / 1000);
     const state: KiroStreamState = {
       endDetected: false,
       finishEmitted: false,
+      doneEmitted: false,
       stopSeen: false,
       hasToolCalls: false,
       toolCallIndex: 0,
       seenToolIds: new Map(),
+      totalContentLength: 0,
+      contextUsagePercentage: 0,
     };
 
-    const transformStream = new TransformStream({
-      async transform(chunk, controller) {
+    const clearPostStopTimer = () => {
+      if (!postStopTimer) return;
+      clearTimeout(postStopTimer);
+      postStopTimer = null;
+    };
+
+    const emitKiroFinal = (
+      controller: TransformStreamDefaultController<Uint8Array>,
+      terminate = false
+    ) => {
+      clearPostStopTimer();
+      if (!state.finishEmitted) {
+        state.finishEmitted = true;
+        ensureKiroUsage(state);
+        const finishChunk = buildKiroFinishChunk(state, responseId, created, model, true);
+        controller.enqueue(TEXT_ENCODER.encode(`data: ${JSON.stringify(finishChunk)}\n\n`));
+      }
+      if (!state.doneEmitted) {
+        state.doneEmitted = true;
+        controller.enqueue(TEXT_ENCODER.encode("data: [DONE]\n\n"));
+      }
+      if (terminate) {
+        controller.terminate();
+      }
+    };
+
+    const schedulePostStopFinish = (controller: TransformStreamDefaultController<Uint8Array>) => {
+      if (postStopTimer || state.finishEmitted) return;
+      postStopTimer = setTimeout(() => {
+        postStopTimer = null;
+        emitKiroFinal(controller, true);
+      }, KIRO_POST_STOP_USAGE_WAIT_MS);
+    };
+
+    const transformStream = new TransformStream<Uint8Array, Uint8Array>({
+      async transform(chunk: Uint8Array, controller: TransformStreamDefaultController<Uint8Array>) {
         buffer.push(chunk);
 
         // Parse events from buffer
@@ -277,10 +315,6 @@ export class KiroExecutor extends BaseExecutor {
           if (!event) continue;
 
           const eventType = event.headers[":event-type"] || "";
-
-          // Track total content length for token estimation
-          if (!state.totalContentLength) state.totalContentLength = 0;
-          if (!state.contextUsagePercentage) state.contextUsagePercentage = 0;
 
           // Handle assistantResponseEvent
           if (eventType === "assistantResponseEvent") {
@@ -418,6 +452,7 @@ export class KiroExecutor extends BaseExecutor {
           // Handle messageStopEvent
           if (eventType === "messageStopEvent") {
             state.stopSeen = true;
+            schedulePostStopFinish(controller);
           }
 
           // Handle contextUsageEvent to extract contextUsagePercentage
@@ -484,16 +519,7 @@ export class KiroExecutor extends BaseExecutor {
       },
 
       flush(controller) {
-        // Emit finish chunk if not already sent
-        if (!state.finishEmitted) {
-          state.finishEmitted = true;
-          ensureKiroUsage(state);
-          const finishChunk = buildKiroFinishChunk(state, responseId, created, model, true);
-          controller.enqueue(TEXT_ENCODER.encode(`data: ${JSON.stringify(finishChunk)}\n\n`));
-        }
-
-        // Send final done message
-        controller.enqueue(TEXT_ENCODER.encode("data: [DONE]\n\n"));
+        emitKiroFinal(controller);
       },
     });
 

--- a/open-sse/translator/request/openai-to-kiro.ts
+++ b/open-sse/translator/request/openai-to-kiro.ts
@@ -6,7 +6,7 @@ import { register } from "../registry.ts";
 import { FORMATS } from "../formats.ts";
 import { v4 as uuidv4, v5 as uuidv5 } from "uuid";
 
-function parseToolInput(value) {
+function parseToolInput(value: unknown) {
   if (value && typeof value === "object" && !Array.isArray(value)) {
     return value;
   }

--- a/open-sse/translator/request/openai-to-kiro.ts
+++ b/open-sse/translator/request/openai-to-kiro.ts
@@ -6,6 +6,27 @@ import { register } from "../registry.ts";
 import { FORMATS } from "../formats.ts";
 import { v4 as uuidv4, v5 as uuidv5 } from "uuid";
 
+function parseToolInput(value) {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return value;
+  }
+  if (typeof value !== "string") {
+    return {};
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return {};
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
 /**
  * Convert OpenAI messages to Kiro format
  * Rules: system/tool/user -> user role, merge consecutive same roles
@@ -183,16 +204,13 @@ function convertMessages(messages, tools, model) {
               return {
                 toolUseId: tc.id || uuidv4(),
                 name: tc.function.name,
-                input:
-                  typeof tc.function.arguments === "string"
-                    ? JSON.parse(tc.function.arguments)
-                    : tc.function.arguments || {},
+                input: parseToolInput(tc.function.arguments),
               };
             } else {
               return {
                 toolUseId: tc.id || uuidv4(),
                 name: tc.name,
-                input: tc.input || {},
+                input: parseToolInput(tc.input),
               };
             }
           });

--- a/open-sse/utils/requestLogger.ts
+++ b/open-sse/utils/requestLogger.ts
@@ -44,9 +44,11 @@ type RequestLoggerOptions = {
   enabled?: boolean;
   captureStreamChunks?: boolean;
   maxStreamChunkBytes?: number;
+  maxStreamChunkItems?: number;
 };
 
 const DEFAULT_MAX_STREAM_CHUNK_BYTES = 128 * 1024;
+const DEFAULT_MAX_STREAM_CHUNK_ITEMS = 512;
 const MAX_LOG_STRING_LENGTH = 64 * 1024;
 const MAX_LOG_ARRAY_ITEMS = 24;
 const MAX_LOG_OBJECT_KEYS = 80;
@@ -129,9 +131,15 @@ function appendBoundedChunk(
   chunks: string[],
   bytes: { value: number; truncated: boolean },
   chunk: string,
-  maxBytes: number
+  maxBytes: number,
+  maxItems = DEFAULT_MAX_STREAM_CHUNK_ITEMS
 ) {
   if (typeof chunk !== "string" || chunk.length === 0) {
+    return;
+  }
+  if (chunks.length >= maxItems) {
+    bytes.truncated = true;
+    chunks[maxItems - 1] = `[stream chunk log truncated after ${maxItems} chunks]`;
     return;
   }
   if (bytes.value >= maxBytes) {
@@ -147,7 +155,9 @@ function appendBoundedChunk(
   }
 
   chunks.push(chunk.slice(0, remaining));
-  chunks.push(`[stream chunk log truncated after ${maxBytes} bytes]`);
+  if (chunks.length < maxItems) {
+    chunks.push(`[stream chunk log truncated after ${maxBytes} bytes]`);
+  }
   bytes.value = maxBytes;
   bytes.truncated = true;
 }
@@ -218,6 +228,10 @@ export async function createRequestLogger(
     Number.isInteger(options.maxStreamChunkBytes) && Number(options.maxStreamChunkBytes) > 0
       ? Number(options.maxStreamChunkBytes)
       : DEFAULT_MAX_STREAM_CHUNK_BYTES;
+  const maxStreamChunkItems =
+    Number.isInteger(options.maxStreamChunkItems) && Number(options.maxStreamChunkItems) > 0
+      ? Number(options.maxStreamChunkItems)
+      : DEFAULT_MAX_STREAM_CHUNK_ITEMS;
   const streamChunks = createEmptyStreamChunks();
   const streamChunkBytes = {
     provider: { value: 0, truncated: false },
@@ -272,13 +286,20 @@ export async function createRequestLogger(
         streamChunks.provider,
         streamChunkBytes.provider,
         chunk,
-        maxStreamChunkBytes
+        maxStreamChunkBytes,
+        maxStreamChunkItems
       );
     },
 
     appendOpenAIChunk(chunk) {
       if (!captureStreamChunks) return;
-      appendBoundedChunk(streamChunks.openai, streamChunkBytes.openai, chunk, maxStreamChunkBytes);
+      appendBoundedChunk(
+        streamChunks.openai,
+        streamChunkBytes.openai,
+        chunk,
+        maxStreamChunkBytes,
+        maxStreamChunkItems
+      );
     },
 
     logConvertedResponse(body) {
@@ -290,7 +311,13 @@ export async function createRequestLogger(
 
     appendConvertedChunk(chunk) {
       if (!captureStreamChunks) return;
-      appendBoundedChunk(streamChunks.client, streamChunkBytes.client, chunk, maxStreamChunkBytes);
+      appendBoundedChunk(
+        streamChunks.client,
+        streamChunkBytes.client,
+        chunk,
+        maxStreamChunkBytes,
+        maxStreamChunkItems
+      );
     },
 
     logError(error, requestBody = null) {

--- a/src/lib/usage/callLogArtifacts.ts
+++ b/src/lib/usage/callLogArtifacts.ts
@@ -8,6 +8,7 @@ const isBuildPhase = process.env.NEXT_PHASE === "phase-production-build";
 const DATA_DIR = resolveDataDir({ isCloud });
 
 export const CALL_LOGS_DIR = isCloud ? null : path.join(DATA_DIR, "call_logs");
+export const MAX_CALL_LOG_ARTIFACT_BYTES = 512 * 1024;
 
 export type CallLogDetailState = "none" | "ready" | "missing" | "corrupt" | "legacy-inline";
 
@@ -72,6 +73,92 @@ function computeArtifactChecksum(serialized: string): string {
   return hash.toString(16).padStart(8, "0");
 }
 
+function truncateArtifactForStorage(artifact: CallLogArtifact): CallLogArtifact {
+  const pipeline = artifact.pipeline;
+  if (!pipeline?.streamChunks) return artifact;
+
+  return {
+    ...artifact,
+    pipeline: {
+      ...pipeline,
+      streamChunks: {
+        provider: pipeline.streamChunks.provider?.length
+          ? ["[stream chunks omitted: call log artifact size limit exceeded]"]
+          : undefined,
+        openai: pipeline.streamChunks.openai?.length
+          ? ["[stream chunks omitted: call log artifact size limit exceeded]"]
+          : undefined,
+        client: pipeline.streamChunks.client?.length
+          ? ["[stream chunks omitted: call log artifact size limit exceeded]"]
+          : undefined,
+      },
+    },
+  };
+}
+
+function omitOversizedPipeline(artifact: CallLogArtifact): CallLogArtifact {
+  if (!artifact.pipeline) return artifact;
+
+  return {
+    ...artifact,
+    pipeline: {
+      error: {
+        _omniroute_truncated: true,
+        reason: "call_log_artifact_size_limit_exceeded",
+      },
+    },
+  };
+}
+
+function serializeArtifactForStorage(artifact: CallLogArtifact): string {
+  const serialized = JSON.stringify(artifact, null, 2);
+  if (Buffer.byteLength(serialized) <= MAX_CALL_LOG_ARTIFACT_BYTES) {
+    return serialized;
+  }
+
+  const truncated = JSON.stringify(truncateArtifactForStorage(artifact), null, 2);
+  if (Buffer.byteLength(truncated) <= MAX_CALL_LOG_ARTIFACT_BYTES) {
+    return truncated;
+  }
+
+  const withoutPipeline = JSON.stringify(omitOversizedPipeline(artifact), null, 2);
+  if (Buffer.byteLength(withoutPipeline) <= MAX_CALL_LOG_ARTIFACT_BYTES) {
+    return withoutPipeline;
+  }
+
+  const minimal = JSON.stringify(
+    {
+      ...omitOversizedPipeline(artifact),
+      requestBody: "[omitted: call log artifact size limit exceeded]",
+      responseBody: "[omitted: call log artifact size limit exceeded]",
+      error: artifact.error ? "[omitted: call log artifact size limit exceeded]" : null,
+    },
+    null,
+    2
+  );
+  if (Buffer.byteLength(minimal) <= MAX_CALL_LOG_ARTIFACT_BYTES) {
+    return minimal;
+  }
+
+  return JSON.stringify(
+    {
+      schemaVersion: artifact.schemaVersion,
+      summary: artifact.summary,
+      requestBody: "[omitted: call log artifact size limit exceeded]",
+      responseBody: "[omitted: call log artifact size limit exceeded]",
+      error: artifact.error ? "[omitted: call log artifact size limit exceeded]" : null,
+      pipeline: {
+        error: {
+          _omniroute_truncated: true,
+          reason: "call_log_artifact_size_limit_exceeded",
+        },
+      },
+    },
+    null,
+    2
+  );
+}
+
 export function writeCallArtifact(
   artifact: CallLogArtifact,
   relativePath = buildArtifactRelativePath(artifact.summary.timestamp, artifact.summary.id)
@@ -82,7 +169,7 @@ export function writeCallArtifact(
   const tmpPath = `${absPath}.${process.pid}.${Date.now()}.tmp`;
 
   try {
-    const serialized = JSON.stringify(artifact, null, 2);
+    const serialized = serializeArtifactForStorage(artifact);
     const sizeBytes = Buffer.byteLength(serialized);
     // Keep the legacy field name for storage compatibility, but use a non-cryptographic checksum
     // so artifact bookkeeping is not treated as password hashing by static analysis.

--- a/tests/unit/call-log-cap.test.ts
+++ b/tests/unit/call-log-cap.test.ts
@@ -452,6 +452,95 @@ test("saveCallLog keeps large payloads out of SQLite while preserving explicit d
   assert.equal((exported[0] as any).requestBody.payload.length, requestBody.payload.length);
 });
 
+test("saveCallLog truncates oversized call log artifacts for storage", async () => {
+  const hugeChunk = "x".repeat(600 * 1024);
+
+  await callLogs.saveCallLog({
+    id: "truncated-artifact",
+    timestamp: "2026-03-31T10:05:00.000Z",
+    method: "POST",
+    path: "/v1/chat/completions",
+    status: 200,
+    model: "openai/gpt-4.1",
+    provider: "openai",
+    requestBody: { payload: "request" },
+    responseBody: { output: "response" },
+    pipelinePayloads: {
+      streamChunks: {
+        provider: [hugeChunk],
+        openai: [hugeChunk],
+        client: [hugeChunk],
+      },
+    },
+  });
+
+  const db = core.getDbInstance();
+  const row = db
+    .prepare(
+      `
+      SELECT artifact_relpath, artifact_size_bytes, detail_state
+      FROM call_logs WHERE id = ?
+    `
+    )
+    .get("truncated-artifact");
+  assert.equal((row as any).detail_state, "ready");
+  assert.ok((row as any).artifact_size_bytes <= 512 * 1024);
+
+  const artifactPath = path.join(TEST_DATA_DIR, "call_logs", (row as any).artifact_relpath);
+  const artifact = JSON.parse(fs.readFileSync(artifactPath, "utf8"));
+  assert.deepEqual(artifact.requestBody, { payload: "request" });
+  assert.deepEqual(artifact.responseBody, { output: "response" });
+  assert.equal(artifact.error, null);
+  assert.deepEqual(artifact.pipeline.streamChunks, {
+    provider: ["[stream chunks omitted: call log artifact size limit exceeded]"],
+    openai: ["[stream chunks omitted: call log artifact size limit exceeded]"],
+    client: ["[stream chunks omitted: call log artifact size limit exceeded]"],
+  });
+});
+
+test("saveCallLog omits oversized non-stream pipeline payloads to enforce artifact cap", async () => {
+  const hugePayload = "x".repeat(600 * 1024);
+
+  await callLogs.saveCallLog({
+    id: "truncated-pipeline-artifact",
+    timestamp: "2026-03-31T10:06:00.000Z",
+    method: "POST",
+    path: "/v1/chat/completions",
+    status: 200,
+    model: "openai/gpt-4.1",
+    provider: "openai",
+    requestBody: { payload: "request" },
+    responseBody: { output: "response" },
+    pipelinePayloads: {
+      providerRequest: { body: hugePayload },
+      providerResponse: { body: hugePayload },
+    },
+  });
+
+  const db = core.getDbInstance();
+  const row = db
+    .prepare(
+      `
+      SELECT artifact_relpath, artifact_size_bytes, detail_state
+      FROM call_logs WHERE id = ?
+    `
+    )
+    .get("truncated-pipeline-artifact");
+  assert.equal((row as any).detail_state, "ready");
+  assert.ok((row as any).artifact_size_bytes <= 512 * 1024);
+
+  const artifactPath = path.join(TEST_DATA_DIR, "call_logs", (row as any).artifact_relpath);
+  const artifact = JSON.parse(fs.readFileSync(artifactPath, "utf8"));
+  assert.deepEqual(artifact.requestBody, { payload: "request" });
+  assert.deepEqual(artifact.responseBody, { output: "response" });
+  assert.deepEqual(artifact.pipeline, {
+    error: {
+      _omniroute_truncated: true,
+      reason: "call_log_artifact_size_limit_exceeded",
+    },
+  });
+});
+
 test("saveCallLog logs and returns when sqlite persistence throws unexpectedly", async () => {
   const db = core.getDbInstance();
   const originalPrepare = db.prepare;

--- a/tests/unit/executor-antigravity.test.ts
+++ b/tests/unit/executor-antigravity.test.ts
@@ -244,6 +244,70 @@ test("AntigravityExecutor.collectStreamToResponse turns SSE Gemini chunks into a
   });
 });
 
+test("AntigravityExecutor.collectStreamToResponse parses fragmented SSE lines incrementally", async () => {
+  const executor = new AntigravityExecutor();
+  const encoder = new TextEncoder();
+  const streamText = [
+    `data: ${JSON.stringify({
+      response: {
+        candidates: [{ content: { parts: [{ text: "Frag" }] } }],
+      },
+    })}\n\n`,
+    `data: ${JSON.stringify({
+      response: {
+        candidates: [
+          {
+            content: { parts: [{ text: "mented" }] },
+            finishReason: "STOP",
+          },
+        ],
+        usageMetadata: {
+          promptTokenCount: 9,
+          candidatesTokenCount: 4,
+          totalTokenCount: 13,
+        },
+      },
+    })}\n\n`,
+  ].join("");
+  const response = new Response(
+    new ReadableStream({
+      start(controller) {
+        for (const chunk of [
+          streamText.slice(0, 6),
+          streamText.slice(6, 31),
+          streamText.slice(31, 79),
+          streamText.slice(79, 143),
+          streamText.slice(143),
+        ]) {
+          controller.enqueue(encoder.encode(chunk));
+        }
+        controller.close();
+      },
+    }),
+    {
+      status: 200,
+      headers: { "Content-Type": "text/event-stream" },
+    }
+  );
+
+  const result = await executor.collectStreamToResponse(
+    response,
+    "gemini-2.5-flash",
+    "https://example.com",
+    { Authorization: "Bearer ag-token" },
+    { request: {} }
+  );
+  const payload = (await result.response.json()) as any;
+
+  assert.equal(payload.choices[0].message.content, "Fragmented");
+  assert.equal(payload.choices[0].finish_reason, "stop");
+  assert.deepEqual(payload.usage, {
+    prompt_tokens: 9,
+    completion_tokens: 4,
+    total_tokens: 13,
+  });
+});
+
 test("AntigravityExecutor.refreshCredentials refreshes Google OAuth tokens", async () => {
   const executor = new AntigravityExecutor();
   const originalFetch = globalThis.fetch;

--- a/tests/unit/executor-github.test.ts
+++ b/tests/unit/executor-github.test.ts
@@ -68,7 +68,68 @@ test("GithubExecutor.buildHeaders prefers Copilot token and sets GitHub-specific
   assert.equal(headers["user-agent"], "GitHubCopilotChat/0.38.0");
   assert.equal(headers["x-github-api-version"], "2025-04-01");
   assert.equal(headers["openai-intent"], "conversation-panel");
+  assert.equal(headers["X-Initiator"], "user");
   assert.ok(headers["x-request-id"]);
+});
+
+test("GithubExecutor.buildHeaders forwards valid client x-initiator and falls back for invalid values", () => {
+  const executor = new GithubExecutor();
+
+  const agentHeaders = executor.buildHeaders({ accessToken: "gh-access-token" }, true, {
+    "x-initiator": "agent",
+  });
+  assert.equal(agentHeaders["X-Initiator"], "agent");
+
+  const invalidHeaders = executor.buildHeaders({ accessToken: "gh-access-token" }, true, {
+    "x-initiator": "automation",
+  });
+  assert.equal(invalidHeaders["X-Initiator"], "user");
+
+  const mixedCaseHeaders = executor.buildHeaders({ accessToken: "gh-access-token" }, true, {
+    "X-InItIaToR": "agent",
+  });
+  assert.equal(mixedCaseHeaders["X-Initiator"], "agent");
+});
+
+test("GithubExecutor.execute forwards client x-initiator headers without shared state", async () => {
+  const executor = new GithubExecutor();
+  const originalFetch = globalThis.fetch;
+  const seenInitiators: string[] = [];
+
+  globalThis.fetch = async (_url, init: RequestInit = {}) => {
+    seenInitiators.push((init.headers as Record<string, string>)["X-Initiator"]);
+    return new Response(JSON.stringify({ choices: [] }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+
+  try {
+    await executor.execute({
+      model: "gpt-4.1",
+      body: { messages: [{ role: "user", content: "hi" }] },
+      stream: false,
+      credentials: {
+        accessToken: "gh-access-token",
+        providerSpecificData: { copilotToken: "copilot-token" },
+      },
+      clientHeaders: { "x-initiator": "agent" },
+    });
+    await executor.execute({
+      model: "gpt-4.1",
+      body: { messages: [{ role: "user", content: "hi" }] },
+      stream: false,
+      credentials: {
+        accessToken: "gh-access-token",
+        providerSpecificData: { copilotToken: "copilot-token" },
+      },
+      clientHeaders: { "x-initiator": "user" },
+    });
+
+    assert.deepEqual(seenInitiators, ["agent", "user"]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 });
 
 test("GithubExecutor.refreshCredentials returns Copilot token directly when available", async () => {
@@ -108,7 +169,7 @@ test("GithubExecutor.refreshCredentials falls back to GitHub OAuth refresh befor
   const originalFetch = globalThis.fetch;
   const calls = [];
 
-  globalThis.fetch = async (url, options = {}) => {
+  globalThis.fetch = async (url, options: RequestInit = {}) => {
     calls.push(String(url));
 
     if (String(url).includes("/copilot_internal/v2/token") && calls.length === 1) {
@@ -127,7 +188,7 @@ test("GithubExecutor.refreshCredentials falls back to GitHub OAuth refresh befor
     }
 
     if (String(url).includes("/copilot_internal/v2/token")) {
-      assert.equal(options.headers.Authorization, "token new-gh-token");
+      assert.equal((options.headers as Record<string, string>).Authorization, "token new-gh-token");
       return new Response(
         JSON.stringify({
           token: "new-copilot-token",
@@ -189,7 +250,7 @@ test("GithubExecutor.needsRefresh checks missing and expiring Copilot tokens", (
   );
 });
 
-test("GithubExecutor.execute strips terminal [DONE] frames from SSE responses", async () => {
+test("GithubExecutor.execute preserves complete SSE responses including terminal [DONE] frames", async () => {
   const executor = new GithubExecutor();
   const originalFetch = globalThis.fetch;
   globalThis.fetch = async () =>
@@ -217,7 +278,7 @@ test("GithubExecutor.execute strips terminal [DONE] frames from SSE responses", 
     const text = await result.response.text();
 
     assert.match(text, /"chunk":"one"/);
-    assert.doesNotMatch(text, /\[DONE\]/);
+    assert.match(text, /\[DONE\]/);
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/tests/unit/executor-kiro.test.ts
+++ b/tests/unit/executor-kiro.test.ts
@@ -69,11 +69,15 @@ function buildEventFrame(eventType, payload) {
 }
 
 function buildEventStreamResponse(frames) {
+  return buildEventStreamResponseFromChunks(frames);
+}
+
+function buildEventStreamResponseFromChunks(chunks) {
   return new Response(
     new ReadableStream({
       start(controller) {
-        for (const frame of frames) {
-          controller.enqueue(frame);
+        for (const chunk of chunks) {
+          controller.enqueue(chunk);
         }
         controller.close();
       },
@@ -83,6 +87,15 @@ function buildEventStreamResponse(frames) {
       headers: { "Content-Type": "application/vnd.amazon.eventstream" },
     }
   );
+}
+
+function parseSSEJsonChunks(text) {
+  return text
+    .split("\n")
+    .filter((line) => line.startsWith("data: "))
+    .map((line) => line.slice(6).trim())
+    .filter((payload) => payload && payload !== "[DONE]")
+    .map((payload) => JSON.parse(payload));
 }
 
 test("KiroExecutor.buildHeaders includes Kiro-specific auth and metadata", () => {
@@ -147,6 +160,39 @@ test("KiroExecutor.transformEventStreamToSSE converts text, tool calls, usage an
   assert.match(text, /"prompt_tokens":4/);
   assert.match(text, /"completion_tokens":6/);
   assert.match(text, /"finish_reason":"tool_calls"/);
+  assert.match(text, /\[DONE\]/);
+});
+
+test("KiroExecutor.transformEventStreamToSSE parses fragmented frames and waits for post-stop usage", async () => {
+  const executor = new KiroExecutor();
+  const bytes = concatArrays(
+    buildEventFrame("assistantResponseEvent", { content: "Hello fragmented" }),
+    buildEventFrame("messageStopEvent", {}),
+    buildEventFrame("metricsEvent", { inputTokens: 11, outputTokens: 13 }),
+    buildEventFrame("contextUsageEvent", { contextUsagePercentage: 17 }),
+    buildEventFrame("meteringEvent", {})
+  );
+  const response = buildEventStreamResponseFromChunks([
+    bytes.subarray(0, 2),
+    bytes.subarray(2, 9),
+    bytes.subarray(9, 37),
+    bytes.subarray(37, 91),
+    bytes.subarray(91),
+  ]);
+
+  const transformed = executor.transformEventStreamToSSE(response, "kiro-model");
+  const text = await transformed.text();
+  const chunks = parseSSEJsonChunks(text);
+  const finishChunks = chunks.filter((chunk) => chunk.choices?.[0]?.finish_reason);
+
+  assert.match(text, /"content":"Hello fragmented"/);
+  assert.equal(finishChunks.length, 1);
+  assert.equal(finishChunks[0].choices[0].finish_reason, "stop");
+  assert.deepEqual(finishChunks[0].usage, {
+    prompt_tokens: 11,
+    completion_tokens: 13,
+    total_tokens: 24,
+  });
   assert.match(text, /\[DONE\]/);
 });
 

--- a/tests/unit/executor-kiro.test.ts
+++ b/tests/unit/executor-kiro.test.ts
@@ -196,6 +196,32 @@ test("KiroExecutor.transformEventStreamToSSE parses fragmented frames and waits 
   assert.match(text, /\[DONE\]/);
 });
 
+test("KiroExecutor.transformEventStreamToSSE finalizes after messageStopEvent even if upstream stays open", async () => {
+  const executor = new KiroExecutor();
+  const response = new Response(
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue(buildEventFrame("assistantResponseEvent", { content: "Done soon" }));
+        controller.enqueue(buildEventFrame("messageStopEvent", {}));
+      },
+    }),
+    {
+      status: 200,
+      headers: { "Content-Type": "application/vnd.amazon.eventstream" },
+    }
+  );
+
+  const transformed = executor.transformEventStreamToSSE(response, "kiro-model");
+  const text = await transformed.text();
+  const chunks = parseSSEJsonChunks(text);
+  const finishChunks = chunks.filter((chunk) => chunk.choices?.[0]?.finish_reason);
+
+  assert.match(text, /"content":"Done soon"/);
+  assert.equal(finishChunks.length, 1);
+  assert.equal(finishChunks[0].choices[0].finish_reason, "stop");
+  assert.match(text, /\[DONE\]/);
+});
+
 test("KiroExecutor.transformEventStreamToSSE deduplicates tool starts and handles malformed payload JSON", async () => {
   const executor = new KiroExecutor();
   const response = buildEventStreamResponse([

--- a/tests/unit/stream-utils.test.ts
+++ b/tests/unit/stream-utils.test.ts
@@ -953,3 +953,22 @@ test("createRequestLogger skips disabled logs and caps retained stream chunk byt
     "[stream chunk log truncated after 5 bytes]",
   ]);
 });
+
+test("createRequestLogger caps retained stream chunk item count", async () => {
+  const logger = await createRequestLogger("openai", "openai", "gpt-test", {
+    enabled: true,
+    captureStreamChunks: true,
+    maxStreamChunkBytes: 1024,
+    maxStreamChunkItems: 2,
+  });
+
+  logger.appendProviderChunk("one");
+  logger.appendProviderChunk("two");
+  logger.appendProviderChunk("three");
+
+  const payloads = logger.getPipelinePayloads();
+  assert.deepEqual(payloads.streamChunks.provider, [
+    "one",
+    "[stream chunk log truncated after 2 chunks]",
+  ]);
+});

--- a/tests/unit/t27-github-copilot-response-format.test.ts
+++ b/tests/unit/t27-github-copilot-response-format.test.ts
@@ -53,7 +53,7 @@ test("T27: non-Claude models keep response_format untouched", () => {
   assert.deepEqual(transformed.response_format, { type: "json_object" });
 });
 
-test("T27: SSE [DONE] guard applies only in streaming mode", async () => {
+test("T27: GitHub executor preserves SSE frames and only materializes non-streaming bodies", async () => {
   const executor = new GithubExecutor();
   const originalExecute = BaseExecutor.prototype.execute;
 
@@ -66,6 +66,8 @@ test("T27: SSE [DONE] guard applies only in streaming mode", async () => {
       }
     ),
     url: "https://api.githubcopilot.com/chat/completions",
+    headers: {},
+    transformedBody: {},
   });
 
   try {
@@ -76,7 +78,7 @@ test("T27: SSE [DONE] guard applies only in streaming mode", async () => {
       credentials: { accessToken: "token" },
     });
     const streamingText = await streamingResult.response.text();
-    assert.equal(streamingText.includes("data: [DONE]"), false);
+    assert.equal(streamingText.includes("data: [DONE]"), true);
     assert.equal(streamingText.includes("data: tail"), true);
 
     const nonStreamingResult = await executor.execute({
@@ -102,6 +104,8 @@ test("T27: streaming error responses keep their original body readable", async (
       headers: { "content-type": "text/plain; charset=utf-8" },
     }),
     url: "https://api.githubcopilot.com/chat/completions",
+    headers: {},
+    transformedBody: {},
   });
 
   try {
@@ -120,8 +124,8 @@ test("T27: streaming error responses keep their original body readable", async (
 });
 
 test("T27: requests use copilotToken from providerSpecificData when available", async () => {
-  globalThis.fetch = async (_url, init = {}) => {
-    assert.equal(init.headers.Authorization, "Bearer copilot_test");
+  globalThis.fetch = async (_url, init: RequestInit = {}) => {
+    assert.equal((init.headers as Record<string, string>).Authorization, "Bearer copilot_test");
     return new Response(
       JSON.stringify({
         choices: [
@@ -157,7 +161,14 @@ test("T27: non-stream execute materializes provider responses before returning",
   const originalExecute = BaseExecutor.prototype.execute;
 
   class WeirdResponse {
-    constructor(body, init = {}) {
+    _body: string;
+    status: number;
+    statusText: string;
+    headers: Headers;
+    bodyUsed: boolean;
+    body: Record<string, unknown>;
+
+    constructor(body: string, init: ResponseInit = {}) {
       this._body = body;
       this.status = init.status || 200;
       this.statusText = init.statusText || "OK";
@@ -181,6 +192,8 @@ test("T27: non-stream execute materializes provider responses before returning",
       headers: { "content-type": "application/json" },
     }),
     url: "https://api.githubcopilot.com/chat/completions",
+    headers: {},
+    transformedBody: {},
   });
 
   try {

--- a/tests/unit/translator-openai-to-kiro.test.ts
+++ b/tests/unit/translator-openai-to-kiro.test.ts
@@ -110,6 +110,90 @@ test("OpenAI -> Kiro preserves prior history, tool uses and accumulated tool res
   assert.equal(context.tools[0].toolSpecification.name, "read_file");
 });
 
+test("OpenAI -> Kiro maps invalid or empty assistant tool call arguments to empty input", () => {
+  const invalidResult = buildKiroPayload(
+    "claude-sonnet-4",
+    {
+      messages: [
+        { role: "user", content: "Call a tool" },
+        {
+          role: "assistant",
+          tool_calls: [
+            {
+              id: "call_invalid",
+              type: "function",
+              function: { name: "read_file", arguments: "{not-json" },
+            },
+          ],
+        },
+        { role: "user", content: "continue" },
+      ],
+    },
+    false,
+    null
+  );
+
+  assert.deepEqual(
+    (invalidResult.conversationState.history[1] as any).assistantResponseMessage.toolUses[0].input,
+    {}
+  );
+
+  const emptyResult = buildKiroPayload(
+    "claude-sonnet-4",
+    {
+      messages: [
+        { role: "user", content: "Call a tool" },
+        {
+          role: "assistant",
+          tool_calls: [
+            {
+              id: "call_empty",
+              type: "function",
+              function: { name: "read_file", arguments: "" },
+            },
+          ],
+        },
+        { role: "user", content: "continue" },
+      ],
+    },
+    false,
+    null
+  );
+
+  assert.deepEqual(
+    (emptyResult.conversationState.history[1] as any).assistantResponseMessage.toolUses[0].input,
+    {}
+  );
+
+  const toolUseResult = buildKiroPayload(
+    "claude-sonnet-4",
+    {
+      messages: [
+        { role: "user", content: "Call a tool" },
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool_use",
+              id: "call_tool_use",
+              name: "read_file",
+              input: "{not-json",
+            },
+          ],
+        },
+        { role: "user", content: "continue" },
+      ],
+    },
+    false,
+    null
+  );
+
+  assert.deepEqual(
+    (toolUseResult.conversationState.history[1] as any).assistantResponseMessage.toolUses[0].input,
+    {}
+  );
+});
+
 test("OpenAI -> Kiro derives a stable conversationId for the same first history turn", () => {
   const first = buildSamplePayload();
   const second = buildSamplePayload();


### PR DESCRIPTION
## Summary

This follow-up hardens the remaining streaming/performance paths that were intentionally left out of the first transport cleanup pass.

### Kiro
- Replace the EventStream accumulator that rebuilt a new `Uint8Array` on every incoming chunk with a small `ByteQueue`, avoiding O(n²) copying when AWS EventStream frames arrive fragmented.
- Keep parsing after `messageStopEvent` so late `metricsEvent`, `contextUsageEvent`, or `meteringEvent` frames can still contribute usage before the final OpenAI-compatible finish chunk is emitted.
- Add regression coverage for fragmented EventStream frames and for post-stop usage events.

### Antigravity
- Rework non-streaming collection to parse SSE incrementally as chunks arrive instead of storing the full upstream stream in `chunks[]` and then doing `join/split` at the end.
- Preserve the existing response assembly semantics: text accumulation, finish reason mapping, usage metadata, and remaining Google One AI credits extraction.
- Add regression coverage for JSON/SSE lines split across multiple upstream chunks.

### Streaming/request logging
- Add a hard item-count cap for retained raw stream chunks in `createRequestLogger`, not just a byte cap, so pathological tiny chunks cannot create huge arrays of strings.
- Keep a visible truncation sentinel when the chunk-count cap is reached.

### Call-log artifacts
- Enforce a size cap for written call-log artifacts.
- First trim raw stream chunks, then omit oversized pipeline details if needed, and finally fall back to a minimal artifact while preserving summary metadata.
- Add regression coverage for both oversized stream chunks and oversized non-stream pipeline payloads.

## Validation

- `node --import tsx/esm --test tests/unit/executor-kiro.test.ts tests/unit/executor-antigravity.test.ts tests/unit/stream-utils.test.ts tests/unit/call-log-cap.test.ts`
- `npm run typecheck:core`