### PR TITLE
fix(deps): bump dompurify to 3.4.11 (security) [cherry-pick → v3.8.30]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13268,9 +13268,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.4.10",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
-      "integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/package.json
+++ b/package.json
@@ -338,7 +338,7 @@
     ]
   },
   "overrides": {
-    "dompurify": "^3.4.9",
+    "dompurify": "^3.4.11",
     "postcss": "^8.5.14",
     "ip-address": "10.2.0",
     "qs": "^6.15.2",


### PR DESCRIPTION
## Resumo

Cherry-pick de `73ea462e2` (PR #4304 → `main`) para `release/v3.8.30`, fechando os mesmos alertas do Dependabot nesta release.

**Importante:** a `release/v3.8.30` **já havia recebido** os bumps de `undici` → 7.28.0 (jsdom transitivo + electron + node-gyp 6.27.0) via outra PR. Portanto, o cherry-pick aplicou apenas a parte que ainda faltava nesta branch:

| Pacote | De | Para | GHSA | Sev |
|--------|----|------|------|-----|
| `dompurify` (override + lockfile root) | 3.4.10 | **3.4.11** | `GHSA-cmwh-pvxp-8882` | MED |

- **dompurify ≤ 3.4.10** — poluição permanente de `ALLOWED_ATTR` via `setConfig()` driblando o clone-guard de hooks (correção incompleta do patch 3.4.7).
- `package.json`: floor do override `dompurify` `^3.4.9` → `^3.4.11`.
- `package-lock.json`: `dompurify` → 3.4.11.

### Validação

- `npm audit` lendo o lockfile isolado: **undici OK, dompurify OK**, 0 high / 0 critical.
- Estado final da release: todos os alvos de segurança (undici 7.28.0 / 6.27.0, dompurify 3.4.11) nas versões corrigidas.
- Mudança lockfile/override apenas — sem código de produção (hard rule #8 N/A).

> Equivalente em `main`: #4304.