### PR TITLE
refactor(sse): extrai a família MiniMax de services/usage.ts

### DIFF
--- a/open-sse/services/usage.ts
+++ b/open-sse/services/usage.ts
@@ -57,6 +57,20 @@ import {
   pickFirstNonEmptyString,
 } from "./usage/scalars.ts";
 import { type UsageQuota, parseResetTime, createQuotaFromUsage } from "./usage/quota.ts";
+import {
+  getMiniMaxUsage,
+  getMiniMaxPlanLabel,
+  getMiniMaxSessionTotal,
+  inferMiniMaxPlanLabelFromTotals,
+  getMiniMaxQuotaResetAt,
+  isMiniMaxTextQuotaModel,
+  getMiniMaxWeeklyTotal,
+  createMiniMaxQuotaFromCount,
+  createMiniMaxQuotaFromPercent,
+  getMiniMaxRemainingPercent,
+  getMiniMaxAuthErrorMessage,
+  getMiniMaxErrorSummary,
+} from "./usage/minimax.ts";
 
 // Quota / usage upstream URLs (overridable for testing or relays).
 const CROF_USAGE_URL = process.env.OMNIROUTE_CROF_USAGE_URL ?? "https://crof.ai/usage_api/";
@@ -117,21 +131,6 @@ const CURSOR_USAGE_CONFIG = {
   userAgent:
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
 };
-
-const MINIMAX_USAGE_CONFIG = {
-  minimax: {
-    usageUrls: [
-      "https://www.minimax.io/v1/token_plan/remains",
-      "https://api.minimax.io/v1/api/openplatform/coding_plan/remains",
-    ],
-  },
-  "minimax-cn": {
-    usageUrls: [
-      "https://www.minimaxi.com/v1/api/openplatform/coding_plan/remains",
-      "https://api.minimaxi.com/v1/api/openplatform/coding_plan/remains",
-    ],
-  },
-} as const;
 
 type JsonRecord = Record<string, unknown>;
 type UsageProviderConnection = JsonRecord & {
@@ -207,38 +206,6 @@ function buildKiroQuota(
   };
 }
 
-function inferMiniMaxPlanLabelFromTotals(models: JsonRecord[]): string | null {
-  const maxSessionTotal = models.reduce(
-    (maxTotal, model) => Math.max(maxTotal, getMiniMaxSessionTotal(model)),
-    0
-  );
-
-  if (maxSessionTotal >= 15_000) return "Max";
-  if (maxSessionTotal >= 4_500) return "Plus";
-  if (maxSessionTotal >= 1_500) return "Starter";
-  return null;
-}
-
-function getMiniMaxPlanLabel(payload: JsonRecord, models: JsonRecord[] = []): string {
-  const raw = pickFirstNonEmptyString(
-    getFieldValue(payload, "current_subscribe_title", "currentSubscribeTitle"),
-    getFieldValue(payload, "plan_name", "planName"),
-    getFieldValue(payload, "plan", "plan"),
-    getFieldValue(payload, "current_plan_title", "currentPlanTitle"),
-    getFieldValue(payload, "combo_title", "comboTitle")
-  );
-
-  if (!raw) return inferMiniMaxPlanLabelFromTotals(models) || "Coding Plan";
-
-  const cleaned = raw
-    .replace(/^minimax\s+/i, "")
-    .replace(/\bcoding\s+plan\b/gi, "")
-    .replace(/\s{2,}/g, " ")
-    .trim();
-
-  return cleaned || inferMiniMaxPlanLabelFromTotals(models) || "Coding Plan";
-}
-
 function getClaudePlanLabel(...candidates: Array<string | null | undefined>): string | null {
   for (const candidate of candidates) {
     if (typeof candidate !== "string") continue;
@@ -253,290 +220,6 @@ function getClaudePlanLabel(...candidates: Array<string | null | undefined>): st
     return trimmed;
   }
   return null;
-}
-
-function getMiniMaxQuotaResetAt(
-  model: JsonRecord,
-  capturedAtMs: number,
-  remainsTimeSnakeKey: string,
-  remainsTimeCamelKey: string,
-  endTimeSnakeKey: string,
-  endTimeCamelKey: string
-): string | null {
-  const remainsMs = toNumber(getFieldValue(model, remainsTimeSnakeKey, remainsTimeCamelKey), 0);
-  if (remainsMs > 0) {
-    return new Date(capturedAtMs + remainsMs).toISOString();
-  }
-
-  return parseResetTime(getFieldValue(model, endTimeSnakeKey, endTimeCamelKey));
-}
-
-function isMiniMaxTextQuotaModel(modelName: string): boolean {
-  const normalized = modelName.trim().toLowerCase();
-  return (
-    normalized.startsWith("minimax-m") ||
-    normalized.startsWith("coding-plan") ||
-    // MiniMax Coding Plan surfaces the text/coding quota under model "general"
-    // (media buckets like "video"/"image"/"music" are excluded).
-    normalized === "general"
-  );
-}
-
-function getMiniMaxSessionTotal(model: JsonRecord): number {
-  return Math.max(
-    0,
-    toNumber(getFieldValue(model, "current_interval_total_count", "currentIntervalTotalCount"), 0)
-  );
-}
-
-function getMiniMaxWeeklyTotal(model: JsonRecord): number {
-  return Math.max(
-    0,
-    toNumber(getFieldValue(model, "current_weekly_total_count", "currentWeeklyTotalCount"), 0)
-  );
-}
-
-function pickMiniMaxRepresentativeModel(
-  models: JsonRecord[],
-  getTotal: (model: JsonRecord) => number
-): JsonRecord | null {
-  const withQuota = models.filter((model) => getTotal(model) > 0);
-  const pool = withQuota.length > 0 ? withQuota : models;
-  if (pool.length === 0) return null;
-
-  return pool.reduce((best, current) => (getTotal(current) > getTotal(best) ? current : best));
-}
-
-function createMiniMaxQuotaFromCount(
-  total: number,
-  count: number,
-  resetAt: string | null,
-  countMeansRemaining: boolean
-): UsageQuota {
-  const used = countMeansRemaining ? Math.max(total - count, 0) : count;
-  return createQuotaFromUsage(used, total, resetAt);
-}
-
-/**
- * MiniMax Coding Plan exposes per-window remaining as a 0–100 percent
- * (`current_interval_remaining_percent` / `current_weekly_remaining_percent`)
- * with zero request counts. Read it defensively (string-encoded numbers ok).
- */
-function getMiniMaxRemainingPercent(
-  model: JsonRecord,
-  snakeKey: string,
-  camelKey: string
-): number | null {
-  const raw = getFieldValue(model, snakeKey, camelKey);
-  if (raw === null || raw === undefined || raw === "") return null;
-  const parsed = toNumber(raw, NaN);
-  return Number.isFinite(parsed) ? Math.max(0, Math.min(100, parsed)) : null;
-}
-
-/** Build a 0–100 percent-based window quota (used = 100 − remaining). */
-function createMiniMaxQuotaFromPercent(
-  remainingPercent: number,
-  resetAt: string | null
-): UsageQuota {
-  const clamped = Math.max(0, Math.min(100, remainingPercent));
-  return createQuotaFromUsage(100 - clamped, 100, resetAt);
-}
-
-/**
- * Build one MiniMax usage window (session or weekly) from the representative
- * model. Token Plan keys report request counts (`*_total_count`); Coding Plan
- * keys report zero counts and a `*_remaining_percent` instead — fall back to
- * that so the Coding Plan still surfaces a quota. The percent signal is keyed
- * off "counts == 0 + percent present", NOT the endpoint URL, because the
- * `token_plan/remains` and `coding_plan/remains` endpoints return identical
- * Coding-Plan payloads for a Coding Plan key.
- */
-function buildMiniMaxWindow(
-  models: JsonRecord[],
-  getTotal: (model: JsonRecord) => number,
-  usageCountKeys: [string, string],
-  percentKeys: [string, string],
-  resetKeys: [string, string, string, string],
-  capturedAtMs: number,
-  countMeansRemaining: boolean
-): UsageQuota | null {
-  const model = pickMiniMaxRepresentativeModel(models, getTotal);
-  if (!model) return null;
-
-  const resetAt = getMiniMaxQuotaResetAt(model, capturedAtMs, ...resetKeys);
-  const total = getTotal(model);
-
-  if (total > 0) {
-    const count = Math.max(0, toNumber(getFieldValue(model, ...usageCountKeys), 0));
-    return createMiniMaxQuotaFromCount(total, count, resetAt, countMeansRemaining);
-  }
-
-  const remainingPercent = getMiniMaxRemainingPercent(model, ...percentKeys);
-  return remainingPercent !== null
-    ? createMiniMaxQuotaFromPercent(remainingPercent, resetAt)
-    : null;
-}
-
-function getMiniMaxAuthErrorMessage(message: string): string {
-  const normalized = message.toLowerCase();
-  if (
-    normalized.includes("token plan") ||
-    normalized.includes("coding plan") ||
-    normalized.includes("active period") ||
-    normalized.includes("invalid api key") ||
-    normalized.includes("invalid key") ||
-    normalized.includes("subscription")
-  ) {
-    return "MiniMax Token Plan API key invalid or inactive. Use an active Token Plan key.";
-  }
-
-  return "MiniMax access denied. Confirm the key is an active Token Plan API key.";
-}
-
-function getMiniMaxErrorSummary(status: number, message: string): string {
-  const compact = message.replace(/\s+/g, " ").trim();
-  if (!compact) {
-    return `MiniMax usage endpoint error (${status}).`;
-  }
-  if (compact.length <= 160) {
-    return `MiniMax usage endpoint error (${status}): ${compact}`;
-  }
-  return `MiniMax usage endpoint error (${status}): ${compact.slice(0, 157)}...`;
-}
-
-async function getMiniMaxUsage(apiKey: string, provider: "minimax" | "minimax-cn") {
-  if (!apiKey) {
-    return { message: "MiniMax API key not available. Add a Token Plan API key." };
-  }
-
-  const usageUrls = MINIMAX_USAGE_CONFIG[provider].usageUrls;
-  let lastErrorMessage = "";
-
-  for (let index = 0; index < usageUrls.length; index += 1) {
-    const usageUrl = usageUrls[index];
-    const canFallback = index < usageUrls.length - 1;
-
-    try {
-      const response = await fetch(usageUrl, {
-        method: "GET",
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          Accept: "application/json",
-          "Content-Type": "application/json",
-        },
-      });
-
-      const rawText = await response.text();
-      let payload: JsonRecord = {};
-      if (rawText) {
-        try {
-          payload = toRecord(JSON.parse(rawText));
-        } catch {
-          payload = {};
-        }
-      }
-
-      const baseResp = toRecord(getFieldValue(payload, "base_resp", "baseResp"));
-      const apiStatusCode = toNumber(getFieldValue(baseResp, "status_code", "statusCode"), 0);
-      const apiStatusMessage = String(
-        getFieldValue(baseResp, "status_msg", "statusMsg") ?? ""
-      ).trim();
-      const combinedMessage = `${apiStatusMessage} ${rawText}`.trim();
-      const authLikeStatusMessage =
-        /token plan|coding plan|invalid api key|invalid key|unauthorized|inactive/i;
-
-      if (
-        response.status === 401 ||
-        response.status === 403 ||
-        apiStatusCode === 1004 ||
-        authLikeStatusMessage.test(apiStatusMessage)
-      ) {
-        return { message: getMiniMaxAuthErrorMessage(apiStatusMessage || combinedMessage) };
-      }
-
-      if (!response.ok) {
-        lastErrorMessage = getMiniMaxErrorSummary(response.status, combinedMessage);
-        if (
-          (response.status === 404 || response.status === 405 || response.status >= 500) &&
-          canFallback
-        ) {
-          continue;
-        }
-        return { message: `MiniMax connected. ${lastErrorMessage}` };
-      }
-
-      if (rawText && Object.keys(payload).length === 0) {
-        return { message: "MiniMax connected. Unable to parse usage response." };
-      }
-
-      if (apiStatusCode !== 0) {
-        if (apiStatusMessage) {
-          return { message: `MiniMax connected. ${apiStatusMessage}` };
-        }
-        return { message: "MiniMax connected. Upstream quota API returned an error." };
-      }
-
-      const capturedAtMs = Date.now();
-      const modelRemains = getFieldValue(payload, "model_remains", "modelRemains");
-      const allModels = Array.isArray(modelRemains)
-        ? modelRemains.map((item) => toRecord(item))
-        : [];
-      const textModels = allModels.filter((model) => {
-        const modelName = String(getFieldValue(model, "model_name", "modelName") ?? "");
-        return isMiniMaxTextQuotaModel(modelName);
-      });
-
-      if (textModels.length === 0) {
-        return { message: "MiniMax connected. No text quota data was returned." };
-      }
-
-      const countMeansRemaining = usageUrl.includes("/coding_plan/remains");
-      const quotas: Record<string, UsageQuota> = {};
-
-      const sessionQuota = buildMiniMaxWindow(
-        textModels,
-        getMiniMaxSessionTotal,
-        ["current_interval_usage_count", "currentIntervalUsageCount"],
-        ["current_interval_remaining_percent", "currentIntervalRemainingPercent"],
-        ["remains_time", "remainsTime", "end_time", "endTime"],
-        capturedAtMs,
-        countMeansRemaining
-      );
-      if (sessionQuota) {
-        quotas["session (5h)"] = sessionQuota;
-      }
-
-      const weeklyQuota = buildMiniMaxWindow(
-        textModels,
-        getMiniMaxWeeklyTotal,
-        ["current_weekly_usage_count", "currentWeeklyUsageCount"],
-        ["current_weekly_remaining_percent", "currentWeeklyRemainingPercent"],
-        ["weekly_remains_time", "weeklyRemainsTime", "weekly_end_time", "weeklyEndTime"],
-        capturedAtMs,
-        countMeansRemaining
-      );
-      if (weeklyQuota) {
-        quotas["weekly (7d)"] = weeklyQuota;
-      }
-
-      if (Object.keys(quotas).length === 0) {
-        return { message: "MiniMax connected. Unable to extract text quota usage." };
-      }
-
-      return { plan: getMiniMaxPlanLabel(payload, textModels), quotas };
-    } catch (error) {
-      lastErrorMessage = (error as Error).message;
-      if (!canFallback) {
-        break;
-      }
-    }
-  }
-
-  return {
-    message: lastErrorMessage
-      ? `MiniMax connected. Unable to fetch usage: ${lastErrorMessage}`
-      : "MiniMax connected. Unable to fetch usage.",
-  };
 }
 
 // CrofAI surfaces a tiny endpoint with two signals:

--- a/open-sse/services/usage/minimax.ts
+++ b/open-sse/services/usage/minimax.ts
@@ -1,0 +1,346 @@
+/**
+ * usage/minimax.ts — MiniMax (minimax / minimax-cn) usage fetcher + quota helpers.
+ *
+ * Extracted from services/usage.ts (god-file decomposition): the full MiniMax family —
+ * plan-label inference, per-window quota assembly, and the getMiniMaxUsage fetcher that
+ * probes the coding-plan remains endpoints. Depends only on the sibling scalar/quota
+ * leaves — no host coupling — so it lives as a co-located provider leaf. usage.ts imports
+ * getMiniMaxUsage (dispatcher) + getMiniMaxPlanLabel/getMiniMaxSessionTotal (__testing).
+ * Behavior-preserving move.
+ */
+
+import { toRecord, toNumber, getFieldValue, pickFirstNonEmptyString } from "./scalars.ts";
+import { type UsageQuota, parseResetTime, createQuotaFromUsage } from "./quota.ts";
+
+type JsonRecord = Record<string, unknown>;
+
+const MINIMAX_USAGE_CONFIG = {
+  minimax: {
+    usageUrls: [
+      "https://www.minimax.io/v1/token_plan/remains",
+      "https://api.minimax.io/v1/api/openplatform/coding_plan/remains",
+    ],
+  },
+  "minimax-cn": {
+    usageUrls: [
+      "https://www.minimaxi.com/v1/api/openplatform/coding_plan/remains",
+      "https://api.minimaxi.com/v1/api/openplatform/coding_plan/remains",
+    ],
+  },
+} as const;
+
+export function inferMiniMaxPlanLabelFromTotals(models: JsonRecord[]): string | null {
+  const maxSessionTotal = models.reduce(
+    (maxTotal, model) => Math.max(maxTotal, getMiniMaxSessionTotal(model)),
+    0
+  );
+
+  if (maxSessionTotal >= 15_000) return "Max";
+  if (maxSessionTotal >= 4_500) return "Plus";
+  if (maxSessionTotal >= 1_500) return "Starter";
+  return null;
+}
+
+export function getMiniMaxPlanLabel(payload: JsonRecord, models: JsonRecord[] = []): string {
+  const raw = pickFirstNonEmptyString(
+    getFieldValue(payload, "current_subscribe_title", "currentSubscribeTitle"),
+    getFieldValue(payload, "plan_name", "planName"),
+    getFieldValue(payload, "plan", "plan"),
+    getFieldValue(payload, "current_plan_title", "currentPlanTitle"),
+    getFieldValue(payload, "combo_title", "comboTitle")
+  );
+
+  if (!raw) return inferMiniMaxPlanLabelFromTotals(models) || "Coding Plan";
+
+  const cleaned = raw
+    .replace(/^minimax\s+/i, "")
+    .replace(/\bcoding\s+plan\b/gi, "")
+    .replace(/\s{2,}/g, " ")
+    .trim();
+
+  return cleaned || inferMiniMaxPlanLabelFromTotals(models) || "Coding Plan";
+}
+
+export function getMiniMaxQuotaResetAt(
+  model: JsonRecord,
+  capturedAtMs: number,
+  remainsTimeSnakeKey: string,
+  remainsTimeCamelKey: string,
+  endTimeSnakeKey: string,
+  endTimeCamelKey: string
+): string | null {
+  const remainsMs = toNumber(getFieldValue(model, remainsTimeSnakeKey, remainsTimeCamelKey), 0);
+  if (remainsMs > 0) {
+    return new Date(capturedAtMs + remainsMs).toISOString();
+  }
+
+  return parseResetTime(getFieldValue(model, endTimeSnakeKey, endTimeCamelKey));
+}
+
+export function isMiniMaxTextQuotaModel(modelName: string): boolean {
+  const normalized = modelName.trim().toLowerCase();
+  return (
+    normalized.startsWith("minimax-m") ||
+    normalized.startsWith("coding-plan") ||
+    // MiniMax Coding Plan surfaces the text/coding quota under model "general"
+    // (media buckets like "video"/"image"/"music" are excluded).
+    normalized === "general"
+  );
+}
+
+export function getMiniMaxSessionTotal(model: JsonRecord): number {
+  return Math.max(
+    0,
+    toNumber(getFieldValue(model, "current_interval_total_count", "currentIntervalTotalCount"), 0)
+  );
+}
+
+export function getMiniMaxWeeklyTotal(model: JsonRecord): number {
+  return Math.max(
+    0,
+    toNumber(getFieldValue(model, "current_weekly_total_count", "currentWeeklyTotalCount"), 0)
+  );
+}
+
+function pickMiniMaxRepresentativeModel(
+  models: JsonRecord[],
+  getTotal: (model: JsonRecord) => number
+): JsonRecord | null {
+  const withQuota = models.filter((model) => getTotal(model) > 0);
+  const pool = withQuota.length > 0 ? withQuota : models;
+  if (pool.length === 0) return null;
+
+  return pool.reduce((best, current) => (getTotal(current) > getTotal(best) ? current : best));
+}
+
+export function createMiniMaxQuotaFromCount(
+  total: number,
+  count: number,
+  resetAt: string | null,
+  countMeansRemaining: boolean
+): UsageQuota {
+  const used = countMeansRemaining ? Math.max(total - count, 0) : count;
+  return createQuotaFromUsage(used, total, resetAt);
+}
+
+/**
+ * MiniMax Coding Plan exposes per-window remaining as a 0–100 percent
+ * (`current_interval_remaining_percent` / `current_weekly_remaining_percent`)
+ * with zero request counts. Read it defensively (string-encoded numbers ok).
+ */
+export function getMiniMaxRemainingPercent(
+  model: JsonRecord,
+  snakeKey: string,
+  camelKey: string
+): number | null {
+  const raw = getFieldValue(model, snakeKey, camelKey);
+  if (raw === null || raw === undefined || raw === "") return null;
+  const parsed = toNumber(raw, NaN);
+  return Number.isFinite(parsed) ? Math.max(0, Math.min(100, parsed)) : null;
+}
+
+/** Build a 0–100 percent-based window quota (used = 100 − remaining). */
+export function createMiniMaxQuotaFromPercent(
+  remainingPercent: number,
+  resetAt: string | null
+): UsageQuota {
+  const clamped = Math.max(0, Math.min(100, remainingPercent));
+  return createQuotaFromUsage(100 - clamped, 100, resetAt);
+}
+
+/**
+ * Build one MiniMax usage window (session or weekly) from the representative
+ * model. Token Plan keys report request counts (`*_total_count`); Coding Plan
+ * keys report zero counts and a `*_remaining_percent` instead — fall back to
+ * that so the Coding Plan still surfaces a quota. The percent signal is keyed
+ * off "counts == 0 + percent present", NOT the endpoint URL, because the
+ * `token_plan/remains` and `coding_plan/remains` endpoints return identical
+ * Coding-Plan payloads for a Coding Plan key.
+ */
+function buildMiniMaxWindow(
+  models: JsonRecord[],
+  getTotal: (model: JsonRecord) => number,
+  usageCountKeys: [string, string],
+  percentKeys: [string, string],
+  resetKeys: [string, string, string, string],
+  capturedAtMs: number,
+  countMeansRemaining: boolean
+): UsageQuota | null {
+  const model = pickMiniMaxRepresentativeModel(models, getTotal);
+  if (!model) return null;
+
+  const resetAt = getMiniMaxQuotaResetAt(model, capturedAtMs, ...resetKeys);
+  const total = getTotal(model);
+
+  if (total > 0) {
+    const count = Math.max(0, toNumber(getFieldValue(model, ...usageCountKeys), 0));
+    return createMiniMaxQuotaFromCount(total, count, resetAt, countMeansRemaining);
+  }
+
+  const remainingPercent = getMiniMaxRemainingPercent(model, ...percentKeys);
+  return remainingPercent !== null
+    ? createMiniMaxQuotaFromPercent(remainingPercent, resetAt)
+    : null;
+}
+
+export function getMiniMaxAuthErrorMessage(message: string): string {
+  const normalized = message.toLowerCase();
+  if (
+    normalized.includes("token plan") ||
+    normalized.includes("coding plan") ||
+    normalized.includes("active period") ||
+    normalized.includes("invalid api key") ||
+    normalized.includes("invalid key") ||
+    normalized.includes("subscription")
+  ) {
+    return "MiniMax Token Plan API key invalid or inactive. Use an active Token Plan key.";
+  }
+
+  return "MiniMax access denied. Confirm the key is an active Token Plan API key.";
+}
+
+export function getMiniMaxErrorSummary(status: number, message: string): string {
+  const compact = message.replace(/\s+/g, " ").trim();
+  if (!compact) {
+    return `MiniMax usage endpoint error (${status}).`;
+  }
+  if (compact.length <= 160) {
+    return `MiniMax usage endpoint error (${status}): ${compact}`;
+  }
+  return `MiniMax usage endpoint error (${status}): ${compact.slice(0, 157)}...`;
+}
+
+export async function getMiniMaxUsage(apiKey: string, provider: "minimax" | "minimax-cn") {
+  if (!apiKey) {
+    return { message: "MiniMax API key not available. Add a Token Plan API key." };
+  }
+
+  const usageUrls = MINIMAX_USAGE_CONFIG[provider].usageUrls;
+  let lastErrorMessage = "";
+
+  for (let index = 0; index < usageUrls.length; index += 1) {
+    const usageUrl = usageUrls[index];
+    const canFallback = index < usageUrls.length - 1;
+
+    try {
+      const response = await fetch(usageUrl, {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+      });
+
+      const rawText = await response.text();
+      let payload: JsonRecord = {};
+      if (rawText) {
+        try {
+          payload = toRecord(JSON.parse(rawText));
+        } catch {
+          payload = {};
+        }
+      }
+
+      const baseResp = toRecord(getFieldValue(payload, "base_resp", "baseResp"));
+      const apiStatusCode = toNumber(getFieldValue(baseResp, "status_code", "statusCode"), 0);
+      const apiStatusMessage = String(
+        getFieldValue(baseResp, "status_msg", "statusMsg") ?? ""
+      ).trim();
+      const combinedMessage = `${apiStatusMessage} ${rawText}`.trim();
+      const authLikeStatusMessage =
+        /token plan|coding plan|invalid api key|invalid key|unauthorized|inactive/i;
+
+      if (
+        response.status === 401 ||
+        response.status === 403 ||
+        apiStatusCode === 1004 ||
+        authLikeStatusMessage.test(apiStatusMessage)
+      ) {
+        return { message: getMiniMaxAuthErrorMessage(apiStatusMessage || combinedMessage) };
+      }
+
+      if (!response.ok) {
+        lastErrorMessage = getMiniMaxErrorSummary(response.status, combinedMessage);
+        if (
+          (response.status === 404 || response.status === 405 || response.status >= 500) &&
+          canFallback
+        ) {
+          continue;
+        }
+        return { message: `MiniMax connected. ${lastErrorMessage}` };
+      }
+
+      if (rawText && Object.keys(payload).length === 0) {
+        return { message: "MiniMax connected. Unable to parse usage response." };
+      }
+
+      if (apiStatusCode !== 0) {
+        if (apiStatusMessage) {
+          return { message: `MiniMax connected. ${apiStatusMessage}` };
+        }
+        return { message: "MiniMax connected. Upstream quota API returned an error." };
+      }
+
+      const capturedAtMs = Date.now();
+      const modelRemains = getFieldValue(payload, "model_remains", "modelRemains");
+      const allModels = Array.isArray(modelRemains)
+        ? modelRemains.map((item) => toRecord(item))
+        : [];
+      const textModels = allModels.filter((model) => {
+        const modelName = String(getFieldValue(model, "model_name", "modelName") ?? "");
+        return isMiniMaxTextQuotaModel(modelName);
+      });
+
+      if (textModels.length === 0) {
+        return { message: "MiniMax connected. No text quota data was returned." };
+      }
+
+      const countMeansRemaining = usageUrl.includes("/coding_plan/remains");
+      const quotas: Record<string, UsageQuota> = {};
+
+      const sessionQuota = buildMiniMaxWindow(
+        textModels,
+        getMiniMaxSessionTotal,
+        ["current_interval_usage_count", "currentIntervalUsageCount"],
+        ["current_interval_remaining_percent", "currentIntervalRemainingPercent"],
+        ["remains_time", "remainsTime", "end_time", "endTime"],
+        capturedAtMs,
+        countMeansRemaining
+      );
+      if (sessionQuota) {
+        quotas["session (5h)"] = sessionQuota;
+      }
+
+      const weeklyQuota = buildMiniMaxWindow(
+        textModels,
+        getMiniMaxWeeklyTotal,
+        ["current_weekly_usage_count", "currentWeeklyUsageCount"],
+        ["current_weekly_remaining_percent", "currentWeeklyRemainingPercent"],
+        ["weekly_remains_time", "weeklyRemainsTime", "weekly_end_time", "weeklyEndTime"],
+        capturedAtMs,
+        countMeansRemaining
+      );
+      if (weeklyQuota) {
+        quotas["weekly (7d)"] = weeklyQuota;
+      }
+
+      if (Object.keys(quotas).length === 0) {
+        return { message: "MiniMax connected. Unable to extract text quota usage." };
+      }
+
+      return { plan: getMiniMaxPlanLabel(payload, textModels), quotas };
+    } catch (error) {
+      lastErrorMessage = (error as Error).message;
+      if (!canFallback) {
+        break;
+      }
+    }
+  }
+
+  return {
+    message: lastErrorMessage
+      ? `MiniMax connected. Unable to fetch usage: ${lastErrorMessage}`
+      : "MiniMax connected. Unable to fetch usage.",
+  };
+}

--- a/scripts/check/check-public-creds.mjs
+++ b/scripts/check/check-public-creds.mjs
@@ -81,15 +81,17 @@ const ENV_KEY_RE = /(clientId|clientSecret|apiKey)Env\s*:/;
 //
 // 6A.8: Expanded scope to open-sse/** + src/lib/oauth/**. Newly discovered FPs:
 //
-//   open-sse/services/usage.ts L499: `getMiniMaxUsage(apiKey: string, provider: "minimax" | "minimax-cn")`
+//   open-sse/services/usage/minimax.ts L213: `getMiniMaxUsage(apiKey: string, provider: "minimax" | "minimax-cn")`
 //   The CRED_KEY_RE matches `apiKey:` in the TypeScript function-parameter type annotation.
 //   "minimax" and "minimax-cn" are provider-name strings in the type annotation, NOT credentials.
 //   This is a false positive (the gate was designed for object-literal assignments, not fn params).
 //   TODO(6A.8): Consider tightening CRED_KEY_RE to exclude function-signature contexts — but
 //   that adds complexity; the FP rate is low (1 file). Frozen by file:line:value key.
+//   The MiniMax family was extracted from services/usage.ts into services/usage/minimax.ts
+//   (god-file decomposition), so the FP moved with the getMiniMaxUsage signature.
 export const KNOWN_LITERAL_CREDS = new Set([
-  "open-sse/services/usage.ts:504:minimax", // TODO(6A.8): pre-existing FP — TS fn-param type, not a credential (moved to 504 by OpenCode/Ollama + codebuddy-cn import insertions)
-  "open-sse/services/usage.ts:504:minimax-cn", // TODO(6A.8): pre-existing FP — TS fn-param type, not a credential (moved to 504 by OpenCode/Ollama + codebuddy-cn import insertions)
+  "open-sse/services/usage/minimax.ts:213:minimax", // TODO(6A.8): pre-existing FP — TS fn-param type, not a credential (getMiniMaxUsage signature)
+  "open-sse/services/usage/minimax.ts:213:minimax-cn", // TODO(6A.8): pre-existing FP — TS fn-param type, not a credential (getMiniMaxUsage signature)
 ]);
 
 /**

--- a/tests/unit/check-public-creds.test.ts
+++ b/tests/unit/check-public-creds.test.ts
@@ -23,10 +23,9 @@ test("flags a clientId behind a process.env fallback (env || literal)", () => {
 });
 
 test("flags clientSecret and apiKey literals too", () => {
-  const src = [
-    `clientSecret: "GOCSPX-secret-literal",`,
-    `apiKey: "AIzaSyLeakedFirebaseKey",`,
-  ].join("\n");
+  const src = [`clientSecret: "GOCSPX-secret-literal",`, `apiKey: "AIzaSyLeakedFirebaseKey",`].join(
+    "\n"
+  );
   const v = findLiteralCreds(src, new Set(), "x.ts");
   assert.equal(v.length, 2);
 });
@@ -41,7 +40,7 @@ test("does NOT flag resolvePublicCredMulti() with literal env-name args", () => 
   assert.deepEqual(findLiteralCreds(src, new Set(), "x.ts"), []);
 });
 
-test("does NOT flag empty-string fallback (process.env || \"\")", () => {
+test('does NOT flag empty-string fallback (process.env || "")', () => {
   const src = `clientIdDefault: process.env.GITLAB_OAUTH_CLIENT_ID || "",`;
   assert.deepEqual(findLiteralCreds(src, new Set(), "x.ts"), []);
 });
@@ -75,10 +74,7 @@ test("a NEW literal is still flagged even with the real frozen allowlist", () =>
 });
 
 test("real scanned files produce ZERO violations with the frozen allowlist (gate exits 0)", () => {
-  const scanned = [
-    "open-sse/config/providerRegistry.ts",
-    "src/lib/oauth/constants/oauth.ts",
-  ];
+  const scanned = ["open-sse/config/providerRegistry.ts", "src/lib/oauth/constants/oauth.ts"];
   for (const rel of scanned) {
     const src = fs.readFileSync(path.join(repoRoot, rel), "utf8") as string;
     const v = findLiteralCreds(src, KNOWN_LITERAL_CREDS, rel);
@@ -91,10 +87,7 @@ test("every frozen literal is actually present in a scanned file (no dead allowl
   // per-provider plugins (#3993), so providerRegistry.ts is now a re-export barrel;
   // entries keyed by an explicit `file:line:value` are checked against the file named
   // in the key (which is where the literal actually lives), not this anchor blob.
-  const anchorFiles = [
-    "open-sse/config/providerRegistry.ts",
-    "src/lib/oauth/constants/oauth.ts",
-  ];
+  const anchorFiles = ["open-sse/config/providerRegistry.ts", "src/lib/oauth/constants/oauth.ts"];
   const anchorBlob = anchorFiles
     .map((rel) => fs.readFileSync(path.join(repoRoot, rel), "utf8") as string)
     .join("\n");
@@ -107,9 +100,15 @@ test("every frozen literal is actually present in a scanned file (no dead allowl
       // match on file content rather than the exact line number.
       const file = entry.replace(/:\d+:.*$/, "");
       const src = fs.readFileSync(path.join(repoRoot, file), "utf8") as string;
-      assert.ok(src.includes(value), `frozen literal not found in its source file ${file}: ${value}`);
+      assert.ok(
+        src.includes(value),
+        `frozen literal not found in its source file ${file}: ${value}`
+      );
     } else {
-      assert.ok(anchorBlob.includes(value), `frozen literal not found in any anchor file: ${value}`);
+      assert.ok(
+        anchorBlob.includes(value),
+        `frozen literal not found in any anchor file: ${value}`
+      );
     }
   }
 });
@@ -127,8 +126,16 @@ test("with an empty allowlist the real scanned files surface zero violations (al
   ) as string;
   const regViolations = findLiteralCreds(reg, new Set(), "providerRegistry.ts");
   const oauthViolations = findLiteralCreds(oauth, new Set(), "oauth.ts");
-  assert.equal(regViolations.length, 0, `providerRegistry.ts should be clean, got: ${regViolations.join(", ")}`);
-  assert.equal(oauthViolations.length, 0, `oauth.ts should be clean, got: ${oauthViolations.join(", ")}`);
+  assert.equal(
+    regViolations.length,
+    0,
+    `providerRegistry.ts should be clean, got: ${regViolations.join(", ")}`
+  );
+  assert.equal(
+    oauthViolations.length,
+    0,
+    `oauth.ts should be clean, got: ${oauthViolations.join(", ")}`
+  );
 });
 
 // --- 6A.8: expanded scope (open-sse/** and src/lib/oauth/**) ---
@@ -164,21 +171,33 @@ test("6A.8 stale: known literal that was removed from the codebase is detected a
   const liveViolations = findLiteralCreds(src, new Set(), "file.ts");
   // The allowlist has an entry "old-literal" but it's not in live violations.
   const stale = (reportStale as (a: Set<string>, b: string[], c: string) => string[])(
-    new Set(["old-literal"]), liveViolations, "check-public-creds"
+    new Set(["old-literal"]),
+    liveViolations,
+    "check-public-creds"
   );
   assert.deepEqual(stale, ["old-literal"]);
 });
 
 test("6A.8: open-sse/services/usage.ts FP — function-signature apiKey is suppressed by allowlist", () => {
-  // open-sse/services/usage.ts L543: `getMiniMaxUsage(apiKey: string, provider: "minimax" | "minimax-cn")`
+  // open-sse/services/usage/minimax.ts L213: `getMiniMaxUsage(apiKey: string, provider: "minimax" | "minimax-cn")`
   // The CRED_KEY_RE matches `apiKey:` in the TypeScript function-parameter type annotation.
   // "minimax" and "minimax-cn" are provider-name strings in the type, NOT credentials.
-  // Frozen in KNOWN_LITERAL_CREDS as FPs by file:line:value key.
-  const realSrc = fs.readFileSync(path.join(repoRoot, "open-sse/services/usage.ts"), "utf8") as string;
+  // Frozen in KNOWN_LITERAL_CREDS as FPs by file:line:value key. The MiniMax family was
+  // extracted from services/usage.ts into services/usage/minimax.ts (god-file decomposition),
+  // so the FP moved with the getMiniMaxUsage signature.
+  const minimaxPath = "open-sse/services/usage/minimax.ts";
+  const realSrc = fs.readFileSync(path.join(repoRoot, minimaxPath), "utf8") as string;
   // With empty allowlist the FP shows up (it IS flagged by the regex).
-  const vWithEmpty = findLiteralCreds(realSrc, new Set(), "open-sse/services/usage.ts");
-  assert.ok(vWithEmpty.some((v) => v.includes("minimax")), `expected FP 'minimax' violations with empty allowlist, got: ${vWithEmpty.join(", ")}`);
+  const vWithEmpty = findLiteralCreds(realSrc, new Set(), minimaxPath);
+  assert.ok(
+    vWithEmpty.some((v) => v.includes("minimax")),
+    `expected FP 'minimax' violations with empty allowlist, got: ${vWithEmpty.join(", ")}`
+  );
   // With KNOWN_LITERAL_CREDS the FPs are suppressed.
-  const vWithAllowlist = findLiteralCreds(realSrc, KNOWN_LITERAL_CREDS, "open-sse/services/usage.ts");
-  assert.deepEqual(vWithAllowlist, [], `FP violations should be suppressed, got: ${vWithAllowlist.join(", ")}`);
+  const vWithAllowlist = findLiteralCreds(realSrc, KNOWN_LITERAL_CREDS, minimaxPath);
+  assert.deepEqual(
+    vWithAllowlist,
+    [],
+    `FP violations should be suppressed, got: ${vWithAllowlist.join(", ")}`
+  );
 });

--- a/tests/unit/usage-minimax-family-split.test.ts
+++ b/tests/unit/usage-minimax-family-split.test.ts
@@ -1,0 +1,49 @@
+// Characterization of the services/usage.ts MiniMax-family split (god-file decomposition): the full
+// MiniMax usage family (plan-label inference, per-window quota assembly, getMiniMaxUsage fetcher) moved
+// into services/usage/minimax.ts. Behavior-preserving move — these locks pin the module surface and a
+// couple of the pure helpers; the fetcher + quota math stay covered by minimax-coding-plan-usage and
+// usage-utils (which exercise them via usage.ts __testing).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+const M = await import("../../open-sse/services/usage/minimax.ts");
+const HOST = await import("../../open-sse/services/usage.ts");
+
+test("leaf exposes the twelve MiniMax helpers the host re-exposes via __testing", () => {
+  for (const name of [
+    "inferMiniMaxPlanLabelFromTotals",
+    "getMiniMaxPlanLabel",
+    "getMiniMaxQuotaResetAt",
+    "isMiniMaxTextQuotaModel",
+    "getMiniMaxSessionTotal",
+    "getMiniMaxWeeklyTotal",
+    "createMiniMaxQuotaFromCount",
+    "createMiniMaxQuotaFromPercent",
+    "getMiniMaxRemainingPercent",
+    "getMiniMaxAuthErrorMessage",
+    "getMiniMaxErrorSummary",
+    "getMiniMaxUsage",
+  ]) {
+    assert.equal(typeof (M as Record<string, unknown>)[name], "function", `missing ${name}`);
+  }
+});
+
+test("host __testing re-exports the same MiniMax function identities", () => {
+  const t = (HOST as Record<string, Record<string, unknown>>).__testing;
+  assert.equal(t.getMiniMaxUsage, M.getMiniMaxUsage);
+  assert.equal(t.getMiniMaxPlanLabel, M.getMiniMaxPlanLabel);
+  assert.equal(t.getMiniMaxSessionTotal, M.getMiniMaxSessionTotal);
+});
+
+test("getMiniMaxPlanLabel cleans the raw plan title, falls back by session totals", () => {
+  // explicit title wins, "MiniMax"/"Coding Plan" noise stripped
+  assert.equal(M.getMiniMaxPlanLabel({ plan_name: "MiniMax Max Coding Plan" }), "Max");
+  // no title → inferred from session totals (>= 15000 → Max)
+  assert.equal(M.getMiniMaxPlanLabel({}, [{ current_interval_total_count: 20000 }]), "Max");
+  // nothing → default
+  assert.equal(M.getMiniMaxPlanLabel({}, []), "Coding Plan");
+});
+
+test("isMiniMaxTextQuotaModel flags text models", () => {
+  assert.equal(typeof M.isMiniMaxTextQuotaModel("MiniMax-Text-01"), "boolean");
+});


### PR DESCRIPTION
## Contexto

Continua a decomposição do god-file `services/usage.ts` (Tier 2), sobre os leaves `scalars`/`quota` (já na release). Move a **família MiniMax completa** para um provider leaf co-localizado.

## Mudança

- **`services/usage/minimax.ts`** (novo, 346L) — família MiniMax inteira: inferência de plan-label, montagem de quota por-janela (session/weekly), o fetcher `getMiniMaxUsage` (sonda os endpoints coding-plan remains de `minimax`/`minimax-cn`) e `MINIMAX_USAGE_CONFIG`. Depende **apenas** dos leaves irmãos `scalars` + `quota` — sem acoplamento com o host.
- **`services/usage.ts`** (host) — reimporta as 12 funções MiniMax (dispatcher usa `getMiniMaxUsage`; o objeto `__testing` re-expõe as 12 aos testes). `getClaudePlanLabel` (intercalado, não-MiniMax) preservado. `3147 → 2817` linhas.

### Acoplamento cross-file tratado
O secret-scanner (`check-public-creds`) tinha 2 FPs congelados apontando para `usage.ts` — a assinatura `getMiniMaxUsage(apiKey: string, provider: "minimax" | "minimax-cn")` casa com `CRED_KEY_RE` (`"minimax"` é nome de provider no tipo, não credencial). Como a função migrou, atualizei a allowlist `KNOWN_LITERAL_CREDS` **e** o teste `6A.8` para `services/usage/minimax.ts:213`.

## Validação

- `typecheck:core` limpo · `eslint` 0/0 · `check:cycles` OK · `check:file-size` OK (leaf 346 < 800)
- `check:public-creds` OK + teste `6A.8` (19/19)
- regressão: `usage-utils` (47/47), `minimax-coding-plan-usage` (5/5), `usage-service-hardening` (24/24)
- `usage-minimax-family-split` (novo, 4/4) — surface + identidade do re-export `__testing`

> Independente; base release/v3.8.36 (scalars+quota já mergeados).