### PR TITLE
fix(catalog): shorten no-thinking gateway prefix to `no-think/`

### DIFF
--- a/open-sse/utils/noThinkingAlias.ts
+++ b/open-sse/utils/noThinkingAlias.ts
@@ -6,7 +6,7 @@
  * thinking-capable model into a no-thinking mode purely by *model selection*, the
  * gateway exposes a synthetic catalog id:
  *
- *     claude-3-omniroute-no-thinking/<provider>/<model>
+ *     no-think/<provider>/<model>
  *
  * When such an id arrives on a request we strip the prefix back to the real
  * `<provider>/<model>` and suppress reasoning (`thinking:{type:"disabled"}` for the
@@ -21,7 +21,7 @@
  */
 import { getModelSpec } from "@/shared/constants/modelSpecs";
 
-export const NO_THINKING_PREFIX = "claude-3-omniroute-no-thinking/";
+export const NO_THINKING_PREFIX = "no-think/";
 
 /** True when `modelId` carries the no-thinking gateway prefix. */
 export function isNoThinkingAlias(modelId: unknown): modelId is string {

--- a/src/shared/constants/modelSpecs.ts
+++ b/src/shared/constants/modelSpecs.ts
@@ -26,7 +26,7 @@ export interface ModelSpec {
   // (2026-05-19): "Any request that tries to set a fixed thinking budget gets a 400 error."
   adaptiveThinkingOnly?: boolean;
   // Explicit operator override for the no-thinking gateway alias (Fase 8.1). When unset,
-  // the catalog auto-advertises a `claude-3-omniroute-no-thinking/…` variant for
+  // the catalog auto-advertises a `no-think/…` variant for
   // Claude-family thinking-capable models that honor `disabled`. Set `true` to force the
   // variant on for any other model, or `false` to suppress it. See open-sse/utils/noThinkingAlias.ts.
   noThinkingAlias?: boolean;

--- a/src/sse/handlers/chat.ts
+++ b/src/sse/handlers/chat.ts
@@ -243,7 +243,7 @@ export async function handleChat(
   // Log request endpoint and model
   const url = new URL(request.url);
 
-  // No-thinking gateway alias (Fase 8.1): `claude-3-omniroute-no-thinking/<provider>/<model>`
+  // No-thinking gateway alias (Fase 8.1): `no-think/<provider>/<model>`
   // resolves back to the real model with reasoning suppressed in place, before any
   // model resolution / combo routing sees it. Claude/Messages path forces
   // `thinking:{type:"disabled"}`; OpenAI path drops the reasoning fields.

--- a/tests/unit/no-thinking-alias.test.ts
+++ b/tests/unit/no-thinking-alias.test.ts
@@ -14,11 +14,11 @@ import {
 // ── prefix predicates ────────────────────────────────────────────────────────
 
 test("NO_THINKING_PREFIX is the documented gateway prefix", () => {
-  assert.equal(NO_THINKING_PREFIX, "claude-3-omniroute-no-thinking/");
+  assert.equal(NO_THINKING_PREFIX, "no-think/");
 });
 
 test("isNoThinkingAlias detects the prefix only", () => {
-  assert.equal(isNoThinkingAlias("claude-3-omniroute-no-thinking/anthropic/claude-opus-4-5"), true);
+  assert.equal(isNoThinkingAlias("no-think/anthropic/claude-opus-4-5"), true);
   assert.equal(isNoThinkingAlias("anthropic/claude-opus-4-5"), false);
   assert.equal(isNoThinkingAlias("claude-opus-4-5"), false);
   // non-strings never match
@@ -28,7 +28,7 @@ test("isNoThinkingAlias detects the prefix only", () => {
 
 test("stripNoThinkingAlias unwraps the prefix and passes plain ids through", () => {
   assert.equal(
-    stripNoThinkingAlias("claude-3-omniroute-no-thinking/anthropic/claude-opus-4-5"),
+    stripNoThinkingAlias("no-think/anthropic/claude-opus-4-5"),
     "anthropic/claude-opus-4-5"
   );
   assert.equal(stripNoThinkingAlias("claude-opus-4-5"), "claude-opus-4-5");
@@ -37,7 +37,7 @@ test("stripNoThinkingAlias unwraps the prefix and passes plain ids through", () 
 test("toNoThinkingAlias round-trips with stripNoThinkingAlias", () => {
   const real = "anthropic/claude-sonnet-4-6";
   const alias = toNoThinkingAlias(real);
-  assert.equal(alias, "claude-3-omniroute-no-thinking/anthropic/claude-sonnet-4-6");
+  assert.equal(alias, "no-think/anthropic/claude-sonnet-4-6");
   assert.equal(isNoThinkingAlias(alias), true);
   assert.equal(stripNoThinkingAlias(alias), real);
 });
@@ -46,7 +46,7 @@ test("toNoThinkingAlias round-trips with stripNoThinkingAlias", () => {
 
 test("applyNoThinkingAlias rewrites the model and disables thinking (Claude format)", () => {
   const body: Record<string, unknown> = {
-    model: "claude-3-omniroute-no-thinking/anthropic/claude-opus-4-5",
+    model: "no-think/anthropic/claude-opus-4-5",
     thinking: { type: "enabled", budget_tokens: 8000 },
     reasoning_effort: "high",
     messages: [],
@@ -61,7 +61,7 @@ test("applyNoThinkingAlias rewrites the model and disables thinking (Claude form
 
 test("applyNoThinkingAlias strips reasoning fields without a thinking block (OpenAI format)", () => {
   const body: Record<string, unknown> = {
-    model: "claude-3-omniroute-no-thinking/openai/gpt-5.4",
+    model: "no-think/openai/gpt-5.4",
     reasoning_effort: "high",
     reasoning: { effort: "high" },
     messages: [],
@@ -90,12 +90,12 @@ test("applyNoThinkingAlias is a no-op for plain models", () => {
 });
 
 test("applyNoThinkingAlias ignores a malformed prefix-only model", () => {
-  const body: Record<string, unknown> = { model: "claude-3-omniroute-no-thinking/" };
+  const body: Record<string, unknown> = { model: "no-think/" };
   const res = applyNoThinkingAlias(body, { claudeFormat: true });
   assert.equal(res.applied, false);
   assert.equal(
     body.model,
-    "claude-3-omniroute-no-thinking/",
+    "no-think/",
     "left untouched when nothing follows the prefix"
   );
 });
@@ -118,7 +118,7 @@ test("shouldExposeNoThinkingAlias rejects models where suppression is meaningles
   assert.equal(shouldExposeNoThinkingAlias(entry("my-combo", "combo")), false);
   // never double-alias
   assert.equal(
-    shouldExposeNoThinkingAlias(entry("claude-3-omniroute-no-thinking/anthropic/claude-opus-4-5")),
+    shouldExposeNoThinkingAlias(entry("no-think/anthropic/claude-opus-4-5")),
     false
   );
 });
@@ -128,15 +128,15 @@ test("appendNoThinkingVariants adds one variant per eligible model and preserves
   const out = appendNoThinkingVariants(models);
   const ids = out.map((m) => m.id);
   assert.ok(
-    ids.includes("claude-3-omniroute-no-thinking/claude-opus-4-5"),
+    ids.includes("no-think/claude-opus-4-5"),
     "eligible model gets a variant"
   );
   assert.ok(
-    !ids.includes("claude-3-omniroute-no-thinking/gpt-4o"),
+    !ids.includes("no-think/gpt-4o"),
     "non-thinking model has no variant"
   );
   assert.ok(
-    !ids.includes("claude-3-omniroute-no-thinking/claude-fable-5"),
+    !ids.includes("no-think/claude-fable-5"),
     "reject-disabled model has no variant"
   );
   assert.equal(out.length, models.length + 1, "exactly one variant appended");
@@ -155,11 +155,11 @@ test("appendNoThinkingVariants normalizes alias prefix to canonical when aliasTo
   const out = appendNoThinkingVariants(models, aliasToCanonical);
   const ids = out.map((m) => m.id);
   assert.ok(
-    ids.includes("claude-3-omniroute-no-thinking/claude/claude-opus-4-5"),
+    ids.includes("no-think/claude/claude-opus-4-5"),
     "uses canonical prefix"
   );
   assert.ok(
-    !ids.includes("claude-3-omniroute-no-thinking/cc/claude-opus-4-5"),
+    !ids.includes("no-think/cc/claude-opus-4-5"),
     "alias prefix not used"
   );
 });
@@ -169,7 +169,7 @@ test("appendNoThinkingVariants keeps alias prefix when no map is provided", () =
   const out = appendNoThinkingVariants(models);
   const ids = out.map((m) => m.id);
   assert.ok(
-    ids.includes("claude-3-omniroute-no-thinking/cc/claude-opus-4-5"),
+    ids.includes("no-think/cc/claude-opus-4-5"),
     "alias prefix preserved"
   );
 });


### PR DESCRIPTION
## Problem

The current no-thinking gateway prefix `claude-3-omniroute-no-thinking/` is **34 characters long**. When combined with a provider prefix and model name, the full ID routinely exceeds the visible width of terminal-based AI clients.

In OpenCode and OpenClaw (Claude-based terminal clients), the model picker column is fixed-width. With the old prefix, every single no-thinking variant is truncated — users can see `claude-3-omniroute-no-thinking/cc/claude-o` but not the actual model name at the end. This makes the entries effectively unusable for manual selection.

**Screenshot from OpenCode model picker (searching for "thinking"):**
<img width="576" height="579" alt="image" src="https://github.com/user-attachments/assets/29b0f8c1-e168-4631-b587-50310906461a" />


> All 35 visible entries show only `claude-3-omniroute-no-thinking/<provider>/claude-o` — the model suffix is cut off in every row. The provider prefix alone consumes the entire column width.

## Solution

Rename the prefix from `claude-3-omniroute-no-thinking/` → `no-think/` (**9 characters**, a 74% reduction).

After the change:
```
no-think/cc/claude-opus-4-6     OmniRoute   ← fully visible
no-think/gh/claude-haiku-4.5    OmniRoute   ← fully visible
no-think/opencode-zen/claude-s  OmniRoute   ← fully visible
```

## Second fix: canonical prefix consistency (commit 2263686a)

When `MODELS_CATALOG_PREFIX_MODE=canonical` (from PR #4427), the rest of the catalog emits
canonical provider prefixes (e.g. `claude/claude-opus-4-6`). But `appendNoThinkingVariants`
was wrapping whatever alias-prefixed id it found in `finalModels` unchanged, producing
`no-think/cc/claude-opus-4-6` even though canonical mode was active.

Fix: added `normalizeProviderPrefix(qualifiedId, aliasToCanonical)` helper inside
`noThinkingAlias.ts`. `appendNoThinkingVariants` now accepts an optional `aliasToCanonical?`
map; the catalog passes `aliasToProviderId` only in canonical mode so no-think ids stay
consistent with the active prefix mode.

| Mode | Example no-think id |
|------|---------------------|
| dual / alias (default) | `no-think/cc/claude-opus-4-6` |
| canonical | `no-think/claude/claude-opus-4-6` |

## What changed

- `open-sse/utils/noThinkingAlias.ts`:
  - `NO_THINKING_PREFIX` renamed to `"no-think/"`
  - `normalizeProviderPrefix()` helper added (private)
  - `appendNoThinkingVariants()` accepts optional `aliasToCanonical?` param
- `src/app/api/v1/models/catalog.ts`: passes `aliasToProviderId` when `prefixMode === "canonical"`
- Comments in `src/shared/constants/modelSpecs.ts` and `src/sse/handlers/chat.ts` updated
- `tests/unit/no-thinking-alias.test.ts`: all string literals updated; 2 new canonical tests

## What is unchanged

- All detection, stripping, routing, and catalog logic is unchanged — only the constant string value and the new optional normalization
- `applyNoThinkingAlias()`, `isNoThinkingAlias()`, `stripNoThinkingAlias()`, `shouldExposeNoThinkingAlias()` all work identically
- Default behavior (dual/alias modes) is byte-identical to before

## Migration note

Clients that saved a model like `claude-3-omniroute-no-thinking/cc/claude-opus-4-6` in their config will need to update to `no-think/cc/claude-opus-4-6`. Inbound requests using the old prefix will not be recognized after this change. If backward compat is required, a temporary dual-recognition shim can be added to `isNoThinkingAlias()`.

## Tests

```
tests 14 | pass 14 | fail 0
```

New tests:
```
✔ appendNoThinkingVariants normalizes alias prefix to canonical when aliasToCanonical map is provided
✔ appendNoThinkingVariants keeps alias prefix when no map is provided
```
