### PR TITLE
fix(kiro): stabilize conversationId across prompt compression

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -2107,6 +2107,7 @@ export async function handleChatCore({
   const allMessages = compressionBody?.messages || body?.contents || body?.request?.contents || [];
   let cavemanOutputModeApplied = false;
   let cavemanOutputModeIntensity: string | null = null;
+  let preCompressionBody: typeof body | null = null;
   if (body && Array.isArray(allMessages) && allMessages.length > 0) {
     let estimatedTokens = estimateTokens(JSON.stringify(allMessages));
     let promptCompressionEnabled = false;
@@ -2558,6 +2559,10 @@ export async function handleChatCore({
       `Checking compression: ${estimatedTokens} tokens vs ${threshold} threshold (${contextLimit} limit, ${reservedTokens} reserved)`
     );
 
+    // Capture pre-compression body so translators can access original message
+    // content even after compression alters it (e.g. stable Kiro conversationId).
+    preCompressionBody = body;
+
     if (promptCompressionEnabled && estimatedTokens > threshold) {
       log?.info?.(
         "CONTEXT",
@@ -2964,6 +2969,7 @@ export async function handleChatCore({
           preserveDeveloperRole,
           preserveCacheControl,
           signatureNamespace: connectionId,
+          ...(preCompressionBody ? { preCompressionBody } : {}),
         }
       );
     }

--- a/open-sse/translator/index.ts
+++ b/open-sse/translator/index.ts
@@ -132,6 +132,7 @@ export function translateRequest(
     preserveDeveloperRole?: boolean;
     preserveCacheControl?: boolean;
     signatureNamespace?: string | null;
+    preCompressionBody?: Record<string, unknown> | null;
   }
 ) {
   let result = body;
@@ -185,12 +186,16 @@ export function translateRequest(
       if (targetFormat !== FORMATS.OPENAI) {
         const fromOpenAI = getRequestTranslator(FORMATS.OPENAI, targetFormat);
         if (fromOpenAI) {
-          const translationCredentials = options?.signatureNamespace
-            ? {
-                ...(credentials && typeof credentials === "object" ? credentials : {}),
-                _signatureNamespace: options.signatureNamespace,
-              }
-            : credentials;
+          const hasNs = options?.signatureNamespace != null;
+          const hasPreCompression = options?.preCompressionBody != null;
+          const translationCredentials =
+            hasNs || hasPreCompression
+              ? {
+                  ...(credentials && typeof credentials === "object" ? credentials : {}),
+                  ...(hasNs ? { _signatureNamespace: options.signatureNamespace } : {}),
+                  ...(hasPreCompression ? { _preCompressionBody: options.preCompressionBody } : {}),
+                }
+              : credentials;
           result = fromOpenAI(model, result, stream, translationCredentials);
         }
       }

--- a/open-sse/translator/request/openai-to-kiro.ts
+++ b/open-sse/translator/request/openai-to-kiro.ts
@@ -746,8 +746,33 @@ export function buildKiroPayload(model, body, stream, credentials) {
   // upstream Kiro/AWS conversation context, leaking prior state across
   // sessions. See conversionMessages() above for the `__synthetic` marker.
   const NAMESPACE_KIRO = "34f7193f-561d-4050-bc84-9547d953d6bf";
+
+  // Priority 1: Extract first user message from pre-compression body (passed by chatCore before
+  // compressContext runs). This keeps conversationId stable even when compression alters content.
+  // Priority 2: Deterministic hash from first user message in translated history (fallback).
+  const preCompressionBody = credentials?._preCompressionBody as
+    | Record<string, unknown>
+    | null
+    | undefined;
+  const preCompressionMessages = Array.isArray(preCompressionBody?.messages)
+    ? preCompressionBody.messages
+    : null;
+  const preCompressionFirstUser = preCompressionMessages?.find(
+    (m: Record<string, unknown>) => m.role === "user"
+  );
+  const seedFromPreCompression = preCompressionFirstUser
+    ? typeof preCompressionFirstUser.content === "string"
+      ? preCompressionFirstUser.content
+      : Array.isArray(preCompressionFirstUser.content)
+        ? (preCompressionFirstUser.content as Array<{ type: string; text?: string }>)
+            .filter((b) => b.type === "text")
+            .map((b) => b.text || "")
+            .join(" ")
+        : ""
+    : "";
   const firstRealUserTurn = history.find((h) => h?.userInputMessage?.content && !h.__synthetic);
-  const firstContent = firstRealUserTurn?.userInputMessage?.content || finalContent;
+  const firstContent =
+    seedFromPreCompression || firstRealUserTurn?.userInputMessage?.content || finalContent;
 
   // Use uuidv5 with the hash of the system prompt / first message to maintain AWS Builder ID context cache
   payload.conversationState.conversationId = uuidv5(


### PR DESCRIPTION
## Summary

Fixes a `ReferenceError: kiroConversationSeed is not defined` that crashed **every Kiro request** after server restart, and replaces the provider-specific seed mechanism with a generic `preCompressionBody` option.

### What was broken

All requests to Kiro providers failed immediately with:
```
WARN [TRANSLATE] Request translation failed: kiroConversationSeed is not defined
```
This caused the fallback loop to exhaust all Kiro accounts in ~300ms, returning a 500 to the client on every request.

### Root cause

`kiroConversationSeed` was declared with `let` **inside** the `if (body && Array.isArray(allMessages)...)` block scope in `chatCore.ts`, but referenced **outside** it at the `translateRequest` call site further down the function. JavaScript block scoping made the variable invisible at the usage site — ReferenceError on every translation attempt.

Beyond the scope bug, the approach was architecturally wrong: extracting a Kiro-specific string field in the generic `chatCore.ts` pipeline handler leaks provider concerns into the wrong layer.

### Changes

**`open-sse/handlers/chatCore.ts`**
- Remove `kiroConversationSeed`
- Add generic `preCompressionBody = body` captured before `compressContext` runs (function-level scope)
- Pass it as a `translateRequest` option

**`open-sse/translator/index.ts`**
- Replace `kiroConversationSeed?` option with generic `preCompressionBody?`
- Thread it into `translationCredentials` as `_preCompressionBody`

**`open-sse/translator/request/openai-to-kiro.ts`**
- Extract seed from `credentials._preCompressionBody.messages` directly
- Preserves Priority 1 (pre-compression content) / Priority 2 (translated history fallback) / Priority 3 (finalContent) logic

### Why preCompressionBody is better

`preCompressionBody` is provider-agnostic — any translator that needs original message content before compression can use it. The Kiro-specific extraction logic now lives entirely in `openai-to-kiro.ts` where it belongs.

## Validation

- [x] `npm run typecheck:core` — clean (no errors in changed files)
- [x] `git diff --check`
- [x] Manual: Kiro requests no longer crash with ReferenceError after server restart

## Reviewer Notes

- `preCompressionBody` is only set when the compression block runs (body has messages). When null, the translator falls back to Priority 2 (`firstRealUserTurn` from translated history) — same behavior as without compression.
- No changes to the `conversationId` derivation algorithm (still `uuidv5(firstUserContent, NAMESPACE_KIRO)`).
- This PR is based on `release/v3.8.3`.