### PR TITLE
fix(translator): preserve reasoning_effort for non-Copilot Responses clients (port decolua/9router#1817)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 _In development — bullets added per PR; finalized at release._
 
+### 🐛 Bug Fixes
+
+- **fix(translator): preserve `reasoning_effort` across Responses ↔ Chat hop for all clients** — `reasoning.effort` from Responses-API clients is now promoted to the OpenAI-native `reasoning_effort` on the Chat-Completions side unconditionally (previously the promotion was Copilot-only, so OpenCode / Cursor / raw Responses clients silently lost the hint). The Copilot-specific `summary` → Claude summarized-thinking marker stays behind its existing UA gate. Ported from upstream PR [decolua/9router#1817](https://github.com/decolua/9router/pull/1817) — thanks @ryanngit.
+
 ### 📝 Maintenance
 
 - **chore(quality): release-green pre-flight validator + nightly signal** — new `npm run check:release-green` (`scripts/quality/validate-release-green.mjs`) reproduces the release-equivalent validation (full unit + vitest + ratchets + typecheck + lint, optional `--with-build` package-artifact) against the current working tree and classifies each red as **HARD** (real defect) vs **DRIFT** (ratchet, rebaselined at release) — purely diagnostic, never blocking contributors. A new `nightly-release-green` workflow runs it on the active release branch and opens/updates a tracking issue on hard failures. Closes the gap where the full gate (`ci.yml`) only ran on the release PR, so reds accrued silently on `release/**` and surfaced in layers at release time. (thanks @diegosouzapw)

--- a/open-sse/translator/request/openai-responses.ts
+++ b/open-sse/translator/request/openai-responses.ts
@@ -445,11 +445,14 @@ export function openaiResponsesToOpenAIRequest(
   }
   delete result.store;
 
-  // Copilot-only: promote Responses `reasoning.{effort,summary}` to Chat fields
-  // so the downstream openai-to-claude translator can enable extended thinking.
-  // Gated by the UA marker from translateRequest; other clients see `reasoning` dropped.
+  // Promote Responses `reasoning.effort` to the Chat-Completions-native
+  // `reasoning_effort` field so OpenAI-family upstreams (and the downstream
+  // openai-to-claude translator's extended-thinking path) keep the hint when a
+  // Responses client is routed across formats. The Copilot-only `summary` ->
+  // Claude summarized-thinking marker stays behind the UA gate from
+  // translateRequest because it is Copilot-specific glue, not an OpenAI-native
+  // field. Ported from upstream PR decolua/9router#1817 (ryanngit).
   if (
-    credentialRecord._copilotClient === true &&
     root.reasoning &&
     typeof root.reasoning === "object" &&
     !Array.isArray(root.reasoning)
@@ -459,7 +462,10 @@ export function openaiResponsesToOpenAIRequest(
     if (effort && result.reasoning_effort === undefined) {
       result.reasoning_effort = normalizeResponsesReasoningEffort(effort);
     }
-    if (shouldRequestClaudeSummarizedThinking(reasoningRec.summary)) {
+    if (
+      credentialRecord._copilotClient === true &&
+      shouldRequestClaudeSummarizedThinking(reasoningRec.summary)
+    ) {
       result[COPILOT_REASONING_SUMMARY_MARKER] = "summarized";
     }
   }

--- a/tests/unit/openai-responses-reasoning-effort.test.ts
+++ b/tests/unit/openai-responses-reasoning-effort.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Reasoning-effort mapping across the OpenAI Chat <-> Responses request translators.
+ *
+ * Chat Completions carries the reasoning hint as top-level `reasoning_effort`; the
+ * Responses API nests it as `reasoning.effort`. These tests pin both directions so
+ * the hint survives when a request crosses formats (e.g. a Responses client routed
+ * to an OpenAI-native Chat Completions upstream).
+ *
+ * Ported from upstream PR https://github.com/decolua/9router/pull/1817 (ryanngit).
+ * Adapted: OmniRoute previously promoted `reasoning.effort` only behind the
+ * Copilot-client gate (commit 75d9a83c25), which silently dropped the field for
+ * every other Responses client (OpenCode, Cursor, raw OpenAI Responses, ...).
+ * This test pins the unconditional promotion of effort while keeping the
+ * Copilot-only `summary` -> Claude thinking marker behind its existing gate.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  openaiToOpenAIResponsesRequest,
+  openaiResponsesToOpenAIRequest,
+} from "../../open-sse/translator/request/openai-responses.ts";
+import { convertResponsesApiFormat } from "../../open-sse/translator/helpers/responsesApiHelper.ts";
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value as Record<string, unknown>;
+}
+
+test("Responses -> Chat promotes reasoning.effort for non-Copilot clients", () => {
+  const out = asRecord(
+    openaiResponsesToOpenAIRequest(
+      "gpt-test",
+      { input: "hello", reasoning: { effort: "high" } },
+      true,
+      {} // no _copilotClient marker
+    )
+  );
+  assert.equal(out.reasoning_effort, "high");
+  assert.equal(out.reasoning, undefined);
+});
+
+test("Responses -> Chat preserves reasoning.effort via the helper wrapper", () => {
+  const out = asRecord(
+    convertResponsesApiFormat({ input: "hello", reasoning: { effort: "medium" } })
+  );
+  assert.equal(out.reasoning_effort, "medium");
+  assert.equal(out.reasoning, undefined);
+});
+
+test("Responses -> Chat does not overwrite an explicit reasoning_effort", () => {
+  const out = asRecord(
+    openaiResponsesToOpenAIRequest(
+      "gpt-test",
+      { input: "hello", reasoning_effort: "low", reasoning: { effort: "high" } },
+      true,
+      {}
+    )
+  );
+  // Explicit Chat-level field wins over the Responses nesting.
+  assert.equal(out.reasoning_effort, "low");
+});
+
+test("Chat -> Responses already wraps reasoning_effort into reasoning.effort", () => {
+  const out = asRecord(
+    openaiToOpenAIResponsesRequest(
+      "gpt-test",
+      { messages: [{ role: "user", content: "hi" }], reasoning_effort: "high" },
+      true,
+      {}
+    )
+  );
+  assert.deepEqual(out.reasoning, { effort: "high" });
+});

--- a/tests/unit/translator-openai-responses-req.test.ts
+++ b/tests/unit/translator-openai-responses-req.test.ts
@@ -623,7 +623,10 @@ test("Chat -> Responses prefers max_completion_tokens over max_tokens when both 
   assert.equal((result as any).max_completion_tokens, undefined);
 });
 
-test("Responses -> Chat drops `reasoning` and does not synthesize reasoning_effort without Copilot marker", () => {
+test("Responses -> Chat drops `reasoning` and promotes effort to reasoning_effort even without Copilot marker", () => {
+  // Updated per upstream PR decolua/9router#1817 (ryanngit): the OpenAI-native
+  // `reasoning_effort` hint is always preserved across the Responses -> Chat
+  // hop; only the Copilot-specific `summary` -> Claude marker stays gated.
   const result = openaiResponsesToOpenAIRequest(
     "claude-opus-4-7",
     {
@@ -635,7 +638,7 @@ test("Responses -> Chat drops `reasoning` and does not synthesize reasoning_effo
   ) as Record<string, unknown>;
 
   assert.equal(result.reasoning, undefined);
-  assert.equal(result.reasoning_effort, undefined);
+  assert.equal(result.reasoning_effort, "high");
 });
 
 test("Responses -> Chat promotes reasoning.effort to reasoning_effort when _copilotClient is set", () => {


### PR DESCRIPTION
## Summary

Ported from upstream PR [decolua/9router#1817](https://github.com/decolua/9router/pull/1817).

OpenAI Responses-API clients send the reasoning hint as `reasoning.effort`; on the Chat-Completions side it is OpenAI-native `reasoning_effort`. OmniRoute's translator only promoted it behind the `_copilotClient` UA gate (commit `75d9a83c25`, May 2026), so every other Responses client — OpenCode, Cursor, raw OpenAI Responses, ... — silently lost the hint when routed across formats. The Chat -> Responses direction (`reasoning_effort` -> `reasoning.effort`) was already correct.

This PR promotes `reasoning.effort` -> `reasoning_effort` **unconditionally** in `openaiResponsesToOpenAIRequest`. The Copilot-specific `summary` -> Claude summarized-thinking marker (`COPILOT_REASONING_SUMMARY_MARKER`) stays behind the `_copilotClient` gate because that one IS Copilot-specific glue, not an OpenAI-native field.

### Divergence from upstream

- Upstream is `.js`; OmniRoute is TypeScript. Adapted accordingly.
- Upstream had no prior gate; OmniRoute's pre-existing Copilot gate is preserved for the `summary` marker only.
- Upstream added a tiny pass-through in the thin `responsesApiHelper`; in OmniRoute that helper already delegates to the canonical translator, so the change happens once in the canonical path and the helper inherits it for free (no duplicate logic per CLAUDE.md style).

## Test plan

- [x] New TDD suite `tests/unit/openai-responses-reasoning-effort.test.ts` (4 cases): non-Copilot promotion, helper pass-through, explicit `reasoning_effort` is not overwritten, Chat -> Responses round-trip.
- [x] Updated the one existing test that pinned the old (Copilot-gated) contract, with an in-test comment pointing at the upstream PR.
- [x] Regression-ran the full openai-responses translator suite — 67/67 green.
- [ ] CI: `test-unit` + `test-vitest` + quality gates.

## Attribution

- Upstream PR: https://github.com/decolua/9router/pull/1817
- Upstream author: @ryanngit (GitHub user, type=User; commit was authored by `OpenClaw Patch <patch@openclaw.local>` — a tooling-synthesized author, so credit goes via the GitHub `noreply` form to route attribution to the human contributor)
- Commit trailer: `Co-authored-by: ryanngit <74137224+ryanngit@users.noreply.github.com>` + `Inspired-by` link.

**DO NOT MERGE** — leave open for review.