### PR TITLE
fix(mitm): mask bare "Bearer <token>" header values in the inspector

### DIFF
--- a/src/mitm/maskSecrets.ts
+++ b/src/mitm/maskSecrets.ts
@@ -6,14 +6,20 @@
  * Pattern sources: plano 11 §4.8 (origin: llm-interceptor proxy.py:310)
  */
 
-// Pre-compiled regex patterns — ORDER IS SIGNIFICANT (BEARER must run first)
-const BEARER = /(authorization:\s*Bearer\s+)[A-Za-z0-9._-]+/gi;
+// Pre-compiled regex patterns — ORDER IS SIGNIFICANT (BEARER must run first).
+// BEARER matches the token after a standalone "Bearer " — NOT only after a
+// literal "authorization:" prefix. sanitizeHeaders() masks header *values*
+// ("Bearer <token>") with the key already stripped, so a prefix-anchored regex
+// never fired there and short/opaque-but-<40 tokens leaked into the inspector
+// (found by the AgentBridge live capture). The char class is bounded + linear
+// (no nested quantifiers) to stay ReDoS-safe.
+const BEARER = /(\bBearer\s+)[A-Za-z0-9._~+/-]+=*/gi;
 const SK_KEY = /\b(sk|ak|pk)-[A-Za-z0-9_-]{16,}\b/g;
 const LONG_TOKEN = /\b[A-Za-z0-9_-]{40,}\b/g;
 
 /**
  * Mask secrets in a string value.
- * - Bearer tokens: replaces token after "Bearer " with "***"
+ * - Bearer tokens: replaces the token after any "Bearer " with "***"
  * - sk-/ak-/pk- keys: keeps first 6 chars + last 2 chars
  * - Long opaque tokens (≥40 chars): keeps first 4 chars + last 2 chars
  */

--- a/tests/unit/mitm-masksecrets.test.ts
+++ b/tests/unit/mitm-masksecrets.test.ts
@@ -61,3 +61,28 @@ test("maskSecret — short sk- key below 16 chars is NOT masked", () => {
   const shortKey = "sk-shortkey";
   assert.equal(maskSecret(shortKey), shortKey);
 });
+
+// Regression: sanitizeHeaders() masks header *values* ("Bearer <token>" with the
+// "authorization:" key already stripped). The previous prefix-anchored BEARER
+// regex never fired there, so short/opaque-<40 Bearer tokens leaked into the
+// Traffic Inspector (found by the AgentBridge live capture).
+test("maskSecret — Bearer token in a bare header value (no authorization: prefix) is masked", () => {
+  const result = maskSecret("Bearer sk-secret-TESTE");
+  assert.equal(result, "Bearer ***");
+});
+
+test("maskSecret — a short opaque Bearer token is still masked", () => {
+  assert.equal(maskSecret("Bearer abc123"), "Bearer ***");
+});
+
+test("maskSecret — a realistic Google OAuth Bearer value is masked whole", () => {
+  const result = maskSecret("Bearer ya29.a0AfH6SMxLONGTOKEN_1234567890-abcdefghij");
+  assert.equal(result, "Bearer ***");
+  assert.ok(!result.includes("LONGTOKEN"), "no part of the token should survive");
+});
+
+test("maskSecret — 'authorization: Bearer <token>' still masks (no regression)", () => {
+  const result = maskSecret("authorization: Bearer sk-proj-abcdefghijklmnop");
+  assert.ok(result.startsWith("authorization: Bearer ***"), `got: ${result}`);
+  assert.ok(!result.includes("abcdefghijklmnop"));
+});


### PR DESCRIPTION
## Summary
Security fix surfaced by the **AgentBridge live capture** (the #4285/#4299 validation on the lab VPS): a request header `Authorization: Bearer sk-secret-TESTE` showed up **unmasked** in `/api/tools/traffic-inspector/requests`.

**Root cause:** `sanitizeHeaders()` masks header *values* — it calls `maskSecret("Bearer <token>")` with the `authorization:` key already stripped. But the `BEARER` regex was anchored to a literal `authorization:` prefix, so it **never fired** on bare header values. Tokens shorter than the `sk-`(16+) / opaque-(40+) thresholds then leaked verbatim (Hard Rule #12).

Real Google OAuth tokens are long enough to be caught by `LONG_TOKEN`, so the practical risk was low — but the `Bearer` pattern must mask regardless of token length/shape.

**Fix:** re-anchor `BEARER` to a standalone `\bBearer\s+<token>`. Still ReDoS-safe (bounded char class, no nested quantifiers). Masks both `Bearer <token>` header values **and** `authorization: Bearer <token>` raw lines.

## Test Plan
- [x] `mitm-masksecrets.test.ts` — +4: bare `Bearer` value, short opaque `Bearer`, realistic Google OAuth `Bearer`, and an `authorization:`-prefixed regression
- [x] Existing maskSecret cases unchanged (sk-/ak-/pk-, short keys, no-secret strings)
- [x] `cli-output.test.ts` (the other `maskSecret` consumer) green
- [x] `typecheck:core` clean, lint clean
- [ ] Live: re-confirm `secret-vazou? false` in the inspector on the next deploy (maskSecrets compiles into `.next`)

Follow-up to #4285 (Traffic Inspector capture) — same lab-VPS validation that found it.