### PR TITLE
fix(claude): clamp thinking budget to caller max_tokens

### DIFF
--- a/open-sse/translator/request/openai-to-claude.ts
+++ b/open-sse/translator/request/openai-to-claude.ts
@@ -10,6 +10,7 @@ import { DEFAULT_THINKING_CLAUDE_SIGNATURE } from "../../config/defaultThinkingS
 // Can be disabled per-request via body._disableToolPrefix = true
 export const CLAUDE_OAUTH_TOOL_PREFIX = "proxy_";
 const CLAUDE_TOOL_CHOICE_REQUIRED = "an" + "y";
+const MIN_CLAUDE_THINKING_BUDGET = 1024;
 
 type ClaudeContentBlock = Record<string, unknown>;
 type ClaudeMessage = {
@@ -28,6 +29,25 @@ type ClaudeTool = {
   cache_control?: { type: string; ttl?: string };
   defer_loading?: boolean;
 };
+
+function fitThinkingToMaxTokens(
+  maxTokens: number,
+  thinking?: Record<string, unknown>
+): Record<string, unknown> | undefined {
+  const budgetTokens = Number(thinking?.budget_tokens) || 0;
+  if (budgetTokens <= 0) return thinking;
+  if (maxTokens > budgetTokens) return thinking;
+
+  const fittedBudget = maxTokens - 1;
+  if (fittedBudget < MIN_CLAUDE_THINKING_BUDGET) {
+    return { type: "disabled" };
+  }
+
+  return {
+    ...thinking,
+    budget_tokens: fittedBudget,
+  };
+}
 
 /**
  * T02: Recursively strips empty text blocks from content arrays.
@@ -374,19 +394,12 @@ export function openaiToClaudeRequest(model, body, stream) {
           type: "enabled",
           budget_tokens: budget,
         };
-        // Claude requires max_tokens > budget_tokens
-        if (result.max_tokens <= budget) {
-          result.max_tokens = budget + 8192;
-        }
       }
     }
   }
 
-  // Ensure max_tokens > budget_tokens for all thinking configurations (#627)
-  const budgetTokens = Number(result.thinking?.budget_tokens) || 0;
-  if (budgetTokens > 0 && result.max_tokens <= budgetTokens) {
-    result.max_tokens = budgetTokens + 8192;
-  }
+  // Preserve the caller's max_tokens and fit Claude thinking under it.
+  result.thinking = fitThinkingToMaxTokens(result.max_tokens, result.thinking);
 
   // Attach toolNameMap to result for response translation
   if (toolNameMap.size > 0) {

--- a/tests/unit/translator-openai-to-claude.test.ts
+++ b/tests/unit/translator-openai-to-claude.test.ts
@@ -236,7 +236,7 @@ test("OpenAI -> Claude maps tool_choice and injects response_format instructions
   assert.match(jsonObjectResult.system[0].text, /Respond ONLY with a JSON object/i);
 });
 
-test("OpenAI -> Claude turns reasoning settings into thinking budgets and expands max tokens", () => {
+test("OpenAI -> Claude turns reasoning settings into thinking budgets without inflating max tokens", () => {
   const effortResult = openaiToClaudeRequest(
     "claude-4-sonnet",
     {
@@ -247,8 +247,8 @@ test("OpenAI -> Claude turns reasoning settings into thinking budgets and expand
     false
   );
 
-  assert.deepEqual(effortResult.thinking, { type: "enabled", budget_tokens: 1024 });
-  assert.equal(effortResult.max_tokens, 9216);
+  assert.deepEqual(effortResult.thinking, { type: "disabled" });
+  assert.equal(effortResult.max_tokens, 10);
 
   const explicitThinkingResult = openaiToClaudeRequest(
     "claude-4-sonnet",
@@ -261,11 +261,9 @@ test("OpenAI -> Claude turns reasoning settings into thinking budgets and expand
   );
 
   assert.deepEqual(explicitThinkingResult.thinking, {
-    type: "enabled",
-    budget_tokens: 2000,
-    max_tokens: 3000,
+    type: "disabled",
   });
-  assert.equal(explicitThinkingResult.max_tokens, 10192);
+  assert.equal(explicitThinkingResult.max_tokens, 1000);
 });
 
 test("OpenAI -> Claude preserves xhigh only for Claude models that expose it", () => {
@@ -290,9 +288,24 @@ test("OpenAI -> Claude preserves xhigh only for Claude models that expose it", (
 
   assert.deepEqual(preserved.thinking, { type: "adaptive" });
   assert.deepEqual(preserved.output_config, { effort: "xhigh" });
-  assert.deepEqual(downgraded.thinking, { type: "enabled", budget_tokens: 131072 });
+  assert.deepEqual(downgraded.thinking, { type: "disabled" });
   assert.equal(downgraded.output_config, undefined);
-  assert.equal(downgraded.max_tokens, 139264);
+  assert.equal(downgraded.max_tokens, 10);
+});
+
+test("OpenAI -> Claude clamps thinking budget to fit caller max_tokens", () => {
+  const result = openaiToClaudeRequest(
+    "claude-4-sonnet",
+    {
+      messages: [{ role: "user", content: "Think harder" }],
+      max_tokens: 5000,
+      reasoning_effort: "high",
+    },
+    false
+  );
+
+  assert.deepEqual(result.thinking, { type: "enabled", budget_tokens: 4999 });
+  assert.equal(result.max_tokens, 5000);
 });
 
 test("OpenAI -> Claude can disable OAuth prefixes and Antigravity strips Claude-only prompting", () => {


### PR DESCRIPTION
## Summary

`openaiToClaudeRequest` previously inflated the caller's `max_tokens` by 8192 whenever Claude thinking was enabled with a budget at or above the requested `max_tokens`. That silently overrode the user's quota and surprised gateway clients (and downstream API-key budget guards) that had already sized their output cap.

This PR replaces the inflate-max_tokens path with a clamp on the thinking budget itself:

- If `max_tokens > budget` → keep both as-is.
- If `max_tokens <= budget` and the fitted budget (`max_tokens - 1`) is ≥ 1024 (Claude's `MIN_CLAUDE_THINKING_BUDGET`) → clamp `budget_tokens` to `max_tokens - 1`.
- Otherwise → disable thinking for this request (`{ type: \"disabled\" }`).

The caller's `max_tokens` contract is preserved in every branch.

## Test Plan

- All 10 cases in \`tests/unit/translator-openai-to-claude.test.ts\` pass.
- Updated existing two cases to reflect new behaviour (no inflate) and added a new third case \`OpenAI -> Claude clamps thinking budget to fit caller max_tokens\` that exercises the clamp branch.

\`\`\`
✔ OpenAI -> Claude turns reasoning settings into thinking budgets without inflating max tokens
✔ OpenAI -> Claude preserves xhigh only for Claude models that expose it
✔ OpenAI -> Claude clamps thinking budget to fit caller max_tokens
...
ℹ tests 10  pass 10  fail 0
\`\`\`

## Compatibility

- Behavioural change: callers that were relying on the implicit \`max_tokens += 8192\` boost will now either get a smaller thinking budget or disabled thinking instead. They will not silently exceed their requested cap.
- For \`reasoning_effort\` callers who pass small \`max_tokens\` (e.g. counted-tokens probes) thinking will now be disabled rather than getting an oversized output cap.