### PR TITLE
fix(combo): add 429 to PROVIDER_FAILURE_ERROR_CODES to prevent infinite retry loop

### DIFF
--- a/open-sse/services/accountFallback.ts
+++ b/open-sse/services/accountFallback.ts
@@ -81,9 +81,11 @@ function toJsonRecord(value: unknown): JsonRecord {
 // Error codes that count toward provider-level failure threshold
 // 429 (rate limit) is intentionally excluded: rate limits are connection-scoped
 // and handled via Connection Cooldown, not provider-wide circuit breaker.
-// Counting 429 toward provider failure causes cascading provider trips at scale
-// when many connections hit rate limits simultaneously (Issue #1846).
-const PROVIDER_FAILURE_ERROR_CODES = new Set([408, 500, 502, 503, 504]);
+// 429 included so the circuit breaker opens on repeated rate limits,
+// preventing infinite combo retries. Per-error-type cooldowns
+// (rate_limit: 60s, quota_exhausted: 1h) prevent cascading provider
+// trips at scale (Issue #1846).
+const PROVIDER_FAILURE_ERROR_CODES = new Set([408, 429, 500, 502, 503, 504]);
 
 // Per-connection failure deduplication: prevents rapid-fire failures from the
 // same connection from counting multiple times toward the provider breaker.

--- a/open-sse/services/accountFallback.ts
+++ b/open-sse/services/accountFallback.ts
@@ -78,13 +78,11 @@ function toJsonRecord(value: unknown): JsonRecord {
 }
 
 // Provider-level failure tracking for circuit breaker behavior
-// Error codes that count toward provider-level failure threshold
-// 429 (rate limit) is intentionally excluded: rate limits are connection-scoped
-// and handled via Connection Cooldown, not provider-wide circuit breaker.
-// 429 included so the circuit breaker opens on repeated rate limits,
-// preventing infinite combo retries. Per-error-type cooldowns
-// (rate_limit: 60s, quota_exhausted: 1h) prevent cascading provider
-// trips at scale (Issue #1846).
+// Error codes that count toward provider-level failure threshold.
+// 429 is included: per-error-type cooldowns (rate_limit: 60s, quota_exhausted: 1h)
+// prevent cascading provider trips at scale (Issue #1846 concern addressed),
+// while still allowing the circuit breaker to open on sustained 429s and
+// prevent infinite combo retries (Issue #3200).
 const PROVIDER_FAILURE_ERROR_CODES = new Set([408, 429, 500, 502, 503, 504]);
 
 // Per-connection failure deduplication: prevents rapid-fire failures from the

--- a/src/sse/handlers/chat.ts
+++ b/src/sse/handlers/chat.ts
@@ -173,7 +173,7 @@ function intersectAllowedConnectionIds(primary: unknown, secondary: unknown): st
   return first || second || null;
 }
 
-const PROVIDER_BREAKER_FAILURE_STATUSES = new Set([408, 500, 502, 503, 504]);
+const PROVIDER_BREAKER_FAILURE_STATUSES = new Set([408, 429, 500, 502, 503, 504]);
 
 /**
  * Handle chat completion request

--- a/tests/unit/account-fallback-service.test.ts
+++ b/tests/unit/account-fallback-service.test.ts
@@ -536,7 +536,7 @@ test("recordModelLockoutFailure uses provider profile cooldowns, backoff, and re
 
 // Provider-level failure circuit breaker tests
 test("isProviderFailureCode correctly identifies provider-wide transient error codes", () => {
-  assert.equal(isProviderFailureCode(429), false);
+  assert.equal(isProviderFailureCode(429), true);
   assert.equal(isProviderFailureCode(408), true);
   assert.equal(isProviderFailureCode(500), true);
   assert.equal(isProviderFailureCode(502), true);


### PR DESCRIPTION
## Description

`isProviderFailureCode(429)` returns `false` because 429 was excluded from `PROVIDER_FAILURE_ERROR_CODES`, so `recordProviderFailure()` is never called on rate-limited responses. Without `recordProviderFailure`, the circuit breaker never opens and the combo keeps retrying all targets from the same failing provider infinitely.

## Root Cause

`PROVIDER_FAILURE_ERROR_CODES` = `{408, 500, 502, 503, 504}` — 429 was intentionally removed (Issue #1846) to prevent cascading provider trips at scale when many connections hit rate limits simultaneously.

However, the current architecture has per-error-type cooldowns (`rate_limit`: 60s, `quota_exhausted`: 1h) via `useUpstream429BreakerHints` + `classifyError`, which prevent cascading failures while still allowing the circuit breaker to open on sustained 429s.

Additionally, the combo routing already distinguishes 429 types:
- `isTokenLimitBreach` catches token-limit 429s (terminal for the client, never retried)
- Non-token-limit 429s are treated as transient and retried up to `maxRetries`

## Changes

| File | Change |
|------|--------|
| `open-sse/services/accountFallback.ts` | Added 429 to `PROVIDER_FAILURE_ERROR_CODES` |
| `src/sse/handlers/chat.ts` | Added 429 to `PROVIDER_BREAKER_FAILURE_STATUSES` |
| `tests/unit/account-fallback-service.test.ts` | Updated assertion: `isProviderFailureCode(429)` is now `true` |

Fixes: #3200