### PR TITLE
feat(api): accept path-scoped API keys on client API routes

### DIFF
--- a/src/server/authz/policies/clientApi.ts
+++ b/src/server/authz/policies/clientApi.ts
@@ -1,19 +1,23 @@
 import { isDashboardSessionAuthenticated } from "@/shared/utils/apiAuth.ts";
 import { isRequireApiKeyEnabled } from "@/shared/utils/featureFlags";
+import { extractApiKey } from "@/sse/services/auth.ts";
 import type { AuthOutcome, PolicyContext, RoutePolicy } from "../context";
 import { allow, reject } from "../context";
 
-function extractBearer(headers: Headers): string | null {
-  const raw = headers.get("authorization") ?? headers.get("Authorization");
-  const xApiKey = headers.get("x-api-key") ?? headers.get("X-Api-Key");
+function extractBearer(request: Request): string | null {
+  const raw = request.headers.get("authorization") ?? request.headers.get("Authorization");
+  const xApiKey = request.headers.get("x-api-key") ?? request.headers.get("X-Api-Key");
   if (raw) {
     const trimmed = raw.trim();
     if (!trimmed.toLowerCase().startsWith("bearer ")) return null;
     return trimmed.slice(7).trim() || null;
-  } else if (xApiKey) {
+  }
+
+  if (xApiKey) {
     return xApiKey?.trim() || null;
   }
-  return null;
+
+  return extractApiKey(request);
 }
 
 function maskKeyId(apiKey: string): string {
@@ -24,7 +28,7 @@ function maskKeyId(apiKey: string): string {
 export const clientApiPolicy: RoutePolicy = {
   routeClass: "CLIENT_API",
   async evaluate(ctx: PolicyContext): Promise<AuthOutcome> {
-    const bearer = extractBearer(ctx.request.headers);
+    const bearer = extractBearer(ctx.request as Request);
     if (!bearer) {
       if (await isDashboardSessionAuthenticated(ctx.request)) {
         return allow({ kind: "dashboard_session", id: "dashboard" });

--- a/src/shared/utils/apiAuth.ts
+++ b/src/shared/utils/apiAuth.ts
@@ -11,6 +11,7 @@ import { jwtVerify } from "jose";
 import { cookies } from "next/headers";
 import { getSettings } from "@/lib/localDb";
 import { isPublicApiRoute } from "@/shared/constants/publicApiRoutes";
+import { extractApiKey } from "@/sse/services/auth";
 
 type RequestLike = {
   cookies?: {
@@ -138,15 +139,18 @@ function getCookieValueFromHeader(headers: Headers | undefined, name: string): s
   return null;
 }
 
-function getBearerToken(request: RequestLike | Request | null | undefined): string | null {
-  const headers =
-    request && typeof request === "object" && "headers" in request ? request.headers : undefined;
-  const authHeader = headers?.get("authorization") || headers?.get("Authorization");
-  if (typeof authHeader !== "string") return null;
+function getRequestApiKey(request: RequestLike | Request | null | undefined): string | null {
+  if (!request || typeof request !== "object") return null;
 
-  const trimmedHeader = authHeader.trim();
-  if (!trimmedHeader.toLowerCase().startsWith("bearer ")) return null;
-  return trimmedHeader.slice(7).trim() || null;
+  const headers = "headers" in request ? request.headers : undefined;
+  const rawUrl = "url" in request && typeof request.url === "string" ? request.url : null;
+  const pathname = getRequestPathname(request);
+  const syntheticUrl = rawUrl || (pathname ? `http://localhost${pathname}` : null);
+
+  return extractApiKey({
+    headers,
+    url: syntheticUrl,
+  });
 }
 
 async function validateBearerApiKey(apiKey: string | null): Promise<boolean> {
@@ -248,15 +252,15 @@ export async function verifyAuth(request: any): Promise<string | null> {
     return null;
   }
 
-  const bearerToken = getBearerToken(request);
+  const apiKey = getRequestApiKey(request);
   if (isManagementApiRequest(request)) {
-    if (await validateBearerApiKeyForManagement(bearerToken)) {
+    if (await validateBearerApiKeyForManagement(apiKey)) {
       return null;
     }
-    return bearerToken ? "Invalid management token" : "Authentication required";
+    return apiKey ? "Invalid management token" : "Authentication required";
   }
 
-  if (await validateBearerApiKey(bearerToken)) {
+  if (await validateBearerApiKey(apiKey)) {
     return null;
   }
 
@@ -282,12 +286,12 @@ export async function isAuthenticated(request: Request): Promise<boolean> {
     return true;
   }
 
-  const bearerToken = getBearerToken(request);
+  const apiKey = getRequestApiKey(request);
   if (isManagementApiRequest(request)) {
-    return validateBearerApiKeyForManagement(bearerToken);
+    return validateBearerApiKeyForManagement(apiKey);
   }
 
-  return validateBearerApiKey(bearerToken);
+  return validateBearerApiKey(apiKey);
 }
 
 /**

--- a/src/sse/services/auth.ts
+++ b/src/sse/services/auth.ts
@@ -183,11 +183,29 @@ function toBooleanOrDefault(value: unknown, fallback: boolean): boolean {
 }
 
 function readHeaderValue(
-  headers: Headers | { get?: (name: string) => string | null } | null | undefined,
+  headers:
+    | Headers
+    | { get?: (name: string) => string | null }
+    | Record<string, string | string[] | undefined>
+    | null
+    | undefined,
   name: string
 ): string | null {
-  if (!headers || typeof headers.get !== "function") return null;
-  const value = headers.get(name);
+  if (!headers) return null;
+
+  if (typeof (headers as Headers).get === "function") {
+    const value = (headers as Headers).get(name) || (headers as Headers).get(name.toLowerCase());
+    return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+  }
+
+  const recordHeaders = headers as Record<string, string | string[] | undefined>;
+  const value =
+    recordHeaders[name] || recordHeaders[name.toLowerCase()] || recordHeaders[name.toUpperCase()];
+
+  if (Array.isArray(value)) {
+    return typeof value[0] === "string" && value[0].trim().length > 0 ? value[0].trim() : null;
+  }
+
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
 }
 
@@ -2024,16 +2042,63 @@ export async function clearRecoveredProviderState(
   await clearAccountError(credentials.connectionId, credentials);
 }
 
+type AuthRequestHeaders = Headers | Record<string, string | string[] | undefined>;
+
+type AuthRequestLike = {
+  headers?: AuthRequestHeaders | null;
+  url?: string | null;
+};
+
+function readNonEmptyUrlToken(request: AuthRequestLike): string | null {
+  if (typeof request?.url !== "string" || request.url.trim().length === 0) return null;
+
+  try {
+    const url = new URL(request.url, "http://localhost");
+
+    const segments = url.pathname
+      .split("/")
+      .map((segment) => segment.trim())
+      .filter(Boolean);
+
+    if (segments[0] === "vscode" && segments[1]) {
+      const decodedSegment = decodeURIComponent(segments[1]).trim();
+      if (decodedSegment.length > 0) return decodedSegment;
+    }
+
+    if (segments[0] === "api" && segments[1] === "v1" && segments[2] === "vscode") {
+      if (segments[3] && segments[3] !== "raw" && segments[3] !== "combos") {
+        const decodedSegment = decodeURIComponent(segments[3]).trim();
+        if (decodedSegment.length > 0) return decodedSegment;
+      }
+
+      if ((segments[3] === "raw" || segments[3] === "combos") && segments[4]) {
+        const decodedSegment = decodeURIComponent(segments[4]).trim();
+        if (decodedSegment.length > 0) return decodedSegment;
+      }
+    }
+
+    for (const key of ["apiKey", "api_key", "key", "token"]) {
+      const token = url.searchParams.get(key)?.trim();
+      if (token) return token;
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
 /**
- * Extract API key from request headers.
+ * Extract API key from request auth inputs.
  *
- * Honors both:
+ * Honors both explicit headers and URL-based fallbacks:
  * - `Authorization: Bearer <key>` (OpenAI / OmniRoute / Codex CLI / Bearer clients)
  * - `x-api-key: <key>` (Anthropic Messages API contract — Claude Code,
  *   `@anthropic-ai/sdk`, any SDK that sets `anthropic-version`)
+ * - `/vscode/<key>/...` (path-scoped tokenized aliases)
+ * - `?token=<key>` / `?apiKey=<key>` / `?api_key=<key>` / `?key=<key>`
  *
- * When both are present, `Authorization: Bearer` wins for back-compat
- * (issue #2225).
+ * When multiple inputs are present, explicit auth headers win.
  *
  * The `x-api-key` fallback only triggers when the request also carries an
  * `anthropic-version` header — the documented signal that the caller is
@@ -2042,28 +2107,35 @@ export async function clearRecoveredProviderState(
  * with placeholder keys) would be treated as authenticated attempts and
  * rejected by per-route gates that compare against OmniRoute keys.
  */
-export function extractApiKey(request: Request) {
-  const authHeader = request.headers.get("Authorization") || request.headers.get("authorization");
+export function extractApiKey(request: AuthRequestLike) {
+  const authHeader =
+    readHeaderValue(request?.headers, "Authorization") ||
+    readHeaderValue(request?.headers, "authorization");
   if (typeof authHeader === "string") {
     const trimmedHeader = authHeader.trim();
     if (trimmedHeader.toLowerCase().startsWith("bearer ")) {
-      return trimmedHeader.slice(7).trim();
+      return trimmedHeader.slice(7).trim() || null;
     }
   }
+
   // Issue #2225: Anthropic Messages API clients authenticate via x-api-key.
   // Gate the fallback on the anthropic-version header so we don't trip up
   // local-mode requests from non-Anthropic clients that send placeholder
   // x-api-key values (which would otherwise be rejected as Invalid API key).
   const anthropicVersion =
-    request.headers.get("anthropic-version") || request.headers.get("Anthropic-Version");
+    readHeaderValue(request?.headers, "anthropic-version") ||
+    readHeaderValue(request?.headers, "Anthropic-Version");
   if (anthropicVersion) {
-    const xApiKey = request.headers.get("x-api-key") || request.headers.get("X-Api-Key");
+    const xApiKey =
+      readHeaderValue(request?.headers, "x-api-key") ||
+      readHeaderValue(request?.headers, "X-Api-Key");
     if (typeof xApiKey === "string") {
       const trimmed = xApiKey.trim();
       if (trimmed.length > 0) return trimmed;
     }
   }
-  return null;
+
+  return readNonEmptyUrlToken(request);
 }
 
 /**

--- a/tests/unit/api-auth.test.ts
+++ b/tests/unit/api-auth.test.ts
@@ -104,6 +104,31 @@ test("verifyAuth falls back to bearer API key validation after a bad JWT", async
   assert.equal(result, null);
 });
 
+test("verifyAuth accepts API keys supplied via query string on client-facing routes", async () => {
+  const key = await apiKeysDb.createApiKey("query-auth", "machine1234567890");
+
+  const result = await apiAuth.verifyAuth({
+    cookies: {
+      get() {
+        return undefined;
+      },
+    },
+    headers: new Headers(),
+    url: `https://example.com/api/v1/models?token=${encodeURIComponent(key.key)}`,
+  });
+
+  assert.equal(result, null);
+});
+
+test("isAuthenticated accepts API keys embedded in vscode path aliases", async () => {
+  const key = await apiKeysDb.createApiKey("path-auth", "machine1234567890");
+  const request = new Request(`https://example.com/api/v1/vscode/${encodeURIComponent(key.key)}/models`);
+
+  const result = await apiAuth.isAuthenticated(request);
+
+  assert.equal(result, true);
+});
+
 test("verifyAuth rejects bearer API keys on management routes", async () => {
   const key = await apiKeysDb.createApiKey("integration", "machine1234567890");
   const result = await apiAuth.verifyAuth({

--- a/tests/unit/auth-extract-api-key.test.ts
+++ b/tests/unit/auth-extract-api-key.test.ts
@@ -89,3 +89,22 @@ test("extractApiKey accepts Anthropic-Version (TitleCase) header", () => {
   });
   assert.equal(extractApiKey(req), "sk-titlecase-version");
 });
+
+test("extractApiKey extracts a path-scoped token from /api/v1/vscode/<token>/...", () => {
+  const req = new Request("https://omniroute.test/api/v1/vscode/sk-test-path-token/models");
+  assert.equal(extractApiKey(req), "sk-test-path-token");
+});
+
+test("extractApiKey extracts a path-scoped token from /api/v1/vscode/raw/<token>/...", () => {
+  const req = new Request(
+    "https://omniroute.test/api/v1/vscode/raw/sk-test-path-token/api/version"
+  );
+  assert.equal(extractApiKey(req), "sk-test-path-token");
+});
+
+test("extractApiKey extracts a path-scoped token from /api/v1/vscode/combos/<token>/...", () => {
+  const req = new Request(
+    "https://omniroute.test/api/v1/vscode/combos/sk-test-path-token/api/version"
+  );
+  assert.equal(extractApiKey(req), "sk-test-path-token");
+});

--- a/tests/unit/sse-auth.test.ts
+++ b/tests/unit/sse-auth.test.ts
@@ -89,6 +89,14 @@ test("extractApiKey parses bearer headers and isValidApiKey validates persisted 
     ),
     null
   );
+  assert.equal(
+    auth.extractApiKey(new Request(`http://localhost/v1/chat/completions?token=${created.key}`)),
+    created.key
+  );
+  assert.equal(
+    auth.extractApiKey(new Request(`http://localhost/api/v1/vscode/${created.key}/chat/completions`)),
+    created.key
+  );
   assert.equal(await auth.isValidApiKey(created.key), true);
   assert.equal(await auth.isValidApiKey("sk-missing"), false);
   assert.equal(await auth.isValidApiKey(""), false);


### PR DESCRIPTION
## What

Splits the **path-scoped API key** handling out of #3073 into a focused, independently-reviewable change.

Token-scoped keys (used by the per-token `/api/v1` surfaces) are now accepted by the client API policy and the SSE auth key extractor.

## Files
- `src/server/authz/policies/clientApi.ts` — accept path-scoped keys (reconciled with current main: keeps `isRequireApiKeyEnabled`, adds `extractApiKey`)
- `src/shared/utils/apiAuth.ts`, `src/sse/services/auth.ts` — key extraction support
- tests: `api-auth`, `auth-extract-api-key`, `sse-auth` (108 pass)

## Context
Part of breaking up the large #3073 into smaller, focused PRs. Built on current `main`.