### PR TITLE
fix(github): route claude-opus-4.6 via chat completions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ ENV OMNIROUTE_USE_TURBOPACK=1
 
 COPY . ./
 RUN --mount=type=cache,target=/app/.next/cache \
-  mkdir -p /app/data && NODE_OPTIONS="--max-old-space-size=4096" npm run build -- --webpack
+  mkdir -p /app/data && npm run build
 
 # ── Runner base ────────────────────────────────────────────────────────────
 FROM base AS runner-base

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ ENV OMNIROUTE_USE_TURBOPACK=1
 
 COPY . ./
 RUN --mount=type=cache,target=/app/.next/cache \
-  mkdir -p /app/data && npm run build
+  mkdir -p /app/data && NODE_OPTIONS="--max-old-space-size=4096" npm run build -- --webpack
 
 # ── Runner base ────────────────────────────────────────────────────────────
 FROM base AS runner-base

--- a/open-sse/config/providerRegistry.ts
+++ b/open-sse/config/providerRegistry.ts
@@ -951,7 +951,6 @@ export const REGISTRY: Record<string, RegistryEntry> = {
       {
         id: "claude-opus-4.6",
         name: "Claude Opus 4.6",
-        targetFormat: "openai-responses",
         contextLength: 1000000,
         maxOutputTokens: 128000,
       },

--- a/tests/unit/executor-github.test.ts
+++ b/tests/unit/executor-github.test.ts
@@ -25,6 +25,12 @@ test("GithubExecutor.buildUrl routes response-format models to /responses", () =
   }
 });
 
+test("GithubExecutor.buildUrl keeps GitHub Claude Opus 4.6 on /chat/completions", () => {
+  const executor = new GithubExecutor();
+  const url = executor.buildUrl("claude-opus-4.6", true);
+  assert.equal(url, "https://api.githubcopilot.com/chat/completions");
+});
+
 test("GithubExecutor.transformRequest injects JSON response instructions for Claude and strips reasoning fields", () => {
   const executor = new GithubExecutor();
   const body = {

--- a/tests/unit/provider-models-config.test.ts
+++ b/tests/unit/provider-models-config.test.ts
@@ -68,9 +68,11 @@ test("GitHub Copilot registry reflects the current supported model lineup", () =
   assert.ok(ids.has("gpt-5.4"));
   assert.ok(ids.has("gpt-5.4-mini"));
   assert.ok(ids.has("claude-opus-4.7"));
+  assert.ok(ids.has("claude-opus-4.6"));
   assert.ok(ids.has("claude-sonnet-4.6"));
   assert.ok(ids.has("gemini-3-flash-preview"));
   assert.equal(getModelTargetFormat("gh", "gpt-5.3-codex"), "openai-responses");
+  assert.equal(getModelTargetFormat("gh", "claude-opus-4.6"), null);
   assert.equal(ids.has("gpt-5.1"), false);
   assert.equal(ids.has("gpt-5.1-codex"), false);
   assert.equal(ids.has("claude-opus-4.1"), false);


### PR DESCRIPTION
GitHub Copilot Claude Opus 4.6 was incorrectly marked as an openai-responses model, which caused OmniRoute to send requests to /api.githubcopilot.com/responses.

For the current Copilot upstream behavior, claude-opus-4.6 works via /chat/completions and fails on /responses with
"unsupported_api_for_model".

This change removes the responses targetFormat override for gh/claude-opus-4.6 and adds regression coverage for the GitHub executor and provider model config.

## Summary

- Describe the user-facing or operational change.

## Related Issues

No related issues.

## Validation

- [x ] `npm run lint`
- [x] `npm run test:unit`
- [x] `npm run test:coverage`
- [x] Coverage is still `>= 60%` for statements, lines, functions, and branches
- [x ] SonarQube PR analysis is green or any remaining issues are explicitly documented below

## Tests Added Or Updated

- open-sse/config/providerRegistry.ts
- tests/unit/executor-github.test.ts
- tests/unit/provider-models-config.test.ts

## Coverage Notes

All code changes are fully covered by the newly added regression tests, and code coverage meets the requirements.

## Reviewer Notes

This change only adjusts model API configurations. There are no data migrations, feature flags or other potential risks.
Please verify manually: invoke the Claude Opus 4.6 model to confirm the API request works normally and the "unsupported API for model" error no longer occurs.