### PR TITLE
fix(sse): redact api key from the AUTH debug log in the chat handler

### DIFF
--- a/src/sse/handlers/chat.ts
+++ b/src/sse/handlers/chat.ts
@@ -270,11 +270,13 @@ export async function handleChat(
     `${url.pathname} | ${modelStr} | ${msgCount} msgs${toolCount ? ` | ${toolCount} tools` : ""}${effort ? ` | effort=${effort}` : ""}`
   );
 
-  // Log API key (masked)
+  // Log only that an API key was provided — never the key itself, not even a
+  // masked prefix/last4. These debug lines get copied verbatim into bug reports
+  // and support tickets, so any key fragment is sensitive.
   const authHeader = request.headers.get("Authorization");
   const apiKey = extractApiKey(request);
   if (authHeader && apiKey) {
-    log.debug("AUTH", `API Key: ${log.maskKey(apiKey)}`);
+    log.debug("AUTH", "API key provided");
   } else {
     log.debug("AUTH", "No API key provided (local mode)");
   }

--- a/tests/unit/chat-auth-log-redaction.test.ts
+++ b/tests/unit/chat-auth-log-redaction.test.ts
@@ -1,0 +1,43 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+/**
+ * Regression guard: the AUTH debug log in the SSE chat handler must NOT
+ * emit any form of the API key — not even a masked prefix/last4 — because
+ * such logs get copied verbatim into bug reports and support tickets.
+ *
+ * Before the fix, src/sse/handlers/chat.ts logged:
+ *   log.debug("AUTH", `API Key: ${log.maskKey(apiKey)}`)
+ * which leaks a masked key. After the fix it logs a fixed string:
+ *   log.debug("AUTH", "API key provided")
+ *
+ * Ported from decolua/9router#1794 (thanks @sacwooky).
+ */
+const here = dirname(fileURLToPath(import.meta.url));
+const chatHandlerPath = resolve(here, "../../src/sse/handlers/chat.ts");
+
+test("chat handler AUTH debug log does not interpolate the (masked) api key", () => {
+  const src = readFileSync(chatHandlerPath, "utf8");
+
+  // The leaky pattern: a debug log that interpolates maskKey(apiKey).
+  assert.ok(
+    !/log\.debug\([^)]*maskKey\(/s.test(src),
+    "chat.ts must not pass log.maskKey(apiKey) into a debug log — it leaks the key into logs/bug reports"
+  );
+
+  // And no "API Key: ${...}" style interpolation in a debug AUTH line.
+  assert.ok(
+    !/log\.debug\(\s*["']AUTH["']\s*,\s*`[^`]*API Key:[^`]*\$\{/s.test(src),
+    'chat.ts must not log `API Key: ${...}` — use a fixed "API key provided" string instead'
+  );
+
+  // Positive assertion: the redacted fixed string is present.
+  assert.match(
+    src,
+    /log\.debug\(\s*["']AUTH["']\s*,\s*["']API key provided["']\s*\)/,
+    'chat.ts should log the fixed "API key provided" string when an api key is present'
+  );
+});


### PR DESCRIPTION
## Summary

- The SSE chat handler logged `API Key: ${log.maskKey(apiKey)}` at debug level. Even a *masked* key prefix/last4 is sensitive once these debug lines are copied verbatim into bug reports or support tickets.
- Replaced it with a fixed `"API key provided"` string, mirroring the existing `"No API key provided (local mode)"` branch. No key material — masked or otherwise — now reaches the logs.

## Changes

- `src/sse/handlers/chat.ts`: AUTH debug log no longer interpolates the (masked) API key.
- `tests/unit/chat-auth-log-redaction.test.ts`: source-scan regression guard — fails if `log.maskKey(apiKey)` or an `API Key: ${...}` interpolation reappears in a debug line; asserts the fixed redacted string is present.
- `CHANGELOG.md`: one bullet under 3.8.35.

## Attribution

Thanks to [@sacwooky](https://github.com/sacwooky) for the original implementation.

> Note: the OmniRoute usage schema stores an `api_key_id` / `api_key_name` reference (never the raw key), so the upstream usage-history hashing half is already satisfied by a different model and is intentionally out of scope here. This port covers the log-hardening half — the only place OmniRoute reproduced the leak.

## Test plan

- [x] `node --import tsx/esm --test tests/unit/chat-auth-log-redaction.test.ts` (fails before the fix, passes after)