### PR TITLE
feat(models): add MiniMax M3 across all provider tiers (#3110)

### DIFF
--- a/open-sse/config/providerRegistry.ts
+++ b/open-sse/config/providerRegistry.ts
@@ -1195,6 +1195,8 @@ const _REGISTRY_EAGER: Record<string, RegistryEntry> = {
       { id: "work", name: "Work (Auto · fast)" },
       { id: "gemini-3.1-pro", name: "Gemini 3.1 Pro" },
       { id: "gemini-3-flash-solo", name: "Gemini 3 Flash" },
+      // #3110: MiniMax M3 via Trae
+      { id: "minimax-m3", name: "MiniMax M3", contextLength: 1048576 },
       { id: "minimax-m2.7", name: "MiniMax M2.7" },
       { id: "kimi-k2.5", name: "Kimi K2.5" },
       { id: "gpt-5.4", name: "GPT 5.4" },
@@ -1381,6 +1383,8 @@ const _REGISTRY_EAGER: Record<string, RegistryEntry> = {
         interleavedField: "reasoning_content",
       },
       { id: "deepseek-v4-flash-free", name: "DeepSeek V4 Flash Free", supportsReasoning: true },
+      // #3110: MiniMax M3 free tier via OpenCode
+      { id: "minimax-m3-free", name: "MiniMax M3 Free", contextLength: 1048576 },
       { id: "minimax-m2.5-free", name: "MiniMax M2.5 Free", contextLength: 204800 },
       { id: "ling-2.6-1t-free", name: "Ling 2.6 Free", contextLength: 262000 },
       {
@@ -1420,6 +1424,8 @@ const _REGISTRY_EAGER: Record<string, RegistryEntry> = {
       { id: "mimo-v2.5", name: "MiMo-V2.5" },
       { id: "mimo-v2-pro", name: "MiMo-V2-Pro" },
       { id: "mimo-v2-omni", name: "MiMo-V2-Omni" },
+      // #3110: MiniMax M3 via OpenCode Go tier
+      { id: "minimax-m3", name: "MiniMax M3", targetFormat: "claude", contextLength: 1048576 },
       { id: "minimax-m2.7", name: "MiniMax M2.7", targetFormat: "claude" },
       { id: "minimax-m2.5", name: "MiniMax M2.5", targetFormat: "claude" },
       // Issue #2292: Qwen models on opencode-go reject oa-compat format
@@ -1504,6 +1510,8 @@ const _REGISTRY_EAGER: Record<string, RegistryEntry> = {
       { id: "glm-5.1", name: "GLM-5.1" },
 
       // ── MiniMax ────────────────────────────────────────────────
+      // #3110: MiniMax M3 — frontier coding model with 1M context
+      { id: "minimax-m3", name: "MiniMax M3", contextLength: 1048576 },
       { id: "minimax-m2.5", name: "MiniMax M2.5" },
       { id: "minimax-m2.7", name: "MiniMax M2.7" },
 
@@ -2185,6 +2193,8 @@ const _REGISTRY_EAGER: Record<string, RegistryEntry> = {
     },
     models: [
       // T12/T28: MiniMax default upgraded from M2.5 to M2.7
+      // #3110: MiniMax M3 — frontier coding model with 1M context
+      { id: "MiniMax-M3", name: "MiniMax M3", contextLength: 1048576 },
       { id: "MiniMax-M2.7", name: "MiniMax M2.7" },
       { id: "MiniMax-M2.7-highspeed", name: "MiniMax M2.7 Highspeed" },
       { id: "MiniMax-M2.5", name: "MiniMax M2.5" },
@@ -2206,6 +2216,8 @@ const _REGISTRY_EAGER: Record<string, RegistryEntry> = {
     },
     models: [
       // Keep parity with minimax to ensure model discovery works for minimax-cn connections.
+      // #3110: MiniMax M3 — frontier coding model with 1M context
+      { id: "MiniMax-M3", name: "MiniMax M3", contextLength: 1048576 },
       { id: "MiniMax-M2.7", name: "MiniMax M2.7" },
       { id: "MiniMax-M2.7-highspeed", name: "MiniMax M2.7 Highspeed" },
       { id: "MiniMax-M2.5", name: "MiniMax M2.5" },
@@ -2663,6 +2675,8 @@ const _REGISTRY_EAGER: Record<string, RegistryEntry> = {
       { id: "glm-5", name: "GLM 5" },
       { id: "mimo-v2.5-pro", name: "MiMo-V2.5-Pro" },
       { id: "mimo-v2.5", name: "MiMo-V2.5" },
+      // #3110: MiniMax M3 via OpenCode Zen
+      { id: "minimax-m3", name: "MiniMax M3", contextLength: 1048576 },
       { id: "minimax-m2.7", name: "MiniMax M2.7" },
       { id: "minimax-m2.5", name: "MiniMax M2.5" },
       { id: "llama-4-maverick", name: "Llama 4 Maverick" },
@@ -3153,6 +3167,8 @@ const _REGISTRY_EAGER: Record<string, RegistryEntry> = {
       { id: "deepseek-v4-flash", name: "DeepSeek V4 Flash", supportsReasoning: true },
       { id: "kimi-k2.6", name: "Kimi K2.6" },
       { id: "glm-5.1", name: "GLM 5.1" },
+      // #3110: MiniMax M3 via Ollama
+      { id: "minimax-m3", name: "MiniMax M3", contextLength: 1048576 },
       { id: "minimax-m2.7", name: "MiniMax M2.7" },
       { id: "gemma4:31b", name: "Gemma 4 31B" },
       { id: "nemotron-3-super", name: "NVIDIA Nemotron 3 Super" },
@@ -3198,6 +3214,8 @@ const _REGISTRY_EAGER: Record<string, RegistryEntry> = {
     authHeader: "bearer",
     models: [
       { id: "z-ai/glm-5.1", name: "GLM 5.1" },
+      // #3110: MiniMax M3 via NVIDIA
+      { id: "minimaxai/minimax-m3", name: "MiniMax M3", contextLength: 1048576 },
       { id: "minimaxai/minimax-m2.7", name: "MiniMax M2.7" },
       { id: "google/gemma-4-31b-it", name: "Gemma 4 31B" },
       { id: "mistralai/mistral-small-4-119b-2603", name: "Mistral Small 4 2603" },

--- a/tests/unit/minimax-m3-model-registry.test.ts
+++ b/tests/unit/minimax-m3-model-registry.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Unit tests for MiniMax M3 model registration (#3110)
+ *
+ * Verifies that MiniMax-M3 is present in the provider registry across
+ * all relevant provider entries (minimax, minimax-cn, opencode, opencode-go,
+ * opencode-zen, kiro, ollama, nvidia).
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { REGISTRY } from "../../open-sse/config/providerRegistry.ts";
+
+describe("MiniMax M3 model registration (#3110)", () => {
+  it("minimax provider has MiniMax-M3 with 1M context", () => {
+    const entry = REGISTRY.minimax;
+    assert.ok(entry, "minimax registry entry must exist");
+    const m3 = entry.models.find((m) => m.id === "MiniMax-M3");
+    assert.ok(m3, "MiniMax-M3 must be in minimax models");
+    assert.equal(m3.name, "MiniMax M3");
+    assert.equal(m3.contextLength, 1_048_576);
+  });
+
+  it("minimax-cn provider has MiniMax-M3 with 1M context", () => {
+    const entry = REGISTRY["minimax-cn"];
+    assert.ok(entry, "minimax-cn registry entry must exist");
+    const m3 = entry.models.find((m) => m.id === "MiniMax-M3");
+    assert.ok(m3, "MiniMax-M3 must be in minimax-cn models");
+    assert.equal(m3.name, "MiniMax M3");
+    assert.equal(m3.contextLength, 1_048_576);
+  });
+
+  it("opencode provider has minimax-m3-free with 1M context", () => {
+    const entry = REGISTRY.opencode;
+    assert.ok(entry, "opencode registry entry must exist");
+    const m3 = entry.models.find((m) => m.id === "minimax-m3-free");
+    assert.ok(m3, "minimax-m3-free must be in opencode models");
+    assert.equal(m3.name, "MiniMax M3 Free");
+    assert.equal(m3.contextLength, 1_048_576);
+  });
+
+  it("opencode-go provider has minimax-m3 with Claude targetFormat", () => {
+    const entry = REGISTRY["opencode-go"];
+    assert.ok(entry, "opencode-go registry entry must exist");
+    const m3 = entry.models.find((m) => m.id === "minimax-m3");
+    assert.ok(m3, "minimax-m3 must be in opencode-go models");
+    assert.equal(m3.name, "MiniMax M3");
+    assert.equal(m3.targetFormat, "claude");
+    assert.equal(m3.contextLength, 1_048_576);
+  });
+
+  it("opencode-zen provider has minimax-m3 with 1M context", () => {
+    const entry = REGISTRY["opencode-zen"];
+    assert.ok(entry, "opencode-zen registry entry must exist");
+    const m3 = entry.models.find((m) => m.id === "minimax-m3");
+    assert.ok(m3, "minimax-m3 must be in opencode-zen models");
+    assert.equal(m3.name, "MiniMax M3");
+    assert.equal(m3.contextLength, 1_048_576);
+  });
+
+  it("trae provider has minimax-m3 with 1M context", () => {
+    const entry = REGISTRY.trae;
+    assert.ok(entry, "trae registry entry must exist");
+    const m3 = entry.models.find((m) => m.id === "minimax-m3");
+    assert.ok(m3, "minimax-m3 must be in trae models");
+    assert.equal(m3.name, "MiniMax M3");
+    assert.equal(m3.contextLength, 1_048_576);
+  });
+
+  it("ollama-cloud provider has minimax-m3 with 1M context", () => {
+    const entry = REGISTRY["ollama-cloud"];
+    assert.ok(entry, "ollama-cloud registry entry must exist");
+    const m3 = entry.models.find((m) => m.id === "minimax-m3");
+    assert.ok(m3, "minimax-m3 must be in ollama-cloud models");
+    assert.equal(m3.name, "MiniMax M3");
+    assert.equal(m3.contextLength, 1_048_576);
+  });
+
+  it("nvidia provider has minimaxai/minimax-m3 with 1M context", () => {
+    const entry = REGISTRY.nvidia;
+    assert.ok(entry, "nvidia registry entry must exist");
+    const m3 = entry.models.find((m) => m.id === "minimaxai/minimax-m3");
+    assert.ok(m3, "minimaxai/minimax-m3 must be in nvidia models");
+    assert.equal(m3.name, "MiniMax M3");
+    assert.equal(m3.contextLength, 1_048_576);
+  });
+});


### PR DESCRIPTION
MiniMax M3 is a frontier coding & agentic model with 1M context window, announced 2026-05-31. It uses the same Anthropic-compatible API as M2.7.

**Changes:**
- `minimax` / `minimax-cn`: add `MiniMax-M3` with 1M context
- `opencode`: add `minimax-m3-free` (free tier)
- `opencode-go`: add `minimax-m3` with `targetFormat: claude`
- `opencode-zen`: add `minimax-m3` with 1M context
- `trae`: add `minimax-m3` with 1M context
- `ollama-cloud`: add `minimax-m3` with 1M context
- `nvidia`: add `minimaxai/minimax-m3` with 1M context

**Tests:** 8 unit tests in `tests/unit/minimax-m3-model-registry.test.ts` covering all provider entries.

**Docs:** https://platform.minimax.io/docs/guides/models-intro

Fixes #3110