### PR TITLE
fix(sse): preserve Kiro streaming finish_reason tool_calls (#3980)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - **fix(security): eliminate a polynomial ReDoS in the combo `<omniModel>` tag regex** — `comboAgentMiddleware`'s cache-tag pattern wrapped the tag in an unbounded newline run (`(?:\n|\r)*`), making `.test()` / `.replace()` run in O(n²) on inputs with many newlines (CodeQL `js/polynomial-redos`). The detection pattern now matches only the core `<omniModel>…</omniModel>` and the global strip pattern bounds the surrounding newline runs, keeping it linear; detection / extraction / multi-tag stripping behavior is unchanged. ([#3982](https://github.com/diegosouzapw/OmniRoute/pull/3982) — thanks @diegosouzapw)
 
+### 🐛 Fixed
+
+- **fix(kiro): preserve `finish_reason: "tool_calls"` on the Kiro streaming path** — streaming tool-call requests through the Kiro (Responses API) provider had their terminal `finish_reason` reported as `"stop"` instead of `"tool_calls"`, so agent clients (Hermes) treated the tool-call turn as a finished turn, never ran the tool, and the next request failed with HTTP 400 on the incomplete tool state. `convertKiroToOpenAI`'s terminal `messageStopEvent`/`done` branch hardcoded `finish_reason: "stop"` regardless of whether the stream had emitted `toolUseEvent`s. The translator now records `state.sawToolUse` when a tool-use chunk is emitted and reports `finish_reason: "tool_calls"` on the terminal chunk (and in `state.finishReason`) whenever the stream produced tool calls. The non-streaming path was already correct. ([#3980](https://github.com/diegosouzapw/OmniRoute/issues/3980) — thanks @lordavadon2)
+
 ---
 
 ## [3.8.26] — 2026-06-15

--- a/open-sse/translator/response/kiro-to-openai.ts
+++ b/open-sse/translator/response/kiro-to-openai.ts
@@ -120,6 +120,11 @@ export function convertKiroToOpenAI(chunk, state) {
     const toolName = toolUse.name || "";
     const toolInput = toolUse.input || {};
 
+    // #3980: record that this stream produced tool calls so the terminal
+    // event reports finish_reason: "tool_calls" instead of "stop" — otherwise
+    // agent clients (Hermes) treat the tool-call turn as finished and break.
+    state.sawToolUse = true;
+
     const openaiChunk = {
       id: state.responseId,
       object: "chat.completion.chunk",
@@ -153,7 +158,10 @@ export function convertKiroToOpenAI(chunk, state) {
 
   // Handle completion/done events
   if (eventType === "messageStopEvent" || eventType === "done" || data.messageStopEvent) {
-    state.finishReason = "stop"; // Mark for usage injection in stream.js
+    // #3980: if the stream produced tool calls, the terminal finish_reason must
+    // be "tool_calls" (OpenAI semantics), not "stop".
+    const finishReason = state.sawToolUse ? "tool_calls" : "stop";
+    state.finishReason = finishReason; // Mark for usage injection in stream.js
 
     const openaiChunk: Record<string, unknown> = {
       id: state.responseId,
@@ -164,7 +172,7 @@ export function convertKiroToOpenAI(chunk, state) {
         {
           index: 0,
           delta: {},
-          finish_reason: "stop",
+          finish_reason: finishReason,
         },
       ],
     };

--- a/tests/unit/kiro-streaming-finish-reason-3980.test.ts
+++ b/tests/unit/kiro-streaming-finish-reason-3980.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Regression test for #3980 — Kiro (Responses API) streaming tool calls:
+ * OmniRoute changed `finish_reason` from `tool_calls` to `stop`, breaking
+ * agent workflows (Hermes). The terminal `messageStopEvent` hardcoded
+ * `finish_reason: "stop"` even when the stream contained tool calls.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { convertKiroToOpenAI } = await import(
+  "../../open-sse/translator/response/kiro-to-openai.ts"
+);
+
+test("#3980 streaming tool call → terminal finish_reason is 'tool_calls'", () => {
+  const state: Record<string, unknown> = {};
+
+  // 1. Kiro emits a tool-use event (mid-stream)
+  const toolChunk = convertKiroToOpenAI(
+    {
+      _eventType: "toolUseEvent",
+      toolUseEvent: { toolUseId: "call_1", name: "ping", input: { text: "hi" } },
+    },
+    state
+  ) as { choices: { delta: Record<string, unknown>; finish_reason: unknown }[] };
+
+  assert.ok(toolChunk?.choices?.[0]?.delta?.tool_calls, "tool_calls delta should be emitted");
+  assert.equal(toolChunk.choices[0].finish_reason, null, "mid-stream finish_reason stays null");
+
+  // 2. Kiro emits the terminal stop event
+  const stopChunk = convertKiroToOpenAI({ _eventType: "messageStopEvent" }, state) as {
+    choices: { finish_reason: unknown }[];
+  };
+
+  assert.equal(
+    stopChunk.choices[0].finish_reason,
+    "tool_calls",
+    "terminal finish_reason must be 'tool_calls' when the stream produced tool calls"
+  );
+  assert.equal(
+    state.finishReason,
+    "tool_calls",
+    "state.finishReason (used for usage injection) must also be 'tool_calls'"
+  );
+});
+
+test("#3980 plain text stream → terminal finish_reason stays 'stop'", () => {
+  const state: Record<string, unknown> = {};
+
+  convertKiroToOpenAI(
+    { _eventType: "assistantResponseEvent", assistantResponseEvent: { content: "hello" } },
+    state
+  );
+
+  const stopChunk = convertKiroToOpenAI({ _eventType: "messageStopEvent" }, state) as {
+    choices: { finish_reason: unknown }[];
+  };
+
+  assert.equal(
+    stopChunk.choices[0].finish_reason,
+    "stop",
+    "no tool calls → terminal finish_reason remains 'stop'"
+  );
+  assert.equal(state.finishReason, "stop");
+});


### PR DESCRIPTION
Closes #3980

## Problem
Streaming tool-call requests through the **Kiro (Responses API)** provider had their terminal `finish_reason` reported as `"stop"` instead of `"tool_calls"`. Agent clients (Hermes) treated the tool-call turn as finished, never ran the tool, and the next request failed with HTTP 400 on incomplete tool state. Non-streaming worked.

## Root cause
`open-sse/translator/response/kiro-to-openai.ts` — the terminal `messageStopEvent`/`done` branch hardcoded `finish_reason: "stop"` (and `state.finishReason = "stop"`) regardless of whether the stream had emitted `toolUseEvent`s.

## Fix
- Record `state.sawToolUse = true` in the `toolUseEvent` branch.
- In the terminal branch, emit `finish_reason: state.sawToolUse ? "tool_calls" : "stop"` (both on the chunk and `state.finishReason`).

## Test (TDD, RED→GREEN)
`tests/unit/kiro-streaming-finish-reason-3980.test.ts`:
1. `toolUseEvent` → `messageStopEvent` ⇒ terminal `finish_reason === "tool_calls"` (RED before the fix: was `"stop"`).
2. `assistantResponseEvent` → `messageStopEvent` ⇒ terminal `finish_reason === "stop"` (unchanged).

Validated locally: test GREEN, `typecheck:core` clean, eslint clean on touched files.