### PR TITLE
feat(muse-spark-web): continue the same meta.ai conversation across turns

### DIFF
--- a/open-sse/executors/muse-spark-web.ts
+++ b/open-sse/executors/muse-spark-web.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import {
   BaseExecutor,
   mergeAbortSignals,
@@ -89,7 +91,20 @@ function extractMessageText(content: unknown): string {
     .trim();
 }
 
-function parseOpenAIMessages(messages: Array<Record<string, unknown>>): string {
+type ParsedHistory = {
+  /** Whole history folded into one string (used when starting a new conversation). */
+  foldedPrompt: string;
+  /** Just the last user turn — sent on its own when we're continuing a cached conversation. */
+  latestUserContent: string;
+  /**
+   * The most recent assistant turn from the OpenAI-side history, or null if
+   * none. Used as a cache lookup key to recover the meta.ai conversation id
+   * we created on the previous turn.
+   */
+  lastAssistantContent: string | null;
+};
+
+function parseOpenAIMessages(messages: Array<Record<string, unknown>>): ParsedHistory {
   const extracted: Array<{ role: string; content: string }> = [];
 
   for (const message of messages) {
@@ -102,7 +117,7 @@ function parseOpenAIMessages(messages: Array<Record<string, unknown>>): string {
   }
 
   if (extracted.length === 0) {
-    return "";
+    return { foldedPrompt: "", latestUserContent: "", lastAssistantContent: null };
   }
 
   let lastUserIndex = -1;
@@ -113,7 +128,15 @@ function parseOpenAIMessages(messages: Array<Record<string, unknown>>): string {
     }
   }
 
-  return extracted
+  let lastAssistantContent: string | null = null;
+  for (let i = extracted.length - 1; i >= 0; i--) {
+    if (extracted[i].role === "assistant") {
+      lastAssistantContent = extracted[i].content;
+      break;
+    }
+  }
+
+  const foldedPrompt = extracted
     .map((message, index) => {
       if (index === lastUserIndex) {
         return message.content;
@@ -122,6 +145,10 @@ function parseOpenAIMessages(messages: Array<Record<string, unknown>>): string {
     })
     .join("\n\n")
     .trim();
+
+  const latestUserContent = lastUserIndex >= 0 ? extracted[lastUserIndex].content : "";
+
+  return { foldedPrompt, latestUserContent, lastAssistantContent };
 }
 
 function estimateTokens(text: string): number {
@@ -206,8 +233,83 @@ function getMuseSparkModelInfo(model: string): MuseSparkModelInfo {
   return MODEL_MAP[model] || MODEL_MAP["muse-spark"];
 }
 
-function buildMetaAiRequestBody(prompt: string, model: string) {
-  const conversationId = generateMetaConversationId();
+// ─── Conversation continuity cache ──────────────────────────────────────────
+// The default behavior of /v1/chat/completions is stateless: the caller passes
+// the full message history each turn. Without continuation, every turn would
+// open a brand-new meta.ai conversation containing the OpenAI history folded
+// into a single user prompt — three real chat turns become three separate
+// conversations in the user's meta.ai history, each polluted with the prior
+// turns rendered as "user: …" / "assistant: …" text.
+//
+// To present a clean single growing conversation in meta.ai, we cache the
+// conversationId we created on the previous turn keyed by a hash of the last
+// assistant message we returned. On the next turn, if the OpenAI history's
+// most recent assistant turn matches a cached entry, we reuse the cached
+// conversationId, set isNewConversation=false, and send only the latest user
+// turn — Meta then appends to the existing conversation tree.
+//
+// Cache key includes connectionId + model so concurrent users / model
+// switches don't collide. TTL is 30 minutes (Meta's web client also expires
+// idle conversations on a similar window).
+
+type CachedConversation = {
+  conversationId: string;
+  branchPath: string;
+  expiresAt: number;
+};
+
+const MUSE_CONV_CACHE_MAX = 500;
+const MUSE_CONV_CACHE_TTL_MS = 30 * 60 * 1000;
+const conversationCache = new Map<string, CachedConversation>();
+
+function makeConversationCacheKey(
+  connectionId: string,
+  model: string,
+  assistantContent: string
+): string {
+  return createHash("sha256")
+    .update(`${connectionId}\x1f${model}\x1f${assistantContent}`)
+    .digest("hex");
+}
+
+function lookupCachedConversation(key: string): CachedConversation | null {
+  const entry = conversationCache.get(key);
+  if (!entry) return null;
+  if (Date.now() > entry.expiresAt) {
+    conversationCache.delete(key);
+    return null;
+  }
+  return entry;
+}
+
+function rememberConversation(
+  key: string,
+  context: { conversationId: string; branchPath: string }
+): void {
+  if (conversationCache.size >= MUSE_CONV_CACHE_MAX && !conversationCache.has(key)) {
+    // Map iteration is insertion order, so the first key is the oldest.
+    const oldest = conversationCache.keys().next().value;
+    if (oldest) conversationCache.delete(oldest);
+  }
+  conversationCache.set(key, {
+    conversationId: context.conversationId,
+    branchPath: context.branchPath,
+    expiresAt: Date.now() + MUSE_CONV_CACHE_TTL_MS,
+  });
+}
+
+/** Test hook — exported for unit tests; not wired to runtime callers. */
+export function __resetMuseSparkConversationCacheForTesting(): void {
+  conversationCache.clear();
+}
+
+type ConversationContext = {
+  conversationId: string;
+  branchPath: string;
+  isNewConversation: boolean;
+};
+
+function buildMetaAiRequestBody(prompt: string, model: string, conversation: ConversationContext) {
   const userUniqueMessageId = generateNumericMessageId();
 
   return {
@@ -221,14 +323,14 @@ function buildMetaAiRequestBody(prompt: string, model: string) {
         typeof Intl !== "undefined" ? Intl.DateTimeFormat().resolvedOptions().timeZone : "UTC",
       clippyIp: null,
       content: prompt,
-      conversationId,
+      conversationId: conversation.conversationId,
       conversationStarterId: null,
-      currentBranchPath: META_AI_ROOT_BRANCH_PATH,
+      currentBranchPath: conversation.branchPath,
       developerOverridesForMessage: null,
       devicePixelRatio: 1,
       entryPoint: META_AI_ENTRY_POINT,
       imagineOperationRequest: null,
-      isNewConversation: true,
+      isNewConversation: conversation.isNewConversation,
       mentions: null,
       mode: getMuseSparkModelInfo(model).mode,
       promptEditType: null,
@@ -243,7 +345,7 @@ function buildMetaAiRequestBody(prompt: string, model: string) {
       // input fields are nullable-by-omission by default.
       turnId: crypto.randomUUID(),
       userAgent: META_AI_USER_AGENT,
-      userEventId: generateMetaEventId(conversationId),
+      userEventId: generateMetaEventId(conversation.conversationId),
       userLocale: normalizeMetaLocale(),
       userMessageId: crypto.randomUUID(),
       userUniqueMessageId,
@@ -860,8 +962,8 @@ export class MuseSparkWebExecutor extends BaseExecutor {
       };
     }
 
-    const prompt = parseOpenAIMessages(messages);
-    if (!prompt) {
+    const parsedHistory = parseOpenAIMessages(messages);
+    if (!parsedHistory.foldedPrompt) {
       return {
         response: buildErrorResponse(
           400,
@@ -874,8 +976,37 @@ export class MuseSparkWebExecutor extends BaseExecutor {
       };
     }
 
+    // Look up a prior meta.ai conversation we created for this caller +
+    // model. Cache hit → continue that conversation by sending only the
+    // latest user turn. Cache miss (first turn, restart, expired) →
+    // generate a fresh conversationId and fold the full OpenAI history into
+    // the prompt so the assistant has context.
+    const continuationCacheKey =
+      parsedHistory.lastAssistantContent && credentials.connectionId
+        ? makeConversationCacheKey(
+            credentials.connectionId,
+            model,
+            parsedHistory.lastAssistantContent
+          )
+        : null;
+    const cached = continuationCacheKey ? lookupCachedConversation(continuationCacheKey) : null;
+
+    const conversationContext: ConversationContext = cached
+      ? {
+          conversationId: cached.conversationId,
+          branchPath: cached.branchPath,
+          isNewConversation: false,
+        }
+      : {
+          conversationId: generateMetaConversationId(),
+          branchPath: META_AI_ROOT_BRANCH_PATH,
+          isNewConversation: true,
+        };
+
+    const prompt = cached ? parsedHistory.latestUserContent : parsedHistory.foldedPrompt;
+
     const modelInfo = getMuseSparkModelInfo(model);
-    const transformedBody = buildMetaAiRequestBody(prompt, model);
+    const transformedBody = buildMetaAiRequestBody(prompt, model, conversationContext);
     const cookieHeader = selectMetaAiCookieHeader(credentials);
     const headers = buildMetaAiHeaders(cookieHeader);
     mergeUpstreamExtraHeaders(headers, upstreamExtraHeaders);
@@ -907,6 +1038,12 @@ export class MuseSparkWebExecutor extends BaseExecutor {
     }
 
     if (!upstreamResponse.ok) {
+      // If we tried to continue a cached conversation and Meta rejected,
+      // evict the cache entry so the next retry falls back to a fresh
+      // conversationId instead of looping on the same dead one.
+      if (cached && continuationCacheKey) {
+        conversationCache.delete(continuationCacheKey);
+      }
       let message = `Meta AI returned HTTP ${upstreamResponse.status}`;
       if (upstreamResponse.status === 401 || upstreamResponse.status === 403) {
         message =
@@ -943,6 +1080,11 @@ export class MuseSparkWebExecutor extends BaseExecutor {
     const responseText = await readTextResponse(upstreamResponse.body, signal);
     const parsed = parseMetaAiResponseText(responseText, modelInfo.isThinking);
     if (parsed.status !== 200 || parsed.errorMessage) {
+      // Same eviction rule as the HTTP-level branch above: if we attempted
+      // to continue and Meta returned a parsed error, drop the stale entry.
+      if (cached && continuationCacheKey) {
+        conversationCache.delete(continuationCacheKey);
+      }
       return {
         response: buildErrorResponse(
           parsed.status,
@@ -959,6 +1101,24 @@ export class MuseSparkWebExecutor extends BaseExecutor {
     const created = Math.floor(Date.now() / 1000);
     const deltas = parsed.deltas.length > 0 ? parsed.deltas : [parsed.content];
     const reasoningDeltas = parsed.reasoningDeltas;
+
+    // Remember this turn's conversationId keyed by what we're about to
+    // emit, so the next /v1/chat/completions request that has this content
+    // as its prior assistant turn can continue the same meta.ai conversation
+    // instead of starting a new one. Best-effort: skip silently if we don't
+    // have a stable connectionId or assistant content.
+    if (parsed.content && credentials.connectionId) {
+      rememberConversation(
+        makeConversationCacheKey(credentials.connectionId, model, parsed.content),
+        {
+          conversationId: conversationContext.conversationId,
+          // Reuse the same branch path on every continuation. Linear chats
+          // don't fan out into a tree, and Meta's web UI just reflects the
+          // last reply regardless of the path value we send.
+          branchPath: conversationContext.branchPath,
+        }
+      );
+    }
 
     return {
       response: stream

--- a/tests/unit/muse-spark-web-continuation.test.ts
+++ b/tests/unit/muse-spark-web-continuation.test.ts
@@ -1,0 +1,233 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  MuseSparkWebExecutor,
+  __resetMuseSparkConversationCacheForTesting,
+} from "../../open-sse/executors/muse-spark-web.ts";
+
+// Canned Meta AI response shape. parseMetaAiResponseText accepts either a
+// plain JSON body or an SSE stream of `data: <json>` frames; we send a plain
+// JSON body since the assertions don't care about delta structure.
+function metaAiSseResponse(content: string): Response {
+  const body = JSON.stringify({
+    data: {
+      sendMessageStream: {
+        __typename: "AssistantMessage",
+        content,
+      },
+    },
+  });
+  return new Response(body, {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+type CapturedRequest = { url: string; init: RequestInit | undefined; body: unknown };
+
+function captureFetch(reply: () => Response): {
+  fetchFn: typeof fetch;
+  captured: CapturedRequest[];
+} {
+  const captured: CapturedRequest[] = [];
+  const fetchFn: typeof fetch = async (input, init) => {
+    let body: unknown = undefined;
+    if (init?.body && typeof init.body === "string") {
+      try {
+        body = JSON.parse(init.body);
+      } catch {
+        body = init.body;
+      }
+    }
+    captured.push({
+      url: typeof input === "string" ? input : (input as URL).toString(),
+      init,
+      body,
+    });
+    return reply();
+  };
+  return { fetchFn, captured };
+}
+
+function executeInputs(messages: Array<{ role: string; content: string }>) {
+  return {
+    model: "muse-spark",
+    body: { messages },
+    stream: false,
+    credentials: { apiKey: "abra_sess=foo", connectionId: "conn-test-1" },
+    signal: null,
+    log: null,
+    upstreamExtraHeaders: undefined,
+  } as Parameters<MuseSparkWebExecutor["execute"]>[0];
+}
+
+test("muse-spark-web: first turn opens a new meta.ai conversation", async () => {
+  __resetMuseSparkConversationCacheForTesting();
+  const executor = new MuseSparkWebExecutor();
+  const original = globalThis.fetch;
+  const { fetchFn, captured } = captureFetch(() => metaAiSseResponse("pong"));
+  globalThis.fetch = fetchFn;
+  try {
+    const result = await executor.execute(executeInputs([{ role: "user", content: "ping" }]));
+    assert.equal(captured.length, 1, "exactly one upstream call");
+    const sentVars = (captured[0].body as { variables: Record<string, unknown> }).variables;
+    assert.equal(sentVars.isNewConversation, true, "first turn → isNewConversation: true");
+    assert.equal(sentVars.content, "ping", "first turn → bare user content");
+    assert.match(String(sentVars.conversationId), /^c\./, "fresh meta.ai conversation id");
+    assert.equal(result.response.status, 200);
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+test("muse-spark-web: follow-up turn continues the cached conversation", async () => {
+  __resetMuseSparkConversationCacheForTesting();
+  const executor = new MuseSparkWebExecutor();
+  const original = globalThis.fetch;
+  let nthReply = 0;
+  const { fetchFn, captured } = captureFetch(() =>
+    metaAiSseResponse(nthReply++ === 0 ? "pong" : "pong-again")
+  );
+  globalThis.fetch = fetchFn;
+  try {
+    // Turn 1
+    await executor.execute(executeInputs([{ role: "user", content: "ping" }]));
+    // Turn 2 — caller sends the OpenAI history including the prior assistant.
+    await executor.execute(
+      executeInputs([
+        { role: "user", content: "ping" },
+        { role: "assistant", content: "pong" },
+        { role: "user", content: "ping again" },
+      ])
+    );
+    assert.equal(captured.length, 2, "two upstream calls");
+    const turn1 = (captured[0].body as { variables: Record<string, unknown> }).variables;
+    const turn2 = (captured[1].body as { variables: Record<string, unknown> }).variables;
+    assert.equal(turn1.isNewConversation, true);
+    assert.equal(turn2.isNewConversation, false, "second turn → continues");
+    assert.equal(
+      turn2.conversationId,
+      turn1.conversationId,
+      "second turn reuses first turn's conversation id"
+    );
+    assert.equal(turn2.content, "ping again", "second turn → only the latest user content");
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+test("muse-spark-web: connection isolation — different connectionId → independent conversations", async () => {
+  __resetMuseSparkConversationCacheForTesting();
+  const executor = new MuseSparkWebExecutor();
+  const original = globalThis.fetch;
+  const { fetchFn, captured } = captureFetch(() => metaAiSseResponse("pong"));
+  globalThis.fetch = fetchFn;
+  try {
+    const baseInputs = (id: string) => ({
+      model: "muse-spark",
+      body: {
+        messages: [
+          { role: "user", content: "ping" },
+          { role: "assistant", content: "pong" },
+          { role: "user", content: "again" },
+        ],
+      },
+      stream: false,
+      credentials: { apiKey: "abra_sess=foo", connectionId: id },
+      signal: null,
+      log: null,
+      upstreamExtraHeaders: undefined,
+    });
+    // Two different connections both have the same OpenAI history with the
+    // same prior assistant content. They must not collide on the cache.
+    await executor.execute(baseInputs("conn-A") as Parameters<MuseSparkWebExecutor["execute"]>[0]);
+    await executor.execute(baseInputs("conn-B") as Parameters<MuseSparkWebExecutor["execute"]>[0]);
+    const a = (captured[0].body as { variables: Record<string, unknown> }).variables;
+    const b = (captured[1].body as { variables: Record<string, unknown> }).variables;
+    assert.equal(a.isNewConversation, true);
+    assert.equal(b.isNewConversation, true);
+    assert.notEqual(a.conversationId, b.conversationId);
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+test("muse-spark-web: meta error during continuation evicts the stale cache entry", async () => {
+  __resetMuseSparkConversationCacheForTesting();
+  const executor = new MuseSparkWebExecutor();
+  const original = globalThis.fetch;
+
+  // Reply 1: success. Reply 2: HTTP 400 (e.g. Meta deleted the conversation).
+  // Reply 3: success again — cache must have been evicted, so this turn
+  // should open a fresh conversation, not reuse the dead one.
+  let n = 0;
+  const fetchFn: typeof fetch = async () => {
+    n++;
+    if (n === 2) {
+      return new Response(JSON.stringify({ errors: [{ message: "conversation not found" }] }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    return metaAiSseResponse(n === 1 ? "pong" : "pong-2");
+  };
+  const captured: CapturedRequest[] = [];
+  globalThis.fetch = (async (input, init) => {
+    let body: unknown = undefined;
+    if (init?.body && typeof init.body === "string") {
+      try {
+        body = JSON.parse(init.body);
+      } catch {
+        body = init.body;
+      }
+    }
+    captured.push({
+      url: typeof input === "string" ? input : (input as URL).toString(),
+      init,
+      body,
+    });
+    return fetchFn(input as never, init as never);
+  }) as typeof fetch;
+
+  try {
+    // Turn 1 — opens conversation A and caches it.
+    await executor.execute(executeInputs([{ role: "user", content: "ping" }]));
+    // Turn 2 — would continue conversation A but Meta returns 400.
+    await executor.execute(
+      executeInputs([
+        { role: "user", content: "ping" },
+        { role: "assistant", content: "pong" },
+        { role: "user", content: "again" },
+      ])
+    );
+    // Turn 3 — same prior-assistant content, retried by the user. Cache
+    // should have been evicted on turn 2, so this turn opens a new
+    // conversation rather than re-trying the dead one.
+    await executor.execute(
+      executeInputs([
+        { role: "user", content: "ping" },
+        { role: "assistant", content: "pong" },
+        { role: "user", content: "again" },
+      ])
+    );
+    const t1 = (captured[0].body as { variables: Record<string, unknown> }).variables;
+    const t2 = (captured[1].body as { variables: Record<string, unknown> }).variables;
+    const t3 = (captured[2].body as { variables: Record<string, unknown> }).variables;
+    assert.equal(t1.isNewConversation, true);
+    assert.equal(t2.isNewConversation, false, "turn 2 attempted to continue");
+    assert.equal(t2.conversationId, t1.conversationId);
+    assert.equal(
+      t3.isNewConversation,
+      true,
+      "turn 3 must open a fresh conversation after the stale entry was evicted"
+    );
+    assert.notEqual(
+      t3.conversationId,
+      t1.conversationId,
+      "turn 3 must not reuse the dead conversation id"
+    );
+  } finally {
+    globalThis.fetch = original;
+  }
+});


### PR DESCRIPTION
## Summary

Follow-up to #1668. Now that `muse-spark-web` requests succeed again, a UX issue surfaces: each `/v1/chat/completions` opens a fresh meta.ai conversation and folds the entire OpenAI history into a single user prompt — so a 3-turn chat in OpenWebUI shows up as 3 separate conversations in the user's meta.ai history, each containing the prior turns rendered verbatim as `user: …` / `assistant: …` text. Reported by the user post-merge of #1668.

This PR caches the meta.ai `conversationId` we created on each turn and reuses it on subsequent turns of the same logical chat, so the user sees a single growing conversation in meta.ai instead of one new polluted conversation per turn.

## Mechanism

Module-level cache in `muse-spark-web.ts`:

| | |
| --- | --- |
| Key | `sha256(connectionId \x1f model \x1f lastAssistantContent)` |
| Value | `{ conversationId, branchPath, expiresAt }` |
| TTL | 30 min |
| Bound | 500 entries (oldest evicted, insertion-order Map) |

Per-turn flow in `execute()`:

1. Parse OpenAI history into `{ foldedPrompt, latestUserContent, lastAssistantContent }`.
2. Compute the cache key from `connectionId + model + lastAssistantContent`.
3. **Cache hit**: reuse `conversationId`, set `isNewConversation: false`, send only `latestUserContent`. Meta appends to the existing tree.
4. **Cache miss** (first turn / restart / TTL): generate fresh `conversationId`, `isNewConversation: true`, send `foldedPrompt` (current behavior — preserves context for the assistant's first reply).
5. After a successful response: cache `(connectionId, model, response.content) → (conversationId, branchPath)` for the next turn.
6. After a failed response (HTTP 4xx or parsed `errorMessage`): evict the cache entry that drove this attempt so the next retry opens a fresh conversation rather than looping on a now-dead conversationId.

## What's intentionally **not** in scope

- **Branch-path tracking.** Linear chats don't fan out into a tree, and Meta's web UI reflects only the latest reply regardless of `currentBranchPath`. We reuse `\"0\"` on every turn. If a user wants regenerate/branch semantics later, that's a separate feature.
- **Cross-process state.** The cache is in-memory only; on process restart, the next turn falls back to a fresh conversation. Acceptable for OmniRoute's typical deployment, and a persistent store would add a lot of surface for marginal benefit.
- **Concurrent in-flight requests for the same key.** Two parallel turns with identical prior-assistant content will both reuse the same conversationId. Meta tolerates this in practice; if it ever becomes a problem we'd add an in-flight lock.

## Privacy / connection isolation

The cache key includes `connectionId`, so two different users with identical chat content (e.g. the assistant's stock greeting) cannot collide on each other's conversations. Without `connectionId` (e.g. an unauthenticated test path), continuation is skipped entirely and we fall through to the fresh-conversation path.

## Tests (`tests/unit/muse-spark-web-continuation.test.ts`, 4 cases)

- **First turn opens a new meta.ai conversation** — `isNewConversation: true`, fresh `c.…`-prefixed conversationId, payload contains the bare user content.
- **Follow-up turn continues the cached conversation** — second call reuses turn 1's conversationId, sets `isNewConversation: false`, and sends only `latestUserContent` (not the folded history).
- **Connection isolation** — two different `connectionId`s with identical histories produce two separate conversationIds.
- **Eviction-on-error prevents stale-entry loops** — after a continuation gets a 400 from Meta, the cache entry is dropped so the next retry opens a fresh conversation rather than re-using the dead one.

All tests use `globalThis.fetch` overrides to capture upstream payloads — no network calls.

## Risk

Low. Behavior on the cache-miss path is identical to today's executor (same fetch, same body shape, same parse). The only new failure mode is a stale cached `conversationId` reaching Meta, which is recovered automatically by the eviction-on-error path on the very next retry.

## Verification

- [x] `npm run typecheck:core` clean
- [x] `node --import tsx/esm --test tests/unit/muse-spark-web-continuation.test.ts` — 4/4 pass
- [ ] Live: send 3+ turns in a single OpenWebUI chat; verify only one new entry appears in meta.ai's web history (was 3 before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)