### PR TITLE
refactor(chatCore): extrai recordStreamingCost (custo por-request streaming, #3501)

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -173,6 +173,7 @@ import { emitRequestGamificationEvent } from "./chatCore/gamificationEvent.ts";
 import { runPluginOnResponseHook } from "./chatCore/pluginOnResponse.ts";
 import { scheduleStreamingQuotaShareConsumption } from "./chatCore/streamingQuotaShare.ts";
 import { recordStreamingUsageStats } from "./chatCore/streamingUsageStats.ts";
+import { recordStreamingCost } from "./chatCore/streamingCost.ts";
 import {
   appendNonStreamingSseTerminalSignal,
   type NonStreamingSseTerminalState,
@@ -4003,13 +4004,15 @@ export async function handleChatCore({
       cacheSource: "upstream",
     });
 
-    if (apiKeyInfo?.id && streamUsage) {
-      calculateCost(provider, model, streamUsage, { serviceTier: effectiveServiceTier })
-        .then((estimatedCost) => {
-          if (estimatedCost > 0) recordCost(apiKeyInfo.id, estimatedCost);
-        })
-        .catch(() => {});
-    }
+    recordStreamingCost({
+      apiKeyId: apiKeyInfo?.id,
+      provider,
+      model,
+      streamUsage,
+      serviceTier: effectiveServiceTier,
+      calculateCost,
+      recordCost,
+    });
 
     // === Quota Share POST-hook streaming (B/F7) — fire-and-forget, fail-open ===
     // Resolve the real per-request cost (calculateCost) so USD-unit pools accrue

--- a/open-sse/handlers/chatCore/streamingCost.ts
+++ b/open-sse/handlers/chatCore/streamingCost.ts
@@ -1,0 +1,37 @@
+/**
+ * chatCore streaming per-request cost recording (Quality Gate v2 / Fase 9 — chatCore god-file
+ * decomposition, #3501).
+ *
+ * Extracted from handleChatCore's onStreamComplete: resolves the real per-request cost for a
+ * completed streaming response and records it against the api key. onStreamComplete is synchronous,
+ * so this is a sync fire-and-forget driven through calculateCost().then().catch() that never throws
+ * to the caller. calculateCost and recordCost are injected so the hook stays decoupled. Behaviour
+ * is byte-identical to the previous inline block.
+ */
+
+type CostResolver = (
+  provider: string,
+  model: string,
+  usage: Record<string, number | undefined> | null | undefined,
+  options: { serviceTier?: string }
+) => Promise<number>;
+
+export function recordStreamingCost(args: {
+  apiKeyId: string | null | undefined;
+  provider: string | null | undefined;
+  model: string | null | undefined;
+  streamUsage: Record<string, number | undefined> | null | undefined;
+  serviceTier?: string;
+  calculateCost: CostResolver;
+  recordCost: (apiKeyId: string, cost: number) => void;
+}): void {
+  if (!args.apiKeyId || !args.streamUsage) return;
+
+  const apiKeyId = args.apiKeyId;
+  args
+    .calculateCost(args.provider, args.model, args.streamUsage, { serviceTier: args.serviceTier })
+    .then((estimatedCost) => {
+      if (estimatedCost > 0) args.recordCost(apiKeyId, estimatedCost);
+    })
+    .catch(() => {});
+}

--- a/tests/unit/chatcore-streaming-cost.test.ts
+++ b/tests/unit/chatcore-streaming-cost.test.ts
@@ -1,0 +1,99 @@
+// Characterization of recordStreamingCost — the streaming per-request cost recording extracted
+// from handleChatCore's onStreamComplete (chatCore god-file decomposition, #3501). Sync
+// fire-and-forget; calculateCost and recordCost are injected, so both are observable without a DB.
+// Locks: the guard (missing api-key OR usage → no-op), recordCost with the resolved cost, and the
+// estimatedCost<=0 skip.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+const { recordStreamingCost } = await import(
+  "../../open-sse/handlers/chatCore/streamingCost.ts"
+);
+
+function spies(costValue: number) {
+  const recorded: Array<{ apiKeyId: string; cost: number }> = [];
+  const costArgs: Array<{ provider: string; model: string }> = [];
+  return {
+    recorded,
+    costArgs,
+    calculateCost: async (provider: string, model: string) => {
+      costArgs.push({ provider, model });
+      return costValue;
+    },
+    recordCost: (apiKeyId: string, cost: number) => {
+      recorded.push({ apiKeyId, cost });
+    },
+  };
+}
+
+async function waitFor(pred: () => boolean, timeoutMs = 2000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline && !pred()) {
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
+test("missing apiKeyId → no-op (calculateCost never called)", async () => {
+  const s = spies(0.5);
+  recordStreamingCost({
+    apiKeyId: null,
+    provider: "openai",
+    model: "gpt-x",
+    streamUsage: { prompt_tokens: 10 },
+    serviceTier: "standard",
+    calculateCost: s.calculateCost,
+    recordCost: s.recordCost,
+  });
+  await new Promise((r) => setTimeout(r, 50));
+  assert.equal(s.costArgs.length, 0);
+  assert.equal(s.recorded.length, 0);
+});
+
+test("missing streamUsage → no-op", async () => {
+  const s = spies(0.5);
+  recordStreamingCost({
+    apiKeyId: "key-1",
+    provider: "openai",
+    model: "gpt-x",
+    streamUsage: null,
+    calculateCost: s.calculateCost,
+    recordCost: s.recordCost,
+  });
+  await new Promise((r) => setTimeout(r, 50));
+  assert.equal(s.costArgs.length, 0);
+  assert.equal(s.recorded.length, 0);
+});
+
+test("valid input records the resolved cost against the api key", async () => {
+  const s = spies(0.0073);
+  recordStreamingCost({
+    apiKeyId: "key-1",
+    provider: "deepseek",
+    model: "deepseek-chat",
+    streamUsage: { prompt_tokens: 100, completion_tokens: 50 },
+    serviceTier: "standard",
+    calculateCost: s.calculateCost,
+    recordCost: s.recordCost,
+  });
+  await waitFor(() => s.recorded.length > 0);
+  assert.equal(s.costArgs[0].provider, "deepseek");
+  assert.equal(s.recorded.length, 1);
+  assert.equal(s.recorded[0].apiKeyId, "key-1");
+  assert.equal(s.recorded[0].cost, 0.0073);
+});
+
+test("estimatedCost <= 0 does not record", async () => {
+  const s = spies(0);
+  recordStreamingCost({
+    apiKeyId: "key-1",
+    provider: "openai",
+    model: "gpt-x",
+    streamUsage: { prompt_tokens: 1 },
+    calculateCost: s.calculateCost,
+    recordCost: s.recordCost,
+  });
+  await waitFor(() => s.costArgs.length > 0);
+  await new Promise((r) => setTimeout(r, 30));
+  assert.equal(s.costArgs.length, 1);
+  assert.equal(s.recorded.length, 0);
+});


### PR DESCRIPTION
## O quê

Decomposição do god-file `chatCore.ts` (#3501). Extrai a **resolução de custo por-request streaming** (`calculateCost` → `recordCost`) do `onStreamComplete` de `handleChatCore` para `chatCore/streamingCost.ts`.

## Como

`recordStreamingCost({ apiKeyId, provider, model, streamUsage, serviceTier, calculateCost, recordCost })`. Sync fire-and-forget (`.then().catch()`); `calculateCost` e `recordCost` são **injetados** para desacoplar e permitir teste sem DB. Guard `apiKeyId && streamUsage` preservado. Comportamento byte-idêntico.

## Validação (Rule #18 — TDD)

- **+4 caracterizações** com ambos os deps injetados como observáveis: guard api-key/usage ausente → no-op, grava o custo resolvido contra a api key, e skip quando `estimatedCost <= 0`.
- Caracterizações chatcore pré-existentes intactas → **301 → 305 verde**.
- `typecheck:core` limpo; `eslint` 0.

## Nota

O call-site (objeto com deps injetados) é levemente maior que o bloco inline; o ganho aqui é **desacoplamento + testabilidade** da lógica de custo, não redução de linhas. Dentro do file-size gate.

## ⚠️ Base-reds pré-existentes (NÃO deste slice)

- `check:db-rules` (`compressionRunTelemetry.ts`) e `check:complexity` (1919 > 1916) — drift de merge paralelo, slice **delta-0** (provado no tip pristine).
