### PR TITLE
fix(proxy): fail closed for OAuth usage account proxies

### DIFF
--- a/src/lib/usage/providerLimits.ts
+++ b/src/lib/usage/providerLimits.ts
@@ -200,6 +200,19 @@ function isNetworkFailureMessage(message: unknown): boolean {
   );
 }
 
+function isAccountScopedProxyResolution(proxyInfo: unknown): boolean {
+  if (!isRecord(proxyInfo)) return false;
+  if (!proxyInfo.proxy) return false;
+  return proxyInfo.level === "key" || proxyInfo.level === "account";
+}
+
+function shouldFailClosedForProviderLimitsProxy(
+  connection: ProviderConnectionLike,
+  proxyInfo: unknown
+): boolean {
+  return connection.authType === "oauth" && isAccountScopedProxyResolution(proxyInfo);
+}
+
 async function syncExpiredStatusIfNeeded(connection: ProviderConnectionLike, usage: JsonRecord) {
   const errorMessage = typeof usage.message === "string" ? usage.message.toLowerCase() : "";
   const isAuthError =
@@ -398,6 +411,7 @@ async function fetchLiveProviderLimitsWithOptions(
 
   let result: { usage: JsonRecord };
   const proxyConfig = proxyInfo?.proxy || null;
+  const failClosedOnProxyFailure = shouldFailClosedForProviderLimitsProxy(connection, proxyInfo);
 
   try {
     result = await fetchUsageWithContext(proxyConfig);
@@ -409,6 +423,14 @@ async function fetchLiveProviderLimitsWithOptions(
       error?.cause?.code === "ECONNREFUSED";
 
     if (proxyConfig && isThrownNetworkError) {
+      if (failClosedOnProxyFailure) {
+        console.warn(
+          `[ProviderLimits] Account-scoped ${connection.provider} proxy fetch failed for ${connectionId}; failing closed without direct retry:`,
+          error?.message
+        );
+        throw error;
+      }
+
       console.warn(
         `[ProviderLimits] Proxy fetch threw for ${connectionId}, retrying without proxy:`,
         error?.message
@@ -420,6 +442,18 @@ async function fetchLiveProviderLimitsWithOptions(
   }
 
   if (proxyConfig && isNetworkFailureMessage(result.usage?.message)) {
+    if (failClosedOnProxyFailure) {
+      const message =
+        typeof result.usage.message === "string"
+          ? result.usage.message
+          : "Provider-limits proxy request failed";
+      console.warn(
+        `[ProviderLimits] Account-scoped ${connection.provider} proxy usage failed for ${connectionId}; failing closed without direct retry:`,
+        message
+      );
+      throw withStatus(new Error(message), 503);
+    }
+
     console.warn(
       `[ProviderLimits] Proxy usage returned network error for ${connectionId}, retrying without proxy:`,
       result.usage.message

--- a/tests/unit/provider-limits-proxy-fail-closed.test.ts
+++ b/tests/unit/provider-limits-proxy-fail-closed.test.ts
@@ -1,0 +1,195 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-provider-limits-proxy-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.API_KEY_SECRET = "test-provider-limits-proxy-secret";
+
+const core = await import("../../src/lib/db/core.ts");
+const providersDb = await import("../../src/lib/db/providers.ts");
+const settingsDb = await import("../../src/lib/db/settings.ts");
+const providerLimits = await import("../../src/lib/usage/providerLimits.ts");
+
+const originalFetch = globalThis.fetch;
+
+async function resetStorage() {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+async function withMockedFetch(fetchImpl: typeof fetch, fn: () => Promise<void>) {
+  const previousFetch = globalThis.fetch;
+  globalThis.fetch = fetchImpl;
+  try {
+    await fn();
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+}
+
+async function createClaudeOAuthConnection() {
+  return providersDb.createProviderConnection({
+    provider: "claude",
+    authType: "oauth",
+    name: `Claude Provider Limits ${Date.now()} ${Math.random()}`,
+    email: `claude-${Date.now()}-${Math.random()}@example.test`,
+    accessToken: "claude-access-token",
+    refreshToken: "claude-refresh-token",
+    expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+  });
+}
+
+function claudeUsageResponse() {
+  return new Response(
+    JSON.stringify({
+      tier: "pro",
+      five_hour: {
+        utilization: 25,
+        resets_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      },
+      seven_day: {
+        utilization: 50,
+        resets_at: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+      },
+    }),
+    { status: 200, headers: { "content-type": "application/json" } }
+  );
+}
+
+function claudeBootstrapResponse() {
+  return new Response(
+    JSON.stringify({
+      oauth_account: {
+        account_uuid: "account-uuid-test",
+        account_email: "claude@example.test",
+        organization_uuid: "org-uuid-test",
+        organization_name: "Test Org",
+        organization_type: "pro",
+        organization_rate_limit_tier: "pro",
+      },
+    }),
+    { status: 200, headers: { "content-type": "application/json" } }
+  );
+}
+
+test.beforeEach(async () => {
+  globalThis.fetch = originalFetch;
+  await resetStorage();
+});
+
+test.after(async () => {
+  globalThis.fetch = originalFetch;
+  await resetStorage();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("Claude provider limits fail closed when an account proxy is unreachable", async () => {
+  const connection = await createClaudeOAuthConnection();
+  const connectionId = (connection as any).id;
+  const directFetchUrls: string[] = [];
+
+  await settingsDb.setProxyForLevel("key", connectionId, {
+    type: "http",
+    host: "127.0.0.1",
+    port: 1,
+  });
+
+  await withMockedFetch(
+    (async (url) => {
+      directFetchUrls.push(String(url));
+      return claudeUsageResponse();
+    }) as typeof fetch,
+    async () => {
+      await assert.rejects(
+        () => providerLimits.fetchAndPersistProviderLimits(connectionId, "manual"),
+        /Proxy unreachable|fetch failed|ECONNREFUSED|UND_ERR_CONNECT_TIMEOUT/i
+      );
+    }
+  );
+
+  assert.deepEqual(directFetchUrls, [], "account-proxied Claude usage must not retry direct");
+});
+
+test("non-Claude OAuth provider limits fail closed when an account proxy is unreachable", async () => {
+  const connection = await providersDb.createProviderConnection({
+    provider: "github",
+    authType: "oauth",
+    name: `GitHub Provider Limits ${Date.now()} ${Math.random()}`,
+    email: `github-${Date.now()}-${Math.random()}@example.test`,
+    accessToken: "github-access-token",
+    refreshToken: "github-refresh-token",
+    expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+  });
+  const connectionId = (connection as any).id;
+  const directFetchUrls: string[] = [];
+
+  await settingsDb.setProxyForLevel("key", connectionId, {
+    type: "http",
+    host: "127.0.0.1",
+    port: 1,
+  });
+
+  await withMockedFetch(
+    (async (url) => {
+      directFetchUrls.push(String(url));
+      return new Response(
+        JSON.stringify({
+          copilot_plan: "free",
+          monthly_quotas: { chat: 500 },
+          limited_user_quotas: { chat: 500 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      );
+    }) as typeof fetch,
+    async () => {
+      await assert.rejects(
+        () => providerLimits.fetchAndPersistProviderLimits(connectionId, "manual"),
+        /Proxy unreachable|fetch failed|ECONNREFUSED|UND_ERR_CONNECT_TIMEOUT/i
+      );
+    }
+  );
+
+  assert.deepEqual(directFetchUrls, [], "account-proxied OAuth usage must not retry direct");
+});
+
+test("Claude provider limits preserve direct retry for non-account proxy failures", async () => {
+  const connection = await createClaudeOAuthConnection();
+  const connectionId = (connection as any).id;
+  const directFetchUrls: string[] = [];
+
+  await settingsDb.setProxyForLevel("provider", "claude", {
+    type: "http",
+    host: "127.0.0.1",
+    port: 1,
+  });
+
+  await withMockedFetch(
+    (async (url) => {
+      const urlText = String(url);
+      directFetchUrls.push(urlText);
+      if (urlText.includes("/api/claude_cli/bootstrap")) {
+        return claudeBootstrapResponse();
+      }
+      if (urlText.includes("/api/oauth/usage")) {
+        return claudeUsageResponse();
+      }
+      throw new Error(`Unexpected direct fetch: ${urlText}`);
+    }) as typeof fetch,
+    async () => {
+      const result = await providerLimits.fetchAndPersistProviderLimits(connectionId, "manual");
+      assert.equal(result.connection.id, connectionId);
+      assert.ok(result.usage.quotas);
+      assert.equal(result.cache.source, "manual");
+    }
+  );
+
+  assert.equal(
+    directFetchUrls.some((url) => url.includes("/api/oauth/usage")),
+    true,
+    "provider-level proxy failures should retain the existing direct retry behavior"
+  );
+});


### PR DESCRIPTION
## Problem

Provider-limits / usage sync resolves the selected connection proxy before fetching usage for OAuth connections. However, if that proxied usage fetch fails with a network/proxy error, the code currently retries the same usage fetch without any proxy:

```ts
result = await fetchUsageWithContext(null);
```

That direct retry is unsafe for account-isolated setups. If a connection has an explicit account/key proxy configured, provider-limits traffic is account-bound traffic and should not silently fall back to the OmniRoute host IP when the account proxy is unavailable.

This was first identified through Claude/Anthropic hardening, where risky endpoints include:

- `https://api.anthropic.com/api/oauth/usage`
- `https://api.anthropic.com/api/claude_cli/bootstrap`
- legacy usage fallback endpoints under `https://api.anthropic.com/v1/...`

But the isolation rule is broader than Claude:

> An explicit account/key proxy means traffic for that OAuth connection should either use that account proxy or fail closed.

## Solution

Add a narrow fail-closed policy in `src/lib/usage/providerLimits.ts` for OAuth connections whose resolved proxy is account-scoped:

```ts
function isAccountScopedProxyResolution(proxyInfo: unknown): boolean {
  if (!isRecord(proxyInfo)) return false;
  if (!proxyInfo.proxy) return false;
  return proxyInfo.level === "key" || proxyInfo.level === "account";
}

function shouldFailClosedForProviderLimitsProxy(
  connection: ProviderConnectionLike,
  proxyInfo: unknown
): boolean {
  return connection.authType === "oauth" && isAccountScopedProxyResolution(proxyInfo);
}
```

When this policy applies:

- thrown proxy/network failures are re-thrown instead of retried directly
- usage responses that contain proxy/network failure messages are converted into a 503 failure instead of retried directly

This keeps the change scoped to explicit account isolation:

```text
OAuth + key/account proxy + proxy works   -> usage sync works through proxy
OAuth + key/account proxy + proxy fails   -> fail closed; no direct retry
OAuth + provider/global proxy + failure   -> preserve existing direct retry behavior
No account/key proxy                      -> preserve existing behavior
```

## Tests

Added `tests/unit/provider-limits-proxy-fail-closed.test.ts`.

Coverage:

1. `Claude provider limits fail closed when an account proxy is unreachable`
   - creates a Claude OAuth connection
   - assigns an unreachable key/account proxy
   - calls `fetchAndPersistProviderLimits()`
   - verifies the call rejects
   - verifies no direct Anthropic usage fetch is attempted

2. `non-Claude OAuth provider limits fail closed when an account proxy is unreachable`
   - creates a GitHub OAuth connection
   - assigns an unreachable key/account proxy
   - calls `fetchAndPersistProviderLimits()`
   - verifies the call rejects
   - verifies no direct usage fetch is attempted

3. `Claude provider limits preserve direct retry for non-account proxy failures`
   - creates a Claude OAuth connection
   - assigns an unreachable provider-level proxy
   - calls `fetchAndPersistProviderLimits()`
   - verifies the existing direct retry path still succeeds

Targeted test command:

```bash
node --import tsx/esm --test tests/unit/provider-limits-proxy-fail-closed.test.ts
```

Result:

```text
tests 3
pass 3
fail 0
```

Typecheck command:

```bash
npm run typecheck:core
```

Result:

```text
passed
```or manual validation that reviewers should know about.