### PR TITLE
fix(cli): register tsx loader and add opencode config subcommand

### DIFF
--- a/bin/cli/commands/config.mjs
+++ b/bin/cli/commands/config.mjs
@@ -268,27 +268,52 @@ export function registerConfig(program) {
   config
     .command("set <tool>")
     .description("Write config for a tool")
-    .option("--base-url <url>", "OmniRoute API base URL", "http://localhost:20128/v1")
-    .option("--api-key <key>", "API key for the tool")
     .option("--model <model>", "Model identifier (where applicable)")
     .option("--non-interactive", "Do not prompt for confirmation")
     .option("--yes", "Skip confirmation prompt")
     .action(async (tool, opts, cmd) => {
       const globalOpts = cmd.parent.optsWithGlobals();
-      const exitCode = await runConfigSetCommand(tool, { ...opts, output: globalOpts.output });
+      const exitCode = await runConfigSetCommand(tool, {
+        ...opts,
+        apiKey: opts.apiKey || globalOpts.apiKey || process.env.OMNIROUTE_API_KEY,
+        baseUrl: opts.baseUrl || globalOpts.baseUrl || process.env.OMNIROUTE_BASE_URL,
+        output: globalOpts.output,
+      });
       if (exitCode !== 0) process.exit(exitCode);
     });
 
   config
     .command("validate <tool>")
     .description("Validate config format without writing")
-    .option("--base-url <url>", "OmniRoute API base URL", "http://localhost:20128/v1")
-    .option("--api-key <key>", "API key for the tool")
     .option("--model <model>", "Model identifier (where applicable)")
     .option("--json", "Output as JSON")
     .action(async (tool, opts, cmd) => {
       const globalOpts = cmd.parent.optsWithGlobals();
-      const exitCode = await runConfigValidateCommand(tool, { ...opts, output: globalOpts.output });
+      const exitCode = await runConfigValidateCommand(tool, {
+        ...opts,
+        apiKey: opts.apiKey || globalOpts.apiKey || process.env.OMNIROUTE_API_KEY,
+        baseUrl: opts.baseUrl || globalOpts.baseUrl || process.env.OMNIROUTE_BASE_URL,
+        output: globalOpts.output,
+      });
+      if (exitCode !== 0) process.exit(exitCode);
+    });
+
+  // Convenience alias: `config opencode` → `config set opencode`
+  // Matches the documented CLI usage in docs/frameworks/OPENCODE.md.
+  config
+    .command("opencode")
+    .description("Generate OpenCode config (alias for 'config set opencode')")
+    .option("--model <model>", "Model identifier")
+    .option("--non-interactive", "Do not prompt for confirmation")
+    .option("--yes", "Skip confirmation prompt")
+    .action(async (opts, cmd) => {
+      const globalOpts = cmd.parent.optsWithGlobals();
+      const exitCode = await runConfigSetCommand("opencode", {
+        ...opts,
+        apiKey: opts.apiKey || globalOpts.apiKey || process.env.OMNIROUTE_API_KEY,
+        baseUrl: opts.baseUrl || globalOpts.baseUrl || process.env.OMNIROUTE_BASE_URL,
+        output: globalOpts.output,
+      });
       if (exitCode !== 0) process.exit(exitCode);
     });
 

--- a/bin/omniroute.mjs
+++ b/bin/omniroute.mjs
@@ -16,6 +16,11 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { homedir, platform } from "node:os";
 import updateNotifier from "update-notifier";
 
+// Register tsx so dynamic imports of .ts source files (referenced as .js per
+// TypeScript conventions) resolve correctly. The build never emits .js for
+// src/lib/cli-helper/, so tsx handles the .ts → .js resolution at runtime.
+await import("tsx/esm");
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const ROOT = join(__dirname, "..");


### PR DESCRIPTION
## Summary

Two bugs in the CLI that caused `omniroute config list` and `omniroute config opencode` to fail with unhelpful errors.

### Bug 1 — `config list` crashes with MODULE_NOT_FOUND

`bin/cli/commands/config.mjs` dynamically imports `src/lib/cli-helper/tool-detector.js` (and other `.js` files), but the source files are `.ts` with `"noEmit": true` in tsconfig — no `.js` output is ever produced. The CLI entry point runs with plain `node` and never registers `tsx`, so Node cannot resolve `.js` → `.ts`.

**Fix:** Register `tsx/esm` at the top of `bin/omniroute.mjs` so all subsequent dynamic imports of `.ts` source files resolve correctly. This also fixes the same pattern in `status.mjs`, `logs.mjs`, and `doctor.mjs` which have identical broken imports.

### Bug 2 — `config opencode` does not exist

The docs at `docs/frameworks/OPENCODE.md` document `omniroute config opencode --baseUrl <url> --apiKey <key>`, but there is no `opencode` subcommand registered under `config`. Additionally, Commander v14 assigns `--api-key`/`--base-url` to the parent command level when both parent and child define the same option, leaving `opts.apiKey` undefined in action handlers.

**Fix:** Add an `opencode` convenience subcommand that delegates to `config set opencode`. Remove duplicate `--api-key`/`--base-url` definitions from child commands (`set`, `validate`) and merge from global options in action handlers.

## Files Changed

- `bin/omniroute.mjs` — register tsx/esm at startup (+5 lines)
- `bin/cli/commands/config.mjs` — fix option inheritance, add opencode alias (+31/-6 lines)

## Validation

- [x] `omniroute config list` now works (detects OpenCode, Claude Code, etc.)
- [x] `omniroute config set opencode --api-key <key>` works
- [x] `omniroute config opencode --api-key <key>` works (new alias)
- [x] Pre-commit hooks pass (lint, docs-sync, i18n checks)