### PR TITLE
fix(security): replace Math.random with crypto.randomUUID and fix URL hostname check

### DIFF
--- a/src/lib/cloudAgent/baseAgent.ts
+++ b/src/lib/cloudAgent/baseAgent.ts
@@ -86,10 +86,10 @@ export abstract class CloudAgentBase {
   }
 
   protected generateTaskId(): string {
-    return `task_${Date.now()}_${Math.random().toString(36).substring(2, 11)}`;
+    return `task_${Date.now()}_${crypto.randomUUID().replace(/-/g, "").substring(0, 9)}`;
   }
 
   protected generateActivityId(): string {
-    return `act_${Date.now()}_${Math.random().toString(36).substring(2, 11)}`;
+    return `act_${Date.now()}_${crypto.randomUUID().replace(/-/g, "").substring(0, 9)}`;
   }
 }

--- a/tests/unit/antigravity-discovery-bootstrap.test.ts
+++ b/tests/unit/antigravity-discovery-bootstrap.test.ts
@@ -152,7 +152,7 @@ describe("ensureAntigravityProjectAssigned", () => {
 
     const mockFetch = async (url: string, _init?: RequestInit): Promise<Response> => {
       hitUrls.push(url);
-      if (url.includes("daily-cloudcode-pa.googleapis.com")) {
+      if (new URL(url).hostname === "daily-cloudcode-pa.googleapis.com") {
         // First URL fails
         return new Response("not found", { status: 404 });
       }


### PR DESCRIPTION
## Fixes

Corrige os 2 alertas de code scanning CodeQL em aberto.

### Alert #251 — Insecure randomness (`js/insecure-randomness`)

**File**: `src/lib/cloudAgent/baseAgent.ts` (linhas 88–93)

`Math.random()` era usado para gerar os sufixos aleatórios de `taskId` e `activityId`. O CodeQL sinalizou o uso como inseguro para um contexto de segurança (os IDs são usados como identificadores externos para tarefas do Jules).

**Fix**: substituído por `crypto.randomUUID()` (disponível globalmente no Node.js ≥20, alinhado ao runtime alvo do projeto):

```ts
// Antes
return `task_${Date.now()}_${Math.random().toString(36).substring(2, 11)}`;

// Depois
return `task_${Date.now()}_${crypto.randomUUID().replace(/-/g, "").substring(0, 9)}`;
```

### Alert #252 — Incomplete URL substring sanitization (`js/incomplete-url-substring-sanitization`)

**File**: `tests/unit/antigravity-discovery-bootstrap.test.ts` (linha 155)

`url.includes("daily-cloudcode-pa.googleapis.com")` pode ser satisfeito por uma URL do tipo `http://evil.com/daily-cloudcode-pa.googleapis.com`, pois a string pode aparecer em qualquer posição.

**Fix**: substituído por verificação explícita do hostname via `new URL()`:

```ts
// Antes
if (url.includes("daily-cloudcode-pa.googleapis.com")) {

// Depois
if (new URL(url).hostname === "daily-cloudcode-pa.googleapis.com") {
```

## Test plan

- [ ] `node --import tsx/esm --test tests/unit/antigravity-discovery-bootstrap.test.ts` → 10/10 pass
- [ ] `npx tsc --noEmit` → sem erros nos arquivos modificados
- [ ] Após merge + re-scan do CodeQL → alertas #251 e #252 fechados como `fixed`