### PR TITLE
fix(compression): harden engines against I/O failures and misconfig (F5.3)

### DIFF
--- a/open-sse/services/compression/engines/index.ts
+++ b/open-sse/services/compression/engines/index.ts
@@ -9,7 +9,10 @@ import { llmlinguaEngine } from "./llmlingua/index.ts";
 let registered = false;
 
 export function registerBuiltinCompressionEngines(): void {
-  if (registered) return;
+  // The `registered` latch is a fast-path to skip the loop, but it must not block
+  // re-registration after clearCompressionEngineRegistry() empties the map (tests do this).
+  // Re-run when the registry was cleared so the builtins are restored.
+  if (registered && getCompressionEngine(liteEngine.id)) return;
   registered = true;
 
   if (!getCompressionEngine(liteEngine.id)) registerCompressionEngine(liteEngine);

--- a/open-sse/services/compression/engines/mcpAccessibility/index.ts
+++ b/open-sse/services/compression/engines/mcpAccessibility/index.ts
@@ -19,9 +19,14 @@ export function smartFilterText(text: string, config: McpAccessibilityConfig): s
   );
 
   if (out.length > config.maxTextChars) {
-    const headSize = config.maxTextChars - 300;
+    // Clamp to >=0: a maxTextChars below the 300-char tail reservation would make headSize
+    // negative, and slice(0, negative) counts from the END — silently keeping a wrong,
+    // oversized fragment instead of the intended head.
+    const headSize = Math.max(0, config.maxTextChars - 300);
     const head = out.slice(0, headSize);
-    const omitted = text.length - head.length;
+    // Measure omitted against the FILTERED text (out), not the raw input (text), which may
+    // have shrunk via noise removal / collapse above.
+    const omitted = out.length - head.length;
     out =
       `${head}\n\n... [truncated ${omitted} chars by OmniRoute MCP filter. ` +
       `Page is large; ask user to scroll/navigate to a specific section, or click an element with the refs shown above]`;

--- a/open-sse/services/compression/engines/rtk/filterLoader.ts
+++ b/open-sse/services/compression/engines/rtk/filterLoader.ts
@@ -130,10 +130,19 @@ function collectFilterSources(options: RtkFilterLoadOptions = {}): FilterSource[
 
   const builtinDir = getFiltersDir();
   if (fs.existsSync(builtinDir)) {
-    for (const file of fs
-      .readdirSync(builtinDir)
-      .filter((entry) => entry.endsWith(".json"))
-      .sort()) {
+    let builtinFiles: string[] = [];
+    try {
+      builtinFiles = fs
+        .readdirSync(builtinDir)
+        .filter((entry) => entry.endsWith(".json"))
+        .sort();
+    } catch {
+      // A read failure on the builtin dir (lost permission, TOCTOU after existsSync, NFS
+      // timeout, read-only container) must not fail the request — degrade to the filters
+      // already collected. listRtkCommandSamples guards readdirSync the same way.
+      builtinFiles = [];
+    }
+    for (const file of builtinFiles) {
       sources.push({
         source: "builtin",
         path: path.join(builtinDir, file),

--- a/open-sse/services/compression/engines/rtk/rawOutput.ts
+++ b/open-sse/services/compression/engines/rtk/rawOutput.ts
@@ -89,8 +89,14 @@ export function maybePersistRtkRawOutput(
   const id = safeId(`${now}:${commandSlug}:${raw.length}:${redaction.text}`);
   const dir = path.join(dataDir(), "rtk", "raw-output");
   const filePath = path.join(dir, `${now}-${commandSlug || "tool-output"}-${id}.log`);
-  fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(filePath, redaction.text);
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(filePath, redaction.text);
+  } catch {
+    // Best-effort capture: a disk error (ENOSPC / EACCES / read-only DATA_DIR) must NEVER
+    // fail the compression pipeline. Skip the capture, exactly like retention "never".
+    return null;
+  }
 
   // Sidecar metadata: the .log filename only carries a lossy command SLUG, so persist
   // the FULL command (and timestamp/flags) next to it. Keeps the .log pure output (the

--- a/tests/unit/compression/compression-registry-clear.test.ts
+++ b/tests/unit/compression/compression-registry-clear.test.ts
@@ -1,0 +1,28 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  registerBuiltinCompressionEngines,
+  clearCompressionEngineRegistry,
+  getCompressionEngine,
+} from "../../../open-sse/services/compression/index.ts";
+
+// F5.3: registerBuiltinCompressionEngines() guards on a module-level `registered` latch.
+// clearCompressionEngineRegistry() empties the engine map but does NOT reset that latch, so
+// a subsequent registerBuiltinCompressionEngines() no-ops and leaves the registry empty —
+// any getCompressionEngine() then returns null. This file runs in its own process so the
+// latch starts false (no cross-file interference).
+describe("builtin compression engine registration after clear", () => {
+  it("re-registers builtin engines after the registry is cleared", () => {
+    registerBuiltinCompressionEngines();
+    assert.ok(getCompressionEngine("rtk"), "builtins registered initially");
+
+    clearCompressionEngineRegistry();
+    assert.equal(getCompressionEngine("rtk"), null, "registry emptied by clear");
+
+    // The `registered` latch must not block this re-registration.
+    registerBuiltinCompressionEngines();
+    assert.ok(getCompressionEngine("rtk"), "builtins must repopulate after a clear");
+    assert.ok(getCompressionEngine("session-dedup"), "all builtins restored, not just one");
+  });
+});

--- a/tests/unit/compression/mcpAccessibility-clamp.test.ts
+++ b/tests/unit/compression/mcpAccessibility-clamp.test.ts
@@ -1,0 +1,46 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { smartFilterText } from "../../../open-sse/services/compression/engines/mcpAccessibility/index.ts";
+import { DEFAULT_MCP_ACCESSIBILITY_CONFIG } from "../../../open-sse/services/compression/engines/mcpAccessibility/constants.ts";
+
+// F5.3: `headSize = config.maxTextChars - 300` goes negative when maxTextChars is below the
+// 300-char tail reservation, and `out.slice(0, negative)` counts from the END — silently
+// keeping a wrong (and oversized) fragment instead of the intended head. maxTextChars is
+// only floored to > 0 on the write path, so a stored value in [1,300] reaches this code.
+test("clamps head to >=0 when maxTextChars is below the tail reservation (≤300)", () => {
+  const config = {
+    ...DEFAULT_MCP_ACCESSIBILITY_CONFIG,
+    maxTextChars: 50,
+    minLengthToProcess: 1,
+  };
+  const input = "A".repeat(500);
+  const out = smartFilterText(input, config);
+
+  // Bug: headSize = -250 → slice(0,-250) keeps the first 250 chars → output leaks a long
+  // run of 'A' and is far larger than maxTextChars. Fixed: headSize clamps to 0 → empty
+  // head → output is just the truncation notice (which contains no capital 'A').
+  assert.ok(!out.includes("A"), "head must be empty (clamped) — no leaked content from a negative slice");
+  assert.ok(out.includes("truncated"), "still emits the truncation notice");
+});
+
+test("reports omitted chars relative to the filtered text, not the raw input", () => {
+  // Noise lines get stripped before truncation, so `omitted` must be measured against the
+  // filtered text (`out`), not the longer raw `text`.
+  const noise = "- generic:\n".repeat(10); // stripped by NOISE_PATTERNS
+  const input = noise + "B".repeat(1000);
+  const config = {
+    ...DEFAULT_MCP_ACCESSIBILITY_CONFIG,
+    maxTextChars: 400,
+    minLengthToProcess: 1,
+  };
+  const out = smartFilterText(input, config);
+  const match = out.match(/truncated (\d+) chars/);
+  assert.ok(match, "emits a truncation notice with an omitted count");
+  const omitted = Number(match[1]);
+  // Filtered text is ~1010 chars; head keeps 100 → omitted ~910. The raw input is 1110, so
+  // the buggy `text.length - head.length` would report ~1010 (> filtered length).
+  assert.ok(
+    omitted <= 1000,
+    `omitted must reflect the filtered text (<=1000), got ${omitted}`
+  );
+});

--- a/tests/unit/compression/rtk-filter-loader-resilience.test.ts
+++ b/tests/unit/compression/rtk-filter-loader-resilience.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, afterEach, mock } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+import { loadRtkFilters } from "../../../open-sse/services/compression/engines/rtk/filterLoader.ts";
+
+// F5.3: collectFilterSources() enumerates the builtin filters dir with an unguarded
+// fs.readdirSync. A read failure there (lost permission, TOCTOU between existsSync and
+// readdirSync, NFS timeout, removed dir on a read-only container) must NOT propagate into
+// the compression pipeline — compression is best-effort and may never fail the request.
+describe("RTK filter loader resilience", () => {
+  afterEach(() => {
+    mock.restoreAll();
+    // Drop any cache poisoned during the mocked run.
+    loadRtkFilters({ refresh: true });
+  });
+
+  it("degrades gracefully (does not throw) when the builtin dir cannot be read", () => {
+    // The only readdirSync on the loadRtkFilters path is the builtin enumeration, so an
+    // unconditional throw exercises exactly that call site.
+    mock.method(fs, "readdirSync", () => {
+      throw Object.assign(new Error("EACCES (mock)"), { code: "EACCES" });
+    });
+
+    assert.doesNotThrow(() => loadRtkFilters({ refresh: true }));
+  });
+});

--- a/tests/unit/compression/rtk-raw-output.test.ts
+++ b/tests/unit/compression/rtk-raw-output.test.ts
@@ -128,4 +128,22 @@ describe("RTK raw output retention", () => {
     assert.ok(pointer);
     assert.ok(readRtkRawOutput(pointer.id)?.includes("[REDACTED"));
   });
+
+  it("never throws when the raw-output write fails (disk error → null pointer)", () => {
+    // Point DATA_DIR underneath a regular FILE so mkdirSync(recursive) throws ENOTDIR.
+    // maybePersistRtkRawOutput is best-effort capture: a write failure must degrade to a
+    // skipped capture (null), never propagate into the compression pipeline (F5.3).
+    const blocker = path.join(os.tmpdir(), `omniroute-rtk-blocked-${process.pid}-${Date.now()}`);
+    fs.writeFileSync(blocker, "x");
+    process.env.DATA_DIR = path.join(blocker, "nested");
+
+    let pointer: ReturnType<typeof maybePersistRtkRawOutput> | undefined;
+    assert.doesNotThrow(() => {
+      pointer = maybePersistRtkRawOutput("error: boom\n" + "noise\n".repeat(8), {
+        retention: "always",
+      });
+    });
+    assert.equal(pointer, null);
+    fs.rmSync(blocker, { force: true });
+  });
 });


### PR DESCRIPTION
## Contexto

Rodada 2 de code review (**F5.3**) dos engines de compressão (5 reviewers paralelos sobre o que vive em `release/v3.8.29`). Trust-but-verify aplicado a cada achado: 4 gaps reais de robustez confirmados e corrigidos com TDD (RED→GREEN), achados latentes/dead-code rastreados, e 1 achado real **deliberadamente deixado fora** por colidir com uma decisão de design testada (detalhe abaixo).

## Fixes (cada um com teste falhando→passando)

| Arquivo | Gap | Fix |
|---|---|---|
| `engines/rtk/rawOutput.ts` | Write primário do `.log` (`mkdirSync`+`writeFileSync`) **sem guard**, enquanto o sidecar já era best-effort. Erro de disco (ENOSPC/EACCES/`DATA_DIR` read-only) propagava no pipeline. | `try/catch` → retorna `null` (captura pulada), igual a `retention: "never"`. |
| `engines/rtk/filterLoader.ts` | `readdirSync` do dir de filtros builtin **sem guard** após `existsSync` (TOCTOU / permissão / NFS). | Degrada para os filtros já coletados, espelhando `listRtkCommandSamples`. |
| `engines/mcpAccessibility/index.ts` | `maxTextChars < 300` → `headSize` negativo → `slice(0, negativo)` conta **do fim**, mantendo fragmento errado e maior que o limite. (`maxTextChars` só é validado `> 0` no write path.) | `Math.max(0, …)` no `headSize`; `omitted` medido contra o texto **filtrado** (`out`), não o input cru. |
| `engines/index.ts` | `registerBuiltinCompressionEngines` travava no latch `registered` e **nunca re-registrava** após `clearCompressionEngineRegistry` esvaziar o mapa → registry vazio. | Re-executa quando o mapa foi limpo. |

Tema comum: **compressão é best-effort e nunca pode falhar a request** — guards de I/O + correção de slice negativo.

## Deixado de fora (achado real, decisão de design do owner)

O branch **default** (bailout OFF) de `applyStackedCompression`/`applyStackedCompressionAsync` chama `engine.apply()` sem `try/catch` — um engine que lança propaga (no path do combo fallback isso derruba o target silenciosamente). **Não corrigido aqui**: guardar isso sobrescreveria o design **opt-in** deliberado do TV1, que `bailout.test.ts` trava explicitamente (`"bail-out OFF (default): throwing engine propagates — unchanged existing behavior"`). As opções (tornar graceful-degradation o novo default vs. fazer o combo dar opt-in no bailout — que toca `combo.ts`, em refactor paralelo) são decisão de produto.

### Outros achados rastreados (latentes/YAGNI, não acionáveis agora)
- `reconstruct*` (headroom/ccr/session-dedup): **sem caller de produção** (dead code) → marker-collision é latente.
- `session-dedup` msgIdx composto: colisão só com ≥100k partes numa mensagem (reachability ~zero).
- ReDoS via pattern de filtro custom + gaps de redação (Basic auth) no `rawOutput`: hardening (store é local, sob `DATA_DIR`).
- `readRtkRawOutput` pointerId: **já mitigado na borda** (a rota valida `/^[a-f0-9]{24}$/` + exige auth de management).

## Validação
- TDD: 5 testes novos RED→GREEN (1 rawOutput, 1 filterLoader, 2 mcpAccessibility, 1 registry-clear).
- Suíte **completa** de compressão: **671/671** ✅ (0 regressões).
- `typecheck:core` ✅ · `eslint` (arquivos alterados) ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)