### PR TITLE
fix(cache): preserve client cache_control for Xiaomi MiMo (#3088)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 
 _Development cycle in progress — entries are added as work merges into `release/v3.8.9` and finalized by the release flow._
 
+### 🔧 Bug Fixes
+
+- **cache:** preserve client-side `cache_control` breakpoints for Xiaomi MiMo — added `xiaomi-mimo` to the prompt-caching provider allowlist so Claude Code (via cc-switch) cache hints are no longer stripped by the OpenAI-format translator, restoring cache hits. ([#3088](https://github.com/diegosouzapw/OmniRoute/issues/3088))
+
 ---
 
 ## [3.8.8] — 2026-06-03

--- a/open-sse/utils/cacheControlPolicy.ts
+++ b/open-sse/utils/cacheControlPolicy.ts
@@ -72,7 +72,18 @@ const DETERMINISTIC_STRATEGIES: Set<RoutingStrategyValue> = new Set(["priority",
 /**
  * Providers that support prompt caching
  */
-const CACHING_PROVIDERS = new Set(["claude", "anthropic", "zai", "qwen", "deepseek"]);
+const CACHING_PROVIDERS = new Set([
+  "claude",
+  "anthropic",
+  "zai",
+  "qwen",
+  "deepseek",
+  // #3088 — Xiaomi MiMo honors OpenAI-format cache_control breakpoints. Without
+  // this entry, shouldPreserveCacheControl() returns false for Claude Code
+  // clients and filterToOpenAIFormat() strips cache_control, so Xiaomi never
+  // sees the cache hints and every request is a cache miss.
+  "xiaomi-mimo",
+]);
 
 /**
  * Detect if the client is Claude Code or another caching-aware client

--- a/tests/unit/cache-control-policy.test.ts
+++ b/tests/unit/cache-control-policy.test.ts
@@ -38,6 +38,10 @@ describe("Cache Control Policy", () => {
       assert.equal(providerSupportsCaching("anthropic"), true);
       assert.equal(providerSupportsCaching("zai"), true);
       assert.equal(providerSupportsCaching("qwen"), true);
+      assert.equal(providerSupportsCaching("deepseek"), true);
+      // #3088 — Xiaomi MiMo supports prompt caching; cache_control breakpoints
+      // sent by Claude Code (via cc-switch) must be preserved, not stripped.
+      assert.equal(providerSupportsCaching("xiaomi-mimo"), true);
     });
 
     test("rejects non-caching providers", () => {
@@ -51,6 +55,20 @@ describe("Cache Control Policy", () => {
     test("is case-insensitive", () => {
       assert.equal(providerSupportsCaching("Claude"), true);
       assert.equal(providerSupportsCaching("ANTHROPIC"), true);
+      assert.equal(providerSupportsCaching("Xiaomi-MiMo"), true);
+    });
+
+    // #3088 — regression: a Claude Code client routed to xiaomi-mimo must keep
+    // its client-side cache_control breakpoints so Xiaomi's API sees cache hints.
+    test("preserves client cache_control for xiaomi-mimo single model", () => {
+      assert.equal(
+        shouldPreserveCacheControl({
+          userAgent: "claude-cli/2.1.113 (external, sdk-cli)",
+          isCombo: false,
+          targetProvider: "xiaomi-mimo",
+        }),
+        true
+      );
     });
   });
 


### PR DESCRIPTION
Closes #3088

## Problem
Xiaomi MiMo via cc-switch + OmniRoute showed **zero cache hits**, while calling Xiaomi directly cached normally.

## Root cause
`CACHING_PROVIDERS` in `open-sse/utils/cacheControlPolicy.ts` did not include `xiaomi-mimo`. So `providerSupportsCaching("xiaomi-mimo")` returned `false` → `shouldPreserveCacheControl()` returned `false` → `filterToOpenAIFormat()` stripped every `cache_control` block before forwarding. Xiaomi's API therefore never saw the cache breakpoints and treated each request as a miss.

## Fix
Add `xiaomi-mimo` to the prompt-caching provider allowlist (1 line). Now Claude Code's `cache_control` hints are preserved for single-model routing.

## Tests
Added regression assertions to `tests/unit/cache-control-policy.test.ts`:
- `providerSupportsCaching("xiaomi-mimo")` → true (+ case-insensitive)
- `shouldPreserveCacheControl({ userAgent: claude-cli, isCombo: false, targetProvider: "xiaomi-mimo" })` → true

`node --import tsx/esm --test tests/unit/cache-control-policy.test.ts` → 37 pass / 0 fail. ESLint clean.