### PR TITLE
fix(#2575): check DB feature flag override in arePrivateProviderUrlsAllowed()

### DIFF
--- a/src/shared/network/outboundUrlGuard.ts
+++ b/src/shared/network/outboundUrlGuard.ts
@@ -1,4 +1,5 @@
 import { isIP } from "node:net";
+import { resolveFeatureFlag } from "@/shared/utils/featureFlags";
 
 const TRUE_ENV_VALUES = new Set(["1", "true", "yes", "on"]);
 
@@ -127,6 +128,14 @@ export function arePrivateProviderUrlsAllowed() {
   const legacyValue = process.env["OUTBOUND_SSRF_GUARD_ENABLED"];
   if (legacyValue && ["false", "0", "no", "off"].includes(legacyValue.trim().toLowerCase()))
     return true;
+
+  // Check feature flag DB override — supports runtime toggle without restart
+  try {
+    const dbValue = resolveFeatureFlag(PRIVATE_PROVIDER_URLS_ENV);
+    if (dbValue && TRUE_ENV_VALUES.has(dbValue.trim().toLowerCase())) return true;
+  } catch {
+    // DB not initialized yet — fall back to env-only check
+  }
 
   return false;
 }


### PR DESCRIPTION
Fixes #2575.

## Problem

Toggling `OMNIROUTE_ALLOW_PRIVATE_PROVIDER_URLS` in the Feature Flags UI (marked `requiresRestart: false`) had no effect in Electron mode. The actual behavior was only driven by the `process.env` value set at startup, so users had to restart the server for the change to take effect — defeating the purpose of the 'no restart required' flag.

## Root Cause

`arePrivateProviderUrlsAllowed()` in `src/shared/network/outboundUrlGuard.ts` only read from `process.env[PRIVATE_PROVIDER_URLS_ENV]`. It never consulted the DB-backed feature flag store, so UI toggles were silently ignored.

## Changes

- `src/shared/network/outboundUrlGuard.ts`: Added a fallback call to `resolveFeatureFlag(PRIVATE_PROVIDER_URLS_ENV)` from the shared feature flag utils. If the DB override exists and is `true`, it returns `true` immediately. The env-var check remains primary (same priority order as the rest of the feature flag resolution chain).
- Wrapped in try/catch for startup safety — if the DB isn't initialized yet, it degrades gracefully to env-only behavior.

## Testing

- `lsp_diagnostics` clean on changed file
- Runtime logic: env var still takes precedence; DB override applies when env var is unset