### PR TITLE
Fase 7 — instalar scanners advisory no CI (gitleaks/osv/actionlint/zizmor)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,20 @@ jobs:
         run: npm run check:codeql-ratchet
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Fase 7 INT: install the advisory security scanners so the gates below
+      # actually run (they self-skip when the binaries are absent). go install
+      # uses documented module paths (no fragile version-pinned URLs); zizmor is
+      # a PyPI package. Whole job is continue-on-error, so an install hiccup never
+      # blocks the build. Exercised at the next release→main run.
+      - name: Install advisory security scanners (gitleaks/osv/actionlint/zizmor)
+        continue-on-error: true
+        run: |
+          go install github.com/rhysd/actionlint/cmd/actionlint@latest
+          go install github.com/gitleaks/gitleaks/v8@latest
+          go install github.com/google/osv-scanner/v2/cmd/osv-scanner@latest
+          echo "$HOME/go/bin" >> "$GITHUB_PATH"
+          pipx install zizmor || pip install --user zizmor
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: Secret scan (gitleaks; skips if absent)
         run: npm run check:secrets
       - name: Vulnerability ratchet (osv-scanner; skips if absent)


### PR DESCRIPTION
## Ativa os scanners de segurança advisory da Fase 7

O job `quality-extended` (advisory, `continue-on-error`) já **chama** os gates `check:secrets` (gitleaks), `check:vuln-ratchet` (osv-scanner) e `check:workflows` (actionlint+zizmor) — mas eles **auto-skipam** porque os binários não estavam instalados no runner. Este PR adiciona um step que instala os 4 via `go install @latest` (módulos documentados, sem URL com versão pinada frágil) + `pipx` (zizmor), e os põe no `GITHUB_PATH`.

- Step próprio `continue-on-error: true` → uma falha de install nunca bloqueia.
- Zero input não-confiável (só comandos estáticos `go install`/`echo`).
- **Validação:** `quality-extended` roda em `pull_request → main`, então é exercitado no próximo merge `release → main` (não neste PR→release). Os gates seguem **advisory** (não bloqueiam) até serem baselinados conscientemente.

Parte da finalização da Fase 7 (ativação de infra). Os que exigem secret (SonarQube `SONAR_TOKEN`/`SONAR_HOST_URL`, promptfoo/garak `PROMPTFOO_PROVIDER_KEY`) ficam para o owner configurar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)