### PR TITLE
[urgent] fix(dev): enable Turbopack and repair Codex CORS headers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,6 +71,10 @@ PORT=20128
 # API_HOST=0.0.0.0
 # DASHBOARD_PORT=20128
 
+# Use Turbopack in local dev. Next 16.2.4 can fail to compile next/font/google
+# through the custom dev runner without this on Windows.
+OMNIROUTE_USE_TURBOPACK=1
+
 # Docker production port mappings (docker-compose.prod.yml only).
 # These set the HOST-side published ports. Container ports use PORT/API_PORT.
 # PROD_DASHBOARD_PORT=20130

--- a/open-sse/executors/codex.ts
+++ b/open-sse/executors/codex.ts
@@ -10,7 +10,7 @@ import { PROVIDERS } from "../config/constants.ts";
 import { getCodexClientVersion, getCodexUserAgent } from "../config/codexClient.ts";
 import { getAccessToken } from "../services/tokenRefresh.ts";
 import { getThinkingBudgetConfig, ThinkingMode } from "../services/thinkingBudget.ts";
-import { getCorsOrigin } from "../utils/cors.ts";
+import { CORS_HEADERS } from "../utils/cors.ts";
 import { createRequire } from "module";
 
 // ─── wreq-js lazy loader ───────────────────────────────────────────────────
@@ -65,7 +65,7 @@ function codexWebSocketUnavailableResponse(): Response {
       status: 503,
       headers: {
         "Content-Type": "application/json",
-        "Access-Control-Allow-Origin": getCorsOrigin(),
+        ...CORS_HEADERS,
       },
     }
   );


### PR DESCRIPTION
## Summary

Set OMNIROUTE_USE_TURBOPACK=1 in the example env so local Next.js dev avoids the next/font/google compiler failure.

Also replace the stale getCorsOrigin import in the Codex executor with the shared CORS_HEADERS export that actually exists.

## Validation

- [ ] `npm run lint`
- [ ] `npm run test:unit`
- [ ] `npm run test:coverage`
- [ ] Coverage is still `>= 60%` for statements, lines, functions, and branches
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below

## Coverage Notes

- This PR changes `open-sse/executors/codex.ts`.
- The Codex executor change is covered by existing dev/runtime compilation because the stale `getCorsOrigin` import previously caused Next.js dev startup to fail during instrumentation compilation.
- Manual validation performed:
  - `npm run dev`
  - `GET http://localhost:20129/login` returned `200`
- No coverage decrease was measured.

## Reviewer Notes

- `.env.example` now sets `OMNIROUTE_USE_TURBOPACK=1` so local dev uses Turbopack by default and avoids the Next 16.2.4 `next/font/google` dev compiler failure.
- `open-sse/executors/codex.ts` now uses the existing `CORS_HEADERS` export instead of importing the removed/nonexistent `getCorsOrigin`.
- Local pre-push tests are currently blocked by an unrelated migration numbering conflict: both `032_apikey_lifecycle.sql` and `032_create_reasoning_cache.sql` exist.