### PR TITLE
fix(codex): preserve final_answer responses replay

### DIFF
--- a/open-sse/services/responsesInputSanitizer.ts
+++ b/open-sse/services/responsesInputSanitizer.ts
@@ -1,4 +1,5 @@
 type JsonRecord = Record<string, unknown>;
+const INTERNAL_ASSISTANT_PHASES = new Set(["commentary"]);
 
 function toRecord(value: unknown): JsonRecord | null {
   return value && typeof value === "object" && !Array.isArray(value) ? (value as JsonRecord) : null;
@@ -15,9 +16,9 @@ export function isInternalAssistantMessage(record: JsonRecord): boolean {
   const phase = typeof record.phase === "string" ? record.phase.trim().toLowerCase() : "";
   if (!phase) return false;
 
-  // OpenCode can send assistant-side commentary/analysis frames in Responses
-  // shape. Those frames are local runtime state, not durable conversation turns.
-  return phase !== "final";
+  // Drop only known internal runtime frames. Visible assistant turns such as
+  // `final` and `final_answer` must survive replay for Codex/OpenCode follow-ups.
+  return INTERNAL_ASSISTANT_PHASES.has(phase);
 }
 
 export function sanitizeResponsesInputItems(items: readonly unknown[], clone = true): unknown[] {

--- a/tests/unit/executor-codex.test.ts
+++ b/tests/unit/executor-codex.test.ts
@@ -468,6 +468,57 @@ test("CodexExecutor.transformRequest does not replay internal assistant commenta
   assert.equal(result.input[3].type, "function_call_output");
 });
 
+test("CodexExecutor.transformRequest preserves replayed assistant final_answer messages", () => {
+  const executor = new CodexExecutor();
+  rememberResponseConversationState(
+    "resp_prev_final_answer_123",
+    [
+      {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: "9+10?" }],
+      },
+      {
+        type: "message",
+        role: "assistant",
+        phase: "final_answer",
+        content: [{ type: "output_text", text: "19" }],
+      },
+    ],
+    []
+  );
+
+  const result = executor.transformRequest(
+    "gpt-5.5-low",
+    {
+      _nativeCodexPassthrough: true,
+      previous_response_id: "resp_prev_final_answer_123",
+      input: [
+        {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "did you answered?" }],
+        },
+      ],
+      stream: false,
+    },
+    false,
+    { requestEndpointPath: "/responses" }
+  );
+
+  assert.equal(
+    result.input.some((item) => JSON.stringify(item).includes('"text":"19"')),
+    true
+  );
+  assert.equal(
+    result.input.some((item) => {
+      if (!item || typeof item !== "object" || Array.isArray(item)) return false;
+      return item.role === "assistant" && item.phase === "final_answer";
+    }),
+    true
+  );
+});
+
 test("CodexExecutor.transformRequest strips raw internal assistant commentary without dropping useful Responses items", () => {
   const executor = new CodexExecutor();
   const body = {
@@ -489,6 +540,12 @@ test("CodexExecutor.transformRequest strips raw internal assistant commentary wi
         role: "assistant",
         phase: "final",
         content: [{ type: "output_text", text: "Visible final assistant answer." }],
+      },
+      {
+        type: "message",
+        role: "assistant",
+        phase: "final_answer",
+        content: [{ type: "output_text", text: "Visible final_answer assistant answer." }],
       },
       {
         type: "message",
@@ -524,6 +581,12 @@ test("CodexExecutor.transformRequest strips raw internal assistant commentary wi
   );
   assert.equal(
     result.input.some((item) => JSON.stringify(item).includes("Visible final assistant answer")),
+    true
+  );
+  assert.equal(
+    result.input.some((item) =>
+      JSON.stringify(item).includes("Visible final_answer assistant answer")
+    ),
     true
   );
   assert.equal(


### PR DESCRIPTION
## Summary
Switch the Responses replay sanitizer from a `final` whitelist to a narrow blacklist of known internal assistant phases.

Today OmniRoute drops every assistant message whose `phase` is not exactly `final`. That correctly removes internal `commentary` frames, but it also drops visible assistant turns such as `phase: "final_answer"`.

## Why I want this change
I am reproducing a conversation-state bug when using Codex CLI through OmniRoute over the Responses API. My setup is Codex CLI with `gpt-5.4` (via the Codex provider / `codex/gpt-5.4`).

A simple repro looks like this:
1. Ask `9+10?`
2. Assistant replies `19`
3. Ask `did you answered?`
4. The next request replays prior Responses items, but OmniRoute strips the assistant `phase: "final_answer"` item, so the model behaves as if it never answered.

I saw the same symptom class with other proxy stacks that reconstruct Responses state, which is why preserving visible assistant replay items matters here.

## Why blacklist is safer than the current whitelist
The original intent of the sanitizer makes sense: internal runtime frames like `commentary` should not be replayed as durable conversation turns.

The problem is that the current rule is effectively:
- keep only `phase: "final"`
- drop everything else

That is too strict for Codex/OpenCode-style Responses replay, where visible assistant turns can legitimately arrive as `final_answer`.

This PR keeps the filter, but narrows it to a blacklist of known internal phases instead:
- drop `commentary`
- keep `final`
- keep `final_answer`
- keep assistant history without a `phase`

That preserves the original protection against commentary leakage without deleting valid assistant history.

## Tests
Added regression coverage for:
- remembered conversation replay preserving assistant `phase: "final_answer"`
- raw Responses `input` preserving assistant `phase: "final_answer"`
- existing `commentary` stripping behavior

## Validation
- `node --import tsx/esm --test tests/unit/executor-codex.test.ts`

## Note
A full `git push` pre-push run in my environment hit an unrelated existing failure outside this diff:
- `tests/unit/plan3-p0.test.ts`: `getModelInfoCore resolves unique non-openai unprefixed model`
