### PR TITLE
fix: Error: Unable to inspect existing database #2771

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,6 +90,10 @@ RUN chown -R node:node /app
 
 EXPOSE 20128
 
+# Warns if the mounted data volume has wrong ownership
+COPY --chmod=755 scripts/check-permissions.sh /tmp/check-permissions.sh
+ENTRYPOINT ["/tmp/check-permissions.sh"]
+
 USER node
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \

--- a/scripts/check-permissions.sh
+++ b/scripts/check-permissions.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+if [ -d "/app/data" ] && [ ! -w "/app/data" ]; then
+    echo "WARNING: /app/data is not writable by the current user (UID $(id -u))."
+    echo "Run this on the Docker host to fix:"
+    echo "  sudo chown -R 1000:1000 ./data"
+    echo "  chmod -R u+rwX ./data"
+    exit 1
+fi
+
+exec "$@"


### PR DESCRIPTION
## Summary

Add small information for user to easier see why the docker container fails to launch.

```
% docker compose --profile base up --build                
[+] Building 183.6s (38/38) FINISHED                                                                                                                                                                               
 => [internal] load local bake definitions                                                                                                                                                                    0.0s
 => => reading from stdin 570B                                                                                                                                                                                0.0s
 => [internal] load build definition from Dockerfile                                                                                                                                                          0.0s
 => => transferring dockerfile: 5.80kB                                                                                                                                                                        0.0s
 => [internal] load metadata for docker.io/library/node:24-trixie-slim                                                                                                                                        0.5s
 => [internal] load .dockerignore                                                                                                                                                                             0.1s
 => => transferring context: 1.88kB                                                                                                                                                                           0.0s
 => [internal] load build context                                                                                                                                                                             0.5s
 => => transferring context: 25.42MB                                                                                                                                                                          0.4s
 => [builder  1/11] FROM docker.io/library/node:24-trixie-slim@sha256:05c08ce4291e9a58f59456a7985176defb12cdd42271f35ff81a3e167ea61d4c                                                                        0.0s
 => CACHED [builder  2/11] WORKDIR /app                                                                                                                                                                       0.0s
 => CACHED [builder  3/11] RUN --mount=type=cache,target=/var/cache/apt,sharing=locked   --mount=type=cache,target=/var/lib/apt/lists,sharing=locked   apt-get update   && apt-get install -y --no-install-r  0.0s
 => CACHED [builder  4/11] COPY package*.json ./                                                                                                                                                              0.0s
 => CACHED [builder  5/11] COPY scripts/build/postinstall.mjs ./scripts/build/postinstall.mjs                                                                                                                 0.0s
 => CACHED [builder  6/11] COPY scripts/build/postinstallSupport.mjs ./scripts/build/postinstallSupport.mjs                                                                                                   0.0s
 => CACHED [builder  7/11] COPY scripts/build/native-binary-compat.mjs ./scripts/build/native-binary-compat.mjs                                                                                               0.0s
 => CACHED [builder  8/11] RUN test -f package-lock.json   || (echo "package-lock.json is required for reproducible Docker builds" >&2 && exit 1)                                                             0.0s
 => CACHED [builder  9/11] RUN --mount=type=cache,target=/root/.npm   npm ci --no-audit --no-fund --legacy-peer-deps --ignore-scripts   && npm rebuild better-sqlite3   && node -e "require('better-sqlite3'  0.0s
 => [builder 10/11] COPY . ./                                                                                                                                                                                 0.6s
 => [builder 11/11] RUN --mount=type=cache,target=/app/.next/cache   mkdir -p /app/data && npm run build -- --webpack                                                                                       164.9s
 => CACHED [runner-base  3/22] RUN --mount=type=cache,target=/var/cache/apt,sharing=locked   --mount=type=cache,target=/var/lib/apt/lists,sharing=locked   apt-get update   && apt-get install -y --no-insta  0.0s 
 => CACHED [runner-base  4/22] RUN mkdir -p /app/data                                                                                                                                                         0.0s 
 => CACHED [runner-base  5/22] COPY --from=builder /app/public ./public                                                                                                                                       0.0s 
 => [runner-base  6/22] COPY --from=builder /app/.next/static ./.next/static                                                                                                                                  0.4s 
 => [runner-base  7/22] COPY --from=builder /app/.next/standalone ./                                                                                                                                          0.7s 
 => [runner-base  8/22] COPY --from=builder /app/node_modules/@swc/helpers ./node_modules/@swc/helpers                                                                                                        0.5s 
 => [runner-base  9/22] COPY --from=builder /app/node_modules/better-sqlite3 ./node_modules/better-sqlite3                                                                                                    0.2s
 => [runner-base 10/22] COPY --from=builder /app/node_modules/pino-abstract-transport ./node_modules/pino-abstract-transport                                                                                  0.2s
 => [runner-base 11/22] COPY --from=builder /app/node_modules/pino-pretty ./node_modules/pino-pretty                                                                                                          0.2s
 => [runner-base 12/22] COPY --from=builder /app/node_modules/split2 ./node_modules/split2                                                                                                                    0.2s
 => [runner-base 13/22] COPY --from=builder /app/src/lib/db/migrations ./migrations                                                                                                                           0.2s
 => [runner-base 14/22] COPY --from=builder /app/src/mitm/server.cjs ./src/mitm/server.cjs                                                                                                                    0.2s
 => [runner-base 15/22] COPY --from=builder /app/.next/standalone/docs ./docs                                                                                                                                 0.2s
 => [runner-base 16/22] COPY --from=builder /app/scripts/dev/run-standalone.mjs ./dev/run-standalone.mjs                                                                                                      0.2s
 => [runner-base 17/22] COPY --from=builder /app/scripts/build/runtime-env.mjs ./build/runtime-env.mjs                                                                                                        0.2s
 => [runner-base 18/22] COPY --from=builder /app/scripts/build/bootstrap-env.mjs ./build/bootstrap-env.mjs                                                                                                    0.2s
 => [runner-base 19/22] COPY --from=builder /app/scripts/dev/healthcheck.mjs ./healthcheck.mjs                                                                                                                0.2s
 => [runner-base 20/22] RUN node -e "require('better-sqlite3')(':memory:').close()"                                                                                                                           0.4s
 => [runner-base 21/22] RUN chown -R node:node /app                                                                                                                                                           0.5s
 => [runner-base 22/22] COPY --chmod=755 scripts/check-permissions.sh /tmp/check-permissions.sh                                                                                                               0.3s
 => exporting to image                                                                                                                                                                                        7.8s
 => => exporting layers                                                                                                                                                                                       7.7s
 => => writing image sha256:02af88ca1c66cc6d25d49647b5fc08678f55c4ce35187a009122fda030f89d2d                                                                                                                  0.0s
 => => naming to docker.io/library/omniroute:base                                                                                                                                                             0.0s
 => resolving provenance for metadata file                                                                                                                                                                    0.0s
[+] up 2/2
 ✔ Image omniroute:base Built                                                                                                                                                                                183.7s
 ✔ Container omniroute  Recreated                                                                                                                                                                              0.8s
Attaching to omniroute, omniroute-redis
omniroute  | WARNING: /app/data is not writable by the current user (UID 1000).
omniroute  | Run this on the Docker host to fix:
omniroute  |   sudo chown -R 1000:1000 ./data
omniroute  |   chmod -R u+rwX ./data
omniroute exited with code 1 (restarting)
omniroute  | WARNING: /app/data is not writable by the current user (UID 1000).
omniroute  | Run this on the Docker host to fix:
omniroute  |   sudo chown -R 1000:1000 ./data
omniroute  |   chmod -R u+rwX ./data
omniroute exited with code 1 (restarting)
Gracefully Stopping... press Ctrl+C again to force
Container omniroute-redis Stopping 
Container omniroute Stopping 
omniroute-redis  | 1:signal-handler (1779897980) Received SIGTERM scheduling shutdown...
Container omniroute Stopped 
omniroute-redis  | 1:M 27 May 2026 16:06:20.568 # Redis is now ready to exit, bye bye...
Container omniroute-redis Stopped 
omniroute-redis exited with code 0
^CContainer omniroute-redis Killing 
Container omniroute Killing 
Container omniroute-redis Error Error while Killing
Container omniroute Error Error while Killing

docker compose --profile base up --build  11.82s user 0.47s system 6% cpu 3:21.71 total
% chmod -R u+rwX ./data
% chmod -R u+rwX ./data
markus@staropramen ~/code/docker/OmniRoute (git)-[bug/docker-sqlite-fix] % docker compose --profile base up --build
[+] Building 1.1s (38/38) FINISHED                                                                                                                                                                                 
 => [internal] load local bake definitions                                                                                                                                                                    0.0s
 => => reading from stdin 570B                                                                                                                                                                                0.0s
 => [internal] load build definition from Dockerfile                                                                                                                                                          0.0s
 => => transferring dockerfile: 5.80kB                                                                                                                                                                        0.0s
 => [internal] load metadata for docker.io/library/node:24-trixie-slim                                                                                                                                        0.4s
 => [internal] load .dockerignore                                                                                                                                                                             0.0s
 => => transferring context: 1.88kB                                                                                                                                                                           0.0s
 => [internal] load build context                                                                                                                                                                             0.3s
 => => transferring context: 187.68kB                                                                                                                                                                         0.2s
 => [builder  1/11] FROM docker.io/library/node:24-trixie-slim@sha256:05c08ce4291e9a58f59456a7985176defb12cdd42271f35ff81a3e167ea61d4c                                                                        0.0s
 => CACHED [builder  2/11] WORKDIR /app                                                                                                                                                                       0.0s
 => CACHED [runner-base  3/22] RUN --mount=type=cache,target=/var/cache/apt,sharing=locked   --mount=type=cache,target=/var/lib/apt/lists,sharing=locked   apt-get update   && apt-get install -y --no-insta  0.0s
 => CACHED [runner-base  4/22] RUN mkdir -p /app/data                                                                                                                                                         0.0s
 => CACHED [builder  3/11] RUN --mount=type=cache,target=/var/cache/apt,sharing=locked   --mount=type=cache,target=/var/lib/apt/lists,sharing=locked   apt-get update   && apt-get install -y --no-install-r  0.0s
 => CACHED [builder  4/11] COPY package*.json ./                                                                                                                                                              0.0s
 => CACHED [builder  5/11] COPY scripts/build/postinstall.mjs ./scripts/build/postinstall.mjs                                                                                                                 0.0s
 => CACHED [builder  6/11] COPY scripts/build/postinstallSupport.mjs ./scripts/build/postinstallSupport.mjs                                                                                                   0.0s
 => CACHED [builder  7/11] COPY scripts/build/native-binary-compat.mjs ./scripts/build/native-binary-compat.mjs                                                                                               0.0s
 => CACHED [builder  8/11] RUN test -f package-lock.json   || (echo "package-lock.json is required for reproducible Docker builds" >&2 && exit 1)                                                             0.0s
 => CACHED [builder  9/11] RUN --mount=type=cache,target=/root/.npm   npm ci --no-audit --no-fund --legacy-peer-deps --ignore-scripts   && npm rebuild better-sqlite3   && node -e "require('better-sqlite3'  0.0s
 => CACHED [builder 10/11] COPY . ./                                                                                                                                                                          0.0s
 => CACHED [builder 11/11] RUN --mount=type=cache,target=/app/.next/cache   mkdir -p /app/data && npm run build -- --webpack                                                                                  0.0s
 => CACHED [runner-base  5/22] COPY --from=builder /app/public ./public                                                                                                                                       0.0s
 => CACHED [runner-base  6/22] COPY --from=builder /app/.next/static ./.next/static                                                                                                                           0.0s
 => CACHED [runner-base  7/22] COPY --from=builder /app/.next/standalone ./                                                                                                                                   0.0s
 => CACHED [runner-base  8/22] COPY --from=builder /app/node_modules/@swc/helpers ./node_modules/@swc/helpers                                                                                                 0.0s
 => CACHED [runner-base  9/22] COPY --from=builder /app/node_modules/better-sqlite3 ./node_modules/better-sqlite3                                                                                             0.0s
 => CACHED [runner-base 10/22] COPY --from=builder /app/node_modules/pino-abstract-transport ./node_modules/pino-abstract-transport                                                                           0.0s
 => CACHED [runner-base 11/22] COPY --from=builder /app/node_modules/pino-pretty ./node_modules/pino-pretty                                                                                                   0.0s
 => CACHED [runner-base 12/22] COPY --from=builder /app/node_modules/split2 ./node_modules/split2                                                                                                             0.0s
 => CACHED [runner-base 13/22] COPY --from=builder /app/src/lib/db/migrations ./migrations                                                                                                                    0.0s
 => CACHED [runner-base 14/22] COPY --from=builder /app/src/mitm/server.cjs ./src/mitm/server.cjs                                                                                                             0.0s
 => CACHED [runner-base 15/22] COPY --from=builder /app/.next/standalone/docs ./docs                                                                                                                          0.0s
 => CACHED [runner-base 16/22] COPY --from=builder /app/scripts/dev/run-standalone.mjs ./dev/run-standalone.mjs                                                                                               0.0s
 => CACHED [runner-base 17/22] COPY --from=builder /app/scripts/build/runtime-env.mjs ./build/runtime-env.mjs                                                                                                 0.0s
 => CACHED [runner-base 18/22] COPY --from=builder /app/scripts/build/bootstrap-env.mjs ./build/bootstrap-env.mjs                                                                                             0.0s
 => CACHED [runner-base 19/22] COPY --from=builder /app/scripts/dev/healthcheck.mjs ./healthcheck.mjs                                                                                                         0.0s
 => CACHED [runner-base 20/22] RUN node -e "require('better-sqlite3')(':memory:').close()"                                                                                                                    0.0s
 => CACHED [runner-base 21/22] RUN chown -R node:node /app                                                                                                                                                    0.0s
 => CACHED [runner-base 22/22] COPY --chmod=755 scripts/check-permissions.sh /tmp/check-permissions.sh                                                                                                        0.0s
 => exporting to image                                                                                                                                                                                        0.0s
 => => exporting layers                                                                                                                                                                                       0.0s
 => => writing image sha256:02af88ca1c66cc6d25d49647b5fc08678f55c4ce35187a009122fda030f89d2d                                                                                                                  0.0s
 => => naming to docker.io/library/omniroute:base                                                                                                                                                             0.0s
 => resolving provenance for metadata file                                                                                                                                                                    0.1s
[+] up 1/1
 ✔ Image omniroute:base Built                                                                                                                                                                                  1.2s
Attaching to omniroute, omniroute-redis
omniroute  | ▲ Next.js 16.2.6
omniroute  | - Local:         http://localhost:20128
omniroute  | - Network:       http://0.0.0.0:20128
omniroute  | ✓ Ready in 0ms
omniroute  | [CREDENTIALS] No external credentials file found, using defaults.
omniroute  | [DB] Preserved critical DB state before potential recreation: key_value(418), provider_connections(8), provider_nodes(2), combos(1), api_keys(1)
omniroute  | [DB] Added usage_history.combo_strategy column
omniroute  | [Migration] Reconciled renamed migration 052_manifest_routing to 059_manifest_routing to preserve pending migrations.
omniroute  | [Migration] 🔄 RECONCILIATION: Found missing intermediate migration 052_api_key_combo_throttle (highest applied is 61). This gap will be back-filled to ensure schema integrity.
```