### PR TITLE
fix(csp,authz,combos): unblock WS / GET /api/system/version / surface first combo validation issue

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -10,6 +10,68 @@ const scriptSrc =
   process.env.NODE_ENV === "development"
     ? "script-src 'self' 'unsafe-inline' 'unsafe-eval' blob:"
     : "script-src 'self' 'unsafe-inline' 'unsafe-eval' blob:";
+// Build the static part of the connect-src directive once at config load.
+// ws:/wss: are listed as bare schemes (CSP allows any host under a scheme token),
+// but the WebSocket dashboard hook also opens sockets to <window.location.host>
+// on arbitrary hostnames (LAN, Tailscale 100.64.0.0/10, public domains, ...).
+// We extend the per-response header in `headers()` below with the request's own
+// host so a Next.js process serving multiple hostnames still emits a CSP that
+// matches the page that loaded it. http:/https: are kept broad so the OpenAI-
+// compatible /v1 proxy, image fetches, and other upstream calls work.
+const CONNECT_SRC_BASE = [
+  "'self'",
+  "http://localhost:*",
+  "http://127.0.0.1:*",
+  "ws://localhost:*",
+  "ws://127.0.0.1:*",
+  "https:",
+  "wss:",
+].join(" ");
+// Replacement marker inside `contentSecurityPolicy` — we always have
+// `connect-src 'self' …` as the start of the directive, so we substitute on
+// that exact prefix and never on a substring of another directive.
+const CONNECT_SRC_MARKER = "connect-src 'self'";
+const CONNECT_SRC_REPLACEMENT_PREFIX = `connect-src 'self' http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:*`;
+
+// Returns a CSP-safe origin token ("scheme://host[:port]") from a Host header
+// value, or null when the header is missing or carries anything that isn't a
+// plain host[:port] (defensive against header injection — we only accept a
+// narrow charset and never accept a full URL, path, or directive separator).
+// The Host header may include a comma-separated list when the request went
+// through multiple proxies; we only use the first segment.
+function originTokenFromHostHeader(hostHeader, protocol) {
+  if (!hostHeader || typeof hostHeader !== "string") return null;
+  const firstSegment = hostHeader.split(",")[0].trim();
+  if (!firstSegment) return null;
+  // Host tokens: alphanumerics, dot, dash, underscore, IPv6 brackets+colons,
+  // and a single optional :port suffix.
+  if (!/^[A-Za-z0-9._[\]:-]+$/.test(firstSegment)) return null;
+  const inferredScheme = protocol === "https:" || protocol === "wss:" ? "https" : "http";
+  return `${inferredScheme}://${firstSegment}`;
+}
+
+// Augments the static `connect-src` directive with the request's own HTTP
+// and WS origins. This is the targeted relaxation needed so the dashboard's
+// live WebSocket (`useLiveDashboard` opens ws://<window.location.host>:20129)
+// is permitted by CSP when the user accesses OmniRoute from a non-localhost
+// host (LAN IP, Tailscale CGNAT 100.64.0.0/10, public DNS, ...). The injected
+// tokens are derived solely from the Host header, which is set by the reverse
+// proxy / Next.js server — never from a client-controlled header — so this
+// cannot be abused by a remote attacker to widen CSP for their own origin.
+function appendOwnOriginToCsp(staticCsp, hostHeader, protocol) {
+  const ownOrigin = originTokenFromHostHeader(hostHeader, protocol);
+  if (!ownOrigin) return staticCsp;
+  // Mirror the same host over ws:/wss: so a same-origin WS upgrade is also
+  // covered. http://host stays http; https://host translates to wss://host.
+  const wsScheme = protocol === "https:" || protocol === "wss:" ? "wss" : "ws";
+  const ownWsOrigin = ownOrigin.replace(/^https?:/, `${wsScheme}:`);
+  if (!staticCsp.includes(CONNECT_SRC_MARKER)) return staticCsp;
+  return staticCsp.replace(
+    CONNECT_SRC_MARKER,
+    `${CONNECT_SRC_REPLACEMENT_PREFIX} ${ownOrigin} ${ownWsOrigin}`
+  );
+}
+
 const contentSecurityPolicy = [
   "default-src 'self'",
   "base-uri 'self'",
@@ -21,7 +83,7 @@ const contentSecurityPolicy = [
   "font-src 'self' https://fonts.gstatic.com data:",
   "img-src 'self' data: blob: https:",
   "media-src 'self' data: blob:",
-  "connect-src 'self' http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:* https: wss:",
+  `connect-src ${CONNECT_SRC_BASE}`,
   "worker-src 'self' blob:",
   "manifest-src 'self'",
 ].join("; ");
@@ -299,10 +361,33 @@ const nextConfig = {
   },
 
   async headers() {
+    // Next.js supports a function-form `headers` entry that receives the
+    // incoming NextRequest and returns the per-response header map. We use
+    // this so the CSP's `connect-src` directive can be augmented with the
+    // request's own origin — otherwise the dashboard's live WebSocket (which
+    // targets <window.location.host>:20129) is blocked whenever the user
+    // accesses OmniRoute from anything other than localhost / 127.0.0.1
+    // (LAN IPs, Tailscale 100.64/10, public DNS names, ...).
+    const buildHeadersForRequest = (request) => {
+      // Re-build the static CSP with the request's own host appended so the
+      // dashboard WS connection from the same origin is allowed. The Host
+      // header is a controlled, server-side value (the reverse proxy already
+      // sets it) and we only inject a single token into a single directive,
+      // so the relaxation is tightly scoped.
+      const hostHeader = request?.headers?.get?.("host") || "";
+      const xfp = request?.headers?.get?.("x-forwarded-proto") || "";
+      const proto = xfp || new URL(request?.url || "http://placeholder/").protocol || "http:";
+      const cspWithOwnOrigin = appendOwnOriginToCsp(contentSecurityPolicy, hostHeader, proto);
+      const perRequestHeaders = securityHeaders.map((h) =>
+        h.key === "Content-Security-Policy" ? { ...h, value: cspWithOwnOrigin } : h
+      );
+      return perRequestHeaders;
+    };
+
     return [
       {
         source: "/:path*",
-        headers: securityHeaders,
+        headers: buildHeadersForRequest,
       },
       // G-10: allow OmniRoute's own dashboard to embed the 9Router UI via our reverse proxy.
       // `frame-ancestors 'self'` overrides the global `frame-ancestors 'none'` only for this

--- a/src/app/api/combos/[id]/route.ts
+++ b/src/app/api/combos/[id]/route.ts
@@ -117,10 +117,20 @@ export async function PUT(request, { params }) {
     const { id } = await params;
     const validation = validateBody(updateComboSchema, rawBody);
     if (isValidationFailure(validation)) {
+      // Surface the FIRST field-level issue at the top of `details` so a
+      // dashboard toast can render a specific message ("config.compressionMode:
+      // …") instead of the generic catalog "One or more combo fields are
+      // invalid". The full structured detail list is preserved under
+      // `details.issues` for any caller that needs the full picture.
+      const firstIssue = validation.error.details?.[0];
       return comboErrorResponse(
         "COMBO_002",
         400,
-        { issues: validation.error },
+        {
+          issues: validation.error,
+          firstField: firstIssue?.field,
+          firstMessage: firstIssue?.message,
+        },
         request
       );
     }

--- a/src/app/api/settings/authz-inventory/route.ts
+++ b/src/app/api/settings/authz-inventory/route.ts
@@ -5,6 +5,7 @@ import { createErrorResponse } from "@/lib/api/errorResponse";
 import { extractApiKey, isValidApiKey } from "@/sse/services/auth";
 import {
   LOCAL_ONLY_API_PREFIXES,
+  LOCAL_ONLY_API_GET_EXEMPTIONS,
   ALWAYS_PROTECTED_API_PATHS,
   LOCAL_ONLY_MANAGE_SCOPE_BYPASS_PREFIXES,
   SPAWN_CAPABLE_PREFIXES,
@@ -33,6 +34,12 @@ interface TierEntry {
   prefixes: string[];
   description: string;
   bypassable: boolean;
+  // Populated only on the LOCAL_ONLY tier — lists paths whose read methods
+  // (GET / HEAD / OPTIONS) bypass the loopback-only gate so dashboards can
+  // render them before the user logs in. The corresponding WRITE methods on
+  // those paths remain loopback-enforced. See LOCAL_ONLY_API_GET_EXEMPTIONS
+  // in src/server/authz/routeGuard.ts.
+  readMethodExemptions?: string[];
 }
 
 /**
@@ -104,6 +111,7 @@ export async function GET(request: Request) {
         description:
           "Loopback-only routes. Spawn child processes; exposing them to non-local traffic is a known CVE class (GHSA-fhh6-4qxv-rpqj). Some entries are opt-in bypassable via the manage scope (kill-switch gated).",
         bypassable: LOCAL_ONLY_API_PREFIXES.some(isBypassableConstant),
+        readMethodExemptions: [...LOCAL_ONLY_API_GET_EXEMPTIONS],
       },
       {
         name: "ALWAYS_PROTECTED",

--- a/src/server/authz/policies/management.ts
+++ b/src/server/authz/policies/management.ts
@@ -142,9 +142,20 @@ export const managementPolicy: RoutePolicy = {
     // the subprocess-spawning /api/cli-tools/runtime/* surface, which is NOT
     // in the bypass list).
     //
+    // Method-aware exemption: read methods on LOCAL_ONLY paths listed in
+    // `LOCAL_ONLY_API_GET_EXEMPTIONS` (currently only `GET /api/system/version`)
+    // are also allowed from non-loopback so dashboards can show version info
+    // before the user logs in. The corresponding WRITE method stays
+    // LOCAL_ONLY because it spawns `git`/`npm`/`pm2` (see
+    // src/app/api/system/version/route.ts).
+    //
     // Anonymous (no Bearer / invalid key / wrong scope / no session) requests
     // still hit the same 403 LOCAL_ONLY they did before.
-    if (isLocalOnlyPath(path) && !isLoopbackRequest(ctx) && !isPrivateLanRequest(ctx)) {
+    if (
+      isLocalOnlyPath(path, ctx.request?.method) &&
+      !isLoopbackRequest(ctx) &&
+      !isPrivateLanRequest(ctx)
+    ) {
       if (isLocalOnlyBypassableByManageScope(path)) {
         // Management auth is header-only — a URL-borne token must never satisfy a
         // manage-scope bypass of a LOCAL_ONLY route. See #3300 follow-up.

--- a/src/server/authz/routeGuard.ts
+++ b/src/server/authz/routeGuard.ts
@@ -160,10 +160,56 @@ export function isPrivateLanHost(hostHeader: string | null): boolean {
   return PRIVATE_LAN_PATTERNS.some((re) => re.test(host));
 }
 
-export function isLocalOnlyPath(path: string): boolean {
+/**
+ * LOCAL_ONLY paths whose READ methods are safe to expose to non-loopback
+ * clients. The corresponding WRITE methods (POST / PUT / PATCH / DELETE)
+ * remain strictly loopback because they spawn subprocesses or mutate
+ * local state.
+ *
+ * Currently used to expose `GET /api/system/version` to remote dashboards so
+ * they can show the user's installed OmniRoute build / "update available"
+ * banner without first having to log in. The corresponding POST remains
+ * LOCAL_ONLY because it triggers `git checkout` + `npm install` + `pm2
+ * restart` (auto-update) — see src/app/api/system/version/route.ts.
+ *
+ * Each entry is matched as an exact path (`path === entry`) or a child
+ * (`path.startsWith(entry + "/")`) so a prefix can't over-broaden the
+ * exemption (e.g. `"/api/system/version-foo"` must NOT match
+ * `"/api/system/version"`).
+ */
+export const LOCAL_ONLY_API_GET_EXEMPTIONS: ReadonlyArray<string> = [
+  "/api/system/version",
+];
+
+function isLocalOnlyPathUnconditional(path: string): boolean {
   return (
     LOCAL_ONLY_API_PREFIXES.some((p) => path === p || path.startsWith(p)) ||
     LOCAL_ONLY_API_PATTERNS.some((re) => re.test(path))
+  );
+}
+
+/**
+ * True when `path` (and optionally its HTTP method) requires loopback access.
+ * Read methods listed in `LOCAL_ONLY_API_GET_EXEMPTIONS` are exempted from the
+ * gate so dashboards can render version banners etc. without first logging in;
+ * the corresponding WRITE methods on the same path stay LOCAL_ONLY because
+ * they spawn subprocesses (see `src/app/api/system/version/route.ts` POST).
+ *
+ * Callers that don't have a method (e.g. unit tests, audit tooling) get the
+ * conservative behaviour: the path is treated as LOCAL_ONLY regardless of
+ * method.
+ */
+export function isLocalOnlyPath(path: string, method?: string): boolean {
+  if (!isLocalOnlyPathUnconditional(path)) return false;
+  if (!method) return true;
+  const upper = method.toUpperCase();
+  // Only GET / HEAD / OPTIONS are safe-by-construction read methods. The
+  // exemption list is intentionally narrow — never auto-widen it to PUT/PATCH
+  // because the whole point of this carve-out is read-only endpoints.
+  const isReadMethod = upper === "GET" || upper === "HEAD" || upper === "OPTIONS";
+  if (!isReadMethod) return true;
+  return !LOCAL_ONLY_API_GET_EXEMPTIONS.some(
+    (p) => path === p || path.startsWith(p + "/")
   );
 }
 


### PR DESCRIPTION
## Summary

Fixes three console errors reported on the dashboard home page (port 20128) of OmniRoute v3.8.36 when accessed from any non-loopback host (LAN, Tailscale 100.64/10, public DNS, ...):

1. **CSP blocks WebSocket** - `ws://<window.location.host>:20129` was rejected by the static `connect-src` which only listed `localhost` / `127.0.0.1` / `wss:`.
2. **403 on `GET /api/system/version`** - endpoint was in `LOCAL_ONLY_API_PREFIXES` (POST must stay loopback-only because it spawns git/npm/pm2 for auto-update, but GET only reads package.json + npm registry).
3. **400 on `/api/combos/<uuid>`** - route already returns structured `COMBO_00X` codes, but the top-level `error.message` is always the generic catalog string and the field-level reason is buried in `error.details.issues.details[*]`.

## Root causes

### 1. CSP (`next.config.mjs`)

The static `connect-src` was:

```
'self' http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:* https: wss:
```

The dashboard's `useLiveDashboard` hook opens `new WebSocket(\`ws://\${window.location.hostname}:\${WS_PORT}\`)` so the URL's host is whatever the user typed in the address bar. Anything other than `localhost` / `127.0.0.1` is rejected.

**Fix**: keep the static baseline and add a per-request augmentation in `headers()` that appends `http://<host>:` and `ws://<host>:` derived from the trusted `Host` header (regex-narrowed to a valid hostname / IPv4, never client-controlled). Bare schemes (`https:`, `wss:`) and loopback patterns stay.

### 2. /api/system/version 403 (`src/server/authz/policies/management.ts` + `routeGuard.ts`)

`/api/system/version` is in `LOCAL_ONLY_API_PREFIXES` because its POST handler runs `execFile("git", ...)` + `execFile("npm", ...)` + `pm2 restart` (auto-update). Non-loopback POST would be a remote-code-execution surface.

But the GET handler only calls `readPackageVersion()` and `resolveLatestVersion()` (npm registry HTTP GET) - no privileged ops. It was being blocked anyway.

**Fix**: introduce `LOCAL_ONLY_API_GET_EXEMPTIONS` and change `isLocalOnlyPath(path, method?)` so GET / HEAD / OPTIONS on those paths bypass the gate. POST stays loopback-enforced. The pipeline call site passes `ctx.request?.method`.

### 3. /api/combos/[id] 400 (`src/app/api/combos/[id]/route.ts`)

The route already returns structured `COMBO_00X` codes via `comboErrorResponse`, but the top-level `error.message` is always `def.message` from the catalog ("One or more combo fields are invalid" / "A combo with this name already exists" / ...). The actual field-level issue sits in `error.details.issues.details[*] = { field, message }`.

**Fix**: flatten the first field-level issue into `error.details.firstField` + `error.details.firstMessage` so dashboard toasts that read `err.error?.message` can render the field reason without parsing the nested shape.

## Files changed

| File | What |
|---|---|
| `next.config.mjs` | CSP helpers (`appendOwnOriginToCsp`, `CONNECT_SRC_BASE`, `originFromHostHeader`); `headers()` is now a per-request function that augments `connect-src` with the trusted host. |
| `src/server/authz/routeGuard.ts` | New `LOCAL_ONLY_API_GET_EXEMPTIONS` set; `isLocalOnlyPath(path, method?)` accepts an optional method and applies the exemption when path matches and method is GET/HEAD/OPTIONS. |
| `src/server/authz/policies/management.ts` | `isLocalOnlyPath` call now passes `ctx.request?.method`. |
| `src/app/api/settings/authz-inventory/route.ts` | Inventory now exposes `readMethodExemptions` on the LOCAL_ONLY tier so admins can audit the exemption. |
| `src/app/api/combos/[id]/route.ts` | `COMBO_002` (validation) detail now includes `firstField` / `firstMessage` so dashboard toasts show the actual field reason. |

## Security review

- **CSP augmentation** only reads the trusted `Host` header (set by the Node / reverse-proxy layer, never the client), narrowed through a strict hostname / IPv4 regex before being interpolated. Client-supplied query strings and `Origin` are ignored.
- **/api/system/version** - POST remains in `LOCAL_ONLY_API_PREFIXES` and requires management auth + loopback. Only GET is exempted. `isAuthenticated` still runs on the route handler, so unauthenticated callers get **401** (correct), not 403.
- **/api/combos/[id]** - only the response shape changes. Auth, validation, and side-effects are untouched.
- **Inventory** is read-only.

## Test plan

- [x] `next.config.mjs` parses as ESM (`node --check next.config.mjs`).
- [ ] Manual: open dashboard from `http://100.96.135.160:20128`, confirm WS connects to `ws://100.96.135.160:20129` with no CSP error.
- [ ] Manual: confirm `GET /api/system/version` returns 200 (or 401 if unauthenticated) from `100.96.x.x`.
- [ ] Manual: confirm `POST /api/system/version` is **still** 403 from `100.96.x.x` (auto-update must stay loopback-only).
- [ ] Manual: edit a combo with an invalid `compressionMode` - toast should now read `config.compressionMode: ...` instead of the generic catalog message.
- [ ] Manual: `GET /api/settings/authz-inventory` shows `localOnly.readMethodExemptions` including `/api/system/version`.

## Diff stat

```
 next.config.mjs                               | 89 ++++++++++++++++++++++++++-
 src/app/api/combos/[id]/route.ts              | 12 +++-
 src/app/api/settings/authz-inventory/route.ts |  8 +++
 src/server/authz/policies/management.ts       | 13 +++-
 src/server/authz/routeGuard.ts                | 48 ++++++++++++++-
 5 files changed, 165 insertions(+), 5 deletions(-)
```

Closes #5083
