### PR TITLE
fix(pricing): price gpt-5.x-pro openai models + align opencode-go discovery test

### DIFF
--- a/config/quality/file-size-baseline.json
+++ b/config/quality/file-size-baseline.json
@@ -169,7 +169,7 @@
     "src/shared/components/RequestLoggerV2.tsx": 1287,
     "src/shared/components/analytics/charts.tsx": 1558,
     "src/shared/constants/cliTools.ts": 875,
-    "src/shared/constants/pricing.ts": 1581,
+    "src/shared/constants/pricing.ts": 1592,
     "src/shared/constants/providers.ts": 3242,
     "src/shared/constants/sidebarVisibility.ts": 1100,
     "src/shared/services/cliRuntime.ts": 1090,
@@ -203,7 +203,7 @@
     "tests/unit/models-catalog-route.test.ts": 1507,
     "tests/unit/oauth-providers-config.test.ts": 855,
     "tests/unit/perplexity-web.test.ts": 959,
-    "tests/unit/provider-models-route.test.ts": 1616,
+    "tests/unit/provider-models-route.test.ts": 1618,
     "tests/unit/provider-validation-specialty.test.ts": 2752,
     "tests/unit/providers-page-utils.test.ts": 1004,
     "tests/unit/reasoning-cache.test.ts": 980,
@@ -255,5 +255,6 @@
   "_rebaseline_2026_06_16_4004_livews_bridge": "PR #4004 own growth: chatCore.ts 5830->5851 (+21 = forwardDashboardEventToLiveWs — a best-effort, non-blocking, timeout-bounded POST that bridges compression.completed events from the main process to the LiveWS sidecar so the dashboard updates under a reverse proxy). Cohesive fire-and-forget beacon at the existing compression emit site; not extractable. Structural shrink of chatCore.ts tracked in #3501.",
   "_rebaseline_2026_06_17_4107_pending_reaper": "PR #4107 own growth: usageHistory.ts 854->934 (+80 = orphaned-pending-request reaper — sweepStalePendingRequests() evicts pending details older than 15min + a hard 5000 cap, plus an unref'd 5min sweep timer wired lazily into trackPendingRequest). Fixes an unbounded memory leak where abnormally-terminated requests left payload previews in pendingById forever. Cohesive with the existing pending-request bookkeeping (mirrors the normal removal path: decrement counters + cleanup buckets); not extractable.",
   "_rebaseline_2026_06_17_4116_combo_hedge_listener": "combo.ts: +9 lines from #4116 (detach per-target listener from shared hedge abort signal to fix a listener leak). Behavior-preserving cleanup; 5289 -> 5298.",
+  "_rebaseline_2026_06_20_4355_gpt5x_pro_pricing": "PR #4355 own growth: pricing.ts 1581->1592 (+11 = pure-data pricing rows for openai gpt-5.5-pro + gpt-5.4-pro, closing the $0 gap that tripped the catalog pricing gate after the #4324 sweep added them to the registry; -pro mirrors its base family tier). provider-models-route.test.ts 1616->1618 (+2 = test-only alignment to the intentional opencode-go discovery behavior: owned_by stamp + T39 two-endpoint fail-path fetchCalls). Both are data/test-only; not extractable.",
   "_rebaseline_2026_06_19_4293_codex_spark_scope": "PR #4293 (isolate Codex Spark quota scope) own growth, MEASURED on the actual merged tree (release/v3.8.30 + #4293). Production: auth.ts 2219->2279 (+60) threads requestedModel into Codex quota-policy/headroom/preflight/P2C scoring so normal Codex and GPT-5.3-Codex-Spark windows are evaluated independently; chatCore.ts 5116->5125 (+9) passes the failing model scope into Codex 429 failover (markCodexScopeRateLimited) instead of a connection-wide rateLimitedUntil write; accountFallback.ts 1727->1731 (+4) scopes Codex model-lock keys to codex vs spark. Heavy parsing/display logic lives in new leaf helpers under the cap (codexQuotaScopes.ts, codexUsageQuotas.ts, codexFailover.ts). Tests: account-fallback-service 1544->1569, executor-codex 1336->1339, sse-auth 1527->1553, usage-service-hardening 1612->1633 (added Spark-scope regression coverage). Cohesive wiring at existing selection/failover lockout boundaries; not extractable."
 }

--- a/src/shared/constants/pricing.ts
+++ b/src/shared/constants/pricing.ts
@@ -652,10 +652,21 @@ export const DEFAULT_PRICING = {
   // OpenAI
   openai: {
     "gpt-5.5": GPT_5_5_PRICING,
+    // The -pro tier mirrors its base family pricing until OpenAI publishes a
+    // distinct pro rate; without these rows the openai provider's gpt-5.x-pro
+    // models (in the registry) resolved to $0 and tripped the catalog pricing gate.
+    "gpt-5.5-pro": GPT_5_5_PRICING,
     // gpt-5.4 family (public API tier; mirrors the codex 5.4 tier for the
     // base/mini, with a lower nano tier). Without these rows the openai
     // provider's gpt-5.4* models resolved to $0.
     "gpt-5.4": {
+      input: 5.0,
+      output: 20.0,
+      cached: 2.5,
+      reasoning: 30.0,
+      cache_creation: 5.0,
+    },
+    "gpt-5.4-pro": {
       input: 5.0,
       output: 20.0,
       cached: 2.5,

--- a/tests/unit/provider-models-route.test.ts
+++ b/tests/unit/provider-models-route.test.ts
@@ -569,7 +569,7 @@ test("provider models route caches discovered opencode-go models per connection"
 
   assert.equal(firstResponse.status, 200);
   assert.equal(firstBody.source, "api");
-  assert.deepEqual(firstBody.models, [{ id: "glm-5.1", name: "GLM 5.1" }]);
+  assert.deepEqual(firstBody.models, [{ id: "glm-5.1", name: "GLM 5.1", owned_by: "opencode-go" }]);
   assert.deepEqual(cachedModels, [{ id: "glm-5.1", name: "GLM 5.1", source: "imported" }]);
 
   globalThis.fetch = async () => {
@@ -606,7 +606,9 @@ test("provider models route falls back to cached models when a refresh fails", a
   assert.equal(body.source, "cache");
   assert.match(body.warning, /cached catalog/i);
   assert.deepEqual(body.models, [{ id: "cached-go", name: "Cached Go", source: "imported" }]);
-  assert.equal(fetchCalls, 1);
+  // T39 multi-endpoint discovery probes `${base}/v1/models` then `${base}/models`
+  // before giving up; both 503 here, so it makes 2 attempts and then falls back to cache.
+  assert.equal(fetchCalls, 2);
 });
 
 test("provider models route clears cached discovery when a refresh returns no remote models", async () => {


### PR DESCRIPTION
Fixes the **two remaining pre-existing reds** on release/v3.8.30's full unit suite (both only surface under `__RUN_ALL__`, which is why the narrow Fast-QG of the PRs that introduced them didn't catch them). The other two from the same batch (db-rules count, lmarena metadata) landed in #4346; the `opencode-plugin dist/ not built` line was a false alarm — a negative-path `console.error`, not a test failure (`cli-setup-opencode.test.ts` passes 4/4).

## 1. gpt-5.x-pro openai pricing (from #4324 sweep)

The provider-model sweep added `gpt-5.5-pro` and `gpt-5.4-pro` to the **openai** registry but not to `pricing.ts`. `getPricingForModel` is an exact lookup, so both resolved to `null` → $0 → the `Every OpenAI registry model resolves a non-zero pricing row` gate failed. Added both under the `openai` block; the `-pro` rows mirror their base family tier (GPT_5_5_PRICING for 5.5, the 5.4 row for 5.4) until OpenAI publishes a distinct pro rate.

## 2. opencode-go discovery test alignment (from #4324 / T39)

`provider-models-route.test.ts` fixtures predated two intentional route changes: discovered models now carry `owned_by` (fallback = provider id), and discovery probes `${base}/v1/models` then `${base}/models` (T39 multi-endpoint). Updated the expected model to include `owned_by: "opencode-go"` and bumped the all-503 fail-path `fetchCalls` from 1 to 2. Test-only; the route behavior is unchanged.

## Validation (Hard Rule #18)

- `catalog-updates-v3x.test.ts`: **8/8** (was 1 fail).
- `provider-models-route.test.ts`: **55/55** (was 2 fail).
- 156 pricing/cost/catalog/route tests green; lint clean.

No CHANGELOG entry — fills an in-cycle gap for models added this same unreleased cycle + test alignment; no released behavior changed.