### PR TITLE
fix(providers): route Pollinations to gen.pollinations.ai/v1 (#2987)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,9 @@
 
 ### Fixed
 
+- **providers/pollinations:** route to `gen.pollinations.ai/v1` instead of the
+  retired `text.pollinations.ai` host, which now returns `404 "legacy API"` for
+  all models. The gen gateway is the current OpenAI-compatible endpoint. (#2987)
 - **executors/codex:** drop the CLI-injected `image_generation` hosted tool for
   free-plan Codex accounts (`workspacePlanType === "free"`), which can't run it
   server-side and would otherwise get an upstream 400. Paid plans keep it.

--- a/open-sse/config/providerRegistry.ts
+++ b/open-sse/config/providerRegistry.ts
@@ -3441,13 +3441,11 @@ export const REGISTRY: Record<string, RegistryEntry> = {
     alias: "pol",
     format: "openai",
     executor: "pollinations",
-    // Primary endpoint is text.pollinations.ai. gen.pollinations.ai is the current
-    // OpenAI-compatible fallback used when the primary edge is rate-limited or unavailable.
-    baseUrl: "https://text.pollinations.ai/openai/chat/completions",
-    baseUrls: [
-      "https://text.pollinations.ai/openai/chat/completions",
-      "https://gen.pollinations.ai/v1/chat/completions",
-    ],
+    // #2987: Pollinations retired the legacy text.pollinations.ai host (it now
+    // returns 404 "This is our legacy API"). The current OpenAI-compatible gateway
+    // is gen.pollinations.ai/v1, so route there as the primary endpoint.
+    baseUrl: "https://gen.pollinations.ai/v1/chat/completions",
+    baseUrls: ["https://gen.pollinations.ai/v1/chat/completions"],
     authType: "apikey",
     authHeader: "bearer",
     models: [

--- a/open-sse/executors/pollinations.ts
+++ b/open-sse/executors/pollinations.ts
@@ -11,7 +11,7 @@ export class PollinationsExecutor extends BaseExecutor {
   buildUrl(_model: string, _stream: boolean, urlIndex = 0, _credentials = null): string {
     const baseUrls = this.getBaseUrls();
     return (
-      baseUrls[urlIndex] || baseUrls[0] || "https://text.pollinations.ai/openai/chat/completions"
+      baseUrls[urlIndex] || baseUrls[0] || "https://gen.pollinations.ai/v1/chat/completions"
     );
   }
 

--- a/tests/unit/executor-pollinations.test.ts
+++ b/tests/unit/executor-pollinations.test.ts
@@ -3,12 +3,15 @@ import assert from "node:assert/strict";
 
 import { PollinationsExecutor } from "../../open-sse/executors/pollinations.ts";
 
-test("PollinationsExecutor.buildUrl uses the primary endpoint and the gen fallback", () => {
+test("#2987 PollinationsExecutor.buildUrl uses the gen.pollinations.ai gateway (not the legacy text host)", () => {
   const executor = new PollinationsExecutor();
+  // Legacy text.pollinations.ai now 404s ("legacy API"); gen.pollinations.ai/v1
+  // is the current OpenAI-compatible endpoint and must be the primary.
   assert.equal(
     executor.buildUrl("openai", true),
-    "https://text.pollinations.ai/openai/chat/completions"
+    "https://gen.pollinations.ai/v1/chat/completions"
   );
+  // No legacy text.pollinations.ai endpoint should remain in the rotation.
   assert.equal(
     executor.buildUrl("openai", true, 1),
     "https://gen.pollinations.ai/v1/chat/completions"


### PR DESCRIPTION
Closes #2987

## Problem
The Pollinations provider 404s with `This is our legacy API` for **all** models. The registry's primary `baseUrl` (and the executor's hardcoded fallback) pointed at `https://text.pollinations.ai/openai/chat/completions`, which Pollinations **retired**. The current OpenAI-compatible gateway is `https://gen.pollinations.ai/v1` — it was already present as the secondary fallback (`baseUrls[1]`), but the executor defaults to `baseUrls[0]`.

Confirmed via Pollinations docs: `gen.pollinations.ai/v1/chat/completions` is the current endpoint; `text.pollinations.ai` returns the legacy-API 404.

## Fix
- `providerRegistry.ts`: `baseUrl` + `baseUrls` → `gen.pollinations.ai/v1/chat/completions` (dropped the dead legacy host).
- `pollinations.ts`: hardcoded fallback updated to the gen gateway.
- Aligned `executor-pollinations.test.ts` (it asserted the legacy host as primary).

## Tests
`executor-pollinations.test.ts` 4/4. No `text.pollinations.ai` remains in source. typecheck:core clean; lint clean.

Sources: https://github.com/pollinations/pollinations/blob/main/APIDOCS.md · https://enter.pollinations.ai/api/docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)