### PR TITLE
fix(antigravity): harden signatureless tool history

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -5105,6 +5105,7 @@ export async function handleChatCore({
       status: failureResponse.status,
       error: reason,
       errorType: streamReadiness.type,
+      errorCode: streamReadiness.code,
       response: failureResponse,
     };
   }

--- a/open-sse/translator/request/openai-to-gemini.ts
+++ b/open-sse/translator/request/openai-to-gemini.ts
@@ -183,6 +183,32 @@ function applyAntigravityGenerationDefaults(generationConfig: GeminiGenerationCo
   return config;
 }
 
+function stringifyHistoricalToolArguments(value: unknown): string {
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value ?? {});
+  } catch {
+    return String(value ?? "{}");
+  }
+}
+
+function buildInertHistoricalToolCallText(name: string | undefined, args: unknown): string {
+  const toolName = name || "unknown";
+  return [
+    "Historical tool-call record only. Do not execute, imitate, or continue this as a tool call.",
+    `Tool name: ${toolName}`,
+    `Tool arguments JSON: ${stringifyHistoricalToolArguments(args || "{}")}`,
+  ].join("\n");
+}
+
+function buildInertHistoricalToolResponseText(name: string, response: unknown): string {
+  return [
+    "Historical tool-response record only. Do not execute, imitate, or continue this as a tool response.",
+    `Tool name: ${name || "unknown"}`,
+    `Tool result: ${typeof response === "string" ? response : stringifyHistoricalToolArguments(response)}`,
+  ].join("\n");
+}
+
 // Core: Convert OpenAI request to Gemini format (base for all variants)
 function openaiToGeminiBase(
   model: string,
@@ -355,7 +381,7 @@ function openaiToGeminiBase(
             if (!signatureForToolCall && stringifySignaturelessToolCalls) {
               const args = fn.arguments || "{}";
               parts.push({
-                text: `[Tool call: ${fn.name || "unknown"}]\nArguments: ${args}`,
+                text: buildInertHistoricalToolCallText(fn.name, args),
               });
               continue;
             }
@@ -444,7 +470,7 @@ function openaiToGeminiBase(
                   const name = tcID2Name[id] || fn?.name || "unknown";
                   const resp = toolResponses[id];
                   toolParts.push({
-                    text: `[Tool response: ${name}]\nResult: ${resp}`,
+                    text: buildInertHistoricalToolResponseText(name, resp),
                   });
                 }
               }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "open-sse/mcp-server/schemas/",
     "open-sse/mcp-server/tools/",
     "open-sse/mcp-server/README.md",
+    "open-sse/utils/setupPolyfill.ts",
     "src/shared/contracts/",
     "src/shared/utils/nodeRuntimeSupport.ts",
     ".env.example",

--- a/src/sse/handlers/chat.ts
+++ b/src/sse/handlers/chat.ts
@@ -1005,9 +1005,62 @@ async function handleSingleModelChat(
         return result.response;
       }
 
-      if (result.errorType === "stream_timeout" || result.errorType === "stream_early_eof") {
+      const isAntigravityStreamReadinessFailure =
+        provider === "antigravity" &&
+        (result.errorCode === "STREAM_READINESS_TIMEOUT" ||
+          result.errorCode === "STREAM_EARLY_EOF" ||
+          result.errorType === "stream_timeout" ||
+          result.errorType === "stream_early_eof");
+
+      if (
+        (result.errorType === "stream_timeout" || result.errorType === "stream_early_eof") &&
+        !isAntigravityStreamReadinessFailure
+      ) {
         // Stream readiness timeout is an upstream stall after an HTTP response was received,
         // not an account/quota failure. Do NOT mark the account unavailable here.
+        return result.response;
+      }
+
+      if (isAntigravityStreamReadinessFailure) {
+        const { shouldFallback, cooldownMs } = await markAccountUnavailable(
+          credentials.connectionId,
+          result.status || HTTP_STATUS.BAD_GATEWAY,
+          result.error || result.errorCode || "Antigravity stream ended before useful content",
+          provider,
+          model,
+          providerProfile
+        );
+
+        if (shouldFallback && !hasForcedConnection) {
+          log.warn(
+            "AUTH",
+            `Antigravity connection ${accountId}... produced no useful stream content, trying fallback connection`
+          );
+          if (Number.isFinite(cooldownMs) && cooldownMs > 0) {
+            lastCooldownMs = cooldownMs;
+            requestRetryLastCooldownMs = cooldownMs;
+          }
+          if (runtimeOptions.sessionAffinityKey) {
+            try {
+              const affinity = getSessionAccountAffinity(
+                runtimeOptions.sessionAffinityKey,
+                provider
+              );
+              if (affinity?.connectionId === credentials.connectionId) {
+                deleteSessionAccountAffinity(runtimeOptions.sessionAffinityKey, provider);
+              }
+            } catch {
+              // best-effort: selection also excludes this connection for the current retry.
+            }
+          }
+          excludedConnectionIds.add(credentials.connectionId);
+          lastError = result.error;
+          lastStatus = result.status;
+          requestRetryLastError = result.error;
+          requestRetryLastStatus = result.status;
+          continue;
+        }
+
         return result.response;
       }
 

--- a/tests/unit/translator-openai-to-gemini.test.ts
+++ b/tests/unit/translator-openai-to-gemini.test.ts
@@ -620,7 +620,7 @@ test("OpenAI -> Antigravity wraps Gemini requests in a Cloud Code envelope", () 
   });
 });
 
-test("OpenAI -> Antigravity Gemini stringifies signature-less historical tool calls", () => {
+test("OpenAI -> Antigravity Gemini preserves signature-less historical tool calls as inert text", () => {
   const result = openaiToAntigravityRequest(
     "gemini-3.5-flash-low",
     {
@@ -662,9 +662,18 @@ test("OpenAI -> Antigravity Gemini stringifies signature-less historical tool ca
     modelTurn.parts.some(
       (part) =>
         typeof part.text === "string" &&
-        part.text.includes("[Tool call: default_api:todowrite_ide]")
+        part.text.includes("Historical tool-call record only") &&
+        part.text.includes("Tool name: default_api:todowrite_ide") &&
+        part.text.includes('Tool arguments JSON: {"todos":[]}')
     ),
-    "expected signature-less tool call to be preserved as text"
+    "expected signature-less tool call to be preserved as inert text"
+  );
+  assert.equal(
+    modelTurn.parts.some(
+      (part) => typeof part.text === "string" && part.text.includes("[Tool call:")
+    ),
+    false,
+    "signature-less historical call must not use executable textual tool-call markers"
   );
   assert.equal(
     modelTurn.parts.some((part) => part.functionCall),
@@ -678,10 +687,19 @@ test("OpenAI -> Antigravity Gemini stringifies signature-less historical tool ca
       content.parts.some(
         (part) =>
           typeof part.text === "string" &&
-          part.text.includes("[Tool response: default_api:todowrite_ide]")
+          part.text.includes("Historical tool-response record only") &&
+          part.text.includes("Tool name: default_api:todowrite_ide") &&
+          part.text.includes("Tool result: []")
       )
   );
-  assert.ok(toolTurn, "expected signature-less tool response to be preserved as text");
+  assert.ok(toolTurn, "expected signature-less tool response to be preserved as inert text");
+  assert.equal(
+    toolTurn.parts.some(
+      (part) => typeof part.text === "string" && part.text.includes("[Tool response:")
+    ),
+    false,
+    "signature-less historical response must not use executable textual tool-response markers"
+  );
   assert.equal(
     toolTurn.parts.some((part) => part.functionResponse),
     false,


### PR DESCRIPTION
## Summary

This PR hardens the Antigravity/Gemini replay path for historical tool calls that do not have a cached Gemini `thoughtSignature`.

It complements #2828 by preserving the existing `signaturelessToolCallMode: "text"` behavior while making that text explicitly inert, so old OpenAI-style tool-call history cannot be misread as a fresh tool call or as provider-internal reasoning syntax.

## Motivation

Gemini/Antigravity requires thought signatures for native tool-call history. When a historical OpenAI `tool_calls` entry or `tool` response has no signature, OmniRoute currently falls back to text. That is the right compatibility path, but the previous text looked like executable transcript syntax:

- `[Tool call: ...]`
- `[Tool response: ...]`

In long tool-heavy conversations this can be interpreted too aggressively by the model, causing visible pseudo-tool-call/reasoning artifacts and bad continuations. The fallback text should preserve context, but it should not look like a tool instruction or a native function call frame.

## Changes

- Converts signature-less historical tool calls into explicit inert text records:
  - `Historical tool-call record only...`
  - `Tool name: ...`
  - `Tool arguments JSON: ...`
- Converts signature-less historical tool responses into explicit inert text records:
  - `Historical tool-response record only...`
  - `Tool name: ...`
  - `Tool result: ...`
- Keeps signed Gemini tool-call history native; this only affects the signature-less fallback path.
- Preserves `STREAM_READINESS_TIMEOUT` / `STREAM_EARLY_EOF` as `errorCode` from `chatCore`.
- Lets Antigravity retry another eligible connection when a stream returns headers but ends before useful content, using the existing cooldown/fallback selector instead of returning the 502 immediately.
- Adds the missing packaged `open-sse/utils/setupPolyfill.ts` entry so CLI/package installs can load the runtime polyfill file.
- Updates translator unit coverage to assert that executable-looking `[Tool call:]` / `[Tool response:]` markers are no longer emitted for signature-less Antigravity Gemini history.

## Scope / Compatibility

- This is scoped to Antigravity/Gemini signature-less historical tool-call replay.
- It does not change normal signed Gemini thought-signature replay.
- It does not remove or alter Gemini CLI support.
- It does not introduce a new connection scheduler; the stream-empty recovery uses the existing credential fallback/cooldown flow.
- Non-Antigravity providers keep the existing stream-readiness behavior.

## Validation

- `npm run typecheck:core`
- `DISABLE_SQLITE_AUTO_BACKUP=true node --import tsx --import ./open-sse/utils/setupPolyfill.ts --test tests/unit/translator-openai-to-gemini.test.ts`
- `DISABLE_SQLITE_AUTO_BACKUP=true node --import tsx --import ./open-sse/utils/setupPolyfill.ts --test tests/unit/stream-readiness.test.ts tests/unit/executor-antigravity.test.ts`
- `git diff --check`
- Local Antigravity Explorer smoke against `antigravity/gemini-3-flash-agent`: completed successfully with tool calls and final answer; no visible pseudo tool-call markers in responses.
