### PR TITLE
fix(security/quality): clear CodeQL high + SonarCloud reliability gate (v3.8.10 hardening)

### DIFF
--- a/open-sse/executors/antigravity.ts
+++ b/open-sse/executors/antigravity.ts
@@ -54,9 +54,9 @@ const MAX_RETRY_AFTER_MS = 60_000;
 const LONG_RETRY_THRESHOLD_MS = 60_000;
 const CREDITS_EXHAUSTED_TTL_MS = 5 * 60 * 60 * 1000; // 5 hours
 // The upstream API uses plain model IDs (no -high/-low suffix).
-// Tier suffixes were speculative and caused 404 for gemini-3.x models.
-// Only keep models that are live-proven via streamGenerateContent.
-const BARE_PRO_IDS: Set<string> = new Set();
+// Tier suffixes were speculative and caused 404 for gemini-3.x models — the
+// bare-Pro→Low normalization was retired (the set stayed empty, making the guard
+// dead code). Only keep models that are live-proven via streamGenerateContent.
 
 interface AntigravityContent {
   role: string;
@@ -432,11 +432,6 @@ async function cleanModelName(model: string): Promise<string> {
     clean = resolveAntigravityModelId(clean);
   }
 
-  // 3. Normalize bare Pro IDs to the Low tier (matching OpenClaw convention).
-  //    The upstream API requires an explicit tier suffix; bare IDs cause errors.
-  if (BARE_PRO_IDS.has(clean)) {
-    clean = `${clean}-low`;
-  }
   return clean;
 }
 

--- a/tests/unit/llama-cpp-local-url.test.ts
+++ b/tests/unit/llama-cpp-local-url.test.ts
@@ -16,5 +16,8 @@ test("llama-cpp buildUrl routes to the configured local baseUrl, not OpenAI", ()
   });
 
   assert.equal(url, "http://127.0.0.1:8080/v1/chat/completions");
-  assert.ok(!url.includes("api.openai.com"), `expected local URL, got ${url}`);
+  // Assert the resolved host is the local one — parse the URL and compare the
+  // hostname exactly (a substring check like `url.includes("api.openai.com")`
+  // is an incomplete URL sanitization pattern: `api.openai.com.evil` would match).
+  assert.equal(new URL(url).hostname, "127.0.0.1", `expected local host, got ${url}`);
 });


### PR DESCRIPTION
Post-merge hardening for the v3.8.10 release — turns the pipeline green:

- **CodeQL HIGH** (`js/incomplete-url-substring-sanitization`) in `tests/unit/llama-cpp-local-url.test.ts`: replaced the `url.includes("api.openai.com")` substring check with an exact parsed-hostname comparison (`new URL(url).hostname`).
- **SonarCloud reliability BUG** in `open-sse/executors/antigravity.ts`: `BARE_PRO_IDS` was an always-empty `Set`, so the `if (BARE_PRO_IDS.has(clean))` normalization was dead code. Removed the set + the dead branch (no behavior change).

Validation: affected tests 29/29, `typecheck:core` clean, lint 0 errors. Both were the only gate-failing findings on #3140.