### PR TITLE
feat(mitm): TPROXY IP_TRANSPARENT native addon + conditional loader (Epic A)

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "build:secure": "OMNIROUTE_BUILD_PROFILE=minimal node scripts/build/build-next-isolated.mjs",
     "build:cli": "node --import tsx scripts/build/prepublish.ts",
     "build:release": "rm -rf .build dist && OMNIROUTE_BUILD_SHA=$(git rev-parse --short HEAD) npm run build && npm run build:cli && node scripts/build/write-build-sha.mjs",
+    "build:native:tproxy": "cd src/mitm/tproxy/native && npx --yes node-gyp rebuild",
     "start": "node scripts/dev/run-next.mjs start",
     "lint": "eslint .",
     "lint:md": "npx --yes markdownlint-cli2 \"docs/**/*.md\" \"*.md\" \"!docs/i18n\" \"!docs/research\"",

--- a/src/mitm/tproxy/native/.gitignore
+++ b/src/mitm/tproxy/native/.gitignore
@@ -1,0 +1,2 @@
+build/
+prebuilds/

--- a/src/mitm/tproxy/native/README.md
+++ b/src/mitm/tproxy/native/README.md
@@ -1,0 +1,41 @@
+# TPROXY transparent-socket native addon
+
+Tiny N-API addon for Fase 3 / Epic A (TPROXY transparent capture mode). Node's
+`net` module cannot `setsockopt(IP_TRANSPARENT)` before `bind()`, which TPROXY
+requires (otherwise the kernel drops the redirected packets). `transparent.c`
+does `socket()`+`SO_REUSEADDR`+`IP_TRANSPARENT`+`bind()`+`listen()` and returns
+the raw fd; Node adopts it via `server.listen({ fd })` and reads the original
+destination from `socket.localAddress`/`localPort` (TPROXY preserves it — no
+`SO_ORIGINAL_DST`/NAT).
+
+## Status: groundwork (opt-in, not wired into a capture mode yet)
+
+Loaded conditionally by `../transparentSocket.ts`. A JS-only install (no
+toolchain, or non-Linux) keeps working — the TPROXY mode is gated on the addon
+being available.
+
+**Viability proven on the VPS (kernel 6.8.0-124):** the prebuilt `.node`,
+compiled under one Node version, loaded under a different one (N-API is
+ABI-stable) and, as root, created the IP_TRANSPARENT socket which Node adopted
+via `server.listen({ fd })`. The TPROXY iptables/ip-rule apply+revert was also
+validated against the same kernel (see PR #4139).
+
+## Build (opt-in, Linux + C toolchain)
+
+```bash
+npm run build:native:tproxy      # -> build/Release/transparent.node
+```
+
+`build/` and `prebuilds/` are git-ignored. Distribution via per-platform
+prebuilds (linux-x64 / linux-arm64) is a follow-up — IP_TRANSPARENT is
+Linux-only, so only Linux prebuilds are needed; everywhere else the loader
+returns "unavailable".
+
+## Remaining for the full Epic A (gated follow-ups)
+
+- The TPROXY listener that adopts the fd, terminates TLS, and feeds the capture
+  buffer (reusing the MITM path).
+- `repairMitm()` calling `revertTproxy()` so a crash flushes the mangle rules.
+- The capture-mode route + Traffic Inspector UI tab.
+- A live end-to-end intercept (TPROXY → listener) in a dedicated test
+  environment (needs a routing scenario; risky on a production proxy).

--- a/src/mitm/tproxy/native/binding.gyp
+++ b/src/mitm/tproxy/native/binding.gyp
@@ -1,0 +1,9 @@
+{
+  "targets": [
+    {
+      "target_name": "transparent",
+      "sources": ["transparent.c"],
+      "cflags": ["-Wall", "-O2"]
+    }
+  ]
+}

--- a/src/mitm/tproxy/native/transparent.c
+++ b/src/mitm/tproxy/native/transparent.c
@@ -1,0 +1,74 @@
+/*
+ * Spike: minimal N-API addon to create a TPROXY IP_TRANSPARENT listening socket.
+ *
+ * Node's net module cannot setsockopt(IP_TRANSPARENT) before bind(), which TPROXY
+ * requires (otherwise the kernel drops the redirected packets). This addon does
+ * socket()+SO_REUSEADDR+IP_TRANSPARENT+bind()+listen() and returns the raw fd;
+ * Node then adopts it via `server.listen({ fd })`. On each accepted connection,
+ * socket.localAddress/localPort report the ORIGINAL destination (TPROXY preserves
+ * it via getsockname), so no SO_ORIGINAL_DST / NAT is needed.
+ *
+ * Pure C N-API (node_api.h) — no node-addon-api dependency.
+ */
+#include <node_api.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netinet/ip.h>
+#include <arpa/inet.h>
+#include <string.h>
+#include <unistd.h>
+#include <errno.h>
+
+#define THROW(env, code, msg) do { napi_throw_error((env), (code), (msg)); return NULL; } while (0)
+
+static napi_value CreateTransparentListener(napi_env env, napi_callback_info info) {
+  size_t argc = 2;
+  napi_value argv[2];
+  napi_get_cb_info(env, info, &argc, argv, NULL, NULL);
+
+  char ip[64] = {0};
+  size_t ip_len = 0;
+  napi_get_value_string_utf8(env, argv[0], ip, sizeof(ip), &ip_len);
+  int32_t port = 0;
+  napi_get_value_int32(env, argv[1], &port);
+
+  int fd = socket(AF_INET, SOCK_STREAM, 0);
+  if (fd < 0) THROW(env, "ESOCKET", strerror(errno));
+
+  int one = 1;
+  if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one)) < 0) {
+    close(fd); THROW(env, "ESO_REUSEADDR", strerror(errno));
+  }
+  /* The critical, Node-unsupported option. Requires CAP_NET_ADMIN. */
+  if (setsockopt(fd, SOL_IP, IP_TRANSPARENT, &one, sizeof(one)) < 0) {
+    int e = errno; close(fd); THROW(env, "EIP_TRANSPARENT", strerror(e));
+  }
+
+  struct sockaddr_in addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.sin_family = AF_INET;
+  addr.sin_port = htons((uint16_t)port);
+  if (inet_pton(AF_INET, ip, &addr.sin_addr) != 1) {
+    close(fd); THROW(env, "EADDR", "invalid IPv4 address");
+  }
+  if (bind(fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+    int e = errno; close(fd); THROW(env, "EBIND", strerror(e));
+  }
+  if (listen(fd, 511) < 0) {
+    int e = errno; close(fd); THROW(env, "ELISTEN", strerror(e));
+  }
+
+  napi_value result;
+  napi_create_int32(env, fd, &result);
+  return result;
+}
+
+static napi_value Init(napi_env env, napi_value exports) {
+  napi_value fn;
+  napi_create_function(env, "createTransparentListener", NAPI_AUTO_LENGTH,
+                       CreateTransparentListener, NULL, &fn);
+  napi_set_named_property(env, exports, "createTransparentListener", fn);
+  return exports;
+}
+
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/src/mitm/tproxy/transparentSocket.ts
+++ b/src/mitm/tproxy/transparentSocket.ts
@@ -1,0 +1,77 @@
+/**
+ * Fase 3 / Epic A — loader for the TPROXY IP_TRANSPARENT native addon.
+ *
+ * Node's `net` module cannot `setsockopt(IP_TRANSPARENT)` before `bind()`, which
+ * TPROXY requires. `src/mitm/tproxy/native/transparent.c` is a tiny N-API addon
+ * that creates the transparent listening socket and returns its fd; Node adopts
+ * it via `server.listen({ fd })` and reads the original destination from
+ * `socket.localAddress`/`localPort` (TPROXY preserves it — no SO_ORIGINAL_DST).
+ *
+ * The addon is **optional**: it is Linux-only and must be built with a native
+ * toolchain (`npm run build:native:tproxy`) or shipped as a prebuild. This
+ * loader degrades gracefully so a JS-only install (no toolchain, or a non-Linux
+ * host) keeps working — the TPROXY capture mode is simply gated on availability.
+ *
+ * Viability proven on the VPS (kernel 6.8.0): the prebuilt `.node` loaded under
+ * a different Node version (N-API ABI-stable) and, as root, created the
+ * IP_TRANSPARENT socket which Node adopted.
+ */
+import { createRequire } from "node:module";
+import { platform } from "node:os";
+
+export interface TransparentAddon {
+  /** socket()+SO_REUSEADDR+IP_TRANSPARENT+bind()+listen(); returns the raw fd. */
+  createTransparentListener(ip: string, port: number): number;
+}
+
+/** Candidate locations for the built/prebuilt addon, relative to this module. */
+const ADDON_PATHS = [
+  "./native/build/Release/transparent.node",
+  "./native/prebuilds/transparent.node",
+];
+
+/**
+ * Attempt to load the native addon. Returns null (never throws) when the host is
+ * non-Linux or the addon hasn't been built. `req`/`os` are injectable for tests.
+ */
+export function loadTransparentAddon(
+  req: (path: string) => unknown = createRequire(import.meta.url),
+  os: () => string = platform
+): TransparentAddon | null {
+  if (os() !== "linux") return null; // IP_TRANSPARENT is a Linux-only socket option
+  for (const path of ADDON_PATHS) {
+    try {
+      const mod = req(path) as Partial<TransparentAddon> | undefined;
+      if (mod && typeof mod.createTransparentListener === "function") {
+        return mod as TransparentAddon;
+      }
+    } catch {
+      // not built / not present at this path — try the next.
+    }
+  }
+  return null;
+}
+
+const cached: TransparentAddon | null = loadTransparentAddon();
+
+/** True when the TPROXY transparent-socket addon is loadable on this host. */
+export function isTransparentSocketAvailable(): boolean {
+  return cached !== null;
+}
+
+/**
+ * Create an IP_TRANSPARENT listening socket and return its fd for Node to adopt
+ * via `server.listen({ fd })`. Throws a clear, actionable error when the addon
+ * is unavailable (callers should check `isTransparentSocketAvailable()` first
+ * and disable the TPROXY capture mode).
+ */
+export function createTransparentListenerFd(ip: string, port: number): number {
+  if (!cached) {
+    throw new Error(
+      "TPROXY transparent-socket addon is not available. It is Linux-only and must be built " +
+        "(`npm run build:native:tproxy`, needs a C toolchain) or shipped as a prebuild; " +
+        "CAP_NET_ADMIN is required at runtime."
+    );
+  }
+  return cached.createTransparentListener(ip, port);
+}

--- a/tests/unit/tproxy-transparent-socket.test.ts
+++ b/tests/unit/tproxy-transparent-socket.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Fase 3 / Epic A — TPROXY IP_TRANSPARENT socket wrapper.
+ *
+ * Node's net module can't setsockopt(IP_TRANSPARENT), so the TPROXY listener
+ * needs a tiny native addon (src/mitm/tproxy/native/transparent.c). Viability
+ * was proven on the VPS: the prebuilt .node loaded under a different Node
+ * version (N-API ABI-stable) and, as root, created the transparent socket which
+ * Node adopted via server.listen({fd}). This wrapper loads that prebuilt addon
+ * CONDITIONALLY — TPROXY mode is gated on its availability so a JS-only install
+ * (no toolchain, or non-Linux) keeps working. These tests pin the graceful
+ * fallback and the load logic (injected require/platform — deterministic).
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { loadTransparentAddon, isTransparentSocketAvailable, createTransparentListenerFd } =
+  await import("../../src/mitm/tproxy/transparentSocket.ts");
+
+test("loadTransparentAddon returns null on non-Linux (IP_TRANSPARENT is Linux-only)", () => {
+  const addon = loadTransparentAddon(() => ({ createTransparentListener: () => 3 }), () => "darwin");
+  assert.equal(addon, null);
+});
+
+test("loadTransparentAddon returns null when the prebuilt addon is absent (require throws)", () => {
+  const addon = loadTransparentAddon(
+    () => {
+      throw new Error("Cannot find module");
+    },
+    () => "linux"
+  );
+  assert.equal(addon, null);
+});
+
+test("loadTransparentAddon returns the addon when present and well-shaped", () => {
+  const fake = { createTransparentListener: () => 42 };
+  const addon = loadTransparentAddon(() => fake, () => "linux");
+  assert.equal(addon, fake);
+  assert.equal(addon?.createTransparentListener("0.0.0.0", 1), 42);
+});
+
+test("loadTransparentAddon rejects a module missing createTransparentListener", () => {
+  const addon = loadTransparentAddon(() => ({ somethingElse: true }), () => "linux");
+  assert.equal(addon, null);
+});
+
+test("isTransparentSocketAvailable returns a boolean (false in CI — addon not built)", () => {
+  assert.equal(typeof isTransparentSocketAvailable(), "boolean");
+  assert.equal(isTransparentSocketAvailable(), false);
+});
+
+test("createTransparentListenerFd throws a clear, actionable error when unavailable", () => {
+  assert.throws(() => createTransparentListenerFd("0.0.0.0", 8443), /not available|Linux|build/i);
+});


### PR DESCRIPTION
## Summary

Resolves the architectural blocker for Fase 3 / Epic A (TPROXY transparent capture mode): **Node's `net` cannot `setsockopt(IP_TRANSPARENT)` before `bind()`**, which TPROXY requires (the kernel drops the redirected packets otherwise). This PR adds a tiny N-API addon that creates the transparent socket, plus a **conditional loader** so it never breaks a JS-only install.

- `src/mitm/tproxy/native/transparent.c` — `socket()`+`SO_REUSEADDR`+`IP_TRANSPARENT`+`bind()`+`listen()`, returns the raw fd. Node adopts it via `server.listen({ fd })` and reads the original destination from `socket.localAddress`/`localPort` (TPROXY preserves it — no `SO_ORIGINAL_DST`/NAT).
- `src/mitm/tproxy/transparentSocket.ts` — loads the prebuilt addon **conditionally** (Linux-only, optional build). `isTransparentSocketAvailable()` gates the TPROXY mode; `createTransparentListenerFd()` throws a clear, actionable error when unavailable. Injected `require`/`platform` make the load logic unit-testable.
- Build is **opt-in** (`npm run build:native:tproxy`); `build/`+`prebuilds/` are git-ignored, so the addon is **not** committed and CI exercises the graceful-unavailable path.

## Viability proven on the VPS (Hard Rule #18)

Validated on `root@192.168.0.15` (kernel `6.8.0-124-generic`):

```
- compiled the .node locally (Node v24.16), copied to the VPS (Node v24.14) → loaded fine (N-API is ABI-stable)
- as root: createTransparentListener("0.0.0.0", 18443) → fd=21 (IP_TRANSPARENT set OK)
- net.createServer().listen({ fd }) → "LISTENING on adopted transparent fd — Node owns it"
- as non-root: setsockopt(IP_TRANSPARENT) → EPERM (expected; needs CAP_NET_ADMIN)
```

Together with the iptables/ip-rule apply+revert already validated on the same kernel (#4139), **both Epic A blockers — the TPROXY rules and the transparent socket — are now proven on a real kernel.**

## Not in this PR (gated follow-ups)

- The TPROXY listener that adopts the fd, terminates TLS, and feeds the capture buffer (reusing the MITM path).
- `repairMitm()` calling `revertTproxy()` (#4144) so a crash flushes the mangle rules.
- Capture-mode route + Traffic Inspector UI tab.
- Per-platform prebuild distribution (`prebuildify`, linux-x64/arm64 only — IP_TRANSPARENT is Linux-only).
- A live end-to-end intercept in a dedicated test environment (needs a routing scenario; risky on a production proxy).

## Test Plan

- [x] `node --test tproxy-transparent-socket.test.ts` — 6/6 (non-Linux skip, absent-addon graceful, well-shaped load, bad-shape reject, unavailable-throws)
- [x] `npm run build:native:tproxy` compiles the addon cleanly (node-gyp)
- [x] `typecheck:core` — 0 errors · `eslint` — 0
- [x] VPS: real IP_TRANSPARENT socket created + adopted by Node (evidence above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)