### PR TITLE
fix(claude): guard orphan tool_use/tool_result pairs before upstream send

### DIFF
--- a/open-sse/executors/base.ts
+++ b/open-sse/executors/base.ts
@@ -14,6 +14,7 @@ import { getClaudeCodeCompatibleRequestDefaults } from "@/lib/providers/requestD
 import { remapToolNamesInRequest } from "../services/claudeCodeToolRemapper.ts";
 import { obfuscateInBody } from "../services/claudeCodeObfuscation.ts";
 import { applySystemTransformPipeline, PROVIDER_CLAUDE } from "../services/systemTransforms.ts";
+import { fixToolPairs } from "../services/contextManager.ts";
 import { randomUUID } from "node:crypto";
 import {
   CLAUDE_CODE_VERSION,
@@ -861,6 +862,16 @@ export class BaseExecutor {
         delete (transformedBody as Record<string, unknown>)[
           "_claudeCodeRequiresLowercaseToolNames"
         ];
+        // Guard against orphan tool_use / tool_result pairs. Clients can ship
+        // truncated histories mid-tool-call which Anthropic rejects with
+        // `messages.N: tool_use ids were found without tool_result blocks
+        // immediately after: toolu_...`. fixToolPairs is idempotent on clean
+        // histories.
+        if (Array.isArray((transformedBody as Record<string, unknown>).messages)) {
+          (transformedBody as Record<string, unknown>).messages = fixToolPairs(
+            (transformedBody as Record<string, unknown>).messages as Record<string, unknown>[]
+          );
+        }
         let bodyString = JSON.stringify(transformedBody);
 
         const shouldFingerprint =

--- a/open-sse/executors/base.ts
+++ b/open-sse/executors/base.ts
@@ -14,7 +14,7 @@ import { getClaudeCodeCompatibleRequestDefaults } from "@/lib/providers/requestD
 import { remapToolNamesInRequest } from "../services/claudeCodeToolRemapper.ts";
 import { obfuscateInBody } from "../services/claudeCodeObfuscation.ts";
 import { applySystemTransformPipeline, PROVIDER_CLAUDE } from "../services/systemTransforms.ts";
-import { fixToolPairs } from "../services/contextManager.ts";
+import { fixToolPairs, stripTrailingAssistantOrphanToolUse } from "../services/contextManager.ts";
 import { randomUUID } from "node:crypto";
 import {
   CLAUDE_CODE_VERSION,
@@ -865,12 +865,17 @@ export class BaseExecutor {
         // Guard against orphan tool_use / tool_result pairs. Clients can ship
         // truncated histories mid-tool-call which Anthropic rejects with
         // `messages.N: tool_use ids were found without tool_result blocks
-        // immediately after: toolu_...`. fixToolPairs is idempotent on clean
-        // histories.
-        if (Array.isArray((transformedBody as Record<string, unknown>).messages)) {
-          (transformedBody as Record<string, unknown>).messages = fixToolPairs(
-            (transformedBody as Record<string, unknown>).messages as Record<string, unknown>[]
-          );
+        // immediately after: toolu_...`. fixToolPairs strips orphans, then
+        // stripTrailingAssistantOrphanToolUse catches the case where the
+        // request body itself ends on an unmatched assistant(tool_use) —
+        // invalid for an upstream-send turn since the body must end on a
+        // user message. Both are idempotent on clean histories.
+        {
+          const tb = transformedBody as Record<string, unknown>;
+          if (Array.isArray(tb?.messages)) {
+            const fixed = fixToolPairs(tb.messages as Record<string, unknown>[]);
+            tb.messages = stripTrailingAssistantOrphanToolUse(fixed);
+          }
         }
         let bodyString = JSON.stringify(transformedBody);
 

--- a/open-sse/services/claudeCodeCompatible.ts
+++ b/open-sse/services/claudeCodeCompatible.ts
@@ -13,6 +13,7 @@ import {
 } from "./claudeCodeConstraints.ts";
 import { obfuscateInBody } from "./claudeCodeObfuscation.ts";
 import { applySystemTransformPipeline, PROVIDER_CC_BRIDGE } from "./systemTransforms.ts";
+import { fixToolPairs } from "./contextManager.ts";
 
 /**
  * `anthropic-compatible-cc-*` targets Anthropic relay gateways that only accept
@@ -347,6 +348,18 @@ export async function buildAndSignClaudeCodeRequest(
     if (transformResult.appliedOpKinds.length > 0) {
       console.log(`[SystemTransforms] cc-bridge: ${transformResult.appliedOpKinds.join(", ")}`);
     }
+  }
+
+  // Step 5c: Guard against orphan tool_use / tool_result blocks.
+  // Anthropic rejects requests where a tool_use has no matching tool_result
+  // in the next user message (e.g. `messages.N: tool_use ids were found
+  // without tool_result blocks immediately after: toolu_...`). Clients can
+  // ship truncated histories mid-tool-call; fixToolPairs strips orphans and
+  // drops messages that become empty. Idempotent on clean histories.
+  if (Array.isArray((body as Record<string, unknown>).messages)) {
+    (body as Record<string, unknown>).messages = fixToolPairs(
+      (body as Record<string, unknown>).messages as Record<string, unknown>[]
+    );
   }
 
   // Step 6: Obfuscation (optional, per-provider setting)

--- a/open-sse/services/claudeCodeCompatible.ts
+++ b/open-sse/services/claudeCodeCompatible.ts
@@ -13,7 +13,7 @@ import {
 } from "./claudeCodeConstraints.ts";
 import { obfuscateInBody } from "./claudeCodeObfuscation.ts";
 import { applySystemTransformPipeline, PROVIDER_CC_BRIDGE } from "./systemTransforms.ts";
-import { fixToolPairs } from "./contextManager.ts";
+import { fixToolPairs, stripTrailingAssistantOrphanToolUse } from "./contextManager.ts";
 
 /**
  * `anthropic-compatible-cc-*` targets Anthropic relay gateways that only accept
@@ -354,12 +354,18 @@ export async function buildAndSignClaudeCodeRequest(
   // Anthropic rejects requests where a tool_use has no matching tool_result
   // in the next user message (e.g. `messages.N: tool_use ids were found
   // without tool_result blocks immediately after: toolu_...`). Clients can
-  // ship truncated histories mid-tool-call; fixToolPairs strips orphans and
-  // drops messages that become empty. Idempotent on clean histories.
-  if (Array.isArray((body as Record<string, unknown>).messages)) {
-    (body as Record<string, unknown>).messages = fixToolPairs(
-      (body as Record<string, unknown>).messages as Record<string, unknown>[]
-    );
+  // ship truncated histories mid-tool-call; fixToolPairs strips orphans
+  // (preserving final-message tool_use for in-flight rounds), then
+  // stripTrailingAssistantOrphanToolUse catches the case where the request
+  // body itself ends on an unmatched assistant(tool_use) — invalid for an
+  // upstream-send turn since the body must end on a user message.
+  // Both are idempotent on clean histories.
+  {
+    const b = body as Record<string, unknown>;
+    if (Array.isArray(b.messages)) {
+      const fixed = fixToolPairs(b.messages as Record<string, unknown>[]);
+      b.messages = stripTrailingAssistantOrphanToolUse(fixed);
+    }
   }
 
   // Step 6: Obfuscation (optional, per-provider setting)

--- a/open-sse/services/contextManager.ts
+++ b/open-sse/services/contextManager.ts
@@ -297,7 +297,7 @@ function purifyHistory(messages: Record<string, unknown>[], targetTokens: number
  *   - OpenAI: "Invalid message format"
  *   - Gemini: "Function response without function call"
  */
-function fixToolPairs(messages: Record<string, unknown>[]) {
+export function fixToolPairs(messages: Record<string, unknown>[]) {
   // Pass 1: Collect all tool_result IDs from user/tool messages
   const toolResultIds = new Set();
   for (const msg of messages) {

--- a/open-sse/services/contextManager.ts
+++ b/open-sse/services/contextManager.ts
@@ -400,3 +400,71 @@ export function fixToolPairs(messages: Record<string, unknown>[]) {
     })
     .filter(Boolean) as Record<string, unknown>[];
 }
+
+/**
+ * Upstream-send guard: after `fixToolPairs`, strip a trailing assistant
+ * message whose only/remaining content is an orphan `tool_use` block.
+ *
+ * `fixToolPairs` intentionally preserves a final-message `tool_use` because
+ * during context pruning the client is still waiting on the matching
+ * `tool_result` — dropping it there would lose state. But on the
+ * upstream-send path the request body must end on a user turn; a trailing
+ * `assistant(tool_use)` triggers the same Anthropic 400 the guard is
+ * trying to prevent:
+ *   messages.N: `tool_use` ids were found without `tool_result` blocks
+ *   immediately after: toolu_...
+ *
+ * Behavior:
+ *  - If the last message is `assistant` and contains any `tool_use` block,
+ *    those blocks are removed.
+ *  - If removal leaves the message with no content / tool_calls at all, the
+ *    message itself is dropped.
+ *  - Idempotent on clean histories (trailing user, trailing assistant with
+ *    only text/thinking, etc.).
+ */
+export function stripTrailingAssistantOrphanToolUse(
+  messages: Record<string, unknown>[]
+): Record<string, unknown>[] {
+  if (!Array.isArray(messages) || messages.length === 0) return messages;
+
+  const lastIdx = messages.length - 1;
+  const last = messages[lastIdx];
+  if (!last || last.role !== "assistant") return messages;
+
+  let modified = false;
+  const newLast: Record<string, unknown> = { ...last };
+
+  if (Array.isArray(newLast.tool_calls)) {
+    const filteredCalls = (newLast.tool_calls as Record<string, unknown>[]).filter(
+      () => false // remove all trailing tool_calls (none can be paired by definition)
+    );
+    if (filteredCalls.length !== (newLast.tool_calls as unknown[]).length) {
+      newLast.tool_calls = filteredCalls;
+      modified = true;
+    }
+  }
+
+  if (Array.isArray(newLast.content)) {
+    const filteredContent = (newLast.content as Record<string, unknown>[]).filter(
+      (block) => block.type !== "tool_use"
+    );
+    if (filteredContent.length !== (newLast.content as unknown[]).length) {
+      newLast.content = filteredContent;
+      modified = true;
+    }
+  }
+
+  if (!modified) return messages;
+
+  // If the last message is now empty, drop it.
+  const hasContent =
+    typeof newLast.content === "string"
+      ? (newLast.content as string).trim().length > 0
+      : Array.isArray(newLast.content) && (newLast.content as unknown[]).length > 0;
+  const hasToolCalls =
+    Array.isArray(newLast.tool_calls) && (newLast.tool_calls as unknown[]).length > 0;
+
+  const result = messages.slice(0, lastIdx);
+  if (hasContent || hasToolCalls) result.push(newLast);
+  return result;
+}

--- a/tests/unit/cc-bridge-tool-pair-guard.test.ts
+++ b/tests/unit/cc-bridge-tool-pair-guard.test.ts
@@ -3,9 +3,10 @@ import assert from "node:assert/strict";
 
 const { buildAndSignClaudeCodeRequest } =
   await import("../../open-sse/services/claudeCodeCompatible.ts");
-const { fixToolPairs } = await import("../../open-sse/services/contextManager.ts");
+const { fixToolPairs, stripTrailingAssistantOrphanToolUse } =
+  await import("../../open-sse/services/contextManager.ts");
 
-// Regression for prod 400 (call log fd429ec8-34f7-4f24-8154-f220f0cc3cd3):
+// Regression for the Anthropic 400:
 //   `messages.N: tool_use ids were found without tool_result blocks
 //   immediately after: toolu_...`
 // The CC bridge now invokes fixToolPairs in step 5c before serialization
@@ -102,4 +103,91 @@ test("buildAndSignClaudeCodeRequest invokes fixToolPairs via step 5c", async () 
   const text = JSON.stringify(body.messages);
   assert.ok(!text.includes("toolu_orphan"), "orphan tool_use must be stripped before send");
   assert.ok(text.includes("toolu_kept"), "paired tool_use must survive");
+});
+
+test("stripTrailingAssistantOrphanToolUse strips trailing assistant tool_use blocks", () => {
+  const messages = [
+    { role: "user", content: "hi" },
+    {
+      role: "assistant",
+      content: [
+        { type: "text", text: "thinking" },
+        { type: "tool_use", id: "toolu_trailing", name: "Bash", input: {} },
+      ],
+    },
+  ];
+
+  const stripped = stripTrailingAssistantOrphanToolUse(messages as never);
+  const text = JSON.stringify(stripped);
+  assert.ok(!text.includes("toolu_trailing"), "trailing tool_use must be removed");
+  // Text content survives — message kept, only tool_use blocks removed.
+  assert.ok(text.includes("thinking"), "non-tool_use content must survive");
+});
+
+test("stripTrailingAssistantOrphanToolUse drops final message if it becomes empty", () => {
+  const messages = [
+    { role: "user", content: "hi" },
+    {
+      role: "assistant",
+      content: [{ type: "tool_use", id: "toolu_only", name: "Bash", input: {} }],
+    },
+  ];
+
+  const stripped = stripTrailingAssistantOrphanToolUse(messages as never);
+  assert.equal(stripped.length, 1, "now-empty assistant message dropped entirely");
+  assert.equal(stripped[0].role, "user");
+});
+
+test("stripTrailingAssistantOrphanToolUse is a no-op when last message is a user turn", () => {
+  const messages = [
+    { role: "user", content: "hi" },
+    { role: "assistant", content: [{ type: "text", text: "hello" }] },
+    { role: "user", content: "follow up" },
+  ];
+
+  const stripped = stripTrailingAssistantOrphanToolUse(messages as never);
+  assert.deepEqual(stripped, messages);
+});
+
+test("stripTrailingAssistantOrphanToolUse is a no-op on text-only trailing assistant", () => {
+  const messages = [
+    { role: "user", content: "hi" },
+    { role: "assistant", content: [{ type: "text", text: "answer" }] },
+  ];
+
+  const stripped = stripTrailingAssistantOrphanToolUse(messages as never);
+  assert.deepEqual(stripped, messages);
+});
+
+test("buildAndSignClaudeCodeRequest strips trailing assistant tool_use (gemini HIGH review)", async () => {
+  // Anthropic rejects a body whose LAST message is assistant(tool_use)
+  // with no matching tool_result in the next user message — by definition
+  // there is no next message. fixToolPairs alone preserves the trailing
+  // tool_use (intentional for context pruning), so the guard pipeline
+  // pairs it with stripTrailingAssistantOrphanToolUse.
+  const result = await buildAndSignClaudeCodeRequest({
+    model: "claude-opus-4-7",
+    apiKey: "test-key",
+    claudeBody: {
+      model: "claude-opus-4-7",
+      max_tokens: 32,
+      messages: [
+        { role: "user", content: "hi" },
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "calling" },
+            { type: "tool_use", id: "toolu_trailing", name: "Bash", input: {} },
+          ],
+        },
+      ],
+    },
+  });
+
+  const body = JSON.parse(result.bodyString);
+  const text = JSON.stringify(body.messages);
+  assert.ok(
+    !text.includes("toolu_trailing"),
+    "trailing assistant tool_use must be stripped before upstream send"
+  );
 });

--- a/tests/unit/cc-bridge-tool-pair-guard.test.ts
+++ b/tests/unit/cc-bridge-tool-pair-guard.test.ts
@@ -1,0 +1,105 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { buildAndSignClaudeCodeRequest } =
+  await import("../../open-sse/services/claudeCodeCompatible.ts");
+const { fixToolPairs } = await import("../../open-sse/services/contextManager.ts");
+
+// Regression for prod 400 (call log fd429ec8-34f7-4f24-8154-f220f0cc3cd3):
+//   `messages.N: tool_use ids were found without tool_result blocks
+//   immediately after: toolu_...`
+// The CC bridge now invokes fixToolPairs in step 5c before serialization
+// so orphan tool_use blocks from mid-tool-call truncated histories are
+// stripped before reaching Anthropic.
+
+test("fixToolPairs strips orphan tool_use blocks from non-final assistant messages", () => {
+  const messages = [
+    { role: "user", content: "hi" },
+    {
+      role: "assistant",
+      content: [
+        { type: "text", text: "calling" },
+        { type: "tool_use", id: "toolu_orphan", name: "Bash", input: {} },
+      ],
+    },
+    { role: "user", content: "no tool result here" },
+    {
+      role: "assistant",
+      content: [
+        { type: "text", text: "done" },
+        { type: "tool_use", id: "toolu_kept", name: "Bash", input: {} },
+      ],
+    },
+    {
+      role: "user",
+      content: [{ type: "tool_result", tool_use_id: "toolu_kept", content: "ok" }],
+    },
+  ];
+
+  const fixed = fixToolPairs(messages as never);
+  const text = JSON.stringify(fixed);
+  assert.ok(!text.includes("toolu_orphan"), "orphan tool_use must be stripped");
+  assert.ok(text.includes("toolu_kept"), "paired tool_use must survive");
+});
+
+test("fixToolPairs is idempotent on clean histories", () => {
+  const cleanMessages = [
+    { role: "user", content: "hi" },
+    {
+      role: "assistant",
+      content: [
+        { type: "text", text: "calling" },
+        { type: "tool_use", id: "toolu_a", name: "Bash", input: {} },
+      ],
+    },
+    {
+      role: "user",
+      content: [{ type: "tool_result", tool_use_id: "toolu_a", content: "ok" }],
+    },
+  ];
+
+  const once = fixToolPairs(cleanMessages as never);
+  const twice = fixToolPairs(once);
+  assert.deepEqual(once, twice, "idempotent on clean histories");
+});
+
+test("buildAndSignClaudeCodeRequest invokes fixToolPairs via step 5c", async () => {
+  // Pass messages via claudeBody (BuildRequestOptions accepts sourceBody/
+  // normalizedBody/claudeBody — claudeBody is the path that preserves the
+  // shape we expect for an Anthropic-format upstream).
+  const result = await buildAndSignClaudeCodeRequest({
+    model: "claude-opus-4-7",
+    apiKey: "test-key",
+    claudeBody: {
+      model: "claude-opus-4-7",
+      max_tokens: 32,
+      messages: [
+        { role: "user", content: "hi" },
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "calling" },
+            { type: "tool_use", id: "toolu_orphan", name: "Bash", input: {} },
+          ],
+        },
+        { role: "user", content: "no tool result here" },
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "done" },
+            { type: "tool_use", id: "toolu_kept", name: "Bash", input: {} },
+          ],
+        },
+        {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "toolu_kept", content: "ok" }],
+        },
+      ],
+    },
+  });
+
+  const body = JSON.parse(result.bodyString);
+  const text = JSON.stringify(body.messages);
+  assert.ok(!text.includes("toolu_orphan"), "orphan tool_use must be stripped before send");
+  assert.ok(text.includes("toolu_kept"), "paired tool_use must survive");
+});


### PR DESCRIPTION
## Problem

Anthropic returns 400 when a request's `messages` array contains a
`tool_use` block whose matching `tool_result` is missing from the next
user message:

```
[400]: messages.N: `tool_use` ids were found without `tool_result`
blocks immediately after: toolu_...
```

This happens in normal client flows whenever the conversation history
is truncated mid-tool-call:

- mid-stream abort dropped the upstream `tool_result` before it was
  appended to history
- client-side context truncation cut between an assistant `tool_use`
  and the user's `tool_result`
- retry on a different model after the previous tool answer was lost
- combo fallthrough where step N+1 inherits a partially-completed
  history from step N

OmniRoute forwards these histories to Anthropic as-is and the entire
request fails — even though the orphan block is recoverable by simply
dropping it.

## Existing code

OmniRoute already has a function that handles exactly this case:
`fixToolPairs()` in `open-sse/services/contextManager.ts`. It runs a
four-pass cleanup:

1. Collect all `tool_result` IDs present in user/tool messages.
2. Filter assistant messages — drop `tool_use` blocks whose ID has no
   matching `tool_result` in the next user message (preserves the
   final assistant turn's `tool_use` since the client is still waiting
   on a response).
3. Collect remaining `tool_use` IDs after pass 2.
4. Filter user messages — drop orphan `tool_result` blocks; drop
   messages that become empty.

The doc comment on the function explicitly cites the Anthropic 400
this PR is about.

**The gap:** `fixToolPairs` was invoked only from `purifyHistory()` in
the same file, which is called from the **token-budget context-window
pruning** path. A request that fits in the model's context window
skips that path entirely, so the cleanup never runs and the orphan
blocks survive to upstream.

## Fix

Wire the existing cleanup into both upstream send paths as an
unconditional pre-serialization guard:

1. Export `fixToolPairs` from `contextManager.ts` (one-line change —
   it was an internal helper).

2. CC bridge path (`open-sse/services/claudeCodeCompatible.ts`,
   `buildAndSignClaudeCodeRequest`) — insert as **step 5c**, between
   the system-block transforms (5b) and the obfuscation pass (6):

   ```ts
   if (Array.isArray((body as Record<string, unknown>).messages)) {
     (body as Record<string, unknown>).messages = fixToolPairs(
       (body as Record<string, unknown>).messages as Record<string, unknown>[],
     );
   }
   ```

3. Native claude path (`open-sse/executors/base.ts`) — same guard,
   placed right before `JSON.stringify(transformedBody)`.

`fixToolPairs` is idempotent (running it on a clean history is a
no-op) and O(N) on message count, so the always-on guard adds
negligible cost.

## What this solves

| Before | After |
|--------|-------|
| Client truncates mid-tool-call → request reaches Anthropic with orphan `tool_use` → 400, request fails. | Same input → guard strips the orphan → Anthropic receives a valid history → request succeeds. |
| Stripping logic existed but ran only when the request was already too big to fit. | Stripping logic now runs on every request, regardless of token count. |
| Same recovery code duplicated client-side in plugin wrappers. | Recovery handled server-side; client wrappers can be retired. |

## Tests

`tests/unit/cc-bridge-tool-pair-guard.test.ts` — 3 new tests:

- Orphan `tool_use` in a non-final assistant message is stripped while
  paired `tool_use` blocks survive.
- Running `fixToolPairs` twice is identical to running it once
  (idempotent on clean histories).
- Full `buildAndSignClaudeCodeRequest` integration via `claudeBody`
  proves step 5c fires inside the real CC bridge pipeline.

Regression check: `tests/unit/context-manager.test.ts` (21 existing
tests covering `fixToolPairs` semantics + the pruning path) and
`tests/unit/claude-code-compatible-helpers.test.ts` (6 existing tests)
all pass unchanged.

## Scope

- 1 new file: `tests/unit/cc-bridge-tool-pair-guard.test.ts`
- 3 modified files:
  - `open-sse/services/contextManager.ts` — one-line export
  - `open-sse/services/claudeCodeCompatible.ts` — import + step 5c
  - `open-sse/executors/base.ts` — import + guard before `JSON.stringify`
- No DB, env, route, dep, or schema changes
- No breaking changes — clean histories pass through identically;
  affected requests previously failed with 400 and now succeed
