### PR TITLE
refactor(chatCore): extrai predicados puros de combo de compressão (#3501)

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -166,6 +166,11 @@ import {
   mergeResponseToolNameMap,
 } from "./chatCore/passthroughToolNames.ts";
 import { resolveCompressionSettings } from "./chatCore/compressionSettings.ts";
+import {
+  isBuiltinStackedPipeline,
+  isStackedCompressionCombo,
+  type RuntimeCompressionCombo,
+} from "./chatCore/compressionComboPredicates.ts";
 import { recordContextEditingTelemetryHook } from "./chatCore/contextEditingTelemetry.ts";
 import { recordCompressionCacheStats } from "./chatCore/compressionCacheStats.ts";
 import { writeCavemanOutputAnalytics } from "./chatCore/cavemanOutputAnalytics.ts";
@@ -908,27 +913,6 @@ export async function handleChatCore({
       }
       let compressionComboKey = comboName ?? null;
       let compressionComboApplied = false;
-      type RuntimeCompressionCombo = {
-        id: string;
-        pipeline: NonNullable<CompressionConfig["stackedPipeline"]>;
-        languagePacks: string[];
-        outputMode: boolean;
-        outputModeIntensity: string;
-      };
-      const isBuiltinStackedPipeline = (
-        pipeline: CompressionConfig["stackedPipeline"] | undefined
-      ): boolean => {
-        if (!Array.isArray(pipeline) || pipeline.length !== 2) return false;
-        const [first, second] = pipeline;
-        return (
-          first?.engine === "rtk" &&
-          (first.intensity === undefined || first.intensity === "standard") &&
-          !first.config &&
-          second?.engine === "caveman" &&
-          (second.intensity === undefined || second.intensity === "full") &&
-          !second.config
-        );
-      };
       const applyCompressionComboConfig = (
         compressionCombo: RuntimeCompressionCombo | null,
         routingOverrideIds: string[] = []
@@ -986,14 +970,6 @@ export async function handleChatCore({
         };
         compressionComboApplied = true;
         return true;
-      };
-      const isStackedCompressionCombo = (
-        compressionCombo: RuntimeCompressionCombo | null
-      ): compressionCombo is RuntimeCompressionCombo => {
-        // >= 1: a single-engine default combo (user enabled exactly one layer via the
-        // per-engine config page) must still apply. applyCompressionComboConfig already
-        // guards length === 0.
-        return Boolean(compressionCombo && compressionCombo.pipeline.length >= 1);
       };
       if (isCombo && comboName) {
         try {

--- a/open-sse/handlers/chatCore/compressionComboPredicates.ts
+++ b/open-sse/handlers/chatCore/compressionComboPredicates.ts
@@ -1,0 +1,41 @@
+/**
+ * chatCore compression-combo predicates (Quality Gate v2 / Fase 9 — chatCore god-file
+ * decomposition, #3501).
+ *
+ * Pure predicates extracted from handleChatCore's compression setup: detect the built-in
+ * RTK→caveman stacked pipeline and whether a runtime combo has at least one pipeline layer.
+ * No handler state is captured; behaviour is byte-identical to the previous inline closures.
+ */
+
+import type { CompressionConfig } from "../../services/compression/types.ts";
+
+export type RuntimeCompressionCombo = {
+  id: string;
+  pipeline: NonNullable<CompressionConfig["stackedPipeline"]>;
+  languagePacks: string[];
+  outputMode: boolean;
+  outputModeIntensity: string;
+};
+
+export function isBuiltinStackedPipeline(
+  pipeline: CompressionConfig["stackedPipeline"] | undefined
+): boolean {
+  if (!Array.isArray(pipeline) || pipeline.length !== 2) return false;
+  const [first, second] = pipeline;
+  return (
+    first?.engine === "rtk" &&
+    (first.intensity === undefined || first.intensity === "standard") &&
+    !first.config &&
+    second?.engine === "caveman" &&
+    (second.intensity === undefined || second.intensity === "full") &&
+    !second.config
+  );
+}
+
+export function isStackedCompressionCombo(
+  compressionCombo: RuntimeCompressionCombo | null
+): compressionCombo is RuntimeCompressionCombo {
+  // >= 1: a single-engine default combo (user enabled exactly one layer via the per-engine config
+  // page) must still apply. applyCompressionComboConfig already guards length === 0.
+  return Boolean(compressionCombo && compressionCombo.pipeline.length >= 1);
+}

--- a/tests/unit/chatcore-compression-combo-predicates.test.ts
+++ b/tests/unit/chatcore-compression-combo-predicates.test.ts
@@ -1,0 +1,64 @@
+// Characterization of the pure compression-combo predicates extracted from handleChatCore's
+// compression setup (chatCore god-file decomposition, #3501). No DB, no handler state.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+const { isBuiltinStackedPipeline, isStackedCompressionCombo } = await import(
+  "../../open-sse/handlers/chatCore/compressionComboPredicates.ts"
+);
+
+test("isBuiltinStackedPipeline true only for the rtk(standard)→caveman(full) shape", () => {
+  assert.equal(
+    isBuiltinStackedPipeline([{ engine: "rtk" }, { engine: "caveman" }] as never),
+    true
+  );
+  assert.equal(
+    isBuiltinStackedPipeline([
+      { engine: "rtk", intensity: "standard" },
+      { engine: "caveman", intensity: "full" },
+    ] as never),
+    true
+  );
+});
+
+test("isBuiltinStackedPipeline false for wrong length / engines / intensities / config", () => {
+  assert.equal(isBuiltinStackedPipeline(undefined), false);
+  assert.equal(isBuiltinStackedPipeline([] as never), false);
+  assert.equal(isBuiltinStackedPipeline([{ engine: "rtk" }] as never), false);
+  assert.equal(
+    isBuiltinStackedPipeline([{ engine: "caveman" }, { engine: "rtk" }] as never),
+    false
+  );
+  assert.equal(
+    isBuiltinStackedPipeline([
+      { engine: "rtk", intensity: "aggressive" },
+      { engine: "caveman", intensity: "full" },
+    ] as never),
+    false
+  );
+  assert.equal(
+    isBuiltinStackedPipeline([
+      { engine: "rtk", config: { x: 1 } },
+      { engine: "caveman" },
+    ] as never),
+    false
+  );
+});
+
+test("isStackedCompressionCombo true when the combo has >= 1 pipeline layer", () => {
+  assert.equal(isStackedCompressionCombo(null), false);
+  assert.equal(
+    isStackedCompressionCombo({ id: "c", pipeline: [], languagePacks: [], outputMode: false, outputModeIntensity: "full" } as never),
+    false
+  );
+  assert.equal(
+    isStackedCompressionCombo({
+      id: "c",
+      pipeline: [{ engine: "rtk" }],
+      languagePacks: [],
+      outputMode: false,
+      outputModeIntensity: "full",
+    } as never),
+    true
+  );
+});


### PR DESCRIPTION
## O quê

Decomposição do god-file `chatCore.ts` (#3501, novo plano — Bloco I). Extrai os **predicados puros de combo de compressão** do setup de `handleChatCore` para `chatCore/compressionComboPredicates.ts`.

## Como

`isBuiltinStackedPipeline(pipeline)` e `isStackedCompressionCombo(combo)` são **funções puras** (nenhum estado do handler capturado), mais o tipo `RuntimeCompressionCombo`. O `applyCompressionComboConfig` (que muta `config`) **permanece no handler** e importa o tipo de volta. Comportamento byte-idêntico.

## Validação (Rule #18 — TDD)

- **+3 caracterizações puras** (sem DB): o shape `rtk(standard)→caveman(full)` do built-in pipeline, rejeições por length/engine/intensity/config, e `>= 1` layer no combo.
- Suíte chatcore completa → **346 verde**.
- `typecheck:core` limpo; `eslint` 0; complexity por-arquivo OK.

## Estado dos gates

- `check:db-rules` **VERDE**.
- `check:complexity` — **1920 > baseline 1916** base-red (drift). Slice **delta-0** (predicados triviais).

## Impacto

`chatCore.ts` **−24 linhas**. Sem mudança de API/comportamento público.
