### PR TITLE
fix(skills): avoid Claude assistant tool_result blocks

### DIFF
--- a/src/lib/skills/interception.ts
+++ b/src/lib/skills/interception.ts
@@ -290,18 +290,52 @@ export async function handleToolCallExecution(
       };
     }
 
-    case "anthropic":
+    case "anthropic": {
+      // Anthropic only permits tool_result blocks in user messages. This helper
+      // returns a single assistant response, so there is no valid place to put a
+      // server-side skill result as tool_result here. Keep client-native tool_use
+      // blocks untouched, remove the OmniRoute-handled tool_use blocks, and expose
+      // their results as plain assistant text instead of corrupting history with
+      // assistant-side tool_result blocks. See #2815.
+      //
+      // When no client-native tool_use blocks remain (all were handled here), the
+      // upstream stop_reason "tool_use" is stale and would make clients wait for
+      // tool_use blocks that no longer exist — so it is normalized to "end_turn"
+      // (with stop_sequence cleared). The mixed-tool branch keeps the original
+      // stop_reason because real native tool_use blocks still need the client.
+      const handledToolCallIds = new Set(results.map((r) => r.id));
+      const toolNamesById = new Map(toolCalls.map((call) => [call.id, call.name]));
+      const remainingContent = (Array.isArray(response.content) ? response.content : []).filter(
+        (block: any) => !(block?.type === "tool_use" && handledToolCallIds.has(block.id))
+      );
+      const resultTextBlocks = results.map((r) => ({
+        type: "text",
+        text: `[Skill result: ${toolNamesById.get(r.id) || r.id}]\n${JSON.stringify(
+          r.result
+        )}`,
+      }));
+      const firstRemainingToolUseIndex = remainingContent.findIndex(
+        (block: any) => block?.type === "tool_use"
+      );
+
+      if (firstRemainingToolUseIndex === -1) {
+        return {
+          ...response,
+          content: [...remainingContent, ...resultTextBlocks],
+          stop_reason: "end_turn",
+          stop_sequence: null,
+        };
+      }
+
       return {
         ...response,
         content: [
-          ...response.content,
-          ...results.map((r) => ({
-            type: "tool_result",
-            tool_use_id: r.id,
-            content: JSON.stringify(r.result),
-          })),
+          ...remainingContent.slice(0, firstRemainingToolUseIndex),
+          ...resultTextBlocks,
+          ...remainingContent.slice(firstRemainingToolUseIndex),
         ],
       };
+    }
 
     default:
       return response;

--- a/tests/unit/skills-interception.test.ts
+++ b/tests/unit/skills-interception.test.ts
@@ -215,9 +215,10 @@ test("handleToolCallExecution appends OpenAI tool results and leaves empty respo
   assert.equal(await handleToolCallExecution(untouched, "gpt-4.1", executionContext), untouched);
 });
 
-test("handleToolCallExecution appends Anthropic tool_result blocks", async () => {
+test("handleToolCallExecution returns Anthropic skill results as text", async () => {
   const anthropicResponse = await handleToolCallExecution(
     {
+      stop_reason: "tool_use",
       content: [{ type: "tool_use", id: "tool-1", name: "lookup@1.0.0", input: { id: "77" } }],
     },
     "claude-3-7-sonnet",
@@ -225,13 +226,17 @@ test("handleToolCallExecution appends Anthropic tool_result blocks", async () =>
   );
 
   assert.deepEqual(anthropicResponse.content, [
-    { type: "tool_use", id: "tool-1", name: "lookup@1.0.0", input: { id: "77" } },
     {
-      type: "tool_result",
-      tool_use_id: "tool-1",
-      content: '{"record":"resolved:77"}',
+      type: "text",
+      text: '[Skill result: lookup@1.0.0]\n{"record":"resolved:77"}',
     },
   ]);
+  assert.equal(
+    anthropicResponse.content.some((b: { type: string }) => b.type === "tool_result"),
+    false
+  );
+  assert.equal(anthropicResponse.stop_reason, "end_turn");
+  assert.equal(anthropicResponse.stop_sequence, null);
 });
 
 test("handleToolCallExecution appends Responses API function_call_output items", async () => {
@@ -285,6 +290,7 @@ test("handleToolCallExecution forwards unregistered client-native tool_use untou
 test("handleToolCallExecution intercepts a registered skill alongside an unregistered tool (#2815)", async () => {
   const mixed = await handleToolCallExecution(
     {
+      stop_reason: "tool_use",
       content: [
         { type: "tool_use", id: "tool-native", name: "Bash", input: { command: "ls" } },
         { type: "tool_use", id: "tool-skill", name: "lookup@1.0.0", input: { id: "9" } },
@@ -295,14 +301,14 @@ test("handleToolCallExecution intercepts a registered skill alongside an unregis
   );
 
   assert.deepEqual(mixed.content, [
-    { type: "tool_use", id: "tool-native", name: "Bash", input: { command: "ls" } },
-    { type: "tool_use", id: "tool-skill", name: "lookup@1.0.0", input: { id: "9" } },
     {
-      type: "tool_result",
-      tool_use_id: "tool-skill",
-      content: '{"record":"resolved:9"}',
+      type: "text",
+      text: '[Skill result: lookup@1.0.0]\n{"record":"resolved:9"}',
     },
+    { type: "tool_use", id: "tool-native", name: "Bash", input: { command: "ls" } },
   ]);
+  assert.equal(mixed.content.some((b: { type: string }) => b.type === "tool_result"), false);
+  assert.equal(mixed.stop_reason, "tool_use");
 });
 
 test("handleToolCallExecution loads registry from DB on cold cache (covers loadFromDatabase fix)", async () => {
@@ -316,6 +322,7 @@ test("handleToolCallExecution loads registry from DB on cold cache (covers loadF
 
   const result = await handleToolCallExecution(
     {
+      stop_reason: "tool_use",
       content: [
         { type: "tool_use", id: "tool-skill", name: "lookup@1.0.0", input: { id: "cold" } },
       ],
@@ -325,11 +332,12 @@ test("handleToolCallExecution loads registry from DB on cold cache (covers loadF
   );
 
   assert.deepEqual(result.content, [
-    { type: "tool_use", id: "tool-skill", name: "lookup@1.0.0", input: { id: "cold" } },
     {
-      type: "tool_result",
-      tool_use_id: "tool-skill",
-      content: '{"record":"resolved:cold"}',
+      type: "text",
+      text: '[Skill result: lookup@1.0.0]\n{"record":"resolved:cold"}',
     },
   ]);
+  assert.equal(result.content.some((b: { type: string }) => b.type === "tool_result"), false);
+  assert.equal(result.stop_reason, "end_turn");
+  assert.equal(result.stop_sequence, null);
 });


### PR DESCRIPTION
# fix(skills): avoid Claude assistant `tool_result` blocks

## Summary

Fixes the remaining Claude/Anthropic-format edge case from the original issue:

- Original issue: https://github.com/diegosouzapw/OmniRoute/issues/2815

PR #2817 already stopped unregistered Claude Code native tools like `Bash`, `Read`, and `Edit` from being intercepted as OmniRoute skills. However, registered OmniRoute skills in Claude format could still produce an invalid assistant message by appending Anthropic `tool_result` blocks directly into assistant content.

Anthropic only allows `tool_result` blocks in `user` messages, so this could still lead to malformed history or client-side stalls.

## Changes

- For Anthropic/Claude-format skill interception, registered skill results are now returned as plain assistant text instead of assistant-side `tool_result` blocks.
- Handled OmniRoute skill `tool_use` blocks are removed from the returned assistant content.
- Client-native/unhandled `tool_use` blocks are preserved so clients can still execute them normally.
- If all `tool_use` blocks were handled and removed, `stop_reason` is normalized from stale `tool_use` to `end_turn`, and `stop_sequence` is cleared.
- If native/unhandled `tool_use` blocks remain, `stop_reason: "tool_use"` is preserved.

## Why

The old behavior could produce an Anthropic-invalid assistant message like:

```json
{
  "role": "assistant",
  "content": [
    { "type": "tool_use", "id": "tool-skill", "name": "lookup@1.0.0" },
    { "type": "tool_result", "tool_use_id": "tool-skill", "content": "..." }
  ],
  "stop_reason": "tool_use"
}
```

This PR avoids emitting assistant-side `tool_result` blocks entirely for Claude-format skill interception.

## Tests

Updated `tests/unit/skills-interception.test.ts` to cover:

- registered Claude skill results are returned as text, not `tool_result`
- native Claude Code tools like `Bash` remain untouched
- mixed native tool + registered skill preserves the native `tool_use`
- no assistant-side `tool_result` blocks are emitted
- `stop_reason` becomes `end_turn` when all tool uses were handled
- `stop_reason` remains `tool_use` when a native/unhandled tool use remains

Validation run locally:

```text
npx eslint src/lib/skills/interception.ts tests/unit/skills-interception.test.ts
node --import tsx/esm --test tests/unit/skills-interception.test.ts
```

Result:

```text
8 pass / 0 fail
```

Note: full `npm run typecheck:core` is currently blocked by an unrelated existing dependency/type-resolution issue:

```text
src/lib/memory/embedding/transformersLocal.ts(32,39): error TS2307: Cannot find module '@huggingface/transformers' or its corresponding type declarations.
```