### PR TITLE
fix(ci): skip auto-deploy when VPS host is unreachable from the runner

### DIFF
--- a/.github/workflows/deploy-vps.yml
+++ b/.github/workflows/deploy-vps.yml
@@ -17,7 +17,33 @@ jobs:
     name: Deploy OmniRoute to VPS
     runs-on: ubuntu-latest
     steps:
+      - name: Check VPS SSH reachability from runner
+        id: reach
+        env:
+          # Pass the host via env (never interpolate a secret straight into the
+          # script body) so /dev/tcp gets a shell variable, not inlined text.
+          VPS_HOST: ${{ secrets.VPS_HOST }}
+        run: |
+          set -uo pipefail
+          # A GitHub-hosted runner can only deploy when it can actually open a TCP
+          # connection to the VPS SSH port. The Local VPS lives on a private LAN and
+          # the Akamai host firewalls :22 to known IPs, so the runner is routinely
+          # unable to reach it (`dial tcp ***:22: i/o timeout`). Treat "unreachable
+          # from the runner" as a SKIP — the real deploys are run manually from an
+          # allowed network via the deploy-vps-local / deploy-vps-akamai skills — so
+          # an unreachable host no longer red-fails every release/push pipeline.
+          # When the host IS reachable, the deploy step below still runs in full and
+          # its health gate surfaces any genuine deploy failure.
+          if timeout 15 bash -c 'exec 3<>"/dev/tcp/${VPS_HOST}/22"' 2>/dev/null; then
+            echo "reachable=true" >> "$GITHUB_OUTPUT"
+            echo "✅ VPS_HOST:22 reachable from the runner — proceeding with deploy."
+          else
+            echo "reachable=false" >> "$GITHUB_OUTPUT"
+            echo "::warning title=Auto-deploy skipped::VPS_HOST:22 is not reachable from this GitHub runner (private LAN / firewalled). Deploy manually with the deploy-vps-local or deploy-vps-akamai skill."
+          fi
+
       - name: Deploy via SSH
+        if: steps.reach.outputs.reachable == 'true'
         uses: appleboy/ssh-action@v1
         with:
           host: ${{ secrets.VPS_HOST }}


### PR DESCRIPTION
## Problem

The **Deploy to VPS** workflow (`deploy-vps.yml`, `workflow_run` after *Publish to Docker Hub* + `workflow_dispatch`) fails on **every release/push** with:

```
2026/06/06 12:11:39 dial tcp ***:22: i/o timeout
##[error]Process completed with exit code 1.
```

GitHub-hosted runners cannot open a TCP connection to `VPS_HOST:22`:
- the **Local VPS** lives on a private LAN, and
- the **Akamai** host firewalls `:22` to known IPs.

This was always the case — but #3270 (correctly) removed the `continue-on-error: true` that used to mask it, so the honest connectivity failure now red-fails the whole release pipeline. Real deploys are performed manually from an allowed network via the `deploy-vps-local` / `deploy-vps-akamai` skills.

## Fix

Add a **reachability pre-check** step that probes `VPS_HOST:22` from the runner:

- **Unreachable** → emit a `::warning::` and **skip** the deploy step (job succeeds). An unreachable host is no longer a release-blocking failure.
- **Reachable** → the existing `appleboy/ssh-action` deploy runs in full, and its `/api/monitoring/health` `"status":"healthy"` gate still **fails honestly** on a genuine deploy/boot failure (the #3270 behavior is preserved).

The host is passed through the step `env:` block and referenced as the shell variable `${VPS_HOST}` — never interpolated as `${{ secrets.VPS_HOST }}` into the script body (shell-injection hard rule #13).

## Validation

CI/workflow change — validated by structural review (YAML parses; 2 steps; deploy gated on `steps.reach.outputs.reachable == 'true'`). End-to-end behavior validates on the next release/`workflow_dispatch`: from a cloud runner the reachability probe should report unreachable → warn + skip → green job, instead of the current red `i/o timeout` failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)