### PR TITLE
feat(api-airforce): add free provider with 55 models

### DIFF
--- a/open-sse/config/providerRegistry.ts
+++ b/open-sse/config/providerRegistry.ts
@@ -146,7 +146,13 @@ const KIMI_CODING_SHARED = {
     "Anthropic-Version": ANTHROPIC_VERSION_HEADER,
   },
   models: [
-    { id: "kimi-k2.6", name: "Kimi K2.6", contextLength: 262144, maxOutputTokens: 262144, supportsVision: true },
+    {
+      id: "kimi-k2.6",
+      name: "Kimi K2.6",
+      contextLength: 262144,
+      maxOutputTokens: 262144,
+      supportsVision: true,
+    },
     {
       id: "kimi-k2.6-thinking",
       name: "Kimi K2.6 Thinking",
@@ -1509,6 +1515,62 @@ export const REGISTRY: Record<string, RegistryEntry> = {
       "X-Title": "Endpoint Proxy",
     },
     models: [{ id: "auto", name: "Auto (Best Available)" }],
+  },
+
+  "api-airforce": {
+    id: "api-airforce",
+    alias: "af",
+    format: "openai",
+    executor: "default",
+    baseUrl: "https://api.airforce/v1/chat/completions",
+    modelsUrl: "https://api.airforce/v1/models",
+    authType: "apikey",
+    authHeader: "bearer",
+    defaultContextLength: 128000,
+    headers: {
+      "HTTP-Referer": "https://endpoint-proxy.local",
+      "X-Title": "Endpoint Proxy",
+    },
+    models: [
+      // Free tier models (55 available)
+      { id: "x-ai/grok-3", name: "Grok-3 (Free)", contextLength: 131072, maxOutputTokens: 65536 },
+      {
+        id: "x-ai/grok-2-1212",
+        name: "Grok-2 1212 (Free)",
+        contextLength: 131072,
+        maxOutputTokens: 65536,
+      },
+      {
+        id: "anthropic/claude-3.7-sonnet",
+        name: "Claude 3.7 Sonnet (Free)",
+        contextLength: 200000,
+        maxOutputTokens: 8192,
+      },
+      {
+        id: "qwen/qwen3-32b",
+        name: "Qwen3 32B (Free)",
+        contextLength: 128000,
+        maxOutputTokens: 8192,
+      },
+      {
+        id: "moonshot/kimi-k2.6",
+        name: "Kimi K2.6 (Free)",
+        contextLength: 262144,
+        maxOutputTokens: 65536,
+      },
+      {
+        id: "google/gemini-2.5-flash",
+        name: "Gemini 2.5 Flash (Free)",
+        contextLength: 1048576,
+        maxOutputTokens: 65536,
+      },
+      {
+        id: "deepseek/deepseek-v3",
+        name: "DeepSeek V3 (Free)",
+        contextLength: 262144,
+        maxOutputTokens: 16384,
+      },
+    ],
   },
 
   qianfan: {

--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -316,6 +316,21 @@ export const APIKEY_PROVIDERS = {
     hasFree: true,
     freeNote: "Free models at $0/token with :free suffix - 20 RPM / 200 RPD",
   },
+  "api-airforce": {
+    id: "api-airforce",
+    alias: "af",
+    name: "Api.airforce",
+    icon: "flight",
+    color: "#1E3A5F",
+    textIcon: "AF",
+    website: "https://api.airforce",
+    hasFree: true,
+    freeNote:
+      "55 free tier models including Grok-3, Claude 3.7, Qwen3, Kimi-K2, Gemini 2.5 Flash, DeepSeek-V3",
+    apiHint:
+      "Get your API key from https://panel.api.airforce — OpenAI-compatible endpoint at https://api.airforce/v1",
+    capabilities: { embeddings: false },
+  },
   astraflow: {
     id: "astraflow",
     alias: "astraflow",


### PR DESCRIPTION
Adds api.airforce as free tier provider. 55 free models via https://api.airforce/v1.

Closes #2205