### PR TITLE
Add provider display modes

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/components/ProviderDisplayModeControl.tsx
+++ b/src/app/(dashboard)/dashboard/providers/components/ProviderDisplayModeControl.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import type { ProviderDisplayMode } from "../providerPageStorage";
+
+type ProviderMessageTranslator = ((key: string, values?: Record<string, unknown>) => string) & {
+  has?: (key: string) => boolean;
+};
+
+function providerText(
+  t: ProviderMessageTranslator,
+  key: string,
+  fallback: string,
+  values?: Record<string, unknown>
+): string {
+  if (typeof t.has === "function" && t.has(key)) {
+    return t(key, values);
+  }
+  if (values) {
+    return Object.entries(values).reduce(
+      (acc, [name, value]) => acc.replaceAll(`{${name}}`, String(value)),
+      fallback
+    );
+  }
+  return fallback;
+}
+
+interface ProviderDisplayModeControlProps {
+  disabledConfigured: boolean;
+  mode: ProviderDisplayMode;
+  onChange(mode: ProviderDisplayMode): void;
+  t: ProviderMessageTranslator;
+}
+
+export default function ProviderDisplayModeControl({
+  disabledConfigured,
+  mode,
+  onChange,
+  t,
+}: ProviderDisplayModeControlProps) {
+  const options: Array<{
+    mode: ProviderDisplayMode;
+    label: string;
+    icon: string;
+    disabled?: boolean;
+    title: string;
+  }> = [
+    {
+      mode: "all",
+      label: providerText(t, "providerDisplayModeAll", "All"),
+      icon: "view_module",
+      title: providerText(
+        t,
+        "providerDisplayModeAllDesc",
+        "Show every provider in grouped sections."
+      ),
+    },
+    {
+      mode: "configured",
+      label: providerText(t, "providerDisplayModeConfigured", "Configured"),
+      icon: "check_circle",
+      disabled: disabledConfigured,
+      title: providerText(
+        t,
+        "providerDisplayModeConfiguredDesc",
+        "Show providers with saved connections."
+      ),
+    },
+    {
+      mode: "compact",
+      label: providerText(t, "providerDisplayModeCompact", "Compact"),
+      icon: "view_agenda",
+      title: providerText(
+        t,
+        "providerDisplayModeCompactDesc",
+        "Show configured and no-auth providers once in a single flat list."
+      ),
+    },
+  ];
+
+  return (
+    <div
+      className="flex items-center rounded-lg border border-border bg-bg-subtle p-0.5"
+      role="radiogroup"
+      aria-label={providerText(t, "providerDisplayMode", "Provider display mode")}
+      data-testid="provider-display-mode-control"
+    >
+      {options.map((option) => {
+        const isActive = mode === option.mode;
+        return (
+          <label
+            key={option.mode}
+            title={option.title}
+            data-testid={`provider-display-mode-${option.mode}`}
+            data-active={isActive ? "true" : "false"}
+            className={`inline-flex h-7 items-center gap-1.5 rounded-md px-2.5 text-xs font-medium transition-colors ${
+              isActive
+                ? "bg-bg-primary text-text-main shadow-sm"
+                : "text-text-muted hover:bg-bg-primary/70 hover:text-text-main"
+            } ${option.disabled ? "cursor-not-allowed opacity-50" : ""}`}
+          >
+            <input
+              type="radio"
+              name="provider-display-mode"
+              value={option.mode}
+              checked={isActive}
+              disabled={option.disabled}
+              onChange={() => onChange(option.mode)}
+              className="sr-only"
+              aria-label={option.title}
+            />
+            <span className="material-symbols-outlined text-[14px]" aria-hidden="true">
+              {option.icon}
+            </span>
+            <span>{option.label}</span>
+          </label>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/providers/components/ProviderSummaryCard.tsx
+++ b/src/app/(dashboard)/dashboard/providers/components/ProviderSummaryCard.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import { Button, Card, Input } from "@/shared/components";
+import type { ProviderDisplayMode } from "../providerPageStorage";
+import { CategoryDot } from "./CategoryDot";
+import ProviderDisplayModeControl from "./ProviderDisplayModeControl";
+
+type ProviderMessageTranslator = ((key: string, values?: Record<string, unknown>) => string) & {
+  has?: (key: string) => boolean;
+};
+
+type SummaryStat = {
+  configured: number;
+  total: number;
+};
+
+export interface ProviderSummaryStats {
+  all: SummaryStat;
+  free: SummaryStat;
+  noauth: SummaryStat;
+  oauth: SummaryStat;
+  apikey: SummaryStat;
+  compatible: SummaryStat;
+  webcookie: SummaryStat;
+  search: SummaryStat;
+  audio: SummaryStat;
+  local: SummaryStat;
+  upstreamproxy: SummaryStat;
+  cloudagent: SummaryStat;
+  ide: SummaryStat;
+  webfetch: SummaryStat;
+}
+
+interface ProviderSummaryCardProps {
+  activeCategory: string | null;
+  disabledConfigured: boolean;
+  displayMode: ProviderDisplayMode;
+  onBatchTest(mode: string): void;
+  onCategoryChange(category: string | null, freeOnly: boolean): void;
+  onDisplayModeChange(mode: ProviderDisplayMode): void;
+  onNewProvider(): void;
+  searchQuery: string;
+  setSearchQuery(value: string): void;
+  showFreeOnly: boolean;
+  summaryStats: ProviderSummaryStats;
+  t: ProviderMessageTranslator;
+  tc: ProviderMessageTranslator;
+  testingMode: string | null;
+}
+
+function providerText(
+  t: ProviderMessageTranslator,
+  key: string,
+  fallback: string,
+  values?: Record<string, unknown>
+): string {
+  if (typeof t.has === "function" && t.has(key)) {
+    return t(key, values);
+  }
+  if (values) {
+    return Object.entries(values).reduce(
+      (acc, [name, value]) => acc.replaceAll(`{${name}}`, String(value)),
+      fallback
+    );
+  }
+  return fallback;
+}
+
+export default function ProviderSummaryCard({
+  activeCategory,
+  disabledConfigured,
+  displayMode,
+  onBatchTest,
+  onCategoryChange,
+  onDisplayModeChange,
+  onNewProvider,
+  searchQuery,
+  setSearchQuery,
+  showFreeOnly,
+  summaryStats,
+  t,
+  tc,
+  testingMode,
+}: ProviderSummaryCardProps) {
+  const categories = [
+    { key: null, color: null, label: t("providerSummaryAll"), stat: summaryStats.all },
+    { key: "oauth", color: "bg-blue-500", label: t("oauthLabel"), stat: summaryStats.oauth },
+    { key: "ide", color: "bg-cyan-500", label: "IDE", stat: summaryStats.ide },
+    {
+      key: "free",
+      color: "bg-green-500",
+      label: t("freeTier"),
+      stat: summaryStats.free,
+      title: t("freeAggregated"),
+    },
+    { key: "no-auth", color: "bg-stone-500", label: t("noAuthLabel"), stat: summaryStats.noauth },
+    {
+      key: "upstream-proxy",
+      color: "bg-indigo-500",
+      label: t("upstreamProxyLabel"),
+      stat: summaryStats.upstreamproxy,
+    },
+    { key: "apikey", color: "bg-amber-500", label: t("apiKeyLabel"), stat: summaryStats.apikey },
+    {
+      key: "compatible",
+      color: "bg-orange-500",
+      label: t("compatibleLabel"),
+      stat: summaryStats.compatible,
+    },
+    { key: "webcookie", color: "bg-purple-500", label: "Web Cookie", stat: summaryStats.webcookie },
+    { key: "search", color: "bg-teal-500", label: "Search", stat: summaryStats.search },
+    {
+      key: "webfetch",
+      color: "bg-orange-500",
+      label: t("webFetch"),
+      stat: summaryStats.webfetch,
+      title: t("webFetchTooltip"),
+    },
+    { key: "audio", color: "bg-rose-500", label: "Audio", stat: summaryStats.audio },
+    { key: "local", color: "bg-emerald-500", label: "Local", stat: summaryStats.local },
+    {
+      key: "cloudagent",
+      color: "bg-violet-500",
+      label: "Cloud Agent",
+      stat: summaryStats.cloudagent,
+    },
+  ];
+
+  return (
+    <Card padding="sm">
+      <div className="flex flex-col gap-3">
+        <div className="flex items-center gap-3 flex-wrap">
+          <div className="relative flex-1 min-w-[160px]">
+            <Input
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              placeholder={t("searchProviders")}
+              aria-label={t("searchProviders")}
+              icon="search"
+              inputClassName={searchQuery ? "pr-9" : ""}
+            />
+            {searchQuery && (
+              <button
+                onClick={() => setSearchQuery("")}
+                className="absolute inset-y-0 right-0 flex items-center pr-2.5 text-text-muted hover:text-text-primary transition-colors"
+                aria-label={tc("clear")}
+              >
+                <span className="material-symbols-outlined text-[18px]">close</span>
+              </button>
+            )}
+          </div>
+          <ProviderDisplayModeControl
+            disabledConfigured={disabledConfigured}
+            mode={displayMode}
+            onChange={onDisplayModeChange}
+            t={t}
+          />
+          <Button size="sm" icon="add" onClick={onNewProvider}>
+            {providerText(t, "onboardingWizardShort", "Onboarding Wizard")}
+          </Button>
+          <button
+            onClick={() => onBatchTest("all")}
+            disabled={!!testingMode}
+            className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border transition-colors ${
+              testingMode === "all"
+                ? "bg-primary/20 border-primary/40 text-primary animate-pulse"
+                : "bg-bg-subtle border-border text-text-muted hover:text-text-primary hover:border-primary/40"
+            }`}
+            title={t("testAll")}
+          >
+            <span className="material-symbols-outlined text-[14px]">
+              {testingMode === "all" ? "sync" : "play_arrow"}
+            </span>
+            {testingMode === "all" ? t("testing") : t("testAll")}
+          </button>
+        </div>
+
+        <div className="border-t border-border pt-3 flex flex-wrap items-center gap-2">
+          {categories.map((cat) => {
+            const isActive =
+              (cat.key === null && !activeCategory && !showFreeOnly) ||
+              (cat.key === "free" && showFreeOnly) ||
+              (cat.key !== "free" &&
+                cat.key !== null &&
+                !showFreeOnly &&
+                activeCategory === cat.key);
+            return (
+              <button
+                key={cat.key ?? "all"}
+                onClick={() => onCategoryChange(cat.key, cat.key === "free")}
+                className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full border text-xs font-medium transition-colors ${
+                  isActive
+                    ? "bg-primary text-white border-primary"
+                    : "bg-bg-subtle border-border text-text-muted hover:text-text-primary hover:border-primary/30"
+                }`}
+                title={cat.title || cat.label}
+              >
+                {cat.color && <CategoryDot color={cat.color} label={cat.label} />}
+                <span>{cat.label}</span>
+                <span className={`text-[11px] ${isActive ? "text-white/80" : "text-text-muted"}`}>
+                  {cat.stat.configured}
+                  <span className="opacity-70">/{cat.stat.total}</span>
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/src/app/(dashboard)/dashboard/providers/page.tsx
+++ b/src/app/(dashboard)/dashboard/providers/page.tsx
@@ -1,15 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import {
-  Card,
-  CardSkeleton,
-  Badge,
-  Button,
-  Input,
-  Toggle,
-  CollapsibleSection,
-} from "@/shared/components";
+import { Card, CardSkeleton, Badge, Button, CollapsibleSection } from "@/shared/components";
 import {
   AGGREGATOR_PROVIDER_IDS,
   EMBEDDING_RERANK_PROVIDER_IDS,
@@ -28,11 +20,15 @@ import { useTranslations } from "next-intl";
 import {
   buildStaticProviderEntries,
   filterConfiguredProviderEntries,
-  shouldApplyConfiguredOnlyFilter,
+  shouldFilterProviderEntriesForDisplayMode,
   shouldShowFirstProviderHint,
 } from "./providerPageUtils";
 import type { ProviderEntry } from "./providerPageUtils";
-import { readConfiguredOnlyPreference, writeConfiguredOnlyPreference } from "./providerPageStorage";
+import {
+  readProviderDisplayModePreference,
+  writeProviderDisplayModePreference,
+  type ProviderDisplayMode,
+} from "./providerPageStorage";
 import {
   getCodexEffectiveServiceTier,
   getCodexGlobalServiceMode,
@@ -42,6 +38,11 @@ import AddCompatibleProviderModal from "./components/AddCompatibleProviderModal"
 import { CategoryDot } from "./components/CategoryDot";
 import ProviderCard from "./components/ProviderCard";
 import ProviderCountBadge from "./components/ProviderCountBadge";
+import ProviderSummaryCard from "./components/ProviderSummaryCard";
+import {
+  buildCompactProviderEntriesForPage,
+  getCompactProviderAuthType,
+} from "./providerCompactMode";
 
 type DashboardProviderInfo = {
   id?: string;
@@ -174,8 +175,8 @@ export default function ProvidersPage() {
   const [showAddCcCompatibleModal, setShowAddCcCompatibleModal] = useState(false);
   const [testingMode, setTestingMode] = useState<string | null>(null);
   const [testResults, setTestResults] = useState<any>(null);
-  const [showConfiguredOnly, setShowConfiguredOnly] = useState(false);
-  const [configuredOnlyPreferenceReady, setConfiguredOnlyPreferenceReady] = useState(false);
+  const [providerDisplayMode, setProviderDisplayMode] = useState<ProviderDisplayMode>("all");
+  const [displayModePreferenceReady, setDisplayModePreferenceReady] = useState(false);
   const [oauthEnvRepairStatus, setOauthEnvRepairStatus] = useState<{
     available: boolean;
     missingCount: number;
@@ -210,8 +211,8 @@ export default function ProvidersPage() {
   const searchParams = useSearchParams();
 
   useEffect(() => {
-    setShowConfiguredOnly(readConfiguredOnlyPreference());
-    setConfiguredOnlyPreferenceReady(true);
+    setProviderDisplayMode(readProviderDisplayModePreference());
+    setDisplayModePreferenceReady(true);
   }, []);
 
   useEffect(() => {
@@ -251,10 +252,21 @@ export default function ProvidersPage() {
   }, []);
 
   useEffect(() => {
-    if (!configuredOnlyPreferenceReady) return;
+    if (!displayModePreferenceReady) return;
 
-    writeConfiguredOnlyPreference(showConfiguredOnly);
-  }, [configuredOnlyPreferenceReady, showConfiguredOnly]);
+    const storedDisplayMode =
+      connections.length === 0 && providerDisplayMode === "configured"
+        ? "all"
+        : providerDisplayMode;
+    writeProviderDisplayModePreference(storedDisplayMode);
+  }, [connections.length, displayModePreferenceReady, providerDisplayMode]);
+
+  useEffect(() => {
+    if (!displayModePreferenceReady) return;
+    if (connections.length === 0 && providerDisplayMode === "configured") {
+      setProviderDisplayMode("all");
+    }
+  }, [connections.length, displayModePreferenceReady, providerDisplayMode]);
 
   const fetchOauthEnvRepairStatus = useCallback(async () => {
     try {
@@ -492,10 +504,13 @@ export default function ProvidersPage() {
       textIcon: "CC",
     }));
 
-  const effectiveShowConfiguredOnly = shouldApplyConfiguredOnlyFilter(
-    showConfiguredOnly,
+  const effectiveProviderDisplayMode =
+    providerDisplayMode === "configured" && connections.length === 0 ? "all" : providerDisplayMode;
+  const effectiveShowConfiguredOnly = shouldFilterProviderEntriesForDisplayMode(
+    effectiveProviderDisplayMode,
     connections.length
   );
+  const isCompactProviderDisplay = effectiveProviderDisplayMode === "compact";
 
   const oauthProviderEntriesAll = buildStaticProviderEntries("oauth", getProviderStats);
   const oauthProviderEntries = filterConfiguredProviderEntries(
@@ -705,6 +720,29 @@ export default function ProvidersPage() {
     showFreeOnly
   );
 
+  const compactProviderEntries = buildCompactProviderEntriesForPage({
+    activeCategory,
+    showFreeOnly,
+    freeSectionEntries,
+    compatibleProviderEntries,
+    oauthProviderEntries,
+    ideProviderEntries,
+    noAuthEntries,
+    upstreamProxyEntries,
+    llmProviderEntries,
+    aggregatorProviderEntries,
+    enterpriseProviderEntries,
+    embeddingRerankProviderEntries,
+    imageProviderEntries,
+    videoProviderEntries,
+    webCookieProviderEntries,
+    searchProviderEntries,
+    webFetchEntries,
+    audioProviderEntries,
+    localProviderEntries,
+    cloudAgentProviderEntries,
+  });
+
   const summaryStats = {
     all: countConfigured(dashboardProviderEntriesAll),
     free: countConfigured(freeSectionEntriesAll),
@@ -721,7 +759,6 @@ export default function ProvidersPage() {
     ide: countConfigured(ideProviderEntriesAll),
     webfetch: countConfigured(webFetchEntriesAll),
   };
-
   if (loading) {
     return (
       <div className="flex flex-col gap-8">
@@ -767,192 +804,25 @@ export default function ProvidersPage() {
         </Card>
       )}
 
-      {/* Provider Summary Card */}
-      <Card padding="sm">
-        <div className="flex flex-col gap-3">
-          {/* Row 1: Search + Controls */}
-          <div className="flex items-center gap-3 flex-wrap">
-            <div className="relative flex-1 min-w-[160px]">
-              <Input
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                placeholder={t("searchProviders")}
-                aria-label={t("searchProviders")}
-                icon="search"
-                inputClassName={searchQuery ? "pr-9" : ""}
-              />
-              {searchQuery && (
-                <button
-                  onClick={() => setSearchQuery("")}
-                  className="absolute inset-y-0 right-0 flex items-center pr-2.5 text-text-muted hover:text-text-primary transition-colors"
-                  aria-label={tc("clear")}
-                >
-                  <span className="material-symbols-outlined text-[18px]">close</span>
-                </button>
-              )}
-            </div>
-            <Toggle
-              size="sm"
-              checked={effectiveShowConfiguredOnly}
-              onChange={setShowConfiguredOnly}
-              label={t("showConfiguredOnly")}
-              disabled={connections.length === 0}
-              className="rounded-lg border border-border bg-bg-subtle px-3 py-1.5"
-            />
-            <Button size="sm" icon="add" onClick={() => router.push("/dashboard/providers/new")}>
-              {providerText(t, "onboardingWizardShort", "Onboarding Wizard")}
-            </Button>
-            <button
-              onClick={() => handleBatchTest("all")}
-              disabled={!!testingMode}
-              className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border transition-colors ${
-                testingMode === "all"
-                  ? "bg-primary/20 border-primary/40 text-primary animate-pulse"
-                  : "bg-bg-subtle border-border text-text-muted hover:text-text-primary hover:border-primary/40"
-              }`}
-              title={t("testAll")}
-            >
-              <span className="material-symbols-outlined text-[14px]">
-                {testingMode === "all" ? "sync" : "play_arrow"}
-              </span>
-              {testingMode === "all" ? t("testing") : t("testAll")}
-            </button>
-          </div>
-
-          {/* Category filter pills with embedded counters */}
-          <div className="border-t border-border pt-3 flex flex-wrap items-center gap-2">
-            {(
-              [
-                { key: null, color: null, label: t("providerSummaryAll"), stat: summaryStats.all },
-                {
-                  key: "oauth",
-                  color: "bg-blue-500",
-                  label: t("oauthLabel"),
-                  stat: summaryStats.oauth,
-                },
-                {
-                  key: "ide",
-                  color: "bg-cyan-500",
-                  label: "IDE",
-                  stat: summaryStats.ide,
-                },
-                {
-                  key: "free",
-                  color: "bg-green-500",
-                  label: t("freeTier"),
-                  stat: summaryStats.free,
-                  title: t("freeAggregated"),
-                },
-                {
-                  key: "no-auth",
-                  color: "bg-stone-500",
-                  label: t("noAuthLabel"),
-                  stat: summaryStats.noauth,
-                },
-                {
-                  key: "upstream-proxy",
-                  color: "bg-indigo-500",
-                  label: t("upstreamProxyLabel"),
-                  stat: summaryStats.upstreamproxy,
-                },
-                {
-                  key: "apikey",
-                  color: "bg-amber-500",
-                  label: t("apiKeyLabel"),
-                  stat: summaryStats.apikey,
-                },
-                {
-                  key: "compatible",
-                  color: "bg-orange-500",
-                  label: t("compatibleLabel"),
-                  stat: summaryStats.compatible,
-                },
-                {
-                  key: "webcookie",
-                  color: "bg-purple-500",
-                  label: "Web Cookie",
-                  stat: summaryStats.webcookie,
-                },
-                {
-                  key: "search",
-                  color: "bg-teal-500",
-                  label: "Search",
-                  stat: summaryStats.search,
-                },
-                {
-                  key: "webfetch",
-                  color: "bg-orange-500",
-                  label: t("webFetch"),
-                  stat: summaryStats.webfetch,
-                  title: t("webFetchTooltip"),
-                },
-                {
-                  key: "audio",
-                  color: "bg-rose-500",
-                  label: "Audio",
-                  stat: summaryStats.audio,
-                },
-                {
-                  key: "local",
-                  color: "bg-emerald-500",
-                  label: "Local",
-                  stat: summaryStats.local,
-                },
-                {
-                  key: "cloudagent",
-                  color: "bg-violet-500",
-                  label: "Cloud Agent",
-                  stat: summaryStats.cloudagent,
-                },
-              ] as Array<{
-                key: string | null;
-                color: string | null;
-                label: string;
-                stat: { configured: number; total: number };
-                title?: string;
-              }>
-            ).map((cat) => {
-              const isActive =
-                (cat.key === null && !activeCategory && !showFreeOnly) ||
-                (cat.key === "free" && showFreeOnly) ||
-                (cat.key !== "free" &&
-                  cat.key !== null &&
-                  !showFreeOnly &&
-                  activeCategory === cat.key);
-              return (
-                <button
-                  key={cat.key ?? "all"}
-                  onClick={() => {
-                    if (cat.key === null) {
-                      setShowFreeOnly(false);
-                      setActiveCategory(null);
-                    } else if (cat.key === "free") {
-                      setShowFreeOnly(true);
-                      setActiveCategory(null);
-                    } else {
-                      setShowFreeOnly(false);
-                      setActiveCategory(cat.key);
-                    }
-                  }}
-                  className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full border text-xs font-medium transition-colors ${
-                    isActive
-                      ? "bg-primary text-white border-primary"
-                      : "bg-bg-subtle border-border text-text-muted hover:text-text-primary hover:border-primary/30"
-                  }`}
-                  title={cat.title || cat.label}
-                >
-                  {cat.color && <CategoryDot color={cat.color} label={cat.label} />}
-                  <span>{cat.label}</span>
-                  <span className={`text-[11px] ${isActive ? "text-white/80" : "text-text-muted"}`}>
-                    {cat.stat.configured}
-                    <span className="opacity-70">/{cat.stat.total}</span>
-                  </span>
-                </button>
-              );
-            })}
-          </div>
-        </div>
-      </Card>
+      <ProviderSummaryCard
+        activeCategory={activeCategory}
+        disabledConfigured={connections.length === 0}
+        displayMode={effectiveProviderDisplayMode}
+        onBatchTest={handleBatchTest}
+        onCategoryChange={(category, freeOnly) => {
+          setShowFreeOnly(freeOnly);
+          setActiveCategory(freeOnly ? null : category);
+        }}
+        onDisplayModeChange={setProviderDisplayMode}
+        onNewProvider={() => router.push("/dashboard/providers/new")}
+        searchQuery={searchQuery}
+        setSearchQuery={setSearchQuery}
+        showFreeOnly={showFreeOnly}
+        summaryStats={summaryStats}
+        t={t}
+        tc={tc}
+        testingMode={testingMode}
+      />
 
       {/* Expiration Banner */}
       {expirations?.summary &&
@@ -990,322 +860,520 @@ export default function ProvidersPage() {
           </div>
         )}
 
-      {/* API Key Compatible Providers — dynamic (OpenAI/Anthropic compatible) */}
-      {showSection("compatible") && (
-        <div className="flex flex-col gap-4">
-          <div className="flex flex-wrap items-center gap-2">
-            <h2 className="text-xl font-semibold flex items-center gap-2 flex-1 min-w-0">
-              {t("compatibleProviders")}{" "}
-              <span className="size-2.5 rounded-full bg-orange-500" title={t("compatibleLabel")} />
-              <ProviderCountBadge {...countConfigured(compatibleProviderEntriesAll)} />
-            </h2>
-            <div className="flex flex-wrap gap-2">
-              {(compatibleProviders.length > 0 ||
-                anthropicCompatibleProviders.length > 0 ||
-                ccCompatibleProviders.length > 0) && (
+      {isCompactProviderDisplay ? (
+        compactProviderEntries.length > 0 ? (
+          <div
+            className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 gap-3"
+            data-testid="provider-compact-grid"
+          >
+            {compactProviderEntries.map((entry) => (
+              <ProviderCard
+                key={`compact-${entry.providerId}`}
+                providerId={entry.providerId}
+                provider={entry.provider}
+                stats={entry.stats}
+                authType={getCompactProviderAuthType(entry, showFreeOnly)}
+                onToggle={(active) =>
+                  handleToggleProvider(entry.providerId, entry.toggleAuthType, active)
+                }
+              />
+            ))}
+          </div>
+        ) : (
+          <div
+            className="flex items-center justify-center gap-2 py-8 border border-dashed border-border rounded-xl text-text-muted text-sm"
+            data-testid="provider-compact-empty"
+          >
+            <span className="material-symbols-outlined text-[18px]">search_off</span>
+            <span>{providerText(t, "noProvidersMatch", "No providers match your search.")}</span>
+          </div>
+        )
+      ) : (
+        <>
+          {/* API Key Compatible Providers — dynamic (OpenAI/Anthropic compatible) */}
+          {showSection("compatible") && (
+            <div className="flex flex-col gap-4">
+              <div className="flex flex-wrap items-center gap-2">
+                <h2 className="text-xl font-semibold flex items-center gap-2 flex-1 min-w-0">
+                  {t("compatibleProviders")}{" "}
+                  <span
+                    className="size-2.5 rounded-full bg-orange-500"
+                    title={t("compatibleLabel")}
+                  />
+                  <ProviderCountBadge {...countConfigured(compatibleProviderEntriesAll)} />
+                </h2>
+                <div className="flex flex-wrap gap-2">
+                  {(compatibleProviders.length > 0 ||
+                    anthropicCompatibleProviders.length > 0 ||
+                    ccCompatibleProviders.length > 0) && (
+                    <button
+                      onClick={() => handleBatchTest("compatible")}
+                      disabled={!!testingMode}
+                      className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border transition-colors ${
+                        testingMode === "compatible"
+                          ? "bg-primary/20 border-primary/40 text-primary animate-pulse"
+                          : "bg-bg-subtle border-border text-text-muted hover:text-text-primary hover:border-primary/40"
+                      }`}
+                      title={t("testAllCompatible")}
+                    >
+                      <span className="material-symbols-outlined text-[14px]">
+                        {testingMode === "compatible" ? "sync" : "play_arrow"}
+                      </span>
+                      {testingMode === "compatible" ? t("testing") : t("testAll")}
+                    </button>
+                  )}
+                  {ccCompatibleProviderEnabled && (
+                    <Button size="sm" icon="add" onClick={() => setShowAddCcCompatibleModal(true)}>
+                      {addCcCompatibleLabel}
+                    </Button>
+                  )}
+                  <Button
+                    size="sm"
+                    icon="add"
+                    onClick={() => setShowAddAnthropicCompatibleModal(true)}
+                  >
+                    {t("addAnthropicCompatible")}
+                  </Button>
+                  <Button size="sm" icon="add" onClick={() => setShowAddCompatibleModal(true)}>
+                    {t("addOpenAICompatible")}
+                  </Button>
+                </div>
+              </div>
+              <p className="text-sm text-text-muted -mt-2">{t("compatibleProvidersDesc")}</p>
+              {compatibleProviders.length === 0 &&
+              anthropicCompatibleProviders.length === 0 &&
+              ccCompatibleProviders.length === 0 ? (
+                <div className="flex items-center justify-center gap-2 py-2 border border-dashed border-border rounded-xl text-text-muted text-sm">
+                  <span className="material-symbols-outlined text-[18px]">extension</span>
+                  <span>{t("noCompatibleYet")}</span>
+                </div>
+              ) : (
+                <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 gap-3">
+                  {compatibleProviderEntries.map(
+                    ({ providerId, provider, stats, displayAuthType, toggleAuthType }) => (
+                      <ProviderCard
+                        key={providerId}
+                        providerId={providerId}
+                        provider={provider}
+                        stats={stats}
+                        authType={displayAuthType}
+                        onToggle={(active) =>
+                          handleToggleProvider(providerId, toggleAuthType, active)
+                        }
+                      />
+                    )
+                  )}
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* OAuth Providers (including providers that expose free tiers via OAuth) */}
+          {showSection("oauth") && (
+            <div className="flex flex-col gap-4">
+              <div className="flex flex-wrap items-center gap-2">
+                <h2 className="text-xl font-semibold flex items-center gap-2 flex-1 min-w-0">
+                  {t("oauthProviders")}{" "}
+                  <span className="size-2.5 rounded-full bg-blue-500" title={t("oauthLabel")} />
+                  <ProviderCountBadge
+                    {...countConfigured(
+                      oauthProviderEntriesAll.filter((e) => !IDE_PROVIDER_IDS.has(e.providerId))
+                    )}
+                  />
+                </h2>
+                <div className="flex items-center gap-2">
+                  {oauthEnvRepairStatus?.available && oauthEnvRepairStatus.missingCount > 0 && (
+                    <button
+                      onClick={handleRepairEnv}
+                      disabled={repairingEnv}
+                      className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border transition-colors ${
+                        repairingEnv
+                          ? "bg-primary/20 border-primary/40 text-primary animate-pulse"
+                          : "bg-bg-subtle border-border text-text-muted hover:text-text-primary hover:border-primary/40"
+                      }`}
+                      title={t("repairEnvHint")}
+                      aria-label={t("repairEnv")}
+                    >
+                      <span className="material-symbols-outlined text-[14px]">
+                        {repairingEnv ? "sync" : "settings_backup_restore"}
+                      </span>
+                      {repairingEnv ? t("repairEnvWorking") : t("repairEnv")}
+                    </button>
+                  )}
+                  <button
+                    onClick={() => handleBatchTest("oauth")}
+                    disabled={!!testingMode}
+                    className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border transition-colors ${
+                      testingMode === "oauth"
+                        ? "bg-primary/20 border-primary/40 text-primary animate-pulse"
+                        : "bg-bg-subtle border-border text-text-muted hover:text-text-primary hover:border-primary/40"
+                    }`}
+                    title={t("testAllOAuth")}
+                    aria-label={t("testAllOAuth")}
+                  >
+                    <span className="material-symbols-outlined text-[14px]">
+                      {testingMode === "oauth" ? "sync" : "play_arrow"}
+                    </span>
+                    {testingMode === "oauth" ? t("testing") : t("testAll")}
+                  </button>
+                </div>
+              </div>
+              <p className="text-sm text-text-muted -mt-2">{t("oauthProvidersDesc")}</p>
+              <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 gap-3">
+                {oauthProviderEntries
+                  .filter((e) => !IDE_PROVIDER_IDS.has(e.providerId))
+                  .map(({ providerId, provider, stats, displayAuthType, toggleAuthType }) => (
+                    <ProviderCard
+                      key={providerId}
+                      providerId={providerId}
+                      provider={provider}
+                      stats={stats}
+                      authType={displayAuthType}
+                      onToggle={(active) =>
+                        handleToggleProvider(providerId, toggleAuthType, active)
+                      }
+                    />
+                  ))}
+              </div>
+            </div>
+          )}
+
+          {/* IDE Providers (Cursor, Zed, Trae) — editors with built-in AI subscription */}
+          {showSection("ide") && (
+            <div className="flex flex-col gap-4">
+              <div className="flex flex-wrap items-center gap-2">
+                <h2 className="text-xl font-semibold flex items-center gap-2 flex-1 min-w-0">
+                  {t("ideProviders") || "IDE Providers"}{" "}
+                  <span
+                    className="size-2.5 rounded-full bg-cyan-500"
+                    title={t("ideProviders") || "IDE Providers"}
+                  />
+                  <ProviderCountBadge {...countConfigured(ideProviderEntriesAll)} />
+                </h2>
                 <button
-                  onClick={() => handleBatchTest("compatible")}
+                  onClick={() => handleBatchTest("ide")}
                   disabled={!!testingMode}
                   className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border transition-colors ${
-                    testingMode === "compatible"
+                    testingMode === "ide"
                       ? "bg-primary/20 border-primary/40 text-primary animate-pulse"
                       : "bg-bg-subtle border-border text-text-muted hover:text-text-primary hover:border-primary/40"
                   }`}
-                  title={t("testAllCompatible")}
+                  title={t("testAll")}
+                  aria-label={t("testAll")}
                 >
                   <span className="material-symbols-outlined text-[14px]">
-                    {testingMode === "compatible" ? "sync" : "play_arrow"}
+                    {testingMode === "ide" ? "sync" : "play_arrow"}
                   </span>
-                  {testingMode === "compatible" ? t("testing") : t("testAll")}
+                  {testingMode === "ide" ? t("testing") : t("testAll")}
                 </button>
+              </div>
+              <p className="text-sm text-text-muted -mt-2">
+                {t("ideProvidersDesc") ||
+                  "Editors with built-in AI subscription. Use the provider page to import credentials directly from the IDE's keychain."}
+              </p>
+              {ideProviderEntries.length === 0 ? (
+                <div className="rounded-lg border border-dashed border-border bg-bg-subtle p-6 text-center text-sm text-text-muted">
+                  {t("noIdeProviders") || "No IDE providers match the current filters."}
+                </div>
+              ) : (
+                <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 gap-3">
+                  {ideProviderEntries.map(
+                    ({ providerId, provider, stats, displayAuthType, toggleAuthType }) => (
+                      <ProviderCard
+                        key={`ide-${providerId}`}
+                        providerId={providerId}
+                        provider={provider}
+                        stats={stats}
+                        authType={displayAuthType}
+                        onToggle={(active) =>
+                          handleToggleProvider(providerId, toggleAuthType, active)
+                        }
+                      />
+                    )
+                  )}
+                </div>
               )}
-              {ccCompatibleProviderEnabled && (
-                <Button size="sm" icon="add" onClick={() => setShowAddCcCompatibleModal(true)}>
-                  {addCcCompatibleLabel}
-                </Button>
-              )}
-              <Button size="sm" icon="add" onClick={() => setShowAddAnthropicCompatibleModal(true)}>
-                {t("addAnthropicCompatible")}
-              </Button>
-              <Button size="sm" icon="add" onClick={() => setShowAddCompatibleModal(true)}>
-                {t("addOpenAICompatible")}
-              </Button>
             </div>
-          </div>
-          <p className="text-sm text-text-muted -mt-2">{t("compatibleProvidersDesc")}</p>
-          {compatibleProviders.length === 0 &&
-          anthropicCompatibleProviders.length === 0 &&
-          ccCompatibleProviders.length === 0 ? (
-            <div className="flex items-center justify-center gap-2 py-2 border border-dashed border-border rounded-xl text-text-muted text-sm">
-              <span className="material-symbols-outlined text-[18px]">extension</span>
-              <span>{t("noCompatibleYet")}</span>
-            </div>
-          ) : (
-            <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 gap-3">
-              {compatibleProviderEntries.map(
-                ({ providerId, provider, stats, displayAuthType, toggleAuthType }) => (
+          )}
+
+          {/* Web / Cookie Providers */}
+          {showSection("web") && webCookieProviderEntries.length > 0 && (
+            <div className="flex flex-col gap-4">
+              <div className="flex flex-wrap items-center gap-2">
+                <h2 className="text-xl font-semibold flex items-center gap-2 flex-1 min-w-0">
+                  {t("webCookieProviders")}{" "}
+                  <span
+                    className="size-2.5 rounded-full bg-purple-500"
+                    title={t("webCookieProviders")}
+                  />
+                  <ProviderCountBadge {...countConfigured(webCookieProviderEntriesAll)} />
+                </h2>
+                <button
+                  onClick={() => handleBatchTest("web-cookie")}
+                  disabled={!!testingMode}
+                  className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border transition-colors ${
+                    testingMode === "web-cookie"
+                      ? "bg-primary/20 border-primary/40 text-primary animate-pulse"
+                      : "bg-bg-subtle border-border text-text-muted hover:text-text-primary hover:border-primary/40"
+                  }`}
+                  title={t("testAll")}
+                >
+                  <span className="material-symbols-outlined text-[14px]">
+                    {testingMode === "web-cookie" ? "sync" : "play_arrow"}
+                  </span>
+                  {testingMode === "web-cookie" ? t("testing") : t("testAll")}
+                </button>
+              </div>
+              <p className="text-sm text-text-muted -mt-2">{t("webCookieProvidersDesc")}</p>
+              <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 gap-3">
+                {webCookieProviderEntries.map(({ providerId, provider, stats, toggleAuthType }) => (
                   <ProviderCard
                     key={providerId}
                     providerId={providerId}
                     provider={provider}
                     stats={stats}
-                    authType={displayAuthType}
+                    authType="web-cookie"
                     onToggle={(active) => handleToggleProvider(providerId, toggleAuthType, active)}
                   />
-                )
-              )}
+                ))}
+              </div>
             </div>
           )}
-        </div>
-      )}
 
-      {/* OAuth Providers (including providers that expose free tiers via OAuth) */}
-      {showSection("oauth") && (
-        <div className="flex flex-col gap-4">
-          <div className="flex flex-wrap items-center gap-2">
-            <h2 className="text-xl font-semibold flex items-center gap-2 flex-1 min-w-0">
-              {t("oauthProviders")}{" "}
-              <span className="size-2.5 rounded-full bg-blue-500" title={t("oauthLabel")} />
-              <ProviderCountBadge
-                {...countConfigured(
-                  oauthProviderEntriesAll.filter((e) => !IDE_PROVIDER_IDS.has(e.providerId))
-                )}
-              />
-            </h2>
-            <div className="flex items-center gap-2">
-              {oauthEnvRepairStatus?.available && oauthEnvRepairStatus.missingCount > 0 && (
+          {/* Free Tier Providers */}
+          {showSection("free") && freeSectionEntries.length > 0 && (
+            <div className="flex flex-col gap-4">
+              <div className="flex flex-wrap items-start gap-2">
+                <div className="flex-1 min-w-0">
+                  <h2 className="text-xl font-semibold flex items-center gap-2">
+                    {t("freeTierProviders")}
+                    <CategoryDot color="bg-green-500" label={t("freeTierLabel")} />
+                    <ProviderCountBadge {...countConfigured(freeSectionEntriesAll)} />
+                  </h2>
+                  <p className="text-sm text-text-muted mt-1">{t("freeAggregated")}</p>
+                </div>
                 <button
-                  onClick={handleRepairEnv}
-                  disabled={repairingEnv}
+                  onClick={() => handleBatchTest("free")}
+                  disabled={!!testingMode}
                   className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border transition-colors ${
-                    repairingEnv
+                    testingMode === "free"
                       ? "bg-primary/20 border-primary/40 text-primary animate-pulse"
                       : "bg-bg-subtle border-border text-text-muted hover:text-text-primary hover:border-primary/40"
                   }`}
-                  title={t("repairEnvHint")}
-                  aria-label={t("repairEnv")}
+                  title={t("testAll")}
                 >
                   <span className="material-symbols-outlined text-[14px]">
-                    {repairingEnv ? "sync" : "settings_backup_restore"}
+                    {testingMode === "free" ? "sync" : "play_arrow"}
                   </span>
-                  {repairingEnv ? t("repairEnvWorking") : t("repairEnv")}
+                  {testingMode === "free" ? t("testing") : t("testAll")}
                 </button>
-              )}
-              <button
-                onClick={() => handleBatchTest("oauth")}
-                disabled={!!testingMode}
-                className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border transition-colors ${
-                  testingMode === "oauth"
-                    ? "bg-primary/20 border-primary/40 text-primary animate-pulse"
-                    : "bg-bg-subtle border-border text-text-muted hover:text-text-primary hover:border-primary/40"
-                }`}
-                title={t("testAllOAuth")}
-                aria-label={t("testAllOAuth")}
-              >
-                <span className="material-symbols-outlined text-[14px]">
-                  {testingMode === "oauth" ? "sync" : "play_arrow"}
-                </span>
-                {testingMode === "oauth" ? t("testing") : t("testAll")}
-              </button>
+              </div>
+              <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 gap-3">
+                {freeSectionEntries.map(
+                  ({ providerId, provider, stats, displayAuthType, toggleAuthType }) => (
+                    <ProviderCard
+                      key={`free-section-${providerId}`}
+                      providerId={providerId}
+                      provider={provider}
+                      stats={stats}
+                      authType={toggleAuthType === "free" ? "free" : displayAuthType}
+                      onToggle={(active) =>
+                        handleToggleProvider(providerId, toggleAuthType, active)
+                      }
+                    />
+                  )
+                )}
+              </div>
             </div>
-          </div>
-          <p className="text-sm text-text-muted -mt-2">{t("oauthProvidersDesc")}</p>
-          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 gap-3">
-            {oauthProviderEntries
-              .filter((e) => !IDE_PROVIDER_IDS.has(e.providerId))
-              .map(({ providerId, provider, stats, displayAuthType, toggleAuthType }) => (
-                <ProviderCard
-                  key={providerId}
-                  providerId={providerId}
-                  provider={provider}
-                  stats={stats}
-                  authType={displayAuthType}
-                  onToggle={(active) => handleToggleProvider(providerId, toggleAuthType, active)}
-                />
-              ))}
-          </div>
-        </div>
-      )}
+          )}
 
-      {/* IDE Providers (Cursor, Zed, Trae) — editors with built-in AI subscription */}
-      {showSection("ide") && (
-        <div className="flex flex-col gap-4">
-          <div className="flex flex-wrap items-center gap-2">
-            <h2 className="text-xl font-semibold flex items-center gap-2 flex-1 min-w-0">
-              {t("ideProviders") || "IDE Providers"}{" "}
-              <span
-                className="size-2.5 rounded-full bg-cyan-500"
-                title={t("ideProviders") || "IDE Providers"}
-              />
-              <ProviderCountBadge {...countConfigured(ideProviderEntriesAll)} />
-            </h2>
-            <button
-              onClick={() => handleBatchTest("ide")}
-              disabled={!!testingMode}
-              className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border transition-colors ${
-                testingMode === "ide"
-                  ? "bg-primary/20 border-primary/40 text-primary animate-pulse"
-                  : "bg-bg-subtle border-border text-text-muted hover:text-text-primary hover:border-primary/40"
-              }`}
-              title={t("testAll")}
-              aria-label={t("testAll")}
-            >
-              <span className="material-symbols-outlined text-[14px]">
-                {testingMode === "ide" ? "sync" : "play_arrow"}
-              </span>
-              {testingMode === "ide" ? t("testing") : t("testAll")}
-            </button>
-          </div>
-          <p className="text-sm text-text-muted -mt-2">
-            {t("ideProvidersDesc") ||
-              "Editors with built-in AI subscription. Use the provider page to import credentials directly from the IDE's keychain."}
-          </p>
-          {ideProviderEntries.length === 0 ? (
-            <div className="rounded-lg border border-dashed border-border bg-bg-subtle p-6 text-center text-sm text-text-muted">
-              {t("noIdeProviders") || "No IDE providers match the current filters."}
-            </div>
-          ) : (
-            <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 gap-3">
-              {ideProviderEntries.map(
-                ({ providerId, provider, stats, displayAuthType, toggleAuthType }) => (
-                  <ProviderCard
-                    key={`ide-${providerId}`}
-                    providerId={providerId}
-                    provider={provider}
-                    stats={stats}
-                    authType={displayAuthType}
-                    onToggle={(active) => handleToggleProvider(providerId, toggleAuthType, active)}
-                  />
-                )
+          {/* API Key Providers — fixed list */}
+          {showSection("apikey") && (
+            <div className="flex flex-col gap-4">
+              <div className="flex flex-wrap items-center gap-2">
+                <h2 className="text-xl font-semibold flex items-center gap-2 flex-1 min-w-0">
+                  {t("apiKeyProviders")}{" "}
+                  <span className="size-2.5 rounded-full bg-amber-500" title={t("apiKeyLabel")} />
+                  <ProviderCountBadge {...countConfigured(apiKeyProviderEntriesAll)} />
+                </h2>
+                <button
+                  onClick={() => handleBatchTest("apikey")}
+                  disabled={!!testingMode}
+                  className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border transition-colors ${
+                    testingMode === "apikey"
+                      ? "bg-primary/20 border-primary/40 text-primary animate-pulse"
+                      : "bg-bg-subtle border-border text-text-muted hover:text-text-primary hover:border-primary/40"
+                  }`}
+                  title={t("testAllApiKey")}
+                  aria-label={t("testAllApiKey")}
+                >
+                  <span className="material-symbols-outlined text-[14px]">
+                    {testingMode === "apikey" ? "sync" : "play_arrow"}
+                  </span>
+                  {testingMode === "apikey" ? t("testing") : t("testAll")}
+                </button>
+              </div>
+              <p className="text-sm text-text-muted -mt-2">{t("apiKeyProvidersDesc")}</p>
+              {llmProviderEntries.length > 0 && (
+                <div className="flex flex-col gap-3">
+                  <h3 className="text-xs font-semibold uppercase tracking-wider text-text-muted">
+                    {t("llmProviders")}
+                  </h3>
+                  <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 gap-3">
+                    {llmProviderEntries.map(
+                      ({ providerId, provider, stats, displayAuthType, toggleAuthType }) => (
+                        <ProviderCard
+                          key={providerId}
+                          providerId={providerId}
+                          provider={provider}
+                          stats={stats}
+                          authType={displayAuthType}
+                          onToggle={(active) =>
+                            handleToggleProvider(providerId, toggleAuthType, active)
+                          }
+                        />
+                      )
+                    )}
+                  </div>
+                </div>
               )}
             </div>
           )}
-        </div>
-      )}
 
-      {/* Web / Cookie Providers */}
-      {showSection("web") && webCookieProviderEntries.length > 0 && (
-        <div className="flex flex-col gap-4">
-          <div className="flex flex-wrap items-center gap-2">
-            <h2 className="text-xl font-semibold flex items-center gap-2 flex-1 min-w-0">
-              {t("webCookieProviders")}{" "}
-              <span
-                className="size-2.5 rounded-full bg-purple-500"
-                title={t("webCookieProviders")}
-              />
-              <ProviderCountBadge {...countConfigured(webCookieProviderEntriesAll)} />
-            </h2>
-            <button
-              onClick={() => handleBatchTest("web-cookie")}
-              disabled={!!testingMode}
-              className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border transition-colors ${
-                testingMode === "web-cookie"
-                  ? "bg-primary/20 border-primary/40 text-primary animate-pulse"
-                  : "bg-bg-subtle border-border text-text-muted hover:text-text-primary hover:border-primary/40"
-              }`}
-              title={t("testAll")}
-            >
-              <span className="material-symbols-outlined text-[14px]">
-                {testingMode === "web-cookie" ? "sync" : "play_arrow"}
-              </span>
-              {testingMode === "web-cookie" ? t("testing") : t("testAll")}
-            </button>
-          </div>
-          <p className="text-sm text-text-muted -mt-2">{t("webCookieProvidersDesc")}</p>
-          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 gap-3">
-            {webCookieProviderEntries.map(({ providerId, provider, stats, toggleAuthType }) => (
-              <ProviderCard
-                key={providerId}
-                providerId={providerId}
-                provider={provider}
-                stats={stats}
-                authType="web-cookie"
-                onToggle={(active) => handleToggleProvider(providerId, toggleAuthType, active)}
-              />
-            ))}
-          </div>
-        </div>
-      )}
-
-      {/* Free Tier Providers */}
-      {showSection("free") && freeSectionEntries.length > 0 && (
-        <div className="flex flex-col gap-4">
-          <div className="flex flex-wrap items-start gap-2">
-            <div className="flex-1 min-w-0">
-              <h2 className="text-xl font-semibold flex items-center gap-2">
-                {t("freeTierProviders")}
-                <CategoryDot color="bg-green-500" label={t("freeTierLabel")} />
-                <ProviderCountBadge {...countConfigured(freeSectionEntriesAll)} />
-              </h2>
-              <p className="text-sm text-text-muted mt-1">{t("freeAggregated")}</p>
-            </div>
-            <button
-              onClick={() => handleBatchTest("free")}
-              disabled={!!testingMode}
-              className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border transition-colors ${
-                testingMode === "free"
-                  ? "bg-primary/20 border-primary/40 text-primary animate-pulse"
-                  : "bg-bg-subtle border-border text-text-muted hover:text-text-primary hover:border-primary/40"
-              }`}
-              title={t("testAll")}
-            >
-              <span className="material-symbols-outlined text-[14px]">
-                {testingMode === "free" ? "sync" : "play_arrow"}
-              </span>
-              {testingMode === "free" ? t("testing") : t("testAll")}
-            </button>
-          </div>
-          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 gap-3">
-            {freeSectionEntries.map(
-              ({ providerId, provider, stats, displayAuthType, toggleAuthType }) => (
-                <ProviderCard
-                  key={`free-section-${providerId}`}
-                  providerId={providerId}
-                  provider={provider}
-                  stats={stats}
-                  authType={toggleAuthType === "free" ? "free" : displayAuthType}
-                  onToggle={(active) => handleToggleProvider(providerId, toggleAuthType, active)}
-                />
-              )
-            )}
-          </div>
-        </div>
-      )}
-
-      {/* API Key Providers — fixed list */}
-      {showSection("apikey") && (
-        <div className="flex flex-col gap-4">
-          <div className="flex flex-wrap items-center gap-2">
-            <h2 className="text-xl font-semibold flex items-center gap-2 flex-1 min-w-0">
-              {t("apiKeyProviders")}{" "}
-              <span className="size-2.5 rounded-full bg-amber-500" title={t("apiKeyLabel")} />
-              <ProviderCountBadge {...countConfigured(apiKeyProviderEntriesAll)} />
-            </h2>
-            <button
-              onClick={() => handleBatchTest("apikey")}
-              disabled={!!testingMode}
-              className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border transition-colors ${
-                testingMode === "apikey"
-                  ? "bg-primary/20 border-primary/40 text-primary animate-pulse"
-                  : "bg-bg-subtle border-border text-text-muted hover:text-text-primary hover:border-primary/40"
-              }`}
-              title={t("testAllApiKey")}
-              aria-label={t("testAllApiKey")}
-            >
-              <span className="material-symbols-outlined text-[14px]">
-                {testingMode === "apikey" ? "sync" : "play_arrow"}
-              </span>
-              {testingMode === "apikey" ? t("testing") : t("testAll")}
-            </button>
-          </div>
-          <p className="text-sm text-text-muted -mt-2">{t("apiKeyProvidersDesc")}</p>
-          {llmProviderEntries.length > 0 && (
-            <div className="flex flex-col gap-3">
-              <h3 className="text-xs font-semibold uppercase tracking-wider text-text-muted">
-                {t("llmProviders")}
-              </h3>
+          {/* No Auth Providers */}
+          {showSection("noauth") && noAuthEntries.length > 0 && (
+            <div className="flex flex-col gap-4">
+              <div className="flex flex-wrap items-center gap-2">
+                <h2 className="text-xl font-semibold flex items-center gap-2 flex-1 min-w-0">
+                  {t("noAuthProviders")}{" "}
+                  <span className="size-2.5 rounded-full bg-stone-500" title={t("noAuthLabel")} />
+                  <ProviderCountBadge {...countConfigured(noAuthEntriesAll)} />
+                </h2>
+                <button
+                  onClick={() => handleBatchTest("no-auth")}
+                  disabled={!!testingMode}
+                  className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border transition-colors ${
+                    testingMode === "no-auth"
+                      ? "bg-primary/20 border-primary/40 text-primary animate-pulse"
+                      : "bg-bg-subtle border-border text-text-muted hover:text-text-primary hover:border-primary/40"
+                  }`}
+                  title={t("testAll")}
+                >
+                  <span className="material-symbols-outlined text-[14px]">
+                    {testingMode === "no-auth" ? "sync" : "play_arrow"}
+                  </span>
+                  {testingMode === "no-auth" ? t("testing") : t("testAll")}
+                </button>
+              </div>
+              <p className="text-sm text-text-muted -mt-2">{t("noAuthProvidersDesc")}</p>
               <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 gap-3">
-                {llmProviderEntries.map(
+                {noAuthEntries.map(({ providerId, provider, stats, toggleAuthType }) => (
+                  <ProviderCard
+                    key={providerId}
+                    providerId={providerId}
+                    provider={provider}
+                    stats={stats}
+                    authType="no-auth"
+                    onToggle={(active) => handleToggleProvider(providerId, toggleAuthType, active)}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Upstream Proxy Providers */}
+          {showSection("proxy") && upstreamProxyEntries.length > 0 && (
+            <div className="flex flex-col gap-4">
+              <div className="flex flex-wrap items-center gap-2">
+                <h2 className="text-xl font-semibold flex items-center gap-2 flex-1 min-w-0">
+                  {t("upstreamProxyProviders")}{" "}
+                  <span
+                    className="size-2.5 rounded-full bg-indigo-500"
+                    title={t("upstreamProxyProviders")}
+                  />
+                  <ProviderCountBadge {...countConfigured(upstreamProxyEntriesAll)} />
+                </h2>
+                <button
+                  onClick={() => handleBatchTest("upstream-proxy")}
+                  disabled={!!testingMode}
+                  className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border transition-colors ${
+                    testingMode === "upstream-proxy"
+                      ? "bg-primary/20 border-primary/40 text-primary animate-pulse"
+                      : "bg-bg-subtle border-border text-text-muted hover:text-text-primary hover:border-primary/40"
+                  }`}
+                  title={t("testAll")}
+                >
+                  <span className="material-symbols-outlined text-[14px]">
+                    {testingMode === "upstream-proxy" ? "sync" : "play_arrow"}
+                  </span>
+                  {testingMode === "upstream-proxy" ? t("testing") : t("testAll")}
+                </button>
+              </div>
+              <p className="text-sm text-text-muted -mt-2">{t("upstreamProxyProvidersDesc")}</p>
+              <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 gap-3">
+                {upstreamProxyEntries.map(({ providerId, provider, stats, toggleAuthType }) => (
+                  <ProviderCard
+                    key={providerId}
+                    providerId={providerId}
+                    provider={provider}
+                    stats={stats}
+                    authType="upstream-proxy"
+                    onToggle={(active) => handleToggleProvider(providerId, toggleAuthType, active)}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Web Fetch Providers */}
+          {showSection("webfetch") && webFetchEntries.length > 0 && (
+            <div className="flex flex-col gap-4">
+              <div className="flex flex-wrap items-center gap-2">
+                <h2 className="text-xl font-semibold flex items-center gap-2 flex-1 min-w-0">
+                  {t("webFetchProvidersHeading")}{" "}
+                  <span
+                    className="size-2.5 rounded-full bg-orange-500"
+                    title={t("webFetchTooltip")}
+                  />
+                  <ProviderCountBadge {...countConfigured(webFetchEntriesAll)} />
+                </h2>
+              </div>
+              <p className="text-sm text-text-muted -mt-2">{t("webFetchProvidersDesc")}</p>
+              <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 gap-3">
+                {webFetchEntries.map(
+                  ({ providerId, provider, stats, displayAuthType, toggleAuthType }) => (
+                    <ProviderCard
+                      key={`webfetch-${providerId}`}
+                      providerId={providerId}
+                      provider={provider}
+                      stats={stats}
+                      authType={displayAuthType}
+                      onToggle={(active) =>
+                        handleToggleProvider(providerId, toggleAuthType, active)
+                      }
+                    />
+                  )
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Aggregators Gateways */}
+          {showSection("apikey") && aggregatorProviderEntries.length > 0 && (
+            <div className="flex flex-col gap-4">
+              <div className="flex flex-wrap items-center gap-2">
+                <h2 className="text-xl font-semibold flex items-center gap-2 flex-1 min-w-0">
+                  {t("aggregatorsGateways")}{" "}
+                  <span
+                    className="size-2.5 rounded-full bg-amber-500"
+                    title={t("aggregatorsGateways")}
+                  />
+                  <ProviderCountBadge {...countConfigured(aggregatorProviderEntriesAll)} />
+                </h2>
+              </div>
+              <p className="text-sm text-text-muted -mt-2">{t("aggregatorsGatewaysDesc")}</p>
+              <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 gap-3">
+                {aggregatorProviderEntries.map(
                   ({ providerId, provider, stats, displayAuthType, toggleAuthType }) => (
                     <ProviderCard
                       key={providerId}
@@ -1322,439 +1390,319 @@ export default function ProvidersPage() {
               </div>
             </div>
           )}
-        </div>
-      )}
 
-      {/* No Auth Providers */}
-      {showSection("noauth") && noAuthEntries.length > 0 && (
-        <div className="flex flex-col gap-4">
-          <div className="flex flex-wrap items-center gap-2">
-            <h2 className="text-xl font-semibold flex items-center gap-2 flex-1 min-w-0">
-              {t("noAuthProviders")}{" "}
-              <span className="size-2.5 rounded-full bg-stone-500" title={t("noAuthLabel")} />
-              <ProviderCountBadge {...countConfigured(noAuthEntriesAll)} />
-            </h2>
-            <button
-              onClick={() => handleBatchTest("no-auth")}
-              disabled={!!testingMode}
-              className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border transition-colors ${
-                testingMode === "no-auth"
-                  ? "bg-primary/20 border-primary/40 text-primary animate-pulse"
-                  : "bg-bg-subtle border-border text-text-muted hover:text-text-primary hover:border-primary/40"
-              }`}
-              title={t("testAll")}
-            >
-              <span className="material-symbols-outlined text-[14px]">
-                {testingMode === "no-auth" ? "sync" : "play_arrow"}
-              </span>
-              {testingMode === "no-auth" ? t("testing") : t("testAll")}
-            </button>
-          </div>
-          <p className="text-sm text-text-muted -mt-2">{t("noAuthProvidersDesc")}</p>
-          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 gap-3">
-            {noAuthEntries.map(({ providerId, provider, stats, toggleAuthType }) => (
-              <ProviderCard
-                key={providerId}
-                providerId={providerId}
-                provider={provider}
-                stats={stats}
-                authType="no-auth"
-                onToggle={(active) => handleToggleProvider(providerId, toggleAuthType, active)}
-              />
-            ))}
-          </div>
-        </div>
-      )}
+          {/* Enterprise & Cloud */}
+          {showSection("apikey") && enterpriseProviderEntries.length > 0 && (
+            <div className="flex flex-col gap-4">
+              <div className="flex flex-wrap items-center gap-2">
+                <h2 className="text-xl font-semibold flex items-center gap-2 flex-1 min-w-0">
+                  {t("enterpriseCloud")}{" "}
+                  <span
+                    className="size-2.5 rounded-full bg-amber-500"
+                    title={t("enterpriseCloud")}
+                  />
+                  <ProviderCountBadge {...countConfigured(enterpriseProviderEntriesAll)} />
+                </h2>
+              </div>
+              <p className="text-sm text-text-muted -mt-2">{t("enterpriseCloudDesc")}</p>
+              <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 gap-3">
+                {enterpriseProviderEntries.map(
+                  ({ providerId, provider, stats, displayAuthType, toggleAuthType }) => (
+                    <ProviderCard
+                      key={providerId}
+                      providerId={providerId}
+                      provider={provider}
+                      stats={stats}
+                      authType={displayAuthType}
+                      onToggle={(active) =>
+                        handleToggleProvider(providerId, toggleAuthType, active)
+                      }
+                    />
+                  )
+                )}
+              </div>
+            </div>
+          )}
 
-      {/* Upstream Proxy Providers */}
-      {showSection("proxy") && upstreamProxyEntries.length > 0 && (
-        <div className="flex flex-col gap-4">
-          <div className="flex flex-wrap items-center gap-2">
-            <h2 className="text-xl font-semibold flex items-center gap-2 flex-1 min-w-0">
-              {t("upstreamProxyProviders")}{" "}
-              <span
-                className="size-2.5 rounded-full bg-indigo-500"
-                title={t("upstreamProxyProviders")}
-              />
-              <ProviderCountBadge {...countConfigured(upstreamProxyEntriesAll)} />
-            </h2>
-            <button
-              onClick={() => handleBatchTest("upstream-proxy")}
-              disabled={!!testingMode}
-              className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border transition-colors ${
-                testingMode === "upstream-proxy"
-                  ? "bg-primary/20 border-primary/40 text-primary animate-pulse"
-                  : "bg-bg-subtle border-border text-text-muted hover:text-text-primary hover:border-primary/40"
-              }`}
-              title={t("testAll")}
-            >
-              <span className="material-symbols-outlined text-[14px]">
-                {testingMode === "upstream-proxy" ? "sync" : "play_arrow"}
-              </span>
-              {testingMode === "upstream-proxy" ? t("testing") : t("testAll")}
-            </button>
-          </div>
-          <p className="text-sm text-text-muted -mt-2">{t("upstreamProxyProvidersDesc")}</p>
-          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 gap-3">
-            {upstreamProxyEntries.map(({ providerId, provider, stats, toggleAuthType }) => (
-              <ProviderCard
-                key={providerId}
-                providerId={providerId}
-                provider={provider}
-                stats={stats}
-                authType="upstream-proxy"
-                onToggle={(active) => handleToggleProvider(providerId, toggleAuthType, active)}
-              />
-            ))}
-          </div>
-        </div>
-      )}
+          {/* Cloud Agent Providers */}
+          {showSection("cloud") && cloudAgentProviderEntries.length > 0 && (
+            <div className="flex flex-col gap-4">
+              <div className="flex flex-wrap items-center gap-2">
+                <h2 className="text-xl font-semibold flex items-center gap-2 flex-1 min-w-0">
+                  {t("cloudAgentProviders")}{" "}
+                  <span
+                    className="size-2.5 rounded-full bg-violet-500"
+                    title={t("cloudAgentProviders")}
+                  />
+                  <ProviderCountBadge {...countConfigured(cloudAgentProviderEntriesAll)} />
+                </h2>
+                <button
+                  onClick={() => handleBatchTest("cloud-agent")}
+                  disabled={!!testingMode}
+                  className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border transition-colors ${
+                    testingMode === "cloud-agent"
+                      ? "bg-primary/20 border-primary/40 text-primary animate-pulse"
+                      : "bg-bg-subtle border-border text-text-muted hover:text-text-primary hover:border-primary/40"
+                  }`}
+                  title={t("testAll")}
+                >
+                  <span className="material-symbols-outlined text-[14px]">
+                    {testingMode === "cloud-agent" ? "sync" : "play_arrow"}
+                  </span>
+                  {testingMode === "cloud-agent" ? t("testing") : t("testAll")}
+                </button>
+              </div>
+              <p className="text-sm text-text-muted -mt-2">{t("cloudAgentProvidersDesc")}</p>
+              <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 gap-3">
+                {cloudAgentProviderEntries.map(
+                  ({ providerId, provider, stats, toggleAuthType }) => (
+                    <ProviderCard
+                      key={providerId}
+                      providerId={providerId}
+                      provider={provider}
+                      stats={stats}
+                      authType="cloud-agent"
+                      onToggle={(active) =>
+                        handleToggleProvider(providerId, toggleAuthType, active)
+                      }
+                    />
+                  )
+                )}
+              </div>
+            </div>
+          )}
 
-      {/* Web Fetch Providers */}
-      {showSection("webfetch") && webFetchEntries.length > 0 && (
-        <div className="flex flex-col gap-4">
-          <div className="flex flex-wrap items-center gap-2">
-            <h2 className="text-xl font-semibold flex items-center gap-2 flex-1 min-w-0">
-              {t("webFetchProvidersHeading")}{" "}
-              <span className="size-2.5 rounded-full bg-orange-500" title={t("webFetchTooltip")} />
-              <ProviderCountBadge {...countConfigured(webFetchEntriesAll)} />
-            </h2>
-          </div>
-          <p className="text-sm text-text-muted -mt-2">{t("webFetchProvidersDesc")}</p>
-          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 gap-3">
-            {webFetchEntries.map(
-              ({ providerId, provider, stats, displayAuthType, toggleAuthType }) => (
-                <ProviderCard
-                  key={`webfetch-${providerId}`}
-                  providerId={providerId}
-                  provider={provider}
-                  stats={stats}
-                  authType={displayAuthType}
-                  onToggle={(active) => handleToggleProvider(providerId, toggleAuthType, active)}
-                />
-              )
-            )}
-          </div>
-        </div>
-      )}
+          {/* Local / Self-Hosted Providers */}
+          {showSection("local") && localProviderEntries.length > 0 && (
+            <div className="flex flex-col gap-4">
+              <div className="flex flex-wrap items-center gap-2">
+                <h2 className="text-xl font-semibold flex items-center gap-2 flex-1 min-w-0">
+                  {t("localProviders")}{" "}
+                  <span
+                    className="size-2.5 rounded-full bg-emerald-500"
+                    title={t("localProviders")}
+                  />
+                  <ProviderCountBadge {...countConfigured(localProviderEntriesAll)} />
+                </h2>
+                <button
+                  onClick={() => handleBatchTest("local")}
+                  disabled={!!testingMode}
+                  className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border transition-colors ${
+                    testingMode === "local"
+                      ? "bg-primary/20 border-primary/40 text-primary animate-pulse"
+                      : "bg-bg-subtle border-border text-text-muted hover:text-text-primary hover:border-primary/40"
+                  }`}
+                  title={t("testAll")}
+                >
+                  <span className="material-symbols-outlined text-[14px]">
+                    {testingMode === "local" ? "sync" : "play_arrow"}
+                  </span>
+                  {testingMode === "local" ? t("testing") : t("testAll")}
+                </button>
+              </div>
+              <p className="text-sm text-text-muted -mt-2">{t("localProvidersDesc")}</p>
+              <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 gap-3">
+                {localProviderEntries.map(({ providerId, provider, stats, toggleAuthType }) => (
+                  <ProviderCard
+                    key={providerId}
+                    providerId={providerId}
+                    provider={provider}
+                    stats={stats}
+                    authType="local"
+                    onToggle={(active) => handleToggleProvider(providerId, toggleAuthType, active)}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
 
-      {/* Aggregators Gateways */}
-      {showSection("apikey") && aggregatorProviderEntries.length > 0 && (
-        <div className="flex flex-col gap-4">
-          <div className="flex flex-wrap items-center gap-2">
-            <h2 className="text-xl font-semibold flex items-center gap-2 flex-1 min-w-0">
-              {t("aggregatorsGateways")}{" "}
-              <span
-                className="size-2.5 rounded-full bg-amber-500"
-                title={t("aggregatorsGateways")}
-              />
-              <ProviderCountBadge {...countConfigured(aggregatorProviderEntriesAll)} />
-            </h2>
-          </div>
-          <p className="text-sm text-text-muted -mt-2">{t("aggregatorsGatewaysDesc")}</p>
-          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 gap-3">
-            {aggregatorProviderEntries.map(
-              ({ providerId, provider, stats, displayAuthType, toggleAuthType }) => (
-                <ProviderCard
-                  key={providerId}
-                  providerId={providerId}
-                  provider={provider}
-                  stats={stats}
-                  authType={displayAuthType}
-                  onToggle={(active) => handleToggleProvider(providerId, toggleAuthType, active)}
-                />
-              )
-            )}
-          </div>
-        </div>
-      )}
+          {/* Search Providers */}
+          {showSection("search") && searchProviderEntries.length > 0 && (
+            <div className="flex flex-col gap-4">
+              <div className="flex flex-wrap items-center gap-2">
+                <h2 className="text-xl font-semibold flex items-center gap-2 flex-1 min-w-0">
+                  {t("searchProvidersHeading")}{" "}
+                  <span
+                    className="size-2.5 rounded-full bg-teal-500"
+                    title={t("searchProvidersHeading")}
+                  />
+                  <ProviderCountBadge {...countConfigured(searchProviderEntriesAll)} />
+                </h2>
+                <button
+                  onClick={() => handleBatchTest("search")}
+                  disabled={!!testingMode}
+                  className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border transition-colors ${
+                    testingMode === "search"
+                      ? "bg-primary/20 border-primary/40 text-primary animate-pulse"
+                      : "bg-bg-subtle border-border text-text-muted hover:text-text-primary hover:border-primary/40"
+                  }`}
+                  title={t("testAll")}
+                >
+                  <span className="material-symbols-outlined text-[14px]">
+                    {testingMode === "search" ? "sync" : "play_arrow"}
+                  </span>
+                  {testingMode === "search" ? t("testing") : t("testAll")}
+                </button>
+              </div>
+              <p className="text-sm text-text-muted -mt-2">{t("searchProvidersDesc")}</p>
+              <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 gap-3">
+                {searchProviderEntries.map(({ providerId, provider, stats, toggleAuthType }) => (
+                  <ProviderCard
+                    key={providerId}
+                    providerId={providerId}
+                    provider={provider}
+                    stats={stats}
+                    authType="search"
+                    onToggle={(active) => handleToggleProvider(providerId, toggleAuthType, active)}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
 
-      {/* Enterprise & Cloud */}
-      {showSection("apikey") && enterpriseProviderEntries.length > 0 && (
-        <div className="flex flex-col gap-4">
-          <div className="flex flex-wrap items-center gap-2">
-            <h2 className="text-xl font-semibold flex items-center gap-2 flex-1 min-w-0">
-              {t("enterpriseCloud")}{" "}
-              <span className="size-2.5 rounded-full bg-amber-500" title={t("enterpriseCloud")} />
-              <ProviderCountBadge {...countConfigured(enterpriseProviderEntriesAll)} />
-            </h2>
-          </div>
-          <p className="text-sm text-text-muted -mt-2">{t("enterpriseCloudDesc")}</p>
-          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 gap-3">
-            {enterpriseProviderEntries.map(
-              ({ providerId, provider, stats, displayAuthType, toggleAuthType }) => (
-                <ProviderCard
-                  key={providerId}
-                  providerId={providerId}
-                  provider={provider}
-                  stats={stats}
-                  authType={displayAuthType}
-                  onToggle={(active) => handleToggleProvider(providerId, toggleAuthType, active)}
-                />
-              )
-            )}
-          </div>
-        </div>
-      )}
+          {/* Embeddings & Rerank */}
+          {showSection("apikey") && embeddingRerankProviderEntries.length > 0 && (
+            <div className="flex flex-col gap-4">
+              <div className="flex flex-wrap items-center gap-2">
+                <h2 className="text-xl font-semibold flex items-center gap-2 flex-1 min-w-0">
+                  {t("embeddingRerankProviders")}{" "}
+                  <span
+                    className="size-2.5 rounded-full bg-amber-500"
+                    title={t("embeddingRerankProviders")}
+                  />
+                  <ProviderCountBadge {...countConfigured(embeddingRerankProviderEntriesAll)} />
+                </h2>
+              </div>
+              <p className="text-sm text-text-muted -mt-2">{t("embeddingRerankProvidersDesc")}</p>
+              <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 gap-3">
+                {embeddingRerankProviderEntries.map(
+                  ({ providerId, provider, stats, displayAuthType, toggleAuthType }) => (
+                    <ProviderCard
+                      key={providerId}
+                      providerId={providerId}
+                      provider={provider}
+                      stats={stats}
+                      authType={displayAuthType}
+                      onToggle={(active) =>
+                        handleToggleProvider(providerId, toggleAuthType, active)
+                      }
+                    />
+                  )
+                )}
+              </div>
+            </div>
+          )}
 
-      {/* Cloud Agent Providers */}
-      {showSection("cloud") && cloudAgentProviderEntries.length > 0 && (
-        <div className="flex flex-col gap-4">
-          <div className="flex flex-wrap items-center gap-2">
-            <h2 className="text-xl font-semibold flex items-center gap-2 flex-1 min-w-0">
-              {t("cloudAgentProviders")}{" "}
-              <span
-                className="size-2.5 rounded-full bg-violet-500"
-                title={t("cloudAgentProviders")}
-              />
-              <ProviderCountBadge {...countConfigured(cloudAgentProviderEntriesAll)} />
-            </h2>
-            <button
-              onClick={() => handleBatchTest("cloud-agent")}
-              disabled={!!testingMode}
-              className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border transition-colors ${
-                testingMode === "cloud-agent"
-                  ? "bg-primary/20 border-primary/40 text-primary animate-pulse"
-                  : "bg-bg-subtle border-border text-text-muted hover:text-text-primary hover:border-primary/40"
-              }`}
-              title={t("testAll")}
-            >
-              <span className="material-symbols-outlined text-[14px]">
-                {testingMode === "cloud-agent" ? "sync" : "play_arrow"}
-              </span>
-              {testingMode === "cloud-agent" ? t("testing") : t("testAll")}
-            </button>
-          </div>
-          <p className="text-sm text-text-muted -mt-2">{t("cloudAgentProvidersDesc")}</p>
-          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 gap-3">
-            {cloudAgentProviderEntries.map(({ providerId, provider, stats, toggleAuthType }) => (
-              <ProviderCard
-                key={providerId}
-                providerId={providerId}
-                provider={provider}
-                stats={stats}
-                authType="cloud-agent"
-                onToggle={(active) => handleToggleProvider(providerId, toggleAuthType, active)}
-              />
-            ))}
-          </div>
-        </div>
-      )}
+          {/* Image Providers */}
+          {showSection("apikey") && imageProviderEntries.length > 0 && (
+            <div className="flex flex-col gap-4">
+              <div className="flex flex-wrap items-center gap-2">
+                <h2 className="text-xl font-semibold flex items-center gap-2 flex-1 min-w-0">
+                  {t("imageProviders")}{" "}
+                  <span
+                    className="size-2.5 rounded-full bg-amber-500"
+                    title={t("imageProviders")}
+                  />
+                  <ProviderCountBadge {...countConfigured(imageProviderEntriesAll)} />
+                </h2>
+              </div>
+              <p className="text-sm text-text-muted -mt-2">{t("imageProvidersDesc")}</p>
+              <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 gap-3">
+                {imageProviderEntries.map(
+                  ({ providerId, provider, stats, displayAuthType, toggleAuthType }) => (
+                    <ProviderCard
+                      key={providerId}
+                      providerId={providerId}
+                      provider={provider}
+                      stats={stats}
+                      authType={displayAuthType}
+                      onToggle={(active) =>
+                        handleToggleProvider(providerId, toggleAuthType, active)
+                      }
+                    />
+                  )
+                )}
+              </div>
+            </div>
+          )}
 
-      {/* Local / Self-Hosted Providers */}
-      {showSection("local") && localProviderEntries.length > 0 && (
-        <div className="flex flex-col gap-4">
-          <div className="flex flex-wrap items-center gap-2">
-            <h2 className="text-xl font-semibold flex items-center gap-2 flex-1 min-w-0">
-              {t("localProviders")}{" "}
-              <span className="size-2.5 rounded-full bg-emerald-500" title={t("localProviders")} />
-              <ProviderCountBadge {...countConfigured(localProviderEntriesAll)} />
-            </h2>
-            <button
-              onClick={() => handleBatchTest("local")}
-              disabled={!!testingMode}
-              className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border transition-colors ${
-                testingMode === "local"
-                  ? "bg-primary/20 border-primary/40 text-primary animate-pulse"
-                  : "bg-bg-subtle border-border text-text-muted hover:text-text-primary hover:border-primary/40"
-              }`}
-              title={t("testAll")}
-            >
-              <span className="material-symbols-outlined text-[14px]">
-                {testingMode === "local" ? "sync" : "play_arrow"}
-              </span>
-              {testingMode === "local" ? t("testing") : t("testAll")}
-            </button>
-          </div>
-          <p className="text-sm text-text-muted -mt-2">{t("localProvidersDesc")}</p>
-          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 gap-3">
-            {localProviderEntries.map(({ providerId, provider, stats, toggleAuthType }) => (
-              <ProviderCard
-                key={providerId}
-                providerId={providerId}
-                provider={provider}
-                stats={stats}
-                authType="local"
-                onToggle={(active) => handleToggleProvider(providerId, toggleAuthType, active)}
-              />
-            ))}
-          </div>
-        </div>
-      )}
+          {/* Audio Only Providers */}
+          {showSection("audio") && audioProviderEntries.length > 0 && (
+            <div className="flex flex-col gap-4">
+              <div className="flex flex-wrap items-center gap-2">
+                <h2 className="text-xl font-semibold flex items-center gap-2 flex-1 min-w-0">
+                  {t("audioProvidersHeading")}{" "}
+                  <span
+                    className="size-2.5 rounded-full bg-rose-500"
+                    title={t("audioProvidersHeading")}
+                  />
+                  <ProviderCountBadge {...countConfigured(audioProviderEntriesAll)} />
+                </h2>
+                <button
+                  onClick={() => handleBatchTest("audio")}
+                  disabled={!!testingMode}
+                  className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border transition-colors ${
+                    testingMode === "audio"
+                      ? "bg-primary/20 border-primary/40 text-primary animate-pulse"
+                      : "bg-bg-subtle border-border text-text-muted hover:text-text-primary hover:border-primary/40"
+                  }`}
+                  title={t("testAll")}
+                >
+                  <span className="material-symbols-outlined text-[14px]">
+                    {testingMode === "audio" ? "sync" : "play_arrow"}
+                  </span>
+                  {testingMode === "audio" ? t("testing") : t("testAll")}
+                </button>
+              </div>
+              <p className="text-sm text-text-muted -mt-2">{t("audioProvidersDesc")}</p>
+              <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 gap-3">
+                {audioProviderEntries.map(({ providerId, provider, stats, toggleAuthType }) => (
+                  <ProviderCard
+                    key={providerId}
+                    providerId={providerId}
+                    provider={provider}
+                    stats={stats}
+                    authType="audio"
+                    onToggle={(active) => handleToggleProvider(providerId, toggleAuthType, active)}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
 
-      {/* Search Providers */}
-      {showSection("search") && searchProviderEntries.length > 0 && (
-        <div className="flex flex-col gap-4">
-          <div className="flex flex-wrap items-center gap-2">
-            <h2 className="text-xl font-semibold flex items-center gap-2 flex-1 min-w-0">
-              {t("searchProvidersHeading")}{" "}
-              <span
-                className="size-2.5 rounded-full bg-teal-500"
-                title={t("searchProvidersHeading")}
-              />
-              <ProviderCountBadge {...countConfigured(searchProviderEntriesAll)} />
-            </h2>
-            <button
-              onClick={() => handleBatchTest("search")}
-              disabled={!!testingMode}
-              className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border transition-colors ${
-                testingMode === "search"
-                  ? "bg-primary/20 border-primary/40 text-primary animate-pulse"
-                  : "bg-bg-subtle border-border text-text-muted hover:text-text-primary hover:border-primary/40"
-              }`}
-              title={t("testAll")}
-            >
-              <span className="material-symbols-outlined text-[14px]">
-                {testingMode === "search" ? "sync" : "play_arrow"}
-              </span>
-              {testingMode === "search" ? t("testing") : t("testAll")}
-            </button>
-          </div>
-          <p className="text-sm text-text-muted -mt-2">{t("searchProvidersDesc")}</p>
-          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 gap-3">
-            {searchProviderEntries.map(({ providerId, provider, stats, toggleAuthType }) => (
-              <ProviderCard
-                key={providerId}
-                providerId={providerId}
-                provider={provider}
-                stats={stats}
-                authType="search"
-                onToggle={(active) => handleToggleProvider(providerId, toggleAuthType, active)}
-              />
-            ))}
-          </div>
-        </div>
-      )}
-
-      {/* Embeddings & Rerank */}
-      {showSection("apikey") && embeddingRerankProviderEntries.length > 0 && (
-        <div className="flex flex-col gap-4">
-          <div className="flex flex-wrap items-center gap-2">
-            <h2 className="text-xl font-semibold flex items-center gap-2 flex-1 min-w-0">
-              {t("embeddingRerankProviders")}{" "}
-              <span
-                className="size-2.5 rounded-full bg-amber-500"
-                title={t("embeddingRerankProviders")}
-              />
-              <ProviderCountBadge {...countConfigured(embeddingRerankProviderEntriesAll)} />
-            </h2>
-          </div>
-          <p className="text-sm text-text-muted -mt-2">{t("embeddingRerankProvidersDesc")}</p>
-          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 gap-3">
-            {embeddingRerankProviderEntries.map(
-              ({ providerId, provider, stats, displayAuthType, toggleAuthType }) => (
-                <ProviderCard
-                  key={providerId}
-                  providerId={providerId}
-                  provider={provider}
-                  stats={stats}
-                  authType={displayAuthType}
-                  onToggle={(active) => handleToggleProvider(providerId, toggleAuthType, active)}
-                />
-              )
-            )}
-          </div>
-        </div>
-      )}
-
-      {/* Image Providers */}
-      {showSection("apikey") && imageProviderEntries.length > 0 && (
-        <div className="flex flex-col gap-4">
-          <div className="flex flex-wrap items-center gap-2">
-            <h2 className="text-xl font-semibold flex items-center gap-2 flex-1 min-w-0">
-              {t("imageProviders")}{" "}
-              <span className="size-2.5 rounded-full bg-amber-500" title={t("imageProviders")} />
-              <ProviderCountBadge {...countConfigured(imageProviderEntriesAll)} />
-            </h2>
-          </div>
-          <p className="text-sm text-text-muted -mt-2">{t("imageProvidersDesc")}</p>
-          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 gap-3">
-            {imageProviderEntries.map(
-              ({ providerId, provider, stats, displayAuthType, toggleAuthType }) => (
-                <ProviderCard
-                  key={providerId}
-                  providerId={providerId}
-                  provider={provider}
-                  stats={stats}
-                  authType={displayAuthType}
-                  onToggle={(active) => handleToggleProvider(providerId, toggleAuthType, active)}
-                />
-              )
-            )}
-          </div>
-        </div>
-      )}
-
-      {/* Audio Only Providers */}
-      {showSection("audio") && audioProviderEntries.length > 0 && (
-        <div className="flex flex-col gap-4">
-          <div className="flex flex-wrap items-center gap-2">
-            <h2 className="text-xl font-semibold flex items-center gap-2 flex-1 min-w-0">
-              {t("audioProvidersHeading")}{" "}
-              <span
-                className="size-2.5 rounded-full bg-rose-500"
-                title={t("audioProvidersHeading")}
-              />
-              <ProviderCountBadge {...countConfigured(audioProviderEntriesAll)} />
-            </h2>
-            <button
-              onClick={() => handleBatchTest("audio")}
-              disabled={!!testingMode}
-              className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border transition-colors ${
-                testingMode === "audio"
-                  ? "bg-primary/20 border-primary/40 text-primary animate-pulse"
-                  : "bg-bg-subtle border-border text-text-muted hover:text-text-primary hover:border-primary/40"
-              }`}
-              title={t("testAll")}
-            >
-              <span className="material-symbols-outlined text-[14px]">
-                {testingMode === "audio" ? "sync" : "play_arrow"}
-              </span>
-              {testingMode === "audio" ? t("testing") : t("testAll")}
-            </button>
-          </div>
-          <p className="text-sm text-text-muted -mt-2">{t("audioProvidersDesc")}</p>
-          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 gap-3">
-            {audioProviderEntries.map(({ providerId, provider, stats, toggleAuthType }) => (
-              <ProviderCard
-                key={providerId}
-                providerId={providerId}
-                provider={provider}
-                stats={stats}
-                authType="audio"
-                onToggle={(active) => handleToggleProvider(providerId, toggleAuthType, active)}
-              />
-            ))}
-          </div>
-        </div>
-      )}
-
-      {/* Video Generation */}
-      {showSection("apikey") && videoProviderEntries.length > 0 && (
-        <div className="flex flex-col gap-4">
-          <div className="flex flex-wrap items-center gap-2">
-            <h2 className="text-xl font-semibold flex items-center gap-2 flex-1 min-w-0">
-              {t("videoProviders")}{" "}
-              <span className="size-2.5 rounded-full bg-amber-500" title={t("videoProviders")} />
-              <ProviderCountBadge {...countConfigured(videoProviderEntriesAll)} />
-            </h2>
-          </div>
-          <p className="text-sm text-text-muted -mt-2">{t("videoProvidersDesc")}</p>
-          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 gap-3">
-            {videoProviderEntries.map(
-              ({ providerId, provider, stats, displayAuthType, toggleAuthType }) => (
-                <ProviderCard
-                  key={providerId}
-                  providerId={providerId}
-                  provider={provider}
-                  stats={stats}
-                  authType={displayAuthType}
-                  onToggle={(active) => handleToggleProvider(providerId, toggleAuthType, active)}
-                />
-              )
-            )}
-          </div>
-        </div>
+          {/* Video Generation */}
+          {showSection("apikey") && videoProviderEntries.length > 0 && (
+            <div className="flex flex-col gap-4">
+              <div className="flex flex-wrap items-center gap-2">
+                <h2 className="text-xl font-semibold flex items-center gap-2 flex-1 min-w-0">
+                  {t("videoProviders")}{" "}
+                  <span
+                    className="size-2.5 rounded-full bg-amber-500"
+                    title={t("videoProviders")}
+                  />
+                  <ProviderCountBadge {...countConfigured(videoProviderEntriesAll)} />
+                </h2>
+              </div>
+              <p className="text-sm text-text-muted -mt-2">{t("videoProvidersDesc")}</p>
+              <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 gap-3">
+                {videoProviderEntries.map(
+                  ({ providerId, provider, stats, displayAuthType, toggleAuthType }) => (
+                    <ProviderCard
+                      key={providerId}
+                      providerId={providerId}
+                      provider={provider}
+                      stats={stats}
+                      authType={displayAuthType}
+                      onToggle={(active) =>
+                        handleToggleProvider(providerId, toggleAuthType, active)
+                      }
+                    />
+                  )
+                )}
+              </div>
+            </div>
+          )}
+        </>
       )}
 
       <AddCompatibleProviderModal

--- a/src/app/(dashboard)/dashboard/providers/providerCompactMode.ts
+++ b/src/app/(dashboard)/dashboard/providers/providerCompactMode.ts
@@ -1,0 +1,131 @@
+import { IDE_PROVIDER_IDS } from "@/shared/constants/providers";
+import {
+  buildCompactProviderEntries,
+  resolveDashboardProviderInfo,
+  type ProviderEntry,
+} from "./providerPageUtils";
+
+type ProviderCategoryEntries<TProvider> = ProviderEntry<TProvider>[];
+
+export interface CompactProviderEntryOptions<TProvider> {
+  activeCategory: string;
+  showFreeOnly: boolean;
+  freeSectionEntries: ProviderCategoryEntries<TProvider>;
+  compatibleProviderEntries: ProviderCategoryEntries<TProvider>;
+  oauthProviderEntries: ProviderCategoryEntries<TProvider>;
+  ideProviderEntries: ProviderCategoryEntries<TProvider>;
+  noAuthEntries: ProviderCategoryEntries<TProvider>;
+  upstreamProxyEntries: ProviderCategoryEntries<TProvider>;
+  llmProviderEntries: ProviderCategoryEntries<TProvider>;
+  aggregatorProviderEntries: ProviderCategoryEntries<TProvider>;
+  enterpriseProviderEntries: ProviderCategoryEntries<TProvider>;
+  embeddingRerankProviderEntries: ProviderCategoryEntries<TProvider>;
+  imageProviderEntries: ProviderCategoryEntries<TProvider>;
+  videoProviderEntries: ProviderCategoryEntries<TProvider>;
+  webCookieProviderEntries: ProviderCategoryEntries<TProvider>;
+  searchProviderEntries: ProviderCategoryEntries<TProvider>;
+  webFetchEntries: ProviderCategoryEntries<TProvider>;
+  audioProviderEntries: ProviderCategoryEntries<TProvider>;
+  localProviderEntries: ProviderCategoryEntries<TProvider>;
+  cloudAgentProviderEntries: ProviderCategoryEntries<TProvider>;
+}
+
+function getCompactProviderEntryGroups<TProvider>({
+  activeCategory,
+  showFreeOnly,
+  freeSectionEntries,
+  compatibleProviderEntries,
+  oauthProviderEntries,
+  ideProviderEntries,
+  noAuthEntries,
+  upstreamProxyEntries,
+  llmProviderEntries,
+  aggregatorProviderEntries,
+  enterpriseProviderEntries,
+  embeddingRerankProviderEntries,
+  imageProviderEntries,
+  videoProviderEntries,
+  webCookieProviderEntries,
+  searchProviderEntries,
+  webFetchEntries,
+  audioProviderEntries,
+  localProviderEntries,
+  cloudAgentProviderEntries,
+}: CompactProviderEntryOptions<TProvider>): ProviderEntry<TProvider>[][] {
+  const oauthEntries = oauthProviderEntries.filter(
+    (entry) => !IDE_PROVIDER_IDS.has(entry.providerId)
+  );
+  const apiKeyEntries = [
+    llmProviderEntries,
+    aggregatorProviderEntries,
+    enterpriseProviderEntries,
+    embeddingRerankProviderEntries,
+    imageProviderEntries,
+    videoProviderEntries,
+  ];
+
+  if (showFreeOnly) return [freeSectionEntries];
+
+  if (activeCategory === "compatible") return [compatibleProviderEntries];
+  if (activeCategory === "oauth") return [oauthEntries];
+  if (activeCategory === "ide") return [ideProviderEntries];
+  if (activeCategory === "no-auth") return [noAuthEntries];
+  if (activeCategory === "upstream-proxy") return [upstreamProxyEntries];
+  if (activeCategory === "apikey") return apiKeyEntries;
+  if (activeCategory === "webcookie") return [webCookieProviderEntries];
+  if (activeCategory === "search") return [searchProviderEntries];
+  if (activeCategory === "webfetch") return [webFetchEntries];
+  if (activeCategory === "audio") return [audioProviderEntries];
+  if (activeCategory === "local") return [localProviderEntries];
+  if (activeCategory === "cloudagent") return [cloudAgentProviderEntries];
+
+  return [
+    compatibleProviderEntries,
+    oauthEntries,
+    ideProviderEntries,
+    webCookieProviderEntries,
+    llmProviderEntries,
+    upstreamProxyEntries,
+    aggregatorProviderEntries,
+    enterpriseProviderEntries,
+    cloudAgentProviderEntries,
+    localProviderEntries,
+    searchProviderEntries,
+    embeddingRerankProviderEntries,
+    imageProviderEntries,
+    audioProviderEntries,
+    videoProviderEntries,
+    noAuthEntries,
+  ];
+}
+
+export function buildCompactProviderEntriesForPage<TProvider>(
+  options: CompactProviderEntryOptions<TProvider>
+): ProviderEntry<TProvider>[] {
+  return buildCompactProviderEntries(getCompactProviderEntryGroups(options), {
+    deferNoAuth: options.activeCategory !== "no-auth",
+  });
+}
+
+const CATEGORY_AUTH_TYPES: Record<string, string> = {
+  "cloud-agent": "cloud-agent",
+  "no-auth": "no-auth",
+  "upstream-proxy": "upstream-proxy",
+  "web-cookie": "web-cookie",
+  audio: "audio",
+  local: "local",
+  search: "search",
+};
+
+export function getCompactProviderAuthType<TProvider>(
+  entry: ProviderEntry<TProvider>,
+  showFreeOnly: boolean
+): string {
+  if (showFreeOnly && entry.toggleAuthType === "free") return "free";
+  if (entry.displayAuthType === "compatible") return "compatible";
+
+  const info = resolveDashboardProviderInfo(entry.providerId);
+  if (!info) return entry.displayAuthType;
+
+  return CATEGORY_AUTH_TYPES[info.category] ?? entry.displayAuthType;
+}

--- a/src/app/(dashboard)/dashboard/providers/providerPageStorage.ts
+++ b/src/app/(dashboard)/dashboard/providers/providerPageStorage.ts
@@ -1,4 +1,7 @@
 export const SHOW_CONFIGURED_ONLY_STORAGE_KEY = "omniroute-providers-show-configured-only";
+export const PROVIDER_DISPLAY_MODE_STORAGE_KEY = "omniroute-providers-display-mode";
+
+export type ProviderDisplayMode = "all" | "configured" | "compact";
 
 interface StorageReader {
   getItem(key: string): string | null;
@@ -9,8 +12,18 @@ interface StorageWriter extends StorageReader {
   removeItem(key: string): void;
 }
 
+type StorageReaderWriter = StorageReader & Partial<StorageWriter>;
+
 export function parseConfiguredOnlyPreference(value: string | null | undefined): boolean {
   return value === "true";
+}
+
+export function parseProviderDisplayModePreference(
+  value: string | null | undefined
+): ProviderDisplayMode | null {
+  if (value === "all" || value === "configured" || value === "compact") return value;
+
+  return null;
 }
 
 function getBrowserStorage(): StorageWriter | null {
@@ -39,4 +52,37 @@ export function writeConfiguredOnlyPreference(
   }
 
   storage.removeItem(SHOW_CONFIGURED_ONLY_STORAGE_KEY);
+}
+
+export function readProviderDisplayModePreference(
+  storage: StorageReaderWriter | null = getBrowserStorage()
+): ProviderDisplayMode {
+  if (!storage) return "all";
+
+  const storedMode = parseProviderDisplayModePreference(
+    storage.getItem(PROVIDER_DISPLAY_MODE_STORAGE_KEY)
+  );
+  if (storedMode) return storedMode;
+
+  if (!readConfiguredOnlyPreference(storage)) return "all";
+
+  storage.setItem?.(PROVIDER_DISPLAY_MODE_STORAGE_KEY, "configured");
+  storage.removeItem?.(SHOW_CONFIGURED_ONLY_STORAGE_KEY);
+  return "configured";
+}
+
+export function writeProviderDisplayModePreference(
+  mode: ProviderDisplayMode,
+  storage: StorageWriter | null = getBrowserStorage()
+) {
+  if (!storage) return;
+
+  storage.removeItem(SHOW_CONFIGURED_ONLY_STORAGE_KEY);
+
+  if (mode === "all") {
+    storage.removeItem(PROVIDER_DISPLAY_MODE_STORAGE_KEY);
+    return;
+  }
+
+  storage.setItem(PROVIDER_DISPLAY_MODE_STORAGE_KEY, mode);
 }

--- a/src/app/(dashboard)/dashboard/providers/providerPageUtils.ts
+++ b/src/app/(dashboard)/dashboard/providers/providerPageUtils.ts
@@ -8,6 +8,7 @@ import {
   type StaticProviderCatalogCategory,
 } from "@/lib/providers/catalog";
 import { compareTr, matchesSearch } from "@/shared/utils/turkishText";
+import type { ProviderDisplayMode } from "./providerPageStorage";
 
 export interface ProviderStatsSnapshot {
   total?: number;
@@ -27,6 +28,15 @@ export function shouldApplyConfiguredOnlyFilter(
   connectionCount: number
 ): boolean {
   return showConfiguredOnly && connectionCount > 0;
+}
+
+export function shouldFilterProviderEntriesForDisplayMode(
+  displayMode: ProviderDisplayMode,
+  connectionCount: number
+): boolean {
+  if (displayMode === "compact") return true;
+
+  return shouldApplyConfiguredOnlyFilter(displayMode === "configured", connectionCount);
 }
 
 export function shouldShowFirstProviderHint(
@@ -133,6 +143,44 @@ export function filterConfiguredProviderEntries<TProvider>(
   }
 
   return sortProviderEntriesByName(filtered);
+}
+
+function pushUniqueProviderEntry<TProvider>(
+  entries: ProviderEntry<TProvider>[],
+  seenProviderIds: Set<string>,
+  entry: ProviderEntry<TProvider>
+) {
+  if (seenProviderIds.has(entry.providerId)) return;
+
+  seenProviderIds.add(entry.providerId);
+  entries.push(entry);
+}
+
+export function buildCompactProviderEntries<TProvider>(
+  groups: ProviderEntry<TProvider>[][],
+  options: { deferNoAuth?: boolean } = {}
+): ProviderEntry<TProvider>[] {
+  const seenProviderIds = new Set<string>();
+  const visibleEntries: ProviderEntry<TProvider>[] = [];
+  const deferredNoAuthEntries: ProviderEntry<TProvider>[] = [];
+  const seenDeferredNoAuthProviderIds = new Set<string>();
+
+  for (const group of groups) {
+    for (const entry of group) {
+      if (options.deferNoAuth && entry.displayAuthType === "no-auth") {
+        pushUniqueProviderEntry(deferredNoAuthEntries, seenDeferredNoAuthProviderIds, entry);
+        continue;
+      }
+
+      pushUniqueProviderEntry(visibleEntries, seenProviderIds, entry);
+    }
+  }
+
+  for (const entry of deferredNoAuthEntries) {
+    pushUniqueProviderEntry(visibleEntries, seenProviderIds, entry);
+  }
+
+  return visibleEntries;
 }
 
 export function resolveDashboardProviderInfo(

--- a/tests/unit/providers-page-utils.test.ts
+++ b/tests/unit/providers-page-utils.test.ts
@@ -114,6 +114,74 @@ test("configured-only filter keeps no-auth providers even without a saved connec
   );
 });
 
+test("compact provider entries dedupe providers and move no-auth entries to the end", () => {
+  const openRouterFromFree = {
+    providerId: "openrouter",
+    provider: { id: "openrouter", name: "OpenRouter" },
+    stats: { total: 1 },
+    displayAuthType: "apikey",
+    toggleAuthType: "apikey",
+  };
+  const openRouterFromAggregator = {
+    providerId: "openrouter",
+    provider: { id: "openrouter", name: "OpenRouter" },
+    stats: { total: 1 },
+    displayAuthType: "apikey",
+    toggleAuthType: "apikey",
+  };
+  const claude = {
+    providerId: "claude",
+    provider: { id: "claude", name: "Claude" },
+    stats: { total: 1 },
+    displayAuthType: "oauth",
+    toggleAuthType: "oauth",
+  };
+  const opencode = {
+    providerId: "opencode",
+    provider: { id: "opencode", name: "OpenCode" },
+    stats: { total: 0 },
+    displayAuthType: "no-auth",
+    toggleAuthType: "no-auth",
+  };
+
+  const visible = providerPageUtils.buildCompactProviderEntries(
+    [[opencode, openRouterFromFree], [claude, openRouterFromAggregator], [opencode]],
+    { deferNoAuth: true }
+  );
+
+  assert.deepEqual(
+    visible.map((entry) => entry.providerId),
+    ["openrouter", "claude", "opencode"]
+  );
+  assert.equal(visible.filter((entry) => entry.providerId === "openrouter").length, 1);
+});
+
+test("compact provider entries prefer non-no-auth duplicates over deferred no-auth entries", () => {
+  const noAuthEntry = {
+    providerId: "opencode",
+    provider: { id: "opencode", name: "OpenCode" },
+    stats: { total: 0 },
+    displayAuthType: "no-auth",
+    toggleAuthType: "no-auth",
+  };
+  const configuredEntry = {
+    providerId: "opencode",
+    provider: { id: "opencode", name: "OpenCode" },
+    stats: { total: 1 },
+    displayAuthType: "apikey",
+    toggleAuthType: "apikey",
+  };
+
+  const visible = providerPageUtils.buildCompactProviderEntries(
+    [[noAuthEntry], [configuredEntry]],
+    { deferNoAuth: true }
+  );
+
+  assert.equal(visible.length, 1);
+  assert.equal(visible[0].providerId, "opencode");
+  assert.equal(visible[0].displayAuthType, "apikey");
+});
+
 test("search filter matches provider name and id case-insensitively", () => {
   const entries = [
     {
@@ -227,10 +295,27 @@ test("configured-only preference parser only enables explicit true values", () =
   assert.equal(providerPageStorage.parseConfiguredOnlyPreference(undefined), false);
 });
 
+test("provider display mode preference parser accepts only known modes", () => {
+  assert.equal(providerPageStorage.parseProviderDisplayModePreference("all"), "all");
+  assert.equal(providerPageStorage.parseProviderDisplayModePreference("configured"), "configured");
+  assert.equal(providerPageStorage.parseProviderDisplayModePreference("compact"), "compact");
+  assert.equal(providerPageStorage.parseProviderDisplayModePreference("true"), null);
+  assert.equal(providerPageStorage.parseProviderDisplayModePreference(null), null);
+});
+
 test("configured-only filter is ignored before the first provider is connected", () => {
   assert.equal(providerPageUtils.shouldApplyConfiguredOnlyFilter(true, 0), false);
   assert.equal(providerPageUtils.shouldApplyConfiguredOnlyFilter(false, 0), false);
   assert.equal(providerPageUtils.shouldApplyConfiguredOnlyFilter(true, 1), true);
+});
+
+test("compact display mode always uses the configured provider set", () => {
+  assert.equal(providerPageUtils.shouldFilterProviderEntriesForDisplayMode("all", 0), false);
+  assert.equal(providerPageUtils.shouldFilterProviderEntriesForDisplayMode("all", 2), false);
+  assert.equal(providerPageUtils.shouldFilterProviderEntriesForDisplayMode("configured", 0), false);
+  assert.equal(providerPageUtils.shouldFilterProviderEntriesForDisplayMode("configured", 2), true);
+  assert.equal(providerPageUtils.shouldFilterProviderEntriesForDisplayMode("compact", 0), true);
+  assert.equal(providerPageUtils.shouldFilterProviderEntriesForDisplayMode("compact", 2), true);
 });
 
 test("first-provider hint is shown only when no providers are connected and search is empty", () => {
@@ -263,6 +348,37 @@ test("configured-only preference storage round-trips correctly", () => {
   providerPageStorage.writeConfiguredOnlyPreference(false, mockStorage);
   assert.equal(storage.has(providerPageStorage.SHOW_CONFIGURED_ONLY_STORAGE_KEY), false);
   assert.equal(providerPageStorage.readConfiguredOnlyPreference(mockStorage), false);
+});
+
+test("provider display mode storage round-trips and migrates the old configured-only key", () => {
+  const storage = new Map();
+  const mockStorage = {
+    getItem(key) {
+      return storage.has(key) ? storage.get(key) : null;
+    },
+    setItem(key, value) {
+      storage.set(key, value);
+    },
+    removeItem(key) {
+      storage.delete(key);
+    },
+  };
+
+  assert.equal(providerPageStorage.readProviderDisplayModePreference(mockStorage), "all");
+
+  storage.set(providerPageStorage.SHOW_CONFIGURED_ONLY_STORAGE_KEY, "true");
+  assert.equal(providerPageStorage.readProviderDisplayModePreference(mockStorage), "configured");
+  assert.equal(storage.get(providerPageStorage.PROVIDER_DISPLAY_MODE_STORAGE_KEY), "configured");
+  assert.equal(storage.has(providerPageStorage.SHOW_CONFIGURED_ONLY_STORAGE_KEY), false);
+
+  providerPageStorage.writeProviderDisplayModePreference("compact", mockStorage);
+  assert.equal(storage.get(providerPageStorage.PROVIDER_DISPLAY_MODE_STORAGE_KEY), "compact");
+  assert.equal(storage.has(providerPageStorage.SHOW_CONFIGURED_ONLY_STORAGE_KEY), false);
+  assert.equal(providerPageStorage.readProviderDisplayModePreference(mockStorage), "compact");
+
+  providerPageStorage.writeProviderDisplayModePreference("all", mockStorage);
+  assert.equal(storage.has(providerPageStorage.PROVIDER_DISPLAY_MODE_STORAGE_KEY), false);
+  assert.equal(providerPageStorage.readProviderDisplayModePreference(mockStorage), "all");
 });
 
 test("static catalog entries resolve local, search, audio, web-cookie and upstream providers", () => {


### PR DESCRIPTION
## Summary
- Replace the Providers page configured-only toggle with All, Configured, and Compact display modes.
- Keep Compact mode aligned with Configured content while rendering providers once in a flat ungrouped grid with no-auth providers last.
- Persist the new display mode preference and migrate the legacy configured-only localStorage key.
- Cover compact dedupe, display-mode filtering, and preference storage behavior in unit tests.

## Verification
- node --import tsx/esm --test tests/unit/providers-page-utils.test.ts
- npx vitest run src/app/(dashboard)/dashboard/providers/[id]/__tests__/phase1f.test.tsx
- npm run typecheck:core
- npm run lint
- npm run build
- Local seeded-provider browser checks for All, Configured, and Compact modes