### PR TITLE
refactor(chatCore): extrai scheduleStreamingQuotaShareConsumption (POST-hook streaming, #3501)

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -171,6 +171,7 @@ import { writeCavemanOutputAnalytics } from "./chatCore/cavemanOutputAnalytics.t
 import { scheduleQuotaShareConsumption } from "./chatCore/quotaShareConsumption.ts";
 import { emitRequestGamificationEvent } from "./chatCore/gamificationEvent.ts";
 import { runPluginOnResponseHook } from "./chatCore/pluginOnResponse.ts";
+import { scheduleStreamingQuotaShareConsumption } from "./chatCore/streamingQuotaShare.ts";
 import {
   appendNonStreamingSseTerminalSignal,
   type NonStreamingSseTerminalState,
@@ -4030,29 +4031,17 @@ export async function handleChatCore({
     // Resolve the real per-request cost (calculateCost) so USD-unit pools accrue
     // on streaming traffic too; this previously recorded usd:0 hardcoded, which
     // meant DeepSeek-style `usd/monthly` shared pools never blocked on streams.
-    if (apiKeyInfo?.id && credentials?.connectionId && normalizedStreamStatus === 200) {
-      const quotaApiKeyId = apiKeyInfo.id;
-      const quotaConnectionId = credentials.connectionId;
-      // onStreamComplete is sync — use .then() (fire-and-forget, fail-open) instead of await
-      import("@/lib/quota/spendRecorder")
-        .then(({ recordStreamingConsumption }) =>
-          recordStreamingConsumption(
-            {
-              apiKeyId: quotaApiKeyId,
-              connectionId: quotaConnectionId,
-              provider,
-              model,
-              streamUsage,
-              streamStatus: normalizedStreamStatus,
-              serviceTier: effectiveServiceTier,
-            },
-            { calculateCost, log }
-          )
-        )
-        .catch(() => {
-          // Outer fail-open — never throws to caller
-        });
-    }
+    scheduleStreamingQuotaShareConsumption({
+      apiKeyId: apiKeyInfo?.id,
+      connectionId: credentials?.connectionId,
+      provider,
+      model,
+      streamUsage,
+      streamStatus: normalizedStreamStatus,
+      serviceTier: effectiveServiceTier,
+      calculateCost,
+      log,
+    });
     // === /Quota Share POST-hook streaming ===
 
     if (

--- a/open-sse/handlers/chatCore/streamingQuotaShare.ts
+++ b/open-sse/handlers/chatCore/streamingQuotaShare.ts
@@ -1,0 +1,54 @@
+/**
+ * chatCore streaming quota-share consumption POST-hook (Quality Gate v2 / Fase 9 — chatCore
+ * god-file decomposition, #3501).
+ *
+ * Extracted from handleChatCore's onStreamComplete (B/F7): records shared-quota consumption for a
+ * completed streaming response, resolving the real per-request cost via the injected calculateCost
+ * so USD-unit pools accrue on streaming traffic too. onStreamComplete is synchronous, so this is a
+ * sync fire-and-forget that drives the work through import().then().catch() and never throws to the
+ * caller. Behaviour is byte-identical to the previous inline block.
+ */
+
+type LoggerLike = { warn?: (...args: unknown[]) => void } | null | undefined;
+type CostResolver = (
+  provider: string,
+  model: string,
+  usage: Record<string, number | undefined> | null | undefined,
+  options: { serviceTier?: string }
+) => Promise<number>;
+
+export function scheduleStreamingQuotaShareConsumption(args: {
+  apiKeyId: string | null | undefined;
+  connectionId: string | null | undefined;
+  provider: string | null | undefined;
+  model: string | null | undefined;
+  streamUsage: unknown;
+  streamStatus: number;
+  serviceTier?: string;
+  calculateCost: CostResolver;
+  log?: LoggerLike;
+}): void {
+  if (!args.apiKeyId || !args.connectionId || args.streamStatus !== 200) return;
+
+  const quotaApiKeyId = args.apiKeyId;
+  const quotaConnectionId = args.connectionId;
+  // onStreamComplete is sync — use .then() (fire-and-forget, fail-open) instead of await
+  import("@/lib/quota/spendRecorder")
+    .then(({ recordStreamingConsumption }) =>
+      recordStreamingConsumption(
+        {
+          apiKeyId: quotaApiKeyId,
+          connectionId: quotaConnectionId,
+          provider: args.provider,
+          model: args.model,
+          streamUsage: args.streamUsage,
+          streamStatus: args.streamStatus,
+          serviceTier: args.serviceTier,
+        },
+        { calculateCost: args.calculateCost, log: args.log }
+      )
+    )
+    .catch(() => {
+      // Outer fail-open — never throws to caller
+    });
+}

--- a/tests/unit/chatcore-streaming-quota-share.test.ts
+++ b/tests/unit/chatcore-streaming-quota-share.test.ts
@@ -1,0 +1,96 @@
+// Characterization of scheduleStreamingQuotaShareConsumption — the streaming shared-quota POST-hook
+// extracted from handleChatCore's onStreamComplete (chatCore god-file decomposition, #3501). Sync
+// fire-and-forget / fail-open. The injected calculateCost is used as the observable. Locks: the
+// guard (missing ids OR streamStatus != 200 → no recording) and that a valid 200 stream resolves
+// the cost via calculateCost.
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const testDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "omni-stream-quota-test-"));
+process.env.DATA_DIR = testDataDir;
+
+const coreDb = await import("../../src/lib/db/core.ts");
+const { scheduleStreamingQuotaShareConsumption } = await import(
+  "../../open-sse/handlers/chatCore/streamingQuotaShare.ts"
+);
+
+function makeCostSpy() {
+  const calls: Array<{ provider: string; model: string }> = [];
+  const calculateCost = async (provider: string, model: string) => {
+    calls.push({ provider, model });
+    return 0.0042;
+  };
+  return { calculateCost, calls };
+}
+
+async function waitFor(pred: () => boolean, timeoutMs = 2000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline && !pred()) {
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
+before(async () => {
+  await coreDb.ensureDbInitialized();
+});
+
+after(() => {
+  coreDb.resetDbInstance();
+  try {
+    fs.rmSync(testDataDir, { recursive: true, force: true });
+  } catch {
+    // best-effort cleanup
+  }
+});
+
+test("streamStatus != 200 records nothing (calculateCost never called)", async () => {
+  const { calculateCost, calls } = makeCostSpy();
+  scheduleStreamingQuotaShareConsumption({
+    apiKeyId: "key-1",
+    connectionId: "conn-1",
+    provider: "openai",
+    model: "gpt-x",
+    streamUsage: { prompt_tokens: 10, completion_tokens: 5 },
+    streamStatus: 500,
+    serviceTier: "standard",
+    calculateCost,
+  });
+  await new Promise((r) => setTimeout(r, 80));
+  assert.equal(calls.length, 0);
+});
+
+test("missing connectionId records nothing", async () => {
+  const { calculateCost, calls } = makeCostSpy();
+  scheduleStreamingQuotaShareConsumption({
+    apiKeyId: "key-1",
+    connectionId: null,
+    provider: "openai",
+    model: "gpt-x",
+    streamUsage: { prompt_tokens: 10 },
+    streamStatus: 200,
+    calculateCost,
+  });
+  await new Promise((r) => setTimeout(r, 80));
+  assert.equal(calls.length, 0);
+});
+
+test("valid 200 stream resolves cost via injected calculateCost", async () => {
+  const { calculateCost, calls } = makeCostSpy();
+  scheduleStreamingQuotaShareConsumption({
+    apiKeyId: "key-1",
+    connectionId: "conn-1",
+    provider: "deepseek",
+    model: "deepseek-chat",
+    streamUsage: { prompt_tokens: 100, completion_tokens: 50 },
+    streamStatus: 200,
+    serviceTier: "standard",
+    calculateCost,
+  });
+  await waitFor(() => calls.length > 0);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].provider, "deepseek");
+  assert.equal(calls[0].model, "deepseek-chat");
+});


### PR DESCRIPTION
## O quê

Decomposição do god-file `chatCore.ts` (#3501). Extrai o **POST-hook de quota-share streaming (B/F7)** do `onStreamComplete` de `handleChatCore` para `chatCore/streamingQuotaShare.ts`.

## Como

`scheduleStreamingQuotaShareConsumption({ apiKeyId, connectionId, provider, model, streamUsage, streamStatus, serviceTier, calculateCost, log })`. `onStreamComplete` é **síncrono**, então o helper é sync e dirige o trabalho via `import().then().catch()` (fire-and-forget, fail-open). Guard `apiKeyId && connectionId && streamStatus === 200`; `calculateCost` injetado. Comportamento byte-idêntico.

## Validação (Rule #18 — TDD)

- **+3 caracterizações** usando o `calculateCost` injetado como observável: guard `streamStatus != 200` e `connectionId` ausente não gravam; stream 200 válido resolve o custo via `calculateCost` (provider/model corretos).
- Caracterizações chatcore pré-existentes intactas → **301 → 304 verde**.
- `typecheck:core` limpo; `eslint` 0.

## ⚠️ Base-reds pré-existentes (NÃO deste slice, provados no tip pristine)

- `check:db-rules` — `compressionRunTelemetry.ts` não re-exportado.
- `check:complexity` — 1919 > baseline 1916. Slice **delta-0**.

## Impacto

`chatCore.ts` **−11 linhas**. Sem mudança de API/comportamento público.
