### PR TITLE
feat(provider-limits): add SiliconFlow balance support

### DIFF
--- a/open-sse/services/siliconflowQuotaFetcher.ts
+++ b/open-sse/services/siliconflowQuotaFetcher.ts
@@ -20,9 +20,10 @@
  *     }
  *   }
  *
- * We prefer totalBalance when available, falling back to balance. When the
- * balance is zero, the top-level status is false, or the account status is a
- * known non-active value, the account quota is considered exhausted.
+ * The public API exposes legacy credit-balance fields. SiliconFlow's dashboard
+ * has moved pre-2025-11-30 credits into vouchers, so totalBalance can be
+ * negative while the account remains normal and has usable voucher balance.
+ * Treat only explicit API/account status failures as exhausted.
  *
  * Cache: in-memory TTL (60s) to avoid hammering the user-info API on every request.
  *
@@ -40,6 +41,7 @@ export interface SiliconFlowBalanceInfo {
   balance: number;
   chargeBalance: number | null;
   totalBalance: number;
+  displayBalance: number;
   accountStatus: string | null;
 }
 
@@ -154,8 +156,10 @@ function parseSiliconFlowQuotaResponse(data: unknown, currency: string): Silicon
   const rootStatusOk = root.status !== false;
   const accountStatus = typeof payload.status === "string" ? payload.status : null;
   const accountStatusOk = isHealthyAccountStatus(accountStatus);
-  const limitReached = !rootStatusOk || !accountStatusOk || effectiveBalance <= 0;
+  const limitReached = !rootStatusOk || !accountStatusOk;
   const percentUsed = limitReached ? 1 : 0;
+  const displayBalance =
+    effectiveBalance < 0 && !limitReached ? Math.max(balance ?? 0, 0) : effectiveBalance;
 
   return {
     used: percentUsed * 100,
@@ -167,6 +171,7 @@ function parseSiliconFlowQuotaResponse(data: unknown, currency: string): Silicon
       balance: balance ?? effectiveBalance,
       chargeBalance,
       totalBalance: effectiveBalance,
+      displayBalance,
       accountStatus,
     },
     isAvailable: !limitReached,

--- a/open-sse/services/siliconflowQuotaFetcher.ts
+++ b/open-sse/services/siliconflowQuotaFetcher.ts
@@ -1,0 +1,238 @@
+/**
+ * siliconflowQuotaFetcher.ts — SiliconFlow Balance Quota Fetcher
+ *
+ * Implements QuotaFetcher for the SiliconFlow provider (quotaPreflight.ts + quotaMonitor.ts).
+ *
+ * SiliconFlow provides a user-info API on both international and China endpoints:
+ *   GET https://api.siliconflow.com/v1/user/info
+ *   GET https://api.siliconflow.cn/v1/user/info
+ *
+ * Response format (official docs):
+ *   {
+ *     "code": 20000,
+ *     "message": "OK",
+ *     "status": true,
+ *     "data": {
+ *       "balance": "0.88",
+ *       "chargeBalance": "88.00",
+ *       "totalBalance": "88.88",
+ *       "status": "normal"
+ *     }
+ *   }
+ *
+ * We prefer totalBalance when available, falling back to balance. When the
+ * balance is zero, the top-level status is false, or the account status is a
+ * known non-active value, the account quota is considered exhausted.
+ *
+ * Cache: in-memory TTL (60s) to avoid hammering the user-info API on every request.
+ *
+ * Registration: call registerSiliconFlowQuotaFetcher() once at server startup.
+ */
+
+import { registerQuotaFetcher, type QuotaInfo } from "./quotaPreflight.ts";
+import { registerMonitorFetcher } from "./quotaMonitor.ts";
+
+const SILICONFLOW_DEFAULT_BASE_URL = "https://api.siliconflow.com/v1";
+const CACHE_TTL_MS = 60_000;
+
+export interface SiliconFlowBalanceInfo {
+  currency: string;
+  balance: number;
+  chargeBalance: number | null;
+  totalBalance: number;
+  accountStatus: string | null;
+}
+
+export interface SiliconFlowQuota extends QuotaInfo {
+  balance: SiliconFlowBalanceInfo;
+  isAvailable: boolean;
+  limitReached: boolean;
+  accountStatus: string | null;
+}
+
+interface CacheEntry {
+  quota: SiliconFlowQuota;
+  fetchedAt: number;
+}
+
+const quotaCache = new Map<string, CacheEntry>();
+
+const _cacheCleanup = setInterval(() => {
+  const now = Date.now();
+  for (const [key, entry] of quotaCache) {
+    if (now - entry.fetchedAt > CACHE_TTL_MS * 5) {
+      quotaCache.delete(key);
+    }
+  }
+}, 5 * 60_000);
+
+if (typeof _cacheCleanup === "object" && "unref" in _cacheCleanup) {
+  (_cacheCleanup as { unref?: () => void }).unref?.();
+}
+
+function toRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function toNumberOrNull(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return null;
+}
+
+function normalizeConfiguredBaseUrl(baseUrl: unknown): string {
+  const raw =
+    typeof baseUrl === "string" && baseUrl.trim() ? baseUrl.trim() : SILICONFLOW_DEFAULT_BASE_URL;
+  return /^https?:\/\//i.test(raw) ? raw : `https://${raw}`;
+}
+
+function pathSegments(pathname: string): string[] {
+  return pathname.split("/").filter(Boolean);
+}
+
+function versionRootPath(pathname: string): string {
+  const segments = pathSegments(pathname);
+  const versionIndex = segments.findIndex((segment) => /^v\d+(?:beta)?$/i.test(segment));
+
+  if (versionIndex >= 0) {
+    return `/${segments.slice(0, versionIndex + 1).join("/")}`;
+  }
+
+  if (segments.length === 0) return "/v1";
+
+  const withoutKnownEndpoint = [...segments];
+  const tail = withoutKnownEndpoint.slice(-2).join("/").toLowerCase();
+  if (["chat/completions", "user/info"].includes(tail)) {
+    withoutKnownEndpoint.splice(-2, 2);
+  } else if (["models", "responses"].includes(String(withoutKnownEndpoint.at(-1)).toLowerCase())) {
+    withoutKnownEndpoint.pop();
+  }
+
+  return withoutKnownEndpoint.length > 0 ? `/${withoutKnownEndpoint.join("/")}` : "/v1";
+}
+
+export function resolveSiliconFlowUserInfoUrl(baseUrl?: unknown): string {
+  try {
+    const url = new URL(normalizeConfiguredBaseUrl(baseUrl));
+    const rootPath = versionRootPath(url.pathname).replace(/\/+$/, "") || "/v1";
+    return `${url.origin}${rootPath}/user/info`;
+  } catch {
+    return `${SILICONFLOW_DEFAULT_BASE_URL}/user/info`;
+  }
+}
+
+export function inferSiliconFlowCurrency(baseUrl?: unknown): string {
+  try {
+    const url = new URL(normalizeConfiguredBaseUrl(baseUrl));
+    return url.hostname.toLowerCase().endsWith(".cn") ? "CNY" : "USD";
+  } catch {
+    return "USD";
+  }
+}
+
+function isHealthyAccountStatus(status: unknown): boolean {
+  if (typeof status !== "string" || status.trim().length === 0) return true;
+  return new Set(["normal", "active", "enabled", "ok"]).has(status.trim().toLowerCase());
+}
+
+function parseSiliconFlowQuotaResponse(data: unknown, currency: string): SiliconFlowQuota | null {
+  const root = toRecord(data);
+  const payload = Object.keys(toRecord(root.data)).length > 0 ? toRecord(root.data) : root;
+
+  const totalBalance = toNumberOrNull(payload.totalBalance ?? payload.total_balance);
+  const balance = toNumberOrNull(payload.balance);
+  const chargeBalance = toNumberOrNull(payload.chargeBalance ?? payload.charge_balance);
+  const effectiveBalance = totalBalance ?? balance ?? chargeBalance;
+
+  if (effectiveBalance === null) return null;
+
+  const rootStatusOk = root.status !== false;
+  const accountStatus = typeof payload.status === "string" ? payload.status : null;
+  const accountStatusOk = isHealthyAccountStatus(accountStatus);
+  const limitReached = !rootStatusOk || !accountStatusOk || effectiveBalance <= 0;
+  const percentUsed = limitReached ? 1 : 0;
+
+  return {
+    used: percentUsed * 100,
+    total: 100,
+    percentUsed,
+    resetAt: null,
+    balance: {
+      currency,
+      balance: balance ?? effectiveBalance,
+      chargeBalance,
+      totalBalance: effectiveBalance,
+      accountStatus,
+    },
+    isAvailable: !limitReached,
+    limitReached,
+    accountStatus,
+  };
+}
+
+function getProviderSpecificData(connection?: Record<string, unknown>): Record<string, unknown> {
+  return toRecord(connection?.providerSpecificData);
+}
+
+export async function fetchSiliconFlowQuota(
+  connectionId: string,
+  connection?: Record<string, unknown>
+): Promise<QuotaInfo | null> {
+  const cached = quotaCache.get(connectionId);
+  if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
+    return cached.quota;
+  }
+
+  const apiKey =
+    typeof connection?.apiKey === "string" && connection.apiKey.trim().length > 0
+      ? connection.apiKey.trim()
+      : null;
+
+  if (!apiKey) return null;
+
+  const providerSpecificData = getProviderSpecificData(connection);
+  const baseUrl = providerSpecificData.baseUrl;
+  const url = resolveSiliconFlowUserInfoUrl(baseUrl);
+  const currency = inferSiliconFlowCurrency(baseUrl);
+
+  try {
+    const response = await fetch(url, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        Accept: "application/json",
+      },
+      signal: AbortSignal.timeout(8_000),
+    });
+
+    if (response.status === 401 || response.status === 403) {
+      quotaCache.delete(connectionId);
+      return null;
+    }
+
+    if (!response.ok) return null;
+
+    const data = await response.json();
+    const quota = parseSiliconFlowQuotaResponse(data, currency);
+    if (!quota) return null;
+
+    quotaCache.set(connectionId, { quota, fetchedAt: Date.now() });
+    return quota;
+  } catch {
+    return null;
+  }
+}
+
+export function invalidateSiliconFlowQuotaCache(connectionId: string): void {
+  quotaCache.delete(connectionId);
+}
+
+export function registerSiliconFlowQuotaFetcher(): void {
+  registerQuotaFetcher("siliconflow", fetchSiliconFlowQuota);
+  registerMonitorFetcher("siliconflow", fetchSiliconFlowQuota);
+}

--- a/open-sse/services/usage.ts
+++ b/open-sse/services/usage.ts
@@ -143,6 +143,8 @@ type UsageQuota = {
   currency?: string;
   grantedBalance?: number;
   toppedUpBalance?: number;
+  apiBalance?: number;
+  totalBalance?: number;
 };
 type UsageProviderConnection = JsonRecord & {
   id?: string;
@@ -1001,12 +1003,14 @@ async function getSiliconFlowUsage(
       [quotaKey]: {
         used: 0,
         total: 0,
-        remaining: balance.totalBalance,
-        remainingPercentage: balance.totalBalance > 0 ? 100 : 0,
+        remaining: balance.displayBalance,
+        remainingPercentage: balance.displayBalance > 0 ? 100 : 0,
         resetAt: null,
         unlimited: true,
         currency: balance.currency,
         toppedUpBalance: chargeBalance,
+        apiBalance: balance.balance,
+        totalBalance: balance.totalBalance,
       },
     };
 

--- a/open-sse/services/usage.ts
+++ b/open-sse/services/usage.ts
@@ -19,6 +19,7 @@ import { safePercentage } from "@/shared/utils/formatting";
 import { getDbInstance } from "@/lib/db/core";
 import { fetchBailianQuota, type BailianTripleWindowQuota } from "./bailianQuotaFetcher.ts";
 import { fetchDeepseekQuota, type DeepseekQuota } from "./deepseekQuotaFetcher.ts";
+import { fetchSiliconFlowQuota, type SiliconFlowQuota } from "./siliconflowQuotaFetcher.ts";
 import { fetchOpencodeQuota, type OpencodeTripleWindowQuota } from "./opencodeQuotaFetcher.ts";
 import { getOllamaCloudUsage, getOpenCodeGoUsage } from "./opencodeOllamaUsage.ts";
 import {
@@ -970,6 +971,60 @@ async function getDeepseekUsage(connectionId: string, apiKey: string) {
   }
 }
 
+/**
+ * SiliconFlow Usage
+ * Fetches balance from SiliconFlow's /user/info API on the configured region.
+ */
+async function getSiliconFlowUsage(
+  connectionId: string,
+  apiKey: string,
+  providerSpecificData?: Record<string, unknown>
+) {
+  try {
+    const connection = { apiKey, providerSpecificData };
+    const quota = await fetchSiliconFlowQuota(connectionId, connection);
+
+    if (!quota) {
+      return { message: "SiliconFlow API key not available. Add a key to view usage." };
+    }
+
+    const siliconFlowQuota = quota as SiliconFlowQuota;
+    const { balance, isAvailable, limitReached, accountStatus } = siliconFlowQuota;
+    const quotaKey = `credits_${balance.currency.toLowerCase()}`;
+
+    const chargeBalance =
+      typeof balance.chargeBalance === "number" && Number.isFinite(balance.chargeBalance)
+        ? balance.chargeBalance
+        : undefined;
+
+    const quotas: Record<string, UsageQuota> = {
+      [quotaKey]: {
+        used: 0,
+        total: 0,
+        remaining: balance.totalBalance,
+        remainingPercentage: balance.totalBalance > 0 ? 100 : 0,
+        resetAt: null,
+        unlimited: true,
+        currency: balance.currency,
+        toppedUpBalance: chargeBalance,
+      },
+    };
+
+    const plan =
+      isAvailable && !limitReached ? "SiliconFlow" : "SiliconFlow (Insufficient Balance)";
+
+    return {
+      plan,
+      quotas,
+      isAvailable,
+      limitReached,
+      accountStatus,
+    };
+  } catch (error) {
+    return { message: `SiliconFlow error: ${(error as Error).message}` };
+  }
+}
+
 // Xiaomi MiMo Token Plan monthly limit (tokens). Keep in sync with the
 // "xiaomi-mimo" preset in src/lib/quota/planRegistry.ts.
 const XIAOMI_MIMO_MONTHLY_TOKEN_LIMIT = 4_100_000_000;
@@ -1327,6 +1382,7 @@ export const USAGE_FETCHER_PROVIDERS = [
   "bailian-coding-plan",
   "nanogpt",
   "deepseek",
+  "siliconflow",
   "opencode",
   "opencode-zen",
   "xiaomi-mimo",
@@ -1405,6 +1461,8 @@ export async function getUsageForProvider(
       return await getNanoGptUsage(apiKey || "");
     case "deepseek":
       return await getDeepseekUsage(id || "", apiKey || "");
+    case "siliconflow":
+      return await getSiliconFlowUsage(id || "", apiKey || "", providerSpecificData);
     case "opencode":
     case "opencode-zen":
       return await getOpencodeUsage(id || "", apiKey || "");

--- a/scripts/check/check-public-creds.mjs
+++ b/scripts/check/check-public-creds.mjs
@@ -81,15 +81,15 @@ const ENV_KEY_RE = /(clientId|clientSecret|apiKey)Env\s*:/;
 //
 // 6A.8: Expanded scope to open-sse/** + src/lib/oauth/**. Newly discovered FPs:
 //
-//   open-sse/services/usage.ts L499: `getMiniMaxUsage(apiKey: string, provider: "minimax" | "minimax-cn")`
+//   open-sse/services/usage.ts L500: `getMiniMaxUsage(apiKey: string, provider: "minimax" | "minimax-cn")`
 //   The CRED_KEY_RE matches `apiKey:` in the TypeScript function-parameter type annotation.
 //   "minimax" and "minimax-cn" are provider-name strings in the type annotation, NOT credentials.
 //   This is a false positive (the gate was designed for object-literal assignments, not fn params).
 //   TODO(6A.8): Consider tightening CRED_KEY_RE to exclude function-signature contexts — but
 //   that adds complexity; the FP rate is low (1 file). Frozen by file:line:value key.
 export const KNOWN_LITERAL_CREDS = new Set([
-  "open-sse/services/usage.ts:499:minimax", // TODO(6A.8): pre-existing FP — TS fn-param type, not a credential (moved 582→499 by the OpenCode/Ollama usage extraction)
-  "open-sse/services/usage.ts:499:minimax-cn", // TODO(6A.8): pre-existing FP — TS fn-param type, not a credential (moved 582→499 by the OpenCode/Ollama usage extraction)
+  "open-sse/services/usage.ts:500:minimax", // TODO(6A.8): pre-existing FP — TS fn-param type, not a credential (moved 499→500 by SiliconFlow usage import)
+  "open-sse/services/usage.ts:500:minimax-cn", // TODO(6A.8): pre-existing FP — TS fn-param type, not a credential (moved 499→500 by SiliconFlow usage import)
 ]);
 
 /**

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.tsx
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.tsx
@@ -53,6 +53,7 @@ const PROVIDER_LABEL: Record<string, string> = {
   "minimax-cn": "MiniMax CN",
   nanogpt: "NanoGPT",
   deepseek: "DeepSeek",
+  siliconflow: "SiliconFlow",
 };
 
 // Group ordering — single source of truth for provider placement.
@@ -72,6 +73,8 @@ const PROVIDER_ORDER: Record<string, number> = {
   minimax: 13,
   "minimax-cn": 14,
   nanogpt: 15,
+  deepseek: 16,
+  siliconflow: 17,
 };
 
 const TIER_FILTERS = [

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/quotaParsing.ts
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/quotaParsing.ts
@@ -133,7 +133,7 @@ function parseGeminiCli(data: any) {
   );
 }
 
-function parseDeepseekQuota(quotaKey: string, quota: any) {
+function parseCreditBalanceQuota(quotaKey: string, quota: any) {
   const match = quotaKey.match(/^credits(?:_([a-z]{3}))?$/);
   if (!match) return normalizeQuotaEntry(quotaKey, quota);
   const remaining = Number(quota?.remaining ?? 0);
@@ -143,8 +143,8 @@ function parseDeepseekQuota(quotaKey: string, quota: any) {
   });
 }
 
-function parseDeepseek(data: any) {
-  return quotaEntries(data).map(([quotaKey, quota]) => parseDeepseekQuota(quotaKey, quota));
+function parseCreditBalances(data: any) {
+  return quotaEntries(data).map(([quotaKey, quota]) => parseCreditBalanceQuota(quotaKey, quota));
 }
 
 function parseProviderQuotas(providerId: string, data: any) {
@@ -154,7 +154,7 @@ function parseProviderQuotas(providerId: string, data: any) {
   if (providerId === "codex") return parseCodex(data);
   if (providerId === "claude") return parseClaude(data);
   if (providerId === "gemini-cli") return parseGeminiCli(data);
-  if (providerId === "deepseek") return parseDeepseek(data);
+  if (providerId === "deepseek" || providerId === "siliconflow") return parseCreditBalances(data);
   return parseGeneric(data);
 }
 

--- a/src/lib/usage/providerLimits.ts
+++ b/src/lib/usage/providerLimits.ts
@@ -69,6 +69,7 @@ const PROVIDER_LIMITS_APIKEY_PROVIDERS = new Set([
   "crof",
   "nanogpt",
   "deepseek",
+  "siliconflow",
   "xiaomi-mimo",
   "vertex",
   "vertex-partner",

--- a/src/lib/usage/providerLimits.ts
+++ b/src/lib/usage/providerLimits.ts
@@ -36,7 +36,6 @@ import { onUsageRecorded } from "./usageEvents";
 
 type JsonRecord = Record<string, unknown>;
 type SyncSource = "manual" | "scheduled";
-
 interface ProviderConnectionLike {
   id: string;
   provider: string;

--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -3231,6 +3231,7 @@ export const USAGE_SUPPORTED_PROVIDERS = [
   "crof",
   "nanogpt",
   "deepseek",
+  "siliconflow",
   "xiaomi-mimo",
   "vertex",
   "vertex-partner",

--- a/src/sse/handlers/chat.ts
+++ b/src/sse/handlers/chat.ts
@@ -109,6 +109,7 @@ import {
 import { registerBailianCodingPlanQuotaFetcher } from "@omniroute/open-sse/services/bailianQuotaFetcher.ts";
 import { registerCrofUsageFetcher } from "@omniroute/open-sse/services/crofUsageFetcher.ts";
 import { registerDeepseekQuotaFetcher } from "@omniroute/open-sse/services/deepseekQuotaFetcher.ts";
+import { registerSiliconFlowQuotaFetcher } from "@omniroute/open-sse/services/siliconflowQuotaFetcher.ts";
 import { registerOpencodeQuotaFetcher } from "@omniroute/open-sse/services/opencodeQuotaFetcher.ts";
 import { registerGenericQuotaFetchers } from "@omniroute/open-sse/services/genericQuotaFetcher.ts";
 import {
@@ -133,6 +134,10 @@ registerCrofUsageFetcher();
 // Register DeepSeek balance quota fetcher.
 // Hooks into quotaPreflight + quotaMonitor so combos can switch accounts before balance is exhausted.
 registerDeepseekQuotaFetcher();
+
+// Register SiliconFlow balance quota fetcher.
+// Hooks into quotaPreflight + quotaMonitor so combos can switch accounts before balance is exhausted.
+registerSiliconFlowQuotaFetcher();
 
 // Register OpenCode quota fetcher (opencode-go / opencode / opencode-zen).
 // Surfaces the $12/5h, $30/wk, $60/mo windows in the limits page and enables

--- a/src/sse/handlers/chat.ts
+++ b/src/sse/handlers/chat.ts
@@ -131,12 +131,7 @@ registerBailianCodingPlanQuotaFetcher();
 // opt-in) when the active bucket reaches zero.
 registerCrofUsageFetcher();
 
-// Register DeepSeek balance quota fetcher.
-// Hooks into quotaPreflight + quotaMonitor so combos can switch accounts before balance is exhausted.
 registerDeepseekQuotaFetcher();
-
-// Register SiliconFlow balance quota fetcher.
-// Hooks into quotaPreflight + quotaMonitor so combos can switch accounts before balance is exhausted.
 registerSiliconFlowQuotaFetcher();
 
 // Register OpenCode quota fetcher (opencode-go / opencode / opencode-zen).

--- a/tests/unit/check-public-creds.test.ts
+++ b/tests/unit/check-public-creds.test.ts
@@ -170,7 +170,7 @@ test("6A.8 stale: known literal that was removed from the codebase is detected a
 });
 
 test("6A.8: open-sse/services/usage.ts FP — function-signature apiKey is suppressed by allowlist", () => {
-  // open-sse/services/usage.ts L543: `getMiniMaxUsage(apiKey: string, provider: "minimax" | "minimax-cn")`
+  // open-sse/services/usage.ts L500: `getMiniMaxUsage(apiKey: string, provider: "minimax" | "minimax-cn")`
   // The CRED_KEY_RE matches `apiKey:` in the TypeScript function-parameter type annotation.
   // "minimax" and "minimax-cn" are provider-name strings in the type, NOT credentials.
   // Frozen in KNOWN_LITERAL_CREDS as FPs by file:line:value key.

--- a/tests/unit/kimi-coding-apikey-quota-4435.test.ts
+++ b/tests/unit/kimi-coding-apikey-quota-4435.test.ts
@@ -29,8 +29,7 @@ before(() => {
     return {
       ok: true,
       status: 200,
-      text: async () =>
-        JSON.stringify({ usage: { limit: "100", used: "10", remaining: "90" } }),
+      text: async () => JSON.stringify({ usage: { limit: "100", used: "10", remaining: "90" } }),
     } as unknown as Response;
   }) as typeof fetch;
 });
@@ -75,6 +74,17 @@ test("kimi-coding-apikey is wired into both usage source-of-truth lists", () => 
   );
   assert.ok(
     (USAGE_FETCHER_PROVIDERS as readonly string[]).includes("kimi-coding-apikey"),
+    "must be in USAGE_FETCHER_PROVIDERS (else auto-routing preflight never registers a fetcher)"
+  );
+});
+
+test("siliconflow is wired into both usage source-of-truth lists", () => {
+  assert.ok(
+    USAGE_SUPPORTED_PROVIDERS.includes("siliconflow"),
+    "must be in USAGE_SUPPORTED_PROVIDERS (else the dashboard gate returns 400)"
+  );
+  assert.ok(
+    (USAGE_FETCHER_PROVIDERS as readonly string[]).includes("siliconflow"),
     "must be in USAGE_FETCHER_PROVIDERS (else auto-routing preflight never registers a fetcher)"
   );
 });

--- a/tests/unit/provider-limits-ui.test.ts
+++ b/tests/unit/provider-limits-ui.test.ts
@@ -150,10 +150,32 @@ test("quota labels normalize session and weekly windows while preserving readabl
   assert.equal(providerLimitUtils.formatQuotaLabel("mcp_monthly"), "Monthly");
 });
 
-test("MiniMax providers are exposed to the limits dashboard support list", () => {
+test("MiniMax and SiliconFlow providers are exposed to the limits dashboard support list", () => {
   assert.ok(providerConstants.USAGE_SUPPORTED_PROVIDERS.includes("zai"));
   assert.ok(providerConstants.USAGE_SUPPORTED_PROVIDERS.includes("minimax"));
   assert.ok(providerConstants.USAGE_SUPPORTED_PROVIDERS.includes("minimax-cn"));
+  assert.ok(providerConstants.USAGE_SUPPORTED_PROVIDERS.includes("siliconflow"));
+});
+
+test("SiliconFlow balance payloads render as currency credits", () => {
+  const parsed = providerLimitUtils.parseQuotaData("siliconflow", {
+    quotas: {
+      credits_cny: {
+        used: 0,
+        total: 0,
+        remaining: 88.88,
+        remainingPercentage: 100,
+        unlimited: true,
+        currency: "CNY",
+      },
+    },
+  });
+
+  assert.equal(parsed.length, 1);
+  assert.equal(parsed[0].isCredits, true);
+  assert.equal(parsed[0].name, "CNY");
+  assert.equal(parsed[0].currency, "CNY");
+  assert.equal(parsed[0].creditCount, 88.88);
 });
 
 test("MiniMax quota payloads use generic provider parsing and stale resets still refill", () => {

--- a/tests/unit/siliconflow-quota-fetcher.test.ts
+++ b/tests/unit/siliconflow-quota-fetcher.test.ts
@@ -190,19 +190,29 @@ test("fetchSiliconFlowQuota marks exhausted for non-normal account status", asyn
   invalidateSiliconFlowQuotaCache(connectionId);
 });
 
-test("fetchSiliconFlowQuota marks exhausted when balance is zero", async () => {
-  const connectionId = `siliconflow-zero-${Date.now()}`;
+test("fetchSiliconFlowQuota keeps normal accounts available when API balance is non-positive", async () => {
+  const connectionId = `siliconflow-normal-nonpositive-${Date.now()}`;
 
   globalThis.fetch = async () =>
     new Response(
-      JSON.stringify({ status: true, data: { totalBalance: "0.00", status: "normal" } }),
+      JSON.stringify({
+        status: true,
+        data: {
+          balance: "0",
+          chargeBalance: "-240.9806",
+          totalBalance: "-240.9806",
+          status: "normal",
+        },
+      }),
       { status: 200, headers: { "content-type": "application/json" } }
     );
 
   const quota = await fetchSiliconFlowQuota(connectionId, { apiKey: "sf-key" });
 
-  assert.equal(quota?.limitReached, true);
-  assert.equal(quota?.percentUsed, 1);
+  assert.equal(quota?.limitReached, false);
+  assert.equal(quota?.percentUsed, 0);
+  assert.equal((quota as any)?.balance?.totalBalance, -240.9806);
+  assert.equal((quota as any)?.balance?.chargeBalance, -240.9806);
 
   invalidateSiliconFlowQuotaCache(connectionId);
 });
@@ -254,7 +264,7 @@ test("registerSiliconFlowQuotaFetcher exposes SiliconFlow quota to preflight and
 
   globalThis.fetch = async () =>
     new Response(
-      JSON.stringify({ status: true, data: { totalBalance: "0.00", status: "normal" } }),
+      JSON.stringify({ status: false, data: { totalBalance: "9.00", status: "normal" } }),
       { status: 200, headers: { "content-type": "application/json" } }
     );
 

--- a/tests/unit/siliconflow-quota-fetcher.test.ts
+++ b/tests/unit/siliconflow-quota-fetcher.test.ts
@@ -1,0 +1,279 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  fetchSiliconFlowQuota,
+  inferSiliconFlowCurrency,
+  invalidateSiliconFlowQuotaCache,
+  registerSiliconFlowQuotaFetcher,
+  resolveSiliconFlowUserInfoUrl,
+} from "../../open-sse/services/siliconflowQuotaFetcher.ts";
+import { preflightQuota } from "../../open-sse/services/quotaPreflight.ts";
+import {
+  clearQuotaMonitors,
+  getActiveMonitorCount,
+  startQuotaMonitor,
+  stopQuotaMonitor,
+} from "../../open-sse/services/quotaMonitor.ts";
+import { clearSessions, touchSession } from "../../open-sse/services/sessionManager.ts";
+
+const originalFetch = globalThis.fetch;
+
+test.afterEach(() => {
+  globalThis.fetch = originalFetch;
+  clearQuotaMonitors();
+  clearSessions();
+});
+
+test("resolveSiliconFlowUserInfoUrl normalizes global and China base URLs", () => {
+  assert.equal(resolveSiliconFlowUserInfoUrl(), "https://api.siliconflow.com/v1/user/info");
+  assert.equal(
+    resolveSiliconFlowUserInfoUrl("https://api.siliconflow.com/v1/chat/completions"),
+    "https://api.siliconflow.com/v1/user/info"
+  );
+  assert.equal(
+    resolveSiliconFlowUserInfoUrl("https://api.siliconflow.cn/v1"),
+    "https://api.siliconflow.cn/v1/user/info"
+  );
+  assert.equal(
+    resolveSiliconFlowUserInfoUrl("https://api.siliconflow.cn/v1/"),
+    "https://api.siliconflow.cn/v1/user/info"
+  );
+});
+
+test("inferSiliconFlowCurrency follows selected endpoint region", () => {
+  assert.equal(inferSiliconFlowCurrency("https://api.siliconflow.cn/v1"), "CNY");
+  assert.equal(inferSiliconFlowCurrency("https://api.siliconflow.com/v1"), "USD");
+});
+
+test("fetchSiliconFlowQuota returns null when no API key exists", async () => {
+  const quota = await fetchSiliconFlowQuota(`siliconflow-missing-${Date.now()}`);
+  assert.equal(quota, null);
+});
+
+test("fetchSiliconFlowQuota uses default global user-info endpoint", async () => {
+  const connectionId = `siliconflow-global-${Date.now()}`;
+  const calls: Array<{ url: string; init: RequestInit }> = [];
+
+  globalThis.fetch = async (url, init = {}) => {
+    calls.push({ url: String(url), init });
+    return new Response(
+      JSON.stringify({
+        code: 20000,
+        message: "OK",
+        status: true,
+        data: {
+          balance: "0.88",
+          chargeBalance: "88.00",
+          totalBalance: "88.88",
+          status: "normal",
+        },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } }
+    );
+  };
+
+  const quota = await fetchSiliconFlowQuota(connectionId, { apiKey: "sf-key" });
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, "https://api.siliconflow.com/v1/user/info");
+  assert.equal((calls[0].init.headers as Record<string, string>).Authorization, "Bearer sf-key");
+  assert.equal(quota?.percentUsed, 0);
+  assert.equal(quota?.limitReached, false);
+  assert.equal((quota as any)?.balance?.currency, "USD");
+  assert.equal((quota as any)?.balance?.totalBalance, 88.88);
+  assert.equal((quota as any)?.balance?.balance, 0.88);
+  assert.equal((quota as any)?.balance?.chargeBalance, 88);
+
+  invalidateSiliconFlowQuotaCache(connectionId);
+});
+
+test("fetchSiliconFlowQuota respects China providerSpecificData base URL", async () => {
+  const connectionId = `siliconflow-cn-${Date.now()}`;
+  let calledUrl = "";
+
+  globalThis.fetch = async (url) => {
+    calledUrl = String(url);
+    return new Response(
+      JSON.stringify({
+        code: 20000,
+        status: true,
+        data: { balance: "12.34", totalBalance: "12.34", status: "normal" },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } }
+    );
+  };
+
+  const quota = await fetchSiliconFlowQuota(connectionId, {
+    apiKey: "sf-key",
+    providerSpecificData: { baseUrl: "https://api.siliconflow.cn/v1" },
+  });
+
+  assert.equal(calledUrl, "https://api.siliconflow.cn/v1/user/info");
+  assert.equal((quota as any)?.balance?.currency, "CNY");
+  assert.equal((quota as any)?.balance?.totalBalance, 12.34);
+
+  invalidateSiliconFlowQuotaCache(connectionId);
+});
+
+test("fetchSiliconFlowQuota normalizes endpoint-shaped configured base URL", async () => {
+  const connectionId = `siliconflow-chat-base-${Date.now()}`;
+  let calledUrl = "";
+
+  globalThis.fetch = async (url) => {
+    calledUrl = String(url);
+    return new Response(
+      JSON.stringify({ status: true, data: { totalBalance: "5.00", status: "normal" } }),
+      { status: 200, headers: { "content-type": "application/json" } }
+    );
+  };
+
+  await fetchSiliconFlowQuota(connectionId, {
+    apiKey: "sf-key",
+    providerSpecificData: { baseUrl: "https://api.siliconflow.cn/v1/chat/completions" },
+  });
+
+  assert.equal(calledUrl, "https://api.siliconflow.cn/v1/user/info");
+
+  invalidateSiliconFlowQuotaCache(connectionId);
+});
+
+test("fetchSiliconFlowQuota falls back to balance when totalBalance is absent", async () => {
+  const connectionId = `siliconflow-balance-only-${Date.now()}`;
+
+  globalThis.fetch = async () =>
+    new Response(JSON.stringify({ status: true, data: { balance: "7.50", status: "normal" } }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+
+  const quota = await fetchSiliconFlowQuota(connectionId, { apiKey: "sf-key" });
+
+  assert.equal((quota as any)?.balance?.totalBalance, 7.5);
+  assert.equal(quota?.limitReached, false);
+
+  invalidateSiliconFlowQuotaCache(connectionId);
+});
+
+test("fetchSiliconFlowQuota marks exhausted for false top-level status", async () => {
+  const connectionId = `siliconflow-status-false-${Date.now()}`;
+
+  globalThis.fetch = async () =>
+    new Response(
+      JSON.stringify({ status: false, data: { totalBalance: "9.00", status: "normal" } }),
+      { status: 200, headers: { "content-type": "application/json" } }
+    );
+
+  const quota = await fetchSiliconFlowQuota(connectionId, { apiKey: "sf-key" });
+
+  assert.equal(quota?.limitReached, true);
+  assert.equal(quota?.percentUsed, 1);
+
+  invalidateSiliconFlowQuotaCache(connectionId);
+});
+
+test("fetchSiliconFlowQuota marks exhausted for non-normal account status", async () => {
+  const connectionId = `siliconflow-status-disabled-${Date.now()}`;
+
+  globalThis.fetch = async () =>
+    new Response(
+      JSON.stringify({ status: true, data: { totalBalance: "9.00", status: "disabled" } }),
+      { status: 200, headers: { "content-type": "application/json" } }
+    );
+
+  const quota = await fetchSiliconFlowQuota(connectionId, { apiKey: "sf-key" });
+
+  assert.equal(quota?.limitReached, true);
+  assert.equal(quota?.percentUsed, 1);
+  assert.equal((quota as any)?.accountStatus, "disabled");
+
+  invalidateSiliconFlowQuotaCache(connectionId);
+});
+
+test("fetchSiliconFlowQuota marks exhausted when balance is zero", async () => {
+  const connectionId = `siliconflow-zero-${Date.now()}`;
+
+  globalThis.fetch = async () =>
+    new Response(
+      JSON.stringify({ status: true, data: { totalBalance: "0.00", status: "normal" } }),
+      { status: 200, headers: { "content-type": "application/json" } }
+    );
+
+  const quota = await fetchSiliconFlowQuota(connectionId, { apiKey: "sf-key" });
+
+  assert.equal(quota?.limitReached, true);
+  assert.equal(quota?.percentUsed, 1);
+
+  invalidateSiliconFlowQuotaCache(connectionId);
+});
+
+test("fetchSiliconFlowQuota returns null on 401/403 and fail-open errors", async () => {
+  const authId = `siliconflow-auth-${Date.now()}`;
+
+  globalThis.fetch = async () => new Response(null, { status: 401 });
+  assert.equal(await fetchSiliconFlowQuota(authId, { apiKey: "bad" }), null);
+
+  globalThis.fetch = async () => new Response(null, { status: 500 });
+  assert.equal(await fetchSiliconFlowQuota(`${authId}-500`, { apiKey: "sf-key" }), null);
+
+  globalThis.fetch = async () => {
+    throw new Error("network down");
+  };
+  assert.equal(await fetchSiliconFlowQuota(`${authId}-network`, { apiKey: "sf-key" }), null);
+});
+
+test("fetchSiliconFlowQuota caches results within TTL", async () => {
+  const connectionId = `siliconflow-cache-${Date.now()}`;
+  let calls = 0;
+
+  globalThis.fetch = async () => {
+    calls += 1;
+    return new Response(
+      JSON.stringify({ status: true, data: { totalBalance: "6.00", status: "normal" } }),
+      { status: 200, headers: { "content-type": "application/json" } }
+    );
+  };
+
+  const first = await fetchSiliconFlowQuota(connectionId, { apiKey: "sf-key" });
+  const second = await fetchSiliconFlowQuota(connectionId, { apiKey: "sf-key" });
+
+  assert.equal(calls, 1);
+  assert.deepEqual(first, second);
+
+  invalidateSiliconFlowQuotaCache(connectionId);
+  await fetchSiliconFlowQuota(connectionId, { apiKey: "sf-key" });
+  assert.equal(calls, 2);
+
+  invalidateSiliconFlowQuotaCache(connectionId);
+});
+
+test("registerSiliconFlowQuotaFetcher exposes SiliconFlow quota to preflight and monitor", async () => {
+  const connectionId = `siliconflow-preflight-${Date.now()}`;
+
+  registerSiliconFlowQuotaFetcher();
+
+  globalThis.fetch = async () =>
+    new Response(
+      JSON.stringify({ status: true, data: { totalBalance: "0.00", status: "normal" } }),
+      { status: 200, headers: { "content-type": "application/json" } }
+    );
+
+  const preflight = await preflightQuota("siliconflow", connectionId, {
+    id: connectionId,
+    provider: "siliconflow",
+    apiKey: "sf-key",
+  });
+
+  assert.equal(preflight.proceed, false);
+  assert.equal(preflight.reason, "quota_exhausted");
+
+  touchSession("session-1", connectionId);
+  startQuotaMonitor("session-1", "siliconflow", connectionId, {
+    apiKey: "sf-key",
+    providerSpecificData: { quotaMonitorEnabled: true },
+  });
+  assert.equal(getActiveMonitorCount(), 1);
+  stopQuotaMonitor("session-1");
+
+  invalidateSiliconFlowQuotaCache(connectionId);
+});

--- a/tests/unit/usage-service-siliconflow.test.ts
+++ b/tests/unit/usage-service-siliconflow.test.ts
@@ -78,30 +78,38 @@ test("getUsageForProvider handles siliconflow China endpoint as CNY", async () =
   invalidateSiliconFlowQuotaCache("sf-usage-cn");
 });
 
-test("getUsageForProvider handles siliconflow insufficient balance", async () => {
+test("getUsageForProvider does not label normal siliconflow accounts insufficient from API balance alone", async () => {
   globalThis.fetch = async () =>
     new Response(
       JSON.stringify({
         code: 20000,
         status: true,
-        data: { balance: "0.00", totalBalance: "0.00", status: "normal" },
+        data: {
+          balance: "0",
+          chargeBalance: "-240.9806",
+          totalBalance: "-240.9806",
+          status: "normal",
+        },
       }),
       { status: 200, headers: { "content-type": "application/json" } }
     );
 
   const result = await getUsageForProvider({
-    id: "sf-usage-zero",
+    id: "sf-usage-normal-nonpositive",
     provider: "siliconflow",
     apiKey: "sf-key",
   });
 
-  assert.equal(result.plan, "SiliconFlow (Insufficient Balance)");
-  assert.equal(result.isAvailable, false);
-  assert.equal(result.limitReached, true);
+  assert.equal(result.plan, "SiliconFlow");
+  assert.equal(result.isAvailable, true);
+  assert.equal(result.limitReached, false);
   assert.ok(result.quotas?.credits_usd);
   assert.equal(result.quotas.credits_usd.remaining, 0);
+  assert.equal(result.quotas.credits_usd.apiBalance, 0);
+  assert.equal(result.quotas.credits_usd.totalBalance, -240.9806);
+  assert.equal(result.quotas.credits_usd.toppedUpBalance, -240.9806);
 
-  invalidateSiliconFlowQuotaCache("sf-usage-zero");
+  invalidateSiliconFlowQuotaCache("sf-usage-normal-nonpositive");
 });
 
 test("getUsageForProvider treats false top-level status as insufficient balance", async () => {

--- a/tests/unit/usage-service-siliconflow.test.ts
+++ b/tests/unit/usage-service-siliconflow.test.ts
@@ -1,0 +1,161 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { getUsageForProvider } from "../../open-sse/services/usage.ts";
+import { invalidateSiliconFlowQuotaCache } from "../../open-sse/services/siliconflowQuotaFetcher.ts";
+
+const originalFetch = globalThis.fetch;
+
+test.afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+test("getUsageForProvider handles siliconflow with valid global balance", async () => {
+  let calledUrl = "";
+  globalThis.fetch = async (url) => {
+    calledUrl = String(url);
+    return new Response(
+      JSON.stringify({
+        code: 20000,
+        message: "OK",
+        status: true,
+        data: {
+          balance: "0.88",
+          chargeBalance: "88.00",
+          totalBalance: "88.88",
+          status: "normal",
+        },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } }
+    );
+  };
+
+  const result = await getUsageForProvider({
+    id: "sf-usage-global",
+    provider: "siliconflow",
+    apiKey: "sf-key",
+  });
+
+  assert.equal(calledUrl, "https://api.siliconflow.com/v1/user/info");
+  assert.equal(result.plan, "SiliconFlow");
+  assert.equal(result.isAvailable, true);
+  assert.equal(result.limitReached, false);
+  assert.ok(result.quotas?.credits_usd);
+  assert.equal(result.quotas.credits_usd.remaining, 88.88);
+  assert.equal(result.quotas.credits_usd.currency, "USD");
+  assert.equal(result.quotas.credits_usd.toppedUpBalance, 88);
+
+  invalidateSiliconFlowQuotaCache("sf-usage-global");
+});
+
+test("getUsageForProvider handles siliconflow China endpoint as CNY", async () => {
+  let calledUrl = "";
+  globalThis.fetch = async (url) => {
+    calledUrl = String(url);
+    return new Response(
+      JSON.stringify({
+        code: 20000,
+        status: true,
+        data: { balance: "10.00", totalBalance: "10.00", status: "normal" },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } }
+    );
+  };
+
+  const result = await getUsageForProvider({
+    id: "sf-usage-cn",
+    provider: "siliconflow",
+    apiKey: "sf-key",
+    providerSpecificData: { baseUrl: "https://api.siliconflow.cn/v1" },
+  });
+
+  assert.equal(calledUrl, "https://api.siliconflow.cn/v1/user/info");
+  assert.equal(result.plan, "SiliconFlow");
+  assert.ok(result.quotas?.credits_cny);
+  assert.equal(result.quotas.credits_cny.remaining, 10);
+  assert.equal(result.quotas.credits_cny.currency, "CNY");
+
+  invalidateSiliconFlowQuotaCache("sf-usage-cn");
+});
+
+test("getUsageForProvider handles siliconflow insufficient balance", async () => {
+  globalThis.fetch = async () =>
+    new Response(
+      JSON.stringify({
+        code: 20000,
+        status: true,
+        data: { balance: "0.00", totalBalance: "0.00", status: "normal" },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } }
+    );
+
+  const result = await getUsageForProvider({
+    id: "sf-usage-zero",
+    provider: "siliconflow",
+    apiKey: "sf-key",
+  });
+
+  assert.equal(result.plan, "SiliconFlow (Insufficient Balance)");
+  assert.equal(result.isAvailable, false);
+  assert.equal(result.limitReached, true);
+  assert.ok(result.quotas?.credits_usd);
+  assert.equal(result.quotas.credits_usd.remaining, 0);
+
+  invalidateSiliconFlowQuotaCache("sf-usage-zero");
+});
+
+test("getUsageForProvider treats false top-level status as insufficient balance", async () => {
+  const testId = "sf-usage-status-false";
+
+  globalThis.fetch = async () =>
+    new Response(
+      JSON.stringify({
+        code: 20000,
+        status: false,
+        data: { balance: "0.88", totalBalance: "9.50", status: "normal" },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } }
+    );
+
+  const result = await getUsageForProvider({
+    id: testId,
+    provider: "siliconflow",
+    apiKey: "sf-key",
+  });
+
+  assert.equal(result.plan, "SiliconFlow (Insufficient Balance)");
+  assert.equal(result.isAvailable, false);
+  assert.equal(result.limitReached, true);
+  assert.ok(result.quotas?.credits_usd);
+  assert.equal(result.quotas.credits_usd.remaining, 9.5);
+
+  invalidateSiliconFlowQuotaCache(testId);
+});
+
+test("getUsageForProvider returns message when siliconflow API key is missing", async () => {
+  globalThis.fetch = async () => {
+    throw new Error("Fetch should not be called");
+  };
+
+  const result = await getUsageForProvider({
+    id: "sf-usage-no-key",
+    provider: "siliconflow",
+    apiKey: "",
+  });
+
+  assert.equal(result.message, "SiliconFlow API key not available. Add a key to view usage.");
+});
+
+test("getUsageForProvider handles siliconflow network error gracefully", async () => {
+  globalThis.fetch = async () => {
+    throw new Error("Network error");
+  };
+
+  const result = await getUsageForProvider({
+    id: "sf-usage-network",
+    provider: "siliconflow",
+    apiKey: "sf-key",
+  });
+
+  assert.ok(result.message);
+});


### PR DESCRIPTION
## Summary
- add a SiliconFlow balance quota fetcher for `GET /v1/user/info` with `.com`/`.cn` endpoint normalization, 60s cache, fail-open errors, and quota preflight/monitor registration
- wire SiliconFlow into usage/provider-limits support lists and the Provider Limits dashboard credit-balance parser
- add focused unit coverage for SiliconFlow balance parsing, usage mapping, exhausted balance/status handling, dashboard rendering, and usage source-of-truth wiring

## Validation
- `node --import tsx/esm --test --test-concurrency=1 tests/unit/siliconflow-quota-fetcher.test.ts tests/unit/usage-service-siliconflow.test.ts tests/unit/kimi-coding-apikey-quota-4435.test.ts tests/unit/provider-limits-ui.test.ts` — 44/44 passing
- `node node_modules/typescript/bin/tsc --pretty false -p tsconfig.typecheck-core.json`
- `git show --check --pretty=short HEAD`
- pre-commit/pre-push hooks: prettier, eslint, docs sync, `check:any-budget:t11`, `check:tracked-artifacts`
