### PR TITLE
[codex] Enable Codex websocket beta header

### DIFF
--- a/open-sse/config/codexClient.ts
+++ b/open-sse/config/codexClient.ts
@@ -36,6 +36,7 @@ export function getCodexDefaultHeaders(): Record<string, string> {
   return {
     Version: getCodexClientVersion(),
     "Openai-Beta": "responses=experimental",
+    "X-Codex-Beta-Features": "responses_websockets",
     "User-Agent": getCodexUserAgent(),
   };
 }

--- a/tests/unit/executor-codex.test.ts
+++ b/tests/unit/executor-codex.test.ts
@@ -108,6 +108,8 @@ test("CodexExecutor.buildHeaders binds workspace ids and disables SSE accept for
   assert.equal(standardHeaders.Accept, "text/event-stream");
   assert.equal(standardHeaders["chatgpt-account-id"], "workspace-1");
   assert.equal(standardHeaders.Version, "0.125.0");
+  assert.equal(standardHeaders["Openai-Beta"], "responses=experimental");
+  assert.equal(standardHeaders["X-Codex-Beta-Features"], "responses_websockets");
   assert.equal(standardHeaders["User-Agent"], "codex-cli/0.125.0 (Windows 10.0.26100; x64)");
   assert.equal(compactHeaders.Accept, "application/json");
 });

--- a/tests/unit/t20-t22-provider-headers.test.ts
+++ b/tests/unit/t20-t22-provider-headers.test.ts
@@ -59,6 +59,7 @@ test("T20: codex config advertises current client headers and auto-review model"
   const codex = REGISTRY.codex;
   assert.equal(codex.headers.Version, "0.125.0");
   assert.equal(codex.headers["Openai-Beta"], "responses=experimental");
+  assert.equal(codex.headers["X-Codex-Beta-Features"], "responses_websockets");
   assert.equal(codex.headers["User-Agent"], "codex-cli/0.125.0 (Windows 10.0.26100; x64)");
   assert.ok(codex.models.some((model) => model.id === "codex-auto-review"));
 });


### PR DESCRIPTION
## Summary
- Add `X-Codex-Beta-Features: responses_websockets` to the shared Codex default headers.
- Cover both registry/executor header paths with unit assertions.

## Why
Native Codex `gpt-5.5` uses the Responses WebSocket path. In local 3.7.1 runtime verification, the unpatched compiled headers did not include `responses_websockets`; after adding the header to the native OmniRoute path, `gpt-5.5` `/v1/responses` succeeds without routing through CLIProxyAPI.

This keeps OmniRoute native Codex routing self-contained instead of relying on a CLIProxyAPI/direct passthrough.

## Validation
- `node --import tsx/esm --test tests/unit/executor-codex.test.ts tests/unit/t20-t22-provider-headers.test.ts` — 23/23 pass.
- `npm run typecheck:core` — pass.
- `npm run lint` — pass with existing warnings only.
- `git diff --check` — pass.
- Local Docker runtime: `diegosouzapw/omniroute:3.7.1` healthy on `127.0.0.1:20128`; `gpt-5.5` `/v1/responses` returned HTTP 200, completed, output `OK-55`, and latest call log provider was `codex`.

## Known unrelated issue
- Full `npm run test:unit` currently fails on upstream `tests/unit/api-key-reveal-route.test.ts` (`GET /api/keys returns 500 when key loading fails unexpectedly`, log-capture assertion). The targeted Codex tests added/affected by this PR pass.
