### PR TITLE
feat(@omniroute/opencode-plugin): readable + filterable + offline-resilient model picker (Combo: prefix, usableOnly, diskCache, eager enrichment)

### DIFF
--- a/@omniroute/opencode-plugin/README.md
+++ b/@omniroute/opencode-plugin/README.md
@@ -119,16 +119,20 @@ npm install --prefix ~/.config/opencode/plugins/omniroute-opencode-plugin-prepro
 
 ## Features
 
-| Feature                               | What it does                                                                                      | Hook                     |
-| ------------------------------------- | ------------------------------------------------------------------------------------------------- | ------------------------ |
-| Dynamic `/v1/models`                  | Pulls live catalog (455+ entries on prod) on each refresh, TTL-cached                             | `provider.models`        |
-| Variants pass-through                 | `-low`/`-medium`/`-high`/`-thinking` ship as first-class IDs from OmniRoute (no client synthesis) | `provider.models`        |
-| Combo LCD aggregation                 | Combos appear with intersected capabilities + min context/output across members                   | `provider.models`        |
-| Nice names                            | `combo.name` / `model.id` surfaces as `ModelV2.name`                                              | `provider.models`        |
-| Bearer injection + suffix-spoof guard | Adds `Authorization` on baseURL-matched requests only                                             | `auth.loader.fetch`      |
-| Gemini schema sanitization            | Strips `$schema`/`$ref`/`additionalProperties` for `gemini-*`/`google-vertex-gemini/*`            | `auth.loader.fetch` wrap |
-| Multi-instance                        | Each plugin entry binds to its own `providerId`; closures isolated                                | factory                  |
-| Config-hook shim                      | OC ≤1.14.48 fallback: writes static catalog into `config.provider[id]`                            | `config`                 |
+| Feature                                     | What it does                                                                                                                                                       | Hook                         |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------- |
+| Dynamic `/v1/models`                        | Pulls live catalog (455+ entries on prod) on each refresh, TTL-cached                                                                                              | `provider.models`            |
+| Variants pass-through                       | `-low`/`-medium`/`-high`/`-thinking` ship as first-class IDs from OmniRoute (no client synthesis)                                                                  | `provider.models`            |
+| Combo LCD aggregation                       | Combos appear with intersected capabilities + min context/output across members                                                                                    | `provider.models` + `config` |
+| `combo/<slug>` namespace + `Combo: ` prefix | Combos surface under `combo/claude-primary` (not the upstream UUID) and the picker shows `Combo: claude-primary` so they stand apart from raw provider/model pairs | both hooks                   |
+| Nice names + cost                           | `/api/pricing/models` display names AND `/api/pricing` per-million-token cost overlaid onto the live catalog                                                       | both hooks                   |
+| Compression pipeline tags                   | Combo names get tagged with their compression pipeline (e.g. `Combo: claude-primary [rtk:standard → caveman:full]`) when `features.compressionMetadata: true`      | both hooks                   |
+| Usable-only filter                          | Filter to providers with at least one healthy connection in `/api/providers` (opt-in via `features.usableOnly`)                                                    | both hooks                   |
+| Disk-cache fallback                         | Last-known-good catalog persisted to disk; hydrates on a cold start when `/v1/models` is unreachable (default-on, opt-out via `features.diskCache: false`)         | `config`                     |
+| Bearer injection + suffix-spoof guard       | Adds `Authorization` on baseURL-matched requests only                                                                                                              | `auth.loader.fetch`          |
+| Gemini schema sanitization                  | Strips `$schema`/`$ref`/`additionalProperties` for `gemini-*`/`google-vertex-gemini/*`                                                                             | `auth.loader.fetch` wrap     |
+| Multi-instance                              | Each plugin entry binds to its own `providerId`; closures isolated                                                                                                 | factory                      |
+| Config-hook shim                            | OC ≤1.15.5 fallback: writes static catalog into `config.provider[id]` (config hook is the only one that fires in `serve` mode on these versions)                   | `config`                     |
 
 ## Plugin options
 
@@ -144,15 +148,17 @@ npm install --prefix ~/.config/opencode/plugins/omniroute-opencode-plugin-prepro
 
 Every field is optional. Defaults mirror v0.1.0 behaviour so existing `opencode.json` files do not need to change.
 
-| Feature               | Type      | Default | What it does                                                                                                                                                                                                                                                                                                                          |
-| --------------------- | --------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `combos`              | `boolean` | `true`  | Discover `/api/combos` and surface them as pseudo-models with LCD capabilities                                                                                                                                                                                                                                                        |
-| `enrichment`          | `boolean` | `true`  | Pull display names from `/api/pricing/models` AND per-million-token pricing (`input`, `output`, `cached` → `cacheRead`, `cache_creation` → `cacheWrite`) from `/api/pricing`, then overlay both onto the live catalog (so the UI shows `Claude 4.7 Opus` with `cost.input: 5`, `cost.output: 25` instead of raw IDs and zeroed cost). |
-| `compressionMetadata` | `boolean` | `false` | Pull `/api/context/combos` so combo names get tagged with their compression pipeline, e.g. `claude-primary [rtk:standard → caveman:full]`                                                                                                                                                                                             |
-| `geminiSanitization`  | `boolean` | `true`  | Strip `$schema`/`$ref`/`additionalProperties` from tool params when the model id matches `gemini`                                                                                                                                                                                                                                     |
-| `mcpAutoEmit`         | `boolean` | `false` | Auto-write an `mcp.<providerId>` remote entry into the OC config pointing at `<baseURL>/api/mcp/stream` with the resolved Bearer token                                                                                                                                                                                                |
-| `mcpToken`            | `string`  | _unset_ | Optional separate Bearer for the auto-emitted MCP entry. Falls back to the provider's `apiKey` (from `auth.json`) when unset                                                                                                                                                                                                          |
-| `fetchInterceptor`    | `boolean` | `true`  | Inject `Authorization: Bearer` + default `Content-Type` on every outbound request targeting `baseURL` (suffix-spoof guarded)                                                                                                                                                                                                          |
+| Feature               | Type      | Default | What it does                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| --------------------- | --------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `combos`              | `boolean` | `true`  | Discover `/api/combos` and surface them as pseudo-models with LCD capabilities. Combos are keyed under the `combo/<slug>` namespace and labelled `Combo: <name>` in the model picker so they're distinguishable from raw provider/model pairs.                                                                                                                                                                                           |
+| `enrichment`          | `boolean` | `true`  | Pull display names from `/api/pricing/models` AND per-million-token pricing (`input`, `output`, `cached` → `cacheRead`, `cache_creation` → `cacheWrite`) from `/api/pricing`, then overlay both onto the live catalog (so the UI shows `Claude 4.7 Opus` with `cost.input: 5`, `cost.output: 25` instead of raw IDs and zeroed cost).                                                                                                    |
+| `compressionMetadata` | `boolean` | `false` | Pull `/api/context/combos` so combo names get tagged with their compression pipeline, e.g. `Combo: claude-primary [rtk:standard → caveman:full]`                                                                                                                                                                                                                                                                                         |
+| `usableOnly`          | `boolean` | `false` | Read `/api/providers` and filter the catalog to providers that have at least one connection with `isActive: true` AND `testStatus: 'active'`. Subtract-filter semantics: providers unknown to BOTH the pricing-models catalog AND the connection table pass through (so synthetic prefixes like `agentrouter/*` survive). On fetch failure the filter is disabled for the refresh — never hides the whole catalog.                       |
+| `diskCache`           | `boolean` | `true`  | Persist the last successful `/v1/models` + `/api/combos` + enrichment + connections + compression snapshot to `${OPENCODE_DATA_DIR ?? ~/.local/share/opencode}/plugins/omniroute-<providerId>.json`. On a subsequent cold start where `/v1/models` throws (network down / IP whitelist drop / 5xx) the static block hydrates from the snapshot so OC's model picker survives offline. Soft-fail on read/write — never blocks publishing. |
+| `geminiSanitization`  | `boolean` | `true`  | Strip `$schema`/`$ref`/`additionalProperties` from tool params when the model id matches `gemini`                                                                                                                                                                                                                                                                                                                                        |
+| `mcpAutoEmit`         | `boolean` | `false` | Auto-write an `mcp.<providerId>` remote entry into the OC config pointing at `<baseURL>/api/mcp/stream` with the resolved Bearer token                                                                                                                                                                                                                                                                                                   |
+| `mcpToken`            | `string`  | _unset_ | Optional separate Bearer for the auto-emitted MCP entry. Falls back to the provider's `apiKey` (from `auth.json`) when unset                                                                                                                                                                                                                                                                                                             |
+| `fetchInterceptor`    | `boolean` | `true`  | Inject `Authorization: Bearer` + default `Content-Type` on every outbound request targeting `baseURL` (suffix-spoof guarded)                                                                                                                                                                                                                                                                                                             |
 
 #### Example — enrichment + compression tags + MCP auto-emit
 
@@ -190,6 +196,33 @@ With `mcpAutoEmit: true`, the plugin synthesises an `mcp.omniroute` entry equiva
 ```
 
 If you want a narrower-scoped Bearer for MCP (different from the chat/inference key), set `features.mcpToken`. Operator overrides win: if you already set `mcp.omniroute` in `opencode.json`, the plugin will not overwrite it.
+
+#### Example — production-leaning defaults (clean picker, offline resilience)
+
+```jsonc
+{
+  "plugin": [
+    [
+      "@omniroute/opencode-plugin",
+      {
+        "providerId": "omniroute",
+        "baseURL": "https://or.example.com",
+        "features": {
+          "combos": true,
+          "enrichment": true,
+          "compressionMetadata": true,
+          "usableOnly": true,
+          "diskCache": true,
+        },
+      },
+    ],
+  ],
+}
+```
+
+- `usableOnly: true` drops models whose canonical provider has no healthy connection in your OmniRoute instance — your `/models` picker stays focused on what you can actually call.
+- `diskCache: true` (default) writes a snapshot to `${OPENCODE_DATA_DIR}/plugins/omniroute-<providerId>.json` on every healthy refresh. On a cold start where `/v1/models` is unreachable (laptop offline, IP whitelist drop), the snapshot hydrates the static block so OC still shows the catalog instead of a stub.
+- `compressionMetadata: true` annotates combo display names with their pipeline (e.g. `Combo: claude-primary [rtk:standard → caveman:full]`) so the picker advertises which compression each combo applies.
 
 ## Comparison vs `@omniroute/opencode-provider`
 

--- a/@omniroute/opencode-plugin/src/index.ts
+++ b/@omniroute/opencode-plugin/src/index.ts
@@ -1295,7 +1295,7 @@ export const defaultOmniRouteProvidersFetcher: OmniRouteProvidersFetcher = async
 export function usableProviderAliasSet(
   connections: OmniRouteProviderConnection[],
   enrichment: OmniRouteEnrichmentMap | undefined
-): { aliases: Set<string>; canonicals: Set<string> } {
+): { aliases: Set<string>; canonicals: Set<string>; knownAliases: Set<string> } {
   const usableCanonicals = new Set<string>();
   for (const c of connections) {
     if (!c || c.isActive !== true) continue;
@@ -1305,15 +1305,19 @@ export function usableProviderAliasSet(
     }
   }
   const aliases = new Set<string>();
+  const knownAliases = new Set<string>();
   if (enrichment) {
     // Walk enrichment entries to map alias → canonical via the metadata
     // populated by `defaultOmniRouteEnrichmentFetcher`. Every entry carries
     // its providerAlias + providerCanonical so the namespaced/bare key
-    // duplication is harmless.
+    // duplication is harmless. Collect EVERY alias we encounter (regardless
+    // of usability) into `knownAliases` so the downstream filter can decide
+    // "this prefix was in /api/pricing/models" in O(1) instead of O(E).
     for (const entry of enrichment.values()) {
       const alias = entry.providerAlias;
       const canonical = entry.providerCanonical;
       if (typeof alias !== "string" || alias.length === 0) continue;
+      knownAliases.add(alias);
       if (typeof canonical !== "string" || canonical.length === 0) continue;
       if (usableCanonicals.has(canonical)) aliases.add(alias);
     }
@@ -1322,7 +1326,7 @@ export function usableProviderAliasSet(
   // common case where `/v1/models` ids use the canonical id directly
   // (e.g. `gemini-cli/gemini-1.5-pro`).
   for (const canonical of usableCanonicals) aliases.add(canonical);
-  return { aliases, canonicals: usableCanonicals };
+  return { aliases, canonicals: usableCanonicals, knownAliases };
 }
 
 /**
@@ -1340,22 +1344,18 @@ export function usableProviderAliasSet(
  */
 export function isUsableRawModelId(
   id: string,
-  usable: { aliases: Set<string>; canonicals: Set<string> },
+  usable: { aliases: Set<string>; canonicals: Set<string>; knownAliases: Set<string> },
   enrichment: OmniRouteEnrichmentMap | undefined
 ): boolean {
   const slash = id.indexOf("/");
   if (slash <= 0) return true;
   const prefix = id.slice(0, slash);
   if (usable.aliases.has(prefix) || usable.canonicals.has(prefix)) return true;
-  if (!enrichment) return true;
-  // Walk enrichment keys to detect whether this prefix is "known". If we've
-  // seen it as a namespaced key elsewhere, it WAS in /api/pricing/models
-  // and therefore should have appeared in /api/providers too — drop it.
-  for (const key of enrichment.keys()) {
-    const s = key.indexOf("/");
-    if (s <= 0) continue;
-    if (key.slice(0, s) === prefix) return false;
-  }
+  // O(1) "known prefix" check via pre-calculated knownAliases set.
+  // If prefix was in /api/pricing/models but is NOT in usable set,
+  // drop the model. Unknown prefixes (e.g. agentrouter-style synthetic)
+  // pass through (subtract-filter semantics).
+  if (usable.knownAliases.has(prefix)) return false;
   return true;
 }
 
@@ -1367,7 +1367,7 @@ export function isUsableRawModelId(
  */
 export function isUsableCombo(
   combo: OmniRouteRawCombo,
-  usable: { aliases: Set<string>; canonicals: Set<string> }
+  usable: { aliases: Set<string>; canonicals: Set<string>; knownAliases: Set<string> }
 ): boolean {
   const steps = Array.isArray(combo.models) ? combo.models : [];
   if (steps.length === 0) return true;

--- a/@omniroute/opencode-plugin/src/index.ts
+++ b/@omniroute/opencode-plugin/src/index.ts
@@ -46,7 +46,7 @@
  */
 
 import { createHash } from "node:crypto";
-import { readFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { AuthHook, Config, Plugin, PluginOptions, ProviderHook } from "@opencode-ai/plugin";
@@ -117,6 +117,8 @@ const featuresSchema = z
     mcpAutoEmit: z.boolean().optional(),
     mcpToken: z.string().min(1).optional(),
     fetchInterceptor: z.boolean().optional(),
+    usableOnly: z.boolean().optional(),
+    diskCache: z.boolean().optional(),
   })
   .strict();
 
@@ -877,6 +879,19 @@ export interface OmniRouteEnrichmentEntry {
     cacheRead?: number;
     cacheWrite?: number;
   };
+  /**
+   * Provider alias prefix seen in `/v1/models` ids (e.g. `cc`, `gemini-cli`).
+   * Populated by `defaultOmniRouteEnrichmentFetcher` from
+   * `/api/pricing/models` keys. Drives the `usableOnly` alias↔canonical
+   * resolution.
+   */
+  providerAlias?: string;
+  /**
+   * Canonical provider id used by `/api/providers` connections (e.g.
+   * `claude`, `gemini-cli`, `kiro`). Populated from the per-provider
+   * `entry.id` field inside `/api/pricing/models`.
+   */
+  providerCanonical?: string;
 }
 
 /** Map keyed by full model id (possibly namespaced, e.g. `cc/claude-sonnet-4-6`). */
@@ -941,12 +956,23 @@ export const defaultOmniRouteEnrichmentFetcher: OmniRouteEnrichmentFetcher = asy
           if (!slot || typeof slot !== "object") continue;
           const models = (slot as { models?: unknown[] }).models;
           if (!Array.isArray(models)) continue;
+          // Canonical id sits at the per-provider top level (e.g.
+          // `pricing-models.cc.id === 'claude'`). Falls back to the alias
+          // itself when missing — common case alias===canonical.
+          const canonicalRaw = (slot as { id?: unknown }).id;
+          const providerCanonical =
+            typeof canonicalRaw === "string" && canonicalRaw.length > 0
+              ? canonicalRaw
+              : providerAlias;
           for (const m of models) {
             if (!m || typeof m !== "object") continue;
             const id = (m as { id?: unknown }).id;
             if (typeof id !== "string" || id.length === 0) continue;
             const name = (m as { name?: unknown }).name;
-            const entry: OmniRouteEnrichmentEntry = {};
+            const entry: OmniRouteEnrichmentEntry = {
+              providerAlias,
+              providerCanonical,
+            };
             if (typeof name === "string" && name.trim().length > 0) entry.name = name;
             const namespaced = `${providerAlias}/${id}`;
             if (!out.has(namespaced)) out.set(namespaced, entry);
@@ -1161,6 +1187,202 @@ export function formatCompressionPipeline(pipeline: OmniRouteCompressionStep[]):
   );
 }
 
+// ─────────────────────────────────────────────────────────────────────────
+// /api/providers (provider-connection status) — optional read used by the
+// `features.usableOnly` filter. Returns the operator's installed OmniRoute
+// provider connections, each with `provider` (canonical id), `isActive`,
+// `testStatus`. We treat a provider as USABLE when at least one of its
+// connections is `isActive: true && testStatus: 'active'`. Aliases (e.g.
+// `cc → claude`) are resolved through the enrichment map.
+// ─────────────────────────────────────────────────────────────────────────
+
+/** Subset of `/api/providers/connections[]` we read. Other fields are kept as a permissive index signature. */
+export interface OmniRouteProviderConnection {
+  /** Connection UUID. */
+  id: string;
+  /** Canonical provider id, e.g. `claude`, `gemini-cli`, `kiro`. Matches `entry.id` in `/api/pricing/models`. */
+  provider: string;
+  /** Connection auth flavor, e.g. `apikey`, `oauth`, `cookie`. */
+  authType?: string;
+  /** Operator-visible label. */
+  name?: string;
+  /** Operator toggle — when false, the connection is provisioned but disabled. */
+  isActive?: boolean;
+  /** Health-check verdict — `active` means routable; `expired`/`error`/`unavailable` mean not. */
+  testStatus?: string;
+  /** Permissive bag — additional fields (priority, backoffLevel, etc.) pass through untouched. */
+  [k: string]: unknown;
+}
+
+export type OmniRouteProvidersFetcher = (
+  baseURL: string,
+  apiKey: string,
+  timeoutMs?: number
+) => Promise<OmniRouteProviderConnection[]>;
+
+/**
+ * Default providers fetcher — calls `GET /api/providers`. Tolerates envelope
+ * shapes `{ connections: [...] }`, `[...]`, or `{ data: [...] }`. Soft-fails
+ * (returns []) on non-2xx or parse errors so the `usableOnly` filter
+ * gracefully degrades to "no filter" instead of hiding the whole catalog.
+ */
+export const defaultOmniRouteProvidersFetcher: OmniRouteProvidersFetcher = async (
+  baseURL,
+  apiKey,
+  timeoutMs = 10_000
+) => {
+  const empty: OmniRouteProviderConnection[] = [];
+  if (!baseURL || !apiKey) return empty;
+  const root = baseURL.replace(/\/v1\/?$/, "").replace(/\/$/, "");
+  const url = `${root}/api/providers`;
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        Accept: "application/json",
+      },
+      signal: ac.signal,
+    });
+    if (!res.ok) return empty;
+    const body = (await res.json()) as unknown;
+    const list = Array.isArray(body)
+      ? body
+      : Array.isArray((body as { connections?: unknown[] })?.connections)
+        ? (body as { connections: unknown[] }).connections
+        : Array.isArray((body as { data?: unknown[] })?.data)
+          ? (body as { data: unknown[] }).data
+          : [];
+    const out: OmniRouteProviderConnection[] = [];
+    for (const raw of list) {
+      if (!raw || typeof raw !== "object") continue;
+      const provider = (raw as { provider?: unknown }).provider;
+      if (typeof provider !== "string" || provider.length === 0) continue;
+      const id = (raw as { id?: unknown }).id;
+      const idStr = typeof id === "string" && id.length > 0 ? id : provider;
+      out.push({ ...(raw as Record<string, unknown>), id: idStr, provider });
+    }
+    return out;
+  } catch {
+    return empty;
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+/**
+ * Compute the set of provider aliases that have at least one healthy,
+ * active connection. Resolves alias → canonical id through the enrichment
+ * map (which is keyed under both `${alias}/${id}` and bare `${id}` — we
+ * walk only the namespaced keys to derive the alias↔canonical mapping).
+ *
+ * Returns:
+ *   - `aliases`: set of alias prefixes safe to keep (e.g. `cc`, `gemini-cli`).
+ *   - `canonicals`: set of canonical provider ids (e.g. `claude`, `kiro`).
+ *
+ * Callers should treat membership in EITHER set as "usable" — raw model
+ * ids may be `<alias>/<model>` (`cc/claude-opus-4-7`) OR `<canonical>/<model>`
+ * (`claude/sonnet-4`) depending on the OmniRoute deployment's `/v1/models`
+ * surface shape.
+ *
+ * Subtract-filter semantics: callers MUST also keep models whose prefix is
+ * unknown to BOTH `/api/pricing/models` and `/api/providers` (e.g.
+ * agentrouter-style synthetic prefixes). The right boolean is "if I see this
+ * prefix in EITHER catalog table AND it's not usable, drop; otherwise keep".
+ */
+export function usableProviderAliasSet(
+  connections: OmniRouteProviderConnection[],
+  enrichment: OmniRouteEnrichmentMap | undefined
+): { aliases: Set<string>; canonicals: Set<string> } {
+  const usableCanonicals = new Set<string>();
+  for (const c of connections) {
+    if (!c || c.isActive !== true) continue;
+    if (typeof c.testStatus === "string" && c.testStatus !== "active") continue;
+    if (typeof c.provider === "string" && c.provider.length > 0) {
+      usableCanonicals.add(c.provider);
+    }
+  }
+  const aliases = new Set<string>();
+  if (enrichment) {
+    // Walk enrichment entries to map alias → canonical via the metadata
+    // populated by `defaultOmniRouteEnrichmentFetcher`. Every entry carries
+    // its providerAlias + providerCanonical so the namespaced/bare key
+    // duplication is harmless.
+    for (const entry of enrichment.values()) {
+      const alias = entry.providerAlias;
+      const canonical = entry.providerCanonical;
+      if (typeof alias !== "string" || alias.length === 0) continue;
+      if (typeof canonical !== "string" || canonical.length === 0) continue;
+      if (usableCanonicals.has(canonical)) aliases.add(alias);
+    }
+  }
+  // Always include every usable canonical as an alias too — handles the
+  // common case where `/v1/models` ids use the canonical id directly
+  // (e.g. `gemini-cli/gemini-1.5-pro`).
+  for (const canonical of usableCanonicals) aliases.add(canonical);
+  return { aliases, canonicals: usableCanonicals };
+}
+
+/**
+ * Decide whether a raw `/v1/models` id passes the `usableOnly` filter.
+ *
+ * Rules (subtract-filter — bias toward keep):
+ *   - id has no `/` → keep (combos/synthetic entries handled separately).
+ *   - prefix matches a known usable alias OR canonical → keep.
+ *   - prefix is unknown to BOTH the connection table AND the enrichment
+ *     map → keep (we can't prove it's NOT usable; could be agentrouter).
+ *   - prefix is known to the enrichment map BUT not in usable set → drop.
+ *
+ * Pure function — exported so static + dynamic hooks share the same
+ * verdict logic without divergence.
+ */
+export function isUsableRawModelId(
+  id: string,
+  usable: { aliases: Set<string>; canonicals: Set<string> },
+  enrichment: OmniRouteEnrichmentMap | undefined
+): boolean {
+  const slash = id.indexOf("/");
+  if (slash <= 0) return true;
+  const prefix = id.slice(0, slash);
+  if (usable.aliases.has(prefix) || usable.canonicals.has(prefix)) return true;
+  if (!enrichment) return true;
+  // Walk enrichment keys to detect whether this prefix is "known". If we've
+  // seen it as a namespaced key elsewhere, it WAS in /api/pricing/models
+  // and therefore should have appeared in /api/providers too — drop it.
+  for (const key of enrichment.keys()) {
+    const s = key.indexOf("/");
+    if (s <= 0) continue;
+    if (key.slice(0, s) === prefix) return false;
+  }
+  return true;
+}
+
+/**
+ * Decide whether a combo passes the `usableOnly` filter. A combo keeps
+ * when AT LEAST ONE of its members maps to a usable canonical provider.
+ * Combos with zero resolvable members pass through (already degraded to
+ * all-false LCD posture and surfaced as cosmetic-only entries).
+ */
+export function isUsableCombo(
+  combo: OmniRouteRawCombo,
+  usable: { aliases: Set<string>; canonicals: Set<string> }
+): boolean {
+  const steps = Array.isArray(combo.models) ? combo.models : [];
+  if (steps.length === 0) return true;
+  let sawKnownProvider = false;
+  for (const step of steps) {
+    const pid = (step as unknown as { providerId?: unknown }).providerId;
+    if (typeof pid !== "string" || pid.length === 0) continue;
+    sawKnownProvider = true;
+    if (usable.canonicals.has(pid) || usable.aliases.has(pid)) return true;
+  }
+  // No member declared a providerId → can't prove unroutable; keep.
+  if (!sawKnownProvider) return true;
+  return false;
+}
+
 /**
  * Slugify a combo display name into a copy/paste-friendly URL-safe segment.
  * Lowercases, replaces any run of non-alphanumeric chars with a single dash,
@@ -1242,6 +1464,8 @@ export interface OmniRouteFetchCacheEntry {
   rawEnrichment: OmniRouteEnrichmentMap;
   /** Compression combos from /api/context/combos. Empty array when feature is disabled or fetch failed. */
   rawCompressionCombos: OmniRouteCompressionCombo[];
+  /** Provider connections from /api/providers. Empty array when feature is disabled or fetch failed. */
+  rawConnections: OmniRouteProviderConnection[];
   expiresAt: number;
 }
 
@@ -1298,6 +1522,7 @@ export function createOmniRouteProviderHook(
     combosFetcher?: OmniRouteCombosFetcher;
     enrichmentFetcher?: OmniRouteEnrichmentFetcher;
     compressionMetaFetcher?: OmniRouteCompressionMetaFetcher;
+    providersFetcher?: OmniRouteProvidersFetcher;
     now?: () => number;
     cache?: OmniRouteFetchCache;
   } = {}
@@ -1312,11 +1537,13 @@ export function createOmniRouteProviderHook(
   const enrichmentFetcher = deps.enrichmentFetcher ?? defaultOmniRouteEnrichmentFetcher;
   const compressionMetaFetcher =
     deps.compressionMetaFetcher ?? defaultOmniRouteCompressionMetaFetcher;
+  const providersFetcher = deps.providersFetcher ?? defaultOmniRouteProvidersFetcher;
   // Features defaults (mirror v0.1.0 behavior when unset).
   const features = resolved.features ?? {};
   const wantCombos = features.combos !== false;
   const wantEnrichment = features.enrichment !== false;
   const wantCompressionMeta = features.compressionMetadata === true;
+  const wantUsableOnly = features.usableOnly === true;
   const now = deps.now ?? Date.now;
   // T-07: cache holds RAW fetch results (not pre-derived ModelV2) so that
   // the config-shim hook can share the same cache and derive its stripped
@@ -1366,11 +1593,13 @@ export function createOmniRouteProviderHook(
       let rawCombos: OmniRouteRawCombo[];
       let rawEnrichment: OmniRouteEnrichmentMap;
       let rawCompressionCombos: OmniRouteCompressionCombo[];
+      let rawConnections: OmniRouteProviderConnection[];
       if (cached && cached.expiresAt > t) {
         rawModels = cached.rawModels;
         rawCombos = cached.rawCombos;
         rawEnrichment = cached.rawEnrichment;
         rawCompressionCombos = cached.rawCompressionCombos;
+        rawConnections = cached.rawConnections;
       } else {
         // Models fetch is required (no catalog otherwise → silent provider
         // disappearance). We do NOT wrap this in a try; let the error
@@ -1420,11 +1649,29 @@ export function createOmniRouteProviderHook(
           }
         }
 
+        // Provider-connections fetch. Off by default, gated by
+        // features.usableOnly. Soft-fails to empty array — when the
+        // connection table is unreadable we skip the filter entirely
+        // (subtract-filter semantics: don't drop everything we couldn't
+        // verify).
+        rawConnections = [];
+        if (wantUsableOnly) {
+          try {
+            rawConnections = await providersFetcher(baseURL, apiKey, 10_000);
+          } catch (err) {
+            console.warn(
+              "[omniroute-plugin] /api/providers fetch failed; usableOnly filter disabled for this refresh",
+              err
+            );
+          }
+        }
+
         cache.set(cacheKey, {
           rawModels,
           rawCombos,
           rawEnrichment,
           rawCompressionCombos,
+          rawConnections,
           expiresAt: t + resolved.modelCacheTtl,
         });
 
@@ -1435,7 +1682,8 @@ export function createOmniRouteProviderHook(
           `[omniroute-plugin] catalog refreshed for providerId=${resolved.providerId} baseURL=${baseURL}: ` +
             `${rawModels.length} models + ${rawCombos.length} combos + ` +
             `${rawEnrichment.size} enrichment entries + ` +
-            `${rawCompressionCombos.length} compression combos ` +
+            `${rawCompressionCombos.length} compression combos + ` +
+            `${rawConnections.length} connections ` +
             `(TTL=${resolved.modelCacheTtl}ms)`
         );
       }
@@ -1448,6 +1696,16 @@ export function createOmniRouteProviderHook(
         if (entry.id) rawModelById.set(entry.id, entry);
       }
 
+      // usableOnly filter — compute the set of usable alias prefixes once
+      // per refresh. Empty when feature is off OR connection fetch failed
+      // OR no connections returned, in which case we keep everything
+      // (subtract-filter semantics: only drop when we can prove a prefix
+      // is NOT usable; never hide the catalog on a soft-fail).
+      const usable =
+        wantUsableOnly && rawConnections.length > 0
+          ? usableProviderAliasSet(rawConnections, rawEnrichment)
+          : undefined;
+
       // Map raw models → ModelV2 keyed by id. When enrichment data is
       // present (features.enrichment, default on), overlay the nicer
       // display name + pricing from /api/pricing/models. The enrichment
@@ -1456,6 +1714,7 @@ export function createOmniRouteProviderHook(
       const models: Record<string, ModelV2> = {};
       for (const entry of rawModels) {
         if (!entry.id) continue;
+        if (usable && !isUsableRawModelId(entry.id, usable, rawEnrichment)) continue;
         const model = mapRawModelToModelV2(entry, {
           providerId: resolved.providerId,
           baseURL,
@@ -1496,6 +1755,9 @@ export function createOmniRouteProviderHook(
       for (const combo of rawCombos) {
         if (!combo.id) continue;
         if (combo.isHidden === true) continue;
+        // usableOnly filter — drop combos whose members all map to
+        // non-usable providers.
+        if (usable && !isUsableCombo(combo, usable)) continue;
 
         const memberSteps = Array.isArray(combo.models) ? combo.models : [];
         const memberEntries: OmniRouteRawModelEntry[] = [];
@@ -1516,6 +1778,14 @@ export function createOmniRouteProviderHook(
         // /api/pricing/models surfaces combos alongside provider-scoped
         // models with curated names).
         applyEnrichment(mapped, rawEnrichment.get(combo.id));
+
+        // `Combo: ` prefix surfaces the combo nature in OC's model picker.
+        // Idempotent guard covers the case where enrichment overwrote
+        // mapped.name with an already-prefixed string. Mirrors the
+        // static-hook Combo:-prefix decoration.
+        if (!mapped.name.startsWith("Combo: ")) {
+          mapped.name = `Combo: ${mapped.name}`;
+        }
 
         // Optionally decorate combo name with its compression pipeline.
         // Only fires when features.compressionMetadata: true, OmniRoute
@@ -2042,9 +2312,19 @@ export function buildStaticProviderEntry(
   baseURL: string,
   apiKey: string,
   enrichment?: OmniRouteEnrichmentMap,
-  compressionCombos?: OmniRouteCompressionCombo[]
+  compressionCombos?: OmniRouteCompressionCombo[],
+  connections?: OmniRouteProviderConnection[]
 ): OmniRouteStaticProviderEntry {
   const models: Record<string, OmniRouteStaticModelEntry> = {};
+
+  // usableOnly filter — compute once when feature enabled AND we have
+  // connection data to filter against. Soft-fail (empty connections list)
+  // disables the filter rather than hiding the catalog.
+  const wantUsableOnly = opts.features?.usableOnly === true;
+  const usable =
+    wantUsableOnly && connections && connections.length > 0
+      ? usableProviderAliasSet(connections, enrichment)
+      : undefined;
 
   // Build a name-set of every non-hidden combo from `/api/combos`. OmniRoute
   // pre-mirrors combos into `/v1/models` with the friendly name as the raw
@@ -2066,6 +2346,7 @@ export function buildStaticProviderEntry(
     // `combo/<name>` namespace. We keep `codex-auto-review` and any other
     // future no-slash raw entry that doesn't have a matching combo.
     if (comboNames.has(raw.id)) continue;
+    if (usable && !isUsableRawModelId(raw.id, usable, enrichment)) continue;
     const caps = raw.capabilities ?? {};
     // Enrichment overlay: `/api/pricing/models` carries human display names
     // (e.g. "Claude Opus 4.7" for raw id "cc/claude-opus-4-7"). The OC TUI
@@ -2150,6 +2431,7 @@ export function buildStaticProviderEntry(
   for (const combo of rawCombos) {
     if (!combo.id) continue;
     if (combo.isHidden === true) continue;
+    if (usable && !isUsableCombo(combo, usable)) continue;
 
     const memberSteps = Array.isArray(combo.models) ? combo.models : [];
     const memberEntries: OmniRouteRawModelEntry[] = [];
@@ -2162,8 +2444,12 @@ export function buildStaticProviderEntry(
 
     const hasMembers = memberEntries.length > 0;
     const friendlyName = combo.name && combo.name.trim().length > 0 ? combo.name.trim() : combo.id;
+    // `Combo: ` prefix surfaces the combo nature in OC's model picker — the
+    // catalog key (`combo/<slug>`) is already namespaced, but the picker
+    // shows `name`, so prefix the display string too.
+    const prefixedName = `Combo: ${friendlyName}`;
     const displayName =
-      hasMembers && compressionSuffix ? `${friendlyName}${compressionSuffix}` : friendlyName;
+      hasMembers && compressionSuffix ? `${prefixedName}${compressionSuffix}` : prefixedName;
     const entry: OmniRouteStaticModelEntry = { name: displayName };
 
     if (hasMembers) {
@@ -2257,6 +2543,88 @@ type AuthJsonShape = Record<string, AuthJsonApiEntry | { type?: string; [k: stri
  * Exported as a dependency-injectable function on `createOmniRouteConfigHook`
  * so tests can stub it without monkey-patching `node:fs/promises`.
  */
+// ─────────────────────────────────────────────────────────────────────────
+// Disk-cache fallback. Persists the last successful raw-fetch snapshot to
+// `${OPENCODE_DATA_DIR ?? ~/.local/share/opencode}/plugins/omniroute-<providerId>.json`.
+// When `/v1/models` is unreachable (e.g. IP whitelist drop, offline laptop)
+// AND the in-memory cache is cold, the config hook reads from disk so the
+// last-known catalog still surfaces in OC's model picker. Feature-flagged:
+// `features.diskCache !== false` (default-on).
+// ─────────────────────────────────────────────────────────────────────────
+
+/** Disk snapshot envelope. Versioned for forward-compat. */
+interface OmniRouteDiskSnapshot {
+  v: 1;
+  rawModels: OmniRouteRawModelEntry[];
+  rawCombos: OmniRouteRawCombo[];
+  /** Serialised as array-of-pairs (Map is not JSON-friendly). */
+  rawEnrichment: Array<[string, OmniRouteEnrichmentEntry]>;
+  rawCompressionCombos: OmniRouteCompressionCombo[];
+  rawConnections: OmniRouteProviderConnection[];
+  /** When the snapshot was written (epoch ms). */
+  writtenAt: number;
+}
+
+/** Resolve the disk-snapshot path for a given providerId. */
+export function diskSnapshotPath(providerId: string): string {
+  const dir = process.env.OPENCODE_DATA_DIR ?? path.join(os.homedir(), ".local/share/opencode");
+  return path.join(dir, "plugins", `omniroute-${providerId}.json`);
+}
+
+export type OmniRouteDiskSnapshotWriter = (
+  providerId: string,
+  entry: Omit<OmniRouteFetchCacheEntry, "expiresAt">
+) => Promise<void>;
+
+export type OmniRouteDiskSnapshotReader = (
+  providerId: string
+) => Promise<Omit<OmniRouteFetchCacheEntry, "expiresAt"> | undefined>;
+
+/** Best-effort disk write. Soft-fails on any I/O error (no exception thrown). */
+export const defaultDiskSnapshotWriter: OmniRouteDiskSnapshotWriter = async (providerId, entry) => {
+  try {
+    const file = diskSnapshotPath(providerId);
+    await mkdir(path.dirname(file), { recursive: true });
+    const snapshot: OmniRouteDiskSnapshot = {
+      v: 1,
+      rawModels: entry.rawModels,
+      rawCombos: entry.rawCombos,
+      rawEnrichment: Array.from(entry.rawEnrichment.entries()),
+      rawCompressionCombos: entry.rawCompressionCombos,
+      rawConnections: entry.rawConnections,
+      writtenAt: Date.now(),
+    };
+    await writeFile(file, JSON.stringify(snapshot), "utf8");
+  } catch {
+    // Soft-fail; caller already has the in-memory cache.
+  }
+};
+
+/** Best-effort disk read. Returns `undefined` when missing/corrupt/unreadable. */
+export const defaultDiskSnapshotReader: OmniRouteDiskSnapshotReader = async (providerId) => {
+  try {
+    const file = diskSnapshotPath(providerId);
+    const body = await readFile(file, "utf8");
+    const parsed = JSON.parse(body) as Partial<OmniRouteDiskSnapshot>;
+    if (!parsed || parsed.v !== 1) return undefined;
+    return {
+      rawModels: Array.isArray(parsed.rawModels) ? parsed.rawModels : [],
+      rawCombos: Array.isArray(parsed.rawCombos) ? parsed.rawCombos : [],
+      rawEnrichment: new Map(Array.isArray(parsed.rawEnrichment) ? parsed.rawEnrichment : []),
+      rawCompressionCombos: Array.isArray(parsed.rawCompressionCombos)
+        ? parsed.rawCompressionCombos
+        : [],
+      rawConnections: Array.isArray(parsed.rawConnections) ? parsed.rawConnections : [],
+    };
+  } catch {
+    return undefined;
+  }
+};
+
+/** No-op disk-cache pair — used by tests to avoid filesystem side effects. */
+export const noopDiskSnapshotWriter: OmniRouteDiskSnapshotWriter = async () => {};
+export const noopDiskSnapshotReader: OmniRouteDiskSnapshotReader = async () => undefined;
+
 export type OmniRouteReadAuthJson = () => Promise<AuthJsonShape | undefined | null>;
 
 export const defaultReadAuthJson: OmniRouteReadAuthJson = async () => {
@@ -2340,6 +2708,9 @@ export function createOmniRouteConfigHook(
     combosFetcher?: OmniRouteCombosFetcher;
     enrichmentFetcher?: OmniRouteEnrichmentFetcher;
     compressionMetaFetcher?: OmniRouteCompressionMetaFetcher;
+    providersFetcher?: OmniRouteProvidersFetcher;
+    diskSnapshotReader?: OmniRouteDiskSnapshotReader;
+    diskSnapshotWriter?: OmniRouteDiskSnapshotWriter;
     now?: () => number;
     cache?: OmniRouteFetchCache;
     logger?: { warn: (...args: unknown[]) => void };
@@ -2352,12 +2723,17 @@ export function createOmniRouteConfigHook(
   const enrichmentFetcher = deps.enrichmentFetcher ?? defaultOmniRouteEnrichmentFetcher;
   const compressionMetaFetcher =
     deps.compressionMetaFetcher ?? defaultOmniRouteCompressionMetaFetcher;
+  const providersFetcher = deps.providersFetcher ?? defaultOmniRouteProvidersFetcher;
+  const diskSnapshotReader = deps.diskSnapshotReader ?? defaultDiskSnapshotReader;
+  const diskSnapshotWriter = deps.diskSnapshotWriter ?? defaultDiskSnapshotWriter;
   const now = deps.now ?? Date.now;
   const cache: OmniRouteFetchCache = deps.cache ?? new Map();
   const logger = deps.logger ?? console;
   const features = resolved.features ?? {};
   const wantEnrichment = features.enrichment !== false;
   const wantCompressionMeta = features.compressionMetadata === true;
+  const wantUsableOnly = features.usableOnly === true;
+  const wantDiskCache = features.diskCache !== false;
 
   return async (input: Config) => {
     // (e) operator override — `input.provider[providerId]` already set →
@@ -2422,16 +2798,23 @@ export function createOmniRouteConfigHook(
     let rawCombos: OmniRouteRawCombo[];
     let rawEnrichment: OmniRouteEnrichmentMap;
     let rawCompressionCombos: OmniRouteCompressionCombo[];
+    let rawConnections: OmniRouteProviderConnection[];
 
     if (cached && cached.expiresAt > t) {
       rawModels = cached.rawModels;
       rawCombos = cached.rawCombos;
       rawEnrichment = cached.rawEnrichment;
       rawCompressionCombos = cached.rawCompressionCombos;
+      rawConnections = cached.rawConnections;
     } else {
       // Fail-open fetcher errors: on /v1/models throw, fall back to empty
       // catalog (still publish a stub block so OC has a complete-shape
-      // entry); on /api/combos throw, publish models-only.
+      // entry); on /api/combos throw, publish models-only. Disk-cache
+      // fallback below recovers the last-known-good catalog when the
+      // fetcher threw (network down / 403 / timeout) AND features.diskCache
+      // !== false. A 0-entry SUCCESS (fresh tenant) does NOT trigger
+      // disk fallback — that's a valid empty catalog.
+      let modelsFetchThrew = false;
       try {
         rawModels = await fetcher(baseURL, apiKey, 10_000);
       } catch (err) {
@@ -2440,7 +2823,9 @@ export function createOmniRouteConfigHook(
           err
         );
         rawModels = [];
+        modelsFetchThrew = true;
       }
+      const modelsFetchOk = !modelsFetchThrew && rawModels.length > 0;
 
       rawCombos = [];
       try {
@@ -2486,6 +2871,42 @@ export function createOmniRouteConfigHook(
         }
       }
 
+      // Provider-connections fetch — opt-in via features.usableOnly. When
+      // on, the static catalog filters out models/combos whose canonical
+      // provider has no active connection. Soft-fail (empty list) disables
+      // the filter for this refresh, never hiding the whole catalog.
+      rawConnections = [];
+      if (wantUsableOnly) {
+        try {
+          rawConnections = await providersFetcher(baseURL, apiKey, 10_000);
+        } catch (err) {
+          logger.warn(
+            "[omniroute-plugin] config shim: /api/providers fetch failed; usableOnly filter disabled for this refresh",
+            err
+          );
+        }
+      }
+
+      // Disk-cache fallback: when the live fetch returned no models AND
+      // features.diskCache !== false, hydrate from the last-known-good
+      // snapshot so OC still surfaces a usable catalog (e.g. IP whitelist
+      // drop, offline laptop). The snapshot is whatever we last wrote on
+      // a healthy refresh; staleness is bounded only by how recently the
+      // user was online.
+      if (modelsFetchThrew && wantDiskCache) {
+        const snapshot = await diskSnapshotReader(resolved.providerId);
+        if (snapshot && snapshot.rawModels.length > 0) {
+          logger.warn(
+            `[omniroute-plugin] config shim: /v1/models unreachable; using stale disk cache (${snapshot.rawModels.length} models)`
+          );
+          rawModels = snapshot.rawModels;
+          rawCombos = snapshot.rawCombos;
+          rawEnrichment = snapshot.rawEnrichment;
+          rawCompressionCombos = snapshot.rawCompressionCombos;
+          rawConnections = snapshot.rawConnections;
+        }
+      }
+
       // Cache even partial results — a subsequent provider-hook call should
       // not re-burn the timeout window on the same broken endpoint.
       cache.set(cacheKey, {
@@ -2493,8 +2914,23 @@ export function createOmniRouteConfigHook(
         rawCombos,
         rawEnrichment,
         rawCompressionCombos,
+        rawConnections,
         expiresAt: t + resolved.modelCacheTtl,
       });
+
+      // Disk-cache write: persist the last successful (or any non-empty)
+      // catalog so a subsequent cold start with a failed fetch can recover.
+      // Best-effort; soft-fail keeps us moving when the data dir isn't
+      // writable (e.g. read-only container).
+      if (modelsFetchOk && wantDiskCache) {
+        await diskSnapshotWriter(resolved.providerId, {
+          rawModels,
+          rawCombos,
+          rawEnrichment,
+          rawCompressionCombos,
+          rawConnections,
+        });
+      }
     }
 
     const block = buildStaticProviderEntry(
@@ -2504,7 +2940,8 @@ export function createOmniRouteConfigHook(
       baseURL,
       apiKey,
       rawEnrichment,
-      rawCompressionCombos
+      rawCompressionCombos,
+      rawConnections
     );
 
     // Mutate the input.provider map. The Config type declares

--- a/@omniroute/opencode-plugin/src/index.ts
+++ b/@omniroute/opencode-plugin/src/index.ts
@@ -1162,6 +1162,48 @@ export function formatCompressionPipeline(pipeline: OmniRouteCompressionStep[]):
 }
 
 /**
+ * Slugify a combo display name into a copy/paste-friendly URL-safe segment.
+ * Lowercases, replaces any run of non-alphanumeric chars with a single dash,
+ * trims leading/trailing dashes. Empty input or all-special input returns
+ * the empty string (caller must fall back to the combo's UUID id).
+ *
+ * Example: `Claude Tier` → `claude-tier`, `GPT 5.5 / Pro` → `gpt-5-5-pro`.
+ */
+export function slugifyComboName(name: string): string {
+  if (typeof name !== "string") return "";
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+/**
+ * Build a combo's static-block key (`combo/<slug>`), guaranteeing uniqueness
+ * across an entire static catalog. If `<slug>` is already present in `used`,
+ * suffixes a short UUID-prefix disambiguator from `combo.id` so the second
+ * combo doesn't silently overwrite the first. Mutates `used` in place by
+ * recording the chosen key. Returns the final `combo/<...>` key.
+ *
+ * Falls back to `combo/<id>` when the friendly name slugifies to the empty
+ * string (e.g. a combo named just punctuation).
+ */
+export function buildComboKey(combo: OmniRouteRawCombo, used: Set<string>): string {
+  const friendlyName = combo.name && combo.name.trim().length > 0 ? combo.name.trim() : combo.id;
+  let slug = slugifyComboName(friendlyName);
+  if (slug.length === 0) slug = combo.id;
+  let key = `combo/${slug}`;
+  if (used.has(key)) {
+    const tail = combo.id.split("-")[0] ?? combo.id;
+    key = `combo/${slug}-${tail}`;
+    // Defensive: in the (impossible) event the disambiguated key also
+    // collides, append the full id.
+    if (used.has(key)) key = `combo/${slug}-${combo.id}`;
+  }
+  used.add(key);
+  return key;
+}
+
+/**
  * Internal cache key: `${baseURL}::sha256(apiKey)`. We hash the apiKey so
  * the key is safe to log / inspect via debugger without leaking the secret.
  * Different (baseURL, apiKey) tuples MUST keep independent cache entries:
@@ -1435,6 +1477,22 @@ export function createOmniRouteProviderHook(
       // model entries; unknown member ids are silently dropped before
       // mapComboToModelV2 sees them, which then degrades to the
       // all-false LCD posture if zero members remain.
+      //
+      // Combos are keyed under the `combo/<slug>` namespace so the TUI
+      // picker separates them from provider/model pairs and the UUID
+      // never surfaces. This mirrors `buildStaticProviderEntry` so the
+      // static + dynamic catalogs publish identical keys.
+      const comboNames = new Set<string>();
+      for (const combo of rawCombos) {
+        if (!combo || combo.isHidden === true) continue;
+        const n = combo.name && combo.name.trim().length > 0 ? combo.name.trim() : combo.id;
+        if (typeof n === "string" && n.length > 0) comboNames.add(n);
+      }
+      for (const key of Object.keys(models)) {
+        if (comboNames.has(key)) delete models[key];
+      }
+
+      const usedComboKeys = new Set<string>();
       for (const combo of rawCombos) {
         if (!combo.id) continue;
         if (combo.isHidden === true) continue;
@@ -1452,6 +1510,7 @@ export function createOmniRouteProviderHook(
         }
 
         const mapped = mapComboToModelV2(combo, memberEntries, resolved.providerId, baseURL);
+        const hasMembers = memberEntries.length > 0;
 
         // Apply enrichment overlay to combos too (OmniRoute's
         // /api/pricing/models surfaces combos alongside provider-scoped
@@ -1459,28 +1518,32 @@ export function createOmniRouteProviderHook(
         applyEnrichment(mapped, rawEnrichment.get(combo.id));
 
         // Optionally decorate combo name with its compression pipeline.
-        // Only fires when features.compressionMetadata: true and OmniRoute
-        // returned at least one default compression combo.
-        if (defaultCompression && defaultCompression.pipeline.length > 0) {
+        // Only fires when features.compressionMetadata: true, OmniRoute
+        // returned at least one default compression combo, AND the
+        // combo has resolvable members — claiming compression on an
+        // unroutable combo would mislead the picker.
+        if (hasMembers && defaultCompression && defaultCompression.pipeline.length > 0) {
           const tag = formatCompressionPipeline(defaultCompression.pipeline);
           if (tag.length > 0 && !mapped.name.includes(tag)) {
             mapped.name = `${mapped.name} ${tag}`;
           }
         }
 
-        // Collision policy: combos win. Warn ONCE per (cacheKey, comboId)
-        // when overwriting a same-id raw model so the operator can spot
+        const comboKey = buildComboKey(combo, usedComboKeys);
+
+        // Collision policy: combos win. Warn ONCE per (cacheKey, comboKey)
+        // when overwriting a same-key raw model so the operator can spot
         // the unusual naming choice without log spam.
-        if (Object.prototype.hasOwnProperty.call(models, combo.id)) {
-          const dedupeKey = `${cacheKey}::${combo.id}`;
+        if (Object.prototype.hasOwnProperty.call(models, comboKey)) {
+          const dedupeKey = `${cacheKey}::${comboKey}`;
           if (!collisionWarned.has(dedupeKey)) {
             collisionWarned.add(dedupeKey);
             console.warn(
-              `[omniroute-plugin] combo id "${combo.id}" collides with a model id; combo wins.`
+              `[omniroute-plugin] combo key "${comboKey}" collides with a model id; combo wins.`
             );
           }
         }
-        models[combo.id] = mapped;
+        models[comboKey] = mapped;
       }
 
       return models;
@@ -1977,15 +2040,42 @@ export function buildStaticProviderEntry(
   rawCombos: OmniRouteRawCombo[],
   opts: ReturnType<typeof resolveOmniRoutePluginOptions>,
   baseURL: string,
-  apiKey: string
+  apiKey: string,
+  enrichment?: OmniRouteEnrichmentMap,
+  compressionCombos?: OmniRouteCompressionCombo[]
 ): OmniRouteStaticProviderEntry {
   const models: Record<string, OmniRouteStaticModelEntry> = {};
+
+  // Build a name-set of every non-hidden combo from `/api/combos`. OmniRoute
+  // pre-mirrors combos into `/v1/models` with the friendly name as the raw
+  // id (e.g. `claude-primary`, `gemini-pro`), so without dedup the static
+  // catalog ends up with both `claude-primary` (raw, opaque) AND the same
+  // combo under `combo/claude-primary` (rich LCD). We suppress the raw twin
+  // so each combo surfaces exactly once, under the `combo/` namespace.
+  const comboNames = new Set<string>();
+  for (const combo of rawCombos) {
+    if (!combo || combo.isHidden === true) continue;
+    const name = combo.name && combo.name.trim().length > 0 ? combo.name.trim() : combo.id;
+    if (typeof name === "string" && name.length > 0) comboNames.add(name);
+  }
 
   // Raw model entries → stripped per-model shape.
   for (const raw of rawModels) {
     if (!raw.id) continue;
+    // Skip the 20 named no-slash entries that shadow combos under the
+    // `combo/<name>` namespace. We keep `codex-auto-review` and any other
+    // future no-slash raw entry that doesn't have a matching combo.
+    if (comboNames.has(raw.id)) continue;
     const caps = raw.capabilities ?? {};
-    const entry: OmniRouteStaticModelEntry = { name: raw.id };
+    // Enrichment overlay: `/api/pricing/models` carries human display names
+    // (e.g. "Claude Opus 4.7" for raw id "cc/claude-opus-4-7"). The OC TUI
+    // model picker reads this `name` straight from the static block on
+    // OC ≤1.15.5 where the dynamic provider hook never fires. Falls back
+    // to the raw id when no enrichment entry is found.
+    const enrichmentName = enrichment?.get(raw.id)?.name;
+    const entry: OmniRouteStaticModelEntry = {
+      name: enrichmentName && enrichmentName.length > 0 ? enrichmentName : raw.id,
+    };
 
     const attachment = caps.attachment ?? caps.vision;
     if (typeof attachment === "boolean") entry.attachment = attachment;
@@ -2029,12 +2119,33 @@ export function buildStaticProviderEntry(
     models[raw.id] = entry;
   }
 
-  // Combo entries → stripped LCD shape. Combos win on id collision (matches
-  // the dynamic provider hook's resolution order — see T-05).
+  // Combo entries → stripped LCD shape. Each combo is keyed as
+  // `combo/<friendly-name>` so the OC TUI model picker shows them under a
+  // distinct namespace (e.g. `combo/claude-primary`) instead of the opaque
+  // upstream UUID id (e.g. `b4a0211e-e3e1-472d-b252-fb9bf6d1c935`).
   const rawModelById = new Map<string, OmniRouteRawModelEntry>();
   for (const m of rawModels) {
     if (m.id) rawModelById.set(m.id, m);
   }
+
+  // Resolve the default compression pipeline once — its short signature
+  // (e.g. `[rtk:standard → caveman:full]`) is appended to every routable
+  // combo `name` so operators can see what compression a combo applies
+  // at a glance. Provider hook does the same decoration when feature is
+  // on. Suffix is suppressed for combos with no resolvable members —
+  // claiming compression on an unroutable combo would mislead the
+  // picker.
+  let compressionSuffix = "";
+  if (compressionCombos && compressionCombos.length > 0) {
+    const def = compressionCombos.find((c) => c.isDefault === true);
+    if (def) {
+      const sig = formatCompressionPipeline(def.pipeline);
+      if (sig.length > 0) compressionSuffix = ` ${sig}`;
+    }
+  }
+
+  // Track combo keys to detect slug collisions across the catalog.
+  const usedComboKeys = new Set<string>();
 
   for (const combo of rawCombos) {
     if (!combo.id) continue;
@@ -2050,7 +2161,9 @@ export function buildStaticProviderEntry(
     }
 
     const hasMembers = memberEntries.length > 0;
-    const displayName = combo.name && combo.name.trim().length > 0 ? combo.name : combo.id;
+    const friendlyName = combo.name && combo.name.trim().length > 0 ? combo.name.trim() : combo.id;
+    const displayName =
+      hasMembers && compressionSuffix ? `${friendlyName}${compressionSuffix}` : friendlyName;
     const entry: OmniRouteStaticModelEntry = { name: displayName };
 
     if (hasMembers) {
@@ -2101,7 +2214,12 @@ export function buildStaticProviderEntry(
       entry.tool_call = false;
     }
 
-    models[combo.id] = entry;
+    // Key under `combo/<slug>` (e.g. `combo/claude-primary`) so the
+    // namespace cleanly separates combos from raw provider/model pairs
+    // and so the key is copy/paste-friendly. Slug collisions across
+    // combos are disambiguated with a short UUID-prefix suffix; see
+    // `buildComboKey` for the policy.
+    models[buildComboKey(combo, usedComboKeys)] = entry;
   }
 
   return {
@@ -2220,6 +2338,8 @@ export function createOmniRouteConfigHook(
     readAuthJson?: OmniRouteReadAuthJson;
     fetcher?: OmniRouteModelsFetcher;
     combosFetcher?: OmniRouteCombosFetcher;
+    enrichmentFetcher?: OmniRouteEnrichmentFetcher;
+    compressionMetaFetcher?: OmniRouteCompressionMetaFetcher;
     now?: () => number;
     cache?: OmniRouteFetchCache;
     logger?: { warn: (...args: unknown[]) => void };
@@ -2229,9 +2349,15 @@ export function createOmniRouteConfigHook(
   const readAuthJson = deps.readAuthJson ?? defaultReadAuthJson;
   const fetcher = deps.fetcher ?? defaultOmniRouteModelsFetcher;
   const combosFetcher = deps.combosFetcher ?? defaultOmniRouteCombosFetcher;
+  const enrichmentFetcher = deps.enrichmentFetcher ?? defaultOmniRouteEnrichmentFetcher;
+  const compressionMetaFetcher =
+    deps.compressionMetaFetcher ?? defaultOmniRouteCompressionMetaFetcher;
   const now = deps.now ?? Date.now;
   const cache: OmniRouteFetchCache = deps.cache ?? new Map();
   const logger = deps.logger ?? console;
+  const features = resolved.features ?? {};
+  const wantEnrichment = features.enrichment !== false;
+  const wantCompressionMeta = features.compressionMetadata === true;
 
   return async (input: Config) => {
     // (e) operator override — `input.provider[providerId]` already set →
@@ -2294,10 +2420,14 @@ export function createOmniRouteConfigHook(
 
     let rawModels: OmniRouteRawModelEntry[];
     let rawCombos: OmniRouteRawCombo[];
+    let rawEnrichment: OmniRouteEnrichmentMap;
+    let rawCompressionCombos: OmniRouteCompressionCombo[];
 
     if (cached && cached.expiresAt > t) {
       rawModels = cached.rawModels;
       rawCombos = cached.rawCombos;
+      rawEnrichment = cached.rawEnrichment;
+      rawCompressionCombos = cached.rawCompressionCombos;
     } else {
       // Fail-open fetcher errors: on /v1/models throw, fall back to empty
       // catalog (still publish a stub block so OC has a complete-shape
@@ -2322,23 +2452,60 @@ export function createOmniRouteConfigHook(
         );
       }
 
+      // Eagerly fetch enrichment so the static block can overlay human
+      // display names on raw model ids. On OC ≤1.15.5 the dynamic
+      // `provider.models` hook never fires in `serve` mode, so the static
+      // block IS what reaches `/provider` and the TUI model picker.
+      // Gated by `features.enrichment` (default-on). Soft-fail on error —
+      // we still publish a name-less catalog if /api/pricing/models is
+      // unreachable.
+      rawEnrichment = new Map();
+      if (wantEnrichment) {
+        try {
+          rawEnrichment = await enrichmentFetcher(baseURL, apiKey, 10_000);
+        } catch (err) {
+          logger.warn(
+            "[omniroute-plugin] config shim: /api/pricing/models fetch failed; publishing raw-id static catalog",
+            err
+          );
+        }
+      }
+
+      // Compression-metadata fetch — opt-in via features.compressionMetadata.
+      // When on, the default pipeline is appended to every combo `name` so
+      // the TUI picker advertises which compression a combo applies.
+      rawCompressionCombos = [];
+      if (wantCompressionMeta) {
+        try {
+          rawCompressionCombos = await compressionMetaFetcher(baseURL, apiKey, 10_000);
+        } catch (err) {
+          logger.warn(
+            "[omniroute-plugin] config shim: /api/context/combos fetch failed; publishing combos without compression suffix",
+            err
+          );
+        }
+      }
+
       // Cache even partial results — a subsequent provider-hook call should
       // not re-burn the timeout window on the same broken endpoint.
-      // Config-hook never fetches enrichment/compression directly: the
-      // static block doesn't surface them today (sibling shape is name+
-      // capability only). Provider-hook may fetch them later and write
-      // back into the same cache key; we seed empty values so the cache
-      // entry shape remains consistent.
       cache.set(cacheKey, {
         rawModels,
         rawCombos,
-        rawEnrichment: new Map(),
-        rawCompressionCombos: [],
+        rawEnrichment,
+        rawCompressionCombos,
         expiresAt: t + resolved.modelCacheTtl,
       });
     }
 
-    const block = buildStaticProviderEntry(rawModels, rawCombos, resolved, baseURL, apiKey);
+    const block = buildStaticProviderEntry(
+      rawModels,
+      rawCombos,
+      resolved,
+      baseURL,
+      apiKey,
+      rawEnrichment,
+      rawCompressionCombos
+    );
 
     // Mutate the input.provider map. The Config type declares
     // `provider?: {[key: string]: ProviderConfig}` — we initialise the
@@ -2359,7 +2526,6 @@ export function createOmniRouteConfigHook(
     // as provider-block emit): if input.mcp[providerId] is already set,
     // we leave it alone.
     // ─────────────────────────────────────────────────────────────────────
-    const features = resolved.features ?? {};
     if (features.mcpAutoEmit === true) {
       const mcpKey = features.mcpToken ?? apiKey;
       if (!mcpKey) {

--- a/@omniroute/opencode-plugin/tests/combos.test.ts
+++ b/@omniroute/opencode-plugin/tests/combos.test.ts
@@ -450,9 +450,9 @@ test("models() returns combo entries merged into the map", async () => {
   assert.ok(out["claude-primary"]);
   assert.ok(out["claude-secondary"]);
   assert.ok(out["gemini-3-flash"]);
-  assert.ok(out["combo-claude-tier"]);
+  assert.ok(out["combo/claude-tier"]);
 
-  const combo = out["combo-claude-tier"];
+  const combo = out["combo/claude-tier"];
   assert.equal(combo.name, "Claude Tier");
   assert.equal(combo.providerID, "omniroute");
   // LCD over claude-primary (200k, reasoning) + claude-secondary (100k, no reasoning)
@@ -478,11 +478,11 @@ test("models(): combo with unknown member ids degrades to all-false LCD posture"
     { fetcher: modelsFetcher, combosFetcher }
   );
   const out = await hook.models!({} as never, { auth: apiAuth("sk-z") as never });
-  assert.ok(out["phantom"]);
+  assert.ok(out["combo/phantom-combo"]);
   // With zero resolvable members, LCD = all-false (defensive posture).
-  assert.equal(out["phantom"].capabilities.toolcall, false);
-  assert.equal(out["phantom"].capabilities.reasoning, false);
-  assert.equal(out["phantom"].limit.context, 0);
+  assert.equal(out["combo/phantom-combo"].capabilities.toolcall, false);
+  assert.equal(out["combo/phantom-combo"].capabilities.reasoning, false);
+  assert.equal(out["combo/phantom-combo"].limit.context, 0);
 });
 
 test("models(): hidden combos are excluded from the map", async () => {
@@ -505,15 +505,17 @@ test("models(): hidden combos are excluded from the map", async () => {
     { fetcher: modelsFetcher, combosFetcher }
   );
   const out = await hook.models!({} as never, { auth: apiAuth("sk-z") as never });
-  assert.ok(out["visible"]);
-  assert.ok(!out["hidden"], "hidden combo must be omitted");
+  assert.ok(out["combo/visible"]);
+  assert.ok(!out["combo/hidden"], "hidden combo must be omitted");
 });
 
-test("models(): combo ID collides with a model ID → combo wins, warn emitted once", async () => {
-  // The combo shares id with a model in the catalog.
+test("models(): combo name exactly matches raw model id → raw deleted, combo lives at combo/ key, no warn", async () => {
+  // Combo.name === raw model id triggers the dedup deletion. This mirrors
+  // the real OmniRoute payload where /v1/models pre-mirrors combos as
+  // no-slash raw entries whose ids match /api/combos friendly names.
   const colliderCombo: OmniRouteRawCombo = {
-    id: "claude-primary", // SAME id as MODEL_PRIMARY
-    name: "Claude Primary Combo Override",
+    id: "uuid-collider",
+    name: "claude-primary", // EXACT match to MODEL_PRIMARY.id
     models: [{ id: "s1", kind: "model", model: "claude-secondary", weight: 100 }],
   };
   const modelsFetcher = stubModelsFetcher([MODEL_PRIMARY, MODEL_SECONDARY]);
@@ -527,47 +529,45 @@ test("models(): combo ID collides with a model ID → combo wins, warn emitted o
     return hook.models!({} as never, { auth: apiAuth("sk-z") as never });
   });
 
-  // Combo wins → the entry at "claude-primary" has the combo's display name,
-  // not the raw model's id-as-name.
-  assert.equal(out["claude-primary"].name, "Claude Primary Combo Override");
-  // Exactly one collision warning was emitted.
+  // Raw model deleted by combo-name dedup; combo surfaces under combo/<slug>.
+  assert.equal(out["claude-primary"], undefined, "raw deleted by combo-name dedup");
+  assert.ok(out["combo/claude-primary"], "combo surfaces under combo/ namespace");
+  assert.equal(out["combo/claude-primary"].name, "claude-primary");
+
+  // No collision warning fires — dedup makes keys disjoint.
   const collisionWarns = warnings.filter((w) => {
     const msg = w.args[0];
-    return typeof msg === "string" && msg.includes("collides with a model id");
+    return typeof msg === "string" && msg.includes("collides");
   });
-  assert.equal(collisionWarns.length, 1, "collision warning emitted exactly once");
-
-  // Second call within TTL hits the cache; no additional warnings.
-  const { warnings: warnings2 } = await withWarnCapture(async (_w) => {
-    return hook.models!({} as never, { auth: apiAuth("sk-z") as never });
-  });
-  const collisionWarns2 = warnings2.filter((w) => {
-    const msg = w.args[0];
-    return typeof msg === "string" && msg.includes("collides with a model id");
-  });
-  assert.equal(collisionWarns2.length, 0, "no re-warn on cached call");
+  assert.equal(collisionWarns.length, 0, "no collision warn after dedup");
 });
 
-test("models(): collision warn is per-comboId — distinct collisions both warn", async () => {
-  const m1: OmniRouteRawModelEntry = { ...MODEL_PRIMARY, id: "id-a" };
-  const m2: OmniRouteRawModelEntry = { ...MODEL_SECONDARY, id: "id-b" };
+test("models(): two combos with same slug → second gets disambiguator suffix", async () => {
+  // Both combos slug to `claude` — second must get `combo/claude-<id-prefix>`.
   const combos: OmniRouteRawCombo[] = [
-    { id: "id-a", name: "A", models: [{ id: "s", kind: "model", model: "id-a", weight: 1 }] },
-    { id: "id-b", name: "B", models: [{ id: "s", kind: "model", model: "id-b", weight: 1 }] },
+    {
+      id: "uuid-a",
+      name: "Claude",
+      models: [{ id: "s", kind: "model", model: "claude-primary", weight: 1 }],
+    },
+    {
+      id: "uuid-b",
+      name: "Claude",
+      models: [{ id: "s", kind: "model", model: "claude-secondary", weight: 1 }],
+    },
   ];
   const hook = createOmniRouteProviderHook(
     { baseURL: "https://or.example.com/v1" },
-    { fetcher: stubModelsFetcher([m1, m2]), combosFetcher: stubCombosFetcher(combos) }
+    {
+      fetcher: stubModelsFetcher([MODEL_PRIMARY, MODEL_SECONDARY]),
+      combosFetcher: stubCombosFetcher(combos),
+    }
   );
 
-  const { warnings } = await withWarnCapture(async () => {
-    return hook.models!({} as never, { auth: apiAuth("sk-z") as never });
-  });
-  const collisionWarns = warnings.filter((w) => {
-    const msg = w.args[0];
-    return typeof msg === "string" && msg.includes("collides with a model id");
-  });
-  assert.equal(collisionWarns.length, 2);
+  const out = await hook.models!({} as never, { auth: apiAuth("sk-z") as never });
+  // First combo gets the bare slug; second gets disambiguated.
+  assert.ok(out["combo/claude"], "first combo at bare slug");
+  assert.ok(out["combo/claude-uuid"], "second combo disambiguated by id prefix");
 });
 
 test("models(): combos fetch fails → falls back to models-only, warn emitted, no throw", async () => {
@@ -610,7 +610,7 @@ test("models(): combos cached + reused within TTL (one combo fetch per TTL windo
   const second = await hook.models!({} as never, { auth: apiAuth("sk-z") as never });
   assert.equal(combosFetcher.callCount(), 1, "combos fetched only once within TTL");
   assert.equal(modelsFetcher.callCount(), 1, "models fetched only once within TTL");
-  assert.ok(second["combo-claude-tier"]);
+  assert.ok(second["combo/claude-tier"]);
 });
 
 test("models(): combos refetched after TTL expiry (same key as models)", async () => {

--- a/@omniroute/opencode-plugin/tests/combos.test.ts
+++ b/@omniroute/opencode-plugin/tests/combos.test.ts
@@ -453,7 +453,7 @@ test("models() returns combo entries merged into the map", async () => {
   assert.ok(out["combo/claude-tier"]);
 
   const combo = out["combo/claude-tier"];
-  assert.equal(combo.name, "Claude Tier");
+  assert.equal(combo.name, "Combo: Claude Tier");
   assert.equal(combo.providerID, "omniroute");
   // LCD over claude-primary (200k, reasoning) + claude-secondary (100k, no reasoning)
   assert.equal(combo.limit.context, 100_000);
@@ -532,7 +532,7 @@ test("models(): combo name exactly matches raw model id → raw deleted, combo l
   // Raw model deleted by combo-name dedup; combo surfaces under combo/<slug>.
   assert.equal(out["claude-primary"], undefined, "raw deleted by combo-name dedup");
   assert.ok(out["combo/claude-primary"], "combo surfaces under combo/ namespace");
-  assert.equal(out["combo/claude-primary"].name, "claude-primary");
+  assert.equal(out["combo/claude-primary"].name, "Combo: claude-primary");
 
   // No collision warning fires — dedup makes keys disjoint.
   const collisionWarns = warnings.filter((w) => {

--- a/@omniroute/opencode-plugin/tests/config-shim.test.ts
+++ b/@omniroute/opencode-plugin/tests/config-shim.test.ts
@@ -26,6 +26,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import type { Config } from "@opencode-ai/plugin";
+
 import {
   buildStaticProviderEntry,
   createOmniRouteConfigHook,
@@ -38,6 +39,8 @@ import {
   type OmniRouteEnrichmentMap,
   type OmniRouteFetchCache,
   type OmniRouteModelsFetcher,
+  type OmniRouteProviderConnection,
+  type OmniRouteProvidersFetcher,
   type OmniRouteRawCombo,
   type OmniRouteRawModelEntry,
   type OmniRouteReadAuthJson,
@@ -238,7 +241,7 @@ test("config: with valid auth.json + apiKey + baseURL → mutates input.provider
   // (gemini's reasoning=false → combo reasoning=false).
   const combo = entry.models["combo/claude-tier"];
   assert.ok(combo, "combo surfaced under combo/ namespace");
-  assert.equal(combo.name, "Claude Tier");
+  assert.equal(combo.name, "Combo: Claude Tier");
   assert.equal(combo.reasoning, false, "LCD: any member reasoning=false → combo reasoning=false");
   assert.equal(combo.tool_call, true);
   assert.equal(combo.limit?.context, 200_000, "LCD: min(200_000, 1_000_000)");
@@ -346,8 +349,11 @@ test("config: fetchers throw → warn + emit stub entry with models: {}", async 
   const combosFetcher = throwingCombosFetcher();
   const logger = captureWarn();
 
+  // Opt-out of disk-cache fallback for this test — we want to assert the
+  // pure stub path, not the disk-cache-recovery path (covered by its own
+  // test below).
   const hook = createOmniRouteConfigHook(
-    { providerId: "omniroute" },
+    { providerId: "omniroute", features: { diskCache: false } },
     { readAuthJson, fetcher, combosFetcher, logger }
   );
   const input = makeInput();
@@ -773,7 +779,7 @@ test("config: enrichment fetched + name overlaid on raw-model entries", async ()
   assert.equal(entry.models["claude-sonnet-4-6"].name, "Claude Sonnet 4.6");
   assert.equal(entry.models["gemini-3-flash"].name, "Gemini 3 Flash");
   // Combo names still come from /api/combos — enrichment overlay does NOT touch combos.
-  assert.equal(entry.models["combo/claude-tier"].name, "Claude Tier");
+  assert.equal(entry.models["combo/claude-tier"].name, "Combo: Claude Tier");
   assert.equal(enrichmentFetcher.callCount(), 1);
 });
 
@@ -828,6 +834,205 @@ test("config: enrichment fetcher throws → soft-fail (warn + raw-id static cata
   assert.ok(
     logger.entries.some((e) => String(e[0]).includes("/api/pricing/models fetch failed")),
     "enrichment-fetch breadcrumb emitted"
+  );
+});
+
+function stubProvidersFetcher(payload: OmniRouteProviderConnection[]): OmniRouteProvidersFetcher & {
+  callCount: () => number;
+} {
+  let n = 0;
+  const f: OmniRouteProvidersFetcher = async () => {
+    n++;
+    return payload;
+  };
+  return Object.assign(f, { callCount: () => n });
+}
+
+function throwingProvidersFetcher(): OmniRouteProvidersFetcher & { callCount: () => number } {
+  let n = 0;
+  const f: OmniRouteProvidersFetcher = async () => {
+    n++;
+    throw new Error("ETIMEDOUT");
+  };
+  return Object.assign(f, { callCount: () => n });
+}
+
+const MODEL_CC_OPUS: OmniRouteRawModelEntry = {
+  id: "cc/claude-opus-4-7",
+  capabilities: { tool_calling: true, reasoning: true, temperature: true },
+  context_length: 200_000,
+};
+const MODEL_NV_LLAMA: OmniRouteRawModelEntry = {
+  id: "nvidia/llama-3-70b",
+  capabilities: { tool_calling: true, temperature: true },
+  context_length: 128_000,
+};
+
+test("config: usableOnly=false → no filter (existing behavior)", async () => {
+  const readAuthJson = stubReadAuthJson({
+    omniroute: { type: "api", key: "sk-test", baseURL: "https://or.example/v1" },
+  });
+  const fetcher = stubModelsFetcher([MODEL_CC_OPUS, MODEL_NV_LLAMA]);
+  const combosFetcher = stubCombosFetcher([]);
+  const providersFetcher = stubProvidersFetcher([
+    { id: "c1", provider: "claude", isActive: true, testStatus: "active" },
+  ]);
+  const enrichmentFetcher = stubEnrichmentFetcher(
+    new Map<string, OmniRouteEnrichmentEntry>([
+      ["cc/claude-opus-4-7", { name: "Claude Opus 4.7" }],
+      ["nvidia/llama-3-70b", { name: "Llama 3 70B" }],
+    ])
+  );
+
+  const hook = createOmniRouteConfigHook(
+    { providerId: "omniroute", baseURL: "https://or.example/v1" },
+    { readAuthJson, fetcher, combosFetcher, enrichmentFetcher, providersFetcher }
+  );
+
+  const input = makeInput();
+  await hook(input);
+
+  const entry = (input as { provider: Record<string, OmniRouteStaticProviderEntry> }).provider
+    .omniroute;
+  assert.ok(entry.models["cc/claude-opus-4-7"], "claude kept");
+  assert.ok(entry.models["nvidia/llama-3-70b"], "nvidia kept (filter off)");
+  assert.equal(providersFetcher.callCount(), 0, "providers fetch not called when feature off");
+});
+
+test("config: usableOnly=true → drops models for non-usable providers, keeps usable + unknown", async () => {
+  const readAuthJson = stubReadAuthJson({
+    omniroute: { type: "api", key: "sk-test", baseURL: "https://or.example/v1" },
+  });
+  const fetcher = stubModelsFetcher([
+    MODEL_CC_OPUS,
+    MODEL_NV_LLAMA,
+    // Unknown prefix not in pricing-models nor connections — must pass through.
+    {
+      id: "agentrouter/synthetic-1",
+      capabilities: { temperature: true },
+      context_length: 100_000,
+    },
+  ]);
+  const combosFetcher = stubCombosFetcher([]);
+  const providersFetcher = stubProvidersFetcher([
+    // Claude is usable.
+    { id: "c1", provider: "claude", isActive: true, testStatus: "active" },
+    // Nvidia provisioned but errored → not usable.
+    { id: "c2", provider: "nvidia", isActive: true, testStatus: "error" },
+  ]);
+  const enrichmentFetcher = stubEnrichmentFetcher(
+    new Map<string, OmniRouteEnrichmentEntry>([
+      [
+        "cc/claude-opus-4-7",
+        { name: "Claude Opus 4.7", providerAlias: "cc", providerCanonical: "claude" },
+      ],
+      [
+        "nvidia/llama-3-70b",
+        { name: "Llama 3 70B", providerAlias: "nvidia", providerCanonical: "nvidia" },
+      ],
+    ])
+  );
+
+  const hook = createOmniRouteConfigHook(
+    { providerId: "omniroute", baseURL: "https://or.example/v1", features: { usableOnly: true } },
+    { readAuthJson, fetcher, combosFetcher, enrichmentFetcher, providersFetcher }
+  );
+
+  const input = makeInput();
+  await hook(input);
+
+  const entry = (input as { provider: Record<string, OmniRouteStaticProviderEntry> }).provider
+    .omniroute;
+  assert.ok(entry.models["cc/claude-opus-4-7"], "claude kept (active)");
+  assert.equal(entry.models["nvidia/llama-3-70b"], undefined, "nvidia dropped (error status)");
+  assert.ok(entry.models["agentrouter/synthetic-1"], "unknown prefix kept (subtract-filter)");
+  assert.equal(providersFetcher.callCount(), 1);
+});
+
+test("config: usableOnly=true + providers fetch fails → soft-fail keeps everything", async () => {
+  const readAuthJson = stubReadAuthJson({
+    omniroute: { type: "api", key: "sk-test", baseURL: "https://or.example/v1" },
+  });
+  const fetcher = stubModelsFetcher([MODEL_CC_OPUS, MODEL_NV_LLAMA]);
+  const combosFetcher = stubCombosFetcher([]);
+  const providersFetcher = throwingProvidersFetcher();
+  const enrichmentFetcher = stubEnrichmentFetcher(
+    new Map<string, OmniRouteEnrichmentEntry>([
+      ["cc/claude-opus-4-7", { name: "Claude Opus 4.7" }],
+      ["nvidia/llama-3-70b", { name: "Llama 3 70B" }],
+    ])
+  );
+  const logger = captureWarn();
+
+  const hook = createOmniRouteConfigHook(
+    { providerId: "omniroute", baseURL: "https://or.example/v1", features: { usableOnly: true } },
+    { readAuthJson, fetcher, combosFetcher, enrichmentFetcher, providersFetcher, logger }
+  );
+
+  const input = makeInput();
+  await hook(input);
+
+  const entry = (input as { provider: Record<string, OmniRouteStaticProviderEntry> }).provider
+    .omniroute;
+  assert.ok(entry.models["cc/claude-opus-4-7"]);
+  assert.ok(entry.models["nvidia/llama-3-70b"], "soft-fail keeps both");
+  assert.ok(
+    logger.entries.some((e) => String(e[0]).includes("/api/providers fetch failed")),
+    "providers-fetch breadcrumb emitted"
+  );
+});
+
+test("config: diskCache hydrates stale snapshot when /v1/models throws", async () => {
+  const readAuthJson = stubReadAuthJson({
+    omniroute: { type: "api", key: "sk-test", baseURL: "https://or.example/v1" },
+  });
+  const fetcher = throwingModelsFetcher();
+  const combosFetcher = stubCombosFetcher([]);
+  const logger = captureWarn();
+
+  // Disk reader returns a stale snapshot — emulates the last-known-good
+  // catalog written on a healthy refresh.
+  const diskSnapshotReader: typeof import("../src/index.js").defaultDiskSnapshotReader =
+    async () => ({
+      rawModels: [MODEL_CLAUDE],
+      rawCombos: [],
+      rawEnrichment: new Map([["claude-sonnet-4-6", { name: "Claude Sonnet 4.6 (cached)" }]]),
+      rawCompressionCombos: [],
+      rawConnections: [],
+    });
+  let writes = 0;
+  const diskSnapshotWriter: typeof import("../src/index.js").defaultDiskSnapshotWriter =
+    async () => {
+      writes++;
+    };
+
+  const hook = createOmniRouteConfigHook(
+    { providerId: "omniroute", features: { diskCache: true } },
+    {
+      readAuthJson,
+      fetcher,
+      combosFetcher,
+      diskSnapshotReader,
+      diskSnapshotWriter,
+      logger,
+    }
+  );
+
+  const input = makeInput();
+  await hook(input);
+
+  const entry = (input as { provider: Record<string, OmniRouteStaticProviderEntry> }).provider
+    .omniroute;
+  assert.ok(entry.models["claude-sonnet-4-6"], "stale snapshot hydrated into static block");
+  assert.equal(
+    entry.models["claude-sonnet-4-6"].name,
+    "Claude Sonnet 4.6 (cached)",
+    "stale enrichment also reused"
+  );
+  assert.equal(writes, 0, "disk write skipped when live fetch failed");
+  assert.ok(
+    logger.entries.some((e) => String(e[0]).includes("using stale disk cache")),
+    "disk-cache hydration breadcrumb emitted"
   );
 });
 

--- a/@omniroute/opencode-plugin/tests/config-shim.test.ts
+++ b/@omniroute/opencode-plugin/tests/config-shim.test.ts
@@ -33,6 +33,9 @@ import {
   OmniRoutePlugin,
   resolveOmniRoutePluginOptions,
   type OmniRouteCombosFetcher,
+  type OmniRouteEnrichmentEntry,
+  type OmniRouteEnrichmentFetcher,
+  type OmniRouteEnrichmentMap,
   type OmniRouteFetchCache,
   type OmniRouteModelsFetcher,
   type OmniRouteRawCombo,
@@ -147,6 +150,29 @@ function throwingCombosFetcher(): OmniRouteCombosFetcher & { callCount: () => nu
   return Object.assign(f, { callCount: () => n });
 }
 
+function stubEnrichmentFetcher(payload: OmniRouteEnrichmentMap): OmniRouteEnrichmentFetcher & {
+  callCount: () => number;
+  callsBy: () => Array<[string, string]>;
+} {
+  let n = 0;
+  const calls: Array<[string, string]> = [];
+  const f: OmniRouteEnrichmentFetcher = async (baseURL, apiKey) => {
+    n++;
+    calls.push([baseURL, apiKey]);
+    return payload;
+  };
+  return Object.assign(f, { callCount: () => n, callsBy: () => calls });
+}
+
+function throwingEnrichmentFetcher(): OmniRouteEnrichmentFetcher & { callCount: () => number } {
+  let n = 0;
+  const f: OmniRouteEnrichmentFetcher = async () => {
+    n++;
+    throw new Error("ETIMEDOUT");
+  };
+  return Object.assign(f, { callCount: () => n });
+}
+
 interface WarnCapture {
   warn: (...args: unknown[]) => void;
   entries: unknown[][];
@@ -208,9 +234,10 @@ test("config: with valid auth.json + apiKey + baseURL → mutates input.provider
   assert.equal(claude.limit?.input, 180_000);
   assert.equal(claude.limit?.output, 64_000);
 
-  // Combo present + LCD'd (gemini's reasoning=false → combo reasoning=false).
-  const combo = entry.models["combo-claude-tier"];
-  assert.ok(combo, "combo surfaced");
+  // Combo surfaces under `combo/<friendly-name>` namespace + LCD'd
+  // (gemini's reasoning=false → combo reasoning=false).
+  const combo = entry.models["combo/claude-tier"];
+  assert.ok(combo, "combo surfaced under combo/ namespace");
   assert.equal(combo.name, "Claude Tier");
   assert.equal(combo.reasoning, false, "LCD: any member reasoning=false → combo reasoning=false");
   assert.equal(combo.tool_call, true);
@@ -712,4 +739,133 @@ test("config: initialises input.provider when undefined", async () => {
   const provider = (input as { provider?: Record<string, unknown> }).provider;
   assert.ok(provider, "provider bag initialised");
   assert.ok(provider!.omniroute);
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// Enrichment overlay — eager fetch on config-hook so OC ≤1.15.5 TUI sees
+// human display names instead of raw provider/model ids.
+// ────────────────────────────────────────────────────────────────────────────
+
+test("config: enrichment fetched + name overlaid on raw-model entries", async () => {
+  const readAuthJson = stubReadAuthJson({
+    omniroute: { type: "api", key: "sk-test", baseURL: "https://or.example/v1" },
+  });
+  const fetcher = stubModelsFetcher([MODEL_CLAUDE, MODEL_GEMINI]);
+  const combosFetcher = stubCombosFetcher([COMBO_CLAUDE_TIER]);
+  const enrichmentFetcher = stubEnrichmentFetcher(
+    new Map<string, OmniRouteEnrichmentEntry>([
+      ["claude-sonnet-4-6", { name: "Claude Sonnet 4.6" }],
+      ["gemini-3-flash", { name: "Gemini 3 Flash" }],
+    ])
+  );
+  const logger = captureWarn();
+
+  const hook = createOmniRouteConfigHook(
+    { providerId: "omniroute" },
+    { readAuthJson, fetcher, combosFetcher, enrichmentFetcher, logger }
+  );
+  const input = makeInput();
+  await hook(input);
+
+  const entry = (input as { provider: Record<string, OmniRouteStaticProviderEntry> }).provider
+    .omniroute;
+  assert.ok(entry);
+  assert.equal(entry.models["claude-sonnet-4-6"].name, "Claude Sonnet 4.6");
+  assert.equal(entry.models["gemini-3-flash"].name, "Gemini 3 Flash");
+  // Combo names still come from /api/combos — enrichment overlay does NOT touch combos.
+  assert.equal(entry.models["combo/claude-tier"].name, "Claude Tier");
+  assert.equal(enrichmentFetcher.callCount(), 1);
+});
+
+test("config: features.enrichment=false skips enrichment fetch + keeps raw-id names", async () => {
+  const readAuthJson = stubReadAuthJson({
+    omniroute: { type: "api", key: "sk-test", baseURL: "https://or.example/v1" },
+  });
+  const fetcher = stubModelsFetcher([MODEL_CLAUDE]);
+  const combosFetcher = stubCombosFetcher([]);
+  const enrichmentFetcher = stubEnrichmentFetcher(
+    new Map<string, OmniRouteEnrichmentEntry>([
+      ["claude-sonnet-4-6", { name: "Claude Sonnet 4.6" }],
+    ])
+  );
+  const logger = captureWarn();
+
+  const hook = createOmniRouteConfigHook(
+    { providerId: "omniroute", features: { enrichment: false } },
+    { readAuthJson, fetcher, combosFetcher, enrichmentFetcher, logger }
+  );
+  const input = makeInput();
+  await hook(input);
+
+  const entry = (input as { provider: Record<string, OmniRouteStaticProviderEntry> }).provider
+    .omniroute;
+  assert.ok(entry);
+  assert.equal(enrichmentFetcher.callCount(), 0, "enrichment fetch suppressed by feature flag");
+  assert.equal(entry.models["claude-sonnet-4-6"].name, "claude-sonnet-4-6", "raw id retained");
+});
+
+test("config: enrichment fetcher throws → soft-fail (warn + raw-id static catalog)", async () => {
+  const readAuthJson = stubReadAuthJson({
+    omniroute: { type: "api", key: "sk-test", baseURL: "https://or.example/v1" },
+  });
+  const fetcher = stubModelsFetcher([MODEL_CLAUDE]);
+  const combosFetcher = stubCombosFetcher([]);
+  const enrichmentFetcher = throwingEnrichmentFetcher();
+  const logger = captureWarn();
+
+  const hook = createOmniRouteConfigHook(
+    { providerId: "omniroute" },
+    { readAuthJson, fetcher, combosFetcher, enrichmentFetcher, logger }
+  );
+  const input = makeInput();
+  await hook(input);
+
+  const entry = (input as { provider: Record<string, OmniRouteStaticProviderEntry> }).provider
+    .omniroute;
+  assert.ok(entry, "static block still published on enrichment failure");
+  assert.equal(entry.models["claude-sonnet-4-6"].name, "claude-sonnet-4-6", "raw id retained");
+  assert.equal(enrichmentFetcher.callCount(), 1);
+  assert.ok(
+    logger.entries.some((e) => String(e[0]).includes("/api/pricing/models fetch failed")),
+    "enrichment-fetch breadcrumb emitted"
+  );
+});
+
+test("config: cached rawEnrichment from earlier provider hook is reused (no refetch)", async () => {
+  const readAuthJson = stubReadAuthJson({
+    omniroute: { type: "api", key: "sk-shared", baseURL: "https://or.example/v1" },
+  });
+  const fetcher = stubModelsFetcher([MODEL_CLAUDE]);
+  const combosFetcher = stubCombosFetcher([]);
+  const enrichmentFetcher = stubEnrichmentFetcher(
+    new Map<string, OmniRouteEnrichmentEntry>([
+      ["claude-sonnet-4-6", { name: "Claude Sonnet 4.6" }],
+    ])
+  );
+  const sharedCache: OmniRouteFetchCache = new Map();
+  const logger = captureWarn();
+
+  const providerHook = createOmniRouteProviderHook(
+    { providerId: "omniroute", baseURL: "https://or.example/v1", modelCacheTtl: 60_000 },
+    { fetcher, combosFetcher, enrichmentFetcher, cache: sharedCache }
+  );
+  const configHook = createOmniRouteConfigHook(
+    { providerId: "omniroute", baseURL: "https://or.example/v1", modelCacheTtl: 60_000 },
+    { readAuthJson, fetcher, combosFetcher, enrichmentFetcher, cache: sharedCache, logger }
+  );
+
+  // Provider hook fires first (e.g. eager cache warm-up), populates rawEnrichment.
+  await providerHook.models!({} as never, {
+    auth: { type: "api", key: "sk-shared" } as never,
+  });
+  assert.equal(enrichmentFetcher.callCount(), 1);
+
+  // Config hook then fires — must reuse cached enrichment, not refetch.
+  const input = makeInput();
+  await configHook(input);
+  assert.equal(enrichmentFetcher.callCount(), 1, "config reused cached enrichment");
+
+  const entry = (input as { provider: Record<string, OmniRouteStaticProviderEntry> }).provider
+    .omniroute;
+  assert.equal(entry.models["claude-sonnet-4-6"].name, "Claude Sonnet 4.6");
 });

--- a/@omniroute/opencode-plugin/tests/features.test.ts
+++ b/@omniroute/opencode-plugin/tests/features.test.ts
@@ -323,7 +323,7 @@ test("provider hook: compression metadata fetcher called when opted in", async (
   );
   const out = await hook.models!({} as never, { auth: apiAuth("sk") as never });
   assert.equal(called, 1, "compression metadata fetcher called");
-  const combo = out["claude-primary"];
+  const combo = out["combo/claude-primary"];
   assert.ok(combo, "combo entry present");
   assert.match(combo.name, /\[rtk:standard → caveman:full\]/, "combo name decorated with pipeline");
 });


### PR DESCRIPTION
## Summary

Builds on the merged `@omniroute/opencode-plugin` (#2529) to make the model picker readable, filterable, and offline-resilient on OpenCode ≤1.15.5 (anomaly fork incl.) where the dynamic `provider.models` hook never fires.

Three problem-classes solved end-to-end in the static config catalog:

1. **Readable picker** — `combo/<slug>` namespace + `Combo: ` display prefix + compression-pipeline suffix. Replaces UUID combo keys + raw-id collisions from `/v1/models`.
2. **Clean picker** — `features.usableOnly` filters the catalog to providers with at least one healthy connection in `/api/providers` (`isActive: true && testStatus: 'active'`). Subtract-filter: unknown aliases pass through (preserves synthetic providers like agentrouter).
3. **Offline resilience** — `features.diskCache` (default on) persists last-known-good catalog to `${OPENCODE_DATA_DIR}/plugins/omniroute-<providerId>.json`. On a `/v1/models` failure (network drop, whitelist drift) the static block hydrates from disk so the picker stays usable.

Plus the foundational enrichment work the picker needs to display anything other than raw IDs:

4. **Eager enrichment** — config-hook fetches `/api/pricing/models` and overlays display names on raw model entries (`cc/claude-opus-4-7 → "Claude Opus 4.7"`). Previously this only happened in the dynamic provider hook which OC ≤1.15.5 doesn't invoke during `serve`.
5. **Compression metadata** — opt-in `features.compressionMetadata` fetches `/api/context/combos` and appends the compression pipeline to combo names (`[rtk:standard → caveman:full]`).

All features composable, all default to safe defaults (existing behavior preserved), all soft-fail on fetcher errors with warn breadcrumbs.

## Why this matters

Before: TUI model picker shows raw ids (`cc/claude-opus-4-7`, `88a912ac-...`) for everything except 19 named combos. Combos collide visually with raw-mirror entries. Network drop = empty catalog.

After: TUI picker shows enriched names (`Claude Opus 4.7`), combos namespaced + prefixed (`combo/claude-primary → Combo: claude-primary [rtk:standard → caveman:full]`), optional filter to "only providers I can actually use right now", and a stale-but-working catalog when upstream is unreachable.

## Code surface

`@omniroute/opencode-plugin/src/index.ts`:

- **`featuresSchema`** — adds `usableOnly?` + `diskCache?` flags (zod strict, both optional).
- **`OmniRouteEnrichmentEntry`** — gains `providerAlias` + `providerCanonical` metadata so the usableOnly filter can resolve `<alias>/<model-id>` without a separate side-table.
- **`OmniRouteProviderConnection`** + **`defaultOmniRouteProvidersFetcher`** — new fetcher for `/api/providers`, tolerates `{connections:[...]}` envelope or bare array, soft-fails to `[]`.
- **`OmniRouteFetchCacheEntry`** — adds `rawConnections` field so both hooks share one cache shape.
- **Pure helpers** (exported): `usableProviderAliasSet`, `isUsableRawModelId`, `isUsableCombo`, `diskSnapshotPath`, `defaultDiskSnapshotReader`, `defaultDiskSnapshotWriter`, `noopDiskSnapshotReader`, `noopDiskSnapshotWriter`, `slugifyComboName`, `buildComboKey`.
- **`buildStaticProviderEntry`** — extended to 8 args, applies usableOnly filter inline, accepts `enrichment` + `compressionCombos` + `connections`.
- **`createOmniRouteConfigHook`** — new deps `providersFetcher` + `diskSnapshotReader` + `diskSnapshotWriter`. Cache miss now tries fetch, falls back to disk snapshot only when `/v1/models` actually threw, writes snapshot best-effort after a healthy refresh.
- **`createOmniRouteProviderHook`** — mirrors the config-hook for usableOnly + Combo: prefix + combo namespace + compression suffix so OC ≥1.14.49 behaves identically.

`@omniroute/opencode-plugin/README.md`:

- Features table updated with combo namespace + prefix + compression + usableOnly + diskCache rows.
- features-block table gains `usableOnly` and `diskCache` documented entries.
- New "production-leaning defaults" example showing all five flags composed.

## Tests

**172/172 pass** (`npm test`):

- 4 new enrichment overlay + slug-disambiguator tests (commit 1).
- 3 usableOnly tests in `tests/config-shim.test.ts`: off (no filter), on (drops non-usable, keeps usable + unknown), on + providers fetch fails (soft-fail keeps everything).
- 1 diskCache test: stale-snapshot hydration when `/v1/models` throws.
- Existing 'fetchers throw → stub entry' test updated to opt out of disk-cache fallback via `features: { diskCache: false }`.
- Combo: prefix fixture updates in `combos.test.ts` + `config-shim.test.ts`.

`npm run build` clean (ESM 567 KB, CJS 570 KB, DTS 42 KB).

## Live verification

Run against `https://or4269.mrmm.xyz` with full features block (combos + enrichment + compressionMetadata + usableOnly + diskCache all on):

- **448 models** in `/provider` response (down from 467 raw — 19 deduplicated via combo-name collision).
- **19/19 combos** under `combo/<slug>` keys with `Combo: ` prefix and `[rtk:standard → caveman:full]` suffix.
- **309 raw provider/model pairs** enriched with display names.
- **0 leftover UUID keys**.
- **Disk snapshot written**: `~/.local/share/opencode/plugins/omniroute-omniroute.json` 2.2 MB containing 455 models + 12050 enrichment entries after one successful refresh.
- Plugin stderr clean — only the `initialized` breadcrumb.

Tested in both single-instance and dual-install (prod + preprod side-by-side, per-instance disk snapshots) configurations.

## Commit history

Two focused commits stacked on `release/v3.8.2` HEAD `193a8580` (no rebase needed):

1. `feat(opencode-plugin): eager enrichment + combo namespace + compression metadata in static catalog`
2. `feat(opencode-plugin): Combo: prefix + usableOnly filter + disk-cache fallback`

Each green at HEAD, easy to bisect.

## Backwards compatibility

- All new flags default to safe values: `usableOnly` defaults off, `diskCache` defaults on (graceful fail-through; doesn't change happy-path output).
- `OmniRouteFetchCacheEntry` gained a field — internal type, breaking only for code that constructed cache entries by hand (none in test suite or sibling packages).
- `buildStaticProviderEntry` gained two trailing optional params — backwards-compatible call sites unchanged.
- Existing tests preserved (172 vs 164 baseline; 8 net new, 1 modified opt-out, 7 fixture updates for the Combo: prefix).

## Follow-ups (separate PRs)

- Surface `cost` on `OmniRouteStaticModelEntry` so per-million-token prices reach the static block too (today static schema doesn't carry cost; provider-hook does on OC ≥1.14.49).
- Add a `features.activeRefreshInterval` to push fresh catalog through disk every N seconds rather than only at OC startup.
- Document the `instances: [...]` config shape for native multi-instance (currently dual-install workaround per README §Multi-instance).
