### PR TITLE
fix(quota): dedup quota_snapshots — persist only on change (#4438)

### DIFF
--- a/src/domain/quotaCache.ts
+++ b/src/domain/quotaCache.ts
@@ -18,6 +18,7 @@ import { getProviderConnectionById, resolveProxyForConnection } from "@/lib/loca
 import { runWithProxyContext } from "@omniroute/open-sse/utils/proxyFetch.ts";
 import { safePercentage } from "@/shared/utils/formatting";
 import { saveQuotaSnapshot, cleanupOldSnapshots } from "@/lib/db/quotaSnapshots";
+import { quotaSnapshotChanged, type SnapshotState } from "@/lib/db/quotaSnapshotDedup";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -47,6 +48,11 @@ interface QuotaWindowStatus {
 
 const ACTIVE_TTL_MS = 5 * 60 * 1000; // 5 minutes for active accounts
 const EXHAUSTED_TTL_MS = 5 * 60 * 1000; // 5 minutes for 429-sourced entries (no resetAt)
+
+// #4438: in-memory record of the last snapshot persisted per `${connectionId}:${windowKey}`,
+// so the 60s background refresh only writes a row when the quota actually changed — idle
+// connections otherwise produced hundreds of thousands of duplicate rows/day.
+const lastSnapshotState = new Map<string, SnapshotState>();
 const EXHAUSTED_REFRESH_MS = 5 * 60 * 1000; // 5 minutes: recheck exhausted accounts (aligned with TTL)
 const REFRESH_INTERVAL_MS = 60 * 1000; // Background tick every 1 minute
 export const DEFAULT_QUOTA_THRESHOLD_PERCENT = 99;
@@ -201,6 +207,13 @@ export function setQuotaCache(
         (quotaInfo.total > 0
           ? Math.round(((quotaInfo.total - (quotaInfo.used || 0)) / quotaInfo.total) * 100)
           : 0);
+      // #4438: only persist a snapshot when it differs from the last one for this
+      // connection+window — skips the duplicate rows the 60s refresh wrote for idle
+      // connections whose quota never changes.
+      const snapKey = `${connectionId}:${windowKey}`;
+      const nextSnapshot: SnapshotState = { remainingPercentage, isExhausted: !!entry.exhausted };
+      if (!quotaSnapshotChanged(lastSnapshotState.get(snapKey), nextSnapshot)) continue;
+      lastSnapshotState.set(snapKey, nextSnapshot);
       try {
         saveQuotaSnapshot({
           provider,

--- a/src/lib/db/quotaSnapshotDedup.ts
+++ b/src/lib/db/quotaSnapshotDedup.ts
@@ -1,0 +1,27 @@
+/**
+ * Quota-snapshot dedup helper (#4438).
+ *
+ * The quota-cache background refresh writes a snapshot row for every connection on each
+ * 60s tick. For idle connections whose quota never changes that produced 400K+ identical
+ * rows/day. A snapshot only needs to be persisted when it DIFFERS from the last one
+ * recorded for the same connection+window, so the history still captures every real
+ * change while skipping the redundant duplicates.
+ *
+ * Kept dependency-free so it can be unit-tested without a DB.
+ */
+
+export interface SnapshotState {
+  remainingPercentage: number;
+  isExhausted: boolean;
+}
+
+/** True when `next` should be persisted (no prior snapshot, or a meaningful change). */
+export function quotaSnapshotChanged(
+  prev: SnapshotState | undefined,
+  next: SnapshotState
+): boolean {
+  if (!prev) return true;
+  return (
+    prev.remainingPercentage !== next.remainingPercentage || prev.isExhausted !== next.isExhausted
+  );
+}

--- a/tests/unit/quota-snapshot-dedup-4438.test.ts
+++ b/tests/unit/quota-snapshot-dedup-4438.test.ts
@@ -1,0 +1,27 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// #4438: the quota-cache background refresh persisted a snapshot row for ALL ~273
+// connections every 60s (400K+ rows/day), most of them identical for idle connections.
+// quotaSnapshotChanged gates the write so only real changes are recorded.
+
+const { quotaSnapshotChanged } = await import("../../src/lib/db/quotaSnapshotDedup.ts");
+
+test("#4438 records the first snapshot (no prior state)", () => {
+  assert.equal(quotaSnapshotChanged(undefined, { remainingPercentage: 80, isExhausted: false }), true);
+});
+
+test("#4438 skips an identical snapshot (idle connection, unchanged quota)", () => {
+  const prev = { remainingPercentage: 80, isExhausted: false };
+  assert.equal(quotaSnapshotChanged(prev, { remainingPercentage: 80, isExhausted: false }), false);
+});
+
+test("#4438 records when remaining percentage changes", () => {
+  const prev = { remainingPercentage: 80, isExhausted: false };
+  assert.equal(quotaSnapshotChanged(prev, { remainingPercentage: 79, isExhausted: false }), true);
+});
+
+test("#4438 records when exhaustion flips", () => {
+  const prev = { remainingPercentage: 0, isExhausted: false };
+  assert.equal(quotaSnapshotChanged(prev, { remainingPercentage: 0, isExhausted: true }), true);
+});


### PR DESCRIPTION
Closes #4438

## Problem
The quota-cache background refresh wrote a `quota_snapshots` row for every connection on each 60s tick — 400K–545K rows/day, most identical for the ~83 idle connections whose quota never changes.

## Fix
Dedup: `quotaSnapshotChanged` (`src/lib/db/quotaSnapshotDedup.ts`, dependency-free) gates the write so a snapshot is persisted only when it differs (remaining % or exhaustion) from the last one recorded for that `connectionId:windowKey` (tracked in an in-memory `Map` in `quotaCache.ts`). History still captures every real change; idle connections stop emitting duplicate rows.

## Validation (TDD)
New `tests/unit/quota-snapshot-dedup-4438.test.ts` (4/4): first snapshot recorded, identical skipped, percentage change recorded, exhaustion flip recorded. `typecheck:core` + lint clean.