### PR TITLE
fix(providers): empty refresh must not resurface just-cleared synced models

### DIFF
--- a/src/app/api/providers/[id]/models/route.ts
+++ b/src/app/api/providers/[id]/models/route.ts
@@ -923,10 +923,52 @@ export async function GET(
         });
       }
 
-      const fallback = buildLocalCatalogResponse(
-        "No remote models discovered — using local catalog"
-      );
-      if (fallback) return fallback;
+      // Empty discovery just cleared THIS connection's synced cache (via
+      // persistDiscoveredModels([])). `providerSyncedModels` was read at the top
+      // of the handler and is now stale, so it must not leak the just-cleared
+      // models back into the response (#3148 made synced authoritative for the
+      // normal path; here we re-read the current state instead). Re-derive the
+      // local catalog from the provider's remaining synced models (union across
+      // its other connections) or the static catalog when none remain.
+      let freshSynced: Awaited<ReturnType<typeof getSyncedAvailableModels>> = [];
+      try {
+        freshSynced = await getSyncedAvailableModels(provider);
+      } catch {
+        /* DB unavailable — fall through to static catalog */
+      }
+      const freshRegistry = freshSynced.length
+        ? freshSynced.map((m) => ({
+            id: m.id,
+            name: m.name || m.id,
+            ...(m.apiFormat ? { apiFormat: m.apiFormat } : {}),
+            ...(m.supportedEndpoints ? { supportedEndpoints: m.supportedEndpoints } : {}),
+          }))
+        : getModelsByProviderId(provider) || [];
+      const freshSpecialty = freshSynced.length ? [] : getStaticModelsForProvider(provider) || [];
+      const freshLocal = mergeLocalCatalogModels(freshRegistry, freshSpecialty).map((model) => ({
+        id: model.id,
+        name: model.name || model.id,
+        ...((model as Record<string, unknown>).apiFormat
+          ? { apiFormat: (model as Record<string, unknown>).apiFormat as string | undefined }
+          : {}),
+        ...((model as Record<string, unknown>).supportedEndpoints
+          ? {
+              supportedEndpoints: (model as Record<string, unknown>).supportedEndpoints as
+                | string[]
+                | undefined,
+            }
+          : {}),
+        ...(freshRegistry.length > 0 ? { owned_by: provider } : {}),
+      }));
+      if (freshLocal.length > 0) {
+        return buildResponse({
+          provider,
+          connectionId,
+          models: freshLocal,
+          source: "local_catalog",
+          warning: "No remote models discovered — using local catalog",
+        });
+      }
 
       return buildResponse({
         provider,


### PR DESCRIPTION
## Why

The combined release-branch validation (typecheck + full test:unit) surfaced one **real** pre-existing failure:

```
✖ provider models route clears cached discovery when a refresh returns no remote models
  assert.ok(body.models.every((model) => model.id !== "cached-go"))  // false
```

Root cause — interaction of two prior merges: #3148 (synced models become the authoritative local catalog) × #3120. On `GET /api/providers/[id]/models?refresh=true` with an empty upstream result, `persistDiscoveredModels([])` clears **this connection's** synced cache, but the handler's top-level `providerSyncedModels` snapshot (read before the refresh) was stale and leaked the just-cleared models back into the `local_catalog` fallback.

## Fix

In the empty-discovery branch of `buildApiDiscoveryResponse`, re-read the provider's synced models so the response reflects the **current** (cleared) state — the union across the provider's remaining connections, or the static catalog when none remain. The normal (non-refresh) path keeps #3148's behavior untouched.

## Validation (TDD — the existing test is the regression guard)

- `provider models route clears cached discovery when a refresh returns no remote models` → was **red**, now **green**.
- Full `tests/unit/provider-models-route.test.ts` suite: **54/54** (incl. the #3148 synced-authoritative test — no regression).
- `typecheck:core` clean, lint clean.

> Release-blocker for v3.8.10 — needed before `/generate-release`.