### PR TITLE
fix(dev): force webpack in custom dev server (Turbopack 16.2.x panics)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -109,9 +109,13 @@ PORT=20128
 # Used by: src/app/api/v1/relay/chat/completions/route.ts
 # RELAY_IP_PER_MINUTE=30
 
-# Use Turbopack in local dev. Next 16.2.4 can fail to compile next/font/google
-# through the custom dev runner without this on Windows.
-OMNIROUTE_USE_TURBOPACK=1
+# Bundler selection for `npm run dev`. Set to 1 to opt into Turbopack.
+# Default is 0 (webpack) because Turbopack 16.2.x panics on the OmniRoute
+# module graph with "internal error: entered unreachable code: there must be
+# a path to a root" (turbopack-core/module_graph/mod.rs:662). Same bug class
+# the production Docker build worked around in PR #4052. Webpack starts
+# slower but compiles cleanly. Re-enable once upstream Turbopack ships a fix.
+OMNIROUTE_USE_TURBOPACK=0
 
 # Skip the SQLite integrity health check on startup (faster boot on large DBs).
 # Used by: src/lib/db/core.ts, src/lib/db/healthCheck.ts. Set to 1 to skip.

--- a/scripts/dev/run-next.mjs
+++ b/scripts/dev/run-next.mjs
@@ -64,12 +64,24 @@ process.env.OMNIROUTE_WS_BRIDGE_SECRET ||= randomUUID();
 // server (read by the authz middleware in the same process). See peer-stamp.mjs.
 ensurePeerStampToken();
 
+// Next 16 picks Turbopack by default in dev. Passing `turbopack: false` to the
+// programmatic next() entry is *not* enough on its own:
+//   - parseBundlerArgs (node_modules/next/dist/lib/bundler.js) sees no positive
+//     bundler flag and falls back to `process.env.TURBOPACK = 'auto'`.
+//   - next-dev-server.js then reads `process.env.TURBOPACK` directly and
+//     starts Turbopack regardless of the option we passed.
+// Force webpack by both passing `webpack: true` and clearing the env var.
+// Mirrors the workaround PR #4052 applied for the production Docker build.
+if (!useTurbopack) {
+  delete process.env.TURBOPACK;
+}
 const nextApp = next({
   dev,
   dir: process.cwd(),
   hostname,
   port: dashboardPort,
   turbopack: useTurbopack,
+  webpack: !useTurbopack,
 });
 
 async function start() {


### PR DESCRIPTION
## What

Force webpack in the custom dev server (`scripts/dev/run-next.mjs`) so `npm run dev` no longer boots Turbopack on Next 16.2.x, where it panics on the OmniRoute module graph.

This extends to the dev runner the same workaround that PR #4052 applied to the production Docker build.

## Why

Without this fix, `npm run dev` on Next 16.2.9 with `OMNIROUTE_USE_TURBOPACK=0` still boots Turbopack and crashes with a flood of:

```
thread 'tokio-runtime-worker' panicked at
turbopack/crates/turbopack-core/src/module_graph/mod.rs:662:25:
internal error: entered unreachable code: there must be a path to a root
```

(observed ~250+ panic lines before the dev server bails with `TurbopackInternalError`, never binds the port).

## Root cause

The custom server passes `turbopack: useTurbopack` to the programmatic `next()` entry, but in Next 16 that option alone is not enough:

- `parseBundlerArgs` (`node_modules/next/dist/lib/bundler.js:75`) sees no positive bundler flag and falls back to `process.env.TURBOPACK = 'auto'`.
- `next-dev-server.js:204` then reads `process.env.TURBOPACK` directly and starts Turbopack regardless of the option we passed.

So `turbopack: false` is silently overridden by the env-var fallback path.

## Fix

1. **`scripts/dev/run-next.mjs`** — pass `webpack: !useTurbopack` to `next()` AND `delete process.env.TURBOPACK` when not using Turbopack, so neither code path picks Turbopack. Mirrors what `--webpack` does on the CLI path.
2. **`.env.example`** — flip `OMNIROUTE_USE_TURBOPACK` default from `1` to `0`, so fresh clones get a working dev server. Comment updated to explain the bug and reference #4052. Re-enable once upstream Turbopack ships a fix.

The Playwright dev runner (`scripts/dev/run-next-playwright.mjs`) is unaffected — it spawns the Next CLI as a child process and already passes `--webpack` via `shouldUseWebpackForPlaywrightDev`.

## Diff size

```
.env.example             | 10 +++++++---
scripts/dev/run-next.mjs | 12 ++++++++++++
2 files changed, 19 insertions(+), 3 deletions(-)
```

## Hard Rule #18 validation — live test

Per the bug-fix protocol in `CLAUDE.md`, this is a real-environment validation (TDD doesn't fit a Next-internals bundler-selection bug; reproducing it would require launching Next and observing its bundler choice, which is exactly the flaky thing we're trying to test).

**Environment**: Windows 11, Node 24.16.0, Next 16.2.9, base `upstream/release/v3.8.28`, in a worktree per Hard Rule #19.

**Command**:
```bash
PORT=20129 npm run dev
```

**Result**: port bound in ~20s, bundler is webpack, zero Turbopack panics.

```
[Next] dev server listening on http://0.0.0.0:20129 (webpack)
```

```
$ grep -c "panicked" /tmp/wt-dev.log
0
```

All startup probes green:
- `[DB] SQLite database ready: ...storage.sqlite`
- `[STARTUP] Embedded services bootstrap complete`
- `[STARTUP] Arena ELO sync initialized`
- `[EmbedWsProxy] Listening on 127.0.0.1:20131`
- `[ARENA_ELO_SYNC] Initial sync complete: 162 model intelligence entries`

Webpack `<w>` warnings about dynamic imports in `fumadocs-mdx/dist/load-from-file-*.js` and `next-intl/dist/esm/production/extractor/format/index.js` are pre-existing on `release/v3.8.28` and unrelated to this change.

## Backout

- Set `OMNIROUTE_USE_TURBOPACK=1` in `.env` to opt back into Turbopack on a checkout where it happens to work.
- Revert this commit if the upstream Turbopack panic gets fixed and you want the old default back.
