### PR TITLE
refactor(compression): remove vestigial SLM seam + dead deprecated alias

### DIFF
--- a/open-sse/services/compression/index.ts
+++ b/open-sse/services/compression/index.ts
@@ -151,8 +151,8 @@ export { compressAggressive } from "./aggressive.ts";
 
 export { STOPWORDS, FORCE_PRESERVE_RE, scoreToken, pruneByScore } from "./ultraHeuristic.ts";
 
-export type { SLMInterface, UltraCompressResult } from "./ultra.ts";
-export { createSLMStub, ultraCompress } from "./ultra.ts";
+export type { UltraCompressResult } from "./ultra.ts";
+export { ultraCompress } from "./ultra.ts";
 
 export type { UltraConfig } from "./types.ts";
 export { DEFAULT_ULTRA_CONFIG } from "./types.ts";

--- a/open-sse/services/compression/stats.ts
+++ b/open-sse/services/compression/stats.ts
@@ -16,9 +16,6 @@ export function estimateCompressionTokens(text: string | object | null | undefin
   return Math.ceil(str.length / CHARS_PER_TOKEN);
 }
 
-/** @deprecated Use estimateCompressionTokens instead. */
-export const estimateTokensForStats = estimateCompressionTokens;
-
 export function createCompressionStats(
   originalBody: Record<string, unknown>,
   compressedBody: Record<string, unknown>,

--- a/open-sse/services/compression/ultra.ts
+++ b/open-sse/services/compression/ultra.ts
@@ -5,18 +5,6 @@ import { extractTextContent, mapTextContent, type ChatMessageLike } from "./mess
 
 const COMPRESSED_PREFIX = "[COMPRESSED:";
 
-export interface SLMInterface {
-  compress(text: string, rate: number): Promise<string>;
-}
-
-export function createSLMStub(): SLMInterface {
-  return {
-    async compress(text: string, rate: number): Promise<string> {
-      return pruneByScore(text, rate);
-    },
-  };
-}
-
 export interface UltraCompressResult {
   messages: Array<{ role: string; content?: string | unknown[]; [key: string]: unknown }>;
   stats: CompressionStats;

--- a/tests/unit/compression/ultra.test.ts
+++ b/tests/unit/compression/ultra.test.ts
@@ -6,11 +6,7 @@ import {
   STOPWORDS,
   FORCE_PRESERVE_RE,
 } from "../../../open-sse/services/compression/ultraHeuristic.ts";
-import {
-  ultraCompress,
-  createSLMStub,
-  type SLMInterface,
-} from "../../../open-sse/services/compression/ultra.ts";
+import { ultraCompress } from "../../../open-sse/services/compression/ultra.ts";
 import type { UltraConfig } from "../../../open-sse/services/compression/types.ts";
 
 describe("scoreToken", () => {
@@ -253,37 +249,5 @@ describe("ultraCompress", () => {
     const messages = [{ role: "user", content: "the quick brown fox" }];
     const result = await ultraCompress(messages, config);
     assert.strictEqual(result.stats.savingsPercent, 0);
-  });
-});
-
-describe("createSLMStub", () => {
-  it("should return object with compress function", () => {
-    const stub = createSLMStub();
-    assert(stub);
-    assert(typeof stub.compress === "function");
-  });
-
-  it("stub.compress should return a string", async () => {
-    const stub = createSLMStub();
-    const result = await stub.compress("hello world", 0.5);
-    assert(typeof result === "string");
-  });
-
-  it("stub.compress result should be <= input length", async () => {
-    const stub = createSLMStub();
-    const input = "the quick brown fox jumps over the lazy dog";
-    const result = await stub.compress(input, 0.5);
-    assert(result.length <= input.length);
-  });
-
-  it("stub.compress on empty string should return empty", async () => {
-    const stub = createSLMStub();
-    const result = await stub.compress("", 0.5);
-    assert.strictEqual(result, "");
-  });
-
-  it("stub should have a name or identifier", () => {
-    const stub = createSLMStub();
-    assert(stub !== null && typeof stub === "object");
   });
 });


### PR DESCRIPTION
## Sweep final de dead-code/scaffold — encerra o "compressão 100% funcional"

Varredura de verificação de completude no subsistema achou **2 vestígios** que escaparam do #4223:

### 1. Seam SLM morto (`ultra.ts`)
`SLMInterface` + `createSLMStub` eram um ponto de injeção de "small language model" para o engine ultra — **nunca consumido**. `ultraCompress` poda **inline** via `pruneByScore` (linha 55) e o caminho de modelo real vive no engine **llmlingua** separado (worker ONNX). A interface tinha **zero consumidores de produção**; só os próprios testes a exercitavam.

### 2. Alias `@deprecated` morto (`stats.ts`)
`estimateTokensForStats` = alias de `estimateCompressionTokens` marcado `@deprecated`, com **zero callers**.

### Mudanças
- `ultra.ts`: remove `SLMInterface` + `createSLMStub`.
- `stats.ts`: remove `estimateTokensForStats`.
- `index.ts`: remove os re-exports correspondentes.
- `ultra.test.ts`: remove o bloco `describe("createSLMStub")` (o scaffold que ele testava sumiu; o comportamento **real** do ultra segue 100% coberto — **39 testes**).

### Observação (deixada como está — decisão maior)
O config do ultra ainda carrega `modelPath` / `slmFallbackToAggressive`, que `ultraCompress` **também ignora**. Sinalizado para decisão separada (ligar ao llmlingua **vs** remover) — não toquei pois mexe em schema/DB/defaults.

**Validação:** suíte de compressão **709/709** ✓ · `typecheck:core` ✓ · `lint` ✓ · zero referências pendentes aos símbolos removidos.