### PR TITLE
fix(proxy): apply pipelining:0 + connections cap to the direct dispatcher (#4580)

### DIFF
--- a/open-sse/utils/proxyDispatcher.ts
+++ b/open-sse/utils/proxyDispatcher.ts
@@ -108,10 +108,42 @@ function getProxyDispatcherOptions(env: Record<string, string | undefined> = pro
   };
 }
 
+export function getDefaultDispatcherConnectionLimit(
+  env: Record<string, string | undefined> = process.env
+): number {
+  const raw = env.OMNIROUTE_DIRECT_DISPATCHER_CONNECTIONS;
+  if (raw == null || raw.trim() === "") return DEFAULT_PROXY_DISPATCHER_CONNECTIONS;
+
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    console.warn(
+      `[ProxyDispatcher] Invalid OMNIROUTE_DIRECT_DISPATCHER_CONNECTIONS="${raw}". Using default ${DEFAULT_PROXY_DISPATCHER_CONNECTIONS}.`
+    );
+    return DEFAULT_PROXY_DISPATCHER_CONNECTIONS;
+  }
+
+  return Math.min(Math.floor(parsed), MAX_PROXY_DISPATCHER_CONNECTIONS);
+}
+
+function getDefaultDispatcherOptions(env: Record<string, string | undefined> = process.env) {
+  const options = getDispatcherOptions();
+  // #4580 — On the direct egress path, undici's default pipelining (1) lets a long
+  // SSE stream monopolize the single pooled socket per origin, serializing every
+  // other concurrent request to that same provider. Mirror the proxy fix (#4288):
+  // disable pipelining and keep several connections available. Unlike the proxy
+  // path we KEEP keep-alive — the 1ms TTL there is a cheap-proxy-socket workaround,
+  // not needed (and harmful to perf) for direct connections.
+  return {
+    ...options,
+    connections: getDefaultDispatcherConnectionLimit(env),
+    pipelining: 0,
+  };
+}
+
 export function getDefaultDispatcher(): Dispatcher {
   const globalWithCache = globalThis as GlobalWithDispatcherCache;
   if (!globalWithCache[DEFAULT_DISPATCHER_KEY]) {
-    globalWithCache[DEFAULT_DISPATCHER_KEY] = new Agent(getDispatcherOptions());
+    globalWithCache[DEFAULT_DISPATCHER_KEY] = new Agent(getDefaultDispatcherOptions());
   }
   return globalWithCache[DEFAULT_DISPATCHER_KEY];
 }
@@ -360,6 +392,12 @@ export function __getProxyDispatcherOptionsForTest(
   env: Record<string, string | undefined> = process.env
 ) {
   return getProxyDispatcherOptions(env);
+}
+
+export function __getDefaultDispatcherOptionsForTest(
+  env: Record<string, string | undefined> = process.env
+) {
+  return getDefaultDispatcherOptions(env);
 }
 
 export function createProxyDispatcher(proxyUrl: string): Dispatcher {

--- a/tests/unit/direct-dispatcher-pipelining-4580.test.ts
+++ b/tests/unit/direct-dispatcher-pipelining-4580.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  __getDefaultDispatcherOptionsForTest,
+  __getProxyDispatcherOptionsForTest,
+  getDefaultDispatcherConnectionLimit,
+  clearDispatcherCache,
+} from "../../open-sse/utils/proxyDispatcher.ts";
+
+afterEach(() => clearDispatcherCache());
+
+// #4580 — On the DIRECT egress path, concurrent same-provider requests serialized
+// behind a long/streaming request. The proxy dispatcher already got pipelining:0 +
+// a connections cap in #4288, but the first-attempt direct dispatcher
+// (getDispatcherOptions → new Agent) kept undici's default pipelining (1), so long
+// SSE streams bottlenecked the single pooled socket. The direct dispatcher now
+// mirrors that fix while KEEPING keep-alive (a proxy-only concern was the 1ms TTL).
+
+describe("#4580 direct dispatcher options", () => {
+  it("disables pipelining so concurrent streams open separate sockets", () => {
+    const opts = __getDefaultDispatcherOptionsForTest({});
+    assert.equal(opts.pipelining, 0);
+  });
+
+  it("caps connections to a finite number (default 32)", () => {
+    const opts = __getDefaultDispatcherOptionsForTest({});
+    assert.equal(typeof opts.connections, "number");
+    assert.equal(opts.connections, 32);
+  });
+
+  it("preserves keep-alive (NOT the 1ms TTL the proxy path forces)", () => {
+    const direct = __getDefaultDispatcherOptionsForTest({});
+    const proxy = __getProxyDispatcherOptionsForTest({});
+    assert.equal(proxy.keepAliveTimeout, 1);
+    assert.ok(
+      (direct.keepAliveTimeout ?? 0) > 1,
+      `direct keepAliveTimeout should stay > 1 (got ${direct.keepAliveTimeout})`
+    );
+  });
+
+  it("connection limit honors OMNIROUTE_DIRECT_DISPATCHER_CONNECTIONS", () => {
+    assert.equal(getDefaultDispatcherConnectionLimit({ OMNIROUTE_DIRECT_DISPATCHER_CONNECTIONS: "8" }), 8);
+  });
+
+  it("connection limit clamps invalid values to the default", () => {
+    assert.equal(
+      getDefaultDispatcherConnectionLimit({ OMNIROUTE_DIRECT_DISPATCHER_CONNECTIONS: "nonsense" }),
+      32
+    );
+    assert.equal(getDefaultDispatcherConnectionLimit({}), 32);
+  });
+});


### PR DESCRIPTION
Closes #4580

## Problem
On the **direct** (non-proxy) egress path, while a long/streaming generation was in flight on a provider, every other concurrent request to that **same** provider blocked for ~the full duration of the heavy one — even trivial requests. Different providers were unaffected. The reporter runs `proxy=direct`, `max_concurrent=null` (so the account semaphore is bypassed — not the cause).

## Root cause
#4288 fixed this for the **proxy** dispatcher by setting `pipelining: 0` + a `connections` cap in `getProxyDispatcherOptions`. But the first-attempt **direct** dispatcher (`getDefaultDispatcher` → `new Agent(getDispatcherOptions())`) kept undici's default `pipelining: 1`, so a long SSE stream monopolized the single pooled socket per origin and serialized concurrent same-origin requests. This is the direct-path twin of #4163 — same symptom, different code path, so **not a duplicate**.

## Fix (mirrors #4288, direct-path appropriate)
- New `getDefaultDispatcherConnectionLimit(env)` — reads `OMNIROUTE_DIRECT_DISPATCHER_CONNECTIONS` (default 32, max 256), same shape as the proxy limit.
- New `getDefaultDispatcherOptions(env)` — `{ ...getDispatcherOptions(), connections, pipelining: 0 }`. Unlike the proxy options it **keeps keep-alive** (the proxy path's 1ms keep-alive TTL is a cheap-proxy-socket workaround, not wanted for direct connections).
- `getDefaultDispatcher()` now builds the Agent from `getDefaultDispatcherOptions()`.

## Validation (Hard Rule #18 — TDD)
Behavioral socket-level serialization can't be asserted deterministically in a unit test, so this follows #4288's precedent of pinning the dispatcher **config** (the config is the fix). `tests/unit/direct-dispatcher-pipelining-4580.test.ts` — 5 cases (RED before the new exports → GREEN):
- direct options set `pipelining: 0`
- direct options cap `connections` (default 32)
- direct **preserves** keep-alive (`keepAliveTimeout > 1`) while proxy forces `1`
- `OMNIROUTE_DIRECT_DISPATCHER_CONNECTIONS` honored + invalid clamps to default

Existing `proxy-dispatcher-family.test.ts` (11) green; `typecheck:core` clean; ESLint 0 errors.