### PR TITLE
test(db,sse): de-flake db-backup + chatcore streaming timing assertions

### DIFF
--- a/tests/unit/chatcore-translation-paths.test.ts
+++ b/tests/unit/chatcore-translation-paths.test.ts
@@ -433,14 +433,13 @@ test("chatCore times out upstream execution before provider response headers", a
       userAgent: "unit-test",
     } as any);
 
-    const pendingDetail = (await waitFor(
-      () =>
-        // details[connectionId] is Record<modelKey, PendingRequestDetail[]> —
-        // the original predicate tested each ARRAY's .providerRequest (always
-        // undefined), so the waitFor could never resolve. Flatten to the details.
-        Object.values(getPendingRequests().details[connectionId] || {})
-          .flat()
-          .find((detail: any) => detail?.providerRequest?.model === "gpt-4o-mini")
+    const pendingDetail = (await waitFor(() =>
+      // details[connectionId] is Record<modelKey, PendingRequestDetail[]> —
+      // the original predicate tested each ARRAY's .providerRequest (always
+      // undefined), so the waitFor could never resolve. Flatten to the details.
+      Object.values(getPendingRequests().details[connectionId] || {})
+        .flat()
+        .find((detail: any) => detail?.providerRequest?.model === "gpt-4o-mini")
     )) as any;
     assert.equal(pendingDetail?.providerRequest?.model, "gpt-4o-mini");
     assert.deepEqual(pendingDetail?.providerRequest?.messages, body.messages);
@@ -2519,7 +2518,13 @@ test("chatCore returns streaming responses without waiting for upstream completi
 
   const raceResult = await Promise.race([
     invocation.then(() => "returned"),
-    new Promise((resolve) => setTimeout(() => resolve("blocked"), 1000)),
+    // 10s ceiling: a non-buffering streaming impl resolves the invocation as soon
+    // as the Response is returned (upstream still open), but on a starved CI event
+    // loop that legitimate early return can exceed a 1s wall-clock budget (flake
+    // repro: 5/8 runs returned at 1.3–2.2s under CPU contention → false "blocked").
+    // The ceiling only bounds the buffered-failure case: a buffering impl never
+    // resolves until closeUpstream() fires below, so it still trips "blocked".
+    new Promise((resolve) => setTimeout(() => resolve("blocked"), 10000)),
   ]);
 
   if (raceResult !== "returned") {

--- a/tests/unit/db-backup-extended.test.ts
+++ b/tests/unit/db-backup-extended.test.ts
@@ -43,12 +43,25 @@ function seedConnections(count = 8) {
   }
 }
 
-async function waitForFile(filePath) {
-  for (let attempt = 0; attempt < 20; attempt++) {
-    if (fs.existsSync(filePath)) return;
+// backupDbFile() kicks off db.backup() fire-and-forget — better-sqlite3 creates
+// the destination file when the page copy STARTS, not when it finishes. Waiting
+// on file existence alone races the copy: under load listDbBackups() can open a
+// partially-written backup and read connectionCount as 0 (flake repro: under CPU
+// contention the backup file existed but the seeded rows were not yet copied →
+// connectionCount 0 ≠ 12). Wait for the real completion condition instead — the
+// backup actually contains the seeded connections. The 30s ceiling only bounds
+// the failure case; the green path returns as soon as the data lands (sub-second
+// in practice — the wide ceiling absorbs heavy CI page-copy contention).
+async function waitForBackupEntry(filename, expectedConnectionCount, timeoutMs = 30000) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    const entry = (await backupDb.listDbBackups()).find((backup) => backup.id === filename);
+    if (entry && entry.connectionCount === expectedConnectionCount) return entry;
     await new Promise((resolve) => setTimeout(resolve, 50));
   }
-  throw new Error(`Timed out waiting for file: ${filePath}`);
+  throw new Error(
+    `Timed out waiting for backup ${filename} to finish copying ${expectedConnectionCount} connections`
+  );
 }
 
 function makeDbBackupsJsonRequest(method: string, body: unknown): NextRequest {
@@ -75,13 +88,12 @@ test("backupDbFile creates manual backups and listDbBackups returns metadata", a
   assert.ok(result);
 
   const backupPath = path.join(core.DB_BACKUPS_DIR, result.filename);
-  await waitForFile(backupPath);
+  // Wait for the async backup to finish copying the 12 seeded connections, not
+  // merely for the destination file to appear (see waitForBackupEntry).
+  const entry = await waitForBackupEntry(result.filename, 12);
 
-  const backups = await backupDb.listDbBackups();
-
-  assert.equal(backups.length >= 1, true);
-  assert.equal(backups[0].reason, "manual");
-  assert.equal(backups[0].connectionCount, 12);
+  assert.equal(entry.reason, "manual");
+  assert.equal(entry.connectionCount, 12);
   assert.equal(fs.existsSync(backupPath), true);
 });
 


### PR DESCRIPTION
## Problema

Dois testes unitários eram **flaky sob paralelismo de CI** (documentados na memória do ciclo v3.8.28: `db-backup-extended` ~IO e `chatcore-translation-paths` ~streaming timing). Reproduzidos **localmente sob contenção de CPU** (RED → GREEN após o fix). Nenhum é bug de produto — ambos são **suposições de timing nos próprios testes**.

## Causa raiz (investigada, não adivinhada)

### 1. `db-backup-extended` → *"backupDbFile creates manual backups"*
`backupDbFile()` é síncrona e retorna imediatamente, mas dispara `db.backup(file)` como **promise fire-and-forget**. O better-sqlite3 cria o arquivo destino no **início** da cópia de páginas, não no fim. O teste esperava só pela **existência** do arquivo (`waitForFile`) e então chamava `listDbBackups()`, que abria um backup **parcial** e lia `connectionCount = 0 ≠ 12`.

**Repro:** `actual: 0, expected: 12` em ~5.6s sob carga.

**Fix:** esperar a **condição real de conclusão** — o backup conter as 12 conexões semeadas (`waitForBackupEntry`). Teto de 30s só limita o caso de falha; o caminho verde retorna sub-segundo.

### 2. `chatcore-translation-paths` → *"returns streaming responses without waiting for upstream completion"*
O teste corria a invocação contra um **timeout fixo de 1000ms**. Numa event-loop de CI faminta, o retorno *legítimo* (não-bufferizado) do `handleChatCore` passava de 1s de wall-clock → o timeout vencia → `raceResult='blocked'` → falha.

**Repro:** 5/8 cópias retornaram em 1.3–2.2s sob contenção → falso `"blocked"`.

**Fix:** teto **1000→10000ms** (mesmo padrão do helper `waitFor` já existente no arquivo). Só limita o caso bufferizado — a detecção de regressão de buffering (`closeUpstream()` abaixo) é **inalterada**.

## Validação (Rule #18 — repro RED → GREEN)

| Nível | Comando | Antes | Depois |
|-------|---------|-------|--------|
| Realista (~CI 1:1) | 8 db + 8 cc concorrentes + 2 burners × 2 rodadas | RED | **db 16/16, cc 16/16** ✅ |
| Extremo | 12 db + 12 cc + 14 CPU burners (16 cores) × 2 rodadas | RED | **db 12/12, streaming verde** ✅ |
| Isolado | cada arquivo | — | db 15/15, cc 65/65 ✅ |

Gates locais: ESLint **0 errors**, `check:test-discovery` OK, prettier clean, file-size baseline não rastreia esses arquivos.

## Notas

- **Test-only**: nenhum código de produção tocado.
- Sob carga **sintética-extrema** (26× em 16 cores, além de CI real ~4-em-4) um **terceiro** teste pré-existente (`chatCore times out upstream execution`) também pode estourar seu teto de 10s — **fora do escopo** destes 2 (não falha em carga realista). Tentei endurecê-lo e revertí (o fix não resolveu e adicionava 3s de runtime); fica registrado para investigação separada se desejado.
- O `prettier --write` do pre-commit também normalizou **uma região pré-existente não-conforme** no `chatcore-translation-paths.test.ts` (puro re-wrap, lógica idêntica) — inevitável via lint-staged.