### PR TITLE
fix(docker): honor OMNIROUTE_MEMORY_MB heap limit in standalone launcher (#2939)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -919,10 +919,11 @@ APP_LOG_TO_FILE=true
 # 17. MEMORY OPTIMIZATION (Low-RAM / Docker)
 # ═══════════════════════════════════════════════════════════════════════════════
 
-# Node.js V8 heap limit in MB.
-# Used by: Docker entrypoint — sets --max-old-space-size.
-# Default: 256 (Docker) | system default (npm)
-# OMNIROUTE_MEMORY_MB=256
+# Node.js V8 heap limit in MB, passed to the server via --max-old-space-size.
+# Used by the standalone launcher (Docker CMD) and `omniroute serve`.
+# Default: 512. Clamped to [64, 16384]. Raise it (e.g. 1024) if you see random
+# OOM crashes under load or with a large SQLite DB (#2939).
+# OMNIROUTE_MEMORY_MB=512
 
 # ── CLI helpers (bin/cli/) ──
 # Override UI language for CLI output. Accepts BCP-47 locale (e.g. en, pt-BR).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,10 @@
 
 ### Fixed
 
+- **docker:** the standalone launcher (Docker `CMD`) now honors
+  `OMNIROUTE_MEMORY_MB` (default 512, clamped [64, 16384]) and overrides the
+  baked `--max-old-space-size=256`, fixing random OOM crashes under load / with
+  large SQLite DBs. Previously only `omniroute serve` honored the knob. (#2939)
 - **docker:** add a `web` compose profile (`omniroute-web`, target `runner-web`,
   image `omniroute:web`) so web-cookie providers (gemini-web, claude-web,
   claude-turnstile) work out of the box — the default `base` image ships without

--- a/scripts/build/runtime-env.mjs
+++ b/scripts/build/runtime-env.mjs
@@ -6,6 +6,20 @@ export function parsePort(value, fallback) {
 }
 
 /**
+ * Resolve the V8 heap ceiling (MB) for the server process from
+ * `OMNIROUTE_MEMORY_MB`, mirroring `omniroute serve`. Clamped to [64, 16384];
+ * invalid/unset → fallback (512). The Docker image bakes
+ * NODE_OPTIONS=--max-old-space-size=256, which OOMs under load / large DBs
+ * (#2939) — the standalone launcher uses this to override that cap.
+ * @param {string | number | undefined | null} value
+ * @param {number} [fallback]
+ */
+export function resolveMaxOldSpaceMb(value, fallback = 512) {
+  const parsed = Number.parseInt(String(value), 10);
+  return Number.isFinite(parsed) && parsed >= 64 && parsed <= 16384 ? parsed : fallback;
+}
+
+/**
  * @param {NodeJS.ProcessEnv | Record<string, string | undefined>} [fromEnv]
  *        Defaults to process.env. Pass bootstrap `merged` so project `.env` PORT applies before spawn.
  */

--- a/scripts/dev/run-standalone.mjs
+++ b/scripts/dev/run-standalone.mjs
@@ -3,14 +3,24 @@
 import {
   resolveRuntimePorts,
   withRuntimePortEnv,
+  resolveMaxOldSpaceMb,
   spawnWithForwardedSignals,
 } from "../build/runtime-env.mjs";
 import { bootstrapEnv } from "../build/bootstrap-env.mjs";
 
 const env = bootstrapEnv();
 const runtimePorts = resolveRuntimePorts(env);
+const childEnv = withRuntimePortEnv(env, runtimePorts);
+
+// #2939: the Docker image bakes NODE_OPTIONS=--max-old-space-size=256, which OOMs
+// under load / large SQLite DBs. Honor OMNIROUTE_MEMORY_MB (default 512), the same
+// knob `omniroute serve` uses. A trailing --max-old-space-size wins, so this
+// overrides the baked 256 without clobbering any other NODE_OPTIONS flags.
+const maxOldSpaceMb = resolveMaxOldSpaceMb(childEnv.OMNIROUTE_MEMORY_MB);
+childEnv.NODE_OPTIONS =
+  `${childEnv.NODE_OPTIONS || ""} --max-old-space-size=${maxOldSpaceMb}`.trim();
 
 spawnWithForwardedSignals("node", ["server.js"], {
   stdio: "inherit",
-  env: withRuntimePortEnv(env, runtimePorts),
+  env: childEnv,
 });

--- a/tests/unit/runtime-env-max-old-space.test.ts
+++ b/tests/unit/runtime-env-max-old-space.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Issue #2939 — random OOM in Docker. The image bakes
+ * NODE_OPTIONS=--max-old-space-size=256, and the standalone launcher
+ * (`scripts/dev/run-standalone.mjs`, the Docker CMD) did not honor
+ * OMNIROUTE_MEMORY_MB, so the server child inherited the 256 MB cap and OOMed
+ * under load / large SQLite DBs.
+ *
+ * `resolveMaxOldSpaceMb` is the shared heap-ceiling resolver the launcher now
+ * uses (mirroring `omniroute serve`): OMNIROUTE_MEMORY_MB clamped to [64, 16384],
+ * default 512.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { resolveMaxOldSpaceMb } = await import("../../scripts/build/runtime-env.mjs");
+
+test("#2939 default is 512 when unset/invalid", () => {
+  assert.equal(resolveMaxOldSpaceMb(undefined), 512);
+  assert.equal(resolveMaxOldSpaceMb(null), 512);
+  assert.equal(resolveMaxOldSpaceMb(""), 512);
+  assert.equal(resolveMaxOldSpaceMb("abc"), 512);
+});
+
+test("#2939 honors a valid OMNIROUTE_MEMORY_MB (string or number)", () => {
+  assert.equal(resolveMaxOldSpaceMb("1024"), 1024);
+  assert.equal(resolveMaxOldSpaceMb(2048), 2048);
+  assert.equal(resolveMaxOldSpaceMb("256"), 256);
+});
+
+test("#2939 clamps out-of-range values to the default", () => {
+  assert.equal(resolveMaxOldSpaceMb("32"), 512, "below 64 → default");
+  assert.equal(resolveMaxOldSpaceMb("99999"), 512, "above 16384 → default");
+  assert.equal(resolveMaxOldSpaceMb("64"), 64, "lower bound inclusive");
+  assert.equal(resolveMaxOldSpaceMb("16384"), 16384, "upper bound inclusive");
+});
+
+test("#2939 a custom fallback is respected", () => {
+  assert.equal(resolveMaxOldSpaceMb(undefined, 1024), 1024);
+});


### PR DESCRIPTION
Closes #2939

## Problem

Random OOM crashes in Docker. The image bakes `ENV NODE_OPTIONS="--max-old-space-size=256"` (`Dockerfile:60`), and the Docker `CMD` (`node dev/run-standalone.mjs`) spawned `node server.js` **without overriding it** — so the server ran with a 256 MB V8 heap and OOMed under load / with a large SQLite DB. The reporter's workaround (`NODE_OPTIONS=--max-old-space-size=1024`) confirmed the cause. `omniroute serve` already honored `OMNIROUTE_MEMORY_MB`, but the Docker/standalone path did not.

## Fix

- Add a shared `resolveMaxOldSpaceMb(value, fallback=512)` helper in `scripts/build/runtime-env.mjs` (clamp [64, 16384], default 512) — the same contract `omniroute serve` uses.
- In `scripts/dev/run-standalone.mjs`, append `--max-old-space-size=${OMNIROUTE_MEMORY_MB||512}` to the child `NODE_OPTIONS`. A trailing `--max-old-space-size` wins, so it overrides the baked 256 without clobbering other flags.
- Update `.env.example` to document the 512 default + OOM guidance.

## Tests

New `tests/unit/runtime-env-max-old-space.test.ts` (4 tests): default 512, honors valid values, clamps out-of-range, custom fallback. `node --check` on the launcher; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)