### PR TITLE
fix(cli): harden launch/launch-codex with free-claude-code patterns

### DIFF
--- a/bin/cli/commands/launch-codex.mjs
+++ b/bin/cli/commands/launch-codex.mjs
@@ -1,15 +1,76 @@
 import { spawn } from "node:child_process";
 import { t } from "../i18n.mjs";
+import { resolveActiveContext } from "../contexts.mjs";
+
+/** OpenAI/Codex env keys stripped from the child so a stale OpenAI key/base-url
+ *  in the shell can't shadow the omniroute provider (defense-in-depth). Mirrors
+ *  free-claude-code's codex adapter. NOTE: this does NOT silence codex's
+ *  `refresh_token` log noise — that comes from a stored OpenAI session in
+ *  ~/.codex/auth.json, not the env; it is cosmetic and does not block requests. */
+const STRIPPED_CODEX_ENV_KEYS = [
+  "OPENAI_API_KEY",
+  "OPENAI_BASE_URL",
+  "OPENAI_API_BASE",
+  "OPENAI_ORG_ID",
+  "OPENAI_ORGANIZATION",
+  "CODEX_API_KEY",
+];
+
+/** Placeholder so codex's `env_key` is always satisfied when the backend is open. */
+const NO_AUTH_SENTINEL = "omniroute-no-auth";
+
+function stripTrailingSlash(value) {
+  let s = String(value);
+  let end = s.length;
+  while (end > 0 && s.charCodeAt(end - 1) === 47) end--;
+  return end === s.length ? s : s.slice(0, end);
+}
+
+/** TOML assignment for a `-c key=value` codex flag (strings get quoted). */
+function tomlAssign(key, value) {
+  if (typeof value === "boolean" || typeof value === "number") return `${key}=${value}`;
+  return `${key}=${JSON.stringify(String(value))}`;
+}
 
 /**
- * Health-check an OmniRoute endpoint (local or remote) before launching Codex.
- * @param {string} baseUrl
- * @param {number} timeoutMs
- * @returns {Promise<boolean>}
+ * Resolve the OmniRoute root base URL + auth for codex, honouring (in order):
+ * explicit flags → active context (remote mode) → localhost:<port>.
+ * @returns {{ baseUrl:string, authToken:string|undefined }}
  */
+export function resolveCodexTarget(opts = {}) {
+  const explicit = opts.remote ?? opts.baseUrl;
+  let baseUrl;
+  if (explicit) {
+    baseUrl = stripTrailingSlash(explicit).replace(/\/v1$/, "");
+  } else {
+    let fromCtx;
+    try {
+      fromCtx = resolveActiveContext(opts.context ?? process.env.OMNIROUTE_CONTEXT)?.baseUrl;
+    } catch {
+      /* no context */
+    }
+    baseUrl = fromCtx
+      ? stripTrailingSlash(fromCtx).replace(/\/v1$/, "")
+      : `http://localhost:${Number(opts.port ?? process.env.PORT ?? 20128) || 20128}`;
+  }
+
+  let authToken = opts.apiKey ?? opts["api-key"];
+  if (!authToken) {
+    try {
+      const ctx = resolveActiveContext(opts.context ?? process.env.OMNIROUTE_CONTEXT);
+      authToken = ctx?.accessToken || ctx?.apiKey || undefined;
+    } catch {
+      /* no context auth */
+    }
+  }
+  if (!authToken) authToken = process.env.OMNIROUTE_API_KEY;
+  return { baseUrl, authToken };
+}
+
+/** Health-check an OmniRoute root URL before launching Codex. */
 async function healthCheck(baseUrl, timeoutMs = 3000) {
   try {
-    const res = await fetch(`${baseUrl.replace(/\/v1$/, "")}/api/monitoring/health`, {
+    const res = await fetch(`${baseUrl}/api/monitoring/health`, {
       signal: AbortSignal.timeout(timeoutMs),
     });
     return res.ok;
@@ -19,17 +80,40 @@ async function healthCheck(baseUrl, timeoutMs = 3000) {
 }
 
 /**
- * Build the env for the Codex child process.
- * Injects OMNIROUTE_API_KEY if an explicit api-key was provided on the command line
- * (useful when launching against a remote VPS whose key differs from ~/.bashrc).
+ * Build the env for the Codex child: strip stale OpenAI/Codex creds, then set
+ * OMNIROUTE_API_KEY (the provider env_key) to the resolved token or a sentinel.
  * @param {Record<string,string>} baseEnv
- * @param {string|undefined} apiKey
+ * @param {string|undefined} authToken
  * @returns {Record<string,string>}
  */
-export function buildCodexEnv(baseEnv, apiKey) {
+export function buildCodexEnv(baseEnv, authToken) {
   const env = { ...baseEnv };
-  if (apiKey) env.OMNIROUTE_API_KEY = apiKey;
+  for (const key of STRIPPED_CODEX_ENV_KEYS) delete env[key];
+  env.OMNIROUTE_API_KEY = (authToken && String(authToken).trim()) || NO_AUTH_SENTINEL;
   return env;
+}
+
+/**
+ * Codex `-c` flags that define the `omniroute` provider inline, so launch works
+ * WITHOUT a pre-existing ~/.codex/config.toml. Mirrors free-claude-code.
+ * @param {string} baseUrl  OmniRoute root URL (no /v1)
+ * @returns {string[]}
+ */
+export function buildCodexProviderArgs(baseUrl) {
+  return [
+    "-c",
+    tomlAssign("model_provider", "omniroute"),
+    "-c",
+    tomlAssign("model_providers.omniroute.name", "OmniRoute"),
+    "-c",
+    tomlAssign("model_providers.omniroute.base_url", `${baseUrl}/v1`),
+    "-c",
+    tomlAssign("model_providers.omniroute.env_key", "OMNIROUTE_API_KEY"),
+    "-c",
+    tomlAssign("model_providers.omniroute.wire_api", "responses"),
+    "-c",
+    tomlAssign("model_providers.omniroute.requires_openai_auth", false),
+  ];
 }
 
 /**
@@ -38,30 +122,31 @@ export function buildCodexEnv(baseEnv, apiKey) {
  * @returns {Promise<number>} exit code
  */
 export async function runLaunchCodexCommand(opts = {}, codexArgs = []) {
-  const port = Number(opts.port ?? process.env.PORT ?? 20128) || 20128;
-  const baseUrl = opts.remote ?? `http://localhost:${port}/v1`;
+  const { baseUrl, authToken } = resolveCodexTarget(opts);
 
-  const ok = await healthCheck(baseUrl);
-  if (!ok) {
-    const location = opts.remote ?? `port ${port}`;
+  if (!(await healthCheck(baseUrl))) {
     console.error(
-      (t("launch.notRunning") || "OmniRoute is not running on port {port}. Start it with 'omniroute serve'.")
-        .replace("{port}", String(location))
+      (t("launch.notRunning") || "OmniRoute is not reachable at {port}. Start it with 'omniroute serve'.").replace(
+        "{port}",
+        baseUrl
+      )
     );
     return 1;
   }
 
-  const profile = opts.profile;
-  const extraArgs = profile ? ["--profile", profile, ...codexArgs] : codexArgs;
-  const env = buildCodexEnv(process.env, opts.apiKey ?? opts["api-key"]);
+  // Provider injected via -c (works without config.toml); then the profile (model),
+  // then the user's pass-through args.
+  const providerArgs = buildCodexProviderArgs(baseUrl);
+  const profileArgs = opts.profile ? ["--profile", opts.profile] : [];
+  const extraArgs = [...providerArgs, ...profileArgs, ...codexArgs];
+  const env = buildCodexEnv(process.env, authToken);
 
   return await new Promise((resolve) => {
     const child = spawn("codex", extraArgs, { env, stdio: "inherit" });
     child.on("error", (err) => {
       if (err?.code === "ENOENT") {
         console.error(
-          "The 'codex' CLI was not found in PATH. Install with:\n" +
-            "  npm install -g @openai/codex"
+          "The 'codex' CLI was not found in PATH. Install with:\n  npm install -g @openai/codex"
         );
         resolve(127);
       } else {
@@ -77,25 +162,17 @@ export function registerLaunchCodex(program) {
   program
     .command("launch-codex")
     .description(
-      t("launchCodex.description") ||
-        "Launch Codex CLI pointed at OmniRoute (local or remote VPS)"
+      t("launchCodex.description") || "Launch Codex CLI pointed at OmniRoute (local or remote VPS)"
     )
     .option("--port <port>", "Local OmniRoute port (ignored when --remote is set)", "20128")
-    .option(
-      "--remote <url>",
-      "Remote OmniRoute base URL, e.g. http://100.67.86.91:20128/v1 (overrides --port)"
-    )
+    .option("--remote <url>", "Remote OmniRoute base URL, e.g. http://192.168.0.15:20128 (overrides --port + context)")
     .option("--profile <name>", "Codex profile to activate (passed as --profile <name>)")
     .option("-p, --p <name>", "Alias for --profile")
-    .option(
-      "--api-key <key>",
-      "OmniRoute API key (overrides OMNIROUTE_API_KEY env var for this invocation)"
-    )
+    .option("--api-key <key>", "OmniRoute API key (overrides OMNIROUTE_API_KEY env var for this invocation)")
     .allowUnknownOption(true)
     .allowExcessArguments(true)
     .argument("[codexArgs...]", "arguments passed through to the codex binary")
     .action(async (codexArgs, opts) => {
-      // -p is an alias for --profile
       const merged = { ...opts, profile: opts.profile ?? opts.p };
       const exitCode = await runLaunchCodexCommand(merged, codexArgs ?? []);
       if (exitCode !== 0) process.exit(exitCode);

--- a/bin/cli/commands/launch.mjs
+++ b/bin/cli/commands/launch.mjs
@@ -39,7 +39,11 @@ export function buildClaudeEnv(baseEnv, baseUrlOrPort, authToken, opts = {}) {
   }
 
   env.ANTHROPIC_BASE_URL = baseUrl;
-  if (authToken) env.ANTHROPIC_AUTH_TOKEN = authToken;
+  // Always set a token: when none is resolved, a sentinel keeps newer Claude Code
+  // from stopping at its local login gate before it ever contacts OmniRoute (an
+  // open backend ignores the value). Mirrors free-claude-code. ANTHROPIC_API_KEY
+  // stays stripped (above) so it can't shadow the Bearer token.
+  env.ANTHROPIC_AUTH_TOKEN = (authToken && String(authToken).trim()) || "omniroute-no-auth";
   env.CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY = "1";
   env.CLAUDE_CODE_AUTO_COMPACT_WINDOW = "190000";
   // Profile isolation (Claude Code has no native profiles — CLAUDE_CONFIG_DIR is

--- a/tests/unit/cli/launch-codex.test.ts
+++ b/tests/unit/cli/launch-codex.test.ts
@@ -1,0 +1,59 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildCodexEnv,
+  buildCodexProviderArgs,
+  resolveCodexTarget,
+} from "../../../bin/cli/commands/launch-codex.mjs";
+
+test("buildCodexEnv strips stale OpenAI/Codex creds from the child env (defense-in-depth)", () => {
+  const env = buildCodexEnv(
+    {
+      OPENAI_API_KEY: "leak",
+      OPENAI_BASE_URL: "https://api.openai.com/v1",
+      OPENAI_ORG_ID: "org",
+      CODEX_API_KEY: "leak2",
+      PATH: "/bin",
+    },
+    "oma_live_x"
+  );
+  assert.equal(env.OPENAI_API_KEY, undefined);
+  assert.equal(env.OPENAI_BASE_URL, undefined);
+  assert.equal(env.OPENAI_ORG_ID, undefined);
+  assert.equal(env.CODEX_API_KEY, undefined);
+  assert.equal(env.OMNIROUTE_API_KEY, "oma_live_x");
+  assert.equal(env.PATH, "/bin", "unrelated vars preserved");
+});
+
+test("buildCodexEnv uses a no-auth sentinel when no token is given", () => {
+  const env = buildCodexEnv({ PATH: "/bin" }, undefined);
+  assert.equal(env.OMNIROUTE_API_KEY, "omniroute-no-auth");
+});
+
+test("buildCodexEnv does not mutate the input env", () => {
+  const input = { OPENAI_API_KEY: "leak", PATH: "/bin" };
+  buildCodexEnv(input, "x");
+  assert.equal(input.OPENAI_API_KEY, "leak");
+});
+
+test("buildCodexProviderArgs defines the omniroute provider inline (works without config.toml)", () => {
+  const args = buildCodexProviderArgs("http://vps:20128");
+  const joined = args.join(" ");
+  assert.ok(joined.includes('model_provider="omniroute"'));
+  assert.ok(joined.includes('model_providers.omniroute.base_url="http://vps:20128/v1"'));
+  assert.ok(joined.includes('model_providers.omniroute.env_key="OMNIROUTE_API_KEY"'));
+  assert.ok(joined.includes('model_providers.omniroute.wire_api="responses"'));
+  assert.ok(joined.includes("model_providers.omniroute.requires_openai_auth=false"));
+  // each assignment is preceded by a -c flag
+  assert.equal(args.filter((a) => a === "-c").length, 6);
+});
+
+test("resolveCodexTarget: --remote wins and /v1 is stripped from the root", () => {
+  const { baseUrl } = resolveCodexTarget({ remote: "http://vps:20128/v1" });
+  assert.equal(baseUrl, "http://vps:20128");
+});
+
+test("resolveCodexTarget: explicit --api-key wins", () => {
+  const { authToken } = resolveCodexTarget({ remote: "http://x:20128", apiKey: "tok-explicit" });
+  assert.equal(authToken, "tok-explicit");
+});

--- a/tests/unit/cli/launch-command.test.ts
+++ b/tests/unit/cli/launch-command.test.ts
@@ -12,9 +12,9 @@ test("buildClaudeEnv strips ANTHROPIC_* and injects proxy vars", () => {
   assert.equal(env.PATH, "/bin", "non-ANTHROPIC vars are preserved");
 });
 
-test("buildClaudeEnv omits the auth token when none is provided", () => {
+test("buildClaudeEnv uses a no-auth sentinel when no token is provided (bypasses Claude's login gate)", () => {
   const env = buildClaudeEnv({ PATH: "/bin" }, 20128, undefined);
-  assert.equal("ANTHROPIC_AUTH_TOKEN" in env, false);
+  assert.equal(env.ANTHROPIC_AUTH_TOKEN, "omniroute-no-auth");
   assert.equal(env.ANTHROPIC_BASE_URL, "http://localhost:20128");
 });
 


### PR DESCRIPTION
## What

Applies proven patterns from the **free-claude-code** reference adapters (`cli/adapters/{claude,codex}.py`) to OmniRoute's launchers.

### `launch` (Claude Code)
- Always set `ANTHROPIC_AUTH_TOKEN` — a **no-auth sentinel** (`omniroute-no-auth`) when none is resolved — so newer Claude Code doesn't stop at its local **login gate** before it ever contacts OmniRoute (an open backend ignores the value; `ANTHROPIC_API_KEY` stays stripped so it can't shadow the Bearer token).

### `launch-codex`
- **Remote-aware**: resolves the root base URL + auth from `--remote`/`--api-key` → active context → localhost (was localhost/`--remote` only — now `omniroute connect <vps>` then `omniroute launch-codex` just works).
- **Inject the `omniroute` provider via `-c`** flags (`model_provider` + `model_providers.omniroute.{base_url,env_key,wire_api=responses,requires_openai_auth=false}`) so it works **without a pre-existing `~/.codex/config.toml`**.
- **Strip `OPENAI_*`/`CODEX_*`** from the child env (defense-in-depth) and set `OMNIROUTE_API_KEY` to the token or sentinel.
- Replaced a hard-coded Tailscale IP in `--remote` help with a placeholder.

> **Honest note:** stripping `OPENAI_*` does **not** silence codex's `refresh_token` log lines — those come from a stored OpenAI session in `~/.codex/auth.json`, are cosmetic, and don't block requests. The code comment + test name say so.

## Validation

- Remote (VPS v3.8.30): `omniroute launch-codex --remote … exec -m glm/glm-5-turbo "…"` → **"OK"** (exit 0), provider injected, no `config.toml` needed.
- 19 unit tests (`buildCodexEnv` strip+sentinel+no-mutate, `buildCodexProviderArgs` inline provider, `resolveCodexTarget`, updated `buildClaudeEnv` sentinel). `check:cli-i18n` ✓.

## Series context

Hardening follow-up after Codex #4270 / Claude Code #4274 / OpenCode #4277. Next: continue the per-CLI series (Cline #4) using these patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)