### PR TITLE
fix(translator): preserve Gemini thoughtSignature across Claude tool replay

### DIFF
--- a/open-sse/translator/request/claude-to-gemini.ts
+++ b/open-sse/translator/request/claude-to-gemini.ts
@@ -7,6 +7,7 @@ import {
 } from "../helpers/geminiHelper.ts";
 import { DEFAULT_THINKING_GEMINI_SIGNATURE } from "../../config/defaultThinkingSignature.ts";
 import { buildGeminiTools, sanitizeGeminiToolName } from "../helpers/geminiToolsSanitizer.ts";
+import { resolveGeminiThoughtSignature } from "../../services/geminiThoughtSignatureStore.ts";
 
 /**
  * Direct Claude → Gemini request translator.
@@ -70,12 +71,17 @@ export function claudeToGeminiRequest(model, body, stream) {
 
   // ── Build tool_use name lookup (for tool_result matching) ──────
   const toolUseNames = {};
+  const toolUseSignatures = {};
   if (body.messages && Array.isArray(body.messages)) {
     for (const msg of body.messages) {
       if (msg.role === "assistant" && Array.isArray(msg.content)) {
         for (const block of msg.content) {
           if (block.type === "tool_use" && block.id && block.name) {
             toolUseNames[block.id] = sanitizeToolName(block.name);
+            const signature = resolveGeminiThoughtSignature(block.id);
+            if (typeof signature === "string" && signature.length > 0) {
+              toolUseSignatures[block.id] = signature;
+            }
           }
         }
       }
@@ -160,14 +166,19 @@ export function claudeToGeminiRequest(model, body, stream) {
         // batch. If the assistant turn had no explicit thinking block, inject a fallback
         // signature into all functionCalls.
         if (geminiRole === "model") {
-          const hasFunctionCall = parts.some((p) => p.functionCall);
+          const functionCallParts = parts.filter((p) => p.functionCall);
+          const hasFunctionCall = functionCallParts.length > 0;
           const hasSignature = parts.some((p) => p.thoughtSignature);
           if (hasFunctionCall && !hasSignature) {
+            const persistedSignature = functionCallParts
+              .map((p) => p.functionCall?.id)
+              .map((id) => toolUseSignatures[id])
+              .find((signature) => typeof signature === "string" && signature.length > 0);
             for (let i = 0; i < parts.length; i++) {
               if (parts[i].functionCall) {
                 parts[i] = {
                   ...parts[i],
-                  thoughtSignature: DEFAULT_THINKING_GEMINI_SIGNATURE,
+                  thoughtSignature: persistedSignature || DEFAULT_THINKING_GEMINI_SIGNATURE,
                 };
               }
             }

--- a/open-sse/translator/response/gemini-to-claude.ts
+++ b/open-sse/translator/response/gemini-to-claude.ts
@@ -1,5 +1,6 @@
 import { register } from "../registry.ts";
 import { FORMATS } from "../formats.ts";
+import { storeGeminiThoughtSignature } from "../../services/geminiThoughtSignatureStore.ts";
 
 /**
  * Direct Gemini → Claude response translator.
@@ -84,6 +85,10 @@ export function geminiToClaudeResponse(chunk, state) {
         const restoredToolName = state.toolNameMap?.get(rawToolName) || rawToolName;
         const idx = state.contentBlockIndex++;
         const toolId = fc.id || `toolu_${Date.now()}_${idx}`;
+
+        if (typeof hasThoughtSig === "string" && hasThoughtSig.length > 0) {
+          storeGeminiThoughtSignature(toolId, hasThoughtSig);
+        }
 
         results.push({
           type: "content_block_start",

--- a/tests/unit/translator-claude-to-gemini.test.ts
+++ b/tests/unit/translator-claude-to-gemini.test.ts
@@ -7,6 +7,12 @@ const { DEFAULT_SAFETY_SETTINGS } =
   await import("../../open-sse/translator/helpers/geminiHelper.ts");
 const { DEFAULT_THINKING_GEMINI_SIGNATURE } =
   await import("../../open-sse/config/defaultThinkingSignature.ts");
+const { storeGeminiThoughtSignature, clearGeminiThoughtSignatures } =
+  await import("../../open-sse/services/geminiThoughtSignatureStore.ts");
+
+test.afterEach(() => {
+  clearGeminiThoughtSignatures();
+});
 
 test("Claude -> Gemini maps system, thinking, tool use, tool result and tools", () => {
   const result = claudeToGeminiRequest(
@@ -130,6 +136,27 @@ test("Claude -> Gemini injects a fallback thoughtSignature on tool-call batches 
   assert.equal(result.contents[0].role, "model");
   assert.equal(result.contents[0].parts[0].functionCall.name, "read_file");
   assert.equal(result.contents[0].parts[0].thoughtSignature, DEFAULT_THINKING_GEMINI_SIGNATURE);
+});
+
+test("Claude -> Gemini reuses persisted thoughtSignature for replayed tool_use blocks", () => {
+  storeGeminiThoughtSignature("tu_cached", "sig-from-gemini");
+
+  const result = claudeToGeminiRequest(
+    "gemini-2.5-flash",
+    {
+      messages: [
+        {
+          role: "assistant",
+          content: [{ type: "tool_use", id: "tu_cached", name: "Skill_ide", input: {} }],
+        },
+      ],
+    },
+    false
+  );
+
+  assert.equal(result.contents.length, 1);
+  assert.equal(result.contents[0].parts[0].functionCall.name, "Skill_ide");
+  assert.equal(result.contents[0].parts[0].thoughtSignature, "sig-from-gemini");
 });
 
 test("Claude -> Gemini sanitizes long tool names and exposes a restore map", () => {

--- a/tests/unit/translator-resp-gemini-to-claude.test.ts
+++ b/tests/unit/translator-resp-gemini-to-claude.test.ts
@@ -3,10 +3,16 @@ import assert from "node:assert/strict";
 
 const { geminiToClaudeResponse } =
   await import("../../open-sse/translator/response/gemini-to-claude.ts");
+const { getGeminiThoughtSignature, clearGeminiThoughtSignatures } =
+  await import("../../open-sse/services/geminiThoughtSignatureStore.ts");
 
 function flatten(items) {
   return items.flatMap((item) => item || []);
 }
+
+test.afterEach(() => {
+  clearGeminiThoughtSignatures();
+});
 
 test("Gemini -> Claude stream: text block stays open across sequential text chunks", () => {
   const state = {};
@@ -111,6 +117,41 @@ test("Gemini -> Claude stream: functionCall becomes tool_use and MAX_TOKENS maps
   assert.equal(result[4].usage.output_tokens, 5);
   assert.equal(result[4].usage.cache_read_input_tokens, 1);
   assert.equal(result[5].type, "message_stop");
+});
+
+test("Gemini -> Claude stores thoughtSignature using emitted tool_use id", () => {
+  const state = {};
+  const result = geminiToClaudeResponse(
+    {
+      responseId: "resp-store-sig",
+      modelVersion: "gemini-2.5-pro",
+      candidates: [
+        {
+          content: {
+            parts: [
+              {
+                thoughtSignature: "sig-direct-claude",
+                functionCall: {
+                  name: "Skill_ide",
+                  args: { skill: "using-superpowers" },
+                },
+              },
+            ],
+          },
+          finishReason: "STOP",
+        },
+      ],
+    },
+    state
+  );
+
+  const toolUseStart = result.find((item) => item.type === "content_block_start");
+  assert.ok(toolUseStart, "Expected a tool_use block to be emitted");
+  assert.equal(
+    getGeminiThoughtSignature(toolUseStart.content_block.id),
+    "sig-direct-claude",
+    "tool_use id should retain the Gemini thought signature for replay"
+  );
 });
 
 test("Gemini -> Claude stream: STOP after prior tool use still maps to tool_use", () => {


### PR DESCRIPTION
## Summary

- Preserve Gemini `thoughtSignature` across the `Gemini -> Claude -> Gemini` tool replay path.
- Prevent follow-up Gemini tool turns from failing with `Function call is missing a thought_signature in functionCall parts` when OmniRoute bridges through Claude-format `tool_use` / `tool_result` messages.

## Related Issues

- Closes #2024
- Related to Antigravity / Cloud Code Gemini tool-call replay failures reported downstream

## Validation

- [ ] `npm run lint`
- [x] `npm run test:unit`
- [ ] `npm run test:coverage`
- [ ] Coverage is still `>= 60%` for statements, lines, functions, and branches
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below

## Tests Added Or Updated

- `tests/unit/translator-claude-to-gemini.test.ts`
- `tests/unit/translator-resp-gemini-to-claude.test.ts`

## Coverage Notes

- This PR changes `open-sse/translator/` and is covered by targeted unit tests for both directions of the bridge.
- The new tests verify that a Gemini `thoughtSignature` emitted on the original `functionCall` is preserved when OmniRoute converts that turn to Claude `tool_use` and later replays it back into Gemini.

## Reviewer Notes

- The patch is intentionally narrow and only touches translator state for Gemini tool-call replay.
- I validated the regression with targeted unit tests locally. Full repo hooks in this local checkout include unrelated version-skew noise, so I avoided broad unrelated changes in this PR.
