### PR TITLE
test(translator): align gemini-2.5-flash maxOutputTokens cap to 65536 (#3358 drift)

### DIFF
--- a/tests/unit/translator-claude-to-gemini.test.ts
+++ b/tests/unit/translator-claude-to-gemini.test.ts
@@ -116,7 +116,9 @@ test("Claude -> Gemini clamps maxOutputTokens to the model cap", () => {
     false
   );
 
-  assert.equal(result.generationConfig.maxOutputTokens, 8192);
+  // #3358 added the gemini-2.5-flash model spec (real cap 65536, not the old
+  // 8192 default). An over-cap request clamps to the model's true max output.
+  assert.equal(result.generationConfig.maxOutputTokens, 65536);
 });
 
 test("Claude -> Gemini converts text and base64 images to Gemini parts", () => {


### PR DESCRIPTION
The only **real** failure behind the v3.8.14 CI red. #3358 added the `gemini-2.5-flash` model spec (real cap **65536**; the model previously had no spec → fell to an 8192 default), but did not update `translator-claude-to-gemini.test.ts`, which still asserted the clamp at 8192. That single deterministic failure tripped Unit Tests (3/8), Coverage Shard (3/8) and Node 24/26 Compatibility (1/2) (same shard partition), and fail-fast cancelled E2E (5/6). Align the expectation to 65536. Verified isolated 9/9.