### PR TITLE
fix(dashboard): add missing onboarding.tiers step title (#4698)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ _In development — bullets added per PR; finalized at release._
 ### 🔧 Bug Fixes
 
 - **db-backups**: make the database-import size cap configurable via `OMNIROUTE_DB_IMPORT_MAX_MB` (default 100 MB, 4 GB ceiling) so backups larger than 100 MB can be restored; error message now points to the env var and to VACUUM (#4719).
+- **Onboarding**: add the missing `onboarding.tiers` step-title translation so the setup wizard no longer crashes with `MISSING_MESSAGE: onboarding.tiers` (#4698).
 
 ---
 

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -3816,6 +3816,7 @@
   },
   "onboarding": {
     "welcome": "Welcome",
+    "tiers": "Tiers",
     "security": "Security",
     "test": "Test",
     "ready": "Ready!",

--- a/tests/unit/onboarding-step-titles-i18n-4698.test.ts
+++ b/tests/unit/onboarding-step-titles-i18n-4698.test.ts
@@ -1,0 +1,34 @@
+// #4698 — the onboarding wizard rendered each step title via t(stepId), but the "tiers"
+// step had no matching onboarding.tiers key, so next-intl threw
+// "MISSING_MESSAGE: onboarding.tiers (en)" and the wizard crashed. Guard that every step
+// id used as a title resolves to a string in the source (en) catalog.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+// Mirrors STEP_IDS in src/app/(dashboard)/dashboard/onboarding/page.tsx and the
+// title lookup `t(id === "done" ? "ready" : id)`.
+const STEP_IDS = ["welcome", "tiers", "security", "provider", "test", "done"];
+const titleKeyFor = (id: string) => (id === "done" ? "ready" : id);
+
+const enPath = fileURLToPath(
+  new URL("../../src/i18n/messages/en.json", import.meta.url)
+);
+const en = JSON.parse(readFileSync(enPath, "utf8"));
+
+test("every onboarding step has a string title key in en.json (#4698)", () => {
+  const onboarding = en.onboarding ?? {};
+  for (const id of STEP_IDS) {
+    const key = titleKeyFor(id);
+    assert.equal(
+      typeof onboarding[key],
+      "string",
+      `onboarding.${key} (for step "${id}") must be a string title`
+    );
+  }
+});
+
+test("onboarding.tiers specifically exists (regression guard #4698)", () => {
+  assert.equal(typeof en.onboarding?.tiers, "string");
+});


### PR DESCRIPTION
Closes #4698

The onboarding wizard renders each step title via `t(stepId)` (`page.tsx:77`), but the `tiers` step had no matching `onboarding.tiers` key in any locale catalog, so next-intl threw `MISSING_MESSAGE: onboarding.tiers (en)` and the wizard crashed.

**Fix:** add the `onboarding.tiers` title string to `en.json` (other locales fall back to en until translated by the i18n pipeline).

**Test (TDD):** `tests/unit/onboarding-step-titles-i18n-4698.test.ts` — asserts every onboarding step id used as a title resolves to a string in en.json (fails before, passes after). i18n UI coverage gate stays green at the CI threshold (65%).