### PR TITLE
fix(oauth): allow per-connection refresh lead-time override via providerSpecificData.refreshLeadMs

### DIFF
--- a/open-sse/services/tokenRefresh.ts
+++ b/open-sse/services/tokenRefresh.ts
@@ -50,9 +50,22 @@ export const REFRESH_LEAD_MS: Record<string, number> = {
 
 /**
  * Get the proactive refresh lead time (ms) for a given provider.
- * Falls back to TOKEN_EXPIRY_BUFFER_MS (5 min) when not explicitly listed.
+ *
+ * Precedence:
+ *   1. A per-connection override in `providerSpecificData.refreshLeadMs`
+ *      (must be a positive finite number), so an operator can tune the lead
+ *      time for a single connection without touching the provider defaults.
+ *   2. The provider default from REFRESH_LEAD_MS.
+ *   3. TOKEN_EXPIRY_BUFFER_MS (5 min) when nothing else applies.
  */
-export function getRefreshLeadMs(provider: string): number {
+export function getRefreshLeadMs(
+  provider: string,
+  providerSpecificData?: { refreshLeadMs?: unknown } | null
+): number {
+  const override = providerSpecificData?.refreshLeadMs;
+  if (typeof override === "number" && Number.isFinite(override) && override > 0) {
+    return override;
+  }
   return REFRESH_LEAD_MS[provider] ?? TOKEN_EXPIRY_BUFFER_MS;
 }
 

--- a/src/sse/services/tokenRefresh.ts
+++ b/src/sse/services/tokenRefresh.ts
@@ -174,7 +174,7 @@ export async function checkAndRefreshToken(provider: string, credentials: any) {
   if (updatedCredentials.expiresAt) {
     const expiresAt = new Date(updatedCredentials.expiresAt).getTime();
     const now = Date.now();
-    const refreshLead = _getRefreshLeadMs(provider);
+    const refreshLead = _getRefreshLeadMs(provider, updatedCredentials.providerSpecificData);
 
     if (expiresAt - now < refreshLead) {
       log.info("TOKEN_REFRESH", "Token expiring soon, refreshing proactively", {

--- a/tests/unit/service-token-refresh.test.ts
+++ b/tests/unit/service-token-refresh.test.ts
@@ -17,6 +17,32 @@ describe("tokenRefresh helpers", () => {
       assert.equal(mod.getRefreshLeadMs("unknown-provider"), mod.TOKEN_EXPIRY_BUFFER_MS);
       assert.equal(mod.getRefreshLeadMs(""), mod.TOKEN_EXPIRY_BUFFER_MS);
     });
+
+    it("honors a positive per-connection refreshLeadMs override", () => {
+      // Override beats both the provider default and the fallback buffer.
+      assert.equal(mod.getRefreshLeadMs("codex", { refreshLeadMs: 90_000 }), 90_000);
+      assert.equal(
+        mod.getRefreshLeadMs("unknown-provider", { refreshLeadMs: 12_345 }),
+        12_345
+      );
+    });
+
+    it("ignores invalid or non-positive override values", () => {
+      // Falls through to provider default / buffer when the override is unusable.
+      assert.equal(mod.getRefreshLeadMs("codex", null), 5 * 60 * 1000);
+      assert.equal(mod.getRefreshLeadMs("codex", {}), 5 * 60 * 1000);
+      assert.equal(mod.getRefreshLeadMs("codex", { refreshLeadMs: 0 }), 5 * 60 * 1000);
+      assert.equal(mod.getRefreshLeadMs("codex", { refreshLeadMs: -1 }), 5 * 60 * 1000);
+      assert.equal(
+        mod.getRefreshLeadMs("codex", { refreshLeadMs: "60000" as unknown as number }),
+        5 * 60 * 1000
+      );
+      assert.equal(mod.getRefreshLeadMs("codex", { refreshLeadMs: NaN }), 5 * 60 * 1000);
+      assert.equal(
+        mod.getRefreshLeadMs("unknown-provider", { refreshLeadMs: -5 }),
+        mod.TOKEN_EXPIRY_BUFFER_MS
+      );
+    });
   });
 
   describe("supportsTokenRefresh", () => {


### PR DESCRIPTION
## Summary

- `getRefreshLeadMs()` now accepts an optional `providerSpecificData` argument and returns a positive numeric `providerSpecificData.refreshLeadMs` override before falling back to the per-provider `REFRESH_LEAD_MS` default and the 5-minute `TOKEN_EXPIRY_BUFFER_MS` buffer.
- The local `checkAndRefreshToken()` call site forwards `credentials.providerSpecificData`, so a single OAuth connection can tune how far ahead of expiry its access token is proactively refreshed without changing the shared provider defaults.
- Invalid / non-numeric / `NaN` / zero / negative overrides fall through to the existing behavior.

## Changes

- `open-sse/services/tokenRefresh.ts` — add the optional, guarded `providerSpecificData.refreshLeadMs` override to `getRefreshLeadMs()`.
- `src/sse/services/tokenRefresh.ts` — pass `updatedCredentials.providerSpecificData` at the refresh-lead call site.
- `tests/unit/service-token-refresh.test.ts` — cover honoring a positive override and ignoring invalid/non-positive values (fails before the helper change, passes after).

## Attribution

Thanks to [@anuragg-saxenaa](https://github.com/anuragg-saxenaa) for the original implementation.

## Test plan

- [x] `node --import tsx/esm --test tests/unit/service-token-refresh.test.ts` (14/14 pass; new cases fail without the fix)
- [x] `npm run typecheck:core`