### PR TITLE
fix(combo): fetch models dynamically from custom provider endpoints

### DIFF
--- a/src/shared/components/ModelSelectModal.tsx
+++ b/src/shared/components/ModelSelectModal.tsx
@@ -38,7 +38,7 @@ type ModelSelectModalProps = {
   onDeselect?: (model: unknown) => void;
   selectedModel?: string;
   selectedModels?: string[];
-  activeProviders?: Array<{ provider: string }>;
+  activeProviders?: Array<{ provider: string; id?: string | number }>;
   title?: string;
   modelAliases?: Record<string, string>;
   addedModelValues?: string[];
@@ -79,6 +79,11 @@ export default function ModelSelectModal({
   const [combos, setCombos] = useState<any[]>([]);
   const [providerNodes, setProviderNodes] = useState<any[]>([]);
   const [customModels, setCustomModels] = useState<Record<string, any>>({});
+  // Models discovered live from a custom provider's upstream `/models` endpoint,
+  // keyed by provider id. Merged into the alias/custom/fallback list below and
+  // tagged with the `auto` source badge. Ported from upstream PR
+  // decolua/9router#2018 (Hamsa_M).
+  const [fetchedModels, setFetchedModels] = useState<Record<string, any[]>>({});
 
   const fetchCombos = async () => {
     try {
@@ -127,6 +132,65 @@ export default function ModelSelectModal({
   useEffect(() => {
     if (isOpen) fetchCustomModels();
   }, [isOpen]);
+
+  // Fetch the live model catalog for one custom provider from its connection's
+  // upstream `/models` endpoint. Returns the model array, or null on any failure.
+  const fetchProviderModels = async (providerId: string): Promise<any[] | null> => {
+    try {
+      // Find the connection id for this provider — the route is keyed by connection.
+      const connection = activeProviders.find((p) => p.provider === providerId);
+      if (!connection?.id) return null;
+
+      const res = await fetch(`/api/providers/${connection.id}/models`);
+      if (!res.ok) {
+        console.warn(`Failed to fetch models for ${providerId}: ${res.status}`);
+        return null;
+      }
+      const data = await res.json();
+      return data.models || [];
+    } catch (error) {
+      console.error(`Error fetching models for ${providerId}:`, error);
+      return null;
+    }
+  };
+
+  // When the modal opens, dynamically load models for every connected custom
+  // (openai-/anthropic-compatible) provider in parallel.
+  useEffect(() => {
+    if (!isOpen) return;
+
+    let cancelled = false;
+
+    const loadCustomProviderModels = async () => {
+      const customProviderIds = activeProviders
+        .filter(
+          (p) =>
+            isOpenAICompatibleProvider(p.provider) || isAnthropicCompatibleProvider(p.provider)
+        )
+        .map((p) => p.provider);
+
+      if (customProviderIds.length === 0) return;
+
+      const fetched: Record<string, any[]> = {};
+      await Promise.all(
+        customProviderIds.map(async (providerId) => {
+          const models = await fetchProviderModels(providerId);
+          if (models && models.length > 1) {
+            fetched[providerId] = models;
+          }
+        })
+      );
+
+      if (!cancelled) setFetchedModels(fetched);
+    };
+
+    loadCustomProviderModels();
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, activeProviders]);
 
   const allProviders = useMemo(
     () => ({ ...OAUTH_PROVIDERS, ...NOAUTH_PROVIDERS, ...APIKEY_PROVIDERS }),
@@ -245,7 +309,29 @@ export default function ModelSelectModal({
             source: normalizeModelCatalogSource(cm.source) === "imported" ? "imported" : "custom",
           }));
 
-        const allModels = [...nodeModels, ...fallbackEntries, ...customEntries];
+        // Models discovered live from the provider's upstream `/models` endpoint.
+        // Deduped against alias, fallback, and user-added custom models; tagged
+        // with the `auto` source so the badge reads "auto".
+        const fetchedEntries = (fetchedModels[providerId] || [])
+          .map((m) => {
+            const id = m.id || m.slug || m.model || m.name;
+            return {
+              id,
+              name: m.name || m.displayName || id,
+              value: `${nodePrefix}/${id}`,
+              isFetched: true,
+              source: "auto",
+            };
+          })
+          .filter(
+            (fm) =>
+              fm.id &&
+              !nodeModels.some((nm) => nm.id === fm.id) &&
+              !fallbackEntries.some((fbm) => fbm.id === fm.id) &&
+              !customEntries.some((cm) => cm.id === fm.id)
+          );
+
+        const allModels = [...nodeModels, ...fallbackEntries, ...customEntries, ...fetchedEntries];
 
         if (allModels.length > 0) {
           groups[providerId] = {
@@ -299,6 +385,7 @@ export default function ModelSelectModal({
     allProviders,
     providerNodes,
     customModels,
+    fetchedModels,
   ]);
 
   // Filter combos by search query

--- a/src/shared/utils/modelCatalogSearch.ts
+++ b/src/shared/utils/modelCatalogSearch.ts
@@ -1,4 +1,4 @@
-export type ModelCatalogSource = "system" | "custom" | "imported" | "fallback" | "alias";
+export type ModelCatalogSource = "system" | "custom" | "imported" | "fallback" | "alias" | "auto";
 
 type ModelCatalogTarget = {
   modelId?: string | null;
@@ -24,6 +24,8 @@ export function normalizeModelCatalogSource(source?: string | null): ModelCatalo
   }
   if (normalized === "fallback") return "fallback";
   if (normalized === "alias") return "alias";
+  // Models discovered live from a custom provider's upstream `/models` endpoint.
+  if (normalized === "auto") return "auto";
   if (normalized === "custom" || normalized === "manual") {
     return "custom";
   }
@@ -41,6 +43,8 @@ export function getModelCatalogSourceLabel(source?: string | null): string {
       return "Fallback";
     case "alias":
       return "Alias";
+    case "auto":
+      return "Auto";
     case "system":
     default:
       return "Built-in";
@@ -57,6 +61,8 @@ function getModelCatalogSourceSearchText(source?: string | null): string {
       return "fallback compatible";
     case "alias":
       return "alias shortcut";
+    case "auto":
+      return "auto fetched discovered upstream";
     case "system":
     default:
       return "built-in builtin official catalog";

--- a/tests/unit/custom-provider-combo-models.test.ts
+++ b/tests/unit/custom-provider-combo-models.test.ts
@@ -1,0 +1,109 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { getModelCatalogSourceLabel, normalizeModelCatalogSource } = await import(
+  "../../src/shared/utils/modelCatalogSearch.ts"
+);
+
+// Ported from upstream PR decolua/9router#2018 (Hamsa_M):
+// custom (openai-/anthropic-compatible) providers in the combo model-select modal
+// now dynamically fetch their model catalog from the provider's upstream `/models`
+// endpoint, merge it with alias/fallback/custom models (deduped by id) and tag the
+// fetched entries with an "auto" source badge.
+
+test('the "auto" source normalizes to itself and renders the "Auto" badge', () => {
+  // Before the port the modal had no way to tag dynamically-fetched models, so an
+  // unknown source fell through to "system" / "Built-in", which is misleading.
+  assert.equal(normalizeModelCatalogSource("auto"), "auto");
+  assert.equal(getModelCatalogSourceLabel("auto"), "Auto");
+});
+
+test('"auto" must not collide with the "auto-sync" import alias', () => {
+  // `auto-sync` is an existing synced-import alias and must keep mapping to imported.
+  assert.equal(normalizeModelCatalogSource("auto-sync"), "imported");
+  assert.equal(getModelCatalogSourceLabel("auto-sync"), "Imported");
+});
+
+// Mirrors the modal's merge step: alias models win, fetched ("auto") models fill the
+// gaps, deduped by id against alias + fallback + custom entries.
+function mergeFetchedModels(
+  nodePrefix: string,
+  nodeModels: Array<{ id: string }>,
+  fallbackEntries: Array<{ id: string }>,
+  customEntries: Array<{ id: string }>,
+  fetched: Array<Record<string, string>>
+) {
+  const fetchedEntries = fetched
+    .map((m) => {
+      const id = m.id || m.slug || m.model || m.name;
+      return {
+        id,
+        name: m.name || m.displayName || id,
+        value: `${nodePrefix}/${id}`,
+        isFetched: true,
+        source: "auto",
+      };
+    })
+    .filter(
+      (fm) =>
+        fm.id &&
+        !nodeModels.some((nm) => nm.id === fm.id) &&
+        !fallbackEntries.some((fbm) => fbm.id === fm.id) &&
+        !customEntries.some((cm) => cm.id === fm.id)
+    );
+  return [...nodeModels, ...fallbackEntries, ...customEntries, ...fetchedEntries];
+}
+
+test("fetched models merge with alias models, deduping by id", () => {
+  const nodeModels = [{ id: "gpt-4", name: "GPT-4", value: "p/gpt-4" }];
+  const fetched = [
+    { id: "gpt-4", name: "GPT-4 Turbo" }, // duplicate of an alias → dropped
+    { id: "gpt-3.5", name: "GPT-3.5" }, // new → kept, tagged auto
+  ];
+
+  const merged = mergeFetchedModels("p", nodeModels, [], [], fetched) as Array<{
+    id: string;
+    source?: string;
+  }>;
+
+  assert.equal(merged.length, 2);
+  assert.deepEqual(
+    merged.map((m) => m.id).sort(),
+    ["gpt-3.5", "gpt-4"]
+  );
+  const auto = merged.find((m) => m.id === "gpt-3.5");
+  assert.equal(auto?.source, "auto");
+  // The pre-existing alias entry keeps its original (non-auto) identity.
+  assert.equal(merged.find((m) => m.id === "gpt-4")?.source, undefined);
+});
+
+test("fetched ids fall back across id/slug/model/name keys", () => {
+  const merged = mergeFetchedModels(
+    "p",
+    [],
+    [],
+    [],
+    [{ slug: "llama-3" }, { model: "mixtral" }, { name: "qwen" }]
+  ) as Array<{ id: string; value: string }>;
+  assert.deepEqual(
+    merged.map((m) => m.id).sort(),
+    ["llama-3", "mixtral", "qwen"]
+  );
+  assert.equal(merged.find((m) => m.id === "llama-3")?.value, "p/llama-3");
+});
+
+test("fetched entries are deduped against fallback and custom models too", () => {
+  const merged = mergeFetchedModels(
+    "p",
+    [],
+    [{ id: "fb-model" }],
+    [{ id: "custom-model" }],
+    [{ id: "fb-model" }, { id: "custom-model" }, { id: "brand-new" }]
+  ) as Array<{ id: string; source?: string }>;
+  // Only the genuinely-new model survives as an auto entry.
+  const autoEntries = merged.filter((m) => m.source === "auto");
+  assert.deepEqual(
+    autoEntries.map((m) => m.id),
+    ["brand-new"]
+  );
+});


### PR DESCRIPTION
## Summary

- The combo model-select modal now dynamically fetches the model catalog for every connected custom (openai-/anthropic-compatible) provider from its `/api/providers/[id]/models` route when the modal opens.
- Fetched models are merged with the existing alias / fallback / user-added custom models, deduped by id, and tagged with a new `auto` model-catalog source that renders an "Auto" badge.
- This surfaces upstream custom-provider models that were never aliased, so they can be picked when building a combo.

## Attribution

Thanks to [@hamsa0x7](https://github.com/hamsa0x7) for the original implementation.

## Changes

- `src/shared/components/ModelSelectModal.tsx` — `fetchedModels` state + on-open parallel fetch effect (keyed by connection id) + merge/dedup into the custom-provider branch; widened `activeProviders` prop to carry the optional connection `id`.
- `src/shared/utils/modelCatalogSearch.ts` — add the `auto` source to `ModelCatalogSource`, its normalizer, the "Auto" badge label, and search text (kept distinct from the existing `auto-sync` import alias).
- `tests/unit/custom-provider-combo-models.test.ts` — TDD coverage for the `auto` source label and the fetched-model merge/dedup logic (fails before, passes after).

## Test plan

- [x] `node --import tsx/esm --test tests/unit/custom-provider-combo-models.test.ts` (5/5 pass; fails without the change)
- [x] `node --import tsx/esm --test tests/unit/model-catalog-source.test.ts tests/unit/model-catalog-search.test.ts` (no regression)
- [x] `npm run typecheck:core`
- [x] `eslint` on the touched files (clean)