### PR TITLE
fix(pollinations): only enable jsonMode when JSON output is requested (#3981)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ _In development — bullets added per PR; finalized at release._
 
 - **fix(dashboard):** show custom provider given-name instead of internal id across dashboard pages — cache, combo health, compression analytics, cost overview, health/autopilot, provider stats, route explainability, provider utilization, runtime. Adds shared `resolveProviderName` resolver and `useProviderNodeMap` hook. (#4603)
 - **fix(dashboard):** on OAuth providers (e.g. GLM Coding), "Test all models" with auto-hide-failed now switches the model list to the "visible" filter after the run, so just-hidden failed models actually disappear on-screen — parity with the passthrough-provider path (#3610). Previously they were hidden in the DB but stayed visible under the "All" filter, so it looked like nothing was hidden. (#4887)
+- **fix(pollinations):** stop forcing `jsonMode` on every request. Pollinations treats `jsonMode=true` as "the model MUST return JSON" and rejects (HTTP 400 "messages must contain the word 'json'") any normal chat request whose messages don't mention "json", so all non-JSON chat was broken. `jsonMode` is now only enabled when the caller actually requests JSON output (`response_format.type` of `json_object` or `json_schema`). (#3981)
 
 ---
 

--- a/open-sse/executors/pollinations.ts
+++ b/open-sse/executors/pollinations.ts
@@ -38,7 +38,13 @@ export class PollinationsExecutor extends BaseExecutor {
     if (typeof body === "object" && body !== null) {
       body.model = model;
       body.stream = stream;
-      body.jsonMode = true;
+      // #3981: Pollinations treats jsonMode=true as "the model MUST return JSON"
+      // and rejects (HTTP 400) any request whose messages don't mention "json".
+      // Only enable it when the caller actually asked for JSON output.
+      const responseFormatType = body.response_format?.type;
+      if (responseFormatType === "json_object" || responseFormatType === "json_schema") {
+        body.jsonMode = true;
+      }
     }
     return body;
   }

--- a/tests/unit/pollinations-jsonmode-3981.test.ts
+++ b/tests/unit/pollinations-jsonmode-3981.test.ts
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { PollinationsExecutor } from "../../open-sse/executors/pollinations.ts";
+
+// #3981: Pollinations rejects (HTTP 400 "messages must contain the word 'json'")
+// any request with jsonMode=true whose messages don't mention "json". Setting
+// jsonMode unconditionally broke every normal chat request. jsonMode must only
+// be enabled when the caller actually requested JSON output.
+
+test("#3981 transformRequest does NOT force jsonMode for a normal request", () => {
+  const executor = new PollinationsExecutor();
+  const body: any = {
+    messages: [{ role: "user", content: "Hello there" }],
+  };
+  const out = executor.transformRequest("openai", body, true, null);
+  assert.notEqual(out.jsonMode, true);
+});
+
+test("#3981 transformRequest enables jsonMode when response_format json_object is requested", () => {
+  const executor = new PollinationsExecutor();
+  const body: any = {
+    messages: [{ role: "user", content: "Return json" }],
+    response_format: { type: "json_object" },
+  };
+  const out = executor.transformRequest("openai", body, true, null);
+  assert.equal(out.jsonMode, true);
+});
+
+test("#3981 transformRequest enables jsonMode when response_format json_schema is requested", () => {
+  const executor = new PollinationsExecutor();
+  const body: any = {
+    messages: [{ role: "user", content: "Return structured json" }],
+    response_format: { type: "json_schema", json_schema: { name: "x", schema: {} } },
+  };
+  const out = executor.transformRequest("openai", body, true, null);
+  assert.equal(out.jsonMode, true);
+});


### PR DESCRIPTION
Closes #3981

## Problem
`PollinationsExecutor.transformRequest` set `body.jsonMode = true` **unconditionally**. Pollinations treats `jsonMode=true` as "the model MUST return JSON" and rejects (HTTP 400 "messages must contain the word 'json'") any request whose messages don't mention "json" — so every normal chat broke.

## Fix
Only set `jsonMode` when the caller actually requested JSON output (`response_format.type === 'json_object' | 'json_schema'`). Otherwise it's left unset and plain chat works.

## Test
`tests/unit/pollinations-jsonmode-3981.test.ts` (node:test) — RED before (normal request forced jsonMode), GREEN after (3/3). No baseline bump.