### PR TITLE
fix(mitm): surface AgentBridge traffic in the Traffic Inspector (D4 ingest)

### DIFF
--- a/src/app/api/tools/traffic-inspector/internal/ingest/route.ts
+++ b/src/app/api/tools/traffic-inspector/internal/ingest/route.ts
@@ -24,6 +24,8 @@ import { createHash, timingSafeEqual } from "node:crypto";
 import { randomUUID } from "node:crypto";
 import { InterceptedRequestSchema } from "@/mitm/inspector/types";
 import { globalTrafficBuffer } from "@/mitm/inspector/buffer";
+import { maskSecret } from "@/mitm/maskSecrets";
+import { sanitizeHeaders } from "@/mitm/sanitizeHeaders";
 
 // ── Token management ────────────────────────────────────────────────────────
 
@@ -101,11 +103,20 @@ export async function POST(request: Request): Promise<Response> {
   }
 
   try {
-    // Fill in any missing optional fields with sensible defaults.
+    // Fill in any missing optional fields with sensible defaults, then mask
+    // secrets and strip hop-by-hop headers before the entry enters the buffer.
+    // The proxy (server.cjs) sends bodies + headers raw over the token-gated
+    // loopback ingest; sanitization is centralized here so the inspector never
+    // stores bearer tokens / API keys (Hard Rule #12).
+    const data = parsed.data;
     const req = {
       requestBody: null,
       responseBody: null,
-      ...parsed.data,
+      ...data,
+      requestHeaders: sanitizeHeaders(data.requestHeaders || {}),
+      responseHeaders: sanitizeHeaders(data.responseHeaders || {}),
+      requestBody: data.requestBody != null ? maskSecret(data.requestBody) : null,
+      responseBody: data.responseBody != null ? maskSecret(data.responseBody) : null,
     };
     globalTrafficBuffer.push(req);
     return Response.json({ ok: true, id: req.id }, { status: 200 });

--- a/src/mitm/_internal/ingest.cjs
+++ b/src/mitm/_internal/ingest.cjs
@@ -1,0 +1,82 @@
+"use strict";
+
+// =========================================================================
+// Inspector ingest shim (D4 fallback) — used by the standalone CommonJS
+// `server.cjs` proxy, which cannot import the TypeScript `agentBridgeHook.ts`.
+//
+// The proxy intercepts AgentBridge traffic inline (no MitmHandlerBase), so it
+// never reaches the TS hook that pushes into `globalTrafficBuffer`. To make the
+// Traffic Inspector show AgentBridge traffic, `server.cjs` posts a captured
+// entry to the local-only `/api/tools/traffic-inspector/internal/ingest`
+// endpoint, which pushes it into the buffer (and sanitizes it server-side).
+//
+// This module holds the pure payload builder + the fire-and-forget poster so
+// both are unit-testable without standing up the proxy. Mirrors the entry
+// shape produced by `inspector/agentBridgeHook.ts::recordRequestStart`.
+// =========================================================================
+
+const { randomUUID } = require("node:crypto");
+
+const INGEST_PATH = "/api/tools/traffic-inspector/internal/ingest";
+
+/**
+ * Build a schema-valid `InterceptedRequest` entry for the ingest endpoint.
+ * Pure: the caller injects `id`/`timestamp` so the result is deterministic and
+ * testable. `source` is always "agent-bridge" — this shim is only used by the
+ * AgentBridge MITM proxy. Optional fields are omitted/defaulted so the result
+ * satisfies `InterceptedRequestSchema` (and the partial ingest schema).
+ */
+function buildIngestEntry(opts) {
+  const o = opts || {};
+  const entry = {
+    id: o.id || randomUUID(),
+    source: "agent-bridge",
+    timestamp: o.timestamp || new Date().toISOString(),
+    method: o.method || "GET",
+    host: o.host || "",
+    path: o.path || "/",
+    requestHeaders: o.requestHeaders || {},
+    requestBody: o.requestBody != null ? o.requestBody : null,
+    requestSize: Number.isFinite(o.requestSize) ? o.requestSize : 0,
+    responseHeaders: o.responseHeaders || {},
+    responseBody: o.responseBody != null ? o.responseBody : null,
+    responseSize: Number.isFinite(o.responseSize) ? o.responseSize : 0,
+    status: o.status,
+  };
+  if (o.agentId) entry.agent = o.agentId;
+  if (o.sourceModel !== undefined) entry.sourceModel = o.sourceModel;
+  if (o.mappedModel) entry.mappedModel = o.mappedModel;
+  if (typeof o.error === "string") entry.error = o.error;
+  if (typeof o.proxyLatencyMs === "number") entry.proxyLatencyMs = o.proxyLatencyMs;
+  if (typeof o.upstreamLatencyMs === "number") entry.upstreamLatencyMs = o.upstreamLatencyMs;
+  if (typeof o.proxyLatencyMs === "number" && typeof o.upstreamLatencyMs === "number") {
+    entry.totalLatencyMs = o.proxyLatencyMs + o.upstreamLatencyMs;
+  }
+  return entry;
+}
+
+/**
+ * Fire-and-forget POST of a captured entry to the ingest endpoint. NEVER throws
+ * and NEVER rejects — inspector capture must not be able to break proxy
+ * traffic. Returns true only on a 2xx response (used by tests); false on a
+ * missing token/base/fetch, a non-2xx, or any network error.
+ */
+async function postIngestEntry(baseUrl, token, entry, fetchImpl) {
+  const doFetch = fetchImpl || globalThis.fetch;
+  if (!token || !baseUrl || typeof doFetch !== "function") return false;
+  try {
+    const res = await doFetch(`${baseUrl}${INGEST_PATH}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(entry),
+    });
+    return !!(res && res.ok === true);
+  } catch {
+    return false;
+  }
+}
+
+module.exports = { buildIngestEntry, postIngestEntry, INGEST_PATH };

--- a/src/mitm/manager.ts
+++ b/src/mitm/manager.ts
@@ -494,11 +494,31 @@ export async function startMitm(
     options.port <= 65535
       ? options.port
       : 443;
+  // D4 — resolve the inspector ingest token so the spawned proxy can post
+  // captured AgentBridge traffic to the local-only ingest endpoint. The token
+  // is shared with the OmniRoute process: getIngestTokenForBootstrap() returns
+  // the same value the ingest route validates against (env or auto-generated).
+  // Best-effort — if it cannot be resolved, the proxy simply skips capture.
+  let ingestToken = process.env.INSPECTOR_INTERNAL_INGEST_TOKEN || "";
+  if (!ingestToken) {
+    try {
+      const ingestMod = await import(
+        "@/app/api/tools/traffic-inspector/internal/ingest/route"
+      );
+      if (typeof ingestMod.getIngestTokenForBootstrap === "function") {
+        ingestToken = ingestMod.getIngestTokenForBootstrap();
+      }
+    } catch (err) {
+      log.warn({ err }, "Could not resolve inspector ingest token; capture disabled");
+    }
+  }
+
   serverProcess = spawn(process.execPath, [MITM_SERVER_PATH], {
     env: {
       ...process.env,
       ROUTER_API_KEY: apiKey,
       MITM_LOCAL_PORT: String(port),
+      INSPECTOR_INTERNAL_INGEST_TOKEN: ingestToken,
       NODE_ENV: "production",
     },
     detached: false,

--- a/src/mitm/server.cjs
+++ b/src/mitm/server.cjs
@@ -134,6 +134,36 @@ function sanitizeErrorMessage(message) {
 // =========================================================================
 
 const bypassShim = require("./_internal/bypass.cjs");
+const ingestShim = require("./_internal/ingest.cjs");
+
+// Inspector capture (D4 fallback). The standalone proxy intercepts AgentBridge
+// traffic inline (no MitmHandlerBase / agentBridgeHook), so it posts captured
+// entries to the local-only ingest endpoint to make them visible in the Traffic
+// Inspector. The token is injected by manager.ts (same value the OmniRoute
+// process uses); absent token → capture is silently skipped.
+const INGEST_TOKEN = process.env.INSPECTOR_INTERNAL_INGEST_TOKEN || "";
+// Cap captured bodies to keep proxy memory bounded (the buffer truncates again).
+const INGEST_MAX_BODY = 65536;
+
+// Flatten Node http headers (plain object, values string|string[]) or a fetch
+// Headers instance into a Record<string,string> for the inspector entry.
+function headersToObject(headers) {
+  const out = {};
+  if (!headers) return out;
+  if (typeof headers.forEach === "function") {
+    // fetch Headers instance: forEach(value, key)
+    headers.forEach((value, key) => {
+      out[String(key)] = String(value);
+    });
+    return out;
+  }
+  for (const key of Object.keys(headers)) {
+    const v = headers[key];
+    if (v == null) continue;
+    out[key] = Array.isArray(v) ? v.join(", ") : String(v);
+  }
+  return out;
+}
 
 // Routing-decision log verbosity (Gap 15). MITM_VERBOSE=0 silences the
 // per-request decision lines; default 1 preserves the previous behavior.
@@ -387,19 +417,60 @@ async function passthrough(req, res, bodyBuffer) {
   forwardReq.end();
 }
 
-async function intercept(req, res, bodyBuffer, mappedModel) {
+// Build + fire-and-forget the inspector capture entry. NEVER throws — capture
+// must not be able to break proxy traffic. Bodies/headers are sent raw over the
+// token-gated loopback ingest endpoint, which masks secrets server-side.
+function captureToInspector(o) {
+  if (!INGEST_TOKEN) return; // capture disabled (no token wired by manager)
+  try {
+    const entry = ingestShim.buildIngestEntry({
+      method: o.req.method,
+      host: o.req.headers.host || "",
+      path: o.req.url || "/",
+      agentId: o.agentId,
+      sourceModel: o.sourceModel != null ? o.sourceModel : null,
+      mappedModel: o.mappedModel,
+      requestHeaders: headersToObject(o.req.headers),
+      requestBody:
+        o.bodyBuffer && o.bodyBuffer.length > 0
+          ? o.bodyBuffer.toString("utf8").slice(0, INGEST_MAX_BODY)
+          : null,
+      requestSize: o.bodyBuffer ? o.bodyBuffer.length : 0,
+      status: o.status,
+      responseHeaders: o.respHeaders || {},
+      responseBody: o.respBody ? o.respBody : null,
+      responseSize: o.respSize || 0,
+      error: o.error,
+      proxyLatencyMs: o.proxyLatencyMs,
+      upstreamLatencyMs: o.upstreamLatencyMs,
+    });
+    void ingestShim.postIngestEntry(ROUTER_BASE_URL, INGEST_TOKEN, entry);
+  } catch {
+    // capture is best-effort — never break proxy traffic
+  }
+}
+
+async function intercept(req, res, bodyBuffer, mappedModel, sourceModel) {
+  // C2 — Inject AgentBridge correlation headers per master plan §3.5.
+  // The OmniRoute router uses these to distinguish AgentBridge traffic from
+  // other inbound clients and to record the originating IDE agent id.
+  // Resolve agent id from the Host header against the target map; defensive
+  // fallback to "unknown" when the host is somehow not in the map.
+  const reqHost = String(req.headers.host || "").split(":")[0].toLowerCase();
+  const agentId = TARGET_HOST_AGENT.get(reqHost) || "unknown";
+  const startedAt = Date.now();
+  let upstreamStartedAt = startedAt;
+  let captureStatus = "error";
+  let respHeaders = {};
+  let respBody = "";
+  let respSize = 0;
+  let captureError;
+
   try {
     const body = JSON.parse(bodyBuffer.toString());
     body.model = mappedModel;
 
-    // C2 — Inject AgentBridge correlation headers per master plan §3.5.
-    // The OmniRoute router uses these to distinguish AgentBridge traffic from
-    // other inbound clients and to record the originating IDE agent id.
-    // Resolve agent id from the Host header against the target map; defensive
-    // fallback to "unknown" when the host is somehow not in the map.
-    const reqHost = String(req.headers.host || "").split(":")[0].toLowerCase();
-    const agentId = TARGET_HOST_AGENT.get(reqHost) || "unknown";
-
+    upstreamStartedAt = Date.now();
     const response = await fetch(ROUTER_URL, {
       method: "POST",
       headers: {
@@ -411,8 +482,13 @@ async function intercept(req, res, bodyBuffer, mappedModel) {
       body: JSON.stringify(body),
     });
 
+    captureStatus = response.status;
+    respHeaders = headersToObject(response.headers);
+
     if (!response.ok) {
       const errText = await response.text().catch(() => "");
+      respBody = errText.slice(0, INGEST_MAX_BODY);
+      respSize = Buffer.byteLength(errText);
       throw new Error(`OmniRoute ${response.status}: ${errText}`);
     }
 
@@ -432,21 +508,42 @@ async function intercept(req, res, bodyBuffer, mappedModel) {
         res.end();
         break;
       }
-      res.write(decoder.decode(value, { stream: true }));
+      const text = decoder.decode(value, { stream: true });
+      if (respBody.length < INGEST_MAX_BODY) respBody += text;
+      respSize += value ? value.length : 0;
+      res.write(text);
     }
   } catch (error) {
     // Log the raw message locally (server console only) but never expose it
     // in the response body. Hard Rule #12 — sanitize before sending.
+    captureError = sanitizeErrorMessage(error && error.message);
     console.error(`❌ ${error.message}`);
     if (!res.headersSent) res.writeHead(500, { "Content-Type": "application/json" });
     res.end(
       JSON.stringify({
         error: {
-          message: sanitizeErrorMessage(error && error.message),
+          message: captureError,
           type: "mitm_error",
         },
       })
     );
+  } finally {
+    // D4 — make the intercepted (decrypted) request visible in the Traffic
+    // Inspector. Fire-and-forget; failures here never affect the client.
+    captureToInspector({
+      req,
+      bodyBuffer,
+      agentId,
+      sourceModel,
+      mappedModel,
+      status: captureStatus,
+      respHeaders,
+      respBody,
+      respSize,
+      error: captureError,
+      proxyLatencyMs: Math.max(0, upstreamStartedAt - startedAt),
+      upstreamLatencyMs: Math.max(0, Date.now() - upstreamStartedAt),
+    });
   }
 }
 
@@ -492,7 +589,7 @@ const server = https.createServer(sslOptions, async (req, res) => {
   writeStats();
 
   vlog(1, `[MITM] INTERCEPTED ${model} → ${mappedModel}`);
-  return intercept(req, res, bodyBuffer, mappedModel);
+  return intercept(req, res, bodyBuffer, mappedModel, model);
 });
 
 // =========================================================================

--- a/src/server/authz/policies/management.ts
+++ b/src/server/authz/policies/management.ts
@@ -90,6 +90,12 @@ function isValidWsBridgeRequest(ctx: PolicyContext): boolean {
   return timingSafeEqual(expectedHash, providedHash);
 }
 
+// Loopback-only inspector ingest endpoint (D4). Token-gated in its own route
+// handler (INSPECTOR_INTERNAL_INGEST_TOKEN); exempt from management auth so the
+// standalone MITM proxy (server.cjs) can post captured traffic without a
+// dashboard cookie. See the carve-out in evaluate() below.
+const INSPECTOR_INGEST_PATH = "/api/tools/traffic-inspector/internal/ingest";
+
 export const managementPolicy: RoutePolicy = {
   routeClass: "MANAGEMENT",
   async evaluate(ctx: PolicyContext): Promise<AuthOutcome> {
@@ -171,6 +177,20 @@ export const managementPolicy: RoutePolicy = {
         }
       }
       return reject(403, "LOCAL_ONLY", "This endpoint requires localhost access");
+    }
+
+    // Inspector ingest (D4): the standalone MITM proxy (server.cjs) posts
+    // captured AgentBridge traffic to this loopback-only endpoint. It carries
+    // its own shared-secret token (validated in the route handler), so it does
+    // not also need a dashboard session / management key. The LOCAL_ONLY gate
+    // above already rejected any non-loopback caller; we additionally require a
+    // strict loopback request here so a LAN peer cannot reach it without auth.
+    if (path === INSPECTOR_INGEST_PATH && isLoopbackRequest(ctx)) {
+      return allow({
+        kind: "management_key",
+        id: "inspector-ingest",
+        label: "inspector-ingest-token",
+      });
     }
 
     if (isInternalModelSyncRequest(ctx)) {

--- a/tests/unit/authz/management-policy.test.ts
+++ b/tests/unit/authz/management-policy.test.ts
@@ -392,3 +392,41 @@ test("managementPolicy: allows internal model sync only on the dedicated provide
   const denied = await policy.evaluate(ctx(internalHeaders, "POST", "/api/keys"));
   assert.equal(denied.allow, false);
 });
+
+const INGEST_PATH = "/api/tools/traffic-inspector/internal/ingest";
+
+test("managementPolicy: allows loopback inspector ingest without a dashboard session (D4)", async () => {
+  // Auth is required (password set), and there is NO dashboard cookie / API key.
+  process.env.JWT_SECRET = "test-jwt-secret-for-ingest";
+  process.env.INITIAL_PASSWORD = "initial-pass";
+  await settingsDb.updateSettings({ requireLogin: true });
+
+  const policy = await loadPolicy();
+  // Loopback peer (socket.remoteAddress) + ingest path → exempt from management
+  // auth; the route handler validates the shared-secret ingest token.
+  const out = await policy.evaluate(
+    ctx(new Headers(), "POST", INGEST_PATH, { socket: { remoteAddress: "127.0.0.1" } })
+  );
+
+  assert.equal(out.allow, true);
+  if (out.allow) {
+    assert.equal(out.subject.id, "inspector-ingest");
+    assert.equal(out.subject.label, "inspector-ingest-token");
+  }
+});
+
+test("managementPolicy: rejects remote inspector ingest as LOCAL_ONLY (D4)", async () => {
+  process.env.JWT_SECRET = "test-jwt-secret-for-ingest";
+  process.env.INITIAL_PASSWORD = "initial-pass";
+  await settingsDb.updateSettings({ requireLogin: true });
+
+  const policy = await loadPolicy();
+  // Non-loopback caller hits the LOCAL_ONLY gate before the ingest carve-out —
+  // the loopback exemption must never widen the endpoint to off-box peers.
+  const out = await policy.evaluate(remoteCtx(new Headers(), "POST", INGEST_PATH));
+
+  assert.equal(out.allow, false);
+  if (!out.allow) {
+    assert.equal(out.code, "LOCAL_ONLY");
+  }
+});

--- a/tests/unit/mitm-ingest-route-sanitize.test.ts
+++ b/tests/unit/mitm-ingest-route-sanitize.test.ts
@@ -1,0 +1,78 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// The internal ingest endpoint receives raw bodies/headers from the standalone
+// proxy (server.cjs) over the token-gated loopback. It MUST mask secrets before
+// the entry enters the traffic buffer (Hard Rule #12). The token must be set
+// BEFORE the route module is first imported so getIngestToken() caches it.
+const INGEST_TOKEN = "test-ingest-token-1234567890";
+process.env.INSPECTOR_INTERNAL_INGEST_TOKEN = INGEST_TOKEN;
+
+const INGEST_URL = "http://localhost:20128/api/tools/traffic-inspector/internal/ingest";
+
+test("ingest masks bearer tokens / secrets before they enter the buffer", async () => {
+  const { POST } = await import("@/app/api/tools/traffic-inspector/internal/ingest/route");
+  const { globalTrafficBuffer } = await import("@/mitm/inspector/buffer");
+  globalTrafficBuffer.clear();
+
+  const SECRET = "sk-supersecret-DEADBEEF0123456789";
+  const entry = {
+    id: "33333333-3333-4333-8333-333333333333",
+    source: "agent-bridge",
+    agent: "antigravity",
+    timestamp: "2026-06-19T00:00:00.000Z",
+    method: "POST",
+    host: "daily-cloudcode-pa.googleapis.com",
+    path: "/v1internal:streamGenerateContent",
+    requestHeaders: {
+      authorization: `Bearer ${SECRET}`,
+      "content-type": "application/json",
+    },
+    requestBody: `{"auth":"Bearer ${SECRET}"}`,
+    requestSize: 40,
+    responseHeaders: { "content-type": "text/event-stream" },
+    responseBody: null,
+    responseSize: 0,
+    status: 200,
+    mappedModel: "glm-5.2",
+    sourceModel: "gemini-2.5-pro",
+  };
+
+  const res = await POST(
+    new Request(INGEST_URL, {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: `Bearer ${INGEST_TOKEN}` },
+      body: JSON.stringify(entry),
+    })
+  );
+
+  assert.equal(res.status, 200);
+
+  const list = globalTrafficBuffer.list();
+  assert.equal(list.length, 1);
+  // The captured entry must be present (source/model preserved)...
+  assert.equal(list[0].source, "agent-bridge");
+  assert.equal(list[0].mappedModel, "glm-5.2");
+  // ...but the raw secret must NOT survive anywhere in the stored entry.
+  const stored = JSON.stringify(list[0]);
+  assert.ok(!stored.includes(SECRET), "bearer secret must be masked out of the buffered entry");
+
+  globalTrafficBuffer.clear();
+});
+
+test("ingest rejects a wrong token with 403 (and does not buffer)", async () => {
+  const { POST } = await import("@/app/api/tools/traffic-inspector/internal/ingest/route");
+  const { globalTrafficBuffer } = await import("@/mitm/inspector/buffer");
+  globalTrafficBuffer.clear();
+
+  const res = await POST(
+    new Request(INGEST_URL, {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: "Bearer wrong-token" },
+      body: JSON.stringify({ id: "x" }),
+    })
+  );
+
+  assert.equal(res.status, 403);
+  assert.equal(globalTrafficBuffer.list().length, 0);
+});

--- a/tests/unit/mitm-ingest-shim.test.ts
+++ b/tests/unit/mitm-ingest-shim.test.ts
@@ -1,0 +1,110 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import { InterceptedRequestSchema } from "@/mitm/inspector/types";
+
+const require = createRequire(import.meta.url);
+const { buildIngestEntry, postIngestEntry, INGEST_PATH } = require("../../src/mitm/_internal/ingest.cjs");
+
+test("buildIngestEntry produces a schema-valid agent-bridge entry", () => {
+  const entry = buildIngestEntry({
+    id: "11111111-1111-4111-8111-111111111111",
+    timestamp: "2026-06-19T00:00:00.000Z",
+    method: "POST",
+    host: "daily-cloudcode-pa.googleapis.com",
+    path: "/v1internal:streamGenerateContent?alt=sse",
+    agentId: "antigravity",
+    sourceModel: "gemini-2.5-pro",
+    mappedModel: "glm-5.2",
+    requestHeaders: { "content-type": "application/json" },
+    requestBody: '{"model":"gemini-2.5-pro"}',
+    requestSize: 26,
+    status: 200,
+    responseHeaders: { "content-type": "text/event-stream" },
+    responseBody: "data: {}",
+    responseSize: 8,
+    proxyLatencyMs: 5,
+    upstreamLatencyMs: 100,
+  });
+
+  assert.equal(entry.source, "agent-bridge");
+  assert.equal(entry.agent, "antigravity");
+  assert.equal(entry.sourceModel, "gemini-2.5-pro");
+  assert.equal(entry.mappedModel, "glm-5.2");
+  assert.equal(entry.totalLatencyMs, 105);
+
+  // Must satisfy the same schema the ingest endpoint validates against.
+  const parsed = InterceptedRequestSchema.safeParse(entry);
+  assert.ok(parsed.success, parsed.success ? "" : JSON.stringify(parsed.error.issues));
+});
+
+test("buildIngestEntry defaults missing optional fields to a valid entry", () => {
+  const entry = buildIngestEntry({
+    id: "22222222-2222-4222-8222-222222222222",
+    timestamp: "2026-06-19T00:00:00.000Z",
+    method: "POST",
+    host: "daily-cloudcode-pa.googleapis.com",
+    path: "/v1internal:streamGenerateContent",
+    status: "error",
+    error: "OmniRoute 400: bad request",
+  });
+
+  assert.equal(entry.requestBody, null);
+  assert.equal(entry.responseBody, null);
+  assert.equal(entry.requestSize, 0);
+  assert.equal(entry.responseSize, 0);
+  assert.deepEqual(entry.requestHeaders, {});
+  assert.equal(entry.status, "error");
+  assert.equal(entry.error, "OmniRoute 400: bad request");
+  // No latencies → no totalLatencyMs key.
+  assert.equal("totalLatencyMs" in entry, false);
+
+  const parsed = InterceptedRequestSchema.safeParse(entry);
+  assert.ok(parsed.success, parsed.success ? "" : JSON.stringify(parsed.error.issues));
+});
+
+test("postIngestEntry posts to the ingest path with a bearer token and returns true on 2xx", async () => {
+  type FetchOpts = { method: string; headers: Record<string, string>; body: string };
+  const calls: Array<{ url: string; opts: FetchOpts }> = [];
+  const fakeFetch = async (url: string, opts: FetchOpts) => {
+    calls.push({ url, opts });
+    return { ok: true };
+  };
+
+  const ok = await postIngestEntry("http://localhost:20128", "tok123", { id: "x" }, fakeFetch);
+
+  assert.equal(ok, true);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, `http://localhost:20128${INGEST_PATH}`);
+  assert.equal(calls[0].opts.headers.Authorization, "Bearer tok123");
+  assert.equal(calls[0].opts.method, "POST");
+});
+
+test("postIngestEntry returns false without a token and never calls fetch", async () => {
+  let called = false;
+  const ok = await postIngestEntry(
+    "http://localhost:20128",
+    "",
+    { id: "x" },
+    async () => {
+      called = true;
+      return { ok: true };
+    }
+  );
+  assert.equal(ok, false);
+  assert.equal(called, false);
+});
+
+test("postIngestEntry swallows fetch errors (never throws)", async () => {
+  const ok = await postIngestEntry("http://localhost:20128", "tok", { id: "x" }, async () => {
+    throw new Error("network down");
+  });
+  assert.equal(ok, false);
+});
+
+test("postIngestEntry returns false on a non-2xx response", async () => {
+  const ok = await postIngestEntry("http://localhost:20128", "tok", { id: "x" }, async () => ({
+    ok: false,
+  }));
+  assert.equal(ok, false);
+});


### PR DESCRIPTION
## Summary
Closes **Gap A** from the live MITM validation: AgentBridge (Antigravity) traffic never appeared in the Traffic Inspector even on successful intercepts. The standalone `server.cjs` proxy intercepts inline (no `MitmHandlerBase`/`agentBridgeHook`), so nothing ever pushed into `globalTrafficBuffer`.

Wires the documented **D4 ingest** fallback end-to-end:
- `_internal/ingest.cjs` (new): pure payload builder + fire-and-forget poster (never throws — capture must not break proxy traffic).
- `server.cjs`: `intercept()` captures request + bounded response + status/headers and posts the entry to the local-only `/internal/ingest` in a `finally` (also captures error/4xx intercepts).
- `manager.ts`: resolves the ingest token via `getIngestTokenForBootstrap()` and passes it to the spawned proxy.
- authz management policy: exempts the **loopback** `/internal/ingest` from management auth — it has its own shared-secret token gate and `server.cjs` has no dashboard cookie. Stays strictly loopback (LOCAL_ONLY gate unchanged).
- ingest route: masks secrets / strips hop-by-hop headers before buffering (Hard Rule #12).

## Why the authz change
Live validation on the lab VPS surfaced that `/internal/ingest` sat behind the management-auth policy (`403 AUTH_001`) — so `server.cjs` (loopback + ingest token, no cookie) could never post, and the buffer stayed empty. The unit test had called the route handler directly, bypassing the pipeline. This is exactly the class of bug the VPS e2e catches that local TDD misses.

## Test Plan
- [x] `mitm-ingest-shim.test.ts` — schema-valid payload + poster (token/no-token/error/non-2xx) — 6
- [x] `mitm-ingest-route-sanitize.test.ts` — secret masked before buffer + wrong-token 403 — 2
- [x] `management-policy.test.ts` — loopback ingest allowed / remote ingest LOCAL_ONLY — 2
- [x] `typecheck:core` clean, lint clean (0 warnings)
- [x] Live (lab VPS, partial): decrypt + intercept + forward → `glm-5.2` confirmed; the `403` this PR fixes was reproduced live. Full inspector-capture e2e validates on the next standalone deploy (policy + route are compiled into `.next`).

Scope: this is Gap A only. Gap B (cloudcode→OpenAI bidirectional translation so the Antigravity IDE's real `request.contents` payloads forward correctly) is a separate, larger change.