### PR TITLE
feat(memory): opt-in sqlite-vec int8 vector quantization (F4.4 Q2)

### DIFF
--- a/src/lib/memory/vectorStore.ts
+++ b/src/lib/memory/vectorStore.ts
@@ -76,10 +76,54 @@ const TOP_K_DEFAULT = Number(process.env["MEMORY_VEC_TOP_K"] ?? 20);
 
 /**
  * Encode a Float32Array as a Buffer of little-endian bytes.
- * sqlite-vec accepts this format for FLOAT[] column values.
+ * sqlite-vec accepts this format for FLOAT[] column values. For int8 tables the
+ * SAME float32 blob is passed and quantized in SQL via vec_quantize_int8.
  */
 function encodeVector(v: Float32Array): Buffer {
   return Buffer.from(v.buffer, v.byteOffset, v.byteLength);
+}
+
+// ──────────────── Quantization (F4.4 / Q2) ────────────────
+
+/** Vector storage quantization mode. Opt-in via MEMORY_VEC_QUANTIZATION=int8. */
+export type VecQuantization = "none" | "int8";
+
+/** Mode requested for a NEWLY (re)created vec table (env opt-in, default none). */
+function requestedVecQuantization(): VecQuantization {
+  return process.env["MEMORY_VEC_QUANTIZATION"] === "int8" ? "int8" : "none";
+}
+
+/**
+ * Mode actually in effect for the EXISTING table, derived from the stored
+ * signature. Reads/writes use this (not the env) so they always match the
+ * on-disk column type — an env change only takes effect on the next reset.
+ */
+function storedVecQuantization(signature: string | null): VecQuantization {
+  return signature && signature.endsWith(":int8") ? "int8" : "none";
+}
+
+/** Append the int8 marker so switching modes is a signature change → reindex. */
+function withQuantizationSignature(base: string, q: VecQuantization): string {
+  return q === "int8" ? `${base}:int8` : base;
+}
+
+/** vec0 column type for the embedding column. */
+function vecColumnType(dim: number, q: VecQuantization): string {
+  return q === "int8" ? `int8[${dim}]` : `FLOAT[${dim}]`;
+}
+
+/**
+ * SQL placeholder for a bound float32 blob. int8 tables quantize it in SQL via
+ * `vec_quantize_int8(?, 'unit')` (embeddings are unit-normalized); float32 tables
+ * bind the raw blob. The bound parameter is ALWAYS the float32 blob either way.
+ */
+function vecValueExpr(q: VecQuantization): string {
+  return q === "int8" ? "vec_quantize_int8(?, 'unit')" : "?";
+}
+
+/** Quantization mode of the live table (from the persisted signature). */
+function liveVecQuantization(): VecQuantization {
+  return storedVecQuantization(getMemoryVecMeta().embeddingSignature);
 }
 
 // ──────────────── Implementation ────────────────
@@ -88,11 +132,19 @@ class VectorStoreImpl implements VectorStore {
   async ensureReady(resolution: EmbeddingResolution): Promise<{ ready: boolean; reason: string }> {
     const db = getDbInstance();
     const meta = getMemoryVecMeta();
+    const requested = requestedVecQuantization();
 
-    // Signature changed (or first time with a known dim) → recreate with new dim.
-    if (resolution.dimensions !== null && resolution.signature !== meta.embeddingSignature) {
-      await this.resetForSignature(resolution.signature, resolution.dimensions);
-      return { ready: true, reason: `vec_memories recreated with dim=${resolution.dimensions}` };
+    // The quantization mode is folded into the signature so flipping it (e.g.
+    // none → int8) is detected as a signature change and triggers a reindex.
+    if (resolution.dimensions !== null) {
+      const effectiveSignature = withQuantizationSignature(resolution.signature, requested);
+      if (effectiveSignature !== meta.embeddingSignature) {
+        await this.resetForSignature(effectiveSignature, resolution.dimensions);
+        return {
+          ready: true,
+          reason: `vec_memories recreated with dim=${resolution.dimensions} (${requested})`,
+        };
+      }
     }
 
     // Already marked loaded → idempotent no-op.
@@ -100,15 +152,17 @@ class VectorStoreImpl implements VectorStore {
       return { ready: true, reason: "vec_memories already ready" };
     }
 
-    // Not yet loaded but we have a dim — create the table now.
+    // Not yet loaded but we have a dim — create the table now. Use the mode of the
+    // EXISTING data (from the stored signature) so the column type matches on-disk.
     if (resolution.dimensions !== null) {
       const dim = meta.activeDim ?? resolution.dimensions;
+      const q = storedVecQuantization(meta.embeddingSignature);
       try {
         db.exec(
-          `CREATE VIRTUAL TABLE IF NOT EXISTS vec_memories USING vec0(embedding FLOAT[${dim}])`,
+          `CREATE VIRTUAL TABLE IF NOT EXISTS vec_memories USING vec0(embedding ${vecColumnType(dim, q)})`,
         );
         setMemoryVecMeta({ vecLoaded: true, activeDim: dim });
-        return { ready: true, reason: `vec_memories created with dim=${dim}` };
+        return { ready: true, reason: `vec_memories created with dim=${dim} (${q})` };
       } catch (err: unknown) {
         const msg = sanitizeErrorMessage(err instanceof Error ? err.message : String(err));
         return { ready: false, reason: `failed to create vec_memories: ${msg}` };
@@ -132,8 +186,10 @@ class VectorStoreImpl implements VectorStore {
 
     // vec0 v0.1.9 requires BigInt for explicit rowid insertion — plain numbers are rejected.
     // INSERT OR REPLACE is not supported by vec0 — use DELETE + INSERT for upsert semantics.
+    // int8 tables quantize the float32 blob in SQL (vec_quantize_int8); float32 bind raw.
+    const q = liveVecQuantization();
     db.prepare("DELETE FROM vec_memories WHERE rowid = ?").run(BigInt(row.rowid));
-    db.prepare("INSERT INTO vec_memories(rowid, embedding) VALUES (?, ?)").run(
+    db.prepare(`INSERT INTO vec_memories(rowid, embedding) VALUES (?, ${vecValueExpr(q)})`).run(
       BigInt(row.rowid),
       encodeVector(vector),
     );
@@ -154,12 +210,13 @@ class VectorStoreImpl implements VectorStore {
     const db = getDbInstance();
     const k = topK > 0 ? topK : TOP_K_DEFAULT;
 
+    const q = liveVecQuantization();
     const rows = db
       .prepare(
         `SELECT m.id AS memory_id, v.distance
          FROM vec_memories v
          JOIN memories m ON m.rowid = v.rowid
-         WHERE v.embedding MATCH ?
+         WHERE v.embedding MATCH ${vecValueExpr(q)}
            AND ($apiKeyId IS NULL OR m.api_key_id = $apiKeyId)
            AND k = ?
          ORDER BY v.distance ASC`,
@@ -185,6 +242,7 @@ class VectorStoreImpl implements VectorStore {
     const db = getDbInstance();
     const k = topK > 0 ? topK : TOP_K_DEFAULT;
     const rrfK = RRF_K;
+    const q = liveVecQuantization();
 
     // SQLite does not support FULL OUTER JOIN — use UNION ALL + GROUP BY (RRF recipe).
     // Reference: https://alexgarcia.xyz/blog/2024/sqlite-vec-hybrid-search/
@@ -196,7 +254,7 @@ class VectorStoreImpl implements VectorStore {
                   v.distance AS vec_distance
            FROM vec_memories v
            JOIN memories m ON m.rowid = v.rowid
-           WHERE v.embedding MATCH ?
+           WHERE v.embedding MATCH ${vecValueExpr(q)}
              AND ($apiKeyId IS NULL OR m.api_key_id = $apiKeyId)
              AND k = ?
          ),
@@ -290,10 +348,12 @@ class VectorStoreImpl implements VectorStore {
 
   async resetForSignature(signature: string, dim: number): Promise<void> {
     const db = getDbInstance();
+    // The column type follows the mode encoded in the (effective) signature.
+    const q = storedVecQuantization(signature);
 
     // DROP + CREATE is intentionally destructive — triggers lazy backfill via F5.
     db.exec("DROP TABLE IF EXISTS vec_memories");
-    db.exec(`CREATE VIRTUAL TABLE vec_memories USING vec0(embedding FLOAT[${dim}])`);
+    db.exec(`CREATE VIRTUAL TABLE vec_memories USING vec0(embedding ${vecColumnType(dim, q)})`);
 
     markAllMemoriesNeedReindex();
     setMemoryVecMeta({

--- a/tests/unit/memory-vectorstore-int8-quant.test.ts
+++ b/tests/unit/memory-vectorstore-int8-quant.test.ts
@@ -1,0 +1,165 @@
+/**
+ * tests/unit/memory-vectorstore-int8-quant.test.ts
+ *
+ * F4.4 / Q2 — opt-in sqlite-vec int8 storage quantization.
+ *   - When MEMORY_VEC_QUANTIZATION=int8, ensureReady stores an ":int8"-suffixed
+ *     signature and creates the vec table with an int8[N] column (vectors stored
+ *     via vec_quantize_int8 'unit').
+ *   - Recall: int8 nearest-neighbor matches the exact float32 nearest-neighbor on
+ *     a deterministic fixture (top-1 identical, top-3 overlap >= 2/3).
+ *   - Switching mode (none -> int8) is a signature change → resetForSignature
+ *     recreates the table and marks all memories needs_reindex.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omr-vecstore-int8-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.DISABLE_SQLITE_AUTO_BACKUP = "true";
+
+const core = await import("../../src/lib/db/core.ts");
+const vsModule = await import("../../src/lib/memory/vectorStore.ts");
+const { getVectorStore, _resetVectorStoreSingleton } = vsModule;
+
+import type { EmbeddingResolution } from "../../src/lib/memory/embedding/types.ts";
+
+const DIM = 8;
+
+function makeResolution(): EmbeddingResolution {
+  return {
+    source: "remote",
+    model: "test/dim8",
+    dimensions: DIM,
+    signature: `test:dim8:${DIM}`,
+    reason: "test",
+  };
+}
+
+function vec(values: number[]): Float32Array {
+  return new Float32Array(values);
+}
+
+// Deterministic, well-separated unit-ish fixture (8 dims, 6 memories).
+const FIXTURE: Array<{ id: string; v: number[] }> = [
+  { id: "m0", v: [1, 0, 0, 0, 0, 0, 0, 0] },
+  { id: "m1", v: [0, 1, 0, 0, 0, 0, 0, 0] },
+  { id: "m2", v: [0, 0, 1, 0, 0, 0, 0, 0] },
+  { id: "m3", v: [0.6, 0.8, 0, 0, 0, 0, 0, 0] },
+  { id: "m4", v: [0, 0, 0, 1, 0, 0, 0, 0] },
+  { id: "m5", v: [0, 0, 0, 0, 0.7071, 0.7071, 0, 0] },
+];
+
+function l2(a: number[], b: number[]): number {
+  let s = 0;
+  for (let i = 0; i < a.length; i++) s += (a[i] - b[i]) ** 2;
+  return Math.sqrt(s);
+}
+
+function exactNearestIds(query: number[], k: number): string[] {
+  return [...FIXTURE]
+    .map((f) => ({ id: f.id, d: l2(f.v, query) }))
+    .sort((a, b) => a.d - b.d)
+    .slice(0, k)
+    .map((x) => x.id);
+}
+
+function cleanup() {
+  _resetVectorStoreSingleton();
+  core.resetDbInstance();
+  if (fs.existsSync(TEST_DATA_DIR)) fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+test.afterEach(() => {
+  delete process.env.MEMORY_VEC_QUANTIZATION;
+  cleanup();
+});
+
+test.after(() => {
+  core.resetDbInstance();
+  if (fs.existsSync(TEST_DATA_DIR)) fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+function getStoreOrSkip(t: { skip: (msg: string) => void }): ReturnType<typeof getVectorStore> {
+  _resetVectorStoreSingleton();
+  const store = getVectorStore();
+  if (store === null) {
+    t.skip("sqlite-vec not available in this environment — skipping");
+    return null;
+  }
+  return store;
+}
+
+function insertMemory(db: ReturnType<typeof core.getDbInstance>, id: string) {
+  db.prepare(
+    `INSERT INTO memories (id, api_key_id, type, key, content, created_at)
+     VALUES (?, 'key1', 'factual', ?, ?, datetime('now'))`,
+  ).run(id, `key-${id}`, `content-${id}`);
+}
+
+async function seedFixture(store: NonNullable<ReturnType<typeof getVectorStore>>) {
+  const db = core.getDbInstance();
+  await store.ensureReady(makeResolution());
+  for (const f of FIXTURE) {
+    insertMemory(db, f.id);
+    await store.upsertVector(f.id, vec(f.v));
+  }
+}
+
+test("int8 mode: ensureReady stores an ':int8' signature", async (t) => {
+  process.env.MEMORY_VEC_QUANTIZATION = "int8";
+  const store = getStoreOrSkip(t);
+  if (!store) return;
+
+  await store.ensureReady(makeResolution());
+  const stats = await store.stats();
+  assert.ok(
+    stats.signature?.endsWith(":int8"),
+    `signature must carry the int8 marker, got ${stats.signature}`,
+  );
+});
+
+test("int8 recall: nearest-neighbor matches exact float32 NN on the fixture", async (t) => {
+  process.env.MEMORY_VEC_QUANTIZATION = "int8";
+  const store = getStoreOrSkip(t);
+  if (!store) return;
+
+  await seedFixture(store);
+
+  // Query close to m2 ([0,0,1,...]).
+  const query = [0.05, 0.05, 0.95, 0, 0, 0, 0, 0];
+  const hits = await store.searchVector(vec(query), 3);
+  assert.ok(hits.length >= 1, "int8 search must return results");
+
+  const exact = exactNearestIds(query, 3);
+  assert.equal(hits[0].memoryId, exact[0], `top-1 must match exact NN (${exact[0]})`);
+
+  const overlap = hits.slice(0, 3).filter((h) => exact.includes(h.memoryId)).length;
+  assert.ok(overlap >= 2, `top-3 overlap must be >= 2/3 (got ${overlap}; int8=${hits
+    .map((h) => h.memoryId)
+    .join(",")} exact=${exact.join(",")})`);
+});
+
+test("switching none → int8 is a signature change that triggers reindex", async (t) => {
+  const store = getStoreOrSkip(t);
+  if (!store) return;
+
+  // Start in float32 mode and seed.
+  await seedFixture(store);
+  const before = await store.stats();
+  assert.ok(!before.signature?.endsWith(":int8"), "baseline should be float32 (no int8 marker)");
+
+  // Flip to int8 and re-run ensureReady → recreate + mark all needs_reindex.
+  process.env.MEMORY_VEC_QUANTIZATION = "int8";
+  const res = await store.ensureReady(makeResolution());
+  assert.match(res.reason, /recreated/i, "ensureReady must recreate the table on mode switch");
+
+  const after = await store.stats();
+  assert.ok(after.signature?.endsWith(":int8"), "signature must now carry the int8 marker");
+  assert.equal(after.rowCount, 0, "table recreated empty (vectors await reindex)");
+  assert.ok(after.needsReindex >= FIXTURE.length, "all memories must be marked needs_reindex");
+});


### PR DESCRIPTION
## F4.4 / Q2 — Opt-in sqlite-vec int8 vector quantization

Follow-up to #4187 (Q1, Qdrant). Closes the second half of the rodada4 **F4.4** gap — the
local sqlite-vec vector store now has an opt-in int8 storage mode.

### What
Adds **opt-in** int8 quantization to the local `vec_memories` (sqlite-vec) index. Default
is float32 — **unchanged behavior**. Enable with `MEMORY_VEC_QUANTIZATION=int8` for ~4×
less vector storage/IO with rescore-grade recall.

### How (surgical — one file)
- The mode is **folded into the embedding signature** (`:int8` suffix), so the existing
  `resetForSignature()` + `markAllMemoriesNeedReindex()` infra treats a mode flip as a
  representation change → DROP/CREATE the table as `int8[N]` + lazy reindex (re-embed).
- Reads/writes derive the mode from the **stored signature** (the live table's actual
  column type), not the env — so an env change only takes effect on the next reset, never a
  mid-flight column-type mismatch.
- Quantization happens in SQL via `vec_quantize_int8(?, 'unit')` (embeddings are
  unit-normalized); the bound parameter is always the float32 blob → `encodeVector`
  unchanged. `CREATE` / `INSERT` / `MATCH` (`searchVector` + `searchHybrid`) are all
  mode-aware.

### Why opt-in / never automatic
Switching modes is a **destructive** representation change (reindex required) — per the
spec's "what NOT to do", it is never applied automatically to existing data; the signature
mechanism makes the reindex explicit and observable (`needs_reindex`).

### Tests (TDD)
`tests/unit/memory-vectorstore-int8-quant.test.ts`:
- int8 mode stores a `:int8` signature;
- **recall** — int8 nearest-neighbor matches the exact float32 NN on a deterministic
  fixture (top-1 identical, top-3 overlap ≥ 2/3);
- `none → int8` switch recreates the table empty and marks all memories `needs_reindex`.

Regression: 30/30 incl. float32 `crud`/`ensure-ready`/`rrf`/`stats`/`load`; memory
`reindex`/`engine-status`/`store-sync` 23/23. `typecheck:core` / `lint` / `check:cycles` clean.

### Follow-ups (not here)
Qdrant binary mode tuning; a UI toggle + reindex-progress surface for the local mode.
