### PR TITLE
fix(opencode-plugin): map caps.thinking → ModelV2.capabilities.interleaved

### DIFF
--- a/@omniroute/opencode-plugin/src/index.ts
+++ b/@omniroute/opencode-plugin/src/index.ts
@@ -595,7 +595,7 @@ export function mapRawModelToModelV2(
         video: outMods.has("video"),
         pdf: outMods.has("pdf"),
       },
-      interleaved: false,
+      interleaved: Boolean(caps.thinking),
     },
     cost: {
       input: 0,
@@ -845,7 +845,7 @@ export function mapComboToModelV2(
       video: modalityAllHave(memberOutMods, "video"),
       pdf: modalityAllHave(memberOutMods, "pdf"),
     },
-    interleaved: false,
+    interleaved: hasMembers && members.every((m) => Boolean(m.capabilities?.thinking)),
   };
 
   return {


### PR DESCRIPTION
## Problem

`ModelV2.capabilities.interleaved` was hardcoded `false` in both `mapRawModelToModelV2` and `mapComboToModelV2`. OmniRoute returns `capabilities.thinking: true` on Anthropic thinking models (e.g. `cc/claude-opus-4-8`, `cc/claude-sonnet-4-6`), but this flag was never propagated to OpenCode's `interleaved` capability.

**Effect:** extended thinking UI never activated in OpenCode for any OmniRoute-backed model — even when the model explicitly supports it.

## Fix

```ts
// mapRawModelToModelV2
interleaved: Boolean(caps.thinking),

// mapComboToModelV2
interleaved: hasMembers && members.every((m) => Boolean(m.capabilities?.thinking)),
```

## Tests

All 228 existing tests pass. No new tests added (no existing test covers the `interleaved` field — follow-up ticket to add coverage).