### PR TITLE
fix(oauth): classify /api/oauth/cursor/auto-import as local-only (route-guard)

### DIFF
--- a/src/server/authz/routeGuard.ts
+++ b/src/server/authz/routeGuard.ts
@@ -40,6 +40,7 @@ export const LOCAL_ONLY_API_PREFIXES: ReadonlyArray<string> = [
   "/api/local/", // T-12: 1-click local service launchers (Redis today; spawns podman/docker) — loopback-enforced by isLocalRequestAllowed() in src/lib/security/localEndpoints.ts (Hard Rules #15 + #17)
   "/api/headroom/start", // Headroom token-saver proxy lifecycle: spawns headroom-ai python CLI (Hard Rules #15 + #17)
   "/api/headroom/stop", // Headroom token-saver proxy lifecycle: sends SIGTERM/SIGKILL to managed PID (Hard Rules #15 + #17)
+  "/api/oauth/cursor/auto-import", // spawns `execFile("which", ["cursor"])` to verify a local Cursor install before importing creds — RCE-via-tunnel surface (Hard Rules #15 + #17, found by 6A.8 route-guard gate). Specific path only: the rest of /api/oauth/ (browser redirect/callback flows) must stay remote-reachable.
 ];
 
 /**

--- a/tests/unit/authz/route-guard-local-prefix.test.ts
+++ b/tests/unit/authz/route-guard-local-prefix.test.ts
@@ -27,6 +27,25 @@ test("isLocalOnlyPath: /api/local* does NOT match the bare /api/localifications 
   assert.equal(isLocalOnlyPath("/api/localhost-check"), false);
 });
 
+// ─── /api/oauth/cursor/auto-import is local-only (spawns `which cursor`) ──
+
+test("isLocalOnlyPath: /api/oauth/cursor/auto-import is local-only (spawns child process)", () => {
+  // The Cursor auto-import route runs `execFile("which", ["cursor"])` to verify a
+  // local Cursor install before importing its credentials — a child-process spawn
+  // that must be loopback-enforced BEFORE any auth check (Hard Rules #15/#17), so a
+  // leaked JWT via tunnel cannot reach the spawn. Found by check:route-guard-membership.
+  assert.equal(isLocalOnlyPath("/api/oauth/cursor/auto-import"), true);
+});
+
+test("isLocalOnlyPath: the rest of /api/oauth/ stays remote-reachable (no over-broadening)", () => {
+  // Only the spawn-capable auto-import path is loopback-locked. The rest of the OAuth
+  // surface (browser redirect / callback flows) MUST remain reachable remotely — a
+  // flat /api/oauth/ prefix would wrongly lock the whole OAuth subtree.
+  assert.equal(isLocalOnlyPath("/api/oauth/cursor"), false);
+  assert.equal(isLocalOnlyPath("/api/oauth/cursor/callback"), false);
+  assert.equal(isLocalOnlyPath("/api/oauth/anthropic/callback"), false);
+});
+
 test("isLocalOnlyBypassableByManageScope: /api/local/ is NOT bypassable (defence in depth)", () => {
   // The kill-switch path. Even if a DB row tries to whitelist /api/local/ via
   // the manage-scope bypass list, the runtime predicate must reject it because


### PR DESCRIPTION
## What

`check:route-guard-membership` (Hard Rules #15/#17) was failing on **every** PR to `release/v3.8.37` — a pre-existing base-red surfaced while validating #5067.

`src/app/api/oauth/cursor/auto-import/route.ts` runs `execFile("which", ["cursor"])` to verify a local Cursor install before importing credentials — a **child-process spawn** — but the route was **not classified loopback-only**. That makes it reachable past the loopback gate: an RCE-via-tunnel surface where a leaked JWT over a tunnel could trigger the spawn (the GHSA-fhh6-4qxv-rpqj surface the LOCAL_ONLY tier exists to close).

## Fix

Classify the **specific path** `/api/oauth/cursor/auto-import` in `LOCAL_ONLY_API_PREFIXES` so loopback enforcement runs unconditionally before any auth check.

Scoped to the exact path on purpose — a flat `/api/oauth/` prefix would wrongly lock the whole OAuth subtree; the browser redirect / callback flows must stay remote-reachable.

## Validation (TDD — Hard Rule #18)

Added a failing-then-passing assertion in `tests/unit/authz/route-guard-local-prefix.test.ts`:
- `isLocalOnlyPath("/api/oauth/cursor/auto-import")` → `true` (was `false` before the fix)
- over-broadening guard: `/api/oauth/cursor`, `/api/oauth/cursor/callback`, `/api/oauth/anthropic/callback` stay `false`

Results:
- Test confirmed red before the fix (`false !== true`), green after.
- `npm run check:route-guard-membership` → `OK — 28 routes all local-only; 0 new gaps` (was CRITICAL/exit 1).
- `tests/unit/authz/*` + `check-route-guard-membership.test.ts` → **48/48 passing**.
- `eslint` on changed files → clean.

Surgical diff: +1 prefix entry + the regression test (2 files, +20 lines).