### PR TITLE
fix(providers): route Copilot Claude/Gemini via chat/completions (#2911)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,13 @@
   back to the API` (its DeepSeek-thinking upstream is not detectable from the
   model id, and `requiresReasoningReplay` does not consume `supportsReasoning`).
   `getResolvedModelCapabilities` now surfaces the registry `interleavedField`. (#2900)
+- **providers/github-copilot:** built-in GitHub Copilot Claude Opus and Gemini
+  models (`claude-opus-4.7`, `claude-opus-4-5-20251101`, `gemini-3.1-pro-preview`,
+  `gemini-3-flash-preview`) no longer carry `targetFormat: "openai-responses"`, so
+  they route through `chat/completions` (the provider default, like the working
+  `claude-opus-4.6`) instead of the Responses API, which Copilot does not serve for
+  non-OpenAI models (returned `[400]`). Native OpenAI `gpt-*` models keep the
+  Responses API. (#2911)
 
 ### ✨ New Features
 

--- a/open-sse/config/providerRegistry.ts
+++ b/open-sse/config/providerRegistry.ts
@@ -983,9 +983,10 @@ export const REGISTRY: Record<string, RegistryEntry> = {
         maxOutputTokens: 64000,
       },
       {
+        // #2911: GitHub Copilot's Responses API does not serve Claude/Gemini —
+        // route them via chat/completions (provider default) like claude-opus-4.6.
         id: "claude-opus-4-5-20251101",
         name: "Claude Opus 4.5 (Full ID)",
-        targetFormat: "openai-responses",
         contextLength: 200000,
         maxOutputTokens: 64000,
       },
@@ -996,14 +997,15 @@ export const REGISTRY: Record<string, RegistryEntry> = {
         maxOutputTokens: 128000,
       },
       {
+        // #2911: Claude on Copilot must use chat/completions, not the Responses API.
         id: "claude-opus-4.7",
         name: "Claude Opus 4.7",
-        targetFormat: "openai-responses",
         contextLength: 1000000,
         maxOutputTokens: 128000,
       },
-      { id: "gemini-3.1-pro-preview", name: "Gemini 3.1 Pro", targetFormat: "openai-responses" },
-      { id: "gemini-3-flash-preview", name: "Gemini 3 Flash", targetFormat: "openai-responses" },
+      // #2911: Gemini on Copilot must use chat/completions, not the Responses API.
+      { id: "gemini-3.1-pro-preview", name: "Gemini 3.1 Pro" },
+      { id: "gemini-3-flash-preview", name: "Gemini 3 Flash" },
       { id: "oswe-vscode-prime", name: "Raptor Mini", targetFormat: "openai-responses" },
       //{ id: "?", name: "Goldeneye" },
     ],

--- a/tests/unit/provider-registry-github-copilot-targetformat.test.ts
+++ b/tests/unit/provider-registry-github-copilot-targetformat.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Issue #2911 — Built-in GitHub Copilot Claude Opus / Gemini models fail.
+ *
+ * The `github` provider has `format: "openai"` (baseUrl .../chat/completions)
+ * and a separate `responsesBaseUrl` (.../responses). A model only routes to the
+ * Responses API when it sets `targetFormat: "openai-responses"`.
+ *
+ * GitHub Copilot's Responses API does NOT serve the Claude/Gemini models, so
+ * `claude-opus-4.7`, `claude-opus-4-5-20251101`, `gemini-3.1-pro-preview` and
+ * `gemini-3-flash-preview` failed with a 400. The working `claude-opus-4.6`
+ * carries no `targetFormat` and goes through chat/completions.
+ *
+ * Fix: drop `targetFormat: "openai-responses"` from the Claude/Gemini entries so
+ * they use the provider default (chat/completions). The native OpenAI `gpt-*`
+ * models legitimately keep the Responses API and must NOT be touched.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { REGISTRY } = await import("../../open-sse/config/providerRegistry.ts");
+const { getModelsByProviderId } = await import("../../open-sse/config/providerModels.ts");
+
+type ModelEntry = { id: string; targetFormat?: string; [k: string]: unknown };
+
+function githubModel(id: string): ModelEntry | undefined {
+  const provider = (REGISTRY as Record<string, { models?: ModelEntry[] }>)["github"];
+  return provider?.models?.find((m) => m.id === id);
+}
+
+// Claude/Gemini models that must NOT route through the Responses API.
+const MUST_NOT_BE_RESPONSES = [
+  "claude-opus-4.7",
+  "claude-opus-4-5-20251101",
+  "gemini-3.1-pro-preview",
+  "gemini-3-flash-preview",
+];
+
+for (const id of MUST_NOT_BE_RESPONSES) {
+  test(`#2911 github/${id} must not use openai-responses targetFormat`, () => {
+    const model = githubModel(id);
+    assert.ok(model, `${id} must be registered under github`);
+    assert.notEqual(
+      model.targetFormat,
+      "openai-responses",
+      `github/${id} must route via chat/completions (Copilot Responses API rejects it)`
+    );
+  });
+}
+
+test("#2911 github/claude-opus-4.6 baseline stays on chat/completions (no targetFormat)", () => {
+  const model = githubModel("claude-opus-4.6");
+  assert.ok(model, "claude-opus-4.6 must be registered");
+  assert.notEqual(model.targetFormat, "openai-responses");
+});
+
+// Regression guard: native OpenAI models keep the Responses API.
+for (const id of ["gpt-5.4", "gpt-5.4-mini"]) {
+  test(`#2911 github/${id} (OpenAI-native) still uses openai-responses`, () => {
+    const model = githubModel(id);
+    assert.ok(model, `${id} must be registered`);
+    assert.equal(
+      model.targetFormat,
+      "openai-responses",
+      `github/${id} is OpenAI-native and must keep the Responses API`
+    );
+  });
+}
+
+// Sanity: lookup-by-id helper resolves the same entries.
+test("#2911 getModelsByProviderId(github) reflects the targetFormat changes", () => {
+  const models = getModelsByProviderId("github") as ModelEntry[];
+  const opus47 = models.find((m) => m.id === "claude-opus-4.7");
+  assert.ok(opus47, "claude-opus-4.7 resolvable via getModelsByProviderId");
+  assert.notEqual(opus47.targetFormat, "openai-responses");
+});


### PR DESCRIPTION
Closes #2911

## Problem

Built-in GitHub Copilot **Claude Opus / Gemini** models fail; **OpenAI gpt-\* models work**, and `claude-opus-4.6` works.

## Root cause (verified)

The `github` provider is `format: "openai"` with `baseUrl: https://api.githubcopilot.com/chat/completions` and a separate `responsesBaseUrl: .../responses`. A model routes to the **Responses API** only when it declares `targetFormat: "openai-responses"`.

These Claude/Gemini entries carried `targetFormat: "openai-responses"` but GitHub Copilot's Responses API does **not** serve non-OpenAI models → `[400]`. The working `claude-opus-4.6` has no `targetFormat` and uses `chat/completions`.

## Fix

Remove `targetFormat: "openai-responses"` from:
- `claude-opus-4.7`
- `claude-opus-4-5-20251101`
- `gemini-3.1-pro-preview`
- `gemini-3-flash-preview`

They now use the provider default (`chat/completions`), matching `claude-opus-4.6`. **Native OpenAI `gpt-*` models and `oswe-vscode-prime` keep the Responses API** (verified untouched).

## Tests

New `tests/unit/provider-registry-github-copilot-targetformat.test.ts` (8 tests): the 4 Claude/Gemini models must not be `openai-responses`; `gpt-5.4`/`gpt-5.4-mini` regression guard that they *stay* `openai-responses`; `claude-opus-4.6` baseline. typecheck:core clean for touched files; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)