### PR TITLE
fix(codex): stabilize VS Code Copilot /responses replay state after #1750

### DIFF
--- a/open-sse/executors/codex.ts
+++ b/open-sse/executors/codex.ts
@@ -21,7 +21,11 @@ import {
   createCodexClientIdentity,
 } from "../config/codexIdentity.ts";
 import { getAccessToken } from "../services/tokenRefresh.ts";
-import { getRememberedResponseFunctionCalls } from "../services/responsesToolCallState.ts";
+import {
+  getRememberedFunctionCallsByIds,
+  getRememberedResponseConversationItems,
+  getRememberedResponseFunctionCalls,
+} from "../services/responsesToolCallState.ts";
 import { getThinkingBudgetConfig, ThinkingMode } from "../services/thinkingBudget.ts";
 import { CORS_HEADERS } from "../utils/cors.ts";
 import { createRequire } from "module";
@@ -296,6 +300,23 @@ function convertSystemToDeveloperRole(body: Record<string, unknown>): void {
   }
 }
 
+function buildRecoveredToolContextMessage(
+  droppedItems: Array<Record<string, unknown>>
+): Record<string, unknown> {
+  return {
+    type: "message",
+    role: "user",
+    content: [
+      {
+        type: "input_text",
+        text:
+          "Recovered tool context from the previous turn. Continue using this context instead of calling the same tools again unless you must.\n" +
+          JSON.stringify(droppedItems),
+      },
+    ],
+  };
+}
+
 /**
  * Strip server-generated item IDs from the input array.
  *
@@ -312,18 +333,30 @@ function convertSystemToDeveloperRole(body: Record<string, unknown>): void {
  *   3. Strips the "id" field from any object in input whose id matches a
  *      server-generated prefix (rs_, fc_, resp_, msg_) — so the content is
  *      preserved but the backend won't try to look it up
- *   4. Rehydrates missing function_call items for stateful tool-output follow-ups
- *      using locally remembered response state, then deletes previous_response_id
+ *   4. Expands locally remembered conversation snapshots for stateful follow-ups
+ *      when the upstream backend rejects previous_response_id
+ *   5. Falls back to rehydrating missing function_call items if only the older
+ *      tool-call state is available
+ *   6. Filters orphaned function_call/function_call_output items when one side
+ *      of the tool exchange is still missing after local replay/fallback repair
  */
 function stripStoredItemReferences(body: Record<string, unknown>): void {
   const hasInput = Array.isArray(body.input) && body.input.length > 0;
   const inputItems = Array.isArray(body.input) ? body.input : [];
   const previousResponseId =
     typeof body.previous_response_id === "string" ? body.previous_response_id : "";
+  const rememberedConversationItems =
+    hasInput && previousResponseId
+      ? getRememberedResponseConversationItems(previousResponseId)
+      : [];
+
+  if (rememberedConversationItems.length > 0) {
+    body.input = [...rememberedConversationItems, ...inputItems];
+  }
   const inputFunctionCallIds = new Set<string>();
   const inputFunctionCallOutputIds = new Set<string>();
 
-  for (const item of inputItems) {
+  for (const item of Array.isArray(body.input) ? body.input : []) {
     if (!item || typeof item !== "object" || Array.isArray(item)) continue;
     const record = item as Record<string, unknown>;
     const type = typeof record.type === "string" ? record.type : "";
@@ -344,9 +377,15 @@ function stripStoredItemReferences(body: Record<string, unknown>): void {
 
   if (hasInput && previousResponseId && missingFunctionCallIds.length > 0) {
     const rememberedFunctionCalls = getRememberedResponseFunctionCalls(previousResponseId);
-    const injectedFunctionCalls = rememberedFunctionCalls
+    const globallyRememberedFunctionCalls = getRememberedFunctionCallsByIds(missingFunctionCallIds);
+    const injectedFunctionCalls = [...rememberedFunctionCalls, ...globallyRememberedFunctionCalls]
       .filter((functionCall) => missingFunctionCallIds.includes(functionCall.call_id))
       .filter((functionCall) => !inputFunctionCallIds.has(functionCall.call_id))
+      .filter(
+        (functionCall, index, allFunctionCalls) =>
+          allFunctionCalls.findIndex((candidate) => candidate.call_id === functionCall.call_id) ===
+          index
+      )
       .map((functionCall) => ({
         type: "function_call",
         call_id: functionCall.call_id,
@@ -362,14 +401,91 @@ function stripStoredItemReferences(body: Record<string, unknown>): void {
     }
   }
 
-  // Strip previous_response_id whenever the request already carries input items.
-  // Codex rejects this field outright, so stateful follow-up turns must be made
-  // self-contained via the local function_call replay above.
-  //
-  // If input is missing entirely (e.g. Cursor trying to continue generation), keep
-  // previous_response_id so upstream can decide whether to fall back.
-  if (hasInput) {
-    delete body.previous_response_id;
+  const finalFunctionCallIds = new Set<string>();
+  const finalFunctionCallOutputIds = new Set<string>();
+  if (Array.isArray(body.input)) {
+    for (const item of body.input) {
+      if (!item || typeof item !== "object" || Array.isArray(item)) continue;
+      const record = item as Record<string, unknown>;
+      const type = typeof record.type === "string" ? record.type : "";
+      const callId = typeof record.call_id === "string" ? record.call_id : "";
+      if (!callId) continue;
+      if (type === "function_call") {
+        finalFunctionCallIds.add(callId);
+        continue;
+      }
+      if (type === "function_call_output") {
+        finalFunctionCallOutputIds.add(callId);
+      }
+    }
+  }
+
+  const droppedOrphanFunctionCallIds: string[] = [];
+  const droppedOrphanFunctionCallOutputIds: string[] = [];
+  const droppedOrphanItems: Array<Record<string, unknown>> = [];
+  if (Array.isArray(body.input)) {
+    body.input = body.input.filter((item) => {
+      if (!item || typeof item !== "object" || Array.isArray(item)) {
+        return true;
+      }
+
+      const record = item as Record<string, unknown>;
+      const callId = typeof record.call_id === "string" ? record.call_id : "";
+      if (!callId) {
+        return true;
+      }
+
+      if (record.type === "function_call") {
+        if (finalFunctionCallOutputIds.has(callId)) {
+          return true;
+        }
+
+        droppedOrphanFunctionCallIds.push(callId);
+        droppedOrphanItems.push({ ...record });
+        return false;
+      }
+
+      if (record.type === "function_call_output") {
+        if (finalFunctionCallIds.has(callId)) {
+          return true;
+        }
+
+        droppedOrphanFunctionCallOutputIds.push(callId);
+        droppedOrphanItems.push({ ...record });
+        return false;
+      }
+
+      return true;
+    });
+  }
+
+  if (droppedOrphanFunctionCallIds.length > 0) {
+    console.warn(
+      `[Codex] stripStoredItemReferences: dropped ${droppedOrphanFunctionCallIds.length} orphan function_call item(s): ${droppedOrphanFunctionCallIds.join(", ")}`
+    );
+  }
+
+  if (droppedOrphanFunctionCallOutputIds.length > 0) {
+    console.warn(
+      `[Codex] stripStoredItemReferences: dropped ${droppedOrphanFunctionCallOutputIds.length} orphan function_call_output item(s): ${droppedOrphanFunctionCallOutputIds.join(", ")}`
+    );
+  }
+
+  if (
+    Array.isArray(body.input) &&
+    body.input.length === 0 &&
+    droppedOrphanItems.length > 0
+  ) {
+    body.input = [buildRecoveredToolContextMessage(droppedOrphanItems)];
+    console.warn(
+      `[Codex] stripStoredItemReferences: synthesized recovery message from ${droppedOrphanItems.length} dropped orphan tool item(s)`
+    );
+  }
+
+  // Codex rejects previous_response_id for passthrough requests.
+  delete body.previous_response_id;
+  if (Array.isArray(body.input) && body.input.length === 0) {
+    delete body.input;
   }
 
   if (!Array.isArray(body.input)) return;
@@ -1150,10 +1266,8 @@ export class CodexExecutor extends BaseExecutor {
     }
     delete body.reasoning_effort;
 
-    // previous_response_id: always stripped by stripStoredItemReferences().
-    // The /codex/responses endpoint does not persist responses, so any reference
-    // to a previous response ID would cause a 404. This matches the behavior of
-    // both the official Codex CLI (sets None) and CLIProxyAPI (deletes the field).
+    // previous_response_id is expanded into a self-contained local replay when
+    // input is present because Codex rejects that parameter upstream.
 
     // Remove unsupported token limit parameters BEFORE the passthrough return.
     // Codex API rejects both max_tokens and max_output_tokens regardless of
@@ -1182,13 +1296,9 @@ export class CodexExecutor extends BaseExecutor {
 
     // Delete session_id and conversation_id from the body.
     // These are often injected by OmniRoute's fallback logic for store=true,
-    // but the upstream Codex API strictly rejects them as unsupported parameters
-    // UNLESS the request lacks input entirely (where they are required to avoid a 400 Schema Error).
+    // but the upstream Codex API strictly rejects them as unsupported parameters.
     delete body.session_id;
-    const hasInput = Array.isArray(body.input) && body.input.length > 0;
-    if (hasInput) {
-      delete body.conversation_id;
-    }
+    delete body.conversation_id;
 
     if (nativeCodexPassthrough) {
       return body;

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -3505,6 +3505,7 @@ export async function handleChatCore({
     clientResponseFormat === FORMATS.OPENAI &&
     !isResponsesEndpoint &&
     !isDroidCLI;
+  const streamStateBody = finalBody || body;
 
   if (needsResponsesTranslation) {
     // Provider returns openai-responses, translate to openai (Chat Completions) that clients expect
@@ -3517,7 +3518,7 @@ export async function handleChatCore({
       responseToolNameMap,
       model,
       connectionId,
-      body,
+      streamStateBody,
       onStreamComplete,
       apiKeyInfo,
       handleStreamFailure
@@ -3533,7 +3534,7 @@ export async function handleChatCore({
       responseToolNameMap,
       model,
       connectionId,
-      body,
+      streamStateBody,
       onStreamComplete,
       apiKeyInfo,
       handleStreamFailure
@@ -3546,7 +3547,7 @@ export async function handleChatCore({
       responseToolNameMap,
       model,
       connectionId,
-      body,
+      streamStateBody,
       onStreamComplete,
       apiKeyInfo,
       handleStreamFailure,

--- a/open-sse/services/responsesToolCallState.ts
+++ b/open-sse/services/responsesToolCallState.ts
@@ -8,6 +8,12 @@ type RememberedFunctionCall = {
 
 type RememberedResponseToolState = {
   functionCalls: RememberedFunctionCall[];
+  conversationItems: unknown[];
+  expiresAt: number;
+  updatedAt: number;
+};
+
+type RememberedFunctionCallByIdState = RememberedFunctionCall & {
   expiresAt: number;
   updatedAt: number;
 };
@@ -16,6 +22,7 @@ const RESPONSE_TOOL_CALL_TTL_MS = 30 * 60 * 1000;
 const RESPONSE_TOOL_CALL_CACHE_MAX_ENTRIES = 512;
 
 const rememberedResponseToolCalls = new Map<string, RememberedResponseToolState>();
+const rememberedFunctionCallsById = new Map<string, RememberedFunctionCallByIdState>();
 
 function toRecord(value: unknown): JsonRecord | null {
   return value && typeof value === "object" && !Array.isArray(value) ? (value as JsonRecord) : null;
@@ -28,18 +35,40 @@ function cleanupRememberedResponseToolCalls(now: number = Date.now()) {
     }
   }
 
-  if (rememberedResponseToolCalls.size <= RESPONSE_TOOL_CALL_CACHE_MAX_ENTRIES) {
-    return;
+  for (const [callId, entry] of rememberedFunctionCallsById.entries()) {
+    if (entry.expiresAt <= now) {
+      rememberedFunctionCallsById.delete(callId);
+    }
   }
 
-  const oldestEntries = [...rememberedResponseToolCalls.entries()].sort(
-    (a, b) => a[1].updatedAt - b[1].updatedAt
-  );
+  if (rememberedResponseToolCalls.size <= RESPONSE_TOOL_CALL_CACHE_MAX_ENTRIES) {
+    if (rememberedFunctionCallsById.size <= RESPONSE_TOOL_CALL_CACHE_MAX_ENTRIES) {
+      return;
+    }
+  }
 
-  while (rememberedResponseToolCalls.size > RESPONSE_TOOL_CALL_CACHE_MAX_ENTRIES) {
-    const oldest = oldestEntries.shift();
-    if (!oldest) break;
-    rememberedResponseToolCalls.delete(oldest[0]);
+  if (rememberedResponseToolCalls.size > RESPONSE_TOOL_CALL_CACHE_MAX_ENTRIES) {
+    const oldestEntries = [...rememberedResponseToolCalls.entries()].sort(
+      (a, b) => a[1].updatedAt - b[1].updatedAt
+    );
+
+    while (rememberedResponseToolCalls.size > RESPONSE_TOOL_CALL_CACHE_MAX_ENTRIES) {
+      const oldest = oldestEntries.shift();
+      if (!oldest) break;
+      rememberedResponseToolCalls.delete(oldest[0]);
+    }
+  }
+
+  if (rememberedFunctionCallsById.size > RESPONSE_TOOL_CALL_CACHE_MAX_ENTRIES) {
+    const oldestCallEntries = [...rememberedFunctionCallsById.entries()].sort(
+      (a, b) => a[1].updatedAt - b[1].updatedAt
+    );
+
+    while (rememberedFunctionCallsById.size > RESPONSE_TOOL_CALL_CACHE_MAX_ENTRIES) {
+      const oldest = oldestCallEntries.shift();
+      if (!oldest) break;
+      rememberedFunctionCallsById.delete(oldest[0]);
+    }
   }
 }
 
@@ -51,6 +80,8 @@ export function rememberResponseFunctionCalls(
   if (!normalizedResponseId || !Array.isArray(outputItems) || outputItems.length === 0) {
     return;
   }
+
+  const existingEntry = rememberedResponseToolCalls.get(normalizedResponseId);
 
   const functionCalls: RememberedFunctionCall[] = [];
 
@@ -80,8 +111,46 @@ export function rememberResponseFunctionCalls(
 
   cleanupRememberedResponseToolCalls();
 
+  const now = Date.now();
+  for (const functionCall of functionCalls) {
+    rememberedFunctionCallsById.set(functionCall.call_id, {
+      ...functionCall,
+      updatedAt: now,
+      expiresAt: now + RESPONSE_TOOL_CALL_TTL_MS,
+    });
+  }
+
   rememberedResponseToolCalls.set(normalizedResponseId, {
     functionCalls,
+    conversationItems: existingEntry?.conversationItems?.map((item) => structuredClone(item)) || [],
+    updatedAt: now,
+    expiresAt: now + RESPONSE_TOOL_CALL_TTL_MS,
+  });
+}
+
+export function rememberResponseConversationState(
+  responseId: unknown,
+  requestInput: readonly unknown[],
+  outputItems: readonly unknown[]
+) {
+  const normalizedResponseId = typeof responseId === "string" ? responseId.trim() : "";
+  if (!normalizedResponseId) {
+    return;
+  }
+
+  const normalizedRequestInput = Array.isArray(requestInput) ? requestInput : [];
+  const normalizedOutputItems = Array.isArray(outputItems) ? outputItems : [];
+  const conversationItems = [...normalizedRequestInput, ...normalizedOutputItems];
+  if (conversationItems.length === 0) {
+    return;
+  }
+
+  cleanupRememberedResponseToolCalls();
+
+  const existingEntry = rememberedResponseToolCalls.get(normalizedResponseId);
+  rememberedResponseToolCalls.set(normalizedResponseId, {
+    functionCalls: existingEntry?.functionCalls?.map((functionCall) => ({ ...functionCall })) || [],
+    conversationItems: conversationItems.map((item) => structuredClone(item)),
     updatedAt: Date.now(),
     expiresAt: Date.now() + RESPONSE_TOOL_CALL_TTL_MS,
   });
@@ -103,6 +172,46 @@ export function getRememberedResponseFunctionCalls(responseId: unknown): Remembe
   return entry.functionCalls.map((functionCall) => ({ ...functionCall }));
 }
 
+export function getRememberedResponseConversationItems(responseId: unknown): unknown[] {
+  cleanupRememberedResponseToolCalls();
+
+  const normalizedResponseId = typeof responseId === "string" ? responseId.trim() : "";
+  if (!normalizedResponseId) {
+    return [];
+  }
+
+  const entry = rememberedResponseToolCalls.get(normalizedResponseId);
+  if (!entry) {
+    return [];
+  }
+
+  return entry.conversationItems.map((item) => structuredClone(item));
+}
+
+export function getRememberedFunctionCallsByIds(callIds: readonly string[]): RememberedFunctionCall[] {
+  cleanupRememberedResponseToolCalls();
+
+  if (!Array.isArray(callIds) || callIds.length === 0) {
+    return [];
+  }
+
+  const remembered: RememberedFunctionCall[] = [];
+  for (const rawCallId of callIds) {
+    const callId = typeof rawCallId === "string" ? rawCallId.trim() : "";
+    if (!callId) continue;
+    const entry = rememberedFunctionCallsById.get(callId);
+    if (!entry) continue;
+    remembered.push({
+      call_id: entry.call_id,
+      name: entry.name,
+      arguments: entry.arguments,
+    });
+  }
+
+  return remembered;
+}
+
 export function clearRememberedResponseFunctionCallsForTesting() {
   rememberedResponseToolCalls.clear();
+  rememberedFunctionCallsById.clear();
 }

--- a/open-sse/utils/stream.ts
+++ b/open-sse/utils/stream.ts
@@ -28,7 +28,10 @@ import {
   sanitizeStreamingChunk,
   extractThinkingFromContent,
 } from "../handlers/responseSanitizer.ts";
-import { rememberResponseFunctionCalls } from "../services/responsesToolCallState.ts";
+import {
+  rememberResponseConversationState,
+  rememberResponseFunctionCalls,
+} from "../services/responsesToolCallState.ts";
 import { buildErrorBody } from "./error.ts";
 
 /**
@@ -54,6 +57,48 @@ export function withBodyTimeout<T>(
 export { COLORS, formatSSE };
 
 type JsonRecord = Record<string, unknown>;
+
+function buildResponsesOutputItemKey(item: unknown): string | null {
+  if (!item || typeof item !== "object" || Array.isArray(item)) {
+    return null;
+  }
+
+  const record = item as JsonRecord;
+  const type = typeof record.type === "string" ? record.type : "";
+  const id = typeof record.id === "string" ? record.id : "";
+  const callId = typeof record.call_id === "string" ? record.call_id : "";
+  const outputIndex = typeof record.output_index === "number" ? record.output_index : "";
+  const name = typeof record.name === "string" ? record.name : "";
+
+  if (!type && !id && !callId) {
+    return null;
+  }
+
+  return `${type}:${id}:${callId}:${outputIndex}:${name}`;
+}
+
+function pushUniqueResponsesOutputItems(target: unknown[], items: readonly unknown[]) {
+  const seen = new Set<string>();
+
+  for (const existingItem of target) {
+    const key = buildResponsesOutputItemKey(existingItem);
+    if (key) {
+      seen.add(key);
+    }
+  }
+
+  for (const item of items) {
+    const key = buildResponsesOutputItemKey(item);
+    if (key && seen.has(key)) {
+      continue;
+    }
+
+    target.push(item);
+    if (key) {
+      seen.add(key);
+    }
+  }
+}
 
 type StreamLogger = {
   appendProviderChunk?: (value: string) => void;
@@ -524,7 +569,9 @@ export function createSSEStream(options: StreamOptions = {}) {
   // used to backfill `response.completed.response.output` when upstream returns it
   // empty (which happens when `store: false` — see backfillResponsesCompletedOutput).
   const passthroughResponsesOutputItems: unknown[] = [];
+  const passthroughResponsesPendingFunctionCalls = new Map<string, JsonRecord>();
   let passthroughResponsesId: string | null = null;
+  let passthroughResponsesCurrentFunctionCallKey: string | null = null;
   const passthroughResponsesReasoningSummarySeen = new Set<string>();
   const streamStartedAt = Date.now();
 
@@ -949,12 +996,94 @@ export function createSSEStream(options: StreamOptions = {}) {
                       passthroughResponsesReasoningSummarySeen.add(reasoningKey);
                     }
                   }
+                  if (parsed.type === "response.output_item.added" && parsed.item?.type === "function_call") {
+                    const item =
+                      parsed.item && typeof parsed.item === "object" && !Array.isArray(parsed.item)
+                        ? { ...(parsed.item as JsonRecord) }
+                        : null;
+                    const pendingKey =
+                      item && typeof item.id === "string"
+                        ? item.id
+                        : item && typeof item.call_id === "string"
+                          ? item.call_id
+                          : null;
+                    if (item && pendingKey) {
+                      if (typeof item.arguments !== "string") {
+                        item.arguments = "";
+                      }
+                      passthroughResponsesPendingFunctionCalls.set(pendingKey, item);
+                      passthroughResponsesCurrentFunctionCallKey = pendingKey;
+                    }
+                  }
+                  if (parsed.type === "response.function_call_arguments.delta") {
+                    const pendingKey =
+                      typeof parsed.item_id === "string"
+                        ? parsed.item_id
+                        : passthroughResponsesCurrentFunctionCallKey;
+                    const pending = pendingKey
+                      ? passthroughResponsesPendingFunctionCalls.get(pendingKey)
+                      : undefined;
+                    if (pending && typeof parsed.delta === "string") {
+                      const previousArgs = typeof pending.arguments === "string" ? pending.arguments : "";
+                      pending.arguments = previousArgs + parsed.delta;
+                    }
+                  }
+                  if (parsed.type === "response.function_call_arguments.done") {
+                    const pendingKey =
+                      typeof parsed.item_id === "string"
+                        ? parsed.item_id
+                        : passthroughResponsesCurrentFunctionCallKey;
+                    const pending = pendingKey
+                      ? passthroughResponsesPendingFunctionCalls.get(pendingKey)
+                      : undefined;
+                    if (pending) {
+                      if (typeof parsed.arguments === "string") {
+                        pending.arguments = parsed.arguments;
+                      }
+                      pushUniqueResponsesOutputItems(passthroughResponsesOutputItems, [pending]);
+                    }
+                  }
                   // Capture each completed output item so the final
                   // response.completed snapshot can be backfilled when upstream
                   // returns an empty `output` (happens with store: false).
                   if (parsed.type === "response.output_item.done" && parsed.item) {
                     emitSyntheticResponsesReasoningSummary(controller, parsed);
-                    passthroughResponsesOutputItems.push(parsed.item);
+                    pushUniqueResponsesOutputItems(passthroughResponsesOutputItems, [parsed.item]);
+                    if (parsed.item?.type === "function_call") {
+                      const pendingKey =
+                        typeof parsed.item.id === "string"
+                          ? parsed.item.id
+                          : typeof parsed.item.call_id === "string"
+                            ? parsed.item.call_id
+                            : null;
+                      if (pendingKey) {
+                        passthroughResponsesPendingFunctionCalls.delete(pendingKey);
+                        if (passthroughResponsesCurrentFunctionCallKey === pendingKey) {
+                          passthroughResponsesCurrentFunctionCallKey = null;
+                        }
+                      }
+                    }
+                  }
+                  if (
+                    parsed.type === "response.completed" &&
+                    Array.isArray(parsed.response?.output) &&
+                    parsed.response.output.length > 0
+                  ) {
+                    pushUniqueResponsesOutputItems(
+                      passthroughResponsesOutputItems,
+                      parsed.response.output
+                    );
+                  }
+                  if (
+                    parsed.type === "response.completed" &&
+                    passthroughResponsesPendingFunctionCalls.size > 0
+                  ) {
+                    pushUniqueResponsesOutputItems(
+                      passthroughResponsesOutputItems,
+                      [...passthroughResponsesPendingFunctionCalls.values()]
+                    );
+                    passthroughResponsesPendingFunctionCalls.clear();
+                    passthroughResponsesCurrentFunctionCallKey = null;
                   }
                   // Two transport-level fixes for Responses passthrough:
                   //   1) Strip echoed `instructions` + `tools` from lifecycle
@@ -1412,6 +1541,20 @@ export function createSSEStream(options: StreamOptions = {}) {
               });
             }
             clearPendingPassthroughEvent();
+
+            if (passthroughResponsesId) {
+              const requestInput =
+                body &&
+                typeof body === "object" &&
+                Array.isArray((body as JsonRecord).input)
+                  ? ((body as JsonRecord).input as unknown[])
+                  : [];
+              rememberResponseConversationState(
+                passthroughResponsesId,
+                requestInput,
+                passthroughResponsesOutputItems
+              );
+            }
 
             if (passthroughResponsesId && passthroughResponsesOutputItems.length > 0) {
               rememberResponseFunctionCalls(

--- a/tests/unit/codex-stream-false.test.ts
+++ b/tests/unit/codex-stream-false.test.ts
@@ -11,6 +11,11 @@ const core = await import("../../src/lib/db/core.ts");
 const { handleChatCore } = await import("../../open-sse/handlers/chatCore.ts");
 const { handleComboChat } = await import("../../open-sse/services/combo.ts");
 const { CodexExecutor } = await import("../../open-sse/executors/codex.ts");
+const {
+  clearRememberedResponseFunctionCallsForTesting,
+  getRememberedResponseConversationItems,
+  rememberResponseFunctionCalls,
+} = await import("../../open-sse/services/responsesToolCallState.ts");
 
 const originalFetch = globalThis.fetch;
 
@@ -187,13 +192,85 @@ async function invokeChatCore({
 
 test.beforeEach(async () => {
   globalThis.fetch = originalFetch;
+  clearRememberedResponseFunctionCallsForTesting();
   await resetStorage();
 });
 
 test.after(async () => {
   globalThis.fetch = originalFetch;
+  clearRememberedResponseFunctionCallsForTesting();
   await resetStorage();
   fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("chatCore remembers Codex Responses conversation state from transformed body, not raw client input", async () => {
+  rememberResponseFunctionCalls("resp_prev_tool_123", [
+    {
+      type: "function_call",
+      call_id: "call_tool_123",
+      name: "workspace_read_file",
+      arguments: "{\"path\":\"README.md\"}",
+    },
+  ]);
+
+  const { result } = await invokeChatCore({
+    endpoint: "/v1/responses",
+    accept: "text/event-stream",
+    provider: "codex",
+    model: "gpt-5.5-low",
+    body: {
+      model: "gpt-5.5-low",
+      previous_response_id: "resp_prev_tool_123",
+      input: [
+        {
+          type: "function_call_output",
+          call_id: "call_tool_123",
+          output: "{\"ok\":true}",
+        },
+      ],
+    },
+    responseFactory: () =>
+      new Response(
+        [
+          "event: response.created",
+          'data: {"type":"response.created","response":{"id":"resp_current_456","model":"gpt-5.5-low","status":"in_progress","output":[]}}',
+          "",
+          "event: response.completed",
+          'data: {"type":"response.completed","response":{"id":"resp_current_456","object":"response","model":"gpt-5.5-low","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"done"}]}],"usage":{"input_tokens":6,"output_tokens":1}}}',
+          "",
+          "data: [DONE]",
+          "",
+        ].join("\n"),
+        {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        }
+      ),
+  });
+
+  assert.equal(result.success, true);
+  await result.response.text();
+  await waitForAsyncSideEffects();
+
+  const rememberedItems = getRememberedResponseConversationItems("resp_current_456");
+  const rememberedFunctionCall = rememberedItems.find(
+    (item) => item && typeof item === "object" && item.type === "function_call"
+  );
+  const rememberedFunctionCallOutput = rememberedItems.find(
+    (item) => item && typeof item === "object" && item.type === "function_call_output"
+  );
+
+  assert.deepEqual(rememberedFunctionCall, {
+    type: "function_call",
+    call_id: "call_tool_123",
+    name: "workspace_read_file",
+    arguments: "{\"path\":\"README.md\"}",
+  });
+  assert.deepEqual(rememberedFunctionCallOutput, {
+    type: "function_call_output",
+    call_id: "call_tool_123",
+    output: "{\"ok\":true}",
+  });
 });
 
 test("CodexExecutor.transformRequest clones the request body before forcing stream=true", () => {

--- a/tests/unit/executor-codex.test.ts
+++ b/tests/unit/executor-codex.test.ts
@@ -14,6 +14,7 @@ import {
 } from "../../open-sse/executors/codex.ts";
 import {
   clearRememberedResponseFunctionCallsForTesting,
+  rememberResponseConversationState,
   rememberResponseFunctionCalls,
 } from "../../open-sse/services/responsesToolCallState.ts";
 import {
@@ -300,7 +301,6 @@ test("CodexExecutor.transformRequest preserves store-enabled responses state whe
   assert.equal(result.store, true);
   assert.equal(result.previous_response_id, "resp_prev_123");
 });
-
 test("CodexExecutor.transformRequest strips store from compact requests even when store is enabled", () => {
   const executor = new CodexExecutor();
   const body = {
@@ -323,6 +323,74 @@ test("CodexExecutor.transformRequest strips store from compact requests even whe
   assert.equal(result.store, undefined);
   assert.equal(result.stream, undefined);
   assert.equal(result.instructions, "keep this");
+});
+
+test("CodexExecutor.transformRequest expands remembered conversation state for stateful tool outputs", () => {
+  const executor = new CodexExecutor();
+  rememberResponseConversationState(
+    "resp_prev_tool_123",
+    [
+      {
+        type: "message",
+        role: "user",
+        content: [
+          {
+            type: "input_text",
+            text: "Read README.md and summarize it.",
+          },
+        ],
+      },
+    ],
+    [
+      {
+        type: "function_call",
+        call_id: "call_tool_123",
+        name: "workspace_read_file",
+        arguments: "{\"path\":\"README.md\"}",
+      },
+    ]
+  );
+  const body = {
+    _nativeCodexPassthrough: true,
+    previous_response_id: "resp_prev_tool_123",
+    input: [
+      {
+        type: "function_call_output",
+        call_id: "call_tool_123",
+        output: "{\"ok\":true}",
+      },
+    ],
+    stream: false,
+  };
+
+  const result = executor.transformRequest("gpt-5.5-low", body, false, {
+    requestEndpointPath: "/responses",
+  });
+
+  assert.equal(result.previous_response_id, undefined);
+  assert.equal(result.store, false);
+  assert.equal(result.input.length, 3);
+  assert.deepEqual(result.input[0], {
+    type: "message",
+    role: "user",
+    content: [
+      {
+        type: "input_text",
+        text: "Read README.md and summarize it.",
+      },
+    ],
+  });
+  assert.deepEqual(result.input[1], {
+    type: "function_call",
+    call_id: "call_tool_123",
+    name: "workspace_read_file",
+    arguments: "{\"path\":\"README.md\"}",
+  });
+  assert.deepEqual(result.input[2], {
+    type: "function_call_output",
+    call_id: "call_tool_123",
+    output: "{\"ok\":true}",
+  });
 });
 
 test("CodexExecutor.transformRequest rehydrates missing function_call items for stateful tool outputs", () => {
@@ -364,6 +432,162 @@ test("CodexExecutor.transformRequest rehydrates missing function_call items for 
     type: "function_call_output",
     call_id: "call_tool_123",
     output: '{"ok":true}',
+  });
+});
+
+test("CodexExecutor.transformRequest filters orphaned function_call_output items after replay repair", () => {
+  const executor = new CodexExecutor();
+  const body = {
+    _nativeCodexPassthrough: true,
+    previous_response_id: "resp_prev_orphan_123",
+    input: [
+      {
+        type: "function_call",
+        call_id: "call_valid_123",
+        name: "workspace_read_file",
+        arguments: "{\"path\":\"README.md\"}",
+      },
+      {
+        type: "function_call_output",
+        call_id: "call_valid_123",
+        output: "{\"ok\":true}",
+      },
+      {
+        type: "function_call_output",
+        call_id: "call_orphan_123",
+        output: "{\"stale\":true}",
+      },
+    ],
+    stream: false,
+  };
+
+  const result = executor.transformRequest("gpt-5.5-low", body, false, {
+    requestEndpointPath: "/responses",
+  });
+
+  assert.equal(result.previous_response_id, undefined);
+  assert.equal(
+    result.input.filter((item) => item.type === "function_call_output").length,
+    1
+  );
+  assert.equal(result.input.find((item) => item.type === "function_call_output")?.call_id, "call_valid_123");
+});
+
+test("CodexExecutor.transformRequest filters orphaned function_call items after replay repair", () => {
+  const executor = new CodexExecutor();
+  const body = {
+    _nativeCodexPassthrough: true,
+    previous_response_id: "resp_prev_orphan_call_123",
+    input: [
+      {
+        type: "function_call",
+        call_id: "call_valid_456",
+        name: "workspace_read_file",
+        arguments: "{\"path\":\"README.md\"}",
+      },
+      {
+        type: "function_call_output",
+        call_id: "call_valid_456",
+        output: "{\"ok\":true}",
+      },
+      {
+        type: "function_call",
+        call_id: "call_orphan_456",
+        name: "workspace_search",
+        arguments: "{\"query\":\"Authorization\"}",
+      },
+    ],
+    stream: false,
+  };
+
+  const result = executor.transformRequest("gpt-5.5-low", body, false, {
+    requestEndpointPath: "/responses",
+  });
+
+  assert.equal(result.previous_response_id, undefined);
+  assert.equal(result.input.filter((item) => item.type === "function_call").length, 1);
+  assert.equal(result.input.find((item) => item.type === "function_call")?.call_id, "call_valid_456");
+});
+
+test("CodexExecutor.transformRequest synthesizes a recovery message when orphan cleanup empties input", () => {
+  const executor = new CodexExecutor();
+  const body = {
+    _nativeCodexPassthrough: true,
+    conversation_id: "conv_empty_after_cleanup",
+    session_id: "sess_empty_after_cleanup",
+    previous_response_id: "resp_prev_empty_after_cleanup",
+    input: [
+      {
+        type: "function_call",
+        call_id: "call_orphan_only_1",
+        name: "workspace_search",
+        arguments: "{\"query\":\"auth\"}",
+      },
+      {
+        type: "function_call_output",
+        call_id: "call_orphan_only_2",
+        output: "{\"matches\":1}",
+      },
+    ],
+    stream: false,
+  };
+
+  const result = executor.transformRequest("gpt-5.5-low", body, false, {
+    requestEndpointPath: "/responses",
+  });
+
+  assert.equal(result.previous_response_id, undefined);
+  assert.equal(result.conversation_id, undefined);
+  assert.equal(result.session_id, undefined);
+  assert.equal(result.prompt_cache_key, "conv_empty_after_cleanup");
+  assert.equal(Array.isArray(result.input), true);
+  assert.equal(result.input.length, 1);
+  assert.deepEqual(result.input[0].type, "message");
+  assert.deepEqual(result.input[0].role, "user");
+  assert.match(result.input[0].content[0].text, /Recovered tool context from the previous turn/);
+  assert.match(result.input[0].content[0].text, /call_orphan_only_1/);
+  assert.match(result.input[0].content[0].text, /call_orphan_only_2/);
+});
+
+test("CodexExecutor.transformRequest repairs orphan function_call_output from global remembered call_id cache", () => {
+  const executor = new CodexExecutor();
+  rememberResponseFunctionCalls("resp_older_tool_123", [
+    {
+      type: "function_call",
+      call_id: "call_old_123",
+      name: "workspace_search",
+      arguments: "{\"query\":\"Authorization\"}",
+    },
+  ]);
+
+  const body = {
+    _nativeCodexPassthrough: true,
+    previous_response_id: "resp_prev_without_that_call",
+    input: [
+      {
+        type: "function_call_output",
+        call_id: "call_old_123",
+        output: "{\"matches\":1}",
+      },
+    ],
+    stream: false,
+  };
+
+  const result = executor.transformRequest("gpt-5.5-low", body, false, {
+    requestEndpointPath: "/responses",
+  });
+
+  assert.equal(result.previous_response_id, undefined);
+  assert.deepEqual(result.input[0], {
+    type: "function_call",
+    call_id: "call_old_123",
+    name: "workspace_search",
+    arguments: "{\"query\":\"Authorization\"}",
+  });
+  assert.deepEqual(result.input[1], {
+    type: "function_call_output",
+    call_id: "call_old_123",
+    output: "{\"matches\":1}",
   });
 });
 test("CodexExecutor.transformRequest applies per-connection reasoning and service tier defaults", () => {

--- a/tests/unit/stream-utilities.test.ts
+++ b/tests/unit/stream-utilities.test.ts
@@ -133,6 +133,53 @@ test("createPassthroughStreamWithLogger synthesizes reasoning summary events fro
   assert.match(result, /event: response\.output_item\.done/);
 });
 
+test("createPassthroughStreamWithLogger backfills completed output from function_call arguments events", async () => {
+  const transform = createPassthroughStreamWithLogger(
+    "codex",
+    null,
+    null,
+    "gpt-5.5-low",
+    null,
+    null,
+    null,
+    null,
+    null,
+    "openai-responses"
+  );
+
+  const writer = transform.writable.getWriter();
+  await writer.write(
+    new TextEncoder().encode(
+      [
+        'data: {"type":"response.created","response":{"id":"resp_fc_1"}}',
+        'event: response.output_item.added',
+        'data: {"type":"response.output_item.added","response_id":"resp_fc_1","output_index":0,"item":{"id":"fc_call_1","type":"function_call","call_id":"call_1","name":"workspace_read_file","arguments":""}}',
+        'event: response.function_call_arguments.done',
+        'data: {"type":"response.function_call_arguments.done","response_id":"resp_fc_1","output_index":0,"item_id":"fc_call_1","arguments":"{\"path\":\"README.md\"}"}',
+        'event: response.completed',
+        'data: {"type":"response.completed","response":{"id":"resp_fc_1","status":"completed","output":[],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}}',
+        "",
+      ].join("\n")
+    )
+  );
+  await writer.close();
+
+  const reader = transform.readable.getReader();
+  const decoder = new TextDecoder();
+  let result = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    result += decoder.decode(value);
+  }
+
+  assert.match(result, /event: response\.completed/);
+  assert.match(result, /"type":"function_call"/);
+  assert.match(result, /"call_id":"call_1"/);
+  assert.match(result, /"arguments":"\\{\\\"path\\\":\\\"README\.md\\\"\\}"/);
+});
+
 test("createStreamController returns valid controller", () => {
   let completeLogged = false;
   let disconnectLogged = false;


### PR DESCRIPTION
## Summary

- continue the Codex/Copilot `/v1/responses` stabilization from #1750 for both VS Code GitHub Copilot BYOK via `/v1/responses#models.ai.azure.com` and Custom OAI `/v1/responses` in VS Code Insiders
- persist the Responses replay state from the **actual transformed Codex request** instead of the raw client payload so long multi-tool Copilot sessions keep their machine-readable tool chain
- extend the local Codex compatibility layer with remembered conversation snapshots, function-call reconstruction from Responses SSE, orphan repair/filtering, and a last-resort text recovery fallback when Codex-compatible self-contained replay would otherwise become empty
- add targeted regression coverage for the transformed replay-state path and for the extended Responses stream/tool-follow-up repair logic

## Problem

After #1750, Copilot `/v1/responses` flows were much more stable, but long real-world sessions in VS Code could still drift after several tool calls.

The failure mode looked like this:

- Copilot invoked several tools successfully
- then a later follow-up turn lost part of the machine-readable tool context
- OmniRoute started logging orphan `function_call` / `function_call_output` items
- Codex still returned a text response, but Copilot stopped behaving like a tool-calling agent and prematurely emitted a report to chat instead of continuing the task

The core bug was that the Responses replay state used on follow-up turns was being remembered from the raw client `body` rather than from the transformed request that OmniRoute actually sent upstream to Codex. That mismatch let repaired `function_call` items fall out of the remembered conversation snapshot, which then caused orphan drift on later turns.

## What changed

### Replay state / executor

- expand remembered conversation snapshots when rebuilding Codex self-contained follow-up requests
- remember function calls globally by `call_id` so a later follow-up can still repair missing tool-call items even when the immediate `response_id` snapshot is incomplete
- filter orphan `function_call` / `function_call_output` pairs only after repair attempts, with explicit logging
- if cleanup would leave an empty Codex request, synthesize a conservative recovery message instead of sending an invalid empty request or unsupported state anchor

### Stream handling

- collect/deduplicate Responses output items more aggressively during SSE passthrough
- reconstruct function calls from incremental Responses events such as:
  - `response.output_item.added`
  - `response.function_call_arguments.delta`
  - `response.function_call_arguments.done`
  - `response.output_item.done`
  - `response.completed`
- persist remembered conversation snapshots on stream completion

### `chatCore` integration

- pass the transformed `finalBody` into the streaming pipeline so the remembered replay state matches the actual Codex request that was forwarded upstream
- this is the key fix for the long-session Copilot tool-context drift

## Manual validation

Manual testing in the target environment after the full patch series shows the previously failing long Copilot `/v1/responses` sessions now remain stable, including extended multi-tool flows where the old implementation eventually degraded with loss of part of the context.

## Validation

- [ ] `npm run lint`
- [ ] `npm run test:unit`
- [ ] `npm run test:coverage`
- [ ] Coverage is still `>= 60%` for statements, lines, functions, and branches
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below

## Tests Added Or Updated

- `tests/unit/codex-stream-false.test.ts`
- `tests/unit/executor-codex.test.ts`
- `tests/unit/stream-utilities.test.ts`

## Coverage Notes

- Production code changed in:
  - `open-sse/executors/codex.ts`
  - `open-sse/handlers/chatCore.ts`
  - `open-sse/services/responsesToolCallState.ts`
  - `open-sse/utils/stream.ts`

## Related

- Continues / complements #1750
- Focuses on VS Code GitHub Copilot `/v1/responses` support for Codex in long tool-calling sessions
