### PR TITLE
fix(executors): only enable Pollinations jsonMode when JSON response_format requested (#3981)

### DIFF
--- a/open-sse/executors/pollinations.ts
+++ b/open-sse/executors/pollinations.ts
@@ -11,9 +11,7 @@ export class PollinationsExecutor extends BaseExecutor {
 
   buildUrl(_model: string, _stream: boolean, urlIndex = 0, _credentials = null): string {
     const baseUrls = this.getBaseUrls();
-    return (
-      baseUrls[urlIndex] || baseUrls[0] || "https://gen.pollinations.ai/v1/chat/completions"
-    );
+    return baseUrls[urlIndex] || baseUrls[0] || "https://gen.pollinations.ai/v1/chat/completions";
   }
 
   buildHeaders(credentials: any, stream = true): Record<string, string> {
@@ -38,7 +36,14 @@ export class PollinationsExecutor extends BaseExecutor {
     if (typeof body === "object" && body !== null) {
       body.model = model;
       body.stream = stream;
-      body.jsonMode = true;
+      // Pollinations' `jsonMode` forces JSON-only output. Only enable it when the
+      // caller actually requested a JSON response via OpenAI's `response_format`.
+      // Forcing it on every request makes ordinary (non-JSON) chat completions
+      // fail upstream with HTTP 400 (issue #3981).
+      const responseFormatType = body.response_format?.type;
+      if (responseFormatType === "json_object" || responseFormatType === "json_schema") {
+        body.jsonMode = true;
+      }
     }
     return body;
   }
@@ -90,13 +95,21 @@ export class PollinationsExecutor extends BaseExecutor {
       }
       // Enhance 401 errors with actionable guidance
       if (err?.status === 401 || err?.statusCode === 401) {
-        const premiumModels = ["claude", "claude-fast", "claude-large", "gemini", "gemini-fast", "midijourney", "midijourney-large"];
+        const premiumModels = [
+          "claude",
+          "claude-fast",
+          "claude-large",
+          "gemini",
+          "gemini-fast",
+          "midijourney",
+          "midijourney-large",
+        ];
         const model = input.model || "";
         if (premiumModels.includes(model)) {
           const enhanced = new Error(
             `Pollinations model "${model}" requires an API key. ` +
-            `Free keyless models: openai, openai-fast, openai-large, qwen-coder, mistral, deepseek, grok, gemini-flash-lite-3.1, perplexity-fast, perplexity-reasoning. ` +
-            `Get a Pollinations API key at https://enter.pollinations.ai and add it in Settings → API Keys.`
+              `Free keyless models: openai, openai-fast, openai-large, qwen-coder, mistral, deepseek, grok, gemini-flash-lite-3.1, perplexity-fast, perplexity-reasoning. ` +
+              `Get a Pollinations API key at https://enter.pollinations.ai and add it in Settings → API Keys.`
           );
           (enhanced as any).status = 401;
           (enhanced as any).type = "authentication_error";

--- a/tests/unit/executor-pollinations.test.ts
+++ b/tests/unit/executor-pollinations.test.ts
@@ -47,7 +47,9 @@ test("PollinationsExecutor enhances 401 errors for premium models with actionabl
   // Mock super.execute (BaseExecutor.prototype.execute) to throw a 401
   const origBaseExec = Object.getPrototypeOf(Object.getPrototypeOf(executor)).execute;
   Object.getPrototypeOf(Object.getPrototypeOf(executor)).execute = async function () {
-    const err = new Error("Authentication required. Please provide an API key via Authorization header (Bearer token) or ?key= query parameter.");
+    const err = new Error(
+      "Authentication required. Please provide an API key via Authorization header (Bearer token) or ?key= query parameter."
+    );
     (err as any).status = 401;
     throw err;
   };
@@ -95,4 +97,33 @@ test("PollinationsExecutor passes through 401 errors for non-premium models", as
   } finally {
     Object.getPrototypeOf(Object.getPrototypeOf(executor)).execute = origBaseExec;
   }
+});
+
+test("#3981 PollinationsExecutor.transformRequest does not force jsonMode on a plain (non-JSON) request", () => {
+  const executor = new PollinationsExecutor();
+  // A normal chat request has no response_format. Forcing jsonMode here makes
+  // pollinations reject the request with HTTP 400 (the bug reported in #3981).
+  const body: any = { messages: [{ role: "user", content: "hello" }] };
+  executor.transformRequest("openai", body, false, {});
+  assert.equal(body.jsonMode, undefined);
+});
+
+test("#3981 PollinationsExecutor.transformRequest enables jsonMode when response_format requests json_object", () => {
+  const executor = new PollinationsExecutor();
+  const body: any = {
+    messages: [{ role: "user", content: "hi" }],
+    response_format: { type: "json_object" },
+  };
+  executor.transformRequest("openai", body, false, {});
+  assert.equal(body.jsonMode, true);
+});
+
+test("#3981 PollinationsExecutor.transformRequest enables jsonMode when response_format requests json_schema", () => {
+  const executor = new PollinationsExecutor();
+  const body: any = {
+    messages: [{ role: "user", content: "hi" }],
+    response_format: { type: "json_schema", json_schema: { name: "x", schema: {} } },
+  };
+  executor.transformRequest("openai", body, false, {});
+  assert.equal(body.jsonMode, true);
 });


### PR DESCRIPTION
## Summary

The Pollinations executor's `transformRequest` set `body.jsonMode = true` on **every** request. Pollinations' `jsonMode` forces JSON-only output, so ordinary (non-JSON) chat completions were rejected upstream with HTTP 400 — the bug reported in #3981 and confirmed by @diegosouzapw ("the pollinations executor forces `jsonMode` unconditionally (`pollinations.ts:41`), which breaks non-JSON requests").

This maps `jsonMode` from the standard OpenAI `response_format` field, so it is enabled only when the caller actually requests `json_object` or `json_schema` output. Plain chat requests no longer carry `jsonMode`, matching the working "custom OpenAI endpoint" behavior the reporter described.

Fixes #3981

## Changes

| File | Change |
|---|---|
| `open-sse/executors/pollinations.ts` | `transformRequest` sets `jsonMode` only when `response_format.type` is `json_object` / `json_schema` |
| `tests/unit/executor-pollinations.test.ts` | +3 regression tests (plain request -> no `jsonMode`; `json_object` / `json_schema` -> `jsonMode: true`) |

## Testing

- `node --import tsx/esm --test tests/unit/executor-pollinations.test.ts` -> 9/9 pass (6 existing + 3 new)
- `npx eslint open-sse/executors/pollinations.ts tests/unit/executor-pollinations.test.ts` -> 0 errors