### PR TITLE
Fix Ollama Cloud max reasoning effort

### DIFF
--- a/open-sse/executors/base.ts
+++ b/open-sse/executors/base.ts
@@ -236,10 +236,10 @@ function hasActiveClaudeThinking(body: Record<string, unknown>): boolean {
  * provider. Apply provider-aware sanitation here (after transformRequest, so
  * reintroductions by per-provider transforms are also caught) before fetch.
  * xhigh support is opt-out: pass through unchanged unless the registry marks
- * a model as unsupported. Literal max support is Claude/CC-compatible only and
- * intentionally separate: older Opus/Sonnet models may support max even when
- * they do not support xhigh. For OpenAI-shape providers, max normalizes to
- * xhigh by default and falls back to high only for explicit xhigh opt-outs.
+ * a model as unsupported. Literal max support is provider-specific and
+ * intentionally separate: some upstreams accept max even when they do not
+ * accept xhigh. For OpenAI-shape providers, max normalizes to xhigh by default
+ * and falls back to high only for explicit xhigh opt-outs.
  */
 const MISTRAL_NO_REASONING_EFFORT_PATTERN = /devstral/i;
 // GitHub Copilot Claude routing is granular (upstream port: decolua/9router#791):
@@ -264,9 +264,12 @@ function supportsMaxEffortForProvider(provider: string, model: string): boolean 
   // normalized to xhigh (the OmniRoute-internal top tier) and rejected by the
   // upstream. Scoped to opencode-go deliberately: OpenRouter's DeepSeek path
   // (pi#4055) is the documented inverse and expects xhigh, not max.
+  // Ollama Cloud also accepts literal max (for example GLM 5.2 supports
+  // low|medium|high|max|none) and rejects xhigh.
   const isOpencodeGoDeepSeek =
     provider === "opencode-go" && model.toLowerCase().includes("deepseek");
-  return isClaude || isOpencodeGoDeepSeek;
+  const isOllamaCloud = provider === "ollama-cloud";
+  return isClaude || isOpencodeGoDeepSeek || isOllamaCloud;
 }
 
 export function sanitizeReasoningEffortForProvider(

--- a/tests/unit/base-executor-sanitize-effort.test.ts
+++ b/tests/unit/base-executor-sanitize-effort.test.ts
@@ -88,6 +88,31 @@ test("sanitizeReasoningEffortForProvider: xiaomi-mimo normalizes max → xhigh b
   );
 });
 
+test("sanitizeReasoningEffortForProvider: Ollama Cloud preserves max", () => {
+  const log = makeLog();
+  const body = {
+    model: "glm-5.2",
+    reasoning_effort: "max",
+    messages: [{ role: "user", content: "hi" }],
+  };
+  const result = sanitizeReasoningEffortForProvider(body, "ollama-cloud", "glm-5.2", log);
+  assert.equal(result, body, "Ollama Cloud accepts max literally");
+  assert.equal((result as any).reasoning_effort, "max");
+  assert.equal(log.messages.length, 0);
+});
+
+test("sanitizeReasoningEffortForProvider: Ollama Cloud preserves nested max", () => {
+  const body = {
+    model: "glm-5.2",
+    reasoning: { effort: "max", summary: "auto" },
+    input: [],
+  };
+  const result = sanitizeReasoningEffortForProvider(body, "ollama-cloud", "glm-5.2", null);
+  assert.equal(result, body, "Ollama Cloud accepts max literally");
+  assert.equal((result as any).reasoning.effort, "max");
+  assert.equal((result as any).reasoning.summary, "auto");
+});
+
 test("sanitizeReasoningEffortForProvider: OpenRouter DeepSeek normalizes max → xhigh", () => {
   const log = makeLog();
   const body = {


### PR DESCRIPTION
## Problem

Ollama Cloud accepts `reasoning_effort` values `high`, `medium`, `low`, `max`, and `none`. It rejects `xhigh`.

OmniRoute currently treats literal `max` support as opt-in. Because `ollama-cloud` was not in `supportsMaxEffortForProvider()`, requests such as this were normalized before the upstream call:

```json
{
  "model": "ollama-cloud/glm-5.2",
  "reasoning_effort": "max",
  "messages": [{ "role": "user", "content": "hi" }]
}
```

The executor rewrote that to `reasoning_effort: "xhigh"`, and Ollama Cloud returned:

```text
invalid reasoning value: 'xhigh' (must be "high", "medium", "low", "max", or "none")
```

The same issue applies to Responses-style nested reasoning input:

```json
{
  "model": "ollama-cloud/glm-5.2",
  "reasoning": { "effort": "max" },
  "input": []
}
```

## Fix

Add `ollama-cloud` to `supportsMaxEffortForProvider()` so OmniRoute preserves literal `max` for Ollama Cloud instead of normalizing it to `xhigh`.

This keeps the existing default behavior for other OpenAI-shape providers, including OpenRouter DeepSeek paths that expect `xhigh`.

## Tests

Added unit coverage for:

- top-level `reasoning_effort: "max"` passthrough on `ollama-cloud/glm-5.2`
- nested `reasoning.effort: "max"` passthrough on `ollama-cloud/glm-5.2`
- existing OpenRouter DeepSeek `max -> xhigh` behavior remains covered

Ran:

```bash
DISABLE_SQLITE_AUTO_BACKUP=true node --max-old-space-size=8192 --import tsx --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test --test-force-exit tests/unit/base-executor-sanitize-effort.test.ts
```

Result: 34 passed.
