### PR TITLE
refactor(api): extrai camada-folha pura de validation.ts (URL/headers/transport)

### DIFF
--- a/src/lib/providers/validation.ts
+++ b/src/lib/providers/validation.ts
@@ -2,7 +2,6 @@ import { randomUUID } from "node:crypto";
 import { getEmbeddingProvider } from "@omniroute/open-sse/config/embeddingRegistry.ts";
 import { getRerankProvider } from "@omniroute/open-sse/config/rerankRegistry.ts";
 import { getRegistryEntry } from "@omniroute/open-sse/config/providerRegistry.ts";
-import { selectProxyForValidation } from "@omniroute/open-sse/services/proxyAutoSelector.ts";
 import {
   buildClaudeCodeCompatibleHeaders,
   buildClaudeCodeCompatibleValidationPayload,
@@ -10,8 +9,6 @@ import {
   CLAUDE_CODE_COMPATIBLE_DEFAULT_MODELS_PATH,
   joinClaudeCodeCompatibleUrl,
   joinBaseUrlAndPath,
-  stripClaudeCodeCompatibleEndpointSuffix,
-  stripAnthropicMessagesSuffix,
 } from "@omniroute/open-sse/services/claudeCodeCompatible.ts";
 import {
   isClaudeCodeCompatibleProvider,
@@ -24,11 +21,9 @@ import {
 } from "@/shared/constants/providers";
 import {
   SAFE_OUTBOUND_FETCH_PRESETS,
-  SafeOutboundFetchError,
-  getSafeOutboundFetchErrorStatus,
   safeOutboundFetch,
 } from "@/shared/network/safeOutboundFetch";
-import { getProviderOutboundGuard, isPrivateHost } from "@/shared/network/outboundUrlGuard";
+import { getProviderOutboundGuard } from "@/shared/network/outboundUrlGuard";
 import {
   buildGrokCookieHeader,
   buildQwenCookieHeader,
@@ -85,324 +80,41 @@ import {
 import { signAwsRequest } from "@omniroute/open-sse/utils/awsSigV4.ts";
 import { validateImageProviderApiKey } from "@/lib/providers/imageValidation";
 
-const OPENAI_LIKE_FORMATS = new Set(["openai", "openai-responses"]);
-const GEMINI_LIKE_FORMATS = new Set(["gemini", "gemini-cli"]);
+import {
+  OPENAI_LIKE_FORMATS,
+  GEMINI_LIKE_FORMATS,
+  normalizeBaseUrl,
+  normalizeAzureOpenAIBaseUrl,
+  normalizeAnthropicBaseUrl,
+  normalizeClaudeCodeCompatibleBaseUrl,
+  addModelsSuffix,
+  resolveBaseUrl,
+  resolveChatUrl,
+  normalizeHerokuChatUrl,
+  normalizeDatabricksChatUrl,
+  normalizeSnowflakeChatUrl,
+  normalizeGigachatChatUrl,
+} from "./validation/urlHelpers";
+import {
+  STANDARD_USER_AGENT,
+  applyCustomUserAgent,
+  withCustomUserAgent,
+  directHttpsRequest,
+  buildBearerHeaders,
+  buildRekaHeaders,
+  buildClarifaiHeaders,
+  buildKeyHeaders,
+  buildTokenHeaders,
+} from "./validation/headers";
+import {
+  validationRead,
+  validationWrite,
+  toValidationErrorResult,
+} from "./validation/transport";
 
-function normalizeBaseUrl(baseUrl: string) {
-  // Guard against a non-string baseUrl reaching .trim() / .replace() — see #2463
-  // where NVIDIA NIM validation surfaced as `e.startsWith is not a function`
-  // after the bundler renamed `baseUrl` to `e`. Any malformed providerSpecificData
-  // (e.g. saved as object from a UI bug) would otherwise crash mid-validation.
-  const value = typeof baseUrl === "string" ? baseUrl : "";
-  return value.trim().replace(/\/$/, "");
-}
-
-function normalizeAzureOpenAIBaseUrl(baseUrl: string) {
-  return normalizeBaseUrl(baseUrl)
-    .replace(/\/openai$/i, "")
-    .replace(/\/openai\/deployments\/[^/]+\/chat\/completions.*$/i, "");
-}
-
-function normalizeAnthropicBaseUrl(baseUrl: string) {
-  return stripAnthropicMessagesSuffix(baseUrl || "");
-}
-
-function normalizeClaudeCodeCompatibleBaseUrl(baseUrl: string) {
-  return stripClaudeCodeCompatibleEndpointSuffix(baseUrl || "");
-}
-
-function addModelsSuffix(baseUrl: string) {
-  const normalized = normalizeBaseUrl(baseUrl);
-  if (!normalized) return "";
-
-  const suffixes = ["/chat/completions", "/responses", "/chat", "/messages"];
-  if (normalized.endsWith("/models")) {
-    return normalized;
-  }
-  for (const suffix of suffixes) {
-    if (normalized.endsWith(suffix)) {
-      return `${normalized.slice(0, -suffix.length)}/models`;
-    }
-  }
-
-  return `${normalized}/models`;
-}
-
-function resolveBaseUrl(entry: any, providerSpecificData: any = {}) {
-  if (providerSpecificData?.baseUrl) return normalizeBaseUrl(providerSpecificData.baseUrl);
-  if (entry?.baseUrl) return normalizeBaseUrl(entry.baseUrl);
-  return "";
-}
-
-function resolveChatUrl(provider: string, baseUrl: string, providerSpecificData: any = {}) {
-  const normalized = normalizeBaseUrl(baseUrl);
-  if (!normalized) return "";
-
-  if (isOpenAICompatibleProvider(provider)) {
-    if (providerSpecificData?.chatPath) {
-      return `${normalized}${providerSpecificData.chatPath}`;
-    }
-    if (providerSpecificData?.apiType === "responses") {
-      return `${normalized}/responses`;
-    }
-    return `${normalized}/chat/completions`;
-  }
-
-  if (
-    normalized.endsWith("/chat/completions") ||
-    normalized.endsWith("/responses") ||
-    normalized.endsWith("/chat")
-  ) {
-    return normalized;
-  }
-
-  if (normalized.endsWith("/v1")) {
-    return `${normalized}/chat/completions`;
-  }
-
-  return normalized;
-}
-
-function normalizeHerokuChatUrl(baseUrl: string) {
-  const normalized = normalizeBaseUrl(baseUrl);
-  if (!normalized) return "";
-  return normalized.endsWith("/v1/chat/completions")
-    ? normalized
-    : `${normalized}/v1/chat/completions`;
-}
-
-function normalizeDatabricksChatUrl(baseUrl: string) {
-  const normalized = normalizeBaseUrl(baseUrl);
-  if (!normalized) return "";
-  return normalized.endsWith("/chat/completions") ? normalized : `${normalized}/chat/completions`;
-}
-
-function normalizeSnowflakeChatUrl(baseUrl: string) {
-  const normalized = normalizeBaseUrl(baseUrl)
-    .replace(/\/cortex\/inference:complete$/, "")
-    .replace(/\/api\/v2$/, "");
-  if (!normalized) return "";
-  return `${normalized}/api/v2/cortex/inference:complete`;
-}
-
-function normalizeGigachatChatUrl(baseUrl: string) {
-  const normalized = normalizeBaseUrl(baseUrl).replace(/\/chat\/completions$/, "");
-  if (!normalized) return "";
-  return `${normalized}/chat/completions`;
-}
-
-// Standardized desktop Chrome UA for web-cookie/no-auth session probes (minimizes anti-bot detection).
-const STANDARD_USER_AGENT =
-  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36";
-
-function getCustomUserAgent(providerSpecificData: any = {}) {
-  if (typeof providerSpecificData?.customUserAgent !== "string") return null;
-  const customUserAgent = providerSpecificData.customUserAgent.trim();
-  return customUserAgent || null;
-}
-
-function applyCustomUserAgent(headers: Record<string, string>, providerSpecificData: any = {}) {
-  const customUserAgent = getCustomUserAgent(providerSpecificData);
-  if (!customUserAgent) return headers;
-  headers["User-Agent"] = customUserAgent;
-  if ("user-agent" in headers) {
-    headers["user-agent"] = customUserAgent;
-  }
-  return headers;
-}
-
-function withCustomUserAgent(init: RequestInit, providerSpecificData: any = {}) {
-  return {
-    ...init,
-    headers: applyCustomUserAgent(
-      { ...((init.headers as Record<string, string> | undefined) || {}) },
-      providerSpecificData
-    ),
-  };
-}
-
-/**
- * Direct HTTPS request utility that bypasses the global patched fetch.
- * Used for provider validation where the patched fetch has compatibility issues.
- * Uses safeOutboundFetch with bypassProxyPatch to use native Node.js fetch directly.
- */
-function directHttpsRequest(
-  url: string,
-  options: { method?: string; headers?: Record<string, string>; body?: string },
-  timeoutMs: number
-): Promise<{ status: number; ok: boolean; text: () => Promise<string> }> {
-  return safeOutboundFetch(url, {
-    method: options.method || "GET",
-    headers: (options.headers || {}) as Record<string, string>,
-    body: options.body,
-    timeoutMs,
-    bypassProxyPatch: true,
-    allowRedirect: true,
-    guard: "none",
-    retry: false,
-  }).then(async (response) => ({
-    status: response.status,
-    ok: response.ok,
-    text: async () => await response.text(),
-  }));
-}
-
-function buildBearerHeaders(apiKey: string, providerSpecificData: any = {}) {
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-  };
-  if (apiKey) {
-    headers.Authorization = `Bearer ${apiKey}`;
-  }
-  return applyCustomUserAgent(headers, providerSpecificData);
-}
-
-function buildRekaHeaders(apiKey: string, providerSpecificData: any = {}) {
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-  };
-
-  if (apiKey) {
-    headers.Authorization = `Bearer ${apiKey}`;
-    headers["X-Api-Key"] = apiKey;
-  }
-
-  return applyCustomUserAgent(headers, providerSpecificData);
-}
-
-function buildClarifaiHeaders(apiKey: string, providerSpecificData: any = {}) {
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-  };
-
-  if (apiKey) {
-    headers.Authorization = `Key ${apiKey}`;
-  }
-
-  return applyCustomUserAgent(headers, providerSpecificData);
-}
-
-function buildKeyHeaders(apiKey: string, providerSpecificData: any = {}) {
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-  };
-
-  if (apiKey) {
-    headers.Authorization = `Key ${apiKey}`;
-  }
-
-  return applyCustomUserAgent(headers, providerSpecificData);
-}
-
-function buildTokenHeaders(apiKey: string, providerSpecificData: any = {}) {
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-  };
-
-  if (apiKey) {
-    headers.Authorization = `Token ${apiKey}`;
-  }
-
-  return applyCustomUserAgent(headers, providerSpecificData);
-}
-
-/**
- * Wrapped fetch call that auto-retries with a proxy when the direct connection
- * fails.  This happens transparently so individual validators don't need to
- * think about proxy fallback.
- */
-async function fetchWithProxyFallback(
-  url: string,
-  init: RequestInit,
-  presets: typeof SAFE_OUTBOUND_FETCH_PRESETS.validationRead,
-  isLocal: boolean
-): Promise<Response> {
-  try {
-    return await safeOutboundFetch(url, {
-      ...presets,
-      guard: isLocal ? "none" : getProviderOutboundGuard(),
-      ...init,
-    });
-  } catch (err: unknown) {
-    // Only attempt proxy fallback for retryable errors (network / timeout)
-    // and only when the target is not a local / LAN address.
-    const fetchErr = err as SafeOutboundFetchError;
-    const isNetworkIssue = fetchErr?.code === "NETWORK_ERROR" || fetchErr?.code === "TIMEOUT";
-    const isRetryable = fetchErr?.isRetryable !== false;
-    const isValidTarget = !isLocal && isRetryableProxyTarget(url);
-
-    if (isLocal || !isNetworkIssue || !isRetryable) throw err;
-    if (!isValidTarget) throw err;
-
-    const proxyUrl = await selectProxyForValidation(url);
-    if (!proxyUrl) throw err;
-
-    return safeOutboundFetch(url, {
-      ...presets,
-      guard: isLocal ? "none" : getProviderOutboundGuard(),
-      ...init,
-      proxyConfig: proxyUrl,
-    });
-  }
-}
-
-export function isRetryableProxyTarget(url: string): boolean {
-  try {
-    const hostname = new URL(url).hostname.toLowerCase();
-    // Never proxy-fallback to a private/link-local/metadata host. Delegates to
-    // the canonical SSRF guard (covers 169.254, 0.0.0.0, 172.16/12, CGNAT,
-    // IPv6 fc/fd/fe80, .internal — gaps the previous inline check missed).
-    return !isPrivateHost(hostname);
-  } catch {
-    return false;
-  }
-}
-
-async function validationRead(url: string, init: RequestInit, isLocal: boolean = false) {
-  return fetchWithProxyFallback(url, init, SAFE_OUTBOUND_FETCH_PRESETS.validationRead, isLocal);
-}
-
-async function validationWrite(url: string, init: RequestInit, isLocal: boolean = false) {
-  return fetchWithProxyFallback(url, init, SAFE_OUTBOUND_FETCH_PRESETS.validationWrite, isLocal);
-}
-
-// A validation failure should only be flagged `securityBlocked` (which the route
-// surfaces as a `provider.validation.ssrf_blocked` audit event + a security warning in
-// the UI) when it is a GENUINE SSRF/guard block — not for every outbound-guard 503.
-// A blocked redirect (REDIRECT_BLOCKED) to a PUBLIC host is benign: the redirect was
-// never followed, so no SSRF occurred. Web-cookie providers like qwen-web answer their
-// probe with a 307 to a public host, which used to be mislabeled as an SSRF block
-// (#3288 / #3758). Only treat a blocked redirect as a security event when its target is
-// a private/internal host.
-export function isSecurityBlockError(error: unknown): boolean {
-  if (!(error instanceof SafeOutboundFetchError)) return false;
-  if (error.code === "URL_GUARD_BLOCKED" || error.code === "INVALID_URL") return true;
-  if (error.code === "REDIRECT_BLOCKED") {
-    if (!error.location) return false;
-    try {
-      return isPrivateHost(new URL(error.location, error.url).hostname);
-    } catch {
-      return false;
-    }
-  }
-  return false;
-}
-
-function toValidationErrorResult(error: unknown) {
-  const message = error instanceof Error ? error.message : String(error || "Validation failed");
-  const statusCode = getSafeOutboundFetchErrorStatus(error);
-
-  return {
-    valid: false,
-    error: message || "Validation failed",
-    unsupported: false as const,
-    ...(statusCode ? { statusCode } : {}),
-    ...(error instanceof SafeOutboundFetchError && error.code === "TIMEOUT"
-      ? { timeout: true }
-      : {}),
-    ...(isSecurityBlockError(error) ? { securityBlocked: true } : {}),
-  };
-}
+// isRetryableProxyTarget + isSecurityBlockError now live in ./validation/transport. Re-export them
+// here to preserve the historical public surface (tests + route handlers import them via this module).
+export { isRetryableProxyTarget, isSecurityBlockError } from "./validation/transport";
 
 async function validateBedrockProvider({ apiKey, providerSpecificData = {} }: any) {
   if (!apiKey) {

--- a/src/lib/providers/validation/headers.ts
+++ b/src/lib/providers/validation/headers.ts
@@ -1,0 +1,120 @@
+// Request-header builders + custom-UA handling + a direct (proxy-bypassing) HTTPS helper, extracted
+// from validation.ts (god-file decomposition). Pure header construction except directHttpsRequest,
+// which delegates to safeOutboundFetch with bypassProxyPatch. Behavior is byte-identical.
+import { safeOutboundFetch } from "@/shared/network/safeOutboundFetch";
+
+
+// Standardized desktop Chrome UA for web-cookie/no-auth session probes (minimizes anti-bot detection).
+export const STANDARD_USER_AGENT =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36";
+
+export function getCustomUserAgent(providerSpecificData: any = {}) {
+  if (typeof providerSpecificData?.customUserAgent !== "string") return null;
+  const customUserAgent = providerSpecificData.customUserAgent.trim();
+  return customUserAgent || null;
+}
+
+export function applyCustomUserAgent(headers: Record<string, string>, providerSpecificData: any = {}) {
+  const customUserAgent = getCustomUserAgent(providerSpecificData);
+  if (!customUserAgent) return headers;
+  headers["User-Agent"] = customUserAgent;
+  if ("user-agent" in headers) {
+    headers["user-agent"] = customUserAgent;
+  }
+  return headers;
+}
+
+export function withCustomUserAgent(init: RequestInit, providerSpecificData: any = {}) {
+  return {
+    ...init,
+    headers: applyCustomUserAgent(
+      { ...((init.headers as Record<string, string> | undefined) || {}) },
+      providerSpecificData
+    ),
+  };
+}
+
+/**
+ * Direct HTTPS request utility that bypasses the global patched fetch.
+ * Used for provider validation where the patched fetch has compatibility issues.
+ * Uses safeOutboundFetch with bypassProxyPatch to use native Node.js fetch directly.
+ */
+export function directHttpsRequest(
+  url: string,
+  options: { method?: string; headers?: Record<string, string>; body?: string },
+  timeoutMs: number
+): Promise<{ status: number; ok: boolean; text: () => Promise<string> }> {
+  return safeOutboundFetch(url, {
+    method: options.method || "GET",
+    headers: (options.headers || {}) as Record<string, string>,
+    body: options.body,
+    timeoutMs,
+    bypassProxyPatch: true,
+    allowRedirect: true,
+    guard: "none",
+    retry: false,
+  }).then(async (response) => ({
+    status: response.status,
+    ok: response.ok,
+    text: async () => await response.text(),
+  }));
+}
+
+export function buildBearerHeaders(apiKey: string, providerSpecificData: any = {}) {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (apiKey) {
+    headers.Authorization = `Bearer ${apiKey}`;
+  }
+  return applyCustomUserAgent(headers, providerSpecificData);
+}
+
+export function buildRekaHeaders(apiKey: string, providerSpecificData: any = {}) {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+
+  if (apiKey) {
+    headers.Authorization = `Bearer ${apiKey}`;
+    headers["X-Api-Key"] = apiKey;
+  }
+
+  return applyCustomUserAgent(headers, providerSpecificData);
+}
+
+export function buildClarifaiHeaders(apiKey: string, providerSpecificData: any = {}) {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+
+  if (apiKey) {
+    headers.Authorization = `Key ${apiKey}`;
+  }
+
+  return applyCustomUserAgent(headers, providerSpecificData);
+}
+
+export function buildKeyHeaders(apiKey: string, providerSpecificData: any = {}) {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+
+  if (apiKey) {
+    headers.Authorization = `Key ${apiKey}`;
+  }
+
+  return applyCustomUserAgent(headers, providerSpecificData);
+}
+
+export function buildTokenHeaders(apiKey: string, providerSpecificData: any = {}) {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+
+  if (apiKey) {
+    headers.Authorization = `Token ${apiKey}`;
+  }
+
+  return applyCustomUserAgent(headers, providerSpecificData);
+}

--- a/src/lib/providers/validation/transport.ts
+++ b/src/lib/providers/validation/transport.ts
@@ -1,0 +1,109 @@
+// Outbound fetch wrappers for provider validation: proxy-fallback, SSRF-aware proxy targeting, and
+// error→result mapping. Extracted from validation.ts (god-file decomposition). Behavior is
+// byte-identical to the original inline defs.
+import {
+  SAFE_OUTBOUND_FETCH_PRESETS,
+  SafeOutboundFetchError,
+  getSafeOutboundFetchErrorStatus,
+  safeOutboundFetch,
+} from "@/shared/network/safeOutboundFetch";
+import { getProviderOutboundGuard, isPrivateHost } from "@/shared/network/outboundUrlGuard";
+import { selectProxyForValidation } from "@omniroute/open-sse/services/proxyAutoSelector.ts";
+
+/**
+ * Wrapped fetch call that auto-retries with a proxy when the direct connection
+ * fails.  This happens transparently so individual validators don't need to
+ * think about proxy fallback.
+ */
+export async function fetchWithProxyFallback(
+  url: string,
+  init: RequestInit,
+  presets: typeof SAFE_OUTBOUND_FETCH_PRESETS.validationRead,
+  isLocal: boolean
+): Promise<Response> {
+  try {
+    return await safeOutboundFetch(url, {
+      ...presets,
+      guard: isLocal ? "none" : getProviderOutboundGuard(),
+      ...init,
+    });
+  } catch (err: unknown) {
+    // Only attempt proxy fallback for retryable errors (network / timeout)
+    // and only when the target is not a local / LAN address.
+    const fetchErr = err as SafeOutboundFetchError;
+    const isNetworkIssue = fetchErr?.code === "NETWORK_ERROR" || fetchErr?.code === "TIMEOUT";
+    const isRetryable = fetchErr?.isRetryable !== false;
+    const isValidTarget = !isLocal && isRetryableProxyTarget(url);
+
+    if (isLocal || !isNetworkIssue || !isRetryable) throw err;
+    if (!isValidTarget) throw err;
+
+    const proxyUrl = await selectProxyForValidation(url);
+    if (!proxyUrl) throw err;
+
+    return safeOutboundFetch(url, {
+      ...presets,
+      guard: isLocal ? "none" : getProviderOutboundGuard(),
+      ...init,
+      proxyConfig: proxyUrl,
+    });
+  }
+}
+
+export function isRetryableProxyTarget(url: string): boolean {
+  try {
+    const hostname = new URL(url).hostname.toLowerCase();
+    // Never proxy-fallback to a private/link-local/metadata host. Delegates to
+    // the canonical SSRF guard (covers 169.254, 0.0.0.0, 172.16/12, CGNAT,
+    // IPv6 fc/fd/fe80, .internal — gaps the previous inline check missed).
+    return !isPrivateHost(hostname);
+  } catch {
+    return false;
+  }
+}
+
+export async function validationRead(url: string, init: RequestInit, isLocal: boolean = false) {
+  return fetchWithProxyFallback(url, init, SAFE_OUTBOUND_FETCH_PRESETS.validationRead, isLocal);
+}
+
+export async function validationWrite(url: string, init: RequestInit, isLocal: boolean = false) {
+  return fetchWithProxyFallback(url, init, SAFE_OUTBOUND_FETCH_PRESETS.validationWrite, isLocal);
+}
+
+// A validation failure should only be flagged `securityBlocked` (which the route
+// surfaces as a `provider.validation.ssrf_blocked` audit event + a security warning in
+// the UI) when it is a GENUINE SSRF/guard block — not for every outbound-guard 503.
+// A blocked redirect (REDIRECT_BLOCKED) to a PUBLIC host is benign: the redirect was
+// never followed, so no SSRF occurred. Web-cookie providers like qwen-web answer their
+// probe with a 307 to a public host, which used to be mislabeled as an SSRF block
+// (#3288 / #3758). Only treat a blocked redirect as a security event when its target is
+// a private/internal host.
+export function isSecurityBlockError(error: unknown): boolean {
+  if (!(error instanceof SafeOutboundFetchError)) return false;
+  if (error.code === "URL_GUARD_BLOCKED" || error.code === "INVALID_URL") return true;
+  if (error.code === "REDIRECT_BLOCKED") {
+    if (!error.location) return false;
+    try {
+      return isPrivateHost(new URL(error.location, error.url).hostname);
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
+export function toValidationErrorResult(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error || "Validation failed");
+  const statusCode = getSafeOutboundFetchErrorStatus(error);
+
+  return {
+    valid: false,
+    error: message || "Validation failed",
+    unsupported: false as const,
+    ...(statusCode ? { statusCode } : {}),
+    ...(error instanceof SafeOutboundFetchError && error.code === "TIMEOUT"
+      ? { timeout: true }
+      : {}),
+    ...(isSecurityBlockError(error) ? { securityBlocked: true } : {}),
+  };
+}

--- a/src/lib/providers/validation/urlHelpers.ts
+++ b/src/lib/providers/validation/urlHelpers.ts
@@ -1,0 +1,114 @@
+// URL/format normalizers for provider key validation. Pure string helpers extracted from
+// validation.ts (god-file decomposition): no I/O, no side effects — they only shape base URLs
+// and chat endpoints per provider format. Behavior is byte-identical to the original inline defs.
+import {
+  stripAnthropicMessagesSuffix,
+  stripClaudeCodeCompatibleEndpointSuffix,
+} from "@omniroute/open-sse/services/claudeCodeCompatible.ts";
+import { isOpenAICompatibleProvider } from "@/shared/constants/providers";
+
+export const OPENAI_LIKE_FORMATS = new Set(["openai", "openai-responses"]);
+export const GEMINI_LIKE_FORMATS = new Set(["gemini", "gemini-cli"]);
+
+export function normalizeBaseUrl(baseUrl: string) {
+  // Guard against a non-string baseUrl reaching .trim() / .replace() — see #2463
+  // where NVIDIA NIM validation surfaced as `e.startsWith is not a function`
+  // after the bundler renamed `baseUrl` to `e`. Any malformed providerSpecificData
+  // (e.g. saved as object from a UI bug) would otherwise crash mid-validation.
+  const value = typeof baseUrl === "string" ? baseUrl : "";
+  return value.trim().replace(/\/$/, "");
+}
+
+export function normalizeAzureOpenAIBaseUrl(baseUrl: string) {
+  return normalizeBaseUrl(baseUrl)
+    .replace(/\/openai$/i, "")
+    .replace(/\/openai\/deployments\/[^/]+\/chat\/completions.*$/i, "");
+}
+
+export function normalizeAnthropicBaseUrl(baseUrl: string) {
+  return stripAnthropicMessagesSuffix(baseUrl || "");
+}
+
+export function normalizeClaudeCodeCompatibleBaseUrl(baseUrl: string) {
+  return stripClaudeCodeCompatibleEndpointSuffix(baseUrl || "");
+}
+
+export function addModelsSuffix(baseUrl: string) {
+  const normalized = normalizeBaseUrl(baseUrl);
+  if (!normalized) return "";
+
+  const suffixes = ["/chat/completions", "/responses", "/chat", "/messages"];
+  if (normalized.endsWith("/models")) {
+    return normalized;
+  }
+  for (const suffix of suffixes) {
+    if (normalized.endsWith(suffix)) {
+      return `${normalized.slice(0, -suffix.length)}/models`;
+    }
+  }
+
+  return `${normalized}/models`;
+}
+
+export function resolveBaseUrl(entry: any, providerSpecificData: any = {}) {
+  if (providerSpecificData?.baseUrl) return normalizeBaseUrl(providerSpecificData.baseUrl);
+  if (entry?.baseUrl) return normalizeBaseUrl(entry.baseUrl);
+  return "";
+}
+
+export function resolveChatUrl(provider: string, baseUrl: string, providerSpecificData: any = {}) {
+  const normalized = normalizeBaseUrl(baseUrl);
+  if (!normalized) return "";
+
+  if (isOpenAICompatibleProvider(provider)) {
+    if (providerSpecificData?.chatPath) {
+      return `${normalized}${providerSpecificData.chatPath}`;
+    }
+    if (providerSpecificData?.apiType === "responses") {
+      return `${normalized}/responses`;
+    }
+    return `${normalized}/chat/completions`;
+  }
+
+  if (
+    normalized.endsWith("/chat/completions") ||
+    normalized.endsWith("/responses") ||
+    normalized.endsWith("/chat")
+  ) {
+    return normalized;
+  }
+
+  if (normalized.endsWith("/v1")) {
+    return `${normalized}/chat/completions`;
+  }
+
+  return normalized;
+}
+
+export function normalizeHerokuChatUrl(baseUrl: string) {
+  const normalized = normalizeBaseUrl(baseUrl);
+  if (!normalized) return "";
+  return normalized.endsWith("/v1/chat/completions")
+    ? normalized
+    : `${normalized}/v1/chat/completions`;
+}
+
+export function normalizeDatabricksChatUrl(baseUrl: string) {
+  const normalized = normalizeBaseUrl(baseUrl);
+  if (!normalized) return "";
+  return normalized.endsWith("/chat/completions") ? normalized : `${normalized}/chat/completions`;
+}
+
+export function normalizeSnowflakeChatUrl(baseUrl: string) {
+  const normalized = normalizeBaseUrl(baseUrl)
+    .replace(/\/cortex\/inference:complete$/, "")
+    .replace(/\/api\/v2$/, "");
+  if (!normalized) return "";
+  return `${normalized}/api/v2/cortex/inference:complete`;
+}
+
+export function normalizeGigachatChatUrl(baseUrl: string) {
+  const normalized = normalizeBaseUrl(baseUrl).replace(/\/chat\/completions$/, "");
+  if (!normalized) return "";
+  return `${normalized}/chat/completions`;
+}

--- a/tests/unit/validation-helpers-split.test.ts
+++ b/tests/unit/validation-helpers-split.test.ts
@@ -1,0 +1,57 @@
+// Characterization of the validation.ts split (god-file decomposition): the pure infra layer
+// (URL normalizers, header builders, fetch/error transport) moved into co-located leaf modules under
+// providers/validation/. The host re-imports them and re-exports the two historically-public helpers
+// (isRetryableProxyTarget, isSecurityBlockError). These were a behavior-preserving move — no logic
+// change — so the locks here are: public surface stays intact, the new modules expose the helpers,
+// and a few pure functions still compute identically.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+const HOST = await import("../../src/lib/providers/validation.ts");
+const urls = await import("../../src/lib/providers/validation/urlHelpers.ts");
+const headers = await import("../../src/lib/providers/validation/headers.ts");
+const transport = await import("../../src/lib/providers/validation/transport.ts");
+
+test("host preserves its public surface (dispatcher + claude-code validator + re-exported guards)", () => {
+  for (const name of [
+    "validateProviderApiKey",
+    "validateClaudeCodeCompatibleProvider",
+    "validateWebCookieProvider",
+    "validateCommandCodeProvider",
+    "isRetryableProxyTarget",
+    "isSecurityBlockError",
+  ]) {
+    assert.equal(typeof (HOST as Record<string, unknown>)[name], "function", `missing ${name}`);
+  }
+});
+
+test("re-exported guards are the same function objects as transport's", () => {
+  assert.equal(
+    (HOST as Record<string, unknown>).isRetryableProxyTarget,
+    transport.isRetryableProxyTarget
+  );
+  assert.equal(
+    (HOST as Record<string, unknown>).isSecurityBlockError,
+    transport.isSecurityBlockError
+  );
+});
+
+test("urlHelpers: normalizeBaseUrl trims + strips trailing slash; addModelsSuffix swaps endpoints", () => {
+  assert.equal(urls.normalizeBaseUrl("  https://api.x.com/v1/  "), "https://api.x.com/v1");
+  assert.equal(urls.normalizeBaseUrl(123 as unknown as string), ""); // non-string guard (#2463)
+  assert.equal(urls.addModelsSuffix("https://api.x.com/v1/chat/completions"), "https://api.x.com/v1/models");
+  assert.equal(urls.addModelsSuffix("https://api.x.com/v1/models"), "https://api.x.com/v1/models");
+});
+
+test("headers: buildBearerHeaders sets Authorization; builders vary the scheme", () => {
+  assert.equal(headers.buildBearerHeaders("k").Authorization, "Bearer k");
+  assert.equal(headers.buildClarifaiHeaders("k").Authorization, "Key k");
+  assert.equal(headers.buildTokenHeaders("k").Authorization, "Token k");
+  assert.equal(headers.buildBearerHeaders("").Authorization, undefined); // empty key → no auth header
+});
+
+test("transport: isRetryableProxyTarget fails closed on bad URL and blocks private hosts", () => {
+  assert.equal(transport.isRetryableProxyTarget("not a url"), false);
+  assert.equal(transport.isRetryableProxyTarget("http://169.254.169.254/"), false);
+  assert.equal(transport.isRetryableProxyTarget("https://api.openai.com/v1"), true);
+});


### PR DESCRIPTION
## Contexto

Decomposição de god-files — **Tier 1 / M2** do roadmap-mestre (padrão #3501). Primeira fatia de `src/lib/providers/validation.ts` (4522 LOC), o maior arquivo de lógica pura do projeto.

Move a **camada-folha de infra pura** (sem mudança de comportamento, byte-idêntica ao inline original) para 3 módulos co-localizados:

| Módulo | Conteúdo |
|--------|----------|
| `providers/validation/urlHelpers.ts` | normalizadores de `baseUrl`/`chatUrl` por formato (`normalizeBaseUrl`, `addModelsSuffix`, `resolveChatUrl`, …) |
| `providers/validation/headers.ts` | builders de header + UA custom + `directHttpsRequest` |
| `providers/validation/transport.ts` | `fetchWithProxyFallback` (SSRF-aware), `validationRead/Write`, `toValidationErrorResult`, guards |

`validation.ts`: **4522 → 4234 (−288)**. O host re-importa os helpers e **re-exporta** `isRetryableProxyTarget` / `isSecurityBlockError` para preservar a superfície pública (importados por testes e route handlers via este módulo).

Imports órfãos no host (símbolos que só os blocos movidos usavam) foram removidos: `stripAnthropicMessagesSuffix`, `stripClaudeCodeCompatibleEndpointSuffix`, `selectProxyForValidation`, `isPrivateHost`, `SafeOutboundFetchError`, `getSafeOutboundFetchErrorStatus`.

## Validação

- `typecheck:core` ✓ · `eslint` 0/0 nos 4 arquivos ✓ · `check:cycles` ✓ · `check:file-size` ✓ (módulos novos <800)
- **173** testes de validação existentes (`provider-validation-*`, `proxy-fallback-ssrf`, `search-provider-validation`, `noauth`, `providers-validate-route`) — todos verdes, sem alteração
- **+5** testes de caracterização do split (`validation-helpers-split.test.ts`): superfície pública do host, identidade dos guards re-exportados, e funções puras computando idêntico

Refactor puro behavior-preserving — sem VPS.