### PR TITLE
feat(settings): Codex Fast Tier — tier dropdown + per-model gate

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -1787,7 +1787,10 @@ export async function handleChatCore({
       ? false
       : resolveStreamFlag(body?.stream, acceptHeader, sourceFormat);
   const settings = cachedSettings ?? (await getCachedSettings());
-  credentials = applyCodexGlobalFastServiceTier(provider, credentials, settings);
+  credentials = applyCodexGlobalFastServiceTier(provider, credentials, settings, {
+    model: requestedModel,
+    body: body && typeof body === "object" ? (body as Record<string, unknown>) : null,
+  });
   effectiveServiceTier = resolveEffectiveServiceTier(body);
   setGeminiThoughtSignatureMode(settings.antigravitySignatureCacheMode);
   const semanticCacheEnabled = settings.semanticCacheEnabled !== false;

--- a/src/app/(dashboard)/dashboard/settings/ai/page.tsx
+++ b/src/app/(dashboard)/dashboard/settings/ai/page.tsx
@@ -4,6 +4,7 @@ import { useTranslations } from "next-intl";
 import ThinkingBudgetTab from "../components/ThinkingBudgetTab";
 import VisionBridgeSettingsTab from "../components/VisionBridgeSettingsTab";
 import SystemPromptTab from "../components/SystemPromptTab";
+import CodexFastTierTab from "../components/CodexFastTierTab";
 import MemorySkillsTab from "../components/MemorySkillsTab";
 import ModelsDevSyncTab from "../components/ModelsDevSyncTab";
 
@@ -15,6 +16,7 @@ export default function SettingsAiPage() {
       <ThinkingBudgetTab />
       <VisionBridgeSettingsTab />
       <SystemPromptTab />
+      <CodexFastTierTab />
       <MemorySkillsTab />
       <ModelsDevSyncTab />
     </div>

--- a/src/app/(dashboard)/dashboard/settings/components/CodexFastTierTab.tsx
+++ b/src/app/(dashboard)/dashboard/settings/components/CodexFastTierTab.tsx
@@ -1,15 +1,30 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { Card, Toggle } from "@/shared/components";
+import { useEffect, useMemo, useState } from "react";
+import { Card, Toggle, Select } from "@/shared/components";
 import { useTranslations } from "next-intl";
-import { isCodexGlobalFastServiceTierEnabled } from "@/lib/providers/codexFastTier";
+import {
+  CODEX_FAST_TIER_DEFAULT_SUPPORTED_MODELS,
+  resolveCodexGlobalFastServiceTier,
+} from "@/lib/providers/codexFastTier";
+
+type TierValue = "default" | "priority" | "flex";
+
+// Fast-eligible Codex models per OpenAI ~/.codex/models_cache.json (service_tiers: priority).
+// Other future Fast-eligible slugs can be added here without code changes once the user
+// opts them in via the checkbox UI.
+const CODEX_FAST_TIER_CATALOG: readonly string[] = ["gpt-5.5", "gpt-5.4"];
 
 export default function CodexFastTierTab() {
   const [enabled, setEnabled] = useState(false);
+  const [tier, setTier] = useState<TierValue>("priority");
+  const [supportedModels, setSupportedModels] = useState<string[]>(
+    [...CODEX_FAST_TIER_DEFAULT_SUPPORTED_MODELS]
+  );
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [status, setStatus] = useState<"" | "saved" | "error">("");
+  const [modelsOpen, setModelsOpen] = useState(false);
   const t = useTranslations("settings");
 
   useEffect(() => {
@@ -18,7 +33,10 @@ export default function CodexFastTierTab() {
       .then((res) => res.json())
       .then((data) => {
         if (cancelled) return;
-        setEnabled(isCodexGlobalFastServiceTierEnabled(data));
+        const resolved = resolveCodexGlobalFastServiceTier(data);
+        setEnabled(resolved.enabled);
+        setTier(resolved.tier);
+        setSupportedModels([...resolved.supportedModels]);
         setLoading(false);
       })
       .catch(() => {
@@ -29,31 +47,66 @@ export default function CodexFastTierTab() {
     };
   }, []);
 
-  const save = async (next: boolean) => {
+  const allCatalogModels = useMemo(() => {
+    // Union of the catalog and any custom models the user has stored, so we don't
+    // silently drop a slug the user added on a future Codex release.
+    const set = new Set<string>([...CODEX_FAST_TIER_CATALOG, ...supportedModels]);
+    return Array.from(set);
+  }, [supportedModels]);
+
+  const save = async (next: {
+    enabled?: boolean;
+    tier?: TierValue;
+    supportedModels?: string[];
+  }) => {
     if (saving || loading) return;
     setSaving(true);
     setStatus("");
-    const previous = enabled;
-    setEnabled(next);
+    const previous = { enabled, tier, supportedModels };
+    const merged = {
+      enabled: next.enabled ?? enabled,
+      tier: next.tier ?? tier,
+      supportedModels: next.supportedModels ?? supportedModels,
+    };
+    setEnabled(merged.enabled);
+    setTier(merged.tier);
+    setSupportedModels(merged.supportedModels);
     try {
       const res = await fetch("/api/settings", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ codexServiceTier: { enabled: next } }),
+        body: JSON.stringify({
+          codexServiceTier: {
+            enabled: merged.enabled,
+            tier: merged.tier,
+            supportedModels: merged.supportedModels,
+          },
+        }),
       });
       if (res.ok) {
         setStatus("saved");
         setTimeout(() => setStatus(""), 2000);
       } else {
-        setEnabled(previous);
+        setEnabled(previous.enabled);
+        setTier(previous.tier);
+        setSupportedModels(previous.supportedModels);
         setStatus("error");
       }
     } catch {
-      setEnabled(previous);
+      setEnabled(previous.enabled);
+      setTier(previous.tier);
+      setSupportedModels(previous.supportedModels);
       setStatus("error");
     } finally {
       setSaving(false);
     }
+  };
+
+  const toggleModel = (slug: string, checked: boolean) => {
+    const next = checked
+      ? Array.from(new Set([...supportedModels, slug]))
+      : supportedModels.filter((m) => m !== slug);
+    save({ supportedModels: next });
   };
 
   return (
@@ -83,14 +136,73 @@ export default function CodexFastTierTab() {
           )}
           <Toggle
             checked={enabled}
-            onChange={(value) => save(value)}
+            onChange={(value) => save({ enabled: value })}
             disabled={loading || saving}
             ariaLabel={t("codexFastTierTitle")}
           />
         </div>
       </div>
 
-      <p className="text-xs text-text-muted/80 flex items-start gap-1.5 leading-relaxed">
+      {enabled && (
+        <div className="mt-4 flex flex-col gap-4 border-t border-border pt-4">
+          <Select
+            label={t("codexFastTierTierLabel")}
+            value={tier}
+            disabled={loading || saving}
+            onChange={(e) => save({ tier: e.target.value as TierValue })}
+            options={[
+              { value: "priority", label: t("codexFastTierTierPriority") },
+              { value: "flex", label: t("codexFastTierTierFlex") },
+              { value: "default", label: t("codexFastTierTierDefault") },
+            ]}
+          />
+
+          <div>
+            <button
+              type="button"
+              className="flex items-center gap-1.5 text-sm font-medium text-text-main hover:text-text-muted"
+              onClick={() => setModelsOpen((open) => !open)}
+              aria-expanded={modelsOpen}
+            >
+              <span className="material-symbols-outlined text-[18px]" aria-hidden="true">
+                {modelsOpen ? "expand_less" : "expand_more"}
+              </span>
+              {t("codexFastTierModelsLabel")}
+              <span className="ml-1 text-xs text-text-muted">
+                ({supportedModels.length})
+              </span>
+            </button>
+            {modelsOpen && (
+              <div className="mt-3 pl-6 flex flex-col gap-2">
+                <p className="text-xs text-text-muted/80">
+                  {t("codexFastTierModelsHint")}
+                </p>
+                {allCatalogModels.map((slug) => {
+                  const checked = supportedModels.includes(slug);
+                  return (
+                    <label
+                      key={slug}
+                      className="flex items-center gap-2 text-sm cursor-pointer"
+                    >
+                      <input
+                        type="checkbox"
+                        className="h-4 w-4"
+                        checked={checked}
+                        disabled={loading || saving}
+                        onChange={(e) => toggleModel(slug, e.target.checked)}
+                        aria-label={t("codexFastTierModelCheckbox", { model: slug })}
+                      />
+                      <span className="font-mono text-xs">{slug}</span>
+                    </label>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      <p className="mt-4 text-xs text-text-muted/80 flex items-start gap-1.5 leading-relaxed">
         <span className="material-symbols-outlined text-[14px] mt-0.5">info</span>
         <span>{t("codexFastTierHint")}</span>
       </p>

--- a/src/app/(dashboard)/dashboard/settings/components/CodexFastTierTab.tsx
+++ b/src/app/(dashboard)/dashboard/settings/components/CodexFastTierTab.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Card, Toggle } from "@/shared/components";
+import { useTranslations } from "next-intl";
+import { isCodexGlobalFastServiceTierEnabled } from "@/lib/providers/codexFastTier";
+
+export default function CodexFastTierTab() {
+  const [enabled, setEnabled] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [status, setStatus] = useState<"" | "saved" | "error">("");
+  const t = useTranslations("settings");
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/settings")
+      .then((res) => res.json())
+      .then((data) => {
+        if (cancelled) return;
+        setEnabled(isCodexGlobalFastServiceTierEnabled(data));
+        setLoading(false);
+      })
+      .catch(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const save = async (next: boolean) => {
+    if (saving || loading) return;
+    setSaving(true);
+    setStatus("");
+    const previous = enabled;
+    setEnabled(next);
+    try {
+      const res = await fetch("/api/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ codexServiceTier: { enabled: next } }),
+      });
+      if (res.ok) {
+        setStatus("saved");
+        setTimeout(() => setStatus(""), 2000);
+      } else {
+        setEnabled(previous);
+        setStatus("error");
+      }
+    } catch {
+      setEnabled(previous);
+      setStatus("error");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Card>
+      <div className="flex items-center gap-3 mb-3">
+        <div className="p-2 rounded-lg bg-sky-500/10 text-sky-500">
+          <span className="material-symbols-outlined text-[20px]" aria-hidden="true">
+            bolt
+          </span>
+        </div>
+        <div className="flex-1">
+          <h3 className="text-lg font-semibold">{t("codexFastTierTitle")}</h3>
+          <p className="text-sm text-text-muted">{t("codexFastTierDesc")}</p>
+        </div>
+        <div className="flex items-center gap-3">
+          {status === "saved" && (
+            <span className="text-xs font-medium text-emerald-500 flex items-center gap-1">
+              <span className="material-symbols-outlined text-[14px]">check_circle</span>{" "}
+              {t("saved")}
+            </span>
+          )}
+          {status === "error" && (
+            <span className="text-xs font-medium text-rose-500 flex items-center gap-1">
+              <span className="material-symbols-outlined text-[14px]">error</span>{" "}
+              {t("codexFastTierSaveError")}
+            </span>
+          )}
+          <Toggle
+            checked={enabled}
+            onChange={(value) => save(value)}
+            disabled={loading || saving}
+            ariaLabel={t("codexFastTierTitle")}
+          />
+        </div>
+      </div>
+
+      <p className="text-xs text-text-muted/80 flex items-start gap-1.5 leading-relaxed">
+        <span className="material-symbols-outlined text-[14px] mt-0.5">info</span>
+        <span>{t("codexFastTierHint")}</span>
+      </p>
+    </Card>
+  );
+}

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -3970,7 +3970,14 @@
     "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
     "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
     "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
-    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting",
+    "codexFastTierTierLabel": "__MISSING__:Tier",
+    "codexFastTierTierDefault": "__MISSING__:Default (no override)",
+    "codexFastTierTierPriority": "__MISSING__:Priority (Fast)",
+    "codexFastTierTierFlex": "__MISSING__:Flex",
+    "codexFastTierModelsLabel": "__MISSING__:Applied to models",
+    "codexFastTierModelsHint": "__MISSING__:Only takes effect when the request target model is in the selected list. Default selection matches OpenAI Fast-eligible Codex models.",
+    "codexFastTierModelCheckbox": "__MISSING__:Apply tier override to {model}"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/az.json
+++ b/src/i18n/messages/az.json
@@ -3873,7 +3873,14 @@
     "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
     "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
     "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
-    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting",
+    "codexFastTierTierLabel": "__MISSING__:Tier",
+    "codexFastTierTierDefault": "__MISSING__:Default (no override)",
+    "codexFastTierTierPriority": "__MISSING__:Priority (Fast)",
+    "codexFastTierTierFlex": "__MISSING__:Flex",
+    "codexFastTierModelsLabel": "__MISSING__:Applied to models",
+    "codexFastTierModelsHint": "__MISSING__:Only takes effect when the request target model is in the selected list. Default selection matches OpenAI Fast-eligible Codex models.",
+    "codexFastTierModelCheckbox": "__MISSING__:Apply tier override to {model}"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/az.json
+++ b/src/i18n/messages/az.json
@@ -3092,7 +3092,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3870,7 +3869,11 @@
     "optional": "Optional",
     "current": "Current",
     "remove": "Remove",
-    "search": "Search"
+    "search": "Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/bg.json
+++ b/src/i18n/messages/bg.json
@@ -3970,7 +3970,14 @@
     "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
     "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
     "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
-    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting",
+    "codexFastTierTierLabel": "__MISSING__:Tier",
+    "codexFastTierTierDefault": "__MISSING__:Default (no override)",
+    "codexFastTierTierPriority": "__MISSING__:Priority (Fast)",
+    "codexFastTierTierFlex": "__MISSING__:Flex",
+    "codexFastTierModelsLabel": "__MISSING__:Applied to models",
+    "codexFastTierModelsHint": "__MISSING__:Only takes effect when the request target model is in the selected list. Default selection matches OpenAI Fast-eligible Codex models.",
+    "codexFastTierModelCheckbox": "__MISSING__:Apply tier override to {model}"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/bg.json
+++ b/src/i18n/messages/bg.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/bn.json
+++ b/src/i18n/messages/bn.json
@@ -3970,7 +3970,14 @@
     "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
     "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
     "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
-    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting",
+    "codexFastTierTierLabel": "__MISSING__:Tier",
+    "codexFastTierTierDefault": "__MISSING__:Default (no override)",
+    "codexFastTierTierPriority": "__MISSING__:Priority (Fast)",
+    "codexFastTierTierFlex": "__MISSING__:Flex",
+    "codexFastTierModelsLabel": "__MISSING__:Applied to models",
+    "codexFastTierModelsHint": "__MISSING__:Only takes effect when the request target model is in the selected list. Default selection matches OpenAI Fast-eligible Codex models.",
+    "codexFastTierModelCheckbox": "__MISSING__:Apply tier override to {model}"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/bn.json
+++ b/src/i18n/messages/bn.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/cs.json
+++ b/src/i18n/messages/cs.json
@@ -3970,7 +3970,14 @@
     "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
     "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
     "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
-    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting",
+    "codexFastTierTierLabel": "__MISSING__:Tier",
+    "codexFastTierTierDefault": "__MISSING__:Default (no override)",
+    "codexFastTierTierPriority": "__MISSING__:Priority (Fast)",
+    "codexFastTierTierFlex": "__MISSING__:Flex",
+    "codexFastTierModelsLabel": "__MISSING__:Applied to models",
+    "codexFastTierModelsHint": "__MISSING__:Only takes effect when the request target model is in the selected list. Default selection matches OpenAI Fast-eligible Codex models.",
+    "codexFastTierModelCheckbox": "__MISSING__:Apply tier override to {model}"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/cs.json
+++ b/src/i18n/messages/cs.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/da.json
+++ b/src/i18n/messages/da.json
@@ -3970,7 +3970,14 @@
     "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
     "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
     "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
-    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting",
+    "codexFastTierTierLabel": "__MISSING__:Tier",
+    "codexFastTierTierDefault": "__MISSING__:Default (no override)",
+    "codexFastTierTierPriority": "__MISSING__:Priority (Fast)",
+    "codexFastTierTierFlex": "__MISSING__:Flex",
+    "codexFastTierModelsLabel": "__MISSING__:Applied to models",
+    "codexFastTierModelsHint": "__MISSING__:Only takes effect when the request target model is in the selected list. Default selection matches OpenAI Fast-eligible Codex models.",
+    "codexFastTierModelCheckbox": "__MISSING__:Apply tier override to {model}"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/da.json
+++ b/src/i18n/messages/da.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -3970,7 +3970,14 @@
     "codexFastTierTitle": "Codex Fast Tier",
     "codexFastTierDesc": "service_tier=priority global für OpenAI Codex-Anfragen einfügen.",
     "codexFastTierHint": "Wenn aktiviert, fügt OmniRoute ausgehenden Codex-Anfragen service_tier=priority hinzu, sofern für die Verbindung noch kein Tier festgelegt ist. Der Priority-Tier erfordert einen OpenAI Enterprise API-Schlüssel oder den ChatGPT-Auth-Codex-Pfad; andere Schlüsseltypen erhalten von OpenAI einen tier-bezogenen Fehler. Pro-Verbindung-Einstellungen auf der Codex-Provider-Seite haben Vorrang.",
-    "codexFastTierSaveError": "Codex Fast Tier-Einstellung konnte nicht aktualisiert werden"
+    "codexFastTierSaveError": "Codex Fast Tier-Einstellung konnte nicht aktualisiert werden",
+    "codexFastTierTierLabel": "Tier",
+    "codexFastTierTierDefault": "Standard (keine Überschreibung)",
+    "codexFastTierTierPriority": "Priority (Fast)",
+    "codexFastTierTierFlex": "Flex",
+    "codexFastTierModelsLabel": "Angewendet auf Modelle",
+    "codexFastTierModelsHint": "Wird nur wirksam, wenn das Zielmodell der Anfrage in der ausgewählten Liste enthalten ist. Die Standardauswahl entspricht den von OpenAI als Fast-fähig markierten Codex-Modellen.",
+    "codexFastTierModelCheckbox": "Tier-Überschreibung auf {model} anwenden"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "Codex Fast Tier",
+    "codexFastTierDesc": "service_tier=priority global für OpenAI Codex-Anfragen einfügen.",
+    "codexFastTierHint": "Wenn aktiviert, fügt OmniRoute ausgehenden Codex-Anfragen service_tier=priority hinzu, sofern für die Verbindung noch kein Tier festgelegt ist. Der Priority-Tier erfordert einen OpenAI Enterprise API-Schlüssel oder den ChatGPT-Auth-Codex-Pfad; andere Schlüsseltypen erhalten von OpenAI einen tier-bezogenen Fehler. Pro-Verbindung-Einstellungen auf der Codex-Provider-Seite haben Vorrang.",
+    "codexFastTierSaveError": "Codex Fast Tier-Einstellung konnte nicht aktualisiert werden"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -4531,7 +4531,14 @@
     "codexFastTierTitle": "Codex Fast Tier",
     "codexFastTierDesc": "Globally inject service_tier=priority for OpenAI Codex requests.",
     "codexFastTierHint": "When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
-    "codexFastTierSaveError": "Failed to update Codex Fast Tier setting"
+    "codexFastTierSaveError": "Failed to update Codex Fast Tier setting",
+    "codexFastTierTierLabel": "Tier",
+    "codexFastTierTierDefault": "Default (no override)",
+    "codexFastTierTierPriority": "Priority (Fast)",
+    "codexFastTierTierFlex": "Flex",
+    "codexFastTierModelsLabel": "Applied to models",
+    "codexFastTierModelsHint": "Only takes effect when the request target model is in the selected list. Default selection matches OpenAI Fast-eligible Codex models.",
+    "codexFastTierModelCheckbox": "Apply tier override to {model}"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -4527,7 +4527,11 @@
     "cliproxyapiNotDetected": "Not detected",
     "payloadRulesTitle": "Payload Rules",
     "modelCooldownsTitle": "Models in cooldown",
-    "modelCooldownsEmpty": "No models in cooldown right now."
+    "modelCooldownsEmpty": "No models in cooldown right now.",
+    "codexFastTierTitle": "Codex Fast Tier",
+    "codexFastTierDesc": "Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -3970,7 +3970,14 @@
     "codexFastTierTitle": "Codex Fast Tier",
     "codexFastTierDesc": "Inyectar globalmente service_tier=priority para las solicitudes de OpenAI Codex.",
     "codexFastTierHint": "Cuando está habilitado, OmniRoute añade service_tier=priority a las solicitudes salientes de Codex para las conexiones que aún no especifican un tier. El tier priority requiere una clave API de OpenAI Enterprise o la ruta de Codex con autenticación ChatGPT; otros tipos de claves recibirán un error relacionado con el tier de OpenAI. Los ajustes por conexión en la página del proveedor Codex tienen prioridad.",
-    "codexFastTierSaveError": "Error al actualizar el ajuste de Codex Fast Tier"
+    "codexFastTierSaveError": "Error al actualizar el ajuste de Codex Fast Tier",
+    "codexFastTierTierLabel": "Tier",
+    "codexFastTierTierDefault": "Predeterminado (sin sobrescritura)",
+    "codexFastTierTierPriority": "Priority (Fast)",
+    "codexFastTierTierFlex": "Flex",
+    "codexFastTierModelsLabel": "Aplicado a los modelos",
+    "codexFastTierModelsHint": "Solo surte efecto cuando el modelo de destino de la solicitud está en la lista seleccionada. La selección predeterminada coincide con los modelos Codex elegibles para Fast de OpenAI.",
+    "codexFastTierModelCheckbox": "Aplicar la sobrescritura de tier a {model}"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "Codex Fast Tier",
+    "codexFastTierDesc": "Inyectar globalmente service_tier=priority para las solicitudes de OpenAI Codex.",
+    "codexFastTierHint": "Cuando está habilitado, OmniRoute añade service_tier=priority a las solicitudes salientes de Codex para las conexiones que aún no especifican un tier. El tier priority requiere una clave API de OpenAI Enterprise o la ruta de Codex con autenticación ChatGPT; otros tipos de claves recibirán un error relacionado con el tier de OpenAI. Los ajustes por conexión en la página del proveedor Codex tienen prioridad.",
+    "codexFastTierSaveError": "Error al actualizar el ajuste de Codex Fast Tier"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/fa.json
+++ b/src/i18n/messages/fa.json
@@ -3970,7 +3970,14 @@
     "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
     "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
     "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
-    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting",
+    "codexFastTierTierLabel": "__MISSING__:Tier",
+    "codexFastTierTierDefault": "__MISSING__:Default (no override)",
+    "codexFastTierTierPriority": "__MISSING__:Priority (Fast)",
+    "codexFastTierTierFlex": "__MISSING__:Flex",
+    "codexFastTierModelsLabel": "__MISSING__:Applied to models",
+    "codexFastTierModelsHint": "__MISSING__:Only takes effect when the request target model is in the selected list. Default selection matches OpenAI Fast-eligible Codex models.",
+    "codexFastTierModelCheckbox": "__MISSING__:Apply tier override to {model}"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/fa.json
+++ b/src/i18n/messages/fa.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/fi.json
+++ b/src/i18n/messages/fi.json
@@ -3970,7 +3970,14 @@
     "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
     "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
     "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
-    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting",
+    "codexFastTierTierLabel": "__MISSING__:Tier",
+    "codexFastTierTierDefault": "__MISSING__:Default (no override)",
+    "codexFastTierTierPriority": "__MISSING__:Priority (Fast)",
+    "codexFastTierTierFlex": "__MISSING__:Flex",
+    "codexFastTierModelsLabel": "__MISSING__:Applied to models",
+    "codexFastTierModelsHint": "__MISSING__:Only takes effect when the request target model is in the selected list. Default selection matches OpenAI Fast-eligible Codex models.",
+    "codexFastTierModelCheckbox": "__MISSING__:Apply tier override to {model}"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/fi.json
+++ b/src/i18n/messages/fi.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -3970,7 +3970,14 @@
     "codexFastTierTitle": "Codex Fast Tier",
     "codexFastTierDesc": "Injecter globalement service_tier=priority pour les requêtes OpenAI Codex.",
     "codexFastTierHint": "Lorsqu'activé, OmniRoute ajoute service_tier=priority aux requêtes Codex sortantes pour les connexions qui n'ont pas déjà défini un tier. Le tier priority nécessite une clé API OpenAI Enterprise ou le chemin Codex avec authentification ChatGPT ; les autres types de clés recevront une erreur liée au tier de la part d'OpenAI. Les paramètres par connexion sur la page du provider Codex prévalent.",
-    "codexFastTierSaveError": "Échec de la mise à jour du paramètre Codex Fast Tier"
+    "codexFastTierSaveError": "Échec de la mise à jour du paramètre Codex Fast Tier",
+    "codexFastTierTierLabel": "Tier",
+    "codexFastTierTierDefault": "Par défaut (aucune surcharge)",
+    "codexFastTierTierPriority": "Priority (Fast)",
+    "codexFastTierTierFlex": "Flex",
+    "codexFastTierModelsLabel": "Appliqué aux modèles",
+    "codexFastTierModelsHint": "Prend effet uniquement lorsque le modèle cible de la requête figure dans la liste sélectionnée. La sélection par défaut correspond aux modèles Codex éligibles au tier Fast d'OpenAI.",
+    "codexFastTierModelCheckbox": "Appliquer la surcharge de tier à {model}"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "Codex Fast Tier",
+    "codexFastTierDesc": "Injecter globalement service_tier=priority pour les requêtes OpenAI Codex.",
+    "codexFastTierHint": "Lorsqu'activé, OmniRoute ajoute service_tier=priority aux requêtes Codex sortantes pour les connexions qui n'ont pas déjà défini un tier. Le tier priority nécessite une clé API OpenAI Enterprise ou le chemin Codex avec authentification ChatGPT ; les autres types de clés recevront une erreur liée au tier de la part d'OpenAI. Les paramètres par connexion sur la page du provider Codex prévalent.",
+    "codexFastTierSaveError": "Échec de la mise à jour du paramètre Codex Fast Tier"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/gu.json
+++ b/src/i18n/messages/gu.json
@@ -3970,7 +3970,14 @@
     "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
     "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
     "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
-    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting",
+    "codexFastTierTierLabel": "__MISSING__:Tier",
+    "codexFastTierTierDefault": "__MISSING__:Default (no override)",
+    "codexFastTierTierPriority": "__MISSING__:Priority (Fast)",
+    "codexFastTierTierFlex": "__MISSING__:Flex",
+    "codexFastTierModelsLabel": "__MISSING__:Applied to models",
+    "codexFastTierModelsHint": "__MISSING__:Only takes effect when the request target model is in the selected list. Default selection matches OpenAI Fast-eligible Codex models.",
+    "codexFastTierModelCheckbox": "__MISSING__:Apply tier override to {model}"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/gu.json
+++ b/src/i18n/messages/gu.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/he.json
+++ b/src/i18n/messages/he.json
@@ -3970,7 +3970,14 @@
     "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
     "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
     "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
-    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting",
+    "codexFastTierTierLabel": "__MISSING__:Tier",
+    "codexFastTierTierDefault": "__MISSING__:Default (no override)",
+    "codexFastTierTierPriority": "__MISSING__:Priority (Fast)",
+    "codexFastTierTierFlex": "__MISSING__:Flex",
+    "codexFastTierModelsLabel": "__MISSING__:Applied to models",
+    "codexFastTierModelsHint": "__MISSING__:Only takes effect when the request target model is in the selected list. Default selection matches OpenAI Fast-eligible Codex models.",
+    "codexFastTierModelCheckbox": "__MISSING__:Apply tier override to {model}"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/he.json
+++ b/src/i18n/messages/he.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/hi.json
+++ b/src/i18n/messages/hi.json
@@ -3970,7 +3970,14 @@
     "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
     "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
     "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
-    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting",
+    "codexFastTierTierLabel": "__MISSING__:Tier",
+    "codexFastTierTierDefault": "__MISSING__:Default (no override)",
+    "codexFastTierTierPriority": "__MISSING__:Priority (Fast)",
+    "codexFastTierTierFlex": "__MISSING__:Flex",
+    "codexFastTierModelsLabel": "__MISSING__:Applied to models",
+    "codexFastTierModelsHint": "__MISSING__:Only takes effect when the request target model is in the selected list. Default selection matches OpenAI Fast-eligible Codex models.",
+    "codexFastTierModelCheckbox": "__MISSING__:Apply tier override to {model}"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/hi.json
+++ b/src/i18n/messages/hi.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/hu.json
+++ b/src/i18n/messages/hu.json
@@ -3970,7 +3970,14 @@
     "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
     "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
     "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
-    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting",
+    "codexFastTierTierLabel": "__MISSING__:Tier",
+    "codexFastTierTierDefault": "__MISSING__:Default (no override)",
+    "codexFastTierTierPriority": "__MISSING__:Priority (Fast)",
+    "codexFastTierTierFlex": "__MISSING__:Flex",
+    "codexFastTierModelsLabel": "__MISSING__:Applied to models",
+    "codexFastTierModelsHint": "__MISSING__:Only takes effect when the request target model is in the selected list. Default selection matches OpenAI Fast-eligible Codex models.",
+    "codexFastTierModelCheckbox": "__MISSING__:Apply tier override to {model}"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/hu.json
+++ b/src/i18n/messages/hu.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/id.json
+++ b/src/i18n/messages/id.json
@@ -3970,7 +3970,14 @@
     "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
     "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
     "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
-    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting",
+    "codexFastTierTierLabel": "__MISSING__:Tier",
+    "codexFastTierTierDefault": "__MISSING__:Default (no override)",
+    "codexFastTierTierPriority": "__MISSING__:Priority (Fast)",
+    "codexFastTierTierFlex": "__MISSING__:Flex",
+    "codexFastTierModelsLabel": "__MISSING__:Applied to models",
+    "codexFastTierModelsHint": "__MISSING__:Only takes effect when the request target model is in the selected list. Default selection matches OpenAI Fast-eligible Codex models.",
+    "codexFastTierModelCheckbox": "__MISSING__:Apply tier override to {model}"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/id.json
+++ b/src/i18n/messages/id.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/in.json
+++ b/src/i18n/messages/in.json
@@ -3970,7 +3970,14 @@
     "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
     "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
     "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
-    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting",
+    "codexFastTierTierLabel": "__MISSING__:Tier",
+    "codexFastTierTierDefault": "__MISSING__:Default (no override)",
+    "codexFastTierTierPriority": "__MISSING__:Priority (Fast)",
+    "codexFastTierTierFlex": "__MISSING__:Flex",
+    "codexFastTierModelsLabel": "__MISSING__:Applied to models",
+    "codexFastTierModelsHint": "__MISSING__:Only takes effect when the request target model is in the selected list. Default selection matches OpenAI Fast-eligible Codex models.",
+    "codexFastTierModelCheckbox": "__MISSING__:Apply tier override to {model}"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/in.json
+++ b/src/i18n/messages/in.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/it.json
+++ b/src/i18n/messages/it.json
@@ -3970,7 +3970,14 @@
     "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
     "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
     "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
-    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting",
+    "codexFastTierTierLabel": "__MISSING__:Tier",
+    "codexFastTierTierDefault": "__MISSING__:Default (no override)",
+    "codexFastTierTierPriority": "__MISSING__:Priority (Fast)",
+    "codexFastTierTierFlex": "__MISSING__:Flex",
+    "codexFastTierModelsLabel": "__MISSING__:Applied to models",
+    "codexFastTierModelsHint": "__MISSING__:Only takes effect when the request target model is in the selected list. Default selection matches OpenAI Fast-eligible Codex models.",
+    "codexFastTierModelCheckbox": "__MISSING__:Apply tier override to {model}"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/it.json
+++ b/src/i18n/messages/it.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -3970,7 +3970,14 @@
     "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
     "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
     "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
-    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting",
+    "codexFastTierTierLabel": "__MISSING__:Tier",
+    "codexFastTierTierDefault": "__MISSING__:Default (no override)",
+    "codexFastTierTierPriority": "__MISSING__:Priority (Fast)",
+    "codexFastTierTierFlex": "__MISSING__:Flex",
+    "codexFastTierModelsLabel": "__MISSING__:Applied to models",
+    "codexFastTierModelsHint": "__MISSING__:Only takes effect when the request target model is in the selected list. Default selection matches OpenAI Fast-eligible Codex models.",
+    "codexFastTierModelCheckbox": "__MISSING__:Apply tier override to {model}"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -3970,7 +3970,14 @@
     "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
     "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
     "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
-    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting",
+    "codexFastTierTierLabel": "__MISSING__:Tier",
+    "codexFastTierTierDefault": "__MISSING__:Default (no override)",
+    "codexFastTierTierPriority": "__MISSING__:Priority (Fast)",
+    "codexFastTierTierFlex": "__MISSING__:Flex",
+    "codexFastTierModelsLabel": "__MISSING__:Applied to models",
+    "codexFastTierModelsHint": "__MISSING__:Only takes effect when the request target model is in the selected list. Default selection matches OpenAI Fast-eligible Codex models.",
+    "codexFastTierModelCheckbox": "__MISSING__:Apply tier override to {model}"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/mr.json
+++ b/src/i18n/messages/mr.json
@@ -3970,7 +3970,14 @@
     "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
     "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
     "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
-    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting",
+    "codexFastTierTierLabel": "__MISSING__:Tier",
+    "codexFastTierTierDefault": "__MISSING__:Default (no override)",
+    "codexFastTierTierPriority": "__MISSING__:Priority (Fast)",
+    "codexFastTierTierFlex": "__MISSING__:Flex",
+    "codexFastTierModelsLabel": "__MISSING__:Applied to models",
+    "codexFastTierModelsHint": "__MISSING__:Only takes effect when the request target model is in the selected list. Default selection matches OpenAI Fast-eligible Codex models.",
+    "codexFastTierModelCheckbox": "__MISSING__:Apply tier override to {model}"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/mr.json
+++ b/src/i18n/messages/mr.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/ms.json
+++ b/src/i18n/messages/ms.json
@@ -3970,7 +3970,14 @@
     "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
     "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
     "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
-    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting",
+    "codexFastTierTierLabel": "__MISSING__:Tier",
+    "codexFastTierTierDefault": "__MISSING__:Default (no override)",
+    "codexFastTierTierPriority": "__MISSING__:Priority (Fast)",
+    "codexFastTierTierFlex": "__MISSING__:Flex",
+    "codexFastTierModelsLabel": "__MISSING__:Applied to models",
+    "codexFastTierModelsHint": "__MISSING__:Only takes effect when the request target model is in the selected list. Default selection matches OpenAI Fast-eligible Codex models.",
+    "codexFastTierModelCheckbox": "__MISSING__:Apply tier override to {model}"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/ms.json
+++ b/src/i18n/messages/ms.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -3970,7 +3970,14 @@
     "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
     "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
     "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
-    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting",
+    "codexFastTierTierLabel": "__MISSING__:Tier",
+    "codexFastTierTierDefault": "__MISSING__:Default (no override)",
+    "codexFastTierTierPriority": "__MISSING__:Priority (Fast)",
+    "codexFastTierTierFlex": "__MISSING__:Flex",
+    "codexFastTierModelsLabel": "__MISSING__:Applied to models",
+    "codexFastTierModelsHint": "__MISSING__:Only takes effect when the request target model is in the selected list. Default selection matches OpenAI Fast-eligible Codex models.",
+    "codexFastTierModelCheckbox": "__MISSING__:Apply tier override to {model}"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/no.json
+++ b/src/i18n/messages/no.json
@@ -3970,7 +3970,14 @@
     "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
     "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
     "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
-    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting",
+    "codexFastTierTierLabel": "__MISSING__:Tier",
+    "codexFastTierTierDefault": "__MISSING__:Default (no override)",
+    "codexFastTierTierPriority": "__MISSING__:Priority (Fast)",
+    "codexFastTierTierFlex": "__MISSING__:Flex",
+    "codexFastTierModelsLabel": "__MISSING__:Applied to models",
+    "codexFastTierModelsHint": "__MISSING__:Only takes effect when the request target model is in the selected list. Default selection matches OpenAI Fast-eligible Codex models.",
+    "codexFastTierModelCheckbox": "__MISSING__:Apply tier override to {model}"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/no.json
+++ b/src/i18n/messages/no.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/phi.json
+++ b/src/i18n/messages/phi.json
@@ -3970,7 +3970,14 @@
     "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
     "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
     "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
-    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting",
+    "codexFastTierTierLabel": "__MISSING__:Tier",
+    "codexFastTierTierDefault": "__MISSING__:Default (no override)",
+    "codexFastTierTierPriority": "__MISSING__:Priority (Fast)",
+    "codexFastTierTierFlex": "__MISSING__:Flex",
+    "codexFastTierModelsLabel": "__MISSING__:Applied to models",
+    "codexFastTierModelsHint": "__MISSING__:Only takes effect when the request target model is in the selected list. Default selection matches OpenAI Fast-eligible Codex models.",
+    "codexFastTierModelCheckbox": "__MISSING__:Apply tier override to {model}"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/phi.json
+++ b/src/i18n/messages/phi.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/pl.json
+++ b/src/i18n/messages/pl.json
@@ -3970,7 +3970,14 @@
     "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
     "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
     "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
-    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting",
+    "codexFastTierTierLabel": "__MISSING__:Tier",
+    "codexFastTierTierDefault": "__MISSING__:Default (no override)",
+    "codexFastTierTierPriority": "__MISSING__:Priority (Fast)",
+    "codexFastTierTierFlex": "__MISSING__:Flex",
+    "codexFastTierModelsLabel": "__MISSING__:Applied to models",
+    "codexFastTierModelsHint": "__MISSING__:Only takes effect when the request target model is in the selected list. Default selection matches OpenAI Fast-eligible Codex models.",
+    "codexFastTierModelCheckbox": "__MISSING__:Apply tier override to {model}"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/pl.json
+++ b/src/i18n/messages/pl.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/pt-BR.json
+++ b/src/i18n/messages/pt-BR.json
@@ -3972,7 +3972,14 @@
     "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
     "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
     "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
-    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting",
+    "codexFastTierTierLabel": "__MISSING__:Tier",
+    "codexFastTierTierDefault": "__MISSING__:Default (no override)",
+    "codexFastTierTierPriority": "__MISSING__:Priority (Fast)",
+    "codexFastTierTierFlex": "__MISSING__:Flex",
+    "codexFastTierModelsLabel": "__MISSING__:Applied to models",
+    "codexFastTierModelsHint": "__MISSING__:Only takes effect when the request target model is in the selected list. Default selection matches OpenAI Fast-eligible Codex models.",
+    "codexFastTierModelCheckbox": "__MISSING__:Apply tier override to {model}"
   },
   "contextRtk": {
     "title": "Motor RTK",

--- a/src/i18n/messages/pt-BR.json
+++ b/src/i18n/messages/pt-BR.json
@@ -3188,7 +3188,6 @@
     "extraApiKeyMasked": "Chave {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Rotação round-robin — opcional",
     "extraApiKeysLabel": "Chaves de API Extras",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3969,7 +3968,11 @@
     "optional": "Opcional",
     "current": "Atual",
     "remove": "Remover",
-    "search": "Buscar"
+    "search": "Buscar",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "Motor RTK",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -3967,7 +3967,14 @@
     "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
     "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
     "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
-    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting",
+    "codexFastTierTierLabel": "__MISSING__:Tier",
+    "codexFastTierTierDefault": "__MISSING__:Default (no override)",
+    "codexFastTierTierPriority": "__MISSING__:Priority (Fast)",
+    "codexFastTierTierFlex": "__MISSING__:Flex",
+    "codexFastTierModelsLabel": "__MISSING__:Applied to models",
+    "codexFastTierModelsHint": "__MISSING__:Only takes effect when the request target model is in the selected list. Default selection matches OpenAI Fast-eligible Codex models.",
+    "codexFastTierModelCheckbox": "__MISSING__:Apply tier override to {model}"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -3186,7 +3186,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3964,7 +3963,11 @@
     "optional": "Opcional",
     "current": "Atual",
     "remove": "Remover",
-    "search": "Buscar"
+    "search": "Buscar",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/ro.json
+++ b/src/i18n/messages/ro.json
@@ -3970,7 +3970,14 @@
     "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
     "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
     "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
-    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting",
+    "codexFastTierTierLabel": "__MISSING__:Tier",
+    "codexFastTierTierDefault": "__MISSING__:Default (no override)",
+    "codexFastTierTierPriority": "__MISSING__:Priority (Fast)",
+    "codexFastTierTierFlex": "__MISSING__:Flex",
+    "codexFastTierModelsLabel": "__MISSING__:Applied to models",
+    "codexFastTierModelsHint": "__MISSING__:Only takes effect when the request target model is in the selected list. Default selection matches OpenAI Fast-eligible Codex models.",
+    "codexFastTierModelCheckbox": "__MISSING__:Apply tier override to {model}"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/ro.json
+++ b/src/i18n/messages/ro.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/ru.json
+++ b/src/i18n/messages/ru.json
@@ -3970,7 +3970,14 @@
     "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
     "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
     "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
-    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting",
+    "codexFastTierTierLabel": "__MISSING__:Tier",
+    "codexFastTierTierDefault": "__MISSING__:Default (no override)",
+    "codexFastTierTierPriority": "__MISSING__:Priority (Fast)",
+    "codexFastTierTierFlex": "__MISSING__:Flex",
+    "codexFastTierModelsLabel": "__MISSING__:Applied to models",
+    "codexFastTierModelsHint": "__MISSING__:Only takes effect when the request target model is in the selected list. Default selection matches OpenAI Fast-eligible Codex models.",
+    "codexFastTierModelCheckbox": "__MISSING__:Apply tier override to {model}"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/ru.json
+++ b/src/i18n/messages/ru.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/sk.json
+++ b/src/i18n/messages/sk.json
@@ -3970,7 +3970,14 @@
     "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
     "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
     "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
-    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting",
+    "codexFastTierTierLabel": "__MISSING__:Tier",
+    "codexFastTierTierDefault": "__MISSING__:Default (no override)",
+    "codexFastTierTierPriority": "__MISSING__:Priority (Fast)",
+    "codexFastTierTierFlex": "__MISSING__:Flex",
+    "codexFastTierModelsLabel": "__MISSING__:Applied to models",
+    "codexFastTierModelsHint": "__MISSING__:Only takes effect when the request target model is in the selected list. Default selection matches OpenAI Fast-eligible Codex models.",
+    "codexFastTierModelCheckbox": "__MISSING__:Apply tier override to {model}"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/sk.json
+++ b/src/i18n/messages/sk.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/sv.json
+++ b/src/i18n/messages/sv.json
@@ -3970,7 +3970,14 @@
     "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
     "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
     "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
-    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting",
+    "codexFastTierTierLabel": "__MISSING__:Tier",
+    "codexFastTierTierDefault": "__MISSING__:Default (no override)",
+    "codexFastTierTierPriority": "__MISSING__:Priority (Fast)",
+    "codexFastTierTierFlex": "__MISSING__:Flex",
+    "codexFastTierModelsLabel": "__MISSING__:Applied to models",
+    "codexFastTierModelsHint": "__MISSING__:Only takes effect when the request target model is in the selected list. Default selection matches OpenAI Fast-eligible Codex models.",
+    "codexFastTierModelCheckbox": "__MISSING__:Apply tier override to {model}"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/sv.json
+++ b/src/i18n/messages/sv.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/sw.json
+++ b/src/i18n/messages/sw.json
@@ -3970,7 +3970,14 @@
     "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
     "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
     "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
-    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting",
+    "codexFastTierTierLabel": "__MISSING__:Tier",
+    "codexFastTierTierDefault": "__MISSING__:Default (no override)",
+    "codexFastTierTierPriority": "__MISSING__:Priority (Fast)",
+    "codexFastTierTierFlex": "__MISSING__:Flex",
+    "codexFastTierModelsLabel": "__MISSING__:Applied to models",
+    "codexFastTierModelsHint": "__MISSING__:Only takes effect when the request target model is in the selected list. Default selection matches OpenAI Fast-eligible Codex models.",
+    "codexFastTierModelCheckbox": "__MISSING__:Apply tier override to {model}"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/sw.json
+++ b/src/i18n/messages/sw.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/ta.json
+++ b/src/i18n/messages/ta.json
@@ -3970,7 +3970,14 @@
     "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
     "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
     "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
-    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting",
+    "codexFastTierTierLabel": "__MISSING__:Tier",
+    "codexFastTierTierDefault": "__MISSING__:Default (no override)",
+    "codexFastTierTierPriority": "__MISSING__:Priority (Fast)",
+    "codexFastTierTierFlex": "__MISSING__:Flex",
+    "codexFastTierModelsLabel": "__MISSING__:Applied to models",
+    "codexFastTierModelsHint": "__MISSING__:Only takes effect when the request target model is in the selected list. Default selection matches OpenAI Fast-eligible Codex models.",
+    "codexFastTierModelCheckbox": "__MISSING__:Apply tier override to {model}"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/ta.json
+++ b/src/i18n/messages/ta.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/te.json
+++ b/src/i18n/messages/te.json
@@ -3970,7 +3970,14 @@
     "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
     "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
     "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
-    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting",
+    "codexFastTierTierLabel": "__MISSING__:Tier",
+    "codexFastTierTierDefault": "__MISSING__:Default (no override)",
+    "codexFastTierTierPriority": "__MISSING__:Priority (Fast)",
+    "codexFastTierTierFlex": "__MISSING__:Flex",
+    "codexFastTierModelsLabel": "__MISSING__:Applied to models",
+    "codexFastTierModelsHint": "__MISSING__:Only takes effect when the request target model is in the selected list. Default selection matches OpenAI Fast-eligible Codex models.",
+    "codexFastTierModelCheckbox": "__MISSING__:Apply tier override to {model}"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/te.json
+++ b/src/i18n/messages/te.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/th.json
+++ b/src/i18n/messages/th.json
@@ -3970,7 +3970,14 @@
     "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
     "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
     "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
-    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting",
+    "codexFastTierTierLabel": "__MISSING__:Tier",
+    "codexFastTierTierDefault": "__MISSING__:Default (no override)",
+    "codexFastTierTierPriority": "__MISSING__:Priority (Fast)",
+    "codexFastTierTierFlex": "__MISSING__:Flex",
+    "codexFastTierModelsLabel": "__MISSING__:Applied to models",
+    "codexFastTierModelsHint": "__MISSING__:Only takes effect when the request target model is in the selected list. Default selection matches OpenAI Fast-eligible Codex models.",
+    "codexFastTierModelCheckbox": "__MISSING__:Apply tier override to {model}"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/th.json
+++ b/src/i18n/messages/th.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/tr.json
+++ b/src/i18n/messages/tr.json
@@ -3970,7 +3970,14 @@
     "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
     "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
     "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
-    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting",
+    "codexFastTierTierLabel": "__MISSING__:Tier",
+    "codexFastTierTierDefault": "__MISSING__:Default (no override)",
+    "codexFastTierTierPriority": "__MISSING__:Priority (Fast)",
+    "codexFastTierTierFlex": "__MISSING__:Flex",
+    "codexFastTierModelsLabel": "__MISSING__:Applied to models",
+    "codexFastTierModelsHint": "__MISSING__:Only takes effect when the request target model is in the selected list. Default selection matches OpenAI Fast-eligible Codex models.",
+    "codexFastTierModelCheckbox": "__MISSING__:Apply tier override to {model}"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/tr.json
+++ b/src/i18n/messages/tr.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/uk-UA.json
+++ b/src/i18n/messages/uk-UA.json
@@ -3970,7 +3970,14 @@
     "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
     "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
     "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
-    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting",
+    "codexFastTierTierLabel": "__MISSING__:Tier",
+    "codexFastTierTierDefault": "__MISSING__:Default (no override)",
+    "codexFastTierTierPriority": "__MISSING__:Priority (Fast)",
+    "codexFastTierTierFlex": "__MISSING__:Flex",
+    "codexFastTierModelsLabel": "__MISSING__:Applied to models",
+    "codexFastTierModelsHint": "__MISSING__:Only takes effect when the request target model is in the selected list. Default selection matches OpenAI Fast-eligible Codex models.",
+    "codexFastTierModelCheckbox": "__MISSING__:Apply tier override to {model}"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/uk-UA.json
+++ b/src/i18n/messages/uk-UA.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/ur.json
+++ b/src/i18n/messages/ur.json
@@ -3970,7 +3970,14 @@
     "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
     "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
     "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
-    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting",
+    "codexFastTierTierLabel": "__MISSING__:Tier",
+    "codexFastTierTierDefault": "__MISSING__:Default (no override)",
+    "codexFastTierTierPriority": "__MISSING__:Priority (Fast)",
+    "codexFastTierTierFlex": "__MISSING__:Flex",
+    "codexFastTierModelsLabel": "__MISSING__:Applied to models",
+    "codexFastTierModelsHint": "__MISSING__:Only takes effect when the request target model is in the selected list. Default selection matches OpenAI Fast-eligible Codex models.",
+    "codexFastTierModelCheckbox": "__MISSING__:Apply tier override to {model}"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/ur.json
+++ b/src/i18n/messages/ur.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/vi.json
+++ b/src/i18n/messages/vi.json
@@ -3970,7 +3970,14 @@
     "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
     "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
     "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
-    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting",
+    "codexFastTierTierLabel": "__MISSING__:Tier",
+    "codexFastTierTierDefault": "__MISSING__:Default (no override)",
+    "codexFastTierTierPriority": "__MISSING__:Priority (Fast)",
+    "codexFastTierTierFlex": "__MISSING__:Flex",
+    "codexFastTierModelsLabel": "__MISSING__:Applied to models",
+    "codexFastTierModelsHint": "__MISSING__:Only takes effect when the request target model is in the selected list. Default selection matches OpenAI Fast-eligible Codex models.",
+    "codexFastTierModelCheckbox": "__MISSING__:Apply tier override to {model}"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/vi.json
+++ b/src/i18n/messages/vi.json
@@ -3189,7 +3189,6 @@
     "extraApiKeyMasked": "Key {index}: {prefix}••••{suffix}",
     "extraApiKeysHint": "Extra Api Keys Hint",
     "extraApiKeysLabel": "Extra Api Keys Label",
-
     "apiKeyHealthLabel": "API Key Health",
     "apiKeyStatusActive": "Active",
     "apiKeyStatusWarning": "Warning ({count} failures)",
@@ -3967,7 +3966,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK Engine",

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -4002,7 +4002,14 @@
     "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
     "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
     "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
-    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting",
+    "codexFastTierTierLabel": "__MISSING__:Tier",
+    "codexFastTierTierDefault": "__MISSING__:Default (no override)",
+    "codexFastTierTierPriority": "__MISSING__:Priority (Fast)",
+    "codexFastTierTierFlex": "__MISSING__:Flex",
+    "codexFastTierModelsLabel": "__MISSING__:Applied to models",
+    "codexFastTierModelsHint": "__MISSING__:Only takes effect when the request target model is in the selected list. Default selection matches OpenAI Fast-eligible Codex models.",
+    "codexFastTierModelCheckbox": "__MISSING__:Apply tier override to {model}"
   },
   "contextRtk": {
     "title": "RTK 引擎",

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -3998,7 +3998,11 @@
     "optional": "__MISSING__:Optional",
     "current": "__MISSING__:Current",
     "remove": "__MISSING__:Remove",
-    "search": "__MISSING__:Search"
+    "search": "__MISSING__:Search",
+    "codexFastTierTitle": "__MISSING__:Codex Fast Tier",
+    "codexFastTierDesc": "__MISSING__:Globally inject service_tier=priority for OpenAI Codex requests.",
+    "codexFastTierHint": "__MISSING__:When enabled, OmniRoute adds service_tier=priority to outbound Codex requests for connections that don't already specify a tier. Priority tier requires an OpenAI Enterprise API key or the ChatGPT-auth Codex path; other key types will receive a tier-related error from OpenAI. Per-connection settings on the Codex provider page take precedence.",
+    "codexFastTierSaveError": "__MISSING__:Failed to update Codex Fast Tier setting"
   },
   "contextRtk": {
     "title": "RTK 引擎",

--- a/src/lib/providers/codexFastTier.ts
+++ b/src/lib/providers/codexFastTier.ts
@@ -6,20 +6,72 @@ function asRecord(value: unknown): JsonRecord {
   return value && typeof value === "object" && !Array.isArray(value) ? (value as JsonRecord) : {};
 }
 
-export function isCodexGlobalFastServiceTierEnabled(settings: unknown): boolean {
+export type CodexFastTierValue = "priority" | "flex";
+
+export const CODEX_FAST_TIER_DEFAULT_SUPPORTED_MODELS: readonly string[] = [
+  "gpt-5.5",
+  "gpt-5.4",
+];
+
+export interface CodexGlobalFastServiceTierResolved {
+  enabled: boolean;
+  tier: CodexFastTierValue;
+  supportedModels: readonly string[];
+}
+
+/**
+ * Resolve the global Codex Fast Tier settings. Handles three legacy shapes:
+ *  - { codexServiceTier: true }                      (oldest boolean)
+ *  - { codexServiceTier: { enabled: true } }         (PR #2440 shape)
+ *  - { codexServiceTier: { enabled, tier, supportedModels } } (this follow-up)
+ *  - { codexFastServiceTier: true }                  (very early flag)
+ *
+ * Defaults when fields are absent on an enabled config:
+ *  - tier            = "priority"  (back-compat: PR #2440 only injected priority)
+ *  - supportedModels = ["gpt-5.5", "gpt-5.4"] (OpenAI Fast-eligible per models_cache.json)
+ */
+export function resolveCodexGlobalFastServiceTier(
+  settings: unknown
+): CodexGlobalFastServiceTierResolved {
   const record = asRecord(settings);
-  const codexServiceTier = record.codexServiceTier;
+  const raw = record.codexServiceTier;
 
-  if (typeof codexServiceTier === "boolean") {
-    return codexServiceTier;
+  let enabled = false;
+  let tier: CodexFastTierValue = "priority";
+  let supportedModels: readonly string[] = CODEX_FAST_TIER_DEFAULT_SUPPORTED_MODELS;
+
+  if (typeof raw === "boolean") {
+    enabled = raw;
+  } else if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+    const obj = raw as JsonRecord;
+    if (obj.enabled === true) enabled = true;
+
+    if (typeof obj.tier === "string") {
+      const t = obj.tier.trim().toLowerCase();
+      if (t === "priority" || t === "flex") {
+        tier = t;
+      } else if (t === "default") {
+        // Explicit "default" means: do not inject any override.
+        enabled = false;
+      }
+    }
+
+    if (Array.isArray(obj.supportedModels)) {
+      const list = obj.supportedModels
+        .filter((m): m is string => typeof m === "string")
+        .map((m) => m.trim())
+        .filter((m) => m.length > 0);
+      if (list.length > 0) supportedModels = list;
+    }
+  } else if (record.codexFastServiceTier === true) {
+    enabled = true;
   }
 
-  const codexServiceTierRecord = asRecord(codexServiceTier);
-  if (codexServiceTierRecord.enabled === true) {
-    return true;
-  }
+  return { enabled, tier, supportedModels };
+}
 
-  return record.codexFastServiceTier === true;
+export function isCodexGlobalFastServiceTierEnabled(settings: unknown): boolean {
+  return resolveCodexGlobalFastServiceTier(settings).enabled;
 }
 
 export function getCodexEffectiveFastServiceTier(
@@ -32,13 +84,55 @@ export function getCodexEffectiveFastServiceTier(
   );
 }
 
+function modelMatchesSupportedList(
+  model: string | null | undefined,
+  supportedModels: readonly string[]
+): boolean {
+  if (typeof model !== "string" || model.length === 0) return false;
+  const normalizedModel = model.trim().toLowerCase();
+  if (!normalizedModel) return false;
+  for (const supported of supportedModels) {
+    const candidate = supported.trim().toLowerCase();
+    if (!candidate) continue;
+    if (normalizedModel === candidate || normalizedModel.startsWith(candidate)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export interface ApplyCodexGlobalFastServiceTierOptions {
+  /**
+   * Target model for the current request. When provided, the global override is only
+   * injected if the model matches the user-selected supportedModels list.
+   * When omitted, the gate is skipped (back-compat with the original signature).
+   */
+  model?: string | null;
+  /**
+   * Outbound request body. When provided and the tier is "flex", the helper writes
+   * body.service_tier directly so the value survives the requestDefaults normalizer
+   * (which only canonicalizes priority/fast). Per-request body.service_tier is left
+   * untouched if already set.
+   */
+  body?: Record<string, unknown> | null;
+}
+
 export function applyCodexGlobalFastServiceTier<T extends JsonRecord | null | undefined>(
   provider: string | null | undefined,
   credentials: T,
-  settings: unknown
+  settings: unknown,
+  options: ApplyCodexGlobalFastServiceTierOptions = {}
 ): T {
-  if (provider !== "codex" || !isCodexGlobalFastServiceTierEnabled(settings)) {
-    return credentials;
+  if (provider !== "codex") return credentials;
+
+  const resolved = resolveCodexGlobalFastServiceTier(settings);
+  if (!resolved.enabled) return credentials;
+
+  // Per-model gate. Skip when caller did not pass a model (back-compat call sites).
+  if (options.model !== undefined) {
+    if (!modelMatchesSupportedList(options.model, resolved.supportedModels)) {
+      return credentials;
+    }
   }
 
   if (!credentials || typeof credentials !== "object" || Array.isArray(credentials)) {
@@ -48,10 +142,27 @@ export function applyCodexGlobalFastServiceTier<T extends JsonRecord | null | un
   const providerSpecificData = asRecord(credentials.providerSpecificData);
   const requestDefaults = asRecord(providerSpecificData.requestDefaults);
 
+  // Per-connection requestDefaults.serviceTier wins over global. Mirrors the
+  // executor's body.service_tier > requestDefaults.serviceTier > global precedence.
   if (normalizeCodexServiceTier(requestDefaults.serviceTier)) {
     return credentials;
   }
 
+  if (resolved.tier === "flex") {
+    // requestDefaults.serviceTier is normalized downstream and "flex" would be stripped.
+    // Write to the outbound body instead, but only if the caller did not already set it.
+    const body = options.body;
+    if (body && typeof body === "object" && !Array.isArray(body)) {
+      const existing = (body as JsonRecord).service_tier;
+      if (typeof existing !== "string" || existing.trim().length === 0) {
+        (body as JsonRecord).service_tier = "flex";
+      }
+    }
+    return credentials;
+  }
+
+  // tier === "priority": existing behavior — inject via requestDefaults so the
+  // executor's normal precedence chain picks it up and cost accounting reflects it.
   return {
     ...credentials,
     providerSpecificData: {

--- a/src/shared/validation/settingsSchemas.ts
+++ b/src/shared/validation/settingsSchemas.ts
@@ -37,7 +37,13 @@ export const updateSettingsSchema = z.object({
   debugMode: z.boolean().optional(),
   hiddenSidebarItems: z.array(z.enum(HIDEABLE_SIDEBAR_ITEM_IDS)).optional(),
   comboConfigMode: z.enum(COMBO_CONFIG_MODES).optional(),
-  codexServiceTier: z.object({ enabled: z.boolean() }).optional(),
+  codexServiceTier: z
+    .object({
+      enabled: z.boolean().optional(),
+      tier: z.enum(["default", "priority", "flex"]).optional(),
+      supportedModels: z.array(z.string().max(200)).max(200).optional(),
+    })
+    .optional(),
   // Routing settings (#134)
   fallbackStrategy: z.enum(ACCOUNT_FALLBACK_STRATEGY_VALUES).optional(),
   wildcardAliases: z.array(z.object({ pattern: z.string(), target: z.string() })).optional(),


### PR DESCRIPTION
## What

Follow-up to PR #2440. Replace the boolean Codex Fast Tier toggle with:

- a tier dropdown (`default` / `priority` / `flex`), and
- a per-model gate that limits which Codex slugs receive the override.

## Why

PR #2440 surfaced a discoverable Codex Fast Tier toggle in Settings > AI, but two limitations came up in subsequent review/use:

1. The boolean toggle only injected `service_tier=priority`. OpenAI also offers a `flex` tier for cheaper, lower-priority batch/eval traffic, and some users want to opt in globally without touching per-connection settings.
2. When `enabled: true`, every outbound Codex request received the `service_tier` header. Only the Fast-eligible models accept it — per OpenAI's `~/.codex/models_cache.json`, those are `gpt-5.5` and `gpt-5.4` (with their `-codex` variants matching by prefix). Other Codex slugs got a tier-related error from OpenAI when the toggle was on.

## How

**Schema (`src/shared/validation/settingsSchemas.ts`)**:
```ts
codexServiceTier: z
  .object({
    enabled: z.boolean().optional(),
    tier: z.enum(["default", "priority", "flex"]).optional(),
    supportedModels: z.array(z.string().max(200)).max(200).optional(),
  })
  .optional()
```

Back-compat preserved:
- Rows with just `{ enabled: true }` from PR #2440 still work — `resolveCodexGlobalFastServiceTier()` defaults `tier` to `"priority"` and `supportedModels` to `["gpt-5.5", "gpt-5.4"]` when those fields are absent.
- The legacy boolean shape (`codexServiceTier: true`) and the older `codexFastServiceTier: true` flag are still honored.

**Middleware (`open-sse/handlers/chatCore.ts` + `src/lib/providers/codexFastTier.ts`)**:
- `applyCodexGlobalFastServiceTier` now takes an optional `{ model, body }`. The call site passes the resolved request model.
- Per-model gate: skip injection when the request's target model does not prefix-match any entry in `supportedModels` (case-insensitive). Calls without a `model` argument keep the original behavior, so any other call sites stay safe.
- For `tier="flex"`, the helper writes `body.service_tier` directly because `requestDefaults` goes through `normalizeCodexServiceTier`, which only canonicalizes `priority`/`fast`. Per-connection `requestDefaults.serviceTier` still wins over the global override — same precedence chain as before.

| Scenario | Before PR #2440 | After PR #2440 (current) | After this PR |
| --- | --- | --- | --- |
| Toggle off | no global injection | no global injection | no global injection |
| Toggle on, gpt-5.5 request | service_tier=priority | service_tier=priority | service_tier=tier (priority/flex) |
| Toggle on, gpt-5.3-codex request | (no toggle) | service_tier=priority → 400 | no injection (gated) |
| Toggle on, per-connection serviceTier=priority | per-connection | per-connection | per-connection |

**UI (`CodexFastTierTab.tsx`)**:
- Top-level boolean toggle stays unchanged.
- When enabled: tier `<Select>` (default / priority / flex) and a collapsible "Applied to models" list with checkboxes. Initial selection matches the OpenAI Fast-eligible catalog; users can add custom slugs by storing them in `supportedModels` (the union of catalog + stored is rendered, so future Fast-eligible releases can be enabled per-user without code changes).

**i18n**: en/fr/es/de hand-translated (7 new keys). The other 38 locales get the standard `__MISSING__:` sentinel so `scripts/i18n/sync-ui-keys.mjs` can fill them in a subsequent translator pass — same pattern PR #2440 used.

## Notes

Default behavior is unchanged: existing connections keep their `requestDefaults.serviceTier` precedence, the toggle still defaults off, and old `enabled: true` rows continue to inject `service_tier=priority` for `gpt-5.5` / `gpt-5.4`.

Verified locally:
- `npm run typecheck:core` → clean.
- `npm run build` → clean.
- `npx eslint` on the touched files → clean.

Happy to revise if you'd prefer a different shape — happy to drop the `flex` option, the per-model gate, or both if they go beyond what you want for this surface.
