### PR TITLE
fix(dashboard): remove orphaned useLiveRequests call breaking home page (#4745)

### DIFF
--- a/src/app/(dashboard)/dashboard/HomePageClient.tsx
+++ b/src/app/(dashboard)/dashboard/HomePageClient.tsx
@@ -114,9 +114,6 @@ export default function HomePageClient({ machineId }: HomePageClientProps) {
     Array<{ id?: string; prefix?: string; name?: string }>
   >([]);
 
-  // Live in-flight requests for Provider Topology pulse animation (#3507)
-  const { activeRequests: liveActiveRequests } = useLiveRequests();
-
   const [versionInfo, setVersionInfo] = useState<VersionInfo | null>(null);
   const [updating, setUpdating] = useState(false);
 

--- a/tests/unit/ui/home-page-client-no-orphan-hooks.test.ts
+++ b/tests/unit/ui/home-page-client-no-orphan-hooks.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+// Regression guard for #4745 / discussion #4744.
+// The v3.8.34 release refactor (commit 19d91d82e) removed the
+// `import { useLiveRequests } from "@/hooks/useLiveDashboard"` line and the prop
+// that consumed it, but left an orphaned `useLiveRequests()` call in the body.
+// At runtime that threw `ReferenceError: useLiveRequests is not defined`, which
+// the error boundary rendered as "Internal Server Error" -- the dashboard home
+// page was completely broken in the shipped build. This test fails if any
+// `useLive*` hook is *called* in HomePageClient without being imported.
+
+const FILE = "src/app/(dashboard)/dashboard/HomePageClient.tsx";
+
+test("HomePageClient does not call any useLive* hook without importing it (#4745)", () => {
+  const source = readFileSync(FILE, "utf8");
+
+  // Collect every hook called as `useLiveXxx(` in the component body.
+  const calledHooks = new Set<string>();
+  for (const m of source.matchAll(/\b(useLive[A-Za-z0-9]*)\s*\(/g)) {
+    calledHooks.add(m[1]);
+  }
+
+  // Collect every identifier imported from the live-dashboard hook module.
+  const importedHooks = new Set<string>();
+  for (const m of source.matchAll(
+    /import\s*\{([^}]*)\}\s*from\s*["']@\/hooks\/useLive[A-Za-z]*["']/g
+  )) {
+    for (const name of m[1].split(",")) {
+      const clean = name.trim().split(/\s+as\s+/)[0].trim();
+      if (clean) importedHooks.add(clean);
+    }
+  }
+
+  for (const hook of calledHooks) {
+    assert.ok(
+      importedHooks.has(hook),
+      `HomePageClient calls ${hook}() but never imports it -> ReferenceError at render (regression #4745)`
+    );
+  }
+});


### PR DESCRIPTION
## Problem

The dashboard **home** page is completely broken in the shipped v3.8.34 build: it renders the "Internal Server Error" boundary instead of the dashboard. Other routes (System Status, Providers, Logs) work, so it looks like a partial outage.

Root cause: the v3.8.34 release refactor (commit `19d91d82e`) moved the live-requests rendering into `HomeProviderTopologySection` (which imports and uses `useLiveRequests` correctly) and removed from `HomePageClient.tsx` **both** the `import { useLiveRequests } from "@/hooks/useLiveDashboard"` line and the prop that consumed the value -- but left behind the orphaned hook call:

```ts
const { activeRequests: liveActiveRequests } = useLiveRequests();
```

`useLiveRequests` is now referenced but never imported, so the home page throws `ReferenceError: useLiveRequests is not defined` at render. `liveActiveRequests` has no other consumer in the file (its only use, the topology prop, was removed in the same refactor).

## Fix

Delete the orphaned hook call (3 lines: comment + call + trailing blank). Live in-flight request handling for the Provider Topology pulse already lives in `HomeProviderTopologySection`, which imports the hook properly -- so nothing is lost.

## Validation (Rule #18 -- TDD)

Added `tests/unit/ui/home-page-client-no-orphan-hooks.test.ts`: a source-level guard that fails if any `useLive*` hook is *called* in `HomePageClient` without being imported. Confirmed failing-then-passing:

- On the broken code: `AssertionError: HomePageClient calls useLiveRequests() but never imports it -> ReferenceError at render (regression #4745)`.
- After the fix: passes.

Also: `npm run typecheck:core` clean, `eslint` on the changed files reports 0 errors (1 pre-existing unrelated `react-hooks/exhaustive-deps` warning untouched).

Closes #4745.
Reported in discussion #4744.
