### PR TITLE
fix(install): make transformers optional for CUDA-host installs

### DIFF
--- a/docs/compression/COMPRESSION_ENGINES.md
+++ b/docs/compression/COMPRESSION_ENGINES.md
@@ -116,7 +116,7 @@ override points it at a local copy instead (offline / air-gapped installs).
 
 ### Optional dependencies & on-demand install
 
-The LLMLingua runtime stack is **optional**. Three packages are declared as
+The prunable LLMLingua runtime peer stack is **optional**. Three packages are declared as
 `optionalDependencies` in `package.json` and kept **external** by the production build
 (`scripts/build/prepublish.ts` does not bundle them):
 
@@ -126,9 +126,12 @@ The LLMLingua runtime stack is **optional**. Three packages are declared as
 | `@tensorflow/tfjs`   | `4.22.0`      | Heaviest dep — dominates the ~800 MB footprint |
 | `js-tiktoken`        | `^1.0.20`     | Tokenizer                                      |
 
-`@huggingface/transformers` is pinned at `3.5.2` as a **regular** dependency (shared with
-the local embeddings path), so it always ships — only the three packages above are
-prunable. A standard `npm install` (dev) installs them automatically.
+`@huggingface/transformers` is pinned at `3.5.2` as an **optional** dependency (shared with
+the local embeddings path and also traced into the standalone bundle). Keeping it optional prevents
+`onnxruntime-node` CUDA provider postinstall failures on CUDA 11 hosts from aborting the whole
+OmniRoute install; when the optional stack is absent, LLMLingua still fail-opens. Only the three
+packages above are prunable SLM peers. A standard `npm install` (dev) installs the optional stack
+automatically unless optional dependencies are omitted.
 
 **Why on-demand:** the npm-published package, the standalone bundle, and the Docker image
 ship **without** these deps to stay slim. When they are absent, the worker's dependency

--- a/docs/ops/RELEASE_CHECKLIST.md
+++ b/docs/ops/RELEASE_CHECKLIST.md
@@ -269,14 +269,15 @@ Before shipping any v3.8.x release, verify these additional items:
 - [ ] Update path keeps optional deps: `omniroute update --apply` and the auto-updater
       run `npm install -g … --include=optional` so `optionalDependencies` (better-sqlite3,
       keytar, tls-client, and the llmlingua SLM stack: `@atjsh/llmlingua-2`,
-      `@tensorflow/tfjs`, `js-tiktoken`) survive an update. The ultra `modelPath` SLM tier
-      additionally needs `@huggingface/transformers@3.5.2` (pinned — llmlingua-2 uses the 3.x
-      tokenizer API) and the tinybert model, auto-downloaded to `${DATA_DIR}/models/llmlingua`
-      on first use. Postinstall (`scripts/build/colocateOptionals.mjs`) then co-locates the SLM
-      optional closure into `dist/node_modules` so the worker resolves a SINGLE
-      `@huggingface/transformers` 3.5.2 instance — the standalone trace bundles only transformers,
-      not the dynamically-imported optionals, so without this the worker would load llmlingua-2
-      against the root's transformers and the SLM tier would silently fail-open.
+      `@huggingface/transformers@3.5.2`, `@tensorflow/tfjs`, `js-tiktoken`) survive an update.
+      `@huggingface/transformers` stays optional so its `onnxruntime-node` CUDA provider postinstall
+      cannot abort installation on CUDA 11 hosts. The ultra `modelPath` SLM tier also needs the
+      tinybert model, auto-downloaded to `${DATA_DIR}/models/llmlingua` on first use. Postinstall
+      (`scripts/build/colocateOptionals.mjs`) then co-locates the SLM optional closure into
+      `dist/node_modules` so the worker resolves a SINGLE `@huggingface/transformers` 3.5.2
+      optional instance — the standalone trace bundles only transformers, not the dynamically-imported
+      optionals, so without this the worker would load llmlingua-2 against the root's transformers
+      and the SLM tier would silently fail-open.
 - [ ] `omniroute status` works with no `.env` (CLI token path, loopback only)
 - [ ] `curl http://localhost:20128/api/shutdown` returns 401 (always-protected route)
 - [ ] `curl -H "host: evil.com" http://localhost:20128/api/mcp/sse` returns 401 (loopback guard)

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
-        "@huggingface/transformers": "3.5.2",
         "@lobehub/icons": "^5.8.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@monaco-editor/react": "^4.7.0",
@@ -140,6 +139,7 @@
       },
       "optionalDependencies": {
         "@atjsh/llmlingua-2": "2.0.3",
+        "@huggingface/transformers": "3.5.2",
         "@tensorflow/tfjs": "4.22.0",
         "better-sqlite3": "^12.10.0",
         "js-tiktoken": "^1.0.20",
@@ -2578,7 +2578,8 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
+      },
+      "optional": true
     },
     "node_modules/@huggingface/transformers": {
       "version": "3.5.2",
@@ -2590,7 +2591,8 @@
         "onnxruntime-node": "1.21.0",
         "onnxruntime-web": "1.22.0-dev.20250409-89f8206ba4",
         "sharp": "^0.34.1"
-      }
+      },
+      "optional": true
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -2668,7 +2670,8 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
+      },
+      "optional": true
     },
     "node_modules/@img/sharp-darwin-arm64": {
       "version": "0.34.5",
@@ -3565,7 +3568,8 @@
       },
       "engines": {
         "node": ">=18.0.0"
-      }
+      },
+      "devOptional": true
     },
     "node_modules/@isaacs/string-locale-compare": {
       "version": "1.1.0",
@@ -6244,25 +6248,29 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
       "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
       "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/@protobufjs/codegen": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
       "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
       "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.1",
@@ -6271,31 +6279,36 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.1"
-      }
+      },
+      "optional": true
     },
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
       "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
       "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
       "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.2",
@@ -9416,7 +9429,8 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
-      }
+      },
+      "devOptional": true
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.13",
@@ -11169,7 +11183,8 @@
       "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
       "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
       "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/bottleneck": {
       "version": "2.19.5",
@@ -13295,7 +13310,8 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
+      },
+      "devOptional": true
     },
     "node_modules/define-lazy-prop": {
       "version": "3.0.0",
@@ -13324,7 +13340,8 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
+      },
+      "devOptional": true
     },
     "node_modules/delaunator": {
       "version": "5.1.0",
@@ -13395,7 +13412,8 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
@@ -13973,7 +13991,8 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/esast-util-from-estree": {
       "version": "2.0.0",
@@ -15306,7 +15325,8 @@
       "version": "25.9.23",
       "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
       "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "optional": true
     },
     "node_modules/flatted": {
       "version": "3.4.2",
@@ -16056,7 +16076,8 @@
       },
       "engines": {
         "node": ">=10.0"
-      }
+      },
+      "optional": true
     },
     "node_modules/global-agent/node_modules/semver": {
       "version": "7.8.4",
@@ -16068,7 +16089,8 @@
       },
       "engines": {
         "node": ">=10"
-      }
+      },
+      "optional": true
     },
     "node_modules/global-directory": {
       "version": "4.0.1",
@@ -16121,7 +16143,8 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
+      },
+      "devOptional": true
     },
     "node_modules/gopd": {
       "version": "1.2.0",
@@ -16145,7 +16168,8 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
       "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/hachure-fill": {
       "version": "0.5.2",
@@ -16185,7 +16209,8 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
+      },
+      "devOptional": true
     },
     "node_modules/has-proto": {
       "version": "1.2.0",
@@ -18265,7 +18290,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -19788,7 +19814,8 @@
       },
       "engines": {
         "node": ">=10"
-      }
+      },
+      "optional": true
     },
     "node_modules/material-symbols": {
       "version": "0.45.2",
@@ -21037,7 +21064,8 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
-      }
+      },
+      "devOptional": true
     },
     "node_modules/minipass-collect": {
       "version": "2.0.1",
@@ -21159,7 +21187,8 @@
       },
       "engines": {
         "node": ">= 18"
-      }
+      },
+      "devOptional": true
     },
     "node_modules/mkdirp": {
       "version": "1.0.4",
@@ -22053,7 +22082,8 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
-      }
+      },
+      "devOptional": true
     },
     "node_modules/object.assign": {
       "version": "4.1.7",
@@ -22222,7 +22252,8 @@
       "version": "1.21.0",
       "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.21.0.tgz",
       "integrity": "sha512-Q632iLLrtCAVOTO65dh2+mNbQir/QNTVBG3h/QdZBpns7mZ0RYbLRBgGABPbpU9351AgYy7SJf1WaeVwMrBFPQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/onnxruntime-node": {
       "version": "1.21.0",
@@ -22239,7 +22270,8 @@
         "global-agent": "^3.0.0",
         "onnxruntime-common": "1.21.0",
         "tar": "^7.0.1"
-      }
+      },
+      "optional": true
     },
     "node_modules/onnxruntime-web": {
       "version": "1.22.0-dev.20250409-89f8206ba4",
@@ -22253,19 +22285,22 @@
         "onnxruntime-common": "1.22.0-dev.20250409-89f8206ba4",
         "platform": "^1.3.6",
         "protobufjs": "^7.2.4"
-      }
+      },
+      "optional": true
     },
     "node_modules/onnxruntime-web/node_modules/long": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "optional": true
     },
     "node_modules/onnxruntime-web/node_modules/onnxruntime-common": {
       "version": "1.22.0-dev.20250409-89f8206ba4",
       "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.22.0-dev.20250409-89f8206ba4.tgz",
       "integrity": "sha512-vDJMkfCfb0b1A836rgHj+ORuZf4B4+cc2bASQtpeoJLueuFc5DuYwjIZUBrSvx/fO5IrLjLz+oTrB3pcGlhovQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/open": {
       "version": "11.0.0",
@@ -22944,7 +22979,8 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
       "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/playwright": {
       "version": "1.61.0",
@@ -23291,13 +23327,15 @@
       },
       "engines": {
         "node": ">=12.0.0"
-      }
+      },
+      "optional": true
     },
     "node_modules/protobufjs/node_modules/long": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "optional": true
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -24427,13 +24465,15 @@
       },
       "engines": {
         "node": ">=8.0"
-      }
+      },
+      "optional": true
     },
     "node_modules/roarr/node_modules/sprintf-js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/robust-predicates": {
       "version": "3.0.3",
@@ -24750,7 +24790,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
       "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/send": {
       "version": "1.2.1",
@@ -24791,7 +24832,8 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
+      },
+      "optional": true
     },
     "node_modules/serialize-error/node_modules/type-fest": {
       "version": "0.13.1",
@@ -24803,7 +24845,8 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
+      },
+      "optional": true
     },
     "node_modules/serve-static": {
       "version": "2.2.1",
@@ -24921,7 +24964,8 @@
         "@img/sharp-win32-arm64": "0.34.5",
         "@img/sharp-win32-ia32": "0.34.5",
         "@img/sharp-win32-x64": "0.34.5"
-      }
+      },
+      "optional": true
     },
     "node_modules/sharp/node_modules/semver": {
       "version": "7.7.4",
@@ -24933,7 +24977,8 @@
       },
       "engines": {
         "node": ">=10"
-      }
+      },
+      "optional": true
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -26174,7 +26219,8 @@
       },
       "engines": {
         "node": ">=18"
-      }
+      },
+      "devOptional": true
     },
     "node_modules/tar-fs": {
       "version": "2.1.4",
@@ -26213,7 +26259,8 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
-      }
+      },
+      "devOptional": true
     },
     "node_modules/tar/node_modules/yallist": {
       "version": "5.0.0",
@@ -26222,7 +26269,8 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
-      }
+      },
+      "devOptional": true
     },
     "node_modules/terminal-size": {
       "version": "4.0.1",
@@ -26987,7 +27035,8 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "devOptional": true
     },
     "node_modules/unicode-emoji-modifier-base": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -202,7 +202,6 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
-    "@huggingface/transformers": "3.5.2",
     "@lobehub/icons": "^5.8.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@monaco-editor/react": "^4.7.0",
@@ -272,6 +271,7 @@
   },
   "optionalDependencies": {
     "@atjsh/llmlingua-2": "2.0.3",
+    "@huggingface/transformers": "3.5.2",
     "@tensorflow/tfjs": "4.22.0",
     "better-sqlite3": "^12.10.0",
     "js-tiktoken": "^1.0.20",

--- a/tests/unit/build/optional-transformers-dependency.test.ts
+++ b/tests/unit/build/optional-transformers-dependency.test.ts
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const repoRoot = process.cwd();
+
+function readJson<T = Record<string, unknown>>(relPath: string): T {
+  return JSON.parse(readFileSync(join(repoRoot, relPath), "utf8")) as T;
+}
+
+test("@huggingface/transformers is optional so onnxruntime CUDA install failures cannot abort OmniRoute install", () => {
+  const pkg = readJson<{
+    dependencies?: Record<string, string>;
+    optionalDependencies?: Record<string, string>;
+  }>("package.json");
+
+  assert.equal(
+    pkg.dependencies?.["@huggingface/transformers"],
+    undefined,
+    "transformers must not be a regular dependency because it pulls onnxruntime-node install scripts"
+  );
+  assert.equal(pkg.optionalDependencies?.["@huggingface/transformers"], "3.5.2");
+});
+
+test("package-lock marks transformers and its onnxruntime runtime as optional", () => {
+  const lock = readJson<{
+    packages: Record<string, { optional?: boolean; dependencies?: Record<string, string>; optionalDependencies?: Record<string, string> }>;
+  }>("package-lock.json");
+
+  assert.equal(
+    lock.packages[""]?.dependencies?.["@huggingface/transformers"],
+    undefined,
+    "root lock dependencies must not keep transformers as mandatory"
+  );
+  assert.equal(lock.packages[""]?.optionalDependencies?.["@huggingface/transformers"], "3.5.2");
+
+  for (const packagePath of [
+    "node_modules/@huggingface/transformers",
+    "node_modules/onnxruntime-node",
+    "node_modules/onnxruntime-common",
+  ]) {
+    assert.equal(lock.packages[packagePath]?.optional, true, `${packagePath} should be optional`);
+  }
+});


### PR DESCRIPTION
## Summary
- move `@huggingface/transformers` from regular dependencies to optionalDependencies
- keep the lockfile optional metadata for transformers and the onnxruntime subtree
- document why this avoids fatal `onnxruntime-node` CUDA provider postinstall failures on CUDA 11 hosts
- add a unit test guarding the package/lockfile contract

## Why
`@huggingface/transformers` pulls `onnxruntime-node`. On Linux hosts with CUDA 11 detected by `nvcc`, `onnxruntime-node` attempts to install CUDA provider binaries and exits fatally because its installer does not support CUDA 11 auto-install. OmniRoute already fail-opens LLMLingua when optional SLM deps are absent, and the standalone bundle traces transformers, so this runtime should not make the whole OmniRoute install fail.

## Tests
- `node --import tsx --test tests/unit/build/optional-transformers-dependency.test.ts`
- `npm run check:lockfile`
- `npm run check:deps`
- `npm run check:test-discovery`
- `npm run check:docs-sync`
- `npm run check:docs-counts` (passes; existing soft executor-count drift warnings only)
