### PR TITLE
fix(openai-responses): propagate include so chat clients stream reasoning summaries

### DIFF
--- a/open-sse/translator/request/openai-responses.ts
+++ b/open-sse/translator/request/openai-responses.ts
@@ -568,6 +568,14 @@ export function openaiToOpenAIResponsesRequest(
       result.reasoning = { effort };
     }
   }
+
+  // Propagate Responses-API-only fields when a chat client sent them.
+  // Without this, e.g. `include: ["reasoning.encrypted_content"]` is lost on
+  // the way upstream and Codex returns an empty reasoning summary, so clients
+  // (OpenCode, Cursor, etc.) see no thinking stream.
+  if (Array.isArray(root.include) && root.include.length > 0) {
+    result.include = root.include;
+  }
   if (storeEnabled) {
     if (root[RESPONSES_STORE_MARKER] !== undefined) {
       result.store = root[RESPONSES_STORE_MARKER];

--- a/tests/unit/translator-openai-responses-req.test.ts
+++ b/tests/unit/translator-openai-responses-req.test.ts
@@ -297,6 +297,35 @@ test("Chat -> Responses preserves explicit reasoning objects", () => {
   assert.equal((result as any).store, false);
 });
 
+test("Chat -> Responses propagates include so upstream streams the reasoning summary", () => {
+  const result = openaiToOpenAIResponsesRequest(
+    "gpt-5.3-codex-spark",
+    {
+      messages: [{ role: "user", content: "Hello" }],
+      reasoning: { effort: "high", summary: "auto" },
+      include: ["reasoning.encrypted_content"],
+    },
+    false,
+    null
+  );
+
+  assert.deepEqual((result as any).include, ["reasoning.encrypted_content"]);
+});
+
+test("Chat -> Responses does not inject include when caller did not set one", () => {
+  const result = openaiToOpenAIResponsesRequest(
+    "gpt-5.3-codex-spark",
+    {
+      messages: [{ role: "user", content: "Hello" }],
+      reasoning: { effort: "high" },
+    },
+    false,
+    null
+  );
+
+  assert.equal((result as any).include, undefined);
+});
+
 test("Chat -> Responses maps reasoning_effort into Responses reasoning", () => {
   const result = openaiToOpenAIResponsesRequest(
     "gpt-5.3-codex-spark",


### PR DESCRIPTION
## Summary

- Propagate the Chat Completions `include` array into the Chat → Responses translator so upstream Codex Responses API streams the reasoning summary to chat clients.
- Without this, clients like OpenCode (`@ai-sdk/openai-compatible`) that send `reasoning: { effort: "high", summary: "auto" }` and `include: ["reasoning.encrypted_content"]` via `/v1/chat/completions` silently lose `include`, upstream returns `summary: []`, and no `reasoning_summary_text.*` events are emitted. After the fix, the thinking panel populates again.

## Related Issues

- Closes #
- Related to #

## Validation

- [x] `npm run lint`
- [x] `npm run test:unit` (scoped: `tests/unit/translator-openai-responses-req.test.ts` — 15/15 pass)
- [ ] `npm run test:coverage`
- [ ] Coverage is still `>= 60%` for statements, lines, functions, and branches
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below

```
/v1/responses            + include=[reasoning.encrypted_content]  => reasoning_summary_text.delta events present, summary populated
/v1/chat/completions     + include=[reasoning.encrypted_content]  BEFORE fix  => no reasoning_content / reasoning.summary chunks
/v1/chat/completions     + include=[reasoning.encrypted_content]  AFTER fix   => upstream emits reasoning_summary_text.delta, chat translator forwards as reasoning_content/reasoning.summary chunks
```

## Tests Added Or Updated

- `tests/unit/translator-openai-responses-req.test.ts`
  - `Chat -> Responses propagates include so upstream streams the reasoning summary` (new)
  - `Chat -> Responses does not inject include when caller did not set one` (new)

## Coverage Notes

- Change is confined to `openaiToOpenAIResponsesRequest` in `open-sse/translator/request/openai-responses.ts`.
- The two new tests cover both the forward and the no-op paths. The existing reasoning/pass-through tests in the same file remain green.

## Reviewer Notes

### Root cause

- Chat-format clients (OpenCode, Cursor, Droid via the AI SDK, etc.) hit `/v1/chat/completions`.
- In OmniRoute, `openaiToOpenAIResponsesRequest` converts that to the Responses API shape for Codex. It propagates `reasoning`, `prompt_cache_key`, `session_id`, `previous_response_id`, `temperature`, `top_p`, `max_output_tokens`, and others — but **not** `include`.
- Codex Responses API only streams `response.reasoning_summary_text.*` events when the request carries `include: ["reasoning.encrypted_content"]`. Without that field, the upstream response contains `reasoning: { effort, summary }` in the final object but `summary: []` and no incremental events. The chat-format response therefore has no `reasoning_content` / `reasoning.summary` chunks, so client UIs render no thinking.
- Confirmed behavior by curling the live service with and without `include` on both `/v1/responses` and `/v1/chat/completions` (see Validation above).

### Fix

- `open-sse/translator/request/openai-responses.ts` — `openaiToOpenAIResponsesRequest` now forwards `root.include` to `result.include` when the caller provided a non-empty array. Zero behavior change when the caller omits `include`; purely additive.
- The reverse translator (Responses → Chat) still strips `include` because that field has no meaning on the Chat Completions wire format.
- No changes to response translation or to any other provider.

### Confirmed non-regressions

- Existing Chat → Responses tests (messages, tool calls, tool outputs, max_tokens mapping, reasoning_effort normalization, round-trip with `store`, etc.) still pass.
- Reverse Responses → Chat translator and reasoning SSE event remapping in `open-sse/translator/response/openai-responses.ts` are untouched.
- No config, migration, credential, or env changes.

### Residual risk / follow-ups

- Some future `include` entries may be Responses-API-only (e.g. `file_search_call.results`). Forwarding them verbatim is correct today; if upstream ever rejects an unknown include key, we can allowlist.
- OpenCode users were already setting this field via `options.include`; no client-side change is required.

### Files touched

- `open-sse/translator/request/openai-responses.ts`
- `tests/unit/translator-openai-responses-req.test.ts`

### No changes to

- Response translators, streaming, or SSE shaping.
- Credentials / OAuth refresh.
- Migrations, env vars, or config.
- Dashboard endpoints.
