### PR TITLE
feat(webhooks): enrich telegram request notifications

### DIFF
--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -1549,6 +1549,11 @@ export async function handleComboChat({
               combo: combo.name,
               provider,
               model: modelStr,
+              account:
+                typeof target.label === "string" && target.label.trim().length > 0
+                  ? target.label.trim()
+                  : "",
+              accountId: target.connectionId ?? "",
               latencyMs,
               fallbackCount,
             });

--- a/src/lib/webhooks/integrations/telegram.ts
+++ b/src/lib/webhooks/integrations/telegram.ts
@@ -1,5 +1,6 @@
 import type { WebhookEvent } from "../eventDescriptions";
 import { EVENT_DESCRIPTIONS } from "../eventDescriptions";
+import { getAccountDisplayName } from "@/lib/display/names";
 
 export interface TelegramSendMessagePayload {
   chat_id: string;
@@ -32,10 +33,29 @@ export function buildTelegramPayload(
   const model = typeof data.model === "string" ? escapeMd(data.model) : null;
   const error = typeof data.error === "string" ? escapeMd(data.error) : null;
   const provider = typeof data.provider === "string" ? escapeMd(data.provider) : null;
+  const combo = typeof data.combo === "string" ? escapeMd(data.combo) : null;
+  const account =
+    typeof data.account === "string" && data.account.trim().length > 0
+      ? escapeMd(data.account)
+      : null;
+  const accountId = typeof data.accountId === "string" ? data.accountId.trim() : null;
+  const accountDisplay =
+    account ||
+    (accountId ? escapeMd(getAccountDisplayName({ id: accountId, name: null })) : null);
+  const latencyMs =
+    typeof data.latencyMs === "number" && Number.isFinite(data.latencyMs) ? data.latencyMs : null;
+  const fallbackCount =
+    typeof data.fallbackCount === "number" && Number.isFinite(data.fallbackCount)
+      ? data.fallbackCount
+      : null;
 
   const lines: string[] = [`${desc.emoji} *${desc.label}*`];
   if (model) lines.push(`Model: \`${model}\``);
-  if (provider && !model) lines.push(`Provider: \`${provider}\``);
+  if (provider) lines.push(`Provider: \`${provider}\``);
+  if (accountDisplay) lines.push(`Account: \`${accountDisplay}\``);
+  if (combo) lines.push(`Combo: \`${combo}\``);
+  if (latencyMs !== null) lines.push(`Latency: \`${latencyMs}ms\``);
+  if (fallbackCount !== null) lines.push(`Fallbacks: \`${fallbackCount}\``);
   if (error) lines.push(`Error: \`${error}\``);
   lines.push(`_OmniRoute · ${new Date().toISOString()}_`);
 

--- a/tests/unit/webhook-telegram-dispatcher.test.ts
+++ b/tests/unit/webhook-telegram-dispatcher.test.ts
@@ -36,6 +36,41 @@ test("buildTelegramPayload — request.failed includes model and event label", (
   assert.equal(payload.parse_mode, "Markdown");
 });
 
+test("buildTelegramPayload — request.completed includes provider, account, combo, and metrics", () => {
+  const payload = buildTelegramPayload(
+    "request.completed",
+    {
+      model: "codex/gpt-5.5",
+      provider: "codex",
+      account: "Workspace Principal",
+      combo: "auto-fallback",
+      latencyMs: 1421,
+      fallbackCount: 2,
+    },
+    "-100123"
+  );
+
+  assert.ok(payload.text.includes("Model: `codex/gpt-5.5`"));
+  assert.ok(payload.text.includes("Provider: `codex`"));
+  assert.ok(payload.text.includes("Account: `Workspace Principal`"));
+  assert.ok(payload.text.includes("Combo: `auto-fallback`"));
+  assert.ok(payload.text.includes("Latency: `1421ms`"));
+  assert.ok(payload.text.includes("Fallbacks: `2`"));
+});
+
+test("buildTelegramPayload — accountId falls back to short account label", () => {
+  const payload = buildTelegramPayload(
+    "request.completed",
+    {
+      provider: "codex",
+      accountId: "12345678-abcd-efgh-ijkl-1234567890ab",
+    },
+    "-100123"
+  );
+
+  assert.ok(payload.text.includes("Account: `Account #123456`"));
+});
+
 test("buildTelegramPayload — chat_id matches provided value for groups", () => {
   const payload = buildTelegramPayload("test.ping", { message: "ping" }, "-1001234567890");
   assert.equal(payload.chat_id, "-1001234567890");


### PR DESCRIPTION
## Summary
- enrich Telegram request.completed notifications with provider/account/combo/latency/fallback details
- send empty strings instead of undefined for missing account fields
- add focused tests for Telegram payload rendering