### PR TITLE
fix: add Antigravity 'invalid argument' fallback + NVIDIA Minimax model family

### DIFF
--- a/open-sse/services/modelFamilyFallback.ts
+++ b/open-sse/services/modelFamilyFallback.ts
@@ -87,6 +87,10 @@ const MODEL_FAMILIES: Record<string, string[]> = {
   "claude-sonnet-4-6": ["claude-sonnet-4-5-20250929", "claude-sonnet-4-20250514"],
   "claude-sonnet-4-5-20250929": ["claude-sonnet-4-6", "claude-sonnet-4-20250514"],
 
+  // NVIDIA Minimax family
+  "minimaxai/minimax-m2.7": ["minimaxai/minimax-m2.5", "minimax-m2.7", "minimax-m2.5"],
+  "minimaxai/minimax-m2.5": ["minimaxai/minimax-m2.7", "minimax-m2.5", "minimax-m2.7"],
+
   // GPT-5 family
   "gpt-5": ["gpt-5-mini", "gpt-4o"],
   "gpt-5.1": ["gpt-5.1-mini", "gpt-5", "gpt-4o"],
@@ -113,6 +117,7 @@ const MODEL_UNAVAILABLE_FRAGMENTS = [
   "not enabled for",
   "access to model",
   "improperly formed request", // Kiro 400 (model unavailable)
+  "invalid argument", // Antigravity 400 (model unavailable)
 ];
 
 /**


### PR DESCRIPTION
## Summary

Cherry-picks a small, focused fix from the KooshaPari fork that broadens provider model-unavailable detection and adds a NVIDIA Minimax model family. The change is **purely additive** — no existing logic is altered, and all behaviour is gated on the existing `isModelUnavailableError()` matcher plus the `MODEL_FAMILIES` lookup table.

### Why it matters

- **Antigravity 400 fallback**: Antigravity (an OpenAI-compatible provider) returns a 400 with body text `invalid argument` when `claude-opus-4-6-thinking` is not available on the current account. Without this fragment, the request fails hard instead of falling back to `claude-opus-4-6` or `claude-opus-4-5-20251101`.
- **NVIDIA Minimax model family**: Adds cross-model fallback for `minimaxai/minimax-m2.7` ↔ `minimaxai/minimax-m2.5` when one returns 404 Function not found.

### Files

```
M  open-sse/services/modelFamilyFallback.ts
```

### Diff

```diff
@@ -87,6 +87,10 @@ const MODEL_FAMILIES: Record<string, string[]> = {
   "claude-sonnet-4-6": ["claude-sonnet-4-5-20250929", "claude-sonnet-4-20250514"],
   "claude-sonnet-4-5-20250929": ["claude-sonnet-4-6", "claude-sonnet-4-20250514"],
 
+  // NVIDIA Minimax family
+  "minimaxai/minimax-m2.7": ["minimaxai/minimax-m2.5", "minimax-m2.7", "minimax-m2.5"],
+  "minimaxai/minimax-m2.5": ["minimaxai/minimax-m2.7", "minimax-m2.5", "minimax-m2.7"],
+
   // GPT-5 family
   "gpt-5": ["gpt-5-mini", "gpt-4o"],
@@ -113,6 +117,7 @@ const MODEL_UNAVAILABLE_FRAGMENTS = [
   "not enabled for",
   "access to model",
   "improperly formed request", // Kiro 400 (model unavailable)
+  "invalid argument", // Antigravity 400 (model unavailable)
 ];
```

### Compatibility

- **No breaking changes** — strictly additive. Defaults to existing model-resolution path if neither new fragment nor new family is matched.
- **Behaviour parity** — Antigravity 400 errors and NVIDIA Minimax 404s now route through the same `isModelUnavailableError()` path as every other provider.
- **No new deps** — uses only the existing `MODEL_FAMILIES` table and `MODEL_UNAVAILABLE_FRAGMENTS` array.

### Test plan

- Existing test suite for `modelFamilyFallback.ts` should pass unchanged.
- Manual: trigger a 400 with body `invalid argument` on `claude-opus-4-6-thinking` and verify fallback to `claude-opus-4-6`.
- Manual: trigger a 404 on `minimaxai/minimax-m2.7` and verify fallback to `minimaxai/minimax-m2.5`.

### Refs

- Source PR: KooshaPari/OmniRoute#1 (original author: KooshaPari)
- Source SHA: `bc62557e047bc98ed559985c156fe4468f9a663e`
- Cherry-picked via `git cherry-pick -x` (commit `(cherry picked from commit bc62557e0)`)
- Forks involved: KooshaPari/OmniRoute (origin), diegosouzapw/OmniRoute (upstream)