### PR TITLE
fix: Firecrawl web_fetch 500 with include_metadata=true

### DIFF
--- a/open-sse/executors/firecrawl-fetch.ts
+++ b/open-sse/executors/firecrawl-fetch.ts
@@ -55,9 +55,12 @@ export async function firecrawlFetch(opts: FirecrawlScrapeOptions): Promise<WebF
     formats,
   };
 
-  if (includeMetadata) {
-    requestBody.includeTags = ["title", "description", "og:title", "og:description"];
-  }
+  // NOTE: Firecrawl returns metadata (title, description, og:title, etc.)
+  // automatically in response.data.metadata — no special request params needed.
+  // Sending the `includeTags` parameter with non-CSS-selector values like
+  // "og:title" or "description" causes Firecrawl's parser to crash (HTTP 500).
+  // The `includeMetadata` flag only controls whether we surface metadata
+  // in our response (see response parsing below).
 
   if (depth > 0) {
     requestBody.maxDepth = depth;

--- a/tests/unit/firecrawl-executor.test.ts
+++ b/tests/unit/firecrawl-executor.test.ts
@@ -183,3 +183,41 @@ test("firecrawlFetch forwards depth and wait_for_selector", async () => {
     globalThis.fetch = originalFetch;
   }
 });
+
+// ── #4692 regression: includeMetadata must NOT send invalid includeTags ────────
+// Firecrawl returns metadata automatically in response.data.metadata. Sending
+// includeTags with non-CSS-selector values ("og:title", "description") crashed
+// Firecrawl's parser with HTTP 500. The includeMetadata flag must only gate
+// whether we surface metadata, never inject includeTags into the request.
+test("firecrawlFetch with includeMetadata=true does not send includeTags (4692)", async () => {
+  const originalFetch = globalThis.fetch;
+  let capturedBody: Record<string, unknown> = {};
+
+  globalThis.fetch = async (_url, init = {}) => {
+    capturedBody = JSON.parse(String((init as RequestInit).body ?? "{}"));
+    return new Response(
+      JSON.stringify({
+        data: { markdown: "# Result", metadata: { title: "Test", description: "Desc" } },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } }
+    );
+  };
+
+  try {
+    const result = await firecrawlFetch({
+      url: "https://example.com",
+      format: "markdown",
+      depth: 0,
+      includeMetadata: true,
+      credentials: { apiKey: "fc-test-key" },
+    });
+
+    assert.equal(result.success, true);
+    assert.ok(
+      !("includeTags" in capturedBody),
+      "includeMetadata must not inject includeTags (Firecrawl 500)"
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
## Problem

Every `web_fetch` call routed through the Firecrawl provider fails with HTTP 500 (or 502) **iff `include_metadata=true`** is set. The crash is URL-agnostic — it reproduces on trivial pages like `https://example.com` as well as on complex JS-heavy pages. Without `include_metadata` the same URLs succeed. Other providers (Tavily) handle `include_metadata=true` correctly.

### Steps to reproduce

1. Call `omniroute_web_fetch` with any URL, `format=markdown`, `include_metadata=true`, `provider="firecrawl"`.
2. Observe 500 error:

```
500: {"success":false,"code":"UNKNOWN_ERROR",
  "error":"An unexpected error occurred...",
  "exception ID":"019ef0c0-886b-70ea-8b41-500da228f385"}
```

### Test matrix

| URL | format | include_metadata | provider | Result |
|---|---|---|---|---|
| example.com | markdown | true | firecrawl | **500** |
| example.com | html | true | firecrawl | **502** |
| github.com/... | markdown | true | firecrawl | **500** |
| news.ycombinator.com | markdown | true | firecrawl | **500** |
| example.com | markdown | false | firecrawl | 200 OK |
| example.com | html | false | firecrawl | 200 OK |
| example.com | markdown | true | tavily-search | 200 OK |

## Root Cause

In `open-sse/executors/firecrawl-fetch.ts`, when `includeMetadata` is true, the code sends:

```typescript
requestBody.includeTags = ["title", "description", "og:title", "og:description"];
```

Firecrawl's `includeTags` parameter is a **content filter** — it expects HTML tags or CSS selectors (e.g. `"title"`, `"meta"`, `".content"`). The values `"description"`, `"og:title"`, and `"og:description"` are **not valid CSS selectors** and cause Firecrawl's internal parser to crash with HTTP 500.

Critically, this parameter is **unnecessary** — Firecrawl returns metadata (title, description, OpenGraph tags, etc.) automatically in every scrape response via `response.data.metadata`. The response parsing code in this same file already reads it correctly:

```typescript
const rawMeta = scraped.metadata as Record<string, unknown> | null | undefined;
const metadata = includeMetadata
  ? {
      title: rawMeta?.title != null ? String(rawMeta.title) : null,
      description: rawMeta?.description != null ? String(rawMeta.description) : null,
    }
  : null;
```

The `includeMetadata` flag should only control whether the metadata object is surfaced in OmniRoute's response — not send invalid parameters to Firecrawl.

## Fix

Remove the `includeTags` assignment block entirely. Metadata is already extracted from `response.data.metadata` in the response parsing code.

## Verification

- `include_metadata=true` + firecrawl → **500** (before fix, confirmed across 10+ calls)
- `include_metadata=false` + firecrawl → **200 OK** (unaffected)
- `include_metadata=true` + tavily → **200 OK** (unaffected, different API endpoint)
- Firecrawl API docs confirm: `includeTags` = "Tags to include in the output" (content filter), `metadata` = automatic response field

## Environment

OmniRoute v3.8.33, consistent across 10+ calls from same session.