### PR TITLE
fix(proxyfetch): skip live ws bridge when disabled

### DIFF
--- a/open-sse/handlers/chatCore/telemetryHelpers.ts
+++ b/open-sse/handlers/chatCore/telemetryHelpers.ts
@@ -1,11 +1,25 @@
 import { fetchLiveProviderLimits } from "@/lib/usage/providerLimits";
 import { isClaudeExtraUsageBlockEnabled } from "@/lib/providers/claudeExtraUsage";
 
+export function resolveLiveWsEventPort(): string | null {
+  const configuredPort = process.env.LIVE_WS_PORT?.trim();
+  if (configuredPort) {
+    return configuredPort;
+  }
+
+  const enabled = process.env.OMNIROUTE_ENABLE_LIVE_WS?.trim().toLowerCase();
+  return enabled === "1" || enabled === "true" ? "20129" : null;
+}
+
 export async function forwardDashboardEventToLiveWs(
   event: string,
   payload: unknown
 ): Promise<void> {
-  const port = process.env.LIVE_WS_PORT || "20129";
+  const port = resolveLiveWsEventPort();
+  if (!port) {
+    return;
+  }
+
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 1_500);
   try {

--- a/tests/unit/chatcore-telemetry-helpers.test.ts
+++ b/tests/unit/chatcore-telemetry-helpers.test.ts
@@ -9,13 +9,16 @@ import path from "node:path";
 const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-telemetry-"));
 process.env.DATA_DIR = TEST_DATA_DIR;
 
-const { forwardDashboardEventToLiveWs, maybeSyncClaudeExtraUsageState } = await import(
-  "../../open-sse/handlers/chatCore/telemetryHelpers.ts"
-);
+const {
+  forwardDashboardEventToLiveWs,
+  maybeSyncClaudeExtraUsageState,
+  resolveLiveWsEventPort,
+} = await import("../../open-sse/handlers/chatCore/telemetryHelpers.ts");
 const core = await import("../../src/lib/db/core.ts");
 
 const originalFetch = globalThis.fetch;
 const originalLiveWsPort = process.env.LIVE_WS_PORT;
+const originalLiveWsEnabled = process.env.OMNIROUTE_ENABLE_LIVE_WS;
 
 test.afterEach(() => {
   globalThis.fetch = originalFetch;
@@ -24,18 +27,43 @@ test.afterEach(() => {
   } else {
     process.env.LIVE_WS_PORT = originalLiveWsPort;
   }
+  if (originalLiveWsEnabled === undefined) {
+    delete process.env.OMNIROUTE_ENABLE_LIVE_WS;
+  } else {
+    process.env.OMNIROUTE_ENABLE_LIVE_WS = originalLiveWsEnabled;
+  }
 });
 
 test.after(() => {
   globalThis.fetch = originalFetch;
   core.resetDbInstance();
-  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  try {
+    fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+  } catch {
+    // Windows can hold the SQLite temp directory briefly after handle teardown.
+  }
 });
 
-// ─── forwardDashboardEventToLiveWs ───────────────────────────────────────────
+// forwardDashboardEventToLiveWs
 
-test("forwardDashboardEventToLiveWs POSTs event+payload+timestamp as JSON to the default port", async () => {
+test("forwardDashboardEventToLiveWs skips when live WebSocket telemetry is not configured", async () => {
   delete process.env.LIVE_WS_PORT;
+  delete process.env.OMNIROUTE_ENABLE_LIVE_WS;
+  let fetchCalled = false;
+  globalThis.fetch = (async () => {
+    fetchCalled = true;
+    return new Response("ok", { status: 200 });
+  }) as typeof fetch;
+
+  await forwardDashboardEventToLiveWs("my-event", { foo: "bar" });
+
+  assert.equal(resolveLiveWsEventPort(), null);
+  assert.equal(fetchCalled, false);
+});
+
+test("forwardDashboardEventToLiveWs POSTs event+payload+timestamp as JSON to the default port when explicitly enabled", async () => {
+  delete process.env.LIVE_WS_PORT;
+  process.env.OMNIROUTE_ENABLE_LIVE_WS = "true";
   let capturedUrl: string | undefined;
   let capturedInit: RequestInit | undefined;
   globalThis.fetch = (async (url: string, init: RequestInit) => {
@@ -48,7 +76,8 @@ test("forwardDashboardEventToLiveWs POSTs event+payload+timestamp as JSON to the
   await forwardDashboardEventToLiveWs("my-event", { foo: "bar" });
   const after = Date.now();
 
-  // Default port is 20129 when LIVE_WS_PORT is unset.
+  // The default port is only used when live telemetry is explicitly enabled.
+  assert.equal(resolveLiveWsEventPort(), "20129");
   assert.equal(capturedUrl, "http://127.0.0.1:20129/__omniroute_event");
   assert.equal(capturedInit?.method, "POST");
   assert.equal(
@@ -69,6 +98,7 @@ test("forwardDashboardEventToLiveWs POSTs event+payload+timestamp as JSON to the
 
 test("forwardDashboardEventToLiveWs honors LIVE_WS_PORT override", async () => {
   process.env.LIVE_WS_PORT = "31337";
+  delete process.env.OMNIROUTE_ENABLE_LIVE_WS;
   let capturedUrl: string | undefined;
   globalThis.fetch = (async (url: string) => {
     capturedUrl = url;
@@ -77,19 +107,21 @@ test("forwardDashboardEventToLiveWs honors LIVE_WS_PORT override", async () => {
 
   await forwardDashboardEventToLiveWs("e", null);
 
+  assert.equal(resolveLiveWsEventPort(), "31337");
   assert.equal(capturedUrl, "http://127.0.0.1:31337/__omniroute_event");
 });
 
 test("forwardDashboardEventToLiveWs swallows fetch rejection and still resolves", async () => {
+  process.env.LIVE_WS_PORT = "31337";
   globalThis.fetch = (async () => {
     throw new Error("sidecar down");
   }) as typeof fetch;
 
-  // Must not throw — best-effort sidecar bridge; the catch swallows.
+  // Must not throw - best-effort sidecar bridge; the catch swallows.
   await assert.doesNotReject(forwardDashboardEventToLiveWs("e", { a: 1 }));
 });
 
-// ─── maybeSyncClaudeExtraUsageState ──────────────────────────────────────────
+// maybeSyncClaudeExtraUsageState
 
 test("maybeSyncClaudeExtraUsageState returns early when connectionId is falsy (no fetch)", async () => {
   let fetchCalled = false;


### PR DESCRIPTION
Fixes #4604. Validation: node --import tsx/esm --test tests/unit/chatcore-telemetry-helpers.test.ts