### PR TITLE
fix(ci): stop E2E shard 5/6 being cancelled mid-run (timeout headroom)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -500,7 +500,11 @@ jobs:
   test-e2e:
     name: E2E Tests (${{ matrix.shard }}/6)
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # 20m was too tight for the heaviest shard: each shard re-runs `npm run build`
+    # (~5m) before Playwright, so a slow shard's tests + build overran 20m and the
+    # job was cancelled mid-run. 35m gives headroom; the per-test cap in
+    # playwright.config.ts bounds any genuine hang to a fast, visible failure.
+    timeout-minutes: 35
     needs: build
     strategy:
       fail-fast: false

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -25,7 +25,11 @@ export default defineConfig({
     "**/skills-marketplace.spec.ts",
   ],
   fullyParallel: false,
-  timeout: 600_000,
+  // Per-test cap. 600s was high enough that one hung test (× retries) could
+  // exhaust the e2e job's wall-clock budget, so the GitHub job hit its
+  // timeout-minutes and was CANCELLED mid-run instead of the test failing fast.
+  // 180s is generous for a UI flow yet bounds a hang to a clear per-test failure.
+  timeout: 180_000,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: 1,


### PR DESCRIPTION
**The deferred 'esteira' flake.** `E2E Tests (5/6)` repeatedly hit the job's 20-minute `timeout-minutes` and was **cancelled mid-run** ('Terminate orphan process' on Playwright/chrome/next-server) — not a test failure. Root cause: each e2e shard re-runs `npm run build` (~5m) before Playwright, then runs ~24 serial tests (the heaviest shard: 12 responsive-viewport + studio + smoke) with `retries:2` and a **600s per-test cap**, so the heaviest shard's cumulative time overran 20m.

- `test-e2e` `timeout-minutes` 20 → 35 (cumulative build+tests headroom; other shards finish well under 20m so they're unaffected).
- Playwright per-test `timeout` 600s → 180s so a genuine hang fails fast and **visibly** (clear per-test timeout) instead of silently consuming the job budget and cancelling the whole run.

Re-running e2e on this branch to confirm 5/6 goes green.