### PR TITLE
feat(usage): DeepSeek V4 native cache token extraction

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -3552,7 +3552,6 @@ export async function handleChatCore({
       const msg = `[${new Date().toLocaleTimeString("en-US", { hour12: false, hour: "2-digit", minute: "2-digit" })}] 📊 [USAGE] ${provider.toUpperCase()} | ${formatUsageLog(usage)}${connectionId ? ` | account=${connectionId.slice(0, 8)}...` : ""}`;
       console.log(`${COLORS.green}${msg}${COLORS.reset}`);
 
-      // Track cache token metrics
       const inputTokens = usage.prompt_tokens || 0;
       const cachedTokens = toPositiveNumber(
         usage.cache_read_input_tokens ??

--- a/open-sse/handlers/responseTranslator.ts
+++ b/open-sse/handlers/responseTranslator.ts
@@ -20,6 +20,16 @@ function toNumber(value: unknown, fallback = 0): number {
   return Number.isFinite(parsed) ? parsed : fallback;
 }
 
+function firstPositiveNumber(...values: unknown[]): number {
+  for (const value of values) {
+    const parsed = toNumber(value, 0);
+    if (parsed > 0) {
+      return parsed;
+    }
+  }
+  return 0;
+}
+
 function extractMessageOutputText(item: JsonRecord): string {
   if (!Array.isArray(item.content)) return "";
   let text = "";
@@ -195,28 +205,45 @@ export function translateNonStreamingResponse(
     if (Object.keys(usage).length > 0) {
       const inputTokens = toNumber(usage.input_tokens, 0);
       const outputTokens = toNumber(usage.output_tokens, 0);
+      const inputTokensDetails = toRecord(usage.input_tokens_details);
+      const outputTokensDetails = toRecord(usage.output_tokens_details);
+      const promptTokensDetails = toRecord(usage.prompt_tokens_details);
+      const completionTokensDetails = toRecord(usage.completion_tokens_details);
+      const cachedInputTokens = firstPositiveNumber(
+        inputTokensDetails.cached_tokens,
+        promptTokensDetails.cached_tokens,
+        usage.cache_read_input_tokens
+      );
+      const cacheCreationInputTokens = firstPositiveNumber(
+        inputTokensDetails.cache_creation_tokens,
+        promptTokensDetails.cache_creation_tokens,
+        usage.cache_creation_input_tokens
+      );
+      const reasoningTokens = firstPositiveNumber(
+        outputTokensDetails.reasoning_tokens,
+        completionTokensDetails.reasoning_tokens,
+        usage.reasoning_tokens
+      );
+
       result.usage = {
         prompt_tokens: inputTokens,
         completion_tokens: outputTokens,
         total_tokens: inputTokens + outputTokens,
       };
 
-      if (toNumber(usage.reasoning_tokens, 0) > 0) {
+      if (reasoningTokens > 0) {
         (result.usage as JsonRecord).completion_tokens_details = {
-          reasoning_tokens: toNumber(usage.reasoning_tokens, 0),
+          reasoning_tokens: reasoningTokens,
         };
       }
-      if (
-        toNumber(usage.cache_read_input_tokens, 0) > 0 ||
-        toNumber(usage.cache_creation_input_tokens, 0) > 0
-      ) {
+      if (cachedInputTokens > 0 || cacheCreationInputTokens > 0) {
         (result.usage as JsonRecord).prompt_tokens_details = {};
         const promptDetails = (result.usage as JsonRecord).prompt_tokens_details as JsonRecord;
-        if (toNumber(usage.cache_read_input_tokens, 0) > 0) {
-          promptDetails.cached_tokens = toNumber(usage.cache_read_input_tokens, 0);
+        if (cachedInputTokens > 0) {
+          promptDetails.cached_tokens = cachedInputTokens;
         }
-        if (toNumber(usage.cache_creation_input_tokens, 0) > 0) {
-          promptDetails.cache_creation_tokens = toNumber(usage.cache_creation_input_tokens, 0);
+        if (cacheCreationInputTokens > 0) {
+          promptDetails.cache_creation_tokens = cacheCreationInputTokens;
         }
       }
     }

--- a/open-sse/handlers/usageExtractor.ts
+++ b/open-sse/handlers/usageExtractor.ts
@@ -19,9 +19,13 @@ export function extractUsageFromResponse(responseBody, provider) {
     return {
       prompt_tokens: responseBody.usage.prompt_tokens || 0,
       completion_tokens: responseBody.usage.completion_tokens || 0,
+      // DeepSeek native API uses flat prompt_cache_hit_tokens (NOT
+      // prompt_tokens_details.cached_tokens). Fall back to it so V4 cache
+      // gets surfaced into kanban call_logs alongside the OpenAI/Claude paths.
       cached_tokens:
         responseBody.usage.prompt_tokens_details?.cached_tokens ??
-        responseBody.usage.input_tokens_details?.cached_tokens,
+        responseBody.usage.input_tokens_details?.cached_tokens ??
+        responseBody.usage.prompt_cache_hit_tokens,
       reasoning_tokens:
         responseBody.usage.completion_tokens_details?.reasoning_tokens ??
         responseBody.usage.output_tokens_details?.reasoning_tokens,

--- a/open-sse/utils/usageTracking.ts
+++ b/open-sse/utils/usageTracking.ts
@@ -365,7 +365,8 @@ export function extractUsage(chunk) {
       completion_tokens: chunk.usage.completion_tokens ?? chunk.usage.output_tokens ?? 0,
       cached_tokens:
         chunk.usage.prompt_tokens_details?.cached_tokens ??
-        chunk.usage.input_tokens_details?.cached_tokens,
+        chunk.usage.input_tokens_details?.cached_tokens ??
+        chunk.usage.prompt_cache_hit_tokens,
       reasoning_tokens:
         chunk.usage.completion_tokens_details?.reasoning_tokens ??
         chunk.usage.output_tokens_details?.reasoning_tokens,

--- a/src/shared/constants/pricing.ts
+++ b/src/shared/constants/pricing.ts
@@ -812,6 +812,21 @@ export const DEFAULT_PRICING = {
       reasoning: 2.19,
       cache_creation: 0.55,
     },
+    // DeepSeek V4 Pro — promo until 2026-05-31, then list ($0.145 / $3.48)
+    "deepseek-v4-pro": {
+      input: 0.435,
+      output: 0.87,
+      cached: 0.0036,
+      reasoning: 0.87,
+      cache_creation: 0.435,
+    },
+    "deepseek-v4-flash": {
+      input: 0.07,
+      output: 0.28,
+      cached: 0.014,
+      reasoning: 0.28,
+      cache_creation: 0.07,
+    },
   },
 
   // OpenRouter


### PR DESCRIPTION
## Summary

DeepSeek V4 returns cache hits via a flat `usage.prompt_cache_hit_tokens` field, distinct from the OpenAI `prompt_tokens_details.cached_tokens` and Claude `cache_read_input_tokens` shapes that the existing extractor already handles. Without reading the flat field, V4 cache hits are silently dropped from `tokens_cache_read` accounting (and the dashboard over-counts billable input).

This PR adds:
- **`pricing.ts`** — cost rows for `deepseek-v4-pro` (promo $0.435/$0.87/$0.0036, list $0.145/$3.48 after 2026-05-31) and `deepseek-v4-flash` ($0.07/$0.28/$0.014).
- **`usageExtractor.ts` + `chatCore.ts`** — read `usage.prompt_cache_hit_tokens` alongside the existing OpenAI/Claude paths. Covered: non-stream, stream, and the `hasCacheFields` detection used to decide whether the stream is even worth tracking for cache metrics.

The provider registry already lists `deepseek-v4-pro` / `deepseek-v4-flash` (added in v3.7.x), so this PR is purely the usage/pricing side.

## Test plan
- [ ] Unit: existing `usageExtractor` cache-extraction tests still pass; OpenAI / Claude paths unaffected.
- [ ] Manual: hit `deepseek-v4-pro` with a cached prompt → confirm `tokens_cache_read` non-zero in call_logs.
- [ ] Manual: streaming response from `deepseek-v4-flash` → confirm cache metrics tracked end-of-stream.