### PR TITLE
feat(routing): advertise auto/cheap, auto/offline, auto/smart combos (#4235 Phase A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 _In development — bullets added per PR; finalized at release._
 
+### ✨ New Features
+
+- **feat(routing): advertise the `auto/cheap`, `auto/offline`, `auto/smart` combos (catalog ↔ README sync)** — the README lists `auto/cheap` (cheapest-per-token first), `auto/offline` (most quota/rate-limit headroom first) and `auto/smart` (quality-first + 10% exploration), and they already resolved at request time via `parseAutoPrefix` → `createVirtualAutoCombo`. But they were missing from `AUTO_TEMPLATE_VARIANTS`, so `/v1/models` and the dashboard combos list (which iterate that catalog) never showed them — the catalog drifted from the docs (visible in the issue's screenshots). Added the three entries so they're advertised everywhere alongside the other built-in `auto/*` combos. First slice of #4235 (OpenRouter-style `auto/<category>:<tier>` suffixes + new categories follow). ([#4235](https://github.com/diegosouzapw/OmniRoute/issues/4235) — thanks @MRDGH2821)
+
 ### 🐛 Fixed
 
 - **fix(providers): qwen-web model discovery now lists the live catalog instead of nothing** — the `qwen-web` cookie provider had no entry in `PROVIDER_MODELS_CONFIG`, so its model-discovery page returned an empty/stale local catalog (the OAuth fallback at the top of the route only fires for `provider === "qwen"`, leaving `qwen-web` to fall through to the no-config branch). Added a `qwen-web` entry that fetches the **public** `https://chat.qwen.ai/api/v2/models` endpoint (no auth header) and parses the `{ data: { data: [{ id, name, owned_by }] } }` shape (with a flatter `{ data: [] }` fallback). This is Problem #3 of #3931 (diagnosed by @thezukiru); Problem #1 — validator bare-token false-positive — shipped earlier in #3958, and Problem #2 — empty stream from Qwen WAF bot-detection on the streaming endpoint — remains a separate upstream/stealth concern. ([#3931](https://github.com/diegosouzapw/OmniRoute/issues/3931) — thanks @thezukiru)

--- a/open-sse/services/autoCombo/builtinCatalog.ts
+++ b/open-sse/services/autoCombo/builtinCatalog.ts
@@ -28,6 +28,12 @@ export const AUTO_TEMPLATE_VARIANTS: Record<string, AutoVariant | undefined> = {
   "auto/coding": "coding",
   "auto/fast": "fast",
   "auto/chat": undefined,
+  // #4235 Phase A: these are valid variants (parseAutoPrefix accepts them) and
+  // the README advertises them, but they were missing from this catalog so
+  // `/v1/models` + the dashboard never listed them. Surface them explicitly.
+  "auto/cheap": "cheap",
+  "auto/offline": "offline",
+  "auto/smart": "smart",
   "auto/claude-opus": "smart",
   "auto/claude-sonnet": "coding",
 };

--- a/tests/unit/auto-combos-enhanced-4235.test.ts
+++ b/tests/unit/auto-combos-enhanced-4235.test.ts
@@ -1,0 +1,60 @@
+/**
+ * #4235 — Enhanced `auto/*` combos.
+ *
+ * Phase A: the README advertises `auto/cheap`, `auto/offline`, `auto/smart`
+ * (and they already resolve via parseAutoPrefix → createVirtualAutoCombo), but
+ * they were missing from AUTO_TEMPLATE_VARIANTS, so `/v1/models` and the
+ * dashboard never listed them — the catalog/UI drifted from the README.
+ *
+ * Later phases (suffix parser `auto/<category>:<tier>`, new categories, `:pro`)
+ * extend the assertions below.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-4235-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.API_KEY_SECRET = process.env.API_KEY_SECRET || "auto-4235-test-secret";
+
+const core = await import("../../src/lib/db/core.ts");
+const builtinCatalog = await import("../../open-sse/services/autoCombo/builtinCatalog.ts");
+
+function resetStorage() {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+test.beforeEach(() => {
+  resetStorage();
+});
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("#4235 Phase A: README-advertised cheap/offline/smart are in the built-in catalog", () => {
+  const ids = Object.keys(builtinCatalog.AUTO_TEMPLATE_VARIANTS);
+  for (const id of ["auto/cheap", "auto/offline", "auto/smart"]) {
+    assert.ok(ids.includes(id), `expected ${id} in AUTO_TEMPLATE_VARIANTS (advertised in /v1/models)`);
+  }
+});
+
+test("#4235 Phase A: cheap/offline/smart map to their scoring variant", () => {
+  assert.equal(builtinCatalog.AUTO_TEMPLATE_VARIANTS["auto/cheap"], "cheap");
+  assert.equal(builtinCatalog.AUTO_TEMPLATE_VARIANTS["auto/offline"], "offline");
+  assert.equal(builtinCatalog.AUTO_TEMPLATE_VARIANTS["auto/smart"], "smart");
+});
+
+test("#4235 Phase A: each new entry materializes into a virtual auto-combo", async () => {
+  for (const id of ["auto/cheap", "auto/offline", "auto/smart"]) {
+    const suffix = id.slice("auto/".length);
+    const combo = await builtinCatalog.createBuiltinAutoCombo(id, suffix);
+    assert.equal(combo.id, id, `${id} combo id`);
+    assert.equal(combo.strategy, "auto", `${id} uses the auto strategy`);
+  }
+});


### PR DESCRIPTION
Part of #4235 (Phase A — does **not** close it; the suffix parser + new categories follow).

## What

The README's "zero-setup `auto/*`" table advertises `auto/cheap`, `auto/offline`, and `auto/smart`, and they already resolve at request time (`parseAutoPrefix` accepts them and `createVirtualAutoCombo` materializes them). But they were missing from `AUTO_TEMPLATE_VARIANTS`, which is what `/v1/models` (#4164) and the dashboard combos list iterate to advertise the built-in combos — so they never appeared in either. That's the catalog↔README drift visible in the issue's screenshots.

## Change

Add the three entries to `AUTO_TEMPLATE_VARIANTS`:

```ts
"auto/cheap": "cheap",     // cheapest-per-token first (cost-saver pack)
"auto/offline": "offline", // most quota / rate-limit headroom (offline-friendly pack)
"auto/smart": "smart",     // quality-first + 10% exploration
```

No new routing logic — these variants already worked; they're now *advertised*. The `/v1/models` catalog and the dashboard pick them up automatically (both iterate `AUTO_TEMPLATE_VARIANTS`).

## Regression test (TDD)

`tests/unit/auto-combos-enhanced-4235.test.ts`:
1. The three ids are present in `AUTO_TEMPLATE_VARIANTS` (**verified RED** before the change). 
2. They map to their scoring variant (cheap/offline/smart).
3. Each materializes into a virtual auto-combo via `createBuiltinAutoCombo`.

## Validation

- `eslint` ✅ · `typecheck:core` ✅ · `check:file-size` ✅
- new test: 3/3 GREEN (RED proven first)

## Follow-ups (rest of #4235)

- Phase B: OpenRouter-style `auto/<category>:<tier>` suffix parser (`auto/coding:fast`, `:cheap`/`:floor`, `:free`, `:reliable`, `:pro`) composing existing mode-packs + `classifyTier` free/premium candidate filters.
- New category roots `auto/vision`, `auto/reasoning` (capability-filtered). Media roots (`video`/`image`/`speech`) are separate non-chat endpoints — out of scope for the combo router.

Thanks @MRDGH2821 for the report.