### PR TITLE
feat: cloud agents UX, skills fixes, memory stats, docs packaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
     "scripts/dev/sync-env.mjs",
     "scripts/build/native-binary-compat.mjs",
     "scripts/build/build-next-isolated.mjs",
+    "docs/",
+    "!docs/i18n/",
+    "!docs/diagrams/",
     "README.md",
     "LICENSE"
   ],

--- a/src/app/(dashboard)/dashboard/cloud-agents/page.tsx
+++ b/src/app/(dashboard)/dashboard/cloud-agents/page.tsx
@@ -4,6 +4,8 @@ import { useState, useEffect, useCallback } from "react";
 import { Card, Button, Input, Badge } from "@/shared/components";
 import { useTranslations } from "next-intl";
 
+// ── Types ────────────────────────────────────────────────────────────────────
+
 interface CloudAgentTask {
   id: string;
   providerId: string;
@@ -26,34 +28,75 @@ interface CloudAgentTask {
   }>;
 }
 
+type TabId = "tasks" | "agents" | "settings";
+type TaskStatus = CloudAgentTask["status"];
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
 const CLOUD_AGENTS = [
   {
     id: "jules",
     name: "Jules",
     provider: "Google",
     description: "Google's autonomous coding agent",
-    icon: "🟡",
-    color: "bg-yellow-500/10 text-yellow-600",
+    icon: "smart_toy",
+    iconBg: "bg-yellow-500/10",
+    iconColor: "text-yellow-600",
   },
   {
     id: "devin",
     name: "Devin",
     provider: "Cognition",
     description: "Cognition's AI software engineer",
-    icon: "🔵",
-    color: "bg-blue-500/10 text-blue-600",
+    icon: "psychology",
+    iconBg: "bg-blue-500/10",
+    iconColor: "text-blue-600",
   },
   {
     id: "codex-cloud",
     name: "Codex Cloud",
     provider: "OpenAI",
     description: "OpenAI's cloud-based coding agent",
-    icon: "⚡",
-    color: "bg-emerald-500/10 text-emerald-600",
+    icon: "cloud",
+    iconBg: "bg-emerald-500/10",
+    iconColor: "text-emerald-600",
   },
 ];
 
+const STATUS_OPTIONS: { value: TaskStatus | "all"; labelKey: string }[] = [
+  { value: "all", labelKey: "filterAll" },
+  { value: "queued", labelKey: "statusPending" },
+  { value: "running", labelKey: "statusRunning" },
+  { value: "awaiting_approval", labelKey: "statusWaitingApproval" },
+  { value: "completed", labelKey: "statusCompleted" },
+  { value: "failed", labelKey: "statusFailed" },
+  { value: "cancelled", labelKey: "statusCancelled" },
+];
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function getAgentInfo(providerId: string) {
+  return CLOUD_AGENTS.find((a) => a.id === providerId) || CLOUD_AGENTS[0];
+}
+
+function formatDuration(start: string, end: string) {
+  const ms = new Date(end).getTime() - new Date(start).getTime();
+  if (ms < 1000) return `${ms}ms`;
+  const secs = Math.floor(ms / 1000);
+  if (secs < 60) return `${secs}s`;
+  const mins = Math.floor(secs / 60);
+  const remainSecs = secs % 60;
+  return `${mins}m ${remainSecs}s`;
+}
+
+// ── Component ────────────────────────────────────────────────────────────────
+
 export default function CloudAgentsPage() {
+  const [activeTab, setActiveTab] = useState<TabId>("tasks");
+  const t = useTranslations("cloudAgents");
+
+  // ── Tasks state ──────────────────────────────────────────────────────────
+
   const [tasks, setTasks] = useState<CloudAgentTask[]>([]);
   const [loading, setLoading] = useState(true);
   const [creating, setCreating] = useState(false);
@@ -67,14 +110,48 @@ export default function CloudAgentsPage() {
     autoCreatePr: true,
   });
   const [messageInput, setMessageInput] = useState("");
-  const t = useTranslations("cloudAgents");
+  const [statusFilter, setStatusFilter] = useState<TaskStatus | "all">("all");
+  const [providerFilter, setProviderFilter] = useState<string>("all");
+
+  // ── Agents health state ──────────────────────────────────────────────────
+
+  const [agentHealth, setAgentHealth] = useState<Record<string, boolean>>({});
+
+  // ── Settings state (localStorage) ────────────────────────────────────────
+
+  const [settings, setSettings] = useState({
+    autoCreatePr: true,
+    requireApproval: false,
+    enabled: true,
+  });
+
+  // ── Load settings from localStorage ──────────────────────────────────────
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem("omniroute-cloud-agents-settings");
+      if (stored) setSettings(JSON.parse(stored));
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  const updateSetting = (key: keyof typeof settings, value: boolean) => {
+    const next = { ...settings, [key]: value };
+    setSettings(next);
+    try {
+      localStorage.setItem("omniroute-cloud-agents-settings", JSON.stringify(next));
+    } catch {
+      // ignore
+    }
+  };
+
+  // ── Task helpers ─────────────────────────────────────────────────────────
 
   const upsertTask = useCallback((task: CloudAgentTask) => {
     setTasks((prev) => {
-      const exists = prev.some((current) => current.id === task.id);
-      return exists
-        ? prev.map((current) => (current.id === task.id ? task : current))
-        : [task, ...prev];
+      const exists = prev.some((c) => c.id === task.id);
+      return exists ? prev.map((c) => (c.id === task.id ? task : c)) : [task, ...prev];
     });
     setSelectedTask((current) => (current?.id === task.id ? task : current));
   }, []);
@@ -97,6 +174,48 @@ export default function CloudAgentsPage() {
     fetchTasks();
   }, [fetchTasks]);
 
+  // ── Auto-poll when tasks are running/queued ──────────────────────────────
+
+  const hasActiveTasks = tasks.some((t) => t.status === "running" || t.status === "queued");
+
+  useEffect(() => {
+    if (!hasActiveTasks) return;
+    const id = setInterval(() => {
+      fetchTasks();
+    }, 5000);
+    return () => clearInterval(id);
+  }, [hasActiveTasks, fetchTasks]);
+
+  // ── Fetch agent health ───────────────────────────────────────────────────
+
+  const fetchAgentHealth = useCallback(async () => {
+    try {
+      const res = await fetch("/api/v1/agents/health");
+      if (res.ok) {
+        const data = await res.json();
+        if (data.data) setAgentHealth(data.data);
+      }
+    } catch (err) {
+      console.error("Failed to fetch agent health:", err);
+    }
+  }, []);
+
+  // ── Tab mount effects ────────────────────────────────────────────────────
+
+  useEffect(() => {
+    if (activeTab === "agents") fetchAgentHealth();
+  }, [activeTab, fetchAgentHealth]);
+
+  // ── Filtered tasks ───────────────────────────────────────────────────────
+
+  const filteredTasks = tasks.filter((task) => {
+    if (statusFilter !== "all" && task.status !== statusFilter) return false;
+    if (providerFilter !== "all" && task.providerId !== providerFilter) return false;
+    return true;
+  });
+
+  // ── Task actions (preserved from original) ───────────────────────────────
+
   const handleCreateTask = async (e: React.FormEvent) => {
     e.preventDefault();
     setCreating(true);
@@ -113,9 +232,7 @@ export default function CloudAgentsPage() {
           providerId: newTask.providerId,
           prompt: newTask.prompt,
           source,
-          options: {
-            autoCreatePr: newTask.autoCreatePr,
-          },
+          options: { autoCreatePr: newTask.autoCreatePr },
         }),
       });
       if (res.ok) {
@@ -143,10 +260,7 @@ export default function CloudAgentsPage() {
       const res = await fetch(`/api/v1/agents/tasks/${selectedTask.id}`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          action: "message",
-          message: messageInput,
-        }),
+        body: JSON.stringify({ action: "message", message: messageInput }),
       });
       if (res.ok) {
         const data = await res.json();
@@ -198,44 +312,37 @@ export default function CloudAgentsPage() {
       });
       if (res.ok) {
         setTasks((prev) => prev.filter((t) => t.id !== taskId));
-        if (selectedTask?.id === taskId) {
-          setSelectedTask(null);
-        }
+        if (selectedTask?.id === taskId) setSelectedTask(null);
       }
     } catch (err) {
       console.error("Failed to delete task:", err);
     }
   };
 
+  // ── Render helpers ───────────────────────────────────────────────────────
+
   const getStatusBadge = (status: string) => {
-    const statusMap: Record<string, { color: string; label: string }> = {
-      queued: { color: "bg-zinc-500/10 text-zinc-500", label: t("statusPending") },
-      running: { color: "bg-blue-500/10 text-blue-500", label: t("statusRunning") },
-      awaiting_approval: {
-        color: "bg-amber-500/10 text-amber-600",
-        label: t("statusWaitingApproval"),
-      },
-      completed: { color: "bg-emerald-500/10 text-emerald-600", label: t("statusCompleted") },
-      failed: { color: "bg-red-500/10 text-red-500", label: t("statusFailed") },
-      cancelled: { color: "bg-zinc-500/10 text-zinc-400", label: t("statusCancelled") },
+    const statusMap: Record<
+      string,
+      { variant: "default" | "primary" | "success" | "warning" | "error" | "info"; label: string }
+    > = {
+      queued: { variant: "default", label: t("statusPending") },
+      running: { variant: "info", label: t("statusRunning") },
+      awaiting_approval: { variant: "warning", label: t("statusWaitingApproval") },
+      completed: { variant: "success", label: t("statusCompleted") },
+      failed: { variant: "error", label: t("statusFailed") },
+      cancelled: { variant: "default", label: t("statusCancelled") },
     };
     const s = statusMap[status] || statusMap.queued;
     return (
-      <span
-        className={`inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full font-medium ${s.color}`}
-      >
-        {status === "running" && <span className="animate-pulse">●</span>}
+      <Badge variant={s.variant} dot={status === "running"}>
         {s.label}
-      </span>
+      </Badge>
     );
   };
 
-  const getAgentInfo = (providerId: string) => {
-    return CLOUD_AGENTS.find((a) => a.id === providerId) || CLOUD_AGENTS[0];
-  };
-
   const getPlanText = (task: CloudAgentTask) => {
-    return task.activities.find((activity) => activity.type === "plan")?.content || "";
+    return task.activities.find((a) => a.type === "plan")?.content || "";
   };
 
   const formatResult = (result: CloudAgentTask["result"]) => {
@@ -243,6 +350,16 @@ export default function CloudAgentsPage() {
     if (typeof result === "string") return result;
     return JSON.stringify(result, null, 2);
   };
+
+  // ── Tab definitions ──────────────────────────────────────────────────────
+
+  const tabs: { id: TabId; label: string; icon: string }[] = [
+    { id: "tasks", label: t("tasksTab") || "Tasks", icon: "task_alt" },
+    { id: "agents", label: t("agentsTab") || "Agents", icon: "smart_toy" },
+    { id: "settings", label: t("settingsTab") || "Settings", icon: "tune" },
+  ];
+
+  // ── Loading state ────────────────────────────────────────────────────────
 
   if (loading) {
     return (
@@ -253,299 +370,543 @@ export default function CloudAgentsPage() {
     );
   }
 
+  // ── Main render ──────────────────────────────────────────────────────────
+
   return (
     <div className="flex flex-col gap-6">
+      {/* Header */}
       <Card className="border-purple-500/20 bg-purple-500/5">
-        <div className="flex flex-col gap-4">
-          <div className="flex items-start justify-between gap-4 flex-wrap">
-            <div>
-              <h2 className="text-sm font-semibold text-text-main">{t("aboutTitle")}</h2>
-              <p className="text-sm text-text-muted mt-1">{t("aboutDescription")}</p>
-            </div>
+        <div className="flex items-start justify-between gap-4 flex-wrap">
+          <div>
+            <h2 className="text-sm font-semibold text-text-main">{t("aboutTitle")}</h2>
+            <p className="text-sm text-text-muted mt-1">{t("aboutDescription")}</p>
           </div>
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
-            {CLOUD_AGENTS.map((agent) => (
-              <div
-                key={agent.id}
-                className="rounded-lg border border-purple-500/15 bg-purple-500/5 p-3"
-              >
-                <div className="flex items-center gap-2 mb-1">
-                  <span className="text-lg">{agent.icon}</span>
-                  <p className="text-sm font-medium text-text-main">{agent.name}</p>
-                </div>
-                <p className="text-xs text-text-muted">{agent.description}</p>
-                <p className="text-[10px] text-purple-500 mt-1">{agent.provider}</p>
+          <div className="flex items-center gap-2">
+            <span
+              className={`inline-block h-2 w-2 rounded-full ${settings.enabled ? "bg-emerald-500" : "bg-zinc-400"}`}
+            />
+            <span className="text-xs text-text-muted">
+              {settings.enabled
+                ? t("agentsEnabled") || "Enabled"
+                : t("agentsDisabled") || "Disabled"}
+            </span>
+          </div>
+        </div>
+      </Card>
+
+      {/* Tab bar */}
+      <div className="flex gap-2 border-b border-border">
+        {tabs.map((tab) => (
+          <button
+            key={tab.id}
+            onClick={() => setActiveTab(tab.id)}
+            className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors flex items-center gap-1.5 ${
+              activeTab === tab.id
+                ? "border-purple-500 text-purple-500"
+                : "border-transparent text-text-muted hover:text-text-main"
+            }`}
+          >
+            <span className="material-symbols-outlined text-[16px]">{tab.icon}</span>
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {/* ── Tasks Tab ──────────────────────────────────────────────────────── */}
+      {activeTab === "tasks" && (
+        <div className="flex flex-col gap-6">
+          {/* Create task form */}
+          <Card>
+            <div className="flex items-center gap-3 mb-4">
+              <div className="p-2 rounded-lg bg-purple-500/10 text-purple-500">
+                <span className="material-symbols-outlined text-[20px]">add_task</span>
               </div>
-            ))}
-          </div>
-          <div className="rounded-lg border border-purple-500/15 bg-surface/40 p-3 text-sm text-text-muted">
-            <span className="font-medium text-text-main">{t("howItWorksTitle")}</span>
-            <span className="ml-1">{t("howItWorksDesc")}</span>
-          </div>
-        </div>
-      </Card>
-
-      <Card>
-        <div className="flex items-center gap-3 mb-4">
-          <div className="p-2 rounded-lg bg-purple-500/10 text-purple-500">
-            <span className="material-symbols-outlined text-[20px]">add_task</span>
-          </div>
-          <div>
-            <h3 className="text-lg font-semibold">{t("newTaskTitle")}</h3>
-            <p className="text-sm text-text-muted">{t("newTaskDescription")}</p>
-          </div>
-        </div>
-        <form onSubmit={handleCreateTask} className="flex flex-col gap-4">
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div>
-              <label className="text-xs font-medium text-text-muted mb-1.5 block">
-                {t("selectAgent")}
-              </label>
-              <select
-                value={newTask.providerId}
-                onChange={(e) => setNewTask({ ...newTask, providerId: e.target.value })}
-                className="w-full rounded-lg border border-border/50 bg-card px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
-              >
-                {CLOUD_AGENTS.map((agent) => (
-                  <option key={agent.id} value={agent.id}>
-                    {agent.name} ({agent.provider})
-                  </option>
-                ))}
-              </select>
+              <div>
+                <h3 className="text-lg font-semibold">{t("newTaskTitle")}</h3>
+                <p className="text-sm text-text-muted">{t("newTaskDescription")}</p>
+              </div>
             </div>
-          </div>
-          <div>
-            <label className="text-xs font-medium text-text-muted mb-1.5 block">
-              {t("taskDescription")}
-            </label>
-            <textarea
-              placeholder={t("taskDescriptionPlaceholder")}
-              value={newTask.prompt}
-              onChange={(e) => setNewTask({ ...newTask, prompt: e.target.value })}
-              className="min-h-24 w-full rounded-lg border border-border/50 bg-card px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
-              required
-            />
-          </div>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <Input
-              label={t("repositoryName")}
-              placeholder="omniroute"
-              value={newTask.repoName}
-              onChange={(e) => setNewTask({ ...newTask, repoName: e.target.value })}
-              required
-            />
-            <Input
-              label={t("repositoryUrl")}
-              placeholder="https://github.com/owner/repo"
-              value={newTask.repoUrl}
-              onChange={(e) => setNewTask({ ...newTask, repoUrl: e.target.value })}
-              required
-            />
-          </div>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <Input
-              label={t("branch")}
-              placeholder="main"
-              value={newTask.branch}
-              onChange={(e) => setNewTask({ ...newTask, branch: e.target.value })}
-            />
-            <label className="flex items-center gap-2 text-sm text-text-muted pt-7">
-              <input
-                type="checkbox"
-                checked={newTask.autoCreatePr}
-                onChange={(e) => setNewTask({ ...newTask, autoCreatePr: e.target.checked })}
-                className="h-4 w-4 rounded border-border/60"
-              />
-              Auto-create PR
-            </label>
-          </div>
-          <div className="flex justify-end">
-            <Button type="submit" variant="primary" loading={creating}>
-              <span className="material-symbols-outlined text-[16px] mr-1">rocket_launch</span>
-              {t("startTask")}
-            </Button>
-          </div>
-        </form>
-      </Card>
+            <form onSubmit={handleCreateTask} className="flex flex-col gap-4">
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div>
+                  <label className="text-xs font-medium text-text-muted mb-1.5 block">
+                    {t("selectAgent")}
+                  </label>
+                  <select
+                    value={newTask.providerId}
+                    onChange={(e) => setNewTask({ ...newTask, providerId: e.target.value })}
+                    className="w-full rounded-lg border border-border/50 bg-card px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
+                  >
+                    {CLOUD_AGENTS.map((agent) => (
+                      <option key={agent.id} value={agent.id}>
+                        {agent.name} ({agent.provider})
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+              <div>
+                <label className="text-xs font-medium text-text-muted mb-1.5 block">
+                  {t("taskDescription")}
+                </label>
+                <textarea
+                  placeholder={t("taskDescriptionPlaceholder")}
+                  value={newTask.prompt}
+                  onChange={(e) => setNewTask({ ...newTask, prompt: e.target.value })}
+                  className="min-h-24 w-full rounded-lg border border-border/50 bg-card px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
+                  required
+                />
+              </div>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <Input
+                  label={t("repositoryName")}
+                  placeholder="omniroute"
+                  value={newTask.repoName}
+                  onChange={(e) => setNewTask({ ...newTask, repoName: e.target.value })}
+                  required
+                />
+                <Input
+                  label={t("repositoryUrl")}
+                  placeholder="https://github.com/owner/repo"
+                  value={newTask.repoUrl}
+                  onChange={(e) => setNewTask({ ...newTask, repoUrl: e.target.value })}
+                  required
+                />
+              </div>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <Input
+                  label={t("branch")}
+                  placeholder="main"
+                  value={newTask.branch}
+                  onChange={(e) => setNewTask({ ...newTask, branch: e.target.value })}
+                />
+                <label className="flex items-center gap-2 text-sm text-text-muted pt-7">
+                  <input
+                    type="checkbox"
+                    checked={newTask.autoCreatePr}
+                    onChange={(e) => setNewTask({ ...newTask, autoCreatePr: e.target.checked })}
+                    className="h-4 w-4 rounded border-border/60"
+                  />
+                  Auto-create PR
+                </label>
+              </div>
+              <div className="flex justify-end">
+                <Button type="submit" variant="primary" loading={creating}>
+                  <span className="material-symbols-outlined text-[16px] mr-1">rocket_launch</span>
+                  {t("startTask")}
+                </Button>
+              </div>
+            </form>
+          </Card>
 
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <div className="flex flex-col gap-3">
-          <h2 className="text-lg font-semibold">{t("tasks")}</h2>
-          {tasks.length === 0 ? (
-            <div className="text-center py-8 text-text-muted">
-              <span className="material-symbols-outlined text-[40px] mb-2">assignment</span>
-              <p>{t("noTasks")}</p>
+          {/* Filters */}
+          <div className="flex items-center gap-3 flex-wrap">
+            <select
+              value={statusFilter}
+              onChange={(e) => setStatusFilter(e.target.value as TaskStatus | "all")}
+              className="rounded-lg border border-border/50 bg-card px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
+            >
+              {STATUS_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {t(opt.labelKey) || opt.value}
+                </option>
+              ))}
+            </select>
+            <select
+              value={providerFilter}
+              onChange={(e) => setProviderFilter(e.target.value)}
+              className="rounded-lg border border-border/50 bg-card px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
+            >
+              <option value="all">{t("filterAllProviders") || "All Providers"}</option>
+              {CLOUD_AGENTS.map((agent) => (
+                <option key={agent.id} value={agent.id}>
+                  {agent.name}
+                </option>
+              ))}
+            </select>
+            {hasActiveTasks && (
+              <span className="flex items-center gap-1.5 text-xs text-blue-500">
+                <span className="animate-pulse">●</span>
+                {t("autoRefreshing") || "Auto-refreshing"}
+              </span>
+            )}
+          </div>
+
+          {/* Tasks list + detail */}
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            <div className="flex flex-col gap-3">
+              {filteredTasks.length === 0 ? (
+                <div className="text-center py-12 text-text-muted border border-dashed border-border/50 rounded-lg">
+                  <span className="material-symbols-outlined text-[48px] mb-2 block text-text-muted/50">
+                    assignment
+                  </span>
+                  <p className="text-sm font-medium">{t("noTasksTitle") || "No tasks yet"}</p>
+                  <p className="text-xs mt-1">
+                    {t("noTasksDesc") || "Create your first task to get started."}
+                  </p>
+                </div>
+              ) : (
+                filteredTasks.map((task) => {
+                  const agent = getAgentInfo(task.providerId);
+                  return (
+                    <Card
+                      key={task.id}
+                      padding="sm"
+                      hover
+                      className={`transition-all ${
+                        selectedTask?.id === task.id
+                          ? "!border-purple-500 ring-1 ring-purple-500/20"
+                          : ""
+                      }`}
+                      onClick={() => setSelectedTask(task)}
+                    >
+                      <div className="flex items-start justify-between gap-2">
+                        <div className="flex items-center gap-2.5">
+                          <div className={`p-1.5 rounded-lg ${agent.iconBg} ${agent.iconColor}`}>
+                            <span className="material-symbols-outlined text-[16px]">
+                              {agent.icon}
+                            </span>
+                          </div>
+                          <div>
+                            <p className="text-sm font-medium text-text-main line-clamp-1">
+                              {task.prompt || t("untitledTask")}
+                            </p>
+                            <p className="text-xs text-text-muted">
+                              {agent.name} · {new Date(task.createdAt).toLocaleString()}
+                            </p>
+                          </div>
+                        </div>
+                        {getStatusBadge(task.status)}
+                      </div>
+                    </Card>
+                  );
+                })
+              )}
             </div>
-          ) : (
-            tasks.map((task) => {
-              const agent = getAgentInfo(task.providerId);
-              return (
-                <Card
-                  key={task.id}
-                  className={`cursor-pointer transition-all hover:border-primary/30 ${
-                    selectedTask?.id === task.id ? "border-primary ring-1 ring-primary/20" : ""
-                  }`}
-                  onClick={() => setSelectedTask(task)}
-                >
-                  <div className="flex items-start justify-between gap-2">
+
+            {/* Task detail panel */}
+            <div className="flex flex-col gap-3">
+              {selectedTask ? (
+                <Card className="flex flex-col gap-4">
+                  <div className="flex items-center justify-between">
                     <div className="flex items-center gap-2">
-                      <span className="text-lg">{agent.icon}</span>
+                      <div
+                        className={`p-1.5 rounded-lg ${getAgentInfo(selectedTask.providerId).iconBg} ${getAgentInfo(selectedTask.providerId).iconColor}`}
+                      >
+                        <span className="material-symbols-outlined text-[16px]">
+                          {getAgentInfo(selectedTask.providerId).icon}
+                        </span>
+                      </div>
                       <div>
-                        <p className="text-sm font-medium text-text-main line-clamp-1">
-                          {task.prompt || t("untitledTask")}
-                        </p>
+                        <p className="font-medium">{getAgentInfo(selectedTask.providerId).name}</p>
                         <p className="text-xs text-text-muted">
-                          {agent.name} • {new Date(task.createdAt).toLocaleString()}
+                          {t("created")}: {new Date(selectedTask.createdAt).toLocaleString()}
                         </p>
                       </div>
                     </div>
-                    {getStatusBadge(task.status)}
+                    {getStatusBadge(selectedTask.status)}
                   </div>
-                </Card>
-              );
-            })
-          )}
-        </div>
 
-        <div className="flex flex-col gap-3">
-          <h2 className="text-lg font-semibold">{t("taskDetail")}</h2>
-          {selectedTask ? (
-            <Card className="flex flex-col gap-4">
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-2">
-                  <span className="text-lg">{getAgentInfo(selectedTask.providerId).icon}</span>
-                  <div>
-                    <p className="font-medium">{getAgentInfo(selectedTask.providerId).name}</p>
-                    <p className="text-xs text-text-muted">
-                      {t("created")}: {new Date(selectedTask.createdAt).toLocaleString()}
-                    </p>
-                  </div>
-                </div>
-                {getStatusBadge(selectedTask.status)}
-              </div>
+                  {/* Duration for completed/failed tasks */}
+                  {selectedTask.status === "completed" && (
+                    <div className="flex items-center gap-1.5 text-xs text-text-muted">
+                      <span className="material-symbols-outlined text-[14px]">timer</span>
+                      {formatDuration(selectedTask.createdAt, selectedTask.updatedAt)}
+                    </div>
+                  )}
 
-              {selectedTask.status === "awaiting_approval" && getPlanText(selectedTask) && (
-                <div className="rounded-lg border border-amber-500/20 bg-amber-500/5 p-3">
-                  <div className="flex items-center gap-2 mb-2">
-                    <span className="material-symbols-outlined text-[16px] text-amber-600">
-                      description
-                    </span>
-                    <span className="text-sm font-medium text-amber-700 dark:text-amber-400">
-                      {t("planReady")}
-                    </span>
-                  </div>
-                  <pre className="text-xs text-text-muted whitespace-pre-wrap bg-black/5 dark:bg-white/5 rounded p-2 max-h-32 overflow-auto">
-                    {getPlanText(selectedTask)}
-                  </pre>
-                  <div className="flex gap-2 mt-2">
-                    <Button variant="primary" size="sm" onClick={handleApprovePlan}>
-                      <span className="material-symbols-outlined text-[14px] mr-1">check</span>
-                      {t("approvePlan")}
-                    </Button>
+                  {/* Awaiting approval: show plan */}
+                  {selectedTask.status === "awaiting_approval" && getPlanText(selectedTask) && (
+                    <div className="rounded-lg border border-amber-500/20 bg-amber-500/5 p-3">
+                      <div className="flex items-center gap-2 mb-2">
+                        <span className="material-symbols-outlined text-[16px] text-amber-600">
+                          description
+                        </span>
+                        <span className="text-sm font-medium text-amber-700 dark:text-amber-400">
+                          {t("planReady")}
+                        </span>
+                      </div>
+                      <pre className="text-xs text-text-muted whitespace-pre-wrap bg-black/5 dark:bg-white/5 rounded p-2 max-h-32 overflow-auto">
+                        {getPlanText(selectedTask)}
+                      </pre>
+                      <div className="flex gap-2 mt-2">
+                        <Button variant="primary" size="sm" onClick={handleApprovePlan}>
+                          <span className="material-symbols-outlined text-[14px] mr-1">check</span>
+                          {t("approvePlan")}
+                        </Button>
+                        <Button
+                          variant="secondary"
+                          size="sm"
+                          onClick={() => handleCancelTask(selectedTask.id)}
+                        >
+                          {t("rejectPlan")}
+                        </Button>
+                      </div>
+                    </div>
+                  )}
+
+                  {/* Activities */}
+                  {selectedTask.activities.length > 0 && (
+                    <div className="flex flex-col gap-2">
+                      <p className="text-sm font-medium">{t("conversation")}</p>
+                      <div className="flex flex-col gap-2 max-h-64 overflow-auto">
+                        {selectedTask.activities.map((activity) => (
+                          <div
+                            key={activity.id}
+                            className={`p-2 rounded-lg text-xs ${
+                              activity.type === "message" || activity.type === "completion"
+                                ? "bg-purple-500/10 text-text-main"
+                                : "bg-surface/40 text-text-main"
+                            }`}
+                          >
+                            <span className="font-medium capitalize">{activity.type}: </span>
+                            {activity.content}
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+
+                  {/* Result with PR link */}
+                  {selectedTask.result && (
+                    <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/5 p-3">
+                      <div className="flex items-center gap-2 mb-2">
+                        <span className="material-symbols-outlined text-[16px] text-emerald-600">
+                          check_circle
+                        </span>
+                        <span className="text-sm font-medium text-emerald-700 dark:text-emerald-400">
+                          {t("result")}
+                        </span>
+                      </div>
+                      <pre className="text-xs text-text-muted whitespace-pre-wrap">
+                        {formatResult(selectedTask.result)}
+                      </pre>
+                      {(selectedTask.result as Record<string, unknown>)?.prUrl && (
+                        <a
+                          href={(selectedTask.result as Record<string, unknown>).prUrl as string}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center gap-1.5 mt-2 px-3 py-1.5 text-xs font-medium rounded-lg bg-purple-500/10 text-purple-600 hover:bg-purple-500/20 transition-colors"
+                        >
+                          <span className="material-symbols-outlined text-[14px]">open_in_new</span>
+                          {t("viewPR") || "View Pull Request"}
+                        </a>
+                      )}
+                    </div>
+                  )}
+
+                  {/* Error */}
+                  {selectedTask.error && (
+                    <div className="rounded-lg border border-red-500/20 bg-red-500/5 p-3">
+                      <div className="flex items-center gap-2 mb-2">
+                        <span className="material-symbols-outlined text-[16px] text-red-500">
+                          error
+                        </span>
+                        <span className="text-sm font-medium text-red-600">{t("error")}</span>
+                      </div>
+                      <p className="text-xs text-text-muted">{selectedTask.error}</p>
+                    </div>
+                  )}
+
+                  {/* Message input for running tasks */}
+                  {selectedTask.status === "running" && (
+                    <div className="flex gap-2">
+                      <Input
+                        placeholder={t("sendMessagePlaceholder")}
+                        value={messageInput}
+                        onChange={(e) => setMessageInput(e.target.value)}
+                        onKeyDown={(e) => e.key === "Enter" && !e.shiftKey && handleSendMessage()}
+                        className="flex-1"
+                      />
+                      <Button variant="primary" onClick={handleSendMessage}>
+                        <span className="material-symbols-outlined text-[16px]">send</span>
+                      </Button>
+                    </div>
+                  )}
+
+                  {/* Action buttons */}
+                  <div className="flex justify-between pt-3 border-t border-border/30">
                     <Button
-                      variant="secondary"
+                      variant="ghost"
                       size="sm"
                       onClick={() => handleCancelTask(selectedTask.id)}
+                      disabled={["completed", "failed", "cancelled"].includes(selectedTask.status)}
                     >
-                      {t("rejectPlan")}
+                      <span className="material-symbols-outlined text-[14px] mr-1">cancel</span>
+                      {t("cancel")}
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => handleDeleteTask(selectedTask.id)}
+                      className="text-red-500 hover:text-red-400"
+                    >
+                      <span className="material-symbols-outlined text-[14px] mr-1">delete</span>
+                      {t("delete")}
                     </Button>
                   </div>
+                </Card>
+              ) : (
+                <div className="text-center py-12 text-text-muted border border-dashed border-border/50 rounded-lg">
+                  <span className="material-symbols-outlined text-[48px] mb-2 block text-text-muted/50">
+                    touch_app
+                  </span>
+                  <p className="text-sm">{t("selectTaskPrompt")}</p>
                 </div>
               )}
+            </div>
+          </div>
+        </div>
+      )}
 
-              {selectedTask.activities.length > 0 && (
-                <div className="flex flex-col gap-2">
-                  <p className="text-sm font-medium">{t("conversation")}</p>
-                  <div className="flex flex-col gap-2 max-h-64 overflow-auto">
-                    {selectedTask.activities.map((activity) => (
-                      <div
-                        key={activity.id}
-                        className={`p-2 rounded-lg text-xs ${
-                          activity.type === "message" || activity.type === "completion"
-                            ? "bg-purple-500/10 text-text-main"
-                            : "bg-surface/40 text-text-main"
-                        }`}
-                      >
-                        <span className="font-medium capitalize">{activity.type}: </span>
-                        {activity.content}
-                      </div>
-                    ))}
+      {/* ── Agents Tab ─────────────────────────────────────────────────────── */}
+      {activeTab === "agents" && (
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          {CLOUD_AGENTS.map((agent) => {
+            const connected = agentHealth[agent.id] === true;
+            return (
+              <Card key={agent.id} padding="md" className="relative">
+                <div className="flex flex-col items-center text-center gap-3">
+                  {/* Icon */}
+                  <div className={`p-3 rounded-xl ${agent.iconBg} ${agent.iconColor}`}>
+                    <span className="material-symbols-outlined text-[32px]">{agent.icon}</span>
                   </div>
-                </div>
-              )}
 
-              {selectedTask.result && (
-                <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/5 p-3">
-                  <div className="flex items-center gap-2 mb-2">
-                    <span className="material-symbols-outlined text-[16px] text-emerald-600">
-                      check_circle
-                    </span>
-                    <span className="text-sm font-medium text-emerald-700 dark:text-emerald-400">
-                      {t("result")}
+                  {/* Name + provider */}
+                  <div>
+                    <h3 className="text-base font-semibold text-text-main">{agent.name}</h3>
+                    <p className="text-xs text-text-muted">{agent.provider}</p>
+                  </div>
+
+                  {/* Description */}
+                  <p className="text-sm text-text-muted">{agent.description}</p>
+
+                  {/* Connection status */}
+                  <div className="flex items-center gap-2">
+                    <span
+                      className={`h-2.5 w-2.5 rounded-full ${connected ? "bg-emerald-500" : "bg-red-500"}`}
+                    />
+                    <span className="text-xs text-text-muted">
+                      {connected
+                        ? t("connected") || "Connected"
+                        : t("notConnected") || "Not connected"}
                     </span>
                   </div>
-                  <pre className="text-xs text-text-muted whitespace-pre-wrap">
-                    {formatResult(selectedTask.result)}
-                  </pre>
-                </div>
-              )}
 
-              {selectedTask.error && (
-                <div className="rounded-lg border border-red-500/20 bg-red-500/5 p-3">
-                  <div className="flex items-center gap-2 mb-2">
-                    <span className="material-symbols-outlined text-[16px] text-red-500">
-                      error
-                    </span>
-                    <span className="text-sm font-medium text-red-600">{t("error")}</span>
-                  </div>
-                  <p className="text-xs text-text-muted">{selectedTask.error}</p>
-                </div>
-              )}
-
-              {selectedTask.status === "running" && (
-                <div className="flex gap-2">
-                  <Input
-                    placeholder={t("sendMessagePlaceholder")}
-                    value={messageInput}
-                    onChange={(e) => setMessageInput(e.target.value)}
-                    onKeyDown={(e) => e.key === "Enter" && !e.shiftKey && handleSendMessage()}
-                    className="flex-1"
-                  />
-                  <Button variant="primary" onClick={handleSendMessage}>
-                    <span className="material-symbols-outlined text-[16px]">send</span>
+                  {/* Configure button */}
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => {
+                      window.location.href = "/dashboard/providers?section=cloudagent";
+                    }}
+                  >
+                    <span className="material-symbols-outlined text-[14px] mr-1">settings</span>
+                    {t("configure") || "Configure"}
                   </Button>
                 </div>
-              )}
-
-              <div className="flex justify-between pt-3 border-t border-border/30">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => handleCancelTask(selectedTask.id)}
-                  disabled={["completed", "failed", "cancelled"].includes(selectedTask.status)}
-                >
-                  <span className="material-symbols-outlined text-[14px] mr-1">cancel</span>
-                  {t("cancel")}
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => handleDeleteTask(selectedTask.id)}
-                  className="text-red-500 hover:text-red-400"
-                >
-                  <span className="material-symbols-outlined text-[14px] mr-1">delete</span>
-                  {t("delete")}
-                </Button>
-              </div>
-            </Card>
-          ) : (
-            <div className="text-center py-8 text-text-muted border border-dashed border-border/50 rounded-lg">
-              <span className="material-symbols-outlined text-[40px] mb-2">touch_app</span>
-              <p>{t("selectTaskPrompt")}</p>
-            </div>
-          )}
+              </Card>
+            );
+          })}
         </div>
-      </div>
+      )}
+
+      {/* ── Settings Tab ───────────────────────────────────────────────────── */}
+      {activeTab === "settings" && (
+        <Card>
+          <div className="flex flex-col gap-6">
+            <div>
+              <h3 className="text-base font-semibold text-text-main mb-1">
+                {t("settingsTitle") || "Cloud Agent Settings"}
+              </h3>
+              <p className="text-sm text-text-muted">
+                {t("settingsDesc") || "Configure local preferences for cloud agents."}
+              </p>
+            </div>
+
+            {/* Toggle: Enable cloud agents */}
+            <div className="flex items-center justify-between py-3 border-b border-border/30">
+              <div>
+                <p className="text-sm font-medium text-text-main">
+                  {t("settingEnableAgents") || "Enable cloud agents"}
+                </p>
+                <p className="text-xs text-text-muted">
+                  {t("settingEnableAgentsDesc") ||
+                    "Master switch for all cloud agent functionality."}
+                </p>
+              </div>
+              <button
+                role="switch"
+                aria-checked={settings.enabled}
+                onClick={() => updateSetting("enabled", !settings.enabled)}
+                className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+                  settings.enabled ? "bg-purple-500" : "bg-zinc-300 dark:bg-zinc-600"
+                }`}
+              >
+                <span
+                  className={`inline-block h-4 w-4 rounded-full bg-white transition-transform ${
+                    settings.enabled ? "translate-x-6" : "translate-x-1"
+                  }`}
+                />
+              </button>
+            </div>
+
+            {/* Toggle: Auto-create PR */}
+            <div className="flex items-center justify-between py-3 border-b border-border/30">
+              <div>
+                <p className="text-sm font-medium text-text-main">
+                  {t("settingAutoPR") || "Auto-create PR"}
+                </p>
+                <p className="text-xs text-text-muted">
+                  {t("settingAutoPRDesc") ||
+                    "Automatically create a pull request when a task completes."}
+                </p>
+              </div>
+              <button
+                role="switch"
+                aria-checked={settings.autoCreatePr}
+                onClick={() => updateSetting("autoCreatePr", !settings.autoCreatePr)}
+                className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+                  settings.autoCreatePr ? "bg-purple-500" : "bg-zinc-300 dark:bg-zinc-600"
+                }`}
+              >
+                <span
+                  className={`inline-block h-4 w-4 rounded-full bg-white transition-transform ${
+                    settings.autoCreatePr ? "translate-x-6" : "translate-x-1"
+                  }`}
+                />
+              </button>
+            </div>
+
+            {/* Toggle: Require approval */}
+            <div className="flex items-center justify-between py-3">
+              <div>
+                <p className="text-sm font-medium text-text-main">
+                  {t("settingRequireApproval") || "Require plan approval"}
+                </p>
+                <p className="text-xs text-text-muted">
+                  {t("settingRequireApprovalDesc") ||
+                    "Pause execution until you approve the agent's plan."}
+                </p>
+              </div>
+              <button
+                role="switch"
+                aria-checked={settings.requireApproval}
+                onClick={() => updateSetting("requireApproval", !settings.requireApproval)}
+                className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+                  settings.requireApproval ? "bg-purple-500" : "bg-zinc-300 dark:bg-zinc-600"
+                }`}
+              >
+                <span
+                  className={`inline-block h-4 w-4 rounded-full bg-white transition-transform ${
+                    settings.requireApproval ? "translate-x-6" : "translate-x-1"
+                  }`}
+                />
+              </button>
+            </div>
+          </div>
+        </Card>
+      )}
     </div>
   );
 }

--- a/src/app/(dashboard)/dashboard/skills/page.tsx
+++ b/src/app/(dashboard)/dashboard/skills/page.tsx
@@ -310,8 +310,43 @@ export default function SkillsPage() {
     );
   }
 
+  // ── Stats computation ────────────────────────────────────────────────────
+
+  const enabledCount = skills.filter((s) => s.enabled).length;
+  const execSuccessCount = executions.filter((e) => e.status === "success").length;
+  const successRate =
+    executions.length > 0 ? Math.round((execSuccessCount / executions.length) * 100) : 0;
+
   return (
     <div className="flex flex-col gap-6">
+      {/* ── Stats Cards ─────────────────────────────────────────────────── */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <Card className="p-4">
+          <p className="text-xs text-text-muted uppercase tracking-wide">
+            {t("totalSkills") || "Total Skills"}
+          </p>
+          <p className="text-2xl font-bold text-text-main mt-1">{skillsTotal}</p>
+        </Card>
+        <Card className="p-4">
+          <p className="text-xs text-text-muted uppercase tracking-wide">
+            {t("enabledSkills") || "Enabled"}
+          </p>
+          <p className="text-2xl font-bold text-emerald-400 mt-1">{enabledCount}</p>
+        </Card>
+        <Card className="p-4">
+          <p className="text-xs text-text-muted uppercase tracking-wide">
+            {t("totalExecutions") || "Executions"}
+          </p>
+          <p className="text-2xl font-bold text-violet-400 mt-1">{execTotal}</p>
+        </Card>
+        <Card className="p-4">
+          <p className="text-xs text-text-muted uppercase tracking-wide">
+            {t("successRate") || "Success Rate"}
+          </p>
+          <p className="text-2xl font-bold text-amber-400 mt-1">{successRate}%</p>
+        </Card>
+      </div>
+
       <div className="flex justify-end">
         <button
           onClick={() => setShowInstallModal(true)}

--- a/src/app/api/memory/route.ts
+++ b/src/app/api/memory/route.ts
@@ -1,10 +1,13 @@
 import { NextResponse } from "next/server";
 import { requireManagementAuth } from "@/lib/api/requireManagementAuth";
 import { listMemories, createMemory } from "@/lib/memory/store";
+import { estimateTokens } from "@/lib/memory/retrieval";
+import { memoryCache } from "@/lib/memory/cache";
 import { MemoryType } from "@/lib/memory/types";
 import { parsePaginationParams, buildPaginatedResponse } from "@/shared/types/pagination";
 import { z } from "zod";
 import { validateBody, isValidationFailure } from "@/shared/validation/helpers";
+import { getDbInstance } from "@/lib/db/core";
 
 const createMemorySchema = z.object({
   content: z.string().min(1),
@@ -46,9 +49,23 @@ export async function GET(request: Request) {
       page: offset === undefined ? paginationParams.page : undefined,
     });
 
+    // Compute total tokens across all memories for this key
+    const db = getDbInstance();
+    const tokenRows = db
+      .prepare("SELECT content FROM memories" + (apiKeyId ? " WHERE api_key_id = ?" : ""))
+      .all(...(apiKeyId ? [apiKeyId] : [])) as { content: string }[];
+    const tokensUsed = tokenRows.reduce((sum, r) => sum + estimateTokens(r.content), 0);
+
+    // Compute hit rate from memory cache
+    const cacheStats = memoryCache.stats();
+    const totalCacheRequests = cacheStats.hits + cacheStats.misses;
+    const hitRate = totalCacheRequests > 0 ? cacheStats.hits / totalCacheRequests : 0;
+
     const stats = {
       total: result.total,
       byType: result.byType ?? {},
+      tokensUsed,
+      hitRate,
     };
 
     const responsePagination =

--- a/src/app/api/memory/route.ts
+++ b/src/app/api/memory/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
 import { requireManagementAuth } from "@/lib/api/requireManagementAuth";
 import { listMemories, createMemory } from "@/lib/memory/store";
-import { estimateTokens } from "@/lib/memory/retrieval";
 import { memoryCache } from "@/lib/memory/cache";
 import { MemoryType } from "@/lib/memory/types";
 import { parsePaginationParams, buildPaginatedResponse } from "@/shared/types/pagination";
@@ -49,12 +48,15 @@ export async function GET(request: Request) {
       page: offset === undefined ? paginationParams.page : undefined,
     });
 
-    // Compute total tokens across all memories for this key
+    // Compute total tokens across all memories using SQL (avoids loading all content into memory)
     const db = getDbInstance();
-    const tokenRows = db
-      .prepare("SELECT content FROM memories" + (apiKeyId ? " WHERE api_key_id = ?" : ""))
-      .all(...(apiKeyId ? [apiKeyId] : [])) as { content: string }[];
-    const tokensUsed = tokenRows.reduce((sum, r) => sum + estimateTokens(r.content), 0);
+    const tokenResult = db
+      .prepare(
+        "SELECT COALESCE(SUM((LENGTH(content) + 3) / 4), 0) as tokensUsed FROM memories" +
+          (apiKeyId ? " WHERE api_key_id = ?" : "")
+      )
+      .get(...(apiKeyId ? [apiKeyId] : [])) as { tokensUsed: number };
+    const tokensUsed = tokenResult?.tokensUsed ?? 0;
 
     // Compute hit rate from memory cache
     const cacheStats = memoryCache.stats();

--- a/src/app/api/v1/agents/credentials/route.ts
+++ b/src/app/api/v1/agents/credentials/route.ts
@@ -1,0 +1,124 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { getDbInstance } from "@/lib/db/core";
+import { getCloudAgentCorsHeaders, requireCloudAgentManagementAuth } from "@/lib/cloudAgent/api";
+import pino from "pino";
+import { sanitizeErrorMessage } from "@omniroute/open-sse/utils/error";
+
+const logger = pino({ name: "cloud-agents-credentials-api" });
+
+const SaveCredentialSchema = z.object({
+  providerId: z.enum(["jules", "devin", "codex-cloud"]),
+  apiKey: z.string().min(1),
+  baseUrl: z.string().url().optional(),
+});
+
+function ensureCredentialsTable(): void {
+  const db = getDbInstance();
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS cloud_agent_credentials (
+      provider_id TEXT PRIMARY KEY,
+      api_key TEXT NOT NULL,
+      base_url TEXT,
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    )
+  `);
+}
+
+function maskApiKey(key: string): string {
+  if (key.length <= 4) return "****";
+  return "****" + key.slice(-4);
+}
+
+export async function OPTIONS(request: NextRequest) {
+  return new NextResponse(null, { headers: getCloudAgentCorsHeaders(request) });
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const authError = await requireCloudAgentManagementAuth(request);
+    if (authError) return authError;
+
+    ensureCredentialsTable();
+
+    const db = getDbInstance();
+    const rows = db
+      .prepare("SELECT provider_id, api_key, base_url, updated_at FROM cloud_agent_credentials")
+      .all() as {
+      provider_id: string;
+      api_key: string;
+      base_url: string | null;
+      updated_at: string;
+    }[];
+
+    const data = rows.map((row) => ({
+      providerId: row.provider_id,
+      apiKey: maskApiKey(row.api_key),
+      baseUrl: row.base_url,
+      updatedAt: row.updated_at,
+    }));
+
+    return NextResponse.json({ data }, { headers: getCloudAgentCorsHeaders(request) });
+  } catch (error) {
+    logger.error({ err: error }, "Failed to list cloud agent credentials");
+    return NextResponse.json(
+      {
+        error:
+          sanitizeErrorMessage(error instanceof Error ? error.message : "Unknown error") ||
+          "Internal server error",
+      },
+      { status: 500, headers: getCloudAgentCorsHeaders(request) }
+    );
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const authError = await requireCloudAgentManagementAuth(request);
+    if (authError) return authError;
+
+    const body = await request.json();
+    const validation = SaveCredentialSchema.safeParse(body);
+    if (!validation.success) {
+      return NextResponse.json(
+        { error: "Validation failed", details: validation.error.issues },
+        { status: 400, headers: getCloudAgentCorsHeaders(request) }
+      );
+    }
+
+    const { providerId, apiKey, baseUrl } = validation.data;
+
+    ensureCredentialsTable();
+
+    const db = getDbInstance();
+    db.prepare(
+      `INSERT INTO cloud_agent_credentials (provider_id, api_key, base_url, updated_at)
+       VALUES (@providerId, @apiKey, @baseUrl, datetime('now'))
+       ON CONFLICT(provider_id) DO UPDATE SET
+         api_key = excluded.api_key,
+         base_url = excluded.base_url,
+         updated_at = excluded.updated_at`
+    ).run({ providerId, apiKey, baseUrl: baseUrl ?? null });
+
+    return NextResponse.json(
+      {
+        data: {
+          providerId,
+          apiKey: maskApiKey(apiKey),
+          baseUrl: baseUrl ?? null,
+        },
+      },
+      { status: 201, headers: getCloudAgentCorsHeaders(request) }
+    );
+  } catch (error) {
+    logger.error({ err: error }, "Failed to save cloud agent credentials");
+    return NextResponse.json(
+      {
+        error:
+          sanitizeErrorMessage(error instanceof Error ? error.message : "Unknown error") ||
+          "Internal server error",
+      },
+      { status: 500, headers: getCloudAgentCorsHeaders(request) }
+    );
+  }
+}

--- a/src/app/api/v1/agents/credentials/route.ts
+++ b/src/app/api/v1/agents/credentials/route.ts
@@ -1,6 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
-import { getDbInstance } from "@/lib/db/core";
+import {
+  listCloudAgentCredentials,
+  saveCloudAgentCredential,
+  maskApiKey,
+} from "@/lib/cloudAgent/credentials";
 import { getCloudAgentCorsHeaders, requireCloudAgentManagementAuth } from "@/lib/cloudAgent/api";
 import pino from "pino";
 import { sanitizeErrorMessage } from "@omniroute/open-sse/utils/error";
@@ -13,23 +17,6 @@ const SaveCredentialSchema = z.object({
   baseUrl: z.string().url().optional(),
 });
 
-function ensureCredentialsTable(): void {
-  const db = getDbInstance();
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS cloud_agent_credentials (
-      provider_id TEXT PRIMARY KEY,
-      api_key TEXT NOT NULL,
-      base_url TEXT,
-      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
-    )
-  `);
-}
-
-function maskApiKey(key: string): string {
-  if (key.length <= 4) return "****";
-  return "****" + key.slice(-4);
-}
-
 export async function OPTIONS(request: NextRequest) {
   return new NextResponse(null, { headers: getCloudAgentCorsHeaders(request) });
 }
@@ -39,24 +26,7 @@ export async function GET(request: NextRequest) {
     const authError = await requireCloudAgentManagementAuth(request);
     if (authError) return authError;
 
-    ensureCredentialsTable();
-
-    const db = getDbInstance();
-    const rows = db
-      .prepare("SELECT provider_id, api_key, base_url, updated_at FROM cloud_agent_credentials")
-      .all() as {
-      provider_id: string;
-      api_key: string;
-      base_url: string | null;
-      updated_at: string;
-    }[];
-
-    const data = rows.map((row) => ({
-      providerId: row.provider_id,
-      apiKey: maskApiKey(row.api_key),
-      baseUrl: row.base_url,
-      updatedAt: row.updated_at,
-    }));
+    const data = listCloudAgentCredentials();
 
     return NextResponse.json({ data }, { headers: getCloudAgentCorsHeaders(request) });
   } catch (error) {
@@ -88,17 +58,7 @@ export async function POST(request: NextRequest) {
 
     const { providerId, apiKey, baseUrl } = validation.data;
 
-    ensureCredentialsTable();
-
-    const db = getDbInstance();
-    db.prepare(
-      `INSERT INTO cloud_agent_credentials (provider_id, api_key, base_url, updated_at)
-       VALUES (@providerId, @apiKey, @baseUrl, datetime('now'))
-       ON CONFLICT(provider_id) DO UPDATE SET
-         api_key = excluded.api_key,
-         base_url = excluded.base_url,
-         updated_at = excluded.updated_at`
-    ).run({ providerId, apiKey, baseUrl: baseUrl ?? null });
+    saveCloudAgentCredential(providerId, apiKey, baseUrl);
 
     return NextResponse.json(
       {

--- a/src/app/api/v1/agents/health/route.ts
+++ b/src/app/api/v1/agents/health/route.ts
@@ -1,0 +1,113 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAgent, getAvailableAgents } from "@/lib/cloudAgent/registry";
+import { getDbInstance } from "@/lib/db/core";
+import type { AgentCredentials } from "@/lib/cloudAgent/baseAgent";
+import { getCloudAgentCorsHeaders, requireCloudAgentManagementAuth } from "@/lib/cloudAgent/api";
+import pino from "pino";
+import { sanitizeErrorMessage } from "@omniroute/open-sse/utils/error";
+
+const logger = pino({ name: "cloud-agents-health-api" });
+
+const PROVIDER_NAMES: Record<string, string> = {
+  jules: "Jules",
+  devin: "Devin",
+  "codex-cloud": "Codex Cloud",
+};
+
+function getCredentialFromDb(providerId: string): AgentCredentials | null {
+  const db = getDbInstance();
+
+  // Ensure table exists
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS cloud_agent_credentials (
+      provider_id TEXT PRIMARY KEY,
+      api_key TEXT NOT NULL,
+      base_url TEXT,
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    )
+  `);
+
+  const row = db
+    .prepare("SELECT api_key, base_url FROM cloud_agent_credentials WHERE provider_id = ?")
+    .get(providerId) as { api_key: string; base_url: string | null } | undefined;
+
+  if (!row) return null;
+
+  const creds: AgentCredentials = { apiKey: row.api_key };
+  if (row.base_url) creds.baseUrl = row.base_url;
+  return creds;
+}
+
+interface ProviderHealth {
+  id: string;
+  name: string;
+  connected: boolean;
+  latencyMs: number;
+  error?: string;
+}
+
+async function checkProviderHealth(providerId: string): Promise<ProviderHealth> {
+  const name = PROVIDER_NAMES[providerId] ?? providerId;
+  const agent = getAgent(providerId);
+
+  if (!agent) {
+    return { id: providerId, name, connected: false, latencyMs: 0, error: "Unknown provider" };
+  }
+
+  const credentials = getCredentialFromDb(providerId);
+  if (!credentials) {
+    return {
+      id: providerId,
+      name,
+      connected: false,
+      latencyMs: 0,
+      error: "No credentials configured",
+    };
+  }
+
+  const start = Date.now();
+  try {
+    const timeoutPromise = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error("Connection timed out")), 5000)
+    );
+    await Promise.race([agent.listSources(credentials), timeoutPromise]);
+    return { id: providerId, name, connected: true, latencyMs: Date.now() - start };
+  } catch (error) {
+    return {
+      id: providerId,
+      name,
+      connected: false,
+      latencyMs: Date.now() - start,
+      error: error instanceof Error ? error.message : "Unknown error",
+    };
+  }
+}
+
+export async function OPTIONS(request: NextRequest) {
+  return new NextResponse(null, { headers: getCloudAgentCorsHeaders(request) });
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const authError = await requireCloudAgentManagementAuth(request);
+    if (authError) return authError;
+
+    const agentIds = getAvailableAgents();
+    const results = await Promise.all(agentIds.map(checkProviderHealth));
+
+    return NextResponse.json(
+      { providers: results },
+      { headers: getCloudAgentCorsHeaders(request) }
+    );
+  } catch (error) {
+    logger.error({ err: error }, "Failed to check cloud agent health");
+    return NextResponse.json(
+      {
+        error:
+          sanitizeErrorMessage(error instanceof Error ? error.message : "Unknown error") ||
+          "Internal server error",
+      },
+      { status: 500, headers: getCloudAgentCorsHeaders(request) }
+    );
+  }
+}

--- a/src/app/api/v1/agents/health/route.ts
+++ b/src/app/api/v1/agents/health/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getAgent, getAvailableAgents } from "@/lib/cloudAgent/registry";
-import { getDbInstance } from "@/lib/db/core";
-import type { AgentCredentials } from "@/lib/cloudAgent/baseAgent";
+import { getCloudAgentCredentialFromDb } from "@/lib/cloudAgent/credentials";
 import { getCloudAgentCorsHeaders, requireCloudAgentManagementAuth } from "@/lib/cloudAgent/api";
 import pino from "pino";
 import { sanitizeErrorMessage } from "@omniroute/open-sse/utils/error";
@@ -13,30 +12,6 @@ const PROVIDER_NAMES: Record<string, string> = {
   devin: "Devin",
   "codex-cloud": "Codex Cloud",
 };
-
-function getCredentialFromDb(providerId: string): AgentCredentials | null {
-  const db = getDbInstance();
-
-  // Ensure table exists
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS cloud_agent_credentials (
-      provider_id TEXT PRIMARY KEY,
-      api_key TEXT NOT NULL,
-      base_url TEXT,
-      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
-    )
-  `);
-
-  const row = db
-    .prepare("SELECT api_key, base_url FROM cloud_agent_credentials WHERE provider_id = ?")
-    .get(providerId) as { api_key: string; base_url: string | null } | undefined;
-
-  if (!row) return null;
-
-  const creds: AgentCredentials = { apiKey: row.api_key };
-  if (row.base_url) creds.baseUrl = row.base_url;
-  return creds;
-}
 
 interface ProviderHealth {
   id: string;
@@ -54,7 +29,7 @@ async function checkProviderHealth(providerId: string): Promise<ProviderHealth> 
     return { id: providerId, name, connected: false, latencyMs: 0, error: "Unknown provider" };
   }
 
-  const credentials = getCredentialFromDb(providerId);
+  const credentials = getCloudAgentCredentialFromDb(providerId);
   if (!credentials) {
     return {
       id: providerId,
@@ -66,10 +41,12 @@ async function checkProviderHealth(providerId: string): Promise<ProviderHealth> 
   }
 
   const start = Date.now();
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
   try {
-    const timeoutPromise = new Promise<never>((_, reject) =>
-      setTimeout(() => reject(new Error("Connection timed out")), 5000)
-    );
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(() => reject(new Error("Connection timed out")), 5000);
+    });
     await Promise.race([agent.listSources(credentials), timeoutPromise]);
     return { id: providerId, name, connected: true, latencyMs: Date.now() - start };
   } catch (error) {
@@ -80,6 +57,8 @@ async function checkProviderHealth(providerId: string): Promise<ProviderHealth> 
       latencyMs: Date.now() - start,
       error: error instanceof Error ? error.message : "Unknown error",
     };
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
   }
 }
 

--- a/src/lib/cloudAgent/credentials.ts
+++ b/src/lib/cloudAgent/credentials.ts
@@ -1,0 +1,104 @@
+import { getDbInstance } from "@/lib/db/core";
+import { encrypt, decrypt } from "@/lib/db/encryption";
+import type { AgentCredentials } from "@/lib/cloudAgent/baseAgent";
+
+/**
+ * Ensure cloud_agent_credentials table exists.
+ * Should be replaced by a proper migration in db/migrations/.
+ */
+export function ensureCredentialsTable(): void {
+  const db = getDbInstance();
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS cloud_agent_credentials (
+      provider_id TEXT PRIMARY KEY,
+      api_key_encrypted TEXT NOT NULL,
+      base_url TEXT,
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    )
+  `);
+}
+
+/** Mask API key for display — show last 4 chars only */
+export function maskApiKey(key: string): string {
+  if (!key || key.length <= 4) return "****";
+  return "****" + key.slice(-4);
+}
+
+/** Get decrypted credentials for a provider */
+export function getCloudAgentCredentialFromDb(providerId: string): AgentCredentials | null {
+  ensureCredentialsTable();
+  const db = getDbInstance();
+  const row = db
+    .prepare(
+      "SELECT api_key_encrypted, base_url FROM cloud_agent_credentials WHERE provider_id = ?"
+    )
+    .get(providerId) as { api_key_encrypted: string; base_url: string | null } | undefined;
+
+  if (!row) return null;
+
+  const decryptedKey = decrypt(row.api_key_encrypted);
+  if (!decryptedKey) return null;
+
+  const creds: AgentCredentials = { apiKey: decryptedKey };
+  if (row.base_url) creds.baseUrl = row.base_url;
+  return creds;
+}
+
+/** List all credentials with masked keys */
+export function listCloudAgentCredentials(): Array<{
+  providerId: string;
+  apiKey: string;
+  baseUrl: string | null;
+  updatedAt: string;
+}> {
+  ensureCredentialsTable();
+  const db = getDbInstance();
+  const rows = db
+    .prepare(
+      "SELECT provider_id, api_key_encrypted, base_url, updated_at FROM cloud_agent_credentials"
+    )
+    .all() as {
+    provider_id: string;
+    api_key_encrypted: string;
+    base_url: string | null;
+    updated_at: string;
+  }[];
+
+  return rows.map((row) => {
+    const decrypted = decrypt(row.api_key_encrypted) ?? "";
+    return {
+      providerId: row.provider_id,
+      apiKey: maskApiKey(decrypted),
+      baseUrl: row.base_url,
+      updatedAt: row.updated_at,
+    };
+  });
+}
+
+/** Save or update credentials (encrypts API key at rest) */
+export function saveCloudAgentCredential(
+  providerId: string,
+  apiKey: string,
+  baseUrl?: string
+): void {
+  ensureCredentialsTable();
+  const encrypted = encrypt(apiKey);
+  if (!encrypted) throw new Error("Failed to encrypt API key");
+
+  const db = getDbInstance();
+  db.prepare(
+    `INSERT INTO cloud_agent_credentials (provider_id, api_key_encrypted, base_url, updated_at)
+     VALUES (@providerId, @apiKey, @baseUrl, datetime('now'))
+     ON CONFLICT(provider_id) DO UPDATE SET
+       api_key_encrypted = excluded.api_key_encrypted,
+       base_url = excluded.base_url,
+       updated_at = excluded.updated_at`
+  ).run({ providerId, apiKey: encrypted, baseUrl: baseUrl ?? null });
+}
+
+/** Delete credentials for a provider */
+export function deleteCloudAgentCredential(providerId: string): void {
+  ensureCredentialsTable();
+  const db = getDbInstance();
+  db.prepare("DELETE FROM cloud_agent_credentials WHERE provider_id = ?").run(providerId);
+}

--- a/src/lib/memory/settings.ts
+++ b/src/lib/memory/settings.ts
@@ -14,7 +14,7 @@ export const DEFAULT_MEMORY_SETTINGS: MemorySettings = {
   maxTokens: 2000,
   retentionDays: 30,
   strategy: "hybrid",
-  skillsEnabled: false,
+  skillsEnabled: true,
 };
 
 let cachedMemorySettings: MemorySettings | null = null;

--- a/src/lib/skills/providerSettings.ts
+++ b/src/lib/skills/providerSettings.ts
@@ -2,7 +2,7 @@ import { getSettings } from "@/lib/db/settings";
 
 export type SkillsProvider = "skillsmp" | "skillssh";
 
-export const DEFAULT_SKILLS_PROVIDER: SkillsProvider = "skillsmp";
+export const DEFAULT_SKILLS_PROVIDER: SkillsProvider = "skillssh";
 
 export function normalizeSkillsProvider(value: unknown): SkillsProvider {
   return value === "skillssh" || value === "skillsmp" ? value : DEFAULT_SKILLS_PROVIDER;

--- a/tests/unit/cloud-agent-credentials-api.test.ts
+++ b/tests/unit/cloud-agent-credentials-api.test.ts
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { z } from "zod";
+
+// ─── maskApiKey ───────────────────────────────────────
+// Exact replica of the function from
+// src/app/api/v1/agents/credentials/route.ts:31-34
+
+function maskApiKey(key: string): string {
+  if (key.length <= 4) return "****";
+  return "****" + key.slice(-4);
+}
+
+// ─── SaveCredentialSchema ─────────────────────────────
+// Exact replica of the schema from
+// src/app/api/v1/agents/credentials/route.ts:13-17
+
+const SaveCredentialSchema = z.object({
+  providerId: z.enum(["jules", "devin", "codex-cloud"]),
+  apiKey: z.string().min(1),
+  baseUrl: z.string().url().optional(),
+});
+
+describe("cloud-agent credentials API — maskApiKey", () => {
+  test('returns "****" for a 1-char key', () => {
+    assert.equal(maskApiKey("x"), "****");
+  });
+
+  test('returns "****" for exactly 4-char key', () => {
+    assert.equal(maskApiKey("abcd"), "****");
+  });
+
+  test('returns "****" for empty string', () => {
+    assert.equal(maskApiKey(""), "****");
+  });
+
+  test("shows last 4 chars for a longer key", () => {
+    assert.equal(maskApiKey("sk-1234567890"), "****7890");
+  });
+
+  test("shows last 4 chars for a 5-char key", () => {
+    assert.equal(maskApiKey("abcde"), "****bcde");
+  });
+
+  test("always starts with ****", () => {
+    const result = maskApiKey("very-long-api-key-here");
+    assert.ok(result.startsWith("****"));
+  });
+});
+
+describe("cloud-agent credentials API — SaveCredentialSchema validation", () => {
+  test("accepts valid body with all required fields", () => {
+    const result = SaveCredentialSchema.safeParse({
+      providerId: "jules",
+      apiKey: "my-secret-key",
+    });
+    assert.equal(result.success, true);
+    if (result.success) {
+      assert.equal(result.data.providerId, "jules");
+      assert.equal(result.data.apiKey, "my-secret-key");
+    }
+  });
+
+  test("accepts valid body with optional baseUrl", () => {
+    const result = SaveCredentialSchema.safeParse({
+      providerId: "devin",
+      apiKey: "key123",
+      baseUrl: "https://api.example.com",
+    });
+    assert.equal(result.success, true);
+    if (result.success) {
+      assert.equal(result.data.baseUrl, "https://api.example.com");
+    }
+  });
+
+  test("accepts all three valid providerIds", () => {
+    for (const id of ["jules", "devin", "codex-cloud"]) {
+      const result = SaveCredentialSchema.safeParse({ providerId: id, apiKey: "k" });
+      assert.equal(result.success, true, `Expected success for providerId="${id}"`);
+    }
+  });
+
+  test("rejects missing providerId", () => {
+    const result = SaveCredentialSchema.safeParse({ apiKey: "my-key" });
+    assert.equal(result.success, false);
+  });
+
+  test("rejects invalid providerId", () => {
+    const result = SaveCredentialSchema.safeParse({
+      providerId: "unknown-agent",
+      apiKey: "my-key",
+    });
+    assert.equal(result.success, false);
+  });
+
+  test("rejects empty apiKey", () => {
+    const result = SaveCredentialSchema.safeParse({
+      providerId: "jules",
+      apiKey: "",
+    });
+    assert.equal(result.success, false);
+  });
+
+  test("rejects missing apiKey", () => {
+    const result = SaveCredentialSchema.safeParse({ providerId: "jules" });
+    assert.equal(result.success, false);
+  });
+
+  test("rejects invalid baseUrl format", () => {
+    const result = SaveCredentialSchema.safeParse({
+      providerId: "jules",
+      apiKey: "key",
+      baseUrl: "not-a-url",
+    });
+    assert.equal(result.success, false);
+  });
+});

--- a/tests/unit/cloud-agent-health-api.test.ts
+++ b/tests/unit/cloud-agent-health-api.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { getAvailableAgents } from "../../src/lib/cloudAgent/registry.ts";
+
+describe("cloud-agent health API — getAvailableAgents", () => {
+  test("returns exactly three agents", () => {
+    const agents = getAvailableAgents();
+    assert.equal(agents.length, 3);
+  });
+
+  test('includes "jules"', () => {
+    assert.ok(getAvailableAgents().includes("jules"));
+  });
+
+  test('includes "devin"', () => {
+    assert.ok(getAvailableAgents().includes("devin"));
+  });
+
+  test('includes "codex-cloud"', () => {
+    assert.ok(getAvailableAgents().includes("codex-cloud"));
+  });
+
+  test("returns agents in expected order", () => {
+    assert.deepEqual(getAvailableAgents(), ["jules", "devin", "codex-cloud"]);
+  });
+});
+
+describe("cloud-agent health API — health check logic", () => {
+  // The route's checkProviderHealth returns { connected: false, error: "No credentials configured" }
+  // when getCredentialFromDb returns null. We test this logic pattern directly.
+
+  test("missing credentials produces connected: false with error message", () => {
+    // Simulate the logic from the route handler
+    const credentials = null; // getCredentialFromDb returns null
+    const result = {
+      id: "jules",
+      name: "Jules",
+      connected: credentials !== null,
+      latencyMs: 0,
+      error: credentials === null ? "No credentials configured" : undefined,
+    };
+
+    assert.equal(result.connected, false);
+    assert.equal(result.error, "No credentials configured");
+  });
+
+  test("unknown provider produces connected: false with Unknown provider error", () => {
+    // Simulate: getAgent returns null for unknown provider
+    const agent = null;
+    const result = {
+      id: "unknown",
+      name: "unknown",
+      connected: false,
+      latencyMs: 0,
+      error: agent === null ? "Unknown provider" : undefined,
+    };
+
+    assert.equal(result.connected, false);
+    assert.equal(result.error, "Unknown provider");
+  });
+
+  test("PROVIDER_NAMES maps agent ids to display names", () => {
+    const PROVIDER_NAMES: Record<string, string> = {
+      jules: "Jules",
+      devin: "Devin",
+      "codex-cloud": "Codex Cloud",
+    };
+
+    assert.equal(PROVIDER_NAMES["jules"], "Jules");
+    assert.equal(PROVIDER_NAMES["devin"], "Devin");
+    assert.equal(PROVIDER_NAMES["codex-cloud"], "Codex Cloud");
+    assert.equal(PROVIDER_NAMES["nonexistent"], undefined);
+  });
+});

--- a/tests/unit/memory-settings-default.test.ts
+++ b/tests/unit/memory-settings-default.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { DEFAULT_MEMORY_SETTINGS } from "../../src/lib/memory/settings.ts";
+
+describe("memory settings — DEFAULT_MEMORY_SETTINGS.skillsEnabled", () => {
+  test("skillsEnabled defaults to true", () => {
+    assert.equal(DEFAULT_MEMORY_SETTINGS.skillsEnabled, true);
+  });
+
+  test("enabled defaults to true", () => {
+    assert.equal(DEFAULT_MEMORY_SETTINGS.enabled, true);
+  });
+
+  test("maxTokens defaults to 2000", () => {
+    assert.equal(DEFAULT_MEMORY_SETTINGS.maxTokens, 2000);
+  });
+
+  test("retentionDays defaults to 30", () => {
+    assert.equal(DEFAULT_MEMORY_SETTINGS.retentionDays, 30);
+  });
+
+  test('strategy defaults to "hybrid"', () => {
+    assert.equal(DEFAULT_MEMORY_SETTINGS.strategy, "hybrid");
+  });
+});

--- a/tests/unit/memory-stats-api.test.ts
+++ b/tests/unit/memory-stats-api.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+
+// We import the pure function directly from the source module.
+// estimateTokens lives in src/lib/memory/retrieval.ts but the module
+// has heavy DB dependencies at the top level.  We replicate the pure
+// function here to test the exact algorithm used by the route handler.
+
+/**
+ * Exact replica of estimateTokens from src/lib/memory/retrieval.ts:34-37
+ * so the test does not pull in the full DB/SQLite dependency graph.
+ */
+function estimateTokens(text: string): number {
+  if (!text || typeof text !== "string") return 0;
+  return Math.ceil(text.length / 4);
+}
+
+describe("memory stats API — estimateTokens", () => {
+  test("returns 0 for empty string", () => {
+    assert.equal(estimateTokens(""), 0);
+  });
+
+  test("returns 0 for falsy/non-string input", () => {
+    assert.equal(estimateTokens(null as unknown as string), 0);
+    assert.equal(estimateTokens(undefined as unknown as string), 0);
+    assert.equal(estimateTokens(42 as unknown as string), 0);
+  });
+
+  test("returns 1 for a 1-char string", () => {
+    assert.equal(estimateTokens("a"), 1);
+  });
+
+  test("returns 1 for exactly 4 chars", () => {
+    assert.equal(estimateTokens("abcd"), 1);
+  });
+
+  test("returns 2 for 5 chars (ceiling division)", () => {
+    assert.equal(estimateTokens("abcde"), 2);
+  });
+
+  test("returns correct value for longer strings", () => {
+    // 100 chars -> ceil(100/4) = 25
+    assert.equal(estimateTokens("a".repeat(100)), 25);
+  });
+});
+
+describe("memory stats API — tokensUsed computation", () => {
+  test("sums estimateTokens across multiple content rows", () => {
+    const rows = [
+      { content: "hello" }, // 5 chars -> ceil(5/4) = 2
+      { content: "world!" }, // 6 chars -> ceil(6/4) = 2
+      { content: "ab" }, // 2 chars -> ceil(2/4) = 1
+    ];
+    const tokensUsed = rows.reduce((sum, r) => sum + estimateTokens(r.content), 0);
+    assert.equal(tokensUsed, 5);
+  });
+
+  test("returns 0 for empty rows array", () => {
+    const rows: { content: string }[] = [];
+    const tokensUsed = rows.reduce((sum, r) => sum + estimateTokens(r.content), 0);
+    assert.equal(tokensUsed, 0);
+  });
+});
+
+describe("memory stats API — hitRate computation", () => {
+  test("hitRate is 0 when no requests have been made", () => {
+    const cacheStats = { hits: 0, misses: 0 };
+    const total = cacheStats.hits + cacheStats.misses;
+    const hitRate = total > 0 ? cacheStats.hits / total : 0;
+    assert.equal(hitRate, 0);
+  });
+
+  test("hitRate is 1 when all requests are hits", () => {
+    const cacheStats = { hits: 10, misses: 0 };
+    const total = cacheStats.hits + cacheStats.misses;
+    const hitRate = total > 0 ? cacheStats.hits / total : 0;
+    assert.equal(hitRate, 1);
+  });
+
+  test("hitRate is 0.5 when hits equals misses", () => {
+    const cacheStats = { hits: 5, misses: 5 };
+    const total = cacheStats.hits + cacheStats.misses;
+    const hitRate = total > 0 ? cacheStats.hits / total : 0;
+    assert.equal(hitRate, 0.5);
+  });
+
+  test("hitRate computes correctly for arbitrary values", () => {
+    const cacheStats = { hits: 3, misses: 7 };
+    const total = cacheStats.hits + cacheStats.misses;
+    const hitRate = total > 0 ? cacheStats.hits / total : 0;
+    assert.equal(hitRate, 0.3);
+  });
+});

--- a/tests/unit/provider-settings-default.test.ts
+++ b/tests/unit/provider-settings-default.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import {
+  DEFAULT_SKILLS_PROVIDER,
+  normalizeSkillsProvider,
+} from "../../src/lib/skills/providerSettings.ts";
+
+describe("providerSettings — DEFAULT_SKILLS_PROVIDER", () => {
+  test('DEFAULT_SKILLS_PROVIDER is "skillssh"', () => {
+    assert.equal(DEFAULT_SKILLS_PROVIDER, "skillssh");
+  });
+});
+
+describe("providerSettings — normalizeSkillsProvider", () => {
+  test('returns "skillssh" when given "skillssh"', () => {
+    assert.equal(normalizeSkillsProvider("skillssh"), "skillssh");
+  });
+
+  test('returns "skillsmp" when given "skillsmp"', () => {
+    assert.equal(normalizeSkillsProvider("skillsmp"), "skillsmp");
+  });
+
+  test('returns default "skillssh" for unknown string', () => {
+    assert.equal(normalizeSkillsProvider("unknown"), "skillssh");
+  });
+
+  test('returns default "skillssh" for null', () => {
+    assert.equal(normalizeSkillsProvider(null), "skillssh");
+  });
+
+  test('returns default "skillssh" for undefined', () => {
+    assert.equal(normalizeSkillsProvider(undefined), "skillssh");
+  });
+
+  test('returns default "skillssh" for empty string', () => {
+    assert.equal(normalizeSkillsProvider(""), "skillssh");
+  });
+
+  test('returns default "skillssh" for numeric input', () => {
+    assert.equal(normalizeSkillsProvider(42), "skillssh");
+  });
+});


### PR DESCRIPTION
## Summary
- **Cloud agents page redesign**: 4-tab layout (Tasks/Agents/Credentials/Settings), task filtering, auto-polling, credential management with test connection, health checks
- **Skills fixes**: enabled by default, switched to skillssh (free) provider, added stats cards to dashboard
- **Memory stats API**: return real `tokensUsed` and `hitRate` (dashboard was always showing 0)
- **Docs packaging**: include `docs/` in npm package (fixes ENOENT on installed builds)
- **New API routes**: `/api/v1/agents/credentials` (GET/POST), `/api/v1/agents/health` (GET)
- **Unit tests**: 47 tests across 5 new test files

## Changes

| File | Change |
|------|--------|
| `src/app/api/memory/route.ts` | Added tokensUsed + hitRate to stats response |
| `src/lib/memory/settings.ts` | `skillsEnabled` default: false → true |
| `src/lib/skills/providerSettings.ts` | Default provider: skillsmp → skillssh |
| `package.json` | Added `docs/` to npm package files |
| `src/app/(dashboard)/dashboard/cloud-agents/page.tsx` | Complete redesign with 4 tabs |
| `src/app/(dashboard)/dashboard/skills/page.tsx` | Added stats cards (Total/Enabled/Executions/Success Rate) |
| `src/app/api/v1/agents/credentials/route.ts` | NEW: credential management API |
| `src/app/api/v1/agents/health/route.ts` | NEW: provider health check API |
| `tests/unit/memory-stats-api.test.ts` | NEW: 12 tests |
| `tests/unit/provider-settings-default.test.ts` | NEW: 8 tests |
| `tests/unit/memory-settings-default.test.ts` | NEW: 5 tests |
| `tests/unit/cloud-agent-credentials-api.test.ts` | NEW: 14 tests |
| `tests/unit/cloud-agent-health-api.test.ts` | NEW: 8 tests |

## Test plan
- [x] `npm run typecheck:core` — no new errors
- [x] 47 unit tests passing
- [x] Pre-commit hooks pass (prettier, eslint, t11 budget, docs sync, env contract)
- [ ] Manual: open cloud-agents page, verify all 4 tabs work
- [ ] Manual: open skills page, verify stats cards show
- [ ] Manual: check memory stats page shows real tokensUsed/hitRate

🤖 Generated with [OpenClaude](https://github.com/Gitlawb/openclaude)