### PR TITLE
feat(blackbox-web): add tool-call translation via webTools prompt injection

### DIFF
--- a/open-sse/executors/blackbox-web.ts
+++ b/open-sse/executors/blackbox-web.ts
@@ -6,6 +6,7 @@ import {
 } from "./base.ts";
 import { FETCH_TIMEOUT_MS } from "../config/constants.ts";
 import { normalizeSessionCookieHeader } from "@/lib/providers/webCookieAuth";
+import { serializeToolsToPrompt, parseToolCallsFromText } from "../translator/webTools.ts";
 
 const BLACKBOX_CHAT_API = "https://app.blackbox.ai/api/chat";
 const BLACKBOX_DEFAULT_COOKIE = "next-auth.session-token";
@@ -323,8 +324,16 @@ export class BlackboxWebExecutor extends BaseExecutor {
       };
     }
 
+    const bodyObj = (body || {}) as Record<string, unknown>;
+    const requestedTools = bodyObj.tools;
+    const hasTools = Array.isArray(requestedTools) && requestedTools.length > 0;
+    const toolSystemPrompt = hasTools ? serializeToolsToPrompt(requestedTools) : "";
+    const effectiveMessages = toolSystemPrompt
+      ? [{ role: "system", content: toolSystemPrompt }, ...messages]
+      : messages;
+
     const chatId = crypto.randomUUID().slice(0, 7);
-    const parsedMessages = parseOpenAIMessages(messages, chatId);
+    const parsedMessages = parseOpenAIMessages(effectiveMessages, chatId);
     if (parsedMessages.length === 0) {
       const errorResponse = new Response(
         JSON.stringify({
@@ -644,6 +653,33 @@ export class BlackboxWebExecutor extends BaseExecutor {
 
     const id = `chatcmpl-blackbox-${crypto.randomUUID().slice(0, 12)}`;
     const created = Math.floor(Date.now() / 1000);
+
+    if (hasTools) {
+      const { content: cleanedContent, toolCalls } = parseToolCallsFromText(
+        responseText, `call-${Date.now()}`, requestedTools
+      );
+      if (toolCalls) {
+        const toolResponse = new Response(
+          JSON.stringify({
+            id, object: "chat.completion", created, model,
+            choices: [{
+              index: 0,
+              message: { role: "assistant", content: null, tool_calls: toolCalls },
+              finish_reason: "tool_calls",
+            }],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        );
+        return { response: toolResponse, url: BLACKBOX_CHAT_API, headers, transformedBody };
+      }
+      const finalResponse = stream
+        ? new Response(buildStreamingResponse(cleanedContent, model, id, created), {
+            status: 200,
+            headers: { "Content-Type": "text/event-stream", "Cache-Control": "no-cache", "X-Accel-Buffering": "no" },
+          })
+        : buildNonStreamingResponse(cleanedContent, model, id, created);
+      return { response: finalResponse, url: BLACKBOX_CHAT_API, headers, transformedBody };
+    }
 
     const finalResponse = stream
       ? new Response(buildStreamingResponse(responseText, model, id, created), {


### PR DESCRIPTION
## Description

Blackbox web API has no native function calling support. This PR adds tool-call translation using the same pattern as deepseek-web (#2820), qwen-web (#3252), and ddg-web (#3253).

## How it works

1. **Request side**: Serialize OpenAI `tools[]` into a system prompt instruction via `serializeToolsToPrompt()`. Injects into the `parseOpenAIMessages` system instruction chain (prepended to first user message).

2. **Response side**: Parse `<tool>{...}</tool>` blocks from model text response via `parseToolCallsFromText()`. Returns proper OpenAI `tool_calls` format.

## Files Changed

- `open-sse/executors/blackbox-web.ts` — +37 lines

## Tests

All 21 existing tests pass.