### PR TITLE
refactor(sse): extrai scalar/format helpers de services/usage.ts

### DIFF
--- a/open-sse/services/usage.ts
+++ b/open-sse/services/usage.ts
@@ -38,16 +38,24 @@ import {
 } from "../executors/antigravity.ts";
 import { getCreditsMode } from "./antigravityCredits.ts";
 import { CLAUDE_CODE_VERSION, fetchClaudeBootstrap } from "../executors/claudeIdentity.ts";
-import {
-  isClaudeOauthUsageCoolingDown,
-  markClaudeOauthUsage429,
-} from "./claudeUsageCooldown.ts";
+import { isClaudeOauthUsageCoolingDown, markClaudeOauthUsage429 } from "./claudeUsageCooldown.ts";
 import { generateAntigravityRequestId, getAntigravitySessionId } from "./antigravityIdentity.ts";
 import {
   extractCodeAssistOnboardTierId,
   extractCodeAssistSubscriptionTier,
 } from "./codeAssistSubscription.ts";
 import { sanitizeErrorMessage } from "../utils/error.ts";
+import {
+  toRecord,
+  toNumber,
+  toPercentage,
+  toTitleCase,
+  getFieldValue,
+  clampPercentage,
+  roundCurrency,
+  toDisplayLabel,
+  pickFirstNonEmptyString,
+} from "./usage/scalars.ts";
 
 // Quota / usage upstream URLs (overridable for testing or relays).
 const CROF_USAGE_URL = process.env.OMNIROUTE_CROF_USAGE_URL ?? "https://crof.ai/usage_api/";
@@ -162,33 +170,6 @@ type SubscriptionCacheEntry = {
   fetchedAt: number;
 };
 
-function toRecord(value: unknown): JsonRecord {
-  return value && typeof value === "object" && !Array.isArray(value) ? (value as JsonRecord) : {};
-}
-
-function toNumber(value: unknown, fallback = 0): number {
-  const parsed =
-    typeof value === "number"
-      ? value
-      : typeof value === "string" && value.trim().length > 0
-        ? Number(value)
-        : Number.NaN;
-  return Number.isFinite(parsed) ? parsed : fallback;
-}
-
-function toPercentage(value: unknown): number {
-  return Math.max(0, Math.min(100, toNumber(value, 0)));
-}
-
-function toTitleCase(value: string): string {
-  return value
-    .trim()
-    .split(/[\s_-]+/)
-    .filter(Boolean)
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
-    .join(" ");
-}
-
 function getGlmTokenQuotaName(
   limit: JsonRecord,
   existingQuotas: Record<string, UsageQuota>
@@ -207,34 +188,6 @@ function getGlmQuotaDisplayName(quotaName: string): string {
   if (quotaName === "weekly") return "Weekly Quota";
   return quotaName;
 }
-function getFieldValue(source: unknown, snakeKey: string, camelKey: string): unknown {
-  const obj = toRecord(source);
-  return obj[snakeKey] ?? obj[camelKey] ?? null;
-}
-
-function clampPercentage(value: number): number {
-  return Math.max(0, Math.min(100, value));
-}
-
-function roundCurrency(value: number): number {
-  return Math.round(value * 100) / 100;
-}
-
-function toDisplayLabel(value: string): string {
-  return value
-    .replace(/^copilot[_\s-]*/i, "")
-    .split(/[\s_-]+/)
-    .filter(Boolean)
-    .map((part) => {
-      if (/^pro\+$/i.test(part)) return "Pro+";
-      if (/^[a-z]{2,}$/.test(part))
-        return part.charAt(0).toUpperCase() + part.slice(1).toLowerCase();
-      return part;
-    })
-    .join(" ")
-    .trim();
-}
-
 function shouldDisplayGitHubQuota(quota: UsageQuota | null): quota is UsageQuota {
   if (!quota) return false;
   if (quota.unlimited && quota.total <= 0) return false;
@@ -274,15 +227,6 @@ function buildKiroQuota(
     resetAt,
     unlimited: true,
   };
-}
-
-function pickFirstNonEmptyString(...values: unknown[]): string | undefined {
-  for (const value of values) {
-    if (typeof value !== "string") continue;
-    const trimmed = value.trim();
-    if (trimmed) return trimmed;
-  }
-  return undefined;
 }
 
 function inferMiniMaxPlanLabelFromTotals(models: JsonRecord[]): string | null {

--- a/open-sse/services/usage/scalars.ts
+++ b/open-sse/services/usage/scalars.ts
@@ -1,0 +1,75 @@
+/**
+ * usage/scalars.ts — pure scalar + string coercion helpers for usage fetchers.
+ *
+ * Extracted from services/usage.ts (god-file decomposition): the zero-dependency
+ * primitives that the per-provider usage fetchers lean on to coerce raw upstream JSON
+ * (numbers, percentages, snake/camel field lookups, display labels). Pure — no network,
+ * no DB, no module state — so they live as a neutral leaf that usage.ts (and future
+ * per-provider fetcher leaves) import without a cycle. Behavior-preserving move.
+ */
+
+type JsonRecord = Record<string, unknown>;
+
+export function toRecord(value: unknown): JsonRecord {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as JsonRecord) : {};
+}
+
+export function toNumber(value: unknown, fallback = 0): number {
+  const parsed =
+    typeof value === "number"
+      ? value
+      : typeof value === "string" && value.trim().length > 0
+        ? Number(value)
+        : Number.NaN;
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+export function toPercentage(value: unknown): number {
+  return Math.max(0, Math.min(100, toNumber(value, 0)));
+}
+
+export function toTitleCase(value: string): string {
+  return value
+    .trim()
+    .split(/[\s_-]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join(" ");
+}
+
+export function getFieldValue(source: unknown, snakeKey: string, camelKey: string): unknown {
+  const obj = toRecord(source);
+  return obj[snakeKey] ?? obj[camelKey] ?? null;
+}
+
+export function clampPercentage(value: number): number {
+  return Math.max(0, Math.min(100, value));
+}
+
+export function roundCurrency(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+export function toDisplayLabel(value: string): string {
+  return value
+    .replace(/^copilot[_\s-]*/i, "")
+    .split(/[\s_-]+/)
+    .filter(Boolean)
+    .map((part) => {
+      if (/^pro\+$/i.test(part)) return "Pro+";
+      if (/^[a-z]{2,}$/.test(part))
+        return part.charAt(0).toUpperCase() + part.slice(1).toLowerCase();
+      return part;
+    })
+    .join(" ")
+    .trim();
+}
+
+export function pickFirstNonEmptyString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value !== "string") continue;
+    const trimmed = value.trim();
+    if (trimmed) return trimmed;
+  }
+  return undefined;
+}

--- a/tests/unit/usage-scalars-split.test.ts
+++ b/tests/unit/usage-scalars-split.test.ts
@@ -1,0 +1,69 @@
+// Characterization of the services/usage.ts scalar-helpers split (god-file decomposition): the pure
+// coercion/format primitives the per-provider usage fetchers share moved into services/usage/scalars.ts.
+// Behavior-preserving move — these locks pin the coercion edges (NaN/empty fallbacks, percentage
+// clamping, snake/camel field lookup precedence, copilot-prefix stripping in display labels).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+const S = await import("../../open-sse/services/usage/scalars.ts");
+
+test("module exposes the nine scalar helpers", () => {
+  for (const name of [
+    "toRecord",
+    "toNumber",
+    "toPercentage",
+    "toTitleCase",
+    "getFieldValue",
+    "clampPercentage",
+    "roundCurrency",
+    "toDisplayLabel",
+    "pickFirstNonEmptyString",
+  ]) {
+    assert.equal(typeof (S as Record<string, unknown>)[name], "function", `missing ${name}`);
+  }
+});
+
+test("toRecord only passes through plain objects", () => {
+  assert.deepEqual(S.toRecord({ a: 1 }), { a: 1 });
+  assert.deepEqual(S.toRecord([1, 2]), {});
+  assert.deepEqual(S.toRecord(null), {});
+  assert.deepEqual(S.toRecord("x"), {});
+});
+
+test("toNumber coerces strings, falls back on NaN/empty", () => {
+  assert.equal(S.toNumber(42), 42);
+  assert.equal(S.toNumber("3.5"), 3.5);
+  assert.equal(S.toNumber("", 7), 7);
+  assert.equal(S.toNumber("abc", 9), 9);
+  assert.equal(S.toNumber(undefined, -1), -1);
+});
+
+test("toPercentage / clampPercentage clamp into 0..100", () => {
+  assert.equal(S.toPercentage(150), 100);
+  assert.equal(S.toPercentage(-5), 0);
+  assert.equal(S.toPercentage("42"), 42);
+  assert.equal(S.clampPercentage(250), 100);
+  assert.equal(S.clampPercentage(-3), 0);
+});
+
+test("getFieldValue prefers snake key, then camel, else null", () => {
+  assert.equal(S.getFieldValue({ plan_name: "a", planName: "b" }, "plan_name", "planName"), "a");
+  assert.equal(S.getFieldValue({ planName: "b" }, "plan_name", "planName"), "b");
+  assert.equal(S.getFieldValue({}, "plan_name", "planName"), null);
+});
+
+test("roundCurrency rounds to two decimals", () => {
+  assert.equal(S.roundCurrency(1.005), 1.0); // standard JS rounding edge
+  assert.equal(S.roundCurrency(2.347), 2.35);
+});
+
+test("toTitleCase / toDisplayLabel format labels", () => {
+  assert.equal(S.toTitleCase("pro_plus plan"), "Pro Plus Plan");
+  assert.equal(S.toDisplayLabel("copilot_pro+"), "Pro+");
+  assert.equal(S.toDisplayLabel("copilot business"), "Business");
+});
+
+test("pickFirstNonEmptyString returns first trimmed non-empty string", () => {
+  assert.equal(S.pickFirstNonEmptyString(null, 3, "  ", " hi "), "hi");
+  assert.equal(S.pickFirstNonEmptyString(null, 1), undefined);
+});


### PR DESCRIPTION
## Contexto

Inicia a decomposição do god-file `services/usage.ts` (3275 LOC, Tier 2). Move a **fatia-fundação**: as 9 primitivas puras de coerção/formatação que os fetchers de uso por-provider compartilham.

## Mudança

- **`services/usage/scalars.ts`** (novo, 75L) — `toRecord`, `toNumber`, `toPercentage`, `toTitleCase`, `getFieldValue`, `clampPercentage`, `roundCurrency`, `toDisplayLabel`, `pickFirstNonEmptyString`. Zero-dependência: sem rede, sem DB, sem estado de módulo.
- **`services/usage.ts`** (host) — reimporta as 9 (usadas em ~230 call sites: `toRecord` 64×, `toNumber` 55×, `getFieldValue` 31×, …). `3275 → 3222` linhas.

Por que esta fatia primeiro: como leaf neutro de zero-dependência, **destrava a extração futura das famílias de provider** (MiniMax/GLM/Antigravity/…) sem ciclo — cada família poderá importar os escalares em vez de puxá-los do host (que importaria o fetcher de volta).

## Validação

- `typecheck:core` limpo
- `eslint` 0/0 (host + leaf)
- `check:cycles` OK
- `check:file-size` OK
- `tests/unit/usage-service-hardening.test.ts` (24/24) — regressão que exercita os fetchers consumidores dos escalares
- `tests/unit/usage-scalars-split.test.ts` (novo, 8/8) — caracterização das bordas de coerção

> Independente das fatias `db/` (base release/v3.8.36).