### PR TITLE
fix(opencode-plugin): drop CJS bundle to fix OpenCode plugin loader

### DIFF
--- a/@omniroute/opencode-plugin/package.json
+++ b/@omniroute/opencode-plugin/package.json
@@ -3,19 +3,16 @@
   "version": "0.1.0",
   "description": "OpenCode plugin for the OmniRoute AI Gateway. Drives dynamic model discovery, /connect auth flow, and multi-instance OmniRoute providers via the official @opencode-ai/plugin contract.",
   "type": "module",
-  "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
+  "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./runtime": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
     }
   },
   "files": [

--- a/@omniroute/opencode-plugin/tsup.config.ts
+++ b/@omniroute/opencode-plugin/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: ["src/index.ts"],
-  format: ["esm", "cjs"],
+  format: ["esm"],
   dts: true,
   clean: true,
   sourcemap: false,
@@ -11,7 +11,7 @@ export default defineConfig({
   target: "node22",
   outDir: "dist",
   minify: false,
-  cjsInterop: true,
+  cjsInterop: false,
   // Bundle runtime deps so the .tgz / npm install is self-contained.
   // `zod` is required at runtime by the options schema and would otherwise
   // need a peer install when the plugin is loaded directly from a file path

--- a/tests/unit/build/opencode-plugin-esm-only.test.ts
+++ b/tests/unit/build/opencode-plugin-esm-only.test.ts
@@ -1,0 +1,65 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+// Regression guard for #3883: the @omniroute/opencode-plugin must ship an
+// ESM-only bundle. OpenCode's Bun-based plugin loader resolves the package
+// `main`/`exports` and applies CJS-to-ESM interop on a dual CJS bundle, which
+// turns `mod.default` into the whole exports namespace, fails V1 plugin
+// detection, and makes the loader throw "Plugin export is not a function".
+// Shipping ESM-only (with a `./runtime` subpath) keeps `mod.default` the V1
+// plugin object so the loader registers it. Do NOT re-introduce a CJS bundle.
+
+const PKG_URL = new URL("../../../@omniroute/opencode-plugin/package.json", import.meta.url);
+const TSUP_URL = new URL("../../../@omniroute/opencode-plugin/tsup.config.ts", import.meta.url);
+
+function readJson(url: URL): Record<string, unknown> {
+  return JSON.parse(readFileSync(fileURLToPath(url), "utf8"));
+}
+
+test("opencode-plugin package.json ships ESM-only (no CJS bundle)", () => {
+  const pkg = readJson(PKG_URL);
+
+  // main must point at the ESM build, never the .cjs bundle.
+  assert.equal(pkg.main, "./dist/index.js", "main must be the ESM build");
+  assert.equal(
+    typeof pkg.main === "string" && pkg.main.endsWith(".cjs"),
+    false,
+    "main must not be a .cjs bundle"
+  );
+  // The legacy dual-bundle `module` field should be gone.
+  assert.equal("module" in pkg, false, "the dual-bundle `module` field must be removed");
+
+  const exports = pkg.exports as Record<string, unknown> | undefined;
+  assert.ok(exports && typeof exports === "object", "exports map must exist");
+
+  const root = exports["."] as Record<string, unknown>;
+  assert.ok(root && typeof root === "object", 'exports["."] must exist');
+  assert.equal(root.import, "./dist/index.js", 'exports["."].import must be the ESM build');
+  // A `require` condition would re-introduce the CJS path the loader chokes on.
+  assert.equal("require" in root, false, 'exports["."] must not declare a `require` condition');
+
+  // The `./runtime` subpath used by the OpenCode loader must resolve to ESM.
+  const runtime = exports["./runtime"] as Record<string, unknown>;
+  assert.ok(runtime && typeof runtime === "object", 'exports["./runtime"] must exist');
+  assert.equal(runtime.import, "./dist/index.js", 'exports["./runtime"].import must be ESM');
+});
+
+test("opencode-plugin tsup config builds ESM-only with cjsInterop disabled", () => {
+  const tsup = readFileSync(fileURLToPath(TSUP_URL), "utf8");
+
+  const formatMatch = tsup.match(/format:\s*\[([^\]]*)\]/);
+  assert.ok(formatMatch, "tsup config must declare a format array");
+  const formats = formatMatch[1]
+    .split(",")
+    .map((s) => s.trim().replace(/['"]/g, ""))
+    .filter(Boolean);
+  assert.deepEqual(formats, ["esm"], "tsup must build esm only (no cjs)");
+
+  assert.equal(
+    /cjsInterop:\s*true/.test(tsup),
+    false,
+    "cjsInterop must not be true for an ESM-only build"
+  );
+});


### PR DESCRIPTION
## Summary

The `@omniroute/opencode-plugin` v0.1.0 ships a dual ESM+CJS bundle via tsup, but OpenCode's Bun-based plugin loader resolves the package's `main` field (which points to the CJS bundle). When Bun applies CJS-to-ESM interop, the resulting `mod.default` becomes the full exports namespace (not the V1 plugin object), so `readV1Plugin` in OpenCode's loader fails the V1 detection and the loader falls through to `getLegacyPlugins`, which iterates `Object.values(mod)` and chokes on the many named exports with:

```
TypeError: Plugin export is not a function
```

Net effect: the plugin fails to register in OpenCode v1.17.x and the OmniRoute provider never appears in the model picker.

## Fix

Drop the CJS bundle; ship ESM only, with a `./runtime` subpath export — matching the pattern used by the predecessor `opencode-omniroute-auth` package that worked correctly.

### Changes

**`@omniroute/opencode-plugin/tsup.config.ts`**
```diff
-  format: ["esm", "cjs"],
+  format: ["esm"],
```

**`@omniroute/opencode-plugin/package.json`**
```diff
-  "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
+  "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "import": { "types": "./dist/index.d.ts", "default": "./dist/index.js" },
-      "require": { "types": "./dist/index.d.cts", "default": "./dist/index.cjs" }
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./runtime": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
     }
   },
```

## Why this happens (root cause)

OpenCode's plugin loader does `import(entry)` on the resolved file and uses Bun's CJS-interop on the dual-bundle CJS file. `mod.default` ends up being the entire exports namespace, not the V1 plugin object. `readV1Plugin(mod, spec, 'server', 'detect')` does the V1 detection but the namespace lacks the V1 `id`/`server` top-level keys, so it falls through to `getLegacyPlugins`, which iterates the namespace and throws on the first non-function export.

With the ESM-only fix, the loader imports `./dist/index.js` directly. `mod.default` is `{ id, server: <function> }` — V1 detection succeeds.

## Note on related OpenCode bug

The same `Plugin export is not a function` error fires for `superpowers@0.0.2` and any other plugin with named exports. The fix landed upstream in commit `anomalyco/opencode@2e27403b26e9795d5ab60ec2b71585aa540abfd0` but is not in OpenCode 1.17.7. Tracking upstream: anomalyco/opencode#13543.

## Verification

After the fix, with the rebuilt plugin installed:

- Direct import test with Bun: `mod.default` is the V1 object with `server: function`
- OpenCode loader test: no more `failed to load plugin` errors; `service=omniroute` log lines appear
- Model picker: `omniroute` provider shows live catalog + combos
- Existing tests pass: `npm test` green

cc @diegosouzapw