### PR TITLE
fix(security): redact public Firebase Web key (secret-scanning #7) + document SHA-256 cache-key (code-scanning #261)

### DIFF
--- a/docs/superpowers/specs/2026-05-29-windsurf-login-fix-design.md
+++ b/docs/superpowers/specs/2026-05-29-windsurf-login-fix-design.md
@@ -40,7 +40,7 @@ Akibatnya user tidak bisa login ke Windsurf via OmniRoute. Provider effectively 
 ```
 
 Konstanta publik yang harus di-embed (extracted from Windsurf extension.js, public Firebase Web key — bukan secret):
-- `FIREBASE_API_KEY = "AIzaSyDsOl-1XpT5err0Tcnx8FFod1H8gVGIycY"`
+- `FIREBASE_API_KEY = "<REDACTED-public-firebase-web-key>"`
 - `GOOGLE_CLIENT_ID = "957777847521-egrk5uakal87pjkqctk89fe7b7qtd1dq.apps.googleusercontent.com"`
 - `REGISTER_SERVER = "https://register.windsurf.com"`
 
@@ -189,7 +189,7 @@ Restore browser-based login automation. User klik tombol Google/GitHub/Microsoft
 | File | Change |
 |---|---|
 | `src/lib/oauth/constants/oauth.ts` | Add `WINDSURF_FIREBASE_CONFIG` block: `firebaseApiKey` via `resolvePublicCred("windsurf_fb", "WINDSURF_FIREBASE_API_KEY")`, `googleClientId` via `resolvePublicCred("windsurf_google", "WINDSURF_GOOGLE_CLIENT_ID")`, `registerUrl: "https://register.windsurf.com"`, `firebaseAuthUrl`, `firebaseTokenUrl`, OAuth redirect uri `https://windsurf.com/login`. |
-| `open-sse/utils/publicCreds.ts` | Add embedded defaults: `windsurf_fb: "AIzaSyDsOl-1XpT5err0Tcnx8FFod1H8gVGIycY"`, `windsurf_google: "957777847521-egrk5uakal87pjkqctk89fe7b7qtd1dq.apps.googleusercontent.com"`. Both are public Web keys/client_ids — non-sensitive but must follow rule #11 pattern. |
+| `open-sse/utils/publicCreds.ts` | Add embedded defaults: `windsurf_fb: "<REDACTED-public-firebase-web-key>"`, `windsurf_google: "957777847521-egrk5uakal87pjkqctk89fe7b7qtd1dq.apps.googleusercontent.com"`. Both are public Web keys/client_ids — non-sensitive but must follow rule #11 pattern. |
 | `src/lib/oauth/providers/index.ts` | Register `"windsurf-firebase"` provider entry. |
 | `src/lib/db/migrations/<NNN>_windsurf_firebase.sql` | Add columns to `connections`: `firebase_refresh_token TEXT NULL` (encrypted), `firebase_expires_at INTEGER NULL`. Idempotent (`IF NOT EXISTS` pattern). |
 | `src/lib/db/connections.ts` | Update CRUD to handle new optional columns. Encrypt/decrypt via existing `connectionEncryption` helpers. |

--- a/open-sse/executors/inner-ai.ts
+++ b/open-sse/executors/inner-ai.ts
@@ -61,6 +61,12 @@ function lruSet<V>(map: Map<string, V>, key: string, value: V): void {
   }
 }
 
+// SHA-256 here derives an in-memory cache key from the session token — it is NOT
+// password-at-rest storage. The slow KDFs CWE-916 recommends (bcrypt/scrypt/Argon2)
+// are salted and non-deterministic, so they cannot be used as a stable Map key and
+// would defeat the cache entirely. CodeQL js/insufficient-password-hash flags this as
+// a false positive (dismissed); a fast cryptographic digest is the correct primitive
+// for keying an ephemeral, process-local cache.
 function tokenCacheKey(token: string): string {
   return createHash("sha256").update(token).digest("hex");
 }


### PR DESCRIPTION
Mirrors the security-scanning fixes already applied to `main` (commit dc3915a4e) onto `release/v3.8.6`. Scoped to **only** these two findings — no unrelated changes.

## Secret-scanning alert #7 — `google_api_key`
`docs/superpowers/specs/2026-05-29-windsurf-login-fix-design.md` embedded the literal public **Firebase Web API key** (`AIza…IycY`) on lines 43 and 192.

Firebase Web API keys are **non-sensitive by design** — they identify the Firebase project, they do not authenticate; access is gated by Firebase Security Rules + API-key restrictions (per Google's docs). The doc itself already annotated it as *"public Firebase Web key — bukan secret"*. Still, the literal trips GitHub secret scanning, so it is now redacted to a placeholder. The embedded default continues to flow through `resolvePublicCred()` per hard rule #11 (`docs/security/PUBLIC_CREDS.md`).

> Note: this doc is **not present on `main`** (it lives on `release/v3.8.6` and a few `fix/windsurf-*` branches), so there was nothing to redact on `main` for this alert. The key also remains in immutable git history and on those other fix branches — out of scope for this PR.

## Code-scanning alert #261 — `js/insufficient-password-hash`
`open-sse/executors/inner-ai.ts::tokenCacheKey()` uses `createHash("sha256")` to derive an **in-memory cache key** from the Inner.ai session token — **not** password-at-rest storage. The slow KDFs CWE-916 recommends (bcrypt/scrypt/Argon2) are salted and non-deterministic, so they cannot serve as a stable `Map` key and would defeat the cache. This is a **false positive**; added an explanatory comment (identical to the one landed on `main`). The GitHub alert is being dismissed as a false positive with this justification.

## Validation
- `inner-ai.ts`: prettier clean; comment-only change, ≤100 col.
- doc: minimal 2-line redaction (the file was already prettier-non-conformant before this change — intentionally not reformatting unrelated lines to keep the diff scoped).