### PR TITLE
fix(providers): fix missing i18n keys and add 'Add Provider' button to empty state

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/page.tsx
+++ b/src/app/(dashboard)/dashboard/providers/page.tsx
@@ -117,6 +117,7 @@ export default function ProvidersPage() {
   const [expirations, setExpirations] = useState<any>(null);
   const [codexGlobalFastServiceTier, setCodexGlobalFastServiceTier] = useState(false);
   const [loading, setLoading] = useState(true);
+  const [showAllProviders, setShowAllProviders] = useState(false);
   const [showAddCompatibleModal, setShowAddCompatibleModal] = useState(false);
   const [showAddAnthropicCompatibleModal, setShowAddAnthropicCompatibleModal] = useState(false);
   const [showAddCcCompatibleModal, setShowAddCcCompatibleModal] = useState(false);
@@ -623,20 +624,18 @@ export default function ProvidersPage() {
     webCookieProviderEntriesAll.filter((e) => Number(e.stats?.total || 0) > 0).length +
     localProviderEntriesAll.filter((e) => Number(e.stats?.total || 0) > 0).length;
 
-  if (totalConfigured === 0 && !searchQuery) {
+  if (totalConfigured === 0 && !searchQuery && !showAllProviders) {
     return (
       <div className="flex flex-col items-center justify-center py-20 text-center">
         <div className="flex items-center justify-center size-16 rounded-full bg-primary/10 mb-4">
           <span className="material-symbols-outlined text-[32px] text-primary">dns</span>
         </div>
-        <h2 className="text-xl font-semibold text-text-main">
-          {t("addFirstProvider") || "Add your first provider"}
-        </h2>
-        <p className="text-sm text-text-muted mt-2 max-w-md">
-          {t("addFirstProviderDesc") ||
-            "Connect an AI provider to start routing requests through OmniRoute. You can use free providers, API keys, or OAuth accounts."}
-        </p>
+        <h2 className="text-xl font-semibold text-text-main">{t("addFirstProvider")}</h2>
+        <p className="text-sm text-text-muted mt-2 max-w-md">{t("addFirstProviderDesc")}</p>
         <div className="flex items-center gap-3 mt-4">
+          <Button icon="add" onClick={() => setShowAllProviders(true)}>
+            {t("addProvider")}
+          </Button>
           <a
             href="https://docs.omniroute.io/providers"
             target="_blank"
@@ -644,7 +643,7 @@ export default function ProvidersPage() {
             className="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium rounded-lg border border-border text-text-muted hover:text-text-main hover:bg-bg-subtle transition-colors"
           >
             <span className="material-symbols-outlined text-[16px]">help</span>
-            {t("learnMore") || "Learn more"}
+            {t("learnMore")}
           </a>
         </div>
       </div>

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -2771,6 +2771,9 @@
   "providers": {
     "title": "Providers",
     "addProvider": "Add Provider",
+    "addFirstProvider": "Add your first provider",
+    "addFirstProviderDesc": "Connect an AI provider to start routing requests through OmniRoute. You can use free providers, API keys, or OAuth accounts.",
+    "learnMore": "Learn more",
     "editProvider": "Edit Provider",
     "deleteProvider": "Delete Provider",
     "noProviders": "No providers configured",


### PR DESCRIPTION
## Summary

- **Bug 1 (i18n)**: `addFirstProvider`, `addFirstProviderDesc`, `learnMore` were in the `common` namespace but `ProvidersPage` uses `t = useTranslations("providers")` — the page showed raw keys (`providers.addFirstProvider`) on fresh installs. Fix: add the 3 keys to the `providers` namespace in `en.json`.
- **Bug 2 (missing button)**: The empty state (shown when `totalConfigured === 0`) had only a "Learn more" external link — no way to actually add a provider. Fix: add a primary `Add Provider` button that reveals the full providers grid (`showAllProviders` state) so users can click any provider card to configure it.
- Both bugs were introduced together in commit `a4a870cda` (feat(ui): add newbie-friendly UX improvements).

## Test plan

- [ ] Fresh install with no providers: page shows correct text (not raw i18n keys)
- [ ] "Add Provider" button is visible on empty state
- [ ] Clicking "Add Provider" reveals the full provider grid
- [ ] Existing installs with configured providers: no regression (empty state not shown)
- [ ] i18n: `providers.addFirstProvider`, `providers.addFirstProviderDesc`, `providers.learnMore` resolve correctly in English
- [ ] Pre-commit hooks pass (cli-i18n, i18n-ui-coverage, docs-sync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)