### PR TITLE
fix(openai-responses): emit reasoning summary as delta.reasoning_content

### DIFF
--- a/open-sse/translator/response/openai-responses.ts
+++ b/open-sse/translator/response/openai-responses.ts
@@ -823,13 +823,18 @@ export function openaiResponsesToOpenAIResponse(chunk, state) {
     };
   }
 
-  // Handle true reasoning summary ("Thought for 15s")
+  // Handle true reasoning summary ("Thought for 15s").
+  // Emit as `delta.reasoning_content` — matches the shape used by the
+  // `reasoning_content_text.delta` branch above and is what Chat clients
+  // (OpenCode, Claude Code, Cursor, etc.) actually render in their thinking
+  // panel. A nested `delta.reasoning.summary` object is swallowed by most
+  // stream mergers and never reaches the user.
   if (eventType === "response.reasoning_summary_text.delta") {
     const reasoningDelta = data.delta || "";
     if (!reasoningDelta) return null;
     const reasoningDeltaShape = state.copilotCompatibleReasoning
       ? { reasoning_text: reasoningDelta }
-      : { reasoning: { summary: reasoningDelta } };
+      : { reasoning_content: reasoningDelta };
     return {
       id: state.chatId,
       object: "chat.completion.chunk",

--- a/tests/unit/responses-translation-fixes.test.ts
+++ b/tests/unit/responses-translation-fixes.test.ts
@@ -406,7 +406,7 @@ test("Responses→Chat streaming: reasoning delta emits reasoning_content in Cha
   };
   const result = openaiResponsesToOpenAIResponse(chunk, state);
   assert.ok(result, "should return a chunk");
-  assert.equal(result.choices[0].delta.reasoning.summary, "thinking step...");
+  assert.equal(result.choices[0].delta.reasoning_content, "thinking step...");
 });
 
 test("Responses→Chat streaming: Copilot mode emits reasoning_text for summary deltas", () => {

--- a/tests/unit/translator-resp-openai-responses.test.ts
+++ b/tests/unit/translator-resp-openai-responses.test.ts
@@ -289,7 +289,7 @@ test("Responses -> OpenAI: tool-call delta, reasoning delta and completed usage 
 
   assert.equal(added.choices[0].delta.tool_calls[0].function.name, "weather");
   assert.equal(args.choices[0].delta.tool_calls[0].function.arguments, '{"city":"SP"}');
-  assert.equal(reasoning.choices[0].delta.reasoning.summary, "Need weather info.");
+  assert.equal(reasoning.choices[0].delta.reasoning_content, "Need weather info.");
   assert.equal(completed.choices[0].finish_reason, "tool_calls");
   assert.equal((completed as any).usage.prompt_tokens, 8);
   assert.equal((completed as any).usage.completion_tokens, 2);


### PR DESCRIPTION
## Summary

- Emit the Codex "thinking" stream as `delta.reasoning_content` (flat) instead of `delta.reasoning.summary` (nested) when translating Responses SSE back into Chat Completions chunks.
- The nested shape was not rendered by Chat-Completions clients (OpenCode, Claude Code, Cursor, etc.); switching to the flat field that every other reasoning branch in OmniRoute already uses makes the thinking panel populate again.

## Related Issues

- Closes #
- Related to #2154 (follow-up: #2154 made the Chat → Responses translator forward `include`, so upstream now streams `response.reasoning_summary_text.delta`; this PR fixes the response-side emit shape so those events actually reach Chat Completions clients.)

## Validation

- [x] `npm run lint`
- [x] `npm run test:unit` (scoped: 76/76 pass — `tests/unit/translator-resp-openai-responses.test.ts`, `tests/unit/responses-translation-fixes.test.ts`, `tests/unit/responses-transformer.test.ts`, `tests/unit/stream-utilities.test.ts`, `tests/unit/stream-strip-responses-lifecycle-echo.test.ts`, `tests/unit/translator-openai-responses-req.test.ts`)
- [ ] `npm run test:coverage`
- [ ] Coverage is still `>= 60%` for statements, lines, functions, and branches
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below

End-to-end verification against live Codex via OmniRoute (`/v1/chat/completions`, provider `cx`, model `gpt-5.3-codex`):

```
upstream response.reasoning_summary_text.delta events    : 182 observed (per call_log artifact)
before patch  -> client chat chunk shape                 : delta.reasoning.summary (swallowed by clients, thinking not rendered)
after  patch  -> client chat chunk shape                 : delta.reasoning_content (rendered by OpenCode/Claude Code/Cursor)
```

## Tests Added Or Updated

- `tests/unit/translator-resp-openai-responses.test.ts`
  - Updated `Responses -> OpenAI: tool-call delta, reasoning delta and completed usage are normalized` to assert `delta.reasoning_content` instead of `delta.reasoning.summary`.
- `tests/unit/responses-translation-fixes.test.ts`
  - Updated `Responses→Chat streaming: reasoning delta emits reasoning_content in Chat chunk` to assert `delta.reasoning_content`.

## Coverage Notes

- Change is confined to `openaiResponsesToOpenAIResponse` in `open-sse/translator/response/openai-responses.ts`, specifically the `response.reasoning_summary_text.delta` branch.
- Copilot-compatibility path (`state.copilotCompatibleReasoning` → `delta.reasoning_text`) is preserved unchanged.
- All sibling branches in the same file (`reasoning_content_text.delta`, `reasoning_text.delta`) already used the flat `reasoning_content` shape; this change aligns the summary branch with them.

## Reviewer Notes

### Root cause

- Codex (OpenAI Responses API) streams reasoning summaries as `response.reasoning_summary_text.delta` events once the request carries `include: ["reasoning.encrypted_content"]`.
- OmniRoute's `openaiResponsesToOpenAIResponse` branch for that event used to emit a nested `delta: { reasoning: { summary: reasoningDelta } }` shape.
- Chat-Completions clients and OmniRoute's own downstream reasoning consumers (e.g. `services/reasoningCache.ts`, all per-provider executors) read `message.reasoning_content` / `delta.reasoning_content`. The nested shape is therefore silently dropped by the stream merger and never rendered by the client.
- Confirmed by inspecting the pipeline artifact on a live OmniRoute deployment: upstream emitted 182 `reasoning_summary_text.delta` events for a single request, but the client response chunks contained only `content`, no `reasoning_content` / `reasoning.summary`.

### Fix

- `open-sse/translator/response/openai-responses.ts` — in the `response.reasoning_summary_text.delta` branch, emit `delta.reasoning_content` (flat string) to match the other reasoning branches and the shape every client/consumer already expects.
- Copilot-compatibility mode (`reasoning_text`) is left alone to avoid breaking that path.

### Confirmed non-regressions

- No consumer in the repo reads `delta.reasoning.summary`:
  - `sseParser.ts` accumulates `reasoning_summary_text.delta` into Responses-API output items (not Chat deltas).
  - `utils/stream.ts` only tracks whether a reasoning event was seen, without relying on its shape.
  - `transformer/responsesTransformer.ts` emits Responses API events (upstream format), which is the inverse direction.
  - `services/reasoningCache.ts` and per-provider executors already use `reasoning_content`.
- Existing translator tests plus two updated tests all pass (76/76 in the scoped suite).

### Residual risk / follow-ups

- Any external client that was parsing the old nested shape would stop seeing thinking chunks. No such consumer was found in-repo; the flat `reasoning_content` is the OpenAI-standard field and is already produced by every other reasoning code path in OmniRoute.

### Files touched

- `open-sse/translator/response/openai-responses.ts`
- `tests/unit/responses-translation-fixes.test.ts`
- `tests/unit/translator-resp-openai-responses.test.ts`

### No changes to

- Request-side translators or executors.
- Credentials / OAuth refresh.
- Migrations, env vars, or config.
- Dashboard endpoints.
