### PR TITLE
feat: Enhance extractBearer to support x-api-key for anthropic api style auth

### DIFF
--- a/src/server/authz/policies/clientApi.ts
+++ b/src/server/authz/policies/clientApi.ts
@@ -4,10 +4,15 @@ import { allow, reject } from "../context";
 
 function extractBearer(headers: Headers): string | null {
   const raw = headers.get("authorization") ?? headers.get("Authorization");
-  if (!raw) return null;
-  const trimmed = raw.trim();
-  if (!trimmed.toLowerCase().startsWith("bearer ")) return null;
-  return trimmed.slice(7).trim() || null;
+  const xApiKey = headers.get("x-api-key") ?? headers.get("X-Api-Key");
+  if (raw) {
+    const trimmed = raw.trim();
+    if (!trimmed.toLowerCase().startsWith("bearer ")) return null;
+    return trimmed.slice(7).trim() || null;
+  } else if (xApiKey) {
+    return xApiKey?.trim() || null;
+  }
+  return null;
 }
 
 function maskKeyId(apiKey: string): string {

--- a/tests/unit/authz/client-api-policy-fallback.test.ts
+++ b/tests/unit/authz/client-api-policy-fallback.test.ts
@@ -123,6 +123,50 @@ test("#2257 — invalid bearer + REQUIRE_API_KEY=false → anonymous (with warni
   }
 });
 
+test("#2257 — invalid x-api-key + REQUIRE_API_KEY=false → anonymous (with warning log)", async () => {
+  const originalWarn = console.warn;
+  const warnings: string[] = [];
+  console.warn = (msg: string) => warnings.push(String(msg));
+  try {
+    const policy = await loadPolicy();
+    const headers = new Headers({ "x-api-key": "sk-stub-bogus" });
+    const out = await policy.evaluate(ctx(headers));
+    assert.equal(out.allow, true);
+    if (out.allow) {
+      assert.equal(out.subject.kind, "anonymous");
+      assert.equal(out.subject.id, "local");
+    }
+    assert.ok(
+      warnings.some((w) => w.includes("[clientApiPolicy]") && w.includes("REQUIRE_API_KEY=false")),
+      "expected a warning about the fallback"
+    );
+  } finally {
+    console.warn = originalWarn;
+  }
+});
+
+test("#2257 — fallback warning masks the x-api-key (only last-4 in log)", async () => {
+  const originalWarn = console.warn;
+  const warnings: string[] = [];
+  console.warn = (msg: string) => warnings.push(String(msg));
+  try {
+    const policy = await loadPolicy();
+    const headers = new Headers({ "x-api-key": "sk-secretprefix-secretmiddle-XYZW" });
+    const out = await policy.evaluate(ctx(headers));
+    assert.equal(out.allow, true);
+    assert.ok(
+      warnings.every((w) => !w.includes("secretprefix") && !w.includes("secretmiddle")),
+      "warning leaked the full bearer; only masked key id should be logged"
+    );
+    assert.ok(
+      warnings.some((w) => w.includes("key_XYZW")),
+      "expected masked key id (last-4) in the warning"
+    );
+  } finally {
+    console.warn = originalWarn;
+  }
+});
+
 test("#2257 — fallback warning masks the bearer (only last-4 in log)", async () => {
   const originalWarn = console.warn;
   const warnings: string[] = [];

--- a/tests/unit/authz/client-api-policy.test.ts
+++ b/tests/unit/authz/client-api-policy.test.ts
@@ -151,3 +151,17 @@ test("clientApiPolicy: environment API key remains accepted for client API route
     assert.equal(out.subject.kind, "client_api_key");
   }
 });
+
+test("clientApiPolicy: x-api-key header is accepted as client_api_key subject", async () => {
+  const created = await apiKeysDb.createApiKey("policy-test-xkey", "machine-xkey-1234");
+  assert.ok(created?.key, "createApiKey must return a key");
+
+  const policy = await loadPolicy();
+  const headers = new Headers({ "x-api-key": created.key });
+  const out = await policy.evaluate(ctx(headers));
+  assert.equal(out.allow, true);
+  if (out.allow) {
+    assert.equal(out.subject.kind, "client_api_key");
+    assert.match(out.subject.id, /^key_/);
+  }
+});


### PR DESCRIPTION
## Summary

Update `extractBearer` to accept an Authorization: Bearer … token or fall back to an x-api-key header so clients using an Anthropics-style x-api-key can authenticate.


## Validation

- [x] `npm run lint`
- [x] `npm run test:unit`
- [x] `npm run test:coverage`
- [x] Coverage is still `>= 60%` for statements, lines, functions, and branches
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below

## Tests Added Or Updated

`tests\unit\authz\client-api-policy.test.ts`: added x-api-key acceptance test.
`tests\unit\authz\client-api-policy-fallback.test.ts`: added x-api-key fallback / logging-mask tests.

## Coverage Notes

The change touches `src\server\authz\policies\clientApi.ts`