### PR TITLE
[Urgent] fix: add neutral instructions for bare chat in Codex provider

### DIFF
--- a/open-sse/config/codexInstructions.ts
+++ b/open-sse/config/codexInstructions.ts
@@ -1,6 +1,8 @@
 // Default instructions for Codex models
 // Source: CLIProxyAPI internal/misc/codex_instructions/
 
+export const CODEX_CHAT_DEFAULT_INSTRUCTIONS = "You are a ChatGPT agent.";
+
 export const CODEX_DEFAULT_INSTRUCTIONS = `You are Codex, based on GPT-5. You are running as a coding agent in the Codex CLI on a user's computer.
 
 ## General

--- a/open-sse/executors/codex.ts
+++ b/open-sse/executors/codex.ts
@@ -227,6 +227,7 @@ export function getCodexDualWindowCooldownMs(
 // Ordered list of effort levels from lowest to highest
 const EFFORT_ORDER = ["none", "low", "medium", "high", "xhigh"] as const;
 type EffortLevel = (typeof EFFORT_ORDER)[number];
+const CODEX_CHAT_DEFAULT_INSTRUCTIONS = "You are a ChatGPT agent.";
 const CODEX_FAST_WIRE_VALUE = "priority";
 const CODEX_RESPONSES_WS_URL = "wss://chatgpt.com/backend-api/codex/responses";
 
@@ -994,9 +995,9 @@ export class CodexExecutor extends BaseExecutor {
         body.instructions = "Follow the developer instructions in the conversation.";
       }
     } else {
-      // Translated: use CODEX_DEFAULT_INSTRUCTIONS as fallback when no system
-      // prompt was provided by the client, BUT only if tools are requested.
-      // Injecting tool instructions on bare requests causes Harmony leaks (#1686).
+      // Translated: keep the full Codex tool instructions only for tool-capable
+      // requests. Bare chat requests still need a neutral instructions value
+      // because the Codex Responses backend rejects requests without it.
       const hasTools = Array.isArray(body.tools) && body.tools.length > 0;
       if (
         !body.instructions ||
@@ -1005,7 +1006,7 @@ export class CodexExecutor extends BaseExecutor {
         if (hasTools) {
           body.instructions = CODEX_DEFAULT_INSTRUCTIONS;
         } else {
-          delete body.instructions;
+          body.instructions = CODEX_CHAT_DEFAULT_INSTRUCTIONS;
         }
       }
     }

--- a/open-sse/executors/codex.ts
+++ b/open-sse/executors/codex.ts
@@ -5,7 +5,10 @@ import {
   setUserAgentHeader,
   type ExecuteInput,
 } from "./base.ts";
-import { CODEX_DEFAULT_INSTRUCTIONS } from "../config/codexInstructions.ts";
+import {
+  CODEX_CHAT_DEFAULT_INSTRUCTIONS,
+  CODEX_DEFAULT_INSTRUCTIONS,
+} from "../config/codexInstructions.ts";
 import { PROVIDERS } from "../config/constants.ts";
 import { getCodexClientVersion, getCodexUserAgent } from "../config/codexClient.ts";
 import { getAccessToken } from "../services/tokenRefresh.ts";
@@ -227,7 +230,6 @@ export function getCodexDualWindowCooldownMs(
 // Ordered list of effort levels from lowest to highest
 const EFFORT_ORDER = ["none", "low", "medium", "high", "xhigh"] as const;
 type EffortLevel = (typeof EFFORT_ORDER)[number];
-const CODEX_CHAT_DEFAULT_INSTRUCTIONS = "You are a ChatGPT agent.";
 const CODEX_FAST_WIRE_VALUE = "priority";
 const CODEX_RESPONSES_WS_URL = "wss://chatgpt.com/backend-api/codex/responses";
 

--- a/tests/unit/executor-codex.test.ts
+++ b/tests/unit/executor-codex.test.ts
@@ -17,6 +17,7 @@ import {
   setThinkingBudgetConfig,
   ThinkingMode,
 } from "../../open-sse/services/thinkingBudget.ts";
+import { CODEX_CHAT_DEFAULT_INSTRUCTIONS } from "../../open-sse/config/codexInstructions.ts";
 
 test.afterEach(() => {
   setThinkingBudgetConfig(DEFAULT_THINKING_CONFIG);
@@ -224,7 +225,7 @@ test("CodexExecutor.transformRequest sends neutral instructions for bare chat re
     requestEndpointPath: "/responses",
   });
 
-  assert.equal(result.instructions, "You are a ChatGPT agent.");
+  assert.equal(result.instructions, CODEX_CHAT_DEFAULT_INSTRUCTIONS);
   assert.equal(result.stream, true);
   assert.equal(result.model, "gpt-5.5");
   assert.equal(result.input.length, 1);

--- a/tests/unit/executor-codex.test.ts
+++ b/tests/unit/executor-codex.test.ts
@@ -200,6 +200,37 @@ test("CodexExecutor.transformRequest injects default instructions, clamps reason
   assert.equal(result.stream_options, undefined);
 });
 
+test("CodexExecutor.transformRequest sends neutral instructions for bare chat requests", () => {
+  const executor = new CodexExecutor();
+  const body = {
+    model: "gpt-5.5-medium",
+    input: [
+      {
+        type: "message",
+        role: "user",
+        content: [
+          {
+            type: "input_text",
+            text: "Calculate 79530+41475, and reply with the result only.",
+          },
+        ],
+      },
+    ],
+    instructions: "",
+    stream: false,
+  };
+
+  const result = executor.transformRequest("gpt-5.5-medium", body, false, {
+    requestEndpointPath: "/responses",
+  });
+
+  assert.equal(result.instructions, "You are a ChatGPT agent.");
+  assert.equal(result.stream, true);
+  assert.equal(result.model, "gpt-5.5");
+  assert.equal(result.input.length, 1);
+  assert.equal(result.tools, undefined);
+});
+
 test("CodexExecutor.transformRequest preserves compact requests and native passthrough semantics", () => {
   const executor = new CodexExecutor();
   const body = {


### PR DESCRIPTION
## Summary

- Keep the full Codex tool instructions only for tool-capable requests.
- Add neutral fallback instructions (`You are a ChatGPT agent.`) for bare translated chat requests so the Codex Responses backend accepts them.
- Add unit coverage for a no-tools GPT-5.5 Codex chat request.

## Scope

This fallback is Codex-provider-only. It is applied inside `CodexExecutor` after a request has already been routed to the `codex` provider and translated for the Codex `/responses` backend. It does not change the generic Responses API path, native `/v1/responses` handling, or any non-Codex provider behavior.

## Root Cause

PR #1686 stopped injecting the large Codex tool prompt for bare Chat Completions requests, which avoids protocol leakage. The no-tools path deleted `instructions` entirely, but the Codex `/responses` backend now rejects requests without that top-level field with `Instructions are required`.

In practice, that means the Codex provider cannot be used for normal chat at all: any bare translated conversation request reaches the Codex backend without `instructions` and is rejected with HTTP 400 before a response can be generated.

## Validation

- `npx prettier --write open-sse/executors/codex.ts tests/unit/executor-codex.test.ts`
- `node --import tsx/esm --test tests/unit/executor-codex.test.ts`
- `node --import tsx/esm --test tests/unit/guide-settings-route.test.ts tests/unit/qwen-api-key-auto-create.test.ts tests/unit/t40-opencode-cli-tools-integration.test.ts`
- Pre-push `npm run test:unit`: 3801 passed, 0 failed
