### PR TITLE
feat(cli): setup-crush — OmniRoute openai-compat provider in crush.json

### DIFF
--- a/bin/cli/commands/registry.mjs
+++ b/bin/cli/commands/registry.mjs
@@ -65,6 +65,7 @@ import { registerSetupKilo } from "./setup-kilo.mjs";
 import { registerSetupContinue } from "./setup-continue.mjs";
 import { registerSetupCursor } from "./setup-cursor.mjs";
 import { registerSetupRoo } from "./setup-roo.mjs";
+import { registerSetupCrush } from "./setup-crush.mjs";
 import { registerConnect } from "./connect.mjs";
 import { registerTokens } from "./tokens.mjs";
 import { registerConfigure } from "./configure.mjs";
@@ -140,6 +141,7 @@ export function registerCommands(program) {
   registerSetupContinue(program);
   registerSetupCursor(program);
   registerSetupRoo(program);
+  registerSetupCrush(program);
   registerConnect(program);
   registerTokens(program);
   registerConfigure(program);

--- a/bin/cli/commands/setup-crush.mjs
+++ b/bin/cli/commands/setup-crush.mjs
@@ -1,0 +1,148 @@
+/**
+ * omniroute setup-crush — configure Crush (charmbracelet/crush) for OmniRoute.
+ *
+ * Crush is a terminal AI agent with a file-based config: ~/.config/crush/crush.json
+ * (or ./crush.json). It supports a custom `openai-compat` provider. base_url must
+ * include /v1; the api_key may reference an env var (`$OMNIROUTE_API_KEY`) so the
+ * secret stays out of the file. Remote-aware; curated catalog models.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import os from "node:os";
+import { printHeading, printInfo, printSuccess, printError } from "../io.mjs";
+import { resolveActiveContext } from "../contexts.mjs";
+import { categoriseModel } from "./setup-codex.mjs";
+
+const API_KEY_REF = "$OMNIROUTE_API_KEY";
+
+function ensureV1(url) {
+  const s = String(url || "").replace(/\/+$/, "");
+  return s.endsWith("/v1") ? s : `${s}/v1`;
+}
+
+/** Resolve base_url (WITH /v1) + apiKey from flags → active context → localhost. */
+export function resolveCrushTarget(opts = {}) {
+  let root;
+  if (opts.remote) root = String(opts.remote).replace(/\/+$/, "");
+  else {
+    try {
+      root = resolveActiveContext(opts.context ?? process.env.OMNIROUTE_CONTEXT)?.baseUrl;
+    } catch {
+      /* none */
+    }
+    if (!root) root = `http://localhost:${Number(opts.port ?? process.env.PORT ?? 20128) || 20128}`;
+  }
+  let apiKey = opts.apiKey ?? opts["api-key"];
+  if (!apiKey) {
+    try {
+      const c = resolveActiveContext(opts.context ?? process.env.OMNIROUTE_CONTEXT);
+      apiKey = c?.accessToken || c?.apiKey;
+    } catch {
+      /* none */
+    }
+  }
+  if (!apiKey) apiKey = process.env.OMNIROUTE_API_KEY || "";
+  return { baseUrl: ensureV1(root), apiKey };
+}
+
+/** Build the Crush `openai-compat` provider block from curated catalog ids. */
+export function buildCrushProvider(modelIds, baseUrl) {
+  const models = [];
+  for (const id of modelIds) {
+    const cfg = categoriseModel(id);
+    if (!cfg) continue;
+    models.push({ id, name: `OmniRoute: ${id}`, context_window: cfg.ctx });
+  }
+  return {
+    type: "openai-compat",
+    base_url: baseUrl,
+    api_key: API_KEY_REF,
+    models,
+  };
+}
+
+/** Merge the OmniRoute provider into an existing crush.json (preserve the rest). */
+export function mergeCrushConfig(existing, provider) {
+  const cfg = existing && typeof existing === "object" ? { ...existing } : {};
+  cfg.providers = { ...(cfg.providers || {}), omniroute: provider };
+  return cfg;
+}
+
+function readJson(path) {
+  try {
+    if (existsSync(path)) return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    /* corrupt/missing */
+  }
+  return {};
+}
+
+async function fetchModelIds(baseUrl, apiKey) {
+  const headers = { "Content-Type": "application/json" };
+  if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
+  const res = await fetch(`${baseUrl.replace(/\/v1$/, "")}/v1/models`, {
+    headers,
+    signal: AbortSignal.timeout(10000),
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const body = await res.json();
+  const list = Array.isArray(body) ? body : body.data ?? body.models ?? [];
+  return list.map((m) => (typeof m === "string" ? m : m?.id)).filter(Boolean);
+}
+
+export async function runSetupCrushCommand(opts = {}) {
+  const { baseUrl, apiKey } = resolveCrushTarget(opts);
+  const dryRun = Boolean(opts.dryRun ?? opts["dry-run"]);
+  const only = opts.only ? opts.only.split(",").map((s) => s.trim()).filter(Boolean) : null;
+  const configPath = opts.configPath ?? opts["config-path"] ?? join(os.homedir(), ".config", "crush", "crush.json");
+
+  printHeading("OmniRoute → Crush (openai-compat)");
+  printInfo(`base_url: ${baseUrl}`);
+
+  let ids;
+  try {
+    ids = await fetchModelIds(baseUrl, apiKey);
+  } catch (e) {
+    printError(`Could not fetch models: ${e.message}`);
+    printInfo("Make sure OmniRoute is running and --remote/--api-key are correct.");
+    return 1;
+  }
+  if (only) ids = ids.filter((id) => only.some((f) => id.includes(f)));
+
+  const provider = buildCrushProvider(ids, baseUrl);
+  if (!provider.models.length) {
+    printError("No matching curated models (try --only or check the server).");
+    return 1;
+  }
+  const merged = mergeCrushConfig(readJson(configPath), provider);
+  const out = JSON.stringify(merged, null, 2) + "\n";
+
+  if (dryRun) {
+    console.log("\n" + (out.length > 3500 ? out.slice(0, 3500) + "\n… (truncated)" : out));
+    printInfo(`[dry-run] ${provider.models.length} model(s) under providers.omniroute → ${configPath}`);
+    return 0;
+  }
+  mkdirSync(join(configPath, ".."), { recursive: true });
+  writeFileSync(configPath, out, "utf8");
+  printSuccess(`Wrote ${configPath} (${provider.models.length} models under providers.omniroute)`);
+  printInfo("Provide the key (config references $OMNIROUTE_API_KEY):  export OMNIROUTE_API_KEY=...");
+  printInfo("Then run:  crush");
+  return 0;
+}
+
+export function registerSetupCrush(program) {
+  program
+    .command("setup-crush")
+    .description("Generate the OmniRoute openai-compat provider in ~/.config/crush/crush.json")
+    .option("--port <port>", "Local OmniRoute port (ignored when --remote is set)", "20128")
+    .option("--remote <url>", "Remote OmniRoute URL, e.g. http://192.168.0.15:20128")
+    .option("--api-key <key>", "OmniRoute API key (defaults to OMNIROUTE_API_KEY env var)")
+    .option("--only <patterns>", "Comma-separated substrings — keep only matching model IDs")
+    .option("--config-path <path>", "crush.json path (default: ~/.config/crush/crush.json)")
+    .option("--dry-run", "Print what would be written without touching the filesystem")
+    .action(async (opts) => {
+      const code = await runSetupCrushCommand(opts);
+      if (code !== 0) process.exit(code);
+    });
+}

--- a/docs/guides/REMOTE-MODE.md
+++ b/docs/guides/REMOTE-MODE.md
@@ -152,6 +152,7 @@ context, or `--remote <url> --api-key <key>`):
 | Continue | `omniroute setup-continue` | `~/.continue/config.yaml` (VS Code/JetBrains + `cn` CLI) — `provider: openai`, `apiBase` **with** `/v1`, key via `${{ secrets.OMNIROUTE_API_KEY }}` |
 | Cursor | `omniroute setup-cursor` | prints the in-app steps (Settings → Models → Override OpenAI Base URL **with** `/v1` + key + model). Cursor config is opaque SQLite — chat panel only |
 | Roo Code | `omniroute setup-roo` | writes a Roo import JSON (`~/.omniroute/roo-settings.json`) + sets `roo-cline.autoImportSettingsPath` + prints UI steps (OpenAI-compatible, Base URL **with** `/v1`) |
+| Crush | `omniroute setup-crush` | `~/.config/crush/crush.json` — `openai-compat` provider, `base_url` **with** `/v1`, key via `$OMNIROUTE_API_KEY` |
 
 ```bash
 # OpenCode (openai-compatible provider, all catalog models, remote VPS)

--- a/tests/unit/cli/setup-crush.test.ts
+++ b/tests/unit/cli/setup-crush.test.ts
@@ -1,0 +1,25 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { resolveCrushTarget, buildCrushProvider, mergeCrushConfig } from "../../../bin/cli/commands/setup-crush.mjs";
+
+test("resolveCrushTarget ensures /v1", () => {
+  assert.equal(resolveCrushTarget({ remote: "http://vps:20128" }).baseUrl, "http://vps:20128/v1");
+});
+test("resolveCrushTarget: explicit --api-key wins", () => {
+  assert.equal(resolveCrushTarget({ remote: "http://x:20128", apiKey: "sk-x" }).apiKey, "sk-x");
+});
+test("buildCrushProvider emits openai-compat + env-ref key + curated models w/ context_window", () => {
+  const p = buildCrushProvider(["glm/glm-5.2", "some/unknown"], "http://vps:20128/v1");
+  assert.equal(p.type, "openai-compat");
+  assert.equal(p.base_url, "http://vps:20128/v1");
+  assert.equal(p.api_key, "$OMNIROUTE_API_KEY");
+  assert.equal(p.models.length, 1); // unknown skipped
+  assert.equal(p.models[0].id, "glm/glm-5.2");
+  assert.ok(p.models[0].context_window > 0);
+});
+test("mergeCrushConfig adds providers.omniroute, preserves the rest", () => {
+  const m = mergeCrushConfig({ options: { tui: true }, providers: { local: {} } }, buildCrushProvider(["glm/glm-5.2"], "http://x/v1"));
+  assert.deepEqual(m.options, { tui: true });
+  assert.ok(m.providers.local);
+  assert.ok(m.providers.omniroute);
+});


### PR DESCRIPTION
## What
CLI **#9**. `omniroute setup-crush` writes Crush's file-based `~/.config/crush/crush.json` with an `openai-compat` provider for OmniRoute: `base_url` **WITH `/v1`**, `api_key` = `$OMNIROUTE_API_KEY` (secret off disk), curated catalog models with `context_window`. Merges (preserves existing). Remote-aware; `--only`.

## Validation
- Remote (VPS v3.8.30): `setup-crush --remote --only glm --dry-run` → correct provider JSON.
- Crush's wire (`/v1/chat/completions`) already validated → "OK". 4 unit tests; `check:cli-i18n` ✓.

Series: …Cursor #4291 · Roo #4292 · **Crush (this)**. Next: Goose, Qwen Code, Gemini CLI, Aider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
