### PR TITLE
fix: use api.anthropic.com for Claude OAuth token exchange to avoid Cloudflare bot blocking

### DIFF
--- a/open-sse/config/constants.ts
+++ b/open-sse/config/constants.ts
@@ -67,8 +67,8 @@ export const OAUTH_ENDPOINTS = {
     auth: "https://auth.openai.com/oauth/authorize",
   },
   anthropic: {
-    token: "https://console.anthropic.com/v1/oauth/token",
-    auth: "https://console.anthropic.com/v1/oauth/authorize",
+    token: "https://api.anthropic.com/v1/oauth/token",
+    auth: "https://api.anthropic.com/v1/oauth/authorize",
   },
   qwen: {
     token: "https://chat.qwen.ai/api/v1/oauth2/token", // From CLIProxyAPI

--- a/src/lib/oauth/constants/oauth.ts
+++ b/src/lib/oauth/constants/oauth.ts
@@ -36,7 +36,7 @@ import { buildGitLabOAuthEndpoints, GITLAB_DUO_DEFAULT_BASE_URL } from "../gitla
 export const CLAUDE_CONFIG = {
   clientId: process.env.CLAUDE_OAUTH_CLIENT_ID || "9d1c250a-e61b-44d9-88ed-5944d1962f5e",
   authorizeUrl: "https://claude.ai/oauth/authorize",
-  tokenUrl: "https://console.anthropic.com/v1/oauth/token",
+  tokenUrl: "https://api.anthropic.com/v1/oauth/token",
   redirectUri:
     process.env.CLAUDE_CODE_REDIRECT_URI || "https://platform.claude.com/oauth/code/callback",
   scopes: [


### PR DESCRIPTION
## Problem

On self-hosted VPS instances, connecting a Claude account via OAuth fails with an internal server error. The browser-side authorization flow completes successfully, but the server-side token exchange returns a Cloudflare challenge page instead of the token.

**Error in logs:**
```
OAuth POST error: Error: Token exchange failed: <!DOCTYPE html>...<title>Just a moment...</title>
...Cloudflare challenge... cZone: 'console.anthropic.com'
```

## Root Cause

`console.anthropic.com` is behind **Cloudflare Bot Management**. When a headless server makes a server-to-server `POST` to `https://console.anthropic.com/v1/oauth/token`, Cloudflare blocks it as a bot request and returns a JS challenge page.

This affects **all self-hosted deployments on VPS/cloud servers**.

## Fix

Use `api.anthropic.com` instead — Anthropic's public API domain, designed for programmatic access and not behind Cloudflare bot protection.

Both endpoints accept the same OAuth token exchange payload.

## Changes

- `src/lib/oauth/constants/oauth.ts`: `tokenUrl` → `api.anthropic.com`
- `open-sse/config/constants.ts`: `token` + `auth` → `api.anthropic.com`

## Reference

Closes #3192