### PR TITLE
fix(gemini): refresh AI Studio model fallback

### DIFF
--- a/open-sse/config/providerRegistry.ts
+++ b/open-sse/config/providerRegistry.ts
@@ -722,6 +722,43 @@ const _REGISTRY_EAGER: Record<string, RegistryEntry> = {
     models: [
       { id: "gemini-2.0-flash", name: "Gemini 2.0 Flash", toolCalling: true, supportsVision: true },
       {
+        id: "gemini-3.1-pro-preview",
+        name: "Gemini 3.1 Pro Preview",
+        toolCalling: true,
+        supportsVision: true,
+      },
+      {
+        id: "gemini-3-flash-preview",
+        name: "Gemini 3 Flash Preview",
+        toolCalling: true,
+        supportsVision: true,
+      },
+      {
+        id: "gemini-3.1-flash-lite-preview",
+        name: "Gemini 3.1 Flash Lite Preview",
+        toolCalling: true,
+        supportsVision: true,
+      },
+      {
+        id: "gemini-3.5-flash",
+        name: "Gemini 3.5 Flash",
+        toolCalling: true,
+        supportsVision: true,
+      },
+      { id: "gemini-2.5-pro", name: "Gemini 2.5 Pro", toolCalling: true, supportsVision: true },
+      {
+        id: "gemini-2.5-flash",
+        name: "Gemini 2.5 Flash",
+        toolCalling: true,
+        supportsVision: true,
+      },
+      {
+        id: "gemini-2.5-flash-lite",
+        name: "Gemini 2.5 Flash Lite",
+        toolCalling: true,
+        supportsVision: true,
+      },
+      {
         id: "gemini-2.0-flash-thinking-exp-01-21",
         name: "Gemini 2.0 Flash Thinking",
         supportsReasoning: true,

--- a/tests/unit/t28-model-catalog-updates.test.ts
+++ b/tests/unit/t28-model-catalog-updates.test.ts
@@ -5,12 +5,18 @@ import { getModelInfoCore } from "../../open-sse/services/model.ts";
 import { REGISTRY } from "../../open-sse/config/providerRegistry.ts";
 import { getStaticModelsForProvider } from "../../src/lib/providers/staticModels.ts";
 
-test("T28: gemini-cli catalog includes preview models, gemini provides a static fallback", () => {
+test("T28: gemini AI Studio catalog includes current preview models", () => {
   // Gemini (AI Studio) carries a small hardcoded fallback for first-run UX when no
   // API key has been added yet; the full catalog is populated by API sync via
   // /api/providers/:id/models with pageSize=1000 once a key exists.
   const geminiIds = REGISTRY.gemini.models.map((m) => m.id);
-  assert.ok(geminiIds.length >= 1, "gemini static fallback should expose at least one model");
+  assert.ok(geminiIds.includes("gemini-3.1-pro-preview"));
+  assert.ok(geminiIds.includes("gemini-3-flash-preview"));
+  assert.ok(geminiIds.includes("gemini-3.1-flash-lite-preview"));
+  assert.ok(geminiIds.includes("gemini-3.5-flash"));
+  assert.ok(geminiIds.includes("gemini-2.5-flash"));
+  assert.ok(geminiIds.includes("gemini-2.5-pro"));
+  assert.equal(geminiIds[0], "gemini-2.0-flash", "preserve the existing Gemini default");
 
   // gemini-cli still has hardcoded models (Cloud Code doesn't have a models API)
   const geminiCliIds = REGISTRY["gemini-cli"].models.map((m) => m.id);


### PR DESCRIPTION
Fixes #3231.

## Summary
- refresh the Gemini (Google AI Studio) static fallback so the provider tab exposes current 3.x models
- include Gemini 2.5 fallback entries while preserving the existing `gemini-2.0-flash` default ordering
- strengthen the model catalog regression test to assert the AI Studio fallback includes the current models

## Tests
- `node --import tsx/esm --test tests/unit/t28-model-catalog-updates.test.ts tests/unit/executor-default-base.test.ts tests/unit/provider-models-config.test.ts`
- `node --import tsx/esm -e 'const { getDefaultModel, getModelsByProviderId } = await import("./open-sse/config/providerModels.ts"); console.log("default", getDefaultModel("gemini")); console.log(getModelsByProviderId("gemini").slice(0,10).map(m=>m.id));'`\n- `git diff --check`