### PR TITLE
fix(docs): SUPPLY_CHAIN.md MDX frontmatter — unblocks main Build

### DIFF
--- a/docs/security/SUPPLY_CHAIN.md
+++ b/docs/security/SUPPLY_CHAIN.md
@@ -1,3 +1,7 @@
+---
+title: "Supply-Chain Gates"
+---
+
 # Supply-Chain Gates (Fase 8 · Bloco A)
 
 OmniRoute publica artefatos npm + Docker. Estes gates dão proveniência,


### PR DESCRIPTION
O job **Build** E o **Publish to Docker Hub** da main quebraram pela MESMA causa: `npm run build` (Next/fumadocs-mdx) falha com `[MDX] invalid frontmatter in docs/security/SUPPLY_CHAIN.md — title: expected string, received undefined`. `docs/security/*.md` são renderizados como páginas MDX e exigem frontmatter YAML (`title:string`); o SUPPLY_CHAIN.md (#3824) foi sem. Adicionado `---\ntitle: "Supply-Chain Gates"\n---` (igual a todos os outros docs/security). **Este fix destrava Build + Docker Hub.**

⚠️ Demais falhas da main NÃO são deste fix: (1) **Lint + Docs Sync** = drift de i18n CHANGELOG (root cresceu sem re-sync — só o /generate-release sincroniza o CHANGELOG i18n, e isso gera versão); (2) **nightly-llm-security** = Bloco D advisory, calibração 1º-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)