### PR TITLE
fix(sse): skip third-party tool-name cloak for Anthropic server tools

### DIFF
--- a/open-sse/services/claudeCodeToolRemapper.ts
+++ b/open-sse/services/claudeCodeToolRemapper.ts
@@ -197,6 +197,28 @@ export function needsThirdPartyCloak(name: string): boolean {
   return /[a-z]/.test(name.charAt(0)) || name.includes("_") || name.includes("-");
 }
 
+/**
+ * Anthropic server-side tool types whose `name` is a reserved literal that the
+ * Messages API validates exactly (e.g. type `web_search_20250305` REQUIRES
+ * `name: "web_search"`). These look like third-party harness tools to the name
+ * cloak (`web_search` has a `_`, fails the PascalCase test) so without this
+ * guard the cloak rewrites the name to `WebSearch` and Anthropic 400s with
+ * `tools.N.web_search_20250305.name: Input should be 'web_search'`.
+ *
+ * Detection mirrors the codebase's existing convention: a versioned built-in
+ * tool type carries an 8-digit date suffix (`web_search_20250305`,
+ * `code_execution_20250522`, `bash_20250124`, …) — see
+ * `stripVersionedToolModelPrefix` in executors/base.ts. The non-versioned
+ * aliases (`web_search`, `web_search_preview`) are covered explicitly.
+ */
+const VERSIONED_SERVER_TOOL_TYPE = /^[a-z][a-z0-9_]*_\d{8}$/;
+const NON_VERSIONED_SERVER_TOOL_TYPES = new Set(["web_search", "web_search_preview"]);
+
+export function isAnthropicServerToolType(type: unknown): boolean {
+  if (typeof type !== "string" || type.length === 0) return false;
+  return VERSIONED_SERVER_TOOL_TYPE.test(type) || NON_VERSIONED_SERVER_TOOL_TYPES.has(type);
+}
+
 export interface CloakOptions {
   /**
    * Names matching this predicate are left untouched, so a caller that owns a
@@ -265,6 +287,11 @@ export function cloakThirdPartyToolNames(
   // not corrupt an input body that may be logged or replayed on fallback).
   if (Array.isArray(tools)) {
     body.tools = tools.map((tool) => {
+      // Never rewrite the reserved name of an Anthropic server-side tool — its
+      // `type` (web_search_20250305, …) binds the API to an exact `name`.
+      if (tool && isAnthropicServerToolType(tool.type)) {
+        return tool;
+      }
       if (tool && typeof tool.name === "string" && shouldCloak(tool.name)) {
         return { ...tool, name: aliasFor(tool.name) };
       }

--- a/tests/unit/claude-oauth-tool-cloak.test.ts
+++ b/tests/unit/claude-oauth-tool-cloak.test.ts
@@ -13,6 +13,7 @@ import assert from "node:assert/strict";
 import {
   cloakThirdPartyToolNames,
   needsThirdPartyCloak,
+  isAnthropicServerToolType,
 } from "../../open-sse/services/claudeCodeToolRemapper.ts";
 import {
   sanitizeClaudeToolSchema,
@@ -106,6 +107,40 @@ describe("cloakThirdPartyToolNames", () => {
     assert.equal(needsThirdPartyCloak("TodoWrite"), false);
     assert.equal(needsThirdPartyCloak("read_file"), true);
     assert.equal(needsThirdPartyCloak("mixture_of_agents"), true);
+  });
+
+  it("preserves the reserved name of a versioned Anthropic server tool", () => {
+    const body: AnyRecord = {
+      tools: [{ type: "web_search_20250305", name: "web_search", max_uses: 5 }],
+    };
+    cloakThirdPartyToolNames(body);
+    // Anthropic requires tools.N.web_search_20250305.name === "web_search".
+    assert.equal((body.tools as AnyRecord[])[0].name, "web_search");
+    // No reverse-map entry needed because nothing was cloaked.
+    assert.equal((body._toolNameMap as Map<string, string> | undefined)?.has("WebSearch") ?? false, false);
+  });
+
+  it("still cloaks a genuine third-party tool sitting next to a server tool", () => {
+    const body: AnyRecord = {
+      tools: [
+        { type: "web_search_20250305", name: "web_search" },
+        { name: "mixture_of_agents" },
+      ],
+    };
+    cloakThirdPartyToolNames(body);
+    assert.equal((body.tools as AnyRecord[])[0].name, "web_search");
+    assert.equal((body.tools as AnyRecord[])[1].name, "MixtureOfAgents");
+  });
+
+  it("isAnthropicServerToolType detects versioned + non-versioned server tools", () => {
+    assert.equal(isAnthropicServerToolType("web_search_20250305"), true);
+    assert.equal(isAnthropicServerToolType("code_execution_20250522"), true);
+    assert.equal(isAnthropicServerToolType("web_search"), true);
+    assert.equal(isAnthropicServerToolType("web_search_preview"), true);
+    // Not server tools — must remain cloakable.
+    assert.equal(isAnthropicServerToolType("mixture_of_agents"), false);
+    assert.equal(isAnthropicServerToolType("Bash"), false);
+    assert.equal(isAnthropicServerToolType(undefined), false);
   });
 });
 


### PR DESCRIPTION
## What
Skip the third-party tool-name cloak for Anthropic server-side tools so their reserved `name` (e.g. `web_search`) is forwarded verbatim.

## Why
On the native Claude OAuth passthrough, `cloakThirdPartyToolNames` rewrites any tool whose name looks third-party (lowercase / contains `_`). Anthropic's server tool `{ type: "web_search_20250305", name: "web_search" }` matches that heuristic, so the name is rewritten to `WebSearch` and the request 400s:

```
tools.0.web_search_20250305.name: Input should be 'web_search'
```

The cloak only inspected `tool.name`, never `tool.type`.

## How
- Add `isAnthropicServerToolType(type)` — versioned built-in tool types carry an 8-digit date suffix (reuses the `/^[a-z][a-z0-9_]*_\d{8}$/` convention already used by `stripVersionedToolModelPrefix` in `executors/base.ts`), plus the non-versioned `web_search` / `web_search_preview` aliases.
- Skip name rewriting in the `tools[]` loop when the tool is a server tool.
- Tests in `claude-oauth-tool-cloak.test.ts`: reserved name preserved, a third-party tool beside a server tool still cloaked, predicate unit coverage.

## Notes
Happy to revise if you'd prefer a different approach.
