### PR TITLE
fix(publish): remove onnxruntime CUDA binary from tarball to avoid 413

### DIFF
--- a/scripts/build/pack-artifact-policy.ts
+++ b/scripts/build/pack-artifact-policy.ts
@@ -25,6 +25,10 @@ const STAGING_FORBIDDEN_FILES = ["audit-report.json", "package-lock.json"];
 export const APP_STAGING_REMOVAL_PATHS: string[] = [
   ...STAGING_FORBIDDEN_DIRECTORIES,
   ...STAGING_FORBIDDEN_FILES,
+  // onnxruntime CUDA provider binary (~316 MB) inflates the npm tarball
+  // past the registry 413 limit for npm.org.  It's only needed on systems
+  // with a CUDA GPU — users install CUDA providers separately.
+  "node_modules/onnxruntime-node/bin/napi-v6/linux/x64/libonnxruntime_providers_cuda.so",
 ];
 
 export const APP_STAGING_ALLOWED_EXACT_PATHS: string[] = [


### PR DESCRIPTION
## Problem

The onnxruntime CUDA provider shared library (`libonnxruntime_providers_cuda.so`) at \~316 MB inflates the npm tarball past the npm registry's \~100 MB size limit, causing a `413 Payload Too Large` error on `npm publish`.

## Solution

Append the CUDA binary path to `APP_STAGING_REMOVAL_PATHS` in `scripts/build/pack-artifact-policy.ts` so it is stripped during the prepublish staging step.

## Impact

Users on CUDA systems can install the provider binary independently — this is a packaging-only change that doesn't affect runtime behavior.