### PR TITLE
feat(api): add MiniMax-M3 pricing row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ _In development — bullets added per PR; finalized at release._
 
 ### 🔧 Bug Fixes
 
+- **pricing**: add the `MiniMax-M3` cost row (canonical + lowercase alias) so the new MiniMax default model gets accurate per-request cost accounting instead of falling back to a zero/default rate (thanks @octo-patch).
+
 - **fix(sse):** Kiro tool-schema sanitizer — strip unsupported JSON-Schema keywords (`anyOf`/`$ref`/`if`-`then`, etc.) and hash-truncate tool names >64 chars before dispatch, mapping the streamed tool-call name back for the client, so Kiro no longer rejects tool calls with `400 "Improperly formed request"`. (thanks @smarthomeblack)
 
 - **sse**: make the `anthropic-version` default-guard case-insensitive for `anthropic-compatible-*` providers, so a caller/operator-supplied `Anthropic-Version` (any casing) is no longer clobbered by a second lowercase `anthropic-version: 2023-06-01` header. (thanks @zakirkun)

--- a/src/shared/constants/pricing/regional.ts
+++ b/src/shared/constants/pricing/regional.ts
@@ -71,6 +71,22 @@ export const DEFAULT_PRICING_REGIONAL = {
     "kimi-latest": { input: 1.0, output: 4.0, cached: 0.5, reasoning: 6.0, cache_creation: 1.0 },
   },
   minimax: {
+    // MiniMax M3 — new default model (upstream upgrade from M2.7).
+    // Same api.minimax.io endpoint; pricing mirrors the M2.x base tier.
+    "minimax-m3": {
+      input: 0.5,
+      output: 2.0,
+      cached: 0.25,
+      reasoning: 3.0,
+      cache_creation: 0.5,
+    },
+    "MiniMax-M3": {
+      input: 0.5,
+      output: 2.0,
+      cached: 0.25,
+      reasoning: 3.0,
+      cache_creation: 0.5,
+    },
     "minimax-m2.1": {
       input: 0.5,
       output: 2.0,

--- a/tests/unit/t12-pricing-updates.test.ts
+++ b/tests/unit/t12-pricing-updates.test.ts
@@ -42,6 +42,21 @@ test("T12: codex catalog includes GPT 5.5 variations", () => {
   assert.equal(codexModels.get("gpt-5.5-xhigh")?.targetFormat, "openai-responses");
 });
 
+test("T12: pricing table includes MiniMax-M3 (canonical + lowercase alias)", () => {
+  const pricing = getDefaultPricing();
+
+  assert.ok(pricing.minimax["MiniMax-M3"], "missing minimax/MiniMax-M3");
+  assert.ok(pricing.minimax["minimax-m3"], "missing minimax/minimax-m3 alias");
+
+  for (const key of ["MiniMax-M3", "minimax-m3"]) {
+    assert.equal(pricing.minimax[key].input, 0.5, `${key} input`);
+    assert.equal(pricing.minimax[key].output, 2.0, `${key} output`);
+    assert.equal(pricing.minimax[key].cached, 0.25, `${key} cached`);
+    assert.equal(pricing.minimax[key].reasoning, 3.0, `${key} reasoning`);
+    assert.equal(pricing.minimax[key].cache_creation, 0.5, `${key} cache_creation`);
+  }
+});
+
 test("T12: minimax default model list starts with M3", () => {
   const minimaxModels = REGISTRY.minimax.models.map((m) => m.id);
   const minimaxCnModels = REGISTRY["minimax-cn"].models.map((m) => m.id);


### PR DESCRIPTION
## Summary

- MiniMax upgraded its default model from M2.7 to **M3**. OmniRoute's provider registry already lists `MiniMax-M3`, but `src/shared/constants/pricing.ts` had no cost row for it, so requests against the new default fell back to a zero/default rate.
- Adds the `MiniMax-M3` pricing entry (canonical case + lowercase alias) mirroring the M2.x base tier so per-request cost accounting is accurate.

## Attribution

Thanks to [@octo-patch](https://github.com/octo-patch) for the original implementation.

## Changes

- `src/shared/constants/pricing.ts`: add `MiniMax-M3` / `minimax-m3` cost rows (input 0.5, output 2.0, cached 0.25, reasoning 3.0, cache_creation 0.5).
- `tests/unit/t12-pricing-updates.test.ts`: assert the new pricing rows exist with the expected rates (fails before the fix, passes after).
- `CHANGELOG.md`: one bullet under the in-development 3.8.35 section.

## Test plan

- [x] `node --import tsx/esm --test tests/unit/t12-pricing-updates.test.ts` — fails before the pricing edit, passes after (TDD).