### PR TITLE
chore(compression): remove dead exports + fix stale llmlingua docs

### DIFF
--- a/open-sse/services/compression/engines/headroom/gcf/decode_generic.ts
+++ b/open-sse/services/compression/engines/headroom/gcf/decode_generic.ts
@@ -10,7 +10,6 @@ import {
   parseQuotedString,
   splitRespectingQuotes,
   splitFieldDecl,
-  isBareKey,
   MISSING,
   ATTACHMENT,
 } from "./scalar.ts";

--- a/open-sse/services/compression/engines/headroom/gcf/generic.ts
+++ b/open-sse/services/compression/engines/headroom/gcf/generic.ts
@@ -5,7 +5,7 @@
  *
  * SPDX-License-Identifier: MIT
  */
-import { formatScalar, formatKey, ATTACHMENT } from "./scalar.ts";
+import { formatScalar, formatKey } from "./scalar.ts";
 
 function indent(depth: number): string {
   return "  ".repeat(depth);

--- a/open-sse/services/compression/engines/llmlingua/index.ts
+++ b/open-sse/services/compression/engines/llmlingua/index.ts
@@ -11,8 +11,8 @@
  * Promise<string>` contract (the opts carry model selection / compression rate /
  * offline model-path override; single-arg fakes remain assignable).
  * Tests inject a fake backend via `setLlmlinguaBackend()`. Production code uses
- * `workerBackend` from `./worker.ts` (a stub today — see that file for the L1
- * VPS-validation follow-up before the real ONNX model is wired).
+ * `workerBackend` from `./worker.ts` — the real MobileBERT ONNX worker-thread backend
+ * (strictly fail-open: missing optional deps or any error return the original text).
  *
  * ### Code-block protection (inviolable)
  * Before any prose segment reaches the backend, `extractPreservedBlocks` from
@@ -37,11 +37,11 @@
  * caveman=20) but before ultra (40). Semantic pruning is most effective after
  * simpler structural compression has already reduced noise.
  *
- * ### Production follow-up (L1 — not yet done)
- * Replace `workerBackend` stub in `./worker.ts` with real `@atjsh/llmlingua-2`
- * (MobileBERT ONNX, 99 MB) in a worker_threads.Worker. Gate by minimum token
- * count (≥2 k estimated). Validate on VPS per Hard Rule #18. See `./worker.ts`
- * for the exact spec.
+ * ### Real backend
+ * `./worker.ts` runs `@atjsh/llmlingua-2` (MobileBERT ONNX) in a worker_threads.Worker,
+ * gated by a minimum token count and strictly fail-open. The optional deps are not
+ * installed by default (CI / most installs), so the engine no-ops there; the real model
+ * is exercised on the VPS behind RUN_LLMLINGUA_INT (Hard Rule #18). See `./worker.ts`.
  */
 
 import { createCompressionStats, estimateCompressionTokens } from "../../stats.ts";

--- a/open-sse/services/compression/engines/rtk/codeStripper.ts
+++ b/open-sse/services/compression/engines/rtk/codeStripper.ts
@@ -140,14 +140,3 @@ export function stripCode(
   const strippedLines = Math.max(0, originalLines - (result ? result.split(/\r?\n/).length : 0));
   return { text: result, strippedLines, language: resolvedLanguage };
 }
-
-export function stripCodeComments(
-  text: string,
-  language = "typescript"
-): {
-  text: string;
-  stripped: boolean;
-} {
-  const result = stripCode(text, normalizeCodeLanguage(language));
-  return { text: result.text, stripped: result.strippedLines > 0 || result.text !== text };
-}

--- a/open-sse/services/compression/engines/rtk/commandDetector.ts
+++ b/open-sse/services/compression/engines/rtk/commandDetector.ts
@@ -461,8 +461,4 @@ export function detectCommandType(text: string, command?: string | null): Comman
   );
 }
 
-export function listCommandTypes(): string[] {
-  return DETECTORS.map((detector) => detector.type);
-}
-
 export const detectCommandOutput = detectCommandType;

--- a/open-sse/services/compression/engines/rtk/filterSchema.ts
+++ b/open-sse/services/compression/engines/rtk/filterSchema.ts
@@ -69,7 +69,7 @@ const rtkFilterPreserveSchema = z
   })
   .strict();
 
-export const rtkFilterPackSchema = z
+const rtkFilterPackSchema = z
   .object({
     id: z.string().min(1),
     label: z.string().min(1),
@@ -78,7 +78,9 @@ export const rtkFilterPackSchema = z
     priority: z.number().int().min(0).max(100).default(50),
     match: rtkFilterMatchSchema,
     rules: rtkFilterRulesSchema.default({} as unknown as z.infer<typeof rtkFilterRulesSchema>),
-    preserve: rtkFilterPreserveSchema.default({} as unknown as z.infer<typeof rtkFilterPreserveSchema>),
+    preserve: rtkFilterPreserveSchema.default(
+      {} as unknown as z.infer<typeof rtkFilterPreserveSchema>
+    ),
     tests: z.array(rtkInlineTestSchema).default([]),
   })
   .strict();
@@ -110,7 +112,7 @@ const legacyRtkFilterSchema = z
 
 export const rtkFilterSchema = z.union([rtkFilterPackSchema, legacyRtkFilterSchema]);
 
-export type RtkFilterPack = z.infer<typeof rtkFilterPackSchema>;
+type RtkFilterPack = z.infer<typeof rtkFilterPackSchema>;
 
 export interface RtkFilterDefinition {
   id: string;

--- a/open-sse/services/compression/index.ts
+++ b/open-sse/services/compression/index.ts
@@ -137,7 +137,6 @@ export {
   detectCodeLanguage,
   normalizeCodeLanguage,
   stripCode,
-  stripCodeComments,
 } from "./engines/rtk/codeStripper.ts";
 export type { CodeLanguage, CodeStripperOptions } from "./engines/rtk/codeStripper.ts";
 

--- a/src/lib/db/compression.ts
+++ b/src/lib/db/compression.ts
@@ -216,9 +216,7 @@ function normalizeContextEditingConfig(value: unknown): ContextEditingConfig {
   return {
     ...DEFAULT_CONTEXT_EDITING_CONFIG,
     enabled:
-      typeof record.enabled === "boolean"
-        ? record.enabled
-        : DEFAULT_CONTEXT_EDITING_CONFIG.enabled,
+      typeof record.enabled === "boolean" ? record.enabled : DEFAULT_CONTEXT_EDITING_CONFIG.enabled,
   };
 }
 
@@ -501,22 +499,6 @@ export async function updateCompressionSettings(
   compressionSettingsCache = null;
   invalidateDbCache();
   return getCompressionSettings();
-}
-
-export function getDefaultAggressiveConfig(): AggressiveConfig {
-  return {
-    ...DEFAULT_AGGRESSIVE_CONFIG,
-    thresholds: { ...DEFAULT_AGGRESSIVE_CONFIG.thresholds },
-    toolStrategies: { ...DEFAULT_AGGRESSIVE_CONFIG.toolStrategies },
-  };
-}
-
-export function getDefaultUltraConfig(): UltraConfig {
-  return { ...DEFAULT_ULTRA_CONFIG };
-}
-
-export function getDefaultRtkConfig(): RtkConfig {
-  return { ...DEFAULT_RTK_CONFIG };
 }
 
 function normalizeMcpAccessibilityConfig(value: unknown): McpAccessibilityConfig {


### PR DESCRIPTION
## Contexto
Programa **compressão 100% funcional** — item 7 (remover vestigial), **parte 1/2** (a limpa/baixo-risco). Remoções puras de símbolos exportados-mas-sem-uso (verificado por grep: zero caller de produção ou teste) + 1 fix de doc mentiroso. **Zero mudança de comportamento.**

## Removidos (dead exports)
- `rtk/codeStripper.ts`: `stripCodeComments` (+ re-export em `compression/index.ts`)
- `rtk/commandDetector.ts`: `listCommandTypes`
- `db/compression.ts`: `getDefaultAggressiveConfig` / `getDefaultUltraConfig` / `getDefaultRtkConfig` (as constantes `DEFAULT_*` que eles envolviam já são exportadas e usadas direto)
- `headroom/gcf`: imports mortos (`ATTACHMENT` em generic.ts, `isBareKey` em decode_generic.ts)

## Un-exportados (module-private — ainda usados internamente)
- `rtk/filterSchema.ts`: `rtkFilterPackSchema`, `RtkFilterPack` (usados na união `rtkFilterSchema` + `isCanonicalFilter`)

## Doc fix (mentiroso → real)
- `llmlingua/index.ts`: os comentários "workerBackend é um stub today / L1 not-yet-done" estavam **stale** — ⭐ **verifiquei `worker.ts`**: é o backend ONNX MobileBERT **real** (worker-thread, stable desde a validação VPS de 2026-06-16). Corrigido para descrever o backend real fail-open. (Os comentários `call_logs follow-up` do discover/learn foram **mantidos** — descrevem tarefa pendente, não falsidade.)

## Validação
- Suíte **completa** de compressão: **690/690** ✅ (nada dependia dos símbolos removidos).
- `typecheck:core` ✅ (sem imports/types órfãos) · `eslint` ✅ (0 erros; só warnings `any` pré-existentes).
- Sem testes removidos → sem risco de cobertura (dead code era não-coberto).

## Parte 2 (PR seguinte)
A remoção dos `reconstruct{Headroom,Ccr,SessionDedup}` — que toca o `apply` **live** do session-dedup (reverse-map órfão) + 4 test files + gate de cobertura — vem separada por ser mais delicada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)