### PR TITLE
fix(sse): repair RTK engine defaults so dedup and direct calls work

### DIFF
--- a/open-sse/services/compression/engines/rtk/index.ts
+++ b/open-sse/services/compression/engines/rtk/index.ts
@@ -316,13 +316,11 @@ export function processRtkText(
     }
   }
 
-  if (config.intensity !== "minimal") {
-    const deduped = deduplicateRepeatedLines(result, { threshold: config.deduplicateThreshold });
-    if (deduped.collapsed > 0) {
-      result = deduped.text;
-      techniquesUsed.push("rtk-dedup");
-      rulesApplied.push("rtk:dedup");
-    }
+  const deduped = deduplicateRepeatedLines(result, { threshold: config.deduplicateThreshold });
+  if (deduped.collapsed > 0) {
+    result = deduped.text;
+    techniquesUsed.push("rtk-dedup");
+    rulesApplied.push("rtk:dedup");
   }
 
   const truncated = smartTruncate(result, {
@@ -441,7 +439,10 @@ export function applyRtkCompression(
     options.stepConfig && options.stepConfig.enabled === undefined
       ? { enabled: true, ...options.stepConfig }
       : options.stepConfig;
-  const config = mergeRtkConfig(options.config, stepConfig);
+  const explicitConfig = options.config && Object.keys(options.config).length > 0;
+  const baseConfig =
+    !explicitConfig && !stepConfig ? { enabled: true } : (options.config ?? {});
+  const config = mergeRtkConfig(baseConfig, stepConfig);
   if (!config.enabled) return { body, compressed: false, stats: null };
 
   const adapter = adaptBodyForCompression(body);


### PR DESCRIPTION
## Summary

Fixes 3 pre-existing failing tests in `tests/unit/compression/rtk-engine.test.ts` (on main as of writing) caused by two RTK engine defaults that made the compression engine effectively no-op when invoked without explicit config.

## The bugs

### 1. Consecutive-line dedup gated behind non-default intensity

```ts
// open-sse/services/compression/engines/rtk/index.ts:319 (before)
if (config.intensity !== "minimal") {
  const deduped = deduplicateRepeatedLines(...);
  ...
}
```

`processRtkText()` only ran `deduplicateRepeatedLines()` when intensity was non-minimal. But `DEFAULT_RTK_CONFIG.intensity = "minimal"` — so by default, runs of 20 identical lines passed through unchanged.

Collapsing 3+ consecutive identical lines into `line\n[line repeated Nx]\n[rtk:dropped N repeated lines]` is information-preserving (the count survives), so the gate had no semantic value while breaking the documented contract.

**Fix**: removed the gate. Dedup now runs at every intensity.

### 2. `applyRtkCompression()` no-op on direct invocation

```ts
// before
const stepConfig =
  options.stepConfig && options.stepConfig.enabled === undefined
    ? { enabled: true, ...options.stepConfig }
    : options.stepConfig;
const config = mergeRtkConfig(options.config, stepConfig);
if (!config.enabled) return { body, compressed: false, stats: null };
```

When called via a pipeline step (`stepConfig` present), the function correctly defaults `enabled: true`. But when called **directly** with no args (`applyRtkCompression(body)`), neither config nor stepConfig is set, so it falls through to `DEFAULT_RTK_CONFIG.enabled = false` and returns immediately.

This made every direct call a no-op unless the caller knew to pass `{ config: { enabled: true } }` — which contradicts the test suite's expectation that direct calls compress by default.

**Fix**: extended the default-enabled heuristic to cover the no-args case:

```ts
const explicitConfig = options.config && Object.keys(options.config).length > 0;
const baseConfig =
  !explicitConfig && !stepConfig ? { enabled: true } : (options.config ?? {});
```

Explicit `{ enabled: false }` overrides still work — only the truly-no-config path defaults to enabled.

## Test plan

- [x] `rtk-engine.test.ts`: was 6/9, now **9/9**
- [x] All `rtk-*.test.ts` files: **51/51 pass**
- [x] `compression-preview-auth.test.ts` failure is pre-existing and unrelated (SQLite infra issue, returns 503 instead of 403)

## Restored tests

- `compresses repeated tool output`
- `applies to chat tool messages`
- `compresses multipart text parts independently without duplicating output`