### PR TITLE
fix(intelligence): run pricing + models.dev sync from the live startup path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 ## [3.8.25] — TBD
 
-_Development cycle in progress — entries are added here as PRs merge._
+### 🐛 Fixed
+
+- **fix(intelligence): run pricing + models.dev sync from the live startup path** — like the Arena ELO sync (v3.8.24), the external **pricing sync** (`PRICING_SYNC_ENABLED`) and the **models.dev capability sync** (Settings → AI toggle) were only initialized from `server-init.ts`, which the Next standalone runtime never executes — and models.dev had no caller at all. Their toggles were inert in production. Both are now initialized from `instrumentation-node.ts` (self-gated, opt-in preserved, non-blocking, never fatal). (thanks @diegosouzapw)
 
 ---
 

--- a/src/instrumentation-node.ts
+++ b/src/instrumentation-node.ts
@@ -278,5 +278,27 @@ export async function registerNodejs(): Promise<void> {
         console.warn("[STARTUP] Arena ELO sync failed to start (non-fatal):", msg);
       }
     }
+
+    // Pricing sync: opt-in external pricing data (self-gated by PRICING_SYNC_ENABLED inside
+    // initPricingSync). Was only wired into the unused server-init.ts, so it never ran in the
+    // standalone runtime even when enabled. Non-blocking, never fatal.
+    try {
+      const { initPricingSync } = await import("@/lib/pricingSync");
+      await initPricingSync();
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn("[STARTUP] Pricing sync failed to start (non-fatal):", msg);
+    }
+
+    // models.dev capability sync: opt-in via Settings > AI (self-gated by
+    // settings.modelsDevSyncEnabled inside initModelsDevSync). Previously had no caller at all,
+    // so the toggle was inert. Non-blocking, never fatal.
+    try {
+      const { initModelsDevSync } = await import("@/lib/modelsDevSync");
+      await initModelsDevSync();
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn("[STARTUP] models.dev sync failed to start (non-fatal):", msg);
+    }
   }
 }

--- a/tests/integration/integration-wiring.test.ts
+++ b/tests/integration/integration-wiring.test.ts
@@ -92,6 +92,14 @@ describe("Pipeline Wiring — instrumentation-node.ts", () => {
     assert.match(src, /initArenaEloSync/);
     assert.match(src, /ARENA_ELO_SYNC_ENABLED !== "false"/);
   });
+
+  it("should initialize pricing + models.dev sync on the live startup path (self-gated, opt-in)", () => {
+    // Same dead-path bug as Arena: these were only wired into the never-executed server-init.ts
+    // (models.dev had no caller at all), so their toggles were inert. They self-gate internally
+    // (PRICING_SYNC_ENABLED / settings.modelsDevSyncEnabled), so calling them here preserves opt-in.
+    assert.match(src, /initPricingSync/);
+    assert.match(src, /initModelsDevSync/);
+  });
 });
 
 describe("Pipeline Wiring — sse chat handler", () => {


### PR DESCRIPTION
Follow-up to the v3.8.24 Arena ELO fix. `PRICING_SYNC` and the models.dev capability sync had the same dead-path bug: only initialized from `server-init.ts` (never executed by the Next standalone runtime); models.dev had no caller at all, so its Settings→AI toggle was inert. Both are now wired into `instrumentation-node.ts`. They self-gate internally (`PRICING_SYNC_ENABLED` / `settings.modelsDevSyncEnabled`), so opt-in defaults are preserved. Non-blocking, never fatal. + wiring-guard test. typecheck/docs-sync green.