### PR TITLE
fix: remove duplicate cloud agent provider constants

### DIFF
--- a/open-sse/config/providerRegistry.ts
+++ b/open-sse/config/providerRegistry.ts
@@ -593,20 +593,10 @@ export const REGISTRY: Record<string, RegistryEntry> = {
       { id: "auto-kiro", name: "Auto (Kiro picks best model)" },
       { id: "claude-opus-4.7", name: "Claude Opus 4.7" },
       { id: "claude-opus-4.6", name: "Claude Opus 4.6" },
-      { id: "claude-opus-4.5", name: "Claude Opus 4.5" },
       { id: "claude-sonnet-4.6", name: "Claude Sonnet 4.6" },
+      // models for kiro free tier
       { id: "claude-sonnet-4.5", name: "Claude Sonnet 4.5" },
-      { id: "claude-sonnet-4", name: "Claude Sonnet 4" },
       { id: "claude-haiku-4.5", name: "Claude Haiku 4.5" },
-      { id: "claude-3.7-sonnet", name: "Claude 3.7 Sonnet" },
-      // Dash aliases — Claude Code sends dashes, Kiro API uses dots
-      { id: "claude-opus-4-7", name: "Claude Opus 4.7" },
-      { id: "claude-opus-4-6", name: "Claude Opus 4.6" },
-      { id: "claude-opus-4-5", name: "Claude Opus 4.5" },
-      { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
-      { id: "claude-sonnet-4-5", name: "Claude Sonnet 4.5" },
-      { id: "claude-haiku-4-5", name: "Claude Haiku 4.5" },
-      // Non-Claude models on Kiro subscription
       { id: "deepseek-3.2", name: "DeepSeek V3.2" },
       { id: "minimax-m2.5", name: "MiniMax M2.5" },
       { id: "minimax-m2.1", name: "MiniMax M2.1" },

--- a/open-sse/services/model.ts
+++ b/open-sse/services/model.ts
@@ -55,6 +55,13 @@ const PROVIDER_MODEL_ALIASES: ProviderModelAliasMap = {
     "nvidia/gpt-oss-20b": "openai/gpt-oss-20b",
   },
   antigravity: { ...ANTIGRAVITY_MODEL_ALIASES },
+  kiro: {
+    "claude-opus-4-7": "claude-opus-4.7",
+    "claude-opus-4-6": "claude-opus-4.6",
+    "claude-sonnet-4-6": "claude-sonnet-4.6",
+    "claude-sonnet-4-5": "claude-sonnet-4.5",
+    "claude-haiku-4-5": "claude-haiku-4.5",
+  },
 };
 
 const CROSS_PROXY_MODEL_ALIASES: Record<string, string> = {

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -2984,6 +2984,7 @@
     "apikey": "Apikey",
     "audio": "Audio",
     "audioProvidersHeading": "Audio Providers Heading",
+    "cloudAgentProviders": "Cloud Agent Providers",
     "audioShortLabel": "Audio Short Label",
     "azureOpenAiBaseUrlHint": "Azure Open Ai Base Url Hint",
     "bailianBaseUrlHint": "Bailian Base Url Hint",

--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -1913,37 +1913,6 @@ export function isSelfHostedChatProvider(providerId: unknown): boolean {
   return typeof providerId === "string" && SELF_HOSTED_CHAT_PROVIDER_IDS.has(providerId);
 }
 
-// ── Cloud Agent Providers ───────────────────────────────────────────────────
-export const CLOUD_AGENT_PROVIDERS = {
-  jules: {
-    id: "jules",
-    alias: "jules",
-    name: "Jules",
-    icon: "engineering",
-    color: "#EAB308",
-    textIcon: "JU",
-    website: "https://jules.google.com",
-  },
-  devin: {
-    id: "devin",
-    alias: "devin",
-    name: "Devin",
-    icon: "smart_toy",
-    color: "#2563EB",
-    textIcon: "DV",
-    website: "https://devin.ai",
-  },
-  "codex-cloud": {
-    id: "codex-cloud",
-    alias: "codex-cloud",
-    name: "Codex Cloud",
-    icon: "code",
-    color: "#10B981",
-    textIcon: "CX",
-    website: "https://chatgpt.com/codex",
-  },
-};
-
 // ── System Providers (virtual, not user-connectable) ──────────────────────────
 export const SYSTEM_PROVIDERS = {
   auto: {
@@ -1955,19 +1924,6 @@ export const SYSTEM_PROVIDERS = {
     textIcon: "Auto",
     systemOnly: true,
     description: "Zero-config auto-routing with LKGP across all connected providers",
-  },
-};
-
-// Cloud Agent Providers
-export const CLOUD_AGENT_PROVIDERS = {
-  jules: { id: "jules", alias: "jules", name: "Jules AI", icon: "smart_toy", color: "#6366F1" },
-  devin: { id: "devin", alias: "devin", name: "Devin AI", icon: "auto_fix_high", color: "#10B981" },
-  "codex-cloud": {
-    id: "codex-cloud",
-    alias: "codex-cloud",
-    name: "Codex Cloud",
-    icon: "cloud",
-    color: "#3B82F6",
   },
 };
 

--- a/tests/unit/model-cross-proxy-compat.test.ts
+++ b/tests/unit/model-cross-proxy-compat.test.ts
@@ -50,3 +50,17 @@ test("explicit provider routes can still normalize cross-proxy model dialects", 
     extendedContext: false,
   });
 });
+
+test("Kiro Claude Code-style model aliases resolve without polluting the visible catalog", async () => {
+  assert.deepEqual(await getModelInfoCore("kr/claude-opus-4-7", {}), {
+    provider: "kiro",
+    model: "claude-opus-4.7",
+    extendedContext: false,
+  });
+
+  assert.deepEqual(await getModelInfoCore("kiro/claude-sonnet-4-6", {}), {
+    provider: "kiro",
+    model: "claude-sonnet-4.6",
+    extendedContext: false,
+  });
+});

--- a/tests/unit/provider-models-config.test.ts
+++ b/tests/unit/provider-models-config.test.ts
@@ -84,4 +84,7 @@ test("Kiro registry exposes the current CLI model lineup with context windows", 
   assert.equal(byId.get("claude-opus-4.7")?.contextLength, undefined); // Uses default
   assert.ok(byId.has("claude-sonnet-4.6"));
   assert.ok(byId.has("claude-haiku-4.5"));
+  assert.equal(byId.has("claude-opus-4-7"), false);
+  assert.equal(byId.has("claude-sonnet-4-6"), false);
+  assert.equal(byId.has("claude-haiku-4-5"), false);
 });


### PR DESCRIPTION
## Summary

Fix this error when try turn on server.

[FATAL] Failed to start Next custom server: Error [ChunkLoadError]: An error occurred while loading instrumentation hook: Failed to load chunk server/chunks/src_shared_0swknjv._.js from module [project]/open-sse/index.ts [instrumentation] (ecmascript, async loader)
    at <unknown> (.next/dev/server/chunks/_12gj5b5._.js:36:40)
    at Array.map (<anonymous>)
    at <unknown> (.next/dev/server/chunks/_12gj5b5._.js:36:3)
    at registerNodejs (file:/Users/backryun/OmniRoute/src/instrumentation-node.ts:73:3)
    at Module.register (file:/Users/backryun/OmniRoute/src/instrumentation.ts:17:11)
    at async start (scripts/run-next.mjs:51:3)
  71 | export async function registerNodejs(): Promise<void> {
  72 |   // Initialize proxy fetch patch FIRST (before any HTTP requests)
> 73 |   await import("index.ts");
     |   ^
  74 |   console.log("[STARTUP] Global fetch proxy patch initialized");
  75 |
  76 |   await ensureSecrets(); {
  [cause]: SyntaxError: Identifier 'CLOUD_AGENT_PROVIDERS' has already been declared
      at <unknown> (file:/Users/backryun/OmniRoute/src/shared/constants/providers.ts:1917:8)
      at <unknown> (.next/dev/server/chunks/_12gj5b5._.js:36:40)
      at Array.map (<anonymous>)
      at <unknown> (.next/dev/server/chunks/_12gj5b5._.js:36:3)
      at registerNodejs (file:/Users/backryun/OmniRoute/src/instrumentation-node.ts:73:3)
      at Module.register (file:/Users/backryun/OmniRoute/src/instrumentation.ts:17:11)
      at async start (scripts/run-next.mjs:51:3)
    1915 |
    1916 | // ── Cloud Agent Providers ───────────────────────────────────────────────────
  > 1917 | export const CLOUD_AGENT_PROVIDERS = {
         |        ^
    1918 |   jules: {
    1919 |     id: "jules",
    1920 |     alias: "jules",
}