### PR TITLE
fix(docker): build release image with webpack (Turbopack panic on v3.8.27)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,8 +38,13 @@ RUN --mount=type=cache,target=/root/.npm \
   && npm rebuild better-sqlite3 \
   && node -e "require('better-sqlite3')(':memory:').close()"
 
-# Use Turbopack for significant build speedup
-ENV OMNIROUTE_USE_TURBOPACK=1
+# Build with webpack (stable). Turbopack hit a non-recoverable internal panic on this
+# Next.js version during the v3.8.27 release build — TurbopackInternalError "entered
+# unreachable code: there must be a path to a root" in ImportTracer::get_traces, on both
+# linux/amd64 and linux/arm64. Webpack is the proven engine (build:release / VPS / CI Build
+# all green). Re-enable Turbopack (=1) once the upstream tracer bug is fixed.
+# See docs/ops/QUALITY_GATE_PLAYBOOK.md Parte 6.
+ENV OMNIROUTE_USE_TURBOPACK=0
 
 COPY . ./
 RUN --mount=type=cache,target=/app/.build/next/cache \


### PR DESCRIPTION
Post-release fragment fix for **v3.8.27** (Phase 4).

The Docker publish failed on BOTH `linux/amd64` and `linux/arm64` with a deterministic Turbopack panic at `RUN npm run build`:

```
TurbopackInternalError: internal error: entered unreachable code: there must be a path to a root
  - <ModuleGraphImportTracer as ImportTracer>::get_traces failed
```

A re-run does not help (deterministic, both arches). The **webpack** build is the proven engine — `build:release` (deployed to the VPS), the CI `Build` job, and `npm run build:cli` all use it and are green. This switches the Docker build to webpack (`OMNIROUTE_USE_TURBOPACK=0`); re-enable once the upstream Turbopack tracer bug is fixed.

After merge: the `v3.8.27` tag is moved to include this fix and `docker-publish` is re-dispatched for `:3.8.27`. Documented in `QUALITY_GATE_PLAYBOOK.md` Parte 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)