### PR TITLE
feat(combo): add context_length input field to combo edit form

### DIFF
--- a/src/app/(dashboard)/dashboard/combos/page.tsx
+++ b/src/app/(dashboard)/dashboard/combos/page.tsx
@@ -2655,18 +2655,17 @@ function ComboFormModal({ isOpen, combo, onClose, onSave, activeProviders, combo
     else delete saveData.context_cache_protection;
 
     // Validate and save context_length
-    if (contextLength !== undefined && contextLength !== null && contextLength !== "") {
+    if (contextLength !== undefined && contextLength !== null) {
       const ctxLen = Number(contextLength);
       if (isNaN(ctxLen) || !Number.isInteger(ctxLen)) {
-        setContextLengthError("Context length must be a valid integer");
+        setContextLengthError(t("agentFeaturesContextLengthErrorInteger"));
         setSaving(false);
         return;
       }
       if (ctxLen >= 1000 && ctxLen <= 2000000) {
         saveData.context_length = ctxLen;
       } else {
-        // Out of range - don't save, show error
-        setContextLengthError(`Context length must be between 1000 and 2000000`);
+        setContextLengthError(t("agentFeaturesContextLengthErrorRange"));
         setSaving(false);
         return;
       }
@@ -3806,10 +3805,10 @@ function ComboFormModal({ isOpen, combo, onClose, onSave, activeProviders, combo
                     }
                     const num = Number(value);
                     if (isNaN(num) || !Number.isInteger(num)) {
-                      setContextLengthError("Context length must be a valid integer");
-                      setContextLength(undefined);
+                      setContextLengthError(t("agentFeaturesContextLengthErrorInteger"));
+                      // Keep the raw input value so the user can correct it
                     } else if (num < 1000 || num > 2000000) {
-                      setContextLengthError("Context length must be between 1000 and 2000000");
+                      setContextLengthError(t("agentFeaturesContextLengthErrorRange"));
                       setContextLength(num);
                     } else {
                       setContextLength(num);

--- a/src/app/(dashboard)/dashboard/combos/page.tsx
+++ b/src/app/(dashboard)/dashboard/combos/page.tsx
@@ -1869,6 +1869,7 @@ function ComboFormModal({ isOpen, combo, onClose, onSave, activeProviders, combo
     agentSystemMessage: string;
     agentToolFilter: string;
     agentContextCache: boolean;
+    contextLength: number | undefined;
   };
 
   const getEmptyCreateDraftSnapshot = useCallback(
@@ -1882,6 +1883,7 @@ function ComboFormModal({ isOpen, combo, onClose, onSave, activeProviders, combo
       agentSystemMessage: "",
       agentToolFilter: "",
       agentContextCache: false,
+      contextLength: undefined,
     }),
     []
   );
@@ -1923,6 +1925,10 @@ function ComboFormModal({ isOpen, combo, onClose, onSave, activeProviders, combo
   const [agentContextCache, setAgentContextCache] = useState<boolean>(
     !!combo?.context_cache_protection
   );
+  const [contextLength, setContextLength] = useState<number | undefined>(
+    combo?.context_length || undefined
+  );
+  const [contextLengthError, setContextLengthError] = useState<string>("");
   const comboBuilderStages = useMemo(() => getComboBuilderStages({ strategy }), [strategy]);
   const visibleStageMeta = useMemo(
     () => COMBO_FORM_STAGE_META.filter((stageMeta) => comboBuilderStages.includes(stageMeta.id)),
@@ -1951,11 +1957,13 @@ function ComboFormModal({ isOpen, combo, onClose, onSave, activeProviders, combo
       setConfig(nextConfig);
       setShowAdvanced(isExpertMode);
       setNameError("");
+      setContextLengthError("");
       setAgentSystemMessage(nextCombo?.system_message || "");
       setAgentToolFilter(nextCombo?.tool_filter_regex || "");
       setAgentContextCache(!!nextCombo?.context_cache_protection);
+      setContextLength(nextCombo?.context_length || undefined);
     },
-    [isExpertMode, setAgentContextCache]
+    [isExpertMode, setAgentContextCache, setContextLength]
   );
 
   useEffect(() => {
@@ -1969,6 +1977,7 @@ function ComboFormModal({ isOpen, combo, onClose, onSave, activeProviders, combo
       agentSystemMessage,
       agentToolFilter,
       agentContextCache,
+      contextLength,
     };
   }, [
     name,
@@ -1980,6 +1989,7 @@ function ComboFormModal({ isOpen, combo, onClose, onSave, activeProviders, combo
     agentSystemMessage,
     agentToolFilter,
     agentContextCache,
+    contextLength,
   ]);
 
   useEffect(() => {
@@ -2093,6 +2103,7 @@ function ComboFormModal({ isOpen, combo, onClose, onSave, activeProviders, combo
   const saveBlocked =
     !name.trim() ||
     !!nameError ||
+    !!contextLengthError ||
     saving ||
     hasNoModels ||
     hasInvalidWeightedTotal ||
@@ -2235,7 +2246,8 @@ function ComboFormModal({ isOpen, combo, onClose, onSave, activeProviders, combo
           draft.nameError.length === 0 &&
           draft.agentSystemMessage.length === 0 &&
           draft.agentToolFilter.length === 0 &&
-          draft.agentContextCache === false;
+          draft.agentContextCache === false &&
+          draft.contextLength === undefined;
 
         if (!cancelled && isPristineDraft) {
           resetFormForCombo(null, data.comboDefaults || null);
@@ -2641,6 +2653,29 @@ function ComboFormModal({ isOpen, combo, onClose, onSave, activeProviders, combo
     else delete saveData.tool_filter_regex;
     if (agentContextCache) saveData.context_cache_protection = true;
     else delete saveData.context_cache_protection;
+
+    // Validate and save context_length
+    if (contextLength !== undefined && contextLength !== null && contextLength !== "") {
+      const ctxLen = Number(contextLength);
+      if (isNaN(ctxLen) || !Number.isInteger(ctxLen)) {
+        setContextLengthError("Context length must be a valid integer");
+        setSaving(false);
+        return;
+      }
+      if (ctxLen >= 1000 && ctxLen <= 2000000) {
+        saveData.context_length = ctxLen;
+      } else {
+        // Out of range - don't save, show error
+        setContextLengthError(`Context length must be between 1000 and 2000000`);
+        setSaving(false);
+        return;
+      }
+    } else if (isEdit) {
+      // Editing: send null to explicitly clear context_length
+      saveData.context_length = null;
+    } else {
+      delete saveData.context_length;
+    }
 
     await onSave(saveData);
     setSaving(false);
@@ -3749,6 +3784,56 @@ function ComboFormModal({ isOpen, combo, onClose, onSave, activeProviders, combo
                   onChange={(e) => setAgentContextCache(e.target.checked)}
                   className="accent-primary shrink-0"
                 />
+              </div>
+
+              {/* Context Length */}
+              <div>
+                <label className="text-[11px] font-medium text-text-muted block mb-0.5">
+                  {getI18nOrFallback(t, "agentFeaturesContextLength", "Context length")}
+                </label>
+                <input
+                  type="number"
+                  min="1000"
+                  max="2000000"
+                  step="1000"
+                  value={contextLength || ""}
+                  onChange={(e) => {
+                    const value = e.target.value;
+                    setContextLengthError("");
+                    if (value === "") {
+                      setContextLength(undefined);
+                      return;
+                    }
+                    const num = Number(value);
+                    if (isNaN(num) || !Number.isInteger(num)) {
+                      setContextLengthError("Context length must be a valid integer");
+                      setContextLength(undefined);
+                    } else if (num < 1000 || num > 2000000) {
+                      setContextLengthError("Context length must be between 1000 and 2000000");
+                      setContextLength(num);
+                    } else {
+                      setContextLength(num);
+                    }
+                  }}
+                  placeholder={getI18nOrFallback(
+                    t,
+                    "agentFeaturesContextLengthPlaceholder",
+                    "e.g. 128000"
+                  )}
+                  className="w-full text-xs py-1.5 px-2 rounded border border-black/10 dark:border-white/10 bg-transparent focus:border-primary focus:outline-none"
+                />
+                {contextLengthError && (
+                  <p className="text-[10px] text-red-500 mt-0.5">{contextLengthError}</p>
+                )}
+                {!contextLengthError && !isExpertMode && (
+                  <p className="text-[10px] text-text-muted mt-0.5">
+                    {getI18nOrFallback(
+                      t,
+                      "agentFeaturesContextLengthHint",
+                      "Defines the context window for this combo in /v1/models."
+                    )}
+                  </p>
+                )}
               </div>
             </div>
           )}

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -4607,5 +4607,10 @@
     "noProxyLogs": "No proxy logs yet. Configure proxies and make API calls to see them here.",
     "noMatchingLogs": "No logs match the current filters.",
     "tlsFingerprint": "Chrome 124 TLS Fingerprint"
+  },
+  "agentFeatures": {
+    "agentFeaturesContextLength": "Context length",
+    "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
   }
 }

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -4611,6 +4611,8 @@
   "agentFeatures": {
     "agentFeaturesContextLength": "Context length",
     "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
-    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1/models.",
+    "agentFeaturesContextLengthErrorInteger": "Context length must be a valid integer",
+    "agentFeaturesContextLengthErrorRange": "Context length must be between 1000 and 2000000"
   }
 }

--- a/src/i18n/messages/bg.json
+++ b/src/i18n/messages/bg.json
@@ -4607,5 +4607,10 @@
     "noProxyLogs": "No proxy logs yet. Configure proxies and make API calls to see them here.",
     "noMatchingLogs": "No logs match the current filters.",
     "tlsFingerprint": "Chrome 124 TLS Fingerprint"
+  },
+  "agentFeatures": {
+    "agentFeaturesContextLength": "Context length",
+    "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
   }
 }

--- a/src/i18n/messages/bg.json
+++ b/src/i18n/messages/bg.json
@@ -4611,6 +4611,8 @@
   "agentFeatures": {
     "agentFeaturesContextLength": "Context length",
     "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
-    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1/models.",
+    "agentFeaturesContextLengthErrorInteger": "Context length must be a valid integer",
+    "agentFeaturesContextLengthErrorRange": "Context length must be between 1000 and 2000000"
   }
 }

--- a/src/i18n/messages/bn.json
+++ b/src/i18n/messages/bn.json
@@ -4900,5 +4900,10 @@
     "noProxyLogs": "No proxy logs yet. Configure proxies and make API calls to see them here.",
     "noMatchingLogs": "No logs match the current filters.",
     "tlsFingerprint": "Chrome 124 TLS Fingerprint"
+  },
+  "agentFeatures": {
+    "agentFeaturesContextLength": "Context length",
+    "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
   }
 }

--- a/src/i18n/messages/bn.json
+++ b/src/i18n/messages/bn.json
@@ -4904,6 +4904,8 @@
   "agentFeatures": {
     "agentFeaturesContextLength": "Context length",
     "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
-    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1/models.",
+    "agentFeaturesContextLengthErrorInteger": "Context length must be a valid integer",
+    "agentFeaturesContextLengthErrorRange": "Context length must be between 1000 and 2000000"
   }
 }

--- a/src/i18n/messages/cs.json
+++ b/src/i18n/messages/cs.json
@@ -4607,5 +4607,10 @@
     "noProxyLogs": "No proxy logs yet. Configure proxies and make API calls to see them here.",
     "noMatchingLogs": "No logs match the current filters.",
     "tlsFingerprint": "Chrome 124 TLS Fingerprint"
+  },
+  "agentFeatures": {
+    "agentFeaturesContextLength": "Context length",
+    "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
   }
 }

--- a/src/i18n/messages/cs.json
+++ b/src/i18n/messages/cs.json
@@ -4611,6 +4611,8 @@
   "agentFeatures": {
     "agentFeaturesContextLength": "Context length",
     "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
-    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1/models.",
+    "agentFeaturesContextLengthErrorInteger": "Context length must be a valid integer",
+    "agentFeaturesContextLengthErrorRange": "Context length must be between 1000 and 2000000"
   }
 }

--- a/src/i18n/messages/da.json
+++ b/src/i18n/messages/da.json
@@ -4607,5 +4607,10 @@
     "noProxyLogs": "No proxy logs yet. Configure proxies and make API calls to see them here.",
     "noMatchingLogs": "No logs match the current filters.",
     "tlsFingerprint": "Chrome 124 TLS Fingerprint"
+  },
+  "agentFeatures": {
+    "agentFeaturesContextLength": "Context length",
+    "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
   }
 }

--- a/src/i18n/messages/da.json
+++ b/src/i18n/messages/da.json
@@ -4611,6 +4611,8 @@
   "agentFeatures": {
     "agentFeaturesContextLength": "Context length",
     "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
-    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1/models.",
+    "agentFeaturesContextLengthErrorInteger": "Context length must be a valid integer",
+    "agentFeaturesContextLengthErrorRange": "Context length must be between 1000 and 2000000"
   }
 }

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -4607,5 +4607,10 @@
     "noProxyLogs": "No proxy logs yet. Configure proxies and make API calls to see them here.",
     "noMatchingLogs": "No logs match the current filters.",
     "tlsFingerprint": "Chrome 124 TLS Fingerprint"
+  },
+  "agentFeatures": {
+    "agentFeaturesContextLength": "Context length",
+    "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
   }
 }

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -4611,6 +4611,8 @@
   "agentFeatures": {
     "agentFeaturesContextLength": "Context length",
     "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
-    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1/models.",
+    "agentFeaturesContextLengthErrorInteger": "Context length must be a valid integer",
+    "agentFeaturesContextLengthErrorRange": "Context length must be between 1000 and 2000000"
   }
 }

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1887,7 +1887,10 @@
     "agentFeaturesToolFilterRegex": "/regex-pattern/",
     "agentFeaturesToolFilterHint": "Tool filter regex for agents",
     "agentFeaturesContextCacheHint": "Enable in-context cache for agent tools",
-    "agentFeaturesContextCacheProtection": "Protect cache from agent tool mutations"
+    "agentFeaturesContextCacheProtection": "Protect cache from agent tool mutations",
+    "agentFeaturesContextLength": "Context length",
+    "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1/models."
   },
   "costs": {
     "title": "Costs",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1890,7 +1890,9 @@
     "agentFeaturesContextCacheProtection": "Protect cache from agent tool mutations",
     "agentFeaturesContextLength": "Context length",
     "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
-    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1/models."
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1/models.",
+    "agentFeaturesContextLengthErrorInteger": "Context length must be a valid integer",
+    "agentFeaturesContextLengthErrorRange": "Context length must be between 1000 and 2000000"
   },
   "costs": {
     "title": "Costs",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -4607,5 +4607,10 @@
     "noProxyLogs": "No proxy logs yet. Configure proxies and make API calls to see them here.",
     "noMatchingLogs": "No logs match the current filters.",
     "tlsFingerprint": "Chrome 124 TLS Fingerprint"
+  },
+  "agentFeatures": {
+    "agentFeaturesContextLength": "Context length",
+    "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
   }
 }

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -4611,6 +4611,8 @@
   "agentFeatures": {
     "agentFeaturesContextLength": "Context length",
     "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
-    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1/models.",
+    "agentFeaturesContextLengthErrorInteger": "Context length must be a valid integer",
+    "agentFeaturesContextLengthErrorRange": "Context length must be between 1000 and 2000000"
   }
 }

--- a/src/i18n/messages/fa.json
+++ b/src/i18n/messages/fa.json
@@ -4900,5 +4900,10 @@
     "noProxyLogs": "No proxy logs yet. Configure proxies and make API calls to see them here.",
     "noMatchingLogs": "No logs match the current filters.",
     "tlsFingerprint": "Chrome 124 TLS Fingerprint"
+  },
+  "agentFeatures": {
+    "agentFeaturesContextLength": "Context length",
+    "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
   }
 }

--- a/src/i18n/messages/fa.json
+++ b/src/i18n/messages/fa.json
@@ -4904,6 +4904,8 @@
   "agentFeatures": {
     "agentFeaturesContextLength": "Context length",
     "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
-    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1/models.",
+    "agentFeaturesContextLengthErrorInteger": "Context length must be a valid integer",
+    "agentFeaturesContextLengthErrorRange": "Context length must be between 1000 and 2000000"
   }
 }

--- a/src/i18n/messages/fi.json
+++ b/src/i18n/messages/fi.json
@@ -4607,5 +4607,10 @@
     "noProxyLogs": "No proxy logs yet. Configure proxies and make API calls to see them here.",
     "noMatchingLogs": "No logs match the current filters.",
     "tlsFingerprint": "Chrome 124 TLS Fingerprint"
+  },
+  "agentFeatures": {
+    "agentFeaturesContextLength": "Context length",
+    "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
   }
 }

--- a/src/i18n/messages/fi.json
+++ b/src/i18n/messages/fi.json
@@ -4611,6 +4611,8 @@
   "agentFeatures": {
     "agentFeaturesContextLength": "Context length",
     "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
-    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1/models.",
+    "agentFeaturesContextLengthErrorInteger": "Context length must be a valid integer",
+    "agentFeaturesContextLengthErrorRange": "Context length must be between 1000 and 2000000"
   }
 }

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -4607,5 +4607,10 @@
     "noProxyLogs": "No proxy logs yet. Configure proxies and make API calls to see them here.",
     "noMatchingLogs": "No logs match the current filters.",
     "tlsFingerprint": "Chrome 124 TLS Fingerprint"
+  },
+  "agentFeatures": {
+    "agentFeaturesContextLength": "Context length",
+    "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
   }
 }

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -4611,6 +4611,8 @@
   "agentFeatures": {
     "agentFeaturesContextLength": "Context length",
     "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
-    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1/models.",
+    "agentFeaturesContextLengthErrorInteger": "Context length must be a valid integer",
+    "agentFeaturesContextLengthErrorRange": "Context length must be between 1000 and 2000000"
   }
 }

--- a/src/i18n/messages/gu.json
+++ b/src/i18n/messages/gu.json
@@ -4900,5 +4900,10 @@
     "noProxyLogs": "No proxy logs yet. Configure proxies and make API calls to see them here.",
     "noMatchingLogs": "No logs match the current filters.",
     "tlsFingerprint": "Chrome 124 TLS Fingerprint"
+  },
+  "agentFeatures": {
+    "agentFeaturesContextLength": "Context length",
+    "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
   }
 }

--- a/src/i18n/messages/gu.json
+++ b/src/i18n/messages/gu.json
@@ -4904,6 +4904,8 @@
   "agentFeatures": {
     "agentFeaturesContextLength": "Context length",
     "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
-    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1/models.",
+    "agentFeaturesContextLengthErrorInteger": "Context length must be a valid integer",
+    "agentFeaturesContextLengthErrorRange": "Context length must be between 1000 and 2000000"
   }
 }

--- a/src/i18n/messages/he.json
+++ b/src/i18n/messages/he.json
@@ -4607,5 +4607,10 @@
     "noProxyLogs": "No proxy logs yet. Configure proxies and make API calls to see them here.",
     "noMatchingLogs": "No logs match the current filters.",
     "tlsFingerprint": "Chrome 124 TLS Fingerprint"
+  },
+  "agentFeatures": {
+    "agentFeaturesContextLength": "Context length",
+    "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
   }
 }

--- a/src/i18n/messages/he.json
+++ b/src/i18n/messages/he.json
@@ -4611,6 +4611,8 @@
   "agentFeatures": {
     "agentFeaturesContextLength": "Context length",
     "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
-    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1/models.",
+    "agentFeaturesContextLengthErrorInteger": "Context length must be a valid integer",
+    "agentFeaturesContextLengthErrorRange": "Context length must be between 1000 and 2000000"
   }
 }

--- a/src/i18n/messages/hi.json
+++ b/src/i18n/messages/hi.json
@@ -4607,5 +4607,10 @@
     "noProxyLogs": "No proxy logs yet. Configure proxies and make API calls to see them here.",
     "noMatchingLogs": "No logs match the current filters.",
     "tlsFingerprint": "Chrome 124 TLS Fingerprint"
+  },
+  "agentFeatures": {
+    "agentFeaturesContextLength": "Context length",
+    "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
   }
 }

--- a/src/i18n/messages/hi.json
+++ b/src/i18n/messages/hi.json
@@ -4611,6 +4611,8 @@
   "agentFeatures": {
     "agentFeaturesContextLength": "Context length",
     "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
-    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1/models.",
+    "agentFeaturesContextLengthErrorInteger": "Context length must be a valid integer",
+    "agentFeaturesContextLengthErrorRange": "Context length must be between 1000 and 2000000"
   }
 }

--- a/src/i18n/messages/hu.json
+++ b/src/i18n/messages/hu.json
@@ -4607,5 +4607,10 @@
     "noProxyLogs": "No proxy logs yet. Configure proxies and make API calls to see them here.",
     "noMatchingLogs": "No logs match the current filters.",
     "tlsFingerprint": "Chrome 124 TLS Fingerprint"
+  },
+  "agentFeatures": {
+    "agentFeaturesContextLength": "Context length",
+    "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
   }
 }

--- a/src/i18n/messages/hu.json
+++ b/src/i18n/messages/hu.json
@@ -4611,6 +4611,8 @@
   "agentFeatures": {
     "agentFeaturesContextLength": "Context length",
     "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
-    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1/models.",
+    "agentFeaturesContextLengthErrorInteger": "Context length must be a valid integer",
+    "agentFeaturesContextLengthErrorRange": "Context length must be between 1000 and 2000000"
   }
 }

--- a/src/i18n/messages/id.json
+++ b/src/i18n/messages/id.json
@@ -4607,5 +4607,10 @@
     "noProxyLogs": "No proxy logs yet. Configure proxies and make API calls to see them here.",
     "noMatchingLogs": "No logs match the current filters.",
     "tlsFingerprint": "Chrome 124 TLS Fingerprint"
+  },
+  "agentFeatures": {
+    "agentFeaturesContextLength": "Context length",
+    "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
   }
 }

--- a/src/i18n/messages/id.json
+++ b/src/i18n/messages/id.json
@@ -4611,6 +4611,8 @@
   "agentFeatures": {
     "agentFeaturesContextLength": "Context length",
     "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
-    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1/models.",
+    "agentFeaturesContextLengthErrorInteger": "Context length must be a valid integer",
+    "agentFeaturesContextLengthErrorRange": "Context length must be between 1000 and 2000000"
   }
 }

--- a/src/i18n/messages/in.json
+++ b/src/i18n/messages/in.json
@@ -4900,5 +4900,10 @@
     "noProxyLogs": "No proxy logs yet. Configure proxies and make API calls to see them here.",
     "noMatchingLogs": "No logs match the current filters.",
     "tlsFingerprint": "Chrome 124 TLS Fingerprint"
+  },
+  "agentFeatures": {
+    "agentFeaturesContextLength": "Context length",
+    "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
   }
 }

--- a/src/i18n/messages/in.json
+++ b/src/i18n/messages/in.json
@@ -4904,6 +4904,8 @@
   "agentFeatures": {
     "agentFeaturesContextLength": "Context length",
     "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
-    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1/models.",
+    "agentFeaturesContextLengthErrorInteger": "Context length must be a valid integer",
+    "agentFeaturesContextLengthErrorRange": "Context length must be between 1000 and 2000000"
   }
 }

--- a/src/i18n/messages/it.json
+++ b/src/i18n/messages/it.json
@@ -4607,5 +4607,10 @@
     "noProxyLogs": "No proxy logs yet. Configure proxies and make API calls to see them here.",
     "noMatchingLogs": "No logs match the current filters.",
     "tlsFingerprint": "Chrome 124 TLS Fingerprint"
+  },
+  "agentFeatures": {
+    "agentFeaturesContextLength": "Context length",
+    "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
   }
 }

--- a/src/i18n/messages/it.json
+++ b/src/i18n/messages/it.json
@@ -4611,6 +4611,8 @@
   "agentFeatures": {
     "agentFeaturesContextLength": "Context length",
     "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
-    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1/models.",
+    "agentFeaturesContextLengthErrorInteger": "Context length must be a valid integer",
+    "agentFeaturesContextLengthErrorRange": "Context length must be between 1000 and 2000000"
   }
 }

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -4607,5 +4607,10 @@
     "noProxyLogs": "No proxy logs yet. Configure proxies and make API calls to see them here.",
     "noMatchingLogs": "No logs match the current filters.",
     "tlsFingerprint": "Chrome 124 TLS Fingerprint"
+  },
+  "agentFeatures": {
+    "agentFeaturesContextLength": "Context length",
+    "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
   }
 }

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -4611,6 +4611,8 @@
   "agentFeatures": {
     "agentFeaturesContextLength": "Context length",
     "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
-    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1/models.",
+    "agentFeaturesContextLengthErrorInteger": "Context length must be a valid integer",
+    "agentFeaturesContextLengthErrorRange": "Context length must be between 1000 and 2000000"
   }
 }

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -4609,5 +4609,10 @@
     "noProxyLogs": "No proxy logs yet. Configure proxies and make API calls to see them here.",
     "noMatchingLogs": "No logs match the current filters.",
     "tlsFingerprint": "Chrome 124 TLS Fingerprint"
+  },
+  "agentFeatures": {
+    "agentFeaturesContextLength": "Context length",
+    "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
   }
 }

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -4613,6 +4613,8 @@
   "agentFeatures": {
     "agentFeaturesContextLength": "Context length",
     "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
-    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1/models.",
+    "agentFeaturesContextLengthErrorInteger": "Context length must be a valid integer",
+    "agentFeaturesContextLengthErrorRange": "Context length must be between 1000 and 2000000"
   }
 }

--- a/src/i18n/messages/mr.json
+++ b/src/i18n/messages/mr.json
@@ -4900,5 +4900,10 @@
     "noProxyLogs": "No proxy logs yet. Configure proxies and make API calls to see them here.",
     "noMatchingLogs": "No logs match the current filters.",
     "tlsFingerprint": "Chrome 124 TLS Fingerprint"
+  },
+  "agentFeatures": {
+    "agentFeaturesContextLength": "Context length",
+    "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
   }
 }

--- a/src/i18n/messages/mr.json
+++ b/src/i18n/messages/mr.json
@@ -4904,6 +4904,8 @@
   "agentFeatures": {
     "agentFeaturesContextLength": "Context length",
     "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
-    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1/models.",
+    "agentFeaturesContextLengthErrorInteger": "Context length must be a valid integer",
+    "agentFeaturesContextLengthErrorRange": "Context length must be between 1000 and 2000000"
   }
 }

--- a/src/i18n/messages/ms.json
+++ b/src/i18n/messages/ms.json
@@ -4607,5 +4607,10 @@
     "noProxyLogs": "No proxy logs yet. Configure proxies and make API calls to see them here.",
     "noMatchingLogs": "No logs match the current filters.",
     "tlsFingerprint": "Chrome 124 TLS Fingerprint"
+  },
+  "agentFeatures": {
+    "agentFeaturesContextLength": "Context length",
+    "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
   }
 }

--- a/src/i18n/messages/ms.json
+++ b/src/i18n/messages/ms.json
@@ -4611,6 +4611,8 @@
   "agentFeatures": {
     "agentFeaturesContextLength": "Context length",
     "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
-    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1/models.",
+    "agentFeaturesContextLengthErrorInteger": "Context length must be a valid integer",
+    "agentFeaturesContextLengthErrorRange": "Context length must be between 1000 and 2000000"
   }
 }

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -4607,5 +4607,10 @@
     "noProxyLogs": "No proxy logs yet. Configure proxies and make API calls to see them here.",
     "noMatchingLogs": "No logs match the current filters.",
     "tlsFingerprint": "Chrome 124 TLS Fingerprint"
+  },
+  "agentFeatures": {
+    "agentFeaturesContextLength": "Context length",
+    "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
   }
 }

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -4611,6 +4611,8 @@
   "agentFeatures": {
     "agentFeaturesContextLength": "Context length",
     "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
-    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1/models.",
+    "agentFeaturesContextLengthErrorInteger": "Context length must be a valid integer",
+    "agentFeaturesContextLengthErrorRange": "Context length must be between 1000 and 2000000"
   }
 }

--- a/src/i18n/messages/no.json
+++ b/src/i18n/messages/no.json
@@ -4607,5 +4607,10 @@
     "noProxyLogs": "No proxy logs yet. Configure proxies and make API calls to see them here.",
     "noMatchingLogs": "No logs match the current filters.",
     "tlsFingerprint": "Chrome 124 TLS Fingerprint"
+  },
+  "agentFeatures": {
+    "agentFeaturesContextLength": "Context length",
+    "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
   }
 }

--- a/src/i18n/messages/no.json
+++ b/src/i18n/messages/no.json
@@ -4611,6 +4611,8 @@
   "agentFeatures": {
     "agentFeaturesContextLength": "Context length",
     "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
-    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1/models.",
+    "agentFeaturesContextLengthErrorInteger": "Context length must be a valid integer",
+    "agentFeaturesContextLengthErrorRange": "Context length must be between 1000 and 2000000"
   }
 }

--- a/src/i18n/messages/phi.json
+++ b/src/i18n/messages/phi.json
@@ -4607,5 +4607,10 @@
     "noProxyLogs": "No proxy logs yet. Configure proxies and make API calls to see them here.",
     "noMatchingLogs": "No logs match the current filters.",
     "tlsFingerprint": "Chrome 124 TLS Fingerprint"
+  },
+  "agentFeatures": {
+    "agentFeaturesContextLength": "Context length",
+    "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
   }
 }

--- a/src/i18n/messages/phi.json
+++ b/src/i18n/messages/phi.json
@@ -4611,6 +4611,8 @@
   "agentFeatures": {
     "agentFeaturesContextLength": "Context length",
     "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
-    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1/models.",
+    "agentFeaturesContextLengthErrorInteger": "Context length must be a valid integer",
+    "agentFeaturesContextLengthErrorRange": "Context length must be between 1000 and 2000000"
   }
 }

--- a/src/i18n/messages/pl.json
+++ b/src/i18n/messages/pl.json
@@ -4607,5 +4607,10 @@
     "noProxyLogs": "No proxy logs yet. Configure proxies and make API calls to see them here.",
     "noMatchingLogs": "No logs match the current filters.",
     "tlsFingerprint": "Chrome 124 TLS Fingerprint"
+  },
+  "agentFeatures": {
+    "agentFeaturesContextLength": "Context length",
+    "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
   }
 }

--- a/src/i18n/messages/pl.json
+++ b/src/i18n/messages/pl.json
@@ -4611,6 +4611,8 @@
   "agentFeatures": {
     "agentFeaturesContextLength": "Context length",
     "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
-    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1/models.",
+    "agentFeaturesContextLengthErrorInteger": "Context length must be a valid integer",
+    "agentFeaturesContextLengthErrorRange": "Context length must be between 1000 and 2000000"
   }
 }

--- a/src/i18n/messages/pt-BR.json
+++ b/src/i18n/messages/pt-BR.json
@@ -4785,5 +4785,10 @@
     "noProxyLogs": "No proxy logs yet. Configure proxies and make API calls to see them here.",
     "noMatchingLogs": "No logs match the current filters.",
     "tlsFingerprint": "Chrome 124 TLS Fingerprint"
+  },
+  "agentFeatures": {
+    "agentFeaturesContextLength": "Context length",
+    "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
   }
 }

--- a/src/i18n/messages/pt-BR.json
+++ b/src/i18n/messages/pt-BR.json
@@ -4789,6 +4789,8 @@
   "agentFeatures": {
     "agentFeaturesContextLength": "Context length",
     "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
-    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1/models.",
+    "agentFeaturesContextLengthErrorInteger": "Context length must be a valid integer",
+    "agentFeaturesContextLengthErrorRange": "Context length must be between 1000 and 2000000"
   }
 }

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -4639,5 +4639,10 @@
     "noProxyLogs": "No proxy logs yet. Configure proxies and make API calls to see them here.",
     "noMatchingLogs": "No logs match the current filters.",
     "tlsFingerprint": "Chrome 124 TLS Fingerprint"
+  },
+  "agentFeatures": {
+    "agentFeaturesContextLength": "Context length",
+    "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
   }
 }

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -4643,6 +4643,8 @@
   "agentFeatures": {
     "agentFeaturesContextLength": "Context length",
     "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
-    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1/models.",
+    "agentFeaturesContextLengthErrorInteger": "Context length must be a valid integer",
+    "agentFeaturesContextLengthErrorRange": "Context length must be between 1000 and 2000000"
   }
 }

--- a/src/i18n/messages/ro.json
+++ b/src/i18n/messages/ro.json
@@ -4607,5 +4607,10 @@
     "noProxyLogs": "No proxy logs yet. Configure proxies and make API calls to see them here.",
     "noMatchingLogs": "No logs match the current filters.",
     "tlsFingerprint": "Chrome 124 TLS Fingerprint"
+  },
+  "agentFeatures": {
+    "agentFeaturesContextLength": "Context length",
+    "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
   }
 }

--- a/src/i18n/messages/ro.json
+++ b/src/i18n/messages/ro.json
@@ -4611,6 +4611,8 @@
   "agentFeatures": {
     "agentFeaturesContextLength": "Context length",
     "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
-    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1/models.",
+    "agentFeaturesContextLengthErrorInteger": "Context length must be a valid integer",
+    "agentFeaturesContextLengthErrorRange": "Context length must be between 1000 and 2000000"
   }
 }

--- a/src/i18n/messages/ru.json
+++ b/src/i18n/messages/ru.json
@@ -4631,5 +4631,10 @@
     "noProxyLogs": "No proxy logs yet. Configure proxies and make API calls to see them here.",
     "noMatchingLogs": "No logs match the current filters.",
     "tlsFingerprint": "Chrome 124 TLS Fingerprint"
+  },
+  "agentFeatures": {
+    "agentFeaturesContextLength": "Context length",
+    "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
   }
 }

--- a/src/i18n/messages/ru.json
+++ b/src/i18n/messages/ru.json
@@ -4635,6 +4635,8 @@
   "agentFeatures": {
     "agentFeaturesContextLength": "Context length",
     "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
-    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1/models.",
+    "agentFeaturesContextLengthErrorInteger": "Context length must be a valid integer",
+    "agentFeaturesContextLengthErrorRange": "Context length must be between 1000 and 2000000"
   }
 }

--- a/src/i18n/messages/sk.json
+++ b/src/i18n/messages/sk.json
@@ -4607,5 +4607,10 @@
     "noProxyLogs": "No proxy logs yet. Configure proxies and make API calls to see them here.",
     "noMatchingLogs": "No logs match the current filters.",
     "tlsFingerprint": "Chrome 124 TLS Fingerprint"
+  },
+  "agentFeatures": {
+    "agentFeaturesContextLength": "Context length",
+    "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
   }
 }

--- a/src/i18n/messages/sk.json
+++ b/src/i18n/messages/sk.json
@@ -4611,6 +4611,8 @@
   "agentFeatures": {
     "agentFeaturesContextLength": "Context length",
     "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
-    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1/models.",
+    "agentFeaturesContextLengthErrorInteger": "Context length must be a valid integer",
+    "agentFeaturesContextLengthErrorRange": "Context length must be between 1000 and 2000000"
   }
 }

--- a/src/i18n/messages/sv.json
+++ b/src/i18n/messages/sv.json
@@ -4607,5 +4607,10 @@
     "noProxyLogs": "No proxy logs yet. Configure proxies and make API calls to see them here.",
     "noMatchingLogs": "No logs match the current filters.",
     "tlsFingerprint": "Chrome 124 TLS Fingerprint"
+  },
+  "agentFeatures": {
+    "agentFeaturesContextLength": "Context length",
+    "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
   }
 }

--- a/src/i18n/messages/sv.json
+++ b/src/i18n/messages/sv.json
@@ -4611,6 +4611,8 @@
   "agentFeatures": {
     "agentFeaturesContextLength": "Context length",
     "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
-    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1/models.",
+    "agentFeaturesContextLengthErrorInteger": "Context length must be a valid integer",
+    "agentFeaturesContextLengthErrorRange": "Context length must be between 1000 and 2000000"
   }
 }

--- a/src/i18n/messages/sw.json
+++ b/src/i18n/messages/sw.json
@@ -4900,5 +4900,10 @@
     "noProxyLogs": "No proxy logs yet. Configure proxies and make API calls to see them here.",
     "noMatchingLogs": "No logs match the current filters.",
     "tlsFingerprint": "Chrome 124 TLS Fingerprint"
+  },
+  "agentFeatures": {
+    "agentFeaturesContextLength": "Context length",
+    "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
   }
 }

--- a/src/i18n/messages/sw.json
+++ b/src/i18n/messages/sw.json
@@ -4904,6 +4904,8 @@
   "agentFeatures": {
     "agentFeaturesContextLength": "Context length",
     "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
-    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1/models.",
+    "agentFeaturesContextLengthErrorInteger": "Context length must be a valid integer",
+    "agentFeaturesContextLengthErrorRange": "Context length must be between 1000 and 2000000"
   }
 }

--- a/src/i18n/messages/ta.json
+++ b/src/i18n/messages/ta.json
@@ -4900,5 +4900,10 @@
     "noProxyLogs": "No proxy logs yet. Configure proxies and make API calls to see them here.",
     "noMatchingLogs": "No logs match the current filters.",
     "tlsFingerprint": "Chrome 124 TLS Fingerprint"
+  },
+  "agentFeatures": {
+    "agentFeaturesContextLength": "Context length",
+    "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
   }
 }

--- a/src/i18n/messages/ta.json
+++ b/src/i18n/messages/ta.json
@@ -4904,6 +4904,8 @@
   "agentFeatures": {
     "agentFeaturesContextLength": "Context length",
     "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
-    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1/models.",
+    "agentFeaturesContextLengthErrorInteger": "Context length must be a valid integer",
+    "agentFeaturesContextLengthErrorRange": "Context length must be between 1000 and 2000000"
   }
 }

--- a/src/i18n/messages/te.json
+++ b/src/i18n/messages/te.json
@@ -4900,5 +4900,10 @@
     "noProxyLogs": "No proxy logs yet. Configure proxies and make API calls to see them here.",
     "noMatchingLogs": "No logs match the current filters.",
     "tlsFingerprint": "Chrome 124 TLS Fingerprint"
+  },
+  "agentFeatures": {
+    "agentFeaturesContextLength": "Context length",
+    "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
   }
 }

--- a/src/i18n/messages/te.json
+++ b/src/i18n/messages/te.json
@@ -4904,6 +4904,8 @@
   "agentFeatures": {
     "agentFeaturesContextLength": "Context length",
     "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
-    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1/models.",
+    "agentFeaturesContextLengthErrorInteger": "Context length must be a valid integer",
+    "agentFeaturesContextLengthErrorRange": "Context length must be between 1000 and 2000000"
   }
 }

--- a/src/i18n/messages/th.json
+++ b/src/i18n/messages/th.json
@@ -4607,5 +4607,10 @@
     "noProxyLogs": "No proxy logs yet. Configure proxies and make API calls to see them here.",
     "noMatchingLogs": "No logs match the current filters.",
     "tlsFingerprint": "Chrome 124 TLS Fingerprint"
+  },
+  "agentFeatures": {
+    "agentFeaturesContextLength": "Context length",
+    "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
   }
 }

--- a/src/i18n/messages/th.json
+++ b/src/i18n/messages/th.json
@@ -4611,6 +4611,8 @@
   "agentFeatures": {
     "agentFeaturesContextLength": "Context length",
     "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
-    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1/models.",
+    "agentFeaturesContextLengthErrorInteger": "Context length must be a valid integer",
+    "agentFeaturesContextLengthErrorRange": "Context length must be between 1000 and 2000000"
   }
 }

--- a/src/i18n/messages/tr.json
+++ b/src/i18n/messages/tr.json
@@ -4607,5 +4607,10 @@
     "noProxyLogs": "No proxy logs yet. Configure proxies and make API calls to see them here.",
     "noMatchingLogs": "No logs match the current filters.",
     "tlsFingerprint": "Chrome 124 TLS Fingerprint"
+  },
+  "agentFeatures": {
+    "agentFeaturesContextLength": "Context length",
+    "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
   }
 }

--- a/src/i18n/messages/tr.json
+++ b/src/i18n/messages/tr.json
@@ -4611,6 +4611,8 @@
   "agentFeatures": {
     "agentFeaturesContextLength": "Context length",
     "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
-    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1/models.",
+    "agentFeaturesContextLengthErrorInteger": "Context length must be a valid integer",
+    "agentFeaturesContextLengthErrorRange": "Context length must be between 1000 and 2000000"
   }
 }

--- a/src/i18n/messages/uk-UA.json
+++ b/src/i18n/messages/uk-UA.json
@@ -4607,5 +4607,10 @@
     "noProxyLogs": "No proxy logs yet. Configure proxies and make API calls to see them here.",
     "noMatchingLogs": "No logs match the current filters.",
     "tlsFingerprint": "Chrome 124 TLS Fingerprint"
+  },
+  "agentFeatures": {
+    "agentFeaturesContextLength": "Context length",
+    "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
   }
 }

--- a/src/i18n/messages/uk-UA.json
+++ b/src/i18n/messages/uk-UA.json
@@ -4611,6 +4611,8 @@
   "agentFeatures": {
     "agentFeaturesContextLength": "Context length",
     "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
-    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1/models.",
+    "agentFeaturesContextLengthErrorInteger": "Context length must be a valid integer",
+    "agentFeaturesContextLengthErrorRange": "Context length must be between 1000 and 2000000"
   }
 }

--- a/src/i18n/messages/ur.json
+++ b/src/i18n/messages/ur.json
@@ -4900,5 +4900,10 @@
     "noProxyLogs": "No proxy logs yet. Configure proxies and make API calls to see them here.",
     "noMatchingLogs": "No logs match the current filters.",
     "tlsFingerprint": "Chrome 124 TLS Fingerprint"
+  },
+  "agentFeatures": {
+    "agentFeaturesContextLength": "Context length",
+    "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
   }
 }

--- a/src/i18n/messages/ur.json
+++ b/src/i18n/messages/ur.json
@@ -4904,6 +4904,8 @@
   "agentFeatures": {
     "agentFeaturesContextLength": "Context length",
     "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
-    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1/models.",
+    "agentFeaturesContextLengthErrorInteger": "Context length must be a valid integer",
+    "agentFeaturesContextLengthErrorRange": "Context length must be between 1000 and 2000000"
   }
 }

--- a/src/i18n/messages/vi.json
+++ b/src/i18n/messages/vi.json
@@ -4607,5 +4607,10 @@
     "noProxyLogs": "No proxy logs yet. Configure proxies and make API calls to see them here.",
     "noMatchingLogs": "No logs match the current filters.",
     "tlsFingerprint": "Chrome 124 TLS Fingerprint"
+  },
+  "agentFeatures": {
+    "agentFeaturesContextLength": "Context length",
+    "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
   }
 }

--- a/src/i18n/messages/vi.json
+++ b/src/i18n/messages/vi.json
@@ -4611,6 +4611,8 @@
   "agentFeatures": {
     "agentFeaturesContextLength": "Context length",
     "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
-    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1/models.",
+    "agentFeaturesContextLengthErrorInteger": "Context length must be a valid integer",
+    "agentFeaturesContextLengthErrorRange": "Context length must be between 1000 and 2000000"
   }
 }

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -4855,5 +4855,10 @@
     "noProxyLogs": "No proxy logs yet. Configure proxies and make API calls to see them here.",
     "noMatchingLogs": "No logs match the current filters.",
     "tlsFingerprint": "Chrome 124 TLS Fingerprint"
+  },
+  "agentFeatures": {
+    "agentFeaturesContextLength": "Context length",
+    "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
   }
 }

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -4859,6 +4859,8 @@
   "agentFeatures": {
     "agentFeaturesContextLength": "Context length",
     "agentFeaturesContextLengthPlaceholder": "e.g. 128000",
-    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1.models."
+    "agentFeaturesContextLengthHint": "Defines the context window for this combo in /v1/models.",
+    "agentFeaturesContextLengthErrorInteger": "Context length must be a valid integer",
+    "agentFeaturesContextLengthErrorRange": "Context length must be between 1000 and 2000000"
   }
 }

--- a/src/lib/db/combos.ts
+++ b/src/lib/db/combos.ts
@@ -161,6 +161,12 @@ export async function updateCombo(id: string, data: JsonRecord) {
     sortOrder,
     updatedAt: new Date().toISOString(),
   };
+  // Remove fields explicitly set to null (for deletion support)
+  for (const key of Object.keys(data)) {
+    if (data[key] === null) {
+      delete merged[key];
+    }
+  }
   const currentName = typeof current.name === "string" ? current.name : "";
   const nextName =
     typeof merged["name"] === "string" && merged["name"].trim().length > 0

--- a/src/shared/validation/schemas.ts
+++ b/src/shared/validation/schemas.ts
@@ -1325,7 +1325,7 @@ export const updateComboSchema = z
     system_message: z.string().max(50000).optional(),
     tool_filter_regex: z.string().max(1000).optional(),
     context_cache_protection: z.boolean().optional(),
-    context_length: z.number().int().min(1000).max(2000000).optional(),
+    context_length: z.number().int().min(1000).max(2000000).optional().nullable(),
     compressionOverride: comboCompressionOverrideSchema.optional(),
   })
   .superRefine((value, ctx) => {

--- a/tests/unit/combo-context-length.test.ts
+++ b/tests/unit/combo-context-length.test.ts
@@ -1,0 +1,265 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-combo-ctx-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const combosDb = await import("../../src/lib/db/combos.ts");
+const schemas = await import("../../src/shared/validation/schemas.ts");
+
+async function resetStorage() {
+  core.resetDbInstance();
+
+  for (let attempt = 0; attempt < 10; attempt++) {
+    try {
+      if (fs.existsSync(TEST_DATA_DIR)) {
+        fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+      }
+      break;
+    } catch (error: any) {
+      if ((error?.code === "EBUSY" || error?.code === "EPERM") && attempt < 9) {
+        await new Promise((resolve) => setTimeout(resolve, 50 * (attempt + 1)));
+      } else {
+        throw error;
+      }
+    }
+  }
+
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+test.beforeEach(async () => {
+  await resetStorage();
+});
+
+test.after(async () => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+// ─── Zod Schema Validation (createComboSchema) ───
+
+test("createComboSchema accepts valid context_length", () => {
+  const result = schemas.createComboSchema.safeParse({
+    name: "TestCombo",
+    context_length: 128000,
+  });
+  assert.equal(result.success, true);
+});
+
+test("createComboSchema rejects context_length below minimum (1000)", () => {
+  const result = schemas.createComboSchema.safeParse({
+    name: "TestCombo",
+    context_length: 999,
+  });
+  assert.equal(result.success, false);
+});
+
+test("createComboSchema rejects context_length above maximum (2000000)", () => {
+  const result = schemas.createComboSchema.safeParse({
+    name: "TestCombo",
+    context_length: 2000001,
+  });
+  assert.equal(result.success, false);
+});
+
+test("createComboSchema accepts context_length at exact boundaries", () => {
+  const min = schemas.createComboSchema.safeParse({
+    name: "MinCombo",
+    context_length: 1000,
+  });
+  assert.equal(min.success, true);
+
+  const max = schemas.createComboSchema.safeParse({
+    name: "MaxCombo",
+    context_length: 2000000,
+  });
+  assert.equal(max.success, true);
+});
+
+test("createComboSchema rejects non-integer context_length", () => {
+  const result = schemas.createComboSchema.safeParse({
+    name: "TestCombo",
+    context_length: 128000.5,
+  });
+  assert.equal(result.success, false);
+});
+
+test("createComboSchema accepts omitted context_length", () => {
+  const result = schemas.createComboSchema.safeParse({
+    name: "TestCombo",
+  });
+  assert.equal(result.success, true);
+});
+
+// ─── Zod Schema Validation (updateComboSchema) ───
+
+test("updateComboSchema accepts valid context_length", () => {
+  const result = schemas.updateComboSchema.safeParse({
+    context_length: 256000,
+  });
+  assert.equal(result.success, true);
+});
+
+test("updateComboSchema accepts null context_length (for clearing)", () => {
+  const result = schemas.updateComboSchema.safeParse({
+    context_length: null,
+  });
+  assert.equal(result.success, true);
+});
+
+test("updateComboSchema rejects context_length below minimum", () => {
+  const result = schemas.updateComboSchema.safeParse({
+    context_length: 500,
+  });
+  assert.equal(result.success, false);
+});
+
+test("updateComboSchema rejects context_length above maximum", () => {
+  const result = schemas.updateComboSchema.safeParse({
+    context_length: 3000000,
+  });
+  assert.equal(result.success, false);
+});
+
+test("updateComboSchema rejects empty object (no fields)", () => {
+  const result = schemas.updateComboSchema.safeParse({});
+  assert.equal(result.success, false);
+});
+
+// ─── DB Operations ───
+
+test("createCombo with context_length stores it correctly", async () => {
+  const combo = await combosDb.createCombo({
+    name: "CtxCombo",
+    models: [{ provider: "openai", model: "gpt-4.1" }],
+    context_length: 128000,
+  });
+
+  assert.equal(combo.context_length, 128000);
+
+  const retrieved = await combosDb.getComboById(combo.id);
+  assert.equal(retrieved?.context_length, 128000);
+});
+
+test("createCombo without context_length stores undefined", async () => {
+  const combo = await combosDb.createCombo({
+    name: "NoCtxCombo",
+    models: [{ provider: "openai", model: "gpt-4.1" }],
+  });
+
+  assert.equal(combo.context_length, undefined);
+});
+
+test("updateCombo can set context_length", async () => {
+  const combo = await combosDb.createCombo({
+    name: "UpdateCtxCombo",
+    models: [{ provider: "openai", model: "gpt-4.1" }],
+  });
+
+  assert.equal(combo.context_length, undefined);
+
+  const updated = await combosDb.updateCombo(combo.id, { context_length: 256000 });
+  assert.equal(updated?.context_length, 256000);
+
+  const retrieved = await combosDb.getComboById(combo.id);
+  assert.equal(retrieved?.context_length, 256000);
+});
+
+test("updateCombo can clear context_length with null", async () => {
+  const combo = await combosDb.createCombo({
+    name: "ClearCtxCombo",
+    models: [{ provider: "openai", model: "gpt-4.1" }],
+    context_length: 128000,
+  });
+
+  assert.equal(combo.context_length, 128000);
+
+  const updated = await combosDb.updateCombo(combo.id, { context_length: null });
+  assert.equal(updated?.context_length, undefined);
+
+  const retrieved = await combosDb.getComboById(combo.id);
+  assert.equal(retrieved?.context_length, undefined);
+});
+
+test("updateCombo preserves context_length when not included in update", async () => {
+  const combo = await combosDb.createCombo({
+    name: "PreserveCtxCombo",
+    models: [{ provider: "openai", model: "gpt-4.1" }],
+    context_length: 128000,
+  });
+
+  const updated = await combosDb.updateCombo(combo.id, { strategy: "round-robin" });
+  assert.equal(updated?.context_length, 128000);
+});
+
+test("getCombos returns context_length for all combos", async () => {
+  await combosDb.createCombo({
+    name: "ComboA",
+    models: [{ provider: "openai", model: "gpt-4.1" }],
+    context_length: 64000,
+  });
+  await combosDb.createCombo({
+    name: "ComboB",
+    models: [{ provider: "anthropic", model: "claude-3-7-sonnet" }],
+    context_length: 128000,
+  });
+  await combosDb.createCombo({
+    name: "ComboC",
+    models: [{ provider: "openai", model: "gpt-4o" }],
+  });
+
+  const combos = await combosDb.getCombos();
+  const comboA = combos.find((c) => c.name === "ComboA");
+  const comboB = combos.find((c) => c.name === "ComboB");
+  const comboC = combos.find((c) => c.name === "ComboC");
+
+  assert.equal(comboA?.context_length, 64000);
+  assert.equal(comboB?.context_length, 128000);
+  assert.equal(comboC?.context_length, undefined);
+});
+
+// ─── Edge Cases ───
+
+test("context_length boundary value: exactly 1000", async () => {
+  const combo = await combosDb.createCombo({
+    name: "MinBoundary",
+    models: [{ provider: "openai", model: "gpt-4.1" }],
+    context_length: 1000,
+  });
+  assert.equal(combo.context_length, 1000);
+});
+
+test("context_length boundary value: exactly 2000000", async () => {
+  const combo = await combosDb.createCombo({
+    name: "MaxBoundary",
+    models: [{ provider: "openai", model: "gpt-4.1" }],
+    context_length: 2000000,
+  });
+  assert.equal(combo.context_length, 2000000);
+});
+
+test("updateCombo with context_length 0 is rejected by schema", () => {
+  const result = schemas.updateComboSchema.safeParse({
+    context_length: 0,
+  });
+  assert.equal(result.success, false);
+});
+
+test("updateCombo with negative context_length is rejected by schema", () => {
+  const result = schemas.updateComboSchema.safeParse({
+    context_length: -100,
+  });
+  assert.equal(result.success, false);
+});
+
+test("updateCombo with string context_length is rejected by schema", () => {
+  const result = schemas.updateComboSchema.safeParse({
+    context_length: "128000",
+  } as any);
+  assert.equal(result.success, false);
+});


### PR DESCRIPTION
## Summary

Adds a `context_length` number input field to the Agent Features section in the combo edit form, allowing users to set the context window size for combos that appears in `/v1/models` API responses.

## Changes

### Frontend (`src/app/(dashboard)/dashboard/combos/page.tsx`)
- Added `contextLength` and `contextLengthError` state variables
- Added number input field in Agent Features section (min: 1000, max: 2000000, step: 1000)
- Real-time validation on input change (integer check, range validation)
- Field-level error messages displayed below the input
- `saveBlocked` includes `!!contextLengthError` to prevent saving invalid values
- Draft snapshot tracking includes `contextLength` for pristine detection

### Backend Schema (`src/shared/validation/schemas.ts`)
- Updated `updateComboSchema` to accept `null` for `context_length` (`.nullable()`)

### Database Layer (`src/lib/db/combos.ts`)
- Updated `updateCombo` to remove fields with explicit `null` values, enabling deletion of `context_length` on edit

### i18n (`src/i18n/messages/*.json`)
- Added 3 i18n keys to all 41 language files: `agentFeaturesContextLength`, `agentFeaturesContextLengthPlaceholder`, `agentFeaturesContextLengthHint`

### Tests (`tests/unit/combo-context-length.test.ts`)
- 22 new unit tests covering Zod schema validation (11), DB CRUD (7), and edge cases (4)

## Validation Rules
- Must be a valid integer
- Range: 1000 - 2,000,000
- Empty field in edit mode: sends `null` to delete existing value
- Empty field in create mode: omits from save data

## Testing
- [x] Build passes (`npm run build`)
- [x] Type checking passes (`npm run typecheck:core`)
- [x] All 4164 tests pass (including 22 new)
- [x] Lint and format checks pass (lint-staged)
- [x] i18n keys added to all 41 languages
- [x] Manual browser testing completed

## Review Notes
- Security review: PASS (no vulnerabilities identified)
- Code quality review: PASS (all major findings addressed)
- Addressed review findings:
  1. Fixed inability to delete existing `context_length` on edit (added `.nullable()` + null deletion logic)
  2. Fixed hidden save blocker in guided mode (added real-time validation + `saveBlocked` integration)
  3. Fixed dedicated error state (`contextLengthError`) instead of reusing unrelated error state