### PR TITLE
fix(codex): omit compact client metadata

### DIFF
--- a/open-sse/executors/codex.ts
+++ b/open-sse/executors/codex.ts
@@ -1146,6 +1146,7 @@ export class CodexExecutor extends BaseExecutor {
     if (isCompactRequest) {
       delete body.stream;
       delete body.stream_options;
+      delete body.client_metadata;
     } else {
       body.stream = true;
     }
@@ -1288,7 +1289,9 @@ export class CodexExecutor extends BaseExecutor {
         body.prompt_cache_key = cacheSessionId;
       }
     }
-    applyCodexClientMetadata(body, credentials?.providerSpecificData?.codexClientIdentity);
+    if (!isCompactRequest) {
+      applyCodexClientMetadata(body, credentials?.providerSpecificData?.codexClientIdentity);
+    }
 
     // Delete session_id and conversation_id from the body.
     // These are often injected by OmniRoute's fallback logic for store=true,

--- a/tests/unit/executor-codex.test.ts
+++ b/tests/unit/executor-codex.test.ts
@@ -698,6 +698,33 @@ test("CodexExecutor.transformRequest merges Codex installation metadata", () => 
   });
 });
 
+test("CodexExecutor.transformRequest omits client metadata for compact requests", () => {
+  const executor = new CodexExecutor();
+  const result = executor.transformRequest(
+    "gpt-5.5",
+    {
+      model: "gpt-5.5",
+      input: [],
+      client_metadata: { existing: "drop" },
+      _nativeCodexPassthrough: true,
+    },
+    false,
+    {
+      requestEndpointPath: "/responses/compact",
+      providerSpecificData: {
+        codexClientIdentity: {
+          sessionId: "session-1",
+          turnId: "turn-1",
+          windowId: "session-1:0",
+          installationId: "11111111-1111-4111-a111-111111111111",
+        },
+      },
+    }
+  );
+
+  assert.equal(result.client_metadata, undefined);
+});
+
 test("CodexExecutor.execute falls back to HTTP when websocket transport is unavailable", async () => {
   __setCodexWebSocketTransportForTesting(null);
   const executor = new CodexExecutor();


### PR DESCRIPTION
## Summary

  - omit `client_metadata` for Codex `/responses/compact` requests
  - skip Codex installation metadata injection on the compact endpoint
  while keeping it for normal `/responses` calls
  - add a regression test for compact request transformation

  ## Related Issues

  - Related to #1777
  - Related to #1363
  - Related to #1368

  ## Context

  This is another compact-specific Codex passthrough cleanup. We
  already fixed `/responses/compact` handling in #1777 by removing
  unsupported `store` and forcing the compact endpoint through the non-
  streaming JSON path. Earlier compaction-related work in #1363 and
  #1368 focused on context handoff timeouts/limits.

  The new failure was a different unsupported field:


  Error running remote compact task: {"error":{"message":"[400]:
  Unknown parameter:
  client_metadata","type":"invalid_request_error","code":"bad_request"}
  }


  It came back because the Codex executor still reused the normal `/
  responses` metadata decoration for compact requests. That decoration
  is useful for regular Codex Responses calls, but `/responses/compact`
  has a stricter schema and rejects `client_metadata` entirely, just
  like it rejected `store` in #1777.

  ## Validation

  - [ ] `npm run lint`
  - [x] `npm run test:unit`
  - [ ] `npm run test:coverage`
  - [ ] Coverage is still `>= 60%` for statements, lines, functions,
  and branches
  - [ ] SonarQube PR analysis is green or any remaining issues are
  explicitly documented below

  ## Tests Added Or Updated

  - `tests/unit/executor-codex.test.ts` adds coverage that compact
  requests drop incoming `client_metadata` and do not receive injected
  Codex installation metadata.

  ## Coverage Notes

  The production change is limited to `open-sse/executors/codex.ts`.
  The new unit test covers the compact branch of
  `CodexExecutor.transformRequest`, while the existing metadata test
  continues to cover normal `/responses` behavior.

  ## Reviewer Notes

  The change intentionally keeps `client_metadata` on regular Codex `/
  responses` requests. Only `/responses/compact` strips it because the
  compact endpoint rejects the parameter upstream.