### PR TITLE
chore(deps): freeze @huggingface/transformers in dependabot (hard-pin)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,14 @@ updates:
       # the duplication gate — migrate the gate intentionally, not via dependabot.
       - dependency-name: "jscpd"
         update-types: ["version-update:semver-major"]
+      # @huggingface/transformers is HARD-PINNED at 3.5.2 (exact, no caret) — FROZEN.
+      # It is load-bearing for the LLMLingua ONNX compression engine (open-sse/services/
+      # compression/engines/llmlingua/ — worker.ts pins @huggingface/transformers@3.5.2)
+      # and for local memory embeddings (src/lib/memory/embedding/transformersLocal.ts),
+      # and was VPS-validated at 3.5.2 (#4014). 4.x breaks both, and even 3.x minors must
+      # be re-validated on the VPS — so freeze ALL auto-bumps (no update-types = ignore
+      # every version). Migrate it intentionally, not via dependabot (#4050).
+      - dependency-name: "@huggingface/transformers"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## O quê
Congela `@huggingface/transformers` no `.github/dependabot.yml` (bloco npm `/`) — ignora **todas** as atualizações (sem `update-types` = ignora qualquer versão), não só o major.

## Por quê
`@huggingface/transformers` está **hard-pinned em `3.5.2`** (exato, sem caret) e é **load-bearing**:
- engine de compressão **LLMLingua** (ONNX) em `open-sse/services/compression/engines/llmlingua/` — `worker.ts` cita literalmente `@huggingface/transformers@3.5.2`;
- **embeddings locais de memória** em `src/lib/memory/embedding/transformersLocal.ts`;
- **VPS-validado** em 3.5.2 (#4014).

O major 4.x quebra ambos; e **mesmo um minor** (o dependabot chegou a propor 3.8.1 no #4050 após o ignore-major) precisa de re-validação no VPS. Por isso congelamos qualquer bump automático — o pin só deve mover via migração deliberada e validada, não por PR do dependabot. Espelha o precedente do pin `jscpd@4`.

## Validação
- `dependabot.yml` YAML válido. Config-only.