### PR TITLE
fix: dynamic tool limit detection to prevent 400 errors from upstream providers

### DIFF
--- a/open-sse/config/constants.ts
+++ b/open-sse/config/constants.ts
@@ -184,3 +184,6 @@ export const DEFAULT_API_LIMITS = {
 
 // Skip patterns - requests containing these texts will bypass provider
 export const SKIP_PATTERNS = ["Please write a 5-10 word title for the following conversation:"];
+
+// Tool limit to prevent 400 errors from upstream providers (e.g., OpenAI API limit)
+export const MAX_TOOLS_LIMIT = 128;

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -30,6 +30,7 @@ import {
 import {
   COOLDOWN_MS,
   HTTP_STATUS,
+  MAX_TOOLS_LIMIT,
   PROVIDER_MAX_TOKENS,
   STREAM_IDLE_TIMEOUT_MS,
 } from "../config/constants.ts";
@@ -83,6 +84,12 @@ import { getCacheMetrics } from "@/lib/db/settings.ts";
 import { getCachedSettings } from "@/lib/db/readCache";
 import { cacheReasoningFromAssistantMessage } from "../services/reasoningCache.ts";
 import { sanitizeOpenAITool } from "../services/toolSchemaSanitizer.ts";
+import {
+  getDetectedToolLimit,
+  setDetectedToolLimit,
+  parseToolLimitFromError,
+  shouldDetectLimit,
+} from "../services/toolLimitDetector.ts";
 
 import {
   parseCodexQuotaHeaders,
@@ -1537,6 +1544,18 @@ export async function handleChatCore({
     // sanitizeOpenAITool is safe to call on any input — it no-ops non-function
     // tools (e.g. Responses API built-ins) and non-object values.
     body.tools = body.tools.map((tool) => sanitizeOpenAITool(tool) as (typeof body.tools)[number]);
+
+    // Truncate tools to prevent 400 errors from upstream providers
+    // (e.g., OpenAI API returns: "'tools': maximum number of items is 128")
+    // Use dynamically detected limit per provider, fallback to MAX_TOOLS_LIMIT
+    const effectiveToolLimit = getDetectedToolLimit(provider);
+    if (body.tools.length > effectiveToolLimit) {
+      body.tools = body.tools.slice(0, effectiveToolLimit);
+      log?.debug?.(
+        "TOOLS",
+        `Truncated ${body.tools.length} tools to ${effectiveToolLimit} limit for ${provider}`
+      );
+    }
   }
 
   const memoryOwnerId = resolveMemoryOwnerId(apiKeyInfo as Record<string, unknown> | null);
@@ -3135,6 +3154,18 @@ export async function handleChatCore({
       message = details.message;
       retryAfterMs = details.retryAfterMs;
       upstreamErrorBody = details.responseBody;
+    }
+
+    // Dynamically detect and cache tool limits from 400 errors
+    if (shouldDetectLimit(message, statusCode)) {
+      const detectedLimit = parseToolLimitFromError(message, statusCode);
+      if (detectedLimit !== null) {
+        const currentLimit = getDetectedToolLimit(provider);
+        if (detectedLimit < currentLimit) {
+          setDetectedToolLimit(provider, detectedLimit);
+          log?.debug?.("TOOLS", `Detected new tool limit for ${provider}: ${detectedLimit}`);
+        }
+      }
     }
 
     // T06/T10/T36: classify provider errors and persist terminal account states.

--- a/open-sse/services/toolLimitDetector.ts
+++ b/open-sse/services/toolLimitDetector.ts
@@ -1,0 +1,54 @@
+import { MAX_TOOLS_LIMIT } from "../config/constants.ts";
+
+interface ToolLimitCache {
+  limit: number;
+  timestamp: number;
+}
+
+const TOOL_LIMIT_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+const toolLimitCache = new Map<string, ToolLimitCache>();
+
+export function getDetectedToolLimit(provider: string): number {
+  const cached = toolLimitCache.get(provider);
+  if (cached && Date.now() - cached.timestamp < TOOL_LIMIT_CACHE_TTL_MS) {
+    return cached.limit;
+  }
+  return MAX_TOOLS_LIMIT;
+}
+
+export function setDetectedToolLimit(provider: string, limit: number): void {
+  toolLimitCache.set(provider, { limit, timestamp: Date.now() });
+}
+
+export function parseToolLimitFromError(errorMessage: string, statusCode: number): number | null {
+  if (statusCode !== 400) return null;
+
+  const patterns = [
+    /['"]tools['"]:\s*maximum\s+number\s+of\s+items\s+is\s+(\d+)/i,
+    /maximum\s+number\s+of\s+tools\s+(?:is\s+)?(\d+)/i,
+    /tools.*limit.*?(\d+)/i,
+    /too\s+many\s+tools.*?(\d+)/i,
+  ];
+
+  for (const pattern of patterns) {
+    const match = errorMessage.match(pattern);
+    if (match) {
+      const limit = parseInt(match[1], 10);
+      if (limit > 0 && limit <= 10000) {
+        return limit;
+      }
+    }
+  }
+
+  return null;
+}
+
+export function shouldDetectLimit(errorMessage: string, statusCode: number): boolean {
+  if (statusCode !== 400) return false;
+  const lowerMsg = errorMessage.toLowerCase();
+  return (lowerMsg.includes("tool") || lowerMsg.includes("tools")) && lowerMsg.includes("maximum");
+}
+
+export function clearToolLimitCache(): void {
+  toolLimitCache.clear();
+}

--- a/tests/unit/tool-limit-detector.test.ts
+++ b/tests/unit/tool-limit-detector.test.ts
@@ -1,0 +1,77 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const {
+  getDetectedToolLimit,
+  setDetectedToolLimit,
+  parseToolLimitFromError,
+  shouldDetectLimit,
+  clearToolLimitCache,
+} = await import("../../open-sse/services/toolLimitDetector.ts");
+
+test("getDetectedToolLimit returns default 128 when no cache", () => {
+  clearToolLimitCache();
+  assert.equal(getDetectedToolLimit("openai"), 128);
+});
+
+test("setDetectedToolLimit stores limit in cache", () => {
+  clearToolLimitCache();
+  setDetectedToolLimit("custom-provider", 64);
+  assert.equal(getDetectedToolLimit("custom-provider"), 64);
+});
+
+test("setDetectedToolLimit updates existing provider", () => {
+  clearToolLimitCache();
+  setDetectedToolLimit("test-provider", 100);
+  setDetectedToolLimit("test-provider", 50);
+  assert.equal(getDetectedToolLimit("test-provider"), 50);
+});
+
+test("parseToolLimitFromError extracts limit from OpenAI error", () => {
+  const result = parseToolLimitFromError("{'tools': maximum number of items is 128}", 400);
+  assert.equal(result, 128);
+});
+
+test("parseToolLimitFromError extracts limit from alternate format", () => {
+  const result = parseToolLimitFromError("Maximum number of tools is 64", 400);
+  assert.equal(result, 64);
+});
+
+test("parseToolLimitFromError extracts limit from 'too many tools' format", () => {
+  const result = parseToolLimitFromError("Too many tools. Maximum allowed is 96.", 400);
+  assert.equal(result, 96);
+});
+
+test("parseToolLimitFromError returns null for non-400 status", () => {
+  const result = parseToolLimitFromError("Some error", 500);
+  assert.equal(result, null);
+});
+
+test("parseToolLimitFromError returns null when no match", () => {
+  const result = parseToolLimitFromError("Some unrelated error", 400);
+  assert.equal(result, null);
+});
+
+test("shouldDetectLimit returns true for tool-related 400 errors", () => {
+  assert.equal(shouldDetectLimit("'tools': maximum number of items is 128", 400), true);
+  assert.equal(shouldDetectLimit("Maximum number of tools is 64", 400), true);
+});
+
+test("shouldDetectLimit returns false for non-400 status", () => {
+  assert.equal(shouldDetectLimit("Error message", 500), false);
+});
+
+test("shouldDetectLimit returns false for non-tool errors", () => {
+  assert.equal(shouldDetectLimit("Invalid API key", 400), false);
+});
+
+test("getDetectedToolLimit falls back to default for unknown provider", () => {
+  clearToolLimitCache();
+  assert.equal(getDetectedToolLimit("unknown-provider"), 128);
+});
+
+test("cache respects TTL - returns cached value within TTL", () => {
+  clearToolLimitCache();
+  setDetectedToolLimit("temp-provider", 32);
+  assert.equal(getDetectedToolLimit("temp-provider"), 32);
+});

--- a/tests/unit/tool-request-sanitization.test.ts
+++ b/tests/unit/tool-request-sanitization.test.ts
@@ -190,3 +190,19 @@ test("translateRequest injects reasoning_content for DeepSeek assistant tool cal
 
   assert.equal(translated.messages[1].reasoning_content, "");
 });
+
+const { MAX_TOOLS_LIMIT } = await import("../../open-sse/config/constants.ts");
+test("MAX_TOOLS_LIMIT is set to 128 to match upstream provider limits", () => {
+  assert.equal(MAX_TOOLS_LIMIT, 128);
+});
+
+test("tool limit truncation: truncates array to 128 items", () => {
+  const tools = Array.from({ length: 200 }, (_, i) => ({
+    type: "function",
+    function: { name: `tool_${i}`, description: `tool ${i}`, parameters: { type: "object" } },
+  }));
+  const truncated = tools.length > MAX_TOOLS_LIMIT ? tools.slice(0, MAX_TOOLS_LIMIT) : tools;
+  assert.equal(truncated.length, 128);
+  assert.equal(truncated[0].function.name, "tool_0");
+  assert.equal(truncated[127].function.name, "tool_127");
+});


### PR DESCRIPTION
## Problem

Upstream LLM providers (e.g., OpenAI API) have a 128 tool limit per request. When requests exceed this limit, providers return 400 errors like:

[400]: 'tools' : maximum number of items is 128

This is common in scenarios with many MCP tools or skill-injected tools.

## Solution

### 1. Static Fallback Limit
- Added MAX_TOOLS_LIMIT = 128 constant in open-sse/config/constants.ts
- Serves as the default fallback for all providers

### 2. Dynamic Tool Limit Detector
Created open-sse/services/toolLimitDetector.ts with:
- getDetectedToolLimit(provider): Returns cached limit or default (128)
- setDetectedToolLimit(provider, limit): Caches learned limit per provider
- parseToolLimitFromError(): Extracts limit from error messages using regex patterns
- shouldDetectLimit(): Checks if error indicates tool limit issue
- 24-hour TTL on cached limits to adapt to provider changes

### 3. Integration in chatCore.ts
Proactive truncation (before sending request):
const effectiveToolLimit = getDetectedToolLimit(provider);
if (body.tools.length > effectiveToolLimit) {
  body.tools = body.tools.slice(0, effectiveToolLimit);
}

Error-driven detection (when 400 error occurs):
if (shouldDetectLimit(message, statusCode)) {
  const detectedLimit = parseToolLimitFromError(message, statusCode);
  if (detectedLimit !== null) {
    setDetectedToolLimit(provider, detectedLimit);
  }
}

## Test Coverage
- tests/unit/tool-limit-detector.test.ts: 13 tests for detector logic
- tests/unit/tool-request-sanitization.test.ts: 2 tests for constant

All tests passing.

## Files Changed

open-sse/config/constants.ts - Modified (+3 lines)
open-sse/services/toolLimitDetector.ts - New (+57 lines)
open-sse/handlers/chatCore.ts - Modified (+28 lines)
tests/unit/tool-limit-detector.test.ts - New (+75 lines)
tests/unit/tool-request-sanitization.test.ts - Modified (+16 lines)

Key Features:
- Per-provider limit caching (different providers can have different limits)
- Auto-detection from upstream error responses
- 24-hour TTL on learned limits (adapts to provider changes)
- Falls back to static 128 limit if no error detected
- Debug logging for visibility into truncation/detection events