### PR TITLE
fix(sse): include low-level cause details in formatProviderError

### DIFF
--- a/open-sse/utils/error.ts
+++ b/open-sse/utils/error.ts
@@ -487,7 +487,7 @@ export function normalizeCookie(raw: string): string {
  * @returns {string} Formatted error message
  */
 export function formatProviderError(
-  error: { code?: string | number; message?: string } | Error,
+  error: { code?: string | number; message?: string; cause?: unknown } | Error,
   provider: string,
   model: string,
   statusCode?: string | number | null
@@ -495,5 +495,12 @@ export function formatProviderError(
   const providerCode = "code" in error ? error.code : undefined;
   const code = statusCode || providerCode || "FETCH_FAILED";
   const message = error.message || "Unknown error";
-  return `[${code}]: ${message}`;
+  // Expose low-level cause (e.g. UND_ERR_SOCKET, ECONNRESET, ETIMEDOUT) for diagnosing fetch failures
+  const cause = (error as { cause?: unknown }).cause;
+  const causeObj = cause && typeof cause === "object" ? (cause as Record<string, unknown>) : undefined;
+  const causeCode = typeof causeObj?.code === "string" ? causeObj.code : undefined;
+  const causeMsg = typeof causeObj?.message === "string" ? causeObj.message : undefined;
+  const causeStr =
+    causeCode || causeMsg ? ` (cause: ${[causeCode, causeMsg].filter(Boolean).join(": ")})` : "";
+  return `[${code}]: ${message}${causeStr}`;
 }

--- a/tests/unit/format-provider-error-cause.test.ts
+++ b/tests/unit/format-provider-error-cause.test.ts
@@ -1,0 +1,47 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { formatProviderError } = await import("../../open-sse/utils/error.ts");
+
+test("formatProviderError: appends low-level cause.code for fetch failures", () => {
+  const err = Object.assign(new Error("fetch failed"), {
+    cause: { code: "UND_ERR_SOCKET" },
+  });
+  const out = formatProviderError(err, "openai", "gpt-4o", null);
+  assert.equal(out, "[FETCH_FAILED]: fetch failed (cause: UND_ERR_SOCKET)");
+});
+
+test("formatProviderError: appends both cause.code and cause.message when present", () => {
+  const err = Object.assign(new Error("fetch failed"), {
+    cause: { code: "ECONNRESET", message: "socket hang up" },
+  });
+  const out = formatProviderError(err, "anthropic", "claude-3", null);
+  assert.equal(out, "[FETCH_FAILED]: fetch failed (cause: ECONNRESET: socket hang up)");
+});
+
+test("formatProviderError: appends only cause.message when code is absent", () => {
+  const err = Object.assign(new Error("fetch failed"), {
+    cause: { message: "ETIMEDOUT raised" },
+  });
+  const out = formatProviderError(err, "gemini", "gemini-2", null);
+  assert.equal(out, "[FETCH_FAILED]: fetch failed (cause: ETIMEDOUT raised)");
+});
+
+test("formatProviderError: no cause suffix when error has no cause", () => {
+  const err = { code: "rate_limited", message: "Too many requests" };
+  const out = formatProviderError(err, "openai", "gpt-4o", 429);
+  assert.equal(out, "[429]: Too many requests");
+});
+
+test("formatProviderError: ignores a cause that carries neither code nor message", () => {
+  const err = Object.assign(new Error("boom"), { cause: {} });
+  const out = formatProviderError(err, "openai", "gpt-4o", null);
+  assert.equal(out, "[FETCH_FAILED]: boom");
+});
+
+test("formatProviderError: handles a primitive (string) cause without crashing", () => {
+  const err = Object.assign(new Error("boom"), { cause: "raw string cause" });
+  const out = formatProviderError(err, "openai", "gpt-4o", null);
+  // primitive cause has no .code/.message → no suffix appended
+  assert.equal(out, "[FETCH_FAILED]: boom");
+});


### PR DESCRIPTION
## Summary

- `formatProviderError` now appends the underlying `error.cause.code`/`message` (e.g. `UND_ERR_SOCKET`, `ECONNRESET`, `ETIMEDOUT`) to the formatted provider error message.
- Transport/fetch failures become diagnosable from the message itself instead of surfacing a bare `[FETCH_FAILED]: fetch failed`.
- The cause is read defensively: only an object cause contributing a string `code`/`message` adds a `(cause: …)` suffix; primitive or empty causes are ignored. The result still flows through the standard error-body sanitization path.

## Attribution

Thanks to @decolua for the original implementation.

## Changes

- `open-sse/utils/error.ts` — extend `formatProviderError` with the low-level cause suffix (typed `cause?: unknown`, narrowed before use).
- `tests/unit/format-provider-error-cause.test.ts` — new TDD coverage (fails before, passes after) for cause.code, cause.code+message, cause.message-only, no-cause, empty-cause, and primitive-cause cases.
- `CHANGELOG.md` — one bullet in the `[3.8.34]` Fixed section.

## Test plan

- [x] `node --import tsx/esm --test tests/unit/format-provider-error-cause.test.ts` (6/6 pass; failed before the production change)
- [x] `tests/unit/executor-web-cookie-sweep.test.ts` (existing `formatProviderError` consumer — 24/24 pass)
- [x] `npm run typecheck:core` (exit 0, 0 TS errors)