### PR TITLE
feat(settings): surface Codex Fast Tier toggle in Settings > AI

### DIFF
--- a/src/app/(dashboard)/dashboard/settings/ai/page.tsx
+++ b/src/app/(dashboard)/dashboard/settings/ai/page.tsx
@@ -4,6 +4,7 @@ import { useTranslations } from "next-intl";
 import ThinkingBudgetTab from "../components/ThinkingBudgetTab";
 import VisionBridgeSettingsTab from "../components/VisionBridgeSettingsTab";
 import SystemPromptTab from "../components/SystemPromptTab";
+import CodexFastTierTab from "../components/CodexFastTierTab";
 import MemorySkillsTab from "../components/MemorySkillsTab";
 import ModelsDevSyncTab from "../components/ModelsDevSyncTab";
 
@@ -15,6 +16,7 @@ export default function SettingsAiPage() {
       <ThinkingBudgetTab />
       <VisionBridgeSettingsTab />
       <SystemPromptTab />
+      <CodexFastTierTab />
       <MemorySkillsTab />
       <ModelsDevSyncTab />
     </div>

--- a/src/app/(dashboard)/dashboard/settings/components/CodexFastTierTab.tsx
+++ b/src/app/(dashboard)/dashboard/settings/components/CodexFastTierTab.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Card, Toggle } from "@/shared/components";
+import { useTranslations } from "next-intl";
+import { isCodexGlobalFastServiceTierEnabled } from "@/lib/providers/codexFastTier";
+
+export default function CodexFastTierTab() {
+  const [enabled, setEnabled] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [status, setStatus] = useState<"" | "saved" | "error">("");
+  const t = useTranslations("settings");
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/settings")
+      .then((res) => res.json())
+      .then((data) => {
+        if (cancelled) return;
+        setEnabled(isCodexGlobalFastServiceTierEnabled(data));
+        setLoading(false);
+      })
+      .catch(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const save = async (next: boolean) => {
+    if (saving || loading) return;
+    setSaving(true);
+    setStatus("");
+    const previous = enabled;
+    setEnabled(next);
+    try {
+      const res = await fetch("/api/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ codexServiceTier: { enabled: next } }),
+      });
+      if (res.ok) {
+        setStatus("saved");
+        setTimeout(() => setStatus(""), 2000);
+      } else {
+        setEnabled(previous);
+        setStatus("error");
+      }
+    } catch {
+      setEnabled(previous);
+      setStatus("error");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Card>
+      <div className="flex items-center gap-3 mb-3">
+        <div className="p-2 rounded-lg bg-sky-500/10 text-sky-500">
+          <span className="material-symbols-outlined text-[20px]" aria-hidden="true">
+            bolt
+          </span>
+        </div>
+        <div className="flex-1">
+          <h3 className="text-lg font-semibold">{t("codexFastTierTitle")}</h3>
+          <p className="text-sm text-text-muted">{t("codexFastTierDesc")}</p>
+        </div>
+        <div className="flex items-center gap-3">
+          {status === "saved" && (
+            <span className="text-xs font-medium text-emerald-500 flex items-center gap-1">
+              <span className="material-symbols-outlined text-[14px]">check_circle</span>{" "}
+              {t("saved")}
+            </span>
+          )}
+          {status === "error" && (
+            <span className="text-xs font-medium text-rose-500 flex items-center gap-1">
+              <span className="material-symbols-outlined text-[14px]">error</span>{" "}
+              {t("codexFastTierSaveError")}
+            </span>
+          )}
+          <Toggle
+            checked={enabled}
+            onChange={(value) => save(value)}
+            disabled={loading || saving}
+            ariaLabel={t("codexFastTierTitle")}
+          />
+        </div>
+      </div>
+
+      <p className="text-xs text-text-muted/80 flex items-start gap-1.5 leading-relaxed">
+        <span className="material-symbols-outlined text-[14px] mt-0.5">info</span>
+        <span>{t("codexFastTierHint")}</span>
+      </p>
+    </Card>
+  );
+}

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/az.json
+++ b/src/i18n/messages/az.json
@@ -3092,7 +3092,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3870,7 +3869,11 @@
     "optional": "Optional",
     "current": "Current",
     "remove": "Remove",
-    "search": "Search"
+    "search": "Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/bg.json
+++ b/src/i18n/messages/bg.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/bn.json
+++ b/src/i18n/messages/bn.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/cs.json
+++ b/src/i18n/messages/cs.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/da.json
+++ b/src/i18n/messages/da.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "Codex Fast Tier",
+    "codexFastTierDesc": "service_tier=priority global für OpenAI Codex-Anfragen einfügen.",
+    "codexFastTierHint": "Wenn aktiviert, fügt OmniRoute ausgehenden Codex-Anfragen service_tier=priority hinzu, sofern für die Verbindung noch kein Tier festgelegt ist. Der Priority-Tier erfordert einen OpenAI Enterprise API-Schlüssel oder den ChatGPT-Auth-Codex-Pfad; andere Schlüsseltypen erhalten von OpenAI einen tier-bezogenen Fehler. Pro-Verbindung-Einstellungen auf der Codex-Provider-Seite haben Vorrang.",
+    "codexFastTierSaveError": "Codex Fast Tier-Einstellung konnte nicht aktualisiert werden"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -4527,7 +4527,11 @@
     "cliproxyapiNotDetected": "Not detected",
     "payloadRulesTitle": "Payload Rules",
     "modelCooldownsTitle": "Models in cooldown",
-    "modelCooldownsEmpty": "No models in cooldown right now."
+    "modelCooldownsEmpty": "No models in cooldown right now.",
+    "codexFastTierTitle": "Codex Fast Tier",
+    "codexFastTierDesc": "Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "Codex Fast Tier",
+    "codexFastTierDesc": "Inyectar globalmente service_tier=priority para las solicitudes de OpenAI Codex.",
+    "codexFastTierHint": "Cuando está habilitado, OmniRoute añade service_tier=priority a las solicitudes salientes de Codex para las conexiones que aún no especifican un tier. El tier priority requiere una clave API de OpenAI Enterprise o la ruta de Codex con autenticación ChatGPT; otros tipos de claves recibirán un error relacionado con el tier de OpenAI. Los ajustes por conexión en la página del proveedor Codex tienen prioridad.",
+    "codexFastTierSaveError": "Error al actualizar el ajuste de Codex Fast Tier"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/fa.json
+++ b/src/i18n/messages/fa.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/fi.json
+++ b/src/i18n/messages/fi.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "Codex Fast Tier",
+    "codexFastTierDesc": "Injecter globalement service_tier=priority pour les requêtes OpenAI Codex.",
+    "codexFastTierHint": "Lorsqu'activé, OmniRoute ajoute service_tier=priority aux requêtes Codex sortantes pour les connexions qui n'ont pas déjà défini un tier. Le tier priority nécessite une clé API OpenAI Enterprise ou le chemin Codex avec authentification ChatGPT ; les autres types de clés recevront une erreur liée au tier de la part d'OpenAI. Les paramètres par connexion sur la page du provider Codex prévalent.",
+    "codexFastTierSaveError": "Échec de la mise à jour du paramètre Codex Fast Tier"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/gu.json
+++ b/src/i18n/messages/gu.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/he.json
+++ b/src/i18n/messages/he.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/hi.json
+++ b/src/i18n/messages/hi.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/hu.json
+++ b/src/i18n/messages/hu.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/id.json
+++ b/src/i18n/messages/id.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/in.json
+++ b/src/i18n/messages/in.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/it.json
+++ b/src/i18n/messages/it.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/mr.json
+++ b/src/i18n/messages/mr.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/ms.json
+++ b/src/i18n/messages/ms.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/no.json
+++ b/src/i18n/messages/no.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/phi.json
+++ b/src/i18n/messages/phi.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/pl.json
+++ b/src/i18n/messages/pl.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/pt-BR.json
+++ b/src/i18n/messages/pt-BR.json
@@ -3188,7 +3188,6 @@
     "extraApiKeyMasked": "Chave {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Rotação round-robin — opcional",
     "extraApiKeysLabel": "Chaves de API Extras",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3969,7 +3968,11 @@
     "optional": "Opcional",
     "current": "Atual",
     "remove": "Remover",
-    "search": "Buscar"
+    "search": "Buscar",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "Motor RTK",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -3186,7 +3186,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3964,7 +3963,11 @@
     "optional": "Opcional",
     "current": "Atual",
     "remove": "Remover",
-    "search": "Buscar"
+    "search": "Buscar",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/ro.json
+++ b/src/i18n/messages/ro.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/ru.json
+++ b/src/i18n/messages/ru.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/sk.json
+++ b/src/i18n/messages/sk.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/sv.json
+++ b/src/i18n/messages/sv.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/sw.json
+++ b/src/i18n/messages/sw.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/ta.json
+++ b/src/i18n/messages/ta.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/te.json
+++ b/src/i18n/messages/te.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/th.json
+++ b/src/i18n/messages/th.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/tr.json
+++ b/src/i18n/messages/tr.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/uk-UA.json
+++ b/src/i18n/messages/uk-UA.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/ur.json
+++ b/src/i18n/messages/ur.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/vi.json
+++ b/src/i18n/messages/vi.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -3998,7 +3998,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK 引擎",


### PR DESCRIPTION
## What

Surface the existing global Codex Fast Tier toggle (`service_tier=priority`) on the Settings > AI page so it's discoverable next to the other AI-routing toggles.

## Why

The setting itself (`codexServiceTier.enabled`), its persistence path (`PATCH /api/settings`), and the middleware injection (`applyCodexGlobalFastServiceTier` in `open-sse/handlers/chatCore.ts:1790`) are already wired. The only place to flip it today is the `/providers/codex` detail page (`providerDetailFastDefaultLabel`), which is easy to miss for users who land in the Settings UI first. This PR is purely a discoverability surface for an existing feature.

## How

- New component `src/app/(dashboard)/dashboard/settings/components/CodexFastTierTab.tsx` (~95 lines, mirrors `SystemPromptTab` Card shape — header + Toggle + info line). Loads via `GET /api/settings` and re-uses `isCodexGlobalFastServiceTierEnabled` so the reading rules stay in one place. Writes via the same `PATCH /api/settings` call the providers page already uses (`{ codexServiceTier: { enabled } }`).
- Mounted in `src/app/(dashboard)/dashboard/settings/ai/page.tsx` between `SystemPromptTab` and `MemorySkillsTab`.
- 4 new i18n keys (`codexFastTierTitle`, `codexFastTierDesc`, `codexFastTierHint`, `codexFastTierSaveError`). Hand-translated for `en`, `fr`, `es`, `de`; the standard `__MISSING__:` sentinel inserted in the other 38 locales so `scripts/i18n/sync-ui-keys.mjs --translate-markers` can fill them in a subsequent translator pass (matches the established workflow).

No new schema field, no new API route, no middleware change — only the UI surface.

## Default behavior

Toggle defaults off. Per-connection `requestDefaults.serviceTier` settings on the Codex provider page continue to take precedence.

## Caveats

The `priority` service tier requires either an OpenAI Enterprise API key or the ChatGPT-auth Codex path. Free/Plus/Pro API keys will receive a tier-related error from OpenAI when this is enabled — that's expected and orthogonal to this UI change. The hint text in the Card surfaces this so users don't get surprised.

## Test plan

- [x] `npm run build` — succeeds, `/dashboard/settings/ai` route present in output
- [x] `npm run typecheck:core` — clean (full `tsc --noEmit` reports only pre-existing errors in `tests/unit/*`)
- [x] i18n: en/fr/es/de hand-translated; other locales seeded with `__MISSING__:` sentinels (the i18n coverage warning is pre-existing on `release/v3.8.0`, not regressed by this PR)
- [ ] Manual: toggle on/off in Settings > AI, verify `codexServiceTier.enabled` flips in DB and that outbound Codex requests gain `service_tier: priority`

## Notes

Happy to revise — if you'd prefer a different placement (between two other cards, or in its own sub-section), or if you'd rather we extend the per-connection UI instead of adding a global Card, glad to swap. Tried to keep the change surgical: one new component, one mount point, i18n.
