### PR TITLE
fix(mitm): add Linux cert install and skip sudo password when root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,8 @@ COPY --from=builder /app/node_modules/split2 ./node_modules/split2
 # traced by Next.js standalone output — copy them explicitly.
 COPY --from=builder /app/src/lib/db/migrations ./migrations
 ENV OMNIROUTE_MIGRATIONS_DIR=/app/migrations
+# MITM server.cjs is spawned at runtime via child_process — not traced by nft
+COPY --from=builder /app/src/mitm/server.cjs ./src/mitm/server.cjs
 
 COPY --from=builder /app/scripts/run-standalone.mjs ./run-standalone.mjs
 COPY --from=builder /app/scripts/runtime-env.mjs ./runtime-env.mjs

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -83,6 +83,7 @@ const nextConfig = {
     // runtime and are NOT always auto-traced by webpack/turbopack.
     "/*": [
       "./src/lib/db/migrations/**/*",
+      "./src/mitm/server.cjs",
       "./open-sse/services/compression/engines/rtk/filters/**/*.json",
       "./open-sse/services/compression/rules/**/*.json",
     ],

--- a/src/app/api/cli-tools/antigravity-mitm/route.ts
+++ b/src/app/api/cli-tools/antigravity-mitm/route.ts
@@ -15,7 +15,7 @@ export async function GET(request) {
   if (authError) return authError;
 
   try {
-    const { getMitmStatus, getCachedPassword } = await import("@/mitm/manager");
+    const { getMitmStatus, getCachedPassword } = await import("@/mitm/manager.runtime");
     const status = await getMitmStatus();
     return NextResponse.json({
       running: status.running,
@@ -59,7 +59,8 @@ export async function POST(request) {
     // (#523) Extract keyId BEFORE validation — Zod strips unknown fields!
     const apiKeyId = typeof rawBody?.keyId === "string" ? rawBody.keyId.trim() : null;
     const apiKey = await resolveApiKey(apiKeyId, rawApiKey);
-    const { startMitm, getCachedPassword, setCachedPassword } = await import("@/mitm/manager");
+    const { startMitm, getCachedPassword, setCachedPassword } =
+      await import("@/mitm/manager.runtime");
     const isWin = process.platform === "win32";
     const isRootUser = !isWin && isRoot();
     const pwd = sudoPassword || getCachedPassword() || "";
@@ -114,7 +115,8 @@ export async function DELETE(request) {
       return NextResponse.json({ error: validation.error }, { status: 400 });
     }
     const { sudoPassword } = validation.data;
-    const { stopMitm, getCachedPassword, setCachedPassword } = await import("@/mitm/manager");
+    const { stopMitm, getCachedPassword, setCachedPassword } =
+      await import("@/mitm/manager.runtime");
     const isWin = process.platform === "win32";
     const isRootUser = !isWin && isRoot();
     const pwd = sudoPassword || getCachedPassword() || "";

--- a/src/app/api/settings/mitm/route.ts
+++ b/src/app/api/settings/mitm/route.ts
@@ -137,7 +137,7 @@ function readStats(): MitmStats {
 }
 
 async function buildMitmResponse() {
-  const { getMitmStatus, getCachedPassword } = await import("@/mitm/manager");
+  const { getMitmStatus, getCachedPassword } = await import("@/mitm/manager.runtime");
   const status = await getMitmStatus();
   const config = readConfig();
   const stats = readStats();
@@ -204,7 +204,7 @@ export async function PUT(request: Request) {
 
     if (typeof parsed.data.enabled === "boolean") {
       const { getCachedPassword, setCachedPassword, startMitm, stopMitm } =
-        await import("@/mitm/manager");
+        await import("@/mitm/manager.runtime");
       const { isRoot } = await import("@/mitm/systemCommands");
       const isWin = process.platform === "win32";
       const isRootUser = !isWin && isRoot();
@@ -247,7 +247,7 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
     }
 
-    const { getMitmStatus } = await import("@/mitm/manager");
+    const { getMitmStatus } = await import("@/mitm/manager.runtime");
     const status = await getMitmStatus();
     if (status.running) {
       return NextResponse.json(

--- a/src/app/api/settings/mitm/route.ts
+++ b/src/app/api/settings/mitm/route.ts
@@ -205,12 +205,14 @@ export async function PUT(request: Request) {
     if (typeof parsed.data.enabled === "boolean") {
       const { getCachedPassword, setCachedPassword, startMitm, stopMitm } =
         await import("@/mitm/manager");
+      const { isRoot } = await import("@/mitm/systemCommands");
       const isWin = process.platform === "win32";
+      const isRootUser = !isWin && isRoot();
       const sudoPassword = parsed.data.sudoPassword || getCachedPassword() || "";
 
       if (parsed.data.enabled) {
         const apiKey = await resolveApiKey(parsed.data.keyId || null, parsed.data.apiKey || null);
-        if (!apiKey || (!isWin && !sudoPassword)) {
+        if (!apiKey || (!isWin && !isRootUser && !sudoPassword)) {
           return NextResponse.json(
             { error: isWin ? "Missing apiKey" : "Missing apiKey or sudoPassword" },
             { status: 400 }
@@ -219,7 +221,7 @@ export async function PUT(request: Request) {
         await startMitm(apiKey, sudoPassword, { port: config.port });
         if (!isWin) setCachedPassword(sudoPassword);
       } else {
-        if (!isWin && !sudoPassword) {
+        if (!isWin && !isRootUser && !sudoPassword) {
           return NextResponse.json({ error: "Missing sudoPassword" }, { status: 400 });
         }
         await stopMitm(sudoPassword);

--- a/src/mitm/cert/install.ts
+++ b/src/mitm/cert/install.ts
@@ -9,6 +9,11 @@ import {
 } from "../systemCommands.ts";
 
 const IS_WIN = process.platform === "win32";
+const IS_MAC = process.platform === "darwin";
+
+const LINUX_CERT_NAME = "omniroute-mitm.crt";
+const LINUX_CA_DIR = "/usr/local/share/ca-certificates";
+const LINUX_CERT_DEST = `${LINUX_CA_DIR}/${LINUX_CERT_NAME}`;
 
 // Get SHA1 fingerprint from cert file using Node.js crypto
 function getCertFingerprint(certPath: string): string {
@@ -25,10 +30,9 @@ function getCertFingerprint(certPath: string): string {
  * Check if certificate is already installed in system store
  */
 export async function checkCertInstalled(certPath: string): Promise<boolean> {
-  if (IS_WIN) {
-    return checkCertInstalledWindows(certPath);
-  }
-  return checkCertInstalledMac(certPath);
+  if (IS_WIN) return checkCertInstalledWindows(certPath);
+  if (IS_MAC) return checkCertInstalledMac(certPath);
+  return checkCertInstalledLinux(certPath);
 }
 
 async function checkCertInstalledMac(certPath: string): Promise<boolean> {
@@ -41,6 +45,15 @@ async function checkCertInstalledMac(certPath: string): Promise<boolean> {
       "/Library/Keychains/System.keychain",
     ]);
     return output.toUpperCase().includes(fingerprint);
+  } catch {
+    return false;
+  }
+}
+
+async function checkCertInstalledLinux(certPath: string): Promise<boolean> {
+  try {
+    if (!fs.existsSync(LINUX_CERT_DEST)) return false;
+    return getCertFingerprint(certPath) === getCertFingerprint(LINUX_CERT_DEST);
   } catch {
     return false;
   }
@@ -71,8 +84,10 @@ export async function installCert(sudoPassword: string, certPath: string): Promi
 
   if (IS_WIN) {
     await installCertWindows(certPath);
-  } else {
+  } else if (IS_MAC) {
     await installCertMac(sudoPassword, certPath);
+  } else {
+    await installCertLinux(sudoPassword, certPath);
   }
 }
 
@@ -103,6 +118,20 @@ async function installCertMac(sudoPassword: string, certPath: string): Promise<v
   }
 }
 
+async function installCertLinux(sudoPassword: string, certPath: string): Promise<void> {
+  try {
+    await execFileWithPassword("sudo", ["-S", "mkdir", "-p", LINUX_CA_DIR], sudoPassword);
+    await execFileWithPassword("sudo", ["-S", "cp", certPath, LINUX_CERT_DEST], sudoPassword);
+    await execFileWithPassword("sudo", ["-S", "update-ca-certificates"], sudoPassword);
+  } catch (error) {
+    const message = getErrorMessage(error);
+    const msg = message.includes("canceled")
+      ? "User canceled authorization"
+      : "Certificate install failed";
+    throw new Error(msg);
+  }
+}
+
 async function installCertWindows(certPath: string): Promise<void> {
   await runElevatedPowerShell(`
     $certPath = ${quotePowerShell(certPath)};
@@ -124,8 +153,10 @@ export async function uninstallCert(sudoPassword: string, certPath: string): Pro
 
   if (IS_WIN) {
     await uninstallCertWindows();
-  } else {
+  } else if (IS_MAC) {
     await uninstallCertMac(sudoPassword, certPath);
+  } else {
+    await uninstallCertLinux(sudoPassword, certPath);
   }
 }
 
@@ -145,6 +176,17 @@ async function uninstallCertMac(sudoPassword: string, certPath: string): Promise
       sudoPassword
     );
     console.log("✅ Uninstalled certificate from system keychain");
+  } catch (err) {
+    throw new Error("Failed to uninstall certificate");
+  }
+}
+
+async function uninstallCertLinux(sudoPassword: string, certPath: string): Promise<void> {
+  try {
+    if (fs.existsSync(LINUX_CERT_DEST)) {
+      await execFileWithPassword("sudo", ["-S", "rm", "-f", LINUX_CERT_DEST], sudoPassword);
+    }
+    await execFileWithPassword("sudo", ["-S", "update-ca-certificates", "--fresh"], sudoPassword);
   } catch (err) {
     throw new Error("Failed to uninstall certificate");
   }

--- a/src/mitm/manager.runtime.ts
+++ b/src/mitm/manager.runtime.ts
@@ -1,0 +1,5 @@
+// Runtime bypass for Turbopack resolveAlias.
+// Turbopack maps @/mitm/manager → manager.stub.ts so the build doesn't choke
+// on native module imports.  Dynamic import() of @/mitm/manager.runtime does NOT
+// match that alias and loads the real manager at runtime.
+export * from "./manager";

--- a/src/mitm/manager.stub.ts
+++ b/src/mitm/manager.stub.ts
@@ -1,22 +1,25 @@
 // Build-time stub for @/mitm/manager
 // Used by Turbopack during next build to avoid native module resolution errors.
-// The real module is used at runtime via dynamic import in route handlers.
+// Dynamic import() in route handlers should load the REAL manager at runtime.
+// If this stub is reached at runtime, the build alias is incorrectly applied.
+
+const STUB_ERROR =
+  "MITM manager stub reached at runtime — build alias applied incorrectly. " +
+  "Use --webpack for production builds or verify Turbopack is not aliasing at runtime.";
 
 export const getCachedPassword = () => null;
 export const setCachedPassword = (_pwd: string) => {};
 export const clearCachedPassword = () => {};
-export const getMitmStatus = async () => ({
-  running: false,
-  pid: null,
-  dnsConfigured: false,
-  certExists: false,
-});
+export const getMitmStatus = async () => {
+  throw new Error(STUB_ERROR);
+};
 export const startMitm = async (
   _apiKey: string,
   _sudoPassword: string,
   _options: { port?: number } = {}
-) => ({
-  running: false,
-  pid: null,
-});
-export const stopMitm = async (_sudoPassword: string) => ({ running: false, pid: null });
+): Promise<never> => {
+  throw new Error(STUB_ERROR);
+};
+export const stopMitm = async (_sudoPassword: string): Promise<never> => {
+  throw new Error(STUB_ERROR);
+};


### PR DESCRIPTION
## Summary
Add Linux certificate management via update-ca-certificates for Docker support. Skip sudo password validation when running as root, matching the existing cli-tools route behavior.

Turbopack resolveAlias (@/mitm/manager → manager.stub.ts) was designed
for build-time safety but Next.js applies aliases to ALL imports
including dynamic ones. This caused await import("@/mitm/manager") at
runtime to load the stub, which silently returned fake {running: true}
without spawning the MITM proxy. The UI showed "MITM proxy started"
but nothing was actually running.

Fix introduces a two-path design:
- @/mitm/manager        → stub (build-time, safe for Turbopack)
- @/mitm/manager.runtime → real manager (runtime, bypasses alias)

Route handlers now dynamic-import from manager.runtime, which
re-exports from ./manager and does NOT match the alias pattern.

Additional fixes:
- Make stub throw explicit errors at runtime so misconfiguration is
  immediately visible instead of silently faking success
- Add server.cjs to outputFileTracingIncludes (NFT trace) and Dockerfile
  COPY so the MITM server binary exists in standalone/Docker output

## Related Issues

- Closes #
- Related to #

## Validation

- [ ] `npm run lint`
- [ ] `npm run test:unit`
- [ ] `npm run test:coverage`
- [ ] Coverage is still `>= 60%` for statements, lines, functions, and branches
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below

## Tests Added Or Updated

- List every changed or added automated test file.
- If no production code changed, state that here.

## Coverage Notes

- If this PR changes `src/`, `open-sse/`, `electron/`, or `bin/`, explain which tests cover the change.
- If coverage moved down in any touched file, explain why and what follow-up task will recover it.

## Reviewer Notes

- Call out any risky areas, migrations, feature flags, or manual validation that reviewers should know about.