### PR TITLE
fix(kiro): avoid treating high-traffic 429s as quota exhaustion

### DIFF
--- a/open-sse/services/accountFallback.ts
+++ b/open-sse/services/accountFallback.ts
@@ -458,8 +458,14 @@ export function lockModelIfPerModelQuota(
 export function shouldMarkAccountExhaustedFrom429(
   provider: string | null | undefined,
   model: string | null | undefined = null,
-  connectionPassthroughModels?: boolean
+  connectionPassthroughModels?: boolean,
+  failureKind?: FailureKind
 ): boolean {
+  // A plain 429 means transient rate limiting / high traffic for many OAuth providers.
+  // Only connection-poison the quota cache when the upstream body explicitly says
+  // the long-window quota is exhausted; otherwise fallback should try another account
+  // without making this one look quota-depleted for 5 minutes.
+  if (failureKind === "rate_limit" || failureKind === "transient") return false;
   return (
     shouldPreserveQuotaSignalsFor429(provider) &&
     !hasPerModelQuota(provider, model, connectionPassthroughModels)

--- a/src/sse/handlers/chat.ts
+++ b/src/sse/handlers/chat.ts
@@ -1064,15 +1064,18 @@ async function handleSingleModelChat(
         dailyQuotaExhausted = true;
       }
 
-      // 7. Mark account as quota-exhausted on 429 response (non-daily-quota errors)
-      // For providers that route quota/cooldown at model scope, a 429 on one model
-      // does not mean the whole connection is exhausted.
-      // Daily quota errors are handled above; only process regular rate_limit here
+      // 7. Mark account as quota-exhausted only for explicit long-window quota signals.
+      // A plain 429/high-traffic response should trigger fallback/cooldown, not poison
+      // quotaCache as exhausted for 5 minutes while usage quota may still be available.
       if (!dailyQuotaExhausted) {
         const passthroughModels = credentials.providerSpecificData?.passthroughModels;
+        const failureKind =
+          result.status === 429
+            ? classify429FromError({ status: result.status, message: errorStr })
+            : undefined;
         if (
           result.status === 429 &&
-          shouldMarkAccountExhaustedFrom429(provider, model, passthroughModels)
+          shouldMarkAccountExhaustedFrom429(provider, model, passthroughModels, failureKind)
         ) {
           markAccountExhaustedFrom429(credentials.connectionId, provider);
         }

--- a/tests/unit/account-fallback-service.test.ts
+++ b/tests/unit/account-fallback-service.test.ts
@@ -295,6 +295,21 @@ test("shouldMarkAccountExhaustedFrom429 skips connection poisoning for compatibl
   assert.equal(shouldMarkAccountExhaustedFrom429("claude", "claude-sonnet-4-6"), true);
 });
 
+test("shouldMarkAccountExhaustedFrom429 does not poison quota cache for transient 429s", () => {
+  assert.equal(
+    shouldMarkAccountExhaustedFrom429("kiro", "claude-opus-4.7", undefined, "rate_limit"),
+    false
+  );
+  assert.equal(
+    shouldMarkAccountExhaustedFrom429("kiro", "claude-opus-4.7", undefined, "transient"),
+    false
+  );
+  assert.equal(
+    shouldMarkAccountExhaustedFrom429("kiro", "claude-opus-4.7", undefined, "quota_exhausted"),
+    true
+  );
+});
+
 test("hasPerModelQuota returns true for GitHub Copilot provider (#1624)", () => {
   assert.equal(hasPerModelQuota("github"), true);
   assert.equal(hasPerModelQuota("github", "gpt-5.1-codex-max"), true);

--- a/tests/unit/classify429.test.ts
+++ b/tests/unit/classify429.test.ts
@@ -66,6 +66,13 @@ test("classify429: 429 without quota keyword returns 'rate_limit'", () => {
     }),
     "rate_limit"
   );
+  assert.equal(
+    classify429({
+      status: 429,
+      body: "I am experiencing high traffic, please try again shortly.",
+    }),
+    "rate_limit"
+  );
 });
 
 test("looksLikeQuotaExhausted: detects all known keyword variants", () => {


### PR DESCRIPTION
## Summary

- Stop treating transient Kiro 429 responses as quota exhaustion. Upstream messages like `[429]: I am experiencing high traffic, please try again shortly.` were being poisoned into the in-memory quota cache as `exhausted`, which then caused the preflight to report `All kiro accounts have exhausted their quota (reset after 5m)` for every connection on the provider even when real usage quota was still available.
- The chat handler now runs the 429 body through the existing `classify429FromError` helper and only poisons `quotaCache` when the classifier returns `quota_exhausted`. `rate_limit` / `transient` 429s fall through to normal fallback/cooldown.

## Related Issues

- Closes #
- Related to #

## Validation

- [x] `npm run lint`
- [x] `npm run test:unit` (scoped: `tests/unit/classify429.test.ts tests/unit/account-fallback-service.test.ts` — 51/51 pass)
- [ ] `npm run test:coverage`
- [ ] Coverage is still `>= 60%` for statements, lines, functions, and branches
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below

End-to-end sanity check of `classify429FromError` against the real Kiro error strings captured in production logs:

```
kiro high traffic       => rate_limit        (no poison)
kiro raw                => rate_limit        (no poison)
explicit quota exceeded => quota_exhausted   (poison)
daily limit             => quota_exhausted   (poison)
out of credits          => quota_exhausted   (poison)
unknown 429             => rate_limit        (default safe)
non-429                 => transient         (no poison)
no status               => undefined         (status guard in handler still blocks)
```

## Tests Added Or Updated

- `tests/unit/classify429.test.ts`
  - `classify429: 429 without quota keyword returns 'rate_limit'` — extended with the exact Kiro body: `"I am experiencing high traffic, please try again shortly."`.
- `tests/unit/account-fallback-service.test.ts`
  - `shouldMarkAccountExhaustedFrom429 does not poison quota cache for transient 429s` — covers `rate_limit`, `transient`, and `quota_exhausted` kinds.

## Coverage Notes

- Change is confined to:
  - `src/sse/handlers/chat.ts` (429 branch of single-model chat only).
  - `open-sse/services/accountFallback.ts` (`shouldMarkAccountExhaustedFrom429` signature).
- The new and preexisting unit tests exercise every kind that `shouldMarkAccountExhaustedFrom429` inspects. Backward compatibility of the existing 3-arg call sites is preserved and still asserted by `shouldMarkAccountExhaustedFrom429 skips connection poisoning for compatible providers`.

## Reviewer Notes

### Root cause

- `src/sse/handlers/chat.ts` (pre-fix, around line 1071) called `markAccountExhaustedFrom429(connectionId, provider)` on **any** 429 whenever `shouldMarkAccountExhaustedFrom429(...)` returned `true`. For OAuth providers without per-model quota (Kiro included) that returned `true` unconditionally.
- `markAccountExhaustedFrom429` writes `{ exhausted: true, nextResetAt: null }` into `quotaCache` for 5 minutes.
- `src/sse/services/auth.ts` (`isAccountQuotaExhausted`) then filters every policy-eligible connection out of the selection pool and produces the `All ${provider} accounts have exhausted their quota (reset after 5m)` message.
- Classifier `src/shared/utils/classify429.ts` already distinguishes `rate_limit` vs `quota_exhausted` by scanning the body for explicit long-window keywords; it was only being used by the circuit breaker, not by the quota-cache poisoning branch.

### Fix

- `open-sse/services/accountFallback.ts`
  - `shouldMarkAccountExhaustedFrom429(provider, model, connectionPassthroughModels, failureKind?)` now returns `false` when `failureKind` is `"rate_limit"` or `"transient"`. `undefined` (no kind supplied) keeps the old behavior for any legacy caller.
- `src/sse/handlers/chat.ts`
  - After a 429 response, derive `failureKind = classify429FromError({ status: result.status, message: errorStr })` and pass it into `shouldMarkAccountExhaustedFrom429(...)`.
  - `markAccountExhaustedFrom429` is still called only when both conditions hold: `result.status === 429` and `shouldMarkAccountExhaustedFrom429(...)` returns `true`.
- No changes to:
  - `quotaCache.ts` write helpers, `EXHAUSTED_TTL_MS`, or the preflight message text.
  - `markAccountUnavailable()` (DB-level `rateLimitedUntil`) or `recordModelLockoutFailure()` — those are unchanged and continue to apply normal cooldown.
  - Circuit breaker classification — it already understood `rate_limit` vs `quota_exhausted`.
  - Daily-quota branch (`isDailyQuotaExhausted` → `recordModelLockoutFailure`) — still runs first and unchanged.

### Confirmed non-regressions

- `markAccountExhaustedFrom429` has exactly one call site in source (`src/sse/handlers/chat.ts`), so this is the only path that needed guarding.
- 402/403 paths do not write to `quotaCache`; they flow through `markAccountUnavailable` / model lockouts.
- `classify429FromError` never returns `undefined` for a known-number `status === 429` with a non-empty body, so the handler's status guard (`result.status === 429`) remains authoritative.

### Residual risk / follow-ups

- Kiro accounts already poisoned before this change will still wait up to `EXHAUSTED_TTL_MS` (5 min) for the stale `quotaCache` entry to clear. No manual intervention required; acceptable.
- `QUOTA_PATTERNS` in `classify429.ts` uses substring regexes. A hypothetical transient message containing `"quota"` + `"exceed"` could still be misclassified as `quota_exhausted`. Not observed in production Kiro logs; worth a narrow follow-up if new false positives appear.

### Files touched

- `src/sse/handlers/chat.ts`
- `open-sse/services/accountFallback.ts`
- `tests/unit/account-fallback-service.test.ts`
- `tests/unit/classify429.test.ts`

### No changes to

- Response translators or streaming.
- Credentials / OAuth refresh.
- Migrations, env vars, or config.
- Dashboard endpoints.
