### PR TITLE
fix(freetheai): add /chat/completions to baseUrl to resolve 404 errors

### DIFF
--- a/open-sse/config/providerRegistry.ts
+++ b/open-sse/config/providerRegistry.ts
@@ -2125,7 +2125,7 @@ export const REGISTRY: Record<string, RegistryEntry> = {
     alias: "fta",
     format: "openai",
     executor: "default",
-    baseUrl: "https://api.freetheai.xyz/v1",
+    baseUrl: "https://api.freetheai.xyz/v1/chat/completions",
     authType: "apikey",
     authHeader: "bearer",
     models: [


### PR DESCRIPTION
## Summary

- FreeTheAI provider was returning 404 on all chat requests because `baseUrl` in `providerRegistry.ts` was set to `https://api.freetheai.xyz/v1` (missing `/chat/completions` path).
- The `DefaultExecutor.buildUrl()` default case returns `this.config.baseUrl` directly for providers without a `urlSuffix` or special case — so requests went to the API root instead of the chat completions endpoint.
- Fixed by changing `baseUrl` to `https://api.freetheai.xyz/v1/chat/completions`, following the convention used by 60+ other OpenAI-compatible providers in the registry.

## Root Cause

`DefaultExecutor.buildUrl()` at `open-sse/executors/default.ts:234-238`:
```ts
default: {
  const url = this.config.baseUrl;
  const entry = getRegistryEntry(this.provider);
  return entry?.urlSuffix ? `${url}${entry.urlSuffix}` : url;
}
```

FreeTheAI had no `urlSuffix` and `baseUrl` only included `/v1`, so the final URL was `https://api.freetheai.xyz/v1` → 404.

## Verification

```bash
# Endpoint exists but needs valid API key
curl -s https://api.freetheai.xyz/v1/chat/completions -H "Authorization: Bearer test" -d '{"model":"bbl/gpt-4.1",...}'  # → 401 (valid endpoint)
```