### PR TITLE
fix(gemini): emit signaturelessToolCallMode:text for GEMINI format models

### DIFF
--- a/open-sse/translator/request/openai-to-gemini.ts
+++ b/open-sse/translator/request/openai-to-gemini.ts
@@ -523,7 +523,10 @@ export function openaiToGeminiRequest(
   model: string,
   body: Record<string, unknown>,
   stream: boolean,
-  credentials: Record<string, unknown> | null = null
+  credentials: Record<string, unknown> | null = null,
+  options: {
+    signaturelessToolCallMode?: "native" | "text";
+  } = {}
 ) {
   // Thread the signature namespace so a thinking model's thoughtSignature (cached on the
   // response turn under `<connectionId>:<toolCallId>`) is found and re-attached to the
@@ -533,7 +536,10 @@ export function openaiToGeminiRequest(
     credentials && typeof credentials._signatureNamespace === "string"
       ? credentials._signatureNamespace
       : null;
-  return openaiToGeminiBase(model, body, stream, { signatureNamespace });
+  return openaiToGeminiBase(model, body, stream, {
+    signatureNamespace,
+    signaturelessToolCallMode: options.signaturelessToolCallMode,
+  });
 }
 
 // OpenAI -> Gemini CLI (Cloud Code Assist)
@@ -695,7 +701,15 @@ export function openaiToAntigravityRequest(model, body, stream, credentials = nu
 }
 
 // Register
-register(FORMATS.OPENAI, FORMATS.GEMINI, openaiToGeminiRequest, null);
+register(
+  FORMATS.OPENAI,
+  FORMATS.GEMINI,
+  (model, body, stream, credentials) =>
+    openaiToGeminiRequest(model, body, stream, credentials, {
+      signaturelessToolCallMode: "text",
+    }),
+  null
+);
 register(
   FORMATS.OPENAI,
   FORMATS.GEMINI_CLI,

--- a/open-sse/translator/request/openai-to-gemini.ts
+++ b/open-sse/translator/request/openai-to-gemini.ts
@@ -704,7 +704,7 @@ export function openaiToAntigravityRequest(model, body, stream, credentials = nu
 register(
   FORMATS.OPENAI,
   FORMATS.GEMINI,
-  (model, body, stream, credentials) =>
+  (model, body, stream = false, credentials = null) =>
     openaiToGeminiRequest(model, body, stream, credentials, {
       signaturelessToolCallMode: "text",
     }),


### PR DESCRIPTION
## Problem

Google Gemini API now requires `thought_signature` on all `functionCall` parts for thinking models (gemini-3.1-flash-lite-preview, etc.). OmniRoute was sending native `functionCall` parts without `thought_signature` → Gemini rejects with 400 `"missing thought_signature"`.

Full error:
```
Function call is missing a thought_signature in functionCall parts. This is required for tools to work correctly
```

Reference: https://ai.google.dev/gemini-api/docs/thought-signatures

## Fix

Added `signaturelessToolCallMode: "text"` to the **GEMINI** format registration wrapper in `openai-to-gemini.ts`. This stringifies tool calls that lack a `thought_signature` as text (e.g., `[Tool call: bash]\nArguments: {...}`) instead of sending native `functionCall` parts that Google rejects.

## Why only GEMINI?

The **GEMINI_CLI** and **ANTIGRAVITY** paths already had this parameter set correctly — only the plain **GEMINI** format path was missing it.

## Verification

- ✅ 27/27 translator tests pass
- ✅ `lsp_diagnostics` clean on modified file