### PR TITLE
fix(mitm): drop .js extension on manager.runtime re-export for webpack build

### DIFF
--- a/src/mitm/manager.runtime.ts
+++ b/src/mitm/manager.runtime.ts
@@ -2,4 +2,4 @@
 // Turbopack maps @/mitm/manager → manager.stub.ts so the build doesn't choke
 // on native module imports.  Dynamic import() of @/mitm/manager.runtime does NOT
 // match that alias and loads the real manager at runtime.
-export * from "./manager.js";
+export * from "./manager";


### PR DESCRIPTION
## Context

Webpack production build (`npm run build -- --webpack`) on the current `release/v3.8.0` head fails with:

```
./src/mitm/manager.runtime.ts
Module not found: Can't resolve './manager.js'

Import trace for requested module:
./src/app/api/cli-tools/antigravity-mitm/route.ts
```

The `.js` extension was intended for ESM runtime resolution under Node, but webpack at build time cannot resolve it since only `manager.ts` exists at that point in the pipeline (no emitted `.js` sibling).

## Fix

Drop the explicit `.js` extension on the re-export. Webpack default TS resolution then picks up `manager.ts` correctly, and the dynamic runtime import in `antigravity-mitm/route.ts` keeps working the same way.

```diff
-export * from "./manager.js";
+export * from "./manager";
```

Turbopack alias resolution (which maps `@/mitm/manager → manager.stub.ts` in the dev path) is unaffected — the dynamic `import("@/mitm/manager.runtime")` still does not match that alias.

## Provenance

Pure back-port of the same one-line change that landed on `main` in commit `dd790c38` (refactor(gamification): raise federation token hashing cost), where the mitm fix was bundled with the gamification refactor. Extracting it here so production builds from `release/v3.8.0` succeed without pulling the unrelated gamification commit.

## Verification

- Verified webpack production build now succeeds against an arm64 multi-stage docker build (`node:26.1.0-trixie-slim`) on top of release/v3.8.0 HEAD.
- Resulting container runs healthy with the antigravity MITM autostart path exercised.