### PR TITLE
feat(cli): add autostart on/off/toggle shorthand for headless serve mode (#3331)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### ✨ Added
+
+- **feat(cli):** `omniroute autostart` now accepts the shorthand the headless / `omniroute serve` path was missing — `omniroute autostart on` / `... true` (aliases of `enable`), `... off` / `... false` (aliases of `disable`), a new `... toggle`, and a default `... status` (bare `omniroute autostart` is a safe read-only). Previously autostart could only be toggled from the tray (`serve --tray`) or the Electron Appearance tab, so a plain `omniroute serve` user had no way to enable it. (The cross-platform launchd/systemd/registry logic is unchanged — this only wires the ergonomic CLI surface.) ([#3331](https://github.com/diegosouzapw/OmniRoute/issues/3331) — thanks @uniQta)
+
 ### ♻️ Code Quality
 
 - **refactor(chatCore):** extract the chatCore request phases — idempotency check, semantic cache check, common request sanitization, and memory/skills injection — into dedicated `open-sse/handlers/chatCore/` modules (`idempotency.ts`, `semanticCache.ts`, `sanitization.ts`, `memorySkillsInjection.ts`), slimming the monolithic handler with no behavior change. (Maintainer follow-up: re-derive `idempotencyKey` at the Phase 9.2 save site after the check moved into the module, fixing a `ReferenceError` on successful non-cached responses.) ([#3598](https://github.com/diegosouzapw/OmniRoute/pull/3598) — thanks @oyi77)

--- a/bin/cli/commands/autostart.mjs
+++ b/bin/cli/commands/autostart.mjs
@@ -6,8 +6,13 @@ export function registerAutostart(program) {
     .command("autostart")
     .description(t("autostart.description") || "Manage OmniRoute autostart at login");
 
+  // #3331 — autostart could previously only be toggled from the tray
+  // (`serve --tray`) or the Electron Appearance tab; a plain `omniroute serve`
+  // user had no path. These subcommands (with `on`/`off`/`true`/`false`
+  // aliases, e.g. `omniroute autostart on`) make it a first-class CLI action.
   cmd
     .command("enable")
+    .aliases(["on", "true"])
     .description(t("autostart.enable") || "Enable autostart at login")
     .action(async (opts, c) => {
       const globalOpts = c.optsWithGlobals();
@@ -19,6 +24,7 @@ export function registerAutostart(program) {
 
   cmd
     .command("disable")
+    .aliases(["off", "false"])
     .description(t("autostart.disable") || "Disable autostart at login")
     .action(async (opts, c) => {
       const globalOpts = c.optsWithGlobals();
@@ -29,7 +35,19 @@ export function registerAutostart(program) {
     });
 
   cmd
-    .command("status")
+    .command("toggle")
+    .description(t("autostart.toggle") || "Toggle autostart at login")
+    .action(async (opts, c) => {
+      const globalOpts = c.optsWithGlobals();
+      const { enable, disable, isAutostartEnabled } = await import("../tray/autostart.mjs");
+      const next = !isAutostartEnabled();
+      const ok = next ? enable() : disable();
+      emit(next ? { enabled: ok } : { disabled: ok }, globalOpts);
+      if (!ok) process.exit(1);
+    });
+
+  cmd
+    .command("status", { isDefault: true })
     .description(t("autostart.status") || "Show autostart status")
     .action(async (opts, c) => {
       const globalOpts = c.optsWithGlobals();

--- a/bin/cli/locales/en.json
+++ b/bin/cli/locales/en.json
@@ -1228,6 +1228,7 @@
     "description": "Manage OmniRoute autostart at boot (Linux: systemd user service)",
     "enable": "Enable autostart at boot",
     "disable": "Disable autostart at boot",
+    "toggle": "Toggle autostart at boot",
     "status": "Show autostart status"
   },
   "runtime": {

--- a/bin/cli/locales/pt-BR.json
+++ b/bin/cli/locales/pt-BR.json
@@ -1228,6 +1228,7 @@
     "description": "Gerenciar inicialização automática do OmniRoute no login",
     "enable": "Habilitar inicialização automática no login",
     "disable": "Desabilitar inicialização automática no login",
+    "toggle": "Alternar inicialização automática no login",
     "status": "Mostrar status de inicialização automática"
   },
   "runtime": {

--- a/tests/unit/autostart-cli-shorthand-3331.test.ts
+++ b/tests/unit/autostart-cli-shorthand-3331.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Regression test for #3331 — autostart could only be toggled from the tray
+ * (`serve --tray`) or the Electron Appearance tab; a plain `omniroute serve`
+ * user had no way to enable it. The `autostart` command now exposes the
+ * shorthand the reporter asked for (`omniroute autostart on` / `... true`) via
+ * aliases on the enable/disable subcommands, plus a `toggle` subcommand and a
+ * default `status`. This guards that command wiring (introspected, no platform
+ * side effects).
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { Command } from "commander";
+import { registerAutostart } from "../../bin/cli/commands/autostart.mjs";
+
+function buildAutostartCommand() {
+  const program = new Command();
+  registerAutostart(program);
+  const autostart = program.commands.find((c) => c.name() === "autostart");
+  assert.ok(autostart, "autostart command should be registered");
+  return autostart;
+}
+
+test("registers enable/disable/toggle/status subcommands", () => {
+  const names = buildAutostartCommand()
+    .commands.map((c) => c.name())
+    .sort();
+  assert.deepEqual(names, ["disable", "enable", "status", "toggle"]);
+});
+
+test("enable accepts the on/true shorthand aliases (reporter asked for `autostart true`)", () => {
+  const enable = buildAutostartCommand().commands.find((c) => c.name() === "enable");
+  assert.ok(enable.aliases().includes("on"), "`autostart on` should enable");
+  assert.ok(enable.aliases().includes("true"), "`autostart true` should enable");
+});
+
+test("disable accepts the off/false shorthand aliases", () => {
+  const disable = buildAutostartCommand().commands.find((c) => c.name() === "disable");
+  assert.ok(disable.aliases().includes("off"), "`autostart off` should disable");
+  assert.ok(disable.aliases().includes("false"), "`autostart false` should disable");
+});
+
+test("status is the default action (bare `omniroute autostart` is a safe read-only)", () => {
+  const status = buildAutostartCommand().commands.find((c) => c.name() === "status");
+  // Commander marks the default subcommand with `_defaultCommandName`.
+  assert.equal(buildAutostartCommand()._defaultCommandName, "status");
+  assert.ok(status, "status subcommand exists");
+});


### PR DESCRIPTION
Closes #3331

## Problem
Autostart could only be toggled from the tray (`omniroute serve --tray`) or the Electron Appearance tab (guarded behind `isElectron && window.electronAPI`). A plain `omniroute serve` / headless user had **no path** to enable autostart short of hand-writing a launchd plist / systemd unit. The reporter asked for `omniroute autostart true`.

## Fix
The cross-platform autostart logic already exists and is shipped (`bin/cli/tray/autostart.mjs` — launchd / systemd-user / XDG-desktop / Windows registry), and the `autostart enable|disable|status` subcommands already wrap it. This PR adds the **ergonomic shorthand** the reporter asked for, without touching the platform logic:
- `omniroute autostart on` / `... true` → aliases of `enable`
- `omniroute autostart off` / `... false` → aliases of `disable`
- `omniroute autostart toggle` → new subcommand (flips current state)
- `omniroute autostart` (bare) → default `status` (safe read-only)
- `autostart.toggle` i18n key added to en + pt-BR

> Scope note: the **non-Electron Web UI toggle** (an `/api/autostart` route) was deliberately left out — wiring it would mean refactoring the shipped, working, 3-platform autostart core into a Next-bundleable module (re-pointing `resolveCliPath()`'s `import.meta.url` math), a regression risk to the very feature this issue is about that can't be fully validated across macOS/Windows/Linux from CI. The CLI command fully covers the headless/serve gap the issue reports.

## Validation (Hard Rule #18 — TDD)
`tests/unit/autostart-cli-shorthand-3331.test.ts` (4 cases, RED→GREEN) introspects the registered command tree: enable/disable/toggle/status present; `enable` carries `on`/`true` aliases; `disable` carries `off`/`false`; `status` is the default. No platform side-effects in the test.

Verified live on this box: `autostart --help` lists `enable|on` / `disable|off` / `toggle` / `status`; `autostart status` prints the status table; `autostart on --help` resolves to the enable subcommand. `check:cli-i18n` PASS, `eslint` clean (bin/ ignored), `prettier --check` clean.

Co-authored-by: uniQta <uniQta@users.noreply.github.com>