### PR TITLE
feat(kiro): add Claude Opus 4.8 to the Kiro model catalog

### DIFF
--- a/open-sse/config/providerRegistry.ts
+++ b/open-sse/config/providerRegistry.ts
@@ -1067,6 +1067,12 @@ const _REGISTRY_EAGER: Record<string, RegistryEntry> = {
     models: [
       { id: "auto-kiro", name: "Auto (Kiro picks best model)" },
       {
+        id: "claude-opus-4.8",
+        name: "Claude Opus 4.8",
+        contextLength: 1000000,
+        maxOutputTokens: 128000,
+      },
+      {
         id: "claude-opus-4.7",
         name: "Claude Opus 4.7",
         contextLength: 1000000,

--- a/src/shared/constants/pricing.ts
+++ b/src/shared/constants/pricing.ts
@@ -1304,6 +1304,20 @@ export const DEFAULT_PRICING = {
       reasoning: 15.0,
       cache_creation: 3.0,
     },
+    "claude-opus-4.8": {
+      input: 15.0,
+      output: 75.0,
+      cached: 7.5,
+      reasoning: 75.0,
+      cache_creation: 15.0,
+    },
+    "claude-opus-4.7": {
+      input: 15.0,
+      output: 75.0,
+      cached: 7.5,
+      reasoning: 75.0,
+      cache_creation: 15.0,
+    },
     "claude-opus-4.6": {
       input: 15.0,
       output: 75.0,

--- a/tests/unit/catalog-updates-v3x.test.ts
+++ b/tests/unit/catalog-updates-v3x.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 
 import { getModelsByProviderId } from "../../open-sse/config/providerModels.ts";
 import { resolveCanonicalProviderModel } from "../../open-sse/services/model.ts";
+import { DEFAULT_PRICING } from "../../src/shared/constants/pricing.ts";
 
 test("Pollinations catalog mirrors the current public text model lineup", () => {
   const models = getModelsByProviderId("pollinations");
@@ -44,4 +45,20 @@ test("NVIDIA catalog includes the verified 2026 additions and GPT OSS 20B alias 
     provider: "nvidia",
     model: "openai/gpt-oss-20b",
   });
+});
+
+test("Kiro catalog exposes Claude Opus 4.8 alongside 4.7 with matching pricing", () => {
+  const models = getModelsByProviderId("kiro");
+  const ids = new Set(models.map((model) => model.id));
+
+  assert.ok(ids.has("claude-opus-4.8"), "kiro must expose claude-opus-4.8");
+  assert.ok(ids.has("claude-opus-4.7"), "kiro must still expose claude-opus-4.7");
+
+  const opus48 = models.find((model) => model.id === "claude-opus-4.8");
+  assert.equal(opus48?.contextLength, 1000000);
+  assert.equal(opus48?.maxOutputTokens, 128000);
+
+  // Pricing for the Kiro channel must cover the new model so usage cost is non-zero.
+  const kiroPricing = (DEFAULT_PRICING as Record<string, Record<string, unknown>>).kiro;
+  assert.ok(kiroPricing["claude-opus-4.8"], "kiro pricing must include claude-opus-4.8");
 });


### PR DESCRIPTION
## Summary

Kiro (AWS CodeWhisperer) currently tops out at **Claude Opus 4.7** in the provider registry, even though:

- Claude **Opus 4.8** is already defined and served by the `claude` (Claude Code) provider, and
- the Kiro executor's `openai-to-kiro` translator passes the requested model id straight through to CodeWhisperer (`userInputMessage.modelId`), so no special model mapping is required for a new Claude model.

This PR exposes `claude-opus-4.8` on the `kiro` provider so clients can select it via `kiro/claude-opus-4.8` (and `kr/claude-opus-4.8`), consistent with how `claude-opus-4.7` is already wired.

## Changes

- **`open-sse/config/providerRegistry.ts`** — add `claude-opus-4.8` to the `kiro` models list (1M context, 128k max output), placed above `claude-opus-4.7`.
- **`src/shared/constants/pricing.ts`** — add `claude-opus-4.8` to the `kiro` pricing block at Kiro's standard Opus rate (`$15 / $75` per 1M, matching the existing `claude-opus-4.6` Kiro entry). Also adds the previously-missing `claude-opus-4.7` entry to the same block so its usage cost is no longer `$0`.
- **`tests/unit/catalog-updates-v3x.test.ts`** — new assertion that the Kiro catalog exposes `claude-opus-4.8` (with the expected context/output) and that the Kiro pricing block covers it.

## Why the pricing rate

The new Kiro entries follow the rate already used by the existing `kiro` → `claude-opus-4.6` entry (`$15/$75`), keeping the Kiro channel internally consistent. Adjust if Kiro should mirror the Claude Code (`cc`) Opus rate instead.

## Testing

```
node --import tsx --test tests/unit/catalog-updates-v3x.test.ts
```

All tests pass, including the new `Kiro catalog exposes Claude Opus 4.8 alongside 4.7 with matching pricing` case.
