### PR TITLE
fix: in-flight request payload sync

### DIFF
--- a/src/lib/usage/usageHistory.ts
+++ b/src/lib/usage/usageHistory.ts
@@ -289,7 +289,7 @@ export function updatePendingRequest(
   const details = pendingRequests.details[connectionId]?.[modelKey];
   if (!details?.length) return;
   const lastIdx = details.length - 1;
-  details[lastIdx] = { ...details[lastIdx], ...normalizePendingMetadata(metadata) };
+  Object.assign(details[lastIdx], normalizePendingMetadata(metadata));
 }
 
 /**

--- a/tests/unit/request-logger-endpoints.test.ts
+++ b/tests/unit/request-logger-endpoints.test.ts
@@ -87,6 +87,40 @@ test("updatePendingRequestStreamChunks stores stream chunks in the detail", () =
   assert.equal(detail.streamChunks.provider[0], 'data: {"a":1}');
 });
 
+test("updatePendingRequest keeps pending detail API view in sync", () => {
+  usageHistory.clearPendingRequests();
+  const requestId = usageHistory.trackPendingRequest(
+    "claude-sonnet-4-6",
+    "cc-test",
+    "conn-1",
+    true,
+    {
+      clientRequest: { model: "cc-test/claude-sonnet-4-6", reasoning_effort: "xhigh" },
+      providerRequest: { model: "claude-sonnet-4-6", reasoning_effort: "xhigh" },
+    }
+  );
+  assert.ok(requestId, "trackPendingRequest should return an id");
+
+  usageHistory.updatePendingRequest("claude-sonnet-4-6", "cc-test", "conn-1", {
+    providerRequest: { model: "claude-sonnet-4-6", reasoning_effort: "high" },
+    stage: "provider_response_started",
+  });
+
+  const modelKey = "claude-sonnet-4-6 (cc-test)";
+  const detailFromQueue = usageHistory.getPendingRequests().details["conn-1"]?.[modelKey]?.[0];
+  const detailFromId = usageHistory.getPendingById().get(requestId);
+
+  assert.equal(detailFromId, detailFromQueue);
+  assert.deepEqual(detailFromId?.providerRequest, {
+    model: "claude-sonnet-4-6",
+    reasoning_effort: "high",
+  });
+  assert.deepEqual(detailFromId?.clientRequest, {
+    model: "cc-test/claude-sonnet-4-6",
+    reasoning_effort: "xhigh",
+  });
+});
+
 test("updatePendingRequestStreamChunks stores empty streamChunks object (not null)", () => {
   usageHistory.clearPendingRequests();
   usageHistory.trackPendingRequest("gpt-4", "openai", "conn-1", true);


### PR DESCRIPTION
## Summary

Fixes stale payloads in active in-flight request details by keeping the pending detail queue and the ID lookup map synchronized when request metadata is updated.

## Root cause

`trackPendingRequest()` stores the same pending request detail in both the per-connection queue and `pendingById`. `updatePendingRequest()` later replaced the queue entry with a new object, leaving `pendingById` pointing at the original registration-time snapshot. The active log detail endpoint reads `pendingById`, so in-flight details could show an outdated provider request while completed logs showed the final sanitized provider payload.

## Impact

Active request details now reflect updates such as provider payload normalization before the request completes. The original client request remains unchanged, while the provider request view can update from the initial payload to the final provider-bound payload.

## Validation

- `node --import tsx --import ./open-sse/utils/setupPolyfill.ts --test tests/unit/request-logger-endpoints.test.ts`
- `node --import tsx --import ./open-sse/utils/setupPolyfill.ts --test tests/unit/active-request-stream-chunks-lifecycle.test.ts`