### PR TITLE
fix(dashboard): restore home provider-topology card hidden by #4596 default

### DIFF
--- a/src/app/(dashboard)/dashboard/HomePageClient.tsx
+++ b/src/app/(dashboard)/dashboard/HomePageClient.tsx
@@ -14,6 +14,7 @@ import { copyToClipboard } from "@/shared/utils/clipboard";
 import { getProviderDisplayLabel } from "@/shared/utils/providerDisplayLabel";
 import { useIsElectron, useOpenExternal } from "@/shared/hooks/useElectron";
 import { HomeProviderTopologySection } from "./HomeProviderTopologySection";
+import { shouldShowProviderTopologyOnHome } from "./homeAppearance";
 
 const ProviderQuotaWidget = dynamic(() => import("../home/ProviderQuotaWidget"), { ssr: false });
 import type { NewsAnnouncement } from "@/shared/utils/releaseNotes";
@@ -218,9 +219,15 @@ export default function HomePageClient({ machineId }: HomePageClientProps) {
           if (typeof data.showQuickStartOnHome === "boolean") {
             setShowQuickStartOnHome(data.showQuickStartOnHome);
           }
-          if (typeof data.showProviderTopologyOnHome === "boolean") {
-            setShowProviderTopologyOnHome(data.showProviderTopologyOnHome);
-          }
+          // #4596 regression fix: the topology card defaults ON (matches the
+          // AppearanceTab toggle's `!== false`). Honoring only an explicit boolean
+          // left the card hidden whenever the setting was never persisted
+          // (undefined), silently removing it for most installs. The live-WS
+          // connection is still gated by `appearanceSettingsLoaded` in the data
+          // effect, so it is never opened before settings load.
+          setShowProviderTopologyOnHome(
+            shouldShowProviderTopologyOnHome(data.showProviderTopologyOnHome)
+          );
           if (typeof data.autoRefreshProviderQuota === "boolean") {
             setAutoRefreshProviderQuota(data.autoRefreshProviderQuota);
           }

--- a/src/app/(dashboard)/dashboard/homeAppearance.ts
+++ b/src/app/(dashboard)/dashboard/homeAppearance.ts
@@ -1,0 +1,18 @@
+// Appearance-flag resolution for the home dashboard.
+//
+// Regression context (#4596 → restored here): the home provider-topology card
+// (the ReactFlow connection map) defaults ON — the AppearanceTab toggle reads it
+// as `settings.showProviderTopologyOnHome !== false`. #4596 made HomePageClient
+// initialize the flag to `false` and only flip it when the API returned an
+// explicit boolean, so any install that never persisted the setting (the common
+// case → the field is `undefined`) kept the card hidden forever, contradicting
+// the AppearanceTab toggle. This helper centralizes the default-ON semantics so
+// both surfaces agree: absent ⇒ show, explicit `false` ⇒ hide, explicit `true` ⇒ show.
+
+/**
+ * Whether the home provider-topology card should render.
+ * Defaults ON; only an explicit `false` hides it (mirrors AppearanceTab).
+ */
+export function shouldShowProviderTopologyOnHome(setting: unknown): boolean {
+  return setting !== false;
+}

--- a/tests/unit/home-provider-topology-default-4596.test.ts
+++ b/tests/unit/home-provider-topology-default-4596.test.ts
@@ -1,0 +1,27 @@
+// Regression guard for #4596: the home provider-topology card (ReactFlow connection
+// map) vanished for installs that never persisted `showProviderTopologyOnHome`.
+// HomePageClient initialized the flag to `false` and only flipped it on an explicit
+// boolean from /api/settings, so an absent (undefined) setting kept the card hidden
+// forever — while AppearanceTab still showed the toggle as ON (`!== false`).
+// The card defaults ON; only an explicit `false` hides it.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { shouldShowProviderTopologyOnHome } from "../../src/app/(dashboard)/dashboard/homeAppearance.ts";
+
+test("absent setting (undefined) shows the topology card — the #4596 regression", () => {
+  assert.equal(shouldShowProviderTopologyOnHome(undefined), true);
+});
+
+test("explicit false hides the topology card (respects opt-out)", () => {
+  assert.equal(shouldShowProviderTopologyOnHome(false), false);
+});
+
+test("explicit true shows the topology card", () => {
+  assert.equal(shouldShowProviderTopologyOnHome(true), true);
+});
+
+test("non-boolean truthy/absent values keep the default-on behavior", () => {
+  // null (e.g. JSON null) and missing keys must not hide the card — only `false` does.
+  assert.equal(shouldShowProviderTopologyOnHome(null), true);
+});


### PR DESCRIPTION
## Problema
O card do mapa de conexões (ReactFlow, `HomeProviderTopologySection`) sumiu da home para instalações que nunca persistiram `showProviderTopologyOnHome`.

## Causa
#4596 inicializou a flag em `HomePageClient` como `false` e só a ligava quando `/api/settings` devolvia um booleano **explícito**. Com o setting ausente (`undefined` — caso comum), o `setState` nunca era chamado → card escondido permanentemente — embora o AppearanceTab mostre o toggle como ON (`settings.showProviderTopologyOnHome !== false`).

## Fix
Helper `shouldShowProviderTopologyOnHome()` com semântica default-ON (ausente ⇒ mostra, `false` explícito ⇒ esconde, `true` ⇒ mostra), usado no leitor de settings. A intenção do #4596 (não abrir a conexão live-WS antes de carregar settings) é preservada pelo guard `appearanceSettingsLoaded` no efeito de dados.

## Testes (Rule #18)
- `tests/unit/home-provider-topology-default-4596.test.ts` (4/4) — regressão: undefined⇒mostra, false⇒esconde, true⇒mostra, null⇒mostra.
- Suítes relacionadas verdes: appearance-widget-settings-schema (7), home-page-client-hook-imports-4759 (2). typecheck:core limpo, lint 0 erros, file-size OK.