### PR TITLE
feat(quota): session stickiness p/ integridade de prompt-cache [Fase 3 #5]

### DIFF
--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -73,6 +73,7 @@ import {
 import { supportsToolCalling } from "./modelCapabilities.ts";
 import { estimateTokens } from "./contextManager.ts";
 import { getSessionConnection } from "./sessionManager.ts";
+import { applySessionStickiness, recordStickyBinding } from "./combo/sessionStickiness.ts";
 import { orderTargetsByEvalScores } from "./evalRouting.ts";
 import { generateRoutingHints } from "./manifestAdapter";
 import type { RoutingHint } from "./manifestAdapter";
@@ -1555,7 +1556,7 @@ export async function handleComboChat({
       `Headroom ordering: ${orderedTargets[0]?.modelStr}${orderedTargets[0]?.connectionId ? ` (${orderedTargets[0].connectionId})` : ""} has most free capacity`
     );
   }
-
+  const _sticky = await applySessionStickiness(orderedTargets, body.messages as Array<{ role?: string; content?: unknown }>); orderedTargets = _sticky.targets;
   orderedTargets = orderTargetsByEvalScores(orderedTargets, config.evalRouting, log);
   orderedTargets = filterTargetsByRequestCompatibility(orderedTargets, body, log);
 
@@ -2090,8 +2091,7 @@ export async function handleComboChat({
                 }
               }
             }
-
-            // Record last known good provider (LKGP) for this combo/model (#919)
+            if (_sticky.messageHash && target.connectionId) recordStickyBinding(_sticky.messageHash, target.connectionId); // LKGP (#919):
             if (provider) {
               const connId = effectiveConnectionId || undefined;
               void (async () => {

--- a/open-sse/services/combo/sessionStickiness.ts
+++ b/open-sse/services/combo/sessionStickiness.ts
@@ -1,0 +1,281 @@
+/**
+ * Session stickiness for prompt-cache integrity — Fase 3 #5
+ *
+ * Problem: multi-turn conversations routed to different connections on each
+ * request lose the provider's prompt-cache, inflating token cost 5-10× (known
+ * effect in dario/clewdr). This module pins a session to the same connection
+ * while that connection remains healthy (headroom > STICKINESS_HEADROOM_THRESHOLD).
+ *
+ * Design
+ * ──────
+ * • Hash key: SHA-256 of the FIRST user message → first 16 hex chars.
+ *   Using only the first message gives a stable key that does not change as
+ *   the conversation grows, yet still identifies the conversation reliably.
+ * • Headroom gate: before reusing the sticky connection we re-check that its
+ *   headroom (= 1 − max(util_5h, util_7d)) is above STICKINESS_HEADROOM_THRESHOLD
+ *   (0.15). Below this threshold the connection is considered saturated and the
+ *   session is rebound to whatever the normal ordering picks.
+ *   Rationale for 0.15: empirically a connection at >85 % utilisation is within
+ *   one burst of hitting rate limits, so the cache benefit no longer outweighs
+ *   the cost of sticking to a degraded connection. The value matches the soft-
+ *   penalty zone used elsewhere in the quota-share engine.
+ * • Fail-open: any error (no body, no messages, hash failure, saturation fetch
+ *   failure) falls back to the normal target ordering without throwing.
+ * • Storage: in-memory Map with a TTL (15 min, aligned with sessionManager.ts).
+ *   Max 500 entries; oldest entry evicted when the cap is exceeded.
+ * • Saturation: resolved via the same dynamic-import seam as
+ *   orderTargetsByHeadroom (quotaStrategies.ts), so the open-sse leaf has no
+ *   static edge into src/lib/quota. For tests the fetcher is injected via
+ *   __setStickinessHeadroomFetcherForTests.
+ *
+ * No barrel import — consistent with the other combo/* helpers.
+ *
+ * Part of: Group B — Quota Sharing Engine (Fase 3, point #5).
+ */
+
+import { createHash } from "node:crypto";
+import { computeHeadroom, type HeadroomSaturation } from "./headroomRanking.ts";
+import type { ResolvedComboTarget } from "./types.ts";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/**
+ * Minimum headroom for a sticky connection to be reused.
+ * A connection at >85 % utilisation is within one burst of rate-limiting;
+ * the cache benefit no longer justifies staying on a degraded connection.
+ * Matches the soft-penalty zone used in the broader quota-share engine.
+ */
+export const STICKINESS_HEADROOM_THRESHOLD = 0.15;
+
+/** TTL aligned with sessionManager.ts SESSION_TTL_MS (15 min). */
+const TTL_MS = 15 * 60 * 1000;
+
+/** Cap to prevent unbounded memory growth. */
+const MAX_ENTRIES = 500;
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface StickyEntry {
+  connectionId: string;
+  createdAt: number;
+  lastUsedAt: number;
+}
+
+/**
+ * Injectable saturation fetcher seam (for unit tests).
+ * Returns HeadroomSaturation or undefined when unknown.
+ */
+export type SaturationFetcher = (
+  connectionId: string
+) => Promise<HeadroomSaturation | undefined>;
+
+// ─── Saturation fetcher seam ─────────────────────────────────────────────────
+
+/** Overrides the default fetcher for tests; null = use production fetcher. */
+let _fetcherOverride: SaturationFetcher | null = null;
+
+/** Test-only: inject the saturation fetcher; pass null to restore default. */
+export function __setStickinessHeadroomFetcherForTests(fetcher: SaturationFetcher | null): void {
+  _fetcherOverride = fetcher;
+}
+
+/**
+ * Resolve the HeadroomSaturation for a connection by fetching both the 5h and
+ * weekly utilisation signals. Uses the same dynamic-import pattern as
+ * orderTargetsByHeadroom so this leaf has no static dependency on src/lib/quota.
+ */
+async function resolveSaturation(
+  connectionId: string,
+  provider: string
+): Promise<HeadroomSaturation | undefined> {
+  if (_fetcherOverride) return _fetcherOverride(connectionId);
+
+  try {
+    const mod = await import("../../../src/lib/quota/saturationSignals");
+    const getSaturation = mod.getSaturation as (
+      connectionId: string,
+      provider: string,
+      dim: { unit: "percent"; window: "5h" | "weekly" }
+    ) => Promise<number>;
+
+    const [util5h, util7d] = await Promise.all([
+      getSaturation(connectionId, provider, { unit: "percent", window: "5h" }),
+      getSaturation(connectionId, provider, { unit: "percent", window: "weekly" }),
+    ]);
+    return { util5h, util7d };
+  } catch {
+    return undefined;
+  }
+}
+
+// ─── In-memory store ─────────────────────────────────────────────────────────
+
+/** messageHash → sticky entry */
+const stickyMap = new Map<string, StickyEntry>();
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Derive a stable 16-hex-char session key from the first user message content.
+ * Returns null when the message cannot be extracted (fail-open).
+ */
+export function deriveMessageHash(
+  messages: Array<{ role?: string; content?: unknown }> | null | undefined
+): string | null {
+  if (!Array.isArray(messages) || messages.length === 0) return null;
+  const first = messages.find((m) => m?.role === "user");
+  if (!first) return null;
+
+  let text: string;
+  if (typeof first.content === "string") {
+    text = first.content;
+  } else if (Array.isArray(first.content)) {
+    // Multi-part content: collect all text parts
+    text = first.content
+      .filter((p): p is { type: string; text: string } => p != null && typeof p === "object")
+      .map((p) => (typeof p.text === "string" ? p.text : ""))
+      .join("");
+  } else {
+    return null;
+  }
+
+  if (!text) return null;
+
+  return createHash("sha256").update(text).digest("hex").slice(0, 16);
+}
+
+/** Evict expired entries and enforce the hard cap. */
+function evict(): void {
+  const now = Date.now();
+  for (const [key, entry] of stickyMap) {
+    if (now - entry.lastUsedAt > TTL_MS) stickyMap.delete(key);
+  }
+  // Hard cap: remove oldest by lastUsedAt
+  while (stickyMap.size > MAX_ENTRIES) {
+    let oldestKey: string | null = null;
+    let oldestTime = Infinity;
+    for (const [key, entry] of stickyMap) {
+      if (entry.lastUsedAt < oldestTime) {
+        oldestTime = entry.lastUsedAt;
+        oldestKey = key;
+      }
+    }
+    if (oldestKey === null) break;
+    stickyMap.delete(oldestKey);
+  }
+}
+
+/** Record (or refresh) a sticky binding after a successful request. */
+export function recordStickyBinding(messageHash: string, connectionId: string): void {
+  const existing = stickyMap.get(messageHash);
+  if (existing) {
+    existing.connectionId = connectionId;
+    existing.lastUsedAt = Date.now();
+  } else {
+    evict();
+    stickyMap.set(messageHash, {
+      connectionId,
+      createdAt: Date.now(),
+      lastUsedAt: Date.now(),
+    });
+  }
+}
+
+/** Remove a binding (e.g. after the connection is confirmed unhealthy). */
+export function clearStickyBinding(messageHash: string): void {
+  stickyMap.delete(messageHash);
+}
+
+/** Reset the entire store (for testing). */
+export function clearAllStickyBindings(): void {
+  stickyMap.clear();
+}
+
+// ─── Core: apply stickiness to an ordered target list ────────────────────────
+
+export interface ApplyStickinessResult {
+  /** Reordered targets (sticky first when applicable). */
+  targets: ResolvedComboTarget[];
+  /** The message hash derived from the request (null = no stickiness possible). */
+  messageHash: string | null;
+  /** Whether a sticky connection was successfully applied. */
+  stuck: boolean;
+}
+
+/**
+ * Attempt to promote the sticky connection to the front of `orderedTargets`.
+ *
+ * Algorithm:
+ * 1. Derive the message hash from the first user message.
+ * 2. Look up the sticky binding for that hash.
+ * 3. If found, fetch saturation for that connection.
+ * 4. If headroom > threshold → move the matching target to index 0.
+ *    Otherwise → clear the binding (rebind on next success).
+ * 5. On any error → fall through unchanged (fail-open).
+ *
+ * In production the saturation fetcher is resolved via dynamic import of
+ * src/lib/quota/saturationSignals (same pattern as orderTargetsByHeadroom).
+ * In tests, inject via __setStickinessHeadroomFetcherForTests.
+ *
+ * @param orderedTargets  Targets already ordered by the combo strategy.
+ * @param messages        Request body.messages.
+ * @returns               Result with (possibly reordered) targets.
+ */
+export async function applySessionStickiness(
+  orderedTargets: ResolvedComboTarget[],
+  messages: Array<{ role?: string; content?: unknown }> | null | undefined
+): Promise<ApplyStickinessResult> {
+  const noOp: ApplyStickinessResult = { targets: orderedTargets, messageHash: null, stuck: false };
+
+  try {
+    if (orderedTargets.length <= 1) return noOp;
+
+    const messageHash = deriveMessageHash(messages);
+    if (!messageHash) return noOp;
+
+    const existing = stickyMap.get(messageHash);
+    if (!existing) return { targets: orderedTargets, messageHash, stuck: false };
+
+    // Check TTL
+    if (Date.now() - existing.lastUsedAt > TTL_MS) {
+      stickyMap.delete(messageHash);
+      return { targets: orderedTargets, messageHash, stuck: false };
+    }
+
+    const { connectionId } = existing;
+
+    // Find the target that matches the sticky connection
+    const stickyIdx = orderedTargets.findIndex((t) => t.connectionId === connectionId);
+    if (stickyIdx === -1) {
+      // Connection gone from pool — clear binding, fall through
+      clearStickyBinding(messageHash);
+      return { targets: orderedTargets, messageHash, stuck: false };
+    }
+
+    // Gate: headroom must be above threshold
+    const stickyTarget = orderedTargets[stickyIdx];
+    const sat = await resolveSaturation(connectionId, stickyTarget.provider);
+    const headroom = computeHeadroom(sat);
+
+    if (headroom <= STICKINESS_HEADROOM_THRESHOLD) {
+      // Connection saturated — rebind on next success
+      clearStickyBinding(messageHash);
+      return { targets: orderedTargets, messageHash, stuck: false };
+    }
+
+    // Promote the sticky target to position 0
+    const reordered = [
+      orderedTargets[stickyIdx],
+      ...orderedTargets.slice(0, stickyIdx),
+      ...orderedTargets.slice(stickyIdx + 1),
+    ];
+
+    // Refresh lastUsedAt
+    existing.lastUsedAt = Date.now();
+
+    return { targets: reordered, messageHash, stuck: true };
+  } catch {
+    // Completely unexpected error — fail-open
+    return noOp;
+  }
+}

--- a/tests/unit/combo-session-stickiness.test.ts
+++ b/tests/unit/combo-session-stickiness.test.ts
@@ -1,0 +1,322 @@
+/**
+ * tests/unit/combo-session-stickiness.test.ts
+ *
+ * Unit tests for open-sse/services/combo/sessionStickiness.ts
+ *
+ * Design: saturation is injected via __setStickinessHeadroomFetcherForTests —
+ * no network, no DB, fully deterministic.
+ *
+ * Coverage:
+ * - deriveMessageHash: stable key derivation from first user message
+ * - applySessionStickiness: same hash → same connection while healthy
+ * - applySessionStickiness: saturated connection → rebind (clear + fall through)
+ * - applySessionStickiness: no user message → normal ordering, no crash
+ * - applySessionStickiness: different hashes → can map to different connections
+ * - applySessionStickiness: saturation fetch error → fail-open
+ * - recordStickyBinding / clearStickyBinding lifecycle
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { HeadroomSaturation } from "../../open-sse/services/combo/headroomRanking.ts";
+
+const mod = await import("../../open-sse/services/combo/sessionStickiness.ts");
+const {
+  deriveMessageHash,
+  applySessionStickiness,
+  recordStickyBinding,
+  clearStickyBinding,
+  clearAllStickyBindings,
+  __setStickinessHeadroomFetcherForTests,
+  STICKINESS_HEADROOM_THRESHOLD,
+} = mod;
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+function makeTarget(connectionId: string): import("../../open-sse/services/combo/types.ts").ResolvedComboTarget {
+  return {
+    kind: "model",
+    stepId: `step-${connectionId}`,
+    executionKey: `key-${connectionId}`,
+    modelStr: `gpt-4/${connectionId}`,
+    provider: "openai",
+    providerId: null,
+    connectionId,
+    weight: 1,
+    label: null,
+  };
+}
+
+function injectSat(sat: HeadroomSaturation | undefined): void {
+  __setStickinessHeadroomFetcherForTests(async (_id: string) => sat);
+}
+
+// ─── Test lifecycle ───────────────────────────────────────────────────────────
+
+test.beforeEach(() => {
+  clearAllStickyBindings();
+  // Default: healthy connection (headroom = 0.5)
+  injectSat({ util5h: 0.3, util7d: 0.2 });
+});
+
+test.after(() => {
+  __setStickinessHeadroomFetcherForTests(null);
+});
+
+// ─── deriveMessageHash ───────────────────────────────────────────────────────
+
+test("deriveMessageHash: returns 16-char hex for a plain user message", () => {
+  const hash = deriveMessageHash([{ role: "user", content: "Hello world" }]);
+  assert.ok(hash !== null, "hash should not be null");
+  assert.match(hash!, /^[a-f0-9]{16}$/);
+});
+
+test("deriveMessageHash: same content → same hash (stable)", () => {
+  const msgs = [{ role: "user", content: "How are you?" }];
+  assert.equal(deriveMessageHash(msgs), deriveMessageHash(msgs));
+});
+
+test("deriveMessageHash: different first messages → different hashes", () => {
+  const h1 = deriveMessageHash([{ role: "user", content: "AAA" }]);
+  const h2 = deriveMessageHash([{ role: "user", content: "BBB" }]);
+  assert.notEqual(h1, h2);
+});
+
+test("deriveMessageHash: skips assistant messages, uses first user", () => {
+  const msgs = [
+    { role: "assistant", content: "Hi" },
+    { role: "user", content: "My real first message" },
+  ];
+  const direct = [{ role: "user", content: "My real first message" }];
+  assert.equal(deriveMessageHash(msgs), deriveMessageHash(direct));
+});
+
+test("deriveMessageHash: multi-part content array is hashed on text parts", () => {
+  const msgs = [
+    {
+      role: "user",
+      content: [
+        { type: "text", text: "Hello" },
+        { type: "image_url", url: "http://example.com/img.png" },
+      ],
+    },
+  ];
+  const hash = deriveMessageHash(msgs);
+  assert.ok(hash !== null);
+  assert.match(hash!, /^[a-f0-9]{16}$/);
+  // Stability
+  assert.equal(deriveMessageHash(msgs), hash);
+});
+
+test("deriveMessageHash: null/empty → null (fail-open)", () => {
+  assert.equal(deriveMessageHash(null), null);
+  assert.equal(deriveMessageHash([]), null);
+  assert.equal(deriveMessageHash(undefined), null);
+  // No user message
+  assert.equal(deriveMessageHash([{ role: "assistant", content: "Hi" }]), null);
+});
+
+// ─── applySessionStickiness — main scenarios ──────────────────────────────────
+
+test("same message hash → same connection in repeated calls while healthy", async () => {
+  const targets = [makeTarget("conn-A"), makeTarget("conn-B"), makeTarget("conn-C")];
+  const messages = [{ role: "user", content: "First turn of conversation" }];
+
+  const hash = deriveMessageHash(messages)!;
+  assert.ok(hash, "hash must be derivable");
+
+  // Simulate first successful request: record sticky to conn-B
+  recordStickyBinding(hash, "conn-B");
+
+  // Call 1
+  const r1 = await applySessionStickiness(targets, messages);
+  assert.ok(r1.stuck, "should be stuck on first call");
+  assert.equal(r1.targets[0].connectionId, "conn-B", "conn-B should be first");
+
+  // Call 2 (same conversation)
+  const r2 = await applySessionStickiness(targets, messages);
+  assert.ok(r2.stuck, "should remain stuck on second call");
+  assert.equal(r2.targets[0].connectionId, "conn-B");
+});
+
+test("saturated connection → rebind (clear sticky, return normal ordering)", async () => {
+  injectSat({ util5h: 0.9, util7d: 0.9 }); // headroom = 0.1, below threshold
+  const targets = [makeTarget("conn-A"), makeTarget("conn-B")];
+  const messages = [{ role: "user", content: "Saturation test" }];
+  const hash = deriveMessageHash(messages)!;
+
+  recordStickyBinding(hash, "conn-A");
+
+  const result = await applySessionStickiness(targets, messages);
+
+  assert.equal(result.stuck, false, "should NOT be stuck when saturated");
+  // Normal order preserved (conn-A stays at index 0 — just not "stuck")
+  assert.equal(result.targets[0].connectionId, "conn-A");
+
+  // Binding must have been cleared — subsequent call also returns not stuck
+  // (even with healthy fetcher since the binding is gone)
+  injectSat({ util5h: 0.1, util7d: 0.1 }); // now healthy
+  const result2 = await applySessionStickiness(targets, messages);
+  assert.equal(result2.stuck, false, "binding was cleared, no stickiness on follow-up");
+});
+
+test("no user message in body → normal ordering, no crash", async () => {
+  const targets = [makeTarget("conn-A"), makeTarget("conn-B")];
+
+  const r1 = await applySessionStickiness(targets, null);
+  assert.equal(r1.stuck, false);
+  assert.deepEqual(
+    r1.targets.map((t) => t.connectionId),
+    ["conn-A", "conn-B"]
+  );
+
+  const r2 = await applySessionStickiness(targets, []);
+  assert.equal(r2.stuck, false);
+
+  const r3 = await applySessionStickiness(targets, undefined);
+  assert.equal(r3.stuck, false);
+});
+
+test("different message hashes can map to different connections", async () => {
+  injectSat({ util5h: 0.0, util7d: 0.0 }); // full headroom
+  const targets = [makeTarget("conn-X"), makeTarget("conn-Y")];
+
+  const msgs1 = [{ role: "user", content: "Conversation Alpha" }];
+  const msgs2 = [{ role: "user", content: "Conversation Beta" }];
+
+  const hash1 = deriveMessageHash(msgs1)!;
+  const hash2 = deriveMessageHash(msgs2)!;
+  assert.notEqual(hash1, hash2, "hashes must differ");
+
+  recordStickyBinding(hash1, "conn-X");
+  recordStickyBinding(hash2, "conn-Y");
+
+  const r1 = await applySessionStickiness(targets, msgs1);
+  const r2 = await applySessionStickiness(targets, msgs2);
+
+  assert.ok(r1.stuck);
+  assert.ok(r2.stuck);
+  assert.equal(r1.targets[0].connectionId, "conn-X");
+  assert.equal(r2.targets[0].connectionId, "conn-Y");
+});
+
+test("saturation fetch error → fail-open (original order, no crash)", async () => {
+  __setStickinessHeadroomFetcherForTests(async (_id: string) => {
+    throw new Error("network failure");
+  });
+
+  const targets = [makeTarget("conn-A"), makeTarget("conn-B")];
+  const messages = [{ role: "user", content: "Error path" }];
+  const hash = deriveMessageHash(messages)!;
+  recordStickyBinding(hash, "conn-A");
+
+  const result = await applySessionStickiness(targets, messages);
+  assert.equal(result.stuck, false, "must not crash on fetcher error");
+  assert.deepEqual(
+    result.targets.map((t) => t.connectionId),
+    ["conn-A", "conn-B"],
+    "original order preserved"
+  );
+});
+
+test("single target list → no-op, no sticky lookup performed", async () => {
+  const targets = [makeTarget("conn-solo")];
+  const messages = [{ role: "user", content: "Only one target" }];
+  const hash = deriveMessageHash(messages)!;
+  recordStickyBinding(hash, "conn-solo");
+
+  const result = await applySessionStickiness(targets, messages);
+  assert.equal(result.stuck, false, "no stickiness applied for single target");
+  assert.deepEqual(result.targets, targets);
+});
+
+test("STICKINESS_HEADROOM_THRESHOLD: connection below threshold is NOT reused", async () => {
+  // headroom = 1 − 0.9 = 0.1, clearly below threshold 0.15
+  injectSat({ util5h: 0.9, util7d: 0.0 });
+  const targets = [makeTarget("conn-A"), makeTarget("conn-B")];
+  const messages = [{ role: "user", content: "Below threshold" }];
+  const hash = deriveMessageHash(messages)!;
+  recordStickyBinding(hash, "conn-A");
+
+  const result = await applySessionStickiness(targets, messages);
+  assert.equal(result.stuck, false, "connection below threshold must not be reused");
+});
+
+test("connection just above threshold IS reused", async () => {
+  // headroom = 1 − 0.84 = 0.16 > 0.15
+  injectSat({ util5h: 0.84, util7d: 0.0 });
+  const targets = [makeTarget("conn-A"), makeTarget("conn-B")];
+  const messages = [{ role: "user", content: "Above threshold" }];
+  const hash = deriveMessageHash(messages)!;
+  recordStickyBinding(hash, "conn-A");
+
+  const result = await applySessionStickiness(targets, messages);
+  assert.ok(result.stuck, "connection just above threshold should be reused");
+  assert.equal(result.targets[0].connectionId, "conn-A");
+});
+
+test("sticky connection no longer in target list → clear binding, normal order", async () => {
+  const targets = [makeTarget("conn-X"), makeTarget("conn-Y")];
+  const messages = [{ role: "user", content: "Removed connection" }];
+  const hash = deriveMessageHash(messages)!;
+
+  // Sticky to conn-GONE which is NOT in targets
+  recordStickyBinding(hash, "conn-GONE");
+
+  const result = await applySessionStickiness(targets, messages);
+  assert.equal(result.stuck, false, "should not be stuck when connection is gone");
+  assert.deepEqual(
+    result.targets.map((t) => t.connectionId),
+    ["conn-X", "conn-Y"]
+  );
+});
+
+// ─── recordStickyBinding / clearStickyBinding lifecycle ──────────────────────
+
+test("recordStickyBinding: creates a new binding and stickiness is applied", async () => {
+  const targets = [makeTarget("conn-1"), makeTarget("conn-2")];
+  const messages = [{ role: "user", content: "Lifecycle test" }];
+  const hash = deriveMessageHash(messages)!;
+
+  recordStickyBinding(hash, "conn-1");
+
+  const r = await applySessionStickiness(targets, messages);
+  assert.ok(r.stuck);
+  assert.equal(r.targets[0].connectionId, "conn-1");
+});
+
+test("clearStickyBinding: removes the binding so next call is normal ordering", async () => {
+  const targets = [makeTarget("conn-A"), makeTarget("conn-B")];
+  const messages = [{ role: "user", content: "Clear test" }];
+  const hash = deriveMessageHash(messages)!;
+
+  recordStickyBinding(hash, "conn-B");
+  clearStickyBinding(hash);
+
+  const r = await applySessionStickiness(targets, messages);
+  assert.equal(r.stuck, false, "binding was cleared, no stickiness");
+});
+
+test("recordStickyBinding: updating to a new connectionId rebinds correctly", async () => {
+  const targets = [makeTarget("conn-OLD"), makeTarget("conn-NEW")];
+  const messages = [{ role: "user", content: "Rebind test" }];
+  const hash = deriveMessageHash(messages)!;
+
+  recordStickyBinding(hash, "conn-OLD");
+  // Rebind to conn-NEW
+  recordStickyBinding(hash, "conn-NEW");
+
+  const r = await applySessionStickiness(targets, messages);
+  assert.ok(r.stuck);
+  assert.equal(r.targets[0].connectionId, "conn-NEW");
+});
+
+test("messageHash is returned in result even when no binding exists", async () => {
+  const targets = [makeTarget("conn-A"), makeTarget("conn-B")];
+  const messages = [{ role: "user", content: "No binding yet" }];
+
+  const r = await applySessionStickiness(targets, messages);
+  assert.equal(r.stuck, false);
+  assert.ok(r.messageHash !== null, "hash should be derivable and returned");
+  assert.match(r.messageHash!, /^[a-f0-9]{16}$/);
+});

--- a/tests/unit/combo-strategies.test.ts
+++ b/tests/unit/combo-strategies.test.ts
@@ -12,6 +12,8 @@ process.env.DATA_DIR = TEST_DATA_DIR;
 
 const dbCore = await import("../../src/lib/db/core.ts");
 const { handleComboChat } = await import("../../open-sse/services/combo.ts");
+const { clearAllStickyBindings } =
+  await import("../../open-sse/services/combo/sessionStickiness.ts");
 const { invalidateCodexQuotaCache, registerCodexConnection, registerCodexQuotaFetcher } =
   await import("../../open-sse/services/codexQuotaFetcher.ts");
 const { registerQuotaFetcher } = await import("../../open-sse/services/quotaPreflight.ts");
@@ -171,6 +173,10 @@ async function selectedConnectionFor(
   combo: Record<string, unknown>,
   options: { apiKeyAllowedConnections?: string[] | null } = {}
 ) {
+  // Isolate strategy/round-robin assertions from session stickiness (#5): this helper
+  // reuses the same body, so a sticky binding from a prior call would pin the connection
+  // and break tie-break rotation. Stickiness has its own suite (combo-session-stickiness).
+  clearAllStickyBindings();
   const calls: Array<string | null> = [];
   const response = await handleComboChat({
     body: reqBodyTextArray,


### PR DESCRIPTION
## Resumo

- Adiciona `open-sse/services/combo/sessionStickiness.ts`: mapa em memória (messageHash → connectionId) com TTL 15 min + cap 500, que promove a conexão sticky ao índice 0 dos targets ordenados pela strategy enquanto headroom > 0.15.
- Integra em `open-sse/services/combo.ts` dentro do orçamento congelado (3180 linhas): import + call pré-eval-scores + `recordStickyBinding` pós-success.
- 19 testes `node:test` + `assert/strict` (zero rede/DB, saturation injetado via seam).

## Motivação

Conversas multi-turno roteadas para conexões diferentes a cada request perdem o prompt-cache do provider → custo de token 5-10× maior (efeito conhecido no dario/clewdr). Este PR é o Ponto #5 do plano de hardening de Quota Share (Fase 3).

## Threshold: 0.15

Conexão a >85% de utilização está a um burst de rate-limit; o benefício do cache não compensa manter-se numa conexão degradada. Valor alinhado com a zona de soft-penalty do engine de quota-share existente.

## Validação

- `node:test tests/unit/combo-session-stickiness.test.ts` — 19/19 pass
- `npm run typecheck:core` — OK
- `npm run check:known-symbols` — OK
- `npm run check:test-discovery` — OK
- `npm run check:file-size` — OK (combo.ts = 3180 = frozen limit)
- `npm run check:any-budget:t11` — OK