### PR TITLE
docs: add FUNDING.yml + README Support section

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,5 @@
+# Funding links for OmniRoute — rendered as the "Sponsor" button on GitHub.
+# Docs: https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+github: diegosouzapw
+# Additional platforms (uncomment and fill in before enabling):
+# custom: ["https://omniroute.online/donate"]

--- a/README.md
+++ b/README.md
@@ -1013,6 +1013,14 @@ Special thanks to **[RTK - Rust Token Killer](https://github.com/rtk-ai/rtk)** b
 
 Special thanks to **[Troglodita](https://github.com/leninejunior/troglodita)** by **[Lenine Júnior](https://github.com/leninejunior)** — the PT-BR token compression project ("por que gastar muitos tokens quando poucos resolve?") whose Portuguese-native rules power OmniRoute's pt-BR language pack: pleonasm reduction, filler removal tuned for Brazilian Portuguese grammar, and technical abbreviations for the dev BR community.
 
+## ❤️ Support
+
+OmniRoute is free and open source, built and maintained in the open. If it saves you time or money, consider supporting development:
+
+- ⭐ **Star the repo** — it genuinely helps visibility
+- 💖 **[GitHub Sponsors](https://github.com/sponsors/diegosouzapw)** — fund ongoing maintenance and new providers
+- 🐛 **Report bugs and share feedback** in [Discussions](https://github.com/diegosouzapw/OmniRoute/discussions)
+
 ## 📄 License
 
 MIT License - see [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Summary

- Adds `.github/FUNDING.yml` with GitHub Sponsors (`github: diegosouzapw`) so the repo renders the **Sponsor** button (takes effect when it reaches `main` at release time).
- Adds a short **❤️ Support** section to the README (star + sponsors + discussions links), inserted right before the License section.

Suggested by @markbakaa88 in discussion #3607.

## Notes for review

- `FUNDING.yml` has a commented `custom:` line — fill in Pix/donate links if you want them (e.g. `https://omniroute.online/donate`) before or after merge.
- The Sponsor button only renders if the GitHub Sponsors profile for `diegosouzapw` is enrolled; otherwise the file is inert (no error).
- Docs-only change, no production code → no tests (Rule #8 n/a).