### PR TITLE
fix: allow bracketed combo names

### DIFF
--- a/src/shared/validation/schemas.ts
+++ b/src/shared/validation/schemas.ts
@@ -401,12 +401,18 @@ const comboRuntimeConfigSchema = z
   })
   .strict();
 
+const comboNameSchema = z
+  .string()
+  .trim()
+  .min(1, "Name is required")
+  .max(100)
+  .regex(
+    /^[a-zA-Z0-9_/.\-\[\] ]+$/,
+    "Name can only contain letters, numbers, spaces, -, _, /, ., [ and ]."
+  );
+
 export const createComboSchema = z.object({
-  name: z
-    .string()
-    .min(1, "Name is required")
-    .max(100)
-    .regex(/^[a-zA-Z0-9_/.-]+$/, "Name can only contain letters, numbers, -, _, / and ."),
+  name: comboNameSchema,
   models: z.array(comboModelEntry).optional().default([]),
   strategy: comboStrategySchema.optional().default("priority"),
   config: comboRuntimeConfigSchema.optional(),
@@ -1326,12 +1332,7 @@ export const cloudSyncActionSchema = z.object({
 
 export const updateComboSchema = z
   .object({
-    name: z
-      .string()
-      .min(1, "Name is required")
-      .max(100)
-      .regex(/^[a-zA-Z0-9_/.-]+$/, "Name can only contain letters, numbers, -, _, / and .")
-      .optional(),
+    name: comboNameSchema.optional(),
     models: z.array(comboModelEntry).optional(),
     strategy: comboStrategySchema.optional(),
     config: comboRuntimeConfigSchema.optional(),

--- a/tests/unit/combo-bracket-names.test.ts
+++ b/tests/unit/combo-bracket-names.test.ts
@@ -1,0 +1,80 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-combo-brackets-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const combosDb = await import("../../src/lib/db/combos.ts");
+const schemas = await import("../../src/shared/validation/schemas.ts");
+const sseModelService = await import("../../src/sse/services/model.ts");
+
+async function resetStorage() {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+test.beforeEach(async () => {
+  await resetStorage();
+});
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("combo schemas accept names with spaces and square brackets", () => {
+  const createResult = schemas.createComboSchema.safeParse({
+    name: "Claude [1m]",
+  });
+  const updateResult = schemas.updateComboSchema.safeParse({
+    name: "Claude [1m]",
+  });
+
+  assert.equal(createResult.success, true);
+  assert.equal(updateResult.success, true);
+});
+
+test("combo schemas still reject control characters and whitespace-only names", () => {
+  assert.equal(schemas.createComboSchema.safeParse({ name: "Claude\n[1m]" }).success, false);
+  assert.equal(schemas.updateComboSchema.safeParse({ name: "Claude\0[1m]" }).success, false);
+  assert.equal(schemas.createComboSchema.safeParse({ name: "   " }).success, false);
+});
+
+test("getComboForModel treats an exact bracketed name as a combo before model suffix parsing", async () => {
+  const exactCombo = await combosDb.createCombo({
+    name: "Claude [1m]",
+    models: [{ provider: "claude", model: "claude-sonnet-4-6" }],
+  });
+
+  await combosDb.createCombo({
+    name: "Claude",
+    models: [{ provider: "claude", model: "claude-opus-4-6" }],
+  });
+
+  const resolved = await sseModelService.getComboForModel("Claude [1m]");
+  const parsedAsModel = sseModelService.parseModel("Claude [1m]");
+
+  assert.equal(resolved?.id, exactCombo.id);
+  assert.equal(resolved?.name, "Claude [1m]");
+  assert.equal(parsedAsModel.extendedContext, true);
+  assert.equal(parsedAsModel.model, "Claude");
+});
+
+test("getComboForModel does not strip bracket suffix when no exact bracketed combo exists", async () => {
+  await combosDb.createCombo({
+    name: "Claude",
+    models: [{ provider: "claude", model: "claude-sonnet-4-6" }],
+  });
+
+  const resolved = await sseModelService.getComboForModel("Claude [1m]");
+  const parsedAsModel = sseModelService.parseModel("Claude [1m]");
+
+  assert.equal(resolved, null);
+  assert.equal(parsedAsModel.extendedContext, true);
+  assert.equal(parsedAsModel.model, "Claude");
+});

--- a/tests/unit/combo-routes-composite-tiers.test.ts
+++ b/tests/unit/combo-routes-composite-tiers.test.ts
@@ -80,6 +80,59 @@ test.after(() => {
   fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
 });
 
+test("POST /api/combos persists names with spaces and square brackets", async () => {
+  const response = await createRoute.POST(
+    makeCreateRequest({
+      name: "Claude [1m]",
+      strategy: "priority",
+      models: [{ providerId: "claude", model: "claude-sonnet-4-6" }],
+    })
+  );
+  const body = (await response.json()) as any;
+  const stored = await combosDb.getComboByName("Claude [1m]");
+
+  assert.equal(response.status, 201);
+  assert.equal(body.name, "Claude [1m]");
+  assert.equal(stored?.name, "Claude [1m]");
+  assert.equal(stored?.models[0].model, "claude/claude-sonnet-4-6");
+});
+
+test("POST /api/combos rejects duplicate bracketed names", async () => {
+  await combosDb.createCombo({
+    name: "Claude [1m]",
+    models: [{ provider: "claude", model: "claude-sonnet-4-6" }],
+  });
+
+  const response = await createRoute.POST(
+    makeCreateRequest({
+      name: "Claude [1m]",
+      strategy: "priority",
+      models: [{ providerId: "claude", model: "claude-opus-4-6" }],
+    })
+  );
+  const body = (await response.json()) as any;
+
+  assert.equal(response.status, 400);
+  assert.equal(body.error, "Combo name already exists");
+});
+
+test("PUT /api/combos can rename a combo to a bracketed name", async () => {
+  const combo = await combosDb.createCombo({
+    name: "claude-plain",
+    models: [{ provider: "claude", model: "claude-sonnet-4-6" }],
+  });
+
+  const response = await comboRoute.PUT(makeUpdateRequest({ name: "Claude [1m]" }), {
+    params: Promise.resolve({ id: combo.id }),
+  });
+  const body = (await response.json()) as any;
+  const stored = await combosDb.getComboByName("Claude [1m]");
+
+  assert.equal(response.status, 200);
+  assert.equal(body.name, "Claude [1m]");
+  assert.equal(stored?.id, combo.id);
+});
+
 test("POST /api/combos rejects composite tiers that point to unknown steps", async () => {
   const response = await createRoute.POST(
     makeCreateRequest({


### PR DESCRIPTION
## Summary
- Allow combo create/update validation to accept spaces and square brackets, e.g. `Claude [1m]`.
- Add schema, resolver, and combo route tests for bracketed combo names.
- Pin exact combo lookup behavior so `Claude [1m]` resolves as its own combo name when present, without silently stripping `[1m]` to another combo.

## Test Plan
- `DISABLE_SQLITE_AUTO_BACKUP=true node --import tsx/esm --test tests/unit/combo-bracket-names.test.ts tests/unit/combo-routes-composite-tiers.test.ts` — pass, 12/12.
- `git diff --check origin/main...HEAD` — pass.
- Claude Code independent review — pass, no blockers.
- `npm run typecheck:core` — fails on existing `open-sse/services/contextManager.ts` `never` errors in this checkout.
