### PR TITLE
fix(cli): non-interactive-safe prompts + singular `context` alias

### DIFF
--- a/bin/cli/commands/contexts.mjs
+++ b/bin/cli/commands/contexts.mjs
@@ -34,6 +34,7 @@ function maskKey(k) {
 export function registerContexts(program) {
   const ctx = program
     .command("contexts")
+    .alias("context") // singular alias — docs/connect output historically said `context current`
     .description(t("config.contexts.description") || "Manage server contexts/profiles");
 
   ctx

--- a/bin/cli/io.mjs
+++ b/bin/cli/io.mjs
@@ -6,20 +6,43 @@ export function createPrompt() {
     output: process.stdout,
   });
 
+  // Non-interactive stdin (pipe, CI, EOF via `< /dev/null`) cannot answer an
+  // interactive prompt. Without a guard, `rl.question` never fires its callback —
+  // the await stays pending and Node warns about an "unsettled top-level await" at
+  // exit. Resolving on the readline `close` event (which fires on stdin EOF)
+  // returns the default/empty instead of hanging. A genuinely piped line still
+  // arrives via the question callback first, so `echo value | omniroute …` keeps
+  // working — only the no-input EOF case falls back.
   function ask(question, defaultValue = "") {
     const suffix = defaultValue ? ` (${defaultValue})` : "";
     return new Promise((resolve) => {
+      let settled = false;
+      const done = (v) => {
+        if (!settled) {
+          settled = true;
+          resolve(v);
+        }
+      };
+      rl.once("close", () => done(defaultValue));
       rl.question(`${question}${suffix}: `, (answer) => {
         const trimmed = answer.trim();
-        resolve(trimmed || defaultValue);
+        done(trimmed || defaultValue);
       });
     });
   }
 
   function askSecret(question) {
     return new Promise((resolve) => {
-      let prompted = false;
+      let settled = false;
       const saved = rl._writeToOutput.bind(rl);
+      const done = (v) => {
+        if (!settled) {
+          settled = true;
+          rl._writeToOutput = saved;
+          resolve(v);
+        }
+      };
+      let prompted = false;
       rl._writeToOutput = function (str) {
         if (!prompted) {
           rl.output.write(str);
@@ -29,9 +52,9 @@ export function createPrompt() {
         // Suppress character echo; allow only newlines through
         if (str === "\r\n" || str === "\n" || str === "\r") rl.output.write("\n");
       };
+      rl.once("close", () => done("")); // non-interactive EOF → empty secret, no hang
       rl.question(`${question}: `, (answer) => {
-        rl._writeToOutput = saved;
-        resolve(answer.trim());
+        done(answer.trim());
       });
     });
   }

--- a/tests/unit/cli-contexts.test.ts
+++ b/tests/unit/cli-contexts.test.ts
@@ -92,3 +92,40 @@ test("confirm() declines cleanly on non-interactive stdin (no hung await)", asyn
     else delete (process.stdin as { isTTY?: boolean }).isTTY;
   }
 });
+
+test("registerContexts registers the singular `context` alias", async () => {
+  // The connect output and older docs say `omniroute context current` (singular);
+  // the command is `contexts`. An alias keeps the singular muscle-memory working.
+  const { registerContexts } = await import("../../bin/cli/commands/contexts.mjs");
+  let aliasName: string | undefined;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const fakeCtx: any = {
+    command() {
+      return this;
+    },
+    alias(a: string) {
+      aliasName = a;
+      return this;
+    },
+    description() {
+      return this;
+    },
+    requiredOption() {
+      return this;
+    },
+    option() {
+      return this;
+    },
+    action() {
+      return this;
+    },
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const fakeProgram: any = {
+    command() {
+      return fakeCtx;
+    },
+  };
+  registerContexts(fakeProgram);
+  assert.equal(aliasName, "context");
+});

--- a/tests/unit/cli-io.test.ts
+++ b/tests/unit/cli-io.test.ts
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// Regression: the shared interactive prompt helper (createPrompt) used rl.question
+// without an EOF guard, so a non-interactive stdin (pipe, CI, `< /dev/null`) left
+// the promise pending — Node then warned about an "unsettled top-level await" at
+// exit and the command hung. ask/askSecret now resolve on the readline `close`
+// event (fired on EOF) with the default / empty string instead of hanging. close()
+// here simulates that EOF/non-interactive close.
+
+test("createPrompt.ask resolves the default on EOF (non-interactive, no hang)", async () => {
+  const { createPrompt } = await import("../../bin/cli/io.mjs");
+  const p = createPrompt();
+  const pending = p.ask("Name", "fallback");
+  p.close();
+  assert.equal(await pending, "fallback");
+});
+
+test("createPrompt.ask resolves empty when there is no default on EOF", async () => {
+  const { createPrompt } = await import("../../bin/cli/io.mjs");
+  const p = createPrompt();
+  const pending = p.ask("Name");
+  p.close();
+  assert.equal(await pending, "");
+});
+
+test("createPrompt.askSecret resolves empty on EOF (no hang)", async () => {
+  const { createPrompt } = await import("../../bin/cli/io.mjs");
+  const p = createPrompt();
+  const pending = p.askSecret("Secret");
+  p.close();
+  assert.equal(await pending, "");
+});

--- a/tests/unit/cli-remote-mode.test.ts
+++ b/tests/unit/cli-remote-mode.test.ts
@@ -220,6 +220,9 @@ test("commands/contexts.mjs registers a `current` subcommand", async () => {
       sub.push(name.split(" ")[0]);
       return this;
     },
+    alias() {
+      return this;
+    },
     description() {
       return this;
     },


### PR DESCRIPTION
Two CLI-polish follow-ups requested to close out the remote-mode work. (The third — an async-warn refactor for #2807 — is **moot**: #4373 replaced the Gemini remote-URL drop+warn with `fileData` pass-through, so there is no async warn left to refactor.)

### 1. Non-interactive-safe prompts (central fix in `io.mjs`)
`createPrompt` (the shared interactive helper used by ~20 commands) called `rl.question` with no EOF guard, so a non-interactive stdin (pipe, CI, `< /dev/null`) left the promise pending — Node warned about an *unsettled top-level await* and the command hung. `ask`/`askSecret` now resolve on the readline `close` event (fired on EOF) with the default / empty string. A genuinely piped line still arrives via the question callback first, so `echo value | omniroute …` keeps working — only the no-input EOF case falls back. Centralizes the same protection added to `contexts` `confirm()` in #4397.

### 2. Singular `context` alias
`omniroute contexts` gains a `context` alias — the `connect` output and older docs say `omniroute context current` (singular), so this keeps that muscle-memory working.

### Validation
- `cli-io.test.ts`: `ask` (with/without default) and `askSecret` resolve on EOF without hanging.
- `cli-contexts.test.ts`: asserts the `context` alias is registered.
- 11/11 local; verified the EOF behavior in isolation too.
- Note: the full-CLI smoke could not run locally right now (shared checkout mid native-dep rebuild hangs even `--version` on the parent) — the targeted unit tests + isolation proof cover the change; CI runs the full suite.

Client-side only.