### PR TITLE
fix(codex): treat OAuth 401 as unrecoverable refresh failure (port #1821)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 _In development — bullets added per PR; finalized at release._
 
+### 🐛 Fixes
+
+- **fix(codex): treat any 401 from OpenAI's OAuth token endpoint as unrecoverable** — `refreshCodexToken()` already classified `token_expired` / `invalid_token` / `refresh_token_reused` / `invalid_grant` as unrecoverable, but a 401 carrying a payload variant we did not yet recognize (e.g. only the bare `"Could not validate your token. Please try signing in again."` message) slipped through and returned `null`, which triggered the retryable-failure branch — a refresh loop that cannot succeed against a dead refresh token. Now any 401 from the OAuth token endpoint surfaces `unrecoverable_refresh_error` so HealthCheck deactivates the account and the user is prompted to re-authenticate. 429 / 5xx remain transient. Defense-in-depth — does not change behavior for the existing markers. (port from upstream PR [decolua/9router#1821](https://github.com/decolua/9router/pull/1821), thanks @sacwooky)
+
 ### 📝 Maintenance
 
 - **chore(quality): release-green pre-flight validator + nightly signal** — new `npm run check:release-green` (`scripts/quality/validate-release-green.mjs`) reproduces the release-equivalent validation (full unit + vitest + ratchets + typecheck + lint, optional `--with-build` package-artifact) against the current working tree and classifies each red as **HARD** (real defect) vs **DRIFT** (ratchet, rebaselined at release) — purely diagnostic, never blocking contributors. A new `nightly-release-green` workflow runs it on the active release branch and opens/updates a tracking issue on hard failures. Closes the gap where the full gate (`ci.yml`) only ran on the release PR, so reds accrued silently on `release/**` and surfaced in layers at release time. (thanks @diegosouzapw)

--- a/open-sse/services/tokenRefresh.ts
+++ b/open-sse/services/tokenRefresh.ts
@@ -1063,6 +1063,26 @@ export async function refreshCodexToken(refreshToken, log, proxyConfig: unknown 
         return { error: "unrecoverable_refresh_error", code: errorCode };
       }
 
+      // Defense-in-depth (port from decolua/9router#1821): any 401 from OpenAI's
+      // OAuth token endpoint means the refresh credential itself was rejected
+      // (e.g. rotated away, or a payload variant whose code we do not yet
+      // recognize — OpenAI has shipped both `token_expired` and the bare
+      // "Could not validate your token" message). Retrying with the same dead
+      // refresh token will never succeed; surface re-auth instead of looping.
+      // 429 / 5xx remain transient and fall through to the retryable branch.
+      if (response.status === 401) {
+        const code = errorCode || "unauthorized";
+        log?.error?.(
+          "TOKEN_REFRESH",
+          "Codex OAuth token endpoint returned 401. Re-authentication required.",
+          {
+            status: response.status,
+            errorCode: code,
+          }
+        );
+        return { error: "unrecoverable_refresh_error", code };
+      }
+
       log?.error?.("TOKEN_REFRESH", "Failed to refresh Codex token", {
         status: response.status,
         error: errorText,

--- a/open-sse/services/tokenRefresh.ts
+++ b/open-sse/services/tokenRefresh.ts
@@ -994,6 +994,26 @@ export async function refreshCodexToken(refreshToken, log, proxyConfig: unknown 
         return { error: "unrecoverable_refresh_error", code: errorCode };
       }
 
+      // Defense-in-depth (port from decolua/9router#1821): any 401 from OpenAI's
+      // OAuth token endpoint means the refresh credential itself was rejected
+      // (e.g. rotated away, or a payload variant whose code we do not yet
+      // recognize — OpenAI has shipped both `token_expired` and the bare
+      // "Could not validate your token" message). Retrying with the same dead
+      // refresh token will never succeed; surface re-auth instead of looping.
+      // 429 / 5xx remain transient and fall through to the retryable branch.
+      if (response.status === 401) {
+        const code = errorCode || "unauthorized";
+        log?.error?.(
+          "TOKEN_REFRESH",
+          "Codex OAuth token endpoint returned 401. Re-authentication required.",
+          {
+            status: response.status,
+            errorCode: code,
+          }
+        );
+        return { error: "unrecoverable_refresh_error", code };
+      }
+
       log?.error?.("TOKEN_REFRESH", "Failed to refresh Codex token", {
         status: response.status,
         error: errorText,

--- a/tests/unit/token-refresh-service.test.ts
+++ b/tests/unit/token-refresh-service.test.ts
@@ -438,6 +438,37 @@ test("refreshCodexToken recognizes refresh_token_reused responses", async () => 
   );
 });
 
+// Port from decolua/9router#1821 (sacwooky): a 401 from OpenAI's OAuth token
+// endpoint means the refresh credential itself was rejected (e.g. rotated away
+// or a payload whose error code we do not yet recognize). Retrying with the
+// same refresh token will never succeed — surface re-auth, do not loop.
+test("refreshCodexToken treats any 401 from the token endpoint as unrecoverable", async () => {
+  const log = createLog();
+
+  await withMockedFetch(
+    async () =>
+      textResponse(
+        JSON.stringify({
+          error: {
+            // A payload variant whose code/type are NOT in the existing
+            // unrecoverable set — only the 401 status proves the token is dead.
+            message: "Could not validate your token. Please try signing in again.",
+            type: "invalid_request_error",
+          },
+        }),
+        401
+      ),
+    async () => {
+      const result = await refreshCodexToken("codex-refresh", log);
+      assert.equal(
+        result?.error,
+        "unrecoverable_refresh_error",
+        "401 from OpenAI token endpoint must surface re-auth instead of returning null (which triggers retry)"
+      );
+    }
+  );
+});
+
 test("refreshKiroToken uses the AWS OIDC flow when client credentials are present", async () => {
   const log = createLog();
   const calls: any[] = [];


### PR DESCRIPTION
## Summary

Port of upstream PR [decolua/9router#1821](https://github.com/decolua/9router/pull/1821) (by @sacwooky) — defense-in-depth for Codex OAuth refresh classification.

`refreshCodexToken()` already classified `token_expired` / `invalid_token` / `refresh_token_reused` / `invalid_grant` as unrecoverable (existing OmniRoute coverage already exceeds the upstream marker list). The remaining gap was payload-shape sensitivity: a 401 from OpenAI's OAuth token endpoint carrying a variant we don't yet recognize (e.g. only the bare `"Could not validate your token. Please try signing in again."` message, no `code` field) slipped through `extractOAuthErrorCode`/the marker checks and returned `null` — which the caller treats as a transient failure and retries with backoff. A dead refresh token will never recover from retry.

After this change: any 401 from `OAUTH_ENDPOINTS.openai.token` returns `{ error: "unrecoverable_refresh_error", code }` (`code` falls back to `"unauthorized"` when no field-level code is present). `429` / `5xx` continue to fall through to the retryable branch unchanged.

## Changes

- `open-sse/services/tokenRefresh.ts` — `refreshCodexToken()`: add `if (response.status === 401)` branch after the existing marker check, returning the unrecoverable sentinel with a dedicated log line.
- `tests/unit/token-refresh-service.test.ts` — new TDD test: 401 with an unfamiliar payload (no recognized code) must surface `unrecoverable_refresh_error`.
- `CHANGELOG.md` — bullet in `[3.8.34] → 🐛 Fixes`.

## Test plan

- [x] `node --import tsx/esm --test tests/unit/token-refresh-service.test.ts` — 38/38 green (was 37; +1 new test)
- [x] `node --import tsx/esm --test tests/unit/service-token-refresh.test.ts tests/unit/token-refresh-route-service.test.ts` — 21/21 green
- [x] Pre-existing markers unchanged → no regression in behavior for `token_expired` / `invalid_token` / `refresh_token_reused` / `invalid_grant`.

## Attribution

- Upstream PR: [decolua/9router#1821](https://github.com/decolua/9router/pull/1821)
- Original author: [@sacwooky](https://github.com/sacwooky) (credited via `Co-authored-by` on the commit)
- This port adapts the upstream JS change to OmniRoute's TS surface and existing `errorCode`-driven classification (OmniRoute extracts the OAuth code from multiple payload shapes rather than running a separate `classifyOAuthRefreshError` helper, so the 401 defense lives directly in `refreshCodexToken`).

**Do not merge** — opened for review.