### PR TITLE
fix: align managed model cleanup for imported models

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/[id]/page.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.tsx
@@ -2731,10 +2731,7 @@ export default function ProviderDetailPage() {
         notify.error(detail || t("failedSaveCustomModel"));
         return;
       }
-      await Promise.all([
-        fetchProviderModelMeta().catch(() => {}),
-        fetchAliases().catch(() => {}),
-      ]);
+      await Promise.all([fetchProviderModelMeta().catch(() => {}), fetchAliases().catch(() => {})]);
     } catch {
       notify.error(t("failedSaveCustomModel"));
     } finally {
@@ -2760,10 +2757,7 @@ export default function ProviderDetailPage() {
         notify.error(detail || t("failedSaveCustomModel"));
         return;
       }
-      await Promise.all([
-        fetchProviderModelMeta().catch(() => {}),
-        fetchAliases().catch(() => {}),
-      ]);
+      await Promise.all([fetchProviderModelMeta().catch(() => {}), fetchAliases().catch(() => {})]);
     } catch {
       notify.error(t("failedSaveCustomModel"));
     } finally {
@@ -4277,7 +4271,14 @@ function PassthroughModelsSection({
     }
 
     return rows;
-  }, [availableModels, customModelMap, customModels, isModelHidden, providerAlias, providerAliases]);
+  }, [
+    availableModels,
+    customModelMap,
+    customModels,
+    isModelHidden,
+    providerAlias,
+    providerAliases,
+  ]);
   const filteredModels = allModels.filter((model) =>
     matchesModelCatalogQuery(modelFilter, {
       modelId: model.modelId,
@@ -4376,7 +4377,7 @@ function PassthroughModelsSection({
               isHidden={isHidden}
               copied={copied}
               onCopy={onCopy}
-              onDeleteAlias={alias ? () => onDeleteAlias(alias) : undefined}
+              onDeleteAlias={source === "alias" && alias ? () => onDeleteAlias(alias) : undefined}
               t={t}
               showDeveloperToggle
               effectiveModelNormalize={effectiveModelNormalize}
@@ -5346,7 +5347,13 @@ function CompatibleModelsSection({
               isHidden={isHidden}
               copied={copied}
               onCopy={onCopy}
-              onDeleteAlias={() => handleDeleteModel(modelId, alias)}
+              onDeleteAlias={
+                source === "custom" || source === "manual"
+                  ? () => handleDeleteModel(modelId, alias)
+                  : source === "alias" && alias
+                    ? () => onDeleteAlias(alias)
+                    : undefined
+              }
               t={t}
               showDeveloperToggle={!isAnthropic}
               effectiveModelNormalize={effectiveModelNormalize}

--- a/src/app/api/provider-models/route.ts
+++ b/src/app/api/provider-models/route.ts
@@ -4,6 +4,7 @@ import {
   addCustomModel,
   removeCustomModel,
   replaceCustomModels,
+  deleteSyncedAvailableModelsForProvider,
   updateCustomModel,
   getModelCompatOverrides,
   mergeModelCompatOverride,
@@ -369,9 +370,12 @@ export async function DELETE(request) {
     const all = searchParams.get("all");
     if (all === "true") {
       await replaceCustomModels(provider, [], { allowEmpty: true });
+      const syncedAvailableModelListsRemoved =
+        await deleteSyncedAvailableModelsForProvider(provider);
       const removedAliases = await deleteManagedAvailableModelAliasesForProvider(provider);
       return Response.json({
         cleared: true,
+        syncedAvailableModelListsRemoved,
         aliasChanges: { removed: removedAliases, assigned: [] },
       });
     }

--- a/src/lib/db/models.ts
+++ b/src/lib/db/models.ts
@@ -707,6 +707,22 @@ export async function deleteSyncedAvailableModelsForConnection(
   return getSyncedAvailableModels(providerId);
 }
 
+/**
+ * Delete all synced models for every connection belonging to a provider.
+ * Returns the number of connection-scoped synced model lists removed.
+ */
+export async function deleteSyncedAvailableModelsForProvider(providerId: string): Promise<number> {
+  const db = getDbInstance();
+  const keyPrefix = `${providerId}:`;
+  const result = db
+    .prepare(
+      "DELETE FROM key_value WHERE namespace = 'syncedAvailableModels' AND substr(key, 1, ?) = ?"
+    )
+    .run(keyPrefix.length, keyPrefix);
+  backupDbFile("pre-write");
+  return Number(result.changes || 0);
+}
+
 export async function updateCustomModel(
   providerId: string,
   modelId: string,

--- a/src/lib/localDb.ts
+++ b/src/lib/localDb.ts
@@ -65,6 +65,7 @@ export {
   getAllSyncedAvailableModels,
   replaceSyncedAvailableModelsForConnection,
   deleteSyncedAvailableModelsForConnection,
+  deleteSyncedAvailableModelsForProvider,
 } from "./db/models";
 
 export type { ModelCompatPerProtocol, ModelCompatPatch, SyncedAvailableModel } from "./db/models";

--- a/tests/unit/managed-model-import.test.ts
+++ b/tests/unit/managed-model-import.test.ts
@@ -64,3 +64,23 @@ test("merge mode builds aliases from discovered models without pruning missing p
   assert.equal(aliases["model-a"], undefined);
   assert.equal(aliases["model-b"], "openrouter/shared/model-b");
 });
+
+test("provider-level synced model deletion removes only that provider", async () => {
+  await modelsDb.replaceSyncedAvailableModelsForConnection("openrouter", "conn-a", [
+    { id: "shared/model-a", name: "Model A", source: "imported" },
+  ]);
+  await modelsDb.replaceSyncedAvailableModelsForConnection("openrouter", "conn-b", [
+    { id: "shared/model-b", name: "Model B", source: "imported" },
+  ]);
+  await modelsDb.replaceSyncedAvailableModelsForConnection("openai", "conn-a", [
+    { id: "shared/model-c", name: "Model C", source: "imported" },
+  ]);
+
+  const removed = await modelsDb.deleteSyncedAvailableModelsForProvider("openrouter");
+
+  assert.equal(removed, 2);
+  assert.deepEqual(await modelsDb.getSyncedAvailableModels("openrouter"), []);
+  assert.deepEqual(await modelsDb.getSyncedAvailableModels("openai"), [
+    { id: "shared/model-c", name: "Model C", source: "imported" },
+  ]);
+});


### PR DESCRIPTION
## Summary

This PR fixes managed provider model cleanup behavior for imported models.

It includes three related changes:

- Imported and fallback provider models no longer show row-level delete actions in the provider model list.
- `DELETE /api/provider-models?provider=...&all=true` now clears provider-scoped synced available models in addition to custom models and managed aliases.
- Added regression coverage for provider-level synced available model deletion.

## Problem

Imported models are sourced from synced available model lists, not from user-managed custom model records.

Before this change:

- Imported models could show a delete action in the provider UI.
- Clicking delete could report success while the imported model remained visible.
- Clearing all provider models removed custom models and managed aliases, but left synced available models intact.
- As a result, imported models could continue to appear after clearing all models for a provider.

This made the UI behavior misleading and caused provider model cleanup to be incomplete.

## Changes

- Hide row-level delete actions for `imported` and `fallback` model rows.
- Preserve delete behavior for rows that are actually user-managed:
  - `custom` / `manual` models still use provider-model deletion.
  - `alias`-only rows still allow alias-only deletion.
- Add `deleteSyncedAvailableModelsForProvider(providerId)`.
- Update `DELETE /api/provider-models?provider=...&all=true` to clear:
  - custom models
  - synced available model lists
  - managed aliases
- Add a regression test to verify provider-level synced model deletion:
  - removes all synced model lists for the target provider
  - does not remove synced model lists for other providers

## Test Plan

Passed targeted regression test:

```bash
npm exec -- cross-env DISABLE_SQLITE_AUTO_BACKUP=true node --import tsx/esm --test tests/unit/managed-model-import.test.ts
```
Result:
```
# tests 3
# pass 3
# fail 0
```
Also passed during commit hooks:

- prettier --write
- eslint --fix --no-error-on-unmatched-pattern
- docs sync check
- explicit any budget check
- i18n UI coverage check

Not run:

- Full unit test suite
- Full build
- Browser UI verification

