### PR TITLE
fix(antigravity): normalize Gemini bridge payloads

### DIFF
--- a/open-sse/config/toolCloaking.ts
+++ b/open-sse/config/toolCloaking.ts
@@ -27,7 +27,7 @@ const AG_DEFAULT_TOOL_NAMES = [
 
 const AG_DECOY_TOOL_NAMES = [
   ...AG_DEFAULT_TOOL_NAMES,
-  "mcp_sequential-thinking_sequentialthinking",
+  "mcp_sequential_thinking_sequentialthinking",
 ] as const;
 
 export const AG_DEFAULT_TOOLS = new Set<string>(AG_DEFAULT_TOOL_NAMES);

--- a/open-sse/executors/antigravity.ts
+++ b/open-sse/executors/antigravity.ts
@@ -33,10 +33,12 @@ function serializeAntigravityRequest(
   headers: Record<string, string>,
   body: unknown
 ): { headers: Record<string, string>; bodyString: string } {
+  const serializedBody = body && typeof body === "object" ? structuredClone(body) : body;
+
   if (!isCliCompatEnabled(provider)) {
-    return { headers, bodyString: JSON.stringify(body) };
+    return { headers, bodyString: JSON.stringify(serializedBody) };
   }
-  return applyFingerprint(provider, { ...headers }, body);
+  return applyFingerprint(provider, { ...headers }, serializedBody);
 }
 
 type AntigravityCollectedStream = {
@@ -585,7 +587,11 @@ export class AntigravityExecutor extends BaseExecutor {
       }
 
       try {
-        const serializedRequest = serializeAntigravityRequest(this.provider, headers, transformedBody);
+        const serializedRequest = serializeAntigravityRequest(
+          this.provider,
+          headers,
+          transformedBody
+        );
         const finalHeaders = serializedRequest.headers;
 
         const response = await fetch(url, {

--- a/open-sse/executors/antigravity.ts
+++ b/open-sse/executors/antigravity.ts
@@ -28,12 +28,24 @@ const CREDITS_EXHAUSTED_TTL_MS = 5 * 60 * 60 * 1000; // 5 hours
 
 const BARE_PRO_IDS = new Set(["gemini-3.1-pro"]);
 
+function cloneAntigravityRequestBody(body: unknown): unknown {
+  if (!body || typeof body !== "object") {
+    return body;
+  }
+
+  try {
+    return structuredClone(body);
+  } catch {
+    return JSON.parse(JSON.stringify(body));
+  }
+}
+
 function serializeAntigravityRequest(
   provider: string,
   headers: Record<string, string>,
   body: unknown
 ): { headers: Record<string, string>; bodyString: string } {
-  const serializedBody = body && typeof body === "object" ? structuredClone(body) : body;
+  const serializedBody = cloneAntigravityRequestBody(body);
 
   if (!isCliCompatEnabled(provider)) {
     return { headers, bodyString: JSON.stringify(serializedBody) };

--- a/open-sse/translator/helpers/geminiToolsSanitizer.ts
+++ b/open-sse/translator/helpers/geminiToolsSanitizer.ts
@@ -30,12 +30,17 @@ function normalizeGeminiToolName(
   options: GeminiToolSanitizationOptions = {}
 ): string {
   const trimmed = name.trim();
-  if (!options.stripNamespace) {
-    return trimmed;
-  }
+  const namespaceStripped = !options.stripNamespace
+    ? trimmed
+    : (() => {
+        const namespaceIndex = trimmed.indexOf(":");
+        return namespaceIndex >= 0 ? trimmed.slice(namespaceIndex + 1) : trimmed;
+      })();
 
-  const namespaceIndex = trimmed.indexOf(":");
-  return namespaceIndex >= 0 ? trimmed.slice(namespaceIndex + 1) : trimmed;
+  return namespaceStripped
+    .replace(/[^a-zA-Z0-9_]/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^_+|_+$/g, "");
 }
 
 function buildHashedGeminiToolName(

--- a/open-sse/translator/request/claude-to-gemini.ts
+++ b/open-sse/translator/request/claude-to-gemini.ts
@@ -7,6 +7,7 @@ import {
 } from "../helpers/geminiHelper.ts";
 import { DEFAULT_THINKING_GEMINI_SIGNATURE } from "../../config/defaultThinkingSignature.ts";
 import { buildGeminiTools, sanitizeGeminiToolName } from "../helpers/geminiToolsSanitizer.ts";
+import { capMaxOutputTokens } from "../../../src/lib/modelCapabilities.ts";
 
 /**
  * Direct Claude → Gemini request translator.
@@ -49,7 +50,7 @@ export function claudeToGeminiRequest(model, body, stream) {
     result.generationConfig.topK = body.top_k;
   }
   if (body.max_tokens !== undefined) {
-    result.generationConfig.maxOutputTokens = body.max_tokens;
+    result.generationConfig.maxOutputTokens = capMaxOutputTokens(model, body.max_tokens);
   }
 
   // ── System instruction ─────────────────────────────────────────
@@ -62,7 +63,7 @@ export function claudeToGeminiRequest(model, body, stream) {
     }
     if (systemText) {
       result.systemInstruction = {
-        role: "user",
+        role: "system",
         parts: [{ text: systemText }],
       };
     }

--- a/open-sse/translator/request/openai-to-gemini.ts
+++ b/open-sse/translator/request/openai-to-gemini.ts
@@ -186,7 +186,7 @@ function openaiToGeminiBase(model, body, stream, toolNameOptions: GeminiToolName
         if (systemText) {
           if (!result.systemInstruction) {
             result.systemInstruction = {
-              role: "user",
+              role: "system",
               parts: [{ text: systemText }],
             };
           } else {
@@ -413,7 +413,7 @@ function wrapInCloudCodeEnvelope(model, geminiCLI, credentials = null, isAntigra
     if (envelope.request.systemInstruction?.parts) {
       envelope.request.systemInstruction.parts.unshift(defaultPart);
     } else {
-      envelope.request.systemInstruction = { role: "user", parts: [defaultPart] };
+      envelope.request.systemInstruction = { role: "system", parts: [defaultPart] };
     }
 
     // Add toolConfig for Antigravity
@@ -449,6 +449,28 @@ function wrapInCloudCodeEnvelopeForClaude(model, claudeRequest, credentials = nu
 
   const cleanModel = model.includes("/") ? model.split("/").pop()! : model;
 
+  const requestedMaxOutputTokens =
+    typeof claudeRequest.max_tokens === "number" && Number.isFinite(claudeRequest.max_tokens)
+      ? claudeRequest.max_tokens
+      : 4096;
+  const generationConfig: GeminiGenerationConfig = {
+    temperature: claudeRequest.temperature || 1,
+    maxOutputTokens: capMaxOutputTokens(cleanModel, requestedMaxOutputTokens),
+  };
+  const thinkingBudget =
+    claudeRequest.thinking?.type === "enabled" &&
+    typeof claudeRequest.thinking.budget_tokens === "number" &&
+    Number.isFinite(claudeRequest.thinking.budget_tokens)
+      ? Math.floor(claudeRequest.thinking.budget_tokens)
+      : null;
+
+  if (thinkingBudget && thinkingBudget > 0) {
+    generationConfig.thinkingConfig = {
+      thinkingBudget: capThinkingBudget(cleanModel, thinkingBudget),
+      includeThoughts: true,
+    };
+  }
+
   const envelope: CloudCodeEnvelope = {
     project: projectId,
     model: cleanModel,
@@ -458,10 +480,7 @@ function wrapInCloudCodeEnvelopeForClaude(model, claudeRequest, credentials = nu
     request: {
       sessionId: generateSessionId(),
       contents: [],
-      generationConfig: {
-        temperature: claudeRequest.temperature || 1,
-        maxOutputTokens: claudeRequest.max_tokens || 4096,
-      },
+      generationConfig,
     },
   };
 
@@ -555,7 +574,7 @@ function wrapInCloudCodeEnvelopeForClaude(model, claudeRequest, credentials = nu
     }
   }
 
-  envelope.request.systemInstruction = { role: "user", parts: systemParts };
+  envelope.request.systemInstruction = { role: "system", parts: systemParts };
 
   const changedToolNameMap = buildChangedToolNameMap(toolNameMap);
   if (changedToolNameMap) {

--- a/src/shared/services/cliRuntime.ts
+++ b/src/shared/services/cliRuntime.ts
@@ -717,6 +717,19 @@ const locateCommandCandidate = async (
           reason: null,
         };
       }
+
+      if (result.installed && result.reason === "not_executable") {
+        return {
+          command: commands[0],
+          installed: true,
+          commandPath: result.commandPath,
+          reason: "not_executable",
+        };
+      }
+
+      if (result.reason && result.reason !== "not_found") {
+        return { command: commands[0], installed: false, commandPath: null, reason: "not_found" };
+      }
     }
   }
 

--- a/src/shared/services/cliRuntime.ts
+++ b/src/shared/services/cliRuntime.ts
@@ -728,7 +728,7 @@ const locateCommandCandidate = async (
       }
 
       if (result.reason && result.reason !== "not_found") {
-        return { command: commands[0], installed: false, commandPath: null, reason: "not_found" };
+        return { command: commands[0], ...result };
       }
     }
   }

--- a/tests/unit/antigravity-tool-cloaking.test.ts
+++ b/tests/unit/antigravity-tool-cloaking.test.ts
@@ -46,6 +46,10 @@ test("cloakAntigravityToolPayload cloaks custom tools, preserves native tools an
   assert.ok(names.includes(`workspace_read${AG_TOOL_SUFFIX}`));
   assert.ok(names.includes("run_command"));
   assert.ok(names.includes("browser_subagent"));
+  assert.ok(names.includes("mcp_sequential_thinking_sequentialthinking"));
+  for (const name of names) {
+    assert.match(name, /^[a-zA-Z0-9_]+$/);
+  }
   assert.equal(
     result.body.request.contents[0].parts[0].functionCall.name,
     `workspace_read${AG_TOOL_SUFFIX}`

--- a/tests/unit/cli-runtime-extended.test.ts
+++ b/tests/unit/cli-runtime-extended.test.ts
@@ -226,7 +226,7 @@ test("getCliRuntimeStatus ignores suspicious known-path binaries and symlink esc
   const suspiciousStatus = await cliRuntime.getCliRuntimeStatus("qoder");
 
   assert.equal(suspiciousStatus.installed, false);
-  assert.equal(suspiciousStatus.reason, "not_found");
+  assert.equal(suspiciousStatus.reason, "suspicious_size");
 
   if (process.platform !== "win32") {
     const escapePrefix = createTempDir("omniroute-cli-escape-");
@@ -246,7 +246,7 @@ test("getCliRuntimeStatus ignores suspicious known-path binaries and symlink esc
     const escapedStatus = await escapedRuntime.getCliRuntimeStatus("qoder");
 
     assert.equal(escapedStatus.installed, false);
-    assert.equal(escapedStatus.reason, "not_found");
+    assert.equal(escapedStatus.reason, "symlink_escape");
   }
 });
 

--- a/tests/unit/memory-route.test.ts
+++ b/tests/unit/memory-route.test.ts
@@ -67,10 +67,10 @@ test("GET /api/memory filters by q and returns matching stats", async () => {
   assert.equal(response.status, 200);
   const body = (await response.json()) as any;
 
-  assert.deepEqual(
-    body.data.map((memory) => memory.key),
-    ["typescript:tooling", "typescript:guide"]
-  );
+  assert.deepEqual(body.data.map((memory) => memory.key).sort(), [
+    "typescript:guide",
+    "typescript:tooling",
+  ]);
   assert.equal(body.total, 2);
   assert.equal(body.stats.total, 2);
   assert.deepEqual(body.stats.byType, { factual: 1, semantic: 1 });

--- a/tests/unit/translator-claude-to-gemini.test.ts
+++ b/tests/unit/translator-claude-to-gemini.test.ts
@@ -76,7 +76,7 @@ test("Claude -> Gemini maps system, thinking, tool use, tool result and tools", 
   );
 
   assert.deepEqual(result.systemInstruction, {
-    role: "user",
+    role: "system",
     parts: [{ text: "Rules" }],
   });
   assert.equal(result.contents[0].role, "model");
@@ -92,6 +92,7 @@ test("Claude -> Gemini maps system, thinking, tool use, tool result and tools", 
     },
   });
   assert.equal(result.generationConfig.maxOutputTokens, 256);
+  assert.match((result as any).tools[0].functionDeclarations[0].name, /^[a-zA-Z0-9_]+$/);
   assert.equal(result.generationConfig.temperature, 0.4);
   assert.equal(result.generationConfig.topP, 0.8);
   assert.deepEqual(result.generationConfig.thinkingConfig, {
@@ -103,6 +104,19 @@ test("Claude -> Gemini maps system, thinking, tool use, tool result and tools", 
     type: "object",
     properties: { city: { type: "string" } },
   });
+});
+
+test("Claude -> Gemini clamps maxOutputTokens to the model cap", () => {
+  const result = claudeToGeminiRequest(
+    "gemini-2.5-flash",
+    {
+      messages: [{ role: "user", content: [{ type: "text", text: "Hello" }] }],
+      max_tokens: 999999,
+    },
+    false
+  );
+
+  assert.equal(result.generationConfig.maxOutputTokens, 8192);
 });
 
 test("Claude -> Gemini converts text and base64 images to Gemini parts", () => {

--- a/tests/unit/translator-openai-to-gemini.test.ts
+++ b/tests/unit/translator-openai-to-gemini.test.ts
@@ -224,7 +224,7 @@ test("OpenAI -> Gemini request maps messages, merged system instructions, tools 
     false
   );
 
-  assert.equal((result as any).systemInstruction.role, "user");
+  assert.equal((result as any).systemInstruction.role, "system");
   assert.deepEqual((result as any).systemInstruction.parts, [
     { text: "Rule A" },
     { text: "Rule B" },
@@ -558,11 +558,15 @@ test("OpenAI -> Antigravity uses the Claude bridge for Claude-family models", ()
 
   assert.equal(result.project, "proj-claude");
   assert.equal(result.userAgent, "antigravity");
+  assert.equal((result as any).request?.systemInstruction.role, "system");
   assert.equal(
     (result as any).request?.systemInstruction.parts[0].text,
     ANTIGRAVITY_DEFAULT_SYSTEM
   );
   assert.equal((result as any).request?.systemInstruction.parts[1].text, "Project rules");
+  assert.equal((result as any).request?.generationConfig.maxOutputTokens, 8192);
+  assert.equal((result as any).request?.generationConfig.temperature, 1);
+  assert.equal((result as any).request?.generationConfig.thinkingConfig, undefined);
 
   const modelTurn = result.request.contents.find(
     (content) => content.role === "model" && content.parts.some((part) => part.functionCall)
@@ -624,6 +628,7 @@ test("OpenAI -> Antigravity Claude bridge sanitizes long names and preserves res
 
   const sanitizedToolName = (result as any).request?.tools[0].functionDeclarations[0].name;
   assert.equal(sanitizedToolName.length, 64);
+  assert.match(sanitizedToolName, /^[a-zA-Z0-9_]+$/);
   assert.equal((result as any)._toolNameMap.get(sanitizedToolName), longToolName);
 
   const modelTurn = result.request.contents.find(
@@ -637,4 +642,23 @@ test("OpenAI -> Antigravity Claude bridge sanitizes long names and preserves res
   );
   assert.ok(toolTurn, "expected a tool response turn");
   assert.equal(getFunctionResponse(toolTurn.parts[0]).name, sanitizedToolName);
+});
+
+test("OpenAI -> Antigravity Claude bridge clamps output tokens and keeps thinking budget separate", () => {
+  const result = openaiToAntigravityRequest(
+    "claude-3-7-sonnet",
+    {
+      messages: [{ role: "user", content: "Summarize this" }],
+      max_completion_tokens: 32000,
+      reasoning_effort: "high",
+    },
+    false,
+    { projectId: "proj-claude-thinking" } as any
+  );
+
+  assert.equal((result as any).request?.generationConfig.maxOutputTokens, 8192);
+  assert.deepEqual((result as any).request?.generationConfig.thinkingConfig, {
+    thinkingBudget: 131072,
+    includeThoughts: true,
+  });
 });


### PR DESCRIPTION
## Summary

- Fixes antigravity Gemini payload shaping for Claude-family bridge requests by emitting Gemini-compatible `systemInstruction.role = "system"`, clamping `maxOutputTokens` through model capabilities, and keeping reasoning/thinking budgets in `generationConfig.thinkingConfig` instead of conflating them with output token limits.
- Normalizes Gemini-facing tool names to the allowed `[a-zA-Z0-9_]+` shape, updates the antigravity decoy sequential-thinking tool name to avoid hyphenated identifiers, and preserves restore maps for original MCP/tool names through function calls and responses.
- Serializes antigravity request bodies from a cloned payload so fingerprinting and request shaping do not mutate the caller-owned body, which keeps retry/request reuse behavior safer.
- Includes two pre-push stability fixes uncovered while creating this PR: unsafe known CLI paths now stop fallback discovery instead of falling through to PATH, and the memory route test no longer relies on nondeterministic database ordering.

## Related Issues

- Closes #1748
- Related to #1748

## Validation

- [x] `npm run lint`
- [x] `npm run test:unit`
- [ ] `npm run test:coverage`
- [ ] Coverage is still `>= 60%` for statements, lines, functions, and branches
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below

Additional targeted validation run locally:

- [x] `node --import tsx/esm --test tests/unit/translator-openai-to-gemini.test.ts tests/unit/translator-claude-to-gemini.test.ts tests/unit/antigravity-tool-cloaking.test.ts tests/unit/cli-runtime-extended.test.ts`
- [x] `node --import tsx/esm --test tests/unit/memory-route.test.ts`

Notes:

- `npm run lint` exits successfully with existing repo-wide warnings only (`0 errors, 1904 warnings`).
- `npm run test:unit` passes locally (`3863 pass, 0 fail`).
- Coverage and SonarQube were not run locally for this branch.

## Tests Added Or Updated

- `tests/unit/translator-openai-to-gemini.test.ts`
  - Adds antigravity Claude bridge coverage for system role, output-token clamping, thinking budget separation, regex-safe sanitized tool names, and restore-map preservation.
- `tests/unit/translator-claude-to-gemini.test.ts`
  - Updates direct Claude -> Gemini expectations for `system` roles and adds model-cap clamping coverage.
- `tests/unit/antigravity-tool-cloaking.test.ts`
  - Asserts antigravity decoy/custom tool names remain Gemini-safe after cloaking.
- `tests/unit/memory-route.test.ts`
  - Makes the filtered memory-key assertion order-insensitive to avoid flaky full-suite/pre-push runs.

## Coverage Notes

- `open-sse/translator/request/openai-to-gemini.ts` is covered by the updated OpenAI -> Gemini and OpenAI -> Antigravity translator unit tests.
- `open-sse/translator/request/claude-to-gemini.ts` is covered by the updated Claude -> Gemini translator unit tests.
- `open-sse/translator/helpers/geminiToolsSanitizer.ts` and `open-sse/config/toolCloaking.ts` are covered by translator and antigravity tool-cloaking tests.
- `open-sse/executors/antigravity.ts` clone-safe serialization is covered indirectly by existing antigravity request paths; no standalone executor serialization test was added.
- `src/shared/services/cliRuntime.ts` is covered by `tests/unit/cli-runtime-extended.test.ts`, including the unsafe known-path and symlink-escape behavior that blocked pre-push.
- Coverage command was not run locally, so no coverage delta is reported here.

## Reviewer Notes

- Main reviewer focus: verify the Gemini Cloud Code payload contract expectations for `systemInstruction.role`, `maxOutputTokens`, and `thinkingConfig` match current antigravity/Gemini behavior.
- Tool-name normalization intentionally replaces non-alphanumeric/underscore characters with `_`, collapses duplicate underscores, and continues to store restore maps so upstream/original tool names can be recovered.
- The CLI runtime change is a security-hardening/stability fix discovered by the full pre-push suite: once a known install path is present but unsafe, suspicious, escaping, or non-executable, detection stops instead of falling back to a different PATH binary.
- The memory-route test change is test-only and avoids assuming query result ordering when the route contract being tested is filtering/stats, not ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)