### PR TITLE
fix(ci): deploy-vps via omniroute bin + fail on unhealthy boot

### DIFF
--- a/.github/workflows/deploy-vps.yml
+++ b/.github/workflows/deploy-vps.yml
@@ -17,27 +17,52 @@ jobs:
     name: Deploy OmniRoute to VPS
     runs-on: ubuntu-latest
     steps:
+      # NOTE: no `continue-on-error` — a failed SSH/install/boot MUST fail this job.
+      # Masking it (previous behavior) made the workflow report SUCCESS while the
+      # server was left broken or stale on an old version.
       - name: Deploy via SSH
         uses: appleboy/ssh-action@v1
-        continue-on-error: true
         with:
           host: ${{ secrets.VPS_HOST }}
           username: ${{ secrets.VPS_USER }}
           key: ${{ secrets.VPS_SSH_KEY }}
           port: 22
-          timeout: 30s
-          command_timeout: 5m
+          timeout: 60s
+          command_timeout: 15m
           script: |
+            set -e
             echo "=== Updating OmniRoute ==="
-            npm install -g omniroute@latest 2>&1
-            INSTALLED_VERSION=$(omniroute --version 2>/dev/null || echo "unknown")
-            echo "Installed version: $INSTALLED_VERSION"
+            npm install -g omniroute@latest
+            INSTALLED_VERSION=$(omniroute --version 2>/dev/null | tr -d '[:space:]' || echo "unknown")
+            echo "Installed CLI version: $INSTALLED_VERSION"
 
-            echo "=== Restarting PM2 ==="
-            pm2 restart omniroute || pm2 start omniroute --name omniroute -- --port 20128
+            echo "=== (Re)starting PM2 via the omniroute bin ==="
+            # Recreate the process from the bin on every deploy so its script path is
+            # ALWAYS the current bin — never a stale build file. The build output layout
+            # moved (app/ -> dist/, build-output isolation), so a bare `pm2 restart` of a
+            # process saved against the old `app/server-ws.mjs` path silently fails to
+            # boot. The `omniroute` bin loads DATA_DIR/.env and resolves the dist/ layout
+            # (with the legacy app/ fallback), so launching it is version-layout agnostic.
+            pm2 delete omniroute 2>/dev/null || true
+            pm2 start omniroute --name omniroute -- --port 20128
             pm2 save
 
-            echo "=== Health Check ==="
-            sleep 3
-            curl -sf http://localhost:20128/api/settings > /dev/null && echo "✅ OmniRoute is healthy" || echo "❌ Health check failed"
+            echo "=== Health Check (poll up to ~3min for boot) ==="
+            HEALTH_URL="http://localhost:20128/api/monitoring/health"
+            HEALTHY_BODY=""
+            for _ in $(seq 1 36); do
+              BODY=$(curl -sf -m 5 "$HEALTH_URL" 2>/dev/null || true)
+              if printf '%s' "$BODY" | grep -q '"status":"healthy"'; then
+                HEALTHY_BODY="$BODY"
+                break
+              fi
+              sleep 5
+            done
+            if [ -z "$HEALTHY_BODY" ]; then
+              echo "❌ Health check failed — server did not become healthy in time"
+              pm2 logs omniroute --err --lines 40 --nostream || true
+              exit 1
+            fi
+            RUNNING_VERSION=$(printf '%s' "$HEALTHY_BODY" | sed -n 's/.*"version":"\([^"]*\)".*/\1/p' | head -1)
+            echo "✅ OmniRoute is healthy — running version: ${RUNNING_VERSION:-unknown}"
             echo "=== Deploy complete ==="


### PR DESCRIPTION
## Why
The auto-deploy (`Deploy to VPS`) reported **SUCCESS while leaving the VPS broken/stale**. Root-caused during the v3.8.11 homologation incident (server on 192.168.0.15 went down on deploy):

1. **Stale pm2 script path.** The job did `pm2 restart omniroute || pm2 start ...`. A bare `pm2 restart` re-runs the **saved** script path, which after the build-output reorg (`app/` → `dist/`, #3124/#3187) pointed at the removed `app/server-ws.mjs` → process never booted, nothing listened on :20128. The original process survived only because it was started pre-reorg.
2. **`continue-on-error: true` masked the failure** → false green. Launching a raw server file directly also doesn't load `/root/.omniroute/.env` (no listener).

## What changed
- **Launch via the `omniroute` bin every deploy** (`pm2 delete` + `pm2 start omniroute -- --port 20128`), so the process is always started the canonical, layout-agnostic way — the bin loads `DATA_DIR/.env` and resolves `dist/` (with legacy `app/` fallback). No more stale-path restarts.
- **Removed `continue-on-error`** + added `set -e` so SSH/install/boot failures actually fail the job.
- **Real health gate**: poll `/api/monitoring/health` for ~3min, print the running version, dump `pm2 logs --err` and `exit 1` if it never reports `"status":"healthy"`.
- Bumped connect timeout 30s→60s and command timeout 5m→15m (`npm i -g` alone takes ~4m + boot).

## Validation
- The fix mirrors exactly what restored + homologated v3.8.11 on the Local VPS by hand: pm2 pointed at `/usr/bin/omniroute`, boots healthy (`version 3.8.11`, `/login` 200).
- `deploy-vps.yml` triggers on `workflow_run`/`workflow_dispatch` only (not on PRs), and is gated by `vars.DEPLOY_ENABLED`, so merging is safe; next real deploy exercises it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)