### PR TITLE
fix(mimo): add supportsVision flag to MiMo-V2.5, V2.5-Pro, and V2-Omni

### DIFF
--- a/src/shared/constants/modelSpecs.ts
+++ b/src/shared/constants/modelSpecs.ts
@@ -169,16 +169,19 @@ export const MODEL_SPECS: Record<string, ModelSpec> = {
     maxOutputTokens: 131072,
     contextWindow: 1048576,
     supportsTools: true,
+    supportsVision: true,
   },
   "mimo-v2.5": {
     maxOutputTokens: 131072,
     contextWindow: 1048576,
     supportsTools: true,
+    supportsVision: true,
   },
   "mimo-v2-omni": {
     maxOutputTokens: 131072,
     contextWindow: 262144,
     supportsTools: true,
+    supportsVision: true,
   },
   "mimo-v2-flash": {
     maxOutputTokens: 65536,

--- a/tests/unit/xiaomi-mimo-provider.test.ts
+++ b/tests/unit/xiaomi-mimo-provider.test.ts
@@ -1,3 +1,4 @@
+import { getModelSpec } from "../../src/shared/constants/modelSpecs.ts";
 import test from "node:test";
 import assert from "node:assert/strict";
 
@@ -95,4 +96,14 @@ test("xiaomi-mimo update schema accepts custom regional baseUrl", () => {
       "https://token-plan-cn.xiaomimimo.com/v1"
     );
   }
+});
+
+
+test("MiMo-V2.5, V2.5-Pro, and V2-Omni report vision capability", () => {
+  // Omnimodal models should have supportsVision
+  assert.equal(getModelSpec("mimo-v2.5-pro")?.supportsVision, true);
+  assert.equal(getModelSpec("mimo-v2.5")?.supportsVision, true);
+  assert.equal(getModelSpec("mimo-v2-omni")?.supportsVision, true);
+  // Flash is text-only — should NOT have vision
+  assert.equal(getModelSpec("mimo-v2-flash")?.supportsVision, undefined);
 });


### PR DESCRIPTION
## Description

Fixes #2582.

Xiaomi MiMo models **mimo-v2-omni**, **mimo-v2.5**, and **mimo-v2.5-pro** are native omnimodal models that support vision (text, image, video, and audio understanding), but OmniRoute did not report them as vision-capable.

This caused image attachments to be silently dropped when routing requests through these models.

## Changes

- `src/shared/constants/modelSpecs.ts`: Added `supportsVision: true` to `mimo-v2.5-pro`, `mimo-v2.5`, and `mimo-v2-omni`

## Verification

These models are confirmed by Xiaomi official docs as native omnimodal models supporting image, video, and audio understanding alongside text.

## References

- https://huggingface.co/XiaomiMiMo/MiMo-V2.5
- https://mimo.xiaomi.com/mimo-v2-omni