### PR TITLE
test: clear CodeQL js/incomplete-url-substring-sanitization FP (#660) [cherry-pick → v3.8.31]

### DIFF
--- a/tests/unit/mitm-tool-hosts.test.ts
+++ b/tests/unit/mitm-tool-hosts.test.ts
@@ -21,6 +21,9 @@ test("MITM_TOOL_HOSTS stays in sync with the canonical MITM target registry", ()
 });
 
 test("getMitmToolHosts returns the hosts for a known tool and [] for unknown ids", () => {
-  assert.ok(getMitmToolHosts("antigravity").includes("cloudcode-pa.googleapis.com"));
+  // Exact array-element membership (getMitmToolHosts returns string[]). Use `.some(===)`
+  // rather than `.includes()` so CodeQL's js/incomplete-url-substring-sanitization does not
+  // misread this Array.includes as a String.includes URL-substring check (false positive).
+  assert.ok(getMitmToolHosts("antigravity").some((h) => h === "cloudcode-pa.googleapis.com"));
   assert.deepEqual(getMitmToolHosts("does-not-exist"), []);
 });


### PR DESCRIPTION
Cherry-pick de `1bb4f26b5` (PR #4387 → `main`) para `release/v3.8.31`.

Falso positivo do CodeQL (#660): `getMitmToolHosts()` retorna `string[]`, então `.includes(host)` é `Array.prototype.includes` (pertinência exata), não substring de URL. Refactor `.includes("host")` → `.some((h) => h === "host")` — comportamento idêntico, remove o sink que a regra casa.

Validação: `mitm-tool-hosts.test.ts` 2/2 pass.

> Equivalente em `main`: #4387.