### PR TITLE
fix(workflow): build docker images on version tags

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - "v*"
   release:
     types: [published]
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- Add version tag push triggers to the Docker publish workflow.
- Keep the existing main push, release published, and manual dispatch triggers unchanged.

## Why
Docker image tags for v3.7.6 and v3.7.7 were missing because the workflow did not run on tag pushes, and releases created by Actions with GITHUB_TOKEN do not trigger downstream release workflows.

## Validation
- npx prettier --write .github/workflows/docker-publish.yml
- git diff --check
- npm run test:unit (3962 passed)