### PR TITLE
Support root user for MITM sudo handling

### DIFF
--- a/src/app/api/cli-tools/antigravity-mitm/route.ts
+++ b/src/app/api/cli-tools/antigravity-mitm/route.ts
@@ -7,6 +7,7 @@ import { requireCliToolsAuth } from "@/lib/api/requireCliToolsAuth";
 import { cliMitmStartSchema, cliMitmStopSchema } from "@/shared/validation/schemas";
 import { isValidationFailure, validateBody } from "@/shared/validation/helpers";
 import { resolveApiKey } from "@/shared/services/apiKeyResolver";
+import { isRoot } from "@/mitm/systemCommands";
 
 // GET - Check MITM status
 export async function GET(request) {
@@ -60,9 +61,10 @@ export async function POST(request) {
     const apiKey = await resolveApiKey(apiKeyId, rawApiKey);
     const { startMitm, getCachedPassword, setCachedPassword } = await import("@/mitm/manager");
     const isWin = process.platform === "win32";
+    const isRootUser = !isWin && isRoot();
     const pwd = sudoPassword || getCachedPassword() || "";
 
-    if (!apiKey || (!isWin && !pwd)) {
+    if (!apiKey || (!isWin && !pwd && !isRootUser)) {
       return NextResponse.json(
         { error: isWin ? "Missing apiKey" : "Missing apiKey or sudoPassword" },
         { status: 400 }
@@ -114,9 +116,10 @@ export async function DELETE(request) {
     const { sudoPassword } = validation.data;
     const { stopMitm, getCachedPassword, setCachedPassword } = await import("@/mitm/manager");
     const isWin = process.platform === "win32";
+    const isRootUser = !isWin && isRoot();
     const pwd = sudoPassword || getCachedPassword() || "";
 
-    if (!isWin && !pwd) {
+    if (!isWin && !pwd && !isRootUser) {
       return NextResponse.json({ error: "Missing sudoPassword" }, { status: 400 });
     }
 

--- a/src/mitm/systemCommands.ts
+++ b/src/mitm/systemCommands.ts
@@ -4,6 +4,14 @@ export function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+export function isRoot(): boolean {
+  try {
+    return !!(process.getuid && process.getuid() === 0);
+  } catch {
+    return false;
+  }
+}
+
 export function execFileText(command: string, args: string[]): Promise<string> {
   return new Promise((resolve, reject) => {
     execFile(command, args, { encoding: "utf8" }, (error, stdout, stderr) => {
@@ -22,8 +30,22 @@ export function execFileWithPassword(
   password: string,
   stdinAfterPassword = ""
 ): Promise<string> {
+  // When running as root, skip sudo -S and run the target command directly
+  const root = isRoot();
+  const needsPassword = !root || command !== "sudo";
+  let finalCommand = command;
+  let finalArgs = args;
+
+  if (root && command === "sudo") {
+    const realCmdIndex = args.findIndex((arg) => !arg.startsWith("-"));
+    if (realCmdIndex !== -1) {
+      finalCommand = args[realCmdIndex];
+      finalArgs = args.slice(realCmdIndex + 1);
+    }
+  }
+
   return new Promise((resolve, reject) => {
-    const child = spawn(command, args, {
+    const child = spawn(finalCommand, finalArgs, {
       stdio: ["pipe", "pipe", "pipe"],
     });
     let stdout = "";
@@ -57,7 +79,12 @@ export function execFileWithPassword(
       settle(new Error(`Command failed with code ${code}\n${stderr}`));
     });
 
-    child.stdin?.write(`${password}\n${stdinAfterPassword}`);
+    const stdinInput = needsPassword
+      ? `${password}\n${stdinAfterPassword}`
+      : stdinAfterPassword || "";
+    if (stdinInput) {
+      child.stdin?.write(stdinInput);
+    }
     child.stdin?.end();
   });
 }


### PR DESCRIPTION
## Summary

Add isRoot() helper and allow operations when running as root. systemCommands.ts: introduce isRoot(), update execFileWithPassword to skip sudo wrapper when already root (extract real command/args), and avoid sending a password to stdin when not needed. route.ts: use isRoot() to let non-Windows requests proceed without sudoPassword if the process is running as root. This enables running MITM commands as root without requiring a sudo password while keeping existing behavior on Windows and non-root environments.

## Related Issues

- Closes #
- Related to #

## Validation

- [ ] `npm run lint`
- [ ] `npm run test:unit`
- [ ] `npm run test:coverage`
- [ ] Coverage is still `>= 60%` for statements, lines, functions, and branches
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below

## Tests Added Or Updated

- List every changed or added automated test file.
- If no production code changed, state that here.

## Coverage Notes

- If this PR changes `src/`, `open-sse/`, `electron/`, or `bin/`, explain which tests cover the change.
- If coverage moved down in any touched file, explain why and what follow-up task will recover it.

## Reviewer Notes

- Call out any risky areas, migrations, feature flags, or manual validation that reviewers should know about.
