### PR TITLE
feat(providers): update volcengine-ark model list with DeepSeek V4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 _In development — bullets added per PR; finalized at release._
 
+- **feat(providers):** update volcengine-ark model list, adding DeepSeek-V4-Flash and DeepSeek-V4-Pro. (thanks @kenlin8827)
+
 ---
 
 ## [3.8.35] — 2026-06-23

--- a/open-sse/config/providers/shared.ts
+++ b/open-sse/config/providers/shared.ts
@@ -380,6 +380,9 @@ export const CHAT_OPENAI_COMPAT_MODELS: Record<string, RegistryModel[]> = {
     // notices); replaced by kimi-k2-5-260127.
     "kimi-k2-5-260127",
     "glm-4-7-251222",
+    // DeepSeek V4 models available on Volcengine Ark (port from upstream PR #1473)
+    "DeepSeek-V4-Flash",
+    "DeepSeek-V4-Pro",
   ]),
   ai21: buildModels(["jamba-large-1.7", "jamba-mini-2"]),
   gigachat: buildModels(["GigaChat-2-Max", "GigaChat-2-Pro", "GigaChat-2-Lite"]),

--- a/tests/unit/t28-model-catalog-updates.test.ts
+++ b/tests/unit/t28-model-catalog-updates.test.ts
@@ -72,6 +72,23 @@ test("T28: vertex catalog includes partner models when vertex executor is availa
   assert.ok(vertexIds.includes("GLM-5.1-FP8"));
 });
 
+test("T28: volcengine (Ark) catalog includes DeepSeek V4 models", () => {
+  const volcengineIds = REGISTRY.volcengine.models.map((m) => m.id);
+
+  assert.ok(
+    volcengineIds.includes("DeepSeek-V4-Flash"),
+    "volcengine Ark must list DeepSeek-V4-Flash"
+  );
+  assert.ok(
+    volcengineIds.includes("DeepSeek-V4-Pro"),
+    "volcengine Ark must list DeepSeek-V4-Pro"
+  );
+  // Existing models must still be present
+  assert.ok(volcengineIds.includes("deepseek-v3-2-251201"));
+  assert.ok(volcengineIds.includes("kimi-k2-5-260127"));
+  assert.ok(volcengineIds.includes("glm-4-7-251222"));
+});
+
 test("T28: new catalog models resolve through getModelInfoCore", async () => {
   const minimax = await getModelInfoCore("minimax/MiniMax-M2.7", {});
   assert.equal(minimax.provider, "minimax");


### PR DESCRIPTION
## Summary

- Adds **DeepSeek-V4-Flash** and **DeepSeek-V4-Pro** to the volcengine (Ark) provider model list
- Existing models (`deepseek-v3-2-251201`, `kimi-k2-5-260127`, `glm-4-7-251222`, Doubao Seed models) remain unchanged

## Attribution

Thanks to [@kenlin8827](https://github.com/kenlin8827) for the original implementation.

## Changes

- `open-sse/config/providers/shared.ts` — added two DeepSeek V4 model IDs to the `volcengine` entry in `CHAT_OPENAI_COMPAT_MODELS`
- `tests/unit/t28-model-catalog-updates.test.ts` — new test asserting DeepSeek-V4-Flash and DeepSeek-V4-Pro are present in volcengine registry
- `CHANGELOG.md` — added bullet in `[3.8.36]` section

## Test plan

- [x] `node --import tsx/esm --test tests/unit/t28-model-catalog-updates.test.ts` — 7/7 pass
- [x] `npm run typecheck:core` — clean
- [x] `npm run check:cycles` — no cycles
- [x] `npm run check:any-budget:t11` — within budget