### PR TITLE
fix(combo): invalidate nested-combo cache on edits + diagnose DATA_DIR (#3147)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@
 
 _Development cycle in progress — entries are added as work merges into `release/v3.8.10` and finalized by the release flow._
 
+### Bug Fixes
+
+- **fireworks:** preserve fully-qualified router/model IDs so Fire Pass router IDs (`accounts/fireworks/routers/...`) are no longer double-prefixed into an upstream 404. (#3133 — thanks @KooshaPari)
+- **llama-cpp:** route requests to the configured local baseUrl instead of OpenAI's API (which returned an OpenAI-worded 401). (#3136 — thanks @tjengbudi)
+- **t3-chat-web:** parse cookies + convexSessionId from the single stored credential so t3.chat web connections work (the executor previously read fields the credential pipeline never produced). (#3007 — thanks @minhtran162)
+- **minimax:** stop capping MiniMax-M3 / MiniMax-M2.7 `max_tokens` at the 8192 default — add the M3 model spec (512K output) and make model-spec lookups case-insensitive. (#3141 — thanks @totaltube)
+- **github-copilot:** discover the model catalog live from `api.githubcopilot.com/models` so Import Models refreshes and only entitled models are listed (with fallback to the static catalog). (#3120, #3121 — thanks @gabrielmoreira)
+- **combo:** invalidate the nested-combo cache on combo edits so removed targets/models stop being served within the 10s window; log the resolved DATA_DIR at startup to diagnose multi-replica volume mismatches. (#3147 — thanks @ViFigueiredo)
+
 ---
 
 ## [3.8.9] — 2026-06-03

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -1374,24 +1374,33 @@ const PROXY_CONFIG_CACHE_TTL = 10_000;
  */
 let _combosPromise: Promise<unknown[]> | null = null;
 let _combosCacheTs = 0;
+let _combosCacheVersionSnapshot = -1;
 const COMBOS_CACHE_TTL = 10_000;
 
 async function getCombosCached(): Promise<unknown[]> {
   const now = Date.now();
+  const { getCombos, getCombosCacheVersion } = await import("@/lib/localDb");
+  const version = getCombosCacheVersion();
+  // A combo write (create/update/delete/reorder) bumps the shared version via
+  // invalidateDbCache("combos"); when it no longer matches our snapshot we drop
+  // the cached promise so the nested-combo expansion stops serving removed
+  // targets/models within the 10s TTL window (#3147).
+  if (version !== _combosCacheVersionSnapshot) {
+    clearCombosCache();
+  }
   if (_combosPromise && now - _combosCacheTs < COMBOS_CACHE_TTL) {
     return _combosPromise;
   }
   _combosCacheTs = now;
-  _combosPromise = (async () => {
-    const { getCombos } = await import("@/lib/localDb");
-    return getCombos();
-  })();
+  _combosCacheVersionSnapshot = version;
+  _combosPromise = getCombos();
   return _combosPromise;
 }
 
 export function clearCombosCache() {
   _combosPromise = null;
   _combosCacheTs = 0;
+  _combosCacheVersionSnapshot = -1;
 }
 
 export function clearUpstreamProxyConfigCache(providerId?: string) {

--- a/src/lib/db/combos.ts
+++ b/src/lib/db/combos.ts
@@ -5,6 +5,7 @@
 import { v4 as uuidv4 } from "uuid";
 import { getDbInstance } from "./core";
 import { backupDbFile } from "./backup";
+import { invalidateDbCache } from "./readCache";
 import { normalizeComboRecord } from "@/lib/combos/steps";
 
 type JsonRecord = Record<string, unknown>;
@@ -138,6 +139,7 @@ export async function createCombo(data: JsonRecord) {
     "INSERT INTO combos (id, name, data, sort_order, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)"
   ).run(combo.id, combo.name, JSON.stringify(combo), sortOrder, now, now);
 
+  invalidateDbCache("combos");
   backupDbFile("pre-write");
   return combo;
 }
@@ -178,6 +180,7 @@ export async function updateCombo(id: string, data: JsonRecord) {
     "UPDATE combos SET name = ?, data = ?, sort_order = ?, updated_at = ? WHERE id = ?"
   ).run(nextName, JSON.stringify(normalizedMerged), sortOrder, normalizedMerged.updatedAt, id);
 
+  invalidateDbCache("combos");
   backupDbFile("pre-write");
   return normalizedMerged;
 }
@@ -249,6 +252,7 @@ export async function reorderCombos(comboIds: string[]) {
   });
 
   reorderTransaction();
+  invalidateDbCache("combos");
   backupDbFile("pre-write");
   return getCombos();
 }
@@ -257,6 +261,7 @@ export async function deleteCombo(id: string) {
   const db = getDbInstance();
   const result = db.prepare("DELETE FROM combos WHERE id = ?").run(id);
   if (result.changes === 0) return false;
+  invalidateDbCache("combos");
   backupDbFile("pre-write");
   return true;
 }

--- a/src/lib/db/core.ts
+++ b/src/lib/db/core.ts
@@ -1368,7 +1368,14 @@ export function getDbInstance(): SqliteDatabase {
   }
 
   startDbHealthCheckScheduler(db);
-  console.log(`[DB] SQLite database ready: ${sqliteFile}`);
+  // Log the resolved absolute DATA_DIR + SQLITE_FILE once at init so a
+  // multi-replica / Docker volume-topology mismatch (each replica opening a
+  // different on-disk DB → "phantom"/missing combos & connections) is
+  // diagnosable straight from the logs. (#3147)
+  console.log(
+    `[DB] SQLite database ready: ${sqliteFile} ` +
+      `(DATA_DIR=${path.resolve(DATA_DIR)}, SQLITE_FILE=${path.resolve(sqliteFile)})`
+  );
   return db;
 }
 

--- a/src/lib/db/readCache.ts
+++ b/src/lib/db/readCache.ts
@@ -142,11 +142,37 @@ export async function setCachedLKGP(
   lkgpCache.invalidate(`lkgp:${comboName}:${modelId}`);
 }
 
+// ──────────────── Combo Cache Invalidation Signal ────────────────
+//
+// The nested-combo expansion caches live in request handlers
+// (`src/sse/handlers/chat.ts` getCombosCachedForChat and
+// `open-sse/handlers/chatCore.ts` getCombosCached), each with a 10s TTL. A db
+// module must NOT import a request handler (that would create an import cycle),
+// so instead those caches consult this monotonically-incrementing version.
+// Combo writes call `invalidateDbCache("combos")`, which bumps the version;
+// the handlers compare the version they were populated at against the current
+// one and treat a mismatch as a cache miss — so combo edits take effect
+// immediately instead of after the 10s window (#3147).
+let combosCacheVersion = 0;
+
 /**
- * Invalidate all caches (call after writes to any of: settings, pricing, connections).
+ * Current combo-cache version. Cache layers snapshot this when they populate
+ * and re-read it on every access; a change means the underlying combos were
+ * written and the cached expansion must be refreshed.
  */
-export function invalidateDbCache(scope?: "settings" | "pricing" | "connections"): void {
+export function getCombosCacheVersion(): number {
+  return combosCacheVersion;
+}
+
+/**
+ * Invalidate all caches (call after writes to any of: settings, pricing,
+ * connections, combos).
+ */
+export function invalidateDbCache(
+  scope?: "settings" | "pricing" | "connections" | "combos"
+): void {
   if (!scope || scope === "settings") settingsCache.invalidate();
   if (!scope || scope === "pricing") pricingCache.invalidate();
   if (!scope || scope === "connections") connectionsCache.invalidate();
+  if (!scope || scope === "combos") combosCacheVersion++;
 }

--- a/src/lib/localDb.ts
+++ b/src/lib/localDb.ts
@@ -207,6 +207,7 @@ export {
   getCachedLKGP,
   setCachedLKGP,
   invalidateDbCache,
+  getCombosCacheVersion,
 } from "./db/readCache";
 
 export {

--- a/src/sse/handlers/chat.ts
+++ b/src/sse/handlers/chat.ts
@@ -37,6 +37,7 @@ import {
   deleteSessionAccountAffinity,
   getCachedSettings,
   getCombos,
+  getCombosCacheVersion,
   getSessionAccountAffinity,
 } from "@/lib/localDb";
 import {
@@ -129,17 +130,26 @@ registerOpencodeQuotaFetcher();
 registerGenericQuotaFetchers();
 let combosCachePromise: Promise<unknown[]> | null = null;
 let combosCacheTs = 0;
+let combosCacheVersionSnapshot = -1;
 const COMBOS_CACHE_TTL_MS = 10_000;
 
 async function getCombosCachedForChat(): Promise<unknown[]> {
   const now = Date.now();
   // Explicit non-null check: we intentionally cache and return the Promise
   // itself (to dedupe concurrent callers), so this is not a forgotten await.
-  if (combosCachePromise !== null && now - combosCacheTs < COMBOS_CACHE_TTL_MS) {
+  // The version check makes combo edits (create/update/delete/reorder) take
+  // effect immediately instead of after the 10s TTL — otherwise a removed
+  // target/model could keep being served as a "phantom" for up to 10s (#3147).
+  if (
+    combosCachePromise !== null &&
+    now - combosCacheTs < COMBOS_CACHE_TTL_MS &&
+    combosCacheVersionSnapshot === getCombosCacheVersion()
+  ) {
     return combosCachePromise;
   }
 
   combosCacheTs = now;
+  combosCacheVersionSnapshot = getCombosCacheVersion();
   combosCachePromise = getCombos().catch(() => []);
   return combosCachePromise;
 }

--- a/tests/unit/combo-cache-invalidation.test.ts
+++ b/tests/unit/combo-cache-invalidation.test.ts
@@ -1,0 +1,151 @@
+/**
+ * #3147 — Editing a combo must invalidate the 10s nested-combo expansion caches
+ * (src/sse/handlers/chat.ts getCombosCachedForChat + open-sse/handlers/chatCore.ts
+ * getCombosCached) so a parent combo's nested expansion stops serving removed
+ * targets/models ("phantom models") within the TTL window.
+ *
+ * Both cache layers consult a shared monotonic version exposed by readCache
+ * (getCombosCacheVersion). Combo writes call invalidateDbCache("combos"), which
+ * bumps that version. This test drives the real write path and asserts:
+ *   1. each combo write bumps the version (the invalidation hook fires), and
+ *   2. the chat-layer cache-validity predicate (which is what gates staleness)
+ *      flips from "valid" to "stale" immediately after a write — i.e. without
+ *      waiting for the 10s TTL.
+ *
+ * On current code (no invalidation) the version never changes, so the predicate
+ * stays "valid" for the full 10s window → the test FAILS. After the fix it
+ * PASSES.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-combo-cache-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const combosDb = await import("../../src/lib/db/combos.ts");
+const readCache = await import("../../src/lib/db/readCache.ts");
+
+async function resetStorage() {
+  core.resetDbInstance();
+
+  for (let attempt = 0; attempt < 10; attempt++) {
+    try {
+      if (fs.existsSync(TEST_DATA_DIR)) {
+        fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+      }
+      break;
+    } catch (error: any) {
+      if ((error?.code === "EBUSY" || error?.code === "EPERM") && attempt < 9) {
+        await new Promise((resolve) => setTimeout(resolve, 50 * (attempt + 1)));
+      } else {
+        throw error;
+      }
+    }
+  }
+
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+test.beforeEach(async () => {
+  await resetStorage();
+});
+
+test.after(async () => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+// Mirror the cache-validity predicate used by the handler cache layers
+// (getCombosCachedForChat / getCombosCached): a cached entry is only reused
+// while it is within the TTL AND the combo version it was populated at still
+// matches the current version. We freeze "now" so the TTL never expires on its
+// own — the ONLY thing that can make the cache stale here is the version bump.
+const COMBOS_CACHE_TTL_MS = 10_000;
+function cacheStillValid(populatedAtTs: number, populatedAtVersion: number): boolean {
+  const now = populatedAtTs; // same instant → TTL has not elapsed
+  return (
+    now - populatedAtTs < COMBOS_CACHE_TTL_MS &&
+    populatedAtVersion === readCache.getCombosCacheVersion()
+  );
+}
+
+test("createCombo bumps the combos cache version (invalidation hook fires)", async () => {
+  const before = readCache.getCombosCacheVersion();
+  await combosDb.createCombo({
+    name: "Alpha",
+    models: [{ provider: "openai", model: "gpt-4.1" }],
+  });
+  assert.notEqual(
+    readCache.getCombosCacheVersion(),
+    before,
+    "createCombo must invalidate the combos cache"
+  );
+});
+
+test("editing a combo invalidates the nested-expansion cache within the 10s window", async () => {
+  // Warm the cache: snapshot version + timestamp as the handler layers do.
+  const populatedAtTs = Date.now();
+  const populatedAtVersion = readCache.getCombosCacheVersion();
+  await combosDb.createCombo({
+    name: "Child",
+    models: [{ provider: "openai", model: "gpt-4o-mini" }],
+  });
+  const parent = await combosDb.createCombo({
+    name: "Parent",
+    models: ["Child", { model: "anthropic/claude-sonnet-4", weight: 2 }],
+  });
+
+  // A write happened → the cache populated before it must now be considered
+  // stale even though the (frozen) TTL has not elapsed.
+  assert.equal(
+    cacheStillValid(populatedAtTs, populatedAtVersion),
+    false,
+    "cache populated before the combo writes must be invalidated immediately"
+  );
+
+  // Re-warm against the post-write state, then mutate again and confirm the
+  // edit (update) is also picked up within the window.
+  const freshTs = Date.now();
+  const freshVersion = readCache.getCombosCacheVersion();
+  assert.equal(cacheStillValid(freshTs, freshVersion), true);
+
+  await combosDb.updateCombo((parent as any).id, { strategy: "round-robin" });
+  assert.equal(
+    cacheStillValid(freshTs, freshVersion),
+    false,
+    "updateCombo must invalidate the cache without waiting for the TTL"
+  );
+});
+
+test("deleteCombo and reorderCombos also invalidate the cache", async () => {
+  const a = await combosDb.createCombo({
+    name: "A",
+    models: [{ provider: "openai", model: "gpt-4.1" }],
+  });
+  const b = await combosDb.createCombo({
+    name: "B",
+    models: [{ provider: "anthropic", model: "claude-3-7-sonnet" }],
+  });
+
+  let ts = Date.now();
+  let version = readCache.getCombosCacheVersion();
+  await combosDb.reorderCombos([(b as any).id, (a as any).id]);
+  assert.equal(
+    cacheStillValid(ts, version),
+    false,
+    "reorderCombos must invalidate the cache"
+  );
+
+  ts = Date.now();
+  version = readCache.getCombosCacheVersion();
+  await combosDb.deleteCombo((a as any).id);
+  assert.equal(
+    cacheStillValid(ts, version),
+    false,
+    "deleteCombo must invalidate the cache"
+  );
+});


### PR DESCRIPTION
Partially addresses #3147.

A deep investigation found two of the three reported symptoms ("provider removal ignored", "no failover on 429") are **not** code bugs — the router reads combos/connections fresh and the failover loop advances correctly; that symptom (persisting across restart + volume wipe) is a Docker **DATA_DIR / multi-replica volume mismatch** on the deployment side (OmniRoute uses SQLite, not Redis).

One **confirmed** code bug is fixed here: combo edits did not invalidate the 10s nested-combo expansion cache (`clearCombosCache` was dead code), so a removed nested target/model could be served as a phantom for up to 10s. Now wired via a shared combos-cache version in `readCache`.

Also adds a startup log of the resolved `DATA_DIR`/`SQLITE_FILE` to diagnose the volume-topology root cause.

Regression test: `tests/unit/combo-cache-invalidation.test.ts`. Also carries the consolidated CHANGELOG entries for the other 5 fixes in this batch. Thanks @ViFigueiredo.