### PR TITLE
fix(api): fall back to existing access token for any OAuth provider on refresh failure

### DIFF
--- a/src/lib/usage/providerLimits.ts
+++ b/src/lib/usage/providerLimits.ts
@@ -327,7 +327,12 @@ export async function refreshAndUpdateCredentials(
     | null;
 
   if (!refreshResult) {
-    if (connection.provider === "github" && connection.accessToken) {
+    // Refresh failed but we still have an accessToken — fall back to the
+    // existing token for ANY OAuth provider (graceful degradation) instead of
+    // hard-failing. Previously this was qualified to `provider === "github"`,
+    // which left every other provider stuck on a transient refresh failure even
+    // when a usable access token was still on hand.
+    if (connection.accessToken) {
       return { connection, refreshed: false };
     }
     throw withStatus(

--- a/tests/unit/provider-limits-accesstoken-fallback-on-refresh-failure.test.ts
+++ b/tests/unit/provider-limits-accesstoken-fallback-on-refresh-failure.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Graceful-degradation fallback when `refreshCredentials` returns null but the
+ * connection still holds a usable `accessToken`.
+ *
+ * Previously this fallback was qualified to `connection.provider === "github"`:
+ * every OTHER OAuth provider whose refresh momentarily failed was hard-failed
+ * with "Failed to refresh credentials. Please re-authorize the connection.",
+ * even though a still-valid access token was on hand. The fix drops the
+ * github-specific qualifier so the fallback applies to ANY provider that still
+ * has an accessToken.
+ *
+ * Before the fix this test fails: a non-github provider would throw the 401
+ * re-authorize error. After the fix it returns `{ refreshed: false }`.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+process.env.DATA_DIR = fs.mkdtempSync(
+  path.join(os.tmpdir(), "omniroute-accesstoken-fallback-")
+);
+
+const { getExecutor } = await import("../../open-sse/executors/index.ts");
+const { refreshAndUpdateCredentials } = await import("../../src/lib/usage/providerLimits.ts");
+
+// `gemini` is a non-rotating (no rotation lock group), non-github OAuth provider,
+// so `shouldAttemptRotatingRefresh` is true and the refresh path is reached.
+function geminiConnection() {
+  return {
+    id: "gemini-fallback-1",
+    provider: "gemini",
+    accessToken: "still-valid-access-token",
+    refreshToken: "some-refresh-token",
+    tokenExpiresAt: new Date(Date.now() - 60_000).toISOString(), // expired → needsRefresh fires
+    providerSpecificData: {},
+  };
+}
+
+test("falls back to the existing accessToken for a non-github provider when refreshCredentials returns null", async () => {
+  const exec = getExecutor("gemini");
+  const origNeeds = exec.needsRefresh;
+  const origRefresh = exec.refreshCredentials;
+  exec.needsRefresh = () => true; // force the refresh attempt
+  exec.refreshCredentials = async () => null; // upstream refresh failed
+  try {
+    const result = await refreshAndUpdateCredentials(geminiConnection(), {
+      allowRotatingRefresh: true,
+    });
+    assert.equal(
+      result.refreshed,
+      false,
+      "a non-github provider with an accessToken must fall back, not throw"
+    );
+    assert.equal(
+      result.connection.accessToken,
+      "still-valid-access-token",
+      "the existing access token must be preserved"
+    );
+  } finally {
+    exec.needsRefresh = origNeeds;
+    exec.refreshCredentials = origRefresh;
+  }
+});
+
+test("still throws when refresh fails AND there is no accessToken to fall back on", async () => {
+  const exec = getExecutor("gemini");
+  const origNeeds = exec.needsRefresh;
+  const origRefresh = exec.refreshCredentials;
+  exec.needsRefresh = () => true;
+  exec.refreshCredentials = async () => null;
+  try {
+    const conn = geminiConnection();
+    conn.accessToken = ""; // no usable token → must not silently degrade
+    await assert.rejects(
+      () => refreshAndUpdateCredentials(conn, { allowRotatingRefresh: true }),
+      /Failed to refresh credentials/,
+      "without an accessToken the refresh failure must surface as an error"
+    );
+  } finally {
+    exec.needsRefresh = origNeeds;
+    exec.refreshCredentials = origRefresh;
+  }
+});


### PR DESCRIPTION
## Summary

- During a quota credential refresh, when `executor.refreshCredentials` returns null but the connection still holds a usable `accessToken`, OmniRoute now gracefully degrades to that token instead of hard-failing with the 401 "re-authorize" error.
- The fallback in `refreshAndUpdateCredentials` (`src/lib/usage/providerLimits.ts`) was previously gated on `connection.provider === "github"`, so every other OAuth provider was forced to re-authorize on a momentary refresh hiccup. Dropping the github-specific qualifier applies the graceful-degradation fallback to ANY provider that still has an access token.

## Changes

- `src/lib/usage/providerLimits.ts` — remove the `provider === "github"` qualifier on the refresh-failure fallback so it applies to any provider with an `accessToken`.
- `tests/unit/provider-limits-accesstoken-fallback-on-refresh-failure.test.ts` — TDD regression: a non-github provider (`gemini`) with an access token now returns `{ refreshed: false }` when refresh fails (fails before the change, passes after); and the error still surfaces when there is no access token to fall back on.

## Test plan

- [x] `node --import tsx/esm --test tests/unit/provider-limits-accesstoken-fallback-on-refresh-failure.test.ts` — fails before the fix (throws 401), passes after (2/2)
- [x] `tsc --noEmit -p tsconfig.core.json` — no new errors in touched scope

## Attribution

Thanks to @decolua for the original implementation.