### PR TITLE
fix(providers/command-code): send required stream payload

### DIFF
--- a/open-sse/executors/commandCode.ts
+++ b/open-sse/executors/commandCode.ts
@@ -162,6 +162,7 @@ function buildCommandCodeBody(model: string, body: unknown, stream: boolean): Js
     },
     memory: "",
     taste: "",
+    skills: [],
     permissionMode: "standard",
     params: {
       model,

--- a/open-sse/executors/commandCode.ts
+++ b/open-sse/executors/commandCode.ts
@@ -142,7 +142,7 @@ function clampMaxTokens(value: unknown): number {
   return Math.max(1, Math.min(Math.floor(numeric), MAX_COMMAND_CODE_TOKENS));
 }
 
-function buildCommandCodeBody(model: string, body: unknown, stream: boolean): JsonRecord {
+function buildCommandCodeBody(model: string, body: unknown): JsonRecord {
   const input = isRecord(body) ? body : {};
   const converted = convertMessages(input.messages);
   const explicitSystem = typeof input.system === "string" ? input.system : "";
@@ -170,7 +170,7 @@ function buildCommandCodeBody(model: string, body: unknown, stream: boolean): Js
       tools: convertTools(input.tools),
       system,
       max_tokens: clampMaxTokens(input.max_tokens ?? input.max_completion_tokens),
-      stream,
+      stream: true,
     },
   };
 }
@@ -513,7 +513,7 @@ export class CommandCodeExecutor extends BaseExecutor {
     };
     mergeUpstreamExtraHeaders(headers, upstreamExtraHeaders);
 
-    const transformedBody = buildCommandCodeBody(model, body, stream);
+    const transformedBody = buildCommandCodeBody(model, body);
     const url = this.buildUrl();
     const upstream = await fetch(url, {
       method: "POST",

--- a/open-sse/executors/commandCode.ts
+++ b/open-sse/executors/commandCode.ts
@@ -162,7 +162,7 @@ function buildCommandCodeBody(model: string, body: unknown): JsonRecord {
     },
     memory: "",
     taste: "",
-    skills: [],
+    skills: "",
     permissionMode: "standard",
     params: {
       model,

--- a/src/lib/providers/validation.ts
+++ b/src/lib/providers/validation.ts
@@ -412,7 +412,7 @@ export async function validateCommandCodeProvider({ apiKey, providerSpecificData
       "Content-Type": "application/json",
       Authorization: `Bearer ${apiKey}`,
       "x-command-code-version": "0.24.1",
-      "x-cli-environment": "production",
+      "x-cli-environment": "external",
       "x-project-slug": "pi-cc",
       "x-taste-learning": "false",
       "x-co-flag": "false",
@@ -422,7 +422,7 @@ export async function validateCommandCodeProvider({ apiKey, providerSpecificData
       config: {
         workingDir: "/workspace",
         date: new Date().toISOString().slice(0, 10),
-        environment: "omniroute-validation",
+        environment: "external",
         structure: [],
         isGitRepo: false,
         currentBranch: "",

--- a/src/lib/providers/validation.ts
+++ b/src/lib/providers/validation.ts
@@ -404,6 +404,10 @@ export async function validateCommandCodeProvider({ apiKey, providerSpecificData
   const baseUrl = normalizeBaseUrl(entry?.baseUrl || "https://api.commandcode.ai");
   const chatPath = entry?.chatPath || "/alpha/generate";
   const url = `${baseUrl}${chatPath.startsWith("/") ? chatPath : `/${chatPath}`}`;
+  const validationModelId =
+    providerSpecificData?.validationModelId ||
+    entry?.models?.find((model) => model.id === "deepseek/deepseek-v4-flash")?.id ||
+    "deepseek/deepseek-v4-flash";
 
   return validateDirectChatProvider({
     url,
@@ -435,10 +439,7 @@ export async function validateCommandCodeProvider({ apiKey, providerSpecificData
       skills: "",
       permissionMode: "standard",
       params: {
-        model:
-          providerSpecificData?.validationModelId ||
-          entry?.models?.[0]?.id ||
-          "deepseek/deepseek-v4-flash",
+        model: validationModelId,
         messages: [{ role: "user", content: "test" }],
         tools: [],
         system: "",

--- a/src/lib/providers/validation.ts
+++ b/src/lib/providers/validation.ts
@@ -412,7 +412,7 @@ export async function validateCommandCodeProvider({ apiKey, providerSpecificData
       "Content-Type": "application/json",
       Authorization: `Bearer ${apiKey}`,
       "x-command-code-version": "0.24.1",
-      "x-cli-environment": "external",
+      "x-cli-environment": "production",
       "x-project-slug": "pi-cc",
       "x-taste-learning": "false",
       "x-co-flag": "false",
@@ -422,7 +422,7 @@ export async function validateCommandCodeProvider({ apiKey, providerSpecificData
       config: {
         workingDir: "/workspace",
         date: new Date().toISOString().slice(0, 10),
-        environment: "external",
+        environment: "omniroute-validation",
         structure: [],
         isGitRepo: false,
         currentBranch: "",
@@ -432,6 +432,7 @@ export async function validateCommandCodeProvider({ apiKey, providerSpecificData
       },
       memory: "",
       taste: "",
+      skills: [],
       permissionMode: "standard",
       params: {
         model:
@@ -442,7 +443,7 @@ export async function validateCommandCodeProvider({ apiKey, providerSpecificData
         tools: [],
         system: "",
         max_tokens: 1,
-        stream: false,
+        stream: true,
       },
     },
   });

--- a/src/lib/providers/validation.ts
+++ b/src/lib/providers/validation.ts
@@ -432,7 +432,7 @@ export async function validateCommandCodeProvider({ apiKey, providerSpecificData
       },
       memory: "",
       taste: "",
-      skills: [],
+      skills: "",
       permissionMode: "standard",
       params: {
         model:

--- a/tests/unit/command-code-executor.test.ts
+++ b/tests/unit/command-code-executor.test.ts
@@ -129,7 +129,7 @@ test("Command Code executor posts wrapped body and required headers to alpha/gen
   for (const key of ["config", "memory", "taste", "skills", "permissionMode", "params"]) {
     assert.ok(key in posted, `missing ${key}`);
   }
-  assert.deepEqual(posted.skills, []);
+  assert.equal(posted.skills, "");
   assert.equal(posted.params.model, "gpt-5.4-mini");
   assert.equal(posted.params.stream, true);
   assert.equal(posted.params.system, "You are concise.");

--- a/tests/unit/command-code-executor.test.ts
+++ b/tests/unit/command-code-executor.test.ts
@@ -126,11 +126,12 @@ test("Command Code executor posts wrapped body and required headers to alpha/gen
 
   const posted = JSON.parse(String(calls[0].init.body));
   assert.deepEqual(posted, transformedBody);
-  for (const key of ["config", "memory", "taste", "permissionMode", "params"]) {
+  for (const key of ["config", "memory", "taste", "skills", "permissionMode", "params"]) {
     assert.ok(key in posted, `missing ${key}`);
   }
+  assert.deepEqual(posted.skills, []);
   assert.equal(posted.params.model, "gpt-5.4-mini");
-  assert.equal(posted.params.stream, false);
+  assert.equal(posted.params.stream, true);
   assert.equal(posted.params.system, "You are concise.");
   assert.equal(posted.params.messages[0].role, "user");
   assert.equal(posted.params.tools[0].name, "lookup");

--- a/tests/unit/provider-validation-specialty.test.ts
+++ b/tests/unit/provider-validation-specialty.test.ts
@@ -1940,8 +1940,9 @@ test("validateCommandCodeProvider sends Command Code probe URL, headers, and wra
   assert.equal(typeof calls[0].headers["x-session-id"], "string");
   assert.equal(calls[0].body.config.environment, "external");
   assert.equal(calls[0].body.permissionMode, "standard");
+  assert.deepEqual(calls[0].body.skills, []);
   assert.equal(calls[0].body.params.model, "gpt-5.4-mini");
-  assert.equal(calls[0].body.params.stream, false);
+  assert.equal(calls[0].body.params.stream, true);
   assert.equal(calls[0].body.params.max_tokens, 1);
 });
 

--- a/tests/unit/provider-validation-specialty.test.ts
+++ b/tests/unit/provider-validation-specialty.test.ts
@@ -1940,7 +1940,7 @@ test("validateCommandCodeProvider sends Command Code probe URL, headers, and wra
   assert.equal(typeof calls[0].headers["x-session-id"], "string");
   assert.equal(calls[0].body.config.environment, "external");
   assert.equal(calls[0].body.permissionMode, "standard");
-  assert.deepEqual(calls[0].body.skills, []);
+  assert.equal(calls[0].body.skills, "");
   assert.equal(calls[0].body.params.model, "gpt-5.4-mini");
   assert.equal(calls[0].body.params.stream, true);
   assert.equal(calls[0].body.params.max_tokens, 1);

--- a/tests/unit/provider-validation-specialty.test.ts
+++ b/tests/unit/provider-validation-specialty.test.ts
@@ -105,6 +105,18 @@ test("validateCommandCodeProvider ignores caller baseUrl and chatPath overrides"
   assert.equal(result.valid, true);
 });
 
+test("validateCommandCodeProvider defaults probe model to DeepSeek flash", async () => {
+  globalThis.fetch = async (_url, init = {}) => {
+    const body = JSON.parse(String(init.body));
+    assert.equal(body.params.model, "deepseek/deepseek-v4-flash");
+    return new Response("", { status: 400 });
+  };
+
+  const result = await validateCommandCodeProvider({ apiKey: "cc-key" });
+
+  assert.deepEqual(result, { valid: true, error: null });
+});
+
 test("specialty providers surface network failures and non-auth upstream failures", async () => {
   globalThis.fetch = async (url) => {
     const target = String(url);


### PR DESCRIPTION
## Summary
- Force Command Code upstream wrapper payloads to include `skills: ""` and `params.stream: true`.
- Align Command Code validation probe payload with the upstream-required shape and default it to `deepseek/deepseek-v4-flash`.
- Update focused Command Code tests for runtime payloads, validation payloads, and default validation model selection.

## Verification
- `node --import tsx/esm --test tests/unit/command-code-executor.test.ts`
- `node --import tsx/esm --test --test-name-pattern="validateCommandCodeProvider" tests/unit/provider-validation-specialty.test.ts`
- `node --import tsx/esm --test --test-name-pattern="Command Code" tests/unit/responses-handler.test.ts`
- `npm run typecheck:core`