### PR TITLE
fix(release): merge main into release/v3.8.2 — resolve 2 conflicts

### DIFF
--- a/src/lib/cloudAgent/baseAgent.ts
+++ b/src/lib/cloudAgent/baseAgent.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from "node:crypto";
 import type {
   CloudAgentTask,
   CloudAgentStatus,
@@ -86,10 +87,12 @@ export abstract class CloudAgentBase {
   }
 
   protected generateTaskId(): string {
-    return `task_${Date.now()}_${Math.random().toString(36).substring(2, 11)}`;
+    // Cryptographically secure suffix (not Math.random) — task IDs flow into
+    // session/external identifiers, so they must be unpredictable (CodeQL js/insecure-randomness).
+    return `task_${Date.now()}_${randomBytes(8).toString("hex")}`;
   }
 
   protected generateActivityId(): string {
-    return `act_${Date.now()}_${Math.random().toString(36).substring(2, 11)}`;
+    return `act_${Date.now()}_${randomBytes(8).toString("hex")}`;
   }
 }

--- a/tests/unit/antigravity-discovery-bootstrap.test.ts
+++ b/tests/unit/antigravity-discovery-bootstrap.test.ts
@@ -152,7 +152,10 @@ describe("ensureAntigravityProjectAssigned", () => {
 
     const mockFetch = async (url: string, _init?: RequestInit): Promise<Response> => {
       hitUrls.push(url);
-      if (url.includes("daily-cloudcode-pa.googleapis.com")) {
+      // Exact hostname match (not substring .includes) so the check can't be fooled by a
+      // look-alike host like daily-cloudcode-pa.googleapis.com.evil.com (CodeQL
+      // js/incomplete-url-substring-sanitization).
+      if (new URL(url).hostname === "daily-cloudcode-pa.googleapis.com") {
         // First URL fails
         return new Response("not found", { status: 404 });
       }


### PR DESCRIPTION
## Resolves 2 merge conflicts between `main` and `release/v3.8.2`

The `release/v3.8.2` branch has a stale `CONFLICTING` label on GitHub. After pulling in `origin/main`, two files had content conflicts which are now resolved:

### `src/lib/cloudAgent/baseAgent.ts`
- **Main**: security fix using `randomBytes(8).toString(hex)` (CodeQL `js/insecure-randomness`)
- **Release**: alternative fix using `crypto.randomUUID().replace(/-/g, "").substring(0, 9)`
- **Resolution**: took main's `randomBytes` version — it was the reviewed/merged fix in the security PR

### `tests/unit/antigravity-discovery-bootstrap.test.ts`
- **Main**: added 3-line comment block explaining why `.includes()` → `new URL(url).hostname ===` (CodeQL `js/incomplete-url-substring-sanitization`)
- **Resolution**: took main's version with the full comment block

### Verification
- `git merge-tree`: ✅ clean merge after resolution
- `prettier --check`: ✅ passes