### PR TITLE
fix(antigravity): align subscription tier detection with Antigravity Manager

### DIFF
--- a/open-sse/services/antigravityHeaders.ts
+++ b/open-sse/services/antigravityHeaders.ts
@@ -25,20 +25,6 @@ export const ANTIGRAVITY_NODE_API_CLIENT = "google-api-nodejs-client/10.3.0";
 // Harness/bootstrap X-Goog-Api-Client synced with CLIProxyAPI misc.AntigravityGoogAPIClientUA.
 export const ANTIGRAVITY_CREDIT_PROBE_API_CLIENT = "gl-node/22.21.1";
 export const ANTIGRAVITY_API_CLIENT = ANTIGRAVITY_CREDIT_PROBE_API_CLIENT;
-type AntigravityLoadCodeAssistPlatform = "MACOS" | "WINDOWS" | "LINUX";
-
-function getAntigravityLoadCodeAssistPlatformLabel(
-  platform: NodeJS.Platform = process.platform
-): AntigravityLoadCodeAssistPlatform {
-  switch (platform) {
-    case "darwin":
-      return "MACOS";
-    case "win32":
-      return "WINDOWS";
-    default:
-      return "LINUX";
-  }
-}
 
 function withOptionalBearerAuth(
   headers: Record<string, string>,
@@ -84,20 +70,15 @@ export function antigravityNativeOAuthUserAgent(): string {
   return `vscode/1.X.X (Antigravity/${getCachedAntigravityVersion()})`;
 }
 
-export function getAntigravityLoadCodeAssistMetadata(
-  platform: NodeJS.Platform = process.platform
-): Record<string, string> {
+/** Matches Antigravity-Manager quota.rs: only ideType (no platform — LINUX is rejected). */
+export function getAntigravityLoadCodeAssistMetadata(): Record<string, string> {
   return {
     ideType: "ANTIGRAVITY",
-    platform: getAntigravityLoadCodeAssistPlatformLabel(platform),
-    pluginType: "GEMINI",
   };
 }
 
-export function getAntigravityLoadCodeAssistClientMetadata(
-  platform: NodeJS.Platform = process.platform
-): string {
-  return JSON.stringify(getAntigravityLoadCodeAssistMetadata(platform));
+export function getAntigravityLoadCodeAssistClientMetadata(): string {
+  return JSON.stringify(getAntigravityLoadCodeAssistMetadata());
 }
 
 export function getAntigravityHeaders(

--- a/open-sse/services/codeAssistSubscription.ts
+++ b/open-sse/services/codeAssistSubscription.ts
@@ -1,0 +1,93 @@
+/**
+ * Code Assist (loadCodeAssist) subscription tier extraction.
+ * Mirrors Antigravity-Manager src-tauri/src/modules/quota.rs fetch_project_id().
+ */
+
+type JsonRecord = Record<string, unknown>;
+
+function toRecord(value: unknown): JsonRecord {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as JsonRecord) : {};
+}
+
+function pickTierField(tier: unknown, field: "name" | "id"): string | null {
+  const record = toRecord(tier);
+  const value = record[field];
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function isIneligible(subscription: JsonRecord): boolean {
+  const ineligible = subscription.ineligibleTiers;
+  return Array.isArray(ineligible) && ineligible.length > 0;
+}
+
+function findDefaultAllowedTier(subscription: JsonRecord): JsonRecord | null {
+  if (!Array.isArray(subscription.allowedTiers)) return null;
+  for (const tierValue of subscription.allowedTiers) {
+    const tier = toRecord(tierValue);
+    if (tier.isDefault) return tier;
+  }
+  return null;
+}
+
+/**
+ * Display subscription tier from loadCodeAssist (paid → current → restricted default).
+ */
+export function extractCodeAssistSubscriptionTier(subscriptionInfo: unknown): string | null {
+  const subscription = toRecord(subscriptionInfo);
+  if (Object.keys(subscription).length === 0) return null;
+
+  let tier =
+    pickTierField(subscription.paidTier, "name") || pickTierField(subscription.paidTier, "id");
+
+  if (!tier) {
+    if (!isIneligible(subscription)) {
+      tier =
+        pickTierField(subscription.currentTier, "name") ||
+        pickTierField(subscription.currentTier, "id");
+    } else {
+      const defaultTier = findDefaultAllowedTier(subscription);
+      if (defaultTier) {
+        const name = pickTierField(defaultTier, "name");
+        const id = pickTierField(defaultTier, "id");
+        if (name) tier = `${name} (Restricted)`;
+        else if (id) tier = `${id} (Restricted)`;
+      }
+    }
+  }
+
+  return tier;
+}
+
+/**
+ * Tier ID for onboardUser tier_id (paid → current → restricted default → legacy-tier).
+ */
+export function extractCodeAssistOnboardTierId(subscriptionInfo: unknown): string {
+  const subscription = toRecord(subscriptionInfo);
+
+  const paidId = pickTierField(subscription.paidTier, "id");
+  if (paidId) return paidId;
+
+  if (!isIneligible(subscription)) {
+    const currentId = pickTierField(subscription.currentTier, "id");
+    if (currentId) return currentId;
+  } else {
+    const defaultTier = findDefaultAllowedTier(subscription);
+    const defaultId = defaultTier ? pickTierField(defaultTier, "id") : null;
+    if (defaultId) return defaultId;
+  }
+
+  if (Array.isArray(subscription.allowedTiers)) {
+    for (const tierValue of subscription.allowedTiers) {
+      const tier = toRecord(tierValue);
+      if (tier.isDefault) {
+        const id = pickTierField(tier, "id");
+        if (id) return id;
+      }
+    }
+  }
+
+  const currentId = pickTierField(subscription.currentTier, "id");
+  if (currentId) return currentId;
+
+  return "legacy-tier";
+}

--- a/open-sse/services/codeAssistSubscription.ts
+++ b/open-sse/services/codeAssistSubscription.ts
@@ -70,21 +70,11 @@ export function extractCodeAssistOnboardTierId(subscriptionInfo: unknown): strin
   if (!isIneligible(subscription)) {
     const currentId = pickTierField(subscription.currentTier, "id");
     if (currentId) return currentId;
-  } else {
-    const defaultTier = findDefaultAllowedTier(subscription);
-    const defaultId = defaultTier ? pickTierField(defaultTier, "id") : null;
-    if (defaultId) return defaultId;
   }
 
-  if (Array.isArray(subscription.allowedTiers)) {
-    for (const tierValue of subscription.allowedTiers) {
-      const tier = toRecord(tierValue);
-      if (tier.isDefault) {
-        const id = pickTierField(tier, "id");
-        if (id) return id;
-      }
-    }
-  }
+  const defaultTier = findDefaultAllowedTier(subscription);
+  const defaultId = defaultTier ? pickTierField(defaultTier, "id") : null;
+  if (defaultId) return defaultId;
 
   const currentId = pickTierField(subscription.currentTier, "id");
   if (currentId) return currentId;

--- a/open-sse/services/usage.ts
+++ b/open-sse/services/usage.ts
@@ -1562,8 +1562,7 @@ function extractCodeAssistTierId(subscription: JsonRecord): string {
   const tierId = extractCodeAssistOnboardTierId(subscription);
   if (tierId === "legacy-tier") return "";
   const upper = tierId.toUpperCase();
-  if (mapCodeAssistTierIdToLabel(upper)) return upper;
-  return upper;
+  return mapCodeAssistTierIdToLabel(upper) ? upper : "";
 }
 
 function mapCodeAssistTierIdToLabel(tierId: string): string | null {
@@ -1636,15 +1635,26 @@ function mapCodeAssistSubscriptionToPlanLabel(subscriptionInfo: unknown): string
   return "Free";
 }
 
+const KNOWN_ANTIGRAVITY_PLAN_LABELS = new Set([
+  "Ultra",
+  "Pro",
+  "Enterprise",
+  "Business",
+  "Plus",
+  "Lite",
+]);
+
 /**
  * Map raw loadCodeAssist tier data to short display labels (Antigravity Manager parity).
  */
 function getAntigravityPlanLabel(subscriptionInfo: unknown, fallbackInfo?: unknown): string {
-  const plan = mapCodeAssistSubscriptionToPlanLabel(subscriptionInfo);
-  if (plan !== "Free") return plan;
-
+  const livePlan = mapCodeAssistSubscriptionToPlanLabel(subscriptionInfo);
   const fallbackPlan = mapCodeAssistSubscriptionToPlanLabel(fallbackInfo);
-  return fallbackPlan !== "Free" ? fallbackPlan : plan;
+
+  if (KNOWN_ANTIGRAVITY_PLAN_LABELS.has(livePlan)) return livePlan;
+  if (KNOWN_ANTIGRAVITY_PLAN_LABELS.has(fallbackPlan)) return fallbackPlan;
+  if (livePlan !== "Free") return livePlan;
+  return fallbackPlan !== "Free" ? fallbackPlan : livePlan;
 }
 
 /**

--- a/open-sse/services/usage.ts
+++ b/open-sse/services/usage.ts
@@ -1809,8 +1809,9 @@ async function getAntigravityUsage(
     return { plan: "Free", message: "Antigravity access token not available." };
   }
 
+  let subscriptionInfo: unknown = null;
   try {
-    const subscriptionInfo = await getAntigravitySubscriptionInfoCached(
+    subscriptionInfo = await getAntigravitySubscriptionInfoCached(
       accessToken,
       providerSpecificData,
       options
@@ -1908,17 +1909,6 @@ async function getAntigravityUsage(
       subscriptionInfo,
     };
   } catch (error) {
-    let subscriptionInfo: unknown = null;
-    try {
-      subscriptionInfo = await getAntigravitySubscriptionInfoCached(
-        accessToken,
-        providerSpecificData,
-        options
-      );
-    } catch {
-      subscriptionInfo = null;
-    }
-
     return {
       plan: getAntigravityPlanLabel(subscriptionInfo, providerSpecificData),
       subscriptionInfo,

--- a/open-sse/services/usage.ts
+++ b/open-sse/services/usage.ts
@@ -38,6 +38,10 @@ import {
 import { getCreditsMode } from "./antigravityCredits.ts";
 import { CLAUDE_CODE_VERSION, fetchClaudeBootstrap } from "../executors/claudeIdentity.ts";
 import { generateAntigravityRequestId, getAntigravitySessionId } from "./antigravityIdentity.ts";
+import {
+  extractCodeAssistOnboardTierId,
+  extractCodeAssistSubscriptionTier,
+} from "./codeAssistSubscription.ts";
 
 // Antigravity API config (credentials from PROVIDERS via credential loader)
 const ANTIGRAVITY_CONFIG = {
@@ -1467,54 +1471,7 @@ async function getGeminiCliSubscriptionInfo(accessToken: string): Promise<unknow
  * Map Gemini CLI subscription tier to display label (same tiers as Antigravity).
  */
 function getGeminiCliPlanLabel(subscriptionInfo: unknown): string {
-  const subscription = toRecord(subscriptionInfo);
-  if (Object.keys(subscription).length === 0) return "Free";
-
-  let tierId = "";
-  if (Array.isArray(subscription.allowedTiers)) {
-    for (const tierValue of subscription.allowedTiers) {
-      const tier = toRecord(tierValue);
-      if (tier.isDefault && typeof tier.id === "string") {
-        tierId = tier.id.trim().toUpperCase();
-        break;
-      }
-    }
-  }
-
-  if (!tierId) {
-    const currentTier = toRecord(subscription.currentTier);
-    tierId = typeof currentTier.id === "string" ? currentTier.id.toUpperCase() : "";
-  }
-
-  if (tierId) {
-    if (tierId.includes("ULTRA")) return "Ultra";
-    if (tierId.includes("PRO")) return "Pro";
-    if (tierId.includes("ENTERPRISE")) return "Enterprise";
-    if (tierId.includes("BUSINESS") || tierId.includes("STANDARD")) return "Business";
-    if (tierId.includes("FREE") || tierId.includes("INDIVIDUAL") || tierId.includes("LEGACY"))
-      return "Free";
-  }
-
-  const tierName = String(
-    getFieldValue(toRecord(subscription.currentTier), "name", "displayName") ||
-      subscription.subscriptionType ||
-      subscription.tier ||
-      ""
-  );
-  const upper = tierName.toUpperCase();
-
-  if (upper.includes("ULTRA")) return "Ultra";
-  if (upper.includes("PRO")) return "Pro";
-  if (upper.includes("ENTERPRISE")) return "Enterprise";
-  if (upper.includes("STANDARD") || upper.includes("BUSINESS")) return "Business";
-  if (upper.includes("INDIVIDUAL") || upper.includes("FREE")) return "Free";
-
-  if (toRecord(subscription.currentTier).upgradeSubscriptionType) return "Free";
-  if (tierName) {
-    return tierName.charAt(0).toUpperCase() + tierName.slice(1).toLowerCase();
-  }
-
-  return "Free";
+  return mapCodeAssistSubscriptionToPlanLabel(subscriptionInfo);
 }
 
 // ── Antigravity subscription info cache ──────────────────────────────────────
@@ -1601,67 +1558,93 @@ async function fetchAntigravityAvailableModelsCached(
   return promise;
 }
 
-/**
- * Map raw loadCodeAssist tier data to short display labels.
- * Extracts tier from allowedTiers[].isDefault (same logic as providers.js postExchange).
- * Falls back to currentTier.id → currentTier.name → "Free".
- */
-function getAntigravityPlanLabel(subscriptionInfo: unknown): string {
+function extractCodeAssistTierId(subscription: JsonRecord): string {
+  const tierId = extractCodeAssistOnboardTierId(subscription);
+  if (tierId === "legacy-tier") return "";
+  const upper = tierId.toUpperCase();
+  if (mapCodeAssistTierIdToLabel(upper)) return upper;
+  return upper;
+}
+
+function mapCodeAssistTierIdToLabel(tierId: string): string | null {
+  const upper = tierId.toUpperCase();
+  if (upper.includes("ULTRA")) return "Ultra";
+  if (
+    upper.includes("PRO") ||
+    upper.includes("PREMIUM") ||
+    upper.includes("GOOGLE_ONE") ||
+    upper.includes("ONE_AI")
+  )
+    return "Pro";
+  if (upper.includes("ENTERPRISE")) return "Enterprise";
+  if (upper.includes("BUSINESS") || upper.includes("STANDARD")) return "Business";
+  if (upper.includes("PLUS")) return "Plus";
+  if (upper.includes("LITE") || upper.includes("LIGHT")) return "Lite";
+  if (upper.includes("FREE") || upper.includes("INDIVIDUAL") || upper.includes("LEGACY"))
+    return "Free";
+  return null;
+}
+
+function mapSubscriptionTierStringToPlanLabel(tierText: string): string | null {
+  const upper = tierText.toUpperCase();
+  if (upper.includes("ULTRA")) return "Ultra";
+  if (upper.includes("PRO") || upper.includes("PREMIUM") || upper.includes("GOOGLE ONE"))
+    return "Pro";
+  if (upper.includes("ENTERPRISE")) return "Enterprise";
+  if (upper.includes("STANDARD") || upper.includes("BUSINESS")) return "Business";
+  if (upper.includes("PLUS")) return "Plus";
+  if (upper.includes("LITE")) return "Lite";
+  if (upper.includes("INDIVIDUAL") || upper.includes("FREE")) return "Free";
+  const normalizedId = upper.replace(/\s*\(RESTRICTED\)\s*$/i, "").trim();
+  if (normalizedId) {
+    const mapped = mapCodeAssistTierIdToLabel(normalizedId);
+    if (mapped) return mapped;
+  }
+  return null;
+}
+
+function mapCodeAssistSubscriptionToPlanLabel(subscriptionInfo: unknown): string {
   const subscription = toRecord(subscriptionInfo);
   if (Object.keys(subscription).length === 0) return "Free";
 
-  // 1. Extract tier from allowedTiers (primary source — same as providers.js)
-  let tierId = "";
-  if (Array.isArray(subscription.allowedTiers)) {
-    for (const tierValue of subscription.allowedTiers) {
-      const tier = toRecord(tierValue);
-      if (tier.isDefault && typeof tier.id === "string") {
-        tierId = tier.id.trim().toUpperCase();
-        break;
-      }
+  const subscriptionTier = extractCodeAssistSubscriptionTier(subscriptionInfo);
+  if (subscriptionTier) {
+    const mapped = mapSubscriptionTierStringToPlanLabel(subscriptionTier);
+    if (mapped) return mapped;
+    if (subscriptionTier.toLowerCase() !== "free") {
+      return subscriptionTier.charAt(0).toUpperCase() + subscriptionTier.slice(1).toLowerCase();
     }
   }
 
-  // 2. Fall back to currentTier.id
-  if (!tierId) {
-    const currentTier = toRecord(subscription.currentTier);
-    tierId = typeof currentTier.id === "string" ? currentTier.id.toUpperCase() : "";
-  }
-
-  // 3. Map tier ID to display label
-  if (tierId) {
-    if (tierId.includes("ULTRA")) return "Ultra";
-    if (tierId.includes("PRO")) return "Pro";
-    if (tierId.includes("ENTERPRISE")) return "Enterprise";
-    if (tierId.includes("BUSINESS") || tierId.includes("STANDARD")) return "Business";
-    if (tierId.includes("FREE") || tierId.includes("INDIVIDUAL") || tierId.includes("LEGACY"))
-      return "Free";
-  }
-
-  // 4. Try tier name fields as last resort
+  const currentTier = toRecord(subscription.currentTier);
   const tierName = String(
-    getFieldValue(toRecord(subscription.currentTier), "name", "displayName") ||
+    getFieldValue(currentTier, "name", "displayName") ||
       subscription.subscriptionType ||
       subscription.tier ||
       ""
   );
-  const upper = tierName.toUpperCase();
+  const mappedName = tierName ? mapSubscriptionTierStringToPlanLabel(tierName) : null;
+  if (mappedName) return mappedName;
 
-  if (upper.includes("ULTRA")) return "Ultra";
-  if (upper.includes("PRO")) return "Pro";
-  if (upper.includes("ENTERPRISE")) return "Enterprise";
-  if (upper.includes("STANDARD") || upper.includes("BUSINESS")) return "Business";
-  if (upper.includes("INDIVIDUAL") || upper.includes("FREE")) return "Free";
-
-  // 5. If upgradeSubscriptionType exists, account is on free tier
-  if (toRecord(subscription.currentTier).upgradeSubscriptionType) return "Free";
-
-  // 6. If we have a tier name that didn't match known patterns, return it title-cased
-  if (tierName) {
-    return tierName.charAt(0).toUpperCase() + tierName.slice(1).toLowerCase();
+  const tierId = extractCodeAssistTierId(subscription);
+  if (tierId) {
+    const mapped = mapCodeAssistTierIdToLabel(tierId);
+    if (mapped) return mapped;
   }
-
+  if (currentTier.upgradeSubscriptionType) return "Free";
+  if (tierName) return tierName.charAt(0).toUpperCase() + tierName.slice(1).toLowerCase();
   return "Free";
+}
+
+/**
+ * Map raw loadCodeAssist tier data to short display labels (Antigravity Manager parity).
+ */
+function getAntigravityPlanLabel(subscriptionInfo: unknown, fallbackInfo?: unknown): string {
+  const plan = mapCodeAssistSubscriptionToPlanLabel(subscriptionInfo);
+  if (plan !== "Free") return plan;
+
+  const fallbackPlan = mapCodeAssistSubscriptionToPlanLabel(fallbackInfo);
+  return fallbackPlan !== "Free" ? fallbackPlan : plan;
 }
 
 /**
@@ -1829,10 +1812,22 @@ async function getAntigravityUsage(
   try {
     const subscriptionInfo = await getAntigravitySubscriptionInfoCached(
       accessToken,
-      providerSpecificData
+      providerSpecificData,
+      options
     );
+    const savedProjectId =
+      typeof providerSpecificData?.projectId === "string" && providerSpecificData.projectId.trim()
+        ? providerSpecificData.projectId.trim()
+        : null;
+    const subscriptionProject = toRecord(subscriptionInfo).cloudaicompanionProject;
     const projectId =
-      connectionProjectId || toRecord(subscriptionInfo).cloudaicompanionProject?.toString() || null;
+      savedProjectId ||
+      connectionProjectId ||
+      (typeof subscriptionProject === "string"
+        ? subscriptionProject
+        : typeof toRecord(subscriptionProject).id === "string"
+          ? (toRecord(subscriptionProject).id as string)
+          : null);
 
     // Derive accountId for credit balance cache.
     // Must match executor key: credentials.connectionId
@@ -1897,7 +1892,7 @@ async function getAntigravityUsage(
     }
 
     return {
-      plan: getAntigravityPlanLabel(subscriptionInfo),
+      plan: getAntigravityPlanLabel(subscriptionInfo, providerSpecificData),
       quotas: {
         ...quotas,
         ...(creditBalance !== null && {
@@ -1913,7 +1908,22 @@ async function getAntigravityUsage(
       subscriptionInfo,
     };
   } catch (error) {
-    return { message: `Antigravity error: ${(error as Error).message}` };
+    let subscriptionInfo: unknown = null;
+    try {
+      subscriptionInfo = await getAntigravitySubscriptionInfoCached(
+        accessToken,
+        providerSpecificData,
+        options
+      );
+    } catch {
+      subscriptionInfo = null;
+    }
+
+    return {
+      plan: getAntigravityPlanLabel(subscriptionInfo, providerSpecificData),
+      subscriptionInfo,
+      message: `Antigravity error: ${(error as Error).message}`,
+    };
   }
 }
 
@@ -1923,18 +1933,25 @@ async function getAntigravityUsage(
  */
 async function getAntigravitySubscriptionInfoCached(
   accessToken: string,
-  providerSpecificData?: JsonRecord
+  providerSpecificData?: JsonRecord,
+  options: AntigravityUsageOptions = {}
 ): Promise<unknown> {
   const profile = getAntigravityClientProfile({ providerSpecificData });
   const cacheKey = `${accessToken.substring(0, 16)}:${profile}`;
-  const cached = _antigravitySubCache.get(cacheKey);
 
-  if (cached && Date.now() - cached.fetchedAt < ANTIGRAVITY_CACHE_TTL_MS) {
-    return cached.data;
+  if (options.forceRefresh) {
+    _antigravitySubCache.delete(cacheKey);
+  } else {
+    const cached = _antigravitySubCache.get(cacheKey);
+    if (cached && Date.now() - cached.fetchedAt < ANTIGRAVITY_CACHE_TTL_MS) {
+      return cached.data;
+    }
   }
 
   const data = await getAntigravitySubscriptionInfo(accessToken, providerSpecificData);
-  _antigravitySubCache.set(cacheKey, { data, fetchedAt: Date.now() });
+  if (data != null) {
+    _antigravitySubCache.set(cacheKey, { data, fetchedAt: Date.now() });
+  }
   return data;
 }
 
@@ -2551,4 +2568,6 @@ export const __testing = {
   inferGitHubPlanName,
   getGeminiCliPlanLabel,
   getAntigravityPlanLabel,
+  extractCodeAssistSubscriptionTier,
+  extractCodeAssistOnboardTierId,
 };

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.tsx
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.tsx
@@ -404,10 +404,11 @@ export function parseQuotaData(provider, data) {
  */
 export function resolvePlanValue(plan, providerSpecificData) {
   const psd = toRecord(providerSpecificData);
-  const candidates = [
-    plan,
+  const livePlan = normalizePlanCandidate(plan);
+  const persistedCandidates = [
     psd.workspacePlanType,
     psd.plan,
+    psd.subscriptionTier,
     psd.subscription,
     psd.tier,
     psd.accountTier,
@@ -416,12 +417,16 @@ export function resolvePlanValue(plan, providerSpecificData) {
     psd.organizationType,
   ];
 
-  for (const candidate of candidates) {
+  if (livePlan && normalizePlanTier(livePlan).key !== "free") {
+    return livePlan;
+  }
+
+  for (const candidate of persistedCandidates) {
     const normalized = normalizePlanCandidate(candidate);
     if (normalized) return normalized;
   }
 
-  return null;
+  return livePlan || null;
 }
 
 /**

--- a/src/lib/oauth/providers/antigravity.ts
+++ b/src/lib/oauth/providers/antigravity.ts
@@ -4,6 +4,7 @@ import {
   getAntigravityHeaders,
   getAntigravityLoadCodeAssistMetadata,
 } from "@omniroute/open-sse/services/antigravityHeaders.ts";
+import { extractCodeAssistOnboardTierId } from "@omniroute/open-sse/services/codeAssistSubscription.ts";
 
 async function fetchFirstOk(endpoints: string[], init: RequestInit) {
   let lastError: unknown = null;
@@ -82,14 +83,7 @@ export const antigravity = {
       });
       const data = await loadRes.json();
       projectId = data.cloudaicompanionProject?.id || data.cloudaicompanionProject || "";
-      if (Array.isArray(data.allowedTiers)) {
-        for (const tier of data.allowedTiers) {
-          if (tier.isDefault && tier.id) {
-            tierId = tier.id.trim();
-            break;
-          }
-        }
-      }
+      tierId = extractCodeAssistOnboardTierId(data);
     } catch (e) {
       console.log("Failed to load code assist:", e);
     }
@@ -118,7 +112,7 @@ export const antigravity = {
       }
     }
 
-    return { userInfo, projectId };
+    return { userInfo, projectId, tierId };
   },
   mapTokens: (tokens, extra) => ({
     accessToken: tokens.access_token,
@@ -127,5 +121,9 @@ export const antigravity = {
     scope: tokens.scope,
     email: extra?.userInfo?.email,
     projectId: extra?.projectId,
+    providerSpecificData: {
+      projectId: extra?.projectId,
+      tier: extra?.tierId,
+    },
   }),
 };

--- a/src/lib/oauth/services/antigravity.ts
+++ b/src/lib/oauth/services/antigravity.ts
@@ -6,6 +6,7 @@ import {
   getAntigravityHeaders,
   getAntigravityLoadCodeAssistMetadata,
 } from "@omniroute/open-sse/services/antigravityHeaders.ts";
+import { extractCodeAssistOnboardTierId } from "@omniroute/open-sse/services/codeAssistSubscription.ts";
 import { getServerCredentials } from "../config/index";
 import { startLocalServer } from "../utils/server";
 import { spinner as createSpinner } from "../utils/ui";
@@ -145,16 +146,7 @@ export class AntigravityService {
       projectId = projectId.id;
     }
 
-    // Extract tier ID (default to legacy-tier)
-    let tierId = "legacy-tier";
-    if (Array.isArray(data.allowedTiers)) {
-      for (const tier of data.allowedTiers) {
-        if (tier.isDefault && tier.id) {
-          tierId = tier.id.trim();
-          break;
-        }
-      }
-    }
+    const tierId = extractCodeAssistOnboardTierId(data);
 
     return { projectId, tierId, raw: data };
   }

--- a/src/lib/usage/providerLimits.ts
+++ b/src/lib/usage/providerLimits.ts
@@ -18,6 +18,10 @@ import { getMachineId } from "@/shared/utils/machine";
 import { USAGE_SUPPORTED_PROVIDERS } from "@/shared/constants/providers";
 import { getExecutor } from "@omniroute/open-sse/executors/index.ts";
 import { getUsageForProvider } from "@omniroute/open-sse/services/usage.ts";
+import {
+  extractCodeAssistOnboardTierId,
+  extractCodeAssistSubscriptionTier,
+} from "@omniroute/open-sse/services/codeAssistSubscription.ts";
 import { runWithProxyContext } from "@omniroute/open-sse/utils/proxyFetch.ts";
 
 type JsonRecord = Record<string, unknown>;
@@ -220,6 +224,44 @@ async function syncClaudeExtraUsageStateIfNeeded(
   };
 }
 
+/** Persist Antigravity tier from live loadCodeAssist on quota refresh (not only OAuth). */
+async function syncAntigravitySubscriptionIfNeeded(
+  connection: ProviderConnectionLike,
+  usage: JsonRecord
+): Promise<ProviderConnectionLike> {
+  if (connection.provider !== "antigravity") return connection;
+
+  const subscriptionInfo = usage.subscriptionInfo;
+  if (!subscriptionInfo) return connection;
+
+  const psd = (connection.providerSpecificData || {}) as JsonRecord;
+  const nextPsd: JsonRecord = { ...psd };
+  let changed = false;
+
+  const tierId = extractCodeAssistOnboardTierId(subscriptionInfo);
+  if (tierId && tierId !== "legacy-tier" && psd.tier !== tierId) {
+    nextPsd.tier = tierId;
+    changed = true;
+  }
+
+  const subscriptionTier = extractCodeAssistSubscriptionTier(subscriptionInfo);
+  if (subscriptionTier && psd.subscriptionTier !== subscriptionTier) {
+    nextPsd.subscriptionTier = subscriptionTier;
+    changed = true;
+  }
+
+  const plan = typeof usage.plan === "string" ? usage.plan.trim() : "";
+  if (plan && psd.plan !== plan) {
+    nextPsd.plan = plan;
+    changed = true;
+  }
+
+  if (!changed) return connection;
+
+  await updateProviderConnection(connection.id, { providerSpecificData: nextPsd });
+  return { ...connection, providerSpecificData: nextPsd };
+}
+
 /** Persist refreshed Claude bootstrap fields into psd; writes only on diff. */
 async function syncClaudeBootstrapIfNeeded(
   connection: ProviderConnectionLike,
@@ -317,6 +359,7 @@ async function fetchLiveProviderLimitsWithOptions(
     await syncExpiredStatusIfNeeded(connection, usage);
     connection = await syncClaudeExtraUsageStateIfNeeded(connection, usage);
     connection = await syncClaudeBootstrapIfNeeded(connection, usage);
+    connection = await syncAntigravitySubscriptionIfNeeded(connection, usage);
     return { connection, usage };
   }
 
@@ -377,6 +420,7 @@ async function fetchLiveProviderLimitsWithOptions(
   await syncExpiredStatusIfNeeded(connection, result.usage);
   connection = await syncClaudeExtraUsageStateIfNeeded(connection, result.usage);
   connection = await syncClaudeBootstrapIfNeeded(connection, result.usage);
+  connection = await syncAntigravitySubscriptionIfNeeded(connection, result.usage);
 
   return {
     connection,

--- a/tests/unit/antigravity-headers.test.ts
+++ b/tests/unit/antigravity-headers.test.ts
@@ -1,0 +1,9 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { getAntigravityLoadCodeAssistMetadata } from "../../open-sse/services/antigravityHeaders.ts";
+
+test("loadCodeAssist metadata matches Antigravity Manager (ideType only)", () => {
+  assert.deepEqual(getAntigravityLoadCodeAssistMetadata(), { ideType: "ANTIGRAVITY" });
+  assert.equal("platform" in getAntigravityLoadCodeAssistMetadata(), false);
+  assert.equal("pluginType" in getAntigravityLoadCodeAssistMetadata(), false);
+});

--- a/tests/unit/code-assist-subscription.test.ts
+++ b/tests/unit/code-assist-subscription.test.ts
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  extractCodeAssistOnboardTierId,
+  extractCodeAssistSubscriptionTier,
+} from "../../open-sse/services/codeAssistSubscription.ts";
+
+test("extractCodeAssistSubscriptionTier prefers paidTier over currentTier", () => {
+  assert.equal(
+    extractCodeAssistSubscriptionTier({
+      paidTier: { id: "tier_google_one_ai_pro", name: "Google One AI Premium" },
+      currentTier: { id: "free-tier", name: "Free" },
+    }),
+    "Google One AI Premium"
+  );
+});
+
+test("extractCodeAssistSubscriptionTier uses currentTier when not ineligible", () => {
+  assert.equal(
+    extractCodeAssistSubscriptionTier({
+      currentTier: { id: "tier_pro", name: "Pro" },
+      allowedTiers: [{ id: "free-tier", isDefault: true }],
+    }),
+    "Pro"
+  );
+});
+
+test("extractCodeAssistSubscriptionTier uses restricted default when ineligible", () => {
+  assert.equal(
+    extractCodeAssistSubscriptionTier({
+      ineligibleTiers: [{ reasonCode: "POLICY" }],
+      currentTier: { id: "tier_ultra", name: "Ultra" },
+      allowedTiers: [{ id: "tier_pro", name: "Pro", isDefault: true }],
+    }),
+    "Pro (Restricted)"
+  );
+});
+
+test("extractCodeAssistOnboardTierId prefers paidTier id for onboarding", () => {
+  assert.equal(
+    extractCodeAssistOnboardTierId({
+      paidTier: { id: "tier_google_one_ai_pro" },
+      currentTier: { id: "free-tier" },
+    }),
+    "tier_google_one_ai_pro"
+  );
+});
+
+test("extractCodeAssistOnboardTierId skips currentTier when ineligible", () => {
+  assert.equal(
+    extractCodeAssistOnboardTierId({
+      ineligibleTiers: [{}],
+      currentTier: { id: "tier_ultra" },
+      allowedTiers: [{ id: "tier_pro", isDefault: true }],
+    }),
+    "tier_pro"
+  );
+});
+
+test("extractCodeAssistOnboardTierId falls back to legacy-tier", () => {
+  assert.equal(extractCodeAssistOnboardTierId({}), "legacy-tier");
+});

--- a/tests/unit/usage-service-hardening.test.ts
+++ b/tests/unit/usage-service-hardening.test.ts
@@ -1299,6 +1299,13 @@ test("usage helper branches cover Gemini CLI and Antigravity plan label fallback
     }),
     "Custom sky"
   );
+  assert.equal(
+    __testing.getAntigravityPlanLabel(
+      { currentTier: { name: "TIER_UNKNOWN_CUSTOM" } },
+      { allowedTiers: [{ id: "tier_pro", isDefault: true }] }
+    ),
+    "Pro"
+  );
 });
 
 test("usage service covers NanoGPT PRO weekly token quota, FREE plan, auth denial and fetch failures", async () => {

--- a/tests/unit/usage-service-hardening.test.ts
+++ b/tests/unit/usage-service-hardening.test.ts
@@ -414,10 +414,12 @@ test("usage service manual Antigravity refresh bypasses usage TTL caches", async
   process.env.ANTIGRAVITY_CREDITS = "retry";
   let probeCalls = 0;
   let modelCalls = 0;
+  let loadCodeAssistCalls = 0;
 
   globalThis.fetch = async (url) => {
     const urlStr = String(url);
     if (urlStr.includes("loadCodeAssist")) {
+      loadCodeAssistCalls++;
       return new Response(JSON.stringify({ cloudaicompanionProject: "ag-project" }), {
         status: 200,
       });
@@ -460,6 +462,7 @@ test("usage service manual Antigravity refresh bypasses usage TTL caches", async
 
   assert.equal(probeCalls, 2);
   assert.equal(modelCalls, 2);
+  assert.equal(loadCodeAssistCalls, 2);
 });
 
 test("usage service handles missing Antigravity access tokens without probing upstream", async () => {
@@ -1258,6 +1261,20 @@ test("usage helper branches cover Gemini CLI and Antigravity plan label fallback
   );
 
   assert.equal(__testing.getAntigravityPlanLabel(null), "Free");
+  assert.equal(
+    __testing.getAntigravityPlanLabel({
+      paidTier: { name: "Google One AI Premium" },
+      currentTier: { id: "free-tier" },
+    }),
+    "Pro"
+  );
+  assert.equal(
+    __testing.getAntigravityPlanLabel({
+      currentTier: { id: "tier_google_one_ai_pro" },
+      allowedTiers: [{ id: "free-tier", isDefault: true }],
+    }),
+    "Pro"
+  );
   assert.equal(
     __testing.getAntigravityPlanLabel({
       allowedTiers: [{ id: "tier_pro", isDefault: true }],


### PR DESCRIPTION
## Summary

- Add shared `loadCodeAssist` tier extraction (`paidTier` → `currentTier` → restricted `allowedTiers` default), matching Antigravity Manager.
- Fix `loadCodeAssist` metadata on Linux/Docker: send only `{ ideType: "ANTIGRAVITY" }` (Google rejects `platform: "LINUX"`).
- Bust subscription cache on manual quota refresh and persist `tier` / `subscriptionTier` / `plan` back to connections.
- Prefer live usage plan over stale persisted tier in Provider Limits UI.

## Test plan

- [x] `tests/unit/code-assist-subscription.test.ts`
- [x] `tests/unit/antigravity-headers.test.ts`
- [x] `tests/unit/oauth-providers-config.test.ts` (Antigravity OAuth)
- [x] `tests/unit/usage-service-hardening.test.ts` (Antigravity plan labels + refresh cache)
- [ ] Manual: connect Antigravity Pro account on Linux Docker, refresh quotas → plan shows **Pro** without re-auth