### PR TITLE
fix(sse): map reasoning_effort to DeepSeek V4's native {high, max} vocabulary

### DIFF
--- a/config/quality/file-size-baseline.json
+++ b/config/quality/file-size-baseline.json
@@ -57,7 +57,7 @@
   "frozen": {
     "open-sse/config/providerRegistry.ts": 4731,
     "open-sse/executors/antigravity.ts": 1664,
-    "open-sse/executors/base.ts": 1334,
+    "open-sse/executors/base.ts": 1358,
     "open-sse/executors/chatgpt-web.ts": 2870,
     "open-sse/executors/claude-web.ts": 1057,
     "open-sse/executors/codex.ts": 1447,

--- a/open-sse/executors/base.ts
+++ b/open-sse/executors/base.ts
@@ -288,6 +288,30 @@ export function sanitizeReasoningEffortForProvider(
     return next;
   }
 
+  // Native DeepSeek (api.deepseek.com) — V4 thinking mode accepts reasoning_effort
+  // ONLY as {high, max} (its own top tier is literally "max"). OmniRoute's internal
+  // scale is low|medium|high|xhigh where xhigh is the top, so map onto DeepSeek's
+  // vocabulary: xhigh → max (top→top), low|medium → high (below the enum floor).
+  // high/max pass through unchanged. Without this, the claude→openai translator's
+  // xhigh (and max-normalized-to-xhigh below) reaches DeepSeek as an unknown value,
+  // silently dropping the client's requested effort. This is the INVERSE of the
+  // OpenRouter-DeepSeek path, whose normalized API expects xhigh, not max (pi#4055).
+  if (provider === "deepseek") {
+    const mapped =
+      effortStr === "xhigh" ? "max" : effortStr === "low" || effortStr === "medium" ? "high" : null;
+    if (mapped && mapped !== effortStr) {
+      log?.info?.(
+        "REASONING_SANITIZE",
+        `deepseek/${modelStr}: normalized reasoning_effort ${effortStr} → ${mapped}`
+      );
+      const next: Record<string, unknown> = { ...b };
+      if (hasTopLevelReasoningEffort) next.reasoning_effort = mapped;
+      if (reasoning) next.reasoning = { ...reasoning, effort: mapped };
+      return next;
+    }
+    return body;
+  }
+
   const supportsXHigh = supportsXHighEffort(provider, modelStr);
   const shouldDowngradeXHigh = effortStr === "xhigh" && !supportsXHigh;
   const supportsXHighForMax = supportsXHigh;

--- a/tests/unit/base-executor-sanitize-effort.test.ts
+++ b/tests/unit/base-executor-sanitize-effort.test.ts
@@ -337,3 +337,102 @@ test("sanitizeReasoningEffortForProvider: non-object body returns unchanged", ()
   const arr: unknown[] = [];
   assert.equal(sanitizeReasoningEffortForProvider(arr, "xiaomi-mimo", "x", null), arr);
 });
+
+// ── Native DeepSeek (api.deepseek.com) ───────────────────────────────────────
+// DeepSeek V4 thinking mode accepts reasoning_effort ONLY as {high, max}. The
+// internal OmniRoute scale (low|medium|high|xhigh, xhigh = top) must be mapped
+// onto DeepSeek's native vocabulary so the client's requested effort is honored
+// instead of silently dropped to the default. This is the INVERSE of the
+// OpenRouter-DeepSeek path, whose normalized API expects xhigh, not max.
+
+test("sanitizeReasoningEffortForProvider: native deepseek maps xhigh → max", () => {
+  const log = makeLog();
+  const body = {
+    model: "deepseek-v4-pro",
+    reasoning_effort: "xhigh",
+    messages: [{ role: "user", content: "hi" }],
+  };
+  const result = sanitizeReasoningEffortForProvider(body, "deepseek", "deepseek-v4-pro", log);
+  assert.notEqual(result, body, "must return a new object when mutating");
+  assert.equal((result as any).reasoning_effort, "max");
+  assert.equal((result as any).model, "deepseek-v4-pro", "other fields preserved");
+  assert.ok(
+    log.messages.some(([tag, m]) => tag === "REASONING_SANITIZE" && /xhigh → max/.test(m)),
+    "logs the xhigh → max mapping"
+  );
+});
+
+test("sanitizeReasoningEffortForProvider: native deepseek preserves max", () => {
+  const log = makeLog();
+  const body = {
+    model: "deepseek-v4-flash",
+    reasoning_effort: "max",
+    messages: [{ role: "user", content: "hi" }],
+  };
+  const result = sanitizeReasoningEffortForProvider(body, "deepseek", "deepseek-v4-flash", log);
+  assert.equal(result, body, "max is DeepSeek's native top tier — passes through unchanged");
+  assert.equal((result as any).reasoning_effort, "max");
+  assert.equal(log.messages.length, 0);
+});
+
+test("sanitizeReasoningEffortForProvider: native deepseek clamps low → high", () => {
+  const body = {
+    model: "deepseek-v4-pro",
+    reasoning_effort: "low",
+    messages: [{ role: "user", content: "hi" }],
+  };
+  const result = sanitizeReasoningEffortForProvider(body, "deepseek", "deepseek-v4-pro", null);
+  assert.notEqual(result, body, "must return a new object when mutating");
+  assert.equal((result as any).reasoning_effort, "high", "below the {high, max} floor → high");
+});
+
+test("sanitizeReasoningEffortForProvider: native deepseek clamps medium → high", () => {
+  const body = {
+    model: "deepseek-v4-pro",
+    reasoning_effort: "medium",
+    messages: [{ role: "user", content: "hi" }],
+  };
+  const result = sanitizeReasoningEffortForProvider(body, "deepseek", "deepseek-v4-pro", null);
+  assert.equal((result as any).reasoning_effort, "high");
+});
+
+test("sanitizeReasoningEffortForProvider: native deepseek preserves high unchanged", () => {
+  const body = {
+    model: "deepseek-v4-pro",
+    reasoning_effort: "high",
+    messages: [{ role: "user", content: "hi" }],
+  };
+  const result = sanitizeReasoningEffortForProvider(body, "deepseek", "deepseek-v4-pro", null);
+  assert.equal(result, body, "high is already valid — passes through unchanged");
+  assert.equal((result as any).reasoning_effort, "high");
+});
+
+test("sanitizeReasoningEffortForProvider: native deepseek maps nested reasoning.effort xhigh → max", () => {
+  const body = {
+    model: "deepseek-v4-pro",
+    reasoning: { effort: "xhigh", summary: "auto" },
+    input: [],
+  };
+  const result = sanitizeReasoningEffortForProvider(body, "deepseek", "deepseek-v4-pro", null);
+  assert.equal((result as any).reasoning.effort, "max");
+  assert.equal((result as any).reasoning.summary, "auto", "other reasoning fields preserved");
+  assert.equal((result as any).reasoning_effort, undefined);
+});
+
+test("sanitizeReasoningEffortForProvider: OpenRouter DeepSeek still preserves xhigh (not native)", () => {
+  // Regression guard: the native-deepseek mapping must NOT touch openrouter,
+  // whose normalized API expects xhigh (issue earendil-works/pi#4055).
+  const body = {
+    model: "deepseek/deepseek-v4-pro",
+    reasoning_effort: "xhigh",
+    messages: [{ role: "user", content: "hi" }],
+  };
+  const result = sanitizeReasoningEffortForProvider(
+    body,
+    "openrouter",
+    "deepseek/deepseek-v4-pro",
+    null
+  );
+  assert.equal(result, body);
+  assert.equal((result as any).reasoning_effort, "xhigh");
+});


### PR DESCRIPTION
## Contexto

A DeepSeek lançou o **V4** (`deepseek-v4-flash` / `deepseek-v4-pro`, 1M ctx, 384K saída). O thinking mode do V4 aceita `reasoning_effort` **apenas** como `{high, max}` — o topo da escala da DeepSeek se chama literalmente `max` ([docs](https://api-docs.deepseek.com/guides/thinking_mode)).

A escala interna do OmniRoute é `low | medium | high | xhigh` (com `xhigh` no topo), e o tradutor `claude→openai` emite `xhigh` quando um cliente (ex.: Claude Code) manda `output_config.effort=max`.

## Bug

Para o provider **nativo** `deepseek` (`api.deepseek.com`), esse valor chegava ao upstream sem mapeamento:

- `xhigh` passava direto → a DeepSeek nativa **não conhece** `xhigh`;
- um `max` explícito era inclusive **normalizado para `xhigh`** pelo caminho genérico OpenAI-shape (`supportsMaxEffortForProvider` é só Claude/CC) — ou seja, o cliente pedia `max` e saía `xhigh`;
- `low`/`medium` passavam direto (fora do enum `{high, max}`).

Resultado: o esforço pedido pelo cliente era **silenciosamente descartado** (a DeepSeek caía no default), na pior hipótese um 400. Exatamente um "parâmetro com valor diferente" que o filtro por-provider deveria pegar.

## Fix

Branch nativo-deepseek em `sanitizeReasoningEffortForProvider` (`open-sse/executors/base.ts`), antes do caminho genérico:

| entrada | saída |
|---|---|
| `xhigh` | `max` (topo→topo) |
| `low` / `medium` | `high` (abaixo do piso do enum) |
| `high` / `max` | inalterado |

Cobre tanto `reasoning_effort` top-level quanto `reasoning.effort` aninhado. É o **inverso** do caminho OpenRouter-DeepSeek (cuja API normalizada espera `xhigh`, não `max` — [pi#4055](https://github.com/earendil-works/pi/issues/4055)); esse caminho é escopado em `provider === "openrouter"` e fica intocado.

> Escopo restrito ao provider `deepseek` nativo. O `deepseek-web` (executor próprio) e os que roteiam DeepSeek-V4 por backends próprios (fireworks/deepinfra/openrouter/etc.) não são afetados.

## Validação (Hard Rule #18 — TDD)

- **7 novos casos** em `base-executor-sanitize-effort.test.ts` (RED→GREEN): `xhigh→max`, `max` preservado, `low→high`, `medium→high`, `high` preservado, `reasoning.effort` aninhado, e um **regression guard** confirmando que `openrouter` deepseek continua preservando `xhigh`.
- `node --test base-executor-sanitize-effort.test.ts` → **28/28** (21 originais sem regressão + 7 novos).
- Cluster deepseek-adjacente (`provider-models-config`, `chatcore-translation-paths`, `executor-default-base`, `t31-t33-t34-t38-model-specs`) → **125/125**.
- `typecheck:core` limpo · `eslint` 0 errors · `check:file-size` OK (baseline `base.ts` 1334→1358) · `check:any-budget:t11` OK (`base.ts` mantém 0 `any`).

## Fora de escopo (achados da mesma análise, sem ação aqui)

- `thinking:{type:"disabled"}` — o V4 pensa por padrão; não há caminho non-thinking. Custo/latência, não é erro.
- temperature/top_p/penalties não-stripados — a DeepSeek **ignora sem erro** (doc explícita). Limpeza opcional.
- Depreciação de `deepseek-chat`/`deepseek-reasoner` em 2026/07/24; FIM/chat-prefix beta (`/beta`). Nicho.