### PR TITLE
fix(cli): bump better-sqlite3 runtime pin to 12.10.1 for Node 26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 _In development — bullets added per PR; finalized at release._
 
+### Fixed
+
+- **fix(cli): bump pinned `better-sqlite3` runtime version to `12.10.1` for Node 26 compatibility** — `bin/cli/runtime/nativeDeps.mjs` (was `12.9.0`) and `bin/cli/runtime/sqliteRuntime.mjs` (was `^12.6.2`) pinned older versions whose `engines` field stopped at Node 25, so the bundled native binding failed to load on Node 26.x with `Could not locate the bindings file`, triggering a server crash loop on startup. `better-sqlite3@12.10.1` ships prebuilt binaries for Node 26 (ABI 147). Ported from upstream [decolua/9router#1827](https://github.com/decolua/9router/pull/1827) (thanks @0xSkybreaker).
+
 ### 📝 Maintenance
 
 - **chore(quality): release-green pre-flight validator + nightly signal** — new `npm run check:release-green` (`scripts/quality/validate-release-green.mjs`) reproduces the release-equivalent validation (full unit + vitest + ratchets + typecheck + lint, optional `--with-build` package-artifact) against the current working tree and classifies each red as **HARD** (real defect) vs **DRIFT** (ratchet, rebaselined at release) — purely diagnostic, never blocking contributors. A new `nightly-release-green` workflow runs it on the active release branch and opens/updates a tracking issue on hard failures. Closes the gap where the full gate (`ci.yml`) only ran on the release PR, so reds accrued silently on `release/**` and surfaced in layers at release time. (thanks @diegosouzapw)

--- a/bin/cli/runtime/nativeDeps.mjs
+++ b/bin/cli/runtime/nativeDeps.mjs
@@ -12,7 +12,7 @@ import { spawnSync } from "node:child_process";
 import { platform } from "node:os";
 import { resolveDataDir } from "../data-dir.mjs";
 
-const BETTER_SQLITE3_VERSION = "12.9.0";
+const BETTER_SQLITE3_VERSION = "12.10.1";
 
 function runtimeDir() {
   return join(resolveDataDir(), "runtime");

--- a/bin/cli/runtime/sqliteRuntime.mjs
+++ b/bin/cli/runtime/sqliteRuntime.mjs
@@ -6,7 +6,7 @@ import { pathToFileURL } from "node:url";
 import { validateBinaryMagic, platformBinaryLabel } from "./magicBytes.mjs";
 
 const RUNTIME_DIR = join(homedir(), ".omniroute", "runtime");
-const BETTER_SQLITE3_VERSION = "better-sqlite3@^12.6.2";
+const BETTER_SQLITE3_VERSION = "better-sqlite3@^12.10.1";
 
 let resolvedCached = null;
 

--- a/tests/unit/runtime/sqliteRuntime-node26-compat.test.ts
+++ b/tests/unit/runtime/sqliteRuntime-node26-compat.test.ts
@@ -1,0 +1,41 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// Regression guard for upstream PR decolua/9router#1827 (issue #1812):
+// better-sqlite3 < 12.10.1 ships no prebuilt binary for Node 26 (ABI 147),
+// causing "Could not locate the bindings file" on startup. The pinned runtime
+// versions MUST be >= 12.10.1 so omniroute boots on Node 26.x.
+const MIN = [12, 10, 1] as const;
+
+function parseSemver(v: string): [number, number, number] {
+  const m = v.match(/(\d+)\.(\d+)\.(\d+)/);
+  assert.ok(m, `version "${v}" must contain semver`);
+  return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
+function gte(a: readonly [number, number, number], b: readonly [number, number, number]) {
+  for (let i = 0; i < 3; i++) {
+    if (a[i] > b[i]) return true;
+    if (a[i] < b[i]) return false;
+  }
+  return true;
+}
+
+function readPin(file: string): string {
+  const src = readFileSync(join(process.cwd(), file), "utf8");
+  const m = src.match(/BETTER_SQLITE3_VERSION\s*=\s*["'`]([^"'`]+)["'`]/);
+  assert.ok(m, `BETTER_SQLITE3_VERSION not found in ${file}`);
+  return m[1];
+}
+
+test("bin/cli/runtime/nativeDeps.mjs pins better-sqlite3 >= 12.10.1 (Node 26 prebuilt)", () => {
+  const pin = readPin("bin/cli/runtime/nativeDeps.mjs");
+  assert.ok(gte(parseSemver(pin), MIN), `pin "${pin}" must be >= 12.10.1`);
+});
+
+test("bin/cli/runtime/sqliteRuntime.mjs pins better-sqlite3 >= 12.10.1 (Node 26 prebuilt)", () => {
+  const pin = readPin("bin/cli/runtime/sqliteRuntime.mjs");
+  assert.ok(gte(parseSemver(pin), MIN), `pin "${pin}" must be >= 12.10.1`);
+});


### PR DESCRIPTION
## Summary

Ports upstream [decolua/9router#1827](https://github.com/decolua/9router/pull/1827) (fixes upstream #1812). On Node 26.x, the bundled `better-sqlite3` native binding fails to load with `Could not locate the bindings file`, triggering the supervisor's restart loop:

```
[DB] better-sqlite3 unavailable: Could not locate the bindings file.
⚠️  Server exited (code=unknown). Restarting in 1s... (1/2)
```

Root cause: two CLI runtime hooks pin older `better-sqlite3` versions whose `engines` field stops at Node 25:

- `bin/cli/runtime/nativeDeps.mjs` — pinned `12.9.0`
- `bin/cli/runtime/sqliteRuntime.mjs` — pinned `^12.6.2`

`better-sqlite3@12.10.1` ships prebuilt binaries for Node 26 (ABI 147). The repo's `optionalDependencies` range (`^12.10.0`) already covers `12.10.1`, so the `package.json` manifest needs no change — only the two runtime pins move.

## Changes

- `bin/cli/runtime/nativeDeps.mjs`: `12.9.0` → `12.10.1`
- `bin/cli/runtime/sqliteRuntime.mjs`: `better-sqlite3@^12.6.2` → `better-sqlite3@^12.10.1`
- `tests/unit/runtime/sqliteRuntime-node26-compat.test.ts`: TDD regression guard — parses `BETTER_SQLITE3_VERSION` from both files, fails if either drifts below `12.10.1`

## Test plan (Rule #18 — TDD)

- [x] New test red on base, green after fix
- [x] Pre-existing `tests/unit/runtime/sqliteRuntime.test.ts` still green
- [ ] CI green (do not merge yet)

```
✔ bin/cli/runtime/nativeDeps.mjs pins better-sqlite3 >= 12.10.1 (Node 26 prebuilt)
✔ bin/cli/runtime/sqliteRuntime.mjs pins better-sqlite3 >= 12.10.1 (Node 26 prebuilt)
✔ loadSqliteRuntime returns a result with driver and source
... (7 pass / 0 fail)
```

## Attribution

Inspired by upstream PR [decolua/9router#1827](https://github.com/decolua/9router/pull/1827) by @0xSkybreaker (commit author `fjia <fjia@suntekcorps.com>`). Original diff was a one-line bump in `cli/hooks/sqliteRuntime.js` (file does not exist in OmniRoute — equivalent surface lives under `bin/cli/runtime/`).

Co-authored-by: fjia <fjia@suntekcorps.com>
Co-authored-by: Skybreaker <0xskybreaker@users.noreply.github.com>

**DO NOT MERGE** — awaiting CI.