### PR TITLE
fix(combo): avoid false ALL_ACCOUNTS_INACTIVE on quality failures

### DIFF
--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -1574,6 +1574,7 @@ export async function handleComboChat({
       if (result.ok) {
         const quality = await validateResponseQuality(result, clientRequestedStream, log);
         if (!quality.valid) {
+          const qualityFailureReason = `Upstream response failed quality validation: ${quality.reason}`;
           log.warn(
             "COMBO",
             `Model ${modelStr} returned 200 but failed quality check: ${quality.reason}`
@@ -1586,6 +1587,8 @@ export async function handleComboChat({
             target: toRecordedTarget(target),
           });
           recordedAttempts++;
+          lastError = qualityFailureReason;
+          if (!lastStatus) lastStatus = 502;
           if (i > 0) fallbackCount++;
           break; // move to next model
         }
@@ -1955,6 +1958,7 @@ async function handleRoundRobinCombo({
         if (result.ok) {
           const quality = await validateResponseQuality(result, clientRequestedStream, log);
           if (!quality.valid) {
+            const qualityFailureReason = `Upstream response failed quality validation: ${quality.reason}`;
             log.warn(
               "COMBO-RR",
               `${modelStr} returned 200 but failed quality check: ${quality.reason}`
@@ -1967,6 +1971,8 @@ async function handleRoundRobinCombo({
               target: toRecordedTarget(target),
             });
             recordedAttempts++;
+            lastError = qualityFailureReason;
+            if (!lastStatus) lastStatus = 502;
             if (offset > 0) fallbackCount++;
             break; // move to next model
           }

--- a/tests/unit/combo-routing-engine.test.ts
+++ b/tests/unit/combo-routing-engine.test.ts
@@ -1922,6 +1922,60 @@ test("handleComboChat round-robin recovers from provider-scoped 400s when a late
   assert.deepEqual(calls, ["model-a", "model-b"]);
 });
 
+test("handleComboChat single-target quality failure returns explicit quality error instead of ALL_ACCOUNTS_INACTIVE", async () => {
+  const result = await handleComboChat({
+    body: {},
+    combo: {
+      name: "single-target-quality-failure",
+      strategy: "priority",
+      models: ["openai/model-a"],
+      config: { maxRetries: 0 },
+    },
+    handleSingleModel: async () =>
+      new Response('{"choices":[{"message":{"content":"unterminated"}}', {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    isModelAvailable: async () => true,
+    log: createLog(),
+    settings: null,
+    relayOptions: null as any,
+    allCombos: null,
+  });
+
+  const payload = (await result.json()) as any;
+  assert.equal(result.status, 502);
+  assert.match(payload.error.message, /quality validation/i);
+  assert.notEqual(payload.error.code, "ALL_ACCOUNTS_INACTIVE");
+});
+
+test("handleComboChat round-robin single-target quality failure returns explicit quality error instead of ALL_ACCOUNTS_INACTIVE", async () => {
+  const result = await handleComboChat({
+    body: {},
+    combo: {
+      name: "rr-single-target-quality-failure",
+      strategy: "round-robin",
+      models: ["openai/model-a"],
+      config: { maxRetries: 0, retryDelayMs: 1, concurrencyPerModel: 1, queueTimeoutMs: 5 },
+    },
+    handleSingleModel: async () =>
+      new Response('{"choices":[{"message":{"content":"unterminated"}}', {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    isModelAvailable: async () => true,
+    log: createLog(),
+    settings: null,
+    relayOptions: null as any,
+    allCombos: null,
+  });
+
+  const payload = (await result.json()) as any;
+  assert.equal(result.status, 502);
+  assert.match(payload.error.message, /quality validation/i);
+  assert.notEqual(payload.error.code, "ALL_ACCOUNTS_INACTIVE");
+});
+
 test("handleComboChat falls back to next model when first model returns all-accounts-rate-limited 503", async () => {
   const calls: any[] = [];
 


### PR DESCRIPTION
## Summary
- prevent false `ALL_ACCOUNTS_INACTIVE` terminal errors when an upstream `200` response fails combo quality validation
- propagate explicit terminal context (`lastStatus=502`, quality-validation `lastError`) in both priority and round-robin combo paths
- add regression tests covering single-target quality-validation failures for priority and round-robin strategies

## Why
In v3.7.2 combo routing, a `200` response that fails `validateResponseQuality` could exit the loop without terminal status context. In single-target scenarios this fell through to the generic `ALL_ACCOUNTS_INACTIVE` 503, which is misleading and can trigger false outage signals.

## Validation
- `node --import tsx/esm --test tests/unit/combo-routing-engine.test.ts`
- local hook suite passed during commit
- targeted regression tests added in `tests/unit/combo-routing-engine.test.ts`

## Related
- Closes #1707