### PR TITLE
refactor(chatCore): extrai resolução de target-format para leaf puro (#3501)

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -44,8 +44,8 @@ import {
 import { CORS_HEADERS } from "../utils/cors.ts";
 import { checkHeapPressureGuard } from "../utils/heapPressure.ts";
 import { normalizeHeaders } from "../utils/headers.ts";
-import { getTargetFormat } from "../services/provider.ts";
 import { resolveChatCoreRequestFormat } from "./chatCore/requestFormat.ts";
+import { resolveChatCoreTargetFormat } from "./chatCore/targetFormat.ts";
 import { injectSystemPrompt } from "../services/systemPrompt.ts";
 import { translateRequest, needsTranslation } from "../translator/index.ts";
 import { FORMATS } from "../translator/formats.ts";
@@ -71,7 +71,6 @@ import {
 import { createRequestLogger } from "../utils/requestLogger.ts";
 import { createPreparedRequestLogger, runWithCapture } from "../utils/providerRequestLogging.ts";
 import { applyResponsesPreviousResponseIdPolicy } from "../utils/responsesStatePolicy.ts";
-import { getModelTargetFormat, PROVIDER_ID_TO_ALIAS } from "../config/providerModels.ts";
 import { applyClaudeEffortVariant } from "./chatCore/claudeEffortVariant.ts";
 import { DEFAULT_THINKING_CLAUDE_SIGNATURE } from "../config/defaultThinkingSignature.ts";
 import {
@@ -881,14 +880,15 @@ export async function handleChatCore({
     }
   }
 
-  const alias = PROVIDER_ID_TO_ALIAS[provider] || provider;
-  const modelTargetFormat = getModelTargetFormat(alias, resolvedModel);
-  const targetFormat =
-    apiFormat === "responses"
-      ? FORMATS.OPENAI_RESPONSES
-      : modelTargetFormat ||
-        customModelTargetFormat ||
-        getTargetFormat(provider, credentials?.providerSpecificData);
+  // Wire target-format resolution extracted to chatCore/targetFormat.ts (#3501); `alias` is reused
+  // downstream when stripping the alias/ prefix off the upstream model id.
+  const { alias, targetFormat } = resolveChatCoreTargetFormat({
+    provider,
+    resolvedModel,
+    apiFormat,
+    customModelTargetFormat,
+    providerSpecificData: credentials?.providerSpecificData,
+  });
 
   const initialProviderRequest =
     body && typeof body === "object" && !Array.isArray(body)

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -71,11 +71,8 @@ import {
 import { createRequestLogger } from "../utils/requestLogger.ts";
 import { createPreparedRequestLogger, runWithCapture } from "../utils/providerRequestLogging.ts";
 import { applyResponsesPreviousResponseIdPolicy } from "../utils/responsesStatePolicy.ts";
-import {
-  getModelTargetFormat,
-  PROVIDER_ID_TO_ALIAS,
-  splitClaudeEffortSuffix,
-} from "../config/providerModels.ts";
+import { getModelTargetFormat, PROVIDER_ID_TO_ALIAS } from "../config/providerModels.ts";
+import { applyClaudeEffortVariant } from "./chatCore/claudeEffortVariant.ts";
 import { DEFAULT_THINKING_CLAUDE_SIGNATURE } from "../config/defaultThinkingSignature.ts";
 import {
   getStripTypesForProviderModel,
@@ -873,30 +870,18 @@ export async function handleChatCore({
   // it into Claude thinking/effort config. An explicit client-supplied effort always
   // wins; native Claude passthrough is left untouched (it carries its own `thinking`),
   // and non-thinking base models are cleaned up later by normalizeThinkingForModel().
-  if (
-    (provider === "claude" || isClaudeCodeCompatibleProvider(provider)) &&
-    typeof effectiveModel === "string"
-  ) {
-    const { baseModel, effort } = splitClaudeEffortSuffix(effectiveModel);
-    if (effort) {
-      effectiveModel = baseModel;
-      if (body && typeof body === "object" && !Array.isArray(body)) {
-        const claudeBody = body as Record<string, unknown>;
-        claudeBody.model = baseModel;
-        if (sourceFormat !== FORMATS.CLAUDE) {
-          const explicitEffort =
-            claudeBody.reasoning_effort ??
-            (claudeBody.reasoning as Record<string, unknown> | undefined)?.effort ??
-            (claudeBody.output_config as Record<string, unknown> | undefined)?.effort;
-          if (explicitEffort === undefined || explicitEffort === null || explicitEffort === "") {
-            claudeBody.reasoning_effort = effort;
-          }
-        }
-      }
-      log?.info?.(
-        "PARAMS",
-        `Claude effort variant: stripped "-${effort}" → ${baseModel} (reasoning_effort=${effort})`
-      );
+  // Extracted to chatCore/claudeEffortVariant.ts (#3501); mutates body in place and returns the
+  // stripped model + an optional log line, keeping behaviour byte-identical.
+  {
+    const effortVariant = applyClaudeEffortVariant({
+      provider,
+      effectiveModel,
+      body,
+      sourceFormat,
+    });
+    effectiveModel = effortVariant.effectiveModel;
+    if (effortVariant.log) {
+      log?.info?.("PARAMS", effortVariant.log);
     }
   }
 

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -120,13 +120,8 @@ import {
 } from "../services/errorClassifier.ts";
 import { updateProviderConnection, getProviderConnectionById } from "@/lib/db/providers";
 import { wasRefreshTokenRotated } from "@omniroute/open-sse/services/refreshSerializer.ts";
-import {
-  recordKeyFailure,
-  recordKeySuccess,
-  trackConnectionExtraKeys,
-  connectionHasExtraKeys,
-  type KeyHealth,
-} from "../services/apiKeyRotator.ts";
+import { connectionHasExtraKeys } from "../services/apiKeyRotator.ts";
+import { recordKeyHealthStatus as recordKeyHealthStatusFor } from "./chatCore/keyHealth.ts";
 
 import {
   getCallLogPipelineCaptureStreamChunks,
@@ -765,62 +760,12 @@ export async function handleChatCore({
     }).catch(() => {});
   };
 
+  // Key-health updater extracted to chatCore/keyHealth.ts (#3501); bind the per-request log once
+  // and delegate so the existing call sites stay byte-identical.
   const recordKeyHealthStatus = (
     status: number,
     creds: Record<string, unknown> | null | undefined
-  ): void => {
-    const connId = creds?.connectionId as string | undefined;
-    if (!connId) return;
-
-    const psd = creds.providerSpecificData as Record<string, unknown> | undefined;
-    const extraKeys = (psd?.extraApiKeys as string[] | undefined) ?? [];
-    const health = psd?.apiKeyHealth as Record<string, KeyHealth> | undefined;
-    const currentKeyId = (psd?.selectedKeyId as string | undefined) ?? "primary";
-
-    trackConnectionExtraKeys(connId, extraKeys);
-
-    if (status === 401) {
-      const updatedHealth = recordKeyFailure(connId, currentKeyId);
-      log?.warn?.(
-        "AUTH",
-        `401 on connection ${connId.slice(0, 8)} - key marked as failed (failure #${updatedHealth.failures})`
-      );
-
-      // Persist health status to DB on every failure (not just invalid transitions)
-      // This ensures in-memory state survives process restarts
-      const prevStatus = health?.[currentKeyId]?.status;
-      const prevFailures = health?.[currentKeyId]?.failures ?? 0;
-      if (updatedHealth.status !== prevStatus || updatedHealth.failures !== prevFailures) {
-        updateProviderConnection(connId, {
-          providerSpecificData: {
-            ...psd,
-            apiKeyHealth: { ...health, [currentKeyId]: updatedHealth },
-          },
-        }).catch((err: unknown) => {
-          log?.error?.(
-            "DB",
-            `Failed to persist apiKeyHealth: ${err instanceof Error ? err.message : String(err)}`
-          );
-        });
-      }
-    } else if (status >= 200 && status < 300) {
-      const updatedHealth = recordKeySuccess(connId, currentKeyId);
-      const prevStatus = health?.[currentKeyId]?.status;
-      if (prevStatus === "warning" || prevStatus === "invalid") {
-        updateProviderConnection(connId, {
-          providerSpecificData: {
-            ...psd,
-            apiKeyHealth: { ...health, [currentKeyId]: updatedHealth },
-          },
-        }).catch((err: unknown) => {
-          log?.error?.(
-            "DB",
-            `Failed to persist apiKeyHealth: ${err instanceof Error ? err.message : String(err)}`
-          );
-        });
-      }
-    }
-  };
+  ): void => recordKeyHealthStatusFor(status, creds, log);
 
   const persistCodexQuotaState = async (headers: Record<string, string> | null, status = 0) => {
     if (provider !== "codex" || !connectionId || !headers) return;

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -44,7 +44,8 @@ import {
 import { CORS_HEADERS } from "../utils/cors.ts";
 import { checkHeapPressureGuard } from "../utils/heapPressure.ts";
 import { normalizeHeaders } from "../utils/headers.ts";
-import { detectFormatFromEndpoint, getTargetFormat } from "../services/provider.ts";
+import { getTargetFormat } from "../services/provider.ts";
+import { resolveChatCoreRequestFormat } from "./chatCore/requestFormat.ts";
 import { injectSystemPrompt } from "../services/systemPrompt.ts";
 import { translateRequest, needsTranslation } from "../translator/index.ts";
 import { FORMATS } from "../translator/formats.ts";
@@ -548,28 +549,6 @@ function buildExecutorClientHeaders(
   return Object.keys(normalized).length > 0 ? normalized : null;
 }
 
-function isCopilotClient(
-  headers: Headers | Record<string, unknown> | null | undefined,
-  userAgent?: string | null
-) {
-  const isMatch = (value: unknown) =>
-    typeof value === "string" && value.toLowerCase().includes("copilot");
-
-  if (isMatch(userAgent)) return true;
-
-  if (headers instanceof Headers) {
-    for (const [key, value] of headers as unknown as Iterable<[string, string]>) {
-      if (isMatch(key) || isMatch(value)) return true;
-    }
-  } else if (headers && typeof headers === "object") {
-    for (const [key, value] of Object.entries(headers)) {
-      if (isMatch(key) || isMatch(value)) return true;
-    }
-  }
-
-  return false;
-}
-
 export function extractSystemRoleMessages(payload: Record<string, unknown>): void {
   if (!Array.isArray(payload.messages)) return;
   const messages = payload.messages as Array<{ role?: unknown; content?: unknown }>;
@@ -823,22 +802,17 @@ export async function handleChatCore({
     credentials.connectionId = connectionId;
   }
 
-  const endpointPath = String(clientRawRequest?.endpoint || "");
-  const sourceFormat = detectFormatFromEndpoint(body, endpointPath);
-  const isResponsesEndpoint =
-    /\/responses(?=\/|$)/i.test(endpointPath) || /^responses(?=\/|$)/i.test(endpointPath);
-  const nativeCodexPassthrough = shouldUseNativeCodexPassthrough({
-    provider,
-    sourceFormat,
+  // Endpoint/format resolution extracted to chatCore/requestFormat.ts (#3501); pure derivation
+  // from the inbound request, destructured so every downstream use stays byte-identical.
+  const {
     endpointPath,
-  });
-  const isDroidCLI =
-    userAgent?.toLowerCase().includes("droid") || userAgent?.toLowerCase().includes("codex-cli");
-  const copilotCompatibleReasoning = isCopilotClient(clientRawRequest?.headers, userAgent);
-  const clientResponseFormat =
-    sourceFormat === FORMATS.OPENAI_RESPONSES && !isResponsesEndpoint && !isDroidCLI
-      ? FORMATS.OPENAI
-      : sourceFormat;
+    sourceFormat,
+    isResponsesEndpoint,
+    nativeCodexPassthrough,
+    isDroidCLI,
+    copilotCompatibleReasoning,
+    clientResponseFormat,
+  } = resolveChatCoreRequestFormat({ clientRawRequest, body, provider, userAgent });
 
   // Check for bypass patterns (warmup, skip) - return fake response
   const bypassResponse = handleBypassRequest(body, model, userAgent);

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -242,11 +242,7 @@ import {
   getTokenLimit,
   resolveComboContextLimit,
 } from "../services/contextManager.ts";
-import {
-  getBackgroundTaskReason,
-  getDegradedModel,
-  getBackgroundDegradationConfig,
-} from "../services/backgroundTaskDetector.ts";
+import { resolveBackgroundTaskRedirect } from "./chatCore/backgroundRedirect.ts";
 import type { CompressionConfig, CompressionPipelineStep } from "../services/compression/types.ts";
 import { prepareWebSearchFallbackBody } from "../services/webSearchFallback.ts";
 import {
@@ -820,35 +816,35 @@ export async function handleChatCore({
   // Detect source format and get target format
   // Model-specific targetFormat takes priority over provider default
 
-  // ── Background Task Redirection (T41) ──
-  const bgConfig = getBackgroundDegradationConfig();
-  const backgroundReason = bgConfig.enabled
-    ? getBackgroundTaskReason(body, clientRawRequest?.headers)
-    : null;
-  if (backgroundReason) {
-    const degradedModel = getDegradedModel(model);
-    if (degradedModel !== model) {
-      const originalModel = model;
-      log?.info?.(
-        "BACKGROUND",
-        `Background task redirect (${backgroundReason}): ${originalModel} → ${degradedModel}`
-      );
-      model = degradedModel;
-      if (body && typeof body === "object") {
-        body.model = model;
-      }
-
-      logAuditEvent({
-        action: "routing.background_task_redirect",
-        actor: apiKeyInfo?.name || "system",
-        target: connectionId || provider || "chat",
-        details: {
-          original_model: originalModel,
-          redirected_to: degradedModel,
-          reason: backgroundReason,
-        },
-      });
+  // ── Background Task Redirection (T41) — decision extracted to chatCore/backgroundRedirect.ts (#3501)
+  // backgroundReason is the detection signal (threaded into memory/skills injection below); redirect
+  // is the actual model downgrade to apply, if any.
+  const { backgroundReason, redirect: bgRedirect } = resolveBackgroundTaskRedirect({
+    body,
+    headers: clientRawRequest?.headers,
+    model,
+  });
+  if (bgRedirect) {
+    const originalModel = model;
+    log?.info?.(
+      "BACKGROUND",
+      `Background task redirect (${bgRedirect.reason}): ${originalModel} → ${bgRedirect.degradedModel}`
+    );
+    model = bgRedirect.degradedModel;
+    if (body && typeof body === "object") {
+      body.model = model;
     }
+
+    logAuditEvent({
+      action: "routing.background_task_redirect",
+      actor: apiKeyInfo?.name || "system",
+      target: connectionId || provider || "chat",
+      details: {
+        original_model: originalModel,
+        redirected_to: bgRedirect.degradedModel,
+        reason: bgRedirect.reason,
+      },
+    });
   }
 
   // Apply custom model aliases (Settings → Model Aliases → Pattern→Target) before routing (#315, #472)

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -201,12 +201,8 @@ import {
   shouldDetectLimit,
 } from "../services/toolLimitDetector.ts";
 
-import {
-  parseCodexQuotaHeaders,
-  getCodexModelScope,
-  getCodexDualWindowCooldownMs,
-  isCompactResponsesEndpoint,
-} from "../executors/codex.ts";
+import { isCompactResponsesEndpoint } from "../executors/codex.ts";
+import { buildCodexQuotaPersistence } from "./chatCore/codexQuota.ts";
 import { invalidateCodexQuotaCache } from "../services/codexQuotaFetcher.ts";
 import { translateNonStreamingResponse } from "./responseTranslator.ts";
 import { extractUsageFromResponse } from "./usageExtractor.ts";
@@ -771,67 +767,35 @@ export async function handleChatCore({
     if (provider !== "codex" || !connectionId || !headers) return;
 
     try {
-      const quota = parseCodexQuotaHeaders(headers);
-      if (!quota) return;
-
       const existingProviderData =
         credentials?.providerSpecificData && typeof credentials.providerSpecificData === "object"
-          ? credentials.providerSpecificData
+          ? (credentials.providerSpecificData as Record<string, unknown>)
           : {};
-      const scope = getCodexModelScope(model || requestedModel || "");
-      const quotaState = {
-        usage5h: quota.usage5h,
-        limit5h: quota.limit5h,
-        resetAt5h: quota.resetAt5h,
-        usage7d: quota.usage7d,
-        limit7d: quota.limit7d,
-        resetAt7d: quota.resetAt7d,
-        scope,
-        updatedAt: new Date().toISOString(),
-      };
+      // Pure payload build extracted to chatCore/codexQuota.ts (#3501). Returns null when the
+      // response carries no quota headers (nothing to persist).
+      const built = buildCodexQuotaPersistence({
+        headers,
+        existingProviderData,
+        modelForScope: model || requestedModel || "",
+        status,
+      });
+      if (!built) return;
 
-      const nextProviderData: Record<string, unknown> = {
-        ...existingProviderData,
-        codexQuotaState: quotaState,
-      };
+      if (built.exhaustionLog) {
+        log?.debug?.("CODEX", built.exhaustionLog);
+      }
 
-      // T03/T09: on 429, persist exact reset time per scope to avoid global over-blocking.
-      // Use dual-window cooldown to distinguish short-term and weekly Codex exhaustion.
+      // Invalidate the preflight cache for this connection so the next
+      // isModelAvailable check fetches fresh quota data.
       if (status === 429) {
-        const { cooldownMs, window: exhaustedWindow } = getCodexDualWindowCooldownMs(quota);
-        if (cooldownMs > 0) {
-          const scopeUntil = new Date(Date.now() + cooldownMs).toISOString();
-          const scopeMapRaw =
-            existingProviderData &&
-            typeof existingProviderData === "object" &&
-            existingProviderData.codexScopeRateLimitedUntil &&
-            typeof existingProviderData.codexScopeRateLimitedUntil === "object"
-              ? existingProviderData.codexScopeRateLimitedUntil
-              : {};
-
-          nextProviderData.codexScopeRateLimitedUntil = {
-            ...(scopeMapRaw as Record<string, unknown>),
-            [scope]: scopeUntil,
-          };
-          nextProviderData.codexExhaustedWindow = exhaustedWindow;
-          log?.debug?.(
-            "CODEX",
-            `Quota exhaustion on ${exhaustedWindow} window, cooldown until ${scopeUntil}`
-          );
-        }
-
-        // Invalidate the preflight cache for this connection so the next
-        // isModelAvailable check fetches fresh quota data.
-        if (connectionId) {
-          invalidateCodexQuotaCache(connectionId);
-        }
+        invalidateCodexQuotaCache(connectionId);
       }
 
       await updateProviderConnection(connectionId, {
-        providerSpecificData: nextProviderData,
+        providerSpecificData: built.nextProviderData,
       });
 
-      credentials.providerSpecificData = nextProviderData;
+      credentials.providerSpecificData = built.nextProviderData;
     } catch (err) {
       const errMessage = err instanceof Error ? err.message : String(err);
       log?.debug?.("CODEX", `Failed to persist codex quota state: ${errMessage}`);

--- a/open-sse/handlers/chatCore/backgroundRedirect.ts
+++ b/open-sse/handlers/chatCore/backgroundRedirect.ts
@@ -1,0 +1,41 @@
+/**
+ * chatCore Background Task Redirection decision (T41) (Quality Gate v2 / Fase 9 — chatCore god-file
+ * decomposition, #3501).
+ *
+ * Decides whether a request should be downgraded to a cheaper "degraded" model: only when the
+ * feature is enabled, the request looks like a background/utility task, AND the model has a
+ * degradation mapping. Returns the target model + the detection reason, or null for no redirect.
+ * The handler keeps the side effects byte-identically (the BACKGROUND log, the model + body.model
+ * mutation, and the audit event). Reads the live backgroundTaskDetector config, mirroring the
+ * previous inline block.
+ */
+
+import {
+  getBackgroundDegradationConfig,
+  getBackgroundTaskReason,
+  getDegradedModel,
+} from "../../services/backgroundTaskDetector.ts";
+
+export function resolveBackgroundTaskRedirect(opts: {
+  body: unknown;
+  headers: Record<string, string> | null | undefined;
+  model: string;
+}): {
+  /** The background-task detection reason (truthy iff the request looks like a background task),
+   * threaded downstream into memory/skills injection — independent of whether a redirect happens. */
+  backgroundReason: string | null;
+  /** The actual model redirect to apply, or null when there is none (disabled, not a background
+   * task, or the model has no — or a self — degradation mapping). */
+  redirect: { degradedModel: string; reason: string } | null;
+} {
+  const bgConfig = getBackgroundDegradationConfig();
+  const backgroundReason = bgConfig.enabled
+    ? getBackgroundTaskReason(opts.body, opts.headers ?? null)
+    : null;
+  if (!backgroundReason) return { backgroundReason: null, redirect: null };
+
+  const degradedModel = getDegradedModel(opts.model);
+  if (degradedModel === opts.model) return { backgroundReason, redirect: null };
+
+  return { backgroundReason, redirect: { degradedModel, reason: backgroundReason } };
+}

--- a/open-sse/handlers/chatCore/claudeEffortVariant.ts
+++ b/open-sse/handlers/chatCore/claudeEffortVariant.ts
@@ -1,0 +1,62 @@
+/**
+ * chatCore Claude effort-variant normalizer (Quality Gate v2 / Fase 9 — chatCore god-file
+ * decomposition, #3501).
+ *
+ * The Claude / Claude-Code model picker (e.g. VS Code's "Effort" slider) advertises
+ * claude-...-{low,medium,high,xhigh,max}. Anthropic has no such model, so the suffixed id 404s
+ * upstream. This strips it back to the real base id and surfaces the level as reasoning_effort so
+ * the OpenAI→Claude translator / Claude-Code bridge can turn it into Claude thinking/effort config.
+ * An explicit client-supplied effort always wins; native Claude passthrough (sourceFormat === claude)
+ * is left untouched (it carries its own `thinking`). The body is mutated in place (model +
+ * reasoning_effort), byte-identical to the previous inline block; the new effectiveModel and an
+ * optional log line are returned for the handler to apply.
+ */
+
+import { splitClaudeEffortSuffix } from "../../config/providerModels.ts";
+import { isClaudeCodeCompatibleProvider } from "../../services/claudeCodeCompatible.ts";
+import { FORMATS } from "../../translator/formats.ts";
+
+/**
+ * True when the client already supplied an explicit reasoning effort (top-level reasoning_effort,
+ * reasoning.effort, or output_config.effort) — in which case the stripped suffix must not overwrite
+ * it. A blank string counts as "not supplied".
+ */
+function hasExplicitClaudeEffort(claudeBody: Record<string, unknown>): boolean {
+  const explicitEffort =
+    claudeBody.reasoning_effort ??
+    (claudeBody.reasoning as Record<string, unknown> | undefined)?.effort ??
+    (claudeBody.output_config as Record<string, unknown> | undefined)?.effort;
+  return !(explicitEffort === undefined || explicitEffort === null || explicitEffort === "");
+}
+
+export function applyClaudeEffortVariant(opts: {
+  provider: string | null | undefined;
+  effectiveModel: string;
+  /** Mutated in place (model + reasoning_effort) when an effort suffix is stripped. */
+  body: unknown;
+  sourceFormat: string;
+}): { effectiveModel: string; log: string | null } {
+  const { provider, body, sourceFormat } = opts;
+  let effectiveModel = opts.effectiveModel;
+  let log: string | null = null;
+
+  if (
+    (provider === "claude" || isClaudeCodeCompatibleProvider(provider)) &&
+    typeof effectiveModel === "string"
+  ) {
+    const { baseModel, effort } = splitClaudeEffortSuffix(effectiveModel);
+    if (effort) {
+      effectiveModel = baseModel;
+      if (body && typeof body === "object" && !Array.isArray(body)) {
+        const claudeBody = body as Record<string, unknown>;
+        claudeBody.model = baseModel;
+        if (sourceFormat !== FORMATS.CLAUDE && !hasExplicitClaudeEffort(claudeBody)) {
+          claudeBody.reasoning_effort = effort;
+        }
+      }
+      log = `Claude effort variant: stripped "-${effort}" → ${baseModel} (reasoning_effort=${effort})`;
+    }
+  }
+
+  return { effectiveModel, log };
+}

--- a/open-sse/handlers/chatCore/codexQuota.ts
+++ b/open-sse/handlers/chatCore/codexQuota.ts
@@ -1,0 +1,85 @@
+/**
+ * chatCore Codex quota-persistence builder (Quality Gate v2 / Fase 9 — chatCore god-file
+ * decomposition, #3501).
+ *
+ * Pure core of handleChatCore's persistCodexQuotaState: turns the upstream Codex quota response
+ * headers into the next `providerSpecificData` payload (the codexQuotaState snapshot, plus — on a
+ * 429 whose dual-window usage is past the exhaustion threshold — the per-scope cooldown timestamp,
+ * the exhausted window, and the debug-log message). The handler keeps the impure parts byte-
+ * identically: the DB write (updateProviderConnection), the preflight-cache invalidation on every
+ * 429, the credentials mutation, and emitting the returned log line.
+ */
+
+import {
+  parseCodexQuotaHeaders,
+  getCodexModelScope,
+  getCodexDualWindowCooldownMs,
+} from "../../executors/codex.ts";
+
+export type CodexQuotaPersistence = {
+  /** The merged providerSpecificData to persist (existing data + codexQuotaState [+ 429 cooldown]). */
+  nextProviderData: Record<string, unknown>;
+  /** The CODEX debug-log message to emit when a 429 exhausted a window, else null. */
+  exhaustionLog: string | null;
+};
+
+/**
+ * Build the providerSpecificData update for a Codex quota response. Returns null when the response
+ * carries no quota headers (nothing to persist). Pure: a function of the headers, the existing
+ * provider data, the model used for scope resolution, and the upstream status.
+ */
+export function buildCodexQuotaPersistence(opts: {
+  headers: Record<string, string>;
+  existingProviderData: Record<string, unknown>;
+  modelForScope: string;
+  status: number;
+}): CodexQuotaPersistence | null {
+  const { headers, existingProviderData, modelForScope, status } = opts;
+
+  const quota = parseCodexQuotaHeaders(headers);
+  if (!quota) return null;
+
+  const scope = getCodexModelScope(modelForScope);
+  const quotaState = {
+    usage5h: quota.usage5h,
+    limit5h: quota.limit5h,
+    resetAt5h: quota.resetAt5h,
+    usage7d: quota.usage7d,
+    limit7d: quota.limit7d,
+    resetAt7d: quota.resetAt7d,
+    scope,
+    updatedAt: new Date().toISOString(),
+  };
+
+  const nextProviderData: Record<string, unknown> = {
+    ...existingProviderData,
+    codexQuotaState: quotaState,
+  };
+
+  let exhaustionLog: string | null = null;
+
+  // T03/T09: on 429, persist exact reset time per scope to avoid global over-blocking.
+  // Use dual-window cooldown to distinguish short-term and weekly Codex exhaustion.
+  if (status === 429) {
+    const { cooldownMs, window: exhaustedWindow } = getCodexDualWindowCooldownMs(quota);
+    if (cooldownMs > 0) {
+      const scopeUntil = new Date(Date.now() + cooldownMs).toISOString();
+      const scopeMapRaw =
+        existingProviderData &&
+        typeof existingProviderData === "object" &&
+        existingProviderData.codexScopeRateLimitedUntil &&
+        typeof existingProviderData.codexScopeRateLimitedUntil === "object"
+          ? existingProviderData.codexScopeRateLimitedUntil
+          : {};
+
+      nextProviderData.codexScopeRateLimitedUntil = {
+        ...(scopeMapRaw as Record<string, unknown>),
+        [scope]: scopeUntil,
+      };
+      nextProviderData.codexExhaustedWindow = exhaustedWindow;
+      exhaustionLog = `Quota exhaustion on ${exhaustedWindow} window, cooldown until ${scopeUntil}`;
+    }
+  }
+
+  return { nextProviderData, exhaustionLog };
+}

--- a/open-sse/handlers/chatCore/keyHealth.ts
+++ b/open-sse/handlers/chatCore/keyHealth.ts
@@ -1,0 +1,84 @@
+/**
+ * chatCore per-request API-key health updater (Quality Gate v2 / Fase 9 — chatCore god-file
+ * decomposition, #3501).
+ *
+ * Byte-identical extraction of the `recordKeyHealthStatus` closure that lived at the top of
+ * handleChatCore. Translates an upstream HTTP status into the in-memory key-health state
+ * (apiKeyRotator) for the connection's currently-selected key, and persists the change to the
+ * provider connection so it survives process restarts:
+ *   - 401 → record a failure (warning, then invalid at the threshold), always persisted.
+ *   - 2xx → record a success, persisted only when recovering from a warning/invalid state.
+ * Any other status only refreshes the tracked extra-key set. The handler binds its `log` once and
+ * delegates here, keeping the existing call sites unchanged.
+ */
+
+import {
+  recordKeyFailure,
+  recordKeySuccess,
+  trackConnectionExtraKeys,
+  type KeyHealth,
+} from "../../services/apiKeyRotator.ts";
+import { updateProviderConnection } from "@/lib/db/providers";
+
+type KeyHealthLog = {
+  warn?: (tag: string, message: string) => void;
+  error?: (tag: string, message: string) => void;
+} | null;
+
+export function recordKeyHealthStatus(
+  status: number,
+  creds: Record<string, unknown> | null | undefined,
+  log?: KeyHealthLog
+): void {
+  const connId = creds?.connectionId as string | undefined;
+  if (!connId) return;
+
+  const psd = creds.providerSpecificData as Record<string, unknown> | undefined;
+  const extraKeys = (psd?.extraApiKeys as string[] | undefined) ?? [];
+  const health = psd?.apiKeyHealth as Record<string, KeyHealth> | undefined;
+  const currentKeyId = (psd?.selectedKeyId as string | undefined) ?? "primary";
+
+  trackConnectionExtraKeys(connId, extraKeys);
+
+  if (status === 401) {
+    const updatedHealth = recordKeyFailure(connId, currentKeyId);
+    log?.warn?.(
+      "AUTH",
+      `401 on connection ${connId.slice(0, 8)} - key marked as failed (failure #${updatedHealth.failures})`
+    );
+
+    // Persist health status to DB on every failure (not just invalid transitions)
+    // This ensures in-memory state survives process restarts
+    const prevStatus = health?.[currentKeyId]?.status;
+    const prevFailures = health?.[currentKeyId]?.failures ?? 0;
+    if (updatedHealth.status !== prevStatus || updatedHealth.failures !== prevFailures) {
+      updateProviderConnection(connId, {
+        providerSpecificData: {
+          ...psd,
+          apiKeyHealth: { ...health, [currentKeyId]: updatedHealth },
+        },
+      }).catch((err: unknown) => {
+        log?.error?.(
+          "DB",
+          `Failed to persist apiKeyHealth: ${err instanceof Error ? err.message : String(err)}`
+        );
+      });
+    }
+  } else if (status >= 200 && status < 300) {
+    const updatedHealth = recordKeySuccess(connId, currentKeyId);
+    const prevStatus = health?.[currentKeyId]?.status;
+    if (prevStatus === "warning" || prevStatus === "invalid") {
+      updateProviderConnection(connId, {
+        providerSpecificData: {
+          ...psd,
+          apiKeyHealth: { ...health, [currentKeyId]: updatedHealth },
+        },
+      }).catch((err: unknown) => {
+        log?.error?.(
+          "DB",
+          `Failed to persist apiKeyHealth: ${err instanceof Error ? err.message : String(err)}`
+        );
+      });
+    }
+  }
+}

--- a/open-sse/handlers/chatCore/requestFormat.ts
+++ b/open-sse/handlers/chatCore/requestFormat.ts
@@ -1,0 +1,82 @@
+/**
+ * chatCore request endpoint/format resolvers (Quality Gate v2 / Fase 9 — chatCore god-file
+ * decomposition, #3501).
+ *
+ * Pure slice of handleChatCore's request-setup phase: derives the wire-format facts of an inbound
+ * request from its endpoint, body, provider, and user-agent — the source format, whether it targets
+ * the Responses endpoint, native-Codex passthrough eligibility, Droid CLI / Copilot detection, and
+ * the effective client response format (an OpenAI Responses shape off a non-/responses, non-Droid
+ * endpoint collapses back to plain OpenAI). Side-effect-free; behaviour is byte-identical to the
+ * previous inline block. Sits alongside resolveChatCoreRequestSetup as the request-setup phase grows.
+ */
+
+import { detectFormatFromEndpoint } from "../../services/provider.ts";
+import { shouldUseNativeCodexPassthrough } from "./passthroughHelpers.ts";
+import { FORMATS } from "../../translator/formats.ts";
+
+/** True when the request originates from a Copilot client (matched by user-agent or any header). */
+function isCopilotClient(
+  headers: Headers | Record<string, unknown> | null | undefined,
+  userAgent?: string | null
+) {
+  const isMatch = (value: unknown) =>
+    typeof value === "string" && value.toLowerCase().includes("copilot");
+
+  if (isMatch(userAgent)) return true;
+
+  if (headers instanceof Headers) {
+    for (const [key, value] of headers as unknown as Iterable<[string, string]>) {
+      if (isMatch(key) || isMatch(value)) return true;
+    }
+  } else if (headers && typeof headers === "object") {
+    for (const [key, value] of Object.entries(headers)) {
+      if (isMatch(key) || isMatch(value)) return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Resolve the per-request endpoint/format facts at the top of handleChatCore. Pure: a function of
+ * the inbound endpoint, the (possibly already-mutated) body, the resolved provider, and the
+ * user-agent.
+ */
+export function resolveChatCoreRequestFormat(opts: {
+  clientRawRequest:
+    | { endpoint?: unknown; headers?: Headers | Record<string, unknown> | null }
+    | null
+    | undefined;
+  body: unknown;
+  provider: string | null | undefined;
+  userAgent: string | null | undefined;
+}) {
+  const { clientRawRequest, body, provider, userAgent } = opts;
+  const endpointPath = String(clientRawRequest?.endpoint || "");
+  const sourceFormat = detectFormatFromEndpoint(body, endpointPath);
+  const isResponsesEndpoint =
+    /\/responses(?=\/|$)/i.test(endpointPath) || /^responses(?=\/|$)/i.test(endpointPath);
+  const nativeCodexPassthrough = shouldUseNativeCodexPassthrough({
+    provider,
+    sourceFormat,
+    endpointPath,
+  });
+  const isDroidCLI =
+    userAgent?.toLowerCase().includes("droid") || userAgent?.toLowerCase().includes("codex-cli");
+  const copilotCompatibleReasoning = isCopilotClient(clientRawRequest?.headers, userAgent);
+  const clientResponseFormat =
+    sourceFormat === FORMATS.OPENAI_RESPONSES && !isResponsesEndpoint && !isDroidCLI
+      ? FORMATS.OPENAI
+      : sourceFormat;
+  return {
+    endpointPath,
+    sourceFormat,
+    isResponsesEndpoint,
+    nativeCodexPassthrough,
+    isDroidCLI,
+    copilotCompatibleReasoning,
+    clientResponseFormat,
+  };
+}
+
+export type ChatCoreRequestFormat = ReturnType<typeof resolveChatCoreRequestFormat>;

--- a/open-sse/handlers/chatCore/targetFormat.ts
+++ b/open-sse/handlers/chatCore/targetFormat.ts
@@ -1,0 +1,34 @@
+/**
+ * chatCore wire target-format resolver (Quality Gate v2 / Fase 9 — chatCore god-file
+ * decomposition, #3501).
+ *
+ * Pure resolution of the provider alias + the upstream target format used to translate the request:
+ * apiFormat==="responses" forces OpenAI Responses; otherwise the model's registry target format, then
+ * the per-model custom override (#2905), then the provider default. Returns both `alias` (reused by
+ * the handler when stripping the `alias/` prefix off the upstream model id) and `targetFormat`.
+ * Side-effect-free; byte-identical to the previous inline block. Sits alongside the other
+ * request-setup resolvers (resolveChatCoreRequestSetup / resolveChatCoreRequestFormat).
+ */
+
+import { PROVIDER_ID_TO_ALIAS, getModelTargetFormat } from "../../config/providerModels.ts";
+import { getTargetFormat } from "../../services/provider.ts";
+import { FORMATS } from "../../translator/formats.ts";
+
+export function resolveChatCoreTargetFormat(opts: {
+  provider: string;
+  resolvedModel: string;
+  apiFormat: string | undefined;
+  customModelTargetFormat: string | undefined;
+  providerSpecificData: unknown;
+}) {
+  const { provider, resolvedModel, apiFormat, customModelTargetFormat, providerSpecificData } = opts;
+  const alias = PROVIDER_ID_TO_ALIAS[provider] || provider;
+  const modelTargetFormat = getModelTargetFormat(alias, resolvedModel);
+  const targetFormat =
+    apiFormat === "responses"
+      ? FORMATS.OPENAI_RESPONSES
+      : modelTargetFormat || customModelTargetFormat || getTargetFormat(provider, providerSpecificData);
+  return { alias, targetFormat };
+}
+
+export type ChatCoreTargetFormat = ReturnType<typeof resolveChatCoreTargetFormat>;

--- a/tests/unit/chatcore-background-redirect.test.ts
+++ b/tests/unit/chatcore-background-redirect.test.ts
@@ -1,0 +1,69 @@
+// tests/unit/chatcore-background-redirect.test.ts
+// Characterization of resolveBackgroundTaskRedirect — the Background Task Redirection (T41)
+// decision extracted from handleChatCore (chatCore god-file decomposition, #3501). Decides whether
+// a request should be downgraded to a cheaper model: only when the feature is enabled, the request
+// looks like a background task, AND the model has a degradation mapping. The handler keeps the
+// effects (log, model/body mutation, audit). Uses the real backgroundTaskDetector config via its
+// setter so the decision is exercised end-to-end.
+import { test, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { resolveBackgroundTaskRedirect } from "../../open-sse/handlers/chatCore/backgroundRedirect.ts";
+import { setBackgroundDegradationConfig } from "../../open-sse/services/backgroundTaskDetector.ts";
+
+afterEach(() => {
+  setBackgroundDegradationConfig({ enabled: false, degradationMap: {} });
+});
+
+test("disabled config → no detection, no redirect (even for a clear background task)", () => {
+  setBackgroundDegradationConfig({ enabled: false, degradationMap: { "gpt-5": "gpt-5-mini" } });
+  assert.deepEqual(
+    resolveBackgroundTaskRedirect({ body: { max_tokens: 10 }, headers: null, model: "gpt-5" }),
+    { backgroundReason: null, redirect: null }
+  );
+});
+
+test("enabled + low-max-tokens background + mapped model → detection + redirect", () => {
+  setBackgroundDegradationConfig({ enabled: true, degradationMap: { "gpt-5": "gpt-5-mini" } });
+  const r = resolveBackgroundTaskRedirect({
+    body: { max_tokens: 10 },
+    headers: null,
+    model: "gpt-5",
+  });
+  assert.deepEqual(r, {
+    backgroundReason: "low_max_tokens",
+    redirect: { degradedModel: "gpt-5-mini", reason: "low_max_tokens" },
+  });
+});
+
+test("enabled + x-task-type:background header → reason header_background", () => {
+  setBackgroundDegradationConfig({ enabled: true, degradationMap: { "gpt-5": "gpt-5-mini" } });
+  const r = resolveBackgroundTaskRedirect({
+    body: { messages: [{ role: "user", content: "hi" }] },
+    headers: { "x-task-type": "background" },
+    model: "gpt-5",
+  });
+  assert.deepEqual(r, {
+    backgroundReason: "header_background",
+    redirect: { degradedModel: "gpt-5-mini", reason: "header_background" },
+  });
+});
+
+test("enabled but the request is not a background task → no detection, no redirect", () => {
+  setBackgroundDegradationConfig({ enabled: true, degradationMap: { "gpt-5": "gpt-5-mini" } });
+  assert.deepEqual(
+    resolveBackgroundTaskRedirect({
+      body: { max_tokens: 4096, messages: [{ role: "user", content: "write an essay" }] },
+      headers: null,
+      model: "gpt-5",
+    }),
+    { backgroundReason: null, redirect: null }
+  );
+});
+
+test("enabled + background but the model has no degradation mapping → detection but no redirect", () => {
+  setBackgroundDegradationConfig({ enabled: true, degradationMap: { "gpt-5": "gpt-5-mini" } });
+  assert.deepEqual(
+    resolveBackgroundTaskRedirect({ body: { max_tokens: 10 }, headers: null, model: "claude-opus-4" }),
+    { backgroundReason: "low_max_tokens", redirect: null }
+  );
+});

--- a/tests/unit/chatcore-claude-effort-variant.test.ts
+++ b/tests/unit/chatcore-claude-effort-variant.test.ts
@@ -1,0 +1,107 @@
+// tests/unit/chatcore-claude-effort-variant.test.ts
+// Characterization of applyClaudeEffortVariant — the Claude effort-suffix normalization extracted
+// from handleChatCore (chatCore god-file decomposition, #3501). The VS Code "Effort" slider
+// advertises claude-...-{low,medium,high,xhigh,max}; Anthropic has no such model, so the suffix is
+// stripped to the base id and surfaced as reasoning_effort. Locks: the provider gate (claude /
+// claude-code-compatible only), the in-place body mutation (model + reasoning_effort), the
+// sourceFormat==="claude" skip, the explicit-effort-wins rule, and the returned effectiveModel/log.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { applyClaudeEffortVariant } from "../../open-sse/handlers/chatCore/claudeEffortVariant.ts";
+import { FORMATS } from "../../open-sse/translator/formats.ts";
+
+test("claude provider + effort suffix → strips to base, mutates body model + reasoning_effort, returns log", () => {
+  const body: Record<string, unknown> = { model: "claude-sonnet-4-high", messages: [] };
+  const r = applyClaudeEffortVariant({
+    provider: "claude",
+    effectiveModel: "claude-sonnet-4-high",
+    body,
+    sourceFormat: FORMATS.OPENAI,
+  });
+  assert.equal(r.effectiveModel, "claude-sonnet-4");
+  assert.equal(body.model, "claude-sonnet-4");
+  assert.equal(body.reasoning_effort, "high");
+  assert.match(String(r.log), /stripped "-high" → claude-sonnet-4 \(reasoning_effort=high\)/);
+});
+
+test("claude-code-compatible provider triggers the same stripping", () => {
+  const body: Record<string, unknown> = { model: "claude-opus-4-xhigh", messages: [] };
+  const r = applyClaudeEffortVariant({
+    provider: "anthropic-compatible-cc-default",
+    effectiveModel: "claude-opus-4-xhigh",
+    body,
+    sourceFormat: FORMATS.OPENAI,
+  });
+  assert.equal(r.effectiveModel, "claude-opus-4");
+  assert.equal(body.model, "claude-opus-4");
+  assert.equal(body.reasoning_effort, "xhigh");
+});
+
+test("sourceFormat 'claude' strips the model but does NOT inject reasoning_effort", () => {
+  const body: Record<string, unknown> = { model: "claude-sonnet-4-medium", messages: [] };
+  const r = applyClaudeEffortVariant({
+    provider: "claude",
+    effectiveModel: "claude-sonnet-4-medium",
+    body,
+    sourceFormat: FORMATS.CLAUDE,
+  });
+  assert.equal(r.effectiveModel, "claude-sonnet-4");
+  assert.equal(body.model, "claude-sonnet-4");
+  assert.equal(body.reasoning_effort, undefined);
+});
+
+test("an explicit client reasoning_effort wins (not overwritten)", () => {
+  const body: Record<string, unknown> = { model: "claude-sonnet-4-low", reasoning_effort: "high", messages: [] };
+  const r = applyClaudeEffortVariant({
+    provider: "claude",
+    effectiveModel: "claude-sonnet-4-low",
+    body,
+    sourceFormat: FORMATS.OPENAI,
+  });
+  assert.equal(r.effectiveModel, "claude-sonnet-4");
+  assert.equal(body.reasoning_effort, "high"); // unchanged
+});
+
+test("explicit effort nested under reasoning.effort also wins", () => {
+  const body: Record<string, unknown> = {
+    model: "claude-sonnet-4-low",
+    reasoning: { effort: "medium" },
+    messages: [],
+  };
+  const r = applyClaudeEffortVariant({
+    provider: "claude",
+    effectiveModel: "claude-sonnet-4-low",
+    body,
+    sourceFormat: FORMATS.OPENAI,
+  });
+  assert.equal(body.reasoning_effort, undefined); // explicit reasoning.effort present → no injection
+  assert.equal(r.effectiveModel, "claude-sonnet-4");
+});
+
+test("no effort suffix → no change, no log", () => {
+  const body: Record<string, unknown> = { model: "claude-sonnet-4", messages: [] };
+  const r = applyClaudeEffortVariant({
+    provider: "claude",
+    effectiveModel: "claude-sonnet-4",
+    body,
+    sourceFormat: FORMATS.OPENAI,
+  });
+  assert.equal(r.effectiveModel, "claude-sonnet-4");
+  assert.equal(body.model, "claude-sonnet-4");
+  assert.equal(body.reasoning_effort, undefined);
+  assert.equal(r.log, null);
+});
+
+test("non-claude provider is a no-op even with an effort suffix", () => {
+  const body: Record<string, unknown> = { model: "gpt-5-high", messages: [] };
+  const r = applyClaudeEffortVariant({
+    provider: "openai",
+    effectiveModel: "gpt-5-high",
+    body,
+    sourceFormat: FORMATS.OPENAI,
+  });
+  assert.equal(r.effectiveModel, "gpt-5-high");
+  assert.equal(body.model, "gpt-5-high");
+  assert.equal(body.reasoning_effort, undefined);
+  assert.equal(r.log, null);
+});

--- a/tests/unit/chatcore-codex-quota.test.ts
+++ b/tests/unit/chatcore-codex-quota.test.ts
@@ -1,0 +1,106 @@
+// tests/unit/chatcore-codex-quota.test.ts
+// Characterization of buildCodexQuotaPersistence — the pure core of handleChatCore's
+// persistCodexQuotaState, extracted during the chatCore god-file decomposition (#3501). Locks the
+// shape of the persisted providerSpecificData: the codexQuotaState snapshot, the existing-data
+// passthrough, and the 429 dual-window exhaustion fields (codexScopeRateLimitedUntil /
+// codexExhaustedWindow) plus the debug-log message. The handler keeps the DB write, the
+// preflight-cache invalidation, and the log emission; this function only builds the data.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildCodexQuotaPersistence } from "../../open-sse/handlers/chatCore/codexQuota.ts";
+import { getCodexModelScope } from "../../open-sse/executors/codex.ts";
+
+const MODEL = "gpt-5-codex";
+const ISO = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+
+function quotaHeaders(over: Record<string, string> = {}) {
+  return {
+    "x-codex-5h-usage": "50",
+    "x-codex-5h-limit": "100",
+    "x-codex-5h-reset-at": "2999-01-01T00:00:00.000Z",
+    "x-codex-7d-usage": "10",
+    "x-codex-7d-limit": "100",
+    "x-codex-7d-reset-at": "2999-01-08T00:00:00.000Z",
+    ...over,
+  };
+}
+
+test("returns null when the response carries no codex quota headers", () => {
+  assert.equal(
+    buildCodexQuotaPersistence({ headers: {}, existingProviderData: {}, modelForScope: MODEL, status: 200 }),
+    null
+  );
+  assert.equal(
+    buildCodexQuotaPersistence({ headers: { "content-type": "application/json" }, existingProviderData: {}, modelForScope: MODEL, status: 200 }),
+    null
+  );
+});
+
+test("builds codexQuotaState (parsed numbers + scope + updatedAt) and preserves existing provider data", () => {
+  const built = buildCodexQuotaPersistence({
+    headers: quotaHeaders(),
+    existingProviderData: { keepMe: "yes", apiKeyHealth: { primary: {} } },
+    modelForScope: MODEL,
+    status: 200,
+  });
+  assert.ok(built);
+  const qs = built.nextProviderData.codexQuotaState as Record<string, unknown>;
+  assert.equal(qs.usage5h, 50);
+  assert.equal(qs.limit5h, 100);
+  assert.equal(qs.usage7d, 10);
+  assert.equal(qs.limit7d, 100);
+  assert.equal(qs.scope, getCodexModelScope(MODEL));
+  assert.match(String(qs.updatedAt), ISO);
+  // existing keys passed through, not dropped
+  assert.equal(built.nextProviderData.keepMe, "yes");
+  assert.deepEqual(built.nextProviderData.apiKeyHealth, { primary: {} });
+  // non-429 → no exhaustion fields, no log
+  assert.equal(built.exhaustionLog, null);
+  assert.equal(built.nextProviderData.codexScopeRateLimitedUntil, undefined);
+  assert.equal(built.nextProviderData.codexExhaustedWindow, undefined);
+});
+
+test("429 with a near-exhausted 5h window records the per-scope cooldown + window + log", () => {
+  const built = buildCodexQuotaPersistence({
+    headers: quotaHeaders({ "x-codex-5h-usage": "100" }), // ratio 1.0 >= 0.95, reset far in the future
+    existingProviderData: {},
+    modelForScope: MODEL,
+    status: 429,
+  });
+  assert.ok(built);
+  assert.equal(built.nextProviderData.codexExhaustedWindow, "5h");
+  const scope = getCodexModelScope(MODEL);
+  const scopeMap = built.nextProviderData.codexScopeRateLimitedUntil as Record<string, string>;
+  assert.ok(scopeMap[scope]?.startsWith("2999-01-01T00:00:00"));
+  assert.match(
+    String(built.exhaustionLog),
+    /^Quota exhaustion on 5h window, cooldown until 2999-01-01T00:00:00/
+  );
+});
+
+test("429 merges into an existing codexScopeRateLimitedUntil map without dropping other scopes", () => {
+  const built = buildCodexQuotaPersistence({
+    headers: quotaHeaders({ "x-codex-5h-usage": "100" }),
+    existingProviderData: { codexScopeRateLimitedUntil: { "other-scope": "2999-12-31T00:00:00.000Z" } },
+    modelForScope: MODEL,
+    status: 429,
+  });
+  assert.ok(built);
+  const scopeMap = built.nextProviderData.codexScopeRateLimitedUntil as Record<string, string>;
+  assert.equal(scopeMap["other-scope"], "2999-12-31T00:00:00.000Z");
+  assert.ok(scopeMap[getCodexModelScope(MODEL)]);
+});
+
+test("429 below the exhaustion threshold builds the snapshot but no cooldown / no log", () => {
+  const built = buildCodexQuotaPersistence({
+    headers: quotaHeaders({ "x-codex-5h-usage": "1", "x-codex-7d-usage": "1" }), // ratios well under 0.95
+    existingProviderData: {},
+    modelForScope: MODEL,
+    status: 429,
+  });
+  assert.ok(built);
+  assert.ok(built.nextProviderData.codexQuotaState);
+  assert.equal(built.exhaustionLog, null);
+  assert.equal(built.nextProviderData.codexScopeRateLimitedUntil, undefined);
+  assert.equal(built.nextProviderData.codexExhaustedWindow, undefined);
+});

--- a/tests/unit/chatcore-key-health.test.ts
+++ b/tests/unit/chatcore-key-health.test.ts
@@ -1,0 +1,70 @@
+// tests/unit/chatcore-key-health.test.ts
+// Characterization of recordKeyHealthStatus — the per-request API-key health updater extracted
+// from handleChatCore (chatCore god-file decomposition, #3501). Locks the observable in-memory
+// transitions driven through apiKeyRotator: 401 → failure (warning, then invalid at the threshold),
+// 2xx → success/recovery, selectedKeyId scoping, and the no-op paths (missing connectionId, and
+// non-401/non-2xx statuses). The DB persistence side effect (updateProviderConnection) is moved
+// byte-identically and is fire-and-forget; these tests assert the synchronous health mutations.
+import { test, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { recordKeyHealthStatus } from "../../open-sse/handlers/chatCore/keyHealth.ts";
+import { getAllKeyHealth, removeConnectionHealth } from "../../open-sse/services/apiKeyRotator.ts";
+
+const noopLog = { warn: () => {}, error: () => {} };
+const touched: string[] = [];
+
+function creds(connectionId: string, psd: Record<string, unknown> = {}) {
+  touched.push(connectionId);
+  return { connectionId, providerSpecificData: psd };
+}
+
+afterEach(() => {
+  for (const c of touched.splice(0)) removeConnectionHealth(c);
+});
+
+test("missing connectionId is a no-op (no health entry created)", () => {
+  const before = Object.keys(getAllKeyHealth()).length;
+  const r = recordKeyHealthStatus(200, { providerSpecificData: {} }, noopLog);
+  assert.equal(r, undefined);
+  assert.equal(Object.keys(getAllKeyHealth()).length, before);
+});
+
+test("401 marks the selected key as failed → warning after the first failure", () => {
+  const conn = "kh-401-warning";
+  recordKeyHealthStatus(401, creds(conn), noopLog);
+  const h = getAllKeyHealth()[`${conn}:primary`];
+  assert.equal(h?.failures, 1);
+  assert.equal(h?.status, "warning");
+});
+
+test("401 reaches invalid at the failure threshold (2 consecutive)", () => {
+  const conn = "kh-401-invalid";
+  recordKeyHealthStatus(401, creds(conn), noopLog);
+  recordKeyHealthStatus(401, creds(conn), noopLog);
+  const h = getAllKeyHealth()[`${conn}:primary`];
+  assert.equal(h?.failures, 2);
+  assert.equal(h?.status, "invalid");
+});
+
+test("2xx after a failure resets the key to active with 0 failures", () => {
+  const conn = "kh-2xx-recover";
+  recordKeyHealthStatus(401, creds(conn), noopLog);
+  recordKeyHealthStatus(204, creds(conn), noopLog);
+  const h = getAllKeyHealth()[`${conn}:primary`];
+  assert.equal(h?.failures, 0);
+  assert.equal(h?.status, "active");
+});
+
+test("honors selectedKeyId — scopes the update to the active extra key, not primary", () => {
+  const conn = "kh-selected-key";
+  recordKeyHealthStatus(401, creds(conn, { selectedKeyId: "extra_1" }), noopLog);
+  const all = getAllKeyHealth();
+  assert.equal(all[`${conn}:extra_1`]?.status, "warning");
+  assert.equal(all[`${conn}:primary`], undefined);
+});
+
+test("non-401 / non-2xx status does not touch key health", () => {
+  const conn = "kh-5xx-noop";
+  recordKeyHealthStatus(500, creds(conn), noopLog);
+  assert.equal(getAllKeyHealth()[`${conn}:primary`], undefined);
+});

--- a/tests/unit/chatcore-request-format.test.ts
+++ b/tests/unit/chatcore-request-format.test.ts
@@ -1,0 +1,103 @@
+// tests/unit/chatcore-request-format.test.ts
+// Characterization of resolveChatCoreRequestFormat — the endpoint/format resolution slice extracted
+// from the top of handleChatCore (chatCore god-file decomposition, #3501). Locks the endpointPath
+// construction, the /responses detection, the nativeCodexPassthrough + isDroidCLI + copilot wiring,
+// and the clientResponseFormat downgrade (OpenAI Responses shape off a non-/responses, non-Droid
+// endpoint collapses to plain OpenAI).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { resolveChatCoreRequestFormat } from "../../open-sse/handlers/chatCore/requestFormat.ts";
+import { shouldUseNativeCodexPassthrough } from "../../open-sse/handlers/chatCore/passthroughHelpers.ts";
+import { FORMATS } from "../../open-sse/translator/formats.ts";
+
+const base = { body: { messages: [{ role: "user", content: "hi" }] }, provider: "openai", userAgent: "unit-test" };
+
+test("chat/completions endpoint → openai source, not a responses endpoint, no downgrade", () => {
+  const r = resolveChatCoreRequestFormat({
+    ...base,
+    clientRawRequest: { endpoint: "/v1/chat/completions", headers: new Headers() },
+  });
+  assert.equal(r.endpointPath, "/v1/chat/completions");
+  assert.equal(r.sourceFormat, FORMATS.OPENAI);
+  assert.equal(r.isResponsesEndpoint, false);
+  assert.equal(r.clientResponseFormat, FORMATS.OPENAI);
+  assert.equal(r.nativeCodexPassthrough, false); // provider !== codex
+  assert.equal(r.isDroidCLI, false);
+  assert.equal(r.copilotCompatibleReasoning, false);
+});
+
+test("/responses endpoint → openai-responses source + isResponsesEndpoint, kept (no downgrade)", () => {
+  const r = resolveChatCoreRequestFormat({
+    body: { input: "x" },
+    provider: "openai",
+    userAgent: "unit-test",
+    clientRawRequest: { endpoint: "/v1/responses", headers: new Headers() },
+  });
+  assert.equal(r.sourceFormat, FORMATS.OPENAI_RESPONSES);
+  assert.equal(r.isResponsesEndpoint, true);
+  assert.equal(r.clientResponseFormat, FORMATS.OPENAI_RESPONSES);
+});
+
+test("Responses-shaped body on a /chat/completions endpoint downgrades clientResponseFormat to openai", () => {
+  const r = resolveChatCoreRequestFormat({
+    body: { input: "describe" }, // input + no messages → openai-responses via body
+    provider: "openai",
+    userAgent: "unit-test",
+    clientRawRequest: { endpoint: "/v1/chat/completions", headers: new Headers() },
+  });
+  assert.equal(r.sourceFormat, FORMATS.OPENAI_RESPONSES);
+  assert.equal(r.isResponsesEndpoint, false);
+  assert.equal(r.clientResponseFormat, FORMATS.OPENAI); // downgraded
+});
+
+test("Droid CLI suppresses the downgrade (clientResponseFormat stays openai-responses)", () => {
+  const r = resolveChatCoreRequestFormat({
+    body: { input: "describe" },
+    provider: "openai",
+    userAgent: "Droid/1.2 codex-cli",
+    clientRawRequest: { endpoint: "/v1/chat/completions", headers: new Headers() },
+  });
+  assert.equal(r.isDroidCLI, true);
+  assert.equal(r.sourceFormat, FORMATS.OPENAI_RESPONSES);
+  assert.equal(r.clientResponseFormat, FORMATS.OPENAI_RESPONSES); // !isDroidCLI is false → no downgrade
+});
+
+test("copilotCompatibleReasoning detects copilot via header or user-agent", () => {
+  const viaUa = resolveChatCoreRequestFormat({
+    ...base,
+    userAgent: "GitHubCopilotChat/0.1",
+    clientRawRequest: { endpoint: "/v1/chat/completions", headers: new Headers() },
+  });
+  assert.equal(viaUa.copilotCompatibleReasoning, true);
+
+  const viaHeader = resolveChatCoreRequestFormat({
+    ...base,
+    clientRawRequest: {
+      endpoint: "/v1/chat/completions",
+      headers: new Headers({ "x-client": "copilot-vscode" }),
+    },
+  });
+  assert.equal(viaHeader.copilotCompatibleReasoning, true);
+});
+
+test("nativeCodexPassthrough delegates to shouldUseNativeCodexPassthrough (codex + responses)", () => {
+  const r = resolveChatCoreRequestFormat({
+    body: { input: "x" },
+    provider: "codex",
+    userAgent: "unit-test",
+    clientRawRequest: { endpoint: "/v1/responses", headers: new Headers() },
+  });
+  assert.equal(
+    r.nativeCodexPassthrough,
+    shouldUseNativeCodexPassthrough({
+      provider: "codex",
+      sourceFormat: r.sourceFormat,
+      endpointPath: r.endpointPath,
+    })
+  );
+});
+
+test("missing clientRawRequest → empty endpointPath", () => {
+  const r = resolveChatCoreRequestFormat({ ...base, clientRawRequest: null });
+  assert.equal(r.endpointPath, "");
+});

--- a/tests/unit/chatcore-target-format.test.ts
+++ b/tests/unit/chatcore-target-format.test.ts
@@ -1,0 +1,89 @@
+// tests/unit/chatcore-target-format.test.ts
+// Characterization of resolveChatCoreTargetFormat — the wire target-format resolution extracted
+// from handleChatCore (chatCore god-file decomposition, #3501). Resolves the provider alias and the
+// upstream target format: apiFormat==="responses" forces OpenAI Responses; otherwise the model's
+// registry target format, then the custom-model override, then the provider default. Returns both
+// `alias` (reused downstream when stripping the alias/ prefix off the upstream model) and
+// `targetFormat`. Asserted against the inline composition so the delegation stays byte-identical.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { resolveChatCoreTargetFormat } from "../../open-sse/handlers/chatCore/targetFormat.ts";
+import { PROVIDER_ID_TO_ALIAS, getModelTargetFormat } from "../../open-sse/config/providerModels.ts";
+import { getTargetFormat } from "../../open-sse/services/provider.ts";
+import { FORMATS } from "../../open-sse/translator/formats.ts";
+
+function expected(
+  provider: string,
+  resolvedModel: string,
+  apiFormat: string | undefined,
+  customModelTargetFormat: string | undefined,
+  providerSpecificData: unknown
+) {
+  const alias = PROVIDER_ID_TO_ALIAS[provider] || provider;
+  const modelTargetFormat = getModelTargetFormat(alias, resolvedModel);
+  const targetFormat =
+    apiFormat === "responses"
+      ? FORMATS.OPENAI_RESPONSES
+      : modelTargetFormat || customModelTargetFormat || getTargetFormat(provider, providerSpecificData);
+  return { alias, targetFormat };
+}
+
+test("apiFormat='responses' short-circuits to OPENAI_RESPONSES (alias still resolved)", () => {
+  const r = resolveChatCoreTargetFormat({
+    provider: "openai",
+    resolvedModel: "gpt-4o",
+    apiFormat: "responses",
+    customModelTargetFormat: undefined,
+    providerSpecificData: undefined,
+  });
+  assert.equal(r.targetFormat, FORMATS.OPENAI_RESPONSES);
+  assert.equal(r.alias, PROVIDER_ID_TO_ALIAS["openai"] || "openai");
+});
+
+test("delegates byte-identically for a normal model (no apiFormat / no custom override)", () => {
+  const r = resolveChatCoreTargetFormat({
+    provider: "openai",
+    resolvedModel: "gpt-4o",
+    apiFormat: undefined,
+    customModelTargetFormat: undefined,
+    providerSpecificData: undefined,
+  });
+  assert.deepEqual(r, expected("openai", "gpt-4o", undefined, undefined, undefined));
+});
+
+test("customModelTargetFormat is used when the model has no registry target format", () => {
+  const customModel = "totally-unknown-custom-model-xyz";
+  // precondition: the registry has no target format for this unknown model
+  assert.ok(!getModelTargetFormat(PROVIDER_ID_TO_ALIAS["openai"] || "openai", customModel));
+  const r = resolveChatCoreTargetFormat({
+    provider: "openai",
+    resolvedModel: customModel,
+    apiFormat: undefined,
+    customModelTargetFormat: "claude",
+    providerSpecificData: undefined,
+  });
+  assert.equal(r.targetFormat, "claude");
+});
+
+test("falls back to getTargetFormat(provider) when neither model nor custom format apply", () => {
+  const customModel = "totally-unknown-custom-model-xyz";
+  const r = resolveChatCoreTargetFormat({
+    provider: "openai",
+    resolvedModel: customModel,
+    apiFormat: undefined,
+    customModelTargetFormat: undefined,
+    providerSpecificData: undefined,
+  });
+  assert.equal(r.targetFormat, getTargetFormat("openai", undefined));
+});
+
+test("unmapped provider → alias falls back to the provider id", () => {
+  const r = resolveChatCoreTargetFormat({
+    provider: "some-unmapped-provider",
+    resolvedModel: "x",
+    apiFormat: "responses",
+    customModelTargetFormat: undefined,
+    providerSpecificData: undefined,
+  });
+  assert.equal(r.alias, "some-unmapped-provider");
+});


### PR DESCRIPTION
## O quê

7º incremento da decomposição do god-file `chatCore.ts` (QG v2 Fase 9 T5, #3501). Move a resolução de **wire target-format** do topo de `handleChatCore` para o novo leaf puro `open-sse/handlers/chatCore/targetFormat.ts` (`resolveChatCoreTargetFormat`), ao lado de `resolveChatCoreRequestSetup` / `resolveChatCoreRequestFormat`.

> **Stacked sobre o #4526** (cadeia #4477 → #4491 → #4492 → #4507 → #4511 → #4526 → este). Base aponta para `refactor/qg-chatcore-bgredirect`; o GitHub re-aponta a cadeia automaticamente conforme os pais mergeiam.

## Como (preservação de comportamento)

- Retorna `{ alias, targetFormat }`:
  - `targetFormat` — `apiFormat==='responses'` força OpenAI Responses; senão o target-format do modelo no registry, depois o override custom (#2905), depois o default do provider.
  - `alias` — **reusado downstream** ao remover o prefixo `alias/` do model id upstream (lição da extração anterior: grepar TODAS as vars que o bloco declara; `alias` é consumido bem depois, em ~line 2374).
- O handler desestrutura o resultado; `modelTargetFormat` era intermediário local (não vaza).
- Imports órfãos (`getModelTargetFormat` / `PROVIDER_ID_TO_ALIAS` / `getTargetFormat`) migram para o leaf; `FORMATS` permanece (usado em vários pontos).

## Gates

- **file-size**: `chatCore.ts` neutro (4974, sem mudança — call+comentário compensam os 2 imports removidos); sem rebaseline.
- **complexity**: 1905 = baseline 1905 (neutro).
- **typecheck:core**: exit 0 (captura completa, 0 erros).
- **Testes**: `tests/unit/chatcore-target-format.test.ts` — 5 casos asseridos **contra a composição inline** (responses short-circuit, delegação byte-idêntica, custom override quando não há registry format, fallback ao default do provider, alias de provider não-mapeado). `chatcore-imports-cleanly` ✓ + **163/163** na suíte chatcore completa (excluído só o `translation-paths` flaky **pré-existente** — que aliás passou numa execução isolada nesta sessão).

> Nota: shrink de linhas neutro neste leaf — o valor é coesão + a lógica agora unit-testada e co-localizada com os outros resolvers de request-setup.

Extração de god-file sem mudança de comportamento em runtime.