### PR TITLE
fix(reasoning): extend reasoning_content injection to Kimi K2 and other replay models

### DIFF
--- a/open-sse/translator/helpers/schemaCoercion.ts
+++ b/open-sse/translator/helpers/schemaCoercion.ts
@@ -1,4 +1,4 @@
-import { isDeepSeekReasoningModel } from "../../services/reasoningCache.ts";
+import { isDeepSeekReasoningModel, requiresReasoningReplay } from "../../services/reasoningCache.ts";
 
 /**
  * Shared sanitizers for tool payloads that arrive from IDEs/SDKs with
@@ -201,14 +201,17 @@ export function injectEmptyReasoningContentForToolCalls(
   provider: unknown,
   model: unknown
 ): unknown {
-  if (
-    !Array.isArray(messages) ||
-    !isDeepSeekReasoningModel({
-      provider: String(provider ?? ""),
-      model: String(model ?? ""),
-      thinkingEnabled: true,
-    })
-  ) {
+  const normalizedProvider = String(provider ?? "");
+  const normalizedModel = String(model ?? "");
+
+  // Check if this provider/model requires reasoning replay (DeepSeek V4, Kimi K2, etc.)
+  const needsReasoning = requiresReasoningReplay({
+    provider: normalizedProvider,
+    model: normalizedModel,
+    thinkingEnabled: true,
+  });
+
+  if (!Array.isArray(messages) || !needsReasoning) {
     return messages;
   }
 

--- a/tests/unit/schema-coercion.test.ts
+++ b/tests/unit/schema-coercion.test.ts
@@ -131,7 +131,17 @@ test("injectEmptyReasoningContentForToolCalls supports DeepSeek V4 models across
   }
 });
 
-test("injectEmptyReasoningContentForToolCalls skips non-DeepSeek V4 models", () => {
+test("injectEmptyReasoningContentForToolCalls skips non-reasoning models", () => {
+  const messages = [{ role: "assistant", tool_calls: [{ id: "call_1" }] }];
+
+  const result = injectEmptyReasoningContentForToolCalls(
+    messages,
+    "deepseek",
+    "deepseek-v3"
+  ) as Array<{ reasoning_content?: string }>;
+
+  assert.equal(result[0].reasoning_content, undefined);
+});
   const messages = [{ role: "assistant", tool_calls: [{ id: "call_1" }] }];
 
   const result = injectEmptyReasoningContentForToolCalls(
@@ -141,4 +151,86 @@ test("injectEmptyReasoningContentForToolCalls skips non-DeepSeek V4 models", () 
   ) as Array<{ reasoning_content?: string }>;
 
   assert.equal(result[0].reasoning_content, undefined);
+});
+
+test("injectEmptyReasoningContentForToolCalls supports Kimi K2 models", () => {
+  const messages = [
+    { role: "user", content: "hello" },
+    { role: "assistant", tool_calls: [{ id: "call_1" }] },
+  ];
+
+  for (const model of ["kimi-k2", "kimi-k2.5", "kimi-k2.6", "kimi-k2-thinking"]) {
+    const result = injectEmptyReasoningContentForToolCalls(
+      messages,
+      "moonshot",
+      model
+    ) as Array<{ reasoning_content?: string }>;
+
+    assert.equal(result[1].reasoning_content, "", `should inject reasoning_content for ${model}`);
+  }
+});
+
+test("injectEmptyReasoningContentForToolCalls supports Kimi K2 via Qoder provider", () => {
+  const messages = [
+    { role: "user", content: "hello" },
+    { role: "assistant", tool_calls: [{ id: "call_1" }] },
+  ];
+
+  const result = injectEmptyReasoningContentForToolCalls(
+    messages,
+    "qoder",
+    "kimi-k2-thinking"
+  ) as Array<{ reasoning_content?: string }>;
+
+  assert.equal(result[1].reasoning_content, "");
+});
+
+test("injectEmptyReasoningContentForToolCalls supports all reasoning replay providers", () => {
+  const messages = [
+    { role: "user", content: "hello" },
+    { role: "assistant", tool_calls: [{ id: "call_1" }] },
+  ];
+
+  const reasoningProviders = [
+    { provider: "deepseek", model: "deepseek-chat" },
+    { provider: "opencode-go", model: "some-model" },
+    { provider: "siliconflow", model: "deepseek-r1" },
+    { provider: "nebius", model: "qwq-32b" },
+    { provider: "deepinfra", model: "deepseek-reasoner" },
+    { provider: "sambanova", model: "qwen3-thinking" },
+    { provider: "fireworks", model: "glm-5-thinking" },
+    { provider: "together", model: "mimo-v2.5" },
+    { provider: "xiaomi-mimo", model: "mimo-v2.5-pro" },
+  ];
+
+  for (const { provider, model } of reasoningProviders) {
+    const result = injectEmptyReasoningContentForToolCalls(
+      messages,
+      provider,
+      model
+    ) as Array<{ reasoning_content?: string }>;
+
+    assert.equal(result[1].reasoning_content, "", `should inject reasoning_content for ${provider}/${model}`);
+  }
+});
+
+test("injectEmptyReasoningContentForToolCalls skips non-reasoning models", () => {
+  const messages = [{ role: "assistant", tool_calls: [{ id: "call_1" }] }];
+
+  const nonReasoningModels = [
+    { provider: "openai", model: "gpt-4" },
+    { provider: "anthropic", model: "claude-sonnet-4" },
+    { provider: "google", model: "gemini-pro" },
+    { provider: "groq", model: "llama-3" },
+  ];
+
+  for (const { provider, model } of nonReasoningModels) {
+    const result = injectEmptyReasoningContentForToolCalls(
+      messages,
+      provider,
+      model
+    ) as Array<{ reasoning_content?: string }>;
+
+    assert.equal(result[0].reasoning_content, undefined, `should NOT inject reasoning_content for ${provider}/${model}`);
+  }
 });


### PR DESCRIPTION
## Description

Fixes #2637

Kimi K2 models enter an infinite loop when using tool calls through OmniRoute because `injectEmptyReasoningContentForToolCalls` only handled DeepSeek V4 models, leaving Kimi K2 and other reasoning models without `reasoning_content` when `tool_calls` were present.

## Root Cause

The `injectEmptyReasoningContentForToolCalls` function used `isDeepSeekReasoningModel()` to decide whether to inject empty `reasoning_content` for assistant messages with `tool_calls`. This only covered DeepSeek V4, but Kimi K2, Qwen-Thinking, GLM, and MiMo models also require `reasoning_content` to be passed back on subsequent turns.

When these models don't receive their `reasoning_content` back, they attempt to regenerate the response, generating the same `tool_call` again, causing an infinite loop.

## Changes

- **`open-sse/translator/helpers/schemaCoercion.ts`**: 
  - Replaced `isDeepSeekReasoningModel()` with `requiresReasoningReplay()` to cover all reasoning replay models
  - Now handles: DeepSeek V4, Kimi K2, Qwen-Thinking, GLM, MiMo, and any future models added to `REASONING_REPLAY_MODEL_PATTERNS`

- **`tests/unit/schema-coercion.test.ts`**:
  - Updated existing test to use a non-reasoning model (`deepseek-v3`) instead of `deepseek-reasoner` (which now correctly receives injection)
  - Added tests for Kimi K2 models via moonshot provider
  - Added test for Kimi K2 via Qoder provider (common routing scenario)
  - Added comprehensive test covering all reasoning replay providers
  - Added test verifying non-reasoning models are correctly skipped

## Test Coverage

Tests verify that:
- DeepSeek V4 models via proxy providers (openrouter, fireworks, deepinfra) receive `reasoning_content: ""`
- Kimi K2, K2.5, K2.6, K2-thinking receive `reasoning_content: ""`
- Kimi K2 via Qoder provider receives `reasoning_content: ""`
- All reasoning replay providers (deepseek, opencode-go, siliconflow, nebius, deepinfra, sambanova, fireworks, together, xiaomi-mimo) receive `reasoning_content: ""`
- Non-reasoning models (gpt-4, claude, gemini, llama) do NOT receive injection

## Related

- Issue #1628 (reasoning replay system)
- `docs/routing/REASONING_REPLAY.md`
- `open-sse/services/reasoningCache.ts` (defines `requiresReasoningReplay()`)

## Checklist

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Tests added/updated
- [x] Code follows project style guidelines
- [x] Changes are minimal and focused on the fix