### PR TITLE
fix(providers): reduce proxy label noise

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/[id]/page.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.tsx
@@ -186,6 +186,16 @@ function providerText(
   return fallback;
 }
 
+function providerCountText(
+  t: ProviderMessageTranslator,
+  key: string,
+  count: number,
+  singularFallback: string,
+  pluralFallback: string
+): string {
+  return providerText(t, key, count === 1 ? singularFallback : pluralFallback, { count });
+}
+
 function getWebSessionCredentialLabel(
   t: ProviderMessageTranslator,
   requirement: WebSessionCredentialRequirement,
@@ -4768,8 +4778,20 @@ export default function ProviderDetailPage() {
                         />
                         <span className="text-sm font-medium text-text-muted">
                           {selectedIds.size > 0
-                            ? t("selectedCount", { count: selectedIds.size })
-                            : t("accountsCount", { count: connections.length })}
+                            ? providerCountText(
+                                t,
+                                "selectedCount",
+                                selectedIds.size,
+                                "{count} selected",
+                                "{count} selected"
+                              )
+                            : providerCountText(
+                                t,
+                                "accountsCount",
+                                connections.length,
+                                "{count} account",
+                                "{count} accounts"
+                              )}
                         </span>
                       </label>
 
@@ -4917,8 +4939,20 @@ export default function ProviderDetailPage() {
                         />
                         <span className="text-sm font-medium text-text-muted">
                           {selectedIds.size > 0
-                            ? t("selectedCount", { count: selectedIds.size })
-                            : t("accountsCount", { count: connections.length })}
+                            ? providerCountText(
+                                t,
+                                "selectedCount",
+                                selectedIds.size,
+                                "{count} selected",
+                                "{count} selected"
+                              )
+                            : providerCountText(
+                                t,
+                                "accountsCount",
+                                connections.length,
+                                "{count} account",
+                                "{count} accounts"
+                              )}
                         </span>
                       </label>
 
@@ -7919,6 +7953,7 @@ function ConnectionRow({
                 <span className="text-text-muted/30 select-none">|</span>
                 <button
                   onClick={() => onToggleProxyEnabled(!proxyEnabled)}
+                  aria-label={proxyEnabled ? t("proxyEnabledTitle") : t("proxyDisabledTitle")}
                   className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-xs font-medium transition-all cursor-pointer ${
                     proxyEnabled
                       ? "bg-emerald-500/15 text-emerald-500 hover:bg-emerald-500/25"
@@ -7927,7 +7962,7 @@ function ConnectionRow({
                   title={proxyEnabled ? t("proxyEnabledTitle") : t("proxyDisabledTitle")}
                 >
                   <span className="material-symbols-outlined text-[13px]">vpn_lock</span>
-                  {proxyEnabled ? t("proxyOn") : t("proxyOff")}
+                  {proxyEnabled ? <span className="sr-only">{t("proxyOn")}</span> : t("proxyOff")}
                 </button>
               </>
             )}
@@ -7936,6 +7971,7 @@ function ConnectionRow({
                 <span className="text-text-muted/30 select-none">|</span>
                 <button
                   onClick={() => onTogglePerKeyProxyEnabled(!perKeyProxyEnabled)}
+                  aria-label={perKeyProxyEnabled ? t("perKeyProxyEnabledTitle") : t("perKeyProxyDisabledTitle")}
                   className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-xs font-medium transition-all cursor-pointer ${
                     perKeyProxyEnabled
                       ? "bg-violet-500/15 text-violet-500 hover:bg-violet-500/25"
@@ -7944,7 +7980,11 @@ function ConnectionRow({
                   title={perKeyProxyEnabled ? t("perKeyProxyEnabledTitle") : t("perKeyProxyDisabledTitle")}
                 >
                   <span className="material-symbols-outlined text-[13px]">key</span>
-                  {perKeyProxyEnabled ? t("perKeyProxyOn") : t("perKeyProxyOff")}
+                  {perKeyProxyEnabled ? (
+                    t("perKeyProxyOn")
+                  ) : (
+                    <span className="sr-only">{t("perKeyProxyOff")}</span>
+                  )}
                 </button>
               </>
             )}

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -3870,6 +3870,8 @@
     "testAll": "Test All",
     "distributeProxies": "Distribute Proxies",
     "distributing": "Distributing...",
+    "selectedCount": "{count, plural, one {# selected} other {# selected}}",
+    "accountsCount": "{count, plural, one {# account} other {# accounts}}",
     "testAllOAuth": "Test all OAuth connections",
     "testAllFree": "Test all Free connections",
     "testAllApiKey": "Test all API Key connections",

--- a/tests/unit/provider-connections-ui-regression.test.ts
+++ b/tests/unit/provider-connections-ui-regression.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, it } from "node:test";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PROVIDER_PAGE = path.resolve(
+  __dirname,
+  "../../src/app/(dashboard)/dashboard/providers/[id]/page.tsx",
+);
+const EN_MESSAGES = path.resolve(__dirname, "../../src/i18n/messages/en.json");
+
+const providerPageSrc = readFileSync(PROVIDER_PAGE, "utf-8");
+const enMessages = JSON.parse(readFileSync(EN_MESSAGES, "utf-8"));
+
+describe("provider connections UI regression", () => {
+  it("keeps English provider count messages available for the provider detail header", () => {
+    assert.equal(
+      enMessages.providers?.selectedCount,
+      "{count, plural, one {# selected} other {# selected}}",
+    );
+    assert.equal(
+      enMessages.providers?.accountsCount,
+      "{count, plural, one {# account} other {# accounts}}",
+    );
+  });
+
+  it("uses defensive provider count labels instead of leaking raw i18n keys", () => {
+    assert.match(providerPageSrc, /function\s+providerCountText\s*\(/);
+    assert.match(providerPageSrc, /providerCountText\([\s\S]*"selectedCount"[\s\S]*"\{count\} selected"/);
+    assert.match(providerPageSrc, /providerCountText\([\s\S]*"accountsCount"[\s\S]*"\{count\} account"[\s\S]*"\{count\} accounts"/);
+    assert.doesNotMatch(
+      providerPageSrc,
+      /\?\s*t\("selectedCount",\s*\{\s*count:\s*selectedIds\.size\s*\}\)\s*:\s*t\("accountsCount",\s*\{\s*count:\s*connections\.length\s*\}\)/,
+    );
+  });
+
+  it("keeps proxy toggle text accessible without repeating active/default labels visually", () => {
+    assert.ok(
+      providerPageSrc.includes(
+      'aria-label={proxyEnabled ? t("proxyEnabledTitle") : t("proxyDisabledTitle")}',
+      ),
+    );
+    assert.ok(
+      providerPageSrc.includes(
+      'aria-label={perKeyProxyEnabled ? t("perKeyProxyEnabledTitle") : t("perKeyProxyDisabledTitle")}',
+      ),
+    );
+    assert.ok(
+      providerPageSrc.includes(
+      '<span className="sr-only">{t("proxyOn")}</span>',
+      ),
+    );
+    assert.ok(
+      providerPageSrc.includes(
+      '<span className="sr-only">{t("perKeyProxyOff")}</span>',
+      ),
+    );
+    assert.doesNotMatch(providerPageSrc, /\{proxyEnabled \? t\("proxyOn"\) : t\("proxyOff"\)\}/);
+    assert.doesNotMatch(
+      providerPageSrc,
+      /\{perKeyProxyEnabled \? t\("perKeyProxyOn"\) : t\("perKeyProxyOff"\)\}/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add missing English provider connection count messages used by the provider detail header
- prevent raw `providers.accountsCount`/`providers.selectedCount` keys from leaking if a locale is missing those messages
- hide redundant active proxy/default connection labels in connection rows while preserving accessible labels and tooltips
- keep the configured proxy badge/host visible so rows stay informative without repeated “Proxy On” text

## Testing
- `npx eslint 'src/app/(dashboard)/dashboard/providers/[id]/page.tsx'` (passes with pre-existing React hook warnings only)
- `npm run typecheck:core`
