### PR TITLE
fix(sse): defer enqueuing of event lines to align event names and prevent misattribution

### DIFF
--- a/src/lib/sseTextTransform.ts
+++ b/src/lib/sseTextTransform.ts
@@ -54,6 +54,7 @@ export function createSseTextTransform(
   let errored = false;
   let currentEventLine = "";
   let lastEventLine = "";
+  let pendingEventLine = "";
 
   const handleLine = (line: string, controller: TransformStreamDefaultController) => {
     const trimmed = line.trim();
@@ -82,6 +83,10 @@ export function createSseTextTransform(
             controller.enqueue(encoder.encode(prefix + payload + "\n\n"));
           }
           flushed = true;
+        }
+        if (pendingEventLine) {
+          controller.enqueue(encoder.encode(pendingEventLine + "\n"));
+          pendingEventLine = "";
         }
         controller.enqueue(encoder.encode(line + "\n"));
         return;
@@ -167,12 +172,20 @@ export function createSseTextTransform(
           }
 
           lastJson = json;
+          if (pendingEventLine) {
+            controller.enqueue(encoder.encode(pendingEventLine + "\n"));
+            pendingEventLine = "";
+          }
           controller.enqueue(encoder.encode(prefix + JSON.stringify(json) + "\n"));
         } catch (err: any) {
           if (err?.message?.startsWith("[PII]")) {
             throw err;
           }
           if (err instanceof SyntaxError) {
+            if (pendingEventLine) {
+              controller.enqueue(encoder.encode(pendingEventLine + "\n"));
+              pendingEventLine = "";
+            }
             // JSON parsing failed. Check if it looks like JSON that failed to parse.
             if (trimmedSegment.startsWith("{") || trimmedSegment.startsWith("[")) {
               console.warn("[SSE-TRANSFORM] Dropping malformed JSON chunk to prevent syntax injection:", trimmedSegment.slice(0, 100));
@@ -189,14 +202,20 @@ export function createSseTextTransform(
         // Starts with data: but not JSON, process as raw text
         lastEventLine = currentEventLine;
         const processed = processor(segment, "content");
+        if (pendingEventLine) {
+          controller.enqueue(encoder.encode(pendingEventLine + "\n"));
+          pendingEventLine = "";
+        }
         controller.enqueue(encoder.encode(prefix + processed + "\n"));
       }
     } else {
       // Non-data line, pass through (e.g. event: content_block_delta)
       if (line.startsWith("event:")) {
         currentEventLine = line;
+        pendingEventLine = line;
+      } else {
+        controller.enqueue(encoder.encode(line + "\n"));
       }
-      controller.enqueue(encoder.encode(line + "\n"));
     }
   };
 

--- a/src/lib/sseTextTransform.ts
+++ b/src/lib/sseTextTransform.ts
@@ -63,6 +63,10 @@ export function createSseTextTransform(
       if (trimmed === "") {
         currentEventLine = "";
       }
+      if (pendingEventLine) {
+        controller.enqueue(encoder.encode(pendingEventLine + "\n"));
+        pendingEventLine = "";
+      }
       controller.enqueue(encoder.encode(line + "\n"));
       return;
     }
@@ -182,14 +186,15 @@ export function createSseTextTransform(
             throw err;
           }
           if (err instanceof SyntaxError) {
-            if (pendingEventLine) {
-              controller.enqueue(encoder.encode(pendingEventLine + "\n"));
-              pendingEventLine = "";
-            }
             // JSON parsing failed. Check if it looks like JSON that failed to parse.
             if (trimmedSegment.startsWith("{") || trimmedSegment.startsWith("[")) {
               console.warn("[SSE-TRANSFORM] Dropping malformed JSON chunk to prevent syntax injection:", trimmedSegment.slice(0, 100));
+              pendingEventLine = "";
             } else {
+              if (pendingEventLine) {
+                controller.enqueue(encoder.encode(pendingEventLine + "\n"));
+                pendingEventLine = "";
+              }
               // Treat segment as raw text delta (fail-open)
               const processed = processor(segment, "content");
               controller.enqueue(encoder.encode(prefix + processed + "\n"));

--- a/tests/unit/streamingPiiTransform.test.ts
+++ b/tests/unit/streamingPiiTransform.test.ts
@@ -360,6 +360,33 @@ test("two consecutive events with different names each get their own event name 
   assert.ok(output.includes("event: event.type.alpha"), "event-A name should appear in output");
   assert.ok(output.includes("event: event.type.beta"), "event-B name should appear in output");
 });
+
+test("stop signal event name is enqueued correctly without misattribution or loss", async () => {
+  const transform = (createPiiSseTransform as any)({ windowSize: 10 });
+
+  const contentEventLine = "event: response.output_text.delta\n";
+  const contentData = `data: {"choices":[{"delta":{"content":"abcdefghijklmno"}}]}\n\n`;
+
+  const stopEventLine = "event: response.done\n";
+  const stopData = `data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n`;
+  const doneLine = `data: [DONE]\n\n`;
+
+  const output = await testTransform(transform, [
+    contentEventLine + contentData,
+    stopEventLine + stopData + doneLine,
+  ]);
+
+  // The stop signal itself should be preceded by its own event name "response.done"
+  const stopSignalIndex = output.indexOf('"finish_reason":"stop"');
+  assert.ok(stopSignalIndex !== -1, "stop signal should be present in output");
+  const sectionBeforeStop = output.slice(0, stopSignalIndex);
+  const lastEventBeforeStop = sectionBeforeStop.slice(sectionBeforeStop.lastIndexOf("event:"));
+  assert.ok(
+    lastEventBeforeStop.includes("event: response.done"),
+    "stop signal payload must be immediately preceded by event: response.done"
+  );
+});
+
 test.after(async () => {
   if (originalEnv !== undefined) {
     process.env.PII_RESPONSE_SANITIZATION = originalEnv;

--- a/tests/unit/streamingPiiTransform.test.ts
+++ b/tests/unit/streamingPiiTransform.test.ts
@@ -387,6 +387,15 @@ test("stop signal event name is enqueued correctly without misattribution or los
   );
 });
 
+test("verify keep-alive event preservation (no-data event)", async () => {
+  const transform = (createPiiSseTransform as any)({ windowSize: 10 });
+
+  const eventLine = "event: keep-alive\n\n";
+  const output = await testTransform(transform, [eventLine]);
+
+  assert.ok(output.includes("event: keep-alive"), "keep-alive event should be preserved");
+});
+
 test.after(async () => {
   if (originalEnv !== undefined) {
     process.env.PII_RESPONSE_SANITIZATION = originalEnv;


### PR DESCRIPTION
Defers enqueuing of event lines until their corresponding data/sentinel lines are enqueued. Prevents event name misattribution and loss (e.g. for stop signals).