### PR TITLE
fix(antigravity): sanitize Claude Cloud Code payloads

### DIFF
--- a/open-sse/executors/antigravity.ts
+++ b/open-sse/executors/antigravity.ts
@@ -330,16 +330,12 @@ function asRecord(value: unknown): Record<string, unknown> | null {
 }
 
 function sanitizeAntigravityGeminiRequest(
-  request: Record<string, unknown>,
-  fallbackContents: unknown[],
-  credentials: Record<string, unknown> | null | undefined
+  request: Record<string, unknown>
 ): Record<string, unknown> {
   const clean: Record<string, unknown> = {};
 
   if (Array.isArray(request.contents)) {
     clean.contents = request.contents;
-  } else if (fallbackContents.length > 0) {
-    clean.contents = fallbackContents;
   }
 
   if (asRecord(request.systemInstruction)) {
@@ -358,7 +354,9 @@ function sanitizeAntigravityGeminiRequest(
     clean.toolConfig = request.toolConfig;
   }
 
-  clean.sessionId = getAntigravitySessionId(credentials, request.sessionId);
+  if (typeof request.sessionId === "string") {
+    clean.sessionId = request.sessionId;
+  }
 
   return clean;
 }
@@ -477,7 +475,7 @@ export class AntigravityExecutor extends BaseExecutor {
     };
 
     const transformedRequest = isClaude
-      ? sanitizeAntigravityGeminiRequest(rawTransformedRequest, contents, credentials)
+      ? sanitizeAntigravityGeminiRequest(rawTransformedRequest)
       : rawTransformedRequest;
 
     // Obfuscate sensitive client names in user content (e.g. "OpenCode", "Cursor")

--- a/open-sse/executors/antigravity.ts
+++ b/open-sse/executors/antigravity.ts
@@ -27,6 +27,7 @@ import {
   shouldStripCloudCodeThinking,
   stripCloudCodeThinkingConfig,
 } from "../services/cloudCodeThinking.ts";
+import { buildGeminiTools } from "../translator/helpers/geminiToolsSanitizer.ts";
 import {
   deriveAntigravityMachineId,
   generateAntigravityRequestId,
@@ -322,6 +323,46 @@ function applyAntigravityGenerationDefaults(request: Record<string, unknown>): v
   request.generationConfig = generationConfig;
 }
 
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function sanitizeAntigravityGeminiRequest(
+  request: Record<string, unknown>,
+  fallbackContents: unknown[],
+  credentials: Record<string, unknown> | null | undefined
+): Record<string, unknown> {
+  const clean: Record<string, unknown> = {};
+
+  if (Array.isArray(request.contents)) {
+    clean.contents = request.contents;
+  } else if (fallbackContents.length > 0) {
+    clean.contents = fallbackContents;
+  }
+
+  if (asRecord(request.systemInstruction)) {
+    clean.systemInstruction = request.systemInstruction;
+  }
+
+  clean.generationConfig = asRecord(request.generationConfig)
+    ? { ...(request.generationConfig as Record<string, unknown>) }
+    : {};
+
+  const geminiTools = buildGeminiTools(request.tools);
+  if (geminiTools) {
+    clean.tools = geminiTools;
+    clean.toolConfig = { functionCallingConfig: { mode: "VALIDATED" } };
+  } else if (asRecord(request.toolConfig)) {
+    clean.toolConfig = request.toolConfig;
+  }
+
+  clean.sessionId = getAntigravitySessionId(credentials, request.sessionId);
+
+  return clean;
+}
+
 export class AntigravityExecutor extends BaseExecutor {
   constructor() {
     super("antigravity", PROVIDERS.antigravity);
@@ -424,7 +465,7 @@ export class AntigravityExecutor extends BaseExecutor {
       }
     }
 
-    const transformedRequest = {
+    const rawTransformedRequest = {
       ...normalizedBody.request,
       ...(contents.length > 0 && { contents }),
       sessionId: getAntigravitySessionId(credentials, normalizedBody.request?.sessionId),
@@ -435,13 +476,9 @@ export class AntigravityExecutor extends BaseExecutor {
           : normalizedBody.request?.toolConfig,
     };
 
-    if (isClaude) {
-      delete transformedRequest.messages;
-      delete transformedRequest.system;
-      delete transformedRequest.max_tokens;
-      delete transformedRequest.stream;
-      delete transformedRequest.temperature;
-    }
+    const transformedRequest = isClaude
+      ? sanitizeAntigravityGeminiRequest(rawTransformedRequest, contents, credentials)
+      : rawTransformedRequest;
 
     // Obfuscate sensitive client names in user content (e.g. "OpenCode", "Cursor")
     const requestContents = transformedRequest.contents;


### PR DESCRIPTION
## Summary
- Sanitizes Antigravity Claude requests before they are sent to the Gemini/Cloud Code `streamGenerateContent` endpoint.
- Preserves the already-translated Gemini fields (`contents`, `systemInstruction`, `generationConfig`, `tools`, `toolConfig`, `sessionId`) while dropping invalid Anthropic/OpenAI passthrough fields.
- Rebuilds Claude tools as Gemini `functionDeclarations` so `input_schema`/`cache_control` do not leak into the Cloud Code request.

## Why this follow-up is needed
PRs #2055 and #2063 moved Antigravity Claude-branded models through the Cloud Code/Gemini request path. That direction is fine, but it exposed an existing passthrough gap: Claude/OpenAI-shaped fields such as `messages`, `max_tokens`, `stream`, `system`, `tool_choice`, and `tools[].input_schema` could remain inside `request` and trigger Google payload validation errors.

This follow-up keeps the new 3.8.0 Antigravity transport/identity work, but makes the Claude path strict about the Cloud Code schema. It should also address the invalid-argument failure reported in #2072 / #1514 for this payload-shape case.

## Scope
- Antigravity Claude request shaping only.
- Does not change Gemini CLI.
- Does not change Antigravity Gemini request generation.
- Does not change headers or OAuth behavior.

## Validation
- Loaded locally on top of `origin/release/v3.8.0`.
- Verified through the UI/runtime path with Antigravity Claude Sonnet and Opus requests.
- Ran a focused internal smoke for both `antigravity/claude-sonnet-4-6` and `antigravity/claude-opus-4-6-thinking` confirming outgoing request keys are limited to Cloud Code/Gemini fields and tools are emitted as `functionDeclarations`.
- Confirmed `x-omniroute-*` headers are not emitted.
- Ran `git diff --check`.