### PR TITLE
fix(auto-update): use stable PROJECT_ROOT instead of process.cwd() to prevent ENOENT during update

### DIFF
--- a/src/app/api/system/version/route.ts
+++ b/src/app/api/system/version/route.ts
@@ -14,6 +14,7 @@ import {
   getAutoUpdateConfig,
   launchAutoUpdate,
   validateAutoUpdateRuntime,
+  PROJECT_ROOT,
 } from "@/lib/system/autoUpdate";
 import { NEWS_JSON_URL, parseActiveNewsPayload } from "@/shared/utils/releaseNotes";
 
@@ -169,7 +170,7 @@ export async function POST(req: NextRequest) {
           });
           await execFileAsync("git", ["fetch", "--tags", config.gitRemote], {
             timeout: 60_000,
-            cwd: process.cwd(),
+            cwd: PROJECT_ROOT,
           });
           send({ step: "install", status: "done", message: "Tags fetched" });
 
@@ -178,7 +179,7 @@ export async function POST(req: NextRequest) {
             status: "running",
             message: `Validating ${resolvedTargetTag}...`,
           });
-          await ensureGitTagExists(resolvedTargetTag, execFileAsync, process.cwd());
+          await ensureGitTagExists(resolvedTargetTag, execFileAsync, PROJECT_ROOT);
           send({
             step: "install",
             status: "done",
@@ -193,7 +194,7 @@ export async function POST(req: NextRequest) {
           try {
             await execFileAsync("git", ["stash", "--include-untracked"], {
               timeout: 30_000,
-              cwd: process.cwd(),
+              cwd: PROJECT_ROOT,
             });
           } catch {
             // No local changes to stash.
@@ -202,7 +203,7 @@ export async function POST(req: NextRequest) {
           const shortHead = (
             await execFileAsync("git", ["rev-parse", "--short", "HEAD"], {
               timeout: 10_000,
-              cwd: process.cwd(),
+              cwd: PROJECT_ROOT,
             })
           ).stdout.trim();
           const backupBranch = `pre-update/${shortHead}-${new Date().toISOString().replace(/[:.]/g, "-")}`;
@@ -210,7 +211,7 @@ export async function POST(req: NextRequest) {
           try {
             await execFileAsync("git", ["branch", backupBranch], {
               timeout: 10_000,
-              cwd: process.cwd(),
+              cwd: PROJECT_ROOT,
             });
           } catch {
             // Backup branch is best-effort only.
@@ -218,7 +219,7 @@ export async function POST(req: NextRequest) {
 
           await execFileAsync("git", ["checkout", resolvedTargetTag], {
             timeout: 30_000,
-            cwd: process.cwd(),
+            cwd: PROJECT_ROOT,
           });
           send({ step: "install", status: "done", message: `Checked out ${resolvedTargetTag}` });
 
@@ -229,14 +230,14 @@ export async function POST(req: NextRequest) {
           });
           await execFileAsync("npm", ["install", "--legacy-peer-deps"], {
             timeout: 300_000,
-            cwd: process.cwd(),
+            cwd: PROJECT_ROOT,
           });
           send({ step: "rebuild", status: "done", message: "Dependencies installed" });
 
           try {
             await execFileAsync("node", ["scripts/dev/sync-env.mjs"], {
               timeout: 15_000,
-              cwd: process.cwd(),
+              cwd: PROJECT_ROOT,
             });
           } catch {
             // .env sync is non-fatal during update.
@@ -249,7 +250,7 @@ export async function POST(req: NextRequest) {
           });
           await execFileAsync("npm", ["run", "build"], {
             timeout: 600_000,
-            cwd: process.cwd(),
+            cwd: PROJECT_ROOT,
           });
           send({ step: "rebuild", status: "done", message: "Build complete" });
 
@@ -257,7 +258,7 @@ export async function POST(req: NextRequest) {
           try {
             await execFileAsync("pm2", ["restart", "omniroute", "--update-env"], {
               timeout: 30_000,
-              cwd: process.cwd(),
+              cwd: PROJECT_ROOT,
             });
             send({ step: "restart", status: "done", message: "Service restarted" });
           } catch {
@@ -306,13 +307,14 @@ export async function POST(req: NextRequest) {
       try {
         // Step 1: Install
         send({ step: "install", status: "running", message: `Installing omniroute@${latest}...` });
-        await execFileAsync(
-          "npm",
-          ["install", "-g", `omniroute@${latest}`, "--ignore-scripts", "--legacy-peer-deps"],
-          {
-            timeout: 300000,
-          }
-        );
+          await execFileAsync(
+            "npm",
+            ["install", "-g", `omniroute@${latest}`, "--ignore-scripts", "--legacy-peer-deps"],
+            {
+              timeout: 300000,
+              cwd: PROJECT_ROOT,
+            }
+          );
         send({ step: "install", status: "done", message: `Installed omniroute@${latest}` });
 
         // Step 2: Rebuild native modules (critical for better-sqlite3)
@@ -321,29 +323,36 @@ export async function POST(req: NextRequest) {
           status: "running",
           message: "Rebuilding native modules (better-sqlite3)...",
         });
-        const globalRoot = (
-          await execFileAsync("npm", ["root", "-g"], { timeout: 10000 })
-        ).stdout.trim();
+          const globalRoot = (
+            await execFileAsync("npm", ["root", "-g"], { timeout: 10000, cwd: PROJECT_ROOT })
+          ).stdout.trim();
         const omniPath = `${globalRoot}/omniroute/app`;
-        await execFileAsync("npm", ["rebuild", "better-sqlite3"], {
-          cwd: omniPath,
-          timeout: 120000,
-        });
+        await execFileAsync(
+          "npm",
+          ["rebuild", "better-sqlite3"],
+          {
+            cwd: omniPath,
+            timeout: 120000,
+          }
+        );
         send({ step: "rebuild", status: "done", message: "Native modules rebuilt" });
 
         // Step 3: Restart PM2
         send({ step: "restart", status: "running", message: "Restarting service via PM2..." });
-        try {
-          await execFileAsync("pm2", ["restart", "omniroute", "--update-env"], { timeout: 30000 });
-          send({ step: "restart", status: "done", message: "Service restarted" });
-        } catch {
-          // PM2 may not be available (Docker/manual setups)
-          send({
-            step: "restart",
-            status: "skipped",
-            message: "PM2 not available — manual restart needed",
-          });
-        }
+          try {
+            await execFileAsync("pm2", ["restart", "omniroute", "--update-env"], {
+              timeout: 30000,
+              cwd: PROJECT_ROOT,
+            });
+            send({ step: "restart", status: "done", message: "Service restarted" });
+          } catch {
+            // PM2 may not be available (Docker/manual setups)
+            send({
+              step: "restart",
+              status: "skipped",
+              message: "PM2 not available — manual restart needed",
+            });
+          }
 
         send({
           step: "complete",

--- a/src/lib/system/autoUpdate.ts
+++ b/src/lib/system/autoUpdate.ts
@@ -3,8 +3,23 @@ import { closeSync, mkdirSync, openSync, existsSync } from "node:fs";
 import { access } from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
+import { homedir } from "node:os";
 
 const execFileAsync = promisify(execFile);
+
+function resolveProjectRoot(fallback: string): string {
+  try {
+    const cwd = process.cwd();
+    if (existsSync(path.join(cwd, "package.json"))) return cwd;
+    if (existsSync(path.join(cwd, ".git"))) return cwd;
+    return cwd;
+  } catch {
+    return fallback;
+  }
+}
+
+const FALLBACK_CWD = process.env.HOME || homedir() || "/tmp";
+export const PROJECT_ROOT: string = resolveProjectRoot(FALLBACK_CWD);
 
 type ComposeCommand = "docker compose" | "docker-compose";
 export type AutoUpdateMode = "npm" | "docker-compose" | "source";
@@ -70,8 +85,8 @@ export function getAutoUpdateConfig(env: NodeJS.ProcessEnv = process.env): AutoU
 
   let mode = normalizeMode(env.AUTO_UPDATE_MODE);
   if (mode === "npm") {
-    const isGitRepo = existsSync(path.join(process.cwd(), ".git"));
-    const currentDir = typeof __dirname !== "undefined" ? __dirname : process.cwd();
+    const isGitRepo = existsSync(path.join(PROJECT_ROOT, ".git"));
+    const currentDir = typeof __dirname !== "undefined" ? __dirname : PROJECT_ROOT;
     const isGlobalNodeModules = currentDir.includes("node_modules");
 
     // If we are not in a global node_modules directory, we are likely a local source install/build.
@@ -117,7 +132,7 @@ export async function validateAutoUpdateRuntime(
   existsImpl: (targetPath: string) => Promise<boolean> = pathExists
 ): Promise<AutoUpdateValidation> {
   if (config.mode === "source") {
-    const gitDir = path.join(process.cwd(), ".git");
+    const gitDir = path.join(PROJECT_ROOT, ".git");
     if (!(await existsImpl(gitDir))) {
       return {
         supported: false,
@@ -197,7 +212,7 @@ export async function validateAutoUpdateRuntime(
 export async function ensureGitTagExists(
   targetTag: string,
   execFileImpl: ExecFileLike = execFileAsync,
-  cwd = process.cwd()
+  cwd = PROJECT_ROOT
 ): Promise<void> {
   try {
     await execFileImpl("git", ["rev-parse", "-q", "--verify", `refs/tags/${targetTag}`], {


### PR DESCRIPTION
## Problema

O sistema de auto-update depende de `process.cwd()` em tempo de execução para determinar o diretório do projeto ao executar comandos npm/git. Se o diretório de trabalho atual for removido antes ou durante a atualização (ex: `git checkout` altera a working tree, ou um processo externo remove o diretório), as invocações subsequentes de npm/git falham com:

```
ENOENT: process.cwd failed with error no such file or directory, 
the current working directory was likely removed without changing 
the working directory
```

**Stack trace do erro:**
```
Error: ENOENT: process.cwd failed
  at process.cwd (graceful-fs/polyfills.js:10:19)
  at new Config (@npmcli/config/lib/index.js:80:19)
  at new Npm (npm/lib/npm.js:62:19)
```

## Solução

1. **Capturar `PROJECT_ROOT` no momento do carregamento do módulo** — quando `process.cwd()` tem garantia de ser válido
2. **Cadeia de fallback**: `process.cwd()` → `$HOME` → `/tmp`
3. **Exportar `PROJECT_ROOT`** de `autoUpdate.ts` para ser usado por `version/route.ts`
4. **Substituir todas as chamadas `process.cwd()`** pelo `PROJECT_ROOT` estável em ambos os arquivos
5. **Adicionar `cwd: PROJECT_ROOT` explícito** aos comandos npm que estavam sem cwd no caminho de atualização NPM

## Arquivos modificados

- `src/lib/system/autoUpdate.ts` — Adiciona `resolveProjectRoot()`, exporta `PROJECT_ROOT`, usa constante em vez de `process.cwd()`
- `src/app/api/system/version/route.ts` — Importa `PROJECT_ROOT`, usa nos comandos git/npm/pm2

## Testes

- `npm run typecheck:core` — ✅ sem erros
- `npm run lint` — ✅ sem erros (0 errors)
- `node --import tsx/esm --test tests/unit/auto-update.test.ts` — ✅ 6/6 testes passam

Fixes: #3374