### PR TITLE
fix: keep chat completions streams warm

### DIFF
--- a/src/app/api/v1/chat/completions/earlyKeepalive.ts
+++ b/src/app/api/v1/chat/completions/earlyKeepalive.ts
@@ -1,0 +1,35 @@
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function acceptsEventStream(acceptHeader: string | null | undefined): boolean {
+  return String(acceptHeader || "")
+    .split(",")
+    .some((entry) => {
+      const [mediaType, ...params] = entry
+        .split(";")
+        .map((part) => part.trim().toLowerCase());
+      if (mediaType !== "text/event-stream") return false;
+
+      const qParam = params.find((param) => param.startsWith("q="));
+      if (!qParam) return true;
+
+      const q = Number(qParam.slice(2).trim());
+      return Number.isFinite(q) && q > 0;
+    });
+}
+
+export function shouldUseEarlyKeepaliveForChatCompletions(
+  body: unknown,
+  acceptHeader: string | null | undefined
+): boolean {
+  if (!isRecord(body)) return false;
+  if (body.stream === true) return true;
+
+  return acceptsEventStream(acceptHeader) && body.stream === undefined;
+}
+
+export function getChatCompletionsEarlyKeepaliveModel(body: unknown): string | undefined {
+  if (!isRecord(body)) return undefined;
+  return typeof body.model === "string" ? body.model : undefined;
+}

--- a/src/app/api/v1/chat/completions/route.ts
+++ b/src/app/api/v1/chat/completions/route.ts
@@ -3,6 +3,12 @@ import { callCloudWithMachineId } from "@/shared/utils/cloud";
 import { handleChat } from "@/sse/handlers/chat";
 import { initTranslators } from "@omniroute/open-sse/translator/index.ts";
 import { createInjectionGuard } from "@/middleware/promptInjectionGuard";
+import { withEarlyStreamKeepalive } from "@omniroute/open-sse/utils/earlyStreamKeepalive";
+import { resolveKeepaliveThreshold } from "@omniroute/open-sse/utils/keepaliveThreshold";
+import {
+  getChatCompletionsEarlyKeepaliveModel,
+  shouldUseEarlyKeepaliveForChatCompletions,
+} from "./earlyKeepalive";
 
 let initPromise = null;
 
@@ -42,12 +48,14 @@ export async function POST(request) {
     }
   }
 
+  let parsedBody: unknown = null;
+
   // Prompt injection guard — inspect body before forwarding
   try {
     const cloned = request.clone();
-    const body = await cloned.json().catch(() => null);
-    if (body) {
-      const { blocked, result } = injectionGuard(body);
+    parsedBody = await cloned.json().catch(() => null);
+    if (parsedBody) {
+      const { blocked, result } = injectionGuard(parsedBody);
       if (blocked) {
         return new Response(
           JSON.stringify({
@@ -64,6 +72,18 @@ export async function POST(request) {
     }
   } catch (error) {
     console.error("[SECURITY] Prompt injection guard failed:", error);
+  }
+
+  if (
+    shouldUseEarlyKeepaliveForChatCompletions(parsedBody, request.headers.get("accept"))
+  ) {
+    const thresholdMs = resolveKeepaliveThreshold(
+      getChatCompletionsEarlyKeepaliveModel(parsedBody)
+    );
+    return await withEarlyStreamKeepalive(handleChat(request), {
+      signal: request.signal,
+      thresholdMs,
+    });
   }
 
   return await handleChat(request);

--- a/tests/unit/chat-completions-early-keepalive.test.ts
+++ b/tests/unit/chat-completions-early-keepalive.test.ts
@@ -1,0 +1,65 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  getChatCompletionsEarlyKeepaliveModel,
+  shouldUseEarlyKeepaliveForChatCompletions,
+} from "../../src/app/api/v1/chat/completions/earlyKeepalive.ts";
+
+test("chat completions early keepalive applies to explicit streaming requests", () => {
+  assert.equal(
+    shouldUseEarlyKeepaliveForChatCompletions({ stream: true }, "application/json"),
+    true
+  );
+});
+
+test("chat completions early keepalive follows Accept negotiation when stream is omitted", () => {
+  assert.equal(
+    shouldUseEarlyKeepaliveForChatCompletions(
+      { model: "openai/gpt-4.1" },
+      "application/json, text/event-stream"
+    ),
+    true
+  );
+});
+
+test("chat completions early keepalive respects Accept q values", () => {
+  assert.equal(
+    shouldUseEarlyKeepaliveForChatCompletions(
+      { model: "openai/gpt-4.1" },
+      "application/json, text/event-stream;q=0"
+    ),
+    false
+  );
+  assert.equal(
+    shouldUseEarlyKeepaliveForChatCompletions(
+      { model: "openai/gpt-4.1" },
+      "application/json, TEXT/EVENT-STREAM ; Q=0.25"
+    ),
+    true
+  );
+});
+
+test("chat completions early keepalive respects explicit stream=false", () => {
+  assert.equal(
+    shouldUseEarlyKeepaliveForChatCompletions(
+      { stream: false },
+      "application/json, text/event-stream"
+    ),
+    false
+  );
+});
+
+test("chat completions early keepalive stays off for non-streaming requests", () => {
+  assert.equal(
+    shouldUseEarlyKeepaliveForChatCompletions({ model: "openai/gpt-4.1" }, "application/json"),
+    false
+  );
+  assert.equal(shouldUseEarlyKeepaliveForChatCompletions(null, "text/event-stream"), false);
+});
+
+test("chat completions early keepalive extracts string models only", () => {
+  assert.equal(getChatCompletionsEarlyKeepaliveModel({ model: "claude-web/opus" }), "claude-web/opus");
+  assert.equal(getChatCompletionsEarlyKeepaliveModel({ model: 123 }), undefined);
+  assert.equal(getChatCompletionsEarlyKeepaliveModel(null), undefined);
+});


### PR DESCRIPTION
## Summary
- enable early SSE keepalives for streaming /v1/chat/completions requests
- mitigate long-running chat-completions streams ending as client-closed / 499-style / ResponseAborted disconnects when the upstream is still working
- mirror existing Accept: text/event-stream negotiation while respecting explicit stream=false and q=0
- add focused unit coverage for the chat-completions keepalive decision

## Tests
- node --import tsx --import ./open-sse/utils/setupPolyfill.ts --test /Users/roger/GitHub/OmniRoute-pr-chat-keepalive/tests/unit/chat-completions-early-keepalive.test.ts /Users/roger/GitHub/OmniRoute-pr-chat-keepalive/tests/unit/early-stream-keepalive.test.ts