### PR TITLE
fix(sse): sanitize Kiro tool schemas to avoid 400 "Improperly formed request"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ _In development — bullets added per PR; finalized at release._
 
 ### 🔧 Bug Fixes
 
+- **fix(sse):** Kiro tool-schema sanitizer — strip unsupported JSON-Schema keywords (`anyOf`/`$ref`/`if`-`then`, etc.) and hash-truncate tool names >64 chars before dispatch, mapping the streamed tool-call name back for the client, so Kiro no longer rejects tool calls with `400 "Improperly formed request"`. (thanks @smarthomeblack)
+
 - **sse**: make the `anthropic-version` default-guard case-insensitive for `anthropic-compatible-*` providers, so a caller/operator-supplied `Anthropic-Version` (any casing) is no longer clobbered by a second lowercase `anthropic-version: 2023-06-01` header. (thanks @zakirkun)
 
 - **huggingface**: validate API tokens via the `whoami-v2` endpoint as a pure auth probe so fine-grained Inference-Provider tokens (valid even when model/task endpoints reject them) are no longer falsely marked invalid; only 401/403 means an invalid key, other non-OK statuses surface as transient upstream errors. (thanks @Delcado19)

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -64,6 +64,7 @@ import { resolveChatCoreTargetFormat } from "./chatCore/targetFormat.ts";
 import { injectSystemPrompt, injectCustomSystemPrompt } from "../services/systemPrompt.ts";
 import { translateRequest, needsTranslation } from "../translator/index.ts";
 import { FORMATS } from "../translator/formats.ts";
+import { sanitizeKiroTools } from "../utils/kiroSanitizer.ts";
 import { splitMisplacedToolResults } from "../translator/helpers/claudeHelper.ts";
 import {
   createSSETransformStreamWithLogger,
@@ -1769,6 +1770,30 @@ export async function handleChatCore({
   }
 
   trace("post_translation");
+
+  // Kiro: sanitize tool schemas before dispatch. Kiro returns 400 "Improperly
+  // formed request" for unsupported JSON-Schema keywords (anyOf/$ref/if-then,
+  // etc.) and tool names >64 chars. Strip those keys and hash-truncate long
+  // names; merge the truncated→original nameMap into the existing
+  // `_toolNameMap` so kiro-to-openai maps streamed tool-call names back (#1375).
+  if (targetFormat === FORMATS.KIRO) {
+    const kiroTools =
+      translatedBody?.conversationState?.currentMessage?.userInputMessage
+        ?.userInputMessageContext?.tools;
+    if (kiroTools) {
+      const { tools: sanitizedKiroTools, nameMap: kiroNameMap } = sanitizeKiroTools(kiroTools);
+      translatedBody.conversationState.currentMessage.userInputMessage.userInputMessageContext.tools =
+        sanitizedKiroTools;
+      if (kiroNameMap.size > 0) {
+        const existing =
+          translatedBody._toolNameMap instanceof Map
+            ? translatedBody._toolNameMap
+            : new Map<string, string>();
+        kiroNameMap.forEach((original, truncated) => existing.set(truncated, original));
+        translatedBody._toolNameMap = existing;
+      }
+    }
+  }
 
   // Extract toolNameMap for response translation (Claude OAuth)
   const translatedToolNameMap = translatedBody._toolNameMap;

--- a/open-sse/translator/response/kiro-to-openai.ts
+++ b/open-sse/translator/response/kiro-to-openai.ts
@@ -118,7 +118,12 @@ export function convertKiroToOpenAI(chunk, state) {
   if (eventType === "toolUseEvent" || data.toolUseEvent) {
     const toolUse = data.toolUseEvent || data;
     const toolCallId = toolUse.toolUseId || fallbackToolCallId();
-    const toolName = toolUse.name || "";
+    // #1375: long tool names were hash-truncated for Kiro (sanitizeKiroTools).
+    // Map the streamed name back to the original so the client sees the name
+    // it sent. `state.toolNameMap` carries truncated → original entries.
+    const rawName = toolUse.name || "";
+    const toolName =
+      state.toolNameMap instanceof Map ? state.toolNameMap.get(rawName) || rawName : rawName;
     const toolInput = toolUse.input || {};
 
     // #3980: record that this stream produced tool calls so the terminal

--- a/open-sse/utils/kiroSanitizer.ts
+++ b/open-sse/utils/kiroSanitizer.ts
@@ -1,0 +1,127 @@
+/**
+ * Kiro tool-schema sanitizer.
+ *
+ * Kiro / AWS CodeWhisperer rejects requests with HTTP 400 "Improperly formed
+ * request" when a tool's `inputSchema.json` contains JSON-Schema keywords it
+ * does not understand (`additionalProperties`, `anyOf`/`oneOf`/`allOf`/`not`,
+ * `$ref`/`$defs`/`definitions`, `if`/`then`/`else`, etc.) or an empty
+ * `required` array. It also rejects tool names longer than 64 characters.
+ *
+ * This pure helper strips the unsupported keys recursively, ensures a
+ * top-level `required: []` is present, and hash-truncates over-long names —
+ * returning a `nameMap` (truncated → original) so the streamed tool-call name
+ * can be mapped back for the client. See chatCore.ts (request wiring) and
+ * translator/response/kiro-to-openai.ts (response reverse-mapping).
+ */
+import { createHash } from "node:crypto";
+
+/** Max tool-name length Kiro accepts before it rejects the request. */
+const MAX_TOOL_NAME_LENGTH = 64;
+
+/** JSON-Schema keywords Kiro rejects anywhere in a tool schema. */
+const STRIP_KEYS = new Set<string>([
+  "additionalProperties",
+  "anyOf",
+  "oneOf",
+  "allOf",
+  "not",
+  "$schema",
+  "$id",
+  "$ref",
+  "$defs",
+  "definitions",
+  "if",
+  "then",
+  "else",
+  "unevaluatedProperties",
+  "unevaluatedItems",
+  "contentEncoding",
+  "contentMediaType",
+]);
+
+/**
+ * Recursively drop unsupported JSON-Schema keys and empty `required` arrays.
+ * Non-object/array values are returned untouched.
+ */
+function stripKeys(value: unknown): unknown {
+  if (!value || typeof value !== "object") return value;
+  if (Array.isArray(value)) return value.map(stripKeys);
+
+  const cleaned: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+    if (STRIP_KEYS.has(key)) continue;
+    if (key === "required" && Array.isArray(val) && val.length === 0) continue;
+    cleaned[key] = stripKeys(val);
+  }
+  return cleaned;
+}
+
+/** A single Kiro tool entry (loose shape — upstream payloads vary). */
+type KiroTool = {
+  toolSpecification?: {
+    name?: string;
+    inputSchema?: { json?: unknown };
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+};
+
+export interface SanitizeKiroToolsResult<T = unknown> {
+  tools: T;
+  /** Map of truncated tool name → original name, for response reverse-mapping. */
+  nameMap: Map<string, string>;
+}
+
+/**
+ * Sanitize a Kiro `tools` array in place-safely (returns new objects).
+ *
+ * - Strips JSON-Schema keys Kiro rejects from each `inputSchema.json`.
+ * - Ensures the top-level schema carries `required: []` (Kiro requires the key).
+ * - Hash-truncates tool names > 64 chars and records the mapping in `nameMap`.
+ *
+ * Inputs that are not arrays are returned untouched with an empty `nameMap`,
+ * so this is safe to call unconditionally on the Kiro tools slot.
+ */
+export function sanitizeKiroTools<T>(tools: T): SanitizeKiroToolsResult<T> {
+  const nameMap = new Map<string, string>();
+
+  if (!tools || !Array.isArray(tools)) {
+    return { tools, nameMap };
+  }
+
+  const sanitized = (tools as KiroTool[]).map((tool) => {
+    const spec = tool?.toolSpecification;
+    if (!spec) return tool;
+
+    const originalName = spec.name;
+    let name = originalName;
+    if (typeof name === "string" && name.length > MAX_TOOL_NAME_LENGTH) {
+      const hash = createHash("sha256").update(name).digest("hex").slice(0, 7);
+      name = `${name.slice(0, 56)}_${hash}`;
+      nameMap.set(name, originalName as string);
+    }
+
+    const schema = spec.inputSchema?.json;
+    if (schema && typeof schema === "object" && !Array.isArray(schema)) {
+      const cleaned = stripKeys(schema) as Record<string, unknown>;
+      if (!cleaned.required) {
+        cleaned.required = [];
+      }
+      return {
+        ...tool,
+        toolSpecification: {
+          ...spec,
+          name,
+          inputSchema: { json: cleaned },
+        },
+      };
+    }
+
+    return {
+      ...tool,
+      toolSpecification: { ...spec, name },
+    };
+  });
+
+  return { tools: sanitized as T, nameMap };
+}

--- a/tests/unit/kiro-tool-schema-sanitize-1375.test.ts
+++ b/tests/unit/kiro-tool-schema-sanitize-1375.test.ts
@@ -1,0 +1,131 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { sanitizeKiroTools } from "../../open-sse/utils/kiroSanitizer.ts";
+const { convertKiroToOpenAI } = await import(
+  "../../open-sse/translator/response/kiro-to-openai.ts"
+);
+
+// #1375 — Kiro returns 400 "Improperly formed request" when a tool schema
+// carries unsupported JSON-Schema keywords or a tool name longer than 64 chars.
+
+test("sanitizeKiroTools: strips unsupported JSON-Schema keywords recursively", () => {
+  const tools = [
+    {
+      toolSpecification: {
+        name: "search",
+        inputSchema: {
+          json: {
+            type: "object",
+            additionalProperties: false,
+            $schema: "http://json-schema.org/draft-07/schema#",
+            properties: {
+              filter: {
+                anyOf: [{ type: "string" }, { type: "null" }],
+                $ref: "#/$defs/Filter",
+                description: "kept",
+              },
+            },
+            $defs: { Filter: { type: "string" } },
+          },
+        },
+      },
+    },
+  ];
+
+  const { tools: out } = sanitizeKiroTools(tools);
+  const schema = out[0].toolSpecification.inputSchema.json;
+
+  assert.equal("additionalProperties" in schema, false);
+  assert.equal("$schema" in schema, false);
+  assert.equal("$defs" in schema, false);
+  assert.equal("anyOf" in schema.properties.filter, false);
+  assert.equal("$ref" in schema.properties.filter, false);
+  // Non-stripped keys survive.
+  assert.equal(schema.properties.filter.description, "kept");
+  assert.equal(schema.type, "object");
+});
+
+test("sanitizeKiroTools: drops empty required array and guarantees required:[]", () => {
+  const { tools: out } = sanitizeKiroTools([
+    {
+      toolSpecification: {
+        name: "noop",
+        inputSchema: { json: { type: "object", properties: {}, required: [] } },
+      },
+    },
+  ]);
+
+  const schema = out[0].toolSpecification.inputSchema.json;
+  assert.deepEqual(schema.required, []);
+});
+
+test("sanitizeKiroTools: hash-truncates names >64 chars and records nameMap", () => {
+  const longName = "a".repeat(80);
+  const { tools: out, nameMap } = sanitizeKiroTools([
+    {
+      toolSpecification: {
+        name: longName,
+        inputSchema: { json: { type: "object", properties: {} } },
+      },
+    },
+  ]);
+
+  const truncated = out[0].toolSpecification.name;
+  assert.ok(truncated.length <= 64, `truncated name should be <=64, got ${truncated.length}`);
+  assert.notEqual(truncated, longName);
+  // nameMap maps the truncated name back to the original.
+  assert.equal(nameMap.get(truncated), longName);
+});
+
+test("sanitizeKiroTools: short names are left untouched with an empty nameMap", () => {
+  const { tools: out, nameMap } = sanitizeKiroTools([
+    {
+      toolSpecification: {
+        name: "read_file",
+        inputSchema: { json: { type: "object", properties: {}, required: ["path"] } },
+      },
+    },
+  ]);
+
+  assert.equal(out[0].toolSpecification.name, "read_file");
+  assert.equal(out[0].toolSpecification.inputSchema.json.required[0], "path");
+  assert.equal(nameMap.size, 0);
+});
+
+test("sanitizeKiroTools: non-array input is returned untouched", () => {
+  const { tools, nameMap } = sanitizeKiroTools(undefined);
+  assert.equal(tools, undefined);
+  assert.equal(nameMap.size, 0);
+});
+
+test("kiro-to-openai: streamed tool name is reverse-mapped via state.toolNameMap (#1375)", () => {
+  const longName = "b".repeat(80);
+  // Build the truncated name exactly as sanitizeKiroTools would, then verify
+  // the response translator maps the streamed (truncated) name back.
+  const { tools: out, nameMap } = sanitizeKiroTools([
+    {
+      toolSpecification: {
+        name: longName,
+        inputSchema: { json: { type: "object", properties: {} } },
+      },
+    },
+  ]);
+  const truncated = out[0].toolSpecification.name;
+
+  const result = convertKiroToOpenAI(
+    { _eventType: "toolUseEvent", toolUseId: "call_9", name: truncated, input: {} },
+    { toolNameMap: nameMap }
+  );
+
+  assert.equal(result.choices[0].delta.tool_calls[0].function.name, longName);
+});
+
+test("kiro-to-openai: unmapped tool name passes through unchanged", () => {
+  const result = convertKiroToOpenAI(
+    { _eventType: "toolUseEvent", toolUseId: "call_10", name: "read_file", input: {} },
+    { toolNameMap: new Map() }
+  );
+
+  assert.equal(result.choices[0].delta.tool_calls[0].function.name, "read_file");
+});


### PR DESCRIPTION
## Summary

- Kiro / AWS CodeWhisperer rejects requests with HTTP 400 "Improperly formed request" when a tool schema carries JSON-Schema keywords it does not support (`anyOf`/`oneOf`/`allOf`/`not`, `$ref`/`$defs`/`definitions`, `if`/`then`/`else`, etc.) or when a tool name is longer than 64 chars.
- New pure helper `sanitizeKiroTools` (`open-sse/utils/kiroSanitizer.ts`) recursively strips the unsupported keys, guarantees a top-level `required: []`, and hash-truncates over-long names, returning a truncated→original `nameMap`.
- Wired into `chatCore` for `targetFormat === FORMATS.KIRO`; the `nameMap` is merged into the existing `_toolNameMap` channel so `kiro-to-openai` maps the streamed tool-call name back to the name the client sent.

## Attribution

Thanks to [@smarthomeblack](https://github.com/smarthomeblack) for the original implementation.

## Changes

- `open-sse/utils/kiroSanitizer.ts` — new pure helper `sanitizeKiroTools`.
- `open-sse/handlers/chatCore.ts` — sanitize Kiro tools post-translation, merge nameMap into `_toolNameMap`.
- `open-sse/translator/response/kiro-to-openai.ts` — reverse-map truncated tool names via `state.toolNameMap`.
- `tests/unit/kiro-tool-schema-sanitize-1375.test.ts` — TDD unit coverage (fails before, passes after).

## Test plan

- [x] `node --import tsx/esm --test tests/unit/kiro-tool-schema-sanitize-1375.test.ts` (7/7 pass; reverse-map test fails without the kiro-to-openai patch)
- [x] `tests/unit/translator-resp-kiro-to-openai.test.ts` + `translator-openai-to-kiro.test.ts` (31/31)
- [x] `npm run typecheck:core`
- [x] ESLint on touched files (0 errors)