### PR TITLE
feat(ci): wire the F2.4 compression budget-gate ratchet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,8 @@ jobs:
         run: npm run check:cognitive-complexity
       - name: Type coverage ratchet
         run: npm run check:type-coverage
+      - name: Compression budget ratchet (F2.4 / N4)
+        run: npm run check:compression-budget
       # CodeQL alerts ratchet — BLOQUEANTE (promovido de advisory na v3.8.26).
       # Lê metrics.codeqlAlerts.value de quality-baseline.json e sai 1 SOMENTE numa
       # regressão real (alertas abertos > baseline). Falha de medição (gh/auth/api)

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "check:env-doc-sync": "node scripts/check/check-env-doc-sync.mjs",
     "check:docs-counts": "node scripts/check/check-docs-counts-sync.mjs",
     "check:deprecated-versions": "node scripts/check/check-deprecated-versions.mjs",
+    "check:compression-budget": "node --import tsx scripts/check/check-compression-budget.ts",
     "check:doc-links": "node scripts/check/check-doc-links.mjs",
     "check:fabricated-docs": "node scripts/check/check-fabricated-docs.mjs --strict",
     "check:docs-all": "npm run check:docs-sync && npm run check:docs-counts && npm run check:env-doc-sync && npm run check:deprecated-versions && npm run check:doc-links && npm run check:fabricated-docs",

--- a/scripts/check/check-compression-budget.ts
+++ b/scripts/check/check-compression-budget.ts
@@ -1,0 +1,80 @@
+/**
+ * Compression budget gate (F2.4 / N4 ratchet).
+ *
+ * Runs the deterministic compression engines over BENCHMARK_CORPUS and fails if any engine's
+ * mean compressed-tokens-per-task RISES beyond the tolerance versus the frozen baseline — i.e. a
+ * change made compression worse. Falling cost (better compression) always passes.
+ *
+ *   node --import tsx scripts/check/check-compression-budget.ts            # check (CI)
+ *   node --import tsx scripts/check/check-compression-budget.ts --update   # refresh the baseline
+ *
+ * The benchmark is deterministic + API-free (chars/4 estimate over a fixed corpus), so the
+ * committed baseline is portable across local/CI.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  BENCHMARK_CORPUS,
+  DEFAULT_BENCHMARK_ENGINES,
+  benchmarkEngines,
+  runBenchmarkGate,
+} from "../../open-sse/services/compression/harness/benchmark.ts";
+import { tokensPerTask, type BudgetBaseline } from "../../open-sse/services/compression/harness/budgetGate.ts";
+
+const BASELINE_PATH = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "compression-budget-baseline.json"
+);
+const TOLERANCE_PERCENT = 2;
+
+async function main(): Promise<void> {
+  const update = process.argv.includes("--update");
+  const reports = await benchmarkEngines(BENCHMARK_CORPUS, DEFAULT_BENCHMARK_ENGINES);
+
+  if (update) {
+    const baselines: Record<string, BudgetBaseline> = {};
+    for (const [engine, report] of Object.entries(reports)) {
+      baselines[engine] = { tasks: tokensPerTask(report) };
+    }
+    fs.writeFileSync(BASELINE_PATH, JSON.stringify(baselines, null, 2) + "\n");
+    console.log(`Updated compression budget baseline (${Object.keys(baselines).length} engines).`);
+    return;
+  }
+
+  if (!fs.existsSync(BASELINE_PATH)) {
+    console.error("compression budget baseline missing — run with --update to generate it.");
+    process.exit(1);
+  }
+  const baselines = JSON.parse(fs.readFileSync(BASELINE_PATH, "utf8")) as Record<
+    string,
+    BudgetBaseline
+  >;
+
+  const results = runBenchmarkGate(reports, baselines, TOLERANCE_PERCENT);
+  const failed = results.filter((r) => !r.gate.passed);
+
+  if (failed.length === 0) {
+    console.log(`✓ compression budget gate: no regressions (tolerance ${TOLERANCE_PERCENT}%)`);
+    return;
+  }
+
+  console.error("✗ compression budget gate: tokens-per-task regressed (compression got worse):");
+  for (const { engine, gate } of failed) {
+    for (const reg of gate.regressions) {
+      console.error(
+        `  ${engine}/${reg.task}: ${reg.baseline} -> ${reg.current} tokens (+${reg.deltaPercent}%)`
+      );
+    }
+  }
+  console.error(
+    "\nIf this is an intentional improvement/change, refresh: npm run check:compression-budget -- --update"
+  );
+  process.exit(1);
+}
+
+main().catch((err) => {
+  console.error("compression budget gate failed:", err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/scripts/check/compression-budget-baseline.json
+++ b/scripts/check/compression-budget-baseline.json
@@ -1,0 +1,58 @@
+{
+  "lite": {
+    "tasks": {
+      "prose": 129,
+      "tool-output": 127,
+      "json": 160
+    }
+  },
+  "caveman": {
+    "tasks": {
+      "prose": 129,
+      "tool-output": 127,
+      "json": 160
+    }
+  },
+  "aggressive": {
+    "tasks": {
+      "prose": 129,
+      "tool-output": 127,
+      "json": 160
+    }
+  },
+  "ultra": {
+    "tasks": {
+      "prose": 92,
+      "tool-output": 116,
+      "json": 117
+    }
+  },
+  "rtk": {
+    "tasks": {
+      "prose": 129,
+      "tool-output": 127,
+      "json": 160
+    }
+  },
+  "session-dedup": {
+    "tasks": {
+      "prose": 129,
+      "tool-output": 127,
+      "json": 160
+    }
+  },
+  "headroom": {
+    "tasks": {
+      "prose": 129,
+      "tool-output": 127,
+      "json": 160
+    }
+  },
+  "ccr": {
+    "tasks": {
+      "prose": 129,
+      "tool-output": 56,
+      "json": 14
+    }
+  }
+}

--- a/tests/unit/compression/compression-budget-gate.test.ts
+++ b/tests/unit/compression/compression-budget-gate.test.ts
@@ -1,0 +1,49 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  BENCHMARK_CORPUS,
+  DEFAULT_BENCHMARK_ENGINES,
+  benchmarkEngines,
+  runBenchmarkGate,
+} from "../../../open-sse/services/compression/harness/benchmark.ts";
+import { tokensPerTask, type BudgetBaseline } from "../../../open-sse/services/compression/harness/budgetGate.ts";
+
+const BASELINE_PATH = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../../scripts/check/compression-budget-baseline.json"
+);
+
+describe("compression budget gate (F2.4 / N4 ratchet)", () => {
+  it("the committed baseline matches the current benchmark (not stale, no regression)", async () => {
+    const baselines = JSON.parse(fs.readFileSync(BASELINE_PATH, "utf8")) as Record<
+      string,
+      BudgetBaseline
+    >;
+    const reports = await benchmarkEngines(BENCHMARK_CORPUS, DEFAULT_BENCHMARK_ENGINES);
+    const failed = runBenchmarkGate(reports, baselines, 2).filter((r) => !r.gate.passed);
+    assert.equal(
+      failed.length,
+      0,
+      `tokens-per-task regressed vs the committed baseline: ${JSON.stringify(failed)} — ` +
+        `if intentional, run: npm run check:compression-budget -- --update`
+    );
+  });
+
+  it("flags a regression when tokens-per-task rises beyond tolerance", async () => {
+    // ultra is stateless/deterministic. Build a baseline tighter than reality → current regresses.
+    const reports = await benchmarkEngines(BENCHMARK_CORPUS, ["ultra"]);
+    const tight: Record<string, BudgetBaseline> = {
+      ultra: {
+        tasks: Object.fromEntries(
+          Object.entries(tokensPerTask(reports.ultra)).map(([task, n]) => [task, Math.max(1, Math.floor(n / 2))])
+        ),
+      },
+    };
+    const failed = runBenchmarkGate(reports, tight, 2).filter((r) => !r.gate.passed);
+    assert.ok(failed.length > 0, "a halved baseline must be flagged as a regression");
+  });
+});


### PR DESCRIPTION
## Contexto
Programa **compressão 100% funcional** — cauda longa, item de **maior valor**. O `budgetGate.ts` (`tokensPerTask`/`checkTokensPerTaskGate`) existia mas **sem baseline, sem runner, sem CI** — um "ratchet só no nome" (achado da auditoria). Este PR o torna um gate real.

## O que muda
- **`scripts/check/check-compression-budget.ts`**: roda os engines determinísticos sobre o `BENCHMARK_CORPUS` e **falha se** o `tokens-per-task` médio de qualquer engine **subir** > 2% vs a baseline congelada (melhor compressão sempre passa; refresh com `--update`). Determinístico + API-free → portável local↔CI.
- **`compression-budget-baseline.json`**: baseline commitada (por engine × por task: prose/tool-output/json).
- **`npm run check:compression-budget`** + step **"Compression budget ratchet"** no job `quality-gate` do ci.yml.

## Saída real
```
✓ compression budget gate: no regressions (tolerance 2%)
```

## Validação
- TDD: 2 testes RED→GREEN — (a) a baseline commitada **bate com o benchmark atual** (não-stale + sem regressão; vira guarda permanente), (b) uma baseline apertada é **flagada como regressão**.
- Check script roda local ✓ · `typecheck:core` ✅ · `eslint` ✅ · YAML do ci.yml válido (step presente).
- ⭐ Determinismo: o harness é chars/4 sobre corpus fixo (o teste de reprodutibilidade do benchmark já garante) → baseline portável.

Agora uma mudança futura que piora a compressão é pega **na suíte de testes E na CI**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)