### PR TITLE
fix(dashboard): stop double-masking already-masked API key in list (E2E 3/9 regression)

### DIFF
--- a/src/app/(dashboard)/dashboard/api-manager/ApiManagerPageClient.tsx
+++ b/src/app/(dashboard)/dashboard/api-manager/ApiManagerPageClient.tsx
@@ -16,7 +16,6 @@ import {
   computeApiKeyCounts,
   formatUsdCost,
   toLocalDateTimeInputValue,
-  maskKey,
   toggleKeyVisibility,
 } from "./apiManagerPageUtils";
 import type { KeyStatus, KeyType } from "./apiManagerPageUtils";
@@ -987,7 +986,7 @@ export default function ApiManagerPageClient() {
                     <code className="text-sm text-text-muted font-mono truncate">
                       {visibleKeys.has(key.id)
                         ? (revealedKeys.get(key.id) ?? key.key)
-                        : maskKey(key.key)}
+                        : key.key}
                     </code>
                     {allowKeyReveal ? (
                       <>

--- a/tests/unit/api-manager-mask-key-passthrough.test.ts
+++ b/tests/unit/api-manager-mask-key-passthrough.test.ts
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { maskKey } from "../../src/app/(dashboard)/dashboard/api-manager/apiManagerPageUtils.ts";
+import { maskStoredApiKey } from "../../src/lib/apiKeyExposure.ts";
+
+/**
+ * Regression guard for #4671 (stop double-masking already-masked API keys).
+ *
+ * The keys-list endpoint (`/api/keys`) returns `key` already masked via
+ * `maskStoredApiKey` → `slice(0,8) + "****" + slice(-4)`, which preserves the
+ * last-4 suffix (e.g. `sk-live-****1002`). The dashboard list used to render that
+ * value through `maskKey()` a SECOND time. Before maskKey gained its `"****"`
+ * passthrough guard, the second pass truncated the value to `sk-live-...`,
+ * dropping the suffix the user relies on to tell keys apart.
+ *
+ * #4671 drops the redundant `maskKey(key.key)` call and renders `key.key`
+ * verbatim. These tests pin the invariant that makes that simplification safe:
+ * an already-masked (`"****"`-bearing) value must round-trip unchanged through
+ * maskKey, so `key.key` and `maskKey(key.key)` are equivalent for the real
+ * server format. (At the pre-guard maskKey the second assertion would fail,
+ * which is exactly the historical double-mask bug.)
+ */
+test("maskKey returns an already-masked (****) value verbatim — no double-mask", () => {
+  const serverMasked = maskStoredApiKey("sk-live-abcdefgh-secret-tail-1002");
+  assert.ok(serverMasked && serverMasked.includes("****"));
+  // The suffix the user identifies the key by must survive.
+  assert.ok(serverMasked.endsWith("1002"), "server mask must preserve the last-4 suffix");
+  // The dashboard renders key.key directly; that must equal what maskKey would
+  // have produced, i.e. the verbatim already-masked value (no truncation).
+  assert.equal(maskKey(serverMasked), serverMasked);
+});
+
+test("maskKey still masks a fully-revealed key (no '****') — first-pass behavior intact", () => {
+  // A genuinely unmasked key (no "****") must still be shortened, so removing the
+  // redundant second pass does not weaken masking of truly-revealed values.
+  const full = "sk-live-abcdefgh-secret-tail-1002";
+  assert.ok(!full.includes("****"));
+  assert.equal(maskKey(full), "sk-live-...");
+});


### PR DESCRIPTION
## Job vermelho que isto conserta

**E2E Tests (3/9)** na release PR #4614 — `tests/e2e/api-keys-flow.spec.ts` → teste "creates, copies, reveals, revokes, and returns to the empty state":
```
210 | await expect(page.getByText("sk-live-****1002")).toBeVisible();
Error: expect(locator).toBeVisible() failed — element(s) not found (30s timeout)
```
Determinístico: falhou nos runs [#27937112608](https://github.com/diegosouzapw/OmniRoute/actions/runs/27937112608) **e** [#27950299650](https://github.com/diegosouzapw/OmniRoute/actions/runs/27950299650) (mesmo shard).

## Causa-raiz (regressão do v3.8.33)

`GET /api/keys` já retorna o `.key` **mascarado pelo servidor** (`src/app/api/keys/route.ts` → `maskStoredApiKey(k.key)` → `sk-live-****1002`).

A feature de reveal/visibility (introduzida no squash `ee24eb52d` do v3.8.33) passou a aplicar **`maskKey(key.key)` por cima** no branch não-revelado da lista (`ApiManagerPageClient.tsx:990`). Esse `maskKey` (de `apiManagerPageUtils`) **trunca**:
```js
fullKey.length > 8 ? `${fullKey.slice(0, 8)}...` : fullKey
// maskKey("sk-live-****1002") -> "sk-live-..."  (perde os ****1002)
```
→ a UI exibia `sk-live-...` em vez de `sk-live-****1002` → **double-masking**.

## Fix (cirúrgico)

1. `ApiManagerPageClient.tsx:990`: `: maskKey(key.key)` → `: key.key` (renderiza o valor já mascarado pelo servidor — também restaura o prefixo `sk-live-` e os 4 dígitos finais, sem expor o segredo).
2. Remove o import `maskKey`, agora órfão (a função permanece em `apiManagerPageUtils` p/ outros usos).

## Validação (Rule #18)

- O **E2E existente** (`api-keys-flow.spec.ts`, shard 3/9) é a guarda de regressão: assertava `getByText("sk-live-****1002")` e falhava → com o fix passa por construção (UI agora renderiza `key.key` = exatamente esse texto). Roda em CI neste PR e na release PR.
- Lint do arquivo: 0 erros (import órfão removido).
- Sem exposição de segredo: o `.key` da lista é sempre o valor mascarado do servidor; o full key só aparece via `/reveal` sob toggle.