### PR TITLE
fix(translator): implement thought_signature bypass and fix Gemini er…

### DIFF
--- a/open-sse/executors/antigravity.ts
+++ b/open-sse/executors/antigravity.ts
@@ -661,7 +661,9 @@ export class AntigravityExecutor extends BaseExecutor {
             if (typeof p.text === "string" && p.text === "") return false;
             if (p.functionCall && !p.functionCall.name) return false;
 
-            return !p.thought && (hasFunctionCall || !p.thoughtSignature);
+            // Only strip if it's NOT our bypass sentinel. 
+            // Antigravity models (like Gemini) need this sentinel to bypass 400 errors.
+            return !p.thought && (hasFunctionCall || !p.thoughtSignature || p.thoughtSignature === "skip_thought_signature_validator");
           }) || [];
         return { ...c, role, parts };
       }) || [];

--- a/open-sse/translator/request/claude-to-gemini.ts
+++ b/open-sse/translator/request/claude-to-gemini.ts
@@ -104,6 +104,7 @@ export function claudeToGeminiRequest(model, body, stream) {
 
             case "tool_use":
               parts.push({
+                thoughtSignature: "skip_thought_signature_validator",
                 functionCall: {
                   id: block.id,
                   name: sanitizeToolName(block.name),

--- a/open-sse/translator/request/claude-to-gemini.ts
+++ b/open-sse/translator/request/claude-to-gemini.ts
@@ -104,7 +104,6 @@ export function claudeToGeminiRequest(model, body, stream) {
 
             case "tool_use":
               parts.push({
-                thoughtSignature: "skip_thought_signature_validator",
                 functionCall: {
                   id: block.id,
                   name: sanitizeToolName(block.name),

--- a/open-sse/translator/request/openai-to-gemini.ts
+++ b/open-sse/translator/request/openai-to-gemini.ts
@@ -419,8 +419,9 @@ function openaiToGeminiBase(
             // Gemini expects the signature on the functionCall part itself.
             // If we are in a mode where missing signatures cause 400s (and we couldn't find one),
             // safely default to the bypass string to protect against 400s.
+            const finalSignature = embeddedThoughtSignature || (signaturelessToolCallMode !== "text" ? "skip_thought_signature_validator" : undefined);
             parts.push({
-              thoughtSignature: embeddedThoughtSignature || "skip_thought_signature_validator",
+              ...(finalSignature ? { thoughtSignature: finalSignature } : {}),
               functionCall: {
                 id: id,
                 name: sanitizeToolName(fn.name),

--- a/open-sse/translator/request/openai-to-gemini.ts
+++ b/open-sse/translator/request/openai-to-gemini.ts
@@ -406,16 +406,6 @@ function openaiToGeminiBase(
             if (!signatureForToolCall && contextualizeSignaturelessToolResponses) {
               if (!toolCallIds.includes(id)) toolCallIds.push(id);
             }
-            if (!signatureForToolCall && stringifySignaturelessToolCalls) {
-              const args = fn.arguments || "{}";
-              parts.push({
-                text: buildInertHistoricalToolCallText(fn.name, args),
-              });
-              continue;
-            }
-            if (!signatureForToolCall && signaturelessToolCallMode === "context") {
-              continue;
-            }
 
             const args = tryParseJSON(fn.arguments || "{}");
             const embeddedThoughtSignature = shouldUseEmbeddedSignature
@@ -427,18 +417,17 @@ function openaiToGeminiBase(
             }
 
             // Gemini expects the signature on the functionCall part itself.
+            // If we are in a mode where missing signatures cause 400s (and we couldn't find one),
+            // safely default to the bypass string to protect against 400s.
             parts.push({
-              ...(embeddedThoughtSignature ? { thoughtSignature: embeddedThoughtSignature } : {}),
+              thoughtSignature: embeddedThoughtSignature || "skip_thought_signature_validator",
               functionCall: {
                 id: id,
                 name: sanitizeToolName(fn.name),
                 args: args,
               },
             });
-
-            if (!contextualizeSignaturelessToolResponses || signatureForToolCall) {
-              toolCallIds.push(id);
-            }
+            toolCallIds.push(id);
           }
 
           if (parts.length > 0) {
@@ -459,7 +448,6 @@ function openaiToGeminiBase(
             const toolParts: GeminiPart[] = [];
             for (const fid of toolCallIds) {
               if (!toolResponses[fid]) continue;
-              if (contextualizeSignaturelessToolResponses && !resolvedSignatures.has(fid)) continue;
 
               let name = tcID2Name[fid];
               if (!name) {
@@ -490,30 +478,6 @@ function openaiToGeminiBase(
                       : { result: parsedResp },
                 },
               });
-            }
-
-            if (contextualizeSignaturelessToolResponses) {
-              // Signature-less historical tool responses are represented as text
-              // so strict Gemini/Antigravity endpoints don't reject them as native
-              // functionResponse parts missing a matching thoughtSignature.
-              // In context mode the matching historical functionCall is omitted,
-              // avoiding pseudo tool-call records that Gemini Flash can repeat as
-              // the visible final answer.
-              for (const tc of toolCalls) {
-                const id = tc.id as string;
-                if (tc.type !== "function" || !id) continue;
-                if (!resolvedSignatures.has(id) && toolResponses[id]) {
-                  const fn = tc.function as { name?: string } | undefined;
-                  const name = tcID2Name[id] || fn?.name || "unknown";
-                  const resp = toolResponses[id];
-                  toolParts.push({
-                    text:
-                      signaturelessToolCallMode === "text"
-                        ? buildInertHistoricalToolResponseText(name, resp)
-                        : buildHistoricalToolResultContext(name, resp),
-                  });
-                }
-              }
             }
 
             if (toolParts.length > 0) {

--- a/open-sse/utils/error.ts
+++ b/open-sse/utils/error.ts
@@ -229,7 +229,7 @@ export async function parseUpstreamError(response: Response, provider: string | 
     try {
       const parsed = JSON.parse(text);
       // Handle array responses (e.g., from some Gemini APIs)
-      const json = Array.isArray(parsed) && parsed.length > 0 ? parsed[0] : parsed;
+      const json = (Array.isArray(parsed) && parsed.length > 0 ? parsed[0] : parsed) || {};
       message = json.error?.message || json.message || json.error || text;
       errorCode = json.error?.code || json.code;
       errorType = json.error?.type || json.type;

--- a/open-sse/utils/error.ts
+++ b/open-sse/utils/error.ts
@@ -227,7 +227,9 @@ export async function parseUpstreamError(response: Response, provider: string | 
 
     // Try parse as JSON
     try {
-      const json = JSON.parse(text);
+      const parsed = JSON.parse(text);
+      // Handle array responses (e.g., from some Gemini APIs)
+      const json = Array.isArray(parsed) && parsed.length > 0 ? parsed[0] : parsed;
       message = json.error?.message || json.message || json.error || text;
       errorCode = json.error?.code || json.code;
       errorType = json.error?.type || json.type;

--- a/tests/unit/t43-gemini-tool-call-no-thought-signature.test.ts
+++ b/tests/unit/t43-gemini-tool-call-no-thought-signature.test.ts
@@ -89,8 +89,8 @@ test("T43: functionCall parts do NOT get a fake thoughtSignature injected", () =
   // No fake signature should be injected when the client didn't provide one
   assert.equal(
     functionCallParts[0].thoughtSignature,
-    undefined,
-    "functionCall parts must NOT have a fake thoughtSignature injected"
+    "skip_thought_signature_validator",
+    "functionCall parts MUST have skip_thought_signature_validator bypass injected when signaturelessToolCallMode !== 'text'"
   );
 });
 
@@ -134,8 +134,8 @@ test("T43: client-provided thoughtSignature is ignored in default enabled cache 
   // In enabled cache mode, client-provided signatures are NOT forwarded
   assert.equal(
     functionCallParts[0].thoughtSignature,
-    undefined,
-    "Client-provided thoughtSignature should be ignored in enabled cache mode"
+    "skip_thought_signature_validator",
+    "Client-provided thoughtSignature should be ignored in enabled cache mode and fallback to bypass"
   );
 });
 

--- a/tests/unit/t44-antigravity-thought-signature-preserved.test.ts
+++ b/tests/unit/t44-antigravity-thought-signature-preserved.test.ts
@@ -71,3 +71,39 @@ test("T44: Antigravity still strips standalone thoughtSignature without tool cal
 
   assert.deepEqual(transformed.request.contents[0].parts, [{ text: "plain text" }]);
 });
+
+test("T44: Antigravity preserves skip_thought_signature_validator bypass sentinel", async () => {
+  const executor = new AntigravityExecutor();
+  const transformed = await executor.transformRequest(
+    "gemini-3-flash",
+    {
+      request: {
+        contents: [
+          {
+            role: "model",
+            parts: [
+              { thoughtSignature: "skip_thought_signature_validator" },
+              {
+                functionCall: {
+                  id: "call_2",
+                  name: "default_api:bash",
+                  args: { command: "ls" },
+                },
+              },
+            ],
+          },
+        ],
+        tools: [{ functionDeclarations: [{ name: "default_api:bash" }] }],
+      },
+    },
+    true,
+    { projectId: "test-project" }
+  );
+
+  const parts = transformed.request.contents[0].parts;
+  assert.equal(
+    parts.some((part) => part.thoughtSignature === "skip_thought_signature_validator"),
+    true,
+    "executor MUST NOT scrub the skip_thought_signature_validator bypass sentinel"
+  );
+});

--- a/tests/unit/translator-openai-to-gemini.test.ts
+++ b/tests/unit/translator-openai-to-gemini.test.ts
@@ -688,34 +688,28 @@ test("OpenAI -> Antigravity Gemini omits signature-less historical tool calls an
     false,
     "signature-less historical call must not use executable textual tool-call markers"
   );
+  // With skip_thought_signature_validator bypass, functionCall IS emitted natively
   assert.equal(
     modelTurn?.parts.some((part) => part.functionCall) ?? false,
-    false,
-    "signature-less historical call must not be emitted as native functionCall"
+    true,
+    "signature-less historical call MUST be emitted as native functionCall (bypass applied)"
+  );
+  assert.equal(
+    modelTurn?.parts.some((part) => part.thoughtSignature === "skip_thought_signature_validator") ?? false,
+    true,
+    "the bypass sentinel must be injected as thoughtSignature"
   );
 
   const toolTurn = result.request.contents.find(
     (content) =>
       content.role === "user" &&
-      content.parts.some(
-        (part) =>
-          typeof part.text === "string" &&
-          part.text.includes('<previous_tool_result_context source="default_api:todowrite_ide">') &&
-          part.text.includes("[]")
-      )
+      content.parts.some((part) => part.functionResponse)
   );
-  assert.ok(toolTurn, "expected signature-less tool response to be preserved as safe context");
-  assert.equal(
-    toolTurn.parts.some(
-      (part) => typeof part.text === "string" && part.text.includes("[Tool response:")
-    ),
-    false,
-    "signature-less historical response must not use executable textual tool-response markers"
-  );
+  assert.ok(toolTurn, "expected signature-less tool response to be preserved as native functionResponse (bypass applied)");
   assert.equal(
     toolTurn.parts.some((part) => part.functionResponse),
-    false,
-    "signature-less historical response must not be emitted as native functionResponse"
+    true,
+    "signature-less historical response MUST be emitted as native functionResponse (bypass applied)"
   );
 });
 
@@ -757,33 +751,20 @@ test("OpenAI -> Antigravity preserves multiple signature-less historical tool re
     { projectId: "proj-antigravity-gemini" } as any
   );
 
-  const text = JSON.stringify(result.request.contents);
+  // With skip_thought_signature_validator bypass: native functionCall + functionResponse expected
+  const modelTurn = result.request.contents.find(
+    (c) => c.role === "model" && c.parts.some((p) => p.functionCall)
+  );
+  assert.ok(modelTurn, "expected native functionCall turns");
   assert.equal(
-    text.includes("Historical tool-call record only"),
-    false,
-    "signature-less calls must not be emitted as visible historical text"
-  );
-  assert.equal(
-    text.includes("Tool arguments JSON"),
-    false,
-    "signature-less call arguments must not be emitted as visible text"
-  );
-  assert.ok(
-    text.includes('<previous_tool_result_context source=\\"terminal\\">'),
-    "expected signature-less responses as safe context"
-  );
-  assert.ok(
-    text.includes("data/db.json: No such file"),
-    "expected first signature-less tool response as context"
-  );
-  assert.ok(
-    text.includes("storage.sqlite"),
-    "expected second signature-less tool response as context"
+    modelTurn.parts.filter((p) => p.functionCall).length,
+    2,
+    "expected 2 functionCall parts"
   );
   assert.equal(
-    result.request.contents.some((content) => content.parts.some((part) => part.functionResponse)),
-    false,
-    "signature-less historical responses must not be emitted as native functionResponse"
+    result.request.contents.some((c) => c.parts.some((p) => p.functionResponse)),
+    true,
+    "signature-less historical responses MUST be emitted as native functionResponse (bypass applied)"
   );
 });
 
@@ -860,17 +841,12 @@ test("OpenAI -> Antigravity escapes signature-less tool response context content
     { projectId: "proj-antigravity-gemini" } as any
   );
 
-  const text = JSON.stringify(result.request.contents);
-  assert.ok(text.includes("reader&quot;&gt;&lt;x&gt;"), "source attribute must be escaped");
-  assert.ok(
-    text.includes("before &lt;/previous_tool_result_context&gt;&lt;evil&gt; after"),
-    "context content must escape tag-like tool output"
+  // With skip_thought_signature_validator bypass: native functionResponse is emitted
+  // The legacy XML escaping is no longer needed since we send native functionResponse
+  const toolResponseTurn = result.request.contents.find(
+    (c) => c.role === "user" && c.parts.some((p) => p.functionResponse)
   );
-  assert.equal(
-    text.includes("before </previous_tool_result_context><evil> after"),
-    false,
-    "raw context-closing content must not be emitted"
-  );
+  assert.ok(toolResponseTurn, "expected native functionResponse turn");
 });
 
 test("OpenAI -> Antigravity maps Claude-family models to Gemini-compatible schema", () => {


### PR DESCRIPTION
## Summary
This PR addresses two critical issues related to Gemini/Antigravity API endpoints when interacting with signature-less tool calls (e.g., from external CLI agents like Kilo Code) and parsing their error responses.

1. **Missing `thought_signature` 400 Bad Request:**
When processing tool calls that lack a native signature, the previous behavior either stripped the function call (fallback to text) or sent it without a signature, resulting in a strict `400 missing a thought_signature` error from Google's API. This PR introduces the `skip_thought_signature_validator` bypass sentinel (mirroring the CLIProxyAPI implementation). It safely injects this bypass into signature-less `functionCall` parts across both OpenAI and Claude translators, and prevents the Antigravity executor from prematurely scrubbing it.

2. **Array Error Parsing (`[400]: [{`):**
Some Gemini API errors are returned as JSON arrays (e.g., `[{ "error": ... }]`). The `parseUpstreamError` utility assumed a root JSON object, resulting in failed extraction and truncated stringified outputs like `[400]: [{`. This PR adds an `Array.isArray` check to unwrap the first element before extracting the true error message.

## Related Issues
- Related to tool-calling 400 errors from Google Gemini endpoints when using external agents.

## Validation
- [x] `npm run lint`
- [x] `npm run test:unit`
- [x] `npm run test:coverage`
- [ ] Coverage is still `>= 60%` for statements, lines, functions, and branches
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below

## Tests Added Or Updated
- `tests/unit/translator-openai-to-gemini.test.ts`
- `tests/unit/translator-claude-to-gemini.test.ts`
- `tests/unit/t43-gemini-tool-call-no-thought-signature.test.ts`

## Coverage Notes
- Changes in `open-sse/translator/request/` are covered by existing updated unit tests (checking for `skip_thought_signature_validator` injection instead of text fallbacks).

## Reviewer Notes
- Removed legacy text-fallback blocks in `openai-to-gemini.ts` to ensure the `skip_thought_signature_validator` bypass is actively used for all signatureless calls.