### PR TITLE
feat(opencode): DeepSeek V4 Pro reasoning-effort variant injection

### DIFF
--- a/open-sse/config/providers/registry/opencode/index.ts
+++ b/open-sse/config/providers/registry/opencode/index.ts
@@ -23,6 +23,17 @@ export const opencodeProvider: RegistryEntry = {
       interleavedField: "reasoning_content",
     },
     { id: "deepseek-v4-flash-free", name: "DeepSeek V4 Flash Free", supportsReasoning: true },
+    // #xxxx: reasoning-effort variants for DeepSeek V4 Pro. The OpencodeExecutor
+    // rewrites the model id to "deepseek-v4-pro" and injects reasoning_effort from
+    // the suffix so the upstream sees a single canonical id + the chosen effort.
+    { id: "deepseek-v4-pro-low", name: "DeepSeek V4 Pro (low effort)", supportsReasoning: true },
+    {
+      id: "deepseek-v4-pro-medium",
+      name: "DeepSeek V4 Pro (medium effort)",
+      supportsReasoning: true,
+    },
+    { id: "deepseek-v4-pro-high", name: "DeepSeek V4 Pro (high effort)", supportsReasoning: true },
+    { id: "deepseek-v4-pro-max", name: "DeepSeek V4 Pro (max effort)", supportsReasoning: true },
     // #3110: MiniMax M3 free tier via OpenCode
     // #3328: MiniMax M3 is multimodal (verified: describes base64 images via the
     // opencode upstream) — flag it so vision requests aren't gated/stripped.

--- a/open-sse/executors/opencode.ts
+++ b/open-sse/executors/opencode.ts
@@ -79,7 +79,9 @@ export class OpencodeExecutor extends BaseExecutor {
 
       // Forward OpenCode request metadata headers from client
       const findClientHeader = (name: string) =>
-        Object.entries(clientHeaders).find(([key]) => key.toLowerCase() === name.toLowerCase())?.[1];
+        Object.entries(clientHeaders).find(
+          ([key]) => key.toLowerCase() === name.toLowerCase()
+        )?.[1];
 
       const opencodeHeaderKeys = [
         "x-opencode-session",
@@ -144,6 +146,28 @@ export class OpencodeExecutor extends BaseExecutor {
       modifiedBody.tools.length > 128
     ) {
       modifiedBody.tools = modifiedBody.tools.slice(0, 128);
+    }
+    // #xxxx: DeepSeek V4 Pro reasoning-effort variants. The upstream opencode/zen
+    // exposes the base id `deepseek-v4-pro` only; the -low/-medium/-high/-max
+    // suffixes are operator-facing knobs that map to `reasoning_effort`. Rewrite
+    // body.model to the canonical base id (always — the upstream rejects the
+    // suffixed variants) and inject the chosen effort when the caller did not
+    // already set one (explicit beats derived). Mirrors 9router's opencode-go
+    // executor (open-sse/executors/opencode-go.js).
+    if (modifiedBody && typeof modifiedBody === "object") {
+      const mb = modifiedBody as Record<string, unknown>;
+      const m = String(model || "");
+      const effortLevels = ["low", "medium", "high", "max"] as const;
+      const matchedLevel = effortLevels.find((level) => m.endsWith(`-${level}`));
+      if (matchedLevel) {
+        const base = m.slice(0, -`-${matchedLevel}`.length);
+        if (base.toLowerCase() === "deepseek-v4-pro") {
+          mb.model = "deepseek-v4-pro";
+          if (mb.reasoning_effort === undefined) {
+            mb.reasoning_effort = matchedLevel;
+          }
+        }
+      }
     }
     return modifiedBody;
   }

--- a/tests/unit/opencode-executor.test.ts
+++ b/tests/unit/opencode-executor.test.ts
@@ -526,6 +526,69 @@ describe("OpencodeExecutor", () => {
       );
     });
   });
+
+  describe("DeepSeek V4 Pro reasoning-effort variants", () => {
+    // #xxxx: opencode/zen upstream only exposes the base id `deepseek-v4-pro`.
+    // The -low/-medium/-high/-max suffixes are operator-facing knobs that the
+    // executor rewrites to base + injects reasoning_effort, mirroring 9router's
+    // opencode-go executor (open-sse/executors/opencode-go.js).
+    function baseBody(model) {
+      return {
+        model,
+        stream: false,
+        messages: [{ role: "user", content: "ok" }],
+        max_tokens: 16,
+      };
+    }
+
+    const levels = ["low", "medium", "high", "max"];
+    for (const level of levels) {
+      it(`maps deepseek-v4-pro-${level} to base id + reasoning_effort=${level}`, () => {
+        const variant = `deepseek-v4-pro-${level}`;
+        const out = zenExecutor.transformRequest(variant, baseBody(variant), false, {
+          apiKey: "test-key",
+        });
+        assert.equal(out.model, "deepseek-v4-pro");
+        assert.equal(out.reasoning_effort, level);
+        // The variant suffix must not bleed into the upstream payload
+        assert.ok(!String(out.model).endsWith(`-${level}`));
+      });
+    }
+
+    it("preserves explicit reasoning_effort over the variant suffix", () => {
+      const body = baseBody("deepseek-v4-pro-high") as Record<string, unknown>;
+      body.reasoning_effort = "max";
+      const out = zenExecutor.transformRequest("deepseek-v4-pro-high", body, false, {
+        apiKey: "test-key",
+      });
+      assert.equal(out.reasoning_effort, "max");
+      assert.equal(out.model, "deepseek-v4-pro");
+    });
+
+    it("leaves the base id (no suffix) untouched", () => {
+      const out = zenExecutor.transformRequest(
+        "deepseek-v4-pro",
+        baseBody("deepseek-v4-pro"),
+        false,
+        { apiKey: "test-key" }
+      );
+      assert.equal(out.model, "deepseek-v4-pro");
+      assert.equal(out.reasoning_effort, undefined);
+    });
+
+    it("does not rewrite unrelated models with matching suffixes", () => {
+      // -max/-high etc. should only fire for deepseek-v4-pro; another model that
+      // happens to end with -high must be left alone.
+      const out = zenExecutor.transformRequest(
+        "some-other-model-high",
+        baseBody("some-other-model-high"),
+        false,
+        { apiKey: "test-key" }
+      );
+      assert.equal(out.model, "some-other-model-high");
+      assert.equal(out.reasoning_effort, undefined);
+    });
+  });
 });
 
 describe("DefaultExecutor", () => {


### PR DESCRIPTION
## Problem

The opencode/zen upstream exposes the base id `deepseek-v4-pro` only; the operator-facing `-deepseek-v4-pro-{low,medium,high,max}` suffixes 401 with "Model not supported" before reaching the upstream. Operators using omo's fallback chains (or 9router-style effort tiers like `opencode-go/deepseek-v4-pro-medium`) had no path through omniroute.

## Fix

Port the variant logic from 9router's opencode-go executor (`open-sse/executors/opencode-go.js`):

- Detect `-low/-medium/-high/-max` on the routed model id
- When the base id is `deepseek-v4-pro`, rewrite body.model to the canonical base id (always — upstream rejects the suffixed variants) and inject `reasoning_effort` from the suffix
- Explicit `reasoning_effort` from the caller wins over the derived one
- Other models ending with `-high/-max` etc. are left untouched

```diff
+ { id: "deepseek-v4-pro-low",    name: "DeepSeek V4 Pro (low effort)",    supportsReasoning: true },
+ { id: "deepseek-v4-pro-medium", name: "DeepSeek V4 Pro (medium effort)", supportsReasoning: true },
+ { id: "deepseek-v4-pro-high",   name: "DeepSeek V4 Pro (high effort)",   supportsReasoning: true },
+ { id: "deepseek-v4-pro-max",    name: "DeepSeek V4 Pro (max effort)",    supportsReasoning: true },
```

```ts
const m = String(model || "");
const matchedLevel = ["low", "medium", "high", "max"].find((level) => m.endsWith(`-${level}`));
if (matchedLevel) {
  const base = m.slice(0, -(`-${matchedLevel}`).length);
  if (base.toLowerCase() === "deepseek-v4-pro") {
    mb.model = "deepseek-v4-pro";
    if (mb.reasoning_effort === undefined) {
      mb.reasoning_effort = matchedLevel;
    }
  }
}
```

## Tests

4 new tests in `tests/unit/opencode-executor.test.ts`:
- one per variant (`-low/-medium/-high/-max` → `reasoning_effort` injection + model rewrite)
- explicit-override preservation
- base-id passthrough (no suffix)
- unrelated-suffix negative case

`tests/unit/opencode-executor.test.ts` — 52/52 pass.

Pre-commit hooks (prettier, eslint, docs-sync, t11:any-budget, tracked-artifacts) green.

## Notes

- 4 pre-existing TS errors in `opencode.ts` lines 143-146 (the `modifiedBody.tools` access) are not touched by this PR; they exist on `main`.
- Runtime behaviour unchanged for non-DeepSeek requests; the new branch only fires when the model id ends with `-low/-medium/-high/-max` AND the base is exactly `deepseek-v4-pro`.
- 9router reference (forked at DevEstacion/9router): same logic in `open-sse/executors/opencode-go.js`. Was working in 9router pre-fork; missing from omniroute's opencode executor.