### PR TITLE
fix(build): trace-include sql.js sql-wasm.wasm in standalone bundle

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -146,6 +146,10 @@ const nextConfig = {
       "./open-sse/services/compression/rules/**/*.json",
       "./open-sse/lib/sha3_wasm_bg.wasm",
       "./open-sse/lib/deepseek-pow-solver.cjs",
+      // sql.js WASM is loaded at runtime by the sqljsAdapter fallback tier
+      // (better-sqlite3 → node:sqlite → sql.js). Next traces sql-wasm.js but can
+      // omit the runtime sql-wasm.wasm asset from the standalone bundle.
+      "./node_modules/sql.js/dist/sql-wasm.wasm",
     ],
   },
   outputFileTracingExcludes: {

--- a/tests/unit/next-config.test.ts
+++ b/tests/unit/next-config.test.ts
@@ -77,6 +77,13 @@ test("next config declares Turbopack aliases, runtime assets and server external
     tracingIncludes.includes("./open-sse/services/compression/engines/rtk/filters/**/*.json")
   );
   assert.ok(tracingIncludes.includes("./open-sse/services/compression/rules/**/*.json"));
+  // sql.js WASM must ship in the standalone bundle: sqljsAdapter resolves it from
+  // node_modules/sql.js/dist/sql-wasm.wasm at runtime (driver fallback tier), but
+  // Next traces sql-wasm.js without auto-including the runtime .wasm asset.
+  assert.ok(
+    tracingIncludes.includes("./node_modules/sql.js/dist/sql-wasm.wasm"),
+    "sql-wasm.wasm must be trace-included so the sql.js fallback works in standalone builds"
+  );
   assert.ok(tracingExcludes.includes("./_tasks/**/*"));
   assert.ok(tracingExcludes.includes("./tests/**/*"));
 


### PR DESCRIPTION
## Summary

- The `sqljsAdapter` SQLite fallback tier (better-sqlite3 → node:sqlite → sql.js) resolves `node_modules/sql.js/dist/sql-wasm.wasm` at runtime, but Next traces the `sql-wasm.js` loader without auto-including the runtime `.wasm` asset in the standalone bundle.
- Add `./node_modules/sql.js/dist/sql-wasm.wasm` to `outputFileTracingIncludes` so the fallback works in standalone builds when neither native SQLite driver is available — the same missing-asset class already handled for `sha3_wasm_bg.wasm` and the migration SQL files.

## Changes

- `next.config.mjs` — add the sql.js WASM to `outputFileTracingIncludes`.
- `tests/unit/next-config.test.ts` — assert the WASM path is trace-included (fails before, passes after).
- `CHANGELOG.md` — one bug-fix bullet.

## Test plan

- [x] `node --import tsx/esm --test tests/unit/next-config.test.ts` (4/4 pass; the new assertion fails without the prod change)

## Attribution

Thanks to [@Delcado19](https://github.com/Delcado19) for the original implementation.