### PR TITLE
fix(mcp): redirect console.log/warn to stderr in --mcp stdio mode

### DIFF
--- a/bin/omniroute.mjs
+++ b/bin/omniroute.mjs
@@ -32,9 +32,10 @@ const ROOT = join(__dirname, "..");
 // Redirect console.log/warn to stderr early (before loadEnvFile and DB init)
 // so no startup output corrupts the protocol.
 if (process.argv.includes("--mcp")) {
-  const _stderrWrite = (msg) => process.stderr.write(msg + "\n");
-  console.log = (...a) => _stderrWrite(a.join(" "));
-  console.warn = (...a) => _stderrWrite(a.join(" "));
+  const { Console } = await import("node:console");
+  const stderrConsole = new Console({ stdout: process.stderr, stderr: process.stderr });
+  console.log = stderrConsole.log.bind(stderrConsole);
+  console.warn = stderrConsole.warn.bind(stderrConsole);
 }
 
 function loadEnvFile() {

--- a/bin/omniroute.mjs
+++ b/bin/omniroute.mjs
@@ -28,6 +28,15 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const ROOT = join(__dirname, "..");
 
+// MCP stdio transport uses stdout exclusively for JSON-RPC messages.
+// Redirect console.log/warn to stderr early (before loadEnvFile and DB init)
+// so no startup output corrupts the protocol.
+if (process.argv.includes("--mcp")) {
+  const _stderrWrite = (msg) => process.stderr.write(msg + "\n");
+  console.log = (...a) => _stderrWrite(a.join(" "));
+  console.warn = (...a) => _stderrWrite(a.join(" "));
+}
+
 function loadEnvFile() {
   const envPaths = [];
 


### PR DESCRIPTION
## Problem

When OmniRoute starts as an MCP server (`omniroute --mcp`), it uses stdio transport where **stdout is reserved exclusively for JSON-RPC messages**.

However, during startup, multiple `console.log` calls write non-JSON output to stdout:
- `📋 Loaded env from ~/.omniroute/.env` (bin/omniroute.mjs, loadEnvFile)
- `[DB] SQLite database ready: ...` (src/lib/db/)
- `[DB] Added api_keys.xxx column` (src/lib/db/core.ts, apiKeys.ts)
- `[CREDENTIALS] No external credentials file found, using defaults.` (open-sse/config/credentialLoader.ts)

This corrupts the MCP protocol — clients (Hermes Agent, Claude Desktop, etc.) try to parse these lines as JSON-RPC messages, get `ValidationError`, and the connection breaks. All MCP tools become unavailable.

## Fix

Redirect `console.log` and `console.warn` to `process.stderr.write` early in the CLI entry point (`bin/omniroute.mjs`) when `--mcp` flag is present — before `loadEnvFile()` and any DB initialization runs.

This is a minimal, non-breaking fix:
- Normal CLI/server mode: unchanged behavior
- MCP stdio mode: all startup logs go to stderr, stdout stays clean for JSON-RPC
- Logs are still visible via stderr (for debugging)

## Changes

`bin/omniroute.mjs`: +9 lines — early console redirect when `--mcp` is detected