### PR TITLE
fix(sse): strip all <omniModel> tags before forwarding to provider

### DIFF
--- a/open-sse/services/comboAgentMiddleware.ts
+++ b/open-sse/services/comboAgentMiddleware.ts
@@ -36,9 +36,16 @@ interface Message {
 
 // Handles both actual newlines (U+000A) and literal \n sequences injected
 // by combo.ts streaming around the <omniModel> tag (#531). Non-global so that
-// .exec() and .test() stay stateless; callers that need full replacement use
-// String.prototype.replace() which replaces all non-overlapping matches.
+// .exec() and .test() stay stateless (a global regex carries lastIndex between
+// calls and would skip matches).
 const CACHE_TAG_PATTERN = /(?:\\n|\n|\r)*<omniModel>([^<]+)<\/omniModel>(?:\\n|\n|\r)*/;
+
+// Global variant for .replace() callers that must strip EVERY tag. A non-global
+// regex only removes the first match, so a single message carrying more than one
+// <omniModel> tag (e.g. an Open WebUI follow-up/title request that inlines the
+// whole chat history) leaked the remaining tags to the provider — defeating the
+// cache-session protection stripModelTags exists to enforce (#454).
+const CACHE_TAG_PATTERN_GLOBAL = /(?:\\n|\n|\r)*<omniModel>([^<]+)<\/omniModel>(?:\\n|\n|\r)*/g;
 
 /**
  * Inject the model tag into the last assistant message (or append a new one).
@@ -46,10 +53,10 @@ const CACHE_TAG_PATTERN = /(?:\\n|\n|\r)*<omniModel>([^<]+)<\/omniModel>(?:\\n|\
  * Claude/Gemini multi-part message formats.
  */
 export function injectModelTag(messages: Message[], providerModel: string): Message[] {
-  // Remove any existing tag first to avoid duplication on context compaction
+  // Remove any existing tags first to avoid duplication on context compaction
   const cleaned = messages.map((msg) => {
     if (msg.role === "assistant" && typeof msg.content === "string") {
-      return { ...msg, content: msg.content.replace(CACHE_TAG_PATTERN, "").trimEnd() };
+      return { ...msg, content: msg.content.replace(CACHE_TAG_PATTERN_GLOBAL, "").trimEnd() };
     }
     return msg;
   });
@@ -147,7 +154,7 @@ export function applyToolFilter(
 export function stripModelTags(messages: Message[]): Message[] {
   return messages.map((msg) => {
     if (typeof msg.content === "string" && CACHE_TAG_PATTERN.test(msg.content)) {
-      return { ...msg, content: msg.content.replace(CACHE_TAG_PATTERN, "").trimEnd() };
+      return { ...msg, content: msg.content.replace(CACHE_TAG_PATTERN_GLOBAL, "").trimEnd() };
     }
     return msg;
   });

--- a/tests/unit/combo-omnimodel-tag-stripping.test.ts
+++ b/tests/unit/combo-omnimodel-tag-stripping.test.ts
@@ -1,0 +1,58 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  stripModelTags,
+  injectModelTag,
+} from "../../open-sse/services/comboAgentMiddleware.ts";
+
+// Regression for the non-global CACHE_TAG_PATTERN bug: `.replace()` with a
+// non-global regex only removes the FIRST match, so messages carrying more than
+// one <omniModel> tag (e.g. an Open WebUI follow-up/title request that inlines the
+// whole chat history) leaked the remaining tags straight to the provider — exactly
+// what stripModelTags is documented to prevent (#454).
+describe("comboAgentMiddleware — <omniModel> tag stripping (non-global regex bug)", () => {
+  test("stripModelTags removes ALL <omniModel> tags from a single message", () => {
+    const messages = [
+      {
+        role: "user",
+        content:
+          "first <omniModel>claude/claude-opus-4-8</omniModel> " +
+          "middle <omniModel>claude/claude-opus-4-8</omniModel> " +
+          "end <omniModel>claude/claude-opus-4-8</omniModel>",
+      },
+    ];
+
+    const stripped = stripModelTags(messages);
+    const remaining = (String(stripped[0].content).match(/<omniModel>/g) || []).length;
+
+    assert.equal(remaining, 0, "Provider must never see any <omniModel> tag (#454)");
+    assert.ok(
+      !String(stripped[0].content).includes("<omniModel>"),
+      "Stripped content should contain no tag fragments"
+    );
+  });
+
+  test("injectModelTag does not leave duplicate tags when the message already has several", () => {
+    const messages = [
+      { role: "user", content: "Continue" },
+      {
+        role: "assistant",
+        content:
+          "answer <omniModel>old/model-a</omniModel> more <omniModel>old/model-b</omniModel>",
+      },
+    ];
+
+    const result = injectModelTag(messages, "new/model");
+    const tagCount = (String(result[1].content).match(/<omniModel>/g) || []).length;
+
+    assert.equal(tagCount, 1, "Exactly one (the freshly pinned) tag should remain");
+    assert.ok(
+      String(result[1].content).includes("<omniModel>new/model</omniModel>"),
+      "The remaining tag must be the new pin"
+    );
+    assert.ok(
+      !String(result[1].content).includes("old/model"),
+      "All previous pins must be cleaned"
+    );
+  });
+});


### PR DESCRIPTION
CACHE_TAG_PATTERN is non-global, so the .replace() calls in stripModelTags and injectModelTag only removed the first match. A single message carrying multiple <omniModel> tags (e.g. an Open WebUI follow-up/title request that inlines the whole chat history) leaked the remaining tags to the provider, defeating the cache-session protection stripModelTags is meant to  enforce.

Add a global CACHE_TAG_PATTERN_GLOBAL for the .replace() callers while keeping the non-global pattern for .exec()/.test() (a global regex carries lastIndex between calls and would skip matches). Fix the misleading comment that claimed .replace() already removed all matches.

Regression test added: stripModelTags removes all tags from a single message, and injectModelTag leaves exactly one (the fresh) pin.

  ## Summary

  - Combo `context_cache_protection` now strips **every** internal `<omniModel>` pin tag from message content before forwarding upstream, instead of only the first one.
  - Previously, any message containing more than one `<omniModel>` tag (e.g. an Open WebUI follow-up/title generation request that inlines the full chat history) leaked the surplus tags to the provider. The provider then saw the markers as part of the prompt, which both pollutes the visible context and breaks prefix prompt-caching (each tagged request looks like a new cache session — the exact failure mode #454 set out to prevent).
  - No behavior change for the common single-tag case; this only corrects the multi-tag path.

  ## Related Issues

  - Related to #454
  
  ## Validation
  
  - [x] `npm run lint` — 0 errors (3296 pre-existing warnings, per CLAUDE.md)
  - [x] `npm run test:unit` — new + related suites green; 8 failures are unrelated/out of scope (see Reviewer Notes)

  ## Tests Added Or Updated

  - `tests/unit/combo-omnimodel-tag-stripping.test.ts` (new) — two cases:
    - `stripModelTags` removes **all** `<omniModel>` tags from a single message (asserts zero tag fragments reach the provider).
    - `injectModelTag` leaves **exactly one** tag (the freshly pinned model) when the assistant message already carried several, cleaning every prior pin.
  - Verified via TDD: both cases were RED on the base commit (`2 !== 1`, residual tags) and GREEN after the fix.

  ## Coverage Notes
  
  - Change is confined to `open-sse/services/comboAgentMiddleware.ts` (`injectModelTag`, `stripModelTags`, and the `CACHE_TAG_PATTERN` declarations).
  - The new `combo-omnimodel-tag-stripping.test.ts` directly exercises both changed functions; existing `context-pinning-tool-calls.test.ts` and `services-branch-hardening.test.ts` continue to cover the surrounding behavior (15/15 green together).
  - `combo-routing-engine.test.ts` (72/72 green) confirms no regression in the combo path that consumes these helpers.
  - No touched-file coverage decreased; the fix adds tests rather than code paths.

  ## Reviewer Notes
  
  - **Why two patterns:** `.exec()` (in `extractPinnedModel`) and `.test()` (in `stripModelTags`) must stay on the **non-global** `CACHE_TAG_PATTERN` — a global regex retains `lastIndex` between calls and would intermittently skip matches. Only the `.replace()` callers switch to the new global `CACHE_TAG_PATTERN_GLOBAL`. `.replace()` with a global regex resets `lastIndex` after completing, so the shared module-level instance is safe.
