### PR TITLE
fix(translator): enable Claude extended thinking for Copilot Responses-API

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -2820,7 +2820,12 @@ export async function handleChatCore({
           credentials,
           provider,
           reqLogger,
-          { normalizeToolCallId, preserveDeveloperRole, preserveCacheControl }
+          {
+            normalizeToolCallId,
+            preserveDeveloperRole,
+            preserveCacheControl,
+            copilotClient: copilotCompatibleReasoning,
+          }
         );
       }
 
@@ -2979,6 +2984,7 @@ export async function handleChatCore({
           preserveDeveloperRole,
           preserveCacheControl,
           signatureNamespace: connectionId,
+          copilotClient: copilotCompatibleReasoning,
           ...(preCompressionBody ? { preCompressionBody } : {}),
         }
       );

--- a/open-sse/services/claudeCodeCompatible.ts
+++ b/open-sse/services/claudeCodeCompatible.ts
@@ -44,6 +44,7 @@ export const CLAUDE_CODE_COMPATIBLE_USER_AGENT = "claude-cli/2.1.146 (external, 
 export const CLAUDE_CODE_COMPATIBLE_STAINLESS_PACKAGE_VERSION = "0.94.0";
 export const CLAUDE_CODE_COMPATIBLE_STAINLESS_RUNTIME_VERSION = "v24.3.0";
 export const CONTEXT_1M_BETA_HEADER = "context-1m-2025-08-07";
+const COPILOT_REASONING_SUMMARY_MARKER = "_omnirouteCopilotReasoningSummary";
 const CLAUDE_CODE_COMPATIBLE_DEFAULT_SYSTEM_BLOCKS = [
   {
     type: "text",
@@ -1063,11 +1064,30 @@ function resolveClaudeCodeCompatibleThinking({
     readRecord(cloneValue(normalizedBody?.thinking));
 
   if (thinking) {
-    return thinking;
+    return applyClaudeCodeCompatibleThinkingDisplay(thinking, normalizedBody);
   }
 
+  return applyClaudeCodeCompatibleThinkingDisplay(
+    {
+      type: "adaptive",
+    },
+    normalizedBody
+  );
+}
+
+function applyClaudeCodeCompatibleThinkingDisplay(
+  thinking: Record<string, unknown>,
+  normalizedBody?: Record<string, unknown> | null
+) {
+  if (
+    normalizedBody?.[COPILOT_REASONING_SUMMARY_MARKER] !== "summarized" ||
+    thinking.type === "disabled"
+  ) {
+    return thinking;
+  }
   return {
-    type: "adaptive",
+    ...thinking,
+    display: "summarized",
   };
 }
 

--- a/open-sse/translator/index.ts
+++ b/open-sse/translator/index.ts
@@ -133,6 +133,9 @@ export function translateRequest(
     preserveCacheControl?: boolean;
     signatureNamespace?: string | null;
     preCompressionBody?: Record<string, unknown> | null;
+    /** UA-detected GitHub Copilot client. Forwarded to translators via the
+     *  transient `_copilotClient` credential flag (see openai-responses → openai). */
+    copilotClient?: boolean;
   }
 ) {
   let result = body;
@@ -176,7 +179,14 @@ export function translateRequest(
       if (sourceFormat !== FORMATS.OPENAI) {
         const toOpenAI = getRequestTranslator(sourceFormat, FORMATS.OPENAI);
         if (toOpenAI) {
-          result = toOpenAI(model, result, stream, credentials);
+          // Forward Copilot UA marker to source→openai translators only.
+          const step1Credentials = options?.copilotClient
+            ? {
+                ...(credentials && typeof credentials === "object" ? credentials : {}),
+                _copilotClient: true,
+              }
+            : credentials;
+          result = toOpenAI(model, result, stream, step1Credentials);
           // Log OpenAI intermediate format
           reqLogger?.logOpenAIRequest?.(result);
         }
@@ -188,12 +198,14 @@ export function translateRequest(
         if (fromOpenAI) {
           const hasNs = options?.signatureNamespace != null;
           const hasPreCompression = options?.preCompressionBody != null;
+          const hasCopilot = options?.copilotClient === true;
           const translationCredentials =
-            hasNs || hasPreCompression
+            hasNs || hasPreCompression || hasCopilot
               ? {
                   ...(credentials && typeof credentials === "object" ? credentials : {}),
                   ...(hasNs ? { _signatureNamespace: options.signatureNamespace } : {}),
                   ...(hasPreCompression ? { _preCompressionBody: options.preCompressionBody } : {}),
+                  ...(hasCopilot ? { _copilotClient: true } : {}),
                 }
               : credentials;
           result = fromOpenAI(model, result, stream, translationCredentials);

--- a/open-sse/translator/request/openai-responses.ts
+++ b/open-sse/translator/request/openai-responses.ts
@@ -11,6 +11,7 @@ import { register } from "../registry.ts";
 
 type JsonRecord = Record<string, unknown>;
 const RESPONSES_STORE_MARKER = "_omnirouteResponsesStore";
+const COPILOT_REASONING_SUMMARY_MARKER = "_omnirouteCopilotReasoningSummary";
 
 function toRecord(value: unknown): JsonRecord {
   return value && typeof value === "object" && !Array.isArray(value) ? (value as JsonRecord) : {};
@@ -27,6 +28,11 @@ function toString(value: unknown, fallback = ""): string {
 function normalizeResponsesReasoningEffort(value: unknown): string {
   const effort = toString(value).toLowerCase();
   return effort === "max" ? "xhigh" : effort;
+}
+
+function shouldRequestClaudeSummarizedThinking(value: unknown): boolean {
+  const summary = toString(value).toLowerCase();
+  return !!summary && summary !== "off" && summary !== "none" && summary !== "disabled";
 }
 
 function unsupportedFeature(message: string): Error & { statusCode: number; errorType: string } {
@@ -307,6 +313,25 @@ export function openaiResponsesToOpenAIRequest(
     result[RESPONSES_STORE_MARKER] = root.store;
   }
   delete result.store;
+
+  // Copilot-only: promote Responses `reasoning.{effort,summary}` to Chat fields
+  // so the downstream openai-to-claude translator can enable extended thinking.
+  // Gated by the UA marker from translateRequest; other clients see `reasoning` dropped.
+  if (
+    credentialRecord._copilotClient === true &&
+    root.reasoning &&
+    typeof root.reasoning === "object" &&
+    !Array.isArray(root.reasoning)
+  ) {
+    const reasoningRec = toRecord(root.reasoning);
+    const effort = toString(reasoningRec.effort);
+    if (effort && result.reasoning_effort === undefined) {
+      result.reasoning_effort = normalizeResponsesReasoningEffort(effort);
+    }
+    if (shouldRequestClaudeSummarizedThinking(reasoningRec.summary)) {
+      result[COPILOT_REASONING_SUMMARY_MARKER] = "summarized";
+    }
+  }
   delete result.reasoning;
 
   return result;

--- a/open-sse/translator/request/openai-to-claude.ts
+++ b/open-sse/translator/request/openai-to-claude.ts
@@ -11,6 +11,24 @@ import { capMaxOutputTokens } from "../../../src/lib/modelCapabilities.ts";
 // Can be disabled per-request via body._disableToolPrefix = true
 export const CLAUDE_OAUTH_TOOL_PREFIX = "proxy_";
 const CLAUDE_TOOL_CHOICE_REQUIRED = "an" + "y";
+const COPILOT_REASONING_SUMMARY_MARKER = "_omnirouteCopilotReasoningSummary";
+
+function wantsCopilotSummarizedThinking(body: Record<string, unknown> | null | undefined): boolean {
+  return body?.[COPILOT_REASONING_SUMMARY_MARKER] === "summarized";
+}
+
+function applyCopilotSummarizedThinkingDisplay(
+  thinking: Record<string, unknown> | undefined,
+  body: Record<string, unknown> | null | undefined
+): Record<string, unknown> | undefined {
+  if (!thinking || !wantsCopilotSummarizedThinking(body) || thinking.type === "disabled") {
+    return thinking;
+  }
+  return {
+    ...thinking,
+    display: "summarized",
+  };
+}
 
 // Anthropic constraints for the thinking + max_tokens contract:
 //   - thinking.budget_tokens must be >= 1024 when thinking is enabled
@@ -473,8 +491,10 @@ export function openaiToClaudeRequest(model, body, stream) {
   if (fitted.thinking === undefined) {
     delete result.thinking;
   } else {
-    result.thinking = fitted.thinking;
+    result.thinking = applyCopilotSummarizedThinkingDisplay(fitted.thinking, body);
   }
+
+  delete result[COPILOT_REASONING_SUMMARY_MARKER];
 
   // Attach toolNameMap to result for response translation
   if (toolNameMap.size > 0) {

--- a/tests/unit/translator-openai-responses-req.test.ts
+++ b/tests/unit/translator-openai-responses-req.test.ts
@@ -500,3 +500,73 @@ test("Chat -> Responses prefers max_completion_tokens over max_tokens when both 
   assert.equal((result as any).max_tokens, undefined);
   assert.equal((result as any).max_completion_tokens, undefined);
 });
+
+test("Responses -> Chat drops `reasoning` and does not synthesize reasoning_effort without Copilot marker", () => {
+  const result = openaiResponsesToOpenAIRequest(
+    "claude-opus-4-7",
+    {
+      input: [{ role: "user", content: [{ type: "input_text", text: "hi" }] }],
+      reasoning: { effort: "high" },
+    },
+    true,
+    null
+  ) as Record<string, unknown>;
+
+  assert.equal(result.reasoning, undefined);
+  assert.equal(result.reasoning_effort, undefined);
+});
+
+test("Responses -> Chat promotes reasoning.effort to reasoning_effort when _copilotClient is set", () => {
+  const result = openaiResponsesToOpenAIRequest(
+    "claude-opus-4-7",
+    {
+      input: [{ role: "user", content: [{ type: "input_text", text: "hi" }] }],
+      reasoning: { effort: "high" },
+    },
+    true,
+    { _copilotClient: true }
+  ) as Record<string, unknown>;
+
+  assert.equal(result.reasoning, undefined);
+  assert.equal(result.reasoning_effort, "high");
+});
+
+test("Responses -> Chat normalizes Copilot reasoning.effort=max to xhigh", () => {
+  const result = openaiResponsesToOpenAIRequest(
+    "claude-opus-4-7",
+    {
+      input: [{ role: "user", content: [{ type: "input_text", text: "hi" }] }],
+      reasoning: { effort: "max" },
+    },
+    true,
+    { _copilotClient: true }
+  ) as Record<string, unknown>;
+
+  assert.equal(result.reasoning_effort, "xhigh");
+});
+
+test("Responses -> Chat keeps an explicit reasoning_effort over reasoning.effort when _copilotClient is set", () => {
+  const result = openaiResponsesToOpenAIRequest(
+    "claude-opus-4-7",
+    {
+      input: [{ role: "user", content: [{ type: "input_text", text: "hi" }] }],
+      reasoning: { effort: "low" },
+      reasoning_effort: "high",
+    },
+    true,
+    { _copilotClient: true }
+  ) as Record<string, unknown>;
+
+  assert.equal(result.reasoning_effort, "high");
+});
+
+test("Responses -> Chat ignores Copilot marker when reasoning field is absent", () => {
+  const result = openaiResponsesToOpenAIRequest(
+    "claude-opus-4-7",
+    { input: [{ role: "user", content: [{ type: "input_text", text: "hi" }] }] },
+    true,
+    { _copilotClient: true }
+  ) as Record<string, unknown>;
+
+  assert.equal(result.reasoning_effort, undefined);
+});


### PR DESCRIPTION
## Summary

Route `cc/claude-*` models from a GitHub Copilot `/v1/responses` request to a Claude-Code-compatible provider with extended thinking actually enabled.

The Copilot client encodes thinking intent via Responses-API `reasoning.{effort,summary}`. On the Responses → Chat hop those fields are dropped, and `openai-to-claude` only looks at `reasoning_effort`, so the downstream Claude request never enables `thinking` — Copilot users get a non-reasoning response regardless of what they selected in the UI.

This PR adds a UA-conditional promotion, gated by a transient `_copilotClient` credential flag set in `translateRequest` from `options.copilotClient`. Non-Copilot clients see no behavioural change.

Per-file changes:

- `open-sse/translator/index.ts` — forward `options.copilotClient` into both hub-and-spoke steps so step1 (source→openai) and step2 (openai→target) translators can see the marker.
- `open-sse/translator/request/openai-responses.ts` — when `_copilotClient: true`, promote `reasoning.effort` → `reasoning_effort` (with `max` → `xhigh` to match the inverse translator's vocabulary) and forward `reasoning.summary` via the `_omnirouteCopilotReasoningSummary` marker. The existing `reasoning` strip is preserved for every other caller.
- `open-sse/translator/request/openai-to-claude.ts` — when the summary marker is present, attach `display: "summarized"` to the resolved Claude `thinking` object (skipped for `type: "disabled"`). The marker is removed before the body leaves the translator.
- `open-sse/services/claudeCodeCompatible.ts` — same `display: "summarized"` handling for the claude-code-compatible bridge path that bypasses `openai-to-claude`.
- `open-sse/handlers/chatCore.ts` — pass `copilotClient: copilotCompatibleReasoning` into both `translateRequest` call sites (bridge path and generic path).

## Related Issues

- Closes #
- Related to #

## Validation

- [x] `npm run lint` — 0 errors. No new warnings on touched files.
- [x] `npm run test:unit` — 6358 passed / 8 skipped. No translator or claude-code-compatible test failed.
- [ ] `npm run test:coverage`
- [ ] Coverage is still `>= 60%` for statements, lines, functions, and branches
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below

## Tests Added Or Updated

`tests/unit/translator-openai-responses-req.test.ts` — 5 new tests covering the openai-responses → openai branch (22/22 tests in the file pass):

1. `Responses -> Chat drops reasoning and does not synthesize reasoning_effort without Copilot marker` — baseline: every non-Copilot caller is unaffected.
2. `Responses -> Chat promotes reasoning.effort to reasoning_effort when _copilotClient is set`.
3. `Responses -> Chat normalizes Copilot reasoning.effort=max to xhigh` — keeps effort vocabulary symmetric with `openaiToOpenAIResponsesRequest`.
4. `Responses -> Chat keeps an explicit reasoning_effort over reasoning.effort when _copilotClient is set` — explicit field wins, guarding against stale echoes.
5. `Responses -> Chat ignores Copilot marker when reasoning field is absent`.

No other test files changed.

## Coverage Notes

This PR touches `open-sse/` only. The behavioural change is gated behind a single boolean (`_copilotClient`) that is only set by `chatCore.ts` when the request is identified as a Copilot UA. The new branch in `openai-responses.ts` is covered end-to-end by the 5 new unit tests. The marker-driven `display: "summarized"` attachment in `openai-to-claude.ts` and `claudeCodeCompatible.ts` is a guarded spread that short-circuits for `thinking.type === "disabled"`; it reuses the existing thinking-resolution code path already exercised by the suite.

## Reviewer Notes

- Risk surface is intentionally narrow: every behavioural change is conditional on `credentials._copilotClient === true` (request side) or `body._omnirouteCopilotReasoningSummary === "summarized"` (Claude side). Non-Copilot clients hit the same code paths and observe the same output.
- The marker constant `_omnirouteCopilotReasoningSummary` follows the existing `_omnirouteResponsesStore` convention in `openai-responses.ts` (transient, underscore-prefixed, stripped before the body leaves the translator pipeline).
- `max → xhigh` normalisation in the Copilot branch mirrors the existing normalisation in the inverse direction (`openaiToOpenAIResponsesRequest`), keeping the effort vocabulary consistent across the hub-and-spoke.
- No new env vars, no migrations, no schema changes, no feature flags exposed to operators — the behaviour is fully derived from existing UA detection in `chatCore.ts`.
