### PR TITLE
chore(i18n): remove unused config helpers

### DIFF
--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -52,17 +52,3 @@ export const LANGUAGES: readonly {
 export const RTL_LOCALES: readonly Locale[] = config.rtl as readonly Locale[];
 
 export const LOCALE_COOKIE = "NEXT_LOCALE";
-
-// Convenience helpers --------------------------------------------------------
-
-/** Locales that the docs translation pipeline writes to (excludes the source). */
-export const DOCS_TARGET_LOCALES: readonly Locale[] = LANGUAGES.map((l) => l.code).filter(
-  (code) => !(config.docsExcluded ?? []).includes(code)
-) as readonly Locale[];
-
-/** Lookup by code; falls back to the default locale entry if not found. */
-export function getLanguage(code: string) {
-  return (
-    LANGUAGES.find((l) => l.code === code) ?? LANGUAGES.find((l) => l.code === DEFAULT_LOCALE)!
-  );
-}

--- a/tests/unit/i18n-config.test.ts
+++ b/tests/unit/i18n-config.test.ts
@@ -1,0 +1,36 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import i18nConfig from "../../config/i18n.json" with { type: "json" };
+import {
+  DEFAULT_LOCALE,
+  LANGUAGES,
+  LOCALES,
+  LOCALE_COOKIE,
+  RTL_LOCALES,
+} from "../../src/i18n/config.ts";
+
+test("i18n config adapter reflects the JSON source of truth", () => {
+  assert.deepEqual(
+    LOCALES,
+    i18nConfig.locales.map((locale) => locale.code)
+  );
+  assert.equal(DEFAULT_LOCALE, i18nConfig.default);
+  assert.deepEqual(RTL_LOCALES, i18nConfig.rtl);
+  assert.equal(LOCALE_COOKIE, "NEXT_LOCALE");
+});
+
+test("i18n language metadata preserves native and English names", () => {
+  assert.equal(LANGUAGES.length, i18nConfig.locales.length);
+
+  const english = LANGUAGES.find((language) => language.code === "en");
+  const englishConfig = i18nConfig.locales.find((language) => language.code === "en");
+  assert.deepEqual(english, {
+    code: "en",
+    label: englishConfig?.label,
+    name: englishConfig?.name,
+    native: englishConfig?.native,
+    english: englishConfig?.english,
+    flag: englishConfig?.flag,
+  });
+});


### PR DESCRIPTION
## Summary
- remove unused i18n config helper exports that Knip reports as dead code
- reduce the dead-code ratchet total from 341 to 339 without changing runtime locale config exports

## Validation
- npx prettier --write src/i18n/config.ts
- npx eslint src/i18n/config.ts --quiet
- node node_modules/knip/bin/knip.js --reporter json --no-progress --no-exit-code > C:\Users\koosh\OmniRoute-upstream\.git\knip-quality-after.json
  - DEAD_EXPORTS=240
  - DEAD_FILES=99
  - DEAD_TOTAL=339