### PR TITLE
refactor: extract OpenAI chunks to open-sse/utils/stream/openaiChunks.ts (Issue #3594)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_Cycle open — entries are added here as PRs merge into `release/v3.8.27`._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/ar/CHANGELOG.md
+++ b/docs/i18n/ar/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/az/CHANGELOG.md
+++ b/docs/i18n/az/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/bg/CHANGELOG.md
+++ b/docs/i18n/bg/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/bn/CHANGELOG.md
+++ b/docs/i18n/bn/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/cs/CHANGELOG.md
+++ b/docs/i18n/cs/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/da/CHANGELOG.md
+++ b/docs/i18n/da/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/de/CHANGELOG.md
+++ b/docs/i18n/de/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/es/CHANGELOG.md
+++ b/docs/i18n/es/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/fa/CHANGELOG.md
+++ b/docs/i18n/fa/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/fi/CHANGELOG.md
+++ b/docs/i18n/fi/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/fr/CHANGELOG.md
+++ b/docs/i18n/fr/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/gu/CHANGELOG.md
+++ b/docs/i18n/gu/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/he/CHANGELOG.md
+++ b/docs/i18n/he/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/hi/CHANGELOG.md
+++ b/docs/i18n/hi/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/hu/CHANGELOG.md
+++ b/docs/i18n/hu/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/id/CHANGELOG.md
+++ b/docs/i18n/id/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/in/CHANGELOG.md
+++ b/docs/i18n/in/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/it/CHANGELOG.md
+++ b/docs/i18n/it/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/ja/CHANGELOG.md
+++ b/docs/i18n/ja/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/ko/CHANGELOG.md
+++ b/docs/i18n/ko/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/mr/CHANGELOG.md
+++ b/docs/i18n/mr/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/ms/CHANGELOG.md
+++ b/docs/i18n/ms/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/nl/CHANGELOG.md
+++ b/docs/i18n/nl/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/no/CHANGELOG.md
+++ b/docs/i18n/no/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/phi/CHANGELOG.md
+++ b/docs/i18n/phi/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/pl/CHANGELOG.md
+++ b/docs/i18n/pl/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/pt-BR/CHANGELOG.md
+++ b/docs/i18n/pt-BR/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/pt/CHANGELOG.md
+++ b/docs/i18n/pt/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/ro/CHANGELOG.md
+++ b/docs/i18n/ro/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/ru/CHANGELOG.md
+++ b/docs/i18n/ru/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/sk/CHANGELOG.md
+++ b/docs/i18n/sk/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/sv/CHANGELOG.md
+++ b/docs/i18n/sv/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/sw/CHANGELOG.md
+++ b/docs/i18n/sw/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/ta/CHANGELOG.md
+++ b/docs/i18n/ta/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/te/CHANGELOG.md
+++ b/docs/i18n/te/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/th/CHANGELOG.md
+++ b/docs/i18n/th/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/tr/CHANGELOG.md
+++ b/docs/i18n/tr/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/uk-UA/CHANGELOG.md
+++ b/docs/i18n/uk-UA/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/ur/CHANGELOG.md
+++ b/docs/i18n/ur/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/vi/CHANGELOG.md
+++ b/docs/i18n/vi/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/zh-CN/CHANGELOG.md
+++ b/docs/i18n/zh-CN/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/reference/openapi.yaml
+++ b/docs/reference/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: OmniRoute API
-  version: 3.8.26
+  version: 3.8.27
   description: |
     OmniRoute is a local-first AI API proxy router. It provides an OpenAI-compatible
     endpoint that routes requests to multiple AI providers with load balancing,

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "omniroute-desktop",
-  "version": "3.8.26",
+  "version": "3.8.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "omniroute-desktop",
-      "version": "3.8.26",
+      "version": "3.8.27",
       "license": "MIT",
       "dependencies": {
         "electron-updater": "^6.8.9"

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omniroute-desktop",
-  "version": "3.8.26",
+  "version": "3.8.27",
   "description": "OmniRoute Desktop Application",
   "main": "main.js",
   "author": {

--- a/open-sse/package.json
+++ b/open-sse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omniroute/open-sse",
-  "version": "3.8.26",
+  "version": "3.8.27",
   "description": "Express SSE sidecar for OmniRoute — handles streaming, protocol translation, and provider orchestration",
   "type": "module",
   "main": "index.js",

--- a/open-sse/utils/stream/openaiChunks.ts
+++ b/open-sse/utils/stream/openaiChunks.ts
@@ -1,6 +1,3 @@
-import { convertOpenAIToResponsesToolCall } from "../handlers/responseTranslator.ts";
-import { v4 as uuidv4 } from "uuid";
-
 import { JsonRecord } from "./types.ts";
 
 export function getOpenAIIntermediateChunks(value: unknown): unknown[] {

--- a/open-sse/utils/stream/openaiChunks.ts
+++ b/open-sse/utils/stream/openaiChunks.ts
@@ -1,0 +1,10 @@
+import { convertOpenAIToResponsesToolCall } from "../handlers/responseTranslator.ts";
+import { v4 as uuidv4 } from "uuid";
+
+import { JsonRecord } from "./types.ts";
+
+export function getOpenAIIntermediateChunks(value: unknown): unknown[] {
+  if (!value || typeof value !== "object") return [];
+  const candidate = (value as JsonRecord)._openaiIntermediate;
+  return Array.isArray(candidate) ? candidate : [];
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "omniroute",
-  "version": "3.8.26",
+  "version": "3.8.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "omniroute",
-      "version": "3.8.26",
+      "version": "3.8.27",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -27928,7 +27928,7 @@
     },
     "open-sse": {
       "name": "@omniroute/open-sse",
-      "version": "3.8.26"
+      "version": "3.8.27"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omniroute",
-  "version": "3.8.26",
+  "version": "3.8.27",
   "description": "Unified AI router with 160+ providers, RTK+Caveman compression, auto fallback, MCP/A2A, desktop, PWA, and OpenAI-compatible APIs.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Part of modularization effort (Issue #3594).

Extracts OpenAI intermediate chunk handling from the monolithic `open-sse/utils/stream.ts` into a dedicated module.

**Changes:**
- New file: `open-sse/utils/stream/openaiChunks.ts` (9 lines)
- Exports: `getOpenAIIntermediateChunks`

**Testing:** No behavior change. Existing stream tests pass.

**Follow-up PRs will extract:** types (#3917), utils (#3918), errors (#3919), textualToolCalls (#3920), sseFormatters (#3923), claudeLifecycle, responsesLifecycle, and streamCore.