### PR TITLE
fix(sse): parse the chat request body once by threading it from the route guard (#4380)

### DIFF
--- a/config/quality/file-size-baseline.json
+++ b/config/quality/file-size-baseline.json
@@ -1,5 +1,6 @@
 {
   "_comment": "Catraca de tamanho (check-file-size.mjs). frozen so pode encolher; arquivos novos <= cap. --update ratcheta.",
+  "_rebaseline_2026_06_20_4380_parse_once": "PR #4380 own growth: src/sse/handlers/chat.ts 1486->1491 (+5 = thread the once-parsed request body from the route guard into handleChat, replacing the duplicate re-parse). The reusable body accessor lives in the new src/sse/handlers/requestBody.ts (<cap). Thin wiring at the single entry chokepoint; not extractable. Covered by tests/unit/chat-request-body-parse-once-4380.test.ts.",
   "_rebaseline_2026_06_19_4313_harvest_x_sweep_reconcile": "RECONCILIACAO ao mergear #4313 (5 harvested features) APOS o provider-sweep #4324: valores MEDIDOS na arvore combinada release(com #4324)+#4313. route.ts 2580->2586 (sweep +19 NAMED_OPENAI_STYLE + #4313 +3 openadapter/dit/tokenrouter = uniao no Set, regioes disjuntas). providers.ts 3198->3242 (sweep 6 dead-provider marks + #4313 3 novas entries APIKEY_PROVIDERS). combos/page.tsx 4350->4385 (#4313 #3266 allowlist UI) e providers/page.tsx 1925->1927 (#4313 #4240 serviceKind state) — intocados pelo sweep, crescimento puro do #4313. Mesmo padrao release-volatil de medir-no-merge dos baselines de complexity/zizmor deste lote.",
   "_rebaseline_2026_06_19_provider_sweep_merge_reconcile": "provider-model-sweep PR merge into release/v3.8.30: the sweep's route.ts growth (NAMED_OPENAI_STYLE_PROVIDERS +19 entries, base 2538->2564) and #4259's cloudflare parseResponse (2538->2554) are disjoint regions that both land, so the merged route.ts frozen value is reconciled to its measured size here. constants/providers.ts carries the sweep's 6 dead-provider deprecation marks on top of release. chatCore.ts stays at #4266's 5128 (sweep does not touch it).",
   "_rebaseline_2026_06_19_provider_sweep_dead_providers": "provider-model-sweep Track C: src/shared/constants/providers.ts 3169->3198 (+29 = deprecated:true + riskNoticeVariant:\"deprecated\" + a deprecationReason for six providers the sweep confirmed dead — kluster/glhf/predibase/inclusionai/galadriel (DNS no longer resolves) + phind (API shut down 2026-01). Mirrors the existing qwen deprecation-flag pattern; pure additive metadata so the UI surfaces a deprecation notice instead of silently offering a non-working provider. Not extractable (it IS the per-provider constant data).",
@@ -181,7 +182,7 @@
     "src/shared/constants/sidebarVisibility.ts": 1100,
     "src/shared/services/cliRuntime.ts": 1090,
     "src/shared/validation/schemas.ts": 2523,
-    "src/sse/handlers/chat.ts": 1486,
+    "src/sse/handlers/chat.ts": 1491,
     "src/sse/services/auth.ts": 2279
   },
   "testCap": 800,

--- a/src/app/api/v1/chat/completions/route.ts
+++ b/src/app/api/v1/chat/completions/route.ts
@@ -42,12 +42,16 @@ export async function POST(request) {
     }
   }
 
-  // Prompt injection guard — inspect body before forwarding
+  // Prompt injection guard — inspect body before forwarding. Parse the body ONCE here
+  // and thread it to handleChat so the handler does not JSON-parse the (often 270-550 KB)
+  // coding-agent payload a second time — the double parse doubled the body's heap
+  // residency on the hot path and fed the OOM crash-loop (#4380).
+  let parsedBody = null;
   try {
     const cloned = request.clone();
-    const body = await cloned.json().catch(() => null);
-    if (body) {
-      const { blocked, result } = injectionGuard(body);
+    parsedBody = await cloned.json().catch(() => null);
+    if (parsedBody) {
+      const { blocked, result } = injectionGuard(parsedBody);
       if (blocked) {
         return new Response(
           JSON.stringify({
@@ -66,5 +70,5 @@ export async function POST(request) {
     console.error("[SECURITY] Prompt injection guard failed:", error);
   }
 
-  return await handleChat(request);
+  return await handleChat(request, null, parsedBody);
 }

--- a/src/sse/handlers/chat.ts
+++ b/src/sse/handlers/chat.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "crypto";
+import { resolveChatRequestBody } from "./requestBody";
 import {
   getProviderCredentialsWithQuotaPreflight,
   markAccountUnavailable,
@@ -190,7 +191,11 @@ const PROVIDER_BREAKER_FAILURE_STATUSES = new Set([408, 500, 502, 503, 504]);
  * Supports: OpenAI, Claude, Gemini, OpenAI Responses API formats
  * Format detection and translation handled by translator
  */
-export async function handleChat(request: any, clientRawRequest: any = null) {
+export async function handleChat(
+  request: any,
+  clientRawRequest: any = null,
+  preParsedBody: any = null
+) {
   // Pipeline: Start request telemetry
   const reqId = generateRequestId();
   const telemetry = new RequestTelemetry(reqId);
@@ -198,7 +203,7 @@ export async function handleChat(request: any, clientRawRequest: any = null) {
   let body;
   try {
     telemetry.startPhase("parse");
-    body = await request.json();
+    body = await resolveChatRequestBody(request, preParsedBody);
     telemetry.endPhase();
   } catch {
     log.warn("CHAT", "Invalid JSON body");

--- a/src/sse/handlers/requestBody.ts
+++ b/src/sse/handlers/requestBody.ts
@@ -1,0 +1,24 @@
+/**
+ * Request-body resolution helpers for the chat handler.
+ *
+ * Kept dependency-free (no DB / executor imports) so it can be unit-tested in
+ * isolation without pulling the full chat pipeline.
+ */
+
+/**
+ * Resolve the chat request body, preferring a body already parsed upstream (#4380).
+ *
+ * The /v1/chat/completions route parses the body once for the prompt-injection guard,
+ * then hands it here via `preParsedBody` so a large coding-agent payload (270-550 KB) is
+ * not JSON-parsed a second time on the hot path — the double parse materialized the body
+ * twice in heap and fed the OOM crash-loop under concurrent load. Callers that don't
+ * pre-parse (most routes) pass `null`/`undefined` and the body is parsed from the request
+ * as before.
+ */
+export async function resolveChatRequestBody(
+  request: { json: () => Promise<unknown> },
+  preParsedBody: unknown = null
+): Promise<unknown> {
+  if (preParsedBody != null) return preParsedBody;
+  return await request.json();
+}

--- a/tests/unit/chat-request-body-parse-once-4380.test.ts
+++ b/tests/unit/chat-request-body-parse-once-4380.test.ts
@@ -1,0 +1,53 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// #4380: large /v1/chat/completions JSON bodies (270-550 KB coding-agent payloads) were
+// JSON-parsed twice — once in the route for the prompt-injection guard, then again in
+// handleChat — doubling the body's heap residency on the hot path and feeding an OOM
+// crash-loop under concurrent load. The route now threads the already-parsed body to the
+// handler via resolveChatRequestBody, which must NOT re-parse when a body is provided.
+
+const { resolveChatRequestBody } = await import("../../src/sse/handlers/requestBody.ts");
+
+function countingRequest() {
+  let jsonCalls = 0;
+  const request = {
+    json: async () => {
+      jsonCalls++;
+      return { parsed: "from-request" };
+    },
+  };
+  return { request, calls: () => jsonCalls };
+}
+
+test("#4380 returns the pre-parsed body WITHOUT re-parsing the request", async () => {
+  const { request, calls } = countingRequest();
+  const preParsed = { parsed: "from-route-guard", big: "x".repeat(1000) };
+
+  const result = await resolveChatRequestBody(request, preParsed);
+
+  assert.deepEqual(result, preParsed);
+  assert.equal(calls(), 0, "must not JSON-parse the large body a second time");
+});
+
+test("#4380 falls back to request.json() when no pre-parsed body is threaded", async () => {
+  const { request, calls } = countingRequest();
+
+  const viaNull = await resolveChatRequestBody(request, null);
+  const viaUndefined = await resolveChatRequestBody(request, undefined);
+
+  assert.deepEqual(viaNull, { parsed: "from-request" });
+  assert.deepEqual(viaUndefined, { parsed: "from-request" });
+  assert.equal(calls(), 2);
+});
+
+test("#4380 a present-but-empty pre-parsed body is used, not re-parsed (no `!body` regression)", async () => {
+  const { request, calls } = countingRequest();
+
+  // {} != null → must be used as-is. Guards against a `!preParsedBody` check that would
+  // wrongly re-parse a legitimately empty-object body.
+  const result = await resolveChatRequestBody(request, {});
+
+  assert.deepEqual(result, {});
+  assert.equal(calls(), 0);
+});


### PR DESCRIPTION
Closes #4380

## Problem
Large `/v1/chat/completions` JSON bodies (270–550 KB coding-agent payloads) were JSON-parsed **twice**: once in the route (`request.clone().json()` for the prompt-injection guard), then again in `handleChat` (`request.json()`). Under concurrent load this doubled the body's heap residency on the hot path and contributed to the heap-OOM crash-loop (exit 134) reported in #4380.

## Fix
- New dependency-free helper `src/sse/handlers/requestBody.ts::resolveChatRequestBody(request, preParsedBody)` — returns the already-parsed body when present, otherwise parses the request. (Standalone module so it's unit-testable without importing the DB-bound chat pipeline.)
- `handleChat` gains an optional 3rd param `preParsedBody = null` (additive — the 12 existing callers are unchanged and parse as before).
- The chat/completions route threads the body it already parsed for the injection guard into `handleChat`, so the handler no longer re-parses it.

## Validation (TDD)
New `tests/unit/chat-request-body-parse-once-4380.test.ts` (3/3): pre-parsed body is returned without calling `request.json()` (parse-once), null/undefined fall back to parsing, and a present-but-empty body is used as-is. Verified RED by temporarily reverting the guard (the parse-once assertions fail), then GREEN after restore.

`typecheck:core` clean (validates the new signature + the 12 `handleChat` callers + the new import). `chat-pipeline` integration: 28/29 — the one failure (`Codex CLI fingerprint to OAuth responses requests`) reproduces **identically on the base branch without this change**, i.e. a pre-existing flake unrelated to this PR. Lint clean.

This is the parse-once slice of the broader #4041 OOM work (injection-guard scan bound + heap-guard already shipped; `system_prompt_leak` heuristic in the #4041 PR).