### PR TITLE
fix(provider-models): keep a deleted synced model deleted across re-fetch (#3199)

### DIFF
--- a/src/app/api/provider-models/route.ts
+++ b/src/app/api/provider-models/route.ts
@@ -399,6 +399,12 @@ export async function DELETE(request) {
 
     const removedCustom = await removeCustomModel(provider, modelId);
     const removedSynced = await removeSyncedAvailableModel(provider, modelId);
+    if (removedSynced) {
+      // #3199: mark the deleted synced model hidden so a later auto-fetch
+      // re-import (replaceSyncedAvailableModelsForConnection) does not re-add it
+      // — otherwise the model reappears and the delete looks like it did nothing.
+      mergeModelCompatOverride(provider, modelId, { isHidden: true });
+    }
     const removed = removedCustom || removedSynced;
     const removedAliases = await deleteManagedAvailableModelAliases(provider, [modelId]);
     return Response.json({ removed, aliasChanges: { removed: removedAliases, assigned: [] } });

--- a/src/lib/db/models.ts
+++ b/src/lib/db/models.ts
@@ -714,7 +714,11 @@ export async function replaceSyncedAvailableModelsForConnection(
 ): Promise<SyncedAvailableModel[]> {
   const db = getDbInstance();
   const key = `${providerId}:${connectionId}`;
-  const normalizedModels = normalizeSyncedAvailableModels(models);
+  // #3199: drop ids the operator has deleted/hidden so a re-fetch does not
+  // re-import a model that was explicitly removed.
+  const normalizedModels = normalizeSyncedAvailableModels(models).filter(
+    (m) => !getModelIsHidden(providerId, m.id)
+  );
   if (normalizedModels.length === 0) {
     db.prepare("DELETE FROM key_value WHERE namespace = 'syncedAvailableModels' AND key = ?").run(
       key

--- a/tests/unit/synced-model-delete-persist-3199.test.ts
+++ b/tests/unit/synced-model-delete-persist-3199.test.ts
@@ -1,0 +1,55 @@
+/**
+ * #3199 follow-up to #3204 — a deleted synced (fetched) model must STAY deleted
+ * across an auto-fetch re-import.
+ *
+ * #3204 added `removeSyncedAvailableModel`, but the DELETE route did not mark the
+ * model hidden and `replaceSyncedAvailableModelsForConnection` did not skip hidden
+ * ids — so the next `/models` sync re-imported the model and it reappeared. This
+ * test guards that a hidden id is filtered out on re-import.
+ */
+import test, { before, after } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  replaceSyncedAvailableModelsForConnection,
+  getSyncedAvailableModels,
+  mergeModelCompatOverride,
+} from "../../src/lib/localDb.ts";
+import { resetDbInstance } from "../../src/lib/db/core.ts";
+
+before(() => {
+  resetDbInstance();
+});
+
+after(() => {
+  resetDbInstance();
+});
+
+test("a hidden (deleted) synced model is not re-added on re-import", async () => {
+  const provider = "llama-cpp";
+  const connectionId = "conn-3199";
+
+  // Initial sync brings in two models.
+  await replaceSyncedAvailableModelsForConnection(provider, connectionId, [
+    { id: "model-keep", name: "Keep" },
+    { id: "model-del", name: "Delete me" },
+  ]);
+  let synced = (await getSyncedAvailableModels(provider)).map((m) => m.id);
+  assert.ok(synced.includes("model-del"), "both models present after first sync");
+
+  // Operator deletes model-del → the route marks it hidden (#3199).
+  mergeModelCompatOverride(provider, "model-del", { isHidden: true });
+
+  // Auto-fetch re-imports the SAME upstream list (still advertising model-del).
+  await replaceSyncedAvailableModelsForConnection(provider, connectionId, [
+    { id: "model-keep", name: "Keep" },
+    { id: "model-del", name: "Delete me" },
+  ]);
+
+  synced = (await getSyncedAvailableModels(provider)).map((m) => m.id);
+  assert.ok(synced.includes("model-keep"), "non-deleted model stays");
+  assert.ok(
+    !synced.includes("model-del"),
+    "deleted (hidden) model must NOT be re-added by the re-import"
+  );
+});


### PR DESCRIPTION
Closes #3199 (follow-up to #3204).

#3204 added the synced-model delete, but a deleted model **reappeared** on the next auto-fetch: the DELETE route didn't mark it hidden and `replaceSyncedAvailableModelsForConnection` didn't skip hidden ids. Now the route marks the id hidden on delete and the re-import filters hidden ids, so the deletion persists (which is what the reporter needs — otherwise the model 'can't be deleted').

Regression test: `tests/unit/synced-model-delete-persist-3199.test.ts` (fails on the pre-fix re-import path). Thanks @tjengbudi.