### PR TITLE
feat(mitm): TLS-terminating capture for TPROXY (decrypt 2/N)

### DIFF
--- a/src/mitm/inspector/types.ts
+++ b/src/mitm/inspector/types.ts
@@ -1,6 +1,11 @@
 import { z } from "zod";
 
-export type CaptureSource = "agent-bridge" | "custom-host" | "http-proxy" | "system-proxy";
+export type CaptureSource =
+  | "agent-bridge"
+  | "custom-host"
+  | "http-proxy"
+  | "system-proxy"
+  | "tproxy";
 export type DetectedKind = "llm" | "app" | "unknown";
 
 export interface InterceptedRequest {
@@ -35,7 +40,7 @@ export interface InterceptedRequest {
 
 export const InterceptedRequestSchema = z.object({
   id: z.string().uuid(),
-  source: z.enum(["agent-bridge", "custom-host", "http-proxy", "system-proxy"]),
+  source: z.enum(["agent-bridge", "custom-host", "http-proxy", "system-proxy", "tproxy"]),
   agent: z.string().optional(),
   timestamp: z.string().datetime(),
   method: z.string(),

--- a/src/mitm/tproxy/tlsCapture.ts
+++ b/src/mitm/tproxy/tlsCapture.ts
@@ -1,0 +1,361 @@
+/**
+ * Fase 3 / Epic A — TLS-terminating capture for the TPROXY mode (decrypt 2/N).
+ *
+ * The transparent listener (#4169 `captureMode.ts`) intercepts LOCAL outbound
+ * connections and, so far, raw-pipes them to the original destination — bodies
+ * stay opaque. This module is the decrypt engine: given a raw intercepted socket
+ * plus its original destination, it
+ *
+ *   1. TLS-terminates the CLIENT side with a per-SNI leaf issued on demand by the
+ *      dynamic CA (`dynamicCert.ts`, #4173) — the client must trust that CA;
+ *   2. feeds the decrypted plaintext to an internal `http.Server` (Node parses the
+ *      request automatically, exactly like `inspector/httpProxyServer.ts`);
+ *   3. captures the exchange into the Traffic Inspector buffer with
+ *      `source: "tproxy"` (sanitized headers + masked bodies);
+ *   4. forwards the request to the original destination, RE-encrypted. The forward
+ *      seam is injected so the real path can mark its upstream socket with the
+ *      bypass SO_MARK (`connectMarked`) — without that, the OUTPUT-based TPROXY
+ *      rule would re-intercept the proxy's own forward and loop.
+ *
+ * Every effectful seam (`buffer`, `forward`, `now`, `randomId`) is injected so the
+ * decrypt + capture path is unit-testable with a real local TLS round-trip — no
+ * root, no iptables, no native addon. The anti-loop forward (`realForward`, which
+ * needs `connectMarked`) is the only kernel-dependent piece and is validated e2e
+ * on the VPS when wired into the transparent listener (3/N).
+ */
+import http from "node:http";
+import https from "node:https";
+import net from "node:net";
+import tls from "node:tls";
+import { randomUUID } from "node:crypto";
+import { sanitizeErrorMessage } from "@omniroute/open-sse/utils/error";
+import { sanitizeHeaders } from "../sanitizeHeaders.ts";
+import { maskSecret } from "../maskSecrets.ts";
+import { MITM_IDLE_TIMEOUT_MS } from "../socketTimeouts.ts";
+import { globalTrafficBuffer } from "../inspector/buffer.ts";
+import type { InterceptedRequest } from "../inspector/types.ts";
+import type { DynamicCertStore } from "./dynamicCert.ts";
+import { connectMarked } from "./transparentSocket.ts";
+
+/** Default bypass SO_MARK for the forward path (anti-loop). Matches captureMode. */
+export const DEFAULT_BYPASS_MARK = 0x539;
+
+/** First byte of a TLS record carrying a handshake (ClientHello) — RFC 8446 §5.1. */
+export function isTlsClientHello(firstByte: number): boolean {
+  return firstByte === 0x16;
+}
+
+/**
+ * Host to display/route as: prefer the SNI servername the client requested, then
+ * the `Host` header (port stripped), then the raw destination IP as a last resort.
+ */
+export function resolveCaptureHost(
+  sniServername: string | undefined,
+  hostHeader: string | undefined,
+  destIp: string
+): string {
+  const sni = (sniServername ?? "").trim();
+  if (sni) return sni;
+  const host = (hostHeader ?? "").trim();
+  if (host) return host.replace(/:\d+$/, "");
+  return destIp;
+}
+
+/** Original destination of an intercepted connection (TPROXY preserves it). */
+export interface DecryptedDest {
+  ip: string;
+  port: number;
+  /** SNI servername, when already known (otherwise read off the TLS socket). */
+  sni?: string;
+}
+
+export interface ForwardInit {
+  method: string;
+  path: string;
+  headers: Record<string, string>;
+  body: Buffer;
+}
+
+export interface ForwardResult {
+  status: number;
+  headers: Record<string, string>;
+  body: Buffer;
+}
+
+export interface TlsCaptureDeps {
+  buffer: Pick<typeof globalTrafficBuffer, "push" | "update">;
+  /** Forward the decrypted request to `dest`, re-encrypted. Injectable for tests
+   * and so the real path can SO_MARK its upstream socket (anti-loop). */
+  forward: (dest: DecryptedDest, init: ForwardInit) => Promise<ForwardResult>;
+  /** Monotonic clock for latency (default `performance.now`). */
+  now: () => number;
+  /** Request id generator (default `randomUUID`). */
+  randomId: () => string;
+}
+
+function defaultDeps(overrides: Partial<TlsCaptureDeps>): TlsCaptureDeps {
+  return {
+    buffer: globalTrafficBuffer,
+    forward: realForward,
+    now: () => performance.now(),
+    randomId: () => randomUUID(),
+    ...overrides,
+  };
+}
+
+async function readBody(req: http.IncomingMessage): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks);
+}
+
+/**
+ * Headers for the upstream forward: drop hop-by-hop/framing fields (so Node sets
+ * its own) but KEEP auth so the upstream still authenticates, and pin `host` to
+ * the resolved capture host. Mirrors `httpProxyServer.buildFetchHeaders`.
+ */
+export function buildForwardHeaders(
+  raw: http.IncomingHttpHeaders,
+  host: string
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [name, value] of Object.entries(raw)) {
+    if (value === undefined || value === null) continue;
+    const lower = name.toLowerCase();
+    if (
+      lower === "host" ||
+      lower === "connection" ||
+      lower === "keep-alive" ||
+      lower === "proxy-authenticate" ||
+      lower === "proxy-authorization" ||
+      lower === "te" ||
+      lower === "trailer" ||
+      lower === "transfer-encoding" ||
+      lower === "upgrade" ||
+      lower === "content-length"
+    ) {
+      continue;
+    }
+    out[lower] = Array.isArray(value) ? value.join(", ") : String(value);
+  }
+  out.host = host;
+  return out;
+}
+
+/**
+ * Handle one decrypted request: capture it (source "tproxy"), forward it to the
+ * original destination, relay the response, and record the full exchange. Mirrors
+ * `httpProxyServer.handleHttp` but the destination comes from TPROXY (not an
+ * absolute proxy URL) and bodies are visible because the TLS was terminated.
+ */
+export function handleDecryptedRequest(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  dest: DecryptedDest,
+  deps: TlsCaptureDeps
+): void {
+  const startedAt = deps.now();
+  const socket = req.socket as tls.TLSSocket;
+  const sni =
+    dest.sni ?? (typeof socket.servername === "string" ? socket.servername : undefined);
+  const host = resolveCaptureHost(sni, req.headers.host, dest.ip);
+  const path = req.url ?? "/";
+
+  const intercepted: InterceptedRequest = {
+    id: deps.randomId(),
+    source: "tproxy",
+    timestamp: new Date().toISOString(),
+    method: req.method ?? "GET",
+    host,
+    path,
+    requestHeaders: sanitizeHeaders(req.headers),
+    requestBody: null,
+    requestSize: 0,
+    responseHeaders: {},
+    responseBody: null,
+    responseSize: 0,
+    status: "in-flight",
+  };
+
+  deps.buffer.push(intercepted);
+
+  void (async () => {
+    try {
+      const body = await readBody(req);
+      intercepted.requestSize = body.length;
+      intercepted.requestBody = body.length > 0 ? maskSecret(body.toString("utf8")) : null;
+
+      const result = await deps.forward(
+        { ip: dest.ip, port: dest.port, sni },
+        { method: req.method ?? "GET", path, headers: buildForwardHeaders(req.headers, host), body }
+      );
+
+      const totalLatencyMs = deps.now() - startedAt;
+      intercepted.responseHeaders = sanitizeHeaders(result.headers);
+      intercepted.responseBody = maskSecret(result.body.toString("utf8"));
+      intercepted.responseSize = result.body.length;
+      intercepted.status = result.status;
+      intercepted.totalLatencyMs = totalLatencyMs;
+      intercepted.upstreamLatencyMs = totalLatencyMs;
+      intercepted.proxyLatencyMs = 0;
+
+      const safeRespHeaders: Record<string, string> = {};
+      for (const [k, v] of Object.entries(result.headers)) {
+        const lk = k.toLowerCase();
+        if (lk === "content-length" || lk === "transfer-encoding") continue;
+        safeRespHeaders[k] = v;
+      }
+      res.writeHead(result.status, safeRespHeaders);
+      res.end(result.body);
+
+      deps.buffer.update(intercepted.id, intercepted);
+    } catch (err) {
+      intercepted.status = "error";
+      intercepted.error = sanitizeErrorMessage(err);
+      intercepted.totalLatencyMs = deps.now() - startedAt;
+      deps.buffer.update(intercepted.id, intercepted);
+      if (!res.headersSent) {
+        res.writeHead(502, { "content-type": "text/plain" });
+        res.end("Bad Gateway");
+      } else {
+        res.end();
+      }
+    }
+  })();
+}
+
+export interface TlsCaptureServer {
+  /** Internal HTTP server that parses the decrypted plaintext. */
+  server: http.Server;
+  /** TLS-terminate a raw intercepted socket and capture/forward the exchange. */
+  terminate(rawClient: net.Socket, dest: DecryptedDest): void;
+  /** Close the internal server. */
+  close(): Promise<void>;
+}
+
+/**
+ * Build the decrypt engine: an internal `http.Server` whose request handler
+ * captures + forwards, plus `terminate()` to feed it a raw intercepted socket.
+ */
+export function createTlsCaptureServer(
+  certStore: Pick<DynamicCertStore, "createSNICallback">,
+  deps: Partial<TlsCaptureDeps> = {}
+): TlsCaptureServer {
+  const resolved = defaultDeps(deps);
+  const pending = new WeakMap<object, DecryptedDest>();
+  const server = http.createServer();
+
+  // Bound lifetimes so a hung decrypted tunnel cannot exhaust file descriptors.
+  server.requestTimeout = MITM_IDLE_TIMEOUT_MS * 5;
+  server.headersTimeout = MITM_IDLE_TIMEOUT_MS;
+  server.keepAliveTimeout = MITM_IDLE_TIMEOUT_MS;
+
+  server.on("request", (req, res) => {
+    const dest = pending.get(req.socket) ?? { ip: "", port: 0 };
+    handleDecryptedRequest(req, res, dest, resolved);
+  });
+
+  const sniCallback = certStore.createSNICallback();
+
+  return {
+    server,
+    terminate(rawClient, dest) {
+      const tlsSocket = new tls.TLSSocket(rawClient, {
+        isServer: true,
+        SNICallback: sniCallback,
+      });
+      pending.set(tlsSocket, dest);
+      tlsSocket.on("error", () => {
+        try {
+          rawClient.destroy();
+        } catch {
+          // already gone
+        }
+      });
+      // Hand the decrypted stream to the HTTP parser (the MITM termination trick).
+      server.emit("connection", tlsSocket);
+    },
+    close: () =>
+      new Promise<void>((resolve) => {
+        // Destroy any lingering decrypted sockets so their idle timers don't keep
+        // the event loop alive past close (Node 18.2+).
+        server.closeAllConnections?.();
+        server.close(() => resolve());
+      }),
+  };
+}
+
+/**
+ * Build a forward function that opens its upstream TCP socket via `connectRaw`,
+ * then re-encrypts to the original destination over TLS. `connectRaw` is the
+ * anti-loop seam: the real path marks the socket (`connectMarked`) so the
+ * OUTPUT-based TPROXY rule excludes the proxy's own forward; tests pass a plain
+ * `net.connect`.
+ *
+ * `rejectUnauthorized` defaults to `true` (secure by default): the upstream cert
+ * is validated against `servername` (the SNI/Host the client requested), mirroring
+ * what the original client would do — the proxy must not silently accept an
+ * upstream cert the client itself would reject. Callers talking to a self-signed
+ * upstream (e.g. tests) must opt in explicitly with `{ rejectUnauthorized: false }`.
+ */
+export function createForward(
+  connectRaw: (ip: string, port: number) => net.Socket,
+  opts: { rejectUnauthorized?: boolean } = {}
+): TlsCaptureDeps["forward"] {
+  const rejectUnauthorized = opts.rejectUnauthorized ?? true;
+  return (dest, init) =>
+    new Promise<ForwardResult>((resolve, reject) => {
+      const servername = dest.sni || String(init.headers.host || dest.ip);
+      let req: http.ClientRequest;
+      try {
+        req = https.request(
+          {
+            host: dest.ip,
+            port: dest.port,
+            method: init.method,
+            path: init.path,
+            headers: init.headers,
+            servername,
+            rejectUnauthorized,
+            // `agent: false` is required so `createConnection` is honored — the
+            // default Agent would ignore it and open its own (unmarked) socket,
+            // breaking the anti-loop SO_MARK on the real forward path.
+            agent: false,
+            createConnection: () =>
+              tls.connect({ socket: connectRaw(dest.ip, dest.port), servername, rejectUnauthorized }),
+          },
+          (upstream) => {
+            const chunks: Buffer[] = [];
+            upstream.on("data", (c) => chunks.push(Buffer.isBuffer(c) ? c : Buffer.from(c)));
+            upstream.on("end", () => {
+              const headers: Record<string, string> = {};
+              for (const [k, v] of Object.entries(upstream.headers)) {
+                if (v === undefined) continue;
+                headers[k] = Array.isArray(v) ? v.join(", ") : String(v);
+              }
+              resolve({ status: upstream.statusCode ?? 0, headers, body: Buffer.concat(chunks) });
+            });
+          }
+        );
+      } catch (err) {
+        reject(err);
+        return;
+      }
+      req.once("error", reject);
+      if (init.body.length > 0) req.write(init.body);
+      req.end();
+    });
+}
+
+/**
+ * Production forward: re-encrypt to the original destination over a socket marked
+ * with the bypass SO_MARK BEFORE connect, so the OUTPUT-based TPROXY rule excludes
+ * it (anti-loop). Requires the native addon — exercised e2e on the VPS (3/N).
+ * The upstream cert is verified (`rejectUnauthorized` defaults to `true`), so the
+ * proxy rejects exactly what the original client would have rejected.
+ */
+export const realForward: TlsCaptureDeps["forward"] = createForward(
+  (ip, port) => new net.Socket({ fd: connectMarked(ip, port, DEFAULT_BYPASS_MARK) })
+);

--- a/src/shared/schemas/inspector.ts
+++ b/src/shared/schemas/inspector.ts
@@ -42,6 +42,6 @@ export const InspectorListQuerySchema = z.object({
   host: z.string().optional(),
   agent: z.string().optional(),
   status: z.enum(["2xx", "3xx", "4xx", "5xx", "error"]).optional(),
-  source: z.enum(["agent-bridge", "custom-host", "http-proxy", "system-proxy"]).optional(),
+  source: z.enum(["agent-bridge", "custom-host", "http-proxy", "system-proxy", "tproxy"]).optional(),
   sessionId: z.string().uuid().optional(),
 });

--- a/tests/unit/inspector-types.test.ts
+++ b/tests/unit/inspector-types.test.ts
@@ -39,6 +39,10 @@ test("InterceptedRequestSchema — rejects invalid source enum", () => {
   assert.ok(!InterceptedRequestSchema.safeParse({ ...validInterceptedRequest, source: "invalid-source" }).success);
 });
 
+test("InterceptedRequestSchema — accepts the tproxy source (decrypt capture mode)", () => {
+  assert.ok(InterceptedRequestSchema.safeParse({ ...validInterceptedRequest, source: "tproxy" }).success);
+});
+
 test("InterceptedRequestSchema — rejects negative requestSize", () => {
   assert.ok(!InterceptedRequestSchema.safeParse({ ...validInterceptedRequest, requestSize: -1 }).success);
 });

--- a/tests/unit/tproxy-tls-capture.test.ts
+++ b/tests/unit/tproxy-tls-capture.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Fase 3 / Epic A — TLS-terminating capture for TPROXY (decrypt 2/N).
+ *
+ * The decrypt engine TLS-terminates an intercepted client socket with a per-SNI
+ * leaf from the dynamic CA (#4173), feeds the plaintext to Node's HTTP parser,
+ * captures the exchange (source "tproxy"), and forwards it re-encrypted. The
+ * decrypt + capture path needs NO root/iptables/native addon, so it is proven
+ * here with a real local TLS round-trip: a client that trusts the dynamic CA
+ * connects, its request is decrypted + recorded, and the response from a real
+ * local HTTPS upstream flows back. (The anti-loop forward — `realForward` via
+ * `connectMarked` — is the only kernel-dependent piece, validated e2e on the VPS.)
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import net from "node:net";
+import tls from "node:tls";
+import https from "node:https";
+import {
+  isTlsClientHello,
+  resolveCaptureHost,
+  buildForwardHeaders,
+  createForward,
+  createTlsCaptureServer,
+} from "../../src/mitm/tproxy/tlsCapture.ts";
+import { DynamicCertStore, generateMitmCa } from "../../src/mitm/tproxy/dynamicCert.ts";
+import { globalTrafficBuffer } from "../../src/mitm/inspector/buffer.ts";
+
+test("isTlsClientHello matches only the TLS handshake content-type byte (0x16)", () => {
+  assert.equal(isTlsClientHello(0x16), true);
+  assert.equal(isTlsClientHello(0x47), false); // 'G' (start of an HTTP GET)
+  assert.equal(isTlsClientHello(0x00), false);
+});
+
+test("resolveCaptureHost prefers SNI, then Host header (port stripped), then dest IP", () => {
+  assert.equal(resolveCaptureHost("api.example.com", "other:443", "1.2.3.4"), "api.example.com");
+  assert.equal(resolveCaptureHost(undefined, "host.example:8443", "1.2.3.4"), "host.example");
+  assert.equal(resolveCaptureHost("", "  ", "1.2.3.4"), "1.2.3.4");
+});
+
+test("buildForwardHeaders drops hop-by-hop, keeps auth, and pins host", () => {
+  const out = buildForwardHeaders(
+    {
+      host: "old:443",
+      connection: "keep-alive",
+      "transfer-encoding": "chunked",
+      "content-length": "10",
+      authorization: "Bearer keep-me",
+      accept: "application/json",
+    },
+    "api.example.com"
+  );
+  assert.equal(out.host, "api.example.com");
+  assert.equal(out.authorization, "Bearer keep-me"); // upstream still authenticates
+  assert.equal(out.accept, "application/json");
+  assert.equal(out.connection, undefined);
+  assert.equal(out["transfer-encoding"], undefined);
+  assert.equal(out["content-length"], undefined);
+});
+
+async function startHttpsUpstream(): Promise<{ port: number; close: () => Promise<void> }> {
+  const up = await generateMitmCa("test upstream"); // any self-signed key+cert pair
+  const server = https.createServer({ key: up.key, cert: up.cert }, (req, res) => {
+    res.writeHead(200, { "content-type": "text/plain" });
+    res.end(`decrypted-roundtrip:${req.url ?? ""}`);
+  });
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", () => r()));
+  const addr = server.address();
+  const port = typeof addr === "object" && addr ? addr.port : 0;
+  return {
+    port,
+    close: () =>
+      new Promise<void>((res) => {
+        server.closeAllConnections?.();
+        server.close(() => res());
+      }),
+  };
+}
+
+function startEngineListener(
+  certStore: DynamicCertStore,
+  dest: { ip: string; port: number },
+  forward: ReturnType<typeof createForward>
+): Promise<{ port: number; close: () => Promise<void> }> {
+  const engine = createTlsCaptureServer(certStore, { forward });
+  const listener = net.createServer((sock) => engine.terminate(sock, dest));
+  return new Promise((resolve) => {
+    listener.listen(0, "127.0.0.1", () => {
+      const addr = listener.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      resolve({
+        port,
+        close: async () => {
+          await new Promise<void>((r) => listener.close(() => r()));
+          await engine.close();
+        },
+      });
+    });
+  });
+}
+
+function tlsRequest(
+  port: number,
+  servername: string,
+  ca: string,
+  rawRequest: string
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const client = tls.connect({ host: "127.0.0.1", port, ca, servername }, () => {
+      client.write(rawRequest);
+    });
+    const chunks: Buffer[] = [];
+    client.on("data", (c) => chunks.push(c));
+    client.on("end", () => {
+      client.destroy();
+      resolve(Buffer.concat(chunks).toString("utf8"));
+    });
+    client.once("error", reject);
+  });
+}
+
+test("decrypts an intercepted HTTPS request and captures it as source 'tproxy'", async () => {
+  globalTrafficBuffer.clear();
+  const upstream = await startHttpsUpstream();
+  const certStore = new DynamicCertStore("OmniRoute MITM CA (test)");
+  const caPem = await certStore.getCaCertPem();
+  // forward = direct TLS to the test upstream (no SO_MARK — native addon not needed
+  // here). The test upstream uses a self-signed cert, so opt out of verification
+  // explicitly (production `realForward` keeps the secure-by-default `true`).
+  const forward = createForward((ip, port) => net.connect(port, ip), { rejectUnauthorized: false });
+  const engine = await startEngineListener(certStore, { ip: "127.0.0.1", port: upstream.port }, forward);
+
+  try {
+    const body = await tlsRequest(
+      engine.port,
+      "api.example.com",
+      caPem,
+      "GET /v1/models HTTP/1.1\r\n" +
+        "Host: api.example.com\r\n" +
+        "authorization: Bearer sk-supersecret-token-abcdef0123456789\r\n" +
+        "Connection: close\r\n\r\n"
+    );
+
+    assert.match(body, /decrypted-roundtrip:\/v1\/models/, "client gets the upstream response");
+
+    await new Promise((r) => setTimeout(r, 40)); // buffer.update runs on the async path
+    const entry = globalTrafficBuffer.list().at(-1);
+    assert.ok(entry, "an entry was captured");
+    assert.equal(entry.source, "tproxy");
+    assert.equal(entry.method, "GET");
+    assert.equal(entry.host, "api.example.com", "host comes from the SNI servername");
+    assert.equal(entry.path, "/v1/models");
+    assert.equal(entry.status, 200);
+    assert.match(entry.responseBody ?? "", /decrypted-roundtrip/, "decrypted body is captured");
+    // the bearer token in the request must be masked in the buffer
+    assert.ok(
+      !JSON.stringify(entry.requestHeaders).includes("sk-supersecret-token-abcdef0123456789"),
+      "request secret is masked in the captured headers"
+    );
+  } finally {
+    await engine.close();
+    await upstream.close();
+  }
+});
+
+test("a forward failure is recorded as an error entry and the client gets 502", async () => {
+  globalTrafficBuffer.clear();
+  const certStore = new DynamicCertStore("OmniRoute MITM CA (test)");
+  const caPem = await certStore.getCaCertPem();
+  const failingForward = () => Promise.reject(new Error("upstream unreachable"));
+  const engine = await startEngineListener(
+    certStore,
+    { ip: "127.0.0.1", port: 1 },
+    failingForward as ReturnType<typeof createForward>
+  );
+
+  try {
+    const body = await tlsRequest(
+      engine.port,
+      "api.example.com",
+      caPem,
+      "GET /boom HTTP/1.1\r\nHost: api.example.com\r\nConnection: close\r\n\r\n"
+    );
+    assert.match(body, /502 Bad Gateway/, "client receives a 502 status line");
+
+    await new Promise((r) => setTimeout(r, 40));
+    const entry = globalTrafficBuffer.list().at(-1);
+    assert.ok(entry);
+    assert.equal(entry.source, "tproxy");
+    assert.equal(entry.status, "error");
+    assert.ok(entry.error && !entry.error.includes("at /"), "error is sanitized (no stack trace)");
+  } finally {
+    await engine.close();
+  }
+});


### PR DESCRIPTION
## Summary

Epic A / Fase 3 — **decrypt 2/N**. The transparent TPROXY listener (#4169) raw-pipes intercepted connections, so request/response **bodies stay opaque**. This adds the **decrypt engine** that makes captured TPROXY traffic visible in the Traffic Inspector.

`src/mitm/tproxy/tlsCapture.ts`:
- **TLS-terminates** the intercepted client socket with a per-SNI leaf issued on demand by the dynamic CA (#4173, `DynamicCertStore.createSNICallback()`).
- Feeds the decrypted plaintext to an internal `http.Server` (Node parses the HTTP request automatically — same trick as `inspector/httpProxyServer.ts`).
- **Captures** the exchange into `globalTrafficBuffer` with the new `source: "tproxy"` — headers sanitized, body secrets masked (reuses `sanitizeHeaders` / `maskSecret`).
- **Forwards** the request re-encrypted to the original destination. The forward is an injected seam:
  - real path opens its upstream socket via `connectMarked` (SO_MARK **before** connect) so the OUTPUT-based TPROXY rule excludes the proxy's own forward — **anti-loop**;
  - `https.request` gets `agent: false` so the custom `createConnection` (the marked socket) is actually honored — the default Agent would silently open its own unmarked socket and break the anti-loop;
  - upstream cert is **verified by default** (`rejectUnauthorized: true`) — the proxy rejects exactly what the original client would reject; self-signed upstreams require explicit opt-in.

`CaptureSource` gains `"tproxy"` (`src/mitm/inspector/types.ts` union + Zod enum; `src/shared/schemas/inspector.ts` list-query enum).

This is the **engine only**. Wiring it into the transparent listener (replacing the raw pipe in `captureMode.ts`), installing the CA in the OS trust store, the route + Traffic Inspector UI tab, and the VPS e2e-with-decrypt are **3/N**.

## Test Plan

`tests/unit/tproxy-tls-capture.test.ts` (5/5) — the decrypt + capture path needs **no root/iptables/native addon**, so it's proven with a **real local TLS round-trip**:
- [x] `isTlsClientHello`, `resolveCaptureHost`, `buildForwardHeaders` (pure)
- [x] **decrypt round-trip**: a client trusting the dynamic CA connects with SNI `api.example.com` → request is decrypted → captured as `source: "tproxy"` (host from SNI, path, method, status 200) → a real local HTTPS upstream's response flows back; the `Bearer` token in the request header is **masked** in the buffer.
- [x] forward failure → entry recorded `status: "error"` (sanitized, no stack) + client gets `502`.
- [x] `tests/unit/inspector-types.test.ts` — `InterceptedRequestSchema` accepts `source: "tproxy"`.

Validation: `typecheck:core` ✓, `lint` ✓ (0), `check:file-size` ✓, `check:docs-counts` ✓, `inspector-types` 12/12 ✓.

> The anti-loop forward (`connectMarked`) is the only kernel-dependent piece — it is validated **e2e on the VPS** when wired into the transparent listener (3/N), per the same path the earlier Epic A layers (#4139/#4144/#4148/#4156/#4160/#4169) were validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)