### PR TITLE
Refine provider quota card display

### DIFF
--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/ProviderLimitCard.tsx
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/ProviderLimitCard.tsx
@@ -6,7 +6,7 @@ import { useTranslations } from "next-intl";
 import Card from "@/shared/components/Card";
 import Badge from "@/shared/components/Badge";
 import QuotaProgressBar from "./QuotaProgressBar";
-import { calculatePercentage } from "./utils";
+import { calculatePercentage, shouldShowQuotaUsageCount } from "./utils";
 import ProviderIcon from "@/shared/components/ProviderIcon";
 
 const planVariants = {
@@ -160,6 +160,7 @@ export default function ProviderLimitCard({
                 unlimited={unlimited}
                 resetTime={quota.resetAt}
                 staleAfterReset={quota.staleAfterReset === true}
+                showUsageCount={shouldShowQuotaUsageCount(quota)}
               />
             );
           })}

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/QuotaCard.tsx
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/QuotaCard.tsx
@@ -13,6 +13,8 @@ const STATUS_BORDER: Record<CardStatus, string> = {
   empty: "transparent",
 };
 
+const EMPTY_QUOTAS: any[] = [];
+
 interface QuotaCardProps {
   connection: any;
   quota:
@@ -48,7 +50,7 @@ export default function QuotaCard({
   togglingActive,
 }: QuotaCardProps) {
   const isActive = connection.isActive ?? true;
-  const quotas = quota?.quotas ?? [];
+  const quotas = quota?.quotas ?? EMPTY_QUOTAS;
   const cardStatus = useMemo<CardStatus>(() => worstStatus(quotas), [quotas]);
   const tierMeta = useMemo(
     () =>
@@ -82,10 +84,6 @@ export default function QuotaCard({
         resolvedPlan={resolvedPlan}
         emailsVisible={emailsVisible}
         hasStaleData={hasStaleData}
-        refreshing={loading}
-        onRefresh={onRefresh}
-        onOpenCutoff={onOpenCutoff}
-        hasCutoffOverrides={hasOverrides}
         onToggleActive={onToggleActive}
         togglingActive={togglingActive}
       />
@@ -98,6 +96,7 @@ export default function QuotaCard({
         onRefresh={onRefresh}
         onOpenCutoff={onOpenCutoff}
         canEditCutoff={canEditCutoff}
+        hasCutoffOverrides={hasOverrides}
       />
     </Card>
   );

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/QuotaCardGrid.tsx
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/QuotaCardGrid.tsx
@@ -49,7 +49,7 @@ export default function QuotaCardGrid({
               ({conns.length} account{conns.length !== 1 ? "s" : ""})
             </span>
           </h3>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
+          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 gap-3">
             {conns.map((conn) => (
               <QuotaCard
                 key={conn.id}

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/QuotaProgressBar.tsx
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/QuotaProgressBar.tsx
@@ -3,6 +3,7 @@
 import { useTranslations } from "next-intl";
 import { cn } from "@/shared/utils/cn";
 import { formatResetTime } from "./utils";
+import { translateUsageOrFallback } from "./i18nFallback";
 
 // Calculate color based on remaining percentage
 const getColorClasses = (remainingPercentage) => {
@@ -73,6 +74,7 @@ export default function QuotaProgressBar({
   unlimited = false,
   resetTime = null,
   staleAfterReset = false,
+  showUsageCount = true,
 }) {
   const t = useTranslations("usage");
   const colors = getColorClasses(percentage);
@@ -81,7 +83,7 @@ export default function QuotaProgressBar({
 
   // percentage is already remaining percentage (from ProviderLimitCard)
   const remaining = percentage;
-  const usedPercentage = Math.max(0, Math.min(100, 100 - remaining));
+  const remainingPercentage = Math.round(Math.max(0, Math.min(100, remaining)));
 
   return (
     <div className="space-y-2">
@@ -91,7 +93,9 @@ export default function QuotaProgressBar({
         <div className="flex items-center gap-1.5">
           <span className="text-xs">{colors.emoji}</span>
           <span className={cn("font-medium", colors.text)}>
-            {t("percentUsed", { pct: usedPercentage })}
+            {translateUsageOrFallback(t, "percentLeft", `${remainingPercentage}% left`, {
+              pct: remainingPercentage,
+            })}
           </span>
         </div>
       </div>
@@ -109,7 +113,7 @@ export default function QuotaProgressBar({
       {/* Usage details and countdown */}
       <div className="flex items-center justify-between text-xs text-text-muted">
         <span>
-          {used.toLocaleString()} / {total.toLocaleString()} requests
+          {showUsageCount ? `${used.toLocaleString()} / ${total.toLocaleString()} requests` : null}
         </span>
         {staleAfterReset ? (
           <div className="flex items-center gap-1">

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/QuotaTable.tsx
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/QuotaTable.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { formatResetTime, calculatePercentage } from "./utils";
+import { calculatePercentage, formatResetTime, shouldShowQuotaUsageCount } from "./utils";
 import { useLocale, useTranslations } from "next-intl";
 
 /**
@@ -131,8 +131,11 @@ export default function QuotaTable({ quotas = [] }) {
                     {/* Numbers */}
                     <div className="flex items-center justify-between text-xs">
                       <span className="text-text-muted">
-                        {quota.used.toLocaleString()} /{" "}
-                        {quota.total > 0 ? quota.total.toLocaleString() : "∞"}
+                        {shouldShowQuotaUsageCount(quota)
+                          ? `${quota.used.toLocaleString()} / ${
+                              quota.total > 0 ? quota.total.toLocaleString() : "∞"
+                            }`
+                          : null}
                       </span>
                       <span className={`font-medium ${colors.text}`}>{remaining}%</span>
                     </div>

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/parts/QuotaCardBody.tsx
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/parts/QuotaCardBody.tsx
@@ -36,17 +36,22 @@ function QuotaRow({ q }: { q: any }) {
       maximumFractionDigits: 2,
     });
     return (
-      <div className="flex items-center justify-between gap-2 py-0.5">
-        <span className="text-[11px] text-text-main truncate flex items-center gap-1">
-          <span
-            className="material-symbols-outlined text-[12px] shrink-0"
-            style={{ color: colors.text }}
-          >
-            paid
+      <div className="flex min-h-[28px] items-center justify-between gap-2 py-1">
+        <span className="flex min-w-0 flex-1 items-center gap-1.5 text-[11px] leading-none text-text-main">
+          <span className="inline-flex size-5 shrink-0 items-center justify-center">
+            <span
+              className="material-symbols-outlined text-[13px] leading-none"
+              style={{ color: colors.text }}
+            >
+              paid
+            </span>
           </span>
-          {formatQuotaLabel(q.name) || "Credits"}
+          <span className="truncate leading-none">{formatQuotaLabel(q.name) || "Credits"}</span>
         </span>
-        <span className="text-[11px] font-bold tabular-nums" style={{ color: colors.text }}>
+        <span
+          className="inline-flex h-5 shrink-0 items-center text-[11px] font-bold leading-none tabular-nums"
+          style={{ color: colors.text }}
+        >
           {sym}
           {amount}
         </span>

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/parts/QuotaCardBody.tsx
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/parts/QuotaCardBody.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { calculatePercentage, formatQuotaLabel, getBarColor, topQuotas } from "../utils";
+import { formatQuotaLabel, getBarColor, getQuotaRemainingPercentage, topQuotas } from "../utils";
 import QuotaMiniBar from "../QuotaMiniBar";
+import { translateUsageOrFallback } from "../i18nFallback";
 
 const CURRENCY_SYMBOLS: Record<string, string> = {
   USD: "$",
@@ -53,11 +54,8 @@ function QuotaRow({ q }: { q: any }) {
     );
   }
 
-  const pctRaw = q.unlimited
-    ? 100
-    : (q.remainingPercentage ?? calculatePercentage(q.used, q.total));
+  const pctRaw = getQuotaRemainingPercentage(q);
   const pct = Math.round(pctRaw);
-  const usedPct = Math.max(0, Math.min(100, 100 - pct));
   const colors = getBarColor(pct);
   const label = q.displayName || formatQuotaLabel(q.name);
 
@@ -69,7 +67,7 @@ function QuotaRow({ q }: { q: any }) {
           className="text-[11px] font-bold tabular-nums shrink-0"
           style={{ color: colors.text }}
         >
-          {q.unlimited ? "∞" : t("percentUsed", { pct: usedPct })}
+          {q.unlimited ? "∞" : translateUsageOrFallback(t, "percentLeft", `${pct}% left`, { pct })}
         </span>
       </div>
       {!q.unlimited && <QuotaMiniBar percent={pct} />}

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/parts/QuotaCardExpanded.tsx
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/parts/QuotaCardExpanded.tsx
@@ -43,14 +43,22 @@ function QuotaDetailRow({ q }: { q: any }) {
       maximumFractionDigits: 2,
     });
     return (
-      <div className="flex items-center justify-between gap-2 py-1">
-        <span className="text-[12px] font-medium text-text-main flex items-center gap-1.5">
-          <span className="material-symbols-outlined text-[14px]" style={{ color: colors.text }}>
-            paid
+      <div className="flex min-h-[34px] items-center justify-between gap-2 py-1">
+        <span className="flex min-w-0 flex-1 items-center gap-1.5 text-[12px] font-medium leading-none text-text-main">
+          <span className="inline-flex size-6 shrink-0 items-center justify-center">
+            <span
+              className="material-symbols-outlined text-[15px] leading-none"
+              style={{ color: colors.text }}
+            >
+              paid
+            </span>
           </span>
-          {formatQuotaLabel(q.name) || "Credits"}
+          <span className="truncate leading-none">{formatQuotaLabel(q.name) || "Credits"}</span>
         </span>
-        <span className="text-[12px] font-bold tabular-nums" style={{ color: colors.text }}>
+        <span
+          className="inline-flex h-6 shrink-0 items-center text-[12px] font-bold leading-none tabular-nums"
+          style={{ color: colors.text }}
+        >
           {sym}
           {amount}
         </span>

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/parts/QuotaCardExpanded.tsx
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/parts/QuotaCardExpanded.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { calculatePercentage, formatCountdown, formatQuotaLabel, getBarColor } from "../utils";
+import {
+  formatCountdown,
+  formatQuotaLabel,
+  getBarColor,
+  getQuotaRemainingPercentage,
+  shouldShowQuotaUsageCount,
+} from "../utils";
 import QuotaMiniBar from "../QuotaMiniBar";
 import { translateUsageOrFallback, type UsageTranslationValues } from "../i18nFallback";
 
@@ -24,6 +30,7 @@ interface Props {
   onRefresh: () => void;
   onOpenCutoff: () => void;
   canEditCutoff: boolean;
+  hasCutoffOverrides: boolean;
 }
 
 function QuotaDetailRow({ q }: { q: any }) {
@@ -51,17 +58,14 @@ function QuotaDetailRow({ q }: { q: any }) {
     );
   }
 
-  const pctRaw = q.unlimited
-    ? 100
-    : (q.remainingPercentage ?? calculatePercentage(q.used, q.total));
+  const pctRaw = getQuotaRemainingPercentage(q);
   const pct = Math.round(pctRaw);
-  const usedPct = Math.max(0, Math.min(100, 100 - pct));
   const colors = getBarColor(pct);
   const cd = formatCountdown(q.resetAt);
   const label = q.displayName || formatQuotaLabel(q.name);
   const usedNum = Number(q.used || 0);
   const totalNum = Number(q.total || 0);
-  const showUsage = totalNum > 0 && !q.unlimited;
+  const showUsage = shouldShowQuotaUsageCount(q);
 
   return (
     <div className="flex flex-col gap-1 py-1" title={q.modelKey || q.name}>
@@ -71,7 +75,7 @@ function QuotaDetailRow({ q }: { q: any }) {
           className="text-[12px] font-bold tabular-nums shrink-0"
           style={{ color: colors.text }}
         >
-          {q.unlimited ? "∞" : t("percentUsed", { pct: usedPct })}
+          {q.unlimited ? "∞" : translateUsageOrFallback(t, "percentLeft", `${pct}% left`, { pct })}
         </span>
       </div>
       {!q.unlimited && <QuotaMiniBar percent={pct} size="sm" />}
@@ -102,6 +106,7 @@ export default function QuotaCardExpanded({
   onRefresh,
   onOpenCutoff,
   canEditCutoff,
+  hasCutoffOverrides,
 }: Props) {
   const t = useTranslations("usage");
   const tr = (key: string, fallback: string, values?: UsageTranslationValues) =>
@@ -163,7 +168,9 @@ export default function QuotaCardExpanded({
               e.stopPropagation();
               onOpenCutoff();
             }}
-            className="inline-flex items-center gap-1 text-[11px] font-medium px-2 py-1 rounded-md border border-border bg-bg-subtle hover:bg-black/[0.04] dark:hover:bg-white/[0.04] disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
+            className={`inline-flex items-center gap-1 text-[11px] font-medium px-2 py-1 rounded-md border bg-bg-subtle hover:bg-black/[0.04] dark:hover:bg-white/[0.04] disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer ${
+              hasCutoffOverrides ? "border-primary/40 text-primary" : "border-border"
+            }`}
           >
             <span className="material-symbols-outlined text-[12px]">tune</span>
             {tr("editCutoffs", "Edit cutoffs")}

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/parts/QuotaCardHeader.tsx
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/parts/QuotaCardHeader.tsx
@@ -4,8 +4,15 @@ import { useTranslations } from "next-intl";
 import Badge from "@/shared/components/Badge";
 import ProviderIcon from "@/shared/components/ProviderIcon";
 import { pickDisplayValue } from "@/shared/utils/maskEmail";
-import { STATUS_EMOJI, formatCountdown, type CardStatus } from "../utils";
+import { formatCountdown, type CardStatus } from "../utils";
 import { translateUsageOrFallback } from "../i18nFallback";
+
+const STATUS_DOT_CLASS: Record<CardStatus, string> = {
+  critical: "bg-rose-500 shadow-[0_0_0_2px_rgba(244,63,94,0.16)]",
+  alert: "bg-amber-400 shadow-[0_0_0_2px_rgba(251,191,36,0.2)]",
+  ok: "bg-emerald-500 shadow-[0_0_0_2px_rgba(16,185,129,0.18)]",
+  empty: "bg-slate-300 shadow-[0_0_0_2px_rgba(148,163,184,0.18)]",
+};
 
 interface Props {
   connection: any;
@@ -63,40 +70,41 @@ export default function QuotaCardHeader({
   const tokenExpiryTitle = hasTokenExpiry ? new Date(tokenExpiryMs).toLocaleString() : undefined;
 
   return (
-    <div className="flex items-start justify-between gap-2 px-3 pt-2.5 pb-1.5">
-      <div className="flex items-start gap-2 min-w-0 flex-1">
+    <div className="flex min-h-[62px] items-center justify-between gap-2 px-3 py-2">
+      <div className="flex min-w-0 flex-1 items-center gap-2">
         <span
-          className="text-[14px] leading-none mt-0.5 shrink-0"
+          className="inline-flex size-7 shrink-0 items-center justify-center"
           title={cardStatus}
           aria-label={cardStatus}
         >
-          {STATUS_EMOJI[cardStatus]}
+          <span className={`block size-3.5 rounded-full ${STATUS_DOT_CLASS[cardStatus]}`} />
         </span>
-        <div className="size-6 rounded-md flex items-center justify-center overflow-hidden shrink-0">
+        <div className="flex size-7 shrink-0 items-center justify-center overflow-hidden rounded-md">
           <ProviderIcon providerId={connection.provider} size={24} type="color" />
         </div>
-        <div className="flex flex-col min-w-0 flex-1">
-          <div className="flex items-center gap-1.5 min-w-0">
+        <div className="flex min-w-0 flex-1 flex-col justify-center">
+          <div className="flex h-4 min-w-0 items-center gap-1.5">
             <span
-              className="text-[12px] font-semibold text-text-main truncate"
+              className="truncate text-[12px] font-semibold leading-4 text-text-main"
               title={providerLabel}
             >
               {providerLabel}
             </span>
             <span
+              className="inline-flex h-4 shrink-0 items-center"
               title={
                 resolvedPlan
                   ? t("rawPlanWithValue", { plan: resolvedPlan })
                   : t("noPlanFromProvider")
               }
             >
-              <Badge variant={tierMeta.variant} size="sm" dot className="h-4 leading-none">
+              <Badge variant={tierMeta.variant} size="sm" dot className="h-4 px-1.5 py-0 leading-4">
                 {tierMeta.label}
               </Badge>
             </span>
             {hasStaleData && (
               <span
-                className="material-symbols-outlined text-[12px] text-amber-500 shrink-0"
+                className="material-symbols-outlined shrink-0 text-[12px] leading-4 text-amber-500"
                 title={t("staleQuotaTooltip")}
               >
                 schedule
@@ -116,7 +124,7 @@ export default function QuotaCardHeader({
           )}
         </div>
       </div>
-      <div className="flex items-center gap-0.5 shrink-0">
+      <div className="flex shrink-0 items-center gap-0.5 self-center">
         <button
           type="button"
           disabled={togglingActive}

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/parts/QuotaCardHeader.tsx
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/parts/QuotaCardHeader.tsx
@@ -15,11 +15,6 @@ interface Props {
   resolvedPlan: string | null;
   emailsVisible: boolean;
   hasStaleData: boolean;
-  /** Disabled when loading. */
-  refreshing: boolean;
-  onRefresh: () => void;
-  onOpenCutoff: () => void;
-  hasCutoffOverrides: boolean;
   /** Toggle the connection's active state (routing on/off). */
   onToggleActive: (nextActive: boolean) => void;
   /** True while the active-state PUT is in flight. */
@@ -34,10 +29,6 @@ export default function QuotaCardHeader({
   resolvedPlan,
   emailsVisible,
   hasStaleData,
-  refreshing,
-  onRefresh,
-  onOpenCutoff,
-  hasCutoffOverrides,
   onToggleActive,
   togglingActive,
 }: Props) {
@@ -142,36 +133,6 @@ export default function QuotaCardHeader({
         >
           <span className="material-symbols-outlined text-[14px]">
             {isActive ? "toggle_on" : "toggle_off"}
-          </span>
-        </button>
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation();
-            onOpenCutoff();
-          }}
-          title={t("quotaCutoffsButtonHelp")}
-          className={`p-1 rounded-md cursor-pointer transition-colors hover:bg-black/[0.04] dark:hover:bg-white/[0.04] ${
-            hasCutoffOverrides ? "text-primary" : "text-text-muted"
-          }`}
-        >
-          <span className="material-symbols-outlined text-[14px]">tune</span>
-        </button>
-        <button
-          type="button"
-          disabled={refreshing}
-          onClick={(e) => {
-            e.stopPropagation();
-            if (refreshing) return;
-            onRefresh();
-          }}
-          title={t("refreshQuota")}
-          className="p-1 rounded-md text-text-muted cursor-pointer transition-colors hover:bg-black/[0.04] dark:hover:bg-white/[0.04] disabled:opacity-40 disabled:cursor-not-allowed"
-        >
-          <span
-            className={`material-symbols-outlined text-[14px] ${refreshing ? "animate-spin" : ""}`}
-          >
-            refresh
           </span>
         </button>
       </div>

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.tsx
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.tsx
@@ -253,6 +253,8 @@ export function parseQuotaData(provider, data) {
               normalizeQuotaEntry(name, quota, {
                 displayName: quota?.displayName,
                 details: Array.isArray(quota?.details) ? quota.details : undefined,
+                isPercentageOnly:
+                  Number(quota?.total || 0) === 100 && quota?.remainingPercentage !== undefined,
               })
             );
           });
@@ -290,6 +292,7 @@ export function parseQuotaData(provider, data) {
             normalizedQuotas.push(
               normalizeQuotaEntry(modelKey, quota, {
                 modelKey: modelKey,
+                isPercentageOnly: quota?.fractionReported === true,
                 ...(quota?.quotaSource ? { quotaSource: quota.quotaSource } : {}),
                 ...(quota?.fractionReported !== undefined
                   ? { fractionReported: quota.fractionReported }
@@ -303,7 +306,11 @@ export function parseQuotaData(provider, data) {
       case "codex":
         if (data.quotas) {
           Object.entries(data.quotas).forEach(([quotaType, quota]: [string, any]) => {
-            normalizedQuotas.push(normalizeQuotaEntry(quotaType, quota));
+            normalizedQuotas.push(
+              normalizeQuotaEntry(quotaType, quota, {
+                isPercentageOnly: true,
+              })
+            );
           });
         }
         break;
@@ -329,7 +336,11 @@ export function parseQuotaData(provider, data) {
           });
         } else if (data.quotas) {
           Object.entries(data.quotas).forEach(([name, quota]: [string, any]) => {
-            normalizedQuotas.push(normalizeQuotaEntry(name, quota));
+            normalizedQuotas.push(
+              normalizeQuotaEntry(name, quota, {
+                isPercentageOnly: true,
+              })
+            );
           });
         }
         break;
@@ -575,9 +586,7 @@ const QUOTA_BAR_GREEN_THRESHOLD = 50;
 const QUOTA_BAR_YELLOW_THRESHOLD = 20;
 
 function quotaRemainingPercent(q: any): number {
-  if (q?.unlimited) return 100;
-  if (q?.remainingPercentage !== undefined) return Number(q.remainingPercentage);
-  return calculatePercentage(q?.used, q?.total);
+  return getQuotaRemainingPercentage(q);
 }
 
 function quotaStatus(q: any): "critical" | "alert" | "ok" {
@@ -613,6 +622,21 @@ export function topQuotas(quotas: any[], n = 3): any[] {
       return quotaRemainingPercent(a) - quotaRemainingPercent(b);
     })
     .slice(0, n);
+}
+
+export function getQuotaRemainingPercentage(q: any): number {
+  if (q?.unlimited) return 100;
+  if (q?.remainingPercentage !== undefined) return Number(q.remainingPercentage);
+  return calculatePercentage(q?.used, q?.total);
+}
+
+export function isPercentageOnlyQuota(q: any): boolean {
+  return q?.isPercentageOnly === true || q?.fractionReported === true;
+}
+
+export function shouldShowQuotaUsageCount(q: any): boolean {
+  const total = Number(q?.total || 0);
+  return total > 0 && q?.unlimited !== true && !isPercentageOnlyQuota(q);
 }
 
 export function getBarColor(remainingPercentage: number): {

--- a/tests/unit/provider-limits-ui.test.ts
+++ b/tests/unit/provider-limits-ui.test.ts
@@ -110,6 +110,35 @@ test("remaining percentage helpers reflect remaining quota and stale resets refi
   assert.equal(providerLimitUtils.calculatePercentage(parsed[0].used, parsed[0].total), 100);
 });
 
+test("percentage-only quotas hide redundant usage counts while counted quotas keep them", () => {
+  const codex = providerLimitUtils.parseQuotaData("codex", {
+    quotas: {
+      session: { used: 7, total: 100, remainingPercentage: 93 },
+      weekly: { used: 28, total: 100, remainingPercentage: 72 },
+    },
+  });
+
+  assert.equal(codex.length, 2);
+  assert.equal(codex[0].isPercentageOnly, true);
+  assert.equal(providerLimitUtils.shouldShowQuotaUsageCount(codex[0]), false);
+  assert.equal(providerLimitUtils.shouldShowQuotaUsageCount(codex[1]), false);
+
+  const counted = providerLimitUtils.parseQuotaData("kimi-coding", {
+    quotas: {
+      Weekly: {
+        used: 28,
+        total: 100,
+        remaining: 72,
+        remainingPercentage: 72,
+      },
+    },
+  });
+
+  assert.equal(counted.length, 1);
+  assert.equal(counted[0].isPercentageOnly, undefined);
+  assert.equal(providerLimitUtils.shouldShowQuotaUsageCount(counted[0]), true);
+});
+
 test("quota labels normalize session and weekly windows while preserving readable titles", () => {
   assert.equal(providerLimitUtils.formatQuotaLabel("session"), "Session");
   assert.equal(providerLimitUtils.formatQuotaLabel("session (5h)"), "Session");

--- a/tests/unit/quota-deactivate-toggle.test.ts
+++ b/tests/unit/quota-deactivate-toggle.test.ts
@@ -27,6 +27,10 @@ test("QuotaCardHeader renders a toggle that flips the current active state", () 
   assert.match(header, /toggle_on/, "active state icon");
   assert.match(header, /toggle_off/, "inactive state icon");
   assert.match(header, /disabled=\{togglingActive\}/, "disabled while the PUT is in flight");
+  assert.doesNotMatch(header, /onOpenCutoff/, "cutoff control lives in the expanded footer");
+  assert.doesNotMatch(header, /onRefresh/, "refresh control lives in the expanded footer");
+  assert.doesNotMatch(header, />\s*tune\s*</, "top action rail should not render tune");
+  assert.doesNotMatch(header, />\s*refresh\s*</, "top action rail should not render refresh");
 });
 
 test("QuotaCard dims the card and threads the toggle props through", () => {


### PR DESCRIPTION
## Summary
- Show quota card percentages as remaining quota and hide redundant counts for percentage-only provider windows.
- Keep counted quota windows visible and move cutoff/refresh controls out of the card header.
- Widen Provider Limits cards at common dashboard breakpoints.

## Validation
- node --import tsx/esm --test tests/unit/provider-limits-ui.test.ts tests/unit/quota-deactivate-toggle.test.ts
- npx eslint src/app/(dashboard)/dashboard/usage/components/ProviderLimits/ProviderLimitCard.tsx src/app/(dashboard)/dashboard/usage/components/ProviderLimits/QuotaCard.tsx src/app/(dashboard)/dashboard/usage/components/ProviderLimits/QuotaCardGrid.tsx src/app/(dashboard)/dashboard/usage/components/ProviderLimits/QuotaProgressBar.tsx src/app/(dashboard)/dashboard/usage/components/ProviderLimits/QuotaTable.tsx src/app/(dashboard)/dashboard/usage/components/ProviderLimits/parts/QuotaCardBody.tsx src/app/(dashboard)/dashboard/usage/components/ProviderLimits/parts/QuotaCardExpanded.tsx src/app/(dashboard)/dashboard/usage/components/ProviderLimits/parts/QuotaCardHeader.tsx src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.tsx tests/unit/provider-limits-ui.test.ts tests/unit/quota-deactivate-toggle.test.ts
- npm run typecheck:core
- Local dashboard check with mocked provider-limit cache data