### PR TITLE
fix: retain provider cooldowns for configured max window

### DIFF
--- a/open-sse/services/providerCooldownTracker.ts
+++ b/open-sse/services/providerCooldownTracker.ts
@@ -17,13 +17,16 @@ interface CooldownEntry {
   lastFailureAt: number;
   /** Number of consecutive failures (resets on success) */
   failureCount: number;
+  /** How long this entry must be retained for cleanup purposes */
+  retentionMs: number;
 }
 
 // Global cooldown state: keyed by "provider:connectionId" or "provider"
 const cooldownMap = new Map<string, CooldownEntry>();
 
-// Evict entries older than this to prevent unbounded memory growth
-const MAX_ENTRY_AGE_MS = 30 * 60 * 1000; // 30 minutes
+// Evict entries older than their configured retention horizon to prevent
+// unbounded memory growth without shortening operator-configured cooldowns.
+const DEFAULT_ENTRY_RETENTION_MS = 30 * 60 * 1000; // 30 minutes
 const CLEANUP_INTERVAL_MS = 60 * 1000; // Cleanup every 60s
 
 let cleanupTimer: ReturnType<typeof setInterval> | null = null;
@@ -31,15 +34,30 @@ let cleanupTimer: ReturnType<typeof setInterval> | null = null;
 function startCleanupIfNeeded(): void {
   if (cleanupTimer) return;
   cleanupTimer = setInterval(() => {
-    const now = Date.now();
-    for (const [key, entry] of cooldownMap) {
-      if (now - entry.lastFailureAt > MAX_ENTRY_AGE_MS) {
-        cooldownMap.delete(key);
-      }
-    }
+    cleanupExpiredCooldownEntries();
   }, CLEANUP_INTERVAL_MS);
   // Allow Node.js to exit even if the timer is running
   if (cleanupTimer.unref) cleanupTimer.unref();
+}
+
+function getEntryRetentionMs(settings?: ResilienceSettings): number {
+  const maxRetryCooldownMs =
+    settings?.providerCooldown?.maxRetryCooldownMs ??
+    DEFAULT_RESILIENCE_SETTINGS.providerCooldown.maxRetryCooldownMs;
+  return Math.max(DEFAULT_ENTRY_RETENTION_MS, maxRetryCooldownMs);
+}
+
+/**
+ * Remove expired cooldown entries using each entry's configured retention
+ * horizon. Exported for diagnostics and focused tests; normal runtime cleanup is
+ * still performed by the unref'd interval started on first cooldown record.
+ */
+export function cleanupExpiredCooldownEntries(now = Date.now()): void {
+  for (const [key, entry] of cooldownMap) {
+    if (now - entry.lastFailureAt > entry.retentionMs) {
+      cooldownMap.delete(key);
+    }
+  }
 }
 
 /**
@@ -66,12 +84,14 @@ export function recordProviderCooldown(
   const key = cooldownKey(provider, connectionId);
   const existing = cooldownMap.get(key);
   const now = Date.now();
+  const retentionMs = getEntryRetentionMs(settings);
 
   if (existing) {
     existing.lastFailureAt = now;
     existing.failureCount++;
+    existing.retentionMs = Math.max(existing.retentionMs, retentionMs);
   } else {
-    cooldownMap.set(key, { lastFailureAt: now, failureCount: 1 });
+    cooldownMap.set(key, { lastFailureAt: now, failureCount: 1, retentionMs });
   }
 
   startCleanupIfNeeded();

--- a/tests/unit/services/providerCooldownTracker.test.ts
+++ b/tests/unit/services/providerCooldownTracker.test.ts
@@ -7,6 +7,7 @@ import {
   recordProviderSuccess,
   clearCooldownState,
   getCooldownEntryCount,
+  cleanupExpiredCooldownEntries,
 } from "../../../open-sse/services/providerCooldownTracker.ts";
 import {
   resolveResilienceSettings,
@@ -138,6 +139,33 @@ test("cooldown respects maxRetryCooldownMs cap", () => {
 
   const remaining = getRemainingCooldownMs("openai", "conn-1", settings);
   assert.ok(remaining <= 20000, "cooldown capped at maxRetryCooldownMs");
+});
+
+test("cleanup keeps entries for configured long maxRetryCooldownMs", () => {
+  const settings = makeSettings(5000, 60 * 60 * 1000);
+  const originalNow = Date.now;
+
+  try {
+    let fakeNow = Date.now();
+    Date.now = () => fakeNow;
+
+    recordProviderCooldown("openai", "conn-1", settings);
+    assert.equal(getCooldownEntryCount(), 1);
+
+    fakeNow += 31 * 60 * 1000;
+    cleanupExpiredCooldownEntries();
+    assert.equal(
+      getCooldownEntryCount(),
+      1,
+      "cleanup must not evict entries before configured maxRetryCooldownMs"
+    );
+
+    fakeNow += 30 * 60 * 1000;
+    cleanupExpiredCooldownEntries();
+    assert.equal(getCooldownEntryCount(), 0);
+  } finally {
+    Date.now = originalNow;
+  }
 });
 
 test("different connections have independent cooldowns", () => {


### PR DESCRIPTION
## Summary\n- retain provider cooldown tracker entries for the effective configured max retry cooldown window\n- keep the existing 30 minute cleanup floor, but avoid evicting entries early when operators configure longer cooldowns\n- add a focused regression test covering a one hour provider cooldown cleanup window\n\n## Why\nProvider cooldowns can be configured with maxRetryCooldownMs values longer than 30 minutes. The cleanup loop previously used a fixed 30 minute retention window, which could remove an active cooldown entry before the configured retry window elapsed. That lets combo routing re-walk a provider/connection earlier than the operator requested.\n\n## Tests\n- Not run locally in this agent session.\n