### PR TITLE
fix(quota): expose Bailian quota windows

### DIFF
--- a/open-sse/services/bailianQuotaFetcher.ts
+++ b/open-sse/services/bailianQuotaFetcher.ts
@@ -19,7 +19,7 @@
  * Registration: call registerBailianCodingPlanQuotaFetcher() once at server startup.
  */
 
-import { registerQuotaFetcher, type QuotaInfo } from "./quotaPreflight.ts";
+import { registerQuotaFetcher, registerQuotaWindows, type QuotaInfo } from "./quotaPreflight.ts";
 import { registerMonitorFetcher } from "./quotaMonitor.ts";
 
 // Bailian quota hosts (international / china fallback)
@@ -34,9 +34,15 @@ const BAILIAN_QUOTA_PATH =
 // Cache TTL — short enough to be reactive, long enough to avoid rate limits
 const CACHE_TTL_MS = 60_000; // 60 seconds
 
+// Window keys as surfaced to the dashboard and quota-window registry
+export const BAILIAN_WINDOW_5H = "window_5h";
+export const BAILIAN_WINDOW_WEEKLY = "window_weekly";
+export const BAILIAN_WINDOW_MONTHLY = "window_monthly";
+
 // Triple-window quota info (richer than QuotaInfo — includes all 3 windows)
 // [Oracle CONDITIONAL] bailian-coding-plan only — do not reuse for other providers
 export interface BailianTripleWindowQuota extends QuotaInfo {
+  windows: Record<string, { percentUsed: number; resetAt: string | null }>;
   window5h: { percentUsed: number; resetAt: string | null };
   windowWeekly: { percentUsed: number; resetAt: string | null };
   windowMonthly: { percentUsed: number; resetAt: string | null };
@@ -181,6 +187,11 @@ function parseBailianQuotaResponse(data: unknown): BailianTripleWindowQuota | nu
     percentUsed: pctMonthly,
     resetAt: resetAtMonthly > 0 ? new Date(resetAtMonthly * 1000).toISOString() : null,
   };
+  const windows = {
+    [BAILIAN_WINDOW_5H]: window5h,
+    [BAILIAN_WINDOW_WEEKLY]: windowWeekly,
+    [BAILIAN_WINDOW_MONTHLY]: windowMonthly,
+  };
 
   // Dominant reset = reset time of the most restrictive window
   const dominantResetAt =
@@ -195,6 +206,7 @@ function parseBailianQuotaResponse(data: unknown): BailianTripleWindowQuota | nu
     total: 100,
     percentUsed: worstPercentUsed,
     resetAt: dominantResetAt,
+    windows,
     window5h,
     windowWeekly,
     windowMonthly,
@@ -313,4 +325,9 @@ export function invalidateBailianQuotaCache(connectionId: string): void {
 export function registerBailianCodingPlanQuotaFetcher(): void {
   registerQuotaFetcher("bailian-coding-plan", fetchBailianQuota);
   registerMonitorFetcher("bailian-coding-plan", fetchBailianQuota);
+  registerQuotaWindows("bailian-coding-plan", [
+    BAILIAN_WINDOW_5H,
+    BAILIAN_WINDOW_WEEKLY,
+    BAILIAN_WINDOW_MONTHLY,
+  ]);
 }

--- a/tests/unit/bailian-quota-fetcher.test.ts
+++ b/tests/unit/bailian-quota-fetcher.test.ts
@@ -2,6 +2,9 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  BAILIAN_WINDOW_5H,
+  BAILIAN_WINDOW_MONTHLY,
+  BAILIAN_WINDOW_WEEKLY,
   fetchBailianQuota,
   invalidateBailianQuotaCache,
   registerBailianCodingPlanQuotaFetcher,
@@ -216,6 +219,9 @@ test("fetchBailianQuota parses triple-window and returns percentUsed = max(5h%, 
   assert.equal(quota?.window5h?.percentUsed, 0.6);
   assert.equal(quota?.windowWeekly?.percentUsed, 0.8);
   assert.equal(quota?.windowMonthly?.percentUsed, 0.4);
+  assert.equal(quota?.windows?.[BAILIAN_WINDOW_5H]?.percentUsed, 0.6);
+  assert.equal(quota?.windows?.[BAILIAN_WINDOW_WEEKLY]?.percentUsed, 0.8);
+  assert.equal(quota?.windows?.[BAILIAN_WINDOW_MONTHLY]?.percentUsed, 0.4);
 
   invalidateBailianQuotaCache(connectionId);
 });


### PR DESCRIPTION
## Summary

- expose Bailian's 5h, weekly, and monthly quota signals through the shared `QuotaInfo.windows` map
- register those Bailian window names with `quotaPreflight` so per-window thresholds and dashboard metadata can see them
- keep the existing legacy `window5h`, `windowWeekly`, and `windowMonthly` fields intact for current callers

Fixes #4594.

## Verification

- `node --import tsx --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test --test-force-exit tests/unit/bailian-quota-fetcher.test.ts` (14/14)
- `npm run check:file-size`
- `npm run check:env-doc-sync`
- `npm run check:public-creds`
- `npm run typecheck:core -- --pretty false`