### PR TITLE
chore(xiaomi): Update Xiaomi provider model list

### DIFF
--- a/open-sse/config/providerRegistry.ts
+++ b/open-sse/config/providerRegistry.ts
@@ -228,7 +228,7 @@ const CHAT_OPENAI_COMPAT_MODELS: Record<string, RegistryModel[]> = {
   codestral: buildModels(["codestral-2405", "codestral-latest"]),
   upstage: buildModels(["solar-pro", "solar-mini", "solar-docvision", "solar-embedding-1-large"]),
   maritalk: buildModels(["sabia-3", "sabia-3-small"]),
-  "xiaomi-mimo": buildModels(["mimo-v2-pro", "mimo-v2-omni", "mimo-v2-tts"]),
+  "xiaomi-mimo": buildModels(["mimo-v2.5-pro", "mimo-v2.5", "mimo-v2-omni", "mimo-v2-flash"]),
   "inference-net": buildModels([
     "meta-llama/Llama-3.3-70B-Instruct",
     "deepseek-ai/DeepSeek-R1",

--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -1033,7 +1033,7 @@ export const APIKEY_PROVIDERS = {
     icon: "devices",
     color: "#EA580C",
     textIcon: "MM",
-    website: "https://www.mi.com",
+    website: "https://mimo.mi.com",
   },
   "inference-net": {
     id: "inference-net",
@@ -1542,7 +1542,8 @@ export const SEARCH_PROVIDERS = {
     color: "#1A237E",
     textIcon: "SX",
     website: "https://docs.searxng.org",
-    authHint: "API key is optional. Set your SearXNG base URL. Some instances may require a bearer token for access.",
+    authHint:
+      "API key is optional. Set your SearXNG base URL. Some instances may require a bearer token for access.",
   },
 };
 

--- a/tests/unit/xiaomi-mimo-provider.test.ts
+++ b/tests/unit/xiaomi-mimo-provider.test.ts
@@ -16,7 +16,7 @@ test("xiaomi-mimo registry uses the current default base URL and MiMo V2 models"
   assert.equal(entry.baseUrl, "https://api.xiaomimimo.com/v1");
   assert.deepEqual(
     entry.models.map((model) => model.id),
-    ["mimo-v2-pro", "mimo-v2-omni", "mimo-v2-tts"]
+    ["mimo-v2.5-pro", "mimo-v2.5", "mimo-v2-omni", "mimo-v2-flash"]
   );
 });
 
@@ -24,7 +24,7 @@ test("xiaomi-mimo executor appends /chat/completions for regional base URLs", ()
   const executor = new DefaultExecutor("xiaomi-mimo");
 
   assert.equal(
-    executor.buildUrl("mimo-v2-pro", true, 0, {
+    executor.buildUrl("mimo-v2.5", true, 0, {
       providerSpecificData: {
         baseUrl: "https://token-plan-ams.xiaomimimo.com/v1",
       },
@@ -33,7 +33,7 @@ test("xiaomi-mimo executor appends /chat/completions for regional base URLs", ()
   );
 
   assert.equal(
-    executor.buildUrl("mimo-v2-pro", true, 0, {
+    executor.buildUrl("mimo-v2.5", true, 0, {
       providerSpecificData: {
         baseUrl: "https://token-plan-cn.xiaomimimo.com/v1/chat/completions",
       },


### PR DESCRIPTION
## Summary

- Update Xiaomi MiMo provider metadata and default model catalog.
- Replace outdated MiMo model IDs with current `mimo-v2.5-pro`, `mimo-v2.5`, `mimo-v2-omni`, and `mimo-v2-flash`.
- Point the provider website to `https://mimo.mi.com`.

## Tests Added Or Updated

- Updated `tests/unit/xiaomi-mimo-provider.test.ts`.
- Updated `src/shared/constants/providers.ts`.
- Updated `open-sse/config/providerRegistry.ts`.

## Coverage Notes

- `open-sse/config/providerRegistry.ts` is covered by the updated Xiaomi MiMo registry assertions and regional base URL executor checks in `tests/unit/xiaomi-mimo-provider.test.ts`.
- `src/shared/constants/providers.ts` changed provider metadata only; the website URL change is not directly asserted.
- Coverage was not run locally, so no coverage movement was measured.

## Reviewer Notes

- Main review area is whether removed Xiaomi MiMo model IDs are still needed for backward compatibility.
- No migrations or feature flags are involved.