### PR TITLE
fix(sse): scope ollama-cloud per-model 403 to model lockout, not connection cooldown (#3027)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ _Development cycle in progress — entries are added as work merges into `releas
 
 ### 🔧 Bug Fixes
 
+- **resilience:** a per-model subscription/permission `403` from a passthrough provider (e.g. Ollama Cloud `deepseek-v4-pro` → _"this model requires a subscription"_) now locks out **only that model** instead of cooling down the whole connection — the free models on the same key keep serving, and repeated paid-model 403s no longer escalate a connection-wide backoff. Generalizes the grok-web 403 precedent to all `hasPerModelQuota` providers; terminal/credential 403s (banned/deactivated key) still deactivate the connection. ([#3027](https://github.com/diegosouzapw/OmniRoute/issues/3027))
 - **cache:** preserve client-side `cache_control` breakpoints for Xiaomi MiMo — added `xiaomi-mimo` to the prompt-caching provider allowlist so Claude Code (via cc-switch) cache hints are no longer stripped by the OpenAI-format translator, restoring cache hits. ([#3088](https://github.com/diegosouzapw/OmniRoute/issues/3088))
 
 ---

--- a/src/sse/services/auth.ts
+++ b/src/sse/services/auth.ts
@@ -1815,6 +1815,46 @@ export async function markAccountUnavailable(
     );
     const cooldownMs = terminalStatus ? 0 : rawCooldownMs;
 
+    // ── #3027: per-model subscription/permission 403 → model-only lockout ──
+    // Passthrough / per-model-quota providers (e.g. ollama-cloud with
+    // passthroughModels:true) multiplex many upstream models behind one key.
+    // A scoped 403 like "this model requires a subscription, upgrade for access"
+    // is about the paid model, not the key — cooling the whole connection would
+    // knock out the free models on the same key too and escalate backoff
+    // (#3001/#3027). This generalizes the grok-web 403 precedent above to every
+    // hasPerModelQuota provider. Terminal/credential 403s (banned/deactivated
+    // key, credits exhausted) are excluded here because
+    // resolveTerminalConnectionStatus() returns a non-null status for them, so
+    // they keep their existing connection-level cooldown/deactivation path.
+    if (isPerModelQuotaProvider && status === 403 && provider && model && !terminalStatus) {
+      const lockout = recordModelLockoutFailure(
+        provider,
+        connectionId,
+        model,
+        "forbidden",
+        status,
+        fallbackResult.baseCooldownMs ??
+          effectiveProviderProfile?.baseCooldownMs ??
+          COOLDOWN_MS.serviceUnavailable,
+        effectiveProviderProfile,
+        {
+          exactCooldownMs:
+            fallbackResult.usedUpstreamRetryHint === true ? fallbackResult.cooldownMs : null,
+        }
+      );
+      updateProviderConnection(connectionId, {
+        lastErrorType: "forbidden",
+        lastError: `Model ${model} forbidden (per-model access/subscription)`,
+        lastErrorAt: new Date().toISOString(),
+        errorCode: status,
+      }).catch(() => {});
+      log.info(
+        "AUTH",
+        `Model-only lockout for ${provider}:${model} — 403 forbidden ${Math.ceil(lockout.cooldownMs / 1000)}s (per-model quota provider, connection stays active)`
+      );
+      return { shouldFallback: true, cooldownMs: lockout.cooldownMs };
+    }
+
     // ── 404 model-only lockout: connection stays active ──
     // For local providers (detected by URL), a 404 means the specific model
     // doesn't exist or isn't available for this account — it should NOT lock

--- a/tests/unit/sse-auth.test.ts
+++ b/tests/unit/sse-auth.test.ts
@@ -14,6 +14,7 @@ const settingsDb = await import("../../src/lib/db/settings.ts");
 const apiKeysDb = await import("../../src/lib/db/apiKeys.ts");
 const auth = await import("../../src/sse/services/auth.ts");
 const quotaCache = await import("../../src/domain/quotaCache.ts");
+const fallback = await import("../../open-sse/services/accountFallback.ts");
 
 async function resetStorage() {
   core.resetDbInstance();
@@ -1120,6 +1121,91 @@ test("markAccountUnavailable applies a model-only lockout for compatible provide
   assert.equal(updated.rateLimitedUntil, undefined);
   assert.equal(updated.lastErrorType, "rate_limited");
   assert.equal(Number(updated.errorCode), 429);
+});
+
+// #3027 — a per-model subscription/permission 403 from a passthrough provider
+// (ollama-cloud) must lock only the paid model, not the whole connection.
+test("markAccountUnavailable: ollama-cloud per-model subscription 403 locks the model, not the connection (#3027)", async () => {
+  fallback.clearAllModelLockouts();
+  const connection = await seedConnection("ollama-cloud", {
+    name: "ollama-paid-model",
+    providerSpecificData: { passthroughModels: true },
+  });
+
+  const result = await auth.markAccountUnavailable(
+    connection.id,
+    403,
+    "this model requires a subscription, upgrade for access: https://ollama.com/upgrade",
+    "ollama-cloud",
+    "deepseek-v4-pro"
+  );
+  await flushWrites();
+  const updated = await providersDb.getProviderConnectionById(connection.id);
+
+  // Connection stays eligible — only the paid model is cooled down.
+  assert.equal(result.shouldFallback, true);
+  assert.ok(result.cooldownMs > 0);
+  assert.equal(updated.testStatus, "active");
+  assert.equal(updated.rateLimitedUntil, undefined);
+  assert.equal(updated.lastErrorType, "forbidden");
+  assert.equal(Number(updated.errorCode), 403);
+
+  assert.equal(fallback.isModelLocked("ollama-cloud", connection.id, "deepseek-v4-pro"), true);
+  // A free model on the same key is still usable.
+  assert.equal(fallback.isModelLocked("ollama-cloud", connection.id, "gemma4:31b"), false);
+});
+
+// #3027 regression — a genuine whole-key 403 (deactivated/banned key) must NOT
+// be downgraded to a model lockout; the connection still becomes terminal.
+test("markAccountUnavailable: a whole-key 403 still deactivates the ollama-cloud connection (#3027 regression)", async () => {
+  fallback.clearAllModelLockouts();
+  const connection = await seedConnection("ollama-cloud", {
+    name: "ollama-banned-key",
+    providerSpecificData: { passthroughModels: true },
+  });
+
+  await auth.markAccountUnavailable(
+    connection.id,
+    403,
+    "account has been deactivated",
+    "ollama-cloud",
+    "deepseek-v4-pro"
+  );
+  await flushWrites();
+  const updated = await providersDb.getProviderConnectionById(connection.id);
+
+  assert.equal(fallback.isModelLocked("ollama-cloud", connection.id, "deepseek-v4-pro"), false);
+  assert.ok(
+    ["banned", "expired", "credits_exhausted"].includes(updated.testStatus),
+    `expected a terminal connection status, got ${updated.testStatus}`
+  );
+});
+
+// #3027 — repeated subscription 403s on the paid model must never escalate a
+// connection-wide cooldown/backoff (only the model lockout escalates).
+test("markAccountUnavailable: repeated ollama-cloud subscription 403s never escalate connection backoff (#3027)", async () => {
+  fallback.clearAllModelLockouts();
+  const connection = await seedConnection("ollama-cloud", {
+    name: "ollama-repeat-403",
+    providerSpecificData: { passthroughModels: true },
+  });
+
+  for (let i = 0; i < 3; i++) {
+    await auth.markAccountUnavailable(
+      connection.id,
+      403,
+      "this model requires a subscription, upgrade for access",
+      "ollama-cloud",
+      "deepseek-v4-pro"
+    );
+    await flushWrites();
+  }
+  const updated = await providersDb.getProviderConnectionById(connection.id);
+
+  assert.equal(updated.rateLimitedUntil, undefined);
+  assert.notEqual(updated.testStatus, "unavailable");
+  assert.ok(!updated.backoffLevel, "connection backoffLevel must not escalate");
+  assert.equal(fallback.isModelLocked("ollama-cloud", connection.id, "deepseek-v4-pro"), true);
 });
 
 test("markAccountUnavailable honors configured api-key rate-limit cooldowns", async () => {


### PR DESCRIPTION
Closes #3027

## Problem
A per-model subscription **403** from Ollama Cloud (e.g. `deepseek-v4-pro` → `403 "this model requires a subscription, upgrade for access"`) cooled down the **entire** `ollama-cloud` connection. While cooled, the **free** models on the same key (e.g. `gemma4:31b`) also became unavailable, and repeated paid-model 403s escalated a connection-wide exponential backoff.

## Root cause
`ollama-cloud` has `passthroughModels: true` → `hasPerModelQuota()` is true, but every model-lockout path missed the 403:
- `classifyProviderError` returns `null` for an apikey-provider 403 (not a credential error) → chatCore's QUOTA_EXHAUSTED lockout never fires.
- The `markAccountUnavailable` per-model gate (`auth.ts`) was `(404 || 429 || >=500)` — **403 excluded**.
- The only 403→model-lockout special case was hard-coded to `grok-web`.
- Fallthrough → `buildRetryableFallback(AUTH_ERROR)` → connection-wide cooldown.

## Fix
`src/sse/services/auth.ts`: after `terminalStatus` is resolved, add a branch — `isPerModelQuotaProvider && status === 403 && model && !terminalStatus` → `recordModelLockoutFailure(..., "forbidden", ...)` and return, leaving the connection active. Generalizes the grok-web precedent to all per-model-quota providers. The `!terminalStatus` guard means banned/deactivated/credits-exhausted 403s keep their connection-level deactivation path.

## Tests (TDD) — `tests/unit/sse-auth.test.ts`
1. **Reproduction:** ollama-cloud subscription 403 → model `deepseek-v4-pro` locked, connection stays `active` (no `rateLimitedUntil`), sibling `gemma4:31b` still usable. *(fails pre-fix)*
2. **Regression:** whole-key 403 (`account has been deactivated`) → connection becomes terminal, NOT model-locked. *(passes both ways)*
3. **Backoff guard:** 3 repeated subscription 403s → no connection-wide cooldown/backoff escalation. *(fails pre-fix)*

`--test-name-pattern="#3027"` → 3 pass / 0 fail (verified RED→GREEN). ESLint clean (0 errors). `typecheck:core` validated on the integration branch (worktree run hit the 7-min `tsc` timeout — environmental).