### PR TITLE
ci(quality): per-module coverage floors + require-tighten (advisory)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,15 @@ jobs:
       # coverage mergeado). Tamanho de arquivo e duplicação têm gates dedicados.
       - name: Ratchet check
         run: node scripts/quality/check-quality-ratchet.mjs --summary .artifacts/quality-ratchet.md
+      # Fase 6A.5: require-tighten — ADVISORY por enquanto (continue-on-error). Reporta
+      # quando uma métrica MELHOROU sem o baseline ter sido apertado no mesmo PR (força
+      # capturar ganhos permanentes). As métricas coverage.* carregam tightenSlack para
+      # o gap anti-flake (CI mergeado > baseline) não disparar falso-positivo. Promover a
+      # BLOQUEANTE no fim do ciclo removendo o `continue-on-error` (ver a nota
+      # _require_tighten_advisory em config/quality/quality-baseline.json).
+      - name: Require-tighten (advisory — flip to blocking at cycle-end)
+        continue-on-error: true
+        run: node scripts/quality/check-quality-ratchet.mjs --require-tighten
       # Catraca de duplicação (jscpd@4 sobre src+open-sse). Roda neste job (paralelo)
       # para não pesar no caminho crítico do lint.
       - name: Duplication ratchet

--- a/config/quality/quality-baseline.json
+++ b/config/quality/quality-baseline.json
@@ -12,20 +12,72 @@
     },
     "coverage.statements": {
       "value": 76.5,
-      "direction": "up"
+      "direction": "up",
+      "tightenSlack": 5
     },
     "coverage.lines": {
       "value": 76.5,
-      "direction": "up"
+      "direction": "up",
+      "tightenSlack": 5
     },
     "coverage.functions": {
       "value": 82,
-      "direction": "up"
+      "direction": "up",
+      "tightenSlack": 5
     },
     "coverage.branches": {
       "value": 73,
       "direction": "up",
-      "eps": 1.5
+      "eps": 1.5,
+      "tightenSlack": 5
+    },
+    "coverage.chatCore.lines": {
+      "value": 74,
+      "direction": "up",
+      "eps": 1.5,
+      "tightenSlack": 10
+    },
+    "coverage.combo.lines": {
+      "value": 80,
+      "direction": "up",
+      "eps": 1.5,
+      "tightenSlack": 10
+    },
+    "coverage.accountFallback.lines": {
+      "value": 88,
+      "direction": "up",
+      "eps": 1.5,
+      "tightenSlack": 10
+    },
+    "coverage.auth.lines": {
+      "value": 69,
+      "direction": "up",
+      "eps": 1.5,
+      "tightenSlack": 10
+    },
+    "coverage.routeGuard.lines": {
+      "value": 94,
+      "direction": "up",
+      "eps": 1.5,
+      "tightenSlack": 10
+    },
+    "coverage.error.lines": {
+      "value": 88,
+      "direction": "up",
+      "eps": 1.5,
+      "tightenSlack": 10
+    },
+    "coverage.publicCreds.lines": {
+      "value": 92,
+      "direction": "up",
+      "eps": 1.5,
+      "tightenSlack": 10
+    },
+    "coverage.circuitBreaker.lines": {
+      "value": 92,
+      "direction": "up",
+      "eps": 1.5,
+      "tightenSlack": 10
     },
     "openapiCoverage.pct": {
       "value": 38.3,
@@ -57,5 +109,7 @@
   "_eslint_rebaseline_2026_06_13_phase7": "3653 -> 3658: +5 warnings dos scripts .mjs de tooling novos da Fase 7 (check-vuln-ratchet/codeql/secrets/workflows/dead-code/etc). Tooling de qualidade; apertar via --require-tighten no fim do ciclo.",
   "_eslint_rebaseline_2026_06_13_v3825": "3658 -> 3669: +11 drift consciente do ciclo v3.8.24->v3.8.25 (features #3799-#3806: free-provider-rankings, plugins menu, proxy IP-family). Medido em release/v3.8.25 (e38d22512). Crescimento de feature legitima, nao regressao; apertar via --require-tighten no fim do ciclo.",
   "_metrics_added_2026_06_13_6a11": "openapiCoverage.pct (38.3) e i18nUiCoverage.pct (80.1) promovidas de pisos manuais THRESHOLD para metricas de catraca (direction up) na Task 6A.11. eslintErrors fixado em 0 (era metrica orfa detectada pelo motor v2 da 6A.5).",
-  "_int_wiring_2026_06_13": "Fase 7 INT: 3 metricas promovidas de ADVISORY para RATCHET BLOQUEANTE. Valores REAIS medidos em 2026-06-13 no HEAD desta branch: deadExports=327 (knip --reporter json, DEAD_TOTAL=exports+files), cognitiveComplexity=738 (eslint sonarjs/cognitive-complexity via eslint.sonarjs.config.mjs), typeCoveragePct=92.17 (type-coverage --json-output -p open-sse/tsconfig.json). Os scripts check-dead-code.mjs/check-cognitive-complexity.mjs/check-type-coverage.mjs foram convertidos de advisory (exit 0 sempre) para ratchet (exit 1 em regressao). vulnCount e codeqlAlerts permanecem advisory no job quality-extended: dependem de binarios externos (osv-scanner) e token GitHub (gh api) nao disponiveis localmente — nao podem ser medidos/congelados honestamente sem infraestrutura de CI."
+  "_int_wiring_2026_06_13": "Fase 7 INT: 3 metricas promovidas de ADVISORY para RATCHET BLOQUEANTE. Valores REAIS medidos em 2026-06-13 no HEAD desta branch: deadExports=327 (knip --reporter json, DEAD_TOTAL=exports+files), cognitiveComplexity=738 (eslint sonarjs/cognitive-complexity via eslint.sonarjs.config.mjs), typeCoveragePct=92.17 (type-coverage --json-output -p open-sse/tsconfig.json). Os scripts check-dead-code.mjs/check-cognitive-complexity.mjs/check-type-coverage.mjs foram convertidos de advisory (exit 0 sempre) para ratchet (exit 1 em regressao). vulnCount e codeqlAlerts permanecem advisory no job quality-extended: dependem de binarios externos (osv-scanner) e token GitHub (gh api) nao disponiveis localmente — nao podem ser medidos/congelados honestamente sem infraestrutura de CI.",
+  "_coverage_per_module_2026_06_15": "Fase 7 Task 7.9: pisos coverage.<modulo>.lines para os 8 modulos criticos (chatCore/combo/accountFallback/auth/routeGuard/error/publicCreds/circuitBreaker). O coletor (collect-metrics.mjs::coverageByModule + CRITICAL_MODULE_PATHS) ja existia; faltava SO congelar o baseline. Valores semeados CONSERVADORES (~2-3pt abaixo de um run LOCAL de test:coverage de 2026-06-15, que por sua vez mede ~68% global vs ~76.5% do CI mergeado — logo os pisos estao MUITO abaixo do real do CI, zero risco de red). Apertar via 'quality:ratchet -- --update' a partir do 1o run de coverage mergeada do CI que popule essas chaves. tightenSlack alto (10) absorve a variancia local-vs-CI no step advisory de require-tighten.",
+  "_require_tighten_advisory_2026_06_15": "Fase 6A.5: o gate --require-tighten (falha quando uma metrica melhora sem o baseline ser apertado no mesmo PR) foi finalmente WIRADO no CI — porem como STEP ADVISORY (continue-on-error) no job quality-gate, NAO bloqueante. Motivo: (a) o proprio plano sequencia o aperto para 'o fim do ciclo', e a v3.8.26 acabou de abrir; (b) liga-lo bloqueante durante merges ativos travaria qualquer melhoria de metrica ate re-baseline. Para promover a BLOQUEANTE no fim do ciclo: remover o 'continue-on-error: true' do step 'Require-tighten' no ci.yml. tightenSlack nas metricas coverage.* impede falso-disparo pelo gap anti-flake."
 }


### PR DESCRIPTION
Fecha 2 gaps de completude (sem secret) da auditoria de gates.

## #1 — Pisos de cobertura por módulo (Fase 7 Task 7.9)
O coletor (`collect-metrics.mjs::coverageByModule` + `CRITICAL_MODULE_PATHS`) **já emitia** `coverage.<módulo>.lines` para os 8 módulos críticos (chatCore/combo/accountFallback/auth/routeGuard/error/publicCreds/circuitBreaker) — faltava **só congelar o baseline** (a ratchet as tratava como órfãs). Congelados **conservadores**: ~2-3pt abaixo de um run LOCAL de `test:coverage` (que mede ~68% global vs ~76.5% do CI mergeado) → pisos **bem abaixo** do real do CI = **zero risco de red**. Apertar via `--update` a partir do 1º run de coverage mergeada que os popule.

## #4 — Wiring do require-tighten (Fase 6A.5)
A flag `--require-tighten` existia em `check-quality-ratchet.mjs` mas **nunca era invocada no CI**. Wirada no job `quality-gate` como **step ADVISORY** (`continue-on-error`).

**Por que advisory e não bloqueante agora:** o próprio plano sequencia o aperto para "o fim do ciclo", e a v3.8.26 acabou de abrir — ligá-lo bloqueante durante merges ativos travaria qualquer melhoria de métrica até re-baseline. As métricas `coverage.*` recebem `tightenSlack` (5 global / 10 per-módulo) para o gap anti-flake (CI > baseline) não disparar falso-positivo. **Promover a bloqueante no fim do ciclo:** remover o `continue-on-error` do step.

## Validação
- baseline JSON válido (19 métricas, 8 per-módulo) · ci.yml YAML válido.
- require-tighten: **passa** quando métricas==baseline; **reporta** quando uma métrica melhora (ex.: eslintWarnings 3669→3600 → "rode --update"); `tightenSlack` absorve o gap de cobertura.

Config/CI apenas — sem código de produção. Não gera versão.