### PR TITLE
fix(sse): guard non-JSON SSE lines and duplicate [DONE]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ _In development — bullets added per PR; finalized at release._
 - **fix(executors): strip `client_metadata` from forwarded body for Cerebras and Mistral** — Cerebras returns 400 (`wrong_api_format`) and Mistral returns 422 (`extra_forbidden`) when the passthrough body carries `client_metadata` (an OpenAI Codex / Claude CLI field with no equivalent on these upstreams). The default executor now drops it for these two providers before sending downstream; other providers (notably `openai`/`codex`) keep it. (thanks @saurabh321gupta)
 - **fix(codebuddy):** only send reasoning params when the client requests reasoning. (thanks @anki1kr)
 - **fix(sse):** keep streaming for forceStream providers when a JSON client requests it. Providers marked `forceStream:true` reject `stream:false` upstream (HTTP 400); `resolveStreamFlag` now guards against this so stream-only providers keep streaming even when the client sends `Accept: application/json` or `stream:false`. (thanks @anki1kr)
+- **fix(sse):** prevent non-JSON SSE lines and duplicate `[DONE]` from breaking clients. (thanks @qianze0628)
 
 ---
 

--- a/open-sse/utils/stream.ts
+++ b/open-sse/utils/stream.ts
@@ -1791,7 +1791,12 @@ export function createSSEStream(options: StreamOptions = {}) {
                 }
 
                 clientPayload = parsed;
-              } catch {}
+              } catch {
+                // Skip non-JSON data lines silently — don't forward garbage to clients.
+                // Upstream providers sometimes return plain-text errors (HTML, rate-limit
+                // messages) in the SSE stream that would break downstream JSON decoders.
+                continue;
+              }
             }
 
             if (!injectedUsage) {

--- a/tests/unit/stream-non-json-sse.test.ts
+++ b/tests/unit/stream-non-json-sse.test.ts
@@ -1,0 +1,131 @@
+/**
+ * TDD test for fix(sse): guard non-JSON SSE lines and duplicate [DONE]
+ *
+ * Reproduces two bugs from upstream 9router PR #2046:
+ *   1. Non-JSON data lines (e.g. plain-text rate-limit messages) passed
+ *      through raw to the client instead of being silently dropped.
+ *   2. Duplicate `data: [DONE]` events emitted when the stream has two
+ *      emission sites and the guard variable is not shared between them.
+ *
+ * The test drives createSSEStream in passthrough mode (sourceFormat =
+ * targetFormat = "openai"), feeds it a mix of valid JSON chunks + a
+ * non-JSON line + a duplicate upstream [DONE], and checks the output.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-stream-nonjson-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+const core = await import("../../src/lib/db/core.ts");
+
+const { createSSEStream } = await import("../../open-sse/utils/stream.ts");
+
+const textEncoder = new TextEncoder();
+
+async function readTransformed(chunks: string[], options: object): Promise<string> {
+  const source = new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(textEncoder.encode(chunk));
+      }
+      controller.close();
+    },
+  });
+  return new Response(source.pipeThrough(createSSEStream(options))).text();
+}
+
+test.after(() => {
+  core.resetDbInstance();
+  if (fs.existsSync(TEST_DATA_DIR)) {
+    fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  }
+});
+
+const PASSTHROUGH_OPTIONS = {
+  mode: "passthrough",
+  sourceFormat: "openai",
+  targetFormat: "openai",
+};
+
+const validChunk1 = JSON.stringify({
+  id: "chatcmpl-nonjson-1",
+  object: "chat.completion.chunk",
+  created: 1,
+  model: "gpt-4o",
+  choices: [{ index: 0, delta: { content: "Hello" }, finish_reason: null }],
+});
+
+const validChunk2 = JSON.stringify({
+  id: "chatcmpl-nonjson-2",
+  object: "chat.completion.chunk",
+  created: 1,
+  model: "gpt-4o",
+  choices: [{ index: 0, delta: { content: " world" }, finish_reason: "stop" }],
+});
+
+test("non-JSON data line (plain-text rate-limit message) is NOT forwarded to client", async () => {
+  const output = await readTransformed(
+    [
+      `data: ${validChunk1}\n\n`,
+      // Non-JSON line that should be silently dropped
+      "data: Rate limit exceeded\n\n",
+      `data: ${validChunk2}\n\n`,
+      "data: [DONE]\n\n",
+    ],
+    PASSTHROUGH_OPTIONS
+  );
+
+  // The non-JSON line must NOT appear verbatim in the output
+  assert.ok(
+    !output.includes("data: Rate limit exceeded"),
+    `Non-JSON line was forwarded to client.\nOutput: ${output}`
+  );
+
+  // Both valid JSON chunks must appear
+  assert.ok(
+    output.includes("chatcmpl-nonjson-1"),
+    `First valid chunk missing.\nOutput: ${output}`
+  );
+  assert.ok(
+    output.includes("chatcmpl-nonjson-2"),
+    `Second valid chunk missing.\nOutput: ${output}`
+  );
+});
+
+test("exactly one [DONE] emitted even when upstream sends a duplicate", async () => {
+  const output = await readTransformed(
+    [
+      `data: ${validChunk1}\n\n`,
+      "data: [DONE]\n\n",
+      // Second upstream [DONE] — should be suppressed
+      "data: [DONE]\n\n",
+    ],
+    PASSTHROUGH_OPTIONS
+  );
+
+  const doneCount = (output.match(/data: \[DONE\]/g) ?? []).length;
+  assert.equal(
+    doneCount,
+    1,
+    `Expected exactly 1 [DONE] in output, got ${doneCount}.\nOutput: ${output}`
+  );
+});
+
+test("valid JSON chunks pass through correctly in passthrough mode", async () => {
+  const output = await readTransformed(
+    [
+      `data: ${validChunk1}\n\n`,
+      `data: ${validChunk2}\n\n`,
+      "data: [DONE]\n\n",
+    ],
+    PASSTHROUGH_OPTIONS
+  );
+
+  assert.ok(output.includes("chatcmpl-nonjson-1"), `Chunk 1 missing.\nOutput: ${output}`);
+  assert.ok(output.includes("chatcmpl-nonjson-2"), `Chunk 2 missing.\nOutput: ${output}`);
+  assert.ok(output.includes("data: [DONE]"), `[DONE] missing.\nOutput: ${output}`);
+});


### PR DESCRIPTION
## Summary

- Upstream providers occasionally inject plain-text error messages (HTML pages, rate-limit notices) directly into an SSE stream. The passthrough path in `createSSEStream` was forwarding those lines raw to the client because the `catch {}` around `JSON.parse` fell through without a `continue`, causing downstream JSON decoders to break.
- The fix adds a `continue` statement inside the catch block, silently dropping any non-JSON `data:` lines.
- The duplicate `[DONE]` guard was already present via the shared `doneSent` flag covering both emission sites — confirmed by test and no code change required.

## Attribution

Thanks to [@qianze0628](https://github.com/qianze0628) for the original implementation.

## Changes

- `open-sse/utils/stream.ts`: add `continue` in the catch block around JSON.parse (~line 1794) so non-JSON SSE data lines are silently dropped instead of forwarded verbatim.
- `tests/unit/stream-non-json-sse.test.ts`: new TDD test file — was failing before the fix, passes after.
- `CHANGELOG.md`: added bullet under `[3.8.36]`.

## Test plan

- [x] TDD: test was written first and confirmed FAILING against unpatched code (test 1 failed: `non-JSON line was forwarded to client`)
- [x] Fix applied, all 3 tests now PASS: `node --import tsx/esm --test tests/unit/stream-non-json-sse.test.ts`
- [x] `npm run typecheck:core` — clean (exit 0)
- [x] `npx eslint open-sse/utils/stream.ts tests/unit/stream-non-json-sse.test.ts` — clean (exit 0)