### PR TITLE
fix(gemini-cli): prefer real project IDs over default-project

### DIFF
--- a/open-sse/executors/gemini-cli.ts
+++ b/open-sse/executors/gemini-cli.ts
@@ -82,7 +82,10 @@ function resolveGeminiCliProjectId(value: unknown): string {
   if (typeof value !== "string") return "";
   const trimmed = value.trim();
   if (!trimmed) return "";
-  if (trimmed.toLowerCase() === DEFAULT_PROJECT_ID) return "";
+  const normalized = trimmed.toLowerCase();
+  if (normalized === DEFAULT_PROJECT_ID || normalized === `projects/${DEFAULT_PROJECT_ID}`) {
+    return "";
+  }
   return trimmed;
 }
 
@@ -123,8 +126,6 @@ function sleep(ms: number): Promise<void> {
 }
 
 export class GeminiCLIExecutor extends BaseExecutor {
-  private _currentModel = "unknown";
-
   constructor() {
     super("gemini-cli", PROVIDERS["gemini-cli"]);
   }
@@ -144,8 +145,7 @@ export class GeminiCLIExecutor extends BaseExecutor {
   ) {
     void clientHeaders;
 
-    // Fallback to internal tracker if model not explicitly passed (matches older interface calls)
-    const activeModel = model || this._currentModel || "unknown";
+    const activeModel = model || "unknown";
 
     const raw = getGeminiCliHeaders(
       normalizeGeminiModel(activeModel),
@@ -318,7 +318,6 @@ export class GeminiCLIExecutor extends BaseExecutor {
   }
 
   async transformRequest(model, body, stream, credentials) {
-    this._currentModel = normalizeGeminiModel(model);
     const currentModel = normalizeGeminiModel(model);
     const normalizedBody =
       shouldStripCloudCodeThinking(this.provider, currentModel) && body && typeof body === "object"

--- a/open-sse/executors/gemini-cli.ts
+++ b/open-sse/executors/gemini-cli.ts
@@ -78,6 +78,14 @@ function extractProjectId(payload: unknown): string {
   return "";
 }
 
+function resolveGeminiCliProjectId(value: unknown): string {
+  if (typeof value !== "string") return "";
+  const trimmed = value.trim();
+  if (!trimmed) return "";
+  if (trimmed.toLowerCase() === DEFAULT_PROJECT_ID) return "";
+  return trimmed;
+}
+
 function extractDefaultTierId(payload: unknown): string {
   if (!payload || typeof payload !== "object") return DEFAULT_ONBOARD_TIER;
   const tiers = Array.isArray((payload as LoadCodeAssistResponse).allowedTiers)
@@ -115,6 +123,8 @@ function sleep(ms: number): Promise<void> {
 }
 
 export class GeminiCLIExecutor extends BaseExecutor {
+  private _currentModel = "unknown";
+
   constructor() {
     super("gemini-cli", PROVIDERS["gemini-cli"]);
   }
@@ -182,7 +192,7 @@ export class GeminiCLIExecutor extends BaseExecutor {
         const controller = new AbortController();
         const timeoutId = setTimeout(() => controller.abort(), ONBOARD_TIMEOUT_MS);
 
-        let response;
+        let response: Response;
         try {
           response = await fetch(ONBOARD_USER_URL, {
             method: "POST",
@@ -203,7 +213,7 @@ export class GeminiCLIExecutor extends BaseExecutor {
           }
 
           if (payload?.done === true) {
-            return DEFAULT_PROJECT_ID;
+            return null;
           }
         } else {
           console.warn(
@@ -254,7 +264,7 @@ export class GeminiCLIExecutor extends BaseExecutor {
       const controller = new AbortController();
       const timeoutId = setTimeout(() => controller.abort(), LOAD_CODE_ASSIST_TIMEOUT_MS);
 
-      let response;
+      let response: Response;
       try {
         response = await fetch(LOAD_CODE_ASSIST_URL, {
           method: "POST",
@@ -276,7 +286,7 @@ export class GeminiCLIExecutor extends BaseExecutor {
       }
 
       const data = (await response.json()) as LoadCodeAssistResponse;
-      let projectId = extractProjectId(data);
+      let projectId = resolveGeminiCliProjectId(extractProjectId(data));
 
       if (!projectId) {
         console.warn(
@@ -308,6 +318,7 @@ export class GeminiCLIExecutor extends BaseExecutor {
   }
 
   async transformRequest(model, body, stream, credentials) {
+    this._currentModel = normalizeGeminiModel(model);
     const currentModel = normalizeGeminiModel(model);
     const normalizedBody =
       shouldStripCloudCodeThinking(this.provider, currentModel) && body && typeof body === "object"
@@ -323,10 +334,12 @@ export class GeminiCLIExecutor extends BaseExecutor {
         ? cloneGeminiCliRecord(bodyRecord.request as Record<string, any>)
         : {};
 
+    const providerSpecificData = credentials.providerSpecificData as Record<string, unknown>;
     const storedProject =
-      bodyRecord.project ||
-      credentials.projectId ||
-      (credentials.providerSpecificData as Record<string, unknown>)?.projectId;
+      resolveGeminiCliProjectId(providerSpecificData?.projectId) ||
+      resolveGeminiCliProjectId(credentials.projectId) ||
+      resolveGeminiCliProjectId(bodyRecord.project) ||
+      "";
 
     const envelope: Record<string, any> = {
       model: currentModel,
@@ -351,7 +364,7 @@ export class GeminiCLIExecutor extends BaseExecutor {
     // stored project IDs can go stale. Keep the stored value as a fallback.
     if (credentials.accessToken) {
       const freshProject = await this.refreshProject(credentials.accessToken, currentModel);
-      if (freshProject) {
+      if (resolveGeminiCliProjectId(freshProject)) {
         envelope.project = freshProject;
       }
     }

--- a/src/app/api/providers/[id]/models/route.ts
+++ b/src/app/api/providers/[id]/models/route.ts
@@ -93,6 +93,12 @@ function toNonEmptyString(value: unknown): string | null {
   return trimmed.length > 0 ? trimmed : null;
 }
 
+function toGeminiCliProjectId(value: unknown): string | null {
+  const normalized = toNonEmptyString(value);
+  if (!normalized) return null;
+  return normalized.toLowerCase() === "default-project" ? null : normalized;
+}
+
 function getProviderBaseUrl(providerSpecificData: unknown): string | null {
   const data = asRecord(providerSpecificData);
   const baseUrl = data.baseUrl;
@@ -1738,7 +1744,10 @@ export async function GET(
       }
 
       const psd = asRecord(connection.providerSpecificData);
-      const projectId = connection.projectId || psd.projectId || null;
+      const projectId =
+        toGeminiCliProjectId(psd.projectId) ||
+        toGeminiCliProjectId(psd.project) ||
+        toGeminiCliProjectId(connection.projectId);
 
       if (!projectId) {
         return NextResponse.json(

--- a/src/app/api/providers/[id]/models/route.ts
+++ b/src/app/api/providers/[id]/models/route.ts
@@ -96,7 +96,9 @@ function toNonEmptyString(value: unknown): string | null {
 function toGeminiCliProjectId(value: unknown): string | null {
   const normalized = toNonEmptyString(value);
   if (!normalized) return null;
-  return normalized.toLowerCase() === "default-project" ? null : normalized;
+  const lower = normalized.toLowerCase();
+  if (lower === "default-project" || lower === "projects/default-project") return null;
+  return normalized;
 }
 
 function getProviderBaseUrl(providerSpecificData: unknown): string | null {

--- a/tests/unit/executor-gemini-cli.test.ts
+++ b/tests/unit/executor-gemini-cli.test.ts
@@ -313,6 +313,50 @@ test("GeminiCLIExecutor.onboardManagedProject retries until completion", async (
   }
 });
 
+test("GeminiCLIExecutor.onboardManagedProject returns null when done=true has no project", async () => {
+  const executor = new GeminiCLIExecutor();
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = async (url) => {
+    assert.match(String(url), /onboardUser$/);
+    return new Response(JSON.stringify({ done: true, response: {} }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+
+  try {
+    assert.equal(
+      await executor.onboardManagedProject("access-token-no-project", "free-tier", {
+        attempts: 1,
+        delayMs: 0,
+      }),
+      null
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("GeminiCLIExecutor.transformRequest prefers DB projectId over default-project body", async () => {
+  const executor = new GeminiCLIExecutor();
+
+  const transformed = await executor.transformRequest(
+    "gemini-2.5-flash",
+    {
+      project: "default-project",
+      request: { contents: [{ role: "user", parts: [{ text: "Hello" }] }] },
+    },
+    true,
+    {
+      projectId: "projects/custom-from-db",
+      providerSpecificData: { projectId: "projects/custom-from-psd" },
+    }
+  );
+
+  assert.equal(transformed.project, "projects/custom-from-psd");
+});
+
 test("GeminiCLIExecutor.refreshCredentials exchanges refresh tokens via Google OAuth", async () => {
   const executor = new GeminiCLIExecutor();
   const originalFetch = globalThis.fetch;

--- a/tests/unit/executor-gemini-cli.test.ts
+++ b/tests/unit/executor-gemini-cli.test.ts
@@ -357,6 +357,25 @@ test("GeminiCLIExecutor.transformRequest prefers DB projectId over default-proje
   assert.equal(transformed.project, "projects/custom-from-psd");
 });
 
+test("GeminiCLIExecutor.transformRequest ignores projects/default-project placeholders", async () => {
+  const executor = new GeminiCLIExecutor();
+
+  const transformed = await executor.transformRequest(
+    "gemini-2.5-flash",
+    {
+      project: "projects/default-project",
+      request: { contents: [{ role: "user", parts: [{ text: "Hello" }] }] },
+    },
+    true,
+    {
+      projectId: "default-project",
+      providerSpecificData: { projectId: "projects/default-project" },
+    }
+  );
+
+  assert.equal(transformed.project, undefined);
+});
+
 test("GeminiCLIExecutor.refreshCredentials exchanges refresh tokens via Google OAuth", async () => {
   const executor = new GeminiCLIExecutor();
   const originalFetch = globalThis.fetch;

--- a/tests/unit/provider-models-route.test.ts
+++ b/tests/unit/provider-models-route.test.ts
@@ -640,6 +640,33 @@ test("provider models route maps Gemini CLI quota buckets into a model list", as
   ]);
 });
 
+test("provider models route prefers providerSpecificData projectId over default-project", async () => {
+  const connection = await seedConnection("gemini-cli", {
+    authType: "oauth",
+    accessToken: "gemini-cli-access",
+    apiKey: null,
+    projectId: "default-project",
+    providerSpecificData: {
+      projectId: "projects/custom-psd-456",
+    },
+  });
+
+  globalThis.fetch = async (url, init = {}) => {
+    assert.equal(String(url), "https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota");
+    assert.equal(init.headers.Authorization, "Bearer gemini-cli-access");
+    assert.deepEqual(JSON.parse(String(init.body)), { project: "projects/custom-psd-456" });
+    return Response.json({ buckets: [{ modelId: "gemini-3.1-pro-preview" }] });
+  };
+
+  const response = await callRoute(connection.id);
+  const body = (await response.json()) as any;
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(body.models, [
+    { id: "gemini-3.1-pro-preview", name: "gemini-3.1-pro-preview", owned_by: "google" },
+  ]);
+});
+
 test("provider models route retries Antigravity discovery endpoints before returning remote models", async () => {
   const connection = await seedConnection("antigravity", {
     authType: "oauth",

--- a/tests/unit/provider-models-route.test.ts
+++ b/tests/unit/provider-models-route.test.ts
@@ -667,6 +667,28 @@ test("provider models route prefers providerSpecificData projectId over default-
   ]);
 });
 
+test("provider models route rejects projects/default-project placeholders", async () => {
+  const connection = await seedConnection("gemini-cli", {
+    authType: "oauth",
+    accessToken: "gemini-cli-access",
+    apiKey: null,
+    projectId: "projects/default-project",
+    providerSpecificData: {
+      projectId: "default-project",
+    },
+  });
+
+  globalThis.fetch = async () => {
+    throw new Error("retrieveUserQuota should not be called for placeholder project IDs");
+  };
+
+  const response = await callRoute(connection.id);
+  const body = (await response.json()) as any;
+
+  assert.equal(response.status, 400);
+  assert.equal(body.error, "Gemini CLI project ID not available. Please reconnect OAuth.");
+});
+
 test("provider models route retries Antigravity discovery endpoints before returning remote models", async () => {
   const connection = await seedConnection("antigravity", {
     authType: "oauth",


### PR DESCRIPTION
## What
- add Gemini CLI project-id resolver that prioritizes real configured IDs
- prevent `default-project` from being treated as a valid upstream project id
- keep managed onboarding state without forcing fake project fallback
- update provider models route to prefer provider-specific Gemini project ids and ignore `default-project`

## Why
Provider-scoped and Gemini CLI flows could propagate `default-project` as if it were a real upstream project identifier, causing incorrect quota/discovery behavior and bad upstream targeting.

## Testing
- node --import tsx/esm --test tests/unit/executor-gemini-cli.test.ts
- node --import tsx/esm --test tests/unit/provider-models-route.test.ts