### PR TITLE
fix: allow combo fallback on context overflow and param validation 400s; preserve upstream error codes

### DIFF
--- a/open-sse/services/accountFallback.ts
+++ b/open-sse/services/accountFallback.ts
@@ -251,6 +251,15 @@ const MALFORMED_REQUEST_PATTERNS = [
   /tool_call.*name.*(?:blank|empty|missing)/i,
 ];
 
+// Parameter validation errors — model-specific constraints (different models = different limits)
+const PARAM_VALIDATION_PATTERNS = [
+  /max_tokens.*illegal/i,
+  /max_tokens.*must be/i,
+  /max_tokens.*range/i,
+  /parameter is illegal/i,
+  /is illegal.*range/i,
+];
+
 /**
  * T06: Returns true if response body indicates the account is permanently deactivated.
  */
@@ -1575,9 +1584,10 @@ export function checkFallbackError(
 
     const isOverflow = CONTEXT_OVERFLOW_PATTERNS.some((p) => p.test(errorStr));
     const isMalformed = MALFORMED_REQUEST_PATTERNS.some((p) => p.test(errorStr));
+    const isParamValidation = PARAM_VALIDATION_PATTERNS.some((p) => p.test(errorStr));
     const isModelAccessDenied = isModelAccessDeniedStructured || matchesModelAccessPattern;
 
-    if (isOverflow || isMalformed || isModelAccessDenied) {
+    if (isOverflow || isMalformed || isParamValidation || isModelAccessDenied) {
       return {
         shouldFallback: true,
         cooldownMs: 0,

--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -521,6 +521,27 @@ export async function buildAutoCandidates(
  * @param {Object} options.log - Logger object
  * @returns {Promise<Response>}
  */
+// #2101 guard helpers: a 400 caused by context overflow or parameter validation
+// is NOT body-specific — different combo targets have different context windows /
+// output limits, so the request should fall through to the next target instead of
+// being short-circuited. Exported as pure predicates so the guard is unit-testable.
+/** @param {string} errorText */
+export function isContextOverflow400(errorText) {
+  return (
+    /\bcontext.*(?:length_exceeded|too long|overflow|exceeded|window|limit)\b/i.test(errorText) ||
+    /exceeds.*context/i.test(errorText) ||
+    /your input exceeds/i.test(errorText)
+  );
+}
+/** @param {string} errorText */
+export function isParamValidation400(errorText) {
+  return (
+    /\bmax_tokens\b.*(?:illegal|must|range|invalid)/i.test(errorText) ||
+    /\bparameter is illegal\b/i.test(errorText) ||
+    /\bis illegal.*range\b/i.test(errorText)
+  );
+}
+
 /** @param {object} options */
 export async function handleComboChat({
   body,
@@ -1779,13 +1800,18 @@ export async function handleComboChat({
             exhaustedLogLevel: "info",
           });
 
-          // #2101: Prevent infinite fallback loops with 400 Bad Request errors that indicate
-          // request-body-specific issues (context overflow, malformed request, model access denied).
-          // These errors are unlikely to be resolved by trying different target models since
-          // the same problematic request body would be sent to all targets.
+          // #2101: Prevent infinite fallback loops with 400 Bad Request errors that are genuinely
+          // body-specific (malformed JSON, bad format, missing required fields).
+          // Context overflow and parameter validation errors are NOT body-specific:
+          // - Context overflow: different models have different context windows
+          // - Max_tokens / param errors: different models have different output limits
+          // - Model access denied: different providers serve different model sets
+          // These should fall through so the next combo target can try.
           if (
             result.status === 400 &&
             fallbackResult.shouldFallback &&
+            !isContextOverflow400(errorText) &&
+            !isParamValidation400(errorText) &&
             (fallbackResult.reason === RateLimitReason.MODEL_CAPACITY ||
               errorText.toLowerCase().includes("context") ||
               errorText.toLowerCase().includes("prompt") ||

--- a/open-sse/translator/response/openai-responses.ts
+++ b/open-sse/translator/response/openai-responses.ts
@@ -465,7 +465,7 @@ function flushEvents(state) {
   return events;
 }
 
-function normalizeUpstreamFailure(data, fallbackType = "server_error") {
+export function normalizeUpstreamFailure(data, fallbackType = "server_error") {
   const response = data?.response && typeof data.response === "object" ? data.response : null;
   const error =
     response?.error && typeof response.error === "object"
@@ -482,10 +482,29 @@ function normalizeUpstreamFailure(data, fallbackType = "server_error") {
         ? data.message
         : "Upstream failure";
 
+  // Preserve upstream error semantics:
+  // - context_length_exceeded → 400 (client can retry with smaller context)
+  // - rate_limit_exceeded → 429 (client should back off)
+  // - Everything else → 502 (upstream failure)
+  const isContextOverflow = code === "context_length_exceeded";
+  const isRateLimit = code === "rate_limit_exceeded" || code === "rate_limited";
+  let status: number;
+  let type: string;
+  if (isRateLimit) {
+    status = 429;
+    type = "rate_limit_error";
+  } else if (isContextOverflow) {
+    status = 400;
+    type = "invalid_request_error";
+  } else {
+    status = 502;
+    type = fallbackType;
+  }
+
   return {
-    status: code === "rate_limit_exceeded" ? 429 : 502,
-    type: code === "rate_limit_exceeded" ? "rate_limit_error" : fallbackType,
-    code: code || (fallbackType === "rate_limit_error" ? "rate_limit_exceeded" : "bad_gateway"),
+    status,
+    type,
+    code: code || (isRateLimit ? "rate_limit_exceeded" : "bad_gateway"),
     message,
   };
 }

--- a/tests/unit/combo-param-validation-fallback-4519.test.ts
+++ b/tests/unit/combo-param-validation-fallback-4519.test.ts
@@ -1,0 +1,60 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// #4519 — allow combo fallback on context-overflow / param-validation 400s and
+// preserve upstream error semantics. Three regression guards:
+//   1. accountFallback.checkFallbackError classifies param-validation 400s as
+//      fallback-worthy with zero cooldown.
+//   2. combo guard predicates (isContextOverflow400 / isParamValidation400) let
+//      those 400s fall through to the next target instead of short-circuiting.
+//   3. openai-responses.normalizeUpstreamFailure keeps context_length_exceeded as
+//      400 and rate-limit as 429 (instead of rewriting everything to 502).
+
+const { checkFallbackError } = await import("../../open-sse/services/accountFallback.ts");
+const { isContextOverflow400, isParamValidation400 } = await import(
+  "../../open-sse/services/combo.ts"
+);
+const { normalizeUpstreamFailure } = await import(
+  "../../open-sse/translator/response/openai-responses.ts"
+);
+
+test("#4519 checkFallbackError treats per-model max_tokens 400 as fallback-worthy with zero cooldown", () => {
+  const res = checkFallbackError(
+    400,
+    "The max_tokens parameter is illegal.：限制数值范围[1,131072]"
+  );
+  assert.equal(res.shouldFallback, true);
+  assert.equal(res.cooldownMs, 0);
+});
+
+test("#4519 combo guard: context-overflow and param-validation 400 texts are recognized", () => {
+  assert.equal(isContextOverflow400("This model's context_length_exceeded for the input"), true);
+  assert.equal(isContextOverflow400("your input exceeds the allowed size"), true);
+  assert.equal(isParamValidation400("max_tokens must be in range [1,131072]"), true);
+  assert.equal(isParamValidation400("The parameter is illegal"), true);
+});
+
+test("#4519 combo guard: a genuinely body-specific 400 is NOT classified as overflow/param", () => {
+  const malformed = "Invalid JSON: unexpected token at position 12";
+  assert.equal(isContextOverflow400(malformed), false);
+  assert.equal(isParamValidation400(malformed), false);
+});
+
+test("#4519 normalizeUpstreamFailure preserves context_length_exceeded as 400", () => {
+  const out = normalizeUpstreamFailure({
+    error: { code: "context_length_exceeded", message: "too long" },
+  });
+  assert.equal(out.status, 400);
+  assert.equal(out.type, "invalid_request_error");
+});
+
+test("#4519 normalizeUpstreamFailure keeps rate-limit as 429 and unknown as 502", () => {
+  const rl = normalizeUpstreamFailure({
+    error: { code: "rate_limit_exceeded", message: "slow down" },
+  });
+  assert.equal(rl.status, 429);
+  assert.equal(rl.type, "rate_limit_error");
+
+  const unknown = normalizeUpstreamFailure({ error: { code: "weird_error", message: "boom" } });
+  assert.equal(unknown.status, 502);
+});


### PR DESCRIPTION
## Summary

Three coordinated fixes for 400 errors that kill combo fallback when they should not.

## Changes

### 1. combo.ts — Relax #2101 guard for context overflow and param validation

The #2101 guard kills combo fallback for all 400s matching "body-specific" error patterns. Context overflow and param validation errors are NOT body-specific — different models have different context windows and output limits. Added explicit exclusion.

### 2. accountFallback.ts — Add param validation pattern recognition

Patterns for parameter validation errors (e.g. "The max_tokens parameter is illegal") are now classified as shouldFallback: true with MODEL_CAPACITY reason and zero cooldown, so the combo falls through.

### 3. openai-responses.ts — Preserve upstream error codes in normalizeUpstreamFailure

Was rewriting all non-rate-limit errors to 502 bad_gateway. Now preserves upstream semantics:
- context_length_exceeded → 400 invalid_request_error
- rate_limit_exceeded / rate_limited → 429 rate_limit_error
- Everything else → 502 bad_gateway

## Testing

- All 86 combo routing and fallback-resilience tests pass
- All translator and error-sanitizer tests pass
- Pre-commit hooks pass
- codex.ts is untouched (zero diff vs upstream)

## Test plan

1. Create a combo with codex/gpt-5.5 as first target and a larger-context model as fallback
2. Send a prompt exceeding 400K tokens
3. Without fix: 400 context_length_exceeded hits #2101 guard, combo dies
4. With fix: 400 context_length_exceeded excluded from guard, combo falls through to next target
5. Also test: combo with zai-org/GLM-5.2 (max_tokens 131K cap) and another model — 400 on GLM falls through