### PR TITLE
fix: correct no-auth provider validation and kimi executor routing

### DIFF
--- a/open-sse/executors/index.ts
+++ b/open-sse/executors/index.ts
@@ -134,7 +134,6 @@ const executors = {
   "v0-vercel-web": new V0VercelWebExecutor(),
   v0: new V0VercelWebExecutor(), // Alias
   "kimi-web": new KimiWebExecutor(),
-  kimi: new KimiWebExecutor(), // Alias
   "kimi-coding-apikey": new KimiExecutor(), // Alias
   "kimi-coding": new KimiExecutor(), // Alias
   "doubao-web": new DoubaoWebExecutor(),

--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -2976,6 +2976,8 @@ export function providerAllowsOptionalApiKey(providerId: unknown): boolean {
     providerId === "duckduckgo-web" ||
     providerId === "veoaifree-web" ||
     providerId === "hackclub" ||
+    providerId === "theoldllm" ||
+    providerId === "chipotle" ||
     providerId === "huggingchat" ||
     providerId === "gitlawb" ||
     providerId === "gitlawb-gmi" ||

--- a/tests/unit/noauth-provider-validation-fixes.test.ts
+++ b/tests/unit/noauth-provider-validation-fixes.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Tests for provider validation fixes:
+ * - Bug 1: `theoldllm` and `chipotle` no-auth providers not in providerAllowsOptionalApiKey
+ * - Bug 2: `kimi` API key provider incorrectly routed through KimiWebExecutor
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { providerAllowsOptionalApiKey } = await import(
+  "../../src/shared/constants/providers.ts"
+);
+const { hasSpecializedExecutor } = await import(
+  "../../open-sse/executors/index.ts"
+);
+
+// Bug 1: theoldllm and chipotle were missing from providerAllowsOptionalApiKey
+test("theoldllm is recognized as allowing optional API key (no-auth provider)", () => {
+  assert.equal(providerAllowsOptionalApiKey("theoldllm"), true);
+});
+
+test("chipotle is recognized as allowing optional API key (no-auth provider)", () => {
+  assert.equal(providerAllowsOptionalApiKey("chipotle"), true);
+});
+
+// Bug 2: kimi API key provider should NOT have a specialized web-cookie executor
+test("kimi API key provider does not have a specialized web-cookie executor", () => {
+  // kimi should fall through to DefaultExecutor (OpenAI format)
+  // because it is an API key provider, not a web-cookie provider
+  assert.equal(hasSpecializedExecutor("kimi"), false);
+});
+
+// kimi-web still has its specialized executor (no regression)
+test("kimi-web still has its specialized web-cookie executor", () => {
+  assert.equal(hasSpecializedExecutor("kimi-web"), true);
+});
+
+// kimi-coding-apikey still has its specialized executor (no regression)
+test("kimi-coding-apikey still has its specialized executor", () => {
+  assert.equal(hasSpecializedExecutor("kimi-coding-apikey"), true);
+});


### PR DESCRIPTION
## Bugs Fixed

### Bug 1 (HIGH): `kimi` API key provider di-route ke web-cookie executor
**File**: `open-sse/executors/index.ts`
**Issue**: Entry `kimi: new KimiWebExecutor()` — API key provider `kimi` (target: `api.moonshot.ai`, Bearer auth) dikirim ke `KimiWebExecutor` (target: `kimi.moonshot.cn/api/chat`, cookie auth)

**Fix**: Hapus entry `kimi` dari executors map, biar fallback ke `DefaultExecutor` (OpenAI-compatible) sesuai registry config `executor: \"default\"`.

### Bug 2 (MEDIUM): No-auth providers `[provider removed at its operator's request]` dan `chipotle` tidak ada di `providerAllowsOptionalApiKey`
**File**: `src/shared/constants/providers.ts`
**Issue**: Kedua no-auth provider tidak terdaftar di `providerAllowsOptionalApiKey`, jadi validasi gagal dengan \"Provider and API key required\" padahal seharusnya tidak perlu API key.

**Fix**: Tambahkan `[provider removed at its operator's request]` dan `chipotle` ke `providerAllowsOptionalApiKey`.

## Test Coverage
```
tests/unit/noauth-provider-validation-fixes.test.ts
  ✓ [provider removed at its operator's request] is recognized as allowing optional API key
  ✓ chipotle is recognized as allowing optional API key
  ✓ kimi API key provider does not have a specialized web-cookie executor
  ✓ kimi-web still has its specialized web-cookie executor (no regression)
  ✓ kimi-coding-apikey still has its specialized executor (no regression)
```

## Files Changed
- `open-sse/executors/index.ts` — 1 deletion (remove `kimi` alias, was pointing to KimiWebExecutor)
- `src/shared/constants/providers.ts` — 2 insertions (add [provider removed at its operator's request], chipotle)
- `tests/unit/noauth-provider-validation-fixes.test.ts` — new, 42 lines