### PR TITLE
refactor(chatCore): extrai writeCompressionAnalytics (bloco analytics completo, #3501)

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -172,6 +172,7 @@ import {
   type RuntimeCompressionCombo,
 } from "./chatCore/compressionComboPredicates.ts";
 import { emitOutputStyleTelemetry } from "./chatCore/outputStyleTelemetry.ts";
+import { writeCompressionAnalytics } from "./chatCore/compressionAnalyticsWrite.ts";
 import { recordContextEditingTelemetryHook } from "./chatCore/contextEditingTelemetry.ts";
 import { recordCompressionCacheStats } from "./chatCore/compressionCacheStats.ts";
 import { writeCavemanOutputAnalytics } from "./chatCore/cavemanOutputAnalytics.ts";
@@ -1277,74 +1278,19 @@ export async function handleChatCore({
           if (result.compressed || result.stats.fallbackApplied || cavemanOutputModeApplied) {
             trackCompressionStats(result.stats);
             compressionAnalyticsRecorded = true;
-            compressionAnalyticsWritePromise = (async () => {
-              try {
-                const { insertCompressionAnalyticsRow, insertCompressionEngineBreakdown } =
-                  await import("../../src/lib/db/compressionAnalytics.ts");
-                const { calculateCost } = await import("../../src/lib/usage/costCalculator.ts");
-                const tokensSaved = Math.max(
-                  0,
-                  result.stats.originalTokens - result.stats.compressedTokens
-                );
-                const rtkPointers = result.stats.rtkRawOutputPointers ?? [];
-                const estimatedUsdSaved = await calculateCost(
-                  provider ?? "",
-                  effectiveModel ?? "",
-                  {
-                    input: tokensSaved,
-                  },
-                  { serviceTier: effectiveServiceTier }
-                );
-                insertCompressionAnalyticsRow({
-                  timestamp: new Date().toISOString(),
-                  combo_id: comboName ?? null,
-                  provider: provider ?? null,
-                  mode,
-                  engine: result.stats.engine ?? mode,
-                  compression_combo_id:
-                    result.stats.compressionComboId ?? config.compressionComboId ?? null,
-                  original_tokens: result.stats.originalTokens,
-                  compressed_tokens: result.stats.compressedTokens,
-                  tokens_saved: tokensSaved,
-                  duration_ms: result.stats.durationMs ?? null,
-                  request_id: skillRequestId,
-                  estimated_usd_saved: estimatedUsdSaved || null,
-                  validation_fallback: result.stats.fallbackApplied ? 1 : 0,
-                  output_mode: cavemanOutputModeApplied ? cavemanOutputModeIntensity : null,
-                  rtk_raw_output_pointer: rtkPointers[0]?.id ?? null,
-                  rtk_raw_output_bytes: rtkPointers[0]?.bytes ?? null,
-                  rtk_raw_output_pointers: rtkPointers.length
-                    ? JSON.stringify(rtkPointers.map((pointer) => pointer.id))
-                    : null,
-                  rtk_raw_output_total_bytes: rtkPointers.length
-                    ? rtkPointers.reduce((total, pointer) => total + pointer.bytes, 0)
-                    : null,
-                });
-                // Persist the per-engine breakdown of a stacked run so per-engine
-                // analytics (getPerEngineAnalytics) is accurate historically, not just
-                // in the live `compression.completed` event.
-                const engineBreakdown = result.stats.engineBreakdown ?? [];
-                if (engineBreakdown.length > 0) {
-                  insertCompressionEngineBreakdown(
-                    engineBreakdown.map((b) => ({
-                      timestamp: new Date().toISOString(),
-                      request_id: skillRequestId,
-                      engine: b.engine,
-                      original_tokens: b.originalTokens,
-                      compressed_tokens: b.compressedTokens,
-                      tokens_saved: Math.max(0, b.originalTokens - b.compressedTokens),
-                      duration_ms: b.durationMs ?? null,
-                    }))
-                  );
-                }
-              } catch (err) {
-                log?.debug?.(
-                  "COMPRESSION",
-                  "Compression analytics write skipped: " +
-                    (err instanceof Error ? err.message : String(err))
-                );
-              }
-            })();
+            compressionAnalyticsWritePromise = writeCompressionAnalytics({
+              stats: result.stats,
+              provider,
+              effectiveModel,
+              effectiveServiceTier,
+              comboName,
+              mode,
+              compressionComboId: config.compressionComboId,
+              skillRequestId,
+              cavemanOutputModeApplied,
+              cavemanOutputModeIntensity,
+              log,
+            });
           }
 
           if (result.compressed) {

--- a/open-sse/handlers/chatCore/compressionAnalyticsWrite.ts
+++ b/open-sse/handlers/chatCore/compressionAnalyticsWrite.ts
@@ -1,0 +1,113 @@
+/**
+ * chatCore compression analytics write (Quality Gate v2 / Fase 9 — chatCore god-file
+ * decomposition, #3501).
+ *
+ * Extracted from handleChatCore's request-setup compression path: persist the per-run compression
+ * analytics row (cost saved, RTK raw-output pointers) plus the per-engine breakdown of a stacked
+ * run. Returns the write promise (the caller assigns it to compressionAnalyticsWritePromise) and
+ * swallows its own errors — best-effort, off the hot path, never throws into a request. Behaviour
+ * is byte-identical to the previous inline block. Split into small builders so each stays under the
+ * complexity cap.
+ */
+
+import { type CompressionStats } from "../../services/compression/stats.ts";
+
+type LoggerLike = { debug?: (...args: unknown[]) => void } | null | undefined;
+
+type WriteOpts = {
+  stats: CompressionStats;
+  provider: string | null | undefined;
+  effectiveModel: string | null | undefined;
+  effectiveServiceTier: string | undefined;
+  comboName: string | null | undefined;
+  mode: string;
+  compressionComboId: string | null | undefined;
+  skillRequestId: string;
+  cavemanOutputModeApplied: boolean;
+  cavemanOutputModeIntensity: string | null | undefined;
+  log?: LoggerLike;
+};
+
+type RtkPointer = { id?: string | null; bytes?: number | null };
+
+function buildRtkPointerFields(rtkPointers: RtkPointer[]) {
+  return {
+    rtk_raw_output_pointer: rtkPointers[0]?.id ?? null,
+    rtk_raw_output_bytes: rtkPointers[0]?.bytes ?? null,
+    rtk_raw_output_pointers: rtkPointers.length
+      ? JSON.stringify(rtkPointers.map((pointer) => pointer.id))
+      : null,
+    rtk_raw_output_total_bytes: rtkPointers.length
+      ? rtkPointers.reduce((total, pointer) => total + (pointer.bytes ?? 0), 0)
+      : null,
+  };
+}
+
+function buildAnalyticsRow(
+  opts: WriteOpts,
+  tokensSaved: number,
+  rtkPointers: RtkPointer[],
+  estimatedUsdSaved: number
+) {
+  const { stats } = opts;
+  return {
+    timestamp: new Date().toISOString(),
+    combo_id: opts.comboName ?? null,
+    provider: opts.provider ?? null,
+    mode: opts.mode,
+    engine: stats.engine ?? opts.mode,
+    compression_combo_id: stats.compressionComboId ?? opts.compressionComboId ?? null,
+    original_tokens: stats.originalTokens,
+    compressed_tokens: stats.compressedTokens,
+    tokens_saved: tokensSaved,
+    duration_ms: stats.durationMs ?? null,
+    request_id: opts.skillRequestId,
+    estimated_usd_saved: estimatedUsdSaved || null,
+    validation_fallback: stats.fallbackApplied ? 1 : 0,
+    output_mode: opts.cavemanOutputModeApplied ? opts.cavemanOutputModeIntensity : null,
+    ...buildRtkPointerFields(rtkPointers),
+  };
+}
+
+function buildEngineBreakdownRows(stats: CompressionStats, requestId: string) {
+  const engineBreakdown = stats.engineBreakdown ?? [];
+  return engineBreakdown.map((b) => ({
+    timestamp: new Date().toISOString(),
+    request_id: requestId,
+    engine: b.engine,
+    original_tokens: b.originalTokens,
+    compressed_tokens: b.compressedTokens,
+    tokens_saved: Math.max(0, b.originalTokens - b.compressedTokens),
+    duration_ms: b.durationMs ?? null,
+  }));
+}
+
+export function writeCompressionAnalytics(opts: WriteOpts): Promise<void> {
+  return (async () => {
+    try {
+      const { insertCompressionAnalyticsRow, insertCompressionEngineBreakdown } = await import(
+        "@/lib/db/compressionAnalytics"
+      );
+      const { calculateCost } = await import("@/lib/usage/costCalculator");
+      const { stats } = opts;
+      const tokensSaved = Math.max(0, stats.originalTokens - stats.compressedTokens);
+      const rtkPointers = (stats.rtkRawOutputPointers ?? []) as RtkPointer[];
+      const estimatedUsdSaved = await calculateCost(
+        opts.provider ?? "",
+        opts.effectiveModel ?? "",
+        { input: tokensSaved },
+        { serviceTier: opts.effectiveServiceTier }
+      );
+      insertCompressionAnalyticsRow(buildAnalyticsRow(opts, tokensSaved, rtkPointers, estimatedUsdSaved));
+      const breakdownRows = buildEngineBreakdownRows(stats, opts.skillRequestId);
+      if (breakdownRows.length > 0) {
+        insertCompressionEngineBreakdown(breakdownRows);
+      }
+    } catch (err) {
+      opts.log?.debug?.(
+        "COMPRESSION",
+        "Compression analytics write skipped: " + (err instanceof Error ? err.message : String(err))
+      );
+    }
+  })();
+}

--- a/tests/unit/chatcore-compression-analytics-write.test.ts
+++ b/tests/unit/chatcore-compression-analytics-write.test.ts
@@ -1,0 +1,129 @@
+// Characterization of writeCompressionAnalytics — the full compression analytics write extracted
+// from handleChatCore's request-setup compression path (chatCore god-file decomposition, #3501).
+// Returns the write promise; uses a real temp DB. Locks: the analytics row mapping (tokens, engine,
+// validation_fallback, output_mode), the per-engine breakdown insert, and fail-open.
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const testDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "omni-comp-analytics-test-"));
+process.env.DATA_DIR = testDataDir;
+
+const coreDb = await import("../../src/lib/db/core.ts");
+const { writeCompressionAnalytics } = await import(
+  "../../open-sse/handlers/chatCore/compressionAnalyticsWrite.ts"
+);
+
+type Stats = Parameters<typeof writeCompressionAnalytics>[0]["stats"];
+
+function makeStats(overrides: Record<string, unknown> = {}): Stats {
+  return {
+    originalTokens: 200,
+    compressedTokens: 80,
+    fallbackApplied: false,
+    engine: "rtk",
+    compressionComboId: null,
+    durationMs: 12,
+    rtkRawOutputPointers: [],
+    engineBreakdown: [],
+    ...overrides,
+  } as unknown as Stats;
+}
+
+function analyticsRow(requestId: string): Record<string, unknown> | undefined {
+  try {
+    return coreDb
+      .getDbInstance()
+      .prepare(
+        "SELECT mode, engine, original_tokens AS orig, compressed_tokens AS comp, tokens_saved AS saved, validation_fallback AS vf FROM compression_analytics WHERE request_id = ?"
+      )
+      .get(requestId) as Record<string, unknown> | undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function breakdownCount(requestId: string): number {
+  try {
+    const row = coreDb
+      .getDbInstance()
+      .prepare("SELECT COUNT(*) AS n FROM compression_engine_breakdown WHERE request_id = ?")
+      .get(requestId) as { n: number } | undefined;
+    return row?.n ?? 0;
+  } catch {
+    return 0;
+  }
+}
+
+async function waitFor(pred: () => boolean, timeoutMs = 3000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline && !pred()) {
+    await new Promise((r) => setTimeout(r, 25));
+  }
+}
+
+function baseOpts(requestId: string, statsOverrides = {}) {
+  return {
+    stats: makeStats(statsOverrides),
+    provider: "openai",
+    effectiveModel: "gpt-x",
+    effectiveServiceTier: "standard",
+    comboName: null,
+    mode: "rtk",
+    compressionComboId: null,
+    skillRequestId: requestId,
+    cavemanOutputModeApplied: false,
+    cavemanOutputModeIntensity: null,
+  } as Parameters<typeof writeCompressionAnalytics>[0];
+}
+
+before(async () => {
+  await coreDb.ensureDbInitialized();
+});
+
+after(() => {
+  coreDb.resetDbInstance();
+  try {
+    fs.rmSync(testDataDir, { recursive: true, force: true });
+  } catch {
+    // best-effort cleanup
+  }
+});
+
+test("writes the analytics row with mapped tokens/engine and resolves", async () => {
+  await writeCompressionAnalytics(baseOpts("ca-req-1"));
+  const row = analyticsRow("ca-req-1");
+  assert.ok(row, "expected a compression_analytics row");
+  assert.equal(row!.engine, "rtk");
+  assert.equal(row!.orig, 200);
+  assert.equal(row!.comp, 80);
+  assert.equal(row!.saved, 120);
+  assert.equal(row!.vf, 0);
+});
+
+test("validation_fallback is 1 when the stats flagged a fallback", async () => {
+  await writeCompressionAnalytics(baseOpts("ca-req-2", { fallbackApplied: true }));
+  const row = analyticsRow("ca-req-2");
+  assert.equal(row!.vf, 1);
+});
+
+test("inserts a per-engine breakdown when present", async () => {
+  await writeCompressionAnalytics(
+    baseOpts("ca-req-3", {
+      engineBreakdown: [
+        { engine: "rtk", originalTokens: 200, compressedTokens: 120, durationMs: 5 },
+        { engine: "caveman", originalTokens: 120, compressedTokens: 80, durationMs: 4 },
+      ],
+    })
+  );
+  await waitFor(() => breakdownCount("ca-req-3") >= 2);
+  assert.equal(breakdownCount("ca-req-3"), 2);
+});
+
+test("never rejects even on a bad write (fail-open)", async () => {
+  coreDb.resetDbInstance();
+  await assert.doesNotReject(writeCompressionAnalytics(baseOpts("ca-req-4")));
+  await coreDb.ensureDbInitialized();
+});


### PR DESCRIPTION
## O quê

Decomposição do god-file `chatCore.ts` (#3501, novo plano — **quebra grande** do Bloco II). Extrai o **bloco completo de escrita de analytics de compressão** (~70 ln) do setup de request de `handleChatCore` para `chatCore/compressionAnalyticsWrite.ts`.

## Como

`writeCompressionAnalytics(opts): Promise<void>` retorna a Promise de escrita (o caller atribui a `compressionAnalyticsWritePromise`) e engole os próprios erros (best-effort, off-hot-path). Tipado com `CompressionStats`. Split em `buildRtkPointerFields`/`buildAnalyticsRow`/`buildEngineBreakdownRows` para cada função ficar abaixo do cap de complexidade (`buildAnalyticsRow` inline dava 16). `trackCompressionStats` + `compressionAnalyticsRecorded = true` ficam no handler. Comportamento byte-idêntico.

## Validação (Rule #18 — TDD)

- **+4 caracterizações** com DB temp real: mapeamento da row (`original_tokens`/`compressed_tokens`/`tokens_saved`/`engine`), `validation_fallback=1` quando o stats sinaliza fallback, insert do breakdown por-engine, fail-open (nunca rejeita).
- Suíte chatcore completa → **347 verde**.
- `typecheck:core` limpo; `eslint` 0; complexity por-arquivo OK.

## Estado dos gates

- `check:db-rules` **VERDE** (reconciliado no merge anterior).
- `check:complexity` — **1920 > baseline 1916** base-red (drift). Slice **delta-0** (provado no tip pristine `12ae360dc`).

## Impacto

`chatCore.ts` **−54 linhas** (quebra grande). Sem mudança de API/comportamento público.
