### PR TITLE
fix(dashboard): proxy modal stops pre-filling new scopes with an unrelated proxy

### DIFF
--- a/src/shared/components/ProxyConfigModal.tsx
+++ b/src/shared/components/ProxyConfigModal.tsx
@@ -4,6 +4,12 @@ import { useState, useEffect, useMemo } from "react";
 import { useTranslations } from "next-intl";
 import Modal from "./Modal";
 import Button from "./Button";
+import {
+  type ProxyAssignmentItem,
+  normalizeScopeId,
+  isSameScopeAssignment,
+  selectScopeAssignment,
+} from "./proxyAssignment";
 
 const ALL_PROXY_TYPES = [
   { value: "http", label: "HTTP" },
@@ -33,12 +39,6 @@ type ProxyRegistryItem = {
   source?: string | null;
 };
 
-type ProxyAssignmentItem = {
-  proxyId?: string | null;
-  scope?: string | null;
-  scopeId?: string | null;
-};
-
 type ProxyConfigModalProps = {
   isOpen: boolean;
   onClose: () => void;
@@ -57,20 +57,6 @@ function getAssignmentScope(level: ProxyConfigLevel) {
 
 function getAssignmentScopeId(level: ProxyConfigLevel, levelId?: string) {
   return level === "global" ? null : levelId || null;
-}
-
-function normalizeScopeId(scopeId?: string | null) {
-  return !scopeId || scopeId === "__global__" ? null : scopeId;
-}
-
-function isSameScopeAssignment(
-  assignment: ProxyAssignmentItem,
-  scope: string,
-  scopeId: string | null
-) {
-  return (
-    assignment.scope === scope && normalizeScopeId(assignment.scopeId) === normalizeScopeId(scopeId)
-  );
 }
 
 function getCustomProxyName(level: ProxyConfigLevel, levelId?: string, levelLabel?: string) {
@@ -95,7 +81,7 @@ async function fetchAssignmentForScope(scope: string, scopeId: string | null) {
 
   const payload = await readJson(res);
   const items: ProxyAssignmentItem[] = Array.isArray(payload?.items) ? payload.items : [];
-  return items.find((item) => isSameScopeAssignment(item, scope, scopeId)) || items[0] || null;
+  return selectScopeAssignment(items, scope, scopeId);
 }
 
 async function fetchRegistryProxy(proxyId: string, cachedProxies: ProxyRegistryItem[]) {
@@ -198,8 +184,7 @@ export default function ProxyConfigModal({
         if (assignmentRes.ok) {
           const assignmentPayload = await assignmentRes.json();
           const items = Array.isArray(assignmentPayload?.items) ? assignmentPayload.items : [];
-          const target =
-            items.find((item) => isSameScopeAssignment(item, scope, scopeId)) || items[0];
+          const target = selectScopeAssignment(items, scope, scopeId);
           if (target?.proxyId) {
             setSelectedProxyId(target.proxyId);
             setHasOwnProxy(true);

--- a/src/shared/components/proxyAssignment.test.tsx
+++ b/src/shared/components/proxyAssignment.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { selectScopeAssignment } from "./proxyAssignment";
+
+// Regression guard for the escalated bug "when I create a new provider it already
+// comes with a proxy I never configured". The proxy assignments list is global, so
+// its first entry belongs to some other scope. selectScopeAssignment must return null
+// when the current scope has no assignment of its own — never fall back to items[0],
+// which used to pre-fill freshly created providers/keys with an unrelated proxy.
+const ASSIGNMENTS = [
+  { proxyId: "socks5-acct", scope: "key", scopeId: "3c0031c1-existing-account" },
+  { proxyId: "http-claude", scope: "provider", scopeId: "claude" },
+];
+
+describe("selectScopeAssignment", () => {
+  it("returns null (not items[0]) for a scope with no assignment of its own", () => {
+    // A brand-new provider with no proxy assignment.
+    const result = selectScopeAssignment(ASSIGNMENTS, "provider", "newprovider");
+    expect(result).toBeNull();
+  });
+
+  it("returns null for a new account/key scope even when other proxies exist", () => {
+    const result = selectScopeAssignment(ASSIGNMENTS, "key", "brand-new-key");
+    expect(result).toBeNull();
+  });
+
+  it("returns the matching assignment when the scope owns one", () => {
+    const result = selectScopeAssignment(ASSIGNMENTS, "provider", "claude");
+    expect(result?.proxyId).toBe("http-claude");
+  });
+
+  it("treats the global scope (null scopeId) distinctly", () => {
+    const withGlobal = [{ proxyId: "g", scope: "global", scopeId: null }, ...ASSIGNMENTS];
+    expect(selectScopeAssignment(withGlobal, "global", null)?.proxyId).toBe("g");
+    // a provider scope still must not borrow the global assignment
+    expect(selectScopeAssignment(withGlobal, "provider", "unconfigured")).toBeNull();
+  });
+
+  it("returns null for an empty assignments list", () => {
+    expect(selectScopeAssignment([], "provider", "anything")).toBeNull();
+  });
+});

--- a/src/shared/components/proxyAssignment.ts
+++ b/src/shared/components/proxyAssignment.ts
@@ -1,0 +1,40 @@
+/**
+ * Proxy-assignment scope helpers, extracted from ProxyConfigModal so the pure
+ * selection logic can be unit-tested without rendering the React component.
+ */
+
+export type ProxyAssignmentItem = {
+  proxyId?: string | null;
+  scope?: string | null;
+  scopeId?: string | null;
+};
+
+export function normalizeScopeId(scopeId?: string | null) {
+  return !scopeId || scopeId === "__global__" ? null : scopeId;
+}
+
+export function isSameScopeAssignment(
+  assignment: ProxyAssignmentItem,
+  scope: string,
+  scopeId: string | null
+) {
+  return (
+    assignment.scope === scope && normalizeScopeId(assignment.scopeId) === normalizeScopeId(scopeId)
+  );
+}
+
+/**
+ * Pick the proxy assignment that belongs to *this* scope, or `null` when none does.
+ *
+ * Must NOT fall back to `items[0]`: the assignments list is global, so the first
+ * entry belongs to some other scope (e.g. another account's proxy). Returning it
+ * for a scope with no assignment of its own made a freshly created provider/key
+ * appear pre-filled with an unrelated proxy the user never configured. (escalated bug)
+ */
+export function selectScopeAssignment(
+  items: ProxyAssignmentItem[],
+  scope: string,
+  scopeId: string | null
+): ProxyAssignmentItem | null {
+  return items.find((item) => isSameScopeAssignment(item, scope, scopeId)) ?? null;
+}


### PR DESCRIPTION
## Causa

`/api/settings/proxies/assignments` returns the **global** list of proxy assignments, so its first element belongs to some other scope (e.g. another account's proxy). `ProxyConfigModal` resolved the assignment for the current scope with:

```ts
items.find((item) => isSameScopeAssignment(item, scope, scopeId)) || items[0]
```

When the modal opened for a **freshly created provider/key** (no assignment of its own), `find` returned `undefined` and the `|| items[0]` fallback pre-selected an unrelated proxy: it set `selectedProxyId`, flipped `hasOwnProxy = true`, and pre-filled host/port/username/password. Users reported "when I create a new provider it already comes with a proxy I never configured." (Reproduced against a real instance whose only assignment was a per-key SOCKS5 proxy — every new provider inherited it.)

## Fix

Extracted the scope helpers into `src/shared/components/proxyAssignment.ts` and added `selectScopeAssignment`, which returns `null` (never `items[0]`) when the current scope owns no assignment. Both call sites (`fetchAssignmentForScope` and the modal's load effect) now use it, so a new scope shows the empty/custom state instead of borrowing another scope's proxy.

The extraction also keeps `ProxyConfigModal.tsx` under the 800-line file-size cap.

## TDD (red → green)

`src/shared/components/proxyAssignment.test.tsx` (runs in the blocking `test:vitest` suite):
- 🔴→🟢 no-match → `null` for provider, account/key, and global-vs-provider scopes (previously returned `items[0]`)
- regression guards: matching scope returns its assignment; empty list → `null`

Validation: new test 5/5; existing `ProxyConfigModal` component test 3/3; related proxy unit tests 14/14; `typecheck:core` clean; `eslint` 0 errors; `check:file-size` OK.

## Origem

Reported on the mesh (escalated backlog): "quando eu crio um novo provider, ele já vem [com um proxy], isso tá vindo de onde? eu não configurei nenhum proxy aqui."
