### PR TITLE
feat(sse): add GPT-4o mini to GitHub Copilot provider

### DIFF
--- a/open-sse/config/providers/registry/github/index.ts
+++ b/open-sse/config/providers/registry/github/index.ts
@@ -31,6 +31,10 @@ export const githubProvider: RegistryEntry = {
     // 9router#98 — Copilot still serves GPT-4o via chat/completions; keep it
     // alongside the GPT-5.x family so apps that hard-code `gpt-4o` resolve here.
     { id: "gpt-4o", name: "GPT-4o", contextLength: 128000 },
+    // Copilot also serves the cheaper GPT-4o mini via chat/completions; keep it
+    // alongside gpt-4o so apps that hard-code `gpt-4o-mini` resolve to the Copilot
+    // (`gh`) provider rather than only the github-models (`ghm`) marketplace entry.
+    { id: "gpt-4o-mini", name: "GPT-4o mini", contextLength: 128000 },
     { id: "gpt-5-mini", name: "GPT-5 Mini", targetFormat: "openai-responses" },
     { id: "gpt-5.3-codex", name: "GPT-5.3 Codex", targetFormat: "openai-responses" },
     { id: "gpt-5.4-mini", name: "GPT-5.4 Mini", targetFormat: "openai-responses" },

--- a/tests/unit/github-copilot-gpt-4o-mini.test.ts
+++ b/tests/unit/github-copilot-gpt-4o-mini.test.ts
@@ -1,0 +1,45 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { getRegistryEntry } from "../../open-sse/config/providerRegistry.ts";
+
+// Regression guard: the GitHub Copilot (`gh`) provider must expose `gpt-4o-mini`
+// alongside `gpt-4o`. Copilot serves the cheaper mini variant via
+// chat/completions, so apps that hard-code `gpt-4o-mini` should resolve to the
+// Copilot provider — not only to the separate github-models (`ghm`) marketplace
+// entry, which lists it under the `openai/` prefix (`openai/gpt-4o-mini`).
+//
+// Ported from upstream decolua/9router (add GPT-4o mini to GitHub Copilot).
+
+test("github (Copilot) provider exposes gpt-4o-mini next to gpt-4o", () => {
+  const entry = getRegistryEntry("github");
+  assert.ok(entry, "github registry entry should exist");
+  assert.ok(entry.models, "github registry entry should have a models array");
+
+  const ids = entry.models!.map((m) => m.id);
+  assert.ok(ids.includes("gpt-4o"), "gpt-4o should remain registered");
+  assert.ok(
+    ids.includes("gpt-4o-mini"),
+    "gpt-4o-mini should be registered on the Copilot (gh) provider"
+  );
+
+  const mini = entry.models!.find((m) => m.id === "gpt-4o-mini");
+  assert.equal(mini?.name, "GPT-4o mini");
+  assert.equal(mini?.contextLength, 128000);
+});
+
+test("Copilot gpt-4o-mini is distinct from the github-models openai/gpt-4o-mini", () => {
+  const copilot = getRegistryEntry("github");
+  const marketplace = getRegistryEntry("github-models");
+
+  const copilotIds = (copilot?.models ?? []).map((m) => m.id);
+  const marketplaceIds = (marketplace?.models ?? []).map((m) => m.id);
+
+  // The two providers reference the same upstream model under different ids:
+  // Copilot uses the bare `gpt-4o-mini`; the marketplace uses `openai/gpt-4o-mini`.
+  assert.ok(copilotIds.includes("gpt-4o-mini"));
+  assert.ok(marketplaceIds.includes("openai/gpt-4o-mini"));
+  assert.ok(
+    !copilotIds.includes("openai/gpt-4o-mini"),
+    "Copilot should not carry the marketplace-prefixed id"
+  );
+});


### PR DESCRIPTION
## Summary

- Registers `gpt-4o-mini` on the GitHub Copilot (`gh`) provider, alongside the existing `gpt-4o` entry.
- Copilot serves the cheaper GPT-4o mini variant via chat/completions, so apps that hard-code `gpt-4o-mini` now resolve to Copilot instead of only the separate `github-models` (`ghm`) marketplace entry (which exposes it under the `openai/gpt-4o-mini` id).

## Changes

- `open-sse/config/providers/registry/github/index.ts` — add `{ id: "gpt-4o-mini", name: "GPT-4o mini", contextLength: 128000 }` to the Copilot `models` array.
- `tests/unit/github-copilot-gpt-4o-mini.test.ts` — TDD guard: asserts `gpt-4o-mini` is registered on `gh` with the right shape and remains distinct from the marketplace `openai/gpt-4o-mini` (fails before the change, passes after).
- `CHANGELOG.md` — one bullet under 3.8.34.

## Test plan

- [x] `node --import tsx/esm --test tests/unit/github-copilot-gpt-4o-mini.test.ts` (2 fail before, 2 pass after)
- [x] `node --import tsx/esm --test tests/unit/provider-registry-models-guard.test.ts`
- [x] `npm run typecheck:core`

## Attribution

Thanks to @decolua for the original implementation.