### PR TITLE
fix(security): SSRF x-relay-path bypass nos relays edge Deno + Vercel

### DIFF
--- a/src/app/api/settings/proxy/deno-deploy/route.ts
+++ b/src/app/api/settings/proxy/deno-deploy/route.ts
@@ -10,13 +10,74 @@ const DENO_API_BASE = process.env.DENO_DEPLOY_API_BASE || "https://api.deno.com/
 const POLL_INTERVAL_MS = 2000;
 const POLL_MAX_ATTEMPTS = 30; // ~60 s
 
+/**
+ * SSRF-safe resolution of the relay path against an already-validated target.
+ *
+ * The relay worker receives an attacker-controlled `x-relay-path` and must
+ * append it to the target ORIGIN without letting the caller swap the host that
+ * `x-relay-target` was validated for. The pre-#4643-fix worker did
+ * `target.replace(/\/$/, "") + relayPath`, which is bypassable via userinfo
+ * (`/x@evil.com`), a backslash (`\evil.com`), or a protocol-relative path
+ * (`//evil.com/x`). We instead resolve with `new URL(relayPath, targetUrl)` and
+ * re-assert that the resolved host/credentials still match the target.
+ *
+ * Pure (only `URL`, no Node/Deno globals) so the SAME source can be embedded
+ * verbatim into the Deno edge worker AND unit-tested directly in Node. Returns a
+ * tagged result instead of throwing so the worker can map it to an HTTP status.
+ */
+export function resolveRelayTarget(
+  target: string,
+  relayPath: string
+): { ok: true; url: string } | { ok: false; status: 400 | 403; reason: string } {
+  let targetUrl;
+  try {
+    targetUrl = new URL(target);
+  } catch {
+    return { ok: false, status: 400, reason: "invalid x-relay-target" };
+  }
+  // Reject the host-confusion vectors up front. A backslash or '@' has no place
+  // in a legitimate path/query, and `new URL` (special-scheme parsing) would
+  // otherwise treat them as authority/userinfo delimiters.
+  if (
+    typeof relayPath !== "string" ||
+    relayPath.indexOf("@") !== -1 ||
+    relayPath.indexOf("\\") !== -1 ||
+    relayPath.charAt(0) !== "/"
+  ) {
+    return { ok: false, status: 403, reason: "forbidden x-relay-path" };
+  }
+  let finalUrl;
+  try {
+    finalUrl = new URL(relayPath, targetUrl);
+  } catch {
+    return { ok: false, status: 403, reason: "forbidden x-relay-path" };
+  }
+  // A protocol-relative path ("//evil.com/x") resolves to a different host;
+  // userinfo would surface as username/password. Either means the path tried to
+  // re-point the request away from the validated target — reject.
+  if (
+    finalUrl.hostname !== targetUrl.hostname ||
+    finalUrl.protocol !== targetUrl.protocol ||
+    finalUrl.port !== targetUrl.port ||
+    finalUrl.username ||
+    finalUrl.password
+  ) {
+    return { ok: false, status: 403, reason: "forbidden x-relay-path (host mismatch)" };
+  }
+  return { ok: true, url: finalUrl.toString() };
+}
+
 // Inlined Deno Deploy relay worker. The relayAuth secret is generated
 // server-side (no user input); the runtime SSRF guard is inlined into the
 // edge function because Deno Deploy isolates each app and cannot import
-// Node-side helpers. Mirrors the Vercel-relay guard byte-for-byte so a
-// future audit can diff the two and confirm they enforce the same policy.
+// Node-side helpers. The path-resolution guard (`resolveRelayTarget`) is the
+// SAME source used by the server and by the unit tests — embedded here via
+// Function#toString so the worker enforces byte-for-byte the audited policy.
+// Mirrors the Vercel-relay guard so a future audit can diff the two.
 function buildRelayWorker(relayAuth: string): string {
-  return `function isPrivateHostname(h) {
+  return `${resolveRelayTarget.toString()}
+
+function isPrivateHostname(h) {
   if (!h) return true;
   const host = h.trim().toLowerCase().replace(/^\\[|\\]$/g, "");
   if (
@@ -62,6 +123,10 @@ Deno.serve(async (request) => {
     return new Response("forbidden x-relay-target (private/loopback host)", { status: 403 });
   }
   const relayPath = request.headers.get("x-relay-path") || "/";
+  const resolved = resolveRelayTarget(target, relayPath);
+  if (!resolved.ok) {
+    return new Response(resolved.reason, { status: resolved.status });
+  }
   const headers = new Headers(request.headers);
   ["x-relay-target", "x-relay-path", "x-relay-auth", "host"].forEach(h => headers.delete(h));
   const init = { method: request.method, headers };
@@ -70,7 +135,7 @@ Deno.serve(async (request) => {
     init.duplex = "half";
   }
   try {
-    const upstream = await fetch(target.replace(/\\/$/, "") + relayPath, init);
+    const upstream = await fetch(resolved.url, init);
     return new Response(upstream.body, { status: upstream.status, headers: upstream.headers });
   } catch (error) {
     return new Response(JSON.stringify({ error: String(error && error.message || error) }), {
@@ -80,6 +145,13 @@ Deno.serve(async (request) => {
   }
 });`;
 }
+
+/**
+ * Test-only hook exposing the generated worker source so the SSRF regression
+ * test can assert the worker no longer string-concatenates the relay path and
+ * embeds the shared `resolveRelayTarget` guard. Not part of the route contract.
+ */
+export const __buildRelayWorkerForTest = buildRelayWorker;
 
 async function pollRevision(
   revisionId: string,

--- a/src/app/api/settings/proxy/vercel-deploy/route.ts
+++ b/src/app/api/settings/proxy/vercel-deploy/route.ts
@@ -5,6 +5,10 @@ import { isValidationFailure, validateBody } from "@/shared/validation/helpers";
 import { vercelDeploySchema } from "@/shared/validation/freeProxySchemas";
 import { createProxy } from "@/lib/localDb";
 import { encrypt } from "@/lib/db/encryption";
+// Shared SSRF-safe relay-path resolver — the same pure guard embedded in the
+// Deno Deploy worker. Both edge relays must enforce identical path validation,
+// so they import one source of truth rather than diverging copies.
+import { resolveRelayTarget } from "../deno-deploy/route";
 
 const VERCEL_API_BASE = process.env.VERCEL_API_BASE || "https://api.vercel.com";
 const POLL_INTERVAL_MS = 3000;
@@ -15,7 +19,11 @@ function buildRelayFunction(relayAuth: string): string {
   // The runtime SSRF guard is inlined into the edge function (cannot import
   // Node-side helpers from the Edge runtime); it blocks RFC1918, loopback,
   // link-local, IPv6 ULA, and embedded credentials on the x-relay-target host.
+  // `resolveRelayTarget` (shared with the Deno worker) closes the x-relay-path
+  // host-confusion hole and is embedded verbatim via Function#toString.
   return `export const config = { runtime: "edge" };
+
+${resolveRelayTarget.toString()}
 
 function isPrivateHostname(h) {
   if (!h) return true;
@@ -63,9 +71,13 @@ export default async function handler(req) {
     return new Response("forbidden x-relay-target (private/loopback host)", { status: 403 });
   }
   const relayPath = req.headers.get("x-relay-path") || "/";
+  const resolved = resolveRelayTarget(target, relayPath);
+  if (!resolved.ok) {
+    return new Response(resolved.reason, { status: resolved.status });
+  }
   const headers = new Headers(req.headers);
   ["x-relay-target", "x-relay-path", "x-relay-auth", "host"].forEach(h => headers.delete(h));
-  const upstream = await fetch(target.replace(/\\/$/, "") + relayPath, {
+  const upstream = await fetch(resolved.url, {
     method: req.method,
     headers,
     body: req.method !== "GET" && req.method !== "HEAD" ? req.body : undefined,
@@ -74,6 +86,14 @@ export default async function handler(req) {
   return new Response(upstream.body, { status: upstream.status, headers: upstream.headers });
 }`;
 }
+
+/**
+ * Test-only hook exposing the generated Vercel worker source so the SSRF
+ * regression test can assert it no longer string-concatenates the relay path
+ * and embeds the shared `resolveRelayTarget` guard. Not part of the route
+ * contract.
+ */
+export const __buildRelayFunctionForTest = buildRelayFunction;
 
 async function pollDeployment(deploymentApiUrl: string, token: string): Promise<"READY" | "ERROR"> {
   for (let i = 0; i < POLL_MAX_ATTEMPTS; i++) {

--- a/tests/unit/deno-deploy-relay-path-ssrf.test.ts
+++ b/tests/unit/deno-deploy-relay-path-ssrf.test.ts
@@ -1,0 +1,104 @@
+// SSRF regression guard for the Deno Deploy relay worker (PR #4643 follow-up).
+//
+// The generated edge worker reads an attacker-controlled `x-relay-path` header
+// and previously appended it to the (validated) `x-relay-target` origin via
+// string concatenation: `fetch(target.replace(/\/$/, "") + relayPath)`. That
+// lets the caller smuggle a NEW host past the allow/SSRF check using userinfo
+// (`@`), a backslash, or a protocol-relative path:
+//   - x-relay-target: https://api.anthropic.com   (passes the host guard)
+//   - x-relay-path:   //evil.com/x                 → fetches https://evil.com/x
+//   - x-relay-path:   /x@evil.com                  → userinfo confusion
+//   - x-relay-path:   \evil.com                    → backslash host confusion
+//
+// The fix resolves the path against the validated target with `new URL()` and
+// re-checks that the resolved host/credentials still match the target. The
+// path-resolution decision is exported as the pure `resolveRelayTarget()` so it
+// can be unit-tested directly (the worker body — a Deno-runtime string — embeds
+// the SAME function source, asserted below by diffing the generated worker).
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  resolveRelayTarget,
+  __buildRelayWorkerForTest,
+} from "../../src/app/api/settings/proxy/deno-deploy/route";
+
+const TARGET = "https://api.anthropic.com";
+
+describe("resolveRelayTarget — SSRF-safe path join", () => {
+  it("accepts a legitimate absolute path and keeps the validated host", () => {
+    const r = resolveRelayTarget(TARGET, "/v1/foo");
+    assert.equal(r.ok, true, "a normal path must pass");
+    if (r.ok) {
+      assert.equal(r.url, "https://api.anthropic.com/v1/foo");
+    }
+  });
+
+  it("accepts a path with a query string", () => {
+    const r = resolveRelayTarget(TARGET, "/v1/messages?beta=true");
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.url, "https://api.anthropic.com/v1/messages?beta=true");
+    }
+  });
+
+  it("rejects a protocol-relative path that swaps the host (//evil.com/x)", () => {
+    const r = resolveRelayTarget(TARGET, "//evil.com/x");
+    assert.equal(r.ok, false, "//evil.com must NOT be allowed to change the host");
+    if (!r.ok) assert.equal(r.status, 403);
+  });
+
+  it("rejects a path containing userinfo (/x@evil.com)", () => {
+    const r = resolveRelayTarget(TARGET, "/x@evil.com");
+    assert.equal(r.ok, false, "@ in the path must be rejected");
+    if (!r.ok) assert.equal(r.status, 403);
+  });
+
+  it("rejects a backslash host-confusion path (\\evil.com)", () => {
+    const r = resolveRelayTarget(TARGET, "\\evil.com");
+    assert.equal(r.ok, false, "backslash must be rejected");
+    if (!r.ok) assert.equal(r.status, 403);
+  });
+
+  it("rejects a value that does not start with '/'", () => {
+    const r = resolveRelayTarget(TARGET, "evil.com/x");
+    assert.equal(r.ok, false, "a path must start with '/'");
+    if (!r.ok) assert.equal(r.status, 403);
+  });
+
+  it("rejects an embedded-credentials path that resolves a different host", () => {
+    // Classic userinfo trick: everything before '@' becomes userinfo, the real
+    // host is after it.
+    const r = resolveRelayTarget(TARGET, "/@evil.com/path");
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.equal(r.status, 403);
+  });
+
+  it("rejects backslash-prefixed protocol-relative (\\\\evil.com)", () => {
+    const r = resolveRelayTarget(TARGET, "\\\\evil.com/x");
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.equal(r.status, 403);
+  });
+});
+
+describe("buildRelayWorker — generated worker has no string-concat SSRF hole", () => {
+  it("does not concatenate the target with the raw relay path", () => {
+    const worker = __buildRelayWorkerForTest("deadbeefcafe");
+    // The vulnerable pattern was: target.replace(/\/$/, "") + relayPath
+    assert.ok(
+      !/\.replace\(\s*\/\\?\/\$\/\s*,\s*["']{2}\s*\)\s*\+\s*relayPath/.test(worker),
+      "worker must not append relayPath to target by string concatenation"
+    );
+    assert.ok(
+      !worker.includes('+ relayPath'),
+      "worker must not contain `+ relayPath` string concatenation"
+    );
+  });
+
+  it("embeds the resolveRelayTarget guard into the worker body", () => {
+    const worker = __buildRelayWorkerForTest("deadbeefcafe");
+    assert.ok(
+      worker.includes("resolveRelayTarget"),
+      "the worker must call the shared resolveRelayTarget guard"
+    );
+  });
+});

--- a/tests/unit/vercel-deploy-relay-path-ssrf.test.ts
+++ b/tests/unit/vercel-deploy-relay-path-ssrf.test.ts
@@ -1,0 +1,87 @@
+// SSRF regression guard for the Vercel relay worker (lockstep with the Deno
+// Deploy relay fix; PR #4643 / deno-deploy follow-up).
+//
+// The generated Vercel edge function reads an attacker-controlled `x-relay-path`
+// header and previously appended it to the (validated) `x-relay-target` origin
+// via string concatenation: `fetch(target.replace(/\/$/, "") + relayPath)`.
+// That is bypassable via userinfo (`/x@evil.com`), a backslash (`\evil.com`), or
+// a protocol-relative path (`//evil.com/x`) — the same hole the Deno worker had.
+//
+// The fix reuses the SAME pure `resolveRelayTarget()` guard (exported from the
+// deno-deploy route, embedded into both workers via Function#toString). This
+// test mirrors `deno-deploy-relay-path-ssrf.test.ts`: it asserts the generated
+// Vercel worker no longer string-concatenates the path and embeds the guard.
+// The pure-function behavior itself is covered once in the deno test (same
+// function); here we focus on the Vercel worker wiring.
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { resolveRelayTarget } from "../../src/app/api/settings/proxy/deno-deploy/route";
+import { __buildRelayFunctionForTest } from "../../src/app/api/settings/proxy/vercel-deploy/route";
+
+const TARGET = "https://api.anthropic.com";
+
+describe("vercel relay reuses the SSRF-safe resolveRelayTarget guard", () => {
+  it("accepts a legitimate absolute path", () => {
+    const r = resolveRelayTarget(TARGET, "/v1/foo");
+    assert.equal(r.ok, true);
+    if (r.ok) assert.equal(r.url, "https://api.anthropic.com/v1/foo");
+  });
+
+  it("rejects //evil.com/x (host swap)", () => {
+    const r = resolveRelayTarget(TARGET, "//evil.com/x");
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.equal(r.status, 403);
+  });
+
+  it("rejects /x@evil.com (userinfo)", () => {
+    const r = resolveRelayTarget(TARGET, "/x@evil.com");
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.equal(r.status, 403);
+  });
+
+  it("rejects \\evil.com (backslash)", () => {
+    const r = resolveRelayTarget(TARGET, "\\evil.com");
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.equal(r.status, 403);
+  });
+
+  it("rejects a value without a leading '/'", () => {
+    const r = resolveRelayTarget(TARGET, "evil.com/x");
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.equal(r.status, 403);
+  });
+});
+
+describe("buildRelayFunction — generated Vercel worker has no string-concat SSRF hole", () => {
+  it("does not append relayPath to target by string concatenation", () => {
+    const worker = __buildRelayFunctionForTest("deadbeefcafe");
+    assert.ok(
+      !worker.includes("+ relayPath"),
+      "Vercel worker must not contain `+ relayPath` string concatenation"
+    );
+    assert.ok(
+      !/\.replace\(\s*\/\\?\/\$\/\s*,\s*["']{2}\s*\)\s*\+\s*relayPath/.test(worker),
+      "Vercel worker must not append relayPath to target by string concatenation"
+    );
+  });
+
+  it("embeds the resolveRelayTarget guard and fetches the resolved url", () => {
+    const worker = __buildRelayFunctionForTest("deadbeefcafe");
+    assert.ok(
+      worker.includes("resolveRelayTarget"),
+      "the Vercel worker must call the shared resolveRelayTarget guard"
+    );
+    assert.ok(
+      worker.includes("resolved.url"),
+      "the Vercel worker must fetch the SSRF-validated resolved url"
+    );
+  });
+
+  it("still ships the edge runtime config marker", () => {
+    const worker = __buildRelayFunctionForTest("deadbeefcafe");
+    assert.ok(
+      worker.includes('runtime: "edge"'),
+      "the Vercel edge runtime config must be preserved"
+    );
+  });
+});


### PR DESCRIPTION
Corrige um **SSRF allowlist-bypass (HIGH)** nos workers edge de relay **Deno Deploy** e **Vercel**: o header `x-relay-path` era concatenado por string à URL alvo validada (`target + relayPath`), permitindo host-swap via userinfo (`/x@evil.com`), backslash (`\evil.com`) ou protocol-relative (`//evil.com/x`).

Fix: função pura `resolveRelayTarget(target, relayPath)` — rejeita `@`/`\`/path sem `/`, resolve com `new URL(relayPath, targetUrl)` e re-assegura `hostname`/`protocol`/`port` iguais + sem `username`/`password`. Embutida byte-a-byte em ambos os workers via `Function#toString` (single source of truth testada). Defense-in-depth.

O hole veio do **#4643** (Deno relays). **31 testes** (deno 10 + vercel 8 novos + 13 regressão) · typecheck:core · eslint · file-size — todos verdes.