### PR TITLE
fix(dashboard): theme ReactFlow Controls +/- buttons for dark mode

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -412,3 +412,18 @@ select option {
   background-color: var(--color-surface);
   color: var(--color-text-main);
 }
+
+/* ReactFlow Controls (zoom +/- buttons) dark mode theming */
+.react-flow__controls-button {
+  background-color: var(--color-surface);
+  border-bottom-color: var(--color-border);
+  fill: var(--color-text-main);
+}
+
+.react-flow__controls-button:hover {
+  background-color: var(--color-bg-subtle);
+}
+
+.react-flow__controls-button svg {
+  fill: var(--color-text-main);
+}


### PR DESCRIPTION
﻿## Problem

The ReactFlow `<Controls />` component renders zoom +/- buttons with default light-themed styles from `@xyflow/react/dist/style.css`. In dark mode, the buttons displayed incorrect icon/background colors, breaking the visual consistency of the Provider Topology widget on the Home page.

## Solution

Added CSS rules in `src/app/globals.css` to properly theme ReactFlow Controls buttons using the application's CSS custom properties, ensuring they adapt correctly to both light and dark modes.

## Changes

- Themed `.react-flow__controls-button` with `var(--color-surface)`, `var(--color-text-main)`, and `var(--color-border)` for consistent dark mode appearance
- Styled SVG icon fill within controls buttons to use `var(--color-text-main)`
- Applied hover state colors using `var(--color-bg-subtle)`
- Follows the established pattern from the existing select/option dark mode fix
