### PR TITLE
chore(model): Update new models, Delete Deprecated models

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,9 @@
 # ┌─────────────────────────────────────────────────────────────────────────────┐
-# │                          OmniRoute — .env Contract                        │
-# │  This file documents EVERY environment variable read by the runtime.      │
-# │  Copy to .env and adjust values. Lines starting with # are commented out  │
-# │  (optional / off-by-default). Uncomment only what you need.               │
-# │  Reference: docs/ENVIRONMENT.md for full details and usage scenarios.     │
+# │                          OmniRoute — .env Contract                          │
+# │  This file documents EVERY environment variable read by the runtime.        │
+# │  Copy to .env and adjust values. Lines starting with # are commented out    │
+# │  (optional / off-by-default). Uncomment only what you need.                 │
+# │  Reference: docs/ENVIRONMENT.md for full details and usage scenarios.       │
 # └─────────────────────────────────────────────────────────────────────────────┘
 
 

--- a/open-sse/config/imageRegistry.ts
+++ b/open-sse/config/imageRegistry.ts
@@ -131,11 +131,7 @@ export const IMAGE_PROVIDERS: Record<string, ImageProviderConfig> = {
     authType: "oauth",
     authHeader: "bearer",
     format: "codex-responses",
-    models: [
-      { id: "gpt-5.5", name: "GPT 5.5 (Codex Image)" },
-      { id: "gpt-5.4", name: "GPT 5.4 (Codex Image)" },
-      { id: "gpt-5.3-codex", name: "GPT 5.3 Codex (Image)" },
-    ],
+    models: [{ id: "gpt-5.5", name: "GPT 5.5 (Codex Image)" }],
     supportedSizes: ["1024x1024", "1024x1536", "1536x1024"],
   },
 
@@ -156,7 +152,10 @@ export const IMAGE_PROVIDERS: Record<string, ImageProviderConfig> = {
     authType: "apikey",
     authHeader: "bearer",
     format: "openai",
-    models: [{ id: "grok-imagine-image", name: "Grok Imagine Image" }],
+    models: [
+      { id: "grok-imagine-image-pro", name: "Grok Imagine Image Pro" },
+      { id: "grok-imagine-image", name: "Grok Imagine Image" },
+    ],
     supportedSizes: ["1024x1024"],
   },
 

--- a/open-sse/config/providerRegistry.ts
+++ b/open-sse/config/providerRegistry.ts
@@ -133,9 +133,8 @@ const KIMI_CODING_SHARED = {
     "Anthropic-Beta": ANTHROPIC_BETA_API_KEY,
   },
   models: [
-    { id: "kimi-k2.5", name: "Kimi K2.5" },
-    { id: "kimi-k2.5-thinking", name: "Kimi K2.5 Thinking" },
-    { id: "kimi-latest", name: "Kimi Latest" },
+    { id: "kimi-k2.6", name: "Kimi K2.6" },
+    { id: "kimi-k2.6-thinking", name: "Kimi K2.6 Thinking" },
   ] as RegistryModel[],
 } as const;
 
@@ -384,11 +383,9 @@ export const REGISTRY: Record<string, RegistryEntry> = {
       tokenUrl: "https://auth.openai.com/oauth/token",
     },
     models: [
-      { id: "codex-auto-review", name: "Codex Auto Review", targetFormat: "openai-responses" },
       { id: "gpt-5.5-xhigh", name: "GPT 5.5 (xHigh)", ...GPT_5_5_CODEX_CAPABILITIES },
       { id: "gpt-5.5-high", name: "GPT 5.5 (High)", ...GPT_5_5_CODEX_CAPABILITIES },
       { id: "gpt-5.5-medium", name: "GPT 5.5 (Medium)", ...GPT_5_5_CODEX_CAPABILITIES },
-      { id: "gpt-5.5", name: "GPT 5.5", ...GPT_5_5_CODEX_CAPABILITIES },
       { id: "gpt-5.5-low", name: "GPT 5.5 (Low)", ...GPT_5_5_CODEX_CAPABILITIES },
       { id: "gpt-5.4", name: "GPT 5.4", targetFormat: "openai-responses" },
       { id: "gpt-5.4-mini", name: "GPT 5.4 Mini", targetFormat: "openai-responses" },
@@ -493,10 +490,7 @@ export const REGISTRY: Record<string, RegistryEntry> = {
     models: [
       { id: "gpt-4.1", name: "GPT-4.1" },
       { id: "gpt-5-mini", name: "GPT-5 Mini" },
-      { id: "gpt-5.2", name: "GPT-5.2" },
-      { id: "gpt-5.2-codex", name: "GPT-5.2 Codex", targetFormat: "openai-responses" },
       { id: "gpt-5.3-codex", name: "GPT-5.3 Codex", targetFormat: "openai-responses" },
-      { id: "gpt-5.4-nano", name: "GPT-5.4 Nano", targetFormat: "openai-responses" },
       { id: "gpt-5.4-mini", name: "GPT-5.4 Mini", targetFormat: "openai-responses" },
       { id: "gpt-5.4", name: "GPT-5.4", targetFormat: "openai-responses" },
       { id: "gpt-5.5", name: "GPT-5.5", ...GPT_5_5_CODEX_CAPABILITIES },
@@ -510,7 +504,7 @@ export const REGISTRY: Record<string, RegistryEntry> = {
       { id: "gemini-3-flash-preview", name: "Gemini 3 Flash" },
       { id: "grok-code-fast-1", name: "Grok Code Fast 1" },
       { id: "oswe-vscode-prime", name: "Raptor Mini" },
-      //{id: "?", name: "Goldeneye" },
+      //{ id: "?", name: "Goldeneye" },
     ],
   },
 

--- a/open-sse/services/model.ts
+++ b/open-sse/services/model.ts
@@ -73,7 +73,7 @@ for (const [aliasOrId, models] of Object.entries(PROVIDER_MODELS)) {
   }
 }
 const KNOWN_MODEL_IDS = new Set(MODEL_TO_PROVIDERS.keys());
-const CODEX_PREFERRED_UNPREFIXED_MODELS = new Set(["codex-auto-review", "gpt-5.5"]);
+const CODEX_PREFERRED_UNPREFIXED_MODELS = new Set(["gpt-5.5"]);
 
 /**
  * Resolve provider alias to provider ID

--- a/tests/unit/plan3-p0.test.ts
+++ b/tests/unit/plan3-p0.test.ts
@@ -28,15 +28,15 @@ test("getModelInfoCore keeps openai fallback for gpt-4o", async () => {
   assert.equal(info.model, "gpt-4o");
 });
 
-test("getModelInfoCore resolves codex-auto-review to codex", async () => {
+test("getModelInfoCore routes removed codex-auto-review through the default fallback", async () => {
   const info = await getModelInfoCore("codex-auto-review", {});
-  assert.equal(info.provider, "codex");
+  assert.equal(info.provider, "openai");
   assert.equal(info.model, "codex-auto-review");
 });
 
-test("getModelInfoCore resolves gpt-5.5 to codex", async () => {
+test("getModelInfoCore keeps unprefixed gpt-5.5 on the OpenAI fallback", async () => {
   const info = await getModelInfoCore("gpt-5.5", {});
-  assert.equal(info.provider, "codex");
+  assert.equal(info.provider, "openai");
   assert.equal(info.model, "gpt-5.5");
 });
 
@@ -52,15 +52,15 @@ test("getModelInfoCore resolves explicit gpt-5.5 Codex model", async () => {
   assert.equal(info.model, "gpt-5.5");
 });
 
-test("getModelInfoCore resolves gpt-5.5 to codex", async () => {
+test("getModelInfoCore keeps duplicate unprefixed gpt-5.5 checks on OpenAI", async () => {
   const info = await getModelInfoCore("gpt-5.5", {});
-  assert.equal(info.provider, "codex");
+  assert.equal(info.provider, "openai");
   assert.equal(info.model, "gpt-5.5");
 });
 
-test("getModelInfoCore resolves gpt-5.5 to codex", async () => {
+test("getModelInfoCore keeps repeated unprefixed gpt-5.5 checks on OpenAI", async () => {
   const info = await getModelInfoCore("gpt-5.5", {});
-  assert.equal(info.provider, "codex");
+  assert.equal(info.provider, "openai");
   assert.equal(info.model, "gpt-5.5");
 });
 

--- a/tests/unit/t20-t22-provider-headers.test.ts
+++ b/tests/unit/t20-t22-provider-headers.test.ts
@@ -56,11 +56,12 @@ test("T22: github config exposes dedicated responses endpoint", () => {
   assert.equal(github.baseUrl, "https://api.githubcopilot.com/chat/completions");
 });
 
-test("T20: codex config advertises current client headers and auto-review model", () => {
+test("T20: codex config advertises current client headers and supported models", () => {
   const codex = REGISTRY.codex;
   assert.equal(codex.headers.Version, "0.125.0");
   assert.equal(codex.headers["Openai-Beta"], "responses=experimental");
   assert.equal(codex.headers["X-Codex-Beta-Features"], "responses_websockets");
   assert.equal(codex.headers["User-Agent"], "codex-cli/0.125.0 (Windows 10.0.26200; x64)");
-  assert.ok(codex.models.some((model) => model.id === "codex-auto-review"));
+  assert.ok(codex.models.some((model) => model.id === "gpt-5.5-medium"));
+  assert.ok(!codex.models.some((model) => model.id === "codex-auto-review"));
 });


### PR DESCRIPTION
## Summary

- Updated model registries to reflect current supported models.
- Replaced Kimi Coding models with Kimi K2.6 variants.
- Removed deprecated Codex/GitHub Copilot model entries.
- Added Grok Imagine Image Pro to the image model registry.
- Applied formatting cleanup to `.env.example`.

## Tests Added Or Updated

- No automated tests were added or updated.
- Production config changed in:
  - `open-sse/config/providerRegistry.ts`
  - `open-sse/config/imageRegistry.ts`

## Coverage Notes

- This PR changes `open-sse/` model registry configuration only.
- No coverage run was completed.
- Existing tests that assert deprecated model availability may need to be updated if the removals are intended.

## Reviewer Notes
 
1. Explain why delete 'codex-auto-review'.
Read https://alignment.openai.com/auto-review please.
<img width="954" height="104" alt="image" src="https://github.com/user-attachments/assets/c4a580e3-2ed1-4043-8e06-fc1c0724d993" />
It says it uses “5.4 Thinking low.” In other words, since GPT-5.4 is already listed in the model list, I don't understand why they had to upload “5.4 Thinking low” as just a renamed version.

2. why delete gpt-5.5 on codex?
If you simply call GPT-5.5, it will automatically be routed to GPT-5.5-medium. Since I had already registered gpt-5.5-medium, I deleted this one as it was a duplicate.

3. why delete gpt-5.4-nano?
Read https://docs.github.com/en/copilot/reference/ai-models/supported-models
<img width="942" height="571" alt="image" src="https://github.com/user-attachments/assets/8a7506ec-fec3-4ac0-bae3-5c70d4efc3c2" />
<img width="936" height="215" alt="image" src="https://github.com/user-attachments/assets/79bbda99-728c-4f8a-8e02-5764aaea8a4c" />
GPT-5.4 nano not supporting anywhere on Github Copliot.

4. why delete gpt-5.2, 5.2-codex on github copilot?
Read https://github.blog/changelog/2026-05-01-upcoming-deprecation-of-gpt-5-2-and-gpt-5-2-codex

5. why delete kimi-latest?
Check https://platform.kimi.ai/docs/models
<img width="960" height="206" alt="image" src="https://github.com/user-attachments/assets/0931bfd3-5c4f-413d-abcf-15134ab894d2" />
kimi-latest dead on January 28, 2026.