### PR TITLE
fix(sse): resolve custom combos by id and case-insensitive name (#4446)

### DIFF
--- a/src/lib/db/combos.ts
+++ b/src/lib/db/combos.ts
@@ -125,6 +125,24 @@ export async function getComboByName(name: string) {
   return normalizeStoredCombo(combo, db, [name]);
 }
 
+// #4446: case-insensitive name lookup. The opencode dispatch path forwards a
+// lowercased combo slug (e.g. "master-light") for a combo provisioned as
+// "MASTER-LIGHT"; the default BINARY collation of getComboByName misses it.
+// Used only as a fallback after the exact match fails, so it cannot change the
+// resolution of any combo that already resolves today.
+export async function getComboByNameInsensitive(name: string) {
+  const db = getDbInstance();
+  const row = db
+    .prepare(
+      "SELECT data, sort_order, context_cache_protection FROM combos WHERE name = ? COLLATE NOCASE"
+    )
+    .get(name);
+  const combo = parseComboRow(row);
+  if (!combo) return null;
+  const storedName = typeof combo.name === "string" ? combo.name : name;
+  return normalizeStoredCombo(combo, db, [storedName]);
+}
+
 export async function createCombo(data: JsonRecord) {
   const db = getDbInstance();
   const now = new Date().toISOString();

--- a/src/lib/localDb.ts
+++ b/src/lib/localDb.ts
@@ -83,6 +83,7 @@ export {
   getCombos,
   getComboById,
   getComboByName,
+  getComboByNameInsensitive,
   createCombo,
   updateCombo,
   reorderCombos,

--- a/src/sse/services/model.ts
+++ b/src/sse/services/model.ts
@@ -1,5 +1,12 @@
 // Re-export from open-sse with localDb integration
-import { getModelAliases, getComboByName, getProviderNodes, getCustomModels } from "@/lib/localDb";
+import {
+  getModelAliases,
+  getComboByName,
+  getComboById,
+  getComboByNameInsensitive,
+  getProviderNodes,
+  getCustomModels,
+} from "@/lib/localDb";
 import { getCachedSettings } from "@/lib/localDb";
 import { getComboStepTarget } from "@/lib/combos/steps";
 import {
@@ -211,6 +218,22 @@ export async function getCombo(modelStr) {
     if (combo && combo.models && combo.models.length > 0) {
       return combo;
     }
+  }
+
+  // #4446: the opencode-plugin publishes combos as ModelV2 `id: combo.id`, and
+  // the OpenCode `--model` dispatch path forwards a lowercased bare slug. The
+  // exact, case-sensitive name match above misses both a combo addressed by its
+  // stored id (UUID/slug) and a lowercased display name (e.g. "master-light" for
+  // a combo named "MASTER-LIGHT"). These two fallbacks only run after the exact
+  // match fails, so they never re-route a combo that already resolves today.
+  combo = await getComboById(modelStr);
+  if (combo && combo.models && combo.models.length > 0) {
+    return combo;
+  }
+
+  combo = await getComboByNameInsensitive(modelStr);
+  if (combo && combo.models && combo.models.length > 0) {
+    return combo;
   }
 
   return null;

--- a/tests/unit/combo-id-resolution-4446.test.ts
+++ b/tests/unit/combo-id-resolution-4446.test.ts
@@ -1,0 +1,84 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// #4446 — opencode-plugin publishes combos by `combo.id` and the OpenCode
+// `--model` dispatch path forwards a lowercased bare slug (e.g. "master-light")
+// for a combo provisioned as "MASTER-LIGHT". OmniRoute's combo resolver only
+// matched by EXACT, case-sensitive `name`, so the slug resolved to nothing and
+// the request fell through to provider inference → "Unable to determine
+// provider for model 'master-light'". These tests lock the additive fallbacks:
+// resolve a combo by its `id` and by a case-insensitive `name` match.
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-combo-id-4446-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const combosDb = await import("../../src/lib/db/combos.ts");
+const sseModelService = await import("../../src/sse/services/model.ts");
+
+async function resetStorage() {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+test.beforeEach(async () => {
+  await resetStorage();
+});
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("#4446 getComboForModel resolves a combo by a case-insensitive name (lowercased slug)", async () => {
+  await combosDb.createCombo({
+    name: "MASTER-LIGHT",
+    models: [
+      { provider: "groq", model: "llama-3.1-8b-instant" },
+      { provider: "cerebras", model: "llama-3.3-70b" },
+    ],
+  });
+
+  // The opencode `--model opencode-omniroute/master-light` path arrives as the
+  // bare lowercased slug "master-light".
+  const resolved = await sseModelService.getComboForModel("master-light");
+
+  assert.ok(resolved, "expected the lowercased slug to resolve to the MASTER-LIGHT combo");
+  assert.equal((resolved as { name: string }).name, "MASTER-LIGHT");
+  assert.ok(
+    Array.isArray((resolved as { models: unknown[] }).models) &&
+      (resolved as { models: unknown[] }).models.length === 2
+  );
+});
+
+test("#4446 getComboForModel resolves a combo by its stored id", async () => {
+  const created = (await combosDb.createCombo({
+    name: "Explore Combo",
+    models: [{ provider: "groq", model: "llama-3.1-8b-instant" }],
+  })) as { id: string; name: string };
+
+  // The opencode plugin publishes combos as ModelV2 `id: combo.id`, so the
+  // dispatch path can forward the combo's id rather than its display name.
+  const resolved = await sseModelService.getComboForModel(created.id);
+
+  assert.ok(resolved, "expected the combo id to resolve to the combo");
+  assert.equal((resolved as { name: string }).name, "Explore Combo");
+});
+
+test("#4446 exact name match still wins and unknown slugs still return null", async () => {
+  await combosDb.createCombo({
+    name: "MASTER-LIGHT",
+    models: [{ provider: "groq", model: "llama-3.1-8b-instant" }],
+  });
+
+  const exact = await sseModelService.getComboForModel("MASTER-LIGHT");
+  assert.ok(exact, "exact name must still resolve");
+  assert.equal((exact as { name: string }).name, "MASTER-LIGHT");
+
+  const unknown = await sseModelService.getComboForModel("no-such-combo-xyz");
+  assert.equal(unknown, null, "an unknown slug must not resolve to any combo");
+});


### PR DESCRIPTION
Closes #4446

## Problem

`opencode run --model opencode-omniroute/<custom-combo-slug>` failed with:

```
Error: Unable to determine provider for model 'master-light'. Use a provider/model prefix ...
```

while `--model opencode-omniroute/auto` (auto combo) and raw models worked. The reporter (@herjarsa) confirmed the exact arriving body is `{"model": "master-light"}` (a lowercased bare slug) for a combo provisioned as `MASTER-LIGHT`.

## Root cause

The `@omniroute/opencode-plugin` publishes combos as ModelV2 `id: combo.id`, and the OpenCode `--model` dispatch path forwards a **lowercased bare slug**. OmniRoute's combo resolver `getCombo()` (`src/sse/services/model.ts`) matched **only** by exact, case-sensitive `name` via `getComboByName` (`WHERE name = ?`, BINARY collation):

- a combo addressed by its stored **id** (UUID/slug) never matched;
- a **lowercased** display name (`master-light` vs `MASTER-LIGHT`) never matched.

Auto combos resolve because their `id` === `name` (`auto`); raw models resolve because the provider/model prefix splits on `/`.

## Fix (additive — zero regression)

After the existing exact-name and `combo/`-prefix matches fail, `getCombo()` now also tries:

1. `getComboById(modelStr)` — resolves a combo addressed by its stored id;
2. `getComboByNameInsensitive(modelStr)` — `WHERE name = ? COLLATE NOCASE`.

Both run **only** when the exact match already returned nothing, so any combo that resolves today resolves identically — the change can only resolve *more* slugs, never re-route an existing one. `getComboByNameInsensitive` is added to `src/lib/db/combos.ts` and re-exported through `localDb` (Rule #2: re-export only).

## Validation (Hard Rule #18 — TDD)

`tests/unit/combo-id-resolution-4446.test.ts` (failing before, passing after):

- resolves `master-light` → combo `MASTER-LIGHT` (case-insensitive name);
- resolves a combo by its stored `id`;
- exact-name match still wins and an unknown slug still returns `null`.

```
node --import tsx/esm --test tests/unit/combo-id-resolution-4446.test.ts
# pre-fix:  pass 1 / fail 2   post-fix: pass 3 / fail 0
```

Also green: `typecheck:core`, `check:db-rules`, eslint on touched files, and the existing `combo-bracket-names` / `combo-cache-invalidation` suites.