### PR TITLE
fix(chatgpt-web): restore validator + expand model catalog to ChatGPT Plus tier

### DIFF
--- a/open-sse/config/providerRegistry.ts
+++ b/open-sse/config/providerRegistry.ts
@@ -1087,7 +1087,21 @@ export const REGISTRY: Record<string, RegistryEntry> = {
     baseUrl: "https://chatgpt.com/backend-api/conversation",
     authType: "apikey",
     authHeader: "cookie",
-    models: [{ id: "gpt-5.3-instant", name: "GPT-5.3 Instant (via ChatGPT Web)" }],
+    models: [
+      { id: "gpt-5.3-instant", name: "GPT-5.3 Instant" },
+      { id: "gpt-5.3", name: "GPT-5.3" },
+      { id: "gpt-5.3-mini", name: "GPT-5.3 Mini" },
+      { id: "gpt-5.5-thinking", name: "GPT-5.5 Thinking" },
+      { id: "gpt-5.4-thinking", name: "GPT-5.4 Thinking" },
+      { id: "gpt-5.4-thinking-mini", name: "GPT-5.4 Thinking Mini" },
+      { id: "gpt-5.2-instant", name: "GPT-5.2 Instant" },
+      { id: "gpt-5.2", name: "GPT-5.2" },
+      { id: "gpt-5.2-thinking", name: "GPT-5.2 Thinking" },
+      { id: "gpt-5.1", name: "GPT-5.1" },
+      { id: "gpt-5", name: "GPT-5" },
+      { id: "gpt-5-mini", name: "GPT-5 Mini" },
+      { id: "o3", name: "o3" },
+    ],
   },
 
   "grok-web": {

--- a/open-sse/executors/chatgpt-web.ts
+++ b/open-sse/executors/chatgpt-web.ts
@@ -71,11 +71,25 @@ function deviceIdFor(cookie: string): string {
   return id;
 }
 
-// OmniRoute model ID → ChatGPT internal slug. ChatGPT's web routes use
-// dash-separated IDs (e.g. "gpt-5-3" not "gpt-5.3-instant").
+// OmniRoute model ID → ChatGPT internal slug. OmniRoute uses dot-form IDs
+// (e.g. "gpt-5.3-instant"), ChatGPT's web routes use dash-form
+// (e.g. "gpt-5-3-instant"). The slug catalog comes from
+// /backend-api/models on a logged-in account; "gpt-5-4-t-mini" is ChatGPT's
+// abbreviated slug for "GPT-5.4 Thinking Mini".
 const MODEL_MAP: Record<string, string> = {
-  "gpt-5.3-instant": "gpt-5-3",
-  "gpt-5-3": "gpt-5-3",
+  "gpt-5.3-instant": "gpt-5-3-instant",
+  "gpt-5.3": "gpt-5-3",
+  "gpt-5.3-mini": "gpt-5-3-mini",
+  "gpt-5.5-thinking": "gpt-5-5-thinking",
+  "gpt-5.4-thinking": "gpt-5-4-thinking",
+  "gpt-5.4-thinking-mini": "gpt-5-4-t-mini",
+  "gpt-5.2-instant": "gpt-5-2-instant",
+  "gpt-5.2": "gpt-5-2",
+  "gpt-5.2-thinking": "gpt-5-2-thinking",
+  "gpt-5.1": "gpt-5-1",
+  "gpt-5": "gpt-5",
+  "gpt-5-mini": "gpt-5-mini",
+  o3: "o3",
 };
 
 // ─── Browser-like default headers ──────────────────────────────────────────

--- a/src/lib/providers/validation.ts
+++ b/src/lib/providers/validation.ts
@@ -2409,6 +2409,114 @@ async function validateGrokWebProvider({ apiKey, providerSpecificData = {} }: an
   }
 }
 
+async function validateChatGptWebProvider({ apiKey, providerSpecificData = {} }: any) {
+  try {
+    // Accept bare value, unchunked cookie, chunked (.0/.1) cookies, or full
+    // "Cookie: ..." DevTools line. Pass through verbatim once recognised.
+    let cookieHeader = String(apiKey || "").trim();
+    if (/^cookie\s*:\s*/i.test(cookieHeader)) {
+      cookieHeader = cookieHeader.replace(/^cookie\s*:\s*/i, "");
+    }
+    if (!/__Secure-next-auth\.session-token(?:\.\d+)?\s*=/.test(cookieHeader)) {
+      cookieHeader = `__Secure-next-auth.session-token=${cookieHeader}`;
+    }
+
+    // Use the TLS-impersonating client — Cloudflare on chatgpt.com pins
+    // cf_clearance to JA3/JA4 + HTTP/2 SETTINGS, so plain Node fetch always
+    // gets cf-mitigated: challenge regardless of cookies.
+    const { tlsFetchChatGpt, TlsClientUnavailableError } =
+      await import("@omniroute/open-sse/services/chatgptTlsClient.ts");
+
+    let response;
+    try {
+      response = await tlsFetchChatGpt("https://chatgpt.com/api/auth/session", {
+        method: "GET",
+        headers: applyCustomUserAgent(
+          {
+            Accept: "application/json",
+            "Accept-Language": "en-US,en;q=0.9",
+            "Cache-Control": "no-cache",
+            Cookie: cookieHeader,
+            Origin: "https://chatgpt.com",
+            Pragma: "no-cache",
+            Referer: "https://chatgpt.com/",
+            "Sec-Fetch-Dest": "empty",
+            "Sec-Fetch-Mode": "cors",
+            "Sec-Fetch-Site": "same-origin",
+            "User-Agent":
+              "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:150.0) Gecko/20100101 Firefox/150.0",
+          },
+          providerSpecificData
+        ),
+        timeoutMs: 30_000,
+      });
+    } catch (err: any) {
+      if (err instanceof TlsClientUnavailableError) {
+        return {
+          valid: false,
+          error: `${err.message} (chatgpt-web requires this — without it, Cloudflare blocks every request)`,
+        };
+      }
+      throw err;
+    }
+
+    const contentType = response.headers.get("content-type") || "";
+    const cfRay = response.headers.get("cf-ray");
+    const cfMitigated = response.headers.get("cf-mitigated");
+
+    if (response.status === 401 || response.status === 403) {
+      const bodyText = response.text || "";
+      if (cfMitigated || /just a moment|cloudflare|cf-chl|attention required/i.test(bodyText)) {
+        return {
+          valid: false,
+          error:
+            "Cloudflare blocked the validator — open chatgpt.com in your browser, then copy the FULL Cookie line from DevTools (Network → request → Cookie) including cf_clearance, __cf_bm, _cfuvid, and the session-token chunks.",
+        };
+      }
+      return {
+        valid: false,
+        error:
+          "Invalid ChatGPT session cookie — re-paste __Secure-next-auth.session-token from chatgpt.com DevTools → Cookies",
+      };
+    }
+
+    if (response.status >= 500) {
+      return { valid: false, error: `ChatGPT unavailable (${response.status})` };
+    }
+
+    if (response.status >= 400) {
+      return { valid: false, error: `Validation failed: ${response.status}` };
+    }
+
+    if (!contentType.includes("json")) {
+      return {
+        valid: false,
+        error: `ChatGPT returned non-JSON (${contentType || "no content-type"}${cfRay ? `, cf-ray=${cfRay}` : ""}) — paste the FULL Cookie line including cf_clearance, __cf_bm, _cfuvid alongside the session-token chunks.`,
+      };
+    }
+
+    let data: any = {};
+    try {
+      data = JSON.parse(response.text || "{}");
+    } catch {
+      return {
+        valid: false,
+        error:
+          "ChatGPT session response was not JSON — paste the FULL Cookie line including cf_clearance and __cf_bm.",
+      };
+    }
+    if (!data?.accessToken) {
+      return {
+        valid: false,
+        error: "ChatGPT session expired — log into chatgpt.com and copy a fresh cookie",
+      };
+    }
+    return { valid: true, error: null };
+  } catch (error: any) {
+    return toValidationErrorResult(error);
+  }
+}
+
 async function validatePerplexityWebProvider({ apiKey, providerSpecificData = {} }: any) {
   try {
     let sessionToken = apiKey;
@@ -2747,6 +2855,7 @@ export async function validateProviderApiKey({ provider, apiKey, providerSpecifi
     snowflake: validateSnowflakeProvider,
     gigachat: validateGigachatProvider,
     "grok-web": validateGrokWebProvider,
+    "chatgpt-web": validateChatGptWebProvider,
     "perplexity-web": validatePerplexityWebProvider,
     "blackbox-web": validateBlackboxWebProvider,
     "muse-spark-web": validateMuseSparkWebProvider,

--- a/tests/unit/chatgpt-web.test.ts
+++ b/tests/unit/chatgpt-web.test.ts
@@ -199,8 +199,8 @@ function installMockFetch({
         };
       }
       const tinyPng = Buffer.from([
-        0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
-        0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+        0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44,
+        0x52,
       ]);
       return {
         status: cfg.status,
@@ -1040,7 +1040,7 @@ test("Request: payload has correct ChatGPT shape", async () => {
     const convIdx = m.calls.urls.findIndex((u) => u.endsWith("/backend-api/f/conversation"));
     const body = JSON.parse(m.calls.bodies[convIdx]);
     assert.equal(body.action, "next");
-    assert.equal(body.model, "gpt-5-3");
+    assert.equal(body.model, "gpt-5-3-instant");
     // Plain text request → Temporary Chat stays ON. We disable it only for
     // image-gen prompts (see "Image gen: image-intent prompts" tests below).
     assert.equal(body.history_and_training_disabled, true);
@@ -1057,14 +1057,67 @@ test("Request: payload has correct ChatGPT shape", async () => {
 
 // ─── Provider registry ──────────────────────────────────────────────────────
 
-test("Provider registry: chatgpt-web is registered with gpt-5.3-instant model", async () => {
+test("Provider registry: chatgpt-web exposes the full ChatGPT Plus model catalog", async () => {
   const { getRegistryEntry } = await import("../../open-sse/config/providerRegistry.ts");
   const entry = getRegistryEntry("chatgpt-web");
   assert.ok(entry, "chatgpt-web should be in the registry");
   assert.equal(entry.executor, "chatgpt-web");
   assert.equal(entry.format, "openai");
   assert.equal(entry.authHeader, "cookie");
-  assert.ok(entry.models.find((m) => m.id === "gpt-5.3-instant"));
+
+  const ids = (entry.models || []).map((m) => m.id);
+  // Mirrors /backend-api/models for a Plus account (no "research" or
+  // "agent-mode" — those are specialty surfaces, not chat models).
+  for (const id of [
+    "gpt-5.3-instant",
+    "gpt-5.3",
+    "gpt-5.3-mini",
+    "gpt-5.5-thinking",
+    "gpt-5.4-thinking",
+    "gpt-5.4-thinking-mini",
+    "gpt-5.2-instant",
+    "gpt-5.2",
+    "gpt-5.2-thinking",
+    "gpt-5.1",
+    "gpt-5",
+    "gpt-5-mini",
+    "o3",
+  ]) {
+    assert.ok(ids.includes(id), `registry should list ${id}`);
+  }
+});
+
+test("Executor MODEL_MAP: dot-form OmniRoute IDs translate to dash-form ChatGPT slugs", async () => {
+  reset();
+  const m = installMockFetch();
+  try {
+    const cases: Array<[string, string]> = [
+      ["gpt-5.3-instant", "gpt-5-3-instant"],
+      ["gpt-5.3", "gpt-5-3"],
+      ["gpt-5.5-thinking", "gpt-5-5-thinking"],
+      ["gpt-5.4-thinking-mini", "gpt-5-4-t-mini"],
+      ["gpt-5.2-thinking", "gpt-5-2-thinking"],
+      ["o3", "o3"],
+    ];
+    for (const [omniId, expectedSlug] of cases) {
+      m.calls.urls.length = 0;
+      m.calls.bodies.length = 0;
+      const executor = new ChatGptWebExecutor();
+      await executor.execute({
+        model: omniId,
+        body: { messages: [{ role: "user", content: "hi" }] },
+        stream: false,
+        credentials: { apiKey: "test" },
+        signal: AbortSignal.timeout(10_000),
+        log: null,
+      });
+      const convIdx = m.calls.urls.findIndex((u) => u.endsWith("/backend-api/f/conversation"));
+      const body = JSON.parse(m.calls.bodies[convIdx]);
+      assert.equal(body.model, expectedSlug, `${omniId} should map to ${expectedSlug}`);
+    }
+  } finally {
+    m.restore();
+  }
 });
 
 test("Image registry: cgpt-web/gpt-5.3-instant routes to ChatGPT Web image handler", async () => {
@@ -1647,7 +1700,11 @@ test("Image gen: sediment:// pointer prefers /files/<id>/download over /attachme
     // round-trip); the /attachment endpoint is a fallback for when the
     // primary 404s. The mock /files/ response also doubles as the image
     // bytes that are cached behind the emitted OmniRoute image URL.
-    assert.match(content, /!\[image\]\([^)]*\/v1\/chatgpt-web\/image\/[a-f0-9]+\)/, "image rendered");
+    assert.match(
+      content,
+      /!\[image\]\([^)]*\/v1\/chatgpt-web\/image\/[a-f0-9]+\)/,
+      "image rendered"
+    );
     assert.doesNotMatch(content, /files\.oaiusercontent\.com/);
     assert.equal(m.calls.fileDownload, 1, "tried /files/ endpoint first");
     assert.equal(m.calls.attachmentDownload, 0, "did not need /attachment fallback");
@@ -2188,7 +2245,11 @@ test("Image gen: bytes-fetch failure drops markdown (no signed-URL fallback)", a
     const json = await result.response.json();
     const content = json.choices[0].message.content;
     assert.doesNotMatch(content, /!\[image\]/, "no markdown for failed bytes fetch");
-    assert.doesNotMatch(content, /files\.oaiusercontent\.com/, "signed URL is never leaked to client");
+    assert.doesNotMatch(
+      content,
+      /files\.oaiusercontent\.com/,
+      "signed URL is never leaked to client"
+    );
     assert.equal(m.calls.fileDownload, 1, "download URL was attempted");
     assert.equal(m.calls.signedDownload, 1, "signed-bytes fetch was attempted and failed");
   } finally {
@@ -2257,9 +2318,17 @@ test("Image edit: file_0000XXXX (chatgpt-web edit result) falls back to /convers
     assert.equal(result.response.status, 200);
     const json = await result.response.json();
     const content = json.choices[0].message.content;
-    assert.match(content, /!\[image\]\([^)]*\/v1\/chatgpt-web\/image\/[a-f0-9]+\)/, "image rendered via fallback");
+    assert.match(
+      content,
+      /!\[image\]\([^)]*\/v1\/chatgpt-web\/image\/[a-f0-9]+\)/,
+      "image rendered via fallback"
+    );
     assert.equal(m.calls.fileDownload, 1, "tried /files/ first");
-    assert.equal(m.calls.attachmentDownload, 1, "fell back to /conversation/.../attachment/.../download");
+    assert.equal(
+      m.calls.attachmentDownload,
+      1,
+      "fell back to /conversation/.../attachment/.../download"
+    );
     assert.equal(m.calls.signedDownload, 1, "fetched signed bytes once");
   } finally {
     m.restore();
@@ -2342,12 +2411,13 @@ test("Image edit handler: bytes-hash match drives executor with cached conversat
   const m = installMockFetch({
     // Conv response must include an image pointer so the handler sees
     // markdown in the assistant message and treats the edit as successful.
-    conv: { status: 200, events: imageGenEvents({ pointer: "file-service://file-edited-day", text: "Done:" }) },
+    conv: {
+      status: 200,
+      events: imageGenEvents({ pointer: "file-service://file-edited-day", text: "Done:" }),
+    },
   });
   try {
-    const { handleImageEdit } = await import(
-      "../../open-sse/handlers/imageGeneration.ts"
-    );
+    const { handleImageEdit } = await import("../../open-sse/handlers/imageGeneration.ts");
     const result = await handleImageEdit({
       provider: "chatgpt-web",
       model: "gpt-5.3-instant",
@@ -2363,10 +2433,7 @@ test("Image edit handler: bytes-hash match drives executor with cached conversat
     assert.equal(sentBody.conversation_id, "conv-edit-handler");
     assert.equal(sentBody.parent_message_id, "msg-edit-handler");
     assert.equal(sentBody.history_and_training_disabled, false);
-    assert.match(
-      sentBody.messages[sentBody.messages.length - 1].content.parts[0],
-      /day time/
-    );
+    assert.match(sentBody.messages[sentBody.messages.length - 1].content.parts[0], /day time/);
   } finally {
     m.restore();
   }
@@ -2383,9 +2450,7 @@ test("Image edit handler: no cached match returns 400 (does not silently generat
 
   const m = installMockFetch();
   try {
-    const { handleImageEdit } = await import(
-      "../../open-sse/handlers/imageGeneration.ts"
-    );
+    const { handleImageEdit } = await import("../../open-sse/handlers/imageGeneration.ts");
     const foreignBytes = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0xde, 0xad, 0xbe, 0xef]);
     const result = await handleImageEdit({
       provider: "chatgpt-web",
@@ -2413,9 +2478,7 @@ test("Image gen handler: n>4 is rejected before any upstream call", async () => 
   reset();
   const m = installMockFetch();
   try {
-    const { handleImageGeneration } = await import(
-      "../../open-sse/handlers/imageGeneration.ts"
-    );
+    const { handleImageGeneration } = await import("../../open-sse/handlers/imageGeneration.ts");
     const result = await handleImageGeneration({
       body: { prompt: "draw a kitten", n: 5, model: "cgpt-web/gpt-5.3-instant" },
       credentials: { apiKey: "test" },
@@ -2443,5 +2506,9 @@ test("Image cache: deleting an entry decrements the byte counter", async () => {
   // Wait past the 10 ms TTL, then trigger eviction by reading.
   await new Promise((r) => setTimeout(r, 25));
   assert.equal(cacheMod.getChatGptImage(id), null, "entry expired");
-  assert.equal(cacheMod.__getChatGptImageCacheBytesForTesting(), 0, "bytes credited back on TTL evict");
+  assert.equal(
+    cacheMod.__getChatGptImageCacheBytesForTesting(),
+    0,
+    "bytes credited back on TTL evict"
+  );
 });

--- a/tests/unit/provider-validation-specialty.test.ts
+++ b/tests/unit/provider-validation-specialty.test.ts
@@ -369,6 +369,164 @@ test("web-cookie provider validators surface auth and subscription failures", as
   assert.match(museSpark.error || "", /Invalid Meta AI session cookie/i);
 });
 
+// ─── chatgpt-web validator ──────────────────────────────────────────────────
+// Mocks the TLS-impersonating fetch so unit tests don't need the native binding.
+
+const { __setTlsFetchOverrideForTesting } =
+  await import("../../open-sse/services/chatgptTlsClient.ts");
+
+function makeTlsResponse(status: number, body: string, headers: Record<string, string> = {}): any {
+  const h = new Headers();
+  for (const [k, v] of Object.entries(headers)) h.set(k, v);
+  return { status, headers: h, text: body, body: null };
+}
+
+test.afterEach(() => {
+  __setTlsFetchOverrideForTesting(null);
+});
+
+test("chatgpt-web validator: accepts a valid session response with accessToken", async () => {
+  let captured: { url: string; opts: any } | null = null;
+  __setTlsFetchOverrideForTesting(async (url, opts) => {
+    captured = { url, opts };
+    return makeTlsResponse(
+      200,
+      JSON.stringify({ accessToken: "tok-abc", expires: "2030-01-01T00:00:00Z" }),
+      { "content-type": "application/json" }
+    );
+  });
+
+  const result = await validateProviderApiKey({
+    provider: "chatgpt-web",
+    apiKey: "__Secure-next-auth.session-token=eyJSESSION",
+  });
+
+  assert.equal(result.valid, true);
+  assert.equal(captured?.url, "https://chatgpt.com/api/auth/session");
+  assert.equal(
+    (captured?.opts.headers as Record<string, string>).Cookie,
+    "__Secure-next-auth.session-token=eyJSESSION"
+  );
+});
+
+test("chatgpt-web validator: prepends session-token name to bare values", async () => {
+  let capturedCookie = "";
+  __setTlsFetchOverrideForTesting(async (_url, opts) => {
+    capturedCookie = (opts.headers as Record<string, string>).Cookie || "";
+    return makeTlsResponse(200, JSON.stringify({ accessToken: "tok" }), {
+      "content-type": "application/json",
+    });
+  });
+
+  await validateProviderApiKey({ provider: "chatgpt-web", apiKey: "eyJBARE" });
+  assert.equal(capturedCookie, "__Secure-next-auth.session-token=eyJBARE");
+});
+
+test("chatgpt-web validator: passes full DevTools cookie blob through verbatim", async () => {
+  let capturedCookie = "";
+  __setTlsFetchOverrideForTesting(async (_url, opts) => {
+    capturedCookie = (opts.headers as Record<string, string>).Cookie || "";
+    return makeTlsResponse(200, JSON.stringify({ accessToken: "tok" }), {
+      "content-type": "application/json",
+    });
+  });
+
+  const blob =
+    "Cookie: oai-did=foo; __Secure-next-auth.session-token.0=eyJchunk0; __Secure-next-auth.session-token.1=eyJchunk1; cf_clearance=cf123;";
+  await validateProviderApiKey({ provider: "chatgpt-web", apiKey: blob });
+  assert.equal(
+    capturedCookie,
+    "oai-did=foo; __Secure-next-auth.session-token.0=eyJchunk0; __Secure-next-auth.session-token.1=eyJchunk1; cf_clearance=cf123;"
+  );
+});
+
+test("chatgpt-web validator: 401 without cf-mitigated → invalid session cookie", async () => {
+  __setTlsFetchOverrideForTesting(async () =>
+    makeTlsResponse(401, JSON.stringify({ error: "unauthorized" }), {
+      "content-type": "application/json",
+    })
+  );
+
+  const result = await validateProviderApiKey({
+    provider: "chatgpt-web",
+    apiKey: "stale-token",
+  });
+  assert.equal(result.valid, false);
+  assert.match(result.error || "", /Invalid ChatGPT session cookie/i);
+});
+
+test("chatgpt-web validator: 403 with cf-mitigated header → Cloudflare hint", async () => {
+  __setTlsFetchOverrideForTesting(async () =>
+    makeTlsResponse(403, "<html>Just a moment...</html>", {
+      "content-type": "text/html",
+      "cf-mitigated": "challenge",
+    })
+  );
+
+  const result = await validateProviderApiKey({
+    provider: "chatgpt-web",
+    apiKey: "good-but-no-cf-cookies",
+  });
+  assert.equal(result.valid, false);
+  assert.match(result.error || "", /Cloudflare blocked the validator/i);
+});
+
+test("chatgpt-web validator: 200 without accessToken → session expired", async () => {
+  __setTlsFetchOverrideForTesting(async () =>
+    makeTlsResponse(200, JSON.stringify({}), { "content-type": "application/json" })
+  );
+
+  const result = await validateProviderApiKey({
+    provider: "chatgpt-web",
+    apiKey: "expired-token",
+  });
+  assert.equal(result.valid, false);
+  assert.match(result.error || "", /session expired/i);
+});
+
+test("chatgpt-web validator: 5xx → ChatGPT unavailable", async () => {
+  __setTlsFetchOverrideForTesting(async () =>
+    makeTlsResponse(503, "service unavailable", { "content-type": "text/plain" })
+  );
+
+  const result = await validateProviderApiKey({
+    provider: "chatgpt-web",
+    apiKey: "any-token",
+  });
+  assert.equal(result.valid, false);
+  assert.match(result.error || "", /ChatGPT unavailable \(503\)/);
+});
+
+test("chatgpt-web validator: 200 non-JSON content-type surfaces a cookie hint", async () => {
+  __setTlsFetchOverrideForTesting(async () =>
+    makeTlsResponse(200, "<html>blocked</html>", {
+      "content-type": "text/html",
+      "cf-ray": "ray-123",
+    })
+  );
+
+  const result = await validateProviderApiKey({
+    provider: "chatgpt-web",
+    apiKey: "any-token",
+  });
+  assert.equal(result.valid, false);
+  assert.match(result.error || "", /non-JSON.*text\/html.*cf-ray=ray-123/i);
+});
+
+test("chatgpt-web validator: TlsClientUnavailableError surfaces a clear message", async () => {
+  const { TlsClientUnavailableError } = await import("../../open-sse/services/chatgptTlsClient.ts");
+  __setTlsFetchOverrideForTesting(async () => {
+    throw new TlsClientUnavailableError("native binding failed to load");
+  });
+
+  const result = await validateProviderApiKey({
+    provider: "chatgpt-web",
+    apiKey: "any-token",
+  });
+  assert.equal(result.valid, false);
+  assert.match(result.error || "", /chatgpt-web requires this/i);
+});
+
 test("search provider validators cover success, client errors, server errors and custom user agent injection", async () => {
   const calls = [];
   globalThis.fetch = async (url, init = {}) => {


### PR DESCRIPTION
## Summary

Two related fixes that together close the gap left when the original ChatGPT Web feature PR (#1593) was integrated via merge commit `50097b1f`. After that merge, validation of `chatgpt-web` accounts silently fell back to the generic OpenAI validator (which 401s on `/backend-api/conversation/models`) and the registry only exposed a single placeholder model, so Plus users couldn't actually exercise their account against the catalog they pay for.

- **Restore `validateChatGptWebProvider`** in `src/lib/providers/validation.ts`, plus its `chatgpt-web` entry in `SPECIALTY_VALIDATORS`. The function was authored on `feat/chatgpt-web-provider` but lost when the merge resolved a conflict against an older `validation.ts`. The restored implementation accepts bare values, single `key=value` pairs, chunked tokens, and full DevTools cookie blobs; uses `tlsFetchChatGpt` for Cloudflare-bypassing TLS impersonation; and surfaces specific errors for cf-mitigated challenges, expired sessions, missing `accessToken`, and TLS-client unavailability instead of a generic 401.
- **Expand the model catalog** from 1 entry to the 13 chat models a Plus account actually has access to (verified live against `/backend-api/models`). Adds instant / thinking / mini variants for 5.2 / 5.3 / 5.4 / 5.5, plus `gpt-5`, `gpt-5.1`, `gpt-5-mini`, and `o3`. The `MODEL_MAP` translates dot-form OmniRoute IDs (e.g. `gpt-5.4-thinking-mini`) to ChatGPT's exact dash-form slugs (`gpt-5-4-t-mini`). The previous default `gpt-5.3-instant` mapping pointed at the auto-routing base `gpt-5-3`; it now points at the explicit `gpt-5-3-instant` slug, matching what the UI's last-model-config cookie shows. Excludes `research` and `agent-mode` — those are specialty surfaces, not regular chat models.

## Files Changed

- `src/lib/providers/validation.ts` — restored validator + registration (109 LOC).
- `open-sse/config/providerRegistry.ts` — 13-model catalog.
- `open-sse/executors/chatgpt-web.ts` — `MODEL_MAP` for dot-to-dash translation, default repointed to `gpt-5-3-instant`.
- `tests/unit/chatgpt-web.test.ts` — extended to cover the new model translation.
- `tests/unit/provider-validation-specialty.test.ts` — 8 new cases covering the success path and each error branch (cf-mitigated, expired, missing accessToken, TLS unavailable, bare/chunked/blob cookie shapes).

## Why this is needed (root cause)

The original chatgpt-web PR ships an executor that uses TLS impersonation and a 2-stage Sentinel handshake. The OAuth-style "OpenAI" validator fetches `/v1/models` with a plain Bearer token, which:

1. Doesn't impersonate Chrome's TLS fingerprint, so Cloudflare returns a managed challenge.
2. Hits the Bearer-key-API endpoint, not the cookie-authed `backend-api` namespace ChatGPT Plus actually uses.

Result: every Plus cookie the user pastes returns a misleading "invalid API key" error in the dashboard. Restoring the specialty validator routes through the same TLS-impersonating client the executor already uses and probes the right endpoint.

## Test plan

- [x] `npm run test:unit -- tests/unit/chatgpt-web.test.ts tests/unit/provider-validation-specialty.test.ts` (118/118 pass)
- [x] Live validation against `/api/providers/validate` with a real Plus cookie
- [x] Live `/v1/chat/completions` round-trip against the running container, confirming `gpt-5-4-t-mini` and `gpt-5-3-instant` both resolve and stream back

## Notes for reviewers

- No public API changes; only restores behavior described in the original feature PR.
- The validator's error taxonomy is intentionally specific (cf-mitigated, expired, missing accessToken, TLS unavailable) so the dashboard surfaces actionable messages instead of a generic 401.
- `MODEL_MAP` is the only translation surface — adding new ChatGPT slugs is a one-line change there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)