### PR TITLE
chore: Remove Deprecated Models

### DIFF
--- a/open-sse/config/imageRegistry.ts
+++ b/open-sse/config/imageRegistry.ts
@@ -153,10 +153,10 @@ export const IMAGE_PROVIDERS: Record<string, ImageProviderConfig> = {
     authHeader: "bearer",
     format: "openai",
     models: [
-      { id: "grok-imagine-image-pro", name: "Grok Imagine Image Pro" },
+      { id: "grok-imagine-image-quality", name: "Grok Imagine Image Quality" },
       { id: "grok-imagine-image", name: "Grok Imagine Image" },
     ],
-    supportedSizes: ["1024x1024"],
+    supportedSizes: ["1024x1024", "2048x2048"],
   },
 
   together: {

--- a/open-sse/config/providerRegistry.ts
+++ b/open-sse/config/providerRegistry.ts
@@ -1100,8 +1100,6 @@ export const REGISTRY: Record<string, RegistryEntry> = {
       { id: "grok-4.20-multi-agent-0309", name: "Grok 4.20 Multi Agent" },
       { id: "grok-4.20-0309-reasoning", name: "Grok 4.20 Reasoning" },
       { id: "grok-4.20-0309-non-reasoning", name: "Grok 4.20" },
-      { id: "grok-4-1-fast-reasoning", name: "Grok 4.1 Fast Reasoning" },
-      { id: "grok-4-1-fast-non-reasoning", name: "Grok 4.1 Fast" },
     ],
   },
 
@@ -1140,7 +1138,7 @@ export const REGISTRY: Record<string, RegistryEntry> = {
     authHeader: "cookie",
     passthroughModels: true,
     models: [
-      { id: "fast", name: "Grok Fast", toolCalling: true },
+      { id: "fast", name: "Grok 4.20", toolCalling: true },
       { id: "expert", name: "Grok 4.20 Thinking", toolCalling: true },
       { id: "heavy", name: "Grok 4.20 Multi Agent", toolCalling: true },
       { id: "grok-420-computer-use-sa", name: "Grok 4.3 (Beta)", toolCalling: true },
@@ -1157,7 +1155,7 @@ export const REGISTRY: Record<string, RegistryEntry> = {
     authHeader: "bearer",
     models: [
       { id: "mistral-large-latest", name: "Mistral Large 3" },
-      { id: "mistral-medium-latest", name: "Mistral Medium 3.1" },
+      { id: "mistral-medium-3-5", name: "Mistral Medium 3.5" },
       { id: "mistral-small-latest", name: "Mistral Small 4" },
       { id: "devstral-latest", name: "Devstral 2" },
       { id: "codestral-latest", name: "Codestral" },

--- a/tests/unit/bailian-coding-plan-provider.test.ts
+++ b/tests/unit/bailian-coding-plan-provider.test.ts
@@ -274,7 +274,7 @@ test("getStaticModelsForProvider returns local image catalogs for image-only pro
   assert.ok(models, "xAI should expose local image models");
   assert.deepEqual(
     models.map((model) => model.id),
-    ["grok-imagine-image-pro", "grok-imagine-image"]
+    ["grok-imagine-image-quality", "grok-imagine-image"]
   );
 });
 


### PR DESCRIPTION
## Summary

https://docs.x.ai/developers/models
<img width="717" height="177" alt="image" src="https://github.com/user-attachments/assets/7cb00f1c-f14c-45f9-9d87-0b9f7b1da897" />

+ Update Mistral Medium 3.1 -> Mistral Medium 3.5

## Validation

- [ ] `npm run lint` (not run separately; commit hook ran ESLint on staged files)
- [x] `npm run test:unit` (pre-push hook passed: 4142 pass / 0 fail)
- [ ] `npm run test:coverage` (not run)
- [ ] Coverage is still `>= 60%` for statements, lines, functions, and branches (not verified; coverage was not run)
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below (not run locally)

## Tests Added Or Updated

- Updated `tests/unit/bailian-coding-plan-provider.test.ts`

Production code changed:
- `open-sse/config/imageRegistry.ts`
- `open-sse/config/providerRegistry.ts`

## Coverage Notes

This PR changes `open-sse/` registry configuration.

Covered by:
- `tests/unit/bailian-coding-plan-provider.test.ts`
- `tests/unit/provider-models-config.test.ts`
- `tests/unit/chat-openai-compat-providers.test.ts`
- Full `npm run test:unit` via pre-push hook

Coverage movement was not measured because `npm run test:coverage` was not run.

## Reviewer Notes

- Removes deprecated xAI chat model entries from the provider registry.
- Replaces deprecated xAI image model catalog entry with the current image model entry and updates the expected static catalog test.
- Updates Mistral Medium from the deprecated/latest alias to the explicit current model ID.
- No migrations, feature flags, or manual runtime validation are required.