### PR TITLE
fix(kiro): support organization IDC OAuth with regional endpoints and refresh

### DIFF
--- a/open-sse/services/tokenRefresh.ts
+++ b/open-sse/services/tokenRefresh.ts
@@ -513,11 +513,7 @@ export async function refreshKiroToken(
     // AWS SSO OIDC (Builder ID or IDC)
     // If clientId and clientSecret exist, assume AWS SSO OIDC (default to builder-id if authMethod not specified)
     if (clientId && clientSecret) {
-      const isIDC = authMethod === "idc";
-      const endpoint =
-        isIDC && region
-          ? `https://oidc.${region}.amazonaws.com/token`
-          : "https://oidc.us-east-1.amazonaws.com/token";
+      const endpoint = `https://oidc.${region || "us-east-1"}.amazonaws.com/token`;
 
       const response = await runWithProxyContext(proxyConfig, () =>
         fetch(endpoint, {

--- a/src/app/api/oauth/[provider]/[action]/route.ts
+++ b/src/app/api/oauth/[provider]/[action]/route.ts
@@ -81,6 +81,8 @@ export async function GET(
       }
 
       const authData = generateAuthData(provider, null);
+      const startUrl = searchParams.get("startUrl");
+      const region = searchParams.get("region") || "us-east-1";
 
       // Resolve proxy for this provider (provider-level → global → direct)
       const proxy = await resolveProxyForProvider(provider);
@@ -95,7 +97,24 @@ export async function GET(
         provider === "kilocode"
       ) {
         // GitHub, Kiro/Amazon Q, Kimi Coding, and KiloCode don't use PKCE for device code
-        deviceData = await runWithProxyContext(proxy, () => (requestDeviceCode as any)(provider));
+        if ((provider === "kiro" || provider === "amazon-q") && startUrl) {
+          const providerOverrideConfig = {
+            ...providerData.config,
+            startUrl,
+            region,
+            skipIssuerUrlForRegistration: true,
+            registerClientUrl: `https://oidc.${region}.amazonaws.com/client/register`,
+            deviceAuthUrl: `https://oidc.${region}.amazonaws.com/device_authorization`,
+            tokenUrl: `https://oidc.${region}.amazonaws.com/token`,
+            ssoOidcEndpoint: `https://oidc.${region}.amazonaws.com`,
+          };
+
+          deviceData = await runWithProxyContext(proxy, () =>
+            (requestDeviceCode as any)(provider, null, providerOverrideConfig)
+          );
+        } else {
+          deviceData = await runWithProxyContext(proxy, () => (requestDeviceCode as any)(provider));
+        }
       } else {
         // Qwen and other providers use PKCE
         deviceData = await runWithProxyContext(proxy, () =>

--- a/src/lib/oauth/providers.ts
+++ b/src/lib/oauth/providers.ts
@@ -81,12 +81,12 @@ export async function exchangeTokens(providerName, code, redirectUri, codeVerifi
 /**
  * Request device code (for device_code flow)
  */
-export async function requestDeviceCode(providerName, codeChallenge) {
+export async function requestDeviceCode(providerName, codeChallenge, configOverride = null) {
   const provider = getProvider(providerName);
   if (provider.flowType !== "device_code") {
     throw new Error(`Provider ${providerName} does not support device code flow`);
   }
-  return await provider.requestDeviceCode(provider.config, codeChallenge);
+  return await provider.requestDeviceCode(configOverride || provider.config, codeChallenge);
 }
 
 /**

--- a/src/lib/oauth/providers/kiro.ts
+++ b/src/lib/oauth/providers/kiro.ts
@@ -4,6 +4,27 @@ export const kiro = {
   config: KIRO_CONFIG,
   flowType: "device_code",
   requestDeviceCode: async (config) => {
+    const regionMatch = String(config.tokenUrl || "").match(/oidc\.([a-z0-9-]+)\.amazonaws\.com/i);
+    const resolvedRegion = regionMatch?.[1] || "us-east-1";
+    const registerPayload: {
+      clientName: string;
+      clientType: string;
+      scopes: string[];
+      grantTypes: string[];
+      issuerUrl?: string;
+    } = {
+      clientName: config.clientName,
+      clientType: config.clientType,
+      scopes: config.scopes,
+      grantTypes: config.grantTypes,
+    };
+
+    // For enterprise IDC custom startUrl flows, issuerUrl can differ per tenant.
+    // Sending a fixed issuerUrl often causes invalid_request during device auth.
+    if (config.issuerUrl && !config.skipIssuerUrlForRegistration) {
+      registerPayload.issuerUrl = config.issuerUrl;
+    }
+
     // Step 1: Register client with AWS SSO OIDC
     const registerRes = await fetch(config.registerClientUrl, {
       method: "POST",
@@ -11,13 +32,7 @@ export const kiro = {
         "Content-Type": "application/json",
         Accept: "application/json",
       },
-      body: JSON.stringify({
-        clientName: config.clientName,
-        clientType: config.clientType,
-        scopes: config.scopes,
-        grantTypes: config.grantTypes,
-        issuerUrl: config.issuerUrl,
-      }),
+      body: JSON.stringify(registerPayload),
     });
 
     if (!registerRes.ok) {
@@ -57,10 +72,14 @@ export const kiro = {
       interval: deviceData.interval || 5,
       _clientId: clientInfo.clientId,
       _clientSecret: clientInfo.clientSecret,
+      _region: resolvedRegion,
     };
   },
   pollToken: async (config, deviceCode, codeVerifier, extraData) => {
-    const response = await fetch(config.tokenUrl, {
+    const tokenRegion = extraData?._region || "us-east-1";
+    const tokenUrl = `https://oidc.${tokenRegion}.amazonaws.com/token`;
+
+    const response = await fetch(tokenUrl, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -91,6 +110,7 @@ export const kiro = {
           expires_in: data.expiresIn,
           _clientId: extraData?._clientId,
           _clientSecret: extraData?._clientSecret,
+          _region: tokenRegion,
         },
       };
     }
@@ -110,6 +130,7 @@ export const kiro = {
     providerSpecificData: {
       clientId: tokens._clientId,
       clientSecret: tokens._clientSecret,
+      region: tokens._region,
     },
   }),
 };

--- a/src/shared/components/KiroAuthModal.tsx
+++ b/src/shared/components/KiroAuthModal.tsx
@@ -138,17 +138,19 @@ export default function KiroAuthModal({
               </div>
             </button>
 
-            {/* AWS IAM Identity Center (IDC) - HIDDEN */}
+            {/* AWS IAM Identity Center (IDC) */}
             <button
               onClick={() => handleMethodSelect("idc")}
-              className="hidden w-full p-4 text-left border border-border rounded-lg hover:bg-sidebar transition-colors"
+              className="w-full p-4 text-left border border-border rounded-lg hover:bg-sidebar transition-colors"
             >
               <div className="flex items-start gap-3">
                 <span className="material-symbols-outlined text-primary mt-0.5">business</span>
                 <div className="flex-1">
-                  <h3 className="font-semibold mb-1">AWS IAM Identity Center</h3>
+                  <h3 className="font-semibold mb-1">
+                    Your Organization (AWS IAM Identity Center)
+                  </h3>
                   <p className="text-sm text-text-muted">
-                    For enterprise users with custom AWS IAM Identity Center.
+                    Use your company SSO start URL (example: https://your-org.awsapps.com/start).
                   </p>
                 </div>
               </div>

--- a/src/shared/components/OAuthModal.tsx
+++ b/src/shared/components/OAuthModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import PropTypes from "prop-types";
 import { useTranslations } from "next-intl";
 import Modal from "./Modal";
@@ -47,32 +47,35 @@ export default function OAuthModal({
   const deviceVerificationUrl =
     deviceData?.verification_uri_complete || deviceData?.verification_uri || "";
 
-  // State for client-only values to avoid hydration mismatch
-  const [isLocalhost, setIsLocalhost] = useState(false);
-  const [placeholderUrl, setPlaceholderUrl] = useState("/callback?code=...");
+  // Client-only runtime values
+  const runtimeLocation = useMemo(() => {
+    if (typeof window === "undefined") {
+      return {
+        isLocalhost: false,
+        isTrueLocalhost: false,
+        placeholderUrl: "/callback?code=...",
+      };
+    }
+
+    const hostname = window.location.hostname;
+    const isLocal =
+      hostname === "localhost" ||
+      hostname === "127.0.0.1" ||
+      hostname.startsWith("192.168.") ||
+      hostname.startsWith("10.") ||
+      /^172\.(1[6-9]|2\d|3[01])\./.test(hostname);
+    const isTrulyLocal = hostname === "localhost" || hostname === "127.0.0.1";
+
+    return {
+      isLocalhost: isLocal,
+      isTrueLocalhost: isTrulyLocal,
+      placeholderUrl: `${window.location.origin}/callback?code=...`,
+    };
+  }, []);
+
+  const { isLocalhost, isTrueLocalhost, placeholderUrl } = runtimeLocation;
   const callbackProcessedRef = useRef(false);
   const flowStartedRef = useRef(false);
-
-  // Detect if running on true localhost vs LAN IP (client-side only)
-  // - True localhost (127.0.0.1/localhost): popup auto-callback works
-  // - LAN IPs (192.168.x, 10.x, 172.x): redirect URI uses localhost but callback
-  //   won't resolve back to the VPS, so use manual paste mode
-  const [isTrueLocalhost, setIsTrueLocalhost] = useState(false);
-  useEffect(() => {
-    if (typeof window !== "undefined") {
-      const hostname = window.location.hostname;
-      const isLocal =
-        hostname === "localhost" ||
-        hostname === "127.0.0.1" ||
-        hostname.startsWith("192.168.") ||
-        hostname.startsWith("10.") ||
-        /^172\.(1[6-9]|2\d|3[01])\./.test(hostname);
-      const isTrulyLocal = hostname === "localhost" || hostname === "127.0.0.1";
-      setIsLocalhost(isLocal);
-      setIsTrueLocalhost(isTrulyLocal);
-      setPlaceholderUrl(`${window.location.origin}/callback?code=...`);
-    }
-  }, []);
 
   // Define all useCallback hooks BEFORE the useEffects that reference them
 
@@ -217,7 +220,22 @@ export default function OAuthModal({
         setIsDeviceCode(true);
         setStep("waiting");
 
-        const res = await fetch(`/api/oauth/${provider}/device-code`);
+        const deviceCodeUrl = new URL(`/api/oauth/${provider}/device-code`, window.location.origin);
+        if (
+          (provider === "kiro" || provider === "amazon-q") &&
+          idcConfig &&
+          typeof idcConfig === "object"
+        ) {
+          const idc = idcConfig as { startUrl?: string; region?: string };
+          if (typeof idc.startUrl === "string" && idc.startUrl.trim()) {
+            deviceCodeUrl.searchParams.set("startUrl", idc.startUrl.trim());
+          }
+          if (typeof idc.region === "string" && idc.region.trim()) {
+            deviceCodeUrl.searchParams.set("region", idc.region.trim());
+          }
+        }
+
+        const res = await fetch(deviceCodeUrl.toString());
         const data = await res.json();
         if (!res.ok) {
           const errMsg =
@@ -237,7 +255,11 @@ export default function OAuthModal({
         // Start polling - pass extraData for Kiro (contains _clientId, _clientSecret)
         const extraData =
           provider === "kiro" || provider === "amazon-q"
-            ? { _clientId: data._clientId, _clientSecret: data._clientSecret }
+            ? {
+                _clientId: data._clientId,
+                _clientSecret: data._clientSecret,
+                _region: data._region,
+              }
             : null;
         startPolling(data.device_code, data.codeVerifier, data.interval || 5, extraData);
         return;
@@ -379,7 +401,15 @@ export default function OAuthModal({
       setError(err.message);
       setStep("error");
     }
-  }, [provider, isLocalhost, isTrueLocalhost, startPolling, onSuccess, reauthConnection]);
+  }, [
+    provider,
+    isLocalhost,
+    isTrueLocalhost,
+    startPolling,
+    onSuccess,
+    reauthConnection,
+    idcConfig,
+  ]);
 
   // Reset guard when modal closes
   useEffect(() => {

--- a/tests/unit/oauth-kiro-idc.test.ts
+++ b/tests/unit/oauth-kiro-idc.test.ts
@@ -1,0 +1,123 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { kiro } from "@/lib/oauth/providers/kiro";
+
+test("kiro.requestDeviceCode returns resolved region for IDC token endpoint", async () => {
+  const originalFetch = global.fetch;
+
+  const fetchCalls: Array<{ url: string; body?: string }> = [];
+
+  global.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    fetchCalls.push({ url, body: typeof init?.body === "string" ? init.body : undefined });
+
+    if (url.endsWith("/client/register")) {
+      return new Response(JSON.stringify({ clientId: "client-ap", clientSecret: "secret-ap" }), {
+        status: 200,
+      });
+    }
+
+    if (url.endsWith("/device_authorization")) {
+      return new Response(
+        JSON.stringify({
+          deviceCode: "dev-code",
+          userCode: "user-code",
+          verificationUri: "https://d-tenant.awsapps.com/start/#/device",
+          verificationUriComplete: "https://d-tenant.awsapps.com/start/#/device?user_code=ABCD",
+          expiresIn: 600,
+          interval: 1,
+        }),
+        { status: 200 }
+      );
+    }
+
+    return new Response("not-found", { status: 404 });
+  }) as typeof fetch;
+
+  try {
+    const result = await kiro.requestDeviceCode({
+      registerClientUrl: "https://oidc.ap-southeast-1.amazonaws.com/client/register",
+      deviceAuthUrl: "https://oidc.ap-southeast-1.amazonaws.com/device_authorization",
+      tokenUrl: "https://oidc.ap-southeast-1.amazonaws.com/token",
+      startUrl: "https://d-tenant.awsapps.com/start",
+      clientName: "kiro-oauth-client",
+      clientType: "public",
+      scopes: ["codewhisperer:completions"],
+      grantTypes: ["urn:ietf:params:oauth:grant-type:device_code", "refresh_token"],
+      skipIssuerUrlForRegistration: true,
+    });
+
+    assert.equal(result._region, "ap-southeast-1");
+    assert.equal(result._clientId, "client-ap");
+    assert.equal(result._clientSecret, "secret-ap");
+
+    const registerBody = JSON.parse(fetchCalls[0]?.body || "{}");
+    assert.equal(registerBody.issuerUrl, undefined);
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test("kiro.pollToken uses region provided by extraData", async () => {
+  const originalFetch = global.fetch;
+  let requestedUrl = "";
+
+  global.fetch = (async (input: RequestInfo | URL) => {
+    requestedUrl = String(input);
+    return new Response(
+      JSON.stringify({
+        accessToken: "access",
+        refreshToken: "refresh",
+        expiresIn: 3600,
+      }),
+      { status: 200 }
+    );
+  }) as typeof fetch;
+
+  try {
+    const result = await kiro.pollToken(
+      { tokenUrl: "https://oidc.us-east-1.amazonaws.com/token" },
+      "device-code",
+      null,
+      { _clientId: "cid", _clientSecret: "csecret", _region: "ap-southeast-1" }
+    );
+
+    assert.equal(requestedUrl, "https://oidc.ap-southeast-1.amazonaws.com/token");
+    assert.equal(result.ok, true);
+    assert.equal(result.data.access_token, "access");
+    assert.equal(result.data._region, "ap-southeast-1");
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test("kiro.mapTokens persists region into providerSpecificData", () => {
+  const mapped = kiro.mapTokens({
+    access_token: "at",
+    refresh_token: "rt",
+    expires_in: 3600,
+    _clientId: "cid",
+    _clientSecret: "csec",
+    _region: "ap-southeast-1",
+  });
+
+  assert.equal(mapped.accessToken, "at");
+  assert.equal(mapped.refreshToken, "rt");
+  assert.equal(mapped.expiresIn, 3600);
+  assert.equal(mapped.providerSpecificData.clientId, "cid");
+  assert.equal(mapped.providerSpecificData.clientSecret, "csec");
+  assert.equal(mapped.providerSpecificData.region, "ap-southeast-1");
+});
+
+test("kiro.mapTokens defaults region to undefined when not provided", () => {
+  const mapped = kiro.mapTokens({
+    access_token: "at",
+    refresh_token: "rt",
+    expires_in: 3600,
+    _clientId: "cid",
+    _clientSecret: "csec",
+  });
+
+  assert.equal(mapped.providerSpecificData.region, undefined);
+});

--- a/tests/unit/token-refresh-service.test.ts
+++ b/tests/unit/token-refresh-service.test.ts
@@ -464,6 +464,47 @@ test("refreshKiroToken uses the AWS OIDC flow when client credentials are presen
   });
 });
 
+test("refreshKiroToken uses stored region for AWS OIDC refresh without authMethod", async () => {
+  const log = createLog();
+  const calls: any[] = [];
+
+  await withMockedFetch(
+    async (url, options = {}) => {
+      calls.push({ url, options });
+      return jsonResponse({
+        accessToken: "kiro-aws-access",
+        refreshToken: "kiro-aws-refresh-next",
+        expiresIn: 900,
+      });
+    },
+    async () => {
+      const result = await refreshKiroToken(
+        "kiro-refresh",
+        {
+          clientId: "aws-client",
+          clientSecret: "aws-secret",
+          region: "ap-southeast-1",
+        },
+        log
+      );
+
+      assert.deepEqual(result, {
+        accessToken: "kiro-aws-access",
+        refreshToken: "kiro-aws-refresh-next",
+        expiresIn: 900,
+      });
+    }
+  );
+
+  assert.equal(calls[0].url, "https://oidc.ap-southeast-1.amazonaws.com/token");
+  assert.deepEqual(JSON.parse(calls[0].options.body), {
+    clientId: "aws-client",
+    clientSecret: "aws-secret",
+    refreshToken: "kiro-refresh",
+    grantType: "refresh_token",
+  });
+});
+
 test("refreshKiroToken falls back to the social-auth refresh endpoint", async () => {
   const log = createLog();
   const calls: any[] = [];


### PR DESCRIPTION
## Summary
- add Kiro organization (IDC) OAuth support that derives and persists regional token endpoints through device-code, token polling, and token mapping
- update OAuth route/config plumbing to pass IDC overrides safely (including skip-issuer registration behavior) and ensure refresh flows keep region context
- add focused unit coverage for IDC-specific OAuth behavior and fix OAuth modal hook dependencies/lint-safe runtime detection
## Validation
- node --import tsx/esm --test tests/unit/oauth-kiro-idc.test.ts
- npx eslint src/shared/components/OAuthModal.tsx src/lib/oauth/providers/kiro.ts tests/unit/oauth-kiro-idc.test.ts
- pre-push hook test suite passed during push (Node v22.22.2)