### PR TITLE
feat(cli): OpenCode setup commands (openai-compatible provider + remote-aware plugin)

### DIFF
--- a/bin/cli/commands/registry.mjs
+++ b/bin/cli/commands/registry.mjs
@@ -59,6 +59,7 @@ import { registerLaunch } from "./launch.mjs";
 import { registerLaunchCodex } from "./launch-codex.mjs";
 import { registerSetupCodex } from "./setup-codex.mjs";
 import { registerSetupClaude } from "./setup-claude.mjs";
+import { registerSetupOpencode } from "./setup-opencode.mjs";
 import { registerConnect } from "./connect.mjs";
 import { registerTokens } from "./tokens.mjs";
 import { registerConfigure } from "./configure.mjs";
@@ -128,6 +129,7 @@ export function registerCommands(program) {
   registerLaunchCodex(program);
   registerSetupCodex(program);
   registerSetupClaude(program);
+  registerSetupOpencode(program);
   registerConnect(program);
   registerTokens(program);
   registerConfigure(program);

--- a/bin/cli/commands/setup-open-code.mjs
+++ b/bin/cli/commands/setup-open-code.mjs
@@ -29,6 +29,7 @@ import os from "node:os";
 
 import { printHeading, printInfo, printSuccess, printError } from "../io.mjs";
 import { t } from "../i18n.mjs";
+import { resolveActiveContext } from "../contexts.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -254,7 +255,17 @@ function runOpenCodeAuth(providerId) {
  */
 export async function runSetupOpenCodeCommand(opts = {}) {
   const providerId = opts.providerId || "omniroute";
-  const baseURL = opts.baseURL || opts.baseUrl || "http://localhost:20128";
+  // Remote-aware: explicit --remote/--base-url → active context → localhost.
+  let baseURL = opts.remote || opts.baseURL || opts.baseUrl;
+  if (!baseURL) {
+    try {
+      const ctx = resolveActiveContext(opts.context ?? process.env.OMNIROUTE_CONTEXT);
+      baseURL = ctx?.baseUrl;
+    } catch {
+      /* no context */
+    }
+  }
+  if (!baseURL) baseURL = "http://localhost:20128";
   const displayName = opts.displayName || null;
   const wantsAuth = Boolean(opts.auth);
   const nonInteractive = Boolean(opts.nonInteractive);
@@ -356,8 +367,11 @@ export function registerSetupOpenCode(setupCommand) {
     )
     .option(
       "--base-url <url>",
-      "OmniRoute base URL the plugin should talk to (default: http://localhost:20128)",
-      "http://localhost:20128"
+      "OmniRoute base URL the plugin should talk to (default: active context or http://localhost:20128)"
+    )
+    .option(
+      "--remote <url>",
+      "Remote OmniRoute URL, e.g. http://192.168.0.15:20128 (overrides --base-url and the context)"
     )
     .option("--display-name <name>", "Display name in the OpenCode UI (optional)")
     .option(
@@ -376,6 +390,7 @@ export function registerSetupOpenCode(setupCommand) {
         output: globalOpts.output,
         apiKey: opts.apiKey ?? globalOpts.apiKey,
         baseUrl: opts.baseUrl ?? globalOpts.baseUrl,
+        context: globalOpts.context ?? opts.context,
       };
       const { exitCode } = await runSetupOpenCodeCommand(merged);
       if (exitCode !== 0) process.exit(exitCode);

--- a/bin/cli/commands/setup-opencode.mjs
+++ b/bin/cli/commands/setup-opencode.mjs
@@ -1,0 +1,129 @@
+/**
+ * omniroute setup-opencode — Remote-aware OpenCode provider generator
+ * (openai-compatible). Distinct from `omniroute setup opencode` (which wires the
+ * @omniroute/opencode-plugin). This writes the `omniroute` provider into
+ * ~/.config/opencode/opencode.json with every catalog model, so you can run
+ * `opencode -m omniroute/<model>`.
+ *
+ * Reuses the proven server-side generator (config-generator/opencode.ts) for the
+ * catalog fetch + merge, then references the API key by env var (never on disk).
+ */
+
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import os from "node:os";
+import { printHeading, printInfo, printSuccess, printError } from "../io.mjs";
+import { resolveActiveContext } from "../contexts.mjs";
+
+const ENV_KEY_REF = "{env:OMNIROUTE_API_KEY}";
+
+/** Resolve baseUrl + (literal) apiKey from flags → active context → localhost. */
+export function resolveOpencodeTarget(opts = {}) {
+  let baseUrl;
+  if (opts.remote) {
+    baseUrl = String(opts.remote).replace(/\/+$/, "");
+  } else {
+    try {
+      const c = resolveActiveContext(opts.context ?? process.env.OMNIROUTE_CONTEXT);
+      baseUrl = c?.baseUrl;
+    } catch {
+      /* no context */
+    }
+    if (!baseUrl) baseUrl = `http://localhost:${Number(opts.port ?? process.env.PORT ?? 20128) || 20128}`;
+  }
+
+  let apiKey = opts.apiKey ?? opts["api-key"];
+  if (!apiKey) {
+    try {
+      const c = resolveActiveContext(opts.context ?? process.env.OMNIROUTE_CONTEXT);
+      apiKey = c?.accessToken || c?.apiKey;
+    } catch {
+      /* no context auth */
+    }
+  }
+  if (!apiKey) apiKey = process.env.OMNIROUTE_API_KEY || "";
+  return { baseUrl: baseUrl.replace(/\/+$/, ""), apiKey };
+}
+
+/**
+ * Post-process the generator output: reference the API key by env var (keep the
+ * secret off disk) and optionally keep only models whose id matches `only`.
+ * Pure + testable. Returns the final JSON string.
+ *
+ * @param {string} rawJson  output of generateOpencodeConfig
+ * @param {{ only?: string[] }} [opts]
+ * @returns {{ json: string, modelCount: number }}
+ */
+export function postProcessOpencodeConfig(rawJson, opts = {}) {
+  const config = JSON.parse(rawJson);
+  const prov = config.provider?.omniroute;
+  if (prov?.options) prov.options.apiKey = ENV_KEY_REF;
+
+  if (opts.only && opts.only.length && prov?.models) {
+    const kept = {};
+    for (const [id, entry] of Object.entries(prov.models)) {
+      if (opts.only.some((f) => id.includes(f))) kept[id] = entry;
+    }
+    prov.models = kept;
+  }
+  const modelCount = prov?.models ? Object.keys(prov.models).length : 0;
+  return { json: JSON.stringify(config, null, 2) + "\n", modelCount };
+}
+
+export async function runSetupOpencodeCommand(opts = {}) {
+  const { baseUrl, apiKey } = resolveOpencodeTarget(opts);
+  const dryRun = Boolean(opts.dryRun ?? opts["dry-run"]);
+  const only = opts.only ? opts.only.split(",").map((s) => s.trim()).filter(Boolean) : null;
+
+  printHeading("OmniRoute → OpenCode provider (openai-compatible)");
+  printInfo(`Connecting to ${baseUrl} …`);
+
+  // Deferred import: opencode.ts is TypeScript; tsx is registered by
+  // bin/omniroute.mjs before any command runs, so importing here is safe.
+  let raw;
+  try {
+    const { generateOpencodeConfig } = await import(
+      "../../../src/lib/cli-helper/config-generator/opencode.ts"
+    );
+    raw = await generateOpencodeConfig({ baseUrl, apiKey, model: opts.model, providerId: "omniroute" });
+  } catch (err) {
+    printError(`Failed to generate opencode.json: ${err?.message || err}`);
+    printInfo("Make sure OmniRoute is running and --remote/--api-key are correct.");
+    return 1;
+  }
+
+  const { json, modelCount } = postProcessOpencodeConfig(raw, { only });
+  const configDir = join(os.homedir(), ".config", "opencode");
+  const configPath = join(configDir, "opencode.json");
+
+  if (dryRun) {
+    console.log(json.length > 4000 ? json.slice(0, 4000) + "\n… (truncated)" : json);
+    printInfo(`[dry-run] ${modelCount} model(s) under provider 'omniroute' → ${configPath}`);
+    return 0;
+  }
+
+  if (!existsSync(configDir)) mkdirSync(configDir, { recursive: true });
+  writeFileSync(configPath, json, "utf8");
+  printSuccess(`opencode.json updated at ${configPath} (${modelCount} models under 'omniroute')`);
+  printInfo('Use it:  opencode -m omniroute/<model> "..."   (export OMNIROUTE_API_KEY first)');
+  return 0;
+}
+
+export function registerSetupOpencode(program) {
+  program
+    .command("setup-opencode")
+    .description(
+      "Generate the OmniRoute openai-compatible provider in ~/.config/opencode/opencode.json " +
+        "from the live model catalog (local or remote VPS)"
+    )
+    .option("--port <port>", "Local OmniRoute port (ignored when --remote is set)", "20128")
+    .option("--remote <url>", "Remote OmniRoute URL, e.g. http://192.168.0.15:20128")
+    .option("--api-key <key>", "OmniRoute API key (defaults to OMNIROUTE_API_KEY env var)")
+    .option("--model <id>", "Set the default top-level model (omniroute/<id>)")
+    .option("--only <patterns>", "Comma-separated substrings — keep only matching model IDs")
+    .option("--dry-run", "Print what would be written without touching the filesystem")
+    .action(async (opts) => {
+      const code = await runSetupOpencodeCommand(opts);
+      if (code !== 0) process.exit(code);
+    });
+}

--- a/docs/guides/REMOTE-MODE.md
+++ b/docs/guides/REMOTE-MODE.md
@@ -137,6 +137,29 @@ The written profile references the inference key by env var
 base Codex setup (the `[model_providers.omniroute]` block), see
 [CODEX-CLI-CONFIGURATION.md](./CODEX-CLI-CONFIGURATION.md).
 
+### Per-CLI setup commands
+
+Each supported CLI has a remote-aware setup command (all honour the active
+context, or `--remote <url> --api-key <key>`):
+
+| CLI | Command | What it writes |
+|-----|---------|----------------|
+| Codex | `omniroute setup-codex` | `~/.codex/<name>.config.toml` profiles (per model) |
+| Claude Code | `omniroute setup-claude` | `~/.claude/profiles/<name>/settings.json` (per model) |
+| OpenCode | `omniroute setup-opencode` | `~/.config/opencode/opencode.json` — the `omniroute` openai-compatible provider with every catalog model (run `opencode -m omniroute/<model>`) |
+
+```bash
+# OpenCode (openai-compatible provider, all catalog models, remote VPS)
+omniroute setup-opencode --remote http://192.168.0.15:20128 --api-key oma_live_xxx
+omniroute setup-opencode --only glm,kimi        # keep only matching models
+opencode -m omniroute/glm/glm-5.2 "..."          # export OMNIROUTE_API_KEY first
+```
+
+> OpenCode also has a richer **plugin** integration: `omniroute setup opencode`
+> (now remote-aware via `--remote`) installs `@omniroute/opencode-plugin`.
+> `setup-opencode` is the lightweight openai-compatible alternative. The API key
+> is referenced via `{env:OMNIROUTE_API_KEY}` — never written to disk.
+
 ---
 
 ## Switching back to local

--- a/tests/unit/cli/setup-opencode.test.ts
+++ b/tests/unit/cli/setup-opencode.test.ts
@@ -1,0 +1,61 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  postProcessOpencodeConfig,
+  resolveOpencodeTarget,
+} from "../../../bin/cli/commands/setup-opencode.mjs";
+
+const RAW = JSON.stringify({
+  $schema: "https://opencode.ai/config.json",
+  provider: {
+    omniroute: {
+      name: "OmniRoute",
+      npm: "@ai-sdk/openai-compatible",
+      options: { baseURL: "http://vps:20128/v1", apiKey: "sk-secret-literal" },
+      models: {
+        "glm/glm-5.2": { name: "glm/glm-5.2", limit: { context: 131072, output: 32768 } },
+        "kmc/kimi-k2.7": { name: "kmc/kimi-k2.7", limit: { context: 131072 } },
+        "openai/gpt-4o": { name: "openai/gpt-4o", limit: { context: 128000 } },
+      },
+    },
+  },
+});
+
+test("postProcessOpencodeConfig replaces the literal API key with an env ref (no secret on disk)", () => {
+  const { json } = postProcessOpencodeConfig(RAW);
+  assert.equal(json.includes("sk-secret-literal"), false);
+  const cfg = JSON.parse(json);
+  assert.equal(cfg.provider.omniroute.options.apiKey, "{env:OMNIROUTE_API_KEY}");
+  assert.equal(cfg.provider.omniroute.options.baseURL, "http://vps:20128/v1");
+});
+
+test("postProcessOpencodeConfig keeps all models by default", () => {
+  const { modelCount } = postProcessOpencodeConfig(RAW);
+  assert.equal(modelCount, 3);
+});
+
+test("postProcessOpencodeConfig --only filters the model map by substring", () => {
+  const { json, modelCount } = postProcessOpencodeConfig(RAW, { only: ["glm", "kimi"] });
+  const cfg = JSON.parse(json);
+  assert.equal(modelCount, 2);
+  assert.ok(cfg.provider.omniroute.models["glm/glm-5.2"]);
+  assert.ok(cfg.provider.omniroute.models["kmc/kimi-k2.7"]);
+  assert.equal("openai/gpt-4o" in cfg.provider.omniroute.models, false);
+});
+
+test("postProcessOpencodeConfig preserves $schema, provider name and npm", () => {
+  const { json } = postProcessOpencodeConfig(RAW);
+  const cfg = JSON.parse(json);
+  assert.equal(cfg.$schema, "https://opencode.ai/config.json");
+  assert.equal(cfg.provider.omniroute.npm, "@ai-sdk/openai-compatible");
+});
+
+test("resolveOpencodeTarget: --remote wins and trailing slashes are trimmed", () => {
+  const { baseUrl } = resolveOpencodeTarget({ remote: "http://vps:20128/" });
+  assert.equal(baseUrl, "http://vps:20128");
+});
+
+test("resolveOpencodeTarget: explicit --api-key wins", () => {
+  const { apiKey } = resolveOpencodeTarget({ remote: "http://x:20128", apiKey: "sk-explicit" });
+  assert.equal(apiKey, "sk-explicit");
+});


### PR DESCRIPTION
## What

OpenCode parity for remote mode — **both** approaches (per owner decision):

1. **`omniroute setup-opencode`** (new, openai-compatible): generates the `omniroute` provider in `~/.config/opencode/opencode.json` from the live `/v1/models` catalog (local or `--remote` VPS). Run `opencode -m omniroute/<model>`.
   - Reuses the proven `config-generator/opencode.ts` (catalog fetch + merge, preserves existing config) via a deferred `tsx` import.
   - API key referenced as `{env:OMNIROUTE_API_KEY}` — **never written to disk**.
   - `--only <substrings>` filters the model map; `--model` sets the default; `--dry-run` previews.
2. **`omniroute setup opencode`** (the existing **plugin** command) is now **remote-aware**: new `--remote` + resolves baseURL from the active context (was localhost-only).

OpenCode is special — one provider, many models, no native profiles and no model auto-discovery — so this declares the full catalog statically (the correct approach per the OpenCode docs).

## Validation (remote, VPS v3.8.30 via Tailscale)

- `setup-opencode --remote --dry-run` → correct provider config generated from the **1119-model** catalog, with `{env:...}` key ref + per-model `limit.context/output`.
- `/v1/chat/completions` (OpenCode's wire) → streamed **"OK"** ✅.
- `opencode` binary `run` hangs non-interactively in the sandbox (interactive-tool limitation, not a code defect) — the generated config + the wire are validated.
- `check:cli-i18n` ✓ · 6 unit tests (`postProcessOpencodeConfig` env-ref + `--only` filter + `$schema`/`npm` preserved; `resolveOpencodeTarget`).

## Series

CLI #3 (after Codex #4270, Claude Code #4274). Next, one at a time: Cline, Kilo Code, Continue, then the research-heavy ones (Cursor, Roo, Crush, Goose, Qwen Code, Gemini CLI, Aider).

🤖 Generated with [Claude Code](https://claude.com/claude-code)