### PR TITLE
ci(mutation): split over-budget batches by range/pair (re-deliver split orphaned on #4258)

### DIFF
--- a/.github/workflows/nightly-mutation.yml
+++ b/.github/workflows/nightly-mutation.yml
@@ -36,11 +36,15 @@ jobs:
     #     a successful finish); a job cancelled at the cap writes nothing, so the next run is cold
     #     again — an infinite never-seeds loop. actions/cache is also branch-scoped, so each branch
     #     (incl. release) must seed its OWN cache via a run with enough headroom. Measured cold runs
-    #     (run 27801802713): a/b never finished even isolated; c=180min CANCELLED (4 modules),
-    #     d=180min CANCELLED (3 combo modules), g=142min, h=132min, e=66, f=45, i=33. So a/b/c/d get
-    #     350min (job max 360) and g/h a 240min variance buffer; once seeded, later nightlies only
-    #     re-test changed mutants and fit well under the default. NOTE: batch c's old "2 modules ~2h"
-    #     assumption went stale when c grew to 4 modules — keep this budget in sync with the matrix.
+    #     Measured cold totals (run 27801802713, extrapolated from the % at the 180/350 cancel point):
+    #     auth ~375min (2301 mutants — EXCEEDS the 360min job max even isolated), accountFallback
+    #     ~358min (1441), the c security quartet ~348min (1163), d ~197min (1316), g=142, h=132, e=66,
+    #     f=45, i=33. The widely-covered modules blow the budget because the tap-runner re-runs every
+    #     covering test file per mutant (a perTest fixed cost over ~138 test files, times thousands of
+    #     mutants). A flat timeout bump cannot rescue auth (>360min max) — so the three over-budget
+    #     batches are SPLIT so each half fits: auth->a1/a2 and accountFallback->b1/b2 by mutation range
+    #     (`file:startLine-endLine`), the c quartet->c1/c2 by module pair. Splitting also seeds each
+    #     sub-batch's own incremental cache, after which nightlies re-test only changed mutants.
     # Full coverage every night in parallel; wall-clock = the slowest batch's cold run until seeded.
     # Runs at stryker concurrency=4 with per-process DATA_DIR isolation
     # (tests/_setup/isolateDataDir.ts) — see _concurrency_comment in stryker.conf.json.
@@ -48,23 +52,38 @@ jobs:
       fail-fast: false
       matrix:
         batch:
-          # Per-batch `timeout` (minutes) tiers the cold-seeding budget by measured cost — see the
-          # cold-run measurements in the comment above. Batches without the key default to 180.
-          # a/b (large isolated modules) + c/d (4 and 3 modules, observed to exceed 180min cold) get
-          # 350 (GitHub-hosted job max is 360); g/h (142/132min cold — within runner-variance distance
-          # of the 180 cap) get a 240 buffer. e/f/i (33-66min) stay at the 180 default.
-          - name: a
-            mutate: "src/sse/services/auth.ts"
-            timeout: 350
-          - name: b
-            mutate: "open-sse/services/accountFallback.ts"
-            timeout: 350
-          - name: c
-            mutate: "src/server/authz/routeGuard.ts,src/shared/utils/circuitBreaker.ts,open-sse/utils/error.ts,open-sse/utils/publicCreds.ts"
-            timeout: 350
+          # Per-batch `timeout` (minutes) tiers the cold-seeding budget by measured cost; batches
+          # without the key default to 180. Cold-run profiling (run 27801802713) showed the
+          # widely-covered modules need FAR more than the 180 cap because the tap-runner re-runs every
+          # covering test file per mutant: auth ~375min (2301 mutants, EXCEEDS the 360min GitHub job
+          # max even isolated), accountFallback ~358min, the c security quartet ~348min — none fit a
+          # single job. So auth/accountFallback are split by MUTATION RANGE (`file:startLine-endLine`,
+          # ~half the mutants each) into a1/a2, b1/b2; the c quartet is split by MODULE pair into
+          # c1/c2. d (3 combo modules, ~197min) stays whole. Split-heavy batches get 300min headroom
+          # for their cold seeding run; once each batch completes once and writes
+          # stryker-incremental.json, later runs re-test only changed mutants and finish far faster.
+          # g/h (142/132min cold) keep a 240 buffer; e/f/i (33-66min) keep the 180 default.
+          - name: a1
+            mutate: "src/sse/services/auth.ts:1-1109"
+            timeout: 300
+          - name: a2
+            mutate: "src/sse/services/auth.ts:1110-2218"
+            timeout: 300
+          - name: b1
+            mutate: "open-sse/services/accountFallback.ts:1-863"
+            timeout: 300
+          - name: b2
+            mutate: "open-sse/services/accountFallback.ts:864-1726"
+            timeout: 300
+          - name: c1
+            mutate: "src/server/authz/routeGuard.ts,src/shared/utils/circuitBreaker.ts"
+            timeout: 300
+          - name: c2
+            mutate: "open-sse/utils/error.ts,open-sse/utils/publicCreds.ts"
+            timeout: 300
           - name: d
             mutate: "open-sse/services/combo/comboStructure.ts,open-sse/services/combo/autoStrategy.ts,open-sse/services/combo/validateQuality.ts"
-            timeout: 350
+            timeout: 300
           - name: e
             mutate: "open-sse/services/combo/shadowRouting.ts,open-sse/services/combo/targetSorters.ts,open-sse/services/combo/comboPredicates.ts,open-sse/services/combo/rrState.ts,open-sse/services/combo/comboData.ts"
           - name: f
@@ -77,8 +96,12 @@ jobs:
             timeout: 240
           - name: i
             mutate: "open-sse/handlers/chatCore/telemetryHelpers.ts,open-sse/handlers/chatCore/memorySkillsInjection.ts,open-sse/handlers/chatCore/semanticCache.ts"
-    # Per-batch budget: a/b/c/d override to 350min, g/h to 240min; the rest default to 180min.
-    # `matrix.batch.timeout` is null for batches without the key -> `|| 180`.
+    # Per-batch budget: split-heavy batches (a1/a2/b1/b2/c1/c2/d) override to 300min, g/h to 240min;
+    # the rest default to 180min. `matrix.batch.timeout` is null for batches without the key -> `|| 180`.
+    # NOTE: a1+a2 both mutate auth.ts (disjoint line ranges) and b1+b2 both mutate accountFallback.ts;
+    # when merging the per-batch mutation.json for radiography/scores, same-file mutants from sibling
+    # ranges must be UNIONED (scripts/check/check-mutation-ratchet.mjs::measureMutationScores and
+    # scripts/quality/mutation-radiography.mjs both merge per file).
     timeout-minutes: ${{ matrix.batch.timeout || 180 }}
     steps:
       - uses: actions/checkout@v6

--- a/scripts/check/check-mutation-ratchet.mjs
+++ b/scripts/check/check-mutation-ratchet.mjs
@@ -68,17 +68,27 @@ export function mutationScoreForFile(fileData) {
 /**
  * Score por arquivo a partir de um ou mais reports (batches). Arquivos sem mutante
  * coberto (score null) são omitidos.
+ *
+ * ⭐ Sibling batches que fatiam o MESMO arquivo (auth.ts split em a1:1-1109 + a2:1110-2218
+ * por mutation range; accountFallback em b1/b2) carregam fatias DISJUNTAS dos mutantes
+ * daquele arquivo. O score verdadeiro do arquivo precisa de TODAS as fatias juntas, então
+ * unimos `files[<arquivo>].mutants` entre os reports ANTES de pontuar — não sobrescrever
+ * (senão a última fatia venceria e reportaria só metade do arquivo).
  * @param {object|object[]} reportOrReports parsed mutation.json (ou array)
  * @returns {Record<string, number>}
  */
 export function measureMutationScores(reportOrReports) {
   const reports = Array.isArray(reportOrReports) ? reportOrReports : [reportOrReports];
-  const out = {};
+  const mutantsByFile = {};
   for (const report of reports) {
     for (const [file, data] of Object.entries(report?.files || {})) {
-      const score = mutationScoreForFile(data);
-      if (score !== null) out[file] = score;
+      (mutantsByFile[file] ||= []).push(...(data?.mutants || []));
     }
+  }
+  const out = {};
+  for (const [file, mutants] of Object.entries(mutantsByFile)) {
+    const score = mutationScoreForFile({ mutants });
+    if (score !== null) out[file] = score;
   }
   return out;
 }

--- a/tests/unit/build/check-mutation-ratchet.test.ts
+++ b/tests/unit/build/check-mutation-ratchet.test.ts
@@ -67,6 +67,27 @@ test("measureMutationScores accepts several reports (per-batch) and unions them"
   assert.equal(scores["src/b.ts"], 100);
 });
 
+// ── SAME file split across sibling batches (auth.ts -> a1:1-1109 + a2:1110-2218 by
+// mutation range): the file's mutants are DISJOINT per batch and must be UNIONED, not
+// overwritten — else the last batch wins and the score reflects only half the file. ──
+test("measureMutationScores unions same-file mutants across split batches (not overwrite)", () => {
+  // a1 slice: 1 killed, 1 survived (would score 50 alone)
+  const a1 = {
+    files: { "src/sse/services/auth.ts": { mutants: [{ status: "Killed" }, { status: "Survived" }] } },
+  };
+  // a2 slice: 3 killed (would score 100 alone)
+  const a2 = {
+    files: {
+      "src/sse/services/auth.ts": {
+        mutants: [{ status: "Killed" }, { status: "Killed" }, { status: "Killed" }],
+      },
+    },
+  };
+  const scores = measureMutationScores([a1, a2]);
+  // Combined: detected = 4 (1+3), survived = 1 -> 4/5 = 80. NOT 50 (a1) nor 100 (a2).
+  assert.ok(Math.abs(scores["src/sse/services/auth.ts"] - 80) < 1e-9);
+});
+
 // ── readBaselineMutationScores: graceful skip when the file/keys are absent ──
 test("readBaselineMutationScores returns {} when the baseline file is missing", () => {
   assert.deepEqual(readBaselineMutationScores("/no/such/baseline.json"), {});


### PR DESCRIPTION
## Por que este PR existe (split órfão no #4258)

O **#4258** fez squash-merge no seu **1º commit** (o restore flat de 350) **antes** do commit do split ser pushado → o split ficou órfão e **nunca chegou no release**. Resultado: release (agora v3.8.30) carrega a/b/c/d em `timeout: 350`, que **não resgata** os módulos largamente-cobertos. Este PR re-entrega o split (mesmo bug de órfão que o #4225 teve com o seu próprio headroom).

## Evidência (run 27801802713, o tap-runner re-roda todo test file cobridor por mutante)

| Batch | Mutantes | Tempo cold | Cabe no job (teto 360min)? |
|---|---|---|---|
| auth | 2301 | **~375min** | ❌ **excede o teto, mesmo isolado** |
| accountFallback | 1441 | ~358min | borderline (cancelou a 350) |
| c (4 security) | 1163 | ~348min | borderline |
| d (3 combo) | 1316 | ~197min | ✅ |

Job cancelado nunca grava `stryker-incremental.json` → próximo run cold → loop nunca-seda. `actions/cache` é branch-scoped → release seda o próprio cache.

## Fix — split p/ cada metade caber e sedar seu cache

- **auth.ts** → `a1`(`:1-1109`) + `a2`(`:1110-2218`) por **mutation range**
- **accountFallback.ts** → `b1`(`:1-863`) + `b2`(`:864-1726`) por range
- **c quarteto** → `c1`(routeGuard+circuitBreaker) + `c2`(error+publicCreds) por par
- **d** inteiro; tetos 300 (pesados) / 240 (g,h) / 180 (e,f,i)
- **12 batches**; união == `stryker.conf` mutate (**31 módulos, idêntico, zero drift**)

## Fix de tooling

`a1`+`a2` emitem `files["auth.ts"]` com fatias **disjuntas** → `measureMutationScores` **sobrescrevia** (score de meio-arquivo) → agora **une** os mutantes entre reports antes de pontuar. `mutation-radiography.mjs` já mescla por arquivo. **+teste de regressão** (a1=50% + a2=100% → 80%).

## Validação (Hard Rule #18)

1. **Run de validação `27823984918`** (na branch do split) confirma que os batches splitados cabem + produz o set COMPLETO de 31 módulos.
2. **TDD**: 13/13 testes verdes (ratchet 8/8 c/ novo teste de união + radiografia 5/5); sem regressão nos 22 módulos leaf reais.
3. **YAML válido** + union(batches)==conf.mutate idêntico.

Cherry-pick limpo do commit órfão sobre v3.8.30 (mesma base de conteúdo 350). Diff: **3 arquivos, +79/−25**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)