### PR TITLE
fix: allow Unicode letters in API key name validation

### DIFF
--- a/src/app/(dashboard)/dashboard/api-manager/ApiManagerPageClient.tsx
+++ b/src/app/(dashboard)/dashboard/api-manager/ApiManagerPageClient.tsx
@@ -42,8 +42,8 @@ function validateKeyName(
   if (name.length > MAX_KEY_NAME_LENGTH) {
     return { valid: false, error: t("keyNameTooLong", { max: MAX_KEY_NAME_LENGTH }) };
   }
-  // Only allow alphanumeric, spaces, hyphens, underscores
-  if (!/^[a-zA-Z0-9_\-\s]+$/.test(name)) {
+  // Allow Unicode letters (accented chars), numbers, spaces, hyphens, underscores
+  if (!/^[\p{L}\p{N}_\-\s]+$/u.test(name)) {
     return {
       valid: false,
       error: t("keyNameInvalid"),

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -977,7 +977,7 @@
     "tipSeparate": "Create separate keys for different clients or environments",
     "tipRestrict": "Restrict keys to specific models for better security and cost control",
     "keyName": "Key Name",
-    "keyNamePlaceholder": "e.g., Production Key, Development Key",
+    "keyNamePlaceholder": "e.g. Production Key",
     "keyNameDesc": "Choose a descriptive name to identify this key's purpose",
     "keyCreated": "API Key Created",
     "keyCreatedSuccess": "Key created successfully!",

--- a/src/i18n/messages/pt-BR.json
+++ b/src/i18n/messages/pt-BR.json
@@ -875,7 +875,7 @@
     "tipSeparate": "Crie chaves separadas para diferentes clientes ou ambientes",
     "tipRestrict": "Restrinja chaves a modelos específicos para maior segurança e controle de custos",
     "keyName": "Nome da Chave",
-    "keyNamePlaceholder": "ex: Chave de Produção, Chave de Desenvolvimento",
+    "keyNamePlaceholder": "ex: Chave de Produção",
     "keyNameDesc": "Escolha um nome descritivo para identificar o propósito desta chave",
     "keyCreated": "Chave de API Criada",
     "keyCreatedSuccess": "Chave criada com sucesso!",


### PR DESCRIPTION
The validateKeyName function only accepted ASCII chars. Changed regex to Unicode property escapes to allow accented letters. Also fixed placeholder strings that contained commas.