### PR TITLE
fix(api-manager): preserve API key expiration local time

### DIFF
--- a/src/app/(dashboard)/dashboard/api-manager/ApiManagerPageClient.tsx
+++ b/src/app/(dashboard)/dashboard/api-manager/ApiManagerPageClient.tsx
@@ -2144,7 +2144,11 @@ const PermissionsModal = memo(function PermissionsModal({
               value={toLocalDateTimeInputValue(expiresAt)}
               onChange={(e) => {
                 const val = e.target.value;
-                setExpiresAt(val ? new Date(val).toISOString() : "");
+                try {
+                  setExpiresAt(val ? new Date(val).toISOString() : "");
+                } catch {
+                  // Ignore invalid dates to prevent UI crashes
+                }
               }}
               className="min-w-0 flex-1 px-2 py-1.5 text-sm border border-border rounded-md bg-background text-text-main"
             />

--- a/src/app/(dashboard)/dashboard/api-manager/ApiManagerPageClient.tsx
+++ b/src/app/(dashboard)/dashboard/api-manager/ApiManagerPageClient.tsx
@@ -2144,10 +2144,13 @@ const PermissionsModal = memo(function PermissionsModal({
               value={toLocalDateTimeInputValue(expiresAt)}
               onChange={(e) => {
                 const val = e.target.value;
-                try {
-                  setExpiresAt(val ? new Date(val).toISOString() : "");
-                } catch {
-                  // Ignore invalid dates to prevent UI crashes
+                if (!val) {
+                  setExpiresAt("");
+                  return;
+                }
+                const date = new Date(val);
+                if (!Number.isNaN(date.getTime())) {
+                  setExpiresAt(date.toISOString());
                 }
               }}
               className="min-w-0 flex-1 px-2 py-1.5 text-sm border border-border rounded-md bg-background text-text-main"

--- a/src/app/(dashboard)/dashboard/api-manager/ApiManagerPageClient.tsx
+++ b/src/app/(dashboard)/dashboard/api-manager/ApiManagerPageClient.tsx
@@ -30,6 +30,16 @@ import {
 const MAX_KEY_NAME_LENGTH = 200;
 const MAX_SELECTED_MODELS = 500;
 
+function toLocalDateTimeInputValue(value: string | null | undefined): string {
+  if (!value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(
+    date.getHours()
+  )}:${pad(date.getMinutes())}`;
+}
+
 // Debounce hook for search optimization
 function useDebouncedValue<T>(value: T, delay: number): T {
   const [debouncedValue, setDebouncedValue] = useState(value);
@@ -2128,15 +2138,25 @@ const PermissionsModal = memo(function PermissionsModal({
               Key will automatically stop working after this date.
             </p>
           </div>
-          <input
-            type="datetime-local"
-            value={expiresAt ? expiresAt.slice(0, 16) : ""}
-            onChange={(e) => {
-              const val = e.target.value;
-              setExpiresAt(val ? new Date(val).toISOString() : "");
-            }}
-            className="w-full px-2 py-1.5 text-sm border border-border rounded-md bg-background text-text-main"
-          />
+          <div className="flex gap-2">
+            <input
+              type="datetime-local"
+              value={toLocalDateTimeInputValue(expiresAt)}
+              onChange={(e) => {
+                const val = e.target.value;
+                setExpiresAt(val ? new Date(val).toISOString() : "");
+              }}
+              className="min-w-0 flex-1 px-2 py-1.5 text-sm border border-border rounded-md bg-background text-text-main"
+            />
+            <button
+              type="button"
+              onClick={() => setExpiresAt("")}
+              disabled={!expiresAt}
+              className="shrink-0 px-3 py-1.5 text-sm font-medium border border-border rounded-md text-text-muted hover:text-text-main hover:bg-black/5 dark:hover:bg-white/5 disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent"
+            >
+              {tc("clear")}
+            </button>
+          </div>
         </div>
         {/* Management Access */}
         <div className="flex flex-col gap-2 p-3 rounded-lg border border-border bg-surface/40">

--- a/tests/unit/api-manager-page-static.test.ts
+++ b/tests/unit/api-manager-page-static.test.ts
@@ -43,7 +43,8 @@ test("permissions modal converts API key expiration ISO timestamps to local date
   );
 
   assert.match(expirationBlock, /value=\{toLocalDateTimeInputValue\(expiresAt\)\}/);
-  assert.match(expirationBlock, /new Date\(val\)\.toISOString\(\)/);
+  assert.match(expirationBlock, /const date = new Date\(val\)/);
+  assert.match(expirationBlock, /setExpiresAt\(date\.toISOString\(\)\)/);
   assert.match(expirationBlock, /onClick=\{\(\) => setExpiresAt\(""\)\}/);
   assert.match(expirationBlock, /\{tc\("clear"\)\}/);
   assert.doesNotMatch(expirationBlock, /expiresAt\.slice\(0, 16\)/);

--- a/tests/unit/api-manager-page-static.test.ts
+++ b/tests/unit/api-manager-page-static.test.ts
@@ -35,6 +35,20 @@ test("permissions modal uses i18n for management access description", () => {
   assert.doesNotMatch(managementBlock, /Allow this API key to manage OmniRoute configuration\./);
 });
 
+test("permissions modal converts API key expiration ISO timestamps to local datetime input values", () => {
+  const source = readApiManagerPage();
+  const expirationBlock = source.slice(
+    source.indexOf("{/* Expiration Date */}", source.indexOf("const PermissionsModal")),
+    source.indexOf("{/* Management Access */}", source.indexOf("const PermissionsModal"))
+  );
+
+  assert.match(expirationBlock, /value=\{toLocalDateTimeInputValue\(expiresAt\)\}/);
+  assert.match(expirationBlock, /new Date\(val\)\.toISOString\(\)/);
+  assert.match(expirationBlock, /onClick=\{\(\) => setExpiresAt\(""\)\}/);
+  assert.match(expirationBlock, /\{tc\("clear"\)\}/);
+  assert.doesNotMatch(expirationBlock, /expiresAt\.slice\(0, 16\)/);
+});
+
 test("permissions modal switch buttons declare button type", () => {
   const source = readApiManagerPage();
   const modalStart = source.indexOf("const PermissionsModal");

--- a/tests/unit/batch-processor-expiration.test.ts
+++ b/tests/unit/batch-processor-expiration.test.ts
@@ -1,6 +1,5 @@
-import { afterEach, describe, it } from "node:test";
+import { describe, it } from "node:test";
 import assert from "node:assert";
-import { deleteFile, listFiles } from "@/lib/localDb";
 
 // Helper functions from batchProcessor.ts
 function parseBatchWindowSeconds(window: string | null | undefined): number {
@@ -18,15 +17,6 @@ function parseBatchWindowSeconds(window: string | null | undefined): number {
 }
 
 describe("Batch Processor - File Expiration", () => {
-  afterEach(() => {
-    const allFiles = listFiles({ limit: 1000 });
-    for (const f of allFiles) {
-      if (f.filename?.includes("test-batch-")) {
-        deleteFile(f.id);
-      }
-    }
-  });
-
   describe("getBatchOutputExpiresAt logic", () => {
     it("should calculate output expiration as 30 days from batch completion", () => {
       const completedAt = Math.floor(Date.now() / 1000) - 5 * 24 * 60 * 60; // 5 days ago

--- a/tests/unit/console-log-levels.test.ts
+++ b/tests/unit/console-log-levels.test.ts
@@ -8,7 +8,13 @@ import { updateSettings } from "../../src/lib/db/settings";
 
 const TEST_LOG_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-console-log-levels-"));
 const TEST_LOG_PATH = path.join(TEST_LOG_DIR, "app.log");
-process.once("exit", () => fs.rmSync(TEST_LOG_DIR, { recursive: true, force: true }));
+process.once("exit", () => {
+  try {
+    fs.rmSync(TEST_LOG_DIR, { recursive: true, force: true, maxRetries: 3, retryDelay: 50 });
+  } catch {
+    // Best-effort cleanup only; tmpdir residue must not fail otherwise-passing tests.
+  }
+});
 
 const originalLogFilePath = process.env.APP_LOG_FILE_PATH;
 process.env.APP_LOG_FILE_PATH = TEST_LOG_PATH;


### PR DESCRIPTION
## Summary

- Render API key expiration ISO timestamps as local `datetime-local` values instead of slicing UTC text.
- Keep saving valid local `datetime-local` input values as UTC ISO timestamps.
- Add a Clear button so users can remove an API key expiration date.
- Harden two flaky CI test paths exposed by the PR run:
  - make console-log tmpdir cleanup best-effort,
  - remove unnecessary SQLite access from pure batch-expiration arithmetic tests.

## Related Issues

- Related to user-reported API key expiration calendar timezone drift.

## Validation

- [ ] `npm run lint`
- [ ] `npm run test:unit`
- [ ] `npm run test:coverage`
- [ ] Coverage is still `>= 60%` for statements, lines, functions, and branches
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below

Additional validation run in this checkout:

- [x] `node --test tests/unit/api-manager-page-static.test.ts`
- [x] `node --test tests/unit/api-manager-page-static.test.ts tests/unit/batch-processor-expiration.test.ts`
- [x] `git diff --check`

Full project commands requiring `tsx`/installed dependencies were not run locally because this checkout does not have `node_modules` installed. The PR CI run is used for full dependency-backed validation.

## Tests Added Or Updated

- Updated `tests/unit/api-manager-page-static.test.ts` to cover API key expiration input rendering and prevent the `expiresAt.slice(0, 16)` regression.
- Updated `tests/unit/batch-processor-expiration.test.ts` to keep its pure arithmetic tests from touching shared SQLite state.
- Updated `tests/unit/console-log-levels.test.ts` so temporary directory cleanup cannot fail otherwise-passing tests on Node 24.

## Coverage Notes

- This PR changes `src/app/(dashboard)/dashboard/api-manager/ApiManagerPageClient.tsx`.
- Coverage comes from the existing static API manager page test, updated to assert:
  - expiration values use local `datetime-local` formatting,
  - save path still writes ISO strings for valid input,
  - Clear button resets expiration state,
  - UTC string slicing is not reintroduced.
- The CI hardening changes are test-only and should not reduce production coverage.

## Reviewer Notes

- Root cause: `<input type="datetime-local">` has no timezone, but the old UI used `expiresAt.slice(0, 16)` on UTC ISO strings. That displayed UTC wall-clock fields as local fields, causing a shift after saving.
- Expiration enforcement already uses absolute epoch milliseconds (`new Date(expiresAt).getTime()` vs `Date.now()`), so the product fix is UI formatting only.
- No database migrations or feature flags.
