### PR TITLE
fix: restore semantic passthrough system-role-only extraction instead of full normalization

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -1293,8 +1293,7 @@ export function extractSystemRoleMessages(payload: Record<string, unknown>): voi
   const messages = payload.messages as Array<{ role?: unknown; content?: unknown }>;
   // Treat both `system` and `developer` as system-equivalent (OpenAI's Responses
   // API renamed system → developer). Anthropic rejects either as a chat role, so
-  // both must be lifted into the top-level `system` field — parity with the
-  // normal-path extractSystemMessagesToBody closure.
+  // both must be lifted into the top-level `system` field.
   const isSystemRole = (role: unknown): boolean =>
     typeof role === "string" &&
     (role.toLowerCase() === "system" || role.toLowerCase() === "developer");
@@ -2661,45 +2660,6 @@ export async function handleChatCore({
     content?: unknown;
   };
 
-  // Shared helper: lift any system/developer role messages out of the messages
-  // array into the top-level system parameter. Anthropic's Messages API rejects
-  // system/developer roles inside messages[]. Case-insensitive to be defensive.
-  const extractSystemMessagesToBody = (payload: Record<string, unknown>) => {
-    if (!Array.isArray(payload.messages)) return;
-    const messages = payload.messages as ClaudeMessage[];
-    const systemMessages = messages.filter((m) => {
-      const role = String(m.role || "").toLowerCase();
-      return role === "system" || role === "developer";
-    });
-    if (systemMessages.length === 0) return;
-    const extraBlocks: ClaudeContentBlock[] = [];
-    for (const sm of systemMessages) {
-      if (typeof sm.content === "string" && sm.content.length > 0) {
-        extraBlocks.push({ type: "text", text: sm.content });
-      } else if (Array.isArray(sm.content)) {
-        for (const block of sm.content as ClaudeContentBlock[]) {
-          if (block?.type === "text" && typeof block.text === "string" && block.text.length > 0) {
-            extraBlocks.push(block);
-          }
-        }
-      }
-    }
-    if (extraBlocks.length > 0) {
-      const existingSystem = payload.system;
-      if (typeof existingSystem === "string" && existingSystem.length > 0) {
-        payload.system = [{ type: "text", text: existingSystem }, ...extraBlocks];
-      } else if (Array.isArray(existingSystem)) {
-        payload.system = [...(existingSystem as ClaudeContentBlock[]), ...extraBlocks];
-      } else {
-        payload.system = extraBlocks;
-      }
-    }
-    payload.messages = messages.filter((m) => {
-      const role = String(m.role || "").toLowerCase();
-      return role !== "system" && role !== "developer";
-    });
-  };
-
   const normalizeClaudeUpstreamMessages = (
     payload: Record<string, unknown>,
     options?: { preserveToolResultBlocks?: boolean }
@@ -2709,7 +2669,7 @@ export async function handleChatCore({
     let messages = payload.messages as ClaudeMessage[];
 
     // Extract system/developer role messages into top-level system parameter.
-    extractSystemMessagesToBody(payload);
+    extractSystemRoleMessages(payload);
     messages = payload.messages as ClaudeMessage[];
 
     // Anthropic rejects empty text blocks in native Messages payloads.
@@ -2836,7 +2796,7 @@ export async function handleChatCore({
       if (isClaudeCodeSemanticPassthrough) {
         // Semantic passthrough: only lift system/developer role messages
         // without converting file/document blocks, tool history, etc.
-        extractSystemMessagesToBody(translatedBody);
+        extractSystemRoleMessages(translatedBody);
       } else {
         // Non-CC path: full normalization including content type conversion.
         normalizeClaudeUpstreamMessages(translatedBody, { preserveToolResultBlocks: true });
@@ -2868,7 +2828,7 @@ export async function handleChatCore({
       if (isClaudeCodeSemanticPassthrough) {
         // Only lift system/developer messages — preserves Claude Code's
         // native payload structure (documents, tool chains, thinking, etc.)
-        extractSystemMessagesToBody(translatedBody);
+        extractSystemRoleMessages(translatedBody);
       } else {
         normalizeClaudeUpstreamMessages(translatedBody, { preserveToolResultBlocks: true });
       }

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -2833,11 +2833,14 @@ export async function handleChatCore({
       });
       log?.debug?.("FORMAT", "claude-code-compatible bridge enabled");
 
-      // Fix #2468: extract role:"system" from messages → top-level system
-      // in the compatible bridge path. The preserveClaudeMessages flag
-      // skips the OpenAI round-trip but may leave system-role messages in
-      // the array, which Anthropic's Messages API now rejects (400).
-      normalizeClaudeUpstreamMessages(translatedBody, { preserveToolResultBlocks: true });
+      if (isClaudeCodeSemanticPassthrough) {
+        // Semantic passthrough: only lift system/developer role messages
+        // without converting file/document blocks, tool history, etc.
+        extractSystemMessagesToBody(translatedBody);
+      } else {
+        // Non-CC path: full normalization including content type conversion.
+        normalizeClaudeUpstreamMessages(translatedBody, { preserveToolResultBlocks: true });
+      }
     } else if (isClaudePassthrough) {
       // Pure passthrough: forward the body as-is without OpenAI round-trip.
       // The Claude→OpenAI→Claude double translation was lossy and corrupted
@@ -2862,7 +2865,13 @@ export async function handleChatCore({
       // round-trip, but even pure Claude bodies may carry system content as
       // role:"system" messages rather than the top-level system field, which
       // Anthropic's Messages API now rejects with a 400.
-      normalizeClaudeUpstreamMessages(translatedBody, { preserveToolResultBlocks: true });
+      if (isClaudeCodeSemanticPassthrough) {
+        // Only lift system/developer messages — preserves Claude Code's
+        // native payload structure (documents, tool chains, thinking, etc.)
+        extractSystemMessagesToBody(translatedBody);
+      } else {
+        normalizeClaudeUpstreamMessages(translatedBody, { preserveToolResultBlocks: true });
+      }
 
       log?.debug?.("FORMAT", `claude passthrough (preserveCache=${preserveCacheControl})`);
 


### PR DESCRIPTION
## Summary

PR #2519 flattened the semantic passthrough branching from #2351, replacing the lightweight `extractSystemRoleMessages` call with the full `normalizeClaudeUpstreamMessages` on both the native Claude and CC-compatible passthrough paths.

This re-introduced the original problem #2351 was fixing: the full normalization converts file/document blocks to text, flattens tool_use/tool_result chains, and drops unknown content types — corrupting well-formed Claude Code payloads.

This PR restores the semantic passthrough branching so that verified Claude Code requests only run `extractSystemRoleMessages` (lifting system/developer role messages to the top-level `system` field), while non-CC requests still run the full normalization pipeline.

## Highlights

- **CC-compatible bridge path**: When `isClaudeCodeSemanticPassthrough` is true, only extracts system/developer messages instead of full normalization.
- **Native passthrough path**: Same — only system/developer extraction for verified Claude Code clients, full normalization for others.
- **Consolidated on exported `extractSystemRoleMessages`** — the inline `extractSystemMessagesToBody` duplicate (from PR #2497) was removed. The exported function now serves both production code and tests, eliminating dead code and ensuring tests validate the actual runtime path.
- **Zero behavior change** for non-Claude-Code requests (still run full `normalizeClaudeUpstreamMessages`).

## Related Issues

- Fixes #2351 (regression) — semantic passthrough optimization restored.
- Fixes #2468 — system role 400 error still prevented via `extractSystemRoleMessages` in both passthrough paths.

## Validation

- [x] `npm run dev` starts without errors
- [x] Existing `system-role-extraction.test.ts` tests pass (9/9)
- [x] Only 1 file changed (`open-sse/handlers/chatCore.ts`), 4 insertions, 44 deletions — minimal diff

## Reviewer Notes

- `extractSystemRoleMessages` uses case-insensitive role matching and shallow-clones content blocks to prevent shared reference issues.
- `normalizeClaudeUpstreamMessages` itself is unchanged — it still delegates to `extractSystemRoleMessages` for the system-role step, then applies content normalization after.
- Builds on the system-role fix from PR #2497 (@unitythemaker) by restoring the #2351 passthrough branching that #2519 removed.