### PR TITLE
fix(pii): preserve custom event names and insert SSE separators on flush

### DIFF
--- a/.github/workflows/fork-pr-ci.yml
+++ b/.github/workflows/fork-pr-ci.yml
@@ -1,0 +1,36 @@
+name: Fork PR Checks
+
+on:
+  pull_request:
+    branches: ["*"]
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Lint, Typecheck, and Tests
+    if: github.repository == 'dangeReis/OmniRoute'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npm run typecheck:core
+
+      - name: Run targeted PII tests
+        run: node --import tsx/esm --test tests/unit/piiReproduction.test.ts tests/unit/streamingPiiTransform.test.ts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -441,3 +441,9 @@ When parsing streaming LLM responses (e.g. Responses API), check if a chunk repr
 
 ### 3. Database Handles in Tests
 Ensure that any unit tests that trigger database migrations or establish SQLite connections call `resetDbInstance()` and properly clean up/close all DB handles in a `test.after(...)` hook. Failure to release database connection handles will cause Node's native test runner to hang indefinitely.
+
+### 4. Custom SSE Event Names Preservation
+When flushing buffered or partial data in a `TransformStream` (e.g., in `sseTextTransform`), ensure the tracked event name/header (e.g., `event: response.output_text.delta`) is prepended to the flushed chunk if it was the last seen event type. Otherwise, flushed data chunks revert to the default `message` event type, breaking custom listeners.
+
+### 5. IPv6 Pattern Boundaries
+To prevent matching a sub-slice of a longer invalid sequence of hex segments separated by colons, the IPv6 regex must assert segment boundaries using lookbehind `(?<=^|[^A-Za-z0-9:])` and lookahead `(?!:[0-9a-fA-F:])` to ensure that no adjacent colon segments exist outside the matched address scope.

--- a/src/lib/piiSanitizer.ts
+++ b/src/lib/piiSanitizer.ts
@@ -22,7 +22,7 @@ type PiiMode = typeof VALID_MODES[number];
 const getMode = (): PiiMode => {
   const value = resolveFeatureFlag("PII_RESPONSE_SANITIZATION_MODE");
   if (value === "" || value === undefined || value === null) return "redact";
-  if (value === "false") return "off";
+  if ((value as any) === false || value === "false") return "off";
   if ((VALID_MODES as readonly any[]).includes(value)) return value as PiiMode;
   console.error(`[PII] Invalid PII_RESPONSE_SANITIZATION_MODE: "${value}", defaulting to "redact"`);
   return "redact";
@@ -88,7 +88,7 @@ const PII_PATTERNS: PIIPattern[] = [
   },
   {
     name: "ipv6_address",
-    regex: /(?<=^|[^A-Za-z0-9])(?:[0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}(?=$|[^A-Za-z0-9])/g,
+    regex: /(?<=^|[^A-Za-z0-9:])(?:::(?:[0-9a-fA-F]{1,4}:){0,6}[0-9a-fA-F]{1,4}|::|[0-9a-fA-F]{1,4}(?::[0-9a-fA-F]{1,4}){0,6}::(?:[0-9a-fA-F]{1,4}(?::[0-9a-fA-F]{1,4}){0,6})?|[0-9a-fA-F]{1,4}(?::[0-9a-fA-F]{1,4}){7})(?=$|[^A-Za-z0-9])(?!:[0-9a-fA-F:])/g,
     replacement: "[IP_REDACTED]",
     severity: "low",
   },

--- a/src/lib/sseTextTransform.ts
+++ b/src/lib/sseTextTransform.ts
@@ -52,6 +52,7 @@ export function createSseTextTransform(
   let isJsonStream = false;
   let flushed = false;
   let errored = false;
+  let lastEventLine = "";
 
   const handleLine = (line: string, controller: TransformStreamDefaultController) => {
     const trimmed = line.trim();
@@ -71,7 +72,10 @@ export function createSseTextTransform(
           if (flushedValue) {
             const prefix = lastPrefix || "data: ";
             const payload = typeof flushedValue === "string" ? flushedValue : JSON.stringify(flushedValue);
-            controller.enqueue(encoder.encode(prefix + payload + "\n"));
+            if (lastEventLine) {
+              controller.enqueue(encoder.encode(lastEventLine + "\n"));
+            }
+            controller.enqueue(encoder.encode(prefix + payload + "\n\n"));
           }
           flushed = true;
         }
@@ -146,7 +150,10 @@ export function createSseTextTransform(
               const prefix = lastPrefix || "data: ";
               const payload = typeof flushedValue === "string" ? flushedValue : JSON.stringify(flushedValue);
               // Only enqueue if the flushed value actually has content (onFlush usually returns null if buffer is empty now)
-              controller.enqueue(encoder.encode(prefix + payload + "\n"));
+              if (lastEventLine) {
+                controller.enqueue(encoder.encode(lastEventLine + "\n"));
+              }
+              controller.enqueue(encoder.encode(prefix + payload + "\n\n"));
             }
             flushed = true;
           }
@@ -177,6 +184,9 @@ export function createSseTextTransform(
       }
     } else {
       // Non-data line, pass through (e.g. event: content_block_delta)
+      if (line.startsWith("event:")) {
+        lastEventLine = line;
+      }
       controller.enqueue(encoder.encode(line + "\n"));
     }
   };
@@ -221,7 +231,10 @@ export function createSseTextTransform(
           if (flushedValue) {
             const prefix = lastPrefix || "data: ";
             const payload = typeof flushedValue === "string" ? flushedValue : JSON.stringify(flushedValue);
-            controller.enqueue(encoder.encode(prefix + payload + "\n"));
+            if (lastEventLine) {
+              controller.enqueue(encoder.encode(lastEventLine + "\n"));
+            }
+            controller.enqueue(encoder.encode(prefix + payload + "\n\n"));
           }
         }
       } catch (err) {

--- a/tests/unit/piiReproduction.test.ts
+++ b/tests/unit/piiReproduction.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { closeDbInstance } from "../../src/lib/db/core";
 
 // Isolate DB state
 const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-test-repro-"));
@@ -35,6 +36,7 @@ test("PII Reproduction Tests", async (t) => {
 
     // Write 50 alphanumeric characters starting with "sk-"
     const piiText = "sk-123456789012345678901234567890123456789012345678"; // 51 chars
+
     await writer.write(encoder.encode(`data: ${JSON.stringify({ choices: [{ delta: { content: piiText } }] })}\n`));
 
     // Wait a bit — if the buffer is withheld (W=10, PII window), nothing should be emitted yet
@@ -62,9 +64,18 @@ test("PII Reproduction Tests", async (t) => {
     assert.strictEqual(resultWordJoiner.text, "[API_KEY_REDACTED]", "API Key with Word Joiner is now correctly redacted");
     assert.strictEqual(resultSoftHyphen.text, "[API_KEY_REDACTED]", "API Key with Soft Hyphen is now correctly redacted");
 
-    // 2. IPv6 lookbehind/lookahead issues — sanitizer no longer falsely redacts abc::1
-    const resultIpv6Lookbehind = sanitizePII("abc::1");
-    assert.strictEqual(resultIpv6Lookbehind.text, "abc::1", "abc::1 should not be redacted");
+    // 2. IPv6 lookbehind/lookahead issues
+    // xyz::1 (preceded by non-hex alphabetic characters) should NOT be redacted
+    const resultIpv6Lookbehind = sanitizePII("xyz::1");
+    assert.strictEqual(resultIpv6Lookbehind.text, "xyz::1", "xyz::1 should not be redacted");
+
+    // abc::1 (preceded by valid hex characters) is a valid compressed IPv6 address and should be redacted
+    const resultIpv6ValidCompressed = sanitizePII("abc::1");
+    assert.strictEqual(resultIpv6ValidCompressed.text, "[IP_REDACTED]", "abc::1 should be redacted as a valid compressed IP");
+
+    // Invalid IPv6 followed by letters should NOT be redacted
+    const resultIpv6Lookahead = sanitizePII("2001:db8:3333:4444:5555:6666:7777:8888abcd");
+    assert.strictEqual(resultIpv6Lookahead.text, "2001:db8:3333:4444:5555:6666:7777:8888abcd", "Invalid IPv6 with trailing characters should not be redacted");
 
     // Valid IPv6 is correctly redacted
     const resultIpv6Valid = sanitizePII("2001:db8:3333:4444:5555:6666:7777:8888");
@@ -122,4 +133,13 @@ test("PII Reproduction Tests", async (t) => {
     // Verify the content is present — "H" from first window emit + "ello world" from flush.
     assert.ok(outputB.includes('"H"') && outputB.includes("ello world"), "Scenario B: buffered content must not be lost — expect window-split output containing both parts");
   });
+});
+
+test.after(() => {
+  try {
+    closeDbInstance();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  } catch (err) {
+    console.error("Cleanup failed:", err);
+  }
 });

--- a/tests/unit/streamingPiiTransform.test.ts
+++ b/tests/unit/streamingPiiTransform.test.ts
@@ -183,6 +183,48 @@ test("PII split across sliding window boundary is still redacted", async () => {
     "email spanning window boundary should be redacted");
 });
 
+test("preserve event names when flushing buffered SSE text", async () => {
+  const transform = (createPiiSseTransform as any)({ windowSize: 10 });
+
+  const eventLine = "event: response.output_text.delta\n";
+  const inputLine = `data: {"choices":[{"delta":{"content":"abcdefghijklmnopqrst"}}]}\n\n`;
+  const doneLine = `data: [DONE]\n\n`;
+
+  const output = await testTransform(transform, [eventLine + inputLine + doneLine]);
+
+  // Output must include the custom event name
+  assert.ok(output.includes("event: response.output_text.delta"), "should preserve event line");
+});
+
+test("insert an SSE event separator before flushed chunks", async () => {
+  const transform = (createPiiSseTransform as any)({ windowSize: 10 });
+
+  const inputLine = `data: {"choices":[{"delta":{"content":"abcdefghijklmnopqrst"}}]}\n\n`;
+  const doneLine = `data: [DONE]\n\n`;
+
+  const output = await testTransform(transform, [inputLine + doneLine]);
+
+  // Output must contain the payload and [DONE] separated by double newlines to form separate SSE events
+  assert.ok(output.includes("\n\ndata: [DONE]"), "should separate flushed chunk and [DONE] event");
+});
+
+test("sanitize compressed IPv6 addresses", async () => {
+  const transform = createPiiSseTransform();
+  
+  const inputLoopback = `data: {"choices":[{"delta":{"content":"server address is ::1"}}]}\n\n`;
+  const inputCompressed = `data: {"choices":[{"delta":{"content":"server address is 2001:db8::1"}}]}\n\n`;
+  const doneLine = `data: [DONE]\n\n`;
+
+  const outputLoopback = await testTransform(transform, [inputLoopback + doneLine]);
+  assert.ok(!outputLoopback.includes("::1"), "compressed loopback IPv6 should be redacted");
+  assert.ok(outputLoopback.includes("[IP_REDACTED]"), "redaction marker should be present for loopback IPv6");
+
+  const transform2 = createPiiSseTransform();
+  const outputCompressed = await testTransform(transform2, [inputCompressed + doneLine]);
+  assert.ok(!outputCompressed.includes("2001:db8::1"), "compressed IPv6 should be redacted");
+  assert.ok(outputCompressed.includes("[IP_REDACTED]"), "redaction marker should be present for compressed IPv6");
+});
+
 test.after(async () => {
   if (originalEnv !== undefined) {
     process.env.PII_RESPONSE_SANITIZATION = originalEnv;


### PR DESCRIPTION
Addresses the remaining code review comments for the streaming PII sanitization implementation.

- Prepend lastEventLine to enqueued flushed values to maintain custom event subscriptions.
- Append double newlines to flushed chunks to prevent event merging with subsequent sentinel frames.
- Upgrade IPv6 regex to support compressed and loopback formats.
- Add comprehensive unit tests and CLAUDE.md learning entries.