### PR TITLE
fix: add xhigh+max to effortLevel schema; publish @omniroute/opencode-plugin

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -131,3 +131,42 @@ jobs:
           echo "✅ Action finished for GitHub Packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-opencode-plugin:
+    runs-on: ubuntu-latest
+    environment: NPM_TOKEN
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NPM_PUBLISH_NODE_VERSION }}
+          registry-url: https://registry.npmjs.org
+
+      - name: Install plugin dependencies
+        working-directory: "@omniroute/opencode-plugin"
+        run: npm install --no-audit --no-fund
+
+      - name: Build plugin
+        working-directory: "@omniroute/opencode-plugin"
+        run: npm run clean && npm run build
+
+      - name: Test plugin
+        working-directory: "@omniroute/opencode-plugin"
+        run: npm test
+
+      - name: Publish @omniroute/opencode-plugin to npm
+        working-directory: "@omniroute/opencode-plugin"
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          PKG_NAME=$(node -p "require('./package.json').name")
+          if npm view "${PKG_NAME}@${PKG_VERSION}" version --silent 2>/dev/null | grep -q "^${PKG_VERSION}$"; then
+            echo "⚠️ ${PKG_NAME}@${PKG_VERSION} is already published on npm — skipping."
+            exit 0
+          fi
+          npm publish --access public --ignore-scripts
+          echo "✅ Published ${PKG_NAME}@${PKG_VERSION}"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/src/shared/validation/schemas.ts
+++ b/src/shared/validation/schemas.ts
@@ -1134,7 +1134,7 @@ export const updateThinkingBudgetSchema = z
   .object({
     mode: z.enum(["passthrough", "auto", "custom", "adaptive"]).optional(),
     customBudget: z.coerce.number().int().min(0).max(131072).optional(),
-    effortLevel: z.enum(["none", "low", "medium", "high"]).optional(),
+    effortLevel: z.enum(["none", "low", "medium", "high", "xhigh", "max"]).optional(),
     baseBudget: z.coerce.number().int().min(0).max(131072).optional(),
     complexityMultiplier: z.coerce.number().min(0).optional(),
   })


### PR DESCRIPTION
## Changes

### Fix A — `effortLevel` schema missing `xhigh` / `max` (`src/shared/validation/schemas.ts:1137`)

`effortLevel` enum was `["none", "low", "medium", "high"]`. Callers passing `xhigh` or `max` had the value rejected at the Zod validation layer — silently dropped before reaching executors.

- Added `"xhigh"` and `"max"` to the enum
- `"max"` already normalizes → `"xhigh"` in both translators (`open-sse/translator/request/openai-responses.ts:30`, `open-sse/translator/request/claude-to-openai.ts:26`)
- `reasoningEffort` (line 1938) already had `xhigh` — this closes the gap in `effortLevel`
- Downgrade guard at `executors/base.ts:231` still drops `xhigh→high` for models without `supportsXHighEffort: true`

**How xhigh/max flow per provider:**
| Provider | Field | Top-effort value |
|---|---|---|
| cc (Claude Code) | `supportsXHighEffort` flag | `xhigh` — opus-4-7 only (`providerRegistry.ts:639`) |
| Copilot | model-id suffix | `claude-opus-4-7-xhigh` (`providerRegistry.ts:1112`) |
| Cursor | tier display map | `xhigh`→"XHigh", `max`→"Max" (`cursorAgent.ts:82`) |
| OpenAI/Codex | `reasoning_effort` | `xhigh` (`requestDefaults.ts:7`) |
| Windsurf | model-id suffix | `gpt-5.5-xhigh` etc |
| Gemini | `budget_tokens` mapping | `xhigh` → 131072 tokens (`claude-to-gemini.ts:196`) |

### Fix B — `@omniroute/opencode-plugin` never published (`.github/workflows/npm-publish.yml`)

`npm-publish.yml` had a single `publish` job that only published the root `omniroute` package. `@omniroute/opencode-plugin` has been at `0.1.0` locally with no published version on npm. Added a parallel `publish-opencode-plugin` job:
- Installs deps in `@omniroute/opencode-plugin/`
- Runs `clean → build → test`
- Publishes with skip-if-already-published guard (same pattern as main job)

Based on `release/v3.8.3` so it gets included in the v3.8.3 release cut.