### PR TITLE
fix(ci): electron-release publish-npm needs contents:write (v3.8.26 startup_failure)

### DIFF
--- a/.github/workflows/electron-release.yml
+++ b/.github/workflows/electron-release.yml
@@ -268,7 +268,11 @@ jobs:
     name: Publish to npm
     needs: [validate, release]
     permissions:
-      contents: read
+      # Must be `write`, not `read`: this job calls the reusable npm-publish.yml whose
+      # `publish` job needs `contents: write` (gh release upload — attach the SBOM, #3874).
+      # A reusable workflow's job cannot request more permission than the caller grants,
+      # so a `read` here makes GitHub reject the run at startup (startup_failure).
+      contents: write
       id-token: write # npm provenance (forwarded to the reusable workflow)
       packages: write # publish to npm.pkg.github.com
     uses: ./.github/workflows/npm-publish.yml


### PR DESCRIPTION
The v3.8.26 Electron build failed at startup: the `publish-npm` job calls the reusable `npm-publish.yml` whose `publish` job now needs `contents: write` (SBOM `gh release upload`, #3874), but the caller only granted `contents: read`. A reusable job can't exceed the caller's permissions → startup_failure. Fixes it. CI config only.