### PR TITLE
fix(ci): drop secrets-in-job-if from nightly-llm-security (startup_failure on push)

### DIFF
--- a/.github/workflows/nightly-llm-security.yml
+++ b/.github/workflows/nightly-llm-security.yml
@@ -43,16 +43,35 @@ jobs:
   garak:
     name: garak probes (skip without provider secret)
     runs-on: ubuntu-latest
-    if: ${{ secrets.PROMPTFOO_PROVIDER_KEY != '' }}
+    # NOTE: the `secrets` context is NOT available in a job-level `if:` — referencing
+    # it there makes GitHub reject the file on push (startup_failure on every push).
+    # Map the secret into a job-level env and gate each step on a presence check, so
+    # the job stays green and simply skips the probes when the secret is absent.
+    env:
+      PROMPTFOO_PROVIDER_KEY: ${{ secrets.PROMPTFOO_PROVIDER_KEY }}
     steps:
+      - name: Gate on provider secret
+        id: gate
+        run: |
+          if [ -n "$PROMPTFOO_PROVIDER_KEY" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::PROMPTFOO_PROVIDER_KEY not set — skipping garak probes (advisory)."
+          fi
       - uses: actions/checkout@v6
+        if: steps.gate.outputs.run == 'true'
       - uses: actions/setup-node@v6
+        if: steps.gate.outputs.run == 'true'
         with: { node-version: "24", cache: npm }
       - run: npm ci
+        if: steps.gate.outputs.run == 'true'
       - name: Build CLI bundle
+        if: steps.gate.outputs.run == 'true'
         env: { JWT_SECRET: ci-build-secret-with-sufficient-length-for-validation }
         run: npm run build:cli
       - name: Start OmniRoute
+        if: steps.gate.outputs.run == 'true'
         env:
           JWT_SECRET: ci-build-secret-with-sufficient-length-for-validation
           PORT: "20128"
@@ -64,13 +83,16 @@ jobs:
             sleep 2
           done
       - uses: actions/setup-python@v5
+        if: steps.gate.outputs.run == 'true'
         with: { python-version: "3.12" }
       - run: pip install garak
+        if: steps.gate.outputs.run == 'true'
       - name: garak limited probes
+        if: steps.gate.outputs.run == 'true'
         env:
           OPENAI_API_KEY: ${{ secrets.PROMPTFOO_PROVIDER_KEY }}
           OPENAI_BASE_URL: http://localhost:20128/v1
         run: garak --model_type openai --model_name gpt-4o-mini --probes promptinject,dan,leakreplay --report_prefix garak-omniroute || true
       - name: Stop server
-        if: always()
+        if: always() && steps.gate.outputs.run == 'true'
         run: kill "$(cat server.pid)" || true


### PR DESCRIPTION
## Problema

O job `garak` em `.github/workflows/nightly-llm-security.yml` usava:

```yaml
if: ${{ secrets.PROMPTFOO_PROVIDER_KEY != '' }}
```

no **nível de job**. O contexto `secrets` **não está disponível em `if:` de job** no GitHub Actions — isso faz o GitHub **rejeitar o arquivo na validação de push** e produzir um `startup_failure` em **todo push** para `release/**` e `main` (checks vermelhos, ruído no CI). Shipado por engano no Bloco D (#3857).

Evidência: 3 runs `event=push conclusion=failure` com jobs vazios + a mensagem "This run likely failed because of a workflow file issue."

## Correção

Padrão suportado e seguro:
- Mapeia o secret para um **env de job** (`PROMPTFOO_PROVIDER_KEY`).
- Um step `gate` checa a presença (`-n "$PROMPTFOO_PROVIDER_KEY"`) e escreve `run=true/false`.
- Cada step subsequente é **gated** por `if: steps.gate.outputs.run == 'true'`.

Comportamento preservado: **skip-if-no-secret** (job fica verde e pula as probes quando o secret não existe; roda quando existir). Sem interpolação de input não-confiável nos `run:` (apenas env de secret de repo).

## Validação

- `secrets` removido do `if:` de job (não há mais `if` de job no `garak`).
- YAML válido (parse OK; jobs: `promptfoo-guard`, `garak`).
- Workflow é `schedule` + `workflow_dispatch` apenas — a correção elimina o `startup_failure` em push sem mudar o agendamento nightly.

Não toca código de produto, não gera versão.