### PR TITLE
fix(compression): Hub active pipeline + feat(opencode): DeepSeek V4 Pro reasoning-effort variants

### DIFF
--- a/open-sse/config/providers/registry/opencode/index.ts
+++ b/open-sse/config/providers/registry/opencode/index.ts
@@ -23,6 +23,17 @@ export const opencodeProvider: RegistryEntry = {
       interleavedField: "reasoning_content",
     },
     { id: "deepseek-v4-flash-free", name: "DeepSeek V4 Flash Free", supportsReasoning: true },
+    // #xxxx: reasoning-effort variants for DeepSeek V4 Pro. The OpencodeExecutor
+    // rewrites the model id to "deepseek-v4-pro" and injects reasoning_effort from
+    // the suffix so the upstream sees a single canonical id + the chosen effort.
+    { id: "deepseek-v4-pro-low", name: "DeepSeek V4 Pro (low effort)", supportsReasoning: true },
+    {
+      id: "deepseek-v4-pro-medium",
+      name: "DeepSeek V4 Pro (medium effort)",
+      supportsReasoning: true,
+    },
+    { id: "deepseek-v4-pro-high", name: "DeepSeek V4 Pro (high effort)", supportsReasoning: true },
+    { id: "deepseek-v4-pro-max", name: "DeepSeek V4 Pro (max effort)", supportsReasoning: true },
     // #3110: MiniMax M3 free tier via OpenCode
     // #3328: MiniMax M3 is multimodal (verified: describes base64 images via the
     // opencode upstream) — flag it so vision requests aren't gated/stripped.

--- a/open-sse/executors/opencode.ts
+++ b/open-sse/executors/opencode.ts
@@ -79,7 +79,9 @@ export class OpencodeExecutor extends BaseExecutor {
 
       // Forward OpenCode request metadata headers from client
       const findClientHeader = (name: string) =>
-        Object.entries(clientHeaders).find(([key]) => key.toLowerCase() === name.toLowerCase())?.[1];
+        Object.entries(clientHeaders).find(
+          ([key]) => key.toLowerCase() === name.toLowerCase()
+        )?.[1];
 
       const opencodeHeaderKeys = [
         "x-opencode-session",
@@ -144,6 +146,28 @@ export class OpencodeExecutor extends BaseExecutor {
       modifiedBody.tools.length > 128
     ) {
       modifiedBody.tools = modifiedBody.tools.slice(0, 128);
+    }
+    // #xxxx: DeepSeek V4 Pro reasoning-effort variants. The upstream opencode/zen
+    // exposes the base id `deepseek-v4-pro` only; the -low/-medium/-high/-max
+    // suffixes are operator-facing knobs that map to `reasoning_effort`. Rewrite
+    // body.model to the canonical base id (always — the upstream rejects the
+    // suffixed variants) and inject the chosen effort when the caller did not
+    // already set one (explicit beats derived). Mirrors 9router's opencode-go
+    // executor (open-sse/executors/opencode-go.js).
+    if (modifiedBody && typeof modifiedBody === "object") {
+      const mb = modifiedBody as Record<string, unknown>;
+      const m = String(model || "");
+      const effortLevels = ["low", "medium", "high", "max"] as const;
+      const matchedLevel = effortLevels.find((level) => m.endsWith(`-${level}`));
+      if (matchedLevel) {
+        const base = m.slice(0, -`-${matchedLevel}`.length);
+        if (base.toLowerCase() === "deepseek-v4-pro") {
+          mb.model = "deepseek-v4-pro";
+          if (mb.reasoning_effort === undefined) {
+            mb.reasoning_effort = matchedLevel;
+          }
+        }
+      }
     }
     return modifiedBody;
   }

--- a/src/app/(dashboard)/dashboard/context/combos/CompressionHub.tsx
+++ b/src/app/(dashboard)/dashboard/context/combos/CompressionHub.tsx
@@ -132,9 +132,9 @@ export default function CompressionHub() {
           )
         );
       }
-      if (comboData?.id) {
+      if (comboData) {
         setCombo({
-          id: String(comboData.id),
+          id: comboData.id != null ? String(comboData.id) : "default",
           name: String(comboData.name ?? "Default"),
           pipeline: Array.isArray(comboData.pipeline) ? comboData.pipeline : [],
         });

--- a/tests/unit/opencode-executor.test.ts
+++ b/tests/unit/opencode-executor.test.ts
@@ -526,6 +526,69 @@ describe("OpencodeExecutor", () => {
       );
     });
   });
+
+  describe("DeepSeek V4 Pro reasoning-effort variants", () => {
+    // #xxxx: opencode/zen upstream only exposes the base id `deepseek-v4-pro`.
+    // The -low/-medium/-high/-max suffixes are operator-facing knobs that the
+    // executor rewrites to base + injects reasoning_effort, mirroring 9router's
+    // opencode-go executor (open-sse/executors/opencode-go.js).
+    function baseBody(model) {
+      return {
+        model,
+        stream: false,
+        messages: [{ role: "user", content: "ok" }],
+        max_tokens: 16,
+      };
+    }
+
+    const levels = ["low", "medium", "high", "max"];
+    for (const level of levels) {
+      it(`maps deepseek-v4-pro-${level} to base id + reasoning_effort=${level}`, () => {
+        const variant = `deepseek-v4-pro-${level}`;
+        const out = zenExecutor.transformRequest(variant, baseBody(variant), false, {
+          apiKey: "test-key",
+        });
+        assert.equal(out.model, "deepseek-v4-pro");
+        assert.equal(out.reasoning_effort, level);
+        // The variant suffix must not bleed into the upstream payload
+        assert.ok(!String(out.model).endsWith(`-${level}`));
+      });
+    }
+
+    it("preserves explicit reasoning_effort over the variant suffix", () => {
+      const body = baseBody("deepseek-v4-pro-high") as Record<string, unknown>;
+      body.reasoning_effort = "max";
+      const out = zenExecutor.transformRequest("deepseek-v4-pro-high", body, false, {
+        apiKey: "test-key",
+      });
+      assert.equal(out.reasoning_effort, "max");
+      assert.equal(out.model, "deepseek-v4-pro");
+    });
+
+    it("leaves the base id (no suffix) untouched", () => {
+      const out = zenExecutor.transformRequest(
+        "deepseek-v4-pro",
+        baseBody("deepseek-v4-pro"),
+        false,
+        { apiKey: "test-key" }
+      );
+      assert.equal(out.model, "deepseek-v4-pro");
+      assert.equal(out.reasoning_effort, undefined);
+    });
+
+    it("does not rewrite unrelated models with matching suffixes", () => {
+      // -max/-high etc. should only fire for deepseek-v4-pro; another model that
+      // happens to end with -high must be left alone.
+      const out = zenExecutor.transformRequest(
+        "some-other-model-high",
+        baseBody("some-other-model-high"),
+        false,
+        { apiKey: "test-key" }
+      );
+      assert.equal(out.model, "some-other-model-high");
+      assert.equal(out.reasoning_effort, undefined);
+    });
+  });
 });
 
 describe("DefaultExecutor", () => {

--- a/tests/unit/ui/compressionHub.test.tsx
+++ b/tests/unit/ui/compressionHub.test.tsx
@@ -134,37 +134,45 @@ describe("CompressionHub", () => {
     expect(text).toContain("Layer pipeline is active");
   });
 
-  it("INVARIANT #1: no per-layer control issues a PUT/POST to /api/context/combos/default", { timeout: 20000 }, async () => {
-    const comboWrites: { method: string }[] = [];
-    const json = (body: unknown, status = 200) =>
+  it("renders the active pipeline when the default-combo response omits an id", async () => {
+    // Regression: the production /api/context/combos/default endpoint returns
+    // { mode, pipeline, derived } (no `id` field). The previous `if (comboData?.id)`
+    // gate in CompressionHub threw the payload away, so the Hub showed "0 layer(s)"
+    // even when the engines map had layers stacked. Render the pipeline as long as
+    // the endpoint returned anything with a pipeline array.
+    const noIdJson = (body: unknown, status = 200) =>
       new Response(JSON.stringify(body), {
         status,
         headers: { "Content-Type": "application/json" },
       });
-    vi.spyOn(globalThis, "fetch").mockImplementation(
-      async (input: RequestInfo | URL, init?: RequestInit) => {
-        const url = input.toString();
-        if (url.includes("/api/context/combos/default")) {
-          if (init?.method === "PUT" || init?.method === "POST") {
-            comboWrites.push({ method: init.method });
-          }
-          return json({ id: "default", name: "Default", pipeline: [{ engine: "rtk" }] });
-        }
-        if (url.includes("/api/settings/compression")) {
-          return json({ enabled: true, defaultMode: "stacked" });
-        }
-        if (url.includes("/api/compression/engines")) {
-          return json(enginePayload());
-        }
-        if (url.includes("/api/context/combos") || url.includes("/api/combos")) {
-          return json({ combos: [] });
-        }
-        if (url.includes("/api/compression/language-packs")) {
-          return json({ packs: [] });
-        }
-        return json({}, 404);
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("/api/settings/compression")) {
+        return noIdJson({ enabled: true, defaultMode: "stacked" });
       }
-    );
+      if (url.includes("/api/compression/engines")) {
+        return noIdJson(enginePayload());
+      }
+      if (url.includes("/api/context/combos/default")) {
+        // Production shape: no `id` field.
+        return noIdJson({
+          mode: "stacked",
+          pipeline: [
+            { engine: "session-dedup" },
+            { engine: "rtk", intensity: "standard" },
+            { engine: "caveman", intensity: "lite" },
+          ],
+          derived: true,
+        });
+      }
+      if (url.includes("/api/context/combos") || url.includes("/api/combos")) {
+        return noIdJson({ combos: [] });
+      }
+      if (url.includes("/api/compression/language-packs")) {
+        return noIdJson({ packs: [] });
+      }
+      return noIdJson({}, 404);
+    });
 
     const { default: CompressionHub } =
       await import("../../../src/app/(dashboard)/dashboard/context/combos/CompressionHub");
@@ -175,17 +183,71 @@ describe("CompressionHub", () => {
     });
     await flush();
 
-    // Click every on/off switch in the Hub (master + any layer controls that remain).
-    const switches = Array.from(container.querySelectorAll('[role="switch"]'));
-    for (const sw of switches) {
+    const text = container.textContent ?? "";
+    expect(text).toContain("Compression Hub");
+    expect(text).toContain("Layer pipeline is active");
+    // All 3 pipeline steps should render in the active pipeline section.
+    expect(text).toContain("Session Dedup");
+    expect(text).toContain("RTK");
+    expect(text).toContain("Caveman");
+  });
+
+  it(
+    "INVARIANT #1: no per-layer control issues a PUT/POST to /api/context/combos/default",
+    { timeout: 20000 },
+    async () => {
+      const comboWrites: { method: string }[] = [];
+      const json = (body: unknown, status = 200) =>
+        new Response(JSON.stringify(body), {
+          status,
+          headers: { "Content-Type": "application/json" },
+        });
+      vi.spyOn(globalThis, "fetch").mockImplementation(
+        async (input: RequestInfo | URL, init?: RequestInit) => {
+          const url = input.toString();
+          if (url.includes("/api/context/combos/default")) {
+            if (init?.method === "PUT" || init?.method === "POST") {
+              comboWrites.push({ method: init.method });
+            }
+            return json({ id: "default", name: "Default", pipeline: [{ engine: "rtk" }] });
+          }
+          if (url.includes("/api/settings/compression")) {
+            return json({ enabled: true, defaultMode: "stacked" });
+          }
+          if (url.includes("/api/compression/engines")) {
+            return json(enginePayload());
+          }
+          if (url.includes("/api/context/combos") || url.includes("/api/combos")) {
+            return json({ combos: [] });
+          }
+          if (url.includes("/api/compression/language-packs")) {
+            return json({ packs: [] });
+          }
+          return json({}, 404);
+        }
+      );
+
+      const { default: CompressionHub } =
+        await import("../../../src/app/(dashboard)/dashboard/context/combos/CompressionHub");
+
+      let container!: HTMLElement;
       await act(async () => {
-        (sw as HTMLElement).click();
+        container = mountInContainer(<CompressionHub />);
       });
       await flush();
-    }
 
-    expect(comboWrites).toHaveLength(0);
-  });
+      // Click every on/off switch in the Hub (master + any layer controls that remain).
+      const switches = Array.from(container.querySelectorAll('[role="switch"]'));
+      for (const sw of switches) {
+        await act(async () => {
+          (sw as HTMLElement).click();
+        });
+        await flush();
+      }
+
+      expect(comboWrites).toHaveLength(0);
+    }
+  );
 
   it("shows the activation warning when Token Saver is off", async () => {
     setupFetchMock({ enabled: false, mode: "off", pipeline: [] });


### PR DESCRIPTION
## Problem

Two related bugs break the operator experience:

### 1. Hub shows "0 layer(s)" despite engines enabled

The default-combo endpoint (`/api/context/combos/default`) returns the engines-derived stacked pipeline as `{ mode: "stacked", pipeline: [...], derived: true }` — but **without an `id` field**. The Hub gate `if (comboData?.id)` (`src/app/(dashboard)/dashboard/context/combos/CompressionHub.tsx`) throws the payload away, so the page renders:

``"
Active pipeline (execution order)        0 layer(s)
No active layers. Enable a layer in Compression Settings to build the pipeline.
```

even when six engines are toggled on in the panel. The Compression Settings panel (`CompressionPanel.tsx`) shows the correct derived pipeline, so the two pages disagree.

### 2. `deepseek-v4-pro-{low,medium,high,max}` rejected by omniroute

The opencode/zen upstream exposes the base id `deepseek-v4-pro` only; the operator-facing suffix variants 401 with "Model not supported" before reaching the upstream. Operators using omo's fallback chains or 9router-style effort tiers had no path through omniroute.

## Fix

### Commit 1 — Hub UI
Stop gating the Hub's `setCombo` on the response having an `id` field. Use `"default"` as the fallback combo id and render any non-empty pipeline the endpoint returns.

```diff
-if (comboData?.id) {
+if (comboData) {
   setCombo({
-    id: String(comboData.id),
+    id: comboData.id != null ? String(comboData.id) : "default",
     name: String(comboData.name ?? "Default"),
     pipeline: Array.isArray(comboData.pipeline) ? comboData.pipeline : [],
   });
 }
```

### Commit 2 — DeepSeek V4 Pro variants
Port the variant logic from 9router's opencode-go executor (`open-sse/executors/opencode-go.js`):

- Detect `-low/-medium/-high/-max` on the routed model id
- When the base id is `deepseek-v4-pro`, rewrite body.model to the canonical base id (always — upstream rejects the suffixed variants) and inject `reasoning_effort` from the suffix
- Explicit `reasoning_effort` from the caller wins over the derived one
- Other models ending with `-high/-max` etc. are left untouched

```diff
+ { id: "deepseek-v4-pro-low",    name: "DeepSeek V4 Pro (low effort)",    supportsReasoning: true },
+ { id: "deepseek-v4-pro-medium", name: "DeepSeek V4 Pro (medium effort)", supportsReasoning: true },
+ { id: "deepseek-v4-pro-high",   name: "DeepSeek V4 Pro (high effort)",   supportsReasoning: true },
+ { id: "deepseek-v4-pro-max",    name: "DeepSeek V4 Pro (max effort)",    supportsReasoning: true },
```

```ts
const m = String(model || "");
const matchedLevel = ["low", "medium", "high", "max"].find((level) => m.endsWith(`-${level}`));
if (matchedLevel) {
  const base = m.slice(0, -(`-${matchedLevel}`).length);
  if (base.toLowerCase() === "deepseek-v4-pro") {
    mb.model = "deepseek-v4-pro";
    if (mb.reasoning_effort === undefined) {
      mb.reasoning_effort = matchedLevel;
    }
  }
}
```

## Tests

- `tests/unit/ui/compressionHub.test.tsx` — 5/5 pass (one new for missing-id round-trip)
- `tests/unit/ui/compressionHub-context-editing.test.tsx` — 3/3 pass
- `tests/unit/opencode-executor.test.ts` — 52/52 pass (4 new: each variant, explicit-override, base passthrough, unrelated-suffix negative)

Pre-commit hooks (prettier, eslint, docs-sync, t11:any-budget, tracked-artifacts) green on the local commits.

## Heads-up on a pre-existing CI failure

The `Docs Sync (Strict)` check will fail on this PR due to **pre-existing drift unrelated to these changes**: `KIRO_VERIFY_FULL_CRC` is referenced in `open-sse/executors/kiro.ts:118` but not declared in `.env.example` or `docs/reference/ENVIRONMENT.md`. The check `scripts/check/check-env-doc-sync.mjs` flags it. This is independent of the Hub UI / DeepSeek fixes — happy to send a separate one-line PR to clear it (add `# KIRO_VERIFY_FULL_CRC=false` to `.env.example` and a row in `ENVIRONMENT.md`), or include it here as a drive-by if you prefer.

## Notes

- The 4 pre-existing TS errors in `opencode.ts` lines 143-146 (the `modifiedBody.tools` access) are not touched by this PR; they exist on `main`.
- Runtime behaviour unchanged for non-DeepSeek requests; the new branch only fires when the model id ends with `-low/-medium/-high/-max` AND the base is exactly `deepseek-v4-pro`.
- 9router reference (forked at DevEstacion/9router): same logic in `open-sse/executors/opencode-go.js`. Was working in 9router pre-fork; missing from omniroute's opencode executor.