### PR TITLE
feat(compression): Context Editing telemetry (engine: context-editing)

### DIFF
--- a/config/quality/file-size-baseline.json
+++ b/config/quality/file-size-baseline.json
@@ -25,6 +25,7 @@
   "_rebaseline_2026_06_16_4021_context_editing": "PR #4021 own growth: base.ts 1222->1244 (+22 = inject delegated Context Editing at the single Claude pre-serialization chokepoint — applyContextEditingToBody() call gated to the genuine `claude` provider, the contextEditing field on ExecuteInput, its destructure, and a debug log) and chatCore.ts 5868->5875 (+7 = capture contextEditing.enabled at the canonical compression-settings read into a function-scoped flag, threaded to the two executor.execute() callsites). The reusable edit-builder + strategy constants live in the new small open-sse/config/contextEditing.ts (well under cap). Cohesive opt-in feature at the existing dispatch chokepoint; not extractable without hiding the Claude body-finalization boundary.",
   "_rebaseline_2026_06_16_4033_compression_token_saver_ui": "PR #4033 net -46 LOC overall: CompressionSettingsTab.tsx 932->974 (+42 over frozen after relocating Token Saver from Endpoint/Appearance into Compression Settings). This is a deliberate UI ownership redistribution, not aggregate code growth; keeping the control with the compression settings makes the module boundary clearer.",
   "_rebaseline_2026_06_17_4034_usage_command": "PR #4034 own growth: apiKeys.ts 1633->1661 (+28 = the allow_usage_command additive column — fallback definition, parseAllowUsageCommand, prepared-statement SELECT column, and the metadata/create/update wiring, mirroring the existing disable_non_public_models accessor pattern) and chat.ts 1425->1432 (+7 = the handleInternalUsageCommand intercept hook at the existing post-auth chokepoint in handleChat). The reusable command logic lives in the new src/lib/usage/internalUsageCommand.ts (well under cap). Cohesive opt-in feature at the established column/dispatch boundaries; not extractable without splitting the api-keys domain module.",
+  "_rebaseline_2026_06_17_ctx_editing_telemetry": "Context Editing telemetry (F4.1) own growth: chatCore.ts 5875->5898 (+23 = a best-effort, Claude-only, non-streaming block at the existing non-streaming response handler that extracts the provider's server-side context-editing receipt from responseBody and records it under engine \"context-editing\"). The pure extractor (extractContextEditingTelemetry) lives in the existing small open-sse/config/contextEditing.ts and the DB writer (recordContextEditingTelemetry) in src/lib/db/compressionAnalytics.ts — both under cap. Cohesive at the response-handling chokepoint next to the existing attachCompressionUsageReceipt call; not extractable without hiding the receipt-recording boundary.",
   "cap": 800,
   "frozen": {
     "open-sse/config/providerRegistry.ts": 4731,
@@ -40,7 +41,7 @@
     "open-sse/executors/muse-spark-web.ts": 1284,
     "open-sse/executors/perplexity-web.ts": 1013,
     "open-sse/handlers/audioSpeech.ts": 965,
-    "open-sse/handlers/chatCore.ts": 5875,
+    "open-sse/handlers/chatCore.ts": 5898,
     "open-sse/handlers/imageGeneration.ts": 3777,
     "open-sse/handlers/responseSanitizer.ts": 1103,
     "open-sse/handlers/search.ts": 1442,

--- a/open-sse/config/contextEditing.ts
+++ b/open-sse/config/contextEditing.ts
@@ -60,9 +60,7 @@ export function applyContextEditingToBody(
     ? [...(existing.edits as ContextEditingEdit[])]
     : [];
 
-  const hasToolUseEdit = edits.some(
-    (edit) => edit && edit.type === CLEAR_TOOL_USES_STRATEGY
-  );
+  const hasToolUseEdit = edits.some((edit) => edit && edit.type === CLEAR_TOOL_USES_STRATEGY);
 
   if (!hasToolUseEdit) {
     edits.push({
@@ -81,4 +79,78 @@ export function applyContextEditingToBody(
 
   existing.edits = edits;
   body.context_management = existing;
+}
+
+/**
+ * Telemetry receipt for one Claude response that ran server-side context editing.
+ * `clearedInputTokens` is how many input tokens the provider pruned from its own
+ * context window — i.e. the tokens "saved" on subsequent turns by the delegated
+ * clearing (the value we surface in compression analytics under
+ * `engine: "context-editing"`).
+ */
+export interface ContextEditingTelemetry {
+  /** Number of applied edit entries the provider reported. */
+  editCount: number;
+  /** Total input tokens cleared across all applied edits. */
+  clearedInputTokens: number;
+  /** Total tool-use/result pairs cleared across all applied edits. */
+  clearedToolUses: number;
+}
+
+/** Coerce a finite, non-negative integer; returns 0 for junk. */
+function toClearedInt(value: unknown): number {
+  if (typeof value === "number" && Number.isFinite(value)) return Math.max(0, Math.floor(value));
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return Math.max(0, Math.floor(parsed));
+  }
+  return 0;
+}
+
+/** Read a nested property by key path without throwing on missing intermediates. */
+function getNested(obj: unknown, keys: string[]): unknown {
+  let cur: unknown = obj;
+  for (const key of keys) {
+    if (!cur || typeof cur !== "object") return undefined;
+    cur = (cur as Record<string, unknown>)[key];
+  }
+  return cur;
+}
+
+/**
+ * Extract the context-editing telemetry receipt from a Claude (Anthropic Messages)
+ * response body. Returns `null` when context editing did not run (no applied edits,
+ * or nothing was actually cleared).
+ *
+ * Defensive over the response shape: Anthropic surfaces `applied_edits` under
+ * `context_management` (top-level), and some response variants nest it under
+ * `usage`. We probe both rather than pin a single location, so the telemetry keeps
+ * working if the provider moves the field. Per-edit cleared counts are read from
+ * `cleared_input_tokens` / `cleared_tool_uses` (snake_case) with a camelCase
+ * fallback.
+ */
+export function extractContextEditingTelemetry(
+  responseBody: unknown
+): ContextEditingTelemetry | null {
+  if (!responseBody || typeof responseBody !== "object") return null;
+
+  const candidates: unknown[] = [
+    getNested(responseBody, ["context_management", "applied_edits"]),
+    getNested(responseBody, ["usage", "context_management", "applied_edits"]),
+    getNested(responseBody, ["usage", "applied_edits"]),
+  ];
+  const edits = candidates.find((c) => Array.isArray(c)) as unknown[] | undefined;
+  if (!Array.isArray(edits) || edits.length === 0) return null;
+
+  let clearedInputTokens = 0;
+  let clearedToolUses = 0;
+  for (const entry of edits) {
+    if (!entry || typeof entry !== "object") continue;
+    const edit = entry as Record<string, unknown>;
+    clearedInputTokens += toClearedInt(edit.cleared_input_tokens ?? edit.clearedInputTokens);
+    clearedToolUses += toClearedInt(edit.cleared_tool_uses ?? edit.clearedToolUses);
+  }
+
+  if (clearedInputTokens <= 0 && clearedToolUses <= 0) return null;
+  return { editCount: edits.length, clearedInputTokens, clearedToolUses };
 }

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -5115,6 +5115,29 @@ export async function handleChatCore({
     if (usage && typeof usage === "object") {
       attachCompressionUsageReceiptAfterAnalytics(usage as Record<string, unknown>, "provider");
     }
+
+    // Context Editing telemetry: when the delegated server-side clear actually ran,
+    // record the provider's cleared-token receipt under engine "context-editing" so
+    // it surfaces in compression analytics. Best-effort, Claude-only, non-streaming.
+    if (contextEditingEnabled && provider === "claude") {
+      void (async () => {
+        try {
+          const { extractContextEditingTelemetry } = await import("../config/contextEditing.ts");
+          const tele = extractContextEditingTelemetry(responseBody);
+          if (tele) {
+            const { recordContextEditingTelemetry } =
+              await import("../../src/lib/db/compressionAnalytics.ts");
+            recordContextEditingTelemetry(skillRequestId, tele, provider);
+            log?.debug?.(
+              "CONTEXT_EDITING",
+              `cleared ${tele.clearedInputTokens} input tokens / ${tele.clearedToolUses} tool uses (${tele.editCount} edits)`
+            );
+          }
+        } catch {
+          // Telemetry is best-effort and must never affect the response.
+        }
+      })();
+    }
     appendRequestLog({ model, provider, connectionId, tokens: usage, status: "200 OK" }).catch(
       () => {}
     );

--- a/src/lib/db/compressionAnalytics.ts
+++ b/src/lib/db/compressionAnalytics.ts
@@ -154,6 +154,41 @@ export function insertCompressionAnalyticsRow(row: CompressionAnalyticsRow): voi
   );
 }
 
+/**
+ * Record one Anthropic server-side Context Editing receipt as a
+ * `compression_analytics` row under engine `"context-editing"`.
+ *
+ * The provider cleared `clearedInputTokens` of stale tool-use/thinking context from
+ * its own window, so that maps to `tokens_saved` (original = cleared, compressed = 0).
+ * Unlike the local engines there is no separate usage receipt to attach, so the
+ * `request_id` is suffixed (`<id>::context-editing`): it stays traceable to the
+ * originating request while staying collision-free with the exact-match
+ * `attachCompressionUsageReceipt` UPDATE, which would otherwise latch onto this row.
+ *
+ * Best-effort: a zero/absent receipt is a no-op (context editing did not fire).
+ */
+export function recordContextEditingTelemetry(
+  requestId: string | null | undefined,
+  telemetry:
+    | { clearedInputTokens?: number; clearedToolUses?: number; editCount?: number }
+    | null
+    | undefined,
+  provider: string | null = "claude"
+): void {
+  const cleared = telemetry?.clearedInputTokens ?? 0;
+  if (!Number.isFinite(cleared) || cleared <= 0) return;
+  insertCompressionAnalyticsRow({
+    timestamp: new Date().toISOString(),
+    provider,
+    mode: "context-editing",
+    engine: "context-editing",
+    original_tokens: cleared,
+    compressed_tokens: 0,
+    tokens_saved: cleared,
+    request_id: requestId ? `${requestId}::context-editing` : null,
+  });
+}
+
 let breakdownTableEnsuredForDb: unknown = null;
 
 function ensureCompressionEngineBreakdownTable(): void {

--- a/tests/unit/compression/context-editing-telemetry.test.ts
+++ b/tests/unit/compression/context-editing-telemetry.test.ts
@@ -1,0 +1,149 @@
+/**
+ * tests/unit/compression/context-editing-telemetry.test.ts
+ *
+ * TDD for F4.1 — extractContextEditingTelemetry: pulls the server-side context
+ * editing receipt (`applied_edits[].cleared_input_tokens` / `cleared_tool_uses`)
+ * out of a Claude (Anthropic Messages) response body. Defensive over the exact
+ * response shape: the array may live at `context_management.applied_edits`
+ * (top-level) or nested under `usage` — we tolerate both rather than hardcode a
+ * single guess (the spec's Task-1 caution).
+ *
+ * Run: node --import tsx/esm --test tests/unit/compression/context-editing-telemetry.test.ts
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { extractContextEditingTelemetry } from "../../../open-sse/config/contextEditing.ts";
+
+describe("extractContextEditingTelemetry", () => {
+  it("returns null for null/undefined/non-object bodies", () => {
+    assert.equal(extractContextEditingTelemetry(null), null);
+    assert.equal(extractContextEditingTelemetry(undefined), null);
+    assert.equal(extractContextEditingTelemetry("nope"), null);
+    assert.equal(extractContextEditingTelemetry(42), null);
+  });
+
+  it("returns null when there is no context_management / applied_edits", () => {
+    assert.equal(extractContextEditingTelemetry({ usage: { input_tokens: 10 } }), null);
+    assert.equal(extractContextEditingTelemetry({ context_management: {} }), null);
+    assert.equal(
+      extractContextEditingTelemetry({ context_management: { applied_edits: [] } }),
+      null
+    );
+  });
+
+  it("reads applied_edits from the top-level context_management object", () => {
+    const body = {
+      context_management: {
+        applied_edits: [
+          { type: "clear_tool_uses_20250919", cleared_tool_uses: 8, cleared_input_tokens: 50000 },
+        ],
+      },
+    };
+    const out = extractContextEditingTelemetry(body);
+    assert.ok(out);
+    assert.equal(out.editCount, 1);
+    assert.equal(out.clearedInputTokens, 50000);
+    assert.equal(out.clearedToolUses, 8);
+  });
+
+  it("reads applied_edits nested under usage.context_management (alt shape)", () => {
+    const body = {
+      usage: {
+        input_tokens: 120000,
+        context_management: {
+          applied_edits: [{ type: "clear_tool_uses_20250919", cleared_input_tokens: 30000 }],
+        },
+      },
+    };
+    const out = extractContextEditingTelemetry(body);
+    assert.ok(out);
+    assert.equal(out.clearedInputTokens, 30000);
+  });
+
+  it("reads applied_edits directly under usage.applied_edits (alt shape)", () => {
+    const body = {
+      usage: {
+        applied_edits: [{ type: "clear_tool_uses_20250919", cleared_input_tokens: 12345 }],
+      },
+    };
+    const out = extractContextEditingTelemetry(body);
+    assert.ok(out);
+    assert.equal(out.clearedInputTokens, 12345);
+  });
+
+  it("sums cleared tokens/tool_uses across multiple edits", () => {
+    const body = {
+      context_management: {
+        applied_edits: [
+          { type: "clear_thinking_20251015", cleared_input_tokens: 4000, cleared_tool_uses: 0 },
+          { type: "clear_tool_uses_20250919", cleared_input_tokens: 6000, cleared_tool_uses: 5 },
+        ],
+      },
+    };
+    const out = extractContextEditingTelemetry(body);
+    assert.ok(out);
+    assert.equal(out.editCount, 2);
+    assert.equal(out.clearedInputTokens, 10000);
+    assert.equal(out.clearedToolUses, 5);
+  });
+
+  it("falls back to camelCase field names if present", () => {
+    const body = {
+      context_management: {
+        applied_edits: [
+          { type: "clear_tool_uses_20250919", clearedInputTokens: 777, clearedToolUses: 2 },
+        ],
+      },
+    };
+    const out = extractContextEditingTelemetry(body);
+    assert.ok(out);
+    assert.equal(out.clearedInputTokens, 777);
+    assert.equal(out.clearedToolUses, 2);
+  });
+
+  it("returns null when edits exist but cleared nothing (no real telemetry)", () => {
+    const body = {
+      context_management: {
+        applied_edits: [
+          { type: "clear_tool_uses_20250919", cleared_input_tokens: 0, cleared_tool_uses: 0 },
+        ],
+      },
+    };
+    assert.equal(extractContextEditingTelemetry(body), null);
+  });
+
+  it("skips malformed (non-object) edit entries and still sums the valid ones", () => {
+    const body = {
+      context_management: {
+        applied_edits: [
+          null,
+          "garbage",
+          { type: "clear_tool_uses_20250919", cleared_input_tokens: 999 },
+        ],
+      },
+    };
+    const out = extractContextEditingTelemetry(body);
+    assert.ok(out);
+    assert.equal(out.clearedInputTokens, 999);
+  });
+
+  it("coerces numeric strings and ignores non-numeric junk", () => {
+    const body = {
+      context_management: {
+        applied_edits: [
+          {
+            type: "clear_tool_uses_20250919",
+            cleared_input_tokens: "1500",
+            cleared_tool_uses: "x",
+          },
+        ],
+      },
+    };
+    const out = extractContextEditingTelemetry(body);
+    assert.ok(out);
+    assert.equal(out.clearedInputTokens, 1500);
+    assert.equal(out.clearedToolUses, 0);
+  });
+});

--- a/tests/unit/db/context-editing-telemetry-record.test.ts
+++ b/tests/unit/db/context-editing-telemetry-record.test.ts
@@ -1,0 +1,108 @@
+/**
+ * TDD for F4.1 — recordContextEditingTelemetry: writes a compression_analytics
+ * row under engine "context-editing" for the tokens the provider cleared via
+ * server-side context editing.
+ *
+ * DB isolation pattern mirrors tests/unit/db/per-engine-analytics.test.ts:
+ * - Temp DATA_DIR, resetDbInstance() before/after, restore in test.after().
+ *
+ * Run: node --import tsx/esm --test tests/unit/db/context-editing-telemetry-record.test.ts
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-ctx-edit-telemetry-"));
+const originalDataDir = process.env.DATA_DIR;
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../../src/lib/db/core.ts");
+core.resetDbInstance();
+
+const {
+  recordContextEditingTelemetry,
+  getCompressionAnalyticsSummary,
+  getLatestCompressionAnalyticsRun,
+} = await import("../../../src/lib/db/compressionAnalytics.ts");
+
+function resetDb(): void {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+test.beforeEach(() => {
+  resetDb();
+});
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  if (originalDataDir === undefined) delete process.env.DATA_DIR;
+  else process.env.DATA_DIR = originalDataDir;
+});
+
+test("records a context-editing row reflected in byEngine analytics", () => {
+  recordContextEditingTelemetry(
+    "req-1",
+    { editCount: 1, clearedInputTokens: 50000, clearedToolUses: 8 },
+    "claude"
+  );
+  const summary = getCompressionAnalyticsSummary();
+  assert.ok(summary.byEngine["context-editing"], "byEngine has a context-editing bucket");
+  assert.equal(summary.byEngine["context-editing"].count, 1);
+  assert.equal(summary.byEngine["context-editing"].tokensSaved, 50000);
+  assert.equal(summary.totalTokensSaved, 50000);
+});
+
+test("is a no-op when nothing was cleared (clearedInputTokens <= 0)", () => {
+  recordContextEditingTelemetry("req-2", {
+    editCount: 1,
+    clearedInputTokens: 0,
+    clearedToolUses: 0,
+  });
+  const summary = getCompressionAnalyticsSummary();
+  assert.equal(summary.totalRequests, 0, "no row written");
+  assert.equal(summary.byEngine["context-editing"], undefined);
+});
+
+test("is a no-op for null/undefined telemetry", () => {
+  recordContextEditingTelemetry("req-3", null as never);
+  recordContextEditingTelemetry("req-4", undefined as never);
+  assert.equal(getCompressionAnalyticsSummary().totalRequests, 0);
+});
+
+test("uses a suffixed request_id so it never collides with the usage-receipt UPDATE", () => {
+  recordContextEditingTelemetry(
+    "abc123",
+    { editCount: 1, clearedInputTokens: 1000, clearedToolUses: 1 },
+    "claude"
+  );
+  const latest = getLatestCompressionAnalyticsRun();
+  assert.ok(latest);
+  assert.equal(latest.engine, "context-editing");
+  assert.equal(latest.mode, "context-editing");
+  assert.notEqual(latest.request_id, "abc123", "must not reuse the raw request id");
+  assert.ok(
+    typeof latest.request_id === "string" && latest.request_id.startsWith("abc123"),
+    "stays traceable to the originating request"
+  );
+});
+
+test("aggregates multiple context-editing rows", () => {
+  recordContextEditingTelemetry("r1", {
+    editCount: 1,
+    clearedInputTokens: 1000,
+    clearedToolUses: 1,
+  });
+  recordContextEditingTelemetry("r2", {
+    editCount: 2,
+    clearedInputTokens: 2500,
+    clearedToolUses: 3,
+  });
+  const summary = getCompressionAnalyticsSummary();
+  assert.equal(summary.byEngine["context-editing"].count, 2);
+  assert.equal(summary.byEngine["context-editing"].tokensSaved, 3500);
+});


### PR DESCRIPTION
## What

Compression backlog follow-up **F4.1**. Surfaces the input tokens that the provider clears via Anthropic **server-side Context Editing** (shipped in #4021) into compression analytics under `engine: "context-editing"`. Until now the delegated clearing was invisible — we sent the `context_management.edits[]` param but never recorded what it actually cleared.

## How

1. **`extractContextEditingTelemetry(responseBody)`** — `open-sse/config/contextEditing.ts` (pure). Sums `applied_edits[].cleared_input_tokens` / `cleared_tool_uses`. **Defensive over the response shape** (the spec's Task-1 caution: don't hardcode a guess): probes the top-level `context_management.applied_edits` AND the `usage`-nested variants, with a camelCase fallback. Returns `null` when context editing did not run or cleared nothing.
2. **`recordContextEditingTelemetry()`** — `src/lib/db/compressionAnalytics.ts`. Writes a `compression_analytics` row (`original = cleared`, `tokens_saved = cleared`, `engine/mode = "context-editing"`). Uses a **suffixed `request_id` (`<id>::context-editing`)** so the exact-match `attachCompressionUsageReceipt` UPDATE never latches onto this row.
3. **chatCore wiring** — best-effort, **Claude-only, non-streaming** block next to the existing usage-receipt call, gated on `contextEditingEnabled`. Wrapped in try/catch; never affects the response.

## Tests (TDD, Hard Rule #18)

- `tests/unit/compression/context-editing-telemetry.test.ts` — **10** extractor tests (top-level + both nested shapes, multi-edit sum, malformed entries, zero-clear→null, numeric-string coercion).
- `tests/unit/db/context-editing-telemetry-record.test.ts` — **5** recorder DB tests (byEngine aggregation, no-op on zero/null, suffixed-id collision-safety, multi-row aggregate). Isolated temp `DATA_DIR` + `resetDbInstance()` per the DB-handle learning.
- Validation: 15 new tests green; **11 #4021 tests + 28 analytics regression tests** still green; `typecheck:core` clean; lint clean; cycles clean; `check:any-budget:t11` PASS; `file-size` re-baselined (chatCore +23) with justification.

## Scope / deferrals

- **Streaming** context-editing telemetry deferred — the final-snapshot event shape for `applied_edits` over SSE is uncertain; non-streaming (full parsed `responseBody`) is the safe, testable slice.
- The **live VPS token-drop probe** (does Anthropic actually return `applied_edits` in this exact shape) remains the operator's release-time acceptance, same as the #4021 injection probe. The defensive multi-shape parser is built precisely so the telemetry survives if the field location differs from the documented one.