### PR TITLE
fix(cli): replace cli-table3 with hand-rolled formatter (#2752)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ---
 
+## [3.8.6-patch] — 2026-05-27
+
+### 🔧 Bug Fixes
+
+- **fix(cli):** replace `cli-table3` dependency with a ~50-line hand-rolled ASCII formatter to resolve Node 24 / ESM interop breakage and remove tourniquet `package.json` overrides pinning `ansi-regex@^5`, `strip-ansi@^6`, `string-width@^4` ([#2752])
+
+---
+
 ## [3.8.6] — 2026-05-27
 
 ### ✨ New Features

--- a/bin/cli/output.mjs
+++ b/bin/cli/output.mjs
@@ -1,4 +1,3 @@
-import Table from "cli-table3";
 import { stringify as csvStringify } from "csv-stringify/sync";
 
 const MASK_RE = /sk-[A-Za-z0-9]{4,}/g;
@@ -41,6 +40,20 @@ function formatCell(v, col) {
   return String(v);
 }
 
+const CYAN = "\x1b[36m";
+const RESET = "\x1b[0m";
+
+/** Truncate a string to `max` chars, appending "…" if trimmed. */
+function truncateCell(str, max) {
+  if (str.length <= max) return str;
+  return str.slice(0, max - 1) + "…";
+}
+
+/** Pad a string to exactly `width` chars (left-aligned). */
+function padCell(str, width) {
+  return str + " ".repeat(Math.max(0, width - str.length));
+}
+
 function renderTable(rows, schema, opts = {}) {
   if (rows.length === 0) {
     process.stdout.write("(empty)\n");
@@ -48,18 +61,40 @@ function renderTable(rows, schema, opts = {}) {
   }
   const cols = schema || inferSchema(rows[0]);
   const quiet = opts.quiet === true;
-  const widths = cols.map((c) => c.width || null);
-  const hasWidths = widths.some((w) => w !== null);
-  const tableOpts = {
-    head: quiet ? [] : cols.map((c) => c.header),
-    style: { head: quiet ? [] : ["cyan"] },
+
+  // Compute column widths: max(header.length, max cell length), capped by explicit c.width.
+  const colWidths = cols.map((c) => {
+    const headerLen = c.header.length;
+    const maxData = rows.reduce((m, row) => Math.max(m, formatCell(row[c.key], c).length), 0);
+    const natural = Math.max(headerLen, maxData);
+    return c.width ? Math.max(c.width, 1) : natural;
+  });
+
+  const separator = colWidths.map((w) => "-".repeat(w + 2)).join("-+-");
+
+  const renderRow = (cells, cyan) => {
+    const parts = cells.map((cell, i) => {
+      const truncated = truncateCell(cell, colWidths[i]);
+      const padded = padCell(truncated, colWidths[i]);
+      return cyan ? ` ${CYAN}${padded}${RESET} ` : ` ${padded} `;
+    });
+    return `|${parts.join("|")}|`;
   };
-  if (hasWidths) tableOpts.colWidths = widths;
-  const table = new Table(tableOpts);
-  for (const row of rows) {
-    table.push(cols.map((c) => formatCell(row[c.key], c)));
+
+  const lines = [];
+
+  if (!quiet) {
+    lines.push(separator);
+    lines.push(renderRow(cols.map((c) => c.header), true));
   }
-  process.stdout.write(table.toString() + "\n");
+  lines.push(separator);
+
+  for (const row of rows) {
+    lines.push(renderRow(cols.map((c) => formatCell(row[c.key], c)), false));
+  }
+  lines.push(separator);
+
+  process.stdout.write(lines.join("\n") + "\n");
 }
 
 function renderCsv(rows, schema) {

--- a/bin/cli/output.mjs
+++ b/bin/cli/output.mjs
@@ -43,15 +43,46 @@ function formatCell(v, col) {
 const CYAN = "\x1b[36m";
 const RESET = "\x1b[0m";
 
-/** Truncate a string to `max` chars, appending "…" if trimmed. */
+/** Strip ANSI escape sequences so we can measure the visible width of a string. */
+const stripAnsi = (s) => s.replace(/\x1b\[[\d;]*m/g, "");
+
+/** Truncate a string to `max` visible chars, appending "…" if trimmed.
+ *  ANSI escape codes are excluded from the width count and never split. */
 function truncateCell(str, max) {
-  if (str.length <= max) return str;
-  return str.slice(0, max - 1) + "…";
+  const visible = stripAnsi(str);
+  if (visible.length <= max) return str;
+  // Rebuild the string char-by-char, counting only visible chars, stopping at max-1.
+  let count = 0;
+  let result = "";
+  let i = 0;
+  while (i < str.length) {
+    // Detect an ANSI escape sequence starting at position i.
+    if (str[i] === "\x1b" && str[i + 1] === "[") {
+      const end = str.indexOf("m", i + 2);
+      if (end !== -1) {
+        // Include the full escape sequence without counting it as visible width.
+        result += str.slice(i, end + 1);
+        i = end + 1;
+        continue;
+      }
+    }
+    if (count >= max - 1) break;
+    result += str[i];
+    count++;
+    i++;
+  }
+  // Ensure the reset code is always appended so ANSI color never bleeds.
+  if (str.includes("\x1b[")) {
+    result += RESET;
+  }
+  return result + "…";
 }
 
-/** Pad a string to exactly `width` chars (left-aligned). */
+/** Pad a string to exactly `width` visible chars (left-aligned).
+ *  ANSI escape codes are excluded from the padding calculation. */
 function padCell(str, width) {
-  return str + " ".repeat(Math.max(0, width - str.length));
+  const visible = stripAnsi(str);
+  return str + " ".repeat(Math.max(0, width - visible.length));
 }
 
 function renderTable(rows, schema, opts = {}) {
@@ -62,10 +93,13 @@ function renderTable(rows, schema, opts = {}) {
   const cols = schema || inferSchema(rows[0]);
   const quiet = opts.quiet === true;
 
-  // Compute column widths: max(header.length, max cell length), capped by explicit c.width.
+  // Compute column widths: max(header.length, max visible cell length), capped by explicit c.width.
   const colWidths = cols.map((c) => {
     const headerLen = c.header.length;
-    const maxData = rows.reduce((m, row) => Math.max(m, formatCell(row[c.key], c).length), 0);
+    const maxData = rows.reduce(
+      (m, row) => Math.max(m, stripAnsi(formatCell(row[c.key], c)).length),
+      0,
+    );
     const natural = Math.max(headerLen, maxData);
     return c.width ? Math.max(c.width, 1) : natural;
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
         "axios": "^1.16.1",
         "bcryptjs": "^3.0.3",
         "bottleneck": "^2.19.5",
-        "cli-table3": "^0.6.5",
         "commander": "^14.0.3",
         "csv-stringify": "^6.7.0",
         "express": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -149,7 +149,6 @@
     "axios": "^1.16.1",
     "bcryptjs": "^3.0.3",
     "bottleneck": "^2.19.5",
-    "cli-table3": "^0.6.5",
     "commander": "^14.0.3",
     "csv-stringify": "^6.7.0",
     "express": "^5.2.1",
@@ -264,11 +263,6 @@
     "postcss": "^8.5.14",
     "ip-address": "10.2.0",
     "qs": "^6.15.2",
-    "uuid": "^14.0.0",
-    "cli-table3": {
-      "ansi-regex": "^5.0.1",
-      "strip-ansi": "^6.0.1",
-      "string-width": "^4.2.3"
-    }
+    "uuid": "^14.0.0"
   }
 }

--- a/tests/unit/cli-output-render-table.test.ts
+++ b/tests/unit/cli-output-render-table.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Regression tests for renderTable (exposed via emit({ output: "table" })).
+ * Verifies behaviour is preserved after replacing cli-table3 with the hand-rolled formatter.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+function captureStdout(fn: () => void): string {
+  const chunks: string[] = [];
+  const originalWrite = process.stdout.write.bind(process.stdout);
+  process.stdout.write = (chunk: string | Uint8Array) => {
+    chunks.push(typeof chunk === "string" ? chunk : chunk.toString());
+    return true;
+  };
+  try {
+    fn();
+  } finally {
+    process.stdout.write = originalWrite;
+  }
+  return chunks.join("");
+}
+
+// ─── renderTable via emit ────────────────────────────────────────────────────
+
+test("renderTable: header text appears in output", async () => {
+  const { emit } = await import("../../bin/cli/output.mjs");
+  const schema = [
+    { key: "a", header: "A" },
+    { key: "b", header: "B" },
+  ];
+  const out = captureStdout(() => emit([{ a: "foo", b: "bar" }], { output: "table" }, schema));
+  assert.ok(out.includes("A"), `expected "A" in output, got: ${out}`);
+  assert.ok(out.includes("B"), `expected "B" in output, got: ${out}`);
+});
+
+test("renderTable: row values appear in output", async () => {
+  const { emit } = await import("../../bin/cli/output.mjs");
+  const schema = [
+    { key: "a", header: "A" },
+    { key: "b", header: "B" },
+  ];
+  const out = captureStdout(() => emit([{ a: "foo", b: "bar" }], { output: "table" }, schema));
+  assert.ok(out.includes("foo"), `expected "foo" in output, got: ${out}`);
+  assert.ok(out.includes("bar"), `expected "bar" in output, got: ${out}`);
+});
+
+test("renderTable: output contains newline separation", async () => {
+  const { emit } = await import("../../bin/cli/output.mjs");
+  const schema = [{ key: "a", header: "A" }];
+  const out = captureStdout(() => emit([{ a: "foo" }], { output: "table" }, schema));
+  assert.ok(out.includes("\n"), "expected newline in output");
+});
+
+test("renderTable: empty rows prints (empty)", async () => {
+  const { emit } = await import("../../bin/cli/output.mjs");
+  const schema = [{ key: "a", header: "A" }];
+  const out = captureStdout(() => emit([], { output: "table" }, schema));
+  assert.ok(out.includes("empty"), `expected "(empty)" in output, got: ${out}`);
+});
+
+test("renderTable: quiet:true suppresses headers", async () => {
+  const { emit } = await import("../../bin/cli/output.mjs");
+  const schema = [
+    { key: "a", header: "Alpha" },
+    { key: "b", header: "Beta" },
+  ];
+  const out = captureStdout(() =>
+    emit([{ a: "val1", b: "val2" }], { output: "table", quiet: true }, schema),
+  );
+  // headers must NOT appear in quiet mode
+  assert.ok(!out.includes("Alpha"), `header "Alpha" should be hidden in quiet mode, got: ${out}`);
+  assert.ok(!out.includes("Beta"), `header "Beta" should be hidden in quiet mode, got: ${out}`);
+  // data rows still present
+  assert.ok(out.includes("val1"), `expected "val1" in quiet output, got: ${out}`);
+  assert.ok(out.includes("val2"), `expected "val2" in quiet output, got: ${out}`);
+});
+
+test("renderTable: multiple rows all appear", async () => {
+  const { emit } = await import("../../bin/cli/output.mjs");
+  const schema = [{ key: "name", header: "Name" }];
+  const data = [{ name: "alice" }, { name: "bob" }, { name: "charlie" }];
+  const out = captureStdout(() => emit(data, { output: "table" }, schema));
+  assert.ok(out.includes("alice"), "expected 'alice'");
+  assert.ok(out.includes("bob"), "expected 'bob'");
+  assert.ok(out.includes("charlie"), "expected 'charlie'");
+});
+
+test("renderTable: infers schema from data keys when no schema given", async () => {
+  const { emit } = await import("../../bin/cli/output.mjs");
+  const data = [{ id: "x1", status: "ok" }];
+  const out = captureStdout(() => emit(data, { output: "table" }));
+  assert.ok(out.includes("id"), "expected key 'id' as header");
+  assert.ok(out.includes("status"), "expected key 'status' as header");
+  assert.ok(out.includes("x1"), "expected value 'x1'");
+  assert.ok(out.includes("ok"), "expected value 'ok'");
+});
+
+test("renderTable: column separator characters present", async () => {
+  const { emit } = await import("../../bin/cli/output.mjs");
+  const schema = [
+    { key: "col1", header: "Col1" },
+    { key: "col2", header: "Col2" },
+  ];
+  const out = captureStdout(() => emit([{ col1: "a", col2: "b" }], { output: "table" }, schema));
+  // Output must contain some column delimiter — either "|" (hand-rolled) or "│" (cli-table3 box-drawing)
+  const hasSeparator = out.includes("|") || out.includes("│");
+  assert.ok(hasSeparator, `expected column separator in output, got: ${out}`);
+});

--- a/tests/unit/cli-output-render-table.test.ts
+++ b/tests/unit/cli-output-render-table.test.ts
@@ -106,3 +106,29 @@ test("renderTable: column separator characters present", async () => {
   const hasSeparator = out.includes("|") || out.includes("│");
   assert.ok(hasSeparator, `expected column separator in output, got: ${out}`);
 });
+
+test("renderTable: ANSI-wrapped formatter value does not bleed — reset code always present", async () => {
+  const { emit } = await import("../../bin/cli/output.mjs");
+  // Formatter wraps each value in green ANSI codes.
+  const GREEN = "\x1b[32m";
+  const RESET_CODE = "\x1b[0m";
+  const schema = [
+    {
+      key: "status",
+      header: "Status",
+      // Column width (4) is smaller than the raw ANSI string length (e.g. "\x1b[32mok\x1b[0m" = 12 bytes)
+      // but the visible content "ok" is only 2 chars — no truncation needed.
+      // We use a longer visible value to force truncation and verify the reset is preserved.
+      width: 4,
+      formatter: (v: string) => `${GREEN}${v}${RESET_CODE}`,
+    },
+  ];
+  // "active" (6 visible chars) exceeds the column width of 4, triggering truncation.
+  const out = captureStdout(() => emit([{ status: "active" }], { output: "table" }, schema));
+
+  // The rendered output must always contain the ANSI reset code — never a bleed.
+  assert.ok(
+    out.includes(RESET_CODE),
+    `expected ANSI reset code (\\x1b[0m) in output to prevent color bleed, got: ${JSON.stringify(out)}`,
+  );
+});


### PR DESCRIPTION
Closes #2752

## Summary

- `cli-table3@0.6.5` (no upstream release in 18+ months) pulls a CJS `ansi-regex`/`strip-ansi`/`string-width` chain that breaks on Node 24 via ESM-only transitive deps.
- Its sole consumer was `renderTable()` in `bin/cli/output.mjs` (~20 lines of usage).
- Replaced with a ~50-line hand-rolled ASCII table formatter using raw ANSI escapes (`\x1b[36m` for cyan headers) — zero new external deps.
- Removed the tourniquet `overrides` block from `package.json` that was pinning `ansi-regex@^5`, `strip-ansi@^6`, and `string-width@^4`.

## Test plan

- [x] New regression test file: `tests/unit/cli-output-render-table.test.ts` — 8 cases (headers, row values, quiet mode, empty input, multi-row, inferred schema, newline separation, column separator).
- [x] Existing `tests/unit/cli-output.test.ts` — all 7 tests still green.
- [x] `tests/unit/cli-usage.test.ts` and `tests/unit/cli-webhooks-commands.test.ts` — all 13 tests green.
- [x] `npm install --package-lock-only` clean after removing the dependency.
- [x] Husky pre-commit hook passed cleanly.

🔧 Auto-generated by /resolve-issues