### PR TITLE
fix(circuit-breaker): enforce MAX_REGISTRY_SIZE (declared but never applied)

### DIFF
--- a/src/shared/utils/circuitBreaker.ts
+++ b/src/shared/utils/circuitBreaker.ts
@@ -455,6 +455,11 @@ export class CircuitBreakerOpenError extends Error {
 const MAX_REGISTRY_SIZE = 500;
 const registry = new Map<string, CircuitBreaker>();
 
+/** Test-only: current number of registered circuit breakers. */
+export function __getCircuitRegistrySizeForTests(): number {
+  return registry.size;
+}
+
 const _registrySweep = setInterval(() => {
   const now = Date.now();
   for (const [name, breaker] of registry) {
@@ -475,8 +480,37 @@ if (typeof _registrySweep === "object" && "unref" in _registrySweep) {
   (_registrySweep as { unref?: () => void }).unref?.();
 }
 
+/**
+ * Enforce MAX_REGISTRY_SIZE before inserting a new breaker. The cap was previously declared
+ * but never used — the only bound was the 5-min sweep, which evicts a breaker only if it is
+ * CLOSED, has zero failures, AND has been idle for >30 min. With high-cardinality breaker
+ * names that cap could be exceeded for up to 30 min. Evict idle CLOSED breakers (oldest first)
+ * to make room; never evict OPEN/HALF_OPEN breakers, since those carry meaningful state. A
+ * CLOSED breaker with zero failures is behaviorally identical to a freshly-created one, so
+ * evicting and lazily recreating it later changes nothing.
+ */
+function evictColdBreakersIfNeeded(): void {
+  if (registry.size < MAX_REGISTRY_SIZE) return;
+  const candidates: { name: string; lastFailureTime: number }[] = [];
+  for (const [name, breaker] of registry) {
+    const status = breaker.getStatus();
+    if (status.state === STATE.CLOSED && status.failureCount === 0) {
+      candidates.push({ name, lastFailureTime: status.lastFailureTime || 0 });
+    }
+  }
+  candidates.sort((a, b) => a.lastFailureTime - b.lastFailureTime);
+  const target = registry.size - MAX_REGISTRY_SIZE + 1;
+  for (let i = 0; i < candidates.length && i < target; i++) {
+    registry.delete(candidates[i].name);
+    try {
+      deleteCircuitBreakerState(candidates[i].name);
+    } catch {}
+  }
+}
+
 export function getCircuitBreaker(name: string, options?: CircuitBreakerOptions): CircuitBreaker {
   if (!registry.has(name)) {
+    evictColdBreakersIfNeeded();
     registry.set(name, new CircuitBreaker(name, options));
   }
   const breaker = registry.get(name)!;

--- a/tests/unit/circuit-breaker-registry-cap.test.ts
+++ b/tests/unit/circuit-breaker-registry-cap.test.ts
@@ -1,0 +1,42 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const {
+  getCircuitBreaker,
+  resetAllCircuitBreakers,
+  __getCircuitRegistrySizeForTests,
+} = await import("../../src/shared/utils/circuitBreaker.ts");
+
+test("circuit breaker registry stays bounded by MAX_REGISTRY_SIZE", () => {
+  resetAllCircuitBreakers();
+
+  // Create far more than the cap (500) of fresh CLOSED breakers.
+  for (let i = 0; i < 1200; i++) {
+    getCircuitBreaker(`cap-cb-${i}`);
+  }
+
+  const size = __getCircuitRegistrySizeForTests();
+  assert.ok(size <= 500, `registry should be capped at 500, got ${size}`);
+
+  resetAllCircuitBreakers();
+});
+
+test("registry cap never evicts an OPEN breaker", () => {
+  resetAllCircuitBreakers();
+
+  // Trip one breaker OPEN (failureThreshold = 1).
+  const open = getCircuitBreaker("must-survive", { failureThreshold: 1 });
+  open._onFailure();
+  assert.equal(open.getStatus().state, "OPEN");
+
+  // Flood with cold CLOSED breakers to force eviction.
+  for (let i = 0; i < 1200; i++) {
+    getCircuitBreaker(`flood-cb-${i}`);
+  }
+
+  // The OPEN breaker carries meaningful state and must not have been evicted.
+  const survivor = getCircuitBreaker("must-survive");
+  assert.equal(survivor.getStatus().state, "OPEN", "OPEN breaker must survive eviction");
+
+  resetAllCircuitBreakers();
+});


### PR DESCRIPTION
## Problem
`MAX_REGISTRY_SIZE = 500` in `src/shared/utils/circuitBreaker.ts` is **declared but never referenced** — `getCircuitBreaker` just `registry.set(...)` with no cap check. The only bound is the 5-minute sweep, which evicts a breaker **only** if it is `CLOSED`, has zero failures, **and** has been idle for >30 min. With high-cardinality breaker names the registry can exceed the intended cap for up to 30 minutes.

## Fix
Enforce the cap in `getCircuitBreaker`: before inserting a new breaker, evict idle `CLOSED` zero-failure breakers (oldest by `lastFailureTime` first) to make room. `OPEN`/`HALF_OPEN` breakers carry meaningful state and are never evicted. A `CLOSED` zero-failure breaker is behaviorally identical to a freshly-created one, so evicting and lazily recreating it later changes nothing. If everything is OPEN/HALF_OPEN (pathological) the registry is allowed to grow rather than drop live state.

## Tests
New `tests/unit/circuit-breaker-registry-cap.test.ts`: registry stays bounded at 500 under a flood of cold breakers, and an OPEN breaker survives eviction. Existing `circuit-breaker-failure-kind.test.ts` passes.