### PR TITLE
fix(kiro): normalize tool-use payloads

### DIFF
--- a/open-sse/translator/request/openai-to-kiro.ts
+++ b/open-sse/translator/request/openai-to-kiro.ts
@@ -27,6 +27,21 @@ function parseToolInput(value: unknown) {
   }
 }
 
+function normalizeKiroToolSchema(schema: unknown) {
+  if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
+    return { type: "object", properties: {}, required: [] };
+  }
+
+  return {
+    type: "object",
+    properties: {},
+    ...(schema as Record<string, unknown>),
+    required: Array.isArray((schema as { required?: unknown }).required)
+      ? (schema as { required: unknown[] }).required
+      : [],
+  };
+}
+
 /**
  * Convert OpenAI messages to Kiro format
  * Rules: system/tool/user -> user role, merge consecutive same roles
@@ -83,7 +98,9 @@ function convertMessages(messages, tools, model) {
               name,
               description,
               inputSchema: {
-                json: t.function?.parameters || t.parameters || t.input_schema || {},
+                json: normalizeKiroToolSchema(
+                  t.function?.parameters || t.parameters || t.input_schema || {}
+                ),
               },
             },
           };
@@ -144,7 +161,7 @@ function convertMessages(messages, tools, model) {
 
             pendingToolResults.push({
               toolUseId: block.tool_use_id,
-              status: "SUCCESS",
+              status: "success",
               content: [{ text: text }],
             });
           });
@@ -156,7 +173,7 @@ function convertMessages(messages, tools, model) {
         const toolContent = typeof msg.content === "string" ? msg.content : "";
         pendingToolResults.push({
           toolUseId: msg.tool_call_id,
-          status: "SUCCESS",
+          status: "success",
           content: [{ text: toolContent }],
         });
       } else if (content) {
@@ -226,10 +243,13 @@ function convertMessages(messages, tools, model) {
     flushPending();
   }
 
-  // If last message in history is userInputMessage, use it as currentMessage
+  // Kiro requires currentMessage to be a user turn. If the request ends with a
+  // user turn, move that final turn into currentMessage. If it ends with an
+  // assistant/tool turn, keep chronological history intact and ask Kiro to
+  // continue instead of reordering prior turns.
   if (history.length > 0 && history[history.length - 1].userInputMessage) {
     currentMessage = history.pop();
-  } else if (!currentMessage) {
+  } else {
     currentMessage = {
       userInputMessage: {
         content: "Continue",

--- a/tests/unit/translator-openai-to-kiro.test.ts
+++ b/tests/unit/translator-openai-to-kiro.test.ts
@@ -99,15 +99,20 @@ test("OpenAI -> Kiro preserves prior history, tool uses and accumulated tool res
   assert.equal((context.toolResults as any).length, 2);
   assert.deepEqual(context.toolResults[0], {
     toolUseId: "call_1",
-    status: "SUCCESS",
+    status: "success",
     content: [{ text: "file contents" }],
   });
   assert.deepEqual(context.toolResults[1], {
     toolUseId: "call_1",
-    status: "SUCCESS",
+    status: "success",
     content: [{ text: "done" }],
   });
   assert.equal(context.tools[0].toolSpecification.name, "read_file");
+  assert.deepEqual(context.tools[0].toolSpecification.inputSchema.json, {
+    type: "object",
+    properties: { path: { type: "string" } },
+    required: [],
+  });
 });
 
 test("OpenAI -> Kiro maps invalid or empty assistant tool call arguments to empty input", () => {
@@ -192,6 +197,29 @@ test("OpenAI -> Kiro maps invalid or empty assistant tool call arguments to empt
     (toolUseResult.conversationState.history[1] as any).assistantResponseMessage.toolUses[0].input,
     {}
   );
+});
+
+test("OpenAI -> Kiro uses Continue currentMessage when the request ends with assistant history", () => {
+  const result = buildKiroPayload(
+    "claude-sonnet-4",
+    {
+      messages: [
+        { role: "user", content: "First user" },
+        { role: "assistant", content: "Assistant answer" },
+      ],
+    },
+    false,
+    null
+  );
+
+  assert.match(
+    result.conversationState.currentMessage.userInputMessage.content,
+    /^\[Context: Current time is .*Z\]\n\nContinue$/
+  );
+  assert.deepEqual(result.conversationState.history, [
+    { userInputMessage: { content: "First user", modelId: "claude-sonnet-4" } },
+    { assistantResponseMessage: { content: "Assistant answer" } },
+  ]);
 });
 
 test("OpenAI -> Kiro derives a stable conversationId for the same first history turn", () => {


### PR DESCRIPTION
## Summary
- normalize Kiro tool schemas so tool specifications always include a required array
- send Kiro tool result status in lowercase `success`
- keep trailing assistant history while moving the last user turn into `currentMessage`

## Test
- `node --import tsx --test tests/unit/translator-openai-to-kiro.test.ts`