### PR TITLE
feat(compression): make mcpAccessibility config reachable via settings sub-route

### DIFF
--- a/docs/reference/openapi.yaml
+++ b/docs/reference/openapi.yaml
@@ -1966,6 +1966,52 @@ paths:
         "200":
           description: Updated compression settings
 
+  /api/settings/compression/mcp-accessibility:
+    get:
+      tags: [Compression]
+      summary: Get the MCP tool-output accessibility (trimming) config
+      security:
+        - ManagementSessionAuth: []
+      responses:
+        "200":
+          description: Current mcpAccessibility config
+    put:
+      tags: [Compression]
+      summary: Update the MCP tool-output accessibility (trimming) config
+      description: >-
+        Partial-merge update. Numeric floors (e.g. a maxTextChars below the truncation-tail
+        reserve) are folded back to the safe defaults server-side, so the response reflects the
+        effective config.
+      security:
+        - ManagementSessionAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                enabled:
+                  type: boolean
+                maxTextChars:
+                  type: integer
+                  minimum: 1
+                collapseThreshold:
+                  type: integer
+                  minimum: 1
+                collapseKeepHead:
+                  type: integer
+                  minimum: 0
+                collapseKeepTail:
+                  type: integer
+                  minimum: 0
+                minLengthToProcess:
+                  type: integer
+                  minimum: 1
+      responses:
+        "200":
+          description: Updated mcpAccessibility config (numeric floors applied)
+
   /api/compression/preview:
     post:
       tags: [Compression]

--- a/src/app/api/settings/compression/mcp-accessibility/route.ts
+++ b/src/app/api/settings/compression/mcp-accessibility/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getMcpAccessibilityConfig, setMcpAccessibilityConfig } from "@/lib/db/compression";
+import { isAuthenticated } from "@/shared/utils/apiAuth";
+import { isValidationFailure, validateBody } from "@/shared/validation/helpers";
+import { mcpAccessibilityConfigSchema } from "@/shared/validation/compressionConfigSchemas";
+
+// Read/update the mcpAccessibility engine config (compression/mcpAccessibility DB key) that the
+// MCP server consumes on every tool call to trim oversized tool outputs. Kept as a dedicated
+// sub-route (sibling of settings/compression) so the strict main settings schema stays focused
+// and the #4206 numeric bounds become reachable from the dashboard.
+
+export async function GET(request: NextRequest) {
+  if (!(await isAuthenticated(request))) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const config = await getMcpAccessibilityConfig();
+    return NextResponse.json(config);
+  } catch (error) {
+    return NextResponse.json({ error: String(error) }, { status: 500 });
+  }
+}
+
+export async function PUT(request: NextRequest) {
+  if (!(await isAuthenticated(request))) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    let rawBody: unknown;
+    try {
+      rawBody = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+
+    const validation = validateBody(mcpAccessibilityConfigSchema, rawBody);
+    if (isValidationFailure(validation)) {
+      return NextResponse.json({ error: validation.error }, { status: 400 });
+    }
+
+    // Partial-merge over the current config so toggling one field does not reset the others to
+    // their defaults (setMcpAccessibilityConfig folds in DEFAULT + clampMcpAccessibilityConfig).
+    const current = await getMcpAccessibilityConfig();
+    await setMcpAccessibilityConfig({ ...current, ...validation.data });
+    const config = await getMcpAccessibilityConfig();
+    return NextResponse.json(config);
+  } catch (error) {
+    return NextResponse.json({ error: String(error) }, { status: 500 });
+  }
+}

--- a/src/shared/validation/compressionConfigSchemas.ts
+++ b/src/shared/validation/compressionConfigSchemas.ts
@@ -54,6 +54,22 @@ export const rtkConfigSchema = z
   })
   .strict();
 
+// mcpAccessibility tunes how the MCP server trims oversized tool outputs before returning them.
+// The schema only enforces structural validity (positive integers / booleans); the numeric floors
+// (e.g. maxTextChars below the truncation-tail reserve) are owned by clampMcpAccessibilityConfig
+// on the write path, which folds out-of-range values back to the safe defaults. All fields are
+// optional so the settings sub-route can apply a partial merge over the current config.
+export const mcpAccessibilityConfigSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    maxTextChars: z.number().int().min(1).optional(),
+    collapseThreshold: z.number().int().min(1).optional(),
+    collapseKeepHead: z.number().int().min(0).optional(),
+    collapseKeepTail: z.number().int().min(0).optional(),
+    minLengthToProcess: z.number().int().min(1).optional(),
+  })
+  .strict();
+
 export const languageConfigSchema = z
   .object({
     enabled: z.boolean().optional(),

--- a/tests/unit/compression/mcp-accessibility-config.test.ts
+++ b/tests/unit/compression/mcp-accessibility-config.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, beforeEach, afterEach, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { mcpAccessibilityConfigSchema } from "../../../src/shared/validation/compressionConfigSchemas.ts";
+
+// mcpAccessibility tunes how the MCP server filters oversized tool outputs: server.ts reads the
+// `compression/mcpAccessibility` DB key on every tool call (readMcpAccessibilityConfig). The
+// #4206 numeric bounds existed but were unreachable in production — no write route, and the
+// settings PUT schema (.strict()) rejected the key, so get/setMcpAccessibilityConfig had no
+// callers. This proves the new schema + dedicated sub-route + DB round-trip make the config
+// settable end to end, with clampMcpAccessibilityConfig owning the numeric floors.
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-mcpaccess-"));
+const ORIGINAL_DATA_DIR = process.env.DATA_DIR;
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../../src/lib/db/core.ts");
+const { getMcpAccessibilityConfig, setMcpAccessibilityConfig } = await import(
+  "../../../src/lib/db/compression.ts"
+);
+const route = await import(
+  "../../../src/app/api/settings/compression/mcp-accessibility/route.ts"
+);
+
+function resetDir() {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+describe("mcpAccessibility config reachability", () => {
+  beforeEach(resetDir);
+  afterEach(() => core.resetDbInstance());
+  after(() => {
+    core.resetDbInstance();
+    fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+    if (ORIGINAL_DATA_DIR === undefined) delete process.env.DATA_DIR;
+    else process.env.DATA_DIR = ORIGINAL_DATA_DIR;
+  });
+
+  it("validates partial updates and rejects unknown / invalid fields", () => {
+    assert.equal(
+      mcpAccessibilityConfigSchema.safeParse({ enabled: false, maxTextChars: 8000 }).success,
+      true
+    );
+    // unknown key rejected (.strict)
+    assert.equal(mcpAccessibilityConfigSchema.safeParse({ bogus: 1 }).success, false);
+    // non-positive maxTextChars rejected at the schema boundary
+    assert.equal(mcpAccessibilityConfigSchema.safeParse({ maxTextChars: -5 }).success, false);
+    assert.equal(mcpAccessibilityConfigSchema.safeParse({ collapseThreshold: 0 }).success, false);
+  });
+
+  it("persists a partial update through set/getMcpAccessibilityConfig (clamp owns floors)", async () => {
+    await setMcpAccessibilityConfig({ maxTextChars: 8000, collapseThreshold: 12 });
+    let cfg = await getMcpAccessibilityConfig();
+    assert.equal(cfg.maxTextChars, 8000);
+    assert.equal(cfg.collapseThreshold, 12);
+
+    // below the engine floor (MCP_ACCESSIBILITY_MIN_MAX_TEXT_CHARS) → clamp reverts to the
+    // default, the documented "misconfiguration falls back to the default" behavior.
+    await setMcpAccessibilityConfig({ maxTextChars: 100 });
+    cfg = await getMcpAccessibilityConfig();
+    assert.equal(cfg.maxTextChars, 50000);
+  });
+
+  it("PUT + GET round-trip through the dedicated sub-route persists the config", async () => {
+    const putRes = await route.PUT(
+      new Request("http://localhost/api/settings/compression/mcp-accessibility", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ maxTextChars: 12000, minLengthToProcess: 500 }),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      }) as any
+    );
+    assert.equal(putRes.status, 200);
+    const putBody = await putRes.json();
+    assert.equal(putBody.maxTextChars, 12000);
+    assert.equal(putBody.minLengthToProcess, 500);
+
+    // Survives a fresh read from a new DB handle (not just the write-path return value).
+    core.resetDbInstance();
+    const getRes = await route.GET(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      new Request("http://localhost/api/settings/compression/mcp-accessibility") as any
+    );
+    assert.equal(getRes.status, 200);
+    const getBody = await getRes.json();
+    assert.equal(getBody.maxTextChars, 12000);
+    assert.equal(getBody.minLengthToProcess, 500);
+  });
+
+  it("PUT merges over the current config (does not reset untouched fields)", async () => {
+    await setMcpAccessibilityConfig({ maxTextChars: 12000, collapseThreshold: 9 });
+
+    const putRes = await route.PUT(
+      new Request("http://localhost/api/settings/compression/mcp-accessibility", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ enabled: false }),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      }) as any
+    );
+    assert.equal(putRes.status, 200);
+    const body = await putRes.json();
+    assert.equal(body.enabled, false);
+    // untouched fields preserved (partial-merge-over-current, not over the defaults)
+    assert.equal(body.maxTextChars, 12000);
+    assert.equal(body.collapseThreshold, 9);
+  });
+});


### PR DESCRIPTION
## Cauda longa do programa "compressão 100% funcional" — item 2/6

### Problema
O servidor MCP apara saídas de tool grandes lendo a chave DB `compression/mcpAccessibility` (`server.ts::readMcpAccessibilityConfig`, em **toda** chamada de tool). O #4206 adicionou `clampMcpAccessibilityConfig` para limitar os campos numéricos (piso de `maxTextChars`, etc.). **Mas a config era inalcançável em produção:**

- `getMcpAccessibilityConfig` / `setMcpAccessibilityConfig` (`src/lib/db/compression.ts`) tinham **zero callers**.
- O schema da PUT principal de settings é `.strict()` e **rejeitava** a chave `mcpAccessibility`.

Resultado: o engine ficava preso nos defaults para sempre — os bounds do #4206 não tinham como ser exercitados.

### Fix
- **`mcpAccessibilityConfigSchema`** (`compressionConfigSchemas.ts`): validação estrutural (inteiros positivos / boolean, `.strict()`, todos opcionais para partial-merge). Os pisos numéricos continuam de responsabilidade do `clampMcpAccessibilityConfig` no write path (fonte única, como documentado).
- **Sub-rota dedicada** `GET/PUT /api/settings/compression/mcp-accessibility` (irmã de `/api/settings/compression`) — dá callers às funções de DB órfãs e torna os bounds do #4206 alcançáveis pelo dashboard. PUT faz **partial-merge sobre a config atual** (alterar um campo não reseta os outros); a resposta reflete a config efetiva (valores abaixo do piso voltam ao default).
- Documentada em `docs/reference/openapi.yaml` (coverage 193→194/512).

### Por que sub-rota e não no schema principal
Segue o precedente da sub-rota `settings/compression/rules` e mantém o schema `.strict()` da PUT principal focado, sem acoplar `CompressionConfig` ao engine.

### Testes (TDD — RED→GREEN)
`tests/unit/compression/mcp-accessibility-config.test.ts` (espelha o padrão do #4207):
1. schema aceita partial válido / rejeita chave desconhecida + valor não-positivo;
2. round-trip de DB via `set/getMcpAccessibilityConfig` incl. clamp revertendo `maxTextChars` abaixo do piso ao default;
3. round-trip **PUT+GET pela rota** persiste a config;
4. PUT faz merge sobre o atual (não reseta campos intocados).

**Validação:** suíte de compressão **699/699** ✓ · `typecheck:core` ✓ · `lint` ✓ · `check-openapi-routes`/`-coverage`/`check-docs-sync` ✓