### PR TITLE
fix(ci): grant contents:write to npm publish job for SBOM attach

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -50,7 +50,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write # gh release upload (attach SBOM to the GitHub Release)
       id-token: write # npm provenance
       packages: write # publish to npm.pkg.github.com
     steps:


### PR DESCRIPTION
Post-release hotfix for v3.8.25. The TokenPermissions hardening set the npm-publish `publish` job to `contents:read`, but its **Attach SBOM to GitHub Release** step (`gh release upload`) needs `contents:write` → it failed HTTP 403 on the v3.8.25 release.

npm 3.8.25, GH Packages, opencode-plugin, Docker and Electron all published successfully — only the SBOM attach broke. The SBOM for v3.8.25 was attached manually; this fixes the workflow for future releases.

No runtime code changed (CI-only).