### PR TITLE
fix(sse): strip enumDescriptions from antigravity tool schema

### DIFF
--- a/open-sse/translator/request/antigravity-to-openai.ts
+++ b/open-sse/translator/request/antigravity-to-openai.ts
@@ -100,6 +100,7 @@ export function antigravityToOpenAIRequest(model, body, stream) {
 }
 
 // Recursively convert Antigravity schema types (OBJECT, STRING, etc.) to lowercase
+// and strip unsupported fields like enumDescriptions
 function normalizeSchemaTypes(schema) {
   if (!schema || typeof schema !== "object") return schema;
 
@@ -108,6 +109,9 @@ function normalizeSchemaTypes(schema) {
   if (typeof result.type === "string") {
     result.type = result.type.toLowerCase();
   }
+
+  // Strip enumDescriptions — not supported by upstream OpenAI-compatible APIs
+  delete result.enumDescriptions;
 
   if (result.properties) {
     const normalized = {};

--- a/tests/unit/translator-antigravity-to-openai.test.ts
+++ b/tests/unit/translator-antigravity-to-openai.test.ts
@@ -192,3 +192,61 @@ test("Antigravity -> OpenAI lowers schema types recursively", () => {
     },
   });
 });
+
+test("Antigravity -> OpenAI strips enumDescriptions from tool schema (top-level + nested)", () => {
+  const result = antigravityToOpenAIRequest(
+    "gpt-4o",
+    {
+      request: {
+        tools: [
+          {
+            functionDeclarations: [
+              {
+                name: "configure",
+                parameters: {
+                  type: "OBJECT",
+                  enumDescriptions: { ROOT: "should be stripped" },
+                  properties: {
+                    mode: {
+                      type: "STRING",
+                      enum: ["fast", "slow"],
+                      enumDescriptions: { fast: "go fast", slow: "go slow" },
+                    },
+                    tags: {
+                      type: "ARRAY",
+                      items: {
+                        type: "STRING",
+                        enum: ["a", "b"],
+                        enumDescriptions: { a: "alpha", b: "beta" },
+                      },
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        ],
+      },
+    },
+    false
+  );
+
+  const parameters = (result.tools[0].function as any).parameters;
+
+  // enumDescriptions must be removed at every level of the schema tree...
+  assert.equal("enumDescriptions" in parameters, false);
+  assert.equal("enumDescriptions" in parameters.properties.mode, false);
+  assert.equal("enumDescriptions" in parameters.properties.tags.items, false);
+
+  // ...while leaving the rest of the schema (incl. enum values) intact.
+  assert.deepEqual(parameters, {
+    type: "object",
+    properties: {
+      mode: { type: "string", enum: ["fast", "slow"] },
+      tags: {
+        type: "array",
+        items: { type: "string", enum: ["a", "b"] },
+      },
+    },
+  });
+});


### PR DESCRIPTION
## Summary

- The recursive `normalizeSchemaTypes()` helper in `open-sse/translator/request/antigravity-to-openai.ts` lowercased schema `type`s and recursed into `properties`/`items` but never removed the unsupported `enumDescriptions` field from tool-parameter schemas.
- Some OpenAI-compatible upstreams reject `enumDescriptions`, breaking tool calls when an Antigravity request carries it.

## Changes

- Delete `enumDescriptions` inside `normalizeSchemaTypes()` so it is stripped at every level of the schema tree — top-level, nested `properties`, and array `items` — while leaving `enum` values and the rest of the schema intact.
- Added a TDD unit test in `tests/unit/translator-antigravity-to-openai.test.ts` that fails before the fix and passes after (asserts `enumDescriptions` is gone at all three levels and the rest of the schema is preserved).

## Attribution

Thanks to [@anuragg-saxenaa](https://github.com/anuragg-saxenaa) for the original implementation.

## Test plan

- [x] `node --import tsx/esm --test tests/unit/translator-antigravity-to-openai.test.ts` (5/5 pass; new case fails without the production change)
- [x] `npm run typecheck:core` (no errors in touched files)