### PR TITLE
feat(compression): RTK learn/discover (sample source + API + UI)

### DIFF
--- a/open-sse/services/compression/engines/rtk/index.ts
+++ b/open-sse/services/compression/engines/rtk/index.ts
@@ -604,4 +604,12 @@ export {
   detectCommandType,
 } from "./commandDetector.ts";
 export { runRtkFilterTests } from "./verify.ts";
-export { maybePersistRtkRawOutput, readRtkRawOutput, redactRtkRawOutput } from "./rawOutput.ts";
+export {
+  maybePersistRtkRawOutput,
+  readRtkRawOutput,
+  redactRtkRawOutput,
+  listRtkCommandSamples,
+} from "./rawOutput.ts";
+// RTK learn/discover: the sample-source adapter (rawOutput) feeds these pure miners.
+export { discoverRepeatedNoise, type NoiseCandidate, type CommandSample } from "./discover.ts";
+export { suggestFilter, commandToId, type SuggestedFilter } from "./learn.ts";

--- a/open-sse/services/compression/engines/rtk/learn.ts
+++ b/open-sse/services/compression/engines/rtk/learn.ts
@@ -106,7 +106,7 @@ const SUMMARY_PATTERN =
  *   "npm install"  → "npm-install"
  *   "pip install"  → "pip-install"
  */
-function commandToId(command: string): string {
+export function commandToId(command: string): string {
   return command
     .trim()
     .toLowerCase()

--- a/open-sse/services/compression/engines/rtk/rawOutput.ts
+++ b/open-sse/services/compression/engines/rtk/rawOutput.ts
@@ -3,6 +3,8 @@ import path from "node:path";
 import os from "node:os";
 import crypto from "node:crypto";
 
+import type { CommandSample } from "./discover.ts";
+
 export type RtkRawOutputRetention = "never" | "failures" | "always";
 
 export interface RtkRawOutputPointer {
@@ -90,6 +92,27 @@ export function maybePersistRtkRawOutput(
   fs.mkdirSync(dir, { recursive: true });
   fs.writeFileSync(filePath, redaction.text);
 
+  // Sidecar metadata: the .log filename only carries a lossy command SLUG, so persist
+  // the FULL command (and timestamp/flags) next to it. Keeps the .log pure output (the
+  // raw-output recovery route still returns it verbatim) while letting the RTK
+  // learn/discover sample source recover the exact command. Best-effort: a sidecar
+  // write failure never fails the capture.
+  try {
+    const metaPath = filePath.replace(/\.log$/, ".meta.json");
+    fs.writeFileSync(
+      metaPath,
+      JSON.stringify({
+        command: options.command ?? null,
+        timestamp: now,
+        failure,
+        redacted: redaction.redacted,
+        bytes: Buffer.byteLength(redaction.text, "utf8"),
+      })
+    );
+  } catch {
+    // Sidecar is an optimisation for learn/discover; the .log (with slug) still works.
+  }
+
   return {
     id,
     path: filePath,
@@ -109,4 +132,65 @@ export function readRtkRawOutput(pointerId: string): string | null {
   const fullPath = path.join(dir, entry);
   if (!fullPath.startsWith(dir)) return null;
   return fs.readFileSync(fullPath, "utf8");
+}
+
+/** Recover the command for a `.log` from its filename slug (legacy, sidecar-less captures). */
+function commandFromSlug(fileName: string): string {
+  // `<timestamp>-<slug>-<id>.log` → strip the leading timestamp and the trailing id.
+  const slug = fileName
+    .replace(/^\d+-/, "")
+    .replace(/-[0-9a-f]{24}\.log$/i, "")
+    .replace(/\.log$/i, "");
+  return slug.replace(/_+/g, " ").trim();
+}
+
+/**
+ * Read the opt-in RTK raw-output store (`DATA_DIR/rtk/raw-output/*.log`) into
+ * `CommandSample[]` for the pure miners `discoverRepeatedNoise()` / `suggestFilter()`.
+ *
+ * The command comes from the `.meta.json` sidecar when present (exact), else from the
+ * filename slug (lossy, for legacy captures). Empty/unreadable entries are skipped.
+ * Returns the most-recent-first samples, capped at `opts.limit` (default 500) to bound
+ * memory. No throw: a corrupt entry is dropped, not propagated.
+ */
+export function listRtkCommandSamples(opts: { limit?: number } = {}): CommandSample[] {
+  const dir = path.join(dataDir(), "rtk", "raw-output");
+  if (!fs.existsSync(dir)) return [];
+  const limit = Math.max(1, Math.floor(opts.limit ?? 500));
+
+  let logs: string[];
+  try {
+    logs = fs.readdirSync(dir).filter((f) => f.endsWith(".log"));
+  } catch {
+    return [];
+  }
+  // Newest first: the filename is timestamp-prefixed, so a reverse lexical sort works.
+  logs.sort((a, b) => (a < b ? 1 : a > b ? -1 : 0));
+
+  const samples: CommandSample[] = [];
+  for (const fileName of logs) {
+    if (samples.length >= limit) break;
+    const fullPath = path.join(dir, fileName);
+    if (!fullPath.startsWith(dir)) continue;
+    let output: string;
+    try {
+      output = fs.readFileSync(fullPath, "utf8");
+    } catch {
+      continue;
+    }
+    if (output.trim().length === 0) continue;
+
+    let command = "";
+    try {
+      const metaRaw = fs.readFileSync(fullPath.replace(/\.log$/, ".meta.json"), "utf8");
+      const meta = JSON.parse(metaRaw) as { command?: unknown };
+      if (typeof meta.command === "string" && meta.command.trim()) command = meta.command.trim();
+    } catch {
+      // No/!invalid sidecar → fall back to the filename slug below.
+    }
+    if (!command) command = commandFromSlug(fileName) || "tool-output";
+
+    samples.push({ command, output });
+  }
+  return samples;
 }

--- a/src/app/(dashboard)/dashboard/context/rtk/RtkContextPageClient.tsx
+++ b/src/app/(dashboard)/dashboard/context/rtk/RtkContextPageClient.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useTranslations } from "next-intl";
 import { SegmentedControl, Collapsible } from "@/shared/components";
+import RtkLearnDiscoverCard from "./RtkLearnDiscoverCard";
 
 type RtkFilter = {
   id: string;
@@ -383,6 +384,8 @@ export default function RtkContextPageClient() {
           ))}
         </div>
       </Collapsible>
+
+      <RtkLearnDiscoverCard />
     </div>
   );
 }

--- a/src/app/(dashboard)/dashboard/context/rtk/RtkLearnDiscoverCard.tsx
+++ b/src/app/(dashboard)/dashboard/context/rtk/RtkLearnDiscoverCard.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+
+interface NoiseCandidate {
+  pattern: string;
+  hits: number;
+}
+
+interface SuggestedFilter {
+  id: string;
+  label: string;
+  description: string;
+  [key: string]: unknown;
+}
+
+/**
+ * RTK Learn & Discover card (F2.1 / Item 2).
+ *
+ * Surfaces the two read-only suggestion endpoints over the opt-in raw-output sample
+ * store:
+ *   - Discover: GET /api/context/rtk/discover  → ranked repeated-noise candidates.
+ *   - Learn:    GET /api/context/rtk/learn?command=X → a suggested filter draft.
+ *
+ * Suggestions only — the operator reviews the output and saves filters via the
+ * existing filter trust path. Fail-soft: any error shows an inline message.
+ */
+export default function RtkLearnDiscoverCard() {
+  const t = useTranslations("contextRtk");
+
+  const [discovering, setDiscovering] = useState(false);
+  const [candidates, setCandidates] = useState<NoiseCandidate[] | null>(null);
+  const [discoverCount, setDiscoverCount] = useState(0);
+
+  const [command, setCommand] = useState("");
+  const [learning, setLearning] = useState(false);
+  const [suggested, setSuggested] = useState<SuggestedFilter | null>(null);
+  const [learnCount, setLearnCount] = useState(0);
+
+  const [error, setError] = useState<string | null>(null);
+
+  async function runDiscover() {
+    setDiscovering(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/context/rtk/discover");
+      if (!res.ok) throw new Error(String(res.status));
+      const body = (await res.json()) as { sampleCount: number; candidates: NoiseCandidate[] };
+      setDiscoverCount(body.sampleCount);
+      setCandidates(Array.isArray(body.candidates) ? body.candidates : []);
+    } catch {
+      setError(t("suggestionError"));
+      setCandidates(null);
+    } finally {
+      setDiscovering(false);
+    }
+  }
+
+  async function runLearn() {
+    if (!command.trim()) return;
+    setLearning(true);
+    setError(null);
+    try {
+      const res = await fetch(
+        `/api/context/rtk/learn?command=${encodeURIComponent(command.trim())}`
+      );
+      if (!res.ok) throw new Error(String(res.status));
+      const body = (await res.json()) as { sampleCount: number; filter: SuggestedFilter };
+      setLearnCount(body.sampleCount);
+      setSuggested(body.filter ?? null);
+    } catch {
+      setError(t("suggestionError"));
+      setSuggested(null);
+    } finally {
+      setLearning(false);
+    }
+  }
+
+  return (
+    <section
+      className="rounded-lg border border-border bg-surface p-4"
+      data-testid="rtk-learn-discover"
+    >
+      <h2 className="text-sm font-semibold text-text-main">{t("learnDiscoverTitle")}</h2>
+      <p className="mt-1 text-xs text-text-muted">{t("learnDiscoverDesc")}</p>
+
+      {error && (
+        <p className="mt-3 text-xs text-red-600 dark:text-red-400" data-testid="rtk-ld-error">
+          {error}
+        </p>
+      )}
+
+      <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2">
+        {/* ── Discover ─────────────────────────────────────────────── */}
+        <div>
+          <h3 className="text-xs font-medium text-text-main">{t("discoverHeading")}</h3>
+          <button
+            type="button"
+            onClick={runDiscover}
+            disabled={discovering}
+            data-testid="rtk-discover-button"
+            className="mt-2 rounded border border-border px-2.5 py-1 text-xs font-medium text-text-main hover:bg-surface-hover disabled:opacity-50"
+          >
+            {discovering ? t("discoverScanning") : t("discoverButton")}
+          </button>
+
+          {candidates !== null && (
+            <div className="mt-3" data-testid="rtk-discover-results">
+              <p className="text-[11px] text-text-muted">
+                {t("discoverSamples", { count: discoverCount })}
+              </p>
+              {candidates.length === 0 ? (
+                <p className="mt-1 text-[11px] text-text-muted">{t("discoverEmpty")}</p>
+              ) : (
+                <ul className="mt-2 flex flex-col gap-1">
+                  {candidates.slice(0, 20).map((candidate, index) => (
+                    <li
+                      key={`${candidate.pattern}-${index}`}
+                      className="flex items-start justify-between gap-2 text-[11px]"
+                    >
+                      <code className="min-w-0 truncate text-text-main">{candidate.pattern}</code>
+                      <span className="shrink-0 text-text-muted">
+                        {t("discoverHits", { hits: candidate.hits })}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* ── Learn ────────────────────────────────────────────────── */}
+        <div>
+          <h3 className="text-xs font-medium text-text-main">{t("learnHeading")}</h3>
+          <div className="mt-2 flex gap-2">
+            <input
+              type="text"
+              value={command}
+              onChange={(event) => setCommand(event.target.value)}
+              placeholder={t("learnCommandPlaceholder")}
+              data-testid="rtk-learn-command"
+              className="min-w-0 flex-1 rounded border border-border bg-surface px-2 py-1 text-xs text-text-main"
+            />
+            <button
+              type="button"
+              onClick={runLearn}
+              disabled={learning || !command.trim()}
+              data-testid="rtk-learn-button"
+              className="shrink-0 rounded border border-border px-2.5 py-1 text-xs font-medium text-text-main hover:bg-surface-hover disabled:opacity-50"
+            >
+              {t("learnButton")}
+            </button>
+          </div>
+
+          {suggested === null ? (
+            <p className="mt-3 text-[11px] text-text-muted">{t("learnEmpty")}</p>
+          ) : (
+            <div className="mt-3" data-testid="rtk-learn-results">
+              <p className="text-[11px] text-text-muted">
+                {t("learnSamplesUsed", { count: learnCount })}
+              </p>
+              <pre className="mt-2 max-h-48 overflow-auto rounded bg-surface-hover p-2 text-[10px] text-text-main">
+                {JSON.stringify(suggested, null, 2)}
+              </pre>
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/api/context/rtk/discover/route.ts
+++ b/src/app/api/context/rtk/discover/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import {
+  discoverRepeatedNoise,
+  listRtkCommandSamples,
+} from "@omniroute/open-sse/services/compression/engines/rtk";
+import { requireManagementAuth } from "@/lib/api/requireManagementAuth";
+
+/** Parse a positive `limit` query param, clamped to [1, 2000]; default 500. */
+function parseLimit(value: string | null): number {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n <= 0) return 500;
+  return Math.min(2000, Math.floor(n));
+}
+
+/**
+ * GET /api/context/rtk/discover — mine the opt-in RTK raw-output sample store for
+ * recurring noise lines and return them as ranked candidates the operator can review
+ * and turn into strip/collapse filters. Read-only; suggestions only.
+ */
+export async function GET(request: Request) {
+  const authError = await requireManagementAuth(request);
+  if (authError) return authError;
+
+  const limit = parseLimit(new URL(request.url).searchParams.get("limit"));
+  const samples = listRtkCommandSamples({ limit });
+  const candidates = discoverRepeatedNoise(samples);
+
+  return NextResponse.json({ sampleCount: samples.length, candidates });
+}

--- a/src/app/api/context/rtk/learn/route.ts
+++ b/src/app/api/context/rtk/learn/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from "next/server";
+import {
+  suggestFilter,
+  commandToId,
+  listRtkCommandSamples,
+} from "@omniroute/open-sse/services/compression/engines/rtk";
+import { requireManagementAuth } from "@/lib/api/requireManagementAuth";
+
+/** Parse a positive `limit` query param, clamped to [1, 2000]; default 500. */
+function parseLimit(value: string | null): number {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n <= 0) return 500;
+  return Math.min(2000, Math.floor(n));
+}
+
+/**
+ * GET /api/context/rtk/learn?command=<cmd> — suggest an RTK filter draft for a
+ * command, learned from the captured outputs of THAT command in the opt-in raw-output
+ * sample store. Read-only; returns a draft for the operator to review and save (the
+ * existing filter trust path persists it). Other commands' samples are excluded so the
+ * learned drop/preserve patterns stay specific.
+ */
+export async function GET(request: Request) {
+  const authError = await requireManagementAuth(request);
+  if (authError) return authError;
+
+  const url = new URL(request.url);
+  const command = (url.searchParams.get("command") || "").trim();
+  if (!command) {
+    return NextResponse.json(
+      { error: { message: "The 'command' query parameter is required.", type: "invalid_request" } },
+      { status: 400 }
+    );
+  }
+
+  const limit = parseLimit(url.searchParams.get("limit"));
+  const targetId = commandToId(command);
+  const matching = listRtkCommandSamples({ limit }).filter(
+    (sample) => commandToId(sample.command) === targetId
+  );
+  const filter = suggestFilter(command, matching);
+
+  return NextResponse.json({ command, sampleCount: matching.length, filter });
+}

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -6016,7 +6016,21 @@
     "searchFilters": "Search filters...",
     "tooltipDedup": "How aggressively to remove repeated lines.",
     "tooltipMaxChars": "Maximum characters per output block.",
-    "tooltipMaxLines": "Maximum lines to keep from command output. Excess is truncated."
+    "tooltipMaxLines": "Maximum lines to keep from command output. Excess is truncated.",
+    "learnDiscoverTitle": "Learn & Discover filters",
+    "learnDiscoverDesc": "Mine your captured command output (Raw Output retention must be on) to suggest new RTK filters. Suggestions only — you review and save them.",
+    "discoverHeading": "Discover repeated noise",
+    "discoverButton": "Scan samples",
+    "discoverScanning": "Scanning…",
+    "discoverEmpty": "No repeated noise found. Enable Raw Output retention and run a few commands first.",
+    "discoverSamples": "{count} sample(s) scanned",
+    "discoverHits": "{hits}× across samples",
+    "learnHeading": "Learn a filter for a command",
+    "learnCommandPlaceholder": "e.g. npm install",
+    "learnButton": "Suggest filter",
+    "learnEmpty": "No suggestion yet. Type a command you have run and scan.",
+    "learnSamplesUsed": "Learned from {count} matching sample(s)",
+    "suggestionError": "Could not load suggestions. Check management auth and try again."
   },
   "contextCombos": {
     "title": "Compression Combos",

--- a/tests/unit/api/compression/rtk-learn-discover-routes.test.ts
+++ b/tests/unit/api/compression/rtk-learn-discover-routes.test.ts
@@ -1,0 +1,115 @@
+/**
+ * TDD for the RTK learn/discover API routes (F2.1 / Item 2).
+ *
+ * GET /api/context/rtk/discover           → ranked noise candidates mined from the
+ *                                            opt-in rtk raw-output sample store.
+ * GET /api/context/rtk/learn?command=X     → a suggested RTK filter draft for command X.
+ *
+ * Auth: requireManagementAuth — not required in the unconfigured/first-run state
+ * (fresh temp DATA_DIR, no INITIAL_PASSWORD), so these exercise the 200 happy path.
+ * The pure miners (discoverRepeatedNoise/suggestFilter) and the sample adapter
+ * (listRtkCommandSamples) are unit-tested separately; this asserts the wiring.
+ *
+ * Run: node --import tsx/esm --test tests/unit/api/compression/rtk-learn-discover-routes.test.ts
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-rtk-ld-routes-"));
+const ORIGINAL_DATA_DIR = process.env.DATA_DIR;
+const ORIGINAL_INITIAL_PASSWORD = process.env.INITIAL_PASSWORD;
+process.env.DATA_DIR = TEST_DATA_DIR;
+delete process.env.INITIAL_PASSWORD;
+
+const { maybePersistRtkRawOutput } = await import(
+  "../../../../open-sse/services/compression/engines/rtk/index.ts"
+);
+const discoverRoute = await import("../../../../src/app/api/context/rtk/discover/route.ts");
+const learnRoute = await import("../../../../src/app/api/context/rtk/learn/route.ts");
+
+function seedSamples() {
+  // Three runs of the same command with a shared noise line + a unique line each.
+  for (let i = 0; i < 3; i++) {
+    maybePersistRtkRawOutput(
+      `Resolving dependencies...\nnpm warn deprecated foo@1.0.0\nadded ${i} packages in ${i}s\n`,
+      { retention: "always", command: "npm install" }
+    );
+  }
+}
+
+function get(url: string): Request {
+  return new Request(url, { method: "GET" });
+}
+
+test.beforeEach(() => {
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+});
+
+test.after(() => {
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  if (ORIGINAL_DATA_DIR === undefined) delete process.env.DATA_DIR;
+  else process.env.DATA_DIR = ORIGINAL_DATA_DIR;
+  if (ORIGINAL_INITIAL_PASSWORD !== undefined)
+    process.env.INITIAL_PASSWORD = ORIGINAL_INITIAL_PASSWORD;
+});
+
+test("GET /discover — returns ranked noise candidates + sampleCount", async () => {
+  seedSamples();
+  const res = await discoverRoute.GET(get("http://localhost/api/context/rtk/discover"));
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as { sampleCount: number; candidates: Array<{ hits: number }> };
+  assert.equal(body.sampleCount, 3);
+  assert.ok(Array.isArray(body.candidates));
+  assert.ok(body.candidates.length > 0, "the shared 'Resolving dependencies' line is a candidate");
+});
+
+test("GET /discover — empty store → 200 with no candidates", async () => {
+  const res = await discoverRoute.GET(get("http://localhost/api/context/rtk/discover"));
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as { sampleCount: number; candidates: unknown[] };
+  assert.equal(body.sampleCount, 0);
+  assert.equal(body.candidates.length, 0);
+});
+
+test("GET /learn?command=npm install — returns a suggested filter learned from matching samples", async () => {
+  seedSamples();
+  const res = await learnRoute.GET(
+    get("http://localhost/api/context/rtk/learn?command=" + encodeURIComponent("npm install"))
+  );
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as {
+    command: string;
+    sampleCount: number;
+    filter: { id: string; match: { commands: string[] } };
+  };
+  assert.equal(body.command, "npm install");
+  assert.equal(body.sampleCount, 3, "only the matching command's samples are learned from");
+  assert.ok(body.filter.id.length > 0);
+  assert.ok(body.filter.match.commands.length > 0);
+});
+
+test("GET /learn without a command → 400", async () => {
+  const res = await learnRoute.GET(get("http://localhost/api/context/rtk/learn"));
+  assert.equal(res.status, 400);
+  const body = (await res.json()) as { error: { message?: string } | string };
+  // Error must not leak a stack trace (Hard Rule #12).
+  const msg = typeof body.error === "string" ? body.error : (body.error?.message ?? "");
+  assert.ok(!msg.includes("at /"), "no stack trace in error body");
+});
+
+test("GET /learn filters out other commands' samples", async () => {
+  seedSamples(); // 3× "npm install"
+  maybePersistRtkRawOutput("Compiling cargo...\nFinished in 2s\n", {
+    retention: "always",
+    command: "cargo build",
+  });
+  const res = await learnRoute.GET(
+    get("http://localhost/api/context/rtk/learn?command=" + encodeURIComponent("npm install"))
+  );
+  const body = (await res.json()) as { sampleCount: number };
+  assert.equal(body.sampleCount, 3, "the cargo sample is excluded");
+});

--- a/tests/unit/compression/rtk-command-samples.test.ts
+++ b/tests/unit/compression/rtk-command-samples.test.ts
@@ -1,0 +1,121 @@
+/**
+ * TDD for RTK learn/discover sample source (F2.1).
+ *
+ * The pure miners discoverRepeatedNoise()/suggestFilter() already exist and consume
+ * CommandSample[] ({ command, output }). What was missing is the SAMPLE SOURCE: an
+ * adapter over the opt-in rtk raw-output store (DATA_DIR/rtk/raw-output/*.log).
+ *
+ * This also covers the capture enhancement: maybePersistRtkRawOutput now writes a
+ * sidecar <base>.meta.json carrying the FULL command (the .log filename only had a
+ * lossy slug), so listRtkCommandSamples() recovers the exact command — falling back
+ * to the filename slug for legacy .log files written before the sidecar existed.
+ *
+ * Run: node --import tsx/esm --test tests/unit/compression/rtk-command-samples.test.ts
+ */
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  maybePersistRtkRawOutput,
+  listRtkCommandSamples,
+} from "../../../open-sse/services/compression/engines/rtk/rawOutput.ts";
+
+let tmp: string;
+let prevDataDir: string | undefined;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "rtk-samples-"));
+  prevDataDir = process.env.DATA_DIR;
+  process.env.DATA_DIR = tmp;
+});
+
+afterEach(() => {
+  if (prevDataDir === undefined) delete process.env.DATA_DIR;
+  else process.env.DATA_DIR = prevDataDir;
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("maybePersistRtkRawOutput — command sidecar", () => {
+  it("writes a <base>.meta.json sidecar carrying the full command alongside the .log", () => {
+    const ptr = maybePersistRtkRawOutput("error: boom\nline2\n", {
+      retention: "always",
+      command: "npm run build --workspace=@scope/pkg",
+    });
+    assert.ok(ptr, "pointer returned");
+    const sidecar = ptr!.path.replace(/\.log$/, ".meta.json");
+    assert.ok(fs.existsSync(sidecar), "sidecar meta file written");
+    const meta = JSON.parse(fs.readFileSync(sidecar, "utf8"));
+    assert.equal(meta.command, "npm run build --workspace=@scope/pkg", "full command preserved");
+    assert.equal(typeof meta.timestamp, "number");
+  });
+
+  it("still writes the .log with pure output (sidecar does not pollute it)", () => {
+    const ptr = maybePersistRtkRawOutput("just output\n", {
+      retention: "always",
+      command: "ls -la",
+    });
+    assert.ok(ptr);
+    assert.equal(fs.readFileSync(ptr!.path, "utf8"), "just output\n");
+  });
+
+  it("does not write a sidecar when nothing is persisted (retention never)", () => {
+    const ptr = maybePersistRtkRawOutput("x", { retention: "never", command: "git status" });
+    assert.equal(ptr, null);
+    const dir = path.join(tmp, "rtk", "raw-output");
+    assert.ok(!fs.existsSync(dir) || fs.readdirSync(dir).length === 0);
+  });
+});
+
+describe("listRtkCommandSamples", () => {
+  it("returns [] when the store dir does not exist", () => {
+    assert.deepEqual(listRtkCommandSamples(), []);
+  });
+
+  it("recovers the exact command from the sidecar + output from the .log", () => {
+    maybePersistRtkRawOutput("Compiling...\nDone in 3s\n", {
+      retention: "always",
+      command: "cargo build --release",
+    });
+    const samples = listRtkCommandSamples();
+    assert.equal(samples.length, 1);
+    assert.equal(samples[0].command, "cargo build --release");
+    assert.match(samples[0].output, /Compiling/);
+  });
+
+  it("falls back to the filename slug for legacy .log files with no sidecar", () => {
+    // Simulate a legacy capture: write a .log directly, no sidecar.
+    const dir = path.join(tmp, "rtk", "raw-output");
+    fs.mkdirSync(dir, { recursive: true });
+    // Real captures use a 24-hex-char id (safeId().slice(0,24)).
+    fs.writeFileSync(
+      path.join(dir, "1700000000000-git_status-abc123def456abc123def456.log"),
+      "nothing to commit\n"
+    );
+    const samples = listRtkCommandSamples();
+    assert.equal(samples.length, 1);
+    assert.equal(samples[0].command, "git status", "slug underscores → spaces");
+    assert.match(samples[0].output, /nothing to commit/);
+  });
+
+  it("honours a limit and returns the most recent samples first", () => {
+    for (let i = 0; i < 5; i++) {
+      maybePersistRtkRawOutput(`output ${i}\n`, {
+        retention: "always",
+        command: `cmd-${i}`,
+      });
+    }
+    const limited = listRtkCommandSamples({ limit: 2 });
+    assert.equal(limited.length, 2);
+  });
+
+  it("skips empty/unreadable entries without throwing", () => {
+    const dir = path.join(tmp, "rtk", "raw-output");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, "1700000000001-empty-xyz.log"), "");
+    const samples = listRtkCommandSamples();
+    assert.equal(samples.length, 0, "empty output is not a usable sample");
+  });
+});

--- a/tests/unit/ui/rtkLearnDiscoverCard.test.tsx
+++ b/tests/unit/ui/rtkLearnDiscoverCard.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+// Passthrough i18n: t(key) → key, t(key, params) → "key:{json}" so assertions can read params.
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string, params?: Record<string, unknown>) =>
+    params ? `${key}:${JSON.stringify(params)}` : key,
+}));
+
+const { default: RtkLearnDiscoverCard } =
+  await import("@/app/(dashboard)/dashboard/context/rtk/RtkLearnDiscoverCard");
+
+const containers: HTMLElement[] = [];
+function mount(ui: React.ReactElement): HTMLElement {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  containers.push(container);
+  act(() => {
+    createRoot(container).render(ui);
+  });
+  return container;
+}
+async function click(el: Element | null) {
+  await act(async () => {
+    (el as HTMLElement).click();
+  });
+}
+
+beforeEach(() => {
+  (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+});
+afterEach(() => {
+  while (containers.length) containers.pop()?.remove();
+  document.body.innerHTML = "";
+  vi.restoreAllMocks();
+});
+
+describe("RtkLearnDiscoverCard", () => {
+  it("renders the discover + learn controls", () => {
+    const c = mount(<RtkLearnDiscoverCard />);
+    expect(c.querySelector("[data-testid='rtk-learn-discover']")).toBeTruthy();
+    expect(c.querySelector("[data-testid='rtk-discover-button']")).toBeTruthy();
+    expect(c.querySelector("[data-testid='rtk-learn-command']")).toBeTruthy();
+  });
+
+  it("discover: fetches /discover and renders ranked candidates", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              sampleCount: 3,
+              candidates: [{ pattern: "Resolving deps", hits: 3 }],
+            }),
+            { status: 200, headers: { "content-type": "application/json" } }
+          )
+      )
+    );
+    const c = mount(<RtkLearnDiscoverCard />);
+    await click(c.querySelector("[data-testid='rtk-discover-button']"));
+    expect(fetch).toHaveBeenCalledWith("/api/context/rtk/discover");
+    const results = c.querySelector("[data-testid='rtk-discover-results']");
+    expect(results?.textContent).toContain("Resolving deps");
+    expect(results?.textContent).toContain("discoverSamples"); // i18n key rendered with params
+  });
+
+  it("learn: requires a command, then fetches /learn?command= and shows the suggested filter", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            sampleCount: 2,
+            filter: { id: "suggested-npm-install", label: "npm install" },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const c = mount(<RtkLearnDiscoverCard />);
+
+    const input = c.querySelector("[data-testid='rtk-learn-command']") as HTMLInputElement;
+    await act(async () => {
+      // Set value via the native setter so React's onChange fires.
+      const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        "value"
+      )!.set!;
+      setter.call(input, "npm install");
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    await click(c.querySelector("[data-testid='rtk-learn-button']"));
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/context/rtk/learn?command=npm%20install");
+    const results = c.querySelector("[data-testid='rtk-learn-results']");
+    expect(results?.textContent).toContain("suggested-npm-install");
+  });
+
+  it("shows a fail-soft error when discover fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("nope", { status: 500 }))
+    );
+    const c = mount(<RtkLearnDiscoverCard />);
+    await click(c.querySelector("[data-testid='rtk-discover-button']"));
+    expect(c.querySelector("[data-testid='rtk-ld-error']")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## What

Compression backlog **F2.1 + Item 2**, delivered together. The pure RTK miners (`discoverRepeatedNoise` / `suggestFilter`) already shipped; what was missing — and what got Item 2 deferred as "no usable sample source" — was the **sample source**. This wires it end to end.

## Meta-finding

Both the miners AND a capture store already existed: `maybePersistRtkRawOutput` persists redacted, opt-in command output to `DATA_DIR/rtk/raw-output/*.log`. The only real gap was an adapter + the routes + UI. So F2.1 was not a from-scratch sub-project.

## Backend (commit 1)

- **Capture enhancement (backward-compatible):** `maybePersistRtkRawOutput` now writes a `<base>.meta.json` sidecar carrying the **full command** — the `.log` filename only had a lossy slug. The `.log` stays pure output (the raw-output recovery route is unchanged); the sidecar write is best-effort.
- **Adapter `listRtkCommandSamples({limit})`** reads the store into `CommandSample[]` — exact command from the sidecar, falling back to the filename slug for legacy captures; newest-first, empty/corrupt entries skipped, capped to bound memory.
- **Routes** (management-auth, read-only, suggestions-only):
  - `GET /api/context/rtk/discover` → ranked noise candidates over the samples.
  - `GET /api/context/rtk/learn?command=X` → a suggested filter draft for X, learned **only** from that command's samples (`commandToId` match); `400` without a command.
- Barrel re-exports the miners + adapter + `commandToId`.

## UI (commit 2)

A **Learn & Discover** card on Context & Cache → RTK: scan for repeated noise; type a command → preview a suggested filter draft. Suggestions only — the operator reviews and saves via the existing filter trust path. Fail-soft.

## Tests (TDD)

- **8** sample-source (sidecar write, exact/slug command recovery, limit, empty/skip).
- **5** route (discover happy/empty, learn happy/`400`/command-filtering).
- **4** vitest card (controls, discover fetch+render, learn fetch+render, fail-soft).
- 91 rtk regression tests still green; `typecheck:core` clean; lint / file-size / cycles / test-discovery / any-budget clean.

## i18n note

14 EN keys added under `contextRtk`. Locale translation is deferred to the release `i18n:run` — the repo's established flow (locales already sit at ~79% pre-existing coverage debt, and `i18n-ui-coverage` is a PR→main gate, not a release fast-gate). `i18n:sync-ui` was deliberately **not** run here because it would dump the entire pre-existing 42k-key `__MISSING__` backlog into this PR.