### PR TITLE
refactor(combo): de-dup do skip-predicate de exhausted entre os 2 dispatchers

### DIFF
--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -119,6 +119,7 @@ import {
   isStreamReadinessFailureErrorBody,
   isTokenLimitBreachErrorBody,
   toRecordedTarget,
+  getExhaustedTargetSkipReason,
 } from "./combo/comboPredicates.ts";
 import { dedupeTargetsByExecutionKey, isRecord } from "./combo/comboData.ts";
 import { resolveShadowTargets, scheduleShadowRouting } from "./combo/shadowRouting.ts";
@@ -1084,24 +1085,14 @@ export async function handleComboChat({
             }
           : { ...target, modelAbortSignal: abortControllers.get(i)!.signal };
 
-        // #1731v2: Skip targets whose provider:connection pair had a connection-level error.
-        if (provider && target.connectionId) {
-          const connKey = `${provider}:${target.connectionId}`;
-          if (exhaustedConnections.has(connKey)) {
-            log.info(
-              "COMBO",
-              `Skipping ${modelStr} — connection ${target.connectionId} for provider ${provider} had connection error (#1731v2)`
-            );
-            if (i > 0) fallbackCount++;
-            return null;
-          }
-        }
-        // #1731: Skip targets from a provider that already signaled full quota exhaustion this request.
-        if (provider && exhaustedProviders.has(provider)) {
-          log.info(
-            "COMBO",
-            `Skipping ${modelStr} — provider ${provider} marked exhausted this request (#1731)`
-          );
+        // #1731 / #1731v2: skip targets already known-exhausted this request (shared predicate).
+        const exhaustedSkip = getExhaustedTargetSkipReason(
+          target,
+          exhaustedProviders,
+          exhaustedConnections
+        );
+        if (exhaustedSkip) {
+          log.info("COMBO", exhaustedSkip);
           if (i > 0) fallbackCount++;
           return null;
         }
@@ -2115,25 +2106,14 @@ async function handleRoundRobinCombo({
       continue;
     }
 
-    // #1731: Skip targets from a provider that already signaled full quota exhaustion
-    // this request.
-    // #1731v2: Skip targets whose provider:connection pair had a connection-level error.
-    if (provider && target.connectionId) {
-      const connKey = `${provider}:${target.connectionId}`;
-      if (exhaustedConnections.has(connKey)) {
-        log.info(
-          "COMBO-RR",
-          `Skipping ${modelStr} — connection ${target.connectionId} for provider ${provider} had connection error (#1731v2)`
-        );
-        if (offset > 0) fallbackCount++;
-        continue;
-      }
-    }
-    if (provider && exhaustedProviders.has(provider)) {
-      log.info(
-        "COMBO-RR",
-        `Skipping ${modelStr} — provider ${provider} marked exhausted this request (#1731)`
-      );
+    // #1731 / #1731v2: skip targets already known-exhausted this request (shared predicate).
+    const exhaustedSkip = getExhaustedTargetSkipReason(
+      target,
+      exhaustedProviders,
+      exhaustedConnections
+    );
+    if (exhaustedSkip) {
+      log.info("COMBO-RR", exhaustedSkip);
       if (offset > 0) fallbackCount++;
       continue;
     }

--- a/open-sse/services/combo/comboPredicates.ts
+++ b/open-sse/services/combo/comboPredicates.ts
@@ -45,6 +45,36 @@ export function isProviderCircuitOpenResult(
   return /provider_circuit_open/i.test(errorText);
 }
 
+/**
+ * Skip reason for a combo target already known-exhausted THIS request, or null if it is not.
+ *
+ * De-duplicates the byte-identical #1731 / #1731v2 pre-dispatch skip checks that BOTH combo
+ * dispatchers run per target (handleComboChat's speculative loop and handleRoundRobinCombo's
+ * rotation): a target whose `provider:connectionId` pair already had a connection-level error
+ * (`exhaustedConnections`), or whose provider already signaled full quota exhaustion
+ * (`exhaustedProviders`), is skipped for the rest of the request. Returns the log message the
+ * caller emits with its OWN tag ("COMBO" / "COMBO-RR"); each caller keeps its own control flow
+ * (return null vs continue) and its own fallbackCount bookkeeping.
+ */
+export function getExhaustedTargetSkipReason(
+  target: ResolvedComboTarget,
+  exhaustedProviders: ReadonlySet<string>,
+  exhaustedConnections: ReadonlySet<string>
+): string | null {
+  const { provider, modelStr, connectionId } = target;
+  // #1731v2: skip targets whose provider:connection pair had a connection-level error.
+  if (provider && connectionId) {
+    if (exhaustedConnections.has(`${provider}:${connectionId}`)) {
+      return `Skipping ${modelStr} — connection ${connectionId} for provider ${provider} had connection error (#1731v2)`;
+    }
+  }
+  // #1731: skip targets from a provider that already signaled full quota exhaustion this request.
+  if (provider && exhaustedProviders.has(provider)) {
+    return `Skipping ${modelStr} — provider ${provider} marked exhausted this request (#1731)`;
+  }
+  return null;
+}
+
 export const MAX_COMBO_DEPTH = 3;
 // Absolute safety ceiling for operator-configured nesting depth. config.maxComboDepth
 // can raise the default (3) up to this cap, or lower it, but never above — runaway

--- a/tests/unit/combo/combo-exhausted-skip.test.ts
+++ b/tests/unit/combo/combo-exhausted-skip.test.ts
@@ -1,0 +1,73 @@
+// tests/unit/combo/combo-exhausted-skip.test.ts
+// Characterization of getExhaustedTargetSkipReason — the de-duplicated #1731/#1731v2
+// pre-dispatch skip predicate shared by both combo dispatchers (handleComboChat +
+// handleRoundRobinCombo). Locks the exact skip conditions + message strings.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { getExhaustedTargetSkipReason } from "../../../open-sse/services/combo/comboPredicates.ts";
+
+function target(overrides: Record<string, unknown> = {}) {
+  return {
+    kind: "model",
+    executionKey: "ek",
+    modelStr: "openai/gpt-4o",
+    provider: "openai",
+    providerId: null,
+    connectionId: "conn-1",
+    ...overrides,
+  } as Parameters<typeof getExhaustedTargetSkipReason>[0];
+}
+
+test("returns null when nothing is exhausted", () => {
+  assert.equal(getExhaustedTargetSkipReason(target(), new Set(), new Set()), null);
+});
+
+test("#1731v2: skips when the provider:connection pair is in exhaustedConnections", () => {
+  const reason = getExhaustedTargetSkipReason(target(), new Set(), new Set(["openai:conn-1"]));
+  assert.equal(
+    reason,
+    "Skipping openai/gpt-4o — connection conn-1 for provider openai had connection error (#1731v2)"
+  );
+});
+
+test("#1731: skips when the provider is in exhaustedProviders", () => {
+  const reason = getExhaustedTargetSkipReason(target(), new Set(["openai"]), new Set());
+  assert.equal(
+    reason,
+    "Skipping openai/gpt-4o — provider openai marked exhausted this request (#1731)"
+  );
+});
+
+test("connection exhaustion takes precedence over provider exhaustion", () => {
+  const reason = getExhaustedTargetSkipReason(
+    target(),
+    new Set(["openai"]),
+    new Set(["openai:conn-1"])
+  );
+  assert.ok(reason?.includes("(#1731v2)"));
+});
+
+test("a different connection of an exhausted pair is NOT skipped on the connection check", () => {
+  const reason = getExhaustedTargetSkipReason(
+    target({ connectionId: "conn-2" }),
+    new Set(),
+    new Set(["openai:conn-1"])
+  );
+  assert.equal(reason, null);
+});
+
+test("no connectionId: only the provider-level check applies", () => {
+  assert.equal(getExhaustedTargetSkipReason(target({ connectionId: null }), new Set(), new Set()), null);
+  assert.ok(
+    getExhaustedTargetSkipReason(target({ connectionId: null }), new Set(["openai"]), new Set())?.includes(
+      "(#1731)"
+    )
+  );
+});
+
+test("empty provider string is treated as falsy (no skip)", () => {
+  assert.equal(
+    getExhaustedTargetSkipReason(target({ provider: "" }), new Set([""]), new Set([":conn-1"])),
+    null
+  );
+});


### PR DESCRIPTION
## Contexto

Primeiro incremento da **de-dup dos 2 dispatchers de combo** (`handleComboChat` ↔ `handleRoundRobinCombo`) — continuação da decomposição do god-file `combo.ts` (Parte 4, fase 2).

Mapeando a duplicação real, o bloco de **pre-check #1731/#1731v2** (skip de target já exhausted no provider/connection nesta request) era **byte-idêntico** nos dois dispatchers — mesmas condições, mesmas mensagens de log — diferindo apenas na **tag** (`COMBO` / `COMBO-RR`) e no **control-flow** (`return null` no loop especulativo vs `continue` no rotacional).

## O que muda

- **`combo/comboPredicates.ts`**: novo `getExhaustedTargetSkipReason(target, exhaustedProviders, exhaustedConnections)` — predicate **puro** que devolve a mensagem de skip (ou `null`). Cada dispatcher mantém o seu próprio log-tag, control-flow e `fallbackCount`. Vai no lar dos predicates puros, que já está no `mutate` do Stryker (ganha cobertura de mutação).
- **`combo.ts`**: −20 linhas — os 2 blocos duplicados viram 1 chamada cada.
- **7 testes de caracterização** travam as condições + as strings exatas (precedência conexão>provider, conexão diferente não skipa, provider vazio = falsy, etc.).

## Por que é seguro (baixo risco)

Extração **pura** — sem mutação de estado, sem mudança de control-flow, sem reordenar checks (os outros pre-checks ficam inline). Diferente do #4326 (que mexia no `body`), este é um predicate read-only.

- **376/376** testes combo (357 caracterização + 7 novos).
- `sse-correctness` integração → **5/5**.
- `typecheck` 0, `complexity` neutro (1895), `file-size` encolhe.

## Próximo incremento
De-dup do **error-handling / exhausted-tracking** (o `handleTargetError`: classificação de exhaustion + 429 + connection-level). Esse é ~85% idêntico mas com diferenças reais a preservar (`|| isAllAccountsRateLimited` extra no RR, `log.debug` vs `log.info`) — vai num PR próprio com diff cuidadoso.

> Rule #18: coberto pela rede TDD (7 caracterização + 376 combo). Canário VPS opcional dado o perfil puro/read-only — posso rodar se você quiser.