### PR TITLE
chore(quality): reconcile env-doc + file-size base-reds (v3.8.36)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -955,6 +955,15 @@ GEMINI_CLI_USER_AGENT="google-api-nodejs-client/10.3.0"
 # OMNIROUTE_CIRCUIT_BREAKER_LOCAL_THRESHOLD=2
 # OMNIROUTE_CIRCUIT_BREAKER_LOCAL_RESET_MS=15000
 
+# ── Context-cache pin health gate ──
+# Used by: open-sse/services/combo.ts. When a context-cache pin points at a
+# provider that is durably unhealthy, the pin is dropped to allow failover.
+# PIN_DROP_BACKOFF_LEVEL gates how deep a connection's backoff must be before the
+# pin is considered durably unhealthy; PIN_DROP_GRACE_MS is the anti-flap window
+# that tolerates brief transient cooldowns before dropping the pin.
+# PIN_DROP_BACKOFF_LEVEL=2
+# PIN_DROP_GRACE_MS=20000
+
 # ── Stream idle detection ──
 # STREAM_IDLE_TIMEOUT_MS=600000      # Max silence between SSE chunks (default: 600000)
 #                                     # Extended-thinking models rarely pause >90s.

--- a/config/quality/file-size-baseline.json
+++ b/config/quality/file-size-baseline.json
@@ -242,7 +242,7 @@
     "tests/unit/executor-codex.test.ts": 1339,
     "tests/unit/executor-default-base.test.ts": 1339,
     "tests/unit/grok-web.test.ts": 2437,
-    "tests/unit/image-generation-handler.test.ts": 1996,
+    "tests/unit/image-generation-handler.test.ts": 2019,
     "tests/unit/model-sync-route.test.ts": 1016,
     "tests/unit/models-catalog-route.test.ts": 1507,
     "_rebaseline_pr4561_qwen_oauth_url": "Reconcile #4561 (port decolua/9router#683) already-merged growth: oauth-providers-config.test.ts 855->867 (+12, qwen.ai URL regression-pin test). Fast-gate PR->release does not run check:file-size, so this surfaced post-merge.",

--- a/docs/reference/ENVIRONMENT.md
+++ b/docs/reference/ENVIRONMENT.md
@@ -616,6 +616,8 @@ Provider-level circuit breaker tuning. Defaults reflect the scaled values used s
 | `OMNIROUTE_CIRCUIT_BREAKER_API_KEY_RESET_MS`  | `30000` | `open-sse/config/constants.ts` | Reset window (ms) for API-key provider breaker.                             |
 | `OMNIROUTE_CIRCUIT_BREAKER_LOCAL_THRESHOLD`   | `2`     | `open-sse/config/constants.ts` | Consecutive failure threshold for local providers (Ollama, LM Studio, ...). |
 | `OMNIROUTE_CIRCUIT_BREAKER_LOCAL_RESET_MS`    | `15000` | `open-sse/config/constants.ts` | Reset window (ms) for local provider breaker.                               |
+| `PIN_DROP_BACKOFF_LEVEL`                      | `2`     | `open-sse/services/combo.ts`   | Backoff depth at which a context-cache pin's provider is deemed durably unhealthy and the pin is dropped for failover. |
+| `PIN_DROP_GRACE_MS`                           | `20000` | `open-sse/services/combo.ts`   | Anti-flap window (ms) tolerating brief transient cooldowns before dropping a context-cache pin.                       |
 
 ### Scenarios
 


### PR DESCRIPTION
Reconciles two base-reds in release/v3.8.36:
1. **env-doc-sync**: `PIN_DROP_BACKOFF_LEVEL` / `PIN_DROP_GRACE_MS` (introduced by #4864) now documented in `.env.example` + `docs/reference/ENVIRONMENT.md`.
2. **file-size**: `tests/unit/image-generation-handler.test.ts` baseline 1996 → 2019 (actual size, pre-existing drift).

Both gates verified green locally.