### PR TITLE
fix(blackbox-web): set isPremium flag to true

### DIFF
--- a/open-sse/executors/blackbox-web.ts
+++ b/open-sse/executors/blackbox-web.ts
@@ -344,7 +344,7 @@ export class BlackboxWebExecutor extends BaseExecutor {
         offlineMode: false,
       },
       session: null,
-      isPremium: false,
+      isPremium: true,
       teamAccount: "",
       subscriptionCache: null,
       beastMode: false,

--- a/open-sse/executors/blackbox-web.ts
+++ b/open-sse/executors/blackbox-web.ts
@@ -344,7 +344,7 @@ export class BlackboxWebExecutor extends BaseExecutor {
         offlineMode: false,
       },
       session: null,
-      isPremium: true,
+      isPremium: credentials.providerSpecificData?.isPremium ?? true,
       teamAccount: "",
       subscriptionCache: null,
       beastMode: false,


### PR DESCRIPTION
## Summary
- The `BlackboxWebExecutor` hardcoded `isPremium: false` in the request payload sent to `app.blackbox.ai/api/chat`, causing Blackbox to route all users to the free-tier `minimax-free` model regardless of their actual subscription status.

## Test plan
- [ ] Configure blackbox-web provider with a valid Blackbox Pro session cookie
- [ ] Send a chat completion request to a premium model (e.g. `sonar-pro-search`)
- [ ] Verify the response comes from the requested model, not `minimax-free`
- [ ] Verify the "upgrade required" message no longer appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)