### PR TITLE
fix(ci): E2E shard headroom (50m) + live line reporter for diagnosis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -500,11 +500,12 @@ jobs:
   test-e2e:
     name: E2E Tests (${{ matrix.shard }}/6)
     runs-on: ubuntu-latest
-    # 20m was too tight for the heaviest shard: each shard re-runs `npm run build`
-    # (~5m) before Playwright, so a slow shard's tests + build overran 20m and the
-    # job was cancelled mid-run. 35m gives headroom; the per-test cap in
-    # playwright.config.ts bounds any genuine hang to a fast, visible failure.
-    timeout-minutes: 35
+    # The heaviest shard (responsive viewport matrix + studio/smoke) re-runs
+    # `npm run build` (~5m) then ~24 serial tests; at 35m it was still cancelled
+    # mid-run, so it genuinely needs more wall-clock. 50m gives ample headroom
+    # while the per-test cap (playwright.config.ts) bounds any real hang to a fast
+    # visible failure and the `line` reporter streams which test is slow.
+    timeout-minutes: 50
     needs: build
     strategy:
       fail-fast: false

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -33,7 +33,11 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: 1,
-  reporter: process.env.CI ? "github" : "html",
+  // `line` (not `github`) in CI so per-test progress + timing stream live to the
+  // job log. The `github` reporter buffers all output until the run ends, so when
+  // a slow shard was cancelled at its timeout the log showed only "Running N
+  // tests" then silence — impossible to tell which test was slow/hung.
+  reporter: process.env.CI ? "line" : "html",
   expect: {
     timeout: process.env.CI ? 30_000 : 10_000,
   },


### PR DESCRIPTION
Follow-up to #3387 — 35m still cancelled shard 5/6 mid-run. Bump e2e `timeout-minutes` 35→50 (the shard genuinely needs >35m; others finish ~7m) and switch the Playwright CI reporter `github`→`line` so per-test progress/timing streams live (the `github` reporter buffered everything, so the cancelled log showed only 'Running 24 tests' then silence — undiagnosable). Next run's 5/6 log will pinpoint the slow test for a targeted follow-up if needed.