### PR TITLE
feat(dashboard): add Cmd+K / Ctrl+K command palette for sidebar navigation

### DIFF
--- a/src/app/(dashboard)/dashboard/media-providers/components/LlmChatCard.tsx
+++ b/src/app/(dashboard)/dashboard/media-providers/components/LlmChatCard.tsx
@@ -238,7 +238,7 @@ export function LlmChatCard({ providerId, initialModel, embedded = false }: Prop
     <div
       className={cn(
         "flex flex-col gap-3",
-        embedded ? "" : "rounded-lg border border-border bg-bg-card p-4"
+        embedded ? "flex-1 min-h-0" : "rounded-lg border border-border bg-bg-card p-4"
       )}
     >
       {/* Header controls */}
@@ -294,12 +294,10 @@ export function LlmChatCard({ providerId, initialModel, embedded = false }: Prop
         ref={scrollRef}
         className={cn(
           "flex flex-col gap-2 rounded-md border border-border bg-bg-subtle p-3 overflow-y-auto",
-          messages.length === 0
-            ? embedded
-              ? "min-h-[200px]"
-              : "min-h-[60px]"
-            : embedded
-              ? "min-h-[300px] max-h-[50vh]"
+          embedded
+            ? "flex-1 min-h-0"
+            : messages.length === 0
+              ? "min-h-[60px]"
               : "min-h-[80px] max-h-64"
         )}
       >

--- a/src/app/(dashboard)/dashboard/media-providers/components/LlmChatCard.tsx
+++ b/src/app/(dashboard)/dashboard/media-providers/components/LlmChatCard.tsx
@@ -22,6 +22,7 @@ interface Stats {
 interface Props {
   providerId: string;
   initialModel?: string;
+  embedded?: boolean;
 }
 
 function extractDeltaContent(line: string): string {
@@ -58,7 +59,7 @@ function extractUsage(line: string): { prompt_tokens?: number; completion_tokens
   }
 }
 
-export function LlmChatCard({ providerId, initialModel }: Props) {
+export function LlmChatCard({ providerId, initialModel, embedded = false }: Props) {
   const t = useTranslations("miniPlayground");
   const { apiKey, keys } = useApiKey();
   const { models } = useProviderModels(providerId);
@@ -234,7 +235,12 @@ export function LlmChatCard({ providerId, initialModel }: Props) {
   const modelOptions = models.length > 0 ? models : initialModel ? [{ id: initialModel }] : [];
 
   return (
-    <div className="flex flex-col gap-3 rounded-lg border border-border bg-bg-card p-4">
+    <div
+      className={cn(
+        "flex flex-col gap-3",
+        embedded ? "" : "rounded-lg border border-border bg-bg-card p-4"
+      )}
+    >
       {/* Header controls */}
       <div className="flex flex-wrap items-center gap-2">
         {/* Model select */}
@@ -288,7 +294,13 @@ export function LlmChatCard({ providerId, initialModel }: Props) {
         ref={scrollRef}
         className={cn(
           "flex flex-col gap-2 rounded-md border border-border bg-bg-subtle p-3 overflow-y-auto",
-          messages.length === 0 ? "min-h-[60px]" : "min-h-[80px] max-h-64"
+          messages.length === 0
+            ? embedded
+              ? "min-h-[200px]"
+              : "min-h-[60px]"
+            : embedded
+              ? "min-h-[300px] max-h-[50vh]"
+              : "min-h-[80px] max-h-64"
         )}
       >
         {messages.length === 0 && (

--- a/src/app/(dashboard)/dashboard/media-providers/components/LlmChatCard.tsx
+++ b/src/app/(dashboard)/dashboard/media-providers/components/LlmChatCard.tsx
@@ -11,6 +11,7 @@ const ENDPOINT = "/api/v1/chat/completions";
 interface Message {
   role: "user" | "assistant";
   content: string;
+  model?: string;
 }
 
 interface Stats {
@@ -94,7 +95,7 @@ export function LlmChatCard({ providerId, initialModel, embedded = false }: Prop
     if (!trimmed || streaming) return;
 
     const userMsg: Message = { role: "user", content: trimmed };
-    const assistantMsg: Message = { role: "assistant", content: "" };
+    const assistantMsg: Message = { role: "assistant", content: "", model: effectiveModel };
     setMessages((prev) => [...prev, userMsg, assistantMsg]);
     setInput("");
     setStreaming(true);
@@ -138,7 +139,8 @@ export function LlmChatCard({ providerId, initialModel, embedded = false }: Prop
             : `HTTP ${res.status}`;
         setMessages((prev) => {
           const next = [...prev];
-          next[next.length - 1] = { role: "assistant", content: `[Error: ${errMsg}]` };
+          const last = next[next.length - 1];
+          next[next.length - 1] = { ...last, role: "assistant", content: `[Error: ${errMsg}]` };
           return next;
         });
         return;
@@ -166,7 +168,8 @@ export function LlmChatCard({ providerId, initialModel, embedded = false }: Prop
             acc += delta;
             setMessages((prev) => {
               const next = [...prev];
-              next[next.length - 1] = { role: "assistant", content: acc };
+              const last = next[next.length - 1];
+              next[next.length - 1] = { ...last, role: "assistant", content: acc };
               return next;
             });
           }
@@ -187,7 +190,8 @@ export function LlmChatCard({ providerId, initialModel, embedded = false }: Prop
           acc += delta;
           setMessages((prev) => {
             const next = [...prev];
-            next[next.length - 1] = { role: "assistant", content: acc };
+            const last = next[next.length - 1];
+            next[next.length - 1] = { ...last, role: "assistant", content: acc };
             return next;
           });
         }
@@ -206,7 +210,8 @@ export function LlmChatCard({ providerId, initialModel, embedded = false }: Prop
       const msg = err instanceof Error ? err.message : "Request failed";
       setMessages((prev) => {
         const next = [...prev];
-        next[next.length - 1] = { role: "assistant", content: `[Error: ${msg}]` };
+        const last = next[next.length - 1];
+        next[next.length - 1] = { ...last, role: "assistant", content: `[Error: ${msg}]` };
         return next;
       });
     } finally {
@@ -345,9 +350,19 @@ export function LlmChatCard({ providerId, initialModel, embedded = false }: Prop
                     )}
                   </div>
                   <div className="flex flex-col gap-1 min-w-0 flex-1">
-                    <span className="text-[10px] uppercase tracking-wider text-text-muted font-medium">
-                      {isUser ? "You" : isError ? "Error" : "Assistant"}
-                    </span>
+                    <div className="flex items-baseline gap-2 min-w-0">
+                      <span className="text-[10px] uppercase tracking-wider text-text-muted font-medium shrink-0">
+                        {isUser ? "You" : isError ? "Error" : "Assistant"}
+                      </span>
+                      {!isUser && !isError && msg.model && (
+                        <span
+                          className="text-[10px] font-mono text-text-muted/60 truncate"
+                          title={msg.model}
+                        >
+                          · {msg.model}
+                        </span>
+                      )}
+                    </div>
                     <div
                       className={cn(
                         "text-sm whitespace-pre-wrap break-words leading-relaxed",

--- a/src/app/(dashboard)/dashboard/media-providers/components/LlmChatCard.tsx
+++ b/src/app/(dashboard)/dashboard/media-providers/components/LlmChatCard.tsx
@@ -236,9 +236,9 @@ export function LlmChatCard({ providerId, initialModel }: Props) {
   return (
     <div className="flex flex-col gap-3 rounded-lg border border-border bg-bg-card p-4">
       {/* Header controls */}
-      <div className="flex flex-wrap items-center gap-2">
+      <div className="grid grid-cols-1 sm:grid-cols-[1fr_auto_auto] items-center gap-2">
         {/* Model select */}
-        <div className="flex items-center gap-1.5 min-w-0 flex-1">
+        <div className="flex items-center gap-1.5 min-w-0">
           <label className="text-xs text-text-muted shrink-0">{t("model")}:</label>
           <select
             value={model || firstModel}
@@ -255,12 +255,12 @@ export function LlmChatCard({ providerId, initialModel }: Props) {
         </div>
         {/* Key select */}
         {keys.length > 0 && (
-          <div className="flex items-center gap-1.5">
+          <div className="flex items-center gap-1.5 min-w-0">
             <label className="text-xs text-text-muted shrink-0">{t("selectKey")}:</label>
             <select
               value={selectedKey}
               onChange={(e) => setSelectedKey(e.target.value)}
-              className="rounded-md border border-border bg-bg-subtle text-xs px-2 py-1 text-text-main focus:outline-none focus:ring-1 focus:ring-primary"
+              className="min-w-0 flex-1 rounded-md border border-border bg-bg-subtle text-xs px-2 py-1 text-text-main focus:outline-none focus:ring-1 focus:ring-primary"
             >
               <option value="">(default)</option>
               {keys.map((k) => (
@@ -276,7 +276,7 @@ export function LlmChatCard({ providerId, initialModel }: Props) {
           <button
             type="button"
             onClick={handleClear}
-            className="text-xs text-text-muted hover:text-text-primary transition-colors"
+            className="text-xs text-text-muted hover:text-text-primary transition-colors justify-self-start sm:justify-self-end"
           >
             Clear
           </button>

--- a/src/app/(dashboard)/dashboard/media-providers/components/LlmChatCard.tsx
+++ b/src/app/(dashboard)/dashboard/media-providers/components/LlmChatCard.tsx
@@ -293,7 +293,7 @@ export function LlmChatCard({ providerId, initialModel, embedded = false }: Prop
       <div
         ref={scrollRef}
         className={cn(
-          "flex flex-col gap-2 rounded-md border border-border bg-bg-subtle p-3 overflow-y-auto",
+          "rounded-md border border-border bg-bg-subtle overflow-y-auto",
           embedded
             ? "flex-1 min-h-0"
             : messages.length === 0
@@ -301,66 +301,101 @@ export function LlmChatCard({ providerId, initialModel, embedded = false }: Prop
               : "min-h-[80px] max-h-64"
         )}
       >
-        {messages.length === 0 && (
-          <p className="text-xs text-text-muted text-center">
-            Send a message to start the conversation.
-          </p>
-        )}
-        {messages.map((msg, i) => (
-          <div
-            key={i}
-            className={cn(
-              "flex flex-col gap-0.5",
-              msg.role === "user" ? "items-end" : "items-start"
-            )}
-          >
-            <span className="text-[10px] uppercase tracking-wide text-text-muted font-medium">
-              {msg.role}
-            </span>
-            <div
-              className={cn(
-                "max-w-[90%] rounded-lg px-3 py-2 text-sm whitespace-pre-wrap break-words",
-                msg.role === "user"
-                  ? "bg-primary/10 text-text-main border border-primary/20"
-                  : "bg-bg-card text-text-main border border-border"
-              )}
-            >
-              {msg.content}
-              {msg.role === "assistant" && streaming && i === messages.length - 1 && (
-                <span className="inline-block w-1 h-3 bg-text-main ml-0.5 animate-pulse" />
-              )}
+        {messages.length === 0 ? (
+          <div className="flex h-full min-h-[180px] flex-col items-center justify-center gap-3 p-6 text-center">
+            <div className="size-10 rounded-full bg-accent/10 flex items-center justify-center">
+              <span className="material-symbols-outlined text-accent text-[22px]">forum</span>
             </div>
+            <p className="text-sm text-text-muted">Send a message to start the conversation</p>
+            <p className="text-[11px] text-text-muted/70">
+              Shift+Enter for newline · Enter to send
+            </p>
           </div>
-        ))}
+        ) : (
+          <div className="mx-auto flex max-w-3xl flex-col divide-y divide-border/60">
+            {messages.map((msg, i) => {
+              const isUser = msg.role === "user";
+              const isError =
+                !isUser && typeof msg.content === "string" && msg.content.startsWith("[Error");
+              return (
+                <div
+                  key={i}
+                  className={cn(
+                    "flex gap-3 px-4 py-4",
+                    isUser ? "bg-transparent" : "bg-bg-card/40"
+                  )}
+                >
+                  <div
+                    className={cn(
+                      "size-7 rounded-md flex items-center justify-center shrink-0 text-[14px] font-semibold",
+                      isUser
+                        ? "bg-primary/15 text-primary"
+                        : isError
+                          ? "bg-red-500/15 text-red-400"
+                          : "bg-accent/15 text-accent"
+                    )}
+                    aria-hidden="true"
+                  >
+                    {isUser ? (
+                      <span className="material-symbols-outlined text-[16px]">person</span>
+                    ) : isError ? (
+                      <span className="material-symbols-outlined text-[16px]">error</span>
+                    ) : (
+                      <span className="material-symbols-outlined text-[16px]">smart_toy</span>
+                    )}
+                  </div>
+                  <div className="flex flex-col gap-1 min-w-0 flex-1">
+                    <span className="text-[10px] uppercase tracking-wider text-text-muted font-medium">
+                      {isUser ? "You" : isError ? "Error" : "Assistant"}
+                    </span>
+                    <div
+                      className={cn(
+                        "text-sm whitespace-pre-wrap break-words leading-relaxed",
+                        isError ? "text-red-400" : "text-text-main"
+                      )}
+                    >
+                      {msg.content}
+                      {!isUser && streaming && i === messages.length - 1 && (
+                        <span className="inline-block w-1.5 h-3.5 bg-text-main ml-0.5 align-text-bottom animate-pulse" />
+                      )}
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
       </div>
 
       {/* Input row */}
-      <div className="flex gap-2">
+      <div className="relative flex items-end gap-2 rounded-lg border border-border bg-bg-subtle px-3 py-2 focus-within:ring-1 focus-within:ring-primary focus-within:border-primary/50 transition-colors">
         <textarea
           value={input}
           onChange={(e) => setInput(e.target.value)}
           onKeyDown={handleKeyDown}
-          rows={2}
-          placeholder={`${t("send")}… (Shift+Enter for new line)`}
+          rows={1}
+          placeholder={`${t("send")}…`}
           disabled={streaming}
-          className="flex-1 rounded-md border border-border bg-bg-subtle text-sm px-3 py-2 text-text-main placeholder:text-text-muted focus:outline-none focus:ring-1 focus:ring-primary resize-none disabled:opacity-50"
+          className="flex-1 bg-transparent text-sm py-1.5 text-text-main placeholder:text-text-muted focus:outline-none resize-none disabled:opacity-50 max-h-32"
         />
         {streaming ? (
           <button
             type="button"
             onClick={handleStop}
-            className="self-end rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-400 hover:bg-red-500/20 transition-colors"
+            title="Stop"
+            className="size-8 flex items-center justify-center rounded-md border border-red-500/30 bg-red-500/10 text-red-400 hover:bg-red-500/20 transition-colors shrink-0"
           >
-            Stop
+            <span className="material-symbols-outlined text-[18px]">stop</span>
           </button>
         ) : (
           <button
             type="button"
             onClick={() => void handleSend()}
             disabled={!input.trim()}
-            className="self-end rounded-md bg-primary px-3 py-2 text-xs text-white hover:opacity-90 disabled:opacity-40 transition-opacity"
+            title={t("send")}
+            className="size-8 flex items-center justify-center rounded-md bg-primary text-white hover:opacity-90 disabled:opacity-40 transition-opacity shrink-0"
           >
-            {t("send")}
+            <span className="material-symbols-outlined text-[18px]">arrow_upward</span>
           </button>
         )}
       </div>

--- a/src/app/(dashboard)/dashboard/media-providers/components/LlmChatCard.tsx
+++ b/src/app/(dashboard)/dashboard/media-providers/components/LlmChatCard.tsx
@@ -236,9 +236,9 @@ export function LlmChatCard({ providerId, initialModel }: Props) {
   return (
     <div className="flex flex-col gap-3 rounded-lg border border-border bg-bg-card p-4">
       {/* Header controls */}
-      <div className="grid grid-cols-1 sm:grid-cols-[1fr_auto_auto] items-center gap-2">
+      <div className="flex flex-wrap items-center gap-2">
         {/* Model select */}
-        <div className="flex items-center gap-1.5 min-w-0">
+        <div className="flex items-center gap-1.5 min-w-0 flex-1">
           <label className="text-xs text-text-muted shrink-0">{t("model")}:</label>
           <select
             value={model || firstModel}
@@ -255,12 +255,12 @@ export function LlmChatCard({ providerId, initialModel }: Props) {
         </div>
         {/* Key select */}
         {keys.length > 0 && (
-          <div className="flex items-center gap-1.5 min-w-0">
+          <div className="flex items-center gap-1.5">
             <label className="text-xs text-text-muted shrink-0">{t("selectKey")}:</label>
             <select
               value={selectedKey}
               onChange={(e) => setSelectedKey(e.target.value)}
-              className="min-w-0 flex-1 rounded-md border border-border bg-bg-subtle text-xs px-2 py-1 text-text-main focus:outline-none focus:ring-1 focus:ring-primary"
+              className="rounded-md border border-border bg-bg-subtle text-xs px-2 py-1 text-text-main focus:outline-none focus:ring-1 focus:ring-primary"
             >
               <option value="">(default)</option>
               {keys.map((k) => (
@@ -276,7 +276,7 @@ export function LlmChatCard({ providerId, initialModel }: Props) {
           <button
             type="button"
             onClick={handleClear}
-            className="text-xs text-text-muted hover:text-text-primary transition-colors justify-self-start sm:justify-self-end"
+            className="text-xs text-text-muted hover:text-text-primary transition-colors"
           >
             Clear
           </button>

--- a/src/app/(dashboard)/dashboard/providers/components/ProviderCard.tsx
+++ b/src/app/(dashboard)/dashboard/providers/components/ProviderCard.tsx
@@ -361,10 +361,25 @@ export default function ProviderCard({
         <Modal
           isOpen={testExpanded}
           onClose={() => setTestExpanded(false)}
-          title={`${tp("testLabel")} — ${provider.name}`}
-          size="lg"
+          size="full"
+          title={
+            <span className="flex items-center gap-2">
+              <span
+                className="size-7 rounded-md flex items-center justify-center shrink-0"
+                style={{ backgroundColor: `${provider.color || "#64748b"}15` }}
+              >
+                {staticIconPath ? (
+                  <Image src={staticIconPath} alt={provider.name} width={20} height={20} />
+                ) : (
+                  <ProviderIcon providerId={provider.id || providerId} size={20} type="color" />
+                )}
+              </span>
+              <span className="font-semibold">{provider.name}</span>
+              <span className="text-xs font-normal text-text-muted">· {tp("testLabel")}</span>
+            </span>
+          }
         >
-          <LlmChatCard providerId={providerId} />
+          <LlmChatCard providerId={providerId} embedded />
         </Modal>
       )}
     </div>

--- a/src/app/(dashboard)/dashboard/providers/components/ProviderCard.tsx
+++ b/src/app/(dashboard)/dashboard/providers/components/ProviderCard.tsx
@@ -29,6 +29,19 @@ interface ProviderStats {
   codexFastActive?: boolean;
 }
 
+const KIND_LABEL: Record<string, string> = {
+  llm: "Chat",
+  embedding: "Embed",
+  image: "Image",
+  imageToText: "I→T",
+  tts: "TTS",
+  stt: "STT",
+  webSearch: "Search",
+  webFetch: "Fetch",
+  video: "Video",
+  music: "Music",
+};
+
 interface ProviderCardProps {
   providerId: string;
   provider: {

--- a/src/app/(dashboard)/dashboard/providers/components/ProviderCard.tsx
+++ b/src/app/(dashboard)/dashboard/providers/components/ProviderCard.tsx
@@ -228,6 +228,15 @@ export default function ProviderCard({
                 </span>
               </h3>
               <div className="flex items-center gap-1 shrink-0 pt-0.5">
+                {provider.deprecated && (
+                  <span
+                    className="material-symbols-outlined text-[16px] leading-none text-text-muted"
+                    title={provider.deprecationReason || t("deprecatedProvider")}
+                    aria-label={t("deprecated")}
+                  >
+                    block
+                  </span>
+                )}
                 {provider.subscriptionRisk === true && (
                   <span
                     className="material-symbols-outlined text-[16px] leading-none text-amber-500"
@@ -246,48 +255,41 @@ export default function ProviderCard({
               </div>
             </div>
 
-            {/* Row 2 — Capabilities: service-kind chips + compatibility/deprecated badges. Always rendered with min-h to equalize card heights across the grid. */}
-            <div className="flex flex-wrap items-center gap-1 min-h-[22px]">
-              {provider.serviceKinds?.map((k) => (
-                <span
-                  key={k}
-                  className="text-[10px] px-1.5 py-0.5 rounded bg-bg-subtle border border-border text-text-muted leading-none"
-                >
-                  {KIND_LABEL[k] ?? k}
-                </span>
-              ))}
-              {provider.deprecated && (
-                <Badge
-                  variant="default"
-                  size="sm"
-                  title={provider.deprecationReason || t("deprecatedProvider")}
-                >
-                  <span className="flex items-center gap-0.5">
-                    <span className="material-symbols-outlined text-[10px]">block</span>
-                    {t("deprecated")}
+            {/* Row 2 — Capabilities: service-kind chips + compatibility badges (deprecated shown as block icon in Row 1 header). Rendered only when content exists. */}
+            {((provider.serviceKinds && provider.serviceKinds.length > 0) ||
+              isCompatible ||
+              isCcCompatible ||
+              isAnthropicCompatible) && (
+              <div className="flex flex-wrap items-center gap-1">
+                {provider.serviceKinds?.map((k) => (
+                  <span
+                    key={k}
+                    className="text-[10px] px-1.5 py-0.5 rounded bg-bg-subtle border border-border text-text-muted leading-none"
+                  >
+                    {KIND_LABEL[k] ?? k}
                   </span>
-                </Badge>
-              )}
-              {isCompatible && (
-                <Badge variant="default" size="sm">
-                  {provider.apiType === "responses" ? t("responses") : t("chat")}
-                </Badge>
-              )}
-              {isCcCompatible && (
-                <Badge variant="default" size="sm">
-                  CC
-                </Badge>
-              )}
-              {isAnthropicCompatible && (
-                <Badge variant="default" size="sm">
-                  {t("messages")}
-                </Badge>
-              )}
-            </div>
+                ))}
+                {isCompatible && (
+                  <Badge variant="default" size="sm">
+                    {provider.apiType === "responses" ? t("responses") : t("chat")}
+                  </Badge>
+                )}
+                {isCcCompatible && (
+                  <Badge variant="default" size="sm">
+                    CC
+                  </Badge>
+                )}
+                {isAnthropicCompatible && (
+                  <Badge variant="default" size="sm">
+                    {t("messages")}
+                  </Badge>
+                )}
+              </div>
+            )}
 
             {/* Row 3 — Footer: connection status + controls (toggle, test) */}
             <div className="flex items-center justify-between gap-2 mt-auto pt-1.5 border-t border-border/40">
-              <div className="flex items-center gap-1.5 text-xs flex-wrap min-w-0">
+              <div className="flex items-center gap-1.5 text-xs flex-nowrap min-w-0 overflow-hidden">
                 {allDisabled ? (
                   <Badge variant="default" size="sm">
                     <span className="flex items-center gap-1">
@@ -316,7 +318,7 @@ export default function ProviderCard({
                       </Badge>
                     )}
                     {stats.errorTime && (
-                      <span className="text-text-muted">* {stats.errorTime}</span>
+                      <span className="text-text-muted truncate min-w-0">* {stats.errorTime}</span>
                     )}
                   </>
                 )}

--- a/src/app/(dashboard)/dashboard/providers/components/ProviderCard.tsx
+++ b/src/app/(dashboard)/dashboard/providers/components/ProviderCard.tsx
@@ -201,10 +201,11 @@ export default function ProviderCard({
             testExpanded ? "rounded-b-none border-b-0" : ""
           } ${allDisabled ? "opacity-50" : ""} ${provider.deprecated ? "opacity-60" : ""}`}
         >
-          <div className="flex flex-col gap-2 xl:flex-row xl:items-center xl:justify-between">
-            <div className="flex items-center gap-3 min-w-0 xl:pr-2">
+          <div className="flex flex-col gap-2 h-full">
+            {/* Row 1 — Identity: icon + full name + risk/category indicators */}
+            <div className="flex items-start gap-3 min-w-0">
               <div
-                className="size-7 rounded-lg flex items-center justify-center shrink-0"
+                className="size-9 rounded-lg flex items-center justify-center shrink-0"
                 style={{ backgroundColor: `${provider.color || "#64748b"}15` }}
               >
                 {staticIconPath ? (
@@ -220,133 +221,144 @@ export default function ProviderCard({
                   <ProviderIcon providerId={provider.id || providerId} size={24} type="color" />
                 )}
               </div>
-              <div className="min-w-0">
-                {provider.serviceKinds && provider.serviceKinds.length > 0 && (
-                  <div className="flex flex-wrap gap-1 mb-0.5">
-                    {provider.serviceKinds.map((k) => (
-                      <span
-                        key={k}
-                        className="text-[10px] px-1.5 py-0.5 rounded bg-bg-subtle border border-border text-text-muted leading-none"
-                      >
-                        {KIND_LABEL[k] ?? k}
-                      </span>
-                    ))}
-                  </div>
-                )}
-                <h3 className="text-sm font-semibold flex items-center gap-1 min-w-0">
+              <h3 className="text-sm font-semibold leading-snug flex-1 min-w-0">
+                <span
+                  className={`block break-words ${provider.deprecated ? "line-through opacity-60" : ""}`}
+                  title={provider.name}
+                >
+                  {provider.name}
+                </span>
+              </h3>
+              <div className="flex items-center gap-1 shrink-0 pt-0.5">
+                {provider.subscriptionRisk === true && (
                   <span
-                    className={`truncate min-w-0 flex-1 ${provider.deprecated ? "line-through opacity-60" : ""}`}
+                    className="material-symbols-outlined text-[16px] leading-none text-amber-500"
+                    title={t("riskNotice.tooltip")}
+                    aria-label={t("riskNotice.tooltip")}
                   >
-                    {provider.name}
+                    info
                   </span>
-                  {provider.subscriptionRisk === true && (
-                    <span
-                      className="material-symbols-outlined shrink-0 text-[15px] leading-none text-amber-500"
-                      title={t("riskNotice.tooltip")}
-                      aria-label={t("riskNotice.tooltip")}
-                    >
-                      info
-                    </span>
-                  )}
-                  {provider.deprecated && (
-                    <Badge
-                      variant="default"
-                      size="sm"
-                      title={provider.deprecationReason || t("deprecatedProvider")}
-                    >
-                      <span className="flex items-center gap-0.5">
-                        <span className="material-symbols-outlined text-[10px]">block</span>
-                        {t("deprecated")}
-                      </span>
-                    </Badge>
-                  )}
-                  <CategoryDot
-                    color={DOT_COLORS[authType] || DOT_COLORS.apikey}
-                    hasFree={provider.hasFree === true}
-                    label={dotLabels[authType] || t("apiKeyLabel")}
-                    freeLabel={t("hasFreeTooltip")}
-                  />
-                </h3>
-                <div className="flex items-center gap-2 text-xs flex-wrap">
-                  {allDisabled ? (
-                    <Badge variant="default" size="sm">
-                      <span className="flex items-center gap-1">
-                        <span className="material-symbols-outlined text-[12px]">pause_circle</span>
-                        {t("disabled")}
-                      </span>
-                    </Badge>
-                  ) : (
-                    <>
-                      {getStatusDisplay(
-                        connected,
-                        error,
-                        Number(stats.warning || 0),
-                        stats.errorCode,
-                        t,
-                        codexFastChip
-                      )}
-                      {stats.expiryStatus === "expired" && (
-                        <Badge variant="error" size="sm" dot>
-                          {t("expiredBadge")}
-                        </Badge>
-                      )}
-                      {stats.expiryStatus === "expiring_soon" && (
-                        <Badge variant="warning" size="sm" dot>
-                          {t("expiringSoonBadge")}
-                        </Badge>
-                      )}
-                      {isCompatible && (
-                        <Badge variant="default" size="sm">
-                          {provider.apiType === "responses" ? t("responses") : t("chat")}
-                        </Badge>
-                      )}
-                      {isCcCompatible && (
-                        <Badge variant="default" size="sm">
-                          CC
-                        </Badge>
-                      )}
-                      {isAnthropicCompatible && (
-                        <Badge variant="default" size="sm">
-                          {t("messages")}
-                        </Badge>
-                      )}
-                      {stats.errorTime && (
-                        <span className="text-text-muted">* {stats.errorTime}</span>
-                      )}
-                    </>
-                  )}
-                </div>
+                )}
+                <CategoryDot
+                  color={DOT_COLORS[authType] || DOT_COLORS.apikey}
+                  hasFree={provider.hasFree === true}
+                  label={dotLabels[authType] || t("apiKeyLabel")}
+                  freeLabel={t("hasFreeTooltip")}
+                />
               </div>
             </div>
-            <div className="flex items-center gap-2 shrink-0 self-end xl:self-auto">
-              {Number(stats.total || 0) > 0 && (
-                <div onClick={handleToggle}>
-                  <Toggle
-                    size="xs"
-                    checked={!allDisabled}
-                    onChange={() => {}}
-                    title={allDisabled ? t("enableProvider") : t("disableProvider")}
-                  />
-                </div>
-              )}
-              {isLlmProvider && (
-                <button
-                  type="button"
-                  onClick={handleTestClick}
-                  title={testExpanded ? tp("collapseTest") : tp("expandTest")}
-                  className="inline-flex items-center gap-0.5 rounded-md border border-border bg-bg-subtle px-2 py-0.5 text-[11px] text-text-muted hover:text-text-primary hover:border-primary/30 transition-colors"
-                >
-                  <span className="material-symbols-outlined text-[11px] leading-none">
-                    {testExpanded ? "expand_less" : "play_arrow"}
+
+            {/* Row 2 — Capabilities: service-kind chips + compatibility/deprecated badges */}
+            {((provider.serviceKinds && provider.serviceKinds.length > 0) ||
+              provider.deprecated ||
+              isCompatible ||
+              isCcCompatible ||
+              isAnthropicCompatible) && (
+              <div className="flex flex-wrap items-center gap-1">
+                {provider.serviceKinds?.map((k) => (
+                  <span
+                    key={k}
+                    className="text-[10px] px-1.5 py-0.5 rounded bg-bg-subtle border border-border text-text-muted leading-none"
+                  >
+                    {KIND_LABEL[k] ?? k}
                   </span>
-                  {tp("testLabel")}
-                </button>
-              )}
-              {!isLlmProvider && (
-                <span className="material-symbols-outlined text-text-muted opacity-0 group-hover:opacity-100 transition-opacity">
-                  chevron_right
-                </span>
-              )}
+                ))}
+                {provider.deprecated && (
+                  <Badge
+                    variant="default"
+                    size="sm"
+                    title={provider.deprecationReason || t("deprecatedProvider")}
+                  >
+                    <span className="flex items-center gap-0.5">
+                      <span className="material-symbols-outlined text-[10px]">block</span>
+                      {t("deprecated")}
+                    </span>
+                  </Badge>
+                )}
+                {isCompatible && (
+                  <Badge variant="default" size="sm">
+                    {provider.apiType === "responses" ? t("responses") : t("chat")}
+                  </Badge>
+                )}
+                {isCcCompatible && (
+                  <Badge variant="default" size="sm">
+                    CC
+                  </Badge>
+                )}
+                {isAnthropicCompatible && (
+                  <Badge variant="default" size="sm">
+                    {t("messages")}
+                  </Badge>
+                )}
+              </div>
+            )}
+
+            {/* Row 3 — Footer: connection status + controls (toggle, test) */}
+            <div className="flex items-center justify-between gap-2 mt-auto pt-1.5 border-t border-border/40">
+              <div className="flex items-center gap-1.5 text-xs flex-wrap min-w-0">
+                {allDisabled ? (
+                  <Badge variant="default" size="sm">
+                    <span className="flex items-center gap-1">
+                      <span className="material-symbols-outlined text-[12px]">pause_circle</span>
+                      {t("disabled")}
+                    </span>
+                  </Badge>
+                ) : (
+                  <>
+                    {getStatusDisplay(
+                      connected,
+                      error,
+                      Number(stats.warning || 0),
+                      stats.errorCode,
+                      t,
+                      codexFastChip
+                    )}
+                    {stats.expiryStatus === "expired" && (
+                      <Badge variant="error" size="sm" dot>
+                        {t("expiredBadge")}
+                      </Badge>
+                    )}
+                    {stats.expiryStatus === "expiring_soon" && (
+                      <Badge variant="warning" size="sm" dot>
+                        {t("expiringSoonBadge")}
+                      </Badge>
+                    )}
+                    {stats.errorTime && (
+                      <span className="text-text-muted">* {stats.errorTime}</span>
+                    )}
+                  </>
+                )}
+              </div>
+              <div className="flex items-center gap-2 shrink-0">
+                {Number(stats.total || 0) > 0 && (
+                  <div onClick={handleToggle}>
+                    <Toggle
+                      size="xs"
+                      checked={!allDisabled}
+                      onChange={() => {}}
+                      title={allDisabled ? t("enableProvider") : t("disableProvider")}
+                    />
+                  </div>
+                )}
+                {isLlmProvider && (
+                  <button
+                    type="button"
+                    onClick={handleTestClick}
+                    title={testExpanded ? tp("collapseTest") : tp("expandTest")}
+                    className="inline-flex items-center gap-0.5 rounded-md border border-border bg-bg-subtle px-2 py-0.5 text-[11px] text-text-muted hover:text-text-primary hover:border-primary/30 transition-colors"
+                  >
+                    <span className="material-symbols-outlined text-[11px] leading-none">
+                      {testExpanded ? "expand_less" : "play_arrow"}
+                    </span>
+                    {tp("testLabel")}
+                  </button>
+                )}
+                {!isLlmProvider && (
+                  <span className="material-symbols-outlined text-text-muted opacity-0 group-hover:opacity-100 transition-opacity">
+                    chevron_right
+                  </span>
+                )}
+              </div>
             </div>
           </div>
         </Card>

--- a/src/app/(dashboard)/dashboard/providers/components/ProviderCard.tsx
+++ b/src/app/(dashboard)/dashboard/providers/components/ProviderCard.tsx
@@ -193,11 +193,11 @@ export default function ProviderCard({
   };
 
   return (
-    <div className="flex flex-col">
-      <Link href={`/dashboard/providers/${providerId}`} className="group">
+    <div className={`flex flex-col h-full ${testExpanded ? "col-span-full" : ""}`}>
+      <Link href={`/dashboard/providers/${providerId}`} className="group flex-1 flex flex-col">
         <Card
           padding="xs"
-          className={`hover:bg-black/[0.01] dark:hover:bg-white/[0.01] transition-colors cursor-pointer ${
+          className={`h-full flex flex-col hover:bg-black/[0.01] dark:hover:bg-white/[0.01] transition-colors cursor-pointer ${
             testExpanded ? "rounded-b-none border-b-0" : ""
           } ${allDisabled ? "opacity-50" : ""} ${provider.deprecated ? "opacity-60" : ""}`}
         >

--- a/src/app/(dashboard)/dashboard/providers/components/ProviderCard.tsx
+++ b/src/app/(dashboard)/dashboard/providers/components/ProviderCard.tsx
@@ -362,20 +362,24 @@ export default function ProviderCard({
           isOpen={testExpanded}
           onClose={() => setTestExpanded(false)}
           size="full"
+          compactHeader
+          bodyClassName="p-4 max-h-[calc(85vh-60px)] overflow-hidden flex flex-col"
           title={
-            <span className="flex items-center gap-2">
+            <span className="flex items-center gap-2 min-w-0">
               <span
-                className="size-7 rounded-md flex items-center justify-center shrink-0"
+                className="size-6 rounded-md flex items-center justify-center shrink-0"
                 style={{ backgroundColor: `${provider.color || "#64748b"}15` }}
               >
                 {staticIconPath ? (
-                  <Image src={staticIconPath} alt={provider.name} width={20} height={20} />
+                  <Image src={staticIconPath} alt={provider.name} width={18} height={18} />
                 ) : (
-                  <ProviderIcon providerId={provider.id || providerId} size={20} type="color" />
+                  <ProviderIcon providerId={provider.id || providerId} size={18} type="color" />
                 )}
               </span>
-              <span className="font-semibold">{provider.name}</span>
-              <span className="text-xs font-normal text-text-muted">· {tp("testLabel")}</span>
+              <span className="font-semibold truncate">{provider.name}</span>
+              <span className="text-xs font-normal text-text-muted shrink-0">
+                · {tp("testLabel")}
+              </span>
             </span>
           }
         >

--- a/src/app/(dashboard)/dashboard/providers/components/ProviderCard.tsx
+++ b/src/app/(dashboard)/dashboard/providers/components/ProviderCard.tsx
@@ -201,8 +201,8 @@ export default function ProviderCard({
             testExpanded ? "rounded-b-none border-b-0" : ""
           } ${allDisabled ? "opacity-50" : ""} ${provider.deprecated ? "opacity-60" : ""}`}
         >
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-3 min-w-0 pr-2">
+          <div className="flex flex-col gap-2 xl:flex-row xl:items-center xl:justify-between">
+            <div className="flex items-center gap-3 min-w-0 xl:pr-2">
               <div
                 className="size-7 rounded-lg flex items-center justify-center shrink-0"
                 style={{ backgroundColor: `${provider.color || "#64748b"}15` }}
@@ -318,7 +318,7 @@ export default function ProviderCard({
                 </div>
               </div>
             </div>
-            <div className="flex items-center gap-2 shrink-0">
+            <div className="flex items-center gap-2 shrink-0 self-end xl:self-auto">
               {Number(stats.total || 0) > 0 && (
                 <div onClick={handleToggle}>
                   <Toggle

--- a/src/app/(dashboard)/dashboard/providers/components/ProviderCard.tsx
+++ b/src/app/(dashboard)/dashboard/providers/components/ProviderCard.tsx
@@ -363,7 +363,7 @@ export default function ProviderCard({
           onClose={() => setTestExpanded(false)}
           size="full"
           compactHeader
-          bodyClassName="p-4 max-h-[calc(85vh-60px)] overflow-hidden flex flex-col"
+          bodyClassName="pl-4 pr-2 py-3 max-h-[calc(85vh-60px)] overflow-hidden flex flex-col"
           title={
             <span className="flex items-center gap-2 min-w-0">
               <span

--- a/src/app/(dashboard)/dashboard/providers/components/ProviderCard.tsx
+++ b/src/app/(dashboard)/dashboard/providers/components/ProviderCard.tsx
@@ -6,7 +6,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
 
-import { Badge, Card, Toggle } from "@/shared/components";
+import { Badge, Card, Modal, Toggle } from "@/shared/components";
 import ProviderIcon from "@/shared/components/ProviderIcon";
 import {
   isAnthropicCompatibleProvider,
@@ -193,13 +193,11 @@ export default function ProviderCard({
   };
 
   return (
-    <div className={`flex flex-col h-full ${testExpanded ? "col-span-full" : ""}`}>
+    <div className="flex flex-col h-full">
       <Link href={`/dashboard/providers/${providerId}`} className="group flex-1 flex flex-col">
         <Card
           padding="xs"
-          className={`h-full flex flex-col hover:bg-black/[0.01] dark:hover:bg-white/[0.01] transition-colors cursor-pointer ${
-            testExpanded ? "rounded-b-none border-b-0" : ""
-          } ${allDisabled ? "opacity-50" : ""} ${provider.deprecated ? "opacity-60" : ""}`}
+          className={`h-full flex flex-col hover:bg-black/[0.01] dark:hover:bg-white/[0.01] transition-colors cursor-pointer ${allDisabled ? "opacity-50" : ""} ${provider.deprecated ? "opacity-60" : ""}`}
         >
           <div className="flex flex-col gap-2 h-full">
             {/* Row 1 — Identity: icon + full name + risk/category indicators */}
@@ -248,50 +246,44 @@ export default function ProviderCard({
               </div>
             </div>
 
-            {/* Row 2 — Capabilities: service-kind chips + compatibility/deprecated badges */}
-            {((provider.serviceKinds && provider.serviceKinds.length > 0) ||
-              provider.deprecated ||
-              isCompatible ||
-              isCcCompatible ||
-              isAnthropicCompatible) && (
-              <div className="flex flex-wrap items-center gap-1">
-                {provider.serviceKinds?.map((k) => (
-                  <span
-                    key={k}
-                    className="text-[10px] px-1.5 py-0.5 rounded bg-bg-subtle border border-border text-text-muted leading-none"
-                  >
-                    {KIND_LABEL[k] ?? k}
+            {/* Row 2 — Capabilities: service-kind chips + compatibility/deprecated badges. Always rendered with min-h to equalize card heights across the grid. */}
+            <div className="flex flex-wrap items-center gap-1 min-h-[22px]">
+              {provider.serviceKinds?.map((k) => (
+                <span
+                  key={k}
+                  className="text-[10px] px-1.5 py-0.5 rounded bg-bg-subtle border border-border text-text-muted leading-none"
+                >
+                  {KIND_LABEL[k] ?? k}
+                </span>
+              ))}
+              {provider.deprecated && (
+                <Badge
+                  variant="default"
+                  size="sm"
+                  title={provider.deprecationReason || t("deprecatedProvider")}
+                >
+                  <span className="flex items-center gap-0.5">
+                    <span className="material-symbols-outlined text-[10px]">block</span>
+                    {t("deprecated")}
                   </span>
-                ))}
-                {provider.deprecated && (
-                  <Badge
-                    variant="default"
-                    size="sm"
-                    title={provider.deprecationReason || t("deprecatedProvider")}
-                  >
-                    <span className="flex items-center gap-0.5">
-                      <span className="material-symbols-outlined text-[10px]">block</span>
-                      {t("deprecated")}
-                    </span>
-                  </Badge>
-                )}
-                {isCompatible && (
-                  <Badge variant="default" size="sm">
-                    {provider.apiType === "responses" ? t("responses") : t("chat")}
-                  </Badge>
-                )}
-                {isCcCompatible && (
-                  <Badge variant="default" size="sm">
-                    CC
-                  </Badge>
-                )}
-                {isAnthropicCompatible && (
-                  <Badge variant="default" size="sm">
-                    {t("messages")}
-                  </Badge>
-                )}
-              </div>
-            )}
+                </Badge>
+              )}
+              {isCompatible && (
+                <Badge variant="default" size="sm">
+                  {provider.apiType === "responses" ? t("responses") : t("chat")}
+                </Badge>
+              )}
+              {isCcCompatible && (
+                <Badge variant="default" size="sm">
+                  CC
+                </Badge>
+              )}
+              {isAnthropicCompatible && (
+                <Badge variant="default" size="sm">
+                  {t("messages")}
+                </Badge>
+              )}
+            </div>
 
             {/* Row 3 — Footer: connection status + controls (toggle, test) */}
             <div className="flex items-center justify-between gap-2 mt-auto pt-1.5 border-t border-border/40">
@@ -344,11 +336,11 @@ export default function ProviderCard({
                   <button
                     type="button"
                     onClick={handleTestClick}
-                    title={testExpanded ? tp("collapseTest") : tp("expandTest")}
+                    title={tp("expandTest")}
                     className="inline-flex items-center gap-0.5 rounded-md border border-border bg-bg-subtle px-2 py-0.5 text-[11px] text-text-muted hover:text-text-primary hover:border-primary/30 transition-colors"
                   >
                     <span className="material-symbols-outlined text-[11px] leading-none">
-                      {testExpanded ? "expand_less" : "play_arrow"}
+                      play_arrow
                     </span>
                     {tp("testLabel")}
                   </button>
@@ -363,10 +355,15 @@ export default function ProviderCard({
           </div>
         </Card>
       </Link>
-      {testExpanded && isLlmProvider && (
-        <div className="rounded-b-lg border border-t-0 border-border bg-bg-card p-3">
+      {isLlmProvider && (
+        <Modal
+          isOpen={testExpanded}
+          onClose={() => setTestExpanded(false)}
+          title={`${tp("testLabel")} — ${provider.name}`}
+          size="lg"
+        >
           <LlmChatCard providerId={providerId} />
-        </div>
+        </Modal>
       )}
     </div>
   );

--- a/src/app/(dashboard)/dashboard/providers/components/ProviderCard.tsx
+++ b/src/app/(dashboard)/dashboard/providers/components/ProviderCard.tsx
@@ -6,14 +6,14 @@ import Image from "next/image";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
 
-import { Badge, Card, Modal, Toggle } from "@/shared/components";
+import { Badge, Card, Toggle } from "@/shared/components";
+import ProviderTestSlideOver from "@/shared/components/ProviderTestSlideOver";
 import ProviderIcon from "@/shared/components/ProviderIcon";
 import {
   isAnthropicCompatibleProvider,
   isClaudeCodeCompatibleProvider,
   isOpenAICompatibleProvider,
 } from "@/shared/constants/providers";
-import { LlmChatCard } from "@/app/(dashboard)/dashboard/media-providers/components/LlmChatCard";
 
 import { CategoryDot } from "./CategoryDot";
 
@@ -358,33 +358,13 @@ export default function ProviderCard({
         </Card>
       </Link>
       {isLlmProvider && (
-        <Modal
+        <ProviderTestSlideOver
           isOpen={testExpanded}
           onClose={() => setTestExpanded(false)}
-          size="full"
-          compactHeader
-          bodyClassName="pl-4 pr-2 py-3 max-h-[calc(85vh-60px)] overflow-hidden flex flex-col"
-          title={
-            <span className="flex items-center gap-2 min-w-0">
-              <span
-                className="size-6 rounded-md flex items-center justify-center shrink-0"
-                style={{ backgroundColor: `${provider.color || "#64748b"}15` }}
-              >
-                {staticIconPath ? (
-                  <Image src={staticIconPath} alt={provider.name} width={18} height={18} />
-                ) : (
-                  <ProviderIcon providerId={provider.id || providerId} size={18} type="color" />
-                )}
-              </span>
-              <span className="font-semibold truncate">{provider.name}</span>
-              <span className="text-xs font-normal text-text-muted shrink-0">
-                · {tp("testLabel")}
-              </span>
-            </span>
-          }
-        >
-          <LlmChatCard providerId={providerId} embedded />
-        </Modal>
+          providerId={providerId}
+          provider={provider}
+          staticIconPath={staticIconPath}
+        />
       )}
     </div>
   );

--- a/src/app/(dashboard)/dashboard/providers/page.tsx
+++ b/src/app/(dashboard)/dashboard/providers/page.tsx
@@ -992,7 +992,7 @@ export default function ProvidersPage() {
               <span>{t("noCompatibleYet")}</span>
             </div>
           ) : (
-            <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-3">
               {compatibleProviderEntries.map(
                 ({ providerId, provider, stats, displayAuthType, toggleAuthType }) => (
                   <ProviderCard
@@ -1060,7 +1060,7 @@ export default function ProvidersPage() {
               </button>
             </div>
           </div>
-          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-3">
             {oauthProviderEntries
               .filter((e) => !IDE_PROVIDER_IDS.has(e.providerId))
               .map(({ providerId, provider, stats, displayAuthType, toggleAuthType }) => (
@@ -1115,7 +1115,7 @@ export default function ProvidersPage() {
               {t("noIdeProviders") || "No IDE providers match the current filters."}
             </div>
           ) : (
-            <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-3">
               {ideProviderEntries.map(
                 ({ providerId, provider, stats, displayAuthType, toggleAuthType }) => (
                   <ProviderCard
@@ -1161,7 +1161,7 @@ export default function ProvidersPage() {
               {testingMode === "web-cookie" ? t("testing") : t("testAll")}
             </button>
           </div>
-          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-3">
             {webCookieProviderEntries.map(({ providerId, provider, stats, toggleAuthType }) => (
               <ProviderCard
                 key={providerId}
@@ -1204,7 +1204,7 @@ export default function ProvidersPage() {
               {testingMode === "free" ? t("testing") : t("testAll")}
             </button>
           </div>
-          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-3">
             {freeSectionEntries.map(
               ({ providerId, provider, stats, displayAuthType, toggleAuthType }) => (
                 <ProviderCard
@@ -1252,7 +1252,7 @@ export default function ProvidersPage() {
               <h3 className="text-xs font-semibold uppercase tracking-wider text-text-muted">
                 {t("llmProviders")}
               </h3>
-              <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-3">
                 {llmProviderEntries.map(
                   ({ providerId, provider, stats, displayAuthType, toggleAuthType }) => (
                     <ProviderCard
@@ -1298,7 +1298,7 @@ export default function ProvidersPage() {
               {testingMode === "no-auth" ? t("testing") : t("testAll")}
             </button>
           </div>
-          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-3">
             {noAuthEntries.map(({ providerId, provider, stats, toggleAuthType }) => (
               <ProviderCard
                 key={providerId}
@@ -1341,7 +1341,7 @@ export default function ProvidersPage() {
               {testingMode === "upstream-proxy" ? t("testing") : t("testAll")}
             </button>
           </div>
-          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-3">
             {upstreamProxyEntries.map(({ providerId, provider, stats, toggleAuthType }) => (
               <ProviderCard
                 key={providerId}
@@ -1366,7 +1366,7 @@ export default function ProvidersPage() {
               <ProviderCountBadge {...countConfigured(webFetchEntriesAll)} />
             </h2>
           </div>
-          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-3">
             {webFetchEntries.map(
               ({ providerId, provider, stats, displayAuthType, toggleAuthType }) => (
                 <ProviderCard
@@ -1391,7 +1391,7 @@ export default function ProvidersPage() {
             <h2 className="text-base font-semibold">{t("aggregatorsGateways")}</h2>
             <ProviderCountBadge {...countConfigured(aggregatorProviderEntriesAll)} />
           </div>
-          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-3">
             {aggregatorProviderEntries.map(
               ({ providerId, provider, stats, displayAuthType, toggleAuthType }) => (
                 <ProviderCard
@@ -1416,7 +1416,7 @@ export default function ProvidersPage() {
             <h2 className="text-base font-semibold">{t("enterpriseCloud")}</h2>
             <ProviderCountBadge {...countConfigured(enterpriseProviderEntriesAll)} />
           </div>
-          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-3">
             {enterpriseProviderEntries.map(
               ({ providerId, provider, stats, displayAuthType, toggleAuthType }) => (
                 <ProviderCard
@@ -1461,7 +1461,7 @@ export default function ProvidersPage() {
               {testingMode === "cloud-agent" ? t("testing") : t("testAll")}
             </button>
           </div>
-          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-3">
             {cloudAgentProviderEntries.map(({ providerId, provider, stats, toggleAuthType }) => (
               <ProviderCard
                 key={providerId}
@@ -1501,7 +1501,7 @@ export default function ProvidersPage() {
               {testingMode === "local" ? t("testing") : t("testAll")}
             </button>
           </div>
-          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-3">
             {localProviderEntries.map(({ providerId, provider, stats, toggleAuthType }) => (
               <ProviderCard
                 key={providerId}
@@ -1544,7 +1544,7 @@ export default function ProvidersPage() {
               {testingMode === "search" ? t("testing") : t("testAll")}
             </button>
           </div>
-          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-3">
             {searchProviderEntries.map(({ providerId, provider, stats, toggleAuthType }) => (
               <ProviderCard
                 key={providerId}
@@ -1567,7 +1567,7 @@ export default function ProvidersPage() {
             <h2 className="text-base font-semibold">{t("embeddingRerankProviders")}</h2>
             <ProviderCountBadge {...countConfigured(embeddingRerankProviderEntriesAll)} />
           </div>
-          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-3">
             {embeddingRerankProviderEntries.map(
               ({ providerId, provider, stats, displayAuthType, toggleAuthType }) => (
                 <ProviderCard
@@ -1592,7 +1592,7 @@ export default function ProvidersPage() {
             <h2 className="text-base font-semibold">{t("imageProviders")}</h2>
             <ProviderCountBadge {...countConfigured(imageProviderEntriesAll)} />
           </div>
-          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-3">
             {imageProviderEntries.map(
               ({ providerId, provider, stats, displayAuthType, toggleAuthType }) => (
                 <ProviderCard
@@ -1637,7 +1637,7 @@ export default function ProvidersPage() {
               {testingMode === "audio" ? t("testing") : t("testAll")}
             </button>
           </div>
-          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-3">
             {audioProviderEntries.map(({ providerId, provider, stats, toggleAuthType }) => (
               <ProviderCard
                 key={providerId}
@@ -1660,7 +1660,7 @@ export default function ProvidersPage() {
             <h2 className="text-base font-semibold">{t("videoProviders")}</h2>
             <ProviderCountBadge {...countConfigured(videoProviderEntriesAll)} />
           </div>
-          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-3">
             {videoProviderEntries.map(
               ({ providerId, provider, stats, displayAuthType, toggleAuthType }) => (
                 <ProviderCard

--- a/src/shared/components/CommandPalette.tsx
+++ b/src/shared/components/CommandPalette.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+import {
+  SIDEBAR_SECTIONS,
+  getSectionItems,
+  HIDDEN_SIDEBAR_ITEMS_SETTING_KEY,
+  normalizeHiddenSidebarItems,
+} from "@/shared/constants/sidebarVisibility";
+
+interface CommandPaletteProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export default function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
+  if (!isOpen) return null;
+  return <CommandPaletteDialog onClose={onClose} />;
+}
+
+interface PaletteItem {
+  id: string;
+  href: string;
+  icon: string;
+  label: string;
+  subtitle?: string;
+  external: boolean;
+}
+
+function CommandPaletteDialog({ onClose }: { onClose: () => void }) {
+  const router = useRouter();
+  const t = useTranslations("sidebar");
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+  const [query, setQuery] = useState("");
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [hiddenItems, setHiddenItems] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    const ctrl = new AbortController();
+    fetch("/api/settings", { signal: ctrl.signal })
+      .then((res) => res.json())
+      .then((data) => {
+        setHiddenItems(
+          new Set(normalizeHiddenSidebarItems(data?.[HIDDEN_SIDEBAR_ITEMS_SETTING_KEY]))
+        );
+      })
+      .catch(() => {
+        // ignore aborts and fetch failures; palette still works with empty hidden set
+      });
+    return () => ctrl.abort();
+  }, []);
+
+  useEffect(() => {
+    const id = setTimeout(() => inputRef.current?.focus(), 30);
+    return () => clearTimeout(id);
+  }, []);
+
+  const safeTranslate = useCallback(
+    (key: string, fallback: string) => {
+      try {
+        return t(key);
+      } catch {
+        return fallback;
+      }
+    },
+    [t]
+  );
+
+  const allItems = useMemo<PaletteItem[]>(
+    () =>
+      SIDEBAR_SECTIONS.flatMap((section) =>
+        getSectionItems(section)
+          .filter((item) => !hiddenItems.has(item.id))
+          .map((item) => ({
+            id: item.id,
+            href: item.href,
+            icon: item.icon,
+            label: safeTranslate(item.i18nKey, item.id),
+            subtitle: item.subtitleKey ? safeTranslate(item.subtitleKey, "") : undefined,
+            external: item.external ?? false,
+          }))
+      ),
+    [hiddenItems, safeTranslate]
+  );
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return allItems;
+    return allItems.filter(
+      (item) => item.label.toLowerCase().includes(q) || item.subtitle?.toLowerCase().includes(q)
+    );
+  }, [allItems, query]);
+
+  const handleNavigate = useCallback(
+    (href: string, external: boolean) => {
+      onClose();
+      if (external) {
+        window.open(href, "_blank", "noopener,noreferrer");
+      } else {
+        router.push(href);
+      }
+    },
+    [onClose, router]
+  );
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose();
+        return;
+      }
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setSelectedIndex((prev) => (prev + 1) % Math.max(1, filtered.length));
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setSelectedIndex(
+          (prev) => (prev - 1 + Math.max(1, filtered.length)) % Math.max(1, filtered.length)
+        );
+      } else if (e.key === "Enter") {
+        e.preventDefault();
+        const item = filtered[selectedIndex];
+        if (item) {
+          handleNavigate(item.href, item.external);
+        }
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [filtered, selectedIndex, onClose, handleNavigate]);
+
+  useEffect(() => {
+    const list = listRef.current;
+    if (!list) return;
+    const el = list.children[selectedIndex] as HTMLElement | undefined;
+    el?.scrollIntoView({ block: "nearest" });
+  }, [selectedIndex]);
+
+  return (
+    <div className="fixed inset-0 z-[60] flex items-start justify-center pt-[15vh] px-4">
+      <div
+        className="absolute inset-0 bg-black/40 backdrop-blur-sm"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <div
+        className="relative w-full max-w-lg bg-bg border border-black/10 dark:border-white/10 rounded-2xl shadow-2xl overflow-hidden"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Command palette"
+      >
+        <div className="flex items-center gap-3 px-4 py-3 border-b border-black/5 dark:border-white/5">
+          <span className="material-symbols-outlined text-[18px] text-text-muted shrink-0">
+            search
+          </span>
+          <input
+            ref={inputRef}
+            type="text"
+            className="flex-1 bg-transparent text-text placeholder:text-text-muted outline-none text-sm"
+            placeholder="Go to..."
+            value={query}
+            onChange={(e) => {
+              setQuery(e.target.value);
+              setSelectedIndex(0);
+            }}
+            autoComplete="off"
+            spellCheck={false}
+          />
+          {query && (
+            <button
+              className="text-text-muted hover:text-text transition-colors"
+              onClick={() => {
+                setQuery("");
+                setSelectedIndex(0);
+              }}
+              tabIndex={-1}
+              aria-label="Clear search"
+            >
+              <span className="material-symbols-outlined text-[16px]">close</span>
+            </button>
+          )}
+          <kbd className="hidden sm:inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded text-[10px] font-mono bg-black/5 dark:bg-white/5 text-text-muted border border-black/10 dark:border-white/10 shrink-0">
+            Esc
+          </kbd>
+        </div>
+
+        {filtered.length > 0 ? (
+          <ul
+            ref={listRef}
+            className="py-1.5 max-h-80 overflow-y-auto custom-scrollbar"
+            role="listbox"
+          >
+            {filtered.map((item, idx) => (
+              <li key={item.id} role="option" aria-selected={idx === selectedIndex}>
+                <button
+                  className={`w-full flex items-center gap-3 px-4 py-2.5 text-left transition-colors ${
+                    idx === selectedIndex
+                      ? "bg-accent/10 text-accent"
+                      : "text-text hover:bg-black/5 dark:hover:bg-white/5"
+                  }`}
+                  onClick={() => handleNavigate(item.href, item.external)}
+                  onMouseEnter={() => setSelectedIndex(idx)}
+                >
+                  <span
+                    className={`material-symbols-outlined text-[18px] shrink-0 ${
+                      idx === selectedIndex ? "text-accent" : "text-text-muted"
+                    }`}
+                  >
+                    {item.icon}
+                  </span>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-medium truncate">{item.label}</p>
+                    {item.subtitle && (
+                      <p
+                        className={`text-xs truncate ${
+                          idx === selectedIndex ? "text-accent/70" : "text-text-muted"
+                        }`}
+                      >
+                        {item.subtitle}
+                      </p>
+                    )}
+                  </div>
+                  {item.external && (
+                    <span className="material-symbols-outlined text-[14px] text-text-muted shrink-0">
+                      open_in_new
+                    </span>
+                  )}
+                </button>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <div className="py-10 text-center text-text-muted text-sm">No results</div>
+        )}
+
+        <div className="flex items-center gap-4 px-4 py-2 border-t border-black/5 dark:border-white/5 text-[11px] text-text-muted">
+          <span className="flex items-center gap-1">
+            <kbd className="px-1 py-0.5 rounded bg-black/5 dark:bg-white/5 border border-black/10 dark:border-white/10 font-mono">
+              ↑↓
+            </kbd>
+            navigate
+          </span>
+          <span className="flex items-center gap-1">
+            <kbd className="px-1 py-0.5 rounded bg-black/5 dark:bg-white/5 border border-black/10 dark:border-white/10 font-mono">
+              ↵
+            </kbd>
+            open
+          </span>
+          <span className="flex items-center gap-1">
+            <kbd className="px-1 py-0.5 rounded bg-black/5 dark:bg-white/5 border border-black/10 dark:border-white/10 font-mono">
+              Esc
+            </kbd>
+            close
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/shared/components/CommandPalette.tsx
+++ b/src/shared/components/CommandPalette.tsx
@@ -140,27 +140,27 @@ function CommandPaletteDialog({ onClose }: { onClose: () => void }) {
   }, [selectedIndex]);
 
   return (
-    <div className="fixed inset-0 z-[60] flex items-start justify-center pt-[15vh] px-4">
+    <div className="fixed inset-0 z-[60] flex items-start justify-center pt-[10vh] px-4">
       <div
         className="absolute inset-0 bg-black/40 backdrop-blur-sm"
         onClick={onClose}
         aria-hidden="true"
       />
       <div
-        className="relative w-full max-w-lg bg-surface border border-black/10 dark:border-white/10 rounded-xl shadow-2xl overflow-hidden animate-in fade-in zoom-in-95 duration-200"
+        className="relative w-full max-w-3xl bg-surface border border-black/10 dark:border-white/10 rounded-xl shadow-2xl overflow-hidden animate-in fade-in zoom-in-95 duration-200"
         role="dialog"
         aria-modal="true"
         aria-label="Command palette"
       >
-        <div className="flex items-center gap-3 px-4 py-3 border-b border-black/5 dark:border-white/5">
-          <span className="material-symbols-outlined text-[18px] text-text-muted shrink-0">
+        <div className="flex items-center gap-3 px-6 py-4 border-b border-black/5 dark:border-white/5">
+          <span className="material-symbols-outlined text-[20px] text-text-muted shrink-0">
             search
           </span>
           <input
             ref={inputRef}
             type="text"
-            className="flex-1 bg-transparent text-text placeholder:text-text-muted outline-none text-sm"
-            placeholder="Go to..."
+            className="flex-1 bg-transparent text-text placeholder:text-text-muted outline-none text-base"
+            placeholder="Search pages, settings, tools..."
             value={query}
             onChange={(e) => {
               setQuery(e.target.value);
@@ -190,7 +190,7 @@ function CommandPaletteDialog({ onClose }: { onClose: () => void }) {
         {filtered.length > 0 ? (
           <ul
             ref={listRef}
-            className="py-1.5 max-h-80 overflow-y-auto custom-scrollbar"
+            className="py-2 max-h-[60vh] overflow-y-auto custom-scrollbar"
             role="listbox"
           >
             {filtered.map((item, idx) => (

--- a/src/shared/components/CommandPalette.tsx
+++ b/src/shared/components/CommandPalette.tsx
@@ -147,7 +147,7 @@ function CommandPaletteDialog({ onClose }: { onClose: () => void }) {
         aria-hidden="true"
       />
       <div
-        className="relative w-full max-w-lg bg-bg border border-black/10 dark:border-white/10 rounded-2xl shadow-2xl overflow-hidden"
+        className="relative w-full max-w-lg bg-surface border border-black/10 dark:border-white/10 rounded-xl shadow-2xl overflow-hidden animate-in fade-in zoom-in-95 duration-200"
         role="dialog"
         aria-modal="true"
         aria-label="Command palette"
@@ -198,7 +198,7 @@ function CommandPaletteDialog({ onClose }: { onClose: () => void }) {
                 <button
                   className={`w-full flex items-center gap-3 px-4 py-2.5 text-left transition-colors ${
                     idx === selectedIndex
-                      ? "bg-accent/10 text-accent"
+                      ? "bg-accent/10 text-accent ring-1 ring-inset ring-accent/20"
                       : "text-text hover:bg-black/5 dark:hover:bg-white/5"
                   }`}
                   onClick={() => handleNavigate(item.href, item.external)}

--- a/src/shared/components/CommandPalette.tsx
+++ b/src/shared/components/CommandPalette.tsx
@@ -5,10 +5,17 @@ import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import {
   SIDEBAR_SECTIONS,
-  getSectionItems,
   HIDDEN_SIDEBAR_ITEMS_SETTING_KEY,
   normalizeHiddenSidebarItems,
+  type SidebarItemDefinition,
+  type SidebarSectionChild,
 } from "@/shared/constants/sidebarVisibility";
+
+function isSidebarGroup(
+  child: SidebarSectionChild
+): child is Extract<SidebarSectionChild, { type: "group" }> {
+  return "type" in child && child.type === "group";
+}
 
 interface CommandPaletteProps {
   isOpen: boolean;
@@ -29,12 +36,20 @@ interface PaletteItem {
   external: boolean;
   sectionId: string;
   sectionLabel: string;
+  subgroupId?: string;
+  subgroupLabel?: string;
+}
+
+interface PaletteSubgroup {
+  subgroupId: string | null;
+  subgroupLabel: string | null;
+  items: { item: PaletteItem; flatIndex: number }[];
 }
 
 interface PaletteGroup {
   sectionId: string;
   sectionLabel: string;
-  items: { item: PaletteItem; flatIndex: number }[];
+  subgroups: PaletteSubgroup[];
 }
 
 function CommandPaletteDialog({ onClose }: { onClose: () => void }) {
@@ -81,18 +96,39 @@ function CommandPaletteDialog({ onClose }: { onClose: () => void }) {
     () =>
       SIDEBAR_SECTIONS.flatMap((section) => {
         const sectionLabel = safeTranslate(section.titleKey, section.titleFallback);
-        return getSectionItems(section)
-          .filter((item) => !hiddenItems.has(item.id))
-          .map((item) => ({
-            id: item.id,
-            href: item.href,
-            icon: item.icon,
-            label: safeTranslate(item.i18nKey, item.id),
-            subtitle: item.subtitleKey ? safeTranslate(item.subtitleKey, "") : undefined,
-            external: item.external ?? false,
-            sectionId: section.id,
-            sectionLabel,
-          }));
+        return section.children.flatMap<PaletteItem>((child) => {
+          if (isSidebarGroup(child)) {
+            const subgroupLabel = safeTranslate(child.titleKey, child.titleFallback);
+            return child.items
+              .filter((item) => !hiddenItems.has(item.id))
+              .map<PaletteItem>((item) => ({
+                id: item.id,
+                href: item.href,
+                icon: item.icon,
+                label: safeTranslate(item.i18nKey, item.id),
+                subtitle: item.subtitleKey ? safeTranslate(item.subtitleKey, "") : undefined,
+                external: item.external ?? false,
+                sectionId: section.id,
+                sectionLabel,
+                subgroupId: child.id,
+                subgroupLabel,
+              }));
+          }
+          const item = child as SidebarItemDefinition;
+          if (hiddenItems.has(item.id)) return [];
+          return [
+            {
+              id: item.id,
+              href: item.href,
+              icon: item.icon,
+              label: safeTranslate(item.i18nKey, item.id),
+              subtitle: item.subtitleKey ? safeTranslate(item.subtitleKey, "") : undefined,
+              external: item.external ?? false,
+              sectionId: section.id,
+              sectionLabel,
+            },
+          ];
+        });
       }),
     [hiddenItems, safeTranslate]
   );
@@ -104,23 +140,34 @@ function CommandPaletteDialog({ onClose }: { onClose: () => void }) {
       (item) =>
         item.label.toLowerCase().includes(q) ||
         item.subtitle?.toLowerCase().includes(q) ||
-        item.sectionLabel.toLowerCase().includes(q)
+        item.sectionLabel.toLowerCase().includes(q) ||
+        item.subgroupLabel?.toLowerCase().includes(q)
     );
   }, [allItems, query]);
 
   const grouped = useMemo<PaletteGroup[]>(() => {
     const groups: PaletteGroup[] = [];
     filtered.forEach((item, flatIndex) => {
-      const last = groups[groups.length - 1];
-      if (last && last.sectionId === item.sectionId) {
-        last.items.push({ item, flatIndex });
-      } else {
-        groups.push({
+      let section = groups[groups.length - 1];
+      if (!section || section.sectionId !== item.sectionId) {
+        section = {
           sectionId: item.sectionId,
           sectionLabel: item.sectionLabel,
-          items: [{ item, flatIndex }],
-        });
+          subgroups: [],
+        };
+        groups.push(section);
       }
+      const itemSubgroupId = item.subgroupId ?? null;
+      let subgroup = section.subgroups[section.subgroups.length - 1];
+      if (!subgroup || subgroup.subgroupId !== itemSubgroupId) {
+        subgroup = {
+          subgroupId: itemSubgroupId,
+          subgroupLabel: item.subgroupLabel ?? null,
+          items: [],
+        };
+        section.subgroups.push(subgroup);
+      }
+      subgroup.items.push({ item, flatIndex });
     });
     return groups;
   }, [filtered]);
@@ -230,47 +277,68 @@ function CommandPaletteDialog({ onClose }: { onClose: () => void }) {
                   {group.sectionLabel}
                 </div>
                 <ul role="group" aria-label={group.sectionLabel}>
-                  {group.items.map(({ item, flatIndex }) => (
+                  {group.subgroups.map((subgroup) => (
                     <li
-                      key={item.id}
-                      role="option"
-                      aria-selected={flatIndex === selectedIndex}
-                      data-flat-index={flatIndex}
+                      key={`${group.sectionId}::${subgroup.subgroupId ?? "_root"}`}
+                      role="presentation"
                     >
-                      <button
-                        className={`w-full flex items-center gap-3 px-6 py-2.5 text-left transition-colors ${
-                          flatIndex === selectedIndex
-                            ? "bg-accent/10 text-accent ring-1 ring-inset ring-accent/20"
-                            : "text-text hover:bg-black/5 dark:hover:bg-white/5"
-                        }`}
-                        onClick={() => handleNavigate(item.href, item.external)}
-                        onMouseEnter={() => setSelectedIndex(flatIndex)}
-                      >
-                        <span
-                          className={`material-symbols-outlined text-[18px] shrink-0 ${
-                            flatIndex === selectedIndex ? "text-accent" : "text-text-muted"
-                          }`}
-                        >
-                          {item.icon}
-                        </span>
-                        <div className="flex-1 min-w-0">
-                          <p className="text-sm font-medium truncate">{item.label}</p>
-                          {item.subtitle && (
-                            <p
-                              className={`text-xs truncate ${
-                                flatIndex === selectedIndex ? "text-accent/70" : "text-text-muted"
-                              }`}
-                            >
-                              {item.subtitle}
-                            </p>
-                          )}
+                      {subgroup.subgroupLabel && (
+                        <div className="px-6 pt-2 pb-1 text-[10px] font-medium uppercase tracking-wide text-text-muted/70">
+                          {subgroup.subgroupLabel}
                         </div>
-                        {item.external && (
-                          <span className="material-symbols-outlined text-[14px] text-text-muted shrink-0">
-                            open_in_new
-                          </span>
-                        )}
-                      </button>
+                      )}
+                      <ul
+                        role={subgroup.subgroupLabel ? "group" : "presentation"}
+                        aria-label={subgroup.subgroupLabel ?? undefined}
+                      >
+                        {subgroup.items.map(({ item, flatIndex }) => (
+                          <li
+                            key={item.id}
+                            role="option"
+                            aria-selected={flatIndex === selectedIndex}
+                            data-flat-index={flatIndex}
+                          >
+                            <button
+                              className={`w-full flex items-center gap-3 ${
+                                subgroup.subgroupLabel ? "pl-10 pr-6" : "px-6"
+                              } py-2.5 text-left transition-colors ${
+                                flatIndex === selectedIndex
+                                  ? "bg-accent/10 text-accent ring-1 ring-inset ring-accent/20"
+                                  : "text-text hover:bg-black/5 dark:hover:bg-white/5"
+                              }`}
+                              onClick={() => handleNavigate(item.href, item.external)}
+                              onMouseEnter={() => setSelectedIndex(flatIndex)}
+                            >
+                              <span
+                                className={`material-symbols-outlined text-[18px] shrink-0 ${
+                                  flatIndex === selectedIndex ? "text-accent" : "text-text-muted"
+                                }`}
+                              >
+                                {item.icon}
+                              </span>
+                              <div className="flex-1 min-w-0">
+                                <p className="text-sm font-medium truncate">{item.label}</p>
+                                {item.subtitle && (
+                                  <p
+                                    className={`text-xs truncate ${
+                                      flatIndex === selectedIndex
+                                        ? "text-accent/70"
+                                        : "text-text-muted"
+                                    }`}
+                                  >
+                                    {item.subtitle}
+                                  </p>
+                                )}
+                              </div>
+                              {item.external && (
+                                <span className="material-symbols-outlined text-[14px] text-text-muted shrink-0">
+                                  open_in_new
+                                </span>
+                              )}
+                            </button>
+                          </li>
+                        ))}
+                      </ul>
                     </li>
                   ))}
                 </ul>

--- a/src/shared/components/CommandPalette.tsx
+++ b/src/shared/components/CommandPalette.tsx
@@ -27,6 +27,14 @@ interface PaletteItem {
   label: string;
   subtitle?: string;
   external: boolean;
+  sectionId: string;
+  sectionLabel: string;
+}
+
+interface PaletteGroup {
+  sectionId: string;
+  sectionLabel: string;
+  items: { item: PaletteItem; flatIndex: number }[];
 }
 
 function CommandPaletteDialog({ onClose }: { onClose: () => void }) {
@@ -71,8 +79,9 @@ function CommandPaletteDialog({ onClose }: { onClose: () => void }) {
 
   const allItems = useMemo<PaletteItem[]>(
     () =>
-      SIDEBAR_SECTIONS.flatMap((section) =>
-        getSectionItems(section)
+      SIDEBAR_SECTIONS.flatMap((section) => {
+        const sectionLabel = safeTranslate(section.titleKey, section.titleFallback);
+        return getSectionItems(section)
           .filter((item) => !hiddenItems.has(item.id))
           .map((item) => ({
             id: item.id,
@@ -81,8 +90,10 @@ function CommandPaletteDialog({ onClose }: { onClose: () => void }) {
             label: safeTranslate(item.i18nKey, item.id),
             subtitle: item.subtitleKey ? safeTranslate(item.subtitleKey, "") : undefined,
             external: item.external ?? false,
-          }))
-      ),
+            sectionId: section.id,
+            sectionLabel,
+          }));
+      }),
     [hiddenItems, safeTranslate]
   );
 
@@ -90,9 +101,29 @@ function CommandPaletteDialog({ onClose }: { onClose: () => void }) {
     const q = query.trim().toLowerCase();
     if (!q) return allItems;
     return allItems.filter(
-      (item) => item.label.toLowerCase().includes(q) || item.subtitle?.toLowerCase().includes(q)
+      (item) =>
+        item.label.toLowerCase().includes(q) ||
+        item.subtitle?.toLowerCase().includes(q) ||
+        item.sectionLabel.toLowerCase().includes(q)
     );
   }, [allItems, query]);
+
+  const grouped = useMemo<PaletteGroup[]>(() => {
+    const groups: PaletteGroup[] = [];
+    filtered.forEach((item, flatIndex) => {
+      const last = groups[groups.length - 1];
+      if (last && last.sectionId === item.sectionId) {
+        last.items.push({ item, flatIndex });
+      } else {
+        groups.push({
+          sectionId: item.sectionId,
+          sectionLabel: item.sectionLabel,
+          items: [{ item, flatIndex }],
+        });
+      }
+    });
+    return groups;
+  }, [filtered]);
 
   const handleNavigate = useCallback(
     (href: string, external: boolean) => {
@@ -135,7 +166,7 @@ function CommandPaletteDialog({ onClose }: { onClose: () => void }) {
   useEffect(() => {
     const list = listRef.current;
     if (!list) return;
-    const el = list.children[selectedIndex] as HTMLElement | undefined;
+    const el = list.querySelector<HTMLElement>(`[data-flat-index="${selectedIndex}"]`);
     el?.scrollIntoView({ block: "nearest" });
   }, [selectedIndex]);
 
@@ -187,48 +218,62 @@ function CommandPaletteDialog({ onClose }: { onClose: () => void }) {
           </kbd>
         </div>
 
-        {filtered.length > 0 ? (
+        {grouped.length > 0 ? (
           <ul
             ref={listRef}
             className="py-2 max-h-[60vh] overflow-y-auto custom-scrollbar"
             role="listbox"
           >
-            {filtered.map((item, idx) => (
-              <li key={item.id} role="option" aria-selected={idx === selectedIndex}>
-                <button
-                  className={`w-full flex items-center gap-3 px-4 py-2.5 text-left transition-colors ${
-                    idx === selectedIndex
-                      ? "bg-accent/10 text-accent ring-1 ring-inset ring-accent/20"
-                      : "text-text hover:bg-black/5 dark:hover:bg-white/5"
-                  }`}
-                  onClick={() => handleNavigate(item.href, item.external)}
-                  onMouseEnter={() => setSelectedIndex(idx)}
-                >
-                  <span
-                    className={`material-symbols-outlined text-[18px] shrink-0 ${
-                      idx === selectedIndex ? "text-accent" : "text-text-muted"
-                    }`}
-                  >
-                    {item.icon}
-                  </span>
-                  <div className="flex-1 min-w-0">
-                    <p className="text-sm font-medium truncate">{item.label}</p>
-                    {item.subtitle && (
-                      <p
-                        className={`text-xs truncate ${
-                          idx === selectedIndex ? "text-accent/70" : "text-text-muted"
+            {grouped.map((group) => (
+              <li key={group.sectionId} role="presentation">
+                <div className="sticky top-0 z-10 bg-surface/95 backdrop-blur-sm px-6 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-text-muted border-b border-black/5 dark:border-white/5">
+                  {group.sectionLabel}
+                </div>
+                <ul role="group" aria-label={group.sectionLabel}>
+                  {group.items.map(({ item, flatIndex }) => (
+                    <li
+                      key={item.id}
+                      role="option"
+                      aria-selected={flatIndex === selectedIndex}
+                      data-flat-index={flatIndex}
+                    >
+                      <button
+                        className={`w-full flex items-center gap-3 px-6 py-2.5 text-left transition-colors ${
+                          flatIndex === selectedIndex
+                            ? "bg-accent/10 text-accent ring-1 ring-inset ring-accent/20"
+                            : "text-text hover:bg-black/5 dark:hover:bg-white/5"
                         }`}
+                        onClick={() => handleNavigate(item.href, item.external)}
+                        onMouseEnter={() => setSelectedIndex(flatIndex)}
                       >
-                        {item.subtitle}
-                      </p>
-                    )}
-                  </div>
-                  {item.external && (
-                    <span className="material-symbols-outlined text-[14px] text-text-muted shrink-0">
-                      open_in_new
-                    </span>
-                  )}
-                </button>
+                        <span
+                          className={`material-symbols-outlined text-[18px] shrink-0 ${
+                            flatIndex === selectedIndex ? "text-accent" : "text-text-muted"
+                          }`}
+                        >
+                          {item.icon}
+                        </span>
+                        <div className="flex-1 min-w-0">
+                          <p className="text-sm font-medium truncate">{item.label}</p>
+                          {item.subtitle && (
+                            <p
+                              className={`text-xs truncate ${
+                                flatIndex === selectedIndex ? "text-accent/70" : "text-text-muted"
+                              }`}
+                            >
+                              {item.subtitle}
+                            </p>
+                          )}
+                        </div>
+                        {item.external && (
+                          <span className="material-symbols-outlined text-[14px] text-text-muted shrink-0">
+                            open_in_new
+                          </span>
+                        )}
+                      </button>
+                    </li>
+                  ))}
+                </ul>
               </li>
             ))}
           </ul>

--- a/src/shared/components/Header.tsx
+++ b/src/shared/components/Header.tsx
@@ -1,6 +1,15 @@
 "use client";
 
+import { useSyncExternalStore } from "react";
 import { usePathname, useRouter } from "next/navigation";
+
+const subscribePlatform = () => () => {};
+const getPlatformIsMac = () => {
+  if (typeof navigator === "undefined") return false;
+  const platform = navigator.platform || navigator.userAgent;
+  return /Mac|iPhone|iPad|iPod/.test(platform);
+};
+const getPlatformIsMacServer = () => false;
 import ThemeToggle from "./ThemeToggle";
 import TokenHealthBadge from "./TokenHealthBadge";
 import DegradationBadge from "./DegradationBadge";
@@ -118,6 +127,7 @@ function getSidebarItem(pathname: string): SidebarItemDefinition | undefined {
 
 type HeaderProps = {
   onMenuClick?: () => void;
+  onOpenCommandPalette?: () => void;
   showMenuButton?: boolean;
 };
 
@@ -162,7 +172,12 @@ function usePageInfo(pathname: string | null): PageInfo {
   return { title: "", description: "" };
 }
 
-export default function Header({ onMenuClick, showMenuButton = true }: HeaderProps) {
+export default function Header({
+  onMenuClick,
+  onOpenCommandPalette,
+  showMenuButton = true,
+}: HeaderProps) {
+  const isMac = useSyncExternalStore(subscribePlatform, getPlatformIsMac, getPlatformIsMacServer);
   const pathname = usePathname();
   const router = useRouter();
   const isElectron = useIsElectron();
@@ -225,6 +240,31 @@ export default function Header({ onMenuClick, showMenuButton = true }: HeaderPro
 
       {/* Right actions */}
       <div className="flex items-center gap-3 ml-auto">
+        {onOpenCommandPalette && (
+          <>
+            <button
+              type="button"
+              onClick={onOpenCommandPalette}
+              className="hidden md:inline-flex items-center gap-2 px-2.5 py-1.5 rounded-lg border border-black/10 dark:border-white/10 bg-bg-subtle text-text-muted hover:text-text-main hover:bg-black/[0.04] dark:hover:bg-white/[0.04] transition-colors"
+              title="Quick navigation (⌘K / Ctrl+K)"
+              aria-label="Open quick navigation"
+            >
+              <span className="material-symbols-outlined text-[16px]">search</span>
+              <span className="text-xs">Quick nav</span>
+              <kbd className="hidden lg:inline-flex font-mono text-[10px] px-1 py-0.5 rounded bg-black/5 dark:bg-white/5 border border-black/10 dark:border-white/10">
+                {isMac ? "⌘K" : "Ctrl+K"}
+              </kbd>
+            </button>
+            <button
+              type="button"
+              onClick={onOpenCommandPalette}
+              className="md:hidden p-2 rounded-lg text-text-muted hover:text-text-main hover:bg-black/5 dark:hover:bg-white/5 transition-colors"
+              aria-label="Open quick navigation"
+            >
+              <span className="material-symbols-outlined">search</span>
+            </button>
+          </>
+        )}
         <LanguageSelector />
         <ThemeToggle />
         {!isE2EMode && <DegradationBadge />}

--- a/src/shared/components/Modal.tsx
+++ b/src/shared/components/Modal.tsx
@@ -14,6 +14,8 @@ interface ModalProps {
   closeOnOverlay?: boolean;
   showCloseButton?: boolean;
   className?: string;
+  bodyClassName?: string;
+  compactHeader?: boolean;
   maxWidth?: string;
 }
 
@@ -27,6 +29,8 @@ export default function Modal({
   closeOnOverlay = true,
   showCloseButton = true,
   className,
+  bodyClassName,
+  compactHeader = false,
 }: ModalProps) {
   const titleId = useId();
   const dialogRef = useRef(null);
@@ -126,15 +130,47 @@ export default function Modal({
       >
         {/* Header */}
         {(title || showCloseButton) && (
-          <div className="flex items-center justify-between p-6 border-b border-black/5 dark:border-white/5">
-            <div className="flex items-center">
-              <div className="flex items-center gap-2 mr-4" aria-hidden="true">
-                <div className="w-3 h-3 rounded-full bg-[#FF5F56]" />
-                <div className="w-3 h-3 rounded-full bg-[#FFBD2E]" />
-                <div className="w-3 h-3 rounded-full bg-[#27C93F]" />
+          <div
+            className={cn(
+              "flex items-center justify-between border-b border-black/5 dark:border-white/5",
+              compactHeader ? "px-4 py-2.5" : "p-6"
+            )}
+          >
+            <div className="flex items-center min-w-0">
+              <div
+                className={cn(
+                  "flex items-center gap-1.5 mr-3 shrink-0",
+                  compactHeader ? "" : "gap-2 mr-4"
+                )}
+                aria-hidden="true"
+              >
+                <div
+                  className={cn(
+                    "rounded-full bg-[#FF5F56]",
+                    compactHeader ? "w-2.5 h-2.5" : "w-3 h-3"
+                  )}
+                />
+                <div
+                  className={cn(
+                    "rounded-full bg-[#FFBD2E]",
+                    compactHeader ? "w-2.5 h-2.5" : "w-3 h-3"
+                  )}
+                />
+                <div
+                  className={cn(
+                    "rounded-full bg-[#27C93F]",
+                    compactHeader ? "w-2.5 h-2.5" : "w-3 h-3"
+                  )}
+                />
               </div>
               {title && (
-                <h2 id={titleId} className="text-lg font-semibold text-text-main">
+                <h2
+                  id={titleId}
+                  className={cn(
+                    "font-semibold text-text-main truncate min-w-0",
+                    compactHeader ? "text-sm" : "text-lg"
+                  )}
+                >
                   {title}
                 </h2>
               )}
@@ -143,7 +179,7 @@ export default function Modal({
               <button
                 onClick={onClose}
                 aria-label="Close"
-                className="p-1.5 rounded-lg text-text-muted hover:bg-black/5 dark:hover:bg-white/5 transition-colors"
+                className="p-1.5 rounded-lg text-text-muted hover:bg-black/5 dark:hover:bg-white/5 transition-colors shrink-0"
               >
                 <span className="material-symbols-outlined text-[20px]" aria-hidden="true">
                   close
@@ -154,7 +190,9 @@ export default function Modal({
         )}
 
         {/* Body */}
-        <div className="p-6 max-h-[calc(80vh-140px)] overflow-y-auto">{children}</div>
+        <div className={bodyClassName ?? "p-6 max-h-[calc(80vh-140px)] overflow-y-auto"}>
+          {children}
+        </div>
 
         {/* Footer */}
         {footer && (

--- a/src/shared/components/NavigationProgress.tsx
+++ b/src/shared/components/NavigationProgress.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+
+const TICK_MS = 150;
+const STEP_MAX = 12;
+const CEILING = 88;
+const FINISH_DELAY_MS = 220;
+const RESET_DELAY_MS = 320;
+
+export default function NavigationProgress() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const [active, setActive] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const lastKeyRef = useRef<string>(`${pathname}?${searchParams?.toString() ?? ""}`);
+  const tickRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const finishTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const resetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    const onClick = (e: MouseEvent) => {
+      if (e.defaultPrevented) return;
+      if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+      if (e.button !== 0) return;
+      const anchor = (e.target as HTMLElement | null)?.closest?.("a") as HTMLAnchorElement | null;
+      if (!anchor) return;
+      if (anchor.target && anchor.target !== "" && anchor.target !== "_self") return;
+      if (anchor.hasAttribute("download")) return;
+      const href = anchor.getAttribute("href");
+      if (!href) return;
+      if (href.startsWith("#")) return;
+      if (href.startsWith("mailto:") || href.startsWith("tel:")) return;
+      try {
+        const url = new URL(anchor.href, window.location.href);
+        if (url.origin !== window.location.origin) return;
+        const currentKey = `${window.location.pathname}?${window.location.search}`;
+        const nextKey = `${url.pathname}?${url.search}`;
+        if (currentKey === nextKey) return;
+      } catch {
+        return;
+      }
+      // Defer to next microtask to avoid setState-in-handler-during-event issues.
+      queueMicrotask(() => {
+        setActive(true);
+        setProgress(8);
+      });
+    };
+    document.addEventListener("click", onClick, true);
+    return () => document.removeEventListener("click", onClick, true);
+  }, []);
+
+  useEffect(() => {
+    if (!active) return;
+    tickRef.current = setInterval(() => {
+      setProgress((prev) => {
+        if (prev >= CEILING) return prev;
+        const remaining = CEILING - prev;
+        const next = prev + Math.min(STEP_MAX, Math.max(1, remaining * 0.18));
+        return Math.min(CEILING, next);
+      });
+    }, TICK_MS);
+    return () => {
+      if (tickRef.current) {
+        clearInterval(tickRef.current);
+        tickRef.current = null;
+      }
+    };
+  }, [active]);
+
+  useEffect(() => {
+    const key = `${pathname}?${searchParams?.toString() ?? ""}`;
+    if (key === lastKeyRef.current) return;
+    lastKeyRef.current = key;
+    if (finishTimerRef.current) clearTimeout(finishTimerRef.current);
+    if (resetTimerRef.current) clearTimeout(resetTimerRef.current);
+    finishTimerRef.current = setTimeout(() => {
+      setProgress(100);
+      resetTimerRef.current = setTimeout(() => {
+        setActive(false);
+        setProgress(0);
+      }, RESET_DELAY_MS);
+    }, FINISH_DELAY_MS);
+    return () => {
+      if (finishTimerRef.current) clearTimeout(finishTimerRef.current);
+      if (resetTimerRef.current) clearTimeout(resetTimerRef.current);
+    };
+  }, [pathname, searchParams]);
+
+  if (!active && progress === 0) return null;
+
+  return (
+    <div className="pointer-events-none fixed inset-x-0 top-0 z-[9999] h-0.5" aria-hidden="true">
+      <div
+        className="h-full origin-left bg-gradient-to-r from-primary via-accent to-primary transition-[width,opacity] duration-200 ease-out"
+        style={{
+          width: `${progress}%`,
+          opacity: progress >= 100 ? 0 : 1,
+          boxShadow: "0 0 10px rgba(99, 102, 241, 0.6), 0 0 4px rgba(229, 77, 94, 0.4)",
+        }}
+      />
+    </div>
+  );
+}

--- a/src/shared/components/ProviderTestSlideOver.tsx
+++ b/src/shared/components/ProviderTestSlideOver.tsx
@@ -1,0 +1,367 @@
+"use client";
+
+import { useEffect, useState, type ReactNode } from "react";
+import Image from "next/image";
+
+import { LlmChatCard } from "@/app/(dashboard)/dashboard/media-providers/components/LlmChatCard";
+import ProviderIcon from "@/shared/components/ProviderIcon";
+
+interface SlideOverProvider {
+  id?: string;
+  name: string;
+  color?: string;
+  apiType?: string;
+  deprecated?: boolean;
+  deprecationReason?: string;
+  subscriptionRisk?: boolean;
+  serviceKinds?: string[];
+}
+
+interface ProviderTestSlideOverProps {
+  isOpen: boolean;
+  onClose: () => void;
+  providerId: string;
+  provider: SlideOverProvider;
+  staticIconPath?: string | null;
+  initialTab?: TabKey;
+}
+
+type TabKey = "test" | "models" | "keys" | "logs";
+
+const TABS: { key: TabKey; label: string; icon: string }[] = [
+  { key: "test", label: "Test", icon: "play_arrow" },
+  { key: "models", label: "Models", icon: "view_list" },
+  { key: "keys", label: "Keys", icon: "key" },
+  { key: "logs", label: "Logs", icon: "receipt_long" },
+];
+
+export default function ProviderTestSlideOver({
+  isOpen,
+  onClose,
+  providerId,
+  provider,
+  staticIconPath,
+  initialTab = "test",
+}: ProviderTestSlideOverProps) {
+  if (!isOpen) return null;
+  return (
+    <ProviderTestSlideOverPanel
+      onClose={onClose}
+      providerId={providerId}
+      provider={provider}
+      staticIconPath={staticIconPath}
+      initialTab={initialTab}
+    />
+  );
+}
+
+interface PanelProps {
+  onClose: () => void;
+  providerId: string;
+  provider: SlideOverProvider;
+  staticIconPath?: string | null;
+  initialTab: TabKey;
+}
+
+function ProviderTestSlideOverPanel({
+  onClose,
+  providerId,
+  provider,
+  staticIconPath,
+  initialTab,
+}: PanelProps) {
+  const [tab, setTab] = useState<TabKey>(initialTab);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  useEffect(() => {
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, []);
+
+  const color = provider.color || "#64748b";
+
+  return (
+    <div className="fixed inset-0 z-[60] flex justify-end">
+      <div
+        className="absolute inset-0 bg-black/40 backdrop-blur-sm animate-in fade-in duration-200"
+        onClick={onClose}
+        aria-hidden
+      />
+      <div
+        role="dialog"
+        aria-label={`Test ${provider.name}`}
+        className="relative w-full sm:w-[640px] md:w-[720px] lg:w-[820px] max-w-full bg-surface border-l border-black/10 dark:border-white/10 shadow-2xl flex flex-col animate-in slide-in-from-right duration-200"
+      >
+        <SlideOverHeader
+          provider={provider}
+          providerId={providerId}
+          staticIconPath={staticIconPath}
+          color={color}
+          onClose={onClose}
+        />
+        <SlideOverTabs tab={tab} onChange={setTab} />
+        <div className="flex-1 min-h-0 overflow-hidden flex flex-col">
+          {tab === "test" && (
+            <div className="flex-1 min-h-0 flex flex-col pl-4 pr-2 py-3">
+              <LlmChatCard providerId={providerId} embedded />
+            </div>
+          )}
+          {tab === "models" && <ModelsTab providerId={providerId} />}
+          {tab === "keys" && <KeysTab provider={provider} providerId={providerId} />}
+          {tab === "logs" && <LogsTab providerId={providerId} />}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SlideOverHeader({
+  provider,
+  providerId,
+  staticIconPath,
+  color,
+  onClose,
+}: {
+  provider: SlideOverProvider;
+  providerId: string;
+  staticIconPath?: string | null;
+  color: string;
+  onClose: () => void;
+}) {
+  return (
+    <div className="flex items-center gap-3 px-4 py-3 border-b border-black/5 dark:border-white/5 shrink-0">
+      <div
+        className="size-9 rounded-lg flex items-center justify-center shrink-0"
+        style={{ backgroundColor: `${color}15` }}
+      >
+        {staticIconPath ? (
+          <Image src={staticIconPath} alt={provider.name} width={22} height={22} />
+        ) : (
+          <ProviderIcon providerId={provider.id || providerId} size={22} type="color" />
+        )}
+      </div>
+      <div className="flex-1 min-w-0">
+        <h2 className="text-sm font-semibold text-text-main truncate" title={provider.name}>
+          {provider.name}
+        </h2>
+        <div className="flex items-center gap-1.5 text-[11px] text-text-muted">
+          {provider.apiType && <span className="font-mono">{provider.apiType}</span>}
+          {provider.deprecated && (
+            <>
+              <span>·</span>
+              <span className="flex items-center gap-0.5 text-text-muted/70">
+                <span className="material-symbols-outlined text-[12px]">block</span>
+                deprecated
+              </span>
+            </>
+          )}
+          {provider.subscriptionRisk && (
+            <>
+              <span>·</span>
+              <span className="flex items-center gap-0.5 text-amber-500">
+                <span className="material-symbols-outlined text-[12px]">info</span>
+                risk
+              </span>
+            </>
+          )}
+        </div>
+      </div>
+      <button
+        type="button"
+        onClick={onClose}
+        aria-label="Close"
+        className="p-1.5 rounded-lg text-text-muted hover:bg-black/5 dark:hover:bg-white/5 transition-colors"
+      >
+        <span className="material-symbols-outlined text-[20px]">close</span>
+      </button>
+    </div>
+  );
+}
+
+function SlideOverTabs({ tab, onChange }: { tab: TabKey; onChange: (next: TabKey) => void }) {
+  return (
+    <div
+      role="tablist"
+      className="flex items-center gap-1 px-4 pt-2 border-b border-black/5 dark:border-white/5 shrink-0"
+    >
+      {TABS.map((t) => {
+        const active = t.key === tab;
+        return (
+          <button
+            key={t.key}
+            role="tab"
+            type="button"
+            aria-selected={active}
+            onClick={() => onChange(t.key)}
+            className={`relative flex items-center gap-1.5 px-3 py-2 text-xs font-medium transition-colors ${
+              active ? "text-accent" : "text-text-muted hover:text-text-main"
+            }`}
+          >
+            <span className="material-symbols-outlined text-[16px]">{t.icon}</span>
+            <span>{t.label}</span>
+            {active && (
+              <span
+                aria-hidden
+                className="absolute left-0 right-0 -bottom-px h-0.5 bg-accent rounded-t"
+              />
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function TabPlaceholder({ icon, title, body }: { icon: string; title: string; body: ReactNode }) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-3 p-10 text-center flex-1 min-h-0 overflow-y-auto">
+      <div className="size-12 rounded-full bg-accent/10 flex items-center justify-center">
+        <span className="material-symbols-outlined text-accent text-[24px]">{icon}</span>
+      </div>
+      <h3 className="text-sm font-semibold text-text-main">{title}</h3>
+      <div className="text-xs text-text-muted max-w-sm">{body}</div>
+    </div>
+  );
+}
+
+interface ModelEntry {
+  id: string;
+  displayId?: string;
+  owned_by?: string;
+}
+
+type ModelsState =
+  | { status: "loading" }
+  | { status: "ready"; models: ModelEntry[] }
+  | { status: "error"; message: string };
+
+function ModelsTab({ providerId }: { providerId: string }) {
+  const [state, setState] = useState<ModelsState>({ status: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+    queueMicrotask(() => {
+      if (cancelled) return;
+      setState({ status: "loading" });
+    });
+    fetch(`/api/v1/providers/${encodeURIComponent(providerId)}/models`)
+      .then(async (r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        const data = (await r.json()) as { data?: ModelEntry[] };
+        if (!cancelled) setState({ status: "ready", models: data.data ?? [] });
+      })
+      .catch((e: unknown) => {
+        if (!cancelled) {
+          setState({ status: "error", message: e instanceof Error ? e.message : "Failed to load" });
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [providerId]);
+
+  const loading = state.status === "loading";
+  const error = state.status === "error" ? state.message : null;
+  const models = state.status === "ready" ? state.models : [];
+
+  if (loading) {
+    return (
+      <TabPlaceholder
+        icon="hourglass_top"
+        title="Loading models"
+        body="Fetching available models from provider…"
+      />
+    );
+  }
+  if (error) {
+    return <TabPlaceholder icon="error" title="Could not load models" body={error} />;
+  }
+  if (models.length === 0) {
+    return (
+      <TabPlaceholder
+        icon="view_list"
+        title="No models"
+        body="This provider didn't return any models."
+      />
+    );
+  }
+  return (
+    <div className="flex-1 min-h-0 overflow-y-auto px-4 py-3">
+      <ul className="flex flex-col divide-y divide-border/60">
+        {models.map((m) => (
+          <li key={m.id} className="flex items-center justify-between gap-3 py-2.5">
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-mono text-text-main truncate" title={m.id}>
+                {m.displayId || m.id}
+              </p>
+              {m.owned_by && <p className="text-[11px] text-text-muted">{m.owned_by}</p>}
+            </div>
+            <button
+              type="button"
+              onClick={() => navigator.clipboard?.writeText(m.id)}
+              title="Copy model id"
+              className="p-1.5 rounded-md text-text-muted hover:bg-black/5 dark:hover:bg-white/5 transition-colors shrink-0"
+            >
+              <span className="material-symbols-outlined text-[16px]">content_copy</span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function KeysTab({ provider, providerId }: { provider: SlideOverProvider; providerId: string }) {
+  return (
+    <TabPlaceholder
+      icon="key"
+      title="Manage keys"
+      body={
+        <div className="flex flex-col gap-2">
+          <p>
+            Open the full provider page to add or rotate keys for{" "}
+            <span className="font-mono">{provider.name}</span>.
+          </p>
+          <a
+            href={`/dashboard/providers/${providerId}`}
+            className="inline-flex items-center gap-1.5 text-accent hover:underline self-center"
+          >
+            <span className="material-symbols-outlined text-[14px]">open_in_new</span>
+            Go to provider page
+          </a>
+        </div>
+      }
+    />
+  );
+}
+
+function LogsTab({ providerId }: { providerId: string }) {
+  return (
+    <TabPlaceholder
+      icon="receipt_long"
+      title="Recent requests"
+      body={
+        <div className="flex flex-col gap-2">
+          <p>Per-provider log filtering is coming soon. For now, open the global logs view.</p>
+          <a
+            href={`/dashboard/logs?connection=${encodeURIComponent(providerId)}`}
+            className="inline-flex items-center gap-1.5 text-accent hover:underline self-center"
+          >
+            <span className="material-symbols-outlined text-[14px]">open_in_new</span>
+            Open logs
+          </a>
+        </div>
+      }
+    />
+  );
+}

--- a/src/shared/components/layouts/DashboardLayout.tsx
+++ b/src/shared/components/layouts/DashboardLayout.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { Suspense, useEffect, useState } from "react";
 import Sidebar from "../Sidebar";
 import Header from "../Header";
 import NotificationToast from "../NotificationToast";
 import MaintenanceBanner from "../MaintenanceBanner";
 import CommandPalette from "../CommandPalette";
+import NavigationProgress from "../NavigationProgress";
 import { useIsElectron } from "@/shared/hooks/useElectron";
 
 const SIDEBAR_COLLAPSED_KEY = "sidebar-collapsed";
@@ -56,6 +57,9 @@ export default function DashboardLayout({ children }) {
 
   return (
     <div className="flex h-dvh min-h-0 w-full overflow-hidden bg-bg">
+      <Suspense fallback={null}>
+        <NavigationProgress />
+      </Suspense>
       {/* Mobile sidebar overlay */}
       {sidebarOpen && (
         <div

--- a/src/shared/components/layouts/DashboardLayout.tsx
+++ b/src/shared/components/layouts/DashboardLayout.tsx
@@ -87,7 +87,10 @@ export default function DashboardLayout({ children }) {
         id="main-content"
         className="relative flex min-h-0 flex-1 min-w-0 flex-col transition-colors duration-300"
       >
-        <Header onMenuClick={() => setSidebarOpen(true)} />
+        <Header
+          onMenuClick={() => setSidebarOpen(true)}
+          onOpenCommandPalette={() => setCommandPaletteOpen(true)}
+        />
         {!isE2EMode && <MaintenanceBanner />}
         <div className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden custom-scrollbar p-4 sm:p-6 lg:p-10">
           <div className="max-w-7xl mx-auto w-full">{children}</div>

--- a/src/shared/components/layouts/DashboardLayout.tsx
+++ b/src/shared/components/layouts/DashboardLayout.tsx
@@ -5,6 +5,7 @@ import Sidebar from "../Sidebar";
 import Header from "../Header";
 import NotificationToast from "../NotificationToast";
 import MaintenanceBanner from "../MaintenanceBanner";
+import CommandPalette from "../CommandPalette";
 import { useIsElectron } from "@/shared/hooks/useElectron";
 
 const SIDEBAR_COLLAPSED_KEY = "sidebar-collapsed";
@@ -12,6 +13,7 @@ const isE2EMode = process.env.NEXT_PUBLIC_OMNIROUTE_E2E_MODE === "1";
 
 export default function DashboardLayout({ children }) {
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
   const isElectron = useIsElectron();
   const [collapsed, setCollapsed] = useState(() => {
     if (typeof window === "undefined") return false;
@@ -34,6 +36,17 @@ export default function DashboardLayout({ children }) {
       document.body.classList.remove("electron-macos");
     };
   }, [isMacElectron]);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+        e.preventDefault();
+        setCommandPaletteOpen((prev) => !prev);
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, []);
 
   const handleToggleCollapse = () => {
     const next = !collapsed;
@@ -83,6 +96,8 @@ export default function DashboardLayout({ children }) {
 
       {/* Global notification toast system */}
       <NotificationToast />
+
+      <CommandPalette isOpen={commandPaletteOpen} onClose={() => setCommandPaletteOpen(false)} />
     </div>
   );
 }


### PR DESCRIPTION
## What

Adds a quick-access command palette to the dashboard, triggered with **Cmd+K** (macOS) / **Ctrl+K** (Linux/Windows). It exposes every visible sidebar item — across all sections (Omni-Proxy, Analytics, Monitoring, Dev Tools, Agentic, Gamification, Other Features, Configuration, Help) — as a searchable, keyboard-navigable list, letting users jump to any page without reaching for the mouse.

Targets `release/v3.8.3` to ship with the same release as #2617.

## Why

The sidebar already has 50+ items distributed across 10 sections, and the count keeps growing with each release (mini-playground, media providers, web-fetch category, free-tier grouping, etc.). Scrolling/clicking the sidebar to reach a page is increasingly slow. A Cmd+K palette is the standard UX for fast navigation in dense dashboards (VS Code, Linear, GitHub, Vercel, Supabase…), and it's a natural complement to the existing customizable sidebar.

## Behavior

- **Cmd+K** / **Ctrl+K** toggles the palette from anywhere inside the dashboard layout
- **↑** / **↓** to move selection (wraps), **Enter** to navigate
- **Esc** (or backdrop click) to close
- Substring match against item label + subtitle (case-insensitive)
- Respects per-user hidden sidebar items (via `/api/settings` — same source as the customizable sidebar)
- External links (e.g. docs) open in a new tab with `noopener`/`noreferrer` and show an `open_in_new` glyph
- Uses `next-intl` translations from the existing `sidebar` namespace, with a safe fallback to the item id if a key is missing

## Implementation notes

- New `src/shared/components/CommandPalette.tsx` with a thin outer wrapper that returns `null` when closed; an inner `CommandPaletteDialog` is mounted only while open. This keeps all hooks unconditional and avoids React Compiler strict-mode violations (no `setState` inside effects, no ref reads during render).
- `useEffect` cleanups + `AbortController` around the `/api/settings` fetch so unmount cancels in-flight requests cleanly.
- `useMemo` for both `allItems` (derived from `SIDEBAR_SECTIONS` + `hiddenItems`) and the filtered list.
- Material Symbols icons reused from the existing sidebar item definitions for visual parity with the sidebar.
- `DashboardLayout` gains one `useState` (`commandPaletteOpen`), one `useEffect` for the global `keydown` listener, and mounts `<CommandPalette>` once.

## Files

- **NEW** `src/shared/components/CommandPalette.tsx` (240 lines)
- **MOD** `src/shared/components/layouts/DashboardLayout.tsx` (+15 lines — keyboard listener, state, mount)

## Checks

- `npx eslint` on both files → 0 errors / 0 warnings (React Compiler strict)
- `npx tsc --noEmit` → 0 type errors in touched files

## Out of scope (left for later if useful)

- Section grouping inside the palette (currently flat list, ordered by sidebar section + item order — already feels natural)
- Fuzzy ranking (current substring match is fast and predictable; can be revisited if needed)
- A visible `Cmd+K` discoverability badge in the header
- Sharing the `/api/settings` fetch with `Sidebar` (would need a small shared hook/context — separate refactor)

## Screenshots / video

(none — happy to add a recording on request)