### PR TITLE
feat(quota): buckets multi-janela por conexão (5h/7d/per-model) [Fase 3 #3]

### DIFF
--- a/src/lib/quota/accountBuckets.ts
+++ b/src/lib/quota/accountBuckets.ts
@@ -1,0 +1,225 @@
+/**
+ * accountBuckets.ts — Saturating per-connection, per-window buckets.
+ *
+ * Tracks whether a connection has hit 100 % of a quota window (5h / 7d /
+ * per-model 7d). Each bucket is lazily reset: on read, if now >= resetsAtMs
+ * the entry is cleared and the connection is eligible again. No cron needed —
+ * the reset is probed on the read path.
+ *
+ * Fail-open: missing entry → not saturated. All time input is injectable
+ * (the `nowMs` param) so unit tests drive the clock deterministically — the
+ * tested path never calls Date.now() implicitly.
+ *
+ * Complementary to connectionRecovery.ts: that module recovers DB-backed
+ * request-error cooldowns (testStatus 'unavailable' + rateLimitedUntil); this
+ * module tracks in-process plan-window utilization. Orthogonal concerns.
+ *
+ * Part of: Quota Sharing Engine — Phase 3 (#3 multi-window buckets).
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** In-process state for one (connectionId, windowKey) pair. */
+interface BucketEntry {
+  saturated: boolean;
+  resetsAtMs: number; // 0 when the reset instant is unknown
+}
+
+/**
+ * Minimal shape of a parsed UsageQuota entry, as produced by getClaudeUsage in
+ * open-sse/services/usage.ts. `used` = % consumed (0..100); `total` = 100 for
+ * percent-based windows; `resetAt` = ISO 8601 string or null (already
+ * normalized upstream by parseResetTime).
+ */
+export interface UsageQuotaSlim {
+  used: number;
+  total: number;
+  resetAt: string | null;
+}
+
+/**
+ * Partial shape of the getClaudeUsage() return value this module needs. Only
+ * `quotas` is consumed; other fields (plan, extraUsage, bootstrap) are ignored.
+ */
+export interface ClaudeUsageResult {
+  quotas?: Record<string, UsageQuotaSlim | undefined>;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Utilization threshold (0..100) at/above which a window is considered
+ * saturated. 100 = exhausted. Named so it can be tuned globally if Anthropic
+ * ever soft-throttles below the hard cap.
+ */
+export const SATURATION_THRESHOLD_PCT = 100;
+
+// ---------------------------------------------------------------------------
+// In-process store
+// ---------------------------------------------------------------------------
+
+/** Key: `${connectionId}::${windowKey}`. */
+const _buckets = new Map<string, BucketEntry>();
+
+function storeKey(connectionId: string, windowKey: string): string {
+  return `${connectionId}::${windowKey}`;
+}
+
+/**
+ * Parse an ISO 8601 `resetAt` string to epoch ms. Returns 0 on any failure
+ * (unknown reset time → the lazy reset cannot fire for that bucket).
+ */
+function parseResetAtMs(resetAt: string | null | undefined): number {
+  if (!resetAt) return 0;
+  const ms = Date.parse(resetAt);
+  return Number.isFinite(ms) && ms > 0 ? ms : 0;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Check whether the bucket for (connectionId, windowKey) is currently
+ * saturated.
+ *
+ * Lazy reset: if `nowMs >= entry.resetsAtMs` (and resetsAtMs > 0) the entry is
+ * cleared and `false` is returned — the connection is eligible again without
+ * any background sweep.
+ *
+ * Fail-open: a missing entry returns false (not saturated).
+ *
+ * @param connectionId  Opaque string identifier for the connection.
+ * @param windowKey     One of: "5h", "7d", "7d:<modelName>" (e.g. "7d:designer").
+ * @param nowMs         Current epoch ms; defaults to Date.now() (off-path only).
+ */
+export function isBucketSaturated(
+  connectionId: string,
+  windowKey: string,
+  nowMs: number = Date.now()
+): boolean {
+  if (!connectionId || !windowKey) return false; // fail-open
+  const key = storeKey(connectionId, windowKey);
+  const entry = _buckets.get(key);
+  if (!entry) return false; // fail-open
+
+  // Lazy reset: the window rolled over → the saturation is stale.
+  if (entry.resetsAtMs > 0 && nowMs >= entry.resetsAtMs) {
+    _buckets.delete(key);
+    return false;
+  }
+
+  return entry.saturated;
+}
+
+/**
+ * Record a usage observation for one (connectionId, windowKey) pair.
+ *
+ * Marks the bucket saturated when `usedPct >= SATURATION_THRESHOLD_PCT` and the
+ * window has NOT already rolled over. When the observation is below the
+ * threshold (or already past its reset), any existing entry is cleared so the
+ * connection's eligibility is restored promptly. When `resetAt` is a valid ISO
+ * string, the reset epoch is stored so lazy reset can fire later.
+ *
+ * @param connectionId  Opaque connection identifier.
+ * @param windowKey     "5h", "7d", or "7d:<modelName>".
+ * @param usedPct       Utilization percentage (0..100).
+ * @param resetAt       ISO 8601 string (or null) for when this window resets.
+ * @param nowMs         Current epoch ms; defaults to Date.now() (off-path only).
+ */
+export function recordUsage(
+  connectionId: string,
+  windowKey: string,
+  usedPct: number,
+  resetAt: string | null,
+  nowMs: number = Date.now()
+): void {
+  if (!connectionId || !windowKey) return;
+  const key = storeKey(connectionId, windowKey);
+
+  const resetsAtMs = parseResetAtMs(resetAt);
+
+  // Stale signal: the window already reset — discard any state and bail.
+  if (resetsAtMs > 0 && nowMs >= resetsAtMs) {
+    _buckets.delete(key);
+    return;
+  }
+
+  const saturated = Number.isFinite(usedPct) && usedPct >= SATURATION_THRESHOLD_PCT;
+  if (!saturated) {
+    // Below threshold → clear any stale saturation so the bucket is eligible.
+    _buckets.delete(key);
+    return;
+  }
+
+  _buckets.set(key, { saturated: true, resetsAtMs });
+}
+
+/**
+ * Parse the `quotas` map from a getClaudeUsage() result and record each known
+ * window into its bucket.
+ *
+ * Window key mapping:
+ *   "session (5h)"         → "5h"
+ *   "weekly (7d)"          → "7d"
+ *   "weekly <model> (7d)"  → "7d:<model>" (e.g. "weekly designer (7d)" → "7d:designer")
+ *
+ * Fail-open: a null/undefined result, a missing `quotas` map, or any malformed
+ * quota entry is silently skipped.
+ *
+ * @param connectionId  Connection identifier.
+ * @param usageResult   getClaudeUsage() return value (only `quotas` is read).
+ * @param nowMs         Current epoch ms; defaults to Date.now() (off-path only).
+ */
+export function updateAccountBuckets(
+  connectionId: string,
+  usageResult: ClaudeUsageResult | null | undefined,
+  nowMs: number = Date.now()
+): void {
+  if (!connectionId || !usageResult?.quotas) return;
+  const { quotas } = usageResult;
+
+  // Fixed windows.
+  processQuotaEntry(connectionId, "5h", quotas["session (5h)"], nowMs);
+  processQuotaEntry(connectionId, "7d", quotas["weekly (7d)"], nowMs);
+
+  // Per-model weekly windows: "weekly <model> (7d)" → "7d:<model>".
+  for (const [key, entry] of Object.entries(quotas)) {
+    const match = /^weekly (.+) \(7d\)$/.exec(key);
+    if (match?.[1]) {
+      processQuotaEntry(connectionId, `7d:${match[1]}`, entry, nowMs);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function processQuotaEntry(
+  connectionId: string,
+  windowKey: string,
+  entry: UsageQuotaSlim | undefined | null,
+  nowMs: number
+): void {
+  if (!entry || typeof entry.used !== "number") return;
+  recordUsage(connectionId, windowKey, entry.used, entry.resetAt ?? null, nowMs);
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers (never call in production code)
+// ---------------------------------------------------------------------------
+
+/** Clear all bucket entries. Tests only — keeps state isolation between cases. */
+export function _clearBucketsForTest(): void {
+  _buckets.clear();
+}
+
+/** Return the current bucket count. Tests only — black-box size assertion. */
+export function _bucketCountForTest(): number {
+  return _buckets.size;
+}

--- a/src/lib/quota/saturationSignals.ts
+++ b/src/lib/quota/saturationSignals.ts
@@ -24,6 +24,7 @@
  */
 
 import { createLogger } from "@/shared/utils/logger";
+import { updateAccountBuckets, type ClaudeUsageResult } from "./accountBuckets";
 import type { QuotaUnit, QuotaWindow } from "./dimensions";
 
 const log = createLogger("quota:saturation");
@@ -434,6 +435,14 @@ async function fetchAnthropicSaturation(
       (conn.authType === undefined || conn.authType === "oauth");
     if (hasOauthToken) {
       const usage = await deps.fetchUsage(conn as Record<string, unknown>);
+      // Update the per-window saturating buckets (Phase 3 #3) off the request
+      // hot path — this runs behind the 30s saturation cache. Fail-open: any
+      // bucket error must never affect the primary 0..1 saturation signal.
+      try {
+        updateAccountBuckets(connectionId, usage as ClaudeUsageResult, Date.now());
+      } catch {
+        // intentionally swallowed — buckets are additive, never gate-breaking
+      }
       const util = planUtilizationFromUsage(usage, dim.window);
       if (util !== null) return util;
     }

--- a/tests/unit/quota-account-buckets.test.ts
+++ b/tests/unit/quota-account-buckets.test.ts
@@ -1,0 +1,222 @@
+/**
+ * tests/unit/quota-account-buckets.test.ts
+ *
+ * Unit tests for src/lib/quota/accountBuckets.ts.
+ *
+ * Required cases (Phase 3 #3):
+ *   - 5h reaches limit → saturated; after resets_at passes → auto-eligible (lazy)
+ *   - per-model buckets independent: 7d:opus saturated does NOT saturate 7d:sonnet
+ *   - concurrent 5h and 7d: saturating 5h does NOT saturate 7d
+ *   - fail-open: no data → not saturated
+ *
+ * The clock is injected via `nowMs` so the lazy-reset behaviour is deterministic
+ * (no real Date.now() on the tested path).
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  isBucketSaturated,
+  recordUsage,
+  updateAccountBuckets,
+  _clearBucketsForTest,
+  _bucketCountForTest,
+  SATURATION_THRESHOLD_PCT,
+  type ClaudeUsageResult,
+  type UsageQuotaSlim,
+} from "../../src/lib/quota/accountBuckets.ts";
+
+// Fixed epoch for deterministic tests — 2026-06-24T12:00:00Z.
+const NOW = Date.UTC(2026, 5, 24, 12, 0, 0);
+const ONE_HOUR_MS = 60 * 60 * 1000;
+const FUTURE_ISO = new Date(NOW + ONE_HOUR_MS).toISOString(); // window still open
+const PAST_ISO = new Date(NOW - ONE_HOUR_MS).toISOString(); // window already reset
+
+function makeQuota(used: number, resetAt: string | null): UsageQuotaSlim {
+  return { used, total: 100, resetAt };
+}
+
+test.beforeEach(() => {
+  _clearBucketsForTest();
+});
+
+// ─── fail-open ────────────────────────────────────────────────────────────────
+
+test("isBucketSaturated: no entry → false (fail-open, no data)", () => {
+  assert.equal(isBucketSaturated("conn-1", "5h", NOW), false);
+  assert.equal(isBucketSaturated("conn-1", "7d", NOW), false);
+  assert.equal(isBucketSaturated("conn-1", "7d:opus", NOW), false);
+});
+
+test("isBucketSaturated: empty connectionId or windowKey → false", () => {
+  assert.equal(isBucketSaturated("", "5h", NOW), false);
+  assert.equal(isBucketSaturated("conn-1", "", NOW), false);
+});
+
+// ─── 5h window saturation + lazy reset ───────────────────────────────────────
+
+test("5h bucket: reaches 100% → saturated; after resets_at passes → auto-eligible (lazy)", () => {
+  const connectionId = "conn-5h";
+  const windowKey = "5h";
+
+  recordUsage(connectionId, windowKey, 100, FUTURE_ISO, NOW);
+  assert.equal(isBucketSaturated(connectionId, windowKey, NOW), true, "should be saturated at 100%");
+
+  // Advance the clock past resets_at — lazy reset fires on the next read.
+  const afterReset = NOW + ONE_HOUR_MS + 1;
+  assert.equal(
+    isBucketSaturated(connectionId, windowKey, afterReset),
+    false,
+    "should be eligible again once resets_at has passed"
+  );
+});
+
+test("5h bucket: 99% (below threshold) → NOT saturated", () => {
+  recordUsage("conn-99pct", "5h", 99, FUTURE_ISO, NOW);
+  assert.equal(isBucketSaturated("conn-99pct", "5h", NOW), false);
+});
+
+test("SATURATION_THRESHOLD_PCT is 100", () => {
+  assert.equal(SATURATION_THRESHOLD_PCT, 100);
+});
+
+test("5h bucket: stale signal (resets_at already past) is NOT recorded", () => {
+  recordUsage("conn-stale", "5h", 100, PAST_ISO, NOW);
+  assert.equal(isBucketSaturated("conn-stale", "5h", NOW), false);
+  assert.equal(_bucketCountForTest(), 0);
+});
+
+// ─── 7d window ───────────────────────────────────────────────────────────────
+
+test("7d bucket: reaches 100% → saturated", () => {
+  recordUsage("conn-7d", "7d", 100, FUTURE_ISO, NOW);
+  assert.equal(isBucketSaturated("conn-7d", "7d", NOW), true);
+});
+
+test("concurrent windows: saturating 5h does NOT saturate 7d", () => {
+  recordUsage("conn-two-windows", "5h", 100, FUTURE_ISO, NOW);
+  assert.equal(isBucketSaturated("conn-two-windows", "5h", NOW), true, "5h should be saturated");
+  assert.equal(isBucketSaturated("conn-two-windows", "7d", NOW), false, "7d should NOT be saturated");
+});
+
+test("concurrent windows: saturating 7d does NOT saturate 5h", () => {
+  recordUsage("conn-7d-only", "7d", 100, FUTURE_ISO, NOW);
+  assert.equal(isBucketSaturated("conn-7d-only", "7d", NOW), true, "7d should be saturated");
+  assert.equal(isBucketSaturated("conn-7d-only", "5h", NOW), false, "5h should NOT be saturated");
+});
+
+// ─── per-model buckets ────────────────────────────────────────────────────────
+
+test("per-model buckets are independent: 7d:opus saturated does NOT saturate 7d:sonnet", () => {
+  recordUsage("conn-models", "7d:opus", 100, FUTURE_ISO, NOW);
+  assert.equal(isBucketSaturated("conn-models", "7d:opus", NOW), true, "opus should be saturated");
+  assert.equal(
+    isBucketSaturated("conn-models", "7d:sonnet", NOW),
+    false,
+    "sonnet should NOT be saturated"
+  );
+});
+
+test("per-model: 7d:sonnet saturated does NOT affect the base 7d bucket", () => {
+  recordUsage("conn-pm-base", "7d:sonnet", 100, FUTURE_ISO, NOW);
+  assert.equal(isBucketSaturated("conn-pm-base", "7d:sonnet", NOW), true);
+  assert.equal(isBucketSaturated("conn-pm-base", "7d", NOW), false, "base 7d should be independent");
+});
+
+test("per-model: lazy reset works for 7d:designer", () => {
+  recordUsage("conn-designer", "7d:designer", 100, FUTURE_ISO, NOW);
+  assert.equal(isBucketSaturated("conn-designer", "7d:designer", NOW), true);
+
+  const afterReset = NOW + ONE_HOUR_MS + 1;
+  assert.equal(isBucketSaturated("conn-designer", "7d:designer", afterReset), false);
+});
+
+// ─── updateAccountBuckets mapping (getClaudeUsage shape) ──────────────────────
+
+test("updateAccountBuckets: null result → no-op (fail-open)", () => {
+  updateAccountBuckets("conn-null", null, NOW);
+  assert.equal(_bucketCountForTest(), 0);
+});
+
+test("updateAccountBuckets: empty quotas → no-op", () => {
+  updateAccountBuckets("conn-empty", { quotas: {} }, NOW);
+  assert.equal(_bucketCountForTest(), 0);
+});
+
+test("updateAccountBuckets: 'session (5h)' maps to '5h' window key", () => {
+  const usage: ClaudeUsageResult = {
+    quotas: { "session (5h)": makeQuota(100, FUTURE_ISO) },
+  };
+  updateAccountBuckets("conn-map-5h", usage, NOW);
+  assert.equal(isBucketSaturated("conn-map-5h", "5h", NOW), true);
+});
+
+test("updateAccountBuckets: 'weekly (7d)' maps to '7d' window key", () => {
+  const usage: ClaudeUsageResult = {
+    quotas: { "weekly (7d)": makeQuota(100, FUTURE_ISO) },
+  };
+  updateAccountBuckets("conn-map-7d", usage, NOW);
+  assert.equal(isBucketSaturated("conn-map-7d", "7d", NOW), true);
+});
+
+test("updateAccountBuckets: 'weekly designer (7d)' maps to '7d:designer' (base 7d unaffected)", () => {
+  const usage: ClaudeUsageResult = {
+    quotas: { "weekly designer (7d)": makeQuota(100, FUTURE_ISO) },
+  };
+  updateAccountBuckets("conn-designer-map", usage, NOW);
+  assert.equal(isBucketSaturated("conn-designer-map", "7d:designer", NOW), true);
+  assert.equal(isBucketSaturated("conn-designer-map", "7d", NOW), false, "base 7d unaffected");
+});
+
+test("updateAccountBuckets: an unsaturated update clears a previously saturated bucket", () => {
+  recordUsage("conn-unsaturate", "5h", 100, FUTURE_ISO, NOW);
+  assert.equal(isBucketSaturated("conn-unsaturate", "5h", NOW), true);
+
+  const usage: ClaudeUsageResult = {
+    quotas: { "session (5h)": makeQuota(50, FUTURE_ISO) },
+  };
+  updateAccountBuckets("conn-unsaturate", usage, NOW);
+  assert.equal(
+    isBucketSaturated("conn-unsaturate", "5h", NOW),
+    false,
+    "should be cleared when the latest reading is below threshold"
+  );
+});
+
+test("updateAccountBuckets: multiple windows recorded from one usage payload", () => {
+  const usage: ClaudeUsageResult = {
+    quotas: {
+      "session (5h)": makeQuota(100, FUTURE_ISO),
+      "weekly (7d)": makeQuota(85, FUTURE_ISO), // not saturated
+      "weekly designer (7d)": makeQuota(100, FUTURE_ISO),
+    },
+  };
+  updateAccountBuckets("conn-multi", usage, NOW);
+  assert.equal(isBucketSaturated("conn-multi", "5h", NOW), true, "5h saturated");
+  assert.equal(isBucketSaturated("conn-multi", "7d", NOW), false, "7d at 85% not saturated");
+  assert.equal(isBucketSaturated("conn-multi", "7d:designer", NOW), true, "designer 7d saturated");
+});
+
+// ─── recordUsage guards ───────────────────────────────────────────────────────
+
+test("recordUsage: no-op when connectionId is empty", () => {
+  recordUsage("", "5h", 100, FUTURE_ISO, NOW);
+  assert.equal(_bucketCountForTest(), 0);
+});
+
+test("recordUsage: no-op when windowKey is empty", () => {
+  recordUsage("conn-empty-wk", "", 100, FUTURE_ISO, NOW);
+  assert.equal(_bucketCountForTest(), 0);
+});
+
+test("recordUsage: null resetAt → saturated with unknown reset (lazy reset cannot fire)", () => {
+  recordUsage("conn-null-reset", "5h", 100, null, NOW);
+  assert.equal(isBucketSaturated("conn-null-reset", "5h", NOW), true);
+  // Without a known resets_at, the lazy reset has nothing to compare against.
+  assert.equal(
+    isBucketSaturated("conn-null-reset", "5h", NOW + 24 * ONE_HOUR_MS),
+    true,
+    "stays saturated until a fresh non-saturated reading clears it"
+  );
+});


### PR DESCRIPTION
## O que este PR faz

Implementa o **Ponto #3 do hardening de Quota Share** (modelo clewdr/dario): uma camada de **buckets saturáveis por conexão**, rastreando simultaneamente as janelas **5h**, **7d** e **7d por-model** (ex.: `7d:designer`) com **lazy reset** ancorado no `resets_at` de cada janela. Quando um bucket atinge o limite, a conexão fica saturada NAQUELE bucket até `resets_at` passar — então volta a ser auto-elegível, sem cron.

## Arquivos tocados

- **`src/lib/quota/accountBuckets.ts`** (novo, 225 LOC): store em memória de buckets por `(connectionId, windowKey)`.
  - `recordUsage(connectionId, windowKey, usedPct, resetAt, nowMs?)` — marca saturado quando `usedPct >= SATURATION_THRESHOLD_PCT` (100); leituras abaixo do limite limpam o bucket.
  - `isBucketSaturated(connectionId, windowKey, nowMs?)` — **lazy reset**: se `nowMs >= resetsAtMs` o entry é deletado e retorna `false` (elegível de novo, sem sweep de fundo).
  - `updateAccountBuckets(connectionId, usageResult, nowMs?)` — mapeia o shape de `getClaudeUsage()`: `"session (5h)"` → `5h`, `"weekly (7d)"` → `7d`, `"weekly <model> (7d)"` → `7d:<model>`.
  - O relógio é injetável (`nowMs`) — o caminho testado nunca chama `Date.now()` implicitamente.
- **`src/lib/quota/saturationSignals.ts`** (+9 LOC): após resolver o oauth/usage em `fetchAnthropicSaturation`, chama `updateAccountBuckets`. Roda **atrás do cache de 30s** (sem latência no request-path) e é **fail-open** (`try/catch` que engole erros — o sinal primário `0..1` nunca é afetado).
- **`tests/unit/quota-account-buckets.test.ts`** (novo, 222 LOC): 22 casos node:test + assert/strict.

## Lazy reset (sem cron)

`recordUsage` guarda `resetsAtMs` parseado do `resetAt` ISO. Na próxima leitura de `isBucketSaturated`, se `now >= resetsAtMs` o entry é removido e a conexão volta a ser elegível. Sinais já passados do reset (stale) não são gravados.

## Fail-open

- Entrada ausente → `isBucketSaturated` retorna `false`.
- `updateAccountBuckets(null/undefined)` ou `quotas` ausente → no-op.
- Erro dentro de `updateAccountBuckets` no `saturationSignals.ts` → swallowed; sinal de saturação inalterado.

## Ortogonal ao connectionRecovery (#8)

`connectionRecovery.ts` recupera cooldowns de erro-de-request persistidos no DB (`testStatus 'unavailable'` + `rateLimitedUntil`, sweep a cada 60s). Estes buckets rastreiam utilização de janela de plano em memória, com reset por-probe. Concerns complementares — não há duplicação.

## Validação (todos verdes localmente)

- `tests/unit/quota-account-buckets.test.ts` — 22/22 pass
- `npm run typecheck:core` — OK
- `npm run check:known-symbols` — OK
- `npm run check:test-discovery` — OK (coletado pelo glob top-level `tests/unit/*.test.ts`)
- `npm run check:file-size` — OK (novo arquivo 225 LOC < cap 800)
- `npm run check:any-budget:t11` — PASS
- `npm run check:db-rules` — OK