### PR TITLE
fix: Kiro Builder ID token import fails with Bad credentials

### DIFF
--- a/src/app/api/oauth/kiro/import/route.ts
+++ b/src/app/api/oauth/kiro/import/route.ts
@@ -71,7 +71,7 @@ export async function POST(request: Request) {
       email: email || null,
       providerSpecificData: {
         profileArn: tokenData.profileArn,
-        authMethod: "imported",
+        authMethod: tokenData.authMethod || "imported",
         provider: "Imported",
         ...(tokenData.clientId
           ? {

--- a/src/lib/oauth/services/kiro.ts
+++ b/src/lib/oauth/services/kiro.ts
@@ -279,9 +279,9 @@ export class KiroService {
 
   /**
    * Validate and import refresh token.
-   * Registers a dedicated OIDC client so this connection has an isolated refresh session.
-   * If registerClient() fails (network issue, OIDC service down), the import still
-   * succeeds and the connection falls back to the shared social-auth refresh path.
+   * First attempts to validate using cached AWS SSO client credentials (Builder ID path).
+   * If that fails or no cached credentials exist, registers a dedicated OIDC client.
+   * If registerClient() also fails, the import falls back to the shared social-auth refresh path.
    */
   async validateImportToken(refreshToken: string, region: string = "us-east-1") {
     // Validate token format
@@ -289,7 +289,32 @@ export class KiroService {
       throw new Error("Invalid token format. Token should start with aorAAAAAG...");
     }
 
-    // Try to refresh to validate
+    // Try to read cached clientId/clientSecret from AWS SSO cache (Builder ID tokens)
+    const cachedClient = await this.readCachedClientCredentials();
+
+    // Attempt 1: Try Builder ID refresh using cached credentials
+    if (cachedClient) {
+      try {
+        const result = await this.refreshToken(refreshToken, {
+          clientId: cachedClient.clientId,
+          clientSecret: cachedClient.clientSecret,
+          authMethod: "builder-id",
+        });
+        return {
+          accessToken: result.accessToken,
+          refreshToken: result.refreshToken || refreshToken,
+          profileArn: result.profileArn,
+          expiresIn: result.expiresIn,
+          authMethod: "builder-id",
+          clientId: cachedClient.clientId,
+          clientSecret: cachedClient.clientSecret,
+        };
+      } catch {
+        // Cached credentials didn't work, fall through
+      }
+    }
+
+    // Attempt 2: Try social auth refresh
     let result: Awaited<ReturnType<typeof this.refreshToken>>;
     try {
       result = await this.refreshToken(refreshToken);
@@ -319,6 +344,37 @@ export class KiroService {
       authMethod: "imported",
       ...(clientId ? { clientId, clientSecret, clientSecretExpiresAt } : {}),
     };
+  }
+
+  /**
+   * Read clientId/clientSecret from AWS SSO cache (for Builder ID tokens).
+   * The cache is located at ~/.aws/sso/cache/ and contains JSON files from
+   * the OIDC client registration step of the device code flow.
+   */
+  private async readCachedClientCredentials(): Promise<{ clientId: string; clientSecret: string } | null> {
+    try {
+      const { readdir, readFile } = await import("fs/promises");
+      const { homedir } = await import("os");
+      const { join } = await import("path");
+      const cachePath = join(homedir(), ".aws", "sso", "cache");
+      const files = await readdir(cachePath);
+
+      for (const file of files) {
+        if (!file.endsWith(".json")) continue;
+        try {
+          const content = await readFile(join(cachePath, file), "utf-8");
+          const data = JSON.parse(content);
+          if (data.clientId && data.clientSecret) {
+            return { clientId: data.clientId, clientSecret: data.clientSecret };
+          }
+        } catch {
+          continue;
+        }
+      }
+    } catch {
+      // Cache not available
+    }
+    return null;
   }
 
   /**

--- a/tests/unit/kiro-builder-id-import-3333.test.ts
+++ b/tests/unit/kiro-builder-id-import-3333.test.ts
@@ -1,0 +1,116 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// Regression guard for #3333 — Kiro Builder ID token import failed with "Bad
+// credentials" because validateImportToken only ever tried the social-auth
+// refresh path. Builder ID tokens need the cached AWS SSO clientId/clientSecret
+// (~/.aws/sso/cache/*.json) and the OIDC refresh path (authMethod: "builder-id").
+
+const { KiroService } = await import("../../src/lib/oauth/services/kiro.ts");
+
+const ORIGINAL_HOME = process.env.HOME;
+const ORIGINAL_FETCH = globalThis.fetch;
+let tmpHome: string;
+
+function makeFakeSsoCache(home: string, creds: { clientId: string; clientSecret: string } | null) {
+  const cacheDir = path.join(home, ".aws", "sso", "cache");
+  fs.mkdirSync(cacheDir, { recursive: true });
+  if (creds) {
+    // The OIDC client-registration cache entry also carries unrelated keys.
+    fs.writeFileSync(
+      path.join(cacheDir, "client-reg.json"),
+      JSON.stringify({ ...creds, region: "us-east-1", expiresAt: "2099-01-01T00:00:00Z" })
+    );
+  }
+}
+
+test.beforeEach(() => {
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-kiro-3333-"));
+  process.env.HOME = tmpHome;
+});
+
+test.afterEach(() => {
+  process.env.HOME = ORIGINAL_HOME;
+  globalThis.fetch = ORIGINAL_FETCH;
+  if (tmpHome) fs.rmSync(tmpHome, { recursive: true, force: true });
+});
+
+test("validateImportToken uses cached Builder ID client creds + OIDC refresh path", async () => {
+  makeFakeSsoCache(tmpHome, { clientId: "cid-cached", clientSecret: "secret-cached" });
+
+  const calledEndpoints: string[] = [];
+  globalThis.fetch = (async (url: string | URL | Request) => {
+    const u = String(url);
+    calledEndpoints.push(u);
+    // Builder ID refresh hits the AWS OIDC token endpoint.
+    if (u.includes("oidc.") && u.endsWith("/token")) {
+      return new Response(
+        JSON.stringify({
+          accessToken: "access-builder-id",
+          refreshToken: "refreshed-token",
+          expiresIn: 3600,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    }
+    throw new Error(`unexpected fetch to ${u}`);
+  }) as typeof fetch;
+
+  const svc = new KiroService();
+  const result = await svc.validateImportToken("aorAAAAAGtoken-builder-id");
+
+  assert.equal(result.authMethod, "builder-id");
+  assert.equal(result.accessToken, "access-builder-id");
+  assert.equal(result.clientId, "cid-cached");
+  assert.equal(result.clientSecret, "secret-cached");
+  // Must have gone through the OIDC token endpoint, NOT the social-auth service.
+  assert.ok(
+    calledEndpoints.some((u) => u.includes("oidc.") && u.endsWith("/token")),
+    "expected OIDC token endpoint to be used for Builder ID refresh"
+  );
+});
+
+test("validateImportToken falls back to social auth when no cached creds exist", async () => {
+  // No ~/.aws/sso/cache → readCachedClientCredentials() returns null.
+  makeFakeSsoCache(tmpHome, null);
+
+  globalThis.fetch = (async (url: string | URL | Request) => {
+    const u = String(url);
+    // Social-auth refresh endpoint.
+    if (u.includes("auth.desktop.kiro.dev")) {
+      return new Response(
+        JSON.stringify({ accessToken: "access-social", refreshToken: "social-rt", expiresIn: 3600 }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    }
+    // registerClient() for the isolated OIDC client (may fail gracefully).
+    if (u.includes("oidc.") && u.endsWith("/client/register")) {
+      return new Response(JSON.stringify({ clientId: "reg-cid", clientSecret: "reg-secret" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    throw new Error(`unexpected fetch to ${u}`);
+  }) as typeof fetch;
+
+  const svc = new KiroService();
+  const result = await svc.validateImportToken("aorAAAAAGtoken-social");
+
+  assert.equal(result.authMethod, "imported");
+  assert.equal(result.accessToken, "access-social");
+});
+
+test("validateImportToken rejects malformed refresh tokens before touching the cache", async () => {
+  let fetched = false;
+  globalThis.fetch = (async () => {
+    fetched = true;
+    return new Response("{}", { status: 200 });
+  }) as typeof fetch;
+
+  const svc = new KiroService();
+  await assert.rejects(() => svc.validateImportToken("not-a-valid-token"), /Invalid token format/);
+  assert.equal(fetched, false, "must not attempt any network call for a malformed token");
+});


### PR DESCRIPTION
## Problem

When importing a Kiro Builder ID refresh token via the dashboard (Providers > Kiro > Import Token), the import fails with:

```
Token validation failed: Token refresh failed: {"message":"Bad credentials"}
```

Builder ID refresh tokens (which contain a colon `:` as part of the token value) require `clientId` + `clientSecret` to refresh via the AWS SSO OIDC endpoint. However, `validateImportToken()` always tries the social auth endpoint first (`prod.us-east-1.auth.desktop.kiro.dev/refreshToken`), which rejects Builder ID tokens.

Additionally, even when `clientId`/`clientSecret` are obtained via `registerClient()`, the stored `authMethod: "imported"` in `providerSpecificData` causes `refreshToken()` to skip the OIDC path (due to the `authMethod !== "imported"` guard), forcing all subsequent refreshes through the social auth endpoint as well.

## Fix

1. **`src/lib/oauth/services/kiro.ts`** - `validateImportToken` now:
   - Reads cached `clientId`/`clientSecret` from `~/.aws/sso/cache/`
   - Tries AWS SSO OIDC refresh first with `authMethod: "builder-id"`
   - Falls back to social auth + `registerClient()` only if cached credentials are unavailable
   - Added `readCachedClientCredentials()` private method

2. **`src/app/api/oauth/kiro/import/route.ts`** - Stores `tokenData.authMethod` instead of hardcoding `"imported"`, so Builder ID connections use the OIDC refresh path for subsequent health checks.

## Testing

Tested with a real Builder ID token containing a colon delimiter. Token imports successfully and background health checks refresh correctly via OIDC.
