### PR TITLE
fix: recognize Claude API format in detectMalformedNonStream

### DIFF
--- a/open-sse/utils/diagnostics.ts
+++ b/open-sse/utils/diagnostics.ts
@@ -200,6 +200,29 @@ export function detectMalformedNonStream(resp: unknown): MalformedReason | null 
     return null;
   }
 
+  // ── Claude API shape (native passthrough: type:"message" + content:[]) ──
+  if (body.type === "message") {
+    const content = body.content;
+    if (!Array.isArray(content) || content.length === 0) return "empty_choices";
+
+    const hasOutput = content.some((block: Record<string, unknown>) => {
+      if (
+        block.type === "text" &&
+        typeof block.text === "string" &&
+        (block.text as string).length > 0
+      )
+        return true;
+      if (block.type === "tool_use") return true;
+      if (block.type === "tool_result") return true;
+      return false;
+    });
+
+    if (!hasOutput) return "empty_choices";
+    const stopReason = body.stop_reason;
+    if (stopReason === null) return "no_terminal";
+    return null;
+  }
+
   // ── Chat Completions shape ──
   const choices = body.choices;
   if (!Array.isArray(choices) || choices.length === 0) return "empty_choices";

--- a/open-sse/utils/diagnostics.ts
+++ b/open-sse/utils/diagnostics.ts
@@ -206,11 +206,8 @@ export function detectMalformedNonStream(resp: unknown): MalformedReason | null 
     if (!Array.isArray(content) || content.length === 0) return "empty_choices";
 
     const hasOutput = content.some((block: Record<string, unknown>) => {
-      if (
-        block.type === "text" &&
-        typeof block.text === "string" &&
-        (block.text as string).length > 0
-      )
+      if (block === null || typeof block !== "object") return false;
+      if (block.type === "text" && typeof block.text === "string" && block.text.length > 0)
         return true;
       if (block.type === "tool_use") return true;
       if (block.type === "tool_result") return true;


### PR DESCRIPTION
## Summary

`detectMalformedNonStream()` in `open-sse/utils/diagnostics.ts` only recognized two API shapes:

1. **Responses API**: `body.object === "response"` → checks `output` array
2. **Chat Completions**: `body.choices` → checks `choices` array

When a **Claude passthrough** response reaches this check (Claude in → Claude out, no translation needed), the response has `type: "message"` with a `content` array — neither shape matches, so the function falls through and returns `"empty_choices"`.

This causes `chatCore` to reject valid Claude responses with HTTP 502:

```
[MALFORMED-200] mode=nonstream provider=claude model=claude-sonnet-4-6 reason=empty_choices
```

## Fix

Added Claude API format recognition between the Responses API and Chat Completions checks:

- Detects `body.type === "message"` (Claude's native response shape)
- Validates `content` array has at least one text, tool_use, or tool_result block
- Returns `"no_terminal"` when `stop_reason` is null (incomplete response)
- Returns `null` (valid) for complete responses

## Impact

**Fixes 5 pre-existing test failures** on upstream/main:

- chatCore normalizes native Claude Code messages for native Claude OAuth passthrough
- chatCore keeps Claude normalization for non-Claude-Code Claude passthrough
- chatCore normalizes native Claude Code messages before CC-compatible relay transforms
- chatCore restores prefixed Claude passthrough tool names in upstream responses
- chatCore records Claude prompt cache and cache usage metadata in call logs

**Verification:** 65/65 tests pass in `chatcore-translation-paths.test.ts`, 18/18 in `diagnostics.test.ts`.

## Files Changed

- `open-sse/utils/diagnostics.ts` (+23 lines)