### PR TITLE
docs(readme): restore 9router acknowledgment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1652,6 +1652,8 @@ gh release create v2.0.0 --title "v2.0.0" --generate-notes
 
 ## 🙏 Acknowledgments
 
+Special thanks to **[9router](https://github.com/decolua/9router)** by **[decolua](https://github.com/decolua)** — the original project that inspired this fork. OmniRoute builds upon that incredible foundation with additional features, multi-modal APIs, and a full TypeScript rewrite.
+
 Special thanks to **[CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI)** by **[router-for-me](https://github.com/router-for-me)** — the original Go implementation that inspired this JavaScript port.
 
 Special thanks to **[Caveman](https://github.com/JuliusBrussee/caveman)** by **[JuliusBrussee](https://github.com/JuliusBrussee)** (⭐ 51K+) — the viral "why use many token when few token do trick" project whose caveman-speak compression philosophy inspired OmniRoute's standard compression mode and 30+ filler/condensation regex rules.


### PR DESCRIPTION
## Summary

Re-adds the "Special thanks to 9router by decolua" line at the top of the **🙏 Acknowledgments** section in `README.md`. The reference was present through v3.7.x and was inadvertently dropped during a docs cleanup (commit `54be51a66`).

OmniRoute is a TypeScript rewrite that originally built on 9router's design, so this credit belongs alongside the other "inspired-by" entries (CLIProxyAPI, Caveman, RTK).

## Diff
```diff
 ## 🙏 Acknowledgments

+Special thanks to **[9router](https://github.com/decolua/9router)** by **[decolua](https://github.com/decolua)** — the original project that inspired this fork. OmniRoute builds upon that incredible foundation with additional features, multi-modal APIs, and a full TypeScript rewrite.
+
 Special thanks to **[CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI)** by **[router-for-me](https://github.com/router-for-me)** — the original Go implementation that inspired this JavaScript port.
```

## Test plan
- [x] Docs-only change, no code touched.