### PR TITLE
fix(bazaarlink): register in APIKEY_PROVIDERS to allow connection creation

### DIFF
--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -2445,6 +2445,21 @@ export const APIKEY_PROVIDERS = {
     apiHint:
       "TokenRouter exposes an OpenAI-compatible chat completions endpoint at https://api.tokenrouter.com/v1/chat/completions, plus a working /v1/models catalog. OmniRoute uses the OpenAI protocol.",
   },
+  bazaarlink: {
+    id: "bazaarlink",
+    alias: "bzl",
+    name: "BazaarLink",
+    icon: "storefront",
+    color: "#6366F1",
+    textIcon: "BZ",
+    website: "https://bazaarlink.ai",
+    hasFree: true,
+    freeNote: "Free tier with auto:free routing — zero-cost inference, no credit card required. 4M tokens/day per account for most models.",
+    authHint:
+      "Use your BazaarLink API key (starts with sk-bl-) in Authorization: Bearer <key>. Fully OpenAI-compatible — OpenAI SDK works with base URL https://bazaarlink.ai/api/v1.",
+    apiHint:
+      "Get a free API key at https://bazaarlink.ai — supports auto:free for zero-cost routing. Models use provider/model format e.g. xiaomi/mimo-v2.5-pro.",
+  },
 };
 
 // Sub-categories within APIKEY_PROVIDERS (used by dashboard and catalog views).


### PR DESCRIPTION
## Summary

BazaarLink was registered in the execution registry and the PROVIDERS display constant, but was missing from APIKEY_PROVIDERS. This caused isManagedProviderConnectionId to return false, blocking connection creation with an "Invalid provider" error.

## Fix

Added a bazaarlink entry to APIKEY_PROVIDERS with:
- alias: bzl
- API key auth (Bearer, prefix sk-bl-)
- Free tier annotation (4M tokens/day)
- Endpoint hint: https://bazaarlink.ai/api/v1
- Model format note: provider/model-name

Bulk-add works automatically (not in BULK_API_KEY_EXCLUDED).

## Test plan

1. Create an API key at https://bazaarlink.ai
2. In OmniRoute, add a BazaarLink connection with the key
3. Validation should succeed (hits GET /api/v1/models)
4. Connection is created with status "active"

Made with [Cursor](https://cursor.com)