### PR TITLE
chore(quality): rebaseline catalog.ts 1574->1577 (#4630 follow-up)

### DIFF
--- a/config/quality/file-size-baseline.json
+++ b/config/quality/file-size-baseline.json
@@ -189,7 +189,7 @@
     "src/app/api/providers/[id]/models/route.ts": 2590,
     "src/app/api/providers/[id]/test/route.ts": 917,
     "src/app/api/usage/analytics/route.ts": 941,
-    "src/app/api/v1/models/catalog.ts": 1574,
+    "src/app/api/v1/models/catalog.ts": 1577,
     "src/lib/cloudflaredTunnel.ts": 934,
     "src/lib/db/apiKeys.ts": 1662,
     "src/lib/db/core.ts": 1825,


### PR DESCRIPTION
#4630 (alias-backed models) cresceu catalog.ts para 1577 ao assentar sobre a região quota-exclusive já presente na release; o bump do PR previa 1574. Reconcilia o baseline file-size para o tamanho real. Sem mudança de código.