### PR TITLE
fix(combo): keep passthrough quota fallback scoped

### DIFF
--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -16,6 +16,7 @@ import {
   recordModelLockoutFailure,
   recordProviderFailure,
   isProviderExhaustedReason,
+  hasPerModelQuota,
   type ProviderProfile,
 } from "./accountFallback.ts";
 import { FETCH_TIMEOUT_MS, RateLimitReason } from "../config/constants.ts";
@@ -2521,8 +2522,12 @@ export async function handleComboChat({
           // same-provider targets are skipped immediately. API-key 429s still use
           // the short resilience cooldown, but explicit quota text should stop the
           // combo from trying another target for the same provider in this request.
+          // Passthrough/per-model-quota providers multiplex independent upstream
+          // models behind one provider connection; a quota 429 for one model must
+          // not skip fallback targets for another model on the same provider.
           const providerExhausted =
             Boolean(provider && provider !== "unknown") &&
+            !hasPerModelQuota(provider, rawModel) &&
             (isProviderExhaustedReason(fallbackResult) ||
               classifyErrorText(errorText) === RateLimitReason.QUOTA_EXHAUSTED);
           if (providerExhausted) {
@@ -3269,8 +3274,12 @@ async function handleRoundRobinCombo({
         // same-provider targets are skipped immediately. API-key 429s still use
         // the short resilience cooldown, but explicit quota text should stop the
         // combo from trying another target for the same provider in this request.
+        // Passthrough/per-model-quota providers multiplex independent upstream
+        // models behind one provider connection; a quota 429 for one model must
+        // not skip fallback targets for another model on the same provider.
         const providerExhausted =
           Boolean(provider && provider !== "unknown") &&
+          !hasPerModelQuota(provider, parseModel(modelStr).model || modelStr) &&
           (isProviderExhaustedReason(fallbackResult) ||
             classifyErrorText(errorText) === RateLimitReason.QUOTA_EXHAUSTED ||
             isAllAccountsRateLimited);

--- a/tests/unit/combo-prescreen.test.ts
+++ b/tests/unit/combo-prescreen.test.ts
@@ -203,3 +203,41 @@ test("pre-screen: backward compatible with all targets available", async () => {
   assert.equal(calls.length, 1);
   assert.equal(calls[0], "p1/m1");
 });
+
+test("priority combo: quota 429 on passthrough provider does not skip another model on same provider", async () => {
+  const calls: string[] = [];
+
+  const combo = await combosDb.createCombo({
+    name: "passthrough-quota-scope",
+    strategy: "priority",
+    models: ["antigravity/claude-opus-4-6-thinking", "antigravity/gemini-3-flash-agent"],
+  });
+
+  const response = await handleComboChat({
+    body: { ...reqBody, model: combo.name },
+    combo,
+    allCombos: [combo],
+    isModelAvailable: async () => true,
+    relayOptions: undefined,
+    signal: undefined,
+    settings: {},
+    log: makeLog(),
+    handleSingleModel: async (_body: unknown, modelStr: string) => {
+      calls.push(modelStr);
+      if (modelStr.includes("claude-opus")) {
+        return Response.json(
+          { error: { message: "quota exhausted for claude-opus-4-6-thinking" } },
+          { status: 429 }
+        );
+      }
+      return okResponse(modelStr);
+    },
+  });
+
+  assert.equal(response.status, 200);
+  assert.equal(calls.at(-1), "antigravity/gemini-3-flash-agent");
+  assert.ok(
+    calls.includes("antigravity/claude-opus-4-6-thinking"),
+    "first passthrough model should be attempted before fallback"
+  );
+});


### PR DESCRIPTION
## Summary

Fix combo fallback behavior for passthrough/per-model-quota providers such as `antigravity`.

When a quota-exhausted response is returned for one passthrough model, the combo router should not treat the whole provider as exhausted for the current request. Otherwise fallback targets on another model under the same provider (for example `antigravity/gemini-*`) are skipped even though their quota/account path may still be usable.

## What changed

- Import `hasPerModelQuota` in `open-sse/services/combo.ts`.
- In both priority and round-robin provider-exhaustion paths, only add a provider to whole-provider exhaustion when the model/provider does **not** use per-model quota semantics.
- Add a regression test proving that a 429/quota error on `antigravity/claude-opus-4-6-thinking` still allows fallback to `antigravity/gemini-3-flash-agent`.

## Why

`antigravity` is a passthrough provider with model-scoped quota behavior. A quota error for one upstream model should be scoped to that model/account path, not used to skip all subsequent fallback targets for the same provider.

## Test

```bash
DISABLE_SQLITE_AUTO_BACKUP=true node --max-old-space-size=8192 \
  --import tsx \
  --import ./open-sse/utils/setupPolyfill.ts \
  --import ./tests/_setup/isolateDataDir.ts \
  --test --test-force-exit tests/unit/combo-prescreen.test.ts
```

Result:

```text
1..6
# pass 6
# fail 0
```

Pre-commit `any-budget` hook also passed during commit.
