### PR TITLE
docs: clarify Kiro is ~50 credits/month per account, not unlimited

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,7 +561,7 @@ Dashboard at `http://localhost:20128` · API at `http://localhost:20128/v1`.
 
 **2) Connect a FREE provider (no signup)**
 
-Dashboard → **Providers** → connect **Kiro AI** (free Claude unlimited) or **OpenCode Free** (no auth) → done.
+Dashboard → **Providers** → connect **Kiro AI** (free Claude, ~50 credits/month per account) or **OpenCode Free** (no auth) → done.
 
 **3) Point your coding tool**
 
@@ -730,7 +730,7 @@ podman compose --profile base up -d
 **$0 forever:**
 
 ```
-1. kr/claude-sonnet-4.5   (Kiro — unlimited)
+1. kr/claude-sonnet-4.5   (Kiro — ~50 credits/mo per acct)
 2. if/kimi-k2-thinking    (Qoder — unlimited)
 3. pol/gpt-5              (Pollinations — no key)
 4. lc/longcat-flash-lite  (50M tok/day backup)
@@ -787,7 +787,7 @@ Compression: aggressive (~50%) → double your free quota · Cost: $0/mo
 | `DATA_DIR`        | `~/.omniroute` | Database & config storage        |
 
 **Will I be charged by OmniRoute?** No — it's free, open-source software on your machine. You only pay paid providers directly. OmniRoute has no billing system.
-**Are FREE providers really unlimited?** Yes — Kiro, Qoder, Pollinations, LongCat, Cloudflare. No catch.
+**Are FREE providers really unlimited?** Mostly — Qoder, Pollinations, LongCat, and Cloudflare are free with no per-account credit cap. Kiro is free too but capped at ~50 credits/month per account. Stack multiple free providers in a combo and auto-fallback keeps you serving for $0.
 **Will compression hurt quality?** No — it only compresses the **input**; code, URLs, JSON are always protected.
 **Does it work where AI is blocked?** Yes — 3-level proxy + 1proxy marketplace reach all 231 providers.
 

--- a/README.md
+++ b/README.md
@@ -574,7 +574,7 @@ Dashboard at `http://localhost:20128` · API at `http://localhost:20128/v1`.
 
 **2) Connect a FREE provider (no signup)**
 
-Dashboard → **Providers** → connect **Kiro AI** (free Claude unlimited) or **OpenCode Free** (no auth) → done.
+Dashboard → **Providers** → connect **Kiro AI** (free Claude, ~50 credits/month per account) or **OpenCode Free** (no auth) → done.
 
 **3) Point your coding tool**
 
@@ -743,7 +743,7 @@ podman compose --profile base up -d
 **$0 forever:**
 
 ```
-1. kr/claude-sonnet-4.5   (Kiro — unlimited)
+1. kr/claude-sonnet-4.5   (Kiro — ~50 credits/mo per acct)
 2. if/kimi-k2-thinking    (Qoder — unlimited)
 3. pol/gpt-5              (Pollinations — no key)
 4. lc/longcat-flash-lite  (50M tok/day backup)
@@ -800,7 +800,7 @@ Compression: aggressive (~50%) → double your free quota · Cost: $0/mo
 | `DATA_DIR`        | `~/.omniroute` | Database & config storage        |
 
 **Will I be charged by OmniRoute?** No — it's free, open-source software on your machine. You only pay paid providers directly. OmniRoute has no billing system.
-**Are FREE providers really unlimited?** Yes — Kiro, Qoder, Pollinations, LongCat, Cloudflare. No catch.
+**Are FREE providers really unlimited?** Mostly — Qoder, Pollinations, LongCat, and Cloudflare are free with no per-account credit cap. Kiro is free too but capped at ~50 credits/month per account. Stack multiple free providers in a combo and auto-fallback keeps you serving for $0.
 **Will compression hurt quality?** No — it only compresses the **input**; code, URLs, JSON are always protected.
 **Does it work where AI is blocked?** Yes — 3-level proxy + 1proxy marketplace reach all 231 providers.
 

--- a/docs/guides/USER_GUIDE.md
+++ b/docs/guides/USER_GUIDE.md
@@ -57,7 +57,7 @@ Complete guide for configuring providers, creating combos, integrating CLI tools
 |                     | Kimi K2           | $9/mo flat  | 10M tokens/mo    | Predictable cost     |
 | **🆓 FREE**         | Qoder             | $0          | Unlimited        | 8 models free        |
 |                     | Qwen              | $0          | Unlimited        | 3 models free        |
-|                     | Kiro              | $0          | Unlimited        | Claude free          |
+|                     | Kiro              | $0          | ~50 credits/mo   | Claude free          |
 
 **💡 Pro Tip:** Start with Gemini CLI (180K free/month) + Qoder (unlimited free) combo = $0 cost!
 
@@ -240,7 +240,7 @@ Models: if/kimi-k2, if/qwen3-coder-plus, if/qwen3-max, if/qwen3-235b, if/deepsee
 #### Kiro (Claude FREE)
 
 ```bash
-Dashboard → Connect Kiro → AWS Builder ID or Google/GitHub → Unlimited
+Dashboard → Connect Kiro → AWS Builder ID or Google/GitHub → ~50 credits/month
 
 Models: kr/claude-sonnet-4.5, kr/claude-haiku-4.5
 ```


### PR DESCRIPTION
## What

Clarifies that **Kiro** is free but capped at **~50 credits/month per account** — not literally "unlimited" — in the EN canonical docs.

## Why

Discussion [#4672](https://github.com/diegosouzapw/OmniRoute/discussions/4672) flagged the README line `kr/claude-sonnet-4.5 ← FREE, unlimited (never fails)` as misleading. A single Kiro account runs out after ~50 credits/month (already documented in `docs/getting-started/FREE-TIERS-GUIDE.md:242`). "Unlimited / never fails" only describes the **stacked-combo** behavior: when several free providers are combined, OmniRoute's auto-fallback keeps serving when one is exhausted. The wording applied to a single account is wrong.

## Changes

- `README.md` — 3 spots: quick-connect line, `$0 forever` combo example, FAQ "Are FREE providers really unlimited?"
- `docs/guides/USER_GUIDE.md` — 2 spots: pricing table row + Kiro setup line

Scope is the **EN canonical sources only** (operator-confirmed). The 120+ i18n mirrors are regenerated from these by the translation pipeline; CHANGELOG history is left intact.

## Validation

- `npm run check:docs-sync` → PASS (version sync consistent, 41 locales validated)
- Docs-only change; no production code touched, so no unit tests required.

Refs #4672
