### PR TITLE
fix(api/settings): prevent cached /api/settings responses (port from 9router#951)

### DIFF
--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -27,6 +27,19 @@ import { extractApiKey } from "@/sse/services/auth";
 import { getApiKeyMetadata } from "@/lib/db/apiKeys";
 
 /**
+ * Force this route to run dynamically per-request and never be cached/prerendered.
+ * Combined with the `Cache-Control: no-store` response header below, this keeps
+ * persisted settings (e.g. dashboard preferences, debugMode, hidden sidebar
+ * items) visible immediately after refresh or restart instead of falling back
+ * to stale Next.js fetch cache. Ported from upstream decolua/9router#951.
+ */
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+/** Response headers applied to every successful GET/PATCH on /api/settings. */
+const SETTINGS_RESPONSE_HEADERS = { "Cache-Control": "no-store" } as const;
+
+/**
  * Settings keys whose change broadens attack surface. Spec §Security:
  * password re-auth is required when any of these is present in a PATCH body.
  *
@@ -162,19 +175,22 @@ export async function GET(request: Request) {
       // best effort — don't fail GET /api/settings if this lookup fails
     }
 
-    return NextResponse.json({
-      ...safeSettings,
-      hasPassword: hasManagementPasswordConfigured(settings),
-      runtimePorts,
-      apiPort: runtimePorts.apiPort,
-      dashboardPort: runtimePorts.dashboardPort,
-      cloudConfigured: Boolean(cloudUrl),
-      cloudUrl,
-      machineId,
-      ...(cliproxyapiModelMapping !== null
-        ? { cliproxyapi_model_mapping: cliproxyapiModelMapping }
-        : {}),
-    });
+    return NextResponse.json(
+      {
+        ...safeSettings,
+        hasPassword: hasManagementPasswordConfigured(settings),
+        runtimePorts,
+        apiPort: runtimePorts.apiPort,
+        dashboardPort: runtimePorts.dashboardPort,
+        cloudConfigured: Boolean(cloudUrl),
+        cloudUrl,
+        machineId,
+        ...(cliproxyapiModelMapping !== null
+          ? { cliproxyapi_model_mapping: cliproxyapiModelMapping }
+          : {}),
+      },
+      { headers: SETTINGS_RESPONSE_HEADERS }
+    );
   } catch (error) {
     console.log("Error getting settings:", error);
     return NextResponse.json({ error: "Failed to load settings" }, { status: 500 });
@@ -376,7 +392,7 @@ export async function PATCH(request: Request) {
     }
 
     const { password, ...safeSettings } = settings;
-    return NextResponse.json(safeSettings);
+    return NextResponse.json(safeSettings, { headers: SETTINGS_RESPONSE_HEADERS });
   } catch (error) {
     console.log("Error updating settings:", error);
     return NextResponse.json({ error: "Failed to update settings" }, { status: 500 });

--- a/tests/unit/settings-api.test.ts
+++ b/tests/unit/settings-api.test.ts
@@ -209,6 +209,35 @@ describe("Settings API - persisted preferences", () => {
       assert.equal(settings.responsesPreviousResponseIdMode, "strip");
     });
 
+    test("GET /api/settings returns Cache-Control: no-store (ported from upstream #951)", async () => {
+      const response = await harness.settingsRoute.GET(
+        await makeManagementSessionRequest("http://localhost/api/settings", {
+          method: "GET",
+        })
+      );
+      assert.equal(response.status, 200);
+      assert.equal(
+        response.headers.get("Cache-Control"),
+        "no-store",
+        "GET /api/settings must return Cache-Control: no-store so persisted settings stay fresh after refresh/restart"
+      );
+    });
+
+    test("PATCH /api/settings returns Cache-Control: no-store (ported from upstream #951)", async () => {
+      const response = await harness.settingsRoute.PATCH(
+        await makeManagementSessionRequest("http://localhost/api/settings", {
+          method: "PATCH",
+          body: { debugMode: true },
+        })
+      );
+      assert.equal(response.status, 200);
+      assert.equal(
+        response.headers.get("Cache-Control"),
+        "no-store",
+        "PATCH /api/settings must return Cache-Control: no-store"
+      );
+    });
+
     test("PUT /api/settings reuses the PATCH update flow", async () => {
       const response = await harness.settingsRoute.PUT(
         await makeManagementSessionRequest("http://localhost/api/settings", {


### PR DESCRIPTION
## Summary

Port of upstream [decolua/9router#951](https://github.com/decolua/9router/pull/951) by @aqilaziz, adapted from JS to OmniRoute's TypeScript `/api/settings` route.

Forces `/api/settings` to run dynamically per-request and stamps every successful GET/PATCH with `Cache-Control: no-store`, so persisted dashboard preferences (debugMode, hidden sidebar items, Caveman mode, etc.) stay visible immediately after refresh or restart instead of falling back to a stale Next.js prerender / fetch cache.

### Changes

- `src/app/api/settings/route.ts`
  - `export const dynamic = "force-dynamic"` + `export const revalidate = 0`
  - New `SETTINGS_RESPONSE_HEADERS = { "Cache-Control": "no-store" }`
  - Both success paths (GET and PATCH `NextResponse.json(...)`) now pass `{ headers: SETTINGS_RESPONSE_HEADERS }`
- `tests/unit/settings-api.test.ts` — 2 new TDD tests asserting the header on GET and PATCH
- `CHANGELOG.md` — entry under `[3.8.33] → 🐛 Fixed`

### Why this is needed

Next.js 16 may statically render or cache the `/api/settings` GET response. After toggling a setting and refreshing, the UI was reading the cached `hasPassword/debugMode/...` snapshot instead of the freshly-persisted values. `no-store` + `force-dynamic` make every response a per-request read.

## Validation (Hard Rule #18 — TDD)

Added two RED-then-GREEN tests:

```
test("GET /api/settings returns Cache-Control: no-store (ported from upstream #951)")
test("PATCH /api/settings returns Cache-Control: no-store (ported from upstream #951)")
```

Both failed before the route change (`null !== 'no-store'`), pass after.

```
node --import tsx/esm --test tests/unit/settings-api.test.ts
# tests 14, pass 14, fail 0
```

`npx eslint src/app/api/settings/route.ts tests/unit/settings-api.test.ts` → clean.

## Test plan

- [x] `node --import tsx/esm --test tests/unit/settings-api.test.ts` — 14/14 pass
- [x] ESLint clean on changed files
- [ ] CI quality gates green

---

Inspired by: https://github.com/decolua/9router/pull/951

Co-authored-by: Aqil Aziz <gonzes7@gmail.com>