### PR TITLE
fix(reasoning): inject thinking blocks into Claude-format messages for Kimi K2 to prevent infinite loop

### DIFF
--- a/open-sse/translator/index.ts
+++ b/open-sse/translator/index.ts
@@ -312,9 +312,8 @@ export function translateRequest(
         if (hasThinkingBlock) continue;
 
         const toolUseBlocks = msg.content.filter((b) => b?.type === "tool_use");
-        const firstToolUseId = toolUseBlocks[0]?.id || toolUseBlocks[0]?.tool_use_id;
+        const firstToolUseId = toolUseBlocks[0]?.id;
         const firstToolUseIdx = msg.content.findIndex((b) => b?.type === "tool_use");
-        if (firstToolUseIdx < 0) continue;
 
         // Try reasoning cache first
         if (firstToolUseId) {

--- a/open-sse/translator/index.ts
+++ b/open-sse/translator/index.ts
@@ -1,6 +1,6 @@
 import { FORMATS } from "./formats.ts";
 import { ensureToolCallIds, fixMissingToolResponses } from "./helpers/toolCallHelper.ts";
-import { prepareClaudeRequest } from "./helpers/claudeHelper.ts";
+import { NON_ANTHROPIC_THINKING_PLACEHOLDER, prepareClaudeRequest } from "./helpers/claudeHelper.ts";
 import { filterToOpenAIFormat } from "./helpers/openaiHelper.ts";
 import {
   coerceToolSchemas,
@@ -290,12 +290,53 @@ export function translateRequest(
     for (const [messageIndex, msg] of result.messages.entries()) {
       if (msg.role !== "assistant") continue;
 
+      // Detect tool calls in either format
       const hasToolCalls = Array.isArray(msg.tool_calls) && msg.tool_calls.length > 0;
+      // Claude format: tool_use lives in content[] blocks, not msg.tool_calls
+      const hasToolUseBlocks = !hasToolCalls && Array.isArray(msg.content) &&
+        msg.content.some((b) => b?.type === "tool_use");
+
       const shouldReplayReasoningOnly =
-        !hasToolCalls && canReplayReasoningOnly && hasReasoningContentField(msg);
+        !hasToolCalls && !hasToolUseBlocks && canReplayReasoningOnly && hasReasoningContentField(msg);
 
-      if (!hasToolCalls && !shouldReplayReasoningOnly) continue;
+      if (!hasToolCalls && !hasToolUseBlocks && !shouldReplayReasoningOnly) continue;
 
+      if (hasToolUseBlocks) {
+        // ── Claude-format message ──
+        // Has tool_use blocks but no thinking block yet.
+        // Reasoning models (Kimi K2, etc.) require a thinking block before tool_use
+        // on multi-turn or they regenerate the same tool call infinitely.
+        const hasThinkingBlock = msg.content.some(
+          (b) => b?.type === "thinking" || b?.type === "redacted_thinking"
+        );
+        if (hasThinkingBlock) continue;
+
+        const toolUseBlocks = msg.content.filter((b) => b?.type === "tool_use");
+        const firstToolUseId = toolUseBlocks[0]?.id || toolUseBlocks[0]?.tool_use_id;
+        const firstToolUseIdx = msg.content.findIndex((b) => b?.type === "tool_use");
+        if (firstToolUseIdx < 0) continue;
+
+        // Try reasoning cache first
+        if (firstToolUseId) {
+          const cached = lookupReasoning(firstToolUseId);
+          if (cached) {
+            msg.content.splice(firstToolUseIdx, 0, {
+              type: "thinking",
+              thinking: cached,
+            });
+            recordReplay();
+            continue;
+          }
+        }
+        // Fallback: inject placeholder (must be non-empty for kimi-coding)
+        msg.content.splice(firstToolUseIdx, 0, {
+          type: "thinking",
+          thinking: NON_ANTHROPIC_THINKING_PLACEHOLDER,
+        });
+        continue;
+      }
+
+      // ── OpenAI-format message ──
       // Skip if client already provided real reasoning_content
       if (hasNonEmptyReasoningContent(msg)) {
         continue;

--- a/tests/unit/translator-helper-branches.test.ts
+++ b/tests/unit/translator-helper-branches.test.ts
@@ -547,4 +547,125 @@ test("translateRequest does not replay reasoning-only messages for non-DeepSeek 
   assert.equal(result.messages[1].reasoning_content, "");
   assert.equal(getReasoningCacheServiceStats().replays, 0);
   clearReasoningCacheAll();
+
+test("translateRequest injects thinking block into Claude-format messages for Kimi K2 reasoning models", () => {
+  clearReasoningCacheAll();
+  cacheReasoningByKey(
+    "toolu_kimi_claude",
+    "kimi-coding",
+    "kimi-k2.5",
+    "cached thinking for Kimi tool call"
+  );
+
+  // Claude-format request: assistant has tool_use in content[] but NO thinking block
+  // This simulates the scenario that causes infinite loops
+  const result = translateRequest(
+    FORMATS.OPENAI,
+    FORMATS.CLAUDE,
+    "kimi-k2.5",
+    {
+      thinking: { type: "enabled", budget_tokens: 2000 },
+      messages: [
+        { role: "user", content: "read the file" },
+        {
+          role: "assistant",
+          content: [
+            { type: "tool_use", id: "toolu_kimi_claude", name: "read_file", input: { path: "test.ts" } }
+          ]
+        },
+        { role: "tool", tool_call_id: "toolu_kimi_claude", content: "file data" }
+      ]
+    },
+    false,
+    null,
+    "kimi-coding"
+  );
+
+  const assistantMsg = result.messages.find((m) => m.role === "assistant");
+  assert.ok(assistantMsg, "assistant message should exist");
+  assert.ok(Array.isArray(assistantMsg.content), "content should be array");
+
+  // Should have a thinking block injected before tool_use
+  const thinkingBlock = assistantMsg.content.find((b) => b?.type === "thinking");
+  assert.ok(thinkingBlock, "thinking block should be injected");
+  assert.equal(thinkingBlock.thinking, "cached thinking for Kimi tool call", "should use cached reasoning");
+
+  // Thinking block should appear before tool_use
+  const thinkingIdx = assistantMsg.content.indexOf(thinkingBlock);
+  const toolUseIdx = assistantMsg.content.findIndex((b) => b?.type === "tool_use");
+  assert.ok(thinkingIdx < toolUseIdx, "thinking block should be before tool_use");
+
+  assert.equal(getReasoningCacheServiceStats().replays, 1);
+  clearReasoningCacheAll();
+});
+
+test("translateRequest injects placeholder thinking block for Claude-format Kimi K2 on cache miss", () => {
+  clearReasoningCacheAll();
+
+  // No cache seeded - should fall back to placeholder
+  const result = translateRequest(
+    FORMATS.OPENAI,
+    FORMATS.CLAUDE,
+    "kimi-k2.6",
+    {
+      thinking: { type: "enabled", budget_tokens: 2000 },
+      messages: [
+        { role: "user", content: "do it" },
+        {
+          role: "assistant",
+          content: [
+            { type: "tool_use", id: "toolu_miss", name: "bash", input: { command: "ls" } }
+          ]
+        },
+        { role: "tool", tool_call_id: "toolu_miss", content: "output" }
+      ]
+    },
+    false,
+    null,
+    "kimi-coding"
+  );
+
+  const assistantMsg = result.messages.find((m) => m.role === "assistant");
+  assert.ok(assistantMsg, "assistant message should exist");
+
+  const thinkingBlock = Array.isArray(assistantMsg.content) && assistantMsg.content.find((b) => b?.type === "thinking");
+  assert.ok(thinkingBlock, "thinking block should be injected on cache miss");
+  // Must be non-empty for kimi-coding
+  assert.ok(thinkingBlock.thinking && thinkingBlock.thinking.length > 0, "placeholder must be non-empty");
+
+  clearReasoningCacheAll();
+});
+
+test("translateRequest does NOT inject duplicate thinking for Claude-format messages with existing thinking block", () => {
+  clearReasoningCacheAll();
+
+  const result = translateRequest(
+    FORMATS.OPENAI,
+    FORMATS.CLAUDE,
+    "kimi-k2.5",
+    {
+      messages: [
+        { role: "user", content: "hi" },
+        {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "I already have this" },
+            { type: "tool_use", id: "toolu_existing", name: "read", input: {} }
+          ]
+        },
+        { role: "tool", tool_call_id: "toolu_existing", content: "data" }
+      ]
+    },
+    false,
+    null,
+    "kimi-coding"
+  );
+
+  const assistantMsg = result.messages.find((m) => m.role === "assistant");
+  const thinkingBlocks = Array.isArray(assistantMsg.content) && assistantMsg.content.filter((b) => b?.type === "thinking");
+  assert.equal(thinkingBlocks?.length, 1, "should have exactly one thinking block (no duplicate)");
+  assert.equal(thinkingBlocks[0].thinking, "I already have this", "original thinking should be preserved");
+
+  clearReasoningCacheAll();
+});
 });


### PR DESCRIPTION
## Description

Fixes infinite loop for Kimi K2 models (and other reasoning models) when used through Claude-format providers like `kimi-coding` with tool calls and thinking enabled.

The previous fix (PR #2639) addressed the OpenAI-format path where `injectEmptyReasoningContentForToolCalls` injects `reasoning_content: ""` for assistant messages with `tool_calls`. However, this only runs when `targetFormat === FORMATS.OPENAI`. For Claude-format providers (Kimi uses `format: "claude"`), the reasoning replay section runs after messages have been translated to Claude format, where `msg.tool_calls` does not exist (tool_use lives in `msg.content[]` blocks). The `hasToolCalls` check fails, and the message is skipped entirely - no thinking block or reasoning_content is injected. Kimi receives the assistant message without a thinking block and regenerates the same tool call indefinitely.

## Root Cause

1. `injectEmptyReasoningContentForToolCalls` at line 262 is gated by `targetFormat === FORMATS.OPENAI` — skipped for Claude-format providers
2. The reasoning replay section at line 287 checks `Array.isArray(msg.tool_calls)` which is `undefined` in Claude format — all messages are skipped
3. `prepareClaudeRequest` only processes EXISTING thinking blocks (fills in text from cache) but does not CREATE new ones for non-Anthropic providers
4. The `openai-to-claude` translator converts `reasoning_content` to `thinking` block, but only if `reasoning_content` exists on the message — if the client omitted it (common scenario), no thinking block is generated

## Fix

Extended the reasoning replay section in `translateRequest` to detect Claude-format messages with `tool_use` in `content[]` blocks. When such messages have no thinking block:
1. Try to inject cached reasoning from `lookupReasoning(tool_use_id)`
2. Fall back to `NON_ANTHROPIC_THINKING_PLACEHOLDER` (non-empty to satisfy `kimi-coding` requirement)
3. Skip if a thinking/redacted_thinking block already exists

## Testing

- All existing translator tests pass (no regressions)
- Three new tests covering:
  - Claude-format thinking block injection from reasoning cache (Kimi K2)
  - Placeholder injection on cache miss (Kimi K2.6)
  - No duplicate injection when thinking block already exists