### PR TITLE
feat(registry): register muse-spark-web models in provider catalog

### DIFF
--- a/open-sse/config/providerRegistry.ts
+++ b/open-sse/config/providerRegistry.ts
@@ -1197,6 +1197,29 @@ export const REGISTRY: Record<string, RegistryEntry> = {
     ],
   },
 
+  "muse-spark-web": {
+    id: "muse-spark-web",
+    alias: "ms-web",
+    format: "openai",
+    executor: "muse-spark-web",
+    baseUrl: "https://www.meta.ai/api/graphql",
+    authType: "apikey",
+    authHeader: "cookie",
+    models: [
+      { id: "muse-spark", name: "Muse Spark" },
+      {
+        id: "muse-spark-thinking",
+        name: "Muse Spark Thinking",
+        supportsReasoning: true,
+      },
+      {
+        id: "muse-spark-contemplating",
+        name: "Muse Spark Contemplating",
+        supportsReasoning: true,
+      },
+    ],
+  },
+
   together: {
     id: "together",
     alias: "together",


### PR DESCRIPTION
## Summary
Adds \muse-spark-web\ to \providerRegistry.ts\ so the dashboard **Available Models** list and \PROVIDER_MODELS\ / \getModelsByProviderId\ include Meta AI Muse Spark models (aligned with \muse-spark-web\ executor \MODEL_MAP\).

## Models
- \muse-spark\
- \muse-spark-thinking\ (reasoning)
- \muse-spark-contemplating\ (reasoning)

## Context
Executor and UI already supported this provider; the registry entry was missing, which left the provider detail page with an empty model list.

Made with [Cursor](https://cursor.com)