### PR TITLE
fix(open-sse): inner-ai stops silently rerouting unmatched models to models[0]

### DIFF
--- a/open-sse/executors/inner-ai.ts
+++ b/open-sse/executors/inner-ai.ts
@@ -302,16 +302,23 @@ async function resolveModels(
  * 1. Exact `llm_model` match
  * 2. Case-insensitive `llm_model` match
  * 3. `llm_model` contains the requested ID
- * 4. Fallback: first model in list
+ *
+ * Returns `null` when nothing matches. The caller then builds a synthetic entry
+ * carrying the *requested* model name, so the request is sent for the model the
+ * user actually asked for (and Inner.ai can reject it with a meaningful error if
+ * the plan does not expose it). Previously this fell back to `models[0]`, which
+ * silently rerouted every unmatched model to whatever was first in the live list
+ * (typically gpt-4o) — so users saw "only gpt-4o responds" instead of a clear
+ * error. (escalated bug)
  */
-function findModel(models: InnerAiModel[], requestedId: string): InnerAiModel | null {
+export function findModel(models: InnerAiModel[], requestedId: string): InnerAiModel | null {
   if (models.length === 0) return null;
   const lower = requestedId.toLowerCase();
   return (
     models.find((m) => m.llm_model === requestedId) ??
     models.find((m) => m.llm_model.toLowerCase() === lower) ??
     models.find((m) => m.llm_model.toLowerCase().includes(lower)) ??
-    models[0]
+    null
   );
 }
 

--- a/tests/unit/inner-ai-find-model.test.ts
+++ b/tests/unit/inner-ai-find-model.test.ts
@@ -1,0 +1,47 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+const { findModel } = await import("../../open-sse/executors/inner-ai.ts");
+
+// Regression guard for the escalated bug "On Inner.ai the only model that seems to
+// respond is gpt-4o". The live model list is plan-gated, so a requested model the
+// plan does not expose used to silently fall back to `models[0]` (the first entry,
+// typically gpt-4o) instead of returning null. That rerouted every unmatched model
+// to gpt-4o with no error. findModel must return null on no match so the caller can
+// pass the *requested* model through as a synthetic entry.
+const PLAN_MODELS = [
+  { id: "u1", llm_model: "gpt-4o" },
+  { id: "u2", llm_model: "gpt-4.1" },
+  { id: "u3", llm_model: "claude-opus-4-5" },
+];
+
+describe("inner-ai findModel", () => {
+  it("returns null (not models[0]) when the requested model is not in the plan list", () => {
+    const result = findModel(PLAN_MODELS, "gemini-2.5-pro");
+    assert.equal(
+      result,
+      null,
+      "unmatched model must NOT silently fall back to the first plan model (gpt-4o)"
+    );
+  });
+
+  it("returns null for an empty model list", () => {
+    assert.equal(findModel([], "gpt-4o"), null);
+  });
+
+  it("matches exactly by llm_model", () => {
+    assert.equal(findModel(PLAN_MODELS, "gpt-4.1")?.id, "u2");
+  });
+
+  it("matches case-insensitively", () => {
+    assert.equal(findModel(PLAN_MODELS, "GPT-4O")?.id, "u1");
+  });
+
+  it("matches by substring (requested id contained in llm_model)", () => {
+    const models = [
+      { id: "a", llm_model: "anthropic/claude-opus-4-5-20260101" },
+      { id: "b", llm_model: "gpt-4o" },
+    ];
+    assert.equal(findModel(models, "claude-opus-4-5")?.id, "a");
+  });
+});


### PR DESCRIPTION
## Causa

Inner.ai's live model list is **plan-gated** (resolved against the Inner.ai API and filtered by the JWT plan tier). `findModel()` fell back to `models[0]` — the first entry in that live list, typically **gpt-4o** — whenever the requested model did not match by exact / case-insensitive / substring. So every model the plan does not expose was **silently rerouted to gpt-4o**, and users reported that "only gpt-4o responds" on Inner.ai.

## Fix

`findModel()` now returns `null` on no match. The single caller already handles `null` by building a synthetic entry carrying the **actually-requested** model name, so the request is sent for the model the user asked for and Inner.ai can surface a meaningful error if the plan does not expose it — instead of masking it as gpt-4o.

Surgical: 1 production file (`open-sse/executors/inner-ai.ts`) — export `findModel`, update docstring, `models[0]` → `null`.

## TDD (red → green)

`tests/unit/inner-ai-find-model.test.ts`:
- 🔴→🟢 unmatched model → `null` (previously returned the gpt-4o entry)
- regression guards: exact match, case-insensitive match, substring match, empty list

Validation: new test 5/5; existing `executor-inner-ai.test.ts` 6/6; `typecheck:core` clean; `eslint` clean; `check:file-size` OK.

## Origem

Reported on the mesh (escalated backlog): "No Inner.ai o único modelo que parece estar respondendo é o gpt-4o."
