### PR TITLE
fix(deepseek-web): return 400 when client sends tools[] (closes #2848)

### DIFF
--- a/open-sse/executors/deepseek-web.ts
+++ b/open-sse/executors/deepseek-web.ts
@@ -683,6 +683,30 @@ export class DeepSeekWebExecutor extends BaseExecutor {
 
   async execute({ model, body, stream, credentials, signal, log }: ExecuteInput) {
     const bodyObj = (body || {}) as Record<string, unknown>;
+
+    // chat.deepseek.com's web API only accepts {prompt, ref_file_ids,
+    // thinking_enabled, search_enabled} - no tools field. Silently dropping
+    // tools[] is misleading: models reply as if no tools were ever offered,
+    // causing agentic clients (OpenAI-compatible) to hallucinate "I don't
+    // have that tool". Fail fast with a clear error so callers route to the
+    // official DeepSeek API (provider: 'deepseek') or a different provider
+    // for tool-using requests. See #2848.
+    const requestedTools = bodyObj.tools;
+    if (Array.isArray(requestedTools) && requestedTools.length > 0) {
+      return {
+        response: errorResponse(
+          400,
+          "deepseek-web upstream (chat.deepseek.com) does not support function calling. " +
+            "The web interface only accepts text + thinking_enabled + search_enabled flags. " +
+            "Use provider 'deepseek' (official api.deepseek.com) for tool-using requests, " +
+            "or route through a different provider."
+        ),
+        url: COMPLETION_URL,
+        headers: {},
+        transformedBody: body,
+      };
+    }
+
     const messages = (Array.isArray(bodyObj.messages) ? bodyObj.messages : []) as Array<{
       role: string;
       content: string;

--- a/tests/unit/deepseek-web.test.ts
+++ b/tests/unit/deepseek-web.test.ts
@@ -58,6 +58,63 @@ test("execute returns 400 with empty apiKey", async () => {
   assert.equal(result.response.status, 400);
 });
 
+test("execute returns 400 when client sends non-empty tools[] (chat.deepseek.com has no tool support) - issue #2848", async () => {
+  const executor = new DeepSeekWebExecutor();
+  const result = await executor.execute({
+    model: "default",
+    body: {
+      messages: [{ role: "user", content: "call my_tool" }],
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: "my_tool",
+            description: "test",
+            parameters: { type: "object", properties: {} },
+          },
+        },
+      ],
+    },
+    stream: false,
+    credentials: { apiKey: "any-valid-looking-token" },
+    signal: AbortSignal.timeout(5000),
+  });
+  assert.equal(result.response.status, 400);
+  const text = await result.response.text();
+  assert.ok(
+    /does not support function calling/i.test(text),
+    `expected explanatory error body, got: ${text}`
+  );
+  assert.ok(
+    /provider 'deepseek'|api\.deepseek\.com/i.test(text),
+    `expected guidance to use official deepseek provider, got: ${text}`
+  );
+});
+
+test("execute does NOT 400 on tools[]=[] (empty array, equivalent to no tools)", async () => {
+  const executor = new DeepSeekWebExecutor();
+  const result = await executor.execute({
+    model: "default",
+    body: {
+      messages: [{ role: "user", content: "hi" }],
+      tools: [],
+    },
+    stream: false,
+    credentials: {},
+    signal: AbortSignal.timeout(5000),
+  });
+  assert.equal(
+    result.response.status,
+    400,
+    "still returns 400 but for missing userToken, NOT for tools[]"
+  );
+  const text = await result.response.text();
+  assert.ok(
+    text.includes("userToken"),
+    `expected userToken error (not tools error) for empty tools[], got: ${text}`
+  );
+});
+
 // ─── Test connection ─────────────────────────────────────────────────────
 
 test("testConnection returns false with empty credentials", async () => {


### PR DESCRIPTION
## Problem

`deepseek-web` (which proxies through `chat.deepseek.com`) silently drops the `tools[]` array from incoming OpenAI-format chat completion requests. Models routed through this provider never see any tools the client sent, and respond as if no tools are available.

Closes #2848.

### Reproduction (before this PR)

```bash
curl -s http://localhost:20128/v1/chat/completions -H 'Content-Type: application/json' -d '{
  "model": "deepseek-web/deepseek-v4-flash",
  "messages": [{"role": "user", "content": "List every tool function name. None if zero."}],
  "tools": [{"type":"function","function":{"name":"my_tool","description":"X","parameters":{"type":"object","properties":{}}}}],
  "max_tokens": 200
}'
```

Reply (captured live during issue investigation):
- Model says `"none"` when asked to list tools
- With `tool_choice: "required"`: *"I am unable to call the my_tool function because it is not a real or predefined tool in this environment."*

## Root cause

`open-sse/executors/deepseek-web.ts:execute()` builds the upstream request as `{chat_session_id, parent_message_id, model_type, prompt, ref_file_ids, thinking_enabled, search_enabled, preempt}` (L748-757). There is no `tools` field in chat.deepseek.com's web API shape. The executor correctly omits it but does not warn the caller, does not return an error, and does not surface anything in the response to indicate that the requested tools were ignored.

## Fix

Add a tools-array guard at the top of `execute()` that returns `400 Bad Request` with a clear error message when the client sends a non-empty `tools[]`:

```ts
const requestedTools = bodyObj.tools;
if (Array.isArray(requestedTools) && requestedTools.length > 0) {
  return {
    response: errorResponse(
      400,
      "deepseek-web upstream (chat.deepseek.com) does not support function calling. " +
        "The web interface only accepts text + thinking_enabled + search_enabled flags. " +
        "Use provider 'deepseek' (official api.deepseek.com) for tool-using requests, " +
        "or route through a different provider."
    ),
    url: COMPLETION_URL,
    headers: {},
    transformedBody: body,
  };
}
```

Empty `tools[]` arrays (`tools: []`) are still accepted — they are equivalent to omitting the field entirely.

## Tests

Two new tests in `tests/unit/deepseek-web.test.ts`:

1. **`execute returns 400 when client sends non-empty tools[]`** — verifies the guard fires + the error body contains both `"does not support function calling"` and a pointer to the official `'deepseek'` provider.
2. **`execute does NOT 400 on tools[]=[] (empty array)`** — regression guard so the empty-array path doesn't accidentally trigger the new error (it returns 400 for the next reason: missing userToken).

Both pass locally:

```
ok 1 - execute returns 400 when client sends non-empty tools[] (chat.deepseek.com has no tool support) - issue #2848
ok 2 - execute does NOT 400 on tools[]=[] (empty array, equivalent to no tools)
# pass 2 / fail 0
```

## Alternative approaches considered

| Option | Trade-off |
|---|---|
| ✅ 400 (this PR) | Loud, immediate, OpenAI-compatible error shape, no surprises |
| Warning header on success | Clients rarely inspect headers; still hallucinates |
| Drop tools silently (status quo) | The bug being fixed |
| Translate to text-prompt instructions | Brittle, model-dependent, against OpenAI semantics |

## Checklist

- [x] Bug fix (non-breaking for clients that don't send tools)
- [x] Unit tests added and passing
- [x] No changes to upstream chat.deepseek.com request shape (would be impossible)
- [x] Sibling of #2807 (vision passthrough) — same provider, separate fix