### PR TITLE
fix(cli): align data dir env loading

### DIFF
--- a/bin/cli/data-dir.mjs
+++ b/bin/cli/data-dir.mjs
@@ -1,6 +1,6 @@
+import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import fs from "node:fs";
 
 const APP_NAME = "omniroute";
 
@@ -18,12 +18,13 @@ function safeHomeDir() {
   }
 }
 
-export function resolveDataDir() {
-  const configured = normalizeConfiguredPath(process.env.DATA_DIR);
-  if (configured) return configured;
+export function getLegacyDotDataDir(homeDir = safeHomeDir()) {
+  return path.join(homeDir, `.${APP_NAME}`);
+}
 
+export function getDefaultDataDir() {
   const homeDir = safeHomeDir();
-  const legacyDir = path.join(homeDir, `.${APP_NAME}`);
+  const legacyDir = getLegacyDotDataDir(homeDir);
 
   if (fs.existsSync(legacyDir)) {
     try {
@@ -31,7 +32,7 @@ export function resolveDataDir() {
         return legacyDir;
       }
     } catch {
-      // Ignore stat errors.
+      // Ignore stat errors and continue to the platform default.
     }
   }
 
@@ -44,6 +45,13 @@ export function resolveDataDir() {
   if (xdgConfigHome) return path.join(xdgConfigHome, APP_NAME);
 
   return legacyDir;
+}
+
+export function resolveDataDir() {
+  const configured = normalizeConfiguredPath(process.env.DATA_DIR);
+  if (configured) return configured;
+
+  return getDefaultDataDir();
 }
 
 export function resolveStoragePath(dataDir = resolveDataDir()) {

--- a/bin/omniroute.mjs
+++ b/bin/omniroute.mjs
@@ -13,10 +13,10 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { homedir, platform } from "node:os";
 import updateNotifier from "update-notifier";
 import { isNativeBinaryCompatible } from "../scripts/build/native-binary-compat.mjs";
 import { getNodeRuntimeSupport, getNodeRuntimeWarning } from "./nodeRuntimeSupport.mjs";
+import { getDefaultDataDir } from "./cli/data-dir.mjs";
 import { shouldProvisionStorageKey } from "./cli/utils/storageKeyProvision.mjs";
 
 // Register tsx so dynamic imports of .ts source files (referenced as .js per
@@ -41,26 +41,25 @@ if (process.argv.includes("--mcp")) {
 
 function loadEnvFile() {
   const envPaths = [];
+  const loadedEnvPaths = [];
+  const seenEnvPaths = new Set();
+  const addEnvPath = (envPath) => {
+    if (seenEnvPaths.has(envPath)) return;
+    seenEnvPaths.add(envPath);
+    envPaths.push(envPath);
+  };
 
   if (process.env.DATA_DIR) {
-    envPaths.push(join(process.env.DATA_DIR, ".env"));
+    addEnvPath(join(process.env.DATA_DIR, ".env"));
   }
 
-  const home = homedir();
-  if (home) {
-    if (platform() === "win32") {
-      const appData = process.env.APPDATA || join(home, "AppData", "Roaming");
-      envPaths.push(join(appData, "omniroute", ".env"));
-    } else {
-      envPaths.push(join(home, ".omniroute", ".env"));
-    }
-  }
+  addEnvPath(join(getDefaultDataDir(), ".env"));
 
-  envPaths.push(join(process.cwd(), ".env"));
+  addEnvPath(join(process.cwd(), ".env"));
   // Skip the repo-checkout .env when explicitly requested (used by isolation tests
   // that need a deterministic environment without the development repo's defaults).
   if (process.env.OMNIROUTE_CLI_SKIP_REPO_ENV !== "1") {
-    envPaths.push(join(ROOT, ".env"));
+    addEnvPath(join(ROOT, ".env"));
   }
 
   for (const envPath of envPaths) {
@@ -79,11 +78,15 @@ function loadEnvFile() {
             }
           }
         }
-        console.log(`  \x1b[2m📋 Loaded env from ${envPath}\x1b[0m`);
+        loadedEnvPaths.push(envPath);
       }
     } catch {
       // Ignore errors reading env files.
     }
+  }
+
+  for (const envPath of loadedEnvPaths) {
+    console.log(`  \x1b[2m📋 Loaded env from ${envPath}\x1b[0m`);
   }
 }
 

--- a/tests/unit/cli-data-dir-env-loading.test.ts
+++ b/tests/unit/cli-data-dir-env-loading.test.ts
@@ -1,0 +1,157 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const BIN = path.join(ROOT, "bin", "omniroute.mjs");
+const DATA_DIR_MODULE = path.join(ROOT, "bin", "cli", "data-dir.mjs");
+
+async function withEnv<T>(
+  updates: Record<string, string | undefined>,
+  fn: () => Promise<T>
+): Promise<T> {
+  const original = new Map<string, string | undefined>();
+  for (const key of Object.keys(updates)) {
+    original.set(key, process.env[key]);
+    if (updates[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = updates[key];
+    }
+  }
+
+  try {
+    return await fn();
+  } finally {
+    for (const [key, value] of original) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+function readCliEnvShow(env: NodeJS.ProcessEnv, cwd: string): Record<string, string> {
+  const result = spawnSync("node", [BIN, "env", "show", "--json"], {
+    cwd,
+    env,
+    encoding: "utf-8",
+    timeout: 60_000,
+  });
+
+  assert.equal(
+    result.status,
+    0,
+    `omniroute env show failed\nstdout=${result.stdout}\nstderr=${result.stderr}`
+  );
+
+  const stdout = result.stdout ?? "";
+  const jsonStart = stdout.indexOf("{");
+  assert.ok(jsonStart >= 0, `expected JSON in stdout: ${stdout}`);
+  const parsed = JSON.parse(stdout.slice(jsonStart)) as { current: Record<string, string> };
+  return parsed.current;
+}
+
+test("CLI data-dir resolver preserves an existing legacy ~/.omniroute before XDG/app data", async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-cli-data-dir-"));
+  const home = path.join(tmp, "home");
+  const legacyDir = path.join(home, ".omniroute");
+  const appData = path.join(tmp, "appdata");
+  const xdgConfigHome = path.join(tmp, "xdg");
+
+  try {
+    fs.mkdirSync(legacyDir, { recursive: true });
+
+    await withEnv(
+      {
+        DATA_DIR: undefined,
+        HOME: home,
+        USERPROFILE: home,
+        APPDATA: appData,
+        XDG_CONFIG_HOME: xdgConfigHome,
+      },
+      async () => {
+        const { resolveDataDir: cliResolveDataDir } = await import(
+          `${pathToFileURL(DATA_DIR_MODULE).href}?t=${Date.now()}`
+        );
+        const { resolveDataDir: runtimeResolveDataDir } = await import(
+          `../../src/lib/dataPaths.ts?t=${Date.now()}`
+        );
+
+        assert.equal(cliResolveDataDir(), legacyDir);
+        assert.equal(cliResolveDataDir(), runtimeResolveDataDir());
+      }
+    );
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("CLI startup loads later non-conflicting .env files without overriding earlier values", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-cli-env-layers-"));
+  const home = path.join(tmp, "home");
+  const dataDir = path.join(tmp, "data");
+  const cwd = path.join(tmp, "cwd");
+  const appDataDir =
+    process.platform === "win32"
+      ? path.join(tmp, "appdata", "omniroute")
+      : path.join(home, ".omniroute");
+
+  try {
+    fs.mkdirSync(dataDir, { recursive: true });
+    fs.mkdirSync(appDataDir, { recursive: true });
+    fs.mkdirSync(cwd, { recursive: true });
+
+    fs.writeFileSync(
+      path.join(dataDir, ".env"),
+      "OMNIROUTE_BASE_URL=https://data.example/v1\n",
+      "utf-8"
+    );
+    fs.writeFileSync(
+      path.join(appDataDir, ".env"),
+      ["OMNIROUTE_BASE_URL=https://appdata.example/v1", "OMNIROUTE_HTTP_TIMEOUT_MS=1234", ""].join(
+        "\n"
+      ),
+      "utf-8"
+    );
+    fs.writeFileSync(
+      path.join(cwd, ".env"),
+      ["OMNIROUTE_BASE_URL=https://cwd.example/v1", "PORT=34567", ""].join("\n"),
+      "utf-8"
+    );
+
+    const cleanEnv = { ...process.env };
+    for (const key of [
+      "OMNIROUTE_BASE_URL",
+      "OMNIROUTE_HTTP_TIMEOUT_MS",
+      "PORT",
+      "STORAGE_ENCRYPTION_KEY",
+    ]) {
+      delete cleanEnv[key];
+    }
+
+    const env = {
+      ...cleanEnv,
+      DATA_DIR: dataDir,
+      HOME: home,
+      USERPROFILE: home,
+      APPDATA: path.join(tmp, "appdata"),
+      CI: "1",
+      OMNIROUTE_CLI_SKIP_REPO_ENV: "1",
+      OMNIROUTE_NO_UPDATE_NOTIFIER: "1",
+    };
+
+    const current = readCliEnvShow(env, cwd);
+    assert.equal(current.OMNIROUTE_BASE_URL, "https://data.example/v1");
+    assert.equal(current.OMNIROUTE_HTTP_TIMEOUT_MS, "1234");
+    assert.equal(current.PORT, "34567");
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Fixes #4597. Validation: node --import tsx/esm --test tests/unit/cli-data-dir-env-loading.test.ts, node --import tsx/esm --test tests/unit/cli-data-dir-env-loading.test.ts tests/unit/cli-storage-key-bootstrap.test.ts, eslint on the test file.