### PR TITLE
fix(executor): strip provider prefix from versioned built-in tool model field

### DIFF
--- a/open-sse/executors/base.ts
+++ b/open-sse/executors/base.ts
@@ -820,9 +820,19 @@ export class BaseExecutor {
           // separately classified surface. Do not double-prepend here.
 
           // Real CLI never sets cache_control on tools.
+          // Also strip OmniRoute provider prefix from versioned built-in tool
+          // model fields (e.g. cc/claude-opus-4-8 → claude-opus-4-8).
           if (Array.isArray(tb.tools)) {
             for (const t of tb.tools as Array<Record<string, unknown>>) {
               delete t.cache_control;
+              if (
+                typeof t.type === "string" &&
+                /^[a-z][a-z0-9_]*_\d{8}$/.test(t.type) &&
+                typeof t.model === "string" &&
+                t.model.includes("/")
+              ) {
+                t.model = t.model.split("/").pop();
+              }
             }
           }
 

--- a/open-sse/services/claudeCodeCompatible.ts
+++ b/open-sse/services/claudeCodeCompatible.ts
@@ -748,6 +748,18 @@ function buildClaudeCodeCompatibleToolsFromClaude(
     if (!preserveCacheControl) {
       delete preparedTool.cache_control;
     }
+    // Versioned built-in tools (advisor_20260301, bash_20250124, etc.) carry a
+    // `model` field that the client may set to an OmniRoute-prefixed ID like
+    // "cc/claude-opus-4-8". Anthropic rejects the prefix — strip it to the
+    // bare upstream model ID.
+    if (
+      typeof preparedTool.type === "string" &&
+      /^[a-z][a-z0-9_]*_\d{8}$/.test(preparedTool.type) &&
+      typeof preparedTool.model === "string" &&
+      preparedTool.model.includes("/")
+    ) {
+      preparedTool.model = preparedTool.model.split("/").pop();
+    }
     return preparedTool;
   });
 }
@@ -776,6 +788,19 @@ function convertClaudeCodeCompatibleTool(tool: unknown) {
 
   if (typeof toolData.defer_loading === "boolean") {
     converted.defer_loading = toolData.defer_loading;
+  }
+
+  // Versioned built-in tools (advisor_20260301, bash_20250124, etc.) must have
+  // their `type` and `model` fields forwarded to Anthropic. The `model` field
+  // may carry an OmniRoute provider prefix (cc/, claude/) — strip it to the
+  // bare upstream ID.
+  if (typeof rawTool.type === "string" && /^[a-z][a-z0-9_]*_\d{8}$/.test(rawTool.type)) {
+    converted.type = rawTool.type;
+    if (typeof toolData.model === "string") {
+      converted.model = toolData.model.includes("/")
+        ? toolData.model.split("/").pop()
+        : toolData.model;
+    }
   }
 
   return converted;

--- a/open-sse/services/claudeCodeToolRemapper.ts
+++ b/open-sse/services/claudeCodeToolRemapper.ts
@@ -265,6 +265,12 @@ export function cloakThirdPartyToolNames(
   // not corrupt an input body that may be logged or replayed on fallback).
   if (Array.isArray(tools)) {
     body.tools = tools.map((tool) => {
+      // Anthropic versioned built-in tools (e.g. advisor_20260301, bash_20250124,
+      // computer_20250124) require their `name` field to match the type prefix
+      // exactly. Never cloak these — the API rejects any mutation.
+      if (tool && typeof tool.type === "string" && /^[a-z][a-z0-9_]*_\d{8}$/.test(tool.type)) {
+        return tool;
+      }
       if (tool && typeof tool.name === "string" && shouldCloak(tool.name)) {
         return { ...tool, name: aliasFor(tool.name) };
       }

--- a/tests/unit/claude-code-compatible-request.test.ts
+++ b/tests/unit/claude-code-compatible-request.test.ts
@@ -419,3 +419,62 @@ test("buildClaudeCodeCompatibleRequest covers string system input, non-array Cla
   assert.equal(stringSystem.tools.length, 0);
   assert.equal(stringSystem.system.at(-1).text, "custom system");
 });
+
+test("buildClaudeCodeCompatibleRequest strips OmniRoute prefix from versioned built-in tool model field (normalizedBody path)", () => {
+  const payload = buildClaudeCodeCompatibleRequest({
+    normalizedBody: {
+      messages: [{ role: "user", content: "hello" }],
+      tools: [
+        { type: "advisor_20260301", name: "advisor", model: "cc/claude-opus-4-8" },
+        { type: "bash_20250124", name: "bash", model: "claude/claude-sonnet-4-6" },
+        { name: "my_tool", input_schema: { type: "object", properties: {} } },
+      ],
+    },
+    model: "claude-opus-4-8",
+    cwd: "/tmp",
+    now: new Date("2026-01-02T12:00:00.000Z"),
+  });
+
+  const tools = payload.tools as Array<Record<string, unknown>>;
+  const advisor = tools.find((t) => t.type === "advisor_20260301");
+  const bash = tools.find((t) => t.type === "bash_20250124");
+  const myTool = tools.find((t) => t.name === "my_tool");
+
+  assert.equal(advisor?.model, "claude-opus-4-8", "advisor model prefix stripped");
+  assert.equal(bash?.model, "claude-sonnet-4-6", "bash model prefix stripped");
+  assert.equal("model" in (myTool ?? {}), false, "regular tool has no model field");
+});
+
+test("buildClaudeCodeCompatibleRequest strips OmniRoute prefix from versioned built-in tool model field (claudeBody path)", () => {
+  const payload = buildClaudeCodeCompatibleRequest({
+    claudeBody: {
+      messages: [{ role: "user", content: [{ type: "text", text: "hello" }] }],
+      tools: [
+        { type: "advisor_20260301", name: "advisor", model: "cc/claude-opus-4-8" },
+        { name: "Read", input_schema: { type: "object", properties: {} } },
+      ],
+    },
+    model: "claude-opus-4-8",
+    cwd: "/tmp",
+    now: new Date("2026-01-02T12:00:00.000Z"),
+  });
+
+  const tools = payload.tools as Array<Record<string, unknown>>;
+  const advisor = tools.find((t) => t.type === "advisor_20260301");
+  assert.equal(advisor?.model, "claude-opus-4-8", "advisor model prefix stripped via claudeBody path");
+});
+
+test("buildClaudeCodeCompatibleRequest preserves bare model on versioned built-in tool (no prefix)", () => {
+  const payload = buildClaudeCodeCompatibleRequest({
+    normalizedBody: {
+      messages: [{ role: "user", content: "hello" }],
+      tools: [{ type: "advisor_20260301", name: "advisor", model: "claude-opus-4-8" }],
+    },
+    model: "claude-opus-4-8",
+    cwd: "/tmp",
+    now: new Date("2026-01-02T12:00:00.000Z"),
+  });
+
+  const tools = payload.tools as Array<Record<string, unknown>>;
+  assert.equal(tools[0]?.model, "claude-opus-4-8", "bare model preserved unchanged");
+});

--- a/tests/unit/claude-oauth-tool-cloak.test.ts
+++ b/tests/unit/claude-oauth-tool-cloak.test.ts
@@ -244,6 +244,35 @@ describe("review fixes — schema sanitizer scalar / default / numeric", () => {
   });
 });
 
+describe("cloakThirdPartyToolNames — Anthropic versioned built-in tools", () => {
+  it("never cloaks advisor_20260301 — API requires name='advisor' exactly", () => {
+    const body: AnyRecord = { tools: [{ type: "advisor_20260301", name: "advisor" }] };
+    cloakThirdPartyToolNames(body);
+    assert.equal((body.tools as AnyRecord[])[0].name, "advisor");
+  });
+
+  it("never cloaks bash_20250124", () => {
+    const body: AnyRecord = { tools: [{ type: "bash_20250124", name: "bash" }] };
+    cloakThirdPartyToolNames(body);
+    assert.equal((body.tools as AnyRecord[])[0].name, "bash");
+  });
+
+  it("never cloaks computer_20250124", () => {
+    const body: AnyRecord = { tools: [{ type: "computer_20250124", name: "computer" }] };
+    cloakThirdPartyToolNames(body);
+    assert.equal((body.tools as AnyRecord[])[0].name, "computer");
+  });
+
+  it("still cloaks a regular snake_case tool alongside versioned built-ins", () => {
+    const body: AnyRecord = {
+      tools: [{ type: "advisor_20260301", name: "advisor" }, { name: "read_file" }],
+    };
+    cloakThirdPartyToolNames(body);
+    assert.equal((body.tools as AnyRecord[])[0].name, "advisor");
+    assert.equal((body.tools as AnyRecord[])[1].name, "Read");
+  });
+});
+
 describe("review fixes — established aliases + kill-switch", () => {
   it("uses the established Claude Code aliases on the cloak path", () => {
     const body: AnyRecord = {
@@ -268,5 +297,64 @@ describe("review fixes — established aliases + kill-switch", () => {
       if (prev === undefined) delete process.env.CLAUDE_DISABLE_TOOL_NAME_CLOAK;
       else process.env.CLAUDE_DISABLE_TOOL_NAME_CLOAK = prev;
     }
+  });
+});
+
+describe("native claude OAuth path — versioned built-in tool model prefix stripping", () => {
+  it("strips cc/ prefix from advisor_20260301 model field inline (simulates base.ts loop)", () => {
+    // Simulate the inline loop in BaseExecutor.execute() that mirrors the fix.
+    const tools: AnyRecord[] = [
+      { type: "advisor_20260301", name: "advisor", model: "cc/claude-opus-4-8" },
+      { type: "bash_20250124", name: "Bash", cache_control: { type: "ephemeral" } },
+      { name: "Read", input_schema: { type: "object", properties: {} } },
+    ];
+    for (const t of tools) {
+      delete t.cache_control;
+      if (
+        typeof t.type === "string" &&
+        /^[a-z][a-z0-9_]*_\d{8}$/.test(t.type as string) &&
+        typeof t.model === "string" &&
+        (t.model as string).includes("/")
+      ) {
+        t.model = (t.model as string).split("/").pop();
+      }
+    }
+    assert.equal(tools[0].model, "claude-opus-4-8", "cc/ prefix stripped from advisor model");
+    assert.equal("cache_control" in tools[1], false, "cache_control deleted from bash tool");
+    assert.equal("model" in tools[2], false, "regular tool untouched");
+  });
+
+  it("strips multi-segment prefix (claude/claude-sonnet-4-6) from versioned tool model", () => {
+    const tools: AnyRecord[] = [
+      { type: "bash_20250124", name: "Bash", model: "claude/claude-sonnet-4-6" },
+    ];
+    for (const t of tools) {
+      if (
+        typeof t.type === "string" &&
+        /^[a-z][a-z0-9_]*_\d{8}$/.test(t.type as string) &&
+        typeof t.model === "string" &&
+        (t.model as string).includes("/")
+      ) {
+        t.model = (t.model as string).split("/").pop();
+      }
+    }
+    assert.equal(tools[0].model, "claude-sonnet-4-6");
+  });
+
+  it("leaves bare model on versioned tool unchanged", () => {
+    const tools: AnyRecord[] = [
+      { type: "advisor_20260301", name: "advisor", model: "claude-opus-4-8" },
+    ];
+    for (const t of tools) {
+      if (
+        typeof t.type === "string" &&
+        /^[a-z][a-z0-9_]*_\d{8}$/.test(t.type as string) &&
+        typeof t.model === "string" &&
+        (t.model as string).includes("/")
+      ) {
+        t.model = (t.model as string).split("/").pop();
+      }
+    }
+    assert.equal(tools[0].model, "claude-opus-4-8");
   });
 });


### PR DESCRIPTION
## Summary

- Anthropic rejects requests where a versioned built-in tool (`advisor_20260301`, `bash_20250124`, etc.) carries an OmniRoute-prefixed `model` field like `cc/claude-opus-4-8`
- Three code paths fixed to strip the provider prefix down to the bare model ID
- Also fixes `cloakThirdPartyToolNames()` to skip versioned built-in tools (API rejects any name mutation on these)

## Root cause

When Claude Code sends an `advisor_20260301` tool with `model: "cc/claude-opus-4-8"`, OmniRoute was forwarding the `cc/` prefix verbatim to Anthropic's API, which returned `400: tools.104.model: cc/claude-opus-4-8`.

## Changes

| File | Fix |
|------|-----|
| `open-sse/executors/base.ts` | Strip prefix in the native claude OAuth execute path (the live path for `/advisor`) |
| `open-sse/services/claudeCodeCompatible.ts` | Strip prefix in the cc-bridge `claudeBody` and `normalizedBody` paths; also preserve `type` field for versioned tools |
| `open-sse/services/claudeCodeToolRemapper.ts` | Skip versioned built-in tools in `cloakThirdPartyToolNames()` |

## Test plan

- [ ] 48 unit tests pass (`claude-oauth-tool-cloak.test.ts`, `claude-code-compatible-request.test.ts`)
- [ ] `/advisor` mode works end-to-end without `400` errors