### PR TITLE
fix(antigravity): exclude standard Gemini rate limit from quota exhaustion keywords

### DIFF
--- a/open-sse/services/antigravity429Engine.ts
+++ b/open-sse/services/antigravity429Engine.ts
@@ -53,7 +53,6 @@ const CREDITS_EXHAUSTED_KEYWORDS = [
   "minimumcreditamountforusage",
   "minimum credit amount for usage",
   "minimum credit",
-  "resource has been exhausted",
 ];
 
 const SHORT_COOLDOWN_MS = 5 * 60 * 1000; // 5 minutes

--- a/tests/unit/antigravity-429-quota-cooldown.test.ts
+++ b/tests/unit/antigravity-429-quota-cooldown.test.ts
@@ -55,6 +55,17 @@ test("classify429: AG 'Individual quota reached' message → quota_exhausted", (
   assert.equal(classify429(msg), "quota_exhausted");
 });
 
+test("classify429: standard Gemini rate limit 'resource has been exhausted' -> rate_limited or unknown, not quota_exhausted", () => {
+  const msg =
+    "RESOURCE_EXHAUSTED: Resource has been exhausted (e.g. queries per minute limit was reached).";
+  const result = classify429(msg);
+  assert.notEqual(
+    result,
+    "quota_exhausted",
+    "RESOURCE_EXHAUSTED rate limit should not be classified as quota_exhausted"
+  );
+});
+
 // ── DB persistence (the missing wire — Bug #2) ───────────────────────────────
 
 test("markConnectionQuotaExhausted persists 24h cooldown; isConnectionRateLimited returns true", async () => {


### PR DESCRIPTION
### Why the previous logic did not make sense
Previously, the keyword `"resource has been exhausted"` was included in `CREDITS_EXHAUSTED_KEYWORDS` to classify responses as `quota_exhausted`, which maps to a 24-hour total daily quota/credits exhaustion cooldown (`FULL_QUOTA_COOLDOWN_MS`).

However, Gemini's standard queries-per-minute 429 rate limit error message is:
`"RESOURCE_EXHAUSTED: Resource has been exhausted (e.g. queries per minute limit was reached)."`
Because this standard rate limit message contains the substring `"resource has been exhausted"`, any standard rate-limit error from Gemini was misclassified as total daily quota exhaustion. This incorrectly locked out the Antigravity connection for a massive 24 hours instead of executing a standard transient retry/backoff or account rotation.

### Changes
- Removed `"resource has been exhausted"` from `CREDITS_EXHAUSTED_KEYWORDS` in `open-sse/services/antigravity429Engine.ts`.
- Added unit tests to ensure standard Gemini rate limit messages are classified correctly.