### PR TITLE
fix(antigravity): scrub internal OmniRoute headers

### DIFF
--- a/open-sse/services/antigravityHeaderScrub.ts
+++ b/open-sse/services/antigravityHeaderScrub.ts
@@ -52,7 +52,8 @@ export function scrubProxyAndFingerprintHeaders(
 ): Record<string, string> {
   const cleaned: Record<string, string> = {};
   for (const [key, value] of Object.entries(headers)) {
-    if (!HEADERS_TO_REMOVE.includes(key.toLowerCase())) {
+    const lowerKey = key.toLowerCase();
+    if (!lowerKey.startsWith("x-omniroute-") && !HEADERS_TO_REMOVE.includes(lowerKey)) {
       cleaned[key] = value;
     }
   }

--- a/tests/unit/executor-antigravity.test.ts
+++ b/tests/unit/executor-antigravity.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 
 import { AntigravityExecutor } from "../../open-sse/executors/antigravity.ts";
 import { setCliCompatProviders } from "../../open-sse/config/cliFingerprints.ts";
+import { scrubProxyAndFingerprintHeaders } from "../../open-sse/services/antigravityHeaderScrub.ts";
 import {
   clearAntigravityVersionCache,
   seedAntigravityVersionCache,
@@ -43,13 +44,28 @@ test("AntigravityExecutor.buildUrl always targets the streaming endpoint", () =>
   );
 });
 
-test("AntigravityExecutor.buildHeaders includes auth and SSE accept", () => {
+test("AntigravityExecutor.buildHeaders includes native headers without OmniRoute internals", () => {
   const executor = new AntigravityExecutor();
   const headers = executor.buildHeaders({ accessToken: "ag-token" }, false);
 
   assert.equal(headers.Authorization, "Bearer ag-token");
   assert.equal(headers.Accept, "text/event-stream");
-  assert.equal(headers["X-OmniRoute-Source"], "omniroute");
+  assert.equal(headers["X-OmniRoute-Source"], undefined);
+});
+
+test("Antigravity header scrub removes OmniRoute internal headers", () => {
+  const headers = scrubProxyAndFingerprintHeaders({
+    Authorization: "Bearer ag-token",
+    "X-OmniRoute-Source": "omniroute",
+    "X-OmniRoute-No-Cache": "true",
+    "X-Forwarded-For": "127.0.0.1",
+  });
+
+  assert.equal(headers.Authorization, "Bearer ag-token");
+  assert.equal(headers["X-OmniRoute-Source"], undefined);
+  assert.equal(headers["X-OmniRoute-No-Cache"], undefined);
+  assert.equal(headers["X-Forwarded-For"], undefined);
+  assert.equal(headers["Accept-Encoding"], "gzip, deflate, br");
 });
 
 test("AntigravityExecutor.transformRequest normalizes model, project and contents", async () => {


### PR DESCRIPTION
## Summary
- Strip internal `x-omniroute-*` control/diagnostic headers before forwarding Antigravity requests upstream.
- Keep native Antigravity headers intact while preserving existing proxy/fingerprint scrubbing behavior.
- Update existing Antigravity executor coverage without duplicating signature-cache tests.

## Validation
- `node --import tsx/esm --test tests/unit/executor-antigravity.test.ts tests/unit/signature-cache-bypass.test.ts tests/unit/t43-gemini-tool-call-no-thought-signature.test.ts tests/unit/t44-antigravity-thought-signature-preserved.test.ts`
- `git diff --check`