### PR TITLE
feat(mitm): TPROXY capture-mode listener + connectMarked (Epic A)

### DIFF
--- a/src/mitm/tproxy/captureMode.ts
+++ b/src/mitm/tproxy/captureMode.ts
@@ -1,0 +1,168 @@
+/**
+ * Fase 3 / Epic A — TPROXY capture-mode listener (Linux).
+ *
+ * Ties the validated primitives together into a transparent capture mode for
+ * LOCAL outbound traffic (IDE agents on the same host) WITHOUT `/etc/hosts`
+ * spoofing or OS-wide proxy mutation:
+ *
+ *   1. apply the OUTPUT-based TPROXY rules (commands.ts / setup.ts)
+ *   2. open the IP_TRANSPARENT listener (native addon → fd → net.Server)
+ *   3. per intercepted connection: read the ORIGINAL destination
+ *      (`socket.localAddress` — TPROXY preserves it), report it, and forward to
+ *      that destination over a `connectMarked` (SO_MARK bypass) socket so the
+ *      OUTPUT rule excludes the forward (anti-loop), with a raw bidirectional pipe.
+ *
+ * Each primitive was validated e2e on the VPS (kernel 6.8.0): intercept,
+ * anti-loop (the marked SYN was excluded), and Node adoption of the marked fd +
+ * pipe (PONG round-tripped). TLS termination / content decryption (reusing the
+ * MITM core) is a deliberate follow-up — this layer is a transparent tunnel that
+ * surfaces the intercepted connections via `onIntercept`.
+ *
+ * All effectful seams are injected (`deps`) so the orchestration and the
+ * per-connection logic are unit-testable without root.
+ */
+import net from "node:net";
+import { applyTproxy, revertTproxy, type CommandRunner } from "./setup";
+import {
+  createTransparentListenerFd,
+  connectMarked,
+  isTransparentSocketAvailable,
+} from "./transparentSocket";
+import { validateTproxyConfig, type TproxyConfig } from "./commands";
+
+/** Default bypass SO_MARK when `cfg.bypassMark` is unset (anti-loop). */
+const DEFAULT_BYPASS_MARK = 0x539;
+
+/** Strip the IPv4-mapped-IPv6 prefix Node reports for dual-stack sockets. */
+export function normalizeDest(localAddress: string | undefined): string {
+  return (localAddress ?? "").replace(/^::ffff:/, "");
+}
+
+export interface TproxyInterceptInfo {
+  destIp: string;
+  destPort: number;
+}
+
+interface TproxyDeps {
+  applyTproxy: (cfg: TproxyConfig, run?: CommandRunner) => Promise<void>;
+  revertTproxy: (cfg: TproxyConfig, run?: CommandRunner) => Promise<void>;
+  createListenerFd: (ip: string, port: number) => number;
+  connectMarked: (ip: string, port: number, mark: number) => number;
+  createServer: (onConn: (s: net.Socket) => void) => net.Server;
+  createUpstreamSocket: (fd: number) => net.Socket;
+}
+
+const realDeps: TproxyDeps = {
+  applyTproxy,
+  revertTproxy,
+  createListenerFd: createTransparentListenerFd,
+  connectMarked,
+  createServer: (onConn) => net.createServer(onConn),
+  createUpstreamSocket: (fd) => new net.Socket({ fd }),
+};
+
+export interface TproxyCaptureOptions {
+  /** Bind address for the transparent listener. Default "0.0.0.0". */
+  listenIp?: string;
+  /** Invoked for each intercepted connection (e.g. push metadata to the buffer). */
+  onIntercept?: (info: TproxyInterceptInfo) => void;
+  /** Injectable seams for unit testing. */
+  deps?: Partial<TproxyDeps>;
+}
+
+export interface TproxyCaptureHandle {
+  cfg: TproxyConfig;
+  server: net.Server;
+  stop: () => Promise<void>;
+}
+
+/**
+ * Handle one intercepted connection: read the original destination, report it,
+ * and forward to it over a bypass-marked socket with a raw bidirectional pipe.
+ */
+export function handleTproxyConnection(
+  client: net.Socket,
+  cfg: TproxyConfig,
+  deps: Pick<TproxyDeps, "connectMarked" | "createUpstreamSocket">,
+  onIntercept?: (info: TproxyInterceptInfo) => void
+): void {
+  const destIp = normalizeDest(client.localAddress);
+  const destPort = client.localPort ?? 0;
+  onIntercept?.({ destIp, destPort });
+
+  if (!destIp || destPort <= 0) {
+    client.destroy();
+    return;
+  }
+
+  let fd: number;
+  try {
+    fd = deps.connectMarked(destIp, destPort, cfg.bypassMark ?? DEFAULT_BYPASS_MARK);
+  } catch {
+    client.destroy();
+    return;
+  }
+
+  const upstream = deps.createUpstreamSocket(fd);
+  upstream.on("error", () => client.destroy());
+  client.on("error", () => upstream.destroy());
+  client.pipe(upstream);
+  upstream.pipe(client);
+}
+
+/**
+ * Start TPROXY capture: apply the rules, open the transparent listener, and wire
+ * the per-connection forwarder. Returns a handle whose `stop()` closes the
+ * listener and reverts the rules (crash-safe teardown). Throws (after reverting)
+ * if anything fails to come up.
+ */
+export async function startTproxyCapture(
+  cfg: TproxyConfig,
+  options: TproxyCaptureOptions = {}
+): Promise<TproxyCaptureHandle> {
+  const deps: TproxyDeps = { ...realDeps, ...options.deps };
+
+  // In production the native addon is required; tests inject createListenerFd.
+  if (!options.deps?.createListenerFd && !isTransparentSocketAvailable()) {
+    throw new Error("TPROXY capture mode requires the native addon (Linux + CAP_NET_ADMIN).");
+  }
+  const invalid = validateTproxyConfig(cfg);
+  if (invalid) throw new Error(invalid);
+
+  await deps.applyTproxy(cfg);
+
+  let fd: number;
+  try {
+    fd = deps.createListenerFd(options.listenIp ?? "0.0.0.0", cfg.onPort);
+  } catch (err) {
+    await deps.revertTproxy(cfg).catch(() => {});
+    throw err;
+  }
+
+  const server = deps.createServer((client) =>
+    handleTproxyConnection(client, cfg, deps, options.onIntercept)
+  );
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const onErr = (e: Error) => reject(e);
+      server.once("error", onErr);
+      server.listen({ fd }, () => {
+        server.removeListener("error", onErr);
+        resolve();
+      });
+    });
+  } catch (err) {
+    await deps.revertTproxy(cfg).catch(() => {});
+    throw err;
+  }
+
+  return {
+    cfg,
+    server,
+    stop: async () => {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      await deps.revertTproxy(cfg).catch(() => {});
+    },
+  };
+}

--- a/src/mitm/tproxy/native/transparent.c
+++ b/src/mitm/tproxy/native/transparent.c
@@ -18,6 +18,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <errno.h>
+#include <fcntl.h>
 
 #define THROW(env, code, msg) do { napi_throw_error((env), (code), (msg)); return NULL; } while (0)
 
@@ -83,6 +84,50 @@ static napi_value SetSocketMark(napi_env env, napi_callback_info info) {
   return NULL;
 }
 
+/*
+ * connectMarked(ip, port, mark): create a socket, set SO_MARK BEFORE connect so
+ * the SYN itself carries the mark, then start a non-blocking connect. Returns
+ * the fd (connect in progress). This is the anti-loop for the forward path: the
+ * proxy's upstream SYN is excluded by the OUTPUT rule (`-m mark ! --mark`), so
+ * the forward does not re-enter TPROXY. The caller adopts the fd into a Node
+ * socket and waits for it to become writable. Requires CAP_NET_ADMIN.
+ */
+static napi_value ConnectMarked(napi_env env, napi_callback_info info) {
+  size_t argc = 3;
+  napi_value argv[3];
+  napi_get_cb_info(env, info, &argc, argv, NULL, NULL);
+  char ip[64] = {0};
+  size_t ip_len = 0;
+  napi_get_value_string_utf8(env, argv[0], ip, sizeof(ip), &ip_len);
+  int32_t port = 0, mark = 0;
+  napi_get_value_int32(env, argv[1], &port);
+  napi_get_value_int32(env, argv[2], &mark);
+
+  int fd = socket(AF_INET, SOCK_STREAM, 0);
+  if (fd < 0) THROW(env, "ESOCKET", strerror(errno));
+  if (setsockopt(fd, SOL_SOCKET, SO_MARK, &mark, sizeof(mark)) < 0) {
+    int e = errno; close(fd); THROW(env, "ESO_MARK", strerror(e));
+  }
+  int flags = fcntl(fd, F_GETFL, 0);
+  if (flags < 0 || fcntl(fd, F_SETFL, flags | O_NONBLOCK) < 0) {
+    int e = errno; close(fd); THROW(env, "EFCNTL", strerror(e));
+  }
+  struct sockaddr_in addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.sin_family = AF_INET;
+  addr.sin_port = htons((uint16_t)port);
+  if (inet_pton(AF_INET, ip, &addr.sin_addr) != 1) {
+    close(fd); THROW(env, "EADDR", "invalid IPv4 address");
+  }
+  int r = connect(fd, (struct sockaddr *)&addr, sizeof(addr));
+  if (r < 0 && errno != EINPROGRESS) {
+    int e = errno; close(fd); THROW(env, "ECONNECT", strerror(e));
+  }
+  napi_value result;
+  napi_create_int32(env, fd, &result);
+  return result;
+}
+
 static napi_value Init(napi_env env, napi_value exports) {
   napi_value fn;
   napi_create_function(env, "createTransparentListener", NAPI_AUTO_LENGTH,
@@ -92,6 +137,10 @@ static napi_value Init(napi_env env, napi_value exports) {
   napi_value markFn;
   napi_create_function(env, "setSocketMark", NAPI_AUTO_LENGTH, SetSocketMark, NULL, &markFn);
   napi_set_named_property(env, exports, "setSocketMark", markFn);
+
+  napi_value connFn;
+  napi_create_function(env, "connectMarked", NAPI_AUTO_LENGTH, ConnectMarked, NULL, &connFn);
+  napi_set_named_property(env, exports, "connectMarked", connFn);
   return exports;
 }
 

--- a/src/mitm/tproxy/transparentSocket.ts
+++ b/src/mitm/tproxy/transparentSocket.ts
@@ -24,6 +24,8 @@ export interface TransparentAddon {
   createTransparentListener(ip: string, port: number): number;
   /** setsockopt(SO_MARK) on an fd — anti-loop: mark the proxy's own upstream conns. */
   setSocketMark(fd: number, mark: number): void;
+  /** socket()+SO_MARK+non-blocking connect(); returns fd. Anti-loop forward path. */
+  connectMarked(ip: string, port: number, mark: number): number;
 }
 
 /** Candidate locations for the built/prebuilt addon, relative to this module. */
@@ -47,7 +49,8 @@ export function loadTransparentAddon(
       if (
         mod &&
         typeof mod.createTransparentListener === "function" &&
-        typeof mod.setSocketMark === "function"
+        typeof mod.setSocketMark === "function" &&
+        typeof mod.connectMarked === "function"
       ) {
         return mod as TransparentAddon;
       }
@@ -92,4 +95,18 @@ export function setSocketMark(fd: number, mark: number): void {
     throw new Error("TPROXY transparent-socket addon is not available (setSocketMark).");
   }
   cached.setSocketMark(fd, mark);
+}
+
+/**
+ * Create a socket with SO_MARK set BEFORE a non-blocking connect (so the SYN
+ * carries the mark) and return its fd for Node to adopt via `new net.Socket({
+ * fd })`. This is the forward-path anti-loop: the proxy's upstream SYN is
+ * excluded by the OUTPUT rule, so the forward does not re-enter TPROXY. Throws
+ * when the addon is unavailable.
+ */
+export function connectMarked(ip: string, port: number, mark: number): number {
+  if (!cached) {
+    throw new Error("TPROXY transparent-socket addon is not available (connectMarked).");
+  }
+  return cached.connectMarked(ip, port, mark);
 }

--- a/tests/unit/tproxy-capture-mode.test.ts
+++ b/tests/unit/tproxy-capture-mode.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Fase 3 / Epic A — TPROXY capture-mode listener.
+ *
+ * Ties the validated primitives together: apply OUTPUT-based rules → open the
+ * IP_TRANSPARENT listener → per connection, read the ORIGINAL destination
+ * (socket.localAddress — TPROXY preserves it), record it, and forward to that
+ * destination over a SO_MARK-bypass socket (anti-loop) with a raw pipe.
+ *
+ * All seams are injected so the orchestration + per-connection logic are
+ * unit-testable without root. The real intercept/anti-loop/adoption were each
+ * validated e2e on the VPS (kernel 6.8.0).
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+
+const { normalizeDest, handleTproxyConnection, startTproxyCapture } = await import(
+  "../../src/mitm/tproxy/captureMode.ts"
+);
+
+const CFG = { dport: 443, mark: 0x2333, onPort: 8443, routeTable: 233, bypassMark: 0x539 };
+
+test("normalizeDest strips the IPv4-mapped-IPv6 prefix Node reports", () => {
+  assert.equal(normalizeDest("::ffff:1.2.3.4"), "1.2.3.4");
+  assert.equal(normalizeDest("1.2.3.4"), "1.2.3.4");
+  assert.equal(normalizeDest("2001:db8::1"), "2001:db8::1");
+  assert.equal(normalizeDest(undefined), "");
+});
+
+function fakeSocket(localAddress: string, localPort: number) {
+  const s = new EventEmitter() as EventEmitter & {
+    localAddress: string;
+    localPort: number;
+    destroyed: boolean;
+    destroy: () => void;
+    pipe: (d: unknown) => unknown;
+  };
+  s.localAddress = localAddress;
+  s.localPort = localPort;
+  s.destroyed = false;
+  s.destroy = () => {
+    s.destroyed = true;
+  };
+  s.pipe = (d: unknown) => d;
+  return s;
+}
+
+test("handleTproxyConnection reads orig dest, reports it, and forwards via connectMarked(bypass)", () => {
+  const client = fakeSocket("::ffff:140.82.112.3", 443);
+  const calls: Array<{ ip: string; port: number; mark: number }> = [];
+  const intercepts: Array<{ destIp: string; destPort: number }> = [];
+  const deps = {
+    connectMarked: (ip: string, port: number, mark: number) => {
+      calls.push({ ip, port, mark });
+      return 99; // fake fd; upstream-socket factory is injected below
+    },
+    createUpstreamSocket: () => fakeSocket("", 0),
+  };
+  handleTproxyConnection(client as never, CFG, deps as never, (i) => intercepts.push(i));
+
+  assert.deepEqual(intercepts, [{ destIp: "140.82.112.3", destPort: 443 }]);
+  assert.deepEqual(calls, [{ ip: "140.82.112.3", port: 443, mark: 0x539 }]);
+});
+
+test("handleTproxyConnection destroys the client when the destination is unreadable", () => {
+  const client = fakeSocket("", 0);
+  let connectCalled = false;
+  const deps = {
+    connectMarked: () => {
+      connectCalled = true;
+      return 1;
+    },
+    createUpstreamSocket: () => fakeSocket("", 0),
+  };
+  handleTproxyConnection(client as never, CFG, deps as never);
+  assert.equal(client.destroyed, true);
+  assert.equal(connectCalled, false, "must not dial when there is no original destination");
+});
+
+test("startTproxyCapture applies rules, opens the listener, and stop() reverts", async () => {
+  const order: string[] = [];
+  const server = new EventEmitter() as EventEmitter & {
+    listen: (opts: unknown, cb: () => void) => void;
+    close: (cb: () => void) => void;
+  };
+  server.listen = (_opts, cb) => {
+    order.push("listen");
+    cb();
+  };
+  server.close = (cb) => {
+    order.push("close");
+    cb();
+  };
+  const deps = {
+    applyTproxy: async () => {
+      order.push("apply");
+    },
+    revertTproxy: async () => {
+      order.push("revert");
+    },
+    createListenerFd: () => {
+      order.push("createFd");
+      return 20;
+    },
+    connectMarked: () => 1,
+    createServer: () => server,
+    createUpstreamSocket: () => fakeSocket("", 0),
+  };
+  const handle = await startTproxyCapture(CFG, { deps: deps as never });
+  assert.deepEqual(order, ["apply", "createFd", "listen"]);
+  await handle.stop();
+  assert.deepEqual(order, ["apply", "createFd", "listen", "close", "revert"]);
+});
+
+test("startTproxyCapture rejects an invalid config and reverts nothing", async () => {
+  const order: string[] = [];
+  const deps = {
+    applyTproxy: async () => order.push("apply"),
+    revertTproxy: async () => order.push("revert"),
+    createListenerFd: () => 20,
+    connectMarked: () => 1,
+    createServer: () => new EventEmitter(),
+    createUpstreamSocket: () => fakeSocket("", 0),
+  };
+  await assert.rejects(
+    () => startTproxyCapture({ ...CFG, dport: 0 }, { deps: deps as never }),
+    /dport/i
+  );
+  assert.deepEqual(order, [], "invalid config must not apply any rules");
+});

--- a/tests/unit/tproxy-transparent-socket.test.ts
+++ b/tests/unit/tproxy-transparent-socket.test.ts
@@ -32,19 +32,33 @@ test("loadTransparentAddon returns null when the prebuilt addon is absent (requi
 });
 
 test("loadTransparentAddon returns the addon when present and well-shaped", () => {
-  const fake = { createTransparentListener: () => 42, setSocketMark: () => {} };
+  const fake = { createTransparentListener: () => 42, setSocketMark: () => {}, connectMarked: () => 7 };
   const addon = loadTransparentAddon(() => fake, () => "linux");
   assert.equal(addon, fake);
   assert.equal(addon?.createTransparentListener("0.0.0.0", 1), 42);
 });
 
 test("loadTransparentAddon rejects a module missing createTransparentListener", () => {
-  const addon = loadTransparentAddon(() => ({ setSocketMark: () => {} }), () => "linux");
+  const addon = loadTransparentAddon(
+    () => ({ setSocketMark: () => {}, connectMarked: () => 7 }),
+    () => "linux"
+  );
   assert.equal(addon, null);
 });
 
 test("loadTransparentAddon rejects a module missing setSocketMark (anti-loop primitive)", () => {
-  const addon = loadTransparentAddon(() => ({ createTransparentListener: () => 1 }), () => "linux");
+  const addon = loadTransparentAddon(
+    () => ({ createTransparentListener: () => 1, connectMarked: () => 7 }),
+    () => "linux"
+  );
+  assert.equal(addon, null);
+});
+
+test("loadTransparentAddon rejects a module missing connectMarked (forward anti-loop)", () => {
+  const addon = loadTransparentAddon(
+    () => ({ createTransparentListener: () => 1, setSocketMark: () => {} }),
+    () => "linux"
+  );
   assert.equal(addon, null);
 });
 


### PR DESCRIPTION
## Summary

The **listener** for Fase 3 / Epic A — ties the validated TPROXY primitives (#4144 setup, #4156 OUTPUT recipe, #4148/#4160 addon) into a transparent capture mode for **local outbound traffic** (IDE agents on the same host), with **no `/etc/hosts` spoofing or OS-wide proxy mutation**.

`src/mitm/tproxy/captureMode.ts`:
1. apply the OUTPUT-based rules + open the `IP_TRANSPARENT` listener (addon fd → `net.Server`).
2. per intercepted connection: read the **original destination** (`socket.localAddress` — TPROXY preserves it), report it via `onIntercept`, and forward to it over a **`connectMarked` (SO_MARK bypass)** socket so the OUTPUT rule excludes the forward (**anti-loop**), with a raw bidirectional pipe.
3. `stop()` closes the listener and **reverts the rules** (crash-safe).

Adds **`connectMarked(ip, port, mark)`** to the native addon — `socket()` + `SO_MARK` **before** a non-blocking `connect()`, so the forward's SYN already carries the bypass mark — plus the wrapper export; the loader now requires all three addon functions.

All effectful seams are injected (`deps`) so the orchestration + per-connection logic are unit-testable without root.

## Validated end-to-end on the VPS (Hard Rule #18)

Kernel `6.8.0-124`, isolated to a test port (9999) + dedicated fwmark (0x2333) so production 443/80 was untouched:

```
ANTI-LOOP:  connectMarked(bypass) → listener received 0 (SYN excluded)
            plain net.connect     → listener received 1 (looped)
ADOPTION:   connectMarked fd → new net.Socket({fd}) → wrote PING → got PONG:PING
FULL TUNNEL: client connected → intercepted dest=127.0.0.1:9999 preserved →
            forward (connectMarked) → upstream → "PONG:PING" round-tripped to client
```

## Follow-ups (last bits of camera 4)

- **TLS termination / content decryption** (reuse the MITM core / `server.cjs`) — this layer is currently a transparent **tunnel** that surfaces connections via `onIntercept`; decrypt is the next sub-layer.
- `repairMitm()` calling `revertTproxy()` once a TPROXY config is persisted.
- Capture-mode **route + Traffic Inspector UI tab** (+ `source:"tproxy"` in `CaptureSource`, addon prebuilds).

## Test Plan

- [x] `node --test tproxy-capture-mode.test.ts tproxy-transparent-socket.test.ts` — 14/14 (normalizeDest, dest-parse + connectMarked forward, destroy-on-bad-dest, apply/listen/stop+revert order, invalid-config-reverts-nothing, loader requires all 3 fns)
- [x] `npm run build:native:tproxy` compiles with `connectMarked`
- [x] `typecheck:core` — 0 · `eslint` — 0
- [x] VPS: anti-loop + adoption + **full tunnel** (evidence above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)