### PR TITLE
fix(rate-limiter): throttle Redis connection-error logging to stop log flood (#4878)

### DIFF
--- a/src/shared/utils/rateLimiter.ts
+++ b/src/shared/utils/rateLimiter.ts
@@ -9,6 +9,30 @@ if (process.env.NODE_ENV === "production" && !REDIS_URL) {
 
 let redisClient: Redis | null = null;
 
+/**
+ * Throttle Redis connection-error logging. ioredis emits an `error` event on
+ * every failed (re)connection attempt, so a configured-but-unreachable
+ * `REDIS_URL` (e.g. pointing at a host that isn't running) floods the logs with
+ * one `[REDIS] Error:` line per retry. This returns a predicate that logs the
+ * first occurrence of a given message immediately, then at most once per
+ * `intervalMs`. (#4878)
+ */
+export function createRedisErrorThrottle(intervalMs: number) {
+  let lastLoggedAt = 0;
+  let lastMessage: string | null = null;
+  return (message: string, now: number): boolean => {
+    if (message !== lastMessage || now - lastLoggedAt >= intervalMs) {
+      lastMessage = message;
+      lastLoggedAt = now;
+      return true;
+    }
+    return false;
+  };
+}
+
+const REDIS_ERROR_LOG_INTERVAL_MS = 60_000;
+const shouldLogRedisError = createRedisErrorThrottle(REDIS_ERROR_LOG_INTERVAL_MS);
+
 export function isRedisConfigured(): boolean {
   return REDIS_URL.length > 0;
 }
@@ -26,7 +50,11 @@ export function getRedisClient() {
         return Math.min(times * 50, 2000); // Exponential backoff
       },
     });
-    redisClient.on("error", (err) => console.error("[REDIS] Error:", err.message));
+    redisClient.on("error", (err) => {
+      if (shouldLogRedisError(err.message, Date.now())) {
+        console.error("[REDIS] Error:", err.message);
+      }
+    });
   }
   return redisClient;
 }

--- a/tests/unit/redis-log-spam-4878.test.ts
+++ b/tests/unit/redis-log-spam-4878.test.ts
@@ -1,0 +1,23 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createRedisErrorThrottle } from "../../src/shared/utils/rateLimiter.ts";
+
+// #4878 — ioredis emits an `error` event on every failed (re)connection
+// attempt, so a configured-but-unreachable REDIS_URL floods the logs with one
+// `[REDIS] Error:` line per retry. The throttle logs the first occurrence of a
+// message immediately, then at most once per interval.
+
+test("#4878 redis error throttle logs the first occurrence then suppresses repeats within the interval", () => {
+  const shouldLog = createRedisErrorThrottle(60_000);
+  assert.equal(shouldLog("connect ECONNREFUSED 127.0.0.1:6379", 1_000), true);
+  assert.equal(shouldLog("connect ECONNREFUSED 127.0.0.1:6379", 2_000), false);
+  assert.equal(shouldLog("connect ECONNREFUSED 127.0.0.1:6379", 30_000), false);
+  assert.equal(shouldLog("connect ECONNREFUSED 127.0.0.1:6379", 61_001), true);
+});
+
+test("#4878 redis error throttle logs immediately when the error message changes", () => {
+  const shouldLog = createRedisErrorThrottle(60_000);
+  assert.equal(shouldLog("connect ECONNREFUSED 127.0.0.1:6379", 1_000), true);
+  assert.equal(shouldLog("READONLY You can't write against a read only replica", 1_500), true);
+});


### PR DESCRIPTION
## Summary

`getRedisClient()` attached a Redis `error` handler that logged every event:

```ts
redisClient.on("error", (err) => console.error("[REDIS] Error:", err.message));
```

ioredis emits an `error` event on **every** failed (re)connection attempt, so a configured-but-unreachable `REDIS_URL` (e.g. pointing at a localhost Redis that isn't running) floods the logs with one `[REDIS] Error:` line per retry — the spam reported in #4878.

This throttles the handler: it logs the first occurrence of a message immediately, then at most once per minute, and again immediately if the message changes. A real Redis outage is still visible, just not flooding.

Fixes #4878

## Changes

| File | Change |
|---|---|
| `src/shared/utils/rateLimiter.ts` | add `createRedisErrorThrottle()`; the `error` handler logs through it |
| `tests/unit/redis-log-spam-4878.test.ts` | +2 tests (first-occurrence + interval reset; logs immediately on message change) |

## Testing

- `node --import tsx/esm --test tests/unit/redis-log-spam-4878.test.ts` -> 2/2 pass
- `node --import tsx/esm --test tests/unit/rate-limiter-redis-optional.test.ts` -> 3/3 pass (no regression)
- `npx eslint src/shared/utils/rateLimiter.ts tests/unit/redis-log-spam-4878.test.ts` -> 0 errors
- Verified against real ioredis pointed at a dead `localhost:6379`: 15 `error` events emitted, throttle logged only 1 line.