### PR TITLE
fix(usage): informative message instead of blank Kiro quota card when no usage breakdown (#3506)

### DIFF
--- a/open-sse/services/usage.ts
+++ b/open-sse/services/usage.ts
@@ -2729,6 +2729,55 @@ async function getCodexUsage(
 }
 
 /**
+ * Build the Kiro usage result from a GetUsageLimits response. When the account returns no
+ * usage breakdown (some AWS IAM / Builder ID accounts don't expose per-resource quota via
+ * GetUsageLimits), return an informative message instead of empty `quotas:{}` — otherwise the
+ * dashboard renders a blank quota card with no explanation (#3506). Exported for testing.
+ */
+export function buildKiroUsageResult(
+  data: JsonRecord
+): { plan: string; quotas: Record<string, UsageQuota> } | { message: string } {
+  const usageList = Array.isArray(data.usageBreakdownList) ? data.usageBreakdownList : [];
+  const quotaInfo: Record<string, UsageQuota> = {};
+  const resetAt = parseResetTime(data.nextDateReset || data.resetDate);
+
+  usageList.forEach((breakdownValue: unknown) => {
+    const breakdown = toRecord(breakdownValue);
+    const resourceType =
+      typeof breakdown.resourceType === "string" ? breakdown.resourceType.toLowerCase() : "unknown";
+    const used = toNumber(breakdown.currentUsageWithPrecision, 0);
+    const total = toNumber(breakdown.usageLimitWithPrecision, 0);
+
+    quotaInfo[resourceType] = { used, total, remaining: total - used, resetAt, unlimited: false };
+
+    const freeTrialInfo = toRecord(breakdown.freeTrialInfo);
+    if (Object.keys(freeTrialInfo).length > 0) {
+      const freeUsed = toNumber(freeTrialInfo.currentUsageWithPrecision, 0);
+      const freeTotal = toNumber(freeTrialInfo.usageLimitWithPrecision, 0);
+      quotaInfo[`${resourceType}_freetrial`] = {
+        used: freeUsed,
+        total: freeTotal,
+        remaining: freeTotal - freeUsed,
+        resetAt,
+        unlimited: false,
+      };
+    }
+  });
+
+  if (Object.keys(quotaInfo).length === 0) {
+    return {
+      message:
+        "Kiro connected, but the account returned no usage breakdown. Some AWS IAM / Builder ID accounts don't expose per-resource quota via GetUsageLimits.",
+    };
+  }
+
+  return {
+    plan: String(toRecord(data.subscriptionInfo).subscriptionTitle || "").trim() || "Kiro",
+    quotas: quotaInfo,
+  };
+}
+
+/**
  * Kiro (AWS CodeWhisperer) Usage
  */
 async function getKiroUsage(accessToken?: string, providerSpecificData?: JsonRecord) {
@@ -2762,51 +2811,7 @@ async function getKiroUsage(accessToken?: string, providerSpecificData?: JsonRec
     }
 
     const data = toRecord(await response.json());
-
-    // Parse usage data from usageBreakdownList
-    const usageList = Array.isArray(data.usageBreakdownList) ? data.usageBreakdownList : [];
-    const quotaInfo: Record<string, UsageQuota> = {};
-
-    // Parse reset time - supports multiple formats (nextDateReset, resetDate, etc.)
-    const resetAt = parseResetTime(data.nextDateReset || data.resetDate);
-
-    usageList.forEach((breakdownValue: unknown) => {
-      const breakdown = toRecord(breakdownValue);
-      const resourceType =
-        typeof breakdown.resourceType === "string"
-          ? breakdown.resourceType.toLowerCase()
-          : "unknown";
-      const used = toNumber(breakdown.currentUsageWithPrecision, 0);
-      const total = toNumber(breakdown.usageLimitWithPrecision, 0);
-
-      quotaInfo[resourceType] = {
-        used,
-        total,
-        remaining: total - used,
-        resetAt,
-        unlimited: false,
-      };
-
-      // Add free trial if available
-      const freeTrialInfo = toRecord(breakdown.freeTrialInfo);
-      if (Object.keys(freeTrialInfo).length > 0) {
-        const freeUsed = toNumber(freeTrialInfo.currentUsageWithPrecision, 0);
-        const freeTotal = toNumber(freeTrialInfo.usageLimitWithPrecision, 0);
-
-        quotaInfo[`${resourceType}_freetrial`] = {
-          used: freeUsed,
-          total: freeTotal,
-          remaining: freeTotal - freeUsed,
-          resetAt,
-          unlimited: false,
-        };
-      }
-    });
-
-    return {
-      plan: String(toRecord(data.subscriptionInfo).subscriptionTitle || "").trim() || "Kiro",
-      quotas: quotaInfo,
-    };
+    return buildKiroUsageResult(data);
   } catch (error) {
     throw new Error(`Failed to fetch Kiro usage: ${error.message}`);
   }

--- a/tests/unit/kiro-usage-empty-breakdown-3506.test.ts
+++ b/tests/unit/kiro-usage-empty-breakdown-3506.test.ts
@@ -1,0 +1,48 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { buildKiroUsageResult } from "@omniroute/open-sse/services/usage.ts";
+
+// Regression for #3506: a Kiro connection (e.g. via AWS IAM) whose GetUsageLimits response has
+// no usageBreakdownList produced `{ plan, quotas: {} }`, which the dashboard renders as a blank
+// quota card (the empty state) with no explanation. It must instead return an informative
+// `{ message }`, which the card surfaces via the connection-level message path. Accounts that DO
+// return a breakdown still get normalized quotas.
+
+test("#3506 empty usageBreakdownList returns an informative message, not empty quotas", () => {
+  const result = buildKiroUsageResult({ subscriptionInfo: { subscriptionTitle: "Kiro Pro" } });
+  assert.ok("message" in result, "must return a message when there is no breakdown");
+  assert.ok(!("quotas" in result), "must NOT return an empty quotas object (renders blank)");
+  assert.match((result as { message: string }).message, /no usage breakdown/i);
+});
+
+test("#3506 a real usageBreakdownList yields normalized quotas", () => {
+  const result = buildKiroUsageResult({
+    subscriptionInfo: { subscriptionTitle: "Kiro Pro" },
+    nextDateReset: "2026-07-01T00:00:00Z",
+    usageBreakdownList: [
+      { resourceType: "AGENTIC_REQUEST", currentUsageWithPrecision: 30, usageLimitWithPrecision: 100 },
+    ],
+  });
+  assert.ok("quotas" in result, "must return quotas when a breakdown is present");
+  const r = result as { plan: string; quotas: Record<string, { used: number; total: number; remaining: number }> };
+  assert.equal(r.plan, "Kiro Pro");
+  assert.equal(r.quotas.agentic_request.used, 30);
+  assert.equal(r.quotas.agentic_request.total, 100);
+  assert.equal(r.quotas.agentic_request.remaining, 70);
+});
+
+test("#3506 freeTrialInfo adds a _freetrial quota entry", () => {
+  const result = buildKiroUsageResult({
+    usageBreakdownList: [
+      {
+        resourceType: "AGENTIC_REQUEST",
+        currentUsageWithPrecision: 5,
+        usageLimitWithPrecision: 50,
+        freeTrialInfo: { currentUsageWithPrecision: 2, usageLimitWithPrecision: 10 },
+      },
+    ],
+  });
+  const r = result as { quotas: Record<string, { used: number; total: number }> };
+  assert.equal(r.quotas.agentic_request_freetrial.used, 2);
+  assert.equal(r.quotas.agentic_request_freetrial.total, 10);
+});


### PR DESCRIPTION
Closes #3506

**Problem:** a Kiro connection (reported with AWS IAM) showed a **blank** quota card. Root: `getKiroUsage` builds quotas from `usageBreakdownList`; when that's empty on an otherwise-successful GetUsageLimits call (seen with some AWS IAM / Builder ID accounts), it returned `{ plan, quotas: {} }` → the dashboard's empty-state (blank card, no explanation).

**Fix:** extracted a pure `buildKiroUsageResult(data)` that returns an informative `{ message }` when there's no breakdown (the card already surfaces a connection-level message), instead of empty `quotas`. Accounts that DO return a breakdown still get normalized quotas.

**Test (Rule #18):** `tests/unit/kiro-usage-empty-breakdown-3506.test.ts` — empty breakdown → message (RED on the old `quotas:{}`); real breakdown → normalized quotas; freeTrialInfo entry. usage suites green; typecheck clean.

**Caveat (transparent):** this removes the mysterious blank and explains it, but does NOT itself surface live quota for accounts that expose none via `usageBreakdownList`. If AWS IAM accounts DO have quota under a different field, that needs the live GetUsageLimits response to map — please share it (or a `/api/usage/<connectionId>` capture) and I'll wire it up.