### PR TITLE
fix(executors): strip temperature for GitHub Copilot gpt-5.4 family (port from 9router#612)

### DIFF
--- a/open-sse/executors/github.ts
+++ b/open-sse/executors/github.ts
@@ -99,6 +99,20 @@ export class GithubExecutor extends BaseExecutor {
       modifiedBody.tools = modifiedBody.tools.slice(0, 128);
     }
 
+    // GitHub Copilot's gpt-5.4 family rejects requests carrying `temperature` with HTTP 400:
+    //   "Unsupported parameter: 'temperature' is not supported with this model."
+    // OmniRoute's existing `stripGpt5SamplingWhenReasoning` guard only fires for
+    // provider==="openai" (raw api.openai.com Chat Completions), so GitHub Copilot routes
+    // never hit it. Strip temperature here unconditionally for gpt-5.4 so the 400 cannot
+    // reach the user. Port from 9router#612 (closes upstream #536).
+    if (
+      typeof model === "string" &&
+      /gpt-5\.4/i.test(model) &&
+      modifiedBody.temperature !== undefined
+    ) {
+      delete modifiedBody.temperature;
+    }
+
     // GitHub Copilot /chat/completions only accepts {type:'text'} or {type:'image_url'}
     // content parts. Clients like Cursor IDE pass through Anthropic-shape parts
     // (tool_use, tool_result, thinking) untouched when using Claude models, which makes

--- a/tests/unit/executor-github.test.ts
+++ b/tests/unit/executor-github.test.ts
@@ -426,6 +426,44 @@ test("GithubExecutor.execute preserves complete SSE responses including terminal
   }
 });
 
+test("GithubExecutor.transformRequest strips temperature for gpt-5.4 (port from 9router#612 / closes upstream #536)", () => {
+  // GitHub Copilot's gpt-5.4 family rejects requests carrying `temperature` with HTTP 400:
+  //   "Unsupported parameter: 'temperature' is not supported with this model."
+  // OmniRoute's existing `stripGpt5SamplingWhenReasoning` guard only fires for
+  // provider==="openai" (raw api.openai.com Chat Completions) — Copilot requests run
+  // through GithubExecutor and never hit that guard. Strip temperature here so the
+  // 400 cannot reach the user. Other GitHub Copilot models keep temperature intact.
+  const executor = new GithubExecutor();
+
+  const stripped = executor.transformRequest(
+    "gpt-5.4",
+    { temperature: 0.7, messages: [{ role: "user", content: "hi" }] },
+    true,
+    {}
+  );
+  assert.equal(stripped.temperature, undefined, "temperature must be stripped for gpt-5.4");
+
+  const strippedMini = executor.transformRequest(
+    "gpt-5.4-mini",
+    { temperature: 0.3, messages: [{ role: "user", content: "hi" }] },
+    true,
+    {}
+  );
+  assert.equal(
+    strippedMini.temperature,
+    undefined,
+    "temperature must be stripped for gpt-5.4-mini"
+  );
+
+  const kept = executor.transformRequest(
+    "gpt-4.1",
+    { temperature: 0.7, messages: [{ role: "user", content: "hi" }] },
+    true,
+    {}
+  );
+  assert.equal(kept.temperature, 0.7, "temperature must be preserved for non-gpt-5.4 models");
+});
+
 test("GithubExecutor.transformRequest strips invalid synthetic Responses reasoning ids", () => {
   const executor = new GithubExecutor();
   const result = executor.transformRequest(


### PR DESCRIPTION
## Summary

Port of upstream [decolua/9router#612](https://github.com/decolua/9router/pull/612) (closes upstream [decolua/9router#536](https://github.com/decolua/9router/issues/536)) by **@anuragg-saxenaa**.

GitHub Copilot's `gpt-5.4` family rejects requests carrying `temperature` with HTTP 400:

> Unsupported parameter: 'temperature' is not supported with this model.

OmniRoute already has a related guard (`stripGpt5SamplingWhenReasoning` in `open-sse/services/gpt5SamplingGuard.ts`), but it is scoped to `provider === "openai"` (raw `api.openai.com` Chat Completions). GitHub Copilot requests go through `GithubExecutor` and never hit that guard, so the upstream 400 reached the user.

`GithubExecutor.transformRequest` now drops `temperature` unconditionally for any model matching `/gpt-5\.4/i` (covers `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5.4-pro`). Other GitHub Copilot models (e.g. `gpt-4.1`, Claude on Copilot) keep `temperature` intact.

## Changes

- `open-sse/executors/github.ts` — strip `temperature` when `model` matches `/gpt-5\.4/i`.
- `tests/unit/executor-github.test.ts` — TDD coverage (RED→GREEN): gpt-5.4 strips, gpt-5.4-mini strips, gpt-4.1 keeps.
- `CHANGELOG.md` — entry under `[3.8.32]` → `🐛 Fixed`.

## Test plan

- [x] New test fails on baseline (RED): `temperature 0.7 !== undefined`.
- [x] After fix, new test passes (GREEN).
- [x] Full `executor-github.test.ts` suite green (16/16) — no regression in existing Copilot transforms (Anthropic-shape sanitization, JSON response_format injection, x-initiator, refresh, `[DONE]` preservation).
- [x] `gpt5-sampling-guard.test.ts` still green (10/10) — guard for `provider==="openai"` untouched.
- [x] ESLint clean on changed files (only pre-existing warnings).

## Attribution

Inspired by https://github.com/decolua/9router/pull/612.
Closes upstream https://github.com/decolua/9router/issues/536.

Co-authored-by: Anurag Saxena <anuragg.saxenaa@gmail.com>