### PR TITLE
perf(proxy): parallelize provider proxy overlay lookups

### DIFF
--- a/src/app/api/settings/proxy/route.ts
+++ b/src/app/api/settings/proxy/route.ts
@@ -194,18 +194,25 @@ export async function GET(request: Request) {
     const providerAssignments = await getProxyAssignments({ scope: "provider" });
     if (providerAssignments.length > 0) {
       config.providers = { ...(config.providers || {}) };
-      for (const assignment of providerAssignments) {
-        if (!assignment.scopeId || !assignment.proxyId) {
-          continue;
-        }
-        const proxyData = await getProxyById(assignment.proxyId, { includeSecrets: true });
-        if (!proxyData) continue;
-        config.providers[assignment.scopeId] = {
-          type: proxyData.type,
-          host: proxyData.host,
-          port: proxyData.port,
-          username: proxyData.username,
-          password: proxyData.password,
+      const providerProxyResults = await Promise.all(
+        providerAssignments.map(async (assignment) => {
+          if (!assignment.scopeId || !assignment.proxyId) {
+            return null;
+          }
+          const proxyData = await getProxyById(assignment.proxyId, { includeSecrets: true });
+          if (!proxyData) return null;
+          return { scopeId: assignment.scopeId, proxyData };
+        })
+      );
+
+      for (const result of providerProxyResults) {
+        if (!result) continue;
+        config.providers[result.scopeId] = {
+          type: result.proxyData.type,
+          host: result.proxyData.host,
+          port: result.proxyData.port,
+          username: result.proxyData.username,
+          password: result.proxyData.password,
         };
       }
     }


### PR DESCRIPTION
## Summary

Follow-up to #2963, which was merged before this optimization commit landed.

This keeps the existing provider registry overlay behavior unchanged, but avoids resolving provider assignment proxy details sequentially. Provider assignment proxy lookups now run in parallel with `Promise.all`, then successful results are applied to `config.providers`.

## Validation

- `npx eslint src/app/api/settings/proxy/route.ts`
- `npx cross-env DISABLE_SQLITE_AUTO_BACKUP=true node --import tsx --test --test-force-exit tests/unit/route-edge-coverage.test.ts`

Result: 15 pass, 0 fail.