### PR TITLE
fix(guardrails): use validateBody() in /api/guardrails/test route

### DIFF
--- a/src/app/api/guardrails/test/route.ts
+++ b/src/app/api/guardrails/test/route.ts
@@ -14,6 +14,7 @@ import { CORS_HEADERS, handleCorsOptions } from "@/shared/utils/cors";
 import { createErrorResponse } from "@/lib/api/errorResponse";
 import { requireManagementAuth } from "@/lib/api/requireManagementAuth";
 import { registerDefaultGuardrails } from "@/lib/guardrails/registry";
+import { validateBody, isValidationFailure } from "@/shared/validation/helpers";
 
 const TestRequestSchema = z.object({
   input: z.union([z.string(), z.record(z.unknown()), z.array(z.unknown())]),
@@ -28,16 +29,18 @@ export async function POST(request: NextRequest) {
   const authError = await requireManagementAuth(request);
   if (authError) return authError;
 
-  let parsed: z.infer<typeof TestRequestSchema>;
+  let rawBody: unknown;
   try {
-    parsed = TestRequestSchema.parse(await request.json());
+    rawBody = await request.json();
   } catch {
-    return createErrorResponse({
-      status: 400,
-      message: "Invalid request body — expected { input: string | object | array, disabledGuardrails?: string[] }",
-      type: "invalid_request",
-    });
+    return createErrorResponse({ status: 400, message: "Invalid JSON body", type: "invalid_request" });
   }
+
+  const validation = validateBody(TestRequestSchema, rawBody);
+  if (isValidationFailure(validation)) {
+    return createErrorResponse({ status: 400, message: "Invalid request body — expected { input: string | object | array, disabledGuardrails?: string[] }", type: "invalid_request" });
+  }
+  const parsed = validation.data;
 
   const registry = registerDefaultGuardrails();
   const outcome = await registry.runPreCallHooks(parsed.input, {


### PR DESCRIPTION
Fixes CI failure on main (check:route-validation:t06).

The route was using `TestRequestSchema.parse(await request.json())` directly, which is flagged by the gate. Replaced with the canonical `validateBody()` + `isValidationFailure()` pattern from `@/shared/validation/helpers`.