### PR TITLE
fix(cli): register openclaw in tool-detector (#2833)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - **combos:** fix combo handling so transient 429 rate limit errors do not poison or persist the rate limited state for the same-provider connection (#2800 — thanks @apoapostolov)
 - **gemini:** translate signature-less Gemini thinking model tool calls to text parts to prevent `400 "missing thought_signature"` errors (#2801 — thanks @herjarsa)
 - **warning-cleanup:** relax node engine constraint to `>=22.0.0` and clean dependencies (keeping `marked-terminal` to prevent TUI REPL crash) (#2792 — thanks @oyi77)
+- **fix(cli):** register openclaw in the CLI tool-detector so it appears in `omniroute status` alongside its existing API and config support ([#2833](https://github.com/diegosouzapw/OmniRoute/issues/2833))
 
 ### 🧹 Chores
 

--- a/src/lib/cli-helper/tool-detector.ts
+++ b/src/lib/cli-helper/tool-detector.ts
@@ -40,6 +40,7 @@ const TOOLS = [
   { id: "continue", name: "Continue", configPath: "~/.continue/config.yaml" },
   { id: "hermes", name: "Hermes", configPath: "~/.hermes/config.yaml" },
   { id: "hermes-agent", name: "Hermes Agent", configPath: "~/.hermes/config.yaml" },
+  { id: "openclaw", name: "OpenClaw", configPath: "~/.openclaw/openclaw.json" },
 ] as const;
 
 const BINARY_NAMES: Record<string, string> = {
@@ -51,6 +52,7 @@ const BINARY_NAMES: Record<string, string> = {
   continue: "continue",
   hermes: "hermes",
   "hermes-agent": "hermes",
+  openclaw: "openclaw",
 };
 
 function expandHome(p: string): string {

--- a/tests/unit/cli-helper/tool-detector.test.ts
+++ b/tests/unit/cli-helper/tool-detector.test.ts
@@ -13,6 +13,9 @@ describe("tool-detector", () => {
       if (cmd === "hermes") {
         return { stdout: "v0.75.3\n" };
       }
+      if (cmd === "openclaw") {
+        return { stdout: "v0.3.1\n" };
+      }
       if (cmd === "which") {
         return { stdout: "/usr/local/bin/opencode\n" };
       }
@@ -47,6 +50,21 @@ describe("tool-detector", () => {
       assert.ok(result!.configPath.includes(".hermes/config.yaml"));
       assert.strictEqual(typeof result!.configured, "boolean");
     });
+
+    // Regression test for #2833 — openclaw was missing from TOOLS array
+    it("returns DetectedTool object for openclaw with the openclaw config path", async () => {
+      const result = await toolDetector.detectTool("openclaw");
+      assert.ok(result !== null, "detectTool('openclaw') must not return null");
+      assert.strictEqual(result!.id, "openclaw");
+      assert.strictEqual(result!.name, "OpenClaw");
+      assert.strictEqual(result!.installed, true);
+      assert.strictEqual(result!.version, "0.3.1");
+      assert.ok(
+        result!.configPath.includes(".openclaw/openclaw.json"),
+        `expected configPath to include '.openclaw/openclaw.json', got: ${result!.configPath}`,
+      );
+      assert.strictEqual(typeof result!.configured, "boolean");
+    });
   });
 
   describe("detectAllTools", () => {
@@ -61,6 +79,18 @@ describe("tool-detector", () => {
         assert.ok("configPath" in t);
         assert.ok("configured" in t);
       }
+    });
+
+    // Regression test for #2833 — openclaw must appear in detectAllTools()
+    it("includes openclaw in the detected tools list", async () => {
+      const tools = await toolDetector.detectAllTools();
+      const openclaw = tools.find((t) => t.id === "openclaw");
+      assert.ok(openclaw !== undefined, "detectAllTools() must include an entry with id='openclaw'");
+      assert.strictEqual(openclaw!.name, "OpenClaw");
+      assert.ok(
+        openclaw!.configPath.includes(".openclaw/openclaw.json"),
+        `expected configPath to include '.openclaw/openclaw.json', got: ${openclaw!.configPath}`,
+      );
     });
   });
 });


### PR DESCRIPTION
Closes #2833

## Summary
- OpenClaw had complete API route coverage (`/api/cli-tools/openclaw-settings`, `/api/cli-tools/status`, `getCliPrimaryConfigPath("openclaw")`) but was absent from the CLI `tool-detector.ts` `TOOLS` array and `BINARY_NAMES` map.
- It silently dropped out of `omniroute status` even when `~/.openclaw/openclaw.json` existed.
- Registered now: `{ id: "openclaw", name: "OpenClaw", configPath: "~/.openclaw/openclaw.json" }` in `TOOLS` and `"openclaw": "openclaw"` in `BINARY_NAMES`. Config path matches `cliRuntime.ts` `CLI_TOOLS.openclaw.paths.settings`.

## Test plan
- [x] Regression test: `detectTool("openclaw")` returns non-null with correct `id`, `name`, `configPath` (`.openclaw/openclaw.json`), and `version`.
- [x] Regression test: `detectAllTools()` includes an entry with `id="openclaw"`.
- [x] All 6 tool-detector tests green (`pass 6 / fail 0`).
- [x] `eslint` clean on changed files (0 errors/warnings).
- [x] `typecheck:core` clean (exit 0).

🔧 Auto-generated by /resolve-issues round 4