### PR TITLE
fix(providers): reliable NVIDIA key-validation probe model (#3116)

### DIFF
--- a/src/lib/providers/nvidiaValidationModel.ts
+++ b/src/lib/providers/nvidiaValidationModel.ts
@@ -1,0 +1,24 @@
+/**
+ * NVIDIA NIM key-validation probe model (#3116).
+ *
+ * Key validation does a tiny chat/completions probe and only cares whether auth passes
+ * (401/403 ⇒ bad key; anything else ⇒ key OK). The probe model therefore must be one
+ * that responds quickly for every account. The previous default was the first model in
+ * the catalog (`z-ai/glm-5.1`), which requires the "Public API Endpoints" account
+ * permission and has had DEGRADED windows — accounts lacking that permission see the
+ * probe HANG until the validation timeout, which surfaces as a misleading "Upstream
+ * Error" on an otherwise-valid key.
+ *
+ * `meta/llama-3.1-8b-instruct` is a long-lived, universally-available NIM model (no
+ * special permission), so it is a far more reliable auth probe. A connection may still
+ * override it via `providerSpecificData.validationModelId`.
+ */
+export const NVIDIA_DEFAULT_VALIDATION_MODEL = "meta/llama-3.1-8b-instruct";
+
+export function resolveNvidiaValidationModel(providerSpecificData?: {
+  validationModelId?: unknown;
+}): string {
+  const override = providerSpecificData?.validationModelId;
+  if (typeof override === "string" && override.trim()) return override.trim();
+  return NVIDIA_DEFAULT_VALIDATION_MODEL;
+}

--- a/src/lib/providers/validation.ts
+++ b/src/lib/providers/validation.ts
@@ -34,6 +34,7 @@ import {
   normalizeSessionCookieHeader,
 } from "@/lib/providers/webCookieAuth";
 import { buildJulesApiUrl } from "@/lib/cloudAgent/julesApi.ts";
+import { resolveNvidiaValidationModel } from "@/lib/providers/nvidiaValidationModel";
 import { getGigachatAccessToken } from "@omniroute/open-sse/services/gigachatAuth.ts";
 import { validateQoderCliPat } from "@omniroute/open-sse/services/qoderCli.ts";
 import {
@@ -3961,10 +3962,10 @@ export async function validateProviderApiKey({ provider, apiKey, providerSpecifi
         const chatUrl = normalized.endsWith("/chat/completions")
           ? normalized
           : `${normalized}/chat/completions`;
-        const modelId =
-          providerSpecificData?.validationModelId ||
-          getRegistryEntry("nvidia")?.models?.[0]?.id ||
-          "meta/llama-3.1-8b-instruct";
+        // #3116: probe a universally-available model rather than models[0]
+        // (z-ai/glm-5.1), which requires the "Public API Endpoints" account permission
+        // and can hang/be DEGRADED — making a *valid* key fail with "Upstream Error".
+        const modelId = resolveNvidiaValidationModel(providerSpecificData);
         const res = await validationWrite(
           chatUrl,
           {

--- a/tests/unit/nvidia-validation-model-3116.test.ts
+++ b/tests/unit/nvidia-validation-model-3116.test.ts
@@ -1,0 +1,29 @@
+/**
+ * #3116 — NVIDIA key validation probed the first catalog model (`z-ai/glm-5.1`), which
+ * requires the "Public API Endpoints" account permission and can hang/be DEGRADED,
+ * making a *valid* key fail with a misleading "Upstream Error". The probe now defaults to
+ * the universally-available `meta/llama-3.1-8b-instruct`, with a per-connection override.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  NVIDIA_DEFAULT_VALIDATION_MODEL,
+  resolveNvidiaValidationModel,
+} from "../../src/lib/providers/nvidiaValidationModel.ts";
+
+test("defaults to a stable, permission-free NVIDIA model (not the gated glm-5.1)", () => {
+  assert.equal(NVIDIA_DEFAULT_VALIDATION_MODEL, "meta/llama-3.1-8b-instruct");
+  assert.equal(resolveNvidiaValidationModel(), "meta/llama-3.1-8b-instruct");
+  assert.equal(resolveNvidiaValidationModel({}), "meta/llama-3.1-8b-instruct");
+  assert.notEqual(resolveNvidiaValidationModel(undefined), "z-ai/glm-5.1");
+});
+
+test("honors a per-connection validationModelId override", () => {
+  assert.equal(
+    resolveNvidiaValidationModel({ validationModelId: "nvidia/llama-3.3-nemotron-super-49b" }),
+    "nvidia/llama-3.3-nemotron-super-49b"
+  );
+  // blank/whitespace override falls back to the default
+  assert.equal(resolveNvidiaValidationModel({ validationModelId: "  " }), NVIDIA_DEFAULT_VALIDATION_MODEL);
+});


### PR DESCRIPTION
Re: #3116

NVIDIA key validation does a tiny chat/completions probe and only cares whether auth passes (401/403 ⇒ bad key, else OK). It used `models[0]` = `z-ai/glm-5.1` as the probe, which requires the **"Public API Endpoints"** account permission and has had DEGRADED windows — accounts without that permission see the probe **hang** until the validation timeout, which surfaces as a misleading **"Upstream Error"** on a perfectly valid key.

Fix: probe the long-lived, universally-available [`meta/llama-3.1-8b-instruct`](https://build.nvidia.com/meta/llama-3_1-8b-instruct) instead (still overridable per-connection via `providerSpecificData.validationModelId`). Extracted `resolveNvidiaValidationModel()` + unit test.

Robustness improvement — reduces false key-validation failures. Reporter went silent without error details, so #3116 will get a follow-up asking for a debug log if it still reproduces after this.