### PR TITLE
fix(codex): preserve native Responses passthrough tools and history

### DIFF
--- a/open-sse/executors/codex.ts
+++ b/open-sse/executors/codex.ts
@@ -426,6 +426,7 @@ function repairMissingCodexFunctionCallOutputs(body: Record<string, unknown>): v
 // `{ type: "namespace", name: "mcp__atlassian__", tools: [...] }` for MCP tool groups.
 // Keep them through `normalizeCodexTools` so upstream can execute them.
 const CODEX_HOSTED_TOOL_TYPES: ReadonlySet<string> = new Set([
+  "tool_search",
   "image_generation",
   "web_search",
   "web_search_preview",

--- a/open-sse/executors/codex.ts
+++ b/open-sse/executors/codex.ts
@@ -450,7 +450,7 @@ export function isCodexFreePlan(providerSpecificData: unknown): boolean {
 
 export function normalizeCodexTools(
   body: Record<string, unknown>,
-  options?: { dropImageGeneration?: boolean }
+  options?: { dropImageGeneration?: boolean; preserveCustomTools?: boolean }
 ): void {
   if (!Array.isArray(body.tools)) return;
 
@@ -475,6 +475,18 @@ export function normalizeCodexTools(
           }
         }
       }
+      return true;
+    }
+
+    // Native Codex clients send Responses API custom tools such as apply_patch as:
+    // { type: "custom", name, format }. Preserve those only on native passthrough;
+    // translated/non-native requests can still contain provider-specific "custom"
+    // shapes that the Codex backend would reject.
+    if (toolType === "custom" && options?.preserveCustomTools === true) {
+      const name = typeof tool.name === "string" ? tool.name.trim().slice(0, 128) : "";
+      if (!name) return false;
+      tool.name = name;
+      validToolNames.add(name);
       return true;
     }
 
@@ -534,6 +546,12 @@ export function normalizeCodexTools(
             !Array.isArray(functionObject.parameters)
           ? functionObject.parameters
           : { type: "object", properties: {} };
+    const strict =
+      typeof tool.strict === "boolean"
+        ? tool.strict
+        : typeof functionObject?.strict === "boolean"
+          ? functionObject.strict
+          : undefined;
 
     // Rewrite in-place to Responses format
     for (const key of Object.keys(tool)) {
@@ -543,6 +561,7 @@ export function normalizeCodexTools(
     tool.name = name.slice(0, 128);
     if (description) tool.description = description;
     tool.parameters = parameters;
+    if (strict !== undefined) tool.strict = strict;
 
     validToolNames.add(name);
     return true;
@@ -1285,6 +1304,7 @@ export class CodexExecutor extends BaseExecutor {
     // invalid upstream, and translation bugs can leave orphaned/empty tool_choice names.
     normalizeCodexTools(body, {
       dropImageGeneration: isCodexFreePlan(credentials?.providerSpecificData),
+      preserveCustomTools: nativeCodexPassthrough,
     });
 
     // Strip stored response item references (rs_, resp_, msg_ IDs) from input.

--- a/open-sse/executors/codex.ts
+++ b/open-sse/executors/codex.ts
@@ -156,9 +156,7 @@ export interface CodexQuotaSnapshot {
  *   x-codex-5h-usage / x-codex-5h-limit / x-codex-5h-reset-at
  *   x-codex-7d-usage / x-codex-7d-limit / x-codex-7d-reset-at
  */
-export function parseCodexQuotaHeaders(
-  headers: Record<string, string>
-): CodexQuotaSnapshot | null {
+export function parseCodexQuotaHeaders(headers: Record<string, string>): CodexQuotaSnapshot | null {
   const usage5h = headers["x-codex-5h-usage"] ?? null;
   const limit5h = headers["x-codex-5h-limit"] ?? null;
   const resetAt5h = headers["x-codex-5h-reset-at"] ?? null;
@@ -1236,7 +1234,9 @@ export class CodexExecutor extends BaseExecutor {
     }
 
     if (Array.isArray(body.input)) {
-      body.input = sanitizeResponsesInputItems(body.input, false);
+      body.input = sanitizeResponsesInputItems(body.input, false, {
+        dropInternalAssistantMessages: !nativeCodexPassthrough,
+      });
     }
     repairMissingCodexFunctionCallOutputs(body);
 

--- a/open-sse/services/responsesInputSanitizer.ts
+++ b/open-sse/services/responsesInputSanitizer.ts
@@ -1,4 +1,7 @@
 type JsonRecord = Record<string, unknown>;
+type SanitizeResponsesInputOptions = {
+  dropInternalAssistantMessages?: boolean;
+};
 const INTERNAL_ASSISTANT_PHASES = new Set(["commentary"]);
 const SERVER_ITEM_ID_PREFIX_BY_TYPE: Record<string, string> = {
   function_call: "fc_",
@@ -67,12 +70,17 @@ function sanitizeInputItem(item: unknown): unknown {
   return next;
 }
 
-export function sanitizeResponsesInputItems(items: readonly unknown[], clone = true): unknown[] {
+export function sanitizeResponsesInputItems(
+  items: readonly unknown[],
+  clone = true,
+  options: SanitizeResponsesInputOptions = {}
+): unknown[] {
+  const dropInternalAssistantMessages = options.dropInternalAssistantMessages ?? true;
   const sanitized: unknown[] = [];
 
   for (const item of items) {
     const record = toRecord(item);
-    if (record && isInternalAssistantMessage(record)) {
+    if (dropInternalAssistantMessages && record && isInternalAssistantMessage(record)) {
       continue;
     }
 

--- a/tests/unit/executor-codex.test.ts
+++ b/tests/unit/executor-codex.test.ts
@@ -973,6 +973,7 @@ test("CodexExecutor.transformRequest preserves namespace MCP tools and hosted to
           ],
         },
         { type: "image_generation", output_format: "png" },
+        { type: "tool_search" },
         { type: "web_search" },
         { type: "unknown_hosted_tool" },
       ],
@@ -983,7 +984,13 @@ test("CodexExecutor.transformRequest preserves namespace MCP tools and hosted to
   );
 
   const types = (result.tools as Array<Record<string, unknown>>).map((tool) => tool.type);
-  assert.deepEqual(types, ["function", "namespace", "image_generation", "web_search"]);
+  assert.deepEqual(types, [
+    "function",
+    "namespace",
+    "image_generation",
+    "tool_search",
+    "web_search",
+  ]);
 
   const namespaceTool = (result.tools as Array<Record<string, unknown>>).find(
     (tool) => tool.type === "namespace"

--- a/tests/unit/executor-codex.test.ts
+++ b/tests/unit/executor-codex.test.ts
@@ -1003,6 +1003,76 @@ test("CodexExecutor.transformRequest preserves namespace MCP tools and hosted to
   assert.deepEqual(result.tool_choice, { type: "function", name: "jira_get_issue" });
 });
 
+test("CodexExecutor.transformRequest preserves native Codex custom tools", () => {
+  const executor = new CodexExecutor();
+  const result = executor.transformRequest(
+    "gpt-5.5",
+    {
+      _nativeCodexPassthrough: true,
+      model: "gpt-5.5",
+      input: [],
+      tools: [
+        {
+          type: "custom",
+          name: "apply_patch",
+          description: "Use the apply_patch tool to edit files.",
+          format: {
+            type: "grammar",
+            syntax: "lark",
+            definition: "start: /.+/",
+          },
+        },
+        {
+          type: "function",
+          name: "exec_command",
+          description: "Runs a command.",
+          parameters: { type: "object", properties: {} },
+          strict: false,
+        },
+      ],
+    },
+    true,
+    { requestEndpointPath: "/responses" }
+  );
+
+  const tools = result.tools as Array<Record<string, unknown>>;
+  assert.equal(tools.length, 2);
+  assert.deepEqual(tools[0], {
+    type: "custom",
+    name: "apply_patch",
+    description: "Use the apply_patch tool to edit files.",
+    format: {
+      type: "grammar",
+      syntax: "lark",
+      definition: "start: /.+/",
+    },
+  });
+  assert.equal(tools[1].strict, false);
+});
+
+test("CodexExecutor.transformRequest still drops custom tools outside native passthrough", () => {
+  const executor = new CodexExecutor();
+  const result = executor.transformRequest(
+    "gpt-5.5",
+    {
+      model: "gpt-5.5",
+      input: [],
+      tools: [
+        { type: "custom", name: "apply_patch", format: { type: "grammar" } },
+        { type: "function", name: "exec_command", parameters: { type: "object" } },
+      ],
+    },
+    true,
+    { requestEndpointPath: "/responses" }
+  );
+
+  const tools = result.tools as Array<Record<string, unknown>>;
+  assert.deepEqual(
+    tools.map((tool) => tool.name),
+    ["exec_command"]
+  );
+});
+
 test("CodexExecutor maps Codex websocket error events to response.failed SSE", () => {
   const raw = JSON.stringify({
     type: "error",

--- a/tests/unit/executor-codex.test.ts
+++ b/tests/unit/executor-codex.test.ts
@@ -450,7 +450,7 @@ test("CodexExecutor.transformRequest strips store from compact requests even whe
   assert.equal(result.instructions, "keep this");
 });
 
-test("CodexExecutor.transformRequest strips raw internal assistant commentary without dropping useful Responses items", () => {
+test("CodexExecutor.transformRequest preserves native assistant commentary history", () => {
   const executor = new CodexExecutor();
   const body = {
     _nativeCodexPassthrough: true,
@@ -508,7 +508,7 @@ test("CodexExecutor.transformRequest strips raw internal assistant commentary wi
 
   assert.equal(
     result.input.some((item) => JSON.stringify(item).includes("Need maybe inspect tool output")),
-    false
+    true
   );
   assert.equal(
     result.input.some((item) => JSON.stringify(item).includes("Visible final assistant answer")),
@@ -536,6 +536,46 @@ test("CodexExecutor.transformRequest strips raw internal assistant commentary wi
   );
   assert.equal(
     result.input.some((item) => item.type === "function_call_output"),
+    true
+  );
+});
+
+test("CodexExecutor.transformRequest still strips assistant commentary outside native passthrough", () => {
+  const executor = new CodexExecutor();
+  const result = executor.transformRequest(
+    "gpt-5.5-low",
+    {
+      input: [
+        {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "Continue." }],
+        },
+        {
+          type: "message",
+          role: "assistant",
+          phase: "commentary",
+          content: [{ type: "output_text", text: "Internal progress note." }],
+        },
+        {
+          type: "message",
+          role: "assistant",
+          phase: "final_answer",
+          content: [{ type: "output_text", text: "Visible final answer." }],
+        },
+      ],
+      stream: false,
+    },
+    false,
+    { requestEndpointPath: "/responses" }
+  );
+
+  assert.equal(
+    result.input.some((item) => JSON.stringify(item).includes("Internal progress note")),
+    false
+  );
+  assert.equal(
+    result.input.some((item) => JSON.stringify(item).includes("Visible final answer")),
     true
   );
 });
@@ -587,7 +627,7 @@ test("CodexExecutor.transformRequest inserts missing function_call_output items"
   });
 });
 
-test("CodexExecutor.transformRequest strips internal assistant commentary before mapping messages to input", () => {
+test("CodexExecutor.transformRequest preserves native assistant commentary before mapping messages to input", () => {
   const executor = new CodexExecutor();
   const result = executor.transformRequest(
     "gpt-5.5-low",
@@ -614,7 +654,7 @@ test("CodexExecutor.transformRequest strips internal assistant commentary before
 
   assert.equal(
     result.input.some((item) => JSON.stringify(item).includes("Need maybe update PR body")),
-    false
+    true
   );
   assert.equal(
     result.input.some((item) => JSON.stringify(item).includes("Visible final assistant answer")),


### PR DESCRIPTION
## Summary

This PR fixes several Codex native Responses passthrough regressions where OmniRoute was dropping protocol-native tools or history items before forwarding requests to the Codex backend.

Changes:

- Preserve the Responses API `tool_search` hosted tool in `normalizeCodexTools()`.
- Preserve native Codex `custom` tools such as `apply_patch`, including their freeform grammar `format`.
- Preserve function tool `strict` values when normalizing Codex tools.
- Preserve native assistant history messages with `phase: "commentary"` and `output_text` content in Codex native passthrough mode.
- Keep the previous sanitizer behavior for non-native / translated paths, so assistant commentary is still stripped outside Codex native passthrough.

## Background

Recent Codex CLI versions send richer native Responses API payloads through `/v1/responses`. These payloads include protocol-native items that are not plain OpenAI-compatible function tools:

- Codex CLI 0.136 multi-agent v1 discovery can expose subagent tools through the hosted `{ "type": "tool_search" }` tool.
- Native `apply_patch` is sent as a Responses API custom/freeform tool:
  `{ "type": "custom", "name": "apply_patch", "format": ... }`.
- Codex conversation history can include assistant messages with:
  `{ "role": "assistant", "phase": "commentary", "content": [{ "type": "output_text", ... }] }`.

The official Codex client treats these as valid Responses API protocol items. It also sets `store=false` for the ChatGPT Codex backend, so follow-up turns rely on replaying necessary history through `input`.

## Problem

OmniRoute previously normalized Codex requests too aggressively:

- Unknown hosted tools were dropped, including `tool_search`.
- Native `custom` tools were dropped unless they looked like function tools.
- Assistant `phase: "commentary"` history was treated as an internal runtime frame and removed, even in native Codex passthrough mode.

As a result, the upstream Codex backend could receive an incomplete version of the native client request.

## Impact

Affected scenarios include:

- Codex CLI 0.136 multi-agent v1 tool discovery.
- Native Codex `apply_patch` / freeform custom tool calls.
- Multi-turn Codex workflows where assistant commentary/history is replayed through `/v1/responses`.
- Long-running agent flows where prior visible assistant progress messages help preserve execution context.

Without this fix, the model may be unable to discover subagent tools, unable to call native custom tools, or lose part of the assistant history between turns.

## Fix

This PR keeps the behavior scoped by path:

- In Codex native passthrough mode, preserve native Responses API tools and assistant commentary history.
- Outside native passthrough, keep the existing stricter cleanup behavior to avoid forwarding commentary from translated/non-native clients.

## Validation

- [ ] `npm run lint`
- [ ] `npm run test:unit`
- [ ] `npm run test:coverage`
- [ ] Coverage is still `>= 60%` for statements, lines, functions, and branches
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below

Targeted validation:

```bash
node --import tsx/esm --test tests/unit/executor-codex.test.ts
node --import tsx/esm --test tests/unit/responses-input-sanitizer-name.test.ts
```

Results:

- `tests/unit/executor-codex.test.ts`: 39 passed, 0 failed
- `tests/unit/responses-input-sanitizer-name.test.ts`: 8 passed, 0 failed

Manual integration validation:

- Deployed the patched OmniRoute build locally with Docker Compose.
- Confirmed the running container includes the patched Codex executor and sanitizer files.
- Confirmed the service starts healthy.
- Confirmed custom Docker Compose mounts were preserved during local deployment.
- Previously validated Codex CLI 0.136 with:
  - `features.multi_agent=true`
  - `features.multi_agent_v2=false`
  - Responses API provider
- Confirmed `tool_search` returns:
  - `multi_agent_v1.spawn_agent`
  - `multi_agent_v1.resume_agent`
  - `multi_agent_v1.close_agent`
  - `multi_agent_v1.wait_agent`
  - `multi_agent_v1.send_input`
- Confirmed a v1 subagent can be spawned and waited successfully.

## Tests Added Or Updated

- Updated `tests/unit/executor-codex.test.ts`
  - Covers preserving `{ type: "tool_search" }`.
  - Covers preserving native Codex custom tools.
  - Covers preserving function tool `strict`.
  - Covers preserving native assistant `phase: "commentary"` history.
  - Covers continuing to strip assistant commentary outside native passthrough.

## Coverage Notes

The production change is limited to Codex request normalization and Responses input sanitization behavior. No migrations, UI changes, or broad routing changes are included.

## Reviewer Notes

- This PR now contains three focused commits:
  - `fix(codex): preserve tool_search hosted tool`
  - `fix(codex): preserve native custom tools`
  - `fix(codex): preserve native assistant commentary history`
- The second and third commits are follow-up fixes discovered while testing the same Codex native Responses passthrough path.
- The sanitizer change is intentionally opt-in for native passthrough; default behavior remains unchanged.
