### PR TITLE
Add Appearance toggles for endpoint tunnel cards

### DIFF
--- a/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.tsx
+++ b/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.tsx
@@ -103,6 +103,8 @@ export default function APIPageClient({ machineId }) {
   const [tailscaleInstallBusy, setTailscaleInstallBusy] = useState(false);
   const [tailscaleInstallLog, setTailscaleInstallLog] = useState<string[]>([]);
   const [tailscalePassword, setTailscalePassword] = useState("");
+  const [showCloudflaredTunnel, setShowCloudflaredTunnel] = useState(true);
+  const [showTailscaleFunnel, setShowTailscaleFunnel] = useState(true);
 
   const { copied, copy } = useCopyToClipboard();
 
@@ -308,6 +310,8 @@ export default function APIPageClient({ machineId }) {
         if (data.machineId) {
           setResolvedMachineId(data.machineId);
         }
+        setShowCloudflaredTunnel(data.hideEndpointCloudflaredTunnel !== true);
+        setShowTailscaleFunnel(data.hideEndpointTailscaleFunnel !== true);
       }
     } catch (error) {
       console.log("Error loading cloud settings:", error);
@@ -989,236 +993,242 @@ export default function APIPageClient({ machineId }) {
           </Button>
         </div>
 
-        <div className="rounded-xl border border-border/70 bg-surface/40 p-4">
-          <div className="flex flex-col gap-3">
-            <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
-              <div className="min-w-0">
-                <div className="flex flex-wrap items-center gap-2">
-                  <h3 className="text-sm font-semibold">
-                    {translateOrFallback("cloudflaredTitle", "Cloudflare Quick Tunnel")}
-                  </h3>
-                  <span
-                    className={`inline-flex items-center rounded-full border px-2 py-1 text-xs font-medium ${cloudflaredPhaseMeta[cloudflaredPhase].className}`}
-                  >
-                    {cloudflaredPhaseMeta[cloudflaredPhase].label}
-                  </span>
+        {showCloudflaredTunnel && (
+          <div className="rounded-xl border border-border/70 bg-surface/40 p-4">
+            <div className="flex flex-col gap-3">
+              <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                <div className="min-w-0">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <h3 className="text-sm font-semibold">
+                      {translateOrFallback("cloudflaredTitle", "Cloudflare Quick Tunnel")}
+                    </h3>
+                    <span
+                      className={`inline-flex items-center rounded-full border px-2 py-1 text-xs font-medium ${cloudflaredPhaseMeta[cloudflaredPhase].className}`}
+                    >
+                      {cloudflaredPhaseMeta[cloudflaredPhase].label}
+                    </span>
+                  </div>
                 </div>
-              </div>
 
-              {cloudflaredStatus?.supported !== false && (
-                <Button
-                  size="sm"
-                  variant={cloudflaredStatus?.running ? "secondary" : "primary"}
-                  icon={cloudflaredStatus?.running ? "cloud_off" : "cloud_upload"}
-                  onClick={() =>
-                    handleCloudflaredAction(cloudflaredStatus?.running ? "disable" : "enable")
-                  }
-                  loading={cloudflaredBusy}
-                  className={
-                    cloudflaredStatus?.running
-                      ? "border-border/70! text-text-muted! hover:text-text!"
-                      : "bg-linear-to-r from-primary to-cyan-500 hover:from-primary-hover hover:to-cyan-600"
-                  }
-                >
-                  {cloudflaredActionLabel}
-                </Button>
-              )}
-            </div>
-
-            {cloudflaredNotice && (
-              <div
-                className={`flex items-center gap-2 rounded-lg border px-3 py-2 text-sm ${
-                  cloudflaredNotice.type === "success"
-                    ? "border-green-500/30 bg-green-500/10 text-green-400"
-                    : cloudflaredNotice.type === "info"
-                      ? "border-blue-500/30 bg-blue-500/10 text-blue-400"
-                      : "border-red-500/30 bg-red-500/10 text-red-400"
-                }`}
-              >
-                <span className="material-symbols-outlined text-[18px]">
-                  {cloudflaredNotice.type === "success"
-                    ? "check_circle"
-                    : cloudflaredNotice.type === "info"
-                      ? "info"
-                      : "error"}
-                </span>
-                <span className="flex-1">{cloudflaredNotice.message}</span>
-                <button
-                  onClick={() => setCloudflaredNotice(null)}
-                  className="rounded p-0.5 transition-colors hover:bg-white/10"
-                >
-                  <span className="material-symbols-outlined text-[16px]">close</span>
-                </button>
-              </div>
-            )}
-
-            <p className="text-xs text-text-muted">{cloudflaredUrlNotice}</p>
-            <div className="flex flex-col sm:flex-row gap-2">
-              <Input
-                value={cloudflaredStatus?.apiUrl || ""}
-                readOnly
-                placeholder="https://*.trycloudflare.com/v1"
-                className="flex-1 min-w-0 font-mono text-sm"
-              />
-              <Button
-                variant="secondary"
-                icon={copied === "cloudflared_url" ? "check" : "content_copy"}
-                onClick={() =>
-                  cloudflaredStatus?.apiUrl && copy(cloudflaredStatus.apiUrl, "cloudflared_url")
-                }
-                disabled={!cloudflaredStatus?.apiUrl}
-                className="shrink-0 self-start sm:self-auto"
-              >
-                {copied === "cloudflared_url" ? tc("copied") : tc("copy")}
-              </Button>
-            </div>
-            {cloudflaredStatus?.lastError && (
-              <p className="text-xs text-red-400">
-                {translateOrFallback("cloudflaredLastError", "Last error: {error}", {
-                  error: cloudflaredStatus.lastError,
-                })}
-              </p>
-            )}
-          </div>
-        </div>
-
-        <div className="mt-4 rounded-xl border border-border/70 bg-surface/40 p-4">
-          <div className="flex flex-col gap-3">
-            <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
-              <div className="min-w-0">
-                <div className="flex flex-wrap items-center gap-2">
-                  <h3 className="text-sm font-semibold">
-                    {translateOrFallback("tailscaleTitle", "Tailscale Funnel")}
-                  </h3>
-                  <span
-                    className={`inline-flex items-center rounded-full border px-2 py-1 text-xs font-medium ${tailscalePhaseMeta[tailscalePhase].className}`}
-                  >
-                    {tailscalePhaseMeta[tailscalePhase].label}
-                  </span>
-                </div>
-              </div>
-
-              {tailscaleStatus?.supported !== false && (
-                <Button
-                  size="sm"
-                  variant={tailscaleStatus?.running ? "secondary" : "primary"}
-                  icon={tailscaleStatus?.running ? "vpn_lock_off" : "vpn_lock"}
-                  onClick={() => {
-                    if (tailscaleStatus?.running) {
-                      void handleTailscaleDisable();
-                    } else if (!tailscaleStatus?.installed) {
-                      setShowTailscaleInstallModal(true);
-                    } else {
-                      void handleTailscaleEnable();
+                {cloudflaredStatus?.supported !== false && (
+                  <Button
+                    size="sm"
+                    variant={cloudflaredStatus?.running ? "secondary" : "primary"}
+                    icon={cloudflaredStatus?.running ? "cloud_off" : "cloud_upload"}
+                    onClick={() =>
+                      handleCloudflaredAction(cloudflaredStatus?.running ? "disable" : "enable")
                     }
-                  }}
-                  loading={tailscaleBusy}
-                  className={
-                    tailscaleStatus?.running
-                      ? "border-border/70! text-text-muted! hover:text-text!"
-                      : "bg-linear-to-r from-indigo-500 to-cyan-500 hover:from-indigo-600 hover:to-cyan-600"
-                  }
-                >
-                  {tailscaleActionLabel}
-                </Button>
-              )}
-            </div>
-
-            {tailscaleNotice && (
-              <div
-                className={`flex items-center gap-2 rounded-lg border px-3 py-2 text-sm ${
-                  tailscaleNotice.type === "success"
-                    ? "border-green-500/30 bg-green-500/10 text-green-400"
-                    : tailscaleNotice.type === "info"
-                      ? "border-blue-500/30 bg-blue-500/10 text-blue-400"
-                      : "border-red-500/30 bg-red-500/10 text-red-400"
-                }`}
-              >
-                <span className="material-symbols-outlined text-[18px]">
-                  {tailscaleNotice.type === "success"
-                    ? "check_circle"
-                    : tailscaleNotice.type === "info"
-                      ? "info"
-                      : "error"}
-                </span>
-                <span className="flex-1">{tailscaleNotice.message}</span>
-                <button
-                  onClick={() => setTailscaleNotice(null)}
-                  className="rounded p-0.5 transition-colors hover:bg-white/10"
-                >
-                  <span className="material-symbols-outlined text-[16px]">close</span>
-                </button>
-              </div>
-            )}
-
-            <p className="text-xs text-text-muted">{tailscaleUrlNotice}</p>
-            {tailscaleStatus?.phase === "needs_login" && (
-              <p className="text-xs text-blue-400">
-                {translateOrFallback(
-                  "tailscaleNeedsLoginHint",
-                  "Authenticate this machine with Tailscale, then enable Funnel."
+                    loading={cloudflaredBusy}
+                    className={
+                      cloudflaredStatus?.running
+                        ? "border-border/70! text-text-muted! hover:text-text!"
+                        : "bg-linear-to-r from-primary to-cyan-500 hover:from-primary-hover hover:to-cyan-600"
+                    }
+                  >
+                    {cloudflaredActionLabel}
+                  </Button>
                 )}
-              </p>
-            )}
-            {/* Sudo password input — shown when Tailscale is installed but not running (needs sudo to start daemon) */}
-            {tailscaleStatus?.installed &&
-              !tailscaleStatus?.running &&
-              tailscaleStatus?.platform !== "win32" && (
-                <div className="flex flex-col gap-1">
-                  <label className="text-xs text-text-muted">
-                    {translateOrFallback(
-                      "tailscaleSudoLabel",
-                      "Sudo Password (required on macOS/Linux)"
-                    )}
-                  </label>
-                  <Input
-                    type="password"
-                    value={tailscalePassword}
-                    onChange={(event) => setTailscalePassword(event.target.value)}
-                    placeholder={translateOrFallback(
-                      "tailscaleSudoPlaceholder",
-                      "Enter sudo password"
-                    )}
-                    disabled={tailscaleBusy}
-                    className="font-mono text-sm"
-                  />
+              </div>
+
+              {cloudflaredNotice && (
+                <div
+                  className={`flex items-center gap-2 rounded-lg border px-3 py-2 text-sm ${
+                    cloudflaredNotice.type === "success"
+                      ? "border-green-500/30 bg-green-500/10 text-green-400"
+                      : cloudflaredNotice.type === "info"
+                        ? "border-blue-500/30 bg-blue-500/10 text-blue-400"
+                        : "border-red-500/30 bg-red-500/10 text-red-400"
+                  }`}
+                >
+                  <span className="material-symbols-outlined text-[18px]">
+                    {cloudflaredNotice.type === "success"
+                      ? "check_circle"
+                      : cloudflaredNotice.type === "info"
+                        ? "info"
+                        : "error"}
+                  </span>
+                  <span className="flex-1">{cloudflaredNotice.message}</span>
+                  <button
+                    onClick={() => setCloudflaredNotice(null)}
+                    className="rounded p-0.5 transition-colors hover:bg-white/10"
+                  >
+                    <span className="material-symbols-outlined text-[16px]">close</span>
+                  </button>
                 </div>
               )}
-            <div className="flex flex-col sm:flex-row gap-2">
-              <Input
-                value={tailscaleStatus?.apiUrl || ""}
-                readOnly
-                placeholder="https://your-device.tailnet.ts.net/v1"
-                className="flex-1 min-w-0 font-mono text-sm"
-              />
-              <Button
-                variant="secondary"
-                icon={copied === "tailscale_url" ? "check" : "content_copy"}
-                onClick={() =>
-                  tailscaleStatus?.apiUrl && copy(tailscaleStatus.apiUrl, "tailscale_url")
-                }
-                disabled={!tailscaleStatus?.apiUrl}
-                className="shrink-0 self-start sm:self-auto"
-              >
-                {copied === "tailscale_url" ? tc("copied") : tc("copy")}
-              </Button>
+
+              <p className="text-xs text-text-muted">{cloudflaredUrlNotice}</p>
+              <div className="flex flex-col sm:flex-row gap-2">
+                <Input
+                  value={cloudflaredStatus?.apiUrl || ""}
+                  readOnly
+                  placeholder="https://*.trycloudflare.com/v1"
+                  className="flex-1 min-w-0 font-mono text-sm"
+                />
+                <Button
+                  variant="secondary"
+                  icon={copied === "cloudflared_url" ? "check" : "content_copy"}
+                  onClick={() =>
+                    cloudflaredStatus?.apiUrl && copy(cloudflaredStatus.apiUrl, "cloudflared_url")
+                  }
+                  disabled={!cloudflaredStatus?.apiUrl}
+                  className="shrink-0 self-start sm:self-auto"
+                >
+                  {copied === "cloudflared_url" ? tc("copied") : tc("copy")}
+                </Button>
+              </div>
+              {cloudflaredStatus?.lastError && (
+                <p className="text-xs text-red-400">
+                  {translateOrFallback("cloudflaredLastError", "Last error: {error}", {
+                    error: cloudflaredStatus.lastError,
+                  })}
+                </p>
+              )}
             </div>
-            {tailscaleStatus?.binaryPath && (
-              <p className="text-xs text-text-muted">
-                {translateOrFallback("tailscaleBinaryPath", "Binary: {path}", {
-                  path: tailscaleStatus.binaryPath,
-                })}
-              </p>
-            )}
-            {tailscaleStatus?.lastError && (
-              <p className="text-xs text-red-400">
-                {translateOrFallback("tailscaleLastError", "Last error: {error}", {
-                  error: tailscaleStatus.lastError,
-                })}
-              </p>
-            )}
           </div>
-        </div>
+        )}
+
+        {showTailscaleFunnel && (
+          <div
+            className={`${showCloudflaredTunnel ? "mt-4 " : ""}rounded-xl border border-border/70 bg-surface/40 p-4`}
+          >
+            <div className="flex flex-col gap-3">
+              <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                <div className="min-w-0">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <h3 className="text-sm font-semibold">
+                      {translateOrFallback("tailscaleTitle", "Tailscale Funnel")}
+                    </h3>
+                    <span
+                      className={`inline-flex items-center rounded-full border px-2 py-1 text-xs font-medium ${tailscalePhaseMeta[tailscalePhase].className}`}
+                    >
+                      {tailscalePhaseMeta[tailscalePhase].label}
+                    </span>
+                  </div>
+                </div>
+
+                {tailscaleStatus?.supported !== false && (
+                  <Button
+                    size="sm"
+                    variant={tailscaleStatus?.running ? "secondary" : "primary"}
+                    icon={tailscaleStatus?.running ? "vpn_lock_off" : "vpn_lock"}
+                    onClick={() => {
+                      if (tailscaleStatus?.running) {
+                        void handleTailscaleDisable();
+                      } else if (!tailscaleStatus?.installed) {
+                        setShowTailscaleInstallModal(true);
+                      } else {
+                        void handleTailscaleEnable();
+                      }
+                    }}
+                    loading={tailscaleBusy}
+                    className={
+                      tailscaleStatus?.running
+                        ? "border-border/70! text-text-muted! hover:text-text!"
+                        : "bg-linear-to-r from-indigo-500 to-cyan-500 hover:from-indigo-600 hover:to-cyan-600"
+                    }
+                  >
+                    {tailscaleActionLabel}
+                  </Button>
+                )}
+              </div>
+
+              {tailscaleNotice && (
+                <div
+                  className={`flex items-center gap-2 rounded-lg border px-3 py-2 text-sm ${
+                    tailscaleNotice.type === "success"
+                      ? "border-green-500/30 bg-green-500/10 text-green-400"
+                      : tailscaleNotice.type === "info"
+                        ? "border-blue-500/30 bg-blue-500/10 text-blue-400"
+                        : "border-red-500/30 bg-red-500/10 text-red-400"
+                  }`}
+                >
+                  <span className="material-symbols-outlined text-[18px]">
+                    {tailscaleNotice.type === "success"
+                      ? "check_circle"
+                      : tailscaleNotice.type === "info"
+                        ? "info"
+                        : "error"}
+                  </span>
+                  <span className="flex-1">{tailscaleNotice.message}</span>
+                  <button
+                    onClick={() => setTailscaleNotice(null)}
+                    className="rounded p-0.5 transition-colors hover:bg-white/10"
+                  >
+                    <span className="material-symbols-outlined text-[16px]">close</span>
+                  </button>
+                </div>
+              )}
+
+              <p className="text-xs text-text-muted">{tailscaleUrlNotice}</p>
+              {tailscaleStatus?.phase === "needs_login" && (
+                <p className="text-xs text-blue-400">
+                  {translateOrFallback(
+                    "tailscaleNeedsLoginHint",
+                    "Authenticate this machine with Tailscale, then enable Funnel."
+                  )}
+                </p>
+              )}
+              {/* Sudo password input — shown when Tailscale is installed but not running (needs sudo to start daemon) */}
+              {tailscaleStatus?.installed &&
+                !tailscaleStatus?.running &&
+                tailscaleStatus?.platform !== "win32" && (
+                  <div className="flex flex-col gap-1">
+                    <label className="text-xs text-text-muted">
+                      {translateOrFallback(
+                        "tailscaleSudoLabel",
+                        "Sudo Password (required on macOS/Linux)"
+                      )}
+                    </label>
+                    <Input
+                      type="password"
+                      value={tailscalePassword}
+                      onChange={(event) => setTailscalePassword(event.target.value)}
+                      placeholder={translateOrFallback(
+                        "tailscaleSudoPlaceholder",
+                        "Enter sudo password"
+                      )}
+                      disabled={tailscaleBusy}
+                      className="font-mono text-sm"
+                    />
+                  </div>
+                )}
+              <div className="flex flex-col sm:flex-row gap-2">
+                <Input
+                  value={tailscaleStatus?.apiUrl || ""}
+                  readOnly
+                  placeholder="https://your-device.tailnet.ts.net/v1"
+                  className="flex-1 min-w-0 font-mono text-sm"
+                />
+                <Button
+                  variant="secondary"
+                  icon={copied === "tailscale_url" ? "check" : "content_copy"}
+                  onClick={() =>
+                    tailscaleStatus?.apiUrl && copy(tailscaleStatus.apiUrl, "tailscale_url")
+                  }
+                  disabled={!tailscaleStatus?.apiUrl}
+                  className="shrink-0 self-start sm:self-auto"
+                >
+                  {copied === "tailscale_url" ? tc("copied") : tc("copy")}
+                </Button>
+              </div>
+              {tailscaleStatus?.binaryPath && (
+                <p className="text-xs text-text-muted">
+                  {translateOrFallback("tailscaleBinaryPath", "Binary: {path}", {
+                    path: tailscaleStatus.binaryPath,
+                  })}
+                </p>
+              )}
+              {tailscaleStatus?.lastError && (
+                <p className="text-xs text-red-400">
+                  {translateOrFallback("tailscaleLastError", "Last error: {error}", {
+                    error: tailscaleStatus.lastError,
+                  })}
+                </p>
+              )}
+            </div>
+          </div>
+        )}
       </Card>
 
       <Card>

--- a/src/app/(dashboard)/dashboard/settings/components/AppearanceTab.tsx
+++ b/src/app/(dashboard)/dashboard/settings/components/AppearanceTab.tsx
@@ -36,6 +36,8 @@ export default function AppearanceTab() {
   );
   const hiddenSidebarSet = new Set(hiddenSidebarItems);
   const comboConfigMode = normalizeComboConfigMode(settings[COMBO_CONFIG_MODE_SETTING_KEY]);
+  const showCloudflaredTunnel = settings.hideEndpointCloudflaredTunnel !== true;
+  const showTailscaleFunnel = settings.hideEndpointTailscaleFunnel !== true;
 
   const getSettingsLabel = (key: string, fallback: string) =>
     typeof t.has === "function" && t.has(key) ? t(key) : fallback;
@@ -252,6 +254,60 @@ export default function AppearanceTab() {
             <Button onClick={() => setCustomColorTheme(customThemeColor)} disabled={!isValidHex}>
               {t("themeCreate")}
             </Button>
+          </div>
+        </div>
+
+        <div className="pt-4 border-t border-border">
+          <div className="mb-3">
+            <p className="font-medium">
+              {getSettingsLabel("endpointTunnelVisibility", "Endpoint tunnel visibility")}
+            </p>
+            <p className="text-sm text-text-muted">
+              {getSettingsLabel(
+                "endpointTunnelVisibilityDesc",
+                "Hide tunnel controls from the Endpoint page without changing tunnel state."
+              )}
+            </p>
+          </div>
+
+          <div className="rounded-lg border border-border bg-surface/40 divide-y divide-border/70">
+            <div className="flex items-center justify-between gap-4 px-4 py-3">
+              <div>
+                <p className="font-medium">
+                  {getSettingsLabel("showCloudflareTunnel", "Cloudflare Quick Tunnel")}
+                </p>
+                <p className="text-sm text-text-muted">
+                  {getSettingsLabel(
+                    "showCloudflareTunnelDesc",
+                    "Show Cloudflare Quick Tunnel controls on the Endpoint page."
+                  )}
+                </p>
+              </div>
+              <Toggle
+                checked={showCloudflaredTunnel}
+                onChange={(checked) => updateSetting("hideEndpointCloudflaredTunnel", !checked)}
+                disabled={loading}
+              />
+            </div>
+
+            <div className="flex items-center justify-between gap-4 px-4 py-3">
+              <div>
+                <p className="font-medium">
+                  {getSettingsLabel("showTailscaleFunnel", "Tailscale Funnel")}
+                </p>
+                <p className="text-sm text-text-muted">
+                  {getSettingsLabel(
+                    "showTailscaleFunnelDesc",
+                    "Show Tailscale Funnel controls on the Endpoint page."
+                  )}
+                </p>
+              </div>
+              <Toggle
+                checked={showTailscaleFunnel}
+                onChange={(checked) => updateSetting("hideEndpointTailscaleFunnel", !checked)}
+                disabled={loading}
+              />
+            </div>
           </div>
         </div>
 

--- a/src/lib/db/settings.ts
+++ b/src/lib/db/settings.ts
@@ -54,6 +54,8 @@ export async function getSettings() {
     antigravitySignatureCacheMode: "enabled",
     requireLogin: true,
     hiddenSidebarItems: [],
+    hideEndpointCloudflaredTunnel: false,
+    hideEndpointTailscaleFunnel: false,
     comboConfigMode: "guided",
     alwaysPreserveClientCache: "auto",
     idempotencyWindowMs: 5000,

--- a/src/shared/validation/settingsSchemas.ts
+++ b/src/shared/validation/settingsSchemas.ts
@@ -45,6 +45,8 @@ export const updateSettingsSchema = z.object({
   setupComplete: z.boolean().optional(),
   blockedProviders: z.array(z.string().max(100)).optional(),
   hideHealthCheckLogs: z.boolean().optional(),
+  hideEndpointCloudflaredTunnel: z.boolean().optional(),
+  hideEndpointTailscaleFunnel: z.boolean().optional(),
   debugMode: z.boolean().optional(),
   hiddenSidebarItems: z.array(z.enum(HIDEABLE_SIDEBAR_ITEM_IDS)).optional(),
   comboConfigMode: z.enum(COMBO_CONFIG_MODES).optional(),

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -20,6 +20,8 @@ export interface Settings {
   maxRetryIntervalSec: number;
   jwtSecret?: string;
   hideHealthCheckLogs?: boolean;
+  hideEndpointCloudflaredTunnel?: boolean;
+  hideEndpointTailscaleFunnel?: boolean;
   hiddenSidebarItems?: HideableSidebarItemId[];
   resilienceSettings?: ResilienceSettings;
 }

--- a/tests/unit/settings-api.test.ts
+++ b/tests/unit/settings-api.test.ts
@@ -58,7 +58,7 @@ after(() => {
   harness.cleanup();
 });
 
-describe("Settings API - debugMode and hiddenSidebarItems", () => {
+describe("Settings API - persisted preferences", () => {
   describe("debugMode", () => {
     test("updateSettings with debugMode=true succeeds", async () => {
       const result = await harness.updateSettings({ debugMode: true });
@@ -132,6 +132,27 @@ describe("Settings API - debugMode and hiddenSidebarItems", () => {
         "bypass-strict",
         "antigravitySignatureCacheMode should be updated"
       );
+    });
+
+    test("PATCH /api/settings persists endpoint tunnel visibility", async () => {
+      const response = await harness.settingsRoute.PATCH(
+        await makeManagementSessionRequest("http://localhost/api/settings", {
+          method: "PATCH",
+          body: {
+            hideEndpointCloudflaredTunnel: true,
+            hideEndpointTailscaleFunnel: true,
+          },
+        })
+      );
+      const body = (await response.json()) as any;
+
+      assert.equal(response.status, 200);
+      assert.equal(body.hideEndpointCloudflaredTunnel, true);
+      assert.equal(body.hideEndpointTailscaleFunnel, true);
+
+      const settings = await harness.getSettings();
+      assert.equal(settings.hideEndpointCloudflaredTunnel, true);
+      assert.equal(settings.hideEndpointTailscaleFunnel, true);
     });
 
     test("PUT /api/settings reuses the PATCH update flow", async () => {


### PR DESCRIPTION
## Summary
- Added Appearance toggles for showing Cloudflare Quick Tunnel and Tailscale Funnel controls on the Endpoint page.
- Persisted the two visibility preferences through the existing settings API and defaults.
- Conditionally render Endpoint tunnel cards only when enabled, leaving tunnel state and backend behavior unchanged.

## Testing
- `npx prettier --write` on changed files
- `node --import tsx/esm --test tests/unit/settings-api.test.ts`
- `npm run typecheck:core`
- `npm run lint` (0 errors; existing warnings remain)
- `npm run test:coverage` (3844 tests passed; Statements 86.5%, Branches 75.3%, Functions 89.84%, Lines 86.5%)
- `npm run test:unit` via pre-push hook (3844 passing)
- Manual browser verification on local dev server for Appearance and Endpoint pages