### PR TITLE
perf(obfuscation): cache per-word regexes instead of recompiling every request

### DIFF
--- a/open-sse/services/antigravityObfuscation.ts
+++ b/open-sse/services/antigravityObfuscation.ts
@@ -38,12 +38,26 @@ function escapeRegex(str: string): string {
   return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+// Per-word regex cache — avoids recompiling one RegExp per word on every request body.
+// Bounded by distinct configured words; global regexes are safe to reuse (String.replace
+// resets lastIndex).
+const _obfuscationRegexCache = new Map<string, RegExp>();
+function getObfuscationRegex(word: string): RegExp {
+  let regex = _obfuscationRegexCache.get(word);
+  if (!regex) {
+    if (_obfuscationRegexCache.size > 2000) _obfuscationRegexCache.clear();
+    regex = new RegExp(escapeRegex(word), "gi");
+    _obfuscationRegexCache.set(word, regex);
+  }
+  return regex;
+}
+
 export function obfuscateSensitiveWords(text: string): string {
   if (!text || words.length === 0) return text;
   let result = text;
   for (const word of words) {
     if (!word) continue;
-    const regex = new RegExp(escapeRegex(word), "gi");
+    const regex = getObfuscationRegex(word);
     result = result.replace(regex, (m) => (m.length <= 1 ? m : m[0] + ZWJ + m.slice(1)));
   }
   return result;

--- a/open-sse/services/claudeCodeObfuscation.ts
+++ b/open-sse/services/claudeCodeObfuscation.ts
@@ -40,14 +40,28 @@ function obfuscateWord(word: string): string {
   return word[0] + ZWJ + word.slice(1);
 }
 
+// Per-word regex cache — obfuscateSensitiveWords recompiles one RegExp per word on every
+// request body otherwise. Bounded by distinct configured words; global regexes are safe to
+// reuse because String.replace resets lastIndex.
+const _obfuscationRegexCache = new Map<string, RegExp>();
+function getObfuscationRegex(word: string): RegExp {
+  let regex = _obfuscationRegexCache.get(word);
+  if (!regex) {
+    if (_obfuscationRegexCache.size > 2000) _obfuscationRegexCache.clear();
+    regex = new RegExp(escapeRegex(word), "gi");
+    _obfuscationRegexCache.set(word, regex);
+  }
+  return regex;
+}
+
 export function obfuscateSensitiveWords(text: string): string {
   if (!text || sensitiveWords.length === 0) return text;
 
   let result = text;
   for (const word of sensitiveWords) {
     if (!word) continue;
-    // Case-insensitive replacement
-    const regex = new RegExp(escapeRegex(word), "gi");
+    // Case-insensitive replacement (cached: see getObfuscationRegex)
+    const regex = getObfuscationRegex(word);
     result = result.replace(regex, (match) => obfuscateWord(match));
   }
   return result;

--- a/open-sse/services/systemTransforms.ts
+++ b/open-sse/services/systemTransforms.ts
@@ -269,12 +269,27 @@ function obfuscateWord(word: string): string {
  * list instead of the module-level singleton, so concurrent requests with
  * different op configs do not race.
  */
+// Per-word regex cache: obfuscateWithList runs over the whole request body on every
+// request when obfuscation is enabled, recompiling one RegExp per word each time. The
+// word list is stable per op config, so memoize. Bounded by distinct configured words
+// (with a defensive cap). Global regexes are safe to reuse: String.replace resets lastIndex.
+const _obfuscationRegexCache = new Map<string, RegExp>();
+function getObfuscationRegex(word: string): RegExp {
+  let regex = _obfuscationRegexCache.get(word);
+  if (!regex) {
+    if (_obfuscationRegexCache.size > 2000) _obfuscationRegexCache.clear();
+    regex = new RegExp(escapeRegex(word), "gi");
+    _obfuscationRegexCache.set(word, regex);
+  }
+  return regex;
+}
+
 function obfuscateWithList(text: string, words: string[]): string {
   if (!text || words.length === 0) return text;
   let result = text;
   for (const word of words) {
     if (!word) continue;
-    const regex = new RegExp(escapeRegex(word), "gi");
+    const regex = getObfuscationRegex(word);
     result = result.replace(regex, (match) => obfuscateWord(match));
   }
   return result;


### PR DESCRIPTION
## Problem
The three word-obfuscation transforms recompiled a regex **per word, per request**, over the whole request body:
- `open-sse/services/systemTransforms.ts` (`obfuscateWithList`)
- `open-sse/services/claudeCodeObfuscation.ts`
- `open-sse/services/antigravityObfuscation.ts`

` 
for (const word of words) {
  const regex = new RegExp(escapeRegex(word), "gi"); // recompiled every word, every request
  result = result.replace(regex, ...);
}
`

The word list is stable per op config, so the same patterns are recompiled identically on every request — wasted CPU on the request path (scales with word-list size × request rate) when obfuscation is enabled.

## Fix
Memoize compiled regexes in a bounded (cap 2000) module-level `Map` keyed by the raw word. Global-flag regexes are safe to reuse here because `String.prototype.replace` resets `lastIndex` on each call. Behavior is identical.

## Tests
`system-transforms.test.ts` / `service-system-transforms.test.ts` / `piiReproduction.test.ts` (43 tests) pass.