### PR TITLE
fix(quota): migração 107 ativa estratégia quota-share nos combos qtSd/ existentes [Fase 3 #9]

### DIFF
--- a/src/lib/db/migrations/107_quota_combos_quota_share_strategy.sql
+++ b/src/lib/db/migrations/107_quota_combos_quota_share_strategy.sql
@@ -1,0 +1,25 @@
+-- Migration 107: activate the dedicated quota-share strategy on existing qtSd/ combos
+--
+-- Fase 3 #9 introduced a dedicated "quota-share" routing strategy and changed
+-- syncQuotaCombos() to mint the auto-generated qtSd/ combos with it (replacing the
+-- previous "fill-first"). syncQuotaCombos only re-runs when a pool/connection is
+-- created or edited, so combos minted BEFORE the #9 deploy keep their old
+-- "fill-first" strategy and never exercise the new DRR + P2C + per-model gating
+-- engine. This migration aligns those pre-existing combos with the new default.
+--
+-- Scope is deliberately narrow:
+--   - name LIKE 'qtSd/%'              → only the auto-minted, hidden quota-share combos
+--   - strategy = 'fill-first'         → only the stale ones (leaves anything already
+--                                       on quota-share / a user-chosen strategy untouched)
+-- A user's own combo can never match 'qtSd/%' (that prefix is reserved for the
+-- quota-share engine), so no human-authored routing choice is overwritten.
+--
+-- Idempotent: re-running is a no-op once every qtSd/ combo is on quota-share.
+--
+-- Part of: Group B — Quota Sharing Engine, Fase 3 #9 (activation follow-up).
+
+UPDATE combos
+SET data = json_set(data, '$.strategy', 'quota-share'),
+    updated_at = datetime('now')
+WHERE name LIKE 'qtSd/%'
+  AND json_extract(data, '$.strategy') = 'fill-first';

--- a/tests/unit/migration-107-quota-share-strategy.test.ts
+++ b/tests/unit/migration-107-quota-share-strategy.test.ts
@@ -1,0 +1,140 @@
+/**
+ * tests/unit/migration-107-quota-share-strategy.test.ts
+ *
+ * Migration 107 flips the routing strategy of the existing auto-minted qtSd/ combos
+ * from the legacy "fill-first" to the dedicated "quota-share" engine (Fase 3 #9),
+ * WITHOUT touching combos already on quota-share or any user-authored combo.
+ *
+ * The migration is applied in isolation against an in-memory DB seeded with a mix
+ * of combos, so the assertions pin the exact WHERE scope (name LIKE 'qtSd/%' AND
+ * strategy = 'fill-first') and prove the other JSON fields are preserved.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import Database from "better-sqlite3";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MIGRATION_107 = fs.readFileSync(
+  path.join(__dirname, "../../src/lib/db/migrations/107_quota_combos_quota_share_strategy.sql"),
+  "utf-8"
+);
+
+interface TestDb {
+  exec: (sql: string) => unknown;
+  prepare: (sql: string) => {
+    run: (...p: unknown[]) => unknown;
+    get: (...p: unknown[]) => Record<string, unknown> | undefined;
+  };
+  close: () => void;
+}
+
+function makeDb(): TestDb {
+  const db = new Database(":memory:") as unknown as TestDb;
+  db.exec(
+    `CREATE TABLE combos (
+       id TEXT PRIMARY KEY,
+       name TEXT NOT NULL UNIQUE,
+       data TEXT NOT NULL,
+       created_at TEXT NOT NULL,
+       updated_at TEXT NOT NULL
+     );`
+  );
+  return db;
+}
+
+function insertCombo(db: TestDb, id: string, name: string, strategy: string): void {
+  const data = JSON.stringify({
+    name,
+    strategy,
+    models: [{ kind: "model", model: "p/m", weight: 100 }],
+    isHidden: name.startsWith("qtSd/"),
+  });
+  db.prepare(
+    "INSERT INTO combos (id, name, data, created_at, updated_at) VALUES (?, ?, ?, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')"
+  ).run(id, name, data);
+}
+
+function strategyOf(db: TestDb, name: string): string | null {
+  const row = db
+    .prepare("SELECT json_extract(data, '$.strategy') AS s FROM combos WHERE name = ?")
+    .get(name);
+  return (row?.s as string | undefined) ?? null;
+}
+
+function dataOf(db: TestDb, name: string): Record<string, unknown> {
+  const row = db.prepare("SELECT data FROM combos WHERE name = ?").get(name);
+  return JSON.parse(row!.data as string) as Record<string, unknown>;
+}
+
+test("107 flips stale qtSd/ fill-first combos to quota-share", () => {
+  const db = makeDb();
+  insertCombo(db, "c1", "qtSd/grp/deepseek/deepseek-v4-flash", "fill-first");
+  insertCombo(db, "c2", "qtSd/grp/claude/claude-opus-4-8", "fill-first");
+
+  db.exec(MIGRATION_107);
+
+  assert.equal(strategyOf(db, "qtSd/grp/deepseek/deepseek-v4-flash"), "quota-share");
+  assert.equal(strategyOf(db, "qtSd/grp/claude/claude-opus-4-8"), "quota-share");
+  db.close();
+});
+
+test("107 preserves the other JSON fields (only strategy changes)", () => {
+  const db = makeDb();
+  insertCombo(db, "c1", "qtSd/grp/glm/glm-5", "fill-first");
+
+  db.exec(MIGRATION_107);
+
+  const data = dataOf(db, "qtSd/grp/glm/glm-5");
+  assert.equal(data.strategy, "quota-share");
+  assert.equal(data.isHidden, true, "isHidden must be preserved");
+  assert.deepEqual(
+    data.models,
+    [{ kind: "model", model: "p/m", weight: 100 }],
+    "models array must be preserved"
+  );
+  db.close();
+});
+
+test("107 leaves qtSd/ combos already on quota-share untouched", () => {
+  const db = makeDb();
+  insertCombo(db, "c1", "qtSd/grp/glm/glm-4.6", "quota-share");
+
+  db.exec(MIGRATION_107);
+
+  assert.equal(strategyOf(db, "qtSd/grp/glm/glm-4.6"), "quota-share");
+  db.close();
+});
+
+test("107 never touches user-authored (non-qtSd/) combos", () => {
+  const db = makeDb();
+  insertCombo(db, "c1", "my-coding-combo", "fill-first");
+  insertCombo(db, "c2", "team/fast", "fill-first");
+
+  db.exec(MIGRATION_107);
+
+  assert.equal(
+    strategyOf(db, "my-coding-combo"),
+    "fill-first",
+    "a user's fill-first combo must be preserved"
+  );
+  assert.equal(strategyOf(db, "team/fast"), "fill-first");
+  db.close();
+});
+
+test("107 is idempotent (second run is a no-op)", () => {
+  const db = makeDb();
+  insertCombo(db, "c1", "qtSd/grp/minimax/MiniMax-M2.7", "fill-first");
+
+  db.exec(MIGRATION_107);
+  const afterFirst = dataOf(db, "qtSd/grp/minimax/MiniMax-M2.7");
+  db.exec(MIGRATION_107);
+  const afterSecond = dataOf(db, "qtSd/grp/minimax/MiniMax-M2.7");
+
+  assert.equal(strategyOf(db, "qtSd/grp/minimax/MiniMax-M2.7"), "quota-share");
+  assert.deepEqual(afterFirst, afterSecond, "second run must not change the row");
+  db.close();
+});


### PR DESCRIPTION
## Problema
O #9 (#4939) introduziu a estratégia dedicada **quota-share** (DRR + P2C + gating per-model) e mudou `syncQuotaCombos()` para mintar os combos `qtSd/` com ela (antes era `fill-first`). Mas `syncQuotaCombos()` só re-minta ao **criar/editar um pool/conexão** — os combos `qtSd/` já existentes ficaram em `fill-first` e **nunca exercitavam o engine novo**. Faltou uma migração de dados no #4939.

## Correção
Migração `107` faz `UPDATE` `fill-first → quota-share` apenas nos combos cujo `name LIKE 'qtSd/%'` (o prefixo reservado dos auto-mintados/hidden), preservando qualquer combo do usuário e os já em `quota-share`. Idempotente.

## Validação live (VPS)
Antes: **76** combos `fill-first`. Depois: **76** `quota-share`. O roteamento dos `qtSd/` passou a logar:
\`\`\`
Combo "qtSd/chinas/deepseek/deepseek-v4-flash" [quota-share] with 1 models
Quota-share ordering: deepseek/deepseek-v4-flash (...) selected (DRR+P2C)
\`\`\`

## Testes (TDD)
`tests/unit/migration-107-quota-share-strategy.test.ts` — flip, preservação dos demais campos JSON, não-toca-quota-share, não-toca-combo-do-usuário, idempotência. Red-check confirmado (3 testes falham com a migração neutralizada).