### PR TITLE
fix(startup): correct autoRefreshDaemon import alias (#3292)

### DIFF
--- a/src/instrumentation-node.ts
+++ b/src/instrumentation-node.ts
@@ -239,7 +239,9 @@ export async function registerNodejs(): Promise<void> {
     }
 
     try {
-      const { autoRefreshDaemon } = await import("@/open-sse/services/autoRefreshDaemon");
+      const { autoRefreshDaemon } = await import(
+        "@omniroute/open-sse/services/autoRefreshDaemon"
+      );
       autoRefreshDaemon.start();
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);

--- a/tests/unit/no-src-open-sse-alias.test.ts
+++ b/tests/unit/no-src-open-sse-alias.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Regression guard (#3292 / v3.8.13 Electron release fragment).
+ *
+ * `@/*` maps to `src/*`, but the streaming engine lives in the `open-sse/`
+ * workspace (alias `@omniroute/open-sse/*`). So an import of `@/open-sse/...`
+ * resolves to the non-existent `src/open-sse/...` and throws
+ * "Cannot find module '@/open-sse/...'" at runtime in the built standalone.
+ *
+ * This bit the #3292 auto-refresh daemon: `instrumentation-node.ts` did
+ * `await import("@/open-sse/services/autoRefreshDaemon")`. It was caught by a
+ * try/catch (non-fatal), so typecheck and the dev server stayed green, but the
+ * packaged Electron app's strict startup-log smoke test failed on the
+ * "Cannot find module" line. This test fails fast on any such alias.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const srcRoot = join(import.meta.dirname, "../../src");
+
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out.push(...walk(full));
+    } else if (/\.(ts|tsx|js|mjs)$/.test(entry)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+test("src/ never imports the open-sse workspace via the @/ alias (use @omniroute/open-sse)", () => {
+  const offenders: string[] = [];
+  for (const file of walk(srcRoot)) {
+    const src = readFileSync(file, "utf8");
+    // matches  from "@/open-sse/...   and   import("@/open-sse/...
+    if (/["'`]@\/open-sse\//.test(src)) {
+      const line = src.split("\n").findIndex((l) => /["'`]@\/open-sse\//.test(l)) + 1;
+      offenders.push(`${file.replace(srcRoot, "src")}:${line}`);
+    }
+  }
+  assert.deepEqual(
+    offenders,
+    [],
+    `@/open-sse/* resolves to the non-existent src/open-sse/* and throws "Cannot find module" at runtime. Use @omniroute/open-sse/* instead. Offenders:\n${offenders.join("\n")}`
+  );
+});


### PR DESCRIPTION
2nd #3292 packaging bug found via the v3.8.13 Electron smoke test. `instrumentation-node.ts` imported the cookie auto-refresh daemon via `@/open-sse/services/autoRefreshDaemon`; `@/` maps to `src/` but the daemon lives in the `open-sse/` workspace, so it resolved to non-existent `src/open-sse/...` and threw `Cannot find module` at runtime (non-fatal — try/catch — so the daemon silently never ran in npm/Docker/VPS too). The packaged Electron app's strict startup-log smoke test failed on it.

- Fix: use `@omniroute/open-sse/services/autoRefreshDaemon`.
- Regression test bans `@/open-sse/*` imports across `src/` (TDD: red without fix, green with).

After merge: v3.8.13 tag re-moved → Electron + Docker rebuild clean. (npm 3.8.13 is immutable; its non-fatal daemon gap is accepted per release decision.)