### PR TITLE
fix(build): drop @omniroute/open-sse from optimizePackageImports (build OOM)

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -113,6 +113,17 @@ const nextConfig = {
     // PR-2 of diegosouzapw/OmniRoute#3932: tree-shake barrel re-exports so
     // route bundles don't pull in 14 locale files, every lucide-react icon,
     // or the full date-fns surface when only one helper is used.
+    //
+    // NOTE: this list must only contain EXTERNAL barrel libraries. Do NOT add
+    // the internal `@omniroute/open-sse` workspace here: optimizePackageImports
+    // makes Next.js resolve every export of the package's barrel at build time,
+    // and open-sse's `index.ts` re-exports the entire streaming engine
+    // (executors/translators/services/handlers/mcp-server — thousands of
+    // modules). Combined with the #3501 god-file splits (which multiplied the
+    // re-export edges), this drove the webpack production pass into a heap
+    // runaway that OOM'd even at a 28 GB --max-old-space-size (RSS pinned at the
+    // ceiling in a GC death-spiral). Removing it keeps the build's heap bounded.
+    // optimizePackageImports is designed for external libs, not workspaces.
     optimizePackageImports: [
       "lobehub/icons",
       "@lobehub/icons",
@@ -122,7 +133,6 @@ const nextConfig = {
       "lodash-es",
       "material-symbols",
       "next-intl",
-      "@omniroute/open-sse",
     ],
   },
   outputFileTracingRoot: projectRoot,

--- a/tests/unit/next-config.test.ts
+++ b/tests/unit/next-config.test.ts
@@ -232,3 +232,22 @@ test("next-intl webpack hook preserves caller config and filters known extractor
     false
   );
 });
+
+test("optimizePackageImports excludes the internal @omniroute/open-sse workspace (build-OOM guard)", async () => {
+  // Regression guard: adding the internal `@omniroute/open-sse` workspace to
+  // optimizePackageImports makes Next.js resolve its entire barrel at build
+  // time, driving the webpack production pass into a heap runaway that OOM'd
+  // even at 28 GB. optimizePackageImports is for EXTERNAL barrel libs only.
+  const { default: nextConfig } = await loadNextConfig("optimize-pkg-imports");
+  const list = nextConfig.experimental?.optimizePackageImports ?? [];
+
+  assert.ok(Array.isArray(list), "optimizePackageImports should be an array");
+  assert.ok(
+    !list.includes("@omniroute/open-sse"),
+    "do NOT add the internal @omniroute/open-sse workspace to optimizePackageImports — it OOMs the production build"
+  );
+  // The intended external barrel libs must remain optimized.
+  for (const lib of ["lucide-react", "date-fns", "next-intl"]) {
+    assert.ok(list.includes(lib), `expected external barrel lib ${lib} to stay optimized`);
+  }
+});


### PR DESCRIPTION
## Problema
`npm run build:release` (caminho local) passou a **estourar a memória** (`Ineffective mark-compacts near heap limit — JavaScript heap out of memory`) durante a fase `Creating an optimized production build`, em todos os tetos testados (4 / 8 / 16 / 28 GB).

## Causa-raiz
`experimental.optimizePackageImports` faz o Next.js **resolver todo o barrel de cada pacote da lista em build-time** para reescrever imports em granular. A feature é para **libs externas de barrel** (lucide-react, date-fns, lodash, next-intl — que continuam na lista). Mas o **workspace interno `@omniroute/open-sse`** havia sido adicionado: o `index.ts` dele re-exporta o engine inteiro (executors/translators/services/handlers/mcp-server — milhares de módulos). Resolver esse barrel inteiro joga o webpack num runaway de heap.

Os **god-file splits do #3501** (que transformaram arquivos únicos em `index + famílias`) **multiplicaram as arestas de re-export** do barrel, cruzando o limite que antes (por pouco) cabia. `next.config.mjs` e dependências **não mudaram** — era bomba latente.

## Evidência experimental (differential loop, nesta máquina)
| Config | Trajetória de heap | Resultado |
|---|---|---|
| **COM** `@omniroute/open-sse` | RSS pina no teto (28 GB), GC "last resort" sem progredir | death-spiral / OOM mesmo a 28 GB |
| **SEM** `@omniroute/open-sse` | heap limitado, GC reclamando (ex.: 25.7→20.6 GB), build progride ~40 min | bounded (OOM só quando o teto era baixo demais) |

## Fix
Remover `@omniroute/open-sse` do `optimizePackageImports`. Tree-shaking do open-sse continua normal pelo webpack — isto só desliga o otimizador de barrel (mal-aplicado a um workspace interno).

## Validação (Rule #18)
- Guard test em `tests/unit/next-config.test.ts` (5/5): asserta que o workspace interno nunca seja re-adicionado e que as libs externas (lucide-react/date-fns/next-intl) sigam otimizadas — falha se `@omniroute/open-sse` voltar à lista.
- Medição em ambiente real documentada acima (heap bounded vs runaway).

## Follow-up separado (não neste PR)
O build ainda é pesado (~16-20 GB de heap) por ser um monorepo grande, contra o **default local de 4096 MB** em `scripts/build/build-next-isolated.mjs:123` (o fix de heap do #4076/#4104 só foi aplicado ao estágio Docker). Recomendo subir esse default num PR próprio.