### PR TITLE
feat(cc): add summarized thinking display toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ _In development — bullets added per PR; finalized at release._
 - **feat(cursor):** parse Cursor Composer DeepSeek-style inline tool calls — Composer `cu/composer-2.5*` models embed tool invocations in their visible text using `<｜tool▁calls▁begin｜>…<｜tool▁calls▁end｜>` markers instead of structured protobuf frames; a new streaming parser (`composerToolCalls.ts`) intercepts these in both streaming and non-streaming paths, suppresses the markers from the client-visible content, and emits proper OpenAI `tool_calls` deltas so downstream clients handle them natively. (thanks @noestelar)
 - **feat(proxy):** support auth-less `host:port` batch import and surface proxy-test failures. (thanks @dimaslanjaka)
 - **feat(video): Alibaba DashScope video provider (`wan2.7-t2v`)** — adds the `alibaba` video provider (DashScope async task → poll → MP4) wired through the standard apikey credential path, so text-to-video requests can route to Alibaba's `wan2.7-t2v` model. (thanks @josevictorferreira)
+- **feat(cc): per-connection "summarized thinking display" toggle for Claude-Code-compatible providers** — exposes a connection-level toggle that drives the existing Copilot summarized-thinking marker, so operators can opt a CC-compatible connection into summarized reasoning display from the UI (schema + request defaults + provider modals, with i18n). (thanks @rdself)
 
 ### 🔧 Bug Fixes
 

--- a/docs/providers/AGENTROUTER.md
+++ b/docs/providers/AGENTROUTER.md
@@ -121,16 +121,17 @@ provider.
 For reference, the cc-compatible bridge sends the following on each upstream
 request (see `open-sse/services/claudeCodeCompatible.ts`):
 
-| Header                                      | Value                                                                                               |
-| ------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| `Authorization`                             | `Bearer <api-key>`                                                                                  |
-| `User-Agent`                                | `claude-cli/2.1.187 (external, sdk-cli)`                                                            |
-| `anthropic-version`                         | `2023-06-01`                                                                                        |
-| `anthropic-beta`                            | `claude-code-20250219,interleaved-thinking-2025-05-14,effort-2025-11-24`                            |
-| Per-connection redact-thinking beta toggle  | Adds `redact-thinking-2026-02-12` for upstreams that specifically require redacted thinking streams |
-| `anthropic-dangerous-direct-browser-access` | `true`                                                                                              |
-| `x-app`                                     | `cli`                                                                                               |
-| `X-Stainless-*`                             | Various Stainless SDK headers (lang, package version, OS, arch, etc.)                               |
+| Header                                      | Value                                                                                                   |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `Authorization`                             | `Bearer <api-key>`                                                                                      |
+| `User-Agent`                                | `claude-cli/2.1.187 (external, sdk-cli)`                                                                |
+| `anthropic-version`                         | `2023-06-01`                                                                                            |
+| `anthropic-beta`                            | `claude-code-20250219,interleaved-thinking-2025-05-14,effort-2025-11-24`                                |
+| Per-connection redact-thinking beta toggle  | Adds `redact-thinking-2026-02-12` for upstreams that specifically require redacted thinking streams     |
+| Per-connection summarized thinking toggle   | Adds `display: "summarized"` to CC Compatible thinking requests that did not already set a display mode |
+| `anthropic-dangerous-direct-browser-access` | `true`                                                                                                  |
+| `x-app`                                     | `cli`                                                                                                   |
+| `X-Stainless-*`                             | Various Stainless SDK headers (lang, package version, OS, arch, etc.)                                   |
 
 This is what allows requests to pass the upstream WAF / client whitelist.
 

--- a/docs/security/STEALTH_GUIDE.md
+++ b/docs/security/STEALTH_GUIDE.md
@@ -93,6 +93,7 @@ For third-party Anthropic relays that only accept "real Claude Code" traffic:
 - `CLAUDE_CODE_COMPATIBLE_STAINLESS_RUNTIME_VERSION = "v24.3.0"`
 - `anthropic-beta = "claude-code-20250219,interleaved-thinking-2025-05-14,effort-2025-11-24"` by default
 - The per-connection "Enable redact-thinking beta" toggle adds `redact-thinking-2026-02-12` when a CC Compatible upstream specifically requires redacted thinking streams
+- The per-connection "Enable summarized thinking display" toggle stores `providerSpecificData.requestDefaults.summarizeThinking` and adds `display: "summarized"` to CC Compatible thinking requests that did not already set a display mode
 - `CONTEXT_1M_BETA_HEADER = "context-1m-2025-08-07"` (Opus/Sonnet 4.x family)
 - Default path: `/v1/messages?beta=true`
 

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -279,6 +279,7 @@ import { generateRequestId } from "@/shared/utils/requestId";
 import { extractFacts } from "@/lib/memory/extraction";
 import { handleToolCallExecution } from "@/lib/skills/interception";
 import { OMNIROUTE_RESPONSE_HEADERS } from "@/shared/constants/headers";
+import { getClaudeCodeCompatibleRequestDefaults } from "@/lib/providers/requestDefaults";
 import {
   buildClaudeCodeCompatibleRequest,
   isClaudeCodeCompatibleProvider,
@@ -1559,6 +1560,9 @@ export async function handleChatCore({
       }
 
       ccSessionId = resolveClaudeCodeCompatibleSessionId(clientRawRequest?.headers);
+      const ccRequestDefaults = getClaudeCodeCompatibleRequestDefaults(
+        credentials?.providerSpecificData
+      );
       translatedBody = buildClaudeCodeCompatibleRequest({
         sourceBody: body,
         normalizedBody: normalizedForCc,
@@ -1570,6 +1574,7 @@ export async function handleChatCore({
         now: new Date(),
         preserveCacheControl,
         preserveClaudeMessages: sourceFormat === FORMATS.CLAUDE && isClaudeCodeSemanticPassthrough,
+        summarizeThinking: ccRequestDefaults.summarizeThinking === true,
       });
       log?.debug?.("FORMAT", "claude-code-compatible bridge enabled");
 

--- a/open-sse/services/claudeCodeCompatible.ts
+++ b/open-sse/services/claudeCodeCompatible.ts
@@ -12,6 +12,7 @@ import {
   disableThinkingIfToolChoiceForced,
   enforceCacheControlLimit,
 } from "./claudeCodeConstraints.ts";
+import { applyClaudeCodeCompatibleThinkingDisplay } from "./claudeCodeCompatibleThinkingDisplay.ts";
 import { obfuscateInBody } from "./claudeCodeObfuscation.ts";
 import { applySystemTransformPipeline, PROVIDER_CC_BRIDGE } from "./systemTransforms.ts";
 import {
@@ -45,7 +46,6 @@ export const CLAUDE_CODE_COMPATIBLE_USER_AGENT = "claude-cli/2.1.187 (external, 
 export const CLAUDE_CODE_COMPATIBLE_STAINLESS_PACKAGE_VERSION = "0.94.0";
 export const CLAUDE_CODE_COMPATIBLE_STAINLESS_RUNTIME_VERSION = "v24.3.0";
 export const CONTEXT_1M_BETA_HEADER = "context-1m-2025-08-07";
-const COPILOT_REASONING_SUMMARY_MARKER = "_omnirouteCopilotReasoningSummary";
 const CLAUDE_CODE_COMPATIBLE_DEFAULT_SYSTEM_BLOCKS = [
   {
     type: "text",
@@ -86,6 +86,7 @@ type BuildRequestOptions = {
   preserveCacheControl?: boolean;
   preserveClaudeMessages?: boolean;
   redactThinking?: boolean;
+  summarizeThinking?: boolean;
 };
 
 function supportsClaudeXHighEffort(model: string | null | undefined): boolean {
@@ -239,7 +240,7 @@ export function buildClaudeCodeCompatibleRequest({
   sessionId,
   preserveCacheControl = false,
   preserveClaudeMessages = false,
-  redactThinking = false,
+  summarizeThinking = false,
 }: BuildRequestOptions) {
   const normalized = normalizedBody || {};
   const preparedClaudeBody = claudeBody
@@ -297,6 +298,7 @@ export function buildClaudeCodeCompatibleRequest({
     claudeBody: preparedClaudeBody ?? claudeBody,
     sourceBody,
     normalizedBody,
+    summarizeThinking,
   });
   const outputConfig = resolveClaudeCodeCompatibleOutputConfig({
     claudeBody,
@@ -1051,10 +1053,12 @@ function resolveClaudeCodeCompatibleThinking({
   claudeBody,
   sourceBody,
   normalizedBody,
+  summarizeThinking = false,
 }: {
   claudeBody?: Record<string, unknown> | null;
   sourceBody?: Record<string, unknown> | null;
   normalizedBody?: Record<string, unknown> | null;
+  summarizeThinking?: boolean;
 }) {
   const thinking =
     readRecord(cloneValue(claudeBody?.thinking)) ||
@@ -1062,31 +1066,21 @@ function resolveClaudeCodeCompatibleThinking({
     readRecord(cloneValue(normalizedBody?.thinking));
 
   if (thinking) {
-    return applyClaudeCodeCompatibleThinkingDisplay(thinking, normalizedBody);
+    return applyClaudeCodeCompatibleThinkingDisplay(thinking, {
+      normalizedBody,
+      summarizeThinking,
+    });
   }
 
   return applyClaudeCodeCompatibleThinkingDisplay(
     {
       type: "adaptive",
     },
-    normalizedBody
+    {
+      normalizedBody,
+      summarizeThinking,
+    }
   );
-}
-
-function applyClaudeCodeCompatibleThinkingDisplay(
-  thinking: Record<string, unknown>,
-  normalizedBody?: Record<string, unknown> | null
-) {
-  if (
-    normalizedBody?.[COPILOT_REASONING_SUMMARY_MARKER] !== "summarized" ||
-    thinking.type === "disabled"
-  ) {
-    return thinking;
-  }
-  return {
-    ...thinking,
-    display: "summarized",
-  };
 }
 
 function resolveClaudeCodeCompatibleOutputConfig({

--- a/open-sse/services/claudeCodeCompatibleThinkingDisplay.ts
+++ b/open-sse/services/claudeCodeCompatibleThinkingDisplay.ts
@@ -1,0 +1,34 @@
+const COPILOT_REASONING_SUMMARY_MARKER = "_omnirouteCopilotReasoningSummary";
+
+export function applyClaudeCodeCompatibleThinkingDisplay(
+  thinking: Record<string, unknown>,
+  options: {
+    normalizedBody?: Record<string, unknown> | null;
+    summarizeThinking?: boolean;
+  } = {}
+) {
+  if (thinking.type === "disabled") {
+    return thinking;
+  }
+
+  const markerRequestsSummary =
+    options.normalizedBody?.[COPILOT_REASONING_SUMMARY_MARKER] === "summarized";
+  const connectionRequestsSummary = options.summarizeThinking === true;
+  if (!markerRequestsSummary && !connectionRequestsSummary) {
+    return thinking;
+  }
+
+  const hasExplicitDisplay =
+    Object.prototype.hasOwnProperty.call(thinking, "display") &&
+    thinking.display !== undefined &&
+    thinking.display !== null &&
+    String(thinking.display).trim().length > 0;
+  if (hasExplicitDisplay && !markerRequestsSummary) {
+    return thinking;
+  }
+
+  return {
+    ...thinking,
+    display: "summarized",
+  };
+}

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/modals/AddApiKeyModal.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/modals/AddApiKeyModal.tsx
@@ -116,6 +116,7 @@ export default function AddApiKeyModal({
     ...EMPTY_QUOTA_SCRAPING_FIELDS,
     ccCompatibleContext1m: false,
     ccCompatibleRedactThinking: false,
+    ccCompatibleSummarizeThinking: false,
     passthroughModels: false,
     importFreeModelsOnly: false,
   });
@@ -679,14 +680,8 @@ export default function AddApiKeyModal({
               <div className="flex flex-col gap-4 rounded-lg border border-border/50 bg-surface/20 p-4">
                 {isCcCompatible && (
                   <CcCompatibleRequestDefaultsFields
-                    context1m={formData.ccCompatibleContext1m}
-                    redactThinking={formData.ccCompatibleRedactThinking}
-                    onContext1mChange={(checked) =>
-                      setFormData({ ...formData, ccCompatibleContext1m: checked })
-                    }
-                    onRedactThinkingChange={(checked) =>
-                      setFormData({ ...formData, ccCompatibleRedactThinking: checked })
-                    }
+                    values={formData}
+                    onChange={(patch) => setFormData({ ...formData, ...patch })}
                   />
                 )}
                 {openRouterPreset.input}

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/modals/CcCompatibleRequestDefaultsFields.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/modals/CcCompatibleRequestDefaultsFields.tsx
@@ -4,33 +4,38 @@ import { useTranslations } from "next-intl";
 import { Toggle } from "@/shared/components";
 
 type CcCompatibleRequestDefaultsFieldsProps = {
-  context1m: boolean;
-  redactThinking: boolean;
-  onContext1mChange: (checked: boolean) => void;
-  onRedactThinkingChange: (checked: boolean) => void;
+  values: {
+    ccCompatibleContext1m: boolean;
+    ccCompatibleRedactThinking: boolean;
+    ccCompatibleSummarizeThinking: boolean;
+  };
+  onChange: (patch: Partial<CcCompatibleRequestDefaultsFieldsProps["values"]>) => void;
 };
 
-export default function CcCompatibleRequestDefaultsFields({
-  context1m,
-  redactThinking,
-  onContext1mChange,
-  onRedactThinkingChange,
-}: CcCompatibleRequestDefaultsFieldsProps) {
+export default function CcCompatibleRequestDefaultsFields(
+  props: CcCompatibleRequestDefaultsFieldsProps
+) {
   const t = useTranslations("providers");
 
   return (
     <div className="flex flex-col gap-4 rounded-lg border border-border/50 bg-surface/20 p-4">
       <Toggle
-        checked={context1m}
-        onChange={onContext1mChange}
+        checked={props.values.ccCompatibleContext1m}
+        onChange={(checked) => props.onChange({ ccCompatibleContext1m: checked })}
         label={t("ccCompatibleContext1mLabel")}
         description={t("ccCompatibleContext1mDescription")}
       />
       <Toggle
-        checked={redactThinking}
-        onChange={onRedactThinkingChange}
+        checked={props.values.ccCompatibleRedactThinking}
+        onChange={(checked) => props.onChange({ ccCompatibleRedactThinking: checked })}
         label={t("ccCompatibleRedactThinkingLabel")}
         description={t("ccCompatibleRedactThinkingDescription")}
+      />
+      <Toggle
+        checked={props.values.ccCompatibleSummarizeThinking}
+        onChange={(checked) => props.onChange({ ccCompatibleSummarizeThinking: checked })}
+        label={t("ccCompatibleSummarizeThinkingLabel")}
+        description={t("ccCompatibleSummarizeThinkingDescription")}
       />
     </div>
   );

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/modals/EditConnectionModal.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/modals/EditConnectionModal.tsx
@@ -119,6 +119,7 @@ export default function EditConnectionModal({
     ...EMPTY_QUOTA_SCRAPING_FIELDS,
     ccCompatibleContext1m: false,
     ccCompatibleRedactThinking: false,
+    ccCompatibleSummarizeThinking: false,
     cloudCodeProjectId: "",
     antigravityClientProfile: "ide",
     blockExtraUsage:
@@ -280,6 +281,7 @@ export default function EditConnectionModal({
         ollamaCloudUsageCookie: "",
         ccCompatibleContext1m: ccRequestDefaults.context1m,
         ccCompatibleRedactThinking: ccRequestDefaults.redactThinking,
+        ccCompatibleSummarizeThinking: ccRequestDefaults.summarizeThinking,
         cloudCodeProjectId:
           (connection.providerSpecificData?.projectId as string) || connection.projectId || "",
         antigravityClientProfile: normalizeAntigravityClientProfileSetting(
@@ -654,14 +656,8 @@ export default function EditConnectionModal({
           <div className="flex flex-col gap-4 rounded-lg border border-border/50 bg-surface/20 p-4">
             {isCcCompatible && (
               <CcCompatibleRequestDefaultsFields
-                context1m={formData.ccCompatibleContext1m}
-                redactThinking={formData.ccCompatibleRedactThinking}
-                onContext1mChange={(checked) =>
-                  setFormData({ ...formData, ccCompatibleContext1m: checked })
-                }
-                onRedactThinkingChange={(checked) =>
-                  setFormData({ ...formData, ccCompatibleRedactThinking: checked })
-                }
+                values={formData}
+                onChange={(patch) => setFormData({ ...formData, ...patch })}
               />
             )}
             {openRouterPreset.input}

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/modals/ccCompatibleRequestDefaults.ts
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/modals/ccCompatibleRequestDefaults.ts
@@ -1,11 +1,13 @@
 type CcCompatibleRequestDefaultsForm = {
   ccCompatibleContext1m: boolean;
   ccCompatibleRedactThinking: boolean;
+  ccCompatibleSummarizeThinking: boolean;
 };
 
 const CC_COMPATIBLE_BOOLEAN_DEFAULTS = [
   ["context1m", "ccCompatibleContext1m"],
   ["redactThinking", "ccCompatibleRedactThinking"],
+  ["summarizeThinking", "ccCompatibleSummarizeThinking"],
 ] as const;
 
 function asRecord(value: unknown): Record<string, unknown> {

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/modals/connectionProviderSpecificData.ts
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/modals/connectionProviderSpecificData.ts
@@ -13,6 +13,7 @@ type FormData = QuotaScrapingFieldValues & {
   apiRegion: string;
   ccCompatibleContext1m: boolean;
   ccCompatibleRedactThinking: boolean;
+  ccCompatibleSummarizeThinking: boolean;
   consoleApiKey: string;
   customUserAgent: string;
   cx: string;

--- a/src/app/(dashboard)/dashboard/providers/[id]/providerPageHelpers.ts
+++ b/src/app/(dashboard)/dashboard/providers/[id]/providerPageHelpers.ts
@@ -696,12 +696,12 @@ export function getCodexRequestDefaults(providerSpecificData: unknown): {
     ...(defaults.serviceTier ? { serviceTier: defaults.serviceTier } : {}),
   };
 }
-
 export function getClaudeCodeCompatibleRequestDefaults(providerSpecificData: unknown) {
   const defaults = _getClaudeCodeCompatibleRequestDefaults(providerSpecificData);
   return {
     context1m: defaults.context1m === true,
     redactThinking: defaults.redactThinking === true,
+    summarizeThinking: defaults.summarizeThinking === true,
   };
 }
 

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -4159,6 +4159,8 @@
     "ccCompatibleContext1mLabel": "Cc Compatible Context1M Label",
     "ccCompatibleRedactThinkingDescription": "Adds the redact-thinking beta header for CC Compatible upstreams that require hidden Claude thinking streams.",
     "ccCompatibleRedactThinkingLabel": "Enable redact-thinking beta",
+    "ccCompatibleSummarizeThinkingDescription": "Adds `display: \"summarized\"` to CC Compatible thinking requests so supported Claude models stream visible thinking deltas.",
+    "ccCompatibleSummarizeThinkingLabel": "Enable summarized thinking display",
     "ccCompatibleDetailsTitle": "Cc Compatible Details Title",
     "ccCompatibleLabel": "Cc Compatible Label",
     "ccCompatibleModelsDescription": "Cc Compatible Models Description",

--- a/src/i18n/messages/az.json
+++ b/src/i18n/messages/az.json
@@ -4159,6 +4159,8 @@
     "ccCompatibleContext1mLabel": "Enable 1M context beta",
     "ccCompatibleRedactThinkingDescription": "Adds the redact-thinking beta header for CC Compatible upstreams that require hidden Claude thinking streams.",
     "ccCompatibleRedactThinkingLabel": "Enable redact-thinking beta",
+    "ccCompatibleSummarizeThinkingDescription": "Adds `display: \"summarized\"` to CC Compatible thinking requests so supported Claude models stream visible thinking deltas.",
+    "ccCompatibleSummarizeThinkingLabel": "Enable summarized thinking display",
     "ccCompatibleDetailsTitle": "CC-compatible relay details",
     "ccCompatibleLabel": "CC Compatible",
     "ccCompatibleModelsDescription": "CC-compatible relays do not expose model listing. Add the Claude model IDs your relay accepts.",

--- a/src/i18n/messages/bg.json
+++ b/src/i18n/messages/bg.json
@@ -4159,6 +4159,8 @@
     "ccCompatibleContext1mLabel": "Cc Compatible Context1M Label",
     "ccCompatibleRedactThinkingDescription": "Adds the redact-thinking beta header for CC Compatible upstreams that require hidden Claude thinking streams.",
     "ccCompatibleRedactThinkingLabel": "Enable redact-thinking beta",
+    "ccCompatibleSummarizeThinkingDescription": "Adds `display: \"summarized\"` to CC Compatible thinking requests so supported Claude models stream visible thinking deltas.",
+    "ccCompatibleSummarizeThinkingLabel": "Enable summarized thinking display",
     "ccCompatibleDetailsTitle": "Cc Compatible Details Title",
     "ccCompatibleLabel": "Cc Compatible Label",
     "ccCompatibleModelsDescription": "Cc Compatible Models Description",

--- a/src/i18n/messages/bn.json
+++ b/src/i18n/messages/bn.json
@@ -4159,6 +4159,8 @@
     "ccCompatibleContext1mLabel": "Cc Compatible Context1M Label",
     "ccCompatibleRedactThinkingDescription": "Adds the redact-thinking beta header for CC Compatible upstreams that require hidden Claude thinking streams.",
     "ccCompatibleRedactThinkingLabel": "Enable redact-thinking beta",
+    "ccCompatibleSummarizeThinkingDescription": "Adds `display: \"summarized\"` to CC Compatible thinking requests so supported Claude models stream visible thinking deltas.",
+    "ccCompatibleSummarizeThinkingLabel": "Enable summarized thinking display",
     "ccCompatibleDetailsTitle": "Cc Compatible Details Title",
     "ccCompatibleLabel": "Cc Compatible Label",
     "ccCompatibleModelsDescription": "Cc Compatible Models Description",

--- a/src/i18n/messages/cs.json
+++ b/src/i18n/messages/cs.json
@@ -4159,6 +4159,8 @@
     "ccCompatibleContext1mLabel": "Cc Compatible Context1M Label",
     "ccCompatibleRedactThinkingDescription": "Adds the redact-thinking beta header for CC Compatible upstreams that require hidden Claude thinking streams.",
     "ccCompatibleRedactThinkingLabel": "Enable redact-thinking beta",
+    "ccCompatibleSummarizeThinkingDescription": "Adds `display: \"summarized\"` to CC Compatible thinking requests so supported Claude models stream visible thinking deltas.",
+    "ccCompatibleSummarizeThinkingLabel": "Enable summarized thinking display",
     "ccCompatibleDetailsTitle": "Cc Compatible Details Title",
     "ccCompatibleLabel": "Cc Compatible Label",
     "ccCompatibleModelsDescription": "Cc Compatible Models Description",

--- a/src/i18n/messages/da.json
+++ b/src/i18n/messages/da.json
@@ -4159,6 +4159,8 @@
     "ccCompatibleContext1mLabel": "Cc Compatible Context1M Label",
     "ccCompatibleRedactThinkingDescription": "Adds the redact-thinking beta header for CC Compatible upstreams that require hidden Claude thinking streams.",
     "ccCompatibleRedactThinkingLabel": "Enable redact-thinking beta",
+    "ccCompatibleSummarizeThinkingDescription": "Adds `display: \"summarized\"` to CC Compatible thinking requests so supported Claude models stream visible thinking deltas.",
+    "ccCompatibleSummarizeThinkingLabel": "Enable summarized thinking display",
     "ccCompatibleDetailsTitle": "Cc Compatible Details Title",
     "ccCompatibleLabel": "Cc Compatible Label",
     "ccCompatibleModelsDescription": "Cc Compatible Models Description",

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -4164,6 +4164,8 @@
     "ccCompatibleContext1mLabel": "Cc Compatible Context1M Label",
     "ccCompatibleRedactThinkingDescription": "Adds the redact-thinking beta header for CC Compatible upstreams that require hidden Claude thinking streams.",
     "ccCompatibleRedactThinkingLabel": "Enable redact-thinking beta",
+    "ccCompatibleSummarizeThinkingDescription": "Adds `display: \"summarized\"` to CC Compatible thinking requests so supported Claude models stream visible thinking deltas.",
+    "ccCompatibleSummarizeThinkingLabel": "Enable summarized thinking display",
     "ccCompatibleDetailsTitle": "Cc Compatible Details Title",
     "ccCompatibleLabel": "Cc Compatible Label",
     "ccCompatibleModelsDescription": "Cc Compatible Models Description",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -4534,6 +4534,8 @@
     "ccCompatibleContext1mLabel": "Enable 1M context beta",
     "ccCompatibleRedactThinkingDescription": "Adds the redact-thinking beta header for CC Compatible upstreams that require hidden Claude thinking streams.",
     "ccCompatibleRedactThinkingLabel": "Enable redact-thinking beta",
+    "ccCompatibleSummarizeThinkingDescription": "Adds `display: \"summarized\"` to CC Compatible thinking requests so supported Claude models stream visible thinking deltas.",
+    "ccCompatibleSummarizeThinkingLabel": "Enable summarized thinking display",
     "ccCompatibleDetailsTitle": "CC-compatible relay details",
     "ccCompatibleLabel": "CC Compatible",
     "ccCompatibleModelsDescription": "CC-compatible relays do not expose model listing. Add the Claude model IDs your relay accepts.",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -4159,6 +4159,8 @@
     "ccCompatibleContext1mLabel": "Cc Compatible Context1M Label",
     "ccCompatibleRedactThinkingDescription": "Adds the redact-thinking beta header for CC Compatible upstreams that require hidden Claude thinking streams.",
     "ccCompatibleRedactThinkingLabel": "Enable redact-thinking beta",
+    "ccCompatibleSummarizeThinkingDescription": "Adds `display: \"summarized\"` to CC Compatible thinking requests so supported Claude models stream visible thinking deltas.",
+    "ccCompatibleSummarizeThinkingLabel": "Enable summarized thinking display",
     "ccCompatibleDetailsTitle": "Cc Compatible Details Title",
     "ccCompatibleLabel": "Cc Compatible Label",
     "ccCompatibleModelsDescription": "Cc Compatible Models Description",

--- a/src/i18n/messages/fa.json
+++ b/src/i18n/messages/fa.json
@@ -4159,6 +4159,8 @@
     "ccCompatibleContext1mLabel": "Cc Compatible Context1M Label",
     "ccCompatibleRedactThinkingDescription": "Adds the redact-thinking beta header for CC Compatible upstreams that require hidden Claude thinking streams.",
     "ccCompatibleRedactThinkingLabel": "Enable redact-thinking beta",
+    "ccCompatibleSummarizeThinkingDescription": "Adds `display: \"summarized\"` to CC Compatible thinking requests so supported Claude models stream visible thinking deltas.",
+    "ccCompatibleSummarizeThinkingLabel": "Enable summarized thinking display",
     "ccCompatibleDetailsTitle": "Cc Compatible Details Title",
     "ccCompatibleLabel": "Cc Compatible Label",
     "ccCompatibleModelsDescription": "Cc Compatible Models Description",

--- a/src/i18n/messages/fi.json
+++ b/src/i18n/messages/fi.json
@@ -4159,6 +4159,8 @@
     "ccCompatibleContext1mLabel": "Cc Compatible Context1M Label",
     "ccCompatibleRedactThinkingDescription": "Adds the redact-thinking beta header for CC Compatible upstreams that require hidden Claude thinking streams.",
     "ccCompatibleRedactThinkingLabel": "Enable redact-thinking beta",
+    "ccCompatibleSummarizeThinkingDescription": "Adds `display: \"summarized\"` to CC Compatible thinking requests so supported Claude models stream visible thinking deltas.",
+    "ccCompatibleSummarizeThinkingLabel": "Enable summarized thinking display",
     "ccCompatibleDetailsTitle": "Cc Compatible Details Title",
     "ccCompatibleLabel": "Cc Compatible Label",
     "ccCompatibleModelsDescription": "Cc Compatible Models Description",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -4159,6 +4159,8 @@
     "ccCompatibleContext1mLabel": "Cc Compatible Context1M Label",
     "ccCompatibleRedactThinkingDescription": "Adds the redact-thinking beta header for CC Compatible upstreams that require hidden Claude thinking streams.",
     "ccCompatibleRedactThinkingLabel": "Enable redact-thinking beta",
+    "ccCompatibleSummarizeThinkingDescription": "Adds `display: \"summarized\"` to CC Compatible thinking requests so supported Claude models stream visible thinking deltas.",
+    "ccCompatibleSummarizeThinkingLabel": "Enable summarized thinking display",
     "ccCompatibleDetailsTitle": "Cc Compatible Details Title",
     "ccCompatibleLabel": "Cc Compatible Label",
     "ccCompatibleModelsDescription": "Cc Compatible Models Description",

--- a/src/i18n/messages/gu.json
+++ b/src/i18n/messages/gu.json
@@ -4159,6 +4159,8 @@
     "ccCompatibleContext1mLabel": "Cc Compatible Context1M Label",
     "ccCompatibleRedactThinkingDescription": "Adds the redact-thinking beta header for CC Compatible upstreams that require hidden Claude thinking streams.",
     "ccCompatibleRedactThinkingLabel": "Enable redact-thinking beta",
+    "ccCompatibleSummarizeThinkingDescription": "Adds `display: \"summarized\"` to CC Compatible thinking requests so supported Claude models stream visible thinking deltas.",
+    "ccCompatibleSummarizeThinkingLabel": "Enable summarized thinking display",
     "ccCompatibleDetailsTitle": "Cc Compatible Details Title",
     "ccCompatibleLabel": "Cc Compatible Label",
     "ccCompatibleModelsDescription": "Cc Compatible Models Description",

--- a/src/i18n/messages/he.json
+++ b/src/i18n/messages/he.json
@@ -4159,6 +4159,8 @@
     "ccCompatibleContext1mLabel": "Cc Compatible Context1M Label",
     "ccCompatibleRedactThinkingDescription": "Adds the redact-thinking beta header for CC Compatible upstreams that require hidden Claude thinking streams.",
     "ccCompatibleRedactThinkingLabel": "Enable redact-thinking beta",
+    "ccCompatibleSummarizeThinkingDescription": "Adds `display: \"summarized\"` to CC Compatible thinking requests so supported Claude models stream visible thinking deltas.",
+    "ccCompatibleSummarizeThinkingLabel": "Enable summarized thinking display",
     "ccCompatibleDetailsTitle": "Cc Compatible Details Title",
     "ccCompatibleLabel": "Cc Compatible Label",
     "ccCompatibleModelsDescription": "Cc Compatible Models Description",

--- a/src/i18n/messages/hi.json
+++ b/src/i18n/messages/hi.json
@@ -4159,6 +4159,8 @@
     "ccCompatibleContext1mLabel": "Cc Compatible Context1M Label",
     "ccCompatibleRedactThinkingDescription": "Adds the redact-thinking beta header for CC Compatible upstreams that require hidden Claude thinking streams.",
     "ccCompatibleRedactThinkingLabel": "Enable redact-thinking beta",
+    "ccCompatibleSummarizeThinkingDescription": "Adds `display: \"summarized\"` to CC Compatible thinking requests so supported Claude models stream visible thinking deltas.",
+    "ccCompatibleSummarizeThinkingLabel": "Enable summarized thinking display",
     "ccCompatibleDetailsTitle": "Cc Compatible Details Title",
     "ccCompatibleLabel": "Cc Compatible Label",
     "ccCompatibleModelsDescription": "Cc Compatible Models Description",

--- a/src/i18n/messages/hu.json
+++ b/src/i18n/messages/hu.json
@@ -4159,6 +4159,8 @@
     "ccCompatibleContext1mLabel": "Cc Compatible Context1M Label",
     "ccCompatibleRedactThinkingDescription": "Adds the redact-thinking beta header for CC Compatible upstreams that require hidden Claude thinking streams.",
     "ccCompatibleRedactThinkingLabel": "Enable redact-thinking beta",
+    "ccCompatibleSummarizeThinkingDescription": "Adds `display: \"summarized\"` to CC Compatible thinking requests so supported Claude models stream visible thinking deltas.",
+    "ccCompatibleSummarizeThinkingLabel": "Enable summarized thinking display",
     "ccCompatibleDetailsTitle": "Cc Compatible Details Title",
     "ccCompatibleLabel": "Cc Compatible Label",
     "ccCompatibleModelsDescription": "Cc Compatible Models Description",

--- a/src/i18n/messages/id.json
+++ b/src/i18n/messages/id.json
@@ -4159,6 +4159,8 @@
     "ccCompatibleContext1mLabel": "Cc Compatible Context1M Label",
     "ccCompatibleRedactThinkingDescription": "Adds the redact-thinking beta header for CC Compatible upstreams that require hidden Claude thinking streams.",
     "ccCompatibleRedactThinkingLabel": "Enable redact-thinking beta",
+    "ccCompatibleSummarizeThinkingDescription": "Adds `display: \"summarized\"` to CC Compatible thinking requests so supported Claude models stream visible thinking deltas.",
+    "ccCompatibleSummarizeThinkingLabel": "Enable summarized thinking display",
     "ccCompatibleDetailsTitle": "Cc Compatible Details Title",
     "ccCompatibleLabel": "Cc Compatible Label",
     "ccCompatibleModelsDescription": "Cc Compatible Models Description",

--- a/src/i18n/messages/in.json
+++ b/src/i18n/messages/in.json
@@ -4159,6 +4159,8 @@
     "ccCompatibleContext1mLabel": "Cc Compatible Context1M Label",
     "ccCompatibleRedactThinkingDescription": "Adds the redact-thinking beta header for CC Compatible upstreams that require hidden Claude thinking streams.",
     "ccCompatibleRedactThinkingLabel": "Enable redact-thinking beta",
+    "ccCompatibleSummarizeThinkingDescription": "Adds `display: \"summarized\"` to CC Compatible thinking requests so supported Claude models stream visible thinking deltas.",
+    "ccCompatibleSummarizeThinkingLabel": "Enable summarized thinking display",
     "ccCompatibleDetailsTitle": "Cc Compatible Details Title",
     "ccCompatibleLabel": "Cc Compatible Label",
     "ccCompatibleModelsDescription": "Cc Compatible Models Description",

--- a/src/i18n/messages/it.json
+++ b/src/i18n/messages/it.json
@@ -4531,6 +4531,8 @@
     "ccCompatibleContext1mLabel": "Cc Compatible Context1M Label",
     "ccCompatibleRedactThinkingDescription": "Adds the redact-thinking beta header for CC Compatible upstreams that require hidden Claude thinking streams.",
     "ccCompatibleRedactThinkingLabel": "Enable redact-thinking beta",
+    "ccCompatibleSummarizeThinkingDescription": "Adds `display: \"summarized\"` to CC Compatible thinking requests so supported Claude models stream visible thinking deltas.",
+    "ccCompatibleSummarizeThinkingLabel": "Enable summarized thinking display",
     "ccCompatibleDetailsTitle": "Cc Compatible Details Title",
     "ccCompatibleLabel": "Cc Compatible Label",
     "ccCompatibleModelsDescription": "Cc Compatible Models Description",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -4531,6 +4531,8 @@
     "ccCompatibleContext1mLabel": "Cc Compatible Context1M Label",
     "ccCompatibleRedactThinkingDescription": "Adds the redact-thinking beta header for CC Compatible upstreams that require hidden Claude thinking streams.",
     "ccCompatibleRedactThinkingLabel": "Enable redact-thinking beta",
+    "ccCompatibleSummarizeThinkingDescription": "Adds `display: \"summarized\"` to CC Compatible thinking requests so supported Claude models stream visible thinking deltas.",
+    "ccCompatibleSummarizeThinkingLabel": "Enable summarized thinking display",
     "ccCompatibleDetailsTitle": "Cc Compatible Details Title",
     "ccCompatibleLabel": "Cc Compatible Label",
     "ccCompatibleModelsDescription": "Cc Compatible Models Description",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -4531,6 +4531,8 @@
     "ccCompatibleContext1mLabel": "Cc Compatible Context1M Label",
     "ccCompatibleRedactThinkingDescription": "Adds the redact-thinking beta header for CC Compatible upstreams that require hidden Claude thinking streams.",
     "ccCompatibleRedactThinkingLabel": "Enable redact-thinking beta",
+    "ccCompatibleSummarizeThinkingDescription": "Adds `display: \"summarized\"` to CC Compatible thinking requests so supported Claude models stream visible thinking deltas.",
+    "ccCompatibleSummarizeThinkingLabel": "Enable summarized thinking display",
     "ccCompatibleDetailsTitle": "Cc Compatible Details Title",
     "ccCompatibleLabel": "Cc Compatible Label",
     "ccCompatibleModelsDescription": "Cc Compatible Models Description",

--- a/src/i18n/messages/mr.json
+++ b/src/i18n/messages/mr.json
@@ -4531,6 +4531,8 @@
     "ccCompatibleContext1mLabel": "Cc Compatible Context1M Label",
     "ccCompatibleRedactThinkingDescription": "Adds the redact-thinking beta header for CC Compatible upstreams that require hidden Claude thinking streams.",
     "ccCompatibleRedactThinkingLabel": "Enable redact-thinking beta",
+    "ccCompatibleSummarizeThinkingDescription": "Adds `display: \"summarized\"` to CC Compatible thinking requests so supported Claude models stream visible thinking deltas.",
+    "ccCompatibleSummarizeThinkingLabel": "Enable summarized thinking display",
     "ccCompatibleDetailsTitle": "Cc Compatible Details Title",
     "ccCompatibleLabel": "Cc Compatible Label",
     "ccCompatibleModelsDescription": "Cc Compatible Models Description",

--- a/src/i18n/messages/ms.json
+++ b/src/i18n/messages/ms.json
@@ -4531,6 +4531,8 @@
     "ccCompatibleContext1mLabel": "Cc Compatible Context1M Label",
     "ccCompatibleRedactThinkingDescription": "Adds the redact-thinking beta header for CC Compatible upstreams that require hidden Claude thinking streams.",
     "ccCompatibleRedactThinkingLabel": "Enable redact-thinking beta",
+    "ccCompatibleSummarizeThinkingDescription": "Adds `display: \"summarized\"` to CC Compatible thinking requests so supported Claude models stream visible thinking deltas.",
+    "ccCompatibleSummarizeThinkingLabel": "Enable summarized thinking display",
     "ccCompatibleDetailsTitle": "Cc Compatible Details Title",
     "ccCompatibleLabel": "Cc Compatible Label",
     "ccCompatibleModelsDescription": "Cc Compatible Models Description",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -4531,6 +4531,8 @@
     "ccCompatibleContext1mLabel": "Cc Compatible Context1M Label",
     "ccCompatibleRedactThinkingDescription": "Adds the redact-thinking beta header for CC Compatible upstreams that require hidden Claude thinking streams.",
     "ccCompatibleRedactThinkingLabel": "Enable redact-thinking beta",
+    "ccCompatibleSummarizeThinkingDescription": "Adds `display: \"summarized\"` to CC Compatible thinking requests so supported Claude models stream visible thinking deltas.",
+    "ccCompatibleSummarizeThinkingLabel": "Enable summarized thinking display",
     "ccCompatibleDetailsTitle": "Cc Compatible Details Title",
     "ccCompatibleLabel": "Cc Compatible Label",
     "ccCompatibleModelsDescription": "Cc Compatible Models Description",

--- a/src/i18n/messages/no.json
+++ b/src/i18n/messages/no.json
@@ -4531,6 +4531,8 @@
     "ccCompatibleContext1mLabel": "Cc Compatible Context1M Label",
     "ccCompatibleRedactThinkingDescription": "Adds the redact-thinking beta header for CC Compatible upstreams that require hidden Claude thinking streams.",
     "ccCompatibleRedactThinkingLabel": "Enable redact-thinking beta",
+    "ccCompatibleSummarizeThinkingDescription": "Adds `display: \"summarized\"` to CC Compatible thinking requests so supported Claude models stream visible thinking deltas.",
+    "ccCompatibleSummarizeThinkingLabel": "Enable summarized thinking display",
     "ccCompatibleDetailsTitle": "Cc Compatible Details Title",
     "ccCompatibleLabel": "Cc Compatible Label",
     "ccCompatibleModelsDescription": "Cc Compatible Models Description",

--- a/src/i18n/messages/phi.json
+++ b/src/i18n/messages/phi.json
@@ -4531,6 +4531,8 @@
     "ccCompatibleContext1mLabel": "Cc Compatible Context1M Label",
     "ccCompatibleRedactThinkingDescription": "Adds the redact-thinking beta header for CC Compatible upstreams that require hidden Claude thinking streams.",
     "ccCompatibleRedactThinkingLabel": "Enable redact-thinking beta",
+    "ccCompatibleSummarizeThinkingDescription": "Adds `display: \"summarized\"` to CC Compatible thinking requests so supported Claude models stream visible thinking deltas.",
+    "ccCompatibleSummarizeThinkingLabel": "Enable summarized thinking display",
     "ccCompatibleDetailsTitle": "Cc Compatible Details Title",
     "ccCompatibleLabel": "Cc Compatible Label",
     "ccCompatibleModelsDescription": "Cc Compatible Models Description",

--- a/src/i18n/messages/pl.json
+++ b/src/i18n/messages/pl.json
@@ -4531,6 +4531,8 @@
     "ccCompatibleContext1mLabel": "Cc Compatible Context1M Label",
     "ccCompatibleRedactThinkingDescription": "Adds the redact-thinking beta header for CC Compatible upstreams that require hidden Claude thinking streams.",
     "ccCompatibleRedactThinkingLabel": "Enable redact-thinking beta",
+    "ccCompatibleSummarizeThinkingDescription": "Adds `display: \"summarized\"` to CC Compatible thinking requests so supported Claude models stream visible thinking deltas.",
+    "ccCompatibleSummarizeThinkingLabel": "Enable summarized thinking display",
     "ccCompatibleDetailsTitle": "Cc Compatible Details Title",
     "ccCompatibleLabel": "Cc Compatible Label",
     "ccCompatibleModelsDescription": "Cc Compatible Models Description",

--- a/src/i18n/messages/pt-BR.json
+++ b/src/i18n/messages/pt-BR.json
@@ -4531,6 +4531,8 @@
     "ccCompatibleContext1mLabel": "Contexto 1M CC Compatível",
     "ccCompatibleRedactThinkingDescription": "Adds the redact-thinking beta header for CC Compatible upstreams that require hidden Claude thinking streams.",
     "ccCompatibleRedactThinkingLabel": "Enable redact-thinking beta",
+    "ccCompatibleSummarizeThinkingDescription": "Adds `display: \"summarized\"` to CC Compatible thinking requests so supported Claude models stream visible thinking deltas.",
+    "ccCompatibleSummarizeThinkingLabel": "Enable summarized thinking display",
     "ccCompatibleDetailsTitle": "Detalhes CC Compatível",
     "ccCompatibleLabel": "CC Compatível",
     "ccCompatibleModelsDescription": "Os modelos disponíveis de CC Compatível espelham a lista do provedor OAuth Claude Code.",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -4531,6 +4531,8 @@
     "ccCompatibleContext1mLabel": "Cc Compatible Context1M Label",
     "ccCompatibleRedactThinkingDescription": "Adds the redact-thinking beta header for CC Compatible upstreams that require hidden Claude thinking streams.",
     "ccCompatibleRedactThinkingLabel": "Enable redact-thinking beta",
+    "ccCompatibleSummarizeThinkingDescription": "Adds `display: \"summarized\"` to CC Compatible thinking requests so supported Claude models stream visible thinking deltas.",
+    "ccCompatibleSummarizeThinkingLabel": "Enable summarized thinking display",
     "ccCompatibleDetailsTitle": "Cc Compatible Details Title",
     "ccCompatibleLabel": "Cc Compatible Label",
     "ccCompatibleModelsDescription": "Cc Compatible Models Description",

--- a/src/i18n/messages/ro.json
+++ b/src/i18n/messages/ro.json
@@ -4531,6 +4531,8 @@
     "ccCompatibleContext1mLabel": "Cc Compatible Context1M Label",
     "ccCompatibleRedactThinkingDescription": "Adds the redact-thinking beta header for CC Compatible upstreams that require hidden Claude thinking streams.",
     "ccCompatibleRedactThinkingLabel": "Enable redact-thinking beta",
+    "ccCompatibleSummarizeThinkingDescription": "Adds `display: \"summarized\"` to CC Compatible thinking requests so supported Claude models stream visible thinking deltas.",
+    "ccCompatibleSummarizeThinkingLabel": "Enable summarized thinking display",
     "ccCompatibleDetailsTitle": "Cc Compatible Details Title",
     "ccCompatibleLabel": "Cc Compatible Label",
     "ccCompatibleModelsDescription": "Cc Compatible Models Description",

--- a/src/i18n/messages/ru.json
+++ b/src/i18n/messages/ru.json
@@ -4531,6 +4531,8 @@
     "ccCompatibleContext1mLabel": "Cc Compatible Context1M Label",
     "ccCompatibleRedactThinkingDescription": "Adds the redact-thinking beta header for CC Compatible upstreams that require hidden Claude thinking streams.",
     "ccCompatibleRedactThinkingLabel": "Enable redact-thinking beta",
+    "ccCompatibleSummarizeThinkingDescription": "Adds `display: \"summarized\"` to CC Compatible thinking requests so supported Claude models stream visible thinking deltas.",
+    "ccCompatibleSummarizeThinkingLabel": "Enable summarized thinking display",
     "ccCompatibleDetailsTitle": "Cc Compatible Details Title",
     "ccCompatibleLabel": "Cc Compatible Label",
     "ccCompatibleModelsDescription": "Cc Compatible Models Description",

--- a/src/i18n/messages/sk.json
+++ b/src/i18n/messages/sk.json
@@ -4531,6 +4531,8 @@
     "ccCompatibleContext1mLabel": "Cc Compatible Context1M Label",
     "ccCompatibleRedactThinkingDescription": "Adds the redact-thinking beta header for CC Compatible upstreams that require hidden Claude thinking streams.",
     "ccCompatibleRedactThinkingLabel": "Enable redact-thinking beta",
+    "ccCompatibleSummarizeThinkingDescription": "Adds `display: \"summarized\"` to CC Compatible thinking requests so supported Claude models stream visible thinking deltas.",
+    "ccCompatibleSummarizeThinkingLabel": "Enable summarized thinking display",
     "ccCompatibleDetailsTitle": "Cc Compatible Details Title",
     "ccCompatibleLabel": "Cc Compatible Label",
     "ccCompatibleModelsDescription": "Cc Compatible Models Description",

--- a/src/i18n/messages/sv.json
+++ b/src/i18n/messages/sv.json
@@ -4531,6 +4531,8 @@
     "ccCompatibleContext1mLabel": "Cc Compatible Context1M Label",
     "ccCompatibleRedactThinkingDescription": "Adds the redact-thinking beta header for CC Compatible upstreams that require hidden Claude thinking streams.",
     "ccCompatibleRedactThinkingLabel": "Enable redact-thinking beta",
+    "ccCompatibleSummarizeThinkingDescription": "Adds `display: \"summarized\"` to CC Compatible thinking requests so supported Claude models stream visible thinking deltas.",
+    "ccCompatibleSummarizeThinkingLabel": "Enable summarized thinking display",
     "ccCompatibleDetailsTitle": "Cc Compatible Details Title",
     "ccCompatibleLabel": "Cc Compatible Label",
     "ccCompatibleModelsDescription": "Cc Compatible Models Description",

--- a/src/i18n/messages/sw.json
+++ b/src/i18n/messages/sw.json
@@ -4159,6 +4159,8 @@
     "ccCompatibleContext1mLabel": "Cc Compatible Context1M Label",
     "ccCompatibleRedactThinkingDescription": "Adds the redact-thinking beta header for CC Compatible upstreams that require hidden Claude thinking streams.",
     "ccCompatibleRedactThinkingLabel": "Enable redact-thinking beta",
+    "ccCompatibleSummarizeThinkingDescription": "Adds `display: \"summarized\"` to CC Compatible thinking requests so supported Claude models stream visible thinking deltas.",
+    "ccCompatibleSummarizeThinkingLabel": "Enable summarized thinking display",
     "ccCompatibleDetailsTitle": "Cc Compatible Details Title",
     "ccCompatibleLabel": "Cc Compatible Label",
     "ccCompatibleModelsDescription": "Cc Compatible Models Description",

--- a/src/i18n/messages/ta.json
+++ b/src/i18n/messages/ta.json
@@ -4159,6 +4159,8 @@
     "ccCompatibleContext1mLabel": "Cc Compatible Context1M Label",
     "ccCompatibleRedactThinkingDescription": "Adds the redact-thinking beta header for CC Compatible upstreams that require hidden Claude thinking streams.",
     "ccCompatibleRedactThinkingLabel": "Enable redact-thinking beta",
+    "ccCompatibleSummarizeThinkingDescription": "Adds `display: \"summarized\"` to CC Compatible thinking requests so supported Claude models stream visible thinking deltas.",
+    "ccCompatibleSummarizeThinkingLabel": "Enable summarized thinking display",
     "ccCompatibleDetailsTitle": "Cc Compatible Details Title",
     "ccCompatibleLabel": "Cc Compatible Label",
     "ccCompatibleModelsDescription": "Cc Compatible Models Description",

--- a/src/i18n/messages/te.json
+++ b/src/i18n/messages/te.json
@@ -4159,6 +4159,8 @@
     "ccCompatibleContext1mLabel": "Cc Compatible Context1M Label",
     "ccCompatibleRedactThinkingDescription": "Adds the redact-thinking beta header for CC Compatible upstreams that require hidden Claude thinking streams.",
     "ccCompatibleRedactThinkingLabel": "Enable redact-thinking beta",
+    "ccCompatibleSummarizeThinkingDescription": "Adds `display: \"summarized\"` to CC Compatible thinking requests so supported Claude models stream visible thinking deltas.",
+    "ccCompatibleSummarizeThinkingLabel": "Enable summarized thinking display",
     "ccCompatibleDetailsTitle": "Cc Compatible Details Title",
     "ccCompatibleLabel": "Cc Compatible Label",
     "ccCompatibleModelsDescription": "Cc Compatible Models Description",

--- a/src/i18n/messages/th.json
+++ b/src/i18n/messages/th.json
@@ -4159,6 +4159,8 @@
     "ccCompatibleContext1mLabel": "Cc Compatible Context1M Label",
     "ccCompatibleRedactThinkingDescription": "Adds the redact-thinking beta header for CC Compatible upstreams that require hidden Claude thinking streams.",
     "ccCompatibleRedactThinkingLabel": "Enable redact-thinking beta",
+    "ccCompatibleSummarizeThinkingDescription": "Adds `display: \"summarized\"` to CC Compatible thinking requests so supported Claude models stream visible thinking deltas.",
+    "ccCompatibleSummarizeThinkingLabel": "Enable summarized thinking display",
     "ccCompatibleDetailsTitle": "Cc Compatible Details Title",
     "ccCompatibleLabel": "Cc Compatible Label",
     "ccCompatibleModelsDescription": "Cc Compatible Models Description",

--- a/src/i18n/messages/tr.json
+++ b/src/i18n/messages/tr.json
@@ -4159,6 +4159,8 @@
     "ccCompatibleContext1mLabel": "Cc Compatible Context1M Label",
     "ccCompatibleRedactThinkingDescription": "Adds the redact-thinking beta header for CC Compatible upstreams that require hidden Claude thinking streams.",
     "ccCompatibleRedactThinkingLabel": "Enable redact-thinking beta",
+    "ccCompatibleSummarizeThinkingDescription": "Adds `display: \"summarized\"` to CC Compatible thinking requests so supported Claude models stream visible thinking deltas.",
+    "ccCompatibleSummarizeThinkingLabel": "Enable summarized thinking display",
     "ccCompatibleDetailsTitle": "Cc Compatible Details Title",
     "ccCompatibleLabel": "Cc Compatible Label",
     "ccCompatibleModelsDescription": "Cc Compatible Models Description",

--- a/src/i18n/messages/uk-UA.json
+++ b/src/i18n/messages/uk-UA.json
@@ -4156,6 +4156,8 @@
     "ccCompatibleContext1mLabel": "Cc Compatible Context1M Label",
     "ccCompatibleRedactThinkingDescription": "Adds the redact-thinking beta header for CC Compatible upstreams that require hidden Claude thinking streams.",
     "ccCompatibleRedactThinkingLabel": "Enable redact-thinking beta",
+    "ccCompatibleSummarizeThinkingDescription": "Adds `display: \"summarized\"` to CC Compatible thinking requests so supported Claude models stream visible thinking deltas.",
+    "ccCompatibleSummarizeThinkingLabel": "Enable summarized thinking display",
     "ccCompatibleDetailsTitle": "Cc Compatible Details Title",
     "ccCompatibleLabel": "Cc Compatible Label",
     "ccCompatibleModelsDescription": "Cc Compatible Models Description",

--- a/src/i18n/messages/ur.json
+++ b/src/i18n/messages/ur.json
@@ -4159,6 +4159,8 @@
     "ccCompatibleContext1mLabel": "Cc Compatible Context1M Label",
     "ccCompatibleRedactThinkingDescription": "Adds the redact-thinking beta header for CC Compatible upstreams that require hidden Claude thinking streams.",
     "ccCompatibleRedactThinkingLabel": "Enable redact-thinking beta",
+    "ccCompatibleSummarizeThinkingDescription": "Adds `display: \"summarized\"` to CC Compatible thinking requests so supported Claude models stream visible thinking deltas.",
+    "ccCompatibleSummarizeThinkingLabel": "Enable summarized thinking display",
     "ccCompatibleDetailsTitle": "Cc Compatible Details Title",
     "ccCompatibleLabel": "Cc Compatible Label",
     "ccCompatibleModelsDescription": "Cc Compatible Models Description",

--- a/src/i18n/messages/vi.json
+++ b/src/i18n/messages/vi.json
@@ -4159,6 +4159,8 @@
     "ccCompatibleContext1mLabel": "Cc Compatible Context1M Label",
     "ccCompatibleRedactThinkingDescription": "Adds the redact-thinking beta header for CC Compatible upstreams that require hidden Claude thinking streams.",
     "ccCompatibleRedactThinkingLabel": "Enable redact-thinking beta",
+    "ccCompatibleSummarizeThinkingDescription": "Adds `display: \"summarized\"` to CC Compatible thinking requests so supported Claude models stream visible thinking deltas.",
+    "ccCompatibleSummarizeThinkingLabel": "Enable summarized thinking display",
     "ccCompatibleDetailsTitle": "Cc Compatible Details Title",
     "ccCompatibleLabel": "Cc Compatible Label",
     "ccCompatibleModelsDescription": "Cc Compatible Models Description",

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -4398,6 +4398,8 @@
     "ccCompatibleContext1mLabel": "启用 1M context beta",
     "ccCompatibleRedactThinkingDescription": "为要求隐藏 Claude 思考流的 CC Compatible 上游添加 redact-thinking beta header。",
     "ccCompatibleRedactThinkingLabel": "启用 redact-thinking beta",
+    "ccCompatibleSummarizeThinkingDescription": "为 CC Compatible 的 thinking 请求添加 `display: \"summarized\"`，让支持的 Claude 模型流式返回可见思考增量。",
+    "ccCompatibleSummarizeThinkingLabel": "启用 summarized thinking display",
     "ccCompatibleDetailsTitle": "CC 兼容中转站详情",
     "ccCompatibleLabel": "CC 兼容",
     "ccCompatibleModelsDescription": "CC 兼容中转站不提供模型列表。请添加该中转站接受的 Claude 模型 ID。",

--- a/src/lib/providers/requestDefaults.ts
+++ b/src/lib/providers/requestDefaults.ts
@@ -65,6 +65,10 @@ export function normalizeClaudeCodeCompatibleRedactThinking(value: unknown): tru
   return value === true ? true : undefined;
 }
 
+export function normalizeClaudeCodeCompatibleSummarizeThinking(value: unknown): true | undefined {
+  return value === true ? true : undefined;
+}
+
 export function normalizeRequestDefaults(
   provider: string | null | undefined,
   value: unknown
@@ -103,6 +107,15 @@ export function normalizeRequestDefaults(
       normalized.redactThinking = true;
     } else {
       delete normalized.redactThinking;
+    }
+
+    const summarizeThinking = normalizeClaudeCodeCompatibleSummarizeThinking(
+      record.summarizeThinking
+    );
+    if (summarizeThinking) {
+      normalized.summarizeThinking = true;
+    } else {
+      delete normalized.summarizeThinking;
     }
   }
 
@@ -286,6 +299,7 @@ export function getCodexRequestDefaults(providerSpecificData: unknown): {
 export function getClaudeCodeCompatibleRequestDefaults(providerSpecificData: unknown): {
   context1m?: true;
   redactThinking?: true;
+  summarizeThinking?: true;
 } {
   const defaults = getProviderRequestDefaults(
     "anthropic-compatible-cc-default",
@@ -293,8 +307,12 @@ export function getClaudeCodeCompatibleRequestDefaults(providerSpecificData: unk
   );
   const context1m = normalizeClaudeCodeCompatibleContext1m(defaults.context1m);
   const redactThinking = normalizeClaudeCodeCompatibleRedactThinking(defaults.redactThinking);
+  const summarizeThinking = normalizeClaudeCodeCompatibleSummarizeThinking(
+    defaults.summarizeThinking
+  );
   return {
     ...(context1m ? { context1m } : {}),
     ...(redactThinking ? { redactThinking } : {}),
+    ...(summarizeThinking ? { summarizeThinking } : {}),
   };
 }

--- a/src/shared/validation/providerSpecificData.ts
+++ b/src/shared/validation/providerSpecificData.ts
@@ -151,7 +151,7 @@ export function validateProviderSpecificData(
         });
       }
 
-      for (const booleanKey of ["context1m", "redactThinking"] as const) {
+      for (const booleanKey of ["context1m", "redactThinking", "summarizeThinking"] as const) {
         const value = requestDefaultsRecord[booleanKey];
         if (value === undefined || value === null || typeof value === "boolean") continue;
         ctx.addIssue({

--- a/src/shared/validation/schemas/provider.ts
+++ b/src/shared/validation/schemas/provider.ts
@@ -170,6 +170,16 @@ export function validateProviderSpecificData(
           path: ["requestDefaults", "context1m"],
         });
       }
+
+      for (const booleanKey of ["redactThinking", "summarizeThinking"] as const) {
+        const value = requestDefaultsRecord[booleanKey];
+        if (value === undefined || value === null || typeof value === "boolean") continue;
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `providerSpecificData.requestDefaults.${booleanKey} must be a boolean`,
+          path: ["requestDefaults", booleanKey],
+        });
+      }
     }
   }
 

--- a/tests/unit/claude-code-compatible-request.test.ts
+++ b/tests/unit/claude-code-compatible-request.test.ts
@@ -183,6 +183,80 @@ test("buildClaudeCodeCompatibleRequest prefers existing Claude top-level system 
   ]);
 });
 
+test("buildClaudeCodeCompatibleRequest can request summarized thinking display", () => {
+  const defaultPayload = buildClaudeCodeCompatibleRequest({
+    normalizedBody: {
+      messages: [{ role: "user", content: "hello" }],
+    },
+    model: "claude-opus-4-8",
+    cwd: "/tmp/claude-code-compatible",
+    now: new Date("2026-01-02T12:00:00.000Z"),
+  });
+  assert.deepEqual(defaultPayload.thinking, { type: "adaptive" });
+
+  const summarizedDefault = buildClaudeCodeCompatibleRequest({
+    normalizedBody: {
+      messages: [{ role: "user", content: "hello" }],
+    },
+    model: "claude-opus-4-8",
+    cwd: "/tmp/claude-code-compatible",
+    now: new Date("2026-01-02T12:00:00.000Z"),
+    summarizeThinking: true,
+  });
+  assert.deepEqual(summarizedDefault.thinking, {
+    type: "adaptive",
+    display: "summarized",
+  });
+
+  const summarizedExistingThinking = buildClaudeCodeCompatibleRequest({
+    sourceBody: {
+      thinking: { type: "adaptive" },
+    },
+    normalizedBody: {
+      messages: [{ role: "user", content: "hello" }],
+    },
+    model: "claude-opus-4-8",
+    cwd: "/tmp/claude-code-compatible",
+    now: new Date("2026-01-02T12:00:00.000Z"),
+    summarizeThinking: true,
+  });
+  assert.deepEqual(summarizedExistingThinking.thinking, {
+    type: "adaptive",
+    display: "summarized",
+  });
+
+  const explicitDisplay = buildClaudeCodeCompatibleRequest({
+    sourceBody: {
+      thinking: { type: "adaptive", display: "omitted" },
+    },
+    normalizedBody: {
+      messages: [{ role: "user", content: "hello" }],
+    },
+    model: "claude-opus-4-8",
+    cwd: "/tmp/claude-code-compatible",
+    now: new Date("2026-01-02T12:00:00.000Z"),
+    summarizeThinking: true,
+  });
+  assert.deepEqual(explicitDisplay.thinking, {
+    type: "adaptive",
+    display: "omitted",
+  });
+
+  const disabledThinking = buildClaudeCodeCompatibleRequest({
+    sourceBody: {
+      thinking: { type: "disabled" },
+    },
+    normalizedBody: {
+      messages: [{ role: "user", content: "hello" }],
+    },
+    model: "claude-opus-4-8",
+    cwd: "/tmp/claude-code-compatible",
+    now: new Date("2026-01-02T12:00:00.000Z"),
+    summarizeThinking: true,
+  });
+  assert.deepEqual(disabledThinking.thinking, { type: "disabled" });
+});
+
 test("buildClaudeCodeCompatibleRequest does not duplicate an existing default system skeleton", () => {
   const payload = buildClaudeCodeCompatibleRequest({
     claudeBody: {

--- a/tests/unit/provider-page-helpers-3501.test.ts
+++ b/tests/unit/provider-page-helpers-3501.test.ts
@@ -206,6 +206,7 @@ test("getClaudeCodeCompatibleRequestDefaults returns CC-compatible booleans", ()
   const result = getClaudeCodeCompatibleRequestDefaults(null);
   assert.equal(typeof result.context1m, "boolean");
   assert.equal(typeof result.redactThinking, "boolean");
+  assert.equal(typeof result.summarizeThinking, "boolean");
 });
 
 test("compatProtocolLabelKey maps protocol strings to i18n keys", () => {

--- a/tests/unit/provider-specific-data-schema.test.ts
+++ b/tests/unit/provider-specific-data-schema.test.ts
@@ -51,6 +51,7 @@ test("provider schemas accept boolean CC-compatible request defaults", () => {
       requestDefaults: {
         context1m: true,
         redactThinking: true,
+        summarizeThinking: true,
       },
     },
   });
@@ -59,6 +60,7 @@ test("provider schemas accept boolean CC-compatible request defaults", () => {
       requestDefaults: {
         context1m: false,
         redactThinking: false,
+        summarizeThinking: false,
       },
     },
   });
@@ -76,6 +78,7 @@ test("provider schemas reject non-boolean CC-compatible request defaults", () =>
       requestDefaults: {
         context1m: "yes",
         redactThinking: "yes",
+        summarizeThinking: "yes",
       },
     },
   });
@@ -84,6 +87,7 @@ test("provider schemas reject non-boolean CC-compatible request defaults", () =>
       requestDefaults: {
         context1m: 1,
         redactThinking: 1,
+        summarizeThinking: 1,
       },
     },
   });

--- a/tests/unit/request-defaults-store-session.test.ts
+++ b/tests/unit/request-defaults-store-session.test.ts
@@ -50,6 +50,7 @@ test("normalizeProviderSpecificData keeps only boolean CC-compatible request def
     requestDefaults: {
       context1m: true,
       redactThinking: true,
+      summarizeThinking: true,
       customFlag: "keep-me",
     },
   });
@@ -57,10 +58,12 @@ test("normalizeProviderSpecificData keeps only boolean CC-compatible request def
   assert.deepEqual(getClaudeCodeCompatibleRequestDefaults(normalized), {
     context1m: true,
     redactThinking: true,
+    summarizeThinking: true,
   });
   assert.deepEqual(normalized?.requestDefaults, {
     context1m: true,
     redactThinking: true,
+    summarizeThinking: true,
     customFlag: "keep-me",
   });
 
@@ -68,6 +71,7 @@ test("normalizeProviderSpecificData keeps only boolean CC-compatible request def
     requestDefaults: {
       context1m: "yes",
       redactThinking: "yes",
+      summarizeThinking: "yes",
       customFlag: "keep-me",
     },
   });


### PR DESCRIPTION
## Summary

- add a CC Compatible per-connection request default for summarized thinking display
- when enabled, add `thinking.display: "summarized"` to CC Compatible thinking requests unless the client already set a display mode or disabled thinking
- expose the setting in the provider connection UI alongside the existing 1M context and redact-thinking toggles
- extend provider-specific validation, i18n strings, docs, and unit coverage for the new request default

## Why

Claude models that default `thinking.display` to `"omitted"` can stream empty thinking blocks with only signatures unless callers explicitly opt in to summarized thinking. This makes downstream OpenAI-compatible clients appear blank during the thinking phase even though the upstream request is active.

The new toggle is default-off and connection-scoped, so existing CC Compatible connections keep their current wire image until an operator opts in.

## Validation

- Manual CC Compatible upstream smoke checks with summarized display on Sonnet 4.6, Opus 4.6, and Opus 4.8
- `node --import tsx/esm --test tests/unit/claude-code-compatible-request.test.ts tests/unit/request-defaults-store-session.test.ts tests/unit/provider-specific-data-schema.test.ts tests/unit/provider-page-helpers-3501.test.ts`
- `npm run typecheck:core`
- `npm run check:fabricated-docs`
- `git diff --check`
