### PR TITLE
fix(cli): wire the `contexts` command into the CLI program

### DIFF
--- a/bin/cli/commands/registry.mjs
+++ b/bin/cli/commands/registry.mjs
@@ -71,6 +71,7 @@ import { registerSetupQwen } from "./setup-qwen.mjs";
 import { registerSetupAider } from "./setup-aider.mjs";
 import { registerSetupGemini } from "./setup-gemini.mjs";
 import { registerConnect } from "./connect.mjs";
+import { registerContexts } from "./contexts.mjs";
 import { registerTokens } from "./tokens.mjs";
 import { registerConfigure } from "./configure.mjs";
 import { registerApiCommands } from "../api-commands/registry.mjs";
@@ -151,6 +152,7 @@ export function registerCommands(program) {
   registerSetupAider(program);
   registerSetupGemini(program);
   registerConnect(program);
+  registerContexts(program);
   registerTokens(program);
   registerConfigure(program);
   registerApiCommands(program);

--- a/tests/unit/cli-remote-mode.test.ts
+++ b/tests/unit/cli-remote-mode.test.ts
@@ -241,3 +241,21 @@ test("commands/contexts.mjs registers a `current` subcommand", async () => {
   registerContexts(fakeProgram);
   assert.ok(sub.includes("current"), `expected a 'current' subcommand, got: ${sub.join(", ")}`);
 });
+
+test("createProgram wires the remote-mode commands into the real CLI program", async () => {
+  // Regression: contexts.mjs existed and was unit-tested in isolation, but its
+  // registerContexts() was never called by registry.mjs — so `omniroute contexts`
+  // fell through to `serve`, and `connect`'s own advice ("omniroute contexts use
+  // default") was a dead command. Build the REAL program and assert the wiring.
+  const { createProgram } = await import("../../bin/cli/program.mjs");
+  const program = createProgram();
+  const names = program.commands.map((c: any) => c.name());
+  for (const cmd of ["contexts", "connect", "tokens", "configure"]) {
+    assert.ok(names.includes(cmd), `expected top-level '${cmd}' command, got: ${names.join(", ")}`);
+  }
+  const contexts = program.commands.find((c: any) => c.name() === "contexts");
+  const subs = contexts.commands.map((c: any) => c.name());
+  for (const sub of ["list", "use", "current"]) {
+    assert.ok(subs.includes(sub), `expected 'contexts ${sub}' subcommand, got: ${subs.join(", ")}`);
+  }
+});


### PR DESCRIPTION
## Found by E2E testing remote mode

`omniroute contexts list/current/use` fell through to `serve` (`too many arguments for 'serve'`). Worse, `connect` itself prints **"Switch back to local with: omniroute contexts use default"** — pointing users at a command that didn't exist.

### Root cause
`bin/cli/commands/contexts.mjs` fully implements `registerContexts` (subcommands: `list/add/use/current/show/remove/rename/export/import`) and had a unit test — but that test used a **fake** program object. `registry.mjs` never imported or called `registerContexts`, so the command was never wired into the real CLI. The isolated fake-program test passed regardless, hiding the gap.

### Fix
Add the import + `registerContexts(program)` call alongside the other remote-mode commands (`connect`/`tokens`/`configure`). One-line wiring; the command's implementation was already complete.

### Validation
- **TDD**: a new test builds the **real** program via `createProgram()` and asserts `contexts/connect/tokens/configure` are top-level commands and that `contexts` exposes `list/use/current`. It fails before the fix, passes after — exactly the class the old fake-program test could not catch.
- Verified live: `omniroute contexts list` / `contexts current` now render the context table instead of erroring; `contexts use` is available to switch back to local.

Client-side only — no server change, no redeploy. Completes the remote-mode CLI UX surfaced during the item-5 E2E.