### PR TITLE
fix(cli): authenticate `omniroute logs` and honor active context

### DIFF
--- a/bin/cli/commands/logs.mjs
+++ b/bin/cli/commands/logs.mjs
@@ -1,5 +1,6 @@
 import { writeFileSync, appendFileSync, existsSync, unlinkSync } from "node:fs";
 import { t } from "../i18n.mjs";
+import { getBaseUrl, buildHeaders } from "../api.mjs";
 
 export function registerLogs(program) {
   program
@@ -9,7 +10,7 @@ export function registerLogs(program) {
     .option("--filter <level>", t("logs.filter"))
     .option("--lines <n>", t("logs.lines"), "100")
     .option("--timeout <ms>", t("logs.timeout"), "30000")
-    .option("--base-url <url>", t("logs.baseUrl"), "http://localhost:20128")
+    .option("--base-url <url>", t("logs.baseUrl"))
     .option("--request-id <id>", t("logs.requestId"))
     .option("--api-key <key>", t("logs.apiKey"))
     .option("--combo <name>", t("logs.combo"))
@@ -19,7 +20,14 @@ export function registerLogs(program) {
     .option("--export <path>", t("logs.export"))
     .action(async (opts, cmd) => {
       const globalOpts = cmd.optsWithGlobals();
-      const exitCode = await runLogsCommand({ ...opts, output: globalOpts.output });
+      // `--context` and `--output` are global options, so forward them explicitly:
+      // runLogsCommand resolves the base URL via getBaseUrl({ context }), and without
+      // this a user's `--context` would be silently dropped.
+      const exitCode = await runLogsCommand({
+        ...opts,
+        context: globalOpts.context,
+        output: globalOpts.output,
+      });
       if (exitCode !== 0) process.exit(exitCode);
     });
 }
@@ -67,7 +75,10 @@ function buildLogFilter(opts) {
 }
 
 export async function runLogsCommand(opts = {}) {
-  const baseUrl = opts.baseUrl || opts["base-url"] || "http://localhost:20128";
+  // Resolve the base URL the same way every other CLI command does: an explicit
+  // --base-url wins, otherwise fall back to the active context / env / localhost.
+  // Without this, `logs` always hit localhost and ignored a connected remote.
+  const baseUrl = opts.baseUrl || opts["base-url"] || getBaseUrl({ context: opts.context });
   const follow = opts.follow ?? false;
   const timeout = parseInt(String(opts.timeout || "30000"), 10);
   const isJson = opts.output === "json";
@@ -82,8 +93,21 @@ export async function runLogsCommand(opts = {}) {
   // Pass only level filters to the stream (server-side); other filters are client-side
   const levelFilters = opts.filter ? opts.filter.split(",").map((f) => f.trim()) : [];
 
+  // Authenticate the log stream. The /api/cli-tools/logs endpoint requires the
+  // management token; build the same headers (scoped context token + CLI token)
+  // that apiFetch uses, so `logs` works against authenticated/remote servers.
+  // NOTE: --api-key here is a client-side log *filter* (see buildLogFilter), not
+  // an auth credential, so it is deliberately not forwarded to buildHeaders.
+  const headers = await buildHeaders({ baseUrl, context: opts.context });
+
   const { createLogStream } = await import("../../../src/lib/cli-helper/log-streamer.js");
-  const { stream, stop } = createLogStream({ baseUrl, filters: levelFilters, follow, timeout });
+  const { stream, stop } = createLogStream({
+    baseUrl,
+    filters: levelFilters,
+    follow,
+    timeout,
+    headers,
+  });
 
   const reader = stream.getReader();
   const decoder = new TextDecoder();

--- a/src/lib/cli-helper/log-streamer.ts
+++ b/src/lib/cli-helper/log-streamer.ts
@@ -1,11 +1,9 @@
-import os from "node:os";
-import path from "node:path";
-
 export interface LogStreamOptions {
   baseUrl?: string;
   filters?: string[];
   follow?: boolean;
   timeout?: number;
+  headers?: HeadersInit;
 }
 
 export interface LogStream {
@@ -18,6 +16,7 @@ export function createLogStream(options: LogStreamOptions = {}): LogStream {
   const filters = options.filters || [];
   const follow = options.follow ?? false;
   const timeout = options.timeout || 30000;
+  const headers = options.headers;
 
   const controller = new AbortController();
   const { signal } = controller;
@@ -35,7 +34,7 @@ export function createLogStream(options: LogStreamOptions = {}): LogStream {
       }, timeout);
 
       try {
-        const response = await fetch(url, { signal });
+        const response = await fetch(url, { signal, headers });
 
         if (!response.ok) {
           controller.error(new Error(`HTTP ${response.status}: ${response.statusText}`));

--- a/tests/unit/cli-logs-route.test.ts
+++ b/tests/unit/cli-logs-route.test.ts
@@ -35,9 +35,7 @@ const lines = [
 ];
 fs.writeFileSync(logPath, lines.join("\n") + "\n", "utf-8");
 
-const { GET } = await import(
-  "../../src/app/api/cli-tools/logs/route.ts"
-);
+const { GET } = await import("../../src/app/api/cli-tools/logs/route.ts");
 
 test.before(async () => {
   await updateSettings({ requireLogin: false });
@@ -148,7 +146,14 @@ test("log-streamer.ts calls /api/cli-tools/logs (correct URL, not the missing ro
   globalThis.fetch = (async (url: string) => {
     captured.push(typeof url === "string" ? url : String(url));
     // Return a mock Response with a body so the stream doesn't error immediately
-    return new Response(new ReadableStream({ start(c) { c.close(); } }), { status: 200 });
+    return new Response(
+      new ReadableStream({
+        start(c) {
+          c.close();
+        },
+      }),
+      { status: 200 }
+    );
   }) as typeof fetch;
 
   try {
@@ -169,5 +174,43 @@ test("log-streamer.ts calls /api/cli-tools/logs (correct URL, not the missing ro
   assert.ok(
     !captured.some((u) => u.includes("/api/logs/console")),
     "log-streamer should not call /api/logs/console"
+  );
+});
+
+test("log-streamer forwards auth headers to fetch (regression: 401 against authed servers)", async () => {
+  const { createLogStream } = await import("../../src/lib/cli-helper/log-streamer.ts");
+  let capturedInit: RequestInit | undefined;
+  const origFetch = globalThis.fetch;
+
+  globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+    capturedInit = init;
+    return new Response(
+      new ReadableStream({
+        start(c) {
+          c.close();
+        },
+      }),
+      { status: 200 }
+    );
+  }) as typeof fetch;
+
+  try {
+    const { stream, stop } = createLogStream({
+      baseUrl: "http://localhost:20128",
+      headers: { authorization: "Bearer test-token" },
+    });
+    const reader = stream.getReader();
+    await reader.read().catch(() => {});
+    stop();
+  } finally {
+    globalThis.fetch = origFetch;
+  }
+
+  assert.ok(capturedInit, "fetch should receive an init object");
+  const headers = new Headers(capturedInit!.headers);
+  assert.equal(
+    headers.get("authorization"),
+    "Bearer test-token",
+    "createLogStream must forward the provided auth headers to fetch"
   );
 });


### PR DESCRIPTION
Fixes #4637

## Problem

`omniroute logs` always failed with `HTTP 401: Unauthorized` against any server requiring the management token (including remotes connected via `omniroute connect`). It was the only CLI command that did not authenticate, and it also ignored the active context's base URL.

## Root cause

1. **No auth header** — `src/lib/cli-helper/log-streamer.ts` hit the protected `/api/cli-tools/logs` endpoint with a raw `fetch(url, { signal })`. Every other command authenticates via `bin/cli/api.mjs` → `buildHeaders()` (scoped context token + CLI token); `logs` bypassed it → 401.
2. **Hardcoded base URL** — `bin/cli/commands/logs.mjs` defaulted `--base-url` to `http://localhost:20128`, so even with valid auth it queried localhost instead of the connected remote.

## Changes

- `logs.mjs`: resolve base URL via `getBaseUrl()` (explicit `--base-url` still wins), matching every other command's context/env/localhost fallback.
- `logs.mjs`: build auth headers via `buildHeaders()` and forward them through `createLogStream` to `fetch`.
  - `--api-key` on `logs` is a client-side log *filter*, not a credential, so it is deliberately **not** used for auth.
- `log-streamer.ts`: accept an optional `headers` option and pass it to `fetch`; drop unused `os`/`path` imports.

## Testing

- Adds a regression test asserting `createLogStream` forwards auth headers to `fetch`.
- `tests/unit/cli-logs-route.test.ts` — 7/7 pass.
- `npm run typecheck:core` — clean.
- Manually verified: with the fix, `omniroute logs` returns **200** and streams logs from a connected remote that previously returned 401.