### PR TITLE
feat(compression): persist RTK grouping config (unlock R5 enableGrouping)

### DIFF
--- a/open-sse/services/compression/types.ts
+++ b/open-sse/services/compression/types.ts
@@ -230,6 +230,8 @@ export const DEFAULT_RTK_CONFIG: RtkConfig = {
   trustProjectFilters: false,
   rawOutputRetention: "never",
   rawOutputMaxBytes: 1_048_576,
+  enableGrouping: false,
+  groupingThreshold: 3,
 };
 
 export const DEFAULT_COMPRESSION_LANGUAGE_CONFIG: CompressionLanguageConfig = {

--- a/src/lib/db/compression.ts
+++ b/src/lib/db/compression.ts
@@ -171,6 +171,16 @@ function normalizeRtkConfig(value: unknown): RtkConfig {
       1024,
       10_000_000
     ),
+    enableGrouping:
+      typeof record.enableGrouping === "boolean"
+        ? record.enableGrouping
+        : (DEFAULT_RTK_CONFIG.enableGrouping ?? false),
+    groupingThreshold: boundedInt(
+      record.groupingThreshold,
+      DEFAULT_RTK_CONFIG.groupingThreshold ?? 3,
+      2,
+      100
+    ),
   };
 }
 

--- a/src/shared/validation/compressionConfigSchemas.ts
+++ b/src/shared/validation/compressionConfigSchemas.ts
@@ -49,6 +49,8 @@ export const rtkConfigSchema = z
     trustProjectFilters: z.boolean().optional(),
     rawOutputRetention: rtkRawOutputRetentionSchema.optional(),
     rawOutputMaxBytes: z.number().int().min(1024).max(10_000_000).optional(),
+    enableGrouping: z.boolean().optional(),
+    groupingThreshold: z.number().int().min(2).max(100).optional(),
   })
   .strict();
 

--- a/tests/unit/compression/rtk-grouping-config.test.ts
+++ b/tests/unit/compression/rtk-grouping-config.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, beforeEach, afterEach, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { rtkConfigSchema } from "../../../src/shared/validation/compressionConfigSchemas.ts";
+import { DEFAULT_RTK_CONFIG } from "../../../open-sse/services/compression/types.ts";
+
+// The RTK R5 grouping feature is read by the engine (config.enableGrouping / groupingThreshold)
+// but was unreachable in production: the Zod schema (.strict()) rejected the two fields on write
+// and normalizeRtkConfig dropped them on read. This proves both gates now let them through.
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-rtk-grouping-"));
+const ORIGINAL_DATA_DIR = process.env.DATA_DIR;
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../../src/lib/db/core.ts");
+const { getCompressionSettings, updateCompressionSettings } = await import(
+  "../../../src/lib/db/compression.ts"
+);
+
+describe("RTK grouping config persistence (R5)", () => {
+  beforeEach(() => {
+    core.resetDbInstance();
+    fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+    fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    core.resetDbInstance();
+  });
+
+  after(() => {
+    core.resetDbInstance();
+    fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+    if (ORIGINAL_DATA_DIR === undefined) delete process.env.DATA_DIR;
+    else process.env.DATA_DIR = ORIGINAL_DATA_DIR;
+  });
+
+  it("accepts enableGrouping / groupingThreshold on the write schema", () => {
+    assert.equal(
+      rtkConfigSchema.safeParse({ enableGrouping: true, groupingThreshold: 5 }).success,
+      true
+    );
+    // groupingThreshold below the minimum run length (2) is rejected.
+    assert.equal(rtkConfigSchema.safeParse({ groupingThreshold: 1 }).success, false);
+  });
+
+  it("preserves enableGrouping / groupingThreshold through a DB round-trip", async () => {
+    const settings = await updateCompressionSettings({
+      rtkConfig: { ...DEFAULT_RTK_CONFIG, enableGrouping: true, groupingThreshold: 7 },
+    });
+    assert.equal(settings.rtkConfig.enableGrouping, true);
+    assert.equal(settings.rtkConfig.groupingThreshold, 7);
+
+    // Survives a fresh read (not just the write-path return value).
+    core.resetDbInstance();
+    const reread = await getCompressionSettings();
+    assert.equal(reread.rtkConfig.enableGrouping, true);
+    assert.equal(reread.rtkConfig.groupingThreshold, 7);
+  });
+});


### PR DESCRIPTION
## Contexto
Programa **compressão 100% funcional** (follow-up da auditoria). Item: desbloquear o RTK grouping R5.

## Gap
A estratégia R5 (colapsar linhas consecutivas quase-equivalentes em `<linha> [rtk:grouped ×N]`) é **lida pelo engine** (`rtk/index.ts:330` `config.enableGrouping` / `:332` `groupingThreshold`), mas era **inalcançável em produção**:
- `rtkConfigSchema` (`.strict()`) **rejeitava** os 2 campos na escrita.
- `normalizeRtkConfig` os **dropava** na leitura do DB.

→ `enableGrouping` nunca podia ser nada além de `undefined` (sempre OFF).

## Fix
Adicionar `enableGrouping` (bool) + `groupingThreshold` (int, 2..100, default 3) a `DEFAULT_RTK_CONFIG`, `normalizeRtkConfig` e `rtkConfigSchema` → a feature agora é configurável e sobrevive ao round-trip do DB. **Default continua OFF** — zero mudança para configs existentes.

## Validação
- TDD: 2 testes novos RED→GREEN — (a) schema aceita os campos + rejeita `groupingThreshold:1`; (b) round-trip de DB (`updateCompressionSettings`→`getCompressionSettings`) preserva `enableGrouping:true`/`groupingThreshold:7`.
- Suíte **completa** de compressão: **673/673** ✅ — o teste existente "RTK grouping strategy (R5)" (engine aplica/não-aplica) segue passando; nenhuma regressão do shape de `DEFAULT_RTK_CONFIG`.
- `typecheck:core` ✅ · `eslint` ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)