### PR TITLE
chore(db): re-export compressionRunTelemetry from localDb (db-rules base-red)

### DIFF
--- a/src/lib/localDb.ts
+++ b/src/lib/localDb.ts
@@ -91,6 +91,7 @@ export {
 
 export * from "./db/compressionCacheStats";
 export * from "./db/compressionCombos";
+export * from "./db/compressionRunTelemetry";
 
 export {
   // API Keys


### PR DESCRIPTION
The `check:db-rules` gate (Rule #2) was failing on `release/v3.8.35` independently of any feature PR: `src/lib/db/compressionRunTelemetry.ts` (added by the compression Phase 4 telemetry work) was not re-exported from `src/lib/localDb.ts` and not listed as INTENTIONALLY_INTERNAL, so every PR targeting the release inherited a red Fast Quality Gates job.

**Fix:** add `export * from "./db/compressionRunTelemetry";` to the localDb re-export list, alongside its sibling compression db modules (`compressionCacheStats`, `compressionCombos`). Re-export-only line, no logic (Rule #2).

`npm run check:db-rules` now passes (87 db/ modules, 58 re-exported); `typecheck:core` clean (no `export *` collision).