### PR TITLE
fix(combo): clarify log message when combo target is skipped due to unavailable credentials

### DIFF
--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -2042,11 +2042,11 @@ export async function handleComboChat({
         continue;
       }
 
-      // Pre-check: skip models where all accounts are in cooldown
+      // Pre-check: skip models where no credentials are available (excluded, rate-limited, or unavailable)
       if (isModelAvailable) {
         const available = await isModelAvailable(modelStr, target);
         if (!available) {
-          log.info("COMBO", `Skipping ${modelStr} (all accounts in cooldown)`);
+          log.info("COMBO", `Skipping ${modelStr} — no credentials available or model excluded`);
           if (i > 0) fallbackCount++;
           continue;
         }
@@ -2450,7 +2450,7 @@ async function handleRoundRobinCombo({
     if (isModelAvailable) {
       const available = await isModelAvailable(modelStr, target);
       if (!available) {
-        log.info("COMBO-RR", `Skipping ${modelStr} (all accounts in cooldown)`);
+        log.info("COMBO-RR", `Skipping ${modelStr} — no credentials available or model excluded`);
         if (offset > 0) fallbackCount++;
         continue;
       }


### PR DESCRIPTION
## Description

When a combo target is skipped because no credentials are available (e.g., model excluded on all connections, all accounts rate-limited), the combo loop was logging a misleading `"(all accounts in cooldown)"` message.

## Changes

**open-sse/services/combo.ts:**
- Updated log message in the main combo loop from `(all accounts in cooldown)` to `— no credentials available or model excluded`
- Updated log message in the round-robin handler with the same fix

## Related Issue
Closes #2493