### PR TITLE
feat(cli): add 'omniroute launch' zero-config Claude Code launcher

### DIFF
--- a/bin/cli/commands/launch.mjs
+++ b/bin/cli/commands/launch.mjs
@@ -1,0 +1,80 @@
+import { spawn } from "node:child_process";
+import { t } from "../i18n.mjs";
+
+/**
+ * Build a clean child env for Claude Code pointed at the local proxy.
+ * Strips any inherited ANTHROPIC_* (avoids a stale shell token leaking through),
+ * then injects the proxy base URL, gateway model discovery, and auto-compact window.
+ * @param {Record<string,string>} baseEnv
+ * @param {number} port
+ * @param {string|undefined} authToken
+ * @returns {Record<string,string>}
+ */
+export function buildClaudeEnv(baseEnv, port, authToken) {
+  const env = { ...baseEnv };
+  for (const key of Object.keys(env)) {
+    if (key.startsWith("ANTHROPIC_")) delete env[key];
+  }
+  env.ANTHROPIC_BASE_URL = `http://localhost:${port}`;
+  if (authToken) env.ANTHROPIC_AUTH_TOKEN = authToken;
+  env.CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY = "1";
+  env.CLAUDE_CODE_AUTO_COMPACT_WINDOW = "190000";
+  return env;
+}
+
+/**
+ * @param {{port?:string, token?:string}} opts
+ * @param {string[]} claudeArgs  pass-through args for the claude binary
+ * @returns {Promise<number>} exit code
+ */
+export async function runLaunchCommand(opts = {}, claudeArgs = []) {
+  const port = Number(opts.port ?? process.env.PORT ?? 20128) || 20128;
+
+  // Health check the proxy before launching.
+  try {
+    const res = await fetch(`http://localhost:${port}/api/monitoring/health`, {
+      signal: AbortSignal.timeout(1500),
+    });
+    if (!res.ok) throw new Error(`status ${res.status}`);
+  } catch (e) {
+    console.error(
+      (t("launch.notRunning") || "OmniRoute is not running on port {port}. Start it with 'omniroute serve'.").replace(
+        "{port}",
+        String(port)
+      )
+    );
+    return 1;
+  }
+
+  const token = opts.token ?? process.env.ANTHROPIC_AUTH_TOKEN ?? undefined;
+  const env = buildClaudeEnv(process.env, port, token);
+
+  return await new Promise((resolve) => {
+    const child = spawn("claude", claudeArgs, { env, stdio: "inherit" });
+    child.on("error", (err) => {
+      if (err && err.code === "ENOENT") {
+        console.error(t("launch.notFound") || "The 'claude' CLI was not found in PATH.");
+        resolve(127);
+      } else {
+        console.error(String(err?.message || err));
+        resolve(1);
+      }
+    });
+    child.on("exit", (code) => resolve(code ?? 0));
+  });
+}
+
+export function registerLaunch(program) {
+  program
+    .command("launch")
+    .description(t("launch.description") || "Launch Claude Code pointed at the local OmniRoute proxy")
+    .option("--port <port>", t("serve.port") || "Proxy port", "20128")
+    .option("--token <token>", t("launch.token") || "API key the Claude client should send (ANTHROPIC_AUTH_TOKEN)")
+    .allowUnknownOption(true)
+    .allowExcessArguments(true)
+    .argument("[claudeArgs...]", "arguments passed through to the claude binary")
+    .action(async (claudeArgs, opts) => {
+      const exitCode = await runLaunchCommand(opts, claudeArgs ?? []);
+      if (exitCode !== 0) process.exit(exitCode);
+    });
+}

--- a/bin/cli/commands/registry.mjs
+++ b/bin/cli/commands/registry.mjs
@@ -55,6 +55,7 @@ import { registerRuntime } from "./runtime.mjs";
 import { registerTray } from "./tray.mjs";
 import { registerAutostart } from "./autostart.mjs";
 import { registerRepl } from "./repl.mjs";
+import { registerLaunch } from "./launch.mjs";
 import { registerApiCommands } from "../api-commands/registry.mjs";
 import { registerPlugin } from "./plugin.mjs";
 
@@ -117,6 +118,7 @@ export function registerCommands(program) {
   registerTray(program);
   registerAutostart(program);
   registerRepl(program);
+  registerLaunch(program);
   registerApiCommands(program);
   registerPlugin(program);
 }

--- a/bin/cli/locales/en.json
+++ b/bin/cli/locales/en.json
@@ -1256,5 +1256,11 @@
     "search": "Search npm registry for available plugins",
     "update": "Update installed plugin(s)",
     "scaffold": "Scaffold a new plugin boilerplate"
+  },
+  "launch": {
+    "description": "Launch Claude Code pointed at the local OmniRoute proxy",
+    "token": "API key the Claude client should send (ANTHROPIC_AUTH_TOKEN)",
+    "notRunning": "OmniRoute is not running on port {port}. Start it with 'omniroute serve'.",
+    "notFound": "The 'claude' CLI was not found in PATH."
   }
 }

--- a/bin/cli/locales/pt-BR.json
+++ b/bin/cli/locales/pt-BR.json
@@ -1255,5 +1255,11 @@
     "search": "Buscar plugins disponíveis no npm",
     "update": "Atualizar plugin(s) instalado(s)",
     "scaffold": "Gerar boilerplate de novo plugin"
+  },
+  "launch": {
+    "description": "Inicia o Claude Code apontando para o proxy local do OmniRoute",
+    "token": "Chave de API que o cliente Claude deve enviar (ANTHROPIC_AUTH_TOKEN)",
+    "notRunning": "OmniRoute não está rodando na porta {port}. Inicie com 'omniroute serve'.",
+    "notFound": "O CLI 'claude' não foi encontrado no PATH."
   }
 }

--- a/tests/unit/cli/launch-command.test.ts
+++ b/tests/unit/cli/launch-command.test.ts
@@ -1,0 +1,25 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildClaudeEnv } from "../../../bin/cli/commands/launch.mjs";
+
+test("buildClaudeEnv strips ANTHROPIC_* and injects proxy vars", () => {
+  const env = buildClaudeEnv({ ANTHROPIC_API_KEY: "leak", ANTHROPIC_BASE_URL: "old", PATH: "/bin" }, 20128, "secret");
+  assert.equal(env.ANTHROPIC_API_KEY, undefined);
+  assert.equal(env.ANTHROPIC_BASE_URL, "http://localhost:20128");
+  assert.equal(env.ANTHROPIC_AUTH_TOKEN, "secret");
+  assert.equal(env.CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY, "1");
+  assert.equal(env.CLAUDE_CODE_AUTO_COMPACT_WINDOW, "190000");
+  assert.equal(env.PATH, "/bin", "non-ANTHROPIC vars are preserved");
+});
+
+test("buildClaudeEnv omits the auth token when none is provided", () => {
+  const env = buildClaudeEnv({ PATH: "/bin" }, 20128, undefined);
+  assert.equal("ANTHROPIC_AUTH_TOKEN" in env, false);
+  assert.equal(env.ANTHROPIC_BASE_URL, "http://localhost:20128");
+});
+
+test("buildClaudeEnv does not mutate the input env object", () => {
+  const input = { ANTHROPIC_API_KEY: "leak", PATH: "/bin" };
+  buildClaudeEnv(input, 20128, "x");
+  assert.equal(input.ANTHROPIC_API_KEY, "leak");
+});


### PR DESCRIPTION
## Summary

Fase 5 do porte de técnicas do `free-claude-code` (plano: `docs/superpowers/plans/2026-06-17-fcc-portable-features.md`). Porte do `fcc-claude`.

- **`omniroute launch [claude args...]`**: health-check do proxy (`/api/monitoring/health`, timeout 1.5s) → monta env limpo (remove `ANTHROPIC_*` herdado do shell, injeta `ANTHROPIC_BASE_URL`, `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1`, `CLAUDE_CODE_AUTO_COMPACT_WINDOW=190000`) → spawn do `claude` com stdio herdado e exit code propagado.
- Core puro `buildClaudeEnv` (testado), glue fino de spawn, registrado em `registry.mjs`, chaves i18n em `en.json` + `pt-BR.json`.

## Decisão de escopo: prefer_dotenv DROPADO

O plano previa também portar o "prefer_dotenv" do FCC (forçar `.env` sobre `process.env` para o auth token). **Verifiquei que NÃO se aplica ao OmniRoute**: aqui `ANTHROPIC_AUTH_TOKEN` é o token *cliente* (o que o Claude Code envia ao proxy, gerenciado via dashboard/`claudeCliConfig.ts`), enquanto a auth *do proxy* usa `auth.ts` + `REQUIRE_API_KEY`. O cenário de contaminação do FCC não existe aqui — portar seria cargo-cult.

## Test Plan

- [x] `tests/unit/cli/launch-command.test.ts` 3/3 (strip ANTHROPIC_*, injeção, token opcional, imutabilidade)
- [x] `check-cli-i18n.mjs` PASS (chaves em en.json, paridade top-level pt-BR)
- [x] `node bin/omniroute.mjs launch --help` lista o comando sem spawnar claude
- [x] eslint 0, JSON dos locales válido
- [ ] Validação live (spawn real do claude contra proxy rodando) — requer ambiente com claude + proxy; Hard Rule #18 (feature, glue validado via --help)
- [ ] CI completa no PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)