### PR TITLE
fix(kiro): merge adjacent user history turns after role normalization

### DIFF
--- a/open-sse/translator/request/openai-to-kiro.ts
+++ b/open-sse/translator/request/openai-to-kiro.ts
@@ -293,6 +293,13 @@ function convertMessages(messages, tools, model) {
   // contain adjacent user turns, which Kiro can reject. Merge consecutive
   // `userInputMessage` entries by concatenating their content and preserving
   // any attached `userInputMessageContext` (e.g. accumulated toolResults).
+  //
+  // Why this is not redundant with the `flushPending` grouping in the main
+  // loop: the assistant branch resets `currentRole = null` after emitting
+  // `toolUses`. Any following `tool` role (normalized to user) and a
+  // subsequent `user` role therefore each open their own flush, producing
+  // two adjacent `userInputMessage` entries in history. This pass collapses
+  // those.
   const mergedHistory: typeof history = [];
   for (const item of history) {
     const previous = mergedHistory[mergedHistory.length - 1];
@@ -312,8 +319,6 @@ function convertMessages(messages, tools, model) {
           const existing = (previousContext as Record<string, unknown>)[key];
           if (Array.isArray(existing) && Array.isArray(value)) {
             mergedContext[key] = [...existing, ...value];
-          } else if (existing === undefined) {
-            mergedContext[key] = value;
           } else {
             mergedContext[key] = value;
           }

--- a/open-sse/translator/request/openai-to-kiro.ts
+++ b/open-sse/translator/request/openai-to-kiro.ts
@@ -288,7 +288,45 @@ function convertMessages(messages, tools, model) {
     }
   });
 
-  return { history, currentMessage };
+  // Kiro expects history to alternate between user and assistant turns. After
+  // normalizing `system`/`tool` roles into `userInputMessage`, the history can
+  // contain adjacent user turns, which Kiro can reject. Merge consecutive
+  // `userInputMessage` entries by concatenating their content and preserving
+  // any attached `userInputMessageContext` (e.g. accumulated toolResults).
+  const mergedHistory: typeof history = [];
+  for (const item of history) {
+    const previous = mergedHistory[mergedHistory.length - 1];
+    if (item.userInputMessage && previous?.userInputMessage) {
+      const previousContent = previous.userInputMessage.content || "";
+      const currentContent = item.userInputMessage.content || "";
+      previous.userInputMessage.content = previousContent
+        ? `${previousContent}\n\n${currentContent}`
+        : currentContent;
+
+      if (item.userInputMessage.userInputMessageContext) {
+        const previousContext = previous.userInputMessage.userInputMessageContext || {};
+        const nextContext = item.userInputMessage.userInputMessageContext;
+        const mergedContext: Record<string, unknown> = { ...previousContext };
+
+        for (const [key, value] of Object.entries(nextContext)) {
+          const existing = (previousContext as Record<string, unknown>)[key];
+          if (Array.isArray(existing) && Array.isArray(value)) {
+            mergedContext[key] = [...existing, ...value];
+          } else if (existing === undefined) {
+            mergedContext[key] = value;
+          } else {
+            mergedContext[key] = value;
+          }
+        }
+
+        previous.userInputMessage.userInputMessageContext = mergedContext;
+      }
+    } else {
+      mergedHistory.push(item);
+    }
+  }
+
+  return { history: mergedHistory, currentMessage };
 }
 
 /**

--- a/tests/unit/translator-openai-to-kiro.test.ts
+++ b/tests/unit/translator-openai-to-kiro.test.ts
@@ -254,3 +254,38 @@ test("OpenAI -> Kiro still returns a valid payload for minimal requests", () => 
   );
   assert.equal(result.conversationState.currentMessage.userInputMessage.modelId, "claude-sonnet-4");
 });
+
+test("OpenAI -> Kiro merges adjacent user history turns after role normalization", () => {
+  const result = buildKiroPayload(
+    "claude-sonnet-4",
+    {
+      messages: [
+        { role: "system", content: "System rules" },
+        { role: "user", content: "First question" },
+        { role: "assistant", content: "Answer 1" },
+        { role: "tool", tool_call_id: "call_orphan", content: "tool log" },
+        { role: "user", content: "Follow-up" },
+      ],
+    },
+    false,
+    null
+  );
+
+  const history = result.conversationState.history as Array<{
+    userInputMessage?: { content: string };
+    assistantResponseMessage?: { content: string };
+  }>;
+
+  for (let i = 1; i < history.length; i++) {
+    assert.equal(
+      Boolean(history[i - 1].userInputMessage) && Boolean(history[i].userInputMessage),
+      false,
+      "history should not contain adjacent userInputMessage turns"
+    );
+  }
+
+  const firstUser = history[0].userInputMessage;
+  assert.ok(firstUser, "first history turn should be a user turn");
+  assert.equal(firstUser.content, "System rules\n\nFirst question");
+  assert.equal(history[1].assistantResponseMessage?.content, "Answer 1");
+});


### PR DESCRIPTION
## Summary

Follow-up to #2104. After the initial Kiro tool-use normalization, the translator can still produce adjacent Kiro `userInputMessage` entries in history when OpenAI `system` and `tool` roles are normalized into user turns. Kiro expects history to alternate between user and assistant turns, so adjacent user history entries can trigger request shape issues.

This PR merges consecutive `userInputMessage` entries in Kiro history after cleanup, concatenating their content and merging any attached `userInputMessageContext` (such as accumulated `toolResults`).

## Problem

After role normalization in the Kiro translator:

~~~text
system -> user
tool   -> user
~~~

A conversation like this:

~~~text
system
user
assistant
tool
user
~~~

Can produce a Kiro history shape with adjacent user turns:

~~~text
user
user
assistant
user
user
~~~

Kiro history is expected to alternate between user and assistant turns, so adjacent user entries can cause rejections or malformed history.

## Changes

### Translator

Updated:

~~~text
open-sse/translator/request/openai-to-kiro.ts
~~~

- Added a cleanup pass that merges adjacent `userInputMessage` entries in Kiro history.
- Preserves existing content, concatenating with `\n\n` separator.
- Merges `userInputMessageContext` across adjacent user turns, with array-valued fields (e.g. `toolResults`) concatenated.

### Tests

Updated:

~~~text
tests/unit/translator-openai-to-kiro.test.ts
~~~

Added regression coverage:

- `OpenAI -> Kiro merges adjacent user history turns after role normalization`
- Asserts no adjacent `userInputMessage` entries remain in history.
- Asserts merged content and position of the following assistant turn.

## Verification

Focused test:

~~~bash
node --import tsx/esm --test tests/unit/translator-openai-to-kiro.test.ts
~~~

Result:

~~~text
tests 7
pass 7
fail 0
~~~

## Related

- Follow-up to #2104
