### PR TITLE
fix(codex): default gpt-5.5 to HTTP transport instead of WebSocket

### DIFF
--- a/open-sse/executors/codex.ts
+++ b/open-sse/executors/codex.ts
@@ -489,7 +489,7 @@ function consumeResponsesStoreMarker(body: Record<string, unknown>): unknown {
   return marker;
 }
 
-export function isCodexResponsesWebSocketRequired(model: string, credentials: unknown): boolean {
+export function isCodexResponsesWebSocketRequired(_model: string, credentials: unknown): boolean {
   // OmniRoute is an HTTP→SSE gateway — WebSocket transport is unnecessary and
   // breaks when upstream requests go through an HTTP proxy (403 on WS upgrade).
   // Default to the standard HTTP Responses SSE endpoint for all Codex models.
@@ -498,10 +498,7 @@ export function isCodexResponsesWebSocketRequired(model: string, credentials: un
     credentials && typeof credentials === "object"
       ? (credentials as { providerSpecificData?: Record<string, unknown> }).providerSpecificData
       : null;
-  if (providerSpecificData?.codexTransport === "websocket" && getWreqWebsocket()) {
-    return true;
-  }
-  return false;
+  return !!(providerSpecificData?.codexTransport === "websocket" && getWreqWebsocket());
 }
 
 function toStatusCode(value: unknown): number | null {

--- a/open-sse/executors/codex.ts
+++ b/open-sse/executors/codex.ts
@@ -490,13 +490,18 @@ function consumeResponsesStoreMarker(body: Record<string, unknown>): unknown {
 }
 
 export function isCodexResponsesWebSocketRequired(model: string, credentials: unknown): boolean {
-  const normalizedModel = getCodexUpstreamModel(model).trim().toLowerCase();
-  if (normalizedModel === "gpt-5.5") return true;
+  // OmniRoute is an HTTP→SSE gateway — WebSocket transport is unnecessary and
+  // breaks when upstream requests go through an HTTP proxy (403 on WS upgrade).
+  // Default to the standard HTTP Responses SSE endpoint for all Codex models.
+  // Users who need WebSocket can opt in via the provider codexTransport setting.
   const providerSpecificData =
     credentials && typeof credentials === "object"
       ? (credentials as { providerSpecificData?: Record<string, unknown> }).providerSpecificData
       : null;
-  return providerSpecificData?.codexTransport === "websocket";
+  if (providerSpecificData?.codexTransport === "websocket" && getWreqWebsocket()) {
+    return true;
+  }
+  return false;
 }
 
 function toStatusCode(value: unknown): number | null {


### PR DESCRIPTION
## Summary

Default all Codex models (including `gpt-5.5`) to **HTTP Responses SSE** transport instead of forcing WebSocket.

## Problem

The current `isCodexResponsesWebSocketRequired()` hardcodes `return true` for `gpt-5.5`, forcing all requests through the WebSocket transport path. This breaks when OmniRoute's upstream requests go through an HTTP proxy — the proxy rejects the WebSocket upgrade with **403 Forbidden**:

```
❌ codex [502]: Error: error upgrading connection: unexpected status code: 403 Forbidden
```

This is a common deployment scenario: many OmniRoute instances route upstream traffic through HTTP/SOCKS proxies for IP management, rate limit distribution, etc.

## Root Cause

HTTP proxies (CONNECT-based or forward proxies) typically do not support WebSocket protocol upgrades. When `isCodexResponsesWebSocketRequired` returns `true`, the `CodexExecutor.execute()` method attempts a WebSocket connection through the proxy, which fails.

## Fix

Remove the hardcoded WebSocket requirement for `gpt-5.5`. Since OmniRoute acts as an **HTTP→SSE gateway**, WebSocket transport provides no benefit over the standard HTTP Responses SSE endpoint:

- Both deliver identical streaming data
- HTTP works through any proxy configuration
- HTTP integrates with OmniRoute's existing retry/fallback/load-balancing logic
- Token caching via `previous_response_id` works identically on both transports

Users who need WebSocket (e.g. direct connections without a proxy) can still opt in via the provider-level `codexTransport: "websocket"` setting.

## Changes

**`open-sse/executors/codex.ts`** — single function change:

```diff
 export function isCodexResponsesWebSocketRequired(model: string, credentials: unknown): boolean {
-  const normalizedModel = getCodexUpstreamModel(model).trim().toLowerCase();
-  if (normalizedModel === "gpt-5.5") return true;
+  // OmniRoute is an HTTP→SSE gateway — WebSocket transport is unnecessary and
+  // breaks when upstream requests go through an HTTP proxy (403 on WS upgrade).
+  // Default to the standard HTTP Responses SSE endpoint for all Codex models.
+  // Users who need WebSocket can opt in via the provider codexTransport setting.
   const providerSpecificData =
     credentials && typeof credentials === "object"
       ? (credentials as { providerSpecificData?: Record<string, unknown> }).providerSpecificData
       : null;
-  return providerSpecificData?.codexTransport === "websocket";
+  if (providerSpecificData?.codexTransport === "websocket" && getWreqWebsocket()) {
+    return true;
+  }
+  return false;
 }
```

## Relationship to #1656

This PR **complements** #1656, which fixes the `getCodexWebSocketTransport` ReferenceError but still forces WebSocket for `gpt-5.5`. Even after #1656 is merged, `gpt-5.5` requests will fail through HTTP proxies without this change.

Both PRs can be merged independently — they modify different parts of the same function's logic.

## Validation

- Tested with `gpt-5.5-xhigh` through an HTTP proxy — confirmed working via HTTP Responses SSE
- Proxy logs show `SUCCESS` with `HTTP` transport type
- No impact on other Codex models (`gpt-5.3-codex`, etc.) — they already use HTTP

Fixes: #1652