### PR TITLE
Speed up endpoint initial render

### DIFF
--- a/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.tsx
+++ b/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.tsx
@@ -78,6 +78,12 @@ const DEFAULT_TUNNEL_VISIBILITY: EndpointTunnelVisibility = {
   showTailscaleFunnel: true,
 };
 
+function runEndpointBackgroundTask(taskName: string, task: () => Promise<unknown>) {
+  void task().catch((error) => {
+    console.log(`Error running endpoint background task (${taskName}):`, error);
+  });
+}
+
 export default function APIPageClient({ machineId }) {
   const [resolvedMachineId, setResolvedMachineId] = useState(machineId || "");
   const t = useTranslations("endpoint");
@@ -216,20 +222,20 @@ export default function APIPageClient({ machineId }) {
     let mounted = true;
 
     const loadPage = async () => {
-      const tunnelVisibility = await loadCloudSettings();
+      const tunnelVisibility = await loadCloudSettings(() => mounted);
 
       if (!mounted) return;
       setLoading(false);
 
-      void fetchModels();
-      void fetchProtocolStatus();
-      void fetchSearchProviders();
+      runEndpointBackgroundTask("models", fetchModels);
+      runEndpointBackgroundTask("protocol-status", fetchProtocolStatus);
+      runEndpointBackgroundTask("search-providers", fetchSearchProviders);
 
       if (tunnelVisibility.showCloudflaredTunnel) {
-        void fetchCloudflaredStatus(true);
+        runEndpointBackgroundTask("cloudflared-status", () => fetchCloudflaredStatus(true));
       }
       if (tunnelVisibility.showTailscaleFunnel) {
-        void fetchTailscaleStatus(true);
+        runEndpointBackgroundTask("tailscale-status", () => fetchTailscaleStatus(true));
       }
     };
 
@@ -308,18 +314,7 @@ export default function APIPageClient({ machineId }) {
   );
 
   const availableEndpointCount = useMemo(
-    () =>
-      [
-        endpointData.chat,
-        endpointData.embeddings,
-        endpointData.images,
-        endpointData.video,
-        endpointData.rerank,
-        endpointData.audioTranscription,
-        endpointData.audioSpeech,
-        endpointData.moderation,
-        endpointData.music,
-      ].filter((models) => models.length > 0).length + 2,
+    () => Object.values(endpointData).filter((models) => models.length > 0).length + 2,
     [endpointData]
   );
 
@@ -345,7 +340,9 @@ export default function APIPageClient({ machineId }) {
     }
   };
 
-  const loadCloudSettings = async (): Promise<EndpointTunnelVisibility> => {
+  const loadCloudSettings = async (
+    shouldApplyState: () => boolean = () => true
+  ): Promise<EndpointTunnelVisibility> => {
     try {
       const res = await fetch("/api/settings");
       if (res.ok) {
@@ -354,6 +351,11 @@ export default function APIPageClient({ machineId }) {
           showCloudflaredTunnel: data.hideEndpointCloudflaredTunnel !== true,
           showTailscaleFunnel: data.hideEndpointTailscaleFunnel !== true,
         };
+
+        if (!shouldApplyState()) {
+          return tunnelVisibility;
+        }
+
         setCloudEnabled(data.cloudEnabled || false);
         if (typeof data.cloudConfigured === "boolean") {
           setCloudConfigured(data.cloudConfigured);

--- a/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.tsx
+++ b/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.tsx
@@ -68,6 +68,16 @@ type TunnelNotice = {
   message: string;
 };
 
+type EndpointTunnelVisibility = {
+  showCloudflaredTunnel: boolean;
+  showTailscaleFunnel: boolean;
+};
+
+const DEFAULT_TUNNEL_VISIBILITY: EndpointTunnelVisibility = {
+  showCloudflaredTunnel: true,
+  showTailscaleFunnel: true,
+};
+
 export default function APIPageClient({ machineId }) {
   const [resolvedMachineId, setResolvedMachineId] = useState(machineId || "");
   const t = useTranslations("endpoint");
@@ -76,6 +86,7 @@ export default function APIPageClient({ machineId }) {
 
   // Endpoints / models state
   const [allModels, setAllModels] = useState([]);
+  const [modelsLoading, setModelsLoading] = useState(true);
   const [expandedEndpoint, setExpandedEndpoint] = useState(null);
 
   // Cloud sync state
@@ -202,19 +213,35 @@ export default function APIPageClient({ machineId }) {
   );
 
   useEffect(() => {
-    Promise.allSettled([
-      loadCloudSettings(),
-      fetchModels(),
-      fetchProtocolStatus(),
-      fetchSearchProviders(),
-      fetchCloudflaredStatus(true),
-      fetchTailscaleStatus(true),
-    ]).finally(() => {
+    let mounted = true;
+
+    const loadPage = async () => {
+      const tunnelVisibility = await loadCloudSettings();
+
+      if (!mounted) return;
       setLoading(false);
-    });
+
+      void fetchModels();
+      void fetchProtocolStatus();
+      void fetchSearchProviders();
+
+      if (tunnelVisibility.showCloudflaredTunnel) {
+        void fetchCloudflaredStatus(true);
+      }
+      if (tunnelVisibility.showTailscaleFunnel) {
+        void fetchTailscaleStatus(true);
+      }
+    };
+
+    void loadPage();
+
+    return () => {
+      mounted = false;
+    };
   }, [fetchCloudflaredStatus, fetchTailscaleStatus]);
 
   const fetchModels = async () => {
+    setModelsLoading(true);
     try {
       const res = await fetch("/v1/models");
       if (res.ok) {
@@ -223,6 +250,8 @@ export default function APIPageClient({ machineId }) {
       }
     } catch (e) {
       console.log("Error fetching models:", e);
+    } finally {
+      setModelsLoading(false);
     }
   };
 
@@ -273,6 +302,27 @@ export default function APIPageClient({ machineId }) {
     };
   }, [allModels]);
 
+  const totalEndpointModelCount = useMemo(
+    () => Object.values(endpointData).reduce((acc, models) => acc + models.length, 0),
+    [endpointData]
+  );
+
+  const availableEndpointCount = useMemo(
+    () =>
+      [
+        endpointData.chat,
+        endpointData.embeddings,
+        endpointData.images,
+        endpointData.video,
+        endpointData.rerank,
+        endpointData.audioTranscription,
+        endpointData.audioSpeech,
+        endpointData.moderation,
+        endpointData.music,
+      ].filter((models) => models.length > 0).length + 2,
+    [endpointData]
+  );
+
   const postCloudAction = async (action, timeoutMs = CLOUD_ACTION_TIMEOUT_MS) => {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
@@ -295,11 +345,15 @@ export default function APIPageClient({ machineId }) {
     }
   };
 
-  const loadCloudSettings = async () => {
+  const loadCloudSettings = async (): Promise<EndpointTunnelVisibility> => {
     try {
       const res = await fetch("/api/settings");
       if (res.ok) {
         const data = await res.json();
+        const tunnelVisibility = {
+          showCloudflaredTunnel: data.hideEndpointCloudflaredTunnel !== true,
+          showTailscaleFunnel: data.hideEndpointTailscaleFunnel !== true,
+        };
         setCloudEnabled(data.cloudEnabled || false);
         if (typeof data.cloudConfigured === "boolean") {
           setCloudConfigured(data.cloudConfigured);
@@ -310,12 +364,25 @@ export default function APIPageClient({ machineId }) {
         if (data.machineId) {
           setResolvedMachineId(data.machineId);
         }
-        setShowCloudflaredTunnel(data.hideEndpointCloudflaredTunnel !== true);
-        setShowTailscaleFunnel(data.hideEndpointTailscaleFunnel !== true);
+        setShowCloudflaredTunnel(tunnelVisibility.showCloudflaredTunnel);
+        setShowTailscaleFunnel(tunnelVisibility.showTailscaleFunnel);
+
+        if (!tunnelVisibility.showCloudflaredTunnel) {
+          setCloudflaredStatus(null);
+          setCloudflaredNotice(null);
+        }
+        if (!tunnelVisibility.showTailscaleFunnel) {
+          setTailscaleStatus(null);
+          setTailscaleNotice(null);
+        }
+
+        return tunnelVisibility;
       }
     } catch (error) {
       console.log("Error loading cloud settings:", error);
     }
+
+    return DEFAULT_TUNNEL_VISIBILITY;
   };
 
   const handleCloudToggle = (checked) => {
@@ -358,11 +425,15 @@ export default function APIPageClient({ machineId }) {
   useEffect(() => {
     const interval = setInterval(() => {
       void fetchProtocolStatus();
-      void fetchCloudflaredStatus(true);
-      void fetchTailscaleStatus(true);
+      if (showCloudflaredTunnel) {
+        void fetchCloudflaredStatus(true);
+      }
+      if (showTailscaleFunnel) {
+        void fetchTailscaleStatus(true);
+      }
     }, 30000);
     return () => clearInterval(interval);
-  }, [fetchCloudflaredStatus, fetchTailscaleStatus]);
+  }, [fetchCloudflaredStatus, fetchTailscaleStatus, showCloudflaredTunnel, showTailscaleFunnel]);
 
   const dispatchCloudChange = () => {
     globalThis.dispatchEvent(new Event("cloud-status-changed"));
@@ -689,7 +760,7 @@ export default function APIPageClient({ machineId }) {
       setTailscaleBusy(false);
       await fetchTailscaleStatus(true);
     }
-  }, [fetchTailscaleStatus, translateOrFallback]);
+  }, [fetchTailscaleStatus, tailscalePassword, translateOrFallback]);
 
   const handleTailscaleInstall = useCallback(async () => {
     setTailscaleInstallBusy(true);
@@ -1258,24 +1329,12 @@ export default function APIPageClient({ machineId }) {
             <div>
               <h2 className="text-lg font-semibold">{t("available")}</h2>
               <p className="text-sm text-text-muted">
-                {t("modelsAcrossEndpoints", {
-                  models: Object.values(endpointData).reduce(
-                    (acc, models) => acc + models.length,
-                    0
-                  ),
-                  endpoints:
-                    [
-                      endpointData.chat,
-                      endpointData.embeddings,
-                      endpointData.images,
-                      endpointData.video,
-                      endpointData.rerank,
-                      endpointData.audioTranscription,
-                      endpointData.audioSpeech,
-                      endpointData.moderation,
-                      endpointData.music,
-                    ].filter((a) => a.length > 0).length + 2,
-                })}
+                {modelsLoading
+                  ? translateOrFallback("loadingModels", "Loading available models...")
+                  : t("modelsAcrossEndpoints", {
+                      models: totalEndpointModelCount,
+                      endpoints: availableEndpointCount,
+                    })}
               </p>
             </div>
           </div>
@@ -1304,6 +1363,7 @@ export default function APIPageClient({ machineId }) {
                 copy={copy}
                 copied={copied}
                 baseUrl={currentEndpoint}
+                modelsLoading={modelsLoading}
               />
 
               {/* Responses API */}
@@ -1325,6 +1385,7 @@ export default function APIPageClient({ machineId }) {
                 copy={copy}
                 copied={copied}
                 baseUrl={currentEndpoint}
+                modelsLoading={modelsLoading}
               />
 
               {/* Legacy Completions */}
@@ -1346,6 +1407,7 @@ export default function APIPageClient({ machineId }) {
                 copy={copy}
                 copied={copied}
                 baseUrl={currentEndpoint}
+                modelsLoading={modelsLoading}
               />
             </div>
           </div>
@@ -1376,6 +1438,7 @@ export default function APIPageClient({ machineId }) {
                 copy={copy}
                 copied={copied}
                 baseUrl={currentEndpoint}
+                modelsLoading={modelsLoading}
               />
 
               {/* Image Generation */}
@@ -1394,6 +1457,7 @@ export default function APIPageClient({ machineId }) {
                 copy={copy}
                 copied={copied}
                 baseUrl={currentEndpoint}
+                modelsLoading={modelsLoading}
               />
 
               {/* Audio Transcription */}
@@ -1414,6 +1478,7 @@ export default function APIPageClient({ machineId }) {
                 copy={copy}
                 copied={copied}
                 baseUrl={currentEndpoint}
+                modelsLoading={modelsLoading}
               />
 
               {/* Audio Speech (TTS) */}
@@ -1432,6 +1497,7 @@ export default function APIPageClient({ machineId }) {
                 copy={copy}
                 copied={copied}
                 baseUrl={currentEndpoint}
+                modelsLoading={modelsLoading}
               />
 
               {/* Music Generation */}
@@ -1451,6 +1517,7 @@ export default function APIPageClient({ machineId }) {
                 copy={copy}
                 copied={copied}
                 baseUrl={currentEndpoint}
+                modelsLoading={modelsLoading}
               />
 
               {/* Video Generation */}
@@ -1470,6 +1537,7 @@ export default function APIPageClient({ machineId }) {
                 copy={copy}
                 copied={copied}
                 baseUrl={currentEndpoint}
+                modelsLoading={modelsLoading}
               />
             </div>
           </div>
@@ -1541,6 +1609,7 @@ export default function APIPageClient({ machineId }) {
                 copy={copy}
                 copied={copied}
                 baseUrl={currentEndpoint}
+                modelsLoading={modelsLoading}
               />
 
               {/* Moderations */}
@@ -1559,6 +1628,7 @@ export default function APIPageClient({ machineId }) {
                 copy={copy}
                 copied={copied}
                 baseUrl={currentEndpoint}
+                modelsLoading={modelsLoading}
               />
 
               {/* List Models */}
@@ -2078,6 +2148,7 @@ function EndpointSection({
   copy,
   copied,
   baseUrl,
+  modelsLoading = false,
 }) {
   const t = useTranslations("endpoint");
   const grouped = useMemo(() => {
@@ -2111,7 +2182,7 @@ function EndpointSection({
           <div className="flex items-center gap-2">
             <span className="font-semibold text-sm">{title}</span>
             <span className="text-xs px-2 py-0.5 rounded-full bg-surface text-text-muted font-medium">
-              {t("modelsCount", { count: models.length })}
+              {modelsLoading ? "..." : t("modelsCount", { count: models.length })}
             </span>
           </div>
           <p className="text-xs text-text-muted mt-0.5">{description}</p>
@@ -2143,35 +2214,44 @@ function EndpointSection({
           </div>
 
           {/* Models grouped by provider */}
-          <div className="flex flex-col gap-2">
-            {grouped.map(([providerId, providerModels]) => (
-              <div key={providerId}>
-                <div className="flex items-center gap-2 mb-1">
-                  <div
-                    className="size-2.5 rounded-full shrink-0"
-                    style={{ backgroundColor: providerColor(providerId) }}
-                  />
-                  <span className="text-xs font-semibold text-text-main">
-                    {providerName(providerId)}
-                  </span>
-                  <span className="text-xs text-text-muted">
-                    ({(providerModels as any).length})
-                  </span>
-                </div>
-                <div className="ml-5 flex flex-wrap gap-1.5">
-                  {(providerModels as any).map((m) => (
-                    <span
-                      key={m.id}
-                      className="text-xs px-2 py-0.5 rounded-md bg-surface/80 text-text-muted font-mono"
-                      title={m.id}
-                    >
-                      {m.root || m.id.split("/").pop()}
+          {modelsLoading ? (
+            <div className="flex items-center gap-2 rounded-lg border border-border/70 bg-surface/40 px-3 py-2 text-xs text-text-muted">
+              <span className="material-symbols-outlined animate-spin text-sm">
+                progress_activity
+              </span>
+              <span>{t("loadingModels")}</span>
+            </div>
+          ) : (
+            <div className="flex flex-col gap-2">
+              {grouped.map(([providerId, providerModels]) => (
+                <div key={providerId}>
+                  <div className="flex items-center gap-2 mb-1">
+                    <div
+                      className="size-2.5 rounded-full shrink-0"
+                      style={{ backgroundColor: providerColor(providerId) }}
+                    />
+                    <span className="text-xs font-semibold text-text-main">
+                      {providerName(providerId)}
                     </span>
-                  ))}
+                    <span className="text-xs text-text-muted">
+                      ({(providerModels as any).length})
+                    </span>
+                  </div>
+                  <div className="ml-5 flex flex-wrap gap-1.5">
+                    {(providerModels as any).map((m) => (
+                      <span
+                        key={m.id}
+                        className="text-xs px-2 py-0.5 rounded-md bg-surface/80 text-text-muted font-mono"
+                        title={m.id}
+                      >
+                        {m.root || m.id.split("/").pop()}
+                      </span>
+                    ))}
+                  </div>
                 </div>
-              </div>
-            ))}
-          </div>
+              ))}
+            </div>
+          )}
         </div>
       )}
     </div>
@@ -2191,4 +2271,5 @@ EndpointSection.propTypes = {
   copy: PropTypes.func.isRequired,
   copied: PropTypes.string,
   baseUrl: PropTypes.string.isRequired,
+  modelsLoading: PropTypes.bool,
 };

--- a/src/app/(dashboard)/dashboard/endpoint/__tests__/EndpointPageClient.test.tsx
+++ b/src/app/(dashboard)/dashboard/endpoint/__tests__/EndpointPageClient.test.tsx
@@ -1,0 +1,250 @@
+// @vitest-environment jsdom
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import EndpointPageClient from "../EndpointPageClient";
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: unknown) => void;
+};
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function jsonResponse(data: unknown) {
+  return {
+    ok: true,
+    json: async () => data,
+  } as Response;
+}
+
+function getRequestPath(input: RequestInfo | URL) {
+  return typeof input === "string" ? input : input instanceof URL ? input.pathname : input.url;
+}
+
+const cleanupCallbacks: Array<() => void> = [];
+
+async function waitForText(text: string) {
+  const startedAt = Date.now();
+  while (!document.body.textContent?.includes(text)) {
+    if (Date.now() - startedAt > 1000) {
+      throw new Error(`Timed out waiting for text: ${text}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+function renderEndpointPage() {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  let mounted = true;
+
+  act(() => {
+    root.render(<EndpointPageClient machineId="" />);
+  });
+
+  const unmount = () => {
+    if (!mounted) {
+      return;
+    }
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    mounted = false;
+  };
+
+  cleanupCallbacks.push(unmount);
+
+  return {
+    unmount,
+  };
+}
+
+vi.mock("next/link", () => ({
+  default: ({ href, children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <a href={String(href)} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: (namespace?: string) => {
+    const messages: Record<string, string> = {
+      "endpoint.title": "Endpoint",
+      "endpoint.available": "Available endpoints",
+      "endpoint.loadingModels": "Loading available models...",
+      "endpoint.modelsAcrossEndpoints": "{models} models across {endpoints} endpoints",
+      "endpoint.modelsCount": "{count} models",
+      "endpoint.chatCompletions": "Chat Completions",
+      "endpoint.chatDesc": "Chat endpoint",
+      "endpoint.responses": "Responses API",
+      "endpoint.responsesDesc": "Responses endpoint",
+      "endpoint.completionsLegacy": "Completions",
+      "endpoint.completionsLegacyDesc": "Completions endpoint",
+      "endpoint.embeddings": "Embeddings",
+      "endpoint.embeddingsDesc": "Embedding endpoint",
+      "endpoint.imageGeneration": "Image Generation",
+      "endpoint.imageDesc": "Image endpoint",
+      "endpoint.audioTranscription": "Audio Transcription",
+      "endpoint.audioTranscriptionDesc": "Audio transcription endpoint",
+      "endpoint.textToSpeech": "Text to Speech",
+      "endpoint.textToSpeechDesc": "Speech endpoint",
+      "endpoint.musicGeneration": "Music Generation",
+      "endpoint.musicDesc": "Music endpoint",
+      "endpoint.videoGeneration": "Video Generation",
+      "endpoint.videoDesc": "Video endpoint",
+      "endpoint.rerank": "Rerank",
+      "endpoint.rerankDesc": "Rerank endpoint",
+      "endpoint.moderations": "Moderations",
+      "endpoint.moderationsDesc": "Moderation endpoint",
+      "endpoint.listModels": "List Models",
+      "endpoint.listModelsDesc": "List model endpoint",
+      "endpoint.overviewTitle": "Endpoint overview",
+      "endpoint.overviewDescription": "Endpoint overview description",
+      "endpoint.tabApis": "APIs",
+      "endpoint.tabProtocols": "Protocols",
+      "endpoint.categoryCore": "Core APIs",
+      "endpoint.categoryMedia": "Media APIs",
+      "endpoint.categoryUtility": "Utility APIs",
+      "endpoint.machineId": "Machine {id}",
+      "endpoint.usingLocalServer": "Using local server",
+      "common.copy": "Copy",
+      "common.cancel": "Cancel",
+    };
+
+    const translate = (key: string, values?: Record<string, unknown>) => {
+      const fullKey = namespace ? `${namespace}.${key}` : key;
+      let message = messages[fullKey] ?? key;
+      if (values) {
+        for (const [name, value] of Object.entries(values)) {
+          message = message.replace(`{${name}}`, String(value));
+        }
+      }
+      return message;
+    };
+
+    return translate;
+  },
+}));
+
+describe("EndpointPageClient", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    (
+      globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    while (cleanupCallbacks.length > 0) {
+      cleanupCallbacks.pop()?.();
+    }
+    document.body.innerHTML = "";
+    vi.unstubAllGlobals();
+  });
+
+  it("renders the endpoint shell before models finish and skips hidden tunnel probes", async () => {
+    const modelsDeferred = createDeferred<Response>();
+
+    fetchMock.mockImplementation((input: RequestInfo | URL) => {
+      const path = getRequestPath(input);
+      if (path === "/api/settings") {
+        return Promise.resolve(
+          jsonResponse({
+            cloudEnabled: false,
+            cloudConfigured: false,
+            hideEndpointCloudflaredTunnel: true,
+            hideEndpointTailscaleFunnel: true,
+            machineId: "machine-12345678",
+          })
+        );
+      }
+      if (path === "/v1/models") {
+        return modelsDeferred.promise;
+      }
+      if (path === "/api/mcp/status") {
+        return Promise.resolve(jsonResponse({ online: false }));
+      }
+      if (path === "/api/a2a/status") {
+        return Promise.resolve(jsonResponse({ status: "ok", tasks: { activeStreams: 0 } }));
+      }
+      if (path === "/api/search/providers") {
+        return Promise.resolve(jsonResponse({ providers: [] }));
+      }
+      throw new Error(`Unexpected request: ${path}`);
+    });
+
+    renderEndpointPage();
+
+    await waitForText("Endpoint");
+    expect(document.body.textContent).toContain("Loading available models...");
+    expect(fetchMock).toHaveBeenCalledWith("/v1/models");
+    expect(fetchMock).not.toHaveBeenCalledWith("/api/tunnels/cloudflared", expect.anything());
+    expect(fetchMock).not.toHaveBeenCalledWith("/api/tunnels/tailscale", expect.anything());
+
+    modelsDeferred.resolve(
+      jsonResponse({
+        data: [
+          {
+            id: "openai/gpt-4o",
+            owned_by: "openai",
+            root: "gpt-4o",
+          },
+          {
+            id: "openai/text-embedding-3-small",
+            owned_by: "openai",
+            root: "text-embedding-3-small",
+            type: "embedding",
+          },
+        ],
+      })
+    );
+
+    await waitForText("2 models across 4 endpoints");
+  });
+
+  it("does not start background endpoint requests after unmounting during settings load", async () => {
+    const settingsDeferred = createDeferred<Response>();
+    fetchMock.mockImplementation((input: RequestInfo | URL) => {
+      const path = getRequestPath(input);
+      if (path === "/api/settings") {
+        return settingsDeferred.promise;
+      }
+      throw new Error(`Unexpected request after unmount: ${path}`);
+    });
+
+    const { unmount } = renderEndpointPage();
+    unmount();
+
+    await act(async () => {
+      settingsDeferred.resolve(
+        jsonResponse({
+          cloudEnabled: false,
+          cloudConfigured: false,
+          hideEndpointCloudflaredTunnel: false,
+          hideEndpointTailscaleFunnel: false,
+        })
+      );
+      await settingsDeferred.promise;
+    });
+
+    const requestPaths = fetchMock.mock.calls.map(([input]) => getRequestPath(input));
+    expect(requestPaths.length).toBeGreaterThan(0);
+    expect(requestPaths.every((path) => path === "/api/settings")).toBe(true);
+  });
+});

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -1728,6 +1728,7 @@
     "disableCloud": "تعطيل السحابة",
     "enableCloud": "تمكين السحابة",
     "modelsAcrossEndpoints": "نماذج {models} عبر نقاط النهاية {endpoints}",
+    "loadingModels": "Loading available models...",
     "chatDesc": "الدردشة المتدفقة وغير المتدفقة مع جميع مقدمي الخدمة",
     "embeddings": "التضمين",
     "embeddingsDesc": "تضمينات نصية للبحث وخطوط أنابيب RAG",

--- a/src/i18n/messages/bg.json
+++ b/src/i18n/messages/bg.json
@@ -1728,6 +1728,7 @@
     "disableCloud": "Деактивиране на облака",
     "enableCloud": "Активиране на облака",
     "modelsAcrossEndpoints": "{models} модели в {endpoints} крайни точки",
+    "loadingModels": "Loading available models...",
     "chatDesc": "Поточно и нестрийминг чат с всички доставчици",
     "embeddings": "Вграждания",
     "embeddingsDesc": "Текстови вграждания за търсене и RAG тръбопроводи",

--- a/src/i18n/messages/bn.json
+++ b/src/i18n/messages/bn.json
@@ -1832,6 +1832,7 @@
     "disableCloud": "Disable Cloud",
     "enableCloud": "Enable Cloud",
     "modelsAcrossEndpoints": "{models} models across {endpoints} endpoints",
+    "loadingModels": "Loading available models...",
     "chatDesc": "Streaming & non-streaming chat with all providers",
     "embeddings": "Embeddings",
     "embeddingsDesc": "Text embeddings for search & RAG pipelines",

--- a/src/i18n/messages/cs.json
+++ b/src/i18n/messages/cs.json
@@ -1728,6 +1728,7 @@
     "disableCloud": "Zakázat cloud",
     "enableCloud": "Povolit cloud",
     "modelsAcrossEndpoints": "{models} modelů napříč koncovými body {endpoints}",
+    "loadingModels": "Načítání dostupných modelů...",
     "chatDesc": "Streamovací i nestreamovací chat se všemi poskytovateli",
     "embeddings": "Vkládání",
     "embeddingsDesc": "Vkládání textu pro vyhledávání a RAG kanály",

--- a/src/i18n/messages/da.json
+++ b/src/i18n/messages/da.json
@@ -1728,6 +1728,7 @@
     "disableCloud": "Deaktiver Cloud",
     "enableCloud": "Aktiver Cloud",
     "modelsAcrossEndpoints": "{models} modeller på tværs af {endpoints} slutpunkter",
+    "loadingModels": "Loading available models...",
     "chatDesc": "Streaming og ikke-streaming chat med alle udbydere",
     "embeddings": "Indlejringer",
     "embeddingsDesc": "Tekstindlejringer til søge- og RAG-pipelines",

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -1728,6 +1728,7 @@
     "disableCloud": "Cloud deaktivieren",
     "enableCloud": "Cloud aktivieren",
     "modelsAcrossEndpoints": "{models} Modelle über {endpoints} Endpunkte hinweg",
+    "loadingModels": "Loading available models...",
     "chatDesc": "Streaming- und Nicht-Streaming-Chat mit allen Anbietern",
     "embeddings": "Einbettungen",
     "embeddingsDesc": "Texteinbettungen für Such- und RAG-Pipelines",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1833,6 +1833,7 @@
     "disableCloud": "Disable Cloud",
     "enableCloud": "Enable Cloud",
     "modelsAcrossEndpoints": "{models} models across {endpoints} endpoints",
+    "loadingModels": "Loading available models...",
     "chatDesc": "Streaming & non-streaming chat with all providers",
     "embeddings": "Embeddings",
     "embeddingsDesc": "Text embeddings for search & RAG pipelines",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -1728,6 +1728,7 @@
     "disableCloud": "Deshabilitar la nube",
     "enableCloud": "Habilitar la nube",
     "modelsAcrossEndpoints": "{models} modelos en {endpoints} puntos finales",
+    "loadingModels": "Loading available models...",
     "chatDesc": "Chat streaming y no streaming con todos los proveedores",
     "embeddings": "Incrustaciones",
     "embeddingsDesc": "Inserciones de texto para búsqueda y canales RAG",

--- a/src/i18n/messages/fa.json
+++ b/src/i18n/messages/fa.json
@@ -1832,6 +1832,7 @@
     "disableCloud": "Disable Cloud",
     "enableCloud": "Enable Cloud",
     "modelsAcrossEndpoints": "{models} models across {endpoints} endpoints",
+    "loadingModels": "Loading available models...",
     "chatDesc": "Streaming & non-streaming chat with all providers",
     "embeddings": "Embeddings",
     "embeddingsDesc": "Text embeddings for search & RAG pipelines",

--- a/src/i18n/messages/fi.json
+++ b/src/i18n/messages/fi.json
@@ -1728,6 +1728,7 @@
     "disableCloud": "Poista Cloud käytöstä",
     "enableCloud": "Ota Cloud käyttöön",
     "modelsAcrossEndpoints": "{models} mallit {endpoints} päätepisteen välillä",
+    "loadingModels": "Loading available models...",
     "chatDesc": "Suoratoisto ja ei-striimaus chat kaikkien palveluntarjoajien kanssa",
     "embeddings": "Upotukset",
     "embeddingsDesc": "Tekstin upotukset haku- ja RAG-putkistoja varten",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -1728,6 +1728,7 @@
     "disableCloud": "Désactiver le cloud",
     "enableCloud": "Activer le cloud",
     "modelsAcrossEndpoints": "Modèles {models} sur {endpoints} points de terminaison",
+    "loadingModels": "Loading available models...",
     "chatDesc": "Chat en streaming et sans streaming avec tous les fournisseurs",
     "embeddings": "Intégrations",
     "embeddingsDesc": "Intégrations de texte pour les pipelines de recherche et RAG",

--- a/src/i18n/messages/gu.json
+++ b/src/i18n/messages/gu.json
@@ -1832,6 +1832,7 @@
     "disableCloud": "Disable Cloud",
     "enableCloud": "Enable Cloud",
     "modelsAcrossEndpoints": "{models} models across {endpoints} endpoints",
+    "loadingModels": "Loading available models...",
     "chatDesc": "Streaming & non-streaming chat with all providers",
     "embeddings": "Embeddings",
     "embeddingsDesc": "Text embeddings for search & RAG pipelines",

--- a/src/i18n/messages/he.json
+++ b/src/i18n/messages/he.json
@@ -1728,6 +1728,7 @@
     "disableCloud": "השבת את הענן",
     "enableCloud": "אפשר ענן",
     "modelsAcrossEndpoints": "מודלים {models} על פני {endpoints} נקודות קצה",
+    "loadingModels": "Loading available models...",
     "chatDesc": "צ'אט בסטרימינג ושלא בסטרימינג עם כל הספקים",
     "embeddings": "הטבעות",
     "embeddingsDesc": "הטמעת טקסט עבור חיפוש וצינורות RAG",

--- a/src/i18n/messages/hi.json
+++ b/src/i18n/messages/hi.json
@@ -1728,6 +1728,7 @@
     "disableCloud": "बादल अक्षम करें",
     "enableCloud": "क्लाउड सक्षम करें",
     "modelsAcrossEndpoints": "{models} मॉडल {endpoints} समापन बिंदु पर",
+    "loadingModels": "Loading available models...",
     "chatDesc": "सभी प्रदाताओं के साथ स्ट्रीमिंग और गैर-स्ट्रीमिंग चैट",
     "embeddings": "एंबेडिंग",
     "embeddingsDesc": "खोज और RAG पाइपलाइनों के लिए टेक्स्ट एम्बेडिंग",

--- a/src/i18n/messages/hu.json
+++ b/src/i18n/messages/hu.json
@@ -1728,6 +1728,7 @@
     "disableCloud": "Felhő letiltása",
     "enableCloud": "Felhő engedélyezése",
     "modelsAcrossEndpoints": "{models} modellek {endpoints} végpontokon keresztül",
+    "loadingModels": "Loading available models...",
     "chatDesc": "Streaming és nem streaming csevegés minden szolgáltatóval",
     "embeddings": "Beágyazások",
     "embeddingsDesc": "Szövegbeágyazások keresési és RAG-folyamatokhoz",

--- a/src/i18n/messages/id.json
+++ b/src/i18n/messages/id.json
@@ -1728,6 +1728,7 @@
     "disableCloud": "Nonaktifkan Awan",
     "enableCloud": "Aktifkan Awan",
     "modelsAcrossEndpoints": "{models} model di seluruh titik akhir {endpoints}",
+    "loadingModels": "Loading available models...",
     "chatDesc": "Obrolan streaming & non-streaming dengan semua penyedia",
     "embeddings": "Penyematan",
     "embeddingsDesc": "Penyematan teks untuk saluran pencarian & RAG",

--- a/src/i18n/messages/in.json
+++ b/src/i18n/messages/in.json
@@ -1832,6 +1832,7 @@
     "disableCloud": "Disable Cloud",
     "enableCloud": "Enable Cloud",
     "modelsAcrossEndpoints": "{models} models across {endpoints} endpoints",
+    "loadingModels": "Loading available models...",
     "chatDesc": "Streaming & non-streaming chat with all providers",
     "embeddings": "Embeddings",
     "embeddingsDesc": "Text embeddings for search & RAG pipelines",

--- a/src/i18n/messages/it.json
+++ b/src/i18n/messages/it.json
@@ -1728,6 +1728,7 @@
     "disableCloud": "Disabilita Nuvola",
     "enableCloud": "Abilita nuvola",
     "modelsAcrossEndpoints": "Modelli {models} sugli endpoint {endpoints}",
+    "loadingModels": "Loading available models...",
     "chatDesc": "Chat in streaming e non in streaming con tutti i provider",
     "embeddings": "Incorporamenti",
     "embeddingsDesc": "Incorporamenti di testo per pipeline di ricerca e RAG",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -1728,6 +1728,7 @@
     "disableCloud": "クラウドを無効にする",
     "enableCloud": "クラウドを有効にする",
     "modelsAcrossEndpoints": "{endpoints} エンドポイントにわたる {models} モデル",
+    "loadingModels": "Loading available models...",
     "chatDesc": "すべてのプロバイダーとのストリーミングおよび非ストリーミング チャット",
     "embeddings": "埋め込み",
     "embeddingsDesc": "検索および RAG パイプライン用のテキスト埋め込み",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -1728,6 +1728,7 @@
     "disableCloud": "클라우드 비활성화",
     "enableCloud": "클라우드 활성화",
     "modelsAcrossEndpoints": "{endpoints} 엔드포인트 전반의 {models} 모델",
+    "loadingModels": "Loading available models...",
     "chatDesc": "모든 제공업체와의 스트리밍 및 비스트리밍 채팅",
     "embeddings": "임베딩",
     "embeddingsDesc": "검색 및 RAG 파이프라인을 위한 텍스트 임베딩",

--- a/src/i18n/messages/mr.json
+++ b/src/i18n/messages/mr.json
@@ -1832,6 +1832,7 @@
     "disableCloud": "Disable Cloud",
     "enableCloud": "Enable Cloud",
     "modelsAcrossEndpoints": "{models} models across {endpoints} endpoints",
+    "loadingModels": "Loading available models...",
     "chatDesc": "Streaming & non-streaming chat with all providers",
     "embeddings": "Embeddings",
     "embeddingsDesc": "Text embeddings for search & RAG pipelines",

--- a/src/i18n/messages/ms.json
+++ b/src/i18n/messages/ms.json
@@ -1728,6 +1728,7 @@
     "disableCloud": "Lumpuhkan Cloud",
     "enableCloud": "Dayakan Cloud",
     "modelsAcrossEndpoints": "{models} model merentas {endpoints} titik akhir",
+    "loadingModels": "Loading available models...",
     "chatDesc": "Sembang penstriman & bukan penstriman dengan semua pembekal",
     "embeddings": "Embeddings",
     "embeddingsDesc": "Pembenaman teks untuk carian & saluran paip RAG",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -1728,6 +1728,7 @@
     "disableCloud": "Schakel Cloud uit",
     "enableCloud": "Schakel Cloud in",
     "modelsAcrossEndpoints": "{models} modellen voor {endpoints} eindpunten",
+    "loadingModels": "Loading available models...",
     "chatDesc": "Streaming & non-streaming chat met alle providers",
     "embeddings": "Inbedding",
     "embeddingsDesc": "Tekstinsluitingen voor zoek- en RAG-pijplijnen",

--- a/src/i18n/messages/no.json
+++ b/src/i18n/messages/no.json
@@ -1728,6 +1728,7 @@
     "disableCloud": "Deaktiver Cloud",
     "enableCloud": "Aktiver Cloud",
     "modelsAcrossEndpoints": "{models} modeller på tvers av {endpoints} endepunkter",
+    "loadingModels": "Loading available models...",
     "chatDesc": "Streaming og ikke-streaming chat med alle leverandører",
     "embeddings": "Innstøpinger",
     "embeddingsDesc": "Tekstinnbygging for søk og RAG-rørledninger",

--- a/src/i18n/messages/phi.json
+++ b/src/i18n/messages/phi.json
@@ -1728,6 +1728,7 @@
     "disableCloud": "Huwag paganahin ang Cloud",
     "enableCloud": "Paganahin ang Cloud",
     "modelsAcrossEndpoints": "{models} na mga modelo sa {endpoints} na mga endpoint",
+    "loadingModels": "Loading available models...",
     "chatDesc": "Streaming at non-streaming na chat sa lahat ng provider",
     "embeddings": "Mga pag-embed",
     "embeddingsDesc": "Mga text embed para sa paghahanap at RAG pipeline",

--- a/src/i18n/messages/pl.json
+++ b/src/i18n/messages/pl.json
@@ -1728,6 +1728,7 @@
     "disableCloud": "Wyłącz chmurę",
     "enableCloud": "Włącz chmurę",
     "modelsAcrossEndpoints": "{models} modele w {endpoints} punktach końcowych",
+    "loadingModels": "Loading available models...",
     "chatDesc": "Czat strumieniowy i niestreamingowy ze wszystkimi dostawcami",
     "embeddings": "Osadzenia",
     "embeddingsDesc": "Osadzanie tekstu dla potoków wyszukiwania i RAG",

--- a/src/i18n/messages/pt-BR.json
+++ b/src/i18n/messages/pt-BR.json
@@ -1755,6 +1755,7 @@
     "disableCloud": "Desativar Nuvem",
     "enableCloud": "Ativar Nuvem",
     "modelsAcrossEndpoints": "{models} modelos em {endpoints} endpoints",
+    "loadingModels": "Carregando modelos disponíveis...",
     "chatDesc": "Chat streaming e não-streaming com todos os provedores",
     "embeddings": "Incorporações",
     "embeddingsDesc": "Embeddings de texto para busca e pipelines RAG",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -1728,6 +1728,7 @@
     "disableCloud": "Desativar nuvem",
     "enableCloud": "Habilitar nuvem",
     "modelsAcrossEndpoints": "Modelos {models} em endpoints {endpoints}",
+    "loadingModels": "Loading available models...",
     "chatDesc": "Bate-papo com e sem streaming com todos os provedores",
     "embeddings": "Incorporações",
     "embeddingsDesc": "Incorporações de texto para pipelines de pesquisa e RAG",

--- a/src/i18n/messages/ro.json
+++ b/src/i18n/messages/ro.json
@@ -1728,6 +1728,7 @@
     "disableCloud": "Dezactivați Cloud",
     "enableCloud": "Activați Cloud",
     "modelsAcrossEndpoints": "{models} modele în {endpoints} puncte finale",
+    "loadingModels": "Loading available models...",
     "chatDesc": "Chat în flux și non-stream cu toți furnizorii",
     "embeddings": "Înglobări",
     "embeddingsDesc": "Încorporare de text pentru conductele de căutare și RAG",

--- a/src/i18n/messages/ru.json
+++ b/src/i18n/messages/ru.json
@@ -1752,6 +1752,7 @@
     "disableCloud": "Отключить облако",
     "enableCloud": "Включить облако",
     "modelsAcrossEndpoints": "{models} модели на {endpoints} конечных точках",
+    "loadingModels": "Загрузка доступных моделей...",
     "chatDesc": "Потоковое и непотоковое чат со всеми провайдерами",
     "embeddings": "Вложения",
     "embeddingsDesc": "Встраивание текста для конвейеров поиска и RAG",

--- a/src/i18n/messages/sk.json
+++ b/src/i18n/messages/sk.json
@@ -1728,6 +1728,7 @@
     "disableCloud": "Zakázať cloud",
     "enableCloud": "Povoliť cloud",
     "modelsAcrossEndpoints": "{models} modelov v {endpoints} koncových bodoch",
+    "loadingModels": "Loading available models...",
     "chatDesc": "Streaming a non-streaming chat so všetkými poskytovateľmi",
     "embeddings": "Vloženie",
     "embeddingsDesc": "Textové vloženie pre vyhľadávanie a RAG potrubia",

--- a/src/i18n/messages/sv.json
+++ b/src/i18n/messages/sv.json
@@ -1728,6 +1728,7 @@
     "disableCloud": "Inaktivera Cloud",
     "enableCloud": "Aktivera Cloud",
     "modelsAcrossEndpoints": "{models} modeller över {endpoints} slutpunkter",
+    "loadingModels": "Loading available models...",
     "chatDesc": "Strömmande och icke-strömmande chatt med alla leverantörer",
     "embeddings": "Inbäddningar",
     "embeddingsDesc": "Textinbäddningar för sök- och RAG-pipelines",

--- a/src/i18n/messages/sw.json
+++ b/src/i18n/messages/sw.json
@@ -1832,6 +1832,7 @@
     "disableCloud": "Disable Cloud",
     "enableCloud": "Enable Cloud",
     "modelsAcrossEndpoints": "{models} models across {endpoints} endpoints",
+    "loadingModels": "Loading available models...",
     "chatDesc": "Streaming & non-streaming chat with all providers",
     "embeddings": "Embeddings",
     "embeddingsDesc": "Text embeddings for search & RAG pipelines",

--- a/src/i18n/messages/ta.json
+++ b/src/i18n/messages/ta.json
@@ -1832,6 +1832,7 @@
     "disableCloud": "Disable Cloud",
     "enableCloud": "Enable Cloud",
     "modelsAcrossEndpoints": "{models} models across {endpoints} endpoints",
+    "loadingModels": "Loading available models...",
     "chatDesc": "Streaming & non-streaming chat with all providers",
     "embeddings": "Embeddings",
     "embeddingsDesc": "Text embeddings for search & RAG pipelines",

--- a/src/i18n/messages/te.json
+++ b/src/i18n/messages/te.json
@@ -1832,6 +1832,7 @@
     "disableCloud": "Disable Cloud",
     "enableCloud": "Enable Cloud",
     "modelsAcrossEndpoints": "{models} models across {endpoints} endpoints",
+    "loadingModels": "Loading available models...",
     "chatDesc": "Streaming & non-streaming chat with all providers",
     "embeddings": "Embeddings",
     "embeddingsDesc": "Text embeddings for search & RAG pipelines",

--- a/src/i18n/messages/th.json
+++ b/src/i18n/messages/th.json
@@ -1728,6 +1728,7 @@
     "disableCloud": "ปิดการใช้งานคลาวด์",
     "enableCloud": "เปิดใช้งานคลาวด์",
     "modelsAcrossEndpoints": "{models} โมเดลข้ามจุดสิ้นสุด {endpoints}",
+    "loadingModels": "Loading available models...",
     "chatDesc": "การแชทแบบสตรีมมิงและไม่สตรีมกับผู้ให้บริการทั้งหมด",
     "embeddings": "การฝัง",
     "embeddingsDesc": "การฝังข้อความสำหรับการค้นหาและไปป์ไลน์ RAG",

--- a/src/i18n/messages/tr.json
+++ b/src/i18n/messages/tr.json
@@ -1728,6 +1728,7 @@
     "disableCloud": "Bulutu Devre Dışı Bırak",
     "enableCloud": "Bulutu Etkinleştir",
     "modelsAcrossEndpoints": "{endpoints} uç noktada {models} model",
+    "loadingModels": "Kullanılabilir modeller yükleniyor...",
     "chatDesc": "Tüm sağlayıcılarla akışlı ve akışsız sohbet",
     "embeddings": "Embedding'ler",
     "embeddingsDesc": "Arama ve RAG iş akışları için metin embedding'leri",

--- a/src/i18n/messages/uk-UA.json
+++ b/src/i18n/messages/uk-UA.json
@@ -1728,6 +1728,7 @@
     "disableCloud": "Вимкнути хмару",
     "enableCloud": "Увімкнути хмару",
     "modelsAcrossEndpoints": "{models} моделей через {endpoints} кінцевих точок",
+    "loadingModels": "Loading available models...",
     "chatDesc": "Потоковий і непотоковий чат з усіма провайдерами",
     "embeddings": "Вбудовування",
     "embeddingsDesc": "Вбудовування тексту для конвеєрів пошуку та RAG",

--- a/src/i18n/messages/ur.json
+++ b/src/i18n/messages/ur.json
@@ -1832,6 +1832,7 @@
     "disableCloud": "Disable Cloud",
     "enableCloud": "Enable Cloud",
     "modelsAcrossEndpoints": "{models} models across {endpoints} endpoints",
+    "loadingModels": "Loading available models...",
     "chatDesc": "Streaming & non-streaming chat with all providers",
     "embeddings": "Embeddings",
     "embeddingsDesc": "Text embeddings for search & RAG pipelines",

--- a/src/i18n/messages/vi.json
+++ b/src/i18n/messages/vi.json
@@ -1728,6 +1728,7 @@
     "disableCloud": "Tắt đám mây",
     "enableCloud": "Kích hoạt đám mây",
     "modelsAcrossEndpoints": "{models} mô hình trên {endpoints} điểm cuối",
+    "loadingModels": "Loading available models...",
     "chatDesc": "Trò chuyện trực tuyến và không phát trực tuyến với tất cả các nhà cung cấp",
     "embeddings": "Nhúng",
     "embeddingsDesc": "Nhúng văn bản cho đường dẫn tìm kiếm & RAG",

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -1826,6 +1826,7 @@
     "disableCloud": "禁用云端",
     "enableCloud": "启用云端",
     "modelsAcrossEndpoints": "{endpoints} 个端点共提供 {models} 个模型",
+    "loadingModels": "正在加载可用模型...",
     "chatDesc": "支持所有提供商的流式与非流式聊天",
     "embeddings": "Embeddings",
     "embeddingsDesc": "用于搜索和 RAG 流程的文本向量",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,7 +7,8 @@ export default defineConfig({
     environment: "jsdom",
     globals: true,
     include: [
-      "src/app/(dashboard)/dashboard/cache/__tests__/**/*.test.tsx",
+      "src/app/**/dashboard/cache/__tests__/**/*.test.tsx",
+      "src/app/**/dashboard/endpoint/__tests__/**/*.test.tsx",
       "src/lib/memory/__tests__/**/*.test.ts",
       "src/lib/skills/__tests__/**/*.test.ts",
       "open-sse/**/__tests__/**/*.test.ts",


### PR DESCRIPTION
## Summary
- Do not request Cloudflare or Tailscale tunnel status when the corresponding Endpoint page controls are hidden.
- Render the Endpoint page shell after settings load, then fetch models, search providers, protocol status, and visible tunnel status in the background.
- Show model loading placeholders until /v1/models completes so large catalogs do not block the initial page.

## Root Cause
The Endpoint page waited for model catalog loading and tunnel status probes before leaving the global loading state. Hidden tunnel controls only affected rendering, so their status APIs still ran during startup.

## Validation
- npx eslint src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.tsx
- npm run typecheck:core
- npm run test:unit (pre-push hook)
