### PR TITLE
fix(dark-mode): correct background on Compression Override select in Combos page

### DIFF
--- a/src/app/(dashboard)/dashboard/combos/page.tsx
+++ b/src/app/(dashboard)/dashboard/combos/page.tsx
@@ -1737,15 +1737,15 @@ function ComboCard({
                 value={compressionOverride}
                 onChange={(e) => handleCompressionOverrideChange(e.target.value)}
                 disabled={isSavingCompression}
-                className="text-xs py-1 px-2 rounded border border-black/10 dark:border-white/10 bg-white dark:bg-bg-main text-text-main focus:border-primary focus:outline-none transition-colors disabled:opacity-50 max-w-[130px] md:max-w-none"
+                className="text-xs py-1 px-2 rounded border border-black/10 dark:border-white/10 bg-surface text-text-main focus:border-primary focus:outline-none transition-colors disabled:opacity-50 max-w-[130px] md:max-w-none"
                 title={t("compressionOverride")}
               >
-                <option value="">Default</option>
-                <option value="off">Off</option>
-                <option value="lite">Lite</option>
-                <option value="standard">Standard</option>
-                <option value="aggressive">Aggressive</option>
-                <option value="ultra">Ultra</option>
+                <option value="" className="bg-surface text-text-main">Default</option>
+                <option value="off" className="bg-surface text-text-main">Off</option>
+                <option value="lite" className="bg-surface text-text-main">Lite</option>
+                <option value="standard" className="bg-surface text-text-main">Standard</option>
+                <option value="aggressive" className="bg-surface text-text-main">Aggressive</option>
+                <option value="ultra" className="bg-surface text-text-main">Ultra</option>
               </select>
             )}
             <button


### PR DESCRIPTION
## Summary

Fixes the dark mode regression where the **Compression Override** dropdown on the Combos page showed a white background / native light dropdown in dark mode.

## Root Cause

The inline `<select>` used:

```tsx
bg-white dark:bg-bg-main
```

- `bg-white` was unconditional
- `bg-bg-main` is not a defined theme token (`globals.css` only provides `bg-surface`, `bg-bg`, `bg-bg-subtle`, `bg-card`, etc.)

This was the only `<select>` in the app that didn't follow the established `bg-surface` pattern used everywhere else (including the shared `Select` component and all other compression-related selects).

## Changes

- Changed the select to `bg-surface`
- Added `className="bg-surface text-text-main"` to all `<option>` elements for consistent popup item rendering
- Matches the styling approach used in `src/shared/components/Select.tsx`

## Testing

- Verified in both light and dark mode on the Combos page (`/dashboard/combos`)
- The dropdown now uses the correct surface color and respects `color-scheme: dark`

## Related

Fixes #2511

---

Ready for review. Happy to iterate if you'd like the control migrated to the shared `<Select>` component instead of the current compact inline version.
