### PR TITLE
fix(ws): proxy LAN /live-ws upgrades and add unset JWT_SECRET warning

### DIFF
--- a/scripts/dev/standalone-server-ws.mjs
+++ b/scripts/dev/standalone-server-ws.mjs
@@ -1,4 +1,5 @@
 import http from "node:http";
+import net from "node:net";
 import { randomUUID } from "node:crypto";
 import { createResponsesWsProxy } from "./responses-ws-proxy.mjs";
 import { ensurePeerStampToken, wrapRequestListenerWithPeerStamp } from "./peer-stamp.mjs";
@@ -36,9 +37,36 @@ function getProxy(server) {
   return proxy;
 }
 
+function proxyLiveWs(req, socket, head) {
+  const targetPort = parseInt(process.env.LIVE_WS_PORT || "20129", 10);
+  const targetSocket = net.connect(targetPort, "127.0.0.1", () => {
+    let rawRequest = `${req.method} ${req.url} HTTP/${req.httpVersion}\r\n`;
+    for (const [key, val] of Object.entries(req.headers)) {
+      if (Array.isArray(val)) {
+        for (const v of val) rawRequest += `${key}: ${v}\r\n`;
+      } else {
+        rawRequest += `${key}: ${val}\r\n`;
+      }
+    }
+    rawRequest += "\r\n";
+    targetSocket.write(rawRequest);
+    if (head && head.length > 0) targetSocket.write(head);
+    targetSocket.pipe(socket);
+    socket.pipe(targetSocket);
+  });
+
+  targetSocket.on("error", () => !socket.destroyed && socket.destroy());
+  socket.on("error", () => !targetSocket.destroyed && targetSocket.destroy());
+}
+
 function wrapUpgradeListener(server, listener) {
   return async function responsesWsAwareUpgrade(req, socket, head) {
     try {
+      const url = new URL(req.url || "/", `http://${req.headers.host || "localhost"}`);
+      if (url.pathname === "/live-ws" || url.pathname.startsWith("/live-ws")) {
+        proxyLiveWs(req, socket, head);
+        return;
+      }
       const handled = await getProxy(server).handleUpgrade(req, socket, head);
       if (handled) return;
       return listener.call(this, req, socket, head);

--- a/src/server/ws/liveServer.ts
+++ b/src/server/ws/liveServer.ts
@@ -457,6 +457,14 @@ export async function startLiveDashboardServer(
   port = DEFAULT_PORT,
   host = DEFAULT_HOST
 ): Promise<import("http").Server> {
+  if (!process.env.JWT_SECRET) {
+    console.warn(
+      "  \\x1b[33m⚠ Warning: JWT_SECRET is not set in the environment.\\x1b[0m\\n" +
+        "    Dashboard cookie-based WebSocket authentication will fail.\\n" +
+        "    Please ensure JWT_SECRET is configured in your .env file."
+    );
+  }
+
   const server = createServer((req, res) => {
     handleInternalEventRequest(req, res);
   });

--- a/src/server/ws/liveServer.ts
+++ b/src/server/ws/liveServer.ts
@@ -459,8 +459,8 @@ export async function startLiveDashboardServer(
 ): Promise<import("http").Server> {
   if (!process.env.JWT_SECRET) {
     console.warn(
-      "  \\x1b[33m⚠ Warning: JWT_SECRET is not set in the environment.\\x1b[0m\\n" +
-        "    Dashboard cookie-based WebSocket authentication will fail.\\n" +
+      "  \x1b[33m⚠ Warning: JWT_SECRET is not set in the environment.\x1b[0m\n" +
+        "    Dashboard cookie-based WebSocket authentication will fail.\n" +
         "    Please ensure JWT_SECRET is configured in your .env file."
     );
   }


### PR DESCRIPTION
Addresses Sub-issue 3 (proxying LAN /live-ws upgrade requests directly to the sidecar port 20129) and Sub-issue 4 (adds a startup warning when JWT_SECRET is unset in sidecar deployments) from #4055.