### PR TITLE
fix(usage): keep Kiro overage quotas routable

### DIFF
--- a/open-sse/services/usage.ts
+++ b/open-sse/services/usage.ts
@@ -319,6 +319,41 @@ function shouldDisplayGitHubQuota(quota: UsageQuota | null): quota is UsageQuota
   return quota.total > 0 || quota.remainingPercentage !== undefined;
 }
 
+function isKiroOverageEnabled(data: JsonRecord): boolean {
+  const overageConfiguration = toRecord(data.overageConfiguration);
+  const overageStatus = String(overageConfiguration.overageStatus || "")
+    .trim()
+    .toUpperCase();
+
+  return (
+    overageStatus === "ENABLED" ||
+    data.overageEnabled === true ||
+    overageConfiguration.overageEnabled === true
+  );
+}
+
+function buildKiroQuota(
+  used: number,
+  total: number,
+  resetAt: string | null,
+  overageEnabled: boolean
+): UsageQuota {
+  const remaining = total - used;
+
+  if (!overageEnabled) {
+    return { used, total, remaining, resetAt, unlimited: false };
+  }
+
+  return {
+    used,
+    total,
+    remaining,
+    remainingPercentage: 100,
+    resetAt,
+    unlimited: true,
+  };
+}
+
 function pickFirstNonEmptyString(...values: unknown[]): string | undefined {
   for (const value of values) {
     if (typeof value !== "string") continue;
@@ -2933,6 +2968,7 @@ export function buildKiroUsageResult(
   const usageList = Array.isArray(data.usageBreakdownList) ? data.usageBreakdownList : [];
   const quotaInfo: Record<string, UsageQuota> = {};
   const resetAt = parseResetTime(data.nextDateReset || data.resetDate);
+  const overageEnabled = isKiroOverageEnabled(data);
 
   usageList.forEach((breakdownValue: unknown) => {
     const breakdown = toRecord(breakdownValue);
@@ -2941,19 +2977,18 @@ export function buildKiroUsageResult(
     const used = toNumber(breakdown.currentUsageWithPrecision, 0);
     const total = toNumber(breakdown.usageLimitWithPrecision, 0);
 
-    quotaInfo[resourceType] = { used, total, remaining: total - used, resetAt, unlimited: false };
+    quotaInfo[resourceType] = buildKiroQuota(used, total, resetAt, overageEnabled);
 
     const freeTrialInfo = toRecord(breakdown.freeTrialInfo);
     if (Object.keys(freeTrialInfo).length > 0) {
       const freeUsed = toNumber(freeTrialInfo.currentUsageWithPrecision, 0);
       const freeTotal = toNumber(freeTrialInfo.usageLimitWithPrecision, 0);
-      quotaInfo[`${resourceType}_freetrial`] = {
-        used: freeUsed,
-        total: freeTotal,
-        remaining: freeTotal - freeUsed,
+      quotaInfo[`${resourceType}_freetrial`] = buildKiroQuota(
+        freeUsed,
+        freeTotal,
         resetAt,
-        unlimited: false,
-      };
+        overageEnabled
+      );
     }
   });
 

--- a/tests/unit/kiro-overage-usage-4469.test.ts
+++ b/tests/unit/kiro-overage-usage-4469.test.ts
@@ -1,0 +1,74 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { buildKiroUsageResult } from "@omniroute/open-sse/services/usage.ts";
+
+type KiroQuotaResult = {
+  plan: string;
+  quotas: Record<
+    string,
+    {
+      used: number;
+      total: number;
+      remaining: number;
+      remainingPercentage?: number;
+      unlimited: boolean;
+    }
+  >;
+};
+
+function exhaustedKiroUsage(overrides: Record<string, unknown> = {}) {
+  return {
+    subscriptionInfo: { subscriptionTitle: "Kiro Pro" },
+    usageBreakdownList: [
+      {
+        resourceType: "AGENTIC_REQUEST",
+        currentUsageWithPrecision: 100,
+        usageLimitWithPrecision: 100,
+        freeTrialInfo: {
+          currentUsageWithPrecision: 25,
+          usageLimitWithPrecision: 25,
+        },
+      },
+    ],
+    ...overrides,
+  };
+}
+
+test("#4469 Kiro overageStatus ENABLED keeps exhausted base quota routable", () => {
+  const result = buildKiroUsageResult(
+    exhaustedKiroUsage({
+      overageConfiguration: { overageStatus: "ENABLED" },
+    })
+  ) as KiroQuotaResult;
+
+  assert.equal(result.quotas.agentic_request.remaining, 0);
+  assert.equal(result.quotas.agentic_request.remainingPercentage, 100);
+  assert.equal(result.quotas.agentic_request.unlimited, true);
+  assert.equal(result.quotas.agentic_request_freetrial.remainingPercentage, 100);
+  assert.equal(result.quotas.agentic_request_freetrial.unlimited, true);
+});
+
+test("#4469 Kiro top-level overageEnabled keeps exhausted base quota routable", () => {
+  const result = buildKiroUsageResult(
+    exhaustedKiroUsage({
+      overageEnabled: true,
+    })
+  ) as KiroQuotaResult;
+
+  assert.equal(result.quotas.agentic_request.remainingPercentage, 100);
+  assert.equal(result.quotas.agentic_request.unlimited, true);
+});
+
+test("#4469 Kiro disabled overage preserves exhausted quota signal", () => {
+  const result = buildKiroUsageResult(
+    exhaustedKiroUsage({
+      overageConfiguration: { overageStatus: "DISABLED" },
+      overageEnabled: false,
+    })
+  ) as KiroQuotaResult;
+
+  assert.equal(result.quotas.agentic_request.remaining, 0);
+  assert.equal(result.quotas.agentic_request.remainingPercentage, undefined);
+  assert.equal(result.quotas.agentic_request.unlimited, false);
+  assert.equal(result.quotas.agentic_request_freetrial.unlimited, false);
+});


### PR DESCRIPTION
## Summary
- keep Kiro accounts routable when `overageConfiguration.overageStatus` or `overageEnabled` indicates overage access is enabled
- preserve the existing zero-quota exclusion behavior for accounts that are neither quota-positive nor overage-enabled
- add focused unit coverage for the Kiro overage usage parser/routing case

Fixes #4469.

## Verification
- `node --import tsx --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test tests/unit/kiro-overage-usage-4469.test.ts tests/unit/kiro-usage-empty-breakdown-3506.test.ts tests/unit/kiro-iam-profilearn-usage.test.ts`
- `npx eslint open-sse/services/usage.ts tests/unit/kiro-overage-usage-4469.test.ts`
- `npm run typecheck:core`
- `npm run check:file-size`
- pre-push hooks: `check:any-budget:t11`, `check:tracked-artifacts`