### PR TITLE
fix(llama-cpp): route to configured local baseUrl instead of OpenAI (#3136)

### DIFF
--- a/open-sse/executors/default.ts
+++ b/open-sse/executors/default.ts
@@ -205,6 +205,7 @@ export class DefaultExecutor extends BaseExecutor {
         const baseUrl = credentials?.providerSpecificData?.baseUrl || this.config.baseUrl;
         return normalizeOpenAIChatUrl(baseUrl);
       }
+      case "llama-cpp":
       case "lm-studio":
       case "modal":
       case "reka":

--- a/tests/unit/llama-cpp-local-url.test.ts
+++ b/tests/unit/llama-cpp-local-url.test.ts
@@ -1,0 +1,20 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { DefaultExecutor } from "@omniroute/open-sse/executors/default.ts";
+
+// Regression for issue #3136: a `llama-cpp` local provider connection must send
+// requests to the user's configured local baseUrl, not OpenAI's API. Before the
+// fix, `llama-cpp` was missing from the local-provider case group in buildUrl(),
+// so it fell through to the registry/default path and (because llama-cpp is not
+// in the registry → DefaultExecutor falls back to PROVIDERS.openai) resolved to
+// https://api.openai.com/v1/... — producing OpenAI-worded 401 "no api key" errors.
+test("llama-cpp buildUrl routes to the configured local baseUrl, not OpenAI", () => {
+  const executor = new DefaultExecutor("llama-cpp");
+  const url = executor.buildUrl("some-model", true, 0, {
+    providerSpecificData: { baseUrl: "http://127.0.0.1:8080/v1" },
+  });
+
+  assert.equal(url, "http://127.0.0.1:8080/v1/chat/completions");
+  assert.ok(!url.includes("api.openai.com"), `expected local URL, got ${url}`);
+});


### PR DESCRIPTION
Closes #3136

`llama-cpp` was missing from the local-provider group in `buildUrl()`, so requests went to OpenAI's API (OpenAI-worded 401) instead of the user's local server. Adds the missing `case`.

Regression test: `tests/unit/llama-cpp-local-url.test.ts`. Thanks @tjengbudi.