### PR TITLE
docs(opencode-plugin): lead with the why — make plugin the recommended path over @omniroute/opencode-provider

### DIFF
--- a/@omniroute/opencode-plugin/README.md
+++ b/@omniroute/opencode-plugin/README.md
@@ -8,9 +8,9 @@
 
 This plugin solves that by:
 
-- Fetching `/v1/models` and `/api/combos` **at opencode startup, in Node.js** — no CORS, no WebView restrictions
+- Fetching `/v1/models` and `/api/combos` **at OpenCode startup, in Node.js** — no CORS, no WebView restrictions
 - Emitting the provider block **dynamically** in the plugin's `config`/`provider` hook — so `opencode.json` only needs the plugin entry, not a static `provider.omniroute`
-- Re-fetching on a configurable TTL (default 5 min), so new models / combo changes in the OmniRoute UI appear without restarting opencode
+- Re-fetching on a configurable TTL (default 5 min), so new models / combo changes in the OmniRoute UI appear without restarting OpenCode
 - Computing `limit.context` for combos as `min(member.context_length)` from the live catalog (no more `null` values that cause 4K-token truncation)
 - **Auto-pickup of `interleaved` capability** for thinking models (merged via PR #3138)
 

--- a/@omniroute/opencode-plugin/README.md
+++ b/@omniroute/opencode-plugin/README.md
@@ -1,6 +1,20 @@
 # @omniroute/opencode-plugin
 
-First-class OpenCode plugin for the [OmniRoute AI Gateway](https://github.com/diegosouzapw/OmniRoute). Pulls a live model catalog from `/v1/models` (including `-low`/`-medium`/`-high`/`-thinking` variants as first-class IDs), aggregates combos via `/api/combos` using a least-common-denominator capability/limit join, sanitizes Gemini tool schemas in flight, and supports multiple side-by-side OmniRoute instances out of the box.
+> **Recommended way to use OmniRoute with OpenCode.** Pulls a live model catalog from `/v1/models` (including `-low`/`-medium`/`-high`/`-thinking` variants as first-class IDs), aggregates combos via `/api/combos` using a least-common-denominator capability/limit join, sanitizes Gemini tool schemas in flight, and supports multiple side-by-side OmniRoute instances out of the box.
+
+## Why this and not `@omniroute/opencode-provider`?
+
+`@omniroute/opencode-provider` is the legacy config-generator package — it writes a frozen `provider.omniroute` block into `opencode.json` with a **hardcoded list of 8 models** ([`OMNIROUTE_DEFAULT_OPENCODE_MODELS`](https://github.com/diegosouzapw/OmniRoute/blob/main/%40omniroute/opencode-provider/src/index.ts#L48-L56)). It works on the CLI but in the **OpenCode Desktop / Web** builds (Tauri / Electron) the runtime re-runs the model picker and the static block surfaces only a few of those — and they drift behind the live OmniRoute catalog.
+
+This plugin solves that by:
+
+- Fetching `/v1/models` and `/api/combos` **at opencode startup, in Node.js** — no CORS, no WebView restrictions
+- Emitting the provider block **dynamically** in the plugin's `config`/`provider` hook — so `opencode.json` only needs the plugin entry, not a static `provider.omniroute`
+- Re-fetching on a configurable TTL (default 5 min), so new models / combo changes in the OmniRoute UI appear without restarting opencode
+- Computing `limit.context` for combos as `min(member.context_length)` from the live catalog (no more `null` values that cause 4K-token truncation)
+- **Auto-pickup of `interleaved` capability** for thinking models (merged via PR #3138)
+
+**If you only have the legacy `opencode-provider` block in your `opencode.json`, replace it with a single plugin entry.** No other config changes required — the same `auth.json` API key works.
 
 ## Install
 


### PR DESCRIPTION
## Summary

Reorganises the top of `@omniroute/opencode-plugin/README.md` to lead with **why this package is the recommended path** for OmniRoute + OpenCode, rather than the legacy `@omniroute/opencode-provider` package.

## The problem this addresses

Users who installed the legacy `@omniroute/opencode-provider` (or wrote a static `provider.omniroute` block by hand) report that on **OpenCode Desktop / Web** (Tauri / Electron) only a handful of models surface in the `/models` picker, even though the same `opencode.json` works fine on the CLI.

Root cause: `@omniroute/opencode-provider` ships a **hardcoded list of 8 models** ([link to OMNIROUTE_DEFAULT_OPENCODE_MODELS](https://github.com/diegosouzapw/OmniRoute/blob/main/%40omniroute/opencode-provider/src/index.ts#L48-L56)) and writes them as a static `provider.omniroute` block in `opencode.json`. CLI reads that file as-is, but the Desktop / Web runtime re-derives the picker and often shows fewer than 8 — and they drift behind the live OmniRoute catalog.

The plugin (this package) fixes all of that by:

1. Fetching `/v1/models` + `/api/combos` at opencode startup, in Node.js
2. Emitting the provider block dynamically in the plugin hook
3. Re-fetching on a configurable TTL (default 5 min)
4. Computing combo `limit.context` as `min(member.context_length)` from the live catalog
5. Auto-propagating the `interleaved` capability for thinking models (PR #3138)

## What changes

- Adds a `## Why this and not `@omniroute/opencode-provider`?` section at the top
- Adds a one-line migration: "replace `provider.omniroute` block with a single plugin entry; same `auth.json` API key works"

## No code changes

Docs only. The plugin's behaviour is unchanged.