### PR TITLE
fix(dashboard): correct misleading grok/vertex credential hints (#3180, #3091)

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/[id]/webSessionCredentials.ts
+++ b/src/app/(dashboard)/dashboard/providers/[id]/webSessionCredentials.ts
@@ -22,9 +22,11 @@ export const WEB_SESSION_CREDENTIAL_REQUIREMENTS = {
     acceptsFullCookieHeader: true,
   },
   "grok-web": {
+    // Grok needs BOTH the sso and sso-rw cookies (#3180) — the hint previously named
+    // only `sso`, which read as "paste just sso" and produced anti-bot 403s.
     kind: "cookie",
-    credentialName: "sso",
-    placeholder: "sso=...",
+    credentialName: "sso + sso-rw",
+    placeholder: "sso=...; sso-rw=...",
     acceptsFullCookieHeader: true,
   },
   "gemini-web": {

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -4264,7 +4264,7 @@
     "validationModelIdHint": "Validation Model Id Hint",
     "validationModelIdLabel": "Validation Model Id Label",
     "validationModelIdPlaceholder": "Validation Model Id Placeholder",
-    "vertexServiceAccountPlaceholder": "Vertex Service Account Placeholder",
+    "vertexServiceAccountPlaceholder": "Paste your Service Account JSON ({\"type\":\"service_account\",\"project_id\":\"…\",\"client_email\":\"…\",\"private_key\":\"…\"}) or an OAuth access_token",
     "webCookieProviders": "Web Cookie Providers",
     "weeklyShort": "Weekly Short",
     "xiaomiMimoBaseUrlHint": "Xiaomi Mimo Base Url Hint",

--- a/src/i18n/messages/az.json
+++ b/src/i18n/messages/az.json
@@ -4264,7 +4264,7 @@
     "validationModelIdHint": "Validation Model Id Hint",
     "validationModelIdLabel": "Validation Model Id Label",
     "validationModelIdPlaceholder": "Validation Model Id Placeholder",
-    "vertexServiceAccountPlaceholder": "Vertex Service Account Placeholder",
+    "vertexServiceAccountPlaceholder": "Paste your Service Account JSON ({\"type\":\"service_account\",\"project_id\":\"…\",\"client_email\":\"…\",\"private_key\":\"…\"}) or an OAuth access_token",
     "webCookieProviders": "Web Cookie Providers",
     "weeklyShort": "Weekly Short",
     "xiaomiMimoBaseUrlHint": "Xiaomi Mimo Base Url Hint",

--- a/src/i18n/messages/bg.json
+++ b/src/i18n/messages/bg.json
@@ -4264,7 +4264,7 @@
     "validationModelIdHint": "Validation Model Id Hint",
     "validationModelIdLabel": "Validation Model Id Label",
     "validationModelIdPlaceholder": "Validation Model Id Placeholder",
-    "vertexServiceAccountPlaceholder": "Vertex Service Account Placeholder",
+    "vertexServiceAccountPlaceholder": "Paste your Service Account JSON ({\"type\":\"service_account\",\"project_id\":\"…\",\"client_email\":\"…\",\"private_key\":\"…\"}) or an OAuth access_token",
     "webCookieProviders": "Web Cookie Providers",
     "weeklyShort": "Weekly Short",
     "xiaomiMimoBaseUrlHint": "Xiaomi Mimo Base Url Hint",

--- a/src/i18n/messages/bn.json
+++ b/src/i18n/messages/bn.json
@@ -4264,7 +4264,7 @@
     "validationModelIdHint": "Validation Model Id Hint",
     "validationModelIdLabel": "Validation Model Id Label",
     "validationModelIdPlaceholder": "Validation Model Id Placeholder",
-    "vertexServiceAccountPlaceholder": "Vertex Service Account Placeholder",
+    "vertexServiceAccountPlaceholder": "Paste your Service Account JSON ({\"type\":\"service_account\",\"project_id\":\"…\",\"client_email\":\"…\",\"private_key\":\"…\"}) or an OAuth access_token",
     "webCookieProviders": "Web Cookie Providers",
     "weeklyShort": "Weekly Short",
     "xiaomiMimoBaseUrlHint": "Xiaomi Mimo Base Url Hint",

--- a/src/i18n/messages/cs.json
+++ b/src/i18n/messages/cs.json
@@ -4264,7 +4264,7 @@
     "validationModelIdHint": "Validation Model Id Hint",
     "validationModelIdLabel": "Validation Model Id Label",
     "validationModelIdPlaceholder": "Validation Model Id Placeholder",
-    "vertexServiceAccountPlaceholder": "Vertex Service Account Placeholder",
+    "vertexServiceAccountPlaceholder": "Paste your Service Account JSON ({\"type\":\"service_account\",\"project_id\":\"…\",\"client_email\":\"…\",\"private_key\":\"…\"}) or an OAuth access_token",
     "webCookieProviders": "Web Cookie Providers",
     "weeklyShort": "Weekly Short",
     "xiaomiMimoBaseUrlHint": "Xiaomi Mimo Base Url Hint",

--- a/src/i18n/messages/da.json
+++ b/src/i18n/messages/da.json
@@ -4264,7 +4264,7 @@
     "validationModelIdHint": "Validation Model Id Hint",
     "validationModelIdLabel": "Validation Model Id Label",
     "validationModelIdPlaceholder": "Validation Model Id Placeholder",
-    "vertexServiceAccountPlaceholder": "Vertex Service Account Placeholder",
+    "vertexServiceAccountPlaceholder": "Paste your Service Account JSON ({\"type\":\"service_account\",\"project_id\":\"…\",\"client_email\":\"…\",\"private_key\":\"…\"}) or an OAuth access_token",
     "webCookieProviders": "Web Cookie Providers",
     "weeklyShort": "Weekly Short",
     "xiaomiMimoBaseUrlHint": "Xiaomi Mimo Base Url Hint",

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -4269,7 +4269,7 @@
     "validationModelIdHint": "Validation Model Id Hint",
     "validationModelIdLabel": "Validation Model Id Label",
     "validationModelIdPlaceholder": "Validation Model Id Placeholder",
-    "vertexServiceAccountPlaceholder": "Vertex Service Account Placeholder",
+    "vertexServiceAccountPlaceholder": "Paste your Service Account JSON ({\"type\":\"service_account\",\"project_id\":\"…\",\"client_email\":\"…\",\"private_key\":\"…\"}) or an OAuth access_token",
     "webCookieProviders": "Web Cookie Providers",
     "weeklyShort": "Weekly Short",
     "xiaomiMimoBaseUrlHint": "Xiaomi Mimo Base Url Hint",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -4493,7 +4493,7 @@
     "validationModelIdHint": "Validation Model Id Hint",
     "validationModelIdLabel": "Validation Model Id Label",
     "validationModelIdPlaceholder": "Validation Model Id Placeholder",
-    "vertexServiceAccountPlaceholder": "Vertex Service Account Placeholder",
+    "vertexServiceAccountPlaceholder": "Paste your Service Account JSON ({\"type\":\"service_account\",\"project_id\":\"…\",\"client_email\":\"…\",\"private_key\":\"…\"}) or an OAuth access_token",
     "webCookieProviders": "Web Cookie Providers",
     "weeklyShort": "Weekly Short",
     "xiaomiMimoBaseUrlHint": "Xiaomi Mimo Base Url Hint",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -4264,7 +4264,7 @@
     "validationModelIdHint": "Validation Model Id Hint",
     "validationModelIdLabel": "Validation Model Id Label",
     "validationModelIdPlaceholder": "Validation Model Id Placeholder",
-    "vertexServiceAccountPlaceholder": "Vertex Service Account Placeholder",
+    "vertexServiceAccountPlaceholder": "Paste your Service Account JSON ({\"type\":\"service_account\",\"project_id\":\"…\",\"client_email\":\"…\",\"private_key\":\"…\"}) or an OAuth access_token",
     "webCookieProviders": "Web Cookie Providers",
     "weeklyShort": "Weekly Short",
     "xiaomiMimoBaseUrlHint": "Xiaomi Mimo Base Url Hint",

--- a/src/i18n/messages/fa.json
+++ b/src/i18n/messages/fa.json
@@ -4264,7 +4264,7 @@
     "validationModelIdHint": "Validation Model Id Hint",
     "validationModelIdLabel": "Validation Model Id Label",
     "validationModelIdPlaceholder": "Validation Model Id Placeholder",
-    "vertexServiceAccountPlaceholder": "Vertex Service Account Placeholder",
+    "vertexServiceAccountPlaceholder": "Paste your Service Account JSON ({\"type\":\"service_account\",\"project_id\":\"…\",\"client_email\":\"…\",\"private_key\":\"…\"}) or an OAuth access_token",
     "webCookieProviders": "Web Cookie Providers",
     "weeklyShort": "Weekly Short",
     "xiaomiMimoBaseUrlHint": "Xiaomi Mimo Base Url Hint",

--- a/src/i18n/messages/fi.json
+++ b/src/i18n/messages/fi.json
@@ -4264,7 +4264,7 @@
     "validationModelIdHint": "Validation Model Id Hint",
     "validationModelIdLabel": "Validation Model Id Label",
     "validationModelIdPlaceholder": "Validation Model Id Placeholder",
-    "vertexServiceAccountPlaceholder": "Vertex Service Account Placeholder",
+    "vertexServiceAccountPlaceholder": "Paste your Service Account JSON ({\"type\":\"service_account\",\"project_id\":\"…\",\"client_email\":\"…\",\"private_key\":\"…\"}) or an OAuth access_token",
     "webCookieProviders": "Web Cookie Providers",
     "weeklyShort": "Weekly Short",
     "xiaomiMimoBaseUrlHint": "Xiaomi Mimo Base Url Hint",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -4264,7 +4264,7 @@
     "validationModelIdHint": "Validation Model Id Hint",
     "validationModelIdLabel": "Validation Model Id Label",
     "validationModelIdPlaceholder": "Validation Model Id Placeholder",
-    "vertexServiceAccountPlaceholder": "Vertex Service Account Placeholder",
+    "vertexServiceAccountPlaceholder": "Paste your Service Account JSON ({\"type\":\"service_account\",\"project_id\":\"…\",\"client_email\":\"…\",\"private_key\":\"…\"}) or an OAuth access_token",
     "webCookieProviders": "Web Cookie Providers",
     "weeklyShort": "Weekly Short",
     "xiaomiMimoBaseUrlHint": "Xiaomi Mimo Base Url Hint",

--- a/src/i18n/messages/gu.json
+++ b/src/i18n/messages/gu.json
@@ -4264,7 +4264,7 @@
     "validationModelIdHint": "Validation Model Id Hint",
     "validationModelIdLabel": "Validation Model Id Label",
     "validationModelIdPlaceholder": "Validation Model Id Placeholder",
-    "vertexServiceAccountPlaceholder": "Vertex Service Account Placeholder",
+    "vertexServiceAccountPlaceholder": "Paste your Service Account JSON ({\"type\":\"service_account\",\"project_id\":\"…\",\"client_email\":\"…\",\"private_key\":\"…\"}) or an OAuth access_token",
     "webCookieProviders": "Web Cookie Providers",
     "weeklyShort": "Weekly Short",
     "xiaomiMimoBaseUrlHint": "Xiaomi Mimo Base Url Hint",

--- a/src/i18n/messages/he.json
+++ b/src/i18n/messages/he.json
@@ -4264,7 +4264,7 @@
     "validationModelIdHint": "Validation Model Id Hint",
     "validationModelIdLabel": "Validation Model Id Label",
     "validationModelIdPlaceholder": "Validation Model Id Placeholder",
-    "vertexServiceAccountPlaceholder": "Vertex Service Account Placeholder",
+    "vertexServiceAccountPlaceholder": "Paste your Service Account JSON ({\"type\":\"service_account\",\"project_id\":\"…\",\"client_email\":\"…\",\"private_key\":\"…\"}) or an OAuth access_token",
     "webCookieProviders": "Web Cookie Providers",
     "weeklyShort": "Weekly Short",
     "xiaomiMimoBaseUrlHint": "Xiaomi Mimo Base Url Hint",

--- a/src/i18n/messages/hi.json
+++ b/src/i18n/messages/hi.json
@@ -4264,7 +4264,7 @@
     "validationModelIdHint": "Validation Model Id Hint",
     "validationModelIdLabel": "Validation Model Id Label",
     "validationModelIdPlaceholder": "Validation Model Id Placeholder",
-    "vertexServiceAccountPlaceholder": "Vertex Service Account Placeholder",
+    "vertexServiceAccountPlaceholder": "Paste your Service Account JSON ({\"type\":\"service_account\",\"project_id\":\"…\",\"client_email\":\"…\",\"private_key\":\"…\"}) or an OAuth access_token",
     "webCookieProviders": "Web Cookie Providers",
     "weeklyShort": "Weekly Short",
     "xiaomiMimoBaseUrlHint": "Xiaomi Mimo Base Url Hint",

--- a/src/i18n/messages/hu.json
+++ b/src/i18n/messages/hu.json
@@ -4264,7 +4264,7 @@
     "validationModelIdHint": "Validation Model Id Hint",
     "validationModelIdLabel": "Validation Model Id Label",
     "validationModelIdPlaceholder": "Validation Model Id Placeholder",
-    "vertexServiceAccountPlaceholder": "Vertex Service Account Placeholder",
+    "vertexServiceAccountPlaceholder": "Paste your Service Account JSON ({\"type\":\"service_account\",\"project_id\":\"…\",\"client_email\":\"…\",\"private_key\":\"…\"}) or an OAuth access_token",
     "webCookieProviders": "Web Cookie Providers",
     "weeklyShort": "Weekly Short",
     "xiaomiMimoBaseUrlHint": "Xiaomi Mimo Base Url Hint",

--- a/src/i18n/messages/id.json
+++ b/src/i18n/messages/id.json
@@ -4264,7 +4264,7 @@
     "validationModelIdHint": "Validation Model Id Hint",
     "validationModelIdLabel": "Validation Model Id Label",
     "validationModelIdPlaceholder": "Validation Model Id Placeholder",
-    "vertexServiceAccountPlaceholder": "Vertex Service Account Placeholder",
+    "vertexServiceAccountPlaceholder": "Paste your Service Account JSON ({\"type\":\"service_account\",\"project_id\":\"…\",\"client_email\":\"…\",\"private_key\":\"…\"}) or an OAuth access_token",
     "webCookieProviders": "Web Cookie Providers",
     "weeklyShort": "Weekly Short",
     "xiaomiMimoBaseUrlHint": "Xiaomi Mimo Base Url Hint",

--- a/src/i18n/messages/in.json
+++ b/src/i18n/messages/in.json
@@ -4264,7 +4264,7 @@
     "validationModelIdHint": "Validation Model Id Hint",
     "validationModelIdLabel": "Validation Model Id Label",
     "validationModelIdPlaceholder": "Validation Model Id Placeholder",
-    "vertexServiceAccountPlaceholder": "Vertex Service Account Placeholder",
+    "vertexServiceAccountPlaceholder": "Paste your Service Account JSON ({\"type\":\"service_account\",\"project_id\":\"…\",\"client_email\":\"…\",\"private_key\":\"…\"}) or an OAuth access_token",
     "webCookieProviders": "Web Cookie Providers",
     "weeklyShort": "Weekly Short",
     "xiaomiMimoBaseUrlHint": "Xiaomi Mimo Base Url Hint",

--- a/src/i18n/messages/it.json
+++ b/src/i18n/messages/it.json
@@ -4264,7 +4264,7 @@
     "validationModelIdHint": "Validation Model Id Hint",
     "validationModelIdLabel": "Validation Model Id Label",
     "validationModelIdPlaceholder": "Validation Model Id Placeholder",
-    "vertexServiceAccountPlaceholder": "Vertex Service Account Placeholder",
+    "vertexServiceAccountPlaceholder": "Paste your Service Account JSON ({\"type\":\"service_account\",\"project_id\":\"…\",\"client_email\":\"…\",\"private_key\":\"…\"}) or an OAuth access_token",
     "webCookieProviders": "Web Cookie Providers",
     "weeklyShort": "Weekly Short",
     "xiaomiMimoBaseUrlHint": "Xiaomi Mimo Base Url Hint",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -4264,7 +4264,7 @@
     "validationModelIdHint": "Validation Model Id Hint",
     "validationModelIdLabel": "Validation Model Id Label",
     "validationModelIdPlaceholder": "Validation Model Id Placeholder",
-    "vertexServiceAccountPlaceholder": "Vertex Service Account Placeholder",
+    "vertexServiceAccountPlaceholder": "Paste your Service Account JSON ({\"type\":\"service_account\",\"project_id\":\"…\",\"client_email\":\"…\",\"private_key\":\"…\"}) or an OAuth access_token",
     "webCookieProviders": "Web Cookie Providers",
     "weeklyShort": "Weekly Short",
     "xiaomiMimoBaseUrlHint": "Xiaomi Mimo Base Url Hint",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -4264,7 +4264,7 @@
     "validationModelIdHint": "Validation Model Id Hint",
     "validationModelIdLabel": "Validation Model Id Label",
     "validationModelIdPlaceholder": "Validation Model Id Placeholder",
-    "vertexServiceAccountPlaceholder": "Vertex Service Account Placeholder",
+    "vertexServiceAccountPlaceholder": "Paste your Service Account JSON ({\"type\":\"service_account\",\"project_id\":\"…\",\"client_email\":\"…\",\"private_key\":\"…\"}) or an OAuth access_token",
     "webCookieProviders": "Web Cookie Providers",
     "weeklyShort": "Weekly Short",
     "xiaomiMimoBaseUrlHint": "Xiaomi Mimo Base Url Hint",

--- a/src/i18n/messages/mr.json
+++ b/src/i18n/messages/mr.json
@@ -4264,7 +4264,7 @@
     "validationModelIdHint": "Validation Model Id Hint",
     "validationModelIdLabel": "Validation Model Id Label",
     "validationModelIdPlaceholder": "Validation Model Id Placeholder",
-    "vertexServiceAccountPlaceholder": "Vertex Service Account Placeholder",
+    "vertexServiceAccountPlaceholder": "Paste your Service Account JSON ({\"type\":\"service_account\",\"project_id\":\"…\",\"client_email\":\"…\",\"private_key\":\"…\"}) or an OAuth access_token",
     "webCookieProviders": "Web Cookie Providers",
     "weeklyShort": "Weekly Short",
     "xiaomiMimoBaseUrlHint": "Xiaomi Mimo Base Url Hint",

--- a/src/i18n/messages/ms.json
+++ b/src/i18n/messages/ms.json
@@ -4264,7 +4264,7 @@
     "validationModelIdHint": "Validation Model Id Hint",
     "validationModelIdLabel": "Validation Model Id Label",
     "validationModelIdPlaceholder": "Validation Model Id Placeholder",
-    "vertexServiceAccountPlaceholder": "Vertex Service Account Placeholder",
+    "vertexServiceAccountPlaceholder": "Paste your Service Account JSON ({\"type\":\"service_account\",\"project_id\":\"…\",\"client_email\":\"…\",\"private_key\":\"…\"}) or an OAuth access_token",
     "webCookieProviders": "Web Cookie Providers",
     "weeklyShort": "Weekly Short",
     "xiaomiMimoBaseUrlHint": "Xiaomi Mimo Base Url Hint",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -4264,7 +4264,7 @@
     "validationModelIdHint": "Validation Model Id Hint",
     "validationModelIdLabel": "Validation Model Id Label",
     "validationModelIdPlaceholder": "Validation Model Id Placeholder",
-    "vertexServiceAccountPlaceholder": "Vertex Service Account Placeholder",
+    "vertexServiceAccountPlaceholder": "Paste your Service Account JSON ({\"type\":\"service_account\",\"project_id\":\"…\",\"client_email\":\"…\",\"private_key\":\"…\"}) or an OAuth access_token",
     "webCookieProviders": "Web Cookie Providers",
     "weeklyShort": "Weekly Short",
     "xiaomiMimoBaseUrlHint": "Xiaomi Mimo Base Url Hint",

--- a/src/i18n/messages/no.json
+++ b/src/i18n/messages/no.json
@@ -4264,7 +4264,7 @@
     "validationModelIdHint": "Validation Model Id Hint",
     "validationModelIdLabel": "Validation Model Id Label",
     "validationModelIdPlaceholder": "Validation Model Id Placeholder",
-    "vertexServiceAccountPlaceholder": "Vertex Service Account Placeholder",
+    "vertexServiceAccountPlaceholder": "Paste your Service Account JSON ({\"type\":\"service_account\",\"project_id\":\"…\",\"client_email\":\"…\",\"private_key\":\"…\"}) or an OAuth access_token",
     "webCookieProviders": "Web Cookie Providers",
     "weeklyShort": "Weekly Short",
     "xiaomiMimoBaseUrlHint": "Xiaomi Mimo Base Url Hint",

--- a/src/i18n/messages/phi.json
+++ b/src/i18n/messages/phi.json
@@ -4264,7 +4264,7 @@
     "validationModelIdHint": "Validation Model Id Hint",
     "validationModelIdLabel": "Validation Model Id Label",
     "validationModelIdPlaceholder": "Validation Model Id Placeholder",
-    "vertexServiceAccountPlaceholder": "Vertex Service Account Placeholder",
+    "vertexServiceAccountPlaceholder": "Paste your Service Account JSON ({\"type\":\"service_account\",\"project_id\":\"…\",\"client_email\":\"…\",\"private_key\":\"…\"}) or an OAuth access_token",
     "webCookieProviders": "Web Cookie Providers",
     "weeklyShort": "Weekly Short",
     "xiaomiMimoBaseUrlHint": "Xiaomi Mimo Base Url Hint",

--- a/src/i18n/messages/pl.json
+++ b/src/i18n/messages/pl.json
@@ -4264,7 +4264,7 @@
     "validationModelIdHint": "Validation Model Id Hint",
     "validationModelIdLabel": "Validation Model Id Label",
     "validationModelIdPlaceholder": "Validation Model Id Placeholder",
-    "vertexServiceAccountPlaceholder": "Vertex Service Account Placeholder",
+    "vertexServiceAccountPlaceholder": "Paste your Service Account JSON ({\"type\":\"service_account\",\"project_id\":\"…\",\"client_email\":\"…\",\"private_key\":\"…\"}) or an OAuth access_token",
     "webCookieProviders": "Web Cookie Providers",
     "weeklyShort": "Weekly Short",
     "xiaomiMimoBaseUrlHint": "Xiaomi Mimo Base Url Hint",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -4264,7 +4264,7 @@
     "validationModelIdHint": "Validation Model Id Hint",
     "validationModelIdLabel": "Validation Model Id Label",
     "validationModelIdPlaceholder": "Validation Model Id Placeholder",
-    "vertexServiceAccountPlaceholder": "Vertex Service Account Placeholder",
+    "vertexServiceAccountPlaceholder": "Paste your Service Account JSON ({\"type\":\"service_account\",\"project_id\":\"…\",\"client_email\":\"…\",\"private_key\":\"…\"}) or an OAuth access_token",
     "webCookieProviders": "Web Cookie Providers",
     "weeklyShort": "Weekly Short",
     "xiaomiMimoBaseUrlHint": "Xiaomi Mimo Base Url Hint",

--- a/src/i18n/messages/ro.json
+++ b/src/i18n/messages/ro.json
@@ -4264,7 +4264,7 @@
     "validationModelIdHint": "Validation Model Id Hint",
     "validationModelIdLabel": "Validation Model Id Label",
     "validationModelIdPlaceholder": "Validation Model Id Placeholder",
-    "vertexServiceAccountPlaceholder": "Vertex Service Account Placeholder",
+    "vertexServiceAccountPlaceholder": "Paste your Service Account JSON ({\"type\":\"service_account\",\"project_id\":\"…\",\"client_email\":\"…\",\"private_key\":\"…\"}) or an OAuth access_token",
     "webCookieProviders": "Web Cookie Providers",
     "weeklyShort": "Weekly Short",
     "xiaomiMimoBaseUrlHint": "Xiaomi Mimo Base Url Hint",

--- a/src/i18n/messages/ru.json
+++ b/src/i18n/messages/ru.json
@@ -4480,7 +4480,7 @@
     "validationModelIdHint": "Validation Model Id Hint",
     "validationModelIdLabel": "Validation Model Id Label",
     "validationModelIdPlaceholder": "Validation Model Id Placeholder",
-    "vertexServiceAccountPlaceholder": "Vertex Service Account Placeholder",
+    "vertexServiceAccountPlaceholder": "Paste your Service Account JSON ({\"type\":\"service_account\",\"project_id\":\"…\",\"client_email\":\"…\",\"private_key\":\"…\"}) or an OAuth access_token",
     "webCookieProviders": "Web Cookie Providers",
     "weeklyShort": "Weekly Short",
     "xiaomiMimoBaseUrlHint": "Xiaomi Mimo Base Url Hint",

--- a/src/i18n/messages/sk.json
+++ b/src/i18n/messages/sk.json
@@ -4264,7 +4264,7 @@
     "validationModelIdHint": "Validation Model Id Hint",
     "validationModelIdLabel": "Validation Model Id Label",
     "validationModelIdPlaceholder": "Validation Model Id Placeholder",
-    "vertexServiceAccountPlaceholder": "Vertex Service Account Placeholder",
+    "vertexServiceAccountPlaceholder": "Paste your Service Account JSON ({\"type\":\"service_account\",\"project_id\":\"…\",\"client_email\":\"…\",\"private_key\":\"…\"}) or an OAuth access_token",
     "webCookieProviders": "Web Cookie Providers",
     "weeklyShort": "Weekly Short",
     "xiaomiMimoBaseUrlHint": "Xiaomi Mimo Base Url Hint",

--- a/src/i18n/messages/sv.json
+++ b/src/i18n/messages/sv.json
@@ -4264,7 +4264,7 @@
     "validationModelIdHint": "Validation Model Id Hint",
     "validationModelIdLabel": "Validation Model Id Label",
     "validationModelIdPlaceholder": "Validation Model Id Placeholder",
-    "vertexServiceAccountPlaceholder": "Vertex Service Account Placeholder",
+    "vertexServiceAccountPlaceholder": "Paste your Service Account JSON ({\"type\":\"service_account\",\"project_id\":\"…\",\"client_email\":\"…\",\"private_key\":\"…\"}) or an OAuth access_token",
     "webCookieProviders": "Web Cookie Providers",
     "weeklyShort": "Weekly Short",
     "xiaomiMimoBaseUrlHint": "Xiaomi Mimo Base Url Hint",

--- a/src/i18n/messages/sw.json
+++ b/src/i18n/messages/sw.json
@@ -4264,7 +4264,7 @@
     "validationModelIdHint": "Validation Model Id Hint",
     "validationModelIdLabel": "Validation Model Id Label",
     "validationModelIdPlaceholder": "Validation Model Id Placeholder",
-    "vertexServiceAccountPlaceholder": "Vertex Service Account Placeholder",
+    "vertexServiceAccountPlaceholder": "Paste your Service Account JSON ({\"type\":\"service_account\",\"project_id\":\"…\",\"client_email\":\"…\",\"private_key\":\"…\"}) or an OAuth access_token",
     "webCookieProviders": "Web Cookie Providers",
     "weeklyShort": "Weekly Short",
     "xiaomiMimoBaseUrlHint": "Xiaomi Mimo Base Url Hint",

--- a/src/i18n/messages/ta.json
+++ b/src/i18n/messages/ta.json
@@ -4264,7 +4264,7 @@
     "validationModelIdHint": "Validation Model Id Hint",
     "validationModelIdLabel": "Validation Model Id Label",
     "validationModelIdPlaceholder": "Validation Model Id Placeholder",
-    "vertexServiceAccountPlaceholder": "Vertex Service Account Placeholder",
+    "vertexServiceAccountPlaceholder": "Paste your Service Account JSON ({\"type\":\"service_account\",\"project_id\":\"…\",\"client_email\":\"…\",\"private_key\":\"…\"}) or an OAuth access_token",
     "webCookieProviders": "Web Cookie Providers",
     "weeklyShort": "Weekly Short",
     "xiaomiMimoBaseUrlHint": "Xiaomi Mimo Base Url Hint",

--- a/src/i18n/messages/te.json
+++ b/src/i18n/messages/te.json
@@ -4264,7 +4264,7 @@
     "validationModelIdHint": "Validation Model Id Hint",
     "validationModelIdLabel": "Validation Model Id Label",
     "validationModelIdPlaceholder": "Validation Model Id Placeholder",
-    "vertexServiceAccountPlaceholder": "Vertex Service Account Placeholder",
+    "vertexServiceAccountPlaceholder": "Paste your Service Account JSON ({\"type\":\"service_account\",\"project_id\":\"…\",\"client_email\":\"…\",\"private_key\":\"…\"}) or an OAuth access_token",
     "webCookieProviders": "Web Cookie Providers",
     "weeklyShort": "Weekly Short",
     "xiaomiMimoBaseUrlHint": "Xiaomi Mimo Base Url Hint",

--- a/src/i18n/messages/th.json
+++ b/src/i18n/messages/th.json
@@ -4264,7 +4264,7 @@
     "validationModelIdHint": "Validation Model Id Hint",
     "validationModelIdLabel": "Validation Model Id Label",
     "validationModelIdPlaceholder": "Validation Model Id Placeholder",
-    "vertexServiceAccountPlaceholder": "Vertex Service Account Placeholder",
+    "vertexServiceAccountPlaceholder": "Paste your Service Account JSON ({\"type\":\"service_account\",\"project_id\":\"…\",\"client_email\":\"…\",\"private_key\":\"…\"}) or an OAuth access_token",
     "webCookieProviders": "Web Cookie Providers",
     "weeklyShort": "Weekly Short",
     "xiaomiMimoBaseUrlHint": "Xiaomi Mimo Base Url Hint",

--- a/src/i18n/messages/tr.json
+++ b/src/i18n/messages/tr.json
@@ -4264,7 +4264,7 @@
     "validationModelIdHint": "Validation Model Id Hint",
     "validationModelIdLabel": "Validation Model Id Label",
     "validationModelIdPlaceholder": "Validation Model Id Placeholder",
-    "vertexServiceAccountPlaceholder": "Vertex Service Account Placeholder",
+    "vertexServiceAccountPlaceholder": "Paste your Service Account JSON ({\"type\":\"service_account\",\"project_id\":\"…\",\"client_email\":\"…\",\"private_key\":\"…\"}) or an OAuth access_token",
     "webCookieProviders": "Web Cookie Providers",
     "weeklyShort": "Weekly Short",
     "xiaomiMimoBaseUrlHint": "Xiaomi Mimo Base Url Hint",

--- a/src/i18n/messages/uk-UA.json
+++ b/src/i18n/messages/uk-UA.json
@@ -4261,7 +4261,7 @@
     "validationModelIdHint": "Validation Model Id Hint",
     "validationModelIdLabel": "Validation Model Id Label",
     "validationModelIdPlaceholder": "Validation Model Id Placeholder",
-    "vertexServiceAccountPlaceholder": "Vertex Service Account Placeholder",
+    "vertexServiceAccountPlaceholder": "Paste your Service Account JSON ({\"type\":\"service_account\",\"project_id\":\"…\",\"client_email\":\"…\",\"private_key\":\"…\"}) or an OAuth access_token",
     "webCookieProviders": "Web Cookie Providers",
     "weeklyShort": "Weekly Short",
     "xiaomiMimoBaseUrlHint": "Xiaomi Mimo Base Url Hint",

--- a/src/i18n/messages/ur.json
+++ b/src/i18n/messages/ur.json
@@ -4264,7 +4264,7 @@
     "validationModelIdHint": "Validation Model Id Hint",
     "validationModelIdLabel": "Validation Model Id Label",
     "validationModelIdPlaceholder": "Validation Model Id Placeholder",
-    "vertexServiceAccountPlaceholder": "Vertex Service Account Placeholder",
+    "vertexServiceAccountPlaceholder": "Paste your Service Account JSON ({\"type\":\"service_account\",\"project_id\":\"…\",\"client_email\":\"…\",\"private_key\":\"…\"}) or an OAuth access_token",
     "webCookieProviders": "Web Cookie Providers",
     "weeklyShort": "Weekly Short",
     "xiaomiMimoBaseUrlHint": "Xiaomi Mimo Base Url Hint",

--- a/src/i18n/messages/vi.json
+++ b/src/i18n/messages/vi.json
@@ -4264,7 +4264,7 @@
     "validationModelIdHint": "Validation Model Id Hint",
     "validationModelIdLabel": "Validation Model Id Label",
     "validationModelIdPlaceholder": "Validation Model Id Placeholder",
-    "vertexServiceAccountPlaceholder": "Vertex Service Account Placeholder",
+    "vertexServiceAccountPlaceholder": "Paste your Service Account JSON ({\"type\":\"service_account\",\"project_id\":\"…\",\"client_email\":\"…\",\"private_key\":\"…\"}) or an OAuth access_token",
     "webCookieProviders": "Web Cookie Providers",
     "weeklyShort": "Weekly Short",
     "xiaomiMimoBaseUrlHint": "Xiaomi Mimo Base Url Hint",

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -4480,7 +4480,7 @@
     "validationModelIdHint": "用于验证此提供商连接的模型 ID。",
     "validationModelIdLabel": "验证模型 ID",
     "validationModelIdPlaceholder": "输入用于测试的模型 ID",
-    "vertexServiceAccountPlaceholder": "Vertex Service Account",
+    "vertexServiceAccountPlaceholder": "粘贴 Service Account JSON（{\"type\":\"service_account\",...}）或 OAuth access_token",
     "webCookieProviders": "Web Cookie Provider",
     "weeklyShort": "每周",
     "xiaomiMimoBaseUrlHint": "小米 Mimo 服务的 Base URL。",

--- a/tests/unit/credential-hint-copy-3180-3091.test.ts
+++ b/tests/unit/credential-hint-copy-3180-3091.test.ts
@@ -1,0 +1,32 @@
+/**
+ * #3180 — the grok-web credential hint named only `sso`, but Grok needs BOTH `sso` and
+ * `sso-rw`; the misleading hint led users to paste just `sso` and hit anti-bot 403s.
+ * #3091 — the Vertex AI Service Account placeholder was an untranslated stub literal
+ * ("Vertex Service Account Placeholder"), making the field look broken even though
+ * Service Account JSON auth is fully supported.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { getWebSessionCredentialRequirement } from "../../src/app/(dashboard)/dashboard/providers/[id]/webSessionCredentials.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MESSAGES_DIR = path.join(__dirname, "..", "..", "src", "i18n", "messages");
+
+test("#3180 grok-web credential hint names both sso and sso-rw", () => {
+  const req = getWebSessionCredentialRequirement("grok-web");
+  assert.ok(req && req.kind !== "none");
+  assert.match(req!.credentialName, /sso-rw/);
+  assert.match(req!.placeholder, /sso-rw/);
+});
+
+test("#3091 vertex Service Account placeholder is real instructional text, not the stub", () => {
+  const en = JSON.parse(readFileSync(path.join(MESSAGES_DIR, "en.json"), "utf8"));
+  const placeholder = en.providers?.vertexServiceAccountPlaceholder;
+  assert.equal(typeof placeholder, "string");
+  assert.notEqual(placeholder, "Vertex Service Account Placeholder");
+  assert.match(placeholder, /service_account/);
+});


### PR DESCRIPTION
Addresses the UI-copy parts of #3180 and #3091.

**#3180 (grok-web):** the credential hint named only `sso`, but Grok needs **both** `sso` and `sso-rw`. The misleading "Required cookie: sso" copy led users to paste just `sso` → anti-bot 403. Now: `credentialName: "sso + sso-rw"`, `placeholder: "sso=...; sso-rw=..."`. (The deeper Cloudflare anti-bot 403 is upstream/IP-dependent and stays tracked on #3180.)

**#3091 (vertex):** the reporter's core claim — "SA JSON not supported" — is **false** (`open-sse/executors/vertex.ts` does the full RS256 JWT → access-token exchange). But the SA-JSON field's i18n placeholder was an untranslated **stub literal** `"Vertex Service Account Placeholder"` across 40 locales, which is what looked broken. Replaced with real instructional text (JSON example), zh localized, pt-BR preserved.

Guard test (`credential-hint-copy-3180-3091.test.ts`) pins both. #3091 is fully addressed by this; #3180's anti-bot 403 part remains open pending reporter/VPS confirmation.