### PR TITLE
fix(sse): emit reasoning/content as separate SSE deltas, no duplication (#3089 follow-up)

### DIFF
--- a/open-sse/utils/jsonToSse.ts
+++ b/open-sse/utils/jsonToSse.ts
@@ -49,21 +49,26 @@ export function synthesizeOpenAiSseFromJson(jsonText: string): string {
     const index = typeof choice.index === "number" ? choice.index : fallbackIndex;
     const message = isRecord(choice.message) ? choice.message : {};
 
-    // First chunk carries role + whatever the message produced (content,
-    // reasoning_content, tool_calls). Putting them in one delta is valid and
-    // keeps downstream translation simple.
-    const delta: JsonRecord = { role: typeof message.role === "string" ? message.role : "assistant" };
-    if (typeof message.content === "string" && message.content.length > 0) {
-      delta.content = message.content;
-    }
+    // Emit role, reasoning_content, content and tool_calls as SEPARATE sequential
+    // deltas — the same shape a real reasoning model streams (reasoning first,
+    // then content). Combining them in one delta caused the openai→openai
+    // translator to re-split and DUPLICATE reasoning_content across chunks
+    // (#3089 follow-up); separate deltas pass through cleanly with no duplication.
+    const role = typeof message.role === "string" ? message.role : "assistant";
+    const emitDelta = (delta: JsonRecord) => {
+      out += sseEvent({ ...base, choices: [{ index, delta, finish_reason: null }] });
+    };
+
+    emitDelta({ role });
     if (typeof message.reasoning_content === "string" && message.reasoning_content.length > 0) {
-      delta.reasoning_content = message.reasoning_content;
+      emitDelta({ reasoning_content: message.reasoning_content });
+    }
+    if (typeof message.content === "string" && message.content.length > 0) {
+      emitDelta({ content: message.content });
     }
     if (Array.isArray(message.tool_calls) && message.tool_calls.length > 0) {
-      delta.tool_calls = message.tool_calls;
+      emitDelta({ tool_calls: message.tool_calls });
     }
-
-    out += sseEvent({ ...base, choices: [{ index, delta, finish_reason: null }] });
 
     const finishReason =
       typeof choice.finish_reason === "string" && choice.finish_reason ? choice.finish_reason : "stop";

--- a/tests/unit/json-to-sse-3089.test.ts
+++ b/tests/unit/json-to-sse-3089.test.ts
@@ -37,14 +37,26 @@ describe("synthesizeOpenAiSseFromJson (#3089)", () => {
     assert.ok(sse.startsWith("data: "), "must be SSE");
     assert.equal(chunks[chunks.length - 1], "[DONE]", "must terminate with [DONE]");
 
-    const first = JSON.parse(chunks[0]);
-    assert.equal(first.object, "chat.completion.chunk");
-    assert.equal(first.model, "mock-reasoner");
-    assert.equal(first.choices[0].delta.role, "assistant");
-    assert.equal(first.choices[0].delta.content, "HI there");
-    assert.equal(first.choices[0].delta.reasoning_content, "thinking...");
+    const events = chunks.filter((c) => c !== "[DONE]").map((c) => JSON.parse(c));
+    const deltas = events.map((e) => e.choices[0].delta);
 
-    const finishChunk = JSON.parse(chunks[1]);
+    assert.equal(events[0].object, "chat.completion.chunk");
+    assert.equal(events[0].model, "mock-reasoner");
+    assert.equal(deltas[0].role, "assistant", "first delta announces the role");
+
+    // #3089 follow-up: reasoning_content and content are emitted as SEPARATE
+    // deltas, each EXACTLY ONCE (no duplication), with reasoning before content.
+    const reasoningDeltas = deltas.filter((d) => d.reasoning_content !== undefined);
+    const contentDeltas = deltas.filter((d) => d.content !== undefined);
+    assert.equal(reasoningDeltas.length, 1, "reasoning_content must appear exactly once");
+    assert.equal(contentDeltas.length, 1, "content must appear exactly once");
+    assert.equal(reasoningDeltas[0].reasoning_content, "thinking...");
+    assert.equal(contentDeltas[0].content, "HI there");
+    const reasoningIdx = deltas.findIndex((d) => d.reasoning_content !== undefined);
+    const contentIdx = deltas.findIndex((d) => d.content !== undefined);
+    assert.ok(reasoningIdx < contentIdx, "reasoning_content delta precedes content delta");
+
+    const finishChunk = events[events.length - 1];
     assert.equal(finishChunk.choices[0].finish_reason, "stop");
     assert.deepEqual(finishChunk.usage, { prompt_tokens: 7, completion_tokens: 3, total_tokens: 10 });
   });
@@ -53,9 +65,11 @@ describe("synthesizeOpenAiSseFromJson (#3089)", () => {
     const sse = synthesizeOpenAiSseFromJson(
       JSON.stringify({ choices: [{ message: { role: "assistant", content: "ok" } }] })
     );
-    const first = JSON.parse(parseDataChunks(sse)[0]);
-    assert.equal(first.choices[0].delta.content, "ok");
-    assert.equal("reasoning_content" in first.choices[0].delta, false);
+    const deltas = parseDataChunks(sse)
+      .filter((c) => c !== "[DONE]")
+      .map((c) => JSON.parse(c).choices[0].delta);
+    assert.equal(deltas.filter((d) => d.content === "ok").length, 1);
+    assert.equal(deltas.some((d) => d.reasoning_content !== undefined), false);
   });
 
   test("forwards tool_calls in the delta", () => {
@@ -72,8 +86,12 @@ describe("synthesizeOpenAiSseFromJson (#3089)", () => {
         ],
       })
     );
-    const first = JSON.parse(parseDataChunks(sse)[0]);
-    assert.equal(first.choices[0].delta.tool_calls[0].id, "t1");
+    const deltas = parseDataChunks(sse)
+      .filter((c) => c !== "[DONE]")
+      .map((c) => JSON.parse(c).choices[0].delta);
+    const toolDelta = deltas.find((d) => Array.isArray(d.tool_calls));
+    assert.ok(toolDelta, "a delta must carry tool_calls");
+    assert.equal(toolDelta.tool_calls[0].id, "t1");
   });
 
   test("returns empty string for non-completion JSON / invalid JSON", () => {


### PR DESCRIPTION
Follow-up to #3108 (#3089/#2952).

## Problem
`synthesizeOpenAiSseFromJson` emitted `role` + `content` + `reasoning_content` in a **single** delta. On the live #3089 path the openai→openai translator re-split that combined delta and **duplicated `reasoning_content`** across two chunks (content stayed correct). Validated on the local VM.

## Fix
Emit `role`, `reasoning_content`, `content`, and `tool_calls` as **separate sequential deltas** (reasoning before content) — the shape a real reasoning model streams — so the translator passes them through unchanged.

## Validated end-to-end on the VM (mock reasoning upstream returning JSON)
- **#3089** (stream omitted): `200 text/event-stream`, `reasoning_content` delta **×1**, `content` delta **×1**, reasoning before content, no duplication.
- **#2952** (cache hit, `temperature:0`, stream): `x-omniroute-cache: HIT`, SSE, `reasoning_content` ×1 + `content` ×1.

Unit tests updated to assert each field appears exactly once and reasoning precedes content (4 pass). ESLint clean.