### PR TITLE
fix(dashboard): keep play_arrow spinning on provider Test All buttons (port from 9router#715)

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/page.tsx
+++ b/src/app/(dashboard)/dashboard/providers/page.tsx
@@ -951,8 +951,8 @@ export default function ProvidersPage() {
                       }`}
                       title={t("testAllCompatible")}
                     >
-                      <span className="material-symbols-outlined text-[14px]">
-                        {testingMode === "compatible" ? "sync" : "play_arrow"}
+                      <span className={`material-symbols-outlined text-[14px]${testingMode === "compatible" ? " animate-spin" : ""}`}>
+                        play_arrow
                       </span>
                       {testingMode === "compatible" ? t("testing") : t("testAll")}
                     </button>
@@ -1046,8 +1046,8 @@ export default function ProvidersPage() {
                     title={t("testAllOAuth")}
                     aria-label={t("testAllOAuth")}
                   >
-                    <span className="material-symbols-outlined text-[14px]">
-                      {testingMode === "oauth" ? "sync" : "play_arrow"}
+                    <span className={`material-symbols-outlined text-[14px]${testingMode === "oauth" ? " animate-spin" : ""}`}>
+                      play_arrow
                     </span>
                     {testingMode === "oauth" ? t("testing") : t("testAll")}
                   </button>
@@ -1096,8 +1096,8 @@ export default function ProvidersPage() {
                   title={t("testAll")}
                   aria-label={t("testAll")}
                 >
-                  <span className="material-symbols-outlined text-[14px]">
-                    {testingMode === "ide" ? "sync" : "play_arrow"}
+                  <span className={`material-symbols-outlined text-[14px]${testingMode === "ide" ? " animate-spin" : ""}`}>
+                    play_arrow
                   </span>
                   {testingMode === "ide" ? t("testing") : t("testAll")}
                 </button>
@@ -1153,8 +1153,8 @@ export default function ProvidersPage() {
                   }`}
                   title={t("testAll")}
                 >
-                  <span className="material-symbols-outlined text-[14px]">
-                    {testingMode === "web-cookie" ? "sync" : "play_arrow"}
+                  <span className={`material-symbols-outlined text-[14px]${testingMode === "web-cookie" ? " animate-spin" : ""}`}>
+                    play_arrow
                   </span>
                   {testingMode === "web-cookie" ? t("testing") : t("testAll")}
                 </button>
@@ -1197,8 +1197,8 @@ export default function ProvidersPage() {
                   }`}
                   title={t("testAll")}
                 >
-                  <span className="material-symbols-outlined text-[14px]">
-                    {testingMode === "free" ? "sync" : "play_arrow"}
+                  <span className={`material-symbols-outlined text-[14px]${testingMode === "free" ? " animate-spin" : ""}`}>
+                    play_arrow
                   </span>
                   {testingMode === "free" ? t("testing") : t("testAll")}
                 </button>
@@ -1242,8 +1242,8 @@ export default function ProvidersPage() {
                   title={t("testAllApiKey")}
                   aria-label={t("testAllApiKey")}
                 >
-                  <span className="material-symbols-outlined text-[14px]">
-                    {testingMode === "apikey" ? "sync" : "play_arrow"}
+                  <span className={`material-symbols-outlined text-[14px]${testingMode === "apikey" ? " animate-spin" : ""}`}>
+                    play_arrow
                   </span>
                   {testingMode === "apikey" ? t("testing") : t("testAll")}
                 </button>
@@ -1294,8 +1294,8 @@ export default function ProvidersPage() {
                   }`}
                   title={t("testAll")}
                 >
-                  <span className="material-symbols-outlined text-[14px]">
-                    {testingMode === "no-auth" ? "sync" : "play_arrow"}
+                  <span className={`material-symbols-outlined text-[14px]${testingMode === "no-auth" ? " animate-spin" : ""}`}>
+                    play_arrow
                   </span>
                   {testingMode === "no-auth" ? t("testing") : t("testAll")}
                 </button>
@@ -1338,8 +1338,8 @@ export default function ProvidersPage() {
                   }`}
                   title={t("testAll")}
                 >
-                  <span className="material-symbols-outlined text-[14px]">
-                    {testingMode === "upstream-proxy" ? "sync" : "play_arrow"}
+                  <span className={`material-symbols-outlined text-[14px]${testingMode === "upstream-proxy" ? " animate-spin" : ""}`}>
+                    play_arrow
                   </span>
                   {testingMode === "upstream-proxy" ? t("testing") : t("testAll")}
                 </button>
@@ -1481,8 +1481,8 @@ export default function ProvidersPage() {
                   }`}
                   title={t("testAll")}
                 >
-                  <span className="material-symbols-outlined text-[14px]">
-                    {testingMode === "cloud-agent" ? "sync" : "play_arrow"}
+                  <span className={`material-symbols-outlined text-[14px]${testingMode === "cloud-agent" ? " animate-spin" : ""}`}>
+                    play_arrow
                   </span>
                   {testingMode === "cloud-agent" ? t("testing") : t("testAll")}
                 </button>
@@ -1529,8 +1529,8 @@ export default function ProvidersPage() {
                   }`}
                   title={t("testAll")}
                 >
-                  <span className="material-symbols-outlined text-[14px]">
-                    {testingMode === "local" ? "sync" : "play_arrow"}
+                  <span className={`material-symbols-outlined text-[14px]${testingMode === "local" ? " animate-spin" : ""}`}>
+                    play_arrow
                   </span>
                   {testingMode === "local" ? t("testing") : t("testAll")}
                 </button>
@@ -1573,8 +1573,8 @@ export default function ProvidersPage() {
                   }`}
                   title={t("testAll")}
                 >
-                  <span className="material-symbols-outlined text-[14px]">
-                    {testingMode === "search" ? "sync" : "play_arrow"}
+                  <span className={`material-symbols-outlined text-[14px]${testingMode === "search" ? " animate-spin" : ""}`}>
+                    play_arrow
                   </span>
                   {testingMode === "search" ? t("testing") : t("testAll")}
                 </button>
@@ -1683,8 +1683,8 @@ export default function ProvidersPage() {
                   }`}
                   title={t("testAll")}
                 >
-                  <span className="material-symbols-outlined text-[14px]">
-                    {testingMode === "audio" ? "sync" : "play_arrow"}
+                  <span className={`material-symbols-outlined text-[14px]${testingMode === "audio" ? " animate-spin" : ""}`}>
+                    play_arrow
                   </span>
                   {testingMode === "audio" ? t("testing") : t("testAll")}
                 </button>


### PR DESCRIPTION
## Summary

Ports [decolua/9router#715](https://github.com/decolua/9router/pull/715) by @luandiasrj to the OmniRoute TS fork.

The 12 "Test All" buttons on `/dashboard/providers` swap their material-symbol icon between `play_arrow` (idle) and `sync` (running). Two issues:

- `sync` has counter-clockwise arrows by design, which visually fight the CSS `rotate(360deg)` spin animation.
- Swapping the glyph mid-action is jarring.

Fix: always render `play_arrow` and toggle the `animate-spin` class while the matching `testingMode` is active. Mirrors the upstream pattern exactly.

## Affected files

- `src/app/(dashboard)/dashboard/providers/page.tsx` — 12 buttons (compatible, oauth, ide, web-cookie, free, apikey, no-auth, upstream-proxy, cloud-agent, local, search, audio).

Upstream PR also touched `media-providers/[kind]/[id]/page.js` (3 example cards) — in the TS fork that page is a thin server component delegating to `MediaProviderPageClient` and the related cards (`EmbeddingExampleCard.tsx` / `TtsExampleCard.tsx` / `SttExampleCard.tsx` / `PlaygroundCard.tsx` / `LlmChatCard.tsx`) don't use the `play_arrow`/`progress_activity` pattern at all, so nothing to port there.

## Validation (Hard Rule #18, option 2 — UI-only visual regression)

- `npm run typecheck:core` → clean.
- `npx eslint src/app/(dashboard)/dashboard/providers/page.tsx` → clean.
- Visual: open `/dashboard/providers`, click any group's "Test All" — `play_arrow` stays as the glyph and spins clockwise via `animate-spin` for the duration of the batch.

## Attribution

- Inspired-by: https://github.com/decolua/9router/pull/715
- Co-authored-by: Luan Dias <luandias@id.uff.br>