### PR TITLE
fix: stream combo fails over on empty content-filtered response (#3685)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## [3.8.23] — TBD
 
+- fix: streaming combos now fail over to the next target when an upstream returns an empty/content-filtered response instead of surfacing a blank reply (#3685)
+
 ---
 
 ## [3.8.22] — 2026-06-11

--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -446,7 +446,211 @@ export async function validateResponseQuality(
   isStreaming: boolean,
   log: { warn?: (...args: unknown[]) => void }
 ): Promise<{ valid: boolean; reason?: string; clonedResponse?: Response }> {
-  if (isStreaming) return { valid: true };
+  // Issue #3685: For Claude SSE streaming responses, use a BOUNDED PEEK to
+  // detect the empty-content-block pattern (content_filter stop_reason with
+  // no content_block_* events) WITHOUT de-streaming non-empty responses.
+  //
+  // Strategy:
+  // - Read chunks from response.body one at a time, accumulating raw bytes.
+  // - Parse SSE events incrementally.
+  // - If a content_block_* event appears → stream HAS content. Stop buffering.
+  //   Return a clonedResponse whose body replays buffered bytes then pipes the
+  //   remainder of the original reader. Only the chunks up to the first content
+  //   block were held in memory — the rest stream normally.
+  // - If the stream ends with a complete Claude lifecycle but NO content_block
+  //   → return invalid (combo failover). The empty lifecycle is tiny so fully
+  //   reading it is acceptable.
+  // - If the stream ends without a recognisable complete Claude lifecycle →
+  //   return valid with a clonedResponse replaying all buffered bytes (don't
+  //   misclassify non-Claude or partial streams as empty).
+  //
+  // Non-text/event-stream streaming responses are not buffered at all.
+  if (isStreaming) {
+    const contentType = response.headers.get("content-type") || "";
+    if (!contentType.includes("text/event-stream")) {
+      return { valid: true };
+    }
+
+    if (!response.body) {
+      return { valid: true };
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder("utf-8");
+
+    // Raw Uint8Array chunks accumulated so far — used to replay the prefix
+    // in the returned clonedResponse.
+    const bufferedChunks: Uint8Array[] = [];
+    // Decoded text accumulated across chunks for incremental SSE parsing.
+    // Only the tail of the most-recently-processed line window remains here
+    // between iterations (incomplete lines are deferred to the next chunk).
+    let decodedSoFar = "";
+
+    // SSE lifecycle state.
+    let hasMessageStart = false;
+    let hasContentBlock = false;
+    let hasLifecycleEnd = false;
+    // `event:` type line seen before the next `data:` line in the same event.
+    let pendingEventType = "";
+
+    /**
+     * Parse any complete SSE lines from `decodedSoFar`, updating lifecycle
+     * flags in the closure. The last (potentially incomplete) line is kept in
+     * `decodedSoFar` for the next iteration.
+     *
+     * Returns true when a content_block_* event is detected — the caller
+     * should stop peeking and treat the stream as non-empty.
+     */
+    function parseAccumulatedSse(): boolean {
+      const lines = decodedSoFar.split(/\r?\n/);
+      // Retain the potentially-incomplete trailing fragment.
+      decodedSoFar = lines[lines.length - 1];
+
+      for (let i = 0; i < lines.length - 1; i++) {
+        const trimmed = lines[i].trim();
+
+        if (trimmed.startsWith("event:")) {
+          pendingEventType = trimmed.slice(6).trim();
+          continue;
+        }
+
+        if (!trimmed.startsWith("data:")) {
+          if (!trimmed) pendingEventType = "";
+          continue;
+        }
+
+        const data = trimmed.slice(5).trim();
+        if (!data || data === "[DONE]") continue;
+
+        let parsed: Record<string, unknown>;
+        try {
+          parsed = JSON.parse(data);
+        } catch {
+          continue;
+        }
+
+        const eventType =
+          (typeof parsed.type === "string" ? parsed.type : null) || pendingEventType || "";
+        pendingEventType = "";
+
+        switch (eventType) {
+          case "message_start":
+            hasMessageStart = true;
+            break;
+          case "content_block_start":
+          case "content_block_delta":
+          case "content_block_stop":
+            hasContentBlock = true;
+            // Signal caller to stop buffering immediately.
+            return true;
+          case "message_stop":
+            hasLifecycleEnd = true;
+            break;
+          case "message_delta": {
+            const delta = parsed.delta;
+            if (
+              delta &&
+              typeof delta === "object" &&
+              (delta as Record<string, unknown>).stop_reason != null
+            ) {
+              hasLifecycleEnd = true;
+            }
+            break;
+          }
+          default:
+            break;
+        }
+      }
+      return false;
+    }
+
+    /**
+     * Build a Response whose body first replays all bytes in `bufferedChunks`,
+     * then forwards the remainder of `readerToForward` chunk-by-chunk.
+     * Preserves the original response's status, statusText, and headers.
+     */
+    function buildReplayResponse(
+      readerToForward: ReadableStreamDefaultReader<Uint8Array>
+    ): Response {
+      // Snapshot the prefix so mutations after this point don't affect it.
+      const prefix = bufferedChunks.slice();
+      let prefixIdx = 0;
+      const stream = new ReadableStream<Uint8Array>({
+        async pull(controller) {
+          // 1. Drain the buffered prefix one chunk at a time.
+          if (prefixIdx < prefix.length) {
+            controller.enqueue(prefix[prefixIdx++]);
+            return;
+          }
+          // 2. Forward the remainder from the original reader.
+          try {
+            const { done, value } = await readerToForward.read();
+            if (done) {
+              controller.close();
+            } else {
+              controller.enqueue(value);
+            }
+          } catch {
+            controller.close();
+          }
+        },
+      });
+      return new Response(stream, {
+        status: response.status,
+        statusText: response.statusText,
+        headers: response.headers,
+      });
+    }
+
+    // Main bounded-peek loop.
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+
+        if (done) {
+          // Stream finished — flush the TextDecoder and parse any remaining text.
+          const tail = decoder.decode(undefined, { stream: false });
+          if (tail) decodedSoFar += tail;
+          parseAccumulatedSse();
+
+          if (hasMessageStart && hasLifecycleEnd && !hasContentBlock) {
+            // Complete Claude lifecycle with zero content blocks → failover.
+            log.warn?.(
+              "COMBO",
+              "Streaming Claude response has complete lifecycle but zero content blocks (content_filter?) — marking as invalid for combo failover"
+            );
+            return { valid: false, reason: "streaming empty content block" };
+          }
+
+          // Incomplete lifecycle or non-Claude stream — replay all buffered
+          // bytes. The reader is exhausted so the forwarding reader will
+          // immediately signal done.
+          const clonedResponse = buildReplayResponse(reader);
+          return { valid: true, clonedResponse };
+        }
+
+        // Accumulate raw bytes for potential replay.
+        bufferedChunks.push(value);
+
+        // Decode incrementally (stream:true keeps multi-byte char state).
+        decodedSoFar += decoder.decode(value, { stream: true });
+        const foundContent = parseAccumulatedSse();
+
+        if (foundContent) {
+          // A content_block_* event was found — stop peeking. Return a
+          // clonedResponse that replays all buffered bytes (the current chunk
+          // is already in bufferedChunks) and then forwards the remainder of
+          // the original reader unchanged.
+          const clonedResponse = buildReplayResponse(reader);
+          return { valid: true, clonedResponse };
+        }
+      }
+    } catch {
+      // If reading the stream fails, pass through — other mechanisms
+      // (stream readiness timeout) will catch truly broken streams.
+      return { valid: true };
+    }
+  }
 
   const contentType = response.headers.get("content-type") || "";
   if (!contentType.includes("application/json") && !contentType.includes("text/")) {

--- a/tests/unit/combo-streaming-empty-content-failover.test.ts
+++ b/tests/unit/combo-streaming-empty-content-failover.test.ts
@@ -1,0 +1,283 @@
+/**
+ * Issue #3685 — streaming combos must fail over to the next target when the
+ * upstream Claude stream emits a complete lifecycle (message_start →
+ * message_delta with stop_reason → message_stop) but ZERO content_block_*
+ * events (e.g. content_filter). Previously `validateResponseQuality` returned
+ * `{ valid: true }` for ALL streaming responses, so the combo loop never saw
+ * the empty response as a failure and never advanced to the next target.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { validateResponseQuality } = await import("../../open-sse/services/combo.ts");
+
+const encoder = new TextEncoder();
+const silentLog = { warn: () => {} };
+
+/** Build a ReadableStream from an array of SSE-formatted strings (single chunk). */
+function claudeSseStream(events: string[]): ReadableStream<Uint8Array> {
+  const body = events.join("\n") + "\n";
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode(body));
+      controller.close();
+    },
+  });
+}
+
+/**
+ * Build a ReadableStream that emits each SSE event as a SEPARATE chunk,
+ * simulating a real incremental network delivery.
+ */
+function claudeSseStreamMultiChunk(events: string[]): ReadableStream<Uint8Array> {
+  const chunks = events.map((e) => encoder.encode(e + "\n"));
+  let idx = 0;
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (idx < chunks.length) {
+        controller.enqueue(chunks[idx++]);
+      } else {
+        controller.close();
+      }
+    },
+  });
+}
+
+/** Build a mock Claude 200 streaming response with no content blocks (content_filter case). */
+function makeEmptyClaudeStream(): Response {
+  const events = [
+    `event: message_start\ndata: ${JSON.stringify({
+      type: "message_start",
+      message: {
+        id: "msg_test_empty",
+        type: "message",
+        role: "assistant",
+        model: "claude-sonnet-4-6",
+        content: [],
+        stop_reason: null,
+        stop_sequence: null,
+        usage: { input_tokens: 10, output_tokens: 0 },
+      },
+    })}`,
+    "",
+    `event: message_delta\ndata: ${JSON.stringify({
+      type: "message_delta",
+      delta: { stop_reason: "content_filter", stop_sequence: null },
+      usage: { input_tokens: 0, output_tokens: 0 },
+    })}`,
+    "",
+    `event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}`,
+    "",
+  ];
+
+  return new Response(claudeSseStream(events), {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+/** Build a mock Claude 200 streaming response WITH a content block (normal case). */
+function makeNonEmptyClaudeStream(): Response {
+  const events = [
+    `event: message_start\ndata: ${JSON.stringify({
+      type: "message_start",
+      message: {
+        id: "msg_test_content",
+        type: "message",
+        role: "assistant",
+        model: "claude-sonnet-4-6",
+        content: [],
+        stop_reason: null,
+        stop_sequence: null,
+        usage: { input_tokens: 10, output_tokens: 0 },
+      },
+    })}`,
+    "",
+    `event: content_block_start\ndata: ${JSON.stringify({
+      type: "content_block_start",
+      index: 0,
+      content_block: { type: "text", text: "" },
+    })}`,
+    "",
+    `event: content_block_delta\ndata: ${JSON.stringify({
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "text_delta", text: "Hello, world!" },
+    })}`,
+    "",
+    `event: content_block_stop\ndata: ${JSON.stringify({
+      type: "content_block_stop",
+      index: 0,
+    })}`,
+    "",
+    `event: message_delta\ndata: ${JSON.stringify({
+      type: "message_delta",
+      delta: { stop_reason: "end_turn", stop_sequence: null },
+      usage: { input_tokens: 0, output_tokens: 5 },
+    })}`,
+    "",
+    `event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}`,
+    "",
+  ];
+
+  return new Response(claudeSseStream(events), {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test("#3685 empty Claude stream (content_filter, no content blocks) is marked invalid", async () => {
+  const res = makeEmptyClaudeStream();
+  const out = await validateResponseQuality(res, true, silentLog);
+  assert.equal(
+    out.valid,
+    false,
+    `expected invalid for empty content-filtered stream, got valid=true (reason: ${out.reason})`
+  );
+  assert.match(
+    out.reason ?? "",
+    /empty/i,
+    `reason should mention 'empty', got: "${out.reason}"`
+  );
+});
+
+test("#3685 non-empty Claude stream (has content blocks) remains valid", async () => {
+  const res = makeNonEmptyClaudeStream();
+  const out = await validateResponseQuality(res, true, silentLog);
+  assert.equal(
+    out.valid,
+    true,
+    `expected valid for non-empty stream, got invalid: ${out.reason}`
+  );
+  // The clonedResponse must be present so the combo loop can pipe the stream body
+  assert.ok(out.clonedResponse, "clonedResponse must be returned for valid streaming response");
+  assert.ok(out.clonedResponse!.body, "clonedResponse must have a body stream");
+});
+
+test("#3685 non-SSE streaming response (e.g. plain JSON 200) still passes through as valid", async () => {
+  // A streaming=true call that returns plain JSON is not our target — preserve existing behavior.
+  const res = new Response(JSON.stringify({ choices: [{ message: { content: "ok" } }] }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+  const out = await validateResponseQuality(res, true, silentLog);
+  assert.equal(out.valid, true, "non-SSE streaming response should still be valid");
+});
+
+test("#3685 empty Claude stream without message_start lifecycle → valid (incomplete lifecycle, not content_filter)", async () => {
+  // A stream that only has partial events (e.g. disconnected before message_start)
+  // should not trigger the failover since the lifecycle isn't complete — this is
+  // handled by other mechanisms (stream readiness timeout).
+  const partialEvents = [
+    `event: ping\ndata: ${JSON.stringify({ type: "ping" })}`,
+    "",
+  ];
+  const res = new Response(claudeSseStream(partialEvents), {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+  const out = await validateResponseQuality(res, true, silentLog);
+  assert.equal(out.valid, true, "incomplete lifecycle (no message_start) should pass through");
+});
+
+test("#3685 streaming is preserved for non-empty response: clonedResponse body yields full original SSE byte sequence in order", async () => {
+  // Use a multi-chunk stream to simulate real incremental delivery.
+  // The content_block_start arrives in its own chunk so the peek loop can
+  // detect it mid-stream and stop buffering — the rest should forward via
+  // the original reader.
+  const events = [
+    `event: message_start\ndata: ${JSON.stringify({
+      type: "message_start",
+      message: {
+        id: "msg_multipart",
+        type: "message",
+        role: "assistant",
+        model: "claude-sonnet-4-6",
+        content: [],
+        stop_reason: null,
+        stop_sequence: null,
+        usage: { input_tokens: 5, output_tokens: 0 },
+      },
+    })}`,
+    "",
+    `event: content_block_start\ndata: ${JSON.stringify({
+      type: "content_block_start",
+      index: 0,
+      content_block: { type: "text", text: "" },
+    })}`,
+    "",
+    `event: content_block_delta\ndata: ${JSON.stringify({
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "text_delta", text: "Hello" },
+    })}`,
+    "",
+    `event: content_block_delta\ndata: ${JSON.stringify({
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "text_delta", text: ", world!" },
+    })}`,
+    "",
+    `event: content_block_stop\ndata: ${JSON.stringify({ type: "content_block_stop", index: 0 })}`,
+    "",
+    `event: message_delta\ndata: ${JSON.stringify({
+      type: "message_delta",
+      delta: { stop_reason: "end_turn", stop_sequence: null },
+      usage: { input_tokens: 0, output_tokens: 7 },
+    })}`,
+    "",
+    `event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}`,
+    "",
+  ];
+
+  // Build the original byte sequence for comparison.
+  const originalBody = events.map((e) => e + "\n").join("");
+  const originalBytes = encoder.encode(originalBody);
+
+  const res = new Response(claudeSseStreamMultiChunk(events), {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+
+  const out = await validateResponseQuality(res, true, silentLog);
+
+  assert.equal(out.valid, true, "non-empty multi-chunk stream must be valid");
+  assert.ok(out.clonedResponse, "clonedResponse must be present");
+  assert.ok(out.clonedResponse!.body, "clonedResponse must have a readable body");
+
+  // Drain the clonedResponse body and reconstruct the full byte sequence.
+  const reader = out.clonedResponse!.body!.getReader();
+  const receivedChunks: Uint8Array[] = [];
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    receivedChunks.push(value);
+  }
+  const totalLength = receivedChunks.reduce((sum, c) => sum + c.length, 0);
+  const reconstructed = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const chunk of receivedChunks) {
+    reconstructed.set(chunk, offset);
+    offset += chunk.length;
+  }
+
+  // The reconstructed bytes must exactly match the original SSE byte sequence —
+  // no data is lost, duplicated, or reordered by the bounded-peek mechanism.
+  assert.deepEqual(
+    reconstructed,
+    originalBytes,
+    "clonedResponse body must reproduce the FULL original SSE byte sequence (buffered prefix + piped remainder = original)"
+  );
+
+  // Verify the response carries SSE content blocks in the decoded text,
+  // confirming real content was streamed through.
+  const decoded = new TextDecoder().decode(reconstructed);
+  assert.ok(decoded.includes("content_block_start"), "decoded body must contain content_block_start");
+  assert.ok(decoded.includes("Hello"), "decoded body must contain the actual text content");
+  assert.ok(decoded.includes(", world!"), "decoded body must contain the full text delta");
+});


### PR DESCRIPTION
Closes #3685

Streaming combos returned a blank/empty reply instead of failing over when an upstream emitted a complete Claude lifecycle (message_start → message_delta(stop_reason) → message_stop) with **zero content blocks** (content_filter). `validateResponseQuality` had `if(isStreaming) return {valid:true}`, skipping the check.

**Fix:** bounded-peek in `validateResponseQuality` — reads SSE chunks only until the first `content_block_*` event; if found, returns a clonedResponse that replays the buffered prefix then pipes the remainder of the original stream (streaming preserved, NOT fully buffered). If the stream ends with a complete lifecycle but no content block → `valid:false` → combo fails over.

**Regression test:** `tests/unit/combo-streaming-empty-content-failover.test.ts` (5 tests incl. byte-exact streaming-preservation assertion). typecheck:core + lint clean.