### PR TITLE
fix(antigravity): cap Claude bridge output tokens

### DIFF
--- a/open-sse/translator/request/openai-to-gemini.ts
+++ b/open-sse/translator/request/openai-to-gemini.ts
@@ -27,6 +27,12 @@ import {
 } from "../helpers/geminiHelper.ts";
 import { buildGeminiTools, sanitizeGeminiToolName } from "../helpers/geminiToolsSanitizer.ts";
 
+// Observed Antigravity wrapper output cap, not an underlying model capability.
+// Keep this bridge-local: capMaxOutputTokens() falls back to OmniRoute's generic
+// 8192 default for unknown Claude-family IDs, while Antigravity currently caps
+// visible output around 16K. See: https://github.com/keisksw/antigravity-output-analysis
+const ANTIGRAVITY_CLAUDE_MAX_OUTPUT_TOKENS = 16_384;
+
 type GeminiPart = Record<string, unknown>;
 type GeminiContent = { role: string; parts: GeminiPart[] };
 
@@ -430,7 +436,16 @@ function wrapInCloudCodeEnvelope(model, geminiCLI, credentials = null, isAntigra
   return envelope;
 }
 
-function wrapInCloudCodeEnvelopeForClaude(model, claudeRequest, credentials = null) {
+function getAntigravityClaudeOutputTokens(body: Record<string, unknown>): number {
+  const requested = body.max_tokens ?? body.max_completion_tokens;
+  const requestedNumber =
+    typeof requested === "number" && Number.isFinite(requested) && requested > 0
+      ? Math.floor(requested)
+      : null;
+  return Math.min(requestedNumber ?? ANTIGRAVITY_CLAUDE_MAX_OUTPUT_TOKENS, ANTIGRAVITY_CLAUDE_MAX_OUTPUT_TOKENS);
+}
+
+function wrapInCloudCodeEnvelopeForClaude(model, claudeRequest, credentials = null, sourceBody = {}) {
   const toolNameMap = new Map<string, string>();
   const sanitizeToolName = (name: string) =>
     sanitizeGeminiToolName(name, {
@@ -449,27 +464,10 @@ function wrapInCloudCodeEnvelopeForClaude(model, claudeRequest, credentials = nu
 
   const cleanModel = model.includes("/") ? model.split("/").pop()! : model;
 
-  const requestedMaxOutputTokens =
-    typeof claudeRequest.max_tokens === "number" && Number.isFinite(claudeRequest.max_tokens)
-      ? claudeRequest.max_tokens
-      : 4096;
   const generationConfig: GeminiGenerationConfig = {
     temperature: claudeRequest.temperature || 1,
-    maxOutputTokens: capMaxOutputTokens(cleanModel, requestedMaxOutputTokens),
+    maxOutputTokens: getAntigravityClaudeOutputTokens(sourceBody),
   };
-  const thinkingBudget =
-    claudeRequest.thinking?.type === "enabled" &&
-    typeof claudeRequest.thinking.budget_tokens === "number" &&
-    Number.isFinite(claudeRequest.thinking.budget_tokens)
-      ? Math.floor(claudeRequest.thinking.budget_tokens)
-      : null;
-
-  if (thinkingBudget && thinkingBudget > 0) {
-    generationConfig.thinkingConfig = {
-      thinkingBudget: capThinkingBudget(cleanModel, thinkingBudget),
-      includeThoughts: true,
-    };
-  }
 
   const envelope: CloudCodeEnvelope = {
     project: projectId,
@@ -590,7 +588,7 @@ export function openaiToAntigravityRequest(model, body, stream, credentials = nu
 
   if (isClaude) {
     const claudeRequest = openaiToClaudeRequestForAntigravity(model, body, stream);
-    return wrapInCloudCodeEnvelopeForClaude(model, claudeRequest, credentials);
+    return wrapInCloudCodeEnvelopeForClaude(model, claudeRequest, credentials, body);
   }
 
   const geminiCLI = openaiToGeminiCLIRequest(model, body, stream);

--- a/open-sse/translator/request/openai-to-gemini.ts
+++ b/open-sse/translator/request/openai-to-gemini.ts
@@ -438,11 +438,10 @@ function wrapInCloudCodeEnvelope(model, geminiCLI, credentials = null, isAntigra
 
 function getAntigravityClaudeOutputTokens(body: Record<string, unknown>): number {
   const requested = body.max_tokens ?? body.max_completion_tokens;
-  const requestedNumber =
-    typeof requested === "number" && Number.isFinite(requested) && requested > 0
-      ? Math.floor(requested)
-      : null;
-  return Math.min(requestedNumber ?? ANTIGRAVITY_CLAUDE_MAX_OUTPUT_TOKENS, ANTIGRAVITY_CLAUDE_MAX_OUTPUT_TOKENS);
+  if (typeof requested === "number" && Number.isFinite(requested) && requested >= 1) {
+    return Math.min(Math.floor(requested), ANTIGRAVITY_CLAUDE_MAX_OUTPUT_TOKENS);
+  }
+  return ANTIGRAVITY_CLAUDE_MAX_OUTPUT_TOKENS;
 }
 
 function wrapInCloudCodeEnvelopeForClaude(model, claudeRequest, credentials = null, sourceBody = {}) {

--- a/tests/unit/antigravity-model-aliases.test.ts
+++ b/tests/unit/antigravity-model-aliases.test.ts
@@ -7,6 +7,7 @@ import {
   toClientAntigravityModelId,
 } from "../../open-sse/config/antigravityModelAliases.ts";
 import { AntigravityExecutor } from "../../open-sse/executors/antigravity.ts";
+import { openaiToAntigravityRequest } from "../../open-sse/translator/request/openai-to-gemini.ts";
 
 test("resolveAntigravityModelId maps the documented Antigravity aliases to upstream IDs", () => {
   assert.equal(resolveAntigravityModelId("gemini-3-pro-preview"), "gemini-3.1-pro-high");
@@ -56,4 +57,28 @@ test("AntigravityExecutor.transformRequest resolves alias models before dispatch
   );
 
   assert.equal(result.model, "gemini-3.1-pro-high");
+});
+
+test("AntigravityExecutor.transformRequest keeps Claude bridge output cap and strips unsupported thinking", async () => {
+  const executor = new AntigravityExecutor();
+  const bridged = openaiToAntigravityRequest(
+    "claude-sonnet-4-6",
+    {
+      messages: [{ role: "user", content: "Hello" }],
+      max_completion_tokens: 32_000,
+      reasoning_effort: "high",
+    },
+    true,
+    { projectId: "project-1" } as any
+  );
+
+  const result = await executor.transformRequest(
+    "antigravity/claude-sonnet-4-6",
+    bridged,
+    true,
+    { projectId: "project-1" }
+  );
+
+  assert.equal(result.request.generationConfig.maxOutputTokens, 16_384);
+  assert.equal(result.request.generationConfig.thinkingConfig, undefined);
 });

--- a/tests/unit/translator-openai-to-gemini.test.ts
+++ b/tests/unit/translator-openai-to-gemini.test.ts
@@ -564,7 +564,7 @@ test("OpenAI -> Antigravity uses the Claude bridge for Claude-family models", ()
     ANTIGRAVITY_DEFAULT_SYSTEM
   );
   assert.equal((result as any).request?.systemInstruction.parts[1].text, "Project rules");
-  assert.equal((result as any).request?.generationConfig.maxOutputTokens, 8192);
+  assert.equal((result as any).request?.generationConfig.maxOutputTokens, 16384);
   assert.equal((result as any).request?.generationConfig.temperature, 1);
   assert.equal((result as any).request?.generationConfig.thinkingConfig, undefined);
 
@@ -644,7 +644,7 @@ test("OpenAI -> Antigravity Claude bridge sanitizes long names and preserves res
   assert.equal(getFunctionResponse(toolTurn.parts[0]).name, sanitizedToolName);
 });
 
-test("OpenAI -> Antigravity Claude bridge clamps output tokens and keeps thinking budget separate", () => {
+test("OpenAI -> Antigravity Claude bridge applies Antigravity output cap without forwarding thinking", () => {
   const result = openaiToAntigravityRequest(
     "claude-3-7-sonnet",
     {
@@ -656,9 +656,22 @@ test("OpenAI -> Antigravity Claude bridge clamps output tokens and keeps thinkin
     { projectId: "proj-claude-thinking" } as any
   );
 
-  assert.equal((result as any).request?.generationConfig.maxOutputTokens, 8192);
-  assert.deepEqual((result as any).request?.generationConfig.thinkingConfig, {
-    thinkingBudget: 131072,
-    includeThoughts: true,
-  });
+  assert.equal((result as any).request?.generationConfig.maxOutputTokens, 16384);
+  assert.equal((result as any).request?.generationConfig.thinkingConfig, undefined);
+});
+
+test("OpenAI -> Antigravity Claude bridge preserves lower requested output despite reasoning effort", () => {
+  const result = openaiToAntigravityRequest(
+    "claude-3-7-sonnet",
+    {
+      messages: [{ role: "user", content: "Short answer" }],
+      max_completion_tokens: 1000,
+      reasoning_effort: "high",
+    },
+    false,
+    { projectId: "proj-claude-short" } as any
+  );
+
+  assert.equal((result as any).request?.generationConfig.maxOutputTokens, 1000);
+  assert.equal((result as any).request?.generationConfig.thinkingConfig, undefined);
 });


### PR DESCRIPTION
## Summary

Follow-up to #1769 / @uwuclxdy's Antigravity Gemini bridge work.

- Keeps the Claude-family Antigravity bridge from forwarding Claude `thinkingConfig` into the Gemini Cloud Code envelope, because that field is not effective for this wrapper path and can inflate the effective budget before output clamping.
- Applies an Antigravity-local visible output cap of `16,384` tokens for Claude-family bridge requests instead of falling back to OmniRoute's generic unknown-Claude cap of `8,192`.
- Preserves lower client-requested output limits, so requests below 16K are not expanded just because `reasoning_effort` or Claude thinking conversion was present.

## Context

PR #1769 correctly separated output token limits from thinking budgets for the Gemini bridge, but the Antigravity Claude-family path still had two follow-up issues:

1. `reasoning_effort` is first converted through the Claude translator, which can raise `claudeRequest.max_tokens` to satisfy Claude's `max_tokens > thinking.budget_tokens` rule. Reusing that derived Claude value for Antigravity can overstate the user's visible output request.
2. The generic model capability fallback clamps unknown Claude-family IDs to 8K, but Antigravity's wrapper has an observed visible output ceiling around 16K.

The 16K value is treated as an observed Antigravity wrapper cap, not as an official underlying-model limit. Reference investigation:

- https://github.com/keisksw/antigravity-output-analysis

## Validation

- [x] `node --import tsx/esm --test tests/unit/translator-openai-to-gemini.test.ts tests/unit/antigravity-model-aliases.test.ts`
- [x] `npm run typecheck:core`
- [x] `npm run typecheck:noimplicit:core`
- [x] `git diff --check`

## Tests Added Or Updated

- `tests/unit/translator-openai-to-gemini.test.ts`
  - Updates Antigravity Claude bridge expectations from 8K to 16K.
  - Verifies `thinkingConfig` is not forwarded on this wrapper path.
  - Verifies lower client-requested output limits are preserved despite `reasoning_effort`.
- `tests/unit/antigravity-model-aliases.test.ts`
  - Adds executor-level coverage that the transformed Antigravity Claude request keeps the 16K bridge cap and strips unsupported thinking config.

## Reviewer Notes

- This intentionally stays bridge-local to Antigravity Claude-family requests; it does not change generic Gemini/Claude capability tables.
- This is not claiming that Claude/Gemini officially support 16K in every context. It reflects the observed Antigravity wrapper behavior from the linked investigation and avoids the too-low generic 8K fallback.