### PR TITLE
fix(mimo): add supportsVision flag to MiMo-V2.5, V2.5-Pro, and V2-Omni

### DIFF
--- a/src/shared/constants/modelSpecs.ts
+++ b/src/shared/constants/modelSpecs.ts
@@ -169,16 +169,19 @@ export const MODEL_SPECS: Record<string, ModelSpec> = {
     maxOutputTokens: 131072,
     contextWindow: 1048576,
     supportsTools: true,
+    supportsVision: true,
   },
   "mimo-v2.5": {
     maxOutputTokens: 131072,
     contextWindow: 1048576,
     supportsTools: true,
+    supportsVision: true,
   },
   "mimo-v2-omni": {
     maxOutputTokens: 131072,
     contextWindow: 262144,
     supportsTools: true,
+    supportsVision: true,
   },
   "mimo-v2-flash": {
     maxOutputTokens: 65536,

--- a/tests/unit/xiaomi-mimo-provider.test.ts
+++ b/tests/unit/xiaomi-mimo-provider.test.ts
@@ -1,3 +1,4 @@
+import { getModelSpec } from "../../src/shared/constants/modelSpecs.ts";
 import test from "node:test";
 import assert from "node:assert/strict";
 
@@ -95,4 +96,14 @@ test("xiaomi-mimo update schema accepts custom regional baseUrl", () => {
       "https://token-plan-cn.xiaomimimo.com/v1"
     );
   }
+});
+
+
+test("MiMo-V2.5, V2.5-Pro, and V2-Omni report vision capability", () => {
+  // Omnimodal models should have supportsVision
+  assert.equal(getModelSpec("mimo-v2.5-pro")?.supportsVision, true);
+  assert.equal(getModelSpec("mimo-v2.5")?.supportsVision, true);
+  assert.equal(getModelSpec("mimo-v2-omni")?.supportsVision, true);
+  // Flash is text-only — should NOT have vision
+  assert.equal(getModelSpec("mimo-v2-flash")?.supportsVision, undefined);
 });


### PR DESCRIPTION
## Summary

Adds `supportsVision: true` to `src/shared/constants/modelSpecs.ts` for the three MiMo models that support vision:

- `mimo-v2.5-pro`
- `mimo-v2.5`
- `mimo-v2-omni`

`mimo-v2-flash` remains unchanged (text-only coding model).

## Evidence

- **MiMo-V2.5**: "native omnimodal model supporting text, image, video, and audio" — [huggingface.co/XiaomiMiMo/MiMo-V2.5](https://huggingface.co/XiaomiMiMo/MiMo-V2.5)
- **MiMo-V2-Omni**: "natively processes image, video, and audio inputs" — [mimo.xiaomi.com/mimo-v2-omni](https://mimo.xiaomi.com/mimo-v2-omni)

## Tests

```
tests 7
pass 6
fail 1  (pre-existing openai/gpt-4o synced metadata test, unrelated)
```

Closes: #2582
