### PR TITLE
fix(copilot): replace execSync with execFile to prevent command injection

### DIFF
--- a/src/lib/copilot/tools.ts
+++ b/src/lib/copilot/tools.ts
@@ -5,7 +5,11 @@
  * query the codebase via CodeGraph, and execute CLI commands for full control.
  */
 
-import { execSync } from "node:child_process";
+import { execFile, execSync } from "node:child_process";
+import { promisify } from "node:util";
+import { sanitizeErrorMessage } from "@omniroute/open-sse/utils/error";
+
+const execFileAsync = promisify(execFile);
 import { createCombo, getCombos, updateCombo } from "@/lib/db/combos";
 import { getProviderConnections } from "@/lib/db/providers";
 import { createApiKey, revokeApiKey, getApiKeys } from "@/lib/db/apiKeys";
@@ -381,15 +385,20 @@ export const COPILOT_TOOLS: CopilotTool[] = [
       if (!cliPath) return "omniroute CLI not found in PATH. Install OmniRoute first.";
 
       try {
-        const output = execSync(`omniroute ${cmd}`, {
+        const trimmedCmd = cmd.trim();
+        if (!trimmedCmd) return "Please provide a command to execute.";
+        const argv = (trimmedCmd.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g) || []).map((arg) =>
+          arg.replace(/^["']|["']$/g, "")
+        );
+        const { stdout } = await execFileAsync(cliPath, argv, {
           encoding: "utf-8",
           timeout: 30000,
           maxBuffer: 1024 * 1024,
         });
-        return `\`\`\`\n${output.trim()}\n\`\`\``;
+        return `\`\`\`\n${stdout.trim()}\n\`\`\``;
       } catch (err: unknown) {
         const e = err as { stderr?: string; stdout?: string; message?: string };
-        return `Error executing CLI command:\n${e.stderr || e.stdout || e.message || "Unknown error"}`;
+        return `Error executing CLI command:\n${sanitizeErrorMessage(e.stderr || e.stdout || e.message || "Unknown error")}`;
       }
     },
   },

--- a/tests/unit/copilot-runOmniRouteCli.test.ts
+++ b/tests/unit/copilot-runOmniRouteCli.test.ts
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+test("runOmniRouteCli: missing command returns error", async () => {
+  const { getCopilotTool } = await import("../../src/lib/copilot/tools.ts");
+  const tool = getCopilotTool("runOmniRouteCli");
+  assert.ok(tool);
+  const result = await tool.handler({});
+  assert.equal(result, "Please provide a command to execute.");
+});
+
+test("runOmniRouteCli: empty command returns error", async () => {
+  const { getCopilotTool } = await import("../../src/lib/copilot/tools.ts");
+  const tool = getCopilotTool("runOmniRouteCli");
+  assert.ok(tool);
+  const result = await tool.handler({ command: "" });
+  assert.equal(result, "Please provide a command to execute.");
+});
+
+test("runOmniRouteCli: returns CLI-not-found when omniroute unavailable", async () => {
+  const { getCopilotTool } = await import("../../src/lib/copilot/tools.ts");
+  const tool = getCopilotTool("runOmniRouteCli");
+  assert.ok(tool);
+  const result = await tool.handler({ command: "health" });
+  assert.ok(
+    result.includes("omniroute CLI not found in PATH"),
+    `Expected CLI-not-found message, got: ${result}`
+  );
+});


### PR DESCRIPTION
## Summary

Fix command injection in the Copilot `runOmniRouteCli` tool by replacing `execSync()` shell string interpolation with `execFile()`.

## Problem

The `runOmniRouteCli` tool handler used `execSync("omniroute " + cmd)` which passes the user-supplied `command` argument through a shell. An attacker controlling the `command` parameter can inject shell metacharacters (`;`, `|`, `&&`, backtick) to execute arbitrary commands — CVSS 9.8.

## Changes

- **`src/lib/copilot/tools.ts`:** Replaced `execSync()` with `execFileAsync(cliPath, argv)`. `execFile()` does not invoke a shell; arguments are passed directly to the executable, making metacharacters literal.
- **`src/lib/copilot/tools.ts`:** Added `sanitizeErrorMessage()` to error output to prevent leaking paths or internals on failure.

## How it works

1. The `command` string is split into an `argv` array by whitespace
2. `execFileAsync(cliPath, argv)` runs `cliPath` with `argv[0]` as first arg, `argv[1]` as second, etc. — no shell involved
3. Shell metacharacters like `; rm -rf /` are treated as literal argument text, not executed
4. Error output is sanitized through the codebase's standard `sanitizeErrorMessage()` helper
