### PR TITLE
test(release): relocate 2 orphan test files to unblock Lint (test-discovery) on #5078

### DIFF
--- a/tests/unit/blackbox.test.ts
+++ b/tests/unit/blackbox.test.ts
@@ -9,7 +9,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-const { REGISTRY } = await import("../../../open-sse/config/providerRegistry.ts");
+const { REGISTRY } = await import("../../open-sse/config/providerRegistry.ts");
 
 const blackbox = (REGISTRY as Record<string, Record<string, unknown>>).blackbox;
 

--- a/tests/unit/kiro-auto-import-idc-2059.test.ts
+++ b/tests/unit/kiro-auto-import-idc-2059.test.ts
@@ -29,10 +29,10 @@ process.env.DATA_DIR = TEST_DATA_DIR;
 process.env.JWT_SECRET = process.env.JWT_SECRET || "test-jwt-secret-idc-2059";
 process.env.API_KEY_SECRET = process.env.API_KEY_SECRET || "test-api-key-secret-idc-2059";
 
-const core = await import("../../../src/lib/db/core.ts");
+const core = await import("../../src/lib/db/core.ts");
 
 // Import route module once (DB is initialized on first import).
-const { GET } = await import("../../../src/app/api/oauth/kiro/auto-import/route.ts");
+const { GET } = await import("../../src/app/api/oauth/kiro/auto-import/route.ts");
 
 const ORIGINAL_HOME = process.env.HOME;
 const ORIGINAL_APPDATA = process.env.APPDATA;
@@ -302,7 +302,7 @@ test("auto-import: clientIdHash present but registration file missing — gracef
 // ── Tests: schema ─────────────────────────────────────────────────────────────
 
 test("kiroImportSchema: accepts optional IDC fields (clientId, clientSecret, authMethod, profileArn)", async () => {
-  const { kiroImportSchema } = await import("../../../src/shared/validation/schemas/auth.ts");
+  const { kiroImportSchema } = await import("../../src/shared/validation/schemas/auth.ts");
 
   const result = kiroImportSchema.safeParse({
     refreshToken: "aorAAAAAGsome-token",
@@ -330,7 +330,7 @@ test("kiroImportSchema: accepts optional IDC fields (clientId, clientSecret, aut
 });
 
 test("kiroImportSchema: still valid without IDC fields (backward compat)", async () => {
-  const { kiroImportSchema } = await import("../../../src/shared/validation/schemas/auth.ts");
+  const { kiroImportSchema } = await import("../../src/shared/validation/schemas/auth.ts");
 
   const result = kiroImportSchema.safeParse({
     refreshToken: "aorAAAAAGsome-token",
@@ -344,7 +344,7 @@ test("kiroImportSchema: still valid without IDC fields (backward compat)", async
 });
 
 test("kiroImportSchema: rejects non-string clientId", async () => {
-  const { kiroImportSchema } = await import("../../../src/shared/validation/schemas/auth.ts");
+  const { kiroImportSchema } = await import("../../src/shared/validation/schemas/auth.ts");
 
   const result = kiroImportSchema.safeParse({
     refreshToken: "aorAAAAAGsome-token",


### PR DESCRIPTION
Surfaced while confirming the v3.8.38 Release PR (#5078) green: the CI **Lint** job fails on `check:test-discovery` — two NEW orphan test files that no runner collects (they never run):
- `tests/unit/oauth/kiro-auto-import-idc-2059.test.ts`
- `tests/unit/providers/blackbox.test.ts`

The node runner globs `tests/unit/*.test.ts` + an explicit subdir brace-list (api,auth,authz,…) that does **not** include `oauth/` or `providers/`. Each dir held a single misplaced file.

**Fix:** move both to the top-level `tests/unit/` (always collected) and fix their import depth (`../../../` → `../../`). Both green at the new path (24 tests). The 60 grandfathered orphans are untouched.

Unblocks the Lint job on #5078 (combined with #5117 base-red fixes + the file-size rebaseline).