### PR TITLE
fix(sse): friendly 413 message for ChatGPT web payload-too-large

### DIFF
--- a/open-sse/executors/chatgpt-web.ts
+++ b/open-sse/executors/chatgpt-web.ts
@@ -16,6 +16,7 @@
  */
 
 import { BaseExecutor, type ExecuteInput, type ProviderCredentials } from "./base.ts";
+import { describeChatGptWebHttpError } from "./chatgptWebErrors.ts";
 import { createHash, randomUUID, randomBytes } from "node:crypto";
 import {
   tlsFetchChatGpt,
@@ -2742,16 +2743,9 @@ export class ChatGptWebExecutor extends BaseExecutor {
       // upstream message is much more useful than our wrapper. Goes through
       // the executor logger so it respects the application's log config.
       log?.warn?.("CGPT-WEB", `conv ${status}: ${(response.text || "").slice(0, 400)}`);
-      let errMsg = `ChatGPT returned HTTP ${status}`;
+      const errMsg = describeChatGptWebHttpError(status);
       if (status === 401 || status === 403) {
-        errMsg =
-          "ChatGPT auth failed — session may have expired. Re-paste your __Secure-next-auth.session-token.";
         tokenCache.delete(cookieKey(cookie));
-      } else if (status === 404) {
-        errMsg =
-          "ChatGPT returned 404 — usually the model is no longer available on this account or the chat-requirements-token expired. Retry will start a fresh conversation.";
-      } else if (status === 429) {
-        errMsg = "ChatGPT rate limited. Wait a moment and retry.";
       }
       log?.warn?.("CGPT-WEB", errMsg);
       return {

--- a/open-sse/executors/chatgptWebErrors.ts
+++ b/open-sse/executors/chatgptWebErrors.ts
@@ -1,0 +1,18 @@
+/**
+ * User-facing messages for upstream ChatGPT-web HTTP error statuses.
+ *
+ * Pure mapping with no side effects so it can be unit-tested in isolation — the
+ * caller owns any state mutation (e.g. clearing the token cache on 401/403).
+ * Unmapped statuses fall back to the generic `ChatGPT returned HTTP <status>`.
+ */
+const CGPT_WEB_HTTP_ERROR_MESSAGES: Record<number, string> = {
+  401: "ChatGPT auth failed — session may have expired. Re-paste your __Secure-next-auth.session-token.",
+  403: "ChatGPT auth failed — session may have expired. Re-paste your __Secure-next-auth.session-token.",
+  404: "ChatGPT returned 404 — usually the model is no longer available on this account or the chat-requirements-token expired. Retry will start a fresh conversation.",
+  413: "ChatGPT returned 413 — the request payload is too large for ChatGPT web's size limit (often hit by agentic clients like Cline/Kilo that send big system prompts and file context). Reduce the context: enable compression, trim the conversation/files, or use a smaller request.",
+  429: "ChatGPT rate limited. Wait a moment and retry.",
+};
+
+export function describeChatGptWebHttpError(status: number): string {
+  return CGPT_WEB_HTTP_ERROR_MESSAGES[status] ?? `ChatGPT returned HTTP ${status}`;
+}

--- a/tests/unit/chatgpt-web.test.ts
+++ b/tests/unit/chatgpt-web.test.ts
@@ -3,6 +3,9 @@ import assert from "node:assert/strict";
 
 const { ChatGptWebExecutor, __derivePublicBaseUrlForTesting, __resetChatGptWebCachesForTesting } =
   await import("../../open-sse/executors/chatgpt-web.ts");
+const { describeChatGptWebHttpError } = await import(
+  "../../open-sse/executors/chatgptWebErrors.ts"
+);
 const { getExecutor, hasSpecializedExecutor } = await import("../../open-sse/executors/index.ts");
 const { __setTlsFetchOverrideForTesting, looksLikeSse, TlsClientUnavailableError } =
   await import("../../open-sse/services/chatgptTlsClient.ts");
@@ -2771,4 +2774,35 @@ test("Image cache: deleting an entry decrements the byte counter", async () => {
     0,
     "bytes credited back on TTL evict"
   );
+});
+
+// ─── describeChatGptWebHttpError ─────────────────────────────────────────────
+
+test("describeChatGptWebHttpError maps 413 to a payload-too-large message with guidance", () => {
+  const msg = describeChatGptWebHttpError(413);
+  // Must NOT be the cryptic generic — should explain it's a size limit and how to recover.
+  assert.notEqual(
+    msg,
+    "ChatGPT returned HTTP 413",
+    "413 should get a tailored message, not the generic fallback"
+  );
+  assert.match(msg, /413/, "message keeps the status code");
+  assert.match(msg, /too large|payload|size limit/i, "message explains it's a size/payload limit");
+  assert.match(
+    msg,
+    /context|compress/i,
+    "message points the user at reducing context / compression"
+  );
+});
+
+test("describeChatGptWebHttpError preserves the existing 401/403/404/429 mappings", () => {
+  assert.match(describeChatGptWebHttpError(401), /session may have expired/i);
+  assert.match(describeChatGptWebHttpError(403), /session may have expired/i);
+  assert.match(describeChatGptWebHttpError(404), /no longer available|fresh conversation/i);
+  assert.match(describeChatGptWebHttpError(429), /rate limited/i);
+});
+
+test("describeChatGptWebHttpError falls back to the generic message for unmapped statuses", () => {
+  assert.equal(describeChatGptWebHttpError(500), "ChatGPT returned HTTP 500");
+  assert.equal(describeChatGptWebHttpError(502), "ChatGPT returned HTTP 502");
 });


### PR DESCRIPTION
## Problem
`chatgpt-web` (ChatGPT Web provider) surfaces a cryptic `ChatGPT returned HTTP 413` when the upstream rejects an oversized request. The executor already maps `401/403/404/429` to actionable messages, but `413` fell through to the generic wrapper. ChatGPT web returns 413 when the payload exceeds its size limit — commonly hit by agentic clients (Cline/Kilo) that send large system prompts + file context.

Reported via community triage (escalated backlog).

## Fix (message only — behavior unchanged)
- New pure helper `open-sse/executors/chatgptWebErrors.ts` maps status → user-facing message, with a **413** branch that explains the size limit and how to recover (enable compression, trim context). Unmapped statuses keep the generic fallback.
- `chatgpt-web.ts` now calls the helper instead of an inline if-chain. The `401/403` token-cache eviction **side effect is preserved**; the `401/403/404/429` messages are byte-identical. The file **shrinks** (2869 → 2863 LOC).
- Does **not** change the 413 status or any routing behavior — it only improves the error text.

## TDD
Red → green: a test asserting `413` gets a tailored message first failed (returned the generic), then passed after adding the branch.
- New: `describeChatGptWebHttpError` — 413 guidance, 401/403/404/429 preserved, 500/502 generic fallback.
- `tests/unit/chatgpt-web.test.ts`: **79/79** pass.

## Validation
typecheck:core ✓ · lint 0 errors ✓ · check:cycles ✓ · file-size ✓ (no baseline bump; file shrank, new module 18 < 800 cap) · provider-consistency ✓ · known-symbols ✓
