### PR TITLE
feat(browserPool): resolve Playwright proxy from proxy_registry DB

### DIFF
--- a/open-sse/services/browserPool.ts
+++ b/open-sse/services/browserPool.ts
@@ -137,15 +137,33 @@ function startEvictTimer(): void {
   state.evictTimer.unref?.();
 }
 
+async function resolvePlaywrightProxy(): Promise<import("playwright").LaunchOptions["proxy"] | undefined> {
+  try {
+    const { resolveProxyForProvider } = await import("@/lib/db/proxies");
+    // Use global proxy assignment (resolveProxyForProvider falls through to global when no
+    // provider-specific assignment exists — passing a sentinel that won't match any provider).
+    const p = await resolveProxyForProvider("__browser_pool__");
+    if (!p?.host) return undefined;
+    const scheme = p.type === "socks5" ? "socks5" : "http";
+    return {
+      server: `${scheme}://${p.host}:${p.port}`,
+      ...(p.username ? { username: p.username, password: p.password ?? "" } : {}),
+    };
+  } catch {
+    return undefined;
+  }
+}
+
 async function launchBrowser(): Promise<Browser> {
   if (state.browser) return state.browser;
   if (state.launching) return state.launching;
   state.launching = (async () => {
-    const cloakLaunch = await resolveCloakLaunch();
+    const [cloakLaunch, proxy] = await Promise.all([resolveCloakLaunch(), resolvePlaywrightProxy()]);
     let browser: Browser;
     if (cloakLaunch) {
       browser = await cloakLaunch({
         headless: true,
+        proxy,
         args: ["--no-sandbox", "--disable-dev-shm-usage"],
       });
     } else {
@@ -154,6 +172,7 @@ async function launchBrowser(): Promise<Browser> {
       const { chromium } = await import("playwright");
       browser = await chromium.launch({
         headless: true,
+        proxy,
         args: [
           "--no-sandbox",
           "--disable-dev-shm-usage",

--- a/open-sse/services/browserPool.ts
+++ b/open-sse/services/browserPool.ts
@@ -137,19 +137,39 @@ function startEvictTimer(): void {
   state.evictTimer.unref?.();
 }
 
-async function resolvePlaywrightProxy(): Promise<import("playwright").LaunchOptions["proxy"] | undefined> {
+interface ProxyRecord {
+  type?: string;
+  host: string;
+  port: number;
+  username?: string | null;
+  password?: string | null;
+}
+
+interface ResolvePlaywrightProxyDeps {
+  resolveProxy?: (providerId: string) => Promise<ProxyRecord | null | undefined>;
+}
+
+// Exported for tests (deps injection avoids mock.module()).
+export async function resolvePlaywrightProxy(
+  providerKey: string,
+  deps?: ResolvePlaywrightProxyDeps,
+): Promise<import("playwright").LaunchOptions["proxy"] | undefined> {
   try {
-    const { resolveProxyForProvider } = await import("@/lib/db/proxies");
-    // Use global proxy assignment (resolveProxyForProvider falls through to global when no
-    // provider-specific assignment exists — passing a sentinel that won't match any provider).
-    const p = await resolveProxyForProvider("__browser_pool__");
+    const resolver =
+      deps?.resolveProxy ??
+      (async (id: string) => {
+        const { resolveProxyForProvider } = await import("../../src/lib/db/proxies");
+        return resolveProxyForProvider(id);
+      });
+    const p = await resolver(providerKey);
     if (!p?.host) return undefined;
     const scheme = p.type === "socks5" ? "socks5" : "http";
     return {
       server: `${scheme}://${p.host}:${p.port}`,
       ...(p.username ? { username: p.username, password: p.password ?? "" } : {}),
     };
-  } catch {
+  } catch (err) {
+    console.warn("[BrowserPool] Failed to resolve proxy from DB:", err);
     return undefined;
   }
 }
@@ -158,12 +178,11 @@ async function launchBrowser(): Promise<Browser> {
   if (state.browser) return state.browser;
   if (state.launching) return state.launching;
   state.launching = (async () => {
-    const [cloakLaunch, proxy] = await Promise.all([resolveCloakLaunch(), resolvePlaywrightProxy()]);
+    const cloakLaunch = await resolveCloakLaunch();
     let browser: Browser;
     if (cloakLaunch) {
       browser = await cloakLaunch({
         headless: true,
-        proxy,
         args: ["--no-sandbox", "--disable-dev-shm-usage"],
       });
     } else {
@@ -172,7 +191,6 @@ async function launchBrowser(): Promise<Browser> {
       const { chromium } = await import("playwright");
       browser = await chromium.launch({
         headless: true,
-        proxy,
         args: [
           "--no-sandbox",
           "--disable-dev-shm-usage",
@@ -260,13 +278,14 @@ export async function acquireBrowserContext(
   if (pending) return pending;
 
   const createPromise = (async (): Promise<PooledContext> => {
-    const browser = await launchBrowser();
+    const [browser, proxy] = await Promise.all([launchBrowser(), resolvePlaywrightProxy(key)]);
     const isStealth = state.cloakLaunch !== null;
     const context = await browser.newContext({
       userAgent: options.userAgent || DEFAULT_USER_AGENT,
       locale: options.locale || "en-US",
       timezoneId: options.timezone || "America/New_York",
       viewport: { width: 1280, height: 800 },
+      ...(proxy ? { proxy } : {}),
     });
 
     if (options.cookieString) {

--- a/tests/unit/browserPool-proxy.test.ts
+++ b/tests/unit/browserPool-proxy.test.ts
@@ -1,0 +1,87 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { resolvePlaywrightProxy } from "../../open-sse/services/browserPool.ts";
+
+describe("resolvePlaywrightProxy", () => {
+  it("returns undefined when no proxy is configured", async () => {
+    const proxy = await resolvePlaywrightProxy("gemini-web", {
+      resolveProxy: async () => null,
+    });
+    assert.strictEqual(proxy, undefined);
+  });
+
+  it("formats http proxy server string", async () => {
+    const proxy = await resolvePlaywrightProxy("gemini-web", {
+      resolveProxy: async () => ({ type: "http", host: "proxy.example.com", port: 8080 }),
+    });
+    assert.deepStrictEqual(proxy, { server: "http://proxy.example.com:8080" });
+  });
+
+  it("formats socks5 proxy server string", async () => {
+    const proxy = await resolvePlaywrightProxy("gemini-web", {
+      resolveProxy: async () => ({ type: "socks5", host: "socks.example.com", port: 1080 }),
+    });
+    assert.deepStrictEqual(proxy, { server: "socks5://socks.example.com:1080" });
+  });
+
+  it("defaults to http scheme when type is absent", async () => {
+    const proxy = await resolvePlaywrightProxy("claude-web", {
+      resolveProxy: async () => ({ host: "proxy.example.com", port: 3128 }),
+    });
+    assert.deepStrictEqual(proxy, { server: "http://proxy.example.com:3128" });
+  });
+
+  it("includes credentials when username is set", async () => {
+    const proxy = await resolvePlaywrightProxy("claude-web", {
+      resolveProxy: async () => ({
+        type: "http",
+        host: "proxy.example.com",
+        port: 3128,
+        username: "user",
+        password: "pass",
+      }),
+    });
+    assert.deepStrictEqual(proxy, {
+      server: "http://proxy.example.com:3128",
+      username: "user",
+      password: "pass",
+    });
+  });
+
+  it("uses empty string for password when null", async () => {
+    const proxy = await resolvePlaywrightProxy("claude-web", {
+      resolveProxy: async () => ({
+        type: "http",
+        host: "proxy.example.com",
+        port: 3128,
+        username: "user",
+        password: null,
+      }),
+    });
+    assert.deepStrictEqual(proxy, {
+      server: "http://proxy.example.com:3128",
+      username: "user",
+      password: "",
+    });
+  });
+
+  it("swallows DB errors and returns undefined", async () => {
+    const proxy = await resolvePlaywrightProxy("gemini-web", {
+      resolveProxy: async () => {
+        throw new Error("no such table: proxy_registry");
+      },
+    });
+    assert.strictEqual(proxy, undefined);
+  });
+
+  it("passes the actual provider key to the resolver", async () => {
+    let capturedKey = "";
+    await resolvePlaywrightProxy("gemini-web", {
+      resolveProxy: async (id) => {
+        capturedKey = id;
+        return null;
+      },
+    });
+    assert.strictEqual(capturedKey, "gemini-web");
+  });
+});


### PR DESCRIPTION
Instead of reading proxy settings from environment variables, query the proxy_registry / proxy_assignments tables in the SQLite DB at browser launch time. Tries a provider-scoped assignment first, falls back to a global one. This allows per-provider proxy configuration through the OmniRoute admin UI without restarting the server.

## Summary

- Describe the user-facing or operational change.

## Related Issues

- Closes #
- Related to #

## Validation

- [ ] `npm run lint`
- [ ] `npm run test:unit`
- [ ] `npm run test:coverage`
- [ ] Coverage is still `>= 60%` for statements, lines, functions, and branches
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below

## Tests Added Or Updated

- List every changed or added automated test file.
- If no production code changed, state that here.

## Coverage Notes

- If this PR changes `src/`, `open-sse/`, `electron/`, or `bin/`, explain which tests cover the change.
- If coverage moved down in any touched file, explain why and what follow-up task will recover it.

## Reviewer Notes

- Call out any risky areas, migrations, feature flags, or manual validation that reviewers should know about.