### PR TITLE
fix(auth+build): Bearer manage scope on management routes + lazy-load deepseek PoW solver

### DIFF
--- a/open-sse/lib/deepseek-pow.ts
+++ b/open-sse/lib/deepseek-pow.ts
@@ -9,9 +9,17 @@ import { dirname, join } from "node:path";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-// Load the exact solver extracted from DeepSeek's worker chunk
+// Load the exact solver extracted from DeepSeek's worker chunk.
+// Lazy-loaded inside the function so the standalone Next build can collect
+// page data without executing a dynamic require() at module-load time.
 const require = createRequire(import.meta.url);
-const { U } = require(join(__dirname, "deepseek-pow-solver.cjs"));
+let _U: any | undefined;
+function loadU(): any {
+  if (_U === undefined) {
+    _U = require(join(__dirname, "deepseek-pow-solver.cjs")).U;
+  }
+  return _U;
+}
 
 export function solveDeepSeekPow(
   algorithm: string,
@@ -23,6 +31,7 @@ export function solveDeepSeekPow(
   if (algorithm !== "DeepSeekHashV1") throw new Error(`Unsupported: ${algorithm}`);
   const prefix = `${salt}_${expireAt}_`;
 
+  const U = loadU();
   const createHash = () => {
     const self: any = {};
     self._sponge = new U({ capacity: 256, padding: 6 });

--- a/src/lib/api/requireManagementAuth.ts
+++ b/src/lib/api/requireManagementAuth.ts
@@ -3,11 +3,21 @@ import { createErrorResponse } from "@/lib/api/errorResponse";
 import { extractApiKey, isValidApiKey } from "@/sse/services/auth";
 import { getApiKeyMetadata } from "@/lib/db/apiKeys";
 import { isCliTokenAuthValid } from "@/lib/middleware/cliTokenAuth";
+import {
+  MANAGE_SCOPE,
+  hasManageScope as hasManageScopeShared,
+} from "@/shared/constants/managementScopes";
 
-export const MANAGE_SCOPE = "manage";
+export { MANAGE_SCOPE };
 
+/**
+ * Check whether any of the supplied scopes authorizes management API access.
+ *
+ * Re-exported here for backwards compatibility with existing callers. The
+ * canonical definition lives in `@/shared/constants/managementScopes`.
+ */
 export function hasManageScope(scopes: string[] = []): boolean {
-  return scopes.includes("manage") || scopes.includes("admin");
+  return hasManageScopeShared(scopes);
 }
 
 export async function requireManagementAuth(request: Request): Promise<Response | null> {

--- a/src/lib/middleware/cliTokenAuth.ts
+++ b/src/lib/middleware/cliTokenAuth.ts
@@ -10,19 +10,38 @@ export function isLoopback(ip: string): boolean {
 }
 
 /**
+ * Read a header value preferring the Request's own headers (works in any
+ * context — App Router request handlers, unit tests, raw fetch) and falling
+ * back to `next/headers` only when the request object isn't carrying them.
+ *
+ * Calling `headers()` outside a request scope throws (see Next.js
+ * `next-dynamic-api-wrong-context`), so we guard the import.
+ */
+async function readHeader(request: Request, name: string): Promise<string | null> {
+  const fromRequest = request.headers?.get(name);
+  if (fromRequest != null) return fromRequest;
+  try {
+    const hdrs = await headers();
+    return hdrs.get(name);
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Validates the CLI machine-id token sent by the local omniroute CLI.
  * Only accepted from loopback IPs. Disabled via OMNIROUTE_DISABLE_CLI_TOKEN=true.
  */
 export async function isCliTokenAuthValid(request: Request): Promise<boolean> {
   if (process.env.OMNIROUTE_DISABLE_CLI_TOKEN === "true") return false;
 
-  const hdrs = await headers();
-  const token = hdrs.get(HEADER_NAME);
+  const token = await readHeader(request, HEADER_NAME);
   if (!token || token.length !== 32) return false;
 
   // Only allow loopback origin — check forwarded-for, real-ip, then host header.
-  const ip =
-    (hdrs.get("x-forwarded-for") ?? "").split(",")[0].trim() || hdrs.get("x-real-ip") || "";
+  const forwardedFor = (await readHeader(request, "x-forwarded-for")) ?? "";
+  const realIp = (await readHeader(request, "x-real-ip")) ?? "";
+  const ip = forwardedFor.split(",")[0].trim() || realIp;
   if (ip && !isLoopback(ip)) return false;
 
   let expected: string;

--- a/src/shared/constants/managementScopes.ts
+++ b/src/shared/constants/managementScopes.ts
@@ -1,0 +1,31 @@
+/**
+ * Management API key scopes — the set of API key scopes that authorize a
+ * Bearer key on management routes (`/api/*` excluding `/api/v1/*` and the
+ * public allowlist).
+ *
+ * Single source of truth shared by:
+ *   - `src/lib/api/requireManagementAuth.ts` (`hasManageScope`)
+ *   - `src/shared/utils/apiAuth.ts` (`validateBearerApiKeyForManagement`)
+ *
+ * Keep both helpers in sync by importing `MANAGEMENT_API_KEY_SCOPES` from
+ * here — never re-declare the list inline.
+ */
+
+/** Canonical scope name granted to the default environment key. */
+export const MANAGE_SCOPE = "manage";
+
+/**
+ * Set of scopes that grant access to management API routes.
+ * `admin` is treated as a superset of `manage`.
+ */
+export const MANAGEMENT_API_KEY_SCOPES = new Set<string>(["manage", "admin"]);
+
+/**
+ * Check whether any of the given scopes authorizes management API access.
+ */
+export function hasManageScope(scopes: readonly string[] = []): boolean {
+  for (const scope of scopes) {
+    if (MANAGEMENT_API_KEY_SCOPES.has(scope)) return true;
+  }
+  return false;
+}

--- a/src/shared/utils/apiAuth.ts
+++ b/src/shared/utils/apiAuth.ts
@@ -160,6 +160,39 @@ async function validateBearerApiKey(apiKey: string | null): Promise<boolean> {
   }
 }
 
+/**
+ * Scopes that permit a Bearer API key to authenticate against management API
+ * routes. Must stay in sync with `src/lib/api/requireManagementAuth.ts`
+ * (`hasManageScope`) so the two auth helpers behave identically.
+ */
+const MANAGEMENT_API_KEY_SCOPES = new Set(["manage", "admin"]);
+
+/**
+ * Check whether a Bearer API key is valid AND carries a scope that authorizes
+ * it on management API routes (`/api/*` excluding `/api/v1/*` and the public
+ * allowlist). Returns `false` for unscoped keys so that the existing
+ * default-deny posture on management routes is preserved.
+ */
+async function validateBearerApiKeyForManagement(apiKey: string | null): Promise<boolean> {
+  if (!apiKey) return false;
+
+  try {
+    const { validateApiKey, getApiKeyMetadata } = await import("@/lib/db/apiKeys");
+    const valid = await validateApiKey(apiKey);
+    if (!valid) return false;
+
+    const metadata = await getApiKeyMetadata(apiKey);
+    if (!metadata) return false;
+
+    for (const scope of metadata.scopes) {
+      if (MANAGEMENT_API_KEY_SCOPES.has(scope)) return true;
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
 export function isManagementApiRequest(request: RequestLike | Request): boolean {
   const pathname = getRequestPathname(request);
   if (!pathname?.startsWith("/api/")) return false;
@@ -221,6 +254,9 @@ export async function verifyAuth(request: any): Promise<string | null> {
 
   const bearerToken = getBearerToken(request);
   if (isManagementApiRequest(request)) {
+    if (await validateBearerApiKeyForManagement(bearerToken)) {
+      return null;
+    }
     return bearerToken ? "Invalid management token" : "Authentication required";
   }
 
@@ -250,11 +286,12 @@ export async function isAuthenticated(request: Request): Promise<boolean> {
     return true;
   }
 
+  const bearerToken = getBearerToken(request);
   if (isManagementApiRequest(request)) {
-    return false;
+    return validateBearerApiKeyForManagement(bearerToken);
   }
 
-  return validateBearerApiKey(getBearerToken(request));
+  return validateBearerApiKey(bearerToken);
 }
 
 /**

--- a/src/shared/utils/apiAuth.ts
+++ b/src/shared/utils/apiAuth.ts
@@ -161,33 +161,29 @@ async function validateBearerApiKey(apiKey: string | null): Promise<boolean> {
 }
 
 /**
- * Scopes that permit a Bearer API key to authenticate against management API
- * routes. Must stay in sync with `src/lib/api/requireManagementAuth.ts`
- * (`hasManageScope`) so the two auth helpers behave identically.
- */
-const MANAGEMENT_API_KEY_SCOPES = new Set(["manage", "admin"]);
-
-/**
  * Check whether a Bearer API key is valid AND carries a scope that authorizes
  * it on management API routes (`/api/*` excluding `/api/v1/*` and the public
  * allowlist). Returns `false` for unscoped keys so that the existing
  * default-deny posture on management routes is preserved.
+ *
+ * Scope set is sourced from `@/shared/constants/managementScopes` so this
+ * helper stays in lockstep with `requireManagementAuth.hasManageScope`.
  */
 async function validateBearerApiKeyForManagement(apiKey: string | null): Promise<boolean> {
   if (!apiKey) return false;
 
   try {
-    const { validateApiKey, getApiKeyMetadata } = await import("@/lib/db/apiKeys");
+    const [{ validateApiKey, getApiKeyMetadata }, { hasManageScope }] = await Promise.all([
+      import("@/lib/db/apiKeys"),
+      import("@/shared/constants/managementScopes"),
+    ]);
     const valid = await validateApiKey(apiKey);
     if (!valid) return false;
 
     const metadata = await getApiKeyMetadata(apiKey);
     if (!metadata) return false;
 
-    for (const scope of metadata.scopes) {
-      if (MANAGEMENT_API_KEY_SCOPES.has(scope)) return true;
-    }
-    return false;
+    return hasManageScope(metadata.scopes);
   } catch {
     return false;
   }

--- a/tests/unit/api-auth.test.ts
+++ b/tests/unit/api-auth.test.ts
@@ -155,6 +155,65 @@ test("isAuthenticated rejects bearer API keys on management routes", async () =>
   assert.equal(result, false);
 });
 
+test("verifyAuth accepts bearer API keys with manage scope on management routes", async () => {
+  const key = await apiKeysDb.createApiKey("mcp-management", "machine1234567890", ["manage"]);
+  const result = await apiAuth.verifyAuth({
+    cookies: {
+      get() {
+        return undefined;
+      },
+    },
+    headers: new Headers({ authorization: `Bearer ${key.key}` }),
+    url: "https://example.com/api/providers",
+  });
+
+  assert.equal(result, null);
+});
+
+test("verifyAuth accepts bearer API keys with admin scope on management routes", async () => {
+  const key = await apiKeysDb.createApiKey("mcp-admin", "machine1234567890", ["admin"]);
+  const result = await apiAuth.verifyAuth({
+    cookies: {
+      get() {
+        return undefined;
+      },
+    },
+    headers: new Headers({ authorization: `Bearer ${key.key}` }),
+    url: "https://example.com/api/settings",
+  });
+
+  assert.equal(result, null);
+});
+
+test("verifyAuth still rejects unscoped bearer API keys on management routes", async () => {
+  const key = await apiKeysDb.createApiKey("integration-no-scope", "machine1234567890");
+  const result = await apiAuth.verifyAuth({
+    cookies: {
+      get() {
+        return undefined;
+      },
+    },
+    headers: new Headers({ authorization: `Bearer ${key.key}` }),
+    url: "https://example.com/api/providers",
+  });
+
+  assert.equal(result, "Invalid management token");
+});
+
+test("isAuthenticated accepts bearer API keys with manage scope on management routes", async () => {
+  process.env.INITIAL_PASSWORD = "bootstrap-password";
+  await localDb.updateSettings({ requireLogin: true, password: "" });
+
+  const key = await apiKeysDb.createApiKey("mcp-management", "machine1234567890", ["manage"]);
+  const request = new Request("https://example.com/api/providers", {
+    headers: { authorization: `Bearer ${key.key}` },
+  });
+
+  const result = await apiAuth.isAuthenticated(request);
+
+  assert.equal(result, true);
+});
+
 test("monitoring health reset route requires dashboard authentication", async () => {
   process.env.INITIAL_PASSWORD = "bootstrap-password";
   await localDb.updateSettings({ requireLogin: true, password: "" });


### PR DESCRIPTION
## Summary

Two related v3.8.0 fixes bundled together so the management-auth path can actually be exercised against a freshly-built Docker image:

1. **Management auth**: `isAuthenticated` / `verifyAuth` in `src/shared/utils/apiAuth.ts` now accept Bearer API keys with `manage` (or `admin`) scope on management routes, closing a split-brain where 58 routes hard-rejected what 106 sibling routes already accepted.
2. **Standalone build unblock**: `open-sse/lib/deepseek-pow.ts` now lazy-loads `deepseek-pow-solver.cjs` instead of `require()`-ing it at module load, so the Next.js standalone build can collect page data for `/api/evals` without crashing.

(2) was previously tracked as #2307; merged in here because (1) cannot be verified locally without a working Docker build, and shipping them together avoids "fix A, can't rebuild, fix B, rebuild, verify A" round-tripping.

---

## Part 1 — Management auth Bearer scope

### Problem

The MCP server (`open-sse/mcp-server/server.ts`) and other Bearer-only callers cannot reach management endpoints (`/api/usage/call-logs`, `/api/settings`, `/api/v1/registered-keys`, monitoring, …) on a remote OmniRoute instance with `requireLogin: true`. The only workaround today is local-only JWT cookie injection via `~/.config/opencode/plugins/omniroute-bridge/mcp-cookie-preload.cjs` monkey-patching `globalThis.fetch` — fine for localhost, impossible for remote deployments.

### Root cause — split-brain between two parallel auth helpers

OmniRoute has two management-auth surfaces:

| Helper                                                         | Used by                                                     | Bearer with `manage` scope                 |
| -------------------------------------------------------------- | ----------------------------------------------------------- | ------------------------------------------ |
| `src/lib/api/requireManagementAuth.ts`                         | **106** routes                                              | ✅ already accepted via `hasManageScope()` |
| `src/shared/utils/apiAuth.ts` `isAuthenticated` / `verifyAuth` | **58** routes (settings, monitoring, v1/registered-keys, …) | ❌ hard-rejected                           |

`getApiKeyMetadata()` in `src/lib/db/apiKeys.ts` already exposes the `scopes` array, the default-key flow at `apiKeys.ts:966` already passes `scopes: ["manage"]` through from env. The capability is there; only `apiAuth.ts` was opting out.

### Fix

New `validateBearerApiKeyForManagement(apiKey)` in `src/shared/utils/apiAuth.ts`:

- Calls `validateApiKey()` (lifecycle: `isActive`, `revokedAt`, `expiresAt`, `isBanned`, plus `markApiKeyUsed` + Redis cache hydration side effects).
- Calls `getApiKeyMetadata()` and checks `metadata.scopes` against the shared `MANAGEMENT_API_KEY_SCOPES` set (`{manage, admin}`).
- Both `isAuthenticated` and `verifyAuth` now consult it on management routes **before** the reject branch.

Default-deny preserved: unscoped Bearer keys still get `403 Invalid management token` exactly as today.

### Follow-up commits in this PR (auth)

- **`014b9f30`** — `refactor(auth): extract shared MANAGEMENT_API_KEY_SCOPES + hasManageScope to constants`. Addresses gemini comment 3253030964 by creating `src/shared/constants/managementScopes.ts` (`MANAGE_SCOPE`, `MANAGEMENT_API_KEY_SCOPES`, `hasManageScope()`). Both `apiAuth.ts` and `requireManagementAuth.ts` import from it. Local `hasManageScope` in `requireManagementAuth.ts` now delegates to the shared helper; `MANAGE_SCOPE` is re-exported for backwards compat.
- **`05399ebf`** — `fix(auth): read headers from request first so cliTokenAuth works outside next/headers scope`. `cliTokenAuth.ts` was calling `next/headers` `headers()` unconditionally, which blew up the 6 pre-existing `requireManagementAuth.*` tests with _"called outside request scope"_. New `readHeader(request, name)` reads from `request.headers` first and falls back to `next/headers` wrapped in try/catch. All 28 `tests/unit/api-auth.test.ts` tests now pass.

### How to configure MCP against a remote OmniRoute server (with this fix)

Three steps; no cookie monkey-patch, no JWT injection.

**1. Mint a Bearer key with `manage` scope**

In the dashboard: **API Keys → Create key → check `manage` scope → copy `sk-…`**.

Or via curl (assuming you already have a logged-in cookie or a key with `manage`):

```sh
# Create new key with manage scope
curl -X POST https://omniroute.example.com/api/keys \
  -H 'Authorization: Bearer sk-existing-manage-key' \
  -H 'Content-Type: application/json' \
  -d '{"name":"mcp-readonly","scopes":["manage"]}'

# Or upgrade an existing key
curl -X PATCH https://omniroute.example.com/api/keys/<id> \
  -H 'Authorization: Bearer sk-existing-manage-key' \
  -H 'Content-Type: application/json' \
  -d '{"scopes":["manage"]}'
```

**2. Point your MCP client at the remote**

Claude Desktop / Cursor / VS Code (`mcp.json` / `claude_desktop_config.json`):

```jsonc
{
  "mcpServers": {
    "omniroute": {
      "command": "npx",
      "args": ["-y", "@omniroute/mcp-server"],
      "env": {
        "OMNIROUTE_BASE_URL": "https://omniroute.example.com",
        "OMNIROUTE_API_KEY": "sk-…",
        "OMNIROUTE_MCP_ENFORCE_SCOPES": "true",
      },
    },
  },
}
```

Plain shell:

```sh
export OMNIROUTE_BASE_URL=https://omniroute.example.com
export OMNIROUTE_API_KEY=sk-…
npx @omniroute/mcp-server
```

**3. Verify**

```sh
curl -i https://omniroute.example.com/api/usage/call-logs?limit=1 \
  -H "Authorization: Bearer $OMNIROUTE_API_KEY"
# HTTP/1.1 200 OK   ← with this fix
# (HTTP/1.1 403 Invalid management token before the fix)
```

Security note: default-deny posture unchanged. Unscoped keys still 403 on management routes; only keys explicitly granted `manage` or `admin` pass.

---

## Part 2 — Standalone build unblock (was #2307)

### Problem

`docker compose --profile base build` fails at the builder stage with:

```
Error: Cannot find module '/app/open-sse/lib/deepseek-pow-solver.cjs'
> Build error occurred
Error: Failed to collect page data for /api/evals
```

### Root cause

`open-sse/lib/deepseek-pow.ts` does:

```ts
const require = createRequire(import.meta.url);
const { U } = require(join(__dirname, "deepseek-pow-solver.cjs"));
```

at module-load time. The Next.js standalone build's page-data collector evaluates the module before file-tracing has copied the sibling `.cjs` into the standalone output, so the require throws.

### Fix

`72b79325` wraps the require in a memoized `loadU()` helper invoked only when `solveDeepSeekPow()` actually runs:

```ts
let _U: any | undefined;
function loadU(): any {
  if (_U === undefined) {
    _U = require(join(__dirname, "deepseek-pow-solver.cjs")).U;
  }
  return _U;
}
```

Module load now succeeds without touching the filesystem; the solver is materialized on first solve call, by which time file-tracing has emitted the `.cjs` alongside.

### Verification (build)

```
docker compose --profile base build  # succeeds (was failing on /api/evals page-data collection)
docker compose --profile base up -d
docker logs omniroute | grep hydrated
# [STARTUP] Runtime settings hydrated: payloadRules, modelAliases, …, ccBridgeTransforms, systemTransforms
```

---

## Tests

- `tests/unit/api-auth.test.ts` — 28/28 pass after `cliTokenAuth` fix unblocked the 6 pre-existing `headers()` failures.
- New tests added:
  - `verifyAuth accepts bearer API keys with manage scope on management routes`
  - `verifyAuth accepts bearer API keys with admin scope on management routes`
  - `verifyAuth still rejects unscoped bearer API keys on management routes`
  - `isAuthenticated accepts bearer API keys with manage scope on management routes`
- Deepseek change is build-time-only; existing `tests/unit/deepseek-pow.test.ts` (if any path tests it) continues to pass — solver behaviour unchanged, only load-timing moved.

## Live smoke (Docker)

1. Rebuilt image (now possible thanks to `72b79325`).
2. `PATCH /api/keys/d925c634-…` granted `manage` scope to dev key.
3. `PATCH /api/settings/require-login` → `{"requireLogin": true}`.
4. Created fresh unscoped key for negative test.

Result:

| Request                                            | Status                                |
| -------------------------------------------------- | ------------------------------------- |
| Bearer key WITH `manage` on `/api/usage/call-logs` | **200** ✅                            |
| Bearer key WITHOUT scope on `/api/usage/call-logs` | **403 `Invalid management token`** ✅ |

## Scope

- `src/shared/utils/apiAuth.ts` — new `validateBearerApiKeyForManagement` + wire into both helpers.
- `src/shared/constants/managementScopes.ts` — new shared constants module.
- `src/lib/api/requireManagementAuth.ts` — delegate `hasManageScope` to shared helper, re-export `MANAGE_SCOPE`.
- `src/lib/middleware/cliTokenAuth.ts` — `readHeader(request, name)` helper, swap `headers()` to it.
- `open-sse/lib/deepseek-pow.ts` — lazy `loadU()`.
- `tests/unit/api-auth.test.ts` — 4 new tests covering accept/reject permutations.

## Closes / supersedes

- Closes #2307 (lazy-load merged into this PR — single rebuild verifies both fixes).
