### PR TITLE
fix(sse): configurable round-robin combo queue depth for faster failover (#3872)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 _In development — bullets added per PR; finalized at release._
 
+### 🐛 Fixed
+
+- **fix(combo): round-robin members fail over faster under concurrency saturation via a configurable queue depth** — when a round-robin combo member was saturated, requests sat in the per-model semaphore's **unbounded** queue and only failed over to the next member after the full `queueTimeoutMs` (default 30s) elapsed — so a burst of agentic requests deep-queued one hot member instead of spilling to healthy ones. The per-model semaphore now accepts a bounded queue depth and emits `SEMAPHORE_QUEUE_FULL` once it is full (the round-robin loop already cascades on that code), so a configured low depth fails over immediately. A new `queueDepth` combo-config knob (global default / provider override / per-combo, default **20** for backward compatibility; **0** = never queue → fail over now) is exposed in Settings → Combo Defaults. ([#3872](https://github.com/diegosouzapw/OmniRoute/issues/3872) — thanks @KooshaPari)
+
 ---
 
 ## [3.8.31] — 2026-06-20

--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -26,6 +26,7 @@ import {
 import {
   resolveComboConfig,
   getDefaultComboConfig,
+  resolveComboQueueDepth,
 } from "./comboConfig.ts";
 import {
   maybeGenerateHandoff,
@@ -1942,6 +1943,9 @@ async function handleRoundRobinCombo({
     : { ...getDefaultComboConfig(), ...(combo.config || {}) };
   const concurrency = config.concurrencyPerModel ?? 3;
   const queueTimeout = config.queueTimeoutMs ?? 30000;
+  // #3872: pre-cascade queue depth — lower values fail over to the next combo member
+  // sooner under concurrency saturation (0 = never queue). Default 20 (backward-compat).
+  const queueDepth = resolveComboQueueDepth(config);
   const maxRetries = config.maxRetries ?? 1;
   const retryDelayMs = resolveDelayMs(config.retryDelayMs, 2000);
   const fallbackDelayMs = resolveDelayMs(config.fallbackDelayMs, 0);
@@ -2084,6 +2088,7 @@ async function handleRoundRobinCombo({
       release = await semaphore.acquire(semaphoreKey, {
         maxConcurrency: concurrency,
         timeoutMs: queueTimeout,
+        maxQueueSize: queueDepth,
       });
     } catch (err) {
       const errCode = isRecord(err) && typeof err.code === "string" ? err.code : null;

--- a/open-sse/services/comboConfig.ts
+++ b/open-sse/services/comboConfig.ts
@@ -25,6 +25,18 @@ export const PRE_SCREEN_CONCURRENCY = 5;
  */
 export const DEFAULT_COMBO_TARGET_TIMEOUT_MS = 120_000;
 
+/**
+ * Default pre-cascade semaphore queue depth for round-robin combos (#3872). When a
+ * combo member's concurrency slot is saturated, this many requests wait in the
+ * member's queue before `SEMAPHORE_QUEUE_FULL` triggers a cascade to the next member.
+ * Kept at 20 for backward compatibility; operators wanting faster failover can lower
+ * it (0 = never queue, fail over to the next member immediately).
+ */
+export const DEFAULT_COMBO_QUEUE_DEPTH = 20;
+
+/** Upper bound for the configurable combo queue depth (defensive clamp). */
+export const MAX_COMBO_QUEUE_DEPTH = 100;
+
 const DEFAULT_COMBO_CONFIG = {
   strategy: "priority",
   maxRetries: 1,
@@ -32,6 +44,7 @@ const DEFAULT_COMBO_CONFIG = {
   fallbackDelayMs: 0,
   concurrencyPerModel: 3, // max simultaneous requests per model (round-robin)
   queueTimeoutMs: 30000, // max wait time in semaphore queue (round-robin)
+  queueDepth: DEFAULT_COMBO_QUEUE_DEPTH, // pre-cascade semaphore queue depth (round-robin, #3872)
   handoffThreshold: 0.85,
   handoffModel: "",
   handoffProviders: ["codex"],
@@ -145,6 +158,18 @@ export function resolveComboTargetTimeoutMs(
   if (ceilingTimeoutMs <= 0) return ceilingTimeoutMs;
   if (fallbackDefaultMs <= 0) return ceilingTimeoutMs;
   return Math.min(fallbackDefaultMs, ceilingTimeoutMs);
+}
+
+/**
+ * Resolve the effective pre-cascade semaphore queue depth for a round-robin combo
+ * (#3872). Falls back to `DEFAULT_COMBO_QUEUE_DEPTH` for missing/invalid/negative
+ * values and clamps to `MAX_COMBO_QUEUE_DEPTH`. `0` is valid and meaningful: it makes
+ * a saturated combo member fail over to the next member immediately instead of queueing.
+ */
+export function resolveComboQueueDepth(config: Record<string, unknown> | null | undefined): number {
+  const raw = isRecord(config) ? Number(config.queueDepth) : Number.NaN;
+  if (!Number.isFinite(raw) || raw < 0) return DEFAULT_COMBO_QUEUE_DEPTH;
+  return Math.min(Math.floor(raw), MAX_COMBO_QUEUE_DEPTH);
 }
 
 /**

--- a/open-sse/services/rateLimitSemaphore.ts
+++ b/open-sse/services/rateLimitSemaphore.ts
@@ -25,6 +25,14 @@ interface ModelGate {
 interface AcquireOptions {
   maxConcurrency?: number;
   timeoutMs?: number;
+  /**
+   * Maximum number of requests allowed to wait in the per-model queue (#3872). When
+   * the queue is already this deep, a new acquire rejects immediately with
+   * `SEMAPHORE_QUEUE_FULL` instead of waiting, so the round-robin combo loop cascades
+   * to the next member right away (0 = never queue → fail over immediately). Omitted /
+   * negative keeps the historical unbounded-queue behavior.
+   */
+  maxQueueSize?: number;
 }
 
 interface RateLimitStatsEntry {
@@ -124,12 +132,13 @@ function createReleaseFn(modelStr: string): () => void {
  * @param {Object} [options]
  * @param {number} [options.maxConcurrency=3] - Max concurrent requests for this model
  * @param {number} [options.timeoutMs=30000] - Max wait time in queue
+ * @param {number} [options.maxQueueSize] - Max queued waiters before SEMAPHORE_QUEUE_FULL (#3872)
  * @returns {Promise<Function>} Release function — MUST be called when done
- * @throws {Error} If queue timeout expires ("SEMAPHORE_TIMEOUT")
+ * @throws {Error} If queue timeout expires ("SEMAPHORE_TIMEOUT") or the queue is full ("SEMAPHORE_QUEUE_FULL")
  */
 export function acquire(
   modelStr: string,
-  { maxConcurrency = 3, timeoutMs = 30000 }: AcquireOptions = {}
+  { maxConcurrency = 3, timeoutMs = 30000, maxQueueSize }: AcquireOptions = {}
 ): Promise<() => void> {
   const gate = getGate(modelStr, maxConcurrency);
 
@@ -137,6 +146,18 @@ export function acquire(
   if (gate.running < gate.max && !isRateLimited(gate)) {
     gate.running++;
     return Promise.resolve(createReleaseFn(modelStr));
+  }
+
+  // #3872: bounded queue — once the queue is full, fail fast so the round-robin combo
+  // cascades to the next member immediately instead of deep-queueing for up to timeoutMs.
+  if (typeof maxQueueSize === "number" && maxQueueSize >= 0 && gate.queue.length >= maxQueueSize) {
+    const err = new Error(`Semaphore queue full (${maxQueueSize}) for ${modelStr}`) as Error & {
+      code?: string;
+    };
+    err.code = "SEMAPHORE_QUEUE_FULL";
+    // Drop a freshly-created idle gate so we don't leak an empty entry.
+    if (gate.running === 0 && gate.queue.length === 0) gates.delete(modelStr);
+    return Promise.reject(err);
   }
 
   // Slow path: enqueue and wait

--- a/src/app/(dashboard)/dashboard/settings/components/ComboDefaultsTab.tsx
+++ b/src/app/(dashboard)/dashboard/settings/components/ComboDefaultsTab.tsx
@@ -482,6 +482,21 @@ export default function ComboDefaultsTab() {
               }
               className="text-sm"
             />
+            <Input
+              label={t("queueDepth")}
+              type="number"
+              min={0}
+              max={100}
+              value={comboDefaults.queueDepth ?? ""}
+              placeholder="20"
+              onChange={(e) =>
+                setComboDefaults((prev) => ({
+                  ...prev,
+                  queueDepth: parseInt(e.target.value) || 0,
+                }))
+              }
+              className="text-sm"
+            />
           </div>
         )}
 

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -393,6 +393,7 @@
     "cloudBenefitAccess": "Cloud Benefit Access",
     "maxRetries": "Max Retries",
     "queueTimeout": "Queue Timeout",
+    "queueDepth": "Queue Depth",
     "addProvider": "Add Provider",
     "realtime": "Realtime",
     "totalTranslations": "Total Translations",

--- a/src/shared/validation/schemas/combo.ts
+++ b/src/shared/validation/schemas/combo.ts
@@ -133,6 +133,8 @@ export const comboRuntimeConfigSchema = z
     targetTimeoutMs: z.coerce.number().int().min(0).max(MAX_TIMER_TIMEOUT_MS).optional(),
     concurrencyPerModel: z.coerce.number().int().min(1).max(20).optional(),
     queueTimeoutMs: z.coerce.number().int().min(1000).max(120000).optional(),
+    // #3872: pre-cascade semaphore queue depth (round-robin). 0 = fail over immediately.
+    queueDepth: z.coerce.number().int().min(0).max(100).optional(),
     healthCheckEnabled: z.boolean().optional(),
     healthCheckTimeoutMs: z.coerce.number().int().min(100).max(30000).optional(),
     handoffThreshold: z.coerce.number().min(0.5).max(0.94).optional(),

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -60,6 +60,7 @@ export interface ComboDefaults {
   reasoningTokenBufferEnabled?: boolean;
   concurrencyPerModel?: number;
   queueTimeoutMs?: number;
+  queueDepth?: number;
   handoffThreshold?: number;
   handoffModel?: string;
   handoffProviders?: string[];

--- a/tests/unit/combo-config.test.ts
+++ b/tests/unit/combo-config.test.ts
@@ -6,6 +6,7 @@ const {
   getDefaultComboConfig,
   resolveComboTargetTimeoutMs,
   DEFAULT_COMBO_TARGET_TIMEOUT_MS,
+  resolveComboQueueDepth,
 } = await import("../../open-sse/services/comboConfig.ts");
 const { createComboSchema, updateComboDefaultsSchema } =
   await import("../../src/shared/validation/schemas.ts");
@@ -602,4 +603,87 @@ test("resolveComboConfig cascades failoverBeforeRetry, maxSetRetries and setRetr
   assert.equal(result.failoverBeforeRetry, true);
   assert.equal(result.maxSetRetries, 2);
   assert.equal(result.setRetryDelayMs, 3000);
+});
+
+// Issue #3872: combo round-robin always queued ~20 deep before cascading on
+// semaphore saturation because handleRoundRobinCombo never threaded a queue depth
+// into accountSemaphore.acquire (it fell back to the hardcoded DEFAULT_MAX_QUEUE_SIZE
+// of 20). Expose `queueDepth` as combo config so operators can shrink the pre-cascade
+// queue (0 = fail over immediately) for faster failover, while keeping 20 as the
+// backward-compatible default.
+test("getDefaultComboConfig exposes the backward-compatible queueDepth default of 20", () => {
+  assert.equal(getDefaultComboConfig().queueDepth, 20);
+});
+
+test("resolveComboConfig cascades queueDepth from defaults through provider and combo overrides", () => {
+  const fromDefault = resolveComboConfig({ config: {} }, { comboDefaults: {} });
+  assert.equal(fromDefault.queueDepth, 20);
+
+  const cascaded = resolveComboConfig(
+    {
+      config: {
+        queueDepth: 1,
+      },
+    },
+    {
+      comboDefaults: {
+        queueDepth: 10,
+      },
+      providerOverrides: {
+        openai: {
+          queueDepth: 5,
+        },
+      },
+    },
+    "openai"
+  );
+
+  // Most specific (combo.config) wins over provider override and global default.
+  assert.equal(cascaded.queueDepth, 1);
+});
+
+test("resolveComboQueueDepth defaults to 20, honors configured values, and clamps the range", () => {
+  assert.equal(resolveComboQueueDepth(null), 20);
+  assert.equal(resolveComboQueueDepth({}), 20);
+  assert.equal(resolveComboQueueDepth({ queueDepth: 5 }), 5);
+  // 0 is a valid, meaningful value: queue nothing → fail over to the next member immediately.
+  assert.equal(resolveComboQueueDepth({ queueDepth: 0 }), 0);
+  // Invalid / negative inputs fall back to the safe default.
+  assert.equal(resolveComboQueueDepth({ queueDepth: -3 }), 20);
+  assert.equal(resolveComboQueueDepth({ queueDepth: Number.NaN }), 20);
+  // Out-of-range high values are clamped, not trusted.
+  assert.equal(resolveComboQueueDepth({ queueDepth: 99999 }), 100);
+  // Fractional values floor to an integer queue slot count.
+  assert.equal(resolveComboQueueDepth({ queueDepth: 3.9 }), 3);
+});
+
+test("createComboSchema accepts queueDepth, coerces strings, and allows 0 for immediate failover", () => {
+  const parsed = createComboSchema.parse({
+    name: "fast-failover",
+    models: ["openai/gpt-4o-mini", "anthropic/claude-3-haiku"],
+    strategy: "round-robin",
+    config: {
+      queueDepth: "0",
+    },
+  });
+
+  assert.equal(parsed.config.queueDepth, 0);
+});
+
+test("createComboSchema rejects queueDepth outside the supported range", () => {
+  const tooHigh = createComboSchema.safeParse({
+    name: "bad-queue-depth-high",
+    models: ["openai/gpt-4"],
+    strategy: "round-robin",
+    config: { queueDepth: 101 },
+  });
+  assert.equal(tooHigh.success, false);
+
+  const negative = createComboSchema.safeParse({
+    name: "bad-queue-depth-negative",
+    models: ["openai/gpt-4"],
+    strategy: "round-robin",
+    config: { queueDepth: -1 },
+  });
+  assert.equal(negative.success, false);
 });

--- a/tests/unit/rateLimitSemaphore.test.ts
+++ b/tests/unit/rateLimitSemaphore.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Issue #3872 — round-robin combos deep-queued a saturated member (the per-model
+ * rate-limit semaphore had an UNBOUNDED queue and only ever emitted SEMAPHORE_TIMEOUT
+ * after the full queueTimeoutMs), so failover to the next combo member happened far too
+ * late (or the client died first). The fix bounds the queue with a configurable depth
+ * and emits SEMAPHORE_QUEUE_FULL once the queue is full — the round-robin loop already
+ * cascades to the next member on that code — so low depths fail over immediately.
+ */
+import { afterEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  acquire,
+  getStats,
+  resetAll,
+} from "../../open-sse/services/rateLimitSemaphore.ts";
+
+afterEach(() => {
+  resetAll();
+});
+
+describe("rateLimitSemaphore queue depth (#3872)", () => {
+  it("queues unbounded when maxQueueSize is omitted (backward-compatible default)", async () => {
+    const model = "minimax/abab6.5";
+
+    const releaseA = await acquire(model, { maxConcurrency: 1, timeoutMs: 500 });
+    // Three more pile into the queue — none rejected, because no cap was requested.
+    // Swallow the reset-rejection these emit when the gate is torn down below.
+    const queued = [
+      acquire(model, { maxConcurrency: 1, timeoutMs: 500 }).catch(() => {}),
+      acquire(model, { maxConcurrency: 1, timeoutMs: 500 }).catch(() => {}),
+      acquire(model, { maxConcurrency: 1, timeoutMs: 500 }).catch(() => {}),
+    ];
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    const stats = getStats()[model];
+    assert.equal(stats.running, 1);
+    assert.equal(stats.queued, 3);
+
+    releaseA();
+    resetAll();
+    await Promise.all(queued);
+  });
+
+  it("rejects with SEMAPHORE_QUEUE_FULL once the bounded queue is full", async () => {
+    const model = "minimax/abab6.5";
+
+    // Slot taken; queue capacity is 1.
+    const releaseA = await acquire(model, { maxConcurrency: 1, timeoutMs: 500, maxQueueSize: 1 });
+
+    // First waiter fits in the single queue slot.
+    const queued = acquire(model, { maxConcurrency: 1, timeoutMs: 500, maxQueueSize: 1 });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    assert.equal(getStats()[model].queued, 1);
+
+    // Second waiter overflows the queue → immediate SEMAPHORE_QUEUE_FULL (no 30s wait).
+    await assert.rejects(
+      acquire(model, { maxConcurrency: 1, timeoutMs: 500, maxQueueSize: 1 }),
+      (err: unknown) => {
+        assert.ok(err instanceof Error);
+        assert.equal((err as Error & { code?: string }).code, "SEMAPHORE_QUEUE_FULL");
+        return true;
+      }
+    );
+
+    releaseA();
+    await queued.then((release) => release());
+    resetAll();
+  });
+
+  it("fails over immediately with maxQueueSize 0 (never queue → cascade now)", async () => {
+    const model = "minimax/abab6.5";
+
+    const releaseA = await acquire(model, { maxConcurrency: 1, timeoutMs: 500, maxQueueSize: 0 });
+
+    // No queue allowed: the very next over-cap acquire rejects right away.
+    await assert.rejects(
+      acquire(model, { maxConcurrency: 1, timeoutMs: 500, maxQueueSize: 0 }),
+      (err: unknown) => {
+        assert.ok(err instanceof Error);
+        assert.equal((err as Error & { code?: string }).code, "SEMAPHORE_QUEUE_FULL");
+        return true;
+      }
+    );
+
+    assert.equal(getStats()[model].queued, 0);
+
+    releaseA();
+    resetAll();
+  });
+});


### PR DESCRIPTION
Closes #3872

## Problem
When a round-robin combo member is saturated, requests sit in the per-model rate-limit semaphore's **unbounded** queue and only fail over to the next member after the full `queueTimeoutMs` (default 30s) elapses. A burst of agentic requests therefore deep-queues one hot member (e.g. `minimax` at concurrency 3) instead of spilling to healthy members — the client often dies mid-task before failover.

The combo already cascades on `SEMAPHORE_QUEUE_FULL`/`SEMAPHORE_TIMEOUT` (`combo.ts` round-robin loop), but the combo's own semaphore (`rateLimitSemaphore.ts`) never emitted `SEMAPHORE_QUEUE_FULL` — its queue was unbounded, so that fast-cascade path was unreachable.

## Fix
- `rateLimitSemaphore.acquire` accepts an optional `maxQueueSize`; once the queue is that deep it rejects immediately with `SEMAPHORE_QUEUE_FULL` instead of waiting. Omitted/negative keeps the historical unbounded behavior (backward-compatible).
- New `queueDepth` combo-config knob, resolved through the full 3-layer cascade (global default → provider override → per-combo) via a pure `resolveComboQueueDepth` helper (mirrors the existing `resolveComboTargetTimeoutMs` pattern). Default **20** (backward-compatible; matches the number reporters saw); **0** = never queue → fail over to the next member immediately.
- Plumbed into the round-robin `semaphore.acquire(...)` call, surfaced in Settings → Combo Defaults, and validated by the combo Zod schema (`min(0).max(100)`, accepted on create + global defaults + provider overrides).

## Why this is the right lever (investigation note)
The user's exact `Semaphore queue full (20) for minimax:<connId>` 429 comes from the per-account `accountSemaphore` deeper in `chatCore`, but the combo **already** cascades on a 429 result. The actionable lever for *faster* combo failover is bounding the combo's own per-model queue so it cascades before the 30s timeout — which also relieves pressure on the per-account semaphore (fewer requests pile in concurrently).

## Validation (Hard Rule #18 — TDD)
- `tests/unit/rateLimitSemaphore.test.ts` (new): unbounded default unchanged; bounded queue emits `SEMAPHORE_QUEUE_FULL`; `maxQueueSize: 0` fails over immediately. **RED before** the `maxQueueSize` cap, GREEN after.
- `tests/unit/combo-config.test.ts`: `queueDepth` default 20, 3-layer cascade, `resolveComboQueueDepth` clamps (default/0/negative/NaN/>100/fractional), schema accepts `0` + rejects out-of-range. **RED before** the config field.
- Local: combo + semaphore suite **376/376**, `typecheck:core` clean, lint clean, `check:test-discovery` / `check:file-size` / `check:any-budget:t11` / i18n-ui-coverage (`--threshold=65`) green.

Default is unchanged behavior for existing installs (20-deep then cascade vs. previously unbounded-then-30s-timeout — strictly better under burst, no-op under light load).