### PR TITLE
fix(provider): detect Responses API format when body has `input` but …

### DIFF
--- a/open-sse/services/provider.ts
+++ b/open-sse/services/provider.ts
@@ -99,6 +99,15 @@ export function detectFormatFromEndpoint(body, endpointPath = "") {
     /\/(?:chat\/completions|completions)(?=\/|$)/i.test(path) ||
     /^(?:chat\/completions|completions)(?=\/|$)/i.test(path)
   ) {
+    if (
+      body &&
+      typeof body === "object" &&
+      !Array.isArray(body) &&
+      body.input !== undefined &&
+      body.messages === undefined
+    ) {
+      return "openai-responses";
+    }
     return "openai";
   }
 

--- a/tests/unit/provider-detect-format-endpoint.test.ts
+++ b/tests/unit/provider-detect-format-endpoint.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Tests for detectFormatFromEndpoint — the endpoint-aware format detector that
+ * fixes Cursor Responses-API bodies sent to /chat/completions.
+ *
+ * Cursor sends Responses-API-shaped payloads (with `input`, `reasoning.effort`,
+ * `prompt_cache_retention`) to /v1/chat/completions. Without the body-sniff on
+ * the chat/completions path the detector returned "openai", the translator built
+ * `input` from `messages` (undefined), and the upstream received an empty input.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { detectFormatFromEndpoint } = await import("../../open-sse/services/provider.ts");
+
+// ── /responses path ──────────────────────────────────────────────────────────
+
+test("detectFormatFromEndpoint: /responses path → openai-responses regardless of body", () => {
+  assert.equal(detectFormatFromEndpoint({}, "/v1/responses"), "openai-responses");
+  assert.equal(detectFormatFromEndpoint({ messages: [] }, "/responses"), "openai-responses");
+});
+
+// ── /messages path ────────────────────────────────────────────────────────────
+
+test("detectFormatFromEndpoint: /messages path → claude", () => {
+  assert.equal(detectFormatFromEndpoint({}, "/v1/messages"), "claude");
+  assert.equal(detectFormatFromEndpoint({ messages: [] }, "messages"), "claude");
+});
+
+// ── /chat/completions path — standard OpenAI body ────────────────────────────
+
+test("detectFormatFromEndpoint: /chat/completions with messages array → openai", () => {
+  const body = { model: "gpt-4o", messages: [{ role: "user", content: "hi" }] };
+  assert.equal(detectFormatFromEndpoint(body, "/v1/chat/completions"), "openai");
+});
+
+test("detectFormatFromEndpoint: /chat/completions with empty messages array → openai", () => {
+  assert.equal(detectFormatFromEndpoint({ messages: [] }, "/v1/chat/completions"), "openai");
+});
+
+// ── /chat/completions path — Cursor Responses-API body ───────────────────────
+
+test("detectFormatFromEndpoint: /chat/completions with input but no messages → openai-responses", () => {
+  const cursorBody = {
+    model: "gpt-4o",
+    input: [{ role: "user", content: "hello" }],
+    reasoning: { effort: "high" },
+  };
+  assert.equal(detectFormatFromEndpoint(cursorBody, "/v1/chat/completions"), "openai-responses");
+});
+
+test("detectFormatFromEndpoint: /chat/completions with string input and no messages → openai-responses", () => {
+  assert.equal(
+    detectFormatFromEndpoint({ input: "hello" }, "/chat/completions"),
+    "openai-responses"
+  );
+});
+
+test("detectFormatFromEndpoint: /chat/completions with input AND messages → openai (messages wins)", () => {
+  // When both fields are present the body is ambiguous; treat it as a normal
+  // chat-completions request so that the existing messages path is preserved.
+  const body = { input: "hi", messages: [{ role: "user", content: "hi" }] };
+  assert.equal(detectFormatFromEndpoint(body, "/v1/chat/completions"), "openai");
+});
+
+test("detectFormatFromEndpoint: /chat/completions with input: undefined → openai (falsy input ignored)", () => {
+  assert.equal(
+    detectFormatFromEndpoint({ input: undefined, model: "x" }, "/v1/chat/completions"),
+    "openai"
+  );
+});
+
+// ── /completions (non-chat) path ─────────────────────────────────────────────
+
+test("detectFormatFromEndpoint: /completions path with messages → openai", () => {
+  assert.equal(
+    detectFormatFromEndpoint({ messages: [] }, "/v1/completions"),
+    "openai"
+  );
+});
+
+test("detectFormatFromEndpoint: /completions path with input and no messages → openai-responses", () => {
+  assert.equal(
+    detectFormatFromEndpoint({ input: "hello" }, "/completions"),
+    "openai-responses"
+  );
+});
+
+// ── No path / unknown path — falls back to body-based detection ───────────────
+
+test("detectFormatFromEndpoint: no path falls back to body-based detectFormat", () => {
+  // Pure messages body → openai
+  assert.equal(
+    detectFormatFromEndpoint({ messages: [{ role: "user", content: "hi" }] }),
+    "openai"
+  );
+});
+
+test("detectFormatFromEndpoint: unknown path falls back to body-based detectFormat", () => {
+  assert.equal(
+    detectFormatFromEndpoint({ messages: [] }, "/v1/custom/endpoint"),
+    "openai"
+  );
+});


### PR DESCRIPTION
…no `messages`

Cursor sends Responses-API-shaped bodies (with `input`, `reasoning.effort`, `prompt_cache_retention`) to the /chat/completions endpoint. The endpoint-first detector forced sourceFormat=openai, which then built input from `messages` (undefined) and dropped Cursor's actual payload → upstream saw empty input → 400.

When the path is /chat/completions AND the body has `input` but no `messages`, return `openai-responses` so the request is routed correctly.

## Summary

- Describe the user-facing or operational change.

## Related Issues

- Closes #
- Related to #

## Validation

- [ ] `npm run lint`
- [ ] `npm run test:unit`
- [ ] `npm run test:coverage`
- [ ] Coverage is still `>= 60%` for statements, lines, functions, and branches
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below

## Tests Added Or Updated

- List every changed or added automated test file.
- If no production code changed, state that here.

## Coverage Notes

- If this PR changes `src/`, `open-sse/`, `electron/`, or `bin/`, explain which tests cover the change.
- If coverage moved down in any touched file, explain why and what follow-up task will recover it.

## Reviewer Notes

- Call out any risky areas, migrations, feature flags, or manual validation that reviewers should know about.