### PR TITLE
fix(dashboard): surface real analytics error instead of generic placeholder (#3356)

### DIFF
--- a/src/app/api/usage/analytics/route.ts
+++ b/src/app/api/usage/analytics/route.ts
@@ -1321,6 +1321,12 @@ export async function GET(request: Request) {
     return NextResponse.json(analytics);
   } catch (error) {
     console.error("Error computing analytics:", error);
-    return NextResponse.json({ error: "Failed to compute analytics" }, { status: 500 });
+    // Surface the real (sanitized) reason so the dashboard can show it instead of a
+    // generic placeholder (#3356). buildErrorBody strips stacks/absolute paths.
+    const { buildErrorBody } = await import("@omniroute/open-sse/utils/error");
+    const message = error instanceof Error ? error.message : String(error);
+    return NextResponse.json(buildErrorBody(500, message || "Failed to compute analytics"), {
+      status: 500,
+    });
   }
 }

--- a/src/shared/components/UsageAnalytics.tsx
+++ b/src/shared/components/UsageAnalytics.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from "next-intl";
 import Card from "./Card";
 import { CardSkeleton } from "./Loading";
 import { fmtCompact as fmt, fmtFull, fmtCost } from "@/shared/utils/formatting";
+import { readFetchErrorMessage } from "@/shared/utils/fetchError";
 import {
   StatCard,
   CompactStatGrid,
@@ -59,7 +60,7 @@ export default function UsageAnalytics() {
         params.set("apiKeyIds", selectedApiKeys.join(","));
       }
       const res = await fetch(`/api/usage/analytics?${params.toString()}`);
-      if (!res.ok) throw new Error(tCommon("error"));
+      if (!res.ok) throw new Error(await readFetchErrorMessage(res, tCommon("error")));
       const data = await res.json();
       setAnalytics(data);
       setError(null);

--- a/src/shared/utils/fetchError.ts
+++ b/src/shared/utils/fetchError.ts
@@ -1,0 +1,26 @@
+/**
+ * Extract a human-readable message from a failed `fetch` Response body.
+ *
+ * Handles both response shapes OmniRoute routes emit:
+ * - OpenAI-style `{ error: { message, type, code } }` (from `buildErrorBody`)
+ * - legacy `{ error: "..." }` string bodies
+ *
+ * The server already sanitizes these messages (stack traces / absolute paths
+ * stripped via `sanitizeErrorMessage`), so surfacing them in the UI is safe.
+ * Falls back to `fallback` when the body is absent, unparseable, or carries no
+ * usable message. Never throws -- safe to call directly inside a fetch guard.
+ */
+export async function readFetchErrorMessage(res: Response, fallback: string): Promise<string> {
+  try {
+    const body = (await res.json()) as unknown;
+    const err = (body as { error?: unknown } | null)?.error;
+    if (typeof err === "string" && err.trim()) return err.trim();
+    if (err && typeof err === "object") {
+      const message = (err as { message?: unknown }).message;
+      if (typeof message === "string" && message.trim()) return message.trim();
+    }
+  } catch {
+    // Non-JSON body (e.g. an HTML 500 page) or a read failure -> use the fallback.
+  }
+  return fallback;
+}

--- a/tests/unit/fetch-error-message.test.ts
+++ b/tests/unit/fetch-error-message.test.ts
@@ -1,0 +1,47 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { readFetchErrorMessage } from "../../src/shared/utils/fetchError.ts";
+
+const FALLBACK = "An error occurred";
+
+function jsonResponse(body: unknown, status = 500) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+// #3356: the Analytics page rendered a generic "An error occurred" because it
+// discarded the server's error body. The page must surface the real (already
+// sanitized server-side) message instead.
+
+test("reads the OpenAI-style { error: { message } } shape from buildErrorBody", async () => {
+  const res = jsonResponse({ error: { message: "Failed to compute analytics", type: "api_error" } });
+  assert.equal(await readFetchErrorMessage(res, FALLBACK), "Failed to compute analytics");
+});
+
+test("reads the legacy { error: '...' } string shape", async () => {
+  const res = jsonResponse({ error: "no such column: combo_name" });
+  assert.equal(await readFetchErrorMessage(res, FALLBACK), "no such column: combo_name");
+});
+
+test("trims surrounding whitespace from the extracted message", async () => {
+  const res = jsonResponse({ error: { message: "  boom  " } });
+  assert.equal(await readFetchErrorMessage(res, FALLBACK), "boom");
+});
+
+test("falls back when the error message is blank", async () => {
+  const res = jsonResponse({ error: { message: "   " } });
+  assert.equal(await readFetchErrorMessage(res, FALLBACK), FALLBACK);
+});
+
+test("falls back when there is no error field", async () => {
+  const res = jsonResponse({ data: 1 });
+  assert.equal(await readFetchErrorMessage(res, FALLBACK), FALLBACK);
+});
+
+test("falls back on a non-JSON body without throwing", async () => {
+  const res = new Response("<html>500 Internal Server Error</html>", { status: 500 });
+  assert.equal(await readFetchErrorMessage(res, FALLBACK), FALLBACK);
+});


### PR DESCRIPTION
## Problem

Discussion #3356 (@superti4r): after upgrading to v3.8.13 the dashboard **Analytics** page shows a red box reading **"Error Short: An error occurred"** with no detail. The rest of the page (Provider Diversity widget) loads fine -- only the analytics query fails.

Root cause of the *opaque message* (two layers, both ours):

1. **UI** (`src/shared/components/UsageAnalytics.tsx:62`): `if (!res.ok) throw new Error(tCommon("error"))` discarded the server's error body and rendered the generic i18n `common.error` string.
2. **Route** (`src/app/api/usage/analytics/route.ts:1324`): the catch returned a hardcoded `{ error: "Failed to compute analytics" }` and only logged the real error server-side (`console.error("Error computing analytics:", error)`).

So neither the user nor a maintainer could see *why* the endpoint 500'd -- making this class of report impossible to triage from the screenshot alone.

> Note: this PR fixes the **error visibility**, not the underlying 500 for this specific user (that needs their server log line, requested in the discussion -- likely a stale/partial DB after upgrade). The point is the next report will carry the actual reason.

## Fix

- **Route**: return the real reason via `buildErrorBody(500, message)` (sanitized -- stacks/absolute paths stripped, Hard Rule #12). No raw `err.message` reaches the body.
- **UI**: new pure helper `src/shared/utils/fetchError.ts::readFetchErrorMessage(res, fallback)` reads the response body and extracts the message from both the OpenAI-style `{ error: { message } }` shape and the legacy `{ error: "..." }` string shape; falls back to the generic string when the body is absent/unparseable. Never throws.
- The Analytics page now surfaces that message instead of the placeholder.

No other consumer of `/api/usage/analytics` reads the error body (BudgetTab early-returns, CostOverviewTab/ApiManager throw/null on `!res.ok`), so the error-body shape change is safe.

## Tests (TDD, Hard Rule #18)

New `tests/unit/fetch-error-message.test.ts` -- written failing first (helper did not exist), then passing:
- OpenAI-style `{ error: { message } }` -> message
- legacy `{ error: "..." }` -> string
- whitespace trimmed; blank message -> fallback; no error field -> fallback; non-JSON body -> fallback (no throw)

Validation:
- `node --test fetch-error-message.test.ts` -> 6/6 pass
- existing `usage-analytics-route.test.ts` + `usage-analytics.test.ts` -> 38/38 pass (no error-shape assertions there; happy path unchanged)
- `eslint` clean on all 4 files
- `npm run typecheck:core` clean

Closes the visibility half of #3356.
