### PR TITLE
fix(mitm): forward anti-loop — bypass-marked socket on the Agent (decrypt 4d, VPS-validated)

### DIFF
--- a/src/mitm/tproxy/tlsCapture.ts
+++ b/src/mitm/tproxy/tlsCapture.ts
@@ -308,6 +308,19 @@ export function createForward(
   return (dest, init) =>
     new Promise<ForwardResult>((resolve, reject) => {
       const servername = dest.sni || String(init.headers.host || dest.ip);
+      // The bypass-marked socket MUST live on the Agent's `createConnection`:
+      // `https.request({ createConnection })` is silently IGNORED whenever an
+      // agent is present — and `agent: false` still installs a fresh default
+      // Agent, so the request option never runs and the forward would open its
+      // own UNMARKED socket, breaking the anti-loop (TPROXY would re-intercept
+      // the proxy's own forward → infinite loop). Verified e2e on the VPS.
+      const agent = new https.Agent({ maxSockets: 1, keepAlive: false });
+      (agent as unknown as { createConnection: () => net.Socket }).createConnection = () =>
+        tls.connect({
+          socket: connectRaw(dest.ip, dest.port),
+          servername,
+          rejectUnauthorized,
+        }) as unknown as net.Socket;
       let req: http.ClientRequest;
       try {
         req = https.request(
@@ -319,12 +332,7 @@ export function createForward(
             headers: init.headers,
             servername,
             rejectUnauthorized,
-            // `agent: false` is required so `createConnection` is honored — the
-            // default Agent would ignore it and open its own (unmarked) socket,
-            // breaking the anti-loop SO_MARK on the real forward path.
-            agent: false,
-            createConnection: () =>
-              tls.connect({ socket: connectRaw(dest.ip, dest.port), servername, rejectUnauthorized }),
+            agent,
           },
           (upstream) => {
             const chunks: Buffer[] = [];

--- a/tests/unit/tproxy-tls-capture.test.ts
+++ b/tests/unit/tproxy-tls-capture.test.ts
@@ -162,6 +162,45 @@ test("decrypts an intercepted HTTPS request and captures it as source 'tproxy'",
   }
 });
 
+test("the forward dials its upstream through connectRaw — the bypass-marked seam (anti-loop regression)", async () => {
+  // Regression for the bug the VPS e2e caught: `https.request({ createConnection })`
+  // is silently IGNORED whenever an agent is present — and `agent: false` still
+  // installs a fresh default Agent — so the forward opened its OWN unmarked socket.
+  // On a TPROXY host that re-intercepts the proxy's own forward, that loops
+  // infinitely. The fix puts the marked socket on the Agent's createConnection;
+  // this asserts connectRaw (the anti-loop seam) is actually invoked.
+  globalTrafficBuffer.clear();
+  const upstream = await startHttpsUpstream();
+  const certStore = new DynamicCertStore("OmniRoute MITM CA (test)");
+  const caPem = await certStore.getCaCertPem();
+  let connectRawCalls = 0;
+  const forward = createForward(
+    (ip, port) => {
+      connectRawCalls += 1;
+      return net.connect(port, ip);
+    },
+    { rejectUnauthorized: false }
+  );
+  const engine = await startEngineListener(certStore, { ip: "127.0.0.1", port: upstream.port }, forward);
+
+  try {
+    const body = await tlsRequest(
+      engine.port,
+      "api.example.com",
+      caPem,
+      "GET /seam HTTP/1.1\r\nHost: api.example.com\r\nConnection: close\r\n\r\n"
+    );
+    assert.match(body, /decrypted-roundtrip:\/seam/, "client still gets the upstream response");
+    assert.ok(
+      connectRawCalls >= 1,
+      "the forward MUST dial through connectRaw (the bypass-marked seam), not a default socket"
+    );
+  } finally {
+    await engine.close();
+    await upstream.close();
+  }
+});
+
 test("a forward failure is recorded as an error entry and the client gets 502", async () => {
   globalTrafficBuffer.clear();
   const certStore = new DynamicCertStore("OmniRoute MITM CA (test)");


### PR DESCRIPTION
## Summary

Epic A / Fase 3 — **decrypt 4d**: the **VPS e2e validation** of the decrypt capture mode, which **caught and fixed a real anti-loop bug** in the merged forward path.

**The bug.** The decrypt forward (#4179/#4200) opened its upstream socket via `https.request({ agent: false, createConnection })`. But `https.request` **silently ignores the `createConnection` request option whenever an agent is present** — and `agent: false` still installs a fresh default Agent — so `createConnection` (and thus `connectMarked`) **never ran**. The forward opened its own **unmarked** socket. On a real TPROXY host the OUTPUT rule re-intercepts the proxy's own forward → decrypt → forward → re-intercept → **infinite loop**. The local unit test in #4179 couldn't catch this: with no kernel interception, an unmarked forward reaches the upstream just the same.

**The fix.** Move the bypass-marked socket onto a dedicated `https.Agent`'s `createConnection`, where Node actually honors it (`keepAlive:false`, so no socket lingers).

## VPS validation (Hard Rule #18 — documented live test)

Real merged code bundled (esbuild, only the buffer/DB sink stubbed) + the prebuilt native addon, run as **root** on the production VPS (kernel `6.8.0-124`), on a **TEST port `18443` (never 443)**, with sysctls saved/restored and rules/route/CA force-cleaned on exit:

| | before fix | after fix |
|---|---|---|
| `createConnection` invoked | **0×** | per-forward ✓ |
| interceptions for one client request | **1298 (loop)** | **1** |
| client result | timeout | **`HTTP 200 PONG-DECRYPTED`** |
| captured entry | 1298× `in-flight` | `source:"tproxy"`, `GET /decrypt-probe`, `status:200`, **secret masked** |

A control run of the **raw tunnel** (no decrypt, same `connectMarked`) round-tripped cleanly (`rawIntercepts:1`), isolating the defect to the decrypt forward — not loopback. Post-run state: `0` rules, table empty, CA removed.

## Test Plan

`tests/unit/tproxy-tls-capture.test.ts` (6/6) — adds **"the forward dials its upstream through connectRaw (the bypass-marked seam)"**: spies on `connectRaw` and asserts it is invoked. It **fails against the pre-fix code** (createConnection never runs → `connectRaw` never called) and is the permanent regression guard. The existing decrypt round-trip + masking + 502 tests still pass.

Validation: `typecheck:core` ✓, `lint` ✓ (0), `tproxy-tls-capture` 6/6, `tproxy-capture-mode` + `tproxy-capture-manager` 16/16.

> This closes the TLS-decrypt epic's validation: the kernel intercept → TLS-terminate → decrypt → capture (`source:"tproxy"`) → re-encrypted forward → upstream → relay round-trip is now proven end-to-end on the real VPS. Remaining nice-to-have: native-addon prebuilds for distribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)