### PR TITLE
fix(responses): normalize image_url parts across input paths

### DIFF
--- a/open-sse/services/responsesInputSanitizer.ts
+++ b/open-sse/services/responsesInputSanitizer.ts
@@ -55,11 +55,64 @@ function sanitizeInputItemId(record: JsonRecord): JsonRecord {
   return next;
 }
 
+function imageUrlToText(value: unknown): string {
+  if (typeof value === "string") return value;
+  const record = toRecord(value);
+  return typeof record?.url === "string" ? record.url : "";
+}
+
+function sanitizeContentPart(part: unknown, role: string): unknown {
+  const record = toRecord(part);
+  if (!record) return part;
+
+  if (record.type === "image_url") {
+    const url = imageUrlToText(record.image_url);
+    if (role === "user") {
+      const next: JsonRecord = { type: "input_image", image_url: url };
+      const image = toRecord(record.image_url);
+      if (image?.detail !== undefined) next.detail = image.detail;
+      return next;
+    }
+    return { type: "output_text", text: url ? `[Image: ${url}]` : "[Image]" };
+  }
+
+  if (role === "assistant" && record.type === "input_image") {
+    const url = imageUrlToText(record.image_url);
+    return { type: "output_text", text: url ? `[Image: ${url}]` : "[Image]" };
+  }
+
+  return part;
+}
+
+function sanitizeMessageContent(record: JsonRecord): JsonRecord {
+  if (!Array.isArray(record.content)) return record;
+
+  const role = typeof record.role === "string" ? record.role.toLowerCase() : "";
+  const content = record.content.map((part) => sanitizeContentPart(part, role));
+  return { ...record, content };
+}
+
+function sanitizeOutputContent(record: JsonRecord): JsonRecord {
+  if (!Array.isArray(record.output)) return record;
+
+  // Some clients replay previous Responses output items inside the next
+  // Responses input. In that shape OpenAI validates `input[n].output[m].type`
+  // against output content part types, so legacy Chat-style `image_url` parts
+  // must be normalized here too, not only in message.content.
+  const role = record.type === "function_call_output" ? "user" : "assistant";
+  const output = record.output.map((part) => sanitizeContentPart(part, role));
+  return { ...record, output };
+}
+
 function sanitizeInputItem(item: unknown): unknown {
   const record = toRecord(item);
   if (!record) return item;
 
   let next = sanitizeInputItemId(record);
+  if (isResponsesMessageItem(next)) {
+    next = sanitizeMessageContent(next);
+  }
+  next = sanitizeOutputContent(next);
   if (
     (next.type === "function_call" || next.type === "function_call_output") &&
     typeof next.name === "string" &&

--- a/open-sse/translator/request/openai-responses.ts
+++ b/open-sse/translator/request/openai-responses.ts
@@ -13,7 +13,7 @@ type JsonRecord = Record<string, unknown>;
 const RESPONSES_STORE_MARKER = "_omnirouteResponsesStore";
 const COPILOT_REASONING_SUMMARY_MARKER = "_omnirouteCopilotReasoningSummary";
 
-// Forward-compatible regex: matches web_search, web_search_20250305, and any future versioned names.
+// Forward-compatible regex: matches web_search, web_search_20250305, and future versioned names.
 const WEB_SEARCH_TOOL_TYPES = /^web_search/;
 // tool_search is a Responses API built-in sent by newer Codex clients; it has no Chat Completions
 // equivalent and must be silently dropped (not rejected with 400).
@@ -32,6 +32,12 @@ function toArray(value: unknown): unknown[] {
 
 function toString(value: unknown, fallback = ""): string {
   return typeof value === "string" ? value : fallback;
+}
+
+function imageUrlToText(value: unknown): string {
+  if (typeof value === "string") return value;
+  const record = toRecord(value);
+  return toString(record.url);
 }
 
 function normalizeResponsesReasoningEffort(value: unknown): string {
@@ -492,6 +498,9 @@ export function openaiToOpenAIResponsesRequest(
           const contentItem = toRecord(contentValue);
           if (contentItem.type === "text") {
             outputContent.push({ type: "output_text", text: toString(contentItem.text) });
+          } else if (contentItem.type === "image_url") {
+            const url = imageUrlToText(contentItem.image_url);
+            outputContent.push({ type: "output_text", text: url ? `[Image: ${url}]` : "[Image]" });
           } else if (contentItem.type === "thinking" || contentItem.type === "redacted_thinking") {
             // Reasoning already moved above
             continue;

--- a/tests/unit/responses-input-sanitizer-name.test.ts
+++ b/tests/unit/responses-input-sanitizer-name.test.ts
@@ -72,3 +72,75 @@ test("keeps valid server reasoning item ids", () => {
   const result = sanitizeResponsesInputItems(items) as Array<Record<string, unknown>>;
   assert.equal(result[0].id, "rs_123");
 });
+
+test("normalizes user image_url content parts to input_image", () => {
+  const items = [
+    {
+      type: "message",
+      role: "user",
+      content: [{ type: "image_url", image_url: { url: "https://example.com/u.png", detail: "high" } }],
+    },
+  ];
+  const result = sanitizeResponsesInputItems(items) as Array<Record<string, unknown>>;
+  assert.deepEqual((result[0].content as unknown[])[0], {
+    type: "input_image",
+    image_url: "https://example.com/u.png",
+    detail: "high",
+  });
+});
+
+test("normalizes assistant image content parts to output_text", () => {
+  const items = [
+    {
+      type: "message",
+      role: "assistant",
+      content: [
+        { type: "image_url", image_url: { url: "https://example.com/a.png" } },
+        { type: "input_image", image_url: "https://example.com/b.png" },
+      ],
+    },
+  ];
+  const result = sanitizeResponsesInputItems(items) as Array<Record<string, unknown>>;
+  assert.deepEqual(result[0], {
+    type: "message",
+    role: "assistant",
+    content: [
+      { type: "output_text", text: "[Image: https://example.com/a.png]" },
+      { type: "output_text", text: "[Image: https://example.com/b.png]" },
+    ],
+  });
+});
+
+test("normalizes replayed Responses output image parts to output_text", () => {
+  const items = [
+    {
+      type: "message",
+      role: "assistant",
+      output: [{ type: "image_url", image_url: { url: "https://example.com/output.png" } }],
+    },
+  ];
+  const result = sanitizeResponsesInputItems(items) as Array<Record<string, unknown>>;
+  assert.deepEqual(result[0], {
+    type: "message",
+    role: "assistant",
+    output: [{ type: "output_text", text: "[Image: https://example.com/output.png]" }],
+  });
+  assert.equal(JSON.stringify(result).includes('"image_url"'), false);
+});
+
+test("normalizes function_call_output image output parts to input_image", () => {
+  const items = [
+    {
+      type: "function_call_output",
+      call_id: "call_1",
+      output: [{ type: "image_url", image_url: { url: "https://example.com/tool.png" } }],
+    },
+  ];
+  const result = sanitizeResponsesInputItems(items) as Array<Record<string, unknown>>;
+  assert.deepEqual(result[0], {
+    type: "function_call_output",
+    call_id: "call_1",
+    output: [{ type: "input_image", image_url: "https://example.com/tool.png" }],
+  });
+  assert.equal(JSON.stringify(result).includes('"type":"image_url"'), false);
+});

--- a/tests/unit/translator-openai-responses-req.test.ts
+++ b/tests/unit/translator-openai-responses-req.test.ts
@@ -356,6 +356,37 @@ test("Responses round-trip preserves store and previous_response_id when opt-in 
   assert.equal((result as any).instructions, "Rules");
 });
 
+test("Chat -> Responses converts assistant image_url history parts to output_text", () => {
+  const result = openaiToOpenAIResponsesRequest(
+    "gpt-4o",
+    {
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "I inspected the screenshot." },
+            { type: "image_url", image_url: { url: "https://example.com/scope.png" } },
+          ],
+        },
+      ],
+    },
+    true,
+    null
+  );
+
+  assert.deepEqual((result as any).input, [
+    {
+      type: "message",
+      role: "assistant",
+      content: [
+        { type: "output_text", text: "I inspected the screenshot." },
+        { type: "output_text", text: "[Image: https://example.com/scope.png]" },
+      ],
+    },
+  ]);
+  assert.equal(JSON.stringify(result).includes('"image_url"'), false);
+});
+
 test("Chat -> Responses preserves prompt_cache_key and session affinity fields", () => {
   const result = openaiToOpenAIResponsesRequest(
     "gpt-5.3-codex",


### PR DESCRIPTION
## Summary

Fixes a Responses API compatibility issue where legacy Chat Completions-style `image_url` content parts can leak into Responses input payloads through replayed history or tool output content.

Responses validates image/content part types differently depending on the JSON path:

- user/input message content expects `input_image`
- assistant output/history content expects `output_text`
- `function_call_output.output[]` accepts input-style parts such as `input_text` and `input_image`, but not `output_text`

Without this normalization, multimodal agent history/tool-output replay can fail upstream with schema errors like:

```txt
Invalid value: 'image_url'
param: input[n].output[m].type
```

or after partial conversion:

```txt
Invalid value: 'output_text'
param: input[n].output[m].type
```

## Changes

- Converts assistant Chat `image_url` history parts to Responses-safe `output_text`.
- Sanitizes replayed Responses `message.content[]` image parts.
- Sanitizes replayed `output[]` image parts.
- Treats `function_call_output.output[]` as input-style content, mapping legacy `image_url` parts to `input_image`.
- Adds regression coverage for assistant image history, replayed output image parts, and tool output image parts.

## Validation

Passed:

- `npm run typecheck:core`
- targeted unit tests:
  - `tests/unit/responses-input-sanitizer-name.test.ts`
  - `tests/unit/translator-openai-responses-req.test.ts`
- Docker build of a 3.8.9 image with this patch
- production smoke on a compose-managed OmniRoute 3.8.9 deployment:
  - `/v1/models` HTTP 200
  - models count: 132
  - Chat smoke with assistant `image_url` history: HTTP 200
  - no `Invalid value: 'image_url'` schema errors
  - no `Invalid value: 'output_text'` schema errors

Full `npm run test:unit` was also executed. It completed with 10,937 passing tests and 3 failures that appear unrelated to this patch area:

- `tests/unit/cli-doctor-command.test.ts`
- `tests/unit/cloudflaredTunnel-extended.test.ts`
- `tests/unit/quota-pool-update-full.test.ts`

This patch only touches the Responses translator/input sanitizer and related tests.
