### PR TITLE
fix(sse): resolve bare model names to connection defaultModel before upstream calls

### DIFF
--- a/open-sse/services/model.ts
+++ b/open-sse/services/model.ts
@@ -148,6 +148,34 @@ export function resolveProviderAlias(aliasOrId: string | null | undefined): stri
   return ALIAS_TO_PROVIDER_ID[aliasOrId] || aliasOrId;
 }
 
+/**
+ * #474 — Resolve a bare model name to the selected connection's `defaultModel`.
+ *
+ * When the client requested a bare model name (no "/", e.g. an alias that
+ * resolved to "auto") and the chosen connection declares a `defaultModel`, the
+ * upstream provider must receive that concrete model ID instead of the
+ * placeholder. A "/"-qualified model name is an explicit provider/model choice
+ * and is always returned untouched.
+ *
+ * Pure function — `requestedModelStr` is the raw client-facing model string
+ * (used only to decide whether the name is "bare"); `resolvedModel` is the
+ * already-resolved model that would otherwise be sent upstream.
+ */
+export function resolveBareModelToConnectionDefault(
+  requestedModelStr: string | null | undefined,
+  resolvedModel: string | null | undefined,
+  connectionDefaultModel: string | null | undefined
+): string | null {
+  const fallback = typeof resolvedModel === "string" ? resolvedModel : null;
+  if (typeof requestedModelStr !== "string" || requestedModelStr.includes("/")) {
+    return fallback;
+  }
+  if (typeof connectionDefaultModel === "string" && connectionDefaultModel.length > 0) {
+    return connectionDefaultModel;
+  }
+  return fallback;
+}
+
 function isCrossProxyModelCompatEnabled() {
   const raw = process.env.MODEL_ALIAS_COMPAT_ENABLED;
   return raw !== "false" && raw !== "0";

--- a/src/lib/embeddings/service.ts
+++ b/src/lib/embeddings/service.ts
@@ -13,6 +13,7 @@ import { toJsonErrorPayload } from "@/shared/utils/upstreamError";
 import { getProviderCredentials, clearRecoveredProviderState } from "@/sse/services/auth";
 import { getProviderNodes, getComboByName, getCombos, getDatabaseSettings } from "@/lib/localDb";
 import { handleComboChat } from "@omniroute/open-sse/services/combo.ts";
+import { resolveBareModelToConnectionDefault } from "@omniroute/open-sse/services/model.ts";
 import { findEmbeddingComboDimensionConflict } from "./familyGuard";
 import { calculateCost } from "@/lib/usage/costCalculator";
 import { attachOmniRouteMetaHeaders } from "@/domain/omnirouteResponseMeta";
@@ -191,15 +192,29 @@ export async function createEmbeddingResponse(
     }
   }
 
+  // #474: when the request used a bare model name (no "/" — e.g. an alias that
+  // resolved to "auto") and the selected connection declares a defaultModel,
+  // resolve the bare name to that real model ID before the upstream call so the
+  // provider receives a concrete model. A "/"-qualified name is left untouched.
+  const connectionDefaultModel =
+    credentials && typeof (credentials as { defaultModel?: unknown }).defaultModel === "string"
+      ? ((credentials as { defaultModel?: string }).defaultModel as string)
+      : null;
+  const effectiveModel = resolveBareModelToConnectionDefault(
+    modelStr,
+    resolvedModel,
+    connectionDefaultModel
+  );
+
   const result = await handleEmbedding({
-    body,
+    body: effectiveModel !== resolvedModel ? { ...body, model: `${provider}/${effectiveModel}` } : body,
     // getProviderCredentials returns a richer connection object; handleEmbedding
     // only reads apiKey/accessToken, both present at runtime. Bridge the wider
     // selection type to the handler's narrow credential shape.
     credentials: credentials as { apiKey?: string; accessToken?: string } | null,
     log,
     resolvedProvider: providerConfig,
-    resolvedModel,
+    resolvedModel: effectiveModel,
     clientRawRequest: options.clientRawRequest || null,
     apiKeyId: options.apiKeyId || null,
     apiKeyName: options.apiKeyName || null,
@@ -212,10 +227,10 @@ export async function createEmbeddingResponse(
     if (credentials) await clearRecoveredProviderState(credentials);
     responseHeaders.set("Content-Type", "application/json");
     const usage = (result.data as { usage?: Record<string, number> })?.usage ?? null;
-    const costUsd = usage ? await calculateCost(provider, resolvedModel ?? "", usage) : 0;
+    const costUsd = usage ? await calculateCost(provider, effectiveModel ?? "", usage) : 0;
     attachOmniRouteMetaHeaders(responseHeaders, {
       provider,
-      model: resolvedModel,
+      model: effectiveModel,
       usage,
       costUsd,
       latencyMs: Date.now() - startTime,

--- a/src/sse/handlers/chat.ts
+++ b/src/sse/handlers/chat.ts
@@ -17,6 +17,7 @@ import {
   isDailyQuotaExhausted,
 } from "@omniroute/open-sse/services/accountFallback.ts";
 import { getModelInfo, getComboForModel } from "../services/model";
+import { resolveBareModelToConnectionDefault } from "@omniroute/open-sse/services/model.ts";
 import { errorResponse } from "@omniroute/open-sse/utils/error.ts";
 import { applyNoThinkingAlias } from "@omniroute/open-sse/utils/noThinkingAlias.ts";
 import { handleComboChat } from "@omniroute/open-sse/services/combo.ts";
@@ -1076,7 +1077,15 @@ async function handleSingleModelChat(
 
       const accountId = credentials.connectionId.slice(0, 8);
       log.info("AUTH", `Using ${provider} account: ${accountId}...`);
-      let requestBody = body;
+      // #474: when the request used a bare model name (no "/" — e.g. an alias
+      // that resolved to "auto") and the selected connection declares a
+      // defaultModel, resolve the bare name to that real model ID before the
+      // upstream call so the provider receives a concrete model rather than the
+      // placeholder. A "/"-qualified model name is always left untouched.
+      const effectiveModel =
+        resolveBareModelToConnectionDefault(modelStr, model, credentials.defaultModel) ?? model;
+      let requestBody =
+        effectiveModel !== model ? { ...body, model: `${provider}/${effectiveModel}` } : body;
       let injectedHandoff = null;
       if (
         comboStrategy === "context-relay" &&
@@ -1139,7 +1148,7 @@ async function handleSingleModelChat(
         breaker,
         body: requestBody,
         provider,
-        model,
+        model: effectiveModel,
         refreshedCredentials,
         proxyInfo,
         log,

--- a/src/sse/services/auth.ts
+++ b/src/sse/services/auth.ts
@@ -78,6 +78,7 @@ interface ProviderConnectionView {
   tokenExpiresAt: string | null;
   expiresAt: string | null;
   projectId: string | null;
+  defaultModel: string | null;
   providerSpecificData: JsonRecord;
   lastUsedAt: string | null;
   consecutiveUseCount: number;
@@ -171,6 +172,7 @@ function toProviderConnection(value: unknown): ProviderConnectionView {
     tokenExpiresAt: toStringOrNull(row.tokenExpiresAt),
     expiresAt: toStringOrNull(row.expiresAt),
     projectId: toStringOrNull(row.projectId),
+    defaultModel: toStringOrNull(row.defaultModel),
     providerSpecificData: asRecord(row.providerSpecificData),
     lastUsedAt: toStringOrNull(row.lastUsedAt),
     consecutiveUseCount: toNumber(row.consecutiveUseCount, 0),
@@ -787,6 +789,7 @@ function buildSyntheticNoAuthCredentials(providerSpecificData: JsonRecord = {}):
   refreshToken: null;
   expiresAt: null;
   projectId: null;
+  defaultModel: null;
   copilotToken: null;
   providerSpecificData: JsonRecord;
   connectionId: typeof SYNTHETIC_NOAUTH_CONNECTION_ID;
@@ -808,6 +811,7 @@ function buildSyntheticNoAuthCredentials(providerSpecificData: JsonRecord = {}):
     refreshToken: null,
     expiresAt: null,
     projectId: null,
+    defaultModel: null,
     copilotToken: null,
     providerSpecificData,
     connectionId: SYNTHETIC_NOAUTH_CONNECTION_ID,
@@ -1600,6 +1604,10 @@ export async function getProviderCredentials(
       refreshToken: connection.refreshToken,
       expiresAt: connection.tokenExpiresAt || connection.expiresAt || null,
       projectId: connection.projectId,
+      // #474: surface the connection's configured defaultModel so the chat /
+      // embeddings handlers can resolve a bare model name (e.g. an alias that
+      // resolved to "auto") to a real provider model ID before the upstream call.
+      defaultModel: connection.defaultModel || null,
       copilotToken:
         typeof connection.providerSpecificData.copilotToken === "string"
           ? connection.providerSpecificData.copilotToken

--- a/tests/unit/resolve-bare-model-to-connection-default-474.test.ts
+++ b/tests/unit/resolve-bare-model-to-connection-default-474.test.ts
@@ -1,0 +1,43 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { resolveBareModelToConnectionDefault } from "@omniroute/open-sse/services/model.ts";
+
+// #474 — When a bare model name (no "/") reaches the upstream call and the
+// selected connection declares a defaultModel, the bare name must resolve to
+// that real model ID. A "/"-qualified model name is an explicit provider/model
+// choice and must always be left untouched.
+
+test("bare model name resolves to the connection defaultModel", () => {
+  // "auto" came from an alias; the connection's defaultModel is the concrete ID.
+  const effective = resolveBareModelToConnectionDefault("auto", "auto", "gpt-4o-mini");
+  assert.equal(effective, "gpt-4o-mini");
+});
+
+test('"/"-qualified model name is left untouched even when a defaultModel exists', () => {
+  const effective = resolveBareModelToConnectionDefault(
+    "openai/gpt-4o",
+    "gpt-4o",
+    "gpt-4o-mini"
+  );
+  assert.equal(effective, "gpt-4o");
+});
+
+test("bare model name without a connection defaultModel falls back to the resolved model", () => {
+  assert.equal(resolveBareModelToConnectionDefault("auto", "auto", null), "auto");
+  assert.equal(resolveBareModelToConnectionDefault("auto", "auto", undefined), "auto");
+  assert.equal(resolveBareModelToConnectionDefault("auto", "auto", ""), "auto");
+});
+
+test("empty defaultModel string does not override the resolved model", () => {
+  assert.equal(resolveBareModelToConnectionDefault("auto", "resolved-auto", ""), "resolved-auto");
+});
+
+test("null/undefined requested model strings are treated as non-bare (no override)", () => {
+  assert.equal(resolveBareModelToConnectionDefault(null, "resolved", "default"), "resolved");
+  assert.equal(resolveBareModelToConnectionDefault(undefined, "resolved", "default"), "resolved");
+});
+
+test("null resolved model with no defaultModel returns null", () => {
+  assert.equal(resolveBareModelToConnectionDefault("auto", null, null), null);
+});


### PR DESCRIPTION
## Summary

- When a request uses a bare model name (no `/` — e.g. an alias that resolved to `auto`) and the selected connection declares a `defaultModel`, the bare name is now resolved to that real model ID **before** the upstream call, so the provider receives a concrete model instead of the placeholder.
- A `/`-qualified model name is an explicit `provider/model` choice and is always left untouched.
- Applies to both the chat path (`handleSingleModelChat`) and the embeddings path (`createEmbeddingResponse`).

## Changes

- `open-sse/services/model.ts`: new pure helper `resolveBareModelToConnectionDefault(requestedModelStr, resolvedModel, connectionDefaultModel)`.
- `src/sse/services/auth.ts`: surface the connection's `defaultModel` on the credentials object returned by `getProviderCredentials` (plus the `ProviderConnectionView` type and the synthetic no-auth credentials shape).
- `src/sse/handlers/chat.ts`: resolve the effective model after credential selection and pass it (and the rewritten body) to `executeChatWithBreaker`.
- `src/lib/embeddings/service.ts`: same resolution before dispatching to `handleEmbedding`, and report the effective model in cost + response-meta headers.
- `tests/unit/resolve-bare-model-to-connection-default-474.test.ts`: unit coverage for the helper (bare→default, `/`-qualified untouched, empty/null fallbacks).

## Attribution

Thanks to [@anuragg-saxenaa](https://github.com/anuragg-saxenaa) for the original implementation.

## Test plan

- [x] `node --import tsx/esm --test tests/unit/resolve-bare-model-to-connection-default-474.test.ts` (6/6 pass)
- [x] `npm run typecheck:core`
- [x] `npm run check:cycles`
- [x] ESLint on all touched files (0 errors)