### PR TITLE
fix: add default Gemini CLI OAuth client secret

### DIFF
--- a/src/lib/oauth/constants/oauth.ts
+++ b/src/lib/oauth/constants/oauth.ts
@@ -63,7 +63,7 @@ export const GEMINI_CONFIG = {
     process.env.GEMINI_OAUTH_CLIENT_ID ||
     "681255809395-oo8ft2oprdrnp9e3aqf6av3hmdib135j.apps.googleusercontent.com",
   clientSecret:
-    process.env.GEMINI_CLI_OAUTH_CLIENT_SECRET || process.env.GEMINI_OAUTH_CLIENT_SECRET || "",
+    process.env.GEMINI_CLI_OAUTH_CLIENT_SECRET || process.env.GEMINI_OAUTH_CLIENT_SECRET || "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",
   authorizeUrl: "https://accounts.google.com/o/oauth2/v2/auth",
   tokenUrl: "https://oauth2.googleapis.com/token",
   userInfoUrl: "https://www.googleapis.com/oauth2/v1/userinfo",


### PR DESCRIPTION
## Problem

Clicking "Add connection" for Gemini CLI fails with:

```
Token exchange failed: { "error": "invalid_request", "error_description": "client_secret is missing." }
```

The `GEMINI_CONFIG.clientSecret` defaults to an empty string `""`, so the token exchange request to Google omits the `client_secret` parameter.

## Fix

Set the default `clientSecret` to the public OAuth client secret from the official [Gemini CLI source](https://github.com/google-gemini/gemini-cli/blob/main/packages/core/src/code_assist/oauth2.ts):

```ts
// Before
process.env.GEMINI_CLI_OAUTH_CLIENT_SECRET || process.env.GEMINI_OAUTH_CLIENT_SECRET || "",

// After
process.env.GEMINI_CLI_OAUTH_CLIENT_SECRET || process.env.GEMINI_OAUTH_CLIENT_SECRET || "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",
```

This is safe to embed — Google explicitly allows it for installed/desktop applications (see [OAuth 2.0 for Installed Apps](https://developers.google.com/identity/protocols/oauth2#installed)), and the Gemini CLI itself ships this secret in its source code with the comment:

> *"It's ok to save this in git because this is an installed application. The process results in a client ID and, in some cases, a client secret, which you embed in the source code of your application. (In this context, the client secret is obviously not treated as a secret.)"*

This follows the same pattern already used by `ANTIGRAVITY_CONFIG` (line 141) which has its default secret populated from the same type of Google OAuth client.

## Testing

1. Start OmniRoute
2. Navigate to `/dashboard/providers/gemini-cli`
3. Click "Add connection"
4. Sign in with Google account
5. Connection should be established successfully