### PR TITLE
fix(sse): decrement pending requests on passthrough mode failure

### DIFF
--- a/open-sse/utils/stream.ts
+++ b/open-sse/utils/stream.ts
@@ -1202,6 +1202,7 @@ export function createSSEStream(options: StreamOptions = {}) {
                 } catch {}
               }
               clearIdleTimer();
+              trackPendingRequest(model, provider, connectionId, false);
               controller.error(new Error(failurePayload.message || "Upstream failure"));
               return;
             }

--- a/tests/unit/stream-utils.test.ts
+++ b/tests/unit/stream-utils.test.ts
@@ -972,3 +972,63 @@ test("createRequestLogger caps retained stream chunk item count", async () => {
     "[stream chunk log truncated after 2 chunks]",
   ]);
 });
+
+// T-VERIFY: passthrough mode failure decrements pending requests
+// Regression test for missing trackPendingRequest(false) on passthrough failure
+import { getPendingRequests, clearPendingRequests } from "../../src/lib/usage/usageHistory.ts";
+
+test("createSSEStream passthrough mode decrements pending requests on failure", async () => {
+  // Clear any existing pending requests first
+  clearPendingRequests();
+  const initial = getPendingRequests();
+  assert.equal(Object.keys(initial.byModel).length, 0, "should start with no pending requests");
+
+  let failurePayload = null;
+  const testProvider = "openai-compatible-test-failure";
+  const testModel = "gpt-test";
+  const testConnectionId = "test-conn-123";
+
+  await assert.rejects(
+    readTransformed(
+      [
+        `data: ${JSON.stringify({
+          type: "response.failed",
+          response: {
+            id: "resp_failed_test",
+            object: "response",
+            model: testModel,
+            status: "failed",
+            error: {
+              code: "test_failure",
+              message: "Test failure for pending request tracking",
+            },
+          },
+        })}\n\n`,
+      ],
+      {
+        mode: "passthrough",
+        sourceFormat: FORMATS.OPENAI_RESPONSES,
+        provider: testProvider,
+        model: testModel,
+        connectionId: testConnectionId,
+        body: { input: "hello" },
+        onFailure(payload) {
+          failurePayload = payload;
+        },
+      }
+    ),
+    /Test failure|Upstream failure/
+  );
+
+  assert.ok(failurePayload, "should report the stream failure");
+
+  // Verify pending requests are properly decremented after failure
+  const pending = getPendingRequests();
+  const modelKey = `${testModel} (${testProvider})`;
+  const count = pending.byModel[modelKey] || 0;
+  assert.equal(
+    count,
+    0,
+    `pending request count for ${modelKey} should be 0 after failure, got ${count}`
+  );
+});


### PR DESCRIPTION
## Summary

Fixes active request count leak that occurs when passthrough mode encounters a failure payload.

## Problem

When using OpenAI-compatible providers in passthrough mode (e.g., OpenAI Responses API), if the upstream returns a failure response (like usage limit errors), the code path at `stream.ts:1205` would:
1. Call `controller.error()` 
2. Return immediately

This caused `trackPendingRequest(..., false)` to never be called, making the active request counter only increment and never decrement for these failed requests.

## Root Cause

Missing `trackPendingRequest(model, provider, connectionId, false)` call in the passthrough mode failure handling path.

## Changes

- **open-sse/utils/stream.ts**: Add missing `trackPendingRequest(..., false)` before `controller.error()` on line 1205
- **tests/unit/stream-utils.test.ts**: Add regression test to verify pending requests are properly decremented on passthrough failures

## Test Plan

- [x] Added regression test: `createSSEStream passthrough mode decrements pending requests on failure`
- [x] All existing tests pass (1 pre-existing failure unrelated to this change)
- [x] Coverage maintained at 85.78% statements / 75.27% branches

## Verification

```bash
# Run the specific regression test
node --import tsx/esm --test tests/unit/stream-utils.test.ts

# Run full test suite
npm run test:coverage  # 60%+ coverage maintained
```

## Related

This fixes the count leak observed with dynamic OpenAI-compatible provider IDs like:
- `openai-compatible-chat-9dab9785-ae28-4647-9089-09d4301dc219`