### PR TITLE
test: reconcile runtime-timeouts keepAlive baseline after #3907 revert

### DIFF
--- a/tests/unit/runtime-timeouts.test.ts
+++ b/tests/unit/runtime-timeouts.test.ts
@@ -17,7 +17,7 @@ test("upstream timeout config derives hidden fetch timeouts from FETCH_TIMEOUT_M
     fetchHeadersTimeoutMs: 600000,
     fetchBodyTimeoutMs: 600000,
     fetchConnectTimeoutMs: 30000,
-    fetchKeepAliveTimeoutMs: 1000,
+    fetchKeepAliveTimeoutMs: 4000,
   });
 });
 
@@ -54,7 +54,7 @@ test("upstream timeout config honors explicit overrides and falls back on invali
   assert.equal(config.fetchHeadersTimeoutMs, 610000);
   assert.equal(config.fetchBodyTimeoutMs, 0);
   assert.equal(config.fetchConnectTimeoutMs, 45000);
-  assert.equal(config.fetchKeepAliveTimeoutMs, 1000);
+  assert.equal(config.fetchKeepAliveTimeoutMs, 4000);
 });
 
 test("TLS client timeout defaults to FETCH_TIMEOUT_MS and can be overridden", () => {


### PR DESCRIPTION
## Problem
The unit suite is **red release-wide** on `release/v3.8.26`: `tests/unit/runtime-timeouts.test.ts` fails 2 assertions (`fetchKeepAliveTimeoutMs` expected `1000`, actual `4000`).

## Root cause
PR #3907 ("prevent zombie-socket hangs for zai/glm and tighten default keepAlive") changed the test to expect `1000`, anticipating `DEFAULT_FETCH_KEEPALIVE_TIMEOUT_MS` dropping to `1000`. Its own commit message records that the **global keepAlive change was reverted on review** (source kept at `4000`, with a `keepAliveMaxTimeout` pin added instead). The test assertions were left at `1000`, so they no longer match the shipped source.

## Fix
Align the two assertions back to the shipped value (`4000`). Test-only; no production change.

## Validation
`node --import tsx/esm --test tests/unit/runtime-timeouts.test.ts` → **10 pass / 0 fail** (was 8/2).

Unblocks the unit suite so other fixes can be validated against a green baseline.