### PR TITLE
fix: preserve production combo metrics on shadow eviction

### DIFF
--- a/open-sse/services/comboMetrics.ts
+++ b/open-sse/services/comboMetrics.ts
@@ -193,7 +193,10 @@ const shadowMetrics = new Map<string, ComboShadowMetricsEntry>();
 const MAX_METRICS_ENTRIES = 500;
 const METRICS_TTL_MS = 60 * 60 * 1000; // 1 hour
 
-function evictOldestMetric(targetMap: Map<string, { lastUsedAt: string | null }>): void {
+function evictOldestMetric(
+  targetMap: Map<string, { lastUsedAt: string | null }>,
+  options: { deletePairedShadow?: boolean } = {}
+): void {
   let oldest: string | null = null;
   let oldestTime = Infinity;
   for (const [name, entry] of targetMap) {
@@ -201,8 +204,10 @@ function evictOldestMetric(targetMap: Map<string, { lastUsedAt: string | null }>
     if (t < oldestTime) { oldestTime = t; oldest = name; }
   }
   if (oldest) {
-    metrics.delete(oldest);
-    shadowMetrics.delete(oldest);
+    targetMap.delete(oldest);
+    if (options.deletePairedShadow) {
+      shadowMetrics.delete(oldest);
+    }
   }
 }
 
@@ -254,7 +259,7 @@ export function recordComboRequest(
   }
 ): void {
   if (!metrics.has(comboName) && metrics.size >= MAX_METRICS_ENTRIES) {
-    evictOldestMetric(metrics);
+    evictOldestMetric(metrics, { deletePairedShadow: true });
   }
   if (!metrics.has(comboName)) {
     metrics.set(comboName, createComboEntry(strategy));
@@ -445,7 +450,7 @@ export function getAllComboMetrics(): Record<string, ComboMetricsView | null> {
  */
 export function recordComboIntent(comboName: string, intent: string): void {
   if (!metrics.has(comboName) && metrics.size >= MAX_METRICS_ENTRIES) {
-    evictOldestMetric(metrics);
+    evictOldestMetric(metrics, { deletePairedShadow: true });
   }
   if (!metrics.has(comboName)) {
     metrics.set(comboName, createComboEntry("priority"));

--- a/tests/unit/services/combo-metrics-memory.test.ts
+++ b/tests/unit/services/combo-metrics-memory.test.ts
@@ -224,6 +224,30 @@ test("eviction: shadow metrics respect their own MAX_METRICS_ENTRIES cap", () =>
   );
 });
 
+test("eviction: shadow overflow does not delete production metrics with the same name", () => {
+  resetAllComboMetrics();
+  const MAX = 500;
+
+  recordComboRequest("shared-combo", "gpt-4", { success: true, latencyMs: 10 });
+
+  for (let i = 0; i < MAX; i++) {
+    recordComboShadowRequest(i === 0 ? "shared-combo" : "shadow-fill-" + i, "gpt-4", {
+      success: true,
+      latencyMs: 10,
+    });
+  }
+
+  recordComboShadowRequest("shadow-after-capacity", "gpt-4", {
+    success: true,
+    latencyMs: 50,
+  });
+
+  const metrics = getComboMetrics("shared-combo");
+  assert.ok(metrics, "production metrics must survive shadow-only eviction");
+  assert.equal(metrics.productionTraffic, true);
+  assert.equal(metrics.totalRequests, 1);
+});
+
 test("eviction: recordComboIntent respects MAX_METRICS_ENTRIES cap", () => {
   resetAllComboMetrics();
   const MAX = 500;


### PR DESCRIPTION
## Summary\n- prevent shadow/dark-launch combo metrics eviction from deleting production combo metrics with the same name\n- keep production overflow behavior paired with shadow cleanup, but make shadow overflow shadow-only\n- add regression coverage in the existing combo metrics memory tests\n\n## Why\nShadow routing metrics are intentionally isolated so dark-launch traffic does not affect production routing decisions or dashboard counters. When the shadow metrics map hit capacity, the eviction helper deleted from both the shadow and production maps. That meant high-cardinality shadow traffic could erase production combo metrics for a shared combo name.\n\n## Tests\n- Not run locally in this agent session.\n