### PR TITLE
fix(claude): strip reasoning-effort suffix from Claude model ids (VS Code Effort slider 404)

### DIFF
--- a/open-sse/config/providerModels.ts
+++ b/open-sse/config/providerModels.ts
@@ -74,6 +74,38 @@ export function supportsClaudeMaxEffort(modelId: string | null | undefined): boo
   );
 }
 
+// Reasoning-effort suffixes the Claude/Claude-Code model picker appends to a base
+// model id (an "Effort" slider: Low/Medium/High/Extra-High/Max). Longest/most
+// specific token first so the `-${level}` match below picks "xhigh" before "high".
+export const CLAUDE_EFFORT_SUFFIXES = ["xhigh", "max", "high", "medium", "low"] as const;
+export type ClaudeEffortSuffix = (typeof CLAUDE_EFFORT_SUFFIXES)[number];
+
+/**
+ * Split a trailing reasoning-effort suffix off a Claude model id, e.g.
+ * "claude-opus-4-8-high" -> { baseModel: "claude-opus-4-8", effort: "high" }.
+ *
+ * VS Code (and other clients) advertise claude-...-{low,medium,high,xhigh,max} via
+ * the model catalog; Anthropic has no such model id, so the suffixed string must be
+ * stripped before it is sent upstream (otherwise the relay returns HTTP 404) and
+ * surfaced as reasoning_effort so the translator / Claude-Code bridge convert it into
+ * Claude thinking/effort config. Mirrors codex's splitCodexReasoningSuffix but also
+ * covers "max" (codex's EFFORT_ORDER intentionally omits it). The `-${level}` anchor
+ * keeps "xhigh" from colliding with "high".
+ */
+export function splitClaudeEffortSuffix(model: unknown): {
+  baseModel: string;
+  effort: ClaudeEffortSuffix | null;
+} {
+  const id = typeof model === "string" ? model : "";
+  const lower = id.toLowerCase();
+  for (const level of CLAUDE_EFFORT_SUFFIXES) {
+    if (lower.endsWith(`-${level}`)) {
+      return { baseModel: id.slice(0, -(level.length + 1)), effort: level };
+    }
+  }
+  return { baseModel: id, effort: null };
+}
+
 function resolveProviderModelList(aliasOrId: string): {
   alias: string;
   models: RegistryModel[] | null;

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -29,7 +29,11 @@ import {
 } from "../services/tokenRefresh.ts";
 import { createRequestLogger } from "../utils/requestLogger.ts";
 import { applyResponsesPreviousResponseIdPolicy } from "../utils/responsesStatePolicy.ts";
-import { getModelTargetFormat, PROVIDER_ID_TO_ALIAS } from "../config/providerModels.ts";
+import {
+  getModelTargetFormat,
+  PROVIDER_ID_TO_ALIAS,
+  splitClaudeEffortSuffix,
+} from "../config/providerModels.ts";
 import { DEFAULT_THINKING_CLAUDE_SIGNATURE } from "../config/defaultThinkingSignature.ts";
 import {
   getStripTypesForProviderModel,
@@ -1953,9 +1957,44 @@ export async function handleChatCore({
   // the correct, aliased model ID. Without this, aliases only affect format detection.
   const resolvedModel = resolveModelAlias(model);
   // Use resolvedModel for all downstream operations (routing, provider requests, logging)
-  const effectiveModel = resolvedModel === model ? model : resolvedModel;
+  let effectiveModel = resolvedModel === model ? model : resolvedModel;
   if (resolvedModel !== model) {
     log?.info?.("ALIAS", `Model alias applied: ${model} → ${resolvedModel}`);
+  }
+
+  // Effort-variant model ids: the Claude / Claude-Code model picker (e.g. VS Code's
+  // "Effort" slider) advertises claude-...-{low,medium,high,xhigh,max}. Anthropic has
+  // no such model, so the suffixed id 404s upstream. Strip it back to the real base id
+  // (forwarded as the upstream model via finalModelToUpstream below) and surface the
+  // level as reasoning_effort so the OpenAI→Claude translator / Claude-Code bridge turn
+  // it into Claude thinking/effort config. An explicit client-supplied effort always
+  // wins; native Claude passthrough is left untouched (it carries its own `thinking`),
+  // and non-thinking base models are cleaned up later by normalizeThinkingForModel().
+  if (
+    (provider === "claude" || isClaudeCodeCompatibleProvider(provider)) &&
+    typeof effectiveModel === "string"
+  ) {
+    const { baseModel, effort } = splitClaudeEffortSuffix(effectiveModel);
+    if (effort) {
+      effectiveModel = baseModel;
+      if (body && typeof body === "object" && !Array.isArray(body)) {
+        const claudeBody = body as Record<string, unknown>;
+        claudeBody.model = baseModel;
+        if (sourceFormat !== FORMATS.CLAUDE) {
+          const explicitEffort =
+            claudeBody.reasoning_effort ??
+            (claudeBody.reasoning as Record<string, unknown> | undefined)?.effort ??
+            (claudeBody.output_config as Record<string, unknown> | undefined)?.effort;
+          if (explicitEffort === undefined || explicitEffort === null || explicitEffort === "") {
+            claudeBody.reasoning_effort = effort;
+          }
+        }
+      }
+      log?.info?.(
+        "PARAMS",
+        `Claude effort variant: stripped "-${effort}" → ${baseModel} (reasoning_effort=${effort})`
+      );
+    }
   }
 
   const alias = PROVIDER_ID_TO_ALIAS[provider] || provider;

--- a/tests/unit/claude-effort-suffix-strip.test.ts
+++ b/tests/unit/claude-effort-suffix-strip.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Tests for splitClaudeEffortSuffix — stripping the reasoning-effort suffix that
+ * the Claude / Claude-Code model picker (VS Code "Effort" slider) appends to a base
+ * model id (claude-...-{low,medium,high,xhigh,max}). The suffix must be stripped so
+ * the upstream Anthropic relay receives a real model id (else HTTP 404) and surfaced
+ * as reasoning_effort downstream. See chatCore.ts effort-variant normalization.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  splitClaudeEffortSuffix,
+  CLAUDE_EFFORT_SUFFIXES,
+} from "../../open-sse/config/providerModels.ts";
+
+describe("splitClaudeEffortSuffix", () => {
+  it("splits every effort level off claude-opus-4-8", () => {
+    assert.deepEqual(splitClaudeEffortSuffix("claude-opus-4-8-low"), {
+      baseModel: "claude-opus-4-8",
+      effort: "low",
+    });
+    assert.deepEqual(splitClaudeEffortSuffix("claude-opus-4-8-medium"), {
+      baseModel: "claude-opus-4-8",
+      effort: "medium",
+    });
+    assert.deepEqual(splitClaudeEffortSuffix("claude-opus-4-8-high"), {
+      baseModel: "claude-opus-4-8",
+      effort: "high",
+    });
+    assert.deepEqual(splitClaudeEffortSuffix("claude-opus-4-8-xhigh"), {
+      baseModel: "claude-opus-4-8",
+      effort: "xhigh",
+    });
+    assert.deepEqual(splitClaudeEffortSuffix("claude-opus-4-8-max"), {
+      baseModel: "claude-opus-4-8",
+      effort: "max",
+    });
+  });
+
+  it("does not confuse 'xhigh' with 'high' (no strip to '...-x')", () => {
+    const split = splitClaudeEffortSuffix("claude-opus-4-8-xhigh");
+    assert.equal(split.baseModel, "claude-opus-4-8");
+    assert.equal(split.effort, "xhigh");
+  });
+
+  it("returns null effort for a bare base id", () => {
+    assert.deepEqual(splitClaudeEffortSuffix("claude-opus-4-8"), {
+      baseModel: "claude-opus-4-8",
+      effort: null,
+    });
+    assert.deepEqual(splitClaudeEffortSuffix("claude-sonnet-4-6"), {
+      baseModel: "claude-sonnet-4-6",
+      effort: null,
+    });
+  });
+
+  it("is case-insensitive and works across model families", () => {
+    assert.deepEqual(splitClaudeEffortSuffix("claude-sonnet-4-6-HIGH"), {
+      baseModel: "claude-sonnet-4-6",
+      effort: "high",
+    });
+    assert.deepEqual(splitClaudeEffortSuffix("claude-haiku-4-5-low"), {
+      baseModel: "claude-haiku-4-5",
+      effort: "low",
+    });
+  });
+
+  it("tolerates non-string / empty input", () => {
+    assert.deepEqual(splitClaudeEffortSuffix(undefined), { baseModel: "", effort: null });
+    assert.deepEqual(splitClaudeEffortSuffix(null), { baseModel: "", effort: null });
+    assert.deepEqual(splitClaudeEffortSuffix(123), { baseModel: "", effort: null });
+    assert.deepEqual(splitClaudeEffortSuffix(""), { baseModel: "", effort: null });
+  });
+
+  it("orders 'xhigh' before 'high' in the suffix list", () => {
+    assert.ok(
+      CLAUDE_EFFORT_SUFFIXES.indexOf("xhigh") < CLAUDE_EFFORT_SUFFIXES.indexOf("high"),
+      "xhigh must be tested before high so it wins the longest-match"
+    );
+  });
+});


### PR DESCRIPTION
## Problem

The Claude / Claude-Code model picker (VS Code Copilot's "Effort" slider) advertises effort variants by appending a suffix to the base model id: `claude-opus-4-8-{low,medium,high,xhigh,max}` (likewise for sonnet/opus-4-7). Anthropic has no such model, so when one is selected the suffixed id is forwarded verbatim and the relay returns **HTTP 404** (`model: claude-opus-4-8-high`). Repeated 404s then trip the account circuit breaker, which surfaces to clients as a bogus **"rate limited" cooldown** (`all accounts rate limited, reset after Xm`). Base models (no suffix) work because their id is a real Anthropic model.

## Root cause

In `chatCore`, `finalModelToUpstream` only strips `provider/` and `alias/` prefixes — it never strips effort suffixes. Only Codex handled model-encoded effort (via its own `splitCodexReasoningSuffix`); the Claude/CC path had no equivalent, so the suffix leaked all the way to the upstream `model` field for every Claude dispatch branch (CC bridge, native passthrough, grouped/raw — all overwritten by `translatedBody.model = finalModelToUpstream`).

## Fix

1. New `splitClaudeEffortSuffix()` in `providerModels.ts` — mirrors codex's splitter but also covers `max` (codex's `EFFORT_ORDER` omits it) and orders `xhigh` before `high` (with a `-${level}` anchor) so they don't collide.
2. In `chatCore`, for `claude` / Claude-Code-compatible targets, strip the suffix off `effectiveModel` (so the upstream receives the real base id) and surface the level as `reasoning_effort` so the **existing** OpenAI→Claude translator / CC bridge convert it into Claude thinking/effort config. An explicit client-supplied effort is never overridden; native Claude passthrough is left untouched (it carries its own `thinking`); non-thinking base models are cleaned up by `normalizeThinkingForModel()`.

Composes with the extended-thinking temperature/top_p normalization from #3780.

## Verification

- New `tests/unit/claude-effort-suffix-strip.test.ts`: all five levels split correctly off the base id, `xhigh` wins over `high`, base/no-suffix returns `effort: null` (regression guard), case-insensitive, non-string tolerant. `node --test` green; `eslint` + `typecheck:core` clean. Codex effort suites unaffected.
- Validated against a live deployment built from this branch: `cc/claude-opus-4-8-{low,medium,high,xhigh,max}` all return **HTTP 200** (previously 404) and the response model is the base `claude-opus-4-8` (suffix stripped); base model unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)