### PR TITLE
fix(dev): force webpack in custom dev server (Turbopack 16.2.x panics)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -109,9 +109,13 @@ PORT=20128
 # Used by: src/app/api/v1/relay/chat/completions/route.ts
 # RELAY_IP_PER_MINUTE=30
 
-# Use Turbopack in local dev. Next 16.2.4 can fail to compile next/font/google
-# through the custom dev runner without this on Windows.
-OMNIROUTE_USE_TURBOPACK=1
+# Bundler selection for `npm run dev`. Set to 1 to opt into Turbopack.
+# Default is 0 (webpack) because Turbopack 16.2.x panics on the OmniRoute
+# module graph with "internal error: entered unreachable code: there must be
+# a path to a root" (turbopack-core/module_graph/mod.rs:662). Same bug class
+# the production Docker build worked around in PR #4052. Webpack starts
+# slower but compiles cleanly. Re-enable once upstream Turbopack ships a fix.
+OMNIROUTE_USE_TURBOPACK=0
 
 # Skip the SQLite integrity health check on startup (faster boot on large DBs).
 # Used by: src/lib/db/core.ts, src/lib/db/healthCheck.ts. Set to 1 to skip.

--- a/scripts/dev/run-next.mjs
+++ b/scripts/dev/run-next.mjs
@@ -64,12 +64,24 @@ process.env.OMNIROUTE_WS_BRIDGE_SECRET ||= randomUUID();
 // server (read by the authz middleware in the same process). See peer-stamp.mjs.
 ensurePeerStampToken();
 
+// Next 16 picks Turbopack by default in dev. Passing `turbopack: false` to the
+// programmatic next() entry is *not* enough on its own:
+//   - parseBundlerArgs (node_modules/next/dist/lib/bundler.js) sees no positive
+//     bundler flag and falls back to `process.env.TURBOPACK = 'auto'`.
+//   - next-dev-server.js then reads `process.env.TURBOPACK` directly and
+//     starts Turbopack regardless of the option we passed.
+// Force webpack by both passing `webpack: true` and clearing the env var.
+// Mirrors the workaround PR #4052 applied for the production Docker build.
+if (!useTurbopack) {
+  delete process.env.TURBOPACK;
+}
 const nextApp = next({
   dev,
   dir: process.cwd(),
   hostname,
   port: dashboardPort,
   turbopack: useTurbopack,
+  webpack: !useTurbopack,
 });
 
 async function start() {


### PR DESCRIPTION
## Summary

Next 16 picks Turbopack by default in dev. The custom server in `scripts/dev/run-next.mjs` already passed `turbopack: useTurbopack` to the programmatic `next()` entry, but `turbopack: false` is **not enough on its own**:

- `parseBundlerArgs` (`node_modules/next/dist/lib/bundler.js:75`) sees no positive bundler flag and falls back to `process.env.TURBOPACK = 'auto'`.
- `next-dev-server.js:204` then reads `process.env.TURBOPACK` directly and starts Turbopack regardless of the option we passed.

Without this fix, ` + "`npm run dev`" + ` on Next 16.2.9 with `OMNIROUTE_USE_TURBOPACK=0` still boots Turbopack and crashes with a flood of:

\`\`\`
thread 'tokio-runtime-worker' panicked at
turbopack/crates/turbopack-core/src/module_graph/mod.rs:662:25:
internal error: entered unreachable code: there must be a path to a root
\`\`\`

Same bug class that #4052 worked around for the production Docker build by switching it to webpack. This PR extends that workaround to the dev runner.

## Changes

1. `scripts/dev/run-next.mjs` — pass `webpack: !useTurbopack` to the programmatic `next()` entry **and** `delete process.env.TURBOPACK` when not using Turbopack, so neither code path picks Turbopack.
2. `.env.example` — flip `OMNIROUTE_USE_TURBOPACK` default from \`1\` to \`0\`, so fresh clones get a working dev server. Comment updated to explain the bug and reference #4052.

## Verification (live test on Windows, Node 24.16.0, Next 16.2.9)

Per CLAUDE.md Hard Rule #18 (TDD or live-environment validation), this fix was validated live. The Turbopack panic happens at IDE/dev-server startup time and is platform/env-sensitive (Next.js internal env-var precedence), so a unit test would not catch it; live verification is the appropriate gate here.

\`\`\`
PORT=20129 npm run dev
→ port bound in ~20s
→ bundler line: \"[Next] dev server listening on http://0.0.0.0:20129 (webpack)\"
→ 0 panic lines (vs ~250+ before the fix)
→ all startup probes green (DB, Embed WS proxy, Arena ELO sync)
\`\`\`

## Scope notes

- The Playwright dev runner (\`scripts/dev/run-next-playwright.mjs\`) is unaffected — it spawns the Next CLI as a child process and already passes \`--webpack\` via \`shouldUseWebpackForPlaywrightDev\`.
- The production build path is also unaffected — \`build-next-isolated.mjs\` already respects \`OMNIROUTE_USE_TURBOPACK\` correctly (#4052).
- Users who *want* Turbopack can still opt in by setting \`OMNIROUTE_USE_TURBOPACK=1\` — the fix only changes the *default* behavior so it actually matches what the env var says.