### PR TITLE
feat(skills): add 3 operational SKILL.md manifests + AI Skills dashbo…

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -15,18 +15,21 @@ through `$OMNIROUTE_URL/v1/...` with `Authorization: Bearer $OMNIROUTE_KEY`.
 
 ## Skills index
 
-| Capability               | Manifest                                                       |
-| ------------------------ | -------------------------------------------------------------- |
-| Entry point + setup      | [omniroute/SKILL.md](omniroute/SKILL.md)                       |
-| Chat / code-gen          | [omniroute-chat/SKILL.md](omniroute-chat/SKILL.md)             |
-| Image generation         | [omniroute-image/SKILL.md](omniroute-image/SKILL.md)           |
-| Text-to-speech           | [omniroute-tts/SKILL.md](omniroute-tts/SKILL.md)               |
-| Speech-to-text           | [omniroute-stt/SKILL.md](omniroute-stt/SKILL.md)               |
-| Embeddings               | [omniroute-embeddings/SKILL.md](omniroute-embeddings/SKILL.md) |
-| Web search               | [omniroute-web-search/SKILL.md](omniroute-web-search/SKILL.md) |
-| Web fetch (URL→markdown) | [omniroute-web-fetch/SKILL.md](omniroute-web-fetch/SKILL.md)   |
-| MCP server               | [omniroute-mcp/SKILL.md](omniroute-mcp/SKILL.md)               |
-| A2A protocol             | [omniroute-a2a/SKILL.md](omniroute-a2a/SKILL.md)               |
+| Capability               | Manifest                                                         |
+| ------------------------ | ---------------------------------------------------------------- |
+| Entry point + setup      | [omniroute/SKILL.md](omniroute/SKILL.md)                         |
+| Chat / code-gen          | [omniroute-chat/SKILL.md](omniroute-chat/SKILL.md)               |
+| Image generation         | [omniroute-image/SKILL.md](omniroute-image/SKILL.md)             |
+| Text-to-speech           | [omniroute-tts/SKILL.md](omniroute-tts/SKILL.md)                 |
+| Speech-to-text           | [omniroute-stt/SKILL.md](omniroute-stt/SKILL.md)                 |
+| Embeddings               | [omniroute-embeddings/SKILL.md](omniroute-embeddings/SKILL.md)   |
+| Web search               | [omniroute-web-search/SKILL.md](omniroute-web-search/SKILL.md)   |
+| Web fetch (URL→markdown) | [omniroute-web-fetch/SKILL.md](omniroute-web-fetch/SKILL.md)     |
+| MCP server (37 tools)    | [omniroute-mcp/SKILL.md](omniroute-mcp/SKILL.md)                 |
+| A2A protocol             | [omniroute-a2a/SKILL.md](omniroute-a2a/SKILL.md)                 |
+| Routing & combos         | [omniroute-routing/SKILL.md](omniroute-routing/SKILL.md)         |
+| Token compression        | [omniroute-compression/SKILL.md](omniroute-compression/SKILL.md) |
+| Monitoring & health      | [omniroute-monitoring/SKILL.md](omniroute-monitoring/SKILL.md)   |
 
 ## Format
 
@@ -34,9 +37,12 @@ Each `SKILL.md` follows the Anthropic skill manifest spec with YAML frontmatter
 (`name`, `description`) and a self-contained markdown body: setup, endpoints,
 examples, and error codes. Assume the reader is an agent with no prior context.
 
-## Additional skills
+## Skills exclusive to OmniRoute
 
-OmniRoute includes two protocol-level skills not found in other routers:
+These 5 skills have no equivalent in other AI routers:
 
-- `omniroute-mcp` — exposes 37 MCP tools (memory, skills, providers, routing) over SSE/stdio/HTTP
-- `omniroute-a2a` — exposes 5 A2A skills (smart-routing, quota, discovery, cost, health)
+- `omniroute-mcp` — 37 MCP tools (memory, skills, providers, routing, compression) over SSE/stdio/HTTP
+- `omniroute-a2a` — 5 A2A skills (smart-routing, quota, discovery, cost, health) via JSON-RPC 2.0
+- `omniroute-routing` — create/configure combos, 14 strategies, Auto-combo scoring, fallback chains
+- `omniroute-compression` — RTK + Caveman + stacked mode + MCP accessibility filter (60–90% token savings)
+- `omniroute-monitoring` — circuit breakers, p50/p95/p99 latency, budget guard, MCP audit log

--- a/skills/omniroute-compression/SKILL.md
+++ b/skills/omniroute-compression/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: omniroute-compression
+description: Configure OmniRoute token compression to save 60–90% of context tokens. Covers RTK (command/tool output), Caveman (prose), stacked mode (both), and the MCP accessibility-tree filter (browser snapshots). Use when the user wants to reduce costs, fit long sessions into context windows, or speed up AI responses.
+---
+
+# OmniRoute — Compression
+
+Requires `OMNIROUTE_URL` and `OMNIROUTE_KEY`. See [entry-point SKILL](https://raw.githubusercontent.com/diegosouzapw/OmniRoute/main/skills/omniroute/SKILL.md) for setup.
+
+## Overview
+
+OmniRoute compresses token payloads before forwarding to providers. No code changes required — set it once, it applies to all requests transparently.
+
+| Engine                    | Best for                             | Typical savings |
+| ------------------------- | ------------------------------------ | --------------- |
+| RTK                       | Terminal / build / test / git output | 60–90%          |
+| Caveman                   | Human prose, chat history            | 46% input       |
+| Stacked (`rtk → caveman`) | Mixed coding sessions                | 78–95%          |
+| MCP accessibility filter  | Browser/accessibility tool results   | 60–80%          |
+
+## Get current settings
+
+```bash
+curl $OMNIROUTE_URL/api/settings/compression \
+  -H "Authorization: Bearer $OMNIROUTE_KEY"
+```
+
+## Enable RTK (best for coding agents)
+
+```bash
+curl -X PUT $OMNIROUTE_URL/api/settings/compression \
+  -H "Authorization: Bearer $OMNIROUTE_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ "mode": "rtk", "enabled": true }'
+```
+
+## Enable stacked mode (maximum savings)
+
+```bash
+curl -X PUT $OMNIROUTE_URL/api/settings/compression \
+  -H "Authorization: Bearer $OMNIROUTE_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "mode": "stacked",
+    "enabled": true,
+    "stackedPipeline": ["rtk", "caveman"]
+  }'
+```
+
+## Enable Caveman (prose / chat)
+
+```bash
+curl -X PUT $OMNIROUTE_URL/api/settings/compression \
+  -H "Authorization: Bearer $OMNIROUTE_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ "mode": "standard", "enabled": true }'
+```
+
+Caveman intensities: `lite` (safe), `standard` (balanced), `aggressive` (long sessions), `ultra` (context recovery).
+
+## Preview compression before enabling
+
+```bash
+curl -X POST $OMNIROUTE_URL/api/compression/preview \
+  -H "Authorization: Bearer $OMNIROUTE_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "mode": "rtk",
+    "text": "$ npm test\n> jest\n\nPASS src/a.test.ts (2.1s)\nPASS src/b.test.ts (1.8s)\n..."
+  }'
+```
+
+Response includes `compressed`, `original_length`, `compressed_length`, `savings_pct`.
+
+## MCP accessibility-tree filter (browser agent use)
+
+When OmniRoute is used with browser/Playwright MCP tools, it automatically compresses verbose accessibility-tree tool results. Enabled by default; configure thresholds:
+
+```bash
+curl -X PUT $OMNIROUTE_URL/api/settings/compression \
+  -H "Authorization: Bearer $OMNIROUTE_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "mcpAccessibility": {
+      "enabled": true,
+      "collapseThreshold": 30,
+      "maxTextChars": 50000
+    }
+  }'
+```
+
+`collapseThreshold`: collapse sibling lines when ≥ N repeats (default 30).  
+`maxTextChars`: hard truncate after N chars with navigation hint (default 50000).
+
+## Language packs (Caveman)
+
+Caveman supports language-aware rules for pt-BR, es, de, fr, ja:
+
+```bash
+curl -X PUT $OMNIROUTE_URL/api/settings/compression \
+  -H "Authorization: Bearer $OMNIROUTE_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "mode": "standard",
+    "cavemanConfig": {
+      "language": "pt-BR",
+      "autoDetectLanguage": true
+    }
+  }'
+```
+
+## Via MCP
+
+```
+omniroute_compression_status     → current settings + savings analytics
+omniroute_compression_configure  → update mode/threshold/language
+omniroute_set_compression_engine → switch engine at runtime
+```
+
+## Disable compression
+
+```bash
+curl -X PUT $OMNIROUTE_URL/api/settings/compression \
+  -H "Authorization: Bearer $OMNIROUTE_KEY" \
+  -d '{ "enabled": false }'
+```
+
+## Errors
+
+- `400 invalid mode` → use `off`, `lite`, `standard`, `aggressive`, `ultra`, `rtk`, or `stacked`
+- `400 invalid stackedPipeline` → array must contain valid engine ids (`rtk`, `caveman`)

--- a/skills/omniroute-monitoring/SKILL.md
+++ b/skills/omniroute-monitoring/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: omniroute-monitoring
+description: Monitor OmniRoute system health, provider circuit breakers, per-provider latency (p50/p95/p99), quota usage, and set budget guards. Use when the user wants to check if the system is healthy, debug slow providers, manage spend limits, or set up oncall-style monitoring.
+---
+
+# OmniRoute — Monitoring & Health
+
+Requires `OMNIROUTE_URL` and `OMNIROUTE_KEY`. See [entry-point SKILL](https://raw.githubusercontent.com/diegosouzapw/OmniRoute/main/skills/omniroute/SKILL.md) for setup.
+
+## System health
+
+```bash
+curl $OMNIROUTE_URL/api/health \
+  -H "Authorization: Bearer $OMNIROUTE_KEY"
+```
+
+Returns: uptime, memory, active connections, circuit breaker states, rate limit status, cache stats.
+
+Unauthenticated quick check:
+
+```bash
+curl $OMNIROUTE_URL/api/health
+# → {"ok":true}
+```
+
+## Provider circuit breakers
+
+Circuit breakers prevent traffic from hitting failing providers.
+
+States: `CLOSED` (normal), `OPEN` (blocked), `HALF_OPEN` (probe mode — auto-recovers).
+
+```bash
+curl $OMNIROUTE_URL/api/monitoring/health \
+  -H "Authorization: Bearer $OMNIROUTE_KEY"
+```
+
+Response includes `circuitBreakers` array with per-provider state and `resetAt` timestamp.
+
+## Per-provider metrics (p50/p95/p99)
+
+```bash
+curl $OMNIROUTE_URL/api/providers/metrics \
+  -H "Authorization: Bearer $OMNIROUTE_KEY"
+```
+
+Response shape per provider:
+
+```json
+{
+  "provider": "anthropic",
+  "requests": 1247,
+  "successRate": 0.994,
+  "latency": { "p50": 820, "p95": 2100, "p99": 3800 },
+  "circuitState": "CLOSED",
+  "tokensUsed": 2847000
+}
+```
+
+## Via MCP (if OmniRoute is your MCP server)
+
+```
+omniroute_get_health            → full system health snapshot
+omniroute_get_provider_metrics  → p50/p95/p99 + circuit state per provider
+omniroute_get_session_snapshot  → cost, tokens, errors for current session
+omniroute_check_quota           → quota balance + percent remaining + reset time
+omniroute_db_health_check       → diagnose + auto-repair database drift
+```
+
+## Quota check
+
+```bash
+curl $OMNIROUTE_URL/api/quota \
+  -H "Authorization: Bearer $OMNIROUTE_KEY"
+```
+
+Returns used/total tokens and requests per provider/account, with `resetAt` timestamps.
+
+## Budget guard (spend limit)
+
+Set a session spending limit that degrades or blocks requests when hit:
+
+```bash
+curl -X POST $OMNIROUTE_URL/api/budget/guard \
+  -H "Authorization: Bearer $OMNIROUTE_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "limitUsd": 5.00,
+    "action": "degrade",
+    "degradeTo": "openai/gpt-4o-mini"
+  }'
+```
+
+`action` options:
+
+- `degrade` — switch to a cheaper model when limit is hit
+- `block` — return 429 when limit is hit
+- `alert` — continue but add `X-Budget-Warning` header
+
+## MCP audit log
+
+OmniRoute logs every MCP tool call to `mcp_audit` table. Query via API:
+
+```bash
+curl "$OMNIROUTE_URL/api/mcp/status" \
+  -H "Authorization: Bearer $OMNIROUTE_KEY"
+```
+
+Returns: server status, heartbeat, recent audit activity summary.
+
+## Errors
+
+- `503` on health endpoint → OmniRoute is starting up; retry in 5s
+- Circuit breaker `OPEN` → provider is temporarily blocked; check `resetAt` to know when it auto-recovers
+- `429 budget_exceeded` → budget guard limit reached; raise limit or wait for reset

--- a/skills/omniroute-routing/SKILL.md
+++ b/skills/omniroute-routing/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: omniroute-routing
+description: Create and configure OmniRoute routing combos, choose from 14 strategies (priority, weighted, auto, round-robin, cost-optimized, etc.), activate Auto-combo 9-factor scoring, and set up fallback chains. Use when the user wants to configure multi-provider routing, load balancing, or cost-optimized model selection.
+---
+
+# OmniRoute — Routing & Combos
+
+Requires `OMNIROUTE_URL` and `OMNIROUTE_KEY`. See [entry-point SKILL](https://raw.githubusercontent.com/diegosouzapw/OmniRoute/main/skills/omniroute/SKILL.md) for setup.
+
+## What is a combo?
+
+A combo is a named group of providers/models with a routing strategy. All requests through a combo are automatically distributed, failed-over, and load-balanced — the caller uses a single model ID like `my-combo`.
+
+## List existing combos
+
+```bash
+curl $OMNIROUTE_URL/api/combos \
+  -H "Authorization: Bearer $OMNIROUTE_KEY"
+```
+
+Response includes `id`, `name`, `strategy`, `enabled`, and per-target stats.
+
+## Create a combo
+
+```bash
+curl -X POST $OMNIROUTE_URL/api/combos \
+  -H "Authorization: Bearer $OMNIROUTE_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "my-combo",
+    "strategy": "priority",
+    "targets": [
+      { "provider": "anthropic", "model": "claude-opus-4-7", "weight": 1 },
+      { "provider": "openai",    "model": "gpt-4o",           "weight": 1 }
+    ]
+  }'
+```
+
+## 14 routing strategies
+
+| Strategy            | Description                                        |
+| ------------------- | -------------------------------------------------- |
+| `priority`          | Always use target[0]; fall back on error           |
+| `weighted`          | Distribute by weight percentage                    |
+| `round-robin`       | Rotate targets in order                            |
+| `fill-first`        | Fill quota of target[0] before spilling            |
+| `least-used`        | Route to target with fewest active requests        |
+| `cost-optimized`    | Pick cheapest target for the token estimate        |
+| `auto`              | 9-factor scoring: cost + latency + quota + circuit |
+| `random`            | Uniform random selection                           |
+| `strict-random`     | Random without repeating until all used            |
+| `p2c`               | Power-of-2-choices: sample 2, pick better          |
+| `reset-aware`       | Prefer targets near quota reset time               |
+| `lkgp`              | Last-known-good-provider sticky routing            |
+| `context-optimized` | Pick best model for context length                 |
+| `context-relay`     | Chain models for very long contexts                |
+
+## Auto-combo (recommended for production)
+
+Auto-combo scores each candidate on 9 factors every request:
+
+```bash
+curl -X POST $OMNIROUTE_URL/api/combos \
+  -H "Authorization: Bearer $OMNIROUTE_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "prod-auto",
+    "strategy": "auto",
+    "targets": [
+      { "provider": "anthropic", "model": "claude-sonnet-4-6" },
+      { "provider": "openai",    "model": "gpt-4o-mini" },
+      { "provider": "google",    "model": "gemini-2.0-flash" }
+    ]
+  }'
+```
+
+Then call it with:
+
+```bash
+curl -X POST $OMNIROUTE_URL/v1/chat/completions \
+  -H "Authorization: Bearer $OMNIROUTE_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ "model": "prod-auto", "messages": [{ "role": "user", "content": "Hello" }] }'
+```
+
+## Activate / deactivate a combo
+
+```bash
+# Activate
+curl -X PUT $OMNIROUTE_URL/api/combos/{id}/toggle \
+  -H "Authorization: Bearer $OMNIROUTE_KEY" \
+  -d '{ "enabled": true }'
+```
+
+## Get combo metrics
+
+```bash
+curl $OMNIROUTE_URL/api/combos/{id}/metrics \
+  -H "Authorization: Bearer $OMNIROUTE_KEY"
+```
+
+Returns p50/p95/p99 latency, success rate, cost, and per-target breakdown.
+
+## Simulate routing (dry run)
+
+```bash
+curl -X POST $OMNIROUTE_URL/api/routing/simulate \
+  -H "Authorization: Bearer $OMNIROUTE_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ "comboId": "{id}", "messages": [{ "role": "user", "content": "test" }] }'
+```
+
+Returns which provider would be selected and why — no actual API call is made.
+
+## Via MCP (if OmniRoute is your MCP server)
+
+```
+omniroute_list_combos     → list all combos
+omniroute_switch_combo    → enable/disable a combo
+omniroute_set_routing_strategy → change strategy at runtime
+omniroute_simulate_route  → dry-run routing decision
+omniroute_best_combo_for_task → get recommendation by task type
+```
+
+## Errors
+
+- `404 combo not found` → check `id` from `/api/combos`
+- `400 invalid strategy` → use one of the 14 strategies above
+- `409 name conflict` → combo name already exists

--- a/skills/omniroute/SKILL.md
+++ b/skills/omniroute/SKILL.md
@@ -34,17 +34,20 @@ Use `data[].id` as `model` field in requests. Combos appear with `owned_by:"comb
 
 ## Capability skills
 
-| Capability       | Raw URL                                                                                            |
-| ---------------- | -------------------------------------------------------------------------------------------------- |
-| Chat / code-gen  | https://raw.githubusercontent.com/diegosouzapw/OmniRoute/main/skills/omniroute-chat/SKILL.md       |
-| Image generation | https://raw.githubusercontent.com/diegosouzapw/OmniRoute/main/skills/omniroute-image/SKILL.md      |
-| Text-to-speech   | https://raw.githubusercontent.com/diegosouzapw/OmniRoute/main/skills/omniroute-tts/SKILL.md        |
-| Speech-to-text   | https://raw.githubusercontent.com/diegosouzapw/OmniRoute/main/skills/omniroute-stt/SKILL.md        |
-| Embeddings       | https://raw.githubusercontent.com/diegosouzapw/OmniRoute/main/skills/omniroute-embeddings/SKILL.md |
-| Web search       | https://raw.githubusercontent.com/diegosouzapw/OmniRoute/main/skills/omniroute-web-search/SKILL.md |
-| Web fetch        | https://raw.githubusercontent.com/diegosouzapw/OmniRoute/main/skills/omniroute-web-fetch/SKILL.md  |
-| MCP server       | https://raw.githubusercontent.com/diegosouzapw/OmniRoute/main/skills/omniroute-mcp/SKILL.md        |
-| A2A protocol     | https://raw.githubusercontent.com/diegosouzapw/OmniRoute/main/skills/omniroute-a2a/SKILL.md        |
+| Capability            | Raw URL                                                                                             |
+| --------------------- | --------------------------------------------------------------------------------------------------- |
+| Chat / code-gen       | https://raw.githubusercontent.com/diegosouzapw/OmniRoute/main/skills/omniroute-chat/SKILL.md        |
+| Image generation      | https://raw.githubusercontent.com/diegosouzapw/OmniRoute/main/skills/omniroute-image/SKILL.md       |
+| Text-to-speech        | https://raw.githubusercontent.com/diegosouzapw/OmniRoute/main/skills/omniroute-tts/SKILL.md         |
+| Speech-to-text        | https://raw.githubusercontent.com/diegosouzapw/OmniRoute/main/skills/omniroute-stt/SKILL.md         |
+| Embeddings            | https://raw.githubusercontent.com/diegosouzapw/OmniRoute/main/skills/omniroute-embeddings/SKILL.md  |
+| Web search            | https://raw.githubusercontent.com/diegosouzapw/OmniRoute/main/skills/omniroute-web-search/SKILL.md  |
+| Web fetch             | https://raw.githubusercontent.com/diegosouzapw/OmniRoute/main/skills/omniroute-web-fetch/SKILL.md   |
+| MCP server (37 tools) | https://raw.githubusercontent.com/diegosouzapw/OmniRoute/main/skills/omniroute-mcp/SKILL.md         |
+| A2A protocol          | https://raw.githubusercontent.com/diegosouzapw/OmniRoute/main/skills/omniroute-a2a/SKILL.md         |
+| Routing & combos      | https://raw.githubusercontent.com/diegosouzapw/OmniRoute/main/skills/omniroute-routing/SKILL.md     |
+| Token compression     | https://raw.githubusercontent.com/diegosouzapw/OmniRoute/main/skills/omniroute-compression/SKILL.md |
+| Monitoring & health   | https://raw.githubusercontent.com/diegosouzapw/OmniRoute/main/skills/omniroute-monitoring/SKILL.md  |
 
 ## Errors
 

--- a/src/app/(dashboard)/dashboard/skills/page.tsx
+++ b/src/app/(dashboard)/dashboard/skills/page.tsx
@@ -36,11 +36,22 @@ interface Execution {
 
 function AgentSkillCopyButton({ value, label = "Copy link" }: { value: string; label?: string }) {
   const [copied, setCopied] = useState(false);
-  const copy = () => {
-    void navigator.clipboard.writeText(value).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    });
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(value);
+    } catch {
+      // Fallback for HTTP contexts or older browsers
+      const ta = document.createElement("textarea");
+      ta.value = value;
+      ta.style.position = "fixed";
+      ta.style.opacity = "0";
+      document.body.appendChild(ta);
+      ta.select();
+      document.execCommand("copy");
+      document.body.removeChild(ta);
+    }
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
   };
   return (
     <button
@@ -457,7 +468,7 @@ export default function SkillsPage() {
               : "border-transparent text-text-muted hover:text-text-main"
           }`}
         >
-          AI Skills
+          {t("agentSkillsTab")}
         </button>
       </div>
 

--- a/src/app/(dashboard)/dashboard/skills/page.tsx
+++ b/src/app/(dashboard)/dashboard/skills/page.tsx
@@ -4,6 +4,13 @@ import { useState, useEffect, useRef } from "react";
 import { Card } from "@/shared/components";
 import { useTranslations } from "next-intl";
 import type { SkillsProvider } from "@/lib/skills/providerSettings";
+import {
+  AGENT_SKILLS,
+  AGENT_SKILLS_REPO_URL,
+  getAgentSkillRawUrl,
+  getAgentSkillBlobUrl,
+  type AgentSkill,
+} from "@/shared/constants/agentSkills";
 
 interface Skill {
   id: string;
@@ -27,6 +34,82 @@ interface Execution {
   createdAt: string;
 }
 
+function AgentSkillCopyButton({ value, label = "Copy link" }: { value: string; label?: string }) {
+  const [copied, setCopied] = useState(false);
+  const copy = () => {
+    void navigator.clipboard.writeText(value).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+  return (
+    <button
+      onClick={copy}
+      className="px-2 py-1 rounded-md bg-primary text-white text-[11px] font-medium hover:bg-primary/90 transition-colors cursor-pointer shrink-0 inline-flex items-center gap-1"
+      title={value}
+    >
+      <span className="material-symbols-outlined text-[12px]">
+        {copied ? "check" : "content_copy"}
+      </span>
+      {copied ? "Copied!" : label}
+    </button>
+  );
+}
+
+function AgentSkillRow({ skill }: { skill: AgentSkill }) {
+  const url = getAgentSkillRawUrl(skill.id);
+  return (
+    <div
+      className={`flex items-start gap-3 p-4 rounded-[14px] border shadow-[var(--shadow-soft)] transition-colors ${
+        skill.isEntry
+          ? "border-brand-500/40 bg-brand-500/5"
+          : "border-border-subtle bg-surface hover:bg-surface-2"
+      }`}
+    >
+      <div
+        className={`size-9 rounded-lg flex items-center justify-center shrink-0 ${
+          skill.isEntry ? "bg-primary text-white" : "bg-primary/10 text-primary"
+        }`}
+      >
+        <span className="material-symbols-outlined text-[18px]">{skill.icon}</span>
+      </div>
+
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2 flex-wrap">
+          <h3 className="font-semibold text-sm text-text-main">{skill.name}</h3>
+          {skill.isEntry && (
+            <span className="text-[10px] px-1.5 py-0.5 rounded bg-primary/10 text-primary font-medium">
+              START HERE
+            </span>
+          )}
+          {skill.isNew && (
+            <span className="text-[10px] px-1.5 py-0.5 rounded bg-emerald-500/10 text-emerald-400 font-medium">
+              NEW
+            </span>
+          )}
+          {skill.endpoint && (
+            <span className="text-[10px] px-1.5 py-0.5 rounded bg-surface-2 text-text-muted font-mono">
+              {skill.endpoint}
+            </span>
+          )}
+        </div>
+        <p className="text-xs text-text-muted mt-0.5">{skill.description}</p>
+        <a
+          href={getAgentSkillBlobUrl(skill.id)}
+          target="_blank"
+          rel="noreferrer"
+          className="text-[11px] text-text-muted hover:text-primary mt-1 inline-flex items-center gap-1 break-all"
+        >
+          {url}
+          <span className="material-symbols-outlined text-[12px]">open_in_new</span>
+        </a>
+      </div>
+
+      <AgentSkillCopyButton value={url} />
+    </div>
+  );
+}
+
 export default function SkillsPage() {
   const [skills, setSkills] = useState<Skill[]>([]);
   const [executions, setExecutions] = useState<Execution[]>([]);
@@ -42,9 +125,9 @@ export default function SkillsPage() {
   const [execTotal, setExecTotal] = useState(0);
   const [execTotalPages, setExecTotalPages] = useState(1);
 
-  const [activeTab, setActiveTab] = useState<"skills" | "executions" | "sandbox" | "marketplace">(
-    "skills"
-  );
+  const [activeTab, setActiveTab] = useState<
+    "skills" | "executions" | "sandbox" | "marketplace" | "agent-skills"
+  >("skills");
   const [showInstallModal, setShowInstallModal] = useState(false);
   const [installJson, setInstallJson] = useState("");
   const [installStatus, setInstallStatus] = useState<{
@@ -365,6 +448,16 @@ export default function SkillsPage() {
           }`}
         >
           Marketplace
+        </button>
+        <button
+          onClick={() => setActiveTab("agent-skills")}
+          className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+            activeTab === "agent-skills"
+              ? "border-violet-500 text-violet-400"
+              : "border-transparent text-text-muted hover:text-text-main"
+          }`}
+        >
+          AI Skills
         </button>
       </div>
 
@@ -772,6 +865,54 @@ export default function SkillsPage() {
               </div>
             </Card>
           )}
+        </div>
+      )}
+
+      {activeTab === "agent-skills" && (
+        <div className="max-w-4xl mx-auto space-y-4">
+          <Card padding="md">
+            <div className="text-xs text-text-muted mb-2">Paste this to your AI agent:</div>
+            <div className="flex items-center gap-2">
+              <code className="flex-1 px-3 py-2 rounded bg-surface-2 font-mono text-[12px] text-text-main break-all">
+                Read this skill and use it: {getAgentSkillRawUrl("omniroute")}
+              </code>
+              <AgentSkillCopyButton
+                value={`Read this skill and use it: ${getAgentSkillRawUrl("omniroute")}`}
+                label="Copy"
+              />
+            </div>
+            <p className="text-xs text-text-muted mt-3">
+              Your agent fetches the SKILL.md, reads the setup instructions, and follows the links
+              to any capability it needs. Works with Claude, Cursor, ChatGPT, Cline, and any AI that
+              can fetch URLs.
+            </p>
+          </Card>
+
+          <div className="space-y-2">
+            {AGENT_SKILLS.map((skill) => (
+              <AgentSkillRow key={skill.id} skill={skill} />
+            ))}
+          </div>
+
+          <Card padding="md">
+            <div className="flex items-center justify-between gap-3 flex-wrap">
+              <div>
+                <h2 className="text-sm font-semibold text-text-main">Browse on GitHub</h2>
+                <p className="text-xs text-text-muted mt-0.5">
+                  Source, README, and raw links for all 13 skills.
+                </p>
+              </div>
+              <a
+                href={`${AGENT_SKILLS_REPO_URL}/tree/main/skills`}
+                target="_blank"
+                rel="noreferrer"
+                className="text-sm text-primary hover:underline inline-flex items-center gap-1"
+              >
+                <span className="material-symbols-outlined text-[16px]">open_in_new</span>
+                View on GitHub
+              </a>
+            </div>
+          </Card>
         </div>
       )}
 

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -2336,6 +2336,7 @@
     "skillsTab": "Skills",
     "executionsTab": "Executions",
     "sandboxTab": "Sandbox",
+    "agentSkillsTab": "AI Skills",
     "loading": "Loading skills...",
     "noSkills": "No skills found",
     "noExecutions": "No executions found",

--- a/src/shared/constants/agentSkills.ts
+++ b/src/shared/constants/agentSkills.ts
@@ -1,0 +1,133 @@
+// Agent Skills metadata — single source of truth for /dashboard/skills → "AI Skills" tab.
+// Each skill = 1 raw GitHub URL the user copies and pastes to any AI agent.
+
+const REPO = "diegosouzapw/OmniRoute";
+const BRANCH = "main";
+const SKILL_PATH = "skills";
+
+export const AGENT_SKILLS_REPO_URL = `https://github.com/${REPO}`;
+export const AGENT_SKILLS_RAW_BASE = `https://raw.githubusercontent.com/${REPO}/refs/heads/${BRANCH}/${SKILL_PATH}`;
+export const AGENT_SKILLS_BLOB_BASE = `https://github.com/${REPO}/blob/${BRANCH}/${SKILL_PATH}`;
+
+export interface AgentSkill {
+  id: string;
+  name: string;
+  description: string;
+  endpoint: string | null;
+  icon: string;
+  isEntry?: boolean;
+  isNew?: boolean;
+}
+
+export const AGENT_SKILLS: AgentSkill[] = [
+  {
+    id: "omniroute",
+    name: "OmniRoute (Entry)",
+    description:
+      "Setup + index of all capabilities. Start here — covers base URL, auth, model discovery, and links to every capability skill.",
+    endpoint: null,
+    icon: "hub",
+    isEntry: true,
+  },
+  {
+    id: "omniroute-chat",
+    name: "Chat",
+    description: "Chat / code-gen via OpenAI or Anthropic format with streaming and reasoning.",
+    endpoint: "/v1/chat/completions",
+    icon: "chat",
+  },
+  {
+    id: "omniroute-image",
+    name: "Image Generation",
+    description: "Text-to-image via DALL-E, Imagen, FLUX, MiniMax, SDWebUI, and more.",
+    endpoint: "/v1/images/generations",
+    icon: "image",
+  },
+  {
+    id: "omniroute-tts",
+    name: "Text-to-Speech",
+    description: "OpenAI / ElevenLabs / Edge / Google / Deepgram voices.",
+    endpoint: "/v1/audio/speech",
+    icon: "record_voice_over",
+  },
+  {
+    id: "omniroute-stt",
+    name: "Speech-to-Text",
+    description:
+      "Transcribe audio via OpenAI Whisper, Groq, Gemini, Deepgram, AssemblyAI, and more.",
+    endpoint: "/v1/audio/transcriptions",
+    icon: "mic",
+  },
+  {
+    id: "omniroute-embeddings",
+    name: "Embeddings",
+    description: "Vectors for RAG / semantic search via OpenAI, Gemini, Mistral, and more.",
+    endpoint: "/v1/embeddings",
+    icon: "scatter_plot",
+  },
+  {
+    id: "omniroute-web-search",
+    name: "Web Search",
+    description: "Tavily / Exa / Brave / Serper / SearXNG / Google PSE / You.com.",
+    endpoint: "/v1/search",
+    icon: "search",
+  },
+  {
+    id: "omniroute-web-fetch",
+    name: "Web Fetch",
+    description: "URL → markdown / text / HTML via Firecrawl, Jina, Tavily, Exa.",
+    endpoint: "/v1/web/fetch",
+    icon: "language",
+  },
+  {
+    id: "omniroute-mcp",
+    name: "MCP Server",
+    description:
+      "37 tools over SSE/stdio/HTTP: routing, cache, compression, memory, skills, providers, audit.",
+    endpoint: "/api/mcp/sse",
+    icon: "electrical_services",
+  },
+  {
+    id: "omniroute-a2a",
+    name: "A2A Protocol",
+    description:
+      "JSON-RPC 2.0 agent-to-agent server with 5 built-in skills: smart-routing, quota, discovery, cost, health.",
+    endpoint: "/a2a",
+    icon: "device_hub",
+  },
+  {
+    id: "omniroute-routing",
+    name: "Routing & Combos",
+    description:
+      "Create and configure routing combos, 14 strategies, Auto-combo scoring, and fallback chains.",
+    endpoint: "/api/combos",
+    icon: "route",
+    isNew: true,
+  },
+  {
+    id: "omniroute-compression",
+    name: "Compression",
+    description:
+      "RTK (command output), Caveman (prose), stacked mode, and MCP accessibility-tree filter. Save 60–90% tokens.",
+    endpoint: "/api/settings/compression",
+    icon: "compress",
+    isNew: true,
+  },
+  {
+    id: "omniroute-monitoring",
+    name: "Monitoring & Health",
+    description:
+      "Health endpoints, circuit breakers, provider metrics (p50/p95/p99), budget guard, and MCP monitoring tools.",
+    endpoint: "/api/monitoring/health",
+    icon: "monitor_heart",
+    isNew: true,
+  },
+];
+
+export function getAgentSkillRawUrl(id: string): string {
+  return `${AGENT_SKILLS_RAW_BASE}/${id}/SKILL.md`;
+}
+
+export function getAgentSkillBlobUrl(id: string): string {
+  return `${AGENT_SKILLS_BLOB_BASE}/${id}/SKILL.md`;
+}


### PR DESCRIPTION
…ard tab

- skills/omniroute-routing/SKILL.md: combos, 14 strategies, Auto-combo, simulate routing, MCP tools for routing
- skills/omniroute-compression/SKILL.md: RTK, Caveman, stacked mode, MCP accessibility filter, language packs
- skills/omniroute-monitoring/SKILL.md: health, circuit breakers, p50/p95/p99 metrics, quota, budget guard, MCP audit
- src/shared/constants/agentSkills.ts: single source of truth for all 13 external agent skills (equivalent of 9route skills.js, adapted)
- dashboard/skills/page.tsx: new "AI Skills" tab with copy-button UX, GitHub link, NEW badge for 3 new skills
- skills/omniroute/SKILL.md + README.md: updated index with 13 skills (was 10); 5 skills exclusive to OmniRoute highlighted

## Summary

- Describe the user-facing or operational change.

## Related Issues

- Closes #
- Related to #

## Validation

- [ ] `npm run lint`
- [ ] `npm run test:unit`
- [ ] `npm run test:coverage`
- [ ] Coverage is still `>= 60%` for statements, lines, functions, and branches
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below

## Tests Added Or Updated

- List every changed or added automated test file.
- If no production code changed, state that here.

## Coverage Notes

- If this PR changes `src/`, `open-sse/`, `electron/`, or `bin/`, explain which tests cover the change.
- If coverage moved down in any touched file, explain why and what follow-up task will recover it.

## Reviewer Notes

- Call out any risky areas, migrations, feature flags, or manual validation that reviewers should know about.