### PR TITLE
feat(compression): runnable A/B benchmark CLI (F2.4)

### DIFF
--- a/open-sse/services/compression/harness/benchmark.ts
+++ b/open-sse/services/compression/harness/benchmark.ts
@@ -284,3 +284,35 @@ export function runBenchmarkGate(
     return { engine, gate };
   });
 }
+
+// ── CLI helpers ────────────────────────────────────────────────────────────────
+
+/**
+ * Deterministic engines suitable for the sandbox A/B. `llmlingua` is excluded because its real
+ * compression is async-only and needs the MobileBERT ONNX model at runtime; add it once the
+ * model is provisioned (the framework is engine-agnostic).
+ */
+export const DEFAULT_BENCHMARK_ENGINES: string[] = [
+  "lite",
+  "caveman",
+  "aggressive",
+  "ultra",
+  "rtk",
+  "session-dedup",
+  "headroom",
+  "ccr",
+];
+
+/**
+ * Render an A/B summary (from {@link compareReports}) as a GitHub-flavored markdown table,
+ * best-first with the top engine bolded. Pure — used by the `bench:compression` CLI.
+ */
+export function formatBenchmarkTable(rows: EngineSummaryRow[]): string {
+  const header = "| Engine | Mean Savings % | Mean Retention | Total Compressed Tokens |";
+  const sep = "| --- | ---: | ---: | ---: |";
+  const body = rows.map((r, i) => {
+    const engine = i === 0 ? `**${r.engine}**` : r.engine;
+    return `| ${engine} | ${r.meanSavingsPercent.toFixed(1)} | ${r.meanRetention.toFixed(3)} | ${r.totalCompressedTokens} |`;
+  });
+  return [header, sep, ...body].join("\n");
+}

--- a/open-sse/services/compression/harness/index.ts
+++ b/open-sse/services/compression/harness/index.ts
@@ -35,3 +35,15 @@ export {
   type Transcript,
   type TranscriptTurn,
 } from "./replay.ts";
+
+export {
+  BENCHMARK_CORPUS,
+  DEFAULT_BENCHMARK_ENGINES,
+  engineToCompressFn,
+  benchmarkEngines,
+  compareReports,
+  runBenchmarkGate,
+  formatBenchmarkTable,
+  type EngineSummaryRow,
+  type EngineBenchmarkGateRow,
+} from "./benchmark.ts";

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "dev": "node scripts/dev/run-next.mjs dev",
     "prebuild:docs": "node scripts/docs/gen-openapi-module.mjs",
     "gen:provider-reference": "node --import tsx scripts/docs/gen-provider-reference.ts",
+    "bench:compression": "node --import tsx scripts/compression/benchmark.ts",
     "build": "node scripts/build/build-next-isolated.mjs",
     "build:secure": "OMNIROUTE_BUILD_PROFILE=minimal node scripts/build/build-next-isolated.mjs",
     "build:cli": "node --import tsx scripts/build/prepublish.ts",

--- a/scripts/compression/benchmark.ts
+++ b/scripts/compression/benchmark.ts
@@ -1,0 +1,39 @@
+/**
+ * Compression engine A/B benchmark CLI (F2.4 / L2).
+ *
+ * Runs the deterministic compression engines over BENCHMARK_CORPUS through the C1 harness and
+ * prints a best-first markdown table, so the default engine can be chosen from real numbers
+ * rather than intuition. Deterministic and API-free (safe in CI / local dev).
+ *
+ * Usage:
+ *   npm run bench:compression            # the default deterministic engine set
+ *   npm run bench:compression rtk lite   # a specific subset
+ *
+ * llmlingua is excluded by default — its real compression needs the ONNX model at runtime
+ * (pass it explicitly once provisioned; the framework is engine-agnostic).
+ */
+import {
+  BENCHMARK_CORPUS,
+  DEFAULT_BENCHMARK_ENGINES,
+  benchmarkEngines,
+  compareReports,
+  formatBenchmarkTable,
+} from "../../open-sse/services/compression/harness/benchmark.ts";
+
+async function main(): Promise<void> {
+  const requested = process.argv.slice(2).filter((arg) => !arg.startsWith("-"));
+  const engines = requested.length > 0 ? requested : DEFAULT_BENCHMARK_ENGINES;
+
+  const reports = await benchmarkEngines(BENCHMARK_CORPUS, engines);
+  const rows = compareReports(reports);
+
+  console.log("# Compression engine A/B benchmark (F2.4)\n");
+  console.log(`Corpus: ${BENCHMARK_CORPUS.length} cases · engines: ${engines.join(", ")}\n`);
+  console.log(formatBenchmarkTable(rows));
+  console.log("");
+}
+
+main().catch((err) => {
+  console.error("benchmark failed:", err instanceof Error ? err.message : err);
+  process.exitCode = 1;
+});

--- a/tests/unit/compression/compression-benchmark-cli.test.ts
+++ b/tests/unit/compression/compression-benchmark-cli.test.ts
@@ -1,0 +1,49 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  BENCHMARK_CORPUS,
+  DEFAULT_BENCHMARK_ENGINES,
+  benchmarkEngines,
+  compareReports,
+  formatBenchmarkTable,
+} from "../../../open-sse/services/compression/harness/benchmark.ts";
+
+// F2.4: the benchmark harness existed but nothing invoked it and there was no report output.
+// These cover the CLI's core: a markdown formatter + a default engine set that resolves and
+// runs the corpus end-to-end, so `npm run bench:compression` produces a real A/B table.
+describe("compression benchmark CLI core", () => {
+  it("formatBenchmarkTable renders a markdown table with the best engine bolded", () => {
+    const md = formatBenchmarkTable([
+      { engine: "rtk", meanSavingsPercent: 42.5, meanRetention: 0.9, totalCompressedTokens: 100 },
+      { engine: "lite", meanSavingsPercent: 10, meanRetention: 0.99, totalCompressedTokens: 200 },
+    ]);
+    assert.match(md, /\| Engine \|/, "has a header row");
+    assert.match(md, /\*\*rtk\*\*/, "best (first) engine is bolded");
+    assert.match(md, /42\.5/, "renders the savings number");
+    assert.match(md, /\blite\b/, "renders the runner-up");
+    assert.ok(!md.includes("**lite**"), "only the best engine is bolded");
+  });
+
+  it("DEFAULT_BENCHMARK_ENGINES all resolve and run the corpus end-to-end", async () => {
+    assert.ok(DEFAULT_BENCHMARK_ENGINES.length > 0, "has a default engine set");
+    assert.ok(
+      !DEFAULT_BENCHMARK_ENGINES.includes("llmlingua"),
+      "excludes llmlingua (needs the ONNX model at runtime)"
+    );
+
+    const reports = await benchmarkEngines(BENCHMARK_CORPUS, DEFAULT_BENCHMARK_ENGINES);
+    const rows = compareReports(reports);
+    assert.equal(rows.length, DEFAULT_BENCHMARK_ENGINES.length);
+    for (const id of DEFAULT_BENCHMARK_ENGINES) {
+      assert.ok(
+        rows.some((r) => r.engine === id),
+        `${id} present in the comparison table`
+      );
+    }
+    // The formatted table is non-empty and lists every engine.
+    const md = formatBenchmarkTable(rows);
+    for (const id of DEFAULT_BENCHMARK_ENGINES) {
+      assert.ok(md.includes(id), `${id} appears in the markdown table`);
+    }
+  });
+});


### PR DESCRIPTION
## Contexto
Programa **compressão 100% funcional** — item **F2.4**. O harness de benchmark (`benchmarkEngines`/`compareReports`/`BENCHMARK_CORPUS`) existia e era testado, mas **nada o invocava**, não era re-exportado do barrel, e não havia saída de relatório → F2.4 era scaffold test-only.

## O que muda
- **Formatter markdown** `formatBenchmarkTable` (best-first, melhor engine em **negrito**) + **set default** `DEFAULT_BENCHMARK_ENGINES` (8 engines determinísticos; `llmlingua` excluído — precisa do modelo ONNX em runtime).
- **Re-export** da API do benchmark em `harness/index.ts`.
- **CLI** `scripts/compression/benchmark.ts` + script **`npm run bench:compression [engineId ...]`** que roda o corpus e imprime a tabela A/B.

## Saída real (validação real-environment)
```
| Engine | Mean Savings % | Mean Retention | Total Compressed Tokens |
| --- | ---: | ---: | ---: |
| **ccr** | 36.5 | 0.600 | 383 |
| ultra | 19.7 | 0.900 | 532 |
| lite | 0.0 | 1.000 | 670 |
| ... (rtk/caveman/aggressive/session-dedup/headroom) | 0.0 | 1.000 | 670 |
```
Números honestos: o adapter envolve uma string única como 1 mensagem `user`, então rtk/caveman (que comprimem tool-results/multi-msg) marcam ~0% nesse corpus — o benchmark surfacing isso é o ponto.

## Follow-ups rastreados
- N4 budget-gate ratchet (`budgetGate.ts` com baseline commitado + CI) — `runBenchmarkGate` já existe.
- A/B real do `llmlingua` (precisa do modelo ONNX) — framework é engine-agnostic, basta passar o id.

## Validação
- TDD: 2 testes RED→GREEN — `formatBenchmarkTable` (markdown, best bolded) + `DEFAULT_BENCHMARK_ENGINES` resolvem e rodam o corpus end-to-end.
- **CLI rodado de verdade** (`npm run bench:compression`) → tabela acima, exit 0.
- Suíte de compressão verde (incl. `benchmark.test.ts` "reproducibility") · `typecheck:core` ✅ · `eslint` ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)