### PR TITLE
chore(provider): Update Jina AI model catalog

### DIFF
--- a/open-sse/config/embeddingRegistry.ts
+++ b/open-sse/config/embeddingRegistry.ts
@@ -173,13 +173,50 @@ export const EMBEDDING_PROVIDERS: Record<string, EmbeddingProvider> = {
       { id: "text-embedding-3-large", name: "Text Embedding 3 Large (GitHub)", dimensions: 3072 },
     ],
   },
+
+  "jina-ai": {
+    id: "jina-ai",
+    baseUrl: "https://api.jina.ai/v1/embeddings",
+    authType: "apikey",
+    authHeader: "bearer",
+    models: [
+      {
+        id: "jina-embeddings-v5-text-small",
+        name: "Jina Embeddings v5 Text Small",
+        dimensions: 1024,
+      },
+      { id: "jina-embeddings-v5-text-nano", name: "Jina Embeddings v5 Text Nano", dimensions: 768 },
+      { id: "jina-code-embeddings-1.5b", name: "Jina Code Embeddings 1.5B", dimensions: 1536 },
+      { id: "jina-code-embeddings-0.5b", name: "Jina Code Embeddings 0.5B", dimensions: 896 },
+      { id: "jina-embeddings-v4", name: "Jina Embeddings v4", dimensions: 2048 },
+      { id: "jina-clip-v2", name: "Jina CLIP v2", dimensions: 1024 },
+      { id: "jina-colbert-v2", name: "Jina ColBERT v2", dimensions: 128 },
+    ],
+  },
 };
+
+const EMBEDDING_PROVIDER_ALIASES: Record<string, string> = {
+  jina: "jina-ai",
+  voyage: "voyage-ai",
+};
+
+function resolveEmbeddingProviderId(providerId: string): string {
+  return EMBEDDING_PROVIDER_ALIASES[providerId] || providerId;
+}
+
+function normalizeProviderScopedModelId(providerId: string, modelId: string): string {
+  return modelId.startsWith(`${providerId}/`) ? modelId.slice(providerId.length + 1) : modelId;
+}
+
+function toProviderScopedModelId(providerId: string, modelId: string): string {
+  return modelId.startsWith(`${providerId}/`) ? modelId : `${providerId}/${modelId}`;
+}
 
 /**
  * Get embedding provider config by ID
  */
 export function getEmbeddingProvider(providerId: string): EmbeddingProvider | null {
-  return EMBEDDING_PROVIDERS[providerId] || null;
+  return EMBEDDING_PROVIDERS[resolveEmbeddingProviderId(providerId)] || null;
 }
 
 /**
@@ -195,10 +232,23 @@ export function parseEmbeddingModel(
   // Check for "provider/model" format
   const slashIdx = modelStr.indexOf("/");
   if (slashIdx > 0) {
+    const rawProvider = modelStr.slice(0, slashIdx);
+    const resolvedProvider = resolveEmbeddingProviderId(rawProvider);
+
+    if (EMBEDDING_PROVIDERS[resolvedProvider]) {
+      return {
+        provider: resolvedProvider,
+        model: normalizeProviderScopedModelId(resolvedProvider, modelStr.slice(slashIdx + 1)),
+      };
+    }
+
     // Phase 1: Try each hardcoded provider prefix
     for (const [providerId] of Object.entries(EMBEDDING_PROVIDERS)) {
       if (modelStr.startsWith(providerId + "/")) {
-        return { provider: providerId, model: modelStr.slice(providerId.length + 1) };
+        return {
+          provider: providerId,
+          model: normalizeProviderScopedModelId(providerId, modelStr.slice(providerId.length + 1)),
+        };
       }
     }
     // Phase 2: Try dynamic provider_nodes prefix
@@ -233,7 +283,7 @@ export function getAllEmbeddingModels() {
   for (const [providerId, config] of Object.entries(EMBEDDING_PROVIDERS)) {
     for (const model of config.models) {
       models.push({
-        id: `${providerId}/${model.id}`,
+        id: toProviderScopedModelId(providerId, model.id),
         name: model.name,
         provider: providerId,
         dimensions: model.dimensions,

--- a/open-sse/config/rerankRegistry.ts
+++ b/open-sse/config/rerankRegistry.ts
@@ -69,20 +69,32 @@ export const RERANK_PROVIDERS = {
     models: [
       { id: "jina-reranker-v3", name: "Jina Reranker v3" },
       { id: "jina-reranker-m0", name: "Jina Reranker m0" },
-      {
-        id: "jina-reranker-v2-base-multilingual",
-        name: "Jina Reranker v2 Base Multilingual",
-      },
-      { id: "jina-colbert-v2", name: "Jina ColBERT v2" },
     ],
   },
 };
+
+const RERANK_PROVIDER_ALIASES = {
+  jina: "jina-ai",
+  voyage: "voyage-ai",
+};
+
+function resolveRerankProviderId(providerId) {
+  return RERANK_PROVIDER_ALIASES[providerId] || providerId;
+}
+
+function normalizeProviderScopedModelId(providerId, modelId) {
+  return modelId.startsWith(`${providerId}/`) ? modelId.slice(providerId.length + 1) : modelId;
+}
+
+function toProviderScopedModelId(providerId, modelId) {
+  return modelId.startsWith(`${providerId}/`) ? modelId : `${providerId}/${modelId}`;
+}
 
 /**
  * Get rerank provider config by ID
  */
 export function getRerankProvider(providerId) {
-  return RERANK_PROVIDERS[providerId] || null;
+  return RERANK_PROVIDERS[resolveRerankProviderId(providerId)] || null;
 }
 
 /**
@@ -92,10 +104,25 @@ export function getRerankProvider(providerId) {
 export function parseRerankModel(modelStr) {
   if (!modelStr) return { provider: null, model: null };
 
+  const slashIdx = modelStr.indexOf("/");
+  if (slashIdx > 0) {
+    const rawProvider = modelStr.slice(0, slashIdx);
+    const resolvedProvider = resolveRerankProviderId(rawProvider);
+    if (RERANK_PROVIDERS[resolvedProvider]) {
+      return {
+        provider: resolvedProvider,
+        model: normalizeProviderScopedModelId(resolvedProvider, modelStr.slice(slashIdx + 1)),
+      };
+    }
+  }
+
   // Try each provider prefix
   for (const [providerId, config] of Object.entries(RERANK_PROVIDERS)) {
     if (modelStr.startsWith(providerId + "/")) {
-      return { provider: providerId, model: modelStr.slice(providerId.length + 1) };
+      return {
+        provider: providerId,
+        model: normalizeProviderScopedModelId(providerId, modelStr.slice(providerId.length + 1)),
+      };
     }
   }
 
@@ -117,7 +144,7 @@ export function getAllRerankModels() {
   for (const [providerId, config] of Object.entries(RERANK_PROVIDERS)) {
     for (const model of config.models) {
       models.push({
-        id: `${providerId}/${model.id}`,
+        id: toProviderScopedModelId(providerId, model.id),
         name: model.name,
         provider: providerId,
       });

--- a/src/app/(dashboard)/dashboard/providers/[id]/page.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.tsx
@@ -2020,6 +2020,10 @@ export default function ProviderDetailPage() {
             modelId,
             modelName: model.name || modelId,
             source: "imported",
+            ...(typeof model.apiFormat === "string" ? { apiFormat: model.apiFormat } : {}),
+            ...(Array.isArray(model.supportedEndpoints)
+              ? { supportedEndpoints: model.supportedEndpoints }
+              : {}),
           }),
         });
         // Also create an alias for routing
@@ -4212,6 +4216,7 @@ function CustomModelsSection({
               <option value="chat-completions">{t("chatCompletions")}</option>
               <option value="responses">{t("responsesApi")}</option>
               <option value="embeddings">{t("embeddings")}</option>
+              <option value="rerank">Rerank</option>
               <option value="audio-transcriptions">{t("audioTranscriptions")}</option>
               <option value="audio-speech">{t("audioSpeech")}</option>
               <option value="images-generations">{t("imagesGenerations")}</option>
@@ -4222,7 +4227,7 @@ function CustomModelsSection({
               {t("supportedEndpointsLabel")}
             </span>
             <div className="flex items-center gap-3">
-              {["chat", "embeddings", "images", "audio"].map((ep) => (
+              {["chat", "embeddings", "rerank", "images", "audio"].map((ep) => (
                 <label
                   key={ep}
                   className="flex items-center gap-1.5 text-xs text-text-main cursor-pointer"
@@ -4243,9 +4248,11 @@ function CustomModelsSection({
                     ? `💬 ${t("supportedEndpointChat")}`
                     : ep === "embeddings"
                       ? `📐 ${t("supportedEndpointEmbeddings")}`
-                      : ep === "images"
-                        ? `🖼️ ${t("supportedEndpointImages")}`
-                        : `🔊 ${t("supportedEndpointAudio")}`}
+                      : ep === "rerank"
+                        ? "Rerank"
+                        : ep === "images"
+                          ? `🖼️ ${t("supportedEndpointImages")}`
+                          : `🔊 ${t("supportedEndpointAudio")}`}
                 </label>
               ))}
             </div>
@@ -4347,6 +4354,7 @@ function CustomModelsSection({
                             <option value="chat-completions">{t("chatCompletions")}</option>
                             <option value="responses">{t("responsesApi")}</option>
                             <option value="embeddings">{t("embeddings")}</option>
+                            <option value="rerank">Rerank</option>
                             <option value="audio-transcriptions">{t("audioTranscriptions")}</option>
                             <option value="audio-speech">{t("audioSpeech")}</option>
                             <option value="images-generations">{t("imagesGenerations")}</option>
@@ -4357,7 +4365,7 @@ function CustomModelsSection({
                             {t("supportedEndpointsLabel")}
                           </span>
                           <div className="flex flex-wrap items-center gap-x-2 sm:gap-x-3 gap-y-1 min-w-0">
-                            {["chat", "embeddings", "images", "audio"].map((ep) => (
+                            {["chat", "embeddings", "rerank", "images", "audio"].map((ep) => (
                               <label
                                 key={ep}
                                 className="flex items-center gap-1.5 text-xs text-text-main cursor-pointer whitespace-nowrap"
@@ -4380,9 +4388,11 @@ function CustomModelsSection({
                                   ? `💬 ${t("supportedEndpointChat")}`
                                   : ep === "embeddings"
                                     ? `📐 ${t("supportedEndpointEmbeddings")}`
-                                    : ep === "images"
-                                      ? `🖼️ ${t("supportedEndpointImages")}`
-                                      : `🔊 ${t("supportedEndpointAudio")}`}
+                                    : ep === "rerank"
+                                      ? "Rerank"
+                                      : ep === "images"
+                                        ? `🖼️ ${t("supportedEndpointImages")}`
+                                        : `🔊 ${t("supportedEndpointAudio")}`}
                               </label>
                             ))}
                           </div>

--- a/src/app/api/models/test/route.ts
+++ b/src/app/api/models/test/route.ts
@@ -2,8 +2,10 @@ import { randomUUID } from "node:crypto";
 import { NextResponse } from "next/server";
 import { POST as postChatCompletion } from "@/app/api/v1/chat/completions/route";
 import { handleValidatedEmbeddingRequestBody } from "@/app/api/v1/embeddings/route";
+import { POST as postRerank } from "@/app/api/v1/rerank/route";
 import { buildComboTestRequestBody, extractComboTestResponseText } from "@/lib/combos/testHealth";
 import { requireManagementAuth } from "@/lib/api/requireManagementAuth";
+import { getCustomModels } from "@/lib/localDb";
 import { z } from "zod";
 
 const testModelSchema = z.object({
@@ -73,6 +75,45 @@ function buildInternalChatRequest(testBody: Record<string, unknown>, signal: Abo
   });
 }
 
+function buildInternalRerankRequest(testBody: Record<string, unknown>, signal: AbortSignal) {
+  return new Request(`${INTERNAL_ORIGIN}/v1/rerank`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Internal-Test": "combo-health-check",
+      "X-OmniRoute-No-Cache": "true",
+      "X-Request-Id": `model-test-${randomUUID()}`,
+    },
+    body: JSON.stringify(testBody),
+    signal,
+  });
+}
+
+function stripFirstSegment(modelId: string): string | null {
+  const slashIdx = modelId.indexOf("/");
+  return slashIdx > 0 ? modelId.slice(slashIdx + 1) : null;
+}
+
+async function findCustomModelMetadata(providerId: string, modelId: string) {
+  try {
+    const customModels = await getCustomModels(providerId);
+    if (!Array.isArray(customModels)) return null;
+
+    const candidates = new Set([modelId]);
+    const stripped = stripFirstSegment(modelId);
+    if (stripped) candidates.add(stripped);
+    if (modelId.startsWith(`${providerId}/`)) candidates.add(modelId.slice(providerId.length + 1));
+
+    return (
+      customModels.find(
+        (model: any) => typeof model?.id === "string" && candidates.has(model.id)
+      ) || null
+    );
+  } catch {
+    return null;
+  }
+}
+
 export async function POST(request: Request) {
   const authError = await requireManagementAuth(request);
   if (authError) return authError;
@@ -108,19 +149,47 @@ export async function POST(request: Request) {
     }
 
     const startTime = Date.now();
+    const customModel = await findCustomModelMetadata(providerId, fullModelStr);
+    const supportedEndpoints = Array.isArray(customModel?.supportedEndpoints)
+      ? customModel.supportedEndpoints
+      : [];
+    const apiFormat = typeof customModel?.apiFormat === "string" ? customModel.apiFormat : "";
+    const lowerModel = fullModelStr.toLowerCase();
+    const isRerank =
+      apiFormat === "rerank" ||
+      supportedEndpoints.includes("rerank") ||
+      lowerModel.includes("rerank");
     const isEmbedding =
-      fullModelStr.toLowerCase().includes("embedding") ||
-      fullModelStr.toLowerCase().includes("bge-") ||
-      fullModelStr.toLowerCase().includes("text-embed");
+      !isRerank &&
+      (apiFormat === "embeddings" ||
+        supportedEndpoints.includes("embeddings") ||
+        lowerModel.includes("embedding") ||
+        lowerModel.includes("bge-") ||
+        lowerModel.includes("text-embed") ||
+        lowerModel.includes("jina-clip") ||
+        lowerModel.includes("colbert"));
 
-    const testBody = buildComboTestRequestBody(fullModelStr, isEmbedding);
+    const testBody = isRerank
+      ? {
+          model: fullModelStr,
+          query: "What is OmniRoute?",
+          documents: [
+            "OmniRoute routes AI requests across configured providers.",
+            "This document is unrelated to the test query.",
+          ],
+          top_n: 1,
+          return_documents: false,
+        }
+      : buildComboTestRequestBody(fullModelStr, isEmbedding);
 
     const res = await runWithTimeout((signal) =>
       isEmbedding
         ? handleValidatedEmbeddingRequestBody(
             testBody as Record<string, unknown> & { model: string }
           )
-        : postChatCompletion(buildInternalChatRequest(testBody, signal))
+        : isRerank
+          ? postRerank(buildInternalRerankRequest(testBody, signal))
+          : postChatCompletion(buildInternalChatRequest(testBody, signal))
     );
 
     const latencyMs = Date.now() - startTime;
@@ -134,6 +203,13 @@ export async function POST(request: Request) {
       }
 
       const responseText = extractComboTestResponseText(responseBody);
+      if (isRerank) {
+        return NextResponse.json({
+          status: "ok",
+          latencyMs,
+          responseText: "[Rerank completed successfully]",
+        });
+      }
       if (!responseText && !isEmbedding) {
         return NextResponse.json(
           {

--- a/src/app/api/providers/[id]/models/route.ts
+++ b/src/app/api/providers/[id]/models/route.ts
@@ -65,7 +65,12 @@ import {
 } from "@/lib/providerModels/modelDiscovery";
 
 type JsonRecord = Record<string, unknown>;
-type LocalCatalogModel = { id: string; name?: string };
+type LocalCatalogModel = {
+  id: string;
+  name?: string;
+  apiFormat?: string;
+  supportedEndpoints?: string[];
+};
 
 const antigravityDiscoveryInflight = new Map<
   string,
@@ -409,33 +414,41 @@ const STATIC_MODEL_PROVIDERS: Record<string, () => Array<{ id: string; name: str
  * @param provider - Provider ID
  * @returns Array of models or undefined if provider doesn't use static models
  */
-export function getStaticModelsForProvider(
-  provider: string
-): Array<{ id: string; name: string }> | undefined {
+export function getStaticModelsForProvider(provider: string): LocalCatalogModel[] | undefined {
   const staticModelsFn = STATIC_MODEL_PROVIDERS[provider];
   if (staticModelsFn) {
     return staticModelsFn();
   }
 
-  const specialtyModels: Array<{ id: string; name: string }> = [];
-  const appendModels = (models: Array<{ id: string; name?: string }>) => {
+  const specialtyModels: LocalCatalogModel[] = [];
+  const appendModels = (
+    models: Array<{ id: string; name?: string }>,
+    metadata?: Pick<LocalCatalogModel, "apiFormat" | "supportedEndpoints">
+  ) => {
     for (const model of models) {
       if (specialtyModels.some((existing) => existing.id === model.id)) continue;
       specialtyModels.push({
         id: model.id,
         name: model.name || model.id,
+        ...metadata,
       });
     }
   };
 
   const embeddingProvider = getEmbeddingProvider(provider);
   if (embeddingProvider) {
-    appendModels(embeddingProvider.models);
+    appendModels(embeddingProvider.models, {
+      apiFormat: "embeddings",
+      supportedEndpoints: ["embeddings"],
+    });
   }
 
   const rerankProvider = getRerankProvider(provider);
   if (rerankProvider) {
-    appendModels(rerankProvider.models);
+    appendModels(rerankProvider.models, {
+      apiFormat: "rerank",
+      supportedEndpoints: ["rerank"],
+    });
   }
 
   const imageProvider = getImageProvider(provider);
@@ -837,6 +850,8 @@ export async function GET(
       return localCatalog.map((model) => ({
         id: model.id,
         name: model.name || model.id,
+        ...(model.apiFormat ? { apiFormat: model.apiFormat } : {}),
+        ...(model.supportedEndpoints ? { supportedEndpoints: model.supportedEndpoints } : {}),
         ...(registryCatalogModels.length > 0 ? { owned_by: provider } : {}),
       }));
     };
@@ -1770,6 +1785,8 @@ export async function GET(
         models: localCatalog.map((m) => ({
           id: m.id,
           name: m.name || m.id,
+          ...(m.apiFormat ? { apiFormat: m.apiFormat } : {}),
+          ...(m.supportedEndpoints ? { supportedEndpoints: m.supportedEndpoints } : {}),
           ...(registryCatalogModels.length > 0 ? { owned_by: provider } : {}),
         })),
         source: "local_catalog",

--- a/src/app/api/v1/embeddings/route.ts
+++ b/src/app/api/v1/embeddings/route.ts
@@ -23,6 +23,10 @@ import { isValidationFailure, validateBody } from "@/shared/validation/helpers";
 
 import { getAllCustomModels, getProviderNodes } from "@/lib/localDb";
 
+function toProviderScopedModelId(providerId: string, modelId: string): string {
+  return modelId.startsWith(`${providerId}/`) ? modelId : `${providerId}/${modelId}`;
+}
+
 /**
  * Handle CORS preflight
  */
@@ -59,7 +63,7 @@ export async function GET() {
       for (const model of models) {
         if (!model?.id || !Array.isArray(model.supportedEndpoints)) continue;
         if (!model.supportedEndpoints.includes("embeddings")) continue;
-        const fullId = `${providerId}/${model.id}`;
+        const fullId = toProviderScopedModelId(providerId, model.id);
         if (data.some((d) => d.id === fullId)) continue;
         data.push({
           id: fullId,

--- a/src/app/api/v1/models/catalog.ts
+++ b/src/app/api/v1/models/catalog.ts
@@ -210,6 +210,12 @@ export async function getUnifiedModelsResponse(
     if (authRejection) return authRejection;
 
     const { aliasToProviderId, providerIdToAlias } = buildAliasMaps();
+    const resolveCanonicalProviderId = (aliasOrProviderId: string, fallbackProviderId?: string) =>
+      aliasToProviderId[aliasOrProviderId] ||
+      (fallbackProviderId ? aliasToProviderId[fallbackProviderId] : undefined) ||
+      FALLBACK_ALIAS_TO_PROVIDER[aliasOrProviderId] ||
+      fallbackProviderId ||
+      aliasOrProviderId;
 
     // Issue #96: Allow blocking specific providers from the models list
     const blockedProviders: Set<string> = new Set(
@@ -322,7 +328,7 @@ export async function getUnifiedModelsResponse(
     // Add provider models (chat)
     for (const [alias, providerModels] of Object.entries(PROVIDER_MODELS)) {
       const providerId = aliasToProviderId[alias] || alias;
-      const canonicalProviderId = FALLBACK_ALIAS_TO_PROVIDER[alias] || providerId;
+      const canonicalProviderId = resolveCanonicalProviderId(alias, providerId);
 
       // Skip blocked providers (Issue #96)
       if (blockedProviders.has(alias) || blockedProviders.has(canonicalProviderId)) continue;
@@ -387,7 +393,7 @@ export async function getUnifiedModelsResponse(
 
         const prefix = providerIdToPrefix[providerId];
         const alias = prefix || providerIdToAlias[providerId] || providerId;
-        const canonicalProviderId = FALLBACK_ALIAS_TO_PROVIDER[alias] || providerId;
+        const canonicalProviderId = resolveCanonicalProviderId(alias, providerId);
         const parentProviderType = nodeIdToProviderType[providerId];
 
         if (
@@ -405,12 +411,15 @@ export async function getUnifiedModelsResponse(
 
           const aliasId = `${alias}/${sm.id}`;
           const endpoints = Array.isArray(sm.supportedEndpoints) ? sm.supportedEndpoints : ["chat"];
+          const apiFormat = typeof sm.apiFormat === "string" ? sm.apiFormat : "chat-completions";
           let modelType: string | undefined;
           if (endpoints.includes("embeddings")) modelType = "embedding";
+          else if (endpoints.includes("rerank")) modelType = "rerank";
           else if (endpoints.includes("images")) modelType = "image";
           else if (endpoints.includes("audio")) modelType = "audio";
           const syncedFields = {
             ...(modelType ? { type: modelType } : {}),
+            ...(apiFormat !== "chat-completions" ? { api_format: apiFormat } : {}),
             ...(modelType === "audio" ? { subtype: "transcription" } : {}),
             ...(sm.inputTokenLimit ? { context_length: sm.inputTokenLimit } : {}),
             ...(endpoints.length > 1 || !endpoints.includes("chat")
@@ -478,7 +487,7 @@ export async function getUnifiedModelsResponse(
     const isProviderActive = (provider: string) => {
       if (activeAliases.size === 0) return false; // No active connections = show nothing
       const alias = providerIdToAlias[provider] || provider;
-      const canonicalProviderId = FALLBACK_ALIAS_TO_PROVIDER[alias] || provider;
+      const canonicalProviderId = resolveCanonicalProviderId(alias, provider);
 
       // FIX #1752: Ensure blocked providers are not returned for non-chat models
       if (
@@ -492,16 +501,38 @@ export async function getUnifiedModelsResponse(
       return activeAliases.has(alias) || activeAliases.has(provider);
     };
 
+    const hasEquivalentSpecialtyModel = (
+      providerId: string,
+      rawModelId: string,
+      type: string,
+      scopedModelId: string
+    ) =>
+      models.some((model: any) => {
+        if (model?.id === scopedModelId) return true;
+        if (model?.owned_by !== providerId || model?.type !== type) return false;
+        const existingRoot =
+          typeof model?.root === "string"
+            ? model.root
+            : typeof model?.id === "string"
+              ? model.id.split("/").pop()
+              : null;
+        return existingRoot === rawModelId;
+      });
+
     // Add embedding models (filtered by active providers)
     for (const embModel of getAllEmbeddingModels()) {
       if (!isProviderActive(embModel.provider)) continue;
       const rawModelId = embModel.id.split("/").pop() || embModel.id;
       if (!providerSupportsModel(embModel.provider, rawModelId)) continue;
+      if (hasEquivalentSpecialtyModel(embModel.provider, rawModelId, "embedding", embModel.id)) {
+        continue;
+      }
       models.push({
         id: embModel.id,
         object: "model",
         created: timestamp,
         owned_by: embModel.provider,
+        root: rawModelId,
         type: "embedding",
         dimensions: embModel.dimensions,
       });
@@ -530,11 +561,15 @@ export async function getUnifiedModelsResponse(
       if (!isProviderActive(rerankModel.provider)) continue;
       const rawModelId = rerankModel.id.split("/").pop() || rerankModel.id;
       if (!providerSupportsModel(rerankModel.provider, rawModelId)) continue;
+      if (hasEquivalentSpecialtyModel(rerankModel.provider, rawModelId, "rerank", rerankModel.id)) {
+        continue;
+      }
       models.push({
         id: rerankModel.id,
         object: "model",
         created: timestamp,
         owned_by: rerankModel.provider,
+        root: rawModelId,
         type: "rerank",
       });
     }
@@ -611,7 +646,7 @@ export async function getUnifiedModelsResponse(
         // For compatible providers, use the prefix from provider nodes
         const prefix = providerIdToPrefix[providerId];
         const alias = prefix || providerIdToAlias[providerId] || providerId;
-        const canonicalProviderId = FALLBACK_ALIAS_TO_PROVIDER[alias] || providerId;
+        const canonicalProviderId = resolveCanonicalProviderId(alias, providerId);
 
         // Only include if provider is active — check alias, canonical ID, raw providerId,
         // or the parent provider type (for compatible providers whose node ID is a UUID)
@@ -649,8 +684,15 @@ export async function getUnifiedModelsResponse(
             typeof model.apiFormat === "string" ? model.apiFormat : "chat-completions";
           let modelType: string | undefined;
           if (endpoints.includes("embeddings")) modelType = "embedding";
+          else if (endpoints.includes("rerank")) modelType = "rerank";
           else if (endpoints.includes("images")) modelType = "image";
           else if (endpoints.includes("audio")) modelType = "audio";
+          if (
+            modelType &&
+            hasEquivalentSpecialtyModel(canonicalProviderId, modelId, modelType, aliasId)
+          ) {
+            continue;
+          }
           const visionFields =
             modelType === "chat"
               ? getVisionCapabilityFields(aliasId) || getVisionCapabilityFields(modelId)

--- a/src/lib/db/models.ts
+++ b/src/lib/db/models.ts
@@ -351,6 +351,7 @@ export async function addCustomModel(
     | "chat-completions"
     | "responses"
     | "embeddings"
+    | "rerank"
     | "audio-transcriptions"
     | "audio-speech"
     | "images-generations" = "chat-completions",
@@ -525,6 +526,7 @@ export interface SyncedAvailableModel {
   id: string;
   name: string;
   source: "imported";
+  apiFormat?: string;
   supportedEndpoints?: string[];
   inputTokenLimit?: number;
   outputTokenLimit?: number;
@@ -561,6 +563,9 @@ function normalizeSyncedAvailableModel(model: unknown): SyncedAvailableModel | n
     id,
     name,
     source: "imported",
+    ...(toNonEmptyString(record.apiFormat)
+      ? { apiFormat: toNonEmptyString(record.apiFormat)! }
+      : {}),
     ...(supportedEndpoints && supportedEndpoints.length > 0 ? { supportedEndpoints } : {}),
     ...(typeof record.inputTokenLimit === "number"
       ? { inputTokenLimit: record.inputTokenLimit }

--- a/src/lib/providerModels/managedModelImport.ts
+++ b/src/lib/providerModels/managedModelImport.ts
@@ -21,7 +21,7 @@ export type ManagedImportedModel = {
   id: string;
   name: string;
   source: "imported";
-  apiFormat: "chat-completions";
+  apiFormat: string;
   supportedEndpoints?: string[];
   inputTokenLimit?: number;
   outputTokenLimit?: number;
@@ -48,7 +48,7 @@ function normalizeImportedModels(fetchedModels: unknown): ManagedImportedModel[]
     id: model.id,
     name: model.name || model.id,
     source: "imported",
-    apiFormat: "chat-completions",
+    apiFormat: toNonEmptyString(model.apiFormat) || "chat-completions",
     ...(Array.isArray(model.supportedEndpoints) && model.supportedEndpoints.length > 0
       ? { supportedEndpoints: model.supportedEndpoints }
       : {}),

--- a/src/lib/providerModels/modelDiscovery.ts
+++ b/src/lib/providerModels/modelDiscovery.ts
@@ -49,6 +49,9 @@ export function normalizeDiscoveredModels(models: unknown): SyncedAvailableModel
       id,
       name,
       source: "imported",
+      ...(toNonEmptyString(record.apiFormat)
+        ? { apiFormat: toNonEmptyString(record.apiFormat)! }
+        : {}),
       ...(supportedEndpoints && supportedEndpoints.length > 0 ? { supportedEndpoints } : {}),
       ...(typeof record.inputTokenLimit === "number"
         ? { inputTokenLimit: record.inputTokenLimit }

--- a/src/shared/validation/schemas.ts
+++ b/src/shared/validation/schemas.ts
@@ -699,6 +699,7 @@ export const providerModelMutationSchema = z.object({
       "chat-completions",
       "responses",
       "embeddings",
+      "rerank",
       "audio-transcriptions",
       "audio-speech",
       "images-generations",
@@ -709,6 +710,7 @@ export const providerModelMutationSchema = z.object({
       z.enum([
         "chat",
         "embeddings",
+        "rerank",
         "images",
         "audio",
         "audio-transcriptions",

--- a/tests/unit/embedding-rerank-provider-registry.test.ts
+++ b/tests/unit/embedding-rerank-provider-registry.test.ts
@@ -40,7 +40,7 @@ test("voyage-ai and jina-ai rerank registries expose supported models", () => {
   assert.ok(jina);
   assert.equal(jina.baseUrl, "https://api.jina.ai/v1/rerank");
   assert.ok(jina.models.some((model) => model.id === "jina-reranker-v3"));
-  assert.ok(jina.models.some((model) => model.id === "jina-reranker-v2-base-multilingual"));
+  assert.ok(jina.models.some((model) => model.id === "jina-reranker-m0"));
 
   const parsedVoyage = parseRerankModel("voyage-ai/rerank-2.5");
   assert.equal(parsedVoyage.provider, "voyage-ai");
@@ -49,6 +49,10 @@ test("voyage-ai and jina-ai rerank registries expose supported models", () => {
   const parsedJina = parseRerankModel("jina-ai/jina-reranker-v3");
   assert.equal(parsedJina.provider, "jina-ai");
   assert.equal(parsedJina.model, "jina-reranker-v3");
+
+  const parsedJinaAlias = parseRerankModel("jina/jina-reranker-v3");
+  assert.equal(parsedJinaAlias.provider, "jina-ai");
+  assert.equal(parsedJinaAlias.model, "jina-reranker-v3");
 
   const all = getAllRerankModels();
   assert.ok(all.some((model) => model.id === "voyage-ai/rerank-2.5"));

--- a/tests/unit/models-catalog-route.test.ts
+++ b/tests/unit/models-catalog-route.test.ts
@@ -473,6 +473,103 @@ test("v1 models catalog includes media, moderation, rerank, video, and music mod
   assert.equal((byId.get("comfyui/stable-audio-open") as any).type, "music");
 });
 
+test("v1 models catalog does not duplicate imported Jina specialty models", async () => {
+  const connection = await seedConnection("jina-ai", {
+    name: "jina-synced",
+    apiKey: "jina-key",
+  });
+
+  await modelsDb.replaceSyncedAvailableModelsForConnection("jina-ai", (connection as any).id, [
+    {
+      id: "jina-embeddings-v5-text-small",
+      name: "Jina Embeddings v5 Text Small",
+      source: "imported",
+      apiFormat: "embeddings",
+      supportedEndpoints: ["embeddings"],
+    },
+    {
+      id: "jina-reranker-v3",
+      name: "Jina Reranker v3",
+      source: "imported",
+      apiFormat: "rerank",
+      supportedEndpoints: ["rerank"],
+    },
+  ]);
+
+  const response = await v1ModelsCatalog.getUnifiedModelsResponse(
+    new Request("http://localhost/api/v1/models")
+  );
+  const body = (await response.json()) as any;
+  const visibleJinaEmbeddingRows = body.data.filter(
+    (item) =>
+      item.owned_by === "jina-ai" &&
+      item.root === "jina-embeddings-v5-text-small" &&
+      item.type === "embedding" &&
+      !item.parent
+  );
+  const visibleJinaRerankRows = body.data.filter(
+    (item) =>
+      item.owned_by === "jina-ai" &&
+      item.root === "jina-reranker-v3" &&
+      item.type === "rerank" &&
+      !item.parent
+  );
+
+  assert.equal(response.status, 200);
+  assert.equal(visibleJinaEmbeddingRows.length, 1);
+  assert.equal(visibleJinaEmbeddingRows[0].id, "jina/jina-embeddings-v5-text-small");
+  assert.equal(visibleJinaRerankRows.length, 1);
+  assert.equal(visibleJinaRerankRows[0].id, "jina/jina-reranker-v3");
+});
+
+test("v1 models catalog does not duplicate custom Jina specialty models", async () => {
+  await seedConnection("jina-ai", {
+    name: "jina-custom",
+    apiKey: "jina-key",
+  });
+  await modelsDb.addCustomModel(
+    "jina-ai",
+    "jina-embeddings-v5-text-small",
+    "Jina Embeddings v5 Text Small",
+    "imported",
+    "embeddings",
+    ["embeddings"]
+  );
+  await modelsDb.addCustomModel(
+    "jina-ai",
+    "jina-reranker-v3",
+    "Jina Reranker v3",
+    "imported",
+    "rerank",
+    ["rerank"]
+  );
+
+  const response = await v1ModelsCatalog.getUnifiedModelsResponse(
+    new Request("http://localhost/api/v1/models")
+  );
+  const body = (await response.json()) as any;
+  const visibleJinaEmbeddingRows = body.data.filter(
+    (item) =>
+      item.owned_by === "jina-ai" &&
+      item.root === "jina-embeddings-v5-text-small" &&
+      item.type === "embedding" &&
+      !item.parent
+  );
+  const visibleJinaRerankRows = body.data.filter(
+    (item) =>
+      item.owned_by === "jina-ai" &&
+      item.root === "jina-reranker-v3" &&
+      item.type === "rerank" &&
+      !item.parent
+  );
+
+  assert.equal(response.status, 200);
+  assert.equal(visibleJinaEmbeddingRows.length, 1);
+  assert.equal(visibleJinaEmbeddingRows[0].id, "jina-ai/jina-embeddings-v5-text-small");
+  assert.equal(visibleJinaRerankRows.length, 1);
+  assert.equal(visibleJinaRerankRows[0].id, "jina-ai/jina-reranker-v3");
+});
+
 test("v1 models catalog exposes image model input and output modalities for advanced image providers", async () => {
   await seedConnection("together", { name: "together-images" });
   await seedConnection("topaz", { name: "topaz-images" });

--- a/tests/unit/provider-models-route.test.ts
+++ b/tests/unit/provider-models-route.test.ts
@@ -355,8 +355,23 @@ test("provider models route returns the local catalog for embedding and rerank p
   assert.equal(jinaResponse.status, 200);
   assert.equal(jinaBody.provider, "jina-ai");
   assert.equal(jinaBody.source, "local_catalog");
-  assert.ok(jinaBody.models.some((model) => model.id === "jina-reranker-v3"));
-  assert.ok(jinaBody.models.some((model) => model.id === "jina-reranker-v2-base-multilingual"));
+  assert.ok(
+    jinaBody.models.some(
+      (model) =>
+        model.id === "jina-embeddings-v5-text-small" &&
+        model.apiFormat === "embeddings" &&
+        model.supportedEndpoints?.includes("embeddings")
+    )
+  );
+  assert.ok(
+    jinaBody.models.some(
+      (model) =>
+        model.id === "jina-reranker-v3" &&
+        model.apiFormat === "rerank" &&
+        model.supportedEndpoints?.includes("rerank")
+    )
+  );
+  assert.ok(jinaBody.models.some((model) => model.id === "jina-reranker-m0"));
 });
 
 test("provider models route returns the local catalog for Runway video models", async () => {


### PR DESCRIPTION
## Summary

- Update the Jina AI model catalog for embeddings and rerank models.
- Preserve specialty model metadata during model discovery/import so Jina embedding and rerank models keep the correct API format and supported endpoints.
- Fix Jina provider alias handling so `jina/...` and legacy duplicated IDs resolve to the canonical `jina-ai` registry entries.
- Route rerank model validation through the rerank endpoint instead of the chat/OpenAI-compatible test path.

Additional validation run:

- `node --import tsx/esm --test tests/unit/embedding-rerank-provider-registry.test.ts tests/unit/provider-models-route.test.ts tests/unit/provider-models-management-route.test.ts tests/unit/models-catalog-route.test.ts`
- `npm run typecheck:core`

## Tests Added Or Updated

- `tests/unit/embedding-rerank-provider-registry.test.ts`
- `tests/unit/provider-models-route.test.ts`

## Coverage Notes

- The `open-sse/` registry changes are covered by `embedding-rerank-provider-registry.test.ts`.
- The provider model catalog/import behavior in `src/app/api/providers/[id]/models/route.ts` is covered by `provider-models-route.test.ts`.
- The related model management and catalog behavior was also checked with existing provider model and catalog route tests.
- Full coverage was not run locally.

## Reviewer Notes

- Existing manually imported Jina rows may still contain legacy IDs such as `jina/jina-ai/...`; the parser now accepts those forms, but re-importing from `/models` will produce cleaner IDs.
- No database migration is included.
- No feature flags are required.