### PR TITLE
refactor(chatCore): extrai resolução de endpoint/formato para leaf puro (#3501)

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -206,12 +206,8 @@ import {
   shouldDetectLimit,
 } from "../services/toolLimitDetector.ts";
 
-import {
-  parseCodexQuotaHeaders,
-  getCodexModelScope,
-  getCodexDualWindowCooldownMs,
-  isCompactResponsesEndpoint,
-} from "../executors/codex.ts";
+import { isCompactResponsesEndpoint } from "../executors/codex.ts";
+import { buildCodexQuotaPersistence } from "./chatCore/codexQuota.ts";
 import { invalidateCodexQuotaCache } from "../services/codexQuotaFetcher.ts";
 import { translateNonStreamingResponse } from "./responseTranslator.ts";
 import { extractUsageFromResponse } from "./usageExtractor.ts";
@@ -826,67 +822,35 @@ export async function handleChatCore({
     if (provider !== "codex" || !connectionId || !headers) return;
 
     try {
-      const quota = parseCodexQuotaHeaders(headers);
-      if (!quota) return;
-
       const existingProviderData =
         credentials?.providerSpecificData && typeof credentials.providerSpecificData === "object"
-          ? credentials.providerSpecificData
+          ? (credentials.providerSpecificData as Record<string, unknown>)
           : {};
-      const scope = getCodexModelScope(model || requestedModel || "");
-      const quotaState = {
-        usage5h: quota.usage5h,
-        limit5h: quota.limit5h,
-        resetAt5h: quota.resetAt5h,
-        usage7d: quota.usage7d,
-        limit7d: quota.limit7d,
-        resetAt7d: quota.resetAt7d,
-        scope,
-        updatedAt: new Date().toISOString(),
-      };
+      // Pure payload build extracted to chatCore/codexQuota.ts (#3501). Returns null when the
+      // response carries no quota headers (nothing to persist).
+      const built = buildCodexQuotaPersistence({
+        headers,
+        existingProviderData,
+        modelForScope: model || requestedModel || "",
+        status,
+      });
+      if (!built) return;
 
-      const nextProviderData: Record<string, unknown> = {
-        ...existingProviderData,
-        codexQuotaState: quotaState,
-      };
+      if (built.exhaustionLog) {
+        log?.debug?.("CODEX", built.exhaustionLog);
+      }
 
-      // T03/T09: on 429, persist exact reset time per scope to avoid global over-blocking.
-      // Use dual-window cooldown to distinguish short-term and weekly Codex exhaustion.
+      // Invalidate the preflight cache for this connection so the next
+      // isModelAvailable check fetches fresh quota data.
       if (status === 429) {
-        const { cooldownMs, window: exhaustedWindow } = getCodexDualWindowCooldownMs(quota);
-        if (cooldownMs > 0) {
-          const scopeUntil = new Date(Date.now() + cooldownMs).toISOString();
-          const scopeMapRaw =
-            existingProviderData &&
-            typeof existingProviderData === "object" &&
-            existingProviderData.codexScopeRateLimitedUntil &&
-            typeof existingProviderData.codexScopeRateLimitedUntil === "object"
-              ? existingProviderData.codexScopeRateLimitedUntil
-              : {};
-
-          nextProviderData.codexScopeRateLimitedUntil = {
-            ...(scopeMapRaw as Record<string, unknown>),
-            [scope]: scopeUntil,
-          };
-          nextProviderData.codexExhaustedWindow = exhaustedWindow;
-          log?.debug?.(
-            "CODEX",
-            `Quota exhaustion on ${exhaustedWindow} window, cooldown until ${scopeUntil}`
-          );
-        }
-
-        // Invalidate the preflight cache for this connection so the next
-        // isModelAvailable check fetches fresh quota data.
-        if (connectionId) {
-          invalidateCodexQuotaCache(connectionId);
-        }
+        invalidateCodexQuotaCache(connectionId);
       }
 
       await updateProviderConnection(connectionId, {
-        providerSpecificData: nextProviderData,
+        providerSpecificData: built.nextProviderData,
       });
 
-      credentials.providerSpecificData = nextProviderData;
+      credentials.providerSpecificData = built.nextProviderData;
     } catch (err) {
       const errMessage = err instanceof Error ? err.message : String(err);
       log?.debug?.("CODEX", `Failed to persist codex quota state: ${errMessage}`);

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -44,7 +44,8 @@ import {
 import { CORS_HEADERS } from "../utils/cors.ts";
 import { checkHeapPressureGuard } from "../utils/heapPressure.ts";
 import { normalizeHeaders } from "../utils/headers.ts";
-import { detectFormatFromEndpoint, getTargetFormat } from "../services/provider.ts";
+import { getTargetFormat } from "../services/provider.ts";
+import { resolveChatCoreRequestFormat } from "./chatCore/requestFormat.ts";
 import { injectSystemPrompt } from "../services/systemPrompt.ts";
 import { translateRequest, needsTranslation } from "../translator/index.ts";
 import { FORMATS } from "../translator/formats.ts";
@@ -553,28 +554,6 @@ function buildExecutorClientHeaders(
   return Object.keys(normalized).length > 0 ? normalized : null;
 }
 
-function isCopilotClient(
-  headers: Headers | Record<string, unknown> | null | undefined,
-  userAgent?: string | null
-) {
-  const isMatch = (value: unknown) =>
-    typeof value === "string" && value.toLowerCase().includes("copilot");
-
-  if (isMatch(userAgent)) return true;
-
-  if (headers instanceof Headers) {
-    for (const [key, value] of headers as unknown as Iterable<[string, string]>) {
-      if (isMatch(key) || isMatch(value)) return true;
-    }
-  } else if (headers && typeof headers === "object") {
-    for (const [key, value] of Object.entries(headers)) {
-      if (isMatch(key) || isMatch(value)) return true;
-    }
-  }
-
-  return false;
-}
-
 export function extractSystemRoleMessages(payload: Record<string, unknown>): void {
   if (!Array.isArray(payload.messages)) return;
   const messages = payload.messages as Array<{ role?: unknown; content?: unknown }>;
@@ -878,22 +857,17 @@ export async function handleChatCore({
     credentials.connectionId = connectionId;
   }
 
-  const endpointPath = String(clientRawRequest?.endpoint || "");
-  const sourceFormat = detectFormatFromEndpoint(body, endpointPath);
-  const isResponsesEndpoint =
-    /\/responses(?=\/|$)/i.test(endpointPath) || /^responses(?=\/|$)/i.test(endpointPath);
-  const nativeCodexPassthrough = shouldUseNativeCodexPassthrough({
-    provider,
-    sourceFormat,
+  // Endpoint/format resolution extracted to chatCore/requestFormat.ts (#3501); pure derivation
+  // from the inbound request, destructured so every downstream use stays byte-identical.
+  const {
     endpointPath,
-  });
-  const isDroidCLI =
-    userAgent?.toLowerCase().includes("droid") || userAgent?.toLowerCase().includes("codex-cli");
-  const copilotCompatibleReasoning = isCopilotClient(clientRawRequest?.headers, userAgent);
-  const clientResponseFormat =
-    sourceFormat === FORMATS.OPENAI_RESPONSES && !isResponsesEndpoint && !isDroidCLI
-      ? FORMATS.OPENAI
-      : sourceFormat;
+    sourceFormat,
+    isResponsesEndpoint,
+    nativeCodexPassthrough,
+    isDroidCLI,
+    copilotCompatibleReasoning,
+    clientResponseFormat,
+  } = resolveChatCoreRequestFormat({ clientRawRequest, body, provider, userAgent });
 
   // Check for bypass patterns (warmup, skip) - return fake response
   const bypassResponse = handleBypassRequest(body, model, userAgent);

--- a/open-sse/handlers/chatCore/codexQuota.ts
+++ b/open-sse/handlers/chatCore/codexQuota.ts
@@ -1,0 +1,85 @@
+/**
+ * chatCore Codex quota-persistence builder (Quality Gate v2 / Fase 9 — chatCore god-file
+ * decomposition, #3501).
+ *
+ * Pure core of handleChatCore's persistCodexQuotaState: turns the upstream Codex quota response
+ * headers into the next `providerSpecificData` payload (the codexQuotaState snapshot, plus — on a
+ * 429 whose dual-window usage is past the exhaustion threshold — the per-scope cooldown timestamp,
+ * the exhausted window, and the debug-log message). The handler keeps the impure parts byte-
+ * identically: the DB write (updateProviderConnection), the preflight-cache invalidation on every
+ * 429, the credentials mutation, and emitting the returned log line.
+ */
+
+import {
+  parseCodexQuotaHeaders,
+  getCodexModelScope,
+  getCodexDualWindowCooldownMs,
+} from "../../executors/codex.ts";
+
+export type CodexQuotaPersistence = {
+  /** The merged providerSpecificData to persist (existing data + codexQuotaState [+ 429 cooldown]). */
+  nextProviderData: Record<string, unknown>;
+  /** The CODEX debug-log message to emit when a 429 exhausted a window, else null. */
+  exhaustionLog: string | null;
+};
+
+/**
+ * Build the providerSpecificData update for a Codex quota response. Returns null when the response
+ * carries no quota headers (nothing to persist). Pure: a function of the headers, the existing
+ * provider data, the model used for scope resolution, and the upstream status.
+ */
+export function buildCodexQuotaPersistence(opts: {
+  headers: Record<string, string>;
+  existingProviderData: Record<string, unknown>;
+  modelForScope: string;
+  status: number;
+}): CodexQuotaPersistence | null {
+  const { headers, existingProviderData, modelForScope, status } = opts;
+
+  const quota = parseCodexQuotaHeaders(headers);
+  if (!quota) return null;
+
+  const scope = getCodexModelScope(modelForScope);
+  const quotaState = {
+    usage5h: quota.usage5h,
+    limit5h: quota.limit5h,
+    resetAt5h: quota.resetAt5h,
+    usage7d: quota.usage7d,
+    limit7d: quota.limit7d,
+    resetAt7d: quota.resetAt7d,
+    scope,
+    updatedAt: new Date().toISOString(),
+  };
+
+  const nextProviderData: Record<string, unknown> = {
+    ...existingProviderData,
+    codexQuotaState: quotaState,
+  };
+
+  let exhaustionLog: string | null = null;
+
+  // T03/T09: on 429, persist exact reset time per scope to avoid global over-blocking.
+  // Use dual-window cooldown to distinguish short-term and weekly Codex exhaustion.
+  if (status === 429) {
+    const { cooldownMs, window: exhaustedWindow } = getCodexDualWindowCooldownMs(quota);
+    if (cooldownMs > 0) {
+      const scopeUntil = new Date(Date.now() + cooldownMs).toISOString();
+      const scopeMapRaw =
+        existingProviderData &&
+        typeof existingProviderData === "object" &&
+        existingProviderData.codexScopeRateLimitedUntil &&
+        typeof existingProviderData.codexScopeRateLimitedUntil === "object"
+          ? existingProviderData.codexScopeRateLimitedUntil
+          : {};
+
+      nextProviderData.codexScopeRateLimitedUntil = {
+        ...(scopeMapRaw as Record<string, unknown>),
+        [scope]: scopeUntil,
+      };
+      nextProviderData.codexExhaustedWindow = exhaustedWindow;
+      exhaustionLog = `Quota exhaustion on ${exhaustedWindow} window, cooldown until ${scopeUntil}`;
+    }
+  }
+
+  return { nextProviderData, exhaustionLog };
+}

--- a/open-sse/handlers/chatCore/requestFormat.ts
+++ b/open-sse/handlers/chatCore/requestFormat.ts
@@ -1,0 +1,82 @@
+/**
+ * chatCore request endpoint/format resolvers (Quality Gate v2 / Fase 9 — chatCore god-file
+ * decomposition, #3501).
+ *
+ * Pure slice of handleChatCore's request-setup phase: derives the wire-format facts of an inbound
+ * request from its endpoint, body, provider, and user-agent — the source format, whether it targets
+ * the Responses endpoint, native-Codex passthrough eligibility, Droid CLI / Copilot detection, and
+ * the effective client response format (an OpenAI Responses shape off a non-/responses, non-Droid
+ * endpoint collapses back to plain OpenAI). Side-effect-free; behaviour is byte-identical to the
+ * previous inline block. Sits alongside resolveChatCoreRequestSetup as the request-setup phase grows.
+ */
+
+import { detectFormatFromEndpoint } from "../../services/provider.ts";
+import { shouldUseNativeCodexPassthrough } from "./passthroughHelpers.ts";
+import { FORMATS } from "../../translator/formats.ts";
+
+/** True when the request originates from a Copilot client (matched by user-agent or any header). */
+function isCopilotClient(
+  headers: Headers | Record<string, unknown> | null | undefined,
+  userAgent?: string | null
+) {
+  const isMatch = (value: unknown) =>
+    typeof value === "string" && value.toLowerCase().includes("copilot");
+
+  if (isMatch(userAgent)) return true;
+
+  if (headers instanceof Headers) {
+    for (const [key, value] of headers as unknown as Iterable<[string, string]>) {
+      if (isMatch(key) || isMatch(value)) return true;
+    }
+  } else if (headers && typeof headers === "object") {
+    for (const [key, value] of Object.entries(headers)) {
+      if (isMatch(key) || isMatch(value)) return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Resolve the per-request endpoint/format facts at the top of handleChatCore. Pure: a function of
+ * the inbound endpoint, the (possibly already-mutated) body, the resolved provider, and the
+ * user-agent.
+ */
+export function resolveChatCoreRequestFormat(opts: {
+  clientRawRequest:
+    | { endpoint?: unknown; headers?: Headers | Record<string, unknown> | null }
+    | null
+    | undefined;
+  body: unknown;
+  provider: string | null | undefined;
+  userAgent: string | null | undefined;
+}) {
+  const { clientRawRequest, body, provider, userAgent } = opts;
+  const endpointPath = String(clientRawRequest?.endpoint || "");
+  const sourceFormat = detectFormatFromEndpoint(body, endpointPath);
+  const isResponsesEndpoint =
+    /\/responses(?=\/|$)/i.test(endpointPath) || /^responses(?=\/|$)/i.test(endpointPath);
+  const nativeCodexPassthrough = shouldUseNativeCodexPassthrough({
+    provider,
+    sourceFormat,
+    endpointPath,
+  });
+  const isDroidCLI =
+    userAgent?.toLowerCase().includes("droid") || userAgent?.toLowerCase().includes("codex-cli");
+  const copilotCompatibleReasoning = isCopilotClient(clientRawRequest?.headers, userAgent);
+  const clientResponseFormat =
+    sourceFormat === FORMATS.OPENAI_RESPONSES && !isResponsesEndpoint && !isDroidCLI
+      ? FORMATS.OPENAI
+      : sourceFormat;
+  return {
+    endpointPath,
+    sourceFormat,
+    isResponsesEndpoint,
+    nativeCodexPassthrough,
+    isDroidCLI,
+    copilotCompatibleReasoning,
+    clientResponseFormat,
+  };
+}
+
+export type ChatCoreRequestFormat = ReturnType<typeof resolveChatCoreRequestFormat>;

--- a/tests/unit/chatcore-codex-quota.test.ts
+++ b/tests/unit/chatcore-codex-quota.test.ts
@@ -1,0 +1,106 @@
+// tests/unit/chatcore-codex-quota.test.ts
+// Characterization of buildCodexQuotaPersistence — the pure core of handleChatCore's
+// persistCodexQuotaState, extracted during the chatCore god-file decomposition (#3501). Locks the
+// shape of the persisted providerSpecificData: the codexQuotaState snapshot, the existing-data
+// passthrough, and the 429 dual-window exhaustion fields (codexScopeRateLimitedUntil /
+// codexExhaustedWindow) plus the debug-log message. The handler keeps the DB write, the
+// preflight-cache invalidation, and the log emission; this function only builds the data.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildCodexQuotaPersistence } from "../../open-sse/handlers/chatCore/codexQuota.ts";
+import { getCodexModelScope } from "../../open-sse/executors/codex.ts";
+
+const MODEL = "gpt-5-codex";
+const ISO = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+
+function quotaHeaders(over: Record<string, string> = {}) {
+  return {
+    "x-codex-5h-usage": "50",
+    "x-codex-5h-limit": "100",
+    "x-codex-5h-reset-at": "2999-01-01T00:00:00.000Z",
+    "x-codex-7d-usage": "10",
+    "x-codex-7d-limit": "100",
+    "x-codex-7d-reset-at": "2999-01-08T00:00:00.000Z",
+    ...over,
+  };
+}
+
+test("returns null when the response carries no codex quota headers", () => {
+  assert.equal(
+    buildCodexQuotaPersistence({ headers: {}, existingProviderData: {}, modelForScope: MODEL, status: 200 }),
+    null
+  );
+  assert.equal(
+    buildCodexQuotaPersistence({ headers: { "content-type": "application/json" }, existingProviderData: {}, modelForScope: MODEL, status: 200 }),
+    null
+  );
+});
+
+test("builds codexQuotaState (parsed numbers + scope + updatedAt) and preserves existing provider data", () => {
+  const built = buildCodexQuotaPersistence({
+    headers: quotaHeaders(),
+    existingProviderData: { keepMe: "yes", apiKeyHealth: { primary: {} } },
+    modelForScope: MODEL,
+    status: 200,
+  });
+  assert.ok(built);
+  const qs = built.nextProviderData.codexQuotaState as Record<string, unknown>;
+  assert.equal(qs.usage5h, 50);
+  assert.equal(qs.limit5h, 100);
+  assert.equal(qs.usage7d, 10);
+  assert.equal(qs.limit7d, 100);
+  assert.equal(qs.scope, getCodexModelScope(MODEL));
+  assert.match(String(qs.updatedAt), ISO);
+  // existing keys passed through, not dropped
+  assert.equal(built.nextProviderData.keepMe, "yes");
+  assert.deepEqual(built.nextProviderData.apiKeyHealth, { primary: {} });
+  // non-429 → no exhaustion fields, no log
+  assert.equal(built.exhaustionLog, null);
+  assert.equal(built.nextProviderData.codexScopeRateLimitedUntil, undefined);
+  assert.equal(built.nextProviderData.codexExhaustedWindow, undefined);
+});
+
+test("429 with a near-exhausted 5h window records the per-scope cooldown + window + log", () => {
+  const built = buildCodexQuotaPersistence({
+    headers: quotaHeaders({ "x-codex-5h-usage": "100" }), // ratio 1.0 >= 0.95, reset far in the future
+    existingProviderData: {},
+    modelForScope: MODEL,
+    status: 429,
+  });
+  assert.ok(built);
+  assert.equal(built.nextProviderData.codexExhaustedWindow, "5h");
+  const scope = getCodexModelScope(MODEL);
+  const scopeMap = built.nextProviderData.codexScopeRateLimitedUntil as Record<string, string>;
+  assert.ok(scopeMap[scope]?.startsWith("2999-01-01T00:00:00"));
+  assert.match(
+    String(built.exhaustionLog),
+    /^Quota exhaustion on 5h window, cooldown until 2999-01-01T00:00:00/
+  );
+});
+
+test("429 merges into an existing codexScopeRateLimitedUntil map without dropping other scopes", () => {
+  const built = buildCodexQuotaPersistence({
+    headers: quotaHeaders({ "x-codex-5h-usage": "100" }),
+    existingProviderData: { codexScopeRateLimitedUntil: { "other-scope": "2999-12-31T00:00:00.000Z" } },
+    modelForScope: MODEL,
+    status: 429,
+  });
+  assert.ok(built);
+  const scopeMap = built.nextProviderData.codexScopeRateLimitedUntil as Record<string, string>;
+  assert.equal(scopeMap["other-scope"], "2999-12-31T00:00:00.000Z");
+  assert.ok(scopeMap[getCodexModelScope(MODEL)]);
+});
+
+test("429 below the exhaustion threshold builds the snapshot but no cooldown / no log", () => {
+  const built = buildCodexQuotaPersistence({
+    headers: quotaHeaders({ "x-codex-5h-usage": "1", "x-codex-7d-usage": "1" }), // ratios well under 0.95
+    existingProviderData: {},
+    modelForScope: MODEL,
+    status: 429,
+  });
+  assert.ok(built);
+  assert.ok(built.nextProviderData.codexQuotaState);
+  assert.equal(built.exhaustionLog, null);
+  assert.equal(built.nextProviderData.codexScopeRateLimitedUntil, undefined);
+  assert.equal(built.nextProviderData.codexExhaustedWindow, undefined);
+});

--- a/tests/unit/chatcore-request-format.test.ts
+++ b/tests/unit/chatcore-request-format.test.ts
@@ -1,0 +1,103 @@
+// tests/unit/chatcore-request-format.test.ts
+// Characterization of resolveChatCoreRequestFormat — the endpoint/format resolution slice extracted
+// from the top of handleChatCore (chatCore god-file decomposition, #3501). Locks the endpointPath
+// construction, the /responses detection, the nativeCodexPassthrough + isDroidCLI + copilot wiring,
+// and the clientResponseFormat downgrade (OpenAI Responses shape off a non-/responses, non-Droid
+// endpoint collapses to plain OpenAI).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { resolveChatCoreRequestFormat } from "../../open-sse/handlers/chatCore/requestFormat.ts";
+import { shouldUseNativeCodexPassthrough } from "../../open-sse/handlers/chatCore/passthroughHelpers.ts";
+import { FORMATS } from "../../open-sse/translator/formats.ts";
+
+const base = { body: { messages: [{ role: "user", content: "hi" }] }, provider: "openai", userAgent: "unit-test" };
+
+test("chat/completions endpoint → openai source, not a responses endpoint, no downgrade", () => {
+  const r = resolveChatCoreRequestFormat({
+    ...base,
+    clientRawRequest: { endpoint: "/v1/chat/completions", headers: new Headers() },
+  });
+  assert.equal(r.endpointPath, "/v1/chat/completions");
+  assert.equal(r.sourceFormat, FORMATS.OPENAI);
+  assert.equal(r.isResponsesEndpoint, false);
+  assert.equal(r.clientResponseFormat, FORMATS.OPENAI);
+  assert.equal(r.nativeCodexPassthrough, false); // provider !== codex
+  assert.equal(r.isDroidCLI, false);
+  assert.equal(r.copilotCompatibleReasoning, false);
+});
+
+test("/responses endpoint → openai-responses source + isResponsesEndpoint, kept (no downgrade)", () => {
+  const r = resolveChatCoreRequestFormat({
+    body: { input: "x" },
+    provider: "openai",
+    userAgent: "unit-test",
+    clientRawRequest: { endpoint: "/v1/responses", headers: new Headers() },
+  });
+  assert.equal(r.sourceFormat, FORMATS.OPENAI_RESPONSES);
+  assert.equal(r.isResponsesEndpoint, true);
+  assert.equal(r.clientResponseFormat, FORMATS.OPENAI_RESPONSES);
+});
+
+test("Responses-shaped body on a /chat/completions endpoint downgrades clientResponseFormat to openai", () => {
+  const r = resolveChatCoreRequestFormat({
+    body: { input: "describe" }, // input + no messages → openai-responses via body
+    provider: "openai",
+    userAgent: "unit-test",
+    clientRawRequest: { endpoint: "/v1/chat/completions", headers: new Headers() },
+  });
+  assert.equal(r.sourceFormat, FORMATS.OPENAI_RESPONSES);
+  assert.equal(r.isResponsesEndpoint, false);
+  assert.equal(r.clientResponseFormat, FORMATS.OPENAI); // downgraded
+});
+
+test("Droid CLI suppresses the downgrade (clientResponseFormat stays openai-responses)", () => {
+  const r = resolveChatCoreRequestFormat({
+    body: { input: "describe" },
+    provider: "openai",
+    userAgent: "Droid/1.2 codex-cli",
+    clientRawRequest: { endpoint: "/v1/chat/completions", headers: new Headers() },
+  });
+  assert.equal(r.isDroidCLI, true);
+  assert.equal(r.sourceFormat, FORMATS.OPENAI_RESPONSES);
+  assert.equal(r.clientResponseFormat, FORMATS.OPENAI_RESPONSES); // !isDroidCLI is false → no downgrade
+});
+
+test("copilotCompatibleReasoning detects copilot via header or user-agent", () => {
+  const viaUa = resolveChatCoreRequestFormat({
+    ...base,
+    userAgent: "GitHubCopilotChat/0.1",
+    clientRawRequest: { endpoint: "/v1/chat/completions", headers: new Headers() },
+  });
+  assert.equal(viaUa.copilotCompatibleReasoning, true);
+
+  const viaHeader = resolveChatCoreRequestFormat({
+    ...base,
+    clientRawRequest: {
+      endpoint: "/v1/chat/completions",
+      headers: new Headers({ "x-client": "copilot-vscode" }),
+    },
+  });
+  assert.equal(viaHeader.copilotCompatibleReasoning, true);
+});
+
+test("nativeCodexPassthrough delegates to shouldUseNativeCodexPassthrough (codex + responses)", () => {
+  const r = resolveChatCoreRequestFormat({
+    body: { input: "x" },
+    provider: "codex",
+    userAgent: "unit-test",
+    clientRawRequest: { endpoint: "/v1/responses", headers: new Headers() },
+  });
+  assert.equal(
+    r.nativeCodexPassthrough,
+    shouldUseNativeCodexPassthrough({
+      provider: "codex",
+      sourceFormat: r.sourceFormat,
+      endpointPath: r.endpointPath,
+    })
+  );
+});
+
+test("missing clientRawRequest → empty endpointPath", () => {
+  const r = resolveChatCoreRequestFormat({ ...base, clientRawRequest: null });
+  assert.equal(r.endpointPath, "");
+});


### PR DESCRIPTION
## O quê

Próximo incremento da decomposição do god-file `chatCore.ts` (QG v2 Fase 9 T5, #3501). Move o bloco de **resolução de endpoint/formato** do topo de `handleChatCore` para o novo leaf puro `open-sse/handlers/chatCore/requestFormat.ts` (`resolveChatCoreRequestFormat`), ao lado de `resolveChatCoreRequestSetup` (fase de request-setup).

> **Stacked sobre o #4492** (4º da cadeia #4477 → #4491 → #4492 → este). Base aponta para `refactor/qg-chatcore-codexquota`; o GitHub re-aponta a cadeia automaticamente conforme os pais mergeiam.

## Como (preservação de comportamento)

- Os 7 derivados (`endpointPath` / `sourceFormat` / `isResponsesEndpoint` / `nativeCodexPassthrough` / `isDroidCLI` / `copilotCompatibleReasoning` / `clientResponseFormat`) movem byte-idênticos para o leaf puro; o handler **desestrutura** o resultado, então todo uso downstream fica inalterado.
- A função local `isCopilotClient` (usada **só** por esse bloco) vira helper **privado** do leaf.
- Import órfão `detectFormatFromEndpoint` migra para o leaf (`getTargetFormat` permanece no import de `provider.ts`). `shouldUseNativeCodexPassthrough` e `FORMATS` seguem no handler (re-exportado / usado em 26 pontos).
- Tipo via `ReturnType<typeof resolveChatCoreRequestFormat>` (sem anotação manual divergente).

## Gates

- **file-size**: `chatCore.ts` 5019→**4993** (shrink −26, cruza abaixo de 5000); baseline ratchetado.
- **complexity**: 1905 = baseline 1905 (neutro).
- **typecheck:core**: exit 0.
- **Testes**: `tests/unit/chatcore-request-format.test.ts` — 7 casos (incl. o downgrade `OpenAI-Responses → OpenAI` quando a forma Responses chega por endpoint não-`/responses` e não-Droid, e a supressão desse downgrade pelo Droid CLI; delegação do `nativeCodexPassthrough`; detecção Copilot por header/UA). `chatcore-imports-cleanly` ✓ + 207/207 na suíte chatcore + `sse-auth` (excluído só o `translation-paths` flaky **pré-existente**).

Extração de god-file sem mudança de comportamento em runtime.