### PR TITLE
feat(mitm): capture-pipeline self-test route (Gap 12)

### DIFF
--- a/src/app/api/tools/agent-bridge/diagnose/route.ts
+++ b/src/app/api/tools/agent-bridge/diagnose/route.ts
@@ -1,0 +1,63 @@
+/**
+ * GET /api/tools/agent-bridge/diagnose
+ *
+ * Capture-pipeline self-test (Gap 12). Runs the independent checks that
+ * determine whether interception can work — server running, server reachable on
+ * its port, cert generated, cert trusted by the OS store, target hosts spoofed
+ * in DNS — and returns an actionable report (per-failure hints + a single
+ * `healthy` verdict). Answers "why is nothing being captured?" in one call.
+ *
+ * LOCAL_ONLY: covered by the "/api/tools/agent-bridge/" prefix in routeGuard.ts.
+ */
+import net from "node:net";
+import path from "node:path";
+import fs from "node:fs";
+import { sanitizeErrorMessage } from "@omniroute/open-sse/utils/error";
+import { createErrorResponse } from "@/lib/api/errorResponse";
+import { getMitmStatus } from "@/mitm/manager";
+import { checkCertInstalled } from "@/mitm/cert/install";
+import { resolveMitmDataDir } from "@/mitm/dataDir";
+import { summarizeDiagnostics } from "@/mitm/inspector/diagnostics";
+
+/** Best-effort TCP reachability probe; resolves false on error/timeout. */
+function probeTcp(port: number, host = "127.0.0.1", timeoutMs = 1500): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = net.connect({ port, host });
+    const done = (ok: boolean) => {
+      try {
+        socket.destroy();
+      } catch {
+        // ignore
+      }
+      resolve(ok);
+    };
+    socket.setTimeout(timeoutMs, () => done(false));
+    socket.once("connect", () => done(true));
+    socket.once("error", () => done(false));
+  });
+}
+
+export async function GET(): Promise<Response> {
+  try {
+    const status = await getMitmStatus();
+    const certPath = path.join(resolveMitmDataDir(), "mitm", "server.crt");
+    const certExists = fs.existsSync(certPath);
+    const certTrusted = certExists ? await checkCertInstalled(certPath) : false;
+    const port =
+      Number(process.env.MITM_LOCAL_PORT) > 0 ? Number(process.env.MITM_LOCAL_PORT) : 443;
+    const serverReachable = status.running ? await probeTcp(port) : false;
+
+    const report = summarizeDiagnostics({
+      serverRunning: status.running,
+      serverReachable,
+      certExists,
+      certTrusted,
+      dnsConfigured: status.dnsConfigured,
+    });
+
+    return Response.json({ ...report, port });
+  } catch (err) {
+    const msg = sanitizeErrorMessage(err instanceof Error ? err.message : String(err));
+    return createErrorResponse({ status: 500, message: msg });
+  }
+}

--- a/src/mitm/inspector/diagnostics.ts
+++ b/src/mitm/inspector/diagnostics.ts
@@ -1,0 +1,67 @@
+/**
+ * Capture-pipeline self-test (Gap 12).
+ *
+ * MITM/AgentBridge setups fail silently in several independent ways — the cert
+ * is not trusted, the hosts are not spoofed, the server is down or unreachable
+ * on its port — and the user gets nothing actionable, just an empty capture
+ * list. `summarizeDiagnostics()` is the pure core: given each check's boolean
+ * result it produces a single `healthy` verdict plus a per-failure hint telling
+ * the user exactly what to fix. The route layer runs the effectful checks
+ * (getMitmStatus, checkCertInstalled, a TCP probe, checkDNSEntry) and feeds the
+ * booleans in here.
+ */
+
+export interface DiagnosticInput {
+  serverRunning: boolean;
+  serverReachable: boolean;
+  certExists: boolean;
+  certTrusted: boolean;
+  dnsConfigured: boolean;
+}
+
+export interface DiagnosticCheck {
+  name: string;
+  ok: boolean;
+  /** Actionable remediation when `ok` is false; null when the check passes. */
+  hint: string | null;
+}
+
+export interface DiagnosticReport {
+  healthy: boolean;
+  checks: DiagnosticCheck[];
+}
+
+function check(name: string, ok: boolean, failHint: string): DiagnosticCheck {
+  return { name, ok, hint: ok ? null : failHint };
+}
+
+export function summarizeDiagnostics(input: DiagnosticInput): DiagnosticReport {
+  const checks: DiagnosticCheck[] = [
+    check(
+      "server-running",
+      input.serverRunning,
+      "The MITM server is not running. Start it from the AgentBridge tab."
+    ),
+    check(
+      "server-reachable",
+      input.serverReachable,
+      "The MITM server is not accepting connections on its port. Check that the port is free and that you have privileges to bind it."
+    ),
+    check(
+      "cert-exists",
+      input.certExists,
+      "No MITM certificate has been generated yet. Generate one from the AgentBridge tab."
+    ),
+    check(
+      "cert-trusted",
+      input.certTrusted,
+      "The MITM root CA is not trusted by the OS store, so TLS interception will fail. Trust the certificate from the AgentBridge tab."
+    ),
+    check(
+      "dns-configured",
+      input.dnsConfigured,
+      "Target hostnames are not spoofed in /etc/hosts, so traffic never reaches the proxy. Enable DNS for the agent(s) you want to capture."
+    ),
+  ];
+  return { healthy: checks.every((c) => c.ok), checks };
+}

--- a/tests/unit/mitm-diagnostics.test.ts
+++ b/tests/unit/mitm-diagnostics.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Gap 12: capture-pipeline self-test. MITM setups fail silently in many ways
+ * (cert not trusted, DNS not spoofed, server down/unreachable) and the user
+ * gets no actionable signal. summarizeDiagnostics() is the pure core: given the
+ * boolean results of each check, it produces an actionable report with a single
+ * `healthy` verdict and a per-failure hint.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { summarizeDiagnostics } from "../../src/mitm/inspector/diagnostics.ts";
+
+test("all checks green → healthy, no hints", () => {
+  const report = summarizeDiagnostics({
+    serverRunning: true,
+    serverReachable: true,
+    certExists: true,
+    certTrusted: true,
+    dnsConfigured: true,
+  });
+  assert.equal(report.healthy, true);
+  assert.equal(report.checks.length, 5);
+  assert.ok(report.checks.every((c) => c.ok && c.hint === null));
+});
+
+test("cert not trusted → unhealthy with an actionable hint on that check", () => {
+  const report = summarizeDiagnostics({
+    serverRunning: true,
+    serverReachable: true,
+    certExists: true,
+    certTrusted: false,
+    dnsConfigured: true,
+  });
+  assert.equal(report.healthy, false);
+  const certCheck = report.checks.find((c) => c.name === "cert-trusted");
+  assert.ok(certCheck, "must include a cert-trusted check");
+  assert.equal(certCheck!.ok, false);
+  assert.ok(certCheck!.hint && certCheck!.hint.length > 0, "must give an actionable hint");
+});
+
+test("server down → unhealthy and the server-running check carries the hint", () => {
+  const report = summarizeDiagnostics({
+    serverRunning: false,
+    serverReachable: false,
+    certExists: true,
+    certTrusted: true,
+    dnsConfigured: true,
+  });
+  assert.equal(report.healthy, false);
+  const runCheck = report.checks.find((c) => c.name === "server-running");
+  assert.equal(runCheck?.ok, false);
+  assert.ok(runCheck?.hint);
+});
+
+test("every failing check has a non-null hint; every passing check has null", () => {
+  const report = summarizeDiagnostics({
+    serverRunning: false,
+    serverReachable: false,
+    certExists: false,
+    certTrusted: false,
+    dnsConfigured: false,
+  });
+  assert.equal(report.healthy, false);
+  assert.ok(report.checks.every((c) => !c.ok && typeof c.hint === "string" && c.hint.length > 0));
+});


### PR DESCRIPTION
## Summary

MITM/AgentBridge setups fail **silently** in several independent ways — the cert isn't trusted, target hosts aren't spoofed in DNS, the server is down or unreachable on its port — and the user just sees an empty capture list with no actionable signal. This is a recurring support burden ("why is nothing being captured?").

Adds `GET /api/tools/agent-bridge/diagnose`, inspired by ProxyBridge's `TestConnection()` live diagnostic. It runs each check and returns an actionable report:

- **server-running** — is the MITM server up?
- **server-reachable** — TCP probe of the listen port (catches bind/permission issues)
- **cert-exists** — has a cert been generated?
- **cert-trusted** — is the root CA trusted by the OS store? (TLS interception fails otherwise)
- **dns-configured** — are target hosts spoofed in `/etc/hosts`?

Each failing check carries a one-line hint telling the user exactly what to fix; a single `healthy` boolean summarizes.

## Test Plan

- [x] `node --test` — 137 inspector/agent-bridge tests pass (zero regression), incl. new `mitm-diagnostics.test.ts` (4 cases: all-green, cert-untrusted, server-down, all-failing → every failing check has a hint, every passing one is null)
- [x] `typecheck:core` clean; `eslint` clean
- [ ] CI full suite (runs on PR)

## Notes

- Pure core `summarizeDiagnostics()` is fully unit-tested; the route layer only runs the effectful checks (`getMitmStatus`, `checkCertInstalled`, a TCP probe, DNS check) and feeds the booleans in — no VPS validation needed.
- Independent of #4084/#4085 — only adds new files. If #4084 (repair) merges, a follow-up can link an unhealthy verdict to the Repair action.
- **Follow-up:** a "Diagnose" button in the AgentBridge UI (hint strings would need an i18n key across 42 locales via the release autotranslate flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)