### PR TITLE
test(dashboard): smoke e2e for the Combo Live Studio page (F5.2)

### DIFF
--- a/tests/e2e/combo-live-studio.spec.ts
+++ b/tests/e2e/combo-live-studio.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "@playwright/test";
+import { gotoDashboardRoute } from "./helpers/dashboardAuth";
+
+/**
+ * F5.2 — Combo Live Studio (Tela B) smoke e2e.
+ *
+ * The cascade's per-target/per-provider logic is exhaustively unit-tested
+ * (comboFlowModel reducer + enrich overlays) and the badges are vitest-covered
+ * (ProviderCascadeNode). What unit tests CANNOT catch is a client-side render /
+ * hydration crash on the real page — exactly the "no useTranslations trap on the
+ * new page" risk the Tela B plan called out.
+ *
+ * This spec is that guard: it loads /dashboard/combos/live and asserts the studio
+ * renders (cascade shell OR empty state). The visibility assertion IS the
+ * hydration-trap guard — a `useTranslations`-outside-provider crash throws during
+ * render, so neither testid would ever appear, and the page mounting at all proves
+ * the U1b health-poll wiring (in the same client tree) loaded.
+ *
+ * Out of scope (kept unit-covered, to stay non-flaky): driving live combo cascades
+ * (needs WS combo events an e2e cannot inject) and asserting console output
+ * (dev-mode on-demand compilation emits transient fast-refresh noise the production
+ * build CI runs against does not).
+ */
+test.describe("Combo Live Studio (Tela B)", () => {
+  test("loads /dashboard/combos/live and renders the studio without crashing", async ({ page }) => {
+    await gotoDashboardRoute(page, "/dashboard/combos/live");
+
+    // The studio always renders one of these — never a blank/crashed page.
+    const studioOrEmpty = page
+      .locator('[data-testid="combo-live-studio"]')
+      .or(page.locator('[data-testid="combo-live-studio-empty"]'))
+      .first();
+    await expect(studioOrEmpty).toBeVisible({ timeout: 30_000 });
+  });
+});


### PR DESCRIPTION
## What

Compression backlog follow-up **F5.2** — a Playwright **smoke e2e** for `/dashboard/combos/live` (Combo Live Studio / Tela B). Completes the Combo Studio U1b work (Slice 1 #4029 + Slice 2 #4068 are merged; this is their e2e guard).

## Why a smoke test (and not a full cascade drive)

The cascade's logic is already exhaustively covered:
- `comboFlowModel` reducer + `enrichRunWithBreakers` + `enrichRunWithConnectionCooldown` → node:test.
- `ProviderCascadeNode` badges (CB + cooldown) → vitest.

What unit tests **cannot** catch is a **client-side render / hydration crash** on the real page — exactly the *"no `useTranslations` trap on the new page"* risk the Tela B plan flagged. This spec is that guard: it loads the page and asserts the studio renders (cascade shell **or** empty state). The visibility assertion **is** the hydration-trap guard — a `useTranslations`-outside-provider crash throws during render, so neither testid would ever appear, and the page mounting proves the U1b health-poll wiring (same client tree) loaded.

## Deliberately out of scope (to stay non-flaky)

- **Driving live combo cascades** — needs WS `combo.target.*` events an e2e cannot inject without flakiness; that behaviour stays unit-covered.
- **Console-output assertions** — `next dev`'s on-demand compilation emits transient fast-refresh noise the production build CI runs against does not, so a console-error assertion would be flaky (removed after observing exactly this).

## Validation

Run locally against a real booted dev server (isolated `DATA_DIR` + alt port): the render assertion **passed** in repeated runs. `check:test-discovery` recognizes the spec (not an orphan); lint clean.

**CI note:** Playwright e2e runs in `ci.yml` on push/PR to **main** — i.e. when the release merges to main — not in the release-PR fast gates (Fast QG / dast-smoke / semgrep), by repo design. So this spec is validated at the release→main step, consistent with every other e2e spec in the repo.