### PR TITLE
fix(sse): release reader and cancel stream on abort/error to prevent Undici pool socket leak

### DIFF
--- a/open-sse/executors/antigravity.ts
+++ b/open-sse/executors/antigravity.ts
@@ -962,7 +962,17 @@ export class AntigravityExecutor extends BaseExecutor {
         const msg = err?.message || String(err);
         timedOut = msg.includes("timed out");
         log?.warn?.("SSE_COLLECT", `Error collecting SSE stream: ${msg}`);
-        // Fall through — return whatever was collected so far
+        // Cancel the stream to prevent locking the socket in Undici pool
+        try {
+          reader.releaseLock();
+        } catch (_) {}
+        try {
+          response.body?.cancel().catch(() => {});
+        } catch (_) {}
+      } finally {
+        try {
+          reader.releaseLock();
+        } catch (_) {}
       }
       processAntigravitySSEText(decoder.decode(), partialLine, collected, logger);
       flushAntigravitySSEText(partialLine, collected, logger);
@@ -1537,6 +1547,21 @@ export class AntigravityExecutor extends BaseExecutor {
         // that extracts remainingCredits from the final SSE chunk(s) without
         // consuming the stream. The client receives the unmodified SSE data.
         if (response.body) {
+          // If the downstream client aborts, cancel the upstream fetch body immediately
+          // to release the socket back to the Undici agent pool and prevent memory leaks.
+          if (signal) {
+            const abortHandler = () => {
+              try {
+                response.body?.cancel().catch(() => {});
+              } catch (_) {}
+            };
+            if (signal.aborted) {
+              abortHandler();
+            } else {
+              signal.addEventListener("abort", abortHandler, { once: true });
+            }
+          }
+
           let sseBuffer = "";
           const decoder = new TextDecoder(); // Singleton for correct streaming decode
           const MAX_BUFFER_SIZE = 16 * 1024; // Limit to prevent OOM on large streams

--- a/tests/unit/antigravity-sse-collect-socket-release-4309.test.ts
+++ b/tests/unit/antigravity-sse-collect-socket-release-4309.test.ts
@@ -1,0 +1,63 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { AntigravityExecutor } from "../../open-sse/executors/antigravity.ts";
+
+// Regression guard for #4309 (thanks @Ardem2025 / Dmitry Kuznetsov): when the upstream
+// SSE collection aborts or errors, AntigravityExecutor.collectStreamToResponse must
+// release the stream reader AND cancel the response body — otherwise the underlying
+// socket stays checked out of the Undici agent pool (a slow socket/memory leak under
+// abort-heavy load). Previously the catch block just fell through ("return whatever was
+// collected"), leaving the body uncancelled and the reader locked.
+//
+// We drive the error path deterministically with a pre-aborted signal (the first loop
+// iteration throws "Request aborted during SSE collection" before any read), then assert
+// the reader was released and the body cancelled exactly as the fix does.
+test("collectStreamToResponse releases the reader and cancels the body on abort (Undici socket leak #4309)", async () => {
+  const executor = new AntigravityExecutor();
+
+  let releaseLockCalls = 0;
+  let cancelCalls = 0;
+
+  const fakeReader = {
+    // Never resolves — with a pre-aborted signal the loop throws before ever reading,
+    // so read() must not be needed to reach the cleanup path.
+    read: () => new Promise<never>(() => {}),
+    releaseLock: () => {
+      releaseLockCalls += 1;
+    },
+  };
+
+  const fakeBody = {
+    getReader: () => fakeReader,
+    cancel: () => {
+      cancelCalls += 1;
+      return Promise.resolve();
+    },
+  };
+
+  const response = { body: fakeBody } as unknown as Response;
+
+  const controller = new AbortController();
+  controller.abort(); // pre-aborted → the collect loop throws on its first guard check
+
+  await executor.collectStreamToResponse(
+    response,
+    "antigravity-model",
+    "https://example.invalid/sse",
+    {},
+    {},
+    null,
+    controller.signal
+  );
+
+  assert.ok(
+    releaseLockCalls >= 1,
+    "reader.releaseLock() must be called on the abort/error path (was never released before the fix)"
+  );
+  assert.equal(
+    cancelCalls,
+    1,
+    "response.body.cancel() must be called exactly once to return the socket to the Undici pool"
+  );
+});


### PR DESCRIPTION
This PR fixes the Undici pool socket leaks and memory leaks caused by streams being left in a locked / disturbed state during client aborts or SSE collection exceptions. It ensures that standard SSE streams are cancelled upon client cancellation (abort signal) and that the stream reader is properly released and the stream cancelled on collection timeouts or errors.