### PR TITLE
test: clear CodeQL js/incomplete-url-substring-sanitization FP (#660)

### DIFF
--- a/tests/unit/mitm-tool-hosts.test.ts
+++ b/tests/unit/mitm-tool-hosts.test.ts
@@ -21,6 +21,9 @@ test("MITM_TOOL_HOSTS stays in sync with the canonical MITM target registry", ()
 });
 
 test("getMitmToolHosts returns the hosts for a known tool and [] for unknown ids", () => {
-  assert.ok(getMitmToolHosts("antigravity").includes("cloudcode-pa.googleapis.com"));
+  // Exact array-element membership (getMitmToolHosts returns string[]). Use `.some(===)`
+  // rather than `.includes()` so CodeQL's js/incomplete-url-substring-sanitization does not
+  // misread this Array.includes as a String.includes URL-substring check (false positive).
+  assert.ok(getMitmToolHosts("antigravity").some((h) => h === "cloudcode-pa.googleapis.com"));
   assert.deepEqual(getMitmToolHosts("does-not-exist"), []);
 });


### PR DESCRIPTION
## Resumo

Limpa o alerta code-scanning **#660** (`js/incomplete-url-substring-sanitization`, HIGH) em `tests/unit/mitm-tool-hosts.test.ts:24`.

**É falso positivo:** `getMitmToolHosts(toolId)` retorna `string[]` (`src/shared/constants/mitmToolHosts.ts:29`), então `.includes("cloudcode-pa.googleapis.com")` é **`Array.prototype.includes`** (pertinência exata de elemento), **não** `String.includes` de substring de URL — não há URL para sanitizar. O heurístico do CodeQL não distingue `Array.includes` de `String.includes` (mesma regra dos #658/#659 que já corrigi).

## Mudança

Refactor `.includes("host")` → `.some((h) => h === "host")` — remove o sink que o CodeQL casa, **comportamento idêntico**. Test-only (zero produção).

```diff
- assert.ok(getMitmToolHosts("antigravity").includes("cloudcode-pa.googleapis.com"));
+ assert.ok(getMitmToolHosts("antigravity").some((h) => h === "cloudcode-pa.googleapis.com"));
```

## Validação
- `mitm-tool-hosts.test.ts`: **2/2 pass** (comportamento preservado).
- Prettier + ESLint OK.

> Optei por **corrigir** (não dispensar) para manter o painel de segurança limpo, consistente com #656-659. Será cherry-picked para `release/v3.8.31`.