### PR TITLE
fix: add python3, make, g++ to builder stage for native addon compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:26.1.0-trixie-slim AS builder
 WORKDIR /app
 
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends libsecret-1-0 ca-certificates \
+  && apt-get install -y --no-install-recommends libsecret-1-0 ca-certificates python3 make g++ \
   && rm -rf /var/lib/apt/lists/*
 
 COPY package*.json ./
@@ -82,3 +82,4 @@ RUN apt-get update \
 
 # Install CLI tools globally. Separate layer from apt for better cache reuse.
 RUN npm install -g --no-audit --no-fund @openai/codex @anthropic-ai/claude-code droid openclaw@latest
+


### PR DESCRIPTION
## Problem

Closes #2711

The Docker image for v3.8.3 was never published because the builder stage (`node:26.2.0-trixie-slim`) does not include Python, `make`, or `g++`. The `npm ci` step fails with:

```
npm error gyp ERR! stack Error: Could not find any Python installation to use
```

This causes the `Publish to Docker Hub` workflow to fail at the buildx step on every release that includes native addons.

## Fix

Add `python3 make g++` to the **builder stage only** `apt-get install` line:

```diff
- && apt-get install -y --no-install-recommends libsecret-1-0 ca-certificates \
+ && apt-get install -y --no-install-recommends libsecret-1-0 ca-certificates python3 make g++ \
```

These build-time tools are **not** propagated to the `runner-base` stage, so the final production image size is unaffected.

## Action required after merge

The v3.8.3 Docker image still needs to be published. Please re-run the `Publish to Docker Hub` workflow with `workflow_dispatch` targeting the `v3.8.3` tag once this fix is on main.

## Related

The `npm-publish.yml` workflow is also independent from `docker-publish.yml` (noted in #2711). Wiring them together (e.g. via `workflow_run` trigger) would prevent this kind of silent split in the future — tracked separately.