### PR TITLE
fix(providers): fix missing i18n keys and add 'Add Provider' button to empty state

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/page.tsx
+++ b/src/app/(dashboard)/dashboard/providers/page.tsx
@@ -117,6 +117,7 @@ export default function ProvidersPage() {
   const [expirations, setExpirations] = useState<any>(null);
   const [codexGlobalFastServiceTier, setCodexGlobalFastServiceTier] = useState(false);
   const [loading, setLoading] = useState(true);
+  const [showAllProviders, setShowAllProviders] = useState(false);
   const [showAddCompatibleModal, setShowAddCompatibleModal] = useState(false);
   const [showAddAnthropicCompatibleModal, setShowAddAnthropicCompatibleModal] = useState(false);
   const [showAddCcCompatibleModal, setShowAddCcCompatibleModal] = useState(false);
@@ -623,20 +624,18 @@ export default function ProvidersPage() {
     webCookieProviderEntriesAll.filter((e) => Number(e.stats?.total || 0) > 0).length +
     localProviderEntriesAll.filter((e) => Number(e.stats?.total || 0) > 0).length;
 
-  if (totalConfigured === 0 && !searchQuery) {
+  if (totalConfigured === 0 && !searchQuery && !showAllProviders) {
     return (
       <div className="flex flex-col items-center justify-center py-20 text-center">
         <div className="flex items-center justify-center size-16 rounded-full bg-primary/10 mb-4">
           <span className="material-symbols-outlined text-[32px] text-primary">dns</span>
         </div>
-        <h2 className="text-xl font-semibold text-text-main">
-          {t("addFirstProvider") || "Add your first provider"}
-        </h2>
-        <p className="text-sm text-text-muted mt-2 max-w-md">
-          {t("addFirstProviderDesc") ||
-            "Connect an AI provider to start routing requests through OmniRoute. You can use free providers, API keys, or OAuth accounts."}
-        </p>
+        <h2 className="text-xl font-semibold text-text-main">{t("addFirstProvider")}</h2>
+        <p className="text-sm text-text-muted mt-2 max-w-md">{t("addFirstProviderDesc")}</p>
         <div className="flex items-center gap-3 mt-4">
+          <Button icon="add" onClick={() => setShowAllProviders(true)}>
+            {t("addProvider")}
+          </Button>
           <a
             href="https://docs.omniroute.io/providers"
             target="_blank"
@@ -644,7 +643,7 @@ export default function ProvidersPage() {
             className="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium rounded-lg border border-border text-text-muted hover:text-text-main hover:bg-bg-subtle transition-colors"
           >
             <span className="material-symbols-outlined text-[16px]">help</span>
-            {t("learnMore") || "Learn more"}
+            {t("learnMore")}
           </a>
         </div>
       </div>

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -2771,6 +2771,9 @@
   "providers": {
     "title": "Providers",
     "addProvider": "Add Provider",
+    "addFirstProvider": "Add your first provider",
+    "addFirstProviderDesc": "Connect an AI provider to start routing requests through OmniRoute. You can use free providers, API keys, or OAuth accounts.",
+    "learnMore": "Learn more",
     "editProvider": "Edit Provider",
     "deleteProvider": "Delete Provider",
     "noProviders": "No providers configured",


### PR DESCRIPTION
## Summary

- **Bug 1 (i18n)**: `addFirstProvider`, `addFirstProviderDesc`, `learnMore` estavam na namespace `common` mas a página usa `useTranslations("providers")` — exibia chaves brutas em instalações novas.
- **Bug 2 (botão sumido)**: O empty state só tinha link externo "Learn more" sem ação primária. Adicionado botão `Add Provider` que revela o grid completo de provedores.
- Ambos os bugs introduzidos no commit `a4a870cda`.

Cherry-pick de #2333 (já mergeado na `main`).

## Test plan

- [ ] Instalação nova: texto correto (sem chaves brutas)
- [ ] Botão "Add Provider" visível no empty state
- [ ] Clicar exibe o grid completo de provedores
- [ ] Sem regressão em instâncias com provedores já configurados

🤖 Generated with [Claude Code](https://claude.com/claude-code)