### PR TITLE
docs(readme): credit ponytail + OmniCompress; restore env-doc-sync release-green

### DIFF
--- a/README.md
+++ b/README.md
@@ -1084,6 +1084,7 @@ OmniRoute stands on the shoulders of giants. It started as a fork of **[9router]
 | **[LLMLingua](https://github.com/microsoft/LLMLingua)** · Microsoft          |  6.3k | Prompt-compression research (LLMLingua / LLMLingua-2) — inspired our async, code-safe, fail-open `llmlingua` engine.                                                  |
 | **[llmlingua-2-js](https://github.com/atjsh/llmlingua-2-js)** · atjsh        |    27 | The JS/ONNX port (MobileBERT / XLM-RoBERTa) used as the worker-thread backend for our LLMLingua engine.                                                               |
 | **[Troglodita](https://github.com/leninejunior/troglodita)** · Lenine Júnior |    15 | PT-BR token compression — powers our pt-BR language pack: pleonasm reduction and filler removal tuned for Brazilian-Portuguese grammar.                               |
+| **[ponytail](https://github.com/DietrichGebert/ponytail)** · DietrichGebert  | 51.4k | The viral "lazy senior dev" YAGNI-coder skill — inspired our **less-code** Output Style: smallest-working-change steering that cuts *generated* code (the output-axis sibling to Caveman's terse prose).                  |
 
 ### 🧩 Compact formats, token research & code-aware tooling
 
@@ -1096,6 +1097,7 @@ OmniRoute stands on the shoulders of giants. It started as a fork of **[9router]
 | **[token-saver](https://github.com/ppgranger/token-saver)** · ppgranger                        |   103 | Content-aware, per-file-type output compression with failure-aware bail-out — validated our per-type dispatch and minimum-gain skip. |
 | **[token-optimizer](https://github.com/alexgreensh/token-optimizer)** · alexgreensh            |  1.4k | "Find the ghost tokens" — its offload + recoverable-handle pattern informed our CCR offload thinking.                                |
 | **[TokenMizer](https://github.com/Shweta-Mishra-ai/tokenmizer)** · Shweta-Mishra-ai            |     1 | A session-graph + cross-turn line-dedup blueprint that informed our session-dedup design.                                            |
+| **[OmniCompress](https://github.com/jessefreitas/OmniCompress)** · jessefreitas                |     2 | Rust columnar-JSON + content-addressed retrieve + cross-message dedup — validated our `headroom`/`ccr`/`session-dedup` engine design and the cache-stable "compressed form is position-independent" invariant.            |
 | **[mcp-compressor](https://github.com/atlassian-labs/mcp-compressor)** · Atlassian Labs        |    80 | MCP tool-schema/description compression — informed our MCP tool-manifest cardinality reduction.                                      |
 | **[RepoMapper](https://github.com/pdavis68/RepoMapper)** · pdavis68                            |   182 | Aider-style repo-map ranking — informed our repo-map / retrieval-ranking exploration.                                                |
 | **[quiet-shell-mcp](https://github.com/mrsimpson/quiet-shell-mcp)** · mrsimpson                |     4 | Declarative shell-output reduction over MCP — validated our declarative bash-output compaction.                                      |

--- a/scripts/check/check-env-doc-sync.mjs
+++ b/scripts/check/check-env-doc-sync.mjs
@@ -132,6 +132,10 @@ const IGNORE_FROM_CODE = new Set([
   // Test-only opt-out: instructs bin/omniroute.mjs to skip auto-loading the
   // repository .env so isolation tests get a deterministic environment.
   "OMNIROUTE_CLI_SKIP_REPO_ENV",
+  // Eval-harness only: operator-supplied provider credentials JSON read by the
+  // opt-in `npm run eval:compression` CLI (scripts/compression-eval/index.ts).
+  // A dev/ops measurement tool, never OmniRoute runtime config.
+  "OMNIROUTE_EVAL_CREDENTIALS",
   // Build-time only: set by `build:release` (git short SHA) and read by
   // write-build-sha.mjs to stamp dist/BUILD_SHA — injected by the build, never
   // configured by users in .env.


### PR DESCRIPTION
## Two small post-Phase-4 reconciles

### 1. README — compression inspirations (the ask)
Added the two compression projects we used but hadn't credited in the "stands on the shoulders of giants" section:
- **ponytail** (`DietrichGebert/ponytail`, 51.4k⭐, MIT) → engines table. Inspired the **less-code** Output Style (Phase 4A) — the "lazy senior dev" YAGNI injector, the output-axis sibling to Caveman's terse prose.
- **OmniCompress** (`jessefreitas/OmniCompress`, Rust, Apache-2.0) → research table. Validated our `headroom`/`ccr`/`session-dedup` engine design + the cache-stable "compressed form is position-independent" invariant.

Checked the rest of the analyzed set: `wenyan`/terse-cjk comes from **9router** (already credited in Foundation); `gcf-proxy`/`gcf-typescript` are variants of `gcf`/`headroom` (already credited); the others were analyzed but didn't shape a concrete piece. So these two were the only gaps.

### 2. env-doc-sync — restore release-green
The Phase 4 D1 merge introduced `OMNIROUTE_EVAL_CREDENTIALS` (read by the opt-in `npm run eval:compression` CLI), which tripped `check:env-doc-sync` on the release branch ("in code but missing from .env.example"). It's an eval-harness operator knob, not OmniRoute runtime config, so it belongs in the checker's `IGNORE_FROM_CODE` allowlist next to the other harness-only vars (`OMNIROUTE_CLI_SKIP_REPO_ENV`, the QA helpers). After this, `check:env-doc-sync` is green again.

### Validation
- `check:env-doc-sync` ✓ (was red, now in sync) · `check:docs-counts` ✓ · `check:docs-sync` ✓ · doc-links ✓.
- The remaining `check:docs-symbols` red (`docs/THREAT_MODEL.md` → `/api/version`, `/api/management`) is **pre-existing on the release base, unrelated** to this PR or to compression.