### PR TITLE
fix(auto): resolve built-in auto catalog combos

### DIFF
--- a/config/quality/file-size-baseline.json
+++ b/config/quality/file-size-baseline.json
@@ -1,5 +1,6 @@
 {
   "_comment": "Catraca de tamanho (check-file-size.mjs). frozen so pode encolher; arquivos novos <= cap. --update ratcheta.",
+  "_rebaseline_2026_06_17_4058_auto_catalog": "PR #4058 own growth: chat.ts 1432->1458 (+26 = built-in auto/* catalog recognition gating in handleChat: recognizedBuiltInAuto + per-id variant resolution + the 'unknown built-in auto combo' 400 short-circuit). The duplicated AUTO_TEMPLATE_VARIANTS/VALID_AUTO_VARIANTS maps were extracted on review to open-sse/services/autoCombo/builtinCatalog.ts (60 LOC, <cap), imported by BOTH chat.ts and chatHelpers.ts (chatHelpers.ts stays <800 via the same extraction). Remaining growth is genuine routing logic, not the data block; cohesive fix.",
   "_rebaseline_v3.8.25": "Drift consciente do ciclo v3.8.24->v3.8.25 (features #3799-#3806: free-provider-rankings, plugins menu, proxy IP-family selector). 3 arquivos cresceram por feature legitima, nao por regressao de qualidade: ProxyRegistryManager.tsx 1072->1089, sidebarVisibility.ts 990->1006, schemas.ts 2519->2522. Encolher fica como debt para um refactor dedicado.",
   "_rebaseline_2026_06_15_3860_compression_ui": "PR #3860 own growth: sidebarVisibility.ts 1006->1100 (+94 = Compression Hub menu entries: Hub + per-engine Lite/Aggressive/Ultra pages + combos editor) and chatCore.ts 5812->5815 (+3 = compression UI config wiring). Cohesive feature growth, not a quality regression.",
   "_rebaseline_2026_06_15_3885_glm_5_2": "PR #3885 own growth: pricing.ts 1508->1529 (+21 = GLM-5.2 pricing rows for glm-5.2 + effort aliases glm-5.2-high/-max, same $1.2/$5 schedule as glm-5.1; pure data). Also adds glm-5.2 specs to glmProvider.ts/modelSpecs.ts (modelSpecs.ts stays under cap). Cohesive model registration; not extractable.",
@@ -127,7 +128,7 @@
     "src/shared/constants/sidebarVisibility.ts": 1100,
     "src/shared/services/cliRuntime.ts": 1090,
     "src/shared/validation/schemas.ts": 2523,
-    "src/sse/handlers/chat.ts": 1432,
+    "src/sse/handlers/chat.ts": 1458,
     "src/sse/services/auth.ts": 2219
   },
   "_rebaseline_2026_06_09": "Re-baseline consciente pre-release v3.8.19: 9 arquivos cresceram durante o ciclo (features mergeadas: RequestLoggerV2 +281 request-logger rework, stream +101, combo +73, chatCore +45, catalog +32 fable-5/catalog-flag, callLogs +4, accountFallback +2, usageHistory novo 840) + core.ts +7 (fix resetAllDbModuleState, PR 3536). A catraca segue valendo destes valores — proximo crescimento falha. Decisao: encolher (esp. RequestLoggerV2/chatCore) e a issue #3501 ficam para o ciclo seguinte.",

--- a/open-sse/services/autoCombo/builtinCatalog.ts
+++ b/open-sse/services/autoCombo/builtinCatalog.ts
@@ -1,0 +1,60 @@
+import type { AutoVariant } from "./autoPrefix";
+import { VALID_VARIANTS } from "./autoPrefix";
+
+/**
+ * Built-in `auto/*` catalog → AutoVariant resolution.
+ *
+ * The dashboard advertises a zero-setup `auto/*` catalog (e.g. `auto/best-coding`).
+ * Each catalog id maps to a router variant and is materialized into a virtual
+ * auto-combo on demand via `createVirtualAutoCombo`, without requiring persisted DB
+ * combo rows. Extracted from `chatHelpers.ts` so that handler stays under the
+ * file-size cap and the catalog lives alongside the rest of the autoCombo service.
+ */
+
+export const VALID_AUTO_VARIANTS = new Set<AutoVariant>(VALID_VARIANTS);
+
+export const AUTO_TEMPLATE_VARIANTS: Record<string, AutoVariant | undefined> = {
+  "auto/best-coding": "coding",
+  "auto/best-reasoning": "smart",
+  "auto/best-fast": "fast",
+  "auto/best-vision": "smart",
+  "auto/best-chat": undefined,
+  "auto/best-coding-fast": "fast",
+  "auto/pro-coding": "coding",
+  "auto/pro-reasoning": "smart",
+  "auto/pro-vision": "smart",
+  "auto/pro-chat": undefined,
+  "auto/pro-fast": "fast",
+  "auto/coding": "coding",
+  "auto/fast": "fast",
+  "auto/chat": undefined,
+  "auto/claude-opus": "smart",
+  "auto/claude-sonnet": "coding",
+};
+
+type ResolvedAutoVariant =
+  | { recognized: true; variant: AutoVariant | undefined }
+  | { recognized: false };
+
+export function resolveAutoVariant(modelStr: string, suffix: string): ResolvedAutoVariant {
+  if (Object.prototype.hasOwnProperty.call(AUTO_TEMPLATE_VARIANTS, modelStr)) {
+    return { recognized: true, variant: AUTO_TEMPLATE_VARIANTS[modelStr] };
+  }
+  if (VALID_AUTO_VARIANTS.has(suffix as AutoVariant)) {
+    return { recognized: true, variant: suffix as AutoVariant };
+  }
+  return { recognized: false };
+}
+
+export async function createBuiltinAutoCombo(modelStr: string, suffix: string) {
+  const resolved = resolveAutoVariant(modelStr, suffix);
+  if (!resolved.recognized) {
+    throw new Error(`Unknown built-in auto combo: ${modelStr}`);
+  }
+
+  const { createVirtualAutoCombo } = await import("./virtualFactory.ts");
+  const virtualCombo = await createVirtualAutoCombo(resolved.variant);
+  virtualCombo.name = modelStr;
+  virtualCombo.id = modelStr;
+  return virtualCombo;
+}

--- a/src/sse/handlers/chat.ts
+++ b/src/sse/handlers/chat.ts
@@ -29,6 +29,10 @@ import {
   PROVIDER_ID_TO_ALIAS,
 } from "@omniroute/open-sse/config/providerModels.ts";
 import type { AutoVariant } from "@omniroute/open-sse/services/autoCombo/autoPrefix.ts";
+import {
+  AUTO_TEMPLATE_VARIANTS,
+  VALID_AUTO_VARIANTS,
+} from "@omniroute/open-sse/services/autoCombo/builtinCatalog.ts";
 import * as log from "../utils/logger";
 import { checkAndRefreshToken } from "../services/tokenRefresh";
 import { createHookContext, runHooks, initPreRequestRegistry } from "@/lib/middleware/registry";
@@ -379,32 +383,6 @@ export async function handleChat(request: any, clientRawRequest: any = null) {
   // entirely and generate a virtual auto-combo on-the-fly from connected providers.
   let autoVariant: AutoVariant | undefined;
   let isAutoRouting = resolvedModelStr === "auto" || resolvedModelStr.startsWith("auto/");
-  const AUTO_TEMPLATE_VARIANTS: Record<string, AutoVariant | undefined> = {
-    "auto/best-coding": "coding",
-    "auto/best-reasoning": "smart",
-    "auto/best-fast": "fast",
-    "auto/best-vision": "smart",
-    "auto/best-chat": undefined,
-    "auto/best-coding-fast": "fast",
-    "auto/pro-coding": "coding",
-    "auto/pro-reasoning": "smart",
-    "auto/pro-vision": "smart",
-    "auto/pro-chat": undefined,
-    "auto/pro-fast": "fast",
-    "auto/coding": "coding",
-    "auto/fast": "fast",
-    "auto/chat": undefined,
-    "auto/claude-opus": "smart",
-    "auto/claude-sonnet": "coding",
-  };
-  const VALID_AUTO_VARIANTS = new Set<AutoVariant>([
-    "coding",
-    "fast",
-    "cheap",
-    "offline",
-    "smart",
-    "lkgp",
-  ]);
   let recognizedBuiltInAuto = resolvedModelStr === "auto";
   if (Object.prototype.hasOwnProperty.call(AUTO_TEMPLATE_VARIANTS, resolvedModelStr)) {
     recognizedBuiltInAuto = true;

--- a/src/sse/handlers/chat.ts
+++ b/src/sse/handlers/chat.ts
@@ -379,6 +379,41 @@ export async function handleChat(request: any, clientRawRequest: any = null) {
   // entirely and generate a virtual auto-combo on-the-fly from connected providers.
   let autoVariant: AutoVariant | undefined;
   let isAutoRouting = resolvedModelStr === "auto" || resolvedModelStr.startsWith("auto/");
+  const AUTO_TEMPLATE_VARIANTS: Record<string, AutoVariant | undefined> = {
+    "auto/best-coding": "coding",
+    "auto/best-reasoning": "smart",
+    "auto/best-fast": "fast",
+    "auto/best-vision": "smart",
+    "auto/best-chat": undefined,
+    "auto/best-coding-fast": "fast",
+    "auto/pro-coding": "coding",
+    "auto/pro-reasoning": "smart",
+    "auto/pro-vision": "smart",
+    "auto/pro-chat": undefined,
+    "auto/pro-fast": "fast",
+    "auto/coding": "coding",
+    "auto/fast": "fast",
+    "auto/chat": undefined,
+    "auto/claude-opus": "smart",
+    "auto/claude-sonnet": "coding",
+  };
+  const VALID_AUTO_VARIANTS = new Set<AutoVariant>([
+    "coding",
+    "fast",
+    "cheap",
+    "offline",
+    "smart",
+    "lkgp",
+  ]);
+  let recognizedBuiltInAuto = resolvedModelStr === "auto";
+  if (Object.prototype.hasOwnProperty.call(AUTO_TEMPLATE_VARIANTS, resolvedModelStr)) {
+    recognizedBuiltInAuto = true;
+    autoVariant = AUTO_TEMPLATE_VARIANTS[resolvedModelStr];
+  } else if (resolvedModelStr.startsWith("auto/")) {
+    const suffix = resolvedModelStr.slice(5);
+    recognizedBuiltInAuto = VALID_AUTO_VARIANTS.has(suffix as AutoVariant);
+  }
+
   if (isAutoRouting) {
     // C2: Enforce autoRoutingEnabled setting.
     // Issue #2346: `getSettings` was never imported in this module; only
@@ -398,9 +433,15 @@ export async function handleChat(request: any, clientRawRequest: any = null) {
         await import("@omniroute/open-sse/services/autoCombo/autoPrefix.ts");
       const parsed = parseAutoPrefix(resolvedModelStr);
       if (parsed.valid) {
-        autoVariant = parsed.variant;
+        if (!Object.prototype.hasOwnProperty.call(AUTO_TEMPLATE_VARIANTS, resolvedModelStr)) {
+          autoVariant = parsed.variant;
+        }
         // C3: Apply autoRoutingDefaultVariant from settings when bare "auto" is used
-        if (autoVariant === undefined && settings?.autoRoutingDefaultVariant) {
+        if (
+          resolvedModelStr === "auto" &&
+          autoVariant === undefined &&
+          settings?.autoRoutingDefaultVariant
+        ) {
           autoVariant = settings.autoRoutingDefaultVariant as AutoVariant;
         }
         log.info(
@@ -433,8 +474,15 @@ export async function handleChat(request: any, clientRawRequest: any = null) {
     }
   }
 
-  // Auto-prefix short-circuit: if auto/ prefix was detected, replace combo with virtual one
+  // Auto-prefix short-circuit: if a recognized auto/ prefix was detected, replace combo with virtual one
   if (isAutoRouting && combo === null) {
+    if (!recognizedBuiltInAuto) {
+      return errorResponse(
+        HTTP_STATUS.BAD_REQUEST,
+        `Model '${resolvedModelStr}' is not a valid combo or provider. Unknown built-in auto combo.`
+      );
+    }
+
     try {
       const { createVirtualAutoCombo } =
         await import("@omniroute/open-sse/services/autoCombo/virtualFactory.ts");

--- a/src/sse/handlers/chatHelpers.ts
+++ b/src/sse/handlers/chatHelpers.ts
@@ -49,6 +49,64 @@ const PREFERRED_BY_FAMILY: Record<string, string> = {
 
 const CODEX_NATIVE_RESPONSES_MODELS = new Set(["gpt-5.5"]);
 
+type AutoVariant = "coding" | "fast" | "cheap" | "offline" | "smart" | "lkgp";
+
+const VALID_AUTO_VARIANTS = new Set<AutoVariant>([
+  "coding",
+  "fast",
+  "cheap",
+  "offline",
+  "smart",
+  "lkgp",
+]);
+
+const AUTO_TEMPLATE_VARIANTS: Record<string, AutoVariant | undefined> = {
+  "auto/best-coding": "coding",
+  "auto/best-reasoning": "smart",
+  "auto/best-fast": "fast",
+  "auto/best-vision": "smart",
+  "auto/best-chat": undefined,
+  "auto/best-coding-fast": "fast",
+  "auto/pro-coding": "coding",
+  "auto/pro-reasoning": "smart",
+  "auto/pro-vision": "smart",
+  "auto/pro-chat": undefined,
+  "auto/pro-fast": "fast",
+  "auto/coding": "coding",
+  "auto/fast": "fast",
+  "auto/chat": undefined,
+  "auto/claude-opus": "smart",
+  "auto/claude-sonnet": "coding",
+};
+
+type ResolvedAutoVariant =
+  | { recognized: true; variant: AutoVariant | undefined }
+  | { recognized: false };
+
+function resolveAutoVariant(modelStr: string, suffix: string): ResolvedAutoVariant {
+  if (Object.prototype.hasOwnProperty.call(AUTO_TEMPLATE_VARIANTS, modelStr)) {
+    return { recognized: true, variant: AUTO_TEMPLATE_VARIANTS[modelStr] };
+  }
+  if (VALID_AUTO_VARIANTS.has(suffix as AutoVariant)) {
+    return { recognized: true, variant: suffix as AutoVariant };
+  }
+  return { recognized: false };
+}
+
+async function createBuiltinAutoCombo(modelStr: string, suffix: string) {
+  const resolved = resolveAutoVariant(modelStr, suffix);
+  if (!resolved.recognized) {
+    throw new Error(`Unknown built-in auto combo: ${modelStr}`);
+  }
+
+  const { createVirtualAutoCombo } =
+    await import("@omniroute/open-sse/services/autoCombo/virtualFactory.ts");
+  const virtualCombo = await createVirtualAutoCombo(resolved.variant);
+  virtualCombo.name = modelStr;
+  virtualCombo.id = modelStr;
+  return virtualCombo;
+}
+
 type TrafficType = "production" | "shadow";
 
 type ExecuteChatWithBreakerOptions = {
@@ -173,18 +231,20 @@ export async function resolveModelOrError(
     }
   }
 
-  // "auto" is a combo prefix, not a provider. parseModel("auto/fast") splits it into
-  // provider="auto" model="fast" — redirect to matching combo before credential lookup fails.
+  // "auto" is a built-in virtual combo prefix, not a provider. parseModel("auto/fast")
+  // splits it into provider="auto" model="fast", so resolve it before credential lookup.
   if (modelInfo.provider === "auto") {
+    const suffix = modelInfo.model || "";
+    const fuzzyCandidates = [`auto/best-${suffix}`, `auto/${suffix}`];
+
     const exactCombo = await getComboForModel(modelStr);
     if (exactCombo) {
       log.info("ROUTING", `"auto" provider → combo "${modelStr}"`);
-      return { combo: exactCombo, provider: "auto", model: modelInfo.model };
+      return { combo: exactCombo, provider: "auto", model: suffix };
     }
 
-    // Fuzzy: "fast" → "auto/best-fast", "chat" → "auto/best-chat"
-    const suffix = modelInfo.model || "";
-    for (const candidate of [`auto/best-${suffix}`, `auto/${suffix}`]) {
+    // Preserve persisted fuzzy combo behavior before falling back to built-in virtual catalog ids.
+    for (const candidate of fuzzyCandidates) {
       const fuzzyCombo = await getComboForModel(candidate);
       if (fuzzyCombo) {
         log.info("ROUTING", `"auto/${suffix}" → combo "${candidate}" (fuzzy)`);
@@ -192,25 +252,35 @@ export async function resolveModelOrError(
       }
     }
 
-    // List available auto/* combos in error
-    const available: string[] = [];
     try {
-      const { getCombos } = await import("@/lib/localDb");
-      const all = await getCombos();
-      for (const c of all) {
-        const name =
-          typeof c === "object" && c !== null ? (c as Record<string, unknown>).name : undefined;
-        if (typeof name === "string" && name.startsWith("auto/")) available.push(name);
-      }
-    } catch {
-      /* DB unavailable */
+      const virtualCombo = await createBuiltinAutoCombo(modelStr, suffix);
+      log.info(
+        "AUTO",
+        `"auto" provider → built-in virtual combo "${modelStr}" (${virtualCombo.candidatePool?.length || 0} candidates)`
+      );
+      return { combo: virtualCombo, provider: "auto", model: suffix };
+    } catch (err) {
+      log.warn("CHAT", `Failed to create built-in auto combo "${modelStr}"`, { err });
     }
 
-    const hint =
-      available.length > 0
-        ? ` Available auto combos: ${available.join(", ")}`
-        : " No auto combos configured — create one in the Dashboard.";
-    const message = `Model '${modelStr}' is not a valid combo or provider.${hint}`;
+    // Fuzzy: "fast" → "auto/best-fast", "chat" → "auto/best-chat"
+    for (const candidate of fuzzyCandidates) {
+      try {
+        const virtualCombo = await createBuiltinAutoCombo(
+          candidate,
+          candidate.replace(/^auto\/?/, "")
+        );
+        log.info(
+          "AUTO",
+          `"auto/${suffix}" → built-in virtual combo "${candidate}" (fuzzy, ${virtualCombo.candidatePool?.length || 0} candidates)`
+        );
+        return { combo: virtualCombo, provider: "auto", model: suffix };
+      } catch {
+        /* Try next fuzzy candidate */
+      }
+    }
+
+    const message = `Model '${modelStr}' is not a valid combo or provider. Unknown built-in auto combo.`;
     log.warn("CHAT", message, { model: modelStr });
     return { error: errorResponse(HTTP_STATUS.BAD_REQUEST, message) };
   }

--- a/src/sse/handlers/chatHelpers.ts
+++ b/src/sse/handlers/chatHelpers.ts
@@ -1,6 +1,7 @@
 import { getModelInfo, getComboForModel } from "../services/model";
 import { clearAccountError, markAccountUnavailable } from "../services/auth";
 import { connectionHasExtraKeys } from "@omniroute/open-sse/services/apiKeyRotator.ts";
+import { createBuiltinAutoCombo } from "@omniroute/open-sse/services/autoCombo/builtinCatalog.ts";
 import * as log from "../utils/logger";
 import { updateProviderCredentials } from "../services/tokenRefresh";
 import {
@@ -48,64 +49,6 @@ const PREFERRED_BY_FAMILY: Record<string, string> = {
 };
 
 const CODEX_NATIVE_RESPONSES_MODELS = new Set(["gpt-5.5"]);
-
-type AutoVariant = "coding" | "fast" | "cheap" | "offline" | "smart" | "lkgp";
-
-const VALID_AUTO_VARIANTS = new Set<AutoVariant>([
-  "coding",
-  "fast",
-  "cheap",
-  "offline",
-  "smart",
-  "lkgp",
-]);
-
-const AUTO_TEMPLATE_VARIANTS: Record<string, AutoVariant | undefined> = {
-  "auto/best-coding": "coding",
-  "auto/best-reasoning": "smart",
-  "auto/best-fast": "fast",
-  "auto/best-vision": "smart",
-  "auto/best-chat": undefined,
-  "auto/best-coding-fast": "fast",
-  "auto/pro-coding": "coding",
-  "auto/pro-reasoning": "smart",
-  "auto/pro-vision": "smart",
-  "auto/pro-chat": undefined,
-  "auto/pro-fast": "fast",
-  "auto/coding": "coding",
-  "auto/fast": "fast",
-  "auto/chat": undefined,
-  "auto/claude-opus": "smart",
-  "auto/claude-sonnet": "coding",
-};
-
-type ResolvedAutoVariant =
-  | { recognized: true; variant: AutoVariant | undefined }
-  | { recognized: false };
-
-function resolveAutoVariant(modelStr: string, suffix: string): ResolvedAutoVariant {
-  if (Object.prototype.hasOwnProperty.call(AUTO_TEMPLATE_VARIANTS, modelStr)) {
-    return { recognized: true, variant: AUTO_TEMPLATE_VARIANTS[modelStr] };
-  }
-  if (VALID_AUTO_VARIANTS.has(suffix as AutoVariant)) {
-    return { recognized: true, variant: suffix as AutoVariant };
-  }
-  return { recognized: false };
-}
-
-async function createBuiltinAutoCombo(modelStr: string, suffix: string) {
-  const resolved = resolveAutoVariant(modelStr, suffix);
-  if (!resolved.recognized) {
-    throw new Error(`Unknown built-in auto combo: ${modelStr}`);
-  }
-
-  const { createVirtualAutoCombo } =
-    await import("@omniroute/open-sse/services/autoCombo/virtualFactory.ts");
-  const virtualCombo = await createVirtualAutoCombo(resolved.variant);
-  virtualCombo.name = modelStr;
-  virtualCombo.id = modelStr;
-  return virtualCombo;
-}
 
 type TrafficType = "production" | "shadow";
 

--- a/tests/unit/chat-helpers.test.ts
+++ b/tests/unit/chat-helpers.test.ts
@@ -9,6 +9,7 @@ process.env.DATA_DIR = TEST_DATA_DIR;
 
 const core = await import("../../src/lib/db/core.ts");
 const providersDb = await import("../../src/lib/db/providers.ts");
+const combosDb = await import("../../src/lib/db/combos.ts");
 const {
   resolveModelOrError,
   checkPipelineGates,
@@ -37,6 +38,7 @@ async function seedConnection(provider, overrides = {}) {
     isActive: overrides.isActive ?? true,
     testStatus: overrides.testStatus || "active",
     providerSpecificData: overrides.providerSpecificData || {},
+    defaultModel: overrides.defaultModel,
   });
 }
 
@@ -47,6 +49,63 @@ test.beforeEach(async () => {
 test.after(async () => {
   await resetStorage();
   fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("resolveModelOrError resolves built-in auto catalog ids without persisted combo rows", async () => {
+  await seedConnection("openai", { defaultModel: "gpt-4o-mini" });
+
+  const result = await resolveModelOrError(
+    "auto/best-coding",
+    { messages: [{ role: "user", content: "echo hi" }] },
+    "/v1/chat/completions"
+  );
+
+  assert.equal(result.error, undefined);
+  assert.ok(result.combo);
+  assert.equal(result.combo.id, "auto/best-coding");
+  assert.equal(result.combo.name, "auto/best-coding");
+  assert.equal(result.provider, "auto");
+  assert.equal(result.model, "best-coding");
+  assert.ok(Array.isArray(result.combo.models));
+  assert.ok(result.combo.models.length > 0);
+  assert.equal(result.combo.models[0].providerId, "openai");
+});
+
+test("resolveModelOrError rejects unknown built-in auto catalog ids", async () => {
+  await seedConnection("openai", { defaultModel: "gpt-4o-mini" });
+
+  const result = await resolveModelOrError(
+    "auto/not-a-real-template",
+    { messages: [{ role: "user", content: "echo hi" }] },
+    "/v1/chat/completions"
+  );
+
+  assert.ok(result.error);
+  assert.equal(result.error.status, 400);
+  const json = (await result.error.json()) as any;
+  assert.match(json.error.message, /Unknown built-in auto combo/i);
+});
+
+test("resolveModelOrError preserves persisted fuzzy auto combos before virtual catalog ids", async () => {
+  await combosDb.createCombo({
+    id: "persisted-auto-best-legacy",
+    name: "auto/best-legacy",
+    strategy: "priority",
+    models: [{ providerId: "openai", model: "gpt-4o-mini" }],
+  });
+
+  const result = await resolveModelOrError(
+    "auto/legacy",
+    { messages: [{ role: "user", content: "echo hi" }] },
+    "/v1/chat/completions"
+  );
+
+  assert.equal(result.error, undefined);
+  assert.ok(result.combo);
+  assert.equal(result.combo.id, "persisted-auto-best-legacy");
+  assert.equal(result.combo.name, "auto/best-legacy");
+  assert.equal(result.provider, "auto");
+  assert.equal(result.model, "legacy");
 });
 
 test("resolveModelOrError rejects ambiguous aliases without a provider prefix", async () => {


### PR DESCRIPTION
## Summary
- resolve built-in `auto/*` catalog IDs in `resolveModelOrError` before treating `auto` as a real provider
- create virtual auto combos dynamically for catalog IDs like `auto/best-coding` and `auto/best-coding-fast`, without requiring persisted DB combo rows
- keep existing persisted combo lookup/fuzzy routing behavior for backwards compatibility

## Problem
The dashboard advertises the Auto-routing catalog as zero-setup built-in `auto/*` combos, but `/v1/chat/completions` can fail with:

`Model auto/best-coding is not a valid combo or provider. No auto combos configured — create one in the Dashboard.`

`parseModel("auto/best-coding")` yields provider `auto`, and `chatHelpers.ts` returned a 400 after checking only persisted combo rows. That happens before the main chat handler can create a virtual auto combo.

## Tests
- `node --import tsx --import ./open-sse/utils/setupPolyfill.ts --test --test-force-exit tests/unit/chat-helpers.test.ts`
- `npx eslint src/sse/handlers/chatHelpers.ts tests/unit/chat-helpers.test.ts`
- `git diff --check`
