### PR TITLE
feat(dashboard): real circuit-breaker state in the Combo Live cascade (U1b)

### DIFF
--- a/src/app/(dashboard)/dashboard/combos/live/ComboLiveStudio.tsx
+++ b/src/app/(dashboard)/dashboard/combos/live/ComboLiveStudio.tsx
@@ -6,8 +6,10 @@ import { FlowCanvas } from "@/shared/components/flow/FlowCanvas";
 import {
   comboRunToFlow,
   reduceComboEvent,
+  enrichRunWithBreakers,
   type ComboRunModel,
   type ComboEventInput,
+  type ProviderBreakerSnapshot,
 } from "./comboFlowModel";
 import { aggregateComboEventsToSets } from "./fleetAggregation";
 import { StrategyNode } from "./nodes/StrategyNode";
@@ -179,6 +181,13 @@ export interface ComboLiveStudioProps {
    * When false, shows the "Live disabled" banner.
    */
   isConnected?: boolean;
+  /**
+   * Per-provider circuit-breaker snapshot (`providerHealth` from
+   * GET /api/monitoring/health). When supplied, the cascade overlays the REAL
+   * breaker state (CB: OPEN · 41s) onto each target — U1b enrichment. Optional;
+   * absent → no breaker badges (graceful).
+   */
+  providerHealth?: Record<string, ProviderBreakerSnapshot> | null;
 }
 
 // ── Main component ────────────────────────────────────────────────────────
@@ -203,6 +212,7 @@ export function ComboLiveStudio({
   comboEvents = [],
   combos: combosProp,
   isConnected = true,
+  providerHealth,
 }: ComboLiveStudioProps) {
   const [mode, setMode] = useState<"single" | "fleet">("single");
   const [selectedCombo, setSelectedCombo] = useState<string>("");
@@ -215,23 +225,28 @@ export function ComboLiveStudio({
     return [...seen];
   }, [combosProp, comboEvents]);
 
-  // Build the displayed run: static prop wins; otherwise fold live events
+  // Build the displayed run: static prop wins; otherwise fold live events.
+  // Finally overlay real circuit-breaker state (U1b) — a no-op when no health.
   const displayRun = useMemo<ComboRunModel | null>(() => {
-    if (runProp !== undefined) return runProp ?? null;
-
-    if (!selectedCombo) return null;
-
-    const eventsForCombo = comboEvents
-      .filter((e) => e.comboName === selectedCombo)
-      .sort((a, b) => a.timestamp - b.timestamp);
-
-    if (eventsForCombo.length === 0) return null;
-
-    return eventsForCombo.reduce<ComboRunModel | null>(
-      (acc, ev) => reduceComboEvent(acc, ev),
-      null
-    );
-  }, [runProp, selectedCombo, comboEvents]);
+    let baseRun: ComboRunModel | null;
+    if (runProp !== undefined) {
+      baseRun = runProp ?? null;
+    } else if (!selectedCombo) {
+      baseRun = null;
+    } else {
+      const eventsForCombo = comboEvents
+        .filter((e) => e.comboName === selectedCombo)
+        .sort((a, b) => a.timestamp - b.timestamp);
+      baseRun =
+        eventsForCombo.length === 0
+          ? null
+          : eventsForCombo.reduce<ComboRunModel | null>(
+              (acc, ev) => reduceComboEvent(acc, ev),
+              null
+            );
+    }
+    return enrichRunWithBreakers(baseRun, providerHealth);
+  }, [runProp, selectedCombo, comboEvents, providerHealth]);
 
   // Build ReactFlow graph from the current run
   const { nodes, edges } = useMemo(() => {

--- a/src/app/(dashboard)/dashboard/combos/live/comboFlowModel.ts
+++ b/src/app/(dashboard)/dashboard/combos/live/comboFlowModel.ts
@@ -34,6 +34,9 @@ export type TargetState = "idle" | "attempting" | "failed" | "succeeded" | "skip
 
 export type FailKind = "rate-limit" | "circuit-open" | "cooldown" | "other";
 
+/** Provider-level circuit-breaker state, as reported by the resilience runtime. */
+export type CbState = "OPEN" | "HALF_OPEN" | "DEGRADED" | "CLOSED";
+
 export interface TargetNodeModel {
   targetIndex: number;
   provider: string;
@@ -42,6 +45,11 @@ export interface TargetNodeModel {
   latencyMs?: number;
   error?: string;
   failKind?: FailKind;
+  /** Real circuit-breaker state for this target's provider (U1b enrichment).
+   * Only set when the breaker is non-healthy (OPEN/HALF_OPEN/DEGRADED). */
+  cbState?: CbState;
+  /** Milliseconds until the breaker allows a probe again (when cbState is set). */
+  cbRetryAfterMs?: number;
 }
 
 export interface ComboRunModel {
@@ -297,6 +305,8 @@ export function comboRunToFlow(run: ComboRunModel): { nodes: Node[]; edges: Edge
         error: t.error,
         failKind: t.failKind,
         targetIndex: t.targetIndex,
+        cbState: t.cbState,
+        cbRetryAfterMs: t.cbRetryAfterMs,
       },
     });
 
@@ -340,4 +350,68 @@ export function comboRunToFlow(run: ComboRunModel): { nodes: Node[]; edges: Edge
   });
 
   return { nodes, edges };
+}
+
+// ── enrichRunWithBreakers (U1b) ───────────────────────────────────────────
+
+/**
+ * Per-provider circuit-breaker snapshot, as exposed by GET /api/monitoring/health
+ * (`providerHealth[provider]` / `providerBreakers[]`). Only the fields the cascade
+ * badge consumes.
+ */
+export interface ProviderBreakerSnapshot {
+  state?: string;
+  retryAfterMs?: number;
+}
+
+function normalizeCbState(state: string | undefined): CbState | undefined {
+  if (typeof state !== "string") return undefined;
+  const up = state.toUpperCase();
+  if (up === "OPEN" || up === "HALF_OPEN" || up === "DEGRADED" || up === "CLOSED") {
+    return up;
+  }
+  return undefined;
+}
+
+/**
+ * Overlay real circuit-breaker state onto a combo run's targets (U1b). Returns a
+ * new run (pure) only when something changed; otherwise the same reference.
+ *
+ * A badge is attached only when the breaker is non-healthy (OPEN/HALF_OPEN/
+ * DEGRADED); a CLOSED, unknown, or absent breaker clears any stale `cbState` so
+ * the cascade reflects recovery. Provider lookup is by `target.provider`.
+ *
+ * @param run            current combo run model (or null)
+ * @param providerHealth `providerHealth` map from /api/monitoring/health
+ */
+export function enrichRunWithBreakers(
+  run: ComboRunModel | null,
+  providerHealth: Record<string, ProviderBreakerSnapshot> | null | undefined
+): ComboRunModel | null {
+  if (!run) return null;
+  if (!providerHealth) return run;
+
+  let changed = false;
+  const targets = run.targets.map((target) => {
+    const snapshot = providerHealth[target.provider];
+    const cbState = normalizeCbState(snapshot?.state);
+
+    if (cbState && cbState !== "CLOSED") {
+      if (target.cbState === cbState && target.cbRetryAfterMs === snapshot?.retryAfterMs) {
+        return target;
+      }
+      changed = true;
+      return { ...target, cbState, cbRetryAfterMs: snapshot?.retryAfterMs };
+    }
+
+    // Healthy / unknown / absent → strip any stale breaker badge.
+    if (target.cbState !== undefined || target.cbRetryAfterMs !== undefined) {
+      changed = true;
+      const { cbState: _cbState, cbRetryAfterMs: _cbRetryAfterMs, ...rest } = target;
+      return rest;
+    }
+    return target;
+  });
+
+  return changed ? { ...run, targets } : run;
 }

--- a/src/app/(dashboard)/dashboard/combos/live/nodes/ProviderCascadeNode.tsx
+++ b/src/app/(dashboard)/dashboard/combos/live/nodes/ProviderCascadeNode.tsx
@@ -4,7 +4,7 @@ import { Handle, Position, type NodeProps } from "@xyflow/react";
 import ProviderIcon from "@/shared/components/ProviderIcon";
 import { StatusDot } from "@/shared/components/flow/StatusDot";
 import { FLOW_EDGE_COLORS } from "@/shared/components/flow/edgeStyles";
-import type { TargetState, FailKind } from "../comboFlowModel";
+import type { TargetState, FailKind, CbState } from "../comboFlowModel";
 
 // ── State → visual mapping ────────────────────────────────────────────────
 
@@ -43,6 +43,24 @@ const FAIL_KIND_LABELS: Record<FailKind, string> = {
   other: "error",
 };
 
+// Non-healthy circuit-breaker states → badge colour (U1b). OPEN is the hard
+// stop (red); HALF_OPEN/DEGRADED are recovering/partial (amber).
+const CB_BADGE_COLORS: Partial<Record<CbState, string>> = {
+  OPEN: FLOW_EDGE_COLORS.error,
+  HALF_OPEN: FLOW_EDGE_COLORS.last,
+  DEGRADED: FLOW_EDGE_COLORS.last,
+};
+
+/** "CB: OPEN · 41s" — the retry hint is omitted when unknown/elapsed. */
+function formatCbBadge(cbState: CbState, retryAfterMs?: number): string {
+  if (typeof retryAfterMs !== "number" || !Number.isFinite(retryAfterMs) || retryAfterMs <= 0) {
+    return `CB: ${cbState}`;
+  }
+  const seconds = Math.round(retryAfterMs / 1000);
+  const hint = seconds >= 60 ? `${Math.floor(seconds / 60)}m${seconds % 60}s` : `${seconds}s`;
+  return `CB: ${cbState} · ${hint}`;
+}
+
 // ── Node data shape ───────────────────────────────────────────────────────
 
 export interface ProviderCascadeNodeData {
@@ -54,6 +72,9 @@ export interface ProviderCascadeNodeData {
   error?: string;
   failKind?: FailKind;
   targetIndex: number;
+  /** Real circuit-breaker state for this provider (U1b); only set when non-healthy. */
+  cbState?: CbState;
+  cbRetryAfterMs?: number;
   [key: string]: unknown;
 }
 
@@ -71,7 +92,7 @@ export interface ProviderCascadeNodeData {
  * Has Left (target) and Right (source) Handles for the cascade flow.
  */
 export function ProviderCascadeNode({ data }: NodeProps) {
-  const { provider, model, state, latencyMs, failKind, targetIndex } =
+  const { provider, model, state, latencyMs, failKind, targetIndex, cbState, cbRetryAfterMs } =
     data as ProviderCascadeNodeData;
 
   const borderColor = getStateBorderColor(state as TargetState);
@@ -145,6 +166,23 @@ export function ProviderCascadeNode({ data }: NodeProps) {
             data-testid="fail-kind-badge"
           >
             {FAIL_KIND_LABELS[failKind as FailKind]}
+          </span>
+        </div>
+      )}
+
+      {/* Footer: real circuit-breaker state (U1b) — independent of target state,
+          since a provider's breaker can be OPEN while this target is skipped. */}
+      {cbState && CB_BADGE_COLORS[cbState] && (
+        <div className="px-2.5 pb-2">
+          <span
+            className="text-[9px] font-semibold px-1.5 py-0.5 rounded"
+            style={{
+              backgroundColor: `${CB_BADGE_COLORS[cbState]}20`,
+              color: CB_BADGE_COLORS[cbState],
+            }}
+            data-testid="cb-state-badge"
+          >
+            {formatCbBadge(cbState, cbRetryAfterMs)}
           </span>
         </div>
       )}

--- a/src/app/(dashboard)/dashboard/combos/live/page.tsx
+++ b/src/app/(dashboard)/dashboard/combos/live/page.tsx
@@ -2,6 +2,7 @@
 
 import { ComboLiveStudio } from "./ComboLiveStudio";
 import { useLiveComboStatus } from "@/hooks/useLiveDashboard";
+import { useProviderBreakerHealth } from "@/hooks/useProviderBreakerHealth";
 
 /**
  * Combo/Routing Studio (Tela B) — live combo cascade.
@@ -10,10 +11,13 @@ import { useLiveComboStatus } from "@/hooks/useLiveDashboard";
  * `useLiveComboStatus` and feeds the events into the studio. `LiveComboEvent` is
  * structurally compatible with the studio's `ComboEventInput`. The studio shows a
  * "Live disabled" banner + empty state when the WS feed is off, so this degrades
- * gracefully.
+ * gracefully. `useProviderBreakerHealth` overlays the real circuit-breaker state
+ * (U1b) from the monitoring health snapshot — fail-soft, so it never breaks the
+ * cascade when the endpoint is unavailable.
  */
 export default function ComboLiveStudioPage() {
   const { comboEvents, activeCombos, isConnected } = useLiveComboStatus();
+  const providerHealth = useProviderBreakerHealth();
 
   return (
     <div className="p-4 h-[calc(100dvh-6rem)] min-h-[480px]">
@@ -21,6 +25,7 @@ export default function ComboLiveStudioPage() {
         comboEvents={comboEvents}
         combos={[...activeCombos]}
         isConnected={isConnected}
+        providerHealth={providerHealth}
       />
     </div>
   );

--- a/src/hooks/useProviderBreakerHealth.ts
+++ b/src/hooks/useProviderBreakerHealth.ts
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { ProviderBreakerSnapshot } from "@/app/(dashboard)/dashboard/combos/live/comboFlowModel";
+
+const DEFAULT_POLL_MS = 5000;
+
+/**
+ * Polls `GET /api/monitoring/health` and exposes its per-provider circuit-breaker
+ * snapshot (`providerHealth: { [provider]: { state, retryAfterMs } }`).
+ *
+ * Fail-soft by design: any network/parse error keeps the last known map (or the
+ * empty default), so the Combo Live Studio (U1b) simply shows no breaker badges
+ * instead of breaking. Polls every `pollMs` and on mount.
+ */
+export function useProviderBreakerHealth(
+  pollMs = DEFAULT_POLL_MS
+): Record<string, ProviderBreakerSnapshot> {
+  const [providerHealth, setProviderHealth] = useState<
+    Record<string, ProviderBreakerSnapshot>
+  >({});
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const poll = async () => {
+      try {
+        const res = await fetch("/api/monitoring/health");
+        if (!res.ok) return;
+        const json = (await res.json()) as {
+          providerHealth?: Record<string, ProviderBreakerSnapshot>;
+        };
+        if (!cancelled && json && typeof json.providerHealth === "object" && json.providerHealth) {
+          setProviderHealth(json.providerHealth);
+        }
+      } catch {
+        // Fail-soft: keep the previous snapshot; cascade degrades to no badges.
+      }
+    };
+
+    poll();
+    const id = setInterval(poll, pollMs);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [pollMs]);
+
+  return providerHealth;
+}

--- a/tests/unit/ui/comboFlowModel-breakers.test.ts
+++ b/tests/unit/ui/comboFlowModel-breakers.test.ts
@@ -1,0 +1,110 @@
+/**
+ * tests/unit/ui/comboFlowModel-breakers.test.ts
+ *
+ * TDD for U1b — enrichRunWithBreakers: overlays REAL circuit-breaker state
+ * (from GET /api/monitoring/health → providerHealth[provider]) onto a combo run's
+ * targets, so the cascade can show "CB: OPEN · retry 41s" instead of only the
+ * error-string heuristic.
+ * Run: node --import tsx/esm --test tests/unit/ui/comboFlowModel-breakers.test.ts
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  enrichRunWithBreakers,
+  comboRunToFlow,
+  type ComboRunModel,
+  type TargetNodeModel,
+} from "../../../src/app/(dashboard)/dashboard/combos/live/comboFlowModel.ts";
+
+function mkRun(
+  targets: Array<Partial<TargetNodeModel> & { provider: string }>
+): ComboRunModel {
+  return {
+    comboName: "c",
+    strategy: "priority",
+    outcome: "running",
+    startedAt: 0,
+    targets: targets.map((t, i) => ({
+      targetIndex: i,
+      provider: t.provider,
+      model: t.model ?? "m",
+      state: t.state ?? "idle",
+      ...t,
+    })),
+  };
+}
+
+describe("enrichRunWithBreakers", () => {
+  it("returns null for a null run", () => {
+    assert.equal(enrichRunWithBreakers(null, {}), null);
+  });
+
+  it("returns the same run reference when no health map is provided", () => {
+    const run = mkRun([{ provider: "openai" }]);
+    assert.equal(enrichRunWithBreakers(run, null), run);
+    assert.equal(enrichRunWithBreakers(run, undefined), run);
+  });
+
+  it("attaches cbState + retryAfterMs for an OPEN provider breaker only", () => {
+    const run = mkRun([{ provider: "openai" }, { provider: "anthropic" }]);
+    const out = enrichRunWithBreakers(run, {
+      openai: { state: "OPEN", retryAfterMs: 41000 },
+    });
+    assert.ok(out);
+    assert.equal(out.targets[0].cbState, "OPEN");
+    assert.equal(out.targets[0].cbRetryAfterMs, 41000);
+    assert.equal(out.targets[1].cbState, undefined, "healthy/absent provider gets no badge");
+  });
+
+  it("does not attach a badge for a CLOSED (healthy) breaker", () => {
+    const run = mkRun([{ provider: "openai" }]);
+    const out = enrichRunWithBreakers(run, { openai: { state: "CLOSED", retryAfterMs: 0 } });
+    assert.equal(out?.targets[0].cbState, undefined);
+  });
+
+  it("surfaces HALF_OPEN and DEGRADED states (case-insensitive)", () => {
+    const run = mkRun([{ provider: "a" }, { provider: "b" }]);
+    const out = enrichRunWithBreakers(run, {
+      a: { state: "half_open", retryAfterMs: 5000 },
+      b: { state: "DEGRADED" },
+    });
+    assert.equal(out?.targets[0].cbState, "HALF_OPEN");
+    assert.equal(out?.targets[1].cbState, "DEGRADED");
+  });
+
+  it("does not mutate the input run (pure)", () => {
+    const run = mkRun([{ provider: "openai" }]);
+    enrichRunWithBreakers(run, { openai: { state: "OPEN", retryAfterMs: 1 } });
+    assert.equal(run.targets[0].cbState, undefined, "original run must be untouched");
+  });
+
+  it("strips a stale cbState when the breaker recovers to CLOSED", () => {
+    const run = mkRun([{ provider: "openai", cbState: "OPEN", cbRetryAfterMs: 9 }]);
+    const out = enrichRunWithBreakers(run, { openai: { state: "CLOSED" } });
+    assert.equal(out?.targets[0].cbState, undefined);
+    assert.equal(out?.targets[0].cbRetryAfterMs, undefined);
+  });
+
+  it("ignores unknown breaker state strings", () => {
+    const run = mkRun([{ provider: "openai" }]);
+    const out = enrichRunWithBreakers(run, { openai: { state: "WEIRD" } });
+    assert.equal(out?.targets[0].cbState, undefined);
+  });
+
+  it("comboRunToFlow carries cbState/cbRetryAfterMs into the target node data", () => {
+    const run = mkRun([{ provider: "openai" }, { provider: "anthropic" }]);
+    const enriched = enrichRunWithBreakers(run, {
+      openai: { state: "OPEN", retryAfterMs: 41000 },
+    });
+    const { nodes } = comboRunToFlow(enriched as ComboRunModel);
+
+    const target0 = nodes.find((n) => n.id === "target-0");
+    assert.equal(target0?.data.cbState, "OPEN");
+    assert.equal(target0?.data.cbRetryAfterMs, 41000);
+
+    const target1 = nodes.find((n) => n.id === "target-1");
+    assert.equal(target1?.data.cbState, undefined, "healthy provider node has no cbState");
+  });
+});

--- a/tests/unit/ui/providerCascadeNode.test.tsx
+++ b/tests/unit/ui/providerCascadeNode.test.tsx
@@ -181,4 +181,45 @@ describe("ProviderCascadeNode", () => {
       "claude-3-opus"
     );
   });
+
+  // ── U1b: real circuit-breaker badge ──────────────────────────────────────
+
+  it("shows the circuit-breaker badge with retry hint when cbState is OPEN", () => {
+    const container = mount(
+      <ProviderCascadeNode
+        {...makeNodeProps({ state: "skipped", cbState: "OPEN", cbRetryAfterMs: 41000 })}
+      />
+    );
+    const badge = container.querySelector("[data-testid='cb-state-badge']");
+    expect(badge).toBeTruthy();
+    expect(badge?.textContent).toContain("CB: OPEN");
+    expect(badge?.textContent).toContain("41s");
+  });
+
+  it("shows the CB badge independent of target state (idle target, HALF_OPEN breaker)", () => {
+    const container = mount(
+      <ProviderCascadeNode
+        {...makeNodeProps({ state: "idle", cbState: "HALF_OPEN", cbRetryAfterMs: 5000 })}
+      />
+    );
+    expect(
+      container.querySelector("[data-testid='cb-state-badge']")?.textContent
+    ).toContain("CB: HALF_OPEN");
+  });
+
+  it("omits the retry hint when cbRetryAfterMs is absent", () => {
+    const container = mount(
+      <ProviderCascadeNode {...makeNodeProps({ state: "skipped", cbState: "DEGRADED" })} />
+    );
+    expect(
+      container.querySelector("[data-testid='cb-state-badge']")?.textContent?.trim()
+    ).toBe("CB: DEGRADED");
+  });
+
+  it("does NOT show the CB badge when cbState is absent", () => {
+    const container = mount(
+      <ProviderCascadeNode {...makeNodeProps({ state: "failed", failKind: "other" })} />
+    );
+    expect(container.querySelector("[data-testid='cb-state-badge']")).toBeNull();
+  });
 });


### PR DESCRIPTION
## What

Combo backlog **Item 5 — U1b enrichment**. The Combo Live Studio (`/dashboard/combos/live`, shipped in #3848) already draws the routing cascade. This overlays each provider's **real circuit-breaker state** (`CB: OPEN · 41s`) onto its cascade node, instead of only inferring the failure cause from the error string.

It's pure enrichment over the **existing** `GET /api/monitoring/health` snapshot — **no backend change, no combo-engine change**.

## How

- **`enrichRunWithBreakers(run, providerHealth)`** (`comboFlowModel.ts`): pure, immutable overlay of `cbState` / `cbRetryAfterMs` onto each target by provider. Surfaces only **non-healthy** breakers (`OPEN`/`HALF_OPEN`/`DEGRADED`), strips stale badges when a breaker recovers to `CLOSED`, ignores unknown states.
- **`comboRunToFlow`** carries `cbState`/`cbRetryAfterMs` into the target node `data`.
- **`ProviderCascadeNode`** renders a CB badge (red `OPEN`, amber `HALF_OPEN`/`DEGRADED`), shown **independent of target state** — a provider's breaker can be `OPEN` while this target is `skipped`.
- **`useProviderBreakerHealth()`**: fail-soft poll of `providerHealth` from the monitoring snapshot; wired through the thin `page.tsx` wrapper into the studio. Any fetch error → no badges (graceful), never breaks the cascade.

## Tests (TDD)

- **9 node:test** (`comboFlowModel-breakers.test.ts`): enrich semantics (OPEN/HALF_OPEN/DEGRADED, CLOSED→no badge, stale-strip, purity, unknown-state) + the `comboRunToFlow` propagation into node data.
- **4 vitest** (`providerCascadeNode.test.tsx`): badge render with/without retry hint, independent of target state, absent when no `cbState`.

Validation: `typecheck:core` clean; full-app tsc unchanged vs baseline (the 3 `FlowEdgeStyle`/`CSSProperties` notes are pre-existing ReactFlow-edge typing); lint / file-size / cycles green; the 4 flow/combo UI vitest files (38 tests) stay green (no regression).

## Scope / follow-ups (deferred)

- **Per-connection cooldown** (`rateLimitedUntil` badge): the health endpoint exposes per-**provider** CB state today, not per-**connection** cooldown — that needs a small backend extension (`connectionHealth[]`) and is a separate slice.
- **Playwright e2e**: the cascade needs live combo events (WS is opt-in) + a booted server, which is flaky/heavy to make deterministic; the enrichment logic is fully TDD-covered and the badge render is covered by vitest, so the live-browser check is left to CI/VPS (UI-only, Hard Rule #18).

🤖 Generated with [Claude Code](https://claude.com/claude-code)