### PR TITLE
fix(sse): forward AI SDK image parts in Responses translator

### DIFF
--- a/open-sse/translator/request/openai-responses.ts
+++ b/open-sse/translator/request/openai-responses.ts
@@ -553,6 +553,19 @@ export function openaiToOpenAIResponsesRequest(
                   }
                   return imgResult;
                 }
+                if (
+                  contentItem.type === "image" &&
+                  typeof contentItem.image === "string" &&
+                  /^data:([^;]+);base64,(.+)$/.test(contentItem.image)
+                ) {
+                  // AI SDK-style image part: { type: "image", image: "data:...;base64,..." } (#1330)
+                  const imgResult: JsonRecord = {
+                    type: "input_image",
+                    image_url: contentItem.image,
+                    detail: contentItem.detail !== undefined ? contentItem.detail : "auto",
+                  };
+                  return imgResult;
+                }
                 if (contentItem.type === "file" || contentItem.type === "document") {
                   // Accept both the OpenAI `file` shape and the Gemini-style `document` shape,
                   // and map the bare `data`/`url` fields too, so a PDF reaches Codex/Responses

--- a/tests/unit/translator-openai-responses-req.test.ts
+++ b/tests/unit/translator-openai-responses-req.test.ts
@@ -1047,3 +1047,50 @@ test("Responses -> Chat: a valid function_call/output pair is preserved (issue #
   assert.ok(toolMsg, "matching tool result must be preserved");
   assert.equal(toolMsg.tool_call_id, "c1");
 });
+
+// --- AI SDK image content part (#1330) ---
+test("Chat -> Responses converts AI SDK image content part to input_image", () => {
+  // AI SDK emits image parts as { type: "image", image: "data:...;base64,..." }
+  // rather than the OpenAI { type: "image_url", image_url: { url } } shape. The
+  // Responses translator must forward them as input_image (#1330).
+  const imageUrl = "data:image/png;base64,iVBORw0KGgo=";
+  const result = openaiToOpenAIResponsesRequest(
+    "gpt-5.2",
+    {
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "Describe this image" },
+            { type: "image", image: imageUrl, detail: "high" },
+          ],
+        },
+      ],
+    },
+    true,
+    {}
+  ) as Record<string, unknown>;
+
+  const input = result.input as any[];
+  assert.deepEqual(input[0].content, [
+    { type: "input_text", text: "Describe this image" },
+    { type: "input_image", image_url: imageUrl, detail: "high" },
+  ]);
+});
+
+test("Chat -> Responses defaults AI SDK image detail to auto", () => {
+  const imageUrl = "data:image/jpeg;base64,/9j/4AAQ=";
+  const result = openaiToOpenAIResponsesRequest(
+    "gpt-5.2",
+    { messages: [{ role: "user", content: [{ type: "image", image: imageUrl }] }] },
+    true,
+    {}
+  ) as Record<string, unknown>;
+
+  const input = result.input as any[];
+  assert.deepEqual(input[0].content[0], {
+    type: "input_image",
+    image_url: imageUrl,
+    detail: "auto",
+  });
+});


### PR DESCRIPTION
## Summary

- The Responses request translator (`openaiToOpenAIResponsesRequest`) only understood OpenAI-style `{ type: "image_url", image_url }` content parts. AI SDK clients emit images as `{ type: "image", image: "data:…;base64,…" }`, which fell through to the unknown-type branch and was serialized to text — so the image never reached Responses-API providers.
- This adds a branch that converts an AI SDK base64 data-URL image part to the Responses `input_image` shape (defaulting `detail` to `auto`), mirroring the existing `#1330` handling already present in the Claude / Kiro / Gemini translators.

## Changes

- `open-sse/translator/request/openai-responses.ts`: handle `{ type: "image", image }` content parts → `{ type: "input_image", image_url, detail }`.
- `tests/unit/translator-openai-responses-req.test.ts`: two TDD tests (fail before, pass after) covering the AI SDK image part and the `detail` default.

## Test plan

- `node --import tsx/esm --test tests/unit/translator-openai-responses-req.test.ts` → 45 pass (2 new). Verified the new tests fail without the production change.

## Attribution

Thanks to [@mugnimaestra](https://github.com/mugnimaestra) for the original implementation.