### PR TITLE
feat(compression): honor the per-filter RTK deduplicate flag

### DIFF
--- a/open-sse/services/compression/engines/rtk/lineFilter.ts
+++ b/open-sse/services/compression/engines/rtk/lineFilter.ts
@@ -1,5 +1,6 @@
 import type { RtkFilterDefinition } from "./filterSchema.ts";
 import { smartTruncate } from "./smartTruncate.ts";
+import { deduplicateRepeatedLines } from "./deduplicator.ts";
 
 export interface LineFilterResult {
   text: string;
@@ -144,6 +145,17 @@ export function applyLineFilter(text: string, filter: RtkFilterDefinition): Line
     if (truncatedLines.join("\n") !== lines.join("\n")) {
       lines = truncatedLines;
       appliedRules.push(`${filter.id}:truncate-line`);
+    }
+  }
+
+  // Per-filter line dedup (opt-in via the filter's `deduplicate` flag): collapse consecutive
+  // duplicate lines before truncation. The engine-wide dedup (config.deduplicateThreshold) is
+  // separate; this lets a single filter force it for its own output.
+  if (filter.deduplicate) {
+    const deduped = deduplicateRepeatedLines(lines.join("\n"));
+    if (deduped.collapsed > 0) {
+      lines = deduped.text.split(/\r?\n/);
+      appliedRules.push(`${filter.id}:deduplicate`);
     }
   }
 

--- a/tests/unit/compression/rtk-filter-deduplicate.test.ts
+++ b/tests/unit/compression/rtk-filter-deduplicate.test.ts
@@ -1,0 +1,57 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { applyLineFilter } from "../../../open-sse/services/compression/engines/rtk/lineFilter.ts";
+import type { RtkFilterDefinition } from "../../../open-sse/services/compression/engines/rtk/filterSchema.ts";
+
+// A custom RTK filter can set `deduplicate: true` (rules.deduplicate in the filter JSON), and it
+// was carried onto RtkFilterDefinition — but applyLineFilter never read it, so the flag did
+// nothing. This wires it: when set, consecutive duplicate lines in the filter's output are
+// collapsed (the same line-dedup the engine offers globally, now controllable per filter).
+function filter(over: Partial<RtkFilterDefinition>): RtkFilterDefinition {
+  return {
+    id: "t",
+    name: "t",
+    description: "",
+    commandTypes: [],
+    commandPatterns: [],
+    matchPatterns: [],
+    category: "generic",
+    priority: 50,
+    stripPatterns: [],
+    keepPatterns: [],
+    priorityPatterns: [],
+    collapsePatterns: [],
+    stripAnsi: false,
+    replace: [],
+    matchOutput: [],
+    truncateLineAt: 0,
+    onEmpty: "",
+    filterStderr: false,
+    deduplicate: false,
+    maxLines: 0,
+    preserveHead: 20,
+    preserveTail: 20,
+    tests: [],
+    ...over,
+  };
+}
+
+const TEXT = ["start", "dup", "dup", "dup", "dup", "end"].join("\n");
+
+describe("applyLineFilter — per-filter deduplicate flag", () => {
+  it("collapses repeated lines and records the rule when deduplicate is set", () => {
+    const result = applyLineFilter(TEXT, filter({ deduplicate: true }));
+    assert.ok(result.appliedRules.includes("t:deduplicate"), "records the deduplicate rule");
+    const dupCount = result.text.split(/\r?\n/).filter((l) => l === "dup").length;
+    assert.ok(dupCount < 4, `the 4-line dup run must be collapsed (got ${dupCount} dup lines)`);
+    assert.ok(result.text.includes("start") && result.text.includes("end"), "keeps non-dup lines");
+  });
+
+  it("does NOT deduplicate when the flag is off (default)", () => {
+    const result = applyLineFilter(TEXT, filter({ deduplicate: false }));
+    assert.ok(!result.appliedRules.includes("t:deduplicate"));
+    const dupCount = result.text.split(/\r?\n/).filter((l) => l === "dup").length;
+    assert.equal(dupCount, 4, "the dup run must remain intact when deduplicate is off");
+  });
+});


### PR DESCRIPTION
## Contexto
Programa **compressão 100% funcional** — cauda longa da auditoria (itens "read-but-not-applied" que adiei dos PRs principais).

## Gap
Um filtro RTK custom podia setar `deduplicate: true` (`rules.deduplicate` no JSON do filtro), e isso era carregado em `RtkFilterDefinition.deduplicate` — mas `applyLineFilter` **nunca lia** o campo, então a flag não fazia nada.

## Fix
Quando setada, colapsa linhas duplicadas consecutivas na saída do filtro (via o `deduplicateRepeatedLines` existente) **antes** do truncamento, e registra a rule `<id>:deduplicate`. O dedup engine-wide (`config.deduplicateThreshold`) é separado; isto deixa um filtro específico forçar dedup só na própria saída. **Default off** — zero mudança para filtros que não setam.

## Validação
- TDD: 2 testes RED→GREEN — flag on colapsa o run + registra a rule; flag off mantém intacto.
- Suíte de compressão: **693/693** ✅ (os testes RTK de dedup existentes seguem passando — sem regressão no `applyLineFilter`).
- `typecheck:core` ✅ · `eslint` ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)