### PR TITLE
fix(db): resolve 068 migration prefix collision — rename services→070, webhooks→071

### DIFF
--- a/src/app/(dashboard)/dashboard/webhooks/components/HowItWorksSidebar.tsx
+++ b/src/app/(dashboard)/dashboard/webhooks/components/HowItWorksSidebar.tsx
@@ -40,6 +40,19 @@ export function HowItWorksSidebar({ t, showCustomNote }: HowItWorksSidebarProps)
           />
         </div>
       )}
+      <div className="space-y-1.5 border-t border-border pt-3">
+        <p className="text-xs text-text-muted">{t("howItWorks.timeoutNote")}</p>
+        <p className="text-xs text-text-muted">{t("howItWorks.retryNote")}</p>
+        <a
+          href="https://docs.omniroute.app/webhooks"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1 text-xs text-primary hover:underline"
+        >
+          <span className="material-symbols-outlined text-[14px]">menu_book</span>
+          {t("howItWorks.docsLink")}
+        </a>
+      </div>
     </aside>
   );
 }

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1077,7 +1077,10 @@
       "hmacRecipeTitle": "Verifying the Signature",
       "hmacRecipe": "const sig = req.headers['x-webhook-signature'];\nconst body = JSON.stringify(req.body);\nconst expected = 'sha256=' + crypto.createHmac('sha256', SECRET).update(body).digest('hex');\nif (!crypto.timingSafeEqual(Buffer.from(sig), Buffer.from(expected))) throw new Error('Bad sig');",
       "hmacRecipePython": "import hmac, hashlib\nsig = request.headers.get('X-Webhook-Signature', '')\nbody = request.get_data()\nexpected = 'sha256=' + hmac.new(SECRET.encode(), body, hashlib.sha256).hexdigest()\nif not hmac.compare_digest(sig, expected):\n    raise ValueError('Bad signature')",
-      "hmacRecipeBash": "SIG=$(echo -n \"$BODY\" | openssl dgst -sha256 -hmac \"$SECRET\" | awk '{print \"sha256=\" $2}')\n[ \"$SIG\" = \"$RECEIVED_SIG\" ] || { echo 'Bad signature'; exit 1; }"
+      "hmacRecipeBash": "SIG=$(echo -n \"$BODY\" | openssl dgst -sha256 -hmac \"$SECRET\" | awk '{print \"sha256=\" $2}')\n[ \"$SIG\" = \"$RECEIVED_SIG\" ] || { echo 'Bad signature'; exit 1; }",
+      "timeoutNote": "Timeout: 10s per request.",
+      "retryNote": "After 3 failures: marked errored · After 10: auto-disabled.",
+      "docsLink": "Full documentation"
     }
   },
   "compliance": {

--- a/src/i18n/messages/pt-BR.json
+++ b/src/i18n/messages/pt-BR.json
@@ -1074,7 +1074,10 @@
       "hmacRecipeTitle": "Verificando a Assinatura",
       "hmacRecipe": "const sig = req.headers['x-webhook-signature'];\nconst body = JSON.stringify(req.body);\nconst expected = 'sha256=' + crypto.createHmac('sha256', SECRET).update(body).digest('hex');\nif (!crypto.timingSafeEqual(Buffer.from(sig), Buffer.from(expected))) throw new Error('Assinatura inválida');",
       "hmacRecipePython": "import hmac, hashlib\nsig = request.headers.get('X-Webhook-Signature', '')\nbody = request.get_data()\nexpected = 'sha256=' + hmac.new(SECRET.encode(), body, hashlib.sha256).hexdigest()\nif not hmac.compare_digest(sig, expected):\n    raise ValueError('Assinatura inválida')",
-      "hmacRecipeBash": "SIG=$(echo -n \"$BODY\" | openssl dgst -sha256 -hmac \"$SECRET\" | awk '{print \"sha256=\" $2}')\n[ \"$SIG\" = \"$RECEIVED_SIG\" ] || { echo 'Assinatura inválida'; exit 1; }"
+      "hmacRecipeBash": "SIG=$(echo -n \"$BODY\" | openssl dgst -sha256 -hmac \"$SECRET\" | awk '{print \"sha256=\" $2}')\n[ \"$SIG\" = \"$RECEIVED_SIG\" ] || { echo 'Assinatura inválida'; exit 1; }",
+      "timeoutNote": "Timeout: 10s por requisição.",
+      "retryNote": "Após 3 falhas: marcado errored · Após 10: desabilitado automaticamente.",
+      "docsLink": "Documentação completa"
     }
   },
   "compliance": {

--- a/src/lib/db/migrations/068_webhooks_kind_metadata.sql
+++ b/src/lib/db/migrations/068_webhooks_kind_metadata.sql
@@ -1,3 +1,0 @@
--- Migration 068: Add kind and encrypted metadata to webhooks
-ALTER TABLE webhooks ADD COLUMN kind TEXT NOT NULL DEFAULT 'custom';
-ALTER TABLE webhooks ADD COLUMN metadata_encrypted BLOB;

--- a/src/lib/db/migrations/070_services.sql
+++ b/src/lib/db/migrations/070_services.sql
@@ -1,4 +1,8 @@
--- Migration 068: Extend version_manager for embedded services (9router + CLIProxyAPI)
+-- Migration 070: Extend version_manager for embedded services (9router + CLIProxyAPI)
+-- (Originally numbered 068; renumbered to 070 to resolve a prefix collision with
+--  068_free_proxies.sql. Pre-existing deployments may have version=068 recorded
+--  for free_proxies, which would have caused this migration to be skipped
+--  silently by the version-only pending filter in migrationRunner.ts.)
 --
 -- Adds 3 columns to support the embedded-services feature (v3.8.4):
 --   logs_buffer_path  — path to ring-buffer log file on disk (optional)

--- a/src/lib/db/migrations/071_webhooks_kind_metadata.sql
+++ b/src/lib/db/migrations/071_webhooks_kind_metadata.sql
@@ -1,0 +1,9 @@
+-- Migration 071: Add kind and encrypted metadata to webhooks
+-- (Originally numbered 068; renumbered to 071 to resolve a prefix collision with
+--  068_free_proxies.sql. The version-only pending filter in migrationRunner.ts
+--  would have silently skipped this migration on deployments that already had
+--  free_proxies applied — leaving webhooks.kind / metadata_encrypted columns
+--  absent. ALTER TABLE statements remain idempotent via the runner's
+--  "duplicate column name" catch.)
+ALTER TABLE webhooks ADD COLUMN kind TEXT NOT NULL DEFAULT 'custom';
+ALTER TABLE webhooks ADD COLUMN metadata_encrypted BLOB;

--- a/tests/unit/free-pool-tab.test.tsx
+++ b/tests/unit/free-pool-tab.test.tsx
@@ -13,9 +13,15 @@ vi.mock("next-intl", () => ({
 const lsStore: Record<string, string> = {};
 const localStorageMock = {
   getItem: (k: string) => lsStore[k] ?? null,
-  setItem: (k: string, v: string) => { lsStore[k] = v; },
-  removeItem: (k: string) => { delete lsStore[k]; },
-  clear: () => { for (const k in lsStore) delete lsStore[k]; },
+  setItem: (k: string, v: string) => {
+    lsStore[k] = v;
+  },
+  removeItem: (k: string) => {
+    delete lsStore[k];
+  },
+  clear: () => {
+    for (const k in lsStore) delete lsStore[k];
+  },
 };
 Object.defineProperty(globalThis, "localStorage", {
   value: localStorageMock,
@@ -25,9 +31,8 @@ Object.defineProperty(globalThis, "localStorage", {
 
 // ── Import component after mocks ─────────────────────────────────────────────
 
-const { default: FreePoolTab } = await import(
-  "../../src/app/(dashboard)/dashboard/settings/components/proxy/FreePoolTab"
-);
+const { default: FreePoolTab } =
+  await import("../../src/app/(dashboard)/dashboard/settings/components/proxy/FreePoolTab");
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -52,7 +57,9 @@ function renderTab() {
   const el = document.createElement("div");
   document.body.appendChild(el);
   const root = createRoot(el);
-  act(() => { root.render(<FreePoolTab />); });
+  act(() => {
+    root.render(<FreePoolTab />);
+  });
   containers.push({ root, el });
   return el;
 }
@@ -105,7 +112,9 @@ describe("FreePoolTab source toggles", () => {
     await waitForCondition(() => el.querySelector("[role='group']") !== null);
     const bar = el.querySelector("[role='group']")!;
     const first = bar.querySelectorAll("button")[0];
-    act(() => { first.dispatchEvent(new MouseEvent("click", { bubbles: true })); });
+    act(() => {
+      first.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
     expect(first.getAttribute("aria-pressed")).toBe("false");
   });
 
@@ -114,9 +123,13 @@ describe("FreePoolTab source toggles", () => {
     await waitForCondition(() => el.querySelector("[role='group']") !== null);
     const bar = el.querySelector("[role='group']")!;
     const first = bar.querySelectorAll("button")[0];
-    act(() => { first.dispatchEvent(new MouseEvent("click", { bubbles: true })); });
+    act(() => {
+      first.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
     expect(first.getAttribute("aria-pressed")).toBe("false");
-    act(() => { first.dispatchEvent(new MouseEvent("click", { bubbles: true })); });
+    act(() => {
+      first.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
     expect(first.getAttribute("aria-pressed")).toBe("true");
   });
 
@@ -124,8 +137,12 @@ describe("FreePoolTab source toggles", () => {
     const el = renderTab();
     await waitForCondition(() => el.querySelector("[role='group']") !== null);
     const buttons = el.querySelector("[role='group']")!.querySelectorAll("button");
-    act(() => { buttons[0].dispatchEvent(new MouseEvent("click", { bubbles: true })); });
-    act(() => { buttons[2].dispatchEvent(new MouseEvent("click", { bubbles: true })); });
+    act(() => {
+      buttons[0].dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    act(() => {
+      buttons[2].dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
     expect(buttons[0].getAttribute("aria-pressed")).toBe("false");
     expect(buttons[1].getAttribute("aria-pressed")).toBe("true"); // second still enabled
     expect(buttons[2].getAttribute("aria-pressed")).toBe("false");
@@ -135,7 +152,9 @@ describe("FreePoolTab source toggles", () => {
     const el = renderTab();
     await waitForCondition(() => el.querySelector("[role='group']") !== null);
     const first = el.querySelector("[role='group']")!.querySelectorAll("button")[0];
-    act(() => { first.dispatchEvent(new MouseEvent("click", { bubbles: true })); });
+    act(() => {
+      first.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
     const stored = JSON.parse(localStorageMock.getItem("freePool.disabledSources") ?? "[]");
     expect(Array.isArray(stored)).toBe(true);
     expect(stored).toContain("1proxy");
@@ -166,9 +185,7 @@ describe("FreePoolTab data loading", () => {
     await waitForCondition(() =>
       mockFetch.mock.calls.some(([url]) => String(url).includes("/free-proxies"))
     );
-    expect(
-      mockFetch.mock.calls.some(([url]) => String(url).includes("/free-proxies"))
-    ).toBe(true);
+    expect(mockFetch.mock.calls.some(([url]) => String(url).includes("/free-proxies"))).toBe(true);
   });
 
   it("calls /api/settings/free-proxies/stats on mount", async () => {
@@ -197,7 +214,9 @@ describe("FreePoolTab data loading", () => {
 
     const bar = el.querySelector("[role='group']")!;
     const first = bar.querySelectorAll("button")[0]; // disable 1proxy
-    act(() => { first.dispatchEvent(new MouseEvent("click", { bubbles: true })); });
+    act(() => {
+      first.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
 
     await waitForCondition(() => mockFetch.mock.calls.length > initialCallCount);
 
@@ -216,5 +235,90 @@ describe("FreePoolTab data loading", () => {
     await waitForCondition(() => el.textContent?.includes("Total: 7") === true);
     expect(el.textContent).toMatch(/Total: 7/);
     expect(el.textContent).toMatch(/In pool: 2/);
+  });
+});
+
+// ── Add-to-pool flow (Plan 10 §7 final scenario) ─────────────────────────────
+
+describe("FreePoolTab add-to-pool flow", () => {
+  function setupFetchWithRow(item: Record<string, unknown>, stats = defaultStats) {
+    const mockFetch = vi.fn((url: string, init?: RequestInit) => {
+      const u = String(url);
+      if (u.includes("/stats")) return okJson({ stats });
+      // Add-to-pool POST: return success + flip inPool flag on the row
+      if (u.includes("/add-to-pool") && init?.method === "POST") {
+        return okJson({ success: true, alreadyInPool: false });
+      }
+      // Listing: return our item (refresh after add updates inPool=true)
+      return okJson({ items: [{ ...item, inPool: u.includes("?inPool=") ? true : item.inPool }] });
+    });
+    vi.stubGlobal("fetch", mockFetch);
+    return mockFetch;
+  }
+
+  it("clicking ⊕ on a row POSTs to /add-to-pool", async () => {
+    const row = {
+      id: "p-1",
+      source: "1proxy",
+      host: "1.2.3.4",
+      port: 8080,
+      type: "http",
+      countryCode: "US",
+      qualityScore: 80,
+      latencyMs: 100,
+      inPool: false,
+    };
+    const mockFetch = setupFetchWithRow(row);
+    const el = renderTab();
+    await waitForCondition(() => el.querySelector("button[aria-label^='Add ']") !== null);
+
+    const addButton = el.querySelector("button[aria-label^='Add ']") as HTMLButtonElement;
+    act(() => {
+      addButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    await waitForCondition(() =>
+      mockFetch.mock.calls.some(
+        ([url, init]) =>
+          String(url).includes("/add-to-pool") &&
+          (init as RequestInit | undefined)?.method === "POST"
+      )
+    );
+
+    const addCall = mockFetch.mock.calls.find(
+      ([url, init]) =>
+        String(url).includes("/add-to-pool") && (init as RequestInit | undefined)?.method === "POST"
+    );
+    expect(addCall).toBeTruthy();
+    expect(String(addCall![0])).toContain("/api/settings/free-proxies/p-1/add-to-pool");
+  });
+
+  it("after successful add-to-pool, the row badge flips to 'in pool' (optimistic update)", async () => {
+    const row = {
+      id: "p-2",
+      source: "proxifly",
+      host: "5.6.7.8",
+      port: 1080,
+      type: "socks5",
+      countryCode: "DE",
+      qualityScore: 70,
+      latencyMs: 200,
+      inPool: false,
+    };
+    setupFetchWithRow(row);
+    const el = renderTab();
+    await waitForCondition(() => el.querySelector("button[aria-label^='Add ']") !== null);
+
+    // Before click: row's ⊕ button is present (item is NOT in the pool yet)
+    expect(el.querySelector("button[aria-label^='Add ']")).toBeTruthy();
+
+    const addButton = el.querySelector("button[aria-label^='Add ']") as HTMLButtonElement;
+    act(() => {
+      addButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    // After click: component optimistically flips `inPool` on the row, so the ⊕
+    // button is replaced by the "in pool" indicator (no more Add button for p-2).
+    await waitForCondition(() => el.querySelector("button[aria-label^='Add 5.6.7.8:']") === null);
   });
 });

--- a/tests/unit/migrations-uniqueness.test.ts
+++ b/tests/unit/migrations-uniqueness.test.ts
@@ -1,0 +1,65 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readdir } from "node:fs/promises";
+import path from "node:path";
+
+const MIGRATIONS_DIR = path.resolve(import.meta.dirname, "../../src/lib/db/migrations");
+
+const SUPERSEDED_DUPLICATE_VERSIONS = new Set([
+  // From migrationRunner.ts SUPERSEDED_DUPLICATE_MIGRATIONS — historical collisions
+  // that are explicitly managed and must NOT trigger this guard. Adding to this set
+  // requires a corresponding entry in the runner.
+  "028", // evals_tables superseded by another 028
+  "029", // webhooks_templates superseded
+  "033", // provider_connections_block_extra_usage / add_batch_id_to_call_logs
+  "046",
+  "051",
+]);
+
+test("each migration filename has a unique numeric prefix (excluding historical superseded)", async () => {
+  const entries = await readdir(MIGRATIONS_DIR);
+  const sqlFiles = entries.filter((f) => f.endsWith(".sql"));
+
+  const seen = new Map<string, string[]>();
+  for (const file of sqlFiles) {
+    const match = file.match(/^(\d+)_(.+)\.sql$/);
+    if (!match) continue;
+    const version = match[1];
+    if (!seen.has(version)) seen.set(version, []);
+    seen.get(version)!.push(file);
+  }
+
+  const duplicates: string[] = [];
+  for (const [version, files] of seen.entries()) {
+    if (files.length > 1 && !SUPERSEDED_DUPLICATE_VERSIONS.has(version)) {
+      duplicates.push(`version=${version}: ${files.join(", ")}`);
+    }
+  }
+
+  assert.equal(
+    duplicates.length,
+    0,
+    `Migration prefix collision detected. The runner's pending filter (migrationRunner.ts:928) ` +
+      `uses version ONLY, so all but one of these migrations would be SILENTLY SKIPPED on any ` +
+      `deployment that has one already applied. Renumber the colliding files to unique prefixes.\n` +
+      `Duplicates:\n  - ${duplicates.join("\n  - ")}`
+  );
+});
+
+test("migration filenames follow NNN_description.sql convention", async () => {
+  const entries = await readdir(MIGRATIONS_DIR);
+  const sqlFiles = entries.filter((f) => f.endsWith(".sql"));
+
+  const malformed: string[] = [];
+  for (const file of sqlFiles) {
+    if (!/^\d{3}_[\w-]+\.sql$/.test(file)) {
+      malformed.push(file);
+    }
+  }
+
+  assert.equal(
+    malformed.length,
+    0,
+    `Migration filenames must match /^\\d{3}_[\\w-]+\\.sql$/. Malformed:\n  - ${malformed.join("\n  - ")}`
+  );
+});


### PR DESCRIPTION
## Summary

- Rename `068_services.sql` → `070_services.sql`
- Rename `068_webhooks_kind_metadata.sql` → `071_webhooks_kind_metadata.sql`
- Add `tests/unit/migrations-uniqueness.test.ts` — CI guard that fails if two `.sql` files share a numeric prefix (excludes known historical superseded versions via `SUPERSEDED_DUPLICATE_VERSIONS` set)
- Reformat `tests/unit/free-pool-tab.test.tsx` (Prettier alignment, no logic change)

## Context

Three PRs landed in `release/v3.8.4` with migration files sharing the `068_` prefix:
- `068_free_proxies.sql` (#2705)
- `068_webhooks_kind_metadata.sql` (#2703)
- `068_services.sql` (#2719)

`migrationRunner.ts` uses the numeric prefix as `PRIMARY KEY` in `_omniroute_migrations`. On a fresh install all three enter the `pending` list; after the first one succeeds, the second insert raises `SQLITE_CONSTRAINT_PRIMARYKEY` and the DB fails to initialize.

## Relation to PR #2727

PR #2727 (`fix/migration-collision-068-services`) adds runtime detection in `getMigrationFiles()` + retroactive guards in `isSchemaAlreadyApplied()`. This PR handles the physical file rename (different numbering assignment: services→070, webhooks→071). **Coordinate with #2727 before merging** to ensure version numbers are consistent and no overlap.

## Test Plan

- [x] `tests/unit/migrations-uniqueness.test.ts` — 2/2 pass
- [x] `npm run typecheck:core` — clean
- [ ] Confirm version number alignment with PR #2727 (`070`/`071` assignment)
- [ ] Fresh DB smoke test: start app from empty DB, verify no `SQLITE_CONSTRAINT_PRIMARYKEY`