### PR TITLE
feat(email-privacy): integrate email visibility toggle in RequestLoggerV2

### DIFF
--- a/src/shared/components/RequestLoggerV2.tsx
+++ b/src/shared/components/RequestLoggerV2.tsx
@@ -17,6 +17,7 @@ import {
   maskAccount,
   formatApiKeyLabel,
 } from "@/shared/utils/formatting";
+import useEmailPrivacyStore from "@/store/emailPrivacyStore";
 
 // Quick filter categories - status-based only (providers are dynamic from data)
 const STATUS_FILTERS = [
@@ -114,6 +115,7 @@ function getCacheSourceMeta(cacheSource: unknown) {
 
 export default function RequestLoggerV2() {
   const t = useTranslations("requestLogger");
+  const { emailsVisible } = useEmailPrivacyStore();
 
   // Get translated status filters
   const statusFilters = useMemo(
@@ -795,7 +797,7 @@ export default function RequestLoggerV2() {
                           className="px-3 py-2 text-text-muted truncate max-w-[120px]"
                           title={log.account}
                         >
-                          {maskAccount(log.account)}
+                          {maskAccount(log.account, emailsVisible)}
                         </td>
                       )}
                       {visibleColumns.apiKey && (

--- a/src/shared/utils/formatting.ts
+++ b/src/shared/utils/formatting.ts
@@ -65,12 +65,14 @@ export function maskSegment(value, start = 2, end = 2) {
 /**
  * Mask an email or account string for display.
  * @param {string} account - Account identifier (email or username)
+ * @param {boolean} emailsVisible - Whether to show full email (true) or mask it (false)
  * @returns {string}
  */
-export function maskAccount(account) {
+export function maskAccount(account, emailsVisible) {
   if (!account || account === "-") return "-";
   const atIdx = account.indexOf("@");
   if (atIdx > 3) {
+    if (emailsVisible) return account;
     return account.slice(0, 3) + "***" + account.slice(atIdx);
   }
   if (account.length > 8) {


### PR DESCRIPTION
## Summary

* Adds an email visibility toggle to `RequestLoggerV2`
* Allows masking or revealing email fields in logs based on configuration
* Improves privacy control for logged request data without removing observability

## Why

* Enhance privacy compliance and reduce exposure of sensitive user data in logs

## Validation

* `npm run typecheck:core`
