### PR TITLE
fix(cli): align data dir and env loading with runtime

### DIFF
--- a/bin/cli/data-dir.mjs
+++ b/bin/cli/data-dir.mjs
@@ -1,5 +1,6 @@
 import os from "node:os";
 import path from "node:path";
+import fs from "node:fs";
 
 const APP_NAME = "omniroute";
 
@@ -22,6 +23,18 @@ export function resolveDataDir() {
   if (configured) return configured;
 
   const homeDir = safeHomeDir();
+  const legacyDir = path.join(homeDir, `.${APP_NAME}`);
+
+  if (fs.existsSync(legacyDir)) {
+    try {
+      if (fs.statSync(legacyDir).isDirectory()) {
+        return legacyDir;
+      }
+    } catch {
+      // Ignore stat errors.
+    }
+  }
+
   if (process.platform === "win32") {
     const appData = process.env.APPDATA || path.join(homeDir, "AppData", "Roaming");
     return path.join(appData, APP_NAME);
@@ -30,7 +43,7 @@ export function resolveDataDir() {
   const xdgConfigHome = normalizeConfiguredPath(process.env.XDG_CONFIG_HOME);
   if (xdgConfigHome) return path.join(xdgConfigHome, APP_NAME);
 
-  return path.join(homeDir, `.${APP_NAME}`);
+  return legacyDir;
 }
 
 export function resolveStoragePath(dataDir = resolveDataDir()) {

--- a/bin/omniroute.mjs
+++ b/bin/omniroute.mjs
@@ -80,7 +80,6 @@ function loadEnvFile() {
           }
         }
         console.log(`  \x1b[2m📋 Loaded env from ${envPath}\x1b[0m`);
-        return;
       }
     } catch {
       // Ignore errors reading env files.

--- a/tests/unit/cli-data-dir-env.test.ts
+++ b/tests/unit/cli-data-dir-env.test.ts
@@ -1,0 +1,68 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { resolveDataDir as cliResolveDataDir } from "../../bin/cli/data-dir.mjs";
+import { resolveDataDir as runtimeResolveDataDir } from "../../src/lib/dataPaths.ts";
+
+const REPO_ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const BIN = path.join(REPO_ROOT, "bin", "omniroute.mjs");
+
+async function withTempEnv(
+  fn: (paths: { root: string; home: string; cwd: string }) => void | Promise<void>
+) {
+  const originalEnv = { ...process.env };
+  const originalCwd = process.cwd();
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "omni-cli-env-"));
+  const home = path.join(root, "home");
+  const cwd = path.join(root, "cwd");
+  fs.mkdirSync(home, { recursive: true });
+  fs.mkdirSync(cwd, { recursive: true });
+
+  delete process.env.DATA_DIR;
+  delete process.env.XDG_CONFIG_HOME;
+  delete process.env.APPDATA;
+  process.env.HOME = home;
+  process.chdir(cwd);
+
+  try {
+    await fn({ root, home, cwd });
+  } finally {
+    process.chdir(originalCwd);
+    for (const key of Object.keys(process.env)) {
+      if (!(key in originalEnv)) delete process.env[key];
+    }
+    for (const [key, value] of Object.entries(originalEnv)) {
+      process.env[key] = value;
+    }
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test("CLI data dir preserves existing legacy ~/.omniroute before XDG", async () => {
+  await withTempEnv(({ home, root }) => {
+    const legacyDir = path.join(home, ".omniroute");
+    fs.mkdirSync(legacyDir, { recursive: true });
+    process.env.XDG_CONFIG_HOME = path.join(root, "xdg");
+
+    assert.equal(cliResolveDataDir(), legacyDir);
+    assert.equal(cliResolveDataDir(), runtimeResolveDataDir());
+  });
+});
+
+test("CLI env loader scans all env paths while preserving first value wins", () => {
+  const source = fs.readFileSync(BIN, "utf8");
+  const loaderStart = source.indexOf("function loadEnvFile()");
+  const loaderEnd = source.indexOf("loadEnvFile();", loaderStart);
+  const loaderSource = source.slice(loaderStart, loaderEnd);
+
+  assert.match(loaderSource, /for \(const envPath of envPaths\)/);
+  assert.match(loaderSource, /if \(process\.env\[key\] === undefined\)/);
+  assert.doesNotMatch(
+    loaderSource,
+    /Loaded env from \$\{envPath\}[\s\S]{0,80}\breturn;/
+  );
+});


### PR DESCRIPTION
## Summary
- align CLI data-dir resolution with the runtime legacy ~/.omniroute preservation rule before XDG
- make the CLI entrypoint continue loading later non-conflicting env files instead of returning after the first existing .env
- add focused regression coverage for data-dir parity and env-loader first-value-wins scanning

## Why
CLI maintenance commands should operate on the same SQLite store as the runtime, and a minimal DATA_DIR/.env should not suppress non-conflicting cwd/repo configuration.

## Verification
- node --import tsx --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test --test-force-exit tests/unit/cli-data-dir-env.test.ts
- npm run check:file-size
- npm run check:env-doc-sync
- npm run check:public-creds
- npm run typecheck:core -- --pretty false