### PR TITLE
fix(security): redact public Firebase Web key from windsurf spec

### DIFF
--- a/docs/superpowers/specs/2026-05-29-windsurf-login-fix-design.md
+++ b/docs/superpowers/specs/2026-05-29-windsurf-login-fix-design.md
@@ -40,7 +40,7 @@ Akibatnya user tidak bisa login ke Windsurf via OmniRoute. Provider effectively 
 ```
 
 Konstanta publik yang harus di-embed (extracted from Windsurf extension.js, public Firebase Web key — bukan secret):
-- `FIREBASE_API_KEY = "AIzaSyDsOl-1XpT5err0Tcnx8FFod1H8gVGIycY"`
+- `FIREBASE_API_KEY = "<REDACTED-public-firebase-web-key>"`
 - `GOOGLE_CLIENT_ID = "957777847521-egrk5uakal87pjkqctk89fe7b7qtd1dq.apps.googleusercontent.com"`
 - `REGISTER_SERVER = "https://register.windsurf.com"`
 
@@ -189,7 +189,7 @@ Restore browser-based login automation. User klik tombol Google/GitHub/Microsoft
 | File | Change |
 |---|---|
 | `src/lib/oauth/constants/oauth.ts` | Add `WINDSURF_FIREBASE_CONFIG` block: `firebaseApiKey` via `resolvePublicCred("windsurf_fb", "WINDSURF_FIREBASE_API_KEY")`, `googleClientId` via `resolvePublicCred("windsurf_google", "WINDSURF_GOOGLE_CLIENT_ID")`, `registerUrl: "https://register.windsurf.com"`, `firebaseAuthUrl`, `firebaseTokenUrl`, OAuth redirect uri `https://windsurf.com/login`. |
-| `open-sse/utils/publicCreds.ts` | Add embedded defaults: `windsurf_fb: "AIzaSyDsOl-1XpT5err0Tcnx8FFod1H8gVGIycY"`, `windsurf_google: "957777847521-egrk5uakal87pjkqctk89fe7b7qtd1dq.apps.googleusercontent.com"`. Both are public Web keys/client_ids — non-sensitive but must follow rule #11 pattern. |
+| `open-sse/utils/publicCreds.ts` | Add embedded defaults: `windsurf_fb: "<REDACTED-public-firebase-web-key>"`, `windsurf_google: "957777847521-egrk5uakal87pjkqctk89fe7b7qtd1dq.apps.googleusercontent.com"`. Both are public Web keys/client_ids — non-sensitive but must follow rule #11 pattern. |
 | `src/lib/oauth/providers/index.ts` | Register `"windsurf-firebase"` provider entry. |
 | `src/lib/db/migrations/<NNN>_windsurf_firebase.sql` | Add columns to `connections`: `firebase_refresh_token TEXT NULL` (encrypted), `firebase_expires_at INTEGER NULL`. Idempotent (`IF NOT EXISTS` pattern). |
 | `src/lib/db/connections.ts` | Update CRUD to handle new optional columns. Encrypt/decrypt via existing `connectionEncryption` helpers. |


### PR DESCRIPTION
Redact the literal public Firebase Web API key (secret-scanning #7) to a placeholder. Firebase Web API keys are non-sensitive by design but the literal trips GitHub secret scanning. Mirrors the redaction landed on release/v3.8.6 (PR #2894). Embedded default still flows through resolvePublicCred (rule #11).

## Summary

- Describe the user-facing or operational change.

## Related Issues

- Closes #
- Related to #

## Validation

- [ ] `npm run lint`
- [ ] `npm run test:unit`
- [ ] `npm run test:coverage`
- [ ] Coverage is still `>= 60%` for statements, lines, functions, and branches
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below

## Tests Added Or Updated

- List every changed or added automated test file.
- If no production code changed, state that here.

## Coverage Notes

- If this PR changes `src/`, `open-sse/`, `electron/`, or `bin/`, explain which tests cover the change.
- If coverage moved down in any touched file, explain why and what follow-up task will recover it.

## Reviewer Notes

- Call out any risky areas, migrations, feature flags, or manual validation that reviewers should know about.