### PR TITLE
fix(vision): respect native GPT vision support

### DIFF
--- a/src/shared/constants/visionBridgeDefaults.ts
+++ b/src/shared/constants/visionBridgeDefaults.ts
@@ -2,12 +2,16 @@
  * Vision Bridge default configuration values.
  */
 
-const NORMALIZED_GPT_MODEL_PATTERN = /^gpt-/i;
+const FORCED_VISION_BRIDGE_MODELS = new Set<string>([
+  // Fallback list for models whose metadata is known to overstate native vision support.
+]);
 
 export function isVisionBridgeForcedModel(model: string | null | undefined): boolean {
   if (!model) return false;
-  const normalizedModel = model.includes("/") ? model.split("/").pop() || model : model;
-  return NORMALIZED_GPT_MODEL_PATTERN.test(normalizedModel);
+  const normalizedModel = (model.includes("/") ? model.split("/").pop() || model : model)
+    .trim()
+    .toLowerCase();
+  return FORCED_VISION_BRIDGE_MODELS.has(normalizedModel);
 }
 
 export const VISION_BRIDGE_DEFAULTS = {

--- a/tests/unit/guardrails/visionBridge.test.ts
+++ b/tests/unit/guardrails/visionBridge.test.ts
@@ -164,11 +164,10 @@ test("VB-S02: passthroughs for vision-capable model (gpt-4o)", async () => {
   }
 });
 
-test("VB-S02b: forces Vision Bridge for GPT-family models even when model capabilities advertise vision", async () => {
+test("VB-S02b: respects native vision support for GPT-family models", async () => {
   const guardrail = createGuardrail();
 
-  for (const model of ["gpt-5.4", "gpt-5.4-mini", "gpt-4o", "openai/gpt-4o-mini"]) {
-    mockVisionResponse = `Forced bridge description for ${model}`;
+  for (const model of ["gpt-5.5", "gpt-5.5-high", "codex/gpt-5.5", "openai/gpt-4o-mini"]) {
     visionCallCount = 0;
 
     const payload = createPayload({
@@ -189,9 +188,13 @@ test("VB-S02b: forces Vision Bridge for GPT-family models even when model capabi
 
     const result = await guardrail.preCall(payload, createContext({ model }));
 
-    assert.strictEqual(result.block, false, `expected passthrough=false for ${model}`);
-    assert.ok(result.modifiedPayload, `expected modified payload for ${model}`);
-    assert.strictEqual(visionCallCount, 1, `expected one forced bridge call for ${model}`);
+    assert.strictEqual(result.block, false, `expected passthrough for ${model}`);
+    assert.strictEqual(
+      result.modifiedPayload,
+      undefined,
+      `expected unmodified payload for ${model}`
+    );
+    assert.strictEqual(visionCallCount, 0, `expected no bridge call for ${model}`);
   }
 });
 

--- a/tests/unit/visionBridgeDefaults.test.ts
+++ b/tests/unit/visionBridgeDefaults.test.ts
@@ -8,6 +8,7 @@ import {
   VISION_BRIDGE_DEFAULTS,
   VISION_BRIDGE_SETTINGS_KEYS,
   getVisionBridgeConfig,
+  isVisionBridgeForcedModel,
   type VisionBridgeSettings,
 } from "@/shared/constants/visionBridgeDefaults";
 
@@ -30,6 +31,12 @@ test("VISION_BRIDGE_SETTINGS_KEYS exports all expected keys", () => {
     "visionBridgeTimeout",
     "visionBridgeMaxImages",
   ]);
+});
+
+test("isVisionBridgeForcedModel does not blanket-force GPT-family models", () => {
+  assert.strictEqual(isVisionBridgeForcedModel("gpt-5.5"), false);
+  assert.strictEqual(isVisionBridgeForcedModel("codex/gpt-5.5"), false);
+  assert.strictEqual(isVisionBridgeForcedModel("openai/gpt-4o-mini"), false);
 });
 
 test("getVisionBridgeConfig returns defaults when no settings provided", () => {


### PR DESCRIPTION
## Summary
- Removes the blanket Vision Bridge force rule for all normalized `gpt-*` models.
- Keeps a narrow explicit force-list hook for future models whose metadata is known to overstate native vision support.
- Updates Vision Bridge tests to verify GPT-family models with native vision capability pass through without bridge calls.

## Why
Vision Bridge should not override model capability metadata when a model advertises native vision support. The previous blanket `gpt-*` rule forced GPT-family models through the configured bridge model, which can fail for users who do not have that bridge provider configured even though the requested model supports images directly.

## Testing
- `tests/unit/guardrails/visionBridge.test.ts`
- `tests/unit/visionBridgeDefaults.test.ts`
- `npm run build`
- pre-push hook passed with isolated local env

## Notes
This PR intentionally does not include any context compression limit changes.