### PR TITLE
fix(sse): remove dead-code flag leak in claudeCodeToolRemapper

### DIFF
--- a/open-sse/services/claudeCodeToolRemapper.ts
+++ b/open-sse/services/claudeCodeToolRemapper.ts
@@ -88,12 +88,10 @@ export function remapToolNamesInRequest(body: Record<string, unknown>): boolean 
     }
   }
 
-  // NOTE: previously set body._claudeCodeRequiresLowercaseToolNames = true here.
-  // Removed: the flag had no readers in the codebase and leaked into the
-  // outgoing Anthropic request body, causing HTTP 400
-  // "_claudeCodeRequiresLowercaseToolNames: Extra inputs are not permitted".
-  // The response-side lowercase remap is unconditional anyway via
-  // remapToolNamesInResponse(text, forceLowercase=true).
+  // NOTE: do not set body._claudeCodeRequiresLowercaseToolNames here.
+  // The flag has no readers and would leak into the outgoing Anthropic
+  // request body, causing HTTP 400 (Extra inputs are not permitted).
+  // The response-side remap is unconditional via remapToolNamesInResponse.
 
   return hasLowercase && !hasTitleCase;
 }

--- a/open-sse/services/claudeCodeToolRemapper.ts
+++ b/open-sse/services/claudeCodeToolRemapper.ts
@@ -88,9 +88,12 @@ export function remapToolNamesInRequest(body: Record<string, unknown>): boolean 
     }
   }
 
-  if (hasLowercase && !hasTitleCase) {
-    body._claudeCodeRequiresLowercaseToolNames = true;
-  }
+  // NOTE: previously set body._claudeCodeRequiresLowercaseToolNames = true here.
+  // Removed: the flag had no readers in the codebase and leaked into the
+  // outgoing Anthropic request body, causing HTTP 400
+  // "_claudeCodeRequiresLowercaseToolNames: Extra inputs are not permitted".
+  // The response-side lowercase remap is unconditional anyway via
+  // remapToolNamesInResponse(text, forceLowercase=true).
 
   return hasLowercase && !hasTitleCase;
 }

--- a/tests/unit/claude-code-tool-remapper-flag-leak.test.ts
+++ b/tests/unit/claude-code-tool-remapper-flag-leak.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Regression test for the _claudeCodeRequiresLowercaseToolNames flag leak
+ * that caused HTTP 400 "Extra inputs are not permitted" from Anthropic.
+ *
+ * The flag had no readers in the codebase but was assigned to the outgoing
+ * request body. Anthropic's strict schema validation rejected the unknown
+ * field. This test guards against re-introduction.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { remapToolNamesInRequest } from "../../open-sse/services/claudeCodeToolRemapper.ts";
+
+describe("remapToolNamesInRequest — flag-leak regression", () => {
+  it("does NOT add _claudeCodeRequiresLowercaseToolNames when all tools are lowercase", () => {
+    const body: Record<string, unknown> = {
+      tools: [{ name: "bash" }, { name: "read" }, { name: "edit" }],
+    };
+    remapToolNamesInRequest(body);
+    assert.equal(
+      "_claudeCodeRequiresLowercaseToolNames" in body,
+      false,
+      "Flag must not leak into outgoing request body"
+    );
+  });
+
+  it("returns true when only lowercase tools are present", () => {
+    const body: Record<string, unknown> = { tools: [{ name: "bash" }] };
+    assert.equal(remapToolNamesInRequest(body), true);
+  });
+
+  it("returns false when only TitleCase tools are present", () => {
+    const body: Record<string, unknown> = { tools: [{ name: "Bash" }] };
+    assert.equal(remapToolNamesInRequest(body), false);
+  });
+
+  it("returns false when mixed-case tools are present", () => {
+    const body: Record<string, unknown> = {
+      tools: [{ name: "bash" }, { name: "Read" }],
+    };
+    assert.equal(remapToolNamesInRequest(body), false);
+  });
+
+  it("does NOT add flag in any of the above cases", () => {
+    for (const tools of [
+      [{ name: "bash" }],
+      [{ name: "Bash" }],
+      [{ name: "bash" }, { name: "Read" }],
+      [],
+    ]) {
+      const body: Record<string, unknown> = { tools };
+      remapToolNamesInRequest(body);
+      assert.equal(
+        "_claudeCodeRequiresLowercaseToolNames" in body,
+        false,
+        `Flag leaked for tools=${JSON.stringify(tools)}`
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Removes an unused body-level flag (`_claudeCodeRequiresLowercaseToolNames`) that `remapToolNamesInRequest` set when a request contained only lowercase tool names. The flag had no readers in `src/` or `open-sse/` (verified by repo-wide grep) and leaked into the outgoing Anthropic `/v1/messages` payload, causing HTTP 400:

> `_claudeCodeRequiresLowercaseToolNames: Extra inputs are not permitted`

The response-side lowercase remap via `remapToolNamesInResponse(text, true)` is unconditional and independent of this flag, so removing the assignment is a no-op for the response path while fixing the request path.

**Reproduction (pre-fix):** any third-party client (e.g. OpenCode, Cline, Continue) sending lowercase tool names through the Claude-Code-Compatible pipeline to Anthropic gets HTTP 400 rejected by Anthropic schema validation.

## Related Issues

- (none found via PR/Issue search; happy to link if maintainers know of one)

## Validation

- [x] `npm run lint` (scoped to changed files, clean)
- [x] `tests/unit/claude-code-tool-remapper-flag-leak.test.ts` — 5/5 pass locally
- [x] `tests/unit/claude-code-parity.test.ts` — 25/25 pass locally (no regression in adjacent code)
- [ ] `npm run test:unit` — full suite deferred to CI (122 unit files, slow in my local environment)
- [ ] `npm run test:coverage` — deferred to CI; expected ≥ 60% (net positive: new test adds coverage to a previously-uncovered branch)
- [ ] SonarQube PR analysis — appears after CI

## Tests Added Or Updated

- `tests/unit/claude-code-tool-remapper-flag-leak.test.ts` (NEW, 5 cases)

## Coverage Notes

Changes one file under `open-sse/services/`. The new test exercises the affected function in 4 input shapes plus a flag-leak sweep across all four shapes asserting flag absence — increases coverage on the previously-uncovered conditional branch.

## Reviewer Notes

Net change: deletes the 3-line `if (hasLowercase && !hasTitleCase) { body... = true }` block and replaces it with a comment explaining why. Return-value semantics of `remapToolNamesInRequest` are unchanged, so the 5 callers in `executors/base.ts:535`, `services/claudeCodeCompatible.ts:326`, etc. are unaffected. Verified locally against the Anthropic OAuth path with OpenCode as the client (streaming `/v1/messages`).
