### PR TITLE
feat(mitm): TPROXY capture-mode manager (decrypt 4a/N)

### DIFF
--- a/src/mitm/tproxy/captureManager.ts
+++ b/src/mitm/tproxy/captureManager.ts
@@ -1,0 +1,118 @@
+/**
+ * Fase 3 / Epic A — TPROXY capture-mode manager (decrypt 4a/N).
+ *
+ * Singleton lifecycle around the decrypt-capable transparent listener
+ * (`captureMode.ts`): builds the dynamic CA (#4173), gates on native-addon
+ * availability, holds the single running handle, counts interceptions, and
+ * exposes start / stop / status for a (local-only) route to drive.
+ *
+ * The OS trust-store mechanism is deliberately NOT baked in here: `installCa` /
+ * `uninstallCa` are injected by the caller (the route / VPS e2e provides the real
+ * installer, which needs its own trust-store slot so it does not clobber the
+ * static MITM cert). This keeps the manager unit-testable without root and means
+ * it never mutates the trust store on its own.
+ */
+import { DynamicCertStore } from "./dynamicCert";
+import { startTproxyCapture, type TproxyCaptureHandle } from "./captureMode";
+import { isTransparentSocketAvailable } from "./transparentSocket";
+import type { TproxyConfig } from "./commands";
+
+export interface CaptureManagerStatus {
+  /** Whether a capture session is currently running. */
+  running: boolean;
+  /** Whether the native IP_TRANSPARENT addon is loadable on this host. */
+  available: boolean;
+  /** ISO timestamp of when the running session started. */
+  startedAt?: string;
+  /** Number of connections intercepted in the running session. */
+  interceptCount?: number;
+  /** The transparent listener port of the running session. */
+  onPort?: number;
+}
+
+export interface CaptureManagerDeps {
+  startTproxyCapture: typeof startTproxyCapture;
+  isAvailable: () => boolean;
+  createCertStore: () => DynamicCertStore;
+  now: () => string;
+}
+
+const realDeps: CaptureManagerDeps = {
+  startTproxyCapture,
+  isAvailable: isTransparentSocketAvailable,
+  createCertStore: () => new DynamicCertStore(),
+  now: () => new Date().toISOString(),
+};
+
+export interface StartCaptureModeOptions {
+  cfg: TproxyConfig;
+  /** Install the dynamic CA cert (PEM) into the OS trust store. Injected so the
+   * manager never touches the trust store itself. */
+  installCa: (caPem: string) => Promise<void>;
+  /** Remove the CA from the trust store on stop (symmetric teardown). Injected. */
+  uninstallCa: () => Promise<void>;
+  /** Seam overrides for unit testing. */
+  deps?: Partial<CaptureManagerDeps>;
+}
+
+interface ActiveCapture {
+  handle: TproxyCaptureHandle;
+  startedAt: string;
+  intercepts: { count: number };
+}
+
+let active: ActiveCapture | null = null;
+
+/**
+ * Start the decrypt-capable TPROXY capture mode. Rejects if a session is already
+ * running or the native addon is unavailable. The dynamic CA is created here and
+ * installed in the trust store via the injected `installCa`.
+ */
+export async function startCaptureMode(
+  options: StartCaptureModeOptions
+): Promise<CaptureManagerStatus> {
+  if (active) throw new Error("TPROXY capture mode is already running");
+
+  const deps: CaptureManagerDeps = { ...realDeps, ...options.deps };
+  if (!deps.isAvailable()) {
+    throw new Error("TPROXY capture mode requires the native addon (Linux + CAP_NET_ADMIN).");
+  }
+
+  const certStore = deps.createCertStore();
+  const intercepts = { count: 0 };
+  const handle = await deps.startTproxyCapture(options.cfg, {
+    decrypt: { certStore, installCa: options.installCa, uninstallCa: options.uninstallCa },
+    onIntercept: () => {
+      intercepts.count += 1;
+    },
+  });
+  active = { handle, startedAt: deps.now(), intercepts };
+  return getCaptureStatus();
+}
+
+/** Stop the running capture session (closes the listener, uninstalls the CA, and
+ * reverts the rules via the handle). Idempotent — a no-op when nothing runs. */
+export async function stopCaptureMode(): Promise<CaptureManagerStatus> {
+  const current = active;
+  active = null;
+  if (current) await current.handle.stop();
+  return getCaptureStatus();
+}
+
+/** Current capture-mode status (safe to call any time, including when idle). */
+export function getCaptureStatus(): CaptureManagerStatus {
+  const available = isTransparentSocketAvailable();
+  if (!active) return { running: false, available };
+  return {
+    running: true,
+    available,
+    startedAt: active.startedAt,
+    interceptCount: active.intercepts.count,
+    onPort: active.handle.cfg.onPort,
+  };
+}
+
+/** Test-only: clear the singleton without invoking teardown. */
+export function __resetCaptureManager(): void {
+  active = null;
+}

--- a/tests/unit/tproxy-capture-manager.test.ts
+++ b/tests/unit/tproxy-capture-manager.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Fase 3 / Epic A — TPROXY capture-mode manager (decrypt 4a/N).
+ *
+ * The manager is the singleton lifecycle a (local-only) route drives: it gates on
+ * native-addon availability, builds the dynamic CA, wires the injected trust-store
+ * installer through to the decrypt listener, counts interceptions, and reports
+ * status. All effectful seams are injected so this is testable without root or the
+ * native addon. The real intercept/decrypt path was proven in #4169/#4179/#4200.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  startCaptureMode,
+  stopCaptureMode,
+  getCaptureStatus,
+  __resetCaptureManager,
+  type StartCaptureModeOptions,
+} from "../../src/mitm/tproxy/captureManager.ts";
+
+const CFG = { dport: 443, mark: 0x2333, onPort: 8443, routeTable: 233, bypassMark: 0x539 };
+
+interface CapturedStart {
+  cfg?: unknown;
+  options?: {
+    decrypt?: { installCa: (p: string) => Promise<void>; uninstallCa: () => Promise<void> };
+    onIntercept?: (info: { destIp: string; destPort: number }) => void;
+  };
+  stopped: boolean;
+}
+
+/** A fake `startTproxyCapture` that records what it was handed and returns a
+ * handle whose stop() flips a flag. */
+function fakeStart(rec: CapturedStart) {
+  return async (cfg: unknown, options: CapturedStart["options"]) => {
+    rec.cfg = cfg;
+    rec.options = options;
+    return {
+      cfg: cfg as never,
+      server: {} as never,
+      stop: async () => {
+        rec.stopped = true;
+      },
+    };
+  };
+}
+
+function baseOptions(over: Partial<StartCaptureModeOptions> = {}): StartCaptureModeOptions {
+  return {
+    cfg: CFG,
+    installCa: async () => {},
+    uninstallCa: async () => {},
+    ...over,
+  };
+}
+
+test.afterEach(() => __resetCaptureManager());
+
+test("startCaptureMode rejects when the native addon is unavailable", async () => {
+  await assert.rejects(
+    () => startCaptureMode(baseOptions({ deps: { isAvailable: () => false } })),
+    /native addon|CAP_NET_ADMIN/
+  );
+});
+
+test("startCaptureMode wires the injected CA installer into the decrypt listener", async () => {
+  const rec: CapturedStart = { stopped: false };
+  const installCa = async () => {};
+  const uninstallCa = async () => {};
+  const status = await startCaptureMode(
+    baseOptions({
+      installCa,
+      uninstallCa,
+      deps: { isAvailable: () => true, startTproxyCapture: fakeStart(rec) as never },
+    })
+  );
+  assert.equal(status.running, true);
+  assert.equal(status.onPort, 8443);
+  assert.equal(rec.options?.decrypt?.installCa, installCa, "installCa is passed through to decrypt");
+  assert.equal(rec.options?.decrypt?.uninstallCa, uninstallCa, "uninstallCa is passed through");
+});
+
+test("startCaptureMode refuses to start a second concurrent session", async () => {
+  const rec: CapturedStart = { stopped: false };
+  const deps = { isAvailable: () => true, startTproxyCapture: fakeStart(rec) as never };
+  await startCaptureMode(baseOptions({ deps }));
+  await assert.rejects(() => startCaptureMode(baseOptions({ deps })), /already running/);
+});
+
+test("stopCaptureMode stops the handle and clears the running state", async () => {
+  const rec: CapturedStart = { stopped: false };
+  await startCaptureMode(
+    baseOptions({ deps: { isAvailable: () => true, startTproxyCapture: fakeStart(rec) as never } })
+  );
+  const status = await stopCaptureMode();
+  assert.equal(rec.stopped, true, "the handle's stop() was invoked");
+  assert.equal(status.running, false);
+});
+
+test("stopCaptureMode is a no-op when nothing is running", async () => {
+  const status = await stopCaptureMode();
+  assert.equal(status.running, false);
+});
+
+test("getCaptureStatus counts interceptions reported by the listener", async () => {
+  const rec: CapturedStart = { stopped: false };
+  await startCaptureMode(
+    baseOptions({
+      deps: { isAvailable: () => true, startTproxyCapture: fakeStart(rec) as never },
+    })
+  );
+  rec.options?.onIntercept?.({ destIp: "1.2.3.4", destPort: 443 });
+  rec.options?.onIntercept?.({ destIp: "5.6.7.8", destPort: 443 });
+  const status = getCaptureStatus();
+  assert.equal(status.running, true);
+  assert.equal(status.interceptCount, 2);
+});
+
+test("getCaptureStatus reports not-running when idle", () => {
+  const status = getCaptureStatus();
+  assert.equal(status.running, false);
+  assert.equal(typeof status.available, "boolean");
+});


### PR DESCRIPTION
## Summary

Epic A / Fase 3 — **decrypt 4a/N**. A singleton lifecycle manager around the decrypt-capable transparent listener (#4200), so a local-only route (4b) can drive start / stop / status without re-deriving the orchestration.

`src/mitm/tproxy/captureManager.ts`:
- **`startCaptureMode`** — rejects when the native addon is unavailable or a session is already running; builds the dynamic CA (`DynamicCertStore`, #4173); wires the injected `installCa` / `uninstallCa` through to the decrypt listener; counts interceptions via `onIntercept`.
- **`stopCaptureMode`** — stops the running handle (which closes the listener, uninstalls the CA, and reverts the rules); idempotent no-op when nothing runs.
- **`getCaptureStatus`** — `{ running, available, startedAt, interceptCount, onPort }`.

**The manager never touches the OS trust store itself** — `installCa` / `uninstallCa` are injected. This is deliberate: the real Linux installer needs its **own trust-store slot** so it does not clobber the static MITM server cert (which `cert/install.ts::installCert` pins to a fixed `LINUX_CERT_NAME`), and that mechanism is best validated on the VPS. It also keeps the manager unit-testable without root or the native addon.

## Test Plan

`tests/unit/tproxy-capture-manager.test.ts` (7/7) — all seams injected, no root/addon:
- [x] start rejects when the native addon is unavailable.
- [x] start wires the injected `installCa`/`uninstallCa` through to the decrypt listener (`decrypt.installCa === installCa`) and reports `running` + `onPort`.
- [x] start refuses a second concurrent session (`already running`).
- [x] stop invokes the handle's `stop()` and clears running state.
- [x] stop is a no-op when idle.
- [x] status counts interceptions reported via `onIntercept`.
- [x] status reports not-running when idle.

Validation: `typecheck:core` ✓, `lint` ✓ (0).

> The intercept/decrypt/forward data path was proven e2e-locally in #4179 and unit-wired in #4200. **Next (4b):** the local-only API route + the real Linux trust-store installer (dedicated slot) + Traffic Inspector UI tab + **VPS e2e-with-decrypt** (real `connectMarked` + real CA install on the kernel) + addon prebuilds. `startCaptureMode` has no caller until that route lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)