### PR TITLE
fix(docker): keep fumadocs doc assets in Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -41,15 +41,11 @@ blob-report
 # Issue #2348: The Dashboard Docs viewer reads markdown from `/app/docs` at
 # runtime. The previous `docs/*` block hid every file except openapi.yaml,
 # so the in-product help screen failed with ENOENT for every page.
-# We now keep the English markdown tree but drop the bulky assets
-# (translations, screenshots, raster diagrams) that account for ~45 MB
-# of the ~50 MB docs directory. The Docs viewer reads the default-locale
-# (English) sources at runtime, so translations are not required in the
-# container image.
+# We now keep the English markdown tree but drop bulky i18n mirrors (~45 MB).
+# v3.8.3+ (fumadocs-mdx): `npm run build` webpack-bundles docs — keep assets referenced
+# from English markdown (docs/diagrams/exported/*.svg, docs/screenshots/*.png).
 docs/i18n/**
-docs/screenshots/**
-# Keep docs/diagrams/exported/*.svg — fumadocs-mdx resolves them at `npm run build`
-# (see docs/architecture/*.md). Source .mmd files stay in the image; raster formats excluded.
+# Raster sources under docs/diagrams/ only (exported SVGs are required at build time).
 docs/diagrams/**/*.png
 docs/diagrams/**/*.jpg
 docs/diagrams/**/*.jpeg

--- a/.dockerignore
+++ b/.dockerignore
@@ -48,13 +48,13 @@ blob-report
 # container image.
 docs/i18n/**
 docs/screenshots/**
-docs/diagrams/exported/**
+# Keep docs/diagrams/exported/*.svg — fumadocs-mdx resolves them at `npm run build`
+# (see docs/architecture/*.md). Source .mmd files stay in the image; raster formats excluded.
 docs/diagrams/**/*.png
 docs/diagrams/**/*.jpg
 docs/diagrams/**/*.jpeg
 docs/diagrams/**/*.gif
 docs/diagrams/**/*.webp
-docs/diagrams/**/*.svg
 # Note: `*.md` matches the root only (Go filepath.Match does not cross /),
 # so nested docs/**/*.md is implicitly kept without a re-include rule.
 *.md

--- a/tests/unit/dockerignore-docs-coverage.test.ts
+++ b/tests/unit/dockerignore-docs-coverage.test.ts
@@ -33,12 +33,17 @@ const REQUIRED_DOCS = [
   "docs/reference/ENVIRONMENT.md",
 ];
 
-// Referenced from docs/architecture/*.md — webpack fails the production build if missing.
+// Referenced from docs/**/*.md — fumadocs-mdx webpack build fails if missing.
 const REQUIRED_DOC_DIAGRAMS = [
   "docs/diagrams/exported/request-pipeline.svg",
   "docs/diagrams/exported/resilience-3layers.svg",
   "docs/diagrams/exported/authz-pipeline.svg",
   "docs/diagrams/exported/db-schema-overview.svg",
+];
+
+const REQUIRED_DOC_SCREENSHOTS = [
+  "docs/screenshots/01-providers.png",
+  "docs/screenshots/05-translator.png",
 ];
 
 // Compile .dockerignore patterns into a simple matcher.
@@ -128,7 +133,7 @@ test("#2348 .dockerignore keeps every doc the in-product viewer needs", () => {
   const missing: string[] = [];
   const ignored: string[] = [];
 
-  for (const docPath of [...REQUIRED_DOCS, ...REQUIRED_DOC_DIAGRAMS]) {
+  for (const docPath of [...REQUIRED_DOCS, ...REQUIRED_DOC_DIAGRAMS, ...REQUIRED_DOC_SCREENSHOTS]) {
     const absPath = path.resolve(REPO_ROOT, docPath);
     if (!fs.existsSync(absPath)) {
       missing.push(docPath);
@@ -147,15 +152,11 @@ test("#2348 .dockerignore keeps every doc the in-product viewer needs", () => {
   );
 });
 
-test("#2348 .dockerignore still excludes the heavy i18n + screenshots dirs", () => {
+test("#2348 .dockerignore still excludes the heavy i18n tree", () => {
   const parsed = parseDockerignore(fs.readFileSync(DOCKERIGNORE, "utf8"));
-  // These should NOT make it into the container — they are 45+ MB combined
-  // and the in-product viewer reads only the English originals at runtime.
-  const HEAVY_PATHS = ["docs/i18n/pt-BR/docs/AUTO-COMBO.md", "docs/screenshots/dashboard.png"];
-  for (const heavy of HEAVY_PATHS) {
-    assert.ok(
-      isIgnored(heavy, parsed),
-      `${heavy} should be excluded from Docker context but is not — image size will balloon`
-    );
-  }
+  const heavy = "docs/i18n/pt-BR/docs/AUTO-COMBO.md";
+  assert.ok(
+    isIgnored(heavy, parsed),
+    `${heavy} should be excluded from Docker context but is not — image size will balloon`
+  );
 });

--- a/tests/unit/dockerignore-docs-coverage.test.ts
+++ b/tests/unit/dockerignore-docs-coverage.test.ts
@@ -33,6 +33,14 @@ const REQUIRED_DOCS = [
   "docs/reference/ENVIRONMENT.md",
 ];
 
+// Referenced from docs/architecture/*.md — webpack fails the production build if missing.
+const REQUIRED_DOC_DIAGRAMS = [
+  "docs/diagrams/exported/request-pipeline.svg",
+  "docs/diagrams/exported/resilience-3layers.svg",
+  "docs/diagrams/exported/authz-pipeline.svg",
+  "docs/diagrams/exported/db-schema-overview.svg",
+];
+
 // Compile .dockerignore patterns into a simple matcher.
 // We only need to support the directives we actually use: glob `**`, plain
 // path prefixes, and negations starting with `!`.
@@ -120,7 +128,7 @@ test("#2348 .dockerignore keeps every doc the in-product viewer needs", () => {
   const missing: string[] = [];
   const ignored: string[] = [];
 
-  for (const docPath of REQUIRED_DOCS) {
+  for (const docPath of [...REQUIRED_DOCS, ...REQUIRED_DOC_DIAGRAMS]) {
     const absPath = path.resolve(REPO_ROOT, docPath);
     if (!fs.existsSync(absPath)) {
       missing.push(docPath);


### PR DESCRIPTION
## Summary

Fixes Docker production builds after v3.8.3 Fumadocs MDX integration (#2617).

Webpack now bundles English docs at `npm run build` and resolves image paths from markdown. The existing `.dockerignore` excluded `docs/diagrams/exported/*.svg` and `docs/screenshots/**`, causing fatal `Module not found` errors during `docker build` even though runtime docs worked before.

- Keep `docs/diagrams/exported/*.svg` and `docs/screenshots/*.png` in the Docker build context
- Continue excluding `docs/i18n/**` (~45 MB)
- Extend `dockerignore-docs-coverage` regression tests

## Test plan

- [x] `node --import tsx/esm --test tests/unit/dockerignore-docs-coverage.test.ts`
- [x] `docker build` succeeds on headless VPS (reporter verified)
- [ ] Upstream CI green
