### PR TITLE
fix(providerRegistry): update kilocode format and executor

### DIFF
--- a/open-sse/config/providerRegistry.ts
+++ b/open-sse/config/providerRegistry.ts
@@ -1861,8 +1861,8 @@ const _REGISTRY_EAGER: Record<string, RegistryEntry> = {
   kilocode: {
     id: "kilocode",
     alias: "kc",
-    format: "openrouter",
-    executor: "openrouter",
+    format: "openai",
+    executor: "default",
     baseUrl: "https://api.kilo.ai/api/openrouter/chat/completions",
     modelsUrl: "https://api.kilo.ai/api/openrouter/models",
     authType: "oauth",

--- a/tests/unit/provider-registry-kilocode-format.test.ts
+++ b/tests/unit/provider-registry-kilocode-format.test.ts
@@ -1,0 +1,33 @@
+/**
+ * #3166 — kilocode must use the OpenAI-compatible format + default executor.
+ *
+ * kilocode hits an `api.kilo.ai` endpoint (`/api/openrouter/chat/completions`)
+ * that returns the OpenAI chat-completions shape — the same family as its
+ * sibling `kilo-gateway`. It was previously registered with
+ * `format/executor: "openrouter"`, which applied OpenRouter-specific handling
+ * the endpoint does not expect. Align it with `kilo-gateway` (format "openai",
+ * executor "default").
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { REGISTRY } = await import("../../open-sse/config/providerRegistry.ts");
+
+test("#3166 kilocode uses the OpenAI format + default executor (matches kilo-gateway)", () => {
+  const reg = REGISTRY as Record<string, Record<string, unknown>>;
+  const kilocode = reg.kilocode;
+  assert.ok(kilocode, "kilocode should be present in the executor registry");
+  assert.equal(kilocode.format, "openai");
+  assert.equal(kilocode.executor, "default");
+
+  // Consistency with the sibling api.kilo.ai provider.
+  const gateway = reg["kilo-gateway"];
+  if (gateway) {
+    assert.equal(kilocode.format, gateway.format, "kilocode format must match kilo-gateway");
+    assert.equal(
+      kilocode.executor,
+      gateway.executor,
+      "kilocode executor must match kilo-gateway"
+    );
+  }
+});


### PR DESCRIPTION
## Summary

- Kilo calls are still not logged correctly in call_logs in 3.8.9.
- This change allows the call to be logged and no more '[STREAM] Error in flush (openrouter/free): Cannot read properties of null (reading 'choices')' in terminal

## Related Issues

- Related to #3003

## Validation

- [ ] `npm run lint`
- [ ] `npm run test:unit`
- [ ] `npm run test:coverage`
- [ ] Coverage is still `>= 60%` for statements, lines, functions, and branches
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below

## Tests Added Or Updated

- List every changed or added automated test file.
- If no production code changed, state that here.

## Coverage Notes

- If this PR changes `src/`, `open-sse/`, `electron/`, or `bin/`, explain which tests cover the change.
- If coverage moved down in any touched file, explain why and what follow-up task will recover it.

## Reviewer Notes

- Call out any risky areas, migrations, feature flags, or manual validation that reviewers should know about.