### PR TITLE
refactor(chatCore): extrai transforms de mensagens Claude para leaf (#3501)

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -138,6 +138,8 @@ import { buildCacheUsageLogMeta, attachLogMeta } from "./chatCore/cacheUsageMeta
 import { buildExecutorClientHeaders } from "./chatCore/executorClientHeaders.ts";
 import { resolveExecutionCredentials as resolveExecutionCredentialsFor } from "./chatCore/executionCredentials.ts";
 import { resolveExecutorWithProxy as resolveExecutorWithProxyFor } from "./chatCore/executorProxy.ts";
+import type { ClaudeMessage } from "./chatCore/claudeMessageTypes.ts";
+import { normalizeClaudeUpstreamMessages as normalizeClaudeUpstreamMessagesFor } from "./chatCore/claudeUpstreamMessages.ts";
 
 import {
   getCallLogPipelineCaptureStreamChunks,
@@ -1680,138 +1682,12 @@ export async function handleChatCore({
     );
   }
 
-  type ClaudeContentBlock = Record<string, unknown>;
-  type ClaudeMessage = {
-    role?: unknown;
-    content?: unknown;
-  };
-
-  // Shared helper: lift any system/developer role messages out of the messages
-  // array into the top-level system parameter. Anthropic's Messages API rejects
-  // system/developer roles inside messages[]. Case-insensitive to be defensive.
-  const extractSystemMessagesToBody = (payload: Record<string, unknown>) => {
-    if (!Array.isArray(payload.messages)) return;
-    const messages = payload.messages as ClaudeMessage[];
-    const systemMessages = messages.filter((m) => {
-      const role = String(m.role || "").toLowerCase();
-      return role === "system" || role === "developer";
-    });
-    if (systemMessages.length === 0) return;
-    const extraBlocks: ClaudeContentBlock[] = [];
-    for (const sm of systemMessages) {
-      if (typeof sm.content === "string" && sm.content.length > 0) {
-        extraBlocks.push({ type: "text", text: sm.content });
-      } else if (Array.isArray(sm.content)) {
-        for (const block of sm.content as ClaudeContentBlock[]) {
-          if (block?.type === "text" && typeof block.text === "string" && block.text.length > 0) {
-            extraBlocks.push(block);
-          }
-        }
-      }
-    }
-    if (extraBlocks.length > 0) {
-      const existingSystem = payload.system;
-      if (typeof existingSystem === "string" && existingSystem.length > 0) {
-        payload.system = [{ type: "text", text: existingSystem }, ...extraBlocks];
-      } else if (Array.isArray(existingSystem)) {
-        payload.system = [...(existingSystem as ClaudeContentBlock[]), ...extraBlocks];
-      } else {
-        payload.system = extraBlocks;
-      }
-    }
-    payload.messages = messages.filter((m) => {
-      const role = String(m.role || "").toLowerCase();
-      return role !== "system" && role !== "developer";
-    });
-  };
-
+  // extractSystemMessagesToBody + normalizeClaudeUpstreamMessages extracted to
+  // chatCore/claudeUpstreamMessages.ts (#3501); bind `log` once so the call sites stay byte-identical.
   const normalizeClaudeUpstreamMessages = (
     payload: Record<string, unknown>,
     options?: { preserveToolResultBlocks?: boolean }
-  ) => {
-    const preserveToolResultBlocks = options?.preserveToolResultBlocks === true;
-    if (!Array.isArray(payload.messages)) return;
-    let messages = payload.messages as ClaudeMessage[];
-
-    // Extract system/developer role messages into top-level system parameter.
-    extractSystemRoleMessages(payload);
-    messages = payload.messages as ClaudeMessage[];
-
-    // Anthropic rejects empty text blocks in native Messages payloads.
-    for (const msg of messages) {
-      if (Array.isArray(msg.content)) {
-        msg.content = msg.content.filter(
-          (block: ClaudeContentBlock) =>
-            block.type !== "text" || (typeof block.text === "string" && block.text.length > 0)
-        );
-      }
-    }
-
-    // Normalize unsupported content types without reintroducing the Claude -> OpenAI round-trip.
-    for (const msg of messages) {
-      if (msg.role !== "user" || !Array.isArray(msg.content)) continue;
-      msg.content = (msg.content as ClaudeContentBlock[]).flatMap((block: ClaudeContentBlock) => {
-        if (
-          block.type === "text" ||
-          block.type === "image_url" ||
-          block.type === "image" ||
-          block.type === "file_url" ||
-          block.type === "file" ||
-          block.type === "document"
-        ) {
-          const fileData = (block.file_url ?? block.file ?? block.document) as
-            | Record<string, unknown>
-            | undefined;
-          if (
-            (block.type === "file" || block.type === "document") &&
-            !fileData?.url &&
-            !fileData?.data
-          ) {
-            const fileContent =
-              (block.file as ClaudeContentBlock)?.content ??
-              (block.file as ClaudeContentBlock)?.text ??
-              block.content ??
-              block.text;
-            const fileName =
-              (block.file as Record<string, unknown>)?.name ?? block.name ?? "attachment";
-            if (typeof fileContent === "string" && fileContent.length > 0) {
-              return [{ type: "text", text: `[${fileName}]\n${fileContent}` }];
-            }
-          }
-          return [block];
-        }
-
-        if (block.type === "tool_result") {
-          if (preserveToolResultBlocks) {
-            return [block];
-          }
-          const toolId = block.tool_use_id ?? block.id ?? "unknown";
-          const resultContent = block.content ?? block.text ?? block.output ?? "";
-          const resultText =
-            typeof resultContent === "string"
-              ? resultContent
-              : Array.isArray(resultContent)
-                ? resultContent
-                    .filter((c: Record<string, unknown>) => c.type === "text")
-                    .map((c: Record<string, unknown>) => c.text)
-                    .join("\n")
-                : JSON.stringify(resultContent);
-          if (resultText.length > 0) {
-            return [{ type: "text", text: `[Tool Result: ${toolId}]\n${resultText}` }];
-          }
-          return [];
-        }
-
-        log?.debug?.("CONTENT", `Dropped unsupported content part type="${block.type}"`);
-        return [];
-      });
-    }
-
-    // #2815: move stray tool_result blocks out of assistant messages.
-    payload.messages = splitMisplacedToolResults(
-      payload.messages as ClaudeMessage[]
-    ) as unknown as Record<string, unknown>[];
-  };
+  ) => normalizeClaudeUpstreamMessagesFor(payload, options, log);
 
   try {
     if (nativeCodexPassthrough) {

--- a/open-sse/handlers/chatCore/claudeMessageTypes.ts
+++ b/open-sse/handlers/chatCore/claudeMessageTypes.ts
@@ -1,0 +1,15 @@
+/**
+ * chatCore Claude message shape aliases (Quality Gate v2 / Fase 9 — chatCore god-file decomposition,
+ * #3501).
+ *
+ * Minimal structural aliases shared by the Claude upstream-message transforms (and a handful of
+ * narrowing casts left in handleChatCore). Kept intentionally loose — these mirror the permissive
+ * shapes the handler already used inline; behaviour is unchanged.
+ */
+
+export type ClaudeContentBlock = Record<string, unknown>;
+
+export type ClaudeMessage = {
+  role?: unknown;
+  content?: unknown;
+};

--- a/open-sse/handlers/chatCore/claudeUpstreamMessages.ts
+++ b/open-sse/handlers/chatCore/claudeUpstreamMessages.ts
@@ -1,0 +1,143 @@
+/**
+ * chatCore Claude upstream-message transforms (Quality Gate v2 / Fase 9 — chatCore god-file
+ * decomposition, #3501).
+ *
+ * Extracted from handleChatCore. `extractSystemMessagesToBody` lifts system/developer role messages
+ * into the top-level `system` parameter (Anthropic rejects those roles inside messages[]).
+ * `normalizeClaudeUpstreamMessages` prepares a native Claude Messages payload: lifts system roles,
+ * drops empty text blocks, inlines unsupported file/document parts as text, collapses tool_result
+ * blocks to text (unless preserved), drops unsupported parts, and moves stray tool_result blocks out
+ * of assistant messages (#2815). Both mutate the payload in place; behaviour is byte-identical to the
+ * previous inline closures (normalize captured only `log`).
+ */
+
+import type { ClaudeContentBlock, ClaudeMessage } from "./claudeMessageTypes.ts";
+import { extractSystemRoleMessages } from "./claudeSystemRole.ts";
+import { splitMisplacedToolResults } from "../../translator/helpers/claudeHelper.ts";
+
+type LoggerLike = { debug?: (...args: unknown[]) => void } | null | undefined;
+
+export function extractSystemMessagesToBody(payload: Record<string, unknown>) {
+  if (!Array.isArray(payload.messages)) return;
+  const messages = payload.messages as ClaudeMessage[];
+  const systemMessages = messages.filter((m) => {
+    const role = String(m.role || "").toLowerCase();
+    return role === "system" || role === "developer";
+  });
+  if (systemMessages.length === 0) return;
+  const extraBlocks: ClaudeContentBlock[] = [];
+  for (const sm of systemMessages) {
+    if (typeof sm.content === "string" && sm.content.length > 0) {
+      extraBlocks.push({ type: "text", text: sm.content });
+    } else if (Array.isArray(sm.content)) {
+      for (const block of sm.content as ClaudeContentBlock[]) {
+        if (block?.type === "text" && typeof block.text === "string" && block.text.length > 0) {
+          extraBlocks.push(block);
+        }
+      }
+    }
+  }
+  if (extraBlocks.length > 0) {
+    const existingSystem = payload.system;
+    if (typeof existingSystem === "string" && existingSystem.length > 0) {
+      payload.system = [{ type: "text", text: existingSystem }, ...extraBlocks];
+    } else if (Array.isArray(existingSystem)) {
+      payload.system = [...(existingSystem as ClaudeContentBlock[]), ...extraBlocks];
+    } else {
+      payload.system = extraBlocks;
+    }
+  }
+  payload.messages = messages.filter((m) => {
+    const role = String(m.role || "").toLowerCase();
+    return role !== "system" && role !== "developer";
+  });
+}
+
+export function normalizeClaudeUpstreamMessages(
+  payload: Record<string, unknown>,
+  options?: { preserveToolResultBlocks?: boolean },
+  log?: LoggerLike
+) {
+  const preserveToolResultBlocks = options?.preserveToolResultBlocks === true;
+  if (!Array.isArray(payload.messages)) return;
+  let messages = payload.messages as ClaudeMessage[];
+
+  // Extract system/developer role messages into top-level system parameter.
+  extractSystemRoleMessages(payload);
+  messages = payload.messages as ClaudeMessage[];
+
+  // Anthropic rejects empty text blocks in native Messages payloads.
+  for (const msg of messages) {
+    if (Array.isArray(msg.content)) {
+      msg.content = msg.content.filter(
+        (block: ClaudeContentBlock) =>
+          block.type !== "text" || (typeof block.text === "string" && block.text.length > 0)
+      );
+    }
+  }
+
+  // Normalize unsupported content types without reintroducing the Claude -> OpenAI round-trip.
+  for (const msg of messages) {
+    if (msg.role !== "user" || !Array.isArray(msg.content)) continue;
+    msg.content = (msg.content as ClaudeContentBlock[]).flatMap((block: ClaudeContentBlock) => {
+      if (
+        block.type === "text" ||
+        block.type === "image_url" ||
+        block.type === "image" ||
+        block.type === "file_url" ||
+        block.type === "file" ||
+        block.type === "document"
+      ) {
+        const fileData = (block.file_url ?? block.file ?? block.document) as
+          | Record<string, unknown>
+          | undefined;
+        if (
+          (block.type === "file" || block.type === "document") &&
+          !fileData?.url &&
+          !fileData?.data
+        ) {
+          const fileContent =
+            (block.file as ClaudeContentBlock)?.content ??
+            (block.file as ClaudeContentBlock)?.text ??
+            block.content ??
+            block.text;
+          const fileName =
+            (block.file as Record<string, unknown>)?.name ?? block.name ?? "attachment";
+          if (typeof fileContent === "string" && fileContent.length > 0) {
+            return [{ type: "text", text: `[${fileName}]\n${fileContent}` }];
+          }
+        }
+        return [block];
+      }
+
+      if (block.type === "tool_result") {
+        if (preserveToolResultBlocks) {
+          return [block];
+        }
+        const toolId = block.tool_use_id ?? block.id ?? "unknown";
+        const resultContent = block.content ?? block.text ?? block.output ?? "";
+        const resultText =
+          typeof resultContent === "string"
+            ? resultContent
+            : Array.isArray(resultContent)
+              ? resultContent
+                  .filter((c: Record<string, unknown>) => c.type === "text")
+                  .map((c: Record<string, unknown>) => c.text)
+                  .join("\n")
+              : JSON.stringify(resultContent);
+        if (resultText.length > 0) {
+          return [{ type: "text", text: `[Tool Result: ${toolId}]\n${resultText}` }];
+        }
+        return [];
+      }
+
+      log?.debug?.("CONTENT", `Dropped unsupported content part type="${block.type}"`);
+      return [];
+    });
+  }
+
+  // #2815: move stray tool_result blocks out of assistant messages.
+  payload.messages = splitMisplacedToolResults(
+    payload.messages as ClaudeMessage[]
+  ) as unknown as Record<string, unknown>[];
+}

--- a/tests/unit/chatcore-claude-upstream-messages.test.ts
+++ b/tests/unit/chatcore-claude-upstream-messages.test.ts
@@ -1,0 +1,109 @@
+// tests/unit/chatcore-claude-upstream-messages.test.ts
+// Characterization of extractSystemMessagesToBody / normalizeClaudeUpstreamMessages — the Claude
+// upstream-message transforms extracted from handleChatCore (chatCore god-file decomposition,
+// #3501). Locks: system/developer role lifting into top-level `system` (string/array/none merge
+// shapes), empty-text-block dropping, tool_result collapse vs preserve, file/document inlining, and
+// unsupported-part dropping (with the debug log).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  extractSystemMessagesToBody,
+  normalizeClaudeUpstreamMessages,
+} from "../../open-sse/handlers/chatCore/claudeUpstreamMessages.ts";
+
+test("extractSystemMessagesToBody lifts system/developer roles into top-level system", () => {
+  const payload: Record<string, unknown> = {
+    messages: [
+      { role: "system", content: "be terse" },
+      { role: "developer", content: "use json" },
+      { role: "user", content: "hi" },
+    ],
+  };
+  extractSystemMessagesToBody(payload);
+  assert.deepEqual(payload.system, [
+    { type: "text", text: "be terse" },
+    { type: "text", text: "use json" },
+  ]);
+  assert.deepEqual(payload.messages, [{ role: "user", content: "hi" }]);
+});
+
+test("extractSystemMessagesToBody prepends an existing string system", () => {
+  const payload: Record<string, unknown> = {
+    system: "base",
+    messages: [{ role: "system", content: "extra" }],
+  };
+  extractSystemMessagesToBody(payload);
+  assert.deepEqual(payload.system, [
+    { type: "text", text: "base" },
+    { type: "text", text: "extra" },
+  ]);
+});
+
+test("extractSystemMessagesToBody is a no-op without system messages or a messages array", () => {
+  const p1: Record<string, unknown> = { messages: [{ role: "user", content: "hi" }] };
+  extractSystemMessagesToBody(p1);
+  assert.equal(p1.system, undefined);
+  const p2: Record<string, unknown> = { messages: "nope" };
+  extractSystemMessagesToBody(p2);
+  assert.equal(p2.system, undefined);
+});
+
+test("normalizeClaudeUpstreamMessages drops empty text blocks", () => {
+  const payload: Record<string, unknown> = {
+    messages: [
+      { role: "user", content: [{ type: "text", text: "" }, { type: "text", text: "keep" }] },
+    ],
+  };
+  normalizeClaudeUpstreamMessages(payload);
+  const msg = (payload.messages as Record<string, unknown>[])[0];
+  assert.deepEqual(msg.content, [{ type: "text", text: "keep" }]);
+});
+
+test("normalizeClaudeUpstreamMessages collapses tool_result to text by default", () => {
+  const payload: Record<string, unknown> = {
+    messages: [
+      { role: "user", content: [{ type: "tool_result", tool_use_id: "t1", content: "out" }] },
+    ],
+  };
+  normalizeClaudeUpstreamMessages(payload);
+  const msg = (payload.messages as Record<string, unknown>[])[0];
+  assert.deepEqual(msg.content, [{ type: "text", text: "[Tool Result: t1]\nout" }]);
+});
+
+test("normalizeClaudeUpstreamMessages preserves tool_result when asked", () => {
+  const payload: Record<string, unknown> = {
+    messages: [
+      { role: "user", content: [{ type: "tool_result", tool_use_id: "t1", content: "out" }] },
+    ],
+  };
+  normalizeClaudeUpstreamMessages(payload, { preserveToolResultBlocks: true });
+  const msg = (payload.messages as Record<string, unknown>[])[0];
+  assert.deepEqual(msg.content, [{ type: "tool_result", tool_use_id: "t1", content: "out" }]);
+});
+
+test("normalizeClaudeUpstreamMessages inlines a file block without url/data as text", () => {
+  const payload: Record<string, unknown> = {
+    messages: [
+      {
+        role: "user",
+        content: [{ type: "file", file: { name: "notes.txt", content: "hello" } }],
+      },
+    ],
+  };
+  normalizeClaudeUpstreamMessages(payload);
+  const msg = (payload.messages as Record<string, unknown>[])[0];
+  assert.deepEqual(msg.content, [{ type: "text", text: "[notes.txt]\nhello" }]);
+});
+
+test("normalizeClaudeUpstreamMessages drops unsupported parts and logs via the bound logger", () => {
+  const logged: string[] = [];
+  const log = { debug: (_tag: string, msg: string) => logged.push(msg) };
+  const payload: Record<string, unknown> = {
+    messages: [{ role: "user", content: [{ type: "thinking", text: "x" }] }],
+  };
+  normalizeClaudeUpstreamMessages(payload, undefined, log);
+  const msg = (payload.messages as Record<string, unknown>[])[0];
+  assert.deepEqual(msg.content, []);
+  assert.equal(logged.length, 1);
+  assert.match(logged[0], /Dropped unsupported content part type="thinking"/);
+});


### PR DESCRIPTION
## O que

Lote 3 da decomposição do god-file `chatCore.ts` (#3501) — move os **2 transforms de mensagens Claude** do `handleChatCore` para leaves, byte-idêntico:

| Leaf novo | Conteúdo |
|---|---|
| `chatCore/claudeMessageTypes.ts` | tipos `ClaudeMessage` / `ClaudeContentBlock` (eram locais no handler; reimporto só `ClaudeMessage`, ainda usado num cast em `translatedBody.messages as ClaudeMessage[]`) |
| `chatCore/claudeUpstreamMessages.ts` | `extractSystemMessagesToBody` (**puro**) + `normalizeClaudeUpstreamMessages` (captura só `log`; usa `extractSystemRoleMessages` já-leaf + `splitMisplacedToolResults` import) |

O handler mantém um binding fino de `log` → call sites byte-idênticos (1867/1909/1951).

⭐ **trust-but-verify:** `extractSystemMessagesToBody` já era **dead-in-handler na base** (0 call sites; superado por `extractSystemRoleMessages`). Mantido exportado e coberto por teste no leaf, **não** reimportado no handler (senão lint=morto) — sem deleção silenciosa. `ClaudeContentBlock` só era usado dentro dos closures removidos → não reimportado.

`chatCore.ts`: **4585 → 4461 (−124 linhas)**. As únicas adições ao handler são 2 imports + o binding.

## Validação

- `typecheck:core` — exit 0
- 1 teste novo (**8 casos**): lifting system/developer, merge string/array/none, drop de text vazio, tool_result collapse vs preserve, inline de file/document, drop de parte não suportada (com o debug log via logger injetado)
- Suíte chatcore completa: **283/283** · `system-role-extraction` (re-export intacto): **10/10**
- `check:file-size` OK · `check:db-rules` OK · lint exit 0

## Gate de complexity (pré-existente, NÃO deste PR)

`check:complexity` acusa `1908 > baseline 1906` — **mesmo drift dos lotes 1 e 2** (baseline `.33/.34` desatualizado 1906 vs real 1908). Relocação de closures é neutra; meu delta = 0. Reconciliação do baseline a cargo do dono.

## Stack

Empilhado sobre `refactor/qg-chatcore-batch2` (PR #4646). Parte do programa #3501.
