### PR TITLE
feat(sse): parse Gemini CLI 429 retryDelay from structured RetryInfo

### DIFF
--- a/open-sse/executors/gemini-cli.ts
+++ b/open-sse/executors/gemini-cli.ts
@@ -534,10 +534,17 @@ export class GeminiCLIExecutor extends BaseExecutor {
     }
   }
 
-  // Parse retry time from Gemini error message body
-  // Format: "Your quota will reset after 2h7m23s"
+  // Parse retry time from Gemini error message body. Two shapes are handled:
+  //  1. Structured google.rpc.RetryInfo in the 429/503 JSON body:
+  //     { error: { details: [{ "@type": ".../google.rpc.RetryInfo", retryDelay: "30s" }] } }
+  //  2. Human-readable prose: "Your quota will reset after 2h7m23s"
+  // The structured hint is authoritative (it is what the Cloud Code Assist API
+  // sends), so it is checked first and falls through to the prose form on miss.
   parseRetryFromErrorMessage(errorMessage: unknown): number | null {
     if (!errorMessage || typeof errorMessage !== "string") return null;
+
+    const structuredMs = this.parseStructuredRetryDelay(errorMessage);
+    if (structuredMs !== null) return structuredMs;
 
     const match = errorMessage.match(/reset (?:after|in) (\d+h)?(\d+m)?(\d+s)?/i);
     if (!match) return null;
@@ -548,6 +555,32 @@ export class GeminiCLIExecutor extends BaseExecutor {
     if (match[3]) totalMs += parseInt(match[3]) * 1000;
 
     return totalMs || 2_000;
+  }
+
+  // Read google.rpc.RetryInfo.retryDelay from a Google API error JSON body and
+  // convert the protobuf Duration string ("30s", "1.5s", "0.500s") into ms.
+  // Returns null when the body is not JSON or carries no RetryInfo detail.
+  private parseStructuredRetryDelay(bodyText: string): number | null {
+    if (!bodyText.includes("RetryInfo")) return null;
+    try {
+      const parsed = JSON.parse(bodyText);
+      const details = parsed?.error?.details;
+      if (!Array.isArray(details)) return null;
+      for (const detail of details) {
+        if (
+          detail?.["@type"] === "type.googleapis.com/google.rpc.RetryInfo" &&
+          typeof detail?.retryDelay === "string"
+        ) {
+          const seconds = parseFloat(detail.retryDelay.replace(/s$/i, ""));
+          if (Number.isFinite(seconds) && seconds >= 0) {
+            return Math.round(seconds * 1000) || 2_000;
+          }
+        }
+      }
+    } catch {
+      /* not JSON — caller falls back to prose parsing */
+    }
+    return null;
   }
 }
 

--- a/tests/unit/executor-gemini-cli.test.ts
+++ b/tests/unit/executor-gemini-cli.test.ts
@@ -473,3 +473,55 @@ test("GeminiCLIExecutor.execute applies CLI fingerprint to the final Cloud Code 
     globalThis.fetch = originalFetch;
   }
 });
+
+test("GeminiCLIExecutor.parseRetryFromErrorMessage reads structured google.rpc.RetryInfo.retryDelay", () => {
+  const executor = new GeminiCLIExecutor();
+
+  const body = JSON.stringify({
+    error: {
+      code: 429,
+      message: "Resource has been exhausted (e.g. check quota).",
+      status: "RESOURCE_EXHAUSTED",
+      details: [
+        { "@type": "type.googleapis.com/google.rpc.QuotaFailure", violations: [] },
+        { "@type": "type.googleapis.com/google.rpc.RetryInfo", retryDelay: "30s" },
+      ],
+    },
+  });
+
+  // The prose regex would not match this JSON body, so a positive result proves
+  // the structured RetryInfo path is what produced the hint.
+  assert.equal(executor.parseRetryFromErrorMessage(body), 30_000);
+});
+
+test("GeminiCLIExecutor.parseRetryFromErrorMessage parses fractional retryDelay seconds", () => {
+  const executor = new GeminiCLIExecutor();
+
+  const body = JSON.stringify({
+    error: {
+      details: [
+        { "@type": "type.googleapis.com/google.rpc.RetryInfo", retryDelay: "1.5s" },
+      ],
+    },
+  });
+
+  assert.equal(executor.parseRetryFromErrorMessage(body), 1_500);
+});
+
+test("GeminiCLIExecutor.parseRetryFromErrorMessage still parses prose 'reset after' format", () => {
+  const executor = new GeminiCLIExecutor();
+
+  assert.equal(
+    executor.parseRetryFromErrorMessage("Your quota will reset after 1h2m3s"),
+    1 * 3600 * 1000 + 2 * 60 * 1000 + 3 * 1000
+  );
+});
+
+test("GeminiCLIExecutor.parseRetryFromErrorMessage returns null for unrelated JSON", () => {
+  const executor = new GeminiCLIExecutor();
+
+  assert.equal(
+    executor.parseRetryFromErrorMessage(JSON.stringify({ error: { message: "nope" } })),
+    null
+  );
+});


### PR DESCRIPTION
## Summary

- Cloud Code Assist (Gemini CLI) returns its rate-limit backoff as a structured `google.rpc.RetryInfo` detail — `error.details[@type="type.googleapis.com/google.rpc.RetryInfo"].retryDelay`, a protobuf Duration string like `"30s"` or `"1.5s"`.
- The Gemini CLI executor's `parseRetryFromErrorMessage` only matched the human-readable `"reset after 2h7m23s"` prose, so the structured retry hint on a 429/503 was ignored and the retry path fell back to its default backoff.
- `parseRetryFromErrorMessage` now reads the structured `retryDelay` first (converting the duration to ms) and falls through to the existing prose form on miss. The existing 429/503 callsite in `execute()` already feeds the raw body to this helper, so no callsite change was needed.

## Attribution

Thanks to [@NoxzRCW](https://github.com/NoxzRCW) for the original implementation.

## Changes

- `open-sse/executors/gemini-cli.ts` — add `parseStructuredRetryDelay` and check it first inside `parseRetryFromErrorMessage`.
- `tests/unit/executor-gemini-cli.test.ts` — TDD coverage: structured `retryDelay` (`"30s"` → 30000ms), fractional (`"1.5s"` → 1500ms), prose path preserved, and unrelated JSON returns null.

## Test plan

- [x] `node --import tsx/esm --test tests/unit/executor-gemini-cli.test.ts` (18/18 pass; the 2 new structured tests fail before the fix, pass after)
- [x] `npm run typecheck:core` (clean)