### PR TITLE
fix(oauth): verify Cursor installation on Linux before auto-import

### DIFF
--- a/src/app/api/oauth/cursor/auto-import/route.ts
+++ b/src/app/api/oauth/cursor/auto-import/route.ts
@@ -2,7 +2,64 @@ import { NextResponse } from "next/server";
 import { access, constants, readFile } from "fs/promises";
 import { homedir } from "os";
 import { join } from "path";
+import { execFile } from "child_process";
+import { promisify } from "util";
 import { isAuthRequired, isAuthenticated } from "@/shared/utils/apiAuth";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Probe dependencies for {@link verifyLinuxCursorInstalled}. Injectable so the
+ * guard can be unit-tested without spawning a real `which` process or touching
+ * the filesystem — mirrors the `__setExecFileImpl` pattern in
+ * `src/lib/cli-helper/tool-detector.ts`.
+ */
+export interface CursorInstallProbe {
+  /** Runs `which <binary>`; rejects when the binary is not on PATH. */
+  execFile?: (
+    file: string,
+    args: string[],
+    options: { timeout: number }
+  ) => Promise<{ stdout: string; stderr: string }>;
+  /** Resolves when the path is readable; rejects otherwise (e.g. `fs.access`). */
+  access?: (path: string, mode: number) => Promise<void>;
+  /** Override the home directory used to locate the `.desktop` fallback. */
+  home?: string;
+}
+
+/**
+ * On Linux, verify that the Cursor IDE is actually installed before trusting
+ * leftover config files (state.vscdb). A removed Cursor install can leave its
+ * `~/.config/Cursor/...` directory behind, which would otherwise trigger a
+ * false-positive auto-import and create a phantom Cursor provider connection.
+ *
+ * The check prefers `which cursor` and falls back to a readable
+ * `~/.local/share/applications/cursor.desktop` entry (the desktop launcher a
+ * package install drops even when the CLI shim is not on PATH).
+ *
+ * Port of decolua/9router#313 — only the linux probe is added; macOS/Windows
+ * keep their existing behavior (no install probe).
+ */
+export async function verifyLinuxCursorInstalled(
+  probe: CursorInstallProbe = {}
+): Promise<boolean> {
+  const exec = probe.execFile ?? execFileAsync;
+  const canAccess = probe.access ?? access;
+  const home = probe.home ?? homedir();
+
+  try {
+    await exec("which", ["cursor"], { timeout: 5000 });
+    return true;
+  } catch {
+    try {
+      const desktopFile = join(home, ".local/share/applications/cursor.desktop");
+      await canAccess(desktopFile, constants.R_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
 
 /**
  * Known key names Cursor IDE has used over time to persist the auth token
@@ -184,6 +241,17 @@ async function tryIdeAuth(): Promise<{
       };
     }
   } else {
+    // On Linux, verify Cursor is actually installed before trusting leftover
+    // config files — a removed install can leave ~/.config/Cursor behind and
+    // would otherwise create a phantom Cursor connection (port: 9router#313).
+    if (platform === "linux" && !(await verifyLinuxCursorInstalled())) {
+      return {
+        found: false,
+        error:
+          "Cursor config files found but Cursor IDE does not appear to be " +
+          "installed. Skipping auto-import.",
+      };
+    }
     dbPath = candidates[0];
   }
 

--- a/tests/unit/oauth-cursor-auto-import.test.ts
+++ b/tests/unit/oauth-cursor-auto-import.test.ts
@@ -5,6 +5,7 @@ import {
   extractCursorTokensFromRows,
   fuzzyExtractCursorTokensFromRows,
   cursorDbCandidatePaths,
+  verifyLinuxCursorInstalled,
 } from "../../src/app/api/oauth/cursor/auto-import/route";
 
 describe("normalizeVscDbValue", () => {
@@ -136,5 +137,69 @@ describe("cursorDbCandidatePaths", () => {
 
   it("returns empty array for unsupported platforms", () => {
     assert.deepEqual(cursorDbCandidatePaths("freebsd" as NodeJS.Platform, { home: "/x" }), []);
+  });
+});
+
+describe("verifyLinuxCursorInstalled (port: 9router#313)", () => {
+  const okExec = async () => ({ stdout: "/usr/bin/cursor\n", stderr: "" });
+  const failExec = async () => {
+    throw new Error("which: no cursor in PATH");
+  };
+  const okAccess = async () => {};
+  const failAccess = async () => {
+    throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+  };
+
+  it("returns true when `which cursor` succeeds (does not probe the .desktop file)", async () => {
+    let accessCalled = false;
+    const installed = await verifyLinuxCursorInstalled({
+      execFile: okExec,
+      access: async () => {
+        accessCalled = true;
+      },
+      home: "/home/test",
+    });
+    assert.equal(installed, true);
+    assert.equal(accessCalled, false);
+  });
+
+  it("falls back to the cursor.desktop launcher when `which` fails", async () => {
+    let probedPath = "";
+    const installed = await verifyLinuxCursorInstalled({
+      execFile: failExec,
+      access: async (p) => {
+        probedPath = p;
+      },
+      home: "/home/test",
+    });
+    assert.equal(installed, true);
+    assert.equal(probedPath, "/home/test/.local/share/applications/cursor.desktop");
+  });
+
+  it("returns false when neither `which` nor the .desktop file resolve (phantom config)", async () => {
+    const installed = await verifyLinuxCursorInstalled({
+      execFile: failExec,
+      access: failAccess,
+      home: "/home/test",
+    });
+    assert.equal(installed, false);
+  });
+
+  it("probes `which cursor` with a fixed binary name and a bounded timeout", async () => {
+    let calledWith: { file: string; args: string[]; timeout: number } | null = null;
+    const installed = await verifyLinuxCursorInstalled({
+      execFile: async (file, args, options) => {
+        calledWith = { file, args, timeout: options.timeout };
+        return { stdout: "/usr/bin/cursor", stderr: "" };
+      },
+      access: okAccess,
+      home: "/home/test",
+    });
+    assert.equal(installed, true);
+    assert.deepEqual(calledWith, {
+      file: "which",
+      args: ["cursor"],
+      timeout: 5000,
+    });
   });
 });


### PR DESCRIPTION
## Summary

- On Linux, the Cursor auto-import route (`src/app/api/oauth/cursor/auto-import/route.ts`) probed `~/.config/Cursor/.../state.vscdb` and opened it **without** checking that Cursor IDE is actually installed. Leftover config from a removed install triggered a false-positive import and created a phantom Cursor provider connection.
- Adds a DI-injectable `verifyLinuxCursorInstalled()` guard (`which cursor`, falling back to a readable `~/.local/share/applications/cursor.desktop`) wired into `tryIdeAuth()` before the linux DB open. macOS and Windows paths are unchanged.

## Attribution

Thanks to @Ibrahim Ryan for the original implementation.

## Changes

- `src/app/api/oauth/cursor/auto-import/route.ts` — new exported `verifyLinuxCursorInstalled()` + `CursorInstallProbe` interface; linux-only guard in `tryIdeAuth()`. The `execFile` call uses a fixed binary name with no untrusted interpolation (Rule #13).
- `tests/unit/oauth-cursor-auto-import.test.ts` — 4 new TDD cases (which-success skips the desktop probe, desktop-file fallback, both-fail → false, fixed-binary/bounded-timeout assertion). Fails before the change (missing export), passes after.
- `CHANGELOG.md` — one bullet in the in-development section.

## Test plan

- [x] `node --import tsx/esm --test tests/unit/oauth-cursor-auto-import.test.ts` → 21 pass (4 new)
- [x] TDD verified: tests fail against the unpatched route, pass with the fix
- [x] `tsc --noEmit` → 0 errors
- [x] `eslint` on both touched files → 0 errors / 0 warnings
- [x] `npm run check:cycles` → no cycles