### PR TITLE
fix(auth): restore onboarding bootstrap when no password is configured

### DIFF
--- a/src/app/api/settings/require-login/route.ts
+++ b/src/app/api/settings/require-login/route.ts
@@ -20,7 +20,7 @@ function hasConfiguredPassword(settings: Record<string, unknown>) {
 }
 
 function isBootstrapSecurityWindow(settings: Record<string, unknown>) {
-  return settings.setupComplete !== true && !hasConfiguredPassword(settings);
+  return !hasConfiguredPassword(settings);
 }
 
 export async function GET() {

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -87,34 +87,37 @@ export default function LoginPage() {
     }
   };
 
-  const nodeWarningBanner = !nodeCompatible && nodeVersion ? (
-    <div className="w-full max-w-lg mx-auto mb-6 animate-in fade-in slide-in-from-top-2 duration-500">
-      <div className="bg-red-950/60 border-2 border-red-500/40 rounded-2xl p-6 shadow-lg shadow-red-900/20 backdrop-blur-sm">
-        <div className="flex items-start gap-4">
-          <div className="w-12 h-12 rounded-xl bg-red-500/20 flex items-center justify-center flex-shrink-0 mt-0.5">
-            <span className="material-symbols-outlined text-red-400 text-[28px]">error</span>
-          </div>
-          <div className="flex-1 min-w-0">
-            <h3 className="text-base font-bold text-red-300 mb-1">{t("nodeIncompatibleTitle")}</h3>
-            <p className="text-sm text-red-200/80 leading-relaxed mb-3">
-              {t("nodeIncompatibleDesc", { version: nodeVersion })}
-            </p>
-            <div className="bg-black/40 rounded-lg px-4 py-3 font-mono text-sm border border-red-500/20">
-              <div className="flex items-center gap-2 text-red-300/60 mb-1">
-                <span className="material-symbols-outlined text-[14px]">terminal</span>
-                <span className="text-xs">{t("nodeIncompatibleFixLabel")}</span>
-              </div>
-              <code className="text-amber-300">nvm install 22 && nvm use 22</code>
+  const nodeWarningBanner =
+    !nodeCompatible && nodeVersion ? (
+      <div className="w-full max-w-lg mx-auto mb-6 animate-in fade-in slide-in-from-top-2 duration-500">
+        <div className="bg-red-950/60 border-2 border-red-500/40 rounded-2xl p-6 shadow-lg shadow-red-900/20 backdrop-blur-sm">
+          <div className="flex items-start gap-4">
+            <div className="w-12 h-12 rounded-xl bg-red-500/20 flex items-center justify-center flex-shrink-0 mt-0.5">
+              <span className="material-symbols-outlined text-red-400 text-[28px]">error</span>
             </div>
-            <p className="text-xs text-red-300/50 mt-3 flex items-center gap-1.5">
-              <span className="material-symbols-outlined text-[14px]">info</span>
-              {t("nodeIncompatibleHint")}
-            </p>
+            <div className="flex-1 min-w-0">
+              <h3 className="text-base font-bold text-red-300 mb-1">
+                {t("nodeIncompatibleTitle")}
+              </h3>
+              <p className="text-sm text-red-200/80 leading-relaxed mb-3">
+                {t("nodeIncompatibleDesc", { version: nodeVersion })}
+              </p>
+              <div className="bg-black/40 rounded-lg px-4 py-3 font-mono text-sm border border-red-500/20">
+                <div className="flex items-center gap-2 text-red-300/60 mb-1">
+                  <span className="material-symbols-outlined text-[14px]">terminal</span>
+                  <span className="text-xs">{t("nodeIncompatibleFixLabel")}</span>
+                </div>
+                <code className="text-amber-300">nvm install 22 && nvm use 22</code>
+              </div>
+              <p className="text-xs text-red-300/50 mt-3 flex items-center gap-1.5">
+                <span className="material-symbols-outlined text-[14px]">info</span>
+                {t("nodeIncompatibleHint")}
+              </p>
+            </div>
           </div>
         </div>
       </div>
-    </div>
-  ) : null;
+    ) : null;
 
   if (hasPassword === null || setupComplete === null) {
     return (
@@ -194,7 +197,7 @@ export default function LoginPage() {
               <Button
                 variant="primary"
                 className="w-full h-11 text-sm font-medium"
-                onClick={() => router.push("/dashboard/settings?tab=security")}
+                onClick={() => router.push("/dashboard/onboarding")}
               >
                 {t("configurePassword")}
               </Button>
@@ -212,115 +215,115 @@ export default function LoginPage() {
   return (
     <div className="min-h-screen flex flex-col bg-bg">
       {nodeWarningBanner && (
-        <div className="flex justify-center pt-6 px-6">
-          {nodeWarningBanner}
-        </div>
+        <div className="flex justify-center pt-6 px-6">{nodeWarningBanner}</div>
       )}
       <div className="flex-1 flex bg-bg">
-      <div className="flex-1 flex items-center justify-center p-6">
-        <div
-          className={`w-full max-w-sm transition-all duration-700 ease-out ${mounted ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"}`}
-        >
-          <div className="mb-10">
-            <div className="flex items-center gap-3 mb-8">
-              <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-primary to-primary-hover flex items-center justify-center">
-                <span className="material-symbols-outlined text-white text-[20px]">hub</span>
-              </div>
-              <span className="text-xl font-semibold text-text-main tracking-tight">OmniRoute</span>
-            </div>
-            <h1 className="text-2xl font-bold text-text-main tracking-tight">{t("signIn")}</h1>
-            <p className="text-text-muted mt-1.5">{t("enterPassword")}</p>
-          </div>
-
-          <form onSubmit={handleLogin} className="space-y-5">
-            <div className="space-y-2">
-              <label className="text-sm font-medium text-text-main">{t("password")}</label>
-              <Input
-                type="password"
-                placeholder={t("enterPassword")}
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                required
-                autoFocus
-                className="h-11"
-              />
-              {error && (
-                <p className="text-sm text-red-500 flex items-center gap-1.5 pt-1">
-                  <span className="material-symbols-outlined text-base">error</span>
-                  {error}
-                </p>
-              )}
-              <p className="text-xs text-text-muted/60 pt-0.5">{t("defaultPasswordHint")}</p>
-            </div>
-
-            <Button
-              type="submit"
-              variant="primary"
-              className="w-full h-11 text-sm font-medium"
-              loading={loading}
-            >
-              {t("continue")}
-            </Button>
-          </form>
-
-          <div className="mt-6 pt-6 border-t border-border">
-            <a
-              href="/forgot-password"
-              className="text-sm text-text-muted hover:text-primary transition-colors"
-            >
-              {t("forgotPassword")}
-            </a>
-          </div>
-        </div>
-      </div>
-
-      <div className="hidden lg:flex lg:w-1/2 bg-gradient-to-br from-primary/5 via-primary/3 to-transparent items-center justify-center p-12">
-        <div
-          className={`max-w-md transition-all duration-700 delay-200 ease-out ${mounted ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"}`}
-        >
-          <div className="space-y-8">
-            <div>
-              <h2 className="text-2xl font-bold text-text-main mb-3">{t("unifiedAiApiProxy")}</h2>
-              <p className="text-text-muted leading-relaxed">{t("unifiedAiApiProxyDesc")}</p>
-            </div>
-
-            <div className="space-y-4">
-              {[
-                {
-                  icon: "swap_horiz",
-                  title: t("featureMultiProviderTitle"),
-                  desc: t("featureMultiProviderDesc"),
-                },
-                {
-                  icon: "speed",
-                  title: t("featureLoadBalancingTitle"),
-                  desc: t("featureLoadBalancingDesc"),
-                },
-                {
-                  icon: "analytics",
-                  title: t("featureUsageTrackingTitle"),
-                  desc: t("featureUsageTrackingDesc"),
-                },
-              ].map((item) => (
-                <div
-                  key={item.icon}
-                  className="flex items-start gap-4 p-4 rounded-xl bg-surface/50 border border-border"
-                >
-                  <div className="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center flex-shrink-0">
-                    <span className="material-symbols-outlined text-primary text-[20px]">
-                      {item.icon}
-                    </span>
-                  </div>
-                  <div>
-                    <h3 className="font-medium text-text-main">{item.title}</h3>
-                    <p className="text-sm text-text-muted">{item.desc}</p>
-                  </div>
+        <div className="flex-1 flex items-center justify-center p-6">
+          <div
+            className={`w-full max-w-sm transition-all duration-700 ease-out ${mounted ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"}`}
+          >
+            <div className="mb-10">
+              <div className="flex items-center gap-3 mb-8">
+                <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-primary to-primary-hover flex items-center justify-center">
+                  <span className="material-symbols-outlined text-white text-[20px]">hub</span>
                 </div>
-              ))}
+                <span className="text-xl font-semibold text-text-main tracking-tight">
+                  OmniRoute
+                </span>
+              </div>
+              <h1 className="text-2xl font-bold text-text-main tracking-tight">{t("signIn")}</h1>
+              <p className="text-text-muted mt-1.5">{t("enterPassword")}</p>
+            </div>
+
+            <form onSubmit={handleLogin} className="space-y-5">
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-text-main">{t("password")}</label>
+                <Input
+                  type="password"
+                  placeholder={t("enterPassword")}
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  required
+                  autoFocus
+                  className="h-11"
+                />
+                {error && (
+                  <p className="text-sm text-red-500 flex items-center gap-1.5 pt-1">
+                    <span className="material-symbols-outlined text-base">error</span>
+                    {error}
+                  </p>
+                )}
+                <p className="text-xs text-text-muted/60 pt-0.5">{t("defaultPasswordHint")}</p>
+              </div>
+
+              <Button
+                type="submit"
+                variant="primary"
+                className="w-full h-11 text-sm font-medium"
+                loading={loading}
+              >
+                {t("continue")}
+              </Button>
+            </form>
+
+            <div className="mt-6 pt-6 border-t border-border">
+              <a
+                href="/forgot-password"
+                className="text-sm text-text-muted hover:text-primary transition-colors"
+              >
+                {t("forgotPassword")}
+              </a>
             </div>
           </div>
         </div>
-      </div>
+
+        <div className="hidden lg:flex lg:w-1/2 bg-gradient-to-br from-primary/5 via-primary/3 to-transparent items-center justify-center p-12">
+          <div
+            className={`max-w-md transition-all duration-700 delay-200 ease-out ${mounted ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"}`}
+          >
+            <div className="space-y-8">
+              <div>
+                <h2 className="text-2xl font-bold text-text-main mb-3">{t("unifiedAiApiProxy")}</h2>
+                <p className="text-text-muted leading-relaxed">{t("unifiedAiApiProxyDesc")}</p>
+              </div>
+
+              <div className="space-y-4">
+                {[
+                  {
+                    icon: "swap_horiz",
+                    title: t("featureMultiProviderTitle"),
+                    desc: t("featureMultiProviderDesc"),
+                  },
+                  {
+                    icon: "speed",
+                    title: t("featureLoadBalancingTitle"),
+                    desc: t("featureLoadBalancingDesc"),
+                  },
+                  {
+                    icon: "analytics",
+                    title: t("featureUsageTrackingTitle"),
+                    desc: t("featureUsageTrackingDesc"),
+                  },
+                ].map((item) => (
+                  <div
+                    key={item.icon}
+                    className="flex items-start gap-4 p-4 rounded-xl bg-surface/50 border border-border"
+                  >
+                    <div className="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center flex-shrink-0">
+                      <span className="material-symbols-outlined text-primary text-[20px]">
+                        {item.icon}
+                      </span>
+                    </div>
+                    <div>
+                      <h3 className="font-medium text-text-main">{item.title}</h3>
+                      <p className="text-sm text-text-muted">{item.desc}</p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/shared/constants/publicApiRoutes.ts
+++ b/src/shared/constants/publicApiRoutes.ts
@@ -3,16 +3,14 @@ const PUBLIC_API_ROUTE_PREFIXES = [
   "/api/auth/logout",
   "/api/auth/status",
   "/api/init",
+  "/api/settings/require-login",
   "/api/v1/",
   "/api/cloud/",
   "/api/sync/bundle",
   "/api/oauth/",
 ];
 
-const PUBLIC_READONLY_API_ROUTE_PREFIXES = [
-  "/api/monitoring/health",
-  "/api/settings/require-login",
-];
+const PUBLIC_READONLY_API_ROUTE_PREFIXES = ["/api/monitoring/health"];
 
 const PUBLIC_READONLY_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
 

--- a/src/shared/utils/apiAuth.ts
+++ b/src/shared/utils/apiAuth.ts
@@ -54,6 +54,10 @@ function getRequestPathname(request: RequestLike | Request | null | undefined): 
   }
 }
 
+function isOnboardingBootstrapPath(pathname: string | null): boolean {
+  return pathname === "/dashboard/onboarding";
+}
+
 function getRequestMethod(request: RequestLike | Request | null | undefined): string {
   if (
     request &&
@@ -273,6 +277,10 @@ export async function isAuthRequired(
       if (!request) return false;
 
       const pathname = getRequestPathname(request);
+      if (isOnboardingBootstrapPath(pathname)) {
+        return false;
+      }
+
       if (pathname && isPublicApiRoute(pathname, getRequestMethod(request))) {
         return false;
       }

--- a/tests/unit/authz/pipeline.test.ts
+++ b/tests/unit/authz/pipeline.test.ts
@@ -84,6 +84,40 @@ test("runAuthzPipeline redirects unauthenticated dashboard pages to login", asyn
   assert.ok(response.headers.get("x-request-id"));
 });
 
+test("runAuthzPipeline allows onboarding when login is required but no password exists", async () => {
+  delete process.env.INITIAL_PASSWORD;
+  await settingsDb.updateSettings({
+    requireLogin: true,
+    setupComplete: true,
+    password: "",
+  });
+
+  const response = await pipeline.runAuthzPipeline(
+    request("https://example.com/dashboard/onboarding"),
+    { enforce: true }
+  );
+
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get("x-omniroute-route-class"), "MANAGEMENT");
+});
+
+test("runAuthzPipeline allows first password writes when login is required but no password exists", async () => {
+  delete process.env.INITIAL_PASSWORD;
+  await settingsDb.updateSettings({
+    requireLogin: true,
+    setupComplete: true,
+    password: "",
+  });
+
+  const response = await pipeline.runAuthzPipeline(
+    request("https://example.com/api/settings/require-login", { method: "POST" }),
+    { enforce: true }
+  );
+
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get("x-omniroute-route-class"), "PUBLIC");
+});
+
 test("runAuthzPipeline keeps management API rejections as JSON", async () => {
   await forceAuthRequired();
 

--- a/tests/unit/login-bootstrap-route.test.ts
+++ b/tests/unit/login-bootstrap-route.test.ts
@@ -184,6 +184,30 @@ test("login bootstrap route POST rejects unauthenticated writes after setup is c
   assert.equal(settings.requireLogin, true);
 });
 
+test("login bootstrap route POST allows first password creation after setup completed without a password", async () => {
+  await settingsDb.updateSettings({
+    requireLogin: true,
+    password: "",
+    setupComplete: true,
+  });
+
+  const request = new Request("http://localhost/api/settings/require-login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ requireLogin: true, password: "first-secret" }),
+  });
+
+  const response = await route.POST(request);
+  const body = (await response.json()) as any;
+  const settings = await settingsDb.getSettings();
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(body, { success: true });
+  assert.equal(settings.requireLogin, true);
+  assert.ok(settings.password);
+  assert.equal(await bcrypt.compare("first-secret", settings.password), true);
+});
+
 test("public login bootstrap route POST returns 500 when hashing fails", async () => {
   bcrypt.hash = async () => {
     throw new Error("hash failed");

--- a/tests/unit/public-api-routes.test.ts
+++ b/tests/unit/public-api-routes.test.ts
@@ -9,7 +9,7 @@ test("isPublicApiRoute allows public management prefixes", () => {
   assert.equal(isPublicApiRoute("/api/oauth/cursor/callback"), true);
 });
 
-test("isPublicApiRoute allows readonly bootstrap route only for safe methods", () => {
+test("isPublicApiRoute allows readonly health and require-login bootstrap routes", () => {
   assert.equal(isPublicApiRoute("/api/monitoring/health", "GET"), true);
   assert.equal(isPublicApiRoute("/api/monitoring/health", "HEAD"), true);
   assert.equal(isPublicApiRoute("/api/monitoring/health", "OPTIONS"), true);
@@ -18,7 +18,7 @@ test("isPublicApiRoute allows readonly bootstrap route only for safe methods", (
   assert.equal(isPublicApiRoute("/api/settings/require-login", "GET"), true);
   assert.equal(isPublicApiRoute("/api/settings/require-login", "HEAD"), true);
   assert.equal(isPublicApiRoute("/api/settings/require-login", "OPTIONS"), true);
-  assert.equal(isPublicApiRoute("/api/settings/require-login", "POST"), false);
+  assert.equal(isPublicApiRoute("/api/settings/require-login", "POST"), true);
 });
 
 test("isPublicApiRoute rejects non-public management routes", () => {


### PR DESCRIPTION
 ## Summary
 
 - Restores the first-run onboarding flow when login is required but no management password has been configured yet.
 - Prevents fresh installs from getting stuck on the onboarding entry/login screen when `setupComplete` is already true but the instance still has no 
password.
 
 ## Related Issues
 
 - Closes #2036
 - Related to #2001
 
 ## Validation
 
 - [x] `npm run lint`
 - [ ] `npm run test:unit` — currently blocked by an unrelated existing failure in `tests/unit/image-generation-route.test.ts`
 - [x] `npm run test:coverage`
 - [x] Coverage is still `>= 60%` for statements, lines, functions, and branches
 - [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below
 
 ## Tests Added Or Updated
 
 - `tests/unit/authz/pipeline.test.ts`
 - `tests/unit/login-bootstrap-route.test.ts`
 - `tests/unit/public-api-routes.test.ts`
 
 ## Coverage Notes
 
 - This PR changes `src/` auth/bootstrap flow behavior.
 - Coverage for the change is provided by:
   - `tests/unit/authz/pipeline.test.ts` for onboarding/auth gating
   - `tests/unit/login-bootstrap-route.test.ts` for first password creation
   - `tests/unit/public-api-routes.test.ts` for public bootstrap route access
 - `npm run test:coverage` passed with:
   - Statements: `83.56%`
   - Branches: `75.23%`
   - Functions: `85.15%`
   - Lines: `83.56%`
 
 ## Reviewer Notes
 
 - Root cause was a bad state combination in the bootstrap flow: `requireLogin = true`, `hasPassword = false`, and `setupComplete = true`.
 - In that state, the UI still pointed users toward onboarding/password setup, but auth checks could block `/dashboard/onboarding` and the first 
unauthenticated password write.
 - This PR reopens the intended bootstrap path until a password is actually configured.
 - No migrations or feature flags are involved.
 - Local `pre-push` is currently blocked by an unrelated baseline unit-test failure in `tests/unit/image-generation-route.test.ts`.