### PR TITLE
fix(sse): stop infinite account-fallback loop on no-auth providers (#3061)

### DIFF
--- a/src/sse/services/auth.ts
+++ b/src/sse/services/auth.ts
@@ -696,6 +696,14 @@ async function selectSessionAffinityConnection(
   return connection;
 }
 
+/**
+ * Sentinel connection id used for the synthetic credentials of no-auth /
+ * keyless providers (opencode / opencode-zen). It is NOT a real DB row, so it
+ * cannot carry cooldown state — the account-fallback loop must be able to
+ * exclude it (#3061), otherwise it gets re-selected forever.
+ */
+const SYNTHETIC_NOAUTH_CONNECTION_ID = "noauth";
+
 function normalizeExcludedConnectionIds(
   excludeConnectionId: string | null,
   extraExcludedConnectionIds: string[] | null | undefined
@@ -831,6 +839,19 @@ export async function getProviderCredentials(
       WEB_COOKIE_PROVIDERS as Record<string, { noAuth?: boolean } | undefined>,
     ];
     if (providerMaps.some((map) => map[resolvedId]?.noAuth)) {
+      // #3061: there is only one synthetic "noauth" connection for a no-auth
+      // provider. If the caller already tried and excluded it (account-fallback
+      // after a persistent upstream error), do NOT hand it back — that would let
+      // the chat fallback loop re-select "noauth" forever (no real DB row → no
+      // cooldown to brake it), writing logs every iteration until the disk fills.
+      // Returning null here lets the handler stop after a single attempt.
+      const excludedForNoAuth = normalizeExcludedConnectionIds(
+        excludeConnectionId,
+        options.excludeConnectionIds
+      );
+      if (excludedForNoAuth.has(SYNTHETIC_NOAUTH_CONNECTION_ID)) {
+        return null;
+      }
       return {
         apiKey: null,
         accessToken: null,
@@ -839,7 +860,7 @@ export async function getProviderCredentials(
         projectId: null,
         copilotToken: null,
         providerSpecificData: {},
-        connectionId: "noauth",
+        connectionId: SYNTHETIC_NOAUTH_CONNECTION_ID,
         testStatus: "active",
         lastError: null,
         lastErrorType: null,
@@ -953,6 +974,12 @@ export async function getProviderCredentials(
       // OpenCode free model. A configured, active key is still selected above; a
       // rate-limited/terminal key returns its own signal before reaching here.
       if (resolvedId === "opencode-zen") {
+        // #3061: same loop guard as the NOAUTH_PROVIDERS path above — once the
+        // single synthetic "noauth" connection has been excluded by the chat
+        // fallback loop, return null instead of re-handing it back forever.
+        if (excludedConnectionIds.has(SYNTHETIC_NOAUTH_CONNECTION_ID)) {
+          return null;
+        }
         return {
           apiKey: null,
           accessToken: null,
@@ -961,7 +988,7 @@ export async function getProviderCredentials(
           projectId: null,
           copilotToken: null,
           providerSpecificData: {},
-          connectionId: "noauth",
+          connectionId: SYNTHETIC_NOAUTH_CONNECTION_ID,
           testStatus: "active",
           lastError: null,
           lastErrorType: null,

--- a/tests/unit/auth-noauth-fallback-loop-3061.test.ts
+++ b/tests/unit/auth-noauth-fallback-loop-3061.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Issue #3061 — No-auth providers (opencode / opencode-zen) infinite
+ * account-fallback loop on a persistent upstream error → unbounded DB growth /
+ * disk exhaustion.
+ *
+ * For a no-auth provider, getProviderCredentials early-returns synthetic
+ * credentials with connectionId "noauth" BEFORE honoring the exclusion set
+ * (src/sse/services/auth.ts: the NOAUTH_PROVIDERS block and the opencode-zen
+ * keyless fallback). So when the chat fallback loop marks the failed "noauth"
+ * connection and excludes it, the selector hands "noauth" right back → it loops
+ * forever, writing key-health + request logs every iteration until the disk
+ * fills (see @paraflu's "failure #320" trace in discussion #3038).
+ *
+ * Loop-breaking invariant under test: once "noauth" is in excludeConnectionIds,
+ * the selector MUST return null (no remaining candidate) so the chat handler
+ * stops after a single attempt instead of re-selecting the same synthetic
+ * connection. The happy-path (nothing excluded → synthetic noauth) must stay
+ * intact so keyless access still works.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-noauth-loop-3061-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const { getProviderCredentials } = await import("../../src/sse/services/auth.ts");
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+// ── Happy path preserved: first selection (nothing excluded) still works ──
+
+test("#3061 opencode no-auth: first selection returns synthetic noauth (happy path preserved)", async () => {
+  const creds = await getProviderCredentials("opencode", null, null, "minimax-m2.5-free");
+  assert.ok(creds, "opencode must resolve to synthetic no-auth credentials on first selection");
+  assert.equal((creds as { connectionId?: string }).connectionId, "noauth");
+  assert.equal((creds as { apiKey?: unknown }).apiKey, null);
+});
+
+test("#3061 opencode-zen no-auth: first selection returns synthetic noauth (happy path preserved)", async () => {
+  const creds = await getProviderCredentials("opencode-zen");
+  assert.ok(creds, "opencode-zen must resolve to synthetic no-auth credentials on first selection");
+  assert.equal((creds as { connectionId?: string }).connectionId, "noauth");
+});
+
+// ── The fix: once "noauth" is excluded, selection MUST stop (return null) ──
+
+test("#3061 opencode no-auth: excluding 'noauth' returns null (breaks the fallback loop)", async () => {
+  const creds = await getProviderCredentials("opencode", null, null, "minimax-m2.5-free", {
+    excludeConnectionIds: ["noauth"],
+  });
+  assert.equal(
+    creds,
+    null,
+    "after the synthetic noauth connection failed and was excluded, the selector must return " +
+      "null instead of handing back 'noauth' (which would loop forever and fill the disk)"
+  );
+});
+
+test("#3061 opencode-zen no-auth: excluding 'noauth' returns null (breaks the fallback loop)", async () => {
+  const creds = await getProviderCredentials("opencode-zen", null, null, null, {
+    excludeConnectionIds: ["noauth"],
+  });
+  assert.equal(
+    creds,
+    null,
+    "excluded synthetic noauth must not be re-selected for the opencode-zen keyless path"
+  );
+});


### PR DESCRIPTION
## What

Fixes the infinite account-fallback loop that no-auth / keyless providers (`opencode`, `opencode-zen`) trigger on a persistent upstream error — an unbounded loop that writes to the DB every iteration until the disk fills. Reported in discussion #3038 by @paraflu (his trace showed key-health "failure #320" climbing with no backoff), tracked in #3061.

## Root cause

`getProviderCredentials` (`src/sse/services/auth.ts`) early-returns synthetic credentials with `connectionId: "noauth"` for no-auth providers **before honoring `excludeConnectionIds`** — both in the `NOAUTH_PROVIDERS` block and in the `opencode-zen` keyless fallback (the latter added in #2962).

So when the chat account-fallback loop (`src/sse/handlers/chat.ts`) marks the failed `"noauth"` connection, adds it to `excludedConnectionIds`, and retries, the selector hands `"noauth"` straight back. There is no brake: `"noauth"` is not a real DB row, so `markAccountUnavailable` → `updateProviderConnection("noauth", …)` updates 0 rows and no cooldown is persisted. The loop spins immediately, writing key-health + request logs each iteration → unbounded DB growth → "no disk space".

Proximate trigger: `opencode` ("OpenCode Free") is keyless by design (`NOAUTH_PROVIDERS`, `noAuth: true`) and sends no `Authorization` header; the public `zen/v1` endpoint now answers `401: Model <x> is not supported` for the `-free` models. But the loop is provider-agnostic — any no-auth/web-cookie provider with a persistent upstream error reproduces it.

## Fix

Honor the exclusion set in **both** synthetic-credential paths: once `"noauth"` is already in `excludeConnectionIds`, return `null` so the handler stops after a single attempt (`handleNoCredentials` → clean error) instead of re-selecting the synthetic connection forever. Introduces a `SYNTHETIC_NOAUTH_CONNECTION_ID` sentinel to keep the two sites in sync.

Happy path is preserved: the *first* selection (nothing excluded) still returns the synthetic `noauth` credentials, so keyless access works exactly as before.

```
iter 1: select → "noauth" → 401 → fallback adds "noauth" to excluded → continue
iter 2: select with "noauth" excluded → null (was: "noauth" again) → handler returns error → STOP
```

## Tests (TDD)

`tests/unit/auth-noauth-fallback-loop-3061.test.ts` — written test-first:

- **2 exclusion cases** (`opencode`, `opencode-zen` with `excludeConnectionIds: ["noauth"]` must resolve to `null`) — **failed before** the fix (returned synthetic noauth), pass after.
- **2 happy-path guards** (first selection still returns synthetic noauth) — pass before and after, so the fix doesn't over-broaden.

`4 tests, 4 pass`.

## Validation

- `typecheck:core` — clean
- `eslint` (changed files) — clean
- `check:any-budget:t11`, `check:env-doc-sync`, `check:docs-all`, `check:cycles` — pass
- Blast-radius unit tests pass: `sse-auth` (56), `opencode-executor` (33), `auth-opencode-zen-noauth-fallback` (2), `combo-routing-engine` (72), `codex-failover` (10), `auth-terminal-status` (10), `providers-free-tier-filter` (6), `auth-clear-account-error` (4), `chat-cooldown-aware-retry` (6)
- `next build` compiled successfully (BUILD_ID + standalone `server.js` + route/prerender manifests generated). The build's post-step `syncStandaloneExtraModules` errored with `ERR_FS_CP_EINVAL` — environmental only, because this PR was built in a git worktree with a **symlinked** `node_modules` (cp src === dest); the script flags it "Non-fatal". Not related to this change.

## Notes / follow-ups

- Sibling scoping bug #3027 (passthrough per-model failures not staying model-scoped) is related but separate.
- Catalog drift (the keyless `opencode` `-free` models 401ing upstream) is the proximate trigger and is called out in #3061 as a separate decision (update slugs/endpoint, or re-gate behind `opencode-zen`/`opencode-go` with a key). This PR fixes the dangerous loop regardless of catalog state.

Closes #3061.
