### PR TITLE
feat(compression): replace headroom tabular encoder with vendored GCF

### DIFF
--- a/open-sse/services/compression/engines/headroom/gcf/decode_generic.ts
+++ b/open-sse/services/compression/engines/headroom/gcf/decode_generic.ts
@@ -1,0 +1,703 @@
+/**
+ * Decode GCF generic profile text into a JS value.
+ * Vendored from gcf-typescript — generic profile only (graph profile stripped).
+ * https://github.com/blackwell-systems/gcf-typescript
+ *
+ * SPDX-License-Identifier: MIT
+ */
+import {
+  parseScalar,
+  parseQuotedString,
+  splitRespectingQuotes,
+  splitFieldDecl,
+  isBareKey,
+  MISSING,
+  ATTACHMENT,
+} from "./scalar.ts";
+
+/**
+ * Decode GCF generic profile text into a JS value.
+ */
+export function decodeGeneric(input: string): any {
+  input = input.trimEnd();
+  if (!input) throw new Error("missing_header: empty input");
+
+  const lines = input.split("\n");
+  const header = lines[0].replace(/\r$/, "");
+  if (!header.startsWith("GCF "))
+    throw new Error("missing_header: first line does not begin with GCF");
+
+  const profile = parseHeaderProfile(header);
+
+  if (profile !== "generic")
+    throw new Error(
+      `unsupported_profile: ${profile} (only generic profile is supported in this vendored build)`
+    );
+
+  // Filter body.
+  const contentLines: string[] = [];
+  let summaryLine = "";
+  let deferredSectionCount = 0;
+  for (let i = 1; i < lines.length; i++) {
+    const l = lines[i].replace(/\r$/, "");
+    if (l === "") continue;
+    // Tab check.
+    for (let j = 0; j < l.length; j++) {
+      if (l[j] === "\t") throw new Error("tab_indentation: tabs in leading whitespace");
+      if (l[j] !== " ") break;
+    }
+    const trimmed = l.trimStart();
+    if (trimmed.startsWith("# ")) continue;
+    if (trimmed.startsWith("##! ")) {
+      summaryLine = trimmed;
+      continue;
+    }
+    if (trimmed.startsWith("## ") && trimmed.includes("[?]")) deferredSectionCount++;
+    contentLines.push(l);
+  }
+
+  // Validate ##! summary counts.
+  if (summaryLine && deferredSectionCount > 0) {
+    validateSummaryCounts(summaryLine, deferredSectionCount, contentLines);
+  }
+
+  if (contentLines.length === 0) return {};
+
+  const first = contentLines[0].trimStart();
+
+  // Root scalar.
+  if (first.startsWith("=")) {
+    if (contentLines.length > 1)
+      throw new Error("trailing_characters: extra lines after root scalar");
+    return parseScalar(first.slice(1), false);
+  }
+
+  // Root array.
+  if (first.startsWith("## [")) {
+    const [arr] = parseArrayFromHeader(contentLines, 0, 0, first.slice(3));
+    return arr;
+  }
+
+  // Root object.
+  const result: Record<string, any> = {};
+  parseObjectBody(contentLines, 0, 0, result);
+  return result;
+}
+
+function parseHeaderProfile(header: string): string {
+  const parts = header.split(/\s+/);
+  if (parts.length < 2) throw new Error("missing_profile");
+  const seen = new Set<string>();
+  let profile = "";
+  for (let i = 1; i < parts.length; i++) {
+    const eq = parts[i].indexOf("=");
+    if (eq < 0) throw new Error(`malformed_header_field: ${parts[i]}`);
+    const key = parts[i].slice(0, eq);
+    if (seen.has(key)) throw new Error(`duplicate_header_field: ${key}`);
+    seen.add(key);
+    if (key === "profile") profile = parts[i].slice(eq + 1);
+  }
+  if (!profile) throw new Error("missing_profile");
+  return profile;
+}
+
+function parseObjectBody(
+  lines: string[],
+  start: number,
+  depth: number,
+  out: Record<string, any>
+): number {
+  const ind = "  ".repeat(depth);
+  let i = start;
+
+  while (i < lines.length) {
+    const line = lines[i];
+    if (depth > 0 && !line.startsWith(ind)) break;
+    const content = depth > 0 ? line.slice(ind.length) : line;
+    if (content.length > 0 && content[0] === " ") {
+      throw new Error("invalid_indent: indentation increases by more than one level");
+    }
+
+    // Array section.
+    if (content.startsWith("## ")) {
+      const hdr = content.slice(3);
+      const bi = hdr.indexOf(" [");
+      if (bi >= 0) {
+        const name = parseKeyFromHeader(hdr.slice(0, bi));
+        checkDup(out, name);
+        const [arr, consumed] = parseArrayFromHeader(lines, i, depth, hdr.slice(bi));
+        out[name] = arr;
+        i += consumed;
+        continue;
+      }
+      const name = parseKeyFromHeader(hdr);
+      checkDup(out, name);
+      i++;
+      const nested: Record<string, any> = {};
+      const consumed = parseObjectBody(lines, i, depth + 1, nested);
+      out[name] = nested;
+      i += consumed;
+      continue;
+    }
+
+    // Inline array.
+    if (!content.startsWith("@") && !content.startsWith("##")) {
+      const bracketIdx = content.indexOf("[");
+      if (bracketIdx > 0) {
+        const rest = content.slice(bracketIdx);
+        const closeIdx = rest.indexOf("]");
+        if (closeIdx >= 0) {
+          const after = rest.slice(closeIdx + 1);
+          if (after.startsWith(": ") || after === ":") {
+            const name = parseKeyFromHeader(content.slice(0, bracketIdx));
+            checkDup(out, name);
+            const [arr] = parseArrayFromHeader(lines, i, depth, rest);
+            out[name] = arr;
+            i++;
+            continue;
+          }
+        }
+      }
+    }
+
+    // Key=value.
+    const eqIdx = findKeyValueSplit(content);
+    if (eqIdx > 0) {
+      const name = parseKeyFromHeader(content.slice(0, eqIdx));
+      checkDup(out, name);
+      out[name] = parseScalar(content.slice(eqIdx + 1), false);
+      i++;
+      continue;
+    }
+
+    i++;
+  }
+  return i - start;
+}
+
+function findKeyValueSplit(s: string): number {
+  if (!s.length) return -1;
+  if (s[0] === '"') {
+    for (let i = 1; i < s.length; i++) {
+      if (s[i] === "\\") {
+        i++;
+        continue;
+      }
+      if (s[i] === '"') return i + 1 < s.length && s[i + 1] === "=" ? i + 1 : -1;
+    }
+    return -1;
+  }
+  return s.indexOf("=");
+}
+
+function parseKeyFromHeader(s: string): string {
+  s = s.trim();
+  if (s.length >= 2 && s[0] === '"') return parseQuotedString(s);
+  return s;
+}
+
+function checkDup(obj: Record<string, any>, key: string): void {
+  if (key in obj) throw new Error(`duplicate_key: ${key}`);
+}
+
+function parseArrayFromHeader(
+  lines: string[],
+  headerLine: number,
+  depth: number,
+  bracketPart: string
+): [any, number] {
+  const bp = bracketPart.trimStart();
+  if (!bp.startsWith("[")) throw new Error("invalid_count");
+  const closeIdx = bp.indexOf("]");
+  if (closeIdx < 0) throw new Error("invalid_count");
+
+  const countStr = bp.slice(1, closeIdx);
+  const afterBracket = bp.slice(closeIdx + 1);
+  let count = -1;
+  if (countStr !== "?") count = parseCount(countStr);
+
+  if (count === 0 && !afterBracket.startsWith("{") && !afterBracket.startsWith(":")) {
+    return [[], 1];
+  }
+
+  // Inline.
+  if (afterBracket.startsWith(": ") || afterBracket === ":") {
+    const valsStr = afterBracket.startsWith(": ") ? afterBracket.slice(2) : "";
+    if (!valsStr) {
+      if (count >= 0 && count !== 0) throw new Error(`count_mismatch: declared ${count}, got 0`);
+      return [[], 1];
+    }
+    const vals = splitRespectingQuotes(valsStr, ",");
+    if (count >= 0 && vals.length !== count)
+      throw new Error(`count_mismatch: declared ${count}, got ${vals.length}`);
+    return [vals.map((v) => parseScalar(v.trim(), false)), 1];
+  }
+
+  // Tabular.
+  if (afterBracket.startsWith("{")) {
+    const braceEnd = findClosingBrace(afterBracket);
+    if (braceEnd < 0) throw new Error("invalid field declaration");
+    const fields = splitFieldDecl(afterBracket.slice(0, braceEnd + 1));
+    const [rows, consumed] = parseTabularBody(lines, headerLine + 1, depth, fields, count);
+    if (count >= 0 && rows.length !== count)
+      throw new Error(`count_mismatch: declared ${count}, got ${rows.length}`);
+    return [rows, consumed + 1];
+  }
+
+  // Expanded.
+  const [items, consumed] = parseExpandedBody(lines, headerLine + 1, depth);
+  if (count >= 0 && items.length !== count)
+    throw new Error(`count_mismatch: declared ${count}, got ${items.length}`);
+  return [items, consumed + 1];
+}
+
+function findClosingBrace(s: string): number {
+  let inQuote = false,
+    escaped = false;
+  for (let i = 0; i < s.length; i++) {
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (s[i] === "\\" && inQuote) {
+      escaped = true;
+      continue;
+    }
+    if (s[i] === '"') {
+      inQuote = !inQuote;
+      continue;
+    }
+    if (s[i] === "}" && !inQuote) return i;
+  }
+  return -1;
+}
+
+function parseTabularBody(
+  lines: string[],
+  start: number,
+  depth: number,
+  fields: string[],
+  expectedCount: number
+): [any[], number] {
+  const ind = "  ".repeat(depth);
+  const rows: any[] = [];
+  let i = start;
+
+  const inlineSchemas = new Map<string, string[]>();
+  const sharedArraySchemas = new Map<string, string[]>();
+
+  while (i < lines.length) {
+    const line = lines[i];
+    const content = depth > 0 ? (line.startsWith(ind) ? line.slice(ind.length) : null) : line;
+    if (content === null) break;
+    if (content.startsWith("## ") || content.startsWith("##!")) break;
+
+    if (content.length > 0 && content[0] === " ") {
+      const trimmed = content.trimStart();
+      if (trimmed.startsWith(".")) break;
+      break;
+    }
+
+    let rowData = content;
+    let rowHasID = false;
+    if (rowData.startsWith("@")) {
+      const sp = rowData.indexOf(" ");
+      if (sp > 0) {
+        const idStr = rowData.slice(1, sp);
+        if (/^\d+$/.test(idStr)) {
+          rowData = rowData.slice(sp + 1);
+          rowHasID = true;
+        }
+      }
+    }
+
+    const vals = splitRespectingQuotes(rowData, "|");
+    if (vals.length !== fields.length)
+      throw new Error(`row_width_mismatch: expected ${fields.length}, got ${vals.length}`);
+
+    const cellValues = new Map<string, any>();
+    const traditionalAttFields: string[] = [];
+    const inlineAttFields: string[] = [];
+    const inlineAttOrder: string[] = [];
+    const missingFields = new Set<string>();
+
+    for (let j = 0; j < fields.length; j++) {
+      const cellVal = vals[j];
+
+      if (cellVal.startsWith("^{") && cellVal.endsWith("}")) {
+        const schemaStr = cellVal.slice(1);
+        const ifs = splitFieldDecl(schemaStr);
+        inlineSchemas.set(fields[j], ifs);
+        inlineAttFields.push(fields[j]);
+        inlineAttOrder.push(fields[j]);
+        continue;
+      }
+
+      const parsed = parseScalar(cellVal, true);
+      if (parsed === MISSING) {
+        missingFields.add(fields[j]);
+        continue;
+      }
+      if (parsed === ATTACHMENT) {
+        if (inlineSchemas.has(fields[j])) {
+          inlineAttFields.push(fields[j]);
+          inlineAttOrder.push(fields[j]);
+        } else {
+          traditionalAttFields.push(fields[j]);
+        }
+        continue;
+      }
+      if (parsed && typeof parsed === "object" && parsed.__inlineSchema) {
+        const ifs = splitFieldDecl(parsed.__inlineSchema);
+        inlineSchemas.set(fields[j], ifs);
+        inlineAttFields.push(fields[j]);
+        inlineAttOrder.push(fields[j]);
+        continue;
+      }
+      cellValues.set(fields[j], parsed);
+    }
+    i++;
+
+    const allAttFields = [...traditionalAttFields, ...inlineAttFields];
+    const attachmentValues = new Map<string, any>();
+
+    if (rowHasID && allAttFields.length > 0) {
+      let inlineIdx = 0;
+
+      while (i < lines.length && attachmentValues.size < allAttFields.length) {
+        const aLine = lines[i];
+        let aContent: string | null = null;
+        if (depth === 0 || aLine.startsWith(ind)) {
+          aContent = depth > 0 ? aLine.slice(ind.length) : aLine;
+        } else {
+          break;
+        }
+        if (aContent === null) break;
+
+        let attContent = aContent;
+        if (!attContent.startsWith(".") && attContent.startsWith("  .")) {
+          attContent = attContent.slice(2);
+        }
+        if (attContent.startsWith(".")) {
+          const rest = attContent.slice(1);
+          const [attName, afterName] = parseAttachmentName(rest);
+
+          const ifs = inlineSchemas.get(attName);
+          if (
+            ifs &&
+            !afterName.trimStart().startsWith("{}") &&
+            !afterName.trimStart().startsWith("[")
+          ) {
+            const data = afterName.trimStart();
+            const inlineVals = splitRespectingQuotes(data, "|");
+            if (inlineVals.length !== ifs.length)
+              throw new Error(
+                `inline_width_mismatch: ${attName} expected ${ifs.length}, got ${inlineVals.length}`
+              );
+            const obj: Record<string, any> = {};
+            for (let k = 0; k < ifs.length; k++) {
+              const p = parseScalar(inlineVals[k], true);
+              if (p !== MISSING) obj[ifs[k]] = p;
+            }
+            if (attachmentValues.has(attName)) throw new Error(`duplicate_attachment: ${attName}`);
+            attachmentValues.set(attName, obj);
+            i++;
+            continue;
+          }
+
+          const [name, val, consumed, parsedFields] = parseAttachment(
+            lines,
+            i,
+            rest,
+            depth + 2,
+            sharedArraySchemas
+          );
+          if (attachmentValues.has(name)) throw new Error(`duplicate_attachment: ${name}`);
+          if (rows.length === 0 && parsedFields) {
+            sharedArraySchemas.set(name, parsedFields);
+          }
+          attachmentValues.set(name, val);
+          i += consumed;
+          continue;
+        }
+
+        let foundInline = false;
+        let nextInlineField = "";
+        while (inlineIdx < inlineAttOrder.length) {
+          const candidate = inlineAttOrder[inlineIdx];
+          if (!attachmentValues.has(candidate)) {
+            nextInlineField = candidate;
+            foundInline = true;
+            break;
+          }
+          inlineIdx++;
+        }
+        if (!foundInline) break;
+
+        const ifs = inlineSchemas.get(nextInlineField)!;
+        const inlineVals = splitRespectingQuotes(aContent, "|");
+        if (inlineVals.length !== ifs.length)
+          throw new Error(
+            `inline_width_mismatch: ${nextInlineField} expected ${ifs.length}, got ${inlineVals.length}`
+          );
+        const obj: Record<string, any> = {};
+        for (let k = 0; k < ifs.length; k++) {
+          const p = parseScalar(inlineVals[k], true);
+          if (p !== MISSING) obj[ifs[k]] = p;
+        }
+        attachmentValues.set(nextInlineField, obj);
+        inlineIdx++;
+        i++;
+      }
+
+      for (const f of allAttFields) {
+        if (!attachmentValues.has(f)) throw new Error(`missing_attachment: ${f}`);
+      }
+
+      if (i < lines.length) {
+        let peekContent: string | null = null;
+        if (depth === 0 || lines[i].startsWith(ind)) {
+          peekContent = depth > 0 ? lines[i].slice(ind.length) : lines[i];
+        }
+        if (peekContent !== null) {
+          let peekAtt = peekContent;
+          if (!peekAtt.startsWith(".") && peekAtt.startsWith("  .")) {
+            peekAtt = peekAtt.slice(2);
+          }
+          if (peekAtt.startsWith(".")) {
+            const peekRest = peekAtt.slice(1);
+            const [peekName] = parseAttachmentName(peekRest);
+            if (attachmentValues.has(peekName)) {
+              throw new Error(`duplicate_attachment: ${peekName}`);
+            }
+          }
+        }
+      }
+    }
+
+    const row: Record<string, any> = {};
+    for (const f of fields) {
+      if (missingFields.has(f)) continue;
+      if (cellValues.has(f)) {
+        row[f] = cellValues.get(f);
+        continue;
+      }
+      if (attachmentValues.has(f)) {
+        row[f] = attachmentValues.get(f);
+        continue;
+      }
+    }
+
+    if (!rowHasID || allAttFields.length === 0) {
+      const attIndent = ind + "  ";
+      if (i < lines.length && lines[i].startsWith(attIndent)) {
+        const peek = lines[i].slice(attIndent.length);
+        if (peek.startsWith(".")) throw new Error(`orphan_attachment: ${peek}`);
+      }
+    }
+
+    rows.push(row);
+    if (expectedCount >= 0 && rows.length >= expectedCount) break;
+  }
+  return [rows, i - start];
+}
+
+function parseAttachmentName(rest: string): [string, string] {
+  if (rest[0] === '"') {
+    for (let j = 1; j < rest.length; j++) {
+      if (rest[j] === "\\") {
+        j++;
+        continue;
+      }
+      if (rest[j] === '"') {
+        const name = parseQuotedString(rest.slice(0, j + 1));
+        return [name, rest.slice(j + 1)];
+      }
+    }
+    return ["", rest];
+  }
+  const sp = rest.indexOf(" ");
+  if (sp >= 0) return [rest.slice(0, sp), rest.slice(sp)];
+  return [rest, ""];
+}
+
+function parseAttachment(
+  lines: string[],
+  lineIdx: number,
+  rest: string,
+  depth: number,
+  sharedSchemas: Map<string, string[]>
+): [string, any, number, string[] | null] {
+  const [name, afterNameRaw] = parseAttachmentName(rest);
+  const afterName = afterNameRaw.trimStart();
+
+  if (afterName.startsWith("{}")) {
+    const nested: Record<string, any> = {};
+    const consumed = parseObjectBody(lines, lineIdx + 1, depth, nested);
+    return [name, nested, consumed + 1, null];
+  }
+
+  if (afterName.startsWith("[")) {
+    const closeBracket = afterName.indexOf("]");
+    if (closeBracket < 0) throw new Error("invalid_count: missing ]");
+    const afterClose = afterName.slice(closeBracket + 1);
+
+    if (afterClose.startsWith("{")) {
+      const endBrace = findClosingBrace(afterClose);
+      let parsedFields: string[] | null = null;
+      if (endBrace >= 0) {
+        try {
+          parsedFields = splitFieldDecl(afterClose.slice(0, endBrace + 1));
+        } catch {}
+      }
+      const [arr, consumed] = parseArrayFromHeader(lines, lineIdx, depth, afterName);
+      return [name, arr, consumed, parsedFields];
+    }
+
+    const afterCloseForInline = afterName.slice(closeBracket + 1);
+    if (afterCloseForInline.startsWith(": ") || afterCloseForInline === ":") {
+      const [arr, consumed] = parseArrayFromHeader(lines, lineIdx, depth, afterName);
+      return [name, arr, consumed, null];
+    }
+
+    if (sharedSchemas.has(name)) {
+      const sf = sharedSchemas.get(name)!;
+      const countStr = afterName.slice(1, closeBracket);
+      let count = -1;
+      if (countStr !== "?") count = parseInt(countStr, 10);
+      if (count === 0) return [name, [], 1, null];
+
+      const nextIdx = lineIdx + 1;
+      const ind = "  ".repeat(depth);
+      let useShared = true;
+      if (nextIdx < lines.length) {
+        let nextContent = lines[nextIdx];
+        if (depth > 0 && nextContent.startsWith(ind)) nextContent = nextContent.slice(ind.length);
+        if (nextContent.trimStart().startsWith("@")) useShared = false;
+      }
+      if (useShared) {
+        const [rows, consumed] = parseTabularBody(lines, lineIdx + 1, depth, sf, count);
+        if (count >= 0 && rows.length !== count)
+          throw new Error(`count_mismatch: declared ${count}, got ${rows.length}`);
+        return [name, rows, consumed + 1, null];
+      }
+    }
+
+    const [arr, consumed] = parseArrayFromHeader(lines, lineIdx, depth, afterName);
+    return [name, arr, consumed, null];
+  }
+
+  throw new Error(`invalid attachment form: ${afterName}`);
+}
+
+function parseExpandedBody(lines: string[], start: number, depth: number): [any[], number] {
+  const ind = "  ".repeat(depth);
+  const items: any[] = [];
+  let i = start;
+
+  while (i < lines.length) {
+    const line = lines[i];
+    const content = depth > 0 ? (line.startsWith(ind) ? line.slice(ind.length) : null) : line;
+    if (content === null) break;
+    if (content.startsWith("## ") || content.startsWith("##!")) break;
+    if (!content.startsWith("@")) break;
+
+    const sp = content.indexOf(" ");
+    if (sp < 0) break;
+
+    const idStr = content.slice(1, sp);
+    const id = parseInt(idStr, 10);
+    if (!isNaN(id) && id !== items.length) {
+      throw new Error(`invalid_item_id: expected @${items.length}, got @${idStr}`);
+    }
+
+    const marker = content.slice(sp + 1);
+
+    if (marker.startsWith("=")) {
+      items.push(parseScalar(marker.slice(1), false));
+      i++;
+      continue;
+    }
+    if (marker.startsWith("{}")) {
+      const nested: Record<string, any> = {};
+      i++;
+      const consumed = parseObjectBody(lines, i, depth + 1, nested);
+      items.push(nested);
+      i += consumed;
+      continue;
+    }
+    if (marker.startsWith("[")) {
+      const [arr, consumed] = parseArrayFromHeader(lines, i, depth + 1, marker);
+      items.push(arr);
+      i += consumed;
+      continue;
+    }
+    break;
+  }
+  return [items, i - start];
+}
+
+function parseCount(s: string): number {
+  if (s === "0") return 0;
+  if (!s.length || s[0] === "0") throw new Error(`invalid_count: ${s}`);
+  const n = parseInt(s, 10);
+  if (isNaN(n) || String(n) !== s) throw new Error(`invalid_count: ${s}`);
+  return n;
+}
+
+function validateSummaryCounts(
+  summaryLine: string,
+  deferredCount: number,
+  contentLines: string[]
+): void {
+  const parts = summaryLine.split(/\s+/);
+  let countsStr = "";
+  for (const p of parts) {
+    if (p.startsWith("counts=")) {
+      countsStr = p.slice(7);
+      break;
+    }
+  }
+  if (!countsStr) return;
+
+  const countVals = countsStr.split(",");
+  if (countVals.length !== deferredCount) {
+    throw new Error(
+      `count_mismatch: summary has ${countVals.length} count entries but ${deferredCount} deferred sections`
+    );
+  }
+
+  const actualCounts: number[] = [];
+  let inDeferred = false;
+  let currentCount = 0;
+  for (const l of contentLines) {
+    const trimmed = l.trimStart();
+    if (trimmed.startsWith("## ") && trimmed.includes("[?]")) {
+      if (inDeferred) actualCounts.push(currentCount);
+      inDeferred = true;
+      currentCount = 0;
+      continue;
+    }
+    if (trimmed.startsWith("## ")) {
+      if (inDeferred) {
+        actualCounts.push(currentCount);
+        inDeferred = false;
+      }
+      continue;
+    }
+    if (inDeferred && !trimmed.startsWith(" ") && !trimmed.startsWith(".")) {
+      currentCount++;
+    }
+  }
+  if (inDeferred) actualCounts.push(currentCount);
+
+  for (let i = 0; i < countVals.length; i++) {
+    const declared = parseInt(countVals[i], 10);
+    if (isNaN(declared)) throw new Error(`count_mismatch: invalid count value "${countVals[i]}"`);
+    if (i < actualCounts.length && declared !== actualCounts[i]) {
+      throw new Error(
+        `count_mismatch: section ${i} declared ${declared} in summary, actual ${actualCounts[i]}`
+      );
+    }
+  }
+}

--- a/open-sse/services/compression/engines/headroom/gcf/decode_generic.ts
+++ b/open-sse/services/compression/engines/headroom/gcf/decode_generic.ts
@@ -564,7 +564,13 @@ function parseAttachment(
       const sf = sharedSchemas.get(name)!;
       const countStr = afterName.slice(1, closeBracket);
       let count = -1;
-      if (countStr !== "?") count = parseInt(countStr, 10);
+      if (countStr !== "?") {
+        try {
+          count = parseCount(countStr);
+        } catch {
+          count = -1;
+        }
+      }
       if (count === 0) return [name, [], 1, null];
 
       const nextIdx = lineIdx + 1;

--- a/open-sse/services/compression/engines/headroom/gcf/generic.ts
+++ b/open-sse/services/compression/engines/headroom/gcf/generic.ts
@@ -1,0 +1,332 @@
+/**
+ * Generic encoder: converts any JS value into GCF generic profile.
+ * Vendored from gcf-typescript — generic profile only.
+ * https://github.com/blackwell-systems/gcf-typescript
+ *
+ * SPDX-License-Identifier: MIT
+ */
+import { formatScalar, formatKey, ATTACHMENT } from "./scalar.ts";
+
+function indent(depth: number): string {
+  return "  ".repeat(depth);
+}
+
+export function encodeGeneric(data: unknown): string {
+  let out = "GCF profile=generic\n";
+  out += encodeRootValue(data);
+  return out;
+}
+
+function encodeRootValue(v: unknown): string {
+  if (v === null || v === undefined) return "=-\n";
+  if (Array.isArray(v)) return encodeRootArray(v);
+  if (typeof v === "object") return encodeObject(v as Record<string, unknown>, 0);
+  return `=${formatScalar(v, 0)}\n`;
+}
+
+function encodeObject(obj: Record<string, unknown>, depth: number): string {
+  const prefix = indent(depth);
+  let out = "";
+  for (const key of Object.keys(obj)) {
+    const value = obj[key];
+    const fk = formatKey(key);
+    if (Array.isArray(value)) {
+      out += encodeNamedArray(fk, value, depth);
+    } else if (typeof value === "object" && value !== null) {
+      out += `${prefix}## ${fk}\n`;
+      out += encodeObject(value as Record<string, unknown>, depth + 1);
+    } else {
+      out += `${prefix}${fk}=${formatScalar(value, 0)}\n`;
+    }
+  }
+  return out;
+}
+
+function encodeRootArray(arr: unknown[]): string {
+  if (arr.length === 0) return "## [0]\n";
+  if (allPrimitives(arr)) {
+    const vals = arr.map((v) => formatScalar(v, 0x2c));
+    return `## [${arr.length}]: ${vals.join(",")}\n`;
+  }
+  const fields = tabularFields(arr);
+  if (fields) return encodeTabular("## ", arr, fields, 0);
+  return encodeExpanded("## ", arr, 0);
+}
+
+function encodeNamedArray(name: string, arr: unknown[], depth: number): string {
+  const prefix = indent(depth);
+  if (arr.length === 0) return `${prefix}## ${name} [0]\n`;
+  if (allPrimitives(arr)) {
+    const vals = arr.map((v) => formatScalar(v, 0x2c));
+    return `${prefix}${name}[${arr.length}]: ${vals.join(",")}\n`;
+  }
+  const fields = tabularFields(arr);
+  if (fields) return encodeTabular(`${prefix}## ${name} `, arr, fields, depth);
+  return encodeExpanded(`${prefix}## ${name} `, arr, depth);
+}
+
+function tabularFields(arr: unknown[]): string[] | null {
+  if (arr.length === 0) return null;
+  const fieldOrder: string[] = [];
+  const seen = new Set<string>();
+  for (const item of arr) {
+    if (typeof item !== "object" || item === null || Array.isArray(item)) return null;
+    for (const k of Object.keys(item as Record<string, unknown>)) {
+      if (!seen.has(k)) {
+        fieldOrder.push(k);
+        seen.add(k);
+      }
+    }
+  }
+  return fieldOrder.length > 0 ? fieldOrder : null;
+}
+
+/** Check if a field is eligible for inline schema: all rows have same flat object shape with 3+ keys. */
+function inlineSchemaFields(arr: unknown[], fieldName: string): string[] | null {
+  const first = arr[0] as Record<string, unknown> | undefined;
+  if (!first || !(fieldName in first)) return null;
+  const firstVal = first[fieldName];
+  if (
+    firstVal === null ||
+    firstVal === undefined ||
+    typeof firstVal !== "object" ||
+    Array.isArray(firstVal)
+  )
+    return null;
+
+  let canonicalKeys: string[] | null = null;
+  for (const item of arr) {
+    const obj = item as Record<string, unknown>;
+    if (!(fieldName in obj) || obj[fieldName] === null || obj[fieldName] === undefined) continue;
+    const v = obj[fieldName];
+    if (typeof v !== "object" || Array.isArray(v)) return null;
+    const keys = Object.keys(v as Record<string, unknown>);
+    for (const k of keys) {
+      const val = (v as Record<string, unknown>)[k];
+      if (val !== null && val !== undefined && typeof val === "object") return null;
+    }
+    if (!canonicalKeys) {
+      canonicalKeys = keys;
+    } else {
+      if (keys.length !== canonicalKeys.length) return null;
+      for (let i = 0; i < keys.length; i++) {
+        if (keys[i] !== canonicalKeys[i]) return null;
+      }
+    }
+  }
+  if (!canonicalKeys || canonicalKeys.length < 3) return null;
+  return canonicalKeys;
+}
+
+/** Check if array attachment has same tabular schema across all rows. */
+function sharedArraySchema(arr: unknown[], fieldName: string): string[] | null {
+  const first = arr[0] as Record<string, unknown> | undefined;
+  if (!first || !(fieldName in first)) return null;
+  const firstVal = first[fieldName];
+  if (!Array.isArray(firstVal)) return null;
+
+  let canonicalFields: string[] | null = null;
+  for (const item of arr) {
+    const obj = item as Record<string, unknown>;
+    if (!(fieldName in obj) || obj[fieldName] === null || obj[fieldName] === undefined) continue;
+    const v = obj[fieldName];
+    if (!Array.isArray(v)) return null;
+    const fields = tabularFields(v);
+    if (!fields) return null;
+    for (const arrItem of v) {
+      if (typeof arrItem !== "object" || arrItem === null) return null;
+      for (const val of Object.values(arrItem as Record<string, unknown>)) {
+        if (val !== null && val !== undefined && typeof val === "object") return null;
+      }
+    }
+    if (!canonicalFields) {
+      canonicalFields = fields;
+    } else {
+      if (fields.length !== canonicalFields.length) return null;
+      for (let i = 0; i < fields.length; i++) {
+        if (fields[i] !== canonicalFields[i]) return null;
+      }
+    }
+  }
+  return canonicalFields;
+}
+
+function encodeTabular(
+  headerPrefix: string,
+  arr: unknown[],
+  fields: string[],
+  depth: number
+): string {
+  const prefix = indent(depth);
+
+  const inlineSchemas = new Map<string, string[]>();
+  const sharedArrSchemas = new Map<string, string[]>();
+  for (const f of fields) {
+    const ifs = inlineSchemaFields(arr, f);
+    if (ifs) inlineSchemas.set(f, ifs);
+    const sas = sharedArraySchema(arr, f);
+    if (sas) sharedArrSchemas.set(f, sas);
+  }
+
+  const fmtFields = fields.map((f) => formatKey(f));
+  let out = `${headerPrefix}[${arr.length}]{${fmtFields.join(",")}}\n`;
+
+  for (let i = 0; i < arr.length; i++) {
+    const obj = arr[i] as Record<string, unknown>;
+    const cells: string[] = [];
+    const attachments: {
+      name: string;
+      value: unknown;
+      inline: boolean;
+      inlineFields?: string[];
+    }[] = [];
+    let rowHasAttachment = false;
+
+    for (const f of fields) {
+      if (!(f in obj)) {
+        cells.push("~");
+        continue;
+      }
+      const v = obj[f];
+      if (v === null || v === undefined) {
+        cells.push("-");
+        continue;
+      }
+      if (typeof v === "object") {
+        const ifs = inlineSchemas.get(f);
+        if (ifs && !Array.isArray(v)) {
+          if (i === 0) {
+            const fmtIF = ifs.map((k) => formatKey(k));
+            cells.push(`^{${fmtIF.join(",")}}`);
+          } else {
+            cells.push("^");
+          }
+          attachments.push({ name: f, value: v, inline: true, inlineFields: ifs });
+        } else {
+          cells.push("^");
+          attachments.push({ name: f, value: v, inline: false });
+        }
+        rowHasAttachment = true;
+      } else {
+        cells.push(formatScalar(v, 0x7c));
+      }
+    }
+
+    const row = cells.join("|");
+    if (rowHasAttachment) {
+      out += `${prefix}@${i} ${row}\n`;
+    } else {
+      out += `${prefix}${row}\n`;
+    }
+
+    for (const att of attachments) {
+      const fk = formatKey(att.name);
+      if (att.inline && att.inlineFields) {
+        const vals = att.inlineFields.map((inf) => {
+          const val = (att.value as Record<string, unknown>)[inf];
+          if (val === undefined) return "~";
+          return formatScalar(val, 0x7c);
+        });
+        out += `${prefix}${vals.join("|")}\n`;
+      } else if (Array.isArray(att.value)) {
+        const sas = sharedArrSchemas.get(att.name);
+        if (sas && i > 0) {
+          out += encodeAttachmentArrayShared(prefix, fk, att.value as unknown[], depth + 2, sas);
+        } else {
+          out += encodeAttachmentArray(prefix, fk, att.value as unknown[], depth + 2);
+        }
+      } else {
+        out += `${prefix}.${fk} {}\n`;
+        out += encodeObject(att.value as Record<string, unknown>, depth + 2);
+      }
+    }
+  }
+  return out;
+}
+
+function encodeAttachmentArray(
+  attPrefix: string,
+  fk: string,
+  arr: unknown[],
+  depth: number
+): string {
+  if (arr.length === 0) return `${attPrefix}.${fk} [0]\n`;
+  if (allPrimitives(arr)) {
+    const vals = arr.map((v) => formatScalar(v, 0x2c));
+    return `${attPrefix}.${fk} [${arr.length}]: ${vals.join(",")}\n`;
+  }
+  const fields = tabularFields(arr);
+  if (fields) return encodeTabular(`${attPrefix}.${fk} `, arr, fields, depth);
+  return encodeExpanded(`${attPrefix}.${fk} `, arr, depth);
+}
+
+function encodeAttachmentArrayShared(
+  attPrefix: string,
+  fk: string,
+  arr: unknown[],
+  depth: number,
+  sharedFields: string[]
+): string {
+  if (arr.length === 0) return `${attPrefix}.${fk} [0]\n`;
+  if (allPrimitives(arr)) {
+    const vals = arr.map((v) => formatScalar(v, 0x2c));
+    return `${attPrefix}.${fk} [${arr.length}]: ${vals.join(",")}\n`;
+  }
+  const fields = tabularFields(arr);
+  if (
+    fields &&
+    fields.length === sharedFields.length &&
+    fields.every((f, i) => f === sharedFields[i])
+  ) {
+    const prefix = indent(depth);
+    let out = `${attPrefix}.${fk} [${arr.length}]\n`;
+    for (const item of arr) {
+      const obj = item as Record<string, unknown>;
+      const cells = sharedFields.map((f) => {
+        if (!(f in obj)) return "~";
+        if (obj[f] === null || obj[f] === undefined) return "-";
+        return formatScalar(obj[f], 0x7c);
+      });
+      out += `${prefix}${cells.join("|")}\n`;
+    }
+    return out;
+  }
+  return encodeAttachmentArray(attPrefix, fk, arr, depth);
+}
+
+function encodeExpanded(headerPrefix: string, arr: unknown[], depth: number): string {
+  const prefix = indent(depth);
+  let out = `${headerPrefix}[${arr.length}]\n`;
+  for (let i = 0; i < arr.length; i++) {
+    const item = arr[i];
+    if (Array.isArray(item)) {
+      out += encodeExpandedArrayItem(prefix, i, item, depth);
+    } else if (typeof item === "object" && item !== null) {
+      out += `${prefix}@${i} {}\n`;
+      out += encodeObject(item as Record<string, unknown>, depth + 1);
+    } else {
+      out += `${prefix}@${i} =${formatScalar(item, 0)}\n`;
+    }
+  }
+  return out;
+}
+
+function encodeExpandedArrayItem(
+  prefix: string,
+  idx: number,
+  arr: unknown[],
+  depth: number
+): string {
+  if (arr.length === 0) return `${prefix}@${idx} [0]\n`;
+  if (allPrimitives(arr)) {
+    const vals = arr.map((v) => formatScalar(v, 0x2c));
+    return `${prefix}@${idx} [${arr.length}]: ${vals.join(",")}\n`;
+  }
+  const fields = tabularFields(arr);
+  if (fields) return encodeTabular(`${prefix}@${idx} `, arr, fields, depth + 1);
+  return encodeExpanded(`${prefix}@${idx} `, arr, depth + 1);
+}
+
+function allPrimitives(arr: unknown[]): boolean {
+  return arr.every((v) => typeof v !== "object" || v === null);
+}

--- a/open-sse/services/compression/engines/headroom/gcf/index.ts
+++ b/open-sse/services/compression/engines/headroom/gcf/index.ts
@@ -1,0 +1,9 @@
+/**
+ * GCF (Graph Compact Format) — generic profile encoder/decoder.
+ * Vendored from gcf-typescript for zero-dependency integration.
+ * https://github.com/blackwell-systems/gcf-typescript
+ *
+ * SPDX-License-Identifier: MIT
+ */
+export { encodeGeneric } from "./generic.ts";
+export { decodeGeneric } from "./decode_generic.ts";

--- a/open-sse/services/compression/engines/headroom/gcf/scalar.ts
+++ b/open-sse/services/compression/engines/headroom/gcf/scalar.ts
@@ -1,0 +1,331 @@
+/**
+ * Common scalar grammar for GCF (Graph Compact Format).
+ * Vendored from gcf-typescript — generic profile only.
+ * https://github.com/blackwell-systems/gcf-typescript
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+const JSON_NUMBER_RE = /^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?$/;
+const NUMERIC_LIKE_RE = /^[+-]\.?\d|^\.\d|^0\d/;
+
+/** Check if a string value must be quoted per Section 2.4. */
+export function needsQuote(s: string): boolean {
+  if (s === "") return true;
+  if (s === "-" || s === "~" || s === "^" || s === "true" || s === "false") return true;
+  if (JSON_NUMBER_RE.test(s)) return true;
+  if (NUMERIC_LIKE_RE.test(s)) return true;
+  if (s[0] === " " || s[s.length - 1] === " ") return true;
+  if (s[0] === "#" || s[0] === "@" || s[0] === ".") return true;
+  for (let i = 0; i < s.length; i++) {
+    const c = s.charCodeAt(i);
+    if (
+      c === 0x22 ||
+      c === 0x5c ||
+      c < 0x20 ||
+      c === 0x0a ||
+      c === 0x0d ||
+      c === 0x7c ||
+      c === 0x2c
+    )
+      return true; // " \ control \n \r | ,
+    // C1 control characters
+    if (c >= 0x80 && c <= 0x9f) return true;
+    // Unicode whitespace beyond ASCII
+    if (
+      c > 0x7f &&
+      (c === 0xa0 ||
+        c === 0x2028 ||
+        c === 0x2029 ||
+        c === 0xfeff ||
+        c === 0x1680 ||
+        (c >= 0x2000 && c <= 0x200a) ||
+        c === 0x202f ||
+        c === 0x205f ||
+        c === 0x3000)
+    )
+      return true;
+  }
+  return false;
+}
+
+/** Produce a JSON-compatible quoted string. */
+export function quoteString(s: string): string {
+  let out = '"';
+  for (let i = 0; i < s.length; i++) {
+    const c = s.charCodeAt(i);
+    switch (c) {
+      case 0x22:
+        out += '\\"';
+        break;
+      case 0x5c:
+        out += "\\\\";
+        break;
+      case 0x08:
+        out += "\\b";
+        break;
+      case 0x0c:
+        out += "\\f";
+        break;
+      case 0x0a:
+        out += "\\n";
+        break;
+      case 0x0d:
+        out += "\\r";
+        break;
+      case 0x09:
+        out += "\\t";
+        break;
+      default:
+        if (c < 0x20) {
+          out += "\\u" + c.toString(16).padStart(4, "0");
+        } else {
+          out += s[i];
+        }
+    }
+  }
+  return out + '"';
+}
+
+/** Format a JS value as a GCF scalar. delimiter is '|', ',', or 0. */
+export function formatScalar(v: unknown, delimiter: number = 0): string {
+  if (v === null || v === undefined) return "-";
+  if (typeof v === "boolean") return v ? "true" : "false";
+  if (typeof v === "number") return formatNumber(v);
+  const s = String(v);
+  if (needsQuote(s) || (delimiter && s.includes(String.fromCharCode(delimiter)))) {
+    return quoteString(s);
+  }
+  return s;
+}
+
+/** Format a number per Section 2.3 canonical rules. */
+export function formatNumber(f: number): string {
+  if (Object.is(f, -0)) return "-0";
+  if (f === 0) return "0";
+  const abs = Math.abs(f);
+  if (abs >= 1e-6 && abs < 1e21) {
+    return String(f);
+  }
+  // Exponent notation.
+  let s = f.toExponential();
+  // Normalize: lowercase e, no leading zeros in exponent.
+  s = s.replace(/[eE]\+?0*(\d)/, "e+$1").replace(/[eE]-0*(\d)/, "e-$1");
+  return s;
+}
+
+const BARE_KEY_RE = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+/** Check if a key is a valid bare key. */
+export function isBareKey(s: string): boolean {
+  return BARE_KEY_RE.test(s);
+}
+
+/** Format a key, quoting if necessary. */
+export function formatKey(s: string): string {
+  return isBareKey(s) ? s : quoteString(s);
+}
+
+// --- Decoder scalar parsing ---
+
+/** Parse a GCF scalar token per Section 2.1 precedence. */
+export function parseScalar(s: string, tabularContext: boolean): any {
+  if (s === "") return "";
+
+  // 1. Quoted string.
+  if (s[0] === '"') return parseQuotedString(s);
+
+  // 2. Null.
+  if (s === "-") return null;
+
+  // 3. Missing (tabular only).
+  if (s === "~") {
+    if (!tabularContext) throw new Error("invalid_missing: ~ outside tabular row cell");
+    return MISSING;
+  }
+
+  // 4. Attachment (tabular only). Plain ^ or ^{fields} (inline schema).
+  if (s === "^" || (s.startsWith("^{") && s.endsWith("}"))) {
+    if (!tabularContext) throw new Error("invalid_attachment_marker: ^ outside tabular row cell");
+    if (s === "^") return ATTACHMENT;
+    // Inline schema: return the schema string for the caller to parse.
+    return { __inlineSchema: s.slice(1) }; // e.g. "{name,email,tier}"
+  }
+
+  // 5. Boolean.
+  if (s === "true") return true;
+  if (s === "false") return false;
+
+  // 6. Number.
+  if (JSON_NUMBER_RE.test(s)) {
+    const f = Number(s);
+    if (!isNaN(f)) return f;
+  }
+
+  // 7. Bare string.
+  return s;
+}
+
+export const MISSING = Symbol("missing");
+export const ATTACHMENT = Symbol("attachment");
+
+/** Parse a JSON-compatible quoted string. */
+export function parseQuotedString(s: string): string {
+  if (s.length < 2 || s[0] !== '"') throw new Error("unterminated_quote");
+  let out = "";
+  let i = 1;
+  while (i < s.length) {
+    if (s[i] === '"') {
+      if (i + 1 !== s.length) throw new Error("trailing_characters: after closing quote");
+      return out;
+    }
+    if (s[i] === "\\") {
+      if (i + 1 >= s.length) throw new Error("unterminated_quote");
+      i++;
+      switch (s[i]) {
+        case '"':
+          out += '"';
+          break;
+        case "\\":
+          out += "\\";
+          break;
+        case "/":
+          out += "/";
+          break;
+        case "b":
+          out += "\b";
+          break;
+        case "f":
+          out += "\f";
+          break;
+        case "n":
+          out += "\n";
+          break;
+        case "r":
+          out += "\r";
+          break;
+        case "t":
+          out += "\t";
+          break;
+        case "u": {
+          if (i + 4 >= s.length) throw new Error("invalid_escape: incomplete unicode");
+          const hex = s.slice(i + 1, i + 5);
+          const code = parseInt(hex, 16);
+          if (isNaN(code)) throw new Error(`invalid_escape: invalid unicode \\u${hex}`);
+          // Surrogate pair handling.
+          if (code >= 0xd800 && code <= 0xdbff) {
+            if (i + 10 >= s.length || s[i + 5] !== "\\" || s[i + 6] !== "u") {
+              throw new Error("invalid_surrogate: isolated high surrogate");
+            }
+            const hex2 = s.slice(i + 7, i + 11);
+            const low = parseInt(hex2, 16);
+            if (isNaN(low) || low < 0xdc00 || low > 0xdfff) {
+              throw new Error("invalid_surrogate: invalid low surrogate");
+            }
+            out += String.fromCodePoint(0x10000 + (code - 0xd800) * 0x400 + (low - 0xdc00));
+            i += 11;
+            continue;
+          }
+          if (code >= 0xdc00 && code <= 0xdfff) {
+            throw new Error("invalid_surrogate: isolated low surrogate");
+          }
+          out += String.fromCharCode(code);
+          i += 5;
+          continue;
+        }
+        default:
+          throw new Error(`invalid_escape: unknown \\${s[i]}`);
+      }
+      i++;
+      continue;
+    }
+    if (s.charCodeAt(i) < 0x20) {
+      throw new Error(
+        `invalid_escape: unescaped control U+${s.charCodeAt(i).toString(16).padStart(4, "0")}`
+      );
+    }
+    out += s[i];
+    i++;
+  }
+  throw new Error("unterminated_quote");
+}
+
+/** Split a string on a delimiter, respecting quoted strings. */
+export function splitRespectingQuotes(s: string, delim: string): string[] {
+  const parts: string[] = [];
+  let current = "";
+  let inQuote = false;
+  let escaped = false;
+  for (let i = 0; i < s.length; i++) {
+    if (escaped) {
+      current += s[i];
+      escaped = false;
+      continue;
+    }
+    if (s[i] === "\\" && inQuote) {
+      current += s[i];
+      escaped = true;
+      continue;
+    }
+    if (s[i] === '"') {
+      inQuote = !inQuote;
+      current += s[i];
+      continue;
+    }
+    if (s[i] === delim && !inQuote) {
+      parts.push(current);
+      current = "";
+      continue;
+    }
+    current += s[i];
+  }
+  parts.push(current);
+  return parts;
+}
+
+/** Split a field declaration like {id,"display name","a,b"}. */
+export function splitFieldDecl(s: string): string[] {
+  if (s.length < 2 || s[0] !== "{") throw new Error("invalid field declaration");
+  const closeIdx = findClosingBrace(s);
+  if (closeIdx < 0) throw new Error("invalid field declaration");
+  const inner = s.slice(1, closeIdx);
+  if (!inner) return [];
+  const raw = splitRespectingQuotes(inner, ",");
+  const fields: string[] = [];
+  const seen = new Set<string>();
+  for (const f of raw) {
+    const trimmed = f.trim();
+    let name: string;
+    if (trimmed.length >= 2 && trimmed[0] === '"' && trimmed[trimmed.length - 1] === '"') {
+      name = parseQuotedString(trimmed);
+    } else {
+      if (!isBareKey(trimmed)) throw new Error(`invalid field name: ${trimmed}`);
+      name = trimmed;
+    }
+    if (seen.has(name)) throw new Error(`duplicate_field_name: ${name}`);
+    seen.add(name);
+    fields.push(name);
+  }
+  return fields;
+}
+
+function findClosingBrace(s: string): number {
+  let inQuote = false;
+  let escaped = false;
+  for (let i = 0; i < s.length; i++) {
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (s[i] === "\\" && inQuote) {
+      escaped = true;
+      continue;
+    }
+    if (s[i] === '"') {
+      inQuote = !inQuote;
+      continue;
+    }
+    if (s[i] === "}" && !inQuote) return i;
+  }
+  return -1;
+}

--- a/open-sse/services/compression/engines/headroom/index.ts
+++ b/open-sse/services/compression/engines/headroom/index.ts
@@ -37,6 +37,8 @@ import { crushMessages, DEFAULT_MIN_ROWS } from "./smartcrusher.ts";
 import {
   TABULAR_FENCE_OPEN,
   TABULAR_FENCE_CLOSE,
+  GCF_FENCE_OPEN,
+  GCF_FENCE_CLOSE,
   decodeTabular,
   TABULAR_MARKER_RE,
 } from "./tabular.ts";
@@ -178,10 +180,10 @@ type MessageLike = {
 };
 
 /**
- * Reverse the headroom tabular compaction: find every ```omni-tabular block
- * in message contents and decode it back to the original JSON string.
+ * Reverse the headroom compaction: find every ```gcf-generic or ```omni-tabular
+ * block in message contents and decode it back to the original JSON string.
  *
- * Returns a new body with all tabular blocks expanded.
+ * Returns a new body with all compacted blocks expanded.
  */
 export function reconstructHeadroom(body: Record<string, unknown>): Record<string, unknown> {
   const messages = body["messages"];
@@ -224,36 +226,37 @@ export function reconstructHeadroom(body: Record<string, unknown>): Record<strin
 }
 
 /**
- * Restore all omni-tabular blocks in a text string back to their original JSON.
+ * Restore all GCF (```gcf-generic) and legacy (```omni-tabular) blocks
+ * in a text string back to their original JSON.
  */
 function restoreText(text: string): string {
   // Fast path: no fence marker present
-  if (!text.includes(TABULAR_FENCE_OPEN)) return text;
-
-  const fence = TABULAR_FENCE_OPEN;
-  const closeTag = TABULAR_FENCE_CLOSE;
+  if (!text.includes(TABULAR_FENCE_OPEN) && !text.includes(GCF_FENCE_OPEN)) return text;
 
   let result = text;
-  let offset = 0;
 
-  // Find each occurrence of the tabular fence
-  let searchFrom = 0;
-  while (true) {
-    const fenceStart = result.indexOf(fence, searchFrom);
-    if (fenceStart === -1) break;
+  // Process both fence types: GCF first (new format), then legacy omni-tabular
+  for (const fence of [GCF_FENCE_OPEN, TABULAR_FENCE_OPEN]) {
+    const closeTag = fence === GCF_FENCE_OPEN ? GCF_FENCE_CLOSE : TABULAR_FENCE_CLOSE;
 
-    const contentStart = fenceStart + fence.length + 1; // skip "\n" after fence open
-    const fenceEnd = result.indexOf("\n" + closeTag, contentStart);
-    if (fenceEnd === -1) break;
+    let searchFrom = 0;
+    while (true) {
+      const fenceStart = result.indexOf(fence, searchFrom);
+      if (fenceStart === -1) break;
 
-    const blockContent = result.slice(contentStart, fenceEnd);
-    const decoded = decodeTabular(fence + "\n" + blockContent + "\n" + closeTag);
-    const jsonStr = JSON.stringify(decoded);
+      const contentStart = fenceStart + fence.length + 1; // skip "\n" after fence open
+      const fenceEnd = result.indexOf("\n" + closeTag, contentStart);
+      if (fenceEnd === -1) break;
 
-    const fullFence = result.slice(fenceStart, fenceEnd + closeTag.length + 1); // +1 for the "\n"
-    result = result.slice(0, fenceStart) + jsonStr + result.slice(fenceStart + fullFence.length);
+      const blockContent = result.slice(contentStart, fenceEnd);
+      const decoded = decodeTabular(fence + "\n" + blockContent + "\n" + closeTag);
+      const jsonStr = JSON.stringify(decoded);
 
-    searchFrom = fenceStart + jsonStr.length;
+      const fullFence = result.slice(fenceStart, fenceEnd + closeTag.length + 1); // +1 for the "\n"
+      result = result.slice(0, fenceStart) + jsonStr + result.slice(fenceStart + fullFence.length);
+
+      searchFrom = fenceStart + jsonStr.length;
+    }
   }
 
   return result;

--- a/open-sse/services/compression/engines/headroom/smartcrusher.ts
+++ b/open-sse/services/compression/engines/headroom/smartcrusher.ts
@@ -1,19 +1,26 @@
 /**
- * smartcrusher.ts — SmartCrusher: JSON array → tabular compaction (H3 lossless stage).
+ * smartcrusher.ts — SmartCrusher: JSON array → GCF compaction (H3 lossless stage).
  *
  * Scans message contents (strings and ```json fenced blocks inside strings) for
- * homogeneous arrays of objects. When found and when the tabular form is strictly
- * smaller, replaces the JSON array text with a compact omni-tabular block.
+ * arrays of objects. When found and when the GCF form is strictly smaller,
+ * replaces the JSON array text with a compact GCF block.
+ *
+ * GCF (Graph Compact Format) handles homogeneous AND heterogeneous arrays,
+ * mixed-type columns, nested objects, and nullable fields natively.
  *
  * Conservative guards (inherited from headroom upstream):
  *   - Never touch role: "system" messages.
- *   - Only compact arrays that are homogeneous (all objects share the same key set).
  *   - Minimum row count gate (default 8).
- *   - Skip if tabular form is NOT smaller than the original JSON (no regression).
- *   - Skip if the array elements are not "scalar-ish" at top level (i.e. objects, not nested arrays of arrays).
+ *   - Skip if GCF form is NOT smaller than the original JSON (no regression).
+ *   - Elements must be objects (not bare primitives or arrays at the top level).
+ *
+ * Backward compatibility:
+ *   - detectHomogeneous is still exported (used by existing tests and may be
+ *     useful for analytics), but is no longer a gate for encoding. GCF encodes
+ *     both homogeneous and heterogeneous arrays.
  */
 
-import { encodeTabularBlock, kindOf, wrapTabular } from "./tabular.ts";
+import { encodeTabularBlock, wrapTabular, kindOf } from "./tabular.ts";
 
 /** Default minimum number of rows to trigger compaction. */
 export const DEFAULT_MIN_ROWS = 8;
@@ -23,22 +30,22 @@ const JSON_FENCE_RE = /```json\n([\s\S]*?)\n```/g;
 
 /**
  * Checks whether an array of values is homogeneous (all entries are plain objects
- * sharing the same set of keys, with scalar-ish leaf values).
+ * sharing the same set of keys, with uniform column types).
  *
  * Returns the shared keys array if homogeneous, null otherwise.
+ *
+ * Note: this is no longer a gate for GCF encoding (GCF handles heterogeneous
+ * arrays natively), but is kept for backward compatibility and analytics.
  */
 export function detectHomogeneous(arr: unknown[]): string[] | null {
   if (arr.length === 0) return null;
 
-  // Every element must be a plain (non-null, non-array) object
   for (const item of arr) {
     if (item === null || typeof item !== "object" || Array.isArray(item)) return null;
   }
 
-  // Build the union of keys from the first element
   const firstKeys = Object.keys(arr[0] as Record<string, unknown>).sort();
 
-  // All other elements must have the EXACT same key set (same keys, same count)
   for (const item of arr.slice(1)) {
     const itemKeys = Object.keys(item as Record<string, unknown>).sort();
     if (itemKeys.length !== firstKeys.length) return null;
@@ -47,11 +54,6 @@ export function detectHomogeneous(arr: unknown[]): string[] | null {
     }
   }
 
-  // Per-column TYPE uniformity. The decoder applies a single kind per column
-  // (derived from row 0), so every row's value in a column must share that kind —
-  // otherwise the round-trip would be lossy (e.g. a nullable column would decode
-  // every cell as null, or a mixed number/string column would NaN-out). A column
-  // with mixed kinds makes the array effectively heterogeneous → leave it untouched.
   const first = arr[0] as Record<string, unknown>;
   for (const key of firstKeys) {
     const expected = kindOf(first[key]);
@@ -64,8 +66,26 @@ export function detectHomogeneous(arr: unknown[]): string[] | null {
 }
 
 /**
- * Try to crush a JSON string (already verified to be a homogeneous array) into
- * a tabular form. Returns the compact string if it shrinks the input; null otherwise.
+ * Check if all elements in an array are objects (not null, not arrays).
+ * This is the minimum gate for GCF encoding.
+ */
+function allObjects(arr: unknown[]): boolean {
+  for (const item of arr) {
+    if (item === null || typeof item !== "object" || Array.isArray(item)) return false;
+  }
+  return true;
+}
+
+/**
+ * Try to crush a JSON string (array of objects) into GCF form.
+ * Returns the compact string if it shrinks the input; null otherwise.
+ *
+ * GCF handles heterogeneous arrays, mixed-type columns, nested objects,
+ * and nullable fields natively, so the only gates are:
+ *   - Must be a valid JSON array
+ *   - Must have >= minRows elements
+ *   - All elements must be objects
+ *   - GCF form must be strictly smaller than JSON
  */
 export function tryCompactJson(jsonStr: string, minRows: number = DEFAULT_MIN_ROWS): string | null {
   let parsed: unknown;
@@ -77,8 +97,8 @@ export function tryCompactJson(jsonStr: string, minRows: number = DEFAULT_MIN_RO
 
   if (!Array.isArray(parsed) || parsed.length < minRows) return null;
 
-  const keys = detectHomogeneous(parsed);
-  if (!keys) return null;
+  // All elements must be objects (GCF encodes objects in tabular form).
+  if (!allObjects(parsed)) return null;
 
   const arr = parsed as Record<string, unknown>[];
   const blockContent = encodeTabularBlock(arr);

--- a/open-sse/services/compression/engines/headroom/tabular.ts
+++ b/open-sse/services/compression/engines/headroom/tabular.ts
@@ -230,13 +230,14 @@ export function decodeTabular(text: string): Record<string, unknown>[] {
   if (text.startsWith(GCF_FENCE_OPEN + "\n") || text.startsWith("GCF ")) {
     // GCF format: strip fence if present, decode via GCF decoder.
     let inner = text;
-    if (inner.startsWith(GCF_FENCE_OPEN + "\n")) {
+    const hadFence = inner.startsWith(GCF_FENCE_OPEN + "\n");
+    if (hadFence) {
       inner = inner.slice(GCF_FENCE_OPEN.length + 1);
-    }
-    if (inner.endsWith("\n" + GCF_FENCE_CLOSE)) {
-      inner = inner.slice(0, inner.length - GCF_FENCE_CLOSE.length - 1);
-    } else if (inner.endsWith(GCF_FENCE_CLOSE)) {
-      inner = inner.slice(0, inner.length - GCF_FENCE_CLOSE.length);
+      if (inner.endsWith("\n" + GCF_FENCE_CLOSE)) {
+        inner = inner.slice(0, inner.length - GCF_FENCE_CLOSE.length - 1);
+      } else if (inner.endsWith(GCF_FENCE_CLOSE)) {
+        inner = inner.slice(0, inner.length - GCF_FENCE_CLOSE.length);
+      }
     }
     const result = decodeGeneric(inner);
     // decodeGeneric returns the decoded value; for arrays, return directly.

--- a/open-sse/services/compression/engines/headroom/tabular.ts
+++ b/open-sse/services/compression/engines/headroom/tabular.ts
@@ -1,59 +1,87 @@
 /**
- * tabular.ts — dependency-free columnar encoder/decoder for homogeneous JSON arrays.
+ * tabular.ts — GCF-powered encoder + backward-compatible omni-tabular decoder.
  *
- * Format design (lossless, GP5' inspired):
+ * Encoding now uses GCF (Graph Compact Format) generic profile, which handles:
+ *   - Homogeneous AND heterogeneous arrays of objects
+ *   - Mixed-type columns (nullable, number/string mix)
+ *   - Nested objects and arrays (first-class, not JSON-stringified)
+ *   - Tabular layout with inline schemas for repeated structures
  *
- *   ```omni-tabular
- *   [N rows]
- *   __kinds__,s,n,n,b          ← type hints row (hidden metadata)
- *   col1,col2,col3,col4        ← header row
- *   "\"val1\"",42,99,true      ← data rows (strings JSON-encoded to avoid multi-line issues)
- *   ...
- *   ```
+ * Decoding supports BOTH formats for backward compatibility:
+ *   - ```gcf-generic ... ``` (new GCF format)
+ *   - ```omni-tabular ... ``` (legacy format, still decoded correctly)
  *
- * Cell encoding rules (CSV-style, lossless):
- *   - Strings: JSON.stringify-ed (so newlines → \\n, quotes → \\", etc.), then
- *     encodeCell-quoted if the JSON repr contains comma, quote, newline, or leading/trailing space.
- *   - Numbers / booleans / null: written as their unambiguous string representation.
- *   - Objects or arrays (nested): JSON.stringify-ed (same as strings for encoding), then quoted.
- *
- * Decode rules:
- *   - Kind `s`: cell value is a JSON string literal → JSON.parse restores original string.
- *   - Kind `n`: Number(cell).
- *   - Kind `b`: cell === "true".
- *   - Kind `null`: null.
- *   - Kind `j`: JSON.parse restores original object/array.
- *
- * All special characters (newlines, commas, quotes, tabs) inside string/json cells are
- * safely contained inside the JSON representation, which is then CSV-quoted. The line
- * split in the decoder always operates on the outer structure, which is free of raw
- * newlines. This is the key losslessness guarantee.
- *
- * Note: TOON (@toon-format/toon, ~24.6k★) could be a future drop-in encoder here for
- * potentially better compression on heterogeneous shapes; this plain columnar encoder is
- * used instead to avoid npm dependencies (supply-chain safety).
+ * The legacy omni-tabular encoder is preserved as encodeTabularBlockLegacy
+ * for backward-compat decoding and benchmark comparison.
  */
 
+import { encodeGeneric, decodeGeneric } from "./gcf/index.ts";
+
+// ─── fence markers ───────────────────────────────────────────────────────────
+
+/** New GCF fence marker. */
+export const GCF_FENCE_OPEN = "```gcf-generic";
+export const GCF_FENCE_CLOSE = "```";
+
+/** Legacy fence markers (kept for backward-compat decoding). */
 export const TABULAR_FENCE_OPEN = "```omni-tabular";
 export const TABULAR_FENCE_CLOSE = "```";
-export const TABULAR_MARKER_RE = /```omni-tabular\n(\[[\d]+ rows\]\n[\s\S]*?)\n```/g;
+export const TABULAR_MARKER_RE = /```(?:gcf-generic|omni-tabular)\n([\s\S]*?)\n```/g;
 
-/** Cell type hints stored in the second metadata row. */
-type CellKind = "s" | "n" | "b" | "null" | "j"; // string / number / boolean / null / json-object-or-array
+// ─── legacy types (for backward-compat decoder) ─────────────────────────────
+
+type CellKind = "s" | "n" | "b" | "null" | "j";
 
 export function kindOf(val: unknown): CellKind {
   if (val === null) return "null";
   if (typeof val === "number") return "n";
   if (typeof val === "boolean") return "b";
-  if (typeof val === "object") return "j"; // object or array
+  if (typeof val === "object") return "j";
   return "s";
 }
 
+// ─── GCF encoder (replaces old encodeTabularBlock) ───────────────────────────
+
 /**
- * Encode a raw string as a CSV cell.
- * Wraps in `"` and doubles any internal `"` characters (RFC 4180).
- * Used for strings that might contain commas, quotes, or spaces.
+ * Encode an array of objects using GCF generic profile.
+ * Returns the GCF text (without fence markers).
  */
+export function encodeGcfBlock(arr: Record<string, unknown>[]): string {
+  return encodeGeneric(arr);
+}
+
+/**
+ * Wrap a GCF block in the gcf-generic fence.
+ */
+export function wrapGcf(blockContent: string): string {
+  return `${GCF_FENCE_OPEN}\n${blockContent}\n${GCF_FENCE_CLOSE}`;
+}
+
+/**
+ * Public API — encode an array to a fenced GCF string.
+ * This is the new default encoder (replaces encodeTabular for new content).
+ */
+export function encodeTabular(arr: Record<string, unknown>[]): string {
+  return wrapGcf(encodeGcfBlock(arr));
+}
+
+/**
+ * Alias kept for SmartCrusher: encode block content (without fence).
+ * Now delegates to GCF.
+ */
+export function encodeTabularBlock(arr: Record<string, unknown>[]): string {
+  return encodeGcfBlock(arr);
+}
+
+/**
+ * Wrap content in fence markers. Now uses GCF fence.
+ */
+export function wrapTabular(blockContent: string): string {
+  return wrapGcf(blockContent);
+}
+
+// ─── legacy omni-tabular encoder (preserved for tests/benchmarks) ────────────
+
 function encodeCell(raw: string): string {
   const needsQuoting =
     raw.includes(",") ||
@@ -66,12 +94,6 @@ function encodeCell(raw: string): string {
   return '"' + raw.replace(/"/g, '""') + '"';
 }
 
-/**
- * Parse one CSV row (a single line) into cells.
- * Handles RFC 4180 quoting with `""` escaping.
- * Lines are guaranteed to not contain unescaped newlines (all newlines are inside
- * JSON-escaped strings, so the CSV layer never sees a real newline within a cell).
- */
 export function parseCsvRow(line: string): string[] {
   const cells: string[] = [];
   let i = 0;
@@ -79,16 +101,15 @@ export function parseCsvRow(line: string): string[] {
 
   while (i < len) {
     if (line[i] === '"') {
-      // Quoted cell: consume up to the closing unescaped quote
       let cell = "";
-      i++; // skip opening quote
+      i++;
       while (i < len) {
         if (line[i] === '"') {
           if (i + 1 < len && line[i + 1] === '"') {
             cell += '"';
             i += 2;
           } else {
-            i++; // skip closing quote
+            i++;
             break;
           }
         } else {
@@ -96,20 +117,16 @@ export function parseCsvRow(line: string): string[] {
         }
       }
       cells.push(cell);
-      // Skip trailing comma
       if (i < len && line[i] === ",") {
         i++;
-        // Trailing comma at end of line → empty cell
         if (i === len) cells.push("");
       }
     } else {
-      // Unquoted cell: read until comma or end
       const start = i;
       while (i < len && line[i] !== ",") i++;
       cells.push(line.slice(start, i));
       if (i < len) {
-        i++; // skip comma
-        // Trailing comma at end of line → empty cell
+        i++;
         if (i === len) cells.push("");
       }
     }
@@ -119,19 +136,11 @@ export function parseCsvRow(line: string): string[] {
 }
 
 /**
- * Encode a homogeneous array of objects to a compact columnar block (without fence).
- *
- * The block format is:
- *   [N rows]
- *   __kinds__,<kind0>,<kind1>,...
- *   <key0>,<key1>,...
- *   <row0-cell0>,<row0-cell1>,...
- *   ...
+ * Legacy encoder — preserved for backward-compat testing and benchmarks.
  */
-export function encodeTabularBlock(arr: Record<string, unknown>[]): string {
+export function encodeTabularBlockLegacy(arr: Record<string, unknown>[]): string {
   if (arr.length === 0) return "";
 
-  // Collect union of all keys (first-seen order)
   const keysSet = new Set<string>();
   for (const row of arr) {
     for (const k of Object.keys(row)) keysSet.add(k);
@@ -139,7 +148,6 @@ export function encodeTabularBlock(arr: Record<string, unknown>[]): string {
   const keys = Array.from(keysSet);
   const n = arr.length;
 
-  // Determine kinds from first row (homogeneous array → kinds are uniform)
   const kinds: CellKind[] = keys.map((k) => kindOf(arr[0][k]));
 
   const kindsRow = "__kinds__," + kinds.join(",");
@@ -153,10 +161,6 @@ export function encodeTabularBlock(arr: Record<string, unknown>[]): string {
         if (kind === "null") return "null";
         if (kind === "n") return String(val);
         if (kind === "b") return String(val);
-        // kind "s" or "j": JSON.stringify the value, then CSV-quote the result.
-        // JSON.stringify a string gives '"the string with \\n escaped"'
-        // JSON.stringify an object/array gives the full JSON representation.
-        // Both are safe to CSV-quote (no raw newlines in the serialized output).
         return encodeCell(JSON.stringify(val));
       })
       .join(",");
@@ -165,31 +169,28 @@ export function encodeTabularBlock(arr: Record<string, unknown>[]): string {
   return `[${n} rows]\n${kindsRow}\n${headerRow}\n${dataRows.join("\n")}`;
 }
 
+// ─── dual-format decoder ─────────────────────────────────────────────────────
+
 /**
- * Decode a columnar block back to the original array.
- * Input is the raw block content (without the fence markers).
+ * Decode a legacy omni-tabular block back to the original array.
  */
-export function decodeTabularBlock(block: string): Record<string, unknown>[] {
+export function decodeTabularBlockLegacy(block: string): Record<string, unknown>[] {
   const lines = block.split("\n");
   if (lines.length < 3) return [];
 
-  // Line 0: [N rows]
   const countLine = lines[0];
   const countMatch = countLine.match(/^\[(\d+) rows\]$/);
   if (!countMatch) return [];
   const n = parseInt(countMatch[1], 10);
 
-  // Line 1: kinds row
   const kindsLine = lines[1];
   if (!kindsLine.startsWith("__kinds__,")) return [];
   const kindsRaw = parseCsvRow(kindsLine.slice("__kinds__,".length));
   const kinds = kindsRaw as CellKind[];
 
-  // Line 2: header row
   const headerLine = lines[2];
   const keys = parseCsvRow(headerLine);
 
-  // Lines 3..3+n-1: data rows
   const result: Record<string, unknown>[] = [];
   for (let i = 0; i < n; i++) {
     const rowLine = lines[3 + i];
@@ -207,7 +208,6 @@ export function decodeTabularBlock(block: string): Record<string, unknown>[] {
       } else if (kind === "b") {
         obj[key] = cell === "true";
       } else {
-        // kind "s" or "j": cell is a JSON-encoded value → JSON.parse restores it.
         try {
           obj[key] = JSON.parse(cell);
         } catch {
@@ -222,24 +222,30 @@ export function decodeTabularBlock(block: string): Record<string, unknown>[] {
 }
 
 /**
- * Wrap a tabular block content in the omni-tabular fence.
- */
-export function wrapTabular(blockContent: string): string {
-  return `${TABULAR_FENCE_OPEN}\n${blockContent}\n${TABULAR_FENCE_CLOSE}`;
-}
-
-/**
- * Public API — encode an array to a fenced tabular string.
- */
-export function encodeTabular(arr: Record<string, unknown>[]): string {
-  return wrapTabular(encodeTabularBlock(arr));
-}
-
-/**
- * Public API — decode a fenced tabular string back to an array.
+ * Public API — decode a fenced block (either GCF or legacy omni-tabular).
+ * Auto-detects format from the fence marker.
  */
 export function decodeTabular(text: string): Record<string, unknown>[] {
-  // Strip fence markers if present
+  // Detect format from fence marker.
+  if (text.startsWith(GCF_FENCE_OPEN + "\n") || text.startsWith("GCF ")) {
+    // GCF format: strip fence if present, decode via GCF decoder.
+    let inner = text;
+    if (inner.startsWith(GCF_FENCE_OPEN + "\n")) {
+      inner = inner.slice(GCF_FENCE_OPEN.length + 1);
+    }
+    if (inner.endsWith("\n" + GCF_FENCE_CLOSE)) {
+      inner = inner.slice(0, inner.length - GCF_FENCE_CLOSE.length - 1);
+    } else if (inner.endsWith(GCF_FENCE_CLOSE)) {
+      inner = inner.slice(0, inner.length - GCF_FENCE_CLOSE.length);
+    }
+    const result = decodeGeneric(inner);
+    // decodeGeneric returns the decoded value; for arrays, return directly.
+    if (Array.isArray(result)) return result as Record<string, unknown>[];
+    // If it decoded to a single object, wrap it.
+    return [result as Record<string, unknown>];
+  }
+
+  // Legacy omni-tabular format.
   let inner = text;
   if (inner.startsWith(TABULAR_FENCE_OPEN + "\n")) {
     inner = inner.slice(TABULAR_FENCE_OPEN.length + 1);
@@ -249,5 +255,5 @@ export function decodeTabular(text: string): Record<string, unknown>[] {
   } else if (inner.endsWith(TABULAR_FENCE_CLOSE)) {
     inner = inner.slice(0, inner.length - TABULAR_FENCE_CLOSE.length);
   }
-  return decodeTabularBlock(inner);
+  return decodeTabularBlockLegacy(inner);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,7 +98,7 @@
         "@testing-library/react": "^16.3.2",
         "@types/bcryptjs": "^3.0.0",
         "@types/better-sqlite3": "^7.6.13",
-        "@types/bun": "*",
+        "@types/bun": "latest",
         "@types/keytar": "^4.4.2",
         "@types/node": "^25.9.1",
         "@types/react": "^19.2.15",

--- a/tests/unit/compression/gcf-benchmark.test.ts
+++ b/tests/unit/compression/gcf-benchmark.test.ts
@@ -1,0 +1,221 @@
+/**
+ * GCF (Graph Compact Format) vs legacy omni-tabular benchmark.
+ *
+ * Compares compression savings, round-trip correctness, and coverage on
+ * realistic payloads including cases the legacy encoder cannot handle.
+ */
+
+import { describe, it, before } from "node:test";
+import assert from "node:assert/strict";
+
+let encodeTabular: (arr: Record<string, unknown>[]) => string;
+let decodeTabular: (text: string) => Record<string, unknown>[];
+let encodeTabularBlockLegacy: (arr: Record<string, unknown>[]) => string;
+let detectHomogeneous: (arr: unknown[]) => string[] | null;
+let reconstructHeadroom: (body: Record<string, unknown>) => Record<string, unknown>;
+
+before(async () => {
+  const tabMod = await import("../../../open-sse/services/compression/engines/headroom/tabular.ts");
+  encodeTabular = tabMod.encodeTabular;
+  decodeTabular = tabMod.decodeTabular;
+  encodeTabularBlockLegacy = tabMod.encodeTabularBlockLegacy;
+
+  const scMod =
+    await import("../../../open-sse/services/compression/engines/headroom/smartcrusher.ts");
+  detectHomogeneous = scMod.detectHomogeneous;
+
+  const idxMod = await import("../../../open-sse/services/compression/engines/headroom/index.ts");
+  reconstructHeadroom = idxMod.reconstructHeadroom;
+});
+
+// ─── test payloads ──────────────────────────────────────────────────────────
+
+interface Payload {
+  name: string;
+  description: string;
+  data: Record<string, unknown>[];
+  legacyCanHandle: boolean;
+}
+
+function buildPayloads(): Payload[] {
+  return [
+    {
+      name: "homogeneous-simple",
+      description: "50 rows, 4 uniform columns (id, name, value, active)",
+      data: Array.from({ length: 50 }, (_, i) => ({
+        id: i + 1,
+        name: `item-${i + 1}`,
+        value: (i + 1) * 10,
+        active: i % 2 === 0,
+      })),
+      legacyCanHandle: true,
+    },
+    {
+      name: "homogeneous-wide",
+      description: "30 rows, 8 columns with varied types",
+      data: Array.from({ length: 30 }, (_, i) => ({
+        id: i,
+        firstName: `First-${i}`,
+        lastName: `Last-${i}`,
+        email: `user${i}@example.com`,
+        age: 20 + (i % 50),
+        salary: 50000 + i * 1000,
+        department: ["Engineering", "Sales", "Marketing", "Support"][i % 4],
+        active: i % 3 !== 0,
+      })),
+      legacyCanHandle: true,
+    },
+    {
+      name: "heterogeneous-keys",
+      description: "20 rows with different key sets (GCF handles, legacy skips)",
+      data: [
+        ...Array.from({ length: 10 }, (_, i) => ({
+          id: i,
+          name: `user-${i}`,
+          role: "admin",
+        })),
+        ...Array.from({ length: 10 }, (_, i) => ({
+          id: i + 10,
+          email: `u${i}@test.com`,
+          verified: true,
+        })),
+      ],
+      legacyCanHandle: false,
+    },
+    {
+      name: "mixed-type-columns",
+      description: "25 rows with nullable and mixed-type columns",
+      data: Array.from({ length: 25 }, (_, i) => ({
+        id: i + 1,
+        score: i % 3 === 0 ? null : (i + 1) * 7,
+        label: i % 4 === 0 ? null : `label-${i}`,
+        value: i % 2 === 0 ? i * 10 : `str-${i}`,
+      })),
+      legacyCanHandle: false,
+    },
+    {
+      name: "nested-objects",
+      description: "20 rows with nested object values",
+      data: Array.from({ length: 20 }, (_, i) => ({
+        id: i,
+        user: {
+          name: `user-${i}`,
+          email: `user${i}@example.com`,
+          tier: i % 3 === 0 ? "premium" : "free",
+        },
+        amount: i * 100,
+      })),
+      // Legacy detects as homogeneous (same keys), but JSON-stringifies nested objects.
+      // GCF encodes nested objects natively with inline schemas for better compression.
+      legacyCanHandle: true,
+    },
+    {
+      name: "api-response-realistic",
+      description: "Realistic API response: 40 rows with mixed fields",
+      data: Array.from({ length: 40 }, (_, i) => ({
+        id: `req-${i.toString(16).padStart(4, "0")}`,
+        timestamp: `2024-01-${((i % 28) + 1).toString().padStart(2, "0")}T${(i % 24).toString().padStart(2, "0")}:00:00Z`,
+        method: ["GET", "POST", "PUT", "DELETE"][i % 4],
+        path: `/api/v1/resources/${i}`,
+        status: [200, 201, 400, 404, 500][i % 5],
+        latencyMs: 10 + Math.floor(i * 3.7),
+        userId: `user-${i % 15}`,
+        cached: i % 3 === 0,
+      })),
+      legacyCanHandle: true,
+    },
+  ];
+}
+
+// ─── benchmark tests ────────────────────────────────────────────────────────
+
+describe("GCF benchmark — compression savings", () => {
+  const payloads = buildPayloads();
+
+  for (const payload of payloads) {
+    it(`${payload.name}: GCF compresses with positive savings`, () => {
+      const jsonStr = JSON.stringify(payload.data);
+      const gcfEncoded = encodeTabular(payload.data);
+      const savings = ((jsonStr.length - gcfEncoded.length) / jsonStr.length) * 100;
+      assert.ok(
+        savings > 0,
+        `GCF should save space on ${payload.name} (got ${savings.toFixed(1)}%)`
+      );
+    });
+  }
+
+  for (const payload of payloads) {
+    it(`${payload.name}: GCF round-trips losslessly`, () => {
+      const gcfEncoded = encodeTabular(payload.data);
+      const decoded = decodeTabular(gcfEncoded);
+      assert.deepEqual(decoded, payload.data, `${payload.name} must round-trip without data loss`);
+    });
+  }
+});
+
+describe("GCF benchmark — coverage comparison with legacy", () => {
+  const payloads = buildPayloads();
+
+  it("legacy omni-tabular handles only homogeneous payloads", () => {
+    for (const payload of payloads) {
+      const isHomogeneous = detectHomogeneous(payload.data) !== null;
+      if (payload.legacyCanHandle) {
+        // Legacy CAN handle it (but may still use mixed types that corrupt round-trip)
+        // For truly homogeneous data, detectHomogeneous should return non-null
+        // (some payloads are "legacyCanHandle" in terms of key structure but have mixed types)
+      } else {
+        assert.equal(
+          isHomogeneous,
+          false,
+          `${payload.name}: legacy should NOT detect as homogeneous`
+        );
+      }
+    }
+  });
+
+  it("GCF handles ALL payloads (100% coverage)", () => {
+    for (const payload of payloads) {
+      const gcfEncoded = encodeTabular(payload.data);
+      assert.ok(gcfEncoded.includes("gcf-generic"), `${payload.name}: must produce GCF output`);
+      const decoded = decodeTabular(gcfEncoded);
+      assert.deepEqual(decoded, payload.data, `${payload.name}: GCF must round-trip`);
+    }
+  });
+});
+
+describe("GCF benchmark — savings table", () => {
+  it("prints a comparison table (informational)", () => {
+    const payloads = buildPayloads();
+    const rows: string[] = [];
+    rows.push("| Payload | JSON | GCF | Savings | Legacy | Legacy Savings | GCF Advantage |");
+    rows.push("|---------|------|-----|---------|--------|----------------|---------------|");
+
+    for (const payload of payloads) {
+      const jsonStr = JSON.stringify(payload.data);
+      const gcfEncoded = encodeTabular(payload.data);
+      const gcfSavings = ((jsonStr.length - gcfEncoded.length) / jsonStr.length) * 100;
+
+      let legacySize = "-";
+      let legacySavings = "-";
+      let advantage = "N/A (legacy can't encode)";
+
+      if (payload.legacyCanHandle && detectHomogeneous(payload.data)) {
+        const legacyBlock = `\`\`\`omni-tabular\n${encodeTabularBlockLegacy(payload.data)}\n\`\`\``;
+        legacySize = String(legacyBlock.length);
+        const ls = ((jsonStr.length - legacyBlock.length) / jsonStr.length) * 100;
+        legacySavings = ls.toFixed(1) + "%";
+        advantage = (gcfSavings - ls).toFixed(1) + "pp";
+      }
+
+      rows.push(
+        `| ${payload.name} | ${jsonStr.length} | ${gcfEncoded.length} | ${gcfSavings.toFixed(1)}% | ${legacySize} | ${legacySavings} | ${advantage} |`
+      );
+    }
+
+    // Print to stdout for visibility in test output
+    console.log("\n" + rows.join("\n") + "\n");
+
+    // Assert the table was built (not empty)
+    assert.ok(rows.length > 2, "benchmark table should have data rows");
+  });
+});

--- a/tests/unit/compression/headroom-smartcrusher.test.ts
+++ b/tests/unit/compression/headroom-smartcrusher.test.ts
@@ -88,10 +88,11 @@ describe("tabular encoder round-trip", () => {
     assert.deepEqual(decoded, original);
   });
 
-  it("encoded form contains an explicit [N rows] count marker", async () => {
+  it("encoded form contains an explicit [N] count marker with field declaration", async () => {
     const original = makeRows(25);
     const encoded = encodeTabular(original);
-    assert.match(encoded, /\[25 rows\]/);
+    // GCF uses [N]{fields} format (e.g. [25]{id,name,value,active})
+    assert.match(encoded, /\[25\]\{/);
   });
 });
 
@@ -144,7 +145,7 @@ describe("headroomEngine.apply — compression", () => {
     );
   });
 
-  it("compressed body contains the [N rows] count marker", async () => {
+  it("compressed body contains the [N] count marker with field declaration", async () => {
     const n = 22;
     const rows = makeRows(n);
     const body = makeBody(rows);
@@ -153,7 +154,8 @@ describe("headroomEngine.apply — compression", () => {
     assert.equal(result.compressed, true);
 
     const bodyStr = JSON.stringify(result.body);
-    assert.match(bodyStr, /\[22 rows\]/, "compressed body must contain [N rows] marker");
+    // GCF uses [N]{fields} format
+    assert.match(bodyStr, /\[22\]\{/, "compressed body must contain [N]{fields} marker");
   });
 
   it("also compresses when the array is inside a ```json fence in message content", async () => {
@@ -175,16 +177,16 @@ describe("headroomEngine.apply — compression", () => {
 // ─── 3. Conservative guards — nested/flat should NOT regress ─────────────────
 
 describe("headroomEngine.apply — conservative guards (no regression)", () => {
-  it("does NOT compress a heterogeneous array (objects with different key sets)", async () => {
-    // Objects have different keys — not homogeneous
+  it("compresses a heterogeneous array (objects with different key sets) via GCF", async () => {
+    // GCF handles heterogeneous arrays natively: missing fields become ~ (absent)
     const rows: Record<string, unknown>[] = [
       ...Array.from({ length: 10 }, (_, i) => ({ id: i, name: `n${i}` })),
       ...Array.from({ length: 10 }, (_, i) => ({ key: i, label: `l${i}`, extra: true })),
     ];
     const body = makeBody(rows);
     const result = headroomEngine.apply(body);
-    assert.equal(result.compressed, false, "heterogeneous array should NOT be compressed");
-    assert.deepEqual(result.body, body);
+    // GCF encodes heterogeneous arrays with union of all keys
+    assert.equal(result.compressed, true, "heterogeneous array should be compressed by GCF");
   });
 
   it("does NOT compress a tiny array below minRows (< default 8)", async () => {
@@ -303,5 +305,142 @@ describe("headroomEngine — losslessness on mixed-type columns (regression)", (
     const result = headroomEngine.apply(body);
     const restored = await reconstruct(result.body);
     assert.deepEqual(restored, body, "mixed-type column must round-trip without data loss");
+  });
+});
+
+// ─── 6. GCF encoding: capabilities beyond legacy omni-tabular ──────────────
+
+describe("GCF encoding — advanced capabilities", () => {
+  async function reconstruct(body: Record<string, unknown>) {
+    const mod = await import("../../../open-sse/services/compression/engines/headroom/index.ts");
+    return mod.reconstructHeadroom(body);
+  }
+
+  it("compresses heterogeneous arrays (different key sets) losslessly", async () => {
+    const rows: Record<string, unknown>[] = [
+      ...Array.from({ length: 10 }, (_, i) => ({ id: i, name: `user-${i}` })),
+      ...Array.from({ length: 10 }, (_, i) => ({
+        id: i + 10,
+        email: `u${i}@test.com`,
+        verified: true,
+      })),
+    ];
+    const body = makeBody(rows);
+    const result = headroomEngine.apply(body);
+    assert.equal(result.compressed, true, "heterogeneous array should be compressed");
+    const restored = await reconstruct(result.body);
+    assert.deepEqual(restored, body, "heterogeneous array must round-trip losslessly");
+  });
+
+  it("compresses arrays with nested objects losslessly", async () => {
+    const rows = Array.from({ length: 15 }, (_, i) => ({
+      id: i,
+      name: `item-${i}`,
+      metadata: { category: `cat-${i % 3}`, priority: i % 5 },
+    }));
+    const body = makeBody(rows);
+    const result = headroomEngine.apply(body);
+    assert.equal(result.compressed, true, "nested objects should be compressed");
+    const restored = await reconstruct(result.body);
+    assert.deepEqual(restored, body, "nested objects must round-trip losslessly");
+  });
+
+  it("compresses arrays with nested arrays losslessly", async () => {
+    // Use enough rows with enough data to overcome GCF overhead on nested arrays
+    const rows = Array.from({ length: 30 }, (_, i) => ({
+      id: i,
+      name: `item-${i}-with-longer-name-for-savings`,
+      tags: ["alpha", "beta", `tag-${i}`],
+      scores: [i * 10, i * 20, i * 30],
+    }));
+    const body = makeBody(rows);
+    const result = headroomEngine.apply(body);
+    assert.equal(result.compressed, true, "nested arrays should be compressed");
+    const restored = await reconstruct(result.body);
+    assert.deepEqual(restored, body, "nested arrays must round-trip losslessly");
+  });
+
+  it("uses gcf-generic fence marker (not omni-tabular)", async () => {
+    const rows = makeRows(20);
+    const encoded = encodeTabular(rows);
+    assert.ok(encoded.includes("```gcf-generic"), "must use gcf-generic fence marker");
+    assert.ok(!encoded.includes("omni-tabular"), "must not use legacy omni-tabular marker");
+  });
+
+  it("still decodes legacy omni-tabular encoded content (backward compat)", async () => {
+    // Import legacy encoder
+    const mod = await import("../../../open-sse/services/compression/engines/headroom/tabular.ts");
+    const legacyEncode = mod.encodeTabularBlockLegacy;
+
+    const rows = makeRows(10);
+    const legacyBlock = `\`\`\`omni-tabular\n${legacyEncode(rows)}\n\`\`\``;
+    const decoded = decodeTabular(legacyBlock);
+    assert.deepEqual(decoded, rows, "legacy omni-tabular content must still decode correctly");
+  });
+});
+
+// ─── 7. GCF vs legacy benchmark comparison ─────────────────────────────────
+
+describe("GCF vs legacy omni-tabular — compression comparison", () => {
+  it("GCF achieves comparable or better compression on homogeneous arrays", async () => {
+    const rows = makeRows(50);
+    const jsonStr = JSON.stringify(rows);
+
+    // Legacy omni-tabular
+    const mod = await import("../../../open-sse/services/compression/engines/headroom/tabular.ts");
+    const legacyBlock = `\`\`\`omni-tabular\n${mod.encodeTabularBlockLegacy(rows)}\n\`\`\``;
+    const legacySavings = ((jsonStr.length - legacyBlock.length) / jsonStr.length) * 100;
+
+    // GCF
+    const gcfEncoded = encodeTabular(rows);
+    const gcfSavings = ((jsonStr.length - gcfEncoded.length) / jsonStr.length) * 100;
+
+    // GCF should achieve at least as much savings as legacy on homogeneous data
+    assert.ok(
+      gcfSavings >= legacySavings * 0.8, // allow 20% tolerance
+      `GCF savings (${gcfSavings.toFixed(1)}%) should be within 80% of legacy (${legacySavings.toFixed(1)}%)`
+    );
+  });
+
+  it("GCF compresses cases that legacy omni-tabular skips entirely", async () => {
+    // Heterogeneous: legacy would skip, GCF handles it
+    const heteroRows: Record<string, unknown>[] = [
+      ...Array.from({ length: 10 }, (_, i) => ({ id: i, name: `user-${i}`, role: "admin" })),
+      ...Array.from({ length: 10 }, (_, i) => ({ id: i + 10, email: `u${i}@test.com` })),
+    ];
+    const jsonStr = JSON.stringify(heteroRows);
+
+    // Legacy encoder would produce nothing useful for heterogeneous data
+    // (detectHomogeneous returns null)
+    const { detectHomogeneous } =
+      await import("../../../open-sse/services/compression/engines/headroom/smartcrusher.ts");
+    assert.equal(detectHomogeneous(heteroRows), null, "legacy should reject heterogeneous arrays");
+
+    // GCF compresses it
+    const gcfEncoded = encodeTabular(heteroRows);
+    const gcfSavings = ((jsonStr.length - gcfEncoded.length) / jsonStr.length) * 100;
+    assert.ok(
+      gcfSavings > 0,
+      `GCF should compress heterogeneous arrays (savings: ${gcfSavings.toFixed(1)}%)`
+    );
+  });
+
+  it("GCF compresses nested objects that legacy omni-tabular JSON-stringifies", async () => {
+    const nestedRows = Array.from({ length: 20 }, (_, i) => ({
+      id: i,
+      user: {
+        name: `user-${i}`,
+        email: `user${i}@example.com`,
+        tier: i % 3 === 0 ? "premium" : "free",
+      },
+      value: i * 100,
+    }));
+    const jsonStr = JSON.stringify(nestedRows);
+    const gcfEncoded = encodeTabular(nestedRows);
+    const gcfSavings = ((jsonStr.length - gcfEncoded.length) / jsonStr.length) * 100;
+    assert.ok(
+      gcfSavings >= 30,
+      `GCF should achieve >=30% savings on nested objects (got ${gcfSavings.toFixed(1)}%)`
+    );
   });
 });


### PR DESCRIPTION
Closes #3876

## Summary

Replaces headroom's custom `omni-tabular` encoder with GCF (Graph Compact Format) generic profile, vendored directly into the repo. Zero new dependencies.

## Decisions (per #3876 discussion)

1. **Vendoring**: GCF TypeScript source vendored at `engines/headroom/gcf/` (4 files, MIT licensed, zero external imports). Respects OmniRoute's zero-dependency policy.

2. **Engine boundary**: Upgraded headroom's tabular stage rather than adding a standalone engine. SmartCrusher's message scanning, fencing, and guard logic stay as-is. Only the encoder underneath changed. No pipeline config changes needed for users.

## What changed

**Vendored (4 new files):**
- `headroom/gcf/index.ts` - re-exports encodeGeneric/decodeGeneric
- `headroom/gcf/generic.ts` - GCF generic profile encoder
- `headroom/gcf/decode_generic.ts` - GCF generic profile decoder
- `headroom/gcf/scalar.ts` - scalar grammar (encode/decode)

**Modified (4 files):**
- `headroom/tabular.ts` - encoder now delegates to GCF. Legacy `omni-tabular` decoder preserved for backward compat. Fence marker: `gcf-generic`.
- `headroom/smartcrusher.ts` - removed homogeneity gate (GCF handles heterogeneous arrays natively). All other guards unchanged.
- `headroom/index.ts` - `reconstructHeadroom` decodes both `gcf-generic` and legacy `omni-tabular` fences.
- `headroom-smartcrusher.test.ts` - updated 3 assertions, added 8 new tests (heterogeneous, nested, backward compat, GCF vs legacy comparison).

**New test file:**
- `gcf-benchmark.test.ts` - 6 payloads, savings comparison, round-trip verification, coverage comparison.

## Benchmark

| Payload | JSON | GCF | Savings | Legacy | Advantage |
|---------|------|-----|---------|--------|-----------|
| homogeneous-simple | 2649 | 1067 | 59.7% | 48.4% | +11pp |
| homogeneous-wide | 4321 | 1935 | 55.2% | 38.4% | +17pp |
| heterogeneous-keys | 881 | 506 | 42.6% | N/A | legacy can't encode |
| mixed-type-columns | 1317 | 502 | 61.9% | N/A | legacy can't encode |
| nested-objects | 1840 | 969 | 47.3% | 6.6% | +41pp |
| api-response-realistic | 6402 | 3145 | 50.9% | 32.0% | +19pp |

GCF encodes 100% of payloads (legacy handles only homogeneous). All round-trips lossless.

## Backward compatibility

- Legacy `omni-tabular` encoded content still decodes correctly
- `encodeTabularBlock` and `wrapTabular` preserved as aliases delegating to GCF
- `detectHomogeneous` kept (no longer gates encoding, but available for analytics)
- `encodeTabularBlockLegacy` preserved for benchmarks and tests

## Verification

- 44/44 tests pass (29 headroom + 15 benchmark)
- All pre-commit hooks pass (prettier, eslint, docs-sync, any-budget)
- Zero external dependencies added

## Note

This PR reflects the approach proposed in #3876. Happy to refactor naming, directory structure, fence markers, or anything else to match the team's preferences. The aliasing approach (`encodeTabularBlock` → `encodeGcfBlock`) was chosen to minimize diff; renaming across all call sites is straightforward if preferred.

## Links

- GCF spec: https://gcformat.com
- Source: https://github.com/blackwell-systems/gcf-typescript
- Lossless verification: https://gcformat.com/guide/lossless-verification