### PR TITLE
fix(glm): default max_tokens and extended timeout for GLM-5.2+ thinking

### DIFF
--- a/open-sse/config/glmProvider.ts
+++ b/open-sse/config/glmProvider.ts
@@ -136,7 +136,7 @@ export const GLM_QUOTA_URLS = Object.freeze({
 
 export const GLMT_TIMEOUT_MS = 900_000;
 
-export const GLM_TIMEOUT_MS = 900_000;
+export const GLM_TIMEOUT_MS = 3_000_000; // 50 min — aligned with Z.AI Coding Plan FAQ (API_TIMEOUT_MS=3000000)
 
 export const GLM_REQUEST_DEFAULTS = Object.freeze({
   maxTokens: 16_384,

--- a/open-sse/executors/glm.ts
+++ b/open-sse/executors/glm.ts
@@ -63,6 +63,29 @@ function parseGlm52Effort(model: string): { baseModel: string; effort: "high" | 
   return null;
 }
 
+/**
+ * Detects GLM models that support deep thinking (5.2+).
+ * These models share a single max_tokens budget for reasoning + response
+ * (Z.AI does not document a separate thinking budget). When the client
+ * doesn't explicitly request max_tokens, we default to the model's full
+ * output capacity so reasoning isn't truncated by a low generic default.
+ *
+ * To add future models (e.g. glm-5.3, glm-5.4), just extend the regex.
+ * https://docs.z.ai/guides/overview/concept-param
+ */
+const GLM_THINKING_MODEL_PATTERN = /^glm-5\.(?:[2-9]|\d{2,})/i;
+
+function isGlmThinkingModel(model: string): boolean {
+  return GLM_THINKING_MODEL_PATTERN.test(model);
+}
+
+/**
+ * Z.AI's official max output for GLM-5.2+ is 131072 tokens (128K).
+ * This budget covers BOTH reasoning and the final response.
+ * https://z.ai/blog/glm-5.2
+ */
+const GLM_THINKING_DEFAULT_MAX_TOKENS = 131072;
+
 function applyGlmRequestDefaults(body: unknown, defaults?: JsonRecord | null): unknown {
   const record = asRecord(body);
   if (!record || !defaults) return body;
@@ -250,6 +273,21 @@ export class GlmExecutor extends DefaultExecutor {
     // Ensure upstream receives the base model ID, not the effort-suffixed alias
     if (record && effortTier) {
       record.model = effectiveModel;
+    }
+
+    // GLM-5.2+ models share a single max_tokens budget for reasoning + response.
+    // When the client doesn't explicitly set max_tokens, default to the model's
+    // full output capacity (131072) so deep reasoning isn't truncated by the
+    // generic translator defaults (64000 for Anthropic, 16384 for OpenAI).
+    // This acts as the "transparent proxy override" described in Z.AI's own
+    // Terminal-Bench evaluation methodology.
+    // https://huggingface.co/blog/zai-org/glm-52-blog
+    if (record && isGlmThinkingModel(effectiveModel)) {
+      const clientBody = asRecord(body);
+      const clientMaxTokens = clientBody?.max_tokens ?? clientBody?.max_completion_tokens;
+      if (!clientMaxTokens) {
+        record.max_tokens = GLM_THINKING_DEFAULT_MAX_TOKENS;
+      }
     }
 
     if (transport === "openai") {

--- a/tests/unit/glm-executor.test.ts
+++ b/tests/unit/glm-executor.test.ts
@@ -640,3 +640,44 @@ test("GlmExecutor Anthropic fallback keeps tool names unprefixed", async () => {
     globalThis.fetch = originalFetch;
   }
 });
+
+// Regression for #4255 — GLM-5.2+ thinking models share a single max_tokens
+// budget for reasoning + response. When the client omits max_tokens, the
+// executor must default to the model's full output capacity (131072) so deep
+// reasoning isn't truncated by the generic GLM default (16_384). Scoped to
+// GLM-5.2+ via transformForTransport — non-thinking GLM models are untouched.
+test("GlmExecutor defaults GLM-5.2+ max_tokens to 131072 when the client omits it", () => {
+  const executor = new GlmExecutor("glm");
+  const body = { messages: [{ role: "user", content: "hi" }] };
+
+  const transformed = executor.transformForTransport("glm-5.2", body, false, {
+    apiKey: "glm-key",
+  }, "openai") as any;
+
+  assert.equal((body as any).max_tokens, undefined, "caller body must not be mutated");
+  assert.equal(transformed.max_tokens, 131072);
+});
+
+test("GlmExecutor preserves a client-supplied max_tokens for GLM-5.2+ (no override)", () => {
+  const executor = new GlmExecutor("glm");
+  const body = { messages: [{ role: "user", content: "hi" }], max_tokens: 4096 };
+
+  const transformed = executor.transformForTransport("glm-5.2", body, false, {
+    apiKey: "glm-key",
+  }, "openai") as any;
+
+  assert.equal(transformed.max_tokens, 4096);
+});
+
+test("GlmExecutor does NOT bump max_tokens for non-thinking GLM (glm-4.6)", () => {
+  const executor = new GlmExecutor("glm");
+  const body = { messages: [{ role: "user", content: "hi" }] };
+
+  const transformed = executor.transformForTransport("glm-4.6", body, false, {
+    apiKey: "glm-key",
+  }, "openai") as any;
+
+  // Stays at the generic GLM default (16_384) — never the 131072 thinking budget.
+  assert.notEqual(transformed.max_tokens, 131072);
+  assert.equal(transformed.max_tokens, 16_384);
+});


### PR DESCRIPTION
## Problem

GLM-5.2+ models share a **single `max_tokens` budget** for reasoning + response — Z.AI does not document a separate thinking budget. When the client doesn't explicitly set `max_tokens`, the generic translator defaults kick in:

| Transport | Default | Source |
|---|---|---|
| Anthropic (`-high`/`-max`) | **64,000** | `DEFAULT_MAX_TOKENS` in `constants.ts` |
| OpenAI (base `glm-5.2`) | **16,384** | `GLM_REQUEST_DEFAULTS.maxTokens` in `glmProvider.ts` |

Both values are far below GLM-5.2's official max output of **131,072 tokens**. This truncates deep reasoning chains mid-thinking (`finish_reason: "length"`), especially for effort tiers (`glm-5.2-high`/`glm-5.2-max`) where the model is expected to reason extensively.

Z.AI's own Terminal-Bench evaluation explicitly addresses this:

> *We override max_new_tokens to 128k via transparent proxy, bypassing the 64k CLI cap.*
> — https://huggingface.co/blog/zai-org/glm-52-blog

OmniRoute **is** that transparent proxy, so it should apply the override.

Additionally, the hard timeout of **15 minutes** (`GLM_TIMEOUT_MS = 900_000`) aborts valid long-running requests when `effort=max` reasoning takes 10–30 minutes.

## Root Cause

1. **`max_tokens` not defaulted for GLM-5.2+**: `transformForTransport` in `glm.ts` doesn't override `max_tokens` before the transport split, so each transport falls back to its own generic default.
2. **Timeout too low**: `GLM_TIMEOUT_MS` is 15 min, but Z.AI's Coding Plan FAQ recommends `API_TIMEOUT_MS = 3,000,000` (50 min).

## Fix

### Fix 1 — `max_tokens` override (`open-sse/executors/glm.ts`)

Default `max_tokens` to **131,072** (Z.AI's official max output for GLM-5.2+) when the client doesn't explicitly request it. Applied in `transformForTransport` **before** the transport split, so both OpenAI and Anthropic paths benefit.

```typescript
if (record && isGlmThinkingModel(effectiveModel)) {
  const clientBody = asRecord(body);
  const clientMaxTokens = clientBody?.max_tokens ?? clientBody?.max_completion_tokens;
  if (!clientMaxTokens) {
    record.max_tokens = GLM_THINKING_DEFAULT_MAX_TOKENS;
  }
}
```

Model detection uses a regex that automatically covers future GLM-5.x releases:

```typescript
const GLM_THINKING_MODEL_PATTERN = /^glm-5\.(?:[2-9]|\d{2,})/i;
```

| Model | Matched? |
|---|---|
| `glm-5.2`, `glm-5.2-high`, `glm-5.2-max` | ✅ |
| `glm-5.3`, `glm-5.10`, future `glm-5.x` | ✅ |
| `glm-5.1`, `glm-5.0`, `glm-4`, `glm-5-turbo` | ❌ |

Explicit client `max_tokens` is always respected — the override only applies when the client omits it.

### Fix 2 — Extended timeout (`open-sse/config/glmProvider.ts`)

```diff
- export const GLM_TIMEOUT_MS = 900_000;
+ export const GLM_TIMEOUT_MS = 3_000_000; // 50 min
```

Aligned with Z.AI Coding Plan FAQ recommendation (`API_TIMEOUT_MS = 3000000`).

## Files changed

| File | Change |
|---|---|
| `open-sse/executors/glm.ts` | +23 lines (helper + override) |
| `open-sse/config/glmProvider.ts` | 1 line (timeout) |

## Validation

- Regex coverage verified for current and future model IDs (5.2–5.9, 5.10+, excludes 5.0/5.1/4.x/turbo).
- Tested locally: `glm-5.2-max` requests without explicit `max_tokens` now receive 131072 upstream.
- No impact on models outside the GLM-5.2+ family.

## Compatibility

No breaking changes. Models that previously received the generic default (64000/16384) now receive 131072 — only affects how much output the upstream allows, not model behavior. Clients that explicitly set `max_tokens` are unaffected. Future GLM-5.x models are covered automatically by the regex.