### PR TITLE
fix(api): Docker-localhost hint on provider-node validation connection errors

### DIFF
--- a/src/app/api/provider-nodes/validate/route.ts
+++ b/src/app/api/provider-nodes/validate/route.ts
@@ -16,6 +16,48 @@ import { isCcCompatibleProviderEnabled } from "@/shared/utils/featureFlags";
 import { providerNodeValidateSchema } from "@/shared/validation/schemas";
 import { isValidationFailure, validateBody } from "@/shared/validation/helpers";
 
+// Matches a base URL whose host is localhost / 127.0.0.1 (with an optional port).
+const LOCALHOST_BASE_URL_RE = /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?(?:[/?#]|$)/i;
+
+// Extract the underlying network error code from a SafeOutboundFetchError chain.
+// safeOutboundFetch wraps fetch failures and preserves the original error as `cause`,
+// so a connection-refused surfaces as cause.code === "ECONNREFUSED".
+function getOutboundCauseCode(error: unknown): string | undefined {
+  const cause = (error as { cause?: unknown })?.cause;
+  if (cause && typeof cause === "object") {
+    const direct = (cause as { code?: unknown }).code;
+    if (typeof direct === "string") return direct;
+    const nested = (cause as { cause?: { code?: unknown } }).cause?.code;
+    if (typeof nested === "string") return nested;
+  }
+  return undefined;
+}
+
+// When a connection error happens against a localhost base URL, the most common
+// cause is running OmniRoute in Docker — `localhost` then points at the container,
+// not the host. Augment the surfaced message with an actionable hint in that case.
+// Ported from decolua/9router#642.
+export function augmentDockerLocalhostHint(
+  error: unknown,
+  baseUrl: string | undefined,
+  fallbackMessage: string
+): string {
+  if (!baseUrl || !LOCALHOST_BASE_URL_RE.test(baseUrl)) return fallbackMessage;
+
+  const code =
+    error instanceof SafeOutboundFetchError && error.code === "TIMEOUT"
+      ? "ETIMEDOUT"
+      : getOutboundCauseCode(error);
+
+  if (code === "ECONNREFUSED") {
+    return "Connection refused — are you running OmniRoute in Docker? localhost points to the container, not your host. Use your host IP (e.g. http://192.168.x.x:11434) or http://host.docker.internal:11434 on Linux/Mac.";
+  }
+  if (code === "ETIMEDOUT") {
+    return "Connection timeout — are you running OmniRoute in Docker? Use your host IP (e.g. http://192.168.x.x:11434) or http://host.docker.internal:11434 on Linux/Mac.";
+  }
+  return fallbackMessage;
+}
+
 function sanitizeAnthropicBaseUrl(baseUrl: string) {
   return (baseUrl || "")
     .trim()
@@ -212,18 +254,19 @@ export async function POST(request) {
     }
     return NextResponse.json({ valid: false, error: getModelsErrorMessage(res.status) });
   } catch (error) {
+    const attemptedBaseUrl =
+      rawBody && typeof rawBody === "object" && "baseUrl" in rawBody
+        ? String((rawBody as { baseUrl?: unknown }).baseUrl || "")
+        : "";
     const status = getSafeOutboundFetchErrorStatus(error);
     if (status) {
-      const message = error instanceof Error ? error.message : "Validation failed";
+      const rawMessage = error instanceof Error ? error.message : "Validation failed";
+      const message = augmentDockerLocalhostHint(error, attemptedBaseUrl, rawMessage);
       if (
         error instanceof SafeOutboundFetchError &&
         error.code === "URL_GUARD_BLOCKED" &&
         message.includes(PROVIDER_URL_BLOCKED_MESSAGE)
       ) {
-        const attemptedBaseUrl =
-          rawBody && typeof rawBody === "object" && "baseUrl" in rawBody
-            ? String((rawBody as { baseUrl?: unknown }).baseUrl || "")
-            : "";
         logAuditEvent({
           action: "provider.validation.ssrf_blocked",
           actor: "admin",
@@ -242,6 +285,7 @@ export async function POST(request) {
       return NextResponse.json({ error: message }, { status });
     }
     console.log("Error validating provider node:", error);
-    return NextResponse.json({ error: "Validation failed" }, { status: 500 });
+    const message = augmentDockerLocalhostHint(error, attemptedBaseUrl, "Validation failed");
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/tests/unit/provider-nodes-validate-docker-hint.test.ts
+++ b/tests/unit/provider-nodes-validate-docker-hint.test.ts
@@ -1,0 +1,95 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { augmentDockerLocalhostHint } from "../../src/app/api/provider-nodes/validate/route.ts";
+import { SafeOutboundFetchError } from "../../src/shared/network/safeOutboundFetch.ts";
+import { resetDbInstance } from "../../src/lib/db/core.ts";
+
+test.after(() => {
+  resetDbInstance();
+});
+
+function networkError(causeCode: string): SafeOutboundFetchError {
+  const err = new SafeOutboundFetchError("fetch failed", {
+    code: "NETWORK_ERROR",
+    url: "http://localhost:11434/models",
+    method: "GET",
+    attempts: 1,
+    isRetryable: true,
+    cause: { code: causeCode },
+  });
+  return err;
+}
+
+function timeoutError(): SafeOutboundFetchError {
+  return new SafeOutboundFetchError("The operation timed out", {
+    code: "TIMEOUT",
+    url: "http://localhost:11434/models",
+    method: "GET",
+    attempts: 1,
+    isRetryable: true,
+    timeoutMs: 10000,
+  });
+}
+
+const FALLBACK = "Validation failed";
+
+test("ECONNREFUSED against localhost surfaces a Docker host-IP hint", () => {
+  const message = augmentDockerLocalhostHint(
+    networkError("ECONNREFUSED"),
+    "http://localhost:11434",
+    FALLBACK
+  );
+  assert.match(message, /Connection refused/);
+  assert.match(message, /Docker/);
+  assert.match(message, /host\.docker\.internal/);
+  assert.notEqual(message, FALLBACK);
+});
+
+test("ECONNREFUSED against 127.0.0.1 surfaces the Docker hint", () => {
+  const message = augmentDockerLocalhostHint(
+    networkError("ECONNREFUSED"),
+    "http://127.0.0.1:11434/v1",
+    FALLBACK
+  );
+  assert.match(message, /Connection refused/);
+  assert.match(message, /Docker/);
+});
+
+test("TIMEOUT against localhost surfaces a Docker timeout hint", () => {
+  const message = augmentDockerLocalhostHint(timeoutError(), "https://localhost:8080", FALLBACK);
+  assert.match(message, /Connection timeout/);
+  assert.match(message, /Docker/);
+  assert.match(message, /host\.docker\.internal/);
+});
+
+test("connection error against a NON-localhost host keeps the original message", () => {
+  const message = augmentDockerLocalhostHint(
+    networkError("ECONNREFUSED"),
+    "http://192.168.1.50:11434",
+    FALLBACK
+  );
+  assert.equal(message, FALLBACK);
+});
+
+test("a localhost-substring host that is not actually localhost is not hinted", () => {
+  const message = augmentDockerLocalhostHint(
+    networkError("ECONNREFUSED"),
+    "http://localhost.evil.example.com:11434",
+    FALLBACK
+  );
+  assert.equal(message, FALLBACK);
+});
+
+test("a non-connection error against localhost keeps the original message", () => {
+  const message = augmentDockerLocalhostHint(
+    networkError("CERT_HAS_EXPIRED"),
+    "http://localhost:11434",
+    FALLBACK
+  );
+  assert.equal(message, FALLBACK);
+});
+
+test("a missing base URL keeps the original message", () => {
+  const message = augmentDockerLocalhostHint(networkError("ECONNREFUSED"), undefined, FALLBACK);
+  assert.equal(message, FALLBACK);
+});


### PR DESCRIPTION
## Summary

- When validating a provider node whose base URL is `localhost`/`127.0.0.1` and the connection is refused (`ECONNREFUSED`) or times out (`ETIMEDOUT`), the validation route now surfaces a Docker-aware hint instead of a generic error.
- The hint explains that inside a container `localhost` points at the container, not the host, and suggests the host IP or `http://host.docker.internal`.
- Pure, unit-tested helper (`augmentDockerLocalhostHint`) derived from the existing `SafeOutboundFetch` error code/cause; only triggers for genuine localhost base URLs (not `localhost.evil.example.com`).

## Attribution

Thanks to [@anuragg-saxenaa](https://github.com/anuragg-saxenaa) for the original implementation.

## Changes

- `src/app/api/provider-nodes/validate/route.ts`: add `augmentDockerLocalhostHint` and wire it into both the status (504 timeout) and generic 500 catch paths.
- `tests/unit/provider-nodes-validate-docker-hint.test.ts`: 7 cases (ECONNREFUSED/ETIMEDOUT vs localhost/127.0.0.1, non-localhost host, localhost-substring host, non-connection error, missing base URL).
- `CHANGELOG.md`: one bullet under 3.8.35.

## Test plan

- [x] `node --import tsx/esm --test tests/unit/provider-nodes-validate-docker-hint.test.ts` (7 pass)
- [x] `eslint` clean on changed files
- [x] `tsc --noEmit` clean