### PR TITLE
fix(dashboard): keep desktop sidebar visible via explicit CSS class

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -496,3 +496,15 @@ select option {
 .react-flow__controls-button svg {
   fill: var(--color-text-main);
 }
+
+/* Desktop sidebar visibility must not depend on Tailwind's hidden/lg:flex cascade
+   (ordering/specificity can collapse it). Explicit class + 1024px media query. */
+.dashboard-sidebar-desktop {
+  display: none;
+  min-height: 0;
+}
+@media (min-width: 1024px) {
+  .dashboard-sidebar-desktop {
+    display: flex;
+  }
+}

--- a/src/shared/components/layouts/DashboardLayout.tsx
+++ b/src/shared/components/layouts/DashboardLayout.tsx
@@ -73,8 +73,8 @@ export default function DashboardLayout({ children }) {
         />
       )}
 
-      {/* Sidebar - Desktop */}
-      <div className="hidden min-h-0 lg:flex">
+      {/* Sidebar - Desktop: keep visibility independent from Tailwind hidden/lg:flex ordering. */}
+      <div className="dashboard-sidebar-desktop">
         <Sidebar
           collapsed={collapsed}
           onToggleCollapse={handleToggleCollapse}

--- a/tests/unit/dashboard-sidebar-desktop-visible.test.ts
+++ b/tests/unit/dashboard-sidebar-desktop-visible.test.ts
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+function readSrc(path: string): string {
+  return readFileSync(join(ROOT, path), "utf8");
+}
+
+// Regression guard: the desktop dashboard sidebar must stay visible on desktop.
+// The old `hidden ... lg:flex` Tailwind cascade is fragile — class ordering /
+// specificity can collapse the `lg:flex` and leave the sidebar permanently
+// hidden. The fix moves visibility into an explicit `.dashboard-sidebar-desktop`
+// class backed by a 1024px media query in globals.css.
+
+test("DashboardLayout desktop sidebar uses the explicit visibility class, not the hidden/lg:flex cascade", () => {
+  const source = readSrc("src/shared/components/layouts/DashboardLayout.tsx");
+
+  // The desktop sidebar wrapper must reference the dedicated class.
+  assert.match(
+    source,
+    /className="dashboard-sidebar-desktop"/,
+    "Desktop sidebar wrapper must use the dashboard-sidebar-desktop class"
+  );
+
+  // The fragile Tailwind cascade must be gone.
+  assert.doesNotMatch(
+    source,
+    /className="hidden[^"]*lg:flex"/,
+    "Desktop sidebar wrapper must not rely on the hidden/lg:flex Tailwind cascade"
+  );
+});
+
+test("globals.css defines dashboard-sidebar-desktop hidden by default and flex at >=1024px", () => {
+  const css = readSrc("src/app/globals.css");
+
+  // Class exists.
+  assert.match(
+    css,
+    /\.dashboard-sidebar-desktop\s*\{/,
+    "globals.css must define .dashboard-sidebar-desktop"
+  );
+
+  // Hidden by default (mobile-first), then shown via a 1024px desktop media query.
+  const classIndex = css.indexOf(".dashboard-sidebar-desktop");
+  const desktopRule =
+    /@media\s*\(min-width:\s*1024px\)\s*\{[^}]*\.dashboard-sidebar-desktop\s*\{[^}]*display:\s*flex/;
+  assert.match(
+    css.slice(classIndex - 200),
+    desktopRule,
+    "globals.css must show .dashboard-sidebar-desktop with display:flex at min-width:1024px"
+  );
+
+  // Default state hides it (display:none) so mobile is unaffected.
+  const baseRule = /\.dashboard-sidebar-desktop\s*\{[^}]*display:\s*none/;
+  assert.match(
+    css,
+    baseRule,
+    "globals.css must hide .dashboard-sidebar-desktop by default (display:none)"
+  );
+});


### PR DESCRIPTION
## Summary

- The desktop dashboard sidebar relied on the fragile `hidden`/`lg:flex` Tailwind cascade. Class ordering/specificity could collapse the `lg:flex` override and leave the sidebar permanently hidden on desktop.
- Replaced it with an explicit `.dashboard-sidebar-desktop` class (in `globals.css`) hidden by default and shown via a `min-width: 1024px` media query — order-independent. The class keeps `min-height: 0` to preserve the previous `min-h-0` behavior.

## Changes

- `src/shared/components/layouts/DashboardLayout.tsx`: desktop sidebar wrapper now uses `className="dashboard-sidebar-desktop"`.
- `src/app/globals.css`: added the `.dashboard-sidebar-desktop` rule + 1024px media query.
- `tests/unit/dashboard-sidebar-desktop-visible.test.ts`: regression guard (fails before the change, passes after) asserting the wrapper uses the explicit class and the CSS defines the hidden-by-default + flex-at-1024px rules.

## Test plan

- [x] `node --import tsx/esm --test tests/unit/dashboard-sidebar-desktop-visible.test.ts` (fails before fix, passes after)
- [x] `tests/unit/sidebar-visibility.test.ts` still green

## Attribution

Thanks to @Delcado19 for the original implementation.