### PR TITLE
fix(sse): json_schema fallback for OpenAI-compatible providers

### DIFF
--- a/open-sse/executors/default.ts
+++ b/open-sse/executors/default.ts
@@ -563,6 +563,45 @@ export class DefaultExecutor extends BaseExecutor {
   }
 
   /**
+   * Downgrade `response_format: { type: "json_schema" }` to `json_object` for
+   * `openai-compatible-*` providers, injecting the JSON schema into the system
+   * prompt instead. DeepSeek / Ollama / local OpenAI-compatible models often
+   * lack native Structured Output and return empty or malformed content when a
+   * `json_schema` response_format is forwarded as-is. Gated on the
+   * `openai-compatible-` provider family so providers with native Structured
+   * Output support keep the native `json_schema` path.
+   */
+  applyJsonSchemaFallback<T>(body: T): T {
+    if (!this.provider?.startsWith?.("openai-compatible-")) return body;
+    if (!body || typeof body !== "object" || Array.isArray(body)) return body;
+
+    const record = body as Record<string, unknown>;
+    const rf = record.response_format as
+      | { type?: string; json_schema?: { schema?: unknown } }
+      | undefined;
+    if (rf?.type !== "json_schema" || !rf.json_schema?.schema) return body;
+
+    const schemaJson = JSON.stringify(rf.json_schema.schema, null, 2);
+    const prompt = `You must respond with valid JSON that strictly follows this JSON schema:\n\`\`\`json\n${schemaJson}\n\`\`\`\nRespond ONLY with the JSON object, no other text.`;
+
+    const messages: Array<Record<string, unknown>> = Array.isArray(record.messages)
+      ? (record.messages as Array<Record<string, unknown>>).map((m) => ({ ...m }))
+      : [];
+    const sys = messages.find((m) => m.role === "system");
+    if (sys) {
+      if (typeof sys.content === "string") {
+        sys.content = `${sys.content}\n\n${prompt}`;
+      } else if (Array.isArray(sys.content)) {
+        sys.content.push({ type: "text", text: `\n\n${prompt}` });
+      }
+    } else {
+      messages.unshift({ role: "system", content: prompt });
+    }
+
+    return { ...record, messages, response_format: { type: "json_object" } } as T;
+  }
+
+  /**
    * For compatible providers, the model name is already clean by the time
    * it reaches the executor (chatCore sets body.model = modelInfo.model,
    * which is the parsed model ID without internal routing prefixes).
@@ -573,6 +612,7 @@ export class DefaultExecutor extends BaseExecutor {
   transformRequest(model, body, stream, credentials) {
     const cleanedBody = super.transformRequest(model, body, stream, credentials);
     let withDefaults = applyProviderRequestDefaults(cleanedBody, this.config.requestDefaults);
+    withDefaults = this.applyJsonSchemaFallback(withDefaults);
     const targetFormat = getTargetFormat(this.provider, credentials?.providerSpecificData);
     const requestFormat =
       withDefaults && typeof withDefaults === "object" && !Array.isArray(withDefaults)

--- a/tests/unit/executor-default-base.test.ts
+++ b/tests/unit/executor-default-base.test.ts
@@ -930,6 +930,107 @@ test("DefaultExecutor.transformRequest neutralizes incompatible tool_choice for 
   assert.equal((result as any).tool_choice, "auto");
 });
 
+// Port of decolua/9router#1343: openai-compatible-* providers (DeepSeek / Ollama /
+// local OpenAI-compatible models) often lack native Structured Output, so a
+// `json_schema` response_format is downgraded to `json_object` with the schema
+// injected into the system prompt instead.
+test("DefaultExecutor.transformRequest downgrades json_schema to json_object for openai-compatible providers and injects the schema into a fresh system prompt", () => {
+  const executor = new DefaultExecutor("openai-compatible-deepseek");
+  const schema = {
+    type: "object",
+    properties: { answer: { type: "string" } },
+    required: ["answer"],
+  };
+  const body = {
+    model: "deepseek-chat",
+    messages: [{ role: "user", content: "give me JSON" }],
+    response_format: {
+      type: "json_schema",
+      json_schema: { name: "answer_schema", schema },
+    },
+  };
+
+  const result = executor.transformRequest("deepseek-chat", body, true, {
+    providerSpecificData: { baseUrl: "https://proxy.example/v1" },
+  }) as any;
+
+  // response_format is downgraded to json_object.
+  assert.deepEqual(result.response_format, { type: "json_object" });
+  // A system message carrying the schema is injected at the front.
+  assert.equal(result.messages[0].role, "system");
+  assert.match(result.messages[0].content, /strictly follows this JSON schema/);
+  assert.ok(result.messages[0].content.includes('"answer"'));
+  // The original user message is preserved.
+  assert.equal(result.messages[1].role, "user");
+  assert.equal(result.messages[1].content, "give me JSON");
+  // Original body is not mutated.
+  assert.equal((body as any).response_format.type, "json_schema");
+  assert.equal(body.messages.length, 1);
+});
+
+test("DefaultExecutor.transformRequest appends the json_schema prompt to an existing system message", () => {
+  const executor = new DefaultExecutor("openai-compatible-ollama");
+  const body = {
+    model: "llama3.1",
+    messages: [
+      { role: "system", content: "You are concise." },
+      { role: "user", content: "give me JSON" },
+    ],
+    response_format: {
+      type: "json_schema",
+      json_schema: { name: "s", schema: { type: "object" } },
+    },
+  };
+
+  const result = executor.transformRequest("llama3.1", body, true, {
+    providerSpecificData: { baseUrl: "https://proxy.example/v1" },
+  }) as any;
+
+  assert.deepEqual(result.response_format, { type: "json_object" });
+  assert.equal(result.messages[0].role, "system");
+  assert.match(result.messages[0].content, /^You are concise\./);
+  assert.match(result.messages[0].content, /strictly follows this JSON schema/);
+  // Existing system message object is not mutated in place.
+  assert.equal(body.messages[0].content, "You are concise.");
+});
+
+test("DefaultExecutor.transformRequest leaves json_schema response_format untouched for native providers", () => {
+  const executor = new DefaultExecutor("openai");
+  const responseFormat = {
+    type: "json_schema",
+    json_schema: { name: "s", schema: { type: "object" } },
+  };
+  const body = {
+    model: "gpt-4.1",
+    messages: [{ role: "user", content: "give me JSON" }],
+    response_format: responseFormat,
+  };
+
+  const result = executor.transformRequest("gpt-4.1", body, true, {}) as any;
+
+  // Native OpenAI keeps the json_schema response_format; no system prompt injected.
+  assert.deepEqual(result.response_format, responseFormat);
+  assert.equal(result.messages.length, 1);
+  assert.equal(result.messages[0].role, "user");
+});
+
+test("DefaultExecutor.transformRequest ignores non-json_schema response_format for openai-compatible providers", () => {
+  const executor = new DefaultExecutor("openai-compatible-deepseek");
+  const body = {
+    model: "deepseek-chat",
+    messages: [{ role: "user", content: "hi" }],
+    response_format: { type: "json_object" },
+  };
+
+  const result = executor.transformRequest("deepseek-chat", body, true, {
+    providerSpecificData: { baseUrl: "https://proxy.example/v1" },
+  }) as any;
+
+  assert.deepEqual(result.response_format, { type: "json_object" });
+  assert.equal(result.messages.length, 1);
+  assert.equal(result.messages[0].role, "user");
+});
+
 test("DefaultExecutor.transformRequest applies GLMT preset defaults without overriding explicit values", () => {
   const executor = new DefaultExecutor("glmt");
 


### PR DESCRIPTION
## Summary

- `openai-compatible-*` providers (DeepSeek / Ollama / local OpenAI-compatible models) frequently lack native Structured Output, so a `json_schema` `response_format` passed through unchanged returned empty or malformed content.
- `DefaultExecutor.transformRequest` now detects `response_format.type === "json_schema"`, injects the JSON schema into the system prompt, and downgrades `response_format` to `{ type: "json_object" }` so structured output works transparently.
- Gated on `provider.startsWith("openai-compatible-")` — native providers (e.g. `openai`) keep the native `json_schema` path untouched.

## Changes

- `open-sse/executors/default.ts`: add `applyJsonSchemaFallback()` and splice it into the transform pipeline after request defaults.
- `tests/unit/executor-default-base.test.ts`: 4 cases — fresh system prompt injection, append to existing system message, native-provider pass-through, non-`json_schema` pass-through.
- `CHANGELOG.md`: one bullet in the 3.8.34 Fixed section.

## Attribution

Thanks to [@mustafabozkaya](https://github.com/mustafabozkaya) for the original implementation.

## Test plan

- [x] `node --import tsx/esm --test tests/unit/executor-default-base.test.ts` (46/46 pass; the 2 behavior tests fail before the fix, pass after — TDD)
- [x] `npm run typecheck:core` clean