### PR TITLE
refactor(#3501): god-component Phase 1t — client 1376→781 LOC (≤800 TARGET REACHED ✅)

### DIFF
--- a/file-size-baseline.json
+++ b/file-size-baseline.json
@@ -23,11 +23,11 @@
     "open-sse/mcp-server/schemas/tools.ts": 1437,
     "open-sse/mcp-server/server.ts": 1457,
     "open-sse/mcp-server/tools/advancedTools.ts": 1118,
-    "open-sse/services/accountFallback.ts": 1645,
+    "open-sse/services/accountFallback.ts": 1708,
     "open-sse/services/batchProcessor.ts": 828,
     "open-sse/services/browserBackedChat.ts": 850,
     "open-sse/services/claudeCodeCompatible.ts": 1202,
-    "open-sse/services/combo.ts": 4955,
+    "open-sse/services/combo.ts": 5054,
     "open-sse/services/rateLimitManager.ts": 1017,
     "open-sse/services/tokenRefresh.ts": 1997,
     "open-sse/services/usage.ts": 3341,
@@ -48,7 +48,7 @@
     "src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.tsx": 2570,
     "src/app/(dashboard)/dashboard/health/page.tsx": 1091,
     "src/app/(dashboard)/dashboard/playground/components/tabs/ApiTab.tsx": 847,
-    "src/app/(dashboard)/dashboard/providers/[id]/ProviderDetailPageClient.tsx": 1377,
+    "src/app/(dashboard)/dashboard/providers/[id]/ProviderDetailPageClient.tsx": 782,
     "src/app/(dashboard)/dashboard/providers/[id]/components/ConnectionRow.tsx": 941,
     "src/app/(dashboard)/dashboard/providers/[id]/components/modals/AddApiKeyModal.tsx": 843,
     "src/app/(dashboard)/dashboard/providers/[id]/components/modals/EditConnectionModal.tsx": 1171,
@@ -64,7 +64,7 @@
     "src/app/(dashboard)/dashboard/settings/components/MemorySkillsTab.tsx": 880,
     "src/app/(dashboard)/dashboard/settings/components/PricingTab.tsx": 1012,
     "src/app/(dashboard)/dashboard/settings/components/ProxyRegistryManager.tsx": 1072,
-    "src/app/(dashboard)/dashboard/settings/components/ResilienceTab.tsx": 981,
+    "src/app/(dashboard)/dashboard/settings/components/ResilienceTab.tsx": 983,
     "src/app/(dashboard)/dashboard/settings/components/RoutingTab.tsx": 1580,
     "src/app/(dashboard)/dashboard/settings/components/SystemStorageTab.tsx": 1924,
     "src/app/(dashboard)/dashboard/usage/components/BudgetTab.tsx": 1016,
@@ -101,12 +101,13 @@
     "src/shared/constants/sidebarVisibility.ts": 990,
     "src/shared/services/cliRuntime.ts": 1084,
     "src/shared/validation/schemas.ts": 2515,
-    "src/sse/handlers/chat.ts": 1381,
-    "src/sse/services/auth.ts": 2198
+    "src/sse/handlers/chat.ts": 1389,
+    "src/sse/services/auth.ts": 2207
   },
   "_rebaseline_2026_06_09": "Re-baseline consciente pre-release v3.8.19: 9 arquivos cresceram durante o ciclo (features mergeadas: RequestLoggerV2 +281 request-logger rework, stream +101, combo +73, chatCore +45, catalog +32 fable-5/catalog-flag, callLogs +4, accountFallback +2, usageHistory novo 840) + core.ts +7 (fix resetAllDbModuleState, PR 3536). A catraca segue valendo destes valores — proximo crescimento falha. Decisao: encolher (esp. RequestLoggerV2/chatCore) e a issue #3501 ficam para o ciclo seguinte.",
   "_rebaseline_2026_06_11_phase1f": "Phase 1f (#3501): ProviderDetailPageClient.tsx 4948→4062 (-886 LOC); 3 novos hooks extraídos. useProviderConnections.ts=954 acima do cap=800 — justificado: extração direta do god-component (zero lógica nova), própria redução do cliente supera o custo. useProviderSettings.ts=263 e useProviderModels.ts=154 já abaixo do cap.",
   "_rebaseline_2026_06_12_review_issues": "Re-baseline consciente do /review-issues v3.8.23: 27 arquivos com crescimento herdado (v3.8.22 nunca reconciliado) + fixes deste round (combo.ts #3685, openai-to-gemini.ts #3688, tokenRefresh.ts #3692, validation/proxies de outras merges). providerLimits.ts (941) adicionado como frozen (split coeso de usage). Shrink endereçado separadamente pelo #3501.",
   "_rebaseline_2026_06_12_phase1g1j": "Phase 1g-1j (#3501): ProviderDetailPageClient.tsx 4063→3409 (extraídos ProviderPlaygroundPanel, useCommandCodeAuth, useExternalLinkFlow+ExternalLinkModal, useAuthFileHandlers — zero lógica nova). models/route.ts 2344→2426: drift do #3712 (vertex dynamic model discovery) reconciliado aqui.",
-  "_rebaseline_2026_06_12_phase1n1s": "Phase 1n-1s (#3501): ProviderDetailPageClient.tsx 2554→1376 (extraídos ConnectionsListPanel, ConnectionsHeaderToolbar, ZedImportCard, BatchTestResultsModal, AdaptaTutorialModal + hooks/useApiKeySave + 4 helper closures→providerPageHelpers.ts). providerPageHelpers.ts 822→897 justificado: recebe 4 closures do god-component (getApiLabel/getApiDefaultPath/getApiPath/getHeaderIconProviderId), zero lógica nova, cliente encolhe mais do que helpers crescem."
+  "_rebaseline_2026_06_12_phase1n1s": "Phase 1n-1s (#3501): ProviderDetailPageClient.tsx 2554→1376 (extraídos ConnectionsListPanel, ConnectionsHeaderToolbar, ZedImportCard, BatchTestResultsModal, AdaptaTutorialModal + hooks/useApiKeySave + 4 helper closures→providerPageHelpers.ts). providerPageHelpers.ts 822→897 justificado: recebe 4 closures do god-component (getApiLabel/getApiDefaultPath/getApiPath/getHeaderIconProviderId), zero lógica nova, cliente encolhe mais do que helpers crescem.",
+  "_rebaseline_2026_06_12_phase1t": "Phase 1t (#3501): ProviderDetailPageClient.tsx 1377→782 — META ≤800 ATINGIDA (extraídos ProviderPageHeader, CompatibleNodeCard, ProviderModalsPanel, EmptyConnectionsPlaceholder, UpstreamProxyCard, SearchProviderCard + hooks useConnectionGate/useProviderNodeActions). Drift concorrente reconciliado: ResilienceTab/sse-chat/sse-auth/accountFallback/combo (merges #3629 model-lockout etc.)."
 }

--- a/src/app/(dashboard)/dashboard/providers/[id]/ProviderDetailPageClient.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/ProviderDetailPageClient.tsx
@@ -44,7 +44,9 @@ import ProviderPageHeader from "./components/ProviderPageHeader";
 import CompatibleNodeCard from "./components/CompatibleNodeCard";
 import ProviderModalsPanel from "./components/ProviderModalsPanel";
 import EmptyConnectionsPlaceholder from "./components/EmptyConnectionsPlaceholder";
-import { providerText } from "./providerPageHelpers";
+import UpstreamProxyCard from "./components/UpstreamProxyCard";
+import SearchProviderCard from "./components/SearchProviderCard";
+// providerText used by UpstreamProxyCard (Phase 1t.7)
 
 export default function ProviderDetailPageClient() {
   const params = useParams();
@@ -610,44 +612,7 @@ export default function ProviderDetailPageClient() {
           )}
         </Card>
       )}
-      {isUpstreamProxyProvider && (
-        <Card>
-          <div className="flex flex-col gap-3">
-            <div>
-              <h2 className="text-lg font-semibold">
-                {providerText(
-                  t,
-                  "upstreamProxyManagedTitle",
-                  "Managed via Upstream Proxy Settings"
-                )}
-              </h2>
-              <p className="text-sm text-text-muted mt-1">
-                {providerText(
-                  t,
-                  "upstreamProxyManagedDescription",
-                  "CLIProxyAPI is configured as an upstream proxy layer, not as a direct provider connection. Manage the binary/runtime in CLI Tools and enable proxy routing on each provider via the provider proxy controls."
-                )}
-              </p>
-            </div>
-            <div className="flex flex-wrap gap-2">
-              <Link
-                href="/dashboard/cli-code"
-                className="inline-flex items-center gap-2 rounded-lg border border-border px-3 py-2 text-sm text-text-main hover:border-primary/40 hover:text-text-primary transition-colors"
-              >
-                <span className="material-symbols-outlined text-base">terminal</span>
-                {t("openCliTools")}
-              </Link>
-              <Link
-                href="/dashboard/settings"
-                className="inline-flex items-center gap-2 rounded-lg border border-border px-3 py-2 text-sm text-text-main hover:border-primary/40 hover:text-text-primary transition-colors"
-              >
-                <span className="material-symbols-outlined text-base">settings</span>
-                {t("openSettings")}
-              </Link>
-            </div>
-          </div>
-        </Card>
-      )}
+      {isUpstreamProxyProvider && <UpstreamProxyCard t={t} />}
 
       {/* Models — hidden for search providers (they don't have models) */}
       {!isSearchProvider && !isUpstreamProxyProvider && (
@@ -724,30 +689,7 @@ export default function ProviderDetailPageClient() {
       )}
 
       {/* Search provider info */}
-      {isSearchProvider && (
-        <Card>
-          <h2 className="text-lg font-semibold mb-4">{t("searchProvider")}</h2>
-          <p className="text-sm text-text-muted">{t("searchProviderDesc")}</p>
-          {providerId === "perplexity-search" && (
-            <div className="mt-3 flex items-center gap-2 px-3 py-2 rounded-lg bg-blue-500/10 border border-blue-500/20">
-              <span className="material-symbols-outlined text-sm text-blue-400">link</span>
-              <p className="text-xs text-blue-300">{t("perplexitySearchSharedKeyInfo")}</p>
-            </div>
-          )}
-          {providerId === "google-pse-search" && (
-            <div className="mt-3 flex items-center gap-2 px-3 py-2 rounded-lg bg-amber-500/10 border border-amber-500/20">
-              <span className="material-symbols-outlined text-sm text-amber-300">tune</span>
-              <p className="text-xs text-amber-200">{t("googlePseInfo")}</p>
-            </div>
-          )}
-          {providerId === "searxng-search" && (
-            <div className="mt-3 flex items-center gap-2 px-3 py-2 rounded-lg bg-emerald-500/10 border border-emerald-500/20">
-              <span className="material-symbols-outlined text-sm text-emerald-300">dns</span>
-              <p className="text-xs text-emerald-200">{t("searxngInfo")}</p>
-            </div>
-          )}
-        </Card>
-      )}
+      {isSearchProvider && <SearchProviderCard providerId={providerId} t={t} />}
 
       {/* Playground panel — rendered for providers that declare serviceKinds */}
       <ProviderPlaygroundPanel providerId={providerId} />

--- a/src/app/(dashboard)/dashboard/providers/[id]/ProviderDetailPageClient.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/ProviderDetailPageClient.tsx
@@ -143,6 +143,8 @@ import ProviderPageHeader from "./components/ProviderPageHeader";
 import CompatibleNodeCard from "./components/CompatibleNodeCard";
 // Phase 1t.3 extractions — Issue #3501
 import { useConnectionGate } from "./hooks/useConnectionGate";
+// Phase 1t.4 extractions — Issue #3501
+import { useProviderNodeActions } from "./hooks/useProviderNodeActions";
 // recordToHeaderRows moved to components/ModelCompatPopover.tsx (Phase 1d)
 // buildCompatMap, isModelHidden*, effectiveNormalize/Preserve*, anyNormalize/NoPreserveCompatBadge
 // moved to providerPageHelpers.ts + hook useModelCompatState (Phase 1e)
@@ -407,24 +409,6 @@ export default function ProviderDetailPageClient() {
     fetchAliases();
   }, [loading, isSearchProvider, fetchProviderModelMeta, fetchAliases]);
 
-  const handleUpdateNode = async (formData: any) => {
-    try {
-      const res = await fetch(`/api/provider-nodes/${providerId}`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(formData),
-      });
-      const data = await res.json();
-      if (res.ok) {
-        setProviderNode(data.node);
-        await fetchConnections();
-        setShowEditNodeModal(false);
-      }
-    } catch (error) {
-      console.log("Error updating provider node:", error);
-    }
-  };
-
   // loadCodexSettings, loadClaudeRoutingSettings → hooks/useProviderSettings.ts (Phase 1f)
   // loadConnProxies → hooks/useProviderConnections.ts (Phase 1f)
   // onTestModel, handleTestAll, saveModelCompatFlags, handleToggleModelHidden,
@@ -484,25 +468,16 @@ export default function ProviderDetailPageClient() {
     t,
   });
 
-  const handleUpdateConnection = async (formData) => {
-    try {
-      const res = await fetch(`/api/providers/${selectedConnection.id}`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(formData),
-      });
-      if (res.ok) {
-        await fetchConnections();
-        setShowEditModal(false);
-        return null;
-      }
-      const data = await res.json().catch(() => ({}));
-      return data.error?.message || data.error || t("failedSaveConnection");
-    } catch (error) {
-      console.log("Error updating connection:", error);
-      return t("failedSaveConnectionRetry");
-    }
-  };
+  // ── Phase 1t.4: node/connection update handlers ──────────────────────────
+  const { handleUpdateNode, handleUpdateConnection } = useProviderNodeActions({
+    providerId,
+    fetchConnections,
+    selectedConnection,
+    setProviderNode,
+    setShowEditNodeModal,
+    setShowEditModal,
+    t,
+  });
 
   // handleUpdateConnectionStatus, handleToggleProxyEnabled, handleTogglePerKeyProxyEnabled,
   // handleDistributeProxies, handleToggleRateLimit, handleToggleClaudeExtraUsage,

--- a/src/app/(dashboard)/dashboard/providers/[id]/ProviderDetailPageClient.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/ProviderDetailPageClient.tsx
@@ -15,7 +15,7 @@ import { useAuthFileHandlers } from "./hooks/useAuthFileHandlers";
 // Phase 1g: ProviderPlaygroundPanel + helpers extracted to components/ProviderPlaygroundPanel.tsx
 import ProviderPlaygroundPanel from "./components/ProviderPlaygroundPanel";
 import { useNotificationStore } from "@/store/notificationStore";
-import { useParams, useRouter } from "next/navigation";
+import { useParams } from "next/navigation";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
 import {
@@ -119,9 +119,6 @@ import {
   // CommandCodeAuthFlowState moved to hooks/useCommandCodeAuth.ts (Phase 1h)
   // CompatByProtocolMap, CompatModelRow, CompatModelMap → hooks/useModelVisibilityHandlers.ts (Phase 1l)
   // Phase 1s: pure helpers extracted from god-component closures
-  getApiLabel,
-  getApiDefaultPath,
-  getApiPath,
 } from "./providerPageHelpers";
 // CODEX_GLOBAL_SERVICE_MODE_VALUES, getCodexServiceTierLabel, normalizeCodexLimitPolicy
 // moved to hooks/useProviderSettings.ts + hooks/useProviderConnections.ts (Phase 1f)
@@ -142,6 +139,8 @@ import BatchTestResultsModal from "./components/BatchTestResultsModal";
 import { AdaptaTutorialModal } from "./components/AdaptaTutorialModal";
 // Phase 1t.1 extractions — Issue #3501
 import ProviderPageHeader from "./components/ProviderPageHeader";
+// Phase 1t.2 extractions — Issue #3501
+import CompatibleNodeCard from "./components/CompatibleNodeCard";
 // recordToHeaderRows moved to components/ModelCompatPopover.tsx (Phase 1d)
 // buildCompatMap, isModelHidden*, effectiveNormalize/Preserve*, anyNormalize/NoPreserveCompatBadge
 // moved to providerPageHelpers.ts + hook useModelCompatState (Phase 1e)
@@ -164,7 +163,6 @@ import ProviderPageHeader from "./components/ProviderPageHeader";
 
 export default function ProviderDetailPageClient() {
   const params = useParams();
-  const router = useRouter();
   const providerId = params.id as string;
 
   // ── UI-only modal state (not owned by hooks) ─────────────────────────────
@@ -671,77 +669,19 @@ export default function ProviderDetailPageClient() {
 
       {providerId === "zed" && <ZedImportCard fetchConnections={fetchConnections} notify={notify} />}
 
+      {/* CompatibleNodeCard — Phase 1t.2: extracted to components/CompatibleNodeCard.tsx */}
       {isCompatible && providerNode && (
-        <Card>
-          <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <div>
-              <h2 className="text-lg font-semibold">
-                {isCcCompatible
-                  ? t("ccCompatibleDetailsTitle")
-                  : isAnthropicCompatible
-                    ? t("anthropicCompatibleDetails")
-                    : t("openaiCompatibleDetails")}
-              </h2>
-              <p className="text-sm text-text-muted">
-                {getApiLabel(t, isAnthropicProtocolCompatible, providerNode?.apiType)} · {(providerNode.baseUrl || "").replace(/\/$/, "")}/{getApiPath(isCcCompatible, isAnthropicCompatible, providerNode?.apiType, providerNode?.chatPath)}
-              </p>
-            </div>
-            <div className="flex flex-wrap items-center gap-2">
-              <Button size="sm" icon="add" onClick={() => gateConnectionFlow(openApiKeyAddFlow)}>
-                {t("add")}
-              </Button>
-              <Button
-                size="sm"
-                variant="secondary"
-                icon="edit"
-                onClick={() => setShowEditNodeModal(true)}
-              >
-                {t("edit")}
-              </Button>
-              <Button
-                size="sm"
-                variant="secondary"
-                icon="delete"
-                onClick={async () => {
-                  if (
-                    !confirm(
-                      t("deleteCompatibleNodeConfirm", {
-                        type: isCcCompatible
-                          ? t("ccCompatibleLabel")
-                          : isAnthropicCompatible
-                            ? t("anthropic")
-                            : t("openai"),
-                      })
-                    )
-                  )
-                    return;
-                  try {
-                    const res = await fetch(`/api/provider-nodes/${providerId}`, {
-                      method: "DELETE",
-                    });
-                    if (res.ok) {
-                      router.push("/dashboard/providers");
-                    }
-                  } catch (error) {
-                    console.error("Error deleting provider node:", error);
-                  }
-                }}
-              >
-                {t("delete")}
-              </Button>
-            </div>
-          </div>
-          {isCcCompatible && (
-            <div className="mb-4 rounded-lg border border-amber-500/25 bg-amber-500/10 px-3 py-2 text-sm text-text-muted">
-              <div className="flex items-start gap-2">
-                <span className="material-symbols-outlined mt-0.5 text-[18px] text-amber-500">
-                  warning
-                </span>
-                <p>{t("ccCompatibleValidationHint")}</p>
-              </div>
-            </div>
-          )}
-        </Card>
+        <CompatibleNodeCard
+          providerId={providerId}
+          providerNode={providerNode}
+          isCcCompatible={isCcCompatible}
+          isAnthropicCompatible={isAnthropicCompatible}
+          isAnthropicProtocolCompatible={isAnthropicProtocolCompatible}
+          gateConnectionFlow={gateConnectionFlow}
+          openApiKeyAddFlow={openApiKeyAddFlow}
+          onOpenEditNodeModal={() => setShowEditNodeModal(true)}
+          t={t}
+        />
       )}
 
       {/* Connections */}

--- a/src/app/(dashboard)/dashboard/providers/[id]/ProviderDetailPageClient.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/ProviderDetailPageClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef, useMemo } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 // Phase 1f extractions — Issue #3501
 import { useProviderConnections } from "./hooks/useProviderConnections";
 import { useProviderSettings } from "./hooks/useProviderSettings";
@@ -65,7 +65,7 @@ import { type CodexGlobalServiceMode } from "@/lib/providers/codexFastTier";
 import { compareTr } from "@/shared/utils/turkishText";
 import RiskNoticeModal from "../components/RiskNoticeModal";
 import CodexCliGuideModal from "../components/CodexCliGuideModal";
-import { isRiskAcknowledged, useRiskAcknowledged } from "../hooks/useRiskAcknowledged";
+// isRiskAcknowledged, useRiskAcknowledged moved to hooks/useConnectionGate.ts (Phase 1t.3)
 import { resolveDashboardProviderInfo } from "../providerPageUtils";
 // webSessionCredentials used by extracted modals (AddApiKeyModal, EditConnectionModal)
 import {
@@ -141,6 +141,8 @@ import { AdaptaTutorialModal } from "./components/AdaptaTutorialModal";
 import ProviderPageHeader from "./components/ProviderPageHeader";
 // Phase 1t.2 extractions — Issue #3501
 import CompatibleNodeCard from "./components/CompatibleNodeCard";
+// Phase 1t.3 extractions — Issue #3501
+import { useConnectionGate } from "./hooks/useConnectionGate";
 // recordToHeaderRows moved to components/ModelCompatPopover.tsx (Phase 1d)
 // buildCompatMap, isModelHidden*, effectiveNormalize/Preserve*, anyNormalize/NoPreserveCompatBadge
 // moved to providerPageHelpers.ts + hook useModelCompatState (Phase 1e)
@@ -171,7 +173,6 @@ export default function ProviderDetailPageClient() {
   const [showAddApiKeyModal, setShowAddApiKeyModal] = useState(false);
   const [showSiliconFlowEndpointModal, setShowSiliconFlowEndpointModal] = useState(false);
   const [siliconFlowInitialBaseUrl, setSiliconFlowInitialBaseUrl] = useState<string | undefined>();
-  const [showRiskNoticeModal, setShowRiskNoticeModal] = useState(false);
   const [showEditModal, setShowEditModal] = useState(false);
   const [showEditNodeModal, setShowEditNodeModal] = useState(false);
   const [showTutorialModal, setShowTutorialModal] = useState(false);
@@ -181,9 +182,6 @@ export default function ProviderDetailPageClient() {
   const [codexCliGuideOpen, setCodexCliGuideOpen] = useState(false);
   const [importClaudeModalOpen, setImportClaudeModalOpen] = useState(false);
   const [importGeminiModalOpen, setImportGeminiModalOpen] = useState(false);
-  const pendingRiskActionRef = useRef<(() => void) | null>(null);
-  const { acknowledged: riskAcknowledged, acknowledge: acknowledgeRisk } =
-    useRiskAcknowledged(providerId);
   const isOpenAICompatible = isOpenAICompatibleProvider(providerId);
   const isCcCompatible = isClaudeCodeCompatibleProvider(providerId);
   const isCommandCode = providerId === "command-code";
@@ -307,6 +305,11 @@ export default function ProviderDetailPageClient() {
   const providerSupportsOAuth =
     providerInfo?.toggleAuthType === "oauth" || providerInfo?.toggleAuthType === "free";
   const subscriptionRisk = providerInfo?.subscriptionRisk === true;
+
+  // ── Phase 1t.3: connection gate + risk-notice modal state ───────────────
+  const { showRiskNoticeModal, gateConnectionFlow, handleConfirmRiskNotice, handleCancelRiskNotice } =
+    useConnectionGate({ providerId, subscriptionRisk });
+
   const providerSupportsPat = supportsApiKeyOnFreeProvider(providerId);
   const isOAuth = providerSupportsOAuth && !providerSupportsPat;
   const isFreeNoAuth = NOAUTH_PROVIDERS[providerId]?.noAuth === true;
@@ -451,31 +454,6 @@ export default function ProviderDetailPageClient() {
     }
     openApiKeyAddFlow();
   }, [isOAuth, openApiKeyAddFlow]);
-
-  const gateConnectionFlow = useCallback(
-    (callback: () => void) => {
-      if (subscriptionRisk && !riskAcknowledged && !isRiskAcknowledged(providerId)) {
-        pendingRiskActionRef.current = callback;
-        setShowRiskNoticeModal(true);
-        return;
-      }
-      callback();
-    },
-    [providerId, riskAcknowledged, subscriptionRisk]
-  );
-
-  const handleConfirmRiskNotice = useCallback(() => {
-    acknowledgeRisk();
-    setShowRiskNoticeModal(false);
-    const pendingAction = pendingRiskActionRef.current;
-    pendingRiskActionRef.current = null;
-    pendingAction?.();
-  }, [acknowledgeRisk]);
-
-  const handleCancelRiskNotice = useCallback(() => {
-    pendingRiskActionRef.current = null;
-    setShowRiskNoticeModal(false);
-  }, []);
 
   // ── Phase 1h: commandCode auth flow ─────────────────────────────────────
   const {

--- a/src/app/(dashboard)/dashboard/providers/[id]/ProviderDetailPageClient.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/ProviderDetailPageClient.tsx
@@ -59,8 +59,6 @@ import {
 import { useCopyToClipboard } from "@/shared/hooks/useCopyToClipboard";
 import { pickDisplayValue } from "@/shared/utils/maskEmail";
 import useEmailPrivacyStore from "@/store/emailPrivacyStore";
-import EmailPrivacyToggle from "@/shared/components/EmailPrivacyToggle";
-import ProviderIcon from "@/shared/components/ProviderIcon";
 import { type CodexServiceTier } from "@/lib/providers/requestDefaults";
 import { type CodexGlobalServiceMode } from "@/lib/providers/codexFastTier";
 // parseExtraApiKeys used by extracted EditConnectionModal
@@ -124,7 +122,6 @@ import {
   getApiLabel,
   getApiDefaultPath,
   getApiPath,
-  getHeaderIconProviderId,
 } from "./providerPageHelpers";
 // CODEX_GLOBAL_SERVICE_MODE_VALUES, getCodexServiceTierLabel, normalizeCodexLimitPolicy
 // moved to hooks/useProviderSettings.ts + hooks/useProviderConnections.ts (Phase 1f)
@@ -143,6 +140,8 @@ import ZedImportCard from "./components/ZedImportCard";
 import BatchTestResultsModal from "./components/BatchTestResultsModal";
 // Phase 1r extractions — Issue #3501
 import { AdaptaTutorialModal } from "./components/AdaptaTutorialModal";
+// Phase 1t.1 extractions — Issue #3501
+import ProviderPageHeader from "./components/ProviderPageHeader";
 // recordToHeaderRows moved to components/ModelCompatPopover.tsx (Phase 1d)
 // buildCompatMap, isModelHidden*, effectiveNormalize/Preserve*, anyNormalize/NoPreserveCompatBadge
 // moved to providerPageHelpers.ts + hook useModelCompatState (Phase 1e)
@@ -659,55 +658,16 @@ export default function ProviderDetailPageClient() {
 
   return (
     <div className="flex flex-col gap-8">
-      {/* Header */}
-      <div>
-        <Link
-          href="/dashboard/providers"
-          className="inline-flex items-center gap-1 text-sm text-text-muted hover:text-primary transition-colors mb-4"
-        >
-          <span className="material-symbols-outlined text-lg">arrow_back</span>
-          {t("backToProviders")}
-        </Link>
-        <div className="flex items-center gap-4">
-          <div
-            className="rounded-lg flex items-center justify-center"
-            style={{ backgroundColor: `${providerInfo.color}15` }}
-          >
-            <ProviderIcon providerId={getHeaderIconProviderId(isOpenAICompatible, isAnthropicProtocolCompatible, providerInfo.id, providerInfo.apiType)} size={48} type="color" />
-          </div>
-          <div>
-            {providerInfo.website ? (
-              <a
-                href={providerInfo.website}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-3xl font-semibold tracking-tight hover:underline inline-flex items-center gap-2"
-                style={{ color: providerInfo.color }}
-              >
-                {providerInfo.name}
-                <span className="material-symbols-outlined text-lg opacity-60">open_in_new</span>
-              </a>
-            ) : (
-              <h1 className="text-3xl font-semibold tracking-tight">{providerInfo.name}</h1>
-            )}
-            <div className="flex items-center gap-2">
-              <p className="text-text-muted">
-                {t("connectionCountLabel", { count: connections.length })}
-              </p>
-              <EmailPrivacyToggle size="md" />
-              {providerId === "adapta-web" && (
-                <button
-                  onClick={() => setShowTutorialModal(true)}
-                  className="text-sm font-medium underline underline-offset-2 opacity-70 hover:opacity-100 transition-opacity"
-                  style={{ color: providerInfo.color }}
-                >
-                  Tutorial
-                </button>
-              )}
-            </div>
-          </div>
-        </div>
-      </div>
+      {/* Header — Phase 1t.1: extracted to components/ProviderPageHeader.tsx */}
+      <ProviderPageHeader
+        providerId={providerId}
+        providerInfo={providerInfo}
+        connectionsCount={connections.length}
+        isOpenAICompatible={isOpenAICompatible}
+        isAnthropicProtocolCompatible={isAnthropicProtocolCompatible}
+        onOpenTutorial={() => setShowTutorialModal(true)}
+        t={t}
+      />
 
       {providerId === "zed" && <ZedImportCard fetchConnections={fetchConnections} notify={notify} />}
 

--- a/src/app/(dashboard)/dashboard/providers/[id]/ProviderDetailPageClient.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/ProviderDetailPageClient.tsx
@@ -1,32 +1,11 @@
 "use client";
 
+// Issue #3501 strangler-fig decomposition — Phase 1t (final push)
 import { useState, useEffect, useCallback, useMemo } from "react";
-// Phase 1f extractions — Issue #3501
-import { useProviderConnections } from "./hooks/useProviderConnections";
-import { useProviderSettings } from "./hooks/useProviderSettings";
-import { useProviderModels } from "./hooks/useProviderModels";
-// Phase 1h: commandCode auth flow extracted to hooks/useCommandCodeAuth.ts
-import { useCommandCodeAuth } from "./hooks/useCommandCodeAuth";
-// Phase 1i: external link flow extracted to hooks/useExternalLinkFlow.ts
-import { useExternalLinkFlow } from "./hooks/useExternalLinkFlow";
-// ExternalLinkModal — used by components/ProviderModalsPanel.tsx (Phase 1t.5)
-// Phase 1j: auth file handlers extracted to hooks/useAuthFileHandlers.ts
-import { useAuthFileHandlers } from "./hooks/useAuthFileHandlers";
-// Phase 1g: ProviderPlaygroundPanel + helpers extracted to components/ProviderPlaygroundPanel.tsx
-import ProviderPlaygroundPanel from "./components/ProviderPlaygroundPanel";
-import { useNotificationStore } from "@/store/notificationStore";
 import { useParams } from "next/navigation";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
-import {
-  Card,
-  Button,
-  CardSkeleton,
-  NoAuthProviderCard,
-  NoAuthAccountCard,
-} from "@/shared/components";
-// ConfirmModal, OAuthModal, KiroOAuthWrapper, CursorAuthModal, TraeAuthModal, ProxyConfigModal
-// — used by components/ProviderModalsPanel.tsx (Phase 1t.5)
+import { Card, Button, CardSkeleton, NoAuthProviderCard, NoAuthAccountCard } from "@/shared/components";
 import {
   NOAUTH_PROVIDERS,
   getProviderAlias,
@@ -34,85 +13,38 @@ import {
   isAnthropicCompatibleProvider,
   isClaudeCodeCompatibleProvider,
   supportsApiKeyOnFreeProvider,
-  // LOCAL_PROVIDERS, isSelfHostedChatProvider moved to extracted modals/helpers
-  // providerAllowsOptionalApiKey + supportsBulkApiKey used by extracted AddApiKeyModal
 } from "@/shared/constants/providers";
-// antigravityClientProfile + parseBulkApiKeys used by extracted modals (AddApiKeyModal, EditConnectionModal)
 import { getModelsByProviderId } from "@/shared/constants/models";
-import {
-  compatibleProviderSupportsModelImport,
-  getCompatibleFallbackModels,
-} from "@/lib/providers/managedAvailableModels";
+import { compatibleProviderSupportsModelImport, getCompatibleFallbackModels } from "@/lib/providers/managedAvailableModels";
 import { normalizeModelCatalogSource } from "@/shared/utils/modelCatalogSearch";
 import { useCopyToClipboard } from "@/shared/hooks/useCopyToClipboard";
 import useEmailPrivacyStore from "@/store/emailPrivacyStore";
-// pickDisplayValue, compareTr, CodexServiceTier, CodexGlobalServiceMode — used by extracted modals/hooks
-// RiskNoticeModal, CodexCliGuideModal — used by components/ProviderModalsPanel.tsx (Phase 1t.5)
-// isRiskAcknowledged, useRiskAcknowledged moved to hooks/useConnectionGate.ts (Phase 1t.3)
+import { useNotificationStore } from "@/store/notificationStore";
 import { resolveDashboardProviderInfo } from "../providerPageUtils";
-// webSessionCredentials used by extracted modals (AddApiKeyModal, EditConnectionModal)
-// ImportCodexAuthModal, ApplyCodexAuthModal, ImportClaudeAuthModal, ApplyClaudeAuthModal,
-// ImportGeminiAuthModal, ApplyGeminiAuthModal, EditCompatibleNodeModal, AddApiKeyModal,
-// EditConnectionModal — used by components/ProviderModalsPanel.tsx (Phase 1t.5)
-// WebSessionCredentialGuide used by extracted ConnectionRow/modals (Phase 1d/1e)
-// Phase 1d extractions — Issue #3501 (ConnectionRow, ModelCompatPopover, SiliconFlowEndpointModal
-// used by ConnectionsListPanel/ProviderModelsSection/ProviderModalsPanel)
 import { type ConnectionRowConnection } from "./components/ConnectionRow";
-// Phase 1k extractions — Issue #3501
+import { useProviderConnections } from "./hooks/useProviderConnections";
+import { useProviderSettings } from "./hooks/useProviderSettings";
+import { useProviderModels } from "./hooks/useProviderModels";
+import { useCommandCodeAuth } from "./hooks/useCommandCodeAuth";
+import { useExternalLinkFlow } from "./hooks/useExternalLinkFlow";
+import { useAuthFileHandlers } from "./hooks/useAuthFileHandlers";
 import { useModelImportHandlers } from "./hooks/useModelImportHandlers";
-// Phase 1s extractions — Issue #3501
 import { useApiKeySave } from "./hooks/useApiKeySave";
-// ImportProgressModal — used by components/ProviderModalsPanel.tsx (Phase 1t.5)
-// Phase 1l extractions — Issue #3501
 import { useModelVisibilityHandlers } from "./hooks/useModelVisibilityHandlers";
-// Phase 1m extractions — Issue #3501
-import ProviderModelsSection from "./components/ProviderModelsSection";
-import {
-  // All non-used helpers moved to extracted modals/hooks in prior phases
-  providerText,
-} from "./providerPageHelpers";
-// CODEX_GLOBAL_SERVICE_MODE_VALUES, getCodexServiceTierLabel, normalizeCodexLimitPolicy
-// moved to hooks/useProviderSettings.ts + hooks/useProviderConnections.ts (Phase 1f)
-// Phase 1e extractions — Issue #3501
 import { useModelCompatState } from "./hooks/useModelCompatState";
-import CustomModelsSection from "./components/CustomModelsSection";
-// ModelRow, ModelVisibilityToolbar, PassthroughModelsSection, CompatibleModelsSection → ProviderModelsSection (Phase 1m)
-import ConnectionsListPanel from "./components/ConnectionsListPanel";
-// Phase 1o extractions — Issue #3501
-import ConnectionsHeaderToolbar from "./components/ConnectionsHeaderToolbar";
-// Phase 1p extractions — Issue #3501
-import ZedImportCard from "./components/ZedImportCard";
-// Phase 1q extractions — Issue #3501
-// BatchTestResultsModal, AdaptaTutorialModal — used by components/ProviderModalsPanel.tsx (Phase 1t.5)
-// Phase 1t.1 extractions — Issue #3501
-import ProviderPageHeader from "./components/ProviderPageHeader";
-// Phase 1t.2 extractions — Issue #3501
-import CompatibleNodeCard from "./components/CompatibleNodeCard";
-// Phase 1t.5 extractions — Issue #3501
-import ProviderModalsPanel from "./components/ProviderModalsPanel";
-// Phase 1t.3 extractions — Issue #3501
 import { useConnectionGate } from "./hooks/useConnectionGate";
-// Phase 1t.4 extractions — Issue #3501
 import { useProviderNodeActions } from "./hooks/useProviderNodeActions";
-// recordToHeaderRows moved to components/ModelCompatPopover.tsx (Phase 1d)
-// buildCompatMap, isModelHidden*, effectiveNormalize/Preserve*, anyNormalize/NoPreserveCompatBadge
-// moved to providerPageHelpers.ts + hook useModelCompatState (Phase 1e)
-// formatProviderModelsErrorResponse moved to providerPageHelpers.ts (Phase 1e)
-
-// ModelCompatSavePatch → hooks/useModelVisibilityHandlers.ts (Phase 1l)
-// MAX_BULK_IDS moved to hooks/useProviderConnections.ts (Phase 1f)
-// ModelRowProps, PassthroughModelRowProps → components/ModelRow.tsx, PassthroughModelRow.tsx (Phase 1e)
-// PassthroughModelsSectionProps → components/PassthroughModelsSection.tsx (Phase 1e)
-// CustomModelsSectionProps → components/CustomModelsSection.tsx (Phase 1e)
-// CompatibleModelsSectionProps → components/CompatibleModelsSection.tsx (Phase 1e)
-// CooldownTimerProps moved to components/ConnectionRow.tsx (Phase 1d)
-
-// getModelSourceBadgeClass + ModelSourceBadge → components/ModelRow.tsx (Phase 1e)
-// ConnectionRowConnection, ConnectionRowProps moved to components/ConnectionRow.tsx (Phase 1d)
-
-// ModelCompatPopover extracted to components/ModelCompatPopover.tsx (Phase 1d)
-
-// ── ProviderPlaygroundPanel extracted to components/ProviderPlaygroundPanel.tsx (Phase 1g) ──
+import ProviderPlaygroundPanel from "./components/ProviderPlaygroundPanel";
+import ProviderModelsSection from "./components/ProviderModelsSection";
+import CustomModelsSection from "./components/CustomModelsSection";
+import ConnectionsListPanel from "./components/ConnectionsListPanel";
+import ConnectionsHeaderToolbar from "./components/ConnectionsHeaderToolbar";
+import ZedImportCard from "./components/ZedImportCard";
+import ProviderPageHeader from "./components/ProviderPageHeader";
+import CompatibleNodeCard from "./components/CompatibleNodeCard";
+import ProviderModalsPanel from "./components/ProviderModalsPanel";
+import EmptyConnectionsPlaceholder from "./components/EmptyConnectionsPlaceholder";
+import { providerText } from "./providerPageHelpers";
 
 export default function ProviderDetailPageClient() {
   const params = useParams();
@@ -167,7 +99,6 @@ export default function ProviderDetailPageClient() {
     setSelectedIds,
     setBatchDeleteConfirmOpen,
     setBatchTestResults,
-    setConnections,
     setProviderNode,
     fetchConnections,
     fetchProxyConfig,
@@ -232,7 +163,6 @@ export default function ProviderDetailPageClient() {
     externalLinkModalOpen,
     setExternalLinkModalOpen,
     externalLinkUrl,
-    externalLinkToken,
     externalLinkLoading,
     externalLinkError,
     externalLinkCopied,
@@ -318,7 +248,6 @@ export default function ProviderDetailPageClient() {
     togglingAutoSync,
     canImportModels,
     isAutoSyncEnabled,
-    autoSyncConnection,
     setShowImportModal,
     setImportProgress,
     handleImportModels,
@@ -340,32 +269,12 @@ export default function ProviderDetailPageClient() {
     providerStorageAlias,
   });
 
-  // fetchAliases, handleSetAlias, handleDeleteAlias → hooks/useProviderModels.ts (Phase 1f)
-  // fetchProviderModelMeta, fetchProxyConfig, fetchConnections → hooks/useProviderConnections.ts + useProviderModels.ts (Phase 1f)
-  // loadCodexSettings, loadClaudeRoutingSettings → hooks/useProviderSettings.ts (Phase 1f)
-  // loadConnProxies, handleRetestConnection, handleBatchTestAll, handleBatchRetest → hooks/useProviderConnections.ts (Phase 1f)
-  // handleDelete, handleBatchDeleteConfirm, handleBatchSetActive → hooks/useProviderConnections.ts (Phase 1f)
-  // handleUpdateConnectionStatus, handleToggleProxyEnabled, handleTogglePerKeyProxyEnabled → hooks/useProviderConnections.ts (Phase 1f)
-  // handleDistributeProxies, handleToggleRateLimit, handleToggleClaudeExtraUsage → hooks/useProviderConnections.ts (Phase 1f)
-  // handleToggleCliproxyapiMode, handleToggleCodexLimit, handleSwapPriority → hooks/useProviderConnections.ts (Phase 1f)
-  // handleToggleClaudeRoutingPreference, handleChangeCodexGlobalServiceMode → hooks/useProviderSettings.ts (Phase 1f)
-  // handleRefreshToken → hooks/useProviderConnections.ts (Phase 1f)
-
   // ── model-related effects (loading gate) ────────────────────────────────
   useEffect(() => {
     if (loading || isSearchProvider) return;
     fetchProviderModelMeta();
     fetchAliases();
   }, [loading, isSearchProvider, fetchProviderModelMeta, fetchAliases]);
-
-  // loadCodexSettings, loadClaudeRoutingSettings → hooks/useProviderSettings.ts (Phase 1f)
-  // loadConnProxies → hooks/useProviderConnections.ts (Phase 1f)
-  // onTestModel, handleTestAll, saveModelCompatFlags, handleToggleModelHidden,
-  // handleBulkToggleModelHidden, handleClearAllModels, providerAliasEntries
-  // → hooks/useModelVisibilityHandlers.ts (Phase 1l)
-
-  // handleToggleSelectOne/All, handleBatchDeleteOpenModal/Confirm, handleDelete,
-  // handleBatchSetActive → hooks/useProviderConnections.ts (Phase 1f)
 
   const handleOAuthSuccess = useCallback(() => {
     fetchConnections();
@@ -391,9 +300,7 @@ export default function ProviderDetailPageClient() {
   // ── Phase 1h: commandCode auth flow ─────────────────────────────────────
   const {
     commandCodeAuthState,
-    clearCommandCodeAuthTimer,
     handleCloseAddApiKeyModal,
-    handleCommandCodeAuthApply,
     handleStartCommandCodeAuth,
     handleOpenCommandCodeConnect,
   } = useCommandCodeAuth({
@@ -428,34 +335,7 @@ export default function ProviderDetailPageClient() {
     t,
   });
 
-  // handleUpdateConnectionStatus, handleToggleProxyEnabled, handleTogglePerKeyProxyEnabled,
-  // handleDistributeProxies, handleToggleRateLimit, handleToggleClaudeExtraUsage,
-  // handleToggleCliproxyapiMode, handleToggleCodexLimit, handleToggleClaudeRoutingPreference,
-  // handleChangeCodexGlobalServiceMode, handleRetestConnection, runBatchTest,
-  // handleBatchTestAll, handleBatchRetest, parseApiErrorMessage, getAttachmentFilename,
-  // handleRefreshToken → hooks/useProviderConnections.ts + useProviderSettings.ts (Phase 1f)
-
-  // handleToggleProxyEnabled → useProviderConnections (Phase 1f)
-
-  // handleTogglePerKeyProxyEnabled → useProviderConnections (Phase 1f)
-
-  // handleDistributeProxies → useProviderConnections (Phase 1f)
-
-  // handleToggleRateLimit → useProviderConnections (Phase 1f)
-
-  // handleToggleClaudeExtraUsage → useProviderConnections (Phase 1f)
-
-  // [cpaProviderEnabled] state + useEffect + handleToggleCliproxyapiMode → useProviderConnections (Phase 1f)
-
-  // handleToggleCodexLimit → useProviderConnections (Phase 1f)
-
-  // handleToggleClaudeRoutingPreference + handleChangeCodexGlobalServiceMode → useProviderSettings (Phase 1f)
-
-  // handleRetestConnection, runBatchTest, handleBatchTestAll, handleBatchRetest,
-  // [refreshingId], parseApiErrorMessage, getAttachmentFilename, handleRefreshToken
-  // → useProviderConnections (Phase 1f)
-
-  // Phase 1j: auth file handlers extracted to hooks/useAuthFileHandlers.ts
+  // Phase 1j: auth file handlers
   const {
     applyingCodexAuthId,
     applyCodexModalConnectionId,
@@ -477,16 +357,12 @@ export default function ProviderDetailPageClient() {
     handleExportGeminiAuthFile,
   } = useAuthFileHandlers({ parseApiErrorMessage, getAttachmentFilename, notify, t });
 
-  // handleSwapPriority → useProviderConnections (Phase 1f)
-  // handleImportModels, handleCompatibleImportWithProgress, handleToggleAutoSync,
-  // canImportModels, isAutoSyncEnabled, autoSyncConnection → hooks/useModelImportHandlers.ts (Phase 1k)
-
-  // Phase 1e: compat-state derivations moved to useModelCompatState hook.
+  // Phase 1e: compat-state derivations
   const compat = useModelCompatState(
     modelMeta.customModels,
     modelMeta.modelCompatOverrides
   );
-  const { customMap, overrideMap } = compat;
+  const { customMap } = compat;
   const effectiveModelNormalize = compat.effectiveModelNormalize;
   const effectiveModelPreserveDeveloper = compat.effectiveModelPreserveDeveloper;
   const effectiveModelHidden = compat.isModelHidden;
@@ -651,88 +527,23 @@ export default function ProviderDetailPageClient() {
           />
 
           {connections.length === 0 ? (
-            <div className="text-center py-12">
-              <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-primary/10 text-primary mb-4">
-                <span className="material-symbols-outlined text-[32px]">
-                  {isOAuth ? "lock" : "key"}
-                </span>
-              </div>
-              <p className="text-text-main font-medium mb-1">{t("noConnectionsYet")}</p>
-              <p className="text-sm text-text-muted mb-4">{t("addFirstConnectionHint")}</p>
-              {!isCompatible && (
-                <div className="flex items-center justify-center gap-2">
-                  {isCommandCode ? (
-                    <>
-                      <Button
-                        icon="open_in_new"
-                        loading={
-                          commandCodeAuthState.phase === "starting" ||
-                          commandCodeAuthState.phase === "polling" ||
-                          commandCodeAuthState.phase === "applying"
-                        }
-                        onClick={() => gateConnectionFlow(handleOpenCommandCodeConnect)}
-                      >
-                        Connect
-                      </Button>
-                      <Button
-                        variant="secondary"
-                        icon="add"
-                        onClick={() => gateConnectionFlow(openApiKeyAddFlow)}
-                      >
-                        Manual API key
-                      </Button>
-                    </>
-                  ) : (
-                    <>
-                      <Button icon="add" onClick={() => gateConnectionFlow(openPrimaryAddFlow)}>
-                        {providerSupportsPat ? "Add PAT" : t("addConnection")}
-                      </Button>
-                      {providerId === "qoder" && (
-                        <Button
-                          variant="secondary"
-                          onClick={() => gateConnectionFlow(() => setShowOAuthModal(true))}
-                        >
-                          Experimental OAuth
-                        </Button>
-                      )}
-                      {providerId === "codex" && (
-                        <Button
-                          variant="secondary"
-                          icon="upload_file"
-                          onClick={() => gateConnectionFlow(() => setImportCodexModalOpen(true))}
-                        >
-                          {typeof t.has === "function" && t.has("importCodexAuth")
-                            ? t("importCodexAuth")
-                            : "Import auth"}
-                        </Button>
-                      )}
-                      {providerId === "claude" && (
-                        <Button
-                          variant="secondary"
-                          icon="upload_file"
-                          onClick={() => gateConnectionFlow(() => setImportClaudeModalOpen(true))}
-                        >
-                          {typeof t.has === "function" && t.has("importClaudeAuth")
-                            ? t("importClaudeAuth")
-                            : "Import auth"}
-                        </Button>
-                      )}
-                      {providerId === "gemini-cli" && (
-                        <Button
-                          variant="secondary"
-                          icon="upload_file"
-                          onClick={() => gateConnectionFlow(() => setImportGeminiModalOpen(true))}
-                        >
-                          {typeof t.has === "function" && t.has("importGeminiAuth")
-                            ? t("importGeminiAuth")
-                            : "Import auth"}
-                        </Button>
-                      )}
-                    </>
-                  )}
-                </div>
-              )}
-            </div>
+            <EmptyConnectionsPlaceholder
+              isOAuth={isOAuth}
+              isCompatible={isCompatible}
+              isCommandCode={isCommandCode}
+              providerId={providerId}
+              providerSupportsPat={providerSupportsPat}
+              commandCodeAuthState={commandCodeAuthState}
+              gateConnectionFlow={gateConnectionFlow}
+              openApiKeyAddFlow={openApiKeyAddFlow}
+              openPrimaryAddFlow={openPrimaryAddFlow}
+              handleOpenCommandCodeConnect={handleOpenCommandCodeConnect}
+              onOpenOAuthModal={() => setShowOAuthModal(true)}
+              onOpenImportCodex={() => setImportCodexModalOpen(true)}
+              onOpenImportClaude={() => setImportClaudeModalOpen(true)}
+              onOpenImportGemini={() => setImportGeminiModalOpen(true)}
+              t={t}
+            />
           ) : (
             <ConnectionsListPanel
               connections={connections}
@@ -1026,9 +837,3 @@ export default function ProviderDetailPageClient() {
   );
 }
 
-// ModelRow, ModelVisibilityToolbar, PassthroughModelsSection, PassthroughModelRow,
-// CustomModelsSection, CompatibleModelsSection → components/ (Phase 1e — Issue #3501)
-
-// Phase 1d: CooldownTimer, inferErrorType, getStatusPresentation, ConnectionRow → components/ConnectionRow.tsx
-// Phase 1d: ModelCompatPopover, recordToHeaderRows → components/ModelCompatPopover.tsx
-// Phase 1d: SiliconFlowEndpointModal → components/SiliconFlowEndpointModal.tsx

--- a/src/app/(dashboard)/dashboard/providers/[id]/ProviderDetailPageClient.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/ProviderDetailPageClient.tsx
@@ -9,7 +9,7 @@ import { useProviderModels } from "./hooks/useProviderModels";
 import { useCommandCodeAuth } from "./hooks/useCommandCodeAuth";
 // Phase 1i: external link flow extracted to hooks/useExternalLinkFlow.ts
 import { useExternalLinkFlow } from "./hooks/useExternalLinkFlow";
-import ExternalLinkModal from "./components/ExternalLinkModal";
+// ExternalLinkModal — used by components/ProviderModalsPanel.tsx (Phase 1t.5)
 // Phase 1j: auth file handlers extracted to hooks/useAuthFileHandlers.ts
 import { useAuthFileHandlers } from "./hooks/useAuthFileHandlers";
 // Phase 1g: ProviderPlaygroundPanel + helpers extracted to components/ProviderPlaygroundPanel.tsx
@@ -21,29 +21,20 @@ import { useTranslations } from "next-intl";
 import {
   Card,
   Button,
-  Badge,
-  Modal,
-  ConfirmModal,
   CardSkeleton,
-  OAuthModal,
-  KiroOAuthWrapper,
-  CursorAuthModal,
-  TraeAuthModal,
-  Toggle,
-  Select,
-  ProxyConfigModal,
   NoAuthProviderCard,
   NoAuthAccountCard,
 } from "@/shared/components";
+// ConfirmModal, OAuthModal, KiroOAuthWrapper, CursorAuthModal, TraeAuthModal, ProxyConfigModal
+// — used by components/ProviderModalsPanel.tsx (Phase 1t.5)
 import {
-  LOCAL_PROVIDERS,
   NOAUTH_PROVIDERS,
   getProviderAlias,
   isOpenAICompatibleProvider,
   isAnthropicCompatibleProvider,
   isClaudeCodeCompatibleProvider,
-  isSelfHostedChatProvider,
   supportsApiKeyOnFreeProvider,
+  // LOCAL_PROVIDERS, isSelfHostedChatProvider moved to extracted modals/helpers
   // providerAllowsOptionalApiKey + supportsBulkApiKey used by extracted AddApiKeyModal
 } from "@/shared/constants/providers";
 // antigravityClientProfile + parseBulkApiKeys used by extracted modals (AddApiKeyModal, EditConnectionModal)
@@ -52,95 +43,53 @@ import {
   compatibleProviderSupportsModelImport,
   getCompatibleFallbackModels,
 } from "@/lib/providers/managedAvailableModels";
-import {
-  matchesModelCatalogQuery,
-  normalizeModelCatalogSource,
-} from "@/shared/utils/modelCatalogSearch";
+import { normalizeModelCatalogSource } from "@/shared/utils/modelCatalogSearch";
 import { useCopyToClipboard } from "@/shared/hooks/useCopyToClipboard";
-import { pickDisplayValue } from "@/shared/utils/maskEmail";
 import useEmailPrivacyStore from "@/store/emailPrivacyStore";
-import { type CodexServiceTier } from "@/lib/providers/requestDefaults";
-import { type CodexGlobalServiceMode } from "@/lib/providers/codexFastTier";
-// parseExtraApiKeys used by extracted EditConnectionModal
-import { compareTr } from "@/shared/utils/turkishText";
-import RiskNoticeModal from "../components/RiskNoticeModal";
-import CodexCliGuideModal from "../components/CodexCliGuideModal";
+// pickDisplayValue, compareTr, CodexServiceTier, CodexGlobalServiceMode — used by extracted modals/hooks
+// RiskNoticeModal, CodexCliGuideModal — used by components/ProviderModalsPanel.tsx (Phase 1t.5)
 // isRiskAcknowledged, useRiskAcknowledged moved to hooks/useConnectionGate.ts (Phase 1t.3)
 import { resolveDashboardProviderInfo } from "../providerPageUtils";
 // webSessionCredentials used by extracted modals (AddApiKeyModal, EditConnectionModal)
-import {
-  ImportCodexAuthModal,
-  ApplyCodexAuthModal,
-} from "./components/modals/ImportCodexAuthModal";
-import {
-  ImportClaudeAuthModal,
-  ApplyClaudeAuthModal,
-} from "./components/modals/ImportClaudeAuthModal";
-import {
-  ImportGeminiAuthModal,
-  ApplyGeminiAuthModal,
-} from "./components/modals/ImportGeminiAuthModal";
-
-import EditCompatibleNodeModal from "./components/modals/EditCompatibleNodeModal";
-import AddApiKeyModal from "./components/modals/AddApiKeyModal";
-import EditConnectionModal from "./components/modals/EditConnectionModal";
-import WebSessionCredentialGuide from "./components/WebSessionCredentialGuide";
-// Phase 1d extractions — Issue #3501
-import ConnectionRow, {
-  type ConnectionRowConnection,
-} from "./components/ConnectionRow";
-import ModelCompatPopover from "./components/ModelCompatPopover";
-import SiliconFlowEndpointModal from "./components/SiliconFlowEndpointModal";
+// ImportCodexAuthModal, ApplyCodexAuthModal, ImportClaudeAuthModal, ApplyClaudeAuthModal,
+// ImportGeminiAuthModal, ApplyGeminiAuthModal, EditCompatibleNodeModal, AddApiKeyModal,
+// EditConnectionModal — used by components/ProviderModalsPanel.tsx (Phase 1t.5)
+// WebSessionCredentialGuide used by extracted ConnectionRow/modals (Phase 1d/1e)
+// Phase 1d extractions — Issue #3501 (ConnectionRow, ModelCompatPopover, SiliconFlowEndpointModal
+// used by ConnectionsListPanel/ProviderModelsSection/ProviderModalsPanel)
+import { type ConnectionRowConnection } from "./components/ConnectionRow";
 // Phase 1k extractions — Issue #3501
 import { useModelImportHandlers } from "./hooks/useModelImportHandlers";
 // Phase 1s extractions — Issue #3501
 import { useApiKeySave } from "./hooks/useApiKeySave";
-import ImportProgressModal from "./components/ImportProgressModal";
+// ImportProgressModal — used by components/ProviderModalsPanel.tsx (Phase 1t.5)
 // Phase 1l extractions — Issue #3501
 import { useModelVisibilityHandlers } from "./hooks/useModelVisibilityHandlers";
 // Phase 1m extractions — Issue #3501
 import ProviderModelsSection from "./components/ProviderModelsSection";
 import {
-  // CONFIGURABLE_BASE_URL_PROVIDERS, DEFAULT_PROVIDER_BASE_URLS, getLocalProviderMetadata,
-  // isBaseUrlConfigurableProvider, getProviderBaseUrlDefault, getProviderBaseUrlHint,
-  // getProviderBaseUrlPlaceholder, isGlmProvider, parseRoutingTagsInput, parseExcludedModelsInput,
-  // formatRoutingTagsInput, formatExcludedModelsInput, getWebSessionCredentialLabel,
-  // getWebSessionCredentialHint, getWebSessionCredentialCheckLabel, getAddCredentialModalTitle,
-  // CODEX_REASONING_STRENGTH_OPTIONS, CODEX_ACCOUNT_SERVICE_TIER_VALUES, getCodexRequestDefaults,
-  // getClaudeCodeCompatibleRequestDefaults, extractCommandCodeCredentialInput,
-  // normalizeAndValidateHttpBaseUrl, formatTimeAgo
-  // — all moved to extracted modals (AddApiKeyModal, EditConnectionModal, WebSessionCredentialGuide)
+  // All non-used helpers moved to extracted modals/hooks in prior phases
   providerText,
-  providerCountText,
-  readBooleanToggle,
-  // formatProviderModelsErrorResponse → hooks/useModelVisibilityHandlers.ts (Phase 1l)
-  type ProviderMessageTranslator,
-  type LocalProviderMetadata,
-  // CommandCodeAuthFlowState moved to hooks/useCommandCodeAuth.ts (Phase 1h)
-  // CompatByProtocolMap, CompatModelRow, CompatModelMap → hooks/useModelVisibilityHandlers.ts (Phase 1l)
-  // Phase 1s: pure helpers extracted from god-component closures
 } from "./providerPageHelpers";
 // CODEX_GLOBAL_SERVICE_MODE_VALUES, getCodexServiceTierLabel, normalizeCodexLimitPolicy
 // moved to hooks/useProviderSettings.ts + hooks/useProviderConnections.ts (Phase 1f)
 // Phase 1e extractions — Issue #3501
 import { useModelCompatState } from "./hooks/useModelCompatState";
-import ModelRow, { ModelVisibilityToolbar } from "./components/ModelRow";
-import PassthroughModelsSection from "./components/PassthroughModelsSection";
 import CustomModelsSection from "./components/CustomModelsSection";
-import CompatibleModelsSection from "./components/CompatibleModelsSection";
+// ModelRow, ModelVisibilityToolbar, PassthroughModelsSection, CompatibleModelsSection → ProviderModelsSection (Phase 1m)
 import ConnectionsListPanel from "./components/ConnectionsListPanel";
 // Phase 1o extractions — Issue #3501
 import ConnectionsHeaderToolbar from "./components/ConnectionsHeaderToolbar";
 // Phase 1p extractions — Issue #3501
 import ZedImportCard from "./components/ZedImportCard";
 // Phase 1q extractions — Issue #3501
-import BatchTestResultsModal from "./components/BatchTestResultsModal";
-// Phase 1r extractions — Issue #3501
-import { AdaptaTutorialModal } from "./components/AdaptaTutorialModal";
+// BatchTestResultsModal, AdaptaTutorialModal — used by components/ProviderModalsPanel.tsx (Phase 1t.5)
 // Phase 1t.1 extractions — Issue #3501
 import ProviderPageHeader from "./components/ProviderPageHeader";
 // Phase 1t.2 extractions — Issue #3501
 import CompatibleNodeCard from "./components/CompatibleNodeCard";
+// Phase 1t.5 extractions — Issue #3501
+import ProviderModalsPanel from "./components/ProviderModalsPanel";
 // Phase 1t.3 extractions — Issue #3501
 import { useConnectionGate } from "./hooks/useConnectionGate";
 // Phase 1t.4 extractions — Issue #3501
@@ -992,231 +941,87 @@ export default function ProviderDetailPageClient() {
       {/* Playground panel — rendered for providers that declare serviceKinds */}
       <ProviderPlaygroundPanel providerId={providerId} />
 
-      {/* Modals */}
-      {showRiskNoticeModal && subscriptionRisk && (
-        <RiskNoticeModal
-          variant={providerInfo.riskNoticeVariant ?? "oauth"}
-          providerId={providerId}
-          providerName={providerInfo.name}
-          onConfirm={handleConfirmRiskNotice}
-          onCancel={handleCancelRiskNotice}
-        />
-      )}
-      {!isUpstreamProxyProvider &&
-        (providerId === "kiro" || providerId === "amazon-q" ? (
-          <KiroOAuthWrapper
-            isOpen={showOAuthModal}
-            reauthConnection={reauthConnection}
-            providerInfo={{ ...providerInfo, id: providerId }}
-            onSuccess={handleOAuthSuccess}
-            onClose={() => {
-              setShowOAuthModal(false);
-            }}
-          />
-        ) : providerId === "cursor" ? (
-          <CursorAuthModal
-            isOpen={showOAuthModal}
-            reauthConnection={reauthConnection}
-            onSuccess={handleOAuthSuccess}
-            onClose={() => {
-              setShowOAuthModal(false);
-            }}
-          />
-        ) : providerId === "trae" ? (
-          <TraeAuthModal
-            isOpen={showOAuthModal}
-            reauthConnection={reauthConnection}
-            onSuccess={handleOAuthSuccess}
-            onClose={() => {
-              setShowOAuthModal(false);
-            }}
-          />
-        ) : (
-          <OAuthModal
-            isOpen={showOAuthModal}
-            reauthConnection={reauthConnection}
-            provider={providerId}
-            providerInfo={providerInfo}
-            onSuccess={handleOAuthSuccess}
-            onClose={() => {
-              setShowOAuthModal(false);
-            }}
-          />
-        ))}
-      {providerId === "siliconflow" && (
-        <SiliconFlowEndpointModal
-          isOpen={showSiliconFlowEndpointModal}
-          onSelect={(baseUrl) => {
-            setSiliconFlowInitialBaseUrl(baseUrl);
-            setShowSiliconFlowEndpointModal(false);
-            setShowAddApiKeyModal(true);
-          }}
-          onClose={() => {
-            setShowSiliconFlowEndpointModal(false);
-            setSiliconFlowInitialBaseUrl(undefined);
-          }}
-        />
-      )}
-      {!isUpstreamProxyProvider && (
-        <AddApiKeyModal
-          isOpen={showAddApiKeyModal}
-          provider={providerId}
-          providerName={providerInfo.name}
-          initialBaseUrl={siliconFlowInitialBaseUrl}
-          isCompatible={isCompatible}
-          isAnthropic={isAnthropicProtocolCompatible}
-          isCcCompatible={isCcCompatible}
-          isCommandCode={isCommandCode}
-          commandCodeAuthState={commandCodeAuthState}
-          onStartCommandCodeAuth={handleStartCommandCodeAuth}
-          onSave={handleSaveApiKey}
-          onClose={handleCloseAddApiKeyModal}
-        />
-      )}
-      <ConfirmModal
-        isOpen={batchDeleteConfirmOpen}
-        onClose={() => setBatchDeleteConfirmOpen(false)}
-        onConfirm={handleBatchDeleteConfirm}
-        title={t("batchDeleteConfirmTitle", "Delete connections")}
-        message={t("batchDeleteConfirm", { count: selectedIds.size })}
-        confirmText={t("batchDeleteConfirmButton", "Delete")}
-        cancelText={t("cancel", "Cancel")}
-        loading={batchDeleting}
-      />
-      {providerId === "codex" && applyCodexModalConnectionId && (
-        <ApplyCodexAuthModal
-          key={applyCodexModalConnectionId}
-          connectionId={applyCodexModalConnectionId}
-          inProgress={!!applyingCodexAuthId}
-          onConfirm={handleApplyCodexAuthLocal}
-          onClose={() => setApplyCodexModalConnectionId(null)}
-        />
-      )}
-      {!isUpstreamProxyProvider && (
-        <EditConnectionModal
-          isOpen={showEditModal}
-          connection={selectedConnection}
-          onSave={handleUpdateConnection}
-          onClose={() => setShowEditModal(false)}
-        />
-      )}
-      {!isUpstreamProxyProvider && isCompatible && (
-        <EditCompatibleNodeModal
-          isOpen={showEditNodeModal}
-          node={providerNode}
-          onSave={handleUpdateNode}
-          onClose={() => setShowEditNodeModal(false)}
-          isAnthropic={isAnthropicProtocolCompatible}
-          isCcCompatible={isCcCompatible}
-        />
-      )}
-      {/* Codex CLI Guide Modal */}
-      <CodexCliGuideModal isOpen={codexCliGuideOpen} onClose={() => setCodexCliGuideOpen(false)} />
-      {/* Codex Import Auth Modal */}
-      {providerId === "codex" && importCodexModalOpen && (
-        <ImportCodexAuthModal
-          key="import-codex-modal"
-          onClose={() => setImportCodexModalOpen(false)}
-          onSuccess={() => {
-            setImportCodexModalOpen(false);
-            void fetchConnections();
-          }}
-        />
-      )}
-      {providerId === "codex" && externalLinkModalOpen && (
-        <ExternalLinkModal
-          isOpen={externalLinkModalOpen}
-          onClose={() => setExternalLinkModalOpen(false)}
-          loading={externalLinkLoading}
-          error={externalLinkError}
-          url={externalLinkUrl}
-          copied={externalLinkCopied}
-          onCopy={externalLinkCopy}
-        />
-      )}
-      {/* Claude Apply Auth Modal */}
-      {providerId === "claude" && applyClaudeModalConnectionId && (
-        <ApplyClaudeAuthModal
-          key={applyClaudeModalConnectionId}
-          connectionId={applyClaudeModalConnectionId}
-          inProgress={!!applyingClaudeAuthId}
-          onConfirm={handleApplyClaudeAuthLocal}
-          onClose={() => setApplyClaudeModalConnectionId(null)}
-        />
-      )}
-      {/* Claude Import Auth Modal */}
-      {providerId === "claude" && importClaudeModalOpen && (
-        <ImportClaudeAuthModal
-          key="import-claude-modal"
-          onClose={() => setImportClaudeModalOpen(false)}
-          onSuccess={() => {
-            setImportClaudeModalOpen(false);
-            void fetchConnections();
-          }}
-        />
-      )}
-      {/* Gemini Apply Auth Modal */}
-      {providerId === "gemini-cli" && applyGeminiModalConnectionId && (
-        <ApplyGeminiAuthModal
-          key={applyGeminiModalConnectionId}
-          connectionId={applyGeminiModalConnectionId}
-          inProgress={!!applyingGeminiAuthId}
-          onConfirm={handleApplyGeminiAuthLocal}
-          onClose={() => setApplyGeminiModalConnectionId(null)}
-        />
-      )}
-      {/* Gemini Import Auth Modal */}
-      {providerId === "gemini-cli" && importGeminiModalOpen && (
-        <ImportGeminiAuthModal
-          key="import-gemini-modal"
-          onClose={() => setImportGeminiModalOpen(false)}
-          onSuccess={() => {
-            setImportGeminiModalOpen(false);
-            void fetchConnections();
-          }}
-        />
-      )}
-      {/* Batch Test Results Modal */}
-      <BatchTestResultsModal
-        batchTestResults={batchTestResults}
-        providerInfo={providerInfo}
+      {/* Modals — Phase 1t.5: extracted to components/ProviderModalsPanel.tsx */}
+      <ProviderModalsPanel
         providerId={providerId}
+        providerInfo={providerInfo}
+        isCompatible={isCompatible}
+        isAnthropicProtocolCompatible={isAnthropicProtocolCompatible}
+        isCcCompatible={isCcCompatible}
+        isCommandCode={isCommandCode}
+        isUpstreamProxyProvider={isUpstreamProxyProvider}
+        subscriptionRisk={subscriptionRisk}
+        showRiskNoticeModal={showRiskNoticeModal}
+        handleConfirmRiskNotice={handleConfirmRiskNotice}
+        handleCancelRiskNotice={handleCancelRiskNotice}
+        showOAuthModal={showOAuthModal}
+        reauthConnection={reauthConnection}
+        handleOAuthSuccess={handleOAuthSuccess}
+        setShowOAuthModal={setShowOAuthModal}
+        showSiliconFlowEndpointModal={showSiliconFlowEndpointModal}
+        setSiliconFlowInitialBaseUrl={setSiliconFlowInitialBaseUrl}
+        setShowSiliconFlowEndpointModal={setShowSiliconFlowEndpointModal}
+        setShowAddApiKeyModal={setShowAddApiKeyModal}
+        showAddApiKeyModal={showAddApiKeyModal}
+        siliconFlowInitialBaseUrl={siliconFlowInitialBaseUrl}
+        commandCodeAuthState={commandCodeAuthState}
+        handleStartCommandCodeAuth={handleStartCommandCodeAuth}
+        handleSaveApiKey={handleSaveApiKey}
+        handleCloseAddApiKeyModal={handleCloseAddApiKeyModal}
+        batchDeleteConfirmOpen={batchDeleteConfirmOpen}
+        setBatchDeleteConfirmOpen={setBatchDeleteConfirmOpen}
+        handleBatchDeleteConfirm={handleBatchDeleteConfirm}
+        selectedIds={selectedIds}
+        batchDeleting={batchDeleting}
+        applyCodexModalConnectionId={applyCodexModalConnectionId}
+        setApplyCodexModalConnectionId={setApplyCodexModalConnectionId}
+        applyingCodexAuthId={applyingCodexAuthId}
+        handleApplyCodexAuthLocal={handleApplyCodexAuthLocal}
+        importCodexModalOpen={importCodexModalOpen}
+        setImportCodexModalOpen={setImportCodexModalOpen}
+        fetchConnections={fetchConnections}
+        externalLinkModalOpen={externalLinkModalOpen}
+        setExternalLinkModalOpen={setExternalLinkModalOpen}
+        externalLinkLoading={externalLinkLoading}
+        externalLinkError={externalLinkError}
+        externalLinkUrl={externalLinkUrl}
+        externalLinkCopied={externalLinkCopied}
+        externalLinkCopy={externalLinkCopy}
+        showEditModal={showEditModal}
+        setShowEditModal={setShowEditModal}
+        selectedConnection={selectedConnection}
+        handleUpdateConnection={handleUpdateConnection}
+        showEditNodeModal={showEditNodeModal}
+        setShowEditNodeModal={setShowEditNodeModal}
+        providerNode={providerNode}
+        handleUpdateNode={handleUpdateNode}
+        codexCliGuideOpen={codexCliGuideOpen}
+        setCodexCliGuideOpen={setCodexCliGuideOpen}
+        applyClaudeModalConnectionId={applyClaudeModalConnectionId}
+        setApplyClaudeModalConnectionId={setApplyClaudeModalConnectionId}
+        applyingClaudeAuthId={applyingClaudeAuthId}
+        handleApplyClaudeAuthLocal={handleApplyClaudeAuthLocal}
+        importClaudeModalOpen={importClaudeModalOpen}
+        setImportClaudeModalOpen={setImportClaudeModalOpen}
+        applyGeminiModalConnectionId={applyGeminiModalConnectionId}
+        setApplyGeminiModalConnectionId={setApplyGeminiModalConnectionId}
+        applyingGeminiAuthId={applyingGeminiAuthId}
+        handleApplyGeminiAuthLocal={handleApplyGeminiAuthLocal}
+        importGeminiModalOpen={importGeminiModalOpen}
+        setImportGeminiModalOpen={setImportGeminiModalOpen}
+        batchTestResults={batchTestResults}
+        setBatchTestResults={setBatchTestResults}
         emailsVisible={emailsVisible}
-        onClose={() => setBatchTestResults(null)}
-        t={t}
-      />
-      {/* Proxy Config Modal */}
-      {proxyTarget && (
-        <ProxyConfigModal
-          isOpen={!!proxyTarget}
-          onClose={() => setProxyTarget(null)}
-          level={proxyTarget.level}
-          levelId={proxyTarget.id}
-          levelLabel={proxyTarget.label}
-          onSaved={() => {
-            void fetchProxyConfig();
-          }}
-        />
-      )}
-      {/* Import Progress Modal — Phase 1k: extracted to components/ImportProgressModal.tsx */}
-      <ImportProgressModal
+        proxyTarget={proxyTarget}
+        setProxyTarget={setProxyTarget}
+        fetchProxyConfig={fetchProxyConfig}
         importProgress={importProgress}
-        isOpen={showImportModal}
-        onClose={() => {
-          if (importProgress.phase === "done" || importProgress.phase === "error") {
-            setShowImportModal(false);
-          }
-        }}
+        showImportModal={showImportModal}
+        setShowImportModal={setShowImportModal}
+        showTutorialModal={showTutorialModal}
+        setShowTutorialModal={setShowTutorialModal}
         t={t}
       />
-
-      {/* Adapta Web — Tutorial Modal */}
-      {providerId === "adapta-web" && (
-        <AdaptaTutorialModal
-          isOpen={showTutorialModal}
-          onClose={() => setShowTutorialModal(false)}
-        />
-      )}
     </div>
   );
 }

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/CompatibleNodeCard.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/CompatibleNodeCard.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+// Phase 1t.2 extraction — Issue #3501
+import { useRouter } from "next/navigation";
+import { Card, Button } from "@/shared/components";
+import { getApiLabel, getApiPath } from "../providerPageHelpers";
+import type { ProviderMessageTranslator } from "../providerPageHelpers";
+
+interface ProviderNode {
+  baseUrl?: string;
+  apiType?: string;
+  chatPath?: string;
+  prefix?: string;
+  [key: string]: unknown;
+}
+
+interface CompatibleNodeCardProps {
+  providerId: string;
+  providerNode: ProviderNode;
+  isCcCompatible: boolean;
+  isAnthropicCompatible: boolean;
+  isAnthropicProtocolCompatible: boolean;
+  gateConnectionFlow: (callback: () => void) => void;
+  openApiKeyAddFlow: () => void;
+  onOpenEditNodeModal: () => void;
+  t: ProviderMessageTranslator;
+}
+
+export default function CompatibleNodeCard({
+  providerId,
+  providerNode,
+  isCcCompatible,
+  isAnthropicCompatible,
+  isAnthropicProtocolCompatible,
+  gateConnectionFlow,
+  openApiKeyAddFlow,
+  onOpenEditNodeModal,
+  t,
+}: CompatibleNodeCardProps) {
+  const router = useRouter();
+
+  return (
+    <Card>
+      <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h2 className="text-lg font-semibold">
+            {isCcCompatible
+              ? t("ccCompatibleDetailsTitle")
+              : isAnthropicCompatible
+                ? t("anthropicCompatibleDetails")
+                : t("openaiCompatibleDetails")}
+          </h2>
+          <p className="text-sm text-text-muted">
+            {getApiLabel(t, isAnthropicProtocolCompatible, providerNode?.apiType)} ·{" "}
+            {(providerNode.baseUrl || "").replace(/\/$/, "")}/
+            {getApiPath(
+              isCcCompatible,
+              isAnthropicCompatible,
+              providerNode?.apiType,
+              providerNode?.chatPath
+            )}
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <Button size="sm" icon="add" onClick={() => gateConnectionFlow(openApiKeyAddFlow)}>
+            {t("add")}
+          </Button>
+          <Button
+            size="sm"
+            variant="secondary"
+            icon="edit"
+            onClick={onOpenEditNodeModal}
+          >
+            {t("edit")}
+          </Button>
+          <Button
+            size="sm"
+            variant="secondary"
+            icon="delete"
+            onClick={async () => {
+              if (
+                !confirm(
+                  t("deleteCompatibleNodeConfirm", {
+                    type: isCcCompatible
+                      ? t("ccCompatibleLabel")
+                      : isAnthropicCompatible
+                        ? t("anthropic")
+                        : t("openai"),
+                  })
+                )
+              )
+                return;
+              try {
+                const res = await fetch(`/api/provider-nodes/${providerId}`, {
+                  method: "DELETE",
+                });
+                if (res.ok) {
+                  router.push("/dashboard/providers");
+                }
+              } catch (error) {
+                console.error("Error deleting provider node:", error);
+              }
+            }}
+          >
+            {t("delete")}
+          </Button>
+        </div>
+      </div>
+      {isCcCompatible && (
+        <div className="mb-4 rounded-lg border border-amber-500/25 bg-amber-500/10 px-3 py-2 text-sm text-text-muted">
+          <div className="flex items-start gap-2">
+            <span className="material-symbols-outlined mt-0.5 text-[18px] text-amber-500">
+              warning
+            </span>
+            <p>{t("ccCompatibleValidationHint")}</p>
+          </div>
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/EmptyConnectionsPlaceholder.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/EmptyConnectionsPlaceholder.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+// Phase 1t.6 extraction — Issue #3501
+import { Button } from "@/shared/components";
+import type { ProviderMessageTranslator } from "../providerPageHelpers";
+
+interface CommandCodeAuthState {
+  phase: string;
+  [key: string]: unknown;
+}
+
+interface EmptyConnectionsPlaceholderProps {
+  isOAuth: boolean;
+  isCompatible: boolean;
+  isCommandCode: boolean;
+  providerId: string;
+  providerSupportsPat: boolean;
+  commandCodeAuthState: CommandCodeAuthState;
+  gateConnectionFlow: (callback: () => void) => void;
+  openApiKeyAddFlow: () => void;
+  openPrimaryAddFlow: () => void;
+  handleOpenCommandCodeConnect: () => void;
+  onOpenOAuthModal: () => void;
+  onOpenImportCodex: () => void;
+  onOpenImportClaude: () => void;
+  onOpenImportGemini: () => void;
+  t: ProviderMessageTranslator;
+}
+
+export default function EmptyConnectionsPlaceholder({
+  isOAuth,
+  isCompatible,
+  isCommandCode,
+  providerId,
+  providerSupportsPat,
+  commandCodeAuthState,
+  gateConnectionFlow,
+  openApiKeyAddFlow,
+  openPrimaryAddFlow,
+  handleOpenCommandCodeConnect,
+  onOpenOAuthModal,
+  onOpenImportCodex,
+  onOpenImportClaude,
+  onOpenImportGemini,
+  t,
+}: EmptyConnectionsPlaceholderProps) {
+  return (
+    <div className="text-center py-12">
+      <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-primary/10 text-primary mb-4">
+        <span className="material-symbols-outlined text-[32px]">
+          {isOAuth ? "lock" : "key"}
+        </span>
+      </div>
+      <p className="text-text-main font-medium mb-1">{t("noConnectionsYet")}</p>
+      <p className="text-sm text-text-muted mb-4">{t("addFirstConnectionHint")}</p>
+      {!isCompatible && (
+        <div className="flex items-center justify-center gap-2">
+          {isCommandCode ? (
+            <>
+              <Button
+                icon="open_in_new"
+                loading={
+                  commandCodeAuthState.phase === "starting" ||
+                  commandCodeAuthState.phase === "polling" ||
+                  commandCodeAuthState.phase === "applying"
+                }
+                onClick={() => gateConnectionFlow(handleOpenCommandCodeConnect)}
+              >
+                Connect
+              </Button>
+              <Button
+                variant="secondary"
+                icon="add"
+                onClick={() => gateConnectionFlow(openApiKeyAddFlow)}
+              >
+                Manual API key
+              </Button>
+            </>
+          ) : (
+            <>
+              <Button icon="add" onClick={() => gateConnectionFlow(openPrimaryAddFlow)}>
+                {providerSupportsPat ? "Add PAT" : t("addConnection")}
+              </Button>
+              {providerId === "qoder" && (
+                <Button
+                  variant="secondary"
+                  onClick={() => gateConnectionFlow(onOpenOAuthModal)}
+                >
+                  Experimental OAuth
+                </Button>
+              )}
+              {providerId === "codex" && (
+                <Button
+                  variant="secondary"
+                  icon="upload_file"
+                  onClick={() => gateConnectionFlow(onOpenImportCodex)}
+                >
+                  {typeof t.has === "function" && t.has("importCodexAuth")
+                    ? t("importCodexAuth")
+                    : "Import auth"}
+                </Button>
+              )}
+              {providerId === "claude" && (
+                <Button
+                  variant="secondary"
+                  icon="upload_file"
+                  onClick={() => gateConnectionFlow(onOpenImportClaude)}
+                >
+                  {typeof t.has === "function" && t.has("importClaudeAuth")
+                    ? t("importClaudeAuth")
+                    : "Import auth"}
+                </Button>
+              )}
+              {providerId === "gemini-cli" && (
+                <Button
+                  variant="secondary"
+                  icon="upload_file"
+                  onClick={() => gateConnectionFlow(onOpenImportGemini)}
+                >
+                  {typeof t.has === "function" && t.has("importGeminiAuth")
+                    ? t("importGeminiAuth")
+                    : "Import auth"}
+                </Button>
+              )}
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/ProviderModalsPanel.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/ProviderModalsPanel.tsx
@@ -1,0 +1,431 @@
+"use client";
+
+// Phase 1t.5 extraction — Issue #3501
+// Pure composition of all modal elements rendered by ProviderDetailPageClient.
+import { ConfirmModal, OAuthModal, KiroOAuthWrapper, CursorAuthModal, TraeAuthModal, ProxyConfigModal } from "@/shared/components";
+import RiskNoticeModal from "../../components/RiskNoticeModal";
+import CodexCliGuideModal from "../../components/CodexCliGuideModal";
+import SiliconFlowEndpointModal from "./SiliconFlowEndpointModal";
+import AddApiKeyModal from "./modals/AddApiKeyModal";
+import EditConnectionModal from "./modals/EditConnectionModal";
+import EditCompatibleNodeModal from "./modals/EditCompatibleNodeModal";
+import ExternalLinkModal from "./ExternalLinkModal";
+import BatchTestResultsModal from "./BatchTestResultsModal";
+import ImportProgressModal from "./ImportProgressModal";
+import { AdaptaTutorialModal } from "./AdaptaTutorialModal";
+import {
+  ImportCodexAuthModal,
+  ApplyCodexAuthModal,
+} from "./modals/ImportCodexAuthModal";
+import {
+  ImportClaudeAuthModal,
+  ApplyClaudeAuthModal,
+} from "./modals/ImportClaudeAuthModal";
+import {
+  ImportGeminiAuthModal,
+  ApplyGeminiAuthModal,
+} from "./modals/ImportGeminiAuthModal";
+import { type ConnectionRowConnection } from "./ConnectionRow";
+import { type BatchTestResults } from "../hooks/useProviderConnections";
+import { type ImportProgress } from "../hooks/useModelImportHandlers";
+import type { ProviderMessageTranslator } from "../providerPageHelpers";
+
+interface ProviderInfo {
+  name: string;
+  riskNoticeVariant?: string;
+  [key: string]: unknown;
+}
+
+interface ProxyTarget {
+  level: string;
+  id: string;
+  label: string;
+}
+
+interface ProviderModalsPanelProps {
+  providerId: string;
+  providerInfo: ProviderInfo;
+  isCompatible: boolean;
+  isAnthropicProtocolCompatible: boolean;
+  isCcCompatible: boolean;
+  isCommandCode: boolean;
+  isUpstreamProxyProvider: boolean;
+  subscriptionRisk: boolean;
+  // Risk notice
+  showRiskNoticeModal: boolean;
+  handleConfirmRiskNotice: () => void;
+  handleCancelRiskNotice: () => void;
+  // OAuth
+  showOAuthModal: boolean;
+  reauthConnection: ConnectionRowConnection | null;
+  handleOAuthSuccess: () => void;
+  setShowOAuthModal: (show: boolean) => void;
+  // SiliconFlow
+  showSiliconFlowEndpointModal: boolean;
+  setSiliconFlowInitialBaseUrl: (url: string | undefined) => void;
+  setShowSiliconFlowEndpointModal: (open: boolean) => void;
+  setShowAddApiKeyModal: (open: boolean) => void;
+  // AddApiKey
+  showAddApiKeyModal: boolean;
+  siliconFlowInitialBaseUrl: string | undefined;
+  commandCodeAuthState: { phase: string; [key: string]: unknown };
+  handleStartCommandCodeAuth: () => void;
+  handleSaveApiKey: (data: any) => Promise<void>;
+  handleCloseAddApiKeyModal: () => void;
+  // Batch delete confirm
+  batchDeleteConfirmOpen: boolean;
+  setBatchDeleteConfirmOpen: (open: boolean) => void;
+  handleBatchDeleteConfirm: () => void;
+  selectedIds: Set<string>;
+  batchDeleting: boolean;
+  // Codex auth
+  applyCodexModalConnectionId: string | null;
+  setApplyCodexModalConnectionId: (id: string | null) => void;
+  applyingCodexAuthId: string | null;
+  handleApplyCodexAuthLocal: (id: string) => Promise<void>;
+  importCodexModalOpen: boolean;
+  setImportCodexModalOpen: (open: boolean) => void;
+  fetchConnections: () => Promise<void>;
+  // External link
+  externalLinkModalOpen: boolean;
+  setExternalLinkModalOpen: (open: boolean) => void;
+  externalLinkLoading: boolean;
+  externalLinkError: string | null;
+  externalLinkUrl: string | null;
+  externalLinkCopied: boolean;
+  externalLinkCopy: () => void;
+  // Edit connection
+  showEditModal: boolean;
+  setShowEditModal: (open: boolean) => void;
+  selectedConnection: { id: string } | null;
+  handleUpdateConnection: (data: any) => Promise<string | null>;
+  // Edit compatible node
+  showEditNodeModal: boolean;
+  setShowEditNodeModal: (open: boolean) => void;
+  providerNode: any;
+  handleUpdateNode: (data: any) => Promise<void>;
+  // Codex CLI guide
+  codexCliGuideOpen: boolean;
+  setCodexCliGuideOpen: (open: boolean) => void;
+  // Claude auth
+  applyClaudeModalConnectionId: string | null;
+  setApplyClaudeModalConnectionId: (id: string | null) => void;
+  applyingClaudeAuthId: string | null;
+  handleApplyClaudeAuthLocal: (id: string) => Promise<void>;
+  importClaudeModalOpen: boolean;
+  setImportClaudeModalOpen: (open: boolean) => void;
+  // Gemini auth
+  applyGeminiModalConnectionId: string | null;
+  setApplyGeminiModalConnectionId: (id: string | null) => void;
+  applyingGeminiAuthId: string | null;
+  handleApplyGeminiAuthLocal: (id: string) => Promise<void>;
+  importGeminiModalOpen: boolean;
+  setImportGeminiModalOpen: (open: boolean) => void;
+  // Batch test results
+  batchTestResults: BatchTestResults | null;
+  setBatchTestResults: (r: BatchTestResults | null) => void;
+  emailsVisible: boolean;
+  // Proxy config
+  proxyTarget: ProxyTarget | null;
+  setProxyTarget: (t: ProxyTarget | null) => void;
+  fetchProxyConfig: () => Promise<void>;
+  // Import progress
+  importProgress: ImportProgress;
+  showImportModal: boolean;
+  setShowImportModal: (open: boolean) => void;
+  // Tutorial
+  showTutorialModal: boolean;
+  setShowTutorialModal: (open: boolean) => void;
+  t: ProviderMessageTranslator;
+}
+
+export default function ProviderModalsPanel({
+  providerId,
+  providerInfo,
+  isCompatible,
+  isAnthropicProtocolCompatible,
+  isCcCompatible,
+  isUpstreamProxyProvider,
+  subscriptionRisk,
+  showRiskNoticeModal,
+  handleConfirmRiskNotice,
+  handleCancelRiskNotice,
+  showOAuthModal,
+  reauthConnection,
+  handleOAuthSuccess,
+  setShowOAuthModal,
+  showSiliconFlowEndpointModal,
+  setSiliconFlowInitialBaseUrl,
+  setShowSiliconFlowEndpointModal,
+  setShowAddApiKeyModal,
+  showAddApiKeyModal,
+  siliconFlowInitialBaseUrl,
+  commandCodeAuthState,
+  handleStartCommandCodeAuth,
+  handleSaveApiKey,
+  handleCloseAddApiKeyModal,
+  isCommandCode,
+  batchDeleteConfirmOpen,
+  setBatchDeleteConfirmOpen,
+  handleBatchDeleteConfirm,
+  selectedIds,
+  batchDeleting,
+  applyCodexModalConnectionId,
+  setApplyCodexModalConnectionId,
+  applyingCodexAuthId,
+  handleApplyCodexAuthLocal,
+  importCodexModalOpen,
+  setImportCodexModalOpen,
+  fetchConnections,
+  externalLinkModalOpen,
+  setExternalLinkModalOpen,
+  externalLinkLoading,
+  externalLinkError,
+  externalLinkUrl,
+  externalLinkCopied,
+  externalLinkCopy,
+  showEditModal,
+  setShowEditModal,
+  selectedConnection,
+  handleUpdateConnection,
+  showEditNodeModal,
+  setShowEditNodeModal,
+  providerNode,
+  handleUpdateNode,
+  codexCliGuideOpen,
+  setCodexCliGuideOpen,
+  applyClaudeModalConnectionId,
+  setApplyClaudeModalConnectionId,
+  applyingClaudeAuthId,
+  handleApplyClaudeAuthLocal,
+  importClaudeModalOpen,
+  setImportClaudeModalOpen,
+  applyGeminiModalConnectionId,
+  setApplyGeminiModalConnectionId,
+  applyingGeminiAuthId,
+  handleApplyGeminiAuthLocal,
+  importGeminiModalOpen,
+  setImportGeminiModalOpen,
+  batchTestResults,
+  setBatchTestResults,
+  emailsVisible,
+  proxyTarget,
+  setProxyTarget,
+  fetchProxyConfig,
+  importProgress,
+  showImportModal,
+  setShowImportModal,
+  showTutorialModal,
+  setShowTutorialModal,
+  t,
+}: ProviderModalsPanelProps) {
+  return (
+    <>
+      {showRiskNoticeModal && subscriptionRisk && (
+        <RiskNoticeModal
+          variant={(providerInfo.riskNoticeVariant as string) ?? "oauth"}
+          providerId={providerId}
+          providerName={providerInfo.name}
+          onConfirm={handleConfirmRiskNotice}
+          onCancel={handleCancelRiskNotice}
+        />
+      )}
+      {!isUpstreamProxyProvider &&
+        (providerId === "kiro" || providerId === "amazon-q" ? (
+          <KiroOAuthWrapper
+            isOpen={showOAuthModal}
+            reauthConnection={reauthConnection}
+            providerInfo={{ ...providerInfo, id: providerId }}
+            onSuccess={handleOAuthSuccess}
+            onClose={() => setShowOAuthModal(false)}
+          />
+        ) : providerId === "cursor" ? (
+          <CursorAuthModal
+            isOpen={showOAuthModal}
+            reauthConnection={reauthConnection}
+            onSuccess={handleOAuthSuccess}
+            onClose={() => setShowOAuthModal(false)}
+          />
+        ) : providerId === "trae" ? (
+          <TraeAuthModal
+            isOpen={showOAuthModal}
+            reauthConnection={reauthConnection}
+            onSuccess={handleOAuthSuccess}
+            onClose={() => setShowOAuthModal(false)}
+          />
+        ) : (
+          <OAuthModal
+            isOpen={showOAuthModal}
+            reauthConnection={reauthConnection}
+            provider={providerId}
+            providerInfo={providerInfo}
+            onSuccess={handleOAuthSuccess}
+            onClose={() => setShowOAuthModal(false)}
+          />
+        ))}
+      {providerId === "siliconflow" && (
+        <SiliconFlowEndpointModal
+          isOpen={showSiliconFlowEndpointModal}
+          onSelect={(baseUrl) => {
+            setSiliconFlowInitialBaseUrl(baseUrl);
+            setShowSiliconFlowEndpointModal(false);
+            setShowAddApiKeyModal(true);
+          }}
+          onClose={() => {
+            setShowSiliconFlowEndpointModal(false);
+            setSiliconFlowInitialBaseUrl(undefined);
+          }}
+        />
+      )}
+      {!isUpstreamProxyProvider && (
+        <AddApiKeyModal
+          isOpen={showAddApiKeyModal}
+          provider={providerId}
+          providerName={providerInfo.name}
+          initialBaseUrl={siliconFlowInitialBaseUrl}
+          isCompatible={isCompatible}
+          isAnthropic={isAnthropicProtocolCompatible}
+          isCcCompatible={isCcCompatible}
+          isCommandCode={isCommandCode}
+          commandCodeAuthState={commandCodeAuthState}
+          onStartCommandCodeAuth={handleStartCommandCodeAuth}
+          onSave={handleSaveApiKey}
+          onClose={handleCloseAddApiKeyModal}
+        />
+      )}
+      <ConfirmModal
+        isOpen={batchDeleteConfirmOpen}
+        onClose={() => setBatchDeleteConfirmOpen(false)}
+        onConfirm={handleBatchDeleteConfirm}
+        title={t("batchDeleteConfirmTitle", "Delete connections")}
+        message={t("batchDeleteConfirm", { count: selectedIds.size })}
+        confirmText={t("batchDeleteConfirmButton", "Delete")}
+        cancelText={t("cancel", "Cancel")}
+        loading={batchDeleting}
+      />
+      {providerId === "codex" && applyCodexModalConnectionId && (
+        <ApplyCodexAuthModal
+          key={applyCodexModalConnectionId}
+          connectionId={applyCodexModalConnectionId}
+          inProgress={!!applyingCodexAuthId}
+          onConfirm={handleApplyCodexAuthLocal}
+          onClose={() => setApplyCodexModalConnectionId(null)}
+        />
+      )}
+      {!isUpstreamProxyProvider && (
+        <EditConnectionModal
+          isOpen={showEditModal}
+          connection={selectedConnection}
+          onSave={handleUpdateConnection}
+          onClose={() => setShowEditModal(false)}
+        />
+      )}
+      {!isUpstreamProxyProvider && isCompatible && (
+        <EditCompatibleNodeModal
+          isOpen={showEditNodeModal}
+          node={providerNode}
+          onSave={handleUpdateNode}
+          onClose={() => setShowEditNodeModal(false)}
+          isAnthropic={isAnthropicProtocolCompatible}
+          isCcCompatible={isCcCompatible}
+        />
+      )}
+      <CodexCliGuideModal isOpen={codexCliGuideOpen} onClose={() => setCodexCliGuideOpen(false)} />
+      {providerId === "codex" && importCodexModalOpen && (
+        <ImportCodexAuthModal
+          key="import-codex-modal"
+          onClose={() => setImportCodexModalOpen(false)}
+          onSuccess={() => {
+            setImportCodexModalOpen(false);
+            void fetchConnections();
+          }}
+        />
+      )}
+      {providerId === "codex" && externalLinkModalOpen && (
+        <ExternalLinkModal
+          isOpen={externalLinkModalOpen}
+          onClose={() => setExternalLinkModalOpen(false)}
+          loading={externalLinkLoading}
+          error={externalLinkError}
+          url={externalLinkUrl}
+          copied={externalLinkCopied}
+          onCopy={externalLinkCopy}
+        />
+      )}
+      {providerId === "claude" && applyClaudeModalConnectionId && (
+        <ApplyClaudeAuthModal
+          key={applyClaudeModalConnectionId}
+          connectionId={applyClaudeModalConnectionId}
+          inProgress={!!applyingClaudeAuthId}
+          onConfirm={handleApplyClaudeAuthLocal}
+          onClose={() => setApplyClaudeModalConnectionId(null)}
+        />
+      )}
+      {providerId === "claude" && importClaudeModalOpen && (
+        <ImportClaudeAuthModal
+          key="import-claude-modal"
+          onClose={() => setImportClaudeModalOpen(false)}
+          onSuccess={() => {
+            setImportClaudeModalOpen(false);
+            void fetchConnections();
+          }}
+        />
+      )}
+      {providerId === "gemini-cli" && applyGeminiModalConnectionId && (
+        <ApplyGeminiAuthModal
+          key={applyGeminiModalConnectionId}
+          connectionId={applyGeminiModalConnectionId}
+          inProgress={!!applyingGeminiAuthId}
+          onConfirm={handleApplyGeminiAuthLocal}
+          onClose={() => setApplyGeminiModalConnectionId(null)}
+        />
+      )}
+      {providerId === "gemini-cli" && importGeminiModalOpen && (
+        <ImportGeminiAuthModal
+          key="import-gemini-modal"
+          onClose={() => setImportGeminiModalOpen(false)}
+          onSuccess={() => {
+            setImportGeminiModalOpen(false);
+            void fetchConnections();
+          }}
+        />
+      )}
+      <BatchTestResultsModal
+        batchTestResults={batchTestResults}
+        providerInfo={providerInfo}
+        providerId={providerId}
+        emailsVisible={emailsVisible}
+        onClose={() => setBatchTestResults(null)}
+        t={t}
+      />
+      {proxyTarget && (
+        <ProxyConfigModal
+          isOpen={!!proxyTarget}
+          onClose={() => setProxyTarget(null)}
+          level={proxyTarget.level}
+          levelId={proxyTarget.id}
+          levelLabel={proxyTarget.label}
+          onSaved={() => {
+            void fetchProxyConfig();
+          }}
+        />
+      )}
+      <ImportProgressModal
+        importProgress={importProgress}
+        isOpen={showImportModal}
+        onClose={() => {
+          if (importProgress.phase === "done" || importProgress.phase === "error") {
+            setShowImportModal(false);
+          }
+        }}
+        t={t}
+      />
+      {providerId === "adapta-web" && (
+        <AdaptaTutorialModal
+          isOpen={showTutorialModal}
+          onClose={() => setShowTutorialModal(false)}
+        />
+      )}
+    </>
+  );
+}

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/ProviderPageHeader.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/ProviderPageHeader.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+// Phase 1t.1 extraction — Issue #3501
+import Link from "next/link";
+import ProviderIcon from "@/shared/components/ProviderIcon";
+import EmailPrivacyToggle from "@/shared/components/EmailPrivacyToggle";
+import { getHeaderIconProviderId } from "../providerPageHelpers";
+import type { ProviderMessageTranslator } from "../providerPageHelpers";
+
+interface ProviderInfo {
+  id: string;
+  name: string;
+  website?: string;
+  color: string;
+  apiType?: string;
+}
+
+interface ProviderPageHeaderProps {
+  providerId: string;
+  providerInfo: ProviderInfo;
+  connectionsCount: number;
+  isOpenAICompatible: boolean;
+  isAnthropicProtocolCompatible: boolean;
+  onOpenTutorial: () => void;
+  t: ProviderMessageTranslator;
+}
+
+export default function ProviderPageHeader({
+  providerId,
+  providerInfo,
+  connectionsCount,
+  isOpenAICompatible,
+  isAnthropicProtocolCompatible,
+  onOpenTutorial,
+  t,
+}: ProviderPageHeaderProps) {
+  return (
+    <div>
+      <Link
+        href="/dashboard/providers"
+        className="inline-flex items-center gap-1 text-sm text-text-muted hover:text-primary transition-colors mb-4"
+      >
+        <span className="material-symbols-outlined text-lg">arrow_back</span>
+        {t("backToProviders")}
+      </Link>
+      <div className="flex items-center gap-4">
+        <div
+          className="rounded-lg flex items-center justify-center"
+          style={{ backgroundColor: `${providerInfo.color}15` }}
+        >
+          <ProviderIcon
+            providerId={getHeaderIconProviderId(
+              isOpenAICompatible,
+              isAnthropicProtocolCompatible,
+              providerInfo.id,
+              providerInfo.apiType
+            )}
+            size={48}
+            type="color"
+          />
+        </div>
+        <div>
+          {providerInfo.website ? (
+            <a
+              href={providerInfo.website}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-3xl font-semibold tracking-tight hover:underline inline-flex items-center gap-2"
+              style={{ color: providerInfo.color }}
+            >
+              {providerInfo.name}
+              <span className="material-symbols-outlined text-lg opacity-60">open_in_new</span>
+            </a>
+          ) : (
+            <h1 className="text-3xl font-semibold tracking-tight">{providerInfo.name}</h1>
+          )}
+          <div className="flex items-center gap-2">
+            <p className="text-text-muted">
+              {t("connectionCountLabel", { count: connectionsCount })}
+            </p>
+            <EmailPrivacyToggle size="md" />
+            {providerId === "adapta-web" && (
+              <button
+                onClick={onOpenTutorial}
+                className="text-sm font-medium underline underline-offset-2 opacity-70 hover:opacity-100 transition-opacity"
+                style={{ color: providerInfo.color }}
+              >
+                Tutorial
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/SearchProviderCard.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/SearchProviderCard.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+// Phase 1t.7 extraction — Issue #3501
+import { Card } from "@/shared/components";
+import type { ProviderMessageTranslator } from "../providerPageHelpers";
+
+interface SearchProviderCardProps {
+  providerId: string;
+  t: ProviderMessageTranslator;
+}
+
+export default function SearchProviderCard({ providerId, t }: SearchProviderCardProps) {
+  return (
+    <Card>
+      <h2 className="text-lg font-semibold mb-4">{t("searchProvider")}</h2>
+      <p className="text-sm text-text-muted">{t("searchProviderDesc")}</p>
+      {providerId === "perplexity-search" && (
+        <div className="mt-3 flex items-center gap-2 px-3 py-2 rounded-lg bg-blue-500/10 border border-blue-500/20">
+          <span className="material-symbols-outlined text-sm text-blue-400">link</span>
+          <p className="text-xs text-blue-300">{t("perplexitySearchSharedKeyInfo")}</p>
+        </div>
+      )}
+      {providerId === "google-pse-search" && (
+        <div className="mt-3 flex items-center gap-2 px-3 py-2 rounded-lg bg-amber-500/10 border border-amber-500/20">
+          <span className="material-symbols-outlined text-sm text-amber-300">tune</span>
+          <p className="text-xs text-amber-200">{t("googlePseInfo")}</p>
+        </div>
+      )}
+      {providerId === "searxng-search" && (
+        <div className="mt-3 flex items-center gap-2 px-3 py-2 rounded-lg bg-emerald-500/10 border border-emerald-500/20">
+          <span className="material-symbols-outlined text-sm text-emerald-300">dns</span>
+          <p className="text-xs text-emerald-200">{t("searxngInfo")}</p>
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/UpstreamProxyCard.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/UpstreamProxyCard.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+// Phase 1t.7 extraction — Issue #3501
+import Link from "next/link";
+import { Card } from "@/shared/components";
+import { providerText } from "../providerPageHelpers";
+import type { ProviderMessageTranslator } from "../providerPageHelpers";
+
+interface UpstreamProxyCardProps {
+  t: ProviderMessageTranslator;
+}
+
+export default function UpstreamProxyCard({ t }: UpstreamProxyCardProps) {
+  return (
+    <Card>
+      <div className="flex flex-col gap-3">
+        <div>
+          <h2 className="text-lg font-semibold">
+            {providerText(t, "upstreamProxyManagedTitle", "Managed via Upstream Proxy Settings")}
+          </h2>
+          <p className="text-sm text-text-muted mt-1">
+            {providerText(
+              t,
+              "upstreamProxyManagedDescription",
+              "CLIProxyAPI is configured as an upstream proxy layer, not as a direct provider connection. Manage the binary/runtime in CLI Tools and enable proxy routing on each provider via the provider proxy controls."
+            )}
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Link
+            href="/dashboard/cli-code"
+            className="inline-flex items-center gap-2 rounded-lg border border-border px-3 py-2 text-sm text-text-main hover:border-primary/40 hover:text-text-primary transition-colors"
+          >
+            <span className="material-symbols-outlined text-base">terminal</span>
+            {t("openCliTools")}
+          </Link>
+          <Link
+            href="/dashboard/settings"
+            className="inline-flex items-center gap-2 rounded-lg border border-border px-3 py-2 text-sm text-text-main hover:border-primary/40 hover:text-text-primary transition-colors"
+          >
+            <span className="material-symbols-outlined text-base">settings</span>
+            {t("openSettings")}
+          </Link>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/src/app/(dashboard)/dashboard/providers/[id]/hooks/useConnectionGate.ts
+++ b/src/app/(dashboard)/dashboard/providers/[id]/hooks/useConnectionGate.ts
@@ -1,0 +1,48 @@
+// Phase 1t.3 extraction — Issue #3501
+// Encapsulates gateConnectionFlow + risk-notice modal state + confirm/cancel handlers.
+import { useState, useRef, useCallback } from "react";
+import { isRiskAcknowledged, useRiskAcknowledged } from "../../hooks/useRiskAcknowledged";
+
+interface UseConnectionGateParams {
+  providerId: string;
+  subscriptionRisk: boolean;
+}
+
+export function useConnectionGate({ providerId, subscriptionRisk }: UseConnectionGateParams) {
+  const [showRiskNoticeModal, setShowRiskNoticeModal] = useState(false);
+  const pendingRiskActionRef = useRef<(() => void) | null>(null);
+  const { acknowledged: riskAcknowledged, acknowledge: acknowledgeRisk } =
+    useRiskAcknowledged(providerId);
+
+  const gateConnectionFlow = useCallback(
+    (callback: () => void) => {
+      if (subscriptionRisk && !riskAcknowledged && !isRiskAcknowledged(providerId)) {
+        pendingRiskActionRef.current = callback;
+        setShowRiskNoticeModal(true);
+        return;
+      }
+      callback();
+    },
+    [providerId, riskAcknowledged, subscriptionRisk]
+  );
+
+  const handleConfirmRiskNotice = useCallback(() => {
+    acknowledgeRisk();
+    setShowRiskNoticeModal(false);
+    const pendingAction = pendingRiskActionRef.current;
+    pendingRiskActionRef.current = null;
+    pendingAction?.();
+  }, [acknowledgeRisk]);
+
+  const handleCancelRiskNotice = useCallback(() => {
+    pendingRiskActionRef.current = null;
+    setShowRiskNoticeModal(false);
+  }, []);
+
+  return {
+    showRiskNoticeModal,
+    gateConnectionFlow,
+    handleConfirmRiskNotice,
+    handleCancelRiskNotice,
+  };
+}

--- a/src/app/(dashboard)/dashboard/providers/[id]/hooks/useProviderNodeActions.ts
+++ b/src/app/(dashboard)/dashboard/providers/[id]/hooks/useProviderNodeActions.ts
@@ -1,0 +1,63 @@
+// Phase 1t.4 extraction — Issue #3501
+// Encapsulates handleUpdateNode and handleUpdateConnection async handlers.
+import type { ProviderMessageTranslator } from "../providerPageHelpers";
+
+interface UseProviderNodeActionsParams {
+  providerId: string;
+  fetchConnections: () => Promise<void>;
+  selectedConnection: { id: string } | null;
+  setProviderNode: (node: any) => void;
+  setShowEditNodeModal: (open: boolean) => void;
+  setShowEditModal: (open: boolean) => void;
+  t: ProviderMessageTranslator;
+}
+
+export function useProviderNodeActions({
+  providerId,
+  fetchConnections,
+  selectedConnection,
+  setProviderNode,
+  setShowEditNodeModal,
+  setShowEditModal,
+  t,
+}: UseProviderNodeActionsParams) {
+  const handleUpdateNode = async (formData: any) => {
+    try {
+      const res = await fetch(`/api/provider-nodes/${providerId}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(formData),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        setProviderNode(data.node);
+        await fetchConnections();
+        setShowEditNodeModal(false);
+      }
+    } catch (error) {
+      console.log("Error updating provider node:", error);
+    }
+  };
+
+  const handleUpdateConnection = async (formData: any) => {
+    try {
+      const res = await fetch(`/api/providers/${selectedConnection?.id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(formData),
+      });
+      if (res.ok) {
+        await fetchConnections();
+        setShowEditModal(false);
+        return null;
+      }
+      const data = await res.json().catch(() => ({}));
+      return data.error?.message || data.error || t("failedSaveConnection");
+    } catch (error) {
+      console.log("Error updating connection:", error);
+      return t("failedSaveConnectionRetry");
+    }
+  };
+
+  return { handleUpdateNode, handleUpdateConnection };
+}


### PR DESCRIPTION
Final push of #3501 (strangler-fig decomposition). Continues #3717/#3721/#3725.

## 🎯 Target reached: client ≤800
`ProviderDetailPageClient.tsx`: **1,376 → 781 LOC**. The original god-component was **12,882 LOC → 781 (−94%)**.

## What (pure extraction, zero logic change)
- **1t.1** ProviderPageHeader (96) · **1t.2** CompatibleNodeCard (121) · **1t.3** useConnectionGate hook (48) · **1t.4** useProviderNodeActions hook (63) · **1t.5** ProviderModalsPanel (431, all 20 modals composed) · **1t.6** EmptyConnectionsPlaceholder (131) · **1t.7** UpstreamProxyCard (48) + SearchProviderCard (37)
- Baseline ratcheted: client 1377→782. Concurrent drift reconciled (ResilienceTab/sse-chat/sse-auth/accountFallback/combo — #3629 model-lockout etc.).

## Validation
typecheck:core clean, check:cycles OK (providers/[id], 55 files, no cycles), file-size green, provider-page vitest 32/32, lint clean.

#3501 is now functionally complete — the god-component is a thin ~781-line composition shell.

Co-authored-by: oyi77 <14921983+oyi77@users.noreply.github.com>