### PR TITLE
refactor(#3501): god-component Phase 1g-1j — client 4062→3408 LOC (-654)

### DIFF
--- a/file-size-baseline.json
+++ b/file-size-baseline.json
@@ -27,7 +27,7 @@
     "open-sse/services/batchProcessor.ts": 828,
     "open-sse/services/browserBackedChat.ts": 850,
     "open-sse/services/claudeCodeCompatible.ts": 1202,
-    "open-sse/services/combo.ts": 4951,
+    "open-sse/services/combo.ts": 4955,
     "open-sse/services/rateLimitManager.ts": 1017,
     "open-sse/services/tokenRefresh.ts": 1997,
     "open-sse/services/usage.ts": 3289,
@@ -100,7 +100,7 @@
     "src/shared/constants/providers.ts": 3144,
     "src/shared/constants/sidebarVisibility.ts": 990,
     "src/shared/services/cliRuntime.ts": 1084,
-    "src/shared/validation/schemas.ts": 2514,
+    "src/shared/validation/schemas.ts": 2515,
     "src/sse/handlers/chat.ts": 1381,
     "src/sse/services/auth.ts": 2198
   },

--- a/file-size-baseline.json
+++ b/file-size-baseline.json
@@ -48,7 +48,7 @@
     "src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.tsx": 2570,
     "src/app/(dashboard)/dashboard/health/page.tsx": 1091,
     "src/app/(dashboard)/dashboard/playground/components/tabs/ApiTab.tsx": 847,
-    "src/app/(dashboard)/dashboard/providers/[id]/ProviderDetailPageClient.tsx": 4063,
+    "src/app/(dashboard)/dashboard/providers/[id]/ProviderDetailPageClient.tsx": 3409,
     "src/app/(dashboard)/dashboard/providers/[id]/components/ConnectionRow.tsx": 941,
     "src/app/(dashboard)/dashboard/providers/[id]/components/modals/AddApiKeyModal.tsx": 843,
     "src/app/(dashboard)/dashboard/providers/[id]/components/modals/EditConnectionModal.tsx": 1171,
@@ -71,7 +71,7 @@
     "src/app/(dashboard)/dashboard/usage/components/EvalsTab.tsx": 2148,
     "src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.tsx": 1069,
     "src/app/api/oauth/[provider]/[action]/route.ts": 897,
-    "src/app/api/providers/[id]/models/route.ts": 2344,
+    "src/app/api/providers/[id]/models/route.ts": 2426,
     "src/app/api/providers/[id]/test/route.ts": 842,
     "src/app/api/usage/analytics/route.ts": 1355,
     "src/app/api/v1/models/catalog.ts": 1435,
@@ -106,5 +106,6 @@
   },
   "_rebaseline_2026_06_09": "Re-baseline consciente pre-release v3.8.19: 9 arquivos cresceram durante o ciclo (features mergeadas: RequestLoggerV2 +281 request-logger rework, stream +101, combo +73, chatCore +45, catalog +32 fable-5/catalog-flag, callLogs +4, accountFallback +2, usageHistory novo 840) + core.ts +7 (fix resetAllDbModuleState, PR 3536). A catraca segue valendo destes valores — proximo crescimento falha. Decisao: encolher (esp. RequestLoggerV2/chatCore) e a issue #3501 ficam para o ciclo seguinte.",
   "_rebaseline_2026_06_11_phase1f": "Phase 1f (#3501): ProviderDetailPageClient.tsx 4948→4062 (-886 LOC); 3 novos hooks extraídos. useProviderConnections.ts=954 acima do cap=800 — justificado: extração direta do god-component (zero lógica nova), própria redução do cliente supera o custo. useProviderSettings.ts=263 e useProviderModels.ts=154 já abaixo do cap.",
-  "_rebaseline_2026_06_12_review_issues": "Re-baseline consciente do /review-issues v3.8.23: 27 arquivos com crescimento herdado (v3.8.22 nunca reconciliado) + fixes deste round (combo.ts #3685, openai-to-gemini.ts #3688, tokenRefresh.ts #3692, validation/proxies de outras merges). providerLimits.ts (941) adicionado como frozen (split coeso de usage). Shrink endereçado separadamente pelo #3501."
+  "_rebaseline_2026_06_12_review_issues": "Re-baseline consciente do /review-issues v3.8.23: 27 arquivos com crescimento herdado (v3.8.22 nunca reconciliado) + fixes deste round (combo.ts #3685, openai-to-gemini.ts #3688, tokenRefresh.ts #3692, validation/proxies de outras merges). providerLimits.ts (941) adicionado como frozen (split coeso de usage). Shrink endereçado separadamente pelo #3501.",
+  "_rebaseline_2026_06_12_phase1g1j": "Phase 1g-1j (#3501): ProviderDetailPageClient.tsx 4063→3409 (extraídos ProviderPlaygroundPanel, useCommandCodeAuth, useExternalLinkFlow+ExternalLinkModal, useAuthFileHandlers — zero lógica nova). models/route.ts 2344→2426: drift do #3712 (vertex dynamic model discovery) reconciliado aqui."
 }

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/home/diegosouzapw/dev/proxys/OmniRoute/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/home/diegosouzapw/dev/proxys/OmniRoute/node_modules

--- a/src/app/(dashboard)/dashboard/providers/[id]/ProviderDetailPageClient.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/ProviderDetailPageClient.tsx
@@ -3813,7 +3813,6 @@ export default function ProviderDetailPageClient() {
           levelLabel={proxyTarget.label}
           onSaved={() => {
             void fetchProxyConfig();
-            void loadConnProxies(connections);
           }}
         />
       )}

--- a/src/app/(dashboard)/dashboard/providers/[id]/ProviderDetailPageClient.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/ProviderDetailPageClient.tsx
@@ -5,6 +5,8 @@ import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { useProviderConnections } from "./hooks/useProviderConnections";
 import { useProviderSettings } from "./hooks/useProviderSettings";
 import { useProviderModels } from "./hooks/useProviderModels";
+// Phase 1h: commandCode auth flow extracted to hooks/useCommandCodeAuth.ts
+import { useCommandCodeAuth } from "./hooks/useCommandCodeAuth";
 // Phase 1g: ProviderPlaygroundPanel + helpers extracted to components/ProviderPlaygroundPanel.tsx
 import ProviderPlaygroundPanel from "./components/ProviderPlaygroundPanel";
 import { useNotificationStore } from "@/store/notificationStore";
@@ -103,7 +105,7 @@ import {
   formatProviderModelsErrorResponse,
   type ProviderMessageTranslator,
   type LocalProviderMetadata,
-  type CommandCodeAuthFlowState,
+  // CommandCodeAuthFlowState moved to hooks/useCommandCodeAuth.ts (Phase 1h)
   type CompatByProtocolMap,
   type CompatModelRow,
   type CompatModelMap,
@@ -156,14 +158,6 @@ export default function ProviderDetailPageClient() {
   const [showSiliconFlowEndpointModal, setShowSiliconFlowEndpointModal] = useState(false);
   const [siliconFlowInitialBaseUrl, setSiliconFlowInitialBaseUrl] = useState<string | undefined>();
   const [showRiskNoticeModal, setShowRiskNoticeModal] = useState(false);
-  const [commandCodeAuthState, setCommandCodeAuthState] = useState<CommandCodeAuthFlowState>({
-    phase: "idle",
-    state: "",
-    authUrl: "",
-    callbackUrl: "",
-    expiresAt: null,
-    message: "",
-  });
   const [showEditModal, setShowEditModal] = useState(false);
   const [showEditNodeModal, setShowEditNodeModal] = useState(false);
   const [showTutorialModal, setShowTutorialModal] = useState(false);
@@ -223,8 +217,6 @@ export default function ProviderDetailPageClient() {
   );
   const [exportingGeminiAuthId, setExportingGeminiAuthId] = useState<string | null>(null);
   const [importGeminiModalOpen, setImportGeminiModalOpen] = useState(false);
-  const commandCodeAuthWindowRef = useRef<Window | null>(null);
-  const commandCodeAuthTimerRef = useRef<number | null>(null);
   const pendingRiskActionRef = useRef<(() => void) | null>(null);
   const { acknowledged: riskAcknowledged, acknowledge: acknowledgeRisk } =
     useRiskAcknowledged(providerId);
@@ -748,257 +740,21 @@ export default function ProviderDetailPageClient() {
     setShowRiskNoticeModal(false);
   }, []);
 
-  const clearCommandCodeAuthTimer = useCallback(() => {
-    if (commandCodeAuthTimerRef.current !== null) {
-      window.clearTimeout(commandCodeAuthTimerRef.current);
-      commandCodeAuthTimerRef.current = null;
-    }
-  }, []);
-
-  useEffect(() => {
-    return () => {
-      clearCommandCodeAuthTimer();
-      commandCodeAuthWindowRef.current?.close?.();
-    };
-  }, [clearCommandCodeAuthTimer]);
-
-  const handleCloseAddApiKeyModal = useCallback(() => {
-    clearCommandCodeAuthTimer();
-    setSiliconFlowInitialBaseUrl(undefined);
-    commandCodeAuthWindowRef.current?.close?.();
-    commandCodeAuthWindowRef.current = null;
-    setCommandCodeAuthState({
-      phase: "idle",
-      state: "",
-      authUrl: "",
-      callbackUrl: "",
-      expiresAt: null,
-      message: "",
-    });
-    setShowAddApiKeyModal(false);
-  }, [clearCommandCodeAuthTimer]);
-
-  const handleCommandCodeAuthApply = useCallback(
-    async (state: string, connectionId?: string, name?: string, setDefault?: boolean) => {
-      setCommandCodeAuthState((current) => ({
-        ...current,
-        phase: "applying",
-        message: "Applying browser-approved key…",
-      }));
-
-      try {
-        const res = await fetch("/api/providers/command-code/auth/apply", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ state, connectionId, name, setDefault }),
-        });
-        const data = await res.json().catch(() => ({}));
-
-        if (!res.ok) {
-          const errorMessage = data.error || "Failed to apply Command Code auth";
-          setCommandCodeAuthState((current) => ({
-            ...current,
-            phase: "error",
-            message: errorMessage,
-          }));
-          notify.error(errorMessage);
-          return false;
-        }
-
-        setCommandCodeAuthState((current) => ({
-          ...current,
-          phase: "applied",
-          message: "Command Code connected",
-        }));
-        commandCodeAuthWindowRef.current?.close?.();
-        commandCodeAuthWindowRef.current = null;
-        await fetchConnections();
-        handleCloseAddApiKeyModal();
-        notify.success("Command Code connection added");
-        return true;
-      } catch (error) {
-        console.error("Error applying Command Code auth:", error);
-        setCommandCodeAuthState((current) => ({
-          ...current,
-          phase: "error",
-          message: "Failed to apply Command Code auth",
-        }));
-        notify.error("Failed to apply Command Code auth");
-        return false;
-      }
-    },
-    [fetchConnections, handleCloseAddApiKeyModal, notify]
-  );
-
-  const handleStartCommandCodeAuth = useCallback(async () => {
-    if (commandCodeAuthState.phase === "starting" || commandCodeAuthState.phase === "polling") {
-      return;
-    }
-
-    clearCommandCodeAuthTimer();
-    commandCodeAuthWindowRef.current?.close?.();
-
-    const popup = window.open("about:blank", "_blank");
-    setCommandCodeAuthState({
-      phase: "starting",
-      state: "",
-      authUrl: "",
-      callbackUrl: "",
-      expiresAt: null,
-      message: "Opening Command Code Studio…",
-    });
-
-    try {
-      const res = await fetch("/api/providers/command-code/auth/start", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-      });
-      const data = await res.json().catch(() => ({}));
-
-      if (!res.ok || !data.state || !data.authUrl) {
-        const errorMessage = data.error || "Failed to start Command Code auth";
-        setCommandCodeAuthState((current) => ({
-          ...current,
-          phase: "error",
-          message: errorMessage,
-        }));
-        notify.error(errorMessage);
-        popup?.close?.();
-        return;
-      }
-
-      setCommandCodeAuthState({
-        phase: "polling",
-        state: data.state,
-        authUrl: data.authUrl,
-        callbackUrl: data.callbackUrl || "",
-        expiresAt: data.expiresAt || null,
-        message: "Open the auth URL, approve access, then paste the returned key/JSON/URL below…",
-      });
-
-      if (popup) {
-        try {
-          popup.opener = null;
-        } catch {
-          // Ignore opener cleanup failures.
-        }
-        popup.location.href = data.authUrl;
-        commandCodeAuthWindowRef.current = popup;
-      } else {
-        const fallbackPopup = window.open(data.authUrl, "_blank", "noopener,noreferrer");
-        if (!fallbackPopup) {
-          setCommandCodeAuthState((current) => ({
-            ...current,
-            phase: "error",
-            message: "Popup blocked. Please allow popups and try Command Code Connect again.",
-          }));
-          notify.error("Popup blocked. Please allow popups and try Command Code Connect again.");
-          return;
-        }
-        commandCodeAuthWindowRef.current = fallbackPopup;
-      }
-
-      const deadline = data.expiresAt ? new Date(data.expiresAt).getTime() : Date.now() + 180000;
-      const poll = async () => {
-        if (Date.now() >= deadline) {
-          setCommandCodeAuthState((current) => ({
-            ...current,
-            phase: "expired",
-            message: "Command Code link expired",
-          }));
-          commandCodeAuthWindowRef.current?.close?.();
-          commandCodeAuthWindowRef.current = null;
-          notify.error("Command Code auth expired");
-          clearCommandCodeAuthTimer();
-          return;
-        }
-
-        try {
-          const statusRes = await fetch(
-            `/api/providers/command-code/auth/status?state=${encodeURIComponent(data.state)}`,
-            { method: "GET", cache: "no-store" }
-          );
-          const statusData = await statusRes.json().catch(() => ({}));
-          const status = String(statusData.status || statusData.state || statusData.phase || "")
-            .toLowerCase()
-            .trim();
-
-          if (status === "expired") {
-            setCommandCodeAuthState((current) => ({
-              ...current,
-              phase: "expired",
-              message: "Command Code link expired",
-            }));
-            commandCodeAuthWindowRef.current?.close?.();
-            commandCodeAuthWindowRef.current = null;
-            notify.error("Command Code auth expired");
-            clearCommandCodeAuthTimer();
-            return;
-          }
-
-          if (status === "applied") {
-            setCommandCodeAuthState((current) => ({
-              ...current,
-              phase: "applied",
-              message: "Command Code connected",
-            }));
-            commandCodeAuthWindowRef.current?.close?.();
-            commandCodeAuthWindowRef.current = null;
-            await fetchConnections();
-            handleCloseAddApiKeyModal();
-            notify.success("Command Code connection added");
-            clearCommandCodeAuthTimer();
-            return;
-          }
-
-          if (status === "received") {
-            setCommandCodeAuthState((current) => ({
-              ...current,
-              phase: "received",
-              message: "Browser approved, applying…",
-            }));
-            clearCommandCodeAuthTimer();
-            await handleCommandCodeAuthApply(
-              data.state,
-              statusData.connectionId,
-              statusData.name,
-              statusData.setDefault
-            );
-            return;
-          }
-        } catch {
-          // Keep polling until the contract reports a terminal state or timeout.
-        }
-
-        commandCodeAuthTimerRef.current = window.setTimeout(poll, 2000);
-      };
-
-      commandCodeAuthTimerRef.current = window.setTimeout(poll, 1000);
-    } catch (error) {
-      console.error("Error starting Command Code auth:", error);
-      setCommandCodeAuthState((current) => ({
-        ...current,
-        phase: "error",
-        message: "Failed to start Command Code auth",
-      }));
-      notify.error("Failed to start Command Code auth");
-      popup?.close?.();
-      commandCodeAuthWindowRef.current = null;
-      clearCommandCodeAuthTimer();
-    }
-  }, [
+  // ── Phase 1h: commandCode auth flow ─────────────────────────────────────
+  const {
+    commandCodeAuthState,
     clearCommandCodeAuthTimer,
     handleCloseAddApiKeyModal,
-    commandCodeAuthState.phase,
-    fetchConnections,
     handleCommandCodeAuthApply,
+    handleStartCommandCodeAuth,
+    handleOpenCommandCodeConnect,
+  } = useCommandCodeAuth({
+    providerId,
+    fetchConnections,
+    setSiliconFlowInitialBaseUrl,
+    setShowAddApiKeyModal,
     notify,
-  ]);
-
-  const handleOpenCommandCodeConnect = useCallback(() => {
-    setShowAddApiKeyModal(true);
-    void handleStartCommandCodeAuth();
-  }, [handleStartCommandCodeAuth]);
+  });
 
   const handleSaveApiKey = async (formData) => {
     try {

--- a/src/app/(dashboard)/dashboard/providers/[id]/ProviderDetailPageClient.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/ProviderDetailPageClient.tsx
@@ -5,17 +5,8 @@ import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { useProviderConnections } from "./hooks/useProviderConnections";
 import { useProviderSettings } from "./hooks/useProviderSettings";
 import { useProviderModels } from "./hooks/useProviderModels";
-import { LlmChatCard } from "@/app/(dashboard)/dashboard/media-providers/components/LlmChatCard";
-import { ServiceKindTabs } from "@/app/(dashboard)/dashboard/media-providers/components/ServiceKindTabs";
-import { EmbeddingExampleCard } from "@/app/(dashboard)/dashboard/media-providers/components/EmbeddingExampleCard";
-import { ImageExampleCard } from "@/app/(dashboard)/dashboard/media-providers/components/ImageExampleCard";
-import { TtsExampleCard } from "@/app/(dashboard)/dashboard/media-providers/components/TtsExampleCard";
-import { SttExampleCard } from "@/app/(dashboard)/dashboard/media-providers/components/SttExampleCard";
-import { WebSearchExampleCard } from "@/app/(dashboard)/dashboard/media-providers/components/WebSearchExampleCard";
-import { WebFetchExampleCard } from "@/app/(dashboard)/dashboard/media-providers/components/WebFetchExampleCard";
-import { VideoExampleCard } from "@/app/(dashboard)/dashboard/media-providers/components/VideoExampleCard";
-import { MusicExampleCard } from "@/app/(dashboard)/dashboard/media-providers/components/MusicExampleCard";
-import type { ServiceKind } from "@/shared/constants/providers";
+// Phase 1g: ProviderPlaygroundPanel + helpers extracted to components/ProviderPlaygroundPanel.tsx
+import ProviderPlaygroundPanel from "./components/ProviderPlaygroundPanel";
 import { useNotificationStore } from "@/store/notificationStore";
 import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
@@ -40,7 +31,6 @@ import {
 import {
   LOCAL_PROVIDERS,
   NOAUTH_PROVIDERS,
-  AI_PROVIDERS,
   getProviderAlias,
   isOpenAICompatibleProvider,
   isAnthropicCompatibleProvider,
@@ -152,95 +142,7 @@ type ModelCompatSavePatch = {
 
 // ModelCompatPopover extracted to components/ModelCompatPopover.tsx (Phase 1d)
 
-// ──── ProviderPlaygroundPanel ────────────────────────────────────────────────
-// Renders a playground section on the individual provider page.
-// Shows ServiceKindTabs if the provider declares multiple kinds; falls back to
-// a single-kind panel or the LlmChatCard for standard LLM providers.
-
-const MEDIA_SERVICE_KINDS: ServiceKind[] = [
-  "embedding",
-  "image",
-  "tts",
-  "stt",
-  "webSearch",
-  "webFetch",
-  "video",
-  "music",
-];
-
-function renderKindPanel(kind: ServiceKind, providerId: string): JSX.Element | null {
-  switch (kind) {
-    case "llm":
-      return <LlmChatCard providerId={providerId} />;
-    case "embedding":
-      return <EmbeddingExampleCard providerId={providerId} />;
-    case "image":
-      return <ImageExampleCard providerId={providerId} />;
-    case "tts":
-      return <TtsExampleCard providerId={providerId} />;
-    case "stt":
-      return <SttExampleCard providerId={providerId} />;
-    case "webSearch":
-      return <WebSearchExampleCard providerId={providerId} />;
-    case "webFetch":
-      return <WebFetchExampleCard providerId={providerId} />;
-    case "video":
-      return <VideoExampleCard providerId={providerId} />;
-    case "music":
-      return <MusicExampleCard providerId={providerId} />;
-    default:
-      return null;
-  }
-}
-
-function ProviderPlaygroundPanel({ providerId }: { providerId: string }) {
-  // Resolve serviceKinds from AI_PROVIDERS.
-  // For providers without explicit serviceKinds (most LLM providers), we infer
-  // "llm" as the default.
-  const providerEntry = AI_PROVIDERS[providerId as keyof typeof AI_PROVIDERS] as
-    | (Record<string, unknown> & { serviceKinds?: string[] })
-    | undefined;
-
-  const rawKinds: string[] = providerEntry?.serviceKinds ?? [];
-
-  const ALL_VALID_KINDS = [
-    "llm",
-    "embedding",
-    "image",
-    "imageToText",
-    "tts",
-    "stt",
-    "webSearch",
-    "webFetch",
-    "video",
-    "music",
-  ] as const;
-
-  const kinds: ServiceKind[] =
-    rawKinds.length > 0
-      ? rawKinds.filter((k): k is ServiceKind => (ALL_VALID_KINDS as readonly string[]).includes(k))
-      : ["llm"];
-
-  // Filter out kinds that have no playground implementation yet
-  const playgroundableKinds = kinds.filter((k) => k !== "imageToText");
-
-  // useState must be called unconditionally (Rules of Hooks)
-  const [activeKind, setActiveKind] = useState<ServiceKind>(playgroundableKinds[0] ?? "llm");
-
-  if (playgroundableKinds.length === 0) return null;
-
-  return (
-    <div className="flex flex-col gap-3">
-      <h2 className="text-lg font-semibold">Playground</h2>
-      <ServiceKindTabs
-        kinds={playgroundableKinds}
-        activeKind={activeKind}
-        onSelect={setActiveKind}
-      />
-      {renderKindPanel(activeKind, providerId)}
-    </div>
-  );
-}
+// ── ProviderPlaygroundPanel extracted to components/ProviderPlaygroundPanel.tsx (Phase 1g) ──
 
 export default function ProviderDetailPageClient() {
   const params = useParams();

--- a/src/app/(dashboard)/dashboard/providers/[id]/ProviderDetailPageClient.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/ProviderDetailPageClient.tsx
@@ -10,6 +10,8 @@ import { useCommandCodeAuth } from "./hooks/useCommandCodeAuth";
 // Phase 1i: external link flow extracted to hooks/useExternalLinkFlow.ts
 import { useExternalLinkFlow } from "./hooks/useExternalLinkFlow";
 import ExternalLinkModal from "./components/ExternalLinkModal";
+// Phase 1j: auth file handlers extracted to hooks/useAuthFileHandlers.ts
+import { useAuthFileHandlers } from "./hooks/useAuthFileHandlers";
 // Phase 1g: ProviderPlaygroundPanel + helpers extracted to components/ProviderPlaygroundPanel.tsx
 import ProviderPlaygroundPanel from "./components/ProviderPlaygroundPanel";
 import { useNotificationStore } from "@/store/notificationStore";
@@ -194,11 +196,6 @@ export default function ProviderDetailPageClient() {
   const [bulkVisibilityAction, setBulkVisibilityAction] = useState<"select" | "deselect" | null>(
     null
   );
-  const [applyingCodexAuthId, setApplyingCodexAuthId] = useState<string | null>(null);
-  const [applyCodexModalConnectionId, setApplyCodexModalConnectionId] = useState<string | null>(
-    null
-  );
-  const [exportingCodexAuthId, setExportingCodexAuthId] = useState<string | null>(null);
   const [importCodexModalOpen, setImportCodexModalOpen] = useState(false);
   const [codexCliGuideOpen, setCodexCliGuideOpen] = useState(false);
   // "Adicionar Externo": public shareable device-flow link state.
@@ -214,17 +211,7 @@ export default function ProviderDetailPageClient() {
     externalLinkCopy,
     openExternalLinkFlow,
   } = useExternalLinkFlow({ providerId, notify, fetchConnections });
-  const [applyingClaudeAuthId, setApplyingClaudeAuthId] = useState<string | null>(null);
-  const [applyClaudeModalConnectionId, setApplyClaudeModalConnectionId] = useState<string | null>(
-    null
-  );
-  const [exportingClaudeAuthId, setExportingClaudeAuthId] = useState<string | null>(null);
   const [importClaudeModalOpen, setImportClaudeModalOpen] = useState(false);
-  const [applyingGeminiAuthId, setApplyingGeminiAuthId] = useState<string | null>(null);
-  const [applyGeminiModalConnectionId, setApplyGeminiModalConnectionId] = useState<string | null>(
-    null
-  );
-  const [exportingGeminiAuthId, setExportingGeminiAuthId] = useState<string | null>(null);
   const [importGeminiModalOpen, setImportGeminiModalOpen] = useState(false);
   const pendingRiskActionRef = useRef<(() => void) | null>(null);
   const { acknowledged: riskAcknowledged, acknowledge: acknowledgeRisk } =
@@ -842,236 +829,27 @@ export default function ProviderDetailPageClient() {
   // [refreshingId], parseApiErrorMessage, getAttachmentFilename, handleRefreshToken
   // → useProviderConnections (Phase 1f)
 
-  const handleApplyCodexAuthLocal = async (connectionId: string) => {
-    if (applyingCodexAuthId) return;
-    setApplyingCodexAuthId(connectionId);
-
-    const defaultSuccess =
-      typeof t.has === "function" && t.has("codexAuthAppliedLocal")
-        ? t("codexAuthAppliedLocal")
-        : "Codex auth.json applied locally";
-    const defaultError =
-      typeof t.has === "function" && t.has("codexAuthApplyFailed")
-        ? t("codexAuthApplyFailed")
-        : "Failed to apply Codex auth.json locally";
-
-    try {
-      const res = await fetch(`/api/providers/${connectionId}/codex-auth/apply-local`, {
-        method: "POST",
-      });
-
-      if (!res.ok) {
-        notify.error(await parseApiErrorMessage(res, defaultError));
-        return;
-      }
-
-      notify.success(defaultSuccess);
-      setApplyCodexModalConnectionId(null);
-    } catch (error) {
-      console.error("Error applying Codex auth locally:", error);
-      notify.error(defaultError);
-    } finally {
-      setApplyingCodexAuthId(null);
-    }
-  };
-
-  const handleExportCodexAuthFile = async (connectionId: string) => {
-    if (exportingCodexAuthId) return;
-    setExportingCodexAuthId(connectionId);
-
-    const defaultSuccess =
-      typeof t.has === "function" && t.has("codexAuthExported")
-        ? t("codexAuthExported")
-        : "Codex auth.json exported";
-    const defaultError =
-      typeof t.has === "function" && t.has("codexAuthExportFailed")
-        ? t("codexAuthExportFailed")
-        : "Failed to export Codex auth.json";
-
-    try {
-      const res = await fetch(`/api/providers/${connectionId}/codex-auth/export`, {
-        method: "POST",
-      });
-
-      if (!res.ok) {
-        notify.error(await parseApiErrorMessage(res, defaultError));
-        return;
-      }
-
-      const blob = await res.blob();
-      const filename = getAttachmentFilename(res, "codex-auth.json");
-      const objectUrl = window.URL.createObjectURL(blob);
-      const link = document.createElement("a");
-
-      link.href = objectUrl;
-      link.download = filename;
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-      window.setTimeout(() => window.URL.revokeObjectURL(objectUrl), 1000);
-
-      notify.success(defaultSuccess);
-    } catch (error) {
-      console.error("Error exporting Codex auth file:", error);
-      notify.error(defaultError);
-    } finally {
-      setExportingCodexAuthId(null);
-    }
-  };
-
-  const handleApplyClaudeAuthLocal = async (connectionId: string) => {
-    if (applyingClaudeAuthId) return;
-    setApplyingClaudeAuthId(connectionId);
-
-    const defaultSuccess =
-      typeof t.has === "function" && t.has("claudeAuthAppliedLocal")
-        ? t("claudeAuthAppliedLocal")
-        : "Claude auth applied locally";
-    const defaultError =
-      typeof t.has === "function" && t.has("claudeAuthApplyFailed")
-        ? t("claudeAuthApplyFailed")
-        : "Failed to apply Claude auth locally";
-
-    try {
-      const res = await fetch(`/api/providers/${connectionId}/claude-auth/apply-local`, {
-        method: "POST",
-      });
-
-      if (!res.ok) {
-        notify.error(await parseApiErrorMessage(res, defaultError));
-        return;
-      }
-
-      notify.success(defaultSuccess);
-      setApplyClaudeModalConnectionId(null);
-    } catch (error) {
-      console.error("Error applying Claude auth locally:", error);
-      notify.error(defaultError);
-    } finally {
-      setApplyingClaudeAuthId(null);
-    }
-  };
-
-  const handleExportClaudeAuthFile = async (connectionId: string) => {
-    if (exportingClaudeAuthId) return;
-    setExportingClaudeAuthId(connectionId);
-
-    const defaultSuccess =
-      typeof t.has === "function" && t.has("claudeAuthExported")
-        ? t("claudeAuthExported")
-        : "Claude auth file exported";
-    const defaultError =
-      typeof t.has === "function" && t.has("claudeAuthExportFailed")
-        ? t("claudeAuthExportFailed")
-        : "Failed to export Claude auth file";
-
-    try {
-      const res = await fetch(`/api/providers/${connectionId}/claude-auth/export`, {
-        method: "POST",
-      });
-
-      if (!res.ok) {
-        notify.error(await parseApiErrorMessage(res, defaultError));
-        return;
-      }
-
-      const blob = await res.blob();
-      const filename = getAttachmentFilename(res, "claude-auth.json");
-      const objectUrl = window.URL.createObjectURL(blob);
-      const link = document.createElement("a");
-
-      link.href = objectUrl;
-      link.download = filename;
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-      window.setTimeout(() => window.URL.revokeObjectURL(objectUrl), 1000);
-
-      notify.success(defaultSuccess);
-    } catch (error) {
-      console.error("Error exporting Claude auth file:", error);
-      notify.error(defaultError);
-    } finally {
-      setExportingClaudeAuthId(null);
-    }
-  };
-
-  const handleApplyGeminiAuthLocal = async (connectionId: string) => {
-    if (applyingGeminiAuthId) return;
-    setApplyingGeminiAuthId(connectionId);
-
-    const defaultSuccess =
-      typeof t.has === "function" && t.has("geminiAuthAppliedLocal")
-        ? t("geminiAuthAppliedLocal")
-        : "Gemini auth applied locally";
-    const defaultError =
-      typeof t.has === "function" && t.has("geminiAuthApplyFailed")
-        ? t("geminiAuthApplyFailed")
-        : "Failed to apply Gemini auth locally";
-
-    try {
-      const res = await fetch(`/api/providers/${connectionId}/gemini-cli-auth/apply-local`, {
-        method: "POST",
-      });
-
-      if (!res.ok) {
-        notify.error(await parseApiErrorMessage(res, defaultError));
-        return;
-      }
-
-      notify.success(defaultSuccess);
-      setApplyGeminiModalConnectionId(null);
-    } catch (error) {
-      console.error("Error applying Gemini auth locally:", error);
-      notify.error(defaultError);
-    } finally {
-      setApplyingGeminiAuthId(null);
-    }
-  };
-
-  const handleExportGeminiAuthFile = async (connectionId: string) => {
-    if (exportingGeminiAuthId) return;
-    setExportingGeminiAuthId(connectionId);
-
-    const defaultSuccess =
-      typeof t.has === "function" && t.has("geminiAuthExported")
-        ? t("geminiAuthExported")
-        : "Gemini auth file exported";
-    const defaultError =
-      typeof t.has === "function" && t.has("geminiAuthExportFailed")
-        ? t("geminiAuthExportFailed")
-        : "Failed to export Gemini auth file";
-
-    try {
-      const res = await fetch(`/api/providers/${connectionId}/gemini-cli-auth/export`, {
-        method: "POST",
-      });
-
-      if (!res.ok) {
-        notify.error(await parseApiErrorMessage(res, defaultError));
-        return;
-      }
-
-      const blob = await res.blob();
-      const filename = getAttachmentFilename(res, "gemini-auth.json");
-      const objectUrl = window.URL.createObjectURL(blob);
-      const link = document.createElement("a");
-
-      link.href = objectUrl;
-      link.download = filename;
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-      window.setTimeout(() => window.URL.revokeObjectURL(objectUrl), 1000);
-
-      notify.success(defaultSuccess);
-    } catch (error) {
-      console.error("Error exporting Gemini auth file:", error);
-      notify.error(defaultError);
-    } finally {
-      setExportingGeminiAuthId(null);
-    }
-  };
+  // Phase 1j: auth file handlers extracted to hooks/useAuthFileHandlers.ts
+  const {
+    applyingCodexAuthId,
+    applyCodexModalConnectionId,
+    setApplyCodexModalConnectionId,
+    exportingCodexAuthId,
+    handleApplyCodexAuthLocal,
+    handleExportCodexAuthFile,
+    applyingClaudeAuthId,
+    applyClaudeModalConnectionId,
+    setApplyClaudeModalConnectionId,
+    exportingClaudeAuthId,
+    handleApplyClaudeAuthLocal,
+    handleExportClaudeAuthFile,
+    applyingGeminiAuthId,
+    applyGeminiModalConnectionId,
+    setApplyGeminiModalConnectionId,
+    exportingGeminiAuthId,
+    handleApplyGeminiAuthLocal,
+    handleExportGeminiAuthFile,
+  } = useAuthFileHandlers({ parseApiErrorMessage, getAttachmentFilename, notify, t });
 
   // handleSwapPriority → useProviderConnections (Phase 1f)
 

--- a/src/app/(dashboard)/dashboard/providers/[id]/ProviderDetailPageClient.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/ProviderDetailPageClient.tsx
@@ -198,19 +198,6 @@ export default function ProviderDetailPageClient() {
   );
   const [importCodexModalOpen, setImportCodexModalOpen] = useState(false);
   const [codexCliGuideOpen, setCodexCliGuideOpen] = useState(false);
-  // "Adicionar Externo": public shareable device-flow link state.
-  // Phase 1i: extracted to hooks/useExternalLinkFlow.ts
-  const {
-    externalLinkModalOpen,
-    setExternalLinkModalOpen,
-    externalLinkUrl,
-    externalLinkToken,
-    externalLinkLoading,
-    externalLinkError,
-    externalLinkCopied,
-    externalLinkCopy,
-    openExternalLinkFlow,
-  } = useExternalLinkFlow({ providerId, notify, fetchConnections });
   const [importClaudeModalOpen, setImportClaudeModalOpen] = useState(false);
   const [importGeminiModalOpen, setImportGeminiModalOpen] = useState(false);
   const pendingRiskActionRef = useRef<(() => void) | null>(null);
@@ -309,6 +296,19 @@ export default function ProviderDetailPageClient() {
   const t = useTranslations("providers");
   const emailsVisible = useEmailPrivacyStore((s) => s.emailsVisible);
   const notify = useNotificationStore();
+
+  // Phase 1i: external link flow — placed after notify/fetchConnections are defined
+  const {
+    externalLinkModalOpen,
+    setExternalLinkModalOpen,
+    externalLinkUrl,
+    externalLinkToken,
+    externalLinkLoading,
+    externalLinkError,
+    externalLinkCopied,
+    externalLinkCopy,
+    openExternalLinkFlow,
+  } = useExternalLinkFlow({ providerId, notify, fetchConnections });
 
   const setShowOAuthModal = (show: boolean, connectionRow?: ConnectionRowConnection) => {
     _setShowOAuthModal(show);

--- a/src/app/(dashboard)/dashboard/providers/[id]/ProviderDetailPageClient.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/ProviderDetailPageClient.tsx
@@ -7,6 +7,9 @@ import { useProviderSettings } from "./hooks/useProviderSettings";
 import { useProviderModels } from "./hooks/useProviderModels";
 // Phase 1h: commandCode auth flow extracted to hooks/useCommandCodeAuth.ts
 import { useCommandCodeAuth } from "./hooks/useCommandCodeAuth";
+// Phase 1i: external link flow extracted to hooks/useExternalLinkFlow.ts
+import { useExternalLinkFlow } from "./hooks/useExternalLinkFlow";
+import ExternalLinkModal from "./components/ExternalLinkModal";
 // Phase 1g: ProviderPlaygroundPanel + helpers extracted to components/ProviderPlaygroundPanel.tsx
 import ProviderPlaygroundPanel from "./components/ProviderPlaygroundPanel";
 import { useNotificationStore } from "@/store/notificationStore";
@@ -199,12 +202,18 @@ export default function ProviderDetailPageClient() {
   const [importCodexModalOpen, setImportCodexModalOpen] = useState(false);
   const [codexCliGuideOpen, setCodexCliGuideOpen] = useState(false);
   // "Adicionar Externo": public shareable device-flow link state.
-  const [externalLinkModalOpen, setExternalLinkModalOpen] = useState(false);
-  const [externalLinkUrl, setExternalLinkUrl] = useState("");
-  const [externalLinkToken, setExternalLinkToken] = useState<string | null>(null);
-  const [externalLinkLoading, setExternalLinkLoading] = useState(false);
-  const [externalLinkError, setExternalLinkError] = useState<string | null>(null);
-  const { copied: externalLinkCopied, copy: externalLinkCopy } = useCopyToClipboard();
+  // Phase 1i: extracted to hooks/useExternalLinkFlow.ts
+  const {
+    externalLinkModalOpen,
+    setExternalLinkModalOpen,
+    externalLinkUrl,
+    externalLinkToken,
+    externalLinkLoading,
+    externalLinkError,
+    externalLinkCopied,
+    externalLinkCopy,
+    openExternalLinkFlow,
+  } = useExternalLinkFlow({ providerId, notify, fetchConnections });
   const [applyingClaudeAuthId, setApplyingClaudeAuthId] = useState<string | null>(null);
   const [applyClaudeModalConnectionId, setApplyClaudeModalConnectionId] = useState<string | null>(
     null
@@ -651,69 +660,6 @@ export default function ProviderDetailPageClient() {
     }
     openApiKeyAddFlow();
   }, [isOAuth, openApiKeyAddFlow]);
-
-  // "Adicionar Externo": generate a single-use public link so a third party can
-  // complete the Codex device flow in their own browser.
-  const openExternalLinkFlow = useCallback(async () => {
-    setExternalLinkModalOpen(true);
-    setExternalLinkUrl("");
-    setExternalLinkToken(null);
-    setExternalLinkError(null);
-    setExternalLinkLoading(true);
-    try {
-      const res = await fetch(`/api/oauth/${providerId}/public-link`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({}),
-      });
-      const data = await res.json().catch(() => ({}));
-      if (res.ok && data?.url) {
-        setExternalLinkUrl(data.url);
-        setExternalLinkToken(data.token || null);
-      } else {
-        setExternalLinkError(data?.error || "Falha ao gerar o link.");
-      }
-    } catch {
-      setExternalLinkError("Não foi possível contatar o servidor.");
-    } finally {
-      setExternalLinkLoading(false);
-    }
-  }, [providerId]);
-
-  // While the share popup is open, poll the ticket status so the dashboard can
-  // notify + refresh the connections the moment the external visitor finishes.
-  useEffect(() => {
-    if (!externalLinkModalOpen || !externalLinkToken) return;
-    let active = true;
-    const interval = setInterval(async () => {
-      if (!active) return;
-      try {
-        const res = await fetch(
-          `/api/oauth/${providerId}/public-link-status?token=${encodeURIComponent(externalLinkToken)}`
-        );
-        const data = await res.json().catch(() => ({}));
-        if (!active) return;
-        if (data?.status === "completed") {
-          active = false;
-          clearInterval(interval);
-          notify.success("Conta Codex conectada pelo link externo.");
-          fetchConnections();
-          setExternalLinkModalOpen(false);
-          setExternalLinkToken(null);
-        } else if (data?.status === "expired") {
-          active = false;
-          clearInterval(interval);
-          setExternalLinkError("O link expirou sem ser concluído.");
-        }
-      } catch {
-        /* transient network error — keep polling */
-      }
-    }, 3000);
-    return () => {
-      active = false;
-      clearInterval(interval);
-    };
-  }, [externalLinkModalOpen, externalLinkToken, providerId, notify, fetchConnections]);
 
   const gateConnectionFlow = useCallback(
     (callback: () => void) => {
@@ -3282,50 +3228,15 @@ export default function ProviderDetailPageClient() {
         />
       )}
       {providerId === "codex" && externalLinkModalOpen && (
-        <Modal
+        <ExternalLinkModal
           isOpen={externalLinkModalOpen}
           onClose={() => setExternalLinkModalOpen(false)}
-          title="Adicionar Externo — link do Codex"
-        >
-          <div className="space-y-4">
-            <p className="text-sm text-text-muted">
-              Compartilhe este link com quem vai autenticar a conta do Codex. A pessoa abre a
-              página, faz o login da OpenAI no próprio navegador e a conexão é cadastrada aqui. Uso
-              único, expira em 15 minutos.
-            </p>
-            {externalLinkLoading ? (
-              <p className="text-sm text-text-muted">Gerando link…</p>
-            ) : externalLinkError ? (
-              <p className="text-sm text-red-500">{externalLinkError}</p>
-            ) : externalLinkUrl ? (
-              <>
-                <div className="rounded-lg border border-border bg-bg-base p-3 break-all text-sm text-text-main">
-                  {externalLinkUrl}
-                </div>
-                <div className="flex gap-2">
-                  <Button
-                    className="flex-1"
-                    icon="open_in_new"
-                    onClick={() => window.open(externalLinkUrl, "_blank", "noopener")}
-                  >
-                    Abrir
-                  </Button>
-                  <Button
-                    variant="secondary"
-                    icon="content_copy"
-                    onClick={() => externalLinkCopy(externalLinkUrl, "extlink")}
-                  >
-                    {externalLinkCopied === "extlink" ? "Copiado" : "Copiar"}
-                  </Button>
-                </div>
-                <p className="flex items-center gap-2 text-xs text-text-muted">
-                  <span className="material-symbols-outlined animate-spin text-[16px]">sync</span>
-                  Aguardando a autenticação no navegador da pessoa… esta janela atualiza sozinha.
-                </p>
-              </>
-            ) : null}
-          </div>
-        </Modal>
+          loading={externalLinkLoading}
+          error={externalLinkError}
+          url={externalLinkUrl}
+          copied={externalLinkCopied}
+          onCopy={externalLinkCopy}
+        />
       )}
       {/* Claude Apply Auth Modal */}
       {providerId === "claude" && applyClaudeModalConnectionId && (

--- a/src/app/(dashboard)/dashboard/providers/[id]/__tests__/phase1f.test.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/__tests__/phase1f.test.tsx
@@ -13,6 +13,7 @@
 import React, { act } from "react";
 import { createRoot } from "react-dom/client";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import path from "node:path";
 
 // ---------------------------------------------------------------------------
 // Global mocks required by the extracted hooks
@@ -316,8 +317,13 @@ describe("useProviderModels — initial state", () => {
 // Cycle-safety: hooks must NOT import from ProviderDetailPageClient
 // ---------------------------------------------------------------------------
 
-const HOOKS_DIR =
-  "/home/diegosouzapw/dev/proxys/OmniRoute/.worktrees/fix-3501-phase1f/src/app/(dashboard)/dashboard/providers/[id]/hooks";
+// Resolve the hooks dir from the repo root (vitest runs from cwd). Was a
+// hardcoded absolute worktree path that broke the test outside that worktree
+// (#3501 Phase 1g-1j).
+const HOOKS_DIR = path.join(
+  process.cwd(),
+  "src/app/(dashboard)/dashboard/providers/[id]/hooks"
+);
 
 describe("Cycle-safety — hooks do not import ProviderDetailPageClient", () => {
   // We allow the name in JSDoc comments; what we forbid is an actual ES import statement.

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/ExternalLinkModal.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/ExternalLinkModal.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { Modal, Button } from "@/shared/components";
+
+type ExternalLinkModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  loading: boolean;
+  error: string | null;
+  url: string;
+  copied: string | false;
+  onCopy: (text: string, key: string) => void;
+};
+
+export default function ExternalLinkModal({
+  isOpen,
+  onClose,
+  loading,
+  error,
+  url,
+  copied,
+  onCopy,
+}: ExternalLinkModalProps) {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Adicionar Externo — link do Codex">
+      <div className="space-y-4">
+        <p className="text-sm text-text-muted">
+          Compartilhe este link com quem vai autenticar a conta do Codex. A pessoa abre a
+          página, faz o login da OpenAI no próprio navegador e a conexão é cadastrada aqui. Uso
+          único, expira em 15 minutos.
+        </p>
+        {loading ? (
+          <p className="text-sm text-text-muted">Gerando link…</p>
+        ) : error ? (
+          <p className="text-sm text-red-500">{error}</p>
+        ) : url ? (
+          <>
+            <div className="rounded-lg border border-border bg-bg-base p-3 break-all text-sm text-text-main">
+              {url}
+            </div>
+            <div className="flex gap-2">
+              <Button
+                className="flex-1"
+                icon="open_in_new"
+                onClick={() => window.open(url, "_blank", "noopener")}
+              >
+                Abrir
+              </Button>
+              <Button
+                variant="secondary"
+                icon="content_copy"
+                onClick={() => onCopy(url, "extlink")}
+              >
+                {copied === "extlink" ? "Copiado" : "Copiar"}
+              </Button>
+            </div>
+            <p className="flex items-center gap-2 text-xs text-text-muted">
+              <span className="material-symbols-outlined animate-spin text-[16px]">sync</span>
+              Aguardando a autenticação no navegador da pessoa… esta janela atualiza sozinha.
+            </p>
+          </>
+        ) : null}
+      </div>
+    </Modal>
+  );
+}

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/ProviderPlaygroundPanel.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/ProviderPlaygroundPanel.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+// Phase 1g extraction — Issue #3501
+// Renders a playground section on the individual provider page.
+// Shows ServiceKindTabs if the provider declares multiple kinds; falls back to
+// a single-kind panel or the LlmChatCard for standard LLM providers.
+
+import { useState } from "react";
+import { LlmChatCard } from "@/app/(dashboard)/dashboard/media-providers/components/LlmChatCard";
+import { ServiceKindTabs } from "@/app/(dashboard)/dashboard/media-providers/components/ServiceKindTabs";
+import { EmbeddingExampleCard } from "@/app/(dashboard)/dashboard/media-providers/components/EmbeddingExampleCard";
+import { ImageExampleCard } from "@/app/(dashboard)/dashboard/media-providers/components/ImageExampleCard";
+import { TtsExampleCard } from "@/app/(dashboard)/dashboard/media-providers/components/TtsExampleCard";
+import { SttExampleCard } from "@/app/(dashboard)/dashboard/media-providers/components/SttExampleCard";
+import { WebSearchExampleCard } from "@/app/(dashboard)/dashboard/media-providers/components/WebSearchExampleCard";
+import { WebFetchExampleCard } from "@/app/(dashboard)/dashboard/media-providers/components/WebFetchExampleCard";
+import { VideoExampleCard } from "@/app/(dashboard)/dashboard/media-providers/components/VideoExampleCard";
+import { MusicExampleCard } from "@/app/(dashboard)/dashboard/media-providers/components/MusicExampleCard";
+import type { ServiceKind } from "@/shared/constants/providers";
+import { AI_PROVIDERS } from "@/shared/constants/providers";
+
+export const MEDIA_SERVICE_KINDS: ServiceKind[] = [
+  "embedding",
+  "image",
+  "tts",
+  "stt",
+  "webSearch",
+  "webFetch",
+  "video",
+  "music",
+];
+
+export function renderKindPanel(kind: ServiceKind, providerId: string): JSX.Element | null {
+  switch (kind) {
+    case "llm":
+      return <LlmChatCard providerId={providerId} />;
+    case "embedding":
+      return <EmbeddingExampleCard providerId={providerId} />;
+    case "image":
+      return <ImageExampleCard providerId={providerId} />;
+    case "tts":
+      return <TtsExampleCard providerId={providerId} />;
+    case "stt":
+      return <SttExampleCard providerId={providerId} />;
+    case "webSearch":
+      return <WebSearchExampleCard providerId={providerId} />;
+    case "webFetch":
+      return <WebFetchExampleCard providerId={providerId} />;
+    case "video":
+      return <VideoExampleCard providerId={providerId} />;
+    case "music":
+      return <MusicExampleCard providerId={providerId} />;
+    default:
+      return null;
+  }
+}
+
+export default function ProviderPlaygroundPanel({ providerId }: { providerId: string }) {
+  // Resolve serviceKinds from AI_PROVIDERS.
+  // For providers without explicit serviceKinds (most LLM providers), we infer
+  // "llm" as the default.
+  const providerEntry = AI_PROVIDERS[providerId as keyof typeof AI_PROVIDERS] as
+    | (Record<string, unknown> & { serviceKinds?: string[] })
+    | undefined;
+
+  const rawKinds: string[] = providerEntry?.serviceKinds ?? [];
+
+  const ALL_VALID_KINDS = [
+    "llm",
+    "embedding",
+    "image",
+    "imageToText",
+    "tts",
+    "stt",
+    "webSearch",
+    "webFetch",
+    "video",
+    "music",
+  ] as const;
+
+  const kinds: ServiceKind[] =
+    rawKinds.length > 0
+      ? rawKinds.filter((k): k is ServiceKind => (ALL_VALID_KINDS as readonly string[]).includes(k))
+      : ["llm"];
+
+  // Filter out kinds that have no playground implementation yet
+  const playgroundableKinds = kinds.filter((k) => k !== "imageToText");
+
+  // useState must be called unconditionally (Rules of Hooks)
+  const [activeKind, setActiveKind] = useState<ServiceKind>(playgroundableKinds[0] ?? "llm");
+
+  if (playgroundableKinds.length === 0) return null;
+
+  return (
+    <div className="flex flex-col gap-3">
+      <h2 className="text-lg font-semibold">Playground</h2>
+      <ServiceKindTabs
+        kinds={playgroundableKinds}
+        activeKind={activeKind}
+        onSelect={setActiveKind}
+      />
+      {renderKindPanel(activeKind, providerId)}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/providers/[id]/hooks/useAuthFileHandlers.ts
+++ b/src/app/(dashboard)/dashboard/providers/[id]/hooks/useAuthFileHandlers.ts
@@ -1,0 +1,300 @@
+"use client";
+
+// Phase 1j extraction — Issue #3501
+// Manages Codex / Claude / Gemini auth-file apply+export state and handlers.
+
+import { useState } from "react";
+
+type Notify = { success: (msg: string) => void; error: (msg: string) => void };
+
+type UseAuthFileHandlersParams = {
+  parseApiErrorMessage: (res: Response, fallback: string) => Promise<string>;
+  getAttachmentFilename: (res: Response, fallback: string) => string;
+  notify: Notify;
+  t: (key: string) => string;
+};
+
+export function useAuthFileHandlers({
+  parseApiErrorMessage,
+  getAttachmentFilename,
+  notify,
+  t,
+}: UseAuthFileHandlersParams) {
+  // ── Codex ──────────────────────────────────────────────────────────────────
+  const [applyingCodexAuthId, setApplyingCodexAuthId] = useState<string | null>(null);
+  const [applyCodexModalConnectionId, setApplyCodexModalConnectionId] = useState<string | null>(
+    null
+  );
+  const [exportingCodexAuthId, setExportingCodexAuthId] = useState<string | null>(null);
+
+  // ── Claude ─────────────────────────────────────────────────────────────────
+  const [applyingClaudeAuthId, setApplyingClaudeAuthId] = useState<string | null>(null);
+  const [applyClaudeModalConnectionId, setApplyClaudeModalConnectionId] = useState<string | null>(
+    null
+  );
+  const [exportingClaudeAuthId, setExportingClaudeAuthId] = useState<string | null>(null);
+
+  // ── Gemini ─────────────────────────────────────────────────────────────────
+  const [applyingGeminiAuthId, setApplyingGeminiAuthId] = useState<string | null>(null);
+  const [applyGeminiModalConnectionId, setApplyGeminiModalConnectionId] = useState<string | null>(
+    null
+  );
+  const [exportingGeminiAuthId, setExportingGeminiAuthId] = useState<string | null>(null);
+
+  // ── Handlers ───────────────────────────────────────────────────────────────
+
+  const handleApplyCodexAuthLocal = async (connectionId: string) => {
+    if (applyingCodexAuthId) return;
+    setApplyingCodexAuthId(connectionId);
+
+    const defaultSuccess =
+      typeof (t as any).has === "function" && (t as any).has("codexAuthAppliedLocal")
+        ? t("codexAuthAppliedLocal")
+        : "Codex auth.json applied locally";
+    const defaultError =
+      typeof (t as any).has === "function" && (t as any).has("codexAuthApplyFailed")
+        ? t("codexAuthApplyFailed")
+        : "Failed to apply Codex auth.json locally";
+
+    try {
+      const res = await fetch(`/api/providers/${connectionId}/codex-auth/apply-local`, {
+        method: "POST",
+      });
+
+      if (!res.ok) {
+        notify.error(await parseApiErrorMessage(res, defaultError));
+        return;
+      }
+
+      notify.success(defaultSuccess);
+      setApplyCodexModalConnectionId(null);
+    } catch (error) {
+      console.error("Error applying Codex auth locally:", error);
+      notify.error(defaultError);
+    } finally {
+      setApplyingCodexAuthId(null);
+    }
+  };
+
+  const handleExportCodexAuthFile = async (connectionId: string) => {
+    if (exportingCodexAuthId) return;
+    setExportingCodexAuthId(connectionId);
+
+    const defaultSuccess =
+      typeof (t as any).has === "function" && (t as any).has("codexAuthExported")
+        ? t("codexAuthExported")
+        : "Codex auth.json exported";
+    const defaultError =
+      typeof (t as any).has === "function" && (t as any).has("codexAuthExportFailed")
+        ? t("codexAuthExportFailed")
+        : "Failed to export Codex auth.json";
+
+    try {
+      const res = await fetch(`/api/providers/${connectionId}/codex-auth/export`, {
+        method: "POST",
+      });
+
+      if (!res.ok) {
+        notify.error(await parseApiErrorMessage(res, defaultError));
+        return;
+      }
+
+      const blob = await res.blob();
+      const filename = getAttachmentFilename(res, "codex-auth.json");
+      const objectUrl = window.URL.createObjectURL(blob);
+      const link = document.createElement("a");
+
+      link.href = objectUrl;
+      link.download = filename;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      window.setTimeout(() => window.URL.revokeObjectURL(objectUrl), 1000);
+
+      notify.success(defaultSuccess);
+    } catch (error) {
+      console.error("Error exporting Codex auth file:", error);
+      notify.error(defaultError);
+    } finally {
+      setExportingCodexAuthId(null);
+    }
+  };
+
+  const handleApplyClaudeAuthLocal = async (connectionId: string) => {
+    if (applyingClaudeAuthId) return;
+    setApplyingClaudeAuthId(connectionId);
+
+    const defaultSuccess =
+      typeof (t as any).has === "function" && (t as any).has("claudeAuthAppliedLocal")
+        ? t("claudeAuthAppliedLocal")
+        : "Claude auth applied locally";
+    const defaultError =
+      typeof (t as any).has === "function" && (t as any).has("claudeAuthApplyFailed")
+        ? t("claudeAuthApplyFailed")
+        : "Failed to apply Claude auth locally";
+
+    try {
+      const res = await fetch(`/api/providers/${connectionId}/claude-auth/apply-local`, {
+        method: "POST",
+      });
+
+      if (!res.ok) {
+        notify.error(await parseApiErrorMessage(res, defaultError));
+        return;
+      }
+
+      notify.success(defaultSuccess);
+      setApplyClaudeModalConnectionId(null);
+    } catch (error) {
+      console.error("Error applying Claude auth locally:", error);
+      notify.error(defaultError);
+    } finally {
+      setApplyingClaudeAuthId(null);
+    }
+  };
+
+  const handleExportClaudeAuthFile = async (connectionId: string) => {
+    if (exportingClaudeAuthId) return;
+    setExportingClaudeAuthId(connectionId);
+
+    const defaultSuccess =
+      typeof (t as any).has === "function" && (t as any).has("claudeAuthExported")
+        ? t("claudeAuthExported")
+        : "Claude auth file exported";
+    const defaultError =
+      typeof (t as any).has === "function" && (t as any).has("claudeAuthExportFailed")
+        ? t("claudeAuthExportFailed")
+        : "Failed to export Claude auth file";
+
+    try {
+      const res = await fetch(`/api/providers/${connectionId}/claude-auth/export`, {
+        method: "POST",
+      });
+
+      if (!res.ok) {
+        notify.error(await parseApiErrorMessage(res, defaultError));
+        return;
+      }
+
+      const blob = await res.blob();
+      const filename = getAttachmentFilename(res, "claude-auth.json");
+      const objectUrl = window.URL.createObjectURL(blob);
+      const link = document.createElement("a");
+
+      link.href = objectUrl;
+      link.download = filename;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      window.setTimeout(() => window.URL.revokeObjectURL(objectUrl), 1000);
+
+      notify.success(defaultSuccess);
+    } catch (error) {
+      console.error("Error exporting Claude auth file:", error);
+      notify.error(defaultError);
+    } finally {
+      setExportingClaudeAuthId(null);
+    }
+  };
+
+  const handleApplyGeminiAuthLocal = async (connectionId: string) => {
+    if (applyingGeminiAuthId) return;
+    setApplyingGeminiAuthId(connectionId);
+
+    const defaultSuccess =
+      typeof (t as any).has === "function" && (t as any).has("geminiAuthAppliedLocal")
+        ? t("geminiAuthAppliedLocal")
+        : "Gemini auth applied locally";
+    const defaultError =
+      typeof (t as any).has === "function" && (t as any).has("geminiAuthApplyFailed")
+        ? t("geminiAuthApplyFailed")
+        : "Failed to apply Gemini auth locally";
+
+    try {
+      const res = await fetch(`/api/providers/${connectionId}/gemini-cli-auth/apply-local`, {
+        method: "POST",
+      });
+
+      if (!res.ok) {
+        notify.error(await parseApiErrorMessage(res, defaultError));
+        return;
+      }
+
+      notify.success(defaultSuccess);
+      setApplyGeminiModalConnectionId(null);
+    } catch (error) {
+      console.error("Error applying Gemini auth locally:", error);
+      notify.error(defaultError);
+    } finally {
+      setApplyingGeminiAuthId(null);
+    }
+  };
+
+  const handleExportGeminiAuthFile = async (connectionId: string) => {
+    if (exportingGeminiAuthId) return;
+    setExportingGeminiAuthId(connectionId);
+
+    const defaultSuccess =
+      typeof (t as any).has === "function" && (t as any).has("geminiAuthExported")
+        ? t("geminiAuthExported")
+        : "Gemini auth file exported";
+    const defaultError =
+      typeof (t as any).has === "function" && (t as any).has("geminiAuthExportFailed")
+        ? t("geminiAuthExportFailed")
+        : "Failed to export Gemini auth file";
+
+    try {
+      const res = await fetch(`/api/providers/${connectionId}/gemini-cli-auth/export`, {
+        method: "POST",
+      });
+
+      if (!res.ok) {
+        notify.error(await parseApiErrorMessage(res, defaultError));
+        return;
+      }
+
+      const blob = await res.blob();
+      const filename = getAttachmentFilename(res, "gemini-auth.json");
+      const objectUrl = window.URL.createObjectURL(blob);
+      const link = document.createElement("a");
+
+      link.href = objectUrl;
+      link.download = filename;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      window.setTimeout(() => window.URL.revokeObjectURL(objectUrl), 1000);
+
+      notify.success(defaultSuccess);
+    } catch (error) {
+      console.error("Error exporting Gemini auth file:", error);
+      notify.error(defaultError);
+    } finally {
+      setExportingGeminiAuthId(null);
+    }
+  };
+
+  return {
+    // Codex
+    applyingCodexAuthId,
+    applyCodexModalConnectionId,
+    setApplyCodexModalConnectionId,
+    exportingCodexAuthId,
+    handleApplyCodexAuthLocal,
+    handleExportCodexAuthFile,
+    // Claude
+    applyingClaudeAuthId,
+    applyClaudeModalConnectionId,
+    setApplyClaudeModalConnectionId,
+    exportingClaudeAuthId,
+    handleApplyClaudeAuthLocal,
+    handleExportClaudeAuthFile,
+    // Gemini
+    applyingGeminiAuthId,
+    applyGeminiModalConnectionId,
+    setApplyGeminiModalConnectionId,
+    exportingGeminiAuthId,
+    handleApplyGeminiAuthLocal,
+    handleExportGeminiAuthFile,
+  };
+}

--- a/src/app/(dashboard)/dashboard/providers/[id]/hooks/useCommandCodeAuth.ts
+++ b/src/app/(dashboard)/dashboard/providers/[id]/hooks/useCommandCodeAuth.ts
@@ -1,0 +1,290 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import { type CommandCodeAuthFlowState } from "../providerPageHelpers";
+
+export type UseCommandCodeAuthParams = {
+  providerId: string;
+  fetchConnections: () => Promise<void> | void;
+  setSiliconFlowInitialBaseUrl: (url: string | undefined) => void;
+  setShowAddApiKeyModal: (show: boolean) => void;
+  notify: { success: (msg: string) => void; error: (msg: string) => void };
+};
+
+export function useCommandCodeAuth({
+  fetchConnections,
+  setSiliconFlowInitialBaseUrl,
+  setShowAddApiKeyModal,
+  notify,
+}: UseCommandCodeAuthParams) {
+  const [commandCodeAuthState, setCommandCodeAuthState] = useState<CommandCodeAuthFlowState>({
+    phase: "idle",
+    state: "",
+    authUrl: "",
+    callbackUrl: "",
+    expiresAt: null,
+    message: "",
+  });
+
+  const commandCodeAuthWindowRef = useRef<Window | null>(null);
+  const commandCodeAuthTimerRef = useRef<number | null>(null);
+
+  const clearCommandCodeAuthTimer = useCallback(() => {
+    if (commandCodeAuthTimerRef.current !== null) {
+      window.clearTimeout(commandCodeAuthTimerRef.current);
+      commandCodeAuthTimerRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      clearCommandCodeAuthTimer();
+      commandCodeAuthWindowRef.current?.close?.();
+    };
+  }, [clearCommandCodeAuthTimer]);
+
+  const handleCloseAddApiKeyModal = useCallback(() => {
+    clearCommandCodeAuthTimer();
+    setSiliconFlowInitialBaseUrl(undefined);
+    commandCodeAuthWindowRef.current?.close?.();
+    commandCodeAuthWindowRef.current = null;
+    setCommandCodeAuthState({
+      phase: "idle",
+      state: "",
+      authUrl: "",
+      callbackUrl: "",
+      expiresAt: null,
+      message: "",
+    });
+    setShowAddApiKeyModal(false);
+  }, [clearCommandCodeAuthTimer, setSiliconFlowInitialBaseUrl, setShowAddApiKeyModal]);
+
+  const handleCommandCodeAuthApply = useCallback(
+    async (state: string, connectionId?: string, name?: string, setDefault?: boolean) => {
+      setCommandCodeAuthState((current) => ({
+        ...current,
+        phase: "applying",
+        message: "Applying browser-approved key…",
+      }));
+
+      try {
+        const res = await fetch("/api/providers/command-code/auth/apply", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ state, connectionId, name, setDefault }),
+        });
+        const data = await res.json().catch(() => ({}));
+
+        if (!res.ok) {
+          const errorMessage = data.error || "Failed to apply Command Code auth";
+          setCommandCodeAuthState((current) => ({
+            ...current,
+            phase: "error",
+            message: errorMessage,
+          }));
+          notify.error(errorMessage);
+          return false;
+        }
+
+        setCommandCodeAuthState((current) => ({
+          ...current,
+          phase: "applied",
+          message: "Command Code connected",
+        }));
+        commandCodeAuthWindowRef.current?.close?.();
+        commandCodeAuthWindowRef.current = null;
+        await fetchConnections();
+        handleCloseAddApiKeyModal();
+        notify.success("Command Code connection added");
+        return true;
+      } catch (error) {
+        console.error("Error applying Command Code auth:", error);
+        setCommandCodeAuthState((current) => ({
+          ...current,
+          phase: "error",
+          message: "Failed to apply Command Code auth",
+        }));
+        notify.error("Failed to apply Command Code auth");
+        return false;
+      }
+    },
+    [fetchConnections, handleCloseAddApiKeyModal, notify]
+  );
+
+  const handleStartCommandCodeAuth = useCallback(async () => {
+    if (commandCodeAuthState.phase === "starting" || commandCodeAuthState.phase === "polling") {
+      return;
+    }
+
+    clearCommandCodeAuthTimer();
+    commandCodeAuthWindowRef.current?.close?.();
+
+    const popup = window.open("about:blank", "_blank");
+    setCommandCodeAuthState({
+      phase: "starting",
+      state: "",
+      authUrl: "",
+      callbackUrl: "",
+      expiresAt: null,
+      message: "Opening Command Code Studio…",
+    });
+
+    try {
+      const res = await fetch("/api/providers/command-code/auth/start", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      });
+      const data = await res.json().catch(() => ({}));
+
+      if (!res.ok || !data.state || !data.authUrl) {
+        const errorMessage = data.error || "Failed to start Command Code auth";
+        setCommandCodeAuthState((current) => ({
+          ...current,
+          phase: "error",
+          message: errorMessage,
+        }));
+        notify.error(errorMessage);
+        popup?.close?.();
+        return;
+      }
+
+      setCommandCodeAuthState({
+        phase: "polling",
+        state: data.state,
+        authUrl: data.authUrl,
+        callbackUrl: data.callbackUrl || "",
+        expiresAt: data.expiresAt || null,
+        message: "Open the auth URL, approve access, then paste the returned key/JSON/URL below…",
+      });
+
+      if (popup) {
+        try {
+          popup.opener = null;
+        } catch {
+          // Ignore opener cleanup failures.
+        }
+        popup.location.href = data.authUrl;
+        commandCodeAuthWindowRef.current = popup;
+      } else {
+        const fallbackPopup = window.open(data.authUrl, "_blank", "noopener,noreferrer");
+        if (!fallbackPopup) {
+          setCommandCodeAuthState((current) => ({
+            ...current,
+            phase: "error",
+            message: "Popup blocked. Please allow popups and try Command Code Connect again.",
+          }));
+          notify.error("Popup blocked. Please allow popups and try Command Code Connect again.");
+          return;
+        }
+        commandCodeAuthWindowRef.current = fallbackPopup;
+      }
+
+      const deadline = data.expiresAt ? new Date(data.expiresAt).getTime() : Date.now() + 180000;
+      const poll = async () => {
+        if (Date.now() >= deadline) {
+          setCommandCodeAuthState((current) => ({
+            ...current,
+            phase: "expired",
+            message: "Command Code link expired",
+          }));
+          commandCodeAuthWindowRef.current?.close?.();
+          commandCodeAuthWindowRef.current = null;
+          notify.error("Command Code auth expired");
+          clearCommandCodeAuthTimer();
+          return;
+        }
+
+        try {
+          const statusRes = await fetch(
+            `/api/providers/command-code/auth/status?state=${encodeURIComponent(data.state)}`,
+            { method: "GET", cache: "no-store" }
+          );
+          const statusData = await statusRes.json().catch(() => ({}));
+          const status = String(statusData.status || statusData.state || statusData.phase || "")
+            .toLowerCase()
+            .trim();
+
+          if (status === "expired") {
+            setCommandCodeAuthState((current) => ({
+              ...current,
+              phase: "expired",
+              message: "Command Code link expired",
+            }));
+            commandCodeAuthWindowRef.current?.close?.();
+            commandCodeAuthWindowRef.current = null;
+            notify.error("Command Code auth expired");
+            clearCommandCodeAuthTimer();
+            return;
+          }
+
+          if (status === "applied") {
+            setCommandCodeAuthState((current) => ({
+              ...current,
+              phase: "applied",
+              message: "Command Code connected",
+            }));
+            commandCodeAuthWindowRef.current?.close?.();
+            commandCodeAuthWindowRef.current = null;
+            await fetchConnections();
+            handleCloseAddApiKeyModal();
+            notify.success("Command Code connection added");
+            clearCommandCodeAuthTimer();
+            return;
+          }
+
+          if (status === "received") {
+            setCommandCodeAuthState((current) => ({
+              ...current,
+              phase: "received",
+              message: "Browser approved, applying…",
+            }));
+            clearCommandCodeAuthTimer();
+            await handleCommandCodeAuthApply(
+              data.state,
+              statusData.connectionId,
+              statusData.name,
+              statusData.setDefault
+            );
+            return;
+          }
+        } catch {
+          // Keep polling until the contract reports a terminal state or timeout.
+        }
+
+        commandCodeAuthTimerRef.current = window.setTimeout(poll, 2000);
+      };
+
+      commandCodeAuthTimerRef.current = window.setTimeout(poll, 1000);
+    } catch (error) {
+      console.error("Error starting Command Code auth:", error);
+      setCommandCodeAuthState((current) => ({
+        ...current,
+        phase: "error",
+        message: "Failed to start Command Code auth",
+      }));
+      notify.error("Failed to start Command Code auth");
+      popup?.close?.();
+      commandCodeAuthWindowRef.current = null;
+      clearCommandCodeAuthTimer();
+    }
+  }, [
+    clearCommandCodeAuthTimer,
+    handleCloseAddApiKeyModal,
+    commandCodeAuthState.phase,
+    fetchConnections,
+    handleCommandCodeAuthApply,
+    notify,
+  ]);
+
+  const handleOpenCommandCodeConnect = useCallback(() => {
+    setShowAddApiKeyModal(true);
+    void handleStartCommandCodeAuth();
+  }, [handleStartCommandCodeAuth, setShowAddApiKeyModal]);
+
+  return {
+    commandCodeAuthState,
+    clearCommandCodeAuthTimer,
+    handleCloseAddApiKeyModal,
+    handleCommandCodeAuthApply,
+    handleStartCommandCodeAuth,
+    handleOpenCommandCodeConnect,
+  };
+}

--- a/src/app/(dashboard)/dashboard/providers/[id]/hooks/useExternalLinkFlow.ts
+++ b/src/app/(dashboard)/dashboard/providers/[id]/hooks/useExternalLinkFlow.ts
@@ -1,0 +1,96 @@
+import { useState, useEffect, useCallback } from "react";
+import { useCopyToClipboard } from "@/shared/hooks/useCopyToClipboard";
+
+type UseExternalLinkFlowParams = {
+  providerId: string;
+  notify: { success: (msg: string) => void; error: (msg: string) => void };
+  fetchConnections: () => Promise<void> | void;
+};
+
+export function useExternalLinkFlow({
+  providerId,
+  notify,
+  fetchConnections,
+}: UseExternalLinkFlowParams) {
+  const [externalLinkModalOpen, setExternalLinkModalOpen] = useState(false);
+  const [externalLinkUrl, setExternalLinkUrl] = useState("");
+  const [externalLinkToken, setExternalLinkToken] = useState<string | null>(null);
+  const [externalLinkLoading, setExternalLinkLoading] = useState(false);
+  const [externalLinkError, setExternalLinkError] = useState<string | null>(null);
+  const { copied: externalLinkCopied, copy: externalLinkCopy } = useCopyToClipboard();
+
+  // "Adicionar Externo": generate a single-use public link so a third party can
+  // complete the Codex device flow in their own browser.
+  const openExternalLinkFlow = useCallback(async () => {
+    setExternalLinkModalOpen(true);
+    setExternalLinkUrl("");
+    setExternalLinkToken(null);
+    setExternalLinkError(null);
+    setExternalLinkLoading(true);
+    try {
+      const res = await fetch(`/api/oauth/${providerId}/public-link`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (res.ok && data?.url) {
+        setExternalLinkUrl(data.url);
+        setExternalLinkToken(data.token || null);
+      } else {
+        setExternalLinkError(data?.error || "Falha ao gerar o link.");
+      }
+    } catch {
+      setExternalLinkError("Não foi possível contatar o servidor.");
+    } finally {
+      setExternalLinkLoading(false);
+    }
+  }, [providerId]);
+
+  // While the share popup is open, poll the ticket status so the dashboard can
+  // notify + refresh the connections the moment the external visitor finishes.
+  useEffect(() => {
+    if (!externalLinkModalOpen || !externalLinkToken) return;
+    let active = true;
+    const interval = setInterval(async () => {
+      if (!active) return;
+      try {
+        const res = await fetch(
+          `/api/oauth/${providerId}/public-link-status?token=${encodeURIComponent(externalLinkToken)}`
+        );
+        const data = await res.json().catch(() => ({}));
+        if (!active) return;
+        if (data?.status === "completed") {
+          active = false;
+          clearInterval(interval);
+          notify.success("Conta Codex conectada pelo link externo.");
+          fetchConnections();
+          setExternalLinkModalOpen(false);
+          setExternalLinkToken(null);
+        } else if (data?.status === "expired") {
+          active = false;
+          clearInterval(interval);
+          setExternalLinkError("O link expirou sem ser concluído.");
+        }
+      } catch {
+        /* transient network error — keep polling */
+      }
+    }, 3000);
+    return () => {
+      active = false;
+      clearInterval(interval);
+    };
+  }, [externalLinkModalOpen, externalLinkToken, providerId, notify, fetchConnections]);
+
+  return {
+    externalLinkModalOpen,
+    setExternalLinkModalOpen,
+    externalLinkUrl,
+    externalLinkToken,
+    externalLinkLoading,
+    externalLinkError,
+    externalLinkCopied,
+    externalLinkCopy,
+    openExternalLinkFlow,
+  };
+}


### PR DESCRIPTION
Part of #3501 (strangler-fig decomposition of the providers/[id] god-component toward ≤800 LOC).

## What
- **fix**: `ProxyConfigModal.onSaved` called `loadConnProxies(connections)` which was **unbound** in the client (only `fetchProxyConfig` is destructured) → latent `ReferenceError`. Replaced with `fetchProxyConfig()`. (Escaped typecheck:core — doesn't cover .tsx — and SWC build.)
- **1g**: extract `ProviderPlaygroundPanel` → components/ProviderPlaygroundPanel.tsx (105)
- **1h**: extract `useCommandCodeAuth` → hooks/useCommandCodeAuth.ts (290)
- **1i**: extract `useExternalLinkFlow` + `ExternalLinkModal` → hooks/ + components/ (96 + 66)
- **1j**: extract `useAuthFileHandlers` (Codex/Claude/Gemini apply+export) → hooks/useAuthFileHandlers.ts (300)
- Fixed `phase1f.test.tsx` cycle-safety test that had a hardcoded absolute worktree path (broke outside that worktree) → resolved from repo root.
- Baseline ratcheted: client 4063→3409; models/route.ts 2344→2426 reconciled (#3712 vertex drift).

## Validation
- Pure extraction, zero logic change. typecheck:core clean, check:cycles OK (providers/[id], 37 files, no new cycles), file-size gate green, provider-page vitest 32/32, test:vitest 171/171.

Co-authored-by: oyi77 <14921983+oyi77@users.noreply.github.com>