### PR TITLE
feat: add a switch to disable use of non-published models

### DIFF
--- a/src/app/(dashboard)/dashboard/api-manager/ApiManagerPageClient.tsx
+++ b/src/app/(dashboard)/dashboard/api-manager/ApiManagerPageClient.tsx
@@ -98,6 +98,7 @@ interface ApiKey {
   rateLimits?: Array<{ limit: number; window: number }> | null;
   scopes?: string[];
   allowedEndpoints?: string[];
+  disableNonPublicModels?: boolean;
   createdAt: string;
 }
 
@@ -504,7 +505,8 @@ export default function ApiManagerPageClient() {
     accessSchedule: AccessSchedule | null,
     rateLimits: Array<{ limit: number; window: number }> | null,
     scopes: string[],
-    allowedEndpoints: string[]
+    allowedEndpoints: string[],
+    disableNonPublicModels: boolean
   ) => {
     if (!editingKey || !editingKey.id) return;
 
@@ -565,6 +567,7 @@ export default function ApiManagerPageClient() {
           rateLimits,
           scopes,
           allowedEndpoints,
+          disableNonPublicModels,
         }),
       });
 
@@ -1264,7 +1267,8 @@ const PermissionsModal = memo(function PermissionsModal({
     accessSchedule: AccessSchedule | null,
     rateLimits: Array<{ limit: number; window: number }> | null,
     scopes: string[],
-    allowedEndpoints: string[]
+    allowedEndpoints: string[],
+    disableNonPublicModels: boolean
   ) => void;
 }) {
   const t = useTranslations("apiManager");
@@ -1330,6 +1334,9 @@ const PermissionsModal = memo(function PermissionsModal({
   const initialEndpoints = Array.isArray(apiKey?.allowedEndpoints) ? apiKey.allowedEndpoints : [];
   const [selectedEndpoints, setSelectedEndpoints] = useState<string[]>(initialEndpoints);
   const [allowAllEndpoints, setAllowAllEndpoints] = useState(initialEndpoints.length === 0);
+  const [disableNonPublicModels, setDisableNonPublicModels] = useState(
+    apiKey?.disableNonPublicModels === true
+  );
 
   // Memoize callbacks to prevent child re-renders
   const handleToggleModel = useCallback(
@@ -1479,7 +1486,8 @@ const PermissionsModal = memo(function PermissionsModal({
         selfUsageEnabled,
         selfAccountQuotaEnabled,
       }),
-      allowAllEndpoints ? [] : selectedEndpoints
+      allowAllEndpoints ? [] : selectedEndpoints,
+      disableNonPublicModels
     );
   }, [
     onSave,
@@ -1508,6 +1516,7 @@ const PermissionsModal = memo(function PermissionsModal({
     rateLimits,
     allowAllEndpoints,
     selectedEndpoints,
+    disableNonPublicModels,
     apiKey?.scopes,
     t,
   ]);
@@ -1995,6 +2004,30 @@ const PermissionsModal = memo(function PermissionsModal({
             {selfAccountQuotaEnabled ? tc("enabled") : tc("disabled")}
           </button>
           <p className="text-xs text-text-muted">{t("sharedAccountQuotaVisibilityDesc")}</p>
+        </div>
+
+        {/* Disable Non-Public Models Toggle */}
+        <div className="flex items-start justify-between gap-3 p-3 rounded-lg border border-border bg-surface/40">
+          <div className="flex flex-col gap-1">
+            <p className="text-sm font-medium text-text-main">{t("disableNonPublicModels")}</p>
+            <p className="text-xs text-text-muted">{t("disableNonPublicModelsDesc")}</p>
+          </div>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={disableNonPublicModels}
+            onClick={() => setDisableNonPublicModels((prev) => !prev)}
+            className={`inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-xs font-semibold transition-colors ${
+              disableNonPublicModels
+                ? "bg-amber-500/15 text-amber-700 dark:text-amber-300 border border-amber-500/30"
+                : "bg-black/5 dark:bg-white/5 text-text-muted border border-border"
+            }`}
+          >
+            <span className="material-symbols-outlined text-[14px]">
+              {disableNonPublicModels ? "shield_lock" : "shield"}
+            </span>
+            {disableNonPublicModels ? tc("yes") : tc("no")}
+          </button>
         </div>
 
         {/* Selected Models Summary (only in restrict mode) */}

--- a/src/app/api/keys/[id]/route.ts
+++ b/src/app/api/keys/[id]/route.ts
@@ -78,6 +78,7 @@ export async function PATCH(request, { params }) {
       accessSchedule,
       rateLimits,
       scopes,
+      disableNonPublicModels,
     } = validation.data;
 
     const payload: Parameters<typeof updateApiKeyPermissions>[1] = {};
@@ -95,6 +96,7 @@ export async function PATCH(request, { params }) {
     if (accessSchedule !== undefined) payload.accessSchedule = accessSchedule;
     if (rateLimits !== undefined) payload.rateLimits = rateLimits;
     if (scopes !== undefined) payload.scopes = scopes;
+    if (disableNonPublicModels !== undefined) payload.disableNonPublicModels = disableNonPublicModels;
 
     const updated = await updateApiKeyPermissions(id, payload);
     if (!updated) {
@@ -120,6 +122,7 @@ export async function PATCH(request, { params }) {
       ...(accessSchedule !== undefined && { accessSchedule }),
       ...(rateLimits !== undefined && { rateLimits }),
       ...(scopes !== undefined && { scopes }),
+      ...(disableNonPublicModels !== undefined && { disableNonPublicModels }),
     });
   } catch (error) {
     log.error("keys", "Error updating key permissions", error);

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1566,7 +1566,9 @@
     "filterTypeRestricted": "Restricted",
     "shownOf": "{shown} of {total} shown",
     "emptyFilterTitle": "No keys match your filters",
-    "emptyFilterClear": "Clear filters"
+    "emptyFilterClear": "Clear filters",
+    "disableNonPublicModels": "Disable Non-Public Models",
+    "disableNonPublicModelsDesc": "Reject requests for models that are not discovered or not marked as public in the provider catalog"
   },
   "auditLog": {
     "title": "Audit Log",

--- a/src/lib/db/apiKeys.ts
+++ b/src/lib/db/apiKeys.ts
@@ -60,6 +60,7 @@ interface ApiKeyMetadata {
   isBanned: boolean;
   keyHash: string | null;
   allowedEndpoints: string[];
+  disableNonPublicModels: boolean;
 }
 
 interface ApiKeyRow extends JsonRecord {
@@ -121,6 +122,7 @@ interface ApiKeyView extends JsonRecord {
   isBanned?: boolean;
   expiresAt?: string | null;
   allowedEndpoints: string[];
+  disableNonPublicModels: boolean;
 }
 
 // LRU cache for API key validation (valid keys only)
@@ -156,6 +158,7 @@ const API_KEY_COLUMN_FALLBACKS = [
   { name: "is_banned", definition: "is_banned INTEGER NOT NULL DEFAULT 0" },
   { name: "key_hash", definition: "key_hash TEXT" },
   { name: "allowed_endpoints", definition: "allowed_endpoints TEXT" },
+  { name: "disable_non_public_models", definition: "disable_non_public_models INTEGER NOT NULL DEFAULT 0" },
 ] as const;
 
 // Cache for model permission checks
@@ -355,7 +358,7 @@ function getPreparedStatements(db: ApiKeysDbLike): ApiKeysStatements {
       "SELECT id, expires_at, revoked_at, is_active, is_banned FROM api_keys WHERE key = ? OR key_hash = ?"
     );
     _stmtGetKeyMetadata = db.prepare<ApiKeyRow>(
-      "SELECT id, name, machine_id, allowed_models, allowed_combos, allowed_connections, no_log, auto_resolve, is_active, access_schedule, max_requests_per_day, max_requests_per_minute, throttle_delay_ms, max_sessions, revoked_at, expires_at, ip_allowlist, scopes, rate_limits, is_banned, key_hash, allowed_endpoints FROM api_keys WHERE key = ? OR key_hash = ?"
+      "SELECT id, name, machine_id, allowed_models, allowed_combos, allowed_connections, no_log, auto_resolve, is_active, access_schedule, max_requests_per_day, max_requests_per_minute, throttle_delay_ms, max_sessions, revoked_at, expires_at, ip_allowlist, scopes, rate_limits, is_banned, key_hash, allowed_endpoints, disable_non_public_models FROM api_keys WHERE key = ? OR key_hash = ?"
     );
     _stmtInsertKey = db.prepare(
       "INSERT INTO api_keys (id, name, key, machine_id, allowed_models, no_log, created_at, key_prefix, key_hash, scopes) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
@@ -401,6 +404,7 @@ export async function getApiKeys() {
     camelRow.isBanned = parseIsBanned(camelRow.isBanned);
     camelRow.scopes = parseStringList((camelRow as JsonRecord).scopes);
     camelRow.allowedEndpoints = parseStringList((camelRow as JsonRecord).allowedEndpoints);
+    camelRow.disableNonPublicModels = parseDisableNonPublicModels((camelRow as JsonRecord).disableNonPublicModels);
     if (typeof camelRow.id === "string" && camelRow.id.length > 0) {
       setNoLog(camelRow.id, camelRow.noLog === true);
     }
@@ -425,6 +429,7 @@ export async function getApiKeyById(id: string) {
   camelRow.isBanned = parseIsBanned(camelRow.isBanned);
   camelRow.scopes = parseStringList((camelRow as JsonRecord).scopes);
   camelRow.allowedEndpoints = parseStringList((camelRow as JsonRecord).allowedEndpoints);
+  camelRow.disableNonPublicModels = parseDisableNonPublicModels((camelRow as JsonRecord).disableNonPublicModels);
   if (typeof camelRow.id === "string" && camelRow.id.length > 0) {
     setNoLog(camelRow.id, camelRow.noLog === true);
   }
@@ -457,6 +462,10 @@ function parseNoLog(value: unknown): boolean {
 }
 
 function parseAutoResolve(value: unknown): boolean {
+  return value === true || value === 1 || value === "1";
+}
+
+function parseDisableNonPublicModels(value: unknown): boolean {
   return value === true || value === 1 || value === "1";
 }
 
@@ -661,6 +670,7 @@ export async function updateApiKeyPermissions(
         maxSessions?: number | null;
         scopes?: string[] | null;
         allowedEndpoints?: string[] | null;
+        disableNonPublicModels?: boolean;
       }
 ) {
   const db = getDbInstance() as ApiKeysDbLike;
@@ -687,6 +697,7 @@ export async function updateApiKeyPermissions(
           maxSessions: (update as { maxSessions?: number | null }).maxSessions,
           scopes: (update as { scopes?: string[] | null }).scopes,
           allowedEndpoints: (update as { allowedEndpoints?: string[] | null }).allowedEndpoints,
+          disableNonPublicModels: (update as { disableNonPublicModels?: boolean }).disableNonPublicModels,
         };
 
   if (
@@ -706,7 +717,8 @@ export async function updateApiKeyPermissions(
     normalized.expiresAt === undefined &&
     (normalized as Record<string, unknown>).maxSessions === undefined &&
     (normalized as Record<string, unknown>).scopes === undefined &&
-    (normalized as Record<string, unknown>).allowedEndpoints === undefined
+    (normalized as Record<string, unknown>).allowedEndpoints === undefined &&
+    normalized.disableNonPublicModels === undefined
   ) {
     return false;
   }
@@ -730,6 +742,7 @@ export async function updateApiKeyPermissions(
     maxSessions?: number;
     expiresAt?: string | null;
     scopes?: string;
+    disableNonPublicModels?: number;
   } = { id };
 
   if (normalized.name !== undefined) {
@@ -805,6 +818,11 @@ export async function updateApiKeyPermissions(
   if (normalized.expiresAt !== undefined) {
     updates.push("expires_at = @expiresAt");
     params.expiresAt = normalized.expiresAt;
+  }
+
+  if (normalized.disableNonPublicModels !== undefined) {
+    updates.push("disable_non_public_models = @disableNonPublicModels");
+    params.disableNonPublicModels = normalized.disableNonPublicModels ? 1 : 0;
   }
 
   const maxSessionsUpdate = (normalized as Record<string, unknown>).maxSessions;
@@ -1171,6 +1189,7 @@ export async function getApiKeyMetadata(
       keyHash: null,
       scopes: ["manage"],
       allowedEndpoints: [],
+      disableNonPublicModels: false,
     };
   }
 
@@ -1228,6 +1247,7 @@ export async function getApiKeyMetadata(
     allowedEndpoints: parseStringList(
       (record as JsonRecord).allowed_endpoints ?? (record as JsonRecord).allowedEndpoints
     ),
+    disableNonPublicModels: parseDisableNonPublicModels(record.disable_non_public_models ?? record.disableNonPublicModels),
   };
 
   if (!metadata.id) {
@@ -1272,7 +1292,29 @@ export async function isModelAllowedForKey(
   // SECURITY: Key not found in database = deny access (invalid/non-existent key)
   if (!metadata) return false;
 
-  const { allowedModels } = metadata;
+  const { allowedModels, disableNonPublicModels } = metadata;
+
+  // Check disableNonPublicModels flag
+  if (disableNonPublicModels) {
+    const { resolveModelAlias } = await import("@omniroute/open-sse/services/modelDeprecation.ts");
+    const { getSyncedAvailableModelsByConnection, getCustomModels, getModelIsHidden } = await import("@/lib/db/models");
+    
+    const resolvedModelId = resolveModelAlias(modelId);
+    const effectiveModelId = resolvedModelId || modelId;
+    
+    const providerId = effectiveModelId.split("/")[0];
+    const shortModelId = effectiveModelId.split("/").slice(1).join("/");
+    const syncedModelsByConnection = await getSyncedAvailableModelsByConnection(providerId);
+    const customModels = await getCustomModels(providerId);
+    
+    // Combine synced and custom models
+    const allDiscoveredModels = Object.values(syncedModelsByConnection).flat().concat(customModels);
+    const discovered = allDiscoveredModels.some((m) => m.id === shortModelId);
+    if (!discovered) return false;
+    
+    const isPublic = !getModelIsHidden(providerId, shortModelId);
+    if (!isPublic) return false;
+  }
 
   // Empty array means all models allowed
   if (!allowedModels || allowedModels.length === 0) {

--- a/src/lib/db/migrations/077_add_disable_non_public_to_api_keys.sql
+++ b/src/lib/db/migrations/077_add_disable_non_public_to_api_keys.sql
@@ -1,0 +1,3 @@
+-- Migration: Add disable_non_public_models to api_keys
+-- Description: Adds a flag to restrict API keys to discovered and public models.
+ALTER TABLE api_keys ADD COLUMN disable_non_public_models INTEGER NOT NULL DEFAULT 0;

--- a/src/shared/utils/apiKeyPolicy.ts
+++ b/src/shared/utils/apiKeyPolicy.ts
@@ -77,6 +77,7 @@ export interface ApiKeyMetadata {
   maxSessions?: number | null;
   rateLimits?: RateLimitRule[] | null;
   allowedEndpoints?: string[];
+  disableNonPublicModels?: boolean;
 }
 
 /**
@@ -346,7 +347,7 @@ export async function enforceApiKeyPolicy(
     }
   }
 
-  const hasModelRestrictions = apiKeyInfo.allowedModels && apiKeyInfo.allowedModels.length > 0;
+  const hasModelRestrictions = (apiKeyInfo.allowedModels && apiKeyInfo.allowedModels.length > 0) || apiKeyInfo.disableNonPublicModels;
 
   if (!requestedComboName && modelStr && hasModelRestrictions) {
     try {

--- a/src/shared/validation/schemas.ts
+++ b/src/shared/validation/schemas.ts
@@ -1866,6 +1866,7 @@ export const updateKeyPermissionsSchema = z
       .optional(),
     scopes: z.array(z.string().trim().min(1).max(64)).max(32).optional(),
     allowedEndpoints: z.array(z.string().trim().min(1).max(64)).max(20).optional(),
+    disableNonPublicModels: z.boolean().optional(),
   })
   .superRefine((value, ctx) => {
     if (


### PR DESCRIPTION
## Summary

- Add a switch in the API key settings
- This enables a aditionnal policy that only allows models: that are known to Omniroute (discover or custom) and not hidden.

## Related Issues

- Related to #2955 

## Validation

- [x] `npm run lint`
- [x] `npm run test:unit`
- [x] `npm run test:coverage`
- [x] Coverage is still `>= 60%` for statements, lines, functions, and branches
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below

## Tests Added Or Updated

- No check added or updated

## Coverage Notes

- If this PR changes `src/`, `open-sse/`, `electron/`, or `bin/`, explain which tests cover the change.
- If coverage moved down in any touched file, explain why and what follow-up task will recover it.

Coverage before:
```
=============================== Coverage summary ===============================
Statements   : 78.65% ( 208601/265208 )
Branches     : 74.31% ( 33269/44765 )
Functions    : 80.3% ( 7040/8767 )
Lines        : 78.65% ( 208601/265208 )
================================================================================
```

Coverage after:
```
=============================== Coverage summary ===============================
Statements   : 78.65% ( 208632/265255 )
Branches     : 74.3% ( 33279/44786 )
Functions    : 80.31% ( 7042/8768 )
Lines        : 78.65% ( 208632/265255 )
================================================================================
```

## Reviewer Notes

- Maybe it's better to invert everything, to call this option 'Allow unpublished models'
- With current master, 'auto/*' goes through the check and are refused as not in models list.
- I'm not sure about combo management with this change.