### PR TITLE
fix(vision-bridge): auto-route non-standard provider models through OmniRoute self-loop

### DIFF
--- a/src/lib/guardrails/visionBridgeHelpers.ts
+++ b/src/lib/guardrails/visionBridgeHelpers.ts
@@ -2,6 +2,7 @@
  * Vision Bridge helper functions for image processing.
  */
 import { fetchRemoteImage } from "@/shared/network/remoteImageFetch";
+import { getRuntimePorts } from "@/lib/runtime/ports";
 
 /**
  * Provider to environment variable mapping for API key resolution.
@@ -53,14 +54,34 @@ export function resolveProviderApiKey(model: string, explicitKey?: string): stri
  *      registered in OmniRoute (`google/gemini-2.0-flash`,
  *      `openrouter/...`, etc.) instead of being limited to OpenAI/Anthropic.
  *   2. `OPENAI_API_URL` env var (legacy)
- *   3. `https://api.openai.com/v1` (default — works only when the operator
- *      actually has an OpenAI account and OPENAI_API_KEY set)
+ *   3. OmniRoute self-loop (`http://localhost:20128/v1`) — auto-detected when
+ *      the model uses a known OmniRoute-internal provider (e.g. `kr/`, `if/`,
+ *      `pol/`, `groq/`, etc.) instead of a direct OpenAI/Anthropic endpoint.
+ *   4. `https://api.openai.com/v1` (fallback when the model is `openai/*` or
+ *      unprefixed — works only when the operator actually has an OpenAI
+ *      account and OPENAI_API_KEY set)
+ *
+ * @param model - Optional model identifier used to detect non-standard providers
+ *                that require OmniRoute self-loop routing.
  */
-export function resolveVisionBridgeBaseUrl(): string {
+export function resolveVisionBridgeBaseUrl(model?: string): string {
   const explicit = (process.env.VISION_BRIDGE_BASE_URL || "").trim();
   if (explicit) return explicit.replace(/\/+$/, "");
   const legacy = (process.env.OPENAI_API_URL || "").trim();
   if (legacy) return legacy.replace(/\/+$/, "");
+
+  // When the model has a non-standard provider prefix (not openai/ or
+  // anthropic/), it can only be resolved through OmniRoute's own router,
+  // not through a direct OpenAI/Anthropic endpoint. Use the operator-configured
+  // port via OMNIROUTE_PORT / PORT env vars, falling back to the default 20128.
+  if (model && model.includes("/")) {
+    const provider = model.split("/")[0].toLowerCase();
+    if (provider !== "openai" && provider !== "anthropic") {
+      const { port } = getRuntimePorts();
+      return `http://localhost:${port}/v1`;
+    }
+  }
+
   return "https://api.openai.com/v1";
 }
 
@@ -260,17 +281,36 @@ export async function callVisionModel(
       // VISION_BRIDGE_BASE_URL so the vision-bridge call can be routed through
       // OmniRoute itself or any other OpenAI-compatible endpoint instead of
       // hardcoded api.openai.com.
-      const baseUrl = resolveVisionBridgeBaseUrl();
+      const baseUrl = resolveVisionBridgeBaseUrl(config.model);
+
+      // When routing through the OmniRoute self-loop (non-standard provider),
+      // keep the full provider-prefixed model ID so OmniRoute can resolve the
+      // correct provider backend. Only strip the prefix for direct OpenAI calls.
+      const useFullModelId =
+        baseUrl.startsWith("http://localhost") &&
+        config.model.includes("/") &&
+        !config.model.startsWith("openai/");
+      const requestModel = useFullModelId ? config.model : modelName;
+
+      // Build headers with optional recursion guard for self-loop calls.
+      // When routing through OmniRoute's own API, omit the vision-bridge
+      // guardrail on the sub-request to prevent infinite recursion.
+      // Use sk_omniroute as fallback for self-loop if no API key is resolved.
+      const selfLoopApiKey = resolvedApiKey || "sk_omniroute";
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${selfLoopApiKey}`,
+      };
+      if (useFullModelId) {
+        headers["x-omniroute-disabled-guardrails"] = "vision-bridge";
+      }
 
       response = await fetch(`${baseUrl}/chat/completions`, {
         method: "POST",
         signal: controller.signal,
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${resolvedApiKey}`,
-        },
+        headers,
         body: JSON.stringify({
-          model: modelName,
+          model: requestModel,
           messages: [
             {
               role: "user",

--- a/src/shared/constants/modelSpecs.ts
+++ b/src/shared/constants/modelSpecs.ts
@@ -26,6 +26,24 @@ export const MODEL_SPECS: Record<string, ModelSpec> = {
     supportsVision: true,
   },
 
+  // ── GPT-4o family ──────────────────────────────────────────────
+  "gpt-4o-mini": {
+    maxOutputTokens: 16384,
+    contextWindow: 128000,
+    supportsThinking: false,
+    supportsTools: true,
+    supportsVision: true,
+    aliases: ["openai/gpt-4o-mini"],
+  },
+  "gpt-4o": {
+    maxOutputTokens: 16384,
+    contextWindow: 128000,
+    supportsThinking: false,
+    supportsTools: true,
+    supportsVision: true,
+    aliases: ["openai/gpt-4o"],
+  },
+
   // ── Gemini 3 Flash series ───────────────────────────────────────
   "gemini-3-flash": {
     maxOutputTokens: 65536,

--- a/tests/unit/vision-bridge-env-override.test.ts
+++ b/tests/unit/vision-bridge-env-override.test.ts
@@ -81,6 +81,59 @@ test("#2232 — whitespace-only VISION_BRIDGE_BASE_URL falls through to OPENAI_A
   assert.equal(resolveVisionBridgeBaseUrl(), "https://oai.example.com/v1");
 });
 
+test("#2232 — OmniRoute-internal providers default to self-loop when no env vars set", () => {
+  clearEnv();
+  // Non-standard prefixes (kr/, if/, pol/, groq/) should use OmniRoute self-loop
+  assert.equal(
+    resolveVisionBridgeBaseUrl("kr/claude-sonnet-4-5"),
+    "http://localhost:20128/v1"
+  );
+  assert.equal(
+    resolveVisionBridgeBaseUrl("if/kimi-k2-thinking"),
+    "http://localhost:20128/v1"
+  );
+  assert.equal(
+    resolveVisionBridgeBaseUrl("pol/gpt-5"),
+    "http://localhost:20128/v1"
+  );
+});
+
+test("#2232 — OpenAI and Anthropic models still default to api.openai.com", () => {
+  clearEnv();
+  // Standard prefixes should keep default behavior
+  assert.equal(
+    resolveVisionBridgeBaseUrl("openai/gpt-4o"),
+    "https://api.openai.com/v1"
+  );
+  assert.equal(
+    resolveVisionBridgeBaseUrl("anthropic/claude-sonnet-4-5"),
+    "https://api.openai.com/v1"  // anthropic goes through a different code path
+                                   // but if passed here, should not self-loop
+  );
+});
+
+test("#2232 — unprefixed model names default to api.openai.com", () => {
+  clearEnv();
+  // Models without provider prefix should keep default behavior
+  assert.equal(
+    resolveVisionBridgeBaseUrl("gpt-4o-mini"),
+    "https://api.openai.com/v1"
+  );
+  assert.equal(
+    resolveVisionBridgeBaseUrl("deepseek-v4-flash"),
+    "https://api.openai.com/v1"
+  );
+});
+
+test("#2232 — VISION_BRIDGE_BASE_URL env var takes precedence over self-loop auto-detection", () => {
+  clearEnv();
+  process.env.VISION_BRIDGE_BASE_URL = "https://custom-proxy.example.com/v1";
+  assert.equal(
+    resolveVisionBridgeBaseUrl("kr/claude-sonnet-4-5"),
+    "https://custom-proxy.example.com/v1"
+  );
+});
+
 // ─── resolveProviderApiKey ────────────────────────────────────────────────
 
 test("#2232 — VISION_BRIDGE_API_KEY wins for non-anthropic models", () => {


### PR DESCRIPTION
### OmniRoute Version
3.8.2

### Installation Method
Built from source

### Operating System
Windows

### OS Version
Windows 11

### Node.js Version
24.15.0

### Provider(s) Involved
Kiro (kr/), Inflection (if/), Pollinations (pol/), Groq (groq/), and any OmniRoute-internal provider

### Model(s) Involved
kr/claude-sonnet-4-5, if/kimi-k2-thinking, pol/gpt-5, groq/llama-3.3, deepseek-v4-flash, gpt-4o-mini, gpt-4o

### Client Tool
OpenCode

### Description
The Vision Bridge has two bugs that prevent it from working with most provider models:

1. **Missing MODEL_SPECS**: `gpt-4o-mini` and `gpt-4o` are not registered in `MODEL_SPECS` with `supportsVision: true`, so the Vision Bridge incorrectly processes images for these models instead of passthrough.

2. **Hardcoded OpenAI URL**: `callVisionModel` always calls `https://api.openai.com/v1` for any model not prefixed with `anthropic/`. When the user configures a non-OpenAI/non-Anthropic model (e.g. `kr/claude-sonnet-4-5`, `if/kimi-k2-thinking`, `pol/gpt-5`), the bridge tries to reach these models through the OpenAI endpoint, which fails because those models only exist within OmniRoute's provider registry.

### Steps to Reproduce
1. Configure Vision Bridge in Dashboard settings with a non-OpenAI/non-Anthropic model (e.g. `kr/claude-sonnet-4-5`)
2. Send a request with an image to a non-vision model (e.g. `deepseek-v4-flash`)
3. Observe that the image description call fails because it tries to reach OpenAI instead of routing through OmniRoute
4. The description becomes `(unavailable)` and the model receives no useful image context

### Expected Behavior
The Vision Bridge should automatically detect when the configured model uses a known OmniRoute-internal provider prefix (any prefix that is not `openai/` or `anthropic/`) and route the image description request through OmniRoute's own API (self-loop at `http://localhost:20128/v1`), keeping the full provider-prefixed model ID so OmniRoute can resolve the correct backend provider.

### Actual Behavior
The bridge defaults to `https://api.openai.com/v1` for all non-Anthropic models, causing image description requests to fail for any provider that is not OpenAI or Anthropic.

### Test Impact
Existing automated test already fails (VB-S02b for gpt-4o-mini). Plus 4 new tests added for OmniRoute-internal provider auto-detection.

### Validation Plan
- node --import tsx --test tests/unit/vision-bridge-env-override.test.ts
- node --import tsx --test tests/unit/guardrails/visionBridge.test.ts
- node --import tsx --test tests/unit/guardrails/visionBridgeHelpers.*.test.ts
- node --import tsx --test tests/unit/visionBridgeDefaults.test.ts
- node --import tsx --test tests/unit/vision-bridge-settings-schema.test.ts