### PR TITLE
test+ci(chatcore): semanticCache HIT fixture (15/15 mutate) + 350min budget headroom for auth/accountFallback batches

### DIFF
--- a/.github/workflows/nightly-mutation.yml
+++ b/.github/workflows/nightly-mutation.yml
@@ -26,8 +26,9 @@ jobs:
     #     6 chatCore/* leaves with direct unit coverage as batch g. A follow-up then wrote dedicated
     #     unit tests for 6 more leaves and added them as batch h. A final follow-up added dedicated
     #     tests (no mock.module — fetch-override + crafted inputs + temp-DATA_DIR) for telemetryHelpers
-    #     + memorySkillsInjection as batch i (14/15 chatCore leaves). semanticCache stays out (its
-    #     cache-HIT block needs a fixture) — see _mutate_godfiles_excluded_comment in stryker.conf.json.
+    #     + memorySkillsInjection + semanticCache (its cache-HIT block now has a setCachedResponse
+    #     fixture) as batch i — ALL 15/15 chatCore leaves are now mutated. See
+    #     _mutate_godfiles_excluded_comment in stryker.conf.json.
     # 9 PARALLEL batches, each overriding the mutate set via `--mutate` (Stryker 9 CLI:
     # `-m, --mutate <comma-list>`; the conf's `mutate[]` remains the local-run default/union).
     # Each batch targets <180min; full coverage every night in parallel (~180min wall-clock).
@@ -56,7 +57,7 @@ jobs:
           - name: h
             mutate: "open-sse/handlers/chatCore/headers.ts,open-sse/handlers/chatCore/logTruncation.ts,open-sse/handlers/chatCore/memoryExtraction.ts,open-sse/handlers/chatCore/nonStreamingSse.ts,open-sse/handlers/chatCore/passthroughToolNames.ts,open-sse/handlers/chatCore/executorHelpers.ts"
           - name: i
-            mutate: "open-sse/handlers/chatCore/telemetryHelpers.ts,open-sse/handlers/chatCore/memorySkillsInjection.ts"
+            mutate: "open-sse/handlers/chatCore/telemetryHelpers.ts,open-sse/handlers/chatCore/memorySkillsInjection.ts,open-sse/handlers/chatCore/semanticCache.ts"
     timeout-minutes: 180
     steps:
       - uses: actions/checkout@v6

--- a/stryker.conf.json
+++ b/stryker.conf.json
@@ -77,6 +77,7 @@
       "tests/unit/chatcore-non-streaming-sse.test.ts",
       "tests/unit/chatcore-passthrough-tool-names.test.ts",
       "tests/unit/chatcore-sanitization.test.ts",
+      "tests/unit/chatcore-semantic-cache.test.ts",
       "tests/unit/chatcore-strip-stale-headers.test.ts",
       "tests/unit/chatcore-telemetry-helpers.test.ts",
       "tests/unit/chatcore-translation-paths.test.ts",
@@ -219,17 +220,19 @@
     "A later follow-up added dedicated tests (NO mock.module — unavailable under the tap-runner; used",
     "fetch-override + crafted inputs + temp-DATA_DIR) for telemetryHelpers (both fns, all branches) and",
     "memorySkillsInjection (getSkillsProviderForFormat fully + injectMemoryAndSkills guards/empty-DB",
-    "path) and added them as batch i. 14 of 15 chatCore leaves now mutated.",
+    "path) and added them as batch i.",
+    "",
+    "The FINAL chatCore leaf, semanticCache.ts, was added to batch i once its cache-HIT block had a",
+    "fixture: chatcore-semantic-cache now SEEDS the real cache via setCachedResponse (the in-memory",
+    "store getCachedResponse checks first — no mock.module needed) under the exact signature",
+    "checkSemanticCache rebuilds, so the HIT branch runs end-to-end (status 200 / 'semantic' / 'HIT' /",
+    "the stream + content-type ternaries / the cost fallback / the side-effect calls all get killed).",
+    "ALL 15 chatCore leaves are now mutated.",
     "",
     "STILL EXCLUDED (follow-ups, NOT in `mutate` yet):",
     "  - combo.ts + chatCore.ts barrels: their handleComboChat/handleChatCore CORES were not",
     "    split (out of scope — Fase 3 ChatCoreContext refactor). The barrels are now thin-ish",
     "    but still large; keep excluded until the cores are split.",
-    "  - the LAST chatCore/* leaf, semanticCache.ts: it HAS a dedicated test (chatcore-semantic-cache,",
-    "    covers the guard-false + cache-MISS paths) but the cache-HIT block — the bulk of the logic —",
-    "    needs a populated-cache fixture, so most of its mutants would survive (no clean kill). Kept out",
-    "    of `mutate` until a HIT-path fixture test exists; the test runs in the normal test:unit suite",
-    "    as a regression guard.",
     "See project memory: Quality Gate v2 / Fase 9 (project-combo-split)."
   ],
   "mutate": [
@@ -262,7 +265,8 @@
     "open-sse/handlers/chatCore/passthroughToolNames.ts",
     "open-sse/handlers/chatCore/executorHelpers.ts",
     "open-sse/handlers/chatCore/telemetryHelpers.ts",
-    "open-sse/handlers/chatCore/memorySkillsInjection.ts"
+    "open-sse/handlers/chatCore/memorySkillsInjection.ts",
+    "open-sse/handlers/chatCore/semanticCache.ts"
   ],
   "_ignorePatterns_comment": [
     "ignorePatterns = files NOT copied into the Stryker sandbox. It does NOT scope",

--- a/tests/unit/chatcore-semantic-cache.test.ts
+++ b/tests/unit/chatcore-semantic-cache.test.ts
@@ -11,6 +11,13 @@ process.env.DATA_DIR = TEST_DATA_DIR;
 
 const { checkSemanticCache } = await import("../../open-sse/handlers/chatCore/semanticCache.ts");
 const core = await import("../../src/lib/db/core.ts");
+// Seeding the real cache (no mock.module under the Stryker tap-runner) lets us drive the
+// HIT branch deterministically: setCachedResponse populates the in-memory cache that
+// getCachedResponse checks first, so the signature checkSemanticCache rebuilds resolves.
+const { generateSignature, setCachedResponse, clearCache } = await import(
+  "../../src/lib/semanticCache.ts"
+);
+const { OMNIROUTE_RESPONSE_HEADERS } = await import("../../src/shared/constants/headers.ts");
 
 test.after(() => {
   core.resetDbInstance();
@@ -124,4 +131,177 @@ test("checkSemanticCache MISS also works for the Responses-API `input` body shap
 
   assert.equal(result, null);
   assert.equal(persistCalls.length, 0);
+});
+
+// ─── HIT path ────────────────────────────────────────────────────────────────
+// The guard-false / miss tests above only exercise the `return null` branches. These
+// seed the real cache so the `if (cached)` block actually runs end-to-end, killing
+// mutants in the HIT body (status 200 / "semantic" / "HIT" / the stream + content-type
+// ternaries / the cost fallback / the side-effect calls).
+
+// Recording (non-throwing) spies — the HIT path DOES invoke log.debug + logConvertedResponse.
+function makeHitArgs(overrides: Record<string, unknown> = {}) {
+  const persistCalls: Record<string, unknown>[] = [];
+  const convertedCalls: unknown[] = [];
+  const debugCalls: unknown[][] = [];
+  const args = {
+    semanticCacheEnabled: true,
+    body: { model: "gpt-4o", messages: [{ role: "user", content: "cached query" }], temperature: 0 },
+    clientRawRequest: { headers: {} },
+    model: "gpt-4o",
+    provider: "openai",
+    stream: false,
+    reqLogger: {
+      logConvertedResponse: (r: unknown) => {
+        convertedCalls.push(r);
+      },
+    },
+    effectiveServiceTier: undefined,
+    connectionId: null as string | null,
+    startTime: Date.now() - 5,
+    log: {
+      debug: (...a: unknown[]) => {
+        debugCalls.push(a);
+      },
+    },
+    persistAttemptLogs: (a: unknown) => {
+      persistCalls.push(a as Record<string, unknown>);
+    },
+    apiKeyId: null as string | null,
+    ...overrides,
+  };
+  return { args, persistCalls, convertedCalls, debugCalls };
+}
+
+// Seed the cache under the EXACT signature checkSemanticCache rebuilds for `args`.
+function seedHit(args: ReturnType<typeof makeHitArgs>["args"], response: unknown) {
+  const signature = generateSignature(
+    args.model,
+    args.body.messages ?? (args.body as Record<string, unknown>).input,
+    args.body.temperature,
+    (args.body as Record<string, unknown>).top_p,
+    args.apiKeyId ?? undefined
+  );
+  setCachedResponse(signature, args.model, response);
+  return signature;
+}
+
+test("checkSemanticCache returns a non-streaming JSON HIT with cache headers + logging side effects", async () => {
+  clearCache();
+  const cached = {
+    id: "chatcmpl-cached-1",
+    choices: [
+      { index: 0, message: { role: "assistant", content: "cached answer" }, finish_reason: "stop" },
+    ],
+    usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+  };
+  const { args, persistCalls, convertedCalls, debugCalls } = makeHitArgs({
+    body: { model: "gpt-4o", messages: [{ role: "user", content: "hit query one" }], temperature: 0 },
+    stream: false,
+  });
+  seedHit(args, cached);
+
+  const result = await checkSemanticCache(args as Parameters<typeof checkSemanticCache>[0]);
+
+  assert.ok(result, "HIT -> non-null result");
+  assert.equal(result.success, true, "HIT result.success is true");
+  const res = result.response as Response;
+  assert.equal(res.headers.get(OMNIROUTE_RESPONSE_HEADERS.cache), "HIT", "X-OmniRoute-Cache: HIT");
+  assert.equal(
+    res.headers.get(OMNIROUTE_RESPONSE_HEADERS.cacheHit),
+    "true",
+    "cacheHit meta header is true"
+  );
+  assert.equal(
+    res.headers.get("Content-Type"),
+    "application/json",
+    "non-streaming HIT -> application/json"
+  );
+  const bodyText = await res.text();
+  assert.equal(bodyText, JSON.stringify(cached), "non-streaming HIT body is the cached JSON");
+
+  assert.equal(persistCalls.length, 1, "persistAttemptLogs runs exactly once on a HIT");
+  const logged = persistCalls[0];
+  assert.equal(logged.status, 200, "persisted status is 200");
+  assert.equal(logged.cacheSource, "semantic", "persisted cacheSource is 'semantic'");
+  assert.deepEqual(logged.responseBody, cached, "persisted responseBody is the cached object");
+  assert.deepEqual(logged.clientResponse, cached, "persisted clientResponse is the cached object");
+  assert.deepEqual(logged.tokens, cached.usage, "persisted tokens come from cached.usage");
+  assert.equal(logged.providerRequest, null);
+  assert.equal(logged.providerResponse, null);
+
+  assert.equal(convertedCalls.length, 1, "logConvertedResponse called once with the cached body");
+  assert.deepEqual(convertedCalls[0], cached);
+  assert.equal(debugCalls.length, 1, "log.debug fires exactly once on a HIT");
+});
+
+test("checkSemanticCache returns a streaming SSE HIT (text/event-stream) when stream=true", async () => {
+  clearCache();
+  const cached = {
+    id: "chatcmpl-cached-stream",
+    choices: [
+      {
+        index: 0,
+        message: { role: "assistant", content: "streamed cached answer" },
+        finish_reason: "stop",
+      },
+    ],
+    usage: { prompt_tokens: 3, completion_tokens: 4, total_tokens: 7 },
+  };
+  const { args, persistCalls } = makeHitArgs({
+    body: { model: "gpt-4o", messages: [{ role: "user", content: "hit query stream" }], temperature: 0 },
+    stream: true,
+  });
+  seedHit(args, cached);
+
+  const result = await checkSemanticCache(args as Parameters<typeof checkSemanticCache>[0]);
+
+  assert.ok(result, "streaming HIT -> non-null result");
+  assert.equal(result.success, true);
+  const res = result.response as Response;
+  assert.equal(
+    res.headers.get("Content-Type"),
+    "text/event-stream",
+    "streaming HIT -> text/event-stream"
+  );
+  assert.equal(res.headers.get(OMNIROUTE_RESPONSE_HEADERS.cache), "HIT");
+  const bodyText = await res.text();
+  assert.ok(bodyText.includes("data: "), "SSE body contains data frames");
+  assert.ok(bodyText.includes("streamed cached answer"), "SSE body carries the cached content");
+  assert.ok(bodyText.trimEnd().endsWith("data: [DONE]"), "SSE body terminates with [DONE]");
+  assert.equal(persistCalls.length, 1, "persistAttemptLogs runs once on a streaming HIT too");
+});
+
+test("checkSemanticCache HITs even when the cached body has no usage (cost falls back to 0)", async () => {
+  clearCache();
+  const cached = {
+    id: "chatcmpl-cached-no-usage",
+    choices: [
+      { index: 0, message: { role: "assistant", content: "no-usage answer" }, finish_reason: "stop" },
+    ],
+  };
+  const { args, persistCalls } = makeHitArgs({
+    body: {
+      model: "gpt-4o",
+      messages: [{ role: "user", content: "hit query no usage" }],
+      temperature: 0,
+    },
+    stream: false,
+  });
+  seedHit(args, cached);
+
+  const result = await checkSemanticCache(args as Parameters<typeof checkSemanticCache>[0]);
+
+  assert.ok(result, "HIT with no usage -> non-null result");
+  assert.equal(result.success, true);
+  const res = result.response as Response;
+  assert.equal(res.headers.get(OMNIROUTE_RESPONSE_HEADERS.cache), "HIT");
+  // cachedUsage resolves to undefined -> cachedCost = 0 -> the zero-cost sentinel header.
+  assert.equal(
+    res.headers.get(OMNIROUTE_RESPONSE_HEADERS.responseCost),
+    "0.0000000000",
+    "no usage -> zero responseCost header"
+  );
+  assert.equal(persistCalls.length, 1);
+  assert.equal(persistCalls[0].tokens, undefined, "no usage -> persisted tokens is undefined");
 });


### PR DESCRIPTION
## O quê

Fecha o **último** chatCore leaf que faltava no Stryker `mutate`: `semanticCache.ts`. Com isso, **15/15 leaves** do `chatCore/` passam a ser mutados na noturna.

## Por quê estava de fora

O `semanticCache.ts` foi excluído do `mutate` no #4222 porque o **bloco de cache-HIT** (o grosso da lógica) não tinha teste — só os caminhos guard-false / cache-MISS eram exercitados, então a maioria dos mutantes do HIT sobreviveria (sem *clean kill*).

## Como o fixture funciona (sem mock.module)

`mock.module` não está disponível sob o tap-runner do Stryker. O teste então **semeia o cache real** via `setCachedResponse` (o store em-memória que `getCachedResponse` checa primeiro) sob a **assinatura exata** que `checkSemanticCache` reconstrói (`generateSignature` com os mesmos `model`/messages/temperature/top_p/apiKeyId). Isso dispara o branch de HIT ponta-a-ponta.

3 testes de HIT novos:
- **não-streaming** → `application/json`, body = JSON do cached, headers `X-OmniRoute-Cache: HIT` + `Cache-Hit: true`, e os side-effects (`persistAttemptLogs` com `status:200`/`cacheSource:"semantic"`, `logConvertedResponse(cached)`, `log.debug`).
- **streaming** (`stream:true`) → `text/event-stream`, body SSE com frames `data:` + terminador `[DONE]`.
- **sem usage** → `cachedUsage` resolve `undefined` → `cachedCost = 0` → header `responseCost` no sentinel zero.

Matam os mutantes do bloco HIT (status / `"semantic"` / `"HIT"` / os ternários stream+content-type / o fallback de custo / as chamadas de side-effect).

## Mudanças

- `tests/unit/chatcore-semantic-cache.test.ts` — +3 testes de HIT (os 5 guard/miss originais permanecem). **8/8 verde** local.
- `stryker.conf.json` — `semanticCache.ts` → `mutate` (30→31), `chatcore-semantic-cache.test.ts` → `tap.testFiles` (137→138), comentário `_mutate_godfiles_excluded_comment` atualizado (15/15).
- `.github/workflows/nightly-mutation.yml` — `semanticCache.ts` → batch i (3 arquivos); comentário do header atualizado.

## Notas

- **Config/test-only** — zero código de produção. Mutation testing segue **advisory** (noturna, `continue-on-error`).
- Run step do workflow **injection-safe** intacto (`BATCH_MUTATE` env → `--mutate "$BATCH_MUTATE"`).
- União de todos os batches do matrix == conjunto `mutate` do conf (verificado).

QG v2 Fase 9 T5 — Fase 3 follow-up. Encerra a re-habilitação do mutation testing pela via unit-testável: `mutate` 6→31, 9 batches, **15/15 chatCore leaves + todos os combo leaves**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)