### PR TITLE
fix(codex): remove stale websocket transport lookup

### DIFF
--- a/open-sse/executors/codex.ts
+++ b/open-sse/executors/codex.ts
@@ -638,19 +638,6 @@ export class CodexExecutor extends BaseExecutor {
     const headers = normalizeCodexWsHeaders(this.buildHeaders(input.credentials, true));
     mergeUpstreamExtraHeaders(headers, input.upstreamExtraHeaders);
 
-    const websocket = getCodexWebSocketTransport();
-    if (!websocket) {
-      return {
-        response: errorResponse(
-          503,
-          "Codex WebSocket transport unavailable: wreq-js native module is missing for this platform"
-        ),
-        url,
-        headers,
-        transformedBody: input.body,
-      };
-    }
-
     const transformedBody = (await this.transformRequest(
       input.model,
       input.body,


### PR DESCRIPTION
## Summary
- Removes a stale `getCodexWebSocketTransport()` availability check from the Codex WebSocket execution path.
- Keeps the current lazy `getWreqWebsocket()` check and existing 503 fallback for missing `wreq-js` binaries.

## Why
`gpt-5.5` uses the Codex Responses WebSocket path. After the `wreq-js` lazy-loader refactor, the old `getCodexWebSocketTransport()` symbol no longer exists, so the pre-check throws before the current transport fallback can run.

## Testing
- `tests/unit/executor-codex.test.ts`
- `npm run build`
- pre-push hook passed with isolated local env: `3710/3710`