### PR TITLE
Release v3.8.9 — final sync (static-asset fix + contributor credits)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - **cursor:** vision (`image_url`) input for the Cursor provider — OpenAI image parts are encoded as `SelectedContext.selected_images[]` in the `agent.v1` protobuf, plus a tool-commit directive (lifts composer-2.5's tool-call rate), `tool_choice` none/required/specific handling, and `response_format`/`max_tokens`/`stop` output constraints surfaced to the agent. Hardened with SSRF + DNS-rebinding guards, a 1 MiB pre-decode cap, and a protobuf length-overrun check. (#3104 — thanks @payne0420)
 - **deepseek-web:** opt-in persistent session + rolling-window conversation memory (`persistSession`, `historyWindow` per-connection settings) and bidirectional tool-call translation — tool schemas are injected as a system prompt and `<tool>{…}</tool>` blocks in the reply are parsed back into OpenAI `tool_calls` (replacing the old hard `400`). ([#2942](https://github.com/diegosouzapw/OmniRoute/issues/2942), [#2820](https://github.com/diegosouzapw/OmniRoute/issues/2820))
 - **i18n:** Turkish locale-aware search & sorting — a `turkishText` helper (`normalizeForSearch`, `matchesSearch`, `compareTr`) folds the dotted/dotless İ/ı correctly and uses `Intl.Collator("tr")`, wired across dashboard search/sort call-sites with an ESLint guard (warn) against raw `toLowerCase().includes()`. (#3115 — thanks @osrt91)
+- **kiro:** add Claude Opus 4.8 to the Kiro (AWS CodeWhisperer) model catalog — Kiro previously topped out at Opus 4.7 even though Opus 4.8 was already defined and served by the `claude` provider. (#3131 — thanks @artickc)
 
 ### 🔧 Bug Fixes
 
@@ -44,11 +45,14 @@
 - **cli:** handle Windows `.exe` healthchecks with spaces in the path — direct executables skip the shell (so `cmd.exe` doesn't split `C:\…\Name With Spaces\…\claude.exe`) while `.cmd`/`.bat` wrappers still run through it. (#3111 — thanks @EmpRider)
 - **cli:** don't write `STORAGE_ENCRYPTION_KEY` to `.env` on informational commands — `omniroute --version`/`--help` no longer generate a key or create `~/.omniroute/.env`; provisioning is scoped to commands that actually touch encrypted storage (#3129).
 - **tests:** remove a stale lowercase `db-apikeys-crud.test.ts` duplicate that collided with the canonical `db-apiKeys-crud.test.ts` on case-insensitive filesystems (no coverage lost). (#3125 — thanks @juandisay)
+- **kimi:** add a dedicated `KimiExecutor` so Kimi thinking-mode responses no longer drop `reasoning_content` — the reasoning stream is now surfaced instead of being lost. (#3132 — thanks @bypanghu)
+- **handler:** provide a `connectionId` fallback when it is undefined, fixing kilo (kilocode) calls that were silently not being written to `call_logs`. (#3130 — thanks @androw)
 
 ### 🔧 Build
 
 - **build-output-isolation:** unified standalone assembly into one shared `assembleStandalone` module; isolated build output into `.build/` (intermediates, gitignored) and `dist/` (shippable bundle, gitignored), replacing the old repo-root `app/` and `.next/` directories; dropped the duplicate `next build` that prepublish previously ran; added `build:release` script for a clean rebuild with a `dist/BUILD_SHA` HEAD sentinel that guards against deploying stale bundles. **Operators using custom `app/` paths:** the published bundle directory on the VPS image (`/usr/lib/node_modules/omniroute/app/`) is unchanged — only the in-repo build output path moved. Update any local scripts that reference the repo-local `app/` build output to `dist/` instead.
 - **build:** re-apply the build-reorg follow-ups that landed after the main refactor merged — the `serve` CLI now falls back from `dist/` to the legacy `app/` location for upgrade safety, and the deploy skills `pm2 stop` before `rsync --delete` to avoid a transient `Cannot find module ./chunks/…` race (#3127).
+- **build:** fix the standalone static-asset path so the dashboard renders after the build-output reorg — `assembleStandalone` was copying `static/` into `<bundle>/.next/static`, but the standalone server (built with `distDir=.build/next`) serves `/_next/static` from `<bundle>/.build/next/static`, so every JS/CSS chunk 404'd and the login UI rendered as a blank page. The static (and `required-server-files.json` / Turbopack chunk) destinations are now derived from the configured `distDir` instead of a hard-coded `.next`.
 
 ### 📦 Dependencies
 
@@ -62,7 +66,7 @@
 
 Huge thanks to everyone whose work shipped in v3.8.9:
 
-@branben (Obsidian context source), @oyi77 (claude-web 403 fix, autoCombo connection rotation), @xz-dev (SiliconFlow model sync), @nmime (open opaque tool schemas), @payne0420 (Cursor vision input), @mgarmash (image-gen fetch timeout), @yinaoxiong (Codex native passthrough tools/history), @0xtbug (logs page perf), @EmpRider (Windows CLI healthcheck paths), @ahmet-cetinkaya (Antigravity 429 retry bound + quota lockout), @juandisay (duplicate test cleanup), and @osrt91 (Turkish locale-aware search & sorting).
+@branben (Obsidian context source), @oyi77 (claude-web 403 fix, autoCombo connection rotation), @xz-dev (SiliconFlow model sync), @nmime (open opaque tool schemas), @payne0420 (Cursor vision input), @mgarmash (image-gen fetch timeout), @yinaoxiong (Codex native passthrough tools/history), @0xtbug (logs page perf), @EmpRider (Windows CLI healthcheck paths), @ahmet-cetinkaya (Antigravity 429 retry bound + quota lockout), @juandisay (duplicate test cleanup), @osrt91 (Turkish locale-aware search & sorting), @artickc (Kiro Opus 4.8 catalog), @bypanghu (Kimi thinking-mode reasoning_content fix), and @androw (connectionId fallback + kilo call logging).
 
 And thank you to the OmniRoute community for the bug reports, reproductions, and testing that drove these fixes. 🎉
 

--- a/scripts/build/assembleStandalone.mjs
+++ b/scripts/build/assembleStandalone.mjs
@@ -283,11 +283,13 @@ async function syncExtraModulesToDir(projectRoot, outDir, fsImpl, log) {
  * @param {string} outDir       - assembled standalone output directory
  * @returns {number} number of path replacements made
  */
-export function assemblePathSanitize(projectRoot, outDir) {
+export function assemblePathSanitize(projectRoot, outDir, distDir = ".next") {
   const buildRoot = projectRoot.replace(/\\/g, "/"); // normalise for regex safety
   const sanitizeTargets = [
     path.join(outDir, "server.js"),
-    path.join(outDir, ".next", "required-server-files.json"),
+    // required-server-files.json lives under the distDir (e.g. .build/next), not
+    // a literal .next — the standalone preserves the configured distDir path.
+    path.join(outDir, distDir, "required-server-files.json"),
   ];
 
   let sanitisedCount = 0;
@@ -316,8 +318,8 @@ export function assemblePathSanitize(projectRoot, outDir) {
  * @param {string} outDir - assembled standalone output directory
  * @returns {{ patchedFiles: number, patchedMatches: number }}
  */
-export function patchTurbopackChunks(outDir) {
-  const serverOutput = path.join(outDir, ".next", "server");
+export function patchTurbopackChunks(outDir, distDir = ".next") {
+  const serverOutput = path.join(outDir, distDir, "server");
   const HASH_RE = /(['"\\])([a-z@][a-z0-9@./_-]+?-[0-9a-f]{16}(?:\/[^'"\\]+)?)\1/g;
   let patchedFiles = 0;
   let patchedMatches = 0;
@@ -392,6 +394,12 @@ export function assembleStandalone({
   if (!distDir) throw new Error("[assembleStandalone] distDir is required");
   if (!outDir) throw new Error("[assembleStandalone] outDir is required");
 
+  // The standalone bundle preserves the distDir path RELATIVE to projectRoot
+  // (the server's baked config uses e.g. "./.build/next"), so output dest paths
+  // for static / required-server-files / server chunks must use the relative
+  // distDir appended to outDir — never the absolute build-machine distDir.
+  const relDistDir = path.isAbsolute(distDir) ? path.relative(projectRoot, distDir) : distDir;
+
   const standaloneDir = path.resolve(path.join(distDir, "standalone"));
   const resolvedOutDir = path.resolve(outDir);
   if (!fsSync.existsSync(standaloneDir)) {
@@ -425,9 +433,13 @@ export function assembleStandalone({
     }
   }
 
-  // 2. Copy <distDir>/static -> resolvedOutDir/.next/static
+  // 2. Copy <distDir>/static -> resolvedOutDir/<distDir>/static
+  // CRITICAL: the standalone server.js is built with distDir baked into its config
+  // (e.g. "./.build/next"), so it serves /_next/static from <outDir>/<distDir>/static,
+  // NOT a literal <outDir>/.next/static. Copying to .next/static leaves the server's
+  // static dir empty → every JS/CSS chunk 404s → blank page. Mirror the distDir path.
   const staticSrc = path.join(distDir, "static");
-  const staticDest = path.join(resolvedOutDir, ".next", "static");
+  const staticDest = path.join(resolvedOutDir, relDistDir, "static");
   if (fsSync.existsSync(staticSrc)) {
     fsSync.mkdirSync(path.dirname(staticDest), { recursive: true });
     fsSync.cpSync(staticSrc, staticDest, { recursive: true, force: true });
@@ -442,7 +454,7 @@ export function assembleStandalone({
 
   // 4. Optionally sanitize abs paths
   if (sanitizePaths) {
-    const count = assemblePathSanitize(projectRoot, resolvedOutDir);
+    const count = assemblePathSanitize(projectRoot, resolvedOutDir, relDistDir);
     if (count > 0) {
       console.log(`[assembleStandalone] Sanitised ${count} hardcoded path references`);
     }
@@ -450,7 +462,7 @@ export function assembleStandalone({
 
   // 5. Optionally patch Turbopack hashed chunks
   if (doPatchChunks) {
-    const { patchedFiles, patchedMatches } = patchTurbopackChunks(resolvedOutDir);
+    const { patchedFiles, patchedMatches } = patchTurbopackChunks(resolvedOutDir, relDistDir);
     if (patchedMatches > 0) {
       console.log(
         `[assembleStandalone] Hash-strip: patched ${patchedMatches} hashed require() in ${patchedFiles} server chunk file(s)`

--- a/scripts/build/assembleStandalone.mjs
+++ b/scripts/build/assembleStandalone.mjs
@@ -284,7 +284,7 @@ async function syncExtraModulesToDir(projectRoot, outDir, fsImpl, log) {
  * @returns {number} number of path replacements made
  */
 export function assemblePathSanitize(projectRoot, outDir, distDir = ".next") {
-  const buildRoot = projectRoot.replace(/\\/g, "/"); // normalise for regex safety
+  const buildRoot = projectRoot.replaceAll("\\", "/"); // normalise for regex safety
   const sanitizeTargets = [
     path.join(outDir, "server.js"),
     // required-server-files.json lives under the distDir (e.g. .build/next), not
@@ -297,7 +297,7 @@ export function assemblePathSanitize(projectRoot, outDir, distDir = ".next") {
     if (!fsSync.existsSync(filePath)) continue;
     let content = fsSync.readFileSync(filePath, "utf8");
     // Escape special regex characters in the path
-    const escaped = buildRoot.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const escaped = buildRoot.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
     const re = new RegExp(escaped, "g");
     const matches = content.match(re);
     if (matches) {
@@ -366,6 +366,182 @@ export function patchTurbopackChunks(outDir, distDir = ".next") {
 }
 
 /**
+ * Next.js standalone's server.js is CommonJS (uses require()), but the root package.json
+ * (which Next copies into the standalone) has "type":"module". Strip "type" so Node treats
+ * .js files as CJS in the bundle dir — otherwise `node server.js` fails with
+ * "require is not defined in ES module scope".
+ *
+ * @param {string} resolvedOutDir - assembled standalone output directory
+ */
+function patchStandalonePackageJson(resolvedOutDir) {
+  const outDirPkgJson = path.join(resolvedOutDir, "package.json");
+  if (!fsSync.existsSync(outDirPkgJson)) return;
+  try {
+    const pkg = JSON.parse(fsSync.readFileSync(outDirPkgJson, "utf8"));
+    if (pkg.type !== "module") return;
+    delete pkg.type;
+    fsSync.writeFileSync(outDirPkgJson, JSON.stringify(pkg, null, 2) + "\n");
+    console.log(
+      "[assembleStandalone] Removed 'type':'module' from standalone package.json (server.js is CJS)"
+    );
+  } catch (err) {
+    console.warn(`[assembleStandalone] Could not patch standalone package.json: ${err.message}`);
+  }
+}
+
+/**
+ * Copy <distDir>/static -> outDir/<relDistDir>/static and projectRoot/public -> outDir/public.
+ * The static dest mirrors the configured distDir (e.g. .build/next), which is where the
+ * standalone server serves /_next/static from. See step 2 in assembleStandalone for why.
+ *
+ * @param {{ distDir: string, relDistDir: string, projectRoot: string, resolvedOutDir: string }} opts
+ */
+function copyStaticAndPublic({ distDir, relDistDir, projectRoot, resolvedOutDir }) {
+  const staticSrc = path.join(distDir, "static");
+  const staticDest = path.join(resolvedOutDir, relDistDir, "static");
+  if (fsSync.existsSync(staticSrc)) {
+    fsSync.mkdirSync(path.dirname(staticDest), { recursive: true });
+    fsSync.cpSync(staticSrc, staticDest, { recursive: true, force: true });
+  }
+
+  const publicSrc = path.join(projectRoot, "public");
+  if (fsSync.existsSync(publicSrc)) {
+    fsSync.cpSync(publicSrc, path.join(resolvedOutDir, "public"), { recursive: true, force: true });
+  }
+}
+
+/**
+ * Copy native assets (wreq-js, better-sqlite3) and extra runtime modules/sidecars
+ * (pino, migrations, MITM server, helper scripts, sqlite-vec platform packages, …)
+ * into the assembled bundle. Missing sources are skipped silently.
+ *
+ * @param {string} projectRoot
+ * @param {string} resolvedOutDir
+ */
+function copyNativeAssetsAndExtraModules(projectRoot, resolvedOutDir) {
+  const nativeAssets = [
+    {
+      label: "wreq-js native runtime",
+      src: path.join(projectRoot, "node_modules", "wreq-js", "rust"),
+      dest: path.join(resolvedOutDir, "node_modules", "wreq-js", "rust"),
+    },
+    {
+      label: "better-sqlite3 native binary",
+      src: path.join(projectRoot, "node_modules", "better-sqlite3", "build"),
+      dest: path.join(resolvedOutDir, "node_modules", "better-sqlite3", "build"),
+    },
+  ];
+
+  for (const asset of nativeAssets) {
+    if (!fsSync.existsSync(asset.src)) continue;
+    fsSync.mkdirSync(path.dirname(asset.dest), { recursive: true });
+    fsSync.cpSync(asset.src, asset.dest, { recursive: true, force: true });
+    console.log(`[assembleStandalone] Copied native asset: ${asset.label}`);
+  }
+
+  const extraModules = [
+    {
+      label: "@swc/helpers",
+      src: path.join(projectRoot, "node_modules", "@swc", "helpers"),
+      dest: path.join(resolvedOutDir, "node_modules", "@swc", "helpers"),
+    },
+    {
+      label: "pino-abstract-transport",
+      src: path.join(projectRoot, "node_modules", "pino-abstract-transport"),
+      dest: path.join(resolvedOutDir, "node_modules", "pino-abstract-transport"),
+    },
+    {
+      label: "pino-pretty",
+      src: path.join(projectRoot, "node_modules", "pino-pretty"),
+      dest: path.join(resolvedOutDir, "node_modules", "pino-pretty"),
+    },
+    {
+      label: "split2",
+      src: path.join(projectRoot, "node_modules", "split2"),
+      dest: path.join(resolvedOutDir, "node_modules", "split2"),
+    },
+    {
+      label: "migrations",
+      src: path.join(projectRoot, "src", "lib", "db", "migrations"),
+      dest: path.join(resolvedOutDir, "migrations"),
+    },
+    {
+      label: "MITM server",
+      src: path.join(projectRoot, "src", "mitm", "server.cjs"),
+      dest: path.join(resolvedOutDir, "src", "mitm", "server.cjs"),
+    },
+    {
+      label: "run-standalone script",
+      src: path.join(projectRoot, "scripts", "dev", "run-standalone.mjs"),
+      dest: path.join(resolvedOutDir, "dev", "run-standalone.mjs"),
+    },
+    {
+      label: "WS/peer-stamp standalone server wrapper",
+      src: path.join(projectRoot, "scripts", "dev", "standalone-server-ws.mjs"),
+      dest: path.join(resolvedOutDir, "server-ws.mjs"),
+    },
+    {
+      label: "peer-stamp helper",
+      src: path.join(projectRoot, "scripts", "dev", "peer-stamp.mjs"),
+      dest: path.join(resolvedOutDir, "peer-stamp.mjs"),
+    },
+    {
+      label: "responses-ws-proxy",
+      src: path.join(projectRoot, "scripts", "dev", "responses-ws-proxy.mjs"),
+      dest: path.join(resolvedOutDir, "responses-ws-proxy.mjs"),
+    },
+    {
+      label: "runtime-env script",
+      src: path.join(projectRoot, "scripts", "build", "runtime-env.mjs"),
+      dest: path.join(resolvedOutDir, "build", "runtime-env.mjs"),
+    },
+    {
+      label: "bootstrap-env script",
+      src: path.join(projectRoot, "scripts", "build", "bootstrap-env.mjs"),
+      dest: path.join(resolvedOutDir, "build", "bootstrap-env.mjs"),
+    },
+    {
+      label: "healthcheck script",
+      src: path.join(projectRoot, "scripts", "dev", "healthcheck.mjs"),
+      dest: path.join(resolvedOutDir, "healthcheck.mjs"),
+    },
+    {
+      label: "public directory",
+      src: path.join(projectRoot, "public"),
+      dest: path.join(resolvedOutDir, "public"),
+    },
+    {
+      label: "playwright-core",
+      src: path.join(projectRoot, "node_modules", "playwright-core"),
+      dest: path.join(resolvedOutDir, "node_modules", "playwright-core"),
+    },
+    {
+      label: "sqlite-vec wrapper",
+      src: path.join(projectRoot, "node_modules", "sqlite-vec"),
+      dest: path.join(resolvedOutDir, "node_modules", "sqlite-vec"),
+    },
+    ...[
+      "sqlite-vec-linux-x64",
+      "sqlite-vec-linux-arm64",
+      "sqlite-vec-darwin-x64",
+      "sqlite-vec-darwin-arm64",
+      "sqlite-vec-windows-x64",
+    ].map((pkg) => ({
+      label: pkg,
+      src: path.join(projectRoot, "node_modules", pkg),
+      dest: path.join(resolvedOutDir, "node_modules", pkg),
+    })),
+  ];
+
+  for (const mod of extraModules) {
+    if (!fsSync.existsSync(mod.src)) continue;
+    fsSync.mkdirSync(path.dirname(mod.dest), { recursive: true });
+    fsSync.cpSync(mod.src, mod.dest, { recursive: true, force: true });
+    console.log(`[assembleStandalone] Synced module: ${mod.label}`);
+  }
+}
+
+/**
  * Assemble the Next.js standalone bundle into outDir.
  *
  * Copies <distDir>/standalone -> outDir, then <distDir>/static -> outDir/.next/static,
@@ -414,43 +590,15 @@ export function assembleStandalone({
     fsSync.cpSync(standaloneDir, resolvedOutDir, { recursive: true });
   }
 
-  // 1.5. Fix package.json in outDir: Next.js standalone's server.js is CommonJS (uses require()),
-  // but the root package.json (which Next copies into the standalone) has "type":"module".
-  // Remove "type" from the outDir's package.json so Node.js treats .js files as CJS in this dir.
-  // Without this, `node server.js` (or `import("./server.js")`) fails with
-  //   ReferenceError: require is not defined in ES module scope
-  const outDirPkgJson = path.join(resolvedOutDir, "package.json");
-  if (fsSync.existsSync(outDirPkgJson)) {
-    try {
-      const pkg = JSON.parse(fsSync.readFileSync(outDirPkgJson, "utf8"));
-      if (pkg.type === "module") {
-        delete pkg.type;
-        fsSync.writeFileSync(outDirPkgJson, JSON.stringify(pkg, null, 2) + "\n");
-        console.log("[assembleStandalone] Removed 'type':'module' from standalone package.json (server.js is CJS)");
-      }
-    } catch (err) {
-      console.warn(`[assembleStandalone] Could not patch standalone package.json: ${err.message}`);
-    }
-  }
+  // 1.5. Standalone server.js is CJS — strip "type":"module" from the copied package.json.
+  patchStandalonePackageJson(resolvedOutDir);
 
-  // 2. Copy <distDir>/static -> resolvedOutDir/<distDir>/static
+  // 2/3. Copy <distDir>/static -> outDir/<relDistDir>/static and projectRoot/public -> outDir/public.
   // CRITICAL: the standalone server.js is built with distDir baked into its config
-  // (e.g. "./.build/next"), so it serves /_next/static from <outDir>/<distDir>/static,
+  // (e.g. "./.build/next"), so it serves /_next/static from <outDir>/<relDistDir>/static,
   // NOT a literal <outDir>/.next/static. Copying to .next/static leaves the server's
   // static dir empty → every JS/CSS chunk 404s → blank page. Mirror the distDir path.
-  const staticSrc = path.join(distDir, "static");
-  const staticDest = path.join(resolvedOutDir, relDistDir, "static");
-  if (fsSync.existsSync(staticSrc)) {
-    fsSync.mkdirSync(path.dirname(staticDest), { recursive: true });
-    fsSync.cpSync(staticSrc, staticDest, { recursive: true, force: true });
-  }
-
-  // 3. Copy projectRoot/public -> resolvedOutDir/public
-  const publicSrc = path.join(projectRoot, "public");
-  const publicDest = path.join(resolvedOutDir, "public");
-  if (fsSync.existsSync(publicSrc)) {
-    fsSync.cpSync(publicSrc, publicDest, { recursive: true, force: true });
-  }
+  copyStaticAndPublic({ distDir, relDistDir, projectRoot, resolvedOutDir });
 
   // 4. Optionally sanitize abs paths
   if (sanitizePaths) {
@@ -472,125 +620,6 @@ export function assembleStandalone({
 
   // 6. Optionally copy native assets + extra modules (synchronous)
   if (copyNatives) {
-    const nativeAssets = [
-      {
-        label: "wreq-js native runtime",
-        src: path.join(projectRoot, "node_modules", "wreq-js", "rust"),
-        dest: path.join(resolvedOutDir, "node_modules", "wreq-js", "rust"),
-      },
-      {
-        label: "better-sqlite3 native binary",
-        src: path.join(projectRoot, "node_modules", "better-sqlite3", "build"),
-        dest: path.join(resolvedOutDir, "node_modules", "better-sqlite3", "build"),
-      },
-    ];
-
-    for (const asset of nativeAssets) {
-      if (!fsSync.existsSync(asset.src)) continue;
-      fsSync.mkdirSync(path.dirname(asset.dest), { recursive: true });
-      fsSync.cpSync(asset.src, asset.dest, { recursive: true, force: true });
-      console.log(`[assembleStandalone] Copied native asset: ${asset.label}`);
-    }
-
-    const extraModules = [
-      {
-        label: "@swc/helpers",
-        src: path.join(projectRoot, "node_modules", "@swc", "helpers"),
-        dest: path.join(resolvedOutDir, "node_modules", "@swc", "helpers"),
-      },
-      {
-        label: "pino-abstract-transport",
-        src: path.join(projectRoot, "node_modules", "pino-abstract-transport"),
-        dest: path.join(resolvedOutDir, "node_modules", "pino-abstract-transport"),
-      },
-      {
-        label: "pino-pretty",
-        src: path.join(projectRoot, "node_modules", "pino-pretty"),
-        dest: path.join(resolvedOutDir, "node_modules", "pino-pretty"),
-      },
-      {
-        label: "split2",
-        src: path.join(projectRoot, "node_modules", "split2"),
-        dest: path.join(resolvedOutDir, "node_modules", "split2"),
-      },
-      {
-        label: "migrations",
-        src: path.join(projectRoot, "src", "lib", "db", "migrations"),
-        dest: path.join(resolvedOutDir, "migrations"),
-      },
-      {
-        label: "MITM server",
-        src: path.join(projectRoot, "src", "mitm", "server.cjs"),
-        dest: path.join(resolvedOutDir, "src", "mitm", "server.cjs"),
-      },
-      {
-        label: "run-standalone script",
-        src: path.join(projectRoot, "scripts", "dev", "run-standalone.mjs"),
-        dest: path.join(resolvedOutDir, "dev", "run-standalone.mjs"),
-      },
-      {
-        label: "WS/peer-stamp standalone server wrapper",
-        src: path.join(projectRoot, "scripts", "dev", "standalone-server-ws.mjs"),
-        dest: path.join(resolvedOutDir, "server-ws.mjs"),
-      },
-      {
-        label: "peer-stamp helper",
-        src: path.join(projectRoot, "scripts", "dev", "peer-stamp.mjs"),
-        dest: path.join(resolvedOutDir, "peer-stamp.mjs"),
-      },
-      {
-        label: "responses-ws-proxy",
-        src: path.join(projectRoot, "scripts", "dev", "responses-ws-proxy.mjs"),
-        dest: path.join(resolvedOutDir, "responses-ws-proxy.mjs"),
-      },
-      {
-        label: "runtime-env script",
-        src: path.join(projectRoot, "scripts", "build", "runtime-env.mjs"),
-        dest: path.join(resolvedOutDir, "build", "runtime-env.mjs"),
-      },
-      {
-        label: "bootstrap-env script",
-        src: path.join(projectRoot, "scripts", "build", "bootstrap-env.mjs"),
-        dest: path.join(resolvedOutDir, "build", "bootstrap-env.mjs"),
-      },
-      {
-        label: "healthcheck script",
-        src: path.join(projectRoot, "scripts", "dev", "healthcheck.mjs"),
-        dest: path.join(resolvedOutDir, "healthcheck.mjs"),
-      },
-      {
-        label: "public directory",
-        src: path.join(projectRoot, "public"),
-        dest: path.join(resolvedOutDir, "public"),
-      },
-      {
-        label: "playwright-core",
-        src: path.join(projectRoot, "node_modules", "playwright-core"),
-        dest: path.join(resolvedOutDir, "node_modules", "playwright-core"),
-      },
-      {
-        label: "sqlite-vec wrapper",
-        src: path.join(projectRoot, "node_modules", "sqlite-vec"),
-        dest: path.join(resolvedOutDir, "node_modules", "sqlite-vec"),
-      },
-      ...[
-        "sqlite-vec-linux-x64",
-        "sqlite-vec-linux-arm64",
-        "sqlite-vec-darwin-x64",
-        "sqlite-vec-darwin-arm64",
-        "sqlite-vec-windows-x64",
-      ].map((pkg) => ({
-        label: pkg,
-        src: path.join(projectRoot, "node_modules", pkg),
-        dest: path.join(resolvedOutDir, "node_modules", pkg),
-      })),
-    ];
-
-    for (const mod of extraModules) {
-      if (!fsSync.existsSync(mod.src)) continue;
-      fsSync.mkdirSync(path.dirname(mod.dest), { recursive: true });
-      fsSync.cpSync(mod.src, mod.dest, { recursive: true, force: true });
-      console.log(`[assembleStandalone] Synced module: ${mod.label}`);
-    }
+    copyNativeAssetsAndExtraModules(projectRoot, resolvedOutDir);
   }
 }

--- a/tests/unit/build/assemble-standalone.test.ts
+++ b/tests/unit/build/assemble-standalone.test.ts
@@ -20,7 +20,16 @@ test("assembleStandalone copies standalone + static + public + sidecars into out
   assembleStandalone({ distDir, outDir, projectRoot: tmp, sanitizePaths: false, copyNatives: false });
 
   assert.ok(fs.existsSync(path.join(outDir, "server.js")), "server.js copied");
-  assert.ok(fs.existsSync(path.join(outDir, ".next/static/x.js")), "static copied");
+  // Static lands under the distDir path (.build/next/static), where the standalone
+  // server.js — built with distDir baked into its config — serves /_next/static from.
+  assert.ok(
+    fs.existsSync(path.join(outDir, ".build/next/static/x.js")),
+    "static copied under distDir"
+  );
+  assert.ok(
+    !fs.existsSync(path.join(outDir, ".next/static/x.js")),
+    "static is NOT placed under a literal .next (would 404 against distDir server)"
+  );
   assert.ok(fs.existsSync(path.join(outDir, "public/logo.svg")), "public copied");
   fs.rmSync(tmp, { recursive: true, force: true });
 });


### PR DESCRIPTION
Finalizes the **v3.8.9** release for tagging. Brings the two commits that landed on \`release/v3.8.9\` after the initial release merge (#3092):

### Included
- **fix(build):** standalone static-asset path — \`assembleStandalone\` now copies \`static/\` (and \`required-server-files.json\` / Turbopack chunks) under the configured \`distDir\` (\`.build/next/static\`) instead of a hard-coded \`.next\`. Without this, the standalone server (built with \`distDir=.build/next\`) 404'd every JS/CSS chunk and the login UI rendered as a **blank page** after the build-output reorg. (\`49dedecc4\`)
- **docs(changelog):** credit the 3 PRs merged **directly to main** during the v3.8.9 cycle and document the static fix:
  - #3131 Kiro Opus 4.8 catalog (thanks @artickc)
  - #3132 Kimi thinking-mode \`reasoning_content\` fix (thanks @bypanghu)
  - #3130 connectionId fallback + kilo call logging (thanks @androw)
  - Contributors hall now lists all 15 contributors. (\`796267df3\`)

### Validation
- Static fix verified on the VM: built standalone serves chunks → HTTP 200, login UI renders.
- Deployed + validated on the local VPS (192.168.0.15) by the maintainer.

After merge → tag \`v3.8.9\` → npm/docker/electron publishes.