### PR TITLE
fix(dashboard): gate topology side effects behind widget visibility

### DIFF
--- a/src/app/(dashboard)/dashboard/HomePageClient.tsx
+++ b/src/app/(dashboard)/dashboard/HomePageClient.tsx
@@ -13,10 +13,8 @@ import { useNotificationStore } from "@/store/notificationStore";
 import { copyToClipboard } from "@/shared/utils/clipboard";
 import { getProviderDisplayLabel } from "@/shared/utils/providerDisplayLabel";
 import { useIsElectron, useOpenExternal } from "@/shared/hooks/useElectron";
-import { useLiveRequests } from "@/hooks/useLiveDashboard";
-import { selectActiveRequests } from "../home/topologyUtils";
+import { HomeProviderTopologySection } from "./HomeProviderTopologySection";
 
-const ProviderTopology = dynamic(() => import("../home/ProviderTopology"), { ssr: false });
 const ProviderQuotaWidget = dynamic(() => import("../home/ProviderQuotaWidget"), { ssr: false });
 import type { NewsAnnouncement } from "@/shared/utils/releaseNotes";
 
@@ -123,7 +121,8 @@ export default function HomePageClient({ machineId }: HomePageClientProps) {
   const [updating, setUpdating] = useState(false);
 
   // Platform detection and download links for Electron
-  const platform = typeof globalThis.window === "undefined" ? undefined : globalThis.window.electronAPI?.platform;
+  const platform =
+    typeof globalThis.window === "undefined" ? undefined : globalThis.window.electronAPI?.platform;
   const electronDownload = useMemo(() => {
     const latest = versionInfo?.latest || "";
     const cleanLatest = latest.replace(/^v/, "");
@@ -171,7 +170,8 @@ export default function HomePageClient({ machineId }: HomePageClientProps) {
   }>({ status: "idle" });
 
   useEffect(() => {
-    if (!isElectron || typeof globalThis.window === "undefined" || !globalThis.window.electronAPI) return;
+    if (!isElectron || typeof globalThis.window === "undefined" || !globalThis.window.electronAPI)
+      return;
 
     // Trigger initial check silently on mount
     globalThis.window.electronAPI.checkForUpdates().catch((err: any) => {
@@ -199,6 +199,7 @@ export default function HomePageClient({ machineId }: HomePageClientProps) {
   const [showProviderTopologyOnHome, setShowProviderTopologyOnHome] = useState(true); // default on
   const [autoRefreshProviderQuota, setAutoRefreshProviderQuota] = useState(false);
   const [autoRefreshProviderQuotaInterval, setAutoRefreshProviderQuotaInterval] = useState(180);
+  const [appearanceSettingsLoaded, setAppearanceSettingsLoaded] = useState(false);
 
   useEffect(() => {
     // Fetch the pin settings (lightweight)
@@ -225,6 +226,9 @@ export default function HomePageClient({ machineId }: HomePageClientProps) {
       })
       .catch(() => {
         /* ignore — defaults stay */
+      })
+      .finally(() => {
+        setAppearanceSettingsLoaded(true);
       });
   }, []);
 
@@ -236,10 +240,9 @@ export default function HomePageClient({ machineId }: HomePageClientProps) {
 
   const fetchData = useCallback(async () => {
     try {
-      const [provRes, modelsRes, metricsRes, versionRes] = await Promise.all([
+      const [provRes, modelsRes, versionRes] = await Promise.all([
         fetch("/api/providers"),
         fetch("/api/models"),
-        fetch("/api/provider-metrics"),
         fetch("/api/system/version"),
       ]);
       if (provRes.ok) {
@@ -249,10 +252,6 @@ export default function HomePageClient({ machineId }: HomePageClientProps) {
       if (modelsRes.ok) {
         const modelsData = await modelsRes.json();
         setModels(modelsData.models || []);
-      }
-      if (metricsRes.ok) {
-        const metricsData = await metricsRes.json();
-        setProviderMetrics(metricsData.metrics || {});
       }
       if (versionRes.ok) {
         const versionData = await versionRes.json();
@@ -278,6 +277,10 @@ export default function HomePageClient({ machineId }: HomePageClientProps) {
   }, []);
 
   useEffect(() => {
+    if (!appearanceSettingsLoaded || !showProviderTopologyOnHome) {
+      return;
+    }
+
     let cancelled = false;
     let timeoutId: ReturnType<typeof setTimeout> | null = null;
     let controller: AbortController | null = null;
@@ -317,7 +320,7 @@ export default function HomePageClient({ machineId }: HomePageClientProps) {
       if (timeoutId) clearTimeout(timeoutId);
       controller?.abort();
     };
-  }, []);
+  }, [appearanceSettingsLoaded, showProviderTopologyOnHome]);
 
   // T07: Check for unhealthy API keys and show notification (once per session)
   const notifiedUnhealthyKeys = useRef<Set<string>>(new Set());
@@ -1061,9 +1064,7 @@ export default function HomePageClient({ machineId }: HomePageClientProps) {
       {pinProviderQuotaToHome && (
         <Suspense fallback={<CardSkeleton />}>
           <ProviderQuotaWidget
-            autoRefreshInterval={
-              autoRefreshProviderQuota ? autoRefreshProviderQuotaInterval : 0
-            }
+            autoRefreshInterval={autoRefreshProviderQuota ? autoRefreshProviderQuotaInterval : 0}
           />
         </Suspense>
       )}
@@ -1159,35 +1160,12 @@ export default function HomePageClient({ machineId }: HomePageClientProps) {
         </Card>
       )}
 
-      {/* Provider Topology (controlled by Appearance setting, default on) */}
       {showProviderTopologyOnHome && (
-        <Card>
-          <div className="flex items-center justify-between mb-3">
-            <div>
-              <h2 className="text-base font-semibold">{t("providerTopology")}</h2>
-              <p className="text-xs text-text-muted">
-                Connected providers routing through OmniRoute in real time
-              </p>
-            </div>
-            <div className="flex items-center gap-3 text-[11px] text-text-muted">
-              <span className="flex items-center gap-1.5">
-                <span className="size-2 rounded-full bg-green-500" /> Active
-              </span>
-              <span className="flex items-center gap-1.5">
-                <span className="size-2 rounded-full bg-amber-500" /> Recent
-              </span>
-              <span className="flex items-center gap-1.5">
-                <span className="size-2 rounded-full bg-red-500" /> Error
-              </span>
-            </div>
-          </div>
-          <ProviderTopology
-            providers={topologyProviders}
-            activeRequests={selectActiveRequests(liveActiveRequests)}
-            lastProvider={lastProvider}
-            errorProvider={errorProvider}
-          />
-        </Card>
+        <HomeProviderTopologySection
+          providers={topologyProviders}
+          lastProvider={lastProvider}
+          errorProvider={errorProvider}
+        />
       )}
 
       {/* Provider Models Modal */}

--- a/src/app/(dashboard)/dashboard/HomeProviderTopologySection.tsx
+++ b/src/app/(dashboard)/dashboard/HomeProviderTopologySection.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import dynamic from "next/dynamic";
+
+import { Card } from "@/shared/components";
+import { useLiveRequests } from "@/hooks/useLiveDashboard";
+import { selectActiveRequests } from "../home/topologyUtils";
+
+const ProviderTopology = dynamic(() => import("../home/ProviderTopology"), { ssr: false });
+
+type TopologyProvider = {
+  id: string;
+  provider: string;
+  name?: string;
+};
+
+export function HomeProviderTopologySection({
+  providers,
+  lastProvider,
+  errorProvider,
+}: {
+  providers: TopologyProvider[];
+  lastProvider: string;
+  errorProvider: string;
+}) {
+  const t = useTranslations("home");
+  const { activeRequests: liveActiveRequests } = useLiveRequests();
+
+  return (
+    <Card>
+      <div className="flex items-center justify-between mb-3">
+        <div>
+          <h2 className="text-base font-semibold">{t("providerTopology")}</h2>
+          <p className="text-xs text-text-muted">
+            Connected providers routing through OmniRoute in real time
+          </p>
+        </div>
+        <div className="flex items-center gap-3 text-[11px] text-text-muted">
+          <span className="flex items-center gap-1.5">
+            <span className="size-2 rounded-full bg-green-500" /> Active
+          </span>
+          <span className="flex items-center gap-1.5">
+            <span className="size-2 rounded-full bg-amber-500" /> Recent
+          </span>
+          <span className="flex items-center gap-1.5">
+            <span className="size-2 rounded-full bg-red-500" /> Error
+          </span>
+        </div>
+      </div>
+      <ProviderTopology
+        providers={providers}
+        activeRequests={selectActiveRequests(liveActiveRequests)}
+        lastProvider={lastProvider}
+        errorProvider={errorProvider}
+      />
+    </Card>
+  );
+}

--- a/tests/unit/ui/home-provider-topology-section-4606.test.tsx
+++ b/tests/unit/ui/home-provider-topology-section-4606.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+//
+// #4606: the provider-topology card was extracted into HomeProviderTopologySection
+// and its activity fetch gated behind widget visibility in HomePageClient
+// (`appearanceSettingsLoaded && showProviderTopologyOnHome`). This guards the
+// extracted section: it renders the topology card and feeds live active-requests
+// through selectActiveRequests into ProviderTopology (Rule #18 for the change).
+import React from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+vi.mock("next/dynamic", () => ({
+  default: () => (props: Record<string, unknown>) => (
+    <div data-testid="provider-topology" data-providers={String((props.providers as unknown[])?.length ?? 0)} />
+  ),
+}));
+vi.mock("@/shared/components", () => ({
+  Card: ({ children }: { children: React.ReactNode }) => <div data-testid="card">{children}</div>,
+}));
+const liveRequestsMock = vi.fn(() => ({ activeRequests: [] as unknown[] }));
+vi.mock("@/hooks/useLiveDashboard", () => ({
+  useLiveRequests: () => liveRequestsMock(),
+}));
+
+const { HomeProviderTopologySection } = await import(
+  "../../../src/app/(dashboard)/dashboard/HomeProviderTopologySection"
+);
+
+let container: HTMLDivElement;
+let root: ReturnType<typeof createRoot>;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.clearAllMocks();
+});
+
+it("renders the topology card and forwards providers to ProviderTopology", () => {
+  act(() => {
+    root.render(
+      <HomeProviderTopologySection
+        providers={[
+          { id: "p1", provider: "openai", name: "OpenAI" },
+          { id: "p2", provider: "anthropic", name: "Anthropic" },
+        ]}
+        lastProvider="openai"
+        errorProvider=""
+      />
+    );
+  });
+
+  expect(container.querySelector("[data-testid='card']")).not.toBeNull();
+  const topology = container.querySelector("[data-testid='provider-topology']");
+  expect(topology).not.toBeNull();
+  expect(topology?.getAttribute("data-providers")).toBe("2");
+});


### PR DESCRIPTION
## Summary
- move the home topology widget into a small child component so the live request WebSocket hook only mounts when the widget is visible
- remove /api/provider-metrics from the general home dashboard bootstrap fetch
- start the topology metrics polling loop only after appearance settings load and showProviderTopologyOnHome is enabled

## Why
When the provider topology widget is hidden, the dashboard should not keep a live request socket or a 3s provider-metrics polling loop alive for that hidden feature.

## Verification
- npm run check:file-size
- npm run check:env-doc-sync
- npm run check:public-creds
- npm run typecheck:core -- --pretty false
- pre-commit: prettier --write, eslint --fix --no-error-on-unmatched-pattern, docs sync, check:any-budget:t11, check:tracked-artifacts