### PR TITLE
feat(cursor): surface Cursor Pro plan usage on provider-limits dashboard

### DIFF
--- a/open-sse/services/usage.ts
+++ b/open-sse/services/usage.ts
@@ -72,17 +72,37 @@ const NANOGPT_CONFIG = {
   usageUrl: "https://nano-gpt.com/api/subscription/v1/usage",
 };
 
-// Cursor dashboard usage API config
-// The endpoint that powers https://cursor.com/dashboard/spending. Validates the WorkOS
-// session via the WorkosCursorSessionToken cookie (format: `${userId}::${jwt}`) and
-// rejects requests without a matching Origin/Referer (Invalid origin for state-changing request).
-const CURSOR_USAGE_CONFIG = {
+// Cursor dashboard API config — exported so the OAuth import flow can reuse the
+// host / Origin / User-Agent without redefining them.
+//
+// The endpoint that powers https://cursor.com/dashboard/spending. Validates the
+// WorkOS session via the `WorkosCursorSessionToken=${userId}::${jwt}` cookie and
+// rejects requests without a matching Origin (returns 403 "Invalid origin for
+// state-changing request"). Cookie auth via `Authorization: Bearer …` does not
+// work for the dashboard endpoints — only the WorkOS session cookie is honored.
+//
+// `userAgent` is intentionally a real browser UA: the dashboard host appears to
+// gate on UA looking browser-shaped (Cursor IDE / curl UAs get rejected). The
+// exact version isn't validated, so this string is unlikely to age out, but if
+// the dashboard ever tightens UA sniffing this is the knob to bump.
+export const CURSOR_USAGE_CONFIG = {
+  host: "https://cursor.com",
   usageUrl: "https://cursor.com/api/dashboard/get-current-period-usage",
+  authMeUrl: "https://cursor.com/api/auth/me",
   origin: "https://cursor.com",
   referer: "https://cursor.com/dashboard/spending",
   userAgent:
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
 };
+
+/**
+ * Build the WorkOS session cookie value the dashboard expects.
+ * Format: `WorkosCursorSessionToken=${userId}::${accessToken}` (Cursor accepts
+ * either the bare `user_…` or the full `google-oauth2|user_…` for `userId`).
+ */
+export function buildCursorSessionCookie(userId: string, accessToken: string): string {
+  return `WorkosCursorSessionToken=${userId}::${accessToken}`;
+}
 
 const MINIMAX_USAGE_CONFIG = {
   minimax: {
@@ -862,9 +882,11 @@ async function getNanoGptUsage(apiKey: string) {
 
 /**
  * Decode the `sub` claim of a Cursor JWT (the WorkOS user id).
- * Returns null if the token is not a parseable JWT.
+ * Returns null if the token is not a parseable JWT. Exported so the OAuth
+ * import flow in `src/lib/oauth/services/cursor.ts` can reuse it instead of
+ * duplicating the JWT base64-url decode logic.
  */
-function decodeCursorJwtSub(token: string): string | null {
+export function decodeCursorJwtSub(token: string): string | null {
   if (!token || typeof token !== "string") return null;
   const parts = token.split(".");
   if (parts.length !== 3) return null;
@@ -906,7 +928,7 @@ async function getCursorUsage(accessToken: string, providerSpecificData?: unknow
       method: "POST",
       redirect: "manual",
       headers: {
-        Cookie: `WorkosCursorSessionToken=${userId}::${accessToken}`,
+        Cookie: buildCursorSessionCookie(userId, accessToken),
         Origin: CURSOR_USAGE_CONFIG.origin,
         Referer: CURSOR_USAGE_CONFIG.referer,
         "Content-Type": "application/json",
@@ -917,10 +939,14 @@ async function getCursorUsage(accessToken: string, providerSpecificData?: unknow
     });
 
     // 3xx redirect to WorkOS authkit means the session cookie was rejected.
+    // The message must include one of the markers `syncExpiredStatusIfNeeded`
+    // (src/lib/usage/providerLimits.ts) recognizes so the connection actually
+    // gets flipped to `expired` instead of being retried until end-of-time.
     if (response.status >= 300 && response.status < 400) {
       return {
         plan: "Cursor",
-        message: "Cursor session expired. Re-import the token from Cursor IDE.",
+        message:
+          "Cursor session unauthorized: WorkOS token expired. Re-import the token from Cursor IDE.",
       };
     }
 

--- a/src/lib/oauth/services/cursor.ts
+++ b/src/lib/oauth/services/cursor.ts
@@ -1,5 +1,10 @@
 import { CURSOR_CONFIG } from "../constants/oauth";
 import { getCursorUserAgent } from "@omniroute/open-sse/config/providerHeaderProfiles.ts";
+import {
+  CURSOR_USAGE_CONFIG,
+  buildCursorSessionCookie,
+  decodeCursorJwtSub,
+} from "@omniroute/open-sse/services/usage.ts";
 
 /**
  * Cursor IDE OAuth Service
@@ -128,33 +133,28 @@ export class CursorService {
   }
 
   /**
-   * Extract user info from token if possible
-   * Cursor tokens may contain encoded user info
+   * Extract user info from token if possible.
+   * Delegates JWT base64-url decoding to the shared `decodeCursorJwtSub`
+   * helper; this function only adds the email-claim parsing on top.
    */
   extractUserInfo(accessToken: string) {
+    const userId = decodeCursorJwtSub(accessToken);
+    if (!userId) return null;
+
+    let email: string | null = null;
     try {
-      // Try to decode as JWT
       const parts = accessToken.split(".");
-      if (parts.length === 3) {
-        let payload = parts[1];
-        while (payload.length % 4) {
-          payload += "=";
-        }
-        const decoded = JSON.parse(
-          Buffer.from(payload.replace(/-/g, "+").replace(/_/g, "/"), "base64").toString()
-        );
-        const email =
-          typeof decoded.email === "string" && decoded.email.includes("@") ? decoded.email : null;
-        return {
-          email,
-          userId: decoded.sub || decoded.user_id,
-        };
+      let payload = parts[1].replace(/-/g, "+").replace(/_/g, "/");
+      while (payload.length % 4) payload += "=";
+      const decoded = JSON.parse(Buffer.from(payload, "base64").toString("utf8"));
+      if (typeof decoded.email === "string" && decoded.email.includes("@")) {
+        email = decoded.email;
       }
     } catch {
-      // Token is not a JWT, that's okay
+      // Already validated as JWT-shaped via decodeCursorJwtSub; just no email claim.
     }
 
-    return null;
+    return { email, userId };
   }
 
   /**
@@ -168,13 +168,13 @@ export class CursorService {
   ): Promise<{ email: string | null; name: string | null; sub: string | null } | null> {
     if (!accessToken || !userId) return null;
     try {
-      const response = await fetch("https://cursor.com/api/auth/me", {
+      const response = await fetch(CURSOR_USAGE_CONFIG.authMeUrl, {
         method: "GET",
         redirect: "manual",
         headers: {
-          Cookie: `WorkosCursorSessionToken=${userId}::${accessToken}`,
-          Origin: "https://cursor.com",
-          Referer: "https://cursor.com/dashboard",
+          Cookie: buildCursorSessionCookie(userId, accessToken),
+          Origin: CURSOR_USAGE_CONFIG.origin,
+          Referer: `${CURSOR_USAGE_CONFIG.host}/dashboard`,
           Accept: "application/json",
           "User-Agent": getCursorUserAgent(this.config.clientVersion),
         },

--- a/tests/unit/cursor-usage-fetcher.test.ts
+++ b/tests/unit/cursor-usage-fetcher.test.ts
@@ -208,6 +208,19 @@ test("cursor usage: 307 redirect surfaces as expired session message", async () 
     assert.equal(usage.plan, "Cursor");
     assert.match(usage.message, /session expired|Re-import/i);
     assert.equal(usage.quotas, undefined);
+
+    // Contract with src/lib/usage/providerLimits.ts::syncExpiredStatusIfNeeded:
+    // the message MUST include one of these markers, otherwise a rejected
+    // WorkOS session keeps `testStatus = "active"` and gets retried forever
+    // instead of being flipped to `expired`.
+    const lower = usage.message.toLowerCase();
+    assert.ok(
+      lower.includes("token expired") ||
+        lower.includes("access denied") ||
+        lower.includes("re-authenticate") ||
+        lower.includes("unauthorized"),
+      `307 message must include an isAuthError marker, got: ${usage.message}`
+    );
   } finally {
     mock.restore();
   }


### PR DESCRIPTION
## Summary

- Cursor was never wired into the provider-limits dashboard. The previous `getCursorUsage` targeted older endpoints (`/api/usage`, `/api/subscription`) that no longer return JSON for Pro accounts and was deleted as dead code on a local branch.
- This PR replaces it with a fetcher pointed at the same backing API that powers https://cursor.com/dashboard/spending, and registers `cursor` in `USAGE_SUPPORTED_PROVIDERS` so the existing `ProviderLimits` renderer picks it up — no UI changes required.
- Also fixes the connection-card label that previously showed `google-oauth2|user_…` for Cursor: the OAuth import flow now resolves the real account email via `/api/auth/me`.

## How it works

- **Endpoint**: `POST https://cursor.com/api/dashboard/get-current-period-usage`
- **Auth**: `Cookie: WorkosCursorSessionToken=${userId}::${accessToken}` plus `Origin`/`Referer` set to `cursor.com` (the endpoint 403s with `"Invalid origin for state-changing request"` otherwise, and 307-redirects to AuthKit if the cookie format is wrong).
- **userId resolution**: prefer `providerSpecificData.userId` (saved on import), fall back to decoding the JWT `sub` claim so existing connections work without a re-import.
- **Response shape** (live, abbreviated):
  ```json
  {
    "billingCycleEnd": "...",
    "planUsage": {
      "totalSpend":  1529, "limit": 2000,
      "autoPercentUsed": 13.21,
      "apiPercentUsed":   3.16,
      "totalPercentUsed": 10.19
    }
  }
  ```
- Mapped to three quota windows mirroring the dashboard breakdown: **Total**, **Auto + Composer**, **API**, with dollar amounts derived from `planUsage.limit` (cents) and `resetAt` from `billingCycleEnd`.

## Files

- `open-sse/services/usage.ts` — drop legacy `CURSOR_USAGE_CONFIG` + 7 helpers + dispatcher case; add new fetcher + JWT-sub decoder
- `open-sse/config/providerHeaderProfiles.ts` — drop `getCursorUsageHeaders` (legacy)
- `src/shared/constants/providers.ts` — register `"cursor"` in `USAGE_SUPPORTED_PROVIDERS`
- `src/lib/oauth/services/cursor.ts` — stop falling back to JWT `sub` for email; add `fetchUserInfo()` that calls `/api/auth/me`
- `src/app/api/oauth/cursor/import/route.ts` — best-effort fetch real profile after token validation
- `tests/unit/cursor-usage-fetcher.test.ts` — 6 new tests
- `tests/unit/{usage-service-hardening,provider-header-profiles}.test.ts` — drop two stale blocks for the deleted `__testing` exports

`CURSOR_REGISTRY_VERSION` / `getCursorUserAgent` / `getCursorRegistryHeaders` stay — still consumed by `providerRegistry`, `oauth/services/cursor`, and `utils/cursorChecksum`.

No DB schema changes. No UI changes — `ProviderLimits` is generic.

## Test plan

- [x] `node --import tsx/esm --test tests/unit/cursor-usage-fetcher.test.ts` — 6 pass: happy-path 3 windows + dollar amounts, header/cookie/body shape, JWT-sub fallback when `providerSpecificData.userId` is missing, unrecoverable-userId no-fetch path, 307 → expired-session message, empty `planUsage` informational message
- [x] `npm run typecheck:core` clean
- [x] Sibling usage tests (`copilot-usage`, `claude-extra-usage`, `usage-extractor`, `usage-service-hardening`, `provider-header-profiles`) still green
- [x] Live verified end-to-end against a real Cursor JWT: dispatcher returns `{ plan: "Cursor Pro", quotas: { Total, "Auto + Composer", API } }` with percentages and dollar amounts matching the cursor.com/dashboard/spending UI for the same account
- [x] Connection card now renders the masked email (matching how Codex / Claude render) instead of `google-oauth2|user_…`

## Out of scope

- Per-model breakdown via `/api/dashboard/get-aggregated-usage-events` (works, but no UI surface for it yet)
- Hard-limit override from `/api/dashboard/get-hard-limit` (orthogonal feature)

🤖 Generated with [Claude Code](https://claude.com/claude-code)