### PR TITLE
feat(cli): multi-model support for Factory Droid (port decolua/9router#618)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 _In development — bullets added per PR; finalized at release._
 
+### ✨ New Features
+
+- **feat(cli-tools): multi-model support for Factory Droid** — the Droid card in `/dashboard/cli-tools` now accepts a list of models instead of a single slot, writing one `custom:OmniRoute-<i>` entry per model into `~/.factory/settings.json`. The route accepts `models: string[]` (preferred) or the legacy `model: string`, plus an optional `activeModel` to promote one entry to index 0. Reset/detect logic matches every `custom:OmniRoute-*` id so multi-model installs round-trip cleanly. Backed by a pure helper (`buildDroidCustomModels` / `normalizeDroidModelList` / `isOmniRouteCustomModel`) with 11 unit tests. Ported from upstream PR [decolua/9router#618](https://github.com/decolua/9router/pull/618). (thanks @anuragg-saxenaa)
+
 ### 📝 Maintenance
 
 - **chore(quality): release-green pre-flight validator + nightly signal** — new `npm run check:release-green` (`scripts/quality/validate-release-green.mjs`) reproduces the release-equivalent validation (full unit + vitest + ratchets + typecheck + lint, optional `--with-build` package-artifact) against the current working tree and classifies each red as **HARD** (real defect) vs **DRIFT** (ratchet, rebaselined at release) — purely diagnostic, never blocking contributors. A new `nightly-release-green` workflow runs it on the active release branch and opens/updates a tracking issue on hard failures. Closes the gap where the full gate (`ci.yml`) only ran on the release PR, so reds accrued silently on `release/**` and surfaced in layers at release time. (thanks @diegosouzapw)

--- a/src/app/(dashboard)/dashboard/cli-code/components/DroidToolCard.tsx
+++ b/src/app/(dashboard)/dashboard/cli-code/components/DroidToolCard.tsx
@@ -28,7 +28,12 @@ export default function DroidToolCard({
   const [restoring, setRestoring] = useState(false);
   const [message, setMessage] = useState(null);
   const [selectedApiKeyId, setSelectedApiKeyId] = useState("");
-  const [selectedModel, setSelectedModel] = useState("");
+  // (#618) Multi-model support: list of model ids + input box for the next entry.
+  // `selectedModel` is derived as the first entry so existing call sites
+  // (manual-config preview, ModelSelectModal) continue to work.
+  const [modelList, setModelList] = useState([]);
+  const [modelInput, setModelInput] = useState("");
+  const selectedModel = modelList[0] || "";
   const [modalOpen, setModalOpen] = useState(false);
   const [modelAliases, setModelAliases] = useState({});
   const [showManualConfigModal, setShowManualConfigModal] = useState(false);
@@ -40,11 +45,12 @@ export default function DroidToolCard({
   const [restoringBackup, setRestoringBackup] = useState(null);
   const cliReady = !!(droidStatus?.installed && droidStatus?.runnable);
 
+  // (#618) Match any custom:OmniRoute-<i> entry (multi-model).
+  const isOmniRouteEntry = (m) => typeof m?.id === "string" && m.id.startsWith("custom:OmniRoute");
+
   const getConfigStatus = () => {
     if (!cliReady) return null;
-    const currentConfig = droidStatus.settings?.customModels?.find(
-      (m) => m.id === "custom:OmniRoute-0"
-    );
+    const currentConfig = droidStatus.settings?.customModels?.find(isOmniRouteEntry);
     if (!currentConfig) return "not_configured";
     const localMatch =
       currentConfig.baseUrl?.includes("localhost") || currentConfig.baseUrl?.includes("127.0.0.1");
@@ -87,15 +93,19 @@ export default function DroidToolCard({
   useEffect(() => {
     if (droidStatus?.installed && !hasInitializedModel.current) {
       hasInitializedModel.current = true;
-      const customModel = droidStatus.settings?.customModels?.find(
-        (m) => m.id === "custom:OmniRoute-0"
-      );
-      if (customModel) {
-        if (customModel.model) setSelectedModel(customModel.model);
-        if (customModel.apiKey) {
+      // (#618) Pre-fill the multi-model list from every custom:OmniRoute-<i>
+      // entry, preserving the original index order.
+      const existing = (droidStatus.settings?.customModels || [])
+        .filter(isOmniRouteEntry)
+        .slice()
+        .sort((a, b) => (a.index || 0) - (b.index || 0));
+      if (existing.length > 0) {
+        setModelList(existing.map((m) => m.model).filter(Boolean));
+        const first = existing[0];
+        if (first?.apiKey) {
           // (#523) Keys from /api/keys are masked. Match by prefix/suffix.
-          const fileKeyPrefix = customModel.apiKey.slice(0, 8);
-          const fileKeySuffix = customModel.apiKey.slice(-4);
+          const fileKeyPrefix = first.apiKey.slice(0, 8);
+          const fileKeySuffix = first.apiKey.slice(-4);
           const matchedKey = apiKeys?.find(
             (k) => k.key && k.key.startsWith(fileKeyPrefix) && k.key.endsWith(fileKeySuffix)
           );
@@ -104,6 +114,15 @@ export default function DroidToolCard({
       }
     }
   }, [droidStatus, apiKeys]);
+
+  // (#618) Multi-model list manipulation helpers.
+  const addModel = (value) => {
+    const v = (value ?? modelInput).trim();
+    if (!v || modelList.includes(v)) return;
+    setModelList((prev) => [...prev, v]);
+    setModelInput("");
+  };
+  const removeModel = (id) => setModelList((prev) => prev.filter((m) => m !== id));
 
   const checkDroidStatus = async () => {
     setCheckingDroid(true);
@@ -143,7 +162,12 @@ export default function DroidToolCard({
           baseUrl: getEffectiveBaseUrl(),
           apiKey: !cloudEnabled ? "sk_omniroute" : null,
           keyId: selectedKeyId,
+          // (#618) Send both `model` (legacy, first entry) and `models` (array).
+          // Backend prefers `models` when present; `model` keeps Zod happy
+          // for callers still on the single-model contract.
           model: selectedModel,
+          models: modelList,
+          activeModel: selectedModel,
         }),
       });
       const data = await res.json();
@@ -173,7 +197,7 @@ export default function DroidToolCard({
       const data = await res.json();
       if (res.ok) {
         setMessage({ type: "success", text: t("settingsReset") });
-        setSelectedModel("");
+        setModelList([]);
         setSelectedApiKeyId("");
         checkDroidStatus();
       } else {
@@ -192,7 +216,12 @@ export default function DroidToolCard({
   };
 
   const handleModelSelect = (model) => {
-    setSelectedModel(model.value);
+    // (#618) Append to the model list rather than replacing the single slot.
+    if (!model?.value || modelList.includes(model.value)) {
+      setModalOpen(false);
+      return;
+    }
+    setModelList((prev) => [...prev, model.value]);
     setModalOpen(false);
   };
 
@@ -242,20 +271,21 @@ export default function DroidToolCard({
     const keyToDisplay =
       selectedKeyObj?.key || (!cloudEnabled ? "sk_omniroute" : "<API_KEY_FROM_DASHBOARD>");
 
+    // (#618) Render one entry per requested model; fall back to a placeholder
+    // when the list is empty so manual-config preview still shows the shape.
+    const modelsForPreview = modelList.length > 0 ? modelList : ["provider/model-id"];
     const settingsContent = {
-      customModels: [
-        {
-          model: selectedModel || "provider/model-id",
-          id: "custom:OmniRoute-0",
-          index: 0,
-          baseUrl: getEffectiveBaseUrl(),
-          apiKey: keyToDisplay,
-          displayName: selectedModel || "provider/model-id",
-          maxOutputTokens: 131072,
-          noImageSupport: false,
-          provider: "openai",
-        },
-      ],
+      customModels: modelsForPreview.map((m, i) => ({
+        model: m,
+        id: `custom:OmniRoute-${i}`,
+        index: i,
+        baseUrl: getEffectiveBaseUrl(),
+        apiKey: keyToDisplay,
+        displayName: m,
+        maxOutputTokens: 131072,
+        noImageSupport: false,
+        provider: "openai",
+      })),
     };
 
     const platform = typeof navigator !== "undefined" && navigator.platform;
@@ -332,9 +362,8 @@ export default function DroidToolCard({
           {!checkingDroid && cliReady && (
             <>
               <div className="flex flex-col gap-2">
-                {/* Current Base URL */}
-                {droidStatus?.settings?.customModels?.find((m) => m.id === "custom:OmniRoute-0")
-                  ?.baseUrl && (
+                {/* Current Base URL — first OmniRoute entry, any index (#618) */}
+                {droidStatus?.settings?.customModels?.find(isOmniRouteEntry)?.baseUrl && (
                   <div className="flex items-center gap-2">
                     <span className="w-32 shrink-0 text-sm font-semibold text-text-main text-right">
                       {t("current")}
@@ -343,10 +372,7 @@ export default function DroidToolCard({
                       arrow_forward
                     </span>
                     <span className="flex-1 px-2 py-1.5 text-xs text-text-muted truncate">
-                      {
-                        droidStatus.settings.customModels.find((m) => m.id === "custom:OmniRoute-0")
-                          .baseUrl
-                      }
+                      {droidStatus.settings.customModels.find(isOmniRouteEntry).baseUrl}
                     </span>
                   </div>
                 )}
@@ -404,37 +430,68 @@ export default function DroidToolCard({
                   )}
                 </div>
 
-                {/* Model */}
-                <div className="flex items-center gap-2">
-                  <span className="w-32 shrink-0 text-sm font-semibold text-text-main text-right">
+                {/* Models — multi-model support (#618) */}
+                <div className="flex items-start gap-2">
+                  <span className="w-32 shrink-0 text-sm font-semibold text-text-main text-right pt-1.5">
                     {t("model")}
+                    {modelList.length > 0 && (
+                      <span className="text-primary"> ({modelList.length})</span>
+                    )}
                   </span>
-                  <span className="material-symbols-outlined text-text-muted text-[14px]">
+                  <span className="material-symbols-outlined text-text-muted text-[14px] pt-2">
                     arrow_forward
                   </span>
-                  <input
-                    type="text"
-                    value={selectedModel}
-                    onChange={(e) => setSelectedModel(e.target.value)}
-                    placeholder={t("providerModelPlaceholder")}
-                    className="flex-1 px-2 py-1.5 bg-surface rounded border border-border text-xs focus:outline-none focus:ring-1 focus:ring-primary/50"
-                  />
-                  <button
-                    onClick={() => setModalOpen(true)}
-                    disabled={!hasActiveProviders}
-                    className={`px-2 py-1.5 rounded border text-xs transition-colors shrink-0 whitespace-nowrap ${hasActiveProviders ? "bg-surface border-border text-text-main hover:border-primary cursor-pointer" : "opacity-50 cursor-not-allowed border-border"}`}
-                  >
-                    {t("selectModel")}
-                  </button>
-                  {selectedModel && (
-                    <button
-                      onClick={() => setSelectedModel("")}
-                      className="p-1 text-text-muted hover:text-red-500 rounded transition-colors"
-                      title={t("clear")}
-                    >
-                      <span className="material-symbols-outlined text-[14px]">close</span>
-                    </button>
-                  )}
+                  <div className="flex-1 flex flex-col gap-1">
+                    {modelList.length > 0 && (
+                      <div className="flex flex-col gap-0.5 mb-1">
+                        {modelList.map((id) => (
+                          <div
+                            key={id}
+                            className="flex items-center gap-1.5 px-2 py-1 bg-bg-secondary rounded border border-border"
+                          >
+                            <span className="flex-1 text-xs font-mono truncate">{id}</span>
+                            <button
+                              onClick={() => removeModel(id)}
+                              className="text-text-muted hover:text-red-500 transition-colors shrink-0"
+                              title={t("clear")}
+                            >
+                              <span className="material-symbols-outlined text-[12px]">close</span>
+                            </button>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                    <div className="flex items-center gap-1.5">
+                      <input
+                        type="text"
+                        value={modelInput}
+                        onChange={(e) => setModelInput(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter") {
+                            e.preventDefault();
+                            addModel();
+                          }
+                        }}
+                        placeholder={t("providerModelPlaceholder")}
+                        className="flex-1 px-2 py-1.5 bg-surface rounded border border-border text-xs focus:outline-none focus:ring-1 focus:ring-primary/50"
+                      />
+                      <button
+                        onClick={() => setModalOpen(true)}
+                        disabled={!hasActiveProviders}
+                        className={`px-2 py-1.5 rounded border text-xs transition-colors shrink-0 whitespace-nowrap ${hasActiveProviders ? "bg-surface border-border text-text-main hover:border-primary cursor-pointer" : "opacity-50 cursor-not-allowed border-border"}`}
+                      >
+                        {t("selectModel")}
+                      </button>
+                      <button
+                        onClick={() => addModel()}
+                        disabled={!modelInput.trim() || modelList.includes(modelInput.trim())}
+                        className="px-2 py-1.5 rounded border bg-surface border-border hover:border-primary text-xs shrink-0 disabled:opacity-50"
+                        title="Add model"
+                      >
+                        <span className="material-symbols-outlined text-[14px]">add</span>
+                      </button>
+                    </div>
+                  </div>
                 </div>
               </div>
 
@@ -454,7 +511,7 @@ export default function DroidToolCard({
                   variant="primary"
                   size="sm"
                   onClick={handleApplySettings}
-                  disabled={!selectedModel}
+                  disabled={modelList.length === 0}
                   loading={applying}
                 >
                   <span className="material-symbols-outlined text-[14px] mr-1">save</span>

--- a/src/app/api/cli-tools/droid-settings/route.ts
+++ b/src/app/api/cli-tools/droid-settings/route.ts
@@ -11,10 +11,15 @@ import {
 } from "@/shared/services/cliRuntime";
 import { createBackup } from "@/shared/services/backupService";
 import { saveCliToolLastConfigured, deleteCliToolLastConfigured } from "@/lib/db/cliToolState";
-import { cliModelConfigSchema } from "@/shared/validation/schemas";
+import { cliMultiModelConfigSchema } from "@/shared/validation/schemas";
 import { isValidationFailure, validateBody } from "@/shared/validation/helpers";
 import { resolveApiKey } from "@/shared/services/apiKeyResolver";
 import { readJsoncConfig } from "../_lib/jsoncConfig";
+import {
+  buildDroidCustomModels,
+  isOmniRouteCustomModel,
+  normalizeDroidModelList,
+} from "@/shared/services/droidCustomModels";
 
 const getDroidSettingsPath = () => getCliPrimaryConfigPath("droid");
 const getDroidDir = () => path.dirname(getDroidSettingsPath());
@@ -25,10 +30,12 @@ const getDroidDir = () => path.dirname(getDroidSettingsPath());
 // "installed but not configured" instead of a 500 misread as "not installed".
 const readSettings = async () => readJsoncConfig(getDroidSettingsPath());
 
-// Check if settings has OmniRoute customModels
+// Check if settings has OmniRoute customModels.
+// Multi-model entries are stored as `custom:OmniRoute-0`, `custom:OmniRoute-1`, …
+// (Ported from upstream PR decolua/9router#618.)
 const hasOmniRouteConfig = (settings: any) => {
   if (!settings || !settings.customModels) return false;
-  return settings.customModels.some((m) => m.id === "custom:OmniRoute-0");
+  return settings.customModels.some(isOmniRouteCustomModel);
 };
 
 // GET - Check droid CLI and read current settings
@@ -103,12 +110,29 @@ export async function POST(request: Request) {
     // (#549) Extract keyId BEFORE validation — Zod strips unknown fields!
     const keyId = typeof rawBody?.keyId === "string" ? rawBody.keyId.trim() : null;
 
-    const validation = validateBody(cliModelConfigSchema, rawBody);
+    const validation = validateBody(cliMultiModelConfigSchema, rawBody);
     if (isValidationFailure(validation)) {
       return NextResponse.json({ error: validation.error }, { status: 400 });
     }
-    const { baseUrl, model } = validation.data;
+    const { baseUrl, model, models, activeModel } = validation.data;
     const apiKey = await resolveApiKey(keyId, validation.data.apiKey);
+
+    // Multi-model support (ported from decolua/9router#618): accept either a
+    // `models` array or the legacy single `model` string.
+    const modelList = normalizeDroidModelList({ model, models });
+    if (modelList.length === 0) {
+      return NextResponse.json(
+        {
+          error: {
+            message: "Invalid request",
+            details: [
+              { field: "models", message: "baseUrl and at least one model are required" },
+            ],
+          },
+        },
+        { status: 400 }
+      );
+    }
 
     const droidDir = getDroidDir();
     const settingsPath = getDroidSettingsPath();
@@ -133,26 +157,19 @@ export async function POST(request: Request) {
       settings.customModels = [];
     }
 
-    // Remove existing OmniRoute config if any
-    settings.customModels = settings.customModels.filter((m) => m.id !== "custom:OmniRoute-0");
+    // Remove every existing OmniRoute config (multi-model: index 0..N)
+    settings.customModels = settings.customModels.filter((m) => !isOmniRouteCustomModel(m));
 
     // Normalize baseUrl to ensure /v1 suffix
     const normalizedBaseUrl = baseUrl.endsWith("/v1") ? baseUrl : `${baseUrl}/v1`;
 
-    // Add new OmniRoute config
-    const customModel = {
-      model: model,
-      id: "custom:OmniRoute-0",
-      index: 0,
+    // Build and prepend OmniRoute entries (one per requested model)
+    const newEntries = buildDroidCustomModels(modelList, {
       baseUrl: normalizedBaseUrl,
       apiKey: apiKey || "your_api_key",
-      displayName: model,
-      maxOutputTokens: 131072,
-      noImageSupport: false,
-      provider: "openai",
-    };
-
-    settings.customModels.unshift(customModel);
+      activeModel,
+    });
+    settings.customModels = [...newEntries, ...settings.customModels];
 
     // Write settings
     await fs.writeFile(settingsPath, JSON.stringify(settings, null, 2));
@@ -206,9 +223,9 @@ export async function DELETE(request: Request) {
       throw error;
     }
 
-    // Remove OmniRoute customModels
+    // Remove OmniRoute customModels (every index, multi-model)
     if (settings.customModels) {
-      settings.customModels = settings.customModels.filter((m) => m.id !== "custom:OmniRoute-0");
+      settings.customModels = settings.customModels.filter((m) => !isOmniRouteCustomModel(m));
 
       // Remove customModels array if empty
       if (settings.customModels.length === 0) {

--- a/src/app/api/cli-tools/droid-settings/route.ts
+++ b/src/app/api/cli-tools/droid-settings/route.ts
@@ -11,9 +11,14 @@ import {
 } from "@/shared/services/cliRuntime";
 import { createBackup } from "@/shared/services/backupService";
 import { saveCliToolLastConfigured, deleteCliToolLastConfigured } from "@/lib/db/cliToolState";
-import { cliModelConfigSchema } from "@/shared/validation/schemas";
+import { cliMultiModelConfigSchema } from "@/shared/validation/schemas";
 import { isValidationFailure, validateBody } from "@/shared/validation/helpers";
 import { resolveApiKey } from "@/shared/services/apiKeyResolver";
+import {
+  buildDroidCustomModels,
+  isOmniRouteCustomModel,
+  normalizeDroidModelList,
+} from "@/shared/services/droidCustomModels";
 
 const getDroidSettingsPath = () => getCliPrimaryConfigPath("droid");
 const getDroidDir = () => path.dirname(getDroidSettingsPath());
@@ -30,10 +35,12 @@ const readSettings = async () => {
   }
 };
 
-// Check if settings has OmniRoute customModels
+// Check if settings has OmniRoute customModels.
+// Multi-model entries are stored as `custom:OmniRoute-0`, `custom:OmniRoute-1`, …
+// (Ported from upstream PR decolua/9router#618.)
 const hasOmniRouteConfig = (settings: any) => {
   if (!settings || !settings.customModels) return false;
-  return settings.customModels.some((m) => m.id === "custom:OmniRoute-0");
+  return settings.customModels.some(isOmniRouteCustomModel);
 };
 
 // GET - Check droid CLI and read current settings
@@ -108,12 +115,29 @@ export async function POST(request: Request) {
     // (#549) Extract keyId BEFORE validation — Zod strips unknown fields!
     const keyId = typeof rawBody?.keyId === "string" ? rawBody.keyId.trim() : null;
 
-    const validation = validateBody(cliModelConfigSchema, rawBody);
+    const validation = validateBody(cliMultiModelConfigSchema, rawBody);
     if (isValidationFailure(validation)) {
       return NextResponse.json({ error: validation.error }, { status: 400 });
     }
-    const { baseUrl, model } = validation.data;
+    const { baseUrl, model, models, activeModel } = validation.data;
     const apiKey = await resolveApiKey(keyId, validation.data.apiKey);
+
+    // Multi-model support (ported from decolua/9router#618): accept either a
+    // `models` array or the legacy single `model` string.
+    const modelList = normalizeDroidModelList({ model, models });
+    if (modelList.length === 0) {
+      return NextResponse.json(
+        {
+          error: {
+            message: "Invalid request",
+            details: [
+              { field: "models", message: "baseUrl and at least one model are required" },
+            ],
+          },
+        },
+        { status: 400 }
+      );
+    }
 
     const droidDir = getDroidDir();
     const settingsPath = getDroidSettingsPath();
@@ -138,26 +162,19 @@ export async function POST(request: Request) {
       settings.customModels = [];
     }
 
-    // Remove existing OmniRoute config if any
-    settings.customModels = settings.customModels.filter((m) => m.id !== "custom:OmniRoute-0");
+    // Remove every existing OmniRoute config (multi-model: index 0..N)
+    settings.customModels = settings.customModels.filter((m) => !isOmniRouteCustomModel(m));
 
     // Normalize baseUrl to ensure /v1 suffix
     const normalizedBaseUrl = baseUrl.endsWith("/v1") ? baseUrl : `${baseUrl}/v1`;
 
-    // Add new OmniRoute config
-    const customModel = {
-      model: model,
-      id: "custom:OmniRoute-0",
-      index: 0,
+    // Build and prepend OmniRoute entries (one per requested model)
+    const newEntries = buildDroidCustomModels(modelList, {
       baseUrl: normalizedBaseUrl,
       apiKey: apiKey || "your_api_key",
-      displayName: model,
-      maxOutputTokens: 131072,
-      noImageSupport: false,
-      provider: "openai",
-    };
-
-    settings.customModels.unshift(customModel);
+      activeModel,
+    });
+    settings.customModels = [...newEntries, ...settings.customModels];
 
     // Write settings
     await fs.writeFile(settingsPath, JSON.stringify(settings, null, 2));
@@ -211,9 +228,9 @@ export async function DELETE(request: Request) {
       throw error;
     }
 
-    // Remove OmniRoute customModels
+    // Remove OmniRoute customModels (every index, multi-model)
     if (settings.customModels) {
-      settings.customModels = settings.customModels.filter((m) => m.id !== "custom:OmniRoute-0");
+      settings.customModels = settings.customModels.filter((m) => !isOmniRouteCustomModel(m));
 
       // Remove customModels array if empty
       if (settings.customModels.length === 0) {

--- a/src/shared/services/droidCustomModels.ts
+++ b/src/shared/services/droidCustomModels.ts
@@ -1,0 +1,118 @@
+/**
+ * Build the OmniRoute `customModels` entries for Factory Droid's `settings.json`.
+ *
+ * Ported from upstream PR decolua/9router#618 (author Anurag Saxena) — multi-model
+ * support for the Factory Droid CLI tool. Adapted to OmniRoute branding
+ * (`custom:OmniRoute-<i>`) and extracted as a pure helper so the route-handler
+ * logic is unit-testable without touching the filesystem.
+ */
+
+export interface DroidCustomModelOptions {
+  /** Already-normalized base URL (callers must ensure /v1 suffix). */
+  baseUrl: string;
+  /** API key to embed in every entry. */
+  apiKey: string;
+  /**
+   * Model id (e.g. `"openai/gpt-5"`) that should appear first in the array.
+   * When omitted (or not in `models`), entry index 0 stays first.
+   * When the empty string `""` is passed explicitly, no reordering happens
+   * — the caller signalled "do not promote any model to default".
+   */
+  activeModel?: string;
+}
+
+export interface DroidCustomModelEntry {
+  model: string;
+  id: string;
+  index: number;
+  baseUrl: string;
+  apiKey: string;
+  displayName: string;
+  maxOutputTokens: number;
+  noImageSupport: boolean;
+  provider: string;
+}
+
+/**
+ * Returns the trimmed, deduplicated, non-empty model ids in input order.
+ * Accepts either a `models` array (multi-model, upstream #618) or a legacy
+ * `model` string (single-model, pre-#618 behavior).
+ */
+export function normalizeDroidModelList(input: {
+  model?: unknown;
+  models?: unknown;
+}): string[] {
+  const raw: unknown[] = Array.isArray(input.models)
+    ? input.models
+    : typeof input.model === "string"
+      ? [input.model]
+      : [];
+
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const m of raw) {
+    if (typeof m !== "string") continue;
+    const trimmed = m.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    out.push(trimmed);
+  }
+  return out;
+}
+
+/**
+ * Build the final `customModels` array. Throws when `models` is empty —
+ * callers should validate before invoking.
+ */
+export function buildDroidCustomModels(
+  models: string[],
+  opts: DroidCustomModelOptions
+): DroidCustomModelEntry[] {
+  if (models.length === 0) {
+    throw new Error("buildDroidCustomModels requires at least one model");
+  }
+
+  // Default index resolution:
+  //   - undefined  → 0 (first entry stays first)
+  //   - ""         → -1 (do not promote anything)
+  //   - <value>    → index of value in models (or 0 if not found)
+  let defaultIndex: number;
+  if (typeof opts.activeModel === "string") {
+    if (opts.activeModel === "") {
+      defaultIndex = -1;
+    } else {
+      const idx = models.indexOf(opts.activeModel);
+      defaultIndex = idx >= 0 ? idx : 0;
+    }
+  } else {
+    defaultIndex = 0;
+  }
+
+  const entries: DroidCustomModelEntry[] = models.map((m, i) => ({
+    model: m,
+    id: `custom:OmniRoute-${i}`,
+    index: i,
+    baseUrl: opts.baseUrl,
+    apiKey: opts.apiKey,
+    displayName: m,
+    maxOutputTokens: 131072,
+    noImageSupport: false,
+    provider: "openai",
+  }));
+
+  if (defaultIndex > 0 && entries[defaultIndex]) {
+    const [defaultEntry] = entries.splice(defaultIndex, 1);
+    entries.unshift({ ...defaultEntry, index: 0 });
+    entries.forEach((e, i) => {
+      e.index = i;
+      e.id = `custom:OmniRoute-${i}`;
+    });
+  }
+
+  return entries;
+}
+
+/** True when a `customModels` entry was written by OmniRoute (any index). */
+export function isOmniRouteCustomModel(entry: { id?: unknown } | null | undefined): boolean {
+  return typeof entry?.id === "string" && entry.id.startsWith("custom:OmniRoute");
+}

--- a/src/shared/validation/schemas/cli.ts
+++ b/src/shared/validation/schemas/cli.ts
@@ -73,3 +73,14 @@ export const cliModelConfigSchema = z.object({
   wireApi: z.enum(["chat", "responses"]).optional(),
   modelMappings: z.record(z.string().trim().min(1), z.string().trim().min(1)).optional(),
 });
+
+/**
+ * Multi-model variant of `cliModelConfigSchema`. Adds optional `models`
+ * (array of strings, takes precedence over `model`) and `activeModel`
+ * (string id to promote to first position). Ported from upstream PR
+ * decolua/9router#618 for the Factory Droid CLI tool.
+ */
+export const cliMultiModelConfigSchema = cliModelConfigSchema.extend({
+  models: z.array(z.string().trim().min(1)).optional(),
+  activeModel: z.string().optional(),
+});

--- a/tests/unit/droid-custom-models.test.ts
+++ b/tests/unit/droid-custom-models.test.ts
@@ -1,0 +1,122 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildDroidCustomModels,
+  isOmniRouteCustomModel,
+  normalizeDroidModelList,
+} from "../../src/shared/services/droidCustomModels.ts";
+
+test("normalizeDroidModelList accepts legacy single `model` string", () => {
+  assert.deepEqual(normalizeDroidModelList({ model: "openai/gpt-5" }), ["openai/gpt-5"]);
+});
+
+test("normalizeDroidModelList accepts `models` array (upstream #618)", () => {
+  assert.deepEqual(
+    normalizeDroidModelList({ models: ["openai/gpt-5", "anthropic/claude-4"] }),
+    ["openai/gpt-5", "anthropic/claude-4"]
+  );
+});
+
+test("normalizeDroidModelList prefers `models` over legacy `model`", () => {
+  assert.deepEqual(
+    normalizeDroidModelList({ model: "legacy/old", models: ["openai/gpt-5"] }),
+    ["openai/gpt-5"]
+  );
+});
+
+test("normalizeDroidModelList trims and dedupes, drops empty/non-string", () => {
+  assert.deepEqual(
+    normalizeDroidModelList({
+      models: [" openai/gpt-5 ", "openai/gpt-5", "", "  ", 42, null, "anthropic/claude-4"],
+    }),
+    ["openai/gpt-5", "anthropic/claude-4"]
+  );
+});
+
+test("normalizeDroidModelList returns [] on missing/invalid input", () => {
+  assert.deepEqual(normalizeDroidModelList({}), []);
+  assert.deepEqual(normalizeDroidModelList({ model: 7 as unknown }), []);
+  assert.deepEqual(normalizeDroidModelList({ models: "not-an-array" as unknown }), []);
+});
+
+test("buildDroidCustomModels emits one entry per model with sequential ids", () => {
+  const out = buildDroidCustomModels(["openai/gpt-5", "anthropic/claude-4"], {
+    baseUrl: "http://localhost:20128/v1",
+    apiKey: "sk_omniroute",
+  });
+
+  assert.equal(out.length, 2);
+  assert.equal(out[0].id, "custom:OmniRoute-0");
+  assert.equal(out[0].index, 0);
+  assert.equal(out[0].model, "openai/gpt-5");
+  assert.equal(out[0].displayName, "openai/gpt-5");
+  assert.equal(out[0].provider, "openai");
+  assert.equal(out[0].maxOutputTokens, 131072);
+  assert.equal(out[0].noImageSupport, false);
+  assert.equal(out[0].baseUrl, "http://localhost:20128/v1");
+  assert.equal(out[0].apiKey, "sk_omniroute");
+  assert.equal(out[1].id, "custom:OmniRoute-1");
+  assert.equal(out[1].index, 1);
+});
+
+test("buildDroidCustomModels promotes activeModel to index 0", () => {
+  const out = buildDroidCustomModels(["openai/gpt-5", "anthropic/claude-4", "google/gemini"], {
+    baseUrl: "http://localhost:20128/v1",
+    apiKey: "sk_omniroute",
+    activeModel: "anthropic/claude-4",
+  });
+
+  assert.equal(out[0].model, "anthropic/claude-4");
+  assert.equal(out[0].id, "custom:OmniRoute-0");
+  assert.equal(out[0].index, 0);
+  // Remaining entries are re-indexed in their original relative order
+  assert.equal(out[1].model, "openai/gpt-5");
+  assert.equal(out[1].id, "custom:OmniRoute-1");
+  assert.equal(out[1].index, 1);
+  assert.equal(out[2].model, "google/gemini");
+  assert.equal(out[2].id, "custom:OmniRoute-2");
+  assert.equal(out[2].index, 2);
+});
+
+test("buildDroidCustomModels keeps order when activeModel is not in the list", () => {
+  const out = buildDroidCustomModels(["openai/gpt-5", "anthropic/claude-4"], {
+    baseUrl: "http://localhost:20128/v1",
+    apiKey: "sk_omniroute",
+    activeModel: "unknown/model",
+  });
+  assert.equal(out[0].model, "openai/gpt-5");
+  assert.equal(out[1].model, "anthropic/claude-4");
+});
+
+test("buildDroidCustomModels keeps order when activeModel === '' (no promotion)", () => {
+  const out = buildDroidCustomModels(["openai/gpt-5", "anthropic/claude-4"], {
+    baseUrl: "http://localhost:20128/v1",
+    apiKey: "sk_omniroute",
+    activeModel: "",
+  });
+  assert.equal(out[0].model, "openai/gpt-5");
+  assert.equal(out[1].model, "anthropic/claude-4");
+});
+
+test("buildDroidCustomModels throws on empty list", () => {
+  assert.throws(
+    () =>
+      buildDroidCustomModels([], {
+        baseUrl: "http://localhost:20128/v1",
+        apiKey: "sk_omniroute",
+      }),
+    /requires at least one model/
+  );
+});
+
+test("isOmniRouteCustomModel matches any custom:OmniRoute-<i> id (multi-model)", () => {
+  assert.equal(isOmniRouteCustomModel({ id: "custom:OmniRoute-0" }), true);
+  assert.equal(isOmniRouteCustomModel({ id: "custom:OmniRoute-1" }), true);
+  assert.equal(isOmniRouteCustomModel({ id: "custom:OmniRoute-42" }), true);
+  assert.equal(isOmniRouteCustomModel({ id: "custom:Other-0" }), false);
+  assert.equal(isOmniRouteCustomModel({ id: 42 as unknown }), false);
+  assert.equal(isOmniRouteCustomModel(null), false);
+  assert.equal(isOmniRouteCustomModel(undefined), false);
+  assert.equal(isOmniRouteCustomModel({}), false);
+});


### PR DESCRIPTION
## Summary

Ports upstream PR [decolua/9router#618](https://github.com/decolua/9router/pull/618) — multi-model support for the Factory Droid CLI — into OmniRoute.

- The Droid card in `/dashboard/cli-tools` now manages a **list of models** instead of a single slot. Add models by typing + Enter, by clicking **Add**, or by picking from `ModelSelectModal` (now appends instead of replacing). Each model can be removed individually.
- `POST /api/cli-tools/droid-settings` accepts either `models: string[]` (preferred) or the legacy `model: string`. An optional `activeModel` promotes one entry to index 0. Writes one `custom:OmniRoute-<i>` entry per model into `~/.factory/settings.json`.
- Detection (`hasOmniRoute`), pre-fill, `Reset`, and the "Current" base-URL line now match **any** `custom:OmniRoute-*` id so multi-model installs round-trip cleanly.
- Core logic extracted into a pure helper `src/shared/services/droidCustomModels.ts` (normalize → dedupe → build entries → reorder for `activeModel`).
- New `cliMultiModelConfigSchema` (extends `cliModelConfigSchema` with optional `models[]` and `activeModel`); existing single-model schema and all other CLI-tool routes untouched.

## Test plan

- [x] `node --import tsx/esm --test tests/unit/droid-custom-models.test.ts` — **11 passing**
  - legacy single `model` string
  - `models` array (upstream contract)
  - `models` overrides `model` when both present
  - trim / dedupe / drop empty + non-string
  - per-model entry shape (id, index, baseUrl, apiKey, displayName, provider, maxOutputTokens, noImageSupport)
  - `activeModel` promotes to index 0 and re-indexes the rest
  - `activeModel` not in list → no-op
  - `activeModel === ""` → no promotion
  - empty list throws
  - `isOmniRouteCustomModel` matches every `custom:OmniRoute-<i>` id (multi-model)
- [x] `node --import tsx/esm --test tests/unit/cli-tools-schema.test.ts tests/unit/cli-tools.test.ts tests/unit/droid-custom-models.test.ts` — **21 passing** (no regression in adjacent suites)
- [x] `npx tsc --noEmit -p tsconfig.json` — exit 0
- [x] `npx eslint` over touched files — clean
- [ ] Manual VPS smoke (192.168.0.15): apply 2 models → inspect `~/.factory/settings.json` for `custom:OmniRoute-0` + `custom:OmniRoute-1` → reset → confirm both entries removed
- [ ] CI green (do not merge until ✅)

## Attribution

- Upstream PR: [decolua/9router#618](https://github.com/decolua/9router/pull/618) — closes upstream issue [decolua/9router#521](https://github.com/decolua/9router/issues/521)
- Original author: **Anurag Saxena** ([@anuragg-saxenaa](https://github.com/anuragg-saxenaa))
- Adapted to OmniRoute: TypeScript, `custom:OmniRoute-*` namespace, `cliMultiModelConfigSchema`, keyId/Zod validation pipeline, i18n strings, pre-fill from existing config, manual-config modal preview.

## Do not merge

Babysit CI; do not auto-merge.