### PR TITLE
feat: add sidebar group separator toggles

### DIFF
--- a/docs/guides/FEATURES.md
+++ b/docs/guides/FEATURES.md
@@ -115,7 +115,7 @@ Customizable color themes for the entire dashboard. Choose from 7 preset colors 
 Comprehensive settings panel with **7 tabs**:
 
 - **General** — System storage, backup management (export/import database)
-- **Appearance** — Theme selector (dark/light/system), color theme presets and custom colors, health log visibility, sidebar item visibility controls, Endpoint tunnel visibility controls
+- **Appearance** — Theme selector (dark/light/system), color theme presets and custom colors, health log visibility, sidebar item and group separator visibility controls, Endpoint tunnel visibility controls
 - **AI** — AI assistant features, default routing presets (Auto Combo `auto/coding`, `auto/fast`, `auto/cheap`, `auto/smart`), reasoning replay cache, and skill/memory toggles
 - **Security** — API endpoint protection, custom provider blocking, IP filtering, session info
 - **Routing** — Model aliases, background task degradation, manifest-aware tier routing (W1–W4), `fallbackDelayMs`, per-session sticky routing

--- a/src/app/(dashboard)/dashboard/settings/components/SidebarTab.tsx
+++ b/src/app/(dashboard)/dashboard/settings/components/SidebarTab.tsx
@@ -20,6 +20,12 @@ import { Card, Toggle } from "@/shared/components";
 import { cn } from "@/shared/utils/cn";
 import { useTranslations } from "next-intl";
 import {
+  HIDDEN_SIDEBAR_GROUP_LABELS_SETTING_KEY,
+  HIDEABLE_SIDEBAR_GROUP_IDS,
+  normalizeHiddenSidebarGroupLabels,
+  type HideableSidebarGroupId,
+} from "@/shared/constants/sidebarGroupVisibility";
+import {
   HIDDEN_SIDEBAR_ITEMS_SETTING_KEY,
   SIDEBAR_SECTION_ORDER_KEY,
   SIDEBAR_ITEM_ORDER_KEY,
@@ -29,7 +35,6 @@ import {
   SIDEBAR_PRESETS,
   applySectionOrder,
   applyItemOrder,
-  getSectionItems,
   normalizeHiddenSidebarItems,
   type HideableSidebarItemId,
   type SidebarSectionId,
@@ -46,8 +51,10 @@ import {
 interface SortableSectionProps {
   section: SidebarSectionDefinition & { title: string };
   hiddenSet: Set<HideableSidebarItemId>;
+  hiddenGroupLabelsSet: Set<HideableSidebarGroupId>;
   itemOrder: string[];
   onToggleItem: (id: HideableSidebarItemId) => void;
+  onToggleGroupLabel: (id: HideableSidebarGroupId) => void;
   onItemReorder: (sectionId: SidebarSectionId, newOrder: string[]) => void;
   getLabel: (key: string, fallback: string) => string;
 }
@@ -55,8 +62,10 @@ interface SortableSectionProps {
 function SortableSection({
   section,
   hiddenSet,
+  hiddenGroupLabelsSet,
   itemOrder,
   onToggleItem,
+  onToggleGroupLabel,
   onItemReorder,
   getLabel,
 }: SortableSectionProps) {
@@ -140,7 +149,9 @@ function SortableSection({
                       <GroupRow
                         group={group}
                         hiddenSet={hiddenSet}
+                        hiddenGroupLabelsSet={hiddenGroupLabelsSet}
                         onToggleItem={onToggleItem}
+                        onToggleGroupLabel={onToggleGroupLabel}
                         getLabel={getLabel}
                       />
                     </SortableChildRow>
@@ -237,33 +248,59 @@ function ItemRow({ item, hiddenSet, onToggleItem, getLabel }: ItemRowProps) {
 interface GroupRowProps {
   group: SidebarItemGroup;
   hiddenSet: Set<HideableSidebarItemId>;
+  hiddenGroupLabelsSet: Set<HideableSidebarGroupId>;
   onToggleItem: (id: HideableSidebarItemId) => void;
+  onToggleGroupLabel: (id: HideableSidebarGroupId) => void;
   getLabel: (key: string, fallback: string) => string;
 }
 
-function GroupRow({ group, hiddenSet, onToggleItem, getLabel }: GroupRowProps) {
+function GroupRow({
+  group,
+  hiddenSet,
+  hiddenGroupLabelsSet,
+  onToggleItem,
+  onToggleGroupLabel,
+  getLabel,
+}: GroupRowProps) {
   const [open, setOpen] = useState(true);
+  const groupId = group.id as HideableSidebarGroupId;
+  const canToggleSeparator = HIDEABLE_SIDEBAR_GROUP_IDS.includes(groupId);
+  const separatorVisible = !hiddenGroupLabelsSet.has(groupId);
+  const separatorLabel = getLabel("groupSeparatorLabel", "Separator");
+
   return (
     <div className="w-full">
-      <button
-        onClick={() => setOpen((p) => !p)}
-        className="flex items-center gap-2 px-4 py-2.5 w-full text-left hover:bg-black/5 dark:hover:bg-white/5 transition-colors"
-      >
-        <span
-          className={cn(
-            "material-symbols-outlined text-[12px] text-text-muted/40 transition-transform",
-            open && "rotate-90"
-          )}
+      <div className="flex items-center gap-2 px-4 py-2.5 hover:bg-black/5 dark:hover:bg-white/5 transition-colors">
+        <button
+          onClick={() => setOpen((p) => !p)}
+          className="flex min-w-0 flex-1 items-center gap-2 text-left"
         >
-          chevron_right
-        </span>
-        <span className="text-[10px] font-semibold uppercase tracking-widest text-text-muted/50">
-          {getLabel(group.titleKey, group.titleFallback)}
-        </span>
-        <span className="ml-auto text-xs text-text-muted/40">
+          <span
+            className={cn(
+              "material-symbols-outlined text-[12px] text-text-muted/40 transition-transform",
+              open && "rotate-90"
+            )}
+          >
+            chevron_right
+          </span>
+          <span className="truncate text-[10px] font-semibold uppercase tracking-widest text-text-muted/50">
+            {getLabel(group.titleKey, group.titleFallback)}
+          </span>
+        </button>
+        <span className="text-xs text-text-muted/40">
           {group.items.filter((i) => !hiddenSet.has(i.id)).length}/{group.items.length}
         </span>
-      </button>
+        {canToggleSeparator && (
+          <div className="flex items-center gap-2 border-l border-border/60 pl-3">
+            <span className="text-[10px] font-medium text-text-muted/50">{separatorLabel}</span>
+            <Toggle
+              size="sm"
+              checked={separatorVisible}
+              onChange={() => onToggleGroupLabel(groupId)}
+            />
+          </div>
+        )}
+      </div>
       {open && (
         <div className="divide-y divide-border/50 pl-2">
           {group.items.map((item) => (
@@ -306,6 +343,9 @@ export default function SidebarTab() {
 
   const [loading, setLoading] = useState(true);
   const [hiddenSidebarItems, setHiddenSidebarItems] = useState<HideableSidebarItemId[]>([]);
+  const [hiddenSidebarGroupLabels, setHiddenSidebarGroupLabels] = useState<
+    HideableSidebarGroupId[]
+  >([]);
   const [sectionOrder, setSectionOrder] = useState<SidebarSectionId[]>([]);
   const [itemOrder, setItemOrder] = useState<SidebarItemOrder>({});
   const [activePreset, setActivePreset] = useState<SidebarPresetId | null>(null);
@@ -318,6 +358,9 @@ export default function SidebarTab() {
       .then((data) => {
         setHiddenSidebarItems(
           normalizeHiddenSidebarItems(data?.[HIDDEN_SIDEBAR_ITEMS_SETTING_KEY])
+        );
+        setHiddenSidebarGroupLabels(
+          normalizeHiddenSidebarGroupLabels(data?.[HIDDEN_SIDEBAR_GROUP_LABELS_SETTING_KEY])
         );
         setSectionOrder(
           Array.isArray(data?.[SIDEBAR_SECTION_ORDER_KEY]) ? data[SIDEBAR_SECTION_ORDER_KEY] : []
@@ -364,6 +407,16 @@ export default function SidebarTab() {
   };
 
   const hiddenSet = new Set(hiddenSidebarItems);
+  const hiddenGroupLabelsSet = new Set(hiddenSidebarGroupLabels);
+
+  const toggleGroupLabel = (id: HideableSidebarGroupId) => {
+    const next = hiddenSidebarGroupLabels.includes(id)
+      ? hiddenSidebarGroupLabels.filter((x) => x !== id)
+      : [...hiddenSidebarGroupLabels, id];
+    setHiddenSidebarGroupLabels(next);
+    setActivePreset(null);
+    patch({ [HIDDEN_SIDEBAR_GROUP_LABELS_SETTING_KEY]: next, [SIDEBAR_PRESET_KEY]: null });
+  };
 
   const visibleSections = SIDEBAR_SECTIONS.filter((s) => s.visibility !== "debug" || showDebug).map(
     (s) => ({ ...s, title: getLabel(s.titleKey, s.titleFallback) })
@@ -400,12 +453,14 @@ export default function SidebarTab() {
     // Ensure protected items are never hidden, even if a preset includes them
     const safeHidden = preset.hiddenItems.filter((id) => !PROTECTED_ITEM_IDS.has(id));
     setHiddenSidebarItems(safeHidden);
+    setHiddenSidebarGroupLabels([]);
     setSectionOrder([]);
     setItemOrder({});
     setActivePreset(presetId);
     setConfirmPreset(null);
     patch({
       [HIDDEN_SIDEBAR_ITEMS_SETTING_KEY]: safeHidden,
+      [HIDDEN_SIDEBAR_GROUP_LABELS_SETTING_KEY]: [],
       [SIDEBAR_SECTION_ORDER_KEY]: [],
       [SIDEBAR_ITEM_ORDER_KEY]: {},
       [SIDEBAR_PRESET_KEY]: presetId,
@@ -493,6 +548,7 @@ export default function SidebarTab() {
                     if (
                       activePreset !== null ||
                       hiddenSidebarItems.length > 0 ||
+                      hiddenSidebarGroupLabels.length > 0 ||
                       sectionOrder.length > 0
                     ) {
                       setConfirmPreset(preset.id);
@@ -593,8 +649,10 @@ export default function SidebarTab() {
                     key={section.id}
                     section={section}
                     hiddenSet={hiddenSet}
+                    hiddenGroupLabelsSet={hiddenGroupLabelsSet}
                     itemOrder={itemOrder[section.id as SidebarSectionId] ?? []}
                     onToggleItem={toggleItem}
+                    onToggleGroupLabel={toggleGroupLabel}
                     onItemReorder={handleItemReorder}
                     getLabel={getLabel}
                   />

--- a/src/app/api/settings/__tests__/settings.test.ts
+++ b/src/app/api/settings/__tests__/settings.test.ts
@@ -29,6 +29,7 @@ describe("PATCH /api/settings", () => {
     (getSettings as any).mockResolvedValue({
       debugMode: false,
       hiddenSidebarItems: [],
+      hiddenSidebarGroupLabels: [],
       comboConfigMode: "guided",
     });
     // Mock updateSettings to merge updates into the original
@@ -61,6 +62,17 @@ describe("PATCH /api/settings", () => {
     expect(updateSettings).toHaveBeenCalledOnce();
     const calledWith = (updateSettings as any).mock.calls[0][0];
     expect(calledWith.hiddenSidebarItems).toEqual([]);
+  });
+
+  it("updates hiddenSidebarGroupLabels via PATCH", async () => {
+    const req = createPatchRequest({ hiddenSidebarGroupLabels: ["logs", "audit"] });
+    const res = await PATCH(req as any);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.hiddenSidebarGroupLabels).toEqual(["logs", "audit"]);
+    expect(updateSettings).toHaveBeenCalledOnce();
+    const calledWith = (updateSettings as any).mock.calls[0][0];
+    expect(calledWith.hiddenSidebarGroupLabels).toEqual(["logs", "audit"]);
   });
 
   it("updates comboConfigMode via PATCH", async () => {

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -107,6 +107,7 @@
  * @property {string} [corsOrigins] - Allowed CORS origins
  * @property {boolean} [call_log_pipeline_enabled] - Whether per-request pipeline capture is enabled
  * @property {string[]} [hiddenSidebarItems] - Sidebar entry ids hidden for visual decluttering
+ * @property {string[]} [hiddenSidebarGroupLabels] - Sidebar group separator labels hidden from navigation
  */
 
 /**

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1110,7 +1110,8 @@
     "dragReorderSection": "Drag to reorder section",
     "dragReorderItem": "Drag to reorder",
     "cannotHide": "This item cannot be hidden",
-    "alwaysVisible": "Always visible"
+    "alwaysVisible": "Always visible",
+    "groupSeparatorLabel": "Separator"
   },
   "webhooks": {
     "title": "Webhooks",

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -1102,7 +1102,8 @@
     "dragReorderSection": "拖拽以重新排序分区",
     "dragReorderItem": "拖拽以重新排序",
     "cannotHide": "此项无法隐藏",
-    "alwaysVisible": "始终可见"
+    "alwaysVisible": "始终可见",
+    "groupSeparatorLabel": "隔断"
   },
   "webhooks": {
     "title": "Webhook",

--- a/src/lib/db/settings.ts
+++ b/src/lib/db/settings.ts
@@ -111,6 +111,7 @@ export async function getSettings() {
     mcpEnabled: false,
     a2aEnabled: false,
     hiddenSidebarItems: [],
+    hiddenSidebarGroupLabels: [],
     sidebarSectionOrder: [],
     sidebarItemOrder: {},
     sidebarActivePreset: null,
@@ -1139,8 +1140,7 @@ export async function getCacheTrend(hours = 24): Promise<CacheTrendPoint[]> {
 }
 
 export async function resetCacheMetrics() {
-  // No-op: cannot delete historical usage data
-  // Cache metrics are computed from usage_history, so they reflect actual request history
+  // No-op: cache metrics are computed from usage_history.
   console.warn(
     "resetCacheMetrics is deprecated - cache metrics are now computed from usage_history"
   );

--- a/src/shared/components/Sidebar.tsx
+++ b/src/shared/components/Sidebar.tsx
@@ -12,12 +12,15 @@ import { ConfirmModal } from "./Modal";
 import CloudSyncStatus from "./CloudSyncStatus";
 import { useTranslations } from "next-intl";
 import {
+  HIDDEN_SIDEBAR_GROUP_LABELS_SETTING_KEY,
+  normalizeHiddenSidebarGroupLabels,
+} from "@/shared/constants/sidebarGroupVisibility";
+import {
   HIDDEN_SIDEBAR_ITEMS_SETTING_KEY,
   SIDEBAR_SETTINGS_UPDATED_EVENT,
   SIDEBAR_SECTION_ORDER_KEY,
   SIDEBAR_ITEM_ORDER_KEY,
   SIDEBAR_SECTIONS,
-  getSectionItems,
   normalizeHiddenSidebarItems,
   applySectionOrder,
   applyItemOrder,
@@ -75,6 +78,7 @@ export default function Sidebar({
   const [isDisconnected, setIsDisconnected] = useState(false);
   const [showDebug, setShowDebug] = useState(false);
   const [hiddenSidebarItems, setHiddenSidebarItems] = useState<string[]>([]);
+  const [hiddenSidebarGroupLabels, setHiddenSidebarGroupLabels] = useState<string[]>([]);
   const [sidebarSectionOrder, setSidebarSectionOrder] = useState<SidebarSectionId[]>([]);
   const [sidebarItemOrder, setSidebarItemOrder] = useState<SidebarItemOrder>({});
   const [customAppName, setCustomAppName] = useState<string | null>(null);
@@ -117,6 +121,9 @@ export default function Sidebar({
     const applySettings = (data) => {
       setShowDebug(data?.debugMode === true);
       setHiddenSidebarItems(normalizeHiddenSidebarItems(data?.[HIDDEN_SIDEBAR_ITEMS_SETTING_KEY]));
+      setHiddenSidebarGroupLabels(
+        normalizeHiddenSidebarGroupLabels(data?.[HIDDEN_SIDEBAR_GROUP_LABELS_SETTING_KEY])
+      );
       setCustomAppName(data?.instanceName || null);
       setCustomLogo(data?.customLogoBase64 || data?.customLogoUrl || null);
     };
@@ -140,6 +147,11 @@ export default function Sidebar({
       if (HIDDEN_SIDEBAR_ITEMS_SETTING_KEY in detail) {
         setHiddenSidebarItems(
           normalizeHiddenSidebarItems(detail[HIDDEN_SIDEBAR_ITEMS_SETTING_KEY])
+        );
+      }
+      if (HIDDEN_SIDEBAR_GROUP_LABELS_SETTING_KEY in detail) {
+        setHiddenSidebarGroupLabels(
+          normalizeHiddenSidebarGroupLabels(detail[HIDDEN_SIDEBAR_GROUP_LABELS_SETTING_KEY])
         );
       }
       if (SIDEBAR_SECTION_ORDER_KEY in detail && Array.isArray(detail[SIDEBAR_SECTION_ORDER_KEY])) {
@@ -184,6 +196,7 @@ export default function Sidebar({
   };
 
   const hiddenSidebarSet = new Set(hiddenSidebarItems);
+  const hiddenSidebarGroupLabelsSet = new Set(hiddenSidebarGroupLabels);
 
   const orderedSections = applySectionOrder(
     SIDEBAR_SECTIONS.filter((section) => section.visibility !== "debug" || showDebug),
@@ -209,9 +222,11 @@ export default function Sidebar({
             return {
               ...child,
               title: getSidebarLabel(child.titleKey, child.titleFallback),
+              separatorHidden: hiddenSidebarGroupLabelsSet.has(child.id),
               items,
             } as SidebarItemGroup & {
               title: string;
+              separatorHidden: boolean;
               items: (SidebarItemDefinition & { label: string })[];
             };
           }
@@ -578,15 +593,17 @@ export default function Sidebar({
                     {section.children.map((child: any) => {
                       if (child.type === "group") {
                         if (child.items.length === 0) return null;
+                        const separatorHidden = child.separatorHidden === true;
                         return (
-                          <div key={child.id} className="mt-2">
-                            {/* Visual sub-group separator */}
-                            <div className="flex items-center gap-1.5 px-2 py-0.5 mb-0.5">
-                              <div className="h-px flex-1 bg-black/8 dark:bg-white/8" />
-                              <span className="text-[8px] font-semibold text-text-muted/40 uppercase tracking-widest">
-                                {child.title}
-                              </span>
-                            </div>
+                          <div key={child.id} className={separatorHidden ? "mt-0.5" : "mt-2"}>
+                            {!separatorHidden && (
+                              <div className="flex items-center gap-1.5 px-2 py-0.5 mb-0.5">
+                                <div className="h-px flex-1 bg-black/8 dark:bg-white/8" />
+                                <span className="text-[8px] font-semibold text-text-muted/40 uppercase tracking-widest">
+                                  {child.title}
+                                </span>
+                              </div>
+                            )}
                             {child.items.map(renderNavLink)}
                           </div>
                         );

--- a/src/shared/constants/sidebarGroupVisibility.ts
+++ b/src/shared/constants/sidebarGroupVisibility.ts
@@ -1,0 +1,32 @@
+export const HIDEABLE_SIDEBAR_GROUP_IDS = [
+  "compression-context",
+  "tools",
+  "integrations",
+  "proxy",
+  "logs",
+  "audit",
+  "system",
+  "gamification",
+  "batch",
+] as const;
+
+export type HideableSidebarGroupId = (typeof HIDEABLE_SIDEBAR_GROUP_IDS)[number];
+
+export const HIDDEN_SIDEBAR_GROUP_LABELS_SETTING_KEY = "hiddenSidebarGroupLabels";
+
+export function normalizeHiddenSidebarGroupLabels(value: unknown): HideableSidebarGroupId[] {
+  if (!Array.isArray(value)) return [];
+
+  const hiddenGroups = new Set<HideableSidebarGroupId>();
+
+  for (const item of value) {
+    if (
+      typeof item === "string" &&
+      HIDEABLE_SIDEBAR_GROUP_IDS.includes(item as HideableSidebarGroupId)
+    ) {
+      hiddenGroups.add(item as HideableSidebarGroupId);
+    }
+  }
+
+  return HIDEABLE_SIDEBAR_GROUP_IDS.filter((item) => hiddenGroups.has(item));
+}

--- a/src/shared/validation/schemas.ts
+++ b/src/shared/validation/schemas.ts
@@ -7,6 +7,7 @@ import { SUPPORTED_BATCH_ENDPOINTS } from "@/shared/constants/batchEndpoints";
 import { MAX_REQUEST_BODY_LIMIT_MB, MIN_REQUEST_BODY_LIMIT_MB } from "@/shared/constants/bodySize";
 import { COMBO_CONFIG_MODES } from "@/shared/constants/comboConfigMode";
 import { providerAllowsOptionalApiKey } from "@/shared/constants/providers";
+import { HIDEABLE_SIDEBAR_GROUP_IDS } from "@/shared/constants/sidebarGroupVisibility";
 import { HIDEABLE_SIDEBAR_ITEM_IDS } from "@/shared/constants/sidebarVisibility";
 import {
   isForbiddenUpstreamHeaderName,
@@ -507,6 +508,7 @@ export const updateSettingsSchema = z.object({
   showTokenSaverOnEndpoint: z.boolean().optional(),
   bruteForceProtection: z.boolean().optional(),
   hiddenSidebarItems: z.array(z.enum(HIDEABLE_SIDEBAR_ITEM_IDS)).optional(),
+  hiddenSidebarGroupLabels: z.array(z.enum(HIDEABLE_SIDEBAR_GROUP_IDS)).optional(),
   comboConfigMode: z.enum(COMBO_CONFIG_MODES).optional(),
   codexServiceTier: z
     .object({

--- a/src/shared/validation/settingsSchemas.ts
+++ b/src/shared/validation/settingsSchemas.ts
@@ -8,6 +8,7 @@
 import { z } from "zod";
 import { COMBO_CONFIG_MODES } from "@/shared/constants/comboConfigMode";
 import { MAX_REQUEST_BODY_LIMIT_MB, MIN_REQUEST_BODY_LIMIT_MB } from "@/shared/constants/bodySize";
+import { HIDEABLE_SIDEBAR_GROUP_IDS } from "@/shared/constants/sidebarGroupVisibility";
 import { HIDEABLE_SIDEBAR_ITEM_IDS, SIDEBAR_SECTIONS } from "@/shared/constants/sidebarVisibility";
 import { ACCOUNT_FALLBACK_STRATEGY_VALUES } from "@/shared/constants/routingStrategies";
 import { RESPONSES_PREVIOUS_RESPONSE_ID_MODES } from "@/shared/constants/responsesPreviousResponseId";
@@ -71,6 +72,7 @@ export const updateSettingsSchema = z.object({
   customBannedSignals: z.array(z.string().max(200)).optional(),
   debugMode: z.boolean().optional(),
   hiddenSidebarItems: z.array(z.enum(HIDEABLE_SIDEBAR_ITEM_IDS)).optional(),
+  hiddenSidebarGroupLabels: z.array(z.enum(HIDEABLE_SIDEBAR_GROUP_IDS)).optional(),
   sidebarSectionOrder: z
     .array(z.enum(SIDEBAR_SECTIONS.map((s) => s.id) as [string, ...string[]]))
     .optional(),
@@ -332,8 +334,8 @@ export const updateSettingsSchema = z.object({
     .optional(),
 });
 
-export const databaseSettingsSchema = z.object(
-  {
+export const databaseSettingsSchema = z
+  .object({
     // Logs settings
     logs: z.object({
       detailedLogsEnabled: z.boolean(),
@@ -397,7 +399,8 @@ export const databaseSettingsSchema = z.object(
     }),
 
     // Skip location and stats as they're read-only
-}).strict();
+  })
+  .strict();
 
 export type DatabaseSettingsSchema = z.infer<typeof databaseSettingsSchema>;
 

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -1,3 +1,4 @@
+import type { HideableSidebarGroupId } from "@/shared/constants/sidebarGroupVisibility";
 import type {
   HideableSidebarItemId,
   SidebarItemOrder,
@@ -37,6 +38,7 @@ export interface Settings {
   showProviderTopologyOnHome?: boolean;
   showTokenSaverOnEndpoint?: boolean;
   hiddenSidebarItems?: HideableSidebarItemId[];
+  hiddenSidebarGroupLabels?: HideableSidebarGroupId[];
   sidebarSectionOrder?: SidebarSectionId[];
   sidebarItemOrder?: SidebarItemOrder;
   sidebarActivePreset?: SidebarPresetId;

--- a/tests/unit/db-settings-crud.test.ts
+++ b/tests/unit/db-settings-crud.test.ts
@@ -66,6 +66,7 @@ test("getSettings exposes defaults and updateSettings persists typed values", as
   assert.equal(defaults.cloudEnabled, true);
   assert.equal(defaults.requireLogin, true);
   assert.deepEqual(defaults.hiddenSidebarItems, []);
+  assert.deepEqual(defaults.hiddenSidebarGroupLabels, []);
   assert.equal(defaults.idempotencyWindowMs, 5000);
   assert.equal(defaults.requestRetry, 3);
   assert.equal(defaults.maxRetryIntervalSec, 30);
@@ -599,7 +600,8 @@ test("proxy resolution matches combo proxies through aliased model entries", asy
     apiKey: "sk-claude-alias",
   });
   // Enable proxy on this connection so legacy combo/provider proxy checks work
-  core.getDbInstance()
+  core
+    .getDbInstance()
     .prepare("UPDATE provider_connections SET proxy_enabled = 1 WHERE id = ?")
     .run((connection as any).id);
 
@@ -644,10 +646,12 @@ test("proxy resolution prefers legacy key and provider proxies over registry glo
   await proxiesDb.assignProxyToScope("global", null, registryGlobal.id);
 
   // Enable proxy on both connections so legacy key/provider proxy checks work
-  core.getDbInstance()
+  core
+    .getDbInstance()
     .prepare("UPDATE provider_connections SET proxy_enabled = 1 WHERE id = ?")
     .run((keyConnection as any).id);
-  core.getDbInstance()
+  core
+    .getDbInstance()
     .prepare("UPDATE provider_connections SET proxy_enabled = 1 WHERE id = ?")
     .run((providerConnection as any).id);
 

--- a/tests/unit/settings-api.test.ts
+++ b/tests/unit/settings-api.test.ts
@@ -108,6 +108,36 @@ describe("Settings API - persisted preferences", () => {
     });
   });
 
+  describe("hiddenSidebarGroupLabels", () => {
+    test("updateSettings with hiddenSidebarGroupLabels=['logs','audit'] succeeds", async () => {
+      const result = await harness.updateSettings({ hiddenSidebarGroupLabels: ["logs", "audit"] });
+      assert.ok(result, "updateSettings should return truthy result");
+
+      const settings = await harness.getSettings();
+      assert.deepStrictEqual(
+        settings.hiddenSidebarGroupLabels,
+        ["logs", "audit"],
+        "hiddenSidebarGroupLabels should contain logs and audit"
+      );
+    });
+
+    test("PATCH /api/settings persists hiddenSidebarGroupLabels", async () => {
+      const response = await harness.settingsRoute.PATCH(
+        await makeManagementSessionRequest("http://localhost/api/settings", {
+          method: "PATCH",
+          body: { hiddenSidebarGroupLabels: ["system"] },
+        })
+      );
+      const body = (await response.json()) as Record<string, unknown>;
+
+      assert.equal(response.status, 200);
+      assert.deepEqual(body.hiddenSidebarGroupLabels, ["system"]);
+
+      const settings = await harness.getSettings();
+      assert.deepEqual(settings.hiddenSidebarGroupLabels, ["system"]);
+    });
+  });
+
   describe("combined updates", () => {
     test("updateSettings with both debugMode and hiddenSidebarItems succeeds", async () => {
       const result = await harness.updateSettings({


### PR DESCRIPTION
## Summary

Adds independent visibility controls for sidebar group separator labels, so grouped labels like Logs, Audit, and System can be hidden without hiding the navigation items inside those groups.

## Details

- Adds a persisted `hiddenSidebarGroupLabels` setting with schema validation, defaults, normalization, and shared settings types.
- Updates the Sidebar renderer to keep grouped items visible while suppressing only the visual separator label when configured.
- Adds a Separator toggle to grouped rows in Settings -> Sidebar, alongside the existing item visibility toggles.
- Updates focused settings/sidebar tests and the feature guide note for sidebar visibility controls.

## Validation

- `node --import tsx/esm --test tests/unit/db-settings-crud.test.ts tests/unit/settings-api.test.ts`
- `node --import tsx/esm --test tests/unit/sidebar-visibility.test.ts tests/unit/sidebar-monitoring-reorg.test.ts tests/unit/settings-i18n-keys.test.ts`
- `npm run typecheck:core`
- `npm run lint` (passes with existing warnings)
- `npm run check:docs-all` (exit 0; reports existing soft doc drift warnings)
