### PR TITLE
feat(combo): per-combo stickyRoundRobinLimit override on the combos page

### DIFF
--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -1986,11 +1986,17 @@ async function handleRoundRobinCombo({
     log
   );
 
-  // Sticky batch size at the combo level. Reuses the global `stickyRoundRobinLimit`
-  // setting so a single knob controls sticky batching for both account fallback and
-  // combo targets. Values <= 1 preserve the historical one-request-per-target rotation.
+  // Sticky batch size at the combo level. A per-combo `stickyRoundRobinLimit` (in
+  // combo.config, resolved through the cascade) overrides the global setting so one
+  // combo can batch differently from the default. When the per-combo value is unset,
+  // fall back to the global `stickyRoundRobinLimit` so the existing knob still controls
+  // sticky batching for both account fallback and combo targets. Values <= 1 preserve
+  // the historical one-request-per-target rotation.
+  const perComboStickyLimit = (config as Record<string, unknown>).stickyRoundRobinLimit;
   const stickyLimit = clampStickyRoundRobinTargetLimit(
-    (settings as Record<string, unknown> | null)?.stickyRoundRobinLimit
+    perComboStickyLimit !== undefined && perComboStickyLimit !== null
+      ? perComboStickyLimit
+      : (settings as Record<string, unknown> | null)?.stickyRoundRobinLimit
   );
   const stickyRoundRobinEnabled = stickyLimit > 1;
   if (

--- a/src/app/(dashboard)/dashboard/combos/page.tsx
+++ b/src/app/(dashboard)/dashboard/combos/page.tsx
@@ -157,6 +157,8 @@ const ADVANCED_FIELD_HELP_FALLBACK = {
     "Round-robin combo/model limit: max simultaneous requests sent to each model target. This is separate from any provider account-only cap.",
   queueTimeout:
     "How long a request can wait for a round-robin model slot before timing out. This queue is separate from any account-only concurrency cap.",
+  stickyLimit:
+    "Round-robin sticky batch size: consecutive successful requests sent to one target before rotating to the next. Empty inherits the global Sticky Limit setting; 1 disables batching (pure one-request rotation).",
   failoverBeforeRetry:
     "When enabled, a 429 from the upstream triggers immediate target failover instead of retrying the same URL first.",
   targetTimeoutMs:
@@ -2699,6 +2701,8 @@ function ComboFormModal({ isOpen, combo, onClose, onSave, activeProviders, combo
       if (config.concurrencyPerModel !== undefined)
         configToSave.concurrencyPerModel = config.concurrencyPerModel;
       if (config.queueTimeoutMs !== undefined) configToSave.queueTimeoutMs = config.queueTimeoutMs;
+      if (config.stickyRoundRobinLimit !== undefined)
+        configToSave.stickyRoundRobinLimit = config.stickyRoundRobinLimit;
     }
     const hasConfigToSave = Object.keys(configToSave).length > 0;
     const hadExistingConfig = Object.keys(sanitizeComboRuntimeConfig(combo?.config)).length > 0;
@@ -3784,6 +3788,33 @@ function ComboFormModal({ isOpen, combo, onClose, onSave, activeProviders, combo
                             setConfig({
                               ...config,
                               queueTimeoutMs: e.target.value ? Number(e.target.value) : undefined,
+                            })
+                          }
+                          className="w-full text-xs py-1.5 px-2 rounded border border-black/10 dark:border-white/10 bg-transparent focus:border-primary focus:outline-none"
+                        />
+                      </div>
+                      <div className="col-span-2">
+                        <FieldLabelWithHelp
+                          label={getI18nOrFallback(t, "stickyLimit", "Sticky Limit")}
+                          help={getI18nOrFallback(
+                            t,
+                            "advancedHelp.stickyLimit",
+                            ADVANCED_FIELD_HELP_FALLBACK.stickyLimit
+                          )}
+                          showHelp={!isExpertMode}
+                        />
+                        <input
+                          type="number"
+                          min="0"
+                          max="1000"
+                          value={config.stickyRoundRobinLimit ?? ""}
+                          placeholder={getI18nOrFallback(t, "stickyLimitInherit", "inherit")}
+                          onChange={(e) =>
+                            setConfig({
+                              ...config,
+                              stickyRoundRobinLimit: e.target.value
+                                ? Number(e.target.value)
+                                : undefined,
                             })
                           }
                           className="w-full text-xs py-1.5 px-2 rounded border border-black/10 dark:border-white/10 bg-transparent focus:border-primary focus:outline-none"

--- a/src/shared/validation/schemas/combo.ts
+++ b/src/shared/validation/schemas/combo.ts
@@ -14,7 +14,6 @@ import {
 } from "@/shared/constants/upstreamHeaders";
 import { MAX_TIMER_TIMEOUT_MS } from "@/shared/utils/runtimeTimeouts";
 
-
 // ──── Combo Schemas ────
 
 export const comboStepMetaSchema = {
@@ -135,6 +134,10 @@ export const comboRuntimeConfigSchema = z
     queueTimeoutMs: z.coerce.number().int().min(1000).max(120000).optional(),
     // #3872: pre-cascade semaphore queue depth (round-robin). 0 = fail over immediately.
     queueDepth: z.coerce.number().int().min(0).max(100).optional(),
+    // Per-combo sticky round-robin batch size. When unset, handleRoundRobinCombo
+    // falls back to the global `settings.stickyRoundRobinLimit` so the existing
+    // knob still controls the default. 0 clamps to 1 (no batching) upstream.
+    stickyRoundRobinLimit: z.coerce.number().int().min(0).max(1000).optional(),
     healthCheckEnabled: z.boolean().optional(),
     healthCheckTimeoutMs: z.coerce.number().int().min(100).max(30000).optional(),
     handoffThreshold: z.coerce.number().min(0.5).max(0.94).optional(),

--- a/tests/unit/combo-config.test.ts
+++ b/tests/unit/combo-config.test.ts
@@ -531,6 +531,24 @@ test("createComboSchema accepts failoverBeforeRetry, maxSetRetries and setRetryD
   assert.equal(parsed.config.setRetryDelayMs, 1500);
 });
 
+test("createComboSchema accepts per-combo stickyRoundRobinLimit and rejects out-of-range", () => {
+  const parsed = createComboSchema.parse({
+    name: "sticky-override",
+    models: ["openai/gpt-4o-mini"],
+    strategy: "round-robin",
+    config: { stickyRoundRobinLimit: 2 },
+  });
+  assert.equal(parsed.config.stickyRoundRobinLimit, 2);
+
+  const tooHigh = createComboSchema.safeParse({
+    name: "sticky-too-high",
+    models: ["openai/gpt-4o-mini"],
+    strategy: "round-robin",
+    config: { stickyRoundRobinLimit: 1001 },
+  });
+  assert.equal(tooHigh.success, false);
+});
+
 test("createComboSchema coerces string numbers for maxSetRetries and setRetryDelayMs", () => {
   const parsed = createComboSchema.parse({
     name: "coerce-test",

--- a/tests/unit/combo-strategy-fallbacks.test.ts
+++ b/tests/unit/combo-strategy-fallbacks.test.ts
@@ -330,6 +330,32 @@ test("round-robin uses existing stickyRoundRobinLimit for combo target batching"
   ]);
 });
 
+test("per-combo stickyRoundRobinLimit overrides the global setting", async () => {
+  const calls: string[] = [];
+  const combo = {
+    name: "rr-per-combo-sticky-override",
+    strategy: "round-robin",
+    models: ["openai/a", "claude/b", "gemini/c"],
+    config: { maxRetries: 0, retryDelayMs: 0, fallbackDelayMs: 0, stickyRoundRobinLimit: 2 },
+  };
+  for (let i = 0; i < 4; i += 1) {
+    const result = await handleComboChat({
+      body: {},
+      combo,
+      handleSingleModel: async (_body: any, m: string) => {
+        calls.push(m);
+        return okResponse();
+      },
+      isModelAvailable: async () => true,
+      log: createLog(),
+      settings: { stickyRoundRobinLimit: 3 },
+      allCombos: null,
+    });
+    assert.equal(result.ok, true);
+  }
+  assert.deepEqual(calls, ["openai/a", "openai/a", "claude/b", "claude/b"]);
+});
+
 test("round-robin sticky batching fallback success becomes sticky target", async () => {
   const calls: string[] = [];
   const combo = {


### PR DESCRIPTION
## Summary

- Adds an optional per-combo `stickyRoundRobinLimit` (0–1000) to `comboRuntimeConfigSchema`, so a single round-robin combo can set its own sticky batch size independently of the global setting.
- `handleRoundRobinCombo` now prefers the per-combo value (resolved through the DEFAULT → comboDefaults → providerOverrides → combo.config cascade) and falls back to the existing global `settings.stickyRoundRobinLimit` when the combo leaves it unset — preserving the one-knob default shipped in #3846. No new global field; reuses the existing name per the one-unified-knob design.
- Surfaces the control on the **Combos page** (round-robin advanced block, alongside `concurrencyPerModel` and `queueTimeout`), where operators look for it, with placeholder `inherit` and help text explaining the fallback. Empty = inherit global; 1 = pure one-request rotation.

This addresses the discoverability gap left after #3846 was rebased to drop the per-combo-page UI: the shipped feature was global-only, with no way to give combo A a different sticky batch size than combo B. This PR adds that per-combo granularity on top of the global default.

## Test plan

- [x] `npm run check:file-size` — OK (combo.ts 2473/2611, combos/page.tsx 4345/4385; no baseline bump)
- [x] `npm run typecheck:core` — clean
- [x] `node --test tests/unit/combo-strategy-fallbacks.test.ts` — 14/14 pass (new `per-combo stickyRoundRobinLimit overrides the global setting` test proves per-combo=2 beats global=3, yielding `[a,a,b,b]` not `[a,a,a,b]`)
- [x] `node --test tests/unit/combo-config.test.ts` — 27/27 pass (new schema test: accepts 2, rejects 1001)
- [x] `eslint` on changed files — 0 errors
- [x] `prettier --check` on changed files — all clean
- [x] pre-commit hook (prettier + eslint + docs-sync + any-budget:t11 + tracked-artifacts) — all PASS
- [ ] Manual: on the Combos page, edit a round-robin combo → expand advanced → Sticky Limit input visible with `inherit` placeholder; set to 2, save, confirm the combo batches A×2, B×2, C×2; leave another combo unset and confirm it still follows the global Sticky Limit

Made with [Cursor](https://cursor.com)