### PR TITLE
fix(ci): drop explicit any pushing chatCore over the t11 any-budget

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -3985,7 +3985,7 @@ export async function handleChatCore({
                 stage: "sending_to_provider",
               });
               const execCreds = getExecutionCredentials();
-              const rawExecutorResult = await executeWithUpstreamStartTimeout<any>({
+              const rawExecutorResult = await executeWithUpstreamStartTimeout({
                 executor,
                 provider,
                 model: modelToCall,


### PR DESCRIPTION
The v3.8.14 release merge brought `executeWithUpstreamStartTimeout<any>(...)` into `open-sse/handlers/chatCore.ts`, exceeding its t11 any-budget (explicit any: 1, budget: 0) — a **blocking** CI lint-job gate (`check:any-budget:t11`). The generic `T` is inferable from the `execute` callback, so the explicit `<any>` is dropped. typecheck:core clean, behavior unchanged. (noimplicit:core's pre-existing sqljsAdapter note is informational/continue-on-error.)