### PR TITLE
docs(i18n): sync 41 llm.txt mirrors to v3.8.7

### DIFF
--- a/docs/i18n/ar/llm.txt
+++ b/docs/i18n/ar/llm.txt
@@ -12,7 +12,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 
 **Key value:** One endpoint (`http://localhost:20128/v1`), unlimited models, zero downtime, minimal cost.
 
-**Current version:** 3.8.5
+**Current version:** 3.8.7
 
 ## Tech Stack
 
@@ -283,7 +283,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 └── .env.example                  # Environment variable template
 ```
 
-## Key Features (v3.8.5)
+## Key Features (v3.8.7)
 
 ### Core Proxy
 - **177 AI providers** with automatic format translation

--- a/docs/i18n/az/llm.txt
+++ b/docs/i18n/az/llm.txt
@@ -12,7 +12,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 
 **Key value:** One endpoint (`http://localhost:20128/v1`), unlimited models, zero downtime, minimal cost.
 
-**Current version:** 3.8.5
+**Current version:** 3.8.7
 
 ## Tech Stack
 
@@ -283,7 +283,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 └── .env.example                  # Environment variable template
 ```
 
-## Key Features (v3.8.5)
+## Key Features (v3.8.7)
 
 ### Core Proxy
 - **177 AI providers** with automatic format translation

--- a/docs/i18n/bg/llm.txt
+++ b/docs/i18n/bg/llm.txt
@@ -12,7 +12,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 
 **Key value:** One endpoint (`http://localhost:20128/v1`), unlimited models, zero downtime, minimal cost.
 
-**Current version:** 3.8.5
+**Current version:** 3.8.7
 
 ## Tech Stack
 
@@ -283,7 +283,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 └── .env.example                  # Environment variable template
 ```
 
-## Key Features (v3.8.5)
+## Key Features (v3.8.7)
 
 ### Core Proxy
 - **177 AI providers** with automatic format translation

--- a/docs/i18n/bn/llm.txt
+++ b/docs/i18n/bn/llm.txt
@@ -12,7 +12,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 
 **Key value:** One endpoint (`http://localhost:20128/v1`), unlimited models, zero downtime, minimal cost.
 
-**Current version:** 3.8.5
+**Current version:** 3.8.7
 
 ## Tech Stack
 
@@ -283,7 +283,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 └── .env.example                  # Environment variable template
 ```
 
-## Key Features (v3.8.5)
+## Key Features (v3.8.7)
 
 ### Core Proxy
 - **177 AI providers** with automatic format translation

--- a/docs/i18n/cs/llm.txt
+++ b/docs/i18n/cs/llm.txt
@@ -12,7 +12,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 
 **Key value:** One endpoint (`http://localhost:20128/v1`), unlimited models, zero downtime, minimal cost.
 
-**Current version:** 3.8.5
+**Current version:** 3.8.7
 
 ## Tech Stack
 
@@ -283,7 +283,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 └── .env.example                  # Environment variable template
 ```
 
-## Key Features (v3.8.5)
+## Key Features (v3.8.7)
 
 ### Core Proxy
 - **177 AI providers** with automatic format translation

--- a/docs/i18n/da/llm.txt
+++ b/docs/i18n/da/llm.txt
@@ -12,7 +12,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 
 **Key value:** One endpoint (`http://localhost:20128/v1`), unlimited models, zero downtime, minimal cost.
 
-**Current version:** 3.8.5
+**Current version:** 3.8.7
 
 ## Tech Stack
 
@@ -283,7 +283,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 └── .env.example                  # Environment variable template
 ```
 
-## Key Features (v3.8.5)
+## Key Features (v3.8.7)
 
 ### Core Proxy
 - **177 AI providers** with automatic format translation

--- a/docs/i18n/de/llm.txt
+++ b/docs/i18n/de/llm.txt
@@ -12,7 +12,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 
 **Key value:** One endpoint (`http://localhost:20128/v1`), unlimited models, zero downtime, minimal cost.
 
-**Current version:** 3.8.5
+**Current version:** 3.8.7
 
 ## Tech Stack
 
@@ -283,7 +283,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 └── .env.example                  # Environment variable template
 ```
 
-## Key Features (v3.8.5)
+## Key Features (v3.8.7)
 
 ### Core Proxy
 - **177 AI providers** with automatic format translation

--- a/docs/i18n/es/llm.txt
+++ b/docs/i18n/es/llm.txt
@@ -12,7 +12,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 
 **Key value:** One endpoint (`http://localhost:20128/v1`), unlimited models, zero downtime, minimal cost.
 
-**Current version:** 3.8.5
+**Current version:** 3.8.7
 
 ## Tech Stack
 
@@ -283,7 +283,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 └── .env.example                  # Environment variable template
 ```
 
-## Key Features (v3.8.5)
+## Key Features (v3.8.7)
 
 ### Core Proxy
 - **177 AI providers** with automatic format translation

--- a/docs/i18n/fa/llm.txt
+++ b/docs/i18n/fa/llm.txt
@@ -12,7 +12,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 
 **Key value:** One endpoint (`http://localhost:20128/v1`), unlimited models, zero downtime, minimal cost.
 
-**Current version:** 3.8.5
+**Current version:** 3.8.7
 
 ## Tech Stack
 
@@ -283,7 +283,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 └── .env.example                  # Environment variable template
 ```
 
-## Key Features (v3.8.5)
+## Key Features (v3.8.7)
 
 ### Core Proxy
 - **177 AI providers** with automatic format translation

--- a/docs/i18n/fi/llm.txt
+++ b/docs/i18n/fi/llm.txt
@@ -12,7 +12,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 
 **Key value:** One endpoint (`http://localhost:20128/v1`), unlimited models, zero downtime, minimal cost.
 
-**Current version:** 3.8.5
+**Current version:** 3.8.7
 
 ## Tech Stack
 
@@ -283,7 +283,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 └── .env.example                  # Environment variable template
 ```
 
-## Key Features (v3.8.5)
+## Key Features (v3.8.7)
 
 ### Core Proxy
 - **177 AI providers** with automatic format translation

--- a/docs/i18n/fr/llm.txt
+++ b/docs/i18n/fr/llm.txt
@@ -12,7 +12,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 
 **Key value:** One endpoint (`http://localhost:20128/v1`), unlimited models, zero downtime, minimal cost.
 
-**Current version:** 3.8.5
+**Current version:** 3.8.7
 
 ## Tech Stack
 
@@ -283,7 +283,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 └── .env.example                  # Environment variable template
 ```
 
-## Key Features (v3.8.5)
+## Key Features (v3.8.7)
 
 ### Core Proxy
 - **177 AI providers** with automatic format translation

--- a/docs/i18n/gu/llm.txt
+++ b/docs/i18n/gu/llm.txt
@@ -12,7 +12,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 
 **Key value:** One endpoint (`http://localhost:20128/v1`), unlimited models, zero downtime, minimal cost.
 
-**Current version:** 3.8.5
+**Current version:** 3.8.7
 
 ## Tech Stack
 
@@ -283,7 +283,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 └── .env.example                  # Environment variable template
 ```
 
-## Key Features (v3.8.5)
+## Key Features (v3.8.7)
 
 ### Core Proxy
 - **177 AI providers** with automatic format translation

--- a/docs/i18n/he/llm.txt
+++ b/docs/i18n/he/llm.txt
@@ -12,7 +12,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 
 **Key value:** One endpoint (`http://localhost:20128/v1`), unlimited models, zero downtime, minimal cost.
 
-**Current version:** 3.8.5
+**Current version:** 3.8.7
 
 ## Tech Stack
 
@@ -283,7 +283,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 └── .env.example                  # Environment variable template
 ```
 
-## Key Features (v3.8.5)
+## Key Features (v3.8.7)
 
 ### Core Proxy
 - **177 AI providers** with automatic format translation

--- a/docs/i18n/hi/llm.txt
+++ b/docs/i18n/hi/llm.txt
@@ -12,7 +12,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 
 **Key value:** One endpoint (`http://localhost:20128/v1`), unlimited models, zero downtime, minimal cost.
 
-**Current version:** 3.8.5
+**Current version:** 3.8.7
 
 ## Tech Stack
 
@@ -283,7 +283,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 └── .env.example                  # Environment variable template
 ```
 
-## Key Features (v3.8.5)
+## Key Features (v3.8.7)
 
 ### Core Proxy
 - **177 AI providers** with automatic format translation

--- a/docs/i18n/hu/llm.txt
+++ b/docs/i18n/hu/llm.txt
@@ -12,7 +12,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 
 **Key value:** One endpoint (`http://localhost:20128/v1`), unlimited models, zero downtime, minimal cost.
 
-**Current version:** 3.8.5
+**Current version:** 3.8.7
 
 ## Tech Stack
 
@@ -283,7 +283,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 └── .env.example                  # Environment variable template
 ```
 
-## Key Features (v3.8.5)
+## Key Features (v3.8.7)
 
 ### Core Proxy
 - **177 AI providers** with automatic format translation

--- a/docs/i18n/id/llm.txt
+++ b/docs/i18n/id/llm.txt
@@ -12,7 +12,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 
 **Key value:** One endpoint (`http://localhost:20128/v1`), unlimited models, zero downtime, minimal cost.
 
-**Current version:** 3.8.5
+**Current version:** 3.8.7
 
 ## Tech Stack
 
@@ -283,7 +283,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 └── .env.example                  # Environment variable template
 ```
 
-## Key Features (v3.8.5)
+## Key Features (v3.8.7)
 
 ### Core Proxy
 - **177 AI providers** with automatic format translation

--- a/docs/i18n/in/llm.txt
+++ b/docs/i18n/in/llm.txt
@@ -12,7 +12,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 
 **Key value:** One endpoint (`http://localhost:20128/v1`), unlimited models, zero downtime, minimal cost.
 
-**Current version:** 3.8.5
+**Current version:** 3.8.7
 
 ## Tech Stack
 
@@ -283,7 +283,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 └── .env.example                  # Environment variable template
 ```
 
-## Key Features (v3.8.5)
+## Key Features (v3.8.7)
 
 ### Core Proxy
 - **177 AI providers** with automatic format translation

--- a/docs/i18n/it/llm.txt
+++ b/docs/i18n/it/llm.txt
@@ -12,7 +12,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 
 **Key value:** One endpoint (`http://localhost:20128/v1`), unlimited models, zero downtime, minimal cost.
 
-**Current version:** 3.8.5
+**Current version:** 3.8.7
 
 ## Tech Stack
 
@@ -283,7 +283,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 └── .env.example                  # Environment variable template
 ```
 
-## Key Features (v3.8.5)
+## Key Features (v3.8.7)
 
 ### Core Proxy
 - **177 AI providers** with automatic format translation

--- a/docs/i18n/ja/llm.txt
+++ b/docs/i18n/ja/llm.txt
@@ -12,7 +12,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 
 **Key value:** One endpoint (`http://localhost:20128/v1`), unlimited models, zero downtime, minimal cost.
 
-**Current version:** 3.8.5
+**Current version:** 3.8.7
 
 ## Tech Stack
 
@@ -283,7 +283,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 └── .env.example                  # Environment variable template
 ```
 
-## Key Features (v3.8.5)
+## Key Features (v3.8.7)
 
 ### Core Proxy
 - **177 AI providers** with automatic format translation

--- a/docs/i18n/ko/llm.txt
+++ b/docs/i18n/ko/llm.txt
@@ -12,7 +12,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 
 **Key value:** One endpoint (`http://localhost:20128/v1`), unlimited models, zero downtime, minimal cost.
 
-**Current version:** 3.8.5
+**Current version:** 3.8.7
 
 ## Tech Stack
 
@@ -283,7 +283,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 └── .env.example                  # Environment variable template
 ```
 
-## Key Features (v3.8.5)
+## Key Features (v3.8.7)
 
 ### Core Proxy
 - **177 AI providers** with automatic format translation

--- a/docs/i18n/mr/llm.txt
+++ b/docs/i18n/mr/llm.txt
@@ -12,7 +12,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 
 **Key value:** One endpoint (`http://localhost:20128/v1`), unlimited models, zero downtime, minimal cost.
 
-**Current version:** 3.8.5
+**Current version:** 3.8.7
 
 ## Tech Stack
 
@@ -283,7 +283,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 └── .env.example                  # Environment variable template
 ```
 
-## Key Features (v3.8.5)
+## Key Features (v3.8.7)
 
 ### Core Proxy
 - **177 AI providers** with automatic format translation

--- a/docs/i18n/ms/llm.txt
+++ b/docs/i18n/ms/llm.txt
@@ -12,7 +12,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 
 **Key value:** One endpoint (`http://localhost:20128/v1`), unlimited models, zero downtime, minimal cost.
 
-**Current version:** 3.8.5
+**Current version:** 3.8.7
 
 ## Tech Stack
 
@@ -283,7 +283,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 └── .env.example                  # Environment variable template
 ```
 
-## Key Features (v3.8.5)
+## Key Features (v3.8.7)
 
 ### Core Proxy
 - **177 AI providers** with automatic format translation

--- a/docs/i18n/nl/llm.txt
+++ b/docs/i18n/nl/llm.txt
@@ -12,7 +12,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 
 **Key value:** One endpoint (`http://localhost:20128/v1`), unlimited models, zero downtime, minimal cost.
 
-**Current version:** 3.8.5
+**Current version:** 3.8.7
 
 ## Tech Stack
 
@@ -283,7 +283,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 └── .env.example                  # Environment variable template
 ```
 
-## Key Features (v3.8.5)
+## Key Features (v3.8.7)
 
 ### Core Proxy
 - **177 AI providers** with automatic format translation

--- a/docs/i18n/no/llm.txt
+++ b/docs/i18n/no/llm.txt
@@ -12,7 +12,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 
 **Key value:** One endpoint (`http://localhost:20128/v1`), unlimited models, zero downtime, minimal cost.
 
-**Current version:** 3.8.5
+**Current version:** 3.8.7
 
 ## Tech Stack
 
@@ -283,7 +283,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 └── .env.example                  # Environment variable template
 ```
 
-## Key Features (v3.8.5)
+## Key Features (v3.8.7)
 
 ### Core Proxy
 - **177 AI providers** with automatic format translation

--- a/docs/i18n/phi/llm.txt
+++ b/docs/i18n/phi/llm.txt
@@ -12,7 +12,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 
 **Key value:** One endpoint (`http://localhost:20128/v1`), unlimited models, zero downtime, minimal cost.
 
-**Current version:** 3.8.5
+**Current version:** 3.8.7
 
 ## Tech Stack
 
@@ -283,7 +283,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 └── .env.example                  # Environment variable template
 ```
 
-## Key Features (v3.8.5)
+## Key Features (v3.8.7)
 
 ### Core Proxy
 - **177 AI providers** with automatic format translation

--- a/docs/i18n/pl/llm.txt
+++ b/docs/i18n/pl/llm.txt
@@ -12,7 +12,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 
 **Key value:** One endpoint (`http://localhost:20128/v1`), unlimited models, zero downtime, minimal cost.
 
-**Current version:** 3.8.5
+**Current version:** 3.8.7
 
 ## Tech Stack
 
@@ -283,7 +283,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 └── .env.example                  # Environment variable template
 ```
 
-## Key Features (v3.8.5)
+## Key Features (v3.8.7)
 
 ### Core Proxy
 - **177 AI providers** with automatic format translation

--- a/docs/i18n/pt-BR/llm.txt
+++ b/docs/i18n/pt-BR/llm.txt
@@ -12,7 +12,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 
 **Key value:** One endpoint (`http://localhost:20128/v1`), unlimited models, zero downtime, minimal cost.
 
-**Current version:** 3.8.5
+**Current version:** 3.8.7
 
 ## Tech Stack
 
@@ -283,7 +283,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 └── .env.example                  # Environment variable template
 ```
 
-## Key Features (v3.8.5)
+## Key Features (v3.8.7)
 
 ### Core Proxy
 - **177 AI providers** with automatic format translation

--- a/docs/i18n/pt/llm.txt
+++ b/docs/i18n/pt/llm.txt
@@ -12,7 +12,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 
 **Key value:** One endpoint (`http://localhost:20128/v1`), unlimited models, zero downtime, minimal cost.
 
-**Current version:** 3.8.5
+**Current version:** 3.8.7
 
 ## Tech Stack
 
@@ -283,7 +283,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 └── .env.example                  # Environment variable template
 ```
 
-## Key Features (v3.8.5)
+## Key Features (v3.8.7)
 
 ### Core Proxy
 - **177 AI providers** with automatic format translation

--- a/docs/i18n/ro/llm.txt
+++ b/docs/i18n/ro/llm.txt
@@ -12,7 +12,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 
 **Key value:** One endpoint (`http://localhost:20128/v1`), unlimited models, zero downtime, minimal cost.
 
-**Current version:** 3.8.5
+**Current version:** 3.8.7
 
 ## Tech Stack
 
@@ -283,7 +283,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 └── .env.example                  # Environment variable template
 ```
 
-## Key Features (v3.8.5)
+## Key Features (v3.8.7)
 
 ### Core Proxy
 - **177 AI providers** with automatic format translation

--- a/docs/i18n/ru/llm.txt
+++ b/docs/i18n/ru/llm.txt
@@ -12,7 +12,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 
 **Key value:** One endpoint (`http://localhost:20128/v1`), unlimited models, zero downtime, minimal cost.
 
-**Current version:** 3.8.5
+**Current version:** 3.8.7
 
 ## Tech Stack
 
@@ -283,7 +283,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 └── .env.example                  # Environment variable template
 ```
 
-## Key Features (v3.8.5)
+## Key Features (v3.8.7)
 
 ### Core Proxy
 - **177 AI providers** with automatic format translation

--- a/docs/i18n/sk/llm.txt
+++ b/docs/i18n/sk/llm.txt
@@ -12,7 +12,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 
 **Key value:** One endpoint (`http://localhost:20128/v1`), unlimited models, zero downtime, minimal cost.
 
-**Current version:** 3.8.5
+**Current version:** 3.8.7
 
 ## Tech Stack
 
@@ -283,7 +283,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 └── .env.example                  # Environment variable template
 ```
 
-## Key Features (v3.8.5)
+## Key Features (v3.8.7)
 
 ### Core Proxy
 - **177 AI providers** with automatic format translation

--- a/docs/i18n/sv/llm.txt
+++ b/docs/i18n/sv/llm.txt
@@ -12,7 +12,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 
 **Key value:** One endpoint (`http://localhost:20128/v1`), unlimited models, zero downtime, minimal cost.
 
-**Current version:** 3.8.5
+**Current version:** 3.8.7
 
 ## Tech Stack
 
@@ -283,7 +283,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 └── .env.example                  # Environment variable template
 ```
 
-## Key Features (v3.8.5)
+## Key Features (v3.8.7)
 
 ### Core Proxy
 - **177 AI providers** with automatic format translation

--- a/docs/i18n/sw/llm.txt
+++ b/docs/i18n/sw/llm.txt
@@ -12,7 +12,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 
 **Key value:** One endpoint (`http://localhost:20128/v1`), unlimited models, zero downtime, minimal cost.
 
-**Current version:** 3.8.5
+**Current version:** 3.8.7
 
 ## Tech Stack
 
@@ -283,7 +283,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 └── .env.example                  # Environment variable template
 ```
 
-## Key Features (v3.8.5)
+## Key Features (v3.8.7)
 
 ### Core Proxy
 - **177 AI providers** with automatic format translation

--- a/docs/i18n/ta/llm.txt
+++ b/docs/i18n/ta/llm.txt
@@ -12,7 +12,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 
 **Key value:** One endpoint (`http://localhost:20128/v1`), unlimited models, zero downtime, minimal cost.
 
-**Current version:** 3.8.5
+**Current version:** 3.8.7
 
 ## Tech Stack
 
@@ -283,7 +283,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 └── .env.example                  # Environment variable template
 ```
 
-## Key Features (v3.8.5)
+## Key Features (v3.8.7)
 
 ### Core Proxy
 - **177 AI providers** with automatic format translation

--- a/docs/i18n/te/llm.txt
+++ b/docs/i18n/te/llm.txt
@@ -12,7 +12,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 
 **Key value:** One endpoint (`http://localhost:20128/v1`), unlimited models, zero downtime, minimal cost.
 
-**Current version:** 3.8.5
+**Current version:** 3.8.7
 
 ## Tech Stack
 
@@ -283,7 +283,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 └── .env.example                  # Environment variable template
 ```
 
-## Key Features (v3.8.5)
+## Key Features (v3.8.7)
 
 ### Core Proxy
 - **177 AI providers** with automatic format translation

--- a/docs/i18n/th/llm.txt
+++ b/docs/i18n/th/llm.txt
@@ -12,7 +12,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 
 **Key value:** One endpoint (`http://localhost:20128/v1`), unlimited models, zero downtime, minimal cost.
 
-**Current version:** 3.8.5
+**Current version:** 3.8.7
 
 ## Tech Stack
 
@@ -283,7 +283,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 └── .env.example                  # Environment variable template
 ```
 
-## Key Features (v3.8.5)
+## Key Features (v3.8.7)
 
 ### Core Proxy
 - **177 AI providers** with automatic format translation

--- a/docs/i18n/tr/llm.txt
+++ b/docs/i18n/tr/llm.txt
@@ -12,7 +12,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 
 **Key value:** One endpoint (`http://localhost:20128/v1`), unlimited models, zero downtime, minimal cost.
 
-**Current version:** 3.8.5
+**Current version:** 3.8.7
 
 ## Tech Stack
 
@@ -283,7 +283,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 └── .env.example                  # Environment variable template
 ```
 
-## Key Features (v3.8.5)
+## Key Features (v3.8.7)
 
 ### Core Proxy
 - **177 AI providers** with automatic format translation

--- a/docs/i18n/uk-UA/llm.txt
+++ b/docs/i18n/uk-UA/llm.txt
@@ -12,7 +12,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 
 **Key value:** One endpoint (`http://localhost:20128/v1`), unlimited models, zero downtime, minimal cost.
 
-**Current version:** 3.8.5
+**Current version:** 3.8.7
 
 ## Tech Stack
 
@@ -283,7 +283,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 └── .env.example                  # Environment variable template
 ```
 
-## Key Features (v3.8.5)
+## Key Features (v3.8.7)
 
 ### Core Proxy
 - **177 AI providers** with automatic format translation

--- a/docs/i18n/ur/llm.txt
+++ b/docs/i18n/ur/llm.txt
@@ -12,7 +12,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 
 **Key value:** One endpoint (`http://localhost:20128/v1`), unlimited models, zero downtime, minimal cost.
 
-**Current version:** 3.8.5
+**Current version:** 3.8.7
 
 ## Tech Stack
 
@@ -283,7 +283,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 └── .env.example                  # Environment variable template
 ```
 
-## Key Features (v3.8.5)
+## Key Features (v3.8.7)
 
 ### Core Proxy
 - **177 AI providers** with automatic format translation

--- a/docs/i18n/vi/llm.txt
+++ b/docs/i18n/vi/llm.txt
@@ -12,7 +12,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 
 **Key value:** One endpoint (`http://localhost:20128/v1`), unlimited models, zero downtime, minimal cost.
 
-**Current version:** 3.8.5
+**Current version:** 3.8.7
 
 ## Tech Stack
 
@@ -283,7 +283,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 └── .env.example                  # Environment variable template
 ```
 
-## Key Features (v3.8.5)
+## Key Features (v3.8.7)
 
 ### Core Proxy
 - **177 AI providers** with automatic format translation

--- a/docs/i18n/zh-CN/llm.txt
+++ b/docs/i18n/zh-CN/llm.txt
@@ -12,7 +12,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 
 **Key value:** One endpoint (`http://localhost:20128/v1`), unlimited models, zero downtime, minimal cost.
 
-**Current version:** 3.8.5
+**Current version:** 3.8.7
 
 ## Tech Stack
 
@@ -283,7 +283,7 @@ OmniRoute solves the problem of managing multiple AI provider subscriptions, quo
 └── .env.example                  # Environment variable template
 ```
 
-## Key Features (v3.8.5)
+## Key Features (v3.8.7)
 
 ### Core Proxy
 - **177 AI providers** with automatic format translation


### PR DESCRIPTION
## docs(i18n): sync llm.txt mirrors to v3.8.7

The v3.8.7 release bumped the root `llm.txt` to 3.8.7, but the 41 `docs/i18n/*/llm.txt` mirrors were still pinned at **3.8.5** — breaking `check:docs-sync` (Lint + Docs Sync CI gates) on `main` after the release merge (#2919).

Regenerated all 41 mirrors via `scripts/i18n/sync-llm-mirrors.mjs` (translated headers/language bar preserved; body synced to root). Only `docs/i18n/*/llm.txt` changed (41 files, +82/-82).

`check:docs-all` now passes locally (docs-sync + counts + env-doc-sync + deprecated-versions + doc-links).