### PR TITLE
fix(docker): add 'web' compose profile for web-cookie providers (#2832)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,11 @@
 
 ### Fixed
 
+- **docker:** add a `web` compose profile (`omniroute-web`, target `runner-web`,
+  image `omniroute:web`) so web-cookie providers (gemini-web, claude-web,
+  claude-turnstile) work out of the box — the default `base` image ships without
+  Chromium/Playwright, which made those providers fail with
+  "Executable doesn't exist at .../ms-playwright/chromium...". (#2832)
 - **routing/codex:** fix two gpt-5.5 Codex defects (#2877). (A) For a Codex-only
   account, a bare `gpt-5.5` Responses request was rerouted to codex with the
   model hardcoded to `gpt-5.5-medium` (`chatHelpers.ts`); the executor read that

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,12 +4,14 @@
 #
 #  Profiles:
 #    base  → minimal image, no CLI tools
+#    web   → runner-web (+Chromium/Playwright) for web-cookie providers
 #    cli   → CLIs installed inside the container (portable)
 #    host  → runner-base + host-mounted CLI binaries (Linux-first)
 #    cliproxyapi → CLIProxyAPI sidecar on port 8317
 #
 #  Usage:
 #    docker compose --profile base up -d
+#    docker compose --profile web up -d   # gemini-web / claude-web / claude-turnstile
 #    docker compose --profile cli up -d
 #    docker compose --profile host up -d
 #    docker compose --profile cliproxyapi up -d
@@ -68,6 +70,23 @@ services:
       - "${API_PORT:-20129}:${API_PORT:-20129}"
     profiles:
       - base
+
+  # ── Profile: web (runner-web + Chromium/Playwright) ────────────────
+  # Required for web-cookie providers (gemini-web, claude-web, claude-turnstile).
+  # The default `base` image ships without Chromium, so those providers fail
+  # with "Executable doesn't exist at .../ms-playwright/chromium..." (#2832).
+  omniroute-web:
+    <<: *common
+    container_name: omniroute
+    build:
+      context: .
+      target: runner-web
+    image: omniroute:web
+    ports:
+      - "${DASHBOARD_PORT:-${PORT:-20128}}:${DASHBOARD_PORT:-${PORT:-20128}}"
+      - "${API_PORT:-20129}:${API_PORT:-20129}"
+    profiles:
+      - web
 
   # ── Profile: cli (CLIs installed inside container) ─────────────────
   omniroute-cli:


### PR DESCRIPTION
Closes #2832

## Problem

Web-cookie providers (`gemini-web`, `claude-web`, `claude-turnstile`) require Playwright + Chromium, which only ships in the **`runner-web`** image stage (`Dockerfile`). The default `docker-compose.yml` had no service targeting `runner-web`, so `docker compose up` ran the `base` image and those providers failed with:
```
Executable doesn't exist at /home/node/.cache/ms-playwright/chromium...
```

## Fix

Add an `omniroute-web` service (`target: runner-web`, `image: omniroute:web`, `profile: web`) mirroring `omniroute-base`, and document the `web` profile in the header.

```bash
docker compose --profile web up -d
```

## Verification

`docker compose --profile web config` parses and validates cleanly (service resolves to `target: runner-web` / `image: omniroute:web`). No production code (`src/open-sse/electron/bin`) changed, so no unit tests apply; the Dockerfile `runner-web` stage already exists and is documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)