### PR TITLE
fix(sse): remove duplicate const settings in handleChatCore (release-blocker)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,12 @@
 
 ### Fixed
 
+- **sse/chatCore:** remove a duplicate `const settings` declaration in
+  `handleChatCore` (introduced alongside the per-key stream-default-mode
+  feature). The same-scope redeclaration made esbuild/tsx fail with
+  "The symbol 'settings' has already been declared", which turned every unit
+  test that imports chatCore red and broke the production build. The earlier
+  consolidated `settings` const is now reused.
 - **db/migrations:** resolve a `077` migration version collision
   (`077_api_key_stream_default_mode.sql` vs `077_quota_pools.sql`) that made
   `getMigrationFiles()` throw and blocked `getDbInstance()` at startup (app would

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -2151,7 +2151,10 @@ export async function handleChatCore({
           userAgent: streamUserAgent,
           streamDefaultMode: apiKeyInfo?.streamDefaultMode,
         });
-  const settings = cachedSettings ?? (await getCachedSettings());
+  // `settings` is already consolidated once near the top of handleChatCore
+  // (the "fetch once, reuse" const). A second `const settings` here was a
+  // duplicate same-scope declaration that broke the esbuild/tsx transform
+  // ("settings has already been declared") and the production build. Reuse it.
   credentials = applyCodexGlobalFastServiceTier(provider, credentials, settings, {
     model: requestedModel,
     body: body && typeof body === "object" ? (body as Record<string, unknown>) : null,

--- a/tests/unit/chatcore-imports-cleanly.test.ts
+++ b/tests/unit/chatcore-imports-cleanly.test.ts
@@ -1,0 +1,23 @@
+/**
+ * Regression guard: `open-sse/handlers/chatCore.ts` must transform/compile.
+ *
+ * `handleChatCore` declared `const settings` twice in the same function scope
+ * (a "fetch once, reuse" const near the top + a duplicate added by the per-key
+ * stream-default-mode feature). esbuild/tsx rejected it with
+ * "The symbol 'settings' has already been declared", which turned EVERY test
+ * that imports chatCore red and broke the production build.
+ *
+ * Importing the module forces the transform; if the duplicate declaration
+ * returns, this import throws and the test fails loudly.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+test("chatCore.ts imports without a duplicate-declaration transform error", async () => {
+  const mod = await import("../../open-sse/handlers/chatCore.ts");
+  assert.equal(
+    typeof mod.handleChatCore,
+    "function",
+    "handleChatCore must be importable (no duplicate `const settings` in scope)"
+  );
+});


### PR DESCRIPTION
## Problem (release-blocker)

`handleChatCore` (`open-sse/handlers/chatCore.ts`) declared `const settings = cachedSettings ?? (await getCachedSettings())` **twice in the same function scope** — the consolidated "fetch once, reuse" const (~line 1921) plus a duplicate (~line 2154) added alongside the per-key stream-default-mode feature (commit `99d673fe5`).

esbuild/tsx rejects the same-scope redeclaration:
```
chatCore.ts:2154:8: ERROR: The symbol "settings" has already been declared
```
This turned **every unit test that imports chatCore red** (e.g. `system-role-extraction`, `claude-passthrough-thinking-2454`) and breaks the production build (a duplicate block-scoped `const` is a hard JS error).

> Same commit (`99d673fe5`) that introduced the migration-077 collision fixed in #2966.

## Fix

Remove the duplicate declaration; reuse the earlier consolidated `settings`.

## Verification

- `chatcore-imports-cleanly` (new import guard): 1/1
- `system-role-extraction`: **10/10** (was red — TransformError)
- `claude-passthrough-thinking-2454`: **4/4** (was red)
- typecheck:core: no `settings` redeclare error; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)