### PR TITLE
feat(sse): x-omniroute-strip-reasoning header to drop reasoning_content (port decolua/9router#517)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 _In development — bullets added per PR; finalized at release._
 
+### ✨ New Features
+
+- **feat(sse): `x-omniroute-strip-reasoning` header to drop `reasoning_content` from non-streaming JSON** — opt-in per-request header that unconditionally removes `reasoning_content` from the final non-streaming Chat Completions payload (including reasoning-only messages and DeepSeek V4), for clients whose JSON parsers cannot tolerate the non-standard OpenAI extension (e.g. Firecrawl AI SDK `/extract`). Reasoning replay cache is unaffected — capture happens before the sanitize step. Ported from upstream [decolua/9router#517](https://github.com/decolua/9router/pull/517) (closes upstream #509 — thanks @anuragg-saxenaa).
+
 ### 📝 Maintenance
 
 - **chore(quality): release-green pre-flight validator + nightly signal** — new `npm run check:release-green` (`scripts/quality/validate-release-green.mjs`) reproduces the release-equivalent validation (full unit + vitest + ratchets + typecheck + lint, optional `--with-build` package-artifact) against the current working tree and classifies each red as **HARD** (real defect) vs **DRIFT** (ratchet, rebaselined at release) — purely diagnostic, never blocking contributors. A new `nightly-release-green` workflow runs it on the active release branch and opens/updates a tracking issue on hard failures. Closes the gap where the full gate (`ci.yml`) only ran on the release PR, so reds accrued silently on `release/**` and surfaced in layers at release time. (thanks @diegosouzapw)

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -18,6 +18,7 @@ import {
   getHeaderValueCaseInsensitive,
   isNoMemoryRequested,
   resolveCompressionHeader,
+  isStripReasoningRequested,
 } from "./chatCore/headers.ts";
 import { markCodexScopeRateLimited } from "./chatCore/codexFailover.ts";
 import { getCombosCached } from "./chatCore/comboContextCache.ts";
@@ -3493,7 +3494,13 @@ export async function handleChatCore({
     if (clientResponseFormat === FORMATS.OPENAI_RESPONSES) {
       translatedResponse = sanitizeResponsesApiResponse(translatedResponse);
     } else if (clientResponseFormat === FORMATS.OPENAI) {
-      translatedResponse = sanitizeOpenAIResponse(translatedResponse);
+      // Port of decolua/9router#517: opt-in `x-omniroute-strip-reasoning` header
+      // unconditionally drops `reasoning_content` from the final non-streaming
+      // JSON for clients (e.g. Firecrawl AI SDK) whose JSON parsers break on
+      // that non-standard field. Reasoning replay cache is captured above this
+      // sanitize step, so the cache feature is unaffected.
+      const stripReasoning = isStripReasoningRequested(clientRawRequest?.headers ?? null);
+      translatedResponse = sanitizeOpenAIResponse(translatedResponse, { stripReasoning });
     }
 
     applyClientUsageBuffer(translatedResponse, body, clientResponseFormat);

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -7,7 +7,11 @@ import { checkIdempotencyCache } from "./chatCore/idempotency.ts";
 import { checkSemanticCache } from "./chatCore/semanticCache.ts";
 import { sanitizeChatRequestBody } from "./chatCore/sanitization.ts";
 import { cloneBoundedChatLogPayload, truncateForLog } from "./chatCore/logTruncation.ts";
-import { getHeaderValueCaseInsensitive, isNoMemoryRequested } from "./chatCore/headers.ts";
+import {
+  getHeaderValueCaseInsensitive,
+  isNoMemoryRequested,
+  isStripReasoningRequested,
+} from "./chatCore/headers.ts";
 import { markCodexScopeRateLimited } from "./chatCore/codexFailover.ts";
 import { getCombosCached, getUpstreamProxyConfigCached } from "./chatCore/comboContextCache.ts";
 export { clearCombosCache, clearUpstreamProxyConfigCache } from "./chatCore/comboContextCache.ts";
@@ -4253,7 +4257,13 @@ export async function handleChatCore({
     if (clientResponseFormat === FORMATS.OPENAI_RESPONSES) {
       translatedResponse = sanitizeResponsesApiResponse(translatedResponse);
     } else if (clientResponseFormat === FORMATS.OPENAI) {
-      translatedResponse = sanitizeOpenAIResponse(translatedResponse);
+      // Port of decolua/9router#517: opt-in `x-omniroute-strip-reasoning` header
+      // unconditionally drops `reasoning_content` from the final non-streaming
+      // JSON for clients (e.g. Firecrawl AI SDK) whose JSON parsers break on
+      // that non-standard field. Reasoning replay cache is captured above this
+      // sanitize step, so the cache feature is unaffected.
+      const stripReasoning = isStripReasoningRequested(clientRawRequest?.headers ?? null);
+      translatedResponse = sanitizeOpenAIResponse(translatedResponse, { stripReasoning });
     }
 
     // Add buffer and filter usage for client (to prevent CLI context errors)

--- a/open-sse/handlers/chatCore/headers.ts
+++ b/open-sse/handlers/chatCore/headers.ts
@@ -44,3 +44,22 @@ export function resolveCompressionHeader(
   const value = (getHeaderValueCaseInsensitive(headers, "x-omniroute-compression") || "").trim();
   return value || null;
 }
+
+/**
+ * Per-request opt-in to unconditionally strip `reasoning_content` from the
+ * non-streaming JSON response via the `x-omniroute-strip-reasoning` header.
+ * Some clients (e.g. Firecrawl AI SDK) have JSON parsers that break on this
+ * non-standard OpenAI extension even though it's syntactically valid, and even
+ * on reasoning-only messages that the default sanitizer keeps. Truthy values:
+ * `true` / `1` / `yes` (case-insensitive). Ported from upstream 9router#517
+ * (closes upstream #509). Reasoning is still captured for the replay cache
+ * before this header is consulted, so the cache feature is unaffected.
+ */
+export function isStripReasoningRequested(
+  headers: Record<string, unknown> | Headers | null | undefined
+): boolean {
+  const value = (getHeaderValueCaseInsensitive(headers, "x-omniroute-strip-reasoning") || "")
+    .trim()
+    .toLowerCase();
+  return value === "true" || value === "1" || value === "yes";
+}

--- a/open-sse/handlers/chatCore/headers.ts
+++ b/open-sse/handlers/chatCore/headers.ts
@@ -31,3 +31,22 @@ export function isNoMemoryRequested(
     .toLowerCase();
   return value === "true" || value === "1" || value === "yes";
 }
+
+/**
+ * Per-request opt-in to unconditionally strip `reasoning_content` from the
+ * non-streaming JSON response via the `x-omniroute-strip-reasoning` header.
+ * Some clients (e.g. Firecrawl AI SDK) have JSON parsers that break on this
+ * non-standard OpenAI extension even though it's syntactically valid, and even
+ * on reasoning-only messages that the default sanitizer keeps. Truthy values:
+ * `true` / `1` / `yes` (case-insensitive). Ported from upstream 9router#517
+ * (closes upstream #509). Reasoning is still captured for the replay cache
+ * before this header is consulted, so the cache feature is unaffected.
+ */
+export function isStripReasoningRequested(
+  headers: Record<string, unknown> | Headers | null | undefined
+): boolean {
+  const value = (getHeaderValueCaseInsensitive(headers, "x-omniroute-strip-reasoning") || "")
+    .trim()
+    .toLowerCase();
+  return value === "true" || value === "1" || value === "yes";
+}

--- a/open-sse/handlers/responseSanitizer.ts
+++ b/open-sse/handlers/responseSanitizer.ts
@@ -269,10 +269,26 @@ export function extractThinkingFromContent(text: string): {
  * Sanitize a non-streaming OpenAI ChatCompletion response.
  * Strips non-standard fields and normalizes required fields.
  */
-export function sanitizeOpenAIResponse(body: unknown): unknown {
+export interface SanitizeOpenAIResponseOptions {
+  /**
+   * When true, unconditionally remove `reasoning_content` from every choice
+   * message in the final payload — including reasoning-only messages and
+   * DeepSeek V4 — even though the default sanitizer keeps it in those cases.
+   * Wired to the `x-omniroute-strip-reasoning` request header for clients whose
+   * JSON parsers cannot tolerate the non-standard field (e.g. Firecrawl AI SDK).
+   * Ported from upstream 9router#517 (closes upstream #509).
+   */
+  stripReasoning?: boolean;
+}
+
+export function sanitizeOpenAIResponse(
+  body: unknown,
+  options: SanitizeOpenAIResponseOptions = {}
+): unknown {
   const bodyRecord = toRecord(body);
   if (!bodyRecord) return body;
   const isDeepSeekV4 = isDeepSeekV4Model(bodyRecord.model);
+  const stripReasoning = options.stripReasoning === true;
 
   // Build sanitized response with only allowed top-level fields
   const sanitized: JsonRecord = {};
@@ -295,6 +311,9 @@ export function sanitizeOpenAIResponse(body: unknown): unknown {
         sanitizedChoice.finish_reason !== "tool_calls"
       ) {
         sanitizedChoice.finish_reason = "tool_calls";
+      }
+      if (stripReasoning && message && "reasoning_content" in message) {
+        delete message.reasoning_content;
       }
       return sanitizedChoice;
     });

--- a/tests/unit/strip-reasoning-header.test.ts
+++ b/tests/unit/strip-reasoning-header.test.ts
@@ -1,0 +1,124 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// Port of decolua/9router#517: per-request opt-in via the
+// `x-omniroute-strip-reasoning` header to unconditionally strip
+// `reasoning_content` from non-streaming JSON responses. Some clients
+// (Firecrawl AI SDK) have JSON parsers that break on this non-standard
+// extension even when there is no visible content, so the default
+// "keep reasoning-only messages" behavior is not sufficient.
+const { isStripReasoningRequested, getHeaderValueCaseInsensitive } = await import(
+  "../../open-sse/handlers/chatCore/headers.ts"
+);
+const { sanitizeOpenAIResponse } = await import(
+  "../../open-sse/handlers/responseSanitizer.ts"
+);
+
+test("isStripReasoningRequested is true for truthy header values", () => {
+  for (const v of ["true", "1", "yes", "TRUE", "Yes", " true "]) {
+    assert.equal(
+      isStripReasoningRequested({ "x-omniroute-strip-reasoning": v }),
+      true,
+      `expected true for ${JSON.stringify(v)}`
+    );
+  }
+});
+
+test("isStripReasoningRequested is case-insensitive on the header NAME", () => {
+  assert.equal(isStripReasoningRequested({ "X-OmniRoute-Strip-Reasoning": "true" }), true);
+});
+
+test("isStripReasoningRequested works with a Headers instance", () => {
+  const h = new Headers();
+  h.set("x-omniroute-strip-reasoning", "1");
+  assert.equal(isStripReasoningRequested(h), true);
+});
+
+test("isStripReasoningRequested is false when absent / empty / falsy", () => {
+  assert.equal(isStripReasoningRequested(null), false);
+  assert.equal(isStripReasoningRequested(undefined), false);
+  assert.equal(isStripReasoningRequested({}), false);
+  assert.equal(isStripReasoningRequested({ "x-omniroute-strip-reasoning": "" }), false);
+  assert.equal(isStripReasoningRequested({ "x-omniroute-strip-reasoning": "false" }), false);
+  assert.equal(isStripReasoningRequested({ "x-omniroute-strip-reasoning": "0" }), false);
+  assert.equal(isStripReasoningRequested({ "x-omniroute-strip-reasoning": "no" }), false);
+});
+
+test("getHeaderValueCaseInsensitive still resolves the header (sanity)", () => {
+  assert.equal(
+    getHeaderValueCaseInsensitive(
+      { "x-omniroute-strip-reasoning": "true" },
+      "x-omniroute-strip-reasoning"
+    ),
+    "true"
+  );
+});
+
+// Default behavior (regression guard): reasoning-only messages keep
+// reasoning_content. This matches existing logic — non-streaming responses
+// only drop reasoning_content when there is ALSO visible content.
+test("default: reasoning-only message keeps reasoning_content", () => {
+  const out = sanitizeOpenAIResponse({
+    id: "chatcmpl-x",
+    object: "chat.completion",
+    created: 1,
+    model: "deepseek-reasoner",
+    choices: [
+      {
+        index: 0,
+        message: { role: "assistant", content: "", reasoning_content: "internal thoughts" },
+        finish_reason: "stop",
+      },
+    ],
+  }) as { choices: Array<{ message: { reasoning_content?: string } }> };
+  assert.equal(out.choices[0].message.reasoning_content, "internal thoughts");
+});
+
+// Opt-in port of PR#517: when stripReasoning=true, reasoning_content is
+// always removed from the final non-streaming JSON, even on reasoning-only
+// messages. Firecrawl AI SDK and similar JSON parsers cannot tolerate it.
+test("stripReasoning=true: reasoning-only message has reasoning_content removed", () => {
+  const out = sanitizeOpenAIResponse(
+    {
+      id: "chatcmpl-x",
+      object: "chat.completion",
+      created: 1,
+      model: "deepseek-reasoner",
+      choices: [
+        {
+          index: 0,
+          message: { role: "assistant", content: "", reasoning_content: "internal thoughts" },
+          finish_reason: "stop",
+        },
+      ],
+    },
+    { stripReasoning: true }
+  ) as { choices: Array<{ message: Record<string, unknown> }> };
+  assert.equal(out.choices[0].message.reasoning_content, undefined);
+  assert.equal("reasoning_content" in out.choices[0].message, false);
+});
+
+test("stripReasoning=true: message with both content and reasoning_content has reasoning stripped", () => {
+  const out = sanitizeOpenAIResponse(
+    {
+      id: "chatcmpl-x",
+      object: "chat.completion",
+      created: 1,
+      model: "deepseek-v4",
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: "assistant",
+            content: "visible answer",
+            reasoning_content: "internal",
+          },
+          finish_reason: "stop",
+        },
+      ],
+    },
+    { stripReasoning: true }
+  ) as { choices: Array<{ message: Record<string, unknown> }> };
+  assert.equal(out.choices[0].message.reasoning_content, undefined);
+  assert.equal(out.choices[0].message.content, "visible answer");
+});


### PR DESCRIPTION
## Summary

Port of upstream [decolua/9router#517](https://github.com/decolua/9router/pull/517) (closes upstream [#509](https://github.com/decolua/9router/issues/509)).

Adds an opt-in per-request header **`x-omniroute-strip-reasoning: true`** (truthy = `true` / `1` / `yes`, case-insensitive) that unconditionally removes `reasoning_content` from the final non-streaming Chat Completions JSON payload — including reasoning-only messages and DeepSeek V4, cases the default sanitizer otherwise preserves.

### Why opt-in (vs upstream's unconditional strip)

Some clients (notably the **Firecrawl AI SDK `/extract` flow**) have JSON parsers that break on `reasoning_content` even though it's a valid OpenAI extension. Upstream PR #517 strips it unconditionally in the two non-streaming response paths. OmniRoute already has nuanced logic in `sanitizeMessage` (drops `reasoning_content` only when visible content is also present; keeps it for reasoning-only messages and DeepSeek V4) because some clients (LobeChat, etc.) DO consume it. Threading the strip as an opt-in header preserves both behaviors.

### Cache safety

The reasoning replay cache (#1628) captures `reasoning_content` at `chatCore.ts:4237` — **before** the sanitize step at `:4253`. The header only affects the outbound JSON payload, so the replay cache continues to work even when the strip is requested.

## Changes

- `open-sse/handlers/chatCore/headers.ts` — new helper `isStripReasoningRequested()` mirroring `isNoMemoryRequested()`.
- `open-sse/handlers/responseSanitizer.ts` — `sanitizeOpenAIResponse()` accepts an optional `{ stripReasoning }` option that deletes `reasoning_content` from every choice message after the existing sanitize pass.
- `open-sse/handlers/chatCore.ts` — reads the header and threads `stripReasoning` into the OpenAI-format sanitize call.
- `tests/unit/strip-reasoning-header.test.ts` — 8 TDD tests covering header parsing (truthy/falsy, case-insensitive, Headers instance) + sanitizer behavior (default keeps reasoning-only; opt-in strips both reasoning-only and dual content+reasoning cases).
- `CHANGELOG.md` — one bullet under `[3.8.34]` → `New Features`.

## Test plan

- [x] `node --import tsx/esm --test tests/unit/strip-reasoning-header.test.ts` — 8/8 pass.
- [x] `node --import tsx/esm --test tests/unit/response-sanitizer.test.ts tests/unit/no-memory-header.test.ts tests/unit/textual-toolcall-sanitizer-false-positive.test.ts` — 37/37 pass (regression).
- [x] `npm run typecheck:core` — clean.
- [x] `npx eslint` on touched files — clean.

## Attribution

Original upstream PR by **@anuragg-saxenaa** (`anuragg.saxenaa@gmail.com`) — credited via `Co-authored-by` trailer in the commit. The OmniRoute adaptation (opt-in header instead of unconditional strip; threading through the existing nuanced sanitizer) preserves existing reasoning-aware clients while solving the same Firecrawl-class breakage upstream targeted.

Inspired-by: https://github.com/decolua/9router/pull/517

> **DO NOT MERGE** — under review.