### PR TITLE
fix(codex): relax auth_mode check in frontend import preview

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/[id]/page.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.tsx
@@ -7614,7 +7614,15 @@ function extractEmailFromJwtLocal(idToken: string): string | null {
 function previewCodexJson(json: unknown): { valid: boolean; email: string | null } {
   try {
     const doc = json && typeof json === "object" ? (json as Record<string, unknown>) : null;
-    if (!doc || doc.auth_mode !== "chatgpt") return { valid: false, email: null };
+    // Codex CLI no longer writes auth_mode — accept both with and without it.
+    // Only reject when auth_mode is explicitly set to something other than "chatgpt".
+    if (
+      !doc ||
+      (doc.auth_mode !== undefined &&
+        doc.auth_mode !== null &&
+        doc.auth_mode !== "chatgpt")
+    )
+      return { valid: false, email: null };
     const tokens =
       doc.tokens && typeof doc.tokens === "object" ? (doc.tokens as Record<string, unknown>) : null;
     if (!tokens?.id_token || typeof tokens.id_token !== "string")


### PR DESCRIPTION
## Summary

Follow-up to PR #2536 (backend fix, already merged).

The backend was fixed to accept auth.json files without the auth_mode field, but the **frontend preview validation** (previewCodexJson() in page.tsx) still enforced uth_mode === 'chatgpt' strictly. This blocked the import UI before the request even reached the API.

This PR applies the same relaxation to the frontend: accept files where auth_mode is absent/undefined/null, only reject when auth_mode is explicitly set to a non-chatgpt value.

## Test plan

- [ ] Import a Codex CLI-generated auth.json (no auth_mode field) via the UI -- should now show detected email and allow import
- [ ] Import an OmniRoute-exported auth.json (with auth_mode: chatgpt) -- should still work
- [ ] Import a file with auth_mode: something_else -- should still be rejected