### PR TITLE
fix(#2544): add SSE heartbeat keepalive to Responses API transform stream

### DIFF
--- a/open-sse/transformer/responsesTransformer.ts
+++ b/open-sse/transformer/responsesTransformer.ts
@@ -75,7 +75,7 @@ export function createResponsesLogger(model, logsDir = null) {
  * @param {Object} logger - Optional logger instance
  * @returns {TransformStream}
  */
-export function createResponsesApiTransformStream(logger = null) {
+export function createResponsesApiTransformStream(logger = null, keepaliveIntervalMs = 3000) {
   const state = {
     seq: 0,
     responseId: `resp_${Date.now()}`,
@@ -99,6 +99,7 @@ export function createResponsesApiTransformStream(logger = null) {
     buffer: "",
     completedSent: false,
     usage: null,
+    keepaliveTimer: null,
   };
 
   const encoder = new TextEncoder();
@@ -321,6 +322,12 @@ export function createResponsesApiTransformStream(logger = null) {
   };
 
   return new TransformStream({
+    start(controller) {
+      // Periodic keepalive heartbeat to prevent client timeouts (Codex CLI #2544)
+      state.keepaliveTimer = setInterval(() => {
+        controller.enqueue(encoder.encode(": keepalive\n\n"));
+      }, keepaliveIntervalMs);
+    },
     transform(chunk, controller) {
       const text = new TextDecoder().decode(chunk);
       logger?.logInput(text.trim());
@@ -539,6 +546,11 @@ export function createResponsesApiTransformStream(logger = null) {
     },
 
     flush(controller) {
+      // Clear keepalive timer
+      if (state.keepaliveTimer) {
+        clearInterval(state.keepaliveTimer);
+        state.keepaliveTimer = null;
+      }
       for (const i in state.msgItemAdded) closeMessage(controller, i);
       closeReasoning(controller);
       for (const i in state.funcCallIds) closeToolCall(controller, i);


### PR DESCRIPTION
Fixes #2544.

## Problem

Codex CLI 0.130.0 disconnects the Responses API stream after ~5 seconds of inactivity. This occurs when the upstream provider is in a thinking/reasoning phase or when there are long gaps between SSE delta chunks.

## Root Cause

The `createResponsesApiTransformStream` function in `open-sse/transformer/responsesTransformer.ts` had no keepalive mechanism. During idle periods (no SSE data flowing), the TCP connection would timeout from the client side.

## Changes

- `open-sse/transformer/responsesTransformer.ts`:
  - Added `keepaliveIntervalMs` parameter (default: 3000ms) to `createResponsesApiTransformStream()`
  - Added `start()` method to the `TransformStream` that starts a `setInterval` sending SSE comment lines (`: keepalive\n\n`)
  - Added `keepaliveTimer` to `state`, cleared in `flush()`
  - SSE comment lines are spec-compliant — SSE parsers ignore lines starting with `:`

## Testing

- `lsp_diagnostics` clean
- Prettier compatibility verified