### PR TITLE
fix(api): guard rotating providers in manual token-refresh route (Codex family-revocation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,15 @@
 
 ### Fixed
 
+- **codex/providers:** `POST /api/providers/[id]/refresh` (the manual/auto "refresh
+  token" endpoint) no longer rotates rotating-refresh providers (Codex/OpenAI share
+  one Auth0 `client_id`). This was the last unguarded proactive-refresh entry point:
+  when the dashboard auto-refreshed every expiring connection on a page load (or an
+  old cached frontend bulk-called it), each Codex account's single-use refresh_token
+  was rotated, and Auth0 revoked the whole token family (`openai/codex#9648`) — every
+  account but the last died with `[403] <!DOCTYPE`. The endpoint now skips proactive
+  rotation for rotating providers and defers to the reactive, serialized 401 path
+  (same guard as `refreshAndUpdateCredentials` and the connection-test route).
 - **codex/quota:** opening the Quota / Providers dashboard no longer disconnects
   Codex multi-account setups. The quota-sync path
   (`refreshAndUpdateCredentials`) proactively refreshed every connection — for

--- a/src/app/api/providers/[id]/refresh/route.ts
+++ b/src/app/api/providers/[id]/refresh/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { getProviderConnectionById, updateProviderConnection } from "@/lib/db/providers";
 import { getAccessToken, updateProviderCredentials } from "@/sse/services/tokenRefresh";
+import { rotationGroupFor } from "@omniroute/open-sse/services/refreshSerializer.ts";
 
 type RefreshResult = {
   accessToken?: string;
@@ -44,6 +45,33 @@ export async function POST(_request: Request, { params }: { params: Promise<{ id
     }
 
     const provider = connection.provider;
+
+    // Codex multi-account family-revocation cascade guard.
+    // Rotating-refresh providers (Codex/OpenAI share one Auth0 client_id, etc.)
+    // mint a single-use refresh_token on every refresh. This endpoint is invoked
+    // per-connection by the dashboard (incl. an OLD cached frontend that bulk-
+    // refreshes every expiring connection on a page load); rotating several
+    // sibling accounts makes Auth0 revoke the whole token family
+    // (openai/codex#9648), killing every account but the last. Never proactively
+    // rotate a rotating provider here — the access_token is reused as-is and
+    // genuine expiry is handled by the reactive, serialized 401 path on the next
+    // real request. This was the last unguarded proactive-refresh entry point
+    // (refreshAndUpdateCredentials and the connection-test route are already
+    // guarded). Non-rotating providers keep refreshing on demand below.
+    if (rotationGroupFor(provider) !== null) {
+      return NextResponse.json({
+        success: true,
+        skipped: true,
+        connectionId: id,
+        provider,
+        message:
+          "Rotating-refresh provider: the token refreshes automatically on the next request. " +
+          "Manual/bulk refresh is intentionally skipped to avoid Auth0 token-family revocation.",
+        expiresAt: connection.tokenExpiresAt || connection.expiresAt || null,
+        refreshedAt: new Date().toISOString(),
+      });
+    }
+
     const credentials = {
       connectionId: id,
       accessToken: connection.accessToken,

--- a/tests/unit/codex-manual-refresh-rotating-guard.test.ts
+++ b/tests/unit/codex-manual-refresh-rotating-guard.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Codex multi-account family-revocation cascade — manual/auto token refresh guard.
+ *
+ * `POST /api/providers/[id]/refresh` is the explicit "refresh this token" endpoint.
+ * It rotates the refresh_token via getAccessToken. For rotating-refresh providers
+ * (Codex/OpenAI share one Auth0 client_id) rotating several sibling accounts —
+ * which happens when the dashboard auto-refreshes every expiring connection on a
+ * page load, or when an OLD cached frontend bulk-calls this endpoint — makes Auth0
+ * revoke the whole token family (openai/codex#9648) and kills every account but
+ * the last. This was the LAST unguarded proactive-refresh entry point for rotating
+ * providers (refreshAndUpdateCredentials and the connection-test route are already
+ * guarded). It must skip the proactive refresh and defer to the reactive,
+ * serialized 401 path. Non-rotating providers keep refreshing on demand.
+ *
+ * Mirrors the source-assertion style of token-refresh-race-comprehensive.test.ts.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+const root = path.resolve(import.meta.dirname, "../..");
+const ROUTE = path.join(root, "src/app/api/providers/[id]/refresh/route.ts");
+const read = () => readFile(ROUTE, "utf8");
+
+test("manual refresh route imports rotationGroupFor", async () => {
+  const src = await read();
+  assert.match(
+    src,
+    /import\s*\{[^}]*rotationGroupFor[^}]*\}\s*from\s*["'][^"']*refreshSerializer/,
+    "refresh route must import rotationGroupFor to detect rotating providers"
+  );
+});
+
+test("manual refresh route skips proactive refresh for rotating providers BEFORE calling getAccessToken", async () => {
+  const src = await read();
+
+  const guardIdx = src.search(/rotationGroupFor\s*\(\s*[\w.]*provider[\w.]*\s*\)\s*!==\s*null/);
+  assert.ok(
+    guardIdx >= 0,
+    "refresh route must guard with `rotationGroupFor(provider) !== null` to skip rotating providers"
+  );
+
+  const getAccessTokenIdx = src.indexOf("getAccessToken(");
+  assert.ok(getAccessTokenIdx >= 0, "refresh route still calls getAccessToken for non-rotating providers");
+
+  assert.ok(
+    guardIdx < getAccessTokenIdx,
+    "the rotating-provider guard must run BEFORE getAccessToken so the rotating refresh_token is never exercised"
+  );
+
+  // The guard short-circuits with an early return (no token rotation).
+  const guardBlock = src.slice(guardIdx, getAccessTokenIdx);
+  assert.match(
+    guardBlock,
+    /return\b/,
+    "the rotating-provider guard must return early (defer to the reactive 401 path) instead of refreshing"
+  );
+});


### PR DESCRIPTION
## Problem

Even after the quota-sync (`refreshAndUpdateCredentials`) and connection-test guards (#2941), opening the Quota / Providers dashboard **still cascaded Codex multi-account setups** — all accounts of the same domain died with `[403] <!DOCTYPE`.

### Root cause (traced live on the VM via call_logs + proxy_logs + authenticated reproduction)

The deployed quota-page paths are clean:
- `GET /api/usage/[id]` (quota data) → skips rotating providers ✅ (verified, HTTP 200 no refresh)
- `POST /api/providers/[id]/test` (status) → skips rotating providers ✅ (#2941 guard, verified)

But **`POST /api/providers/[id]/refresh`** (the manual/auto "refresh token" endpoint) had **no rotating-provider guard** — verified empirically: calling it on a Codex connection triggered `refresh_token_reused`. The dashboard auto-refreshes every *expiring* connection on a page load (and an **old cached frontend** still bulk-calls it), so each Codex account's single-use refresh_token got rotated. Under the shared Auth0 `client_id`, Auth0 revoked the whole token family (`openai/codex#9648`) → every account but the last died.

This was the **last unguarded proactive-refresh entry point** for rotating providers.

## Fix

`POST /api/providers/[id]/refresh` now skips proactive rotation when `rotationGroupFor(provider) !== null`, returning `{ success: true, skipped: true, message }` and deferring genuine expiry to the reactive, serialized 401 path on the next real request. Non-rotating providers keep refreshing on demand. Same guard pattern as `refreshAndUpdateCredentials` and the connection-test route.

## Test (TDD, red→green)

`tests/unit/codex-manual-refresh-rotating-guard.test.ts` — source-assertion style (matches `token-refresh-race-comprehensive.test.ts` #2941): asserts the route imports `rotationGroupFor` and guards **before** `getAccessToken`, returning early.

Regression: `token-refresh-race-comprehensive`, `refresh-serializer`, `codex-quota-sync-no-proactive-refresh`, `providers-test-route-cli-map` all pass. lint + typecheck clean.

## Operator note

Existing dashboard tabs should be hard-refreshed (Ctrl+Shift+R) to drop the old cached frontend; this backend guard makes the cascade impossible regardless.