### PR TITLE
fix(routing): honor client reasoning.effort for gpt-5.5 + route suffixed variants to codex (#2877)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,14 @@
 
 ### Fixed
 
+- **routing/codex:** fix two gpt-5.5 Codex defects (#2877). (A) For a Codex-only
+  account, a bare `gpt-5.5` Responses request was rerouted to codex with the
+  model hardcoded to `gpt-5.5-medium` (`chatHelpers.ts`); the executor read that
+  `-medium` suffix as an explicit `modelEffort` that (per #2331) overrode a
+  client `reasoning.effort=xhigh`, silently demoting it — now it keeps the bare
+  `gpt-5.5` id so the client effort wins. (B) `gpt-5.5-xhigh`/`-high`/`-low`
+  misrouted to `openai` (→ "No credentials" for codex-only users); the suffixed
+  variants are now in `CODEX_PREFERRED_UNPREFIXED_MODELS` so they infer codex.
 - **sse/chatCore:** remove a duplicate `const settings` declaration in
   `handleChatCore` (introduced alongside the per-key stream-default-mode
   feature). The same-scope redeclaration made esbuild/tsx fail with

--- a/open-sse/services/model.ts
+++ b/open-sse/services/model.ts
@@ -112,7 +112,16 @@ for (const [aliasOrId, models] of Object.entries(PROVIDER_MODELS)) {
   }
 }
 const KNOWN_MODEL_IDS = new Set(MODEL_TO_PROVIDERS.keys());
-const CODEX_PREFERRED_UNPREFIXED_MODELS = new Set(["gpt-5.5"]);
+// #2877(B): include the effort-suffixed variants so a bare `gpt-5.5-xhigh`
+// (and -high/-medium/-low) infers the codex provider instead of falling through
+// the `/^gpt-/` → openai fallback (which 500s for codex-only credentials).
+const CODEX_PREFERRED_UNPREFIXED_MODELS = new Set([
+  "gpt-5.5",
+  "gpt-5.5-xhigh",
+  "gpt-5.5-high",
+  "gpt-5.5-medium",
+  "gpt-5.5-low",
+]);
 const CODEX_PREFERRED_UNPREFIXED_MODEL_ALIASES = new Map([["gpt-5.5", "gpt-5.5-medium"]]);
 export const CODEX_NATIVE_UNPREFIXED_MODELS = new Set(["codex-auto-review"]);
 

--- a/src/sse/handlers/chatHelpers.ts
+++ b/src/sse/handlers/chatHelpers.ts
@@ -130,9 +130,14 @@ export async function resolveModelOrError(
     !isCodexNativeResponsesRequest(body, endpointPath, requestHeaders) &&
     (await hasOnlyActiveCodexAccount())
   ) {
-    log.info("ROUTING", `${modelStr} → codex/gpt-5.5-medium (Codex-only active account)`);
+    // #2877: keep the bare model id (do NOT bake a `-medium` suffix). The Codex
+    // executor reads a model-name suffix as an explicit `modelEffort` that (per
+    // #2331) overrides the client's `reasoning.effort`, so injecting `-medium`
+    // here silently demoted a genuine `reasoning.effort=xhigh`. The default
+    // effort still comes from the connection fallback when the client sends none.
+    log.info("ROUTING", `${modelStr} → codex/gpt-5.5 (Codex-only active account)`);
     modelInfo.provider = "codex";
-    modelInfo.model = "gpt-5.5-medium";
+    modelInfo.model = "gpt-5.5";
   }
 
   // Forced-rewrite: codex provider doesn't serve DeepSeek/Qwen/Kimi/etc. Reroute

--- a/tests/unit/codex-gpt55-effort-routing.test.ts
+++ b/tests/unit/codex-gpt55-effort-routing.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Issue #2877 — two routing/effort defects for the gpt-5.5 Codex family:
+ *
+ * (B) `gpt-5.5-xhigh` (and -high/-low) misrouted to the `openai` provider
+ *     because only bare `gpt-5.5` was in CODEX_PREFERRED_UNPREFIXED_MODELS — the
+ *     suffixed variants fell through to the `/^gpt-/` → openai fallback, so a
+ *     Codex-OAuth-only user got "No credentials for provider: openai". Fixed by
+ *     adding the variants to the set (`open-sse/services/model.ts`).
+ *
+ * (A) For a Codex-only account, a bare `gpt-5.5` Responses request was rerouted
+ *     to codex but with the model hardcoded to `gpt-5.5-medium`
+ *     (`src/sse/handlers/chatHelpers.ts`). The Codex executor reads that `-medium`
+ *     suffix as an explicit `modelEffort`, which (per #2331) overrides the
+ *     client's `reasoning.effort=xhigh` — silently demoting it. Fixed by keeping
+ *     the bare `gpt-5.5` id; the executor's modelEffort-first precedence (#2331)
+ *     is left untouched.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-gpt55-routing-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const providersDb = await import("../../src/lib/db/providers.ts");
+const { getModelInfoCore } = await import("../../open-sse/services/model.ts");
+const { resolveModelOrError } = await import("../../src/sse/handlers/chatHelpers.ts");
+
+test.before(async () => {
+  // Codex-only active account (no openai connection).
+  await providersDb.createProviderConnection({
+    provider: "codex",
+    authType: "oauth",
+    email: "codex@example.com",
+    providerSpecificData: { workspaceId: "ws-1" },
+  });
+});
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+// ── Defect B: suffixed bare names infer codex, not openai ─────────────────────
+for (const variant of ["gpt-5.5-xhigh", "gpt-5.5-high", "gpt-5.5-low"]) {
+  test(`#2877(B) ${variant} infers codex (not openai)`, async () => {
+    const info = await getModelInfoCore(variant, null);
+    assert.equal(info.provider, "codex", `${variant} must infer the codex provider`);
+    assert.equal(info.model, variant, "the explicit effort suffix must be preserved");
+  });
+}
+
+// ── Defect A: Codex-only bare gpt-5.5 reroute must NOT bake a -medium suffix ───
+test("#2877(A) Codex-only bare gpt-5.5 Responses request keeps the bare model id", async () => {
+  const result = (await resolveModelOrError(
+    "gpt-5.5",
+    { input: [{ role: "user", content: [{ type: "input_text", text: "hi" }] }] },
+    "/v1/responses",
+    null
+  )) as { provider?: string; model?: string };
+
+  assert.equal(result.provider, "codex", "Codex-only account must reroute gpt-5.5 to codex");
+  assert.equal(
+    result.model,
+    "gpt-5.5",
+    "must NOT inject a -medium suffix (that would override a client reasoning.effort=xhigh)"
+  );
+});


### PR DESCRIPTION
Closes #2877 (from Discussion #2829)

## Defect A — auto-injected `-medium` demotes a client `reasoning.effort=xhigh`

For a **Codex-only** account, a bare `gpt-5.5` Responses request is rerouted to codex, but `src/sse/handlers/chatHelpers.ts` hardcoded `modelInfo.model = "gpt-5.5-medium"`. The Codex executor reads that `-medium` suffix as an explicit `modelEffort` which — correctly, per #2331 — overrides a client-sent `reasoning.effort`. Net effect: user asks for `xhigh`, wire payload carries `medium` (reporter's observed payload: `{ model: "codex/gpt-5.5-medium", reasoning: { effort: "xhigh" } }`).

**Fix:** keep the bare `gpt-5.5` id on reroute. The default effort still comes from the connection fallback when the client sends none; the executor's `modelEffort`-first precedence is **untouched**, so #2331 stays intact (its source-guard test still passes).

## Defect B — `gpt-5.5-xhigh` misroutes to `openai`

`CODEX_PREFERRED_UNPREFIXED_MODELS` only contained bare `gpt-5.5`, so `gpt-5.5-xhigh`/`-high`/`-low` fell through to the `/^gpt-/` → openai fallback. Codex-OAuth-only users got `No credentials for provider: openai`.

**Fix:** add the effort-suffixed variants to `CODEX_PREFERRED_UNPREFIXED_MODELS` (they are already registered codex models) so they infer codex.

## Tests

New `tests/unit/codex-gpt55-effort-routing.test.ts`: (B) `gpt-5.5-xhigh/-high/-low` infer codex via `getModelInfoCore` with a codex-only account; (A) `resolveModelOrError("gpt-5.5", …, "/v1/responses")` keeps model `gpt-5.5` (not `-medium`). Regression: `codex-effort-alias-priority` (#2331, 6/6), `codex-fast-tier`, `codex-connection-defaults`, `base-executor-sanitize-effort` all green. typecheck:core clean; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)