### PR TITLE
fix(dashboard): keep no-auth providers visible under 'Show configured only' (#3290)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ _Development cycle in progress — entries are added as work merges into `releas
 
 ### 🔧 Bug Fixes
 
+- **fix(dashboard):** keep no-auth providers (opencode, duckduckgo-web, theoldllm, veoaifree-web) visible under the "Show configured only" filter — they never create a connection row (`stats.total === 0`) but are always usable and already appear in `/v1/models`, so the filter now treats `displayAuthType === "no-auth"` as configured. (#3290 — thanks @uniQta)
 - **fix(sse):** harden the passthrough stream against empty upstream responses — emit a synthetic retry chunk on an empty `choices: []` (fixes a Copilot Chat crash) and log empty post-`tool_calls` completions; also registers **MiniMax M3** (1M context) across 8 provider tiers. ([#3297](https://github.com/diegosouzapw/OmniRoute/pull/3297), #3110 — thanks @wilsonicdev)
 - **fix(opencode-provider):** extract `contextLength` from the live `/v1/models` catalog (live > `modelContextLengths` > static map) so passthrough models outside the legacy 8-model map no longer silently truncate to OpenCode's 128K default. ([#3298](https://github.com/diegosouzapw/OmniRoute/pull/3298) — thanks @herjarsa / @diegosouzapw)
 - **fix(dev):** auto-rebuild `better-sqlite3` on a Node ABI mismatch at `npm run dev` startup (nvm 22↔24) — dev-only, no-op on the healthy path, unrelated errors not swallowed. ([#3301](https://github.com/diegosouzapw/OmniRoute/pull/3301) — thanks @zhiru)

--- a/src/app/(dashboard)/dashboard/providers/providerPageUtils.ts
+++ b/src/app/(dashboard)/dashboard/providers/providerPageUtils.ts
@@ -107,7 +107,12 @@ export function filterConfiguredProviderEntries<TProvider>(
   let filtered = entries;
 
   if (showConfiguredOnly) {
-    filtered = filtered.filter((entry) => Number(entry.stats?.total || 0) > 0);
+    // no-auth providers never create a DB connection row (stats.total === 0) but
+    // are always usable and appear unconditionally in the /v1/models catalog, so
+    // they must not be hidden by the configured-only filter (#3290).
+    filtered = filtered.filter(
+      (entry) => entry.displayAuthType === "no-auth" || Number(entry.stats?.total || 0) > 0
+    );
   }
 
   if (showFreeOnly) {

--- a/tests/unit/providers-page-utils.test.ts
+++ b/tests/unit/providers-page-utils.test.ts
@@ -80,6 +80,40 @@ test("configured-only filter keeps only providers with saved connections", () =>
   assert.equal(providerPageUtils.filterConfiguredProviderEntries(entries, false).length, 3);
 });
 
+test("configured-only filter keeps no-auth providers even without a saved connection (#3290)", () => {
+  const entries = [
+    {
+      providerId: "claude",
+      provider: { id: "claude" },
+      stats: { total: 0 },
+      displayAuthType: "oauth",
+      toggleAuthType: "oauth",
+    },
+    {
+      providerId: "opencode",
+      provider: { id: "opencode" },
+      stats: { total: 0 },
+      displayAuthType: "no-auth",
+      toggleAuthType: "no-auth",
+    },
+    {
+      providerId: "duckduckgo-web",
+      provider: { id: "duckduckgo-web" },
+      stats: { total: 0 },
+      displayAuthType: "no-auth",
+      toggleAuthType: "no-auth",
+    },
+  ];
+
+  // no-auth providers never create a DB connection row (total === 0) but are
+  // always usable and appear in /v1/models — they must survive the filter.
+  const visible = providerPageUtils.filterConfiguredProviderEntries(entries, true);
+  assert.deepEqual(
+    visible.map((entry) => entry.providerId),
+    ["duckduckgo-web", "opencode"]
+  );
+});
+
 test("search filter matches provider name and id case-insensitively", () => {
   const entries = [
     {


### PR DESCRIPTION
Closes #3290

## Problem
The providers page "Show configured only" toggle filters out entries with `stats.total === 0`. no-auth providers (opencode, duckduckgo-web, [provider removed at its operator's request], veoaifree-web) never create a DB connection row, so they always have `total: 0` and are always hidden when the filter is on — even though they are usable and appear unconditionally in `/v1/models`.

## Fix
`filterConfiguredProviderEntries` (providerPageUtils.ts) now treats `displayAuthType === "no-auth"` as configured, mirroring how the model catalog adds no-auth providers to `activeAliases`.

## Test (TDD)
Added a failing-then-passing case to `tests/unit/providers-page-utils.test.ts` asserting no-auth entries with `total: 0` survive the configured-only filter while a `total: 0` oauth entry is still hidden. Full file: 13/13 pass.

Reported with a precise root-cause + suggested fix by @uniQta.