### PR TITLE
fix(v1/messages): default to non-stream for Claude format when ambiguous

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -1683,10 +1683,13 @@ export async function handleChatCore({
 
   // Codex /responses/compact is JSON-only: Codex CLI does not send stream=false,
   // so route shape must override the usual Accept/header fallback.
+  // sourceFormat="claude" applies the Anthropic Messages spec default (stream=false
+  // when body omits stream), preventing STREAM_EARLY_EOF on /v1/messages when
+  // clients send Accept: */* without an explicit stream flag.
   const stream =
     nativeCodexPassthrough && isCompactResponsesEndpoint(endpointPath)
       ? false
-      : resolveStreamFlag(body?.stream, acceptHeader);
+      : resolveStreamFlag(body?.stream, acceptHeader, sourceFormat);
   const settings = cachedSettings ?? (await getCachedSettings());
   credentials = applyCodexGlobalFastServiceTier(provider, credentials, settings);
   effectiveServiceTier = resolveEffectiveServiceTier(body);

--- a/open-sse/utils/aiSdkCompat.ts
+++ b/open-sse/utils/aiSdkCompat.ts
@@ -17,11 +17,34 @@ export function clientWantsJsonResponse(acceptHeader: unknown): boolean {
  * Accept header only acts as fallback when stream is not explicitly set.
  * Fixes #656: clients sending both `stream: true` and `Accept: application/json`
  * should still get streaming responses — body intent takes precedence.
+ *
+ * Optional `sourceFormat` argument lets callers apply spec-correct defaults
+ * when both `stream` and `Accept` are ambiguous. The Anthropic Messages API
+ * defaults to non-stream when the body omits `stream`, regardless of Accept
+ * header. Without this hint, OmniRoute previously routed Anthropic /v1/messages
+ * requests with a curl-default wildcard Accept header through the streaming
+ * branch even though upstream returned JSON, producing STREAM_EARLY_EOF /
+ * HTTP 502 errors.
  */
-export function resolveStreamFlag(bodyStream: unknown, acceptHeader: unknown): boolean {
+export function resolveStreamFlag(
+  bodyStream: unknown,
+  acceptHeader: unknown,
+  sourceFormat?: string
+): boolean {
   // Explicit body value always wins
   if (bodyStream === true) return true;
   if (bodyStream === false) return false;
+
+  // Anthropic Messages API spec: stream defaults to false when body omits it.
+  // Only honor an explicit text/event-stream Accept header as a streaming opt-in
+  // for /v1/messages — otherwise default to non-stream so upstream JSON responses
+  // are surfaced correctly instead of triggering stream_early_eof.
+  if (sourceFormat === "claude") {
+    if (typeof acceptHeader === "string" && /text\/event-stream/i.test(acceptHeader)) {
+      return true;
+    }
+    return false;
+  }
 
   // No explicit stream param — preserve OmniRoute's streaming default unless
   // the client explicitly asks for JSON and does not also accept SSE.

--- a/tests/unit/t26-ai-sdk-accept-header-compat.test.ts
+++ b/tests/unit/t26-ai-sdk-accept-header-compat.test.ts
@@ -48,6 +48,39 @@ test("T26: explicit stream:false always prevents streaming", () => {
   assert.equal(resolveStreamFlag(false, undefined), false);
 });
 
+test("T26: sourceFormat=claude applies Anthropic Messages non-stream default (#2325)", () => {
+  // Anthropic Messages API spec: stream defaults to false when body omits it,
+  // regardless of Accept header. Previously OmniRoute defaulted to stream=true
+  // for Accept: */* or undefined, causing STREAM_EARLY_EOF on /v1/messages.
+
+  // Ambiguous cases must default to non-stream when sourceFormat is claude
+  assert.equal(resolveStreamFlag(undefined, undefined, "claude"), false);
+  assert.equal(resolveStreamFlag(undefined, "*/*", "claude"), false);
+  assert.equal(resolveStreamFlag(undefined, "application/json", "claude"), false);
+
+  // Explicit body stream still wins over format default
+  assert.equal(resolveStreamFlag(true, undefined, "claude"), true);
+  assert.equal(resolveStreamFlag(true, "*/*", "claude"), true);
+  assert.equal(resolveStreamFlag(false, "text/event-stream", "claude"), false);
+
+  // Accept: text/event-stream is honored as an explicit SSE opt-in
+  assert.equal(resolveStreamFlag(undefined, "text/event-stream", "claude"), true);
+  assert.equal(resolveStreamFlag(undefined, "application/json, text/event-stream", "claude"), true);
+});
+
+test("T26: non-claude sourceFormat preserves pre-#2325 streaming default", () => {
+  // OpenAI / Gemini / Codex callers keep the existing streaming-by-default heuristic
+  // so we don't break SDKs that omit `stream` and expect SSE.
+  assert.equal(resolveStreamFlag(undefined, undefined, "openai"), true);
+  assert.equal(resolveStreamFlag(undefined, "*/*", "openai"), true);
+  assert.equal(resolveStreamFlag(undefined, "application/json", "openai"), false);
+  assert.equal(resolveStreamFlag(undefined, undefined, "gemini"), true);
+  assert.equal(resolveStreamFlag(undefined, undefined, "codex"), true);
+  // Omitting sourceFormat reproduces the legacy two-arg behavior exactly
+  assert.equal(resolveStreamFlag(undefined, undefined), true);
+  assert.equal(resolveStreamFlag(undefined, "application/json"), false);
+});
+
 test("T26: explicit non-stream aliases are detected", () => {
   assert.equal(hasExplicitNoStreamParam({ non_stream: true }), true);
   assert.equal(hasExplicitNoStreamParam({ disable_stream: true }), true);


### PR DESCRIPTION
## Summary

`POST /v1/messages` without a `stream` field and with a wildcard `Accept` header (curl default `*/*`) returns HTTP 502 `STREAM_EARLY_EOF` in ~1.6s. Stream version (`stream:true`) works correctly.

## Root cause

`resolveStreamFlag(undefined, "*/*")` falls through to `!clientWantsJsonResponse("*/*")` which returns `true`. OmniRoute then takes the streaming branch in `chatCore.ts` and invokes `ensureStreamReadiness` on the upstream response.

But Anthropic's Messages API treats `stream` in the **body** as the source of truth (Accept header is ignored). Since the body has no `stream` field, Anthropic returns a single JSON document with `Content-Type: application/json`. `ensureStreamReadiness` parses this JSON body as SSE, finds no useful `data: {...}` frame, hits EOF on the next read, and returns 502.

The bug is OpenAI-format-centric: OpenAI clients omitting `stream` typically expect SSE by default, but Anthropic's spec is `stream: false` by default.

## Fix

`resolveStreamFlag` now takes an optional `sourceFormat` argument:

- `sourceFormat === "claude"` + ambiguous stream + no explicit `text/event-stream` in Accept → default to **false** (matches Anthropic spec).
- All other sourceFormats (or omitting the argument): unchanged. The #656 fix and OpenAI streaming default are preserved.

Explicit body `stream: true|false` still wins. Explicit `Accept: text/event-stream` is honored as an SSE opt-in for `/v1/messages`.

`chatCore.ts` passes the already-resolved `sourceFormat` (from `detectFormatFromEndpoint`) to the new third argument.

## Tests

`tests/unit/t26-ai-sdk-accept-header-compat.test.ts` (11/11 pass):
- 9 existing tests unchanged.
- New: `sourceFormat=claude` applies Anthropic non-stream default (3 ambiguous cases default false; 3 explicit cases still win; Accept text/event-stream still streams).
- New: non-claude sourceFormats (`openai`, `gemini`, `codex`) preserve pre-#2325 streaming default; omitting sourceFormat reproduces legacy two-arg behavior exactly.

## Repro

**Before:**
```
curl -X POST :20128/v1/messages \
  -H 'Authorization: Bearer ...' \
  -H 'Content-Type: application/json' \
  -d '{"model":"claude/claude-opus-4-7","max_tokens":40,
       "messages":[{"role":"user","content":"hi"}]}'

→ HTTP 502 {"error":{"message":"Stream ended before producing useful content",
              "type":"stream_early_eof","code":"STREAM_EARLY_EOF"}}
```

**After:** HTTP 200 JSON in 2.4s (matches the `stream:false` explicit path).

## Out of scope

A separate, narrower edge case remains for clients sending `Accept: text/event-stream` with no body `stream` field: upstream Anthropic still returns JSON because body lacks `stream`. That bug existed pre-#2325 and is not regressed here. A future PR can sync `body.stream = true` into the upstream passthrough when SSE is being requested.

## Files

- `open-sse/utils/aiSdkCompat.ts` (+23 / -1)
- `open-sse/handlers/chatCore.ts` (+4 / -1)
- `tests/unit/t26-ai-sdk-accept-header-compat.test.ts` (+36)