### PR TITLE
refactor(chatCore): extrai writeCavemanOutputAnalytics (#3501)

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -167,6 +167,7 @@ import {
 } from "./chatCore/passthroughToolNames.ts";
 import { recordContextEditingTelemetryHook } from "./chatCore/contextEditingTelemetry.ts";
 import { recordCompressionCacheStats } from "./chatCore/compressionCacheStats.ts";
+import { writeCavemanOutputAnalytics } from "./chatCore/cavemanOutputAnalytics.ts";
 import {
   appendNonStreamingSseTerminalSignal,
   type NonStreamingSseTerminalState,
@@ -1380,31 +1381,15 @@ export async function handleChatCore({
         }
       }
       if (cavemanOutputModeApplied && !compressionAnalyticsRecorded) {
-        compressionAnalyticsWritePromise = (async () => {
-          try {
-            const { insertCompressionAnalyticsRow } =
-              await import("../../src/lib/db/compressionAnalytics.ts");
-            insertCompressionAnalyticsRow({
-              timestamp: new Date().toISOString(),
-              combo_id: comboName ?? null,
-              provider: provider ?? null,
-              mode: "output-caveman",
-              engine: "caveman-output",
-              compression_combo_id: config.compressionComboId ?? null,
-              original_tokens: estimatedTokens,
-              compressed_tokens: estimatedTokens,
-              tokens_saved: 0,
-              request_id: skillRequestId,
-              output_mode: cavemanOutputModeIntensity,
-            });
-          } catch (err) {
-            log?.debug?.(
-              "COMPRESSION",
-              "Caveman output analytics write skipped: " +
-                (err instanceof Error ? err.message : String(err))
-            );
-          }
-        })();
+        compressionAnalyticsWritePromise = writeCavemanOutputAnalytics({
+          comboName,
+          provider,
+          compressionComboId: config.compressionComboId,
+          estimatedTokens,
+          skillRequestId,
+          cavemanOutputModeIntensity,
+          log,
+        });
       }
       if (outputStyleResult) {
         void (async () => {

--- a/open-sse/handlers/chatCore/cavemanOutputAnalytics.ts
+++ b/open-sse/handlers/chatCore/cavemanOutputAnalytics.ts
@@ -1,0 +1,47 @@
+/**
+ * chatCore caveman-output compression analytics (Quality Gate v2 / Fase 9 — chatCore god-file
+ * decomposition, #3501).
+ *
+ * Extracted from handleChatCore's request-setup compression path: when only the caveman output
+ * mode was applied (no upstream compression run recorded a row), persist a single analytics row so
+ * output-caveman runs still surface in compression analytics. Best-effort — returns the write
+ * promise (the caller assigns it to compressionAnalyticsWritePromise) and swallows its own errors.
+ * Behaviour is byte-identical to the previous inline block.
+ */
+
+type LoggerLike = { debug?: (...args: unknown[]) => void } | null | undefined;
+
+export function writeCavemanOutputAnalytics(args: {
+  comboName: string | null | undefined;
+  provider: string | null | undefined;
+  compressionComboId: string | null | undefined;
+  estimatedTokens: number;
+  skillRequestId: string;
+  cavemanOutputModeIntensity: string | null | undefined;
+  log?: LoggerLike;
+}): Promise<void> {
+  return (async () => {
+    try {
+      const { insertCompressionAnalyticsRow } = await import("@/lib/db/compressionAnalytics");
+      insertCompressionAnalyticsRow({
+        timestamp: new Date().toISOString(),
+        combo_id: args.comboName ?? null,
+        provider: args.provider ?? null,
+        mode: "output-caveman",
+        engine: "caveman-output",
+        compression_combo_id: args.compressionComboId ?? null,
+        original_tokens: args.estimatedTokens,
+        compressed_tokens: args.estimatedTokens,
+        tokens_saved: 0,
+        request_id: args.skillRequestId,
+        output_mode: args.cavemanOutputModeIntensity,
+      });
+    } catch (err) {
+      args.log?.debug?.(
+        "COMPRESSION",
+        "Caveman output analytics write skipped: " +
+          (err instanceof Error ? err.message : String(err))
+      );
+    }
+  })();
+}

--- a/tests/unit/chatcore-caveman-output-analytics.test.ts
+++ b/tests/unit/chatcore-caveman-output-analytics.test.ts
@@ -1,0 +1,75 @@
+// Characterization of writeCavemanOutputAnalytics — the caveman-output-only compression analytics
+// write extracted from handleChatCore's request-setup compression path (chatCore god-file
+// decomposition, #3501). Returns the write promise; uses a real temp DB. Locks: the row written
+// (mode=output-caveman, engine=caveman-output, original==compressed==estimatedTokens, tokens_saved
+// 0, output_mode) and that the returned promise never rejects (best-effort).
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const testDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "omni-caveman-test-"));
+process.env.DATA_DIR = testDataDir;
+
+const coreDb = await import("../../src/lib/db/core.ts");
+const { writeCavemanOutputAnalytics } = await import(
+  "../../open-sse/handlers/chatCore/cavemanOutputAnalytics.ts"
+);
+
+function rowFor(requestId: string): Record<string, unknown> | undefined {
+  return coreDb
+    .getDbInstance()
+    .prepare(
+      "SELECT mode, engine, original_tokens AS orig, compressed_tokens AS comp, tokens_saved AS saved, output_mode AS om FROM compression_analytics WHERE request_id = ?"
+    )
+    .get(requestId) as Record<string, unknown> | undefined;
+}
+
+before(async () => {
+  await coreDb.ensureDbInitialized();
+});
+
+after(() => {
+  coreDb.resetDbInstance();
+  try {
+    fs.rmSync(testDataDir, { recursive: true, force: true });
+  } catch {
+    // best-effort cleanup
+  }
+});
+
+test("writes a caveman-output analytics row and the promise resolves", async () => {
+  await writeCavemanOutputAnalytics({
+    comboName: null,
+    provider: "openai",
+    compressionComboId: null,
+    estimatedTokens: 321,
+    skillRequestId: "caveman-req-1",
+    cavemanOutputModeIntensity: "heavy",
+  });
+  const row = rowFor("caveman-req-1");
+  assert.ok(row, "expected a compression_analytics row");
+  assert.equal(row!.mode, "output-caveman");
+  assert.equal(row!.engine, "caveman-output");
+  assert.equal(row!.orig, 321);
+  assert.equal(row!.comp, 321);
+  assert.equal(row!.saved, 0);
+  assert.equal(row!.om, "heavy");
+});
+
+test("the returned promise never rejects even on a bad write", async () => {
+  // resetting the DB instance makes the dynamic insert path fail; the helper must swallow it
+  coreDb.resetDbInstance();
+  await assert.doesNotReject(
+    writeCavemanOutputAnalytics({
+      comboName: "combo-x",
+      provider: "openai",
+      compressionComboId: "cc-1",
+      estimatedTokens: 10,
+      skillRequestId: "caveman-req-2",
+      cavemanOutputModeIntensity: null,
+    })
+  );
+  await coreDb.ensureDbInitialized();
+});


### PR DESCRIPTION
## O quê

Decomposição do god-file `chatCore.ts` (#3501). Extrai a **gravação de analytics do modo caveman-output-only** do setup de request de `handleChatCore` para `chatCore/cavemanOutputAnalytics.ts`.

## Como

`writeCavemanOutputAnalytics(args)` retorna a Promise de escrita (o caller atribui a `compressionAnalyticsWritePromise`) e engole os próprios erros (best-effort). `insertCompressionAnalyticsRow` com os campos fixos do caveman-output preservados; captures threaded via args. Comportamento byte-idêntico.

## Validação (Rule #18 — TDD)

- **+2 caracterizações** com DB temp real: a linha gravada (`mode=output-caveman`, `engine=caveman-output`, `original==compressed==estimatedTokens`, `tokens_saved=0`, `output_mode`), e a Promise retornada nunca rejeita mesmo com write falho.
- Caracterizações chatcore pré-existentes intactas → **301 → 303 verde**.
- `typecheck:core` limpo; `eslint` 0.

## ⚠️ Base-reds pré-existentes (NÃO deste slice)

- `check:db-rules` (`compressionRunTelemetry.ts`) e `check:complexity` (1919 > 1916) — drift de merge paralelo, slice **delta-0** (provado no tip pristine).

## Impacto

`chatCore.ts` **−15 linhas**. Sem mudança de API/comportamento público.
