### PR TITLE
chore(dashboard): rename Qoder display label from "Qoder AI" to "Qoder"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 - **deps: bump production + development groups; migrate js-yaml to v5 (ESM)** — dependency bumps plus a `js-yaml` v4→v5 migration to the ESM-only namespace import. ([#4697](https://github.com/diegosouzapw/OmniRoute/pull/4697) — thanks @diegosouzapw)
 - **chore(quality): release-green pre-flight validator + nightly signal** — new `npm run check:release-green` (`scripts/quality/validate-release-green.mjs`) reproduces the release-equivalent validation (full unit + vitest + ratchets + typecheck + lint, optional `--with-build` package-artifact) against the current working tree and classifies each red as **HARD** (real defect) vs **DRIFT** (ratchet, rebaselined at release) — purely diagnostic, never blocking contributors. A new `nightly-release-green` workflow runs it on the active release branch and opens/updates a tracking issue on hard failures. Closes the gap where the full gate (`ci.yml`) only ran on the release PR, so reds accrued silently on `release/**` and surfaced in layers at release time. ([#4622](https://github.com/diegosouzapw/OmniRoute/pull/4622) — thanks @diegosouzapw)
 - **chore(quality): reconcile file-size baseline for #4644 (`deepseek-web.ts` 1117→1125)** — rebaselines the file-size gate after the deepseek-web hardening. ([#4695](https://github.com/diegosouzapw/OmniRoute/pull/4695) — thanks @diegosouzapw)
+- **chore(dashboard): rename Qoder provider display label from "Qoder AI" to "Qoder"** — updates the OAuth provider entry's display name to match the official Qoder branding. (thanks @Simon Shi)
 
 ---
 

--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -144,7 +144,7 @@ export const OAUTH_PROVIDERS = {
   qoder: {
     id: "qoder",
     alias: "if",
-    name: "Qoder AI",
+    name: "Qoder",
     icon: "water_drop",
     color: "#6366F1",
     subscriptionRisk: true,

--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -136,7 +136,7 @@ export const OAUTH_PROVIDERS = {
   qoder: {
     id: "qoder",
     alias: "if",
-    name: "Qoder AI",
+    name: "Qoder",
     icon: "water_drop",
     color: "#6366F1",
     subscriptionRisk: true,

--- a/tests/unit/qoder-display-label.test.ts
+++ b/tests/unit/qoder-display-label.test.ts
@@ -1,0 +1,17 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { OAUTH_PROVIDERS, getProviderById } = await import(
+  "../../src/shared/constants/providers.ts"
+);
+
+test("Qoder provider display label is 'Qoder' (not 'Qoder AI')", () => {
+  assert.equal((OAUTH_PROVIDERS as Record<string, { name: string }>).qoder.name, "Qoder");
+});
+
+test("getProviderById('qoder') resolves the renamed display label", () => {
+  const provider = getProviderById("qoder");
+  assert.ok(provider, "qoder provider should resolve");
+  assert.equal(provider.name, "Qoder");
+  assert.notEqual(provider.name, "Qoder AI");
+});


### PR DESCRIPTION
## Summary

- Renames the Qoder OAuth provider's display label from "Qoder AI" to "Qoder" in `src/shared/constants/providers.ts`, matching the official Qoder branding (the upstream product dropped the "AI" suffix).
- Cosmetic display-label change only — `id` / `alias` / `icon` / `color` / `subscriptionRisk` and all routing behaviour are unchanged.

## Attribution

Thanks to @Simon Shi for the original implementation.

## Changes

- `src/shared/constants/providers.ts`: `OAUTH_PROVIDERS.qoder.name` `"Qoder AI"` → `"Qoder"`.
- `tests/unit/qoder-display-label.test.ts`: new TDD regression test (fails before, passes after) asserting the display label via both `OAUTH_PROVIDERS.qoder.name` and `getProviderById("qoder").name`.
- `CHANGELOG.md`: one bullet in the 3.8.34 Maintenance section.

## Test plan

- [x] `node --import tsx/esm --test tests/unit/qoder-display-label.test.ts` — fails before the fix, passes after.
- [x] Related provider tests green (`check-provider-consistency`, `qoder-oauth-config`, `qoder-cli`, `providers-free-tier-filter`).
- [x] `tsc --noEmit` clean for the touched scope.