### PR TITLE
fix(executors): robust deepseek-web tool-call parsing and agentic context retention

### DIFF
--- a/open-sse/executors/deepseek-web.ts
+++ b/open-sse/executors/deepseek-web.ts
@@ -1,10 +1,11 @@
 import { BaseExecutor, type ExecuteInput } from "./base.ts";
 import { solveDeepSeekPowAsync } from "../lib/deepseek-pow.ts";
+import { type OpenAIToolCall } from "../translator/webTools.ts";
 import {
-  serializeToolsToPrompt,
-  parseToolCallsFromText,
-  type OpenAIToolCall,
-} from "../translator/webTools.ts";
+  serializeDeepSeekToolPrompt,
+  parseDeepSeekToolCalls,
+  buildToolConversationPrompt,
+} from "../translator/deepseekWebTools.ts";
 import { sanitizeErrorMessage } from "../utils/error.ts";
 
 export const DEEPSEEK_WEB_BASE = "https://chat.deepseek.com";
@@ -196,170 +197,170 @@ function transformSSE(deepseekStream: ReadableStream, model: string): ReadableSt
 
   return new ReadableStream(
     {
-    async start(controller) {
-      const reader = deepseekStream.getReader();
-      let buffer = "";
+      async start(controller) {
+        const reader = deepseekStream.getReader();
+        let buffer = "";
 
-      const emit = (obj: object) => {
-        controller.enqueue(encoder.encode(`data: ${JSON.stringify(obj)}\n\n`));
-      };
+        const emit = (obj: object) => {
+          controller.enqueue(encoder.encode(`data: ${JSON.stringify(obj)}\n\n`));
+        };
 
-      const chunk = (delta: object, finish?: string) => {
-        emit({
-          id,
-          object: "chat.completion.chunk",
-          created,
-          model: streamModel,
-          choices: [{ index: 0, delta, finish_reason: finish ?? null }],
-        });
-      };
+        const chunk = (delta: object, finish?: string) => {
+          emit({
+            id,
+            object: "chat.completion.chunk",
+            created,
+            model: streamModel,
+            choices: [{ index: 0, delta, finish_reason: finish ?? null }],
+          });
+        };
 
-      const ensureRole = () => {
-        if (!emittedRole) {
-          emittedRole = true;
-          chunk({ role: "assistant", content: "" });
-        }
-      };
+        const ensureRole = () => {
+          if (!emittedRole) {
+            emittedRole = true;
+            chunk({ role: "assistant", content: "" });
+          }
+        };
 
-      const finishStream = () => {
-        const citations = appendSearchCitations(searchResults, streamModel);
-        if (citations) {
+        const finishStream = () => {
+          const citations = appendSearchCitations(searchResults, streamModel);
+          if (citations) {
+            ensureRole();
+            chunk({ content: `\n\n${citations}` });
+          }
           ensureRole();
-          chunk({ content: `\n\n${citations}` });
-        }
-        ensureRole();
-        chunk({}, "stop");
-        controller.enqueue(encoder.encode("data: [DONE]\n\n"));
-        controller.close();
-      };
+          chunk({}, "stop");
+          controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+          controller.close();
+        };
 
-      const sendByPath = (raw: string) => {
-        const text = formatStreamContent(raw, streamModel);
-        if (!text) return;
-        ensureRole();
-        let path = currentPath;
-        if (!path && thinkingModel) path = "thinking";
-        else if (!path && isSearchModel(streamModel)) path = "content";
-        if (path === "thinking") {
-          chunk({ reasoning_content: text });
-        } else {
-          chunk({ content: text });
-        }
-      };
+        const sendByPath = (raw: string) => {
+          const text = formatStreamContent(raw, streamModel);
+          if (!text) return;
+          ensureRole();
+          let path = currentPath;
+          if (!path && thinkingModel) path = "thinking";
+          else if (!path && isSearchModel(streamModel)) path = "content";
+          if (path === "thinking") {
+            chunk({ reasoning_content: text });
+          } else {
+            chunk({ content: text });
+          }
+        };
 
-      const applyFragmentType = (frag: any) => {
-        const type = String(frag?.type || "").toUpperCase();
-        if (type === "THINK") currentPath = "thinking";
-        else if (type === "ANSWER" || type === "RESPONSE") currentPath = "content";
-      };
-
-      const handleFragment = (frag: any, setPathFromType = false) => {
-        if (setPathFromType) applyFragmentType(frag);
-        if (typeof frag?.content !== "string" || frag.content.length === 0) return;
-        if (!setPathFromType) {
+        const applyFragmentType = (frag: any) => {
           const type = String(frag?.type || "").toUpperCase();
           if (type === "THINK") currentPath = "thinking";
           else if (type === "ANSWER" || type === "RESPONSE") currentPath = "content";
-        }
-        sendByPath(frag.content);
-      };
+        };
 
-      try {
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
+        const handleFragment = (frag: any, setPathFromType = false) => {
+          if (setPathFromType) applyFragmentType(frag);
+          if (typeof frag?.content !== "string" || frag.content.length === 0) return;
+          if (!setPathFromType) {
+            const type = String(frag?.type || "").toUpperCase();
+            if (type === "THINK") currentPath = "thinking";
+            else if (type === "ANSWER" || type === "RESPONSE") currentPath = "content";
+          }
+          sendByPath(frag.content);
+        };
 
-          buffer += decoder.decode(value, { stream: true });
-          const lines = buffer.split("\n");
-          buffer = lines.pop() || "";
+        try {
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
 
-          for (const line of lines) {
-            if (!line.startsWith("data: ") && !line.startsWith("data:")) continue;
-            const payload = line.replace(/^data:\s*/, "").trim();
+            buffer += decoder.decode(value, { stream: true });
+            const lines = buffer.split("\n");
+            buffer = lines.pop() || "";
 
-            if (payload === "[DONE]") {
-              finishStream();
-              return;
-            }
+            for (const line of lines) {
+              if (!line.startsWith("data: ") && !line.startsWith("data:")) continue;
+              const payload = line.replace(/^data:\s*/, "").trim();
 
-            let data: Record<string, unknown>;
-            try {
-              data = JSON.parse(payload);
-            } catch {
-              continue;
-            }
-
-            const p = (data as any)?.p;
-            const o = (data as any)?.o;
-            const v = (data as any)?.v;
-
-            if (v && typeof v === "object" && v.response) {
-              if (v.response.thinking_enabled === true) currentPath = "thinking";
-              else if (v.response.thinking_enabled === false) currentPath = "content";
-              const fragments = v.response.fragments;
-              if (Array.isArray(fragments)) {
-                for (const frag of fragments) handleFragment(frag, false);
+              if (payload === "[DONE]") {
+                finishStream();
+                return;
               }
-            }
 
-            if (p === "response/fragments") {
-              if (Array.isArray(v)) {
-                for (const frag of v) handleFragment(frag, true);
-              } else if (v && typeof v === "object") {
-                handleFragment(v, true);
+              let data: Record<string, unknown>;
+              try {
+                data = JSON.parse(payload);
+              } catch {
+                continue;
               }
-            }
 
-            if (p === "response" && Array.isArray(v)) {
-              for (const entry of v) {
-                if (entry?.p === "response" && entry?.v?.thinking_enabled === true) {
-                  currentPath = "thinking";
+              const p = (data as any)?.p;
+              const o = (data as any)?.o;
+              const v = (data as any)?.v;
+
+              if (v && typeof v === "object" && v.response) {
+                if (v.response.thinking_enabled === true) currentPath = "thinking";
+                else if (v.response.thinking_enabled === false) currentPath = "content";
+                const fragments = v.response.fragments;
+                if (Array.isArray(fragments)) {
+                  for (const frag of fragments) handleFragment(frag, false);
                 }
               }
-            }
 
-            if (p === "response/search_status") continue;
+              if (p === "response/fragments") {
+                if (Array.isArray(v)) {
+                  for (const frag of v) handleFragment(frag, true);
+                } else if (v && typeof v === "object") {
+                  handleFragment(v, true);
+                }
+              }
 
-            if (p === "response/search_results" && Array.isArray(v)) {
-              if (o !== "BATCH") {
-                searchResults.length = 0;
-                searchResults.push(...v);
-              } else {
-                for (const op of v) {
-                  const match = String(op?.p || "").match(/^(\d+)\/cite_index$/);
-                  if (match) {
-                    const index = parseInt(match[1], 10);
-                    if (searchResults[index]) searchResults[index].cite_index = op.v;
+              if (p === "response" && Array.isArray(v)) {
+                for (const entry of v) {
+                  if (entry?.p === "response" && entry?.v?.thinking_enabled === true) {
+                    currentPath = "thinking";
                   }
                 }
               }
-              continue;
-            }
 
-            if (typeof v === "string") {
-              sendByPath(v);
-            } else if (Array.isArray(v) && p === "response") {
-              for (const entry of v) {
-                if (Array.isArray(entry?.v)) {
-                  const joined = entry.v.map((item: any) => item?.content || "").join("");
-                  if (joined) sendByPath(joined);
+              if (p === "response/search_status") continue;
+
+              if (p === "response/search_results" && Array.isArray(v)) {
+                if (o !== "BATCH") {
+                  searchResults.length = 0;
+                  searchResults.push(...v);
+                } else {
+                  for (const op of v) {
+                    const match = String(op?.p || "").match(/^(\d+)\/cite_index$/);
+                    if (match) {
+                      const index = parseInt(match[1], 10);
+                      if (searchResults[index]) searchResults[index].cite_index = op.v;
+                    }
+                  }
+                }
+                continue;
+              }
+
+              if (typeof v === "string") {
+                sendByPath(v);
+              } else if (Array.isArray(v) && p === "response") {
+                for (const entry of v) {
+                  if (Array.isArray(entry?.v)) {
+                    const joined = entry.v.map((item: any) => item?.content || "").join("");
+                    if (joined) sendByPath(joined);
+                  }
                 }
               }
-            }
 
-            // Do not close on FINISHED — DeepSeek may still send search_results afterward.
-            if (p === "response/status" && v === "FINISHED") {
-              continue;
+              // Do not close on FINISHED — DeepSeek may still send search_results afterward.
+              if (p === "response/status" && v === "FINISHED") {
+                continue;
+              }
             }
           }
+        } catch (err) {
+          controller.error(err);
+          return;
         }
-      } catch (err) {
-        controller.error(err);
-        return;
-      }
 
-      finishStream();
-    },
+        finishStream();
+      },
     },
     { highWaterMark: 16384 }
   );
@@ -738,6 +739,10 @@ function buildToolAwareResult(opts: {
     const sse = new ReadableStream({
       start(controller) {
         emit(controller, { role: "assistant", content: "" }, null);
+        // Surrounding natural-language text (and reasoning) is emitted before the tool_calls
+        // so a model reply that interleaves a plan with a call still reaches the client (#7).
+        if (reasoningContent) emit(controller, { reasoning_content: reasoningContent }, null);
+        if (content) emit(controller, { content }, null);
         if (hasCalls) {
           emit(
             controller,
@@ -751,8 +756,6 @@ function buildToolAwareResult(opts: {
             },
             null
           );
-        } else if (content) {
-          emit(controller, { content }, null);
         }
         emit(controller, {}, finishReason);
         controller.enqueue(encoder.encode("data: [DONE]\n\n"));
@@ -826,7 +829,7 @@ export class DeepSeekWebExecutor extends BaseExecutor {
     // back into OpenAI tool_calls on the way out.
     const requestedTools = bodyObj.tools;
     const hasTools = Array.isArray(requestedTools) && requestedTools.length > 0;
-    const toolSystemPrompt = hasTools ? serializeToolsToPrompt(requestedTools) : "";
+    const toolSystemPrompt = hasTools ? serializeDeepSeekToolPrompt(requestedTools) : "";
 
     const messages = (Array.isArray(bodyObj.messages) ? bodyObj.messages : []) as Array<{
       role: string;
@@ -868,7 +871,12 @@ export class DeepSeekWebExecutor extends BaseExecutor {
       const accessToken = await acquireAccessToken(userToken, signal, log);
       log?.info?.("DEEPSEEK-WEB", `Token acquired in ${Date.now() - t0}ms`);
 
-      const prompt = messagesToPrompt(promptMessages, historyWindow);
+      // Tool (agentic) requests replay the whole trajectory — prior tool calls and their
+      // results — so the model keeps context across turns instead of restarting each time.
+      // Plain chat keeps the legacy last-user-message / rolling-window behavior.
+      const prompt = hasTools
+        ? buildToolConversationPrompt(messages, toolSystemPrompt)
+        : messagesToPrompt(promptMessages, historyWindow);
       const refFileIds = Array.isArray(bodyObj.ref_file_ids) ? bodyObj.ref_file_ids : [];
       log?.info?.(
         "DEEPSEEK-WEB",
@@ -1030,7 +1038,7 @@ export class DeepSeekWebExecutor extends BaseExecutor {
       if (hasTools) {
         const { content, reasoningContent } = await collectSSEContent(resp.body!, clientModel);
         await cleanupFn();
-        const { content: cleanedContent, toolCalls } = parseToolCallsFromText(
+        const { content: cleanedContent, toolCalls } = parseDeepSeekToolCalls(
           content,
           `call-${Date.now()}`,
           requestedTools

--- a/open-sse/translator/deepseekWebTools.ts
+++ b/open-sse/translator/deepseekWebTools.ts
@@ -1,0 +1,438 @@
+// DeepSeek-web-specific tool-call translation.
+//
+// chat.deepseek.com has no native function calling, so OmniRoute serializes the OpenAI
+// `tools[]` into a prompt contract and parses the model's text reply back into OpenAI
+// `tool_calls`. The canonical `webTools.ts` parser handles the well-behaved
+// `<tool>{json}</tool>` / bare-JSON shapes used by most web-cookie providers, and it MUST
+// stay untouched (it works for the others).
+//
+// DeepSeek, however, emits a much wider zoo of ad-hoc shapes:
+//   <tool:todowrite>{json}</tool>            name in the tag suffix, body is the arguments
+//   <tool_call>{id,type,params}</tool_call>  alternate key names (type → name, params → arguments)
+//   <tool name="x">{json}</tool>             name in an attribute
+//   <tool id="todo_write">{json}</tool>      tool name in the id attribute
+//   <tool><tool ...>{json}</tool></tool>     doubled / nested wrappers
+//   <tool id="1"><name>x</name><arguments>{json}</arguments></tool>   XML children
+//   <tool:write><parameter name="content" content="...">             parameter style
+//
+// A single regex cannot robustly cover all of these (nesting + attributes + XML children),
+// so this parser tokenizes the tool tags and walks them with a stack instead. It reuses the
+// proven JSON-normalization / fuzzy-name-matching / range-stripping helpers from webTools.ts
+// rather than duplicating them.
+
+import {
+  parseToolCallsFromText,
+  parseLooseJsonObject,
+  getRequestedToolNames,
+  resolveRequestedToolName,
+  toArgumentsString,
+  stripRanges,
+  type OpenAIToolCall,
+  type RequestedToolName,
+} from "./webTools.ts";
+
+interface OpenAIToolDef {
+  type?: string;
+  function?: { name?: string; description?: string; parameters?: unknown };
+}
+
+// ── Stricter, compact tool-use prompt ───────────────────────────────────────
+
+/**
+ * Serialize an OpenAI `tools` array into a DeepSeek-specific system-prompt block.
+ *
+ * It is deliberately stricter than the generic `serializeToolsToPrompt`: DeepSeek tends to
+ * (a) invent its own wrappers and (b) merely *describe* a plan instead of emitting a call.
+ * The wording forces the single canonical `<tool>{json}</tool>` shape and forbids the
+ * alternatives, while staying short to avoid wasting tokens.
+ */
+export function serializeDeepSeekToolPrompt(tools: unknown): string {
+  if (!Array.isArray(tools) || tools.length === 0) return "";
+
+  const lines: string[] = [];
+  for (const t of tools as OpenAIToolDef[]) {
+    const fn = t?.function;
+    if (!fn?.name) continue;
+    const desc = typeof fn.description === "string" && fn.description ? fn.description : "";
+    let params = "";
+    try {
+      params = fn.parameters ? JSON.stringify(fn.parameters) : "";
+    } catch {
+      params = "";
+    }
+    lines.push(
+      `- ${fn.name}${desc ? `: ${desc}` : ""}${params ? `\n  parameters: ${params}` : ""}`
+    );
+  }
+  if (lines.length === 0) return "";
+
+  return [
+    "You can call tools. To call a tool, output ONLY this exact block (no markdown fence):",
+    '<tool>{"name": "<tool_name>", "arguments": { ... }}</tool>',
+    "Rules:",
+    "- Use exactly <tool>...</tool>. Do NOT use <tool:name>, <tool_call>, <name>, <parameter>, id=/name= attributes, or code fences.",
+    '- "name" must be one of the tools below; "arguments" must be a JSON object.',
+    "- When a tool is needed, emit the <tool> block instead of only describing the plan.",
+    "- Emit one <tool> block per call; you may put several blocks back to back.",
+    "- If no tool is needed, just answer normally without any <tool> block.",
+    "",
+    "Available tools:",
+    ...lines,
+  ].join("\n");
+}
+
+// ── Tool-aware conversation prompt ───────────────────────────────────────────
+
+interface ChatMessage {
+  role: string;
+  content?: unknown;
+  tool_calls?: Array<{ id?: string; function?: { name?: string; arguments?: unknown } }>;
+  tool_call_id?: string;
+  name?: string;
+}
+
+function extractText(content: unknown): string {
+  if (Array.isArray(content)) {
+    return (content as Array<{ type?: string; text?: string }>)
+      .filter((item) => item?.type === "text")
+      .map((item) => item?.text ?? "")
+      .join("\n");
+  }
+  return content == null ? "" : String(content);
+}
+
+/**
+ * Build the single `prompt` string for an agentic (tool-using) DeepSeek-web turn.
+ *
+ * The web endpoint takes a flat prompt with no `messages[]`, so the legacy `messagesToPrompt`
+ * only forwarded the last user message — which makes an agent loop amnesiac: on every turn the
+ * follow-up messages carry no new *user* text, so DeepSeek only ever saw the original task and
+ * kept restarting (re-creating todos, re-listing files…). This builder instead replays the WHOLE
+ * trajectory — including the assistant's prior `<tool>` calls and each `role:"tool"` result — so
+ * the model continues from where it left off instead of starting over.
+ */
+export function buildToolConversationPrompt(
+  messages: ChatMessage[],
+  toolSystemPrompt: string
+): string {
+  const systemParts: string[] = [];
+  if (toolSystemPrompt) systemParts.push(toolSystemPrompt);
+
+  const lines: string[] = [];
+  const callNameById = new Map<string, string>();
+  let sawToolActivity = false;
+
+  for (const m of messages) {
+    if (m.role === "system") {
+      const t = extractText(m.content).trim();
+      if (t) systemParts.push(t);
+    } else if (m.role === "user") {
+      const t = extractText(m.content).trim();
+      if (t) lines.push(`User: ${t}`);
+    } else if (m.role === "assistant") {
+      const t = extractText(m.content).trim();
+      const calls = Array.isArray(m.tool_calls) ? m.tool_calls : [];
+      const parts: string[] = [];
+      if (t) parts.push(t);
+      for (const c of calls) {
+        const name = typeof c?.function?.name === "string" ? c.function.name : "";
+        const rawArgs = c?.function?.arguments;
+        const args =
+          typeof rawArgs === "string" && rawArgs ? rawArgs : JSON.stringify(rawArgs ?? {});
+        if (c?.id) callNameById.set(c.id, name);
+        parts.push(`<tool>{"name": ${JSON.stringify(name)}, "arguments": ${args}}</tool>`);
+        sawToolActivity = true;
+      }
+      if (parts.length) lines.push(`Assistant: ${parts.join("\n")}`);
+    } else if (m.role === "tool") {
+      const t = extractText(m.content).trim();
+      const name = (m.tool_call_id && callNameById.get(m.tool_call_id)) || m.name || "tool";
+      lines.push(`Tool result (${name}): ${t || "(no output)"}`);
+      sawToolActivity = true;
+    }
+  }
+
+  const parts: string[] = [];
+  if (systemParts.length) parts.push(systemParts.join("\n\n"));
+  if (lines.length) parts.push(lines.join("\n\n"));
+  if (sawToolActivity) {
+    // Anchor the model to the work already done so it advances instead of repeating it.
+    parts.push(
+      "Continue the task using the tool results above. Do NOT repeat tool calls that already " +
+        "succeeded; perform the next step or give the final answer."
+    );
+  }
+
+  return parts.join("\n\n").replace(/!\[.*?\]\(.*?\)/g, "");
+}
+
+// ── Tag tokenizer ────────────────────────────────────────────────────────────
+
+interface TagToken {
+  start: number;
+  end: number;
+  closing: boolean;
+  suffix: string; // tool name after ':' in the tag (e.g. `<tool:bash>` → "bash")
+  attrs: string; // raw attribute text inside the tag
+}
+
+// Matches an opening/closing <tool .../> or <tool_call .../> tag, optionally with a `:name`
+// suffix and an attribute list. `tool_call` is listed first so it wins the alternation.
+const TAG_TOKEN_RE = /<(\/?)(?:tool_call|tool)(:[A-Za-z0-9_.+-]+)?((?:\s[^>]*)?)\/?>/g;
+
+function tokenizeToolTags(text: string): TagToken[] {
+  const tokens: TagToken[] = [];
+  let m: RegExpExecArray | null;
+  TAG_TOKEN_RE.lastIndex = 0;
+  while ((m = TAG_TOKEN_RE.exec(text)) !== null) {
+    tokens.push({
+      start: m.index,
+      end: TAG_TOKEN_RE.lastIndex,
+      closing: m[1] === "/",
+      suffix: m[2] ? m[2].slice(1) : "",
+      attrs: m[3] || "",
+    });
+  }
+  return tokens;
+}
+
+interface ToolBlock {
+  open: TagToken;
+  close: TagToken;
+  innerStart: number;
+  innerEnd: number;
+}
+
+// Pair tags with a stack: every closing tag pairs with the nearest unmatched open. An open
+// left unmatched at the end (e.g. the stray outer `<tool>` of a doubled wrapper, or a
+// never-closed `<tool:write>` followed by `<parameter ...>`) gets a synthetic close at the end
+// of the text so its body is still parsed; the doubled-wrapper outer is then dropped by the
+// leaf filter.
+function pairToolBlocks(tokens: TagToken[], textLen: number): ToolBlock[] {
+  const blocks: ToolBlock[] = [];
+  const stack: TagToken[] = [];
+  for (const tok of tokens) {
+    if (!tok.closing) {
+      stack.push(tok);
+      continue;
+    }
+    const open = stack.pop();
+    if (!open) continue;
+    blocks.push({ open, close: tok, innerStart: open.end, innerEnd: tok.start });
+  }
+  for (const open of stack) {
+    const synthetic: TagToken = {
+      start: textLen,
+      end: textLen,
+      closing: true,
+      suffix: "",
+      attrs: "",
+    };
+    blocks.push({ open, close: synthetic, innerStart: open.end, innerEnd: textLen });
+  }
+  return blocks;
+}
+
+// ── Attribute / XML-child helpers ────────────────────────────────────────────
+
+/** Read an attribute value, tolerating backslash-escaped quotes inside the value. */
+function getAttr(attrs: string, name: string): string | null {
+  const re = new RegExp(`\\b${name}\\s*=\\s*("|')`);
+  const m = re.exec(attrs);
+  if (!m) return null;
+  const quote = m[1];
+  let j = m.index + m[0].length;
+  let out = "";
+  while (j < attrs.length) {
+    const ch = attrs[j];
+    if (ch === "\\") {
+      out += attrs[j + 1] ?? "";
+      j += 2;
+      continue;
+    }
+    if (ch === quote) break;
+    out += ch;
+    j += 1;
+  }
+  return out;
+}
+
+function getXmlChild(inner: string, tag: string): string | null {
+  const m = new RegExp(`<${tag}\\b[^>]*>([\\s\\S]*?)<\\/${tag}>`, "i").exec(inner);
+  return m ? m[1].trim() : null;
+}
+
+const PARAM_TAG_RE = /<parameter\b([^>]*?)\/?>(?:([\s\S]*?)<\/parameter>)?/gi;
+
+/** Collect `<parameter name="x" content="y">` / `<parameter name="x">y</parameter>` into an object. */
+function buildArgsFromParameters(inner: string): Record<string, unknown> | null {
+  const out: Record<string, unknown> = {};
+  let found = false;
+  let m: RegExpExecArray | null;
+  PARAM_TAG_RE.lastIndex = 0;
+  while ((m = PARAM_TAG_RE.exec(inner)) !== null) {
+    const attrs = m[1] || "";
+    const body = m[2];
+    const name = getAttr(attrs, "name");
+    if (!name) continue;
+    const value = getAttr(attrs, "content") ?? (typeof body === "string" ? body.trim() : "");
+    out[name] = value;
+    found = true;
+  }
+  return found ? out : null;
+}
+
+// ── Single-block extraction ──────────────────────────────────────────────────
+
+interface ExtractedCall {
+  name: string;
+  arguments: string;
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+/**
+ * Turn one tool block (tag name + inner text) into a name + JSON-string arguments.
+ * Returns null when no plausible tool name can be recovered.
+ */
+function extractCall(
+  tagName: string,
+  innerRaw: string,
+  requested: RequestedToolName[]
+): ExtractedCall | null {
+  const inner = innerRaw.trim();
+
+  const nameChild = getXmlChild(inner, "name");
+  const argsChild = getXmlChild(inner, "arguments") ?? getXmlChild(inner, "parameters");
+  const paramObj = argsChild ? null : buildArgsFromParameters(inner);
+  const hasXmlChildren = !!nameChild || !!argsChild || !!paramObj;
+
+  const json = hasXmlChildren ? null : parseLooseJsonObject(inner);
+  const jsonName = json ? (asString(json.name) ?? asString(json.type)) : null;
+
+  const childResolved = nameChild ? resolveRequestedToolName(nameChild, requested) : null;
+  const jsonResolved = jsonName ? resolveRequestedToolName(jsonName, requested) : null;
+  const tagResolved = tagName ? resolveRequestedToolName(tagName, requested) : null;
+
+  // Prefer a name that maps to a requested tool. The JSON body wins over the tag attribute
+  // because DeepSeek sometimes emits a bogus tag name (e.g. name="skill", #3260).
+  let name: string | null = null;
+  let nameFromTag = false;
+  const pick = (val: string | null, fromTag: boolean) => {
+    if (!name && val) {
+      name = val;
+      nameFromTag = fromTag;
+    }
+  };
+  pick(childResolved, false);
+  pick(jsonResolved, false);
+  pick(tagResolved, true);
+  pick(nameChild, false);
+  pick(jsonName, false);
+  pick(tagName, true);
+
+  // Shell-style `{ "command": "..." }` with no tag name: treat command as the tool name only
+  // if it actually resolves to a requested tool (the value is otherwise the command itself).
+  if (!name && !tagName && json) {
+    const command = asString(json.command);
+    const resolved = command ? resolveRequestedToolName(command, requested) : null;
+    if (resolved) {
+      name = resolved;
+      nameFromTag = false;
+    }
+  }
+  if (!name) return null;
+
+  let argsValue: unknown;
+  if (argsChild) {
+    argsValue = parseLooseJsonObject(argsChild) ?? argsChild;
+  } else if (paramObj) {
+    argsValue = paramObj;
+  } else if (json) {
+    if (json.arguments !== undefined) argsValue = json.arguments;
+    else if (json.params !== undefined) argsValue = json.params;
+    else if (nameFromTag) {
+      // `<tool:bash>{"command": ...}` — the whole JSON object is the arguments payload.
+      argsValue = json;
+    } else {
+      // Name came from the JSON body — the remaining keys are the arguments.
+      const { name: _n, type: _t, id: _i, command: _c, arguments: _a, params: _p, ...rest } = json;
+      argsValue = rest;
+    }
+  } else {
+    argsValue = {};
+  }
+
+  return { name, arguments: toArgumentsString(argsValue) };
+}
+
+// ── Public parser ─────────────────────────────────────────────────────────────
+
+/**
+ * Parse a DeepSeek-web text reply into OpenAI `tool_calls`. Returns the surrounding text with the recognized blocks stripped (so it can
+ * still be streamed to the client) plus the parsed calls, or `null` when none are present.
+ *
+ * Falls back to the canonical `webTools.parseToolCallsFromText` for tag-free replies so that
+ * bare-JSON and plain `<tool>` behavior stays identical to the shared implementation.
+ */
+export function parseDeepSeekToolCalls(
+  text: string,
+  idSeed = "call",
+  requestedTools?: unknown
+): { content: string; toolCalls: OpenAIToolCall[] | null } {
+  if (typeof text !== "string" || text.length === 0) {
+    return { content: text ?? "", toolCalls: null };
+  }
+
+  const tokens = tokenizeToolTags(text);
+  if (tokens.length === 0) {
+    // No DeepSeek-specific tags — defer to the proven canonical parser (bare JSON, etc.).
+    return parseToolCallsFromText(text, idSeed, requestedTools);
+  }
+
+  const requested = getRequestedToolNames(requestedTools);
+  const blocks = pairToolBlocks(tokens, text.length);
+
+  // Only extract from leaf blocks (no other block nested inside), so a doubled
+  // `<tool><tool>...</tool></tool>` wrapper yields a single call from the inner block.
+  const isLeaf = (b: ToolBlock) =>
+    !blocks.some((o) => o !== b && o.open.start >= b.innerStart && o.close.end <= b.innerEnd);
+
+  const toolCalls: OpenAIToolCall[] = [];
+  const acceptedRanges: Array<{ start: number; end: number }> = [];
+
+  for (const block of blocks.filter(isLeaf).sort((a, b) => a.open.start - b.open.start)) {
+    const tagName =
+      block.open.suffix ||
+      getAttr(block.open.attrs, "name") ||
+      getAttr(block.open.attrs, "id") ||
+      "";
+    const inner = text.slice(block.innerStart, block.innerEnd);
+    const call = extractCall(tagName, inner, requested);
+    if (!call) continue;
+    toolCalls.push({
+      id: `${idSeed}_${toolCalls.length}`,
+      type: "function",
+      function: { name: call.name, arguments: call.arguments },
+    });
+    acceptedRanges.push({ start: block.open.start, end: block.close.end });
+  }
+
+  if (toolCalls.length === 0) {
+    // Tags were present but none parsed (e.g. malformed) — try the canonical bare-JSON path.
+    return parseToolCallsFromText(text, idSeed, requestedTools);
+  }
+
+  // Strip the accepted blocks plus any stray tool tags left outside them (the unmatched outer
+  // `<tool>` of a doubled wrapper, leftover `</tool>` of a non-leaf wrapper, etc.).
+  const within = (tok: TagToken) =>
+    acceptedRanges.some((r) => tok.start >= r.start && tok.end <= r.end);
+  const ranges = [
+    ...acceptedRanges,
+    ...tokens.filter((t) => !within(t)).map((t) => ({ start: t.start, end: t.end })),
+  ];
+
+  return { content: stripRanges(text, ranges), toolCalls };
+}

--- a/open-sse/translator/deepseekWebTools.ts
+++ b/open-sse/translator/deepseekWebTools.ts
@@ -262,7 +262,10 @@ function getXmlChild(inner: string, tag: string): string | null {
   return m ? m[1].trim() : null;
 }
 
-const PARAM_TAG_RE = /<parameter\b([^>]*?)\/?>(?:([\s\S]*?)<\/parameter>)?/gi;
+// The body group is a tempered greedy token: `(?:(?!<parameter\b)[\s\S])*?` so an
+// attribute-only `<parameter ...>` (no closing tag) cannot let the body matcher swallow a
+// following `<parameter>...</parameter>` and drop that parameter.
+const PARAM_TAG_RE = /<parameter\b([^>]*?)\/?>(?:((?:(?!<parameter\b)[\s\S])*?)<\/parameter>)?/gi;
 
 /** Collect `<parameter name="x" content="y">` / `<parameter name="x">y</parameter>` into an object. */
 function buildArgsFromParameters(inner: string): Record<string, unknown> | null {

--- a/open-sse/translator/webTools.ts
+++ b/open-sse/translator/webTools.ts
@@ -34,7 +34,7 @@ interface ToolParseCandidate {
   requireRequestedTool: boolean;
 }
 
-interface RequestedToolName {
+export interface RequestedToolName {
   original: string;
   normalized: string;
 }
@@ -45,7 +45,7 @@ function toRecord(value: unknown): Record<string, unknown> | null {
     : null;
 }
 
-function getRequestedToolNames(tools: unknown): RequestedToolName[] {
+export function getRequestedToolNames(tools: unknown): RequestedToolName[] {
   if (!Array.isArray(tools)) return [];
   const names: RequestedToolName[] = [];
   const seen = new Set<string>();
@@ -102,7 +102,10 @@ function scoreToolName(emitted: string, requested: RequestedToolName): number {
   return similarity >= 0.72 ? similarity : 0;
 }
 
-function resolveRequestedToolName(emitted: string, requestedTools: RequestedToolName[]): string | null {
+export function resolveRequestedToolName(
+  emitted: string,
+  requestedTools: RequestedToolName[]
+): string | null {
   if (requestedTools.length === 0) return emitted;
 
   let best: { name: string; score: number } | null = null;
@@ -227,7 +230,7 @@ function normalizeLooseJson(value: string): string {
     .replace(/,\s*([}\]])/g, "$1");
 }
 
-function parseLooseJsonObject(raw: string): Record<string, unknown> | null {
+export function parseLooseJsonObject(raw: string): Record<string, unknown> | null {
   const trimmed = stripCodeFence(raw);
   for (const candidate of [trimmed, normalizeLooseJson(trimmed)]) {
     try {
@@ -282,7 +285,10 @@ function findBareJsonCandidates(text: string): ToolParseCandidate[] {
       depth -= 1;
       if (depth === 0 && start >= 0) {
         const raw = text.slice(start, i + 1);
-        if (/[{,]\s*["']?(name|command)["']?\s*:/i.test(raw) && /[{,]\s*["']?arguments["']?\s*:/i.test(raw)) {
+        if (
+          /[{,]\s*["']?(name|command)["']?\s*:/i.test(raw) &&
+          /[{,]\s*["']?arguments["']?\s*:/i.test(raw)
+        ) {
           candidates.push({ raw, start, end: i + 1, requireRequestedTool: true });
         }
         start = -1;
@@ -293,11 +299,14 @@ function findBareJsonCandidates(text: string): ToolParseCandidate[] {
   return candidates;
 }
 
-function rangesOverlap(a: { start: number; end: number }, b: { start: number; end: number }): boolean {
+function rangesOverlap(
+  a: { start: number; end: number },
+  b: { start: number; end: number }
+): boolean {
   return a.start < b.end && b.start < a.end;
 }
 
-function stripRanges(text: string, ranges: Array<{ start: number; end: number }>): string {
+export function stripRanges(text: string, ranges: Array<{ start: number; end: number }>): string {
   let content = text;
   const sorted = [...ranges].sort((a, b) => b.start - a.start);
   for (const range of sorted) {
@@ -308,13 +317,18 @@ function stripRanges(text: string, ranges: Array<{ start: number; end: number }>
     const afterOnLine = content.slice(range.end, lineEnd);
     const removeWholeLine = beforeOnLine.trim() === "" && afterOnLine.trim() === "";
     const start = removeWholeLine ? lineStart : range.start;
-    const end = removeWholeLine && nextLineBreak !== -1 ? nextLineBreak + 1 : removeWholeLine ? lineEnd : range.end;
+    const end =
+      removeWholeLine && nextLineBreak !== -1
+        ? nextLineBreak + 1
+        : removeWholeLine
+          ? lineEnd
+          : range.end;
     content = `${content.slice(0, start)}${content.slice(end)}`;
   }
   return content.replace(/\n{3,}/g, "\n\n").trim();
 }
 
-function toArgumentsString(value: unknown): string {
+export function toArgumentsString(value: unknown): string {
   if (value === undefined) return "{}";
   if (typeof value === "string") {
     const parsed = parseLooseJsonObject(value);
@@ -346,7 +360,9 @@ export function serializeToolsToPrompt(tools: unknown): string {
     } catch {
       params = "";
     }
-    lines.push(`- ${fn.name}${desc ? `: ${desc}` : ""}${params ? `\n  parameters: ${params}` : ""}`);
+    lines.push(
+      `- ${fn.name}${desc ? `: ${desc}` : ""}${params ? `\n  parameters: ${params}` : ""}`
+    );
   }
 
   if (lines.length === 0) return "";
@@ -471,7 +487,7 @@ interface ToolPrepResult {
  */
 export function prepareToolMessages(
   bodyObj: Record<string, unknown>,
-  messages: Array<{ role: string; content: unknown }>,
+  messages: Array<{ role: string; content: unknown }>
 ): ToolPrepResult {
   const requestedTools = bodyObj.tools;
   const hasTools = Array.isArray(requestedTools) && requestedTools.length > 0;
@@ -500,9 +516,13 @@ interface ToolCompletionResult {
 export function buildToolAwareResult(
   rawContent: string,
   requestedTools: unknown,
-  idSeed = "call",
+  idSeed = "call"
 ): ToolCompletionResult {
-  const { content, toolCalls } = parseToolCallsFromText(rawContent, `${idSeed}-${Date.now()}`, requestedTools);
+  const { content, toolCalls } = parseToolCallsFromText(
+    rawContent,
+    `${idSeed}-${Date.now()}`,
+    requestedTools
+  );
   return {
     content,
     toolCalls,

--- a/tests/unit/deepseek-web-tools-execute.test.ts
+++ b/tests/unit/deepseek-web-tools-execute.test.ts
@@ -1,0 +1,181 @@
+// @ts-nocheck
+// deepseek-web executor-level tool behavior (full execute() pipeline, fetch mocked):
+//   1. A reply interleaving natural-language text with a (DeepSeek-flavoured) tool call must
+//      surface BOTH the text AND the parsed tool_calls — streaming and non-streaming alike.
+//   2. An agentic (tool-using) conversation must replay the whole trajectory (prior tool calls
+//      + their results) into the flat web `prompt`, so the model keeps context across turns
+//      instead of restarting.
+// Pure parser / prompt-builder unit tests live in deepseek-web-tools-variants.test.ts.
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const dsMod = await import("../../open-sse/executors/deepseek-web.ts");
+const { DeepSeekWebExecutor } = dsMod;
+
+const POW_CHALLENGE = {
+  algorithm: "DeepSeekHashV1",
+  challenge: "311b26ae1e0fe7375e242958ce46db5552a6c67fea3f96880dcd846c63a74286",
+  salt: "1122334455667788",
+  signature: "sig123",
+  difficulty: 1,
+  expire_at: 1778891543095,
+  expire_after: 300000,
+  target_path: "/api/v0/chat/completion",
+};
+
+function sseWithContent(text) {
+  return [
+    "event: ready\n",
+    'data: {"request_message_id":1,"response_message_id":2}\n',
+    "\n",
+    `data: ${JSON.stringify({ v: { response: { message_id: 2, fragments: [{ id: 1, type: "RESPONSE", content: text }] } } })}\n`,
+    "\n",
+    'data: {"p":"response/status","o":"SET","v":"FINISHED"}\n',
+    "\n",
+    "event: close\n",
+    'data: {"click_behavior":"none"}\n',
+  ].join("");
+}
+
+function installMock(completionText) {
+  const original = globalThis.fetch;
+  const calls = { completionBodies: [] };
+  dsMod.tokenCache?.clear();
+  dsMod.sessionCache?.clear();
+  globalThis.fetch = async (url, opts = {}) => {
+    const u = String(url);
+    if (u.includes("/users/current"))
+      return new Response(
+        JSON.stringify({ code: 0, data: { biz_data: { token: "access-token-xyz" } } }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    if (u.includes("/chat_session/create"))
+      return new Response(
+        JSON.stringify({ code: 0, data: { biz_data: { chat_session: { id: "s-1" } } } }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    if (u.includes("/chat_session/delete"))
+      return new Response(JSON.stringify({ code: 0 }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    if (u.includes("/create_pow_challenge"))
+      return new Response(
+        JSON.stringify({ code: 0, data: { biz_data: { challenge: POW_CHALLENGE } } }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    if (u.includes("/chat/completion")) {
+      try {
+        calls.completionBodies.push(JSON.parse(opts.body));
+      } catch {
+        calls.completionBodies.push(null);
+      }
+      return new Response(new TextEncoder().encode(sseWithContent(completionText)), {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      });
+    }
+    return new Response("not found", { status: 404 });
+  };
+  return {
+    calls,
+    restore: () => {
+      globalThis.fetch = original;
+      dsMod.tokenCache?.clear();
+      dsMod.sessionCache?.clear();
+    },
+  };
+}
+
+const TOOLS = [
+  { type: "function", function: { name: "todowrite", description: "Write todos" } },
+  { type: "function", function: { name: "bash", description: "Run a shell command" } },
+];
+
+// ── 1. Surrounding text + tool_calls are both surfaced ──────────────────────
+
+// Explanation text followed by a `<tool:bash>` block.
+const TEXT_PLUS_TOOL = 'I\'ll create a script.\n\n<tool:bash>\n{"command": "echo hi"}\n</tool>';
+const EXPLANATION = "I'll create a script.";
+
+test("non-stream: surrounding text AND tool_calls are both returned", async () => {
+  const mock = installMock(TEXT_PLUS_TOOL);
+  try {
+    const result = await new DeepSeekWebExecutor().execute({
+      model: "default",
+      body: { messages: [{ role: "user", content: "go" }], tools: TOOLS },
+      stream: false,
+      credentials: { apiKey: "tkn-text-ns" },
+      signal: AbortSignal.timeout(10000),
+    });
+    const choice = JSON.parse(await result.response.text()).choices[0];
+    assert.equal(choice.finish_reason, "tool_calls");
+    assert.equal(choice.message.tool_calls[0].function.name, "bash");
+    assert.deepEqual(JSON.parse(choice.message.tool_calls[0].function.arguments), {
+      command: "echo hi",
+    });
+    assert.ok(choice.message.content.includes(EXPLANATION), "explanation text preserved");
+    assert.ok(!choice.message.content.includes("<tool"), "tool block stripped from content");
+  } finally {
+    mock.restore();
+  }
+});
+
+test("stream: SSE carries the text delta AND the tool_calls delta", async () => {
+  const mock = installMock(TEXT_PLUS_TOOL);
+  try {
+    const result = await new DeepSeekWebExecutor().execute({
+      model: "default",
+      body: { messages: [{ role: "user", content: "go" }], tools: TOOLS },
+      stream: true,
+      credentials: { apiKey: "tkn-text-stream" },
+      signal: AbortSignal.timeout(10000),
+    });
+    const text = await result.response.text();
+    assert.ok(text.includes(EXPLANATION), "stream carries the explanation text");
+    assert.ok(text.includes("tool_calls"), "stream carries tool_calls");
+    assert.ok(text.includes("echo hi"), "stream carries the arguments");
+    assert.ok(text.includes('"finish_reason":"tool_calls"'));
+    assert.ok(text.includes("[DONE]"));
+  } finally {
+    mock.restore();
+  }
+});
+
+// ── 2. Agentic context is replayed into the upstream prompt ──────────────────
+
+test("execute forwards the full agentic trajectory into the upstream prompt", async () => {
+  const mock = installMock("All done.");
+  try {
+    await new DeepSeekWebExecutor().execute({
+      model: "default",
+      body: {
+        tools: TOOLS,
+        messages: [
+          { role: "user", content: "write train.py" },
+          {
+            role: "assistant",
+            content: "",
+            tool_calls: [
+              {
+                id: "c1",
+                type: "function",
+                function: { name: "todowrite", arguments: '{"todos":[]}' },
+              },
+            ],
+          },
+          { role: "tool", tool_call_id: "c1", content: "todos created" },
+        ],
+      },
+      stream: false,
+      credentials: { apiKey: "tkn-ctx" },
+      signal: AbortSignal.timeout(10000),
+    });
+    const prompt = mock.calls.completionBodies[0].prompt;
+    assert.ok(prompt.includes("write train.py"), "task retained");
+    assert.ok(prompt.includes("todowrite"), "prior tool call retained");
+    assert.ok(prompt.includes("todos created"), "prior tool result retained");
+  } finally {
+    mock.restore();
+  }
+});

--- a/tests/unit/deepseek-web-tools-variants.test.ts
+++ b/tests/unit/deepseek-web-tools-variants.test.ts
@@ -1,0 +1,213 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  parseDeepSeekToolCalls,
+  serializeDeepSeekToolPrompt,
+  buildToolConversationPrompt,
+} from "../../open-sse/translator/deepseekWebTools.ts";
+
+// chat.deepseek.com emits tool invocations in many ad-hoc shapes. The deepseek-specific
+// parser must recognize all of them, recover the real tool name/arguments, and preserve
+// any surrounding natural-language text so it can still be streamed to the client.
+
+const TOOLS = [
+  { type: "function", function: { name: "todowrite", description: "Write todos" } },
+  { type: "function", function: { name: "bash", description: "Run a shell command" } },
+  { type: "function", function: { name: "write", description: "Write a file" } },
+  {
+    type: "function",
+    function: {
+      name: "get_weather",
+      parameters: { type: "object", properties: { city: { type: "string" } } },
+    },
+  },
+];
+
+function firstCall(text: string) {
+  const { toolCalls } = parseDeepSeekToolCalls(text, "call", TOOLS);
+  assert.ok(toolCalls && toolCalls.length >= 1, `expected a tool call for: ${text.slice(0, 60)}`);
+  return toolCalls[0];
+}
+
+describe("deepseekWebTools — variants", () => {
+  test("Ex1: <tool:todowrite>{json} </tool> — name in tag suffix, body is the arguments", () => {
+    const text = `I'll write a script.\n\n<tool:todowrite>\n{"todos": [{"content": "a", "status": "in_progress", "priority": "high"}]}\n</tool>`;
+    const { content, toolCalls } = parseDeepSeekToolCalls(text, "call", TOOLS);
+    assert.equal(toolCalls?.length, 1);
+    assert.equal(toolCalls![0].function.name, "todowrite");
+    assert.deepEqual(JSON.parse(toolCalls![0].function.arguments), {
+      todos: [{ content: "a", status: "in_progress", priority: "high" }],
+    });
+    assert.ok(content.includes("I'll write a script."), "surrounding text preserved");
+    assert.ok(!content.includes("<tool"), "tool block stripped");
+  });
+
+  test("Ex3: <tool_call> with id/type/params shape", () => {
+    const text = `I'll draft a plan.\n<tool_call>\n{"id": "todo_1", "type": "todo", "params": {"todos": [{"content": "x", "status": "pending", "priority": "high"}]}}\n</tool_call>`;
+    const call = firstCall(text);
+    assert.equal(call.function.name, "todowrite", "type 'todo' fuzzy-resolves to todowrite");
+    assert.deepEqual(JSON.parse(call.function.arguments), {
+      todos: [{ content: "x", status: "pending", priority: "high" }],
+    });
+  });
+
+  test("Ex5: nested <tool><tool>{json}</tool> — inner canonical call", () => {
+    const text = `<tool>\n<tool>{"name": "todowrite", "arguments": {"todos": [{"content": "y", "status": "pending", "priority": "high"}]}}</tool>`;
+    const { content, toolCalls } = parseDeepSeekToolCalls(text, "call", TOOLS);
+    assert.equal(toolCalls?.length, 1);
+    assert.equal(toolCalls![0].function.name, "todowrite");
+    assert.ok(!content.includes("<tool"), "stray/nested tool tags stripped");
+  });
+
+  test("Ex6: <tool:bash>{command} </tool> — body is the arguments payload", () => {
+    const text = `I'll create a script.\n\n<tool:bash>\n{"command": "echo hi"}\n</tool>`;
+    const call = firstCall(text);
+    assert.equal(call.function.name, "bash");
+    assert.deepEqual(JSON.parse(call.function.arguments), { command: "echo hi" });
+  });
+
+  test('Ex7: <tool id="1"><name>write</name><arguments>{json}</arguments></tool>', () => {
+    const text = `I'll create a script.\n<tool id="1">\n  <name>write</name>\n  <arguments>\n    {"filePath": "/tmp/train.py", "content": "print(1)"}\n  </arguments>\n</tool>`;
+    const call = firstCall(text);
+    assert.equal(call.function.name, "write");
+    assert.deepEqual(JSON.parse(call.function.arguments), {
+      filePath: "/tmp/train.py",
+      content: "print(1)",
+    });
+  });
+
+  test('Ex8: <tool><tool name="todowrite">{json}</tool></tool> — name attribute on inner', () => {
+    const text = `<tool>\n<tool name="todowrite">{"todos":[{"content":"c","status":"in_progress","priority":"high"}]}</tool>\n</tool>`;
+    const call = firstCall(text);
+    assert.equal(call.function.name, "todowrite");
+    assert.deepEqual(JSON.parse(call.function.arguments), {
+      todos: [{ content: "c", status: "in_progress", priority: "high" }],
+    });
+  });
+
+  test('Ex9: <tool:write><parameter name="content" content="..."> — parameter style', () => {
+    const text = `<tool:write>\n<parameter name="content" content="print('hi')">`;
+    const call = firstCall(text);
+    assert.equal(call.function.name, "write");
+    assert.deepEqual(JSON.parse(call.function.arguments), { content: "print('hi')" });
+  });
+
+  test('Ex12: <tool id="todo_write">{json}</tool> — id resolves to a tool name', () => {
+    const text = `I'll create a script.\n<tool id="todo_write">\n{"todos": [{"content": "z", "status": "in_progress", "priority": "high"}]}\n</tool>`;
+    const call = firstCall(text);
+    assert.equal(call.function.name, "todowrite");
+    assert.deepEqual(JSON.parse(call.function.arguments), {
+      todos: [{ content: "z", status: "in_progress", priority: "high" }],
+    });
+  });
+
+  test("canonical <tool>{name,arguments}</tool> still works (no regression)", () => {
+    const text = `<tool>{"name": "get_weather", "arguments": {"city": "Paris"}}</tool>`;
+    const call = firstCall(text);
+    assert.equal(call.function.name, "get_weather");
+    assert.deepEqual(JSON.parse(call.function.arguments), { city: "Paris" });
+  });
+
+  test("bare JSON (no tags) still resolves via fuzzy name match", () => {
+    const text = `{"name":"getWeather","arguments":{"city":"Paris"}}`;
+    const call = firstCall(text);
+    assert.equal(call.function.name, "get_weather");
+    assert.deepEqual(JSON.parse(call.function.arguments), { city: "Paris" });
+  });
+
+  test("#3260: tag name attribute is bogus, real name is in JSON body", () => {
+    const text = `<tool_call name="skill">{"name": "get_weather", "arguments": {"city": "SP"}}</tool_call>`;
+    const call = firstCall(text);
+    assert.equal(call.function.name, "get_weather");
+  });
+
+  test("surrounding text is preserved both before and after the tool block", () => {
+    const text = `Before text.\n<tool:bash>\n{"command": "ls"}\n</tool>\nAfter text.`;
+    const { content, toolCalls } = parseDeepSeekToolCalls(text, "call", TOOLS);
+    assert.equal(toolCalls?.length, 1);
+    assert.ok(content.includes("Before text."));
+    assert.ok(content.includes("After text."));
+  });
+});
+
+describe("deepseekWebTools — pure-text (no tool) replies", () => {
+  for (const [label, text] of [
+    ["Ex2 plan only", "I'll build a train animation. Plan:\n1. step\n2. step\nStarting now."],
+    ["Ex4 code fence only", "Plan:\n```python\nimport os\nprint(os.getcwd())\n```"],
+    ["Ex13 bash fence only", "```bash\nuv pip install rich\n```"],
+  ] as const) {
+    test(`${label} — returns plain content, no tool calls`, () => {
+      const { content, toolCalls } = parseDeepSeekToolCalls(text, "call", TOOLS);
+      assert.equal(toolCalls, null, "no tool call should be parsed");
+      assert.equal(content, text, "content returned unchanged");
+    });
+  }
+});
+
+describe("deepseekWebTools — strict prompt", () => {
+  test("lists tools and mandates the exact <tool> JSON format", () => {
+    const prompt = serializeDeepSeekToolPrompt(TOOLS);
+    assert.ok(prompt.includes("todowrite"));
+    assert.ok(prompt.includes("get_weather"));
+    assert.ok(prompt.includes('<tool>{"name"'), "shows the canonical format");
+    assert.ok(/never|not|do not/i.test(prompt), "warns against alternative formats");
+  });
+
+  test("returns empty string when there are no usable tools", () => {
+    assert.equal(serializeDeepSeekToolPrompt([]), "");
+    assert.equal(serializeDeepSeekToolPrompt(undefined), "");
+  });
+});
+
+describe("deepseekWebTools — buildToolConversationPrompt (agentic context)", () => {
+  // A tool-using conversation must replay the WHOLE trajectory (prior assistant tool_calls +
+  // their tool results) into the flat web `prompt`, otherwise the model is amnesiac and
+  // restarts every turn — re-creating todos, re-listing files, etc.
+  // The legacy builder only forwarded the last user message and dropped
+  // tool_calls / role:"tool" messages. The executor-level coverage lives in
+  // deepseek-web-tools-execute.test.ts.
+  test("replays prior tool calls and their results", () => {
+    const messages = [
+      { role: "user", content: "write train.py" },
+      {
+        role: "assistant",
+        content: "",
+        tool_calls: [
+          {
+            id: "c1",
+            type: "function",
+            function: { name: "todowrite", arguments: '{"todos":[{"content":"a"}]}' },
+          },
+        ],
+      },
+      { role: "tool", tool_call_id: "c1", content: "todos created" },
+      {
+        role: "assistant",
+        content: "",
+        tool_calls: [
+          { id: "c2", type: "function", function: { name: "bash", arguments: '{"command":"ls"}' } },
+        ],
+      },
+      { role: "tool", tool_call_id: "c2", content: "train.py\ncat.md" },
+    ];
+
+    const prompt = buildToolConversationPrompt(messages, "TOOLS-HERE");
+
+    assert.ok(prompt.includes("TOOLS-HERE"), "tool system prompt leads");
+    assert.ok(prompt.includes("User: write train.py"), "original task present");
+    assert.ok(prompt.includes('"name": "todowrite"'), "prior todowrite call replayed");
+    assert.ok(
+      prompt.includes("Tool result (todowrite): todos created"),
+      "todowrite result replayed"
+    );
+    assert.ok(prompt.includes('"name": "bash"'), "prior bash call replayed");
+    assert.ok(prompt.includes("Tool result (bash): train.py"), "bash result replayed");
+    assert.ok(/Continue the task/i.test(prompt), "anchored to continue, not restart");
+  });
+
+  test("first-turn (no prior tool activity) omits the continue anchor", () => {
+    const prompt = buildToolConversationPrompt([{ role: "user", content: "hi" }], "TOOLS");
+    assert.ok(prompt.includes("User: hi"));
+    assert.ok(!/Continue the task/i.test(prompt), "no continue anchor on the first turn");
+  });
+});

--- a/tests/unit/deepseek-web-tools-variants.test.ts
+++ b/tests/unit/deepseek-web-tools-variants.test.ts
@@ -121,6 +121,18 @@ describe("deepseekWebTools — variants", () => {
     assert.equal(call.function.name, "get_weather");
   });
 
+  test("multiple <parameter> tags mixing content-attr and body styles are all captured", () => {
+    // Regression: an attribute-style <parameter ...> with no closing tag must not let the
+    // body matcher swallow a following body-style <parameter>...</parameter> (lost param).
+    const text = `<tool:write>\n<parameter name="filePath" content="/tmp/a.py">\n<parameter name="content">print(1)</parameter>\n</tool>`;
+    const call = firstCall(text);
+    assert.equal(call.function.name, "write");
+    assert.deepEqual(JSON.parse(call.function.arguments), {
+      filePath: "/tmp/a.py",
+      content: "print(1)",
+    });
+  });
+
   test("surrounding text is preserved both before and after the tool block", () => {
     const text = `Before text.\n<tool:bash>\n{"command": "ls"}\n</tool>\nAfter text.`;
     const { content, toolCalls } = parseDeepSeekToolCalls(text, "call", TOOLS);


### PR DESCRIPTION
## Summary

- Fixes tool (function-calling) support for the `deepseek-web` provider, used by agentic
  clients.
- **Tool-call parsing:** chat.deepseek.com has no native function calling, so OmniRoute
  serializes tools into a prompt and parses the text reply back into `tool_calls`. The
  shared parser only handled the canonical `<tool>{json}</tool>` form, so DeepSeek's many
  ad-hoc variants (`<tool:name>`, `<tool_call>` with `type`/`params`, `name=`/`id=`
  attributes, nested `<tool><tool>…`, XML `<name>`/`<arguments>` children, `<parameter>`
  style) were returned as plain text and stalled the agent loop. A new DeepSeek-specific
  parser recognizes all observed variants.
- **Context retention:** the upstream prompt was built from the last user message only and
  dropped assistant `tool_calls` and `role:"tool"` results, so the model had no memory of
  prior steps and restarted every turn (re-creating todos, re-listing files, re-checking
  `uv`, …). Tool requests now replay the full trajectory into the prompt.
- **Surrounding text:** explanatory text emitted alongside a tool call is now forwarded to
  the client (stream + non-stream) instead of being dropped.
- The shared `webTools.ts` parser is untouched, only exports added.

## Validation

- [x] `npm run lint`
- [x] `npm run test:unit`
- [x] `npm run test:coverage`
- [x] Coverage is still `>= 60%` for statements, lines, functions, and branches

## Tests Added Or Updated

- `tests/unit/deepseek-web-tools-variants.test.ts` (new) — type-checked unit tests for the
  parser (`parseDeepSeekToolCalls`) across every variant, the strict prompt
  (`serializeDeepSeekToolPrompt`), and the conversation builder
  (`buildToolConversationPrompt`).
- `tests/unit/deepseek-web-tools-execute.test.ts` (new) — executor-pipeline tests
  (fetch mocked): text + `tool_calls` emission (stream and non-stream) and full-trajectory
  context replay into the upstream prompt.

## Coverage Notes

- Production files touched (`open-sse/`):
  - `open-sse/translator/deepseekWebTools.ts` (new) — 92.92% stmts / 79.03% branches /
    100% funcs / 92.92% lines, covered by `deepseek-web-tools-variants.test.ts`.
  - `open-sse/executors/deepseek-web.ts` — 89.59% / 71.81% / 96.87% / 89.59%, the new
    tool/prompt paths covered by `deepseek-web-tools-execute.test.ts` (existing suites
    cover the rest).
  - `open-sse/translator/webTools.ts` — 98.68% / 82.88% / 100% / 98.68%; change is
    `export`-keyword only, existing `web-tools-translation*` suites unaffected.
- No touched file moved below the gate; all are above 60% on every metric.

## Notes

- The shared `webTools.ts` parser is intentionally left untouched (it works for other providers); the DeepSeek logic lives in a separate module that reuses
  `webTools` helpers via newly exported functions (no behavior change there).
- Tool requests now resend the full transcript each turn (stateless, correct for an agent
  loop). Very long sessions grow the prompt; a follow-up could cap it to the system prompt
  - first task + last N tool exchanges if upstream size limits are hit.
- No DB migrations, no feature flags, no new network surfaces.
- Manually validated end-to-end against a live DeepSeek-web agent session by the author.