### PR TITLE
test(ci): reconcile release/v3.8.30 baseline + test drift

### DIFF
--- a/config/quality/complexity-baseline.json
+++ b/config/quality/complexity-baseline.json
@@ -1,6 +1,7 @@
 {
   "_comment": "Catraca de complexidade (check-complexity.mjs, ESLint core rules complexity>=15 e max-lines-per-function>80 sobre src+open-sse+electron+bin via eslint.complexity.config.mjs). Conta total de violacoes; so pode cair. --update ratcheta.",
-  "count": 1800,
+  "count": 1885,
+  "_rebaseline_2026_06_19_v3830": "Re-baseline consciente: drift 1800->1885 (+85) do ciclo v3.8.25->v3.8.29 (round-9, ~130 PRs: combo split D7/D8, chatCore split, novos providers/modelos, cost-telemetry, MITM decrypt, remote-mode CLI). Medido no tip release/v3.8.30 (3e6be4701). Mesma familia dos re-baselines anteriores — crescimento de feature legitima, nao regressao. Reducao fica como debt de refactor dedicado.",
   "_rebaseline_2026_06_13_v3825": "Re-baseline consciente: drift 1794->1800 (+6) do ciclo v3.8.24->v3.8.25 (features #3799-#3806). Mesma familia dos re-baselines anteriores — crescimento de feature legitima, nao regressao. Reducao fica como debt de refactor dedicado.",
   "_rebaseline_2026_06_10": "Re-baseline consciente: 1739 foi medido na branch das Fases 0-6 (base ~v3.8.17); a v3.8.18 publicada ja carrega 1746 (provado: o commit-base 5f2722bd6, anterior a qualquer commit do ciclo v3.8.19, mede 1746 — funcoes complexas dos reworks RequestLoggerV2/stream/combo). Mesma familia dos re-baselines de eslintWarnings/file-size. Reducao = Fase 6A (2026-06-16).",
   "_rebaseline_2026_06_13_6a11": "Re-baseline consciente Task 6A.11: escopo ampliado para src+open-sse+electron+bin (electron/bin contribuem 0 violacoes novas — todos os 4 arquivos .ts em bin/ estao abaixo dos thresholds). Drift 1746→1794 pre-existente de features mergeadas nos ciclos v3.8.22/v3.8.23 (nao causado por esta task). Congelado no valor real medido para destrancar o gate."

--- a/tests/integration/integration-wiring.test.ts
+++ b/tests/integration/integration-wiring.test.ts
@@ -284,7 +284,11 @@ describe("API Routes — dashboard and tool consumers", () => {
     assert.match(globals, /--color-card:\s+#ffffff/);
     assert.match(globals, /--color-card:\s+#161b22/);
     assert.match(globals, /--color-card:\s+var\(--color-card\)/);
-    assert.match(requestLogger, /bg-black\/5 dark:bg-black\/20/);
+    // #4233 ("opaque tables D9") replaced the bg-black/5 tint — which lost to
+    // bg-surface via tailwind-merge — with the opaque bg-surface theme color.
+    // The intent here (request log surface stays opaque over theme colors) is now
+    // expressed by bg-surface itself.
+    assert.match(requestLogger, /bg-surface/);
     assert.doesNotMatch(requestLogger, /\/api\/logs\/active/);
   });
 

--- a/tests/integration/search-providers-catalog.test.ts
+++ b/tests/integration/search-providers-catalog.test.ts
@@ -2,7 +2,7 @@
  * Integration tests for GET /api/search/providers — extended catalog (F4).
  *
  * Tests:
- * - Returns 15 items total (12 search + 3 fetch providers).
+ * - Returns 16 items total (13 search + 3 fetch providers).
  * - Each item carries the correct `kind` field.
  * - Status reflects actual DB credential state:
  *   - "configured"  when an active, non-rate-limited connection exists.
@@ -50,7 +50,10 @@ const route = await import("../../src/app/api/search/providers/route.ts");
 // Constants
 // ---------------------------------------------------------------------------
 
-const EXPECTED_SEARCH_COUNT = 12;
+// 13 search-kind providers: serper, brave, perplexity, exa, tavily, google-pse,
+// linkup, searchapi, youcom, searxng, ollama, zai + duckduckgo-free (added in the
+// v3.8.27 cycle, registry open-sse/config/searchRegistry.ts).
+const EXPECTED_SEARCH_COUNT = 13;
 const EXPECTED_FETCH_COUNT = 3;
 const EXPECTED_TOTAL = EXPECTED_SEARCH_COUNT + EXPECTED_FETCH_COUNT;
 
@@ -137,7 +140,7 @@ test("search-providers-catalog: returns 401 for unauthenticated requests when au
   assert.ok(!bodyStr.includes(" at /"), "error body must not contain stack trace");
 });
 
-test("search-providers-catalog: returns 15 providers (12 search + 3 fetch)", async () => {
+test("search-providers-catalog: returns 16 providers (13 search + 3 fetch)", async () => {
   const req = await buildAuthRequest();
   const res = await route.GET(req);
 

--- a/tests/unit/tproxy-transparent-socket.test.ts
+++ b/tests/unit/tproxy-transparent-socket.test.ts
@@ -113,15 +113,28 @@ test("loadTransparentAddon loads the addon from the cwd-relative standalone path
   assert.equal(addon, fake);
 });
 
-test("isTransparentSocketAvailable returns a boolean (false in CI — addon not built)", () => {
+// The native addon is built CONDITIONALLY (prebuilds — #4236), so its presence is
+// environment-dependent: absent on a JS-only install, present on runners where the
+// prebuilt .node loads (e.g. the Node-compat CI jobs). These tests must hold in both
+// states: when absent, the helpers throw the actionable "not available" guard; when
+// present, the call reaches the OS and throws a runtime error (no CAP_NET_ADMIN /
+// TPROXY privileges in CI) — still throwing, just not the guard message.
+test("isTransparentSocketAvailable returns a boolean (addon presence is environment-dependent)", () => {
   assert.equal(typeof isTransparentSocketAvailable(), "boolean");
-  assert.equal(isTransparentSocketAvailable(), false);
 });
 
-test("createTransparentListenerFd throws a clear, actionable error when unavailable", () => {
-  assert.throws(() => createTransparentListenerFd("0.0.0.0", 8443), /not available|Linux|build/i);
+test("createTransparentListenerFd throws when unavailable (guard) or when present without privileges (OS error)", () => {
+  if (isTransparentSocketAvailable()) {
+    assert.throws(() => createTransparentListenerFd("0.0.0.0", 8443));
+  } else {
+    assert.throws(() => createTransparentListenerFd("0.0.0.0", 8443), /not available|Linux|build/i);
+  }
 });
 
-test("setSocketMark throws when the addon is unavailable", () => {
-  assert.throws(() => setSocketMark(7, 0x539), /not available/i);
+test("setSocketMark throws when unavailable (guard) or when present without privileges (OS error)", () => {
+  if (isTransparentSocketAvailable()) {
+    assert.throws(() => setSocketMark(7, 0x539));
+  } else {
+    assert.throws(() => setSocketMark(7, 0x539), /not available/i);
+  }
 });


### PR DESCRIPTION
## Summary

Four **deterministic** CI failures on `release/v3.8.30` (reproducible on the no-op cycle-open commit `a5c0576c3` AND in clean CI) were stale baselines / test expectations that never got reconciled when the v3.8.30 cycle opened. **None are flaky; none are regressions** — each tracks a change that was already intentional and shipped.

| # | Job | Drift | Fix |
|---|-----|-------|-----|
| 1 | Quality Ratchet | `check:complexity` 1885 > baseline 1800 | re-baseline 1800→1885 + `_rebaseline_2026_06_19_v3830` (legit feature growth, ~130 PRs v3.8.25→v3.8.29) |
| 2 | Integration (1/2) | `integration-wiring` asserts `bg-black/5` | #4233 ("opaque tables D9") replaced it with opaque `bg-surface` → assert `bg-surface` |
| 3 | Integration (1/2) | `search-providers-catalog` `EXPECTED_SEARCH_COUNT=12` | `duckduckgo-free` added in v3.8.27 → bump 12→13 (route returns 13 search + 3 fetch = 16) |
| 4 | Node 24/26 Compat | `tproxy-transparent-socket` hard-asserts addon `=== false` | #4236 (prebuilds) makes the addon load on those runners → branch the 3 tests on `isTransparentSocketAvailable()` |

## NOT in this PR (deliberately)

The round-robin test `resilience-http-e2e.ts:777` fails for a **different reason** and is **left untouched**: the undici dispatcher throws `"fetch failed"` in `proxyFetch.ts` (`getDefaultDispatcher()` path) → the p7 request falls through to p6, so the test reads `round robin A` twice. This is the known **undici-dispatcher** instability (#4252 territory), **NOT** a round-robin combo regression — `handleRoundRobinCombo`'s counter logic is correct (verified: counter 0→1→2, startIndex 0→1). Realigning that test would mask the real dispatcher symptom, so it stays as a canary.

## Validation (RED→GREEN — tests-only + quality baseline, no production code)

- `check:complexity`: REGRESSÃO 1885>1800 → **OK 1885**
- `integration-wiring` opaque-surface: **1/1**
- `search-providers-catalog`: **14/14**
- `tproxy-transparent-socket`: **11/11** (local exercises the `else`/absent branch; the `if`/present branch runs on the Node-compat CI runners with prebuilds)
- `check:file-size`: OK (none of the 4 files frozen)