### PR TITLE
fix(ci): scope TIA to node:test unit files only (fix 99 false failures)

### DIFF
--- a/scripts/quality/build-test-impact-map.mjs
+++ b/scripts/quality/build-test-impact-map.mjs
@@ -53,8 +53,15 @@ function sourceDepsOf(entry) {
   return sources;
 }
 
+// Mirror EXACTLY the `npm run test:unit` glob — the curated set of node:test files.
+// The TIA step runs the selected subset via `node --test`, so it must NOT include
+// vitest files (`.test.tsx`, `open-sse/**/__tests__`, `tests/unit/autoCombo`), nor
+// e2e/integration tests, which can't run under node:test (they 99-false-failed before).
 const testFiles = globSync(
-  ["tests/**/*.test.{ts,tsx,mts}", "src/**/*.test.{ts,tsx}", "open-sse/**/*.test.{ts,tsx}"],
+  [
+    "tests/unit/*.test.ts",
+    "tests/unit/{api,auth,authz,build,cli,cli-helper,compression,correctness,cors,dashboard,db,db-adapters,docs,gamification,guardrails,lib,mcp,runtime,security,services,settings,shared,ui}/**/*.test.ts",
+  ],
   { cwd: ROOT, absolute: true }
 );
 const map = {};

--- a/scripts/quality/select-impacted-tests.mjs
+++ b/scripts/quality/select-impacted-tests.mjs
@@ -5,7 +5,13 @@ import { fileURLToPath } from "node:url";
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const HUB_RE = /(setupPolyfill|tsconfig|package\.json|package-lock\.json|\.env|vitest\.config|stryker\.conf)/;
-const TEST_RE = /\.(test|spec)\.(ts|tsx|mts)$/;
+// A changed file counts as a "run-it" test ONLY if it is a node:test unit file the TIA
+// step can actually run via `node --test` — i.e. it mirrors the `npm run test:unit` glob.
+// This EXCLUDES vitest files (`.test.tsx`, `tests/unit/autoCombo/**`), e2e and integration
+// tests, and `src/**/__tests__`/`open-sse/**/__tests__`, which can't run under node:test.
+const UNIT_SUBDIRS =
+  "api|auth|authz|build|cli|cli-helper|compression|correctness|cors|dashboard|db|db-adapters|docs|gamification|guardrails|lib|mcp|runtime|security|services|settings|shared|ui";
+const TEST_RE = new RegExp(`^tests/unit/([^/]+\\.test\\.ts$|(${UNIT_SUBDIRS})/.*\\.test\\.ts$)`);
 
 export function selectImpacted({ changed, map }) {
   const out = new Set();

--- a/tests/unit/select-impacted-tests.test.ts
+++ b/tests/unit/select-impacted-tests.test.ts
@@ -37,3 +37,26 @@ test("unmapped source file → run all (fail-safe)", () => {
   const sel = selectImpacted({ changed: ["open-sse/brand-new-file.ts"], map: MAP });
   assert.deepEqual(sel, ["__RUN_ALL__"]);
 });
+
+// The TIA step runs selected files via `node --test`, so it must only ever select
+// node:test unit files (the `test:unit` glob). vitest/.tsx/e2e/integration changes
+// must NOT be selected — running them under node:test was the 99-false-failure bug.
+test("changed vitest UI test (.test.tsx) → NOT selected", () => {
+  const sel = selectImpacted({ changed: ["tests/unit/free-pool-tab.test.tsx"], map: MAP });
+  assert.deepEqual(sel, []);
+});
+
+test("changed e2e test → NOT selected (not a node:test unit file)", () => {
+  const sel = selectImpacted({ changed: ["tests/e2e/system-failover.test.ts"], map: MAP });
+  assert.deepEqual(sel, []);
+});
+
+test("changed vitest file in uncurated tests/unit/autoCombo → NOT selected", () => {
+  const sel = selectImpacted({ changed: ["tests/unit/autoCombo/tieredRotation.test.ts"], map: MAP });
+  assert.deepEqual(sel, []);
+});
+
+test("changed unit test in a curated subdir → run itself", () => {
+  const sel = selectImpacted({ changed: ["tests/unit/db/migration.test.ts"], map: MAP });
+  assert.deepEqual(sel, ["tests/unit/db/migration.test.ts"]);
+});


### PR DESCRIPTION
## Problem
The Fase 9 TIA harness globbed `tests/**` + `open-sse/**/__tests__` + `src/**/__tests__` test files and ran the selected subset via `node --test`. That swept in **vitest** (`.test.tsx`, `open-sse/**/__tests__`, `tests/unit/autoCombo`), **e2e**, and **integration** tests — none of which run under node:test — producing **~99 false failures** in the TIA step on PR #4030 (proven: e.g. `tests/unit/autoCombo/tieredRotation.test.ts` uses `vi.queueMock()` and fails identically on base).

## Fix
Mirror the curated `npm run test:unit` glob in BOTH the builder and the selector, so TIA only ever selects node:test unit files:
- `build-test-impact-map.mjs` — glob = `tests/unit/*.test.ts` + the exact `test:unit` subdir set.
- `select-impacted-tests.mjs` — `TEST_RE` now matches only `tests/unit/**/*.test.ts` in the curated subdirs (excludes `.test.tsx`, `autoCombo`, e2e, integration, `__tests__`).
- +4 selector regression tests (vitest/.tsx/e2e/autoCombo → NOT selected; curated subdir → run).

Verified: map now contains **0** non-unit files (was sweeping in e2e/vitest); selector tests 8/8.

## Note on the blocking flip
This keeps the TIA unit-test step **advisory** (as merged in #4016). Flipping it to **blocking** (the final step to fully close the fast-gates hole) is gated on a confirmed-green unit suite — best verified by the CI `test-unit` job (the full local `test:unit` hangs on `chat-route-coverage.test.ts`, a local-env handle-leak hang; CI runs it sharded). Follow-up once green is confirmed.