### PR TITLE
feat: enhance cost formatting and add Codex GPT-5.5 pricing support

### DIFF
--- a/src/app/(dashboard)/dashboard/costs/CostOverviewTab.tsx
+++ b/src/app/(dashboard)/dashboard/costs/CostOverviewTab.tsx
@@ -111,6 +111,27 @@ function createCurrencyFormatter(locale: string) {
   });
 }
 
+function formatCurrencyCost(locale: string, value: number): string {
+  const numericValue = Number(value || 0);
+  if (!Number.isFinite(numericValue) || numericValue === 0) {
+    return new Intl.NumberFormat(locale, {
+      style: "currency",
+      currency: "USD",
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(0);
+  }
+
+  const absValue = Math.abs(numericValue);
+  const fractionDigits = absValue < 0.01 ? 6 : absValue < 1 ? 4 : 2;
+  return new Intl.NumberFormat(locale, {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
+  }).format(numericValue);
+}
+
 function csvCell(value: string | number): string {
   const text = String(value);
   return /[",\n]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text;
@@ -398,25 +419,25 @@ export default function CostOverviewTab() {
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
         <MetricCard
           label={t("spendToday")}
-          value={currencyFormatter.format(presetCosts["1d"] || 0)}
+          value={formatCurrencyCost(locale, presetCosts["1d"] || 0)}
           loading={summaryLoading}
           color="text-emerald-400"
         />
         <MetricCard
           label={t("spend7d")}
-          value={currencyFormatter.format(presetCosts["7d"] || 0)}
+          value={formatCurrencyCost(locale, presetCosts["7d"] || 0)}
           loading={summaryLoading}
           color="text-sky-400"
         />
         <MetricCard
           label={t("spend30d")}
-          value={currencyFormatter.format(presetCosts["30d"] || 0)}
+          value={formatCurrencyCost(locale, presetCosts["30d"] || 0)}
           loading={summaryLoading}
           color="text-violet-400"
         />
         <MetricCard
           label={t("selectedWindow")}
-          value={currencyFormatter.format(summary.totalCost || 0)}
+          value={formatCurrencyCost(locale, summary.totalCost || 0)}
           subValue={selectedRangeLabel}
           color="text-amber-400"
         />
@@ -438,7 +459,7 @@ export default function CostOverviewTab() {
           />
           <CompactMetric
             label={t("avgCostPerRequest")}
-            value={currencyFormatter.format(avgCostPerRequest)}
+            value={formatCurrencyCost(locale, avgCostPerRequest)}
           />
         </div>
       </Card>

--- a/src/app/api/usage/analytics/route.ts
+++ b/src/app/api/usage/analytics/route.ts
@@ -64,6 +64,44 @@ function findKeyInsensitive(obj: Record<string, any> | undefined | null, key: st
   return obj[key.toLowerCase()];
 }
 
+function uniqueValues(values: Array<string | null | undefined>): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const value of values) {
+    const normalized = typeof value === "string" ? value.trim().toLowerCase() : "";
+    if (!normalized || seen.has(normalized)) continue;
+    seen.add(normalized);
+    result.push(normalized);
+  }
+  return result;
+}
+
+function stripCodexEffortSuffix(model: string): string {
+  return model.replace(/-(?:xhigh|high|medium|low|none)$/i, "");
+}
+
+function getPricingModelCandidates(
+  model: string,
+  normalizeModelName: (model: string) => string
+): string[] {
+  const normalizedModel = normalizeModelName(model);
+  const lowerModel = model.toLowerCase();
+  const lowerNormalized = normalizedModel.toLowerCase();
+  const hyphenModel = lowerModel.replace(/\./g, "-");
+  const hyphenNormalized = lowerNormalized.replace(/\./g, "-");
+  const effortBaseModel = stripCodexEffortSuffix(lowerNormalized);
+
+  return uniqueValues([
+    lowerModel,
+    lowerNormalized,
+    hyphenModel,
+    hyphenNormalized,
+    effortBaseModel,
+    effortBaseModel.replace(/\./g, "-"),
+    lowerNormalized === "codex-auto-review" ? "gpt-5.5" : null,
+  ]);
+}
+
 function resolveModelPricing(
   pricingByProvider: PricingByProvider,
   providerAliasMap: Record<string, string>,
@@ -91,22 +129,15 @@ function resolveModelPricing(
     if (pLower === "antigravity") providerPricing = findKeyInsensitive(pricingByProvider, "ag");
   }
 
-  const normalizedModel = normalizeModelName(model).toLowerCase();
-  const shortModel = normalizedModel; // normalizeModelName behaves exactly like shortModelName
-  const hyphenModel = model.toLowerCase().replace(/\./g, "-");
-  const hyphenNormalized = normalizedModel.replace(/\./g, "-");
-  const lowerModel = model.toLowerCase();
+  const modelCandidates = getPricingModelCandidates(model, normalizeModelName);
 
   const tryFind = (prov: Record<string, unknown> | null | undefined) => {
     if (!prov || typeof prov !== "object") return null;
-    return (
-      findKeyInsensitive(prov as Record<string, unknown>, lowerModel) ||
-      findKeyInsensitive(prov as Record<string, unknown>, normalizedModel) ||
-      findKeyInsensitive(prov as Record<string, unknown>, shortModel) ||
-      findKeyInsensitive(prov as Record<string, unknown>, hyphenModel) ||
-      findKeyInsensitive(prov as Record<string, unknown>, hyphenNormalized) ||
-      null
-    );
+    for (const candidate of modelCandidates) {
+      const pricing = findKeyInsensitive(prov as Record<string, unknown>, candidate);
+      if (pricing) return pricing;
+    }
+    return null;
   };
 
   let pricing = providerPricing ? tryFind(providerPricing) : null;
@@ -478,10 +509,20 @@ export async function GET(request: Request) {
           COUNT(*) as total,
           SUM(CASE WHEN requested_model IS NOT NULL AND requested_model != '' THEN 1 ELSE 0 END) as with_requested,
           SUM(CASE
-            WHEN requested_model IS NOT NULL
+            WHEN (combo_name IS NULL OR combo_name = '')
+             AND requested_model IS NOT NULL
              AND requested_model != ''
              AND model IS NOT NULL
-             AND requested_model != model
+             AND model != ''
+            THEN 1 ELSE 0 END
+          ) as fallback_eligible,
+          SUM(CASE
+            WHEN (combo_name IS NULL OR combo_name = '')
+             AND requested_model IS NOT NULL
+             AND requested_model != ''
+             AND model IS NOT NULL
+             AND model != ''
+             AND LOWER(requested_model) != LOWER(model)
             THEN 1 ELSE 0 END
           ) as fallbacks
         FROM call_logs
@@ -515,10 +556,11 @@ export async function GET(request: Request) {
       lastRequest: summaryRow?.lastRequest || "",
       fallbackCount: Number(fallbackRow?.fallbacks || 0),
       fallbackRatePct:
-        Number(fallbackRow?.with_requested || 0) > 0
+        Number(fallbackRow?.fallback_eligible || 0) > 0
           ? Number(
               (
-                (Number(fallbackRow?.fallbacks || 0) / Number(fallbackRow?.with_requested || 1)) *
+                (Number(fallbackRow?.fallbacks || 0) /
+                  Number(fallbackRow?.fallback_eligible || 1)) *
                 100
               ).toFixed(2)
             )

--- a/src/shared/constants/pricing.ts
+++ b/src/shared/constants/pricing.ts
@@ -175,6 +175,7 @@ export const DEFAULT_PRICING = {
 
   // OpenAI Codex (cx)
   cx: {
+    "codex-auto-review": GPT_5_5_PRICING,
     // GPT 5.5
     "gpt-5.5": GPT_5_5_PRICING,
     "gpt5.5": GPT_5_5_PRICING,

--- a/tests/unit/usage-analytics-route.test.ts
+++ b/tests/unit/usage-analytics-route.test.ts
@@ -132,6 +132,74 @@ test("GET /api/usage/analytics includes byModel array with cost calculations", a
   assert.ok(gptEntry.cost > 0);
 });
 
+test("GET /api/usage/analytics resolves Codex GPT-5.5 pricing through provider aliases", async () => {
+  const db = core.getDbInstance();
+  db.prepare(
+    `INSERT INTO usage_history (provider, model, connection_id, tokens_input, tokens_output, success, latency_ms, timestamp)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run("codex", "gpt-5.5", "codex-conn", 1000, 500, 1, 250, new Date().toISOString());
+
+  const response = await analyticsRoute.GET(makeRequest("http://localhost/api/usage/analytics"));
+  const body = await response.json();
+
+  assert.equal(response.status, 200);
+  assertClose(body.summary.totalCost, 0.02);
+  assert.equal(body.byProvider[0].provider, "codex");
+  assertClose(body.byProvider[0].cost, 0.02);
+  assert.equal(body.byModel[0].model, "gpt-5.5");
+  assertClose(body.byModel[0].cost, 0.02);
+});
+
+test("GET /api/usage/analytics maps Codex auto-review usage to GPT-5.5 pricing", async () => {
+  const db = core.getDbInstance();
+  db.prepare(
+    `INSERT INTO usage_history (provider, model, connection_id, tokens_input, tokens_output, success, latency_ms, timestamp)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run(
+    "codex",
+    "codex-auto-review",
+    "codex-conn",
+    1000,
+    500,
+    1,
+    250,
+    new Date().toISOString()
+  );
+
+  const response = await analyticsRoute.GET(makeRequest("http://localhost/api/usage/analytics"));
+  const body = await response.json();
+
+  assert.equal(response.status, 200);
+  assertClose(body.summary.totalCost, 0.02);
+  assert.equal(body.byModel[0].model, "codex-auto-review");
+  assertClose(body.byModel[0].cost, 0.02);
+});
+
+test("GET /api/usage/analytics ignores normal combo routing in fallback statistics", async () => {
+  const db = core.getDbInstance();
+  const timestamp = new Date().toISOString();
+  db.prepare(
+    `INSERT INTO usage_history (provider, model, connection_id, tokens_input, tokens_output, success, latency_ms, timestamp)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run("codex", "gpt-5.5", "codex-conn", 1000, 500, 1, 250, timestamp);
+  db.prepare(
+    `INSERT INTO call_logs (id, provider, model, requested_model, combo_name, connection_id, timestamp)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`
+  ).run("combo-call", "codex", "gpt-5.5", "combo/dev", "dev", "codex-conn", timestamp);
+  db.prepare(
+    `INSERT INTO call_logs (id, provider, model, requested_model, connection_id, timestamp)
+     VALUES (?, ?, ?, ?, ?, ?)`
+  ).run("same-model-call", "codex", "GPT-5.5", "gpt-5.5", "codex-conn", timestamp);
+
+  const response = await analyticsRoute.GET(makeRequest("http://localhost/api/usage/analytics"));
+  const body = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.equal(body.summary.fallbackCount, 0);
+  assert.equal(body.summary.fallbackRatePct, 0);
+  assert.equal(body.summary.requestedModelCoveragePct, 100);
+});
+
 test("GET /api/usage/analytics filters by range parameter", async () => {
   await seedAnalyticsData();
 


### PR DESCRIPTION
## Summary

- Fixes Costs/Analytics cost statistics for Codex GPT-5.5 combo usage so estimated costs no longer show as `$0.00` when token usage exists and pricing is configured.
- Improves Codex pricing resolution for provider aliases, GPT-5.5 effort variants, and `codex-auto-review`.
- Prevents normal combo routing from being counted as a fallback in Costs/Analytics fallback statistics.
- Updates the Costs page to display sub-cent cost values with enough precision instead of rounding them to `$0.00`.

## Related Issues

- Closes #1934
- Related to #

## Validation

- [x] `npm run lint`
  - Passed with `0 errors`, `1994 warnings`.
- [ ] `npm run test:unit`
  - Failed due to an existing unrelated failing test:
    - plan3-p0.test.ts
    - `getModelInfoCore resolves unique non-openai unprefixed model`
    - Assertion: `null !== 'claude'`
  - Targeted changed test passed separately: usage-analytics-route.test.ts (`14/14`).
- [ ] `npm run test:coverage`
  - Failed because the same unrelated unit test failed.
- [x] Coverage is still `>= 60%` for statements, lines, functions, and branches
  - Statements: `83.43%`
  - Lines: `83.43%`
  - Functions: `86.53%`
  - Branches: `75.2%`
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below
  - Not run locally: no active PR was available and `sonar-scanner` was not installed.
  - Remaining known issue: the unrelated plan3-p0.test.ts failure above prevents a fully green local unit/coverage gate.

## Tests Added Or Updated

- Updated usage-analytics-route.test.ts
  - Added Codex GPT-5.5 provider-alias pricing coverage.
  - Added `codex-auto-review` → GPT-5.5 pricing coverage.
  - Added combo-routing fallback-statistics coverage.

## Coverage Notes

- This PR changes production code in src.
- Coverage for the change is provided by usage-analytics-route.test.ts, which validates:
  - estimated cost calculation for `codex/gpt-5.5`,
  - estimated cost calculation for `codex-auto-review`,
  - combo route executions are not counted as fallback events.
- The touched test file passed locally (`14/14`).
- Full coverage remained above the required `60%` threshold for all metrics, but the coverage command exited non-zero due to the unrelated `plan3-p0` test failure.

## Reviewer Notes

- No database migrations or feature flags were added.
- The fallback-rate change intentionally excludes rows with `combo_name` from fallback counting, because combo model selection is normal routing, not a fallback.
- Cost formatting only affects the Costs page KPI display for sub-cent values; exported raw costs and analytics calculations remain numeric.