### PR TITLE
fix(cli): save runtime deps with --save-exact so a sibling install can't prune them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ _In development — bullets added per PR; finalized at release._
 
 ### 🔧 Bug Fixes
 
+- **cli(runtime)**: persist the lazily-installed native runtime deps (`better-sqlite3`, `systray2`) to the shared runtime `package.json` with `--save-exact` instead of `--no-save`, so installing one no longer prunes the other as "extraneous" — fixing a "No SQLite driver available" failure after a `--tray` install (thanks @omartuhintvs).
+
 - **pricing**: add the `MiniMax-M3` cost row (canonical + lowercase alias) so the new MiniMax default model gets accurate per-request cost accounting instead of falling back to a zero/default rate (thanks @octo-patch).
 
 - **fix(sse):** Kiro tool-schema sanitizer — strip unsupported JSON-Schema keywords (`anyOf`/`$ref`/`if`-`then`, etc.) and hash-truncate tool names >64 chars before dispatch, mapping the streamed tool-call name back for the client, so Kiro no longer rejects tool calls with `400 "Improperly formed request"`. (thanks @smarthomeblack)

--- a/bin/cli/runtime/nativeDeps.mjs
+++ b/bin/cli/runtime/nativeDeps.mjs
@@ -79,7 +79,18 @@ export function isBetterSqliteBinaryValid() {
 
 export function npmInstallRuntime(pkgs, opts = {}) {
   const cwd = ensureRuntimeDir();
-  const npmArgs = ["install", ...pkgs, "--no-audit", "--no-fund", "--prefer-online", "--no-save"];
+  // Persist to the runtime package.json (exact version) instead of --no-save so a later
+  // install of a sibling runtime dep (e.g. systray2 from trayRuntime.ts, which writes to the
+  // same runtime dir) does not prune this package as "extraneous" — that pruning otherwise
+  // reproduces "No SQLite driver available" after a tray install removes better-sqlite3.
+  const npmArgs = [
+    "install",
+    ...pkgs,
+    "--no-audit",
+    "--no-fund",
+    "--prefer-online",
+    "--save-exact",
+  ];
   // On Windows .cmd files cannot be executed without a shell; use cmd.exe /c explicitly
   // so we never set shell:true (which would propagate env and enable injection).
   const isWin = platform() === "win32";

--- a/bin/cli/runtime/trayRuntime.ts
+++ b/bin/cli/runtime/trayRuntime.ts
@@ -83,8 +83,12 @@ function isInstalled(): boolean {
 }
 
 function installSystray(): void {
+  // --save-exact persists systray2 to the runtime package.json so installing it does not
+  // prune a sibling runtime dep (e.g. better-sqlite3 from nativeDeps.mjs, which writes to the
+  // same runtime dir) as "extraneous", and so the tray dep survives a later sibling install.
+  // Without it, a sibling install reproduces "No SQLite driver available".
   execSync(
-    `npm install --prefix "${RUNTIME_DIR}" ${SYSTRAY_SPEC} --no-audit --no-fund --silent`,
+    `npm install --prefix "${RUNTIME_DIR}" ${SYSTRAY_SPEC} --no-audit --no-fund --save-exact --silent`,
     { stdio: ["ignore", "ignore", "pipe"], timeout: 120_000 }
   );
 }

--- a/tests/unit/runtime-deps-save-exact-no-prune.test.ts
+++ b/tests/unit/runtime-deps-save-exact-no-prune.test.ts
@@ -1,0 +1,88 @@
+// Regression (port of decolua/9router#1606): the SQLite and tray runtime installers
+// must persist their package to the user-writable runtime dir's package.json
+// (`--save-exact`) instead of using `--no-save`. Both installers write to the SAME
+// runtime dir (`~/.omniroute/runtime`), so a `--no-save` install marks the other's
+// package as "extraneous" and a later sibling `npm install` prunes it — reproducing
+// "No SQLite driver available" after a tray install removes the just-installed
+// better-sqlite3. Saving each dep with an exact version keeps both.
+//
+// Instead of mocking child_process, we put a fake `npm` on PATH that records its
+// arguments to a log file and exits 0. This exercises the real spawnSync/execSync
+// code path with zero network use.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, chmodSync, existsSync, readFileSync } from "node:fs";
+import { join, delimiter } from "node:path";
+import { tmpdir } from "node:os";
+
+let tmpDir: string;
+let binDir: string;
+let logFile: string;
+const original = {
+  DATA_DIR: process.env.DATA_DIR,
+  HOME: process.env.HOME,
+  PATH: process.env.PATH,
+};
+
+function setup(): void {
+  tmpDir = mkdtempSync(join(tmpdir(), "omniroute-runtime-deps-"));
+  binDir = join(tmpDir, "bin");
+  logFile = join(tmpDir, "npm-calls.log");
+  mkdirSync(binDir, { recursive: true });
+  // Fake npm: append its args to the log and succeed without doing anything.
+  const npmStub = join(binDir, "npm");
+  writeFileSync(npmStub, `#!/bin/sh\necho "$@" >> "${logFile}"\nexit 0\n`);
+  chmodSync(npmStub, 0o755);
+
+  // nativeDeps.mjs resolves the runtime dir from DATA_DIR; trayRuntime.ts from HOME.
+  process.env.DATA_DIR = tmpDir;
+  process.env.HOME = tmpDir;
+  process.env.PATH = `${binDir}${delimiter}${original.PATH}`;
+}
+
+function teardown(): void {
+  for (const [k, v] of Object.entries(original)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
+}
+
+function installLineFor(pkgPrefix: string): string | undefined {
+  if (!existsSync(logFile)) return undefined;
+  return readFileSync(logFile, "utf8")
+    .split("\n")
+    .find((line) => line.includes("install") && line.includes(pkgPrefix));
+}
+
+test("npmInstallRuntime saves better-sqlite3 with --save-exact (never --no-save)", async (t) => {
+  if (process.platform === "win32") return; // sh stub is POSIX-only
+  setup();
+  t.after(teardown);
+
+  const { npmInstallRuntime } = await import("../../bin/cli/runtime/nativeDeps.mjs");
+  const ok = npmInstallRuntime(["better-sqlite3@12.9.0"], { silent: true });
+  assert.equal(ok, true, "fake npm should exit 0");
+
+  const line = installLineFor("better-sqlite3");
+  assert.ok(line, "expected an npm install for better-sqlite3");
+  assert.ok(!line!.includes("--no-save"), "must not use --no-save (prunes sibling runtime dep)");
+  assert.ok(line!.includes("--save-exact"), "must persist with --save-exact");
+});
+
+test("installSystray saves systray2 with --save-exact (never --no-save)", async (t) => {
+  if (process.platform === "win32") return; // loadSystray returns null on win32
+  setup();
+  t.after(teardown);
+
+  // loadSystray() lazily installs systray2 (when not already present) then tries to
+  // import it. The import fails against our fake npm (no real module), returning null —
+  // but the fake npm has already recorded the install args, which is what we assert on.
+  const { loadSystray } = await import("../../bin/cli/runtime/trayRuntime.ts");
+  await loadSystray();
+
+  const line = installLineFor("systray2");
+  assert.ok(line, "expected an npm install for systray2");
+  assert.ok(!line!.includes("--no-save"), "must not use --no-save (prunes sibling runtime dep)");
+  assert.ok(line!.includes("--save-exact"), "must persist with --save-exact");
+});


### PR DESCRIPTION
## Summary

- The SQLite (`bin/cli/runtime/nativeDeps.mjs`) and tray (`bin/cli/runtime/trayRuntime.ts`) runtime installers both write to the **same** user-writable runtime dir (`~/.omniroute/runtime`) but installed their package without saving it (`--no-save` for SQLite, no save flag for tray).
- npm therefore treats each package as "extraneous" against the shared runtime `package.json`, so a later **sibling** install prunes the previously-installed dep — reproducing **"No SQLite driver available"** after a `--tray` install removes the just-installed `better-sqlite3`.
- Both installers now persist with `--save-exact`, so each lazily-installed native dep is recorded in the runtime `package.json` and survives a sibling install.

## Attribution

Thanks to [@omartuhintvs](https://github.com/omartuhintvs) for the original implementation.

## Changes

- `bin/cli/runtime/nativeDeps.mjs`: `npmInstallRuntime` swaps `--no-save` for `--save-exact`.
- `bin/cli/runtime/trayRuntime.ts`: `installSystray` adds `--save-exact`.
- `tests/unit/runtime-deps-save-exact-no-prune.test.ts`: fake-npm-on-PATH regression test (fails before, passes after) asserting both installers use `--save-exact` and never `--no-save`.

## Test plan

- [x] `node --import tsx/esm --test tests/unit/runtime-deps-save-exact-no-prune.test.ts` (fails before the fix, passes after)
- [x] runtime-adjacent suites green (`cli-runtime`, `cli-tray`, `dev-ensure-native-sqlite` — 26/26)