### PR TITLE
Add Hermes Agent support to OmniRoute

### DIFF
--- a/src/app/api/cli-tools/guide-settings/[toolId]/route.ts
+++ b/src/app/api/cli-tools/guide-settings/[toolId]/route.ts
@@ -2,9 +2,10 @@ import { NextResponse } from "next/server";
 import fs from "fs/promises";
 import path from "path";
 import os from "os";
+import * as yaml from "js-yaml";
 import { requireCliToolsAuth } from "@/lib/api/requireCliToolsAuth";
 import { getRuntimePorts } from "@/lib/runtime/ports";
-import { getOpenCodeConfigPath } from "@/shared/services/cliRuntime";
+import { getCliPrimaryConfigPath, getOpenCodeConfigPath } from "@/shared/services/cliRuntime";
 import { mergeOpenCodeConfigText } from "@/shared/services/opencodeConfig";
 import { guideSettingsSaveSchema } from "@/shared/validation/schemas";
 import { isValidationFailure, validateBody } from "@/shared/validation/helpers";
@@ -58,6 +59,8 @@ export async function POST(request, { params }) {
         return await saveOpenCodeConfig({ baseUrl, apiKey, model, models, modelLabels });
       case "qwen":
         return await saveQwenConfig({ baseUrl, apiKey, model });
+      case "hermes":
+        return await saveHermesConfig({ baseUrl, apiKey, model });
       default:
         return NextResponse.json(
           { error: `Direct config save not supported for: ${toolId}` },
@@ -238,6 +241,62 @@ async function saveQwenConfig({ baseUrl, apiKey, model }) {
   return NextResponse.json({
     success: true,
     message: `Qwen Code config saved to ${configPath}`,
+    configPath,
+  });
+}
+
+/**
+ * Save Hermes config to ~/.hermes/config.yaml
+ *
+ * Hermes stores its primary routing settings in YAML. Preserve any existing
+ * keys, but make sure the OmniRoute provider entry is present and selected.
+ */
+async function saveHermesConfig({ baseUrl, apiKey, model }) {
+  const configPath = getCliPrimaryConfigPath("hermes") || path.join(os.homedir(), ".hermes", "config.yaml");
+  const configDir = path.dirname(configPath);
+
+  await fs.mkdir(configDir, { recursive: true });
+
+  const normalizedBaseUrl = String(baseUrl || "")
+    .trim()
+    .replace(/\/+$/, "");
+  const providerBaseUrl = normalizedBaseUrl.endsWith("/v1") ? normalizedBaseUrl : `${normalizedBaseUrl}/v1`;
+  const selectedModel = model || "gpt-5.4-mini";
+
+  let existingConfig: Record<string, any> = {};
+  try {
+    const raw = await fs.readFile(configPath, "utf-8");
+    const parsed = yaml.load(raw);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      existingConfig = parsed as Record<string, any>;
+    }
+  } catch {
+    // No existing config or unparsable YAML — start fresh.
+  }
+
+  const nextConfig = {
+    ...existingConfig,
+    model: {
+      ...(existingConfig.model || {}),
+      default: selectedModel,
+      provider: "omniroute",
+      base_url: providerBaseUrl,
+    },
+    providers: {
+      ...(existingConfig.providers || {}),
+      omniroute: {
+        ...((existingConfig.providers && existingConfig.providers.omniroute) || {}),
+        base_url: providerBaseUrl,
+        api_key: apiKey || ((existingConfig.providers && existingConfig.providers.omniroute && existingConfig.providers.omniroute.api_key) || ""),
+      },
+    },
+  };
+
+  await fs.writeFile(configPath, yaml.dump(nextConfig, { lineWidth: -1 }), "utf-8");
+
+  return NextResponse.json({
+    success: true,
+    message: `Hermes config saved to ${configPath}`,
     configPath,
   });
 }

--- a/src/app/api/cli-tools/status/route.ts
+++ b/src/app/api/cli-tools/status/route.ts
@@ -47,6 +47,15 @@ async function checkToolConfigStatus(toolId: string): Promise<string> {
       return "configured";
     }
 
+    if (toolId === "hermes") {
+      const lower = content.toLowerCase();
+      const hasOmniRoute =
+        lower.includes("omniroute") ||
+        lower.includes(`localhost:${apiPort}`) ||
+        lower.includes(`127.0.0.1:${apiPort}`);
+      return hasOmniRoute ? "configured" : "not_configured";
+    }
+
     const config = JSON.parse(content);
 
     // Each tool stores OmniRoute config differently
@@ -142,7 +151,7 @@ export async function GET(request: Request) {
     );
 
     // Check config status for installed+runnable tools via direct file reads
-    const settingsTools = ["claude", "codex", "droid", "openclaw", "cline", "kilo", "qwen"];
+    const settingsTools = ["claude", "codex", "droid", "openclaw", "cline", "kilo", "qwen", "hermes"];
 
     await Promise.all(
       settingsTools.map(async (toolId) => {

--- a/src/lib/cli-helper/config-generator/hermes.ts
+++ b/src/lib/cli-helper/config-generator/hermes.ts
@@ -1,0 +1,44 @@
+import path from "node:path";
+import os from "node:os";
+
+let yaml: typeof import("js-yaml") | null = null;
+async function loadYaml() {
+  if (!yaml) {
+    yaml = await import("js-yaml");
+  }
+  return yaml;
+}
+
+const CONFIG_PATH = path.join(os.homedir(), ".hermes", "config.yaml");
+
+export async function generateHermesConfig(options: {
+  baseUrl: string;
+  apiKey: string;
+  model?: string;
+}): Promise<string> {
+  const y = await loadYaml();
+
+  let base = options.baseUrl;
+  let end = base.length;
+  while (end > 0 && base[end - 1] === "/") end--;
+  base = end < base.length ? base.slice(0, end) : base;
+  if (base.endsWith("/v1")) base = base.slice(0, -3);
+
+  const model = options.model || "gpt-5.4-mini";
+
+  const config = {
+    model: {
+      default: model,
+      provider: "omniroute",
+      base_url: `${base}/v1`,
+    },
+    providers: {
+      omniroute: {
+        base_url: `${base}/v1`,
+        api_key: options.apiKey,
+      },
+    },
+  };
+
+  return y.dump(config, { lineWidth: -1 });
+}

--- a/src/lib/cli-helper/config-generator/index.ts
+++ b/src/lib/cli-helper/config-generator/index.ts
@@ -5,6 +5,7 @@ import { generateClaudeConfig } from "./claude";
 import { generateClineConfig } from "./cline";
 import { generateCodexConfig } from "./codex";
 import { generateContinueConfig } from "./continue";
+import { generateHermesConfig } from "./hermes";
 import { generateKilocodeConfig } from "./kilocode";
 import { generateOpencodeConfig } from "./opencode";
 
@@ -21,7 +22,7 @@ export interface GenerateResult {
   error?: string;
 }
 
-function validateBaseUrl(url: string): boolean {
+export function validateBaseUrl(url: string): boolean {
   try {
     const u = new URL(url);
     return u.protocol === "http:" || u.protocol === "https:";
@@ -42,7 +43,10 @@ const TOOL_CONFIG_PATHS: Record<string, string> = {
   cline: path.join(os.homedir(), ".cline", "data", "globalState.json"),
   kilocode: path.join(os.homedir(), ".config", "kilocode", "settings.json"),
   continue: path.join(os.homedir(), ".continue", "config.yaml"),
+  hermes: path.join(os.homedir(), ".hermes", "config.yaml"),
 };
+
+
 
 type ConfigGenerator = (options: GenerateOptions) => string | Promise<string>;
 
@@ -53,6 +57,7 @@ const GENERATORS: Record<string, ConfigGenerator> = {
   cline: generateClineConfig,
   kilocode: generateKilocodeConfig,
   continue: generateContinueConfig,
+  hermes: generateHermesConfig,
 };
 
 export async function generateConfig(
@@ -86,7 +91,7 @@ export async function generateConfig(
 }
 
 export async function generateAllConfigs(options: GenerateOptions): Promise<GenerateResult[]> {
-  const toolIds = ["claude", "codex", "opencode", "cline", "kilocode", "continue"] as const;
+  const toolIds = ["claude", "codex", "opencode", "cline", "kilocode", "continue", "hermes"] as const;
   const results = await Promise.allSettled(toolIds.map((id) => generateConfig(id, options)));
 
   return results.map((r) =>

--- a/src/lib/cli-helper/tool-detector.ts
+++ b/src/lib/cli-helper/tool-detector.ts
@@ -4,6 +4,11 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
+let execFileImpl = execFileAsync;
+
+export function __setExecFileImpl(fn: typeof execFileAsync): void {
+  execFileImpl = fn;
+}
 
 export interface DetectedTool {
   id: string;
@@ -22,6 +27,7 @@ const TOOLS = [
   { id: "cline", name: "Cline", configPath: "~/.cline/data/globalState.json" },
   { id: "kilocode", name: "Kilo Code", configPath: "~/.config/kilocode/settings.json" },
   { id: "continue", name: "Continue", configPath: "~/.continue/config.yaml" },
+  { id: "hermes", name: "Hermes", configPath: "~/.hermes/config.yaml" },
 ] as const;
 
 const BINARY_NAMES: Record<string, string> = {
@@ -31,6 +37,7 @@ const BINARY_NAMES: Record<string, string> = {
   cline: "cline",
   kilocode: "kilocode",
   continue: "continue",
+  hermes: "hermes",
 };
 
 function expandHome(p: string): string {
@@ -50,7 +57,7 @@ function isConfigured(content: string, baseUrl: string): boolean {
 async function detectBinary(name: string): Promise<{ installed: boolean; version?: string }> {
   const binary = BINARY_NAMES[name] || name;
   try {
-    const { stdout } = await execFileAsync(binary, ["--version"], { timeout: 5000 });
+    const { stdout } = await execFileImpl(binary, ["--version"], { timeout: 5000 });
     const version = stdout.trim().replace(/^v/, "");
     return { installed: true, version };
   } catch {

--- a/src/shared/services/cliRuntime.ts
+++ b/src/shared/services/cliRuntime.ts
@@ -133,10 +133,10 @@ const CLI_TOOLS: Record<string, any> = {
   hermes: {
     defaultCommand: "hermes",
     envBinKey: "CLI_HERMES_BIN",
-    requiresBinary: false,
+    requiresBinary: true,
     healthcheckTimeoutMs: 4000,
     paths: {
-      config: ".config/hermes/config.json",
+      config: ".hermes/config.yaml",
     },
   },
   amp: {

--- a/tests/unit/cli-helper/config-generator.test.ts
+++ b/tests/unit/cli-helper/config-generator.test.ts
@@ -50,6 +50,18 @@ describe("config-generator", () => {
       assert.ok("configPath" in result);
     });
 
+    it("returns success for valid hermes config", async () => {
+      const result = await generator.generateConfig("hermes", {
+        baseUrl: "http://localhost:20128",
+        apiKey: "sk-test",
+        model: "gpt-5.4-mini",
+      });
+      assert.strictEqual(result.success, true);
+      assert.ok(result.configPath.endsWith(".hermes/config.yaml"));
+      assert.ok(String(result.content || "").includes("providers:"));
+      assert.ok(String(result.content || "").includes("omniroute"));
+    });
+
     it("returns error for unknown tool", async () => {
       const result = await generator.generateConfig("unknown-tool-xyz", {
         baseUrl: "http://localhost:20128",
@@ -67,7 +79,7 @@ describe("config-generator", () => {
         apiKey: "sk-xxx",
       });
       assert.ok(Array.isArray(results));
-      assert.strictEqual(results.length, 6); // claude, codex, opencode, cline, kilocode, continue
+      assert.strictEqual(results.length, 7); // claude, codex, opencode, cline, kilocode, continue, hermes
     });
   });
 });

--- a/tests/unit/cli-helper/tool-detector.test.ts
+++ b/tests/unit/cli-helper/tool-detector.test.ts
@@ -10,6 +10,9 @@ describe("tool-detector", () => {
       if (cmd === "opencode") {
         return { stdout: "v1.0.0\n" };
       }
+      if (cmd === "hermes") {
+        return { stdout: "v0.75.3\n" };
+      }
       if (cmd === "which") {
         return { stdout: "/usr/local/bin/opencode\n" };
       }
@@ -33,6 +36,18 @@ describe("tool-detector", () => {
       assert.ok(result!.configPath.includes(".config/opencode"));
       assert.strictEqual(typeof result!.configured, "boolean");
     });
+
+    it("returns DetectedTool object for Hermes with the Hermes config path", async () => {
+      const result = await toolDetector.detectTool("hermes");
+      assert.ok(result !== null);
+      assert.strictEqual(result!.id, "hermes");
+      assert.strictEqual(result!.name, "Hermes");
+      assert.strictEqual(result!.installed, true);
+      assert.strictEqual(result!.version, "0.75.3");
+      assert.ok(result!.configPath.includes(".hermes/config.yaml"));
+      assert.strictEqual(typeof result!.configured, "boolean");
+    });
+
   });
 
   describe("detectAllTools", () => {

--- a/tests/unit/guide-settings-route.test.ts
+++ b/tests/unit/guide-settings-route.test.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { SignJWT } from "jose";
 import { parse } from "jsonc-parser";
+import * as yaml from "js-yaml";
 const guideSettingsRoute =
   await import("../../src/app/api/cli-tools/guide-settings/[toolId]/route.ts");
 
@@ -12,6 +13,7 @@ const DUMMY_HOME = path.join(os.tmpdir(), "omniroute-qwen-test-" + Date.now());
 const QWEN_CONFIG_PATH = path.join(DUMMY_HOME, ".qwen", "settings.json");
 const QWEN_ENV_PATH = path.join(DUMMY_HOME, ".qwen", ".env");
 const OPENCODE_CONFIG_PATH = path.join(DUMMY_HOME, ".config", "opencode", "opencode.json");
+const HERMES_CONFIG_PATH = path.join(DUMMY_HOME, ".hermes", "config.yaml");
 const originalXDG = process.env.XDG_CONFIG_HOME;
 const originalAppData = process.env.APPDATA;
 const originalJwtSecret = process.env.JWT_SECRET;
@@ -86,6 +88,27 @@ test("guide-settings POST creates new qwen settings.json if it doesn't exist", a
   assert.equal(content.security?.auth?.baseUrl, "http://my-omni");
   assert.equal(content.model?.name, "gemini-cli/gemini-3.1-pro-preview");
 });
+
+test("guide-settings POST creates new hermes config.yaml if it doesn't exist", async () => {
+  const req = await buildRequest({
+    baseUrl: "http://my-omni",
+    apiKey: "sk-hermes",
+    model: "gpt-5.4-mini",
+  });
+  const response = (await guideSettingsRoute.POST(req, { params: { toolId: "hermes" } })) as Response;
+  const data = (await response.json()) as any;
+
+  assert.equal(response.status, 200, "Response should be OK");
+  assert.equal(data.success, true);
+
+  const content = yaml.load(await fs.readFile(HERMES_CONFIG_PATH, "utf-8")) as any;
+  assert.equal(content.model?.default, "gpt-5.4-mini");
+  assert.equal(content.model?.provider, "omniroute");
+  assert.equal(content.model?.base_url, "http://my-omni/v1");
+  assert.equal(content.providers?.omniroute?.base_url, "http://my-omni/v1");
+  assert.ok(String(content.providers?.omniroute?.api_key || "").startsWith("sk-"));
+});
+
 
 test("guide-settings POST merges into existing qwen settings.json", async () => {
   await fs.mkdir(path.dirname(QWEN_CONFIG_PATH), { recursive: true });


### PR DESCRIPTION
## What
- Register Hermes as a first-class CLI tool in the runtime registry and config generator.
- Point Hermes at the correct local config path: `~/.hermes/config.yaml`.
- Teach the tool detector and CLI status checks to recognize Hermes configs instead of treating it as unknown.
- Add guide-settings support so the dashboard can write Hermes YAML config directly.

## Why
Hermes was already installed and working on this machine, but OmniRoute was blind to it because the helper layer was stale:
- detector allowlist did not include Hermes
- Hermes config path was wrong in the runtime map
- guide/status flows did not know how to save/read Hermes config

## Validation
- `DISABLE_SQLITE_AUTO_BACKUP=true node --import tsx --test tests/unit/cli-helper/config-generator.test.ts tests/unit/cli-helper/tool-detector.test.ts tests/unit/guide-settings-route.test.ts tests/unit/cli-tools.test.ts`

## Related
Fixes #2509