### PR TITLE
ci(quality): flip TIA impacted-unit-tests gate to blocking (Fase 9 P2)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -56,13 +56,14 @@ jobs:
       # unit tests impacted by this PR's changed files. Fail-safe runs the FULL
       # unit suite on hub/unmapped changes — TIA accelerates, never replaces, the net.
       #
-      # ADVISORY for now (repo convention: advisory -> blocking). release/v3.8.27 carries
-      # ~17 pre-existing red unit tests (budget #3537, apiKey #3552, several Zod schemas,
-      # executors, etc.) unrelated to this PR; running them is what surfaced the debt.
-      # Keep this advisory until that debt is cleared, THEN remove continue-on-error to
-      # block test regressions on PR->release. typecheck:core above stays blocking.
-      - name: Impacted unit tests (TIA, fail-safe full; advisory until release test-debt cleared)
-        continue-on-error: true
+      # BLOCKING (flipped 2026-06-17). The pre-existing release unit test-debt that kept
+      # this advisory was cleared: #4030 (16 Zod/registry reds, lossless restore) and
+      # #4063 (the last red — the LiveWS boot test — root-caused as a real event-loop
+      # stall in the WS sidecar, fixed + relocated to the integration suite). A full
+      # ci.yml run on release/v3.8.28 then showed all 8 unit shards green, so PR->release
+      # now blocks on unit-test regressions in the impacted set (typecheck:core already
+      # blocked above). Fail-safe still runs the FULL unit suite on hub/unmapped changes.
+      - name: Impacted unit tests (TIA, fail-safe full; blocking)
         env:
           GITHUB_BASE_REF: ${{ github.base_ref }}
         run: |


### PR DESCRIPTION
## Quality Gate v2 / Fase 9 — P2 (final step)

Flips the TIA **Impacted unit tests** step in `quality.yml` from `advisory` →
**blocking**, closing the fast-gates "no tests run on PR→release" hole. This is the
last step of P2; the prerequisite fixes are merged.

### Why it's safe now

The pre-existing release unit test-debt that justified `continue-on-error` is cleared:

| Red | Resolution |
|-----|------------|
| 16 Zod/registry reds (oyi77 lossy modularize refactors) | **#4030** — lossless restore |
| LiveWS boot test (the last one) | **#4063** — root-caused as a real deterministic event-loop stall in the WS sidecar (cold ~7s lazy auth import racing a 2nd connection), **not** an env flake; fixed (warm the import at startup) + relocated to the integration suite |

A full `workflow_dispatch` `ci.yml` run on `release/v3.8.28` (sha `3d3ad84d4`, both fixes
in) then showed **all 8 Unit Tests shards green** — proof the unit suite is now
deterministic.

> The Integration Tests / Quality Ratchet reds on that run are **pre-existing and
> unrelated** to this change: combo/resilience env-flakes (some hitting the 2-min
> timeout) that were already red pre-fix, and `eslintWarnings`/`i18nUiCoverage` baseline
> drift from other merges. The TIA gate runs **only unit tests**, so they don't affect it.

### What changes

- Removes `continue-on-error: true` from the TIA step.
- Fail-safe still runs the **full** unit suite on hub/unmapped changes.
- `typecheck:core` was already blocking; this adds the impacted-unit-test net.

The gate mechanism was already proven on #4063's own PR run: it correctly selected
`live-ws-cookie-parse.test.ts` + `live-ws-default.test.ts` for the `liveServer.ts` change
and they passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)