### PR TITLE
fix(quota): cota exclusiva lista qtSd/ no /v1/models (#4806) + limite EPSILON não bloqueia

### DIFF
--- a/src/app/api/v1/models/catalog.ts
+++ b/src/app/api/v1/models/catalog.ts
@@ -1370,15 +1370,18 @@ export async function getUnifiedModelsResponse(
     if (apiKey) {
       const { isModelAllowedForKey, getApiKeyMetadata } = await import("@/lib/db/apiKeys");
 
-      // Quota-exclusive keys (allowedQuotas non-empty): show only the
-      // quotaShared-* virtual models for the key's assigned pools (Phase B3).
-      // This takes precedence over the normal allowedModels filter.
+      // Quota-exclusive keys (allowedQuotas non-empty): list ONLY the pool's qtSd/*
+      // virtual models. #4806: build from the hidden qtSd/* combos directly — the base
+      // `models` list drops hidden combos, so filtering it returned nothing (0 models).
       const keyMeta = await getApiKeyMetadata(apiKey);
       if (keyMeta && keyMeta.allowedQuotas && keyMeta.allowedQuotas.length > 0) {
-        const { resolveQuotaKeyScope } = await import("@/lib/quota/quotaKey");
-        const { filterModelsToQuotaPools } = await import("@/lib/quota/quotaCombos");
-        const scope = await resolveQuotaKeyScope(keyMeta.allowedQuotas);
-        finalModels = filterModelsToQuotaPools(models, scope.poolSlugs);
+        const { buildQuotaExclusiveModels } = await import("@/lib/quota/quotaCombos");
+        finalModels = await buildQuotaExclusiveModels(
+          keyMeta.allowedQuotas,
+          combos,
+          timestamp,
+          (c) => buildComboCatalogMetadata(c, combos)
+        );
       } else {
         const filtered = [];
         for (const m of models) {

--- a/src/lib/quota/enforce.ts
+++ b/src/lib/quota/enforce.ts
@@ -60,7 +60,10 @@ const COUNTABLE_UNITS = new Set(["requests", "tokens", "usd"]);
  */
 export async function enforceQuotaShare(input: EnforceInput): Promise<EnforceDecision> {
   // 1. Find pools that contain this apiKeyId.
-  let allocations: Array<{ poolId: string; allocation: import("@/lib/db/quotaPools").PoolAllocation }>;
+  let allocations: Array<{
+    poolId: string;
+    allocation: import("@/lib/db/quotaPools").PoolAllocation;
+  }>;
   try {
     allocations = listAllocationsForApiKey(input.apiKeyId);
   } catch {
@@ -129,6 +132,13 @@ export async function enforceQuotaShare(input: EnforceInput): Promise<EnforceDec
   const consumedByThisKey: Record<string, number> = {};
 
   for (const dim of plan.dimensions) {
+    // Skip placeholder dimensions whose limit is unknown (Number.EPSILON / 0 — the
+    // "configure manually" seed for glm/minimax/kimi-coding/deepseek in planRegistry.ts).
+    // An unconfigured limit is NOT a real cap: enforcing it would block every request
+    // after the first one, because decideFairShare's global-saturated gate fires as soon
+    // as consumedTotal exceeds ~EPSILON. The real cap kicks in once a limit is set via
+    // the Wizard "Limite" step (provider_plans override).
+    if (!(dim.limit > Number.EPSILON)) continue;
     const dimKey = { poolId: pool.id, unit: dim.unit, window: dim.window };
     const dimKeyStr = dimensionKeyToString(dimKey);
 
@@ -224,7 +234,10 @@ export async function enforceQuotaShare(input: EnforceInput): Promise<EnforceDec
  * Errors are swallowed (B29): the LLM response has already been delivered.
  */
 export async function recordConsumption(input: RecordConsumptionInput): Promise<void> {
-  let allocations: Array<{ poolId: string; allocation: import("@/lib/db/quotaPools").PoolAllocation }>;
+  let allocations: Array<{
+    poolId: string;
+    allocation: import("@/lib/db/quotaPools").PoolAllocation;
+  }>;
   try {
     allocations = listAllocationsForApiKey(input.apiKeyId);
   } catch {
@@ -288,10 +301,7 @@ function messageForReason(reason: string, provider: string): string {
   }
 }
 
-function costForUnit(
-  cost: RecordConsumptionInput["cost"],
-  unit: QuotaUnit
-): number {
+function costForUnit(cost: RecordConsumptionInput["cost"], unit: QuotaUnit): number {
   switch (unit) {
     case "tokens":
       return cost.tokens ?? 0;

--- a/src/lib/quota/quotaCombos.ts
+++ b/src/lib/quota/quotaCombos.ts
@@ -21,7 +21,12 @@ import {
   updateCombo,
 } from "@/lib/db/combos";
 import { REGISTRY } from "@omniroute/open-sse/config/providerRegistry";
-import { quotaModelName, parseQuotaModelName, isQuotaModelName, quotaGroupSlug } from "./quotaModelNaming";
+import {
+  quotaModelName,
+  parseQuotaModelName,
+  isQuotaModelName,
+  quotaGroupSlug,
+} from "./quotaModelNaming";
 import { createLogger } from "@/shared/utils/logger";
 
 const log = createLogger("quota/quotaCombos");
@@ -87,7 +92,11 @@ function getProviderModelIds(provider: string): string[] {
   const models = entry && Array.isArray(entry.models) ? entry.models : [];
   if (models.length === 0) return [];
   return models
-    .map((m) => (typeof m === "object" && m !== null && typeof (m as { id?: unknown }).id === "string" ? (m as { id: string }).id : null))
+    .map((m) =>
+      typeof m === "object" && m !== null && typeof (m as { id?: unknown }).id === "string"
+        ? (m as { id: string }).id
+        : null
+    )
     .filter((id): id is string => id !== null && id.length > 0);
 }
 
@@ -184,7 +193,12 @@ export async function syncQuotaCombos(poolId: string): Promise<void> {
     }));
     try {
       const existing = await getComboByName(comboName);
-      const payload = { name: comboName, models: steps, strategy: "fill-first" as const, isHidden: true };
+      const payload = {
+        name: comboName,
+        models: steps,
+        strategy: "fill-first" as const,
+        isHidden: true,
+      };
       if (existing && typeof existing.id === "string") await updateCombo(existing.id, payload);
       else await createCombo(payload);
     } catch (err) {
@@ -228,7 +242,10 @@ export async function syncQuotaCombos(poolId: string): Promise<void> {
       try {
         await deleteComboByName(name);
       } catch (err) {
-        log.warn({ err: (err as Error)?.message, comboName: name, poolId }, "quota-combo prune failed");
+        log.warn(
+          { err: (err as Error)?.message, comboName: name, poolId },
+          "quota-combo prune failed"
+        );
       }
     }
   }
@@ -262,6 +279,51 @@ export function filterModelsToQuotaPools<T extends { id: string }>(
 }
 
 /**
+ * #4806 — Build the /v1/models catalog list for a quota-exclusive API key.
+ *
+ * The pool's qtSd/<group>/<provider>/<model> combos are isHidden:true, so the
+ * base /v1/models list (which skips hidden combos) never contains them. Filtering
+ * that base list therefore returned nothing and clients (e.g. Claude Desktop)
+ * showed "0 modelo encontrado" once "Cota exclusiva" was enabled on the pool.
+ *
+ * This selects the (hidden) qtSd/* combos whose parsed group slug is in
+ * `poolSlugs` and maps each through `toEntry` — the catalog's own combo-entry
+ * builder — so it stays free of catalog-internal helpers and is unit-testable.
+ *
+ * Fail-closed: an empty `poolSlugs` array yields an empty list (a quota key with
+ * no resolvable pools sees no models).
+ */
+export async function buildQuotaExclusiveModels<TCombo extends { name?: unknown }>(
+  allowedQuotas: string[],
+  combos: TCombo[],
+  timestamp: number,
+  metadataFor: (combo: TCombo) => Record<string, unknown>
+): Promise<Array<Record<string, unknown>>> {
+  const { resolveQuotaKeyScope } = await import("./quotaKey");
+  const scope = await resolveQuotaKeyScope(allowedQuotas);
+  if (scope.poolSlugs.length === 0) return [];
+  const slugSet = new Set(scope.poolSlugs);
+  const out: Array<Record<string, unknown>> = [];
+  for (const combo of combos) {
+    const name = typeof combo.name === "string" ? combo.name : "";
+    if (!isQuotaModelName(name)) continue;
+    const parsed = parseQuotaModelName(name);
+    if (!parsed || !slugSet.has(parsed.groupSlug)) continue;
+    out.push({
+      id: name,
+      object: "model",
+      created: timestamp,
+      owned_by: "combo",
+      permission: [],
+      root: name,
+      parent: null,
+      ...metadataFor(combo),
+    });
+  }
+  return out;
+}
+
+/**
  * Delete ALL `quotaShared-*` combos that belong to the given pool.
  *
  * B4: scoped to this pool's group+provider so that removing one pool does not
@@ -290,7 +352,10 @@ export async function removeQuotaCombosForPool(poolId: string): Promise<void> {
   let poolProvider: string | undefined;
   for (const connId of pool.connectionIds) {
     try {
-      const connection = (await getProviderConnectionById(connId)) as Record<string, unknown> | null;
+      const connection = (await getProviderConnectionById(connId)) as Record<
+        string,
+        unknown
+      > | null;
       if (connection && typeof connection.provider === "string" && connection.provider.length > 0) {
         poolProvider = connection.provider;
         break;
@@ -309,7 +374,10 @@ export async function removeQuotaCombosForPool(poolId: string): Promise<void> {
   try {
     allCombos = await getCombos();
   } catch (err) {
-    log.warn({ err: (err as Error)?.message, poolId }, "removeQuotaCombosForPool: getCombos failed");
+    log.warn(
+      { err: (err as Error)?.message, poolId },
+      "removeQuotaCombosForPool: getCombos failed"
+    );
     return;
   }
 
@@ -328,7 +396,10 @@ export async function removeQuotaCombosForPool(poolId: string): Promise<void> {
     try {
       await deleteComboByName(name);
     } catch (err) {
-      log.warn({ err: (err as Error)?.message, comboName: name, poolId }, "quota-combo remove failed");
+      log.warn(
+        { err: (err as Error)?.message, comboName: name, poolId },
+        "quota-combo remove failed"
+      );
     }
   }
 }

--- a/tests/unit/quota-epsilon-unconfigured-allow.test.ts
+++ b/tests/unit/quota-epsilon-unconfigured-allow.test.ts
@@ -1,0 +1,98 @@
+/**
+ * tests/unit/quota-epsilon-unconfigured-allow.test.ts
+ *
+ * Bug: a quota pool whose provider plan carries a PLACEHOLDER limit
+ * (Number.EPSILON — glm / minimax / kimi-coding / deepseek in planRegistry.ts,
+ * meaning "limit unknown, set it manually in the Wizard 'Limite' step") blocks
+ * every request AFTER the first one.
+ *
+ * decideFairShare's global-saturated gate fires as soon as
+ *   consumedTotal >= effectiveLimit
+ * and effectiveLimit ≈ EPSILON, so ANY recorded consumption trips it — for hard,
+ * soft AND burst policies. planRegistry.ts documents the intent ("Sliding window /
+ * fair-share devem tratar limit=0 como 'manual obrigatório'") but enforce.ts never
+ * implemented the guard.
+ *
+ * Expected: an unconfigured (EPSILON) dimension is NOT enforced — the pool stays
+ * usable until a real limit is configured. Real limits still enforce normally
+ * (covered by quota-division-blocks.test.ts).
+ *
+ * Mirrors the SqliteQuotaStore + enforceQuotaShare integration setup from
+ * quota-division-blocks.test.ts.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-quota-epsilon-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const providersDb = await import("../../src/lib/db/providers.ts");
+const quotaPools = await import("../../src/lib/db/quotaPools.ts");
+const { SqliteQuotaStore } = await import("../../src/lib/quota/sqliteQuotaStore.ts");
+const { enforceQuotaShare } = await import("../../src/lib/quota/enforce.ts");
+const core = await import("../../src/lib/db/core.ts");
+
+test.after(() => {
+  core.resetDbInstance();
+  if (fs.existsSync(TEST_DATA_DIR)) {
+    try {
+      fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+});
+
+test("EPSILON (unconfigured) plan does not block after the first request", async () => {
+  const KEY = "key-eps";
+
+  // glm seeds tokens/5h + tokens/weekly with limit=Number.EPSILON (placeholder).
+  const conn = await providersDb.createProviderConnection({
+    provider: "glm",
+    authType: "apikey",
+    name: "quota-epsilon-glm",
+    apiKey: "sk-glm-epsilon",
+  });
+  const connId = (conn as Record<string, unknown>).id as string;
+  assert.ok(connId, "connection should have an id");
+
+  const pool = quotaPools.createPool({
+    connectionId: connId,
+    name: "EpsilonPool",
+    allocations: [{ apiKeyId: KEY, weight: 100, policy: "hard" }],
+  });
+
+  // First request: allowed (nothing consumed yet).
+  const first = await enforceQuotaShare({
+    apiKeyId: KEY,
+    connectionId: connId,
+    provider: "glm",
+    estimatedCost: { tokens: 5000 },
+  });
+  assert.equal(
+    first.kind,
+    "allow",
+    `first request should be allowed; got ${JSON.stringify(first)}`
+  );
+
+  // Record consumption on the EPSILON dimension (tokens/5h).
+  const store = new SqliteQuotaStore();
+  await store.consume(KEY, { poolId: pool.id, unit: "tokens", window: "5h" }, 5000);
+
+  // Second request: MUST still be allowed — an unconfigured EPSILON limit is not a real cap.
+  const second = await enforceQuotaShare({
+    apiKeyId: KEY,
+    connectionId: connId,
+    provider: "glm",
+    estimatedCost: { tokens: 5000 },
+  });
+  assert.equal(
+    second.kind,
+    "allow",
+    `unconfigured EPSILON plan must not block after the first request; got ${JSON.stringify(second)}`
+  );
+});

--- a/tests/unit/quota-exclusive-catalog-4806.test.ts
+++ b/tests/unit/quota-exclusive-catalog-4806.test.ts
@@ -1,0 +1,122 @@
+/**
+ * tests/unit/quota-exclusive-catalog-4806.test.ts
+ *
+ * Regression for #4806 — "[BUG] Cota Exclusiva: modelos virtuais param de
+ * listar após ativação".
+ *
+ * When an API key is scoped to a quota pool (allowedQuotas non-empty — the
+ * "Cota exclusiva" state), GET /v1/models must list that pool's
+ * qtSd/<group>/<provider>/<model> virtual models. Clients such as Claude
+ * Desktop build their model picker from /v1/models, so an empty list shows
+ * "0 modelo encontrado" and the key cannot be used.
+ *
+ * Root cause (before the fix): getUnifiedModelsResponse filtered the *base*
+ * catalog list with filterModelsToQuotaPools(), but the base list never
+ * contains qtSd/* combos — they are isHidden:true and skipped while the base
+ * list is built (catalog.ts: `if (combo.isHidden === true) continue;`). The
+ * filter only KEEPS qtSd/* names, so filtering a list that has none returns
+ * [] → 0 models for every quota-exclusive key.
+ *
+ * Uses "glm" as the provider because it has a small, stable model list in the
+ * static registry (same convention as quota-combos-sync.test.ts).
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-quota-exclusive-catalog-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.API_KEY_SECRET = process.env.API_KEY_SECRET || "quota-exclusive-catalog-secret";
+
+const core = await import("../../src/lib/db/core.ts");
+const apiKeysDb = await import("../../src/lib/db/apiKeys.ts");
+const poolsDb = await import("../../src/lib/db/quotaPools.ts");
+const groupsDb = await import("../../src/lib/db/quotaGroups.ts");
+const providersDb = await import("../../src/lib/db/providers.ts");
+const v1ModelsCatalog = await import("../../src/app/api/v1/models/catalog.ts");
+const { syncQuotaCombos } = await import("../../src/lib/quota/quotaCombos.ts");
+const { quotaGroupSlug, isQuotaModelName, parseQuotaModelName } =
+  await import("../../src/lib/quota/quotaModelNaming.ts");
+
+async function resetStorage() {
+  apiKeysDb.resetApiKeyState();
+  core.resetDbInstance();
+  for (let attempt = 0; attempt < 10; attempt++) {
+    try {
+      if (fs.existsSync(TEST_DATA_DIR)) {
+        fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+      }
+      break;
+    } catch (error: unknown) {
+      const err = error as NodeJS.ErrnoException;
+      if ((err?.code === "EBUSY" || err?.code === "EPERM") && attempt < 9) {
+        await new Promise((resolve) => setTimeout(resolve, 50 * (attempt + 1)));
+      } else {
+        throw error;
+      }
+    }
+  }
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+test.beforeEach(async () => {
+  await resetStorage();
+});
+
+test.after(async () => {
+  apiKeysDb.resetApiKeyState();
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("#4806 quota-exclusive key lists its qtSd/* virtual models in GET /v1/models", async () => {
+  // Group "Times" → slug "times"; combos will be qtSd/times/glm/<model>.
+  const group = groupsDb.createGroup("Times");
+
+  const conn = await providersDb.createProviderConnection({
+    provider: "glm",
+    authType: "apikey",
+    name: "quota-4806-glm",
+    apiKey: "sk-glm-4806",
+  });
+  const connId = (conn as Record<string, unknown>).id as string;
+  assert.ok(connId, "connection should have an id");
+
+  const pool = poolsDb.createPool({ connectionId: connId, name: "Times", groupId: group.id });
+  await syncQuotaCombos(pool.id); // mint the hidden qtSd/times/glm/* combos
+
+  // Make the key "quota exclusive" by scoping it to the pool.
+  const created = await apiKeysDb.createApiKey("Quota-4806 Key", "machine-4806");
+  await apiKeysDb.updateApiKeyPermissions(created.id, { allowedQuotas: [pool.id] });
+
+  const res = await v1ModelsCatalog.getUnifiedModelsResponse(
+    new Request("http://localhost/api/v1/models", {
+      headers: { Authorization: `Bearer ${created.key}` },
+    })
+  );
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as { data: Array<{ id: string }> };
+
+  const slug = quotaGroupSlug("Times"); // "times"
+  const qtsdForKey = body.data.filter(
+    (m) => isQuotaModelName(m.id) && parseQuotaModelName(m.id)?.groupSlug === slug
+  );
+
+  assert.ok(
+    qtsdForKey.length > 0,
+    `quota-exclusive key must see its qtSd/${slug}/glm/* models in /v1/models; ` +
+      `got ${body.data.length} total, ${qtsdForKey.length} qtSd. ` +
+      `ids=${JSON.stringify(body.data.map((m) => m.id).slice(0, 8))}`
+  );
+
+  // Every returned model must belong to the key's group (no leakage of other pools/raw models).
+  for (const m of body.data) {
+    assert.ok(
+      isQuotaModelName(m.id) && parseQuotaModelName(m.id)?.groupSlug === slug,
+      `quota-exclusive key should only see its own qtSd/${slug}/* models; leaked: ${m.id}`
+    );
+  }
+});

--- a/tests/unit/quota-exclusive-catalog-4806.test.ts
+++ b/tests/unit/quota-exclusive-catalog-4806.test.ts
@@ -120,3 +120,63 @@ test("#4806 quota-exclusive key lists its qtSd/* virtual models in GET /v1/model
     );
   }
 });
+
+test("#4806 quota-exclusive key does NOT see qtSd/* of a group it is not allocated to", async () => {
+  // Group A (glm) — the key's group.
+  const groupA = groupsDb.createGroup("Alpha");
+  const connA = await providersDb.createProviderConnection({
+    provider: "glm",
+    authType: "apikey",
+    name: "quota-4806-glm-a",
+    apiKey: "sk-glm-4806-a",
+  });
+  const poolA = poolsDb.createPool({
+    connectionId: (connA as Record<string, unknown>).id as string,
+    name: "Alpha",
+    groupId: groupA.id,
+  });
+  await syncQuotaCombos(poolA.id);
+
+  // Group B (codex) — a DIFFERENT group the key is NOT allocated to.
+  const groupB = groupsDb.createGroup("Beta");
+  const connB = await providersDb.createProviderConnection({
+    provider: "codex",
+    authType: "apikey",
+    name: "quota-4806-codex-b",
+    apiKey: "sk-codex-4806-b",
+  });
+  const poolB = poolsDb.createPool({
+    connectionId: (connB as Record<string, unknown>).id as string,
+    name: "Beta",
+    groupId: groupB.id,
+  });
+  await syncQuotaCombos(poolB.id);
+
+  // Key scoped ONLY to group A's pool.
+  const created = await apiKeysDb.createApiKey("Quota-4806 Key A", "machine-4806-a");
+  await apiKeysDb.updateApiKeyPermissions(created.id, { allowedQuotas: [poolA.id] });
+
+  const res = await v1ModelsCatalog.getUnifiedModelsResponse(
+    new Request("http://localhost/api/v1/models", {
+      headers: { Authorization: `Bearer ${created.key}` },
+    })
+  );
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as { data: Array<{ id: string }> };
+
+  const slugA = quotaGroupSlug("Alpha");
+  const slugB = quotaGroupSlug("Beta");
+
+  assert.ok(
+    body.data.some((m) => parseQuotaModelName(m.id)?.groupSlug === slugA),
+    "key must see its own group A qtSd/* models"
+  );
+  const leakedFromB = body.data.filter((m) => parseQuotaModelName(m.id)?.groupSlug === slugB);
+  assert.equal(
+    leakedFromB.length,
+    0,
+    `key in group A must NOT see group B (${slugB}) models; leaked: ${JSON.stringify(
+      leakedFromB.map((m) => m.id)
+    )}`
+  );
+});


### PR DESCRIPTION
## Resumo

Dois defeitos na feature **Quota Share** (Compartilhamento de Cota) que, juntos, faziam a "chave exclusiva de cota" não funcionar de ponta a ponta. Diagnóstico confirmado lendo o código e reproduzido por testes (TDD).

## Fix 1 — Cota exclusiva retornava 0 modelos no `/v1/models` (#4806)

**Sintoma (issue #4806):** ao ativar **"Cota exclusiva"** num pool, os modelos virtuais `qtSd/` somem do `GET /v1/models` → o Claude Desktop mostra "0 modelo encontrado".

**Causa raiz:** os combos `qtSd/<grupo>/<provider>/<model>` são `isHidden:true` e são descartados ao montar a lista base do catálogo (`catalog.ts`: `if (combo.isHidden === true) continue`). O branch da chave exclusiva fazia `filterModelsToQuotaPools(models, …)`, mas `models` nunca continha nenhum `qtSd/` → o filtro (que só mantém nomes `qtSd/`) sempre retornava `[]`. Por isso "antes funcionava" (chave normal vê o catálogo) e "zerava após ativar a cota exclusiva".

**Fix:** o branch da chave exclusiva agora monta os modelos diretamente a partir dos combos `qtSd/` (incluindo os hidden) do escopo do grupo, via a nova helper pura `buildQuotaExclusiveModels()` em `quotaCombos.ts`. Combos hidden seguem ocultos para chaves normais e para o catálogo público. Resolvido por **extração** — `catalog.ts` continua sob o teto de file-size, sem rebaseline.

## Fix 2 — Limite placeholder (EPSILON) bloqueava após a 1ª request

**Sintoma:** pools de `glm` / `minimax` / `kimi-coding` / `deepseek` (cujo limite real é desconhecido e fica como `Number.EPSILON` em `planRegistry.ts` até config manual) retornavam `429 "quota window is saturated"` a partir da 2ª request.

**Causa raiz:** o gate `global-saturated` do `decideFairShare` dispara assim que `consumedTotal >= effectiveLimit`, e `effectiveLimit ≈ EPSILON` → qualquer consumo bloqueia (hard, soft **e** burst). O `planRegistry` documentava a intenção ("tratar limit=0 como manual obrigatório") mas `enforce.ts` nunca implementou a guarda.

**Fix:** `enforce.ts` pula dimensões com `limit <= EPSILON` (placeholder não-enforçável) — o pool fica utilizável até um limite real ser configurado no passo "Limite" do Wizard. Limites reais seguem enforçados normalmente.

## Validação (Hard Rule #18 — TDD)

- `tests/unit/quota-exclusive-catalog-4806.test.ts` — integração `GET /v1/models` com chave exclusiva: **falha antes** (0 modelos), **passa depois**; valida que a chave vê apenas os `qtSd/` do seu grupo (sem vazar outros pools nem modelos crus).
- `tests/unit/quota-epsilon-unconfigured-allow.test.ts` — **falha antes** (block na 2ª request), **passa depois** (allow).
- Regressão: **65/65** testes de quota / catálogo / enforce / fair-share / combos / policy verdes (inclui `quota-division-blocks` provando que limites reais continuam bloqueando).
- `typecheck:core` ✓ · `eslint` ✓ · `check:file-size` ✓.

Fixes #4806.
