### PR TITLE
fix(codex): drop image_generation for free-plan accounts (#2980 spin-off)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,10 @@
 
 ### Fixed
 
+- **executors/codex:** drop the CLI-injected `image_generation` hosted tool for
+  free-plan Codex accounts (`workspacePlanType === "free"`), which can't run it
+  server-side and would otherwise get an upstream 400. Paid plans keep it.
+  (mirrors CLIProxyAPI's free-plan guard; spun off from the #2980 analysis)
 - **dashboard:** custom providers (`openai-compatible-*` / `anthropic-compatible-*`)
   now show their user-given node name instead of the raw UUID id across the
   active-requests panel, proxy logger, and home-page provider topology. The

--- a/open-sse/executors/codex.ts
+++ b/open-sse/executors/codex.ts
@@ -436,7 +436,20 @@ const CODEX_HOSTED_TOOL_TYPES: ReadonlySet<string> = new Set([
   "local_shell",
 ]);
 
-function normalizeCodexTools(body: Record<string, unknown>): void {
+// #2980: a free-plan Codex account (workspacePlanType === "free", from the OAuth
+// id_token) cannot run the server-side `image_generation` hosted tool. The Codex
+// CLI injects it into every Responses request regardless of plan, so it must be
+// dropped for free-plan accounts (mirrors CLIProxyAPI's isCodexFreePlanAuth).
+export function isCodexFreePlan(providerSpecificData: unknown): boolean {
+  if (!providerSpecificData || typeof providerSpecificData !== "object") return false;
+  const plan = (providerSpecificData as { workspacePlanType?: unknown }).workspacePlanType;
+  return typeof plan === "string" && plan.trim().toLowerCase() === "free";
+}
+
+export function normalizeCodexTools(
+  body: Record<string, unknown>,
+  options?: { dropImageGeneration?: boolean }
+): void {
   if (!Array.isArray(body.tools)) return;
 
   const validToolNames = new Set<string>();
@@ -470,6 +483,11 @@ function normalizeCodexTools(body: Record<string, unknown>): void {
         return false;
       }
       if (CODEX_HOSTED_TOOL_TYPES.has(toolType)) {
+        // #2980: drop the CLI-injected image_generation tool for free-plan
+        // accounts, which can't run it server-side (upstream 400 otherwise).
+        if (toolType === "image_generation" && options?.dropImageGeneration === true) {
+          return false;
+        }
         return true;
       }
       console.debug(`[Codex] dropping unknown hosted tool type: ${toolType}`);
@@ -1242,7 +1260,9 @@ export class CodexExecutor extends BaseExecutor {
     // Codex Responses only supports function tools with non-empty names.
     // Cursor may include custom tools (e.g. ApplyPatch) that work locally but are
     // invalid upstream, and translation bugs can leave orphaned/empty tool_choice names.
-    normalizeCodexTools(body);
+    normalizeCodexTools(body, {
+      dropImageGeneration: isCodexFreePlan(credentials?.providerSpecificData),
+    });
 
     // Strip stored response item references (rs_, resp_, msg_ IDs) from input.
     // The /codex/responses endpoint does not persist responses even with store=true,

--- a/tests/unit/codex-free-plan-image-generation.test.ts
+++ b/tests/unit/codex-free-plan-image-generation.test.ts
@@ -1,0 +1,53 @@
+/**
+ * #2980 spin-off — free-plan Codex accounts can't run the server-side
+ * `image_generation` hosted tool, but the Codex CLI injects it into every
+ * Responses request, causing an upstream 400. Drop it for free-plan accounts
+ * (mirrors CLIProxyAPI's isCodexFreePlanAuth); preserve it for paid plans.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { normalizeCodexTools, isCodexFreePlan } = await import("../../open-sse/executors/codex.ts");
+
+test("isCodexFreePlan detects workspacePlanType === 'free' (case-insensitive)", () => {
+  assert.equal(isCodexFreePlan({ workspacePlanType: "free" }), true);
+  assert.equal(isCodexFreePlan({ workspacePlanType: "FREE" }), true);
+  assert.equal(isCodexFreePlan({ workspacePlanType: "team" }), false);
+  assert.equal(isCodexFreePlan({ workspacePlanType: "" }), false);
+  assert.equal(isCodexFreePlan({}), false);
+  assert.equal(isCodexFreePlan(undefined), false);
+  assert.equal(isCodexFreePlan(null), false);
+});
+
+test("normalizeCodexTools drops image_generation when dropImageGeneration=true (free plan)", () => {
+  const body: Record<string, unknown> = {
+    tools: [
+      { type: "image_generation", output_format: "png" },
+      { type: "function", name: "foo", parameters: { type: "object" } },
+    ],
+  };
+  normalizeCodexTools(body, { dropImageGeneration: true });
+  const tools = body.tools as Array<{ type?: string; name?: string }>;
+  assert.equal(
+    tools.some((t) => t.type === "image_generation"),
+    false,
+    "image_generation must be dropped for free-plan accounts"
+  );
+  assert.equal(tools.length, 1, "the function tool must survive");
+  assert.equal(tools[0].type, "function");
+});
+
+test("normalizeCodexTools preserves image_generation for paid plans (default / false)", () => {
+  for (const opts of [undefined, { dropImageGeneration: false }]) {
+    const body: Record<string, unknown> = {
+      tools: [{ type: "image_generation", output_format: "png" }],
+    };
+    normalizeCodexTools(body, opts);
+    const tools = body.tools as Array<{ type?: string }>;
+    assert.equal(
+      tools.some((t) => t.type === "image_generation"),
+      true,
+      "image_generation must be preserved for paid/unknown plans"
+    );
+  }
+});


### PR DESCRIPTION
Spun off from the #2980 (Codex OAuth compat) analysis against CLIProxyAPI.

## Problem

Free-plan Codex accounts (`workspacePlanType === "free"`, from the OAuth id_token) **cannot run the server-side `image_generation` hosted tool**, but the Codex CLI injects `{ type: "image_generation", output_format: "png" }` into every Responses request regardless of plan — so free-plan users hit an upstream 400. CLIProxyAPI guards this via `isCodexFreePlanAuth`; OmniRoute read `workspacePlanType` but never used it in the executor.

## Fix

- `isCodexFreePlan(providerSpecificData)` helper (true only when `workspacePlanType === "free"`, case-insensitive — conservative, paid/unknown plans unaffected).
- `normalizeCodexTools(body, { dropImageGeneration })` drops `image_generation` from the hosted-tool pass-through when set; the call site passes `isCodexFreePlan(credentials?.providerSpecificData)`.

## Tests

New `tests/unit/codex-free-plan-image-generation.test.ts` (3): `isCodexFreePlan` truth table; image_generation dropped for free plan; preserved for paid/unknown (default + explicit false). Regression: `codex-base-url`, `codex-stream-false`, `codex-fast-tier` green. typecheck:core clean; lint clean.

> Note: semgrep may surface a pre-existing `ws://` finding in `toWebSocketUrl()` (lines ~749) — that function correctly maps `http→ws` / `https→wss` and is untouched by this PR (from #1573).

🤖 Generated with [Claude Code](https://claude.com/claude-code)