### PR TITLE
fix(relay): apply IP rate limit to Bifrost sidecar

### DIFF
--- a/src/app/api/v1/relay/chat/completions/bifrost/route.ts
+++ b/src/app/api/v1/relay/chat/completions/bifrost/route.ts
@@ -36,8 +36,14 @@ import {
   recordRelayUsage,
 } from "@/lib/db/relayProxies";
 import { buildErrorBody } from "@omniroute/open-sse/utils/error";
-import { createHash } from "node:crypto";
 import { z } from "zod";
+import {
+  checkIpRateLimit,
+  extractToken,
+  getClientIp,
+  hashToken,
+  sanitizeForensicHeader,
+} from "../relaySecurity";
 
 // Minimal request-shape validation (Rule #7). `.passthrough()` keeps every other
 // OpenAI chat-completion field intact (temperature, tools, response_format, …) —
@@ -68,29 +74,9 @@ export async function OPTIONS() {
   return handleCorsOptions();
 }
 
-function sanitizeForensicHeader(value: string | null, max = 256): string {
-  if (!value) return "unknown";
-  return value.replace(/[\r\n]+/g, " ").slice(0, max);
-}
-
-function extractToken(request: Request): string | null {
-  const auth = request.headers.get("authorization") || "";
-  const match = auth.match(/^Bearer\s+(.+)$/i);
-  if (match) return match[1];
-  return request.headers.get("x-relay-token");
-}
-
-function hashToken(token: string): string {
-  return createHash("sha256").update(token).digest("hex");
-}
-
 export async function POST(request: Request) {
   const startTime = Date.now();
-  const clientIp = sanitizeForensicHeader(
-    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
-      request.headers.get("x-real-ip") ||
-      null
-  );
+  const clientIp = getClientIp(request);
   const userAgent = sanitizeForensicHeader(request.headers.get("user-agent"));
 
   if (!BIFROST_ENABLED) {
@@ -165,6 +151,28 @@ export async function POST(request: Request) {
       return new Response(JSON.stringify(buildErrorBody(401, "Relay token expired")), {
         status: 401,
         headers: JSON_CORS_HEADERS,
+      });
+    }
+
+    // 2a. Per-(token,IP) gate — mirrors the TypeScript relay fallback so the
+    // sidecar path does not weaken leaked-token abuse protection.
+    const ipCheck = checkIpRateLimit(token.id, clientIp);
+    if (!ipCheck.allowed) {
+      recordRelayUsage(token.id, {
+        requestId: request.headers.get("x-request-id") || undefined,
+        status: "rate_limited",
+        statusCode: 429,
+        latencyMs: Date.now() - startTime,
+        clientIp,
+        userAgent,
+      });
+      return new Response(JSON.stringify(buildErrorBody(429, "Per-IP rate limit exceeded")), {
+        status: 429,
+        headers: {
+          ...JSON_CORS_HEADERS,
+          "Retry-After": String(ipCheck.resetIn),
+          "X-RateLimit-Scope": "ip",
+        },
       });
     }
 

--- a/src/app/api/v1/relay/chat/completions/relaySecurity.ts
+++ b/src/app/api/v1/relay/chat/completions/relaySecurity.ts
@@ -1,0 +1,72 @@
+import { createHash } from "node:crypto";
+
+// Forensic-only sanitization: client IP / user-agent come from untrusted
+// headers and feed recordRelayUsage() rows. Strip CR/LF so a malicious header
+// cannot forge log lines, and cap length.
+export function sanitizeForensicHeader(value: string | null, max = 256): string {
+  if (!value) return "unknown";
+  return value.replace(/[\r\n]+/g, " ").slice(0, max);
+}
+
+export function getClientIp(request: Request): string {
+  return sanitizeForensicHeader(
+    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+      request.headers.get("x-real-ip") ||
+      null
+  );
+}
+
+export function extractToken(request: Request): string | null {
+  const auth = request.headers.get("authorization") || "";
+  const match = auth.match(/^Bearer\s+(.+)$/i);
+  if (match) return match[1];
+
+  // Also check X-Relay-Token header.
+  return request.headers.get("x-relay-token");
+}
+
+export function hashToken(token: string): string {
+  return createHash("sha256").update(token).digest("hex");
+}
+
+// ── In-memory per-(token,IP) rate limit ─────────────────────────────────────
+// Defence-in-depth on top of the DB-backed per-token limit: a leaked relay
+// token redistributed across N IPs would otherwise consume the per-token quota
+// in parallel. This second gate caps a *single* IP using a token to
+// RELAY_IP_PER_MINUTE req/min.
+//
+// In-memory by design: cheap, no DB round-trip, no extra migration. Per
+// instance only — if you run multiple relay replicas behind a load balancer,
+// the effective ceiling is RELAY_IP_PER_MINUTE * replicas.
+const RELAY_IP_PER_MINUTE = Number(process.env.RELAY_IP_PER_MINUTE || "30");
+const ipBuckets = new Map<string, { count: number; windowStart: number }>();
+
+export function checkIpRateLimit(tokenId: string, ip: string): { allowed: boolean; resetIn: number } {
+  if (!Number.isFinite(RELAY_IP_PER_MINUTE) || RELAY_IP_PER_MINUTE <= 0) {
+    return { allowed: true, resetIn: 0 };
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  const windowStart = Math.floor(now / 60) * 60;
+  const key = tokenId + "|" + ip;
+  const bucket = ipBuckets.get(key);
+
+  if (!bucket || bucket.windowStart !== windowStart) {
+    ipBuckets.set(key, { count: 1, windowStart });
+    if (ipBuckets.size > 10_000) {
+      // Bound memory: drop stale buckets when the table grows past 10k.
+      const cutoff = windowStart - 60;
+      for (const [k, b] of ipBuckets) {
+        if (b.windowStart < cutoff) ipBuckets.delete(k);
+      }
+    }
+    return { allowed: true, resetIn: 60 - (now % 60) };
+  }
+
+  if (bucket.count >= RELAY_IP_PER_MINUTE) {
+    return { allowed: false, resetIn: 60 - (now % 60) };
+  }
+
+  bucket.count++;
+  return { allowed: true, resetIn: 60 - (now % 60) };
+}

--- a/src/app/api/v1/relay/chat/completions/route.ts
+++ b/src/app/api/v1/relay/chat/completions/route.ts
@@ -11,57 +11,15 @@ import { handleChat } from "@/sse/handlers/chat";
 import { createInjectionGuard } from "@/middleware/promptInjectionGuard";
 import { getRelayTokenByHash, checkRateLimit, recordRelayUsage } from "@/lib/db/relayProxies";
 import { buildErrorBody } from "@omniroute/open-sse/utils/error";
-import { createHash } from "node:crypto";
+import {
+  checkIpRateLimit,
+  extractToken,
+  getClientIp,
+  hashToken,
+  sanitizeForensicHeader,
+} from "./relaySecurity";
 
 const JSON_CORS_HEADERS = { ...CORS_HEADERS, "Content-Type": "application/json" } as const;
-
-// Forensic-only sanitization: client IP / user-agent come from untrusted
-// headers and feed `recordRelayUsage()` rows. Strip CR/LF so a malicious
-// header cannot forge log lines, and cap length.
-function sanitizeForensicHeader(value: string | null, max = 256): string {
-  if (!value) return "unknown";
-  return value.replace(/[\r\n]+/g, " ").slice(0, max);
-}
-
-// ── In-memory per-(token,IP) rate limit ─────────────────────────────────────
-// Defence-in-depth on top of the DB-backed per-token limit: a leaked relay
-// token redistributed across N IPs would otherwise consume the per-token
-// quota in parallel. This second gate caps a *single* IP using a token to
-// `RELAY_IP_PER_MINUTE` req/min — legit clients keep working, distributed
-// abuse of one token hits the wall fast.
-//
-// In-memory by design: cheap, no DB round-trip, no extra migration. Per
-// instance only — if you run multiple relay replicas behind a load balancer,
-// the effective ceiling is `RELAY_IP_PER_MINUTE * replicas`, which is still
-// orders of magnitude tighter than no gate.
-const RELAY_IP_PER_MINUTE = Number(process.env.RELAY_IP_PER_MINUTE || "30");
-const ipBuckets = new Map<string, { count: number; windowStart: number }>();
-
-function checkIpRateLimit(tokenId: string, ip: string): { allowed: boolean; resetIn: number } {
-  if (!Number.isFinite(RELAY_IP_PER_MINUTE) || RELAY_IP_PER_MINUTE <= 0) {
-    return { allowed: true, resetIn: 0 };
-  }
-  const now = Math.floor(Date.now() / 1000);
-  const windowStart = Math.floor(now / 60) * 60;
-  const key = tokenId + "|" + ip;
-  const bucket = ipBuckets.get(key);
-  if (!bucket || bucket.windowStart !== windowStart) {
-    ipBuckets.set(key, { count: 1, windowStart });
-    if (ipBuckets.size > 10_000) {
-      // Bound memory: drop the oldest half when the table grows past 10k.
-      const cutoff = windowStart - 60;
-      for (const [k, b] of ipBuckets) {
-        if (b.windowStart < cutoff) ipBuckets.delete(k);
-      }
-    }
-    return { allowed: true, resetIn: 60 - (now % 60) };
-  }
-  if (bucket.count >= RELAY_IP_PER_MINUTE) {
-    return { allowed: false, resetIn: 60 - (now % 60) };
-  }
-  bucket.count++;
-  return { allowed: true, resetIn: 60 - (now % 60) };
-}
 
 const injectionGuard = createInjectionGuard();
 
@@ -69,26 +27,9 @@ export async function OPTIONS() {
   return handleCorsOptions();
 }
 
-function extractToken(request: Request): string | null {
-  const auth = request.headers.get("authorization") || "";
-  const match = auth.match(/^Bearer\s+(.+)$/i);
-  if (match) return match[1];
-
-  // Also check X-Relay-Token header
-  return request.headers.get("x-relay-token");
-}
-
-function hashToken(token: string): string {
-  return createHash("sha256").update(token).digest("hex");
-}
-
 export async function POST(request: Request) {
   const startTime = Date.now();
-  const clientIp = sanitizeForensicHeader(
-    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
-      request.headers.get("x-real-ip") ||
-      null
-  );
+  const clientIp = getClientIp(request);
   const userAgent = sanitizeForensicHeader(request.headers.get("user-agent"));
 
   try {

--- a/tests/unit/api/v1/bifrost-sidecar.test.ts
+++ b/tests/unit/api/v1/bifrost-sidecar.test.ts
@@ -1,6 +1,11 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
+import {
+  checkIpRateLimit,
+  getClientIp,
+  sanitizeForensicHeader,
+} from "../../../../src/app/api/v1/relay/chat/completions/relaySecurity.ts";
 
 // ─── T-12 (#3932 PR-4): bifrost sidecar proxy route ──────────────────────
 //
@@ -116,4 +121,28 @@ test("bifrost route: OPTIONS responds with CORS headers", async () => {
     res.headers.get("Access-Control-Allow-Headers"),
     "missing Access-Control-Allow-Headers header"
   );
+});
+
+test("bifrost route: shared relay IP limiter blocks a repeated token from one IP", () => {
+  const tokenId = `bifrost-ip-limit-${Date.now()}-${Math.random()}`;
+  const ip = "203.0.113.77";
+
+  for (let i = 0; i < 30; i++) {
+    assert.equal(checkIpRateLimit(tokenId, ip).allowed, true);
+  }
+
+  const blocked = checkIpRateLimit(tokenId, ip);
+  assert.equal(blocked.allowed, false);
+  assert.ok(blocked.resetIn >= 0 && blocked.resetIn <= 60);
+});
+
+test("bifrost route: shared relay security helpers sanitize forwarded client metadata", () => {
+  const req = new Request("http://localhost/api/v1/relay/chat/completions/bifrost", {
+    headers: {
+      "x-forwarded-for": "198.51.100.8, 10.0.0.2",
+    },
+  });
+
+  assert.equal(getClientIp(req), "198.51.100.8");
+  assert.equal(sanitizeForensicHeader("ua\r\nforged"), "ua forged");
 });


### PR DESCRIPTION
## Summary\n- extract shared relay security helpers for token extraction, token hashing, forensic metadata sanitization, client IP parsing, and the in-memory per-token/IP limiter\n- apply the same per-token/IP leaked-token limiter to the Bifrost sidecar route before the DB-backed per-token limiter\n- add Bifrost-sidecar regression coverage for the shared IP limiter and forwarded-client metadata helpers\n\n## Why\nThe TypeScript relay fallback already limits a single IP using a relay token before the DB-backed token limiter. The Bifrost sidecar route duplicated auth/rate-limit logic but only ran the DB-backed per-token check, which made the sidecar path a weaker boundary for leaked-token abuse. This keeps the sidecar independent from the heavy TS relay handler while aligning both route security contracts.\n\n## Verification\n- \n- 
> omniroute@3.8.33 check:file-size
> node scripts/check/check-file-size.mjs

[file-size] OK — 104 arquivos congelados, cap 800 para novos (2725 arquivos verificados)
[test-file-size] OK — 42 test files congelados, testCap 800 para novos (2119 test files verificados)\n- 
> omniroute@3.8.33 check:public-creds
> node scripts/check/check-public-creds.mjs

[check-public-creds] OK (716 arquivo(s) em 2 raiz(es), 2 literal(is) congelado(s))\n\n## Notes\n- 
> omniroute@3.8.33 check:env-doc-sync
> node scripts/check/check-env-doc-sync.mjs

Env var contract sync report
============================
Code references:          350 unique vars
In .env.example:          437 unique vars
In docs/reference/ENVIRONMENT.md: 456 unique vars

  ✗ In code but missing from .env.example: 2
     - KIRO_VERIFY_FULL_CRC
     - QUOTA_PREFLIGHT_CUTOFF_ENABLED
  ✓ In .env.example but missing from ENVIRONMENT.md: none
  ✓ In ENVIRONMENT.md but missing from .env.example: none

✗ Env / docs contract is out of sync. Update .env.example, docs/reference/ENVIRONMENT.md,
  or the allowlists in scripts/check/check-env-doc-sync.mjs and try again. currently fails on the release branch baseline because  and  are referenced in code but missing from . That is tracked separately in #4587.\n- Local  could not run in this clean checkout because the earlier dependency install did not provide the eslint binary.\n