### PR TITLE
feat(dashboard): make identity grid visible + unify focus ring on accent (design follow-up)

### DIFF
--- a/design.md
+++ b/design.md
@@ -1,6 +1,6 @@
 # OmniRoute — Design System & Visual Identity
 
-> **Status:** standardization plan. **Phases 1–3 are implemented in this PR** (grid, primitives, status-color centralization, mono token, and the DataTable token migration). The DataTable migration is **faithful** — dark stays byte-identical (the new `--table-*` dark values equal the old hardcoded rgba); light is fixed (it was buggy always-dark via dead `var()` fallbacks). **⚠️ Wants a visual pass before merge** (light-theme tables + the secondary-text shift `#888`→`--color-text-muted`). Phase 4 still pending; note several remaining "hardcoded" hex are _intentional_ (always-dark console terminal, ReactFlow SVG strokes) and must NOT be swept.
+> **Status:** standardization plan. **Phases 1–3 are implemented in this PR** (grid, primitives, status-color centralization, mono token, and the DataTable token migration). The DataTable migration is **faithful** — dark stays byte-identical (the new `--table-*` dark values equal the old hardcoded rgba); light is fixed (it was buggy always-dark via dead `var()` fallbacks). **⚠️ Wants a visual pass before merge** (light-theme tables + the secondary-text shift `#888`→`--color-text-muted`). **Phase 4 is now largely done too** (C6 focus-ring → accent, C7 Checkbox/Textarea primitives, C9 `cn()`→tailwind-merge); only the selective C8 hex-sweep remains. Note several remaining "hardcoded" hex are _intentional_ (always-dark console terminal, ReactFlow SVG strokes) and must NOT be swept.
 > **Date:** 2026-06-16 · **Scope:** unify the OmniRoute dashboard (`src/`) with the marketing site (`_mono_repo/omnirouteSite/`) into **one visual identity** — same graph-paper grid background, same color tokens, standardized components.
 
 ---
@@ -97,14 +97,15 @@ body::before {
 
 ```css
 :root {
-  /* light */
-  --grid-line: rgba(0, 0, 0, 0.045);
+  /* light — grid opacity tuned up from the site's 0.045 so the wallpaper is
+     actually visible on the dense dashboard (cards/chrome cover most of the viewport) */
+  --grid-line: rgba(0, 0, 0, 0.07);
   --grid-size: 46px;
   --section-alt: rgba(0, 0, 0, 0.022);
 }
 .dark {
-  /* dark */
-  --grid-line: rgba(255, 255, 255, 0.035);
+  /* dark — tuned up from 0.035 for the same reason */
+  --grid-line: rgba(255, 255, 255, 0.06);
   --section-alt: rgba(255, 255, 255, 0.018);
 }
 ```
@@ -161,7 +162,7 @@ Custom components (no shadcn/Radix), Tailwind v4, semantic tokens **mostly** ado
 | C3  | **Tables**                             | `DataTable.tsx:122-176`, `logTableStyles.ts`, `globals.css:405-414`                                                      | 100% inline hardcoded rgba + non-existent vars; migrate to tokens, retire divergent styles                          | 3     |
 | C4  | **Centralize status colors**           | `flow/edgeStyles.ts`, `TokenHealthBadge.tsx`, `DegradationBadge.tsx`, `ProviderCascadeNode.tsx`, `Badge.tsx` + 5 helpers | 6+ copies of the same hex → one module off `--color-success/warning/error`                                          | 3     |
 | C5  | **Card border**                        | `Card.tsx:39`                                                                                                            | `border-white/5` → brand `/8`                                                                                       | 2     |
-| C6  | **Focus ring reconcile**               | `globals.css:183` vs component `ring-primary/30`                                                                         | global indigo vs component red → pick one                                                                           | 4     |
+| C6  | **Focus ring reconcile** ✅ DONE       | `globals.css` `--focus-ring` (accent) vs form controls' `ring-primary/30`                                                | unified on **accent (violet)** to match the global ring + disambiguate from the red error ring; error stays red     | 4     |
 | C7  | **Add `Checkbox` + `Textarea`**        | raw `<input>`/`<textarea>` w/ inline `accentColor:#6366f1`                                                               | token-driven primitives                                                                                             | 4     |
 | C8  | **Hardcoded-hex sweep**                | `ConsoleLogViewer.tsx:240`, `ComboLiveStudio.tsx:306`, Modal dots, ~14 chart files                                       | literals → tokens                                                                                                   | 4     |
 | C9  | **`cn()` → clsx + tailwind-merge**     | `src/shared/utils/cn.ts`                                                                                                 | conflicting classes stack; needed for C1 overrides                                                                  | 2     |
@@ -175,7 +176,7 @@ Custom components (no shadcn/Radix), Tailwind v4, semantic tokens **mostly** ado
 - **Phase 1 — Grid + identity tokens (THIS PR).** `globals.css` grid + `--surface-2`/`--grad-brand`/`--radius` tokens; `body::before` wallpaper; remove the `bg-bg` blocker; static guard test. Low risk, reversible in one commit.
 - **Phase 2 — Primitives (C1, C2, C5) — DONE in this PR.** Semantic radius utilities `rounded-card` (14px) / `rounded-control` (9px) added via `@theme` (custom names, so the default `rounded-sm/md/lg/xl` stay untouched — no 400-file blast); Card/Modal → 14px, Button/Input/Select → 9px; Button primary → `--grad-brand` (red→violet) + new `accent` variant; Card borders → the `border-border` token (0.08). **Deferred:** `cn()`→tailwind-merge (C9) needs new deps; the ad-hoc `rounded-lg` sweep (326 files) is left as-is since the primitives carry the bulk of the surface.
 - **Phase 3 — Status colors + tables (C3, C4) — DONE in this PR.** ✅ **C4** (`src/shared/constants/statusColors.ts` — `STATUS_HEX` single source; `flow/edgeStyles.ts` + `TokenHealthBadge` repointed, faithful/same hex). ✅ **`--font-mono`** token. ✅ **C3 (DataTable)** — replaced every inline rgba + the dead `var(--bg-table-header)` / `var(--text-secondary)` fallbacks with a `--table-*` token set (`--table-header-bg/-row-zebra/-row-hover/-cell-border/-row-selected`) whose **dark values exactly equal the old hardcoded rgba** (dark byte-identical) and whose light values fix the previously-always-dark light theme. Header border → `--color-border`, secondary text → `--color-text-muted`. **Wants a visual pass before merge.** (Not touched: `logTableStyles.ts` and the legacy Ant `.ant-table` rules — separate, lower priority.)
-- **Phase 4 — Cleanup (C7, C9 done; C6, C8 pending).** ✅ **C9** `cn()` → `twMerge(clsx(...))` (clsx + tailwind-merge added as deps) — a caller's `className` now correctly _replaces_ a primitive's conflicting class instead of stacking. ✅ **C7** new `Checkbox` + `Textarea` primitives (token-driven, exported from the barrel; additive — adoption of the 32 raw checkboxes / 41 raw textareas can follow incrementally). ⏳ **C6** focus-ring reconcile (global indigo vs component red — taste, wants a visual pass). ⏳ **C8 hex-sweep is NOT a blind find/replace** — confirmed offenders that are _intentional_ and must stay: `ConsoleLogViewer.tsx:240` (always-dark terminal), `TokenHealthBadge` popover, ReactFlow SVG strokes. Only migrate hex genuinely meant to be theme-aware.
+- **Phase 4 — Cleanup (C6, C7, C9 done; C8 pending).** ✅ **C9** `cn()` → `twMerge(clsx(...))` (clsx + tailwind-merge added as deps) — a caller's `className` now correctly _replaces_ a primitive's conflicting class instead of stacking. ✅ **C7** new `Checkbox` + `Textarea` primitives (token-driven, exported from the barrel; additive — adoption of the 32 raw checkboxes / 41 raw textareas can follow incrementally). ✅ **C6** focus-ring reconcile — the form controls (`Input`/`Select`/`Textarea`/`Toggle`/`Checkbox`) now focus on the **accent (violet)** ring to match the global `--focus-ring` and to stop colliding with the red error ring; the red error state is unchanged. ⏳ **C8 hex-sweep is NOT a blind find/replace** — confirmed offenders that are _intentional_ and must stay: `ConsoleLogViewer.tsx:240` (always-dark terminal), `TokenHealthBadge` popover, ReactFlow SVG strokes. Only migrate hex genuinely meant to be theme-aware.
 
 Each phase: `npm run lint` + `npm run typecheck:core` + a visual pass.
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -88,8 +88,10 @@
   --shadow-elevated: 0 12px 28px -4px rgba(20, 20, 40, 0.06);
 
   /* Graph-paper wallpaper grid — shared visual identity with the marketing site
-     (_mono_repo/omnirouteSite/css). Light theme values. Rendered by body::before. */
-  --grid-line: rgba(0, 0, 0, 0.045);
+     (_mono_repo/omnirouteSite/css). Light theme values. Rendered by body::before.
+     Opacity tuned up from the site's 0.045 so the wallpaper is actually visible on
+     the dense dashboard (cards/chrome cover most of the viewport). */
+  --grid-line: rgba(0, 0, 0, 0.07);
   --grid-size: 46px;
   --section-alt: rgba(0, 0, 0, 0.022);
 
@@ -149,8 +151,8 @@
   --shadow-warm: 0 2px 12px -2px rgba(229, 77, 94, 0.15);
   --shadow-elevated: 0 12px 28px -4px rgba(0, 0, 0, 0.3);
 
-  /* Graph-paper wallpaper grid — dark theme values. */
-  --grid-line: rgba(255, 255, 255, 0.035);
+  /* Graph-paper wallpaper grid — dark theme values (tuned up from 0.035 for visibility). */
+  --grid-line: rgba(255, 255, 255, 0.06);
   --section-alt: rgba(255, 255, 255, 0.018);
   --surface-2: #1c2230;
 
@@ -265,7 +267,8 @@ body::before {
   inset: 0;
   z-index: -1;
   pointer-events: none;
-  background-image: linear-gradient(to right, var(--grid-line) 1px, transparent 1px),
+  background-image:
+    linear-gradient(to right, var(--grid-line) 1px, transparent 1px),
     linear-gradient(to bottom, var(--grid-line) 1px, transparent 1px);
   background-size: var(--grid-size) var(--grid-size);
 }

--- a/src/shared/components/Checkbox.tsx
+++ b/src/shared/components/Checkbox.tsx
@@ -18,7 +18,7 @@ export default function Checkbox({ label, className, id, ...props }: CheckboxPro
       id={id}
       className={cn(
         "h-4 w-4 shrink-0 cursor-pointer rounded-[4px] accent-[var(--color-accent)]",
-        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/30",
         "disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}

--- a/src/shared/components/Input.tsx
+++ b/src/shared/components/Input.tsx
@@ -113,7 +113,7 @@ export default function Input({
             "w-full py-2 px-3 text-sm text-text-main",
             "bg-white dark:bg-white/5 border border-black/10 dark:border-white/10 rounded-control",
             "placeholder-text-muted/60",
-            "focus:ring-1 focus:ring-primary/30 focus:border-primary/50 focus:outline-none",
+            "focus:ring-1 focus:ring-accent/30 focus:border-accent/50 focus:outline-none",
             "transition-all shadow-inner disabled:opacity-50 disabled:cursor-not-allowed",
             // iOS zoom fix
             "text-[16px] sm:text-sm",

--- a/src/shared/components/Select.tsx
+++ b/src/shared/components/Select.tsx
@@ -64,7 +64,7 @@ export default function Select({
           className={cn(
             "w-full py-2 px-3 pe-10 text-sm text-text-main",
             "bg-surface border border-black/10 dark:border-white/10 rounded-control appearance-none",
-            "focus:ring-1 focus:ring-primary/30 focus:border-primary/50 focus:outline-none",
+            "focus:ring-1 focus:ring-accent/30 focus:border-accent/50 focus:outline-none",
             "transition-all disabled:opacity-50 disabled:cursor-not-allowed",
             "text-[16px] sm:text-sm",
             error ? "border-red-500 focus:border-red-500 focus:ring-red-500/20" : "",

--- a/src/shared/components/Textarea.tsx
+++ b/src/shared/components/Textarea.tsx
@@ -17,7 +17,7 @@ export default function Textarea({ className, error = false, ...props }: Textare
         "w-full py-2 px-3 text-sm text-text-main",
         "bg-white dark:bg-white/5 border border-black/10 dark:border-white/10 rounded-control",
         "placeholder-text-muted/60",
-        "focus:ring-1 focus:ring-primary/30 focus:border-primary/50 focus:outline-none",
+        "focus:ring-1 focus:ring-accent/30 focus:border-accent/50 focus:outline-none",
         "transition-all disabled:opacity-50 disabled:cursor-not-allowed",
         "text-[16px] sm:text-sm",
         error ? "border-red-500 focus:border-red-500 focus:ring-red-500/20" : "",

--- a/src/shared/components/Toggle.tsx
+++ b/src/shared/components/Toggle.tsx
@@ -74,7 +74,7 @@ export default function Toggle({
           "relative inline-flex shrink-0 cursor-pointer rounded-full",
           "transition-colors duration-200 ease-in-out",
           "border shadow-inner",
-          "focus:outline-none focus:ring-1 focus:ring-primary/30",
+          "focus:outline-none focus:ring-1 focus:ring-accent/30",
           checked ? "border-primary bg-primary" : "border-border bg-surface-2 dark:bg-white/20",
           sizes[size].track,
           disabled && "cursor-not-allowed"

--- a/tests/unit/design-grid-background.test.ts
+++ b/tests/unit/design-grid-background.test.ts
@@ -13,10 +13,11 @@ const dashboardLayout = fs.readFileSync(
 );
 
 test("globals.css defines the grid wallpaper tokens for both themes", () => {
-  // light
-  assert.match(globalsCss, /--grid-line:\s*rgba\(0,\s*0,\s*0,\s*0\.045\)/);
+  // light (opacity tuned up from the site's 0.045 so the grid is visible on the
+  // dense dashboard — see the token comment in globals.css)
+  assert.match(globalsCss, /--grid-line:\s*rgba\(0,\s*0,\s*0,\s*0\.07\)/);
   // dark
-  assert.match(globalsCss, /--grid-line:\s*rgba\(255,\s*255,\s*255,\s*0\.035\)/);
+  assert.match(globalsCss, /--grid-line:\s*rgba\(255,\s*255,\s*255,\s*0\.06\)/);
   // size + alternating-section overlay
   assert.match(globalsCss, /--grid-size:\s*46px/);
   assert.match(globalsCss, /--section-alt:\s*rgba\(0,\s*0,\s*0,\s*0\.022\)/);
@@ -160,4 +161,25 @@ test("Checkbox + Textarea primitives exist and are exported", () => {
     "checkbox uses the brand accent token"
   );
   assert.ok(textarea.includes("rounded-control"), "textarea uses the control radius");
+});
+
+// ── C6: form controls share one accent focus ring (separate from the red error state) ──
+
+test("form controls focus on the accent ring, not the red primary", () => {
+  // The global :focus-visible ring already uses --color-accent. Align the form
+  // controls to it so keyboard focus is one consistent violet everywhere and the
+  // red focus ring no longer collides with the red error state.
+  assert.match(globalsCss, /--focus-ring:.*var\(--color-accent\)/);
+  for (const name of ["Input", "Select", "Textarea", "Toggle", "Checkbox"]) {
+    const src = read(`../../src/shared/components/${name}.tsx`);
+    assert.ok(/ring-accent\/30/.test(src), `${name} uses the accent focus ring`);
+    assert.ok(
+      !/(?:focus|focus-visible):ring-primary\/30/.test(src),
+      `${name} no longer uses the red primary focus ring`
+    );
+    // the red error ring stays intact where the control has an error state
+    if (src.includes("error")) {
+      assert.ok(src.includes("ring-red-500/20"), `${name} keeps the red error ring`);
+    }
+  }
 });


### PR DESCRIPTION
Follow-up to #4122 (which merged the unified visual identity, phases 1–4). Two small adjustments the owner asked for after a first look:

## 1. Grid wallpaper is now actually visible
The grid inherited the marketing site's opacity (light `0.045`, dark `0.035`), which reads as **invisible** on the dense dashboard — cards and chrome cover most of the viewport, so the faint lines only showed in the rare empty gaps. Tuned up so the wallpaper is perceptible while staying a subtle background:

| theme | before | after |
| ----- | ------ | ----- |
| light | `rgba(0,0,0,0.045)` | `rgba(0,0,0,0.07)` |
| dark  | `rgba(255,255,255,0.035)` | `rgba(255,255,255,0.06)` |

Verified in the compiled CSS: `--grid-line` → `#00000012` (light) / `#ffffff0f` (dark).

## 2. Focus-ring reconcile (design.md **C6**)
The global `:focus-visible` ring already uses `--color-accent` (violet), but the form controls (`Input`, `Select`, `Textarea`, `Toggle`, `Checkbox`) focused on `ring-primary` (red) — which **collided with the red error ring** on those same controls. Unified the normal focus ring on **accent (violet)** to match the global default and disambiguate from the error state. The red error ring is unchanged.

## Validation
- Guard test `design-grid-background.test.ts` updated (new grid opacity + a C6 assertion) — **13/13 pass**.
- `typecheck:core` clean, ESLint clean, `npm run build` exit 0.
- Compiled CSS confirms `focus:ring-accent/30` + `focus:border-accent/50` utilities are generated.

⚠️ Still wants the owner's **visual pass** (grid prominence on busy dark/light screens; violet focus ring on forms) before it's considered final.