### PR TITLE
fix(cliproxyapi): preserve bare metadata.user_id on Anthropic-shape bodies

### DIFF
--- a/open-sse/executors/cliproxyapi.ts
+++ b/open-sse/executors/cliproxyapi.ts
@@ -236,7 +236,27 @@ export class CliproxyapiExecutor extends BaseExecutor {
       delete transformed.client_info;
       delete transformed.prompt_cache_key;
       delete transformed.safety_identifier;
-      delete transformed.metadata;
+
+      // Conditional metadata strip. Preserve a bare `{user_id: <string>}`
+      // shape so a CPA-side patch can use the inbound user_id as a
+      // deterministic seed for the cloaked Claude-Code-shaped user_id
+      // (current CPA generates a fresh random UUIDv4 per call → no
+      // Anthropic prompt-cache reuse across calls from the same BYOK
+      // user ; passing through a stable Capy `metadata.user_id` lets CPA
+      // derive a stable `account_uuid`/`session_uuid` triplet from it).
+      //
+      // Strip metadata entirely if it carries any field beyond `user_id`
+      // (Capy's SDK can add `session_id`, `client_info`, etc., which
+      // Anthropic rejects).
+      const md = transformed.metadata;
+      if (md && typeof md === "object") {
+        const mdRec = md as Record<string, unknown>;
+        const isBareUserId = typeof mdRec.user_id === "string" && Object.keys(mdRec).length === 1;
+        if (!isBareUserId) {
+          delete transformed.metadata;
+        }
+        // bare {user_id: <string>} shape : keep as-is.
+      }
 
       // Conditional thinking strip: preserve Anthropic-valid shapes
       // ({type:"enabled"|"disabled", budget_tokens:N}) that applyThinkingBudget

--- a/tests/unit/cliproxyapi-executor.test.ts
+++ b/tests/unit/cliproxyapi-executor.test.ts
@@ -356,15 +356,48 @@ describe("CliproxyapiExecutor", () => {
       assert.equal(result.output_config, undefined);
     });
 
-    it("strips metadata", () => {
+    it("preserves bare metadata {user_id} as a CPA cloak-seed", () => {
       const exec = new CliproxyapiExecutor();
       const result = exec.transformRequest(
         "claude-opus-4-7",
-        anthropicBody({ metadata: { user_id: "abc" } }),
+        anthropicBody({ metadata: { user_id: "user_3DGta5gzamzAUr57ZYZEtmc6lHX" } }),
+        true,
+        {}
+      );
+      assert.deepEqual(result.metadata, {
+        user_id: "user_3DGta5gzamzAUr57ZYZEtmc6lHX",
+      });
+    });
+
+    it("strips metadata when it carries extras beyond user_id", () => {
+      const exec = new CliproxyapiExecutor();
+      const result = exec.transformRequest(
+        "claude-opus-4-7",
+        anthropicBody({
+          metadata: { user_id: "abc", session_id: "s1", client_info: { name: "Capy" } },
+        }),
         true,
         {}
       );
       assert.equal(result.metadata, undefined);
+    });
+
+    it("strips metadata when user_id is missing or non-string", () => {
+      const exec = new CliproxyapiExecutor();
+      const result1 = exec.transformRequest(
+        "claude-opus-4-7",
+        anthropicBody({ metadata: { session_id: "s1" } }),
+        true,
+        {}
+      );
+      assert.equal(result1.metadata, undefined);
+      const result2 = exec.transformRequest(
+        "claude-opus-4-7",
+        anthropicBody({ metadata: { user_id: 42 } }),
+        true,
+        {}
+      );
+      assert.equal(result2.metadata, undefined);
     });
 
     it("strips client_info", () => {


### PR DESCRIPTION
## Summary

#2165 stripped `metadata` unconditionally on Anthropic-shape bodies routed to CPA's `/v1/messages` (alongside `client_info`, `prompt_cache_key`, `safety_identifier`, etc.). That removed a useful signal that some BYOK clients (notably Capy) provide : a stable per-user `metadata.user_id` like `user_3DGta5gzamzAUr57ZYZEtmc6lHX`.

Stripping it means CPA's outbound cloak (which generates a fresh random UUID per call via `uuid.New()`) has no way to make Anthropic see the same `account_uuid` / `session_uuid` across calls from the same end user. No prompt-cache reuse, no per-user session continuity.

This PR preserves a **bare** `{user_id: <string>}` metadata shape only. Anything else under `metadata` (which Capy's SDK sometimes adds — `session_id`, `client_info`, etc.) is still stripped because Anthropic rejects it.

## Related Issues

- Closes #
- Follow-up to #2165 (Capy extras strip on Anthropic-shape bodies)

## Motivation

CPA source : [`router-for-me/CLIProxyAPI`](https://github.com/router-for-me/CLIProxyAPI), file `internal/runtime/executor/helps/cloak_utils.go`. The `generateFakeUserID` function builds a Claude Code-shaped identifier `user_<64hex>_account_<uuidv4>_session_<uuidv4>` where **both UUIDs are produced by `uuid.New()` per call** — no caching, no tie-back to the inbound BYOK request, no propagation of the OAuth account UUID captured during the auth handshake (which CPA's `internal/auth/claude/anthropic_auth.go` parses but doesn't persist into `ClaudeTokenData`).

Net effect from Anthropic's perspective : every call from the same Capy user looks like a different identity. The Anthropic prompt cache, which is keyed on account + prefix, never hits across calls in the same conversation.

A small CPA-side patch can derive a deterministic CC-shaped triplet from any seed string :

```go
func DeterministicFakeUserID(seed string) string {
    h := sha256.Sum256([]byte("cpa-cloak-v1|" + seed))
    return "user_" + hex.EncodeToString(h[:]) +
           "_account_" + uuid.NewSHA1(uuid.NameSpaceOID, []byte("a|"+seed)).String() +
           "_session_" + uuid.NewSHA1(uuid.NameSpaceOID, []byte("s|"+seed)).String()
}
```

…and use it whenever the inbound `metadata.user_id` is non-empty but doesn't match CPA's strict CC regex. That patch is in flight on the CPA side ; this PR is the OmniRoute-side prerequisite so the seed actually arrives.

**Today, with stock CPA**, this PR is a no-op (CPA still overwrites the inbound user_id). **Once the CPA patch ships**, the same Capy `user_3DGta5gz…` gets a stable Anthropic identity, restoring prompt cache hits and (possibly) clearing the `^mcp_[^_]` recognition gate without any other rewrite.

## Changes

`open-sse/executors/cliproxyapi.ts` :

- Replace `delete transformed.metadata` (unconditional) with a conditional check :
  - Keep `metadata` if it's exactly `{ user_id: <string> }` (one key, string value).
  - Strip it in every other case (no `user_id`, non-string `user_id`, extra fields alongside `user_id`).
- Strip order for other Capy extras (`client_info`, `prompt_cache_key`, `safety_identifier`) is unchanged.

## Validation

- [x] `npm run test:unit` — `tests/unit/cliproxyapi-executor.test.ts` — 39/39 pass (3 new tests : preserve bare shape, strip when extras present, strip when user_id missing or non-string)
- [x] Existing test \"strips metadata\" rewritten to assert the new conditional behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)