### PR TITLE
fix: probe container bridge network IP in healthcheck (#3151)

### DIFF
--- a/scripts/dev/healthcheck.mjs
+++ b/scripts/dev/healthcheck.mjs
@@ -11,12 +11,35 @@
  * error, so the container was reported `unhealthy` with an empty, undiagnosable
  * `State.Health[].Output`. We now try an ordered list of hosts and surface the
  * last error on total failure.
+ *
+ * Bridge Network Fix: Also probes the container's internal bridge IP (e.g., 172.17.0.2)
+ * to handle Docker network setups that isolate loopback interfaces.
  */
 
 import { pathToFileURL } from "node:url";
+import { networkInterfaces } from "node:os";
 
 const DEFAULT_HOSTS = ["127.0.0.1", "localhost", "::1"];
 const DEFAULT_TIMEOUT_MS = 4000;
+
+/**
+ * Get the primary non-loopback IPv4 address (container internal IP).
+ * Falls back to null if unable to determine.
+ */
+function getContainerInternalIP() {
+  try {
+    const interfaces = networkInterfaces();
+    for (const [name, addrs] of Object.entries(interfaces)) {
+      // Skip loopback and docker0, prioritize eth0/veth interfaces
+      if (name.startsWith("lo") || name === "docker0") continue;
+      const ipv4 = addrs?.find((a) => a.family === "IPv4" && !a.internal);
+      if (ipv4) return ipv4.address;
+    }
+  } catch {
+    // silently ignore if unable to read interfaces
+  }
+  return null;
+}
 
 /**
  * Build the health URL for a host, bracketing IPv6 literals (e.g. `::1`).
@@ -64,8 +87,16 @@ export async function probeHealth({
 
 async function main() {
   const port = process.env.DASHBOARD_PORT || process.env.PORT || "20128";
+
+  // Build host list: defaults + detected container bridge IP
+  const hosts = [...DEFAULT_HOSTS];
+  const containerIP = getContainerInternalIP();
+  if (containerIP && !hosts.includes(containerIP)) {
+    hosts.push(containerIP);
+  }
+
   try {
-    await probeHealth({ port });
+    await probeHealth({ port, hosts });
     process.exit(0);
   } catch (err) {
     // Surface the failure so `docker inspect ... .State.Health[].Output` is


### PR DESCRIPTION
## Problem
When OmniRoute binds to `0.0.0.0` inside Docker, it becomes reachable on the container's internal bridge network IP (e.g., `172.17.0.2`). Some Docker network setups isolate the loopback interface, causing `127.0.0.1` and `localhost` probes to fail even though the app is healthy and listening.

This causes the Docker healthcheck to fail repeatedly with an empty, undiagnosable `State.Health[].Output`.

## Solution
- Imports `os.networkInterfaces()` to detect the container's primary internal IPv4 address
- Adds the detected container bridge IP to the healthcheck probe host list
- Falls back gracefully if network detection fails
- Maintains backward compatibility with existing loopback probes

## Probe order
The healthcheck now tries these hosts in order, succeeding on the first reachable one:
1. `127.0.0.1` (loopback IPv4)
2. `localhost` (DNS resolution)
3. `::1` (loopback IPv6)
4. `172.x.x.x` (container bridge network IP - auto-detected)

Fixes #3151