### PR TITLE
fix(routing): add agy to executor map so it uses AntigravityExecutor

### DIFF
--- a/open-sse/executors/index.ts
+++ b/open-sse/executors/index.ts
@@ -48,6 +48,7 @@ import { DoubaoWebExecutor } from "./doubao-web.ts";
 
 const executors = {
   antigravity: new AntigravityExecutor(),
+  agy: new AntigravityExecutor(),
   "gemini-cli": new GeminiCLIExecutor(),
   github: new GithubExecutor(),
   qoder: new QoderExecutor(),

--- a/tests/unit/executor-agy.test.ts
+++ b/tests/unit/executor-agy.test.ts
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { getExecutor, AntigravityExecutor } from "../../open-sse/executors/index.ts";
+
+test("getExecutor('agy') returns AntigravityExecutor (not DefaultExecutor)", () => {
+  const executor = getExecutor("agy");
+  assert.ok(executor instanceof AntigravityExecutor, "agy provider should use AntigravityExecutor");
+});
+
+test("getExecutor('antigravity') returns AntigravityExecutor", () => {
+  const executor = getExecutor("antigravity");
+  assert.ok(executor instanceof AntigravityExecutor, "antigravity provider should use AntigravityExecutor");
+});
+
+test("getExecutor('agy') builds valid streaming URL", () => {
+  const executor = getExecutor("agy");
+  const url = executor.buildUrl("gemini-3-flash", true);
+  assert.ok(
+    url.includes("streamGenerateContent?alt=sse"),
+    `expected streaming endpoint URL, got: ${url}`
+  );
+});
+
+test("getExecutor('agy') builds valid non-streaming URL", () => {
+  const executor = getExecutor("agy");
+  const url = executor.buildUrl("gemini-3-flash", false);
+  // Antigravity executor always uses streaming endpoint (buildUrl ignores stream flag)
+  assert.ok(
+    url.includes("streamGenerateContent?alt=sse"),
+    `expected streaming endpoint URL (always), got: ${url}`
+  );
+});
+
+test("getExecutor('agy') buildHeaders returns Bearer auth", () => {
+  const executor = getExecutor("agy");
+  const headers = executor.buildHeaders({ accessToken: "test-token" });
+  assert.equal(headers.Authorization, "Bearer test-token");
+});


### PR DESCRIPTION
## Summary

- The `agy` provider was registered in `providerRegistry.ts` with `executor: "antigravity"` but the executor map in `executors/index.ts` only had an `"antigravity"` entry, no `"agy"` entry. This caused `getExecutor("agy")` to fall through to `DefaultExecutor`, which tried to read `this.config.baseUrl` (singular). The `agy` provider config only has `baseUrls` (plural), so `buildUrl()` returned `undefined`. Passing `undefined` to `fetch()` triggered a `TypeError: Cannot read properties of undefined (reading 'toString')` inside Node's undici HTTP client, surfaced as a 502 to the client.

Fix: Add `agy: new AntigravityExecutor()` to the executor map. One line.

## Related Issues

- Closes #2932
- Related to #2805 (different root cause; that was upstream model naming)

## Validation

- [x] `npm run lint` clean (0 warnings)
- [x] `npm run typecheck:core` clean
- [x] Manual test: `agy/gemini-3-flash`, `agy/claude-sonnet-4-6`, `agy/gemini-3.5-flash-low` all return valid responses on patched dev server

## Tests Added Or Updated

- New: `tests/unit/executor-agy.test.ts` with 5 assertions:
  - `getExecutor("agy")` returns `AntigravityExecutor` (not `DefaultExecutor`)
  - `getExecutor("antigravity")` returns `AntigravityExecutor`
  - `buildUrl()` returns valid streaming endpoint
  - `buildUrl()` returns valid non-streaming endpoint (always streams)
  - `buildHeaders()` sets Bearer auth from `accessToken`

## Coverage Notes

- Change is in `open-sse/executors/index.ts` (one map entry). The new test file covers executor resolution, URL building, and header construction for the `agy` provider. Existing antigravity tests (`antigravity-credits`, `antigravity-version`, `antigravity-projectid`, `executor-default-base`) all pass unchanged.

## Reviewer Notes

- Missing-map-entry bug. No logic changed, no new code paths. The `agy` provider was unusable since its introduction because the executor was never wired up.
- The `AntigravityExecutor` constructor hardcodes `super("antigravity", PROVIDERS.antigravity)`, so both `"antigravity"` and `"agy"` share the same provider config. This is correct: identical base URLs, OAuth credentials, and request format.