### PR TITLE
fix(proxy): resolve registry assignments for combo and key levels

### DIFF
--- a/src/app/api/settings/proxy/route.ts
+++ b/src/app/api/settings/proxy/route.ts
@@ -23,6 +23,12 @@ type UpdateProxyConfigInput = z.infer<typeof updateProxyConfigSchema>;
 type ProxyConfigInput = NonNullable<UpdateProxyConfigInput["proxy"]>;
 type ProxyMapInput = Record<string, ProxyConfigInput | null>;
 type ApiRouteError = Error & { status?: number; type?: string };
+const PROXY_LEVEL_TO_REGISTRY_SCOPE = {
+  global: "global",
+  provider: "provider",
+  combo: "combo",
+  key: "account",
+} as const;
 
 function isSocks5Enabled() {
   return process.env.ENABLE_SOCKS5_PROXY === "true";
@@ -51,6 +57,35 @@ function toApiRouteError(error: unknown): ApiRouteError {
     return error as ApiRouteError;
   }
   return new Error("Unexpected error") as ApiRouteError;
+}
+
+function getRegistryScopeForLevel(level: string) {
+  return PROXY_LEVEL_TO_REGISTRY_SCOPE[
+    level as keyof typeof PROXY_LEVEL_TO_REGISTRY_SCOPE
+  ];
+}
+
+async function getRegistryProxyForLevel(level: string, id: string | null) {
+  const scope = getRegistryScopeForLevel(level);
+  if (!scope) return null;
+  if (scope !== "global" && !id) return null;
+
+  const assignments = await getProxyAssignments({ scope });
+  const assignment =
+    scope === "global" ? assignments[0] : assignments.find((entry) => entry.scopeId === id);
+  if (!assignment?.proxyId) return null;
+
+  return getProxyById(assignment.proxyId, { includeSecrets: true });
+}
+
+function toProxyConfig(proxyData: NonNullable<Awaited<ReturnType<typeof getProxyById>>>) {
+  return {
+    type: proxyData.type,
+    host: proxyData.host,
+    port: proxyData.port,
+    username: proxyData.username,
+    password: proxyData.password,
+  };
 }
 
 function normalizeAndValidateProxy(
@@ -136,55 +171,16 @@ export async function GET(request: Request) {
       return Response.json(result);
     }
 
-    // Get proxy for a specific level - check Proxy Registry first
-    if (level === "global") {
-      const assignments = await getProxyAssignments({ scope: "global" });
-      if (assignments.length > 0 && assignments[0].proxyId) {
-        const proxyData = await getProxyById(assignments[0].proxyId, { includeSecrets: true });
-        if (proxyData) {
-          return Response.json({
-            level: "global",
-            id: null,
-            proxy: {
-              type: proxyData.type,
-              host: proxyData.host,
-              port: proxyData.port,
-              username: proxyData.username,
-              password: proxyData.password,
-            },
-          });
-        }
-      }
-      // Fallback to old system
-      const proxy = await getProxyForLevel(level, id);
-      return Response.json({ level, id, proxy });
-    }
-
-    if (level === "provider" && id) {
-      const assignments = await getProxyAssignments({ scope: "provider" });
-      const assignment = assignments.find((entry) => entry.scopeId === id);
-      if (assignment?.proxyId) {
-        const proxyData = await getProxyById(assignment.proxyId, { includeSecrets: true });
-        if (proxyData) {
-          return Response.json({
-            level,
-            id,
-            proxy: {
-              type: proxyData.type,
-              host: proxyData.host,
-              port: proxyData.port,
-              username: proxyData.username,
-              password: proxyData.password,
-            },
-          });
-        }
-      }
-
-      const proxy = await getProxyForLevel(level, id);
-      return Response.json({ level, id, proxy });
-    }
-
     if (level) {
+      const proxyData = await getRegistryProxyForLevel(level, id);
+      if (proxyData) {
+        return Response.json({
+          level,
+          id: level === "global" ? null : id,
+          proxy: toProxyConfig(proxyData),
+        });
+      }
+
       const proxy = await getProxyForLevel(level, id);
       return Response.json({ level, id, proxy });
     }
@@ -207,13 +203,7 @@ export async function GET(request: Request) {
 
       for (const result of providerProxyResults) {
         if (!result) continue;
-        config.providers[result.scopeId] = {
-          type: result.proxyData.type,
-          host: result.proxyData.host,
-          port: result.proxyData.port,
-          username: result.proxyData.username,
-          password: result.proxyData.password,
-        };
+        config.providers[result.scopeId] = toProxyConfig(result.proxyData);
       }
     }
     return Response.json(config);

--- a/src/app/api/settings/proxy/route.ts
+++ b/src/app/api/settings/proxy/route.ts
@@ -59,7 +59,13 @@ function toApiRouteError(error: unknown): ApiRouteError {
   return new Error("Unexpected error") as ApiRouteError;
 }
 
-function getRegistryScopeForLevel(level: string) {
+function getRegistryScopeForLevel(
+  level: string
+): "global" | "provider" | "combo" | "account" | undefined {
+  if (!Object.prototype.hasOwnProperty.call(PROXY_LEVEL_TO_REGISTRY_SCOPE, level)) {
+    return undefined;
+  }
+
   return PROXY_LEVEL_TO_REGISTRY_SCOPE[
     level as keyof typeof PROXY_LEVEL_TO_REGISTRY_SCOPE
   ];

--- a/tests/unit/route-edge-coverage.test.ts
+++ b/tests/unit/route-edge-coverage.test.ts
@@ -363,6 +363,81 @@ test("settings proxy route covers full config, resolve, validation, delete and g
   assert.equal(missingLevelBody.error.message, "level is required");
 });
 
+test("settings proxy route resolves combo and key registry assignments with legacy fallback", async () => {
+  const legacyPut = await settingsProxyRoute.PUT(
+    makeRequest("http://localhost/api/settings/proxy", {
+      method: "PUT",
+      body: {
+        combos: {
+          comboA: { type: "http", host: "legacy-combo.local", port: "9001" },
+        },
+        keys: {
+          accountA: { type: "https", host: "legacy-key.local", port: "9444" },
+        },
+      },
+    })
+  );
+
+  const legacyComboGet = await settingsProxyRoute.GET(
+    new Request("http://localhost/api/settings/proxy?level=combo&id=comboA")
+  );
+  const legacyKeyGet = await settingsProxyRoute.GET(
+    new Request("http://localhost/api/settings/proxy?level=key&id=accountA")
+  );
+
+  const comboProxy = await localDb.createProxy({
+    name: "Registry Combo Proxy",
+    type: "http",
+    host: "registry-combo.local",
+    port: 8181,
+    username: "combo-user",
+    password: "combo-secret",
+  });
+  const accountProxy = await localDb.createProxy({
+    name: "Registry Account Proxy",
+    type: "https",
+    host: "registry-account.local",
+    port: 9443,
+    username: "account-user",
+    password: "account-secret",
+  });
+  await localDb.assignProxyToScope("combo", "comboA", comboProxy.id);
+  await localDb.assignProxyToScope("account", "accountA", accountProxy.id);
+
+  const registryComboGet = await settingsProxyRoute.GET(
+    new Request("http://localhost/api/settings/proxy?level=combo&id=comboA")
+  );
+  const registryKeyGet = await settingsProxyRoute.GET(
+    new Request("http://localhost/api/settings/proxy?level=key&id=accountA")
+  );
+
+  const legacyPutBody = (await legacyPut.json()) as any;
+  const legacyComboBody = (await legacyComboGet.json()) as any;
+  const legacyKeyBody = (await legacyKeyGet.json()) as any;
+  const registryComboBody = (await registryComboGet.json()) as any;
+  const registryKeyBody = (await registryKeyGet.json()) as any;
+
+  assert.equal(legacyPut.status, 200);
+  assert.equal(legacyPutBody.combos.comboA.host, "legacy-combo.local");
+  assert.equal(legacyPutBody.keys.accountA.host, "legacy-key.local");
+  assert.equal(legacyComboGet.status, 200);
+  assert.equal(legacyComboBody.level, "combo");
+  assert.equal(legacyComboBody.id, "comboA");
+  assert.equal(legacyComboBody.proxy.host, "legacy-combo.local");
+  assert.equal(legacyKeyGet.status, 200);
+  assert.equal(legacyKeyBody.level, "key");
+  assert.equal(legacyKeyBody.id, "accountA");
+  assert.equal(legacyKeyBody.proxy.host, "legacy-key.local");
+  assert.equal(registryComboGet.status, 200);
+  assert.equal(registryComboBody.proxy.host, "registry-combo.local");
+  assert.equal(registryComboBody.proxy.username, "combo-user");
+  assert.equal(registryComboBody.proxy.password, "combo-secret");
+  assert.equal(registryKeyGet.status, 200);
+  assert.equal(registryKeyBody.proxy.host, "registry-account.local");
+  assert.equal(registryKeyBody.proxy.username, "account-user");
+  assert.equal(registryKeyBody.proxy.password, "account-secret");
+});
+
 test("settings proxy route prefers proxy registry assignments and enforces socks5 feature gating", async () => {
   const created = await localDb.createProxy({
     name: "Global Proxy",


### PR DESCRIPTION
## Summary

`GET /api/settings/proxy?level=...&id=...` previously consulted the proxy
registry only for `global` and `provider` levels. Requests for `combo` and
`key` fell straight through to the legacy `getProxyForLevel()` path, so a
proxy assigned through the registry UI was invisible to per-level reads at
those two levels — the response showed the old `proxyConfig.combos` /
`proxyConfig.keys` value (or `null`) instead of the registry assignment.

This PR routes all four levels through a single registry-lookup helper, with
the legacy store kept as a fallback when no registry assignment exists.

## Changes

### `src/app/api/settings/proxy/route.ts`

- New `PROXY_LEVEL_TO_REGISTRY_SCOPE` map translating the route's public
  level names to the canonical `ProxyScope` used by `src/lib/db/proxies.ts`:
  ```
  global   -> global
  provider -> provider
  combo    -> combo
  key      -> account
  ```
  The `key -> account` entry mirrors `normalizeScope()` in `proxies.ts:157`,
  where `account` is the canonical internal scope and `key` is the legacy
  public-API alias.
- New helpers:
  - `getRegistryScopeForLevel(level)` — typed map lookup.
  - `getRegistryProxyForLevel(level, id)` — fetches the assignment for the
    scope, returns the underlying `proxy_registry` row (with secrets), or
    `null` when there is no assignment or the level is unknown.
  - `toProxyConfig(proxyData)` — extracts `{ type, host, port, username,
    password }` from a registry row. Previously inlined twice.
- `GET` handler collapses the four per-level branches into one:
  ```ts
  if (level) {
    const proxyData = await getRegistryProxyForLevel(level, id);
    if (proxyData) {
      return Response.json({
        level,
        id: level === "global" ? null : id,
        proxy: toProxyConfig(proxyData),
      });
    }
    const proxy = await getProxyForLevel(level, id);
    return Response.json({ level, id, proxy });
  }
  ```
- Full-config GET path also uses `toProxyConfig()` for the provider loop,
  removing the last inline duplicate.

### `tests/unit/route-edge-coverage.test.ts`

- New test
  `settings proxy route resolves combo and key registry assignments with
  legacy fallback`:
  1. PUTs legacy `combos.comboA` and `keys.accountA` proxies — asserts both
     GETs return the legacy values (legacy fallback path).
  2. Creates two proxies via `localDb.createProxy`, assigns one to
     `(combo, comboA)` and one to `(account, accountA)` via
     `assignProxyToScope`.
  3. Re-issues both per-level GETs — asserts they now return the registry
     proxy hostnames, usernames, and decrypted passwords (registry path).

## Behavior contract preserved

- `global`: registry uses `assignments[0]` (there is only ever one row,
  keyed by `__global__`); response forces `id: null`.
- Non-global levels: `assignment.scopeId === id` match. `mapAssignmentRow`
  only strips `__global__` for the global scope, so combo and account
  `scopeId`s round-trip unchanged.
- Registry-first, legacy-fallback ordering is unchanged.
- No change to PUT or DELETE handlers.

## Naming note

The route accepts only `key` (not `account`) as the level name on the
public surface. This matches the docstring, the legacy `proxyConfig.keys`
map, and the PUT body's `keys` field. If a caller passes
`?level=account`, the level is unknown to the route, the registry helper
returns `null`, and the request falls through to legacy
`getProxyForLevel("account", ...)`. This is intentional — keeping the
public-vs-internal naming boundary intact.

## Test plan

- [x] `node --import tsx/esm --test tests/unit/route-edge-coverage.test.ts`
      — new test passes; existing `prefers proxy registry assignments…`
      test still passes (no regression on global/provider paths).
- [x] `npm run typecheck:core` — clean.
- [x] `npm run lint` — 0 errors.