### PR TITLE
fix(translator): drop orphan tool results from empty call_id (#2893)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,12 @@
   configured, credential resolution now falls back to anonymous (no-auth) access
   instead of failing with "No credentials for provider: opencode-zen". A
   configured, active key is still used when present. (#2962)
+- **translator/responses:** fixed an upstream `[400] Messages with role 'tool'
+  must be a response to a preceding message with 'tool_calls'` when a Codex
+  client sent a `function_call` with an empty/missing `call_id`. The orphaned
+  `function_call_output` previously slipped past the orphan filter. Now
+  empty-`call_id` function calls are skipped (no dangling assistant tool_call)
+  and any tool result without a matching tool_call id is dropped. (#2893)
 
 ### ✨ New Features
 

--- a/open-sse/translator/request/openai-responses.ts
+++ b/open-sse/translator/request/openai-responses.ts
@@ -197,6 +197,13 @@ export function openaiResponsesToOpenAIRequest(
       if (!fnName) {
         continue;
       }
+      // #2893: Skip tool calls with an empty call_id — they can never be matched
+      // to their function_call_output, so the upstream rejects the orphaned tool
+      // result with "Messages with role 'tool' must be a response to a preceding
+      // message with 'tool_calls'". Dropping the unmatched pair avoids the 400.
+      if (!toString(item.call_id).trim()) {
+        continue;
+      }
 
       // Start or append assistant message with tool_calls
       if (!currentAssistantMsg) {
@@ -311,8 +318,11 @@ export function openaiResponsesToOpenAIRequest(
   }
   result.messages = messages.filter((m) => {
     const rec = toRecord(m);
-    if (rec.role === "tool" && rec.tool_call_id) {
-      return allToolCallIds.has(String(rec.tool_call_id));
+    // #2893: drop ANY tool result whose tool_call_id has no matching tool_call —
+    // including empty/missing ids (the previous `&& rec.tool_call_id` guard let
+    // empty-id orphans slip through and triggered an upstream 400).
+    if (rec.role === "tool") {
+      return allToolCallIds.has(String(rec.tool_call_id ?? ""));
     }
     return true;
   });

--- a/tests/unit/translator-openai-responses-req.test.ts
+++ b/tests/unit/translator-openai-responses-req.test.ts
@@ -797,3 +797,85 @@ test("Responses -> Chat: image_generation is stripped from output tools array (i
   assert.equal(tools[0].type, "function");
   assert.equal(tools[0].function.name, "foo");
 });
+
+// --- Issue #2893: orphaned tool results from empty/missing call_id ---
+
+test("Responses -> Chat: function_call with empty call_id is dropped together with its output (issue #2893)", () => {
+  // Codex can emit a function_call without a usable call_id; its
+  // function_call_output then becomes an orphan tool message that the upstream
+  // rejects ("role 'tool' must be a response to a preceding message with
+  // 'tool_calls'"). Both must be dropped.
+  const result = openaiResponsesToOpenAIRequest(
+    "gpt-4o",
+    {
+      input: [
+        { type: "message", role: "user", content: [{ type: "input_text", text: "hi" }] },
+        { type: "function_call", name: "read", call_id: "", arguments: "{}" },
+        { type: "function_call_output", call_id: "", output: "result" },
+      ],
+    },
+    false,
+    null
+  ) as Record<string, unknown>;
+
+  const messages = result.messages as any[];
+  // No orphan tool message.
+  assert.equal(
+    messages.some((m) => m.role === "tool"),
+    false,
+    "tool result with empty tool_call_id must be dropped"
+  );
+  // No dangling assistant tool_call with an empty id.
+  const danglingEmptyId = messages.some(
+    (m) =>
+      m.role === "assistant" &&
+      Array.isArray(m.tool_calls) &&
+      m.tool_calls.some((tc: any) => !tc.id)
+  );
+  assert.equal(danglingEmptyId, false, "assistant tool_call with empty id must be dropped");
+});
+
+test("Responses -> Chat: function_call with empty name leaves no orphan tool output (issue #2893)", () => {
+  const result = openaiResponsesToOpenAIRequest(
+    "gpt-4o",
+    {
+      input: [
+        { type: "function_call", name: "", call_id: "c-orphan", arguments: "{}" },
+        { type: "function_call_output", call_id: "c-orphan", output: "result" },
+      ],
+    },
+    false,
+    null
+  ) as Record<string, unknown>;
+
+  const messages = result.messages as any[];
+  assert.equal(
+    messages.some((m) => m.role === "tool"),
+    false,
+    "an output whose function_call was skipped (empty name) must not survive as an orphan"
+  );
+});
+
+test("Responses -> Chat: a valid function_call/output pair is preserved (issue #2893 regression)", () => {
+  const result = openaiResponsesToOpenAIRequest(
+    "gpt-4o",
+    {
+      input: [
+        { type: "function_call", name: "read", call_id: "c1", arguments: "{}" },
+        { type: "function_call_output", call_id: "c1", output: "result" },
+      ],
+    },
+    false,
+    null
+  ) as Record<string, unknown>;
+
+  const messages = result.messages as any[];
+  const assistant = messages.find(
+    (m) => m.role === "assistant" && Array.isArray(m.tool_calls)
+  );
+  assert.ok(assistant, "assistant message with tool_calls must be present");
+  assert.equal(assistant.tool_calls[0].id, "c1");
+  const toolMsg = messages.find((m) => m.role === "tool");
+  assert.ok(toolMsg, "matching tool result must be preserved");
+  assert.equal(toolMsg.tool_call_id, "c1");
+});


### PR DESCRIPTION
Closes #2893

## Problem

A Codex client could trigger an upstream rejection:
> `[400]: Messages with role 'tool' must be a response to a preceding message with 'tool_calls'`

## Root cause

In `openaiResponsesToOpenAIRequest` (Responses → Chat), a `function_call` with an empty/missing `call_id` produced an assistant `tool_call` with `id: ""`, and its `function_call_output` produced a `role:'tool'` message with `tool_call_id: ""`. The orphan filter's guard `if (rec.role === "tool" && rec.tool_call_id)` short-circuited on the empty (falsy) id, so the orphan tool message slipped through to the upstream. (A second path: a `function_call` skipped for an empty *name* also left its output as an orphan — already handled when the id is non-empty.)

## Fix

- Skip `function_call` items with an empty `call_id` (mirrors the existing empty-name skip) so no dangling assistant tool_call with an unmatched id is emitted.
- Drop **any** `role:'tool'` message whose `tool_call_id` (including empty/missing) has no matching tool_call, not only those with a truthy id.

Both only affect malformed/unmatched tool pairs; valid pairs are preserved.

## Tests

Added to `tests/unit/translator-openai-responses-req.test.ts`: empty-`call_id` pair → both dropped (no orphan tool message, no dangling empty-id tool_call); empty-name function_call → output not orphaned; valid pair preserved. Full file 36/36 green. typecheck:core clean for the touched file; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)