### PR TITLE
refactor: extract Claude lifecycle to open-sse/utils/stream/claudeLifecycle.ts (Issue #3594)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_Cycle open — entries are added here as PRs merge into `release/v3.8.27`._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/ar/CHANGELOG.md
+++ b/docs/i18n/ar/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/az/CHANGELOG.md
+++ b/docs/i18n/az/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/bg/CHANGELOG.md
+++ b/docs/i18n/bg/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/bn/CHANGELOG.md
+++ b/docs/i18n/bn/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/cs/CHANGELOG.md
+++ b/docs/i18n/cs/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/da/CHANGELOG.md
+++ b/docs/i18n/da/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/de/CHANGELOG.md
+++ b/docs/i18n/de/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/es/CHANGELOG.md
+++ b/docs/i18n/es/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/fa/CHANGELOG.md
+++ b/docs/i18n/fa/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/fi/CHANGELOG.md
+++ b/docs/i18n/fi/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/fr/CHANGELOG.md
+++ b/docs/i18n/fr/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/gu/CHANGELOG.md
+++ b/docs/i18n/gu/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/he/CHANGELOG.md
+++ b/docs/i18n/he/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/hi/CHANGELOG.md
+++ b/docs/i18n/hi/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/hu/CHANGELOG.md
+++ b/docs/i18n/hu/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/id/CHANGELOG.md
+++ b/docs/i18n/id/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/in/CHANGELOG.md
+++ b/docs/i18n/in/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/it/CHANGELOG.md
+++ b/docs/i18n/it/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/ja/CHANGELOG.md
+++ b/docs/i18n/ja/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/ko/CHANGELOG.md
+++ b/docs/i18n/ko/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/mr/CHANGELOG.md
+++ b/docs/i18n/mr/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/ms/CHANGELOG.md
+++ b/docs/i18n/ms/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/nl/CHANGELOG.md
+++ b/docs/i18n/nl/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/no/CHANGELOG.md
+++ b/docs/i18n/no/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/phi/CHANGELOG.md
+++ b/docs/i18n/phi/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/pl/CHANGELOG.md
+++ b/docs/i18n/pl/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/pt-BR/CHANGELOG.md
+++ b/docs/i18n/pt-BR/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/pt/CHANGELOG.md
+++ b/docs/i18n/pt/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/ro/CHANGELOG.md
+++ b/docs/i18n/ro/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/ru/CHANGELOG.md
+++ b/docs/i18n/ru/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/sk/CHANGELOG.md
+++ b/docs/i18n/sk/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/sv/CHANGELOG.md
+++ b/docs/i18n/sv/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/sw/CHANGELOG.md
+++ b/docs/i18n/sw/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/ta/CHANGELOG.md
+++ b/docs/i18n/ta/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/te/CHANGELOG.md
+++ b/docs/i18n/te/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/th/CHANGELOG.md
+++ b/docs/i18n/th/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/tr/CHANGELOG.md
+++ b/docs/i18n/tr/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/uk-UA/CHANGELOG.md
+++ b/docs/i18n/uk-UA/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/ur/CHANGELOG.md
+++ b/docs/i18n/ur/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/vi/CHANGELOG.md
+++ b/docs/i18n/vi/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/i18n/zh-CN/CHANGELOG.md
+++ b/docs/i18n/zh-CN/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## [3.8.27] — TBD
+
+_See English CHANGELOG for v3.8.27 details._
+
+---
+
 ## [3.8.26] — 2026-06-15
 
 ### ✨ New Features

--- a/docs/reference/openapi.yaml
+++ b/docs/reference/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: OmniRoute API
-  version: 3.8.26
+  version: 3.8.27
   description: |
     OmniRoute is a local-first AI API proxy router. It provides an OpenAI-compatible
     endpoint that routes requests to multiple AI providers with load balancing,

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "omniroute-desktop",
-  "version": "3.8.26",
+  "version": "3.8.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "omniroute-desktop",
-      "version": "3.8.26",
+      "version": "3.8.27",
       "license": "MIT",
       "dependencies": {
         "electron-updater": "^6.8.9"

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omniroute-desktop",
-  "version": "3.8.26",
+  "version": "3.8.27",
   "description": "OmniRoute Desktop Application",
   "main": "main.js",
   "author": {

--- a/open-sse/package.json
+++ b/open-sse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omniroute/open-sse",
-  "version": "3.8.26",
+  "version": "3.8.27",
   "description": "Express SSE sidecar for OmniRoute — handles streaming, protocol translation, and provider orchestration",
   "type": "module",
   "main": "index.js",

--- a/open-sse/utils/stream/claudeLifecycle.ts
+++ b/open-sse/utils/stream/claudeLifecycle.ts
@@ -1,6 +1,3 @@
-import { convertOpenAIToResponsesToolCall } from "../handlers/responseTranslator.ts";
-import { v4 as uuidv4 } from "uuid";
-
 import { JsonRecord } from "./types.ts";
 
 export type ClaudeEmptyResponseLifecycle = {

--- a/open-sse/utils/stream/claudeLifecycle.ts
+++ b/open-sse/utils/stream/claudeLifecycle.ts
@@ -1,0 +1,185 @@
+import { convertOpenAIToResponsesToolCall } from "../handlers/responseTranslator.ts";
+import { v4 as uuidv4 } from "uuid";
+
+import { JsonRecord } from "./types.ts";
+
+export type ClaudeEmptyResponseLifecycle = {
+  hasMessageStart: boolean;
+  hasContentBlock: boolean;
+  hasMessageDelta: boolean;
+  hasMessageStop: boolean;
+  hasError: boolean;
+  syntheticContentInjected: boolean;
+  warningLogged: boolean;
+};
+
+export const SYNTHETIC_CLAUDE_EMPTY_RESPONSE_TEXT = "";
+
+export function createClaudeEmptyResponseLifecycle(): ClaudeEmptyResponseLifecycle {
+  return {
+    hasMessageStart: false,
+    hasContentBlock: false,
+    hasMessageDelta: false,
+    hasMessageStop: false,
+    hasError: false,
+    syntheticContentInjected: false,
+    warningLogged: false,
+  };
+}
+
+export function getClaudeEventType(payload: unknown): string | null {
+  if (!payload || typeof payload !== "object") return null;
+  const type = (payload as JsonRecord).type;
+  return typeof type === "string" ? type : null;
+}
+
+export function isClaudeEventPayload(payload: unknown): payload is JsonRecord {
+  return getClaudeEventType(payload) !== null;
+}
+
+export function updateClaudeEmptyResponseLifecycle(
+  lifecycle: ClaudeEmptyResponseLifecycle,
+  payload: unknown
+) {
+  const type = getClaudeEventType(payload);
+  if (!type) return;
+
+  switch (type) {
+    case "message_start":
+      lifecycle.hasMessageStart = true;
+      break;
+    case "content_block_start":
+    case "content_block_delta":
+    case "content_block_stop":
+      lifecycle.hasContentBlock = true;
+      break;
+    case "message_delta":
+      lifecycle.hasMessageDelta = true;
+      break;
+    case "message_stop":
+      lifecycle.hasMessageStop = true;
+      break;
+    case "error":
+      lifecycle.hasError = true;
+      break;
+    default:
+      break;
+  }
+}
+
+export function hasClaudeAssistantLifecycle(lifecycle: ClaudeEmptyResponseLifecycle): boolean {
+  return lifecycle.hasMessageStart || lifecycle.hasMessageDelta || lifecycle.hasMessageStop;
+}
+
+export function shouldInjectClaudeEmptyResponseBeforeCurrentEvent(
+  lifecycle: ClaudeEmptyResponseLifecycle,
+  payload: unknown
+): boolean {
+  const type = getClaudeEventType(payload);
+  if (!type || lifecycle.hasError || lifecycle.hasContentBlock) return false;
+  if (!hasClaudeAssistantLifecycle(lifecycle)) return false;
+  return type === "message_delta" || type === "message_stop";
+}
+
+export function shouldInjectClaudeEmptyResponseOnFlush(
+  lifecycle: ClaudeEmptyResponseLifecycle
+): boolean {
+  if (lifecycle.hasError || lifecycle.hasContentBlock) return false;
+  return hasClaudeAssistantLifecycle(lifecycle);
+}
+
+export function shouldInjectClaudeMissingFinalizersOnFlush(
+  lifecycle: ClaudeEmptyResponseLifecycle
+): boolean {
+  if (lifecycle.hasError || !lifecycle.syntheticContentInjected) return false;
+  return !lifecycle.hasMessageDelta || !lifecycle.hasMessageStop;
+}
+
+export function buildSyntheticClaudeEmptyResponseEvents(
+  lifecycle: ClaudeEmptyResponseLifecycle,
+  model: string | null,
+  options: {
+    includeContentBlock?: boolean;
+    includeMessageDelta?: boolean;
+    includeMessageStop?: boolean;
+  } = {}
+): JsonRecord[] {
+  const {
+    includeContentBlock = true,
+    includeMessageDelta = false,
+    includeMessageStop = false,
+  } = options;
+  const events: JsonRecord[] = [];
+  const resolvedModel = typeof model === "string" && model ? model : "unknown";
+
+  if (includeContentBlock) {
+    if (!lifecycle.hasMessageStart) {
+      events.push({
+        type: "message_start",
+        message: {
+          id: `msg_synthetic_${Date.now()}`,
+          type: "message",
+          role: "assistant",
+          model: resolvedModel,
+          content: [],
+          stop_reason: null,
+          stop_sequence: null,
+          usage: { input_tokens: 0, output_tokens: 0 },
+        },
+      });
+    }
+
+    events.push(
+      {
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "text", text: "" },
+      },
+      {
+        type: "content_block_delta",
+        index: 0,
+        delta: {
+          type: "text_delta",
+          text: SYNTHETIC_CLAUDE_EMPTY_RESPONSE_TEXT,
+        },
+      },
+      {
+        type: "content_block_stop",
+        index: 0,
+      }
+    );
+  }
+
+  if (includeMessageDelta) {
+    events.push({
+      type: "message_delta",
+      delta: { stop_reason: "end_turn", stop_sequence: null },
+      usage: { input_tokens: 0, output_tokens: 0 },
+    });
+  }
+
+  if (includeMessageStop) {
+    events.push({ type: "message_stop" });
+  }
+
+  return events;
+}
+
+export function restoreClaudePassthroughToolUseName(
+  parsed: JsonRecord,
+  toolNameMap: unknown
+): boolean {
+  if (!(toolNameMap instanceof Map)) return false;
+  if (!parsed || typeof parsed !== "object") return false;
+
+  const block =
+    parsed.content_block && typeof parsed.content_block === "object"
+      ? (parsed.content_block as JsonRecord)
+      : null;
+  if (!block || block.type !== "tool_use" || typeof block.name !== "string") return false;
+
+  const restoredName = toolNameMap.get(block.name) ?? block.name;
+  if (restoredName === block.name) return false;
+  block.name = restoredName;
+  return true;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "omniroute",
-  "version": "3.8.26",
+  "version": "3.8.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "omniroute",
-      "version": "3.8.26",
+      "version": "3.8.27",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -27928,7 +27928,7 @@
     },
     "open-sse": {
       "name": "@omniroute/open-sse",
-      "version": "3.8.26"
+      "version": "3.8.27"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omniroute",
-  "version": "3.8.26",
+  "version": "3.8.27",
   "description": "Unified AI router with 160+ providers, RTK+Caveman compression, auto fallback, MCP/A2A, desktop, PWA, and OpenAI-compatible APIs.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Part of modularization effort (Issue #3594).

Extracts Claude-specific lifecycle handling from the monolithic `open-sse/utils/stream.ts` into a dedicated module.

**Changes:**
- New file: `open-sse/utils/stream/claudeLifecycle.ts` (179 lines)
- Exports: `SYNTHETIC_CLAUDE_EMPTY_RESPONSE_TEXT`, `createClaudeEmptyResponseLifecycle`, `getClaudeEventType`, `isClaudeEventPayload`, `updateClaudeEmptyResponseLifecycle`, `shouldInjectClaudeEmptyResponseBeforeCurrentEvent`, `shouldInjectClaudeEmptyResponseOnFlush`, `shouldInjectClaudeMissingFinalizersOnFlush`, `buildSyntheticClaudeEmptyResponseEvents`, `restoreClaudePassthroughToolUseName`

**Testing:** No behavior change. Existing stream tests pass.

**Follow-up PRs will extract:** types (#3917), utils (#3918), errors (#3919), textualToolCalls (#3920), sseFormatters (#3923), openaiChunks (#3924), responsesLifecycle, and streamCore.