### PR TITLE
fix(combo): no-auth OpenCode combos use oc/ prefix, not opencode/ (#2901)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,11 @@
   rejected with `[400] image_generation tool type is not supported`. It is now
   treated like `tool_search`: allowed past the tool-type validator and dropped
   silently from the tools array before forwarding to Chat Completions. (#2950)
+- **combo/builder:** no-auth OpenCode Free combo entries now use the `oc/` routing
+  alias instead of the `opencode/` prefix. `parseModel("opencode/<model>")`
+  resolves to the `opencode-zen` api-key tier (via a manual `ALIAS_TO_PROVIDER_ID`
+  override), so combos built with the bare provider id misrouted away from the
+  no-auth `opencode` provider; `oc/<model>` resolves correctly. (#2901)
 
 ### ✨ New Features
 

--- a/src/lib/combos/builderOptions.ts
+++ b/src/lib/combos/builderOptions.ts
@@ -618,6 +618,17 @@ export async function getComboBuilderOptions(): Promise<ComboBuilderOptionsPaylo
       }
     }
 
+    // #2901: no-auth providers must route under their alias (e.g. "oc"), not
+    // their id — "opencode/<model>" misroutes to the opencode-zen api-key tier
+    // (manual ALIAS_TO_PROVIDER_ID override), while "oc/<model>" resolves to the
+    // no-auth "opencode" provider. Rewrite qualifiedModel to the alias prefix.
+    const routingPrefix = noAuthProvider.alias || providerId;
+    if (routingPrefix !== providerId) {
+      for (const opt of modelMap.values()) {
+        opt.qualifiedModel = `${routingPrefix}/${opt.id}`;
+      }
+    }
+
     const displayName = (providerEntryName(providerId) ||
       getProviderDisplayName(providerId, null) ||
       providerId) as string;

--- a/tests/unit/combo-builder-opencode-prefix.test.ts
+++ b/tests/unit/combo-builder-opencode-prefix.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Issue #2901 — OpenCode Free combo entries use the `opencode/` prefix instead
+ * of `oc/`.
+ *
+ * The no-auth OpenCode provider has id "opencode" and alias "oc". The combo
+ * builder built `qualifiedModel` from the provider *id* (`opencode/big-pickle`),
+ * but `parseModel("opencode/...")` resolves to the **opencode-zen** provider
+ * (an api-key tier) via a manual ALIAS_TO_PROVIDER_ID override — not the no-auth
+ * "opencode" provider. The user-facing routing alias `oc/` resolves correctly
+ * (`oc/big-pickle` → provider "opencode").
+ *
+ * This test drives the real builder against a fresh DB and asserts that no-auth
+ * OpenCode models carry the `oc/` prefix.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-combo-prefix-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const { getComboBuilderOptions } = await import("../../src/lib/combos/builderOptions.ts");
+const { parseModel } = await import("../../open-sse/services/model.ts");
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("#2901 no-auth OpenCode combo models use the oc/ prefix (not opencode/)", async () => {
+  const payload = await getComboBuilderOptions();
+  const opencode = payload.providers.find((p) => p.providerId === "opencode");
+  assert.ok(opencode, "no-auth 'opencode' provider must appear in the combo builder");
+
+  const bigPickle = opencode.models.find((m) => m.id === "big-pickle");
+  assert.ok(bigPickle, "big-pickle must be listed under the no-auth opencode provider");
+  assert.equal(
+    bigPickle.qualifiedModel,
+    "oc/big-pickle",
+    "no-auth opencode/big-pickle combo entry must use the 'oc/' routing alias"
+  );
+
+  // Every model under the no-auth provider must use the alias prefix.
+  for (const m of opencode.models) {
+    assert.ok(
+      m.qualifiedModel.startsWith("oc/"),
+      `qualifiedModel '${m.qualifiedModel}' must start with 'oc/' (got id-prefix instead)`
+    );
+  }
+});
+
+test("#2901 the oc/ prefix actually resolves back to the no-auth opencode provider", () => {
+  // Guards the premise: opencode/ misroutes to opencode-zen, oc/ is correct.
+  assert.equal(parseModel("oc/big-pickle").provider, "opencode");
+  assert.equal(parseModel("opencode/big-pickle").provider, "opencode-zen");
+});

--- a/tests/unit/combo-builder-options-route.test.ts
+++ b/tests/unit/combo-builder-options-route.test.ts
@@ -212,7 +212,9 @@ test("combo builder options route includes no-auth provider (opencode) even with
     opencode.models.some((m: any) => m.id === "big-pickle"),
     "big-pickle should be among opencode models"
   );
-  assert.equal(opencode.models[0].qualifiedModel.startsWith("opencode/"), true);
+  // #2901: no-auth opencode routes under its alias "oc/" (the bare "opencode/"
+  // prefix misroutes to the opencode-zen api-key tier via ALIAS_TO_PROVIDER_ID).
+  assert.equal(opencode.models[0].qualifiedModel.startsWith("oc/"), true);
   assert.equal(opencode.source, "system", "opencode should have source=system");
 });
 


### PR DESCRIPTION
Closes #2901

## Problem

OpenCode Free combo entries were built as `opencode/<model>` (e.g. `opencode/big-pickle`). But `parseModel("opencode/big-pickle")` resolves to **`opencode-zen`** (an api-key tier) via a manual `ALIAS_TO_PROVIDER_ID["opencode"] = "opencode-zen"` override — not the no-auth `opencode` provider. So combos built from the picker misrouted to a provider that needs a key.

Verified at runtime:
```
parseModel("opencode/big-pickle") -> provider=opencode-zen
parseModel("oc/big-pickle")       -> provider=opencode      ✓
```

## Fix

In `src/lib/combos/builderOptions.ts`, the no-auth provider loop now rewrites each model's `qualifiedModel` to the provider **alias** (`oc/`) when the alias differs from the id. `providerId` is still used for `getModelIsHidden`. Authed providers are unchanged.

## Tests

- New `tests/unit/combo-builder-opencode-prefix.test.ts`: drives the real builder against a fresh DB and asserts every no-auth opencode model uses the `oc/` prefix; plus a premise guard that `oc/` → `opencode` and `opencode/` → `opencode-zen`.
- Aligned `combo-builder-options-route.test.ts` (line 215) which previously asserted the buggy `opencode/` prefix.

typecheck:core clean for touched files; lint clean (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)