### PR TITLE
chore(ci): add quota + 6 covered chatCore leaves to stryker mutate (QG v2 Fase 9 T5 Fase 3 follow-up)

### DIFF
--- a/.github/workflows/nightly-mutation.yml
+++ b/.github/workflows/nightly-mutation.yml
@@ -22,9 +22,10 @@ jobs:
     #   - Onda 3 / Fase 9 T5 re-add: combo.ts was split into 11 leaves; the 8 well-covered
     #     combo/* leaves are back in `mutate` (covered by the 24 combo-*.test.ts), grouped into
     #     2 batches (d=heavy, e=light). After #4204 (D7b) merged, the reset-aware quota pair
-    #     quotaScoring/quotaStrategies was added as batch f. chatCore/* leaves remain a follow-up
-    #     (covering-test audit) — see _mutate_godfiles_excluded_comment in stryker.conf.json.
-    # 6 PARALLEL batches, each overriding the mutate set via `--mutate` (Stryker 9 CLI:
+    #     quotaScoring/quotaStrategies was added as batch f. A covering-test audit then added the
+    #     6 chatCore/* leaves with direct unit coverage as batch g; the other 9 chatCore leaves
+    #     remain a follow-up — see _mutate_godfiles_excluded_comment in stryker.conf.json.
+    # 7 PARALLEL batches, each overriding the mutate set via `--mutate` (Stryker 9 CLI:
     # `-m, --mutate <comma-list>`; the conf's `mutate[]` remains the local-run default/union).
     # Each batch targets <180min; full coverage every night in parallel (~180min wall-clock).
     # The `incremental` cache (per-batch key) makes runs after the first cold one much cheaper,
@@ -47,6 +48,8 @@ jobs:
             mutate: "open-sse/services/combo/shadowRouting.ts,open-sse/services/combo/targetSorters.ts,open-sse/services/combo/comboPredicates.ts,open-sse/services/combo/rrState.ts,open-sse/services/combo/comboData.ts"
           - name: f
             mutate: "open-sse/services/combo/quotaScoring.ts,open-sse/services/combo/quotaStrategies.ts"
+          - name: g
+            mutate: "open-sse/handlers/chatCore/comboContextCache.ts,open-sse/handlers/chatCore/idempotency.ts,open-sse/handlers/chatCore/passthroughHelpers.ts,open-sse/handlers/chatCore/responseHeaders.ts,open-sse/handlers/chatCore/sanitization.ts,open-sse/handlers/chatCore/upstreamTimeouts.ts"
     timeout-minutes: 180
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/nightly-mutation.yml
+++ b/.github/workflows/nightly-mutation.yml
@@ -21,9 +21,10 @@ jobs:
     #     big modules are now ISOLATED into their own batches (a=auth, b=accountFallback).
     #   - Onda 3 / Fase 9 T5 re-add: combo.ts was split into 11 leaves; the 8 well-covered
     #     combo/* leaves are back in `mutate` (covered by the 24 combo-*.test.ts), grouped into
-    #     2 batches (d=heavy, e=light). chatCore/* leaves + quotaScoring/quotaStrategies (#4204)
-    #     are follow-ups — see _mutate_godfiles_excluded_comment in stryker.conf.json.
-    # 5 PARALLEL batches, each overriding the mutate set via `--mutate` (Stryker 9 CLI:
+    #     2 batches (d=heavy, e=light). After #4204 (D7b) merged, the reset-aware quota pair
+    #     quotaScoring/quotaStrategies was added as batch f. chatCore/* leaves remain a follow-up
+    #     (covering-test audit) — see _mutate_godfiles_excluded_comment in stryker.conf.json.
+    # 6 PARALLEL batches, each overriding the mutate set via `--mutate` (Stryker 9 CLI:
     # `-m, --mutate <comma-list>`; the conf's `mutate[]` remains the local-run default/union).
     # Each batch targets <180min; full coverage every night in parallel (~180min wall-clock).
     # The `incremental` cache (per-batch key) makes runs after the first cold one much cheaper,
@@ -44,6 +45,8 @@ jobs:
             mutate: "open-sse/services/combo/comboStructure.ts,open-sse/services/combo/autoStrategy.ts,open-sse/services/combo/validateQuality.ts"
           - name: e
             mutate: "open-sse/services/combo/shadowRouting.ts,open-sse/services/combo/targetSorters.ts,open-sse/services/combo/comboPredicates.ts,open-sse/services/combo/rrState.ts,open-sse/services/combo/comboData.ts"
+          - name: f
+            mutate: "open-sse/services/combo/quotaScoring.ts,open-sse/services/combo/quotaStrategies.ts"
     timeout-minutes: 180
     steps:
       - uses: actions/checkout@v6

--- a/stryker.conf.json
+++ b/stryker.conf.json
@@ -202,12 +202,20 @@
     "the 24 combo-*.test.ts files already in tap.testFiles (quota by combo-prescreen/combo-config/",
     "combo-strategy-fallbacks). types.ts is omitted (pure type declarations produce 0 mutants).",
     "",
+    "chatCore/* leaves: a covering-test audit (do any tap.testFiles reference each leaf's exported",
+    "function names?) found 6 with direct unit coverage — comboContextCache/idempotency/",
+    "passthroughHelpers/responseHeaders/sanitization/upstreamTimeouts — ADDED here (batch g).",
+    "",
     "STILL EXCLUDED (follow-ups, NOT in `mutate` yet):",
     "  - combo.ts + chatCore.ts barrels: their handleComboChat/handleChatCore CORES were not",
     "    split (out of scope — Fase 3 ChatCoreContext refactor). The barrels are now thin-ish",
     "    but still large; keep excluded until the cores are split.",
-    "  - chatCore/* leaves (15 modules): thinner test coverage (only ~7 chatcore-*.test.ts in",
-    "    tap.testFiles); add after a covering-test audit so they don't all 'survive (no coverage)'.",
+    "  - the other 9 chatCore/* leaves (executorHelpers/headers/logTruncation/memoryExtraction/",
+    "    memorySkillsInjection/nonStreamingSse/passthroughToolNames/semanticCache/telemetryHelpers):",
+    "    no tap.testFiles reference their exported symbols by name — they are only exercised",
+    "    TRANSITIVELY via handleChatCore, which the tap unit tests may not fully drive. Adding them",
+    "    blindly would produce 'survived (no coverage)' noise. Add each once it gains a dedicated",
+    "    unit test (or after a Stryker --dryRunOnly confirms the perTest map covers it).",
     "See project memory: Quality Gate v2 / Fase 9 (project-combo-split)."
   ],
   "mutate": [
@@ -226,7 +234,13 @@
     "open-sse/services/combo/rrState.ts",
     "open-sse/services/combo/comboData.ts",
     "open-sse/services/combo/quotaScoring.ts",
-    "open-sse/services/combo/quotaStrategies.ts"
+    "open-sse/services/combo/quotaStrategies.ts",
+    "open-sse/handlers/chatCore/comboContextCache.ts",
+    "open-sse/handlers/chatCore/idempotency.ts",
+    "open-sse/handlers/chatCore/passthroughHelpers.ts",
+    "open-sse/handlers/chatCore/responseHeaders.ts",
+    "open-sse/handlers/chatCore/sanitization.ts",
+    "open-sse/handlers/chatCore/upstreamTimeouts.ts"
   ],
   "_ignorePatterns_comment": [
     "ignorePatterns = files NOT copied into the Stryker sandbox. It does NOT scope",

--- a/stryker.conf.json
+++ b/stryker.conf.json
@@ -196,17 +196,16 @@
     "2026-06-18 (Onda 3 / Fase 9 T5 re-add): the combo.ts god-file was split into 11 small",
     "leaf modules under open-sse/services/combo/ (PRs #4162/#4175/#4186/#4196/#4204). The",
     "routing LOGIC that justified combo.ts being in `mutate` now lives in those leaves, so the",
-    "8 well-covered combo/* leaves are ADDED back to `mutate` here (comboStructure/autoStrategy/",
-    "validateQuality/shadowRouting/targetSorters/comboPredicates/rrState/comboData). They are",
-    "covered by the 24 combo-*.test.ts files already in tap.testFiles. types.ts is omitted",
-    "(pure type declarations produce 0 mutants).",
+    "10 well-covered combo/* leaves are ADDED back to `mutate` here (comboStructure/autoStrategy/",
+    "validateQuality/shadowRouting/targetSorters/comboPredicates/rrState/comboData + the reset-aware",
+    "quota pair quotaScoring/quotaStrategies, added after #4204 (D7b) merged). They are covered by",
+    "the 24 combo-*.test.ts files already in tap.testFiles (quota by combo-prescreen/combo-config/",
+    "combo-strategy-fallbacks). types.ts is omitted (pure type declarations produce 0 mutants).",
     "",
     "STILL EXCLUDED (follow-ups, NOT in `mutate` yet):",
     "  - combo.ts + chatCore.ts barrels: their handleComboChat/handleChatCore CORES were not",
     "    split (out of scope — Fase 3 ChatCoreContext refactor). The barrels are now thin-ish",
     "    but still large; keep excluded until the cores are split.",
-    "  - combo/quotaScoring.ts + combo/quotaStrategies.ts: in PR #4204 (D7b), not yet merged.",
-    "    Add them here once #4204 lands (they are covered by combo-prescreen/combo-config tests).",
     "  - chatCore/* leaves (15 modules): thinner test coverage (only ~7 chatcore-*.test.ts in",
     "    tap.testFiles); add after a covering-test audit so they don't all 'survive (no coverage)'.",
     "See project memory: Quality Gate v2 / Fase 9 (project-combo-split)."
@@ -225,7 +224,9 @@
     "open-sse/services/combo/targetSorters.ts",
     "open-sse/services/combo/comboPredicates.ts",
     "open-sse/services/combo/rrState.ts",
-    "open-sse/services/combo/comboData.ts"
+    "open-sse/services/combo/comboData.ts",
+    "open-sse/services/combo/quotaScoring.ts",
+    "open-sse/services/combo/quotaStrategies.ts"
   ],
   "_ignorePatterns_comment": [
     "ignorePatterns = files NOT copied into the Stryker sandbox. It does NOT scope",


### PR DESCRIPTION
## O que

Follow-up da **Fase 3** (#4205) — completa o re-add da lógica de routing/handler ao mutation testing após os splits. Config/CI apenas (nightly **advisory**).

### 1. Quota (após #4204 D7b mergear)
- +`combo/quotaScoring.ts` + `combo/quotaStrategies.ts` → **batch f**. Cobertos por `combo-prescreen`/`combo-config`/`combo-strategy-fallbacks`.

### 2. chatCore leaves (auditoria de cobertura)
Auditei cada um dos 15 `chatCore/*` leaves: "algum tap.testFile referencia os nomes das funções exportadas do leaf?". **6 têm cobertura direta** → adicionados como **batch g**:
`comboContextCache` · `idempotency` · `passthroughHelpers` · `responseHeaders` · `sanitization` · `upstreamTimeouts`

Os outros 9 (executorHelpers/headers/logTruncation/memoryExtraction/memorySkillsInjection/nonStreamingSse/passthroughToolNames/semanticCache/telemetryHelpers) só são exercitados **transitivamente** via `handleChatCore` — adicioná-los às cegas geraria ruído "survived (no coverage)". Deferidos até ganharem teste unitário dedicado (ou um `--dryRunOnly` confirmar a cobertura). Documentado no `_mutate_godfiles_excluded_comment`.

## Resultado
- `stryker.conf.json`: `mutate` 14 → **22** módulos (+2 quota, +6 chatCore).
- `nightly-mutation.yml`: batch-matrix 5 → **7 batches** (f=quota, g=chatCore-6).
- Run step injection-safe (`BATCH_MUTATE` env var).

## Validação
- `stryker.conf.json` parse OK (mutate=22) · `nightly-mutation.yml` YAML OK (7 batches) · todos os 22 paths existem · injection-safe preservado.
- Scores/timing reais vêm da execução noturna (advisory).

## Resta (Fase 3)
- 9 chatCore leaves sem teste dedicado · barrels `combo.ts`/`chatCore.ts` (após split dos cores — ChatCoreContext, sub-plano).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
