### PR TITLE
feat: add K/M/B/T cost shortener to prevent UI overflow

### DIFF
--- a/src/shared/utils/formatting.ts
+++ b/src/shared/utils/formatting.ts
@@ -160,13 +160,39 @@ export const fmtCost = formatCost;
 export function formatCostAbbreviated(usd: number | null | undefined): string {
   const value = Number(usd || 0);
   if (!Number.isFinite(value) || value === 0) return "$0";
-  if (value < 0.01) return `$${value.toFixed(6)}`;
   const abs = Math.abs(value);
-  if (abs >= 1_000_000_000_000) return `$${(value / 1_000_000_000_000).toFixed(1)}T`;
-  if (abs >= 1_000_000_000) return `$${(value / 1_000_000_000).toFixed(1)}B`;
-  if (abs >= 1_000_000) return `$${(value / 1_000_000).toFixed(1)}M`;
-  if (abs >= 1_000) return `$${(value / 1_000).toFixed(1)}K`;
-  return `$${value.toFixed(2)}`;
+  if (abs < 0.01) {
+    if (value < 0) {
+      return `-$${Math.abs(value).toFixed(6)}`;
+    }
+    return `$${value.toFixed(6)}`;
+  }
+  let divisor: number, suffix: string;
+  if (abs >= 1_000_000_000_000) {
+    divisor = 1_000_000_000_000;
+    suffix = "T";
+  } else if (abs >= 1_000_000_000) {
+    divisor = 1_000_000_000;
+    suffix = "B";
+  } else if (abs >= 1_000_000) {
+    divisor = 1_000_000;
+    suffix = "M";
+  } else if (abs >= 1_000) {
+    divisor = 1_000;
+    suffix = "K";
+  } else {
+    if (value < 0) {
+      return `-$${Math.abs(value).toFixed(2)}`;
+    }
+    return `$${value.toFixed(2)}`;
+  }
+  const abbreviated = abs / divisor;
+  let formatted = abbreviated.toFixed(1);
+  if (formatted.includes(".")) {
+    formatted = formatted.replace(/\.?0+$/, "");
+  }
+  const sign = value < 0 ? "-" : "";
+  return `${sign}$${formatted}${suffix}`;
 }
 
 /**

--- a/src/shared/utils/formatting.ts
+++ b/src/shared/utils/formatting.ts
@@ -147,6 +147,29 @@ export function formatCost(usd: number | null | undefined): string {
 export const fmtCost = formatCost;
 
 /**
+ * Format a USD cost for display using abbreviated K/M/B/T suffixes.
+ * Sub-cent values show additional precision.
+ *   - Values >= 1T are shown as $X.XT
+ *   - Values >= 1B are shown as $X.XB
+ *   - Values >= 1M are shown as $X.XM
+ *   - Values >= 1K are shown as $X.XK
+ *   - Otherwise shown as $X.XX
+ * @param {number} usd - Cost in USD
+ * @returns {string}
+ */
+export function formatCostAbbreviated(usd: number | null | undefined): string {
+  const value = Number(usd || 0);
+  if (!Number.isFinite(value) || value === 0) return "$0";
+  if (value < 0.01) return `$${value.toFixed(6)}`;
+  const abs = Math.abs(value);
+  if (abs >= 1_000_000_000_000) return `$${(value / 1_000_000_000_000).toFixed(1)}T`;
+  if (abs >= 1_000_000_000) return `$${(value / 1_000_000_000).toFixed(1)}B`;
+  if (abs >= 1_000_000) return `$${(value / 1_000_000).toFixed(1)}M`;
+  if (abs >= 1_000) return `$${(value / 1_000).toFixed(1)}K`;
+  return `$${value.toFixed(2)}`;
+}
+
+/**
  * Truncate a URL for compact display.
  * @param {string} url - Full URL
  * @param {number} max - Maximum characters (default: 50)


### PR DESCRIPTION
## Summary
Implements cost shortener with K (thousand), M (million), B (billion), T (trillion) suffixes for displaying large cost values.

## Changes
- Added `formatCostAbbreviated()` in `src/shared/utils/formatting.ts`
- Handles sub-cent values with full precision
- Formats using K/M/B/T suffixes for values >= 1K/1M/1B/1T
- Maintains existing `formatCost()` for standard formatting

## Usage
```typescript
import { formatCostAbbreviated } from "@/shared/utils/formatting";

// Examples:
formatCostAbbreviated(1234.56); // ".2K"
formatCostAbbreviated(1234567.89); // ".2M"
formatCostAbbreviated(1234567890.12); // ".2B"
formatCostAbbreviated(1234567890123.45); // ".2T"
```

## Issue Reference
Closes #1900

## Testing
- Build passes
- Commit: 3c8d5cd8