### PR TITLE
fix(ci): increase execFileSync maxBuffer in validate-pack-artifact

### DIFF
--- a/scripts/build/validate-pack-artifact.ts
+++ b/scripts/build/validate-pack-artifact.ts
@@ -25,6 +25,7 @@ function runNpm(args: string[], stdio: "inherit" | "pipe" = "pipe"): string {
     cwd: ROOT,
     encoding: "utf8",
     stdio: stdio === "inherit" ? "inherit" : ["ignore", "pipe", "pipe"],
+    maxBuffer: 64 * 1024 * 1024,
   });
 }
 


### PR DESCRIPTION
Fixes ENOBUFS failure in `check:pack-artifact` ("Publish to npm" CI job).

`npm pack --dry-run --json` on this project generates more than 1 MB of output, exhausting Node's default `execFileSync` buffer. Setting `maxBuffer: 64 * 1024 * 1024` resolves the transient failure.