### PR TITLE
fix(combo): resolve pending request leak on unresponsive combo targets via per-target timeout

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -1347,6 +1347,7 @@ export async function handleChatCore({
   disableEmergencyFallback = false,
   cachedSettings = null,
   skipUpstreamRetry = false,
+  timeoutSignal,
 }) {
   let { provider, model, extendedContext } = modelInfo;
   // apiFormat is an optional custom-model marker injected by getModelInfo for
@@ -3242,6 +3243,17 @@ export async function handleChatCore({
     connectionId,
     clientResponseFormat,
   });
+
+  // Per-target timeout: clean up pending request when timeout fires
+  if (timeoutSignal) {
+    timeoutSignal.addEventListener(
+      "abort",
+      () => {
+        streamController.handleDisconnect("timeout");
+      },
+      { once: true }
+    );
+  }
 
   const dedupRequestBody = { ...translatedBody, model: `${provider}/${model}`, stream };
   const dedupEnabled = shouldDeduplicate(dedupRequestBody);

--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -2134,10 +2134,20 @@ export async function handleComboChat({
             );
           }
         }
+        // Per-target timeout: prevent pending request leak when a model hangs
+        const PER_TARGET_TIMEOUT_MS = 60_000;
+        const timeoutController = new AbortController();
+        const timer = setTimeout(() => {
+          timeoutController.abort();
+          const modelShort = modelStr?.split("/").pop() || modelStr;
+          log.warn("COMBO", `[${modelShort}] Per-target timeout reached (${PER_TARGET_TIMEOUT_MS}ms)`);
+        }, PER_TARGET_TIMEOUT_MS);
         const result = await handleSingleModelWrapped(body, modelStr, {
           ...target,
           failoverBeforeRetry: config.failoverBeforeRetry,
+          timeoutSignal: timeoutController.signal,
         });
+        clearTimeout(timer);
 
         // Success — validate response quality before returning
         if (result.ok) {

--- a/src/sse/handlers/chat.ts
+++ b/src/sse/handlers/chat.ts
@@ -472,6 +472,7 @@ export async function handleChat(request: any, clientRawRequest: any = null) {
           stepId?: string | null;
           allowedConnectionIds?: string[] | null;
           failoverBeforeRetry?: boolean;
+          timeoutSignal?: AbortSignal;
         }
       ) =>
         handleSingleModelChat(
@@ -495,6 +496,7 @@ export async function handleChat(request: any, clientRawRequest: any = null) {
               getComboCredentialCacheKey(m, target)
             ),
             cachedSettings: settings,
+            timeoutSignal: target?.timeoutSignal,
           },
           combo.strategy,
           true
@@ -624,6 +626,7 @@ async function handleSingleModelChat(
     skipUpstreamRetry?: boolean;
     preselectedCredentials?: any;
     cachedSettings?: any;
+    timeoutSignal?: AbortSignal;
   } = {},
   comboStrategy: string | null = null,
   isCombo: boolean = false
@@ -655,6 +658,7 @@ async function handleSingleModelChat(
           executionKey?: string | null;
           stepId?: string | null;
           failoverBeforeRetry?: boolean;
+          timeoutSignal?: AbortSignal;
         }
       ) =>
         handleSingleModelChat(
@@ -673,6 +677,7 @@ async function handleSingleModelChat(
             comboStepId: null,
             comboExecutionKey: null,
             skipUpstreamRetry: target?.failoverBeforeRetry ?? false,
+            timeoutSignal: target?.timeoutSignal,
           },
           redirectCombo.strategy ?? "priority",
           false
@@ -930,6 +935,7 @@ async function handleSingleModelChat(
         providerProfile,
         cachedSettings: runtimeOptions.cachedSettings,
         skipUpstreamRetry: runtimeOptions.skipUpstreamRetry ?? false,
+        timeoutSignal: runtimeOptions.timeoutSignal,
       });
       if (telemetry) telemetry.endPhase();
 

--- a/src/sse/handlers/chatHelpers.ts
+++ b/src/sse/handlers/chatHelpers.ts
@@ -315,6 +315,7 @@ export async function executeChatWithBreaker({
   providerProfile,
   cachedSettings,
   skipUpstreamRetry = false,
+  timeoutSignal,
 }: any): Promise<{ result: any; tlsFingerprintUsed: boolean }> {
   let tlsFingerprintUsed = false;
 
@@ -337,6 +338,7 @@ export async function executeChatWithBreaker({
           comboExecutionKey,
           cachedSettings,
           skipUpstreamRetry,
+          timeoutSignal,
           onCredentialsRefreshed: async (newCreds: any) => {
             await updateProviderCredentials(credentials.connectionId, {
               accessToken: newCreds.accessToken,


### PR DESCRIPTION
#### **Context**
The Combo routing engine (`open-sse/services/combo.ts`) iterates through model targets (e.g., in failover or round-robin strategies) and calls `handleSingleModelWrapped`. The core request tracking (`trackPendingRequest`) increments a counter at the start of a request inside `chatCore.ts` and relies on stream disconnects or completion to decrement it.

#### **Problem Statement**
When a downstream provider hangs indefinitely (does not return headers or body but keeps the TCP connection alive), the request remains stuck in the combo loop. Because the upstream client hasn't disconnected and the provider isn't responding, the `abort` event is never fired.
As a result:
1. The `trackPendingRequest` counter remains artificially elevated for that connection/model.
2. Over time, these zombie requests accumulate.
3. This eventually triggers the rate-limit/concurrency lock, blocking ALL legitimate traffic to that model/provider until the server restarts.

#### **Proposed Solution**
Introduced a rigid **60-second per-target timeout** specifically to bridge the gap between the combo routing loop and the internal core request lifecycle.

**Signal Chain Implementation:**
1. **`combo.ts`**: Wrapped the target execution in an `AbortController` with a 60,000ms `setTimeout`. If the timer fires, `timeoutController.abort()` is called. The `AbortSignal` is passed into the target arguments.
2. **`chat.ts` & `chatHelpers.ts`**: Propagated the `timeoutSignal` safely through the `runtimeOptions` and `executeChatWithBreaker` middleware down to the core execution layer.
3. **`chatCore.ts`**: Bound an event listener to the `timeoutSignal`. If triggered, it calls `streamController.handleDisconnect("timeout")`, which explicitly executes `clearPendingRequest()`, decrementing the zombie counter and freeing the capacity lock.

#### **Testing & Verification**
- **Static Analysis:** Verified `timeoutSignal` types are properly propagated across all callbacks and function signatures (`npx tsc` clean).
- **Unit Tests:** Ran the full combo test suite (`tests/unit/combo-routing-engine.test.ts`). 
  - ✅ **58/58 tests passed** 
  - The addition of the abort cycle does not interfere with existing failover or round-robin logic.