### PR TITLE
docs(env): add GITLAB_DUO_OAUTH_CLIENT_ID to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -387,6 +387,12 @@ ANTIGRAVITY_OAUTH_CLIENT_SECRET=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
 # ── GitHub Copilot ──
 GITHUB_OAUTH_CLIENT_ID=Iv1.b507a08c87ecfe98
 
+# ── GitLab Duo ──
+# Register an OAuth app at: https://gitlab.com/-/profile/applications
+# Set redirect URI to: http://localhost:20128/callback (or your NEXT_PUBLIC_BASE_URL + /callback)
+# Required scopes: api, read_user, openid, profile, email
+# GITLAB_DUO_OAUTH_CLIENT_ID=*** GITLAB_DUO_OAUTH_CLIENT_SECRET=*** optional — PKCE flow does not require a secret
+
 # ── Qoder ──
 QODER_OAUTH_CLIENT_SECRET=4Z3YjXycVsQvyGF1etiNlIBB4RsqSDtW
 

--- a/.env.example
+++ b/.env.example
@@ -391,7 +391,8 @@ GITHUB_OAUTH_CLIENT_ID=Iv1.b507a08c87ecfe98
 # Register an OAuth app at: https://gitlab.com/-/profile/applications
 # Set redirect URI to: http://localhost:20128/callback (or your NEXT_PUBLIC_BASE_URL + /callback)
 # Required scopes: api, read_user, openid, profile, email
-# GITLAB_DUO_OAUTH_CLIENT_ID=*** GITLAB_DUO_OAUTH_CLIENT_SECRET=*** optional — PKCE flow does not require a secret
+# GITLAB_DUO_OAUTH_CLIENT_ID=***
+# GITLAB_DUO_OAUTH_CLIENT_SECRET=***  # optional — PKCE flow does not require a secret
 
 # ── Qoder ──
 QODER_OAUTH_CLIENT_SECRET=4Z3YjXycVsQvyGF1etiNlIBB4RsqSDtW


### PR DESCRIPTION
Closes #2013

Section 11 (OAuth Provider Credentials) in `.env.example` documents all OAuth providers but was missing the GitLab Duo entry. Users configuring GitLab Duo connections from the providers page would immediately get an error about missing `GITLAB_DUO_OAUTH_CLIENT_ID`.

Added the GitLab Duo section between GitHub Copilot and Qoder, following the existing format with registration URL, redirect URI hint, and required scopes.