### PR TITLE
Refresh CLI fingerprint provider profiles

### DIFF
--- a/open-sse/config/cliFingerprints.ts
+++ b/open-sse/config/cliFingerprints.ts
@@ -15,6 +15,7 @@ import {
   GITHUB_COPILOT_CHAT_USER_AGENT,
   getQwenOauthHeaders,
 } from "./providerHeaderProfiles.ts";
+import { normalizeCliCompatProviderId } from "@/shared/utils/cliCompat";
 
 export interface CliFingerprint {
   /** Ordered list of header names (case-sensitive). Unlisted headers are appended. */
@@ -22,7 +23,7 @@ export interface CliFingerprint {
   /** Ordered list of top-level JSON body fields. Unlisted fields are appended. */
   bodyFieldOrder: string[];
   /** User-Agent string to inject (overrides default) */
-  userAgent?: string;
+  userAgent?: string | (() => string);
   /** Extra headers to add */
   extraHeaders?: Record<string, string>;
 }
@@ -54,7 +55,9 @@ export const CLI_FINGERPRINTS: Record<string, CliFingerprint> = {
       "n",
       "stop",
     ],
-    userAgent: "codex-cli",
+    // Codex builds mode-specific client headers in its executor/config. The CLI fingerprint must
+    // only preserve ordering here; overriding User-Agent with a generic value would erase the
+    // executor-provided version or user override.
   },
   claude: {
     headerOrder: [
@@ -172,8 +175,16 @@ export const CLI_FINGERPRINTS: Record<string, CliFingerprint> = {
       "Accept",
       "Accept-Encoding",
     ],
-    bodyFieldOrder: ["project", "model", "userAgent", "requestType", "requestId", "request"],
-    userAgent: getAntigravityUserAgent(),
+    bodyFieldOrder: [
+      "project",
+      "model",
+      "userAgent",
+      "requestType",
+      "requestId",
+      "enabledCreditTypes",
+      "request",
+    ],
+    userAgent: getAntigravityUserAgent,
   },
   qwen: {
     headerOrder: [
@@ -286,9 +297,10 @@ export function applyFingerprint(
   headers: Record<string, string>,
   body: unknown
 ): { headers: Record<string, string>; bodyString: string } {
+  const normalizedProvider = normalizeCliCompatProviderId(provider || "");
   const fingerprintKey = isClaudeCodeCompatible(provider)
     ? "claude-code-compatible"
-    : provider?.toLowerCase();
+    : normalizedProvider;
   const fingerprint = CLI_FINGERPRINTS[fingerprintKey];
 
   if (!fingerprint) {
@@ -297,7 +309,8 @@ export function applyFingerprint(
 
   // Apply user agent override
   if (fingerprint.userAgent) {
-    headers["User-Agent"] = fingerprint.userAgent;
+    headers["User-Agent"] =
+      typeof fingerprint.userAgent === "function" ? fingerprint.userAgent() : fingerprint.userAgent;
   }
 
   // Apply extra headers
@@ -331,7 +344,11 @@ let _cliCompatProviders: Set<string> = new Set();
  * Called from the settings API when cliCompatProviders is updated.
  */
 export function setCliCompatProviders(providers: string[]): void {
-  _cliCompatProviders = new Set((providers || []).map((p) => p.toLowerCase()));
+  _cliCompatProviders = new Set(
+    (providers || [])
+      .map((p) => normalizeCliCompatProviderId(p))
+      .filter((provider) => provider in CLI_FINGERPRINTS)
+  );
 }
 
 /**
@@ -351,7 +368,8 @@ export function isCliCompatEnabled(provider: string): boolean {
   const key = provider?.toLowerCase().replace(/[^a-z0-9]/g, "_");
 
   // 1. Check runtime cache (set via Settings UI)
-  if (_cliCompatProviders.has(provider?.toLowerCase())) return true;
+  const normalizedProvider = normalizeCliCompatProviderId(provider || "");
+  if (_cliCompatProviders.has(normalizedProvider)) return true;
 
   // 2. Check environment variable: CLI_COMPAT_<PROVIDER>=1
   const envKey = `CLI_COMPAT_${key?.toUpperCase()}`;

--- a/open-sse/config/providerHeaderProfiles.ts
+++ b/open-sse/config/providerHeaderProfiles.ts
@@ -46,7 +46,23 @@ export function getGitHubCopilotChatHeaders(
   };
 }
 
-function normalizeStainlessPlatform(platform: string = process.platform): string {
+function getRuntimePlatform(): string {
+  return typeof process !== "undefined" && typeof process.platform === "string"
+    ? process.platform
+    : "unknown";
+}
+
+function getRuntimeArch(): string {
+  return typeof process !== "undefined" && typeof process.arch === "string" ? process.arch : "unknown";
+}
+
+function getRuntimeVersion(): string {
+  return typeof process !== "undefined" && typeof process.version === "string"
+    ? process.version
+    : "unknown";
+}
+
+function normalizeStainlessPlatform(platform: string = getRuntimePlatform()): string {
   const normalized = platform.toLowerCase();
   if (normalized.includes("ios")) return "iOS";
   if (normalized === "android") return "Android";
@@ -58,7 +74,7 @@ function normalizeStainlessPlatform(platform: string = process.platform): string
   return normalized ? `Other:${normalized}` : "Unknown";
 }
 
-function normalizeStainlessArch(arch: string = process.arch): string {
+function normalizeStainlessArch(arch: string = getRuntimeArch()): string {
   if (arch === "x32") return "x32";
   if (arch === "x86_64" || arch === "x64") return "x64";
   if (arch === "arm") return "arm";
@@ -69,7 +85,7 @@ function normalizeStainlessArch(arch: string = process.arch): string {
 export function getQwenCliUserAgent(version = QWEN_CLI_VERSION): string {
   // Qwen Code builds this from the runtime process values. Keep it runtime-derived so
   // packaged deployments use their own platform/architecture instead of a maintainer's host.
-  return `QwenCode/${version} (${process.platform}; ${process.arch})`;
+  return `QwenCode/${version} (${getRuntimePlatform()}; ${getRuntimeArch()})`;
 }
 
 export function getGitHubCopilotInternalUserHeaders(authorization: string): Record<string, string> {
@@ -106,7 +122,7 @@ export function getQwenOauthHeaders(): Record<string, string> {
     "X-Stainless-Package-Version": QWEN_STAINLESS_PACKAGE_VERSION,
     "X-Stainless-Retry-Count": QWEN_STAINLESS_RETRY_COUNT,
     "X-Stainless-Runtime": QWEN_STAINLESS_RUNTIME,
-    "X-Stainless-Runtime-Version": process.version,
+    "X-Stainless-Runtime-Version": getRuntimeVersion(),
     Connection: "keep-alive",
     "Accept-Language": QWEN_ACCEPT_LANGUAGE,
     "Sec-Fetch-Mode": QWEN_SEC_FETCH_MODE,

--- a/open-sse/config/providerHeaderProfiles.ts
+++ b/open-sse/config/providerHeaderProfiles.ts
@@ -11,26 +11,22 @@ export const GITHUB_COPILOT_OPENAI_INTENT = "conversation-panel";
 export const GITHUB_COPILOT_DEFAULT_INITIATOR = "user";
 export const GITHUB_COPILOT_USER_AGENT_LIBRARY = "electron-fetch";
 
-export const QWEN_CLI_USER_AGENT = "QwenCode/0.15.3 (linux; x64)";
-export const QWEN_STAINLESS_ARCH = "x64";
+export const QWEN_CLI_VERSION = "0.15.4";
 export const QWEN_STAINLESS_LANG = "js";
-export const QWEN_STAINLESS_OS = "Linux";
 export const QWEN_STAINLESS_PACKAGE_VERSION = "5.11.0";
 export const QWEN_STAINLESS_RETRY_COUNT = "1";
 export const QWEN_STAINLESS_RUNTIME = "node";
-export const QWEN_STAINLESS_RUNTIME_VERSION = "v18.19.1";
 export const QWEN_ACCEPT_LANGUAGE = "*";
 export const QWEN_SEC_FETCH_MODE = "cors";
 
 export const QODER_DEFAULT_USER_AGENT = "Qoder-Cli";
-export const QODER_DASHSCOPE_COMPAT_USER_AGENT = "QwenCode/0.15.3 (linux; x64)";
 
 export const KIRO_SDK_USER_AGENT = "AWS-SDK-JS/3.0.0 kiro-ide/1.0.0";
 export const KIRO_AMZ_USER_AGENT = "aws-sdk-js/3.0.0 kiro-ide/1.0.0";
 export const KIRO_STREAMING_TARGET =
   "AmazonCodeWhispererStreamingService.GenerateAssistantResponse";
 
-export const CURSOR_REGISTRY_VERSION = "3.1.0";
+export const CURSOR_REGISTRY_VERSION = "3.2.14";
 
 export function getGitHubCopilotChatHeaders(
   accept = "application/json",
@@ -48,6 +44,32 @@ export function getGitHubCopilotChatHeaders(
     Accept: accept,
     "Content-Type": "application/json",
   };
+}
+
+function normalizeStainlessPlatform(platform: string = process.platform): string {
+  const normalized = platform.toLowerCase();
+  if (normalized.includes("ios")) return "iOS";
+  if (normalized === "android") return "Android";
+  if (normalized === "darwin") return "MacOS";
+  if (normalized === "win32") return "Windows";
+  if (normalized === "freebsd") return "FreeBSD";
+  if (normalized === "openbsd") return "OpenBSD";
+  if (normalized === "linux") return "Linux";
+  return normalized ? `Other:${normalized}` : "Unknown";
+}
+
+function normalizeStainlessArch(arch: string = process.arch): string {
+  if (arch === "x32") return "x32";
+  if (arch === "x86_64" || arch === "x64") return "x64";
+  if (arch === "arm") return "arm";
+  if (arch === "aarch64" || arch === "arm64") return "arm64";
+  return arch ? `other:${arch}` : "unknown";
+}
+
+export function getQwenCliUserAgent(version = QWEN_CLI_VERSION): string {
+  // Qwen Code builds this from the runtime process values. Keep it runtime-derived so
+  // packaged deployments use their own platform/architecture instead of a maintainer's host.
+  return `QwenCode/${version} (${process.platform}; ${process.arch})`;
 }
 
 export function getGitHubCopilotInternalUserHeaders(authorization: string): Record<string, string> {
@@ -72,18 +94,19 @@ export function getGitHubCopilotRefreshHeaders(authorization: string): Record<st
 }
 
 export function getQwenOauthHeaders(): Record<string, string> {
+  const userAgent = getQwenCliUserAgent();
   return {
-    "User-Agent": QWEN_CLI_USER_AGENT,
+    "User-Agent": userAgent,
     "X-Dashscope-AuthType": "qwen-oauth",
     "X-Dashscope-CacheControl": "enable",
-    "X-Dashscope-UserAgent": QWEN_CLI_USER_AGENT,
-    "X-Stainless-Arch": QWEN_STAINLESS_ARCH,
+    "X-Dashscope-UserAgent": userAgent,
+    "X-Stainless-Arch": normalizeStainlessArch(),
     "X-Stainless-Lang": QWEN_STAINLESS_LANG,
-    "X-Stainless-Os": QWEN_STAINLESS_OS,
+    "X-Stainless-Os": normalizeStainlessPlatform(),
     "X-Stainless-Package-Version": QWEN_STAINLESS_PACKAGE_VERSION,
     "X-Stainless-Retry-Count": QWEN_STAINLESS_RETRY_COUNT,
     "X-Stainless-Runtime": QWEN_STAINLESS_RUNTIME,
-    "X-Stainless-Runtime-Version": QWEN_STAINLESS_RUNTIME_VERSION,
+    "X-Stainless-Runtime-Version": process.version,
     Connection: "keep-alive",
     "Accept-Language": QWEN_ACCEPT_LANGUAGE,
     "Sec-Fetch-Mode": QWEN_SEC_FETCH_MODE,
@@ -97,14 +120,15 @@ export function getQoderDefaultHeaders(): Record<string, string> {
 }
 
 export function getQoderDashscopeCompatHeaders(): Record<string, string> {
+  const userAgent = getQwenCliUserAgent();
   return {
     "x-dashscope-authtype": "qwen-oauth",
     "x-dashscope-cachecontrol": "enable",
-    "user-agent": QODER_DASHSCOPE_COMPAT_USER_AGENT,
-    "x-dashscope-useragent": QODER_DASHSCOPE_COMPAT_USER_AGENT,
-    "x-stainless-arch": QWEN_STAINLESS_ARCH,
+    "user-agent": userAgent,
+    "x-dashscope-useragent": userAgent,
+    "x-stainless-arch": normalizeStainlessArch(),
     "x-stainless-lang": QWEN_STAINLESS_LANG,
-    "x-stainless-os": QWEN_STAINLESS_OS,
+    "x-stainless-os": normalizeStainlessPlatform(),
   };
 }
 

--- a/open-sse/executors/antigravity.ts
+++ b/open-sse/executors/antigravity.ts
@@ -1,5 +1,6 @@
 import crypto, { randomUUID } from "crypto";
 import { BaseExecutor, mergeUpstreamExtraHeaders, type ExecuteInput } from "./base.ts";
+import { applyFingerprint, isCliCompatEnabled } from "../config/cliFingerprints.ts";
 import { PROVIDERS, OAUTH_ENDPOINTS, HTTP_STATUS } from "../config/constants.ts";
 import { scrubProxyAndFingerprintHeaders } from "../services/antigravityHeaderScrub.ts";
 import { antigravityUserAgent } from "../services/antigravityHeaders.ts";
@@ -26,6 +27,17 @@ const LONG_RETRY_THRESHOLD_MS = 60_000;
 const CREDITS_EXHAUSTED_TTL_MS = 5 * 60 * 60 * 1000; // 5 hours
 
 const BARE_PRO_IDS = new Set(["gemini-3.1-pro"]);
+
+function serializeAntigravityRequest(
+  provider: string,
+  headers: Record<string, string>,
+  body: unknown
+): { headers: Record<string, string>; bodyString: string } {
+  if (!isCliCompatEnabled(provider)) {
+    return { headers, bodyString: JSON.stringify(body) };
+  }
+  return applyFingerprint(provider, { ...headers }, body);
+}
 
 type AntigravityCollectedStream = {
   textContent: string;
@@ -573,10 +585,13 @@ export class AntigravityExecutor extends BaseExecutor {
       }
 
       try {
+        const serializedRequest = serializeAntigravityRequest(this.provider, headers, transformedBody);
+        const finalHeaders = serializedRequest.headers;
+
         const response = await fetch(url, {
           method: "POST",
-          headers,
-          body: JSON.stringify(transformedBody),
+          headers: finalHeaders,
+          body: serializedRequest.bodyString,
           signal,
         });
 
@@ -626,11 +641,17 @@ export class AntigravityExecutor extends BaseExecutor {
               ) {
                 log?.info?.("AG_CREDITS", "Retrying with Google One AI credits");
                 const creditsBody = injectCreditsField(transformedBody);
+                const serializedCreditsRequest = serializeAntigravityRequest(
+                  this.provider,
+                  headers,
+                  creditsBody
+                );
+                const finalCreditsHeaders = serializedCreditsRequest.headers;
                 try {
                   const creditsResp = await fetch(url, {
                     method: "POST",
-                    headers,
-                    body: JSON.stringify(creditsBody),
+                    headers: finalCreditsHeaders,
+                    body: serializedCreditsRequest.bodyString,
                     signal,
                   });
                   if (creditsResp.ok || creditsResp.status !== HTTP_STATUS.RATE_LIMITED) {
@@ -640,7 +661,7 @@ export class AntigravityExecutor extends BaseExecutor {
                         creditsResp,
                         model,
                         url,
-                        headers,
+                        finalCreditsHeaders,
                         creditsBody,
                         log,
                         signal
@@ -668,7 +689,7 @@ export class AntigravityExecutor extends BaseExecutor {
                     return {
                       response: creditsResp,
                       url,
-                      headers,
+                      headers: finalCreditsHeaders,
                       transformedBody: attachToolNameMap(creditsBody, requestToolNameMap),
                     };
                   }
@@ -769,7 +790,7 @@ export class AntigravityExecutor extends BaseExecutor {
             return {
               response: modifiedResponse,
               url,
-              headers,
+              headers: finalHeaders,
               transformedBody: attachToolNameMap(transformedBody, requestToolNameMap),
             };
           } catch (err) {
@@ -785,7 +806,7 @@ export class AntigravityExecutor extends BaseExecutor {
             response,
             model,
             url,
-            headers,
+            finalHeaders,
             transformedBody,
             log,
             signal
@@ -898,7 +919,7 @@ export class AntigravityExecutor extends BaseExecutor {
           return {
             response: tappedResponse,
             url,
-            headers,
+            headers: finalHeaders,
             transformedBody: attachToolNameMap(transformedBody, requestToolNameMap),
           };
         }
@@ -906,7 +927,7 @@ export class AntigravityExecutor extends BaseExecutor {
         return {
           response,
           url,
-          headers,
+          headers: finalHeaders,
           transformedBody: attachToolNameMap(transformedBody, requestToolNameMap),
         };
       } catch (error) {

--- a/open-sse/executors/base.ts
+++ b/open-sse/executors/base.ts
@@ -466,7 +466,7 @@ export class BaseExecutor {
           remapToolNamesInRequest(tb);
           obfuscateInBody(tb);
 
-          const ccVersion = "2.1.114";
+          const ccVersion = "2.1.121";
           // Fix #1638: Use a stable fingerprint instead of message-derived one.
           // The original computeFingerprint() hashed first-user-message chars, which
           // changes every conversation turn. This mutated the system[] prefix on each

--- a/open-sse/handlers/imageGeneration.ts
+++ b/open-sse/handlers/imageGeneration.ts
@@ -99,6 +99,21 @@ const STABILITY_EDIT_ENDPOINTS = {
 
 const STABILITY_CONTROL_MODELS = new Set(["sketch", "structure", "style", "style-transfer"]);
 
+function appendOptionalFormValue(formData, key, value) {
+  if (value === undefined || value === null || value === "") return;
+  formData.append(key, String(value));
+}
+
+function appendImageFormValue(formData, key, source, filename) {
+  formData.append(
+    key,
+    new Blob([source.buffer], {
+      type: source.contentType || "application/octet-stream",
+    }),
+    filename
+  );
+}
+
 const FAL_PRESET_SIZES = {
   "1024x1024": "square_hd",
   "512x512": "square",
@@ -1054,52 +1069,107 @@ async function handleStabilityAIImageGeneration({
         ? normalizeRequestedImageFormat(body, "png", ["png", "webp"])
         : normalizeRequestedImageFormat(body, "png"),
   };
+  const formData = new FormData();
 
-  if (body.prompt) upstreamBody.prompt = body.prompt;
-  if (body.negative_prompt) upstreamBody.negative_prompt = body.negative_prompt;
-  if (body.seed !== undefined) upstreamBody.seed = body.seed;
+  appendOptionalFormValue(formData, "output_format", upstreamBody.output_format);
+  if (body.prompt) {
+    upstreamBody.prompt = body.prompt;
+    appendOptionalFormValue(formData, "prompt", body.prompt);
+  }
+  if (body.negative_prompt) {
+    upstreamBody.negative_prompt = body.negative_prompt;
+    appendOptionalFormValue(formData, "negative_prompt", body.negative_prompt);
+  }
+  if (body.seed !== undefined) {
+    upstreamBody.seed = body.seed;
+    appendOptionalFormValue(formData, "seed", body.seed);
+  }
 
   try {
     if (STABILITY_GENERATION_ENDPOINTS[model]) {
       if (model.startsWith("sd3.5")) {
         upstreamBody.model = model;
+        appendOptionalFormValue(formData, "model", model);
       }
 
       if (imageUrl) {
+        const imageSource = await resolveImageSource(imageUrl);
         upstreamBody.mode = "image-to-image";
-        upstreamBody.image = (await resolveImageSource(imageUrl)).base64;
-        if (body.strength !== undefined) upstreamBody.strength = body.strength;
+        appendOptionalFormValue(formData, "mode", "image-to-image");
+        upstreamBody.image = imageSource.base64;
+        appendImageFormValue(formData, "image", imageSource, "image");
+        if (body.strength !== undefined) {
+          upstreamBody.strength = body.strength;
+          appendOptionalFormValue(formData, "strength", body.strength);
+        }
       } else {
         upstreamBody.mode = "text-to-image";
+        appendOptionalFormValue(formData, "mode", "text-to-image");
       }
 
       if (!model.startsWith("sd3.5") || !imageUrl) {
-        upstreamBody.aspect_ratio = body.aspect_ratio || mapImageSize(body.size);
+        const aspectRatio = body.aspect_ratio || mapImageSize(body.size);
+        upstreamBody.aspect_ratio = aspectRatio;
+        appendOptionalFormValue(formData, "aspect_ratio", aspectRatio);
       }
 
-      if (body.style_preset) upstreamBody.style_preset = body.style_preset;
+      if (body.style_preset) {
+        upstreamBody.style_preset = body.style_preset;
+        appendOptionalFormValue(formData, "style_preset", body.style_preset);
+      }
     } else {
       if (imageUrl) {
-        upstreamBody.image = (await resolveImageSource(imageUrl)).base64;
+        const imageSource = await resolveImageSource(imageUrl);
+        upstreamBody.image = imageSource.base64;
+        appendImageFormValue(formData, "image", imageSource, "image");
       }
 
       if (maskUrl && shouldIncludeStabilityMask(model)) {
-        upstreamBody.mask = (await resolveImageSource(maskUrl)).base64;
+        const maskSource = await resolveImageSource(maskUrl);
+        upstreamBody.mask = maskSource.base64;
+        appendImageFormValue(formData, "mask", maskSource, "mask");
       }
 
-      if (body.search_prompt) upstreamBody.search_prompt = body.search_prompt;
-      if (body.grow_mask !== undefined) upstreamBody.grow_mask = body.grow_mask;
-      if (body.control_strength !== undefined)
+      if (body.search_prompt) {
+        upstreamBody.search_prompt = body.search_prompt;
+        appendOptionalFormValue(formData, "search_prompt", body.search_prompt);
+      }
+      if (body.grow_mask !== undefined) {
+        upstreamBody.grow_mask = body.grow_mask;
+        appendOptionalFormValue(formData, "grow_mask", body.grow_mask);
+      }
+      if (body.control_strength !== undefined) {
         upstreamBody.control_strength = body.control_strength;
-      if (body.creativity !== undefined) upstreamBody.creativity = body.creativity;
-      if (body.left !== undefined) upstreamBody.left = body.left;
-      if (body.right !== undefined) upstreamBody.right = body.right;
-      if (body.up !== undefined) upstreamBody.up = body.up;
-      if (body.down !== undefined) upstreamBody.down = body.down;
-      if (body.style_preset) upstreamBody.style_preset = body.style_preset;
+        appendOptionalFormValue(formData, "control_strength", body.control_strength);
+      }
+      if (body.creativity !== undefined) {
+        upstreamBody.creativity = body.creativity;
+        appendOptionalFormValue(formData, "creativity", body.creativity);
+      }
+      if (body.left !== undefined) {
+        upstreamBody.left = body.left;
+        appendOptionalFormValue(formData, "left", body.left);
+      }
+      if (body.right !== undefined) {
+        upstreamBody.right = body.right;
+        appendOptionalFormValue(formData, "right", body.right);
+      }
+      if (body.up !== undefined) {
+        upstreamBody.up = body.up;
+        appendOptionalFormValue(formData, "up", body.up);
+      }
+      if (body.down !== undefined) {
+        upstreamBody.down = body.down;
+        appendOptionalFormValue(formData, "down", body.down);
+      }
+      if (body.style_preset) {
+        upstreamBody.style_preset = body.style_preset;
+        appendOptionalFormValue(formData, "style_preset", body.style_preset);
+      }
 
       if (STABILITY_CONTROL_MODELS.has(model) && !upstreamBody.prompt) {
         upstreamBody.prompt = body.prompt || "";
+        appendOptionalFormValue(formData, "prompt", body.prompt || "");
       }
     }
 
@@ -1111,11 +1181,10 @@ async function handleStabilityAIImageGeneration({
     const response = await fetch(`${providerConfig.baseUrl.replace(/\/$/, "")}${endpoint}`, {
       method: "POST",
       headers: {
-        "Content-Type": "application/json",
         Accept: "application/json",
         Authorization: `Bearer ${token}`,
       },
-      body: JSON.stringify(upstreamBody),
+      body: formData,
     });
 
     if (!response.ok) {

--- a/open-sse/utils/cursorVersionDetector.ts
+++ b/open-sse/utils/cursorVersionDetector.ts
@@ -12,7 +12,7 @@ import { createRequire } from "module";
 
 const CACHE_TTL_MS = 60 * 60 * 1000;
 const DB_KEY = "cursorupdate.lastUpdatedAndShown.version";
-const FALLBACK_VERSION = "3.1.15";
+const FALLBACK_VERSION = "3.2.14";
 
 let cachedVersion: string | null = null;
 let cachedAt = 0;

--- a/src/app/(dashboard)/dashboard/agents/page.tsx
+++ b/src/app/(dashboard)/dashboard/agents/page.tsx
@@ -6,7 +6,12 @@ import { Card, Button, Input } from "@/shared/components";
 import ProviderIcon from "@/shared/components/ProviderIcon";
 import { useTranslations } from "next-intl";
 import { AI_PROVIDERS } from "@/shared/constants/providers";
-import { CLI_COMPAT_PROVIDER_IDS } from "@/shared/constants/cliCompatProviders";
+import { CLI_TOOLS } from "@/shared/constants/cliTools";
+import {
+  CLI_COMPAT_PROVIDER_IDS,
+  CLI_COMPAT_TOGGLE_IDS,
+  normalizeCliCompatProviderId,
+} from "@/shared/constants/cliCompatProviders";
 
 interface AgentInfo {
   id: string;
@@ -105,6 +110,14 @@ export default function AgentsPage() {
       console.error("Failed to update setting:", err);
     }
   };
+
+  const normalizedCliCompatProviders = Array.from(
+    new Set(
+      (settings.cliCompatProviders || [])
+        .map((providerId: string) => normalizeCliCompatProviderId(providerId))
+        .filter((providerId: string) => CLI_COMPAT_PROVIDER_IDS.includes(providerId))
+    )
+  );
 
   const handleRefresh = async () => {
     setRefreshing(true);
@@ -307,19 +320,19 @@ export default function AgentsPage() {
         <div className="flex flex-col gap-4">
           <p className="text-sm text-text-muted">{ts("cliFingerprintDesc")}</p>
           <div className="flex flex-wrap gap-2">
-            {CLI_COMPAT_PROVIDER_IDS.map((providerId) => {
-              const providerMeta = Object.values(AI_PROVIDERS).find(
-                (p: any) => p.id === providerId
-              ) as any;
-              const isEnabled = (settings.cliCompatProviders || []).includes(providerId);
-              const displayName = providerMeta?.name || providerId;
+            {CLI_COMPAT_TOGGLE_IDS.map((toggleId) => {
+              const providerId = normalizeCliCompatProviderId(toggleId);
+              const providerMeta = Object.values(AI_PROVIDERS).find((p: any) => p.id === providerId) as any;
+              const toolMeta = CLI_TOOLS[toggleId as keyof typeof CLI_TOOLS] as any;
+              const isEnabled = normalizedCliCompatProviders.includes(providerId);
+              const displayName = toolMeta?.name || providerMeta?.name || toggleId;
               const icon = providerMeta?.icon || "terminal";
               const color = providerMeta?.color || "#888";
               return (
                 <button
-                  key={providerId}
+                  key={toggleId}
                   onClick={() => {
-                    const current: string[] = settings.cliCompatProviders || [];
+                    const current = normalizedCliCompatProviders;
                     const updated = current.includes(providerId)
                       ? current.filter((p) => p !== providerId)
                       : [...current, providerId];
@@ -347,11 +360,11 @@ export default function AgentsPage() {
               );
             })}
           </div>
-          {(settings.cliCompatProviders || []).length > 0 && (
+          {normalizedCliCompatProviders.length > 0 && (
             <p className="text-xs text-emerald-600 dark:text-emerald-400 mt-1 flex items-center gap-1">
               <span className="material-symbols-outlined text-[14px]">verified</span>
               {ts("cliFingerprintEnabled", {
-                count: (settings.cliCompatProviders || []).length,
+                count: normalizedCliCompatProviders.length,
               })}
             </p>
           )}

--- a/src/app/(dashboard)/dashboard/cache/media/MediaPageClient.tsx
+++ b/src/app/(dashboard)/dashboard/cache/media/MediaPageClient.tsx
@@ -281,10 +281,35 @@ function getVoiceList(providerId: string) {
 
 /** Parse a human-readable error from the API error response */
 function parseApiError(raw: any, statusCode: number): { message: string; isCredentials: boolean } {
+  const readErrorMessage = (value: any): string | null => {
+    if (!value) return null;
+    if (typeof value === "string") return value;
+    if (Array.isArray(value)) {
+      const messages = value
+        .map((entry: any) => readErrorMessage(entry))
+        .filter((entry: string | null): entry is string => Boolean(entry));
+      if (messages.length > 0) return messages.join(", ");
+      return null;
+    }
+    if (typeof value.message === "string") return value.message;
+    if (typeof value.detail === "string") return value.detail;
+    if (Array.isArray(value.errors)) {
+      const messages = value.errors
+        .map((entry: any) => readErrorMessage(entry))
+        .filter((entry: string | null): entry is string => Boolean(entry));
+      if (messages.length > 0) return messages.join(", ");
+    }
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return null;
+    }
+  };
+
   const msg =
-    raw?.error?.message ||
+    readErrorMessage(raw?.error) ||
+    readErrorMessage(raw?.errors) ||
     raw?.err_msg ||
-    raw?.error ||
     raw?.message ||
     raw?.detail ||
     (typeof raw === "string" ? raw : null) ||

--- a/src/lib/oauth/constants/oauth.ts
+++ b/src/lib/oauth/constants/oauth.ts
@@ -246,7 +246,7 @@ export const CURSOR_CONFIG = {
   agentEndpoint: "https://agent.api5.cursor.sh", // Privacy mode
   agentNonPrivacyEndpoint: "https://agentn.api5.cursor.sh", // Non-privacy mode
   // Client metadata
-  clientVersion: "3.1.15",
+  clientVersion: "3.2.14",
   clientType: "ide",
   // Token storage locations (for user reference)
   tokenStoragePaths: {

--- a/src/lib/providers/imageValidation.ts
+++ b/src/lib/providers/imageValidation.ts
@@ -1,0 +1,164 @@
+import { getImageProvider } from "@omniroute/open-sse/config/imageRegistry";
+
+import { getProviderOutboundGuard } from "@/shared/network/outboundUrlGuard";
+import {
+  SAFE_OUTBOUND_FETCH_PRESETS,
+  SafeOutboundFetchError,
+  getSafeOutboundFetchErrorStatus,
+  safeOutboundFetch,
+} from "@/shared/network/safeOutboundFetch";
+
+const IMAGE_PROVIDER_VALIDATION_ENDPOINTS: Record<
+  string,
+  { baseUrl?: string; path: string; method?: string }
+> = {
+  nanobanana: {
+    baseUrl: "https://api.nanobananaapi.ai",
+    path: "/api/v1/common/credit",
+  },
+  "fal-ai": {
+    baseUrl: "https://api.fal.ai",
+    path: "/v1/models?limit=1",
+  },
+  "stability-ai": {
+    path: "/v1/user/account",
+  },
+  "black-forest-labs": {
+    path: "/v1/credits",
+  },
+  recraft: {
+    path: "/v1/users/me",
+  },
+  topaz: {
+    path: "/account/v1/credits/balance",
+  },
+};
+
+function normalizeBaseUrl(baseUrl: string) {
+  return (baseUrl || "").trim().replace(/\/$/, "");
+}
+
+function applyCustomUserAgent(headers: Record<string, string>, providerSpecificData: any = {}) {
+  const customUserAgent =
+    typeof providerSpecificData?.customUserAgent === "string"
+      ? providerSpecificData.customUserAgent.trim()
+      : "";
+  if (customUserAgent) {
+    headers["user-agent"] = customUserAgent;
+  }
+  return headers;
+}
+
+function toValidationErrorResult(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error || "Validation failed");
+  const statusCode = getSafeOutboundFetchErrorStatus(error);
+
+  return {
+    valid: false,
+    error: message || "Validation failed",
+    unsupported: false,
+    ...(statusCode ? { statusCode } : {}),
+    ...(error instanceof SafeOutboundFetchError && error.code === "TIMEOUT"
+      ? { timeout: true }
+      : {}),
+    ...(statusCode === 400 ? { securityBlocked: true } : {}),
+  };
+}
+
+function buildImageProviderValidationHeaders(
+  imageProvider: any,
+  apiKey: string,
+  providerSpecificData: any = {}
+) {
+  const headers: Record<string, string> = {
+    Accept: "application/json",
+  };
+
+  if (apiKey) {
+    switch (String(imageProvider?.authHeader || "").toLowerCase()) {
+      case "bearer":
+        headers.Authorization = `Bearer ${apiKey}`;
+        break;
+      case "key":
+        headers.Authorization = `Key ${apiKey}`;
+        break;
+      case "x-key":
+        headers["x-key"] = apiKey;
+        break;
+      case "x-api-key":
+        headers["X-API-Key"] = apiKey;
+        break;
+      case "none":
+        break;
+      default:
+        headers.Authorization = `Bearer ${apiKey}`;
+        break;
+    }
+  }
+
+  return applyCustomUserAgent(headers, providerSpecificData);
+}
+
+async function validationRead(url: string, init: RequestInit) {
+  return safeOutboundFetch(url, {
+    ...SAFE_OUTBOUND_FETCH_PRESETS.validationRead,
+    guard: getProviderOutboundGuard(),
+    ...init,
+  });
+}
+
+export async function validateImageProviderApiKey({
+  provider,
+  apiKey,
+  providerSpecificData = {},
+}: any) {
+  const imageProvider = getImageProvider(provider);
+  const validationConfig = IMAGE_PROVIDER_VALIDATION_ENDPOINTS[provider];
+
+  if (!imageProvider || !validationConfig) {
+    return { valid: false, error: "Provider validation not supported", unsupported: true };
+  }
+
+  try {
+    const baseUrl = normalizeBaseUrl(
+      providerSpecificData?.baseUrl || validationConfig.baseUrl || imageProvider.baseUrl
+    );
+    const url = `${baseUrl}${validationConfig.path}`;
+    const response = await validationRead(url, {
+      method: validationConfig.method || "GET",
+      headers: buildImageProviderValidationHeaders(imageProvider, apiKey, providerSpecificData),
+    });
+
+    if (response.ok) {
+      return { valid: true, error: null, method: "image-provider" };
+    }
+
+    if (response.status === 401 || response.status === 403) {
+      return { valid: false, error: "Invalid API key", method: "image-provider" };
+    }
+
+    if (response.status === 429) {
+      return {
+        valid: false,
+        error: "Validation rate limited (429)",
+        method: "image-provider",
+      };
+    }
+
+    if (response.status >= 500) {
+      return {
+        valid: false,
+        error: `Provider unavailable (${response.status})`,
+        method: "image-provider",
+      };
+    }
+
+    return {
+      valid: false,
+      error: `Validation failed: ${response.status}`,
+      method: "image-provider",
+    };
+  } catch (error: any) {
+    return toValidationErrorResult(error);
+  }
+}

--- a/src/lib/providers/validation.ts
+++ b/src/lib/providers/validation.ts
@@ -68,6 +68,7 @@ import {
 } from "@omniroute/open-sse/config/runway.ts";
 import { PETALS_DEFAULT_MODEL, normalizePetalsBaseUrl } from "@omniroute/open-sse/config/petals.ts";
 import { signAwsRequest } from "@omniroute/open-sse/utils/awsSigV4.ts";
+import { validateImageProviderApiKey } from "@/lib/providers/imageValidation";
 
 const OPENAI_LIKE_FORMATS = new Set(["openai", "openai-responses"]);
 const GEMINI_LIKE_FORMATS = new Set(["gemini", "gemini-cli"]);
@@ -672,34 +673,7 @@ async function validateAssemblyAIProvider({ apiKey, providerSpecificData = {} }:
 }
 
 async function validateNanoBananaProvider({ apiKey, providerSpecificData = {} }: any) {
-  try {
-    // NanoBanana doesn't expose a lightweight validation endpoint,
-    // so we send a minimal generate request that will succeed or fail on auth.
-    const response = await validationWrite(
-      "https://api.nanobananaapi.ai/api/v1/nanobanana/generate",
-      {
-        method: "POST",
-        headers: applyCustomUserAgent(
-          {
-            Authorization: `Bearer ${apiKey}`,
-            "Content-Type": "application/json",
-          },
-          providerSpecificData
-        ),
-        body: JSON.stringify({
-          prompt: "test",
-          model: "nanobanana-flash",
-        }),
-      }
-    );
-    // Auth errors → 401/403; anything else (even 400 bad request) means auth passed
-    if (response.status === 401 || response.status === 403) {
-      return { valid: false, error: "Invalid API key" };
-    }
-    return { valid: true, error: null };
-  } catch (error: any) {
-    return toValidationErrorResult(error);
-  }
+  return validateImageProviderApiKey({ provider: "nanobanana", apiKey, providerSpecificData });
 }
 
 async function validateElevenLabsProvider({ apiKey, providerSpecificData = {} }: any) {
@@ -2722,6 +2696,16 @@ export async function validateProviderApiKey({ provider, apiKey, providerSpecifi
     deepgram: validateDeepgramProvider,
     assemblyai: validateAssemblyAIProvider,
     nanobanana: validateNanoBananaProvider,
+    "fal-ai": ({ apiKey, providerSpecificData }: any) =>
+      validateImageProviderApiKey({ provider: "fal-ai", apiKey, providerSpecificData }),
+    "stability-ai": ({ apiKey, providerSpecificData }: any) =>
+      validateImageProviderApiKey({ provider: "stability-ai", apiKey, providerSpecificData }),
+    "black-forest-labs": ({ apiKey, providerSpecificData }: any) =>
+      validateImageProviderApiKey({ provider: "black-forest-labs", apiKey, providerSpecificData }),
+    recraft: ({ apiKey, providerSpecificData }: any) =>
+      validateImageProviderApiKey({ provider: "recraft", apiKey, providerSpecificData }),
+    topaz: ({ apiKey, providerSpecificData }: any) =>
+      validateImageProviderApiKey({ provider: "topaz", apiKey, providerSpecificData }),
     elevenlabs: validateElevenLabsProvider,
     inworld: validateInworldProvider,
     "aws-polly": validateAwsPollyProvider,

--- a/src/shared/constants/cliCompatProviders.ts
+++ b/src/shared/constants/cliCompatProviders.ts
@@ -1,4 +1,53 @@
 import { CLI_TOOLS } from "./cliTools";
+import { normalizeCliCompatProviderId } from "../utils/cliCompat";
+
+export { normalizeCliCompatProviderId };
+
+export const IMPLEMENTED_CLI_FINGERPRINT_PROVIDER_IDS = [
+  "claude",
+  "codex",
+  "github",
+  "antigravity",
+  "qwen",
+] as const;
+
+export const CLI_COMPAT_DISPLAY_PROVIDER_IDS = [
+  "claude",
+  "codex",
+  "copilot",
+  "antigravity",
+  "qwen",
+] as const;
+
+/**
+ * Known CLI/tool providers that are intentionally not exposed as CLI Fingerprint toggles yet.
+ *
+ * This setting controls the generic `applyFingerprint()` pipeline (header/body ordering plus
+ * optional CLI User-Agent overrides). Do not expose providers here just because they have a
+ * CLI Tools card or a provider integration:
+ *
+ * - Kiro and Cursor already apply their native parity inside custom executors, so a toggle would
+ *   be misleading unless it controls additional behavior.
+ * - Droid, OpenClaw, Windsurf and Hermes are CLI tool setup guides/settings, not upstream provider
+ *   fingerprints handled by OmniRoute.
+ * - Cline, Kilo Code, OpenCode and Kimi Coding have real provider/backend integrations, but no
+ *   captured `CLI_FINGERPRINTS` entry is wired to `applyFingerprint()` yet.
+ *
+ * Keep this list as documentation for intentionally omitted candidates. When adding a provider to
+ * the visible toggle list, also add a real `CLI_FINGERPRINTS` entry or wire its custom executor.
+ */
+export const CLI_COMPAT_OMITTED_PROVIDER_IDS = [
+  "kiro",
+  "cursor",
+  "droid",
+  "openclaw",
+  "windsurf",
+  "hermes",
+  "cline",
+  "kilocode",
+  "opencode",
+  "kimi-coding",
+] as const;
 
 /**
  * Provider IDs toggled in Settings -> CLI Fingerprint.
@@ -13,17 +62,12 @@ const TOOL_ID_TO_PROVIDER_ID: Record<string, string> = {
 };
 
 const DERIVED_PROVIDER_IDS = Object.values(CLI_TOOLS)
-  .map((tool: any) => TOOL_ID_TO_PROVIDER_ID[tool.id] ?? tool.id)
+  .map((tool: any) => normalizeCliCompatProviderId(TOOL_ID_TO_PROVIDER_ID[tool.id] ?? tool.id))
   // "continue" currently has no provider id in AI_PROVIDERS
-  .filter((providerId) => providerId !== "continue" && providerId !== "amp");
-
-const LEGACY_PROVIDER_IDS = [
-  // Keep to avoid breaking setups that saved old IDs
-  "copilot",
-  "kimi-coding",
-  "qwen",
-];
+  .filter((providerId) => IMPLEMENTED_CLI_FINGERPRINT_PROVIDER_IDS.includes(providerId as any));
 
 export const CLI_COMPAT_PROVIDER_IDS = Array.from(
-  new Set([...DERIVED_PROVIDER_IDS, ...LEGACY_PROVIDER_IDS])
+  new Set([...DERIVED_PROVIDER_IDS, ...IMPLEMENTED_CLI_FINGERPRINT_PROVIDER_IDS])
 );
+
+export const CLI_COMPAT_TOGGLE_IDS = Array.from(new Set(CLI_COMPAT_DISPLAY_PROVIDER_IDS));

--- a/src/shared/utils/cliCompat.ts
+++ b/src/shared/utils/cliCompat.ts
@@ -1,0 +1,3 @@
+export function normalizeCliCompatProviderId(providerId: string): string {
+  return providerId.toLowerCase() === "copilot" ? "github" : providerId.toLowerCase();
+}

--- a/src/shared/utils/upstreamError.ts
+++ b/src/shared/utils/upstreamError.ts
@@ -23,7 +23,31 @@ export function toJsonErrorPayload(rawError, fallbackMessage = "Upstream provide
       };
     }
     if (errorObj && typeof errorObj === "object") {
+      const nestedMessage = extractErrorMessage(errorObj);
+      if (!("message" in errorObj) && nestedMessage) {
+        return {
+          error: {
+            ...errorObj,
+            message: nestedMessage,
+            type: errorObj.type || "upstream_error",
+            code: errorObj.code || "upstream_error",
+          },
+        };
+      }
       return rawError;
+    }
+    if (!("message" in rawError)) {
+      const message = extractErrorMessage(rawError);
+      if (message) {
+        return {
+          error: {
+            message,
+            type: rawError.type || "upstream_error",
+            code: rawError.code || "upstream_error",
+            details: rawError,
+          },
+        };
+      }
     }
     return { error: rawError };
   }
@@ -49,4 +73,35 @@ export function toJsonErrorPayload(rawError, fallbackMessage = "Upstream provide
   }
 
   return fallback;
+}
+
+function extractErrorMessage(value) {
+  if (!value || typeof value !== "object") return null;
+
+  if (typeof value.message === "string" && value.message.trim()) {
+    return value.message.trim();
+  }
+
+  if (typeof value.detail === "string" && value.detail.trim()) {
+    return value.detail.trim();
+  }
+
+  if (Array.isArray(value.errors)) {
+    const messages = value.errors
+      .map((entry) => {
+        if (typeof entry === "string") return entry.trim();
+        if (entry && typeof entry === "object") {
+          return extractErrorMessage(entry) || JSON.stringify(entry);
+        }
+        return "";
+      })
+      .filter(Boolean);
+    if (messages.length > 0) return messages.join(", ");
+  }
+
+  if (typeof value.name === "string" && value.name.trim()) {
+    return value.name.trim();
+  }
+
+  return null;
 }

--- a/tests/unit/anthropic-cache-fingerprint.test.ts
+++ b/tests/unit/anthropic-cache-fingerprint.test.ts
@@ -24,7 +24,7 @@ function computeOldFingerprint(firstUserMessageText: string, version: string): s
 }
 
 describe("Anthropic billing header fingerprint (#1638)", () => {
-  const ccVersion = "2.1.114";
+  const ccVersion = "2.1.121";
 
   it("should produce the same fingerprint for different messages (stable)", () => {
     const fp1 = computeStableFingerprint(ccVersion);

--- a/tests/unit/cli-tools.test.ts
+++ b/tests/unit/cli-tools.test.ts
@@ -2,9 +2,18 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 const { CLI_TOOLS } = await import("../../src/shared/constants/cliTools.ts");
-const { CLI_COMPAT_PROVIDER_IDS } =
+const {
+  CLI_COMPAT_PROVIDER_IDS,
+  CLI_COMPAT_OMITTED_PROVIDER_IDS,
+  CLI_COMPAT_TOGGLE_IDS,
+  IMPLEMENTED_CLI_FINGERPRINT_PROVIDER_IDS,
+  normalizeCliCompatProviderId,
+} =
   await import("../../src/shared/constants/cliCompatProviders.ts");
 const { CLI_TOOL_IDS } = await import("../../src/shared/services/cliRuntime.ts");
+const { applyFingerprint, isCliCompatEnabled, setCliCompatProviders } = await import(
+  "../../open-sse/config/cliFingerprints.ts"
+);
 
 test("Amp CLI is registered as a guide-based CLI tool with shorthand mapping guidance", () => {
   const amp = CLI_TOOLS.amp;
@@ -36,4 +45,72 @@ test("Hermes quick-config is registered as a guide-based CLI tool", () => {
   assert.ok(Array.isArray(hermes.guideSteps));
   assert.ok(String(hermes.codeBlock?.code || "").includes('"baseURL": "{{baseUrl}}"'));
   assert.ok(CLI_TOOL_IDS.includes("hermes"));
+});
+
+test("CLI fingerprint toggles only expose implemented fingerprints and functional legacy aliases", () => {
+  const implemented = new Set<string>(IMPLEMENTED_CLI_FINGERPRINT_PROVIDER_IDS);
+
+  for (const providerId of CLI_COMPAT_PROVIDER_IDS) {
+    assert.equal(
+      implemented.has(providerId),
+      true,
+      `${providerId} should have an implemented fingerprint`
+    );
+  }
+
+  for (const toggleId of CLI_COMPAT_TOGGLE_IDS) {
+    const providerId = normalizeCliCompatProviderId(toggleId);
+    assert.equal(
+      implemented.has(providerId),
+      true,
+      `${toggleId} should map to an implemented fingerprint provider`
+    );
+  }
+
+  for (const providerId of IMPLEMENTED_CLI_FINGERPRINT_PROVIDER_IDS) {
+    assert.equal(CLI_COMPAT_PROVIDER_IDS.includes(providerId), true);
+  }
+
+  for (const providerId of CLI_COMPAT_OMITTED_PROVIDER_IDS) {
+    assert.equal(CLI_COMPAT_PROVIDER_IDS.includes(providerId), false);
+    assert.equal((CLI_COMPAT_TOGGLE_IDS as readonly string[]).includes(providerId), false);
+  }
+
+  assert.equal(CLI_COMPAT_TOGGLE_IDS.includes("copilot"), true);
+  assert.equal((CLI_COMPAT_TOGGLE_IDS as readonly string[]).includes("github"), false);
+});
+
+test("CLI fingerprint preserves Codex executor User-Agent and maps legacy Copilot alias", () => {
+  const codex = applyFingerprint(
+    "codex",
+    {
+      Authorization: "Bearer token",
+      "User-Agent": "codex-cli/0.125.0 (Windows 10.0.26100; x64)",
+    },
+    { model: "gpt-5.5", messages: [], stream: true }
+  );
+
+  assert.equal(codex.headers["User-Agent"], "codex-cli/0.125.0 (Windows 10.0.26100; x64)");
+  assert.deepEqual(Object.keys(JSON.parse(codex.bodyString)), ["model", "messages", "stream"]);
+
+  const copilot = applyFingerprint(
+    "copilot",
+    { Authorization: "Bearer token", Accept: "application/json" },
+    { model: "gpt-4o", messages: [] }
+  );
+
+  assert.equal(copilot.headers["User-Agent"], "GitHubCopilotChat/0.45.1");
+});
+
+test("CLI fingerprint keeps legacy Copilot settings functional without exposing duplicate UI toggles", () => {
+  assert.equal(normalizeCliCompatProviderId("copilot"), "github");
+  assert.equal(normalizeCliCompatProviderId("GitHub"), "github");
+
+  try {
+    setCliCompatProviders(["copilot"]);
+    assert.equal(isCliCompatEnabled("github"), true);
+    assert.equal(isCliCompatEnabled("copilot"), true);
+  } finally {
+    setCliCompatProviders([]);
+  }
 });

--- a/tests/unit/config-hot-reload.test.ts
+++ b/tests/unit/config-hot-reload.test.ts
@@ -73,7 +73,7 @@ test("updateSettings applies runtime settings incrementally without restart", as
   });
 
   await settingsDb.updateSettings({
-    cliCompatProviders: ["OpenAI", "claude"],
+    cliCompatProviders: ["OpenAI", "claude", "copilot"],
     modelAliases: JSON.stringify({ "team-default": "openai/gpt-4o-mini" }),
     backgroundDegradation: {
       enabled: true,
@@ -92,7 +92,7 @@ test("updateSettings applies runtime settings incrementally without restart", as
     antigravitySignatureCacheMode: "bypass",
   });
 
-  assert.deepEqual(getCliCompatProviders().sort(), ["claude", "openai"]);
+  assert.deepEqual(getCliCompatProviders().sort(), ["claude", "github"]);
   assert.deepEqual(getCustomAliases(), { "team-default": "openai/gpt-4o-mini" });
   assert.equal(getBackgroundDegradationConfig().enabled, true);
   assert.equal(getBackgroundDegradationConfig().degradationMap["gpt-4o"], "gpt-4o-mini");
@@ -136,7 +136,7 @@ test("hot-reload watcher picks up external sqlite changes via polling fallback",
   await waitFor(
     () =>
       getCliCompatProviders().includes("github") &&
-      getCliCompatProviders().includes("openai") &&
+      !getCliCompatProviders().includes("openai") &&
       getGeminiThoughtSignatureMode() === "bypass-strict"
   );
 });

--- a/tests/unit/cursor-version-detector.test.mjs
+++ b/tests/unit/cursor-version-detector.test.mjs
@@ -4,7 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-const FALLBACK_VERSION = "3.1.15";
+const FALLBACK_VERSION = "3.2.14";
 const Database = (await import("better-sqlite3")).default;
 
 const { getCursorVersion, resetCursorVersionCache } =

--- a/tests/unit/display-and-error-utils.test.ts
+++ b/tests/unit/display-and-error-utils.test.ts
@@ -37,6 +37,55 @@ test("toJsonErrorPayload: wraps plain objects under error key", () => {
   });
 });
 
+test("toJsonErrorPayload: extracts provider errors arrays into message strings", () => {
+  assert.deepEqual(
+    toJsonErrorPayload({
+      errors: ["content-type must be multipart/form-data"],
+      name: "bad request",
+    }),
+    {
+      error: {
+        message: "content-type must be multipart/form-data",
+        type: "upstream_error",
+        code: "upstream_error",
+        details: {
+          errors: ["content-type must be multipart/form-data"],
+          name: "bad request",
+        },
+      },
+    }
+  );
+});
+
+test("toJsonErrorPayload: normalizes object entries in provider errors arrays", () => {
+  assert.deepEqual(
+    toJsonErrorPayload({
+      errors: [
+        { message: "first provider error" },
+        { detail: "second provider error" },
+        { code: "invalid_request", field: "prompt" },
+      ],
+      name: "bad request",
+    }),
+    {
+      error: {
+        message:
+          'first provider error, second provider error, {"code":"invalid_request","field":"prompt"}',
+        type: "upstream_error",
+        code: "upstream_error",
+        details: {
+          errors: [
+            { message: "first provider error" },
+            { detail: "second provider error" },
+            { code: "invalid_request", field: "prompt" },
+          ],
+          name: "bad request",
+        },
+      },
+    }
+  );
+});
+
 test("toJsonErrorPayload: parses JSON strings recursively", () => {
   const raw = JSON.stringify({ error: { message: "nested json", code: "bad_request" } });
   assert.deepEqual(toJsonErrorPayload(raw), {

--- a/tests/unit/executor-antigravity.test.ts
+++ b/tests/unit/executor-antigravity.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { AntigravityExecutor } from "../../open-sse/executors/antigravity.ts";
+import { setCliCompatProviders } from "../../open-sse/config/cliFingerprints.ts";
 import {
   clearAntigravityVersionCache,
   seedAntigravityVersionCache,
@@ -367,17 +368,17 @@ test("AntigravityExecutor.execute auto-retries short 429 responses and collects 
       }
     );
   };
-  globalThis.setTimeout = (callback) => {
+  globalThis.setTimeout = ((callback) => {
     callback();
     return 0;
-  };
+  }) as typeof setTimeout;
 
   try {
     const result = await executor.execute({
       model: "antigravity/gemini-2.5-flash",
       body: { request: { contents: [] } },
       stream: false,
-      credentials: { accessToken: "token", projectId: "project-1" },
+      credentials: { accessToken: "token", projectId: "project-1" } as any,
       log: { debug() {}, warn() {} },
     });
     const payload = (await result.response.json()) as any;
@@ -419,7 +420,7 @@ test("AntigravityExecutor.execute embeds retryAfterMs when the upstream asks for
       model: "antigravity/gemini-2.5-flash",
       body: { request: { contents: [] } },
       stream: true,
-      credentials: { accessToken: "token", projectId: "project-1" },
+      credentials: { accessToken: "token", projectId: "project-1" } as any,
       log: { debug() {}, warn() {} },
     });
     const payload = (await result.response.json()) as any;
@@ -427,6 +428,51 @@ test("AntigravityExecutor.execute embeds retryAfterMs when the upstream asks for
     assert.equal(result.response.status, 429);
     assert.equal(payload.retryAfterMs, 7_200_000);
   } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("AntigravityExecutor.execute applies CLI fingerprint when enabled", async () => {
+  const executor = new AntigravityExecutor();
+  const originalFetch = globalThis.fetch;
+  seedAntigravityVersionCache("2026.04.17-test");
+  setCliCompatProviders(["antigravity"]);
+
+  globalThis.fetch = async (_url, init) => {
+    const headers = init?.headers as Record<string, string>;
+    const parsedBody = JSON.parse(String(init?.body));
+
+    assert.equal(headers["User-Agent"], "antigravity/2026.04.17-test darwin/arm64");
+    assert.deepEqual(Object.keys(parsedBody), [
+      "project",
+      "model",
+      "userAgent",
+      "requestType",
+      "requestId",
+      "enabledCreditTypes",
+      "request",
+    ]);
+
+    return new Response('data: {"response":{"candidates":[{"content":{"parts":[{"text":"OK"}]},"finishReason":"STOP"}]}}\n\n', {
+      status: 200,
+      headers: { "Content-Type": "text/event-stream" },
+    });
+  };
+
+  try {
+    const result = await withEnv("ANTIGRAVITY_CREDITS", "always", () =>
+      executor.execute({
+        model: "antigravity/gemini-2.5-flash",
+        body: { request: { contents: [] } },
+        stream: false,
+        credentials: { accessToken: "token", projectId: "project-1" } as any,
+        log: { debug() {}, warn() {}, info() {} },
+      })
+    );
+
+    assert.equal(result.response.status, 200);
+  } finally {
+    setCliCompatProviders([]);
     globalThis.fetch = originalFetch;
   }
 });

--- a/tests/unit/image-generation-handler.test.ts
+++ b/tests/unit/image-generation-handler.test.ts
@@ -354,7 +354,7 @@ test("handleImageGeneration routes Stability AI edit models to native endpoints"
       requestCapture = {
         url: stringUrl,
         headers: options.headers,
-        body: JSON.parse(String(options.body || "{}")),
+        body: options.body,
       };
 
       return new Response(JSON.stringify({ image: "c3RhYmlsaXR5LWltYWdl" }), {
@@ -383,10 +383,65 @@ test("handleImageGeneration routes Stability AI edit models to native endpoints"
     assert.equal(result.success, true);
     assert.equal(requestCapture.url, "https://api.stability.ai/v2beta/stable-image/edit/inpaint");
     assert.equal(requestCapture.headers.Authorization, "Bearer stability-key");
-    assert.equal(requestCapture.body.image, "BAU=");
-    assert.equal(requestCapture.body.mask, "AA==");
-    assert.equal(requestCapture.body.output_format, "png");
+    assert.equal(requestCapture.headers.Accept, "application/json");
+    assert.equal(requestCapture.headers["Content-Type"], undefined);
+    assert.ok(requestCapture.body instanceof FormData);
+    assert.equal(requestCapture.body.get("prompt"), "replace the sky with aurora");
+    assert.equal(requestCapture.body.get("negative_prompt"), "rain");
+    assert.equal(requestCapture.body.get("output_format"), "png");
+    assert.equal((requestCapture.body.get("image") as Blob).size, 2);
+    assert.equal((requestCapture.body.get("mask") as Blob).size, 1);
     assert.equal(result.data.data[0].b64_json, "c3RhYmlsaXR5LWltYWdl");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("handleImageGeneration sends Stability AI text generation as multipart form data", async () => {
+  const originalFetch = globalThis.fetch;
+  let requestCapture;
+
+  globalThis.fetch = async (url, options = {}) => {
+    const stringUrl = String(url);
+    if (stringUrl === "https://api.stability.ai/v2beta/stable-image/generate/core") {
+      requestCapture = {
+        url: stringUrl,
+        headers: options.headers,
+        body: options.body,
+      };
+
+      return new Response(JSON.stringify({ image: "c3RhYmlsaXR5LWNvcmU=" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+
+    throw new Error(`Unexpected URL: ${stringUrl}`);
+  };
+
+  try {
+    const result = await handleImageGeneration({
+      body: {
+        model: "stability-ai/stable-image-core",
+        prompt: "city near beach",
+        size: "1024x1024",
+        response_format: "b64_json",
+      },
+      credentials: { apiKey: "stability-key" },
+      log: null,
+    });
+
+    assert.equal(result.success, true);
+    assert.equal(requestCapture.url, "https://api.stability.ai/v2beta/stable-image/generate/core");
+    assert.equal(requestCapture.headers.Authorization, "Bearer stability-key");
+    assert.equal(requestCapture.headers.Accept, "application/json");
+    assert.equal(requestCapture.headers["Content-Type"], undefined);
+    assert.ok(requestCapture.body instanceof FormData);
+    assert.equal(requestCapture.body.get("prompt"), "city near beach");
+    assert.equal(requestCapture.body.get("mode"), "text-to-image");
+    assert.equal(requestCapture.body.get("aspect_ratio"), "1:1");
+    assert.equal(requestCapture.body.get("output_format"), "png");
+    assert.equal(result.data.data[0].b64_json, "c3RhYmlsaXR5LWNvcmU=");
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/tests/unit/provider-header-profiles.test.ts
+++ b/tests/unit/provider-header-profiles.test.ts
@@ -11,9 +11,9 @@ import {
   GITHUB_COPILOT_REFRESH_USER_AGENT,
   KIRO_AMZ_USER_AGENT,
   KIRO_SDK_USER_AGENT,
-  QODER_DASHSCOPE_COMPAT_USER_AGENT,
-  QWEN_CLI_USER_AGENT,
+  QWEN_CLI_VERSION,
   getCursorUsageHeaders,
+  getQwenCliUserAgent,
   getGitHubCopilotChatHeaders,
   getGitHubCopilotInternalUserHeaders,
   getGitHubCopilotRefreshHeaders,
@@ -47,13 +47,16 @@ test("provider header profiles expose dedicated refresh, qwen, qoder, kiro and c
   assert.equal(refreshHeaders["Editor-Plugin-Version"], GITHUB_COPILOT_REFRESH_PLUGIN_VERSION);
 
   const qwenHeaders = getQwenOauthHeaders();
-  assert.equal(qwenHeaders["User-Agent"], QWEN_CLI_USER_AGENT);
-  assert.equal(qwenHeaders["X-Dashscope-UserAgent"], QWEN_CLI_USER_AGENT);
+  assert.equal(qwenHeaders["User-Agent"], getQwenCliUserAgent());
+  assert.equal(qwenHeaders["User-Agent"], `QwenCode/${QWEN_CLI_VERSION} (${process.platform}; ${process.arch})`);
+  assert.notEqual(qwenHeaders["User-Agent"], "QwenCode/0.15.3 (linux; x64)");
+  assert.equal(qwenHeaders["X-Dashscope-UserAgent"], getQwenCliUserAgent());
   assert.equal(qwenHeaders["X-Stainless-Package-Version"], "5.11.0");
+  assert.equal(qwenHeaders["X-Stainless-Runtime-Version"], process.version);
 
   const qoderHeaders = getQoderDashscopeCompatHeaders();
-  assert.equal(qoderHeaders["user-agent"], QODER_DASHSCOPE_COMPAT_USER_AGENT);
-  assert.equal(qoderHeaders["x-dashscope-useragent"], QODER_DASHSCOPE_COMPAT_USER_AGENT);
+  assert.equal(qoderHeaders["user-agent"], getQwenCliUserAgent());
+  assert.equal(qoderHeaders["x-dashscope-useragent"], getQwenCliUserAgent());
 
   const kiroHeaders = getKiroServiceHeaders("application/json");
   assert.equal(kiroHeaders.Accept, "application/json");

--- a/tests/unit/provider-header-profiles.test.ts
+++ b/tests/unit/provider-header-profiles.test.ts
@@ -69,3 +69,24 @@ test("provider header profiles expose dedicated refresh, qwen, qoder, kiro and c
   assert.equal(cursorHeaders["x-cursor-user-agent"], `Cursor/${CURSOR_REGISTRY_VERSION}`);
   assert.equal(cursorHeaders["x-cursor-client-version"], CURSOR_REGISTRY_VERSION);
 });
+
+test("provider header profiles tolerate browser-like process shims", async () => {
+  const originalPlatform = process.platform;
+  const originalArch = process.arch;
+  const originalVersion = process.version;
+
+  Object.defineProperty(process, "platform", { value: undefined, configurable: true });
+  Object.defineProperty(process, "arch", { value: undefined, configurable: true });
+  Object.defineProperty(process, "version", { value: undefined, configurable: true });
+
+  try {
+    assert.equal(getQwenCliUserAgent(), `QwenCode/${QWEN_CLI_VERSION} (unknown; unknown)`);
+    const qwenHeaders = getQwenOauthHeaders();
+    assert.equal(qwenHeaders["User-Agent"], `QwenCode/${QWEN_CLI_VERSION} (unknown; unknown)`);
+    assert.equal(qwenHeaders["X-Stainless-Runtime-Version"], "unknown");
+  } finally {
+    Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+    Object.defineProperty(process, "arch", { value: originalArch, configurable: true });
+    Object.defineProperty(process, "version", { value: originalVersion, configurable: true });
+  }
+});

--- a/tests/unit/provider-validation-image-only.test.ts
+++ b/tests/unit/provider-validation-image-only.test.ts
@@ -1,0 +1,147 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { validateProviderApiKey } = await import("../../src/lib/providers/validation.ts");
+
+const originalFetch = globalThis.fetch;
+
+test.afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+const imageOnlyProviders = {
+  "fal-ai": {
+    url: "https://api.fal.ai/v1/models?limit=1",
+    header: "Authorization",
+    value: "Key fal-ai-key",
+  },
+  "stability-ai": {
+    url: "https://api.stability.ai/v1/user/account",
+    header: "Authorization",
+    value: "Bearer stability-ai-key",
+  },
+  "black-forest-labs": {
+    url: "https://api.bfl.ai/v1/credits",
+    header: "x-key",
+    value: "black-forest-labs-key",
+  },
+  recraft: {
+    url: "https://external.api.recraft.ai/v1/users/me",
+    header: "Authorization",
+    value: "Bearer recraft-key",
+  },
+  topaz: {
+    url: "https://api.topazlabs.com/account/v1/credits/balance",
+    header: "X-API-Key",
+    value: "topaz-key",
+  },
+};
+
+const expectedValidationError = (status: number) =>
+  status === 429 ? "Validation rate limited (429)" : `Validation failed: ${status}`;
+
+for (const [provider, config] of Object.entries(imageOnlyProviders)) {
+  test(`${provider} API key validator returns valid on 200`, async () => {
+    let fetchCalled = false;
+    globalThis.fetch = async (url, init = {}) => {
+      fetchCalled = true;
+      assert.equal(String(url), config.url);
+      assert.equal((init.headers as Record<string, string>)[config.header], config.value);
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    };
+
+    const result = await validateProviderApiKey({ provider, apiKey: `${provider}-key` });
+
+    assert.equal(result.valid, true, `${provider} should validate a 200 response`);
+    assert.equal(result.error, null, `${provider} should not return an error for 200`);
+    assert.equal(fetchCalled, true, `${provider} should call its validation endpoint`);
+  });
+}
+
+for (const provider of Object.keys(imageOnlyProviders)) {
+  for (const status of [401, 403]) {
+    test(`${provider} API key validator returns invalid on ${status}`, async () => {
+      let fetchCalled = false;
+      globalThis.fetch = async () => {
+        fetchCalled = true;
+        return new Response(JSON.stringify({ error: "unauthorized" }), { status });
+      };
+
+      const result = await validateProviderApiKey({ provider, apiKey: `${provider}-key` });
+
+      assert.equal(result.valid, false, `${provider} should reject ${status}`);
+      assert.equal(result.error, "Invalid API key", `${provider} should surface auth failure`);
+      assert.equal(fetchCalled, true, `${provider} should call its validation endpoint`);
+    });
+  }
+
+  for (const status of [400, 404, 429]) {
+    test(`${provider} API key validator returns validation failed on ${status}`, async () => {
+      let fetchCalled = false;
+      globalThis.fetch = async () => {
+        fetchCalled = true;
+        return new Response(JSON.stringify({ error: "validation failed" }), { status });
+      };
+
+      const result = await validateProviderApiKey({ provider, apiKey: `${provider}-key` });
+
+      assert.equal(result.valid, false, `${provider} should reject ${status}`);
+      assert.equal(
+        result.error,
+        expectedValidationError(status),
+        `${provider} should surface validation failure`
+      );
+      assert.equal(fetchCalled, true, `${provider} should call its validation endpoint`);
+    });
+  }
+}
+
+test("NanoBanana API key validator returns valid on 200", async () => {
+  let fetchCalled = false;
+  globalThis.fetch = async (url, init = {}) => {
+    fetchCalled = true;
+    assert.match(String(url), /nanobanana/i);
+    assert.equal((init.headers as Record<string, string>).Authorization, "Bearer nb-key");
+    return new Response(JSON.stringify({ taskId: "task-1" }), { status: 200 });
+  };
+
+  const result = await validateProviderApiKey({ provider: "nanobanana", apiKey: "nb-key" });
+
+  assert.equal(result.valid, true);
+  assert.equal(result.error, null);
+  assert.equal(fetchCalled, true);
+});
+
+for (const status of [401, 403]) {
+  test(`NanoBanana API key validator returns invalid on ${status}`, async () => {
+    let fetchCalled = false;
+    globalThis.fetch = async (url) => {
+      fetchCalled = true;
+      assert.match(String(url), /nanobanana/i);
+      return new Response(JSON.stringify({ error: "unauthorized" }), { status });
+    };
+
+    const result = await validateProviderApiKey({ provider: "nanobanana", apiKey: "nb-key" });
+
+    assert.equal(result.valid, false, `NanoBanana should reject ${status}`);
+    assert.equal(result.error, "Invalid API key");
+    assert.equal(fetchCalled, true);
+  });
+}
+
+for (const status of [400, 404, 429]) {
+  test(`NanoBanana API key validator returns validation failed on ${status}`, async () => {
+    let fetchCalled = false;
+    globalThis.fetch = async (url) => {
+      fetchCalled = true;
+      assert.match(String(url), /nanobanana/i);
+      return new Response(JSON.stringify({ error: "validation failed" }), { status });
+    };
+
+    const result = await validateProviderApiKey({ provider: "nanobanana", apiKey: "nb-key" });
+
+    assert.equal(result.valid, false, `NanoBanana should reject ${status}`);
+    assert.equal(result.error, expectedValidationError(status));
+    assert.equal(fetchCalled, true);
+  });
+}

--- a/tests/unit/provider-validation-specialty.test.ts
+++ b/tests/unit/provider-validation-specialty.test.ts
@@ -799,7 +799,7 @@ test("specialty validators cover remaining status branches for Deepgram, Assembl
 
   assert.equal(deepgram.error, "Validation failed: 500");
   assert.equal(assembly.valid, true);
-  assert.equal(banana.valid, true);
+  assert.equal(banana.error, "Validation failed: 400");
   assert.equal(eleven.error, "Invalid API key");
   assert.equal(inworld.error, "inworld offline");
   assert.equal(bailian.error, "Validation failed: 500");

--- a/tests/unit/qoder-executor.test.ts
+++ b/tests/unit/qoder-executor.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { QoderExecutor } from "../../open-sse/executors/qoder.ts";
+import { getQwenCliUserAgent } from "../../open-sse/config/providerHeaderProfiles.ts";
 import {
   buildQoderPrompt,
   getStaticQoderModels,
@@ -173,8 +174,8 @@ test("QoderExecutor: non-stream calls target DashScope and map alias models", as
     assert.equal(options.method, "POST");
     assert.equal(options.headers.Authorization, "Bearer pat_test");
     assert.equal(options.headers["x-dashscope-authtype"], "qwen-oauth");
-    assert.equal(options.headers["user-agent"], "QwenCode/0.15.3 (linux; x64)");
-    assert.equal(options.headers["x-dashscope-useragent"], "QwenCode/0.15.3 (linux; x64)");
+    assert.equal(options.headers["user-agent"], getQwenCliUserAgent());
+    assert.equal(options.headers["x-dashscope-useragent"], getQwenCliUserAgent());
     const parsedBody = JSON.parse(String(options.body));
     assert.equal(parsedBody.model, "coder-model");
     return new Response(

--- a/tests/unit/usage-service-hardening.test.ts
+++ b/tests/unit/usage-service-hardening.test.ts
@@ -1034,8 +1034,8 @@ test("usage service parses Cursor team quotas and clamps on-demand ratio", async
   assert.equal(calls.length, 3);
   for (const call of calls) {
     assert.equal(call.init.headers.Authorization, "Bearer cursor-token");
-    assert.equal(call.init.headers["User-Agent"], "Cursor/3.1.0");
-    assert.equal(call.init.headers["x-cursor-client-version"], "3.1.0");
+    assert.equal(call.init.headers["User-Agent"], "Cursor/3.2.14");
+    assert.equal(call.init.headers["x-cursor-client-version"], "3.2.14");
   }
 
   assert.equal(usage.plan, "Cursor Team");
@@ -1149,9 +1149,9 @@ test("usage helper branches cover reset parsing, GitHub quota math, and plan inf
   assert.deepEqual(__testing.buildCursorUsageHeaders("cursor-token"), {
     Authorization: "Bearer cursor-token",
     Accept: "application/json",
-    "User-Agent": "Cursor/3.1.0",
-    "x-cursor-client-version": "3.1.0",
-    "x-cursor-user-agent": "Cursor/3.1.0",
+    "User-Agent": "Cursor/3.2.14",
+    "x-cursor-client-version": "3.2.14",
+    "x-cursor-user-agent": "Cursor/3.2.14",
   });
   assert.equal(
     __testing.getCursorMonthlyRequestLimit(


### PR DESCRIPTION
## Summary

- Refresh CLI-facing provider versions for Claude Code, Qwen/Qoder, and Cursor using current official package or download metadata.
- Tighten CLI fingerprint toggles so the UI only exposes implemented fingerprints, while keeping the legacy Copilot setting mapped to the GitHub Copilot provider.
- Wire the existing Antigravity fingerprint through its custom executor, including dynamic User-Agent resolution and the Google One AI credits body shape.

## Details

### Provider profile refresh

- Claude Code billing/header version is updated to `2.1.121`.
- Qwen/Qoder now build `QwenCode/<version> (<platform>; <arch>)` from the runtime, matching the official Qwen Code package instead of hardcoding a maintainer host.
- Cursor fallback/client metadata is updated to `3.2.14`, based on Cursor's official download metadata for Linux x64/arm64.
- Codex no longer has its executor-provided `User-Agent` overwritten by a generic `codex-cli` fingerprint value.

### Fingerprint toggle cleanup

- The visible CLI Fingerprint toggles are limited to providers with implemented fingerprint behavior:
  - Claude
  - Codex
  - GitHub Copilot
  - Antigravity
  - Qwen
- `copilot` remains supported as a legacy/UI alias, but normalizes to the underlying `github` provider ID.
- Providers/tools that are not wired to the generic fingerprint pipeline are documented as intentionally omitted instead of being shown as ineffective toggles.

### Antigravity executor wiring

- Applies the existing Antigravity fingerprint in the custom executor path, not only through the generic base executor path.
- Resolves the Antigravity User-Agent dynamically so a cached latest version is not replaced by a stale import-time fallback.
- Keeps fingerprinted headers/body aligned in returned executor metadata and handles `enabledCreditTypes` ordering for Google One AI credits retries.

## Follow-up work

This PR intentionally does **not** attempt deeper per-provider transport emulation. A separate investigation should audit real internal parity for providers such as Codex, Kiro, Cursor, and Antigravity by inspecting official builds and/or safe captures where appropriate. That work should be handled in focused PRs because it may require changing provider-specific executors, transport headers, request metadata, or SDK fingerprints beyond the generic CLI fingerprint toggle layer.

## Validation

- `node --import tsx/esm --test tests/unit/cursor-version-detector.test.mjs tests/unit/provider-header-profiles.test.ts tests/unit/cli-tools.test.ts tests/unit/config-hot-reload.test.ts tests/unit/executor-antigravity.test.ts tests/unit/usage-service-hardening.test.ts`
- `npm run typecheck:core`
- `npm run typecheck:noimplicit:core`
- `git diff --check`
- `npm run lint` (0 errors; existing warnings only)