### PR TITLE
fix(timers): unref background interval timers so they don't block clean shutdown

### DIFF
--- a/open-sse/services/autoRefreshDaemon.ts
+++ b/open-sse/services/autoRefreshDaemon.ts
@@ -79,6 +79,8 @@ class AutoRefreshDaemon {
     this.timerId = setInterval(() => {
       this.check().catch(() => {});
     }, this.checkIntervalMs);
+    // Don't keep the process alive solely for this periodic daemon.
+    (this.timerId as { unref?: () => void })?.unref?.();
 
     console.log(
       `[AutoRefreshDaemon] Started — checking ${this.credentialStore.size} credentials every ${this.checkIntervalMs / 1000}s`

--- a/src/lib/services/healthCheck.ts
+++ b/src/lib/services/healthCheck.ts
@@ -25,6 +25,8 @@ export class HealthChecker {
     this.consecutiveFailures = 0;
     this.currentHealth = "unknown";
     this.timer = setInterval(() => void this.poll(), this.intervalMs);
+    // Don't keep the process alive solely for the health poller.
+    (this.timer as { unref?: () => void })?.unref?.();
   }
 
   stop(): void {

--- a/src/server/ws/liveServer.ts
+++ b/src/server/ws/liveServer.ts
@@ -422,6 +422,8 @@ function startHeartbeat(server: WebSocketServer): void {
       sendTo(client.ws, { type: "pong" } as WsServerMessage);
     }
   }, HEARTBEAT_INTERVAL_MS);
+  // Don't keep the process alive solely for the heartbeat (it is also cleared on close).
+  (interval as { unref?: () => void })?.unref?.();
 
   server.on("close", () => clearInterval(interval));
 }


### PR DESCRIPTION
## Problem
Three long-lived background interval timers are not `unref()`'d, so each keeps the Node event loop alive and can delay/prevent a clean process exit. This is inconsistent with the rest of the codebase, which unrefs its background timers (e.g. the circuit-breaker registry sweep, the various `open-sse/services` sweeps):
- `open-sse/services/autoRefreshDaemon.ts` — periodic credential-refresh check.
- `src/lib/services/healthCheck.ts` — `HealthChecker` poll interval (as frequent as every 2s for embedded services).
- `src/server/ws/liveServer.ts` — live-dashboard WebSocket heartbeat.

## Fix
Add `.unref?.()` at each `setInterval` creation site. Purely additive — the timers still fire on schedule and are still cleared on `stop()` / server `close()`; they just no longer hold the event loop open on their own.

## Tests
`token-health-check.test.ts` / `db-health-check.test.ts` (20 tests) pass; type-check clean. The change has no observable runtime behavior beyond shutdown semantics.