### PR TITLE
refactor(api): extrai validators search + embedding/rerank de validation.ts (fatia 5)

### DIFF
--- a/src/lib/providers/validation.ts
+++ b/src/lib/providers/validation.ts
@@ -46,10 +46,8 @@ import {
 import {
   STANDARD_USER_AGENT,
   applyCustomUserAgent,
-  withCustomUserAgent,
   directHttpsRequest,
   buildBearerHeaders,
-  buildClarifaiHeaders,
 } from "./validation/headers";
 import {
   validationRead,
@@ -102,6 +100,15 @@ import {
   validateNousResearchProvider,
   validatePoeProvider,
 } from "./validation/audioMiscProviders";
+import {
+  validateSearchProvider,
+  SEARCH_VALIDATOR_CONFIGS,
+} from "./validation/searchProviders";
+import {
+  validateClarifaiProvider,
+  validateEmbeddingApiProvider,
+  validateRerankApiProvider,
+} from "./validation/embeddingProviders";
 
 // isRetryableProxyTarget + isSecurityBlockError now live in ./validation/transport. Re-export them
 // here to preserve the historical public surface (tests + route handlers import them via this module).
@@ -305,143 +312,6 @@ export async function validateCommandCodeProvider({ apiKey, providerSpecificData
       },
     },
   });
-}
-
-async function validateClarifaiProvider({ apiKey, providerSpecificData = {} }: any) {
-  const baseUrl =
-    normalizeBaseUrl(providerSpecificData.baseUrl) || "https://api.clarifai.com/v2/ext/openai/v1";
-  const modelsUrl = addModelsSuffix(baseUrl);
-
-  try {
-    const modelsRes = await validationRead(modelsUrl, {
-      method: "GET",
-      headers: buildClarifaiHeaders(apiKey, providerSpecificData),
-    });
-
-    if (modelsRes.ok) {
-      return { valid: true, error: null, method: "clarifai_models" };
-    }
-
-    if (modelsRes.status === 401 || modelsRes.status === 403) {
-      return { valid: false, error: "Invalid API key" };
-    }
-
-    const chatUrl = resolveChatUrl("clarifai", baseUrl, providerSpecificData);
-    const chatRes = await validationWrite(chatUrl, {
-      method: "POST",
-      headers: buildClarifaiHeaders(apiKey, providerSpecificData),
-      body: JSON.stringify({
-        model:
-          providerSpecificData?.validationModelId || "openai/chat-completion/models/gpt-oss-120b",
-        messages: [{ role: "user", content: "test" }],
-        max_tokens: 1,
-      }),
-    });
-
-    if (chatRes.ok || chatRes.status === 400 || chatRes.status === 422 || chatRes.status === 429) {
-      return { valid: true, error: null, method: "clarifai_chat_probe" };
-    }
-
-    if (chatRes.status === 401 || chatRes.status === 403) {
-      return { valid: false, error: "Invalid API key" };
-    }
-
-    if (chatRes.status === 404 || chatRes.status === 405) {
-      return { valid: false, error: "Provider validation endpoint not supported" };
-    }
-
-    if (chatRes.status >= 500) {
-      return { valid: false, error: `Provider unavailable (${chatRes.status})` };
-    }
-
-    return { valid: true, error: null, method: "clarifai_chat_probe" };
-  } catch (error: any) {
-    return toValidationErrorResult(error);
-  }
-}
-
-async function validateEmbeddingApiProvider({
-  apiKey,
-  providerSpecificData = {},
-  url,
-  modelId,
-}: any) {
-  if (!url) {
-    return { valid: false, error: "Missing embedding endpoint" };
-  }
-
-  try {
-    const response = await validationWrite(url, {
-      method: "POST",
-      headers: buildBearerHeaders(apiKey, providerSpecificData),
-      body: JSON.stringify({
-        model: providerSpecificData?.validationModelId || modelId,
-        input: ["test"],
-      }),
-    });
-
-    if (response.status === 401 || response.status === 403) {
-      return { valid: false, error: "Invalid API key" };
-    }
-
-    if (
-      response.ok ||
-      response.status === 400 ||
-      response.status === 422 ||
-      response.status === 429
-    ) {
-      return { valid: true, error: null };
-    }
-
-    if (response.status >= 500) {
-      return { valid: false, error: `Provider unavailable (${response.status})` };
-    }
-
-    return { valid: false, error: `Validation failed: ${response.status}` };
-  } catch (error: any) {
-    return toValidationErrorResult(error);
-  }
-}
-
-async function validateRerankApiProvider({ apiKey, providerSpecificData = {}, url, modelId }: any) {
-  if (!url) {
-    return { valid: false, error: "Missing rerank endpoint" };
-  }
-
-  try {
-    const response = await validationWrite(url, {
-      method: "POST",
-      headers: buildBearerHeaders(apiKey, providerSpecificData),
-      body: JSON.stringify({
-        model: providerSpecificData?.validationModelId || modelId,
-        query: "test",
-        documents: ["test"],
-        top_n: 1,
-        return_documents: false,
-      }),
-    });
-
-    if (response.status === 401 || response.status === 403) {
-      return { valid: false, error: "Invalid API key" };
-    }
-
-    if (
-      response.ok ||
-      response.status === 400 ||
-      response.status === 422 ||
-      response.status === 429
-    ) {
-      return { valid: true, error: null };
-    }
-
-    if (response.status >= 500) {
-      return { valid: false, error: `Provider unavailable (${response.status})` };
-    }
-
-    return { valid: false, error: `Validation failed: ${response.status}` };
-  } catch (error: any) {
-    return toValidationErrorResult(error);
-  }
 }
 
 async function validateAnthropicLikeProvider({
@@ -981,212 +851,6 @@ export async function validateClaudeCodeCompatibleProvider({
   }
 }
 
-// ── Search provider validators (factored) ──
-
-async function validateGenericProvider(
-  baseUrl: string,
-  apiKey: string,
-  providerSpecificData: any = {},
-  provider: string,
-  isLocal: boolean = false
-) {
-  const config = SEARCH_VALIDATOR_CONFIGS[provider];
-  if (!config) {
-    return { valid: false, error: "Validator not found", unsupported: true };
-  }
-  const { url, init } = config(apiKey, providerSpecificData);
-  return validateSearchProvider(url, init, providerSpecificData, isLocal);
-}
-
-async function validateSearchProvider(
-  url: string,
-  init: RequestInit,
-  providerSpecificData: any = {},
-  isLocal: boolean = false
-): Promise<{ valid: boolean; error: string | null; unsupported: false }> {
-  try {
-    const response = await safeOutboundFetch(url, {
-      ...SAFE_OUTBOUND_FETCH_PRESETS.validationWrite,
-      guard: isLocal ? "none" : getProviderOutboundGuard(),
-      ...withCustomUserAgent(init, providerSpecificData),
-    });
-    if (response.ok) return { valid: true, error: null, unsupported: false };
-    if (response.status === 401 || response.status === 403) {
-      return { valid: false, error: "Invalid API key", unsupported: false };
-    }
-    // For provider setup we only need to confirm authentication passed.
-    // Search providers may return non-auth statuses for exhausted credits,
-    // rate limiting, or request-shape quirks while still accepting the key.
-    if (response.status < 500) {
-      return { valid: true, error: null, unsupported: false };
-    }
-    return { valid: false, error: `Validation failed: ${response.status}`, unsupported: false };
-  } catch (error: any) {
-    return toValidationErrorResult(error);
-  }
-}
-
-const SEARCH_VALIDATOR_CONFIGS: Record<
-  string,
-  (apiKey: string, providerSpecificData?: any) => { url: string; init: RequestInit }
-> = {
-  "serper-search": (apiKey) => ({
-    url: "https://google.serper.dev/search",
-    init: {
-      method: "POST",
-      headers: { "Content-Type": "application/json", "X-API-Key": apiKey },
-      body: JSON.stringify({ q: "test", num: 1 }),
-    },
-  }),
-  "brave-search": (apiKey) => ({
-    url: "https://api.search.brave.com/res/v1/web/search?q=test&count=1",
-    init: {
-      method: "GET",
-      headers: { Accept: "application/json", "X-Subscription-Token": apiKey },
-    },
-  }),
-  "perplexity-search": (apiKey) => ({
-    url: "https://api.perplexity.ai/search",
-    init: {
-      method: "POST",
-      headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
-      body: JSON.stringify({ query: "test", max_results: 1 }),
-    },
-  }),
-  "exa-search": (apiKey) => ({
-    url: "https://api.exa.ai/search",
-    init: {
-      method: "POST",
-      headers: { "Content-Type": "application/json", "x-api-key": apiKey },
-      body: JSON.stringify({ query: "test", numResults: 1 }),
-    },
-  }),
-  "tavily-search": (apiKey) => ({
-    url: "https://api.tavily.com/search",
-    init: {
-      method: "POST",
-      headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
-      body: JSON.stringify({ query: "test", max_results: 1 }),
-    },
-  }),
-  "google-pse-search": (apiKey, providerSpecificData = {}) => {
-    const cx = providerSpecificData?.cx;
-    if (!cx || typeof cx !== "string") {
-      throw new Error("Programmable Search Engine ID (cx) is required");
-    }
-    return {
-      url: `https://www.googleapis.com/customsearch/v1?key=${encodeURIComponent(apiKey)}&cx=${encodeURIComponent(
-        cx
-      )}&q=test&num=1`,
-      init: {
-        method: "GET",
-        headers: { Accept: "application/json" },
-      },
-    };
-  },
-  "linkup-search": (apiKey) => ({
-    url: "https://api.linkup.so/v1/search",
-    init: {
-      method: "POST",
-      headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
-      body: JSON.stringify({
-        q: "test",
-        depth: "standard",
-        outputType: "searchResults",
-        maxResults: 1,
-      }),
-    },
-  }),
-  "searchapi-search": (apiKey) => ({
-    url: `https://www.searchapi.io/api/v1/search?engine=google&q=test&api_key=${encodeURIComponent(
-      apiKey
-    )}`,
-    init: {
-      method: "GET",
-      headers: { Accept: "application/json" },
-    },
-  }),
-  "youcom-search": (apiKey) => ({
-    url: "https://ydc-index.io/v1/search?query=test&count=1",
-    init: {
-      method: "GET",
-      headers: { Accept: "application/json", "X-API-Key": apiKey },
-    },
-  }),
-  "searxng-search": (apiKey, providerSpecificData = {}) => {
-    const baseUrl =
-      typeof providerSpecificData?.baseUrl === "string" && providerSpecificData.baseUrl.trim()
-        ? providerSpecificData.baseUrl.trim().replace(/\/+$/, "")
-        : "http://localhost:8888/search";
-    const searchUrl = baseUrl.endsWith("/search") ? baseUrl : `${baseUrl}/search`;
-    const headers: Record<string, string> = { Accept: "application/json" };
-    if (apiKey) {
-      headers["Authorization"] = `Bearer ${apiKey}`;
-    }
-    return {
-      url: `${searchUrl}?q=test&format=json`,
-      init: {
-        method: "GET",
-        headers,
-      },
-    };
-  },
-  "ollama-search": (apiKey) => ({
-    url: "https://ollama.com/api/web_search",
-    init: {
-      method: "POST",
-      headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
-      body: JSON.stringify({ query: "test", max_results: 1 }),
-    },
-  }),
-  "zai-search": (apiKey, providerSpecificData = {}) => {
-    const baseUrl =
-      typeof providerSpecificData?.baseUrl === "string" && providerSpecificData.baseUrl.trim()
-        ? providerSpecificData.baseUrl.trim().replace(/\/+$/, "")
-        : "https://api.z.ai/api/mcp/web_search_prime/mcp";
-    return {
-      url: baseUrl,
-      init: {
-        method: "POST",
-        headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
-        body: JSON.stringify({
-          jsonrpc: "2.0",
-          method: "tools/call",
-          params: { name: "web_search_prime", arguments: { search_query: "test" } },
-          id: 1,
-        }),
-      },
-    };
-  },
-  // ── Web-fetch providers (#4401) ──
-  // firecrawl / jina-reader were added as webFetch-kind providers in #2645 with their
-  // own executors but no validator, so the dashboard "Validate" step returned
-  // "Provider validation not supported" and accounts could not be added through the UI.
-  // Probe each provider's real fetch endpoint with the same Bearer auth the executor
-  // uses; validateSearchProvider maps 200/<500 → valid, 401/403 → invalid key,
-  // >=500 → failure (a credit-exhausted / rate-limited key still validates).
-  firecrawl: (apiKey) => ({
-    url: "https://api.firecrawl.dev/v1/scrape",
-    init: {
-      method: "POST",
-      headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
-      body: JSON.stringify({ url: "https://example.com", formats: ["markdown"] }),
-    },
-  }),
-  "jina-reader": (apiKey) => ({
-    url: "https://r.jina.ai/https://example.com",
-    init: {
-      method: "GET",
-      headers: { Authorization: `Bearer ${apiKey}` },
-    },
-  }),
-};
-
-// See open-sse/executors/muse-spark-web.ts for the rationale: Meta migrated
-// from the "Abra" mutation (doc_id 078dfdff…, type RewriteOptionsInput now
-// missing from schema) to the "Ecto" subscription. POST graphql still
-// streams the response; only the persisted-query identifier and operation
-// shape changed.
 /**
  * Validates web-cookie providers by performing a ping request to check if the session is still valid.
  * Returns SESSION_EXPIRED error code if the upstream returns 401/403.

--- a/src/lib/providers/validation/embeddingProviders.ts
+++ b/src/lib/providers/validation/embeddingProviders.ts
@@ -1,0 +1,143 @@
+// Embedding / rerank / clarifai provider key validators. Extracted from validation.ts (god-file
+// decomposition) — top-level functions with no dispatcher-state captures; behavior is byte-identical
+// to the original inline defs.
+import { normalizeBaseUrl, addModelsSuffix, resolveChatUrl } from "./urlHelpers";
+import { buildBearerHeaders, buildClarifaiHeaders } from "./headers";
+import { toValidationErrorResult, validationRead, validationWrite } from "./transport";
+
+export async function validateClarifaiProvider({ apiKey, providerSpecificData = {} }: any) {
+  const baseUrl =
+    normalizeBaseUrl(providerSpecificData.baseUrl) || "https://api.clarifai.com/v2/ext/openai/v1";
+  const modelsUrl = addModelsSuffix(baseUrl);
+
+  try {
+    const modelsRes = await validationRead(modelsUrl, {
+      method: "GET",
+      headers: buildClarifaiHeaders(apiKey, providerSpecificData),
+    });
+
+    if (modelsRes.ok) {
+      return { valid: true, error: null, method: "clarifai_models" };
+    }
+
+    if (modelsRes.status === 401 || modelsRes.status === 403) {
+      return { valid: false, error: "Invalid API key" };
+    }
+
+    const chatUrl = resolveChatUrl("clarifai", baseUrl, providerSpecificData);
+    const chatRes = await validationWrite(chatUrl, {
+      method: "POST",
+      headers: buildClarifaiHeaders(apiKey, providerSpecificData),
+      body: JSON.stringify({
+        model:
+          providerSpecificData?.validationModelId || "openai/chat-completion/models/gpt-oss-120b",
+        messages: [{ role: "user", content: "test" }],
+        max_tokens: 1,
+      }),
+    });
+
+    if (chatRes.ok || chatRes.status === 400 || chatRes.status === 422 || chatRes.status === 429) {
+      return { valid: true, error: null, method: "clarifai_chat_probe" };
+    }
+
+    if (chatRes.status === 401 || chatRes.status === 403) {
+      return { valid: false, error: "Invalid API key" };
+    }
+
+    if (chatRes.status === 404 || chatRes.status === 405) {
+      return { valid: false, error: "Provider validation endpoint not supported" };
+    }
+
+    if (chatRes.status >= 500) {
+      return { valid: false, error: `Provider unavailable (${chatRes.status})` };
+    }
+
+    return { valid: true, error: null, method: "clarifai_chat_probe" };
+  } catch (error: any) {
+    return toValidationErrorResult(error);
+  }
+}
+
+export async function validateEmbeddingApiProvider({
+  apiKey,
+  providerSpecificData = {},
+  url,
+  modelId,
+}: any) {
+  if (!url) {
+    return { valid: false, error: "Missing embedding endpoint" };
+  }
+
+  try {
+    const response = await validationWrite(url, {
+      method: "POST",
+      headers: buildBearerHeaders(apiKey, providerSpecificData),
+      body: JSON.stringify({
+        model: providerSpecificData?.validationModelId || modelId,
+        input: ["test"],
+      }),
+    });
+
+    if (response.status === 401 || response.status === 403) {
+      return { valid: false, error: "Invalid API key" };
+    }
+
+    if (
+      response.ok ||
+      response.status === 400 ||
+      response.status === 422 ||
+      response.status === 429
+    ) {
+      return { valid: true, error: null };
+    }
+
+    if (response.status >= 500) {
+      return { valid: false, error: `Provider unavailable (${response.status})` };
+    }
+
+    return { valid: false, error: `Validation failed: ${response.status}` };
+  } catch (error: any) {
+    return toValidationErrorResult(error);
+  }
+}
+
+export async function validateRerankApiProvider({ apiKey, providerSpecificData = {}, url, modelId }: any) {
+  if (!url) {
+    return { valid: false, error: "Missing rerank endpoint" };
+  }
+
+  try {
+    const response = await validationWrite(url, {
+      method: "POST",
+      headers: buildBearerHeaders(apiKey, providerSpecificData),
+      body: JSON.stringify({
+        model: providerSpecificData?.validationModelId || modelId,
+        query: "test",
+        documents: ["test"],
+        top_n: 1,
+        return_documents: false,
+      }),
+    });
+
+    if (response.status === 401 || response.status === 403) {
+      return { valid: false, error: "Invalid API key" };
+    }
+
+    if (
+      response.ok ||
+      response.status === 400 ||
+      response.status === 422 ||
+      response.status === 429
+    ) {
+      return { valid: true, error: null };
+    }
+
+    if (response.status >= 500) {
+      return { valid: false, error: `Provider unavailable (${response.status})` };
+    }
+
+    return { valid: false, error: `Validation failed: ${response.status}` };
+  } catch (error: any) {
+    return toValidationErrorResult(error);
+  }
+}

--- a/src/lib/providers/validation/searchProviders.ts
+++ b/src/lib/providers/validation/searchProviders.ts
@@ -1,0 +1,206 @@
+// Web-search provider key validators + their per-provider request configs (serper, tavily, jina-reader,
+// …). Extracted from validation.ts (god-file decomposition) — top-level functions/data with no
+// dispatcher-state captures; behavior is byte-identical to the original inline defs.
+import { SAFE_OUTBOUND_FETCH_PRESETS, safeOutboundFetch } from "@/shared/network/safeOutboundFetch";
+import { getProviderOutboundGuard } from "@/shared/network/outboundUrlGuard";
+import { withCustomUserAgent } from "./headers";
+import { toValidationErrorResult, validationWrite } from "./transport";
+
+export async function validateGenericProvider(
+  baseUrl: string,
+  apiKey: string,
+  providerSpecificData: any = {},
+  provider: string,
+  isLocal: boolean = false
+) {
+  const config = SEARCH_VALIDATOR_CONFIGS[provider];
+  if (!config) {
+    return { valid: false, error: "Validator not found", unsupported: true };
+  }
+  const { url, init } = config(apiKey, providerSpecificData);
+  return validateSearchProvider(url, init, providerSpecificData, isLocal);
+}
+
+export async function validateSearchProvider(
+  url: string,
+  init: RequestInit,
+  providerSpecificData: any = {},
+  isLocal: boolean = false
+): Promise<{ valid: boolean; error: string | null; unsupported: false }> {
+  try {
+    const response = await safeOutboundFetch(url, {
+      ...SAFE_OUTBOUND_FETCH_PRESETS.validationWrite,
+      guard: isLocal ? "none" : getProviderOutboundGuard(),
+      ...withCustomUserAgent(init, providerSpecificData),
+    });
+    if (response.ok) return { valid: true, error: null, unsupported: false };
+    if (response.status === 401 || response.status === 403) {
+      return { valid: false, error: "Invalid API key", unsupported: false };
+    }
+    // For provider setup we only need to confirm authentication passed.
+    // Search providers may return non-auth statuses for exhausted credits,
+    // rate limiting, or request-shape quirks while still accepting the key.
+    if (response.status < 500) {
+      return { valid: true, error: null, unsupported: false };
+    }
+    return { valid: false, error: `Validation failed: ${response.status}`, unsupported: false };
+  } catch (error: any) {
+    return toValidationErrorResult(error);
+  }
+}
+
+export const SEARCH_VALIDATOR_CONFIGS: Record<
+  string,
+  (apiKey: string, providerSpecificData?: any) => { url: string; init: RequestInit }
+> = {
+  "serper-search": (apiKey) => ({
+    url: "https://google.serper.dev/search",
+    init: {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "X-API-Key": apiKey },
+      body: JSON.stringify({ q: "test", num: 1 }),
+    },
+  }),
+  "brave-search": (apiKey) => ({
+    url: "https://api.search.brave.com/res/v1/web/search?q=test&count=1",
+    init: {
+      method: "GET",
+      headers: { Accept: "application/json", "X-Subscription-Token": apiKey },
+    },
+  }),
+  "perplexity-search": (apiKey) => ({
+    url: "https://api.perplexity.ai/search",
+    init: {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
+      body: JSON.stringify({ query: "test", max_results: 1 }),
+    },
+  }),
+  "exa-search": (apiKey) => ({
+    url: "https://api.exa.ai/search",
+    init: {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-api-key": apiKey },
+      body: JSON.stringify({ query: "test", numResults: 1 }),
+    },
+  }),
+  "tavily-search": (apiKey) => ({
+    url: "https://api.tavily.com/search",
+    init: {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
+      body: JSON.stringify({ query: "test", max_results: 1 }),
+    },
+  }),
+  "google-pse-search": (apiKey, providerSpecificData = {}) => {
+    const cx = providerSpecificData?.cx;
+    if (!cx || typeof cx !== "string") {
+      throw new Error("Programmable Search Engine ID (cx) is required");
+    }
+    return {
+      url: `https://www.googleapis.com/customsearch/v1?key=${encodeURIComponent(apiKey)}&cx=${encodeURIComponent(
+        cx
+      )}&q=test&num=1`,
+      init: {
+        method: "GET",
+        headers: { Accept: "application/json" },
+      },
+    };
+  },
+  "linkup-search": (apiKey) => ({
+    url: "https://api.linkup.so/v1/search",
+    init: {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
+      body: JSON.stringify({
+        q: "test",
+        depth: "standard",
+        outputType: "searchResults",
+        maxResults: 1,
+      }),
+    },
+  }),
+  "searchapi-search": (apiKey) => ({
+    url: `https://www.searchapi.io/api/v1/search?engine=google&q=test&api_key=${encodeURIComponent(
+      apiKey
+    )}`,
+    init: {
+      method: "GET",
+      headers: { Accept: "application/json" },
+    },
+  }),
+  "youcom-search": (apiKey) => ({
+    url: "https://ydc-index.io/v1/search?query=test&count=1",
+    init: {
+      method: "GET",
+      headers: { Accept: "application/json", "X-API-Key": apiKey },
+    },
+  }),
+  "searxng-search": (apiKey, providerSpecificData = {}) => {
+    const baseUrl =
+      typeof providerSpecificData?.baseUrl === "string" && providerSpecificData.baseUrl.trim()
+        ? providerSpecificData.baseUrl.trim().replace(/\/+$/, "")
+        : "http://localhost:8888/search";
+    const searchUrl = baseUrl.endsWith("/search") ? baseUrl : `${baseUrl}/search`;
+    const headers: Record<string, string> = { Accept: "application/json" };
+    if (apiKey) {
+      headers["Authorization"] = `Bearer ${apiKey}`;
+    }
+    return {
+      url: `${searchUrl}?q=test&format=json`,
+      init: {
+        method: "GET",
+        headers,
+      },
+    };
+  },
+  "ollama-search": (apiKey) => ({
+    url: "https://ollama.com/api/web_search",
+    init: {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
+      body: JSON.stringify({ query: "test", max_results: 1 }),
+    },
+  }),
+  "zai-search": (apiKey, providerSpecificData = {}) => {
+    const baseUrl =
+      typeof providerSpecificData?.baseUrl === "string" && providerSpecificData.baseUrl.trim()
+        ? providerSpecificData.baseUrl.trim().replace(/\/+$/, "")
+        : "https://api.z.ai/api/mcp/web_search_prime/mcp";
+    return {
+      url: baseUrl,
+      init: {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          method: "tools/call",
+          params: { name: "web_search_prime", arguments: { search_query: "test" } },
+          id: 1,
+        }),
+      },
+    };
+  },
+  // ── Web-fetch providers (#4401) ──
+  // firecrawl / jina-reader were added as webFetch-kind providers in #2645 with their
+  // own executors but no validator, so the dashboard "Validate" step returned
+  // "Provider validation not supported" and accounts could not be added through the UI.
+  // Probe each provider's real fetch endpoint with the same Bearer auth the executor
+  // uses; validateSearchProvider maps 200/<500 → valid, 401/403 → invalid key,
+  // >=500 → failure (a credit-exhausted / rate-limited key still validates).
+  firecrawl: (apiKey) => ({
+    url: "https://api.firecrawl.dev/v1/scrape",
+    init: {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
+      body: JSON.stringify({ url: "https://example.com", formats: ["markdown"] }),
+    },
+  }),
+  "jina-reader": (apiKey) => ({
+    url: "https://r.jina.ai/https://example.com",
+    init: {
+      method: "GET",
+      headers: { Authorization: `Bearer ${apiKey}` },
+    },
+  }),
+};

--- a/tests/unit/validation-search-embedding-split.test.ts
+++ b/tests/unit/validation-search-embedding-split.test.ts
@@ -1,0 +1,33 @@
+// Characterization of the validation.ts search + embedding split (god-file decomposition): the
+// web-search validators (+ SEARCH_VALIDATOR_CONFIGS) moved into validation/searchProviders.ts and the
+// embedding/rerank/clarifai validators into validation/embeddingProviders.ts. Behavior-preserving
+// move — the lock is module surface; runtime behavior stays covered by the search-provider-validation
+// and provider-validation-specialty suites.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+const search = await import("../../src/lib/providers/validation/searchProviders.ts");
+const embed = await import("../../src/lib/providers/validation/embeddingProviders.ts");
+const HOST = await import("../../src/lib/providers/validation.ts");
+
+test("searchProviders exposes the search validators + the per-provider config map", () => {
+  assert.equal(typeof (search as Record<string, unknown>).validateSearchProvider, "function");
+  assert.equal(typeof (search as Record<string, unknown>).validateGenericProvider, "function");
+  const cfg = (search as Record<string, Record<string, unknown>>).SEARCH_VALIDATOR_CONFIGS;
+  assert.ok(cfg && typeof cfg === "object");
+  assert.ok(Object.keys(cfg).length > 0, "SEARCH_VALIDATOR_CONFIGS must carry the provider configs");
+});
+
+test("embeddingProviders exposes clarifai + embedding + rerank validators", () => {
+  for (const name of [
+    "validateClarifaiProvider",
+    "validateEmbeddingApiProvider",
+    "validateRerankApiProvider",
+  ]) {
+    assert.equal(typeof (embed as Record<string, unknown>)[name], "function", `missing ${name}`);
+  }
+});
+
+test("host dispatcher surface stays intact after the move", () => {
+  assert.equal(typeof (HOST as Record<string, unknown>).validateProviderApiKey, "function");
+});


### PR DESCRIPTION
## Contexto

Decomposição de god-files — **Tier 1 / M2**, 5ª fatia de `src/lib/providers/validation.ts` (padrão #3501). Base = `release/v3.8.36` (as 4 fatias anteriores já mergeadas).

Move dois grupos coesos (ambos com **zero refs a defs externas**):

| Módulo | Conteúdo | LOC |
|--------|----------|-----|
| `validation/searchProviders.ts` | `validateGenericProvider`, `validateSearchProvider`, `SEARCH_VALIDATOR_CONFIGS` (serper, tavily, jina-reader, …) | 206 |
| `validation/embeddingProviders.ts` | clarifai, embedding-api, rerank-api | 143 |

`validation.ts`: **1771 → 1435 (−336)** — **acumulado −3087** desde o início (4522 → 1435, **−68%**).

O host importa `validateSearchProvider` + `SEARCH_VALIDATOR_CONFIGS` e os 3 validators de embedding para o `SPECIALTY_VALIDATORS`. Removidos imports headers órfãos (`withCustomUserAgent`, `buildClarifaiHeaders`) e um **comentário órfão** sobre muse-spark-web (cujo código já saiu na fatia 2).

## Validação

- `typecheck:core` ✓ · `eslint` 0/0 ✓ · `check:cycles` ✓ · `check:file-size` ✓ (módulos <800)
- **147** testes de validação existentes (`search-provider-validation`, `specialty`, `branches`, `validate-route`) — verdes, sem alteração
- **+3** testes de caracterização (`validation-search-embedding-split.test.ts`)

Refactor puro behavior-preserving — sem VPS.