### PR TITLE
fix(sse): normalize Codex custom tools (apply_patch) to { input: string } schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ _In development — bullets added per PR; finalized at release._
 
 ### 🔧 Bug Fixes
 
+- **codex/translator**: normalize Codex custom/freeform tools (`apply_patch`, `type:"custom"` with no `parameters`) to a `{ input: string }` function schema instead of an empty schema — the empty schema made models invoke `apply_patch` with `{}`, breaking the Codex runtime which expects `{ input: string }`. Also map `custom_tool_call` / `custom_tool_call_output` input items and stream `apply_patch` tool calls via `custom_tool_call_input.delta`/`.done` events. (thanks @nstung463)
+
 - **antigravity-to-openai**: preserve the `required` array when translating Draft 2020-12 tool schemas (e.g. from OpenCode), stripping unsupported JSON Schema meta keywords while keeping mandatory arguments required so the model no longer calls tools without them. (thanks @anuragg-saxenaa)
 
 - **cli(runtime)**: persist the lazily-installed native runtime deps (`better-sqlite3`, `systray2`) to the shared runtime `package.json` with `--save-exact` instead of `--no-save`, so installing one no longer prunes the other as "extraneous" — fixing a "No SQLite driver available" failure after a `--tray` install (thanks @omartuhintvs).

--- a/open-sse/translator/request/openai-responses.ts
+++ b/open-sse/translator/request/openai-responses.ts
@@ -294,6 +294,66 @@ export function openaiResponsesToOpenAIRequest(
       continue;
     }
 
+    if (itemType === "custom_tool_call") {
+      // Codex custom tool call (e.g. apply_patch): `input` is a raw string, not JSON
+      // arguments. Map it onto the assistant tool_calls list as a function call whose
+      // arguments wrap the raw string as { input }, matching the { input: string }
+      // schema the request-side tools normalization advertises for custom tools.
+      const fnName = toString(item.name).trim();
+      if (!fnName) {
+        continue;
+      }
+      if (!currentAssistantMsg) {
+        currentAssistantMsg = {
+          role: "assistant",
+          content: null,
+          tool_calls: [],
+        };
+      }
+      const toolCalls = Array.isArray(currentAssistantMsg.tool_calls)
+        ? currentAssistantMsg.tool_calls
+        : [];
+      toolCalls.push({
+        id: toString(item.call_id),
+        type: "function",
+        function: {
+          name: fnName,
+          arguments: JSON.stringify({ input: item.input }),
+        },
+      });
+      currentAssistantMsg.tool_calls = toolCalls;
+      continue;
+    }
+
+    if (itemType === "custom_tool_call_output") {
+      // Result of a custom tool call — translate the same way as function_call_output.
+      if (currentAssistantMsg) {
+        messages.push(currentAssistantMsg);
+        currentAssistantMsg = null;
+      }
+      if (pendingToolResults.length > 0) {
+        for (const toolResult of pendingToolResults) {
+          messages.push(toolResult);
+        }
+        pendingToolResults = [];
+      }
+      // Unwrap JSON-wrapped output {"output":"...","metadata":{...}} → plain string.
+      const rawOut = typeof item.output === "string" ? item.output : JSON.stringify(item.output);
+      let toolContent = rawOut;
+      try {
+        const parsed = JSON.parse(rawOut);
+        if (parsed && typeof parsed.output === "string") toolContent = parsed.output;
+      } catch {
+        // Not JSON — keep the raw output as the tool content.
+      }
+      messages.push({
+        role: "tool",
+        tool_call_id: toString(item.call_id),
+        content: toolContent,
+      });
+      continue;
+    }
+
     if (itemType === "reasoning") {
       // Skip reasoning items - they are display-only metadata
       continue;
@@ -342,10 +402,11 @@ export function openaiResponsesToOpenAIRequest(
               function: {
                 name: toString(sub.name),
                 description: toString(sub.description),
-                parameters: sub.parameters ?? sub.input_schema ?? {
-                  type: "object",
-                  properties: {},
-                },
+                parameters: sub.parameters ??
+                  sub.input_schema ?? {
+                    type: "object",
+                    properties: {},
+                  },
               },
             }));
         }
@@ -389,6 +450,30 @@ export function openaiResponsesToOpenAIRequest(
         // Skip any tool without a non-empty string name; named tools are unaffected.
         const name = tool.name;
         if (typeof name !== "string" || name.trim() === "") return [];
+
+        // Custom/freeform tools (e.g. Codex apply_patch with type:"custom" and a grammar
+        // format) carry no `parameters` field. Converting them to an empty function schema
+        // makes downstream models invoke them with {}, but the Codex runtime expects
+        // { input: string }. Normalize all custom tools to a well-defined { input: string }
+        // schema so the model produces valid arguments. (#1007)
+        if (toolType === "custom") {
+          return {
+            type: "function",
+            function: {
+              name: toString(tool.name),
+              description: toString(tool.description),
+              parameters: {
+                type: "object",
+                properties: {
+                  input: { type: "string" },
+                },
+                required: ["input"],
+                additionalProperties: false,
+              },
+              strict: tool.strict,
+            },
+          };
+        }
         return {
           type: "function",
           function: {
@@ -460,11 +545,7 @@ export function openaiResponsesToOpenAIRequest(
   // Claude summarized-thinking marker stays behind the UA gate from
   // translateRequest because it is Copilot-specific glue, not an OpenAI-native
   // field. Ported from upstream PR decolua/9router#1817 (ryanngit).
-  if (
-    root.reasoning &&
-    typeof root.reasoning === "object" &&
-    !Array.isArray(root.reasoning)
-  ) {
+  if (root.reasoning && typeof root.reasoning === "object" && !Array.isArray(root.reasoning)) {
     const reasoningRec = toRecord(root.reasoning);
     const effort = toString(reasoningRec.effort);
     if (effort && result.reasoning_effort === undefined) {

--- a/open-sse/translator/response/openai-responses.ts
+++ b/open-sse/translator/response/openai-responses.ts
@@ -346,19 +346,32 @@ function emitToolCall(state, emit, tc) {
 
   if (funcName) state.funcNames[tcIdx] = funcName;
 
+  // Codex custom tools (apply_patch) are surfaced to the client as custom_tool_call items
+  // and stream their raw patch via custom_tool_call_input.* events instead of the
+  // function_call_arguments.* events used for regular function tools. (#1007)
+  const isCustomTool = (state.funcNames[tcIdx] || funcName) === "apply_patch";
+
   if (!state.funcCallIds[tcIdx] && newCallId) {
     state.funcCallIds[tcIdx] = newCallId;
 
     emit("response.output_item.added", {
       type: "response.output_item.added",
       output_index: tcIdx,
-      item: {
-        id: `fc_${newCallId}`,
-        type: "function_call",
-        arguments: "",
-        call_id: newCallId,
-        name: state.funcNames[tcIdx] || "",
-      },
+      item: isCustomTool
+        ? {
+            id: `fc_${newCallId}`,
+            type: "custom_tool_call",
+            input: "",
+            call_id: newCallId,
+            name: state.funcNames[tcIdx] || "",
+          }
+        : {
+            id: `fc_${newCallId}`,
+            type: "function_call",
+            arguments: "",
+            call_id: newCallId,
+            name: state.funcNames[tcIdx] || "",
+          },
     });
   }
 
@@ -372,8 +385,11 @@ function emitToolCall(state, emit, tc) {
     state.funcArgsBuf[tcIdx] = nextArgs;
 
     if (refCallId && emittedDelta) {
-      emit("response.function_call_arguments.delta", {
-        type: "response.function_call_arguments.delta",
+      const deltaEvent = isCustomTool
+        ? "response.custom_tool_call_input.delta"
+        : "response.function_call_arguments.delta";
+      emit(deltaEvent, {
+        type: deltaEvent,
         item_id: `fc_${refCallId}`,
         output_index: tcIdx,
         delta: emittedDelta,
@@ -386,25 +402,57 @@ function closeToolCall(state, emit, idx) {
   const callId = state.funcCallIds[idx];
   if (callId && !state.funcItemDone[idx]) {
     const args = state.funcArgsBuf[idx] || "{}";
+    const isCustomTool = (state.funcNames[idx] || "") === "apply_patch";
 
-    emit("response.function_call_arguments.done", {
-      type: "response.function_call_arguments.done",
-      item_id: `fc_${callId}`,
-      output_index: parseInt(idx),
-      arguments: args,
-    });
+    if (isCustomTool) {
+      // The model produced JSON {"input":"..."} against the normalized custom-tool schema.
+      // Unwrap it back to the raw patch string the Codex runtime expects. (#1007)
+      let rawInput = args;
+      try {
+        const parsed = JSON.parse(args);
+        if (parsed && typeof parsed.input === "string") rawInput = parsed.input;
+      } catch {
+        // Not JSON — fall back to the raw buffered arguments.
+      }
 
-    emit("response.output_item.done", {
-      type: "response.output_item.done",
-      output_index: parseInt(idx),
-      item: {
-        id: `fc_${callId}`,
-        type: "function_call",
+      emit("response.custom_tool_call_input.done", {
+        type: "response.custom_tool_call_input.done",
+        item_id: `fc_${callId}`,
+        output_index: parseInt(idx),
+        input: rawInput,
+      });
+
+      emit("response.output_item.done", {
+        type: "response.output_item.done",
+        output_index: parseInt(idx),
+        item: {
+          id: `fc_${callId}`,
+          type: "custom_tool_call",
+          input: rawInput,
+          call_id: callId,
+          name: state.funcNames[idx] || "",
+        },
+      });
+    } else {
+      emit("response.function_call_arguments.done", {
+        type: "response.function_call_arguments.done",
+        item_id: `fc_${callId}`,
+        output_index: parseInt(idx),
         arguments: args,
-        call_id: callId,
-        name: state.funcNames[idx] || "",
-      },
-    });
+      });
+
+      emit("response.output_item.done", {
+        type: "response.output_item.done",
+        output_index: parseInt(idx),
+        item: {
+          id: `fc_${callId}`,
+          type: "function_call",
+          arguments: args,
+          call_id: callId,
+          name: state.funcNames[idx] || "",
+        },
+      });
+    }
 
     state.funcItemDone[idx] = true;
     state.funcArgsDone[idx] = true;
@@ -434,12 +482,33 @@ function sendCompleted(state, emit) {
     }
     for (const idx in state.funcCallIds) {
       const callId = state.funcCallIds[idx];
+      const name = state.funcNames[idx] || "";
+      const args = state.funcArgsBuf[idx] || "{}";
+      // Mirror the streamed custom_tool_call shape in the final snapshot so Codex can
+      // reconcile the apply_patch item from response.completed. (#1007)
+      if (name === "apply_patch") {
+        let rawInput = args;
+        try {
+          const parsed = JSON.parse(args);
+          if (parsed && typeof parsed.input === "string") rawInput = parsed.input;
+        } catch {
+          // Not JSON — fall back to the raw buffered arguments.
+        }
+        output.push({
+          id: `fc_${callId}`,
+          type: "custom_tool_call",
+          call_id: callId,
+          name,
+          input: rawInput,
+        });
+        continue;
+      }
       output.push({
         id: `fc_${callId}`,
         type: "function_call",
         call_id: callId,
-        name: state.funcNames[idx] || "",
-        arguments: state.funcArgsBuf[idx] || "{}",
+        name,
+        arguments: args,
       });
     }
 

--- a/tests/unit/translator-openai-responses-custom-tool-1007.test.ts
+++ b/tests/unit/translator-openai-responses-custom-tool-1007.test.ts
@@ -1,0 +1,163 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { openaiResponsesToOpenAIRequest } =
+  await import("../../open-sse/translator/request/openai-responses.ts");
+const { openaiToOpenAIResponsesResponse } =
+  await import("../../open-sse/translator/response/openai-responses.ts");
+const { initState } = await import("../../open-sse/translator/index.ts");
+const { FORMATS } = await import("../../open-sse/translator/formats.ts");
+
+function collectEvents(chunks) {
+  const state = initState(FORMATS.OPENAI_RESPONSES);
+  const events = [];
+  for (const chunk of chunks) {
+    const result = openaiToOpenAIResponsesResponse(chunk, state);
+    if (result) events.push(...result);
+  }
+  return events;
+}
+
+// Request side: a Codex custom/freeform tool (type:"custom", no `parameters`) must be
+// normalized to a { input: string } function schema — NOT an empty function schema.
+test("Responses -> Chat: custom tool is normalized to a { input: string } function schema (#1007)", () => {
+  const result = openaiResponsesToOpenAIRequest(
+    "gpt-5.3-codex",
+    {
+      input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "hi" }] }],
+      tools: [
+        {
+          type: "custom",
+          name: "apply_patch",
+          description: "Apply a code patch",
+          format: { type: "grammar", syntax: "lark", definition: "..." },
+        },
+      ],
+    },
+    false,
+    {}
+  );
+
+  assert.equal(Array.isArray(result.tools), true);
+  const tool = result.tools[0];
+  assert.equal(tool.type, "function");
+  assert.equal(tool.function.name, "apply_patch");
+  // The regression: without normalization, parameters is undefined / empty and the model
+  // invokes apply_patch with {}, breaking the Codex runtime.
+  assert.deepEqual(tool.function.parameters, {
+    type: "object",
+    properties: { input: { type: "string" } },
+    required: ["input"],
+    additionalProperties: false,
+  });
+});
+
+// Request side: custom_tool_call / custom_tool_call_output input items round-trip.
+test("Responses -> Chat: custom_tool_call + output items map to tool_calls and tool role (#1007)", () => {
+  const result = openaiResponsesToOpenAIRequest(
+    "gpt-5.3-codex",
+    {
+      input: [
+        { type: "message", role: "user", content: [{ type: "input_text", text: "patch it" }] },
+        {
+          type: "custom_tool_call",
+          call_id: "call_patch_1",
+          name: "apply_patch",
+          input: "*** Begin Patch\n*** End Patch",
+        },
+        {
+          type: "custom_tool_call_output",
+          call_id: "call_patch_1",
+          output: '{"output":"applied","metadata":{"ok":true}}',
+        },
+      ],
+    },
+    false,
+    {}
+  );
+
+  const assistant = result.messages.find(
+    (m) => m.role === "assistant" && Array.isArray(m.tool_calls)
+  );
+  assert.ok(assistant, "expected an assistant message carrying the custom tool call");
+  const tc = assistant.tool_calls[0];
+  assert.equal(tc.id, "call_patch_1");
+  assert.equal(tc.type, "function");
+  assert.equal(tc.function.name, "apply_patch");
+  assert.deepEqual(JSON.parse(tc.function.arguments), {
+    input: "*** Begin Patch\n*** End Patch",
+  });
+
+  const toolMsg = result.messages.find((m) => m.role === "tool");
+  assert.ok(toolMsg, "expected a tool result message");
+  assert.equal(toolMsg.tool_call_id, "call_patch_1");
+  // JSON-wrapped {"output":...} is unwrapped to the plain string.
+  assert.equal(toolMsg.content, "applied");
+});
+
+// Response side: an apply_patch tool call must stream as custom_tool_call_input.* events
+// and the raw patch string is unwrapped from the {"input":"..."} JSON the model produced.
+test("OpenAI -> Responses: apply_patch streams as custom_tool_call with raw input (#1007)", () => {
+  const events = collectEvents([
+    {
+      id: "chatcmpl-1",
+      model: "gpt-5.3-codex",
+      choices: [
+        {
+          index: 0,
+          delta: {
+            tool_calls: [
+              {
+                index: 0,
+                id: "call_1",
+                type: "function",
+                function: { name: "apply_patch", arguments: '{"input":"PATCH' },
+              },
+            ],
+          },
+          finish_reason: null,
+        },
+      ],
+    },
+    {
+      id: "chatcmpl-1",
+      model: "gpt-5.3-codex",
+      choices: [
+        {
+          index: 0,
+          delta: { tool_calls: [{ index: 0, function: { arguments: '_BODY"}' } }] },
+          finish_reason: "tool_calls",
+        },
+      ],
+    },
+  ]);
+
+  const added = events.find((e) => e.event === "response.output_item.added");
+  assert.ok(added);
+  assert.equal(added.data.item.type, "custom_tool_call");
+  assert.equal(added.data.item.name, "apply_patch");
+
+  assert.ok(
+    events.some((e) => e.event === "response.custom_tool_call_input.delta"),
+    "expected a custom_tool_call_input.delta event"
+  );
+  // No function_call_arguments.* events should leak for a custom tool.
+  assert.ok(!events.some((e) => e.event === "response.function_call_arguments.delta"));
+  assert.ok(!events.some((e) => e.event === "response.function_call_arguments.done"));
+
+  const inputDone = events.find((e) => e.event === "response.custom_tool_call_input.done");
+  assert.ok(inputDone);
+  assert.equal(inputDone.data.input, "PATCH_BODY");
+
+  const itemDone = events.find(
+    (e) => e.event === "response.output_item.done" && e.data.item.type === "custom_tool_call"
+  );
+  assert.ok(itemDone);
+  assert.equal(itemDone.data.item.input, "PATCH_BODY");
+
+  const completed = events.find((e) => e.event === "response.completed");
+  assert.ok(completed);
+  const customItem = completed.data.response.output.find((o) => o.type === "custom_tool_call");
+  assert.ok(customItem, "final snapshot should carry the custom_tool_call item");
+  assert.equal(customItem.input, "PATCH_BODY");
+});


### PR DESCRIPTION
## Summary

- The OpenAI Responses request translator allowed `type:"custom"` tools but converted them to an **empty** function schema, so downstream models invoked `apply_patch` with `{}` — breaking the Codex runtime, which expects `{ input: string }`.
- Normalize all custom/freeform tools to a well-defined `{ input: string }` function schema.
- Map `custom_tool_call` / `custom_tool_call_output` input items onto assistant `tool_calls` / `tool` results (JSON-wrapped `{"output":...}` outputs are unwrapped to a plain string).
- Stream `apply_patch` tool calls as `response.custom_tool_call_input.delta` / `.done` events (instead of `function_call_arguments.*`), and emit the matching `custom_tool_call` item in both `output_item.done` and the final `response.completed` snapshot. The raw patch string is unwrapped from the `{"input":"..."}` JSON the model produces.

## Attribution

Thanks to [@nstung463](https://github.com/nstung463) for the original implementation.

## Changes

- `open-sse/translator/request/openai-responses.ts` — custom tool schema normalization + `custom_tool_call`/`custom_tool_call_output` input items.
- `open-sse/translator/response/openai-responses.ts` — `apply_patch` streamed as `custom_tool_call` (added/delta/done + completed snapshot).
- `tests/unit/translator-openai-responses-custom-tool-1007.test.ts` — TDD regression test (fails before, passes after).

## Test plan

- [x] `node --import tsx/esm --test tests/unit/translator-openai-responses-custom-tool-1007.test.ts` (fails on unmodified code, passes after)
- [x] Existing translator suites green (`translator-resp-openai-responses`, `translator-openai-responses-req`, `translator-openai-responses-empty-input-419` — 59 tests)
- [x] `npm run typecheck:core`
- [x] ESLint clean on touched files
- [x] `npm run check:docs-sync`