### PR TITLE
fix(electron): swallow auto-updater check rejection (v3.8.13 macOS-intel smoke)

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -266,7 +266,18 @@ async function checkForUpdates(silent = false) {
     }
     return;
   }
-  await autoUpdater.checkForUpdates();
+  // Update-check failures (404 when the release manifest isn't published yet,
+  // offline, rate-limited) are surfaced to the user via the autoUpdater "error"
+  // event handler. The promise returned by checkForUpdates() ALSO rejects on
+  // those, so it must be caught here — the startup check (line ~928) fires it
+  // unawaited inside a setTimeout, and an uncaught rejection there becomes an
+  // "Unhandled Rejection" that the packaged-app smoke test treats as fatal.
+  try {
+    await autoUpdater.checkForUpdates();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn("[Electron] Update check failed (non-fatal):", msg);
+  }
 }
 
 async function downloadUpdate() {

--- a/tests/unit/electron-main.test.ts
+++ b/tests/unit/electron-main.test.ts
@@ -76,6 +76,36 @@ describe("Electron packaging manifest completeness (#3292)", () => {
   }
 });
 
+// ─── Auto-updater unhandled-rejection guard (v3.8.13) ────────
+//
+// checkForUpdates() is fired unawaited from a setTimeout at startup. The
+// underlying autoUpdater.checkForUpdates() rejects on a 404 (no published
+// update manifest yet), offline, or rate-limit — and an uncaught rejection
+// there surfaces as an "Unhandled Rejection" that the packaged-app smoke test
+// treats as fatal (it failed the macOS-intel build for v3.8.13). The call must
+// be wrapped so the rejection never escapes.
+
+describe("Electron auto-updater rejection handling (v3.8.13)", () => {
+  const mainSrc = readFileSync(join(import.meta.dirname, "../../electron/main.js"), "utf8");
+
+  it("wraps autoUpdater.checkForUpdates() so a 404/offline check can't become an unhandled rejection", () => {
+    const fn = mainSrc.match(/async function checkForUpdates\([\s\S]*?\n}/);
+    assert.ok(fn, "checkForUpdates function should exist in electron/main.js");
+    const body = fn![0];
+    assert.match(body, /try\s*\{/, "checkForUpdates must wrap the update check in try/catch");
+    assert.match(
+      body,
+      /catch\s*\([\s\S]*?\)\s*\{/,
+      "checkForUpdates must catch the rejecting autoUpdater.checkForUpdates() call"
+    );
+    assert.match(
+      body,
+      /try[\s\S]*await autoUpdater\.checkForUpdates\(\)[\s\S]*catch/,
+      "autoUpdater.checkForUpdates() must sit inside the try block"
+    );
+  });
+});
+
 // ─── URL Validation Tests ────────────────────────────────────
 
 describe("Electron URL Validation", () => {


### PR DESCRIPTION
The v3.8.13 Electron build's macOS-intel smoke test failed: the app started and served `/login` (HTTP 200 — the 3 packaging fixes worked), but `autoUpdater.checkForUpdates()` rejected on the expected `latest-mac.yml` 404 (release assets not published during the build), and the unawaited startup call (`setTimeout(() => checkForUpdates(true), 3000)`) let it become an **Unhandled Rejection** — which the smoke test treats as fatal. arm64/win/linux passed only by timing race.

- Fix: wrap `autoUpdater.checkForUpdates()` in try/catch inside `checkForUpdates()` (the `error` event still notifies the user; the promise rejection no longer escapes).
- Regression test asserts the wrap.
- Electron-only — npm/Docker unaffected.