### PR TITLE
fix(search): support optional bearer auth for SearXNG

### DIFF
--- a/open-sse/handlers/search.ts
+++ b/open-sse/handlers/search.ts
@@ -568,11 +568,16 @@ function buildSearxngRequest(
   const page = toSearchPageNumber(params.offset, params.maxResults);
   if (page) qp.set("pageno", String(page));
 
+  const headers: Record<string, string> = { Accept: "application/json" };
+  if (params.token) {
+    headers["Authorization"] = `Bearer ${params.token}`;
+  }
+
   return {
     url: `${url}?${qp}`,
     init: {
       method: "GET",
-      headers: { Accept: "application/json" },
+      headers,
     },
   };
 }

--- a/src/lib/providers/validation.ts
+++ b/src/lib/providers/validation.ts
@@ -2195,17 +2195,21 @@ const SEARCH_VALIDATOR_CONFIGS: Record<
       headers: { Accept: "application/json", "X-API-Key": apiKey },
     },
   }),
-  "searxng-search": (_apiKey, providerSpecificData = {}) => {
+  "searxng-search": (apiKey, providerSpecificData = {}) => {
     const baseUrl =
       typeof providerSpecificData?.baseUrl === "string" && providerSpecificData.baseUrl.trim()
         ? providerSpecificData.baseUrl.trim().replace(/\/+$/, "")
         : "http://localhost:8888/search";
     const searchUrl = baseUrl.endsWith("/search") ? baseUrl : `${baseUrl}/search`;
+    const headers: Record<string, string> = { Accept: "application/json" };
+    if (apiKey) {
+      headers["Authorization"] = `Bearer ${apiKey}`;
+    }
     return {
       url: `${searchUrl}?q=test&format=json`,
       init: {
         method: "GET",
-        headers: { Accept: "application/json" },
+        headers,
       },
     };
   },

--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -1543,7 +1543,7 @@ export const SEARCH_PROVIDERS = {
     color: "#1A237E",
     textIcon: "SX",
     website: "https://docs.searxng.org",
-    authHint: "Set your SearXNG base URL. API key is optional for public/self-hosted instances.",
+    authHint: "API key is optional. Set your SearXNG base URL. Some instances may require a bearer token for access.",
   },
 };
 


### PR DESCRIPTION
## Summary

- SearXNG connector now passes an optional Bearer token (`Authorization: Bearer <key>`) when an API key is provided, while public instances continue to work without any key
- Previously, `authType: "none"` meant no credentials were ever sent — instances behind auth proxies or with SearXNG's limiter requiring a secret key would fail validation with "API key validation failed", blocking the connection from being saved
- Updated the `authHint` to clarify that a bearer token is optional but supported

## Changes

- `open-sse/handlers/search.ts` — `buildSearxngRequest()` sends `Authorization: Bearer` header when token is provided
- `src/lib/providers/validation.ts` — SearXNG validator passes API key as bearer token during validation
- `src/shared/constants/providers.ts` — Updated `authHint` for clarity

## Test plan

- [ ] Verify public SearXNG instances still work without any API key
- [ ] Verify SearXNG instances requiring a bearer token accept the key via the API key field
- [ ] Verify validation succeeds when a valid token is provided