### PR TITLE
fix(logger): hard-cap the error-dedup map to bound memory under unique-message bursts

### DIFF
--- a/src/shared/utils/structuredLogger.ts
+++ b/src/shared/utils/structuredLogger.ts
@@ -109,8 +109,33 @@ function buildEntry(
 const _recentErrors = new Map<string, { count: number; firstSeen: number }>();
 const DEDUP_WINDOW_MS = 5_000;
 const MAX_WRITES_PER_SECOND = 50;
+// Hard cap on tracked distinct error messages. The age-based cleanup only removes entries
+// older than DEDUP_WINDOW_MS, so a burst of >100 *unique* messages within a single 5s window
+// (e.g. messages embedding request ids / urls / timestamps) could outpace it and grow the map.
+// This bound evicts the oldest entries (Map preserves insertion order) as a backstop.
+const MAX_TRACKED_ERRORS = 500;
 let _writeCount = 0;
 let _writeWindowStart = Date.now();
+
+function pruneRecentErrors(now: number): void {
+  // Age-based cleanup of expired entries.
+  if (_recentErrors.size > 100) {
+    for (const [key, entry] of _recentErrors) {
+      if (now - entry.firstSeen > DEDUP_WINDOW_MS) _recentErrors.delete(key);
+    }
+  }
+  // Hard size cap: evict oldest (insertion-order) entries if a unique-message burst outpaced
+  // the age-based cleanup.
+  if (_recentErrors.size >= MAX_TRACKED_ERRORS) {
+    const overflow = _recentErrors.size - MAX_TRACKED_ERRORS + 1;
+    let removed = 0;
+    for (const key of _recentErrors.keys()) {
+      if (removed >= overflow) break;
+      _recentErrors.delete(key);
+      removed++;
+    }
+  }
+}
 
 function shouldSuppressError(message: string): boolean {
   const now = Date.now();
@@ -129,17 +154,19 @@ function shouldSuppressError(message: string): boolean {
     return true;
   }
 
-  // Cleanup old entries
-  if (_recentErrors.size > 100) {
-    for (const [key, entry] of _recentErrors) {
-      if (now - entry.firstSeen > DEDUP_WINDOW_MS) _recentErrors.delete(key);
-    }
-  }
+  pruneRecentErrors(now);
 
   _recentErrors.set(message, { count: 1, firstSeen: now });
   _writeCount++;
   return false;
 }
+
+/** Test-only internals for verifying the dedup-map bound. */
+export const __structuredLoggerInternals = {
+  recentErrors: _recentErrors,
+  pruneRecentErrors,
+  MAX_TRACKED_ERRORS,
+};
 
 export function createLogger(component: string) {
   return {

--- a/tests/unit/structured-logger-dedup-bound.test.ts
+++ b/tests/unit/structured-logger-dedup-bound.test.ts
@@ -1,0 +1,49 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { __structuredLoggerInternals } = await import(
+  "../../src/shared/utils/structuredLogger.ts"
+);
+
+test("pruneRecentErrors enforces a hard cap during a unique-message burst", () => {
+  const { recentErrors, pruneRecentErrors, MAX_TRACKED_ERRORS } = __structuredLoggerInternals;
+  recentErrors.clear();
+
+  const now = Date.now();
+  // Simulate a burst of unique messages within a single dedup window (all firstSeen = now,
+  // so the age-based cleanup removes none of them).
+  for (let i = 0; i < MAX_TRACKED_ERRORS * 2; i++) {
+    pruneRecentErrors(now);
+    recentErrors.set(`unique-error-${i}`, { count: 1, firstSeen: now });
+  }
+  pruneRecentErrors(now);
+
+  assert.ok(
+    recentErrors.size <= MAX_TRACKED_ERRORS,
+    `map should be bounded by ${MAX_TRACKED_ERRORS}, got ${recentErrors.size}`
+  );
+
+  // The cap evicts the OLDEST entries, so the most recent ones survive.
+  assert.ok(
+    recentErrors.has(`unique-error-${MAX_TRACKED_ERRORS * 2 - 1}`),
+    "the newest entry should be retained"
+  );
+
+  recentErrors.clear();
+});
+
+test("pruneRecentErrors removes entries older than the dedup window", () => {
+  const { recentErrors, pruneRecentErrors } = __structuredLoggerInternals;
+  recentErrors.clear();
+
+  const base = Date.now();
+  // 150 entries (>100 so the age cleanup runs), all old.
+  for (let i = 0; i < 150; i++) {
+    recentErrors.set(`old-${i}`, { count: 1, firstSeen: base });
+  }
+  // Advance well past the 5s dedup window.
+  pruneRecentErrors(base + 60_000);
+
+  assert.equal(recentErrors.size, 0, "all expired entries should be cleaned up");
+  recentErrors.clear();
+});


### PR DESCRIPTION
## Problem
`structuredLogger`'s `shouldSuppressError` keeps a `_recentErrors` dedup `Map`. Its cleanup only removes entries **older than** the 5s dedup window. If more than ~100 **unique** error messages arrive within a single window (common when messages embed request ids / urls / timestamps), none are old enough to delete yet new keys keep being inserted — so the map grows past the window bound.

## Fix
Add a hard size cap (`MAX_TRACKED_ERRORS = 500`): after the age-based cleanup, evict the oldest entries (`Map` preserves insertion order) as a backstop. Dedup + rate-limit behavior is unchanged in normal operation. The bounding logic is extracted into `pruneRecentErrors` and exposed via a test hook.

## Tests
New `tests/unit/structured-logger-dedup-bound.test.ts`: the map stays bounded under a unique-message burst (newest entries retained), and expired entries are still cleaned up.