### PR TITLE
feat(quota): saturação proativa por headers de tokens (universal) [Fase 3 #2]

### DIFF
--- a/src/lib/quota/saturationSignals.ts
+++ b/src/lib/quota/saturationSignals.ts
@@ -60,18 +60,124 @@ interface RateLimitHeaderEntry {
   ts: number;
 }
 
+/**
+ * TOKEN rate-limit header snapshot. Unlike the per-minute REQUEST headers, the
+ * token headers ride on EVERY upstream response (success too), so they enable
+ * proactive throttling before a 429. `resetAt` is the upstream reset normalized
+ * to epoch ms (Anthropic RFC3339 → Date.parse; OpenAI duration → now + secs),
+ * or null when the upstream sent no reset header.
+ */
+interface TokenHeaderEntry {
+  limit: number;
+  remaining: number;
+  resetAt: number | null; // epoch ms, normalized; null when unknown
+  ts: number;
+}
+
 const _rateLimitHeaders = new Map<string, RateLimitHeaderEntry>();
+const _tokenHeaders = new Map<string, TokenHeaderEntry>();
 const RL_HEADER_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+/** Test-only: clear the rate-limit + token header caches between asserts. */
+export function _clearRateLimitHeaders(): void {
+  _rateLimitHeaders.clear();
+  _tokenHeaders.clear();
+}
+
+/**
+ * Parse an OpenAI rate-limit reset DURATION string into milliseconds.
+ * OpenAI reports token/request resets as Go-style durations, e.g. "6m0s",
+ * "1s", "1h30m15s", "1.5s". Returns null when unparseable.
+ */
+function parseDurationMs(raw: string): number | null {
+  const s = raw.trim();
+  if (!s) return null;
+  // Bounded, non-overlapping segments to avoid ReDoS (PII learning #1).
+  const re = /(\d+(?:\.\d+)?)(ms|h|m|s)/g;
+  let total = 0;
+  let matched = false;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(s)) !== null) {
+    matched = true;
+    const value = Number(m[1]);
+    if (!Number.isFinite(value)) return null;
+    switch (m[2]) {
+      case "h":
+        total += value * 3_600_000;
+        break;
+      case "m":
+        total += value * 60_000;
+        break;
+      case "s":
+        total += value * 1000;
+        break;
+      case "ms":
+        total += value;
+        break;
+    }
+  }
+  return matched ? total : null;
+}
+
+/**
+ * Normalize a token-reset header value to epoch ms.
+ *   - Anthropic: RFC3339 timestamp ("2026-01-01T00:00:30Z") → Date.parse.
+ *   - OpenAI: duration ("6m0s") → now + parsed ms.
+ * Returns null when absent or unparseable.
+ */
+function normalizeTokenReset(raw: string | undefined, nowMs: number): number | null {
+  if (!raw) return null;
+  const s = raw.trim();
+  if (!s) return null;
+  // RFC3339 / ISO-8601 if it looks like a date (YYYY-MM-DD with a time sep).
+  if (/\d{4}-\d{2}-\d{2}/.test(s) && /[T:]/.test(s)) {
+    const t = Date.parse(s);
+    if (Number.isFinite(t)) return t;
+  }
+  // Otherwise treat as an OpenAI-style duration relative to now.
+  const durMs = parseDurationMs(s);
+  return durMs === null ? null : nowMs + durMs;
+}
+
+/**
+ * Pick the first present {limit, remaining[, reset]} triple from a list of
+ * header-key candidates, in priority order. Returns null when none are usable
+ * (missing keys, non-finite, or limit <= 0).
+ */
+function pickTokenTriple(
+  headers: Record<string, string>,
+  candidates: Array<{ limit: string; remaining: string; reset: string }>
+): { limit: number; remaining: number; reset: string | undefined } | null {
+  for (const c of candidates) {
+    const limitStr = headers[c.limit];
+    const remainingStr = headers[c.remaining];
+    if (limitStr === undefined || remainingStr === undefined) continue;
+    const limit = Number(limitStr);
+    const remaining = Number(remainingStr);
+    if (Number.isFinite(limit) && limit > 0 && Number.isFinite(remaining)) {
+      return { limit, remaining, reset: headers[c.reset] };
+    }
+  }
+  return null;
+}
 
 /**
  * Store rate-limit headers from an upstream response for saturation signal use.
  * Called by the response handler after a successful request.
+ *
+ * Captures two independent signals, both keyed `${provider}:${connectionId}`:
+ *   - REQUEST headers (per-minute RPM burst) — legacy, anthropic fallback.
+ *   - TOKEN headers (per-window TPM) — universal proactive saturation; present
+ *     on EVERY response, so we can throttle before the 429.
  */
 export function storeRateLimitHeaders(
   connectionId: string,
   provider: string,
   headers: Record<string, string>
 ): void {
+  const key = `${provider}:${connectionId}`;
+
+  // ── REQUEST headers (legacy path, unchanged) ──────────────────────────────
   // Anthropic: anthropic-ratelimit-requests-limit / anthropic-ratelimit-requests-remaining
   const limitStr =
     headers["anthropic-ratelimit-requests-limit"] ??
@@ -86,13 +192,63 @@ export function storeRateLimitHeaders(
     const limit = Number(limitStr);
     const remaining = Number(remainingStr);
     if (Number.isFinite(limit) && limit > 0 && Number.isFinite(remaining)) {
-      _rateLimitHeaders.set(`${provider}:${connectionId}`, {
-        limit,
-        remaining,
-        ts: Date.now(),
-      });
+      _rateLimitHeaders.set(key, { limit, remaining, ts: Date.now() });
     }
   }
+
+  // ── TOKEN headers (universal proactive saturation) ────────────────────────
+  // Anthropic base tokens, then OpenAI x-ratelimit-*-tokens, then anthropic
+  // input/output variants as a fallback. First usable triple wins.
+  const tokenTriple = pickTokenTriple(headers, [
+    {
+      limit: "anthropic-ratelimit-tokens-limit",
+      remaining: "anthropic-ratelimit-tokens-remaining",
+      reset: "anthropic-ratelimit-tokens-reset",
+    },
+    {
+      limit: "x-ratelimit-limit-tokens",
+      remaining: "x-ratelimit-remaining-tokens",
+      reset: "x-ratelimit-reset-tokens",
+    },
+    {
+      limit: "anthropic-ratelimit-input-tokens-limit",
+      remaining: "anthropic-ratelimit-input-tokens-remaining",
+      reset: "anthropic-ratelimit-input-tokens-reset",
+    },
+    {
+      limit: "anthropic-ratelimit-output-tokens-limit",
+      remaining: "anthropic-ratelimit-output-tokens-remaining",
+      reset: "anthropic-ratelimit-output-tokens-reset",
+    },
+  ]);
+
+  if (tokenTriple) {
+    const now = Date.now();
+    _tokenHeaders.set(key, {
+      limit: tokenTriple.limit,
+      remaining: tokenTriple.remaining,
+      resetAt: normalizeTokenReset(tokenTriple.reset, now),
+      ts: now,
+    });
+  }
+}
+
+/**
+ * Token-header saturation signal for a (provider, connectionId).
+ * Returns `{ saturation, resetAt }` where saturation = 1 − remaining/limit
+ * (clamped 0..1) and resetAt is the normalized epoch-ms reset (or null), or
+ * null when no fresh token-header data exists.
+ */
+export function getTokenHeaderSaturation(
+  provider: string,
+  connectionId: string
+): { saturation: number; resetAt: number | null } | null {
+  const entry = _tokenHeaders.get(`${provider}:${connectionId}`);
+  if (!entry || Date.now() - entry.ts > RL_HEADER_TTL_MS) return null;
+  if (!(entry.limit > 0)) return null;
+  const used = entry.limit - entry.remaining;
+  const saturation = Math.min(1, Math.max(0, used / entry.limit));
+  return { saturation, resetAt: entry.resetAt };
 }
 
 function cacheKey(connectionId: string, provider: string, dim: DimensionSpec): string {
@@ -292,26 +448,56 @@ async function fetchAnthropicSaturation(
   return anthropicHeaderSaturation(connectionId);
 }
 
+/**
+ * Injectable seam for the generic usage fetch so the token-header
+ * complement/fallback is unit-testable without the open-sse usage service.
+ * Defaults to getUsageForProvider; pass null to restore.
+ */
+type GenericUsageFetcher = (connectionId: string, provider: string) => Promise<unknown>;
+let _genericUsageFetcherOverride: GenericUsageFetcher | null = null;
+
+/** Test-only: inject the generic usage fetcher; pass null to restore. */
+export function __setGenericUsageFetcherForTests(fetcher: GenericUsageFetcher | null): void {
+  _genericUsageFetcherOverride = fetcher;
+}
+
+async function defaultGenericUsageFetch(
+  connectionId: string,
+  provider: string
+): Promise<unknown> {
+  const mod = await import("@omniroute/open-sse/services/usage");
+  const conn = { id: connectionId, provider } as Parameters<typeof mod.getUsageForProvider>[0];
+  return mod.getUsageForProvider(conn);
+}
+
 async function fetchGenericSaturation(
   connectionId: string,
   provider: string
 ): Promise<number> {
+  // 1. Real usage percent is authoritative when present (a provider that
+  //    actually reports utilization beats the burst-window token headers).
   try {
-    const mod = await import("@omniroute/open-sse/services/usage");
-    const conn = { id: connectionId, provider } as Parameters<typeof mod.getUsageForProvider>[0];
-    const result = await mod.getUsageForProvider(conn);
-    if (!result || typeof result !== "object") return 0;
-    const obj = result as Record<string, unknown>;
-    const pct =
-      typeof obj.percentUsed === "number"
-        ? obj.percentUsed
-        : typeof obj.used_percent === "number"
-          ? obj.used_percent
-          : 0;
-    return Math.min(1, Math.max(0, pct));
+    const fetcher = _genericUsageFetcherOverride ?? defaultGenericUsageFetch;
+    const result = await fetcher(connectionId, provider);
+    if (result && typeof result === "object") {
+      const obj = result as Record<string, unknown>;
+      const pct =
+        typeof obj.percentUsed === "number"
+          ? obj.percentUsed
+          : typeof obj.used_percent === "number"
+            ? obj.used_percent
+            : null;
+      if (pct !== null && Number.isFinite(pct)) {
+        return Math.min(1, Math.max(0, pct));
+      }
+    }
   } catch {
-    return 0;
+    // fall through to the token-header complement
   }
+
+  // 2. Complement/fallback: proactive TOKEN-header saturation (universal, rides
+  //    on every response). Fail-open to 0 when no fresh token-header data.
+  return getTokenHeaderSaturation(provider, connectionId)?.saturation ?? 0;
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/quota-saturation-token-headers.test.ts
+++ b/tests/unit/quota-saturation-token-headers.test.ts
@@ -1,0 +1,306 @@
+/**
+ * tests/unit/quota-saturation-token-headers.test.ts
+ *
+ * #2 — Proactive saturation from TOKEN rate-limit headers (universal).
+ *
+ * storeRateLimitHeaders previously only captured the per-minute REQUEST headers
+ * (anthropic-ratelimit-requests-* / x-ratelimit-*-requests). TOKEN headers ride
+ * on EVERY upstream response (success too), so they let us throttle proactively
+ * before a 429.
+ *
+ * This suite asserts:
+ *   - storeRateLimitHeaders parses Anthropic token headers
+ *     (anthropic-ratelimit-tokens-{limit,remaining,reset}, reset = RFC3339)
+ *     and OpenAI token headers (x-ratelimit-{limit,remaining,reset}-tokens,
+ *     reset = duration string like "6m0s"/"1s").
+ *   - the resulting token-header saturation = 1 − remaining/limit (clamped 0..1).
+ *   - reset is normalized to an epoch-ms `resetAt` (RFC3339 → epoch,
+ *     duration → now + parsed seconds).
+ *   - the existing REQUEST path is untouched (no regression).
+ *   - getSaturation for a generic provider (openai) surfaces the token-header
+ *     signal when usage returns nothing (fallback/complement), failing open to 0.
+ *
+ * Pure parse + cache; no DB, no network. The 30s saturation cache and the
+ * token-header cache are cleared between asserts.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const satMod = await import("../../src/lib/quota/saturationSignals.ts");
+const {
+  storeRateLimitHeaders,
+  getTokenHeaderSaturation,
+  getSaturation,
+  _clearSaturationCache,
+  _clearRateLimitHeaders,
+  __setGenericUsageFetcherForTests,
+} = satMod;
+
+test.afterEach(() => {
+  _clearSaturationCache();
+  _clearRateLimitHeaders();
+  __setGenericUsageFetcherForTests(null);
+});
+
+// ─── Anthropic token headers (reset = RFC3339) ───────────────────────────────
+
+test("Anthropic token headers → saturation = 1 − remaining/limit", () => {
+  _clearRateLimitHeaders();
+  // 1000 limit, 250 remaining → 750 used → 0.75 saturation.
+  storeRateLimitHeaders("anth-conn-1", "anthropic", {
+    "anthropic-ratelimit-tokens-limit": "1000",
+    "anthropic-ratelimit-tokens-remaining": "250",
+    "anthropic-ratelimit-tokens-reset": "2026-01-01T00:00:30Z",
+  });
+
+  const sig = getTokenHeaderSaturation("anthropic", "anth-conn-1");
+  assert.ok(sig, "expected a token-header saturation signal");
+  assert.ok(Math.abs(sig!.saturation - 0.75) < 1e-9, `expected ≈0.75, got ${sig!.saturation}`);
+});
+
+test("Anthropic token reset (RFC3339) is normalized to epoch ms", () => {
+  _clearRateLimitHeaders();
+  storeRateLimitHeaders("anth-conn-2", "anthropic", {
+    "anthropic-ratelimit-tokens-limit": "1000",
+    "anthropic-ratelimit-tokens-remaining": "0",
+    "anthropic-ratelimit-tokens-reset": "2026-01-01T00:00:30Z",
+  });
+
+  const sig = getTokenHeaderSaturation("anthropic", "anth-conn-2");
+  assert.ok(sig, "expected signal");
+  const expected = Date.parse("2026-01-01T00:00:30Z");
+  assert.equal(sig!.resetAt, expected, `resetAt should be RFC3339 epoch ${expected}, got ${sig!.resetAt}`);
+  // fully exhausted → saturation 1.
+  assert.equal(sig!.saturation, 1);
+});
+
+test("Anthropic input/output token variants are captured when base tokens header absent", () => {
+  _clearRateLimitHeaders();
+  // No base anthropic-ratelimit-tokens-*; only the input variant present.
+  storeRateLimitHeaders("anth-conn-3", "anthropic", {
+    "anthropic-ratelimit-input-tokens-limit": "2000",
+    "anthropic-ratelimit-input-tokens-remaining": "500",
+    "anthropic-ratelimit-input-tokens-reset": "2026-01-01T00:01:00Z",
+  });
+
+  const sig = getTokenHeaderSaturation("anthropic", "anth-conn-3");
+  assert.ok(sig, "expected signal from input-tokens variant");
+  // 2000 limit, 500 remaining → 1500 used → 0.75.
+  assert.ok(Math.abs(sig!.saturation - 0.75) < 1e-9, `expected ≈0.75, got ${sig!.saturation}`);
+});
+
+// ─── OpenAI token headers (reset = DURATION) ─────────────────────────────────
+
+test("OpenAI token headers → saturation = 1 − remaining/limit", () => {
+  _clearRateLimitHeaders();
+  // 90000 limit, 9000 remaining → 81000 used → 0.9.
+  storeRateLimitHeaders("oai-conn-1", "openai", {
+    "x-ratelimit-limit-tokens": "90000",
+    "x-ratelimit-remaining-tokens": "9000",
+    "x-ratelimit-reset-tokens": "6m0s",
+  });
+
+  const sig = getTokenHeaderSaturation("openai", "oai-conn-1");
+  assert.ok(sig, "expected token-header signal");
+  assert.ok(Math.abs(sig!.saturation - 0.9) < 1e-9, `expected ≈0.9, got ${sig!.saturation}`);
+});
+
+test('OpenAI reset duration "6m0s" → now + 360s (epoch ms)', () => {
+  _clearRateLimitHeaders();
+  const before = Date.now();
+  storeRateLimitHeaders("oai-conn-2", "openai", {
+    "x-ratelimit-limit-tokens": "1000",
+    "x-ratelimit-remaining-tokens": "100",
+    "x-ratelimit-reset-tokens": "6m0s",
+  });
+  const after = Date.now();
+
+  const sig = getTokenHeaderSaturation("openai", "oai-conn-2");
+  assert.ok(sig, "expected signal");
+  // 6m0s = 360_000 ms in the future, measured from the store time.
+  assert.ok(
+    sig!.resetAt >= before + 360_000 && sig!.resetAt <= after + 360_000,
+    `resetAt should be ≈ now+360000, got ${sig!.resetAt} (window ${before + 360_000}..${after + 360_000})`
+  );
+});
+
+test('OpenAI reset duration "1s" → now + 1s (epoch ms)', () => {
+  _clearRateLimitHeaders();
+  const before = Date.now();
+  storeRateLimitHeaders("oai-conn-3", "openai", {
+    "x-ratelimit-limit-tokens": "1000",
+    "x-ratelimit-remaining-tokens": "500",
+    "x-ratelimit-reset-tokens": "1s",
+  });
+  const after = Date.now();
+
+  const sig = getTokenHeaderSaturation("openai", "oai-conn-3");
+  assert.ok(sig, "expected signal");
+  assert.ok(
+    sig!.resetAt >= before + 1000 && sig!.resetAt <= after + 1000,
+    `resetAt should be ≈ now+1000, got ${sig!.resetAt}`
+  );
+});
+
+test('OpenAI compound duration "1h30m15s" → 5415s', () => {
+  _clearRateLimitHeaders();
+  const before = Date.now();
+  storeRateLimitHeaders("oai-conn-4", "openai", {
+    "x-ratelimit-limit-tokens": "1000",
+    "x-ratelimit-remaining-tokens": "10",
+    "x-ratelimit-reset-tokens": "1h30m15s",
+  });
+  const after = Date.now();
+
+  const sig = getTokenHeaderSaturation("openai", "oai-conn-4");
+  assert.ok(sig, "expected signal");
+  const secs = (1 * 3600 + 30 * 60 + 15) * 1000; // 5_415_000
+  assert.ok(
+    sig!.resetAt >= before + secs && sig!.resetAt <= after + secs,
+    `resetAt should be ≈ now+${secs}, got ${sig!.resetAt}`
+  );
+});
+
+test('OpenAI fractional-second duration "1.5s" → 1500ms', () => {
+  _clearRateLimitHeaders();
+  const before = Date.now();
+  storeRateLimitHeaders("oai-conn-5", "openai", {
+    "x-ratelimit-limit-tokens": "1000",
+    "x-ratelimit-remaining-tokens": "10",
+    "x-ratelimit-reset-tokens": "1.5s",
+  });
+  const after = Date.now();
+
+  const sig = getTokenHeaderSaturation("openai", "oai-conn-5");
+  assert.ok(sig, "expected signal");
+  assert.ok(
+    sig!.resetAt >= before + 1500 && sig!.resetAt <= after + 1500,
+    `resetAt should be ≈ now+1500, got ${sig!.resetAt}`
+  );
+});
+
+// ─── Clamp / guards ──────────────────────────────────────────────────────────
+
+test("saturation is clamped to [0,1] (remaining > limit → 0)", () => {
+  _clearRateLimitHeaders();
+  storeRateLimitHeaders("oai-conn-clamp", "openai", {
+    "x-ratelimit-limit-tokens": "1000",
+    "x-ratelimit-remaining-tokens": "5000", // nonsensical but must not go negative
+  });
+
+  const sig = getTokenHeaderSaturation("openai", "oai-conn-clamp");
+  assert.ok(sig, "expected signal");
+  assert.equal(sig!.saturation, 0);
+});
+
+test("missing/invalid token headers → no signal (null)", () => {
+  _clearRateLimitHeaders();
+  storeRateLimitHeaders("oai-conn-none", "openai", {
+    "content-type": "application/json",
+  });
+  assert.equal(getTokenHeaderSaturation("openai", "oai-conn-none"), null);
+
+  // limit=0 must not divide-by-zero / produce a signal.
+  storeRateLimitHeaders("oai-conn-zero", "openai", {
+    "x-ratelimit-limit-tokens": "0",
+    "x-ratelimit-remaining-tokens": "0",
+  });
+  assert.equal(getTokenHeaderSaturation("openai", "oai-conn-zero"), null);
+});
+
+test("reset is optional — signal still produced without a reset header", () => {
+  _clearRateLimitHeaders();
+  storeRateLimitHeaders("oai-conn-noreset", "openai", {
+    "x-ratelimit-limit-tokens": "1000",
+    "x-ratelimit-remaining-tokens": "250",
+  });
+  const sig = getTokenHeaderSaturation("openai", "oai-conn-noreset");
+  assert.ok(sig, "expected signal without reset");
+  assert.ok(Math.abs(sig!.saturation - 0.75) < 1e-9);
+  assert.equal(sig!.resetAt, null);
+});
+
+// ─── No regression on the existing REQUEST path ──────────────────────────────
+
+test("REQUEST headers still drive getSaturation (anthropic header fallback unchanged)", async () => {
+  _clearSaturationCache();
+  _clearRateLimitHeaders();
+  // Only request headers (no oauth/usage, no token headers): the legacy fallback
+  // must still compute (limit-remaining)/limit = 0.7 for anthropic.
+  storeRateLimitHeaders("req-conn", "anthropic", {
+    "anthropic-ratelimit-requests-limit": "100",
+    "anthropic-ratelimit-requests-remaining": "30",
+  });
+
+  // No oauth token on the connection → fetchAnthropicSaturation falls to the header path.
+  satMod.__setAnthropicSaturationDepsForTests({
+    loadConnection: async () => ({ id: "req-conn", provider: "anthropic", authType: "apikey" }),
+    fetchUsage: async () => ({ message: "no plan window" }),
+  });
+
+  const val = await getSaturation("req-conn", "anthropic", { unit: "requests", window: "hourly" });
+  satMod.__setAnthropicSaturationDepsForTests(null);
+  assert.ok(Math.abs(val - 0.7) < 1e-9, `expected request-header fallback ≈0.7, got ${val}`);
+});
+
+// ─── Generic provider: token-header signal surfaces via getSaturation ────────
+
+test("getSaturation(openai) surfaces token-header saturation when usage returns nothing", async () => {
+  _clearSaturationCache();
+  _clearRateLimitHeaders();
+  // usage returns nothing usable → 0; token headers should provide the signal.
+  __setGenericUsageFetcherForTests(async () => null);
+  storeRateLimitHeaders("oai-gen-1", "openai", {
+    "x-ratelimit-limit-tokens": "1000",
+    "x-ratelimit-remaining-tokens": "100",
+    "x-ratelimit-reset-tokens": "30s",
+  });
+
+  const val = await getSaturation("oai-gen-1", "openai", { unit: "tokens", window: "hourly" });
+  assert.ok(Math.abs(val - 0.9) < 1e-9, `expected token-header ≈0.9, got ${val}`);
+});
+
+test("getSaturation(openai) prefers real usage percent over token headers when usage is present", async () => {
+  _clearSaturationCache();
+  _clearRateLimitHeaders();
+  // usage reports 0.5 (50% used) → authoritative; token headers say 0.9 but must not override.
+  __setGenericUsageFetcherForTests(async () => ({ percentUsed: 0.5 }));
+  storeRateLimitHeaders("oai-gen-2", "openai", {
+    "x-ratelimit-limit-tokens": "1000",
+    "x-ratelimit-remaining-tokens": "100", // → 0.9 if it leaked through
+  });
+
+  const val = await getSaturation("oai-gen-2", "openai", { unit: "tokens", window: "hourly" });
+  assert.ok(Math.abs(val - 0.5) < 1e-9, `expected usage ≈0.5 to win, got ${val}`);
+});
+
+test("getSaturation(openai) fails open to 0 when neither usage nor token headers exist", async () => {
+  _clearSaturationCache();
+  _clearRateLimitHeaders();
+  __setGenericUsageFetcherForTests(async () => null);
+
+  const val = await getSaturation("oai-gen-3", "openai", { unit: "tokens", window: "hourly" });
+  assert.equal(val, 0);
+});
+
+// ─── Cross-key / cross-provider isolation ────────────────────────────────────
+
+test("token-header signal is keyed by (provider, connectionId)", () => {
+  _clearRateLimitHeaders();
+  storeRateLimitHeaders("shared-id", "openai", {
+    "x-ratelimit-limit-tokens": "1000",
+    "x-ratelimit-remaining-tokens": "100", // 0.9
+  });
+  storeRateLimitHeaders("shared-id", "anthropic", {
+    "anthropic-ratelimit-tokens-limit": "1000",
+    "anthropic-ratelimit-tokens-remaining": "900", // 0.1
+  });
+
+  const oai = getTokenHeaderSaturation("openai", "shared-id");
+  const anth = getTokenHeaderSaturation("anthropic", "shared-id");
+  assert.ok(oai && Math.abs(oai.saturation - 0.9) < 1e-9);
+  assert.ok(anth && Math.abs(anth.saturation - 0.1) < 1e-9);
+  // A provider with no token headers stored → null.
+  assert.equal(getTokenHeaderSaturation("openai", "never-seen"), null);
+});


### PR DESCRIPTION
**Fase 3 #2.** `storeRateLimitHeaders` só lia headers de REQUESTS (RPM/min). Agora também parseia os headers de **TOKENS** (presentes em toda resposta) → throttle proativo antes do 429:
- Anthropic `anthropic-ratelimit-tokens-{limit,remaining,reset}` (RFC3339)
- OpenAI `x-ratelimit-{limit,remaining,reset}-tokens` (duração `6m0s`)

`saturation = 1 − remaining/limit`; `resetAt` normalizado a epoch (parse de duração ReDoS-safe). `fetchGenericSaturation` passa a usar o sinal — **complementa** o oauth/usage do #1 (que segue primário p/ Claude). Fail-open, cache mantido, request-path inalterado.

**30/30** (16 novos + regressão oauth/usage #1 8/8 + signals 6/6) · typecheck:core · eslint.