### PR TITLE
refactor(chatCore): extrai scheduleQuotaShareConsumption (POST-hook não-streaming, #3501)

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -168,6 +168,7 @@ import {
 import { recordContextEditingTelemetryHook } from "./chatCore/contextEditingTelemetry.ts";
 import { recordCompressionCacheStats } from "./chatCore/compressionCacheStats.ts";
 import { writeCavemanOutputAnalytics } from "./chatCore/cavemanOutputAnalytics.ts";
+import { scheduleQuotaShareConsumption } from "./chatCore/quotaShareConsumption.ts";
 import {
   appendNonStreamingSseTerminalSignal,
   type NonStreamingSseTerminalState,
@@ -3740,23 +3741,14 @@ export async function handleChatCore({
     }
 
     // === Quota Share POST-hook (B/F7) — fire-and-forget, fail-open ===
-    if (apiKeyInfo?.id && credentials?.connectionId) {
-      try {
-        const { scheduleRecordConsumption, buildConsumptionCost } =
-          await import("@/lib/quota/spendRecorder");
-        scheduleRecordConsumption(
-          {
-            apiKeyId: apiKeyInfo.id,
-            connectionId: credentials.connectionId,
-            provider: provider ?? "unknown",
-            cost: buildConsumptionCost(usage, estimatedCost),
-          },
-          log
-        );
-      } catch (_) {
-        // Outer fail-open — never throws to caller
-      }
-    }
+    await scheduleQuotaShareConsumption({
+      apiKeyId: apiKeyInfo?.id,
+      connectionId: credentials?.connectionId,
+      provider,
+      usage,
+      estimatedCost,
+      log,
+    });
     // === /Quota Share POST-hook ===
 
     // ── Gamification event (fire-and-forget) ──

--- a/open-sse/handlers/chatCore/quotaShareConsumption.ts
+++ b/open-sse/handlers/chatCore/quotaShareConsumption.ts
@@ -1,0 +1,38 @@
+/**
+ * chatCore quota-share consumption POST-hook (Quality Gate v2 / Fase 9 — chatCore god-file
+ * decomposition, #3501).
+ *
+ * Extracted from handleChatCore's non-streaming success path (B/F7): schedules a shared-quota
+ * consumption record for a completed non-streaming response. Fire-and-forget and fail-open — guards
+ * on a missing api-key id / connection id and never throws to the caller. Behaviour is
+ * byte-identical to the previous inline block.
+ */
+
+type LoggerLike = { warn?: (...args: unknown[]) => void } | null | undefined;
+
+export async function scheduleQuotaShareConsumption(args: {
+  apiKeyId: string | null | undefined;
+  connectionId: string | null | undefined;
+  provider: string | null | undefined;
+  usage: unknown;
+  estimatedCost: number;
+  log?: LoggerLike;
+}): Promise<void> {
+  if (!args.apiKeyId || !args.connectionId) return;
+  try {
+    const { scheduleRecordConsumption, buildConsumptionCost } = await import(
+      "@/lib/quota/spendRecorder"
+    );
+    scheduleRecordConsumption(
+      {
+        apiKeyId: args.apiKeyId,
+        connectionId: args.connectionId,
+        provider: args.provider ?? "unknown",
+        cost: buildConsumptionCost(args.usage, args.estimatedCost),
+      },
+      args.log
+    );
+  } catch (_) {
+    // Outer fail-open — never throws to caller
+  }
+}

--- a/tests/unit/chatcore-quota-share-consumption.test.ts
+++ b/tests/unit/chatcore-quota-share-consumption.test.ts
@@ -1,0 +1,83 @@
+// Characterization of scheduleQuotaShareConsumption — the non-streaming shared-quota POST-hook
+// extracted from handleChatCore (chatCore god-file decomposition, #3501). Fire-and-forget /
+// fail-open. Locks: the guard (missing api-key id OR connection id → no-op) and that a valid call
+// never throws (the underlying scheduleRecordConsumption is setImmediate + fail-open).
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const testDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "omni-quota-share-test-"));
+process.env.DATA_DIR = testDataDir;
+
+const coreDb = await import("../../src/lib/db/core.ts");
+const { scheduleQuotaShareConsumption } = await import(
+  "../../open-sse/handlers/chatCore/quotaShareConsumption.ts"
+);
+
+const validUsage = { prompt_tokens: 10, completion_tokens: 5 };
+
+before(async () => {
+  await coreDb.ensureDbInitialized();
+});
+
+after(() => {
+  coreDb.resetDbInstance();
+  try {
+    fs.rmSync(testDataDir, { recursive: true, force: true });
+  } catch {
+    // best-effort cleanup
+  }
+});
+
+test("missing apiKeyId is a no-op (never throws)", async () => {
+  await assert.doesNotReject(
+    scheduleQuotaShareConsumption({
+      apiKeyId: null,
+      connectionId: "conn-1",
+      provider: "openai",
+      usage: validUsage,
+      estimatedCost: 0.01,
+    })
+  );
+});
+
+test("missing connectionId is a no-op (never throws)", async () => {
+  await assert.doesNotReject(
+    scheduleQuotaShareConsumption({
+      apiKeyId: "key-1",
+      connectionId: null,
+      provider: "openai",
+      usage: validUsage,
+      estimatedCost: 0.01,
+    })
+  );
+});
+
+test("valid input schedules consumption and never throws (fire-and-forget)", async () => {
+  await assert.doesNotReject(
+    scheduleQuotaShareConsumption({
+      apiKeyId: "key-1",
+      connectionId: "conn-1",
+      provider: "openai",
+      usage: validUsage,
+      estimatedCost: 0.0123,
+    })
+  );
+  // give the scheduled setImmediate consumption a tick to run (fail-open, no assertion on DB
+  // state — pool config is out of scope; this proves the hook does not throw end-to-end)
+  await new Promise((r) => setTimeout(r, 50));
+});
+
+test("absent provider falls back without throwing", async () => {
+  await assert.doesNotReject(
+    scheduleQuotaShareConsumption({
+      apiKeyId: "key-2",
+      connectionId: "conn-2",
+      provider: null,
+      usage: null,
+      estimatedCost: 0,
+    })
+  );
+});


### PR DESCRIPTION
## O quê

Decomposição do god-file `chatCore.ts` (#3501). Extrai o **POST-hook de quota-share (B/F7)** do caminho de sucesso não-streaming de `handleChatCore` para `chatCore/quotaShareConsumption.ts`.

## Como

`scheduleQuotaShareConsumption({ apiKeyId, connectionId, provider, usage, estimatedCost, log })`. Fire-and-forget / fail-open com guard interno de `apiKeyId && connectionId`. O `scheduleRecordConsumption` (setImmediate) e `buildConsumptionCost` seguem idênticos. Comportamento byte-idêntico.

## Validação (Rule #18 — TDD)

- **+4 caracterizações**: guard p/ `apiKeyId`/`connectionId` ausente (no-op), fail-open com input válido (setImmediate roda sem lançar), fallback de provider ausente.
- Caracterizações chatcore pré-existentes intactas → **301 → 305 verde**.
- `typecheck:core` limpo; `eslint` 0.

## ⚠️ Base-reds pré-existentes (NÃO deste slice, provados no tip pristine)

- `check:db-rules` — `compressionRunTelemetry.ts` não re-exportado.
- `check:complexity` — 1919 > baseline 1916. Slice **delta-0**.

## Impacto

`chatCore.ts` **−8 linhas**. Sem mudança de API/comportamento público.
