### PR TITLE
fix(github): remove openai-responses targetFormat from haiku/sonnet models

### DIFF
--- a/open-sse/config/providerRegistry.ts
+++ b/open-sse/config/providerRegistry.ts
@@ -146,7 +146,13 @@ const KIMI_CODING_SHARED = {
     "Anthropic-Version": ANTHROPIC_VERSION_HEADER,
   },
   models: [
-    { id: "kimi-k2.6", name: "Kimi K2.6", contextLength: 262144, maxOutputTokens: 262144, supportsVision: true },
+    {
+      id: "kimi-k2.6",
+      name: "Kimi K2.6",
+      contextLength: 262144,
+      maxOutputTokens: 262144,
+      supportsVision: true,
+    },
     {
       id: "kimi-k2.6-thinking",
       name: "Kimi K2.6 Thinking",
@@ -891,21 +897,18 @@ export const REGISTRY: Record<string, RegistryEntry> = {
       {
         id: "claude-haiku-4.5",
         name: "Claude Haiku 4.5",
-        targetFormat: "openai-responses",
         contextLength: 200000,
         maxOutputTokens: 64000,
       },
       {
         id: "claude-sonnet-4.5",
         name: "Claude Sonnet 4.5",
-        targetFormat: "openai-responses",
         contextLength: 200000,
         maxOutputTokens: 64000,
       },
       {
         id: "claude-sonnet-4.6",
         name: "Claude Sonnet 4.6",
-        targetFormat: "openai-responses",
         contextLength: 200000,
         maxOutputTokens: 64000,
       },


### PR DESCRIPTION
Models claude-haiku-4.5, claude-sonnet-4.5, claude-sonnet-4.6 do not support the Responses API. Setting targetFormat caused 400 errors. Opus models keep their targetFormat.