### PR TITLE
fix: remove count from batch removal

### DIFF
--- a/src/app/(dashboard)/dashboard/batch/BatchListTab.tsx
+++ b/src/app/(dashboard)/dashboard/batch/BatchListTab.tsx
@@ -224,9 +224,7 @@ export default function BatchListTab({
           <span className="material-symbols-outlined text-[16px]">
             {removingCompleted ? "hourglass_empty" : "delete_sweep"}
           </span>
-          {removingCompleted
-            ? "Removing…"
-            : `Remove completed${completedBatches.length > 0 ? ` (${completedBatches.length})` : ""}`}
+          {removingCompleted ? "Removing…" : `Remove completed`}
         </button>
       </div>
 

--- a/src/app/(dashboard)/dashboard/batch/BatchListTab.tsx
+++ b/src/app/(dashboard)/dashboard/batch/BatchListTab.tsx
@@ -224,7 +224,7 @@ export default function BatchListTab({
           <span className="material-symbols-outlined text-[16px]">
             {removingCompleted ? "hourglass_empty" : "delete_sweep"}
           </span>
-          {removingCompleted ? "Removing…" : `Remove completed`}
+          {removingCompleted ? "Removing…" : "Remove completed"}
         </button>
       </div>
 


### PR DESCRIPTION
Small UI change, the count shows the number of completed batches currently visible, but the button removes all completed server side so the number us useless.