### PR TITLE
Add documentation comment to exported GET function in context analytics route

### DIFF
--- a/src/app/api/context/analytics/route.ts
+++ b/src/app/api/context/analytics/route.ts
@@ -1,1 +1,5 @@
+/**
+ * Re-exports the GET function from the analytics/compression route for the context analytics endpoint.
+ * This is used to provide compression analytics data for the context analysis.
+ */
 export { GET } from "@/app/api/analytics/compression/route";


### PR DESCRIPTION
## 问题背景
导出的 GET 函数在 context analytics 路由中缺少文档注释，这可能降低代码的可读性和维护性，使其他开发者难以理解其用途和来源。

## 修改内容
在 `src/app/api/context/analytics/route.ts` 文件中添加了一个 JSDoc 注释，解释该函数是从 analytics/compression 路由重新导出的，并用于提供压缩分析数据。具体注释为：'Re-exports the GET function from the analytics/compression route for the context analytics endpoint. This is used to provide compression analytics data for the context analysis.'

## 验证方式
可以通过代码审查验证注释是否准确、清晰，并确保与仓库现有文档风格一致。建议检查注释是否符合代码规范，并在合并前进行测试以确保功能未受影响。