### PR TITLE
fix(compression): render Hub active pipeline without requiring combo id

### DIFF
--- a/src/app/(dashboard)/dashboard/context/combos/CompressionHub.tsx
+++ b/src/app/(dashboard)/dashboard/context/combos/CompressionHub.tsx
@@ -132,9 +132,9 @@ export default function CompressionHub() {
           )
         );
       }
-      if (comboData?.id) {
+      if (comboData) {
         setCombo({
-          id: String(comboData.id),
+          id: comboData.id != null ? String(comboData.id) : "default",
           name: String(comboData.name ?? "Default"),
           pipeline: Array.isArray(comboData.pipeline) ? comboData.pipeline : [],
         });

--- a/tests/unit/ui/compressionHub.test.tsx
+++ b/tests/unit/ui/compressionHub.test.tsx
@@ -134,37 +134,45 @@ describe("CompressionHub", () => {
     expect(text).toContain("Layer pipeline is active");
   });
 
-  it("INVARIANT #1: no per-layer control issues a PUT/POST to /api/context/combos/default", { timeout: 20000 }, async () => {
-    const comboWrites: { method: string }[] = [];
-    const json = (body: unknown, status = 200) =>
+  it("renders the active pipeline when the default-combo response omits an id", async () => {
+    // Regression: the production /api/context/combos/default endpoint returns
+    // { mode, pipeline, derived } (no `id` field). The previous `if (comboData?.id)`
+    // gate in CompressionHub threw the payload away, so the Hub showed "0 layer(s)"
+    // even when the engines map had layers stacked. Render the pipeline as long as
+    // the endpoint returned anything with a pipeline array.
+    const noIdJson = (body: unknown, status = 200) =>
       new Response(JSON.stringify(body), {
         status,
         headers: { "Content-Type": "application/json" },
       });
-    vi.spyOn(globalThis, "fetch").mockImplementation(
-      async (input: RequestInfo | URL, init?: RequestInit) => {
-        const url = input.toString();
-        if (url.includes("/api/context/combos/default")) {
-          if (init?.method === "PUT" || init?.method === "POST") {
-            comboWrites.push({ method: init.method });
-          }
-          return json({ id: "default", name: "Default", pipeline: [{ engine: "rtk" }] });
-        }
-        if (url.includes("/api/settings/compression")) {
-          return json({ enabled: true, defaultMode: "stacked" });
-        }
-        if (url.includes("/api/compression/engines")) {
-          return json(enginePayload());
-        }
-        if (url.includes("/api/context/combos") || url.includes("/api/combos")) {
-          return json({ combos: [] });
-        }
-        if (url.includes("/api/compression/language-packs")) {
-          return json({ packs: [] });
-        }
-        return json({}, 404);
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("/api/settings/compression")) {
+        return noIdJson({ enabled: true, defaultMode: "stacked" });
       }
-    );
+      if (url.includes("/api/compression/engines")) {
+        return noIdJson(enginePayload());
+      }
+      if (url.includes("/api/context/combos/default")) {
+        // Production shape: no `id` field.
+        return noIdJson({
+          mode: "stacked",
+          pipeline: [
+            { engine: "session-dedup" },
+            { engine: "rtk", intensity: "standard" },
+            { engine: "caveman", intensity: "lite" },
+          ],
+          derived: true,
+        });
+      }
+      if (url.includes("/api/context/combos") || url.includes("/api/combos")) {
+        return noIdJson({ combos: [] });
+      }
+      if (url.includes("/api/compression/language-packs")) {
+        return noIdJson({ packs: [] });
+      }
+      return noIdJson({}, 404);
+    });
 
     const { default: CompressionHub } =
       await import("../../../src/app/(dashboard)/dashboard/context/combos/CompressionHub");
@@ -175,17 +183,71 @@ describe("CompressionHub", () => {
     });
     await flush();
 
-    // Click every on/off switch in the Hub (master + any layer controls that remain).
-    const switches = Array.from(container.querySelectorAll('[role="switch"]'));
-    for (const sw of switches) {
+    const text = container.textContent ?? "";
+    expect(text).toContain("Compression Hub");
+    expect(text).toContain("Layer pipeline is active");
+    // All 3 pipeline steps should render in the active pipeline section.
+    expect(text).toContain("Session Dedup");
+    expect(text).toContain("RTK");
+    expect(text).toContain("Caveman");
+  });
+
+  it(
+    "INVARIANT #1: no per-layer control issues a PUT/POST to /api/context/combos/default",
+    { timeout: 20000 },
+    async () => {
+      const comboWrites: { method: string }[] = [];
+      const json = (body: unknown, status = 200) =>
+        new Response(JSON.stringify(body), {
+          status,
+          headers: { "Content-Type": "application/json" },
+        });
+      vi.spyOn(globalThis, "fetch").mockImplementation(
+        async (input: RequestInfo | URL, init?: RequestInit) => {
+          const url = input.toString();
+          if (url.includes("/api/context/combos/default")) {
+            if (init?.method === "PUT" || init?.method === "POST") {
+              comboWrites.push({ method: init.method });
+            }
+            return json({ id: "default", name: "Default", pipeline: [{ engine: "rtk" }] });
+          }
+          if (url.includes("/api/settings/compression")) {
+            return json({ enabled: true, defaultMode: "stacked" });
+          }
+          if (url.includes("/api/compression/engines")) {
+            return json(enginePayload());
+          }
+          if (url.includes("/api/context/combos") || url.includes("/api/combos")) {
+            return json({ combos: [] });
+          }
+          if (url.includes("/api/compression/language-packs")) {
+            return json({ packs: [] });
+          }
+          return json({}, 404);
+        }
+      );
+
+      const { default: CompressionHub } =
+        await import("../../../src/app/(dashboard)/dashboard/context/combos/CompressionHub");
+
+      let container!: HTMLElement;
       await act(async () => {
-        (sw as HTMLElement).click();
+        container = mountInContainer(<CompressionHub />);
       });
       await flush();
-    }
 
-    expect(comboWrites).toHaveLength(0);
-  });
+      // Click every on/off switch in the Hub (master + any layer controls that remain).
+      const switches = Array.from(container.querySelectorAll('[role="switch"]'));
+      for (const sw of switches) {
+        await act(async () => {
+          (sw as HTMLElement).click();
+        });
+        await flush();
+      }
+
+      expect(comboWrites).toHaveLength(0);
+    }
+  );
 
   it("shows the activation warning when Token Saver is off", async () => {
     setupFetchMock({ enabled: false, mode: "off", pipeline: [] });


### PR DESCRIPTION
## Problem

The default-combo endpoint (`/api/context/combos/default`) returns the engines-derived stacked pipeline as `{ mode: "stacked", pipeline: [...], derived: true }` — but **without an `id` field**. The Hub gate `if (comboData?.id)` (`src/app/(dashboard)/dashboard/context/combos/CompressionHub.tsx`) throws the payload away, so the page renders:

``"
Active pipeline (execution order)        0 layer(s)
No active layers. Enable a layer in Compression Settings to build the pipeline.
```

even when six engines are toggled on in the panel. The Compression Settings panel (`CompressionPanel.tsx`) shows the correct derived pipeline, so the two pages disagree. The Hub API call works fine — the UI is the only thing broken.

## Fix

Stop gating the Hub's `setCombo` on the response having an `id` field. Use `"default"` as the fallback combo id and render any non-empty pipeline the endpoint returns.

```diff
-if (comboData?.id) {
+if (comboData) {
   setCombo({
-    id: String(comboData.id),
+    id: comboData.id != null ? String(comboData.id) : "default",
     name: String(comboData.name ?? "Default"),
     pipeline: Array.isArray(comboData.pipeline) ? comboData.pipeline : [],
   });
 }
```

## Tests

Adds one regression test in `tests/unit/ui/compressionHub.test.tsx` that mocks the production response shape (no `id`) and asserts the active pipeline renders.

- `tests/unit/ui/compressionHub.test.tsx` — 5/5 pass
- `tests/unit/ui/compressionHub-context-editing.test.tsx` — 3/3 pass

Pre-commit hooks (prettier, eslint, docs-sync, t11:any-budget, tracked-artifacts) green.

## Notes

- Minimal, scoped fix — does NOT drop the combo API dependency (the named-combos reorder feature still works through `/api/context/combos/{id}`).
- Runtime behaviour unchanged. The engines-derived pipeline was already being applied to requests at chatCore time (`selectCompressionPlan` + `enginesMapDerivesStackedPipeline` guard); this PR only restores UI/UX fidelity.