### PR TITLE
fix(ci): include coverage/lcov.info in coverage-report artifact for SonarQube

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -846,6 +846,7 @@ jobs:
           path: |
             coverage/coverage-summary.json
             coverage/coverage-report.md
+            coverage/lcov.info
           if-no-files-found: warn
 
   sonarqube:


### PR DESCRIPTION
## Job vermelho que isto conserta

**SonarQube** na release PR #4614 (CI run [#27950299650](https://github.com/diegosouzapw/OmniRoute/actions/runs/27950299650)) — `QUALITY GATE STATUS: FAILED`, precedido de:
```
No LCOV files were found using coverage/lcov.info
No coverage information will be saved because all LCOV files cannot be found.
```

## Causa-raiz

O job `sonarqube` (`needs: test-coverage`) baixa o artifact **`coverage-report`** e o `sonar-project.properties` aponta:
```
sonar.javascript.lcov.reportPaths=coverage/lcov.info
```
Mas o upload do artifact (`Upload coverage artifacts`) só incluía `coverage/coverage-summary.json` + `coverage/coverage-report.md` — **faltava o `coverage/lcov.info`**. Sem LCOV, o Sonar reporta 0% de cobertura no new code → quality gate falha.

## Fix

Adiciona `coverage/lcov.info` ao `path:` do artifact `coverage-report` (1 linha). O `test:coverage` **já gera** o LCOV (`c8 ... --reporter=lcov`), então é só incluí-lo no upload. **Aditivo** — os demais consumidores do artifact (PR coverage comment etc.) ignoram o arquivo extra.

## Verificação

- `npm run test:coverage` usa `--reporter=lcov` → produz `coverage/lcov.info` (confirmado no package.json).
- YAML validado (`yaml.safe_load`).
- 1 linha alterada em `.github/workflows/ci.yml`.

Obs.: o `digest-mismatch` visto no download do artifact tende a ser transiente (re-upload entre runs); o LCOV ausente é a causa **determinística** do gate vermelho.