### PR TITLE
fix(setup): remove stale CJS bundle check from setup-open-code

### DIFF
--- a/bin/cli/commands/setup-open-code.mjs
+++ b/bin/cli/commands/setup-open-code.mjs
@@ -44,8 +44,7 @@ const PACKAGE_ROOT = resolve(__dirname, "..", "..", "..");
 // (see root package.json `files`: ["@omniroute/", ...]). The env override
 // exists so tests can point at a fixture without building the real plugin.
 const BUNDLED_PLUGIN_DIR =
-  process.env.OMNIROUTE_OPENCODE_PLUGIN_DIR ||
-  join(PACKAGE_ROOT, "@omniroute", "opencode-plugin");
+  process.env.OMNIROUTE_OPENCODE_PLUGIN_DIR || join(PACKAGE_ROOT, "@omniroute", "opencode-plugin");
 
 /**
  * Resolve the OpenCode config directory. Honours XDG_CONFIG_HOME and the
@@ -89,7 +88,7 @@ function resolveOpenCodeDirs() {
  *     a clear error instead of running tsup here, because the CLI runtime
  *     may not have tsup available (it's a devDependency).
  *
- * @returns {{ distEntry: string, cjsEntry: string, packageDir: string }}
+ * @returns {{ distEntry: string, packageDir: string }}
  */
 function resolveBundledPlugin() {
   if (!existsSync(BUNDLED_PLUGIN_DIR)) {
@@ -102,17 +101,17 @@ function resolveBundledPlugin() {
   }
 
   const esmEntry = join(BUNDLED_PLUGIN_DIR, "dist", "index.js");
-  const cjsEntry = join(BUNDLED_PLUGIN_DIR, "dist", "index.cjs");
 
-  if (!existsSync(esmEntry) || !existsSync(cjsEntry)) {
+  if (!existsSync(esmEntry)) {
     throw new Error(
       `@omniroute/opencode-plugin dist/ not built (looked for ${esmEntry}).\n` +
         `Run \`cd ${BUNDLED_PLUGIN_DIR} && npm install && npm run build\` and re-run this command.`
     );
   }
 
-  // Prefer ESM. OpenCode (≥1.15) loads ESM modules natively.
-  return { distEntry: esmEntry, cjsEntry, packageDir: BUNDLED_PLUGIN_DIR };
+  // ESM-only build (CJS was dropped in tsup config). OpenCode (>=1.15) loads
+  // ESM modules natively.
+  return { distEntry: esmEntry, packageDir: BUNDLED_PLUGIN_DIR };
 }
 
 /**


### PR DESCRIPTION
Follow-up to #3883.

#3883 dropped the CJS bundle from tsup (`format: ["esm"]` only), but `bin/cli/commands/setup-open-code.mjs::resolveBundledPlugin()` still checks for `dist/index.cjs`:

```js
if (!existsSync(esmEntry) || !existsSync(cjsEntry)) { throw ... }
```

The cjs check always fails now, so `omniroute setup opencode` throws even when the plugin is correctly built (only the ESM dist is present). This breaks the setup command on the release branch post-#3883.

## Changes

- Drop the `cjsEntry` check in `resolveBundledPlugin()`
- Update JSDoc `@returns` to remove `cjsEntry`
- Refresh the comment to reflect ESM-only build

## Testing

- All 4 tests in `tests/unit/cli-setup-opencode.test.ts` pass
- All 4 tests in `tests/unit/cli-setup-command.test.ts` pass
- `npm run typecheck:core` clean

Scoped narrowly to the CJS check; the other follow-ups you mentioned (security validation, Windows USERPROFILE) are skipped here since they touched the same file and would conflict with the version on the release branch. Happy to rebase against a more recent base if you want those too.