### PR TITLE
test(golden): redact live Node version from translate-path snapshot (final #5078 unblock)

### DIFF
--- a/tests/snapshots/provider/translate-path.json
+++ b/tests/snapshots/provider/translate-path.json
@@ -736,7 +736,7 @@
         "X-CORE-VERSION": "0.0.0",
         "X-IS-MULTIROOT": "false",
         "X-PLATFORM": "linux",
-        "X-PLATFORM-VERSION": "v24.16.0",
+        "X-PLATFORM-VERSION": "<NODE>",
         "X-Title": "Cline"
       },
       "nonStream": {
@@ -749,7 +749,7 @@
         "X-CORE-VERSION": "0.0.0",
         "X-IS-MULTIROOT": "false",
         "X-PLATFORM": "linux",
-        "X-PLATFORM-VERSION": "v24.16.0",
+        "X-PLATFORM-VERSION": "<NODE>",
         "X-Title": "Cline"
       },
       "oauth": {
@@ -763,7 +763,7 @@
         "X-CORE-VERSION": "0.0.0",
         "X-IS-MULTIROOT": "false",
         "X-PLATFORM": "linux",
-        "X-PLATFORM-VERSION": "v24.16.0",
+        "X-PLATFORM-VERSION": "<NODE>",
         "X-Title": "Cline"
       }
     },
@@ -3333,7 +3333,7 @@
         "X-Stainless-Package-Version": "5.11.0",
         "X-Stainless-Retry-Count": "1",
         "X-Stainless-Runtime": "node",
-        "X-Stainless-Runtime-Version": "v24.16.0"
+        "X-Stainless-Runtime-Version": "<NODE>"
       },
       "nonStream": {
         "Accept-Language": "*",
@@ -3351,7 +3351,7 @@
         "X-Stainless-Package-Version": "5.11.0",
         "X-Stainless-Retry-Count": "1",
         "X-Stainless-Runtime": "node",
-        "X-Stainless-Runtime-Version": "v24.16.0"
+        "X-Stainless-Runtime-Version": "<NODE>"
       },
       "oauth": {
         "Accept": "text/event-stream",
@@ -3370,7 +3370,7 @@
         "X-Stainless-Package-Version": "5.11.0",
         "X-Stainless-Retry-Count": "1",
         "X-Stainless-Runtime": "node",
-        "X-Stainless-Runtime-Version": "v24.16.0"
+        "X-Stainless-Runtime-Version": "<NODE>"
       }
     },
     "url": {

--- a/tests/unit/provider-translate-path-golden.test.ts
+++ b/tests/unit/provider-translate-path-golden.test.ts
@@ -26,20 +26,29 @@ const OAUTH_CRED = { accessToken: "tok-test-ACCESS", providerSpecificData: {} };
 
 // Strip tokens + dynamic fields (github x-request-id uuid, kimi device-id) so the
 // snapshot is stable run-to-run.
+// Live Node version leaks into headers (e.g. X-PLATFORM-VERSION = process.version)
+// and varies by environment/patch (local v24.16 vs CI v24.17), so it must be
+// normalized away — otherwise the golden is only stable on the exact Node patch it
+// was generated on. Both `vX.Y.Z` (process.version) and `X.Y.Z`
+// (process.versions.node) forms are collapsed to <NODE>.
+const NODE_VERSION = typeof process !== "undefined" ? process.version : "";
+const NODE_VERSION_BARE = typeof process !== "undefined" ? (process.versions?.node ?? "") : "";
+
 function sanitize(headers: Record<string, unknown>): Record<string, unknown> {
   const out: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(headers)) {
-    out[k] =
-      typeof v === "string"
-        ? v
-            .replace(/Bearer .+/, "Bearer <TOK>")
-            .replace(/sk-test-APIKEY|tok-test-ACCESS/g, "<CRED>")
-            .replace(/kimi-\d{10,}/g, "kimi-<TS>")
-            .replace(
-              /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
-              "<UUID>"
-            )
-        : v;
+    if (typeof v !== "string") {
+      out[k] = v;
+      continue;
+    }
+    let s = v
+      .replace(/Bearer .+/, "Bearer <TOK>")
+      .replace(/sk-test-APIKEY|tok-test-ACCESS/g, "<CRED>")
+      .replace(/kimi-\d{10,}/g, "kimi-<TS>")
+      .replace(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i, "<UUID>");
+    if (NODE_VERSION) s = s.split(NODE_VERSION).join("<NODE>");
+    if (NODE_VERSION_BARE) s = s.split(NODE_VERSION_BARE).join("<NODE>");
+    out[k] = s;
   }
   return out;
 }
@@ -60,10 +69,7 @@ type ProviderTranslatePathEntry = {
   format: unknown;
 };
 
-export function buildProviderTranslatePathSnapshot(): Record<
-  string,
-  ProviderTranslatePathEntry
-> {
+export function buildProviderTranslatePathSnapshot(): Record<string, ProviderTranslatePathEntry> {
   const snapshot: Record<string, ProviderTranslatePathEntry> = {};
   for (const pid of providerIds) {
     const noAuth = Boolean((PROVIDERS as Record<string, { noAuth?: boolean }>)[pid]?.noAuth);
@@ -115,16 +121,12 @@ test("GOLDEN guard catches translate-path drift", () => {
     delete process.env.UPDATE_GOLDEN;
 
     // Same value → passes.
-    assert.doesNotThrow(() =>
-      goldenSnapshot("provider/translate-path", snapshot, tmpDir)
-    );
+    assert.doesNotThrow(() => goldenSnapshot("provider/translate-path", snapshot, tmpDir));
 
     // Mutated value → must throw (drift detected).
     const mutated = JSON.parse(JSON.stringify(snapshot)) as typeof snapshot;
     mutated[firstId].format = "DRIFTED-FORMAT";
-    assert.throws(() =>
-      goldenSnapshot("provider/translate-path", mutated, tmpDir)
-    );
+    assert.throws(() => goldenSnapshot("provider/translate-path", mutated, tmpDir));
   } finally {
     delete process.env.UPDATE_GOLDEN;
     fs.rmSync(tmpDir, { recursive: true, force: true });


### PR DESCRIPTION
Last red on the v3.8.38 Release PR (#5078): the `GOLDEN provider.ts translate-path` test failed on Unit Tests (6/8), Coverage (6/8) and Node 24/26 (2/4).

**Root cause:** the golden snapshot captured the **live Node runtime version** (`process.version` → `X-PLATFORM-VERSION` and the cline `X-Stainless-Runtime-Version`), so it only matched the exact Node patch it was generated on. My #5122 regeneration ran on local Node **v24.16.0**; CI runs **v24.17.0** → mismatch.

**Fix (test-robustness):** the `sanitize()` helper already strips run-to-run variance (creds, UUIDs, kimi timestamps); extend it to collapse both `vX.Y.Z` (`process.version`) and `X.Y.Z` (`process.versions.node`) to `<NODE>`, and regenerate the snapshot. The hardcoded CLAUDE_CLI `v24.3.0` constant is untouched (it is not `process.version`). The snapshot is now **Node-version-independent**.

Verified with the **exact CI invocation** (`env -u npm_package_version node --import tsx --import ./tests/_setup/isolateDataDir.ts --test`): **3/3 green**. Test-only change.

After this, the only remaining #5078 red is **Quality Ratchet** (coverage/complexity drift from the merged PRs) — rebaselined at `/generate-release` per the maintainer flow.