### PR TITLE
fix(sse): harden DuckDuckGo lite scraper sanitization (CodeQL)

### DIFF
--- a/open-sse/services/freeWebSearch.ts
+++ b/open-sse/services/freeWebSearch.ts
@@ -27,8 +27,7 @@ const DDG_USER_AGENT =
 // The inner-content captures are HARD-BOUNDED ({0,N}?) and the whole body is truncated
 // (MAX_HTML_BYTES) so adversarial/unclosed HTML can't cause catastrophic backtracking
 // (ReDoS) — real titles/snippets are short. See CLAUDE.md PII learnings §1.
-const ANCHOR_RE =
-  /<a\b([^>]*?class=['"][^'"]*result-link[^'"]*['"][^>]*)>([\s\S]{0,512}?)<\/a>/gi;
+const ANCHOR_RE = /<a\b([^>]*?class=['"][^'"]*result-link[^'"]*['"][^>]*)>([\s\S]{0,512}?)<\/a>/gi;
 const HREF_RE = /href=['"]([^'"]+)['"]/i;
 const SNIPPET_RE =
   /<td\b[^>]*?class=['"][^'"]*result-snippet[^'"]*['"][^>]*>([\s\S]{0,2048}?)<\/td>/gi;
@@ -36,17 +35,37 @@ const SNIPPET_RE =
 const MAX_HTML_BYTES = 256 * 1024;
 
 function decodeEntities(text: string): string {
-  return text
-    .replace(/&nbsp;/gi, " ")
-    .replace(/&amp;/gi, "&")
-    .replace(/&lt;/gi, "<")
-    .replace(/&gt;/gi, ">")
-    .replace(/&quot;/gi, '"')
-    .replace(/&#0*39;|&#x0*27;|&apos;/gi, "'");
+  return (
+    text
+      .replace(/&nbsp;/gi, " ")
+      .replace(/&lt;/gi, "<")
+      .replace(/&gt;/gi, ">")
+      .replace(/&quot;/gi, '"')
+      .replace(/&#0*39;|&#x0*27;|&apos;/gi, "'")
+      // Decode &amp; LAST so an already-escaped entity like "&amp;lt;" survives as the
+      // literal text "&lt;" instead of being double-unescaped into "<" — CodeQL
+      // js/double-escaping. When unescaping, &amp; must resolve after every other entity
+      // it could otherwise re-create.
+      .replace(/&amp;/gi, "&")
+  );
 }
 
 function stripTags(html: string): string {
-  return decodeEntities(html.replace(/<[^>]+>/g, "")).replace(/\s+/g, " ").trim();
+  // Decode entities FIRST so entity-encoded markup (e.g. "&lt;script&gt;") becomes real
+  // markup, then remove every tag. Looping to a fixpoint plus dropping a leftover
+  // unclosed "<…" guarantees the result can't carry "<script" (or any tag) through to the
+  // caller (LLM/client) — CodeQL js/incomplete-multi-character-sanitization. Bounded:
+  // each pass strictly shrinks the string, and MAX_HTML_BYTES caps the input upstream.
+  let text = decodeEntities(html);
+  let previous: string;
+  do {
+    previous = text;
+    text = text.replace(/<[^>]*>/g, "");
+  } while (text !== previous);
+  // After every well-formed tag is gone, any remaining "<" has no closing ">" — strip the
+  // trailing partial tag start so "<script…" can't survive.
+  text = text.replace(/<[^>]*$/, "");
+  return text.replace(/\s+/g, " ").trim();
 }
 
 /**

--- a/tests/unit/free-web-search.test.ts
+++ b/tests/unit/free-web-search.test.ts
@@ -95,3 +95,36 @@ test("parseDuckDuckGoLite tolerates a missing snippet (empty string, not crash)"
   assert.equal(results.length, 1);
   assert.equal(results[0].snippet, "");
 });
+
+test("parseDuckDuckGoLite does not double-unescape entities (CodeQL js/double-escaping)", () => {
+  // A snippet whose author literally wrote "5 &lt; 10" reaches us HTML-escaped as
+  // "5 &amp;lt; 10". Correct single-level decoding must yield the literal "5 &lt; 10",
+  // NOT collapse it into a real "<" ("5 < 10") by unescaping &amp; before &lt;.
+  const html = `<a href="https://e.com" class='result-link'>T</a>
+    <td class='result-snippet'>5 &amp;lt; 10</td>`;
+  const [r] = parseDuckDuckGoLite(html);
+  assert.equal(r.snippet, "5 &lt; 10");
+  assert.doesNotMatch(r.snippet, /5 < 10/, "must not double-unescape &amp;lt; into a real '<'");
+});
+
+test("parseDuckDuckGoLite never emits a live <script> from entity-encoded markup (CodeQL js/incomplete-multi-character-sanitization)", () => {
+  // Entity-encoded markup must not be decoded into a live "<script>" tag AFTER tag
+  // stripping — the result is surfaced to the LLM/client as a search snippet.
+  const html = `<a href="https://e.com" class='result-link'>safe &lt;script&gt;x&lt;/script&gt; title</a>
+    <td class='result-snippet'>ok &lt;script&gt;alert(1)&lt;/script&gt; done</td>`;
+  const [r] = parseDuckDuckGoLite(html);
+  assert.doesNotMatch(r.title, /<script/i, "title must not carry a live <script tag");
+  assert.doesNotMatch(r.snippet, /<script/i, "snippet must not carry a live <script tag");
+  assert.ok(r.title.includes("safe"), "benign title text is preserved");
+  assert.ok(r.snippet.includes("alert(1)"), "benign snippet text is preserved");
+});
+
+test("parseDuckDuckGoLite drops an unclosed entity-encoded tag start (no '<script' leak)", () => {
+  // "&lt;script" with no closing ">" decodes to "<script"; that partial tag must not
+  // survive into the output.
+  const html = `<a href="https://e.com" class='result-link'>safe title</a>
+    <td class='result-snippet'>tail &lt;script foo bar</td>`;
+  const [r] = parseDuckDuckGoLite(html);
+  assert.doesNotMatch(r.snippet, /<script/i);
+  assert.ok(r.snippet.startsWith("tail"));
+});

--- a/tests/unit/search-handler-duckduckgo.test.ts
+++ b/tests/unit/search-handler-duckduckgo.test.ts
@@ -35,7 +35,14 @@ test("handleSearch fulfills duckduckgo-free via the HTML scraping path (no API k
     });
 
     assert.equal(result.success, true);
-    assert.ok(capturedUrl.includes("lite.duckduckgo.com"), "must hit the DDG lite endpoint");
+    // Compare the parsed hostname exactly (not a substring of the raw URL) so a host like
+    // "lite.duckduckgo.com.evil.test" could never satisfy the assertion — CodeQL
+    // js/incomplete-url-substring-sanitization.
+    assert.equal(
+      new URL(capturedUrl).hostname,
+      "lite.duckduckgo.com",
+      "must hit the DDG lite endpoint"
+    );
     assert.equal(result.data.provider, "duckduckgo-free");
     assert.equal(result.data.usage.search_cost_usd, 0, "free provider has zero cost");
     assert.equal(result.data.results.length, 2);
@@ -51,7 +58,9 @@ test("handleSearch fulfills duckduckgo-free via the HTML scraping path (no API k
 test("handleSearch fails over to duckduckgo-free when the primary provider errors", async () => {
   const originalFetch = globalThis.fetch;
   globalThis.fetch = (async (url: string | URL) => {
-    if (String(url).includes("lite.duckduckgo.com")) {
+    // Route by exact parsed hostname rather than a raw-URL substring match — CodeQL
+    // js/incomplete-url-substring-sanitization.
+    if (new URL(String(url)).hostname === "lite.duckduckgo.com") {
       return new Response(DDG_HTML, { status: 200, headers: { "content-type": "text/html" } });
     }
     // Primary (e.g. searxng on localhost) is unreachable.


### PR DESCRIPTION
## Resumo

Corrige os **4 alertas de code-scanning (CodeQL) abertos** (todos HIGH) no caminho de busca gratuita via DuckDuckGo lite (`open-sse/services/freeWebSearch.ts`). Todos **corrigidos** (nenhum dispensado), com TDD.

| # | Regra | Arquivo | Correção |
|---|-------|---------|----------|
| #657 | `js/double-escaping` | `freeWebSearch.ts` `decodeEntities` | decodificar `&amp;` por **último** |
| #656 | `js/incomplete-multi-character-sanitization` | `freeWebSearch.ts` `stripTags` | decodificar **antes** de stripar + loop até fixpoint + remover `<…` inacabado |
| #658 | `js/incomplete-url-substring-sanitization` | `search-handler-duckduckgo.test.ts:38` | `new URL(...).hostname === "lite.duckduckgo.com"` |
| #659 | `js/incomplete-url-substring-sanitization` | `search-handler-duckduckgo.test.ts:54` | idem |

### Detalhes

- **#657** — `decodeEntities` decodificava `&amp;`→`&` **antes** das demais entidades, então um valor já escapado como `&amp;lt;` virava `<` (double-unescape) em vez do literal `&lt;`. Agora `&amp;` é resolvido por último.
- **#656** — `stripTags` removia tags **antes** de decodificar entidades, então `&lt;script&gt;` decodificava para um `<script>` vivo que chegava ao chamador (LLM/cliente). Agora: decodifica primeiro → remove tags em loop até fixpoint → remove qualquer `<…` inacabado no fim. Continua **bounded** (cada passo encurta a string; `MAX_HTML_BYTES` limita a entrada).
- **#658/#659** — testes asseravam/roteavam por `capturedUrl.includes("lite.duckduckgo.com")` (substring de URL crua). Trocado por comparação **exata de hostname parseado**, que rejeita hosts como `lite.duckduckgo.com.evil.test`.

### Validação (TDD — hard rule #18)

3 testes novos em `free-web-search.test.ts` reproduzem cada bug (RED antes do fix → GREEN depois):
- não faz double-unescape de `&amp;lt;` (espera `5 &lt; 10`, não `5 < 10`);
- nunca emite `<script>` vivo de markup entity-encoded;
- descarta `<script` inacabado.

`13/13` testes unitários passam (`free-web-search` + `search-handler-duckduckgo`); `typecheck:core` limpo; ESLint e Prettier OK nos arquivos alterados.

> Será cherry-picked para `release/v3.8.30`.