### PR TITLE
fix(sse): treat MiniMax M3 as multimodal so vision isn't stripped (#3328)

### DIFF
--- a/open-sse/config/providerRegistry.ts
+++ b/open-sse/config/providerRegistry.ts
@@ -1412,7 +1412,14 @@ const _REGISTRY_EAGER: Record<string, RegistryEntry> = {
       },
       { id: "deepseek-v4-flash-free", name: "DeepSeek V4 Flash Free", supportsReasoning: true },
       // #3110: MiniMax M3 free tier via OpenCode
-      { id: "minimax-m3-free", name: "MiniMax M3 Free", contextLength: 1048576 },
+      // #3328: MiniMax M3 is multimodal (verified: describes base64 images via the
+      // opencode upstream) — flag it so vision requests aren't gated/stripped.
+      {
+        id: "minimax-m3-free",
+        name: "MiniMax M3 Free",
+        contextLength: 1048576,
+        supportsVision: true,
+      },
       { id: "minimax-m2.5-free", name: "MiniMax M2.5 Free", contextLength: 204800 },
       { id: "ling-2.6-1t-free", name: "Ling 2.6 Free", contextLength: 262000 },
       {

--- a/open-sse/services/compression/lite.ts
+++ b/open-sse/services/compression/lite.ts
@@ -59,7 +59,10 @@ function modelSupportsVision(model: string): boolean {
     normalized.includes("gpt-4") ||
     normalized.includes("4o") ||
     normalized.includes("claude-3") ||
-    normalized.includes("gemini")
+    normalized.includes("gemini") ||
+    // #3328: MiniMax M3 is multimodal — verified it describes images via the opencode
+    // upstream. Without this, compression strips the image and the model goes "blind".
+    normalized.includes("minimax-m3")
   );
 }
 

--- a/tests/unit/compression/lite.test.ts
+++ b/tests/unit/compression/lite.test.ts
@@ -167,6 +167,24 @@ describe("replaceImageUrls", () => {
     assert.equal(result.applied, false);
   });
 
+  // #3328: MiniMax M3 is multimodal (verified: it describes a base64 image via the
+  // opencode upstream). It must not be treated as a non-vision model, or compression
+  // strips the image and the model goes "blind".
+  it("keeps images for MiniMax M3 (incl. provider-prefixed / free ids)", () => {
+    const mkBody = () => ({
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "image_url", image_url: { url: "data:image/png;base64,iVBOR" } }],
+        },
+      ],
+    });
+    for (const id of ["minimax-m3", "minimax-m3-free", "oc/minimax-m3-free"]) {
+      const result = replaceImageUrls(mkBody(), id);
+      assert.equal(result.applied, false, `expected images kept for ${id}`);
+    }
+  });
+
   it("skips non-image content", () => {
     const body = {
       messages: [{ role: "user", content: "just text" }],

--- a/tests/unit/provider-registry-qwen-vision.test.ts
+++ b/tests/unit/provider-registry-qwen-vision.test.ts
@@ -63,6 +63,19 @@ test("#2822 opencode-go/qwen3.6-plus deve ter supportsVision !== true", () => {
   );
 });
 
+// #3328 — o oposto do #2822: MiniMax M3 (opencode) É multimodal (verificado
+// empiricamente: descreve imagens base64 via o upstream opencode). Deve ter
+// supportsVision: true para não ser barrado/strippado em requests com imagem.
+test("#3328 opencode/minimax-m3-free deve ter supportsVision: true", () => {
+  const model = getModel("opencode", "minimax-m3-free");
+  assert.ok(model, "minimax-m3-free deve estar registrado em opencode");
+  assert.strictEqual(
+    model.supportsVision,
+    true,
+    "opencode/minimax-m3-free é multimodal — supportsVision deve ser true"
+  );
+});
+
 test("#2822 opencode-go/qwen3.5-plus deve ter supportsVision !== true", () => {
   const model = getModel("opencode-go", "qwen3.5-plus");
   assert.ok(model, "qwen3.5-plus deve estar registrado em opencode-go");


### PR DESCRIPTION
## What

Makes MiniMax M3 (opencode provider) treated as the multimodal model it is, so image inputs aren't stripped before dispatch.

## Why

Discussion #3328 (@mikmaneggahommie): `oc/minimax-m3-free` is "blind" -- image inputs don't reach it, while the same model in the official Cline extension can see them.

**Verified empirically (2026-06-06):** registered against the keyless opencode zen upstream and sent a base64 image to `minimax-m3-free` -- it correctly described the image's color. (Remote image *URLs* return a MiniMax 403; it only accepts base64 data URIs.) So MiniMax M3 is multimodal; it was OmniRoute treating it as non-vision.

## Root cause

Two places marked MiniMax M3 as non-vision, so when compression was active the image got replaced with a `[image: ...]` placeholder before dispatch:

1. `open-sse/services/compression/lite.ts` -- `modelSupportsVision()` is a string heuristic matching only `gpt-4` / `4o` / `claude-3` / `gemini` / `vision`. `minimax` wasn't there, so `replaceImageUrls()` stripped the image.
2. `open-sse/config/providerRegistry.ts` -- the opencode `minimax-m3-free` entry had no `supportsVision`, so the combo vision-capability gate (`combo.ts:1240`) could also exclude/mishandle it.

## Changes

- Add `minimax-m3` to the `modelSupportsVision()` heuristic.
- Add `supportsVision: true` to the opencode `minimax-m3-free` catalog entry.

## Test (TDD)

- `tests/unit/compression/lite.test.ts` -- new case asserts `replaceImageUrls()` keeps images for `minimax-m3` / `minimax-m3-free` / `oc/minimax-m3-free` (failing before the heuristic change, passing after).
- `tests/unit/provider-registry-qwen-vision.test.ts` -- new assertion that `opencode/minimax-m3-free` has `supportsVision: true` (the inverse of the #2822 qwen cases).

```
node --import tsx/esm --test tests/unit/compression/lite.test.ts tests/unit/provider-registry-qwen-vision.test.ts   # all pass
npm run typecheck:core   # clean
```

Fixes #3328.

Reported-by: @mikmaneggahommie
