### PR TITLE
feat(muse-spark-web): continue the same meta.ai conversation across turns

### DIFF
--- a/open-sse/executors/muse-spark-web.ts
+++ b/open-sse/executors/muse-spark-web.ts
@@ -91,21 +91,31 @@ function extractMessageText(content: unknown): string {
     .trim();
 }
 
+type NormalizedMessage = { role: string; content: string };
+
 type ParsedHistory = {
   /** Whole history folded into one string (used when starting a new conversation). */
   foldedPrompt: string;
   /** Just the last user turn — sent on its own when we're continuing a cached conversation. */
   latestUserContent: string;
   /**
-   * The most recent assistant turn from the OpenAI-side history, or null if
-   * none. Used as a cache lookup key to recover the meta.ai conversation id
-   * we created on the previous turn.
+   * Index in `normalized` of the most recent assistant turn, or -1 if none.
+   * Used to slice the prefix that anchors the continuation cache key (so two
+   * separate chats with identical assistant responses but different
+   * preceding history don't collide).
    */
-  lastAssistantContent: string | null;
+  lastAssistantIndex: number;
+  /**
+   * The role+content of every non-empty message after normalization, in
+   * order. The continuation-cache key hashes the prefix of this list ending
+   * at the last assistant message, so the key is unique to a specific
+   * (history → response) pair rather than just the response text alone.
+   */
+  normalized: NormalizedMessage[];
 };
 
 function parseOpenAIMessages(messages: Array<Record<string, unknown>>): ParsedHistory {
-  const extracted: Array<{ role: string; content: string }> = [];
+  const extracted: NormalizedMessage[] = [];
 
   for (const message of messages) {
     let role = String(message.role || "user");
@@ -117,7 +127,12 @@ function parseOpenAIMessages(messages: Array<Record<string, unknown>>): ParsedHi
   }
 
   if (extracted.length === 0) {
-    return { foldedPrompt: "", latestUserContent: "", lastAssistantContent: null };
+    return {
+      foldedPrompt: "",
+      latestUserContent: "",
+      lastAssistantIndex: -1,
+      normalized: [],
+    };
   }
 
   let lastUserIndex = -1;
@@ -128,10 +143,10 @@ function parseOpenAIMessages(messages: Array<Record<string, unknown>>): ParsedHi
     }
   }
 
-  let lastAssistantContent: string | null = null;
+  let lastAssistantIndex = -1;
   for (let i = extracted.length - 1; i >= 0; i--) {
     if (extracted[i].role === "assistant") {
-      lastAssistantContent = extracted[i].content;
+      lastAssistantIndex = i;
       break;
     }
   }
@@ -148,7 +163,7 @@ function parseOpenAIMessages(messages: Array<Record<string, unknown>>): ParsedHi
 
   const latestUserContent = lastUserIndex >= 0 ? extracted[lastUserIndex].content : "";
 
-  return { foldedPrompt, latestUserContent, lastAssistantContent };
+  return { foldedPrompt, latestUserContent, lastAssistantIndex, normalized: extracted };
 }
 
 function estimateTokens(text: string): number {
@@ -242,15 +257,23 @@ function getMuseSparkModelInfo(model: string): MuseSparkModelInfo {
 // turns rendered as "user: …" / "assistant: …" text.
 //
 // To present a clean single growing conversation in meta.ai, we cache the
-// conversationId we created on the previous turn keyed by a hash of the last
-// assistant message we returned. On the next turn, if the OpenAI history's
-// most recent assistant turn matches a cached entry, we reuse the cached
-// conversationId, set isNewConversation=false, and send only the latest user
-// turn — Meta then appends to the existing conversation tree.
+// conversationId we created on the previous turn keyed by a hash of the
+// (connectionId, model, normalized history through the last assistant turn).
+// On the next turn, if the incoming OpenAI history's prefix-up-to-the-last-
+// assistant-turn matches a cached entry, we reuse the cached conversationId,
+// set isNewConversation=false, and send only the latest user turn — Meta
+// appends to the existing conversation tree.
 //
-// Cache key includes connectionId + model so concurrent users / model
-// switches don't collide. TTL is 30 minutes (Meta's web client also expires
-// idle conversations on a similar window).
+// Hashing the *full prefix* (not just the assistant text) is important: two
+// independent chats from the same connection that happen to land on identical
+// assistant text (e.g. a generic refusal or greeting) would otherwise collide
+// and route the next turn into the wrong meta.ai conversation, mixing chat
+// state across logical sessions. The differing preceding history makes the
+// hashes distinct.
+//
+// TTL is 30 minutes (Meta's web client also expires idle conversations on a
+// similar window). Cache cap is generous — entries are tiny (~250 B) so 5000
+// entries is ~1.25 MB, plenty of headroom for multi-user setups.
 
 type CachedConversation = {
   conversationId: string;
@@ -258,17 +281,27 @@ type CachedConversation = {
   expiresAt: number;
 };
 
-const MUSE_CONV_CACHE_MAX = 500;
+const MUSE_CONV_CACHE_MAX = 5000;
 const MUSE_CONV_CACHE_TTL_MS = 30 * 60 * 1000;
 const conversationCache = new Map<string, CachedConversation>();
+
+/**
+ * Canonical-stringify a normalized message list so the same logical history
+ * always produces the same hash. Uses ASCII Group Separator / Record
+ * Separator characters as field delimiters so they can't appear inside
+ * normal message content.
+ */
+function canonicalizeNormalizedHistory(messages: NormalizedMessage[]): string {
+  return messages.map((m) => `${m.role}\x1e${m.content}`).join("\x1f");
+}
 
 function makeConversationCacheKey(
   connectionId: string,
   model: string,
-  assistantContent: string
+  normalizedPrefix: NormalizedMessage[]
 ): string {
   return createHash("sha256")
-    .update(`${connectionId}\x1f${model}\x1f${assistantContent}`)
+    .update(`${connectionId}\x1f${model}\x1f${canonicalizeNormalizedHistory(normalizedPrefix)}`)
     .digest("hex");
 }
 
@@ -977,18 +1010,29 @@ export class MuseSparkWebExecutor extends BaseExecutor {
     }
 
     // Look up a prior meta.ai conversation we created for this caller +
-    // model. Cache hit → continue that conversation by sending only the
-    // latest user turn. Cache miss (first turn, restart, expired) →
-    // generate a fresh conversationId and fold the full OpenAI history into
-    // the prompt so the assistant has context.
-    const continuationCacheKey =
-      parsedHistory.lastAssistantContent && credentials.connectionId
-        ? makeConversationCacheKey(
-            credentials.connectionId,
-            model,
-            parsedHistory.lastAssistantContent
-          )
-        : null;
+    // model + chat thread. The lookup key is the connection + model + the
+    // SHA-256 of the normalized history prefix ending at the last assistant
+    // turn — that prefix is exactly what we hashed when we cached on the
+    // previous turn, so a real continuation hits and two parallel chats
+    // with coincidentally-identical assistant text do not.
+    //
+    // We also require `latestUserContent` to be non-empty before using a
+    // cached entry: if the incoming history has no `user` role (e.g. an
+    // assistant-prefill payload), the cache-hit path would otherwise POST
+    // empty content with `isNewConversation: false`, an avoidable upstream
+    // failure. Falling through to the fresh-conversation path uses the
+    // folded history instead, which contains real content.
+    const canCacheLookup =
+      parsedHistory.lastAssistantIndex >= 0 &&
+      !!credentials.connectionId &&
+      parsedHistory.latestUserContent.length > 0;
+    const continuationCacheKey = canCacheLookup
+      ? makeConversationCacheKey(
+          credentials.connectionId as string,
+          model,
+          parsedHistory.normalized.slice(0, parsedHistory.lastAssistantIndex + 1)
+        )
+      : null;
     const cached = continuationCacheKey ? lookupCachedConversation(continuationCacheKey) : null;
 
     const conversationContext: ConversationContext = cached
@@ -1102,22 +1146,26 @@ export class MuseSparkWebExecutor extends BaseExecutor {
     const deltas = parsed.deltas.length > 0 ? parsed.deltas : [parsed.content];
     const reasoningDeltas = parsed.reasoningDeltas;
 
-    // Remember this turn's conversationId keyed by what we're about to
-    // emit, so the next /v1/chat/completions request that has this content
-    // as its prior assistant turn can continue the same meta.ai conversation
-    // instead of starting a new one. Best-effort: skip silently if we don't
-    // have a stable connectionId or assistant content.
+    // Remember this turn's conversationId keyed by the normalized history
+    // ending at the response we're about to emit. The next request will
+    // arrive with that exact prefix (the response becomes the latest
+    // assistant message) and a new trailing user turn; slicing it back to
+    // the last assistant yields the same prefix, so the cache lookup hits.
+    // Hashing the *whole* prefix (not just the assistant text) ensures two
+    // parallel chats whose assistant responses coincidentally match cannot
+    // overwrite each other's entries.
     if (parsed.content && credentials.connectionId) {
-      rememberConversation(
-        makeConversationCacheKey(credentials.connectionId, model, parsed.content),
-        {
-          conversationId: conversationContext.conversationId,
-          // Reuse the same branch path on every continuation. Linear chats
-          // don't fan out into a tree, and Meta's web UI just reflects the
-          // last reply regardless of the path value we send.
-          branchPath: conversationContext.branchPath,
-        }
-      );
+      const writePrefix: NormalizedMessage[] = [
+        ...parsedHistory.normalized,
+        { role: "assistant", content: parsed.content },
+      ];
+      rememberConversation(makeConversationCacheKey(credentials.connectionId, model, writePrefix), {
+        conversationId: conversationContext.conversationId,
+        // Reuse the same branch path on every continuation. Linear chats
+        // don't fan out into a tree, and Meta's web UI just reflects the
+        // last reply regardless of the path value we send.
+        branchPath: conversationContext.branchPath,
+      });
     }
 
     return {

--- a/open-sse/executors/muse-spark-web.ts
+++ b/open-sse/executors/muse-spark-web.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import {
   BaseExecutor,
   mergeAbortSignals,
@@ -89,7 +91,20 @@ function extractMessageText(content: unknown): string {
     .trim();
 }
 
-function parseOpenAIMessages(messages: Array<Record<string, unknown>>): string {
+type ParsedHistory = {
+  /** Whole history folded into one string (used when starting a new conversation). */
+  foldedPrompt: string;
+  /** Just the last user turn — sent on its own when we're continuing a cached conversation. */
+  latestUserContent: string;
+  /**
+   * The most recent assistant turn from the OpenAI-side history, or null if
+   * none. Used as a cache lookup key to recover the meta.ai conversation id
+   * we created on the previous turn.
+   */
+  lastAssistantContent: string | null;
+};
+
+function parseOpenAIMessages(messages: Array<Record<string, unknown>>): ParsedHistory {
   const extracted: Array<{ role: string; content: string }> = [];
 
   for (const message of messages) {
@@ -102,7 +117,7 @@ function parseOpenAIMessages(messages: Array<Record<string, unknown>>): string {
   }
 
   if (extracted.length === 0) {
-    return "";
+    return { foldedPrompt: "", latestUserContent: "", lastAssistantContent: null };
   }
 
   let lastUserIndex = -1;
@@ -113,7 +128,15 @@ function parseOpenAIMessages(messages: Array<Record<string, unknown>>): string {
     }
   }
 
-  return extracted
+  let lastAssistantContent: string | null = null;
+  for (let i = extracted.length - 1; i >= 0; i--) {
+    if (extracted[i].role === "assistant") {
+      lastAssistantContent = extracted[i].content;
+      break;
+    }
+  }
+
+  const foldedPrompt = extracted
     .map((message, index) => {
       if (index === lastUserIndex) {
         return message.content;
@@ -122,6 +145,10 @@ function parseOpenAIMessages(messages: Array<Record<string, unknown>>): string {
     })
     .join("\n\n")
     .trim();
+
+  const latestUserContent = lastUserIndex >= 0 ? extracted[lastUserIndex].content : "";
+
+  return { foldedPrompt, latestUserContent, lastAssistantContent };
 }
 
 function estimateTokens(text: string): number {
@@ -206,8 +233,83 @@ function getMuseSparkModelInfo(model: string): MuseSparkModelInfo {
   return MODEL_MAP[model] || MODEL_MAP["muse-spark"];
 }
 
-function buildMetaAiRequestBody(prompt: string, model: string) {
-  const conversationId = generateMetaConversationId();
+// ─── Conversation continuity cache ──────────────────────────────────────────
+// The default behavior of /v1/chat/completions is stateless: the caller passes
+// the full message history each turn. Without continuation, every turn would
+// open a brand-new meta.ai conversation containing the OpenAI history folded
+// into a single user prompt — three real chat turns become three separate
+// conversations in the user's meta.ai history, each polluted with the prior
+// turns rendered as "user: …" / "assistant: …" text.
+//
+// To present a clean single growing conversation in meta.ai, we cache the
+// conversationId we created on the previous turn keyed by a hash of the last
+// assistant message we returned. On the next turn, if the OpenAI history's
+// most recent assistant turn matches a cached entry, we reuse the cached
+// conversationId, set isNewConversation=false, and send only the latest user
+// turn — Meta then appends to the existing conversation tree.
+//
+// Cache key includes connectionId + model so concurrent users / model
+// switches don't collide. TTL is 30 minutes (Meta's web client also expires
+// idle conversations on a similar window).
+
+type CachedConversation = {
+  conversationId: string;
+  branchPath: string;
+  expiresAt: number;
+};
+
+const MUSE_CONV_CACHE_MAX = 500;
+const MUSE_CONV_CACHE_TTL_MS = 30 * 60 * 1000;
+const conversationCache = new Map<string, CachedConversation>();
+
+function makeConversationCacheKey(
+  connectionId: string,
+  model: string,
+  assistantContent: string
+): string {
+  return createHash("sha256")
+    .update(`${connectionId}\x1f${model}\x1f${assistantContent}`)
+    .digest("hex");
+}
+
+function lookupCachedConversation(key: string): CachedConversation | null {
+  const entry = conversationCache.get(key);
+  if (!entry) return null;
+  if (Date.now() > entry.expiresAt) {
+    conversationCache.delete(key);
+    return null;
+  }
+  return entry;
+}
+
+function rememberConversation(
+  key: string,
+  context: { conversationId: string; branchPath: string }
+): void {
+  if (conversationCache.size >= MUSE_CONV_CACHE_MAX && !conversationCache.has(key)) {
+    // Map iteration is insertion order, so the first key is the oldest.
+    const oldest = conversationCache.keys().next().value;
+    if (oldest) conversationCache.delete(oldest);
+  }
+  conversationCache.set(key, {
+    conversationId: context.conversationId,
+    branchPath: context.branchPath,
+    expiresAt: Date.now() + MUSE_CONV_CACHE_TTL_MS,
+  });
+}
+
+/** Test hook — exported for unit tests; not wired to runtime callers. */
+export function __resetMuseSparkConversationCacheForTesting(): void {
+  conversationCache.clear();
+}
+
+type ConversationContext = {
+  conversationId: string;
+  branchPath: string;
+  isNewConversation: boolean;
+};
+
+function buildMetaAiRequestBody(prompt: string, model: string, conversation: ConversationContext) {
   const userUniqueMessageId = generateNumericMessageId();
 
   return {
@@ -221,14 +323,14 @@ function buildMetaAiRequestBody(prompt: string, model: string) {
         typeof Intl !== "undefined" ? Intl.DateTimeFormat().resolvedOptions().timeZone : "UTC",
       clippyIp: null,
       content: prompt,
-      conversationId,
+      conversationId: conversation.conversationId,
       conversationStarterId: null,
-      currentBranchPath: META_AI_ROOT_BRANCH_PATH,
+      currentBranchPath: conversation.branchPath,
       developerOverridesForMessage: null,
       devicePixelRatio: 1,
       entryPoint: META_AI_ENTRY_POINT,
       imagineOperationRequest: null,
-      isNewConversation: true,
+      isNewConversation: conversation.isNewConversation,
       mentions: null,
       mode: getMuseSparkModelInfo(model).mode,
       promptEditType: null,
@@ -243,7 +345,7 @@ function buildMetaAiRequestBody(prompt: string, model: string) {
       // input fields are nullable-by-omission by default.
       turnId: crypto.randomUUID(),
       userAgent: META_AI_USER_AGENT,
-      userEventId: generateMetaEventId(conversationId),
+      userEventId: generateMetaEventId(conversation.conversationId),
       userLocale: normalizeMetaLocale(),
       userMessageId: crypto.randomUUID(),
       userUniqueMessageId,
@@ -860,8 +962,8 @@ export class MuseSparkWebExecutor extends BaseExecutor {
       };
     }
 
-    const prompt = parseOpenAIMessages(messages);
-    if (!prompt) {
+    const parsedHistory = parseOpenAIMessages(messages);
+    if (!parsedHistory.foldedPrompt) {
       return {
         response: buildErrorResponse(
           400,
@@ -874,8 +976,37 @@ export class MuseSparkWebExecutor extends BaseExecutor {
       };
     }
 
+    // Look up a prior meta.ai conversation we created for this caller +
+    // model. Cache hit → continue that conversation by sending only the
+    // latest user turn. Cache miss (first turn, restart, expired) →
+    // generate a fresh conversationId and fold the full OpenAI history into
+    // the prompt so the assistant has context.
+    const continuationCacheKey =
+      parsedHistory.lastAssistantContent && credentials.connectionId
+        ? makeConversationCacheKey(
+            credentials.connectionId,
+            model,
+            parsedHistory.lastAssistantContent
+          )
+        : null;
+    const cached = continuationCacheKey ? lookupCachedConversation(continuationCacheKey) : null;
+
+    const conversationContext: ConversationContext = cached
+      ? {
+          conversationId: cached.conversationId,
+          branchPath: cached.branchPath,
+          isNewConversation: false,
+        }
+      : {
+          conversationId: generateMetaConversationId(),
+          branchPath: META_AI_ROOT_BRANCH_PATH,
+          isNewConversation: true,
+        };
+
+    const prompt = cached ? parsedHistory.latestUserContent : parsedHistory.foldedPrompt;
+
     const modelInfo = getMuseSparkModelInfo(model);
-    const transformedBody = buildMetaAiRequestBody(prompt, model);
+    const transformedBody = buildMetaAiRequestBody(prompt, model, conversationContext);
     const cookieHeader = selectMetaAiCookieHeader(credentials);
     const headers = buildMetaAiHeaders(cookieHeader);
     mergeUpstreamExtraHeaders(headers, upstreamExtraHeaders);
@@ -907,6 +1038,12 @@ export class MuseSparkWebExecutor extends BaseExecutor {
     }
 
     if (!upstreamResponse.ok) {
+      // If we tried to continue a cached conversation and Meta rejected,
+      // evict the cache entry so the next retry falls back to a fresh
+      // conversationId instead of looping on the same dead one.
+      if (cached && continuationCacheKey) {
+        conversationCache.delete(continuationCacheKey);
+      }
       let message = `Meta AI returned HTTP ${upstreamResponse.status}`;
       if (upstreamResponse.status === 401 || upstreamResponse.status === 403) {
         message =
@@ -943,6 +1080,11 @@ export class MuseSparkWebExecutor extends BaseExecutor {
     const responseText = await readTextResponse(upstreamResponse.body, signal);
     const parsed = parseMetaAiResponseText(responseText, modelInfo.isThinking);
     if (parsed.status !== 200 || parsed.errorMessage) {
+      // Same eviction rule as the HTTP-level branch above: if we attempted
+      // to continue and Meta returned a parsed error, drop the stale entry.
+      if (cached && continuationCacheKey) {
+        conversationCache.delete(continuationCacheKey);
+      }
       return {
         response: buildErrorResponse(
           parsed.status,
@@ -959,6 +1101,24 @@ export class MuseSparkWebExecutor extends BaseExecutor {
     const created = Math.floor(Date.now() / 1000);
     const deltas = parsed.deltas.length > 0 ? parsed.deltas : [parsed.content];
     const reasoningDeltas = parsed.reasoningDeltas;
+
+    // Remember this turn's conversationId keyed by what we're about to
+    // emit, so the next /v1/chat/completions request that has this content
+    // as its prior assistant turn can continue the same meta.ai conversation
+    // instead of starting a new one. Best-effort: skip silently if we don't
+    // have a stable connectionId or assistant content.
+    if (parsed.content && credentials.connectionId) {
+      rememberConversation(
+        makeConversationCacheKey(credentials.connectionId, model, parsed.content),
+        {
+          conversationId: conversationContext.conversationId,
+          // Reuse the same branch path on every continuation. Linear chats
+          // don't fan out into a tree, and Meta's web UI just reflects the
+          // last reply regardless of the path value we send.
+          branchPath: conversationContext.branchPath,
+        }
+      );
+    }
 
     return {
       response: stream

--- a/tests/unit/muse-spark-web-continuation.test.ts
+++ b/tests/unit/muse-spark-web-continuation.test.ts
@@ -1,0 +1,233 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  MuseSparkWebExecutor,
+  __resetMuseSparkConversationCacheForTesting,
+} from "../../open-sse/executors/muse-spark-web.ts";
+
+// Canned Meta AI response shape. parseMetaAiResponseText accepts either a
+// plain JSON body or an SSE stream of `data: <json>` frames; we send a plain
+// JSON body since the assertions don't care about delta structure.
+function metaAiSseResponse(content: string): Response {
+  const body = JSON.stringify({
+    data: {
+      sendMessageStream: {
+        __typename: "AssistantMessage",
+        content,
+      },
+    },
+  });
+  return new Response(body, {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+type CapturedRequest = { url: string; init: RequestInit | undefined; body: unknown };
+
+function captureFetch(reply: () => Response): {
+  fetchFn: typeof fetch;
+  captured: CapturedRequest[];
+} {
+  const captured: CapturedRequest[] = [];
+  const fetchFn: typeof fetch = async (input, init) => {
+    let body: unknown = undefined;
+    if (init?.body && typeof init.body === "string") {
+      try {
+        body = JSON.parse(init.body);
+      } catch {
+        body = init.body;
+      }
+    }
+    captured.push({
+      url: typeof input === "string" ? input : (input as URL).toString(),
+      init,
+      body,
+    });
+    return reply();
+  };
+  return { fetchFn, captured };
+}
+
+function executeInputs(messages: Array<{ role: string; content: string }>) {
+  return {
+    model: "muse-spark",
+    body: { messages },
+    stream: false,
+    credentials: { apiKey: "abra_sess=foo", connectionId: "conn-test-1" },
+    signal: null,
+    log: null,
+    upstreamExtraHeaders: undefined,
+  } as Parameters<MuseSparkWebExecutor["execute"]>[0];
+}
+
+test("muse-spark-web: first turn opens a new meta.ai conversation", async () => {
+  __resetMuseSparkConversationCacheForTesting();
+  const executor = new MuseSparkWebExecutor();
+  const original = globalThis.fetch;
+  const { fetchFn, captured } = captureFetch(() => metaAiSseResponse("pong"));
+  globalThis.fetch = fetchFn;
+  try {
+    const result = await executor.execute(executeInputs([{ role: "user", content: "ping" }]));
+    assert.equal(captured.length, 1, "exactly one upstream call");
+    const sentVars = (captured[0].body as { variables: Record<string, unknown> }).variables;
+    assert.equal(sentVars.isNewConversation, true, "first turn → isNewConversation: true");
+    assert.equal(sentVars.content, "ping", "first turn → bare user content");
+    assert.match(String(sentVars.conversationId), /^c\./, "fresh meta.ai conversation id");
+    assert.equal(result.response.status, 200);
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+test("muse-spark-web: follow-up turn continues the cached conversation", async () => {
+  __resetMuseSparkConversationCacheForTesting();
+  const executor = new MuseSparkWebExecutor();
+  const original = globalThis.fetch;
+  let nthReply = 0;
+  const { fetchFn, captured } = captureFetch(() =>
+    metaAiSseResponse(nthReply++ === 0 ? "pong" : "pong-again")
+  );
+  globalThis.fetch = fetchFn;
+  try {
+    // Turn 1
+    await executor.execute(executeInputs([{ role: "user", content: "ping" }]));
+    // Turn 2 — caller sends the OpenAI history including the prior assistant.
+    await executor.execute(
+      executeInputs([
+        { role: "user", content: "ping" },
+        { role: "assistant", content: "pong" },
+        { role: "user", content: "ping again" },
+      ])
+    );
+    assert.equal(captured.length, 2, "two upstream calls");
+    const turn1 = (captured[0].body as { variables: Record<string, unknown> }).variables;
+    const turn2 = (captured[1].body as { variables: Record<string, unknown> }).variables;
+    assert.equal(turn1.isNewConversation, true);
+    assert.equal(turn2.isNewConversation, false, "second turn → continues");
+    assert.equal(
+      turn2.conversationId,
+      turn1.conversationId,
+      "second turn reuses first turn's conversation id"
+    );
+    assert.equal(turn2.content, "ping again", "second turn → only the latest user content");
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+test("muse-spark-web: connection isolation — different connectionId → independent conversations", async () => {
+  __resetMuseSparkConversationCacheForTesting();
+  const executor = new MuseSparkWebExecutor();
+  const original = globalThis.fetch;
+  const { fetchFn, captured } = captureFetch(() => metaAiSseResponse("pong"));
+  globalThis.fetch = fetchFn;
+  try {
+    const baseInputs = (id: string) => ({
+      model: "muse-spark",
+      body: {
+        messages: [
+          { role: "user", content: "ping" },
+          { role: "assistant", content: "pong" },
+          { role: "user", content: "again" },
+        ],
+      },
+      stream: false,
+      credentials: { apiKey: "abra_sess=foo", connectionId: id },
+      signal: null,
+      log: null,
+      upstreamExtraHeaders: undefined,
+    });
+    // Two different connections both have the same OpenAI history with the
+    // same prior assistant content. They must not collide on the cache.
+    await executor.execute(baseInputs("conn-A") as Parameters<MuseSparkWebExecutor["execute"]>[0]);
+    await executor.execute(baseInputs("conn-B") as Parameters<MuseSparkWebExecutor["execute"]>[0]);
+    const a = (captured[0].body as { variables: Record<string, unknown> }).variables;
+    const b = (captured[1].body as { variables: Record<string, unknown> }).variables;
+    assert.equal(a.isNewConversation, true);
+    assert.equal(b.isNewConversation, true);
+    assert.notEqual(a.conversationId, b.conversationId);
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+test("muse-spark-web: meta error during continuation evicts the stale cache entry", async () => {
+  __resetMuseSparkConversationCacheForTesting();
+  const executor = new MuseSparkWebExecutor();
+  const original = globalThis.fetch;
+
+  // Reply 1: success. Reply 2: HTTP 400 (e.g. Meta deleted the conversation).
+  // Reply 3: success again — cache must have been evicted, so this turn
+  // should open a fresh conversation, not reuse the dead one.
+  let n = 0;
+  const fetchFn: typeof fetch = async () => {
+    n++;
+    if (n === 2) {
+      return new Response(JSON.stringify({ errors: [{ message: "conversation not found" }] }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    return metaAiSseResponse(n === 1 ? "pong" : "pong-2");
+  };
+  const captured: CapturedRequest[] = [];
+  globalThis.fetch = (async (input, init) => {
+    let body: unknown = undefined;
+    if (init?.body && typeof init.body === "string") {
+      try {
+        body = JSON.parse(init.body);
+      } catch {
+        body = init.body;
+      }
+    }
+    captured.push({
+      url: typeof input === "string" ? input : (input as URL).toString(),
+      init,
+      body,
+    });
+    return fetchFn(input as never, init as never);
+  }) as typeof fetch;
+
+  try {
+    // Turn 1 — opens conversation A and caches it.
+    await executor.execute(executeInputs([{ role: "user", content: "ping" }]));
+    // Turn 2 — would continue conversation A but Meta returns 400.
+    await executor.execute(
+      executeInputs([
+        { role: "user", content: "ping" },
+        { role: "assistant", content: "pong" },
+        { role: "user", content: "again" },
+      ])
+    );
+    // Turn 3 — same prior-assistant content, retried by the user. Cache
+    // should have been evicted on turn 2, so this turn opens a new
+    // conversation rather than re-trying the dead one.
+    await executor.execute(
+      executeInputs([
+        { role: "user", content: "ping" },
+        { role: "assistant", content: "pong" },
+        { role: "user", content: "again" },
+      ])
+    );
+    const t1 = (captured[0].body as { variables: Record<string, unknown> }).variables;
+    const t2 = (captured[1].body as { variables: Record<string, unknown> }).variables;
+    const t3 = (captured[2].body as { variables: Record<string, unknown> }).variables;
+    assert.equal(t1.isNewConversation, true);
+    assert.equal(t2.isNewConversation, false, "turn 2 attempted to continue");
+    assert.equal(t2.conversationId, t1.conversationId);
+    assert.equal(
+      t3.isNewConversation,
+      true,
+      "turn 3 must open a fresh conversation after the stale entry was evicted"
+    );
+    assert.notEqual(
+      t3.conversationId,
+      t1.conversationId,
+      "turn 3 must not reuse the dead conversation id"
+    );
+  } finally {
+    globalThis.fetch = original;
+  }
+});

--- a/tests/unit/muse-spark-web-continuation.test.ts
+++ b/tests/unit/muse-spark-web-continuation.test.ts
@@ -231,3 +231,95 @@ test("muse-spark-web: meta error during continuation evicts the stale cache entr
     globalThis.fetch = original;
   }
 });
+
+test("muse-spark-web: parallel chats with identical assistant text but different histories do not collide", async () => {
+  __resetMuseSparkConversationCacheForTesting();
+  const executor = new MuseSparkWebExecutor();
+  const original = globalThis.fetch;
+
+  // Both chats end with the assistant saying the same generic line. Without
+  // hashing the preceding history, both would map to the same cache entry
+  // and the second chat's continuation would route into the first chat's
+  // meta.ai conversation.
+  const COMMON_REPLY = "I don't have access to real-time data.";
+  const { fetchFn, captured } = captureFetch(() => metaAiSseResponse(COMMON_REPLY));
+  globalThis.fetch = fetchFn;
+  try {
+    // Chat A — turn 1 sets up the cache.
+    await executor.execute(executeInputs([{ role: "user", content: "what's the weather" }]));
+    // Chat B — turn 1 (different question, same response) sets up its own cache entry.
+    await executor.execute(executeInputs([{ role: "user", content: "stock price for AAPL" }]));
+    const a1 = (captured[0].body as { variables: Record<string, unknown> }).variables;
+    const b1 = (captured[1].body as { variables: Record<string, unknown> }).variables;
+
+    // Chat A — turn 2 should continue conversation A, not jump to B's id.
+    await executor.execute(
+      executeInputs([
+        { role: "user", content: "what's the weather" },
+        { role: "assistant", content: COMMON_REPLY },
+        { role: "user", content: "any forecast at all?" },
+      ])
+    );
+    // Chat B — turn 2 should continue conversation B.
+    await executor.execute(
+      executeInputs([
+        { role: "user", content: "stock price for AAPL" },
+        { role: "assistant", content: COMMON_REPLY },
+        { role: "user", content: "any market info at all?" },
+      ])
+    );
+    const a2 = (captured[2].body as { variables: Record<string, unknown> }).variables;
+    const b2 = (captured[3].body as { variables: Record<string, unknown> }).variables;
+
+    assert.equal(a2.isNewConversation, false, "chat A turn 2 continues");
+    assert.equal(b2.isNewConversation, false, "chat B turn 2 continues");
+    assert.equal(a2.conversationId, a1.conversationId, "chat A continues into A's conversation");
+    assert.equal(b2.conversationId, b1.conversationId, "chat B continues into B's conversation");
+    assert.notEqual(
+      a2.conversationId,
+      b2.conversationId,
+      "the two chats must not collide despite identical assistant text"
+    );
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+test("muse-spark-web: empty latestUserContent (no `user` role) falls back to fresh conversation", async () => {
+  __resetMuseSparkConversationCacheForTesting();
+  const executor = new MuseSparkWebExecutor();
+  const original = globalThis.fetch;
+  const { fetchFn, captured } = captureFetch(() => metaAiSseResponse("ack"));
+  globalThis.fetch = fetchFn;
+  try {
+    // Pre-seed the cache with a normal turn so a hit IS possible if the
+    // guard isn't in place.
+    await executor.execute(executeInputs([{ role: "user", content: "ping" }]));
+
+    // Now send a payload with no `user` role at all (system + assistant
+    // only). `latestUserContent` is empty; without the guard the executor
+    // would route this through the cache-hit path and POST empty content
+    // with `isNewConversation: false`.
+    await executor.execute(
+      executeInputs([
+        { role: "system", content: "you are helpful" },
+        { role: "assistant", content: "ack" },
+      ])
+    );
+    const t2 = (captured[1].body as { variables: Record<string, unknown> }).variables;
+
+    assert.equal(
+      t2.isNewConversation,
+      true,
+      "empty latestUserContent must NOT use the cache-hit path"
+    );
+    assert.notEqual(t2.content, "", "must not POST empty content");
+    assert.match(
+      String(t2.content),
+      /assistant: ack/,
+      "should fall through to the folded-history prompt"
+    );
+  } finally {
+    globalThis.fetch = original;
+  }
+});


### PR DESCRIPTION
## Summary

Follow-up to #1668. Now that `muse-spark-web` requests succeed again, a UX issue surfaces: each `/v1/chat/completions` opens a fresh meta.ai conversation and folds the entire OpenAI history into a single user prompt — so a 3-turn chat in OpenWebUI shows up as 3 separate conversations in the user's meta.ai history, each containing the prior turns rendered verbatim as `user: …` / `assistant: …` text.

This PR caches the meta.ai `conversationId` we created on each turn and reuses it on subsequent turns of the same logical chat, so the user sees a single growing conversation in meta.ai instead of one new polluted conversation per turn.

## Mechanism

Module-level cache in `muse-spark-web.ts`:

| | |
| --- | --- |
| Key | `sha256(connectionId \x1f model \x1f lastAssistantContent)` |
| Value | `{ conversationId, branchPath, expiresAt }` |
| TTL | 30 min |
| Bound | 500 entries (oldest evicted, insertion-order Map) |

Per-turn flow in `execute()`:

1. Parse OpenAI history into `{ foldedPrompt, latestUserContent, lastAssistantContent }`.
2. Compute the cache key from `connectionId + model + lastAssistantContent`.
3. **Cache hit**: reuse `conversationId`, set `isNewConversation: false`, send only `latestUserContent`. Meta appends to the existing tree.
4. **Cache miss** (first turn / restart / TTL): generate fresh `conversationId`, `isNewConversation: true`, send `foldedPrompt` (current behavior — preserves context for the assistant's first reply).
5. After a successful response: cache `(connectionId, model, response.content) → (conversationId, branchPath)` for the next turn.
6. After a failed response (HTTP 4xx or parsed `errorMessage`): evict the cache entry that drove this attempt so the next retry opens a fresh conversation rather than looping on a now-dead conversationId.

## What's intentionally **not** in scope

- **Branch-path tracking.** Linear chats don't fan out into a tree, and Meta's web UI reflects only the latest reply regardless of `currentBranchPath`. We reuse `\"0\"` on every turn. If a user wants regenerate/branch semantics later, that's a separate feature.
- **Cross-process state.** The cache is in-memory only; on process restart, the next turn falls back to a fresh conversation. Acceptable for OmniRoute's typical deployment, and a persistent store would add a lot of surface for marginal benefit.
- **Concurrent in-flight requests for the same key.** Two parallel turns with identical prior-assistant content will both reuse the same conversationId. Meta tolerates this in practice; if it ever becomes a problem we'd add an in-flight lock.
- **OpenWebUI background helpers (title / followups / tags).** Those each arrive as a single user message containing OWUI's task scaffolding; they have no `assistant` role and naturally fall through to the new-conversation path. They each create a throwaway conversation in the user's meta.ai history. Cleaning those up was tried (delete-after via `useEctoDeleteConversationMutation`) and is intentionally out of scope here — the cleanup path needs more investigation than it's worth right now.

## Privacy / connection isolation

The cache key includes `connectionId`, so two different users with identical chat content (e.g. the assistant's stock greeting) cannot collide on each other's conversations. Without `connectionId` (e.g. an unauthenticated test path), continuation is skipped entirely and we fall through to the fresh-conversation path.

## Tests (`tests/unit/muse-spark-web-continuation.test.ts`, 4 cases)

- **First turn opens a new meta.ai conversation** — `isNewConversation: true`, fresh `c.…`-prefixed conversationId, payload contains the bare user content.
- **Follow-up turn continues the cached conversation** — second call reuses turn 1's conversationId, sets `isNewConversation: false`, and sends only `latestUserContent` (not the folded history).
- **Connection isolation** — two different `connectionId`s with identical histories produce two separate conversationIds.
- **Eviction-on-error prevents stale-entry loops** — after a continuation gets a 400 from Meta, the cache entry is dropped so the next retry opens a fresh conversation rather than re-using the dead one.

All tests use `globalThis.fetch` overrides to capture upstream payloads — no network calls.

## Risk

Low. Behavior on the cache-miss path is identical to today's executor (same fetch, same body shape, same parse). The only new failure mode is a stale cached `conversationId` reaching Meta, which is recovered automatically by the eviction-on-error path on the very next retry.

## Verification

- [x] `npm run typecheck:core` clean
- [x] `node --import tsx/esm --test tests/unit/muse-spark-web-continuation.test.ts` — 4/4 pass
- [x] Live: 3+ turns in a single OpenWebUI chat now produce a single growing conversation in meta.ai (was 3 separate polluted ones).

🤖 Generated with [Claude Code](https://claude.com/claude-code)