### PR TITLE
fix(cursor): add ModelDetails envelope so pinned thinking models resolve (#3714)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Fixed
 
+- fix(cursor): send a `ModelDetails` envelope (`model_id` + `display_model_id` + `display_name`) in the Cursor agent request, alongside the existing `RequestedModel`. Pinned Cursor Claude/GPT *thinking* variants (e.g. `cursor/claude-opus-4-7-thinking-xhigh`) were returning an empty turn → `502 Provider returned empty content`, because Cursor needs the `ModelDetails` envelope (which `cursor-agent`'s real wire format sends) to resolve them; `RequestedModel` alone only resolves server-routed ids (`auto`/`composer-*`). The `-fast` parameter path on `RequestedModel` is preserved. ([#3714](https://github.com/diegosouzapw/OmniRoute/issues/3714))
+
 - fix(docs): correct the OAuth redirect URI in the Fly.io deployment guide. It told users to register `<NEXT_PUBLIC_BASE_URL>/api/oauth/<provider>/callback`, but OmniRoute's browser OAuth flow uses a single `<NEXT_PUBLIC_BASE_URL>/callback` handler (there is no per-provider callback route). The mismatch caused GitLab Duo (and any OAuth provider) to reject the flow with "The redirect URI included is not valid". Added a regression guard test. ([#3732](https://github.com/diegosouzapw/OmniRoute/issues/3732))
 
 - fix(providers): give Ollama Cloud's `kimi-k2.7-code` its real capabilities (262K context, 262K max output, vision + thinking + tools) instead of the degraded `128000 / 8192` defaults. The model had no spec/registry entry, so importing it via "Import from /models" (whose `/v1/models` upstream returns no per-model metadata) left it as a bare custom model with fallback capabilities. Added a global `kimi-k2.7-code` model spec (parity with `kimi-k2.6`) plus a registry entry on `ollama-cloud`. ([#3761](https://github.com/diegosouzapw/OmniRoute/issues/3761) — thanks @SultanKs4)

--- a/open-sse/utils/cursorAgentProtobuf.ts
+++ b/open-sse/utils/cursorAgentProtobuf.ts
@@ -25,6 +25,7 @@ const ACM_RUN_REQUEST = 1; // AgentClientMessage.run_request
 
 const ARR_CONVERSATION_STATE = 1; // AgentRunRequest.conversation_state
 const ARR_ACTION = 2; // AgentRunRequest.action
+const ARR_MODEL_DETAILS = 3; // AgentRunRequest.model_details (ModelDetails, msg 88)
 const ARR_CONVERSATION_ID = 5; // AgentRunRequest.conversation_id
 const ARR_MCP_TOOLS = 4; // AgentRunRequest.mcp_tools (empty placeholder required)
 const ARR_REQUESTED_MODEL = 9; // AgentRunRequest.requested_model
@@ -64,6 +65,15 @@ const DIM_HEIGHT = 2; // SelectedImage.Dimension.height (int32)
 
 const RM_MODEL_ID = 1; // RequestedModel.model_id
 const RM_PARAMETERS = 3; // RequestedModel.parameters [repeated]
+
+// ModelDetails (msg 88) — the model envelope cursor-agent actually uses to resolve
+// pinned model variants. Field numbers pinned from the cursor-agent descriptor (and
+// CLIProxyAPIPlus's cursor proto). #3714: pinned Claude/GPT *thinking* variants returned
+// an empty turn when sent only via RequestedModel (field 9) with a bare model_id; the
+// working reference sends them as ModelDetails with all three string fields set.
+const MD_MODEL_ID = 1; // ModelDetails.model_id
+const MD_DISPLAY_MODEL_ID = 3; // ModelDetails.display_model_id
+const MD_DISPLAY_NAME = 4; // ModelDetails.display_name
 
 const RMP_ID = 1; // RequestedModel.ModelParameter.id
 const RMP_VALUE = 2; // RequestedModel.ModelParameter.value
@@ -581,6 +591,17 @@ export function encodeAgentRunRequest(input: AgentRunInput): Buffer {
   }
   const requestedModel = encodeMessage(ARR_REQUESTED_MODEL, rmParts);
 
+  // ModelDetails { model_id, display_model_id, display_name } — all set to the resolved
+  // model id. #3714: RequestedModel (field 9) alone resolves server-routed ids
+  // (auto → default, composer-*) but pinned Claude/GPT *thinking* variants returned an
+  // empty turn without this envelope. cursor-agent's working wire format sends both, so
+  // we keep RequestedModel (preserves the -fast `parameters` it carries) and add this.
+  const modelDetails = encodeMessage(ARR_MODEL_DETAILS, [
+    encodeString(MD_MODEL_ID, modelId),
+    encodeString(MD_DISPLAY_MODEL_ID, modelId),
+    encodeString(MD_DISPLAY_NAME, modelId),
+  ]);
+
   // mcp_tools: McpTools envelope at field 4 of AgentRunRequest. Each tool
   // is packed inside the envelope at field 1 (repeated McpToolDefinition).
   // Empty placeholder for non-tool calls (the field is observably required
@@ -596,6 +617,7 @@ export function encodeAgentRunRequest(input: AgentRunInput): Buffer {
   const agentRunRequest = [
     conversationState,
     action,
+    modelDetails,
     mcpToolsBlock,
     encodeString(ARR_CONVERSATION_ID, conversationId),
     requestedModel,

--- a/tests/unit/cursor-agent-protobuf.test.ts
+++ b/tests/unit/cursor-agent-protobuf.test.ts
@@ -144,6 +144,39 @@ test("encodeAgentRunRequest emits composer parameters", () => {
   assert.ok(text.includes("true"), "parameter value 'true' present");
 });
 
+test("encodeAgentRunRequest sends ModelDetails for pinned thinking models (#3714)", () => {
+  // #3714: pinned Claude/GPT thinking variants returned an empty turn when sent only via
+  // RequestedModel (field 9, bare model_id). cursor-agent's working wire format also
+  // carries a ModelDetails envelope with model_id + display_model_id + display_name.
+  const modelId = "claude-opus-4-7-thinking-xhigh";
+  const buf = encodeAgentRunRequest({ modelId, userText: "hi" });
+  const occurrences = buf.toString("latin1").split(modelId).length - 1;
+  // RequestedModel.model_id (1) + ModelDetails {model_id, display_model_id, display_name}
+  // (3) → the id must now appear at least 4 times (it appeared once before the fix).
+  assert.ok(
+    occurrences >= 4,
+    `pinned model id must be encoded in both RequestedModel and ModelDetails (got ${occurrences})`
+  );
+});
+
+test("encodeAgentRunRequest keeps RequestedModel + parameters alongside ModelDetails (#3714)", () => {
+  // The ModelDetails addition is additive: server-routed ids and the -fast parameter
+  // path (carried only by RequestedModel) must be unaffected.
+  const composer = encodeAgentRunRequest({ modelId: "composer-2-fast", userText: "hi" });
+  const composerText = composer.toString("latin1");
+  assert.ok(composerText.includes("composer-2"), "split model id still present");
+  assert.ok(composerText.includes("fast"), "'-fast' parameter id still present (RequestedModel)");
+  assert.ok(composerText.includes("true"), "'-fast' parameter value still present (RequestedModel)");
+
+  // auto → default, now appearing in both RequestedModel and ModelDetails.
+  const auto = encodeAgentRunRequest({ modelId: "auto", userText: "hi" });
+  const autoOccurrences = auto.toString("latin1").split("default").length - 1;
+  assert.ok(
+    autoOccurrences >= 4,
+    `'default' must appear in RequestedModel + ModelDetails (got ${autoOccurrences})`
+  );
+});
+
 test("buildAgentRequestBody wraps the message in a Connect-RPC frame", () => {
   const buf = buildAgentRequestBody({ modelId: "claude-4.6-sonnet-medium", userText: "hi" });
   // First byte is flags (0x00 = uncompressed); next 4 bytes are big-endian length.


### PR DESCRIPTION
Closes #3714

## Problem
Pinned Cursor Claude/GPT **thinking** variants (e.g. `cursor/claude-opus-4-7-thinking-xhigh`) return an empty turn → `502 Provider returned empty content` (or a synthetic empty reply with `out=0` on the Anthropic path). `composer`/`auto` work fine.

**Root cause:** OmniRoute encoded the model only as `RequestedModel` (AgentRunRequest field 9) with a bare `model_id`. `cursor-agent`'s real wire format (and the CLIProxyAPIPlus reference) also sends a `ModelDetails` envelope (field 3) with `model_id` + `display_model_id` + `display_name` all set. Server-routed ids (`auto`→`default`, `composer-*`) resolve from the partial signal, but pinned thinking variants need the full `ModelDetails` envelope — without it Cursor accepts the request and runs an empty turn.

## Fix
Additive: keep `RequestedModel` (preserves the `-fast` `parameters` it carries) and **add** `ModelDetails` (field 3) to the AgentRunRequest, matching cursor-agent's format. Field numbers pinned from the cursor-agent descriptor (`MD_ModelId=1`, `MD_DisplayModelId=3`, `MD_DisplayName=4`; `ARR_ModelDetails=3`).

## Validation
`tests/unit/cursor-agent-protobuf.test.ts` — 2 new tests (RED→GREEN verified): the pinned model id now appears ≥4× (RequestedModel + ModelDetails×3) vs 1× before; `composer-2-fast`/`auto` still encode RequestedModel + parameters. Full file 45/45 pass, typecheck:core clean, eslint 0 errors.

> ⚠️ **Shipped without a live Cursor validation** (per maintainer decision — the VPS has no Cursor connection to test against). The change matches the proven-working CLIProxyAPIPlus wire format and is additive (RequestedModel untouched, so the working `composer`/`auto`/`-fast` paths can't regress at the encoding level), but the end-to-end "thinking model now returns content" outcome should be confirmed against a real Cursor login. Reverting is a 2-line change if it misbehaves.