### PR TITLE
refactor(chatCore): extrai emitOutputStyleTelemetry (#3501)

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -171,6 +171,7 @@ import {
   isStackedCompressionCombo,
   type RuntimeCompressionCombo,
 } from "./chatCore/compressionComboPredicates.ts";
+import { emitOutputStyleTelemetry } from "./chatCore/outputStyleTelemetry.ts";
 import { recordContextEditingTelemetryHook } from "./chatCore/contextEditingTelemetry.ts";
 import { recordCompressionCacheStats } from "./chatCore/compressionCacheStats.ts";
 import { writeCavemanOutputAnalytics } from "./chatCore/cavemanOutputAnalytics.ts";
@@ -1374,33 +1375,16 @@ export async function handleChatCore({
           log,
         });
       }
-      if (outputStyleResult) {
-        void (async () => {
-          try {
-            const { buildOutputStyleTelemetry } =
-              await import("../services/compression/outputStyles/telemetry.ts");
-            const { insertCompressionRunTelemetryRow } =
-              await import("../../src/lib/db/compressionRunTelemetry.ts");
-            const record = buildOutputStyleTelemetry({
-              requestId: skillRequestId ?? traceId ?? "",
-              model: effectiveModel ?? "",
-              provider: provider ?? "",
-              source: config.compressionComboId ? "active-profile" : "default",
-              tokensBefore: estimatedTokens,
-              tokensAfter: estimatedTokens,
-              applied: outputStyleResult.applied,
-              appliedStyles: outputStyleResult.appliedStyles,
-              skippedReason: outputStyleResult.skippedReason,
-            });
-            insertCompressionRunTelemetryRow(record);
-          } catch (err) {
-            log?.debug?.(
-              "COMPRESSION",
-              "Run-telemetry emit skipped: " + (err instanceof Error ? err.message : String(err))
-            );
-          }
-        })();
-      }
+      emitOutputStyleTelemetry({
+        outputStyleResult,
+        skillRequestId,
+        traceId,
+        effectiveModel,
+        provider,
+        compressionComboId: config.compressionComboId,
+        estimatedTokens,
+        log,
+      });
     } catch (err) {
       log?.warn?.(
         "COMPRESSION",

--- a/open-sse/handlers/chatCore/outputStyleTelemetry.ts
+++ b/open-sse/handlers/chatCore/outputStyleTelemetry.ts
@@ -1,0 +1,53 @@
+/**
+ * chatCore output-style run-telemetry hook (Quality Gate v2 / Fase 9 — chatCore god-file
+ * decomposition, #3501).
+ *
+ * Extracted from handleChatCore's request-setup compression path: when the unified output styles
+ * ran, emit the per-run telemetry record so output-style usage surfaces in compression analytics.
+ * Best-effort, fire-and-forget — an un-awaited IIFE that swallows its own errors and never affects
+ * the request. Behaviour is byte-identical to the previous inline block.
+ */
+
+import { type OutputStylesResult } from "../../services/compression/outputStyles/apply.ts";
+
+type LoggerLike = { debug?: (...args: unknown[]) => void } | null | undefined;
+
+export function emitOutputStyleTelemetry(args: {
+  outputStyleResult: OutputStylesResult | null | undefined;
+  skillRequestId: string | null | undefined;
+  traceId: string | null | undefined;
+  effectiveModel: string | null | undefined;
+  provider: string | null | undefined;
+  compressionComboId: string | null | undefined;
+  estimatedTokens: number;
+  log?: LoggerLike;
+}): void {
+  const result = args.outputStyleResult;
+  if (!result) return;
+
+  void (async () => {
+    try {
+      const { buildOutputStyleTelemetry } = await import(
+        "../../services/compression/outputStyles/telemetry.ts"
+      );
+      const { insertCompressionRunTelemetryRow } = await import("@/lib/db/compressionRunTelemetry");
+      const record = buildOutputStyleTelemetry({
+        requestId: args.skillRequestId ?? args.traceId ?? "",
+        model: args.effectiveModel ?? "",
+        provider: args.provider ?? "",
+        source: args.compressionComboId ? "active-profile" : "default",
+        tokensBefore: args.estimatedTokens,
+        tokensAfter: args.estimatedTokens,
+        applied: result.applied,
+        appliedStyles: result.appliedStyles,
+        skippedReason: result.skippedReason,
+      });
+      insertCompressionRunTelemetryRow(record);
+    } catch (err) {
+      args.log?.debug?.(
+        "COMPRESSION",
+        "Run-telemetry emit skipped: " + (err instanceof Error ? err.message : String(err))
+      );
+    }
+  })();
+}

--- a/tests/unit/chatcore-output-style-telemetry.test.ts
+++ b/tests/unit/chatcore-output-style-telemetry.test.ts
@@ -1,0 +1,102 @@
+// Characterization of emitOutputStyleTelemetry — the output-style run-telemetry hook extracted from
+// handleChatCore's request-setup compression path (chatCore god-file decomposition, #3501).
+// Fire-and-forget; uses a real temp DB and polls compression_run_telemetry. Locks: the null guard
+// (no-op), and that an applied output-style result records a run-telemetry row with the resolved
+// request id / model / provider / source.
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const testDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "omni-os-telemetry-test-"));
+process.env.DATA_DIR = testDataDir;
+
+const coreDb = await import("../../src/lib/db/core.ts");
+const { emitOutputStyleTelemetry } = await import(
+  "../../open-sse/handlers/chatCore/outputStyleTelemetry.ts"
+);
+
+function rowFor(requestId: string): Record<string, unknown> | undefined {
+  try {
+    return coreDb
+      .getDbInstance()
+      .prepare(
+        "SELECT request_id, model, provider, source FROM compression_run_telemetry WHERE request_id = ?"
+      )
+      .get(requestId) as Record<string, unknown> | undefined;
+  } catch {
+    // table is created lazily by the first fire-and-forget insert; treat "no such table" as "no row"
+    return undefined;
+  }
+}
+
+async function waitForRow(requestId: string, timeoutMs = 3000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (rowFor(requestId)) break;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  return rowFor(requestId);
+}
+
+before(async () => {
+  await coreDb.ensureDbInitialized();
+});
+
+after(() => {
+  coreDb.resetDbInstance();
+  try {
+    fs.rmSync(testDataDir, { recursive: true, force: true });
+  } catch {
+    // best-effort cleanup
+  }
+});
+
+test("null outputStyleResult is a no-op (returns synchronously, no throw)", async () => {
+  assert.doesNotThrow(() =>
+    emitOutputStyleTelemetry({
+      outputStyleResult: null,
+      skillRequestId: "os-noop",
+      traceId: "t",
+      effectiveModel: "gpt-x",
+      provider: "openai",
+      compressionComboId: null,
+      estimatedTokens: 100,
+    })
+  );
+  await new Promise((r) => setTimeout(r, 80));
+  assert.equal(rowFor("os-noop"), undefined);
+});
+
+test("applied output-style result records a run-telemetry row (source=active-profile when combo id set)", async () => {
+  emitOutputStyleTelemetry({
+    outputStyleResult: { body: {} as never, applied: true, appliedStyles: [], skippedReason: undefined },
+    skillRequestId: "os-req-1",
+    traceId: "trace-1",
+    effectiveModel: "gpt-os",
+    provider: "openai",
+    compressionComboId: "combo-9",
+    estimatedTokens: 250,
+  });
+  const row = await waitForRow("os-req-1");
+  assert.ok(row, "expected a compression_run_telemetry row");
+  assert.equal(row!.model, "gpt-os");
+  assert.equal(row!.provider, "openai");
+  assert.equal(row!.source, "active-profile");
+});
+
+test("falls back to traceId for request id and source=default without a combo id", async () => {
+  emitOutputStyleTelemetry({
+    outputStyleResult: { body: {} as never, applied: true, appliedStyles: [] },
+    skillRequestId: null,
+    traceId: "os-trace-2",
+    effectiveModel: "gpt-x",
+    provider: "anthropic",
+    compressionComboId: null,
+    estimatedTokens: 10,
+  });
+  const row = await waitForRow("os-trace-2");
+  assert.ok(row, "expected the row keyed by the traceId fallback");
+  assert.equal(row!.source, "default");
+});


### PR DESCRIPTION
## O quê

Decomposição do god-file `chatCore.ts` (#3501, novo plano — Bloco II). Extrai o **hook de run-telemetry de output-styles** (fire-and-forget) do setup de request de `handleChatCore` para `chatCore/outputStyleTelemetry.ts`.

## Como

`emitOutputStyleTelemetry({ outputStyleResult, skillRequestId, traceId, effectiveModel, provider, compressionComboId, estimatedTokens, log })`. IIFE async **não-awaited** que engole os próprios erros (best-effort, nunca afeta o request). Guard de `outputStyleResult` nulo; `buildOutputStyleTelemetry` + `insertCompressionRunTelemetryRow` preservados. Comportamento byte-idêntico.

## Validação (Rule #18 — TDD)

- **+3 caracterizações** com DB temp real + poll de `compression_run_telemetry`: guard nulo no-op, linha gravada com `model`/`provider`/`source=active-profile` quando há combo id, fallback para `traceId` + `source=default` sem combo id.
- Suíte chatcore completa → **346 verde**.
- `typecheck:core` limpo; `eslint` 0; `file-size` OK.

## Estado dos gates (pós-merge dos 10 PRs anteriores)

- `check:db-rules` agora **VERDE** — o base-red de `compressionRunTelemetry.ts` foi reconciliado no merge.
- `check:complexity` — **1920 > baseline 1916** segue base-red (drift de merge paralelo). Este slice é **delta-0** (provado no tip pristine `12ae360dc`, mesma contagem 1920 sem minha mudança).

## Impacto

`chatCore.ts` **−18 linhas**. Sem mudança de API/comportamento público.
