### PR TITLE
fix(translator): strip safety_identifier in openai-responses cleanup (#2770)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - **oauth:** repair native Google loopback callback flow and support remote callbacks via state matching on 127.0.0.1 (#2796 — thanks @akarray)
 - **combos:** fix combo handling so transient 429 rate limit errors do not poison or persist the rate limited state for the same-provider connection (#2800 — thanks @apoapostolov)
 - **gemini:** translate signature-less Gemini thinking model tool calls to text parts to prevent `400 "missing thought_signature"` errors (#2801 — thanks @herjarsa)
+- **translator:** strip `safety_identifier` from `/v1/responses` body before forwarding to Chat Completions upstream; fixes LobeHub-originated `400` errors (#2770)
 - **warning-cleanup:** relax node engine constraint to `>=22.0.0` and clean dependencies (keeping `marked-terminal` to prevent TUI REPL crash) (#2792 — thanks @oyi77)
 
 ### 🧹 Chores

--- a/open-sse/translator/request/openai-responses.ts
+++ b/open-sse/translator/request/openai-responses.ts
@@ -345,6 +345,9 @@ export function openaiResponsesToOpenAIRequest(
     }
   }
   delete result.reasoning;
+  // Strip Responses-API-only fields that Chat Completions rejects with 400.
+  // safety_identifier is sent by LobeHub and has no Chat Completions equivalent (#2770).
+  delete result.safety_identifier;
 
   return result;
 }

--- a/tests/unit/translator-openai-responses-req.test.ts
+++ b/tests/unit/translator-openai-responses-req.test.ts
@@ -216,6 +216,23 @@ test("Responses -> Chat passes through when background flag is unset or false (n
   }
 });
 
+test("Responses -> Chat strips safety_identifier (LobeHub #2770)", () => {
+  // LobeHub sends safety_identifier in Responses API bodies. Chat Completions rejects it
+  // with HTTP 400. The translator must strip it in the Responses-API cleanup block.
+  const result = openaiResponsesToOpenAIRequest(
+    "gpt-4o",
+    {
+      input: [{ role: "user", content: [{ type: "input_text", text: "hi" }] }],
+      safety_identifier: "sid-xyz",
+    },
+    false,
+    null
+  ) as Record<string, unknown>;
+
+  assert.equal(result.safety_identifier, undefined, "safety_identifier must be stripped before forwarding to Chat Completions");
+  assert.ok(Array.isArray(result.messages), "translation must still produce messages");
+});
+
 test("Chat -> Responses converts messages, tool calls, tool outputs, tools and pass-through params", () => {
   const result = openaiToOpenAIResponsesRequest(
     "gpt-4o",


### PR DESCRIPTION
Closes #2770

## Summary
- LobeHub sends `safety_identifier` in `/v1/responses` calls. The `openaiResponsesToOpenAIRequest` translator was forwarding it, causing upstream Chat Completions to reject the request with HTTP 400.
- Added `delete result.safety_identifier;` to the "Cleanup Responses API specific fields" block in `open-sse/translator/request/openai-responses.ts`, alongside the existing deletions of `input`, `instructions`, `store`, `reasoning`, etc.
- Note: `prompt_cache_key` is intentionally preserved per the existing comment in the cleanup block (used by Codex as a cache-affinity signal).

## Test plan
- [x] Regression test added: `"Responses -> Chat strips safety_identifier (LobeHub #2770)"` — asserts translated body has `safety_identifier === undefined`.
- [x] All 29 translator unit tests pass (`node --import tsx/esm --test tests/unit/translator-openai-responses-req.test.ts`).
- [x] Lint: 0 errors (pre-existing warnings only).

🔧 Auto-generated by /resolve-issues