### PR TITLE
refactor(chatCore): extrai buildPostCallGuardrailContext (contexto guardrail post-call, #3501)

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -6,6 +6,7 @@ export { extractSystemRoleMessages } from "./chatCore/claudeSystemRole.ts";
 import { checkIdempotencyCache } from "./chatCore/idempotency.ts";
 import { checkSemanticCache } from "./chatCore/semanticCache.ts";
 import { applyClientUsageBuffer } from "./chatCore/clientUsageBuffer.ts";
+import { buildPostCallGuardrailContext } from "./chatCore/postCallGuardrailContext.ts";
 import { sanitizeChatRequestBody } from "./chatCore/sanitization.ts";
 import {
   getHeaderValueCaseInsensitive,
@@ -200,7 +201,7 @@ import { getModelNormalizeToolCallId, getModelPreserveOpenAIDeveloperRole } from
 import { getProviderCredentials, extractSessionAffinityKey } from "@/sse/services/auth";
 import { deleteSessionAccountAffinity } from "@/lib/db/sessionAccountAffinity";
 import { getCacheControlSettings } from "@/lib/cacheControlSettings";
-import { guardrailRegistry, resolveDisabledGuardrails } from "@/lib/guardrails";
+import { guardrailRegistry } from "@/lib/guardrails";
 import { shouldPreserveCacheControl } from "../utils/cacheControlPolicy.ts";
 import { getCachedSettings } from "@/lib/db/readCache";
 import { applyCodexGlobalFastServiceTier } from "@/lib/providers/codexFastTier";
@@ -3503,23 +3504,16 @@ export async function handleChatCore({
       );
     }
 
-    const guardrailContext = {
+    const guardrailContext = buildPostCallGuardrailContext({
       apiKeyInfo,
-      disabledGuardrails: resolveDisabledGuardrails({
-        apiKeyInfo: (apiKeyInfo as Record<string, unknown> | null) ?? null,
-        body,
-        headers: (clientRawRequest?.headers as Headers | Record<string, unknown> | null) ?? null,
-      }),
-      endpoint: clientRawRequest?.endpoint || null,
-      headers: (clientRawRequest?.headers as Headers | Record<string, unknown> | null) ?? null,
+      body,
+      clientRawRequest,
       log,
-      method: "POST",
       model,
       provider,
-      sourceFormat: responsePayloadFormat,
-      stream: false,
-      targetFormat: clientResponseFormat,
-    } as const;
+      responsePayloadFormat,
+      clientResponseFormat,
+    });
     const postCallGuardrails = await guardrailRegistry.runPostCallHooks(
       translatedResponse,
       guardrailContext

--- a/open-sse/handlers/chatCore/postCallGuardrailContext.ts
+++ b/open-sse/handlers/chatCore/postCallGuardrailContext.ts
@@ -1,0 +1,47 @@
+/**
+ * chatCore post-call guardrail context builder (Quality Gate v2 / Fase 9 — chatCore god-file
+ * decomposition, #3501).
+ *
+ * Extracted from handleChatCore's non-streaming success path: assemble the context object passed to
+ * `guardrailRegistry.runPostCallHooks`. Pure value builder — no side effects, no early-returns. The
+ * `disabledGuardrails` field is resolved via `resolveDisabledGuardrails` (injectable for tests).
+ * Behaviour is byte-identical to the previous inline literal, including the `method: "POST"` /
+ * `stream: false` constants and the headers/endpoint null-coalescing.
+ */
+import { resolveDisabledGuardrails as defaultResolveDisabled } from "@/lib/guardrails";
+
+type LoggerLike = unknown;
+type HeadersLike = Headers | Record<string, unknown> | null;
+
+export function buildPostCallGuardrailContext(
+  args: {
+    apiKeyInfo: unknown;
+    body: unknown;
+    clientRawRequest: { headers?: unknown; endpoint?: unknown } | null | undefined;
+    log?: LoggerLike;
+    model: string | null | undefined;
+    provider: string | null | undefined;
+    responsePayloadFormat: unknown;
+    clientResponseFormat: unknown;
+  },
+  resolveDisabledGuardrails: typeof defaultResolveDisabled = defaultResolveDisabled
+) {
+  const headers = (args.clientRawRequest?.headers as HeadersLike) ?? null;
+  return {
+    apiKeyInfo: args.apiKeyInfo,
+    disabledGuardrails: resolveDisabledGuardrails({
+      apiKeyInfo: (args.apiKeyInfo as Record<string, unknown> | null) ?? null,
+      body: args.body,
+      headers,
+    }),
+    endpoint: args.clientRawRequest?.endpoint || null,
+    headers,
+    log: args.log,
+    method: "POST",
+    model: args.model,
+    provider: args.provider,
+    sourceFormat: args.responsePayloadFormat,
+    stream: false,
+    targetFormat: args.clientResponseFormat,
+  } as const;
+}

--- a/tests/unit/chatcore-postcall-guardrail-context.test.ts
+++ b/tests/unit/chatcore-postcall-guardrail-context.test.ts
@@ -1,0 +1,72 @@
+// Characterization of buildPostCallGuardrailContext — the context object passed to
+// guardrailRegistry.runPostCallHooks, extracted from handleChatCore (chatCore god-file
+// decomposition, #3501). resolveDisabledGuardrails is injected so the mapping is observable in
+// isolation. Locks: the field mapping (sourceFormat/targetFormat), the constants (method "POST",
+// stream false), endpoint/headers null-coalescing, and that disabled-resolution gets apiKeyInfo/
+// body/headers.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+const { buildPostCallGuardrailContext } = await import(
+  "../../open-sse/handlers/chatCore/postCallGuardrailContext.ts"
+);
+
+function baseArgs(overrides: Record<string, unknown> = {}) {
+  return {
+    apiKeyInfo: { id: "key-1" },
+    body: { messages: [] },
+    clientRawRequest: { headers: { "x-test": "1" }, endpoint: "/v1/chat/completions" },
+    log: { tag: "log" },
+    model: "gpt-x",
+    provider: "openai",
+    responsePayloadFormat: "openai",
+    clientResponseFormat: "claude",
+    ...overrides,
+  } as Parameters<typeof buildPostCallGuardrailContext>[0];
+}
+
+test("maps fields, constants, and source/target formats", () => {
+  const seen: unknown[] = [];
+  const ctx = buildPostCallGuardrailContext(baseArgs(), (arg: unknown) => {
+    seen.push(arg);
+    return ["g1"];
+  });
+  assert.equal(ctx.method, "POST");
+  assert.equal(ctx.stream, false);
+  assert.equal(ctx.model, "gpt-x");
+  assert.equal(ctx.provider, "openai");
+  assert.equal(ctx.sourceFormat, "openai");
+  assert.equal(ctx.targetFormat, "claude");
+  assert.equal(ctx.endpoint, "/v1/chat/completions");
+  assert.deepEqual(ctx.disabledGuardrails, ["g1"]);
+  // resolveDisabledGuardrails received apiKeyInfo/body/headers
+  assert.deepEqual(seen[0], {
+    apiKeyInfo: { id: "key-1" },
+    body: { messages: [] },
+    headers: { "x-test": "1" },
+  });
+});
+
+test("null clientRawRequest → endpoint/headers null", () => {
+  const ctx = buildPostCallGuardrailContext(baseArgs({ clientRawRequest: null }), () => []);
+  assert.equal(ctx.endpoint, null);
+  assert.equal(ctx.headers, null);
+});
+
+test("missing endpoint → null (|| null), headers passes through", () => {
+  const ctx = buildPostCallGuardrailContext(
+    baseArgs({ clientRawRequest: { headers: { a: "b" } } }),
+    () => []
+  );
+  assert.equal(ctx.endpoint, null);
+  assert.deepEqual(ctx.headers, { a: "b" });
+});
+
+test("null apiKeyInfo coalesces to null for resolveDisabledGuardrails", () => {
+  let received: { apiKeyInfo?: unknown } = {};
+  buildPostCallGuardrailContext(baseArgs({ apiKeyInfo: null }), (arg: { apiKeyInfo?: unknown }) => {
+    received = arg;
+    return [];
+  });
+  assert.equal(received.apiKeyInfo, null);
+});


### PR DESCRIPTION
## O quê

Quality Gate v2 / Fase 9 — decomposição do god-file `chatCore.ts` (#3501).

Extrai o builder do **`guardrailContext`** (objeto passado a `guardrailRegistry.runPostCallHooks`) de `handleChatCore` para um leaf novo `open-sse/handlers/chatCore/postCallGuardrailContext.ts` → `buildPostCallGuardrailContext(args, resolveDisabledGuardrails?)`.

- **Valor puro** — sem side-effects, sem early-returns. Mapeamento byte-idêntico ao literal `as const` inline (incluindo `method: "POST"` / `stream: false` e o coalescing de `endpoint`/`headers`).
- O `headers` era computado **duas vezes** idênticas no literal original (arg de `resolveDisabledGuardrails` + campo `headers`) → hoisted para um único `const` (mesmo valor, DRY).
- `resolveDisabledGuardrails` injetável para caracterização isolada; removido do import do handler (agora sem uso lá — sobra só `guardrailRegistry`).

`chatCore.ts`: 4199 → 4193 (−6).

## Testes

`tests/unit/chatcore-postcall-guardrail-context.test.ts` (4 casos): mapeamento de campos/constantes/source-target + args repassados a `resolveDisabledGuardrails`; `clientRawRequest` null → endpoint/headers null; endpoint ausente → null com headers passando; `apiKeyInfo` null → coalesce a null.

## Validação

- `node --test chatcore-postcall-guardrail-context.test.ts` → 4/4 ✔
- Suíte `chatcore-*` completa → 347/347 ✔, 0 fail
- `typecheck:core` limpo
- `eslint` (leaf + handler + teste) limpo; complexity por-arquivo limpo
- `check:file-size` OK; `check:db-rules` OK
- complexity full-gate: base-red pré-existente `1920 > 1916` (delta-0; não reconciliado — no-merge-meddling)

Independente das outras fatias abertas (região non-streaming, arquivo novo distinto).
