### PR TITLE
feat: DeepSeek V4 Pro reasoning-effort variants + compression fixes

### DIFF
--- a/src/shared/validation/compressionConfigSchemas.ts
+++ b/src/shared/validation/compressionConfigSchemas.ts
@@ -195,6 +195,7 @@ export const compressionSettingsUpdateSchema = z
     ultra: ultraConfigSchema.optional(),
     contextEditing: contextEditingConfigSchema.optional(),
     engines: z.record(z.string(), engineToggleSchema).optional(),
+    enginesExplicit: z.boolean().optional(),
     activeComboId: z.string().nullable().optional(),
   })
   .strict();

--- a/tests/unit/api/compression/compression-api.test.ts
+++ b/tests/unit/api/compression/compression-api.test.ts
@@ -158,11 +158,7 @@ describe("settings/compression route — engines + activeComboId", () => {
     assert.equal(getRes.status, 200);
     const body = await getRes.json();
 
-    assert.equal(
-      body.engines?.rtk?.enabled,
-      true,
-      "engines.rtk.enabled should be true after PUT"
-    );
+    assert.equal(body.engines?.rtk?.enabled, true, "engines.rtk.enabled should be true after PUT");
     assert.equal(
       body.engines?.rtk?.level,
       "standard",
@@ -199,15 +195,29 @@ describe("settings/compression route — engines + activeComboId", () => {
 
   it("PUT with invalid engines shape is rejected by schema validation (400)", async () => {
     // engines values must have an `enabled` boolean — passing a string should fail the schema.
-    const putRes = await route.PUT(
-      makeRequest("PUT", { engines: { rtk: { enabled: "yes" } } })
-    );
+    const putRes = await route.PUT(makeRequest("PUT", { engines: { rtk: { enabled: "yes" } } }));
     assert.equal(putRes.status, 400);
     const body = await putRes.json();
     // Validation failures use { error: { message, details } } via validateBody helper.
     assert.ok(body.error !== null && typeof body.error === "object", "error should be an object");
     const errorMessage: string =
-      typeof body.error === "string" ? body.error : (body.error?.message ?? JSON.stringify(body.error));
+      typeof body.error === "string"
+        ? body.error
+        : (body.error?.message ?? JSON.stringify(body.error));
     assert.ok(!errorMessage.includes("at /"), "error must not contain a stack trace");
+  });
+
+  it("PUT accepts enginesExplicit (round-tripped from GET response)", async () => {
+    // Regression: the GET handler injects `enginesExplicit` (compression.ts:632) so the
+    // hub/panel can round-trip the full settings object. The previous .strict() PUT schema
+    // rejected it with 400 ("Unrecognized key: enginesExplicit"), causing every toggle on
+    // the Compression Hub / Panel to revert. Allow it through.
+    const putRes = await route.PUT(makeRequest("PUT", { enabled: true, enginesExplicit: true }));
+    assert.equal(putRes.status, 200);
+
+    core.resetDbInstance();
+
+    const putRes2 = await route.PUT(makeRequest("PUT", { enabled: false, enginesExplicit: false }));
+    assert.equal(putRes2.status, 200);
   });
 });


### PR DESCRIPTION
## Problem

Three related bugs surface in a panel-configured install:

### 1. PUT `/api/settings/compression` rejects round-tripped body with 400

`GET /api/settings/compression` injects a server-computed `enginesExplicit` flag. The Hub / Panel / per-engine pages all round-trip the full GET body on toggle, but the `.strict()` PUT schema never declared `enginesExplicit`. Every toggle reverts with 400.

### 2. Hub shows "0 layer(s)" despite engines enabled

The default-combo endpoint returns `{ mode, pipeline, derived }` (no `id`). The Hub gate `if (comboData?.id)` throws the payload away — Hub renders "No active layers" even when six engines are enabled.

### 3. `deepseek-v4-pro-{low,medium,high,max}` rejected by omniroute

The opencode/zen upstream exposes the base id `deepseek-v4-pro` only; the suffix variants 401 with "Model not supported". Operators using omo's fallback chains or 9router-style effort tiers had no path through omniroute.

## Fix

### Commit 1 — schema (compression)
Allow `enginesExplicit` through the PUT schema as an optional boolean.

### Commit 2 — Hub UI
Stop gating the Hub's `setCombo` on the response having an `id` field.

### Commit 3 — DeepSeek V4 Pro variants
Port the variant logic from 9router's opencode-go executor
(`open-sse/executors/opencode-go.js`):
- Detect `-low/-medium/-high/-max` on the routed model id
- When the base id is `deepseek-v4-pro`, rewrite body.model to the canonical base id and inject `reasoning_effort` from the suffix
- Explicit `reasoning_effort` from the caller wins over the derived one
- Other models ending with `-high/-max` etc. are left untouched
- Adds 4 model entries in the opencode provider registry (`-low/-medium/-high/-max`) so the catalog can route them

```diff
+ { id: "deepseek-v4-pro-low",    name: "DeepSeek V4 Pro (low effort)",    supportsReasoning: true },
+ { id: "deepseek-v4-pro-medium", name: "DeepSeek V4 Pro (medium effort)", supportsReasoning: true },
+ { id: "deepseek-v4-pro-high",   name: "DeepSeek V4 Pro (high effort)",   supportsReasoning: true },
+ { id: "deepseek-v4-pro-max",    name: "DeepSeek V4 Pro (max effort)",    supportsReasoning: true },
```

```ts
const m = String(model || "");
const matchedLevel = ["low", "medium", "high", "max"].find((level) => m.endsWith(`-${level}`));
if (matchedLevel) {
  const base = m.slice(0, -(`-${matchedLevel}`).length);
  if (base.toLowerCase() === "deepseek-v4-pro") {
    mb.model = "deepseek-v4-pro";
    if (mb.reasoning_effort === undefined) {
      mb.reasoning_effort = matchedLevel;
    }
  }
}
```

## Tests

- `tests/unit/api/compression/compression-api.test.ts` — 11/11 pass (one new for enginesExplicit)
- `tests/unit/ui/compressionHub.test.tsx` — 5/5 pass (one new for missing-id round-trip)
- `tests/unit/ui/compressionHub-context-editing.test.tsx` — 3/3 pass
- `tests/unit/opencode-executor.test.ts` — 52/52 pass (4 new: each variant, explicit-override, base passthrough, unrelated-suffix negative)

Pre-commit hooks (prettier, eslint, docs-sync, t11:any-budget, tracked-artifacts) green on all three commits.

## Notes

- The 4 pre-existing TS errors in `opencode.ts` lines 143-146 (the `modifiedBody.tools` access) are not touched by this PR; they exist on `main`.
- Runtime behavior is unchanged for non-DeepSeek requests; the new branch only fires when the model id ends with `-low/-medium/-high/-max` AND the base is exactly `deepseek-v4-pro`.