### PR TITLE
fix: remove private field from root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -270,6 +270,5 @@
       "strip-ansi": "^6.0.1",
       "string-width": "^4.2.3"
     }
-  },
-  "private": true
+  }
 }


### PR DESCRIPTION
Remove the private: true field from package.json to fix EPRIVATE errors during NPM publish.