### PR TITLE
fix(mitm): exact host membership in MITM hosts test (CodeQL false positive)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 _In development — bullets added per PR; finalized at release._
 
+### 🔒 Security
+
+- **fix(mitm): exact host membership in the MITM hosts test (CodeQL false positive)** — `tests/unit/mitm-tool-hosts.test.ts` checked host membership with `Array.includes(host)`, which CodeQL's `js/incomplete-url-substring-sanitization` heuristic misreads as a `String.includes()` URL-substring sanitization test (HIGH false positive). Switched to `.some((h) => h === host)` — identical semantics, no flagged pattern. ([#4386](https://github.com/diegosouzapw/OmniRoute/pull/4386))
+
 ---
 
 ## [3.8.30] — 2026-06-20

--- a/tests/unit/mitm-tool-hosts.test.ts
+++ b/tests/unit/mitm-tool-hosts.test.ts
@@ -21,6 +21,10 @@ test("MITM_TOOL_HOSTS stays in sync with the canonical MITM target registry", ()
 });
 
 test("getMitmToolHosts returns the hosts for a known tool and [] for unknown ids", () => {
-  assert.ok(getMitmToolHosts("antigravity").includes("cloudcode-pa.googleapis.com"));
+  // Exact host membership in the returned string[] — `.some(h => h === host)` rather than
+  // `.includes(host)` so CodeQL's js/incomplete-url-substring-sanitization heuristic does not
+  // misread an Array.prototype.includes() membership check as a String.includes() URL-substring
+  // test. Same semantics (the array contains exactly this host), explicit about intent.
+  assert.ok(getMitmToolHosts("antigravity").some((h) => h === "cloudcode-pa.googleapis.com"));
   assert.deepEqual(getMitmToolHosts("does-not-exist"), []);
 });


### PR DESCRIPTION
## What
`tests/unit/mitm-tool-hosts.test.ts:24` checked host membership with `getMitmToolHosts("antigravity").includes("cloudcode-pa.googleapis.com")`. Since `getMitmToolHosts` returns a `string[]`, that is **`Array.prototype.includes`** (exact membership) — but CodeQL's `js/incomplete-url-substring-sanitization` heuristic reads `.includes(<url-literal>)` as a `String.includes()` URL-substring sanitization check and raises a **HIGH** alert.

## Fix
Switch to `.some((h) => h === "...")` — identical semantics (the array contains exactly this host), explicit about intent, and not a pattern the heuristic flags.

## Why now
Surfaced on the `main` CodeQL re-scan right after the **v3.8.30** release: the test was added this cycle by #4325 (MITM hosts-file tool card) and only reached `main` when v3.8.30 merged. It is the first task of the v3.8.31 cycle.

## Validation
Test-only change, no runtime behavior. `node --import tsx/esm --test tests/unit/mitm-tool-hosts.test.ts` → **2/2 pass**. The CodeQL alert clears on the post-merge re-scan (the flagged pattern is gone).