### PR TITLE
feat(oauth): Codex bulk-import endpoint — POST /api/oauth/codex/import

### DIFF
--- a/src/app/api/oauth/codex/import/route.ts
+++ b/src/app/api/oauth/codex/import/route.ts
@@ -1,0 +1,107 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { normalizeCodexImportRecord, flattenCodexImportPayload } from "@/lib/oauth/services/codexImport";
+import { createProviderConnection } from "@/models";
+import { isAuthRequired, isAuthenticated } from "@/shared/utils/apiAuth";
+import { sanitizeErrorMessage } from "@omniroute/open-sse/utils/error.ts";
+
+/**
+ * POST /api/oauth/codex/import
+ *
+ * Bulk-import Codex (OpenAI) accounts from JSON payloads produced by the Codex
+ * CLI or common token-export tools. Each item may be a flat export
+ * (`access_token`, `refresh_token`, …) or the CLI's nested `auth.json` shape.
+ *
+ * Body: `{ accounts: object | object[] }`
+ *
+ * Returns a per-record summary so partial successes are surfaced to the UI.
+ *
+ * Ported from decolua/9router#1257 (beaaan).
+ */
+
+const bodySchema = z.object({
+  accounts: z.union([z.record(z.unknown()), z.array(z.unknown())], {
+    errorMap: () => ({ message: "accounts must be an object or an array of objects" }),
+  }),
+});
+
+async function requireAuth(request: Request): Promise<NextResponse | null> {
+  if (!(await isAuthRequired(request))) return null;
+  if (await isAuthenticated(request)) return null;
+  return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+}
+
+export async function POST(request: Request) {
+  const authResponse = await requireAuth(request);
+  if (authResponse) return authResponse;
+
+  let rawBody: unknown;
+  try {
+    rawBody = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid or empty JSON body" },
+      { status: 400 },
+    );
+  }
+
+  const parsed = bodySchema.safeParse(rawBody);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.errors[0]?.message ?? "Invalid request body" },
+      { status: 400 },
+    );
+  }
+
+  const flat = flattenCodexImportPayload(parsed.data.accounts);
+  if (!flat.ok) {
+    return NextResponse.json({ error: flat.error }, { status: 400 });
+  }
+  if (flat.records.length === 0) {
+    return NextResponse.json(
+      { error: "No accounts found in payload" },
+      { status: 400 },
+    );
+  }
+
+  const results: Array<
+    | { index: number; ok: true; connectionId: string; email: string }
+    | { index: number; ok: false; error: string }
+  > = [];
+  let imported = 0;
+  let failed = 0;
+
+  for (let i = 0; i < flat.records.length; i++) {
+    const norm = normalizeCodexImportRecord(flat.records[i]);
+    if (!norm.ok) {
+      failed += 1;
+      results.push({ index: i, ok: false, error: norm.error });
+      continue;
+    }
+    try {
+      const conn = await createProviderConnection(norm.payload as Record<string, unknown>);
+      imported += 1;
+      results.push({
+        index: i,
+        ok: true,
+        connectionId: String(conn.id),
+        email: String(conn.email ?? norm.payload.email),
+      });
+    } catch (error) {
+      failed += 1;
+      results.push({
+        index: i,
+        ok: false,
+        error: sanitizeErrorMessage(error instanceof Error ? error.message : String(error)),
+      });
+    }
+  }
+
+  return NextResponse.json({
+    success: failed === 0,
+    imported,
+    failed,
+    total: flat.records.length,
+    results,
+  });
+}

--- a/src/lib/oauth/services/codexImport.ts
+++ b/src/lib/oauth/services/codexImport.ts
@@ -1,0 +1,214 @@
+/**
+ * Codex (OpenAI) bulk-import normalization
+ *
+ * Accepts the JSON shape produced by Codex CLI / common token-export tools and
+ * returns a {@link createProviderConnection} payload (or a typed error).
+ *
+ * Pure: no I/O, no network. Safe to unit-test.
+ *
+ * Ported from decolua/9router#1257 (beaaan).
+ */
+
+const REQUIRED_FIELDS = ["access_token", "refresh_token"] as const;
+
+/** 10 days — the typical OpenAI access-token lifetime when no `expired` is supplied. */
+const DEFAULT_EXPIRY_MS = 10 * 24 * 60 * 60 * 1000;
+
+const BASE64_BLOCK_SIZE = 4;
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export type CodexImportPayload = {
+  provider: "codex";
+  authType: "oauth";
+  accessToken: string;
+  refreshToken: string;
+  idToken?: string;
+  email: string;
+  expiresAt: string;
+  testStatus: "active";
+  providerSpecificData?: {
+    chatgptAccountId?: string;
+    chatgptPlanType?: string;
+  };
+};
+
+export type NormalizeOk = { ok: true; payload: CodexImportPayload };
+export type NormalizeErr = { ok: false; error: string };
+export type NormalizeResult = NormalizeOk | NormalizeErr;
+
+export type FlattenOk = { ok: true; records: unknown[] };
+export type FlattenErr = { ok: false; error: string };
+export type FlattenResult = FlattenOk | FlattenErr;
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Decode a JWT payload to a plain object (no signature verification).
+ *
+ * Mirrors the helper in `providers.ts` but is kept local so this module has no
+ * runtime dependency on the larger OAuth module graph.
+ */
+function decodeJwtPayload(jwt: unknown): Record<string, unknown> | null {
+  try {
+    if (!jwt || typeof jwt !== "string") return null;
+    const parts = jwt.split(".");
+    if (parts.length !== 3) return null;
+    const base64 = parts[1].replace(/-/g, "+").replace(/_/g, "/");
+    const missingPadding =
+      (BASE64_BLOCK_SIZE - (base64.length % BASE64_BLOCK_SIZE)) % BASE64_BLOCK_SIZE;
+    const padded = base64 + "=".repeat(missingPadding);
+    return JSON.parse(Buffer.from(padded, "base64").toString("utf8")) as Record<
+      string,
+      unknown
+    >;
+  } catch {
+    return null;
+  }
+}
+
+function extractCodexAccountInfo(idToken: string): {
+  email?: string;
+  chatgptAccountId?: string;
+  chatgptPlanType?: string;
+} {
+  const payload = decodeJwtPayload(idToken);
+  if (!payload) return {};
+  const chatgpt =
+    (payload["https://api.openai.com/auth"] as Record<string, unknown>) || {};
+  return {
+    email: typeof payload.email === "string" ? payload.email : undefined,
+    chatgptAccountId:
+      typeof chatgpt.chatgpt_account_id === "string"
+        ? chatgpt.chatgpt_account_id
+        : undefined,
+    chatgptPlanType:
+      typeof chatgpt.chatgpt_plan_type === "string"
+        ? chatgpt.chatgpt_plan_type
+        : undefined,
+  };
+}
+
+function pickString(...candidates: (string | undefined)[]): string | undefined {
+  for (const c of candidates) {
+    if (typeof c === "string" && c.trim()) return c.trim();
+  }
+  return undefined;
+}
+
+function parseExpiry(value: unknown): string | undefined {
+  if (typeof value === "string" && value) {
+    const ms = Date.parse(value);
+    if (Number.isFinite(ms)) return new Date(ms).toISOString();
+  }
+  return undefined;
+}
+
+function parseAccessTokenExp(accessToken: string): string {
+  const payload = decodeJwtPayload(accessToken);
+  const exp = payload && typeof payload.exp === "number" ? payload.exp : null;
+  if (exp && Number.isFinite(exp)) {
+    return new Date(exp * 1000).toISOString();
+  }
+  return new Date(Date.now() + DEFAULT_EXPIRY_MS).toISOString();
+}
+
+/**
+ * Codex CLI persists tokens to `auth.json` with the OAuth fields nested under
+ * a `tokens` object: `{ auth_mode, OPENAI_API_KEY, tokens: { id_token, ... } }`.
+ * Flatten that into the same shape as a simple top-level export so the rest of
+ * the normalizer can stay unchanged.
+ */
+function unwrapCodexAuthJson(rec: Record<string, unknown>): Record<string, unknown> {
+  const tokens = rec.tokens as Record<string, unknown> | undefined;
+  if (!tokens || typeof tokens !== "object" || Array.isArray(tokens)) {
+    return rec;
+  }
+  if (typeof tokens.access_token !== "string") return rec;
+  // Tokens take priority; carry through siblings (email / account_id / expired)
+  // only when the nested object doesn't already define them.
+  return { ...rec, ...tokens };
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Normalize a single raw record from an uploaded JSON file into a
+ * `createProviderConnection` payload.
+ *
+ * @param input — single record from the uploaded JSON
+ */
+export function normalizeCodexImportRecord(input: unknown): NormalizeResult {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return { ok: false, error: "Record is not an object" };
+  }
+
+  const rec = unwrapCodexAuthJson(input as Record<string, unknown>);
+
+  // Allow type field to be missing or "codex"; reject anything else explicitly so
+  // users don't accidentally import claude/gemini exports through this path.
+  if (rec.type !== undefined && rec.type !== null && rec.type !== "codex") {
+    return { ok: false, error: `Unsupported type: ${String(rec.type)}` };
+  }
+
+  for (const f of REQUIRED_FIELDS) {
+    if (typeof rec[f] !== "string" || !rec[f]) {
+      return { ok: false, error: `Missing required field: ${f}` };
+    }
+  }
+
+  const accessToken = String(rec.access_token);
+  const refreshToken = String(rec.refresh_token);
+  const idToken = typeof rec.id_token === "string" ? rec.id_token : undefined;
+
+  // Prefer JWT-derived account info, fall back to top-level fields.
+  const fromJwt = idToken ? extractCodexAccountInfo(idToken) : {};
+  const email = pickString(fromJwt.email, rec.email as string | undefined);
+
+  if (!email) {
+    return { ok: false, error: "Missing email (and id_token does not contain one)" };
+  }
+
+  const chatgptAccountId = pickString(
+    fromJwt.chatgptAccountId,
+    rec.account_id as string | undefined,
+  );
+  const chatgptPlanType = pickString(fromJwt.chatgptPlanType);
+
+  const expiresAt =
+    parseExpiry(rec.expired) ?? parseAccessTokenExp(accessToken);
+
+  const providerSpecificData: CodexImportPayload["providerSpecificData"] = {};
+  if (chatgptAccountId) providerSpecificData.chatgptAccountId = chatgptAccountId;
+  if (chatgptPlanType) providerSpecificData.chatgptPlanType = chatgptPlanType;
+
+  const payload: CodexImportPayload = {
+    provider: "codex",
+    authType: "oauth",
+    accessToken,
+    refreshToken,
+    email,
+    expiresAt,
+    testStatus: "active",
+  };
+  if (idToken) payload.idToken = idToken;
+  if (Object.keys(providerSpecificData).length > 0) {
+    payload.providerSpecificData = providerSpecificData;
+  }
+
+  return { ok: true, payload };
+}
+
+/**
+ * Flatten the user-uploaded JSON into an array of candidate records.
+ * Accepts a single record or an array; rejects anything else.
+ */
+export function flattenCodexImportPayload(parsed: unknown): FlattenResult {
+  if (Array.isArray(parsed)) {
+    return { ok: true, records: parsed };
+  }
+  if (parsed && typeof parsed === "object") {
+    return { ok: true, records: [parsed] };
+  }
+  return { ok: false, error: "JSON must be an object or an array of objects" };
+}

--- a/tests/unit/codexBulkImport.test.ts
+++ b/tests/unit/codexBulkImport.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Unit tests for the Codex bulk-import normalizer.
+ *
+ * Pure helpers — no I/O, no network. Synthetic id_tokens are crafted by
+ * base64url-encoding a header/payload/signature triple (only the payload is
+ * decoded; we never verify the signature).
+ *
+ * Ported from decolua/9router#1257 (beaaan).
+ */
+
+import test, { describe } from "node:test";
+import assert from "node:assert/strict";
+import {
+  normalizeCodexImportRecord,
+  flattenCodexImportPayload,
+} from "../../src/lib/oauth/services/codexImport.ts";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function b64url(obj: unknown): string {
+  return Buffer.from(JSON.stringify(obj))
+    .toString("base64")
+    .replace(/=+$/, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+}
+
+function makeIdToken(payload: Record<string, unknown>): string {
+  const header = b64url({ alg: "RS256", typ: "JWT" });
+  const body = b64url(payload);
+  return `${header}.${body}.signature`;
+}
+
+const FULL_RECORD = {
+  id_token: makeIdToken({
+    email: "test-jwt@example.com",
+    "https://api.openai.com/auth": {
+      chatgpt_account_id: "acct-from-jwt",
+      chatgpt_plan_type: "plus",
+    },
+  }),
+  access_token: "access-xyz",
+  refresh_token: "refresh-xyz",
+  account_id: "acct-from-record",
+  email: "test-record@example.com",
+  type: "codex",
+  expired: "2026-05-22T10:34:04+07:00",
+};
+
+// ── normalizeCodexImportRecord ────────────────────────────────────────────────
+
+describe("normalizeCodexImportRecord", () => {
+  test("normalizes a full Codex export record", () => {
+    const result = normalizeCodexImportRecord(FULL_RECORD);
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    const { payload } = result;
+    assert.equal(payload.provider, "codex");
+    assert.equal(payload.authType, "oauth");
+    assert.equal(payload.accessToken, "access-xyz");
+    assert.equal(payload.refreshToken, "refresh-xyz");
+    assert.equal(payload.idToken, FULL_RECORD.id_token);
+    assert.equal(payload.testStatus, "active");
+    // JWT email wins over the record-level email.
+    assert.equal(payload.email, "test-jwt@example.com");
+    assert.deepEqual(payload.providerSpecificData, {
+      chatgptAccountId: "acct-from-jwt",
+      chatgptPlanType: "plus",
+    });
+    // ISO-formatted, parses back to the right instant.
+    const expiresMs = Date.parse(payload.expiresAt);
+    assert.ok(Number.isFinite(expiresMs));
+    assert.equal(expiresMs, Date.parse(FULL_RECORD.expired));
+  });
+
+  test("falls back to record email when id_token has none", () => {
+    const idToken = makeIdToken({
+      "https://api.openai.com/auth": { chatgpt_account_id: "x" },
+    });
+    const result = normalizeCodexImportRecord({
+      access_token: "a",
+      refresh_token: "r",
+      email: "fallback@example.com",
+      id_token: idToken,
+    });
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.payload.email, "fallback@example.com");
+    assert.equal(result.payload.providerSpecificData?.chatgptAccountId, "x");
+  });
+
+  test("falls back to account_id when id_token is missing", () => {
+    const result = normalizeCodexImportRecord({
+      access_token: "a",
+      refresh_token: "r",
+      email: "no-jwt@example.com",
+      account_id: "acct-top-level",
+    });
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.payload.providerSpecificData?.chatgptAccountId, "acct-top-level");
+    assert.equal(result.payload.idToken, undefined);
+  });
+
+  test("synthesizes expiresAt when `expired` is missing", () => {
+    const before = Date.now();
+    const result = normalizeCodexImportRecord({
+      access_token: "a",
+      refresh_token: "r",
+      email: "x@example.com",
+    });
+    const after = Date.now();
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    const expiresMs = Date.parse(result.payload.expiresAt);
+    assert.ok(expiresMs > before, "expiresAt should be in the future");
+    // Default lifetime is 10 days; allow a generous upper bound.
+    assert.ok(
+      expiresMs <= after + 11 * 24 * 60 * 60 * 1000,
+      "expiresAt should be within ~11 days",
+    );
+  });
+
+  test("rejects invalid `expired` strings by falling back to default", () => {
+    const result = normalizeCodexImportRecord({
+      access_token: "a",
+      refresh_token: "r",
+      email: "x@example.com",
+      expired: "not-a-date",
+    });
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.ok(Number.isFinite(Date.parse(result.payload.expiresAt)));
+  });
+
+  test("rejects records missing required fields", () => {
+    assert.equal(normalizeCodexImportRecord({}).ok, false);
+    assert.equal(
+      normalizeCodexImportRecord({ access_token: "a", email: "x@y.z" }).ok,
+      false,
+    );
+    assert.equal(
+      normalizeCodexImportRecord({ access_token: "a", refresh_token: "r" }).ok,
+      false, // no email anywhere
+    );
+  });
+
+  test("rejects records with non-codex `type`", () => {
+    const result = normalizeCodexImportRecord({
+      access_token: "a",
+      refresh_token: "r",
+      email: "x@example.com",
+      type: "claude",
+    });
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.match(result.error, /Unsupported type/);
+  });
+
+  test("rejects non-objects", () => {
+    assert.equal(normalizeCodexImportRecord(null).ok, false);
+    assert.equal(normalizeCodexImportRecord("foo").ok, false);
+    assert.equal(normalizeCodexImportRecord([]).ok, false);
+  });
+
+  test("omits providerSpecificData when no account info is present", () => {
+    const result = normalizeCodexImportRecord({
+      access_token: "a",
+      refresh_token: "r",
+      email: "x@example.com",
+    });
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.payload.providerSpecificData, undefined);
+  });
+
+  test("unwraps the Codex CLI auth.json shape", () => {
+    const idToken = makeIdToken({
+      email: "cli@example.com",
+      "https://api.openai.com/auth": {
+        chatgpt_account_id: "acct-cli",
+        chatgpt_plan_type: "free",
+      },
+    });
+    // Access token's `exp` is the only expiry signal in auth.json.
+    const expEpoch = Math.floor(Date.now() / 1000) + 3600;
+    const accessToken = makeIdToken({ exp: expEpoch });
+    const authJson = {
+      auth_mode: "chatgpt",
+      OPENAI_API_KEY: null,
+      tokens: {
+        id_token: idToken,
+        access_token: accessToken,
+        refresh_token: "rt-cli",
+        account_id: "acct-cli",
+      },
+      last_refresh: "2026-05-16T11:35:58.322795500Z",
+    };
+    const result = normalizeCodexImportRecord(authJson);
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.payload.accessToken, accessToken);
+    assert.equal(result.payload.refreshToken, "rt-cli");
+    assert.equal(result.payload.idToken, idToken);
+    assert.equal(result.payload.email, "cli@example.com");
+    assert.deepEqual(result.payload.providerSpecificData, {
+      chatgptAccountId: "acct-cli",
+      chatgptPlanType: "free",
+    });
+    // Falls back to the access_token's `exp` claim when no `expired` field exists.
+    assert.equal(Date.parse(result.payload.expiresAt), expEpoch * 1000);
+  });
+
+  test("rejects auth.json when nested tokens are incomplete", () => {
+    const result = normalizeCodexImportRecord({
+      auth_mode: "chatgpt",
+      tokens: { id_token: "x" }, // missing access_token + refresh_token
+    });
+    assert.equal(result.ok, false);
+  });
+});
+
+// ── flattenCodexImportPayload ─────────────────────────────────────────────────
+
+describe("flattenCodexImportPayload", () => {
+  test("wraps a single object", () => {
+    const result = flattenCodexImportPayload({ a: 1 });
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.deepEqual(result.records, [{ a: 1 }]);
+  });
+
+  test("passes arrays through", () => {
+    const result = flattenCodexImportPayload([{ a: 1 }, { b: 2 }]);
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.deepEqual(result.records, [{ a: 1 }, { b: 2 }]);
+  });
+
+  test("rejects scalars", () => {
+    assert.equal(flattenCodexImportPayload("nope").ok, false);
+    assert.equal(flattenCodexImportPayload(42).ok, false);
+    assert.equal(flattenCodexImportPayload(null).ok, false);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `POST /api/oauth/codex/import` — a new route to bulk-import Codex (OpenAI) account tokens from JSON payloads produced by the Codex CLI or common token-export tools.
- Adds `src/lib/oauth/services/codexImport.ts` — a **pure, I/O-free** normalizer that handles both the flat export shape and the Codex CLI `auth.json` nested-tokens shape; extracts email and plan info from the `id_token` JWT payload; synthesizes `expiresAt` from access-token `exp` when not provided.
- Zod-validated request body, auth guard matching other `/api/oauth/*/import` routes, and per-record error messages routed through `sanitizeErrorMessage` (Hard Rule #12).

## Test plan

- [x] 14 unit tests in `tests/unit/codexBulkImport.test.ts` — all pass (`node --import tsx/esm --test`)
- [x] Covers: full record, JWT email fallback, `account_id` fallback, expiry synthesis, invalid expiry, missing required fields, unsupported `type`, non-objects, `providerSpecificData` omission, CLI `auth.json` unwrap, incomplete nested tokens
- [ ] Live import validation requires a real Codex token (VPS gate per Hard Rule #18 — deferred to follow-up)

Thanks to @beaaan for the original implementation.