### PR TITLE
fix(antigravity): retry transient upstream failures

### DIFF
--- a/open-sse/executors/antigravity.ts
+++ b/open-sse/executors/antigravity.ts
@@ -60,6 +60,26 @@ import * as prl from "../utils/providerRequestLogging.ts";
 const MAX_RETRY_AFTER_MS = 60_000;
 const LONG_RETRY_THRESHOLD_MS = 60_000;
 const CREDITS_EXHAUSTED_TTL_MS = 5 * 60 * 60 * 1000; // 5 hours
+// Cap for transient 5xx backoff — shorter than the 429 cap to avoid long stalls on
+// infra hiccups ("Agent execution terminated", "high traffic", capacity errors).
+const ANTIGRAVITY_TRANSIENT_RETRY_MAX_MS = 15_000;
+
+const ANTIGRAVITY_TRANSIENT_ERROR_PATTERNS: RegExp[] = [
+  /high\s+traffic/i,
+  /agent\s+(execution\s+)?terminated\s+due\s+to\s+error/i,
+  /capacity/i,
+  /temporarily\s+unavailable/i,
+  /timeout/i,
+  /stream\s+(ended|closed|terminated|interrupted)/i,
+  /empty\s+response/i,
+];
+
+const ANTIGRAVITY_TRANSIENT_STATUSES = new Set([
+  HTTP_STATUS.SERVER_ERROR,
+  HTTP_STATUS.BAD_GATEWAY,
+  HTTP_STATUS.SERVICE_UNAVAILABLE,
+  HTTP_STATUS.GATEWAY_TIMEOUT,
+]);
 // The upstream API uses plain model IDs (no -high/-low suffix).
 // Tier suffixes were speculative and caused 404 for gemini-3.x models — the
 // bare-Pro→Low normalization was retired (the set stayed empty, making the guard
@@ -958,6 +978,40 @@ export class AntigravityExecutor extends BaseExecutor {
   }
 
   /**
+   * Flatten an Antigravity error JSON + raw body text into a single string so
+   * isTransientAntigravityError can match against body patterns.
+   */
+  extractErrorMessage(errorJson: unknown, bodyText = ""): string {
+    const candidates: string[] = [];
+    if (errorJson && typeof errorJson === "object") {
+      const obj = errorJson as Record<string, unknown>;
+      const errField = obj.error;
+      if (errField && typeof errField === "object") {
+        const msg = (errField as Record<string, unknown>).message;
+        if (typeof msg === "string") candidates.push(msg);
+        else if (msg != null) candidates.push(JSON.stringify(msg));
+      } else if (typeof errField === "string") {
+        candidates.push(errField);
+      }
+      if (typeof obj.message === "string") candidates.push(obj.message);
+    }
+    if (bodyText) candidates.push(bodyText);
+    return candidates.filter(Boolean).join("\n");
+  }
+
+  /**
+   * Return true when a status + error message combination should be retried
+   * with exponential backoff instead of immediately failing-over to the next URL.
+   * 429 is always transient. Transient 5xx statuses (500/502/503/504) are also
+   * retried when the body contains a known capacity/traffic/agent pattern.
+   */
+  isTransientAntigravityError(status: number, message: string): boolean {
+    if (status === HTTP_STATUS.RATE_LIMITED) return true;
+    if (ANTIGRAVITY_TRANSIENT_STATUSES.has(status)) return true;
+    return ANTIGRAVITY_TRANSIENT_ERROR_PATTERNS.some((p) => p.test(message || ""));
+  }
+
+  /**
    * Collect an SSE streaming response into a single non-streaming JSON response.
    * Parses Gemini-format SSE chunks and assembles text content + usage into one
    * OpenAI-format chat.completion payload.
@@ -1469,25 +1523,42 @@ export class AntigravityExecutor extends BaseExecutor {
             continue;
           }
 
-          // Auto retry only for 429 when retryMs is 0 or undefined
-          if (
-            response.status === HTTP_STATUS.RATE_LIMITED &&
-            (!retryMs || retryMs === 0) &&
-            retryAttemptsByUrl[urlIndex] < MAX_AUTO_RETRIES
-          ) {
-            retryAttemptsByUrl[urlIndex]++;
-            // Exponential backoff: 2s, 4s, 8s...
-            const backoffMs = Math.min(
-              1000 * 2 ** retryAttemptsByUrl[urlIndex],
-              MAX_RETRY_AFTER_MS
-            );
-            log?.debug?.(
-              "RETRY",
-              `429 auto retry ${retryAttemptsByUrl[urlIndex]}/${MAX_AUTO_RETRIES} after ${backoffMs / 1000}s`
-            );
-            await new Promise((resolve) => setTimeout(resolve, backoffMs));
-            urlIndex--;
-            continue;
+          // Auto retry for 429 (no Retry-After) or transient 5xx errors.
+          // For 5xx we read the body to detect known transient patterns
+          // ("Agent execution terminated due to error", "high traffic", "capacity").
+          if ((!retryMs || retryMs === 0) && retryAttemptsByUrl[urlIndex] < MAX_AUTO_RETRIES) {
+            let shouldAutoRetry = response.status === HTTP_STATUS.RATE_LIMITED;
+            if (!shouldAutoRetry && ANTIGRAVITY_TRANSIENT_STATUSES.has(response.status)) {
+              try {
+                const errBody = await response.clone().text();
+                let errJson: unknown = null;
+                try {
+                  errJson = errBody ? JSON.parse(errBody) : null;
+                } catch {
+                  // non-JSON body — fall through to pattern match against raw text
+                }
+                const errMsg = this.extractErrorMessage(errJson, errBody);
+                shouldAutoRetry = this.isTransientAntigravityError(response.status, errMsg);
+              } catch {
+                // ignore body read errors
+              }
+            }
+            if (shouldAutoRetry) {
+              retryAttemptsByUrl[urlIndex]++;
+              // Exponential backoff: 2s, 4s, 8s… capped per-status
+              const cap =
+                response.status === HTTP_STATUS.RATE_LIMITED
+                  ? MAX_RETRY_AFTER_MS
+                  : ANTIGRAVITY_TRANSIENT_RETRY_MAX_MS;
+              const backoffMs = Math.min(1000 * 2 ** retryAttemptsByUrl[urlIndex], cap);
+              log?.debug?.(
+                "RETRY",
+                `${response.status} transient auto retry ${retryAttemptsByUrl[urlIndex]}/${MAX_AUTO_RETRIES} after ${backoffMs / 1000}s`
+              );
+              await new Promise((resolve) => setTimeout(resolve, backoffMs));
+              urlIndex--;
+              continue;
+            }
           }
 
           log?.debug?.(

--- a/open-sse/translator/helpers/geminiToolsSanitizer.ts
+++ b/open-sse/translator/helpers/geminiToolsSanitizer.ts
@@ -175,6 +175,10 @@ export function buildGeminiTools(
   }
 
   const functionDeclarations: GeminiFunctionDeclaration[] = [];
+  // Track sanitized names already added to prevent Gemini rejection from duplicate
+  // function declaration names (two different raw names that collapse to the same
+  // sanitized form, or the same raw name repeated across tool groups).
+  const seenToolNames = new Set<string>();
   let googleSearchTool: GeminiTool | null = null;
 
   for (const rawTool of tools) {
@@ -194,8 +198,11 @@ export function buildGeminiTools(
           continue;
         }
 
+        const sanitizedName = sanitizeGeminiToolName(fn.name, options);
+        if (seenToolNames.has(sanitizedName)) continue;
+        seenToolNames.add(sanitizedName);
         functionDeclarations.push({
-          name: sanitizeGeminiToolName(fn.name, options),
+          name: sanitizedName,
           description: typeof fn.description === "string" ? fn.description : "",
           parameters: cleanJSONSchemaForAntigravity(toGeminiParametersSchema(fn.parameters)),
         });
@@ -204,11 +211,15 @@ export function buildGeminiTools(
     }
 
     if (typeof rawTool.name === "string" && rawTool.name.trim()) {
-      functionDeclarations.push({
-        name: sanitizeGeminiToolName(rawTool.name, options),
-        description: typeof rawTool.description === "string" ? rawTool.description : "",
-        parameters: cleanJSONSchemaForAntigravity(toGeminiParametersSchema(rawTool.input_schema)),
-      });
+      const sanitizedName = sanitizeGeminiToolName(rawTool.name, options);
+      if (!seenToolNames.has(sanitizedName)) {
+        seenToolNames.add(sanitizedName);
+        functionDeclarations.push({
+          name: sanitizedName,
+          description: typeof rawTool.description === "string" ? rawTool.description : "",
+          parameters: cleanJSONSchemaForAntigravity(toGeminiParametersSchema(rawTool.input_schema)),
+        });
+      }
       continue;
     }
 
@@ -218,11 +229,15 @@ export function buildGeminiTools(
         continue;
       }
 
-      functionDeclarations.push({
-        name: sanitizeGeminiToolName(fn.name, options),
-        description: typeof fn.description === "string" ? fn.description : "",
-        parameters: cleanJSONSchemaForAntigravity(toGeminiParametersSchema(fn.parameters)),
-      });
+      const sanitizedName = sanitizeGeminiToolName(fn.name, options);
+      if (!seenToolNames.has(sanitizedName)) {
+        seenToolNames.add(sanitizedName);
+        functionDeclarations.push({
+          name: sanitizedName,
+          description: typeof fn.description === "string" ? fn.description : "",
+          parameters: cleanJSONSchemaForAntigravity(toGeminiParametersSchema(fn.parameters)),
+        });
+      }
     }
   }
 

--- a/tests/unit/antigravity-retry-hook.test.ts
+++ b/tests/unit/antigravity-retry-hook.test.ts
@@ -1,0 +1,141 @@
+/**
+ * TDD tests for port of upstream PR #2054 (decolua/9router):
+ *   fix(antigravity): retry transient upstream failures
+ *
+ * Covers:
+ *   1. isTransientAntigravityError classifies 5xx + body patterns correctly
+ *   2. extractErrorMessage extracts message from various JSON shapes
+ *   3. Tool-name deduplication in buildGeminiTools (via geminiToolsSanitizer)
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { AntigravityExecutor } from "../../open-sse/executors/antigravity.ts";
+import { buildGeminiTools } from "../../open-sse/translator/helpers/geminiToolsSanitizer.ts";
+
+// ── isTransientAntigravityError ────────────────────────────────────────────────
+
+test("isTransientAntigravityError: 503 → true (transient status)", () => {
+  const ex = new AntigravityExecutor();
+  assert.equal(ex.isTransientAntigravityError(503, ""), true);
+});
+
+test("isTransientAntigravityError: 500 + 'Agent execution terminated due to error' body → true", () => {
+  const ex = new AntigravityExecutor();
+  assert.equal(
+    ex.isTransientAntigravityError(500, "Agent execution terminated due to error"),
+    true
+  );
+});
+
+test("isTransientAntigravityError: 500 + 'high traffic' body → true", () => {
+  const ex = new AntigravityExecutor();
+  assert.equal(ex.isTransientAntigravityError(500, "high traffic"), true);
+});
+
+test("isTransientAntigravityError: 500 + 'capacity' body → true", () => {
+  const ex = new AntigravityExecutor();
+  assert.equal(ex.isTransientAntigravityError(500, "service is at capacity"), true);
+});
+
+test("isTransientAntigravityError: 400 + 'Invalid request' body → false (veto)", () => {
+  const ex = new AntigravityExecutor();
+  assert.equal(ex.isTransientAntigravityError(400, "Invalid request"), false);
+});
+
+test("isTransientAntigravityError: 404 → false", () => {
+  const ex = new AntigravityExecutor();
+  assert.equal(ex.isTransientAntigravityError(404, "not found"), false);
+});
+
+test("isTransientAntigravityError: 429 → true (rate limited is transient)", () => {
+  const ex = new AntigravityExecutor();
+  assert.equal(ex.isTransientAntigravityError(429, ""), true);
+});
+
+test("isTransientAntigravityError: 502 → true (bad gateway is transient)", () => {
+  const ex = new AntigravityExecutor();
+  assert.equal(ex.isTransientAntigravityError(502, ""), true);
+});
+
+test("isTransientAntigravityError: 504 → true (gateway timeout is transient)", () => {
+  const ex = new AntigravityExecutor();
+  assert.equal(ex.isTransientAntigravityError(504, ""), true);
+});
+
+// ── extractErrorMessage ────────────────────────────────────────────────────────
+
+test("extractErrorMessage: extracts error.message from standard JSON shape", () => {
+  const ex = new AntigravityExecutor();
+  const json = { error: { message: "quota exceeded" } };
+  const msg = ex.extractErrorMessage(json, "");
+  assert.ok(msg.includes("quota exceeded"), `expected 'quota exceeded' in: ${msg}`);
+});
+
+test("extractErrorMessage: falls back to top-level message field", () => {
+  const ex = new AntigravityExecutor();
+  const json = { message: "service unavailable" };
+  const msg = ex.extractErrorMessage(json, "");
+  assert.ok(msg.includes("service unavailable"), `expected 'service unavailable' in: ${msg}`);
+});
+
+test("extractErrorMessage: falls back to bodyText when json has no message", () => {
+  const ex = new AntigravityExecutor();
+  const msg = ex.extractErrorMessage(null, "raw error body text");
+  assert.ok(msg.includes("raw error body text"), `expected body text in: ${msg}`);
+});
+
+// ── Tool-name deduplication ────────────────────────────────────────────────────
+
+test("buildGeminiTools: deduplicates tool names that sanitize to the same value", () => {
+  // "read/file" and "read/file" appear twice → only one after dedup
+  const tools = [
+    {
+      functionDeclarations: [
+        {
+          name: "read/file",
+          description: "Read a file",
+          parameters: { type: "object", properties: {} },
+        },
+        {
+          name: "read/file",
+          description: "Read a file (dup)",
+          parameters: { type: "object", properties: {} },
+        },
+      ],
+    },
+  ];
+
+  const result = buildGeminiTools(tools);
+  assert.ok(Array.isArray(result), "should return array");
+  const decls = result![0]?.functionDeclarations ?? [];
+  // After sanitizing "read/file" → "read_file", both resolve to same name; only 1 should remain
+  const names = decls.map((d) => d.name);
+  assert.equal(new Set(names).size, names.length, `Duplicate names found: ${names}`);
+  assert.equal(names.length, 1, `Expected 1 declaration, got ${names.length}: ${names}`);
+});
+
+test("buildGeminiTools: tools with different sanitized names are both kept", () => {
+  const tools = [
+    {
+      functionDeclarations: [
+        {
+          name: "read_file",
+          description: "Read a file",
+          parameters: { type: "object", properties: {} },
+        },
+        {
+          name: "write_file",
+          description: "Write a file",
+          parameters: { type: "object", properties: {} },
+        },
+      ],
+    },
+  ];
+
+  const result = buildGeminiTools(tools);
+  assert.ok(Array.isArray(result), "should return array");
+  const decls = result![0]?.functionDeclarations ?? [];
+  assert.equal(decls.length, 2, `Expected 2 declarations, got ${decls.length}`);
+});


### PR DESCRIPTION
## What

Ports three improvements to the Antigravity executor from an upstream fix.

### Slice 1 — Transient 5xx retry

Adds `ANTIGRAVITY_TRANSIENT_ERROR_PATTERNS` (regex array) and `ANTIGRAVITY_TRANSIENT_STATUSES` (500/502/503/504 set) plus two new public methods:

- `extractErrorMessage(errorJson, bodyText)` — flattens various JSON shapes into a single string for pattern matching
- `isTransientAntigravityError(status, message)` — returns `true` for 429, any transient 5xx status, or body matching a known infra-hiccup pattern ("Agent execution terminated due to error", "high traffic", "capacity", "temporarily unavailable", …)

The intra-request auto-retry block (previously 429-only) is extended to call `isTransientAntigravityError` for any response that hasn't already been handled. Transient 5xx uses a 15 s cap (`ANTIGRAVITY_TRANSIENT_RETRY_MAX_MS`) instead of the 60 s cap used for 429, keeping stall time bounded.

### Slice 2 — Equivalent of upstream per-status `"500": { attempts: 3 }`

OmniRoute TS does not have a per-status registry config; retries are handled inline. The existing `MAX_AUTO_RETRIES = 3` constant now applies to transient 5xx through Slice 1's extended condition — functionally equivalent to the upstream change.

### Slice 3 — Tool-name deduplication in `buildGeminiTools`

Adds a `seenToolNames: Set<string>` inside `buildGeminiTools` (`geminiToolsSanitizer.ts`). After sanitization, any declaration whose sanitized name was already emitted is silently dropped. Prevents Gemini API rejections caused by duplicate `functionDeclaration` names (same raw name repeated across tool groups, or two names that collapse to the same sanitized form).

## Tests

14 new unit tests in `tests/unit/antigravity-retry-hook.test.ts` (TDD — all confirmed failing before implementation, all green after):

- `isTransientAntigravityError`: 503 transient, 500 + body patterns (agent terminated, high traffic, capacity), 400 veto, 404 veto, 429/502/504 transient
- `extractErrorMessage`: standard `error.message` shape, top-level `message`, raw body text fallback
- `buildGeminiTools` dedup: identical raw name (→ same sanitized) deduplicated to one; distinct names both kept

## Validation

```
npm run typecheck:core     → PASS (0 errors)
npx eslint <touched files> → PASS (0 warnings)
npm run check:cycles       → PASS
node --import tsx/esm --test tests/unit/antigravity-retry-hook.test.ts → 14/14 PASS
pre-commit hooks           → PASS
pre-push hooks             → PASS
```

## Attribution

@Jordannst