### PR TITLE
fix(dashboard): home topology shows provider UUID instead of friendly name (#3198)

### DIFF
--- a/src/app/(dashboard)/home/ProviderTopology.tsx
+++ b/src/app/(dashboard)/home/ProviderTopology.tsx
@@ -14,6 +14,7 @@ import {
 import "@xyflow/react/dist/style.css";
 import { AI_PROVIDERS } from "@/shared/constants/providers";
 import ProviderIcon from "@/shared/components/ProviderIcon";
+import { resolveTopologyNodeLabel } from "./topologyLabel";
 
 const FE_ACTIVE_TIMEOUT_MS = 60_000;
 const FE_ACTIVE_TICK_MS = 1_000;
@@ -244,7 +245,7 @@ function buildLayout(
         type: "provider",
         position: { x: cx - nodeW / 2, y: cy - nodeH / 2 },
         data: {
-          label: config.name || p.name || p.provider,
+          label: resolveTopologyNodeLabel(p.name, config.name, p.provider),
           color: config.color || "#6b7280",
           providerId: p.provider,
           active,

--- a/src/app/(dashboard)/home/topologyLabel.ts
+++ b/src/app/(dashboard)/home/topologyLabel.ts
@@ -1,0 +1,17 @@
+/**
+ * Resolve the display label for a provider node in the home topology graph (#3198).
+ *
+ * The parent (HomePageClient) pre-resolves a friendly name into `entry.name` via
+ * `getProviderDisplayLabel` (which knows custom provider nodes). `getProviderConfig`
+ * only knows built-in providers and falls back to `{ name: providerId }` for unknown
+ * ids — so for a custom provider (`openai-compatible-chat-<uuid>`) its `name` is the
+ * raw UUID. The pre-resolved `entry.name` must therefore win over the config fallback;
+ * otherwise the topology renders the UUID instead of the user's provider name.
+ */
+export function resolveTopologyNodeLabel(
+  entryName: string | undefined | null,
+  configName: string | undefined | null,
+  providerId: string
+): string {
+  return (entryName && entryName.trim()) || (configName && configName.trim()) || providerId;
+}

--- a/tests/unit/topology-label-3198.test.ts
+++ b/tests/unit/topology-label-3198.test.ts
@@ -1,0 +1,22 @@
+/**
+ * #3198 — the home provider-topology graph rendered the internal UUID for custom
+ * providers instead of the user's friendly name, because the label precedence was
+ * `config.name || entry.name` and `getProviderConfig` falls back to `{ name: providerId }`
+ * (the UUID) for unknown ids, shadowing the pre-resolved `entry.name`.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { resolveTopologyNodeLabel } from "../../src/app/(dashboard)/home/topologyLabel.ts";
+
+test("custom provider node prefers the pre-resolved friendly name over the UUID config fallback", () => {
+  const uuid = "openai-compatible-chat-1234abcd";
+  // getProviderConfig returns { name: <uuid> } for unknown custom providers
+  assert.equal(resolveTopologyNodeLabel("My Custom GPT", uuid, uuid), "My Custom GPT");
+});
+
+test("falls back to the config name, then the provider id", () => {
+  assert.equal(resolveTopologyNodeLabel(undefined, "OpenAI", "openai"), "OpenAI");
+  assert.equal(resolveTopologyNodeLabel("", "", "anthropic"), "anthropic");
+  assert.equal(resolveTopologyNodeLabel("   ", "Groq", "groq"), "Groq");
+});


### PR DESCRIPTION
Closes #3198

The home provider-topology graph showed the internal UUID (e.g. `openai-compatible-chat-<uuid>`) instead of the user's provider name. `getProviderConfig` returns `{ name: providerId }` for ids not in `AI_PROVIDERS`, and the label precedence `config.name || p.name` let that UUID shadow the friendly name `HomePageClient` already resolves into `p.name` via `getProviderDisplayLabel`.

Fix: extract `resolveTopologyNodeLabel(entryName, configName, providerId)` (pre-resolved entry name first) and use it in `buildLayout`. Safe for built-in providers (their `p.name` is also the friendly label). Unit test guards the precedence.