### PR TITLE
feat(opencode-go): advertise glm-5.2 and kimi-k2.7-code (align with official Go endpoints)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 _In development — bullets added per PR; finalized at release._
 
+### ✨ New Features
+
+- **feat(opencode-go): advertise glm-5.2 and kimi-k2.7-code (align with official Go endpoints)** — added the two model IDs the official Go API now advertises. The plain `kimi-k2.7` alias is rejected by the live `/chat/completions` endpoint even though the docs config example uses it, so chat traffic must target `kimi-k2.7-code`. OmniRoute already routes the Anthropic-format models (`minimax-m3`, `qwen3.7-max`, …) through `/messages` declaratively via `targetFormat: "claude"`, so no executor changes are needed. (port from decolua/9router 8efacc11 — thanks @nguyenha935)
+
 ### 📝 Maintenance
 
 - **chore(quality): release-green pre-flight validator + nightly signal** — new `npm run check:release-green` (`scripts/quality/validate-release-green.mjs`) reproduces the release-equivalent validation (full unit + vitest + ratchets + typecheck + lint, optional `--with-build` package-artifact) against the current working tree and classifies each red as **HARD** (real defect) vs **DRIFT** (ratchet, rebaselined at release) — purely diagnostic, never blocking contributors. A new `nightly-release-green` workflow runs it on the active release branch and opens/updates a tracking issue on hard failures. Closes the gap where the full gate (`ci.yml`) only ran on the release PR, so reds accrued silently on `release/**` and surfaced in layers at release time. (thanks @diegosouzapw)

--- a/open-sse/config/providers/registry/opencode/go/index.ts
+++ b/open-sse/config/providers/registry/opencode/go/index.ts
@@ -13,8 +13,14 @@ export const opencode_goProvider: RegistryEntry = {
   authPrefix: "Bearer",
   defaultContextLength: 200000,
   models: [
+    // Port from decolua/9router 8efacc11: align with official Go endpoints —
+    // glm-5.2 is now advertised and Kimi chat traffic must route through
+    // `kimi-k2.7-code` (the live API rejects the plain `kimi-k2.7` alias for
+    // `/chat/completions`, even though the docs config example uses it).
+    { id: "glm-5.2", name: "GLM-5.2" },
     { id: "glm-5.1", name: "GLM-5.1" },
     { id: "glm-5", name: "GLM-5" },
+    { id: "kimi-k2.7-code", name: "Kimi K2.7 Code" },
     { id: "kimi-k2.6", name: "Kimi K2.6" },
     { id: "kimi-k2.5", name: "Kimi K2.5" },
     { id: "mimo-v2.5-pro", name: "MiMo-V2.5-Pro" },

--- a/tests/unit/opencode-go-catalog-alignment.test.ts
+++ b/tests/unit/opencode-go-catalog-alignment.test.ts
@@ -1,0 +1,45 @@
+/**
+ * OpenCode Go model catalog alignment with the official Go docs.
+ *
+ * Port of decolua/9router 8efacc114 (thanks @nguyenha935): the official Go API
+ * advertises `glm-5.2` and routes Kimi chat traffic through `kimi-k2.7-code`
+ * (the live API rejects the plain `kimi-k2.7` alias for `/chat/completions`
+ * even though the public docs example uses it). OmniRoute previously shipped
+ * the older registry without these IDs.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { opencode_goProvider } = await import(
+  "../../open-sse/config/providers/registry/opencode/go/index.ts"
+);
+
+function modelIds(): string[] {
+  return (opencode_goProvider.models ?? []).map((m) => m.id);
+}
+
+test("opencode-go advertises glm-5.2 (official Go endpoint addition)", () => {
+  assert.ok(
+    modelIds().includes("glm-5.2"),
+    `expected glm-5.2 in opencode-go catalog, got: ${modelIds().join(", ")}`
+  );
+});
+
+test("opencode-go advertises kimi-k2.7-code (live API rejects plain kimi-k2.7 for chat)", () => {
+  assert.ok(
+    modelIds().includes("kimi-k2.7-code"),
+    `expected kimi-k2.7-code in opencode-go catalog, got: ${modelIds().join(", ")}`
+  );
+});
+
+test("opencode-go preserves the pre-existing minimax-m3 and qwen routing via targetFormat=claude", () => {
+  // Routing through the /messages endpoint is OmniRoute's declarative
+  // equivalent of upstream's MESSAGES_FORMAT_MODELS set; the alignment
+  // change must not regress this.
+  const byId = new Map(
+    (opencode_goProvider.models ?? []).map((m) => [m.id, m as Record<string, unknown>])
+  );
+  assert.equal(byId.get("minimax-m3")?.targetFormat, "claude");
+  assert.equal(byId.get("qwen3.7-max")?.targetFormat, "claude");
+});


### PR DESCRIPTION
## Summary

Port of [decolua/9router 8efacc11](https://github.com/decolua/9router/commit/8efacc114775423b5c69f1088b6f61217eb1f414) (thanks @nguyenha935).

The official Go API now advertises `glm-5.2`, and the live `/chat/completions` endpoint rejects the plain `kimi-k2.7` alias even though the docs config example uses it — chat traffic must target `kimi-k2.7-code`. Both IDs are now in the opencode-go registry.

OmniRoute already routes the Anthropic-format models (`minimax-m3`, `qwen3.7-max`, …) through `/messages` declaratively via `targetFormat: "claude"`, so no executor changes are needed (cleaner than upstream's `MESSAGES_FORMAT_MODELS` set duplicated in the executor).

## Test plan

- [x] `node --import tsx/esm --test tests/unit/opencode-go-catalog-alignment.test.ts` → 3/3 pass
- [x] Regression: `tests/unit/{minimax-m3-model-registry,opencode-quota-fetcher,opencode-go-usage,custom-model-target-format}.test.ts` → 37/37 pass
- [x] `npm run typecheck:core` → clean
- [x] `npm run check:file-size` → OK