### PR TITLE
fix(reasoning): gate replay by interleaved field

### DIFF
--- a/open-sse/services/reasoningCache.ts
+++ b/open-sse/services/reasoningCache.ts
@@ -74,10 +74,29 @@ export function requiresReasoningReplay(params: {
   model: string;
   thinkingEnabled?: boolean;
   supportsReasoning?: boolean;
+  interleavedField?: string | null;
+  allowLegacyFallback?: boolean;
 }): boolean {
-  if (isDeepSeekReasoningModel(params)) return true;
   const normalizedProvider = params.provider.trim().toLowerCase();
   const normalizedModel = params.model.trim();
+  const normalizedInterleavedField =
+    typeof params.interleavedField === "string" ? params.interleavedField.trim().toLowerCase() : "";
+
+  // Explicit model signal from models.dev (preferred source of truth).
+  if (normalizedInterleavedField === "reasoning_content") return true;
+  if (normalizedInterleavedField === "reasoning_details") return false;
+
+  // DeepSeek legacy reasoner family has an inverse contract: do not replay.
+  if (/deepseek-reasoner/i.test(normalizedModel) || /deepseek-r1/i.test(normalizedModel)) {
+    return false;
+  }
+
+  // Explicit known contract: DeepSeek V4 thinking with tool calls requires replay.
+  if (isDeepSeekReasoningModel(params)) return true;
+
+  const useLegacyFallback = params.allowLegacyFallback !== false;
+  if (!useLegacyFallback) return false;
+
   if (REASONING_REPLAY_PROVIDERS.has(normalizedProvider)) return true;
   return REASONING_REPLAY_MODEL_PATTERNS.some((p) => p.test(normalizedModel));
 }

--- a/open-sse/translator/index.ts
+++ b/open-sse/translator/index.ts
@@ -290,7 +290,7 @@ export function translateRequest(
     model: normalizedModel,
     thinkingEnabled: hasThinkingConfig(result),
     supportsReasoning: supportsReasoning({ provider: normalizedProvider, model: normalizedModel }),
-    interleavedField: resolvedCapabilities.interleavedField,
+    interleavedField: resolvedCapabilities?.interleavedField ?? null,
     allowLegacyFallback: false,
   });
   if (isReasoner && result.messages && Array.isArray(result.messages)) {

--- a/open-sse/translator/index.ts
+++ b/open-sse/translator/index.ts
@@ -14,7 +14,7 @@ import { getRequestTranslator, getResponseTranslator } from "./registry.ts";
 import { bootstrapTranslatorRegistry } from "./bootstrap.ts";
 import { hasThinkingConfig, normalizeThinkingConfig } from "../services/provider.ts";
 import { applyThinkingBudget } from "../services/thinkingBudget.ts";
-import { supportsReasoning } from "../services/modelCapabilities.ts";
+import { getResolvedModelCapabilities, supportsReasoning } from "../services/modelCapabilities.ts";
 import { normalizeRoles } from "../services/roleNormalizer.ts";
 import {
   lookupReasoning,
@@ -281,11 +281,17 @@ export function translateRequest(
   // back to the API."
   const normalizedProvider = String(provider ?? "");
   const normalizedModel = String(model ?? "");
+  const resolvedCapabilities = getResolvedModelCapabilities({
+    provider: normalizedProvider,
+    model: normalizedModel,
+  });
   const isReasoner = requiresReasoningReplay({
     provider: normalizedProvider,
     model: normalizedModel,
     thinkingEnabled: hasThinkingConfig(result),
     supportsReasoning: supportsReasoning({ provider: normalizedProvider, model: normalizedModel }),
+    interleavedField: resolvedCapabilities.interleavedField,
+    allowLegacyFallback: false,
   });
   if (isReasoner && result.messages && Array.isArray(result.messages)) {
     const canReplayReasoningOnly = isDeepSeekReplayTarget(normalizedProvider, normalizedModel);

--- a/tests/unit/reasoning-cache.test.ts
+++ b/tests/unit/reasoning-cache.test.ts
@@ -38,6 +38,33 @@ import { getDbInstance } from "../../src/lib/db/core.ts";
 import { getReasoningCache, setReasoningCache } from "../../src/lib/db/reasoningCache.ts";
 import { DELETE, GET } from "../../src/app/api/cache/reasoning/route.ts";
 import { updateSettings } from "../../src/lib/db/settings";
+import {
+  clearModelsDevCapabilities,
+  saveModelsDevCapabilities,
+} from "../../src/lib/modelsDevSync.ts";
+
+function buildCapability(overrides = {}) {
+  return {
+    tool_call: null,
+    reasoning: null,
+    attachment: null,
+    structured_output: null,
+    temperature: null,
+    modalities_input: "[]",
+    modalities_output: "[]",
+    knowledge_cutoff: null,
+    release_date: null,
+    last_updated: null,
+    status: null,
+    family: null,
+    open_weights: null,
+    limit_context: null,
+    limit_input: null,
+    limit_output: null,
+    interleaved_field: null,
+    ...overrides,
+  };
+}
 
 before(async () => {
   await updateSettings({ requireLogin: false });
@@ -399,21 +426,21 @@ describe("Reasoning Replay Cache — Provider Detection", () => {
     assert.equal(requiresReasoningReplay({ provider: "opencode-go", model: "some-model" }), true);
   });
 
-  it("should detect siliconflow as requiring replay", () => {
-    assert.equal(requiresReasoningReplay({ provider: "siliconflow", model: "deepseek-r1" }), true);
+  it("should not replay legacy deepseek-r1 even under replay providers", () => {
+    assert.equal(requiresReasoningReplay({ provider: "siliconflow", model: "deepseek-r1" }), false);
   });
 
-  it("should detect deepseek-r1 model pattern", () => {
+  it("should not replay deepseek-r1 model pattern", () => {
     assert.equal(
       requiresReasoningReplay({ provider: "unknown-provider", model: "deepseek-r1" }),
-      true
+      false
     );
   });
 
   it("should detect deepseek-reasoner model pattern", () => {
     assert.equal(
       requiresReasoningReplay({ provider: "unknown-provider", model: "deepseek-reasoner" }),
-      true
+      false
     );
   });
 
@@ -506,10 +533,12 @@ describe("Reasoning Replay Cache — Provider Detection", () => {
 describe("Reasoning Replay Cache — Translator Replay", () => {
   before(() => {
     clearReasoningCacheAll();
+    clearModelsDevCapabilities();
   });
 
   after(() => {
     clearReasoningCacheAll();
+    clearModelsDevCapabilities();
   });
 
   function translateWithToolHistory(provider: string, model: string, callId: string) {
@@ -538,6 +567,16 @@ describe("Reasoning Replay Cache — Translator Replay", () => {
 
   it("should inject cached reasoning for DeepSeek instead of empty fallback", () => {
     clearReasoningCacheAll();
+    clearModelsDevCapabilities();
+    saveModelsDevCapabilities({
+      deepseek: {
+        "deepseek-reasoner": buildCapability({
+          interleaved_field: "reasoning_content",
+          reasoning: true,
+          tool_call: true,
+        }),
+      },
+    });
     cacheReasoning("call_translate_ds", "deepseek", "deepseek-reasoner", "DeepSeek cached plan");
 
     const translated = translateWithToolHistory(
@@ -552,6 +591,16 @@ describe("Reasoning Replay Cache — Translator Replay", () => {
 
   it("should preserve client-provided reasoning content", () => {
     clearReasoningCacheAll();
+    clearModelsDevCapabilities();
+    saveModelsDevCapabilities({
+      deepseek: {
+        "deepseek-reasoner": buildCapability({
+          interleaved_field: "reasoning_content",
+          reasoning: true,
+          tool_call: true,
+        }),
+      },
+    });
     cacheReasoning("call_preserve", "deepseek", "deepseek-reasoner", "Cached reasoning");
 
     const translated = translateRequest(
@@ -586,6 +635,23 @@ describe("Reasoning Replay Cache — Translator Replay", () => {
 
   it("should inject cached reasoning for Qwen and GLM thinking models", () => {
     clearReasoningCacheAll();
+    clearModelsDevCapabilities();
+    saveModelsDevCapabilities({
+      qwen: {
+        "qwen3-thinking-235b": buildCapability({
+          interleaved_field: "reasoning_content",
+          reasoning: true,
+          tool_call: true,
+        }),
+      },
+      glm: {
+        "glm-5-thinking": buildCapability({
+          interleaved_field: "reasoning_content",
+          reasoning: true,
+          tool_call: true,
+        }),
+      },
+    });
     cacheReasoning("call_qwen_think", "qwen", "qwen3-thinking-235b", "Qwen cached plan");
     cacheReasoning("call_glm_think", "glm", "glm-5-thinking", "GLM cached plan");
 
@@ -599,6 +665,7 @@ describe("Reasoning Replay Cache — Translator Replay", () => {
 
   it("should not inject reasoning_content for generic non-reasoning providers", () => {
     clearReasoningCacheAll();
+    clearModelsDevCapabilities();
     cacheReasoning("call_openai", "openai", "gpt-4o", "Should not replay");
 
     const translated = translateWithToolHistory("openai", "gpt-4o", "call_openai");
@@ -609,6 +676,16 @@ describe("Reasoning Replay Cache — Translator Replay", () => {
 
   it("should support the full capture then replay flow", () => {
     clearReasoningCacheAll();
+    clearModelsDevCapabilities();
+    saveModelsDevCapabilities({
+      deepseek: {
+        "deepseek-reasoner": buildCapability({
+          interleaved_field: "reasoning_content",
+          reasoning: true,
+          tool_call: true,
+        }),
+      },
+    });
 
     const captured = cacheReasoningFromAssistantMessage(
       {
@@ -625,6 +702,55 @@ describe("Reasoning Replay Cache — Translator Replay", () => {
     assert.equal(captured, 1);
     assert.equal(translated.messages[1].reasoning_content, "Full flow cached plan");
     assert.equal(getReasoningCacheServiceStats().replays, 1);
+  });
+
+  it("should strip reasoning_content when model has no interleaved replay signal", () => {
+    clearReasoningCacheAll();
+    clearModelsDevCapabilities();
+
+    const translated = translateRequest(
+      FORMATS.OPENAI,
+      FORMATS.OPENAI,
+      "deepseek-reasoner",
+      {
+        messages: [
+          { role: "user", content: "hello" },
+          {
+            role: "assistant",
+            content: "ok",
+            reasoning_content: "should be stripped",
+          },
+        ],
+      },
+      false,
+      null,
+      "deepseek"
+    );
+
+    assert.equal(translated.messages[1].reasoning_content, undefined);
+  });
+
+  it("should not inject reasoning_content when interleaved field is reasoning_details", () => {
+    clearReasoningCacheAll();
+    clearModelsDevCapabilities();
+    saveModelsDevCapabilities({
+      testprovider: {
+        "test-reasoning-details": buildCapability({
+          interleaved_field: "reasoning_details",
+          reasoning: true,
+          tool_call: true,
+        }),
+      },
+    });
+    cacheReasoning("call_details", "testprovider", "test-reasoning-details", "cached");
+
+    const translated = translateWithToolHistory(
+      "testprovider",
+      "test-reasoning-details",
+      "call_details"
+    );
+
+    assert.equal(translated.messages[1].reasoning_content, undefined);
   });
 });
 

--- a/tests/unit/tool-request-sanitization.test.ts
+++ b/tests/unit/tool-request-sanitization.test.ts
@@ -10,6 +10,31 @@ const {
 } = await import("../../open-sse/translator/helpers/schemaCoercion.ts");
 const { translateRequest } = await import("../../open-sse/translator/index.ts");
 const { FORMATS } = await import("../../open-sse/translator/formats.ts");
+const { clearModelsDevCapabilities, saveModelsDevCapabilities } =
+  await import("../../src/lib/modelsDevSync.ts");
+
+function buildCapability(overrides = {}) {
+  return {
+    tool_call: null,
+    reasoning: null,
+    attachment: null,
+    structured_output: null,
+    temperature: null,
+    modalities_input: "[]",
+    modalities_output: "[]",
+    knowledge_cutoff: null,
+    release_date: null,
+    last_updated: null,
+    status: null,
+    family: null,
+    open_weights: null,
+    limit_context: null,
+    limit_input: null,
+    limit_output: null,
+    interleaved_field: null,
+    ...overrides,
+  };
+}
 
 test("tool sanitization: coerces numeric JSON Schema fields recursively", () => {
   const schema = {
@@ -171,6 +196,17 @@ test("tool sanitization: injects empty reasoning_content only for DeepSeek tool-
 });
 
 test("translateRequest injects reasoning_content for DeepSeek assistant tool calls", () => {
+  clearModelsDevCapabilities();
+  saveModelsDevCapabilities({
+    deepseek: {
+      "deepseek-v4-flash": buildCapability({
+        interleaved_field: "reasoning_content",
+        reasoning: true,
+        tool_call: true,
+      }),
+    },
+  });
+
   const translated = translateRequest(
     FORMATS.OPENAI,
     FORMATS.OPENAI,
@@ -193,4 +229,5 @@ test("translateRequest injects reasoning_content for DeepSeek assistant tool cal
   );
 
   assert.equal(translated.messages[1].reasoning_content, "");
+  clearModelsDevCapabilities();
 });

--- a/tests/unit/translator-helper-branches.test.ts
+++ b/tests/unit/translator-helper-branches.test.ts
@@ -10,6 +10,31 @@ const { FORMATS } = await import("../../open-sse/translator/formats.ts");
 const { translateRequest } = await import("../../open-sse/translator/index.ts");
 const { cacheReasoningByKey, clearReasoningCacheAll, getReasoningCacheServiceStats } =
   await import("../../open-sse/services/reasoningCache.ts");
+const { clearModelsDevCapabilities, saveModelsDevCapabilities } =
+  await import("../../src/lib/modelsDevSync.ts");
+
+function buildCapability(overrides = {}) {
+  return {
+    tool_call: null,
+    reasoning: null,
+    attachment: null,
+    structured_output: null,
+    temperature: null,
+    modalities_input: "[]",
+    modalities_output: "[]",
+    knowledge_cutoff: null,
+    release_date: null,
+    last_updated: null,
+    status: null,
+    family: null,
+    open_weights: null,
+    limit_context: null,
+    limit_input: null,
+    limit_output: null,
+    interleaved_field: null,
+    ...overrides,
+  };
+}
 
 const originalMathRandom = Math.random;
 
@@ -489,19 +514,29 @@ test("toolCallHelper normalizes ids, links tool responses and inserts missing to
   assert.deepEqual(toolCallHelper.fixMissingToolResponses({ messages: null }), { messages: null });
 });
 
-test("translateRequest replays cached DeepSeek reasoning messages without tool calls", () => {
+test("translateRequest replays cached reasoning-only messages when interleaved field is reasoning_content", () => {
   clearReasoningCacheAll();
+  clearModelsDevCapabilities();
+  saveModelsDevCapabilities({
+    deepseek: {
+      "deepseek-v4-flash": buildCapability({
+        interleaved_field: "reasoning_content",
+        reasoning: true,
+        tool_call: true,
+      }),
+    },
+  });
   cacheReasoningByKey(
     "request:req_reasoning_only:message:0",
     "deepseek",
-    "deepseek-reasoner",
+    "deepseek-v4-flash",
     "cached reasoning only"
   );
 
   const result = translateRequest(
     FORMATS.OPENAI,
     FORMATS.OPENAI,
-    "deepseek-reasoner",
+    "deepseek-v4-flash",
     {
       _reasoningCacheRequestId: "req_reasoning_only",
       messages: [
@@ -516,6 +551,7 @@ test("translateRequest replays cached DeepSeek reasoning messages without tool c
 
   assert.equal(result.messages[1].reasoning_content, "cached reasoning only");
   assert.equal(getReasoningCacheServiceStats().replays, 1);
+  clearModelsDevCapabilities();
   clearReasoningCacheAll();
 });
 
@@ -544,7 +580,7 @@ test("translateRequest does not replay reasoning-only messages for non-DeepSeek 
     "kimi"
   );
 
-  assert.equal(result.messages[1].reasoning_content, "");
+  assert.equal(result.messages[1].reasoning_content, undefined);
   assert.equal(getReasoningCacheServiceStats().replays, 0);
   clearReasoningCacheAll();
 


### PR DESCRIPTION
## What
- gate reasoning replay injection on model interleaved capability metadata
- avoid injecting `reasoning_content` when provider/model uses incompatible interleaved fields
- tighten replay path assertions with unit coverage updates

## Why
Some providers/models expose different interleaved reasoning field contracts. Injecting `reasoning_content` unconditionally can produce malformed upstream payloads or degraded behavior.

## Testing
- node --import tsx/esm --test tests/unit/reasoning-cache.test.ts