### PR TITLE
chore(docs): update Discord invite link to a non-expiring one

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@
 
 ### 💬 Join the community
 
-[![Discord](https://img.shields.io/badge/Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/hmexnhgE)
+[![Discord](https://img.shields.io/badge/Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/EkzRkpzKYt)
 [![Telegram](https://img.shields.io/badge/Telegram-26A5E4?style=for-the-badge&logo=telegram&logoColor=white)](https://t.me/omnirouteOficial)
 [![WhatsApp Global](https://img.shields.io/badge/WhatsApp_Global-25D366?style=for-the-badge&logo=whatsapp&logoColor=white)](https://chat.whatsapp.com/JI7cDQ1GyaiDHhVBpLxf8b?mode=gi_t)
 [![WhatsApp Brasil](https://img.shields.io/badge/WhatsApp_Brasil-25D366?style=for-the-badge&logo=whatsapp&logoColor=white)](https://chat.whatsapp.com/BTGJXIyjeNIIgExvTMGGhI)
 
-**Questions, provider tips, roadmap & support → [Discord](https://discord.gg/hmexnhgE) · [Telegram](https://t.me/omnirouteOficial) · WhatsApp [🌍 Global](https://chat.whatsapp.com/JI7cDQ1GyaiDHhVBpLxf8b?mode=gi_t) / [🇧🇷 Brasil](https://chat.whatsapp.com/BTGJXIyjeNIIgExvTMGGhI)**
+**Questions, provider tips, roadmap & support → [Discord](https://discord.gg/EkzRkpzKYt) · [Telegram](https://t.me/omnirouteOficial) · WhatsApp [🌍 Global](https://chat.whatsapp.com/JI7cDQ1GyaiDHhVBpLxf8b?mode=gi_t) / [🇧🇷 Brasil](https://chat.whatsapp.com/BTGJXIyjeNIIgExvTMGGhI)**
 
 <br/>
 

--- a/docs/getting-started/QUICK-START.md
+++ b/docs/getting-started/QUICK-START.md
@@ -131,5 +131,5 @@ OmniRoute automatically skips failed providers and tries the next one. You don't
 ## Need Help?
 
 - **[Troubleshooting](./TROUBLESHOOTING.md)** — Common issues and fixes
-- **[Discord](https://discord.gg/hmexnhgE)** — Community support
+- **[Discord](https://discord.gg/EkzRkpzKYt)** — Community support
 - **[GitHub Issues](https://github.com/diegosouzapw/OmniRoute/issues)** — Report bugs

--- a/docs/getting-started/TROUBLESHOOTING.md
+++ b/docs/getting-started/TROUBLESHOOTING.md
@@ -30,7 +30,7 @@ Common problems and solutions for OmniRoute.
 | "401 Unauthorized" | Your credentials are wrong | Check your API key or re-authenticate with OAuth |
 | "429 Too Many Requests" | Rate limited | Wait 1 minute, or connect more providers |
 
-**Still stuck?** See the [Quick Fixes](#quick-fixes) below, or ask on [Discord](https://discord.gg/hmexnhgE).
+**Still stuck?** See the [Quick Fixes](#quick-fixes) below, or ask on [Discord](https://discord.gg/EkzRkpzKYt).
 
 ---
 

--- a/docs/guides/TROUBLESHOOTING.md
+++ b/docs/guides/TROUBLESHOOTING.md
@@ -30,7 +30,7 @@ Common problems and solutions for OmniRoute.
 | "401 Unauthorized" | Your credentials are wrong | Check your API key or re-authenticate with OAuth |
 | "429 Too Many Requests" | Rate limited | Wait 1 minute, or connect more providers |
 
-**Still stuck?** See the [detailed troubleshooting](#detailed-troubleshooting) below, or ask on [Discord](https://discord.gg/hmexnhgE).
+**Still stuck?** See the [detailed troubleshooting](#detailed-troubleshooting) below, or ask on [Discord](https://discord.gg/EkzRkpzKYt).
 
 ---
 


### PR DESCRIPTION
Updates the community Discord invite across the project to a permanent (non-expiring) invite: `https://discord.gg/EkzRkpzKYt`.

The previous invite (`discord.gg/hmexnhgE`) was expiring. Replaced all 5 occurrences across 4 docs:
- `README.md` (community badge + support line)
- `docs/getting-started/QUICK-START.md`
- `docs/getting-started/TROUBLESHOOTING.md`
- `docs/guides/TROUBLESHOOTING.md`

Docs-only change. The `discord.com/api/webhooks/*` references (webhook feature docs/code) are unrelated and were left untouched. `check:docs-sync` + `check:file-size` pass.