### PR TITLE
fix(sse): reject unsupported Kiro [1m] context suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ _In development — bullets added per PR; finalized at release._
 
 ### 🔧 Bug Fixes
 
+- **sse/kiro**: reject the Anthropic-only `[1m]` context-1m suffix in `buildKiroPayload` before it reaches AWS Bedrock — Kiro is Bedrock-backed and cannot honor the beta, so a forwarded `kr/*[1m]` model id was malformed upstream; callers now get a clear error pointing them at a direct-Anthropic provider for 1M-context routing (thanks @Delcado19).
+
 - **Engine Combos editor: saving a pipeline no longer fails silently with HTTP 400 (#4955).** The
   named-combos pipeline dropdown offered four engines (`headroom`, `session-dedup`, `ccr`,
   `llmlingua`) that the `PUT /api/context/combos/[id]` schema rejects, so selecting one made the

--- a/open-sse/translator/request/openai-to-kiro.ts
+++ b/open-sse/translator/request/openai-to-kiro.ts
@@ -6,6 +6,28 @@ import { register } from "../registry.ts";
 import { FORMATS } from "../formats.ts";
 import { v4 as uuidv4, v5 as uuidv5 } from "uuid";
 
+/**
+ * Anthropic's direct-provider `[1m]` context-1m beta suffix. Kiro is AWS
+ * Bedrock-backed and does not honor it, so forwarding a `kr/*` model id that
+ * carries `[1m]` produces a malformed upstream model id at Bedrock.
+ */
+export const KIRO_UNSUPPORTED_CONTEXT_1M_SUFFIX = "[1m]";
+export const KIRO_UNSUPPORTED_CONTEXT_1M_MESSAGE =
+  "[kr/*] '[1m]' suffix is not supported by Kiro upstream. Kiro is AWS " +
+  "Bedrock-backed and does not honor Anthropic's context-1m beta. Use a " +
+  "direct-Anthropic provider for 1M-context routing.";
+
+/**
+ * Kiro is AWS Bedrock-backed, so Anthropic's direct-provider `[1m]` context
+ * beta cannot be forwarded as part of a `kr/*` model id.
+ */
+export function hasUnsupportedKiroContextSuffix(model: unknown): boolean {
+  return (
+    typeof model === "string" &&
+    model.toLowerCase().includes(KIRO_UNSUPPORTED_CONTEXT_1M_SUFFIX)
+  );
+}
+
 function parseToolInput(value: unknown) {
   if (value && typeof value === "object" && !Array.isArray(value)) {
     return value;
@@ -639,6 +661,12 @@ function convertMessages(messages, tools, model) {
  * Build Kiro payload from OpenAI format
  */
 export function buildKiroPayload(model, body, stream, credentials) {
+  // Reject the Anthropic-only `[1m]` context beta before it reaches Bedrock —
+  // Kiro cannot honor it and a forwarded `kr/*[1m]` id is malformed upstream.
+  if (hasUnsupportedKiroContextSuffix(model)) {
+    throw new Error(KIRO_UNSUPPORTED_CONTEXT_1M_MESSAGE);
+  }
+
   // Normalize model name: Claude Code sends dashes (claude-sonnet-4-6),
   // Kiro API expects dots (claude-sonnet-4.6). Convert trailing version segment.
   const normalizedModel = model.replace(

--- a/tests/unit/translator-openai-to-kiro.test.ts
+++ b/tests/unit/translator-openai-to-kiro.test.ts
@@ -977,3 +977,22 @@ test("OpenAI -> Kiro drops images for non-Claude models (glm / auto-kiro)", () =
     );
   }
 });
+
+test("buildKiroPayload rejects the Anthropic-only [1m] context suffix before Bedrock", () => {
+  const body = { messages: [{ role: "user", content: "Hello" }] };
+
+  assert.throws(
+    () => buildKiroPayload("claude-opus-4.7-thinking-agentic[1m]", body, true, {}),
+    /\[1m\]' suffix is not supported by Kiro upstream/,
+    "kr/* model ids carrying [1m] must be rejected, not forwarded to AWS Bedrock"
+  );
+});
+
+test("buildKiroPayload accepts kr/* model ids without the [1m] suffix", () => {
+  const body = { messages: [{ role: "user", content: "Hello" }] };
+
+  assert.doesNotThrow(
+    () => buildKiroPayload("claude-sonnet-4.5", body, true, {}),
+    "model ids without [1m] must continue to build normally"
+  );
+});


### PR DESCRIPTION
## Summary

- Kiro is AWS Bedrock-backed and does not honor Anthropic's direct-provider `[1m]` (context-1m) beta.
- A `kr/*` model id carrying the `[1m]` suffix was being forwarded as a malformed upstream model id to Bedrock.
- `buildKiroPayload` now rejects the `[1m]` suffix at its model-normalization step with a clear, static error pointing callers at a direct-Anthropic provider for 1M-context routing.

## Changes

- `open-sse/translator/request/openai-to-kiro.ts`: add `hasUnsupportedKiroContextSuffix` guard + constants; throw before normalization when the model id includes `[1m]`.
- `tests/unit/translator-openai-to-kiro.test.ts`: TDD coverage — rejects `[1m]` ids (fails before the guard, passes after) and still accepts clean `kr/*` ids.

## Test plan

- [x] `node --import tsx/esm --test tests/unit/translator-openai-to-kiro.test.ts` (26/26 pass; the new reject test fails without the guard)
- [x] `npm run typecheck:core`

## Attribution

Thanks to @Delcado19 for the original implementation.