### PR TITLE
fix(translator): coerce tool descriptions to strings in OpenAI normalization (port decolua/9router#397)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 _In development — bullets added per PR; finalized at release._
 
+### 🐛 Bug Fixes
+
+- **fix(translator): coerce tool descriptions to strings in OpenAI normalization** — `filterToOpenAIFormat` could leak non-string `description` values (null, object, number) from Claude- and Gemini-style tool blocks into the OpenAI-format tool, tripping strict upstream validators (NVIDIA NIM, Codex). Both branches now coerce via `String(value ?? "")`. Inspired by [decolua/9router#397](https://github.com/decolua/9router/pull/397) (thanks @East-rayyy).
+
 ### 📝 Maintenance
 
 - **chore(quality): release-green pre-flight validator + nightly signal** — new `npm run check:release-green` (`scripts/quality/validate-release-green.mjs`) reproduces the release-equivalent validation (full unit + vitest + ratchets + typecheck + lint, optional `--with-build` package-artifact) against the current working tree and classifies each red as **HARD** (real defect) vs **DRIFT** (ratchet, rebaselined at release) — purely diagnostic, never blocking contributors. A new `nightly-release-green` workflow runs it on the active release branch and opens/updates a tracking issue on hard failures. Closes the gap where the full gate (`ci.yml`) only ran on the release PR, so reds accrued silently on `release/**` and surfaced in layers at release time. (thanks @diegosouzapw)

--- a/open-sse/translator/helpers/openaiHelper.ts
+++ b/open-sse/translator/helpers/openaiHelper.ts
@@ -178,7 +178,9 @@ export function filterToOpenAIFormat(body) {
             type: "function",
             function: {
               name: tool.name,
-              description: tool.description || "",
+              // Coerce: strict upstream validators (NVIDIA NIM, Codex) reject
+              // non-string descriptions. Ports decolua/9router#397.
+              description: String(tool.description ?? ""),
               parameters: tool.input_schema || { type: "object", properties: {} },
             },
           };
@@ -190,7 +192,7 @@ export function filterToOpenAIFormat(body) {
             type: "function",
             function: {
               name: fn.name,
-              description: fn.description || "",
+              description: String(fn.description ?? ""),
               parameters: fn.parameters || { type: "object", properties: {} },
             },
           }));

--- a/open-sse/translator/helpers/openaiHelper.ts
+++ b/open-sse/translator/helpers/openaiHelper.ts
@@ -170,7 +170,9 @@ export function filterToOpenAIFormat(body) {
             type: "function",
             function: {
               name: tool.name,
-              description: tool.description || "",
+              // Coerce: strict upstream validators (NVIDIA NIM, Codex) reject
+              // non-string descriptions. Ports decolua/9router#397.
+              description: String(tool.description ?? ""),
               parameters: tool.input_schema || { type: "object", properties: {} },
             },
           };
@@ -182,7 +184,7 @@ export function filterToOpenAIFormat(body) {
             type: "function",
             function: {
               name: fn.name,
-              description: fn.description || "",
+              description: String(fn.description ?? ""),
               parameters: fn.parameters || { type: "object", properties: {} },
             },
           }));

--- a/tests/unit/translator-helper-tool-description-coercion.test.ts
+++ b/tests/unit/translator-helper-tool-description-coercion.test.ts
@@ -1,0 +1,58 @@
+// Regression: tool descriptions must always be strings for strict upstream
+// validation (e.g., NVIDIA NIM, Codex). Ports upstream PR decolua/9router#397
+// (Ibrahim Ryan), restricted to the gap that still exists in OmniRoute —
+// the two non-string-tolerant paths in openaiHelper.filterToOpenAIFormat
+// (Claude-style and Gemini-style tool normalization). The other locations
+// upstream-patched (claude-to-openai.ts, openai-responses.ts) already coerce
+// via String/toString in OmniRoute.
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const openaiHelper = await import(
+  "../../open-sse/translator/helpers/openaiHelper.ts"
+);
+
+test("filterToOpenAIFormat coerces non-string Claude-tool description to string", () => {
+  const result = openaiHelper.filterToOpenAIFormat({
+    messages: [{ role: "user", content: "hi" }],
+    tools: [
+      {
+        name: "claude-tool",
+        // Non-string truthy value — must NOT leak through to upstream.
+        description: { invalid: "object" } as unknown as string,
+        input_schema: { type: "object" },
+      },
+    ],
+  });
+  assert.equal(typeof result.tools[0].function.description, "string");
+});
+
+test("filterToOpenAIFormat coerces null/undefined Claude-tool description to empty string", () => {
+  const result = openaiHelper.filterToOpenAIFormat({
+    messages: [{ role: "user", content: "hi" }],
+    tools: [
+      { name: "t1", description: null as unknown as string, input_schema: {} },
+      { name: "t2", description: undefined, input_schema: {} },
+    ],
+  });
+  assert.equal(result.tools[0].function.description, "");
+  assert.equal(result.tools[1].function.description, "");
+});
+
+test("filterToOpenAIFormat coerces non-string Gemini functionDeclarations description", () => {
+  const result = openaiHelper.filterToOpenAIFormat({
+    messages: [{ role: "user", content: "hi" }],
+    tools: [
+      {
+        functionDeclarations: [
+          {
+            name: "gemini-tool",
+            description: 12345 as unknown as string,
+            parameters: { type: "object" },
+          },
+        ],
+      },
+    ],
+  });
+  assert.equal(typeof result.tools[0].function.description, "string");
+});


### PR DESCRIPTION
## Summary

Ports the still-applicable slice of upstream **[decolua/9router#397](https://github.com/decolua/9router/pull/397)** by @East-rayyy.

`filterToOpenAIFormat` (open-sse/translator/helpers/openaiHelper.ts) normalizes Claude-style and Gemini-style tool blocks into OpenAI-format function tools. The two branches forwarded `description` with a weak `|| ""` guard, which lets non-string truthy values (object/number) leak through. Strict upstream validators (NVIDIA NIM, strict Codex) reject those — they require `description` to be a string.

Both branches now coerce via `String(value ?? "")`.

## Scope vs upstream PR

| Upstream change | OmniRoute status |
|---|---|
| `formats.js` — `/v1/messages` → CLAUDE detection | **N/A** — OmniRoute has no unified `detectFormatByEndpoint`; `/v1/messages` is path-routed directly to a Claude handler (`src/app/api/v1/messages/`) |
| `claude-to-openai.js` — coerce description | **Already done** — `claude-to-openai.ts:182` uses `typeof === "string"` check (#276 fix) |
| `openai-responses.js` — coerce description (2 places) | **Already done** — `openai-responses.ts:344,388,705` use local `toString()` helper |
| `openaiHelper.js` — coerce description (2 places) | **Ported here** ✅ |

## Test plan

- [x] TDD: failing test → fix → green (`tests/unit/translator-helper-tool-description-coercion.test.ts`, 3 cases: non-string Claude desc, null/undefined Claude desc, non-string Gemini `functionDeclarations` desc)
- [x] Existing regression suite still green (`translator-helper-branches.test.ts`)

## Attribution

- **Upstream PR:** decolua/9router#397
- **Original author:** @East-rayyy (Ibrahim Ryan `<ryan@nuevanext.com>`) — credited via `Co-authored-by` trailer
- **Inspired-by** trailer present in the commit

**DO NOT MERGE** — babysitting CI.