### PR TITLE
refactor(chatCore): extrai assembleStreamingPipeline (chain de transforms streaming, #3501)

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -12,6 +12,7 @@ import { buildNonStreamingResponseHeaders } from "./chatCore/nonStreamingRespons
 import { maybeConvertJsonBodyToSse } from "./chatCore/jsonBodyToSse.ts";
 import { assembleStreamingResponseHeaders } from "./chatCore/streamingResponseHeaders.ts";
 import { storeStreamingSemanticCacheResponse } from "./chatCore/streamingSemanticCacheStore.ts";
+import { assembleStreamingPipeline } from "./chatCore/streamingPipeline.ts";
 import { sanitizeChatRequestBody } from "./chatCore/sanitization.ts";
 import {
   getHeaderValueCaseInsensitive,
@@ -71,9 +72,10 @@ import {
 } from "../utils/stream.ts";
 import { ensureStreamReadiness } from "../utils/streamReadiness.ts";
 import { resolveStreamReadinessTimeout } from "../utils/streamReadinessPolicy.ts";
-import { createStreamController, pipeWithDisconnect } from "../utils/streamHandler.ts";
+import { createStreamController } from "../utils/streamHandler.ts";
 import * as streamFailure from "../utils/streamFailureFinalization.ts";
 import { createSseHeartbeatTransform, shapeForClientFormat } from "../utils/sseHeartbeat.ts";
+import { addBufferToUsage, filterUsageForFormat, estimateUsage } from "../utils/usageTracking.ts";
 import {
   refreshWithRetry,
   isUnrecoverableRefreshError,
@@ -91,7 +93,7 @@ import {
 import { resolveModelAlias } from "../services/modelDeprecation.ts";
 import { normalizeMimoThinking } from "../services/mimoThinking.ts";
 import { normalizeClaudeAdaptiveThinking } from "../services/claudeAdaptiveThinking.ts";
-import { echoModelInObject, createModelEchoTransform } from "../services/responseModelEcho.ts";
+import { echoModelInObject } from "../services/responseModelEcho.ts";
 import { stripGpt5SamplingWhenReasoning } from "../services/gpt5SamplingGuard.ts";
 import { getUnsupportedParams } from "../config/providerRegistry.ts";
 import { supportsMaxTokens } from "@/lib/modelCapabilities.ts";
@@ -112,7 +114,6 @@ import {
   HTTP_STATUS,
   FETCH_BODY_TIMEOUT_MS,
   PROVIDER_MAX_TOKENS,
-  SSE_HEARTBEAT_INTERVAL_MS,
   STREAM_IDLE_TIMEOUT_MS,
   STREAM_READINESS_TIMEOUT_MS,
   ANTIGRAVITY_PRE_RESPONSE_TIMEOUT_CODE,
@@ -247,9 +248,6 @@ import {
   isCacheableForWrite,
 } from "@/lib/semanticCache";
 import { saveIdempotency } from "@/lib/idempotencyLayer";
-import { createProgressTransform, wantsProgress } from "../utils/progressTracker.ts";
-import { createPiiSseTransform } from "@/lib/streamingPiiTransform";
-import { isFeatureFlagEnabled } from "@/shared/utils/featureFlags";
 import {
   isModelUnavailableError,
   getNextFamilyFallback,
@@ -3943,36 +3941,16 @@ export async function handleChatCore({
     );
   }
 
-  // ── Phase 9.3: Progress tracking (opt-in) ──
-  const progressEnabled = wantsProgress(clientRawRequest?.headers);
-  let finalStream;
-
-  let piiStream = pipeWithDisconnect(providerResponse, transformStream, streamController);
-  if (typeof createPiiTransform === "function") {
-    piiStream = piiStream.pipeThrough((createPiiTransform as () => TransformStream)());
-  } else if (isFeatureFlagEnabled("PII_RESPONSE_SANITIZATION")) {
-    piiStream = piiStream.pipeThrough(createPiiSseTransform());
-  }
-
-  if (progressEnabled) {
-    const progressTransform = createProgressTransform({ signal: streamController.signal });
-    // Chain: provider → transform → progress → client
-    finalStream = piiStream.pipeThrough(progressTransform);
-    responseHeaders[OMNIROUTE_RESPONSE_HEADERS.progress] = "enabled";
-  } else {
-    finalStream = piiStream;
-  }
-  finalStream = finalStream.pipeThrough(
-    createSseHeartbeatTransform({
-      signal: streamController.signal,
-      intervalMs: SSE_HEARTBEAT_INTERVAL_MS,
-      shape: shapeForClientFormat(clientResponseFormat),
-    })
-  );
-  // #1311: echo the requested alias/combo name in each streamed SSE chunk's model field.
-  if (echoModel) {
-    finalStream = finalStream.pipeThrough(createModelEchoTransform(echoModel));
-  }
+  const finalStream = assembleStreamingPipeline({
+    providerResponse,
+    transformStream,
+    streamController,
+    createPiiTransform,
+    clientRawRequestHeaders: clientRawRequest?.headers,
+    clientResponseFormat,
+    echoModel,
+    responseHeaders,
+  });
 
   // ── Gamification event (fire-and-forget) ──
   await emitRequestGamificationEvent({ apiKeyId: apiKeyInfo?.id, model, provider });

--- a/open-sse/handlers/chatCore/streamingPipeline.ts
+++ b/open-sse/handlers/chatCore/streamingPipeline.ts
@@ -1,0 +1,99 @@
+/**
+ * chatCore streaming response pipeline assembly (Quality Gate v2 / Fase 9 — chatCore god-file
+ * decomposition, #3501).
+ *
+ * Extracted from handleChatCore's streaming success path: chain the response transforms onto the
+ * provider stream — disconnect-aware pipe → PII sanitization (explicit transform or feature-flagged
+ * SSE transform) → optional progress tracking (Phase 9.3) → SSE heartbeat → optional model-echo
+ * (#1311). Returns the assembled `finalStream`; mutates the passed `responseHeaders` to add the
+ * progress marker when progress is enabled. Behaviour is byte-identical to the previous inline
+ * block, including the exact transform order and branch conditions.
+ */
+import { pipeWithDisconnect as defaultPipeWithDisconnect } from "../../utils/streamHandler.ts";
+import {
+  createSseHeartbeatTransform as defaultHeartbeat,
+  shapeForClientFormat as defaultShape,
+} from "../../utils/sseHeartbeat.ts";
+import { createModelEchoTransform as defaultModelEcho } from "../../services/responseModelEcho.ts";
+import {
+  createProgressTransform as defaultProgress,
+  wantsProgress as defaultWantsProgress,
+} from "../../utils/progressTracker.ts";
+import { createPiiSseTransform as defaultPiiSse } from "@/lib/streamingPiiTransform";
+import { isFeatureFlagEnabled as defaultFeatureFlag } from "@/shared/utils/featureFlags";
+import { OMNIROUTE_RESPONSE_HEADERS } from "@/shared/constants/headers";
+import { SSE_HEARTBEAT_INTERVAL_MS } from "../../config/constants.ts";
+
+type HeadersLike = Headers | Record<string, unknown> | null | undefined;
+
+export interface StreamingPipelineDeps {
+  wantsProgress: typeof defaultWantsProgress;
+  pipeWithDisconnect: typeof defaultPipeWithDisconnect;
+  isFeatureFlagEnabled: typeof defaultFeatureFlag;
+  createPiiSseTransform: typeof defaultPiiSse;
+  createProgressTransform: typeof defaultProgress;
+  createSseHeartbeatTransform: typeof defaultHeartbeat;
+  shapeForClientFormat: typeof defaultShape;
+  createModelEchoTransform: typeof defaultModelEcho;
+}
+
+const DEFAULT_DEPS: StreamingPipelineDeps = {
+  wantsProgress: defaultWantsProgress,
+  pipeWithDisconnect: defaultPipeWithDisconnect,
+  isFeatureFlagEnabled: defaultFeatureFlag,
+  createPiiSseTransform: defaultPiiSse,
+  createProgressTransform: defaultProgress,
+  createSseHeartbeatTransform: defaultHeartbeat,
+  shapeForClientFormat: defaultShape,
+  createModelEchoTransform: defaultModelEcho,
+};
+
+export function assembleStreamingPipeline(
+  args: {
+    providerResponse: unknown;
+    transformStream: unknown;
+    streamController: { signal: AbortSignal };
+    createPiiTransform: unknown;
+    clientRawRequestHeaders: HeadersLike;
+    clientResponseFormat: unknown;
+    echoModel: string | null | undefined;
+    responseHeaders: Record<string, string>;
+  },
+  deps: StreamingPipelineDeps = DEFAULT_DEPS
+) {
+  // ── Phase 9.3: Progress tracking (opt-in) ──
+  const progressEnabled = deps.wantsProgress(args.clientRawRequestHeaders);
+  let finalStream;
+
+  let piiStream = deps.pipeWithDisconnect(
+    args.providerResponse,
+    args.transformStream,
+    args.streamController
+  );
+  if (typeof args.createPiiTransform === "function") {
+    piiStream = piiStream.pipeThrough((args.createPiiTransform as () => TransformStream)());
+  } else if (deps.isFeatureFlagEnabled("PII_RESPONSE_SANITIZATION")) {
+    piiStream = piiStream.pipeThrough(deps.createPiiSseTransform());
+  }
+
+  if (progressEnabled) {
+    const progressTransform = deps.createProgressTransform({ signal: args.streamController.signal });
+    // Chain: provider → transform → progress → client
+    finalStream = piiStream.pipeThrough(progressTransform);
+    args.responseHeaders[OMNIROUTE_RESPONSE_HEADERS.progress] = "enabled";
+  } else {
+    finalStream = piiStream;
+  }
+  finalStream = finalStream.pipeThrough(
+    deps.createSseHeartbeatTransform({
+      signal: args.streamController.signal,
+      intervalMs: SSE_HEARTBEAT_INTERVAL_MS,
+      shape: deps.shapeForClientFormat(args.clientResponseFormat),
+    })
+  );
+  // #1311: echo the requested alias/combo name in each streamed SSE chunk's model field.
+  if (args.echoModel) {
+    finalStream = finalStream.pipeThrough(deps.createModelEchoTransform(args.echoModel));
+  }
+  return finalStream;
+}

--- a/tests/unit/chatcore-streaming-pipeline.test.ts
+++ b/tests/unit/chatcore-streaming-pipeline.test.ts
@@ -1,0 +1,102 @@
+// Characterization of assembleStreamingPipeline — the streaming transform-chain assembly extracted
+// from handleChatCore's streaming success path (chatCore god-file decomposition, #3501). All
+// transform factories are injected; a fake "stream" records each pipeThrough so the exact chain
+// order and the branch conditions (PII explicit vs feature-flag, progress, echo) are observable
+// without real ReadableStreams. Locks: transform order, the progress header side-effect, and the
+// PII branch precedence (explicit createPiiTransform wins over the feature flag).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+const { assembleStreamingPipeline } = await import(
+  "../../open-sse/handlers/chatCore/streamingPipeline.ts"
+);
+
+// A fake stream: each pipeThrough appends the transform's tag and returns a new fake stream.
+function fakeStream(tag: string, log: string[]) {
+  return {
+    tag,
+    pipeThrough(t: { __tag: string }) {
+      log.push(t.__tag);
+      return fakeStream(t.__tag, log);
+    },
+  };
+}
+
+function makeDeps(over: Record<string, unknown> = {}) {
+  const log: string[] = [];
+  const deps = {
+    wantsProgress: () => false,
+    pipeWithDisconnect: (..._a: unknown[]) => fakeStream("pii-base", log),
+    isFeatureFlagEnabled: () => false,
+    createPiiSseTransform: () => ({ __tag: "pii-flag" }),
+    createProgressTransform: () => ({ __tag: "progress" }),
+    createSseHeartbeatTransform: () => ({ __tag: "heartbeat" }),
+    shapeForClientFormat: (f: unknown) => f,
+    createModelEchoTransform: () => ({ __tag: "echo" }),
+    ...over,
+  } as Parameters<typeof assembleStreamingPipeline>[1];
+  return { deps, log };
+}
+
+function baseArgs(over: Record<string, unknown> = {}) {
+  return {
+    providerResponse: {},
+    transformStream: {},
+    streamController: { signal: {} as AbortSignal },
+    createPiiTransform: undefined,
+    clientRawRequestHeaders: null,
+    clientResponseFormat: "openai",
+    echoModel: null,
+    responseHeaders: {} as Record<string, string>,
+    ...over,
+  } as Parameters<typeof assembleStreamingPipeline>[0];
+}
+
+test("baseline (no pii, no progress, no echo) → only heartbeat in the chain", () => {
+  const { deps, log } = makeDeps();
+  assembleStreamingPipeline(baseArgs(), deps);
+  assert.deepEqual(log, ["heartbeat"]);
+});
+
+test("feature-flag PII → pii-flag transform applied before heartbeat", () => {
+  const { deps, log } = makeDeps({ isFeatureFlagEnabled: () => true });
+  assembleStreamingPipeline(baseArgs(), deps);
+  assert.deepEqual(log, ["pii-flag", "heartbeat"]);
+});
+
+test("explicit createPiiTransform wins over the feature flag", () => {
+  const { deps, log } = makeDeps({ isFeatureFlagEnabled: () => true });
+  const explicit = () => ({ __tag: "pii-explicit" });
+  assembleStreamingPipeline(baseArgs({ createPiiTransform: explicit }), deps);
+  assert.deepEqual(log, ["pii-explicit", "heartbeat"]);
+});
+
+test("progress enabled → progress transform + progress header set", () => {
+  const { deps, log } = makeDeps({ wantsProgress: () => true });
+  const args = baseArgs();
+  assembleStreamingPipeline(args, deps);
+  assert.deepEqual(log, ["progress", "heartbeat"]);
+  assert.ok(Object.values(args.responseHeaders).includes("enabled"));
+});
+
+test("progress disabled → no progress header", () => {
+  const { deps } = makeDeps({ wantsProgress: () => false });
+  const args = baseArgs();
+  assembleStreamingPipeline(args, deps);
+  assert.deepEqual(args.responseHeaders, {});
+});
+
+test("echoModel set → echo transform applied last", () => {
+  const { deps, log } = makeDeps();
+  assembleStreamingPipeline(baseArgs({ echoModel: "alias-x" }), deps);
+  assert.deepEqual(log, ["heartbeat", "echo"]);
+});
+
+test("full chain order: pii → progress → heartbeat → echo", () => {
+  const { deps, log } = makeDeps({
+    isFeatureFlagEnabled: () => true,
+    wantsProgress: () => true,
+  });
+  assembleStreamingPipeline(baseArgs({ echoModel: "alias-x" }), deps);
+  assert.deepEqual(log, ["pii-flag", "progress", "heartbeat", "echo"]);
+});


### PR DESCRIPTION
## O quê

Quality Gate v2 / Fase 9 — decomposição do god-file `chatCore.ts` (#3501). **Fatia grande (−24).**

Extrai o **assembly do pipeline de transforms da resposta streaming** (Phase 9.3) de `handleChatCore` para um leaf novo `open-sse/handlers/chatCore/streamingPipeline.ts` → `assembleStreamingPipeline(args, deps?)`.

Encadeamento preservado byte-a-byte: `pipeWithDisconnect` → PII (transform explícito OU `createPiiSseTransform` por feature-flag, com o explícito tendo precedência) → progress opcional (seta o header `progress`) → SSE heartbeat → model-echo opcional (#1311). Retorna o `finalStream`; muta o `responseHeaders` passado para o header de progress.

- 6 imports ficaram órfãos no handler após a extração e foram removidos (preservando símbolos co-importados ainda usados — `createStreamController`, `echoModelInObject`): `wantsProgress`, `pipeWithDisconnect`, `createPiiSseTransform`, `createProgressTransform`, `createSseHeartbeatTransform`, `shapeForClientFormat`, `createModelEchoTransform`, `isFeatureFlagEnabled`, `SSE_HEARTBEAT_INTERVAL_MS`. (Importante: eram **warnings** de no-unused — removê-los evita regressão no ratchet de eslint.)
- Todas as factories de transform são `deps` injetáveis → caracterização da ordem do chain e dos branches **sem ReadableStream real**.

`chatCore.ts`: 4207 → 4183 (−24).

## Testes

`tests/unit/chatcore-streaming-pipeline.test.ts` (7 casos) com um "stream" falso que registra cada `pipeThrough`: baseline (só heartbeat); PII por feature-flag; explícito vence o flag; progress → transform+header; sem progress → sem header; echo por último; e a ordem completa `pii → progress → heartbeat → echo`.

## Validação

- `node --test chatcore-streaming-pipeline.test.ts` → 7/7 ✔
- Suíte `chatcore-*` completa → 350/350 ✔, 0 fail
- `typecheck:core` limpo; 0 refs órfãs dos símbolos removidos
- `eslint` (leaf + handler + teste) limpo; complexity por-arquivo limpo
- `check:file-size` OK; `check:db-rules` OK
- complexity full-gate: VERDE (baseline 1920)

Independente das outras fatias abertas (região de finalização streaming, após o callback onStreamComplete).
