### PR TITLE
fix(ws): start LiveWS sidecar with cwd at package root (#4055)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 _In development — bullets added per PR; finalized at release._
 
+### 🐛 Fixed
+
+- **fix(ws): start the LiveWS sidecar with `cwd` at the package root (global/systemd installs)** — the standalone LiveWS launcher (`scripts/start-ws-server.mjs`) re-spawns itself with `node --import tsx <self>` but did not set `cwd`. When the WebSocket sidecar was launched from outside the package directory — a global npm/homebrew install, or a `systemd`/`launchd` unit started from `$HOME` — Node could not resolve the `tsx` package (`ERR_MODULE_NOT_FOUND: Cannot find package 'tsx'`), and even from the package directory `tsx` could not resolve the tsconfig `@/*` path aliases (e.g. `@/types/databaseSettings`), so the sidecar never booted. The spawn now pins `cwd` to the package root (the directory above `scripts/`, where `package.json` + `tsconfig.json` live), which resolves both `tsx` discovery and the `@/*` aliases regardless of launch directory. ([#4055](https://github.com/diegosouzapw/OmniRoute/issues/4055) — thanks @Rahulsharma0810)
+
 ---
 
 ## [3.8.27] — 2026-06-17

--- a/scripts/start-ws-server.mjs
+++ b/scripts/start-ws-server.mjs
@@ -13,51 +13,92 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { fileURLToPath } from "node:url";
-
-if (
-  process.env.OMNIROUTE_DISABLE_LIVE_WS === "1" ||
-  process.env.OMNIROUTE_DISABLE_LIVE_WS === "true"
-) {
-  console.log("[LiveWS] Disabled via OMNIROUTE_DISABLE_LIVE_WS");
-  process.exit(0);
-}
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { dirname, join } from "node:path";
 
 const BOOTSTRAPPED_ENV = "OMNIROUTE_LIVE_WS_BOOTSTRAPPED";
 
-if (process.env[BOOTSTRAPPED_ENV] !== "1") {
-  const result = spawnSync(process.execPath, ["--import", "tsx", fileURLToPath(import.meta.url)], {
-    stdio: "inherit",
-    env: {
-      ...process.env,
-      [BOOTSTRAPPED_ENV]: "1",
-      // Prevent liveServer.ts from auto-starting on import; this script owns
-      // process startup so errors propagate to the supervisor/CLI caller.
-      OMNIROUTE_ENABLE_LIVE_WS: "0",
-    },
-  });
-
-  if (result.signal) {
-    process.kill(process.pid, result.signal);
-  }
-
-  process.exit(result.status ?? 1);
+/**
+ * Package root for the launcher = the directory above `scripts/`, where
+ * `package.json` and `tsconfig.json` (which defines the `@/*` path aliases)
+ * live. Derived from the script URL so it is correct no matter where the
+ * process was launched from.
+ */
+export function resolvePackageRoot(scriptUrl) {
+  return join(dirname(fileURLToPath(scriptUrl)), "..");
 }
 
-const { startLiveDashboardServer } = await import("../src/server/ws/liveServer.ts");
+/**
+ * Build the re-spawn spec for the bootstrap stage. The sidecar is launched with
+ * `node --import tsx <self>`; #4055: without `cwd` pinned to the package root, a
+ * launch from outside the package dir (global npm / homebrew, or a
+ * systemd/launchd unit started from $HOME) fails with
+ * `ERR_MODULE_NOT_FOUND: Cannot find package 'tsx'`, and even from the package
+ * dir tsx cannot resolve the tsconfig `@/*` aliases. Pinning `cwd` to the
+ * package root fixes both — tsx and tsconfig are both discovered there.
+ */
+export function buildSidecarSpawn(scriptUrl, env = process.env) {
+  return {
+    command: process.execPath,
+    args: ["--import", "tsx", fileURLToPath(scriptUrl)],
+    options: {
+      // #4055: pin cwd to the package root so `node --import tsx` resolves the
+      // `tsx` package and the tsconfig `@/*` aliases regardless of where the
+      // process manager (npm-global / homebrew / systemd / launchd) launched us.
+      cwd: resolvePackageRoot(scriptUrl),
+      stdio: "inherit",
+      env: {
+        ...env,
+        [BOOTSTRAPPED_ENV]: "1",
+        // Prevent liveServer.ts from auto-starting on import; this script owns
+        // process startup so errors propagate to the supervisor/CLI caller.
+        OMNIROUTE_ENABLE_LIVE_WS: "0",
+      },
+    },
+  };
+}
 
-const port = parseInt(process.env.LIVE_WS_PORT || "20129", 10);
-const host = process.env.LIVE_WS_HOST || "127.0.0.1";
+async function main() {
+  if (
+    process.env.OMNIROUTE_DISABLE_LIVE_WS === "1" ||
+    process.env.OMNIROUTE_DISABLE_LIVE_WS === "true"
+  ) {
+    console.log("[LiveWS] Disabled via OMNIROUTE_DISABLE_LIVE_WS");
+    process.exit(0);
+  }
 
-console.log(`[LiveWS] Starting dashboard WebSocket server on ${host}:${port}...`);
+  if (process.env[BOOTSTRAPPED_ENV] !== "1") {
+    const { command, args, options } = buildSidecarSpawn(import.meta.url);
+    const result = spawnSync(command, args, options);
 
-startLiveDashboardServer(port, host)
-  .then(() => {
+    if (result.signal) {
+      process.kill(process.pid, result.signal);
+    }
+
+    process.exit(result.status ?? 1);
+  }
+
+  const { startLiveDashboardServer } = await import("../src/server/ws/liveServer.ts");
+
+  const port = parseInt(process.env.LIVE_WS_PORT || "20129", 10);
+  const host = process.env.LIVE_WS_HOST || "127.0.0.1";
+
+  console.log(`[LiveWS] Starting dashboard WebSocket server on ${host}:${port}...`);
+
+  try {
+    await startLiveDashboardServer(port, host);
     console.log(`[LiveWS] Dashboard WebSocket server listening on ws://${host}:${port}`);
     console.log("[LiveWS] Connect via: ws://localhost:%d?token=<api-key>", port);
     console.log("[LiveWS] Channels: requests, combo, credentials");
-  })
-  .catch((err) => {
+  } catch (err) {
     console.error("[LiveWS] Failed to start:", err);
     process.exit(1);
-  });
+  }
+}
+
+// Only run when invoked as the entry point — importing this module (e.g. from a
+// unit test exercising the spawn-spec helpers) must not spawn or exit.
+const invokedPath = process.argv[1] ? pathToFileURL(process.argv[1]).href : "";
+if (import.meta.url === invokedPath) {
+  await main();
+}

--- a/tests/unit/start-ws-server-cwd-4055.test.mjs
+++ b/tests/unit/start-ws-server-cwd-4055.test.mjs
@@ -1,0 +1,47 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { pathToFileURL } from "node:url";
+
+// #4055: the LiveWS sidecar launcher re-spawns itself with `node --import tsx`.
+// Without `cwd` at the package root, a launch from outside the package dir
+// (global npm / homebrew, or a systemd/launchd unit started from $HOME) fails
+// with `ERR_MODULE_NOT_FOUND: Cannot find package 'tsx'` and, even from the
+// package dir, cannot resolve the tsconfig `@/*` path aliases. The spawn must
+// therefore pin `cwd` to the package root (the dir above `scripts/`).
+const mod = await import("../../scripts/start-ws-server.mjs");
+
+test("#4055: resolvePackageRoot points at the dir above scripts/", () => {
+  const scriptUrl = pathToFileURL(
+    "/opt/homebrew/lib/node_modules/omniroute/scripts/start-ws-server.mjs"
+  ).href;
+  assert.equal(
+    mod.resolvePackageRoot(scriptUrl),
+    "/opt/homebrew/lib/node_modules/omniroute"
+  );
+});
+
+test("#4055: the bootstrap spawn pins cwd to the package root so tsx + @/ aliases resolve", () => {
+  const scriptUrl = pathToFileURL(
+    "/opt/homebrew/lib/node_modules/omniroute/scripts/start-ws-server.mjs"
+  ).href;
+  const spec = mod.buildSidecarSpawn(scriptUrl, { PATH: "/usr/bin" });
+
+  // The whole point of #4055: cwd must be the package root, not inherited from
+  // wherever the process manager launched us.
+  assert.equal(spec.options.cwd, "/opt/homebrew/lib/node_modules/omniroute");
+
+  // Spawn shape is preserved: node --import tsx <self>.
+  assert.equal(spec.command, process.execPath);
+  assert.deepEqual(spec.args, [
+    "--import",
+    "tsx",
+    "/opt/homebrew/lib/node_modules/omniroute/scripts/start-ws-server.mjs",
+  ]);
+
+  // Bootstrap guard + auto-start suppression are still wired through the env.
+  assert.equal(spec.options.env.OMNIROUTE_LIVE_WS_BOOTSTRAPPED, "1");
+  assert.equal(spec.options.env.OMNIROUTE_ENABLE_LIVE_WS, "0");
+  // Caller env is preserved.
+  assert.equal(spec.options.env.PATH, "/usr/bin");
+  assert.equal(spec.options.stdio, "inherit");
+});


### PR DESCRIPTION
Closes #4055 (sub-issues 1 & 2 — the tsx + `@/`-alias resolution failures)

## Problem
The standalone LiveWS launcher `scripts/start-ws-server.mjs` re-spawns itself with `node --import tsx <self>` but did **not** set `cwd`. When the sidecar is launched from outside the package directory — a **global npm / homebrew install**, or a **`systemd`/`launchd`** unit started from `$HOME` (exactly the reporter's scenario) — Node can't resolve the `tsx` package:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'tsx' imported from /Users/rvs/
```

…and, even from the package directory, `tsx` can't resolve the tsconfig `@/*` path aliases (`@/types/databaseSettings`, etc.), so the sidecar never boots.

## Root cause & fix
Both sub-issues stem from the **same missing `cwd`**: with `cwd` pinned to the package root (the dir above `scripts/`, where `package.json` + `tsconfig.json` live), `tsx` is discovered **and** the tsconfig path aliases resolve. The fix is a single `cwd` addition to the spawn — the reporter's alternative (converting `@/` imports to relative across 6 core files) is **not needed** and would fight the project's `@/` convention.

The launcher was refactored to extract two pure helpers (`resolvePackageRoot`, `buildSidecarSpawn`) and guard the top-level execution behind an `isMain` check so the spawn logic is unit-testable without spawning. Runtime behavior when invoked as the entry point is unchanged.

## Validation (Hard Rule #18)
- **TDD:** `tests/unit/start-ws-server-cwd-4055.test.mjs` asserts the spawn options pin `cwd` to the package root (+ args/env shape). Confirmed **RED before** (`cwd === undefined`) / **GREEN after**.
- **Behavioral repro:** launching the script from a foreign cwd (`/tmp`) reproduced the exact `Cannot find package 'tsx' imported from /tmp/` error before the fix; **after** the fix the same foreign-cwd launch boots cleanly (`[LiveWS] … listening on ws://…`, no tsx/alias errors).
- typecheck:core clean · file-size OK · docs-sync PASS · ws .mjs test cluster 8/8.

## Out of scope (separate follow-ups, noted on the issue)
- Sub-issue 3 — LAN `/live-ws` proxy in `dist/server-ws.mjs` (production WS wrapper) needs its own LAN-validated change.
- Sub-issue 4 — warn when `JWT_SECRET` is unset (Next.js + sidecar otherwise mint different in-memory secrets).