### PR TITLE
fix(docker): include OpenAPI spec in runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,9 @@ COPY --from=builder /app/node_modules/split2 ./node_modules/split2
 # traced by Next.js standalone output — copy them explicitly.
 COPY --from=builder /app/src/lib/db/migrations ./migrations
 ENV OMNIROUTE_MIGRATIONS_DIR=/app/migrations
+# OpenAPI spec is read from disk by /api/openapi/spec at runtime for the
+# Endpoints dashboard. Next.js standalone tracing does not include it.
+COPY --from=builder /app/docs/openapi.yaml ./docs/openapi.yaml
 
 COPY --from=builder /app/scripts/run-standalone.mjs ./run-standalone.mjs
 COPY --from=builder /app/scripts/runtime-env.mjs ./runtime-env.mjs


### PR DESCRIPTION
## Summary

This PR includes `docs/openapi.yaml` in the Docker runtime image.

It fixes the Endpoints dashboard showing:

```text
openapi.yaml not found
```

when OmniRoute is deployed from the published Docker image with Docker Compose.

## Affected setup

The issue was seen with a straightforward Docker Compose deployment using the published image:

```yaml
services:
  omniroute:
    image: diegosouzapw/omniroute:latest
    container_name: omniroute
    restart: unless-stopped
    stop_grace_period: 40s
    env_file:
      - .env
    ports:
      - "20128:20128"
    volumes:
      - /root/omniroute/data:/app/data
```

In this setup the app itself starts normally and the dashboard is reachable, but the Endpoints dashboard cannot load the OpenAPI catalog because `/api/openapi/spec` cannot find `openapi.yaml` inside the container.

## Root cause

`src/app/api/openapi/spec/route.ts` reads the OpenAPI spec from disk at runtime:

```ts
process.cwd()/docs/openapi.yaml
process.cwd()/app/docs/openapi.yaml
```

However, the Docker image uses Next.js standalone output:

```dockerfile
COPY --from=builder /app/.next/standalone ./
```

Files that are read dynamically with `fs` are not always included in the standalone output. The current Dockerfile already handles this pattern for other runtime filesystem assets, for example migrations are copied explicitly:

```dockerfile
COPY --from=builder /app/src/lib/db/migrations ./migrations
```

`docs/openapi.yaml` needs the same treatment because it is read by `/api/openapi/spec` at runtime for the Endpoints dashboard.

## Fix

Copy the OpenAPI spec into the runtime image:

```dockerfile
COPY --from=builder /app/docs/openapi.yaml ./docs/openapi.yaml
```

This makes the file available at `/app/docs/openapi.yaml`, which matches the route's existing lookup path when the container runs with `WORKDIR /app`.

## Screenshot

Current behavior before this fix:

<img width="1193" height="466" alt="Endpoints dashboard showing openapi.yaml not found" src="https://github.com/user-attachments/assets/6ac595bc-e8a6-4f82-86f3-01b58da871f7" />

## Testing

- Commit hook docs sync passed: OpenAPI version matches `package.json`
- Commit hook any-budget check passed
- Local source route test previously confirmed the spec parses and exposes 171 endpoints

## Expected result after rebuilding the image

After rebuilding/redeploying the Docker image from this Dockerfile, `/app/docs/openapi.yaml` should exist in the container and the Endpoints dashboard should be able to load the OpenAPI endpoint catalog instead of showing `openapi.yaml not found`.
