### PR TITLE
fix(combo): explicit auto routerStrategy wins over task-aware reorder (#4945 regression)

### DIFF
--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -1173,6 +1173,12 @@ export async function handleComboChat({
     }
   }
 
+  // When the "auto" strategy applies an explicit non-rules routerStrategy
+  // (cost / lkgp / sla / …), that decision is authoritative and must NOT be
+  // clobbered by the additive task-aware reorder below (#4945 regression). The
+  // default "rules" path stays eligible for task-aware refinement.
+  let autoExplicitRouterApplied = false;
+
   if (strategy === "auto") {
     const requestHasTools = Array.isArray(body?.tools) && body.tools.length > 0;
     let eligibleTargets = [...orderedTargets];
@@ -1322,6 +1328,9 @@ export async function handleComboChat({
           selectedProvider = decision.provider;
           selectedModel = decision.model;
           selectionReason = decision.reason;
+          // Explicit router strategy produced a selection — it wins over the
+          // task-aware reorder (which would otherwise re-sort by task weight).
+          autoExplicitRouterApplied = Boolean(selectedProvider && selectedModel);
         } catch (err) {
           log.warn(
             "COMBO",
@@ -1585,8 +1594,10 @@ export async function handleComboChat({
   orderedTargets = filterTargetsByRequestCompatibility(orderedTargets, body, log);
 
   // Task-aware reordering: only active for strategies ["smart","task","task-aware","task_aware","auto"].
-  // Additive — does not affect any of the other 15 strategies.
-  if (isTaskRoutingStrategy(strategy)) {
+  // Additive — does not affect any of the other 15 strategies. Skipped when the
+  // "auto" strategy already applied an explicit non-rules routerStrategy
+  // (cost/lkgp/sla/…), whose selection is authoritative (#4945 regression).
+  if (isTaskRoutingStrategy(strategy) && !autoExplicitRouterApplied) {
     const task = classifyTask(body);
     const conversationCacheKey = getConversationCacheKey(body);
     const taskReordered = reorderByTaskWeight(orderedTargets, task);


### PR DESCRIPTION
Conserta a regressão de unit na base `release/v3.8.36` introduzida por **#4945 (task-aware routing)** — os 2 testes falhando que vermelhavam o job `Unit Tests fast-path (1/2)` em **toda PR** aberta para o release (CI: 8877 testes, fail 2).

## Causa-raiz
#4945 adicionou um `reorderByTaskWeight()` que roda para `isTaskRoutingStrategy(strategy)===true` — o que inclui `"auto"`. Esse reorder executa **depois** do bloco `auto` já ter selecionado o alvo pela `routerStrategy` explícita (cost/lkgp/sla) e colocado em primeiro, re-ordenando por peso de tarefa e **descartando a seleção explícita** (o modelo de maior potência, ex.: `gpt-oss-120b`, ia pra frente). Combos `auto` com `routerStrategy=lkgp/cost` passaram a ignorar a estratégia e despachar o 1º modelo do pool.

Testes quebrados (pré-existentes desde v3.8.34 `19d91d82e`):
- `auto strategy honors LKGP after filtering to tool-capable models` — esperava `claude/claude-sonnet-4-6` (LKGP), recebia `openai/gpt-oss-120b`
- `auto strategy falls back to the full pool when tool filtering empties candidates` — esperava `deepseek/reasoner` (cost), recebia `openai/gpt-oss-120b`

## Fix
Quando o `auto` aplica uma `routerStrategy` explícita não-`rules` **e ela produz seleção**, marca `autoExplicitRouterApplied` e **pula** o task-aware reorder — a decisão explícita é autoritativa. O caminho default `"rules"` continua elegível ao refinamento task-aware (comportamento pretendido do #4945 **preservado**). Diff cirúrgico: só `combo.ts`, +13/-2.

## Validação (Rule #18 — testes pré-existentes red→green)
- 2 testes de regressão: **2/2 pass**
- `combo-routing-engine.test.ts`: **81/81**
- `combo-task-aware.test.ts` (core do #4945): **35/35**
- `router-strategies`, `complexity-router`, `pipeline-router`, `wildcard-router` etc.: verdes
- `typecheck:core` limpo, `eslint combo.ts` limpo
- `AutoComboCatalog.test.tsx` (vitest UI, 4 fail) é **pré-existente na base** e advisory — não tocado por este PR

Desbloqueia o gate de unit de todas as PRs do release.