### PR TITLE
fix(mcp): webFetchInput emits 'URL is required' for missing url (#4510)

### DIFF
--- a/open-sse/mcp-server/schemas/tools.ts
+++ b/open-sse/mcp-server/schemas/tools.ts
@@ -462,7 +462,7 @@ export const webSearchTool: McpToolDefinition<typeof webSearchInput, typeof webS
 // --- Tool 10: omniroute_web_fetch ---
 export const webFetchInput = z.object({
   url: z
-    .string()
+    .string({ error: "URL is required" })
     .min(1, "URL is required")
     .describe("The URL to fetch content from"),
   provider: z


### PR DESCRIPTION
## Fix latent base red: `webFetchInput` missing-url message (#4510)

The `omniroute_web_fetch` tool (#4510) defines its input as:

```ts
url: z.string().min(1, "URL is required")
```

`.min(1, …)` only fires for an **empty string**. When `url` is **missing**
(`webFetchInput.parse({})`), Zod v4 fails the `.string()` **type check** first and
emits the default message `Invalid input: expected string, received undefined` —
never reaching `.min()`. So the existing test `webFetchInput rejects missing URL`
(which expects `/URL is required/`) fails.

This surfaced as a **Fast Quality Gates failure** on the full unit suite for PRs into
`release/v3.8.33` (the fast-path that landed #4510 did not run the full suite). It is
unrelated to whichever feature PR happens to trigger the gate.

### Fix
```ts
url: z.string({ error: "URL is required" }).min(1, "URL is required")
```
The `error` param customizes the type-check message, so **both** the missing-field and
the empty-string cases emit `URL is required`; a valid url still passes.

### Verification
- `tests/unit/mcp-web-fetch-tool.test.ts` → **13/13** (was 1 failing: `webFetchInput rejects missing URL`).
- Boundary sanity: `{}` → "URL is required"; `{url:""}` → "URL is required"; `{url:"https://x.com"}` → OK.
- `typecheck:core` clean · `eslint open-sse/mcp-server/schemas/tools.ts` clean.

One-line change; no behavior change to a valid web_fetch call.
