### PR TITLE
fix(sse): classify native Anthropic Messages responses in detectMalformedNonStream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### 🔧 Bug Fixes
+
+- **fix(sse):** classify native Anthropic Messages responses in `detectMalformedNonStream`. `claude → claude` requests are not translated, so the post-translation empty-response check (#4942) received a native Anthropic body (`{ type:"message", content:[…] }`) with no top-level `choices` and misclassified **every** non-streaming `/v1/messages` call routed to a Claude provider as `empty_choices` → HTTP 502 — regardless of content. Most visibly this broke Claude Code's non-streaming Bash command classifier, whose reply is often a `thinking`-only block. Any content block (text / `tool_use` / `thinking`) now counts as usable output, consistent with `isEmptyContentResponse`. (fixes [#5108](https://github.com/diegosouzapw/OmniRoute/issues/5108))
+
 ---
 
 ## [3.8.37] — 2026-06-26

--- a/open-sse/utils/diagnostics.ts
+++ b/open-sse/utils/diagnostics.ts
@@ -11,6 +11,12 @@
 
 import { sanitizeErrorMessage } from "./error.ts";
 
+// Terminal Claude stop_reason values where an empty content array is still a
+// legitimate completion (truncated at the token limit, or a tool-call turn).
+// Mirrors errorClassifier.isEmptyContentResponse so the post-translation check
+// agrees with the raw-body check on native (untranslated) Anthropic responses.
+const LEGIT_EMPTY_CLAUDE_STOP = new Set(["max_tokens", "tool_use"]);
+
 // ── Types ────────────────────────────────────────────────────────────────────
 
 export type MalformedReason =
@@ -168,6 +174,9 @@ export function synthResponsesFailure(reason?: MalformedReason): string {
  * - Tool-call responses (content=null + tool_calls=[…]) are also valid.
  * - Responses API function_call / other structural items count as output even
  *   when they carry no user-visible text.
+ * - Native Anthropic Messages responses (claude→claude, not translated) carry a
+ *   top-level `content` array instead of `choices`; any block (text, tool_use,
+ *   thinking/redacted_thinking, …) counts as usable output.
  */
 export function detectMalformedNonStream(resp: unknown): MalformedReason | null {
   if (!resp || typeof resp !== "object") return "empty_choices";
@@ -198,6 +207,22 @@ export function detectMalformedNonStream(resp: unknown): MalformedReason | null 
     const status = typeof body.status === "string" ? body.status : "";
     if (status && !["completed", "done"].includes(status)) return "no_terminal";
     return null;
+  }
+
+  // ── Anthropic Messages shape ──
+  // claude→claude responses are not translated, so the "translated" body is still
+  // a native Anthropic message ({ type:"message", content:[…blocks…] }) with no
+  // top-level `choices`. Without this branch the chat-completions check below
+  // misclassifies every non-streaming /v1/messages call routed to a Claude
+  // provider as empty_choices and 502s it — e.g. Claude Code's non-streaming Bash
+  // command classifier, whose thinking-only reply ([{ type:"thinking", … }]) has
+  // no `choices`. Any content block (text, tool_use, thinking/redacted_thinking, …)
+  // is usable output; an empty content array is malformed only when no terminal
+  // stop_reason (max_tokens / tool_use) explains it.
+  if (Array.isArray(body.content)) {
+    if ((body.content as unknown[]).length > 0) return null;
+    const stopReason = typeof body.stop_reason === "string" ? body.stop_reason : "";
+    return LEGIT_EMPTY_CLAUDE_STOP.has(stopReason) ? null : "empty_choices";
   }
 
   // ── Chat Completions shape ──

--- a/tests/unit/diagnostics.test.ts
+++ b/tests/unit/diagnostics.test.ts
@@ -168,6 +168,53 @@ test("detectMalformedNonStream allows Responses API function_call items as valid
   assert.equal(detectMalformedNonStream(body), null);
 });
 
+// ── (c2) detectMalformedNonStream — native Anthropic Messages shape ──────────
+// claude→claude responses are not translated, so the body stays in Anthropic
+// shape ({ type:"message", content:[…] }) with no top-level `choices`.
+
+test("detectMalformedNonStream returns null for Anthropic text response", () => {
+  const body = {
+    type: "message",
+    role: "assistant",
+    content: [{ type: "text", text: "git status" }],
+    stop_reason: "end_turn",
+  };
+  assert.equal(detectMalformedNonStream(body), null);
+});
+
+test("detectMalformedNonStream returns null for Anthropic tool_use response", () => {
+  const body = {
+    type: "message",
+    role: "assistant",
+    content: [{ type: "tool_use", id: "toolu_1", name: "get_weather", input: { city: "Paris" } }],
+    stop_reason: "tool_use",
+  };
+  assert.equal(detectMalformedNonStream(body), null);
+});
+
+test("detectMalformedNonStream returns null for Anthropic thinking-only response (regression)", () => {
+  // A reasoning model can return a thinking block whose text is empty but which
+  // carries a valid signature. This is a valid completion, not a 502 — it is
+  // exactly what Claude Code's non-streaming Bash command classifier hits.
+  const body = {
+    type: "message",
+    role: "assistant",
+    content: [{ type: "thinking", thinking: "", signature: "EoACCmMIDxgC…" }],
+    stop_reason: "end_turn",
+  };
+  assert.equal(detectMalformedNonStream(body), null);
+});
+
+test("detectMalformedNonStream allows empty Anthropic content with a terminal stop_reason", () => {
+  const body = { type: "message", role: "assistant", content: [], stop_reason: "max_tokens" };
+  assert.equal(detectMalformedNonStream(body), null);
+});
+
+test("detectMalformedNonStream flags empty Anthropic content with no terminal stop_reason", () => {
+  const body = { type: "message", role: "assistant", content: [], stop_reason: null };
+  assert.equal(detectMalformedNonStream(body), "empty_choices");
+});
+
 // ── (d) no stack trace leakage ───────────────────────────────────────────────
 
 test("synthOpenAIErrorChunk message does NOT contain stack trace path", () => {


### PR DESCRIPTION
## Summary

`claude → claude` requests are not translated, so the post-translation empty-response check added in #4942 receives a **native Anthropic body** (`{ type: "message", content: [...] }`) that has no top-level `choices`. `detectMalformedNonStream` falls through to the Chat Completions branch, finds no `choices`, and returns `empty_choices` → **HTTP 502** for *every* non-streaming `/v1/messages` request routed to a Claude provider — regardless of the actual content.

Because nearly all Claude traffic streams, this mainly breaks non-streaming background calls. The most visible victim is **Claude Code's Bash command classifier** (a non-streaming call whose reply is often a `thinking`-only block): streaming agent turns work fine, but every Bash command 502s, and inside a combo it cascades to `All models failed`.

The fix teaches `detectMalformedNonStream` the Anthropic Messages shape, consistent with the raw-body `isEmptyContentResponse()` (which already handles it): any content block (`text` / `tool_use` / `thinking` / `redacted_thinking`) is usable output; an empty `content` array is malformed only when no terminal `stop_reason` (`max_tokens` / `tool_use`) explains it.

### Reproduction (pre-fix)

`POST /v1/messages`, `stream: false`, model = a thinking-enabled Claude model (or a combo target that enables thinking), any prompt:

```
HTTP 502 {"error":{"message":"[<provider>/<model>] returned an empty response (no usable choices/output)"}}
```

The same request with `stream: true` → `200`.

## Related Issues

- Closes #5108
- Related to #4942 (introduced the `detectMalformedNonStream` check)

## Validation

- [x] `npm run lint` — 0 errors (repo-wide pre-existing warnings only; the two touched files are clean)
- [x] `node --test tests/unit/diagnostics.test.ts` — 23/23 pass (incl. 5 new Anthropic-shape cases)
- [ ] `npm run test:unit` / `npm run test:coverage` — the full suite needs Redis (`127.0.0.1:6399`) and a live DB that I could not provision in my environment; deferred to CI.
- [ ] SonarQube PR analysis — deferred to CI.

## Tests Added Or Updated

- `tests/unit/diagnostics.test.ts` — 5 new cases for `detectMalformedNonStream`:
  - Anthropic `text` response → `null`
  - Anthropic `tool_use` response → `null`
  - Anthropic `thinking`-only response (the regression) → `null`
  - empty Anthropic `content` + terminal `stop_reason` → `null`
  - empty Anthropic `content` + no terminal `stop_reason` → `"empty_choices"`

## Coverage Notes

- The production change is confined to one new branch in `open-sse/utils/diagnostics.ts` (`detectMalformedNonStream`). The 5 added tests exercise **both** outcomes of the new branch (usable output → `null`; empty-without-terminal-stop → `"empty_choices"`), so the branch is fully covered.

## Reviewer Notes

- The new branch keys off `Array.isArray(body.content)`, which uniquely identifies the Anthropic Messages shape here — the Responses API is matched earlier via `object === "response"`, and Chat Completions uses `choices`. It is placed after the Responses branch and before the Chat branch.
- Behavior is intentionally aligned with `errorClassifier.isEmptyContentResponse()` so the raw-body pre-check and the post-translation check agree on the same Anthropic body. `LEGIT_EMPTY_CLAUDE_STOP` is inlined (with a comment flagging the mirror) rather than imported, to keep `open-sse/utils` free of a dependency on `open-sse/services`.
- No error-message strings were added or changed, so the `buildErrorBody()` / `sanitizeErrorMessage()` path is untouched.
