### PR TITLE
fix: avoid redundant Claude Code message clone

### DIFF
--- a/open-sse/services/claudeCodeCompatible.ts
+++ b/open-sse/services/claudeCodeCompatible.ts
@@ -826,7 +826,7 @@ function prepareClaudeCodeCompatibleSemanticBody(claudeBody: Record<string, unkn
   const prepared: Record<string, unknown> = {
     system: normalizeClaudeSystemInput(claudeBody.system),
     messages: Array.isArray(claudeBody.messages)
-      ? (cloneValue(claudeBody.messages) as Array<Record<string, unknown>>)
+      ? (claudeBody.messages as Array<Record<string, unknown>>)
       : [],
     tools: normalizeClaudeToolInput(claudeBody.tools),
     thinking: (readRecord(cloneValue(claudeBody.thinking)) || null) as Record<


### PR DESCRIPTION
## Summary
- Avoids an unnecessary deep clone of Claude-native `messages` during Claude Code semantic passthrough preparation.
- Keeps the downstream final message-cloning path intact, preserving request output isolation while reducing memory/CPU overhead for large Claude Code histories.
## Context
This fix is based on a code review suggestion from @gemini-code-assist[bot] in PR #2351

`prepareClaudeCodeCompatibleSemanticBody()` was deep-cloning `claudeBody.messages`, and `buildClaudeCodeCompatibleRequest()` then passed those messages through `cloneClaudeCodeCompatibleMessagesFromClaude()`, which clones the message objects again.
This removes the first clone because the final cloning step still protects the emitted request body.
## Validation
- `node --import tsx/esm --test tests/unit/claude-code-compatible-request.test.ts` — passed (`10/10`)
- `git diff --check` — passed
- `node --import tsx/esm --test tests/integration/*.test.ts` — still fails with the same pre-existing integration failures observed before the fix