### PR TITLE
fix(executors): opencode-zen format fallback for unknown models + Qwen thinking sanitization

### DIFF
--- a/open-sse/executors/opencode.ts
+++ b/open-sse/executors/opencode.ts
@@ -1,6 +1,9 @@
 import { BaseExecutor, type ExecuteInput, type ProviderCredentials } from "./base.ts";
 import { PROVIDERS } from "../config/constants.ts";
-import { getModelTargetFormat } from "../config/providerModels.ts";
+import { getModelTargetFormat, getProviderModel } from "../config/providerModels.ts";
+import { sanitizeQwenThinkingToolChoice } from "../services/qwenThinking.ts";
+
+const FORMAT_FALLBACK_CHAIN = ["openai", "claude"];
 
 export class OpencodeExecutor extends BaseExecutor {
   _requestFormat: string | null = null;
@@ -10,12 +13,31 @@ export class OpencodeExecutor extends BaseExecutor {
   }
 
   async execute(input: ExecuteInput) {
-    this._requestFormat = getModelTargetFormat(this.provider, input.model) || "openai";
-    try {
-      return await super.execute(input);
-    } finally {
-      this._requestFormat = null;
+    const alias = this.provider;
+    const staticFormat = getModelTargetFormat(alias, input.model);
+    const isStatic = getProviderModel(alias, input.model) !== undefined;
+    const formats = isStatic ? [staticFormat || "openai"] : FORMAT_FALLBACK_CHAIN;
+
+    let lastResult: {
+      response: Response;
+      url: string;
+      headers: Record<string, string>;
+      transformedBody: unknown;
+    } | null = null;
+    for (const format of formats) {
+      this._requestFormat = format;
+      try {
+        lastResult = await super.execute(input);
+        if (lastResult.response.status !== 500 || isStatic) return lastResult;
+        input.log?.debug?.(
+          "FORMAT_FALLBACK",
+          `${input.model}: ${format} returned 500, trying next format`
+        );
+      } finally {
+        this._requestFormat = null;
+      }
     }
+    return lastResult!;
   }
 
   buildUrl(
@@ -69,7 +91,7 @@ export class OpencodeExecutor extends BaseExecutor {
     stream: boolean,
     credentials: ProviderCredentials
   ): any {
-    const modifiedBody = super.transformRequest(model, body, stream, credentials);
+    let modifiedBody = super.transformRequest(model, body, stream, credentials);
     if (
       modifiedBody &&
       typeof modifiedBody === "object" &&
@@ -78,6 +100,7 @@ export class OpencodeExecutor extends BaseExecutor {
     ) {
       modifiedBody.tools = modifiedBody.tools.slice(0, 128);
     }
+    modifiedBody = sanitizeQwenThinkingToolChoice(modifiedBody, "OpencodeExecutor");
     return modifiedBody;
   }
 }

--- a/tests/unit/opencode-executor.test.ts
+++ b/tests/unit/opencode-executor.test.ts
@@ -232,5 +232,50 @@ describe("OpencodeExecutor", () => {
       });
       assert.deepEqual(fetchCalls[0].options.headers, result.headers);
     });
+
+    it("retries unknown models with claude format on 500", async () => {
+      let callIndex = 0;
+      globalThis.fetch = async (url, options) => {
+        fetchCalls.push({ url, options });
+        const status = callIndex++ === 0 ? 500 : 200;
+        return new Response(JSON.stringify({ ok: true }), {
+          status,
+          headers: { "Content-Type": "application/json" },
+        });
+      };
+
+      const result = await zenExecutor.execute(createInput("qwen3.6-plus-free"));
+
+      assert.equal(fetchCalls.length, 2);
+      assert.equal(fetchCalls[0].url, "https://opencode.ai/zen/v1/chat/completions");
+      assert.equal(fetchCalls[1].url, "https://opencode.ai/zen/v1/messages");
+      assert.equal(result.url, "https://opencode.ai/zen/v1/messages");
+      assert.equal(result.headers["x-api-key"], "test-key");
+      assert.equal(result.headers["anthropic-version"], "2023-06-01");
+    });
+
+    it("does not retry static models on 500", async () => {
+      globalThis.fetch = async (url, options) => {
+        fetchCalls.push({ url, options });
+        return new Response(JSON.stringify({ error: "fail" }), {
+          status: 500,
+          headers: { "Content-Type": "application/json" },
+        });
+      };
+
+      const result = await zenExecutor.execute(createInput("big-pickle"));
+
+      assert.equal(fetchCalls.length, 1);
+      assert.equal(fetchCalls[0].url, "https://opencode.ai/zen/v1/chat/completions");
+      assert.equal(result.response.status, 500);
+    });
+
+    it("does not retry when openai format succeeds for unknown model", async () => {
+      const result = await zenExecutor.execute(createInput("new-model"));
+
+      assert.equal(fetchCalls.length, 1);
+      assert.equal(fetchCalls[0].url, "https://opencode.ai/zen/v1/chat/completions");
+      assert.equal(result.response.status, 200);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Add automatic format fallback chain (`openai` → `claude`) for `opencode-zen` models not in the static registry — resolves upstream 500 errors for dynamically-available models like `qwen3.6-plus-free` that require Claude Messages format
- Add `sanitizeQwenThinkingToolChoice` in `OpencodeExecutor.transformRequest` to prevent upstream 500 when thinking mode is active with incompatible `tool_choice` values
- Static models (registered in `providerRegistry.ts`) use their configured format without retry

## Problem
`opencode-zen` models like `qwen3.6-plus-free` are available via the upstream `/v1/models` endpoint but not in the static registry. The executor defaulted all unknown models to OpenAI format (`/chat/completions`), but some models require Claude Messages format (`/messages`). This caused `[500]: An system error has occurred, please try again later.` from the upstream `opencode.ai` API.

## Changes

### `open-sse/executors/opencode.ts`
- **Format fallback**: `execute()` now checks if a model is in the static registry via `getProviderModel()`. Static models use their registered format. Unknown models try `["openai", "claude"]` format chain — if OpenAI returns 500, automatically retries with Claude format.
- **Thinking sanitization**: `transformRequest()` calls `sanitizeQwenThinkingToolChoice()` to neutralize incompatible `tool_choice` values when Qwen thinking mode is active.

### `tests/unit/opencode-executor.test.ts`
- `retries unknown models with claude format on 500` — verifies format fallback for `qwen3.6-plus-free`
- `does not retry static models on 500` — verifies static models (e.g. `big-pickle`) don't retry
- `does not retry when openai format succeeds for unknown model` — verifies no unnecessary retry on success

## Test plan
- [x] All 15 unit tests pass (`node --import tsx/esm --test tests/unit/opencode-executor.test.ts`)
- [x] Pre-commit hooks pass (lint, format, any-budget, i18n, docs-sync)
