### PR TITLE
fix(build): exclude .claude worktrees from tsconfig scope (stops local next build OOM)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -77,6 +77,8 @@ bun.lock
 # Agent config
 .agents
 .gemini
+.claude
+.source
 
 # Misc
 llm.txt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -419,25 +419,33 @@ own dedicated branch, and you MUST confirm the base branch with the operator bef
    `AskUserQuestion`, unless they already told you) from which branch the new worktree/branch
    should be cut. Do NOT assume `main` or "whatever I'm on" — the answer is usually the active
    `release/vX.Y.Z`, but it can be another feature/release branch. Get the base explicitly.
-2. **Create an isolated worktree + branch off that base** (never reuse the main checkout):
+2. **Create an isolated worktree + branch off that base** (never reuse the main checkout).
+   **🔴 MANDATORY PATH: every worktree lives under `.claude/worktrees/` — and nowhere else.**
+   This is the single canonical location (the same dir the native `EnterWorktree` tool uses). It
+   is gitignored AND in the `tsconfig.json` / `.dockerignore` excludes, so worktrees never leak
+   into the build scope. **Never** use `.worktrees/`, repo-root, or any other path — a worktree
+   outside `.claude/worktrees/` (a) escapes the build-scope excludes and poisons `next build` (the
+   `tsconfig` `include: **/*` globs ~70× the codebase → OOM; incident 2026-06-25) and (b) scatters
+   worktrees across two dirs.
 
    ```bash
    BASE_BRANCH="release/vX.Y.Z"          # ← the branch the operator confirmed in step 1
    TASK="feat/your-feature"               # feat/ fix/ refactor/ docs/ test/ chore/
    git fetch origin "$BASE_BRANCH"
-   git worktree add ".worktrees/${TASK##*/}" -b "$TASK" "origin/$BASE_BRANCH"
-   cd ".worktrees/${TASK##*/}"
+   git worktree add ".claude/worktrees/${TASK##*/}" -b "$TASK" "origin/$BASE_BRANCH"
+   cd ".claude/worktrees/${TASK##*/}"
    # symlink node_modules from the main checkout to skip a per-worktree npm install:
    ln -s "$(git -C <main_checkout> rev-parse --show-toplevel)/node_modules" node_modules
    ```
 
-   In Claude Code prefer the native `EnterWorktree` tool (create the worktree with the command
-   above, then call `EnterWorktree` with its `path`).
+   In Claude Code prefer the native `EnterWorktree` tool (it already creates worktrees under
+   `.claude/worktrees/`): create the worktree with the command above, then call `EnterWorktree`
+   with its `path`.
 
 3. **Work, commit, push, open the PR — all from inside the worktree.** Never `git checkout` a
    different branch inside a worktree another session might share.
 4. **Tear down only your own** worktree + branch when done, from the main checkout:
-   `git worktree remove .worktrees/<dir>` then `git branch -D <task>`. Never blanket-delete
+   `git worktree remove .claude/worktrees/<dir>` then `git branch -D <task>`. Never blanket-delete
    `fix/*`/`feat/*` — other sessions keep their own; delete only the branches you created, by name.
 5. **Never touch another session's worktree, branch, or uncommitted changes.** If `git worktree
 list` shows worktrees you didn't create, leave them alone. End every session with the main

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -55,14 +55,16 @@
   "exclude": [
     "node_modules",
     "open-sse",
-    "antigravity-manager-analysis",
-    "app.__qa_backup",
-    "vscode-extension",
-    "vs_ideia",
+    "dist",
+    "coverage",
+    ".source",
+    ".tmp",
+    ".claude",
+    ".worktrees",
+    "@omniroute",
     "_tasks",
+    "_ideia",
     "_mono_repo",
-    "_references",
-    "omnirouteCloud",
-    "omnirouteSite"
+    "_references"
   ]
 }


### PR DESCRIPTION
## Root cause of the local `build:release` OOM/GC-livelock (2026-06-25 deploy blocker)

`tsconfig.json` uses `include: ["**/*.ts","**/*.tsx","**/*.js","**/*.jsx"]` (recursive glob) but `exclude` did **not** list `.claude` — where git worktrees live (`.claude/worktrees/`). With 69 active port-* worktrees present, the TypeScript scope was:

| scope | files |
| --- | --- |
| WITH worktrees | **355,215** (352,261 inside `.claude/worktrees`) |
| real source | **4,547** |

`next build`'s type-check/scan processed ~70× the codebase → OOM at 4GB **and** 16GB, GC-livelock at 32GB **and** 64GB. **CI built fine** because its checkout is clean (no worktrees). This is why "it works in CI but not locally".

## Fix
- **tsconfig.json** `exclude`: add `.claude`, `.worktrees`, `.source`, `coverage`, `@omniroute`, `.tmp`, `dist`, `_ideia`; remove 6 stale entries for dirs that no longer exist.
- **.dockerignore**: add `.claude`, `.source` (the `_*` glob already covered underscore dirs).
- **CLAUDE.md**: standardize ALL worktrees under `.claude/worktrees/` (was split across `.claude/worktrees/` and `.worktrees/`) — the single gitignored + build-excluded location the native `EnterWorktree` tool already uses.

## Evidence
After removing the 69 worktrees + this exclude, `build:release` completes with the **DEFAULT 4GB heap** (no `OMNIROUTE_BUILD_MEMORY_MB` override):

```text
BUILD rc=0 in 17m12s
BUILD_SHA: 182bc398d  ✅
TS scope: 355,215 → 4,547 files (-98.7%)
peak RSS: ~28GB (poisoned) → ~3.9GB (clean)
```

No production code (`src`/`open-sse`/`electron`/`bin`) changed → no test requirement.