### PR TITLE
fix(ci): align pack-artifact-policy with v3.8.21 package.json files expansion

### DIFF
--- a/scripts/build/pack-artifact-policy.ts
+++ b/scripts/build/pack-artifact-policy.ts
@@ -101,10 +101,16 @@ export const PACK_ARTIFACT_ROOT_ALLOWED_PATH_PREFIXES: string[] = [
   "@omniroute/opencode-plugin/",
   "@omniroute/opencode-provider/",
   "bin/cli/",
-  "open-sse/mcp-server/schemas/",
-  "open-sse/mcp-server/tools/",
-  "src/lib/cli-helper/",
-  "src/shared/contracts/",
+  // Broad open-sse + src source dirs added to package.json "files" in v3.8.21
+  // to allow TypeScript-first imports from the published package.
+  "open-sse/",
+  "src/domain/",
+  "src/lib/",
+  "src/mitm/",
+  "src/server/",
+  "src/shared/",
+  "src/sse/",
+  "src/types/",
 ];
 
 export const PACK_ARTIFACT_REQUIRED_PATHS: string[] = [

--- a/scripts/build/validate-pack-artifact.ts
+++ b/scripts/build/validate-pack-artifact.ts
@@ -25,6 +25,7 @@ function runNpm(args: string[], stdio: "inherit" | "pipe" = "pipe"): string {
     cwd: ROOT,
     encoding: "utf8",
     stdio: stdio === "inherit" ? "inherit" : ["ignore", "pipe", "pipe"],
+    maxBuffer: 64 * 1024 * 1024,
   });
 }
 


### PR DESCRIPTION
Fixes CI failures in 'Publish to npm' and Electron workflows.

v3.8.21 expanded `package.json files` to include `open-sse/` and `src/domain/` + `src/lib/` + `src/mitm/` + `src/server/` + `src/shared/` + `src/sse/` + `src/types/` (TypeScript-first imports), but `pack-artifact-policy.ts` was not updated. This PR adds the new path prefixes to `PACK_ARTIFACT_ROOT_ALLOWED_PATH_PREFIXES` and also increases `execFileSync maxBuffer` to 64 MB to prevent ENOBUFS on large `npm pack --dry-run --json` output.