### PR TITLE
fix(deepseek): preserve reasoning_content through full pipeline for DeepSeek V4 models

### DIFF
--- a/open-sse/handlers/responseSanitizer.ts
+++ b/open-sse/handlers/responseSanitizer.ts
@@ -27,8 +27,10 @@ const ALLOWED_RESPONSES_USAGE_FIELDS = new Set([
 
 type JsonRecord = Record<string, unknown>;
 
+const DEEPSEEK_V4_SANITIZER_MODEL_PATTERN = /deepseek[-/]v4/i;
+
 function isDeepSeekV4Model(model: unknown): boolean {
-  return typeof model === "string" && /deepseek[-/]v4/i.test(model);
+  return typeof model === "string" && DEEPSEEK_V4_SANITIZER_MODEL_PATTERN.test(model);
 }
 
 function toRecord(value: unknown): JsonRecord | null {

--- a/open-sse/translator/index.ts
+++ b/open-sse/translator/index.ts
@@ -111,7 +111,7 @@ function isDeepSeekReplayTarget(provider: unknown, model: unknown): boolean {
   const normalizedModel = String(model ?? "")
     .trim()
     .toLowerCase();
-  return normalizedProvider === "deepseek" || normalizedModel.includes("deepseek");
+  return normalizedProvider === "deepseek" || /(^|\/)deepseek/i.test(normalizedModel);
 }
 
 /** @param options.normalizeToolCallId - When true, use 9-char tool call ids (e.g. Mistral); when false, leave ids as-is */


### PR DESCRIPTION

## Summary

Rebased against upstream release/v3.8.0 (bbf3ba0). The 4 core DeepSeek V4 reasoning replay commits from this PR were already cherry-picked by upstream, so only the PR review feedback changes remain.

## Remaining Changes (2 files, 4 insertions, 2 deletions)

### 1. responseSanitizer.ts — Extract inline regex to constant
- Extracted `/deepseek[-/]v4/i` inline regex to `DEEPSEEK_V4_SANITIZER_MODEL_PATTERN` constant
- Improves readability and makes the detection intent explicit

### 2. translator/index.ts — Boundary-aware DeepSeek detection
- Changed `normalizedModel.includes("deepseek")` → `/(^|\/)deepseek/i.test(normalizedModel)`
- Prevents false matches on model strings that happen to contain "deepseek" as a substring

## Verification
- `npm run typecheck:core` — clean (1 pre-existing ioredis error unrelated)
- `lsp_diagnostics` — clean on both changed files
- 1 commit (e8268db) on top of upstream/release/v3.8.0