### PR TITLE
fix(compression): eliminate ReDoS in math_inline preservation pattern (#4795)

### DIFF
--- a/open-sse/services/compression/preservation.ts
+++ b/open-sse/services/compression/preservation.ts
@@ -92,7 +92,14 @@ export function extractPreservedBlocks(
   const builtIns: CompiledPattern[] = [
     { pattern: /\$\$[\s\S]*?\$\$/g, kind: "math_block" },
     { pattern: /\\\[[\s\S]*?\\\]/g, kind: "math_block" },
-    { pattern: /(?<!\$)\$(?![\s$\d])(?:\\.|[^$\n]){1,160}?(?<!\s)\$(?!\$)/g, kind: "math_inline" },
+    // #4795: exclude `\` from the catch-all branch so a backslash is only ever
+    // consumed by the escape branch `\\.`. The previous `[^$\n]` overlapped with
+    // `\\.`, making a run of consecutive backslashes (e.g. unmatched `$` + a
+    // Windows path) exponentially ambiguous → catastrophic backtracking (ReDoS).
+    {
+      pattern: /(?<!\$)\$(?![\s$\d])(?:\\.|[^$\n\\]){1,160}?(?<!\s)\$(?!\$)/g,
+      kind: "math_inline",
+    },
     { pattern: /\\begin\{[A-Za-z*]+\}[\s\S]*?\\end\{[A-Za-z*]+\}/g, kind: "latex_block" },
     { pattern: /^#{1,6}\s+.+$/gm, kind: "markdown_heading" },
     { pattern: /^\s*\|.*\|\s*$/gm, kind: "markdown_table" },

--- a/tests/unit/compression/preservation-redos-4795.test.ts
+++ b/tests/unit/compression/preservation-redos-4795.test.ts
@@ -1,0 +1,59 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  extractPreservedBlocks,
+  restorePreservedBlocks,
+} from "../../../open-sse/services/compression/preservation.ts";
+
+// Regression guard for #4795: a single unmatched `$` followed by a run of
+// consecutive backslashes (e.g. Windows paths pasted into a prompt) triggered
+// catastrophic backtracking in the `math_inline` built-in pattern, pinning one
+// CPU core at 100% and freezing the event loop. The alternation
+// `(?:\\.|[^$\n])` was ambiguous: a backslash could be consumed either by the
+// escape branch `\\.` or by the catch-all `[^$\n]`, so a run of N backslashes
+// could be tiled exponentially many ways before the trailing `$` anchor failed.
+describe("preservation ReDoS guard (#4795)", () => {
+  it("does not hang on a `$` followed by many consecutive backslashes (no closing `$`)", () => {
+    // Without the fix this blows up exponentially (N=38 already exceeds 8s).
+    const evil = "$x" + "\\".repeat(200) + "y";
+    const start = Date.now();
+    const { text } = extractPreservedBlocks(evil);
+    const elapsed = Date.now() - start;
+    assert.ok(
+      elapsed < 1000,
+      `extractPreservedBlocks must not backtrack catastrophically (took ${elapsed}ms)`
+    );
+    // The pathological input is not valid inline math, so it stays untouched.
+    assert.equal(text, evil, "non-math text must be returned unchanged");
+  });
+
+  it("does not hang on Windows-path-style payloads with backslashes after a `$`", () => {
+    const evil =
+      "$C:\\Users\\Alpha\\Net\\DESKTOP\\" + "sub\\".repeat(120) + "no-closing-dollar";
+    const start = Date.now();
+    extractPreservedBlocks(evil);
+    assert.ok(Date.now() - start < 1000, "Windows-path payload must resolve quickly");
+  });
+
+  it("still preserves legitimate inline math", () => {
+    const text = "The identity $E=mc^2$ and $\\alpha + \\beta$ are classics.";
+    const { text: extracted, blocks } = extractPreservedBlocks(text);
+    const mathBlocks = blocks.filter((b) => b.kind === "math_inline");
+    assert.equal(mathBlocks.length, 2, "both inline-math spans must be preserved");
+    assert.ok(!extracted.includes("E=mc^2"), "math content must be replaced by a placeholder");
+    assert.equal(
+      restorePreservedBlocks(extracted, blocks),
+      text,
+      "round-trip must reproduce the original text"
+    );
+  });
+
+  it("preserves inline math that contains an escaped dollar", () => {
+    const text = "Price math: $a \\$ b$ end.";
+    const { blocks } = extractPreservedBlocks(text);
+    assert.ok(
+      blocks.some((b) => b.kind === "math_inline" && b.content === "$a \\$ b$"),
+      "inline math with an escaped dollar must still be captured via the `\\.` branch"
+    );
+  });
+});


### PR DESCRIPTION
Closes #4795

## Problem

A single unmatched `$` followed by a run of consecutive backslashes (e.g. a Windows path like `C:\Users\Alpha\Net\...` pasted into a prompt) with no closing `$` triggers **catastrophic backtracking** in the `math_inline` built-in pattern of `open-sse/services/compression/preservation.ts`. This pins one CPU core at 100% and freezes the Node.js event loop, making the server unresponsive to all HTTP/SSE traffic (and, under PM2, leaving a zombie holding port 20128 → `EADDRINUSE` on restart).

## Root cause

```
/(?<!\$)\$(?![\s$\d])(?:\\.|[^$\n]){1,160}?(?<!\s)\$(?!\$)/g
```

The alternation `(?:\\.|[^$\n])` is **ambiguous**: a `\` can be consumed either by the escape branch `\\.` or by the catch-all `[^$\n]`. A run of N consecutive backslashes can therefore be tiled exponentially many ways before the trailing `$` anchor fails → exponential backtracking.

Measured on the unfixed regex: N=34 backslashes ≈ 1.8 s, N≥38 exceeds 8 s and keeps doubling.

## Fix

One-character change: exclude `\` from the catch-all branch (`[^$\n]` → `[^$\n\\]`) so a backslash is only ever consumed by `\\.`. This removes the overlap and makes the match linear. Aligns with the repo's documented **Regex Security (ReDoS)** rule in `CLAUDE.md` (strictly bounded, non-overlapping sequences).

- Malicious input now resolves in **0 ms** (validated up to 200 backslashes).
- Legitimate inline math is unaffected: `$E=mc^2$`, `$\alpha + \beta$`, and escaped-dollar math `$a \$ b$` still preserve correctly and round-trip.

## Validation (Hard Rule #18 — TDD)

New regression test `tests/unit/compression/preservation-redos-4795.test.ts`:
- **fails (hangs → timeout)** on the unfixed code;
- **passes** after the fix (4/4), each pathological case resolving in < 8 ms.

Suites run green: the new test, `caveman-preservation` + compression `validation` (16/16), `typecheck:core`, ESLint, and `check:file-size`.

> Leaving this PR **open** for review/approval in the next version, per maintainer request.
