### PR TITLE
fix: llama base url normalization

### DIFF
--- a/open-sse/executors/default.ts
+++ b/open-sse/executors/default.ts
@@ -143,7 +143,12 @@ function normalizeOpenAIChatUrl(baseUrl) {
   ) {
     return normalized;
   }
-  return normalized.endsWith("/v1") ? `${normalized}/chat/completions` : normalized;
+  if (normalized.endsWith("/v1")) {
+    return `${normalized}/chat/completions`;
+  }
+  // Assume OpenAI-compatible /v1/chat/completions path structure
+  // when the base URL is a bare hostname or custom path (e.g. llama.cpp, vLLM, LM Studio).
+  return `${normalized}/v1/chat/completions`;
 }
 
 export class DefaultExecutor extends BaseExecutor {

--- a/tests/manual/llama.http
+++ b/tests/manual/llama.http
@@ -1,6 +1,7 @@
 ###
 # @name List model directly from llama-cpp provider
-GET http://localhost:10965/v1/models
+GET http://{{llama-address}}/v1/models
+Authorization: Bearer {{LLAMACPP_API_KEY}}
 
 ###
 # @name List all models
@@ -10,8 +11,8 @@ Content-Type: application/json
 
 ###
 # @name Send a standard OpenAI chat request directly to llama-cpp provider
-POST http://localhost:10965/v1/chat/completions
-Authorization: Bearer {{OMNIROUTE_API_KEY}}
+POST http://{{llama-address}}/chat/completions
+Authorization: Bearer {{LLAMACPP_API_KEY}}
 
 {
   "model": "unsloth/gemma-4-26B-A4B-it-GGUF:UD-IQ2_M",

--- a/tests/unit/executor-default-base.test.ts
+++ b/tests/unit/executor-default-base.test.ts
@@ -416,6 +416,26 @@ test("DefaultExecutor local OpenAI-style providers honor custom base URLs and sk
   assert.equal(vllmHeaders.Accept, "application/json");
 });
 
+test("DefaultExecutor local providers append /v1/chat/completions for bare hostname base URLs", () => {
+  const llamaCpp = new DefaultExecutor("llama-cpp");
+  const lmStudio = new DefaultExecutor("lm-studio");
+  const vllm = new DefaultExecutor("vllm");
+
+  const bareHost = llamaCpp.buildUrl("gemma-4", true, 0, {
+    providerSpecificData: { baseUrl: "https://foo.llama.example.com" },
+  });
+  const customPath = lmStudio.buildUrl("gemma-4", true, 0, {
+    providerSpecificData: { baseUrl: "https://bar.llama.ai/foo" },
+  });
+  const alreadyComplete = vllm.buildUrl("gemma-4", true, 0, {
+    providerSpecificData: { baseUrl: "https://baz.llama.ai/v1/chat/completions" },
+  });
+
+  assert.equal(bareHost, "https://foo.llama.example.com/v1/chat/completions");
+  assert.equal(customPath, "https://bar.llama.ai/foo/v1/chat/completions");
+  assert.equal(alreadyComplete, "https://baz.llama.ai/v1/chat/completions");
+});
+
 test("DefaultExecutor.buildHeaders handles Snowflake PATs and GigaChat access tokens", () => {
   const snowflake = new DefaultExecutor("snowflake");
   const gigachat = new DefaultExecutor("gigachat");


### PR DESCRIPTION
Small fix for llamacpp, if I have baseURL set to llama.example.foo the /model call works but when sending messages to the endpoint I get 404 error because it doesn't add /v1/chat/completions to the base url.

This fix also allows the base url to have this shape aswell:
bar.example.com/foo