### PR TITLE
fix(codebuddy): only send reasoning params when client requests reasoning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ _In development — bullets added per PR; finalized at release._
 ### 🔧 Bug Fixes
 
 - **fix(executors): strip `client_metadata` from forwarded body for Cerebras and Mistral** — Cerebras returns 400 (`wrong_api_format`) and Mistral returns 422 (`extra_forbidden`) when the passthrough body carries `client_metadata` (an OpenAI Codex / Claude CLI field with no equivalent on these upstreams). The default executor now drops it for these two providers before sending downstream; other providers (notably `openai`/`codex`) keep it. (thanks @saurabh321gupta)
+- **fix(codebuddy):** only send reasoning params when the client requests reasoning. (thanks @anki1kr)
 
 ---
 

--- a/open-sse/executors/codebuddy-cn.ts
+++ b/open-sse/executors/codebuddy-cn.ts
@@ -10,10 +10,11 @@ import type { ProviderCredentials } from "./base.ts";
  * as the client sent it, so we force it true here — OmniRoute still re-aggregates
  * the SSE into a JSON response for non-streaming clients.
  *
- * CodeBuddy CN only surfaces model reasoning when the request carries the
- * official CLI's OpenAI-style params: reasoning_effort + reasoning_summary:"auto".
- * Mirror the CLI here. When the caller explicitly asks for "none"/"off" we drop
- * the field entirely (the gateway has no "none" value).
+ * Reasoning params are opt-in: reasoning_summary:"auto" is only added when the
+ * client explicitly sets reasoning_effort. Plain requests are left untouched.
+ * When the caller explicitly asks for "none"/"off" we drop the field entirely
+ * (the gateway has no "none" value). Forcing reasoning on plain requests trips
+ * CodeBuddy's content filter and returns an error.
  */
 export class CodeBuddyCnExecutor extends DefaultExecutor {
   constructor() {
@@ -37,10 +38,14 @@ export class CodeBuddyCnExecutor extends DefaultExecutor {
     if (eff === "none" || eff === "off") {
       // Gateway has no "none" — just omit. Do NOT set reasoning_summary.
       delete out.reasoning_effort;
-    } else {
-      if (!eff) out.reasoning_effort = "medium";
+    } else if (eff) {
+      // Client explicitly asked for reasoning — mirror the CLI's reasoning_summary
+      // so CodeBuddy surfaces the model's reasoning.
       out.reasoning_summary = "auto";
     }
+    // No reasoning requested: leave both unset. Forcing reasoning_effort:"medium"
+    // + reasoning_summary on plain requests makes CodeBuddy trip its content
+    // filter and return an error.
     return out;
   }
 }

--- a/tests/unit/codebuddy-reasoning-optin.test.ts
+++ b/tests/unit/codebuddy-reasoning-optin.test.ts
@@ -1,0 +1,43 @@
+// #2071 — CodeBuddy forced reasoning_effort:"medium" + reasoning_summary:"auto"
+// on requests where the client never asked for reasoning, tripping CodeBuddy's
+// content filter ("model return error"). Reasoning params must be opt-in.
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { CodeBuddyCnExecutor } from "../../open-sse/executors/codebuddy-cn.ts";
+
+describe("CodeBuddyCnExecutor reasoning params are opt-in (#2071)", () => {
+  const exec = new CodeBuddyCnExecutor();
+
+  it("does NOT force reasoning when the client did not request it", () => {
+    const out = exec.transformRequest(
+      "glm-5.2",
+      { messages: [{ role: "user", content: "hi" }] },
+      false,
+      {}
+    ) as Record<string, unknown>;
+    assert.equal(out.reasoning_effort, undefined);
+    assert.equal(out.reasoning_summary, undefined);
+  });
+
+  it("mirrors reasoning_summary:auto when the client explicitly requested reasoning", () => {
+    const out = exec.transformRequest(
+      "glm-5.2",
+      { messages: [{ role: "user", content: "hi" }], reasoning_effort: "high" },
+      false,
+      {}
+    ) as Record<string, unknown>;
+    assert.equal(out.reasoning_effort, "high");
+    assert.equal(out.reasoning_summary, "auto");
+  });
+
+  it("omits reasoning_effort for none/off and adds no reasoning_summary", () => {
+    const out = exec.transformRequest(
+      "glm-5.2",
+      { messages: [{ role: "user", content: "hi" }], reasoning_effort: "none" },
+      false,
+      {}
+    ) as Record<string, unknown>;
+    assert.equal(out.reasoning_effort, undefined);
+    assert.equal(out.reasoning_summary, undefined);
+  });
+});


### PR DESCRIPTION
## Summary
- Gate CodeBuddy `reasoning_effort`/`reasoning_summary` behind an explicit client request, fixing plain (non-reasoning) requests that were tripping CodeBuddy's content filter.
- `transformRequest` no longer forces `reasoning_effort:"medium"` + `reasoning_summary:"auto"` on requests that don't set `reasoning_effort`. Plain requests are left untouched; `none`/`off` still drops the field; only an explicit effort value adds `reasoning_summary:"auto"`.

## Attribution
Thanks to [@anki1kr](https://github.com/anki1kr) for the original implementation.

## Test plan
- [x] `tests/unit/codebuddy-reasoning-optin.test.ts` — 3 tests: fails before fix (forces medium on plain request), passes after (3/3)
- [x] `npm run typecheck:core` — clean
- [x] `npm run lint` — clean