### PR TITLE
Fix bare GPT-5.5 routing for Codex-only installations

### DIFF
--- a/open-sse/config/providerRegistry.ts
+++ b/open-sse/config/providerRegistry.ts
@@ -407,6 +407,7 @@ export const REGISTRY: Record<string, RegistryEntry> = {
       tokenUrl: "https://auth.openai.com/oauth/token",
     },
     models: [
+      { id: "gpt-5.5", name: "GPT 5.5", ...GPT_5_5_CODEX_CAPABILITIES },
       { id: "gpt-5.5-xhigh", name: "GPT 5.5 (xHigh)", ...GPT_5_5_CODEX_CAPABILITIES },
       { id: "gpt-5.5-high", name: "GPT 5.5 (High)", ...GPT_5_5_CODEX_CAPABILITIES },
       { id: "gpt-5.5-medium", name: "GPT 5.5 (Medium)", ...GPT_5_5_CODEX_CAPABILITIES },

--- a/open-sse/services/model.ts
+++ b/open-sse/services/model.ts
@@ -74,7 +74,14 @@ for (const [aliasOrId, models] of Object.entries(PROVIDER_MODELS)) {
 }
 const KNOWN_MODEL_IDS = new Set(MODEL_TO_PROVIDERS.keys());
 const CODEX_PREFERRED_UNPREFIXED_MODELS = new Set(["gpt-5.5"]);
+const CODEX_PREFERRED_UNPREFIXED_MODEL_ALIASES = new Map([["gpt-5.5", "gpt-5.5-medium"]]);
 export const CODEX_NATIVE_UNPREFIXED_MODELS = new Set(["codex-auto-review"]);
+
+interface ProviderConnectionLike {
+  provider?: unknown;
+  isActive?: unknown;
+  is_active?: unknown;
+}
 
 /**
  * Resolve provider alias to provider ID
@@ -125,6 +132,68 @@ function hasKnownProviderModel(providerOrAlias, modelId) {
 
   const canonicalModel = resolveProviderModelAlias(providerId, modelId);
   return canonicalModel !== modelId && models.some((entry) => entry?.id === canonicalModel);
+}
+
+function hasCodexPreferredUnprefixedModel(modelId) {
+  const canonicalModel = CODEX_PREFERRED_UNPREFIXED_MODEL_ALIASES.get(modelId);
+  if (!canonicalModel) return false;
+
+  const providerAlias = PROVIDER_ID_TO_ALIAS.codex || "codex";
+  const models = PROVIDER_MODELS[providerAlias] || PROVIDER_MODELS.codex || [];
+  return models.some((entry) => entry?.id === canonicalModel);
+}
+
+function resolveInferredProviderModel(provider, modelId) {
+  const codexPreferredModel = CODEX_PREFERRED_UNPREFIXED_MODEL_ALIASES.get(modelId);
+  if (provider === "codex" && codexPreferredModel) {
+    return codexPreferredModel;
+  }
+  return resolveProviderModelAlias(provider, modelId);
+}
+
+function getInferredProvidersForModel(modelId) {
+  const providers = [...(MODEL_TO_PROVIDERS.get(modelId) || [])];
+
+  if (
+    CODEX_PREFERRED_UNPREFIXED_MODELS.has(modelId) &&
+    hasCodexPreferredUnprefixedModel(modelId) &&
+    !providers.includes("codex")
+  ) {
+    providers.push("codex");
+  }
+
+  return providers;
+}
+
+function isProviderConnectionActive(connection: ProviderConnectionLike) {
+  if (connection.isActive !== undefined) {
+    return connection.isActive !== false && connection.isActive !== 0;
+  }
+  if (connection.is_active !== undefined) {
+    return connection.is_active !== false && connection.is_active !== 0;
+  }
+  return false;
+}
+
+function getProviderIdFromConnection(connection: unknown) {
+  if (!connection || typeof connection !== "object") return null;
+  const record = connection as ProviderConnectionLike;
+  if (typeof record.provider !== "string" || !record.provider) return null;
+  if (!isProviderConnectionActive(record)) return null;
+  return resolveProviderAlias(record.provider);
+}
+
+async function getActiveProviderSet() {
+  try {
+    const { getProviderConnections } = await import("@/lib/localDb");
+    const conns = (await getProviderConnections()) as unknown[];
+    const providers = conns
+      .map(getProviderIdFromConnection)
+      .filter((provider): provider is string => Boolean(provider));
+    return new Set(providers);
+  } catch {
+    return null;
+  }
 }
 
 function shouldTreatAsExactModelId(modelStr) {
@@ -276,7 +345,7 @@ function parseAliasTarget(target) {
 }
 
 async function resolveModelByProviderInference(modelId, extendedContext) {
-  const providers = MODEL_TO_PROVIDERS.get(modelId) || [];
+  const providers = getInferredProvidersForModel(modelId);
 
   const nonOpenAIProviders = providers.filter((p) => p !== "openai");
 
@@ -288,22 +357,13 @@ async function resolveModelByProviderInference(modelId, extendedContext) {
     };
   }
 
-  let activeProviders: Set<string> | null = null;
-  try {
-    const { getProviderConnections } = await import("@/lib/localDb");
-    const conns = await getProviderConnections();
-    activeProviders = new Set(conns.filter((c: any) => c.is_active).map((c: any) => c.provider));
-  } catch {
-    // DB unavailable
-  }
+  const activeProviders = await getActiveProviderSet();
 
-  const activeCandidates = activeProviders
-    ? providers.filter((p) => activeProviders!.has(p))
-    : [];
+  const activeCandidates = activeProviders ? providers.filter((p) => activeProviders.has(p)) : [];
 
   if (activeCandidates.length === 1) {
     const provider = activeCandidates[0];
-    const canonicalModel = resolveProviderModelAlias(provider, modelId);
+    const canonicalModel = resolveInferredProviderModel(provider, modelId);
     return { provider, model: canonicalModel, extendedContext };
   }
 
@@ -314,7 +374,7 @@ async function resolveModelByProviderInference(modelId, extendedContext) {
   ) {
     return {
       provider: "codex",
-      model: modelId,
+      model: resolveInferredProviderModel("codex", modelId),
       extendedContext,
     };
   }
@@ -329,14 +389,14 @@ async function resolveModelByProviderInference(modelId, extendedContext) {
   }
 
   const eligibleProviders = activeProviders
-    ? nonOpenAIProviders.filter((p) => activeProviders!.has(p))
+    ? nonOpenAIProviders.filter((p) => activeProviders.has(p))
     : nonOpenAIProviders;
 
   const candidatesToUse = eligibleProviders.length > 0 ? eligibleProviders : nonOpenAIProviders;
 
   if (candidatesToUse.length === 1) {
     const provider = candidatesToUse[0];
-    const canonicalModel = resolveProviderModelAlias(provider, modelId);
+    const canonicalModel = resolveInferredProviderModel(provider, modelId);
     return { provider, model: canonicalModel, extendedContext };
   }
 

--- a/open-sse/services/model.ts
+++ b/open-sse/services/model.ts
@@ -288,7 +288,30 @@ async function resolveModelByProviderInference(modelId, extendedContext) {
     };
   }
 
-  if (providers.includes("codex") && CODEX_PREFERRED_UNPREFIXED_MODELS.has(modelId)) {
+  let activeProviders: Set<string> | null = null;
+  try {
+    const { getProviderConnections } = await import("@/lib/localDb");
+    const conns = await getProviderConnections();
+    activeProviders = new Set(conns.filter((c: any) => c.is_active).map((c: any) => c.provider));
+  } catch {
+    // DB unavailable
+  }
+
+  const activeCandidates = activeProviders
+    ? providers.filter((p) => activeProviders!.has(p))
+    : [];
+
+  if (activeCandidates.length === 1) {
+    const provider = activeCandidates[0];
+    const canonicalModel = resolveProviderModelAlias(provider, modelId);
+    return { provider, model: canonicalModel, extendedContext };
+  }
+
+  if (
+    activeProviders?.has("codex") &&
+    providers.includes("codex") &&
+    CODEX_PREFERRED_UNPREFIXED_MODELS.has(modelId)
+  ) {
     return {
       provider: "codex",
       model: modelId,
@@ -303,15 +326,6 @@ async function resolveModelByProviderInference(modelId, extendedContext) {
       model: modelId,
       extendedContext,
     };
-  }
-
-  let activeProviders: Set<string> | null = null;
-  try {
-    const { getProviderConnections } = await import("@/lib/localDb");
-    const conns = await getProviderConnections();
-    activeProviders = new Set(conns.filter((c: any) => c.is_active).map((c: any) => c.provider));
-  } catch {
-    // DB unavailable
   }
 
   const eligibleProviders = activeProviders

--- a/tests/unit/chat-helpers.test.ts
+++ b/tests/unit/chat-helpers.test.ts
@@ -113,6 +113,35 @@ test("resolveModelOrError keeps non-Codex gpt-5.5 Responses requests on OpenAI",
   assert.equal(result.model, "gpt-5.5");
 });
 
+test("resolveModelOrError routes bare gpt-5.5 to Codex when Codex is the only active account", async () => {
+  await seedConnection("codex");
+
+  const result = await resolveModelOrError(
+    "gpt-5.5",
+    { model: "gpt-5.5", input: "hello" },
+    "/v1/responses",
+    { "user-agent": "OpenAI/Node" }
+  );
+
+  assert.equal(result.provider, "codex");
+  assert.equal(result.model, "gpt-5.5");
+  assert.equal(result.targetFormat, "openai-responses");
+});
+
+test("resolveModelOrError keeps bare gpt-5.5 on OpenAI when OpenAI is the only active account", async () => {
+  await seedConnection("openai");
+
+  const result = await resolveModelOrError(
+    "gpt-5.5",
+    { model: "gpt-5.5", input: "hello" },
+    "/v1/responses",
+    { "user-agent": "OpenAI/Node" }
+  );
+
+  assert.equal(result.provider, "openai");
+  assert.equal(result.model, "gpt-5.5");
+});
+
 test("checkPipelineGates blocks providers with an open circuit breaker", async () => {
   const breaker = getCircuitBreaker("openai");
   breaker.state = STATE.OPEN;

--- a/tests/unit/chat-helpers.test.ts
+++ b/tests/unit/chat-helpers.test.ts
@@ -113,7 +113,7 @@ test("resolveModelOrError keeps non-Codex gpt-5.5 Responses requests on OpenAI",
   assert.equal(result.model, "gpt-5.5");
 });
 
-test("resolveModelOrError routes bare gpt-5.5 to Codex when Codex is the only active account", async () => {
+test("resolveModelOrError routes bare gpt-5.5 to Codex medium when Codex is the only active account", async () => {
   await seedConnection("codex");
 
   const result = await resolveModelOrError(
@@ -124,7 +124,7 @@ test("resolveModelOrError routes bare gpt-5.5 to Codex when Codex is the only ac
   );
 
   assert.equal(result.provider, "codex");
-  assert.equal(result.model, "gpt-5.5");
+  assert.equal(result.model, "gpt-5.5-medium");
   assert.equal(result.targetFormat, "openai-responses");
 });
 


### PR DESCRIPTION
## Summary
- add the base `gpt-5.5` model to the Codex provider registry
- prefer the single active provider candidate when resolving bare model names
- cover Codex-only and OpenAI-only `gpt-5.5` routing behavior

## Why
A Codex-only installation can receive OpenAI-compatible `/v1/responses` requests with the bare model name `gpt-5.5`. Since the Codex registry only listed effort-specific variants, the router could fall back to `openai/gpt-5.5` and fail with `No credentials for provider: openai` even though Codex OAuth was configured.

## Tests
- `git diff --check`
- `node --import tsx/esm --test tests/unit/plan3-p0.test.ts`

## Notes
- `tests/unit/chat-helpers.test.ts` was attempted locally, but the local environment could not complete it because `better-sqlite3` native bindings were missing after an `npm install --ignore-scripts` dependency setup.
