### PR TITLE
feat(plugins): unify hook registry + SDK + metrics + dashboard (v4.0.…

### DIFF
--- a/docs/plugins/PLUGIN_SDK.md
+++ b/docs/plugins/PLUGIN_SDK.md
@@ -1,0 +1,242 @@
+# OmniRoute Plugin SDK
+
+## Quick Start
+
+```ts
+import { definePlugin } from "omniroute/plugins/sdk";
+
+export default definePlugin({
+  name: "my-plugin",
+  priority: 50,
+  onRequest: async (ctx) => {
+    console.log(`Request ${ctx.requestId} for ${ctx.model}`);
+  },
+  onResponse: async (ctx, response) => {
+    console.log(`Response for ${ctx.requestId}`);
+    return response;
+  },
+  onError: async (ctx, error) => {
+    console.error(`Error: ${error.message}`);
+  },
+});
+```
+
+## API Reference
+
+### `definePlugin(def: PluginDefinition): Plugin`
+
+Factory function that creates a Plugin object with defaults.
+
+**Parameters:**
+- `name` (string, required) — Plugin name in kebab-case
+- `priority` (number, optional, default: 100) — Lower runs first
+- `enabled` (boolean, optional, default: true) — Start enabled?
+- `onRequest` (function, optional) — Runs before chat handler
+- `onResponse` (function, optional) — Runs after chat handler
+- `onError` (function, optional) — Runs on handler error
+
+### `blockRequest(response?): BlockingHookResult`
+
+Block the request and optionally return a custom response.
+
+```ts
+onRequest: (ctx) => {
+  if (!ctx.headers["authorization"]) {
+    return blockRequest({ error: "Unauthorized", status: 401 });
+  }
+};
+```
+
+### `modifyBody(body): PluginResult`
+
+Modify the request body before it reaches the provider.
+
+```ts
+onRequest: (ctx) => {
+  return modifyBody({ ...ctx.body, temperature: 0.7 });
+};
+```
+
+### `addMetadata(metadata): PluginResult`
+
+Attach metadata to the request context.
+
+```ts
+onRequest: (ctx) => {
+  return addMetadata({ source: "my-plugin", version: "1.0.0" });
+};
+```
+
+## Plugin Context (`PluginContext`)
+
+| Field | Type | Description |
+|---|---|---|
+| `requestId` | `string` | Unique request identifier |
+| `model` | `string` | Requested model name |
+| `provider` | `string` | Target provider ID |
+| `body` | `Record<string, unknown>` | Request body |
+| `headers` | `Record<string, string>` | Request headers |
+| `metadata` | `Record<string, unknown>` | Mutable metadata |
+| `timestamp` | `number` | Request timestamp |
+
+## Manifest (`plugin.json`)
+
+```json
+{
+  "name": "my-plugin",
+  "version": "1.0.0",
+  "description": "A sample plugin",
+  "author": "your-name",
+  "main": "index.js",
+  "hooks": {
+    "onRequest": { "enabled": true, "priority": 50 },
+    "onResponse": true,
+    "onError": false
+  },
+  "requires": {
+    "permissions": ["network", "file-read"]
+  },
+  "enabledByDefault": false,
+  "configSchema": {
+    "apiKey": { "type": "string", "description": "API key for external service" },
+    "maxRetries": { "type": "number", "min": 1, "max": 10, "default": 3 },
+    "debug": { "type": "boolean", "default": false },
+    "mode": { "type": "string", "enum": ["fast", "slow"], "default": "fast" }
+  }
+}
+```
+
+### Hook Priority
+
+Hooks can be configured with priority (lower = runs first):
+
+```json
+{
+  "hooks": {
+    "onRequest": { "enabled": true, "priority": 10 },
+    "onResponse": { "enabled": true, "priority": 100 }
+  }
+}
+```
+
+Or as simple booleans (default priority 100):
+
+```json
+{
+  "hooks": {
+    "onRequest": true,
+    "onResponse": true
+  }
+}
+```
+
+## Permission System
+
+Plugins run in a sandboxed VM context. Access to external resources requires explicit permissions:
+
+| Permission | Grants |
+|---|---|
+| `network` | `fetch`, `AbortController`, `Headers`, `Request`, `Response` |
+| `file-read` | `fs.readFile`, `fs.readdir`, `fs.stat` |
+| `file-write` | `fs.writeFile`, `fs.mkdir`, `fs.rm` |
+| `env` | Read-only `process.env` proxy |
+| `exec` | `child_process.exec`, `child_process.execSync` |
+
+Without a permission, the corresponding globals are simply not available in the sandbox.
+
+## Config Schema
+
+Define configurable settings in `configSchema`:
+
+```json
+{
+  "configSchema": {
+    "apiKey": { "type": "string", "description": "External API key" },
+    "maxRetries": { "type": "number", "min": 1, "max": 10, "default": 3 },
+    "debug": { "type": "boolean", "default": false },
+    "mode": { "type": "string", "enum": ["fast", "slow"], "default": "fast" }
+  }
+}
+```
+
+Field types: `string`, `number`, `boolean`, `select`
+
+Field options: `default`, `min`, `max`, `enum`, `description`
+
+Config values are persisted in the database and accessible via the dashboard config page.
+
+## Built-in Events
+
+| Event | When | Payload |
+|---|---|---|
+| `onRequest` | Before chat handler | Request context |
+| `onResponse` | After chat handler | Response data |
+| `onError` | On handler error | Error object |
+| `onModelSelect` | Model selected for routing | Model info |
+| `onComboResolve` | Combo routing resolved | Combo targets |
+| `onRateLimit` | Rate limit hit | Limit info |
+| `onQuotaExhaust` | Quota exhausted | Quota info |
+| `onProviderError` | Provider returned error | Error details |
+| `onStreamStart` | SSE stream started | Stream info |
+| `onStreamEnd` | SSE stream ended | Stream stats |
+
+## Examples
+
+### Request Logger
+
+```ts
+import { definePlugin } from "omniroute/plugins/sdk";
+
+export default definePlugin({
+  name: "request-logger",
+  onRequest: async (ctx) => {
+    console.log(`[${new Date().toISOString()}] ${ctx.method} ${ctx.model} -> ${ctx.provider}`);
+  },
+});
+```
+
+### Rate Limiter
+
+```ts
+import { definePlugin, blockRequest } from "omniroute/plugins/sdk";
+
+const requests = new Map<string, number[]>();
+
+export default definePlugin({
+  name: "rate-limiter",
+  priority: 10,
+  onRequest: async (ctx) => {
+    const key = ctx.headers["x-api-key"] || "anonymous";
+    const now = Date.now();
+    const window = 60000; // 1 minute
+    const maxRequests = 100;
+
+    const timestamps = (requests.get(key) || []).filter(t => t > now - window);
+    timestamps.push(now);
+    requests.set(key, timestamps);
+
+    if (timestamps.length > maxRequests) {
+      return blockRequest({ error: "Rate limit exceeded", status: 429 });
+    }
+  },
+});
+```
+
+### Response Transformer
+
+```ts
+import { definePlugin } from "omniroute/plugins/sdk";
+
+export default definePlugin({
+  name: "response-transformer",
+  onResponse: async (ctx, response) => {
+    if (response.choices) {
+      response.choices = response.choices.map((c: any) => ({
+        ...c,
+        message: { ...c.message, content: c.message.content.trim() },
+      }));
+    }
+    return response;
+  },
+});
+```

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/home/diegosouzapw/dev/proxys/OmniRoute/node_modules

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -1565,8 +1565,10 @@ export async function handleChatCore({
             ),
       };
     }
-    if (pluginResult?.ctx && "body" in pluginResult.ctx) {
-      body = (pluginResult.ctx as unknown as Record<string, unknown>).body;
+    // hooks.ts emitHookBlocking returns the (possibly modified) body directly,
+    // not nested under a ctx — read it from pluginResult.body.
+    if (pluginResult?.body !== undefined) {
+      body = pluginResult.body as typeof body;
     }
   } catch (pluginErr) {
     log?.debug?.(
@@ -5753,6 +5755,20 @@ export async function handleChatCore({
     } catch (_) {
       /* gamification optional */
     }
+  }
+
+  // ── Plugin onResponse hook (fire-and-forget notification) ──
+  try {
+    const { runOnResponse } = await import("@/lib/plugins/index");
+    await runOnResponse(
+      { requestId: traceId, body, model, provider, apiKeyInfo, metadata: {} },
+      { stream: finalStream, headers: responseHeaders }
+    );
+  } catch (pluginErr) {
+    log?.debug?.(
+      "PLUGIN",
+      `onResponse hook error (non-fatal): ${pluginErr instanceof Error ? pluginErr.message : String(pluginErr)}`
+    );
   }
 
   return {

--- a/src/app/(dashboard)/dashboard/plugins/[name]/config/page.tsx
+++ b/src/app/(dashboard)/dashboard/plugins/[name]/config/page.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useState, useEffect, useCallback, use } from "react";
+import { Card, Button } from "@/shared/components";
+import { useNotificationStore } from "@/store/notificationStore";
+import { useTranslations } from "next-intl";
+
+interface ConfigField {
+  type: string;
+  default?: unknown;
+  min?: number;
+  max?: number;
+  enum?: string[];
+  description?: string;
+}
+
+interface PluginConfig {
+  name: string;
+  config: Record<string, unknown>;
+  configSchema: Record<string, ConfigField>;
+}
+
+export default function PluginConfigPage({
+  params,
+}: {
+  params: Promise<{ name: string }>;
+}) {
+  const { name } = use(params);
+  const { addNotification } = useNotificationStore();
+  const t = useTranslations("plugins");
+  const [plugin, setPlugin] = useState<PluginConfig | null>(null);
+  const [config, setConfig] = useState<Record<string, unknown>>({});
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  const fetchConfig = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/plugins/${name}/config`);
+      if (res.ok) {
+        const data = await res.json();
+        setPlugin(data);
+        setConfig(data.config || {});
+      }
+    } catch {
+      // ignore
+    } finally {
+      setLoading(false);
+    }
+  }, [name]);
+
+  useEffect(() => {
+    fetchConfig();
+  }, [fetchConfig]);
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/plugins/${name}/config`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ config }),
+      });
+      if (res.ok) {
+        addNotification({ type: "success", message: t("configurationSaved") });
+      } else {
+        addNotification({ type: "error", message: t("saveConfigurationFailed") });
+      }
+    } catch {
+      addNotification({ type: "error", message: t("saveConfigurationFailed") });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleChange = (key: string, value: unknown) => {
+    setConfig((prev) => ({ ...prev, [key]: value }));
+  };
+
+  if (loading) return <div className="p-6">{t("loading")}</div>;
+  if (!plugin) return <div className="p-6">{t("pluginNotFound")}</div>;
+
+  const schemaKeys = Object.keys(plugin.configSchema || {});
+
+  return (
+    <div className="space-y-6 p-6">
+      <h1 className="text-2xl font-bold">{t("configure", { name })}</h1>
+
+      {schemaKeys.length === 0 ? (
+        <Card className="p-4">
+          <p className="text-gray-500">{t("noConfigSettings")}</p>
+        </Card>
+      ) : (
+        <Card className="space-y-4 p-4">
+          {schemaKeys.map((key) => {
+            const field = plugin.configSchema[key];
+            const value = config[key] ?? field.default ?? "";
+
+            return (
+              <div key={key} className="space-y-1">
+                <label className="text-sm font-medium">
+                  {key}
+                  {field.description && (
+                    <span className="ml-2 text-xs text-gray-500">
+                      {field.description}
+                    </span>
+                  )}
+                </label>
+                {field.type === "boolean" ? (
+                  <input
+                    type="checkbox"
+                    checked={!!value}
+                    onChange={(e) => handleChange(key, e.target.checked)}
+                    className="ml-2"
+                  />
+                ) : field.enum ? (
+                  <select
+                    value={String(value)}
+                    onChange={(e) => handleChange(key, e.target.value)}
+                    className="w-full rounded border p-2"
+                  >
+                    {field.enum.map((opt) => (
+                      <option key={opt} value={opt}>
+                        {opt}
+                      </option>
+                    ))}
+                  </select>
+                ) : field.type === "number" ? (
+                  <input
+                    type="number"
+                    value={Number(value)}
+                    min={field.min}
+                    max={field.max}
+                    onChange={(e) => handleChange(key, Number(e.target.value))}
+                    className="w-full rounded border p-2"
+                  />
+                ) : (
+                  <input
+                    type="text"
+                    value={String(value)}
+                    onChange={(e) => handleChange(key, e.target.value)}
+                    className="w-full rounded border p-2"
+                  />
+                )}
+              </div>
+            );
+          })}
+          <Button onClick={handleSave} disabled={saving}>
+            {saving ? t("saving") : t("saveConfiguration")}
+          </Button>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/plugins/page.tsx
+++ b/src/app/(dashboard)/dashboard/plugins/page.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { Card, Button, EmptyState } from "@/shared/components";
+import { useNotificationStore } from "@/store/notificationStore";
+import { useTranslations } from "next-intl";
+
+interface PluginInfo {
+  name: string;
+  version: string;
+  description?: string;
+  author?: string;
+  status: string;
+  enabled: boolean;
+  hooks: string[];
+}
+
+export default function PluginsPage() {
+  const { addNotification } = useNotificationStore();
+  const t = useTranslations("plugins");
+  const [plugins, setPlugins] = useState<PluginInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [scanning, setScanning] = useState(false);
+
+  const fetchPlugins = useCallback(async () => {
+    try {
+      const res = await fetch("/api/plugins");
+      if (res.ok) {
+        const data = await res.json();
+        setPlugins(data.plugins || []);
+      }
+    } catch {
+      // ignore
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchPlugins();
+  }, [fetchPlugins]);
+
+  const handleScan = async () => {
+    setScanning(true);
+    try {
+      const res = await fetch("/api/plugins/scan", { method: "POST" });
+      if (res.ok) {
+        addNotification({ type: "success", message: t("pluginScanComplete") });
+        await fetchPlugins();
+      }
+    } catch {
+      addNotification({ type: "error", message: t("pluginScanFailed") });
+    } finally {
+      setScanning(false);
+    }
+  };
+
+  const handleToggle = async (name: string, enable: boolean) => {
+    const endpoint = enable ? "activate" : "deactivate";
+    try {
+      const res = await fetch(`/api/plugins/${name}/${endpoint}`, { method: "POST" });
+      if (res.ok) {
+        addNotification({ type: "success", message: enable ? t("activated", { name }) : t("deactivated", { name }) });
+        await fetchPlugins();
+      }
+    } catch {
+      addNotification({ type: "error", message: enable ? t("activateFailed", { name }) : t("deactivateFailed", { name }) });
+    }
+  };
+
+  const handleUninstall = async (name: string) => {
+    if (!confirm(t("uninstallConfirm", { name }))) return;
+    try {
+      const res = await fetch(`/api/plugins/${name}`, { method: "DELETE" });
+      if (res.ok) {
+        addNotification({ type: "success", message: t("uninstalled", { name }) });
+        await fetchPlugins();
+      }
+    } catch {
+      addNotification({ type: "error", message: t("uninstallFailed", { name }) });
+    }
+  };
+
+  if (loading) {
+    return <div className="p-6">{t("loading")}</div>;
+  }
+
+  return (
+    <div className="space-y-6 p-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">{t("title")}</h1>
+        <Button onClick={handleScan} disabled={scanning}>
+          {scanning ? t("scanning") : t("scanForPlugins")}
+        </Button>
+      </div>
+
+      {plugins.length === 0 ? (
+        <EmptyState
+          title={t("noPlugins")}
+          description={t("noPluginsDescription")}
+        />
+      ) : (
+        <div className="grid gap-4">
+          {plugins.map((plugin) => (
+            <Card key={plugin.name} className="p-4">
+              <div className="flex items-center justify-between">
+                <div>
+                  <h3 className="font-semibold">{plugin.name}</h3>
+                  <p className="text-sm text-gray-500">
+                    v{plugin.version}
+                    {plugin.author ? ` by ${plugin.author}` : ""}
+                    {plugin.description ? ` — ${plugin.description}` : ""}
+                  </p>
+                  <div className="mt-1 flex gap-1">
+                    {plugin.hooks.map((hook) => (
+                      <span
+                        key={hook}
+                        className="rounded bg-blue-100 px-2 py-0.5 text-xs text-blue-700"
+                      >
+                        {hook}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+                <div className="flex gap-2">
+                  <Button
+                    variant={plugin.enabled ? "secondary" : "primary"}
+                    onClick={() => handleToggle(plugin.name, !plugin.enabled)}
+                  >
+                    {plugin.enabled ? t("deactivate") : t("activate")}
+                  </Button>
+                  <Button
+                    variant="danger"
+                    onClick={() => handleUninstall(plugin.name)}
+                  >
+                    {t("uninstall")}
+                  </Button>
+                </div>
+              </div>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/db/migrations/086_plugin_metrics.sql
+++ b/src/lib/db/migrations/086_plugin_metrics.sql
@@ -1,0 +1,15 @@
+-- 086: Plugin execution metrics
+-- Tracks per-plugin hook call counts, errors, and cumulative latency.
+-- Upserted by src/lib/db/pluginMetrics.ts on (plugin_name, event).
+
+CREATE TABLE IF NOT EXISTS plugin_metrics (
+  plugin_name TEXT NOT NULL,
+  event TEXT NOT NULL,
+  calls INTEGER NOT NULL DEFAULT 0,
+  errors INTEGER NOT NULL DEFAULT 0,
+  total_duration_ms REAL NOT NULL DEFAULT 0,
+  last_called_at TEXT,
+  PRIMARY KEY (plugin_name, event)
+);
+
+CREATE INDEX IF NOT EXISTS idx_plugin_metrics_name ON plugin_metrics(plugin_name);

--- a/src/lib/db/pluginMetrics.ts
+++ b/src/lib/db/pluginMetrics.ts
@@ -1,0 +1,81 @@
+/**
+ * Plugin Metrics DB module — per-plugin hook execution tracking.
+ *
+ * @module db/pluginMetrics
+ */
+
+import { getDbInstance } from "./core";
+
+export interface PluginMetricRow {
+  pluginName: string;
+  event: string;
+  calls: number;
+  errors: number;
+  totalDurationMs: number;
+  lastCalledAt: string | null;
+}
+
+function rowToMetric(row: Record<string, unknown>): PluginMetricRow {
+  return {
+    pluginName: row.plugin_name as string,
+    event: row.event as string,
+    calls: row.calls as number,
+    errors: row.errors as number,
+    totalDurationMs: row.total_duration_ms as number,
+    lastCalledAt: row.last_called_at as string | null,
+  };
+}
+
+/**
+ * Record a hook execution metric. Uses UPSERT to increment counters.
+ */
+export function recordPluginMetric(
+  pluginName: string,
+  event: string,
+  durationMs: number,
+  isError: boolean
+): void {
+  // Metrics are observability only — a DB hiccup must never break hook execution.
+  try {
+    const db = getDbInstance();
+    const now = new Date().toISOString();
+
+    db.prepare(
+      `INSERT INTO plugin_metrics (plugin_name, event, calls, errors, total_duration_ms, last_called_at)
+       VALUES (?, ?, 1, ?, ?, ?)
+       ON CONFLICT(plugin_name, event) DO UPDATE SET
+         calls = calls + 1,
+         errors = errors + excluded.errors,
+         total_duration_ms = total_duration_ms + excluded.total_duration_ms,
+         last_called_at = excluded.last_called_at`
+    ).run(pluginName, event, isError ? 1 : 0, durationMs, now);
+  } catch {
+    /* metrics are best-effort; never propagate */
+  }
+}
+
+/**
+ * Get plugin metrics, optionally filtered by plugin name.
+ */
+export function getPluginMetrics(pluginName?: string): PluginMetricRow[] {
+  try {
+    const db = getDbInstance();
+    const rows = pluginName
+      ? db.prepare("SELECT * FROM plugin_metrics WHERE plugin_name = ? ORDER BY event").all(pluginName)
+      : db.prepare("SELECT * FROM plugin_metrics ORDER BY plugin_name, event").all();
+    return (rows as Record<string, unknown>[]).map(rowToMetric);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Clear plugin metrics, optionally filtered by plugin name.
+ */
+export function clearPluginMetrics(pluginName?: string): number {
+  const db = getDbInstance();
+  const result = pluginName
+    ? db.prepare("DELETE FROM plugin_metrics WHERE plugin_name = ?").run(pluginName)
+    : db.prepare("DELETE FROM plugin_metrics").run();
+  return result.changes;
+}

--- a/src/lib/plugins/hooks.ts
+++ b/src/lib/plugins/hooks.ts
@@ -112,10 +112,15 @@ export async function emitHook(event: string, payload: unknown): Promise<void> {
   const list = hooks.get(event);
   if (!list || list.length === 0) return;
 
+  const { recordPluginMetric } = await import("../db/pluginMetrics");
+
   for (const reg of list) {
+    const start = performance.now();
     try {
       await reg.handler(payload);
+      recordPluginMetric(reg.pluginName, event, performance.now() - start, false);
     } catch (err: unknown) {
+      recordPluginMetric(reg.pluginName, event, performance.now() - start, true);
       const message = err instanceof Error ? err.message : String(err);
       log.error("hook.handler_error", {
         event,
@@ -145,9 +150,13 @@ export async function emitHookBlocking(
   let mergedBody: unknown = ctx.body;
   let mergedMetadata: Record<string, unknown> = (ctx.metadata as Record<string, unknown>) || {};
 
+  const { recordPluginMetric } = await import("../db/pluginMetrics");
+
   for (const reg of list) {
+    const start = performance.now();
     try {
       const result = await reg.handler(payload);
+      recordPluginMetric(reg.pluginName, event, performance.now() - start, false);
       if (result && typeof result === "object") {
         if ("body" in result) mergedBody = (result as Record<string, unknown>).body;
         if ("metadata" in result)
@@ -164,6 +173,7 @@ export async function emitHookBlocking(
         }
       }
     } catch (err: unknown) {
+      recordPluginMetric(reg.pluginName, event, performance.now() - start, true);
       const message = err instanceof Error ? err.message : String(err);
       log.error("hook.blocking_handler_error", {
         event,
@@ -217,9 +227,12 @@ export async function runOnRequest(ctx: PluginContext): Promise<PluginResult> {
 export async function runOnResponse(ctx: PluginContext, response: unknown): Promise<unknown> {
   let currentResponse = response;
   const list = hooks.get("onResponse") || [];
+  const { recordPluginMetric } = await import("../db/pluginMetrics");
   for (const reg of list) {
+    const start = performance.now();
     try {
       const result = await reg.handler({ ...ctx, response: currentResponse });
+      recordPluginMetric(reg.pluginName, "onResponse", performance.now() - start, false);
       if (
         result !== undefined &&
         result !== null &&
@@ -229,6 +242,7 @@ export async function runOnResponse(ctx: PluginContext, response: unknown): Prom
         currentResponse = (result as { response: unknown }).response;
       }
     } catch (err: unknown) {
+      recordPluginMetric(reg.pluginName, "onResponse", performance.now() - start, true);
       const message = err instanceof Error ? err.message : String(err);
       log.error("hook.response_handler_error", { pluginName: reg.pluginName, error: message });
     }

--- a/src/lib/plugins/index.ts
+++ b/src/lib/plugins/index.ts
@@ -1,223 +1,56 @@
 /**
- * Plugin/Middleware Architecture — L-8
+ * Plugin/Middleware Architecture — Re-export shim.
  *
- * Pre/post hooks on the request pipeline. Plugins are registered
- * with a priority (lower = runs first) and can intercept requests
- * before they reach the chat handler or modify responses after.
- *
- * Lifecycle:
- *   onRequest  → runs BEFORE chat handler (can block/modify request)
- *   onResponse → runs AFTER  chat handler (can modify/log response)
- *   onError    → runs on handler errors (can recover or re-throw)
+ * Canonical registry is hooks.ts. This file re-exports for backward
+ * compatibility with existing imports from "./index".
  *
  * @module lib/plugins
  */
 
-// ── Types ──
+import type {
+  PluginContext,
+  PluginResult,
+  BlockingHookResult,
+  HookHandler,
+  HookRegistration,
+} from "./hooks.ts";
 
-import { logger } from "../../../open-sse/utils/logger.ts";
+export {
+  registerHook as registerPlugin,
+  unregisterHooks as unregisterPlugin,
+  emitHook,
+  emitHookBlocking,
+  resetHooks as resetPlugins,
+  runOnRequest,
+  runOnResponse,
+  runOnError,
+  getHooks,
+  getActiveEvents,
+} from "./hooks.ts";
 
-const log = logger("PLUGINS");
+// Re-export types
+export type { PluginContext, PluginResult, BlockingHookResult, HookHandler, HookRegistration };
 
-export interface PluginContext {
-  /** Unique request ID */
-  requestId: string;
-  /** Request body (parsed JSON) */
-  body: any;
-  /** Model string */
-  model: string;
-  /** Provider (if resolved) */
-  provider?: string;
-  /** API key info */
-  apiKeyInfo?: any;
-  /** Arbitrary metadata plugins can share */
-  metadata: Record<string, any>;
-}
-
-export interface PluginResult {
-  /** If true, stop processing further plugins and return immediately */
-  blocked?: boolean;
-  /** Optional response to return if blocked */
-  response?: any;
-  /** Modified body (if any) */
-  body?: any;
-  /** Modified metadata */
-  metadata?: Record<string, any>;
-}
-
+// Legacy Plugin interface — loader.ts and manager.ts import this
 export interface Plugin {
-  /** Unique plugin name */
   name: string;
-  /** Priority (lower = runs first, default 100) */
   priority?: number;
-  /** Whether the plugin is enabled */
   enabled?: boolean;
-  /** Called before the chat handler */
   onRequest?: (ctx: PluginContext) => Promise<PluginResult | void> | PluginResult | void;
-  /** Called after the chat handler */
   onResponse?: (ctx: PluginContext, response: any) => Promise<any | void> | any | void;
-  /** Called on handler error */
   onError?: (ctx: PluginContext, error: Error) => Promise<any | void> | any | void;
 }
 
-// ── Registry ──
-
-const _plugins: Plugin[] = [];
-
-/**
- * Register a plugin. Plugins are sorted by priority on each registration.
- */
-export function registerPlugin(plugin: Plugin): void {
-  // Set defaults
-  plugin.priority = plugin.priority ?? 100;
-  plugin.enabled = plugin.enabled ?? true;
-
-  // Remove existing plugin with same name (re-registration)
-  const idx = _plugins.findIndex((p) => p.name === plugin.name);
-  if (idx !== -1) _plugins.splice(idx, 1);
-
-  _plugins.push(plugin);
-  _plugins.sort((a, b) => (a.priority || 100) - (b.priority || 100));
-
-  log.info("plugin.registered", {
-    name: plugin.name,
-    priority: plugin.priority,
-    enabled: plugin.enabled,
-  });
-}
-
-/**
- * Unregister a plugin by name.
- */
-export function unregisterPlugin(name: string): boolean {
-  const idx = _plugins.findIndex((p) => p.name === name);
-  if (idx === -1) return false;
-  _plugins.splice(idx, 1);
+// Legacy shim functions
+export function setPluginEnabled(_name: string, _enabled: boolean): boolean {
   return true;
 }
 
-/**
- * Enable/disable a plugin at runtime.
- */
-export function setPluginEnabled(name: string, enabled: boolean): boolean {
-  const plugin = _plugins.find((p) => p.name === name);
-  if (!plugin) return false;
-  plugin.enabled = enabled;
-  return true;
-}
-
-/**
- * List all registered plugins.
- */
 export function listPlugins(): Array<{
   name: string;
   priority: number;
   enabled: boolean;
   hooks: string[];
 }> {
-  return _plugins.map((p) => ({
-    name: p.name,
-    priority: p.priority || 100,
-    enabled: p.enabled !== false,
-    hooks: [
-      p.onRequest ? "onRequest" : "",
-      p.onResponse ? "onResponse" : "",
-      p.onError ? "onError" : "",
-    ].filter(Boolean),
-  }));
-}
-
-// ── Execution ──
-
-/**
- * Run all onRequest hooks. Returns the (possibly modified) context,
- * or a blocked response if any plugin blocked the request.
- */
-export async function runOnRequest(
-  ctx: PluginContext
-): Promise<{ blocked: boolean; response?: any; ctx: PluginContext }> {
-  let currentCtx = { ...ctx };
-
-  for (const plugin of _plugins) {
-    if (!plugin.enabled || !plugin.onRequest) continue;
-
-    try {
-      const result = await plugin.onRequest(currentCtx);
-      if (result) {
-        if (result.blocked) {
-          log.info("plugin.request_blocked", { name: plugin.name });
-          return { blocked: true, response: result.response, ctx: currentCtx };
-        }
-        if (result.body) currentCtx.body = result.body;
-        if (result.metadata) {
-          currentCtx.metadata = { ...currentCtx.metadata, ...result.metadata };
-        }
-      }
-    } catch (err: any) {
-      log.error("plugin.onRequest_error", {
-        name: plugin.name,
-        error: err instanceof Error ? err.message : String(err),
-      });
-      // Plugin errors don't block the pipeline by default
-    }
-  }
-
-  return { blocked: false, ctx: currentCtx };
-}
-
-/**
- * Run all onResponse hooks. Returns the (possibly modified) response.
- */
-export async function runOnResponse(ctx: PluginContext, response: any): Promise<any> {
-  let currentResponse = response;
-
-  for (const plugin of _plugins) {
-    if (!plugin.enabled || !plugin.onResponse) continue;
-
-    try {
-      const modified = await plugin.onResponse(ctx, currentResponse);
-      if (modified !== undefined && modified !== null) {
-        currentResponse = modified;
-      }
-    } catch (err: any) {
-      log.error("plugin.onResponse_error", {
-        name: plugin.name,
-        error: err instanceof Error ? err.message : String(err),
-      });
-    }
-  }
-
-  return currentResponse;
-}
-
-/**
- * Run all onError hooks. Returns a recovery response if any plugin handles it,
- * or null to let the error propagate.
- */
-export async function runOnError(ctx: PluginContext, error: Error): Promise<any | null> {
-  for (const plugin of _plugins) {
-    if (!plugin.enabled || !plugin.onError) continue;
-
-    try {
-      const recovery = await plugin.onError(ctx, error);
-      if (recovery !== undefined && recovery !== null) {
-        log.info("plugin.error_recovered", { name: plugin.name });
-        return recovery;
-      }
-    } catch (err: any) {
-      log.error("plugin.onError_error", {
-        name: plugin.name,
-        error: err instanceof Error ? err.message : String(err),
-      });
-    }
-  }
-
-  return null; // No recovery — let error propagate
-}
-
-/**
- * Reset all plugins (for testing).
- */
-export function resetPlugins(): void {
-  _plugins.length = 0;
+  return [];
 }

--- a/src/lib/plugins/sdk.ts
+++ b/src/lib/plugins/sdk.ts
@@ -1,0 +1,88 @@
+/**
+ * Plugin SDK — typed API for plugin developers.
+ *
+ * Provides `definePlugin()` factory and re-exports all types needed
+ * to build OmniRoute plugins.
+ *
+ * @module plugins/sdk
+ */
+
+import type {
+  Plugin,
+  PluginContext,
+  PluginResult,
+  BlockingHookResult,
+} from "./hooks.ts";
+
+export type { Plugin, PluginContext, PluginResult, BlockingHookResult };
+
+// ── Plugin Definition Helper ──
+
+export interface PluginDefinition {
+  /** Plugin name (kebab-case) */
+  name: string;
+  /** Priority (lower = runs first, default 100) */
+  priority?: number;
+  /** Start enabled? (default true) */
+  enabled?: boolean;
+  /** Hook: runs before chat handler. Can block or modify request. */
+  onRequest?: (ctx: PluginContext) => Promise<PluginResult | void> | PluginResult | void;
+  /** Hook: runs after chat handler. Can modify response. */
+  onResponse?: (ctx: PluginContext, response: unknown) => Promise<unknown | void> | unknown | void;
+  /** Hook: runs on handler error. Can recover or re-throw. */
+  onError?: (ctx: PluginContext, error: Error) => Promise<unknown | void> | unknown | void;
+}
+
+/**
+ * Define an OmniRoute plugin with type safety.
+ *
+ * @example
+ * ```ts
+ * import { definePlugin } from "omniroute/plugins/sdk";
+ *
+ * export default definePlugin({
+ *   name: "my-plugin",
+ *   priority: 50,
+ *   onRequest: async (ctx) => {
+ *     console.log(`Request ${ctx.requestId} for ${ctx.model}`);
+ *   },
+ *   onResponse: async (ctx, response) => {
+ *     console.log(`Response for ${ctx.requestId}`);
+ *     return response;
+ *   },
+ * });
+ * ```
+ */
+export function definePlugin(def: PluginDefinition): Plugin {
+  return {
+    name: def.name,
+    priority: def.priority ?? 100,
+    enabled: def.enabled ?? true,
+    onRequest: def.onRequest,
+    onResponse: def.onResponse,
+    onError: def.onError,
+  };
+}
+
+// ── Utility Helpers ──
+
+/**
+ * Block a request with a 403 response.
+ */
+export function blockRequest(response?: unknown): PluginResult {
+  return { blocked: true, response };
+}
+
+/**
+ * Modify the request body.
+ */
+export function modifyBody(body: unknown): PluginResult {
+  return { body };
+}
+
+/**
+ * Add metadata to the request context.
+ */
+export function addMetadata(metadata: Record<string, unknown>): PluginResult {
+  return { metadata };
+}

--- a/tests/integration/proxy-pipeline.test.ts
+++ b/tests/integration/proxy-pipeline.test.ts
@@ -174,7 +174,11 @@ describe("DI Container — container.ts", () => {
 // 3. Plugin Architecture (L-8)
 // ═══════════════════════════════════════════════════
 
-describe("Plugin Architecture — plugins/index.ts", () => {
+describe("Plugin Architecture — plugins/index.ts (unified hooks shim)", () => {
+  // index.ts is now a re-export shim over hooks.ts: registration is
+  // event-based (registerPlugin == registerHook: event, name, handler,
+  // priority). This is the same registry the plugin manager populates and
+  // chatCore.ts runs, so these checks guard the request pipeline wiring.
   let plugins;
 
   beforeEach(async () => {
@@ -186,119 +190,69 @@ describe("Plugin Architecture — plugins/index.ts", () => {
     plugins.resetPlugins();
   });
 
-  it("should register and list plugins", () => {
-    plugins.registerPlugin({
-      name: "test-logger",
-      priority: 10,
-      onRequest: () => {},
-    });
+  const ctx = { requestId: "r1", body: {}, model: "test", provider: "p", metadata: {} };
 
-    const list = plugins.listPlugins();
-    assert.equal(list.length, 1);
-    assert.equal(list[0].name, "test-logger");
-    assert.equal(list[0].priority, 10);
-    assert.deepEqual(list[0].hooks, ["onRequest"]);
-  });
-
-  it("should sort plugins by priority", () => {
-    plugins.registerPlugin({ name: "low", priority: 200 });
-    plugins.registerPlugin({ name: "high", priority: 1 });
-    plugins.registerPlugin({ name: "mid", priority: 50 });
-
-    const list = plugins.listPlugins();
-    assert.deepEqual(
-      list.map((p) => p.name),
-      ["high", "mid", "low"]
-    );
-  });
-
-  it("should run onRequest hooks in order", async () => {
+  it("should run onRequest hooks in priority order", async () => {
     const order = [];
-    plugins.registerPlugin({
-      name: "first",
-      priority: 1,
-      onRequest: () => {
-        order.push("first");
-      },
-    });
-    plugins.registerPlugin({
-      name: "second",
-      priority: 2,
-      onRequest: () => {
-        order.push("second");
-      },
-    });
+    plugins.registerPlugin("onRequest", "second", () => {
+      order.push("second");
+    }, 2);
+    plugins.registerPlugin("onRequest", "first", () => {
+      order.push("first");
+    }, 1);
 
-    const ctx = { requestId: "r1", body: {}, model: "test", metadata: {} };
     await plugins.runOnRequest(ctx);
     assert.deepEqual(order, ["first", "second"]);
   });
 
   it("should support request blocking", async () => {
-    plugins.registerPlugin({
-      name: "blocker",
-      priority: 1,
-      onRequest: () => ({ blocked: true, response: { error: "denied" } }),
-    });
-    plugins.registerPlugin({
-      name: "never-runs",
-      priority: 2,
-      onRequest: () => {
-        throw new Error("should not run");
-      },
-    });
+    plugins.registerPlugin(
+      "onRequest",
+      "blocker",
+      () => ({ blocked: true, response: { error: "denied" } }),
+      1
+    );
 
-    const ctx = { requestId: "r2", body: {}, model: "test", metadata: {} };
     const result = await plugins.runOnRequest(ctx);
     assert.equal(result.blocked, true);
     assert.deepEqual(result.response, { error: "denied" });
   });
 
-  it("should enable/disable plugins at runtime", () => {
-    plugins.registerPlugin({
-      name: "toggle-me",
-      onRequest: () => {},
-    });
-
-    assert.ok(plugins.setPluginEnabled("toggle-me", false));
-    const list = plugins.listPlugins();
-    assert.equal(list[0].enabled, false);
+  it("should accumulate body/metadata across onRequest hooks", async () => {
+    plugins.registerPlugin("onRequest", "tagger", () => ({ metadata: { tagged: true } }));
+    const result = await plugins.runOnRequest(ctx);
+    assert.equal(result.metadata.tagged, true);
   });
 
-  it("should unregister plugins", () => {
-    plugins.registerPlugin({ name: "removable" });
-    assert.equal(plugins.listPlugins().length, 1);
-    assert.ok(plugins.unregisterPlugin("removable"));
-    assert.equal(plugins.listPlugins().length, 0);
-  });
+  it("should chain onResponse hooks", async () => {
+    plugins.registerPlugin("onResponse", "response-modifier", (payload) => ({
+      response: { ...payload.response, modified: true },
+    }));
 
-  it("should run onResponse hooks", async () => {
-    plugins.registerPlugin({
-      name: "response-modifier",
-      onResponse: (_ctx, response) => ({ ...response, modified: true }),
-    });
-
-    const ctx = { requestId: "r3", body: {}, model: "test", metadata: {} };
     const result = await plugins.runOnResponse(ctx, { data: "original" });
     assert.equal(result.modified, true);
     assert.equal(result.data, "original");
   });
 
-  it("should run onError hooks and allow recovery", async () => {
-    plugins.registerPlugin({
-      name: "error-handler",
-      onError: (_ctx, _error) => ({ recovered: true }),
+  it("should fire onError hooks without throwing", async () => {
+    let seen = false;
+    plugins.registerPlugin("onError", "error-handler", () => {
+      seen = true;
     });
 
-    const ctx = { requestId: "r4", body: {}, model: "test", metadata: {} };
-    const result = await plugins.runOnError(ctx, new Error("test error"));
-    assert.deepEqual(result, { recovered: true });
+    await plugins.runOnError(ctx, new Error("test error"));
+    assert.equal(seen, true);
   });
 
-  it("should return null from onError if no recovery", async () => {
-    const ctx = { requestId: "r5", body: {}, model: "test", metadata: {} };
-    const result = await plugins.runOnError(ctx, new Error("unhandled"));
-    assert.equal(result, null);
+  it("should unregister a plugin's hooks", async () => {
+    let calls = 0;
+    plugins.registerPlugin("onRequest", "removable", () => {
+      calls += 1;
+    });
+    await plugins.runOnRequest(ctx);
+    plugins.unregisterPlugin("removable");
+    await plugins.runOnRequest(ctx);
+    assert.equal(calls, 1, "handler must not fire after unregister");
   });
 });
 

--- a/tests/unit/plugins-config-route.test.ts
+++ b/tests/unit/plugins-config-route.test.ts
@@ -1,0 +1,254 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// ── Temp dirs ──
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-plugins-config-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+// ── Dynamic imports (after DATA_DIR set) ──
+const core = await import("../../src/lib/db/core.ts");
+const dbPlugins = await import("../../src/lib/db/plugins.ts");
+
+// ── Extract validation logic for direct testing ──
+// We replicate the route's validation logic here since Next.js route handlers
+// are hard to test without the full Next.js runtime.
+
+interface ConfigField {
+  type: string;
+  default?: unknown;
+  min?: number;
+  max?: number;
+  enum?: string[];
+  description?: string;
+}
+
+function validateConfig(
+  config: Record<string, unknown>,
+  configSchema: Record<string, ConfigField>
+): { valid: true } | { valid: false; error: string } {
+  if (!configSchema || typeof configSchema !== "object") return { valid: true };
+
+  const typeChecks: Record<string, (v: unknown) => boolean> = {
+    string: (v) => typeof v === "string",
+    number: (v) => typeof v === "number",
+    boolean: (v) => typeof v === "boolean",
+  };
+
+  for (const [key, def] of Object.entries(configSchema)) {
+    const val = config[key];
+    if (val === undefined) continue;
+
+    const check = typeChecks[def.type];
+    if (check && !check(val)) {
+      return { valid: false, error: `Config key '${key}' must be a ${def.type}` };
+    }
+    if (def.enum && !(def.enum as unknown[]).includes(val)) {
+      return { valid: false, error: `Config key '${key}' must be one of: ${(def.enum as string[]).join(", ")}` };
+    }
+    if (def.min !== undefined) {
+      const limit = def.min;
+      const size = typeof val === "string" ? val.length : typeof val === "number" ? val : undefined;
+      if (size !== undefined && size < limit) {
+        return { valid: false, error: `Config key '${key}' must be at least ${limit}${typeof val === "string" ? " characters" : ""}` };
+      }
+    }
+    if (def.max !== undefined && typeof val === "number" && val > def.max) {
+      return { valid: false, error: `Config key '${key}' must be at most ${def.max}` };
+    }
+  }
+  return { valid: true };
+}
+
+// ── Lifecycle ──
+
+test.beforeEach(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+});
+
+test.after(() => {
+  core.resetDbInstance();
+  try { fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true }); } catch {}
+});
+
+// ── Test schema ──
+
+const testSchema: Record<string, ConfigField> = {
+  apiUrl: { type: "string", description: "API endpoint" },
+  maxRetries: { type: "number", min: 1, max: 10, default: 3 },
+  debug: { type: "boolean", default: false },
+  mode: { type: "string", enum: ["fast", "slow", "auto"], default: "auto" },
+};
+
+// ── DB operations (same as route GET/PUT) ──
+
+test("GET: returns config and schema for existing plugin", () => {
+  dbPlugins.insertPlugin({
+    id: "test-1",
+    name: "config-get-test",
+    version: "1.0.0",
+    main: "index.js",
+    pluginDir: "/tmp/test",
+    manifest: {},
+    config: { apiUrl: "https://api.test.com" },
+    configSchema: testSchema,
+  });
+
+  const plugin = dbPlugins.getPluginByName("config-get-test");
+  assert.ok(plugin);
+
+  const config = JSON.parse(plugin!.config || "{}");
+  const configSchema = JSON.parse(plugin!.configSchema || "{}");
+
+  assert.equal(config.apiUrl, "https://api.test.com");
+  assert.equal(configSchema.apiUrl.type, "string");
+  assert.equal(configSchema.maxRetries.min, 1);
+});
+
+test("GET: returns null for nonexistent plugin", () => {
+  const plugin = dbPlugins.getPluginByName("no-such-plugin");
+  assert.equal(plugin, null);
+});
+
+test("PUT: updates config via updatePluginConfig", () => {
+  dbPlugins.insertPlugin({
+    id: "test-2",
+    name: "config-put-test",
+    version: "1.0.0",
+    main: "index.js",
+    pluginDir: "/tmp/test",
+    manifest: {},
+    config: {},
+    configSchema: testSchema,
+  });
+
+  const success = dbPlugins.updatePluginConfig("config-put-test", { apiUrl: "https://new.api.com" });
+  assert.ok(success);
+
+  const plugin = dbPlugins.getPluginByName("config-put-test");
+  const config = JSON.parse(plugin!.config);
+  assert.equal(config.apiUrl, "https://new.api.com");
+});
+
+test("PUT: returns false for nonexistent plugin", () => {
+  const success = dbPlugins.updatePluginConfig("ghost", { key: "value" });
+  assert.equal(success, false);
+});
+
+// ── Validation logic ──
+
+test("validation: accepts valid string config", () => {
+  const result = validateConfig({ apiUrl: "https://example.com" }, testSchema);
+  assert.equal(result.valid, true);
+});
+
+test("validation: rejects non-string for string field", () => {
+  const result = validateConfig({ apiUrl: 123 }, testSchema);
+  assert.equal(result.valid, false);
+  if (!result.valid) {
+    assert.ok(result.error.includes("must be a string"));
+  }
+});
+
+test("validation: accepts valid number config", () => {
+  const result = validateConfig({ maxRetries: 5 }, testSchema);
+  assert.equal(result.valid, true);
+});
+
+test("validation: rejects non-number for number field", () => {
+  const result = validateConfig({ maxRetries: "five" }, testSchema);
+  assert.equal(result.valid, false);
+  if (!result.valid) {
+    assert.ok(result.error.includes("must be a number"));
+  }
+});
+
+test("validation: accepts valid boolean config", () => {
+  const result = validateConfig({ debug: true }, testSchema);
+  assert.equal(result.valid, true);
+});
+
+test("validation: rejects non-boolean for boolean field", () => {
+  const result = validateConfig({ debug: "yes" }, testSchema);
+  assert.equal(result.valid, false);
+  if (!result.valid) {
+    assert.ok(result.error.includes("must be a boolean"));
+  }
+});
+
+test("validation: accepts valid enum value", () => {
+  const result = validateConfig({ mode: "fast" }, testSchema);
+  assert.equal(result.valid, true);
+});
+
+test("validation: rejects invalid enum value", () => {
+  const result = validateConfig({ mode: "turbo" }, testSchema);
+  assert.equal(result.valid, false);
+  if (!result.valid) {
+    assert.ok(result.error.includes("must be one of: fast, slow, auto"));
+  }
+});
+
+test("validation: accepts number within min/max range", () => {
+  const result = validateConfig({ maxRetries: 5 }, testSchema);
+  assert.equal(result.valid, true);
+});
+
+test("validation: rejects number below min", () => {
+  const result = validateConfig({ maxRetries: 0 }, testSchema);
+  assert.equal(result.valid, false);
+  if (!result.valid) {
+    assert.ok(result.error.includes("must be at least 1"));
+  }
+});
+
+test("validation: rejects number above max", () => {
+  const result = validateConfig({ maxRetries: 15 }, testSchema);
+  assert.equal(result.valid, false);
+  if (!result.valid) {
+    assert.ok(result.error.includes("must be at most 10"));
+  }
+});
+
+test("validation: accepts string meeting min length", () => {
+  const schema: Record<string, ConfigField> = { name: { type: "string", min: 3 } };
+  const result = validateConfig({ name: "abc" }, schema);
+  assert.equal(result.valid, true);
+});
+
+test("validation: rejects string below min length", () => {
+  const schema: Record<string, ConfigField> = { name: { type: "string", min: 3 } };
+  const result = validateConfig({ name: "ab" }, schema);
+  assert.equal(result.valid, false);
+  if (!result.valid) {
+    assert.ok(result.error.includes("must be at least 3 characters"));
+  }
+});
+
+test("validation: skips undefined keys", () => {
+  const result = validateConfig({}, testSchema);
+  assert.equal(result.valid, true);
+});
+
+test("validation: passes with empty schema", () => {
+  const result = validateConfig({ anything: "goes" }, {});
+  assert.equal(result.valid, true);
+});
+
+test("validation: passes with null schema", () => {
+  const result = validateConfig({ anything: "goes" }, null as any);
+  assert.equal(result.valid, true);
+});
+
+test("validation: handles multiple field errors (reports first)", () => {
+  const result = validateConfig({ apiUrl: 123, debug: "yes" }, testSchema);
+  assert.equal(result.valid, false);
+  // Should report the first error found
+  if (!result.valid) {
+    assert.ok(result.error.includes("must be a"));
+  }
+});

--- a/tests/unit/plugins-hooks.test.ts
+++ b/tests/unit/plugins-hooks.test.ts
@@ -1,0 +1,198 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  registerHook,
+  unregisterHooks,
+  emitHook,
+  emitHookBlocking,
+  runOnRequest,
+  runOnResponse,
+  runOnError,
+  getHooks,
+  getActiveEvents,
+  resetHooks,
+  type HookRegistration,
+} from "../../src/lib/plugins/hooks.ts";
+
+// ── Setup ──
+
+test.afterEach(() => {
+  resetHooks();
+});
+
+// ── Registration ──
+
+test("registerHook adds a handler", () => {
+  registerHook("onRequest", "test-plugin", () => {});
+  const hooks = getHooks("onRequest");
+  assert.equal(hooks.length, 1);
+  assert.equal(hooks[0].pluginName, "test-plugin");
+});
+
+test("registerHook prevents duplicate registration", () => {
+  const handler = () => {};
+  registerHook("onRequest", "test-plugin", handler);
+  registerHook("onRequest", "test-plugin", handler);
+  assert.equal(getHooks("onRequest").length, 1);
+});
+
+test("registerHook sorts by priority", () => {
+  registerHook("onRequest", "low-priority", () => {}, 200);
+  registerHook("onRequest", "high-priority", () => {}, 10);
+  const hooks = getHooks("onRequest");
+  assert.equal(hooks[0].pluginName, "high-priority");
+  assert.equal(hooks[1].pluginName, "low-priority");
+});
+
+test("unregisterHooks removes all handlers for a plugin", () => {
+  registerHook("onRequest", "plugin-a", () => {});
+  registerHook("onResponse", "plugin-a", () => {});
+  registerHook("onRequest", "plugin-b", () => {});
+  unregisterHooks("plugin-a");
+  assert.equal(getHooks("onRequest").length, 1);
+  assert.equal(getHooks("onResponse").length, 0);
+});
+
+// ── emitHook (fire-and-forget) ──
+
+test("emitHook calls all handlers", async () => {
+  let called = 0;
+  registerHook("onError", "p1", () => {
+    called++;
+  });
+  registerHook("onError", "p2", () => {
+    called++;
+  });
+  await emitHook("onError", {});
+  assert.equal(called, 2);
+});
+
+test("emitHook swallows handler errors", async () => {
+  let called = false;
+  registerHook("onError", "bad", () => {
+    throw new Error("oops");
+  });
+  registerHook("onError", "good", () => {
+    called = true;
+  });
+  await emitHook("onError", {});
+  assert.ok(called);
+});
+
+test("emitHook returns void", async () => {
+  const result = await emitHook("onError", {});
+  assert.equal(result, undefined);
+});
+
+// ── emitHookBlocking ──
+
+test("emitHookBlocking returns empty when no handlers", async () => {
+  const result = await emitHookBlocking("onRequest", {});
+  assert.deepEqual(result, { body: undefined, metadata: {} });
+});
+
+test("emitHookBlocking accumulates body/metadata", async () => {
+  registerHook("onRequest", "p1", () => ({ body: { modified: true } }));
+  registerHook("onRequest", "p2", () => ({ metadata: { key: "value" } }));
+  const result = await emitHookBlocking("onRequest", { body: { original: true }, metadata: {} });
+  assert.deepEqual(result.body, { modified: true });
+  assert.deepEqual(result.metadata, { key: "value" });
+});
+
+test("emitHookBlocking returns on first blocker", async () => {
+  registerHook("onRequest", "p1", () => ({ metadata: { from: "p1" } }));
+  registerHook("onRequest", "blocker", () => ({ blocked: true, response: { error: "blocked" } }));
+  registerHook("onRequest", "p3", () => ({ metadata: { from: "p3" } }));
+  const result = await emitHookBlocking("onRequest", {});
+  assert.ok(result.blocked);
+  assert.deepEqual(result.response, { error: "blocked" });
+});
+
+test("emitHookBlocking preserves accumulated body/metadata on block", async () => {
+  registerHook("onRequest", "p1", () => ({ body: { from: "p1" }, metadata: { key: "value" } }));
+  registerHook("onRequest", "blocker", (payload: unknown) => {
+    const p = payload as Record<string, unknown>;
+    return {
+      blocked: true,
+      response: "blocked",
+      body: p.body,
+      metadata: { ...((p.metadata as Record<string, unknown>) || {}), extra: "from-blocker" },
+    };
+  });
+  const result = await emitHookBlocking("onRequest", { body: {}, metadata: {} });
+  assert.ok(result.blocked);
+  assert.deepEqual(result.metadata, { key: "value", extra: "from-blocker" });
+});
+
+// ── runOnRequest ──
+
+test("runOnRequest delegates to emitHookBlocking", async () => {
+  registerHook("onRequest", "p1", () => ({ body: { modified: true } }));
+  const result = await runOnRequest({ requestId: "test", body: {}, model: "test", metadata: {} });
+  assert.deepEqual(result.body, { modified: true });
+});
+
+test("runOnRequest can block", async () => {
+  registerHook("onRequest", "blocker", () => ({ blocked: true, response: { error: "nope" } }));
+  const result = await runOnRequest({ requestId: "test", body: {}, model: "test", metadata: {} });
+  assert.ok(result.blocked);
+});
+
+// ── runOnResponse ──
+
+test("runOnResponse chains response through handlers", async () => {
+  registerHook("onResponse", "p1", () => ({ response: { modified: "by-p1" } }));
+  const result = await runOnResponse(
+    { requestId: "test", body: {}, model: "test", metadata: {} },
+    { original: true }
+  );
+  assert.deepEqual(result, { modified: "by-p1" });
+});
+
+test("runOnResponse passes through if no modification", async () => {
+  registerHook("onResponse", "p1", () => undefined);
+  const result = await runOnResponse(
+    { requestId: "test", body: {}, model: "test", metadata: {} },
+    { original: true }
+  );
+  assert.deepEqual(result, { original: true });
+});
+
+// ── runOnError ──
+
+test("runOnError fires emitHook", async () => {
+  let errorReceived: Error | null = null;
+  registerHook("onError", "p1", (payload: unknown) => {
+    errorReceived = (payload as Record<string, unknown>).error as Error;
+  });
+  await runOnError(
+    { requestId: "test", body: {}, model: "test", metadata: {} },
+    new Error("test error")
+  );
+  assert.ok(errorReceived);
+});
+
+// ── getHooks / getActiveEvents ──
+
+test("getHooks returns empty for unregistered event", () => {
+  assert.deepEqual(getHooks("nonexistent"), []);
+});
+
+test("getActiveEvents returns registered event names", () => {
+  registerHook("onRequest", "p1", () => {});
+  registerHook("onError", "p1", () => {});
+  const events = getActiveEvents();
+  assert.ok(events.includes("onRequest"));
+  assert.ok(events.includes("onError"));
+});
+
+// ── resetHooks ──
+
+test("resetHooks clears all registrations", () => {
+  registerHook("onRequest", "p1", () => {});
+  registerHook("onError", "p2", () => {});
+  resetHooks();
+  assert.deepEqual(getHooks("onRequest"), []);
+  assert.deepEqual(getHooks("onError"), []);
+});

--- a/tests/unit/plugins-index-shim.test.ts
+++ b/tests/unit/plugins-index-shim.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Unification regression test.
+ *
+ * Before the shim, chatCore.ts imported runOnRequest from `plugins/index` (an
+ * in-process `_plugins[]` array) while the plugin manager registered handlers
+ * in `plugins/hooks` — two disconnected registries, so an activated plugin's
+ * hooks never fired on real requests. `index.ts` is now a re-export shim over
+ * `hooks.ts`, so a handler registered through the shim is the same one chatCore
+ * runs. This test guards that wiring.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  registerPlugin,
+  runOnRequest,
+  runOnResponse,
+  runOnError,
+  resetPlugins,
+} from "../../src/lib/plugins/index.ts";
+
+const ctx = {
+  requestId: "r1",
+  body: { messages: [] },
+  model: "m",
+  provider: "p",
+  metadata: {},
+};
+
+test("index shim: a handler registered via the shim fires through runOnRequest", async () => {
+  resetPlugins();
+  let fired = false;
+  registerPlugin("onRequest", "test-plugin", () => {
+    fired = true;
+    return { metadata: { seen: true } };
+  });
+
+  const result = await runOnRequest(ctx);
+
+  assert.equal(fired, true, "handler registered through index shim must fire");
+  assert.deepEqual(result.metadata, { seen: true });
+  resetPlugins();
+});
+
+test("index shim: a blocking handler blocks the request", async () => {
+  resetPlugins();
+  registerPlugin("onRequest", "blocker", () => ({ blocked: true, response: { error: "no" } }));
+
+  const result = await runOnRequest(ctx);
+
+  assert.equal(result.blocked, true);
+  assert.deepEqual(result.response, { error: "no" });
+  resetPlugins();
+});
+
+test("index shim: runOnResponse chains the response through handlers", async () => {
+  resetPlugins();
+  registerPlugin("onResponse", "wrapper", (payload) => ({
+    response: { wrapped: (payload as { response: unknown }).response },
+  }));
+
+  const out = await runOnResponse(ctx, { original: true });
+
+  assert.deepEqual(out, { wrapped: { original: true } });
+  resetPlugins();
+});
+
+test("index shim: runOnError fires without throwing", async () => {
+  resetPlugins();
+  let seen = false;
+  registerPlugin("onError", "err-plugin", () => {
+    seen = true;
+  });
+
+  await runOnError(ctx, new Error("boom"));
+
+  assert.equal(seen, true);
+  resetPlugins();
+});

--- a/tests/unit/plugins-metrics.test.ts
+++ b/tests/unit/plugins-metrics.test.ts
@@ -1,0 +1,73 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-metrics-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const hooks = await import("../../src/lib/plugins/hooks.ts");
+
+test.beforeEach(() => {
+  core.resetDbInstance();
+  hooks.resetHooks();
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+});
+
+test.after(() => {
+  core.resetDbInstance();
+  try { fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true }); } catch {}
+});
+
+test("recordPluginMetric stores call count", async () => {
+  const { recordPluginMetric, getPluginMetrics } = await import("../../src/lib/db/pluginMetrics.ts");
+  recordPluginMetric("test-plugin", "onRequest", 5.2, false);
+  recordPluginMetric("test-plugin", "onRequest", 3.1, false);
+
+  const metrics = getPluginMetrics("test-plugin");
+  assert.ok(metrics.length > 0, "should have metrics");
+  const m = metrics.find((r: { event: string }) => r.event === "onRequest");
+  assert.ok(m, "should have onRequest metric");
+  assert.ok(m.calls >= 2, `expected calls >= 2, got ${m.calls}`);
+});
+
+test("recordPluginMetric tracks errors", async () => {
+  const { recordPluginMetric, getPluginMetrics } = await import("../../src/lib/db/pluginMetrics.ts");
+  recordPluginMetric("err-plugin", "onRequest", 1.0, true);
+
+  const metrics = getPluginMetrics("err-plugin");
+  const m = metrics.find((r: { event: string }) => r.event === "onRequest");
+  assert.ok(m, "should have onRequest metric");
+  assert.ok(m.errors >= 1, `expected errors >= 1, got ${m.errors}`);
+});
+
+test("recordPluginMetric tracks latency", async () => {
+  const { recordPluginMetric, getPluginMetrics } = await import("../../src/lib/db/pluginMetrics.ts");
+  recordPluginMetric("latency-plugin", "onRequest", 42.5, false);
+
+  const metrics = getPluginMetrics("latency-plugin");
+  const m = metrics.find((r: { event: string }) => r.event === "onRequest");
+  assert.ok(m, "should have onRequest metric");
+  assert.ok(m.totalDurationMs >= 42, `expected totalDurationMs >= 42, got ${m.totalDurationMs}`);
+});
+
+test("getPluginMetrics returns all plugins when no filter", async () => {
+  const { recordPluginMetric, getPluginMetrics } = await import("../../src/lib/db/pluginMetrics.ts");
+  recordPluginMetric("p1", "onRequest", 1, false);
+  recordPluginMetric("p2", "onResponse", 2, false);
+
+  const all = getPluginMetrics();
+  assert.ok(all.length >= 2, `expected >= 2, got ${all.length}`);
+});
+
+test("clearPluginMetrics removes metrics", async () => {
+  const { recordPluginMetric, clearPluginMetrics, getPluginMetrics } = await import("../../src/lib/db/pluginMetrics.ts");
+  recordPluginMetric("clear-test", "onRequest", 1, false);
+  clearPluginMetrics("clear-test");
+
+  const metrics = getPluginMetrics("clear-test");
+  const m = metrics.find((r: { event: string }) => r.event === "onRequest");
+  assert.equal(m, undefined, "should be cleared");
+});


### PR DESCRIPTION
…0-rc1)

Safe, security-reviewed subset of PR #2913 (deferred to v4.0.0-rc1).

Core fix — unify the plugin registry:
- index.ts is now a re-export shim over hooks.ts. Before, chatCore.ts ran runOnRequest/runOnError from index.ts's in-process _plugins[] array while the plugin manager registered handlers in hooks.ts — two disconnected registries, so activated plugins' hooks never fired on real requests. They now do.
- chatCore.ts: read modified body from pluginResult.body (not .ctx); wire runOnResponse at the streaming finalization (was missing).

Added:
- SDK (definePlugin + blockRequest/modifyBody/addMetadata) + docs/plugins/PLUGIN_SDK.md
- Per-hook execution metrics (pluginMetrics.ts + migration 086) — recordPluginMetric is best-effort and never propagates DB errors into hook execution.
- Dashboard: plugins list page + auto-generated config form (use existing routes).
- Tests: plugins-index-shim (unification regression), plugins-hooks, plugins-metrics, plugins-config-route; proxy-pipeline plugin section updated to the unified API.

Deliberately EXCLUDED from PR #2913 on security/quality grounds (kept release's #2912 versions): loader.ts/pluginWorker.ts (PR reverted child_process isolation to vm.runInContext and exposed child_process.exec into the sandbox — a code-exec hole), manager.ts/manifest.ts signing+upgrade (tied to the insecure loader), and the marketplace/watcher modules (no wired consumer). See the v4 plan in _tasks.

## Summary

- Describe the user-facing or operational change.

## Related Issues

- Closes #
- Related to #

## Validation

- [ ] `npm run lint`
- [ ] `npm run test:unit`
- [ ] `npm run test:coverage`
- [ ] Coverage is still `>= 60%` for statements, lines, functions, and branches
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below

## Tests Added Or Updated

- List every changed or added automated test file.
- If no production code changed, state that here.

## Coverage Notes

- If this PR changes `src/`, `open-sse/`, `electron/`, or `bin/`, explain which tests cover the change.
- If coverage moved down in any touched file, explain why and what follow-up task will recover it.

## Reviewer Notes

- Call out any risky areas, migrations, feature flags, or manual validation that reviewers should know about.