### PR TITLE
fix(embeddings): inject NVIDIA NIM input_type for asymmetric embed models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 _In development — bullets added per PR; finalized at release._
 
+### 🐛 Fixed
+
+- **fix(embeddings): NVIDIA NIM asymmetric embedding models inject the required `input_type`** — NVIDIA NIM asymmetric embedders (e.g. `nvidia/nv-embedqa-e5-v5`) reject requests without an `input_type` parameter with `400 "'input_type' parameter is required"`, but OmniRoute only forwarded `input_type` when the client supplied it — so callers (and OpenAI-style SDKs that don't emit the field) got a hard failure. The embedding registry now carries a model-level default (`input_type: "query"`) for the asymmetric NVIDIA model, and the embeddings handler injects a model's default params into the upstream body **only** when the client didn't already send them — a client-supplied `input_type` (e.g. `"passage"`) is respected unchanged, and symmetric models that carry no default are unaffected. (thanks @hydraromania)
+
 ---
 
 ## [3.8.30] — 2026-06-20

--- a/open-sse/config/embeddingRegistry.ts
+++ b/open-sse/config/embeddingRegistry.ts
@@ -8,12 +8,25 @@
  * keyed by provider ID (e.g. "nebius", "openai").
  */
 
+export interface EmbeddingModel {
+  id: string;
+  name: string;
+  dimensions?: number;
+  /**
+   * Model-level default request parameters injected into the upstream body when
+   * the client did not already supply them. Used for asymmetric embedding models
+   * that require a mandatory parameter — e.g. NVIDIA NIM `nv-embedqa-*` models
+   * reject requests without `input_type` ("query" | "passage"). See issue #1378.
+   */
+  defaultParams?: Record<string, unknown>;
+}
+
 export interface EmbeddingProvider {
   id: string;
   baseUrl: string;
   authType: string;
   authHeader: string;
-  models: { id: string; name: string; dimensions?: number }[];
+  models: EmbeddingModel[];
 }
 
 export interface EmbeddingProviderNodeRow {
@@ -130,7 +143,17 @@ export const EMBEDDING_PROVIDERS: Record<string, EmbeddingProvider> = {
     baseUrl: "https://integrate.api.nvidia.com/v1/embeddings",
     authType: "apikey",
     authHeader: "bearer",
-    models: [{ id: "nvidia/nv-embedqa-e5-v5", name: "NV EmbedQA E5 v5", dimensions: 1024 }],
+    // nv-embedqa-* are asymmetric models: NVIDIA NIM rejects requests without an
+    // `input_type` ("query" | "passage") with 400 "'input_type' parameter is
+    // required". Default to "query" when the client omits it (issue #1378).
+    models: [
+      {
+        id: "nvidia/nv-embedqa-e5-v5",
+        name: "NV EmbedQA E5 v5",
+        dimensions: 1024,
+        defaultParams: { input_type: "query" },
+      },
+    ],
   },
 
   // Issue #2298: Adding DeepInfra to the embedding registry so custom
@@ -357,6 +380,20 @@ export function detectEmbeddingDimensionConflict(modelStrs: string[]): {
   }
   const distinct = [...new Set(Object.values(dimensions))].sort((a, b) => a - b);
   return { conflict: distinct.length > 1, dimensions, distinct };
+}
+
+/**
+ * Resolve the model-level default request params for a given provider config and
+ * model id. Returns undefined when the model has no defaults (the common case),
+ * so callers only inject for models that actually carry one (e.g. NVIDIA NIM
+ * asymmetric embedders requiring `input_type`). See issue #1378.
+ */
+export function getEmbeddingModelDefaultParams(
+  providerConfig: EmbeddingProvider | null,
+  modelId: string | null
+): Record<string, unknown> | undefined {
+  if (!providerConfig || !modelId) return undefined;
+  return providerConfig.models.find((m) => m.id === modelId)?.defaultParams;
 }
 
 /**

--- a/open-sse/handlers/embeddings.ts
+++ b/open-sse/handlers/embeddings.ts
@@ -15,6 +15,7 @@
 
 import {
   getEmbeddingProvider,
+  getEmbeddingModelDefaultParams,
   parseEmbeddingModel,
   type EmbeddingProvider,
 } from "../config/embeddingRegistry.ts";
@@ -140,6 +141,19 @@ export async function handleEmbedding({
   for (const [key, value] of Object.entries(body)) {
     if (!KNOWN_FIELDS.has(key) && value !== undefined) {
       upstreamBody[key] = value;
+    }
+  }
+
+  // Inject model-level default params (e.g. NVIDIA NIM asymmetric models require
+  // `input_type`) only for keys the client did not already supply, so a
+  // client-sent value is never overwritten. Symmetric models carry no defaults
+  // and are unaffected. See issue #1378.
+  const defaultParams = getEmbeddingModelDefaultParams(providerConfig, model);
+  if (defaultParams) {
+    for (const [key, value] of Object.entries(defaultParams)) {
+      if (upstreamBody[key] === undefined) {
+        upstreamBody[key] = value;
+      }
     }
   }
 

--- a/tests/unit/embeddings-nvidia-input-type.test.ts
+++ b/tests/unit/embeddings-nvidia-input-type.test.ts
@@ -1,0 +1,108 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+process.env.DATA_DIR = mkdtempSync(join(tmpdir(), "omniroute-embeddings-nvidia-"));
+
+const { handleEmbedding } = await import("../../open-sse/handlers/embeddings.ts");
+
+// Issue #1378: NVIDIA NIM asymmetric embedding models (e.g. nvidia/nv-embedqa-e5-v5)
+// require an `input_type` parameter ("query" | "passage"); without it the upstream
+// returns 400 "'input_type' parameter is required". OmniRoute must inject the
+// registered model-level default when the client omits input_type, and must respect
+// a client-supplied input_type when present.
+
+function captureFetch(captured: { body?: Record<string, unknown> }) {
+  return async (url: unknown, options: { headers?: unknown; body?: unknown } = {}) => {
+    captured.body = JSON.parse(String(options.body || "{}"));
+    return new Response(
+      JSON.stringify({
+        data: [{ object: "embedding", embedding: [0.1, 0.2], index: 0 }],
+        usage: { prompt_tokens: 4, total_tokens: 4 },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } }
+    );
+  };
+}
+
+test("handleEmbedding injects NVIDIA asymmetric default input_type when client omits it", async () => {
+  const originalFetch = globalThis.fetch;
+  const captured: { body?: Record<string, unknown> } = {};
+  globalThis.fetch = captureFetch(captured) as typeof fetch;
+
+  try {
+    const result = await handleEmbedding({
+      body: {
+        model: "nvidia/nvidia/nv-embedqa-e5-v5",
+        input: "What is the capital of France?",
+      },
+      credentials: { apiKey: "nvidia-key" },
+      log: null,
+    });
+
+    assert.equal(result.success, true);
+    // The model-level default input_type must be forwarded to the upstream body.
+    assert.equal(
+      captured.body?.input_type,
+      "query",
+      "expected NVIDIA asymmetric model default input_type to be injected"
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("handleEmbedding respects a client-supplied input_type (does not overwrite)", async () => {
+  const originalFetch = globalThis.fetch;
+  const captured: { body?: Record<string, unknown> } = {};
+  globalThis.fetch = captureFetch(captured) as typeof fetch;
+
+  try {
+    const result = await handleEmbedding({
+      body: {
+        model: "nvidia/nvidia/nv-embedqa-e5-v5",
+        input: "Paris is the capital of France.",
+        input_type: "passage",
+      },
+      credentials: { apiKey: "nvidia-key" },
+      log: null,
+    });
+
+    assert.equal(result.success, true);
+    assert.equal(
+      captured.body?.input_type,
+      "passage",
+      "expected client-supplied input_type to be respected, not overwritten by the default"
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("handleEmbedding does not inject input_type for symmetric models without a default", async () => {
+  const originalFetch = globalThis.fetch;
+  const captured: { body?: Record<string, unknown> } = {};
+  globalThis.fetch = captureFetch(captured) as typeof fetch;
+
+  try {
+    const result = await handleEmbedding({
+      body: {
+        model: "openai/text-embedding-3-small",
+        input: "hello world",
+      },
+      credentials: { apiKey: "openai-key" },
+      log: null,
+    });
+
+    assert.equal(result.success, true);
+    assert.equal(
+      "input_type" in (captured.body || {}),
+      false,
+      "symmetric models without a default must not receive an injected input_type"
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
## Summary

- NVIDIA NIM **asymmetric** embedding models (e.g. `nvidia/nv-embedqa-e5-v5`) require an `input_type` parameter (`"query"` | `"passage"`). Without it the upstream returns `400 "'input_type' parameter is required"`.
- OmniRoute registered the model with no default and the embeddings handler only forwarded client-sent extra fields, so requests that omitted `input_type` failed.

## Fix

- `embeddingRegistry.ts`: add an optional `defaultParams` to the embedding-model shape and mark `nvidia/nv-embedqa-e5-v5` with `defaultParams: { input_type: "query" }`; add `getEmbeddingModelDefaultParams()`.
- `embeddings.ts`: inject the model's `defaultParams` into the upstream body **only** for keys the client didn't supply (a client-sent `input_type` is never overwritten). Symmetric models carry no defaults and are unaffected.

## Test plan

- [x] New regression `tests/unit/embeddings-nvidia-input-type.test.ts` — injects when omitted; respects client value; symmetric model unaffected (RED→GREEN).
- [x] `embeddings-handler` + registry + family-guard suites green; `typecheck:core` + eslint clean.

## Attribution

Thanks to [@hydraromania](https://github.com/hydraromania) for the original report.