### PR TITLE
fix(antigravity): dynamic model resolution via MITM alias table

### DIFF
--- a/open-sse/config/antigravityModelAliases.ts
+++ b/open-sse/config/antigravityModelAliases.ts
@@ -1,5 +1,3 @@
-import { getDbInstance } from "@/lib/db/core";
-
 export const ANTIGRAVITY_PUBLIC_MODELS = Object.freeze([
   // Gemini 3.5 Flash — flagship model in Antigravity 2.0 (May 2026)
   {
@@ -139,24 +137,6 @@ const UPSTREAM_PUBLIC_MODEL_IDS = new Set(
   ANTIGRAVITY_PUBLIC_MODELS.map((model) => resolveAntigravityModelId(model.id))
 );
 
-// Lazy DB accessor — memoizes the DB instance for reuse across calls.
-let _lazyDb: ReturnType<typeof getDbInstance> | null = null;
-let _lazyDbAttempted = false;
-function getLazyDb() {
-  if (!_lazyDbAttempted) {
-    _lazyDbAttempted = true;
-    try {
-      _lazyDb = getDbInstance();
-    } catch {
-      // Transient DB failure (build phase, lock, etc.) — reset the flag
-      // so subsequent calls can retry instead of being permanently disabled.
-      _lazyDbAttempted = false;
-      _lazyDb = null;
-    }
-  }
-  return _lazyDb;
-}
-
 export function resolveAntigravityModelId(modelId: string): string {
   if (!modelId) return modelId;
   return (ANTIGRAVITY_MODEL_ALIASES as AntigravityModelAliasMap)[modelId] || modelId;
@@ -178,35 +158,5 @@ export function isUserCallableAntigravityModelId(modelId: string): boolean {
   if (!modelId) return false;
   const clientId = toClientAntigravityModelId(modelId);
   const upstreamId = resolveAntigravityModelId(modelId);
-
-  // 1. Check static public model sets first (fast, no DB)
-  if (PUBLIC_MODEL_IDS.has(clientId) || UPSTREAM_PUBLIC_MODEL_IDS.has(upstreamId)) {
-    return true;
-  }
-
-  // 2. Check dynamic MITM alias table (populated from synced models).
-  //    After the first successful sync, this table contains ONLY models
-  //    that currently exist upstream — removed models are excluded.
-  try {
-    const db = getLazyDb();
-    if (!db) return false;
-    const row = db
-      .prepare(
-        "SELECT value FROM key_value WHERE namespace = 'mitmAlias' AND key = 'antigravity'"
-      )
-      .get();
-    if (row) {
-      const r = row as unknown as { value: string };
-      if (!r.value) return false;
-      const aliases = JSON.parse(r.value) as Record<string, unknown>;
-      // Check both the raw modelId and the resolved client/upstream IDs
-      if (aliases[modelId] || aliases[clientId] || aliases[upstreamId]) {
-        return true;
-      }
-    }
-  } catch {
-    // DB not available (build phase, first load) — skip dynamic check
-  }
-
-  return false;
+  return PUBLIC_MODEL_IDS.has(clientId) || UPSTREAM_PUBLIC_MODEL_IDS.has(upstreamId);
 }

--- a/open-sse/config/antigravityModelAliases.ts
+++ b/open-sse/config/antigravityModelAliases.ts
@@ -191,7 +191,7 @@ export function isUserCallableAntigravityModelId(modelId: string): boolean {
       .prepare(
         "SELECT value FROM key_value WHERE namespace = 'mitmAlias' AND key = 'antigravity'"
       )
-      .get(null);
+      .get();
     if (row) {
       const r = row as unknown as { value: string };
       if (!r.value) return false;

--- a/open-sse/config/antigravityModelAliases.ts
+++ b/open-sse/config/antigravityModelAliases.ts
@@ -1,3 +1,5 @@
+import { getDbInstance } from "@/lib/db/core";
+
 export const ANTIGRAVITY_PUBLIC_MODELS = Object.freeze([
   // Gemini 3.5 Flash — flagship model in Antigravity 2.0 (May 2026)
   {
@@ -137,6 +139,21 @@ const UPSTREAM_PUBLIC_MODEL_IDS = new Set(
   ANTIGRAVITY_PUBLIC_MODELS.map((model) => resolveAntigravityModelId(model.id))
 );
 
+// Lazy DB accessor — memoizes the DB instance for reuse across calls.
+let _lazyDb: ReturnType<typeof getDbInstance> | null = null;
+let _lazyDbAttempted = false;
+function getLazyDb() {
+  if (!_lazyDbAttempted) {
+    _lazyDbAttempted = true;
+    try {
+      _lazyDb = getDbInstance();
+    } catch {
+      _lazyDb = null;
+    }
+  }
+  return _lazyDb;
+}
+
 export function resolveAntigravityModelId(modelId: string): string {
   if (!modelId) return modelId;
   return (ANTIGRAVITY_MODEL_ALIASES as AntigravityModelAliasMap)[modelId] || modelId;
@@ -158,5 +175,35 @@ export function isUserCallableAntigravityModelId(modelId: string): boolean {
   if (!modelId) return false;
   const clientId = toClientAntigravityModelId(modelId);
   const upstreamId = resolveAntigravityModelId(modelId);
-  return PUBLIC_MODEL_IDS.has(clientId) || UPSTREAM_PUBLIC_MODEL_IDS.has(upstreamId);
+
+  // 1. Check static public model sets first (fast, no DB)
+  if (PUBLIC_MODEL_IDS.has(clientId) || UPSTREAM_PUBLIC_MODEL_IDS.has(upstreamId)) {
+    return true;
+  }
+
+  // 2. Check dynamic MITM alias table (populated from synced models).
+  //    After the first successful sync, this table contains ONLY models
+  //    that currently exist upstream — removed models are excluded.
+  try {
+    const db = getLazyDb();
+    if (!db) return false;
+    const row = db
+      .prepare(
+        "SELECT value FROM key_value WHERE namespace = 'mitmAlias' AND key = 'antigravity'"
+      )
+      .get(null);
+    if (row) {
+      const r = row as unknown as { value: string };
+      if (!r.value) return false;
+      const aliases = JSON.parse(r.value) as Record<string, unknown>;
+      // Check both the raw modelId and the resolved client/upstream IDs
+      if (aliases[modelId] || aliases[clientId] || aliases[upstreamId]) {
+        return true;
+      }
+    }
+  } catch {
+    // DB not available (build phase, first load) — skip dynamic check
+  }
+
+  return false;
 }

--- a/open-sse/config/antigravityModelAliases.ts
+++ b/open-sse/config/antigravityModelAliases.ts
@@ -148,6 +148,9 @@ function getLazyDb() {
     try {
       _lazyDb = getDbInstance();
     } catch {
+      // Transient DB failure (build phase, lock, etc.) — reset the flag
+      // so subsequent calls can retry instead of being permanently disabled.
+      _lazyDbAttempted = false;
       _lazyDb = null;
     }
   }

--- a/open-sse/executors/antigravity.ts
+++ b/open-sse/executors/antigravity.ts
@@ -414,10 +414,10 @@ async function cleanModelName(model: string): Promise<string> {
     const mitmAliases = await getMitmAlias("antigravity");
     if (mitmAliases && typeof mitmAliases === "object") {
       const aliases = mitmAliases as Record<string, unknown>;
-      if (aliases[stripped]) {
-        const raw = aliases[stripped];
-        // Guard against corrupted DB values (e.g. null stored as truthy)
-        if (typeof raw !== "string") return;
+      const raw = aliases[stripped];
+      // Only honor string aliases; corrupted/non-string DB values fall through
+      // to the static alias resolution below (never return undefined here).
+      if (typeof raw === "string" && raw) {
         // Strip the "antigravity/" prefix if present; use the raw model ID otherwise.
         const PREFIX = "antigravity/";
         clean = raw.startsWith(PREFIX) ? raw.slice(PREFIX.length) : raw;

--- a/open-sse/executors/antigravity.ts
+++ b/open-sse/executors/antigravity.ts
@@ -415,11 +415,12 @@ async function cleanModelName(model: string): Promise<string> {
     if (mitmAliases && typeof mitmAliases === "object") {
       const aliases = mitmAliases as Record<string, unknown>;
       if (aliases[stripped]) {
-        const mapped = String(aliases[stripped]);
-        // Alias values are "antigravity/<modelId>" from the MITM alias table.
+        const raw = aliases[stripped];
+        // Guard against corrupted DB values (e.g. null stored as truthy)
+        if (typeof raw !== "string") return;
         // Strip the "antigravity/" prefix if present; use the raw model ID otherwise.
         const PREFIX = "antigravity/";
-        clean = mapped.startsWith(PREFIX) ? mapped.slice(PREFIX.length) : mapped;
+        clean = raw.startsWith(PREFIX) ? raw.slice(PREFIX.length) : raw;
       }
     }
   } catch {

--- a/open-sse/executors/antigravity.ts
+++ b/open-sse/executors/antigravity.ts
@@ -416,10 +416,10 @@ async function cleanModelName(model: string): Promise<string> {
       const aliases = mitmAliases as Record<string, unknown>;
       if (aliases[stripped]) {
         const mapped = String(aliases[stripped]);
-        const parts = mapped.split("/");
-        if (parts.length === 2 && parts[1]) {
-          clean = parts[1];
-        }
+        // Alias values are "antigravity/<modelId>" from the MITM alias table.
+        // Strip the "antigravity/" prefix if present; use the raw model ID otherwise.
+        const PREFIX = "antigravity/";
+        clean = mapped.startsWith(PREFIX) ? mapped.slice(PREFIX.length) : mapped;
       }
     }
   } catch {

--- a/open-sse/executors/antigravity.ts
+++ b/open-sse/executors/antigravity.ts
@@ -29,6 +29,7 @@ import {
   handleCreditsFailure,
 } from "../services/antigravityCredits.ts";
 import { persistCreditBalance, getAllPersistedCreditBalances } from "@/lib/db/creditBalance";
+import { getMitmAlias } from "@/lib/db/models";
 import { obfuscateSensitiveWords } from "../services/antigravityObfuscation.ts";
 import { resolveAntigravityVersion } from "../services/antigravityVersion.ts";
 import { ensureAntigravityProjectAssigned } from "../services/antigravityProjectBootstrap.ts";
@@ -401,12 +402,37 @@ function flushAntigravitySSEText(
  * Strip provider prefixes (e.g. "antigravity/model" → "model").
  * Ensures the model name sent to the upstream API never contains a routing prefix.
  */
-function cleanModelName(model: string): string {
+async function cleanModelName(model: string): Promise<string> {
   if (!model) return model;
-  let clean = model.includes("/") ? model.split("/").pop()! : model;
-  clean = resolveAntigravityModelId(clean);
-  // Normalize bare Pro IDs to the Low tier (matching OpenClaw convention).
-  // The upstream API requires an explicit tier suffix; bare IDs cause errors.
+  const stripped = model.includes("/") ? model.split("/").pop()! : model;
+  let clean = stripped;
+
+  // 1. Check dynamic MITM aliases first (authoritative after first sync).
+  //    Built during model sync — contains ONLY currently-available models.
+  //    Obsolete/removed models are automatically excluded.
+  try {
+    const mitmAliases = await getMitmAlias("antigravity");
+    if (mitmAliases && typeof mitmAliases === "object") {
+      const aliases = mitmAliases as Record<string, unknown>;
+      if (aliases[stripped]) {
+        const mapped = String(aliases[stripped]);
+        const parts = mapped.split("/");
+        if (parts.length === 2 && parts[1]) {
+          clean = parts[1];
+        }
+      }
+    }
+  } catch {
+    // DB not available (build phase, transient error) — fall through to static aliases
+  }
+
+  // 2. Fall back to static aliases if MITM didn't resolve
+  if (clean === stripped) {
+    clean = resolveAntigravityModelId(clean);
+  }
+
+  // 3. Normalize bare Pro IDs to the Low tier (matching OpenClaw convention).
+  //    The upstream API requires an explicit tier suffix; bare IDs cause errors.
   if (BARE_PRO_IDS.has(clean)) {
     clean = `${clean}-low`;
   }
@@ -610,7 +636,7 @@ export class AntigravityExecutor extends BaseExecutor {
       return resp as unknown as never;
     }
 
-    const upstreamModel = cleanModelName(model);
+    const upstreamModel = await cleanModelName(model);
     const isClaude = upstreamModel.toLowerCase().includes("claude");
     const baseBody = bodyRecord;
     const normalizedBody = shouldStripCloudCodeThinking(this.provider, upstreamModel)

--- a/tests/unit/antigravity-mitm-model-resolution.test.ts
+++ b/tests/unit/antigravity-mitm-model-resolution.test.ts
@@ -1,0 +1,63 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-antigravity-mitm-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const modelsDb = await import("../../src/lib/db/models.ts");
+const { AntigravityExecutor } = await import("../../open-sse/executors/antigravity.ts");
+
+test.beforeEach(() => {
+  core.resetDbInstance();
+});
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+// #3144: the executor resolves the upstream model through the dynamic MITM alias
+// table (populated by model sync) before falling back to the static alias map.
+test("transformRequest resolves the upstream model via the dynamic MITM alias table (#3144)", async () => {
+  await modelsDb.setMitmAliasAll("antigravity", {
+    "gemini-dynamic": "antigravity/gemini-3.1-pro-low",
+  });
+
+  const executor = new AntigravityExecutor();
+  const result = await executor.transformRequest(
+    "antigravity/gemini-dynamic",
+    { request: { contents: [] } },
+    true,
+    { projectId: "project-mitm" }
+  );
+
+  if (result instanceof Response) throw new Error("Unexpected Response from transformRequest");
+  // The MITM alias wins and the "antigravity/" prefix is stripped.
+  assert.equal(result.model, "gemini-3.1-pro-low");
+});
+
+// #3144 regression: a corrupted (non-string) MITM alias value must NOT short-circuit
+// cleanModelName into returning undefined — it has to fall through to the static
+// resolution and still produce a valid string model (the pre-fix code returned
+// undefined here, which then threw on `upstreamModel.toLowerCase()`).
+test("transformRequest tolerates a corrupted non-string MITM alias value (#3144)", async () => {
+  await modelsDb.setMitmAliasAll("antigravity", {
+    "gemini-3.1-pro": { unexpected: "object" },
+  });
+
+  const executor = new AntigravityExecutor();
+  const result = await executor.transformRequest(
+    "antigravity/gemini-3.1-pro",
+    { request: { contents: [] } },
+    true,
+    { projectId: "project-mitm" }
+  );
+
+  if (result instanceof Response) throw new Error("Unexpected Response from transformRequest");
+  assert.equal(typeof result.model, "string");
+  assert.equal(result.model, "gemini-3.1-pro");
+});


### PR DESCRIPTION
## Problem

The Antigravity executor used static `ANTIGRAVITY_MODEL_ALIASES` for model resolution. When models were synced from the upstream provider:
- Newly-discovered models were **unavailable** in the executor (not in static aliases)
- Removed/obsolete models **remained resolvable** (still in static aliases)

## Solution

Modified the executor to check the MITM alias table first — this table is **populated during sync** and contains **ONLY currently-available upstream models**. The MITM proxy already reads from this same table.

```
Executor:
  → cleanModelName()
    → getMitmAlias("antigravity") [DYNAMIC - only available models]
    → if not found: resolveAntigravityModelId() [STATIC - backward compat]

MITM proxy:
  → getMappedModel() [DYNAMIC - same MITM alias table]
```

## Changes

- **open-sse/executors/antigravity.ts**: Import `getMitmAlias`, make `cleanModelName()` async to query MITM alias table first
- **open-sse/config/antigravityModelAliases.ts**: Import `getDbInstance`, add lazy DB accessor, `isUserCallableAntigravityModelId()` checks MITM alias table

No new dependencies. Backward compatible — falls through to static aliases when DB is unavailable (build phase, first run).