### PR TITLE
fix(combos): enable universal handoff by default to preserve cross-model conversation context

### DIFF
--- a/open-sse/services/contextHandoff.ts
+++ b/open-sse/services/contextHandoff.ts
@@ -68,7 +68,7 @@ export interface UniversalHandoffConfig {
 }
 
 export const DEFAULT_UNIVERSAL_HANDOFF_CONFIG: UniversalHandoffConfig = {
-  enabled: false,
+  enabled: true,
   trigger: "on-switch",
   providerAllowlist: [],
   maxMessagesForSummary: 30,


### PR DESCRIPTION
## Problem

Custom combos with multiple model targets switch between models during fallback. Without universal handoff, each switch loses conversation context — the new model has no awareness of previous turns, breaking conversational fluency.

**Universal handoff is not optional** — context preservation across model switches is a core requirement for all combos.

## Fix

Change `DEFAULT_UNIVERSAL_HANDOFF_CONFIG.enabled` from `false` to `true`.

This means ALL combos automatically:
1. Generate a structured handoff summary when switching models (`trigger: "on-switch"`)
2. Inject the summary as context so the new model has full conversation awareness
3. Preserve existing system prompts
4. Users experience seamless multi-model conversations as if it were a single model

No dashboard toggle — always-on by design.

## Changes

`open-sse/services/contextHandoff.ts`: 1 line — `enabled: false` → `enabled: true`

## Verification

- ✅ 11 context handoff tests pass
- ✅ Typecheck clean