### PR TITLE
fix(vision-bridge): force bridge for opencode-go/zen models that overstate vision support

### DIFF
--- a/src/shared/constants/visionBridgeDefaults.ts
+++ b/src/shared/constants/visionBridgeDefaults.ts
@@ -3,14 +3,28 @@
  */
 
 const FORCED_VISION_BRIDGE_MODELS = new Set<string>([
-  // Fallback list for models whose metadata is known to overstate native vision support.
+  // opencode-go/opencode-zen providers: synced capabilities overstate vision support
+  // (modalities_input includes "image" from provider catalog), but the actual backend
+  // models used by these providers do not have native vision. Force Vision Bridge to
+  // convert images to text descriptions for these models.
+  "opencode-go/deepseek-v4-flash",
+  "opencode-go/deepseek-v4-pro",
+  "opencode-go/kimi-k2.6",
+  "opencode-go/kimi-k2.5",
+  "opencode-go/glm-5.1",
+  "opencode-go/glm-5",
+  "opencode-go/qwen3.6-plus",
+  "opencode-go/qwen3.5-plus",
+  "opencode-zen/deepseek-v4-flash",
+  "opencode-zen/deepseek-v4-pro",
 ]);
 
 export function isVisionBridgeForcedModel(model: string | null | undefined): boolean {
   if (!model) return false;
-  const normalizedModel = (model.includes("/") ? model.split("/").pop() || model : model)
-    .trim()
-    .toLowerCase();
+  const lowerModel = model.trim().toLowerCase();
+  if (FORCED_VISION_BRIDGE_MODELS.has(lowerModel)) return true;
+  // Also check just the model name (after /) for backward compatibility
+  const normalizedModel = lowerModel.includes("/") ? lowerModel.split("/").pop() || lowerModel : lowerModel;
   return FORCED_VISION_BRIDGE_MODELS.has(normalizedModel);
 }
 


### PR DESCRIPTION
## Problem

Models from `opencode-go` and `opencode-zen` providers sync `modalities_input` including `"image"` from the provider catalog, which causes OpenCode to allow clipboard image paste. However the actual backend models (deepseek-v4-flash, kimi-k2.6, glm-5, qwen3-plus) do **not** have native vision capability.

The Vision Bridge was skipping these models because `supportsVision === true` from the synced capabilities data (line 62-65 of `visionBridge.ts`), sending raw images to models that cannot process them — resulting in \"Cannot read clipboard (this model does not support image input)\" errors.

## Fix

1. Added all opencode-go and opencode-zen model IDs to `FORCED_VISION_BRIDGE_MODELS` so the Vision Bridge always processes images for these models regardless of what synced capabilities say.
2. Updated `isVisionBridgeForcedModel()` to match both full `provider/model` strings and bare model names for flexibility.

## Testing

- All 68 vision bridge tests pass (17 bridge + 36 helpers + 15 env-override)
- Clean TypeScript diagnostics