### PR TITLE
fix: reject invalid provider cooldown bounds

### DIFF
--- a/src/shared/validation/schemas/settings.ts
+++ b/src/shared/validation/schemas/settings.ts
@@ -101,7 +101,20 @@ export const providerCooldownSettingsSchema = z
     minRetryCooldownMs: z.number().int().min(0).max(300000).optional(),
     maxRetryCooldownMs: z.number().int().min(0).max(3600000).optional(),
   })
-  .strict();
+  .strict()
+  .superRefine((value, ctx) => {
+    if (
+      typeof value.minRetryCooldownMs === "number" &&
+      typeof value.maxRetryCooldownMs === "number" &&
+      value.maxRetryCooldownMs < value.minRetryCooldownMs
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "maxRetryCooldownMs must be greater than or equal to minRetryCooldownMs",
+        path: ["maxRetryCooldownMs"],
+      });
+    }
+  });
 
 export const updateResilienceSchema = z
   .object({

--- a/tests/unit/resilience-provider-cooldown-api-3556.test.ts
+++ b/tests/unit/resilience-provider-cooldown-api-3556.test.ts
@@ -41,6 +41,16 @@ describe("providerCooldown in updateResilienceSchema", () => {
     });
     assert.equal(result.success, false, "Schema should reject unknown keys");
   });
+
+  it("rejects providerCooldown max below min", () => {
+    const result = updateResilienceSchema.safeParse({
+      providerCooldown: {
+        minRetryCooldownMs: 120000,
+        maxRetryCooldownMs: 30000,
+      },
+    });
+    assert.equal(result.success, false, "Schema should reject contradictory cooldown bounds");
+  });
 });
 
 describe("providerCooldown roundtrip through mergeResilienceSettings", () => {


### PR DESCRIPTION
## Summary\n- reject providerCooldown PATCH payloads where maxRetryCooldownMs is lower than minRetryCooldownMs\n- add regression coverage in the existing provider cooldown API/schema test\n\n## Why\nThe runtime normalizer protects itself by raising maxRetryCooldownMs to at least minRetryCooldownMs, but the API boundary accepted contradictory operator input. Rejecting the invalid shape gives callers a clear 400 instead of silently storing surprising resilience settings.\n\n## Tests\n- Not run locally in this agent session.\n