### PR TITLE
feat(compression): per-request `x-omniroute-compression` header (Phase 3)

### DIFF
--- a/docs/compression/2026-06-21-compression-phase3-request-header-design.md
+++ b/docs/compression/2026-06-21-compression-phase3-request-header-design.md
@@ -1,0 +1,229 @@
+---
+title: "Compression Config Panel — Phase 3: Per-Request Header"
+version: 3.8.33
+lastUpdated: 2026-06-21
+---
+
+# Compression Config Panel — Phase 3: Per-Request Header
+
+**Status:** approved direction (2026-06-21), pending spec review
+**Base branch:** `release/v3.8.33` (Phase 1 #4432, Phase 2 #4521 merged)
+**Goal:** Let a client override the resolved compression plan for a single request via the
+`x-omniroute-compression` HTTP header, taking precedence over every operator-configured
+layer (routing override, active profile, auto-trigger, Default). The compression resolver
+is already header-aware in shape; Phase 3 adds the header parsing, threads the value to the
+top of the resolver, and surfaces the resolved plan back to the client via a response header.
+
+Phase 1 (#4432) built the `engines` map, `deriveDefaultPlan`, `resolveCompressionPlan`
+(header/active-combo-aware in signature), and persisted `activeComboId`. Phase 2 (#4521)
+wired the active-profile selector and lifted active-combo resolution into `resolveBasePlan`.
+Phase 3 is the final piece of the original three-phase plan.
+
+---
+
+## 1. Background — current state
+
+The resolver is **partially** header-aware but the header never reaches the top of the
+decision. From the code map:
+
+- **`open-sse/services/compression/resolveCompressionPlan.ts`** already accepts
+  `ResolveCtx.header` and interprets `off` / `default` / `engine:<id>` / `<combo>` via a
+  private `headerToPlan` helper. **But** no caller ever passes `header` today, so the branch
+  is dormant.
+- **`open-sse/services/compression/strategySelector.ts`** is the real entry point
+  (`selectCompressionStrategy`, `selectCompressionPlan`, `getEffectiveMode`, `applyCompression`).
+  Its `resolveBasePlan` only calls `resolveCompressionPlan` in **two** of five precedence
+  paths (routing-combo override and the `enginesExplicit` derived-default). The
+  **active-profile** and **auto-trigger** paths short-circuit and `return` *before* those
+  calls. So merely threading `header` into the existing `resolveCompressionPlan` calls would
+  **not** give the header top precedence — it would be silently ignored whenever an active
+  profile is set (the common case after Phase 2). The header must be evaluated at the **top**
+  of `resolveBasePlan`.
+- **`open-sse/handlers/chatCore/headers.ts`** already has the parsing precedent:
+  `isNoMemoryRequested` (`x-omniroute-no-memory`, PR #4290) + the case-insensitive
+  `getHeaderValueCaseInsensitive` reader.
+- **`src/lib/db/compressionCombos.ts`**: a combo's `id` is a `uuidv4()` (except the seeded
+  `default-caveman`), and its `name` is `TEXT NOT NULL` with **no UNIQUE constraint**
+  (migration 042). So a header value that names a combo is far more usable as the **name**
+  than the opaque UUID `id`.
+- **`open-sse/handlers/chatCore.ts`** builds the response headers (`X-OmniRoute-Model`,
+  `X-OmniRoute-Cache`, …) via `buildStreamingResponseHeaders` + `attachOmniRouteMetaHeaders`
+  on the main response path. There is currently **no** response header reporting the applied
+  compression plan.
+
+---
+
+## 2. The header contract
+
+`x-omniroute-compression: <value>` — mirrors the `x-omniroute-no-memory` / `no-cache`
+convention. Parsed alongside the other omniroute request headers. Keyword values and the
+`engine:` prefix are case-insensitive. Values:
+
+| Value | Meaning |
+|---|---|
+| `off` | No compression for this request. |
+| `default` | The **panel-derived Default** plan, deterministically — ignores active profile, routing override, **and** auto-trigger. |
+| `engine:<id>` | A single engine, when that engine is enabled in config (e.g. `engine:rtk`). |
+| `<combo>` | A named combo. Matched **by name (case-insensitive) first, then by exact id**. |
+
+**Decision A — combo matched by name:** because the stored `id` is a UUID, the ergonomic
+header value is the combo's **name** (e.g. `my-fast-combo`). Names are not unique in the DB,
+so the contract is documented as **first-match-wins**; clients wanting determinism can pass
+the exact `id`.
+
+**Decision B — an explicit header value is authoritative:** any valid value
+(`off` / `default` / `engine:<id>` / `<combo>`) **bypasses auto-trigger**. For example,
+`default` on a very large prompt keeps the panel Default rather than auto-escalating. The
+mental model is "the header decides, full stop."
+
+**Invalid / unknown value → ignored.** Resolution falls through to the normal operator
+precedence; the request is **never** rejected. A debug log line under the `COMPRESSION`
+channel records the unrecognized value for observability.
+
+---
+
+## 3. Architecture
+
+### 3.1 Resolution model (per request, most-specific wins)
+
+```
+x-omniroute-compression header        (per-request)   <- NEW top of precedence
+  -> routing-combo override (comboOverrides[comboId])  (per-route)
+    -> active profile (activeComboId)                  (global, Phase 2)
+      -> auto-trigger (large prompt -> autoTriggerMode)
+        -> Default = derived from panel engines map
+          -> off (master disabled, or zero engines on)
+```
+
+The header is evaluated at the **top** of `resolveBasePlan`. A valid value returns its plan
+immediately; an unknown value falls through to the existing precedence unchanged.
+
+### 3.2 The resolver `source`
+
+`resolveBasePlan` (and the public `selectCompressionPlan`) return the existing
+`DerivedPlan` (`{ mode, stackedPipeline }`) extended with an **optional** `source` field —
+which precedence layer decided the plan:
+
+`request-header` | `routing-override` | `active-profile` | `auto-trigger` | `default` | `off`
+
+`mode` answers *what* compression runs; `source` answers *who* decided. The field is
+optional so Phase 1/2 callers and snapshots are unaffected. chatCore reads `plan.source`
+(+ `plan.mode`) to build the response header.
+
+### 3.3 Header parsing helper
+
+A new pure function in `open-sse/handlers/chatCore/headers.ts`, mirroring
+`isNoMemoryRequested`:
+
+```ts
+export function resolveCompressionHeader(
+  headers: Record<string, unknown> | Headers | null | undefined
+): string | null {
+  const value = (getHeaderValueCaseInsensitive(headers, "x-omniroute-compression") || "").trim();
+  return value || null;
+}
+```
+
+It returns the raw trimmed value (or `null`); the resolver owns interpretation and casing
+rules (so the single source of truth for "what a value means" stays in the resolver, with
+the parser only reading the wire).
+
+### 3.4 Threading
+
+chatCore reads the header from `clientRawRequest?.headers`, then passes it as a new
+`header?: string | null` argument (default `undefined`) through
+`selectCompressionStrategy` / `selectCompressionPlan` / `getEffectiveMode` ->
+`resolveBasePlan`, exactly the pattern Phase 2 used for `combos`. Phase 1/2 call sites that
+omit the argument are byte-for-byte unchanged.
+
+For the `<combo>` form, chatCore builds the named-combo map keyed by **both** combo `id` and
+lowercased `name` (`{ [c.id]: c.pipeline, [c.name.toLowerCase()]: c.pipeline }`). The
+active-profile lookup keys on `config.activeComboId` (always a UUID/slug `id`), so the added
+name keys are inert for it — one map serves both paths. The resolver matches `<combo>`
+**name-first** (per Decision A): it looks up the value lowercased (hitting a `name` key, or an
+already-lowercase `id`), then falls back to the value as-is (an exact `id`) —
+`combos[value.toLowerCase()] ?? combos[value]`. All combo `id`s are lowercase
+(`uuidv4()` hex or the `default-caveman` slug), so an exact id still resolves on the first
+lookup.
+
+### 3.5 Where the header logic lives
+
+The existing `headerToPlan` interpretation (`off` / `default` / `engine:<id>` / `<combo>`)
+is reused. `resolveBasePlan` evaluates the header **before** the routing-override branch.
+`default` routes to `deriveDefaultPlanFromConfig` (which already handles both
+`enginesExplicit` and legacy `defaultMode`), so `default` means "the Default profile" for
+every install type. The resolver remains **pure** — no `src/lib/db` import (enforced by the
+existing cycle/source guard).
+
+---
+
+## 4. Observability
+
+A new `compression` key in `OMNIROUTE_RESPONSE_HEADERS`
+(`src/shared/constants/headers.ts`) -> response header:
+
+```
+X-OmniRoute-Compression: <mode>; source=<source>
+```
+
+Examples: `aggressive; source=request-header`, `off; source=request-header`,
+`stacked; source=active-profile`, `lite; source=auto-trigger`, `off; source=off`.
+
+chatCore captures `{ mode, source }` from the compression resolution (computed early,
+~line 1530) into an outer-scope variable and injects the header when building
+`responseHeaders` (~line 4697), so it appears on both streaming and non-streaming
+responses. The header is informational only and never affects routing.
+
+---
+
+## 5. Error handling & safety
+
+- **Header absent / blank** -> `null`; behaviour is byte-identical to Phase 2.
+- **Unknown value** -> silent fall-through to normal resolution + a `COMPRESSION` debug log;
+  never a 4xx. The response header reflects the layer that actually won (e.g.
+  `source=auto-trigger`), not `request-header`.
+- **`engine:<id>` naming a disabled / unknown engine** -> fall-through (same rule as the
+  current `headerToPlan`: returns `null`).
+- **Gating:** the header is honored **unconditionally**, like `x-omniroute-no-memory`.
+  Rationale: it only affects the compression of the **client's own request**. The worst case
+  is a client opting *itself out* of compression (`off`), which increases only that client's
+  own upstream token count — there is no cross-tenant, security, or cost-shifting concern.
+
+---
+
+## 6. Components (units & responsibilities)
+
+| Unit | Responsibility | Depends on |
+|---|---|---|
+| `resolveCompressionHeader` (`chatCore/headers.ts`) | Read the raw header value off the wire. | `getHeaderValueCaseInsensitive` |
+| `resolveBasePlan` + `headerToPlan` (`strategySelector.ts` / `resolveCompressionPlan.ts`) | Interpret the value, evaluate header-first precedence, return `{ mode, stackedPipeline, source }`. | config, combos map (pure) |
+| `DerivedPlan.source` (`deriveDefaultPlan.ts` type) | Carry which layer decided. | — |
+| `OMNIROUTE_RESPONSE_HEADERS.compression` (`shared/constants/headers.ts`) | Name the response header. | — |
+| chatCore wiring (`chatCore.ts`) | Parse, thread `header`, build id+name combo map, capture `{mode,source}`, emit response header. | all of the above |
+
+---
+
+## 7. Testing
+
+- **Parser unit** (`headers.ts`): each value form, absent, blank, mixed casing, value with
+  surrounding whitespace -> correct raw/`null`.
+- **Resolver unit** (`strategySelector` / `resolveCompressionPlan`): each form resolves the
+  expected plan and `source`; header beats an active profile and a routing override;
+  unknown value falls through to normal resolution; a valid value bypasses auto-trigger on a
+  large prompt; `default` returns the derived Default for both `enginesExplicit` and legacy
+  installs; `<combo>` matches by name and by id.
+- **Integration / fetch-capture**: per-request precedence end-to-end (same config, header
+  present vs absent yields different applied plans) and the `X-OmniRoute-Compression`
+  response header value.
+- **Source guard**: the resolver still has no `src/lib/db` import.
+
+---
+
+## 8. Scope
+
+**In scope:** header parsing, top-of-precedence wiring, `source` on `DerivedPlan`, the
+response header, docs (`API_REFERENCE` / `COMPRESSION_GUIDE`), tests.
+
+**Out of scope (YAGNI):** bare mode names in the header (`lite`/`aggressive`/…); panel UI for
+the header; honoring the header on non-chat paths (`combo.ts` proactive-fallback, the
+preview route). The header is a chat-request feature.

--- a/docs/compression/2026-06-21-compression-phase3-request-header-plan.md
+++ b/docs/compression/2026-06-21-compression-phase3-request-header-plan.md
@@ -1,0 +1,730 @@
+---
+title: "Compression Phase 3: Per-Request Header — Implementation Plan"
+version: 3.8.33
+lastUpdated: 2026-06-21
+---
+
+# Compression Phase 3: Per-Request Header — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the `x-omniroute-compression` per-request header so a client can override the resolved compression plan for a single request, taking precedence over every operator-configured layer.
+
+**Architecture:** A pure header interpreter (`planFromHeader`) is evaluated at the top of the compression resolver (`resolveBasePlan` in `strategySelector.ts`); chatCore parses the header off the wire, threads it through the existing selector signature (the same way Phase 2 threaded `combos`), captures the resolved `{ mode, source }`, and emits an `X-OmniRoute-Compression` response header. The resolver stays pure (no DB import).
+
+**Tech Stack:** TypeScript, Node test runner (`node --import tsx/esm --test`), better-sqlite3 (combos store, read via chatCore only), Next.js handler (`open-sse/handlers/chatCore.ts`).
+
+**Spec:** `docs/compression/2026-06-21-compression-phase3-request-header-design.md`
+
+---
+
+## Key prior-art / facts (read before starting)
+
+- The resolver entry point is `resolveBasePlan` in `open-sse/services/compression/strategySelector.ts`. It already threads a `combos` map (Phase 2). Public selectors: `selectCompressionPlan` / `selectCompressionStrategy` / `getEffectiveMode`, signature ending in `..., combos = {}`.
+- `DerivedPlan` is defined in `open-sse/services/compression/deriveDefaultPlan.ts` as `{ mode: string; stackedPipeline: Array<{ engine: string; intensity?: string }> }`.
+- `open-sse/services/compression/resolveCompressionPlan.ts` carries a **dormant** header branch (`ctx.header` + private `headerToPlan`). No caller ever passes `header` (confirmed: the only `.header` refs in compression code are those lines; no test passes it). This plan **removes** that dormant branch so header interpretation has a single home.
+- Parsing precedent: `isNoMemoryRequested` in `open-sse/handlers/chatCore/headers.ts` (uses `getHeaderValueCaseInsensitive`). Tests for that module: `tests/unit/chatcore-headers.test.ts`.
+- A combo's `id` is a `uuidv4()` (or the seeded slug `default-caveman`); `name` has **no** UNIQUE constraint (migration 042). Header `<combo>` matches **name-first** (Decision A).
+- chatCore reads request headers from `clientRawRequest?.headers`. The compression block builds `namedCombos` (~line 1373) and calls `selectCompressionStrategy` (~line 1532) then `selectCompressionPlan` (~line 1601). Response headers are built at two sites: the non-streaming JSON path (`responseHeaders` at ~line 4570, after `attachOmniRouteMetaHeaders`) and the streaming path (`responseHeaders` at ~line 4697).
+- **Decision A:** `<combo>` matched name-first (lowercased), then exact id. **Decision B:** any valid header value bypasses auto-trigger.
+- **Boundary (implement as written):** the master switch is the hard gate — when `config.enabled` is false, the request is uncompressed regardless of the header (the header redirects among configured plans only when compression is enabled). A test asserts this.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `open-sse/services/compression/deriveDefaultPlan.ts` | `DerivedPlan` type + new `CompressionSource` union + optional `source`. | Modify |
+| `open-sse/services/compression/strategySelector.ts` | `planFromHeader` interpreter, header-first precedence in `resolveBasePlan`, `source` tagging, `formatCompressionMeta`, thread `header` through public selectors. | Modify |
+| `open-sse/services/compression/resolveCompressionPlan.ts` | Remove the dormant `header` branch + `headerToPlan` + `ResolveCtx.header`. | Modify |
+| `open-sse/handlers/chatCore/headers.ts` | `resolveCompressionHeader` parser. | Modify |
+| `src/shared/constants/headers.ts` | `compression` response-header name. | Modify |
+| `open-sse/handlers/chatCore.ts` | Parse header, add name keys to `namedCombos`, thread `header`, capture `{mode,source}`, emit response header at both sites. | Modify |
+| `tests/unit/compression/compression-header-dispatch.test.ts` | Resolver + `planFromHeader` + `source` + precedence + `formatCompressionMeta`. | Create |
+| `tests/unit/chatcore-headers.test.ts` | `resolveCompressionHeader` parsing. | Modify |
+| `docs/reference/API_REFERENCE.md`, `docs/compression/COMPRESSION_GUIDE.md` | Document the header. | Modify |
+| `config/quality/file-size-baseline.json` | Rebaseline chatCore if it crosses its pin. | Modify (if needed) |
+
+---
+
+## Task 1: Header interpreter, precedence, and `source` in the resolver
+
+**Files:**
+- Modify: `open-sse/services/compression/deriveDefaultPlan.ts`
+- Modify: `open-sse/services/compression/strategySelector.ts`
+- Modify: `open-sse/services/compression/resolveCompressionPlan.ts`
+- Test: `tests/unit/compression/compression-header-dispatch.test.ts` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/compression/compression-header-dispatch.test.ts`:
+
+```ts
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  selectCompressionStrategy,
+  selectCompressionPlan,
+  planFromHeader,
+  formatCompressionMeta,
+} from "../../../open-sse/services/compression/strategySelector.ts";
+import {
+  DEFAULT_COMPRESSION_CONFIG,
+  type CompressionConfig,
+} from "../../../open-sse/services/compression/types.ts";
+
+const combos = {
+  c1: [{ engine: "rtk", intensity: "standard" }, { engine: "caveman", intensity: "full" }],
+  "fast combo": [{ engine: "lite" }],
+};
+
+function cfg(overrides: Partial<CompressionConfig> = {}): CompressionConfig {
+  return { ...DEFAULT_COMPRESSION_CONFIG, enabled: true, ...overrides };
+}
+
+// header is the 7th positional arg of selectCompressionPlan/selectCompressionStrategy.
+function planWithHeader(config: CompressionConfig, header: string | null) {
+  return selectCompressionPlan(config, null, 0, undefined, undefined, combos, header);
+}
+
+describe("planFromHeader (Phase 3)", () => {
+  it("off => mode off, source request-header", () => {
+    const p = planFromHeader(cfg(), "off", combos);
+    assert.deepEqual(p, { mode: "off", stackedPipeline: [], source: "request-header" });
+  });
+
+  it("default => the panel-derived default, ignoring the active profile", () => {
+    const config = cfg({
+      activeComboId: "c1",
+      enginesExplicit: true,
+      engines: { rtk: { enabled: true } },
+    });
+    const p = planFromHeader(config, "default", combos);
+    assert.equal(p?.mode, "rtk"); // engines map default, NOT the c1 active profile
+    assert.equal(p?.source, "request-header");
+  });
+
+  it("engine:<id> => that single engine when enabled (case-insensitive)", () => {
+    const config = cfg({ enginesExplicit: true, engines: { rtk: { enabled: true } } });
+    assert.equal(planFromHeader(config, "engine:RTK", combos)?.mode, "rtk");
+  });
+
+  it("engine:<id> => null (fall-through) when the engine is disabled", () => {
+    const config = cfg({ engines: { rtk: { enabled: false } } });
+    assert.equal(planFromHeader(config, "engine:rtk", combos), null);
+  });
+
+  it("<combo> matches by name (case-insensitive) and by id", () => {
+    assert.deepEqual(planFromHeader(cfg(), "FAST COMBO", combos)?.stackedPipeline, combos["fast combo"]);
+    assert.deepEqual(planFromHeader(cfg(), "c1", combos)?.stackedPipeline, combos.c1);
+  });
+
+  it("unknown value => null (fall-through)", () => {
+    assert.equal(planFromHeader(cfg(), "nonsense", combos), null);
+  });
+});
+
+describe("header precedence in resolveBasePlan (Phase 3)", () => {
+  it("a valid header beats the active profile", () => {
+    const config = cfg({ activeComboId: "c1" });
+    assert.equal(planWithHeader(config, "off").mode, "off");
+    assert.equal(planWithHeader(config, "off").source, "request-header");
+  });
+
+  it("a valid header beats a routing-combo override", () => {
+    const config = cfg({ comboOverrides: { "route-x": "stacked" } });
+    const plan = selectCompressionPlan(config, "route-x", 0, undefined, undefined, combos, "off");
+    assert.equal(plan.mode, "off");
+    assert.equal(plan.source, "request-header");
+  });
+
+  it("a valid header bypasses auto-trigger (Decision B)", () => {
+    const config = cfg({
+      autoTriggerTokens: 1000,
+      autoTriggerMode: "aggressive",
+      enginesExplicit: true,
+      engines: { rtk: { enabled: true } },
+    });
+    // Large prompt would auto-escalate to aggressive; the header pins the panel default.
+    assert.equal(planWithHeader(config, "default").mode, "rtk");
+  });
+
+  it("an unknown header falls through to the normal resolution", () => {
+    const config = cfg({ activeComboId: "c1" });
+    const plan = planWithHeader(config, "bogus");
+    assert.equal(plan.mode, "stacked");
+    assert.equal(plan.source, "active-profile");
+  });
+
+  it("master-off beats the header (hard kill switch)", () => {
+    const config = cfg({ enabled: false, engines: { rtk: { enabled: true } } });
+    const plan = planWithHeader(config, "engine:rtk");
+    assert.equal(plan.mode, "off");
+    assert.equal(plan.source, "off");
+  });
+});
+
+describe("source on non-header paths", () => {
+  it("routing-override / active-profile / auto-trigger / default / off", () => {
+    assert.equal(
+      selectCompressionPlan(cfg({ comboOverrides: { r: "lite" } }), "r", 0, undefined, undefined, combos, null).source,
+      "routing-override"
+    );
+    assert.equal(planWithHeader(cfg({ activeComboId: "c1" }), null).source, "active-profile");
+    assert.equal(
+      planWithHeader(cfg({ autoTriggerTokens: 10, autoTriggerMode: "lite" }), null).source,
+      "auto-trigger"
+    );
+    assert.equal(
+      planWithHeader(cfg({ enginesExplicit: true, engines: { rtk: { enabled: true } } }), null).source,
+      "default"
+    );
+    assert.equal(planWithHeader(cfg({ enabled: false }), null).source, "off");
+  });
+});
+
+describe("formatCompressionMeta", () => {
+  it("renders '<mode>; source=<source>'", () => {
+    assert.equal(
+      formatCompressionMeta({ mode: "aggressive", stackedPipeline: [], source: "request-header" }),
+      "aggressive; source=request-header"
+    );
+    assert.equal(formatCompressionMeta({ mode: "off", stackedPipeline: [] }), "off; source=off");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `node --import tsx --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test --test-force-exit tests/unit/compression/compression-header-dispatch.test.ts`
+Expected: FAIL — `planFromHeader`/`formatCompressionMeta` are not exported yet (import error / not a function).
+
+- [ ] **Step 3: Add `CompressionSource` + `source` to `DerivedPlan`**
+
+In `open-sse/services/compression/deriveDefaultPlan.ts`, replace the `DerivedPlan` interface block:
+
+```ts
+export type CompressionSource =
+  | "request-header"
+  | "routing-override"
+  | "active-profile"
+  | "auto-trigger"
+  | "default"
+  | "off";
+
+export interface DerivedPlan {
+  mode: string;
+  stackedPipeline: Array<{ engine: string; intensity?: string }>;
+  /** Which precedence layer decided this plan (Phase 3 observability). Optional so
+   *  Phase 1/2 callers and snapshots are unaffected. */
+  source?: CompressionSource;
+}
+```
+
+(Leave the `deriveDefaultPlan` function body unchanged — it does not set `source`; the resolver tags it.)
+
+- [ ] **Step 4: Remove the dormant header branch from `resolveCompressionPlan.ts`**
+
+In `open-sse/services/compression/resolveCompressionPlan.ts`: delete the `header` field from `ResolveCtx`, delete the `// 1. header` block, and delete the private `headerToPlan` function. The file becomes:
+
+```ts
+import { deriveDefaultPlan, type DerivedPlan } from "./deriveDefaultPlan.ts";
+
+export interface ResolveCtx {
+  comboId?: string | null;
+  combos?: Record<string, Array<{ engine: string; intensity?: string }>>; // named combo pipelines by id
+}
+
+export function resolveCompressionPlan(config: any, ctx: ResolveCtx): DerivedPlan {
+  if (config?.enabled === false) return { mode: "off", stackedPipeline: [] };
+
+  // routing-combo override
+  const ov = ctx.comboId ? config?.comboOverrides?.[ctx.comboId] : undefined;
+  if (ov) return modeToPlan(ov, config);
+
+  // active named combo
+  if (config?.activeComboId && ctx.combos?.[config.activeComboId]) {
+    return { mode: "stacked", stackedPipeline: ctx.combos[config.activeComboId] };
+  }
+
+  // derived default
+  return deriveDefaultPlan(config?.engines ?? {}, config?.enabled !== false);
+}
+
+function modeToPlan(mode: string, config: any): DerivedPlan {
+  return mode === "stacked"
+    ? { mode: "stacked", stackedPipeline: config?.stackedPipeline ?? [] }
+    : { mode, stackedPipeline: [] };
+}
+```
+
+- [ ] **Step 5: Implement `planFromHeader`, `withSource`, header-first precedence, and `formatCompressionMeta` in `strategySelector.ts`**
+
+In `open-sse/services/compression/strategySelector.ts`:
+
+(a) Update the `DerivedPlan` import to also bring `CompressionSource`:
+
+```ts
+import { deriveDefaultPlan, type DerivedPlan, type CompressionSource } from "./deriveDefaultPlan.ts";
+```
+
+(b) Add these helpers (place them just above `resolveBasePlan`):
+
+```ts
+/** Tags a plan with the precedence layer that produced it (Phase 3 observability). */
+function withSource(plan: DerivedPlan, source: CompressionSource): DerivedPlan {
+  return { ...plan, source };
+}
+
+/**
+ * Interprets the `x-omniroute-compression` request header into a plan, or null when the
+ * value is unrecognized (caller falls through to normal resolution). Pure.
+ *   off            -> no compression
+ *   default        -> the panel-derived Default (ignores active profile / routing / auto-trigger)
+ *   engine:<id>    -> that single engine, when enabled in config.engines
+ *   <combo>        -> a named combo, matched name-first (lowercased) then exact id (Decision A)
+ */
+export function planFromHeader(
+  config: CompressionConfig,
+  header: string,
+  combos: NamedCombos
+): DerivedPlan | null {
+  const h = header.trim();
+  if (!h) return null;
+  const lower = h.toLowerCase();
+
+  if (lower === "off") return withSource({ mode: "off", stackedPipeline: [] }, "request-header");
+
+  if (lower === "default") {
+    // Empty combos + null comboId yields the pure panel default (no active-combo leak).
+    return withSource(deriveDefaultPlanFromConfig(config, null, {}), "request-header");
+  }
+
+  if (lower.startsWith("engine:")) {
+    const id = lower.slice("engine:".length);
+    const engine = config.engines?.[id];
+    return engine?.enabled
+      ? withSource(deriveDefaultPlan({ [id]: engine }, true), "request-header")
+      : null;
+  }
+
+  const combo = combos[lower] ?? combos[h];
+  return combo ? withSource({ mode: "stacked", stackedPipeline: combo }, "request-header") : null;
+}
+
+/** Renders the X-OmniRoute-Compression response header value. */
+export function formatCompressionMeta(plan: DerivedPlan): string {
+  return `${plan.mode}; source=${plan.source ?? "off"}`;
+}
+```
+
+(c) Add a `header` parameter to `resolveBasePlan` and tag every return with `withSource`:
+
+```ts
+function resolveBasePlan(
+  config: CompressionConfig,
+  comboId: string | null,
+  estimatedTokens: number,
+  combos: NamedCombos = {},
+  header: string | null = null
+): DerivedPlan {
+  if (!config.enabled) return withSource({ mode: "off", stackedPipeline: [] }, "off");
+
+  // Phase 3: an explicit, recognized header wins over every operator layer (Decision B).
+  // The master switch above is the hard kill: a header cannot turn compression on.
+  if (header) {
+    const fromHeader = planFromHeader(config, header, combos);
+    if (fromHeader) return fromHeader; // already tagged "request-header"
+  }
+
+  const comboMode = checkComboOverride(config, comboId);
+  if (comboMode) {
+    return withSource(resolveCompressionPlan(config, { comboId, combos }), "routing-override");
+  }
+
+  if (config.activeComboId && combos[config.activeComboId]) {
+    return withSource(
+      { mode: "stacked", stackedPipeline: combos[config.activeComboId] },
+      "active-profile"
+    );
+  }
+
+  if (shouldAutoTrigger(config, estimatedTokens)) {
+    const mode = config.autoTriggerMode ?? "lite";
+    return withSource(
+      mode === "stacked"
+        ? { mode, stackedPipeline: config.stackedPipeline ?? [] }
+        : { mode, stackedPipeline: [] },
+      "auto-trigger"
+    );
+  }
+
+  const plan = deriveDefaultPlanFromConfig(config, comboId, combos);
+  return withSource(plan, plan.mode === "off" ? "off" : "default");
+}
+```
+
+(d) Thread `header` through the public selectors (append as the last positional arg, default `null`), preserving `source` through the caching-aware adjustment:
+
+```ts
+export function getEffectiveMode(
+  config: CompressionConfig,
+  comboId: string | null,
+  estimatedTokens: number,
+  combos: NamedCombos = {},
+  header: string | null = null
+): CompressionMode {
+  return resolveBasePlan(config, comboId, estimatedTokens, combos, header).mode as CompressionMode;
+}
+
+export function selectCompressionPlan(
+  config: CompressionConfig,
+  comboId: string | null,
+  estimatedTokens: number,
+  body?: Record<string, unknown>,
+  context?: CachingDetectionContext,
+  combos: NamedCombos = {},
+  header: string | null = null
+): DerivedPlan {
+  const plan = resolveBasePlan(config, comboId, estimatedTokens, combos, header);
+  if (body) {
+    const ctx = detectCachingContext(body, context);
+    const cacheAware = getCacheAwareStrategy(plan.mode as CompressionMode, ctx);
+    return { ...plan, mode: cacheAware.strategy as CompressionMode }; // ...plan preserves source
+  }
+  return plan;
+}
+
+export function selectCompressionStrategy(
+  config: CompressionConfig,
+  comboId: string | null,
+  estimatedTokens: number,
+  body?: Record<string, unknown>,
+  context?: CachingDetectionContext,
+  combos: NamedCombos = {},
+  header: string | null = null
+): CompressionMode {
+  return selectCompressionPlan(config, comboId, estimatedTokens, body, context, combos, header)
+    .mode as CompressionMode;
+}
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `node --import tsx --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test --test-force-exit tests/unit/compression/compression-header-dispatch.test.ts`
+Expected: PASS (all cases).
+
+- [ ] **Step 7: Run the full compression suite to confirm no regression**
+
+Run: `node --import tsx --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test --test-force-exit "tests/unit/compression/**/*.test.ts"`
+Expected: PASS — the existing 774+ compression tests stay green (resolveCompressionPlan / strategySelector / active-combo dispatch unchanged in behavior for header-less callers).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add open-sse/services/compression/deriveDefaultPlan.ts \
+        open-sse/services/compression/strategySelector.ts \
+        open-sse/services/compression/resolveCompressionPlan.ts \
+        tests/unit/compression/compression-header-dispatch.test.ts
+git commit -m "feat(compression): header-first resolver + plan source (Phase 3 core)"
+```
+
+---
+
+## Task 2: `resolveCompressionHeader` parser
+
+**Files:**
+- Modify: `open-sse/handlers/chatCore/headers.ts`
+- Test: `tests/unit/chatcore-headers.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/unit/chatcore-headers.test.ts` (keep existing imports; add `resolveCompressionHeader` to the import from `../../open-sse/handlers/chatCore/headers.ts`):
+
+```ts
+import { resolveCompressionHeader } from "../../open-sse/handlers/chatCore/headers.ts";
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+describe("resolveCompressionHeader", () => {
+  it("reads the raw value case-insensitively and trims it", () => {
+    assert.equal(resolveCompressionHeader({ "x-omniroute-compression": "  engine:rtk " }), "engine:rtk");
+    assert.equal(resolveCompressionHeader(new Headers({ "X-OmniRoute-Compression": "off" })), "off");
+  });
+
+  it("returns null when absent or blank", () => {
+    assert.equal(resolveCompressionHeader({}), null);
+    assert.equal(resolveCompressionHeader({ "x-omniroute-compression": "   " }), null);
+    assert.equal(resolveCompressionHeader(null), null);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `node --import tsx --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test --test-force-exit tests/unit/chatcore-headers.test.ts`
+Expected: FAIL — `resolveCompressionHeader` is not exported.
+
+- [ ] **Step 3: Implement the parser**
+
+Append to `open-sse/handlers/chatCore/headers.ts`:
+
+```ts
+/**
+ * Per-request compression override via the `x-omniroute-compression` header. Mirrors the
+ * `x-omniroute-no-memory` convention (#4290). Returns the raw trimmed value, or null when
+ * absent/blank. The resolver (planFromHeader) owns interpretation and casing rules; this
+ * helper only reads the wire.
+ */
+export function resolveCompressionHeader(
+  headers: Record<string, unknown> | Headers | null | undefined
+): string | null {
+  const value = (getHeaderValueCaseInsensitive(headers, "x-omniroute-compression") || "").trim();
+  return value || null;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `node --import tsx --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test --test-force-exit tests/unit/chatcore-headers.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add open-sse/handlers/chatCore/headers.ts tests/unit/chatcore-headers.test.ts
+git commit -m "feat(compression): resolveCompressionHeader parser (Phase 3)"
+```
+
+---
+
+## Task 3: chatCore wiring + response header
+
+**Files:**
+- Modify: `src/shared/constants/headers.ts`
+- Modify: `open-sse/handlers/chatCore.ts`
+
+- [ ] **Step 1: Add the response-header name constant**
+
+In `src/shared/constants/headers.ts`, add the `compression` entry to `OMNIROUTE_RESPONSE_HEADERS` (alphabetical, after `cacheHit`):
+
+```ts
+  cacheHit: "X-OmniRoute-Cache-Hit",
+  compression: "X-OmniRoute-Compression",
+  costSaved: "X-OmniRoute-Cost-Saved",
+```
+
+- [ ] **Step 2: Import the parser and declare the capture variable**
+
+In `open-sse/handlers/chatCore.ts`, line 7, add `resolveCompressionHeader` to the existing import from `./chatCore/headers.ts`:
+
+```ts
+import { getHeaderValueCaseInsensitive, isNoMemoryRequested, resolveCompressionHeader } from "./chatCore/headers.ts";
+```
+
+Near the other compression-scoped `let`s (~line 1321, beside `let cavemanOutputModeApplied = false;`), add:
+
+```ts
+  let compressionResponseMeta: string | null = null;
+```
+
+- [ ] **Step 3: Parse the header and add name keys to the combos map**
+
+In the compression block, replace the `namedCombos` build (~line 1373) so it keys by **both** id and lowercased name, and parse the header right after:
+
+```ts
+      let namedCombos: Record<string, CompressionPipelineStep[]> = {};
+      try {
+        const { listCompressionCombos } = await import("../../src/lib/db/compressionCombos.ts");
+        namedCombos = Object.fromEntries(
+          listCompressionCombos().flatMap((c) => [
+            [c.id, c.pipeline],
+            [c.name.toLowerCase(), c.pipeline],
+          ])
+        );
+      } catch (err) {
+        log?.debug?.(
+          "COMPRESSION",
+          "Named combos load skipped: " + (err instanceof Error ? err.message : String(err))
+        );
+      }
+      // Phase 3: per-request override. Unknown values fall through in the resolver (never error).
+      const compressionHeader = resolveCompressionHeader(clientRawRequest?.headers ?? null);
+      if (compressionHeader) {
+        log?.debug?.("COMPRESSION", `x-omniroute-compression header: ${compressionHeader}`);
+      }
+```
+
+(The active-profile lookup keys on `config.activeComboId`, always a UUID/slug id, so the added name keys are inert for it — one map serves both paths. A combo named `off`/`default` cannot be selected by name because the keyword branches run first; note this in the docs.)
+
+- [ ] **Step 4: Thread the header into both selector calls**
+
+Append `compressionHeader` as the last argument to `selectCompressionStrategy` (~line 1532) and `selectCompressionPlan` (~line 1601):
+
+```ts
+      const modeBeforeOutputTransform = selectCompressionStrategy(
+        config,
+        compressionComboKey,
+        estimatedTokens,
+        body as Record<string, unknown>,
+        { provider, targetFormat, model: effectiveModel },
+        namedCombos,
+        compressionHeader
+      );
+```
+
+```ts
+      const compressionPlan = selectCompressionPlan(
+        config,
+        compressionComboKey,
+        estimatedTokens,
+        compressionInputBody,
+        { provider, targetFormat, model: effectiveModel },
+        namedCombos,
+        compressionHeader
+      );
+```
+
+- [ ] **Step 5: Capture the resolved meta**
+
+Immediately after `const mode = compressionPlan.mode as CompressionConfig["defaultMode"];` (~line 1609), add (importing `formatCompressionMeta` alongside the other strategySelector imports destructured at ~line 1349):
+
+```ts
+      compressionResponseMeta = formatCompressionMeta(compressionPlan);
+```
+
+And add `formatCompressionMeta` to the destructured import from `../services/compression/strategySelector.ts` (~line 1349):
+
+```ts
+        formatCompressionMeta,
+```
+
+- [ ] **Step 6: Emit the response header at both build sites**
+
+In the non-streaming JSON path, right after the `attachOmniRouteMetaHeaders(responseHeaders, { ... });` call (~line 4582), add:
+
+```ts
+    if (compressionResponseMeta) {
+      responseHeaders[OMNIROUTE_RESPONSE_HEADERS.compression] = compressionResponseMeta;
+    }
+```
+
+In the streaming path, right after the `responseHeaders` object literal closes (the `};` after `"x-omniroute-request-id": pendingRequestId,`, ~line 4708), add:
+
+```ts
+  if (compressionResponseMeta) {
+    responseHeaders[OMNIROUTE_RESPONSE_HEADERS.compression] = compressionResponseMeta;
+  }
+```
+
+- [ ] **Step 7: Typecheck + cycle/source guard**
+
+Run: `npm run typecheck:core`
+Expected: exit 0.
+
+Run: `npm run check:cycles`
+Expected: exit 0 — the resolver still has no `src/lib/db` import (header logic lives in `strategySelector.ts`, name-key map built in chatCore).
+
+- [ ] **Step 8: Run the compression suite again (no regression from wiring)**
+
+Run: `node --import tsx --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test --test-force-exit "tests/unit/compression/**/*.test.ts"`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/shared/constants/headers.ts open-sse/handlers/chatCore.ts
+git commit -m "feat(compression): wire x-omniroute-compression header + response header (Phase 3)"
+```
+
+---
+
+## Task 4: Docs + file-size + full validation
+
+**Files:**
+- Modify: `docs/reference/API_REFERENCE.md`
+- Modify: `docs/compression/COMPRESSION_GUIDE.md`
+- Modify (if needed): `config/quality/file-size-baseline.json`
+
+- [ ] **Step 1: Document the header (API reference)**
+
+In `docs/reference/API_REFERENCE.md`, near the `x-omniroute-no-memory` documentation, add a section:
+
+````markdown
+### `x-omniroute-compression`
+
+Per-request override of the compression plan. Highest precedence — beats the routing-combo
+override, the active profile, auto-trigger, and the panel Default. Values:
+
+| Value | Effect |
+|-------|--------|
+| `off` | No compression for this request. |
+| `default` | The panel-derived Default profile (ignores the active profile). |
+| `engine:<id>` | A single engine when enabled, e.g. `engine:rtk`. |
+| `<combo>` | A named combo, matched by name (case-insensitive) first, then by id. |
+
+Unknown values are ignored (the request is never rejected). The applied plan is echoed in the
+`X-OmniRoute-Compression: <mode>; source=<source>` response header. The master compression
+switch is a hard gate: when compression is disabled globally, this header cannot enable it.
+````
+
+- [ ] **Step 2: Document the header (compression guide)**
+
+In `docs/compression/COMPRESSION_GUIDE.md`, add a short "Per-request override" subsection mirroring the table above (one paragraph + the value table). Keep all angle-bracket tokens (`engine:<id>`, `<combo>`, `<mode>`, `<source>`) inside backticks or fenced blocks (the docs are MDX-compiled).
+
+- [ ] **Step 3: Validate MDX**
+
+Run: `npx fumadocs-mdx`
+Expected: `[MDX] generated files in ...ms` with no error.
+
+- [ ] **Step 4: Reconcile the file-size baseline if chatCore crossed its pin**
+
+Run: `npm run check:file-size`
+Expected: PASS. If it reports `chatCore.ts: <actual> > <frozen>`, update `config/quality/file-size-baseline.json`: set the `open-sse/handlers/chatCore.ts` frozen value to the reported `<actual>` and add a justification key:
+
+```json
+  "_rebaseline_2026_06_21_phase3_request_header": "Compression Phase 3 (x-omniroute-compression per-request header) own growth: chatCore.ts <frozen>-><actual> at the existing compression-dispatch chokepoint — parse the header (resolveCompressionHeader), add lowercased-name keys to the namedCombos map, thread it as the new last arg to selectCompressionStrategy + selectCompressionPlan, capture formatCompressionMeta(compressionPlan) into compressionResponseMeta, and emit X-OmniRoute-Compression at the two response-header build sites. The resolver stays pure (planFromHeader + source live in open-sse/services/compression/strategySelector.ts, <cap). Cohesive wiring at the existing chokepoint, mirroring the Phase 2 rebaseline; not extractable without hiding the dispatch boundary. Structural shrink of chatCore.ts tracked in #3501. Covered by tests/unit/compression/compression-header-dispatch.test.ts + tests/unit/chatcore-headers.test.ts.",
+```
+
+- [ ] **Step 5: Run the full validation suite**
+
+Run each and confirm exit 0 / green:
+- `npm run typecheck:core`
+- `npm run lint`
+- `npm run check:cycles`
+- `npm run check:file-size`
+- `node --import tsx --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test --test-force-exit "tests/unit/compression/**/*.test.ts"` (compression subset) and `tests/unit/chatcore-headers.test.ts`
+- `npm run test:unit` (full unit suite — confirms no cross-suite regression)
+
+Expected: all green. Fix any red before proceeding (do not weaken assertions to pass).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/reference/API_REFERENCE.md docs/compression/COMPRESSION_GUIDE.md config/quality/file-size-baseline.json
+git commit -m "docs(compression): document x-omniroute-compression header + file-size reconcile (Phase 3)"
+```
+
+---
+
+## Self-Review (run by the author after writing)
+
+**1. Spec coverage**
+- §2 contract (off/default/engine/combo, unknown→ignore) → Task 1 `planFromHeader` + tests. ✓
+- Decision A (name-first combo) → Task 1 `planFromHeader` `combos[lower] ?? combos[h]` + Task 3 name-key map + test. ✓
+- Decision B (bypass auto-trigger) → Task 1 header-first in `resolveBasePlan` + test. ✓
+- §3.1 precedence (header at top) → Task 1 + precedence tests (beats active profile, routing override). ✓
+- §3.2 `source` on `DerivedPlan` → Task 1 `CompressionSource` + `withSource` + tests. ✓
+- §3.3 parser → Task 2. ✓
+- §3.4 threading + id+name map → Task 1 (signatures) + Task 3 (chatCore). ✓
+- §4 response header → Task 3 (constant + two sites) + `formatCompressionMeta` test. ✓
+- §5 error handling (unknown→fall-through; disabled engine→fall-through; unconditional gating; master-off boundary) → Task 1 tests. ✓
+- §7 testing (parser, resolver, precedence, source guard) → Tasks 1, 2; source guard via `check:cycles` in Task 3/4. ✓
+- §8 scope (no bare modes, no UI, chat-only) → respected; `planFromHeader` rejects bare mode names (they fall through), no UI/non-chat files touched. ✓
+
+**2. Placeholder scan:** none — every code step shows full code; commands have expected output.
+
+**3. Type consistency:** `DerivedPlan`/`CompressionSource` defined in Task 1 Step 3, imported in Step 5; `planFromHeader(config, header, combos)` / `formatCompressionMeta(plan)` signatures identical across Task 1 tests, implementation, and Task 3 usage; `resolveCompressionHeader(headers)` identical in Task 2 and Task 3; `header` appended as the same final positional arg in `getEffectiveMode`/`selectCompressionPlan`/`selectCompressionStrategy`. ✓
+
+**Note for the implementer:** `typecheck:core`, `check:cycles`, `check:file-size`, and `lint` are existing `package.json` scripts. There is **no** `test:compression` script — run the compression subset directly with the node test runner (`node --import tsx --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test --test-force-exit "tests/unit/compression/**/*.test.ts"`), or run the whole unit suite with `npm run test:unit`. Confirm any other script name in `package.json` before running.

--- a/docs/compression/COMPRESSION_GUIDE.md
+++ b/docs/compression/COMPRESSION_GUIDE.md
@@ -188,6 +188,25 @@ Combo: "free-forever"
 This lets you use stacked compression on free/coding providers while keeping lite mode on paid
 subscriptions.
 
+### Per-request override
+
+Send the `x-omniroute-compression` request header to override the compression plan for a single
+request. It has the highest precedence — it beats the routing-combo override, the active profile,
+auto-trigger, and the panel Default. Unknown values are ignored (the request is never rejected) and
+the global master switch still gates everything: when compression is off globally, the header cannot
+turn it on. Values:
+
+| Value | Effect |
+|-------|--------|
+| `off` | No compression for this request. |
+| `default` | The panel-derived Default profile (ignores the active profile). |
+| `engine:<id>` | A single engine when enabled, e.g. `engine:rtk`. |
+| `<combo>` | A named combo, matched by name (case-insensitive) first, then by id. |
+
+The applied plan is echoed back in the `X-OmniRoute-Compression: <mode>; source=<source>` response
+header, where `<source>` is one of `request-header`, `routing-override`, `active-profile`,
+`auto-trigger`, `default`, or `off`.
+
 ### API
 
 ```bash

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -83,6 +83,32 @@ Content-Type: application/json
 
 > **Cache-hit cost semantics:** on a semantic-cache HIT (`X-OmniRoute-Cache-Hit: true`) no upstream call is made, so `X-OmniRoute-Response-Cost` is `0.0000000000` (the **incremental** cost of serving the hit). The original/would-have-been cost is reported separately in `X-OmniRoute-Cost-Saved`. Billing consumers should sum `X-OmniRoute-Response-Cost` (hits cost nothing); cache analytics can aggregate `X-OmniRoute-Cost-Saved`.
 
+### `x-omniroute-compression`
+
+Per-request override of the compression plan. Highest precedence — beats the routing-combo
+override, the active profile, auto-trigger, and the panel Default. Values:
+
+| Value | Effect |
+|-------|--------|
+| `off` | No compression for this request. |
+| `default` | The panel-derived Default profile (ignores the active profile). |
+| `engine:<id>` | A single engine when enabled, e.g. `engine:rtk`. |
+| `<combo>` | A named combo, matched by name (case-insensitive) first, then by id. |
+
+Notes:
+- Unknown values are ignored (the request is never rejected); resolution falls through to the normal operator precedence.
+- If multiple combos share a name, pass the combo **id** for a deterministic match.
+- A combo whose name is `off` or `default` cannot be selected by name (those keywords are interpreted first); reference such a combo by its id.
+- The master compression switch is a hard gate: when compression is disabled globally, this header cannot enable it.
+
+The applied plan is echoed back in the response header:
+
+```
+X-OmniRoute-Compression: <mode>; source=<source>
+```
+
+where `<source>` is one of `request-header`, `routing-override`, `active-profile`, `auto-trigger`, `default`, or `off`.
+
 ---
 
 ## Embeddings

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -7,7 +7,11 @@ import { checkIdempotencyCache } from "./chatCore/idempotency.ts";
 import { checkSemanticCache } from "./chatCore/semanticCache.ts";
 import { sanitizeChatRequestBody } from "./chatCore/sanitization.ts";
 import { cloneBoundedChatLogPayload, truncateForLog } from "./chatCore/logTruncation.ts";
-import { getHeaderValueCaseInsensitive, isNoMemoryRequested, resolveCompressionHeader } from "./chatCore/headers.ts";
+import {
+  getHeaderValueCaseInsensitive,
+  isNoMemoryRequested,
+  resolveCompressionHeader,
+} from "./chatCore/headers.ts";
 import { markCodexScopeRateLimited } from "./chatCore/codexFailover.ts";
 import { getCombosCached, getUpstreamProxyConfigCached } from "./chatCore/comboContextCache.ts";
 export { clearCombosCache, clearUpstreamProxyConfigCache } from "./chatCore/comboContextCache.ts";
@@ -163,10 +167,7 @@ import {
   normalizeExecutorResult,
   executeWithUpstreamStartTimeout,
 } from "./chatCore/upstreamTimeouts.ts";
-import {
-  getModelNormalizeToolCallId,
-  getModelPreserveOpenAIDeveloperRole,
-} from "@/lib/localDb";
+import { getModelNormalizeToolCallId, getModelPreserveOpenAIDeveloperRole } from "@/lib/localDb";
 import { getProviderCredentials, extractSessionAffinityKey } from "@/sse/services/auth";
 import { deleteSessionAccountAffinity } from "@/lib/db/sessionAccountAffinity";
 import { getExecutor } from "../executors/index.ts";
@@ -903,9 +904,7 @@ export async function handleChatCore({
   // field instead of the upstream model, so strict clients (Claude Desktop) that validate
   // response.model === request.model stop rejecting alias/combo requests with a 401.
   const echoModel =
-    settings.echoRequestedModelName === true &&
-    typeof requestedModel === "string" &&
-    requestedModel
+    settings.echoRequestedModelName === true && typeof requestedModel === "string" && requestedModel
       ? requestedModel
       : null;
   const detailedLoggingEnabled =
@@ -1236,6 +1235,7 @@ export async function handleChatCore({
         applyCompressionAsync,
         resolveCacheAwareConfig,
         formatCompressionMeta,
+        buildNamedComboLookup,
       } = await import("../services/compression/strategySelector.ts");
       const { trackCompressionStats } = await import("../services/compression/stats.ts");
       let config: CompressionConfig = compressionSettings ?? {
@@ -1406,12 +1406,7 @@ export async function handleChatCore({
       let namedCombos: Record<string, CompressionPipelineStep[]> = {};
       try {
         const { listCompressionCombos } = await import("../../src/lib/db/compressionCombos.ts");
-        namedCombos = Object.fromEntries(
-          listCompressionCombos().flatMap((c) => [
-            [c.id, c.pipeline],
-            [c.name.toLowerCase(), c.pipeline],
-          ])
-        );
+        namedCombos = buildNamedComboLookup(listCompressionCombos());
       } catch (err) {
         log?.debug?.(
           "COMPRESSION",
@@ -3335,17 +3330,20 @@ export async function handleChatCore({
         ? 499
         : error.name === "TimeoutError" || error.name === "BodyTimeoutError"
           ? HTTP_STATUS.GATEWAY_TIMEOUT
-          : (error.status && typeof error.status === "number") ? error.status
-          : HTTP_STATUS.BAD_GATEWAY;
+          : error.status && typeof error.status === "number"
+            ? error.status
+            : HTTP_STATUS.BAD_GATEWAY;
     const failureMessage =
       error.name === "AbortError"
         ? "Request aborted"
         : formatProviderError(error, provider, model, failureStatus);
     const upstreamErrorCode = getUpstreamErrorIdentifier(error);
     const upstreamErrorType =
-      upstreamErrorCode === ANTIGRAVITY_PRE_RESPONSE_TIMEOUT_CODE ? "upstream_timeout"
-      : failureStatus === 401 ? "authentication_error"
-      : undefined;
+      upstreamErrorCode === ANTIGRAVITY_PRE_RESPONSE_TIMEOUT_CODE
+        ? "upstream_timeout"
+        : failureStatus === 401
+          ? "authentication_error"
+          : undefined;
     appendRequestLog({
       model,
       provider,

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -7,7 +7,7 @@ import { checkIdempotencyCache } from "./chatCore/idempotency.ts";
 import { checkSemanticCache } from "./chatCore/semanticCache.ts";
 import { sanitizeChatRequestBody } from "./chatCore/sanitization.ts";
 import { cloneBoundedChatLogPayload, truncateForLog } from "./chatCore/logTruncation.ts";
-import { getHeaderValueCaseInsensitive, isNoMemoryRequested } from "./chatCore/headers.ts";
+import { getHeaderValueCaseInsensitive, isNoMemoryRequested, resolveCompressionHeader } from "./chatCore/headers.ts";
 import { markCodexScopeRateLimited } from "./chatCore/codexFailover.ts";
 import { getCombosCached, getUpstreamProxyConfigCached } from "./chatCore/comboContextCache.ts";
 export { clearCombosCache, clearUpstreamProxyConfigCache } from "./chatCore/comboContextCache.ts";
@@ -1203,6 +1203,7 @@ export async function handleChatCore({
   let cavemanOutputModeApplied = false;
   let cavemanOutputModeIntensity: string | null = null;
   let preCompressionBody: typeof body | null = null;
+  let compressionResponseMeta: string | null = null;
   // Delegated Context Editing (Claude only): captured at the canonical compression
   // settings read below, then threaded to executor.execute() further down. Lives at
   // function scope because the read happens inside the per-message compression block.
@@ -1234,6 +1235,7 @@ export async function handleChatCore({
         activeComboResolves,
         applyCompressionAsync,
         resolveCacheAwareConfig,
+        formatCompressionMeta,
       } = await import("../services/compression/strategySelector.ts");
       const { trackCompressionStats } = await import("../services/compression/stats.ts");
       let config: CompressionConfig = compressionSettings ?? {
@@ -1404,12 +1406,22 @@ export async function handleChatCore({
       let namedCombos: Record<string, CompressionPipelineStep[]> = {};
       try {
         const { listCompressionCombos } = await import("../../src/lib/db/compressionCombos.ts");
-        namedCombos = Object.fromEntries(listCompressionCombos().map((c) => [c.id, c.pipeline]));
+        namedCombos = Object.fromEntries(
+          listCompressionCombos().flatMap((c) => [
+            [c.id, c.pipeline],
+            [c.name.toLowerCase(), c.pipeline],
+          ])
+        );
       } catch (err) {
         log?.debug?.(
           "COMPRESSION",
           "Named combos load skipped: " + (err instanceof Error ? err.message : String(err))
         );
+      }
+      // Phase 3: per-request override. Unknown values fall through in the resolver (never error).
+      const compressionHeader = resolveCompressionHeader(clientRawRequest?.headers ?? null);
+      if (compressionHeader) {
+        log?.debug?.("COMPRESSION", `x-omniroute-compression header: ${compressionHeader}`);
       }
       const modeBeforeOutputTransform = selectCompressionStrategy(
         config,
@@ -1417,7 +1429,8 @@ export async function handleChatCore({
         estimatedTokens,
         body as Record<string, unknown>,
         { provider, targetFormat, model: effectiveModel },
-        namedCombos
+        namedCombos,
+        compressionHeader
       );
       if (
         modeBeforeOutputTransform === "stacked" &&
@@ -1486,9 +1499,11 @@ export async function handleChatCore({
         estimatedTokens,
         compressionInputBody,
         { provider, targetFormat, model: effectiveModel },
-        namedCombos
+        namedCombos,
+        compressionHeader
       );
       const mode = compressionPlan.mode as CompressionConfig["defaultMode"];
+      compressionResponseMeta = formatCompressionMeta(compressionPlan);
       // When the per-engine toggle map derives a stacked pipeline (and no named/routing
       // combo already set config.stackedPipeline), feed that derived pipeline through so
       // applyCompressionAsync (which reads config.stackedPipeline for stacked mode) runs the
@@ -4462,6 +4477,9 @@ export async function handleChatCore({
       costUsd: estimatedCost,
       requestId: skillRequestId,
     });
+    if (compressionResponseMeta) {
+      responseHeaders[OMNIROUTE_RESPONSE_HEADERS.compression] = compressionResponseMeta;
+    }
     // #1311: echo the requested alias/combo name in the non-streaming response model.
     if (echoModel) echoModelInObject(translatedResponse, echoModel);
     return {
@@ -4587,6 +4605,9 @@ export async function handleChatCore({
     }),
     "x-omniroute-request-id": pendingRequestId,
   };
+  if (compressionResponseMeta) {
+    responseHeaders[OMNIROUTE_RESPONSE_HEADERS.compression] = compressionResponseMeta;
+  }
 
   // Create transform stream with logger for streaming response
   let transformStream;

--- a/open-sse/handlers/chatCore/headers.ts
+++ b/open-sse/handlers/chatCore/headers.ts
@@ -31,3 +31,16 @@ export function isNoMemoryRequested(
     .toLowerCase();
   return value === "true" || value === "1" || value === "yes";
 }
+
+/**
+ * Per-request compression override via the `x-omniroute-compression` header. Mirrors the
+ * `x-omniroute-no-memory` convention (#4290). Returns the raw trimmed value, or null when
+ * absent/blank. The resolver (planFromHeader) owns interpretation and casing rules; this
+ * helper only reads the wire.
+ */
+export function resolveCompressionHeader(
+  headers: Record<string, unknown> | Headers | null | undefined
+): string | null {
+  const value = (getHeaderValueCaseInsensitive(headers, "x-omniroute-compression") || "").trim();
+  return value || null;
+}

--- a/open-sse/services/compression/deriveDefaultPlan.ts
+++ b/open-sse/services/compression/deriveDefaultPlan.ts
@@ -10,9 +10,20 @@ const SINGLE_MODE_OF: Record<string, string> = {
   rtk: "rtk",
 };
 
+export type CompressionSource =
+  | "request-header"
+  | "routing-override"
+  | "active-profile"
+  | "auto-trigger"
+  | "default"
+  | "off";
+
 export interface DerivedPlan {
   mode: string;
   stackedPipeline: Array<{ engine: string; intensity?: string }>;
+  /** Which precedence layer decided this plan (Phase 3 observability). Optional so
+   *  Phase 1/2 callers and snapshots are unaffected. */
+  source?: CompressionSource;
 }
 
 /**

--- a/open-sse/services/compression/planResolution.ts
+++ b/open-sse/services/compression/planResolution.ts
@@ -1,6 +1,10 @@
 import type { CompressionConfig, CompressionPipelineStep } from "./types.ts";
 import { resolveCompressionPlan } from "./resolveCompressionPlan.ts";
-import { deriveDefaultPlan, type DerivedPlan, type CompressionSource } from "./deriveDefaultPlan.ts";
+import {
+  deriveDefaultPlan,
+  type DerivedPlan,
+  type CompressionSource,
+} from "./deriveDefaultPlan.ts";
 
 /** Named-combo map: combo id → its stacked pipeline (operator-defined profiles). */
 type NamedCombos = Record<string, CompressionPipelineStep[]>;
@@ -35,7 +39,7 @@ export function planFromHeader(
   }
 
   if (lower.startsWith("engine:")) {
-    const id = lower.slice("engine:".length);
+    const id = lower.slice("engine:".length).trim();
     const engine = config.engines?.[id];
     return engine?.enabled
       ? withSource(deriveDefaultPlan({ [id]: engine }, true), "request-header")
@@ -49,6 +53,25 @@ export function planFromHeader(
 /** Renders the X-OmniRoute-Compression response header value. */
 export function formatCompressionMeta(plan: DerivedPlan): string {
   return `${plan.mode}; source=${plan.source ?? "off"}`;
+}
+
+/**
+ * Builds the named-combo lookup keyed by BOTH combo id and lowercased (trimmed) name, so the
+ * `<combo>` header form can match by either. A combo with a blank/whitespace/missing name
+ * contributes only its id key — a blank name would otherwise register a useless "" key, and a
+ * single malformed row must not throw and disable the whole map (`name` is NOT NULL in the DB
+ * but may be an empty string). Pure.
+ */
+export function buildNamedComboLookup(
+  combos: Array<{ id: string; name?: string | null; pipeline: CompressionPipelineStep[] }>
+): NamedCombos {
+  const map: NamedCombos = {};
+  for (const c of combos) {
+    map[c.id] = c.pipeline;
+    const name = c.name?.trim();
+    if (name) map[name.toLowerCase()] = c.pipeline;
+  }
+  return map;
 }
 
 /**

--- a/open-sse/services/compression/planResolution.ts
+++ b/open-sse/services/compression/planResolution.ts
@@ -1,0 +1,83 @@
+import type { CompressionConfig, CompressionPipelineStep } from "./types.ts";
+import { resolveCompressionPlan } from "./resolveCompressionPlan.ts";
+import { deriveDefaultPlan, type DerivedPlan, type CompressionSource } from "./deriveDefaultPlan.ts";
+
+/** Named-combo map: combo id → its stacked pipeline (operator-defined profiles). */
+type NamedCombos = Record<string, CompressionPipelineStep[]>;
+
+/** Tags a plan with the precedence layer that produced it (Phase 3 observability). */
+export function withSource(plan: DerivedPlan, source: CompressionSource): DerivedPlan {
+  return { ...plan, source };
+}
+
+/**
+ * Interprets the `x-omniroute-compression` request header into a plan, or null when the
+ * value is unrecognized (caller falls through to normal resolution). Pure.
+ *   off            -> no compression
+ *   default        -> the panel-derived Default (ignores active profile / routing / auto-trigger)
+ *   engine:<id>    -> that single engine, when enabled in config.engines
+ *   <combo>        -> a named combo, matched name-first (lowercased) then exact id (Decision A)
+ */
+export function planFromHeader(
+  config: CompressionConfig,
+  header: string,
+  combos: NamedCombos
+): DerivedPlan | null {
+  const h = header.trim();
+  if (!h) return null;
+  const lower = h.toLowerCase();
+
+  if (lower === "off") return withSource({ mode: "off", stackedPipeline: [] }, "request-header");
+
+  if (lower === "default") {
+    // Empty combos + null comboId yields the pure panel default (no active-combo leak).
+    return withSource(deriveDefaultPlanFromConfig(config, null, {}), "request-header");
+  }
+
+  if (lower.startsWith("engine:")) {
+    const id = lower.slice("engine:".length);
+    const engine = config.engines?.[id];
+    return engine?.enabled
+      ? withSource(deriveDefaultPlan({ [id]: engine }, true), "request-header")
+      : null;
+  }
+
+  const combo = combos[lower] ?? combos[h];
+  return combo ? withSource({ mode: "stacked", stackedPipeline: combo }, "request-header") : null;
+}
+
+/** Renders the X-OmniRoute-Compression response header value. */
+export function formatCompressionMeta(plan: DerivedPlan): string {
+  return `${plan.mode}; source=${plan.source ?? "off"}`;
+}
+
+/**
+ * Derived-default step. The per-engine toggle map drives the default ONLY when it was
+ * EXPLICITLY configured via the panel (a stored `engines` row — `config.enginesExplicit`).
+ * For legacy installs the map is backfilled for DISPLAY only (so the panel shows current
+ * state); dispatch falls back to the historical `config.defaultMode` so behaviour is
+ * byte-for-byte preserved until the operator opts into the panel by saving. This avoids a
+ * silent behaviour change for installs whose backfilled engine flags don't exactly match
+ * their old defaultMode.
+ */
+export function deriveDefaultPlanFromConfig(
+  config: CompressionConfig,
+  comboId: string | null,
+  combos: NamedCombos = {}
+): DerivedPlan {
+  if (config.enginesExplicit) {
+    // Panel-configured: the engines map (via the resolver, which stays header/active-combo
+    // aware for Phases 2-3) is authoritative — including an explicit "everything off".
+    return resolveCompressionPlan(config, { comboId, combos });
+  }
+
+  // Legacy path: defaultMode carries the effective mode (the engines map is display-only here).
+  const legacyMode = config.defaultMode;
+  if (legacyMode && legacyMode !== "off") {
+    return legacyMode === "stacked"
+      ? { mode: legacyMode, stackedPipeline: config.stackedPipeline ?? [] }
+      : { mode: legacyMode, stackedPipeline: [] };
+  }
+
+  return { mode: "off", stackedPipeline: [] };
+}

--- a/open-sse/services/compression/resolveCompressionPlan.ts
+++ b/open-sse/services/compression/resolveCompressionPlan.ts
@@ -2,32 +2,22 @@ import { deriveDefaultPlan, type DerivedPlan } from "./deriveDefaultPlan.ts";
 
 export interface ResolveCtx {
   comboId?: string | null;
-  header?: string | null; // x-omniroute-compression (Phase 3 parses+passes; Phase 1 callers pass undefined)
   combos?: Record<string, Array<{ engine: string; intensity?: string }>>; // named combo pipelines by id
 }
 
 export function resolveCompressionPlan(config: any, ctx: ResolveCtx): DerivedPlan {
   if (config?.enabled === false) return { mode: "off", stackedPipeline: [] };
 
-  // 1. header (Phase 3 supplies parsed value; here it composes if present)
-  if (ctx.header) {
-    if (ctx.header === "off") return { mode: "off", stackedPipeline: [] };
-    if (ctx.header !== "default") {
-      const fromHeader = headerToPlan(ctx.header, config, ctx);
-      if (fromHeader) return fromHeader; // unknown => fall through
-    }
-  }
-
-  // 2. routing-combo override
+  // routing-combo override
   const ov = ctx.comboId ? config?.comboOverrides?.[ctx.comboId] : undefined;
   if (ov) return modeToPlan(ov, config);
 
-  // 3. active named combo
+  // active named combo
   if (config?.activeComboId && ctx.combos?.[config.activeComboId]) {
     return { mode: "stacked", stackedPipeline: ctx.combos[config.activeComboId] };
   }
 
-  // 4. derived default
+  // derived default
   return deriveDefaultPlan(config?.engines ?? {}, config?.enabled !== false);
 }
 
@@ -35,13 +25,4 @@ function modeToPlan(mode: string, config: any): DerivedPlan {
   return mode === "stacked"
     ? { mode: "stacked", stackedPipeline: config?.stackedPipeline ?? [] }
     : { mode, stackedPipeline: [] };
-}
-
-function headerToPlan(h: string, config: any, ctx: ResolveCtx): DerivedPlan | null {
-  if (h.startsWith("engine:")) {
-    const id = h.slice(7);
-    return config?.engines?.[id]?.enabled ? deriveDefaultPlan({ [id]: config.engines[id] }, true) : null;
-  }
-  if (ctx.combos?.[h]) return { mode: "stacked", stackedPipeline: ctx.combos[h] };
-  return null;
 }

--- a/open-sse/services/compression/strategySelector.ts
+++ b/open-sse/services/compression/strategySelector.ts
@@ -27,10 +27,11 @@ import {
   planFromHeader,
   formatCompressionMeta,
   deriveDefaultPlanFromConfig,
+  buildNamedComboLookup,
 } from "./planResolution.ts";
 
 // Re-export so existing importers (resolver test + chatCore dynamic import) keep resolving.
-export { planFromHeader, formatCompressionMeta };
+export { planFromHeader, formatCompressionMeta, buildNamedComboLookup };
 
 /** Named-combo map: combo id → its stacked pipeline (operator-defined profiles). */
 type NamedCombos = Record<string, CompressionPipelineStep[]>;
@@ -183,7 +184,8 @@ export function selectCompressionStrategy(
   combos: NamedCombos = {},
   header: string | null = null
 ): CompressionMode {
-  return selectCompressionPlan(config, comboId, estimatedTokens, body, context, combos, header).mode as CompressionMode;
+  return selectCompressionPlan(config, comboId, estimatedTokens, body, context, combos, header)
+    .mode as CompressionMode;
 }
 
 /**
@@ -429,9 +431,7 @@ async function applyUltraAsync(
           stats: {
             ...slm.stats,
             mode: "ultra",
-            techniquesUsed: Array.from(
-              new Set([...(slm.stats.techniquesUsed ?? []), "ultra-slm"])
-            ),
+            techniquesUsed: Array.from(new Set([...(slm.stats.techniquesUsed ?? []), "ultra-slm"])),
           },
         };
       }
@@ -441,7 +441,11 @@ async function applyUltraAsync(
   }
 
   // SLM tier unavailable or produced no gain → fall back per slmFallbackToAggressive.
-  return applyCompression(body, ultraConfig?.slmFallbackToAggressive ? "aggressive" : "ultra", options);
+  return applyCompression(
+    body,
+    ultraConfig?.slmFallbackToAggressive ? "aggressive" : "ultra",
+    options
+  );
 }
 
 function normalizePipelineStep(step: CompressionPipelineStep | string): CompressionPipelineStep {

--- a/open-sse/services/compression/strategySelector.ts
+++ b/open-sse/services/compression/strategySelector.ts
@@ -21,7 +21,7 @@ import {
   type CachingDetectionContext,
 } from "./cachingAware.ts";
 import { resolveCompressionPlan } from "./resolveCompressionPlan.ts";
-import { deriveDefaultPlan, type DerivedPlan } from "./deriveDefaultPlan.ts";
+import { deriveDefaultPlan, type DerivedPlan, type CompressionSource } from "./deriveDefaultPlan.ts";
 
 /** Named-combo map: combo id → its stacked pipeline (operator-defined profiles). */
 type NamedCombos = Record<string, CompressionPipelineStep[]>;
@@ -58,36 +58,97 @@ export function shouldAutoTrigger(config: CompressionConfig, estimatedTokens: nu
  * `combos` defaults to `{}` so Phase-1 callers are unchanged; when supplied, chatCore passes
  * its DB-loaded named-combo map so the active profile can resolve here purely (no DB import).
  */
+/** Tags a plan with the precedence layer that produced it (Phase 3 observability). */
+function withSource(plan: DerivedPlan, source: CompressionSource): DerivedPlan {
+  return { ...plan, source };
+}
+
+/**
+ * Interprets the `x-omniroute-compression` request header into a plan, or null when the
+ * value is unrecognized (caller falls through to normal resolution). Pure.
+ *   off            -> no compression
+ *   default        -> the panel-derived Default (ignores active profile / routing / auto-trigger)
+ *   engine:<id>    -> that single engine, when enabled in config.engines
+ *   <combo>        -> a named combo, matched name-first (lowercased) then exact id (Decision A)
+ */
+export function planFromHeader(
+  config: CompressionConfig,
+  header: string,
+  combos: NamedCombos
+): DerivedPlan | null {
+  const h = header.trim();
+  if (!h) return null;
+  const lower = h.toLowerCase();
+
+  if (lower === "off") return withSource({ mode: "off", stackedPipeline: [] }, "request-header");
+
+  if (lower === "default") {
+    // Empty combos + null comboId yields the pure panel default (no active-combo leak).
+    return withSource(deriveDefaultPlanFromConfig(config, null, {}), "request-header");
+  }
+
+  if (lower.startsWith("engine:")) {
+    const id = lower.slice("engine:".length);
+    const engine = config.engines?.[id];
+    return engine?.enabled
+      ? withSource(deriveDefaultPlan({ [id]: engine }, true), "request-header")
+      : null;
+  }
+
+  const combo = combos[lower] ?? combos[h];
+  return combo ? withSource({ mode: "stacked", stackedPipeline: combo }, "request-header") : null;
+}
+
+/** Renders the X-OmniRoute-Compression response header value. */
+export function formatCompressionMeta(plan: DerivedPlan): string {
+  return `${plan.mode}; source=${plan.source ?? "off"}`;
+}
+
 function resolveBasePlan(
   config: CompressionConfig,
   comboId: string | null,
   estimatedTokens: number,
-  combos: NamedCombos = {}
+  combos: NamedCombos = {},
+  header: string | null = null
 ): DerivedPlan {
-  if (!config.enabled) return { mode: "off", stackedPipeline: [] };
+  if (!config.enabled) return withSource({ mode: "off", stackedPipeline: [] }, "off");
+
+  // Phase 3: an explicit, recognized header wins over every operator layer (Decision B).
+  // The master switch above is the hard kill: a header cannot turn compression on.
+  if (header) {
+    const fromHeader = planFromHeader(config, header, combos);
+    if (fromHeader) return fromHeader; // already tagged "request-header"
+  }
 
   const comboMode = checkComboOverride(config, comboId);
   if (comboMode) {
     // A routing-combo "stacked" override still wants the configured stacked pipeline,
     // so route it through the resolver (which reads config.stackedPipeline for stacked).
-    return resolveCompressionPlan(config, { comboId, combos });
+    return withSource(resolveCompressionPlan(config, { comboId, combos }), "routing-override");
   }
 
   // Active profile: an EXPLICIT operator choice. Resolves regardless of enginesExplicit and
   // above auto-trigger (manual choice beats automatic escalation), but below a routing-combo
   // override (route-scoped is more specific).
   if (config.activeComboId && combos[config.activeComboId]) {
-    return { mode: "stacked", stackedPipeline: combos[config.activeComboId] };
+    return withSource(
+      { mode: "stacked", stackedPipeline: combos[config.activeComboId] },
+      "active-profile"
+    );
   }
 
   if (shouldAutoTrigger(config, estimatedTokens)) {
     const mode = config.autoTriggerMode ?? "lite";
-    return mode === "stacked"
-      ? { mode, stackedPipeline: config.stackedPipeline ?? [] }
-      : { mode, stackedPipeline: [] };
+    return withSource(
+      mode === "stacked"
+        ? { mode, stackedPipeline: config.stackedPipeline ?? [] }
+        : { mode, stackedPipeline: [] },
+      "auto-trigger"
+    );
   }
 
-  return deriveDefaultPlanFromConfig(config, comboId, combos);
+  const plan = deriveDefaultPlanFromConfig(config, comboId, combos);
+  return withSource(plan, plan.mode === "off" ? "off" : "default");
 }
 
 /**
@@ -146,9 +207,10 @@ export function getEffectiveMode(
   config: CompressionConfig,
   comboId: string | null,
   estimatedTokens: number,
-  combos: NamedCombos = {}
+  combos: NamedCombos = {},
+  header: string | null = null
 ): CompressionMode {
-  return resolveBasePlan(config, comboId, estimatedTokens, combos).mode as CompressionMode;
+  return resolveBasePlan(config, comboId, estimatedTokens, combos, header).mode as CompressionMode;
 }
 
 /**
@@ -165,15 +227,16 @@ export function selectCompressionPlan(
   estimatedTokens: number,
   body?: Record<string, unknown>,
   context?: CachingDetectionContext,
-  combos: NamedCombos = {}
+  combos: NamedCombos = {},
+  header: string | null = null
 ): DerivedPlan {
-  const plan = resolveBasePlan(config, comboId, estimatedTokens, combos);
+  const plan = resolveBasePlan(config, comboId, estimatedTokens, combos, header);
 
   // Apply caching-aware adjustments to the mode if body is provided
   if (body) {
     const ctx = detectCachingContext(body, context);
     const cacheAware = getCacheAwareStrategy(plan.mode as CompressionMode, ctx);
-    return { ...plan, mode: cacheAware.strategy as CompressionMode };
+    return { ...plan, mode: cacheAware.strategy as CompressionMode }; // ...plan preserves source
   }
 
   return plan;
@@ -185,9 +248,10 @@ export function selectCompressionStrategy(
   estimatedTokens: number,
   body?: Record<string, unknown>,
   context?: CachingDetectionContext,
-  combos: NamedCombos = {}
+  combos: NamedCombos = {},
+  header: string | null = null
 ): CompressionMode {
-  return selectCompressionPlan(config, comboId, estimatedTokens, body, context, combos).mode as CompressionMode;
+  return selectCompressionPlan(config, comboId, estimatedTokens, body, context, combos, header).mode as CompressionMode;
 }
 
 /**

--- a/open-sse/services/compression/strategySelector.ts
+++ b/open-sse/services/compression/strategySelector.ts
@@ -21,7 +21,16 @@ import {
   type CachingDetectionContext,
 } from "./cachingAware.ts";
 import { resolveCompressionPlan } from "./resolveCompressionPlan.ts";
-import { deriveDefaultPlan, type DerivedPlan, type CompressionSource } from "./deriveDefaultPlan.ts";
+import { deriveDefaultPlan, type DerivedPlan } from "./deriveDefaultPlan.ts";
+import {
+  withSource,
+  planFromHeader,
+  formatCompressionMeta,
+  deriveDefaultPlanFromConfig,
+} from "./planResolution.ts";
+
+// Re-export so existing importers (resolver test + chatCore dynamic import) keep resolving.
+export { planFromHeader, formatCompressionMeta };
 
 /** Named-combo map: combo id → its stacked pipeline (operator-defined profiles). */
 type NamedCombos = Record<string, CompressionPipelineStep[]>;
@@ -58,52 +67,6 @@ export function shouldAutoTrigger(config: CompressionConfig, estimatedTokens: nu
  * `combos` defaults to `{}` so Phase-1 callers are unchanged; when supplied, chatCore passes
  * its DB-loaded named-combo map so the active profile can resolve here purely (no DB import).
  */
-/** Tags a plan with the precedence layer that produced it (Phase 3 observability). */
-function withSource(plan: DerivedPlan, source: CompressionSource): DerivedPlan {
-  return { ...plan, source };
-}
-
-/**
- * Interprets the `x-omniroute-compression` request header into a plan, or null when the
- * value is unrecognized (caller falls through to normal resolution). Pure.
- *   off            -> no compression
- *   default        -> the panel-derived Default (ignores active profile / routing / auto-trigger)
- *   engine:<id>    -> that single engine, when enabled in config.engines
- *   <combo>        -> a named combo, matched name-first (lowercased) then exact id (Decision A)
- */
-export function planFromHeader(
-  config: CompressionConfig,
-  header: string,
-  combos: NamedCombos
-): DerivedPlan | null {
-  const h = header.trim();
-  if (!h) return null;
-  const lower = h.toLowerCase();
-
-  if (lower === "off") return withSource({ mode: "off", stackedPipeline: [] }, "request-header");
-
-  if (lower === "default") {
-    // Empty combos + null comboId yields the pure panel default (no active-combo leak).
-    return withSource(deriveDefaultPlanFromConfig(config, null, {}), "request-header");
-  }
-
-  if (lower.startsWith("engine:")) {
-    const id = lower.slice("engine:".length);
-    const engine = config.engines?.[id];
-    return engine?.enabled
-      ? withSource(deriveDefaultPlan({ [id]: engine }, true), "request-header")
-      : null;
-  }
-
-  const combo = combos[lower] ?? combos[h];
-  return combo ? withSource({ mode: "stacked", stackedPipeline: combo }, "request-header") : null;
-}
-
-/** Renders the X-OmniRoute-Compression response header value. */
-export function formatCompressionMeta(plan: DerivedPlan): string {
-  return `${plan.mode}; source=${plan.source ?? "off"}`;
-}
-
 function resolveBasePlan(
   config: CompressionConfig,
   comboId: string | null,
@@ -149,37 +112,6 @@ function resolveBasePlan(
 
   const plan = deriveDefaultPlanFromConfig(config, comboId, combos);
   return withSource(plan, plan.mode === "off" ? "off" : "default");
-}
-
-/**
- * Derived-default step. The per-engine toggle map drives the default ONLY when it was
- * EXPLICITLY configured via the panel (a stored `engines` row — `config.enginesExplicit`).
- * For legacy installs the map is backfilled for DISPLAY only (so the panel shows current
- * state); dispatch falls back to the historical `config.defaultMode` so behaviour is
- * byte-for-byte preserved until the operator opts into the panel by saving. This avoids a
- * silent behaviour change for installs whose backfilled engine flags don't exactly match
- * their old defaultMode.
- */
-function deriveDefaultPlanFromConfig(
-  config: CompressionConfig,
-  comboId: string | null,
-  combos: NamedCombos = {}
-): DerivedPlan {
-  if (config.enginesExplicit) {
-    // Panel-configured: the engines map (via the resolver, which stays header/active-combo
-    // aware for Phases 2-3) is authoritative — including an explicit "everything off".
-    return resolveCompressionPlan(config, { comboId, combos });
-  }
-
-  // Legacy path: defaultMode carries the effective mode (the engines map is display-only here).
-  const legacyMode = config.defaultMode;
-  if (legacyMode && legacyMode !== "off") {
-    return legacyMode === "stacked"
-      ? { mode: legacyMode, stackedPipeline: config.stackedPipeline ?? [] }
-      : { mode: legacyMode, stackedPipeline: [] };
-  }
-
-  return { mode: "off", stackedPipeline: [] };
 }
 
 /**

--- a/src/shared/constants/headers.ts
+++ b/src/shared/constants/headers.ts
@@ -1,6 +1,7 @@
 export const OMNIROUTE_RESPONSE_HEADERS = {
   cache: "X-OmniRoute-Cache",
   cacheHit: "X-OmniRoute-Cache-Hit",
+  compression: "X-OmniRoute-Compression",
   costSaved: "X-OmniRoute-Cost-Saved",
   fallbackAttempts: "X-OmniRoute-Fallback-Attempts",
   latencyMs: "X-OmniRoute-Latency-Ms",

--- a/tests/unit/chatcore-headers.test.ts
+++ b/tests/unit/chatcore-headers.test.ts
@@ -1,7 +1,7 @@
-import test from "node:test";
+import test, { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
-import { getHeaderValueCaseInsensitive } from "../../open-sse/handlers/chatCore/headers.ts";
+import { getHeaderValueCaseInsensitive, resolveCompressionHeader } from "../../open-sse/handlers/chatCore/headers.ts";
 
 test("getHeaderValueCaseInsensitive reads a Headers instance via .get()", () => {
   const h = new Headers({ "Content-Type": "text/event-stream" });
@@ -45,4 +45,17 @@ test("getHeaderValueCaseInsensitive returns null for null/undefined/non-object i
     getHeaderValueCaseInsensitive("text/event-stream" as unknown as Record<string, unknown>, "accept"),
     null
   );
+});
+
+describe("resolveCompressionHeader", () => {
+  it("reads the raw value case-insensitively and trims it", () => {
+    assert.equal(resolveCompressionHeader({ "x-omniroute-compression": "  engine:rtk " }), "engine:rtk");
+    assert.equal(resolveCompressionHeader(new Headers({ "X-OmniRoute-Compression": "off" })), "off");
+  });
+
+  it("returns null when absent or blank", () => {
+    assert.equal(resolveCompressionHeader({}), null);
+    assert.equal(resolveCompressionHeader({ "x-omniroute-compression": "   " }), null);
+    assert.equal(resolveCompressionHeader(null), null);
+  });
 });

--- a/tests/unit/compression/compression-header-dispatch.test.ts
+++ b/tests/unit/compression/compression-header-dispatch.test.ts
@@ -5,6 +5,7 @@ import {
   selectCompressionPlan,
   planFromHeader,
   formatCompressionMeta,
+  buildNamedComboLookup,
 } from "../../../open-sse/services/compression/strategySelector.ts";
 import {
   DEFAULT_COMPRESSION_CONFIG,
@@ -12,7 +13,10 @@ import {
 } from "../../../open-sse/services/compression/types.ts";
 
 const combos = {
-  c1: [{ engine: "rtk", intensity: "standard" }, { engine: "caveman", intensity: "full" }],
+  c1: [
+    { engine: "rtk", intensity: "standard" },
+    { engine: "caveman", intensity: "full" },
+  ],
   "fast combo": [{ engine: "lite" }],
 };
 
@@ -52,8 +56,16 @@ describe("planFromHeader (Phase 3)", () => {
     assert.equal(planFromHeader(config, "engine:rtk", combos), null);
   });
 
+  it("engine: <id> => tolerates whitespace after the colon", () => {
+    const config = cfg({ enginesExplicit: true, engines: { rtk: { enabled: true } } });
+    assert.equal(planFromHeader(config, "engine: rtk", combos)?.mode, "rtk");
+  });
+
   it("<combo> matches by name (case-insensitive) and by id", () => {
-    assert.deepEqual(planFromHeader(cfg(), "FAST COMBO", combos)?.stackedPipeline, combos["fast combo"]);
+    assert.deepEqual(
+      planFromHeader(cfg(), "FAST COMBO", combos)?.stackedPipeline,
+      combos["fast combo"]
+    );
     assert.deepEqual(planFromHeader(cfg(), "c1", combos)?.stackedPipeline, combos.c1);
   });
 
@@ -105,7 +117,15 @@ describe("header precedence in resolveBasePlan (Phase 3)", () => {
 describe("source on non-header paths", () => {
   it("routing-override / active-profile / auto-trigger / default / off", () => {
     assert.equal(
-      selectCompressionPlan(cfg({ comboOverrides: { r: "lite" } }), "r", 0, undefined, undefined, combos, null).source,
+      selectCompressionPlan(
+        cfg({ comboOverrides: { r: "lite" } }),
+        "r",
+        0,
+        undefined,
+        undefined,
+        combos,
+        null
+      ).source,
       "routing-override"
     );
     assert.equal(planWithHeader(cfg({ activeComboId: "c1" }), null).source, "active-profile");
@@ -124,7 +144,8 @@ describe("source on non-header paths", () => {
       "auto-trigger"
     );
     assert.equal(
-      planWithHeader(cfg({ enginesExplicit: true, engines: { rtk: { enabled: true } } }), null).source,
+      planWithHeader(cfg({ enginesExplicit: true, engines: { rtk: { enabled: true } } }), null)
+        .source,
       "default"
     );
     assert.equal(planWithHeader(cfg({ enabled: false }), null).source, "off");
@@ -138,5 +159,33 @@ describe("formatCompressionMeta", () => {
       "aggressive; source=request-header"
     );
     assert.equal(formatCompressionMeta({ mode: "off", stackedPipeline: [] }), "off; source=off");
+  });
+});
+
+describe("buildNamedComboLookup", () => {
+  const pipe = [{ engine: "lite" }];
+
+  it("keys each combo by both id and lowercased name", () => {
+    const map = buildNamedComboLookup([{ id: "abc-123", name: "My Fast Combo", pipeline: pipe }]);
+    assert.deepEqual(map["abc-123"], pipe);
+    assert.deepEqual(map["my fast combo"], pipe);
+  });
+
+  it("skips the name key (no '' key, no crash) when the name is blank/whitespace/missing", () => {
+    const map = buildNamedComboLookup([
+      { id: "id-empty", name: "", pipeline: pipe },
+      { id: "id-space", name: "   ", pipeline: pipe },
+      { id: "id-null", name: null, pipeline: pipe },
+    ]);
+    assert.deepEqual(map["id-empty"], pipe); // id key always present
+    assert.deepEqual(map["id-space"], pipe);
+    assert.deepEqual(map["id-null"], pipe);
+    assert.equal(Object.prototype.hasOwnProperty.call(map, ""), false); // no blank key
+    assert.equal(Object.keys(map).length, 3); // only the three id keys
+  });
+
+  it("trims surrounding whitespace on the name key", () => {
+    const map = buildNamedComboLookup([{ id: "x", name: "  Spaced  ", pipeline: pipe }]);
+    assert.deepEqual(map["spaced"], pipe);
   });
 });

--- a/tests/unit/compression/compression-header-dispatch.test.ts
+++ b/tests/unit/compression/compression-header-dispatch.test.ts
@@ -1,0 +1,142 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  selectCompressionStrategy,
+  selectCompressionPlan,
+  planFromHeader,
+  formatCompressionMeta,
+} from "../../../open-sse/services/compression/strategySelector.ts";
+import {
+  DEFAULT_COMPRESSION_CONFIG,
+  type CompressionConfig,
+} from "../../../open-sse/services/compression/types.ts";
+
+const combos = {
+  c1: [{ engine: "rtk", intensity: "standard" }, { engine: "caveman", intensity: "full" }],
+  "fast combo": [{ engine: "lite" }],
+};
+
+function cfg(overrides: Partial<CompressionConfig> = {}): CompressionConfig {
+  return { ...DEFAULT_COMPRESSION_CONFIG, enabled: true, ...overrides };
+}
+
+// header is the 7th positional arg of selectCompressionPlan/selectCompressionStrategy.
+function planWithHeader(config: CompressionConfig, header: string | null) {
+  return selectCompressionPlan(config, null, 0, undefined, undefined, combos, header);
+}
+
+describe("planFromHeader (Phase 3)", () => {
+  it("off => mode off, source request-header", () => {
+    const p = planFromHeader(cfg(), "off", combos);
+    assert.deepEqual(p, { mode: "off", stackedPipeline: [], source: "request-header" });
+  });
+
+  it("default => the panel-derived default, ignoring the active profile", () => {
+    const config = cfg({
+      activeComboId: "c1",
+      enginesExplicit: true,
+      engines: { rtk: { enabled: true } },
+    });
+    const p = planFromHeader(config, "default", combos);
+    assert.equal(p?.mode, "rtk"); // engines map default, NOT the c1 active profile
+    assert.equal(p?.source, "request-header");
+  });
+
+  it("engine:<id> => that single engine when enabled (case-insensitive)", () => {
+    const config = cfg({ enginesExplicit: true, engines: { rtk: { enabled: true } } });
+    assert.equal(planFromHeader(config, "engine:RTK", combos)?.mode, "rtk");
+  });
+
+  it("engine:<id> => null (fall-through) when the engine is disabled", () => {
+    const config = cfg({ engines: { rtk: { enabled: false } } });
+    assert.equal(planFromHeader(config, "engine:rtk", combos), null);
+  });
+
+  it("<combo> matches by name (case-insensitive) and by id", () => {
+    assert.deepEqual(planFromHeader(cfg(), "FAST COMBO", combos)?.stackedPipeline, combos["fast combo"]);
+    assert.deepEqual(planFromHeader(cfg(), "c1", combos)?.stackedPipeline, combos.c1);
+  });
+
+  it("unknown value => null (fall-through)", () => {
+    assert.equal(planFromHeader(cfg(), "nonsense", combos), null);
+  });
+});
+
+describe("header precedence in resolveBasePlan (Phase 3)", () => {
+  it("a valid header beats the active profile", () => {
+    const config = cfg({ activeComboId: "c1" });
+    assert.equal(planWithHeader(config, "off").mode, "off");
+    assert.equal(planWithHeader(config, "off").source, "request-header");
+  });
+
+  it("a valid header beats a routing-combo override", () => {
+    const config = cfg({ comboOverrides: { "route-x": "stacked" } });
+    const plan = selectCompressionPlan(config, "route-x", 0, undefined, undefined, combos, "off");
+    assert.equal(plan.mode, "off");
+    assert.equal(plan.source, "request-header");
+  });
+
+  it("a valid header bypasses auto-trigger (Decision B)", () => {
+    const config = cfg({
+      autoTriggerTokens: 1000,
+      autoTriggerMode: "aggressive",
+      enginesExplicit: true,
+      engines: { rtk: { enabled: true } },
+    });
+    // Large prompt would auto-escalate to aggressive; the header pins the panel default.
+    assert.equal(planWithHeader(config, "default").mode, "rtk");
+  });
+
+  it("an unknown header falls through to the normal resolution", () => {
+    const config = cfg({ activeComboId: "c1" });
+    const plan = planWithHeader(config, "bogus");
+    assert.equal(plan.mode, "stacked");
+    assert.equal(plan.source, "active-profile");
+  });
+
+  it("master-off beats the header (hard kill switch)", () => {
+    const config = cfg({ enabled: false, engines: { rtk: { enabled: true } } });
+    const plan = planWithHeader(config, "engine:rtk");
+    assert.equal(plan.mode, "off");
+    assert.equal(plan.source, "off");
+  });
+});
+
+describe("source on non-header paths", () => {
+  it("routing-override / active-profile / auto-trigger / default / off", () => {
+    assert.equal(
+      selectCompressionPlan(cfg({ comboOverrides: { r: "lite" } }), "r", 0, undefined, undefined, combos, null).source,
+      "routing-override"
+    );
+    assert.equal(planWithHeader(cfg({ activeComboId: "c1" }), null).source, "active-profile");
+    // auto-trigger only fires once estimatedTokens crosses autoTriggerTokens, so pass an
+    // estimate above the threshold (planWithHeader pins estimatedTokens=0 and never trips it).
+    assert.equal(
+      selectCompressionPlan(
+        cfg({ autoTriggerTokens: 10, autoTriggerMode: "lite" }),
+        null,
+        50,
+        undefined,
+        undefined,
+        combos,
+        null
+      ).source,
+      "auto-trigger"
+    );
+    assert.equal(
+      planWithHeader(cfg({ enginesExplicit: true, engines: { rtk: { enabled: true } } }), null).source,
+      "default"
+    );
+    assert.equal(planWithHeader(cfg({ enabled: false }), null).source, "off");
+  });
+});
+
+describe("formatCompressionMeta", () => {
+  it("renders '<mode>; source=<source>'", () => {
+    assert.equal(
+      formatCompressionMeta({ mode: "aggressive", stackedPipeline: [], source: "request-header" }),
+      "aggressive; source=request-header"
+    );
+    assert.equal(formatCompressionMeta({ mode: "off", stackedPipeline: [] }), "off; source=off");
+  });
+});


### PR DESCRIPTION
## Compression — Phase 3: per-request override header

Final piece of the three-phase compression-config work (Phase 1 #4432 panel engines map; Phase 2 #4521 named profiles + active selector). Lets a client override the resolved compression plan **for a single request** via the `x-omniroute-compression` HTTP header, taking precedence over every operator-configured layer.

### Header contract
`x-omniroute-compression: <value>` (mirrors `x-omniroute-no-memory`). Keyword/`engine:` matching is case-insensitive.

| Value | Effect |
|---|---|
| `off` | No compression for this request. |
| `default` | The panel-derived Default profile (ignores the active profile). |
| `engine:<id>` | A single engine when enabled, e.g. `engine:rtk`. |
| `<combo>` | A named combo, matched by name (case-insensitive) first, then by id (**Decision A**). |

- **Precedence (most-specific wins):** `request-header` > routing-combo override > active profile > auto-trigger > derived Default > off. The header is evaluated at the **top** of `resolveBasePlan`.
- **Decision B:** any valid header value **bypasses auto-trigger** (the header decides, full stop).
- **Unknown value → ignored** (never a 4xx); resolution falls through to the normal operator precedence.
- **Master switch is a hard gate:** when compression is disabled globally, the header cannot enable it.
- **Observability:** the applied plan is echoed back in `X-OmniRoute-Compression: <mode>; source=<source>` (source ∈ `request-header`/`routing-override`/`active-profile`/`auto-trigger`/`default`/`off`).

### What changed
- **Resolver core** (`planResolution.ts`, new pure leaf): `planFromHeader` interpreter + `withSource` tagging + `formatCompressionMeta` + `deriveDefaultPlanFromConfig`. The resolver stays **pure** (no `src/lib/db` import). The previously-dormant header branch in `resolveCompressionPlan.ts` was removed so header interpretation has a single home.
- **`DerivedPlan`** gains an optional `source` field (which precedence layer decided) — optional so Phase 1/2 callers/snapshots are unaffected.
- **Parser** `resolveCompressionHeader` in `chatCore/headers.ts` (mirrors `isNoMemoryRequested`).
- **chatCore wiring**: parse the header, build the named-combo map keyed by **both** id and lowercased name, thread the header through the existing selectors, emit `X-OmniRoute-Compression` on streaming + non-streaming responses.

### Tests & gates
- New `tests/unit/compression/compression-header-dispatch.test.ts` (13) + `resolveCompressionHeader` cases (8): all 4 forms, precedence (beats active profile + routing override), unknown→fall-through, auto-trigger bypass, master-off hard-kill, `source` on every layer.
- Green: `typecheck:core`, `check:cycles` (resolver + leaf pure), `check:file-size` (`strategySelector.ts` kept under the 800 cap by extracting `planResolution.ts`), `lint` (0 errors on touched files), MDX docs, **compression + parser 798/798**, chatCore integration 10/10.

### Docs
`docs/reference/API_REFERENCE.md` + `docs/compression/COMPRESSION_GUIDE.md` document the header, the value table, the duplicate-name → use-id caveat, and the response header. Design spec + implementation plan included under `docs/compression/`.