### PR TITLE
feat: add OpenCode Free provider + homelab configs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,33 @@
+# Auto detect text files and perform LF normalization
+* text=auto eol=lf
+
+# Source code
+*.ts text eol=lf
+*.tsx text eol=lf
+*.js text eol=lf
+*.jsx text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.css text eol=lf
+*.html text eol=lf
+*.sql text eol=lf
+*.sh text eol=lf
+*.svg text eol=lf
+*.ps1 text eol=crlf
+
+# Binary files — don't touch line endings
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.eot binary
+*.mp3 binary
+*.mp4 binary
+*.wasm binary
+*.db binary

--- a/.github/workflows/deploy-homelab.yml
+++ b/.github/workflows/deploy-homelab.yml
@@ -1,0 +1,53 @@
+name: Deploy Homelab
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Image tag to deploy. Defaults to the workflow commit SHA."
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE_NAME: ghcr.io/podporaonline-cz/omniroute
+
+jobs:
+  build:
+    name: Build and push image
+    runs-on: [self-hosted, linux, x64, gh-aw, omniroute, homelab]
+    outputs:
+      image: ${{ steps.meta.outputs.image }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set image tag
+        id: meta
+        run: |
+          TAG="${{ inputs.image_tag }}"
+          if [ -z "$TAG" ]; then TAG="${GITHUB_SHA}"; fi
+          echo "image=${IMAGE_NAME}:${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.image }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,4 +81,4 @@ RUN apt-get update \
   && git config --system url."https://github.com/".insteadOf "ssh://git@github.com/"
 
 # Install CLI tools globally. Separate layer from apt for better cache reuse.
-RUN npm install -g --no-audit --no-fund @openai/codex @anthropic-ai/claude-code droid openclaw@latest
+RUN npm install -g --no-audit --no-fund   @openai/codex   @anthropic-ai/claude-code   opencode-ai   @google/gemini-cli   droid   openclaw@latest

--- a/docker-compose.homelab.yml
+++ b/docker-compose.homelab.yml
@@ -1,0 +1,87 @@
+# OmniRoute homelab/local deployment.
+#
+# This compose file intentionally uses the existing named volume `omniroute-data`
+# so it can adopt the current Docker-run instance without moving application data.
+# For a Proxmox host, copy the repo and .env, restore the volume, then run:
+#   docker compose -f docker-compose.homelab.yml up -d --build
+
+services:
+  redis:
+    image: redis:8.6.2
+    container_name: omniroute-redis
+    restart: unless-stopped
+    command: redis-server --save 60 1 --loglevel warning
+    ports:
+      - "${REDIS_BIND:-127.0.0.1}:${REDIS_PORT:-6379}:6379"
+    volumes:
+      - omniroute-redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+  omniroute:
+    container_name: omniroute
+    image: ${OMNIROUTE_IMAGE:-omniroute:local-ui-fix}
+    build:
+      context: .
+      target: ${OMNIROUTE_BUILD_TARGET:-runner-cli}
+    restart: unless-stopped
+    stop_grace_period: 40s
+    env_file: .env
+    environment:
+      NODE_ENV: ${NODE_ENV:-production}
+      PORT: ${PORT:-20128}
+      HOSTNAME: 0.0.0.0
+      DATA_DIR: /app/data
+      REDIS_URL: redis://redis:6379
+      CLI_CONFIG_HOME: /root
+    depends_on:
+      redis:
+        condition: service_healthy
+    ports:
+      - "${OMNIROUTE_BIND:-0.0.0.0}:${PORT:-20128}:${PORT:-20128}"
+    volumes:
+      - omniroute-data:/app/data
+      - omniroute-codex-home:/root/.codex
+      - omniroute-claude-home:/root/.claude
+      - omniroute-opencode-home:/root/.config/opencode
+      - omniroute-goose-home:/root/.config/goose
+      - omniroute-gemini-home:/root/.gemini
+    healthcheck:
+      test: ["CMD", "node", "healthcheck.mjs"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
+
+  qdrant:
+    image: ${QDRANT_IMAGE:-qdrant/qdrant:latest}
+    container_name: omniroute-qdrant
+    restart: unless-stopped
+    profiles:
+      - qdrant
+    ports:
+      - "${QDRANT_BIND:-127.0.0.1}:${QDRANT_PORT:-6333}:6333"
+    volumes:
+      - omniroute-qdrant-data:/qdrant/storage
+
+volumes:
+  omniroute-data:
+    name: omniroute-data
+    external: true
+  omniroute-redis-data:
+    name: omniroute-redis-data
+  omniroute-qdrant-data:
+    name: omniroute-qdrant-data
+  omniroute-codex-home:
+    name: omniroute-codex-home
+  omniroute-claude-home:
+    name: omniroute-claude-home
+  omniroute-opencode-home:
+    name: omniroute-opencode-home
+  omniroute-goose-home:
+    name: omniroute-goose-home
+  omniroute-gemini-home:
+    name: omniroute-gemini-home

--- a/open-sse/config/providerRegistry.ts
+++ b/open-sse/config/providerRegistry.ts
@@ -1062,6 +1062,17 @@ export const REGISTRY: Record<string, RegistryEntry> = {
     ],
   },
 
+  "opencode": {
+    id: "opencode",
+    alias: "oc",
+    format: "openai",
+    executor: "opencode",
+    baseUrl: "https://opencode.ai/zen/v1",
+    modelsUrl: "https://opencode.ai/zen/v1/models",
+    authType: "none",
+    defaultContextLength: 200000,
+    passthroughModels: true,
+  },
   "opencode-zen": {
     id: "opencode-zen",
     alias: "opencode-zen",

--- a/open-sse/executors/index.ts
+++ b/open-sse/executors/index.ts
@@ -50,6 +50,7 @@ const executors = {
   pol: new PollinationsExecutor(), // Alias
   "cloudflare-ai": new CloudflareAIExecutor(),
   cf: new CloudflareAIExecutor(), // Alias
+  "opencode": new OpencodeExecutor("opencode"),
   "opencode-zen": new OpencodeExecutor("opencode-zen"),
   "opencode-go": new OpencodeExecutor("opencode-go"),
   puter: new PuterExecutor(),

--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -781,6 +781,22 @@ export const APIKEY_PROVIDERS = {
     website: "https://open.bigmodel.cn",
     apiHint: "API key from https://open.bigmodel.cn/usercenter/apikeys",
   },
+  opencode: {
+    id: "opencode",
+    alias: "oc",
+    name: "OpenCode Free",
+    icon: "terminal",
+    color: "#E87040",
+    textIcon: "OC",
+    website: "https://opencode.ai",
+    noAuth: true,
+    authHint: "No API key required — uses OpenCode's public free endpoint.",
+    freeNote:
+      "No API key required — public OpenCode endpoint with Kimi, GLM, Qwen, MiMo, MiniMax models.",
+    notice: {
+      text: "OpenCode Free uses the public OpenCode endpoint (https://opencode.ai/zen/v1). No signup or API key needed. Rate limits apply.",
+    },
+  },
   "opencode-zen": {
     id: "opencode-zen",
     alias: "opencode-zen",


### PR DESCRIPTION
- Add OpenCode Free (noAuth) provider with Bearer public auth
- Register opencode in executor index and provider registry
- Add docker-compose.homelab.yml for local/homelab deployment
- Add deploy-homelab.yml workflow for self-hosted runner
- Add .gitattributes with LF normalization
- Extend Dockerfile with opencode-ai and gemini-cli CLI tools

## Summary

- Describe the user-facing or operational change.

## Related Issues

- Closes #
- Related to #

## Validation

- [ ] `npm run lint`
- [ ] `npm run test:unit`
- [ ] `npm run test:coverage`
- [ ] Coverage is still `>= 60%` for statements, lines, functions, and branches
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below

## Tests Added Or Updated

- List every changed or added automated test file.
- If no production code changed, state that here.

## Coverage Notes

- If this PR changes `src/`, `open-sse/`, `electron/`, or `bin/`, explain which tests cover the change.
- If coverage moved down in any touched file, explain why and what follow-up task will recover it.

## Reviewer Notes

- Call out any risky areas, migrations, feature flags, or manual validation that reviewers should know about.