### PR TITLE
test(combo): reset circuit breakers between stream-readiness cases (restore green)

### DIFF
--- a/tests/unit/combo-stream-readiness-fallback.test.ts
+++ b/tests/unit/combo-stream-readiness-fallback.test.ts
@@ -3,6 +3,18 @@ import assert from "node:assert/strict";
 
 import { handleComboChat, validateResponseQuality } from "../../open-sse/services/combo.ts";
 import { ensureStreamReadiness } from "../../open-sse/utils/streamReadiness.ts";
+import { resetAllCircuitBreakers } from "../../src/shared/utils/circuitBreaker.ts";
+
+// Test isolation: the combo-dispatch cases below deliberately fail `glm` (zombie
+// streams / 504s) several times in a row, which legitimately trips the per-provider
+// circuit breaker. That OPEN state is a module-level singleton, so without a reset it
+// leaks into the next test — combo.ts then SKIPS `glm/*` targets entirely (combo.ts
+// "Skipping … circuit breaker OPEN"), making e.g. "does not retry stream readiness
+// timeouts on the same model" never attempt glm/zombie. Reset before each test so every
+// scenario starts from a clean breaker slate (the breaker behavior itself is correct).
+test.beforeEach(() => {
+  resetAllCircuitBreakers();
+});
 
 const textEncoder = new TextEncoder();
 


### PR DESCRIPTION
## Restore green — pre-existing red on `release/v3.8.31`

`combo does not retry stream readiness timeouts on the same model` (in `combo-stream-readiness-fallback.test.ts`) was failing on the release branch **since the cycle-open tip** (not introduced by any recent PR).

### Root cause (test isolation, not a code bug)
The preceding combo-dispatch cases in the same file deliberately fail `glm` (zombie streams / repeated 504s), which legitimately trips the **per-provider circuit breaker**. That OPEN state is a module-level singleton and leaked into the next test — `combo.ts` then **skips** `glm/*` targets (`Skipping … circuit breaker OPEN`), so the test never attempts `glm/zombie`:
- expected `['glm/zombie','openai/gpt-5.4-mini']`
- got `['openai/gpt-5.4-mini']`

The test **passes in isolation** and only fails after the preceding cases — classic order-dependent pollution.

### Fix
Add `test.beforeEach(resetAllCircuitBreakers)` so every scenario starts from a clean breaker slate. **Test-isolation only** — no production code, no assertion changes; the breaker behavior is correct.

### Validation
- File: 11/11 green (was 4 fail in-file).
- Full combo suite: **390/390 green** (was 1 fail).
- TDD: confirmed red→green via the hook.