### PR TITLE
feat(quota): saturação real do Claude (5h/semanal) no fair-share via /api/oauth/usage [Fase 3 #1]

### DIFF
--- a/src/lib/quota/saturationSignals.ts
+++ b/src/lib/quota/saturationSignals.ts
@@ -3,11 +3,20 @@
  * for a provider/connection/dimension combination.
  *
  * Strategy (per provider):
- *   codex   → codexQuotaFetcher (dual 5h + weekly window)
- *   bailian → bailianQuotaFetcher (triple 5h + weekly + monthly window)
- *   default → getUsageForProvider (open-sse/services/usage.ts)
+ *   codex            → codexQuotaFetcher (dual 5h + weekly window)
+ *   bailian          → bailianQuotaFetcher (triple 5h + weekly + monthly window)
+ *   anthropic/claude → REAL plan-window utilization from GET /api/oauth/usage
+ *                      (the same path usage.ts already uses): window "5h" →
+ *                      five_hour.utilization, "weekly" → seven_day.utilization.
+ *                      Falls back to the per-minute REQUEST rate-limit headers
+ *                      (anthropic-ratelimit-requests-*) only when no OAuth plan
+ *                      window is available (e.g. API-key Claude connections).
+ *   default          → getUsageForProvider (open-sse/services/usage.ts)
  *
- * Cache: in-memory Map, TTL = 30 seconds.
+ * Cache: in-memory Map, TTL = 30 seconds. The 30s TTL is what keeps the
+ * NON-OFFICIAL, rate-limited oauth/usage endpoint from being polled per
+ * request (it returns 429 under load) — never call it on the hot path without
+ * this cache. usage.ts adds its own 429 cooldown on top.
  * Fail-open: on any error, return 0 (generous mode) and log pino.warn.
  * Hard Rule #12: no stack traces propagated to return values.
  *
@@ -158,15 +167,129 @@ async function fetchBailianSaturation(
   return Math.min(1, Math.max(0, pct));
 }
 
-async function fetchAnthropicSaturation(
-  connectionId: string,
-  dim: DimensionSpec
-): Promise<number> {
+/**
+ * Per-minute REQUEST rate-limit headers fallback. Used only when the OAuth
+ * plan-window utilization is unavailable (e.g. API-key Claude connections that
+ * have no /api/oauth/usage data). This signal reflects TPM/RPM bursts, NOT the
+ * 5h/weekly plan window, so it is a weak last resort.
+ */
+function anthropicHeaderSaturation(connectionId: string): number {
   const entry = _rateLimitHeaders.get(`anthropic:${connectionId}`);
   if (!entry || Date.now() - entry.ts > RL_HEADER_TTL_MS) return 0;
 
   const used = entry.limit - entry.remaining;
   return Math.min(1, Math.max(0, used / entry.limit));
+}
+
+/**
+ * Injectable seam (DB lookup + usage fetch) so the oauth/usage plan-window path
+ * is unit-testable without touching the DB or the network. Defaults are wired
+ * lazily to the real implementations inside fetchAnthropicSaturation.
+ */
+interface AnthropicSaturationDeps {
+  /** Resolve a connection (with decrypted accessToken/authType) by id. */
+  loadConnection: (connectionId: string) => Promise<Record<string, unknown> | null>;
+  /** Fetch usage for the connection (delegates to getUsageForProvider). */
+  fetchUsage: (conn: Record<string, unknown>) => Promise<unknown>;
+}
+
+let _anthropicDepsOverride: AnthropicSaturationDeps | null = null;
+
+/** Test-only: inject ({loadConnection, fetchUsage}); pass null to restore. */
+export function __setAnthropicSaturationDepsForTests(
+  deps: AnthropicSaturationDeps | null
+): void {
+  _anthropicDepsOverride = deps;
+}
+
+async function defaultAnthropicDeps(): Promise<AnthropicSaturationDeps> {
+  const [providersMod, usageMod] = await Promise.all([
+    import("@/lib/db/providers"),
+    import("@omniroute/open-sse/services/usage"),
+  ]);
+  return {
+    loadConnection: (connectionId) =>
+      providersMod.getProviderConnectionById(connectionId) as Promise<Record<
+        string,
+        unknown
+      > | null>,
+    fetchUsage: (conn) =>
+      usageMod.getUsageForProvider(conn as Parameters<typeof usageMod.getUsageForProvider>[0]),
+  };
+}
+
+/**
+ * Map a QuotaWindow to the Claude usage quota key produced by getClaudeUsage
+ * (usage.ts). "session (5h)" carries five_hour.utilization and "weekly (7d)"
+ * carries seven_day.utilization.
+ */
+function claudeUsageKeyForWindow(window: QuotaWindow): string | null {
+  switch (window) {
+    case "5h":
+      return "session (5h)";
+    case "weekly":
+    case "monthly":
+      // Anthropic exposes a 7-day plan window, not a monthly one — treat the
+      // longer requested window as the weekly plan saturation.
+      return "weekly (7d)";
+    default:
+      return null;
+  }
+}
+
+/**
+ * Extract the plan utilization (0..1) for the requested window from a
+ * getClaudeUsage() result, or null when the OAuth plan window is unavailable
+ * (e.g. legacy/admin API-key shape with no per-window quotas).
+ */
+function planUtilizationFromUsage(usage: unknown, window: QuotaWindow): number | null {
+  if (!usage || typeof usage !== "object") return null;
+  const quotas = (usage as Record<string, unknown>).quotas;
+  if (!quotas || typeof quotas !== "object" || Array.isArray(quotas)) return null;
+
+  const key = claudeUsageKeyForWindow(window);
+  if (!key) return null;
+  const entry = (quotas as Record<string, unknown>)[key];
+  if (!entry || typeof entry !== "object") return null;
+
+  // getClaudeUsage stores `used` = utilization (% used, 0..100).
+  const used = (entry as Record<string, unknown>).used;
+  if (typeof used !== "number" || !Number.isFinite(used)) return null;
+  return Math.min(1, Math.max(0, used / 100));
+}
+
+async function fetchAnthropicSaturation(
+  connectionId: string,
+  dim: DimensionSpec
+): Promise<number> {
+  // Try the REAL plan-window utilization first (5h / weekly), via the same
+  // /api/oauth/usage path usage.ts already uses. This is the signal fairShare
+  // actually needs for Claude Pro/Max — the per-minute request headers do not
+  // reflect the plan window. Any failure here falls back to the header path,
+  // and ultimately fails open (0).
+  try {
+    const deps = _anthropicDepsOverride ?? (await defaultAnthropicDeps());
+    const conn = await deps.loadConnection(connectionId);
+    // Only OAuth connections have plan-window usage; API-key Claude does not.
+    const hasOauthToken =
+      !!conn &&
+      typeof conn.accessToken === "string" &&
+      conn.accessToken.length > 0 &&
+      (conn.authType === undefined || conn.authType === "oauth");
+    if (hasOauthToken) {
+      const usage = await deps.fetchUsage(conn as Record<string, unknown>);
+      const util = planUtilizationFromUsage(usage, dim.window);
+      if (util !== null) return util;
+    }
+  } catch (err) {
+    log.warn(
+      { err: (err as Error)?.message, connectionId },
+      "anthropic oauth/usage saturation failed — falling back to rate-limit headers"
+    );
+  }
+
+  // Fallback: per-minute REQUEST rate-limit headers (weak, TPM/RPM only).
+  return anthropicHeaderSaturation(connectionId);
 }
 
 async function fetchGenericSaturation(

--- a/tests/unit/quota-saturation-anthropic-oauth.test.ts
+++ b/tests/unit/quota-saturation-anthropic-oauth.test.ts
@@ -1,0 +1,188 @@
+/**
+ * tests/unit/quota-saturation-anthropic-oauth.test.ts
+ *
+ * #1 — Real plan-window saturation for Claude/Anthropic fair-share.
+ *
+ * Before this change, the anthropic/claude branch of getSaturation only read
+ * the per-minute REQUEST rate-limit headers (anthropic-ratelimit-requests-*),
+ * which do NOT reflect the Claude Pro/Max 5h / weekly plan window. fairShare
+ * was therefore nearly blind for Claude.
+ *
+ * This suite asserts the branch now uses the REAL plan utilization that
+ * usage.ts already fetches from GET /api/oauth/usage (five_hour.utilization /
+ * seven_day.utilization), window-aware:
+ *   - dim.window "5h"     → five_hour.utilization  / 100
+ *   - dim.window "weekly" → seven_day.utilization  / 100
+ *
+ * The oauth/usage path and the DB connection lookup are injected (deps seam)
+ * so the test never touches the network or the DB. The 30s saturation cache is
+ * cleared between asserts via _clearSaturationCache().
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const satMod = await import("../../src/lib/quota/saturationSignals.ts");
+const { getSaturation, _clearSaturationCache, __setAnthropicSaturationDepsForTests } = satMod;
+
+// usage.ts shape: getClaudeUsage maps five_hour.utilization → quotas["session (5h)"].used
+// and seven_day.utilization → quotas["weekly (7d)"].used (used = % used, 0..100).
+function claudeUsageStub(fiveHourUtil: number, sevenDayUtil: number) {
+  return {
+    plan: "Claude Pro",
+    quotas: {
+      "session (5h)": {
+        used: fiveHourUtil,
+        total: 100,
+        remaining: Math.max(0, 100 - fiveHourUtil),
+        remainingPercentage: Math.max(0, 100 - fiveHourUtil),
+        resetAt: null,
+        unlimited: false,
+      },
+      "weekly (7d)": {
+        used: sevenDayUtil,
+        total: 100,
+        remaining: Math.max(0, 100 - sevenDayUtil),
+        remainingPercentage: Math.max(0, 100 - sevenDayUtil),
+        resetAt: null,
+        unlimited: false,
+      },
+    },
+    extraUsage: null,
+    bootstrap: null,
+  };
+}
+
+const OAUTH_CONN = {
+  id: "claude-conn-1",
+  provider: "claude",
+  authType: "oauth",
+  accessToken: "fake-oauth-token",
+};
+
+test.afterEach(() => {
+  // Restore real deps and clear cache so suites stay isolated.
+  __setAnthropicSaturationDepsForTests(null);
+  _clearSaturationCache();
+});
+
+// ─── Core: 5h window uses five_hour.utilization ──────────────────────────────
+
+test("getSaturation(claude, 5h) → five_hour.utilization/100 (80% → 0.8)", async () => {
+  _clearSaturationCache();
+  __setAnthropicSaturationDepsForTests({
+    loadConnection: async () => ({ ...OAUTH_CONN }),
+    fetchUsage: async () => claudeUsageStub(80, 40),
+  });
+
+  const val = await getSaturation("claude-conn-1", "claude", { unit: "percent", window: "5h" });
+  assert.ok(Math.abs(val - 0.8) < 1e-9, `expected ≈0.8, got ${val}`);
+});
+
+test("getSaturation(claude, weekly) → seven_day.utilization/100 (40% → 0.4)", async () => {
+  _clearSaturationCache();
+  __setAnthropicSaturationDepsForTests({
+    loadConnection: async () => ({ ...OAUTH_CONN }),
+    fetchUsage: async () => claudeUsageStub(80, 40),
+  });
+
+  const val = await getSaturation("claude-conn-1", "claude", { unit: "percent", window: "weekly" });
+  assert.ok(Math.abs(val - 0.4) < 1e-9, `expected ≈0.4, got ${val}`);
+});
+
+test('provider alias "anthropic" resolves the same plan-window utilization', async () => {
+  _clearSaturationCache();
+  __setAnthropicSaturationDepsForTests({
+    loadConnection: async () => ({ ...OAUTH_CONN }),
+    fetchUsage: async () => claudeUsageStub(95, 10),
+  });
+
+  const five = await getSaturation("claude-conn-1", "anthropic", { unit: "percent", window: "5h" });
+  assert.ok(Math.abs(five - 0.95) < 1e-9, `expected ≈0.95, got ${five}`);
+});
+
+// ─── Clamp ───────────────────────────────────────────────────────────────────
+
+test("utilization > 100 is clamped to 1", async () => {
+  _clearSaturationCache();
+  __setAnthropicSaturationDepsForTests({
+    loadConnection: async () => ({ ...OAUTH_CONN }),
+    fetchUsage: async () => claudeUsageStub(140, 0),
+  });
+
+  const val = await getSaturation("claude-conn-1", "claude", { unit: "percent", window: "5h" });
+  assert.equal(val, 1);
+});
+
+// ─── Fallback: API-key Claude (no OAuth token) → header path ──────────────────
+
+test("API-key Claude (no oauth/usage windows) falls back to rate-limit header path", async () => {
+  _clearSaturationCache();
+  // Seed the header cache the way the response handler would.
+  satMod.storeRateLimitHeaders("apikey-conn", "anthropic", {
+    "anthropic-ratelimit-requests-limit": "100",
+    "anthropic-ratelimit-requests-remaining": "30",
+  });
+  __setAnthropicSaturationDepsForTests({
+    // API-key connection → no usable oauth/usage window for plan saturation.
+    loadConnection: async () => ({
+      id: "apikey-conn",
+      provider: "claude",
+      authType: "apikey",
+      apiKey: "sk-ant-xxx",
+    }),
+    // Legacy/admin shape: no "session (5h)" / "weekly (7d)" keys.
+    fetchUsage: async () => ({ message: "Claude connected. Usage details require admin access." }),
+  });
+
+  const val = await getSaturation("apikey-conn", "claude", { unit: "percent", window: "5h" });
+  // used = 100 - 30 = 70 over limit 100 → 0.7 from the header fallback.
+  assert.ok(Math.abs(val - 0.7) < 1e-9, `expected header-fallback ≈0.7, got ${val}`);
+});
+
+// ─── Fail-open ────────────────────────────────────────────────────────────────
+
+test("no connection found → fails open (0), no throw", async () => {
+  _clearSaturationCache();
+  __setAnthropicSaturationDepsForTests({
+    loadConnection: async () => null,
+    fetchUsage: async () => {
+      throw new Error("must not be called when no connection");
+    },
+  });
+
+  const val = await getSaturation("missing-conn", "claude", { unit: "percent", window: "5h" });
+  assert.equal(val, 0);
+});
+
+test("oauth/usage fetch throws → fails open (0), no throw", async () => {
+  _clearSaturationCache();
+  __setAnthropicSaturationDepsForTests({
+    loadConnection: async () => ({ ...OAUTH_CONN }),
+    fetchUsage: async () => {
+      throw new Error("429 rate limited");
+    },
+  });
+
+  const val = await getSaturation("claude-conn-1", "claude", { unit: "percent", window: "5h" });
+  assert.equal(val, 0);
+});
+
+// ─── Cache: don't poll per request (Rule #18) ────────────────────────────────
+
+test("second call within 30s TTL is served from cache (fetchUsage NOT re-invoked)", async () => {
+  _clearSaturationCache();
+  let calls = 0;
+  __setAnthropicSaturationDepsForTests({
+    loadConnection: async () => ({ ...OAUTH_CONN }),
+    fetchUsage: async () => {
+      calls += 1;
+      return claudeUsageStub(80, 40);
+    },
+  });
+
+  const a = await getSaturation("claude-conn-1", "claude", { unit: "percent", window: "5h" });
+  const b = await getSaturation("claude-conn-1", "claude", { unit: "percent", window: "5h" });
+  assert.equal(a, b);
+  assert.equal(calls, 1, "oauth/usage must be fetched once, not per request");
+});


### PR DESCRIPTION
## Resumo

Ponto **#1** das melhorias de Quota Share: usa a **utilização real do plano** do Claude (janela 5h / semanal) no sinal de saturação do fair-share, em vez dos headers de rate-limit por-minuto — que não refletem a cota de plano Pro/Max e deixavam o `fairShare` quase cego para Claude.

## Mudança (`src/lib/quota/saturationSignals.ts`)

O branch `anthropic`/`claude` de `getSaturation` agora:
- resolve a conexão e, se for OAuth com token, busca a utilização do plano via o **mesmo caminho `/api/oauth/usage` que `usage.ts` já usa** (`getUsageForProvider`): `5h → five_hour.utilization/100`, `weekly → seven_day.utilization/100`;
- **fallback** para o caminho de headers de rate-limit quando não há janela OAuth (Claude por API-key → shape legacy);
- **fail-open** (0) em qualquer erro; mantém o **cache de 30s**, que impede poll por-request no endpoint **não-oficial e rate-limited** (429 sob carga) — Rule #18.

Não refatora `usage.ts`. Seam injetável (`__setAnthropicSaturationDepsForTests`) torna o caminho DB+rede testável sem DB/rede.

## Validação

`tests/unit/quota-saturation-anthropic-oauth.test.ts` (8 testes novos, FALHA-então-PASSA) + 6 de regressão (`quota-saturation-signals`) + 18 downstream (`quota-enforce`/`fair-share`) — verdes. `typecheck:core` ✓ · `eslint` ✓.

Verificado que `getClaudeUsage` (usage.ts ~2628/2633) produz exatamente `quotas["session (5h)"]` / `["weekly (7d)"]` com `used = utilization`.

**Validação live** (oauth/usage real refletindo % de plano) fica para um deploy de marco da Fase 3 — o fix é fail-open e não altera o comportamento quando o endpoint está indisponível.
