### PR TITLE
fix(ci): resolve release/v3.8.6 gate failures (docs-sync, any-budget, pack-artifact)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,14 +33,6 @@
 
 ---
 
-## [3.8.6-patch] — 2026-05-27
-
-### 🔧 Bug Fixes
-
-- **fix(cli):** replace `cli-table3` dependency with a ~50-line hand-rolled ASCII formatter to resolve Node 24 / ESM interop breakage and remove tourniquet `package.json` overrides pinning `ansi-regex@^5`, `strip-ansi@^6`, `string-width@^4` ([#2752])
-
----
-
 ## [3.8.6] — 2026-05-27
 
 ### ✨ New Features
@@ -52,6 +44,7 @@
 ### 🔧 Bug Fixes
 
 - **cli:** restore `omniroute logs` command — create missing `/api/cli-tools/logs` route that `log-streamer.ts` was calling, returning filtered pino log entries with `follow` and `filter` query-param support (#2756)
+- **cli:** replace `cli-table3` dependency with a ~50-line hand-rolled ASCII formatter to resolve Node 24 / ESM interop breakage and remove tourniquet `package.json` overrides pinning `ansi-regex@^5`, `strip-ansi@^6`, `string-width@^4` (#2752)
 - **fix(opencode-go,opencode-zen):** mark qwen3.7-max / 3.6-plus / 3.5-plus as supportsVision:false to stop forwarding image blocks to vision-incapable upstream models ([#2822])
 - **nous-research:** append /chat/completions to provider baseUrl so DefaultExecutor's default URL builder hits the correct endpoint instead of returning 404 ([#2826])
 - **fix(quota):** honor explicit per-connection `quotaPreflightEnabled: false` even when the provider has global window defaults — adds early-return guard before the AND-of-negations gate in auth.ts ([#2831])

--- a/docs/superpowers/specs/2026-05-29-windsurf-login-fix-design.md
+++ b/docs/superpowers/specs/2026-05-29-windsurf-login-fix-design.md
@@ -40,7 +40,7 @@ Akibatnya user tidak bisa login ke Windsurf via OmniRoute. Provider effectively 
 ```
 
 Konstanta publik yang harus di-embed (extracted from Windsurf extension.js, public Firebase Web key — bukan secret):
-- `FIREBASE_API_KEY = "AIzaSyDsOl-1XpT5err0Tcnx8FFod1H8gVGIycY"`
+- `FIREBASE_API_KEY = "<REDACTED-public-firebase-web-key>"`
 - `GOOGLE_CLIENT_ID = "957777847521-egrk5uakal87pjkqctk89fe7b7qtd1dq.apps.googleusercontent.com"`
 - `REGISTER_SERVER = "https://register.windsurf.com"`
 
@@ -189,7 +189,7 @@ Restore browser-based login automation. User klik tombol Google/GitHub/Microsoft
 | File | Change |
 |---|---|
 | `src/lib/oauth/constants/oauth.ts` | Add `WINDSURF_FIREBASE_CONFIG` block: `firebaseApiKey` via `resolvePublicCred("windsurf_fb", "WINDSURF_FIREBASE_API_KEY")`, `googleClientId` via `resolvePublicCred("windsurf_google", "WINDSURF_GOOGLE_CLIENT_ID")`, `registerUrl: "https://register.windsurf.com"`, `firebaseAuthUrl`, `firebaseTokenUrl`, OAuth redirect uri `https://windsurf.com/login`. |
-| `open-sse/utils/publicCreds.ts` | Add embedded defaults: `windsurf_fb: "AIzaSyDsOl-1XpT5err0Tcnx8FFod1H8gVGIycY"`, `windsurf_google: "957777847521-egrk5uakal87pjkqctk89fe7b7qtd1dq.apps.googleusercontent.com"`. Both are public Web keys/client_ids — non-sensitive but must follow rule #11 pattern. |
+| `open-sse/utils/publicCreds.ts` | Add embedded defaults: `windsurf_fb: "<REDACTED-public-firebase-web-key>"`, `windsurf_google: "957777847521-egrk5uakal87pjkqctk89fe7b7qtd1dq.apps.googleusercontent.com"`. Both are public Web keys/client_ids — non-sensitive but must follow rule #11 pattern. |
 | `src/lib/oauth/providers/index.ts` | Register `"windsurf-firebase"` provider entry. |
 | `src/lib/db/migrations/<NNN>_windsurf_firebase.sql` | Add columns to `connections`: `firebase_refresh_token TEXT NULL` (encrypted), `firebase_expires_at INTEGER NULL`. Idempotent (`IF NOT EXISTS` pattern). |
 | `src/lib/db/connections.ts` | Update CRUD to handle new optional columns. Encrypt/decrypt via existing `connectionEncryption` helpers. |

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -4120,7 +4120,7 @@ export async function handleChatCore({
     // which path executed so we don't double-fire (race-prone) or skip (regression).
     let persistFnRan = false;
     const persistFn = onCredentialsRefreshed
-      ? async (refreshResult: any) => {
+      ? async (refreshResult: Record<string, unknown>) => {
           persistFnRan = true;
           // Mutate the shared credentials object so subsequent executor calls
           // in this request see the new tokens. Runs INSIDE the mutex.

--- a/scripts/build/pack-artifact-policy.ts
+++ b/scripts/build/pack-artifact-policy.ts
@@ -72,6 +72,9 @@ export const PACK_ARTIFACT_ROOT_ALLOWED_EXACT_PATHS: string[] = [
   "open-sse/mcp-server/runtimeHeartbeat.ts",
   "open-sse/mcp-server/scopeEnforcement.ts",
   "open-sse/mcp-server/server.ts",
+  // Runtime polyfill eagerly imported by bin/omniroute.mjs (Node <22 compat);
+  // shipped via package.json "files", so it must be allowed in the tarball.
+  "open-sse/utils/setupPolyfill.ts",
   "package.json",
   "scripts/build/build-next-isolated.mjs",
   "scripts/check/check-supported-node-runtime.ts",

--- a/tests/unit/pack-artifact-policy.test.ts
+++ b/tests/unit/pack-artifact-policy.test.ts
@@ -56,6 +56,15 @@ test("findUnexpectedArtifactPaths flags app pack files outside the allowlist", (
   assert.deepEqual(unexpectedPaths, ["app/scripts/build/prepublish.mjs", "docs/extra.md"]);
 });
 
+test("setupPolyfill.ts is allowed in the tarball (bin/omniroute.mjs imports it at startup)", () => {
+  const unexpectedPaths = findUnexpectedArtifactPaths(["open-sse/utils/setupPolyfill.ts"], {
+    exactPaths: PACK_ARTIFACT_ALLOWED_EXACT_PATHS,
+    prefixPaths: PACK_ARTIFACT_ALLOWED_PATH_PREFIXES,
+  });
+
+  assert.deepEqual(unexpectedPaths, []);
+});
+
 test("findMissingArtifactPaths flags missing root runtime files in the tarball", () => {
   const missingPaths = findMissingArtifactPaths(
     [


### PR DESCRIPTION
## Why

CI run [26630300877](https://github.com/diegosouzapw/OmniRoute/actions/runs/26630300877) on `release/v3.8.6` failed three gates. This PR fixes all three at the root cause.

## Failures fixed

| Job | Gate | Root cause | Fix |
|-----|------|-----------|-----|
| **Docs Sync (Strict)** | `check:docs-sync` | A spurious `## [3.8.6-patch]` section sat above `## [3.8.6]`, so the latest changelog release (`3.8.6-patch`) no longer matched `package.json` (`3.8.6`), and all 41 i18n CHANGELOG mirrors were flagged as missing that section. | Folded the lone `#2752` entry into `## [3.8.6]` and removed the `3.8.6-patch` heading. No changelog content lost. |
| **Lint** | `check:any-budget:t11` | `open-sse/handlers/chatCore.ts` regressed to 1 explicit `any` (budget `0`) at the credential-refresh persist callback. | Typed the callback arg as `Record<string, unknown>` — the exact shape of `runWithOnPersist`'s `RefreshPersistFn` contract. Type-only change, no runtime behavior difference. |
| **Package Artifact** | `check:pack-artifact` | `open-sse/utils/setupPolyfill.ts` ships via `package.json` `"files"` (it is eagerly imported by `bin/omniroute.mjs` at startup for Node <22 compat) but was missing from the pack-artifact policy allowlist, so the hygiene check flagged it as unexpected. | Added it to `PACK_ARTIFACT_ROOT_ALLOWED_EXACT_PATHS` + a regression test asserting it is allowed. |

## Verification (local, on this branch)

- `check:any-budget:t11` → PASS (`chatCore.ts` explicit any: 0)
- `check:docs-sync` / `check:docs-all` → exit 0 (`latest changelog release matches package version: 3.8.6`)
- `check:pack-artifact` → `✅ Pack artifact policy check passed.`
- `typecheck:core` + `typecheck:noimplicit:core` → exit 0
- `lint` → 0 errors
- `tests/unit/pack-artifact-policy.test.ts` → 5/5 pass (incl. new `setupPolyfill` assertion)
- pre-push `test:unit` → passed