### PR TITLE
fix(antigravity): normalize tool calls and classify resource exhaustion as lockout

### DIFF
--- a/open-sse/executors/antigravity.ts
+++ b/open-sse/executors/antigravity.ts
@@ -123,9 +123,66 @@ function serializeAntigravityRequest(
 type AntigravityCollectedStream = {
   textContent: string;
   finishReason: string;
+  toolCalls: Array<{
+    id: string;
+    index: number;
+    type: "function";
+    function: { name: string; arguments: string };
+  }>;
   usage: Record<string, unknown> | null;
   remainingCredits: Array<{ creditType: string; creditAmount: string }> | null;
 };
+
+function stripZeroWidth(value: unknown): unknown {
+  if (typeof value === "string") {
+    return value.replace(/[\u200B-\u200D\uFEFF]/g, "");
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => stripZeroWidth(item));
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, item]) => [
+        key,
+        stripZeroWidth(item),
+      ])
+    );
+  }
+  return value;
+}
+
+function parseAntigravityTextualToolCall(text: unknown): { name: string; args: unknown } | null {
+  if (typeof text !== "string") return null;
+  const normalized = text.replace(/[\u200B-\u200D\uFEFF]/g, "");
+  const match = normalized.match(
+    /^[\s\S]*?\[Tool call:\s*([^\]\n]+)\]\s*\nArguments:\s*([\s\S]+?)\s*$/
+  );
+  if (!match) return null;
+  const name = match[1]?.trim();
+  const rawArgs = match[2]?.trim();
+  if (!name || !rawArgs) return null;
+  try {
+    return { name, args: stripZeroWidth(JSON.parse(rawArgs)) };
+  } catch {
+    return null;
+  }
+}
+
+function addAntigravityTextualToolCall(
+  collected: AntigravityCollectedStream,
+  parsed: { name: string; args: unknown }
+): void {
+  collected.toolCalls.push({
+    id: `${parsed.name}-${Date.now()}-${collected.toolCalls.length}`,
+    index: collected.toolCalls.length,
+    type: "function",
+    function: {
+      name: parsed.name,
+      arguments: JSON.stringify(parsed.args || {}),
+    },
+  });
+  collected.finishReason = "tool_calls";
+}
 
 type AntigravityRequestEnvelope = Record<string, unknown> & {
   project: string;
@@ -233,7 +290,12 @@ function processAntigravitySSEPayload(
     if (candidate?.content?.parts) {
       for (const part of candidate.content.parts) {
         if (typeof part.text === "string" && !part.thought && !part.thoughtSignature) {
-          collected.textContent += part.text;
+          const textualToolCall = parseAntigravityTextualToolCall(part.text);
+          if (textualToolCall) {
+            addAntigravityTextualToolCall(collected, textualToolCall);
+          } else {
+            collected.textContent += part.text;
+          }
         }
       }
     }
@@ -717,6 +779,7 @@ export class AntigravityExecutor extends BaseExecutor {
       const collected: AntigravityCollectedStream = {
         textContent: "",
         finishReason: "stop",
+        toolCalls: [],
         usage: null,
         remainingCredits: null,
       };
@@ -761,8 +824,19 @@ export class AntigravityExecutor extends BaseExecutor {
         choices: [
           {
             index: 0,
-            message: { role: "assistant", content: collected.textContent },
-            finish_reason: timedOut ? "length" : collected.finishReason,
+            message:
+              collected.toolCalls.length > 0
+                ? {
+                    role: "assistant",
+                    content: collected.textContent || null,
+                    tool_calls: collected.toolCalls,
+                  }
+                : { role: "assistant", content: collected.textContent },
+            finish_reason: timedOut
+              ? "length"
+              : collected.toolCalls.length > 0
+                ? "tool_calls"
+                : collected.finishReason,
           },
         ],
         ...(collected.usage && { usage: collected.usage }),

--- a/open-sse/handlers/responseSanitizer.ts
+++ b/open-sse/handlers/responseSanitizer.ts
@@ -46,6 +46,56 @@ function toNumber(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
+function stripZeroWidthText(value: string): string {
+  return value.replace(/[\u200B-\u200D\uFEFF]/g, "");
+}
+
+function stripZeroWidthValue(value: unknown): unknown {
+  if (typeof value === "string") return stripZeroWidthText(value);
+  if (Array.isArray(value)) return value.map((item) => stripZeroWidthValue(item));
+  const record = toRecord(value);
+  if (record) {
+    return Object.fromEntries(
+      Object.entries(record).map(([key, item]) => [key, stripZeroWidthValue(item)])
+    );
+  }
+  return value;
+}
+
+function parseTextualToolCallContent(content: unknown): { name: string; args: unknown } | null {
+  if (typeof content !== "string") return null;
+  const normalized = stripZeroWidthText(content);
+  const toolCallIndex = normalized.lastIndexOf("[Tool call:");
+  if (toolCallIndex < 0) return null;
+  const candidate = normalized.slice(toolCallIndex);
+  const headerMatch = candidate.match(/^\[Tool call:\s*([^\]\n]+)\]\s*\nArguments:\s*/);
+  if (!headerMatch) return null;
+  const name = headerMatch[1]?.trim();
+  const rawArgs = candidate.slice(headerMatch[0].length).trim();
+  if (!name || !rawArgs) return null;
+  const decoders = [
+    (value: string) => value,
+    (value: string) => {
+      if (value.startsWith('"') && value.endsWith('"')) {
+        const decoded = JSON.parse(value);
+        return typeof decoded === "string" ? decoded : value;
+      }
+      return value;
+    },
+  ];
+  for (const decode of decoders) {
+    try {
+      const decoded = decode(rawArgs);
+      return { name, args: stripZeroWidthValue(JSON.parse(decoded)) };
+    } catch {}
+  }
+  return null;
+}
+
+function containsTextualToolCallContent(content: unknown): boolean {
+  return typeof content === "string" && stripZeroWidthText(content).includes("[Tool call:");
+}
+
 function hasVisibleMessageContent(content: unknown): boolean {
   if (typeof content === "string") {
     return content.trim().length > 0;
@@ -127,9 +177,19 @@ export function sanitizeOpenAIResponse(body: unknown): unknown {
 
   // Sanitize choices
   if (Array.isArray(bodyRecord.choices)) {
-    sanitized.choices = bodyRecord.choices.map((choice, idx) =>
-      sanitizeChoice(choice, idx, isDeepSeekV4)
-    );
+    sanitized.choices = bodyRecord.choices.map((choice, idx) => {
+      const sanitizedChoice = sanitizeChoice(choice, idx, isDeepSeekV4);
+      const message = toRecord(sanitizedChoice.message);
+      if (
+        message &&
+        Array.isArray(message.tool_calls) &&
+        message.tool_calls.length > 0 &&
+        sanitizedChoice.finish_reason !== "tool_calls"
+      ) {
+        sanitizedChoice.finish_reason = "tool_calls";
+      }
+      return sanitizedChoice;
+    });
   } else {
     sanitized.choices = [];
   }
@@ -302,6 +362,23 @@ function sanitizeMessage(msg: unknown, isDeepSeekV4 = false): unknown {
     !isDeepSeekV4
   ) {
     delete sanitized.reasoning_content;
+  }
+
+  const textualToolCall = parseTextualToolCallContent(sanitized.content);
+  if (textualToolCall && !msgRecord.tool_calls) {
+    sanitized.content = null;
+    sanitized.tool_calls = [
+      {
+        id: `call_${Date.now()}_0`,
+        type: "function",
+        function: {
+          name: textualToolCall.name,
+          arguments: JSON.stringify(textualToolCall.args || {}),
+        },
+      },
+    ];
+  } else if (containsTextualToolCallContent(sanitized.content) && !msgRecord.tool_calls) {
+    sanitized.content = null;
   }
 
   // Preserve tool_calls

--- a/open-sse/handlers/responseTranslator.ts
+++ b/open-sse/handlers/responseTranslator.ts
@@ -34,6 +34,17 @@ function firstPositiveNumber(...values: unknown[]): number {
   return 0;
 }
 
+function normalizeToolCallArgs(args: unknown): unknown {
+  if (typeof args !== "string") return args;
+  const trimmed = args.trim();
+  if (!trimmed || !(trimmed.startsWith("{") || trimmed.startsWith("["))) return args;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return args;
+  }
+}
+
 function parseTextualToolCall(text: unknown): { name: string; args: unknown } | null {
   if (typeof text !== "string") return null;
 
@@ -50,10 +61,24 @@ function parseTextualToolCall(text: unknown): { name: string; args: unknown } | 
   const rawArgs = match[2]?.trim();
   if (!name || !rawArgs) return null;
   try {
-    return { name, args: JSON.parse(rawArgs) };
-  } catch {
-    return null;
-  }
+    let args = JSON.parse(rawArgs);
+    if (typeof args === "string") {
+      const trimmed = args.trim();
+      if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+        args = JSON.parse(trimmed);
+      }
+    }
+    if (args && typeof args === "object" && !Array.isArray(args)) {
+      return { name, args };
+    }
+  } catch {}
+  return null;
+}
+
+function containsTextualToolCallMarker(text: unknown): boolean {
+  return (
+    typeof text === "string" && text.replace(/[\u200B-\u200D\uFEFF]/g, "").includes("[Tool call:")
+  );
 }
 
 function extractMessageOutputText(item: JsonRecord): string {
@@ -335,7 +360,7 @@ export function translateNonStreamingResponse(
                           arguments: JSON.stringify(textualToolCall.args || {}),
                         },
                       });
-                    } else {
+                    } else if (!containsTextualToolCallMarker(partObj.text)) {
                       textContent += partObj.text;
                       contentParts.push({ type: "text", text: partObj.text });
                     }
@@ -378,7 +403,7 @@ export function translateNonStreamingResponse(
                       type: "function",
                       function: {
                         name: restoredName,
-                        arguments: JSON.stringify(fn.args || {}),
+                        arguments: JSON.stringify(normalizeToolCallArgs(fn.args || {})),
                       },
                     });
                   }

--- a/open-sse/handlers/responseTranslator.ts
+++ b/open-sse/handlers/responseTranslator.ts
@@ -34,6 +34,20 @@ function firstPositiveNumber(...values: unknown[]): number {
   return 0;
 }
 
+function parseTextualToolCall(text: unknown): { name: string; args: unknown } | null {
+  if (typeof text !== "string") return null;
+  const match = text.match(/^\s*\[Tool call:\s*([^\]\n]+)\]\s*\nArguments:\s*([\s\S]+?)\s*$/);
+  if (!match) return null;
+  const name = match[1]?.trim();
+  const rawArgs = match[2]?.trim();
+  if (!name || !rawArgs) return null;
+  try {
+    return { name, args: JSON.parse(rawArgs) };
+  } catch {
+    return null;
+  }
+}
+
 function extractMessageOutputText(item: JsonRecord): string {
   if (!Array.isArray(item.content)) return "";
   let text = "";
@@ -302,8 +316,21 @@ export function translateNonStreamingResponse(
                   }
 
                   if (typeof partObj.text === "string") {
-                    textContent += partObj.text;
-                    contentParts.push({ type: "text", text: partObj.text });
+                    const textualToolCall = parseTextualToolCall(partObj.text);
+                    if (textualToolCall) {
+                      const toolCallId = `call_${toString(textualToolCall.name, "unknown")}_${Date.now()}_${toolCalls.length}`;
+                      toolCalls.push({
+                        id: toolCallId,
+                        type: "function",
+                        function: {
+                          name: textualToolCall.name,
+                          arguments: JSON.stringify(textualToolCall.args || {}),
+                        },
+                      });
+                    } else {
+                      textContent += partObj.text;
+                      contentParts.push({ type: "text", text: partObj.text });
+                    }
                   }
 
                   const inlineData = toRecord(partObj.inlineData ?? partObj.inline_data);

--- a/open-sse/handlers/responseTranslator.ts
+++ b/open-sse/handlers/responseTranslator.ts
@@ -36,7 +36,15 @@ function firstPositiveNumber(...values: unknown[]): number {
 
 function parseTextualToolCall(text: unknown): { name: string; args: unknown } | null {
   if (typeof text !== "string") return null;
-  const match = text.match(/^\s*\[Tool call:\s*([^\]\n]+)\]\s*\nArguments:\s*([\s\S]+?)\s*$/);
+
+  // Gemini/Antigravity sometimes imitates the request-side fallback with small
+  // variations, e.g. a leading "(empty)" marker or zero-width chars inserted
+  // into argument strings. Normalize those variants before parsing so the
+  // response is still surfaced as a structured OpenAI tool call.
+  const normalized = text.replace(/[\u200B-\u200D\uFEFF]/g, "");
+  const match = normalized.match(
+    /^[\s\S]*?\[Tool call:\s*([^\]\n]+)\]\s*\nArguments:\s*([\s\S]+?)\s*$/
+  );
   if (!match) return null;
   const name = match[1]?.trim();
   const rawArgs = match[2]?.trim();

--- a/open-sse/services/accountFallback.ts
+++ b/open-sse/services/accountFallback.ts
@@ -109,6 +109,9 @@ export const CREDITS_EXHAUSTED_SIGNALS = [
   "credits exhausted",
   "out of credits",
   "payment required",
+  "resource has been exhausted",
+  "resource_exhausted",
+  "check quota",
 ];
 
 // T11: Signals that indicate OAuth token is invalid/expired (not permanent deactivation)

--- a/open-sse/translator/request/openai-to-gemini.ts
+++ b/open-sse/translator/request/openai-to-gemini.ts
@@ -347,12 +347,18 @@ function openaiToGeminiBase(model, body, stream, toolNameOptions: GeminiToolName
           }
 
           // Check if there are actual tool responses in the next messages
-          const hasSignaturelessTextResponses =
-            stringifySignaturelessToolCalls &&
-            msg.tool_calls.some(
-              (tc) =>
-                tc.type === "function" && !resolvedSignatures.has(tc.id) && toolResponses[tc.id]
-            );
+          const signaturelessToolCallIds = stringifySignaturelessToolCalls
+            ? msg.tool_calls
+                .filter(
+                  (tc) =>
+                    tc.type === "function" &&
+                    tc.id &&
+                    !resolvedSignatures.has(tc.id) &&
+                    toolResponses[tc.id]
+                )
+                .map((tc) => tc.id)
+            : [];
+          const hasSignaturelessTextResponses = signaturelessToolCallIds.length > 0;
           const hasActualResponses =
             toolCallIds.some((fid) => toolResponses[fid]) || hasSignaturelessTextResponses;
 
@@ -398,7 +404,7 @@ function openaiToGeminiBase(model, body, stream, toolNameOptions: GeminiToolName
               // functionResponse parts missing a matching thoughtSignature.
               for (const tc of msg.tool_calls) {
                 if (tc.type !== "function" || !tc.id) continue;
-                if (!resolvedSignatures.has(tc.id) && toolResponses[tc.id]) {
+                if (signaturelessToolCallIds.includes(tc.id)) {
                   const name = tcID2Name[tc.id] || tc.function?.name || "unknown";
                   const resp = toolResponses[tc.id];
                   toolParts.push({
@@ -605,6 +611,16 @@ function getAntigravityClaudeOutputTokens(body: Record<string, unknown>): number
 // OpenAI -> Antigravity (Sandbox Cloud Code with wrapper)
 export function openaiToAntigravityRequest(model, body, stream, credentials = null) {
   const isClaude = model.toLowerCase().includes("claude");
+  // All modern Gemini models (2.5+, 3.x, pro-agent, etc.) use thinking by default
+  // and require thought_signature for multi-turn tool calls.
+  // Safe default: all non-Claude models via Antigravity are thinking Gemini.
+  const modelLower = model.toLowerCase();
+  const isThinkingGemini =
+    !isClaude &&
+    (modelLower.includes("thinking") ||
+      modelLower.includes("gemini-3") ||
+      modelLower.includes("gemini-2.5") ||
+      modelLower.includes("gemini-pro"));
   const signatureNamespace =
     credentials &&
     typeof credentials === "object" &&
@@ -613,7 +629,7 @@ export function openaiToAntigravityRequest(model, body, stream, credentials = nu
       : null;
   const geminiCLI = openaiToGeminiCLIRequest(model, body, stream, {
     signatureNamespace,
-    signaturelessToolCallMode: isClaude ? "native" : "text",
+    signaturelessToolCallMode: isThinkingGemini ? "text" : "native",
   });
 
   if (isClaude) {

--- a/open-sse/translator/response/gemini-to-openai.ts
+++ b/open-sse/translator/response/gemini-to-openai.ts
@@ -23,6 +23,17 @@ type GeminiFunctionCallPart = {
   };
 };
 
+function normalizeToolCallArgs(args: unknown): unknown {
+  if (typeof args !== "string") return args;
+  const trimmed = args.trim();
+  if (!trimmed || !(trimmed.startsWith("{") || trimmed.startsWith("["))) return args;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return args;
+  }
+}
+
 function parseTextualToolCall(text: unknown): { name: string; args: unknown } | null {
   if (typeof text !== "string") return null;
 
@@ -39,10 +50,24 @@ function parseTextualToolCall(text: unknown): { name: string; args: unknown } | 
   const rawArgs = match[2]?.trim();
   if (!name || !rawArgs) return null;
   try {
-    return { name, args: JSON.parse(rawArgs) };
-  } catch {
-    return null;
-  }
+    let args = JSON.parse(rawArgs);
+    if (typeof args === "string") {
+      const trimmed = args.trim();
+      if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+        args = JSON.parse(trimmed);
+      }
+    }
+    if (args && typeof args === "object" && !Array.isArray(args)) {
+      return { name, args };
+    }
+  } catch {}
+  return null;
+}
+
+function containsTextualToolCallMarker(text: unknown): boolean {
+  return (
+    typeof text === "string" && text.replace(/[\u200B-\u200D\uFEFF]/g, "").includes("[Tool call:")
+  );
 }
 
 function buildToolCallId(
@@ -69,7 +94,7 @@ function emitFunctionCallPart(
 ) {
   const rawToolName = part.functionCall.name;
   const fcName = state.toolNameMap?.get(rawToolName) || rawToolName;
-  const fcArgs = part.functionCall.args || {};
+  const fcArgs = normalizeToolCallArgs(part.functionCall.args || {});
   const toolCallIndex = state.functionIndex++;
   const toolCall = {
     id: buildToolCallId(part.functionCall, fcName, toolCallIndex),
@@ -240,6 +265,14 @@ export function geminiToOpenAIResponse(chunk, state) {
             state,
             results
           );
+          continue;
+        }
+
+        // Never leak a malformed textual pseudo tool-call to clients. If the
+        // model emits the marker but the arguments are not parseable yet/at all,
+        // suppress the text; the final finish reason remains `stop` unless a
+        // structured tool call was emitted elsewhere.
+        if (containsTextualToolCallMarker(part.text)) {
           continue;
         }
 

--- a/open-sse/translator/response/gemini-to-openai.ts
+++ b/open-sse/translator/response/gemini-to-openai.ts
@@ -23,6 +23,20 @@ type GeminiFunctionCallPart = {
   };
 };
 
+function parseTextualToolCall(text: unknown): { name: string; args: unknown } | null {
+  if (typeof text !== "string") return null;
+  const match = text.match(/^\s*\[Tool call:\s*([^\]\n]+)\]\s*\nArguments:\s*([\s\S]+?)\s*$/);
+  if (!match) return null;
+  const name = match[1]?.trim();
+  const rawArgs = match[2]?.trim();
+  if (!name || !rawArgs) return null;
+  try {
+    return { name, args: JSON.parse(rawArgs) };
+  } catch {
+    return null;
+  }
+}
+
 function buildToolCallId(
   functionCall: GeminiFunctionCallPart["functionCall"],
   toolName: string,
@@ -169,6 +183,15 @@ export function geminiToOpenAIResponse(chunk, state) {
         const hasTextContent = part.text !== undefined && part.text !== "";
         const hasFunctionCall = !!part.functionCall;
 
+        // Gemini/Antigravity can emit thoughtSignature as a standalone part
+        // immediately before the functionCall part. Keep it pending so the
+        // following functionCall is cached and can be re-attached on later
+        // turns; otherwise OpenAI-format clients lose the signature and the
+        // next Gemini request has to stringify historical tool calls.
+        if (hasThoughtSig && !hasTextContent && !hasFunctionCall) {
+          continue;
+        }
+
         if (hasTextContent) {
           results.push({
             id: `chatcmpl-${state.messageId}`,
@@ -191,8 +214,27 @@ export function geminiToOpenAIResponse(chunk, state) {
         continue;
       }
 
-      // Text content (non-thinking)
+      // Text content (non-thinking). Some Gemini/Antigravity turns can imitate
+      // the request-side signatureless history fallback and emit a textual
+      // "[Tool call: ...]" block instead of native functionCall. Convert that
+      // back to a structured OpenAI tool call so clients/tools do not see it as
+      // assistant prose.
       if (part.text !== undefined && part.text !== "") {
+        const textualToolCall = parseTextualToolCall(part.text);
+        if (textualToolCall) {
+          emitFunctionCallPart(
+            {
+              functionCall: {
+                name: textualToolCall.name,
+                args: textualToolCall.args,
+              },
+            },
+            state,
+            results
+          );
+          continue;
+        }
+
         results.push({
           id: `chatcmpl-${state.messageId}`,
           object: "chat.completion.chunk",

--- a/open-sse/translator/response/gemini-to-openai.ts
+++ b/open-sse/translator/response/gemini-to-openai.ts
@@ -25,7 +25,15 @@ type GeminiFunctionCallPart = {
 
 function parseTextualToolCall(text: unknown): { name: string; args: unknown } | null {
   if (typeof text !== "string") return null;
-  const match = text.match(/^\s*\[Tool call:\s*([^\]\n]+)\]\s*\nArguments:\s*([\s\S]+?)\s*$/);
+
+  // Gemini/Antigravity sometimes imitates the request-side fallback with small
+  // variations, e.g. a leading "(empty)" marker or zero-width chars inserted
+  // into argument strings. Normalize those variants before parsing so the
+  // response is still surfaced as a structured OpenAI tool call.
+  const normalized = text.replace(/[\u200B-\u200D\uFEFF]/g, "");
+  const match = normalized.match(
+    /^[\s\S]*?\[Tool call:\s*([^\]\n]+)\]\s*\nArguments:\s*([\s\S]+?)\s*$/
+  );
   if (!match) return null;
   const name = match[1]?.trim();
   const rawArgs = match[2]?.trim();

--- a/open-sse/utils/stream.ts
+++ b/open-sse/utils/stream.ts
@@ -249,11 +249,11 @@ function containsMalformedTextualToolCall(text: unknown): boolean {
 function collectPassthroughTextualToolCall(
   text: string,
   toolCalls: Map<string, ToolCall>
-): boolean {
+): ToolCall | null {
   const parsed = parseTextualToolCallFromContent(text);
-  if (!parsed) return false;
+  if (!parsed) return null;
   const key = `textual:${toolCalls.size}`;
-  toolCalls.set(key, {
+  const toolCall: ToolCall = {
     id: `call_${Date.now()}_${toolCalls.size}`,
     index: toolCalls.size,
     type: "function",
@@ -261,8 +261,21 @@ function collectPassthroughTextualToolCall(
       name: parsed.name,
       arguments: JSON.stringify(parsed.args || {}),
     },
-  });
-  return true;
+  };
+  toolCalls.set(key, toolCall);
+  return toolCall;
+}
+
+function toStreamingToolCallDelta(toolCall: ToolCall) {
+  return {
+    index: toolCall.index,
+    id: toolCall.id,
+    type: toolCall.type,
+    function: {
+      name: toolCall.function.name,
+      arguments: toolCall.function.arguments,
+    },
+  };
 }
 
 function toStreamFailureStatus(value: unknown): number | null {
@@ -1384,11 +1397,17 @@ export function createSSEStream(options: StreamOptions = {}) {
                     ) {
                       const parsedCandidate = parseTextualToolCallCandidate(bufferedCandidate);
                       if (parsedCandidate?.kind === "complete") {
-                        collectPassthroughTextualToolCall(bufferedCandidate, passthroughToolCalls);
+                        const collectedToolCall = collectPassthroughTextualToolCall(
+                          bufferedCandidate,
+                          passthroughToolCalls
+                        );
+                        if (collectedToolCall) {
+                          delta.tool_calls = [toStreamingToolCallDelta(collectedToolCall)];
+                        }
                         passthroughHasToolCalls = true;
                         textualToolCallConverted = true;
                         passthroughBufferedTextualToolCallContent = "";
-                        delta.content = "";
+                        delete delta.content;
                       } else if (parsedCandidate?.kind === "partial") {
                         passthroughBufferedTextualToolCallContent = appendBoundedText(
                           passthroughBufferedTextualToolCallContent,

--- a/open-sse/utils/stream.ts
+++ b/open-sse/utils/stream.ts
@@ -300,6 +300,79 @@ function toStreamingToolCallDelta(toolCall: ToolCall) {
   };
 }
 
+function toResponsesFunctionCallItem(toolCall: ToolCall) {
+  return {
+    type: "function_call",
+    id: toolCall.id || `fc_${toolCall.index}`,
+    call_id: toolCall.id || `call_${toolCall.index}`,
+    name: toolCall.function.name,
+    arguments: toolCall.function.arguments,
+    status: "completed",
+  };
+}
+
+function buildResponsesFunctionCallEvents(toolCall: ToolCall) {
+  const item = toResponsesFunctionCallItem(toolCall);
+  return [
+    {
+      type: "response.output_item.added",
+      output_index: toolCall.index,
+      item,
+    },
+    {
+      type: "response.function_call_arguments.done",
+      item_id: item.id,
+      output_index: toolCall.index,
+      arguments: toolCall.function.arguments,
+    },
+    {
+      type: "response.output_item.done",
+      output_index: toolCall.index,
+      item,
+    },
+  ];
+}
+
+function formatSSEDataEvents(events: unknown[]) {
+  return events.map((event) => `data: ${JSON.stringify(event)}\n`).join("\n");
+}
+
+function toChatCompletionChunkWithToolCall(base: JsonRecord, toolCall: ToolCall) {
+  const choice = asRecord(Array.isArray(base.choices) ? base.choices[0] : null);
+  const delta = { ...asRecord(choice.delta) };
+  delete delta.content;
+  delete delta.reasoning_content;
+  return {
+    ...base,
+    choices: [
+      {
+        ...choice,
+        index: typeof choice.index === "number" ? choice.index : 0,
+        delta: {
+          ...delta,
+          tool_calls: [toStreamingToolCallDelta(toolCall)],
+        },
+        finish_reason: null,
+      },
+    ],
+  };
+}
+
+function toResponsesCompletedWithToolCalls(parsed: JsonRecord, toolCalls: ToolCall[]) {
+  const response = asRecord(parsed.response);
+  const existingOutput = Array.isArray(response.output) ? response.output : [];
+  return {
+    ...parsed,
+    response: {
+      ...response,
+      output: [
+        ...existingOutput,
+        ...toolCalls.map((toolCall) => toResponsesFunctionCallItem(toolCall)),
+      ],
+    },
+  };
+}
+
 function toStreamFailureStatus(value: unknown): number | null {
   if (typeof value === "number" && Number.isInteger(value) && value >= 400 && value <= 599) {
     return value;
@@ -1133,10 +1206,57 @@ export function createSSEStream(options: StreamOptions = {}) {
                     parsed.type === "response.output_text.delta" &&
                     typeof parsed.delta === "string"
                   ) {
-                    passthroughAccumulatedContent = appendBoundedText(
-                      passthroughAccumulatedContent,
-                      parsed.delta
-                    );
+                    const incomingDelta = parsed.delta;
+                    const bufferedCandidate =
+                      passthroughBufferedTextualToolCallContent + incomingDelta;
+                    if (
+                      passthroughBufferedTextualToolCallContent ||
+                      containsTextualToolCallCandidate(incomingDelta)
+                    ) {
+                      const parsedCandidate = parseTextualToolCallCandidate(bufferedCandidate);
+                      if (parsedCandidate?.kind === "complete") {
+                        const collectedToolCall = collectPassthroughTextualToolCall(
+                          bufferedCandidate,
+                          passthroughToolCalls,
+                          allowedToolNames
+                        );
+                        if (collectedToolCall) {
+                          passthroughHasToolCalls = true;
+                          const responseToolCallEvents =
+                            buildResponsesFunctionCallEvents(collectedToolCall);
+                          output = formatSSEDataEvents(responseToolCallEvents);
+                          clientPayloadCollector.push(...responseToolCallEvents);
+                          reqLogger?.appendConvertedChunk?.(output);
+                          controller.enqueue(encoder.encode(output));
+                          injectedUsage = true;
+                        } else {
+                          output = `data: ${JSON.stringify(parsed)}
+`;
+                          injectedUsage = true;
+                        }
+                        passthroughBufferedTextualToolCallContent = "";
+                        parsed.delta = "";
+                      } else if (parsedCandidate?.kind === "partial") {
+                        passthroughBufferedTextualToolCallContent = appendBoundedText(
+                          passthroughBufferedTextualToolCallContent,
+                          incomingDelta
+                        );
+                        parsed.delta = "";
+                        output = `data: ${JSON.stringify(parsed)}\n`;
+                        injectedUsage = true;
+                      } else {
+                        passthroughAccumulatedContent = appendBoundedText(
+                          passthroughAccumulatedContent,
+                          passthroughBufferedTextualToolCallContent + incomingDelta
+                        );
+                        passthroughBufferedTextualToolCallContent = "";
+                      }
+                    } else {
+                      passthroughAccumulatedContent = appendBoundedText(
+                        passthroughAccumulatedContent,
+                        incomingDelta
+                      );
+                    }
                   }
                   if (parsed.type === "response.failed") {
                     failurePayload = normalizeStreamFailurePayload(parsed);
@@ -1251,12 +1371,19 @@ export function createSSEStream(options: StreamOptions = {}) {
                   //      upstream sent it empty (store: false) — some clients
                   //      build their tool-call list from that snapshot rather
                   //      than from per-item events.
+                  const textualToolCallBackfilled =
+                    parsed.type === "response.completed" && passthroughToolCalls.size > 0;
+                  if (textualToolCallBackfilled) {
+                    parsed = toResponsesCompletedWithToolCalls(parsed as JsonRecord, [
+                      ...passthroughToolCalls.values(),
+                    ]) as typeof parsed;
+                  }
                   const stripped = stripResponsesLifecycleEcho(parsed);
                   const backfilled = backfillResponsesCompletedOutput(
                     parsed,
                     passthroughResponsesOutputItems
                   );
-                  if (stripped || backfilled) {
+                  if (stripped || backfilled || textualToolCallBackfilled) {
                     output = `data: ${JSON.stringify(parsed)}\n`;
                     injectedUsage = true;
                   }
@@ -1309,8 +1436,7 @@ export function createSSEStream(options: StreamOptions = {}) {
                     );
                   }
                   if (restoredToolName) {
-                    output = `data: ${JSON.stringify(parsed)}
-`;
+                    output = `data: ${JSON.stringify(parsed)}\n`;
                     injectedUsage = true;
                   }
                 } else {
@@ -1426,12 +1552,17 @@ export function createSSEStream(options: StreamOptions = {}) {
                           allowedToolNames
                         );
                         if (collectedToolCall) {
-                          delta.tool_calls = [toStreamingToolCallDelta(collectedToolCall)];
+                          parsed = toChatCompletionChunkWithToolCall(
+                            parsed as JsonRecord,
+                            collectedToolCall
+                          ) as typeof parsed;
                           passthroughHasToolCalls = true;
+                        } else {
+                          delete delta.content;
+                          delete delta.reasoning_content;
                         }
                         textualToolCallConverted = true;
                         passthroughBufferedTextualToolCallContent = "";
-                        delete delta.content;
                       } else if (parsedCandidate?.kind === "partial") {
                         passthroughBufferedTextualToolCallContent = appendBoundedText(
                           passthroughBufferedTextualToolCallContent,

--- a/open-sse/utils/stream.ts
+++ b/open-sse/utils/stream.ts
@@ -840,6 +840,64 @@ export function createSSEStream(options: StreamOptions = {}) {
     return output;
   };
 
+  const applyTextualToolCallStreamingGuard = (parsed: Record<string, unknown>) => {
+    const choice = Array.isArray((parsed as JsonRecord).choices)
+      ? (((parsed as JsonRecord).choices as unknown[])[0] as JsonRecord | undefined)
+      : undefined;
+    const delta = asRecord(choice?.delta);
+    let textualToolCallConverted = false;
+
+    if (typeof delta?.content === "string") {
+      const incomingContent = delta.content;
+      const bufferedCandidate = passthroughBufferedTextualToolCallContent + incomingContent;
+      if (
+        passthroughBufferedTextualToolCallContent ||
+        containsTextualToolCallCandidate(incomingContent)
+      ) {
+        const parsedCandidate = parseTextualToolCallCandidate(bufferedCandidate);
+        if (parsedCandidate?.kind === "complete") {
+          const collectedToolCall = collectPassthroughTextualToolCall(
+            bufferedCandidate,
+            passthroughToolCalls,
+            allowedToolNames
+          );
+          if (collectedToolCall) {
+            parsed = toChatCompletionChunkWithToolCall(
+              parsed as JsonRecord,
+              collectedToolCall
+            ) as typeof parsed;
+            passthroughHasToolCalls = true;
+          } else {
+            delete delta.content;
+            delete delta.reasoning_content;
+          }
+          textualToolCallConverted = true;
+          passthroughBufferedTextualToolCallContent = "";
+        } else if (parsedCandidate?.kind === "partial") {
+          passthroughBufferedTextualToolCallContent = appendBoundedText(
+            passthroughBufferedTextualToolCallContent,
+            incomingContent
+          );
+          textualToolCallConverted = true;
+          delta.content = "";
+        } else {
+          passthroughAccumulatedContent = appendBoundedText(
+            passthroughAccumulatedContent,
+            passthroughBufferedTextualToolCallContent + incomingContent
+          );
+          passthroughBufferedTextualToolCallContent = "";
+        }
+      } else {
+        passthroughAccumulatedContent = appendBoundedText(
+          passthroughAccumulatedContent,
+          incomingContent
+        );
+      }
+    }
+
+    return { parsed, textualToolCallConverted };
+  };
+
   const emitSyntheticClaudeEmptyResponse = (
     controller: TransformStreamDefaultController,
     options: {
@@ -1536,53 +1594,12 @@ export function createSSEStream(options: StreamOptions = {}) {
                   if (content && typeof content === "string") {
                     totalContentLength += content.length;
                   }
-                  if (typeof delta?.content === "string") {
-                    const incomingContent = delta.content;
-                    const bufferedCandidate =
-                      passthroughBufferedTextualToolCallContent + incomingContent;
-                    if (
-                      passthroughBufferedTextualToolCallContent ||
-                      containsTextualToolCallCandidate(incomingContent)
-                    ) {
-                      const parsedCandidate = parseTextualToolCallCandidate(bufferedCandidate);
-                      if (parsedCandidate?.kind === "complete") {
-                        const collectedToolCall = collectPassthroughTextualToolCall(
-                          bufferedCandidate,
-                          passthroughToolCalls,
-                          allowedToolNames
-                        );
-                        if (collectedToolCall) {
-                          parsed = toChatCompletionChunkWithToolCall(
-                            parsed as JsonRecord,
-                            collectedToolCall
-                          ) as typeof parsed;
-                          passthroughHasToolCalls = true;
-                        } else {
-                          delete delta.content;
-                          delete delta.reasoning_content;
-                        }
-                        textualToolCallConverted = true;
-                        passthroughBufferedTextualToolCallContent = "";
-                      } else if (parsedCandidate?.kind === "partial") {
-                        passthroughBufferedTextualToolCallContent = appendBoundedText(
-                          passthroughBufferedTextualToolCallContent,
-                          incomingContent
-                        );
-                        textualToolCallConverted = true;
-                        delta.content = "";
-                      } else {
-                        passthroughAccumulatedContent = appendBoundedText(
-                          passthroughAccumulatedContent,
-                          passthroughBufferedTextualToolCallContent + incomingContent
-                        );
-                        passthroughBufferedTextualToolCallContent = "";
-                      }
-                    } else {
-                      passthroughAccumulatedContent = appendBoundedText(
-                        passthroughAccumulatedContent,
-                        incomingContent
-                      );
-                    }
+                  {
+                    const guarded = applyTextualToolCallStreamingGuard(
+                      parsed as Record<string, unknown>
+                    );
+                    parsed = guarded.parsed as typeof parsed;
+                    textualToolCallConverted = guarded.textualToolCallConverted;
                   }
                   if (typeof delta?.reasoning_content === "string")
                     passthroughAccumulatedReasoning = appendBoundedText(

--- a/open-sse/utils/stream.ts
+++ b/open-sse/utils/stream.ts
@@ -202,18 +202,31 @@ function stripZeroWidth(value: unknown): unknown {
 function parseTextualToolCallFromContent(text: unknown): { name: string; args: unknown } | null {
   if (typeof text !== "string") return null;
   const normalized = text.replace(/[\u200B-\u200D\uFEFF]/g, "");
-  const match = normalized.match(
-    /^[\s\S]*?\[Tool call:\s*([^\]\n]+)\]\s*\nArguments:\s*([\s\S]+?)\s*$/
-  );
-  if (!match) return null;
-  const name = match[1]?.trim();
-  const rawArgs = match[2]?.trim();
+  const toolCallIndex = normalized.lastIndexOf("[Tool call:");
+  const candidate = toolCallIndex >= 0 ? normalized.slice(toolCallIndex) : normalized;
+  const headerMatch = candidate.match(/^\[Tool call:\s*([^\]\n]+)\]\s*\nArguments:\s*/);
+  if (!headerMatch) return null;
+  const name = headerMatch[1]?.trim();
+  const rawArgs = candidate.slice(headerMatch[0].length).trim();
   if (!name || !rawArgs) return null;
-  try {
-    return { name, args: stripZeroWidth(JSON.parse(rawArgs)) };
-  } catch {
-    return null;
+  const decoders = [
+    (value: string) => value,
+    (value: string) => {
+      if (value.startsWith('"') && value.endsWith('"')) {
+        const decoded = JSON.parse(value);
+        return typeof decoded === "string" ? decoded : value;
+      }
+      return value;
+    },
+  ];
+  for (const decode of decoders) {
+    try {
+      const decoded = decode(rawArgs);
+      const parsed = JSON.parse(decoded);
+      return { name, args: stripZeroWidth(parsed) };
+    } catch {}
   }
+  return null;
 }
 
 function collectPassthroughTextualToolCall(
@@ -1679,7 +1692,11 @@ export function createSSEStream(options: StreamOptions = {}) {
                 const u = usage as Record<string, unknown> | null;
                 const prompt = Number(u?.prompt_tokens ?? u?.input_tokens ?? 0);
                 const completion = Number(u?.completion_tokens ?? u?.output_tokens ?? 0);
-                const content = passthroughAccumulatedContent.trim() || "";
+                let content = passthroughAccumulatedContent.trim() || "";
+                if (content && collectPassthroughTextualToolCall(content, passthroughToolCalls)) {
+                  passthroughHasToolCalls = true;
+                  content = "";
+                }
                 const message: Record<string, unknown> = {
                   role: "assistant",
                   content: content || null,
@@ -1892,27 +1909,42 @@ export function createSSEStream(options: StreamOptions = {}) {
               const u = state?.usage as Record<string, unknown> | null | undefined;
               const prompt = Number(u?.prompt_tokens ?? u?.input_tokens ?? 0);
               const completion = Number(u?.completion_tokens ?? u?.output_tokens ?? 0);
-              const content = (state?.accumulatedContent ?? "").trim() || "";
+              let content = (state?.accumulatedContent ?? "").trim() || "";
+              const normalizedToolCalls: ToolCall[] = state?.toolCalls?.size
+                ? [...state.toolCalls.values()]
+                    .map(
+                      (tc: Record<string, unknown>): ToolCall => ({
+                        id: (tc.id as string) ?? null,
+                        index: (tc.index as number) ?? (tc.blockIndex as number) ?? 0,
+                        type: (tc.type as string) ?? "function",
+                        function: (tc.function as ToolCall["function"]) ?? {
+                          name: (tc.name as string) ?? "",
+                          arguments: "",
+                        },
+                      })
+                    )
+                    .sort((a, b) => a.index - b.index)
+                : [];
+              const textualToolCall = parseTextualToolCallFromContent(content);
+              if (textualToolCall) {
+                normalizedToolCalls.push({
+                  id: `call_${Date.now()}_${normalizedToolCalls.length}`,
+                  index: normalizedToolCalls.length,
+                  type: "function",
+                  function: {
+                    name: textualToolCall.name,
+                    arguments: JSON.stringify(textualToolCall.args || {}),
+                  },
+                });
+                content = "";
+              }
               const message: Record<string, unknown> = {
                 role: "assistant",
                 content: content || null,
               };
-              const hasToolCalls = state?.toolCalls?.size > 0;
+              const hasToolCalls = normalizedToolCalls.length > 0;
               if (hasToolCalls) {
-                // Normalize shape — translators may store different structures
-                message.tool_calls = [...state.toolCalls.values()]
-                  .map(
-                    (tc: Record<string, unknown>): ToolCall => ({
-                      id: (tc.id as string) ?? null,
-                      index: (tc.index as number) ?? (tc.blockIndex as number) ?? 0,
-                      type: (tc.type as string) ?? "function",
-                      function: (tc.function as ToolCall["function"]) ?? {
-                        name: (tc.name as string) ?? "",
-                        arguments: "",
-                      },
-                    })
-                  )
-                  .sort((a, b) => a.index - b.index);
+                message.tool_calls = normalizedToolCalls;
               }
               const responseBody = {
                 choices: [

--- a/open-sse/utils/stream.ts
+++ b/open-sse/utils/stream.ts
@@ -246,12 +246,34 @@ function containsMalformedTextualToolCall(text: unknown): boolean {
   return text.replace(/[\u200B-\u200D\uFEFF]/g, "").includes("[Tool call:");
 }
 
+function extractAllowedToolNames(body: unknown): Set<string> | null {
+  const record = asRecord(body);
+  const tools = record.tools;
+  if (!Array.isArray(tools)) return null;
+  const names = new Set<string>();
+  for (const tool of tools) {
+    if (!tool || typeof tool !== "object" || Array.isArray(tool)) continue;
+    const item = tool as JsonRecord;
+    const directName = typeof item.name === "string" ? item.name.trim() : "";
+    const fn =
+      item.function && typeof item.function === "object" && !Array.isArray(item.function)
+        ? (item.function as JsonRecord)
+        : null;
+    const functionName = typeof fn?.name === "string" ? fn.name.trim() : "";
+    const name = functionName || directName;
+    if (name) names.add(name);
+  }
+  return names.size > 0 ? names : null;
+}
+
 function collectPassthroughTextualToolCall(
   text: string,
-  toolCalls: Map<string, ToolCall>
+  toolCalls: Map<string, ToolCall>,
+  allowedToolNames?: Set<string> | null
 ): ToolCall | null {
   const parsed = parseTextualToolCallFromContent(text);
   if (!parsed) return null;
+  if (allowedToolNames?.size && !allowedToolNames.has(parsed.name)) return null;
   const key = `textual:${toolCalls.size}`;
   const toolCall: ToolCall = {
     id: `call_${Date.now()}_${toolCalls.size}`,
@@ -669,6 +691,7 @@ export function createSSEStream(options: StreamOptions = {}) {
   /** Passthrough: accumulate tool_calls deltas for call log responseBody */
   const passthroughToolCalls = new Map<string, ToolCall>();
   let passthroughToolCallSeq = 0;
+  const allowedToolNames = extractAllowedToolNames(body);
   let skipPassthroughEvent = false;
 
   // State for translate mode (accumulatedContent for call log response body)
@@ -1399,12 +1422,13 @@ export function createSSEStream(options: StreamOptions = {}) {
                       if (parsedCandidate?.kind === "complete") {
                         const collectedToolCall = collectPassthroughTextualToolCall(
                           bufferedCandidate,
-                          passthroughToolCalls
+                          passthroughToolCalls,
+                          allowedToolNames
                         );
                         if (collectedToolCall) {
                           delta.tool_calls = [toStreamingToolCallDelta(collectedToolCall)];
+                          passthroughHasToolCalls = true;
                         }
-                        passthroughHasToolCalls = true;
                         textualToolCallConverted = true;
                         passthroughBufferedTextualToolCallContent = "";
                         delete delta.content;
@@ -1760,14 +1784,18 @@ export function createSSEStream(options: StreamOptions = {}) {
                   if (
                     collectPassthroughTextualToolCall(
                       finalBufferedTextualToolCall,
-                      passthroughToolCalls
+                      passthroughToolCalls,
+                      allowedToolNames
                     )
                   ) {
                     passthroughHasToolCalls = true;
                   }
                   passthroughBufferedTextualToolCallContent = "";
                 }
-                if (content && collectPassthroughTextualToolCall(content, passthroughToolCalls)) {
+                if (
+                  content &&
+                  collectPassthroughTextualToolCall(content, passthroughToolCalls, allowedToolNames)
+                ) {
                   passthroughHasToolCalls = true;
                   content = "";
                 } else if (containsMalformedTextualToolCall(content)) {

--- a/open-sse/utils/stream.ts
+++ b/open-sse/utils/stream.ts
@@ -199,16 +199,19 @@ function stripZeroWidth(value: unknown): unknown {
   return value;
 }
 
-function parseTextualToolCallFromContent(text: unknown): { name: string; args: unknown } | null {
+function parseTextualToolCallCandidate(
+  text: unknown
+): { kind: "complete"; name: string; args: unknown } | { kind: "partial" } | null {
   if (typeof text !== "string") return null;
   const normalized = text.replace(/[\u200B-\u200D\uFEFF]/g, "");
   const toolCallIndex = normalized.lastIndexOf("[Tool call:");
-  const candidate = toolCallIndex >= 0 ? normalized.slice(toolCallIndex) : normalized;
+  if (toolCallIndex < 0) return null;
+  const candidate = normalized.slice(toolCallIndex);
   const headerMatch = candidate.match(/^\[Tool call:\s*([^\]\n]+)\]\s*\nArguments:\s*/);
-  if (!headerMatch) return null;
+  if (!headerMatch) return { kind: "partial" };
   const name = headerMatch[1]?.trim();
   const rawArgs = candidate.slice(headerMatch[0].length).trim();
-  if (!name || !rawArgs) return null;
+  if (!name || !rawArgs) return { kind: "partial" };
   const decoders = [
     (value: string) => value,
     (value: string) => {
@@ -223,10 +226,19 @@ function parseTextualToolCallFromContent(text: unknown): { name: string; args: u
     try {
       const decoded = decode(rawArgs);
       const parsed = JSON.parse(decoded);
-      return { name, args: stripZeroWidth(parsed) };
+      return { kind: "complete", name, args: stripZeroWidth(parsed) };
     } catch {}
   }
-  return null;
+  return { kind: "partial" };
+}
+
+function parseTextualToolCallFromContent(text: unknown): { name: string; args: unknown } | null {
+  const candidate = parseTextualToolCallCandidate(text);
+  return candidate?.kind === "complete" ? { name: candidate.name, args: candidate.args } : null;
+}
+
+function containsTextualToolCallCandidate(text: unknown): boolean {
+  return parseTextualToolCallCandidate(text) !== null;
 }
 
 function collectPassthroughTextualToolCall(
@@ -659,6 +671,7 @@ export function createSSEStream(options: StreamOptions = {}) {
   // Passthrough: accumulate content and reasoning separately for call log response body
   let passthroughAccumulatedContent = "";
   let passthroughAccumulatedReasoning = "";
+  let passthroughBufferedTextualToolCallContent = "";
   // Passthrough Responses SSE: snapshots of items seen via `response.output_item.done`,
   // used to backfill `response.completed.response.output` when upstream returns it
   // empty (which happens when `store: false` — see backfillResponsesCompletedOutput).
@@ -1357,14 +1370,38 @@ export function createSSEStream(options: StreamOptions = {}) {
                     totalContentLength += content.length;
                   }
                   if (typeof delta?.content === "string") {
-                    if (collectPassthroughTextualToolCall(delta.content, passthroughToolCalls)) {
-                      passthroughHasToolCalls = true;
-                      textualToolCallConverted = true;
-                      delta.content = "";
+                    const incomingContent = delta.content;
+                    const bufferedCandidate =
+                      passthroughBufferedTextualToolCallContent + incomingContent;
+                    if (
+                      passthroughBufferedTextualToolCallContent ||
+                      containsTextualToolCallCandidate(incomingContent)
+                    ) {
+                      const parsedCandidate = parseTextualToolCallCandidate(bufferedCandidate);
+                      if (parsedCandidate?.kind === "complete") {
+                        collectPassthroughTextualToolCall(bufferedCandidate, passthroughToolCalls);
+                        passthroughHasToolCalls = true;
+                        textualToolCallConverted = true;
+                        passthroughBufferedTextualToolCallContent = "";
+                        delta.content = "";
+                      } else if (parsedCandidate?.kind === "partial") {
+                        passthroughBufferedTextualToolCallContent = appendBoundedText(
+                          passthroughBufferedTextualToolCallContent,
+                          incomingContent
+                        );
+                        textualToolCallConverted = true;
+                        delta.content = "";
+                      } else {
+                        passthroughAccumulatedContent = appendBoundedText(
+                          passthroughAccumulatedContent,
+                          passthroughBufferedTextualToolCallContent + incomingContent
+                        );
+                        passthroughBufferedTextualToolCallContent = "";
+                      }
                     } else {
                       passthroughAccumulatedContent = appendBoundedText(
                         passthroughAccumulatedContent,
-                        delta.content
+                        incomingContent
                       );
                     }
                   }
@@ -1693,6 +1730,19 @@ export function createSSEStream(options: StreamOptions = {}) {
                 const prompt = Number(u?.prompt_tokens ?? u?.input_tokens ?? 0);
                 const completion = Number(u?.completion_tokens ?? u?.output_tokens ?? 0);
                 let content = passthroughAccumulatedContent.trim() || "";
+                const finalBufferedTextualToolCall =
+                  passthroughBufferedTextualToolCallContent.trim();
+                if (finalBufferedTextualToolCall) {
+                  if (
+                    collectPassthroughTextualToolCall(
+                      finalBufferedTextualToolCall,
+                      passthroughToolCalls
+                    )
+                  ) {
+                    passthroughHasToolCalls = true;
+                  }
+                  passthroughBufferedTextualToolCallContent = "";
+                }
                 if (content && collectPassthroughTextualToolCall(content, passthroughToolCalls)) {
                   passthroughHasToolCalls = true;
                   content = "";

--- a/open-sse/utils/stream.ts
+++ b/open-sse/utils/stream.ts
@@ -181,6 +181,60 @@ function appendBoundedText(current: string, next: string): string {
   return combined.slice(-STREAM_SUMMARY_TEXT_LIMIT);
 }
 
+function stripZeroWidth(value: unknown): unknown {
+  if (typeof value === "string") {
+    return value.replace(/[\u200B-\u200D\uFEFF]/g, "");
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => stripZeroWidth(item));
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, item]) => [
+        key,
+        stripZeroWidth(item),
+      ])
+    );
+  }
+  return value;
+}
+
+function parseTextualToolCallFromContent(text: unknown): { name: string; args: unknown } | null {
+  if (typeof text !== "string") return null;
+  const normalized = text.replace(/[\u200B-\u200D\uFEFF]/g, "");
+  const match = normalized.match(
+    /^[\s\S]*?\[Tool call:\s*([^\]\n]+)\]\s*\nArguments:\s*([\s\S]+?)\s*$/
+  );
+  if (!match) return null;
+  const name = match[1]?.trim();
+  const rawArgs = match[2]?.trim();
+  if (!name || !rawArgs) return null;
+  try {
+    return { name, args: stripZeroWidth(JSON.parse(rawArgs)) };
+  } catch {
+    return null;
+  }
+}
+
+function collectPassthroughTextualToolCall(
+  text: string,
+  toolCalls: Map<string, ToolCall>
+): boolean {
+  const parsed = parseTextualToolCallFromContent(text);
+  if (!parsed) return false;
+  const key = `textual:${toolCalls.size}`;
+  toolCalls.set(key, {
+    id: `call_${Date.now()}_${toolCalls.size}`,
+    index: toolCalls.size,
+    type: "function",
+    function: {
+      name: parsed.name,
+      arguments: JSON.stringify(parsed.args || {}),
+    },
+  });
+  return true;
+}
+
 function toStreamFailureStatus(value: unknown): number | null {
   if (typeof value === "number" && Number.isInteger(value) && value >= 400 && value <= 599) {
     return value;
@@ -1211,6 +1265,7 @@ export function createSSEStream(options: StreamOptions = {}) {
                   }
 
                   const delta = parsed.choices?.[0]?.delta;
+                  let textualToolCallConverted = false;
 
                   // Extract <think> tags from streaming content
                   if (delta?.content && typeof delta.content === "string") {
@@ -1288,11 +1343,18 @@ export function createSSEStream(options: StreamOptions = {}) {
                   if (content && typeof content === "string") {
                     totalContentLength += content.length;
                   }
-                  if (typeof delta?.content === "string")
-                    passthroughAccumulatedContent = appendBoundedText(
-                      passthroughAccumulatedContent,
-                      delta.content
-                    );
+                  if (typeof delta?.content === "string") {
+                    if (collectPassthroughTextualToolCall(delta.content, passthroughToolCalls)) {
+                      passthroughHasToolCalls = true;
+                      textualToolCallConverted = true;
+                      delta.content = "";
+                    } else {
+                      passthroughAccumulatedContent = appendBoundedText(
+                        passthroughAccumulatedContent,
+                        delta.content
+                      );
+                    }
+                  }
                   if (typeof delta?.reasoning_content === "string")
                     passthroughAccumulatedReasoning = appendBoundedText(
                       passthroughAccumulatedReasoning,
@@ -1328,6 +1390,9 @@ export function createSSEStream(options: StreamOptions = {}) {
                   } else if (isFinishChunk && usage) {
                     const buffered = addBufferToUsage(usage);
                     parsed.usage = filterUsageForFormat(buffered, FORMATS.OPENAI);
+                    output = `data: ${JSON.stringify(parsed)}\n`;
+                    injectedUsage = true;
+                  } else if (textualToolCallConverted) {
                     output = `data: ${JSON.stringify(parsed)}\n`;
                     injectedUsage = true;
                   } else if (idFixed || needsReserialization) {

--- a/open-sse/utils/stream.ts
+++ b/open-sse/utils/stream.ts
@@ -241,6 +241,11 @@ function containsTextualToolCallCandidate(text: unknown): boolean {
   return parseTextualToolCallCandidate(text) !== null;
 }
 
+function containsMalformedTextualToolCall(text: unknown): boolean {
+  if (typeof text !== "string") return false;
+  return text.replace(/[\u200B-\u200D\uFEFF]/g, "").includes("[Tool call:");
+}
+
 function collectPassthroughTextualToolCall(
   text: string,
   toolCalls: Map<string, ToolCall>
@@ -1746,6 +1751,8 @@ export function createSSEStream(options: StreamOptions = {}) {
                 if (content && collectPassthroughTextualToolCall(content, passthroughToolCalls)) {
                   passthroughHasToolCalls = true;
                   content = "";
+                } else if (containsMalformedTextualToolCall(content)) {
+                  content = "";
                 }
                 const message: Record<string, unknown> = {
                   role: "assistant",
@@ -1986,6 +1993,8 @@ export function createSSEStream(options: StreamOptions = {}) {
                     arguments: JSON.stringify(textualToolCall.args || {}),
                   },
                 });
+                content = "";
+              } else if (containsMalformedTextualToolCall(content)) {
                 content = "";
               }
               const message: Record<string, unknown> = {

--- a/scripts/build/build-next-isolated.mjs
+++ b/scripts/build/build-next-isolated.mjs
@@ -209,6 +209,21 @@ export async function main() {
       }
 
       try {
+        const publicDir = path.join(projectRoot, "public");
+        if (await exists(publicDir)) {
+          await fs.cp(publicDir, path.join(projectRoot, ".next", "standalone", "public"), {
+            recursive: true,
+          });
+          console.log("[build-next-isolated] Copied public/ to standalone output");
+        }
+      } catch (publicCopyErr) {
+        console.warn(
+          "[build-next-isolated] Non-fatal error copying public/:",
+          publicCopyErr?.message
+        );
+      }
+
+      try {
         await fs.cp(
           path.join(projectRoot, "docs"),
           path.join(projectRoot, ".next", "standalone", "docs"),

--- a/src/shared/utils/classify429.ts
+++ b/src/shared/utils/classify429.ts
@@ -43,6 +43,8 @@ const QUOTA_PATTERNS: ReadonlyArray<RegExp> = [
   /out of credits/i,
   /hard.?limit/i,
   /plan.*limit/i,
+  /resource.*exhaust/i,
+  /check.*quota/i,
 ];
 
 /**

--- a/src/sse/services/auth.ts
+++ b/src/sse/services/auth.ts
@@ -41,6 +41,7 @@ import {
   classifyProviderError,
   PROVIDER_ERROR_TYPES,
 } from "@omniroute/open-sse/services/errorClassifier.ts";
+import { looksLikeQuotaExhausted } from "@/shared/utils/classify429";
 import { getCodexModelScope } from "@omniroute/open-sse/executors/codex.ts";
 import { getProviderAlias, resolveProviderId, FREE_PROVIDERS } from "@/shared/constants/providers";
 import { isModelExcludedByConnection } from "@/domain/connectionModelRules";
@@ -1604,7 +1605,13 @@ export async function markAccountUnavailable(
       (status === 404 || status === 429 || status >= 500)
     ) {
       const reason =
-        status === 404 ? "not_found" : status === 429 ? "rate_limited" : "server_error";
+        status === 404
+          ? "not_found"
+          : status === 429 && looksLikeQuotaExhausted(errorText)
+            ? "quota_exhausted"
+            : status === 429
+              ? "rate_limited"
+              : "server_error";
       const lockout = recordModelLockoutFailure(
         provider,
         connectionId,

--- a/tests/unit/executor-antigravity.test.ts
+++ b/tests/unit/executor-antigravity.test.ts
@@ -476,6 +476,60 @@ test("AntigravityExecutor.collectStreamToResponse turns SSE Gemini chunks into a
   });
 });
 
+test("AntigravityExecutor.collectStreamToResponse converts textual tool call SSE to structured tool_calls", async () => {
+  const executor = new AntigravityExecutor();
+  const response = new Response(
+    [
+      `data: ${JSON.stringify({
+        response: {
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    text: '[Tool call: search_files]\nArguments: {"file_glob":"*gemini*","output_mode":"files_only","path":"/opt/O\\u200dmniRoute","target":"files"}',
+                  },
+                ],
+              },
+              finishReason: "STOP",
+            },
+          ],
+          usageMetadata: {
+            promptTokenCount: 7,
+            candidatesTokenCount: 4,
+            totalTokenCount: 11,
+          },
+        },
+      })}\n\n`,
+    ].join(""),
+    {
+      status: 200,
+      headers: { "Content-Type": "text/event-stream" },
+    }
+  );
+
+  const result = await executor.collectStreamToResponse(
+    response,
+    "gemini-3.5-flash-low",
+    "https://example.com",
+    { Authorization: "Bearer ag-token" },
+    { request: {} }
+  );
+  const payload = await result.response.json();
+  const choice = payload.choices[0];
+
+  assert.equal(choice.message.content, null);
+  assert.equal(choice.finish_reason, "tool_calls");
+  assert.equal(choice.message.tool_calls.length, 1);
+  assert.equal(choice.message.tool_calls[0].function.name, "search_files");
+  assert.deepEqual(JSON.parse(choice.message.tool_calls[0].function.arguments), {
+    file_glob: "*gemini*",
+    output_mode: "files_only",
+    path: "/opt/OmniRoute",
+    target: "files",
+  });
+});
+
 test("AntigravityExecutor.collectStreamToResponse parses fragmented SSE lines incrementally", async () => {
   const executor = new AntigravityExecutor();
   const encoder = new TextEncoder();

--- a/tests/unit/response-sanitizer.test.ts
+++ b/tests/unit/response-sanitizer.test.ts
@@ -453,3 +453,61 @@ test("sanitize functions return non-object inputs unchanged", () => {
   assert.equal(sanitizeOpenAIResponse(null), null);
   assert.equal(sanitizeStreamingChunk("raw text"), "raw text");
 });
+
+test("sanitizeOpenAIResponse converts textual pseudo tool-call content into structured tool_calls", () => {
+  const sanitized = sanitizeOpenAIResponse({
+    id: "chatcmpl_textual_tool_call",
+    object: "chat.completion",
+    created: 1,
+    model: "MainAgent",
+    choices: [
+      {
+        index: 0,
+        finish_reason: "stop",
+        message: {
+          role: "assistant",
+          content:
+            'Проверю.\n[Tool call: terminal]\nArguments: {"command":"echo hermes_textual_toolcall_guard","timeout":10}',
+        },
+      },
+    ],
+  }) as any;
+
+  const choice = sanitized.choices[0];
+  assert.equal(choice.finish_reason, "tool_calls");
+  assert.equal(choice.message.content, null);
+  assert.equal(choice.message.tool_calls[0].type, "function");
+  assert.equal(choice.message.tool_calls[0].function.name, "terminal");
+  assert.deepEqual(JSON.parse(choice.message.tool_calls[0].function.arguments), {
+    command: "echo hermes_textual_toolcall_guard",
+    timeout: 10,
+  });
+  assert.equal(JSON.stringify(sanitized).includes("[Tool call:"), false);
+  assert.equal(JSON.stringify(sanitized).includes("Arguments:"), false);
+});
+
+test("sanitizeOpenAIResponse suppresses malformed textual pseudo tool-call content", () => {
+  const sanitized = sanitizeOpenAIResponse({
+    id: "chatcmpl_malformed_textual_tool_call",
+    object: "chat.completion",
+    created: 1,
+    model: "MainAgent",
+    choices: [
+      {
+        index: 0,
+        finish_reason: "stop",
+        message: {
+          role: "assistant",
+          content: "[Tool call: terminal]\nArguments: {not json",
+        },
+      },
+    ],
+  }) as any;
+
+  const choice = sanitized.choices[0];
+  assert.equal(choice.finish_reason, "stop");
+  assert.equal(choice.message.content, null);
+  assert.equal(choice.message.tool_calls, undefined);
+  assert.equal(JSON.stringify(sanitized).includes("[Tool call:"), false);
+  assert.equal(JSON.stringify(sanitized).includes("Arguments:"), false);
+});

--- a/tests/unit/stream-utils.test.ts
+++ b/tests/unit/stream-utils.test.ts
@@ -173,6 +173,59 @@ test("createSSEStream passthrough converts textual tool-call content into struct
   assert.doesNotMatch(text, /\[Tool call: terminal\]/);
 });
 
+test("createSSEStream passthrough converts split textual tool-call content at completion", async () => {
+  let onCompletePayload = null;
+  const splitToolArgs = JSON.stringify({
+    command: 'sqlite3 ~/.o\u200dmniroute/o\u200dmniroute.db ".tables"',
+  });
+  const chunks = ["[Tool call: terminal]\n", `Arguments: ${splitToolArgs}`];
+
+  const text = await readTransformed(
+    [
+      `data: ${JSON.stringify({
+        id: "chatcmpl_split_textual_tool",
+        object: "chat.completion.chunk",
+        created: 1,
+        model: "antigravity/gemini-3.5-flash-low",
+        choices: [{ index: 0, delta: { role: "assistant", content: chunks[0] } }],
+      })}\n\n`,
+      `data: ${JSON.stringify({
+        id: "chatcmpl_split_textual_tool",
+        object: "chat.completion.chunk",
+        created: 1,
+        model: "antigravity/gemini-3.5-flash-low",
+        choices: [{ index: 0, delta: { content: chunks[1] } }],
+      })}\n\n`,
+      `data: ${JSON.stringify({
+        id: "chatcmpl_split_textual_tool",
+        object: "chat.completion.chunk",
+        created: 1,
+        model: "antigravity/gemini-3.5-flash-low",
+        choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+      })}\n\n`,
+    ],
+    {
+      mode: "passthrough",
+      sourceFormat: FORMATS.OPENAI,
+      provider: "antigravity",
+      model: "antigravity/gemini-3.5-flash-low",
+      body: { messages: [{ role: "user", content: "inspect db" }] },
+      onComplete(payload) {
+        onCompletePayload = payload;
+      },
+    }
+  );
+
+  const choice = onCompletePayload.responseBody.choices[0];
+  assert.equal(choice.finish_reason, "tool_calls");
+  assert.equal(choice.message.content, null);
+  assert.equal(choice.message.tool_calls[0].function.name, "terminal");
+  assert.deepEqual(JSON.parse(choice.message.tool_calls[0].function.arguments), {
+    command: 'sqlite3 ~/.omniroute/omniroute.db ".tables"',
+  });
+  assert.match(text, /\[Tool call: terminal\]/);
+});
+
 test("createSSEStream passthrough flushes a buffered final line without a trailing newline", async () => {
   const text = await readTransformed(
     [

--- a/tests/unit/stream-utils.test.ts
+++ b/tests/unit/stream-utils.test.ts
@@ -232,6 +232,120 @@ test("createSSEStream passthrough converts split textual tool-call content at co
   assert.doesNotMatch(text, /\[Tool call: terminal\]/);
 });
 
+test("createSSEStream passthrough buffers fragmented textual tool-call JSON before emitting", async () => {
+  let onCompletePayload = null;
+  const text = await readTransformed(
+    [
+      `data: ${JSON.stringify({
+        id: "chatcmpl_fragmented_live_shape",
+        object: "chat.completion.chunk",
+        created: 1,
+        model: "MainAgent",
+        choices: [
+          {
+            index: 0,
+            delta: { role: "assistant", content: '[Tool call: terminal]\nArguments: {"' },
+          },
+        ],
+      })}\n\n`,
+      `data: ${JSON.stringify({
+        id: "chatcmpl_fragmented_live_shape",
+        object: "chat.completion.chunk",
+        created: 1,
+        model: "MainAgent",
+        choices: [
+          {
+            index: 0,
+            delta: { content: 'command":"echo live_shape","timeout":10}' },
+          },
+        ],
+      })}\n\n`,
+      `data: ${JSON.stringify({
+        id: "chatcmpl_fragmented_live_shape",
+        object: "chat.completion.chunk",
+        created: 1,
+        model: "MainAgent",
+        choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+      })}\n\n`,
+    ],
+    {
+      mode: "passthrough",
+      sourceFormat: FORMATS.OPENAI,
+      provider: "omniroute",
+      model: "MainAgent",
+      body: { messages: [{ role: "user", content: "inspect" }] },
+      onComplete(payload) {
+        onCompletePayload = payload;
+      },
+    }
+  );
+
+  assert.doesNotMatch(text, /\[Tool call:/);
+  assert.doesNotMatch(text, /Arguments:/);
+  assert.match(text, /"tool_calls":\[/);
+  assert.match(text, /"finish_reason":"tool_calls"/);
+  const choice = onCompletePayload.responseBody.choices[0];
+  assert.equal(choice.finish_reason, "tool_calls");
+  assert.equal(choice.message.content, null);
+  assert.equal(choice.message.tool_calls[0].function.name, "terminal");
+  assert.deepEqual(JSON.parse(choice.message.tool_calls[0].function.arguments), {
+    command: "echo live_shape",
+    timeout: 10,
+  });
+});
+
+test("createSSEStream passthrough suppresses trailing prose plus textual tool call", async () => {
+  let onCompletePayload = null;
+  const toolArgs = JSON.stringify({
+    command: "echo should_not_leak",
+    timeout: 10,
+  });
+  const toolText = `Вот оно! Статические файлы Next.js отдают 404. Чанки не найдены.\n\n[Tool call: terminal]\nArguments: ${toolArgs}`;
+
+  const text = await readTransformed(
+    [
+      `data: ${JSON.stringify({
+        id: "chatcmpl_trailing_textual_tool",
+        object: "chat.completion.chunk",
+        created: 1,
+        model: "MainAgent",
+        choices: [{ index: 0, delta: { role: "assistant", content: toolText } }],
+      })}\n\n`,
+      `data: ${JSON.stringify({
+        id: "chatcmpl_trailing_textual_tool",
+        object: "chat.completion.chunk",
+        created: 1,
+        model: "MainAgent",
+        choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+      })}\n\n`,
+    ],
+    {
+      mode: "passthrough",
+      sourceFormat: FORMATS.OPENAI,
+      provider: "omniroute",
+      model: "MainAgent",
+      body: { messages: [{ role: "user", content: "inspect static files" }] },
+      onComplete(payload) {
+        onCompletePayload = payload;
+      },
+    }
+  );
+
+  assert.equal(onCompletePayload.status, 200);
+  const choice = onCompletePayload.responseBody.choices[0];
+  assert.equal(choice.finish_reason, "tool_calls");
+  assert.equal(choice.message.content, null);
+  assert.equal(choice.message.tool_calls[0].function.name, "terminal");
+  assert.deepEqual(JSON.parse(choice.message.tool_calls[0].function.arguments), {
+    command: "echo should_not_leak",
+    timeout: 10,
+  });
+  assert.doesNotMatch(text, /\[Tool call: terminal\]/);
+  assert.doesNotMatch(text, /Arguments:/);
+  assert.doesNotMatch(JSON.stringify(onCompletePayload.responseBody), /\[Tool call: terminal\]/);
+  assert.doesNotMatch(JSON.stringify(onCompletePayload.responseBody), /Arguments:/);
+});
+
 test("createSSEStream passthrough suppresses textual tool calls for unknown tools", async () => {
   let onCompletePayload = null;
   const toolText = `[Tool call: search_files_ide]

--- a/tests/unit/stream-utils.test.ts
+++ b/tests/unit/stream-utils.test.ts
@@ -441,6 +441,62 @@ test("createSSEStream translate mode converts Claude SSE into OpenAI chunks and 
   assert.equal(onCompletePayload.responseBody.usage.total_tokens, 4);
 });
 
+test("createSSEStream Responses passthrough converts textual tool-call deltas before streaming", async () => {
+  let onCompletePayload = null;
+  const toolText = `[Tool call: terminal]
+Arguments: {"command":"systemctl status omniroute"}`;
+  const text = await readTransformed(
+    [
+      `data: ${JSON.stringify({
+        type: "response.output_text.delta",
+        delta: toolText,
+      })}
+
+`,
+      `data: ${JSON.stringify({
+        type: "response.completed",
+        response: {
+          id: "resp_textual_tool",
+          object: "response",
+          model: "antigravity/gemini-3.5-flash-low",
+          status: "completed",
+          output: [],
+          usage: { input_tokens: 10, output_tokens: 4, total_tokens: 14 },
+        },
+      })}
+
+`,
+    ],
+    {
+      mode: "passthrough",
+      sourceFormat: FORMATS.OPENAI_RESPONSES,
+      clientResponseFormat: FORMATS.OPENAI_RESPONSES,
+      provider: "antigravity",
+      model: "antigravity/gemini-3.5-flash-low",
+      body: {
+        input: "check service",
+        tools: [{ type: "function", name: "terminal", parameters: { type: "object" } }],
+      },
+      onComplete(payload) {
+        onCompletePayload = payload;
+      },
+    }
+  );
+
+  assert.doesNotMatch(text, /\[Tool call: terminal\]/);
+  assert.doesNotMatch(text, /Arguments:/);
+  assert.match(text, /response.output_item.added/);
+  assert.match(text, /response.function_call_arguments.done/);
+  assert.match(text, /"name":"terminal"/);
+  assert.equal(onCompletePayload.responseBody.choices[0].finish_reason, "tool_calls");
+  assert.equal(onCompletePayload.responseBody.choices[0].message.content, null);
+  assert.equal(
+    onCompletePayload.responseBody.choices[0].message.tool_calls[0].function.name,
+    "terminal"
+  );
+  assert.doesNotMatch(JSON.stringify(onCompletePayload.clientPayload), /\[Tool call: terminal\]/);
+});
+
 test("createSSEStream passthrough preserves Responses API events and completion summaries", async () => {
   let onCompletePayload = null;
   const text = await readTransformed(

--- a/tests/unit/stream-utils.test.ts
+++ b/tests/unit/stream-utils.test.ts
@@ -163,6 +163,9 @@ test("createSSEStream passthrough converts textual tool-call content into struct
   );
 
   assert.equal(onCompletePayload.status, 200);
+  assert.match(text, /"tool_calls":\[/);
+  assert.match(text, /"name":"terminal"/);
+  assert.doesNotMatch(text, /"content":"\[Tool call: terminal/);
   const choice = onCompletePayload.responseBody.choices[0];
   assert.equal(choice.finish_reason, "tool_calls");
   assert.equal(choice.message.content, null);
@@ -216,6 +219,9 @@ test("createSSEStream passthrough converts split textual tool-call content at co
     }
   );
 
+  assert.match(text, /"tool_calls":\[/);
+  assert.match(text, /"name":"terminal"/);
+  assert.doesNotMatch(text, /"content":"\[Tool call: terminal/);
   const choice = onCompletePayload.responseBody.choices[0];
   assert.equal(choice.finish_reason, "tool_calls");
   assert.equal(choice.message.content, null);

--- a/tests/unit/stream-utils.test.ts
+++ b/tests/unit/stream-utils.test.ts
@@ -232,6 +232,53 @@ test("createSSEStream passthrough converts split textual tool-call content at co
   assert.doesNotMatch(text, /\[Tool call: terminal\]/);
 });
 
+test("createSSEStream passthrough suppresses textual tool calls for unknown tools", async () => {
+  let onCompletePayload = null;
+  const toolText = `[Tool call: search_files_ide]
+Arguments: {"path":"/opt/OmniRoute/src","target":"files"}`;
+
+  const text = await readTransformed(
+    [
+      `data: ${JSON.stringify({
+        id: "chatcmpl_unknown_textual_tool",
+        object: "chat.completion.chunk",
+        created: 1,
+        model: "antigravity/gemini-3.5-flash-low",
+        choices: [{ index: 0, delta: { role: "assistant", content: toolText } }],
+      })}\n\n`,
+      `data: ${JSON.stringify({
+        id: "chatcmpl_unknown_textual_tool",
+        object: "chat.completion.chunk",
+        created: 1,
+        model: "antigravity/gemini-3.5-flash-low",
+        choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+      })}\n\n`,
+    ],
+    {
+      mode: "passthrough",
+      sourceFormat: FORMATS.OPENAI,
+      provider: "antigravity",
+      model: "antigravity/gemini-3.5-flash-low",
+      body: {
+        messages: [{ role: "user", content: "inspect files" }],
+        tools: [
+          { type: "function", function: { name: "search_files", parameters: { type: "object" } } },
+        ],
+      },
+      onComplete(payload) {
+        onCompletePayload = payload;
+      },
+    }
+  );
+
+  const choice = onCompletePayload.responseBody.choices[0];
+  assert.equal(choice.finish_reason, "stop");
+  assert.equal(choice.message.content, null);
+  assert.equal(choice.message.tool_calls, undefined);
+  assert.doesNotMatch(text, /search_files_ide/);
+  assert.doesNotMatch(JSON.stringify(onCompletePayload.responseBody), /search_files_ide/);
+});
+
 test("createSSEStream passthrough suppresses malformed textual tool-call content", async () => {
   let onCompletePayload = null;
   const malformedToolText = `(empty)[Tool call: terminal]\nArguments: {"command":"sqlite3 /opt/O\u200dmniRoute/data/o\u200dmniroute.`;

--- a/tests/unit/stream-utils.test.ts
+++ b/tests/unit/stream-utils.test.ts
@@ -223,7 +223,48 @@ test("createSSEStream passthrough converts split textual tool-call content at co
   assert.deepEqual(JSON.parse(choice.message.tool_calls[0].function.arguments), {
     command: 'sqlite3 ~/.omniroute/omniroute.db ".tables"',
   });
-  assert.match(text, /\[Tool call: terminal\]/);
+  assert.doesNotMatch(text, /\[Tool call: terminal\]/);
+});
+
+test("createSSEStream passthrough suppresses malformed textual tool-call content", async () => {
+  let onCompletePayload = null;
+  const malformedToolText = `(empty)[Tool call: terminal]\nArguments: {"command":"sqlite3 /opt/O\u200dmniRoute/data/o\u200dmniroute.`;
+
+  const text = await readTransformed(
+    [
+      `data: ${JSON.stringify({
+        id: "chatcmpl_malformed_textual_tool",
+        object: "chat.completion.chunk",
+        created: 1,
+        model: "antigravity/gemini-3.5-flash-low",
+        choices: [{ index: 0, delta: { role: "assistant", content: malformedToolText } }],
+      })}\n\n`,
+      `data: ${JSON.stringify({
+        id: "chatcmpl_malformed_textual_tool",
+        object: "chat.completion.chunk",
+        created: 1,
+        model: "antigravity/gemini-3.5-flash-low",
+        choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+      })}\n\n`,
+    ],
+    {
+      mode: "passthrough",
+      sourceFormat: FORMATS.OPENAI,
+      provider: "antigravity",
+      model: "antigravity/gemini-3.5-flash-low",
+      body: { messages: [{ role: "user", content: "inspect db" }] },
+      onComplete(payload) {
+        onCompletePayload = payload;
+      },
+    }
+  );
+
+  const choice = onCompletePayload.responseBody.choices[0];
+  assert.equal(choice.finish_reason, "stop");
+  assert.equal(choice.message.content, null);
+  assert.equal(choice.message.tool_calls, undefined);
+  assert.doesNotMatch(text, /\[Tool call: terminal\]/);
+  assert.doesNotMatch(JSON.stringify(onCompletePayload.responseBody), /\[Tool call: terminal\]/);
 });
 
 test("createSSEStream passthrough flushes a buffered final line without a trailing newline", async () => {

--- a/tests/unit/stream-utils.test.ts
+++ b/tests/unit/stream-utils.test.ts
@@ -267,6 +267,46 @@ test("createSSEStream passthrough suppresses malformed textual tool-call content
   assert.doesNotMatch(JSON.stringify(onCompletePayload.responseBody), /\[Tool call: terminal\]/);
 });
 
+test("createSSEStream suppresses malformed compact textual tool-call content", async () => {
+  let onCompletePayload = null;
+
+  const text = await readTransformed(
+    [
+      `data: ${JSON.stringify({
+        candidates: [
+          {
+            content: {
+              parts: [
+                {
+                  text: "[Tool call: search_files_ide{file_glob:*combos*.ts,path:/opt/OmniRoute,target:files}]",
+                },
+              ],
+            },
+          },
+        ],
+      })}\n\n`,
+      `data: ${JSON.stringify({ candidates: [{ finishReason: "STOP" }] })}\n\n`,
+    ],
+    {
+      mode: "translate",
+      targetFormat: FORMATS.ANTIGRAVITY,
+      sourceFormat: FORMATS.OPENAI,
+      provider: "antigravity",
+      model: "antigravity/gemini-3.5-flash-low",
+      body: { messages: [{ role: "user", content: "inspect files" }] },
+      onComplete(payload) {
+        onCompletePayload = payload;
+      },
+    }
+  );
+
+  const choice = onCompletePayload.responseBody.choices[0];
+  assert.equal(choice.finish_reason, "stop");
+  assert.equal(choice.message.content, null);
+  assert.equal(choice.message.tool_calls, undefined);
+  assert.doesNotMatch(JSON.stringify(onCompletePayload.responseBody), /\[Tool call:/);
+});
+
 test("createSSEStream passthrough flushes a buffered final line without a trailing newline", async () => {
   const text = await readTransformed(
     [

--- a/tests/unit/stream-utils.test.ts
+++ b/tests/unit/stream-utils.test.ts
@@ -124,6 +124,55 @@ test("createSSEStream passthrough normalizes tool-call finishes and reports the 
   assert.equal(onCompletePayload.clientPayload._streamed, true);
 });
 
+test("createSSEStream passthrough converts textual tool-call content into structured call log tool_calls", async () => {
+  let onCompletePayload = null;
+  const toolArgs = JSON.stringify({
+    command: 'sqlite3 /root/.o\u200dmniroute/omniroute.db ".tables"',
+  });
+  const toolText = `[Tool call: terminal]\nArguments: ${toolArgs}`;
+
+  const text = await readTransformed(
+    [
+      `data: ${JSON.stringify({
+        id: "chatcmpl_textual_tool",
+        object: "chat.completion.chunk",
+        created: 1,
+        model: "antigravity/gemini-3.5-flash-low",
+        choices: [{ index: 0, delta: { role: "assistant", content: toolText } }],
+      })}\n\n`,
+      `data: ${JSON.stringify({
+        id: "chatcmpl_textual_tool",
+        object: "chat.completion.chunk",
+        created: 1,
+        model: "antigravity/gemini-3.5-flash-low",
+        choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+      })}\n\n`,
+    ],
+    {
+      mode: "passthrough",
+      sourceFormat: FORMATS.OPENAI,
+      provider: "antigravity",
+      model: "antigravity/gemini-3.5-flash-low",
+      body: {
+        messages: [{ role: "user", content: "inspect db" }],
+      },
+      onComplete(payload) {
+        onCompletePayload = payload;
+      },
+    }
+  );
+
+  assert.equal(onCompletePayload.status, 200);
+  const choice = onCompletePayload.responseBody.choices[0];
+  assert.equal(choice.finish_reason, "tool_calls");
+  assert.equal(choice.message.content, null);
+  assert.equal(choice.message.tool_calls[0].function.name, "terminal");
+  assert.deepEqual(JSON.parse(choice.message.tool_calls[0].function.arguments), {
+    command: 'sqlite3 /root/.omniroute/omniroute.db ".tables"',
+  });
+  assert.doesNotMatch(text, /\[Tool call: terminal\]/);
+});
+
 test("createSSEStream passthrough flushes a buffered final line without a trailing newline", async () => {
   const text = await readTransformed(
     [

--- a/tests/unit/translator-openai-to-gemini.test.ts
+++ b/tests/unit/translator-openai-to-gemini.test.ts
@@ -689,6 +689,61 @@ test("OpenAI -> Antigravity Gemini stringifies signature-less historical tool ca
   );
 });
 
+test("OpenAI -> Antigravity preserves multiple signature-less historical tool responses as text", () => {
+  const result = openaiToAntigravityRequest(
+    "gemini-3.5-flash-low",
+    {
+      messages: [
+        { role: "user", content: "Inspect OmniRoute config" },
+        {
+          role: "assistant",
+          tool_calls: [
+            {
+              id: "call_missing_db",
+              type: "function",
+              function: { name: "terminal", arguments: '{"command":"cat data/db.json"}' },
+            },
+            {
+              id: "call_list_dir",
+              type: "function",
+              function: { name: "terminal", arguments: '{"command":"ls ~/.omniroute"}' },
+            },
+          ],
+        },
+        { role: "tool", tool_call_id: "call_missing_db", content: "data/db.json: No such file" },
+        { role: "tool", tool_call_id: "call_list_dir", content: "storage.sqlite" },
+      ],
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: "terminal",
+            parameters: { type: "object", properties: {} },
+          },
+        },
+      ],
+    },
+    false,
+    { projectId: "proj-antigravity-gemini" } as any
+  );
+
+  const text = JSON.stringify(result.request.contents);
+  assert.ok(text.includes("[Tool call: terminal]"), "expected signature-less calls as text");
+  assert.ok(
+    text.includes("data/db.json: No such file"),
+    "expected first signature-less tool response as text"
+  );
+  assert.ok(
+    text.includes("storage.sqlite"),
+    "expected second signature-less tool response as text"
+  );
+  assert.equal(
+    result.request.contents.some((content) => content.parts.some((part) => part.functionResponse)),
+    false,
+    "signature-less historical responses must not be emitted as native functionResponse"
+  );
+});
+
 test("OpenAI -> Antigravity maps Claude-family models to Gemini-compatible schema", () => {
   const result = openaiToAntigravityRequest(
     "claude-3-7-sonnet",

--- a/tests/unit/translator-resp-gemini-to-openai.test.ts
+++ b/tests/unit/translator-resp-gemini-to-openai.test.ts
@@ -470,3 +470,109 @@ test("Gemini stream: safety block without candidates emits role chunk then conte
 test("Gemini stream: null chunk is ignored", () => {
   assert.equal(geminiToOpenAIResponse(null, createStreamingState()), null);
 });
+
+test("Gemini stream: unwraps native functionCall args when emitted as JSON string", () => {
+  const state = createStreamingState();
+  const result = geminiToOpenAIResponse(
+    {
+      responseId: "resp-native-tool-json-string",
+      modelVersion: "gemini-3.5-flash-low",
+      candidates: [
+        {
+          content: {
+            parts: [
+              {
+                functionCall: {
+                  name: "terminal",
+                  args: JSON.stringify({
+                    command: 'ssh test-vps "systemctl cat omniroute.service"',
+                  }),
+                },
+              },
+            ],
+          },
+          finishReason: "STOP",
+        },
+      ],
+    },
+    state
+  );
+
+  const toolCall = result.find((event: any) => event.choices?.[0]?.delta?.tool_calls)?.choices[0]
+    .delta.tool_calls[0];
+  assert.equal(toolCall.function.name, "terminal");
+  assert.equal(
+    toolCall.function.arguments,
+    JSON.stringify({ command: 'ssh test-vps "systemctl cat omniroute.service"' })
+  );
+});
+
+test("Gemini stream: converts JSON-string encoded textual Tool call arguments", () => {
+  const state = createStreamingState();
+  const result = geminiToOpenAIResponse(
+    {
+      responseId: "resp-textual-tool-json-string",
+      modelVersion: "gemini-3.5-flash-low",
+      candidates: [
+        {
+          content: {
+            parts: [
+              {
+                text: '[Tool call: terminal]\nArguments: "{\\\"command\\\":\\\"ssh test-vps \\\\\\\"systemctl cat omniroute.service\\\\\\\"\\\"}"',
+              },
+            ],
+          },
+          finishReason: "STOP",
+        },
+      ],
+    },
+    state
+  );
+
+  const toolCall = result.find((event: any) => event.choices?.[0]?.delta?.tool_calls)?.choices[0]
+    .delta.tool_calls[0];
+  assert.ok(toolCall.id.startsWith("terminal-"));
+  assert.equal(toolCall.function.name, "terminal");
+  assert.equal(
+    toolCall.function.arguments,
+    JSON.stringify({ command: 'ssh test-vps "systemctl cat omniroute.service"' })
+  );
+  assert.equal(
+    result.some((event: any) => event.choices?.[0]?.delta?.content?.includes("[Tool call:")),
+    false
+  );
+  assert.equal(result.at(-1).choices[0].finish_reason, "tool_calls");
+});
+
+test("Gemini stream: suppresses malformed textual Tool call marker", () => {
+  const state = createStreamingState();
+  const result = geminiToOpenAIResponse(
+    {
+      responseId: "resp-textual-tool-malformed",
+      modelVersion: "gemini-3.5-flash-low",
+      candidates: [
+        {
+          content: {
+            parts: [
+              {
+                text: '[Tool call: terminal]\nArguments: {"command":"unterminated}',
+              },
+            ],
+          },
+          finishReason: "STOP",
+        },
+      ],
+    },
+    state
+  );
+
+  assert.equal(
+    result.some((event: any) => event.choices?.[0]?.delta?.content?.includes("[Tool call:")),
+    false
+  );
+  assert.equal(
+    result.some((event: any) => event.choices?.[0]?.delta?.tool_calls),
+    false
+  );
+  assert.equal(result.at(-1).choices[0].finish_reason, "stop");
+});

--- a/tests/unit/translator-resp-gemini-to-openai.test.ts
+++ b/tests/unit/translator-resp-gemini-to-openai.test.ts
@@ -64,7 +64,9 @@ test("Gemini non-stream: multiple candidates keep multimodal content, reasoning 
               { thought: true, text: "Plan first." },
               { text: "Answer:" },
               { inlineData: { mimeType: "image/png", data: "abc123" } },
-              { functionCall: { id: "native-read-1", name: "read_file", args: { path: "/tmp/a" } } },
+              {
+                functionCall: { id: "native-read-1", name: "read_file", args: { path: "/tmp/a" } },
+              },
             ],
           },
           finishReason: "STOP",
@@ -283,10 +285,7 @@ test("Gemini stream: reasoning, tool call, image and MAX_TOKENS finish are conve
   );
 
   assert.equal(result[1].choices[0].delta.reasoning_content, "Need a plan.");
-  assert.equal(
-    result[2].choices[0].delta.tool_calls[0].id,
-    "native-call-1"
-  );
+  assert.equal(result[2].choices[0].delta.tool_calls[0].id, "native-call-1");
   assert.equal(
     result[2].choices[0].delta.tool_calls[0].function.name,
     "mcp__filesystem__read_multiple_files_with_validation_and_metadata_bundle_v2"
@@ -301,6 +300,85 @@ test("Gemini stream: reasoning, tool call, image and MAX_TOKENS finish are conve
   assert.equal(result[4].usage.completion_tokens, 5);
   assert.equal(result[4].usage.prompt_tokens_details.cached_tokens, 1);
   assert.equal(result[4].usage.completion_tokens_details.reasoning_tokens, 2);
+});
+
+test("Gemini stream: stores thoughtSignature when signature-only part precedes functionCall", async () => {
+  const { resolveGeminiThoughtSignature } =
+    await import("../../open-sse/services/geminiThoughtSignatureStore.ts");
+  const state = {
+    ...createStreamingState(),
+    signatureNamespace: "conn-antigravity-1",
+  };
+  const result = geminiToOpenAIResponse(
+    {
+      responseId: "resp-split-signature",
+      modelVersion: "gemini-3-flash-agent",
+      candidates: [
+        {
+          content: {
+            parts: [
+              { thoughtSignature: "sig-split-1" },
+              {
+                functionCall: {
+                  id: "call_split_1",
+                  name: "read_file",
+                  args: { path: "/tmp/a" },
+                },
+              },
+            ],
+          },
+          finishReason: "STOP",
+        },
+      ],
+    },
+    state
+  );
+
+  const toolCall = result.find((event: any) => event.choices?.[0]?.delta?.tool_calls)?.choices[0]
+    .delta.tool_calls[0];
+  assert.equal(toolCall.id, "call_split_1");
+  assert.equal(state.pendingThoughtSignature, null);
+  assert.equal(resolveGeminiThoughtSignature("conn-antigravity-1:call_split_1"), "sig-split-1");
+});
+
+test("Gemini stream: converts textual Tool call block to structured tool_calls", () => {
+  const state = createStreamingState();
+  const result = geminiToOpenAIResponse(
+    {
+      responseId: "resp-textual-tool",
+      modelVersion: "gemini-3.5-flash-low",
+      candidates: [
+        {
+          content: {
+            parts: [
+              {
+                text: '[Tool call: terminal]\nArguments: {"command":"sqlite3 ~/.omniroute/storage.sqlite \\"SELECT name FROM sqlite_master WHERE type=\'table\';\\""}',
+              },
+            ],
+          },
+          finishReason: "STOP",
+        },
+      ],
+    },
+    state
+  );
+
+  const toolCall = result.find((event: any) => event.choices?.[0]?.delta?.tool_calls)?.choices[0]
+    .delta.tool_calls[0];
+  assert.ok(toolCall.id.startsWith("terminal-"));
+  assert.equal(toolCall.function.name, "terminal");
+  assert.equal(
+    toolCall.function.arguments,
+    JSON.stringify({
+      command:
+        "sqlite3 ~/.omniroute/storage.sqlite \"SELECT name FROM sqlite_master WHERE type='table';\"",
+    })
+  );
+  assert.equal(
+    result.some((event: any) => event.choices?.[0]?.delta?.content?.includes("[Tool call:")),
+    false
+  );
+  assert.equal(result.at(-1).choices[0].finish_reason, "tool_calls");
 });
 
 test("Gemini stream: tool calls without native IDs keep deterministic fallback shape", () => {

--- a/tests/unit/translator-resp-gemini-to-openai.test.ts
+++ b/tests/unit/translator-resp-gemini-to-openai.test.ts
@@ -381,6 +381,45 @@ test("Gemini stream: converts textual Tool call block to structured tool_calls",
   assert.equal(result.at(-1).choices[0].finish_reason, "tool_calls");
 });
 
+test("Gemini stream: converts prefixed textual Tool call block with zero-width chars", () => {
+  const state = createStreamingState();
+  const result = geminiToOpenAIResponse(
+    {
+      responseId: "resp-textual-tool-prefixed",
+      modelVersion: "gemini-3.5-flash-low",
+      candidates: [
+        {
+          content: {
+            parts: [
+              {
+                text: '(empty)[Tool call: terminal]\nArguments: {"command":"sqlite3 ~/.o\u200dmniroute/storage.sqlite"}',
+              },
+            ],
+          },
+          finishReason: "STOP",
+        },
+      ],
+    },
+    state
+  );
+
+  const toolCall = result.find((event: any) => event.choices?.[0]?.delta?.tool_calls)?.choices[0]
+    .delta.tool_calls[0];
+  assert.ok(toolCall.id.startsWith("terminal-"));
+  assert.equal(toolCall.function.name, "terminal");
+  assert.equal(
+    toolCall.function.arguments,
+    JSON.stringify({
+      command: "sqlite3 ~/.omniroute/storage.sqlite",
+    })
+  );
+  assert.equal(
+    result.some((event: any) => event.choices?.[0]?.delta?.content?.includes("[Tool call:")),
+    false
+  );
+  assert.equal(result.at(-1).choices[0].finish_reason, "tool_calls");
+});
+
 test("Gemini stream: tool calls without native IDs keep deterministic fallback shape", () => {
   const state = createStreamingState();
   const result = geminiToOpenAIResponse(


### PR DESCRIPTION
### Related Issues & Background
Currently, when utilizing Gemini or customized Antigravity backends with complex routing combinations (such as **combos** incorporating fallback behaviors), the router struggles with two major issues:
1. **Malformed/Unescaped Textual Tool Calls**: Differences in how Gemini-compliant formats and OpenAI envelopes wrap tools sometimes leads to either tool definitions leaking into prose or malformed SSE JSON payload frames (especially when stream chunks split in the middle of pseudo-tool tags).
2. **Repetitive 429 Rate-Limit Cascades**: When a high-tier model's quota gets exhausted (e.g. Google's `Resource has been exhausted` or credits running out), the error was labeled as `rate_limited` rather than `quota_exhausted`. Because `rate_limited` defaults to a tiny cooldown (e.g. 5 seconds), every single incoming request repeatedly attempts to invoke the broken model, suffering slow network timeouts (4s to 12s per call) before eventually routing to a fallback low-tier model.

---

### Key Changes In This Pull Request

#### 1. Gemini / Antigravity Tool Call Normalization & Sanitization
* **Pre-commit Filters**: Added strict zero-width character stripping (`stripZeroWidthText()`) in the response sanitizer to guarantee correct payload parsing.
* **Textual Marker Guard**: Implemented robust tracking (`containsTextualToolCallMarker()` & `parseTextualToolCallContent()`) to transparently capture and convert inline textual tool calls to structured OpenAI `tool_calls` formats when missing, suppressing them from plaintext outputs so client UIs stay clean.
* **Fragment Buffer in SSE Streams**: Modified the stream transformer (`applyTextualToolCallStreamingGuard()`) to buffer fragmented JSON slices before emitting, preventing client-side parsers from choking on partial pseudo-tags.

#### 2. Adaptive Model Lockout for Quota Exhaustion (429 classification)
* **Custom Signature Mapping**: Added regex pattern support to `src/shared/utils/classify429.ts` and `open-sse/services/accountFallback.ts` to seamlessly classify Google's `Resource has been exhausted` and `Check quota` warnings.
* **Lockout Escalation**: Modified `src/sse/services/auth.ts` to analyze 429 response bodies using `looksLikeQuotaExhausted()`. If a quota limit signature is found, the system marks the backend model as `quota_exhausted`.
* **Instant Routing Skips**: Once a model is registered with `quota_exhausted` status, the combo router dynamically skips the node altogether—returning fallback targets (like Flash) *instantly* (reducing latency from 13 seconds of network cascading down to < 2.5 seconds).

---

### Verification & Testing
* Tested against our live self-hosted setups; successfully caught the Antigravity Opus fallback limits and instantaneously bypassed it to Flash.
* Automated unit tests updated and verified:
  - `Node --test tests/unit/classify429.test.ts` (14/14 tests passing)
  - All stream translator tests passing under typescript execution.
