### PR TITLE
refactor(chatCore): restore #4507 + #4511 leaves orphaned from release by churn (#3501)

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -44,7 +44,8 @@ import {
 import { CORS_HEADERS } from "../utils/cors.ts";
 import { checkHeapPressureGuard } from "../utils/heapPressure.ts";
 import { normalizeHeaders } from "../utils/headers.ts";
-import { detectFormatFromEndpoint, getTargetFormat } from "../services/provider.ts";
+import { getTargetFormat } from "../services/provider.ts";
+import { resolveChatCoreRequestFormat } from "./chatCore/requestFormat.ts";
 import { injectSystemPrompt } from "../services/systemPrompt.ts";
 import { translateRequest, needsTranslation } from "../translator/index.ts";
 import { FORMATS } from "../translator/formats.ts";
@@ -549,28 +550,6 @@ function buildExecutorClientHeaders(
   return Object.keys(normalized).length > 0 ? normalized : null;
 }
 
-function isCopilotClient(
-  headers: Headers | Record<string, unknown> | null | undefined,
-  userAgent?: string | null
-) {
-  const isMatch = (value: unknown) =>
-    typeof value === "string" && value.toLowerCase().includes("copilot");
-
-  if (isMatch(userAgent)) return true;
-
-  if (headers instanceof Headers) {
-    for (const [key, value] of headers as unknown as Iterable<[string, string]>) {
-      if (isMatch(key) || isMatch(value)) return true;
-    }
-  } else if (headers && typeof headers === "object") {
-    for (const [key, value] of Object.entries(headers)) {
-      if (isMatch(key) || isMatch(value)) return true;
-    }
-  }
-
-  return false;
-}
-
 export function extractSystemRoleMessages(payload: Record<string, unknown>): void {
   if (!Array.isArray(payload.messages)) return;
   const messages = payload.messages as Array<{ role?: unknown; content?: unknown }>;
@@ -874,22 +853,17 @@ export async function handleChatCore({
     credentials.connectionId = connectionId;
   }
 
-  const endpointPath = String(clientRawRequest?.endpoint || "");
-  const sourceFormat = detectFormatFromEndpoint(body, endpointPath);
-  const isResponsesEndpoint =
-    /\/responses(?=\/|$)/i.test(endpointPath) || /^responses(?=\/|$)/i.test(endpointPath);
-  const nativeCodexPassthrough = shouldUseNativeCodexPassthrough({
-    provider,
-    sourceFormat,
+  // Endpoint/format resolution extracted to chatCore/requestFormat.ts (#3501); pure derivation
+  // from the inbound request, destructured so every downstream use stays byte-identical.
+  const {
     endpointPath,
-  });
-  const isDroidCLI =
-    userAgent?.toLowerCase().includes("droid") || userAgent?.toLowerCase().includes("codex-cli");
-  const copilotCompatibleReasoning = isCopilotClient(clientRawRequest?.headers, userAgent);
-  const clientResponseFormat =
-    sourceFormat === FORMATS.OPENAI_RESPONSES && !isResponsesEndpoint && !isDroidCLI
-      ? FORMATS.OPENAI
-      : sourceFormat;
+    sourceFormat,
+    isResponsesEndpoint,
+    nativeCodexPassthrough,
+    isDroidCLI,
+    copilotCompatibleReasoning,
+    clientResponseFormat,
+  } = resolveChatCoreRequestFormat({ clientRawRequest, body, provider, userAgent });
 
   // Check for bypass patterns (warmup, skip) - return fake response
   const bypassResponse = handleBypassRequest(body, model, userAgent);

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -71,11 +71,8 @@ import {
 import { createRequestLogger } from "../utils/requestLogger.ts";
 import { createPreparedRequestLogger, runWithCapture } from "../utils/providerRequestLogging.ts";
 import { applyResponsesPreviousResponseIdPolicy } from "../utils/responsesStatePolicy.ts";
-import {
-  getModelTargetFormat,
-  PROVIDER_ID_TO_ALIAS,
-  splitClaudeEffortSuffix,
-} from "../config/providerModels.ts";
+import { getModelTargetFormat, PROVIDER_ID_TO_ALIAS } from "../config/providerModels.ts";
+import { applyClaudeEffortVariant } from "./chatCore/claudeEffortVariant.ts";
 import { DEFAULT_THINKING_CLAUDE_SIGNATURE } from "../config/defaultThinkingSignature.ts";
 import {
   getStripTypesForProviderModel,
@@ -924,30 +921,18 @@ export async function handleChatCore({
   // it into Claude thinking/effort config. An explicit client-supplied effort always
   // wins; native Claude passthrough is left untouched (it carries its own `thinking`),
   // and non-thinking base models are cleaned up later by normalizeThinkingForModel().
-  if (
-    (provider === "claude" || isClaudeCodeCompatibleProvider(provider)) &&
-    typeof effectiveModel === "string"
-  ) {
-    const { baseModel, effort } = splitClaudeEffortSuffix(effectiveModel);
-    if (effort) {
-      effectiveModel = baseModel;
-      if (body && typeof body === "object" && !Array.isArray(body)) {
-        const claudeBody = body as Record<string, unknown>;
-        claudeBody.model = baseModel;
-        if (sourceFormat !== FORMATS.CLAUDE) {
-          const explicitEffort =
-            claudeBody.reasoning_effort ??
-            (claudeBody.reasoning as Record<string, unknown> | undefined)?.effort ??
-            (claudeBody.output_config as Record<string, unknown> | undefined)?.effort;
-          if (explicitEffort === undefined || explicitEffort === null || explicitEffort === "") {
-            claudeBody.reasoning_effort = effort;
-          }
-        }
-      }
-      log?.info?.(
-        "PARAMS",
-        `Claude effort variant: stripped "-${effort}" → ${baseModel} (reasoning_effort=${effort})`
-      );
+  // Extracted to chatCore/claudeEffortVariant.ts (#3501); mutates body in place and returns the
+  // stripped model + an optional log line, keeping behaviour byte-identical.
+  {
+    const effortVariant = applyClaudeEffortVariant({
+      provider,
+      effectiveModel,
+      body,
+      sourceFormat,
+    });
+    effectiveModel = effortVariant.effectiveModel;
+    if (effortVariant.log) {
+      log?.info?.("PARAMS", effortVariant.log);
     }
   }
 

--- a/open-sse/handlers/chatCore/claudeEffortVariant.ts
+++ b/open-sse/handlers/chatCore/claudeEffortVariant.ts
@@ -1,0 +1,62 @@
+/**
+ * chatCore Claude effort-variant normalizer (Quality Gate v2 / Fase 9 — chatCore god-file
+ * decomposition, #3501).
+ *
+ * The Claude / Claude-Code model picker (e.g. VS Code's "Effort" slider) advertises
+ * claude-...-{low,medium,high,xhigh,max}. Anthropic has no such model, so the suffixed id 404s
+ * upstream. This strips it back to the real base id and surfaces the level as reasoning_effort so
+ * the OpenAI→Claude translator / Claude-Code bridge can turn it into Claude thinking/effort config.
+ * An explicit client-supplied effort always wins; native Claude passthrough (sourceFormat === claude)
+ * is left untouched (it carries its own `thinking`). The body is mutated in place (model +
+ * reasoning_effort), byte-identical to the previous inline block; the new effectiveModel and an
+ * optional log line are returned for the handler to apply.
+ */
+
+import { splitClaudeEffortSuffix } from "../../config/providerModels.ts";
+import { isClaudeCodeCompatibleProvider } from "../../services/claudeCodeCompatible.ts";
+import { FORMATS } from "../../translator/formats.ts";
+
+/**
+ * True when the client already supplied an explicit reasoning effort (top-level reasoning_effort,
+ * reasoning.effort, or output_config.effort) — in which case the stripped suffix must not overwrite
+ * it. A blank string counts as "not supplied".
+ */
+function hasExplicitClaudeEffort(claudeBody: Record<string, unknown>): boolean {
+  const explicitEffort =
+    claudeBody.reasoning_effort ??
+    (claudeBody.reasoning as Record<string, unknown> | undefined)?.effort ??
+    (claudeBody.output_config as Record<string, unknown> | undefined)?.effort;
+  return !(explicitEffort === undefined || explicitEffort === null || explicitEffort === "");
+}
+
+export function applyClaudeEffortVariant(opts: {
+  provider: string | null | undefined;
+  effectiveModel: string;
+  /** Mutated in place (model + reasoning_effort) when an effort suffix is stripped. */
+  body: unknown;
+  sourceFormat: string;
+}): { effectiveModel: string; log: string | null } {
+  const { provider, body, sourceFormat } = opts;
+  let effectiveModel = opts.effectiveModel;
+  let log: string | null = null;
+
+  if (
+    (provider === "claude" || isClaudeCodeCompatibleProvider(provider)) &&
+    typeof effectiveModel === "string"
+  ) {
+    const { baseModel, effort } = splitClaudeEffortSuffix(effectiveModel);
+    if (effort) {
+      effectiveModel = baseModel;
+      if (body && typeof body === "object" && !Array.isArray(body)) {
+        const claudeBody = body as Record<string, unknown>;
+        claudeBody.model = baseModel;
+        if (sourceFormat !== FORMATS.CLAUDE && !hasExplicitClaudeEffort(claudeBody)) {
+          claudeBody.reasoning_effort = effort;
+        }
+      }
+      log = `Claude effort variant: stripped "-${effort}" → ${baseModel} (reasoning_effort=${effort})`;
+    }
+  }
+
+  return { effectiveModel, log };
+}

--- a/open-sse/handlers/chatCore/requestFormat.ts
+++ b/open-sse/handlers/chatCore/requestFormat.ts
@@ -1,0 +1,82 @@
+/**
+ * chatCore request endpoint/format resolvers (Quality Gate v2 / Fase 9 — chatCore god-file
+ * decomposition, #3501).
+ *
+ * Pure slice of handleChatCore's request-setup phase: derives the wire-format facts of an inbound
+ * request from its endpoint, body, provider, and user-agent — the source format, whether it targets
+ * the Responses endpoint, native-Codex passthrough eligibility, Droid CLI / Copilot detection, and
+ * the effective client response format (an OpenAI Responses shape off a non-/responses, non-Droid
+ * endpoint collapses back to plain OpenAI). Side-effect-free; behaviour is byte-identical to the
+ * previous inline block. Sits alongside resolveChatCoreRequestSetup as the request-setup phase grows.
+ */
+
+import { detectFormatFromEndpoint } from "../../services/provider.ts";
+import { shouldUseNativeCodexPassthrough } from "./passthroughHelpers.ts";
+import { FORMATS } from "../../translator/formats.ts";
+
+/** True when the request originates from a Copilot client (matched by user-agent or any header). */
+function isCopilotClient(
+  headers: Headers | Record<string, unknown> | null | undefined,
+  userAgent?: string | null
+) {
+  const isMatch = (value: unknown) =>
+    typeof value === "string" && value.toLowerCase().includes("copilot");
+
+  if (isMatch(userAgent)) return true;
+
+  if (headers instanceof Headers) {
+    for (const [key, value] of headers as unknown as Iterable<[string, string]>) {
+      if (isMatch(key) || isMatch(value)) return true;
+    }
+  } else if (headers && typeof headers === "object") {
+    for (const [key, value] of Object.entries(headers)) {
+      if (isMatch(key) || isMatch(value)) return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Resolve the per-request endpoint/format facts at the top of handleChatCore. Pure: a function of
+ * the inbound endpoint, the (possibly already-mutated) body, the resolved provider, and the
+ * user-agent.
+ */
+export function resolveChatCoreRequestFormat(opts: {
+  clientRawRequest:
+    | { endpoint?: unknown; headers?: Headers | Record<string, unknown> | null }
+    | null
+    | undefined;
+  body: unknown;
+  provider: string | null | undefined;
+  userAgent: string | null | undefined;
+}) {
+  const { clientRawRequest, body, provider, userAgent } = opts;
+  const endpointPath = String(clientRawRequest?.endpoint || "");
+  const sourceFormat = detectFormatFromEndpoint(body, endpointPath);
+  const isResponsesEndpoint =
+    /\/responses(?=\/|$)/i.test(endpointPath) || /^responses(?=\/|$)/i.test(endpointPath);
+  const nativeCodexPassthrough = shouldUseNativeCodexPassthrough({
+    provider,
+    sourceFormat,
+    endpointPath,
+  });
+  const isDroidCLI =
+    userAgent?.toLowerCase().includes("droid") || userAgent?.toLowerCase().includes("codex-cli");
+  const copilotCompatibleReasoning = isCopilotClient(clientRawRequest?.headers, userAgent);
+  const clientResponseFormat =
+    sourceFormat === FORMATS.OPENAI_RESPONSES && !isResponsesEndpoint && !isDroidCLI
+      ? FORMATS.OPENAI
+      : sourceFormat;
+  return {
+    endpointPath,
+    sourceFormat,
+    isResponsesEndpoint,
+    nativeCodexPassthrough,
+    isDroidCLI,
+    copilotCompatibleReasoning,
+    clientResponseFormat,
+  };
+}
+
+export type ChatCoreRequestFormat = ReturnType<typeof resolveChatCoreRequestFormat>;

--- a/tests/unit/chatcore-claude-effort-variant.test.ts
+++ b/tests/unit/chatcore-claude-effort-variant.test.ts
@@ -1,0 +1,107 @@
+// tests/unit/chatcore-claude-effort-variant.test.ts
+// Characterization of applyClaudeEffortVariant — the Claude effort-suffix normalization extracted
+// from handleChatCore (chatCore god-file decomposition, #3501). The VS Code "Effort" slider
+// advertises claude-...-{low,medium,high,xhigh,max}; Anthropic has no such model, so the suffix is
+// stripped to the base id and surfaced as reasoning_effort. Locks: the provider gate (claude /
+// claude-code-compatible only), the in-place body mutation (model + reasoning_effort), the
+// sourceFormat==="claude" skip, the explicit-effort-wins rule, and the returned effectiveModel/log.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { applyClaudeEffortVariant } from "../../open-sse/handlers/chatCore/claudeEffortVariant.ts";
+import { FORMATS } from "../../open-sse/translator/formats.ts";
+
+test("claude provider + effort suffix → strips to base, mutates body model + reasoning_effort, returns log", () => {
+  const body: Record<string, unknown> = { model: "claude-sonnet-4-high", messages: [] };
+  const r = applyClaudeEffortVariant({
+    provider: "claude",
+    effectiveModel: "claude-sonnet-4-high",
+    body,
+    sourceFormat: FORMATS.OPENAI,
+  });
+  assert.equal(r.effectiveModel, "claude-sonnet-4");
+  assert.equal(body.model, "claude-sonnet-4");
+  assert.equal(body.reasoning_effort, "high");
+  assert.match(String(r.log), /stripped "-high" → claude-sonnet-4 \(reasoning_effort=high\)/);
+});
+
+test("claude-code-compatible provider triggers the same stripping", () => {
+  const body: Record<string, unknown> = { model: "claude-opus-4-xhigh", messages: [] };
+  const r = applyClaudeEffortVariant({
+    provider: "anthropic-compatible-cc-default",
+    effectiveModel: "claude-opus-4-xhigh",
+    body,
+    sourceFormat: FORMATS.OPENAI,
+  });
+  assert.equal(r.effectiveModel, "claude-opus-4");
+  assert.equal(body.model, "claude-opus-4");
+  assert.equal(body.reasoning_effort, "xhigh");
+});
+
+test("sourceFormat 'claude' strips the model but does NOT inject reasoning_effort", () => {
+  const body: Record<string, unknown> = { model: "claude-sonnet-4-medium", messages: [] };
+  const r = applyClaudeEffortVariant({
+    provider: "claude",
+    effectiveModel: "claude-sonnet-4-medium",
+    body,
+    sourceFormat: FORMATS.CLAUDE,
+  });
+  assert.equal(r.effectiveModel, "claude-sonnet-4");
+  assert.equal(body.model, "claude-sonnet-4");
+  assert.equal(body.reasoning_effort, undefined);
+});
+
+test("an explicit client reasoning_effort wins (not overwritten)", () => {
+  const body: Record<string, unknown> = { model: "claude-sonnet-4-low", reasoning_effort: "high", messages: [] };
+  const r = applyClaudeEffortVariant({
+    provider: "claude",
+    effectiveModel: "claude-sonnet-4-low",
+    body,
+    sourceFormat: FORMATS.OPENAI,
+  });
+  assert.equal(r.effectiveModel, "claude-sonnet-4");
+  assert.equal(body.reasoning_effort, "high"); // unchanged
+});
+
+test("explicit effort nested under reasoning.effort also wins", () => {
+  const body: Record<string, unknown> = {
+    model: "claude-sonnet-4-low",
+    reasoning: { effort: "medium" },
+    messages: [],
+  };
+  const r = applyClaudeEffortVariant({
+    provider: "claude",
+    effectiveModel: "claude-sonnet-4-low",
+    body,
+    sourceFormat: FORMATS.OPENAI,
+  });
+  assert.equal(body.reasoning_effort, undefined); // explicit reasoning.effort present → no injection
+  assert.equal(r.effectiveModel, "claude-sonnet-4");
+});
+
+test("no effort suffix → no change, no log", () => {
+  const body: Record<string, unknown> = { model: "claude-sonnet-4", messages: [] };
+  const r = applyClaudeEffortVariant({
+    provider: "claude",
+    effectiveModel: "claude-sonnet-4",
+    body,
+    sourceFormat: FORMATS.OPENAI,
+  });
+  assert.equal(r.effectiveModel, "claude-sonnet-4");
+  assert.equal(body.model, "claude-sonnet-4");
+  assert.equal(body.reasoning_effort, undefined);
+  assert.equal(r.log, null);
+});
+
+test("non-claude provider is a no-op even with an effort suffix", () => {
+  const body: Record<string, unknown> = { model: "gpt-5-high", messages: [] };
+  const r = applyClaudeEffortVariant({
+    provider: "openai",
+    effectiveModel: "gpt-5-high",
+    body,
+    sourceFormat: FORMATS.OPENAI,
+  });
+  assert.equal(r.effectiveModel, "gpt-5-high");
+  assert.equal(body.model, "gpt-5-high");
+  assert.equal(body.reasoning_effort, undefined);
+  assert.equal(r.log, null);
+});

--- a/tests/unit/chatcore-request-format.test.ts
+++ b/tests/unit/chatcore-request-format.test.ts
@@ -1,0 +1,103 @@
+// tests/unit/chatcore-request-format.test.ts
+// Characterization of resolveChatCoreRequestFormat — the endpoint/format resolution slice extracted
+// from the top of handleChatCore (chatCore god-file decomposition, #3501). Locks the endpointPath
+// construction, the /responses detection, the nativeCodexPassthrough + isDroidCLI + copilot wiring,
+// and the clientResponseFormat downgrade (OpenAI Responses shape off a non-/responses, non-Droid
+// endpoint collapses to plain OpenAI).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { resolveChatCoreRequestFormat } from "../../open-sse/handlers/chatCore/requestFormat.ts";
+import { shouldUseNativeCodexPassthrough } from "../../open-sse/handlers/chatCore/passthroughHelpers.ts";
+import { FORMATS } from "../../open-sse/translator/formats.ts";
+
+const base = { body: { messages: [{ role: "user", content: "hi" }] }, provider: "openai", userAgent: "unit-test" };
+
+test("chat/completions endpoint → openai source, not a responses endpoint, no downgrade", () => {
+  const r = resolveChatCoreRequestFormat({
+    ...base,
+    clientRawRequest: { endpoint: "/v1/chat/completions", headers: new Headers() },
+  });
+  assert.equal(r.endpointPath, "/v1/chat/completions");
+  assert.equal(r.sourceFormat, FORMATS.OPENAI);
+  assert.equal(r.isResponsesEndpoint, false);
+  assert.equal(r.clientResponseFormat, FORMATS.OPENAI);
+  assert.equal(r.nativeCodexPassthrough, false); // provider !== codex
+  assert.equal(r.isDroidCLI, false);
+  assert.equal(r.copilotCompatibleReasoning, false);
+});
+
+test("/responses endpoint → openai-responses source + isResponsesEndpoint, kept (no downgrade)", () => {
+  const r = resolveChatCoreRequestFormat({
+    body: { input: "x" },
+    provider: "openai",
+    userAgent: "unit-test",
+    clientRawRequest: { endpoint: "/v1/responses", headers: new Headers() },
+  });
+  assert.equal(r.sourceFormat, FORMATS.OPENAI_RESPONSES);
+  assert.equal(r.isResponsesEndpoint, true);
+  assert.equal(r.clientResponseFormat, FORMATS.OPENAI_RESPONSES);
+});
+
+test("Responses-shaped body on a /chat/completions endpoint downgrades clientResponseFormat to openai", () => {
+  const r = resolveChatCoreRequestFormat({
+    body: { input: "describe" }, // input + no messages → openai-responses via body
+    provider: "openai",
+    userAgent: "unit-test",
+    clientRawRequest: { endpoint: "/v1/chat/completions", headers: new Headers() },
+  });
+  assert.equal(r.sourceFormat, FORMATS.OPENAI_RESPONSES);
+  assert.equal(r.isResponsesEndpoint, false);
+  assert.equal(r.clientResponseFormat, FORMATS.OPENAI); // downgraded
+});
+
+test("Droid CLI suppresses the downgrade (clientResponseFormat stays openai-responses)", () => {
+  const r = resolveChatCoreRequestFormat({
+    body: { input: "describe" },
+    provider: "openai",
+    userAgent: "Droid/1.2 codex-cli",
+    clientRawRequest: { endpoint: "/v1/chat/completions", headers: new Headers() },
+  });
+  assert.equal(r.isDroidCLI, true);
+  assert.equal(r.sourceFormat, FORMATS.OPENAI_RESPONSES);
+  assert.equal(r.clientResponseFormat, FORMATS.OPENAI_RESPONSES); // !isDroidCLI is false → no downgrade
+});
+
+test("copilotCompatibleReasoning detects copilot via header or user-agent", () => {
+  const viaUa = resolveChatCoreRequestFormat({
+    ...base,
+    userAgent: "GitHubCopilotChat/0.1",
+    clientRawRequest: { endpoint: "/v1/chat/completions", headers: new Headers() },
+  });
+  assert.equal(viaUa.copilotCompatibleReasoning, true);
+
+  const viaHeader = resolveChatCoreRequestFormat({
+    ...base,
+    clientRawRequest: {
+      endpoint: "/v1/chat/completions",
+      headers: new Headers({ "x-client": "copilot-vscode" }),
+    },
+  });
+  assert.equal(viaHeader.copilotCompatibleReasoning, true);
+});
+
+test("nativeCodexPassthrough delegates to shouldUseNativeCodexPassthrough (codex + responses)", () => {
+  const r = resolveChatCoreRequestFormat({
+    body: { input: "x" },
+    provider: "codex",
+    userAgent: "unit-test",
+    clientRawRequest: { endpoint: "/v1/responses", headers: new Headers() },
+  });
+  assert.equal(
+    r.nativeCodexPassthrough,
+    shouldUseNativeCodexPassthrough({
+      provider: "codex",
+      sourceFormat: r.sourceFormat,
+      endpointPath: r.endpointPath,
+    })
+  );
+});
+
+test("missing clientRawRequest → empty endpointPath", () => {
+  const r = resolveChatCoreRequestFormat({ ...base, clientRawRequest: null });
+  assert.equal(r.endpointPath, "");
+});


### PR DESCRIPTION
PRs #4507 (endpoint/format leaf → requestFormat.ts) and #4511 (Claude effort-variant leaf → claudeEffortVariant.ts) show MERGED on GitHub but their squash commits (0f67eee11 / aef00dded) were orphaned from release/v3.8.33 by a parallel-session force-push — the leaf files + chatCore.ts wiring vanished and release fell back to the inline form. Re-applies both extractions (clean cherry-pick onto the reverted-to-inline tip). 19/19 chatCore tests pass, typecheck clean, file-size OK (chatCore shrinks, leaves under cap).