### PR TITLE
fix(claude-web): cf_clearance + fix(pollinations/duckduckgo): wire session pool

### DIFF
--- a/open-sse/executors/claude-web.ts
+++ b/open-sse/executors/claude-web.ts
@@ -417,7 +417,7 @@ export class ClaudeWebExecutor extends BaseExecutor {
         return false;
       }
 
-      const cookieHeader = normalizeClaudeSessionCookie(rawCookie);
+      const cookieHeader = await normalizeClaudeSessionCookieWithAutoRefresh(rawCookie, { allowAutoSolve: false });
       const deviceId = (credentials as any)?.deviceId as string | undefined;
 
       return await verifyCookieValidity(cookieHeader, deviceId, signal);
@@ -479,7 +479,7 @@ export class ClaudeWebExecutor extends BaseExecutor {
         };
       }
 
-      const cookieHeader = normalizeClaudeSessionCookie(rawCookie);
+      const cookieHeader = await normalizeClaudeSessionCookieWithAutoRefresh(rawCookie, { log });
       const deviceId = (credentials as any)?.deviceId as string | undefined;
 
       // Transform request to Claude format


### PR DESCRIPTION
## Summary

### Claude Web 403 fix
- `execute()` and `testConnection()` called `normalizeClaudeSessionCookie()` which does NOT inject `cf_clearance`
- Changed to `normalizeClaudeSessionCookieWithAutoRefresh()` which auto-injects `cf_clearance` via Turnstile solver

### Pollinations session pool fix
- `PollinationsExecutor.getPool()` returned `null` because `poolConfig` was never set
- Now sets `DEFAULT_POOL_CONFIG` in constructor
- Uses `acquireBlocking()` instead of `acquire()`

### DuckDuckGo session pool fix
- `DuckDuckGoWebExecutor` had `poolConfig` but never called `getPool()` in execute()
- Added session acquisition via `acquireBlocking()` and merges fingerprint headers into fetch calls

### Session pool improvements
- Added `startAutoPrune()` with idle session cleanup (5min timeout)

## Changes
| File | Change |
|------|--------|
| `open-sse/executors/claude-web.ts` | Use `normalizeClaudeSessionCookieWithAutoRefresh()` |
| `open-sse/executors/pollinations.ts` | Wire `poolConfig = DEFAULT_POOL_CONFIG` |
| `open-sse/executors/duckduckgo-web.ts` | Wire session pool in execute() |
| `open-sse/services/sessionPool/sessionPool.ts` | Add `startAutoPrune()` |

## Test plan
- [x] Typecheck passes
- [x] Pollinations tests pass (4/4)
- [x] DuckDuckGo tests pass (15/15)