### PR TITLE
Fix：Add KimiExecutor to fix  the error of reasoning_content is missing in kimi thing mode

### DIFF
--- a/open-sse/executors/index.ts
+++ b/open-sse/executors/index.ts
@@ -129,6 +129,7 @@ const executors = {
   "kimi-web": new KimiWebExecutor(),
   kimi: new KimiWebExecutor(), // Alias
   "kimi-coding-apikey": new KimiExecutor(), // Alias
+  "kimi-coding": new KimiExecutor(), // Alias
   "doubao-web": new DoubaoWebExecutor(),
   db: new DoubaoWebExecutor(), // Alias
   "qwen-web": new QwenWebExecutor(),

--- a/open-sse/executors/index.ts
+++ b/open-sse/executors/index.ts
@@ -46,6 +46,7 @@ import { V0VercelWebExecutor } from "./v0-vercel-web.ts";
 import { KimiWebExecutor } from "./kimi-web.ts";
 import { DoubaoWebExecutor } from "./doubao-web.ts";
 import { QwenWebExecutor } from "./qwen-web.ts";
+import { KimiExecutor } from "./kimi.ts"
 
 const executors = {
   antigravity: new AntigravityExecutor(),
@@ -127,6 +128,7 @@ const executors = {
   v0: new V0VercelWebExecutor(), // Alias
   "kimi-web": new KimiWebExecutor(),
   kimi: new KimiWebExecutor(), // Alias
+  "kimi-coding-apikey": new KimiExecutor(), // Alias
   "doubao-web": new DoubaoWebExecutor(),
   db: new DoubaoWebExecutor(), // Alias
   "qwen-web": new QwenWebExecutor(),

--- a/open-sse/executors/kimi.ts
+++ b/open-sse/executors/kimi.ts
@@ -66,7 +66,6 @@ function applyKimiRequestDefaults(body: unknown, defaults?: JsonRecord | null): 
   const withDefaults = applyProviderRequestDefaults(body, defaults);
   const record = asRecord(withDefaults);
   if (record && hasActiveKimiThinking(record) && hasTools(record)) {
-    // 此处 kimi 开启了 thinking 功能且存在工具调用，确保 tool_calls 中包含 reasoning_content 字段以兼容老版本 Kimi 后端的要求
     return ensureToolCallReasoningContent(record);
   }
   return withDefaults;

--- a/open-sse/executors/kimi.ts
+++ b/open-sse/executors/kimi.ts
@@ -63,15 +63,13 @@ function asRecord(value: unknown): JsonRecord | null {
 }
 
 function applyKimiRequestDefaults(body: unknown, defaults?: JsonRecord | null): unknown {
-  const record = asRecord(body);
-  if (hasActiveKimiThinking(record ?? {}) && hasTools(record ?? {})) { 
+  const withDefaults = applyProviderRequestDefaults(body, defaults);
+  const record = asRecord(withDefaults);
+  if (record && hasActiveKimiThinking(record) && hasTools(record)) {
     // 此处 kimi 开启了 thinking 功能且存在工具调用，确保 tool_calls 中包含 reasoning_content 字段以兼容老版本 Kimi 后端的要求
-    return ensureToolCallReasoningContent(record ?? {});
-   }
-
-  // 其他默认值
-  return applyProviderRequestDefaults(body, defaults);
-
+    return ensureToolCallReasoningContent(record);
+  }
+  return withDefaults;
 }
 
 export class KimiExecutor extends DefaultExecutor {

--- a/open-sse/executors/kimi.ts
+++ b/open-sse/executors/kimi.ts
@@ -1,0 +1,93 @@
+
+import { DefaultExecutor } from "./default.ts";
+type JsonRecord = Record<string, unknown>;
+import {
+  type ProviderCredentials,
+} from "./base.ts";
+
+import { applyProviderRequestDefaults } from "../services/providerRequestDefaults.ts";
+
+function hasActiveKimiThinking(body: JsonRecord): boolean {
+  const reasoningEffort = body.reasoning_effort;
+  if (typeof reasoningEffort === "string") {
+    const normalized = reasoningEffort.trim().toLowerCase();
+    if (normalized && normalized !== "off" && normalized !== "none") return true;
+  }
+
+  const reasoning = body.reasoning;
+  if (reasoning && typeof reasoning === "object" && !Array.isArray(reasoning)) {
+    const reasoningRecord = reasoning as JsonRecord;
+    const effort = reasoningRecord.effort;
+    if (typeof effort === "string") {
+      const normalized = effort.trim().toLowerCase();
+      if (normalized && normalized !== "off" && normalized !== "none") return true;
+    }
+    if (reasoningRecord.enabled === true || reasoningRecord.type === "enabled") return true;
+  }
+
+  const thinking = body.thinking;
+  if (thinking && typeof thinking === "object" && !Array.isArray(thinking)) {
+    const thinkingRecord = thinking as JsonRecord;
+    return thinkingRecord.type === "enabled" || thinkingRecord.type === "adaptive";
+  }
+
+  return false;
+}
+
+function ensureToolCallReasoningContent(body: JsonRecord): JsonRecord {
+  if (!hasActiveKimiThinking(body) || !Array.isArray(body.messages)) return body;
+
+  let changed = false;
+  const messages = body.messages.map((message: unknown) => {
+    if (!message || typeof message !== "object" || Array.isArray(message)) return message;
+
+    const msg = message as JsonRecord;
+    if (msg.role !== "assistant" || !Array.isArray(msg.tool_calls)) return message;
+    if (Object.prototype.hasOwnProperty.call(msg, "reasoning_content")) return message;
+
+    changed = true;
+    return { ...msg, reasoning_content: "" };
+  });
+
+  return changed ? { ...body, messages } : body;
+}
+
+function hasTools(body: unknown): boolean {
+  const record = asRecord(body);
+  return Array.isArray(record?.tools) && record.tools.length > 0;
+}
+
+
+function asRecord(value: unknown): JsonRecord | null {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as JsonRecord) : null;
+}
+
+function applyKimiRequestDefaults(body: unknown, defaults?: JsonRecord | null): unknown {
+  const record = asRecord(body);
+  if (hasActiveKimiThinking(record ?? {}) && hasTools(record ?? {})) { 
+    // 此处 kimi 开启了 thinking 功能且存在工具调用，确保 tool_calls 中包含 reasoning_content 字段以兼容老版本 Kimi 后端的要求
+    return ensureToolCallReasoningContent(record ?? {});
+   }
+
+  // 其他默认值
+  return applyProviderRequestDefaults(body, defaults);
+
+}
+
+export class KimiExecutor extends DefaultExecutor {
+  constructor(provider = "kimi-coding") {
+    super(provider);
+  }
+
+  transformRequest(
+    model: string,
+    body: unknown,
+    stream: boolean,
+    credentials: ProviderCredentials
+  ) {
+    const cleanedBody = super.transformRequest(model, body, stream, credentials);
+    return applyKimiRequestDefaults(cleanedBody);
+  }
+}
+
+export default KimiExecutor;


### PR DESCRIPTION
## Summary

- Describe the user-facing or operational change.

## Related Issues

- Closes #
- Related to #

## Validation

- [ ] `npm run lint`
- [ ] `npm run test:unit`
- [ ] `npm run test:coverage`
- [ ] Coverage is still `>= 60%` for statements, lines, functions, and branches
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below

## Tests Added Or Updated

- List every changed or added automated test file.
- If no production code changed, state that here.

## Coverage Notes

- If this PR changes `src/`, `open-sse/`, `electron/`, or `bin/`, explain which tests cover the change.
- If coverage moved down in any touched file, explain why and what follow-up task will recover it.

## Reviewer Notes

- Call out any risky areas, migrations, feature flags, or manual validation that reviewers should know about.