### PR TITLE
fix(cost): prevent double-billing of cache_creation_input_tokens

### DIFF
--- a/src/lib/usage/costCalculator.ts
+++ b/src/lib/usage/costCalculator.ts
@@ -94,7 +94,12 @@ export function computeCostFromPricing(
   const inputTokens = tokens.input ?? tokens.prompt_tokens ?? tokens.input_tokens ?? 0;
   const cachedTokens =
     tokens.cacheRead ?? tokens.cached_tokens ?? tokens.cache_read_input_tokens ?? 0;
-  const nonCachedInput = Math.max(0, inputTokens - cachedTokens);
+  const cacheCreationTokens = tokens.cacheCreation ?? tokens.cache_creation_input_tokens ?? 0;
+
+  // prompt_tokens from extractors already includes cache_read + cache_creation,
+  // so we must subtract BOTH cache types to avoid pricing cache at the full
+  // input rate in addition to their dedicated cache_* rates below.
+  const nonCachedInput = Math.max(0, inputTokens - cachedTokens - cacheCreationTokens);
   cost += nonCachedInput * (inputPrice / 1_000_000);
   if (cachedTokens > 0) cost += cachedTokens * (cachedPrice / 1_000_000);
 
@@ -104,7 +109,6 @@ export function computeCostFromPricing(
   const reasoningTokens = tokens.reasoning ?? tokens.reasoning_tokens ?? 0;
   if (reasoningTokens > 0) cost += reasoningTokens * (reasoningPrice / 1_000_000);
 
-  const cacheCreationTokens = tokens.cacheCreation ?? tokens.cache_creation_input_tokens ?? 0;
   if (cacheCreationTokens > 0) cost += cacheCreationTokens * (cacheCreationPrice / 1_000_000);
 
   return cost * getCodexFastCostMultiplier(options.provider, options.model, options.serviceTier);


### PR DESCRIPTION
## Problem

`cache_creation_input_tokens` are billed at the full input token rate **in addition to** the dedicated `cacheCreationPrice` rate, resulting in systematic over-billing for every request that creates a prompt cache.

### Root cause

The usage extractors (`usageExtractor.ts` and `usageTracking.ts::extractUsage()`) set `prompt_tokens = inputTokens + cacheRead + cacheCreation` for Claude-format responses. However, `computeCostFromPricing()` in `costCalculator.ts` only subtracted `cachedTokens` from `inputTokens` before applying `inputPrice`:

```javascript
const nonCachedInput = inputTokens - cachedTokens;
// = inputTokens_nonCached + cacheCreation  ← cacheCreation still included!
cost += nonCachedInput * inputPrice;         // billed at full input rate
// ...
cost += cacheCreationTokens * cacheCreationPrice; // billed AGAIN at cache rate
```

This double-counts `cache_creation_input_tokens`: once implicitly through `inputPrice`, and once explicitly through `cacheCreationPrice`.

## Fix

Subtract both `cachedTokens` and `cacheCreationTokens` from `inputTokens` when computing `nonCachedInput`:

```javascript
const nonCachedInput = Math.max(0, inputTokens - cachedTokens - cacheCreationTokens);
```

Now:
- `nonCachedInput` = truly non-cached portion only → priced at `inputPrice` ✓
- `cacheRead` → priced at `cachedPrice` ✓
- `cacheCreation` → priced at `cacheCreationPrice` ✓

No double-counting.

## Verification

- `lsp_diagnostics`: 0 errors
- `tests/unit/usage-analytics.test.ts`: 11/11 pass (the cost aggregation test uses the same `calculateCost` code path for both expected and actual values, so the fix is self-consistent)
- No regression: the `{ input, cacheRead, cacheCreation }` storage format already includes `cacheCreation` in `input` (via `getLoggedInputTokens`), so the subtraction correctly extracts it.

Fixes #2215