### PR TITLE
feat(adapta-web): add tool-call translation via webTools prompt injection

### DIFF
--- a/open-sse/executors/adapta-web.ts
+++ b/open-sse/executors/adapta-web.ts
@@ -1,4 +1,5 @@
 import { BaseExecutor, type ExecuteInput } from "./base.ts";
+import { serializeToolsToPrompt, parseToolCallsFromText } from "../translator/webTools.ts";
 
 const ADAPTA_APP_URL = "https://agent.adapta.one";
 const ADAPTA_CLERK_URL = "https://clerk.agent.adapta.one";
@@ -353,6 +354,13 @@ export class AdaptaWebExecutor extends BaseExecutor {
     const bodyObj = (body ?? {}) as Record<string, unknown>;
     const messages = (Array.isArray(bodyObj.messages) ? bodyObj.messages : []) as OpenAIMessage[];
 
+    const requestedTools = bodyObj.tools;
+    const hasTools = Array.isArray(requestedTools) && requestedTools.length > 0;
+    const toolSystemPrompt = hasTools ? serializeToolsToPrompt(requestedTools) : "";
+    const effectiveMessages: OpenAIMessage[] = toolSystemPrompt
+      ? [{ role: "system", content: toolSystemPrompt }, ...messages]
+      : messages;
+
     // 1. Extract and validate credentials
     const rawKey = String((credentials as Record<string, unknown>)?.apiKey ?? "");
     if (!rawKey) {
@@ -385,7 +393,7 @@ export class AdaptaWebExecutor extends BaseExecutor {
 
     // 2. Build Adapta request body
     const aiModelId = MODEL_ID_MAP[model] ?? DEFAULT_AI_MODEL_ID;
-    const adaptaMessages = buildAdaptaMessages(messages);
+    const adaptaMessages = buildAdaptaMessages(effectiveMessages);
 
     if (adaptaMessages.length === 0) {
       return {
@@ -486,6 +494,37 @@ export class AdaptaWebExecutor extends BaseExecutor {
       }
     } finally {
       reader.releaseLock();
+    }
+
+    if (hasTools) {
+      const { content: cleanedContent, toolCalls } = parseToolCallsFromText(
+        fullText, `call-${Date.now()}`, requestedTools
+      );
+      if (toolCalls) {
+        return {
+          response: new Response(
+            JSON.stringify({
+              id: `chatcmpl-adp-${Date.now()}`, object: "chat.completion",
+              created: Math.floor(Date.now() / 1000), model,
+              choices: [{ index: 0, message: { role: "assistant", content: null, tool_calls: toolCalls }, finish_reason: "tool_calls" }],
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } }
+          ),
+          url: ADAPTA_STREAM_URL, headers, transformedBody: requestPayload,
+        };
+      }
+      return {
+        response: new Response(
+          JSON.stringify({
+            id: `chatcmpl-adp-${Date.now()}`, object: "chat.completion",
+            created: Math.floor(Date.now() / 1000), model,
+            choices: [{ index: 0, message: { role: "assistant", content: cleanedContent }, finish_reason: "stop" }],
+            usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        ),
+        url: ADAPTA_STREAM_URL, headers, transformedBody: requestPayload,
+      };
     }
 
     return {


### PR DESCRIPTION
## Description

Adapta web API has no native function calling support. This PR adds tool-call translation using the same pattern as deepseek-web (#2820), qwen-web (#3252), ddg-web (#3253), and blackbox-web (#3254).

## How it works

1. **Request side**: Serialize OpenAI `tools[]` into a system prompt instruction via `serializeToolsToPrompt()`. Injects into the `buildAdaptaMessages` system instruction chain.

2. **Response side**: Parse `<tool>{...}</tool>` blocks from model text response via `parseToolCallsFromText()`. Returns proper OpenAI `tool_calls` format.

## Files Changed

- `open-sse/executors/adapta-web.ts` — +40 lines

## Tests

All 5 existing tests pass.