### PR TITLE
fix(auth): harden URL token extraction — drop query-string fallback, gate to client routes (#3300 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ _Development cycle in progress — entries are added as work merges into `releas
 ### ✨ New Features
 
 - **feat(web-cookie):** self-service login infrastructure for 21 web-cookie providers — three login pathways (Electron BrowserWindow, Playwright dashboard fallback, `POST /api/providers/{id}/login`), token-extraction configs, and a 15-min cookie-validity auto-refresh daemon. Hardened on merge: error bodies sanitized (Hard Rule #12), the spawn-capable login route classified LOCAL_ONLY (Hard Rules #15/#17), and the Electron status listener de-duplicated. ([#3292](https://github.com/diegosouzapw/OmniRoute/pull/3292), closes #3070 — thanks @oyi77 / @diegosouzapw)
-- **feat(api):** accept path-scoped API keys on client API routes — keys may now arrive via `/api/v1/vscode/<key>/…` path aliases (incl. `raw`/`combos`) or `?token=`/`?apiKey=`/`?api_key=`/`?key=` query params; explicit `Authorization`/`x-api-key` headers still take precedence. Split out of #3073. ([#3300](https://github.com/diegosouzapw/OmniRoute/pull/3300) — thanks @zhiru)
+- **feat(api):** accept path-scoped API keys on client API routes — keys may arrive via `/api/v1/vscode/<key>/…` path aliases (incl. `raw`/`combos`); explicit `Authorization`/`x-api-key` headers still take precedence. Split out of #3073. ([#3300](https://github.com/diegosouzapw/OmniRoute/pull/3300) — thanks @zhiru)
+
+### 🔒 Security
+
+- **fix(auth):** follow-up hardening of the client-API key extractor (#3300) — removed the generic query-string token fallbacks (`?token=`/`?key=`/`?apiKey=`/`?api_key=`), which leak credentials into access logs / Referer headers, and gated URL-borne tokens to client routes only (management auth is now header-only) so a credential in the URL can never authenticate a management route. The path-scoped `/vscode/<key>/…` form the VS Code integration needs is unchanged. (security review follow-up to [#3300](https://github.com/diegosouzapw/OmniRoute/pull/3300) — thanks @zhiru / @diegosouzapw)
 
 ### 🔧 Bug Fixes
 

--- a/src/lib/api/requireManagementAuth.ts
+++ b/src/lib/api/requireManagementAuth.ts
@@ -34,7 +34,9 @@ export async function requireManagementAuth(request: Request): Promise<Response 
     return null;
   }
 
-  const apiKey = extractApiKey(request);
+  // Management auth never honours a URL-borne credential (header-only) — a token
+  // in the path/query must not authenticate a management route. See #3300 follow-up.
+  const apiKey = extractApiKey(request, { allowUrl: false });
   if (apiKey) {
     let meta: Awaited<ReturnType<typeof getApiKeyMetadata>>;
     try {

--- a/src/server/authz/policies/management.ts
+++ b/src/server/authz/policies/management.ts
@@ -120,7 +120,9 @@ export const managementPolicy: RoutePolicy = {
     // still hit the same 403 LOCAL_ONLY they did before.
     if (isLocalOnlyPath(path) && !isLoopbackRequest(ctx) && !isPrivateLanRequest(ctx)) {
       if (isLocalOnlyBypassableByManageScope(path)) {
-        const apiKey = extractApiKey(ctx.request as unknown as Request);
+        // Management auth is header-only — a URL-borne token must never satisfy a
+        // manage-scope bypass of a LOCAL_ONLY route. See #3300 follow-up.
+        const apiKey = extractApiKey(ctx.request as unknown as Request, { allowUrl: false });
         if (apiKey) {
           try {
             if (await isValidApiKey(apiKey)) {
@@ -198,7 +200,9 @@ export const managementPolicy: RoutePolicy = {
     // unhealthy, which is a 503, not a 403 — masking it as an auth failure
     // would tell callers their credentials are wrong when the real problem
     // is that the server cannot validate any credential right now.
-    const apiKey = extractApiKey(ctx.request as unknown as Request);
+    // Management auth is header-only — a URL-borne token must not authenticate
+    // a management route. See #3300 follow-up.
+    const apiKey = extractApiKey(ctx.request as unknown as Request, { allowUrl: false });
     if (apiKey) {
       try {
         if (await isValidApiKey(apiKey)) {

--- a/src/shared/utils/apiAuth.ts
+++ b/src/shared/utils/apiAuth.ts
@@ -139,7 +139,10 @@ function getCookieValueFromHeader(headers: Headers | undefined, name: string): s
   return null;
 }
 
-function getRequestApiKey(request: RequestLike | Request | null | undefined): string | null {
+function getRequestApiKey(
+  request: RequestLike | Request | null | undefined,
+  opts?: { allowUrl?: boolean }
+): string | null {
   if (!request || typeof request !== "object") return null;
 
   const headers = "headers" in request ? request.headers : undefined;
@@ -147,10 +150,12 @@ function getRequestApiKey(request: RequestLike | Request | null | undefined): st
   const pathname = getRequestPathname(request);
   const syntheticUrl = rawUrl || (pathname ? `http://localhost${pathname}` : null);
 
-  return extractApiKey({
-    headers,
-    url: syntheticUrl,
-  });
+  // Management auth never honours a URL-borne credential (defence-in-depth: the
+  // path-scoped token is a client-API affordance only — a credential in the URL
+  // must not authenticate a management route). See the #3300 security follow-up.
+  const allowUrl = opts?.allowUrl !== false;
+
+  return extractApiKey({ headers, url: allowUrl ? syntheticUrl : null }, { allowUrl });
 }
 
 async function validateBearerApiKey(apiKey: string | null): Promise<boolean> {
@@ -252,8 +257,9 @@ export async function verifyAuth(request: any): Promise<string | null> {
     return null;
   }
 
-  const apiKey = getRequestApiKey(request);
-  if (isManagementApiRequest(request)) {
+  const isManagement = isManagementApiRequest(request);
+  const apiKey = getRequestApiKey(request, { allowUrl: !isManagement });
+  if (isManagement) {
     if (await validateBearerApiKeyForManagement(apiKey)) {
       return null;
     }
@@ -286,8 +292,9 @@ export async function isAuthenticated(request: Request): Promise<boolean> {
     return true;
   }
 
-  const apiKey = getRequestApiKey(request);
-  if (isManagementApiRequest(request)) {
+  const isManagement = isManagementApiRequest(request);
+  const apiKey = getRequestApiKey(request, { allowUrl: !isManagement });
+  if (isManagement) {
     return validateBearerApiKeyForManagement(apiKey);
   }
 

--- a/src/sse/services/auth.ts
+++ b/src/sse/services/auth.ts
@@ -849,7 +849,11 @@ async function getProviderSearchPool(provider: string): Promise<string[]> {
       const nodePrefix = typeof nodeRecord.prefix === "string" ? nodeRecord.prefix.trim() : "";
       const nodeId = typeof nodeRecord.id === "string" ? nodeRecord.id.trim() : "";
       if (!nodePrefix || !nodeId) continue;
-      if (nodePrefix === provider || nodePrefix === canonicalProvider || nodePrefix === canonicalAlias) {
+      if (
+        nodePrefix === provider ||
+        nodePrefix === canonicalProvider ||
+        nodePrefix === canonicalAlias
+      ) {
         searchPool.add(nodeId);
       }
     }
@@ -1602,8 +1606,8 @@ export async function getProviderCredentialsWithQuotaPreflight(
     // false for both "not set" and "explicit false" — we need an explicit check
     // here to distinguish them.
     const legacyForceDisable =
-      (credentials as { providerSpecificData?: Record<string, unknown> })
-        .providerSpecificData?.quotaPreflightEnabled === false;
+      (credentials as { providerSpecificData?: Record<string, unknown> }).providerSpecificData
+        ?.quotaPreflightEnabled === false;
     if (legacyForceDisable) return credentials;
 
     const hasConnectionOverrides = Object.keys(perConnectionWindowOverrides).length > 0;
@@ -2077,10 +2081,12 @@ function readNonEmptyUrlToken(request: AuthRequestLike): string | null {
       }
     }
 
-    for (const key of ["apiKey", "api_key", "key", "token"]) {
-      const token = url.searchParams.get(key)?.trim();
-      if (token) return token;
-    }
+    // NOTE: query-string token fallbacks (`?token=`/`?key=`/`?apiKey=`/`?api_key=`)
+    // were intentionally REMOVED. They are a broad credential-in-URL surface that
+    // leaks into access logs, Referer headers and proxy logs, and — because this
+    // extractor also feeds management auth — would let `?token=<mgmt-key>`
+    // authenticate management routes. The VS Code integration only needs the
+    // path-scoped `/vscode/<token>/…` form above. (security review, #3300 follow-up)
   } catch {
     return null;
   }
@@ -2091,12 +2097,12 @@ function readNonEmptyUrlToken(request: AuthRequestLike): string | null {
 /**
  * Extract API key from request auth inputs.
  *
- * Honors both explicit headers and URL-based fallbacks:
+ * Honors explicit auth headers and (for client-facing routes only) a
+ * path-scoped URL token:
  * - `Authorization: Bearer <key>` (OpenAI / OmniRoute / Codex CLI / Bearer clients)
  * - `x-api-key: <key>` (Anthropic Messages API contract — Claude Code,
  *   `@anthropic-ai/sdk`, any SDK that sets `anthropic-version`)
- * - `/vscode/<key>/...` (path-scoped tokenized aliases)
- * - `?token=<key>` / `?apiKey=<key>` / `?api_key=<key>` / `?key=<key>`
+ * - `/vscode/<key>/...` (path-scoped tokenized aliases — only when `allowUrl`)
  *
  * When multiple inputs are present, explicit auth headers win.
  *
@@ -2106,8 +2112,13 @@ function readNonEmptyUrlToken(request: AuthRequestLike): string | null {
  * non-Anthropic SDKs that happen to set `x-api-key` (or local-mode tools
  * with placeholder keys) would be treated as authenticated attempts and
  * rejected by per-route gates that compare against OmniRoute keys.
+ *
+ * `opts.allowUrl` (default `true`) gates the path-scoped URL token. Management
+ * auth MUST pass `allowUrl: false` — a credential in the URL must never
+ * authenticate a management route (it leaks into logs/Referer and would widen
+ * the management surface). See the #3300 security follow-up.
  */
-export function extractApiKey(request: AuthRequestLike) {
+export function extractApiKey(request: AuthRequestLike, opts?: { allowUrl?: boolean }) {
   const authHeader =
     readHeaderValue(request?.headers, "Authorization") ||
     readHeaderValue(request?.headers, "authorization");
@@ -2135,6 +2146,7 @@ export function extractApiKey(request: AuthRequestLike) {
     }
   }
 
+  if (opts?.allowUrl === false) return null;
   return readNonEmptyUrlToken(request);
 }
 

--- a/tests/unit/api-auth.test.ts
+++ b/tests/unit/api-auth.test.ts
@@ -104,7 +104,8 @@ test("verifyAuth falls back to bearer API key validation after a bad JWT", async
   assert.equal(result, null);
 });
 
-test("verifyAuth accepts API keys supplied via query string on client-facing routes", async () => {
+test("verifyAuth no longer accepts API keys supplied via query string (#3300 follow-up)", async () => {
+  // Query-string token fallbacks were removed (credential-in-URL leaks into logs).
   const key = await apiKeysDb.createApiKey("query-auth", "machine1234567890");
 
   const result = await apiAuth.verifyAuth({
@@ -117,16 +118,40 @@ test("verifyAuth accepts API keys supplied via query string on client-facing rou
     url: `https://example.com/api/v1/models?token=${encodeURIComponent(key.key)}`,
   });
 
-  assert.equal(result, null);
+  // No usable credential → authentication fails (was incorrectly accepted before).
+  assert.notEqual(result, null);
 });
 
 test("isAuthenticated accepts API keys embedded in vscode path aliases", async () => {
   const key = await apiKeysDb.createApiKey("path-auth", "machine1234567890");
-  const request = new Request(`https://example.com/api/v1/vscode/${encodeURIComponent(key.key)}/models`);
+  const request = new Request(
+    `https://example.com/api/v1/vscode/${encodeURIComponent(key.key)}/models`
+  );
 
   const result = await apiAuth.isAuthenticated(request);
 
   assert.equal(result, true);
+});
+
+test("verifyAuth never honours a URL-borne token on MANAGEMENT routes (#3300 follow-up)", async () => {
+  // The historical escalation: a credential in the query string on a management
+  // route (/api/* but not /api/v1/*). It must not be extracted at all, so the
+  // failure is "Authentication required" (no credential) — NOT "Invalid
+  // management token" (which the pre-fix code returned, proving the URL token
+  // had been picked up and tried against management validation).
+  const key = await apiKeysDb.createApiKey("mgmt-url", "machine1234567890");
+
+  const result = await apiAuth.verifyAuth({
+    cookies: {
+      get() {
+        return undefined;
+      },
+    },
+    headers: new Headers(),
+    url: `https://example.com/api/providers?token=${encodeURIComponent(key.key)}`,
+  });
+
+  assert.equal(result, "Authentication required");
 });
 
 test("verifyAuth rejects bearer API keys on management routes", async () => {

--- a/tests/unit/auth-extract-api-key.test.ts
+++ b/tests/unit/auth-extract-api-key.test.ts
@@ -108,3 +108,22 @@ test("extractApiKey extracts a path-scoped token from /api/v1/vscode/combos/<tok
   );
   assert.equal(extractApiKey(req), "sk-test-path-token");
 });
+
+test("extractApiKey does NOT extract a query-string token (#3300 security follow-up)", () => {
+  // Query-string fallbacks (?token / ?key / ?apiKey / ?api_key) were removed —
+  // a credential in the query string leaks into access logs / Referer headers.
+  for (const q of ["token", "key", "apiKey", "api_key"]) {
+    const req = new Request(`https://omniroute.test/api/v1/models?${q}=sk-test-query-token`);
+    assert.equal(extractApiKey(req), null, `?${q}= must not be extracted`);
+  }
+});
+
+test("extractApiKey skips the path-scoped token when allowUrl is false (management auth)", () => {
+  const req = new Request("https://omniroute.test/api/v1/vscode/sk-test-path-token/models");
+  assert.equal(extractApiKey(req, { allowUrl: false }), null);
+  // Headers still work regardless of allowUrl.
+  const withHeader = new Request("https://omniroute.test/api/v1/vscode/sk-test-path-token/models", {
+    headers: { Authorization: "Bearer sk-header-wins" },
+  });
+  assert.equal(extractApiKey(withHeader, { allowUrl: false }), "sk-header-wins");
+});

--- a/tests/unit/sse-auth.test.ts
+++ b/tests/unit/sse-auth.test.ts
@@ -89,13 +89,26 @@ test("extractApiKey parses bearer headers and isValidApiKey validates persisted 
     ),
     null
   );
+  // Security follow-up (#3300): query-string token fallbacks were removed — a
+  // credential in `?token=` must NOT be extracted (it leaks into logs/Referer).
   assert.equal(
     auth.extractApiKey(new Request(`http://localhost/v1/chat/completions?token=${created.key}`)),
+    null
+  );
+  // The path-scoped `/vscode/<token>/…` form (VS Code integration) still works.
+  assert.equal(
+    auth.extractApiKey(
+      new Request(`http://localhost/api/v1/vscode/${created.key}/chat/completions`)
+    ),
     created.key
   );
+  // …but never when the caller opts out of URL extraction (management auth path).
   assert.equal(
-    auth.extractApiKey(new Request(`http://localhost/api/v1/vscode/${created.key}/chat/completions`)),
-    created.key
+    auth.extractApiKey(
+      new Request(`http://localhost/api/v1/vscode/${created.key}/chat/completions`),
+      { allowUrl: false }
+    ),
+    null
   );
   assert.equal(await auth.isValidApiKey(created.key), true);
   assert.equal(await auth.isValidApiKey("sk-missing"), false);
@@ -389,7 +402,9 @@ test("getProviderCredentialsWithQuotaPreflight: explicit quotaPreflightEnabled:f
   });
   // Give the connection per-window overrides (simulates a user-configured
   // threshold) — this is the field that previously caused the gate to keep going.
-  await (await import("../../src/lib/db/providers.ts")).updateProviderConnection(conn.id, {
+  await (
+    await import("../../src/lib/db/providers.ts")
+  ).updateProviderConnection(conn.id, {
     quotaWindowThresholds: { primary: 50 },
   });
 
@@ -687,7 +702,6 @@ test("getProviderCredentials retains rate-limited accounts when allowRateLimited
   assert.equal(blocked.allRateLimited, true);
   assert.equal(bypassed.connectionId, connection.id);
 });
-
 
 test("getProviderCredentials retains terminal accounts for combo live tests", async () => {
   const connection = await seedConnection("openai", {


### PR DESCRIPTION
## Security follow-up to #3300

A background security review flagged the query-string token fallback added in #3300 (`src/sse/services/auth.ts`):

```
[MEDIUM] Secrets/PII in Logs, URLs, or Errors
for (const key of ["apiKey", "api_key", "key", "token"]) {
  const token = url.searchParams.get(key)?.trim();
  if (token) return token;
}
```

Two problems, both confirmed:
1. **Credential-in-URL leak** — query-string tokens land in access logs, `Referer` headers and proxy logs.
2. **Management escalation** — `extractApiKey` also feeds `verifyAuth`/`isAuthenticated`/`requireManagementAuth`, so `?token=<key>` could authenticate a **management** route (`/api/*`, not `/api/v1/*`).

## Fix (Option A — approved)

- **Remove** the generic query-string fallbacks (`?token=`/`?key=`/`?apiKey=`/`?api_key=`) entirely.
- **Keep** the path-scoped `/vscode/<token>/…` form the VS Code integration (#3073) genuinely needs.
- **Gate URL extraction to client routes only.** New `allowUrl` option on `extractApiKey` (default `true`); every management auth seam now passes `allowUrl: false`:
  - `apiAuth.verifyAuth` / `isAuthenticated` (header-only for `isManagementApiRequest`)
  - `requireManagementAuth` (the gate used by #3292's login route)
  - the management policy (`policies/management.ts`, both the manage-scope bypass check and the main path)
- Header `Authorization: Bearer` / `x-api-key` behaviour is **unchanged**.

## Tests (TDD)

- `extractApiKey` no longer extracts any `?token=/?key=/?apiKey=/?api_key=` (asserts `null`).
- path-scoped `/vscode/<key>/…` still extracts.
- `allowUrl: false` skips URL extraction; header still wins.
- `verifyAuth` on a management route with `?token=<key>` now returns `"Authentication required"` — **not** `"Invalid management token"` (the pre-fix value, which proved the URL token had been picked up). This fails on the pre-fix code.

`tests/unit/auth-extract-api-key.test.ts` + `sse-auth.test.ts` + `api-auth.test.ts` → **111/111 green**. ESLint 0 errors, Prettier clean, `check:docs-sync` PASS.

> Access-log redaction (the review's 3rd suggestion) is moot here: the authz pipeline routes on `request.nextUrl.pathname` only and there is no middleware that logs full URLs with query strings; query-token support is removed anyway.

Hardens @zhiru's merged #3300 — original feature credit stands; this is a forward fix on `release/v3.8.13`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
