### PR TITLE
test: align two tests left red by merged PRs (#4335 db-rules count + #4271 arena metadata)

### DIFF
--- a/tests/unit/check-db-rules-classification.test.ts
+++ b/tests/unit/check-db-rules-classification.test.ts
@@ -122,10 +122,12 @@ test("INTENTIONALLY_INTERNAL is exported from check-db-rules.mjs", () => {
   assert.ok(INTENTIONALLY_INTERNAL.size > 0, "INTENTIONALLY_INTERNAL must not be empty");
 });
 
-test("INTENTIONALLY_INTERNAL contains the expected 26 audited modules", () => {
+test("INTENTIONALLY_INTERNAL contains the expected 28 audited modules", () => {
   const expected = [
     "_rowTypes",
     "accessTokens",
+    "apiKeyColumnFallbacks",
+    "apiKeyUsageLimitFields",
     "cleanup",
     "cliToolState",
     "comboForecast",

--- a/tests/unit/web-session-credentials.test.ts
+++ b/tests/unit/web-session-credentials.test.ts
@@ -37,13 +37,15 @@ test("web session credential metadata identifies cookie, token, and no-auth prov
     acceptsFullCookieHeader: false,
     storageKeys: ["token", "userToken"],
   });
-  // lmarena.ai's real auth cookie is `arena-auth-prod-v1`, not `session` (#3810)
+  // lmarena.ai's real auth cookie is `arena-auth-prod-v1`, not `session` (#3810).
+  // The session is now split across `arena-auth-prod-v1.0`, `.1`, … (#4271).
   assert.deepEqual(webSessionCredentials.getWebSessionCredentialRequirement("lmarena"), {
     kind: "cookie",
     credentialName: "arena-auth-prod-v1",
-    placeholder: "arena-auth-prod-v1=... or full Cookie header from lmarena.ai",
+    placeholder:
+      "Paste the full Cookie header from lmarena.ai (the session is now split across arena-auth-prod-v1.0, .1, …)",
     acceptsFullCookieHeader: true,
-    storageKeys: ["cookie", "arena-auth-prod-v1", "session"],
+    storageKeys: ["cookie", "arena-auth-prod-v1", "arena-auth-prod-v1.0", "arena-auth-prod-v1.1", "session"],
   });
   // veoaifree-web is now a NOAUTH provider — not in WEB_SESSION_CREDENTIAL_REQUIREMENTS
   assert.equal(webSessionCredentials.getWebSessionCredentialRequirement("veoaifree-web"), null);


### PR DESCRIPTION
Two **test-only** alignments for unit tests left red on release/v3.8.30 by merged PRs that changed source/config without updating the matching assertion. Both only surface under the full unit suite (`__RUN_ALL__`), so the narrow Fast-QG of the merging PRs didn't catch them.

## 1. db-rules audited-module count (from #4335)

#4335 added `apiKeyColumnFallbacks` + `apiKeyUsageLimitFields` to `INTENTIONALLY_INTERNAL` (both `db-internal`, imported only by `db/apiKeys.ts`) but didn't update `check-db-rules-classification.test.ts`, which hard-codes the audited list and asserts exactly **26**. Now 28 → red. Added the two modules to `expected` and bumped the count to 28.

## 2. lmarena split-cookie metadata (from #4271)

#4271/#4331 updated `webSessionCredentials.ts` for lmarena's split auth cookie (new placeholder + `arena-auth-prod-v1.0`/`.1` storageKeys) but didn't update `web-session-credentials.test.ts`, which still asserted the old placeholder + 3-key array. Aligned the expected metadata to the merged source.

## Validation (Hard Rule #18)

Both were red → green:
- `check-db-rules-classification.test.ts`: **5/5**.
- `web-session-credentials.test.ts`: **4/4**.

Test-only; no production code change.