### PR TITLE
Fix Docker Not Copy SQLite

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,11 @@ COPY --from=builder /app/node_modules/@swc/helpers ./node_modules/@swc/helpers
 COPY --from=builder /app/node_modules/pino-abstract-transport ./node_modules/pino-abstract-transport
 COPY --from=builder /app/node_modules/pino-pretty ./node_modules/pino-pretty
 COPY --from=builder /app/node_modules/split2 ./node_modules/split2
+# Migration SQL files are read via fs.readFileSync at runtime and are NOT
+# traced by Next.js standalone output — copy them explicitly.
+COPY --from=builder /app/src/lib/db/migrations ./migrations
+ENV OMNIROUTE_MIGRATIONS_DIR=/app/migrations
+
 COPY --from=builder /app/scripts/run-standalone.mjs ./run-standalone.mjs
 COPY --from=builder /app/scripts/runtime-env.mjs ./runtime-env.mjs
 COPY --from=builder /app/scripts/bootstrap-env.mjs ./bootstrap-env.mjs

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -33,6 +33,11 @@ const nextConfig = {
     },
   },
   outputFileTracingRoot: projectRoot,
+  outputFileTracingIncludes: {
+    // Migration SQL files are read via fs.readFileSync at runtime and are NOT
+    // auto-traced by webpack/turbopack — include them explicitly.
+    "/*": ["./src/lib/db/migrations/**/*"],
+  },
   outputFileTracingExcludes: {
     // Planning/task docs are not runtime assets and can break standalone copies
     // when broad fs/path tracing pulls the whole repository into the NFT graph.


### PR DESCRIPTION
## Summary

Fixes a critical issue where SQLite migrations fail in Docker environments. Next.js standalone output does not automatically trace `.sql` files loaded via `fs.readFileSync` at runtime. This PR explicitly includes the migration directory in the standalone output and ensures it is copied into the Docker image with the `OMNIROUTE_MIGRATIONS_DIR` environment variable set. This resolves the `SQLITE_ERROR: no such table: batches` error seen on startup in Docker.

## Related Issues

- Closes # (Fixes "no such table: batches" startup error in Docker)

## Validation

- [ ] `npm run lint`
- [ ] `npm run test:unit`
- [ ] `npm run test:coverage`
- [ ] Coverage is still `>= 60%` for statements, lines, functions, and branches
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below

## Tests Added Or Updated

- No production code changed; modified `Dockerfile` and `next.config.mjs` to fix build/deployment artifacts.

## Coverage Notes

- N/A (Build configuration change).

## Reviewer Notes

- This change ensures that the `src/lib/db/migrations` directory is preserved in the Next.js standalone build output and correctly placed/referenced within the Docker container. Without this, migrations cannot run in production Docker builds.
