### PR TITLE
feat(compression): Kiro/CodeWhisperer tool-result compression engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### ✨ New Features
 
+- **feat(compression): Kiro / AWS CodeWhisperer tool-result compression** — every compression engine (RTK, lite, aggressive…) can now rewrite tool-result text inside Kiro's `conversationState.{history,currentMessage}.userInputMessage.userInputMessageContext.toolResults[]` envelope; error tool results (`status === "error"`) are preserved byte-for-byte. (thanks @zanuartri)
 - **feat(combo): nested combo-ref execution (`nestedComboMode: execute`)** — selection strategies can now treat a combo-reference step as a black box, executing the referenced combo as a single unit instead of flattening its targets. ([#4537](https://github.com/diegosouzapw/OmniRoute/pull/4537) — thanks @adivekar-utexas)
 - **feat(combo): sticky weighted selection limit with exhaustion-aware renormalization** — weighted strategies gain a configurable sticky-selection limit; once a target is exhausted, remaining weights renormalize so traffic is redistributed correctly. ([#4489](https://github.com/diegosouzapw/OmniRoute/pull/4489) — thanks @adivekar-utexas)
 - **feat(combos): provider-wildcard expansion in combo steps** — a combo step may now reference a whole provider via wildcard and have it expand to that provider's models at resolution time. ([#4545](https://github.com/diegosouzapw/OmniRoute/pull/4545) — thanks @Rahulsharma0810)

--- a/open-sse/services/compression/bodyAdapter.ts
+++ b/open-sse/services/compression/bodyAdapter.ts
@@ -2,6 +2,7 @@ type MessageLike = {
   role?: unknown;
   content?: unknown;
   [COMPRESSION_INPUT_INDEX]?: number;
+  [KIRO_TOOL_RESULT_PATH]?: KiroToolResultPath;
   [key: string]: unknown;
 };
 
@@ -15,6 +16,23 @@ type ResponsesItem = {
 
 const RESPONSES_MESSAGE_TYPES = new Set(["message", "function_call_output"]);
 const COMPRESSION_INPUT_INDEX = Symbol("compressionInputIndex");
+
+// Kiro envelope path back to the original tool-result text inside
+// `conversationState.{history|currentMessage}[].userInputMessage.userInputMessageContext.toolResults[N].content[M].text`.
+// Stored on the synthesized role:"tool" message so we can restore the rewritten text
+// to the exact source slot after any compression engine runs.
+//
+// This lifts Kiro support from RTK-only (upstream decolua/9router#1194) to the shared
+// adapter layer, so every compression engine (RTK, lite, aggressive…) automatically
+// covers Kiro/CodeWhisperer payloads, not just RTK.
+const KIRO_TOOL_RESULT_PATH = Symbol("kiroToolResultPath");
+
+type KiroToolResultPath = {
+  scope: "currentMessage" | "history";
+  historyIndex: number; // ignored when scope === "currentMessage"
+  toolResultIndex: number;
+  contentIndex: number;
+};
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
@@ -97,6 +115,14 @@ export function adaptBodyForCompression(body: Record<string, unknown>): Compress
     };
   }
 
+  // Kiro / AWS CodeWhisperer envelope: tool results live deep inside
+  // conversationState.{currentMessage|history[]}.userInputMessage.userInputMessageContext.toolResults.
+  // Flatten the tool-result text into synthesized role:"tool" messages so every engine
+  // can compress them, then restore the rewritten text back into the exact source slot.
+  if (isRecord(body.conversationState)) {
+    return adaptKiroBodyForCompression(body);
+  }
+
   if (!Array.isArray(body.input) && typeof body.input !== "string") {
     return {
       body,
@@ -155,6 +181,164 @@ export function adaptBodyForCompression(body: Record<string, unknown>): Compress
         return { ...rest, input: isRecord(first) ? (first.content ?? body.input) : body.input };
       }
       return { ...rest, input: nextInput };
+    },
+  };
+}
+
+/**
+ * Flatten a Kiro / AWS CodeWhisperer body so compression engines can rewrite the
+ * tool-result text, then restore the rewritten text back into the original envelope
+ * shape. Mirrors the OpenAI tool-role contract:
+ *
+ * - Each surviving tool-result content block becomes one role:"tool" message whose
+ *   `content` is its inner text (engines see a familiar shape).
+ * - Error tool results (`status === "error"`) are intentionally left out of the
+ *   synthesized messages so engines cannot rewrite them — preserves diagnostics
+ *   byte-for-byte (matches upstream decolua/9router#1194 behavior).
+ * - Non-string text parts are skipped.
+ * - On restore, only string `content` (or an array whose first text part is a string)
+ *   is written back to `toolResults[N].content[M].text`.
+ */
+function adaptKiroBodyForCompression(body: Record<string, unknown>): CompressionBodyAdapter {
+  const state = body.conversationState as Record<string, unknown>;
+  const history = Array.isArray(state.history) ? (state.history as Array<unknown>) : [];
+  const currentMessage = isRecord(state.currentMessage) ? state.currentMessage : null;
+
+  const messages: MessageLike[] = [];
+
+  const collectFrom = (
+    container: Record<string, unknown>,
+    scope: "currentMessage" | "history",
+    historyIndex: number
+  ): void => {
+    const uim = container.userInputMessage;
+    if (!isRecord(uim)) return;
+    const ctx = uim.userInputMessageContext;
+    if (!isRecord(ctx)) return;
+    const toolResults = ctx.toolResults;
+    if (!Array.isArray(toolResults)) return;
+    toolResults.forEach((tr, trIdx) => {
+      if (!isRecord(tr)) return;
+      if (tr.status === "error") return; // preserve error traces — never compress
+      const content = tr.content;
+      if (!Array.isArray(content)) return;
+      content.forEach((part, partIdx) => {
+        if (!isRecord(part)) return;
+        if (typeof part.text !== "string" || part.text.length === 0) return;
+        messages.push({
+          role: "tool",
+          content: part.text,
+          [KIRO_TOOL_RESULT_PATH]: {
+            scope,
+            historyIndex,
+            toolResultIndex: trIdx,
+            contentIndex: partIdx,
+          },
+        });
+      });
+    });
+  };
+
+  history.forEach((entry, idx) => {
+    if (!isRecord(entry)) return;
+    collectFrom(entry, "history", idx);
+  });
+  if (currentMessage) collectFrom(currentMessage, "currentMessage", -1);
+
+  if (messages.length === 0) {
+    return {
+      body,
+      adapted: false,
+      restore: (compressedBody) => compressedBody,
+    };
+  }
+
+  return {
+    body: { ...body, messages },
+    adapted: true,
+    restore(compressedBody) {
+      // Build a path → rewritten text map from the synthesized tool messages.
+      const rewrites = new Map<string, string>();
+      if (Array.isArray(compressedBody.messages)) {
+        for (const message of compressedBody.messages as MessageLike[]) {
+          const path = message[KIRO_TOOL_RESULT_PATH];
+          if (!path) continue;
+          let nextText: string | null = null;
+          if (typeof message.content === "string") {
+            nextText = message.content;
+          } else if (Array.isArray(message.content)) {
+            const firstText = message.content.find(
+              (part): part is { text: string } =>
+                isRecord(part) && typeof (part as { text?: unknown }).text === "string"
+            );
+            if (firstText) nextText = firstText.text;
+          }
+          if (nextText === null) continue;
+          rewrites.set(kiroPathKey(path), nextText);
+        }
+      }
+
+      const nextState: Record<string, unknown> = { ...state };
+      // Rebuild history with any rewritten tool-result text.
+      if (history.length > 0) {
+        nextState.history = history.map((entry, idx) => {
+          if (!isRecord(entry)) return entry;
+          return rewriteKiroEntry(entry, "history", idx, rewrites);
+        });
+      }
+      if (currentMessage) {
+        nextState.currentMessage = rewriteKiroEntry(currentMessage, "currentMessage", -1, rewrites);
+      }
+
+      const rest = { ...compressedBody };
+      delete rest.messages;
+      return { ...rest, conversationState: nextState };
+    },
+  };
+}
+
+function kiroPathKey(path: KiroToolResultPath): string {
+  return `${path.scope}|${path.historyIndex}|${path.toolResultIndex}|${path.contentIndex}`;
+}
+
+function rewriteKiroEntry(
+  entry: Record<string, unknown>,
+  scope: "currentMessage" | "history",
+  historyIndex: number,
+  rewrites: Map<string, string>
+): Record<string, unknown> {
+  const uim = entry.userInputMessage;
+  if (!isRecord(uim)) return entry;
+  const ctx = uim.userInputMessageContext;
+  if (!isRecord(ctx)) return entry;
+  const toolResults = ctx.toolResults;
+  if (!Array.isArray(toolResults)) return entry;
+
+  let entryChanged = false;
+  const nextToolResults = toolResults.map((tr, trIdx) => {
+    if (!isRecord(tr)) return tr;
+    const content = tr.content;
+    if (!Array.isArray(content)) return tr;
+    let trChanged = false;
+    const nextContent = content.map((part, partIdx) => {
+      if (!isRecord(part) || typeof part.text !== "string") return part;
+      const key = kiroPathKey({ scope, historyIndex, toolResultIndex: trIdx, contentIndex: partIdx });
+      const rewritten = rewrites.get(key);
+      if (rewritten === undefined || rewritten === part.text) return part;
+      trChanged = true;
+      return { ...part, text: rewritten };
+    });
+    if (!trChanged) return tr;
+    entryChanged = true;
+    return { ...tr, content: nextContent };
+  });
+
+  if (!entryChanged) return entry;
+  return {
+    ...entry,
+    userInputMessage: {
+      ...uim,
+      userInputMessageContext: { ...ctx, toolResults: nextToolResults },
     },
   };
 }

--- a/tests/unit/kiro-toolresult-compression.test.ts
+++ b/tests/unit/kiro-toolresult-compression.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Kiro (AWS CodeWhisperer) tool-result compression — ported from upstream
+ * decolua/9router#1194 (zanuartri).
+ *
+ * The upstream PR added Kiro-format support directly inside RTK. OmniRoute
+ * lifts that capability to `bodyAdapter`, so the Kiro envelope
+ * (`conversationState.history[].userInputMessage.userInputMessageContext.toolResults`)
+ * flattens to OpenAI-shape `role:"tool"` messages — every compression engine
+ * (RTK, lite, aggressive, etc.) automatically benefits, not just RTK.
+ *
+ * Error tool results (status === "error") are skipped to preserve diagnostics
+ * (matches upstream behavior).
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { applyRtkCompression } from "../../open-sse/services/compression/engines/rtk/index.ts";
+import { adaptBodyForCompression } from "../../open-sse/services/compression/bodyAdapter.ts";
+
+function buildKiroBodyWithBuildOutput(): Record<string, unknown> {
+  const noisyNpmOutput = [
+    "npm warn deprecated har-validator@5.1.5: this library is no longer supported",
+    "npm warn deprecated uuid@3.4.0: uuid@10 and below is no longer supported",
+    "npm warn deprecated request@2.88.2: request has been deprecated",
+    "npm warn deprecated inflight@1.0.6: This module is not supported",
+    "npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported",
+    "npm warn deprecated rimraf@2.7.1: Rimraf versions prior to v4 are no longer supported",
+    "",
+    "added 47 packages, and audited 48 packages in 13s",
+    "",
+    "3 packages are looking for funding",
+    "  run `npm fund` for details",
+    "",
+    "4 vulnerabilities (2 moderate, 2 critical)",
+    "",
+    "Some issues need review, and may require choosing",
+    "a different dependency.",
+    "",
+    "Run `npm audit` for details.",
+  ].join("\n");
+
+  return {
+    conversationState: {
+      chatTriggerType: "MANUAL",
+      conversationId: "test-port-1194",
+      currentMessage: {
+        userInputMessage: {
+          content: "Install express",
+          modelId: "claude-sonnet-4.5",
+          userInputMessageContext: {
+            toolResults: [
+              {
+                toolUseId: "tool_1",
+                status: "success",
+                content: [{ text: noisyNpmOutput }],
+              },
+            ],
+          },
+        },
+      },
+      history: [],
+    },
+  };
+}
+
+describe("Kiro tool-result compression (port of decolua/9router#1194)", () => {
+  it("adapts a Kiro conversationState body to messages with the tool-result text exposed", () => {
+    const body = buildKiroBodyWithBuildOutput();
+    const adapter = adaptBodyForCompression(body);
+    const messages = (adapter.body.messages ?? []) as Array<{
+      role?: string;
+      content?: unknown;
+    }>;
+    assert.ok(adapter.adapted, "Kiro body must be flagged as adapted");
+    assert.ok(
+      messages.some((m) => m.role === "tool" && typeof m.content === "string"),
+      "adapter must surface tool-result text as a role:tool message"
+    );
+  });
+
+  it("compresses tool-result text inside Kiro currentMessage and writes the rewritten text back", () => {
+    const body = buildKiroBodyWithBuildOutput();
+    const before = (
+      (body.conversationState as Record<string, unknown>).currentMessage as Record<string, unknown>
+    ).userInputMessage as {
+      userInputMessageContext: { toolResults: Array<{ content: Array<{ text: string }> }> };
+    };
+    const originalLen = before.userInputMessageContext.toolResults[0].content[0].text.length;
+
+    const result = applyRtkCompression(body);
+
+    assert.equal(result.compressed, true, "RTK must compress noisy build output");
+    assert.ok(result.stats, "stats must be returned");
+    assert.ok(
+      result.stats!.compressedTokens < result.stats!.originalTokens,
+      "compressedTokens must drop"
+    );
+
+    const restored = (
+      (result.body as Record<string, unknown>).conversationState as Record<string, unknown>
+    ).currentMessage as {
+      userInputMessage: {
+        userInputMessageContext: { toolResults: Array<{ content: Array<{ text: string }> }> };
+      };
+    };
+    const afterLen = restored.userInputMessage.userInputMessageContext.toolResults[0].content[0]
+      .text.length;
+    assert.ok(
+      afterLen < originalLen,
+      `Kiro tool-result text must shrink (before=${originalLen}, after=${afterLen})`
+    );
+  });
+
+  it("compresses tool-result text inside Kiro history[] entries", () => {
+    // Reuse the noisy npm-install fixture (already proven to trigger a build-output
+    // filter in the currentMessage test) so this test exercises the history[] path
+    // without depending on a separate filter (cargo, etc.) being registered.
+    const compilingLines: string[] = [
+      "npm warn deprecated har-validator@5.1.5: this library is no longer supported",
+      "npm warn deprecated uuid@3.4.0: uuid@10 and below is no longer supported",
+      "npm warn deprecated request@2.88.2: request has been deprecated",
+      "npm warn deprecated inflight@1.0.6: This module is not supported",
+      "npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported",
+      "npm warn deprecated rimraf@2.7.1: Rimraf versions prior to v4 are no longer supported",
+      "",
+      "added 47 packages, and audited 48 packages in 13s",
+      "",
+      "3 packages are looking for funding",
+      "  run `npm fund` for details",
+      "",
+      "4 vulnerabilities (2 moderate, 2 critical)",
+      "",
+      "Run `npm audit` for details.",
+    ];
+
+    const body: Record<string, unknown> = {
+      conversationState: {
+        chatTriggerType: "MANUAL",
+        conversationId: "test-history",
+        currentMessage: {
+          userInputMessage: {
+            content: "What happened?",
+            modelId: "claude-sonnet-4.5",
+          },
+        },
+        history: [
+          {
+            userInputMessage: {
+              content: "Run npm install",
+              modelId: "claude-sonnet-4.5",
+              userInputMessageContext: {
+                toolResults: [
+                  {
+                    toolUseId: "tool_2",
+                    status: "success",
+                    content: [{ text: compilingLines.join("\n") }],
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      },
+    };
+
+    const originalLen = compilingLines.join("\n").length;
+    const result = applyRtkCompression(body);
+
+    assert.equal(result.compressed, true, "history tool result must compress");
+    const state = (result.body as Record<string, unknown>).conversationState as {
+      history: Array<{
+        userInputMessage: {
+          userInputMessageContext: { toolResults: Array<{ content: Array<{ text: string }> }> };
+        };
+      }>;
+    };
+    const afterLen = state.history[0].userInputMessage.userInputMessageContext.toolResults[0]
+      .content[0].text.length;
+    assert.ok(
+      afterLen < originalLen,
+      `history tool-result text must shrink (before=${originalLen}, after=${afterLen})`
+    );
+  });
+
+  it("preserves error tool results (status === 'error') without rewriting their text", () => {
+    const errorText =
+      "npm error code E404\nnpm error 404 Not Found - GET https://registry.npmjs.org/invalid-package";
+    const body: Record<string, unknown> = {
+      conversationState: {
+        chatTriggerType: "MANUAL",
+        conversationId: "test-error",
+        currentMessage: {
+          userInputMessage: {
+            content: "Install invalid-package",
+            modelId: "claude-sonnet-4.5",
+            userInputMessageContext: {
+              toolResults: [
+                {
+                  toolUseId: "tool_err",
+                  status: "error",
+                  content: [{ text: errorText }],
+                },
+              ],
+            },
+          },
+        },
+        history: [],
+      },
+    };
+
+    const result = applyRtkCompression(body);
+    const after = (
+      (result.body as Record<string, unknown>).conversationState as {
+        currentMessage: {
+          userInputMessage: {
+            userInputMessageContext: { toolResults: Array<{ content: Array<{ text: string }> }> };
+          };
+        };
+      }
+    ).currentMessage.userInputMessage.userInputMessageContext.toolResults[0].content[0].text;
+    assert.equal(after, errorText, "error tool-result text must be preserved byte-for-byte");
+  });
+
+  it("handles a malformed Kiro body without crashing", () => {
+    const malformed: Array<Record<string, unknown>> = [
+      { conversationState: null },
+      { conversationState: {} },
+      { conversationState: { history: null, currentMessage: null } },
+      { conversationState: { history: "not-an-array" } },
+    ];
+    for (const body of malformed) {
+      const result = applyRtkCompression(body);
+      assert.ok(result, "must not throw on malformed Kiro body");
+      // No tool-result text → engine reports no compression
+      assert.equal(result.compressed, false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Adds tool-result compression for Kiro's `conversationState.{history,currentMessage}.userInputMessage.userInputMessageContext.toolResults[]` envelope across every compression engine (RTK, lite, aggressive, …).
- Error tool results (`status === "error"`) are preserved byte-for-byte to avoid shifting retry semantics; non-error results flow through the active engine's policy.

## Attribution

Thanks to [@zanuartri](https://github.com/zanuartri) for the original implementation.

## Changes

- \`open-sse/services/compression/bodyAdapter.ts\` — Kiro tool-result walker (+184 LOC).
- \`tests/unit/kiro-toolresult-compression.test.ts\` — TDD (5 tests, 5/5 GREEN).
- \`CHANGELOG.md\` — \`[3.8.33] → ✨ New Features\` bullet.

## Test plan

- [x] \`node --import tsx/esm --test tests/unit/kiro-toolresult-compression.test.ts\` (5/5 pass)
- [x] \`npm run typecheck:core\` (clean)
- [ ] CI: \`npm run check\` + \`test:vitest\`