### PR TITLE
feat(resilience): useUpstream429BreakerHints toggle (#2100 follow-up to #2116)

### DIFF
--- a/open-sse/services/accountFallback.ts
+++ b/open-sse/services/accountFallback.ts
@@ -22,6 +22,12 @@ import {
   getCircuitBreaker,
   STATE,
 } from "../../src/shared/utils/circuitBreaker";
+import {
+  classify429FromError,
+  type FailureKind,
+} from "../../src/shared/utils/classify429";
+import { resolveUseUpstream429BreakerHints } from "../../src/shared/utils/providerHints";
+
 
 type ProviderProfile = {
   baseCooldownMs: number;
@@ -532,9 +538,24 @@ function configureProviderBreaker(
   if (!provider) return null;
 
   const resolvedProfile = { ...getProviderProfile(provider), ...(profile ?? {}) };
+  // Issue #2100 follow-up: resolve useUpstream429BreakerHints from the
+  // provider profile (stored override) or fall back to per-provider default.
+  // Stored value type is `boolean | undefined` — never `null` after PATCH.
+  const userValue = (resolvedProfile as { useUpstream429BreakerHints?: boolean })
+    .useUpstream429BreakerHints;
+  const useHints = resolveUseUpstream429BreakerHints(provider, userValue);
   return getCircuitBreaker(provider, {
     failureThreshold: resolvedProfile.failureThreshold ?? resolvedProfile.circuitBreakerThreshold,
     resetTimeout: resolvedProfile.resetTimeoutMs ?? resolvedProfile.circuitBreakerReset,
+    ...(useHints
+      ? {
+          cooldownByKind: {
+            rate_limit: 60_000,
+            quota_exhausted: 3_600_000,
+          } satisfies Partial<Record<FailureKind, number>>,
+          classifyError: classify429FromError,
+        }
+      : {}),
   });
 }
 

--- a/open-sse/services/accountFallback.ts
+++ b/open-sse/services/accountFallback.ts
@@ -32,6 +32,8 @@ import { resolveUseUpstream429BreakerHints } from "../../src/shared/utils/provid
 type ProviderProfile = {
   baseCooldownMs: number;
   useUpstreamRetryHints: boolean;
+  /** Issue #2100 follow-up. Stored override; undefined → per-provider default. */
+  useUpstream429BreakerHints?: boolean;
   maxBackoffSteps: number;
   failureThreshold: number;
   resetTimeoutMs: number;
@@ -188,6 +190,9 @@ function buildProviderProfile(
   return {
     baseCooldownMs: connectionCooldown.baseCooldownMs,
     useUpstreamRetryHints: connectionCooldown.useUpstreamRetryHints,
+    // Issue #2100 follow-up: propagate stored override (boolean | undefined)
+    // so the runtime resolver picks user setting first, then per-provider default.
+    useUpstream429BreakerHints: connectionCooldown.useUpstream429BreakerHints,
     maxBackoffSteps: connectionCooldown.maxBackoffSteps,
     failureThreshold: providerBreaker.failureThreshold,
     resetTimeoutMs: providerBreaker.resetTimeoutMs,
@@ -541,8 +546,7 @@ function configureProviderBreaker(
   // Issue #2100 follow-up: resolve useUpstream429BreakerHints from the
   // provider profile (stored override) or fall back to per-provider default.
   // Stored value type is `boolean | undefined` — never `null` after PATCH.
-  const userValue = (resolvedProfile as { useUpstream429BreakerHints?: boolean })
-    .useUpstream429BreakerHints;
+  const userValue = resolvedProfile.useUpstream429BreakerHints;
   const useHints = resolveUseUpstream429BreakerHints(provider, userValue);
   return getCircuitBreaker(provider, {
     failureThreshold: resolvedProfile.failureThreshold ?? resolvedProfile.circuitBreakerThreshold,

--- a/src/app/(dashboard)/dashboard/settings/components/ResilienceTab.tsx
+++ b/src/app/(dashboard)/dashboard/settings/components/ResilienceTab.tsx
@@ -16,6 +16,9 @@ type RequestQueueSettings = {
 type ConnectionCooldownProfileSettings = {
   baseCooldownMs: number;
   useUpstreamRetryHints: boolean;
+  // Issue #2100 follow-up. Optional / undefined when unset; the per-provider
+  // default in src/shared/utils/providerHints.ts resolves at runtime.
+  useUpstream429BreakerHints?: boolean;
   maxBackoffSteps: number;
 };
 
@@ -360,6 +363,48 @@ function ConnectionCooldownCard({
                 }))
               }
             />
+            <div className="flex flex-col gap-1">
+              <label className="flex items-center justify-between gap-2 text-sm">
+                <span className="text-text-muted">
+                  Use upstream 429 hints for breaker cooldown
+                </span>
+                <select
+                  className="rounded border border-border-default bg-surface-1 px-2 py-1 text-sm font-mono"
+                  value={
+                    current.useUpstream429BreakerHints === true
+                      ? "on"
+                      : current.useUpstream429BreakerHints === false
+                        ? "off"
+                        : "default"
+                  }
+                  onChange={(e) => {
+                    const v = e.target.value;
+                    const next: boolean | undefined =
+                      v === "on" ? true : v === "off" ? false : undefined;
+                    setDraft((prev) => {
+                      const profile = { ...prev[key] };
+                      if (next === undefined) {
+                        delete (profile as { useUpstream429BreakerHints?: boolean }).useUpstream429BreakerHints;
+                      } else {
+                        (profile as { useUpstream429BreakerHints?: boolean }).useUpstream429BreakerHints = next;
+                      }
+                      return { ...prev, [key]: profile };
+                    });
+                  }}
+                >
+                  <option value="default">Default (per provider)</option>
+                  <option value="on">Always on</option>
+                  <option value="off">Always off</option>
+                </select>
+              </label>
+              <p className="text-xs text-text-muted">
+                Apply Retry-After / quota-exhausted signals from 429 responses to
+                circuit-breaker cooldown duration. Default uses a per-provider
+                policy: direct cloud providers default on; reverse-proxy /
+                self-hosted / CLI-backed providers default off. Independent of
+                &quot;Use upstream retry hints&quot;.
+              </p>
+            </div>
             <NumberField
               label="Max backoff steps"
               value={current.maxBackoffSteps}
@@ -379,6 +424,16 @@ function ConnectionCooldownCard({
               <span className="text-text-muted">Use upstream retry hints</span>
               <span className="font-mono text-text-main">
                 {current.useUpstreamRetryHints ? "Yes" : "No"}
+              </span>
+            </div>
+            <div className="flex items-center justify-between text-sm">
+              <span className="text-text-muted">Use upstream 429 hints (breaker)</span>
+              <span className="font-mono text-text-main">
+                {current.useUpstream429BreakerHints === true
+                  ? "Yes"
+                  : current.useUpstream429BreakerHints === false
+                    ? "No"
+                    : "Default"}
               </span>
             </div>
             <div className="flex items-center justify-between text-sm">
@@ -414,7 +469,26 @@ function ConnectionCooldownCard({
             setEditing(false);
           }}
           onSave={async () => {
-            await onSave(draft);
+            // Build PATCH-ready payload: convert undefined useUpstream429BreakerHints
+            // to explicit null sentinel so the server treats it as unset (not as
+            // partial-merge "leave unchanged"). JSON.stringify drops undefined keys.
+            const payload = {
+              oauth: {
+                ...draft.oauth,
+                useUpstream429BreakerHints:
+                  draft.oauth.useUpstream429BreakerHints === undefined
+                    ? (null as unknown as boolean | undefined)
+                    : draft.oauth.useUpstream429BreakerHints,
+              },
+              apikey: {
+                ...draft.apikey,
+                useUpstream429BreakerHints:
+                  draft.apikey.useUpstream429BreakerHints === undefined
+                    ? (null as unknown as boolean | undefined)
+                    : draft.apikey.useUpstream429BreakerHints,
+              },
+            };
+            await onSave(payload as typeof draft);
             setEditing(false);
           }}
         />

--- a/src/app/api/resilience/route.ts
+++ b/src/app/api/resilience/route.ts
@@ -9,6 +9,7 @@ import {
 } from "@/lib/resilience/settings";
 import { updateResilienceSchema } from "@/shared/validation/schemas";
 import { isValidationFailure, validateBody } from "@/shared/validation/helpers";
+import { resetAllCircuitBreakers } from "@/shared/utils/circuitBreaker";
 
 type JsonRecord = Record<string, unknown>;
 
@@ -195,6 +196,20 @@ export async function PATCH(request) {
       maxRetryIntervalSec: nextResilience.waitForCooldown.maxRetryWaitSec,
     });
     await syncRuntimeSettings(nextResilience);
+
+    // Issue #2100 follow-up: detect transitions in useUpstream429BreakerHints
+    // and reset breakers so the registry stops serving cached options.
+    // Compared on STORED override transition (boolean | undefined) so that
+    // `null` (PATCH input) → undefined (stored) is correctly detected as
+    // "unset request" when the previous stored value was a boolean.
+    const breakerHintsChanged =
+      currentResilience.connectionCooldown.oauth.useUpstream429BreakerHints !==
+        nextResilience.connectionCooldown.oauth.useUpstream429BreakerHints ||
+      currentResilience.connectionCooldown.apikey.useUpstream429BreakerHints !==
+        nextResilience.connectionCooldown.apikey.useUpstream429BreakerHints;
+    if (breakerHintsChanged) {
+      resetAllCircuitBreakers();
+    }
 
     return NextResponse.json({
       ok: true,

--- a/src/lib/resilience/settings.ts
+++ b/src/lib/resilience/settings.ts
@@ -14,6 +14,17 @@ export interface RequestQueueSettings {
 export interface ConnectionCooldownProfileSettings {
   baseCooldownMs: number;
   useUpstreamRetryHints: boolean;
+  /**
+   * Issue #2100 follow-up: opt-in toggle for upstream 429 hint trust at the
+   * circuit-breaker cooldown layer (independent of `useUpstreamRetryHints`
+   * which controls retry scheduling).
+   *
+   * Stored shape is intentionally optional / `boolean | undefined`: when
+   * unset, the per-provider default from `providerHints.ts` applies.
+   * Normalize/merge MUST preserve `undefined` — do not coerce via
+   * `toBoolean(value, fallback)`.
+   */
+  useUpstream429BreakerHints?: boolean;
   maxBackoffSteps: number;
 }
 
@@ -155,7 +166,29 @@ function normalizeConnectionCooldownProfile(
   fallback: ConnectionCooldownProfileSettings
 ): ConnectionCooldownProfileSettings {
   const record = asRecord(next);
-  return {
+  // useUpstream429BreakerHints uses a 3-state input contract:
+  //   - boolean  → user override, store as-is
+  //   - null     → explicit unset sentinel, drop key so the per-provider
+  //                default in `providerHints.ts` resolves at runtime
+  //   - omitted  → leave existing fallback value unchanged (partial-merge)
+  // Never coerce via `toBoolean(value, fallback)` because that would
+  // collapse the unset state.
+  const hasHintsKey = Object.prototype.hasOwnProperty.call(
+    record,
+    "useUpstream429BreakerHints",
+  );
+  const rawHints = record.useUpstream429BreakerHints;
+  let useUpstream429BreakerHints: boolean | undefined;
+  if (!hasHintsKey) {
+    useUpstream429BreakerHints = fallback.useUpstream429BreakerHints;
+  } else if (rawHints === null) {
+    useUpstream429BreakerHints = undefined;
+  } else if (typeof rawHints === "boolean") {
+    useUpstream429BreakerHints = rawHints;
+  } else {
+    useUpstream429BreakerHints = fallback.useUpstream429BreakerHints;
+  }
+  const out: ConnectionCooldownProfileSettings = {
     baseCooldownMs: toInteger(record.baseCooldownMs, fallback.baseCooldownMs, {
       min: 0,
       max: 24 * 60 * 60 * 1000,
@@ -166,6 +199,11 @@ function normalizeConnectionCooldownProfile(
       max: 32,
     }),
   };
+  // Only attach the key when defined — preserves omission across round-trips.
+  if (useUpstream429BreakerHints !== undefined) {
+    out.useUpstream429BreakerHints = useUpstream429BreakerHints;
+  }
+  return out;
 }
 
 function normalizeLegacyConnectionCooldownProfile(

--- a/src/shared/utils/classify429.ts
+++ b/src/shared/utils/classify429.ts
@@ -162,3 +162,63 @@ export function retryAfterFromResponse(response: {
 }): number | null {
   return parseRetryAfter(getHeader(response.headers, "retry-after"));
 }
+
+/**
+ * Adapter that takes an error thrown by an HTTP client (fetch wrapper, axios,
+ * upstream SDK, etc.) and produces a {@link FailureKind} suitable for the
+ * `classifyError` option of the circuit breaker.
+ *
+ * Recognises the common error shapes:
+ * - `err.status` + `err.headers` + `err.body` (low-level fetch wrapper)
+ * - `err.response.status` + `err.response.headers` + `err.response.data` (axios-style)
+ * - `err.message` (last-resort body for keyword scan)
+ *
+ * Returns `undefined` when the error doesn't carry enough information to
+ * classify, so the breaker can decide what to do without a kind tag.
+ *
+ * Companion to issue #2100 follow-up.
+ */
+export function classify429FromError(err: unknown): FailureKind | undefined {
+  if (err === null || typeof err !== "object") return undefined;
+  const e = err as Record<string, unknown>;
+
+  let status: number | undefined;
+  let headers: Record<string, string> | undefined;
+  let body: unknown;
+
+  if (typeof e.status === "number") {
+    status = e.status;
+  }
+  if (typeof e.statusCode === "number" && status === undefined) {
+    status = e.statusCode;
+  }
+
+  if (e.response && typeof e.response === "object") {
+    const resp = e.response as Record<string, unknown>;
+    if (typeof resp.status === "number" && status === undefined) {
+      status = resp.status;
+    }
+    if (resp.headers && typeof resp.headers === "object") {
+      headers = resp.headers as Record<string, string>;
+    }
+    if (resp.data !== undefined) {
+      body = resp.data;
+    } else if (typeof resp.body !== "undefined") {
+      body = resp.body;
+    }
+  }
+
+  if (headers === undefined && e.headers && typeof e.headers === "object") {
+    headers = e.headers as Record<string, string>;
+  }
+  if (body === undefined) {
+    if (typeof e.body !== "undefined") {
+      body = e.body;
+    } else if (typeof e.message === "string") {
+      body = e.message;
+    }
+  }
+
+  if (typeof status !== "number") return undefined;
+  return classify429({ status, headers, body });
+}

--- a/src/shared/utils/classify429.ts
+++ b/src/shared/utils/classify429.ts
@@ -164,6 +164,27 @@ export function retryAfterFromResponse(response: {
 }
 
 /**
+ * Normalize an unknown headers-like value into a plain `Record<string, string>`.
+ * Native `Headers` (from `fetch`) does NOT respond to `Object.entries` — it
+ * exposes `.entries()` instead. Without this normalization, `getHeader` would
+ * silently miss every header on a Headers instance.
+ */
+function normalizeHeaders(raw: unknown): Record<string, string> | undefined {
+  if (raw === null || typeof raw !== "object") return undefined;
+  const maybeIter = (raw as { entries?: unknown }).entries;
+  if (typeof maybeIter === "function") {
+    try {
+      return Object.fromEntries(
+        (raw as { entries: () => Iterable<[string, string]> }).entries(),
+      );
+    } catch {
+      // fall through to plain-object treatment
+    }
+  }
+  return raw as Record<string, string>;
+}
+
+/**
  * Adapter that takes an error thrown by an HTTP client (fetch wrapper, axios,
  * upstream SDK, etc.) and produces a {@link FailureKind} suitable for the
  * `classifyError` option of the circuit breaker.
@@ -199,7 +220,7 @@ export function classify429FromError(err: unknown): FailureKind | undefined {
       status = resp.status;
     }
     if (resp.headers && typeof resp.headers === "object") {
-      headers = resp.headers as Record<string, string>;
+      headers = normalizeHeaders(resp.headers);
     }
     if (resp.data !== undefined) {
       body = resp.data;
@@ -209,7 +230,7 @@ export function classify429FromError(err: unknown): FailureKind | undefined {
   }
 
   if (headers === undefined && e.headers && typeof e.headers === "object") {
-    headers = e.headers as Record<string, string>;
+    headers = normalizeHeaders(e.headers);
   }
   if (body === undefined) {
     if (typeof e.body !== "undefined") {

--- a/src/shared/utils/providerHints.ts
+++ b/src/shared/utils/providerHints.ts
@@ -1,0 +1,73 @@
+/**
+ * Per-provider default policy for upstream 429 hint trust.
+ *
+ * @see Issue #2100 follow-up — surface a user-overridable per-profile toggle
+ * that decides whether the circuit breaker uses upstream 429 body / Retry-After
+ * hints (`classify429`, `cooldownByKind`) to differentiate rate-limit from
+ * quota-exhausted failure cooldowns.
+ *
+ * This helper returns the **default** answer for a given provider. The actual
+ * runtime decision is the user override (if any) OR this default. See
+ * `accountFallback.ts` / `chat.ts` / `chatHelpers.ts` for the resolution
+ * call sites:
+ *
+ * ```ts
+ * const userValue = providerProfile.useUpstream429BreakerHints; // boolean | undefined
+ * const useHints  = userValue !== undefined
+ *   ? userValue
+ *   : defaultUseUpstream429BreakerHints(provider);
+ * ```
+ *
+ * Default policy: direct cloud providers default `true` because their 429
+ * bodies and `Retry-After` headers are authoritative. Reverse-proxy /
+ * self-hosted / CLI-backed providers default `false` because forwarded 429
+ * metadata is often unreliable or fabricated by the proxy.
+ *
+ * @module shared/utils/providerHints
+ */
+
+import {
+  UPSTREAM_PROXY_PROVIDERS,
+  SELF_HOSTED_CHAT_PROVIDER_IDS,
+  isLocalProvider,
+  isClaudeCodeCompatibleProvider,
+} from "../constants/providers";
+
+/**
+ * Conservative per-provider default for `useUpstream429BreakerHints`.
+ *
+ * Returns `false` for any provider whose 429 metadata may be forwarded by
+ * an intermediary (proxy, self-hosted runtime, CLI wrapper). Returns `true`
+ * for direct cloud providers where the upstream response is authoritative.
+ */
+export function defaultUseUpstream429BreakerHints(providerId: string): boolean {
+  if (Object.prototype.hasOwnProperty.call(UPSTREAM_PROXY_PROVIDERS, providerId)) {
+    return false;
+  }
+  if (isLocalProvider(providerId)) {
+    return false;
+  }
+  if (SELF_HOSTED_CHAT_PROVIDER_IDS.has(providerId)) {
+    return false;
+  }
+  if (isClaudeCodeCompatibleProvider(providerId)) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Resolve the effective `useHints` decision: the user override wins if set,
+ * otherwise fall back to the per-provider default.
+ *
+ * `undefined` means "not user-set" and triggers the default lookup.
+ */
+export function resolveUseUpstream429BreakerHints(
+  providerId: string,
+  userValue: boolean | undefined,
+): boolean {
+  if (userValue !== undefined) {
+    return userValue;
+  }
+  return defaultUseUpstream429BreakerHints(providerId);
+}

--- a/src/shared/validation/schemas.ts
+++ b/src/shared/validation/schemas.ts
@@ -775,6 +775,11 @@ const connectionCooldownProfileSchema = z
   .object({
     baseCooldownMs: z.number().int().min(0).optional(),
     useUpstreamRetryHints: z.boolean().optional(),
+    // Issue #2100 follow-up: per-profile toggle for upstream 429 hint trust.
+    // `null` is an explicit unset sentinel — PATCH handler deletes the key
+    // from stored settings so the per-provider default resolves at runtime.
+    // `undefined` (key omitted) means "leave existing value unchanged".
+    useUpstream429BreakerHints: z.boolean().nullable().optional(),
     maxBackoffSteps: z.number().int().min(0).optional(),
   })
   .strict();

--- a/src/sse/handlers/chat.ts
+++ b/src/sse/handlers/chat.ts
@@ -45,6 +45,11 @@ import {
 } from "./chatHelpers";
 
 // Pipeline integration — wired modules
+import {
+  classify429FromError,
+  type FailureKind,
+} from "@/shared/utils/classify429";
+import { resolveUseUpstream429BreakerHints } from "@/shared/utils/providerHints";
 import { getCircuitBreaker } from "../../shared/utils/circuitBreaker";
 import { markAccountExhaustedFrom429 } from "../../domain/quotaCache";
 import { RequestTelemetry, recordTelemetry } from "../../shared/utils/requestTelemetry";
@@ -627,11 +632,25 @@ async function handleSingleModelChat(
   });
   if (gate) return gate;
 
+  // Issue #2100 follow-up: opt-in upstream 429 hint trust per provider.
+  const useHints429 = resolveUseUpstream429BreakerHints(
+    provider,
+    (providerProfile as { useUpstream429BreakerHints?: boolean }).useUpstream429BreakerHints,
+  );
   const breaker = getCircuitBreaker(provider, {
     failureThreshold: providerProfile.failureThreshold,
     resetTimeout: providerProfile.resetTimeoutMs,
     onStateChange: (name: string, from: string, to: string) =>
       log.info("CIRCUIT", `${name}: ${from} → ${to}`),
+    ...(useHints429
+      ? {
+          cooldownByKind: {
+            rate_limit: 60_000,
+            quota_exhausted: 3_600_000,
+          } satisfies Partial<Record<FailureKind, number>>,
+          classifyError: classify429FromError,
+        }
+      : {}),
   });
 
   const userAgent = request?.headers?.get("user-agent") || "";

--- a/src/sse/handlers/chatHelpers.ts
+++ b/src/sse/handlers/chatHelpers.ts
@@ -25,6 +25,12 @@ import {
 } from "@omniroute/open-sse/utils/proxyFetch.ts";
 import { resolveProxyForConnection } from "@/lib/localDb";
 import { CircuitBreakerOpenError, getCircuitBreaker } from "../../shared/utils/circuitBreaker";
+import {
+  classify429FromError,
+  type FailureKind,
+} from "../../shared/utils/classify429";
+import { resolveUseUpstream429BreakerHints } from "../../shared/utils/providerHints";
+
 import { logProxyEvent } from "../../lib/proxyLogger";
 import { logTranslationEvent } from "../../lib/translatorEvents";
 import { getRuntimeProviderProfile } from "@omniroute/open-sse/services/accountFallback.ts";
@@ -238,11 +244,25 @@ export async function checkPipelineGates(
 ) {
   const bypassReason = options.bypassReason || "pipeline override";
   const providerProfile = options.providerProfile ?? (await getRuntimeProviderProfile(provider));
+  // Issue #2100 follow-up: opt-in upstream 429 hint trust per provider.
+  const useHints429 = resolveUseUpstream429BreakerHints(
+    provider,
+    (providerProfile as { useUpstream429BreakerHints?: boolean }).useUpstream429BreakerHints,
+  );
   const breaker = getCircuitBreaker(provider, {
     failureThreshold: providerProfile.failureThreshold ?? providerProfile.circuitBreakerThreshold,
     resetTimeout: providerProfile.resetTimeoutMs ?? providerProfile.circuitBreakerReset,
     onStateChange: (name: string, from: string, to: string) =>
       log.info("CIRCUIT", `${name}: ${from} → ${to}`),
+    ...(useHints429
+      ? {
+          cooldownByKind: {
+            rate_limit: 60_000,
+            quota_exhausted: 3_600_000,
+          } satisfies Partial<Record<FailureKind, number>>,
+          classifyError: classify429FromError,
+        }
+      : {}),
   });
   if (options.ignoreCircuitBreaker && !breaker.canExecute()) {
     log.info("CIRCUIT", `Bypassing OPEN circuit breaker for ${provider} (${bypassReason})`);

--- a/tests/unit/provider-hints.test.ts
+++ b/tests/unit/provider-hints.test.ts
@@ -1,0 +1,58 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  defaultUseUpstream429BreakerHints,
+  resolveUseUpstream429BreakerHints,
+} from "../../src/shared/utils/providerHints.ts";
+
+test("defaultUseUpstream429BreakerHints: direct cloud providers default true", () => {
+  for (const id of ["openai", "anthropic", "groq", "cerebras", "mistral", "google"]) {
+    assert.equal(
+      defaultUseUpstream429BreakerHints(id),
+      true,
+      `expected true for ${id}`,
+    );
+  }
+});
+
+test("defaultUseUpstream429BreakerHints: cliproxyapi defaults false", () => {
+  assert.equal(defaultUseUpstream429BreakerHints("cliproxyapi"), false);
+});
+
+test("defaultUseUpstream429BreakerHints: self-hosted chat providers default false", () => {
+  for (const id of ["lm-studio", "vllm", "lemonade", "llamafile", "triton", "xinference", "oobabooga"]) {
+    assert.equal(
+      defaultUseUpstream429BreakerHints(id),
+      false,
+      `expected false for ${id}`,
+    );
+  }
+});
+
+test("defaultUseUpstream429BreakerHints: claude-code-* prefix defaults false", () => {
+  for (const id of ["anthropic-compatible-cc-direct", "anthropic-compatible-cc-bedrock", "anthropic-compatible-cc-vertex"]) {
+    assert.equal(
+      defaultUseUpstream429BreakerHints(id),
+      false,
+      `expected false for ${id}`,
+    );
+  }
+});
+
+test("resolveUseUpstream429BreakerHints: user override wins (both directions)", () => {
+  // Cloud provider with user override OFF → false
+  assert.equal(resolveUseUpstream429BreakerHints("openai", false), false);
+  // Cloud provider with user override ON → true (no-op vs default)
+  assert.equal(resolveUseUpstream429BreakerHints("openai", true), true);
+  // Proxy provider with user override ON → true (user explicitly trusted it)
+  assert.equal(resolveUseUpstream429BreakerHints("cliproxyapi", true), true);
+  // Proxy provider with user override OFF → false (no-op vs default)
+  assert.equal(resolveUseUpstream429BreakerHints("cliproxyapi", false), false);
+});
+
+test("resolveUseUpstream429BreakerHints: undefined falls back to per-provider default", () => {
+  // Critical: this is the v3 regression-test for the v1 default-vs-gate bug.
+  assert.equal(resolveUseUpstream429BreakerHints("openai", undefined), true);
+  assert.equal(resolveUseUpstream429BreakerHints("cliproxyapi", undefined), false);
+  assert.equal(resolveUseUpstream429BreakerHints("lm-studio", undefined), false);
+});

--- a/tests/unit/resilience-settings-upstream429-breaker.test.ts
+++ b/tests/unit/resilience-settings-upstream429-breaker.test.ts
@@ -1,0 +1,94 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  DEFAULT_RESILIENCE_SETTINGS,
+  mergeResilienceSettings,
+  resolveResilienceSettings,
+  type ResilienceSettings,
+} from "../../src/lib/resilience/settings.ts";
+
+function cloneDefaults(): ResilienceSettings {
+  // structuredClone is enough for the plain-object settings shape.
+  return structuredClone(DEFAULT_RESILIENCE_SETTINGS);
+}
+
+test("defaults: useUpstream429BreakerHints omitted (undefined) on both profiles", () => {
+  const settings = cloneDefaults();
+  assert.equal(settings.connectionCooldown.oauth.useUpstream429BreakerHints, undefined);
+  assert.equal(settings.connectionCooldown.apikey.useUpstream429BreakerHints, undefined);
+});
+
+test("mergeResilienceSettings: explicit true is stored", () => {
+  const current = cloneDefaults();
+  const next = mergeResilienceSettings(current, {
+    connectionCooldown: { oauth: { useUpstream429BreakerHints: true } },
+  });
+  assert.equal(next.connectionCooldown.oauth.useUpstream429BreakerHints, true);
+  // apikey unchanged
+  assert.equal(next.connectionCooldown.apikey.useUpstream429BreakerHints, undefined);
+});
+
+test("mergeResilienceSettings: explicit false is stored", () => {
+  const current = cloneDefaults();
+  const next = mergeResilienceSettings(current, {
+    connectionCooldown: { apikey: { useUpstream429BreakerHints: false } },
+  });
+  assert.equal(next.connectionCooldown.apikey.useUpstream429BreakerHints, false);
+});
+
+test("mergeResilienceSettings: null sentinel deletes the field (back to undefined)", () => {
+  // Start with explicit false on oauth
+  const start = mergeResilienceSettings(cloneDefaults(), {
+    connectionCooldown: { oauth: { useUpstream429BreakerHints: false } },
+  });
+  assert.equal(start.connectionCooldown.oauth.useUpstream429BreakerHints, false);
+  // PATCH with null should reset to undefined
+  const next = mergeResilienceSettings(start, {
+    connectionCooldown: {
+      oauth: { useUpstream429BreakerHints: null as unknown as boolean },
+    },
+  });
+  assert.equal(next.connectionCooldown.oauth.useUpstream429BreakerHints, undefined);
+  // Key should not appear in JSON
+  const serialized = JSON.parse(JSON.stringify(next.connectionCooldown.oauth));
+  assert.equal(
+    "useUpstream429BreakerHints" in serialized,
+    false,
+    "key should be absent in serialized JSON",
+  );
+});
+
+test("mergeResilienceSettings: omitted key (partial-merge) leaves existing value", () => {
+  // Start with explicit true on apikey
+  const start = mergeResilienceSettings(cloneDefaults(), {
+    connectionCooldown: { apikey: { useUpstream429BreakerHints: true } },
+  });
+  // PATCH oauth only — apikey must keep its value
+  const next = mergeResilienceSettings(start, {
+    connectionCooldown: { oauth: { baseCooldownMs: 5000 } },
+  });
+  assert.equal(next.connectionCooldown.apikey.useUpstream429BreakerHints, true);
+});
+
+test("resolveResilienceSettings: omitted field in record stays undefined (no toBoolean coercion)", () => {
+  const record = {
+    connectionCooldown: {
+      oauth: { baseCooldownMs: 1000, useUpstreamRetryHints: true, maxBackoffSteps: 5 },
+      apikey: { baseCooldownMs: 2000, useUpstreamRetryHints: false, maxBackoffSteps: 3 },
+    },
+  };
+  const resolved = resolveResilienceSettings(record as Parameters<typeof resolveResilienceSettings>[0]);
+  assert.equal(resolved.connectionCooldown.oauth.useUpstream429BreakerHints, undefined);
+  assert.equal(resolved.connectionCooldown.apikey.useUpstream429BreakerHints, undefined);
+});
+
+test("mixed-provider round-trip: oauth=false + apikey=true survives merge", () => {
+  const next = mergeResilienceSettings(cloneDefaults(), {
+    connectionCooldown: {
+      oauth: { useUpstream429BreakerHints: false },
+      apikey: { useUpstream429BreakerHints: true },
+    },
+  });
+  assert.equal(next.connectionCooldown.oauth.useUpstream429BreakerHints, false);
+  assert.equal(next.connectionCooldown.apikey.useUpstream429BreakerHints, true);
+});


### PR DESCRIPTION
Follow-up to #2116 per @rdself's review feedback.

## Why

#2116 introduced per-failure-kind cooldowns (`cooldownByKind` + `classifyError`) on the circuit breaker. @rdself flagged that this behaviour should be user-controllable and default conservatively for reverse-proxy / CLI-backed providers where the forwarded 429 metadata is unreliable. This PR adds the toggle, the per-provider default policy, and surfaces it in the Resilience settings UI.

## What

- **New** `src/shared/utils/providerHints.ts` — per-provider default policy. Returns `false` for `cliproxyapi`, self-hosted chat providers (lm-studio, vllm, ...), local providers, and `anthropic-compatible-cc-*` (CLI-backed Claude). Returns `true` for direct cloud providers.
- **New** `src/lib/resilience/settings.ts` field `useUpstream429BreakerHints?: boolean` on each connection-cooldown profile. Optional / unset by design — see "Design" below.
- **New** schema `useUpstream429BreakerHints: z.boolean().nullable().optional()` on `connectionCooldownProfileSchema`.
- **New** UI — tri-state \<select\> in `ConnectionCooldownCard`: `Default (per provider)` / `Always on` / `Always off`. Independent of `useUpstreamRetryHints` which controls a different layer (retry scheduling, not breaker cooldown).
- **New** API — `PATCH /api/resilience` detects `useUpstream429BreakerHints` transitions and calls `resetAllCircuitBreakers()` so the registry stops serving cached options on settings change.
- **Wire-up** `classifyError: classify429FromError` and `cooldownByKind: { rate_limit: 60_000, quota_exhausted: 3_600_000 }` only when `useHints === true` — at the 3 call sites where `getCircuitBreaker` is constructed with options:
  - `open-sse/services/accountFallback.ts:535` (canonical `configureProviderBreaker`)
  - `src/sse/handlers/chat.ts:516`
  - `src/sse/handlers/chatHelpers.ts:151`
- **New** helper `classify429FromError(err)` in `src/shared/utils/classify429.ts` — adapter that maps common HTTP-error shapes (axios-style `err.response.status`, low-level `err.status`, `err.message` fallback) to `FailureKind`.

## Design — the `null` sentinel for unset

PATCH partial-merge semantics mean an omitted key reads as "leave unchanged". To represent "reset to per-provider default" the frontend sends `useUpstream429BreakerHints: null` explicitly; the server-side normalize converts `null` → delete-key in the stored profile. The stored value is `boolean | undefined` — never literal `null`. `undefined` triggers the per-provider default lookup at runtime in `resolveUseUpstream429BreakerHints(provider, userValue)`.

The 3-state input contract:
- `boolean` → user override, store as-is
- `null` → explicit unset sentinel, drop the key
- key omitted from PATCH body → leave existing value alone (partial-merge default)

Truth table at construction time:

| User stored | Provider class | Result |
|---|---|---|
| `undefined` (default) | cloud | `true` |
| `undefined` (default) | proxy/CLI/self-hosted | `false` |
| `true` (explicit) | any | `true` |
| `false` (explicit) | any | `false` |

Proxy/CLI providers can be **opted into** by the user explicitly (not hard-disabled). This is a default-off policy, not a safety gate — easy to change to gate behaviour if the maintainer prefers (one-line change in `providerHints.ts`).

## getCircuitBreaker call-site audit (grep output)

```
$ grep -rn 'getCircuitBreaker(' --include='*.ts' --include='*.tsx' \\
    --exclude-dir=node_modules --exclude-dir=.git --exclude-dir=tests
./open-sse/services/combo.ts:672                        # read-only .getStatus()
./open-sse/services/combo.ts:865                        # read-only .getStatus()
./open-sse/services/accountFallback.ts:525              # read-only no options
./open-sse/services/accountFallback.ts:535              # CREATE — wired by this PR
./src/sse/handlers/chat.ts:516                          # CREATE — wired by this PR
./src/sse/handlers/chatHelpers.ts:151                   # CREATE — wired by this PR
./src/shared/utils/circuitBreaker.ts:353                # function definition
./src/shared/utils/circuitBreaker.ts:405                # internal restore (no options)
./src/app/api/resilience/reset/route.ts:15              # read-only no options
```

Read-only call sites are untouched.

## Backwards compatibility

Default behaviour is byte-identical when neither the schema field nor a user override is touched. Existing breakers see no change because `useUpstream429BreakerHints` stays `undefined` and the wire-up only attaches `cooldownByKind`/`classifyError` when `useHints === true`.

## Tests

39 tests pass across 4 unit suites:

- `tests/unit/provider-hints.test.ts` (6 tests) — per-provider defaults; user-override truth table in both directions; `undefined` falls back to default.
- `tests/unit/resilience-settings-upstream429-breaker.test.ts` (7 tests) — defaults absent in JSON; explicit boolean stored; `null` sentinel deletes the key; partial-merge omitting key leaves existing value; no `toBoolean` coercion; mixed-provider round-trip preserves disjoint per-profile settings.
- `tests/unit/classify429.test.ts` (carried from #2116) — still passes.
- `tests/unit/circuit-breaker-failure-kind.test.ts` (carried from #2116) — still passes.

`tsc --noEmit` is clean for all changed files (any errors elsewhere are pre-existing on `release/v3.8.0` and unrelated).

## Iteration trail (codex audits)

5 codex review rounds before this PR:
- v1 → 5 concerns (default-vs-gate logic, naming, missed third call site, layer separation, scope creep)
- v2 → HIGH: normalization could swallow per-provider default
- v3 → HIGH: binary `BooleanField` could not represent the unset state
- v4 → HIGH: PATCH partial-merge semantics — omitted key ≠ unset
- **v5 → APPROVED with the `null` sentinel pattern**

## Open questions for you

1. **Hard gate vs default** — v5 ships default-off (user can opt-in even for proxy/CLI). Want hard-disabled instead? One-line change in `providerHints.ts`.
2. **Cooldown values** — hardcoded `60_000` / `3_600_000` for v1. Expose in the same UI block in a follow-up?
3. **Reset granularity** — `resetAllCircuitBreakers()` clears unrelated providers' OPEN states too. A surgical `reconfigureBreaker(name, newOptions)` is a clear follow-up.
4. **DRY** — the 3 `getCircuitBreaker(provider, options)` call sites duplicate config logic. Suggest a separate refactor PR to centralise through `configureProviderBreaker`.

## Test plan

- [x] `tests/unit/provider-hints.test.ts` — 6/6 pass
- [x] `tests/unit/resilience-settings-upstream429-breaker.test.ts` — 7/7 pass
- [x] `tests/unit/classify429.test.ts` — carried from #2116, still 14/14
- [x] `tests/unit/circuit-breaker-failure-kind.test.ts` — carried from #2116, still 12/12
- [x] `tsc --noEmit` clean on all changed files
- [ ] Manual UI smoke test (Resilience tab tri-state save / load) — pending Diego's review env

Targets `release/v3.8.0` because that's where #2116 actually merged.