### PR TITLE
feat(dashboard): TPROXY decrypt capture toggle in Traffic Inspector (4c/N)

### DIFF
--- a/src/app/(dashboard)/dashboard/tools/traffic-inspector/components/CaptureModesToolbar.tsx
+++ b/src/app/(dashboard)/dashboard/tools/traffic-inspector/components/CaptureModesToolbar.tsx
@@ -1,10 +1,15 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
 import { cn } from "@/shared/utils/cn";
 import { CustomHostsManager } from "./CustomHostsManager";
 import { HttpProxySnippetCard } from "./HttpProxySnippetCard";
+import {
+  fetchTproxyStatus,
+  startTproxyCaptureMode,
+  stopTproxyCaptureMode,
+} from "@/lib/inspector/tproxyCaptureApi";
 
 interface CaptureModeState {
   agentBridge: boolean; // always on, cannot disable
@@ -29,9 +34,53 @@ export function CaptureModesToolbar({ customHostCount }: CaptureModesToolbarProp
   const [showProxy, setShowProxy] = useState(false);
   const [proxyPort] = useState(8080);
 
+  // TPROXY decrypt capture is real backend state (route #4211), gated on the
+  // native addon (Linux + root). Reflect the server status and drive start/stop.
+  const [tproxy, setTproxy] = useState<{
+    running: boolean;
+    available: boolean;
+    interceptCount?: number;
+  }>({ running: false, available: false });
+  const [tproxyBusy, setTproxyBusy] = useState(false);
+
+  useEffect(() => {
+    let alive = true;
+    fetchTproxyStatus()
+      .then((s) => {
+        if (alive) {
+          setTproxy({ running: s.running, available: s.available, interceptCount: s.interceptCount });
+        }
+      })
+      .catch(() => {
+        // status route unreachable → leave defaults (disabled toggle)
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
   const toggleMode = (key: keyof CaptureModeState) => {
     if (key === "agentBridge") return; // always on
     setModes((prev) => ({ ...prev, [key]: !prev[key] }));
+  };
+
+  const toggleTproxy = async () => {
+    if (!tproxy.available || tproxyBusy) return;
+    setTproxyBusy(true);
+    try {
+      const status = tproxy.running
+        ? await stopTproxyCaptureMode()
+        : await startTproxyCaptureMode();
+      setTproxy({
+        running: status.running,
+        available: status.available,
+        interceptCount: status.interceptCount,
+      });
+    } catch {
+      // keep the prior state; the route sanitizes + reports its own errors
+    } finally {
+      setTproxyBusy(false);
+    }
   };
 
   const buttons: Array<{
@@ -89,6 +138,32 @@ export function CaptureModesToolbar({ customHostCount }: CaptureModesToolbarProp
             </button>
           );
         })}
+
+        <button
+          type="button"
+          onClick={toggleTproxy}
+          disabled={!tproxy.available || tproxyBusy}
+          title={!tproxy.available ? t("tproxyModeUnavailable") : undefined}
+          className={cn(
+            "inline-flex items-center gap-1.5 rounded border px-2.5 py-1 text-xs font-medium transition-colors",
+            "focus-ring disabled:cursor-not-allowed disabled:opacity-50",
+            tproxy.running
+              ? "border-amber-500/50 bg-amber-900/30 text-amber-300"
+              : "border-border text-text-muted hover:text-text-main hover:bg-surface"
+          )}
+        >
+          <span
+            className={cn(
+              "inline-block h-1.5 w-1.5 rounded-full",
+              tproxy.running ? "bg-amber-400" : "bg-gray-600"
+            )}
+          />
+          {t("tproxyMode")}
+          {tproxy.running && typeof tproxy.interceptCount === "number" && (
+            <span className="text-amber-400">· {tproxy.interceptCount}</span>
+          )}
+          <span className="text-amber-400">⚠</span>
+        </button>
 
         <div className="ml-auto flex items-center gap-2">
           <button

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -8529,6 +8529,8 @@
     "httpProxyModeDesc": "Use HTTP_PROXY environment variable",
     "systemWideMode": "System-wide",
     "systemWideModeDesc": "Intercept all system traffic (advanced)",
+    "tproxyMode": "TPROXY Decrypt",
+    "tproxyModeUnavailable": "TPROXY decrypt requires Linux + root + the native addon",
     "filterBarTitle": "Filters",
     "profileLlmOnly": "LLM only",
     "profileCustom": "Custom",

--- a/src/lib/inspector/tproxyCaptureApi.ts
+++ b/src/lib/inspector/tproxyCaptureApi.ts
@@ -1,0 +1,60 @@
+/**
+ * Client-side fetch helpers for the TPROXY decrypt capture mode (Epic A, 4c/N).
+ *
+ * Drive the local-only route /api/tools/agent-bridge/tproxy (#4211):
+ *   - GET    → status (running / available / interceptCount / onPort)
+ *   - POST   → start (apply TPROXY rules + open transparent listener + install CA)
+ *   - DELETE → stop (close listener + uninstall CA + revert rules)
+ *
+ * Kept DOM-free so request/response/error handling is unit-testable by stubbing
+ * global.fetch. The status type is imported type-only so this client bundle never
+ * pulls the manager's native-addon / server dependencies.
+ */
+import type { CaptureManagerStatus } from "@/mitm/tproxy/captureManager";
+
+const ROUTE = "/api/tools/agent-bridge/tproxy";
+
+/** Extract the sanitized server error message, falling back to the status. */
+async function errorMessage(res: Response): Promise<string> {
+  const body = (await res.json().catch(() => null)) as { error?: { message?: string } } | null;
+  return body?.error?.message ?? `HTTP ${res.status}`;
+}
+
+async function requestJson<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, init);
+  if (!res.ok) throw new Error(await errorMessage(res));
+  return (await res.json()) as T;
+}
+
+/** Optional TPROXY config overrides + the sudo password (desktop, non-root only). */
+export interface StartTproxyOptions {
+  sudoPassword?: string;
+  dport?: number;
+  onPort?: number;
+  mark?: number;
+  routeTable?: number;
+  bypassMark?: number;
+}
+
+/** Current decrypt-capture status (safe to poll). */
+export function fetchTproxyStatus(): Promise<CaptureManagerStatus> {
+  return requestJson<CaptureManagerStatus>(ROUTE);
+}
+
+/** Start decrypt capture; resolves with the resulting status. */
+export function startTproxyCaptureMode(
+  options: StartTproxyOptions = {}
+): Promise<CaptureManagerStatus> {
+  return requestJson<{ ok: boolean; status: CaptureManagerStatus }>(ROUTE, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(options),
+  }).then((r) => r.status);
+}
+
+/** Stop decrypt capture; resolves with the resulting status. */
+export function stopTproxyCaptureMode(): Promise<CaptureManagerStatus> {
+  return requestJson<{ ok: boolean; status: CaptureManagerStatus }>(ROUTE, {
+    method: "DELETE",
+  }).then((r) => r.status);
+}

--- a/tests/unit/tproxy-capture-api.test.ts
+++ b/tests/unit/tproxy-capture-api.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Client-side fetch helpers the Traffic Inspector uses to drive the TPROXY
+ * decrypt capture route (#4211). Pure integration logic — no DOM — so it is
+ * unit-testable by stubbing global.fetch: each helper must hit the right
+ * method/URL, unwrap the status, and surface the sanitized server error on
+ * !res.ok (with an HTTP-status fallback when the body has no message).
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { fetchTproxyStatus, startTproxyCaptureMode, stopTproxyCaptureMode } = await import(
+  "../../src/lib/inspector/tproxyCaptureApi.ts"
+);
+
+type FetchCall = { url: string; init?: RequestInit };
+
+function stubFetch(handler: (call: FetchCall) => { ok: boolean; status?: number; body: unknown }) {
+  const calls: FetchCall[] = [];
+  const original = global.fetch;
+  global.fetch = (async (url: string, init?: RequestInit) => {
+    const call = { url: String(url), init };
+    calls.push(call);
+    const { ok, status = ok ? 200 : 500, body } = handler(call);
+    return { ok, status, json: async () => body } as unknown as Response;
+  }) as typeof fetch;
+  return {
+    calls,
+    restore() {
+      global.fetch = original;
+    },
+  };
+}
+
+const ROUTE = "/api/tools/agent-bridge/tproxy";
+
+test("fetchTproxyStatus GETs the route and returns the status", async () => {
+  const status = { running: true, available: true, interceptCount: 3, onPort: 8443 };
+  const f = stubFetch(() => ({ ok: true, body: status }));
+  try {
+    const result = await fetchTproxyStatus();
+    assert.equal(result.running, true);
+    assert.equal(result.interceptCount, 3);
+    assert.equal(f.calls[0].url, ROUTE);
+    assert.equal(f.calls[0].init, undefined, "status is a plain GET");
+  } finally {
+    f.restore();
+  }
+});
+
+test("startTproxyCaptureMode POSTs options and unwraps the resulting status", async () => {
+  const f = stubFetch(() => ({
+    ok: true,
+    body: { ok: true, status: { running: true, available: true, onPort: 9443 } },
+  }));
+  try {
+    const result = await startTproxyCaptureMode({ onPort: 9443, sudoPassword: "secret" });
+    assert.equal(result.running, true);
+    assert.equal(result.onPort, 9443);
+    assert.equal(f.calls[0].url, ROUTE);
+    assert.equal(f.calls[0].init?.method, "POST");
+    assert.equal(JSON.parse(String(f.calls[0].init?.body)).onPort, 9443);
+  } finally {
+    f.restore();
+  }
+});
+
+test("stopTproxyCaptureMode DELETEs and unwraps the resulting status", async () => {
+  const f = stubFetch(() => ({ ok: true, body: { ok: true, status: { running: false, available: true } } }));
+  try {
+    const result = await stopTproxyCaptureMode();
+    assert.equal(result.running, false);
+    assert.equal(f.calls[0].url, ROUTE);
+    assert.equal(f.calls[0].init?.method, "DELETE");
+  } finally {
+    f.restore();
+  }
+});
+
+test("a helper surfaces the sanitized server error message on !res.ok", async () => {
+  const f = stubFetch(() => ({
+    ok: false,
+    status: 500,
+    body: { error: { message: "TPROXY capture mode requires the native addon" } },
+  }));
+  try {
+    await assert.rejects(() => startTproxyCaptureMode(), /requires the native addon/);
+  } finally {
+    f.restore();
+  }
+});
+
+test("a helper falls back to the HTTP status when the error body has no message", async () => {
+  const f = stubFetch(() => ({ ok: false, status: 503, body: null }));
+  try {
+    await assert.rejects(() => fetchTproxyStatus(), /HTTP 503/);
+  } finally {
+    f.restore();
+  }
+});


### PR DESCRIPTION
## Summary

Epic A / Fase 3 — **decrypt 4c/N**. Surfaces the decrypt capture mode (route #4211) in the Traffic Inspector's capture-modes toolbar, so it's drivable from the dashboard.

- **`src/lib/inspector/tproxyCaptureApi.ts`** — DOM-free client helpers (`fetchTproxyStatus` / `startTproxyCaptureMode` / `stopTproxyCaptureMode`) driving `GET`/`POST`/`DELETE` `/api/tools/agent-bridge/tproxy`. The status type is imported **type-only**, so the client bundle never pulls the manager's native-addon / server deps. Mirrors the #4127 `agentBridgeMaintenanceApi` pattern — request/response/error handling is **unit-testable by stubbing `fetch`**.
- **`CaptureModesToolbar`** — a **"TPROXY Decrypt"** toggle reflecting the server status, **gated on availability** (disabled with an explanatory tooltip when the native addon is absent — Linux + root required), showing the live **intercept count** when running. Errors are swallowed in the UI (the route already sanitizes + reports them).
- **i18n** — `tproxyMode` + `tproxyModeUnavailable` added to **en.json only** (autotranslate fills the other 40 locales at release; CI i18n-ui-coverage stays well above its 65% threshold).

## Test Plan

`tests/unit/tproxy-capture-api.test.ts` (5/5) — stub `global.fetch`:
- [x] `fetchTproxyStatus` GETs the route and returns the status (plain GET, no init).
- [x] `startTproxyCaptureMode` POSTs the options and unwraps `{ ok, status } → status`.
- [x] `stopTproxyCaptureMode` DELETEs and unwraps the resulting status.
- [x] a helper surfaces the **sanitized server error message** on `!res.ok`.
- [x] a helper falls back to `HTTP <status>` when the error body has no message.

Validation: `typecheck:core` ✓, `lint` ✓ (0), `i18n:check-ui-coverage --threshold=65` ✓ (all 41 locales ≥ 65%), `check:cycles` ✓, `check:file-size` ✓, `check:docs-sync` ✓. No component test exists for the toolbar (UI component tests are advisory); the testable logic lives in the helper.

> The toggle calls the merged route, which on a non-Linux/non-root host reports `available:false` → the toggle renders disabled. The **live decrypt validation on the VPS** (real `connectMarked` + real CA install on the kernel, per Hard Rule #18) and addon prebuilds are the remaining **4d** step — now a simple flow: open the tab, toggle on, drive traffic, watch the `source:"tproxy"` captures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)