### PR TITLE
fix(blackbox-web): correct cookie name and populate session/subscription fields

### DIFF
--- a/open-sse/executors/blackbox-web.ts
+++ b/open-sse/executors/blackbox-web.ts
@@ -12,6 +12,17 @@ const BLACKBOX_DEFAULT_COOKIE = "next-auth.session-token";
 const BLACKBOX_USER_AGENT =
   "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36";
 
+const SESSION_CACHE_TTL_MS = 5 * 60_000; // 5 minutes
+
+type CachedSession = {
+  sessionData: Record<string, unknown> | null;
+  subscriptionCache: Record<string, unknown> | null;
+  teamAccount: string;
+  fetchedAt: number;
+};
+
+const sessionCache = new Map<string, CachedSession>();
+
 type BlackboxMessage = {
   id: string;
   role: "user" | "assistant";
@@ -297,51 +308,72 @@ export class BlackboxWebExecutor extends BaseExecutor {
       "User-Agent": BLACKBOX_USER_AGENT,
     };
 
-    // Fetch session + subscription — Blackbox requires these in the request body
+    // Fetch session + subscription — Blackbox requires these in the request body.
+    // Cached per cookie to avoid redundant round-trips on every request.
     let sessionData: Record<string, unknown> | null = null;
     let subscriptionCache: Record<string, unknown> | null = null;
     let teamAccount = "";
 
-    try {
-      const sessionRes = await fetch("https://app.blackbox.ai/api/auth/session", {
-        method: "GET",
-        headers: { ...baseHeaders, Accept: "application/json" },
-        signal: AbortSignal.timeout(10_000),
-      });
-      sessionData = sessionRes.ok ? ((await sessionRes.json()) as Record<string, unknown>) : null;
-      const email = (sessionData as any)?.user?.email as string | undefined;
-      teamAccount = email || "";
-      log?.debug?.("BLACKBOX-WEB", `Session email: ${email ?? "none"}`);
+    const cacheKey = cookieHeader;
+    const cached = sessionCache.get(cacheKey);
+    if (cached && Date.now() - cached.fetchedAt < SESSION_CACHE_TTL_MS) {
+      sessionData = cached.sessionData;
+      subscriptionCache = cached.subscriptionCache;
+      teamAccount = cached.teamAccount;
+      log?.debug?.("BLACKBOX-WEB", `Session cache hit (${teamAccount || "no email"})`);
+    } else {
+      const sideSignal = signal
+        ? mergeAbortSignals(signal, AbortSignal.timeout(10_000))
+        : AbortSignal.timeout(10_000);
 
-      if (email) {
-        const subRes = await fetch("https://app.blackbox.ai/api/check-subscription", {
-          method: "POST",
-          headers: { ...baseHeaders, "Content-Type": "application/json" },
-          body: JSON.stringify({ email }),
-          signal: AbortSignal.timeout(10_000),
+      try {
+        const sessionRes = await fetch("https://app.blackbox.ai/api/auth/session", {
+          method: "GET",
+          headers: { ...baseHeaders, Accept: "application/json" },
+          signal: sideSignal,
         });
-        const rawSub = subRes.ok ? ((await subRes.json()) as Record<string, unknown>) : null;
-        if (rawSub) {
-          subscriptionCache = {
-            status: rawSub.hasActiveSubscription ? "PREMIUM" : "FREE",
-            customerId: rawSub.customerId ?? null,
-            expiryTimestamp: rawSub.expiryTimestamp ?? null,
-            lastChecked: Date.now(),
-            isTrialSubscription: rawSub.isTrialSubscription ?? false,
-            hasPaymentVerificationFailure: false,
-            verificationFailureTimestamp: null,
-            requiresAuthentication: false,
-            isTeam: rawSub.isTeam ?? false,
-            numSeats: rawSub.numSeats ?? 1,
-            provider: rawSub.provider ?? null,
-            previouslySubscribed: rawSub.previouslySubscribed ?? false,
-            activeInsuffientCredits: rawSub.activeInsuffientCredits ?? false,
-          };
-          log?.debug?.("BLACKBOX-WEB", `Subscription: ${subscriptionCache.status}`);
+        sessionData = sessionRes.ok ? ((await sessionRes.json()) as Record<string, unknown>) : null;
+        const email = (sessionData as any)?.user?.email as string | undefined;
+        teamAccount = email || "";
+        log?.debug?.("BLACKBOX-WEB", `Session email: ${email ?? "none"}`);
+
+        if (email) {
+          const subRes = await fetch("https://app.blackbox.ai/api/check-subscription", {
+            method: "POST",
+            headers: { ...baseHeaders, "Content-Type": "application/json" },
+            body: JSON.stringify({ email }),
+            signal: sideSignal,
+          });
+          const rawSub = subRes.ok ? ((await subRes.json()) as Record<string, unknown>) : null;
+          if (rawSub) {
+            subscriptionCache = {
+              status: rawSub.hasActiveSubscription ? "PREMIUM" : "FREE",
+              customerId: rawSub.customerId ?? null,
+              expiryTimestamp: rawSub.expiryTimestamp ?? null,
+              lastChecked: Date.now(),
+              isTrialSubscription: rawSub.isTrialSubscription ?? false,
+              hasPaymentVerificationFailure: false,
+              verificationFailureTimestamp: null,
+              requiresAuthentication: false,
+              isTeam: rawSub.isTeam ?? false,
+              numSeats: rawSub.numSeats ?? 1,
+              provider: rawSub.provider ?? null,
+              previouslySubscribed: rawSub.previouslySubscribed ?? false,
+              activeInsuffientCredits: rawSub.activeInsuffientCredits ?? false,
+            };
+            log?.debug?.("BLACKBOX-WEB", `Subscription: ${subscriptionCache.status}`);
+          }
         }
+
+        sessionCache.set(cacheKey, {
+          sessionData,
+          subscriptionCache,
+          teamAccount,
+          fetchedAt: Date.now(),
+        });
+      } catch (diagErr) {
+        log?.debug?.("BLACKBOX-WEB", `Session/subscription fetch failed (non-fatal): ${diagErr}`);
       }
-    } catch (diagErr) {
-      log?.debug?.("BLACKBOX-WEB", `Session/subscription fetch failed (non-fatal): ${diagErr}`);
     }
 
     const headers: Record<string, string> = {
@@ -396,7 +428,9 @@ export class BlackboxWebExecutor extends BaseExecutor {
         offlineMode: false,
       },
       session: sessionData,
-      isPremium: credentials.providerSpecificData?.isPremium ?? true,
+      isPremium: subscriptionCache
+        ? subscriptionCache.status === "PREMIUM"
+        : (credentials.providerSpecificData?.isPremium ?? true),
       teamAccount,
       subscriptionCache,
       beastMode: false,

--- a/open-sse/executors/blackbox-web.ts
+++ b/open-sse/executors/blackbox-web.ts
@@ -8,7 +8,7 @@ import { FETCH_TIMEOUT_MS } from "../config/constants.ts";
 import { normalizeSessionCookieHeader } from "@/lib/providers/webCookieAuth";
 
 const BLACKBOX_CHAT_API = "https://app.blackbox.ai/api/chat";
-const BLACKBOX_DEFAULT_COOKIE = "__Secure-authjs.session-token";
+const BLACKBOX_DEFAULT_COOKIE = "next-auth.session-token";
 const BLACKBOX_USER_AGENT =
   "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36";
 
@@ -290,13 +290,65 @@ export class BlackboxWebExecutor extends BaseExecutor {
     }
 
     const cookieHeader = normalizeBlackboxCookieHeader(credentials.apiKey || "");
-    const headers: Record<string, string> = {
-      Accept: "text/plain, */*",
-      "Content-Type": "application/json",
+    const baseHeaders: Record<string, string> = {
+      Accept: "application/json",
       Cookie: cookieHeader,
       Origin: "https://app.blackbox.ai",
-      Referer: `https://app.blackbox.ai/chat/${chatId}`,
       "User-Agent": BLACKBOX_USER_AGENT,
+    };
+
+    // Fetch session + subscription — Blackbox requires these in the request body
+    let sessionData: Record<string, unknown> | null = null;
+    let subscriptionCache: Record<string, unknown> | null = null;
+    let teamAccount = "";
+
+    try {
+      const sessionRes = await fetch("https://app.blackbox.ai/api/auth/session", {
+        method: "GET",
+        headers: { ...baseHeaders, Accept: "application/json" },
+        signal: AbortSignal.timeout(10_000),
+      });
+      sessionData = sessionRes.ok ? ((await sessionRes.json()) as Record<string, unknown>) : null;
+      const email = (sessionData as any)?.user?.email as string | undefined;
+      teamAccount = email || "";
+      log?.debug?.("BLACKBOX-WEB", `Session email: ${email ?? "none"}`);
+
+      if (email) {
+        const subRes = await fetch("https://app.blackbox.ai/api/check-subscription", {
+          method: "POST",
+          headers: { ...baseHeaders, "Content-Type": "application/json" },
+          body: JSON.stringify({ email }),
+          signal: AbortSignal.timeout(10_000),
+        });
+        const rawSub = subRes.ok ? ((await subRes.json()) as Record<string, unknown>) : null;
+        if (rawSub) {
+          subscriptionCache = {
+            status: rawSub.hasActiveSubscription ? "PREMIUM" : "FREE",
+            customerId: rawSub.customerId ?? null,
+            expiryTimestamp: rawSub.expiryTimestamp ?? null,
+            lastChecked: Date.now(),
+            isTrialSubscription: rawSub.isTrialSubscription ?? false,
+            hasPaymentVerificationFailure: false,
+            verificationFailureTimestamp: null,
+            requiresAuthentication: false,
+            isTeam: rawSub.isTeam ?? false,
+            numSeats: rawSub.numSeats ?? 1,
+            provider: rawSub.provider ?? null,
+            previouslySubscribed: rawSub.previouslySubscribed ?? false,
+            activeInsuffientCredits: rawSub.activeInsuffientCredits ?? false,
+          };
+          log?.debug?.("BLACKBOX-WEB", `Subscription: ${subscriptionCache.status}`);
+        }
+      }
+    } catch (diagErr) {
+      log?.debug?.("BLACKBOX-WEB", `Session/subscription fetch failed (non-fatal): ${diagErr}`);
+    }
+
+    const headers: Record<string, string> = {
+      ...baseHeaders,
+      Accept: "text/plain, */*",
+      "Content-Type": "application/json",
+      Referer: `https://app.blackbox.ai/chat/${chatId}`,
     };
     mergeUpstreamExtraHeaders(headers, upstreamExtraHeaders);
 
@@ -343,10 +395,10 @@ export class BlackboxWebExecutor extends BaseExecutor {
         webMode: false,
         offlineMode: false,
       },
-      session: null,
+      session: sessionData,
       isPremium: credentials.providerSpecificData?.isPremium ?? true,
-      teamAccount: "",
-      subscriptionCache: null,
+      teamAccount,
+      subscriptionCache,
       beastMode: false,
       reasoningMode: false,
       designerMode: false,
@@ -434,6 +486,70 @@ export class BlackboxWebExecutor extends BaseExecutor {
     }
 
     const responseText = (await readTextResponse(upstreamResponse.body, signal)).trim();
+
+    log?.debug?.("BLACKBOX-WEB", `Response (first 300 chars): ${responseText.slice(0, 300)}`);
+    log?.debug?.("BLACKBOX-WEB", `userSelectedModel sent: ${transformedBody.userSelectedModel}`);
+    log?.debug?.("BLACKBOX-WEB", `isPremium sent: ${transformedBody.isPremium}`);
+
+    // Blackbox sometimes returns HTTP 200 with in-band error messages instead of proper HTTP status codes.
+    // Detect known error patterns and surface them as real errors.
+    const lowerText = responseText.toLowerCase();
+    const isSubscriptionError =
+      /not upgraded|upgrade to a premium plan|upgrade.required/i.test(responseText) ||
+      lowerText.includes("please upgrade");
+    const isAuthError =
+      /please login|login required|authentication required/i.test(responseText) &&
+      !isSubscriptionError;
+    const isRateLimit = /rate limit|too many requests/i.test(responseText) && !isSubscriptionError;
+
+    if (isSubscriptionError) {
+      log?.warn?.("BLACKBOX-WEB", "Blackbox returned subscription error in response body");
+      const errorResponse = new Response(
+        JSON.stringify({
+          error: {
+            message:
+              "Blackbox reports your account lacks a premium subscription. " +
+              "If you have a paid plan, re-paste your session cookie from app.blackbox.ai.",
+            type: "upstream_error",
+            code: "BLACKBOX_SUBSCRIPTION_REQUIRED",
+          },
+        }),
+        { status: 402, headers: { "Content-Type": "application/json" } }
+      );
+      return { response: errorResponse, url: BLACKBOX_CHAT_API, headers, transformedBody };
+    }
+
+    if (isAuthError) {
+      log?.warn?.("BLACKBOX-WEB", "Blackbox returned auth error in response body");
+      const errorResponse = new Response(
+        JSON.stringify({
+          error: {
+            message:
+              "Blackbox session is not authenticated — re-paste next-auth.session-token from app.blackbox.ai",
+            type: "upstream_error",
+            code: "BLACKBOX_AUTH_REQUIRED",
+          },
+        }),
+        { status: 401, headers: { "Content-Type": "application/json" } }
+      );
+      return { response: errorResponse, url: BLACKBOX_CHAT_API, headers, transformedBody };
+    }
+
+    if (isRateLimit) {
+      log?.warn?.("BLACKBOX-WEB", "Blackbox returned rate-limit error in response body");
+      const errorResponse = new Response(
+        JSON.stringify({
+          error: {
+            message: "Blackbox Web rate limited the session. Wait a moment and retry.",
+            type: "upstream_error",
+            code: "BLACKBOX_RATE_LIMIT",
+          },
+        }),
+        { status: 429, headers: { "Content-Type": "application/json" } }
+      );
+      return { response: errorResponse, url: BLACKBOX_CHAT_API, headers, transformedBody };
+    }
+
     const id = `chatcmpl-blackbox-${crypto.randomUUID().slice(0, 12)}`;
     const created = Math.floor(Date.now() / 1000);
 

--- a/src/lib/providers/validation.ts
+++ b/src/lib/providers/validation.ts
@@ -2491,7 +2491,7 @@ async function validatePerplexityWebProvider({ apiKey, providerSpecificData = {}
 
 async function validateBlackboxWebProvider({ apiKey, providerSpecificData = {} }: any) {
   try {
-    const cookieHeader = normalizeSessionCookieHeader(apiKey, "__Secure-authjs.session-token");
+    const cookieHeader = normalizeSessionCookieHeader(apiKey, "next-auth.session-token");
     const sessionHeaders = applyCustomUserAgent(
       {
         Accept: "application/json",

--- a/tests/unit/blackbox-web.test.ts
+++ b/tests/unit/blackbox-web.test.ts
@@ -148,7 +148,76 @@ test("Error: 401 returns auth error", async () => {
     assert.equal(result.response.status, 401);
     const json = (await result.response.json()) as any;
     assert.match(json.error.message, /auth failed/i);
-    assert.match(json.error.message, /session cookie/i);
+    assert.match(json.error.message, /session/i);
+  } finally {
+    restore();
+  }
+});
+
+test("In-band subscription error in response body returns 402", async () => {
+  const upgradeMessage =
+    "You have not upgraded your account. " +
+    "[Please upgrade to a premium plan to continue](https://app.blackbox.ai/pricing?ref=upgrade-required).";
+  const restore = mockFetch(200, upgradeMessage);
+  try {
+    const executor = new BlackboxWebExecutor();
+    const result = await executor.execute({
+      model: "anthropic/claude-sonnet-4",
+      body: { messages: [{ role: "user", content: "hi" }], stream: false },
+      stream: false,
+      credentials: { apiKey: "bb-session-token" },
+      signal: AbortSignal.timeout(10000),
+      log: null,
+    });
+
+    assert.equal(result.response.status, 402);
+    const json = (await result.response.json()) as any;
+    assert.equal(json.error.code, "BLACKBOX_SUBSCRIPTION_REQUIRED");
+    assert.match(json.error.message, /premium subscription/i);
+  } finally {
+    restore();
+  }
+});
+
+test("In-band auth error in response body returns 401", async () => {
+  const restore = mockFetch(200, "Please login to continue.");
+  try {
+    const executor = new BlackboxWebExecutor();
+    const result = await executor.execute({
+      model: "openai/gpt-5.4",
+      body: { messages: [{ role: "user", content: "hi" }], stream: false },
+      stream: false,
+      credentials: { apiKey: "bb-session-token" },
+      signal: AbortSignal.timeout(10000),
+      log: null,
+    });
+
+    assert.equal(result.response.status, 401);
+    const json = (await result.response.json()) as any;
+    assert.equal(json.error.code, "BLACKBOX_AUTH_REQUIRED");
+    assert.match(json.error.message, /session/i);
+  } finally {
+    restore();
+  }
+});
+
+test("In-band rate limit error in response body returns 429", async () => {
+  const restore = mockFetch(200, "Rate limit exceeded. Try again later.");
+  try {
+    const executor = new BlackboxWebExecutor();
+    const result = await executor.execute({
+      model: "openai/gpt-5.4",
+      body: { messages: [{ role: "user", content: "hi" }], stream: false },
+      stream: false,
+      credentials: { apiKey: "bb-session-token" },
+      signal: AbortSignal.timeout(10000),
+      log: null,
+    });
+
+    assert.equal(result.response.status, 429);
+    const json = (await result.response.json()) as any;
+    assert.equal(json.error.code, "BLACKBOX_RATE_LIMIT");
+    assert.match(json.error.message, /rate limited/i);
   } finally {
     restore();
   }
@@ -192,11 +261,11 @@ test("Error: empty messages returns 400", async () => {
 test("Cookie normalization supports raw tokens, prefixed tokens and full headers", () => {
   assert.equal(
     normalizeBlackboxCookieHeader("raw-session-token"),
-    "__Secure-authjs.session-token=raw-session-token"
+    "next-auth.session-token=raw-session-token"
   );
   assert.equal(
     normalizeBlackboxCookieHeader("cookie:raw-session-token"),
-    "__Secure-authjs.session-token=raw-session-token"
+    "next-auth.session-token=raw-session-token"
   );
   assert.equal(
     normalizeBlackboxCookieHeader("__Secure-authjs.session-token=token; other=value"),
@@ -218,7 +287,7 @@ test("Request: posts to correct Blackbox endpoint with normalized cookie", async
     });
 
     assert.equal(cap.url, "https://app.blackbox.ai/api/chat");
-    assert.equal(cap.headers.Cookie, "__Secure-authjs.session-token=raw-session-token");
+    assert.equal(cap.headers.Cookie, "next-auth.session-token=raw-session-token");
     assert.equal(cap.headers.Origin, "https://app.blackbox.ai");
     assert.match(String(cap.headers.Referer), /^https:\/\/app\.blackbox\.ai\/chat\//);
   } finally {


### PR DESCRIPTION
## Summary

- Fix Blackbox Web cookie name: `next-auth.session-token` (not `__Secure-authjs.session-token`)
- Populate `session`, `subscriptionCache`, and `teamAccount` fields in the chat request body — without these, Blackbox silently downgrades all requests to free tier
- Detect in-band error responses (subscription/auth/rate-limit) returned as HTTP 200 and surface them as proper error codes

## Problem

The Blackbox Web provider was failing for all pro users with "You have not upgraded your account" regardless of subscription status. Root cause was threefold:

1. **Wrong cookie name** — Blackbox uses `next-auth.session-token`, the executor was sending `__Secure-authjs.session-token`
2. **Missing `subscriptionCache`** — The browser sends cached subscription data with `status: "PREMIUM"`; we sent `null`, so the server defaulted to free tier
3. **Missing `session`** — The browser sends the full session object; we sent `null`

## Verification

Captured the real browser request via `Copy as cURL` from app.blackbox.ai and compared against what the executor sends. Confirmed the three missing fields by testing each individually with curl against the live API.

All 14 blackbox-web unit tests pass. Lint and typecheck clean.