### PR TITLE
fix(catalog): stop Codex CLI model-catalog refresh from erroring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 ## [3.8.18] — Unreleased
 
-_Development cycle in progress._
+### 🔧 Bug Fixes
+
+- **fix(catalog):** Codex CLI model-catalog refresh no longer errors — `GET /v1/models` now returns a top-level `models: []` array for Codex clients (detected via the `originator` / `user-agent` = `codex_*` headers it sends on `GET /v1/models?client_version=...`), so `codex_models_manager` stops failing to decode the OpenAI-standard response and no longer logs `failed to refresh available models` on every startup. The array is intentionally empty: Codex replaces its built-in per-model agent prompt (`base_instructions`, ~21k chars) with whatever a populated entry carries for the selected model, so emitting our catalog would break Codex's agent behaviour — an empty list keeps Codex on its built-in model info (same inference as before, minus the error). Non-Codex OpenAI clients receive the unchanged `{object,data}` response. ([#3481](https://github.com/diegosouzapw/OmniRoute/pull/3481) — thanks @diegosouzapw)
 
 ---
 

--- a/src/app/api/v1/models/catalog.ts
+++ b/src/app/api/v1/models/catalog.ts
@@ -302,6 +302,22 @@ function buildAliasMaps() {
 }
 
 /**
+ * Detect the Codex CLI's model-catalog refresh client. Codex sends an `originator` header
+ * of `codex_exec` (codex exec) / `codex_cli_rs` (interactive TUI) — see openai/codex
+ * login/src/auth/default_client.rs DEFAULT_ORIGINATOR — and a matching `codex_*`
+ * User-Agent on its `GET /v1/models?client_version=...` catalog refresh. We only augment
+ * the response shape for these clients so every other OpenAI consumer keeps the
+ * byte-identical `{object,data}` payload.
+ */
+function isCodexModelCatalogClient(request: Request): boolean {
+  const headers = request.headers;
+  const originator = headers.get("originator")?.toLowerCase() ?? "";
+  if (originator.startsWith("codex")) return true;
+  const userAgent = headers.get("user-agent")?.toLowerCase() ?? "";
+  return userAgent.startsWith("codex");
+}
+
+/**
  * Build unified OpenAI-compatible model catalog response.
  * Reused by `/api/v1/models` and `/api/v1` to avoid semantic drift (T09).
  */
@@ -1368,18 +1384,34 @@ export async function getUnifiedModelsResponse(
       return maybeOmitCatalogModelName(listedModel, includeModelNames);
     });
 
-    return Response.json(
-      {
-        object: "list",
-        data: enrichedModels,
+    // Codex CLI compatibility: its model-catalog refresh (codex_models_manager) does
+    // GET /v1/models?client_version=<v> and decodes a JSON object with a TOP-LEVEL
+    // `models` array, so the OpenAI-standard `{object,data}` shape makes it fail with
+    // "missing field `models`" and log "failed to refresh available models" on every
+    // startup. For codex clients only (detected by the codex originator/user-agent) we add
+    // an EMPTY `models: []` so the decode succeeds and the error disappears. Every other
+    // OpenAI consumer keeps the byte-identical `{object,data}` response.
+    //
+    // We deliberately keep it EMPTY rather than mirroring the catalog: codex replaces its
+    // built-in per-model agent prompt (`base_instructions`, ~21k chars) with whatever a
+    // populated entry carries for the selected model, so emitting our models with an
+    // empty/foreign `base_instructions` would drop codex's agent prompt to nothing and
+    // break its agent behavior (verified empirically against codex 0.137). An empty array
+    // keeps codex on its built-in model info — same inference as today, minus the error.
+    const responseBody: Record<string, unknown> = {
+      object: "list",
+      data: enrichedModels,
+    };
+    if (isCodexModelCatalogClient(request)) {
+      responseBody.models = [];
+    }
+
+    return Response.json(responseBody, {
+      headers: {
+        ...corsHeaders,
+        ...diagnosticHeaders,
       },
-      {
-        headers: {
-          ...corsHeaders,
-          ...diagnosticHeaders,
-        },
-      }
-    );
+    });
   } catch (error) {
     console.log("Error fetching models:", error);
     return Response.json(

--- a/tests/unit/codex-models-catalog-refresh.test.ts
+++ b/tests/unit/codex-models-catalog-refresh.test.ts
@@ -1,0 +1,105 @@
+// Codex CLI compatibility for GET /v1/models.
+//
+// The Codex CLI model-catalog refresh (codex_models_manager) does
+//   GET /v1/models?client_version=<v>
+// and decodes a JSON object with a TOP-LEVEL `models` array. OmniRoute answers in the
+// OpenAI-standard `{ object: "list", data: [...] }` shape, so codex's serde fails with
+//   failed to decode models response: missing field `models`
+// and logs "failed to refresh available models" on every startup (verified live against
+// codex 0.137 with a request-capturing stub).
+//
+// Fix: when the caller is a codex client (identified by the `originator` /
+// `user-agent` = `codex_*` headers that codex sends), add an EMPTY top-level
+// `models: []` so the decode succeeds and the error disappears. Non-codex OpenAI clients
+// keep the byte-identical `{object,data}` response (no `models` key).
+//
+// Why EMPTY and not the real catalog: codex replaces its built-in per-model agent prompt
+// (`base_instructions`, ~21k chars) with whatever a populated `models` entry carries for
+// the selected model. Emitting our models with an empty/foreign `base_instructions` was
+// empirically shown to drop codex's agent prompt to 0 chars, breaking its agent behavior.
+// An empty array keeps codex on its built-in model info (same inference as today, minus
+// the error).
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-codex-models-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.API_KEY_SECRET = process.env.API_KEY_SECRET || "catalog-test-secret";
+
+const core = await import("../../src/lib/db/core.ts");
+const apiKeysDb = await import("../../src/lib/db/apiKeys.ts");
+const v1ModelsCatalog = await import("../../src/app/api/v1/models/catalog.ts");
+
+async function resetStorage() {
+  core.resetDbInstance();
+  apiKeysDb.resetApiKeyState();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+test.beforeEach(async () => {
+  await resetStorage();
+});
+
+test.after(async () => {
+  core.resetDbInstance();
+  apiKeysDb.resetApiKeyState();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("codex client (originator: codex_exec) receives a top-level `models` array so the catalog refresh decodes", async () => {
+  const res = await v1ModelsCatalog.getUnifiedModelsResponse(
+    new Request("http://localhost/v1/models?client_version=0.137.0", {
+      headers: {
+        originator: "codex_exec",
+        "user-agent": "codex_exec/0.137.0 (Ubuntu 24.4.0; x86_64) vscode/3.7.19 (codex_exec; 0.137.0)",
+      },
+    })
+  );
+
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as Record<string, unknown>;
+
+  // OpenAI-standard fields are preserved for any OpenAI consumer of the same response.
+  assert.equal(body.object, "list");
+  assert.ok(Array.isArray(body.data), "data[] must still be present for OpenAI clients");
+
+  // The codex-required top-level `models` array is present (and empty by design).
+  assert.ok(Array.isArray(body.models), "codex clients must receive a top-level `models` array");
+  assert.equal(
+    (body.models as unknown[]).length,
+    0,
+    "`models` must be empty so codex keeps its built-in per-model base_instructions"
+  );
+});
+
+test("codex TUI (user-agent: codex_cli_rs) is detected via user-agent too", async () => {
+  const res = await v1ModelsCatalog.getUnifiedModelsResponse(
+    new Request("http://localhost/v1/models", {
+      headers: { "user-agent": "codex_cli_rs/0.137.0 (Ubuntu 24.4.0; x86_64)" },
+    })
+  );
+
+  const body = (await res.json()) as Record<string, unknown>;
+  assert.ok(Array.isArray(body.models), "codex user-agent must also get the `models` array");
+});
+
+test("non-codex OpenAI client keeps the unchanged {object,data} shape (no `models` key)", async () => {
+  const res = await v1ModelsCatalog.getUnifiedModelsResponse(
+    new Request("http://localhost/v1/models", {
+      headers: { "user-agent": "OpenAI/Python 1.99.0" },
+    })
+  );
+
+  const body = (await res.json()) as Record<string, unknown>;
+  assert.equal(body.object, "list");
+  assert.ok(Array.isArray(body.data));
+  assert.ok(
+    !("models" in body),
+    "non-codex clients must NOT receive a `models` key (response stays byte-identical)"
+  );
+});


### PR DESCRIPTION
## Problem

The Codex CLI's model-catalog refresh (`codex_models_manager`) does `GET /v1/models?client_version=<v>` and decodes a JSON object with a **top-level `models` array**. OmniRoute answers in the OpenAI-standard `{object,data}` shape, so codex fails with:

```
ERROR codex_models_manager: failed to refresh available models:
  failed to decode models response: missing field `models`
```

…logging `failed to refresh available models` on every startup. Inference still works (it falls back to codex's built-in model info), but the error is noisy and the catalog refresh is broken.

## Root cause & key finding (verified empirically against codex 0.137)

Using a request-capturing local stub I confirmed:

1. **Detection signal:** codex sends `originator: codex_exec` / `codex_cli_rs` and a `codex_*` User-Agent on its `GET /v1/models?client_version=...` refresh.
2. **Required schema:** the wire response must contain a top-level `models: []` (13 required `ModelInfo` fields per entry: `slug`, `display_name`, `supported_reasoning_levels`, `shell_type`, `visibility`, `supported_in_api`, `priority`, `base_instructions`, `supports_reasoning_summaries`, `support_verbosity`, `truncation_policy`, `supports_parallel_tool_calls`, `experimental_supported_tools`).
3. **Why we do NOT populate the catalog:** codex **replaces** its built-in per-model agent prompt (`base_instructions`, ~21k chars) with whatever a populated entry carries for the *selected* model. Proven:
   - refresh failing (today) → `instructions` = full Codex agent prompt (21,335 chars)
   - `base_instructions: ""` → `instructions` = **0 chars** (agent prompt destroyed)
   - `base_instructions: <ours>` → `instructions` = ours (hijacked)

   OmniRoute can't (and shouldn't) ship OpenAI's proprietary Codex prompt, so mirroring our catalog into `models` would break codex's agent behaviour. **Returning an empty `models: []` keeps codex on its built-in model info — same inference as before, minus the error.**

## Fix

Detect codex clients via the `originator` / `user-agent` headers and add an **empty** top-level `models: []` to the `GET /v1/models` response. Non-codex OpenAI clients get the **byte-identical** `{object,data}` response (no `models` key). Scope is restricted to the response shape — auth, inference routing, and other endpoints are untouched.

## Validation

- **TDD** — `tests/unit/codex-models-catalog-refresh.test.ts` (RED→GREEN): codex via `originator`, codex via `user-agent`, and non-codex (unchanged shape). 3/3 green.
- **End-to-end vs codex 0.137** against the **real** `getUnifiedModelsResponse` handler: `failed to refresh available models` → **0 occurrences**, inference `instructions` preserved (built-in Codex agent prompt, not empty).
- **Lint** clean (changed files); **typecheck** (`tsc -p tsconfig.json`) reports **0 errors** in `catalog.ts` / the test; existing catalog tests (#3200, cc-compatible) pass — no regression.
- Note: the worktree `next build` fails on a **pre-existing, unrelated** fumadocs MDX schema error in `docs/meta.json` (`src/app/docs/api/search/route.ts`); that file is untouched by this PR and the error reproduces on the clean release branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)