### PR TITLE
fix(home): pass providerId to quota widget icons

### DIFF
--- a/src/app/(dashboard)/home/ProviderQuotaWidget.tsx
+++ b/src/app/(dashboard)/home/ProviderQuotaWidget.tsx
@@ -175,7 +175,11 @@ export default function ProviderQuotaWidget({ autoRefreshInterval = 0 }: Provide
           onClick={refreshAll}
           disabled={refreshingAll || loading}
           className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-border bg-bg-subtle text-xs font-medium text-text-main disabled:opacity-50 disabled:cursor-not-allowed hover:bg-surface transition-colors"
-          title={autoRefreshIntervalMs > 0 ? tr("autoRefreshing", "Auto-refreshing") : tr("refreshAll", "Refresh All")}
+          title={
+            autoRefreshIntervalMs > 0
+              ? tr("autoRefreshing", "Auto-refreshing")
+              : tr("refreshAll", "Refresh All")
+          }
         >
           <span
             className={`material-symbols-outlined text-[16px] ${refreshingAll ? "animate-spin" : ""}`}
@@ -187,7 +191,10 @@ export default function ProviderQuotaWidget({ autoRefreshInterval = 0 }: Provide
               ? tr("refreshing", "Refreshing")
               : autoRefreshIntervalMs > 0
                 ? `${tr("autoRefreshing", "Auto-refreshing")} ${formatAutoRefreshCountdown(
-                    Math.max(0, autoRefreshIntervalMs - (autoRefreshClock - lastRefreshAllAtRef.current))
+                    Math.max(
+                      0,
+                      autoRefreshIntervalMs - (autoRefreshClock - lastRefreshAllAtRef.current)
+                    )
                   )}`
                 : tr("refreshAll", "Refresh All")}
           </span>
@@ -224,7 +231,7 @@ export default function ProviderQuotaWidget({ autoRefreshInterval = 0 }: Provide
                   className="rounded-lg border border-border bg-surface/40 p-3 flex flex-col gap-2"
                 >
                   <div className="flex items-center gap-2">
-                    <ProviderIcon provider={provider} size={18} />
+                    <ProviderIcon providerId={provider} size={18} />
                     <span className="font-medium text-sm truncate">
                       {provider.charAt(0).toUpperCase() + provider.slice(1)}
                     </span>

--- a/tests/unit/provider-quota-widget-icon-prop.test.ts
+++ b/tests/unit/provider-quota-widget-icon-prop.test.ts
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const PROVIDER_QUOTA_WIDGET_PATH = join(ROOT, "src/app/(dashboard)/home/ProviderQuotaWidget.tsx");
+
+const providerQuotaWidgetSrc = readFileSync(PROVIDER_QUOTA_WIDGET_PATH, "utf8");
+
+test("ProviderQuotaWidget passes provider IDs using ProviderIcon's providerId prop", () => {
+  assert.ok(
+    providerQuotaWidgetSrc.includes("<ProviderIcon providerId={provider} size={18} />"),
+    "ProviderQuotaWidget must pass provider through ProviderIcon's providerId prop"
+  );
+  assert.equal(
+    providerQuotaWidgetSrc.includes("<ProviderIcon provider={provider}"),
+    false,
+    "ProviderQuotaWidget must not pass an unsupported provider prop to ProviderIcon"
+  );
+});


### PR DESCRIPTION
## Summary

- Fixes the Home provider quota widget so it passes provider IDs through the `ProviderIcon` component's supported `providerId` prop.
- Prevents the Home/Dashboard page from crashing with `Cannot read properties of undefined (reading 'toLowerCase')` when the provider quota widget is pinned to the home page.

## Related Issues

- Related to Home/Dashboard provider quota widget crash

## Validation

- [ ] `npm run lint`
- [ ] `npm run test:unit`
- [ ] `npm run test:coverage`
- [ ] Coverage is still `>= 60%` for statements, lines, functions, and branches
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below
- [x] `node --test tests/unit/provider-quota-widget-icon-prop.test.ts`

## Tests Added Or Updated

- Added `tests/unit/provider-quota-widget-icon-prop.test.ts` to guard that `ProviderQuotaWidget` uses `providerId` and does not pass the unsupported `provider` prop to `ProviderIcon`.

## Coverage Notes

- This changes `src/app/(dashboard)/home/ProviderQuotaWidget.tsx` and is covered by a source-level regression test that verifies the widget uses `ProviderIcon` with the correct prop.
- Full coverage was not run locally.

## Reviewer Notes

- Root cause: `ProviderQuotaWidget` rendered `<ProviderIcon provider={provider} />`, but `ProviderIcon` expects `providerId` and calls `providerId.toLowerCase()`.
- No migrations or feature flags involved.
