### PR TITLE
fix(oauth): update Qwen OAuth URLs from chat.qwen.ai to qwen.ai (port decolua/9router#683)

### DIFF
--- a/src/lib/oauth/constants/oauth.ts
+++ b/src/lib/oauth/constants/oauth.ts
@@ -99,8 +99,8 @@ export const GEMINI_CONFIG = {
 // Qwen OAuth Configuration (Device Code Flow with PKCE)
 export const QWEN_CONFIG = {
   clientId: resolvePublicCred("qwen_id", "QWEN_OAUTH_CLIENT_ID"),
-  deviceCodeUrl: "https://chat.qwen.ai/api/v1/oauth2/device/code",
-  tokenUrl: "https://chat.qwen.ai/api/v1/oauth2/token",
+  deviceCodeUrl: "https://qwen.ai/api/v1/oauth2/device/code",
+  tokenUrl: "https://qwen.ai/api/v1/oauth2/token",
   scope: "openid profile email model.completion",
   codeChallengeMethod: "S256",
 };

--- a/tests/unit/oauth-providers-config.test.ts
+++ b/tests/unit/oauth-providers-config.test.ts
@@ -293,6 +293,18 @@ test("all provider endpoint URLs use HTTPS when a URL is configured", () => {
   }
 });
 
+test("Qwen OAuth uses qwen.ai (not chat.qwen.ai) for device/token URLs — upstream PR #683 / decolua issue #572", () => {
+  // The legacy host `chat.qwen.ai` started returning errors; the correct authoritative
+  // host for Qwen's device-code OAuth endpoints is `qwen.ai`. Regression guard for the
+  // port of decolua/9router#683 (closes decolua issue #572).
+  const deviceUrl = new URL(QWEN_CONFIG.deviceCodeUrl);
+  const tokenUrl = new URL(QWEN_CONFIG.tokenUrl);
+  assert.equal(deviceUrl.hostname, "qwen.ai", "deviceCodeUrl must use qwen.ai");
+  assert.equal(tokenUrl.hostname, "qwen.ai", "tokenUrl must use qwen.ai");
+  assert.equal(deviceUrl.pathname, "/api/v1/oauth2/device/code");
+  assert.equal(tokenUrl.pathname, "/api/v1/oauth2/token");
+});
+
 test("browser-based providers expose buildAuthUrl and return provider-specific auth URLs", () => {
   const redirectUri = "http://localhost:43121/callback";
   const state = "state-123";


### PR DESCRIPTION
## Summary

Port of upstream [decolua/9router#683](https://github.com/decolua/9router/pull/683) (closes decolua/9router#572).

The Qwen device-code OAuth flow in OmniRoute was pointing at the legacy `chat.qwen.ai` host, which started returning errors. The authoritative host is `qwen.ai`.

## Change

`src/lib/oauth/constants/oauth.ts` — `QWEN_CONFIG`:

- `deviceCodeUrl`: `https://chat.qwen.ai/api/v1/oauth2/device/code` → `https://qwen.ai/api/v1/oauth2/device/code`
- `tokenUrl`: `https://chat.qwen.ai/api/v1/oauth2/token` → `https://qwen.ai/api/v1/oauth2/token`

Only the OAuth endpoints are migrated. The `qwen-web` executor + `tokenExtractionConfig` still target `chat.qwen.ai` (the actual Qwen Chat web UI lives there); those are out of scope for this fix.

## Test plan (Hard Rule #18 — TDD)

A new regression test in `tests/unit/oauth-providers-config.test.ts` parses both URLs and asserts `hostname === "qwen.ai"` + the expected paths.

- [x] `node --import tsx/esm --test tests/unit/oauth-providers-config.test.ts` — 27/27 pass
- [ ] CI green

## Attribution

Inspired-by: https://github.com/decolua/9router/pull/683 (thanks @anuragg-saxenaa)

Note: PR #687 upstream is a duplicate of this fix and is intentionally not ported separately.