### PR TITLE
fix(deepseek-web): lazy-load PoW solver to unblock standalone build

### DIFF
--- a/open-sse/lib/deepseek-pow.ts
+++ b/open-sse/lib/deepseek-pow.ts
@@ -9,9 +9,17 @@ import { dirname, join } from "node:path";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-// Load the exact solver extracted from DeepSeek's worker chunk
+// Load the exact solver extracted from DeepSeek's worker chunk.
+// Lazy-loaded inside the function so the standalone Next build can collect
+// page data without executing a dynamic require() at module-load time.
 const require = createRequire(import.meta.url);
-const { U } = require(join(__dirname, "deepseek-pow-solver.cjs"));
+let _U: any | undefined;
+function loadU(): any {
+  if (_U === undefined) {
+    _U = require(join(__dirname, "deepseek-pow-solver.cjs")).U;
+  }
+  return _U;
+}
 
 export function solveDeepSeekPow(
   algorithm: string,
@@ -23,6 +31,7 @@ export function solveDeepSeekPow(
   if (algorithm !== "DeepSeekHashV1") throw new Error(`Unsupported: ${algorithm}`);
   const prefix = `${salt}_${expireAt}_`;
 
+  const U = loadU();
   const createHash = () => {
     const self: any = {};
     self._sponge = new U({ capacity: 256, padding: 6 });


### PR DESCRIPTION
## Problem

The Next.js standalone build (`npm run build -- --webpack`) fails when collecting page data for `/api/evals`:

```
Error: Cannot find module '/app/open-sse/lib/deepseek-pow-solver.cjs'
    at b (.next/server/chunks/37544.js:47:644) ...
> Build error occurred
Error: Failed to collect page data for /api/evals
```

This blocks the Docker image build (`docker compose --profile base build`).

## Root cause

`open-sse/lib/deepseek-pow.ts` was added in #2295 with a module-load-time `require()` using a runtime-computed path:

```ts
const require = createRequire(import.meta.url);
const { U } = require(join(__dirname, "deepseek-pow-solver.cjs"));
```

webpack's static analyzer cannot resolve `join(__dirname, "deepseek-pow-solver.cjs")` to a concrete path, so file-tracing does not include the `.cjs` in the standalone output. When the build runs page-data collection, the `require` executes against the not-yet-traced path and the build aborts.

## Fix

Wrap the require in a memoized `loadU()` helper invoked from `solveDeepSeekPow()`. Module load no longer touches the filesystem, and the solver is materialized only when actually invoked — by then file-tracing has copied the `.cjs` alongside.

```ts
let _U: any | undefined;
function loadU(): any {
  if (_U === undefined) {
    _U = require(join(__dirname, "deepseek-pow-solver.cjs")).U;
  }
  return _U;
}

export function solveDeepSeekPow(...) {
  ...
  const U = loadU();
  const createHash = () => { ... new U(...) ... };
  ...
}
```

## Verification

- `docker compose --profile base build` now succeeds.
- Container starts cleanly, dashboard reachable at `http://localhost:20128`.
- `[STARTUP] Runtime settings hydrated: ...` confirms no startup regression.

## Scope

11 insertions, 2 deletions — single file. No behavior change for `solveDeepSeekPow()` callers (lazy require is transparent).