### PR TITLE
fix(security): exact-host Anthropic baseUrl check (CodeQL #674) [v3.8.38]

### DIFF
--- a/open-sse/executors/default.ts
+++ b/open-sse/executors/default.ts
@@ -18,6 +18,7 @@ import {
   mergeClientAnthropicBeta,
   normalizeAnthropicHeaderVariants,
 } from "../config/anthropicHeaders.ts";
+import { isOfficialAnthropicBaseUrl } from "../utils/anthropicHost.ts";
 import { applyProviderRequestDefaults } from "../services/providerRequestDefaults.ts";
 import { stripUnsupportedParams } from "../translator/paramSupport.ts";
 import {
@@ -488,8 +489,7 @@ export class DefaultExecutor extends BaseExecutor {
           // x-api-key-only behavior to avoid regressing the official path.
           if (effectiveKey && !headers["Authorization"]) {
             const baseUrl = credentials?.providerSpecificData?.baseUrl || "";
-            const isOfficialAnthropic =
-              baseUrl === "" || baseUrl.includes("api.anthropic.com");
+            const isOfficialAnthropic = isOfficialAnthropicBaseUrl(baseUrl);
             if (!isOfficialAnthropic) {
               headers["Authorization"] = `Bearer ${effectiveKey}`;
             }

--- a/open-sse/utils/anthropicHost.ts
+++ b/open-sse/utils/anthropicHost.ts
@@ -1,0 +1,25 @@
+/**
+ * Whether a configured Anthropic `baseUrl` targets the official `api.anthropic.com` host.
+ *
+ * Uses exact hostname equality (parsed via `new URL`) instead of a substring `.includes`,
+ * so a look-alike upstream such as `https://api.anthropic.com.evil.test` or
+ * `https://evil.test/?x=api.anthropic.com` is correctly treated as third-party
+ * (CodeQL `js/incomplete-url-substring-sanitization`). An empty baseUrl means the default
+ * official endpoint; a scheme-less host (e.g. `api.anthropic.com/v1`) is parsed with an
+ * assumed `https://`; an unparseable baseUrl is treated as third-party (safer default —
+ * the Bearer fallback is then emitted).
+ */
+export function isOfficialAnthropicBaseUrl(baseUrl: string): boolean {
+  if (!baseUrl) return true;
+  let host: string | null = null;
+  try {
+    host = new URL(baseUrl).hostname;
+  } catch {
+    try {
+      host = new URL(`https://${baseUrl}`).hostname;
+    } catch {
+      return false;
+    }
+  }
+  return host === "api.anthropic.com";
+}

--- a/tests/unit/anthropic-official-baseurl-host.test.ts
+++ b/tests/unit/anthropic-official-baseurl-host.test.ts
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { isOfficialAnthropicBaseUrl } from "../../open-sse/utils/anthropicHost.ts";
+
+// CodeQL #674 (js/incomplete-url-substring-sanitization): the official-Anthropic check
+// must use exact hostname equality, not a substring `.includes("api.anthropic.com")`, so a
+// look-alike upstream cannot impersonate the official endpoint and suppress the Bearer
+// fallback intended for third-party gateways.
+
+test("official endpoints are recognized (empty / scheme / scheme-less / path)", () => {
+  assert.equal(isOfficialAnthropicBaseUrl(""), true, "empty baseUrl = default official");
+  assert.equal(isOfficialAnthropicBaseUrl("https://api.anthropic.com"), true);
+  assert.equal(isOfficialAnthropicBaseUrl("https://api.anthropic.com/v1"), true);
+  assert.equal(isOfficialAnthropicBaseUrl("https://api.anthropic.com/"), true);
+  // scheme-less host (operator may omit the protocol) is parsed with an assumed https://
+  assert.equal(isOfficialAnthropicBaseUrl("api.anthropic.com"), true);
+  assert.equal(isOfficialAnthropicBaseUrl("api.anthropic.com/v1"), true);
+});
+
+test("look-alike / third-party hosts are NOT treated as official", () => {
+  // The exact strings the old substring check would have wrongly accepted:
+  assert.equal(isOfficialAnthropicBaseUrl("https://api.anthropic.com.evil.test"), false);
+  assert.equal(isOfficialAnthropicBaseUrl("https://api.anthropic.com.evil.test/v1"), false);
+  assert.equal(isOfficialAnthropicBaseUrl("https://evil.test/?x=api.anthropic.com"), false);
+  assert.equal(isOfficialAnthropicBaseUrl("https://evil.test/api.anthropic.com"), false);
+  assert.equal(isOfficialAnthropicBaseUrl("https://my-gateway.test/anthropic"), false);
+  // a genuinely different host
+  assert.equal(isOfficialAnthropicBaseUrl("https://openrouter.ai/api"), false);
+});
+
+test("unparseable baseUrl falls back to third-party (Bearer emitted)", () => {
+  assert.equal(isOfficialAnthropicBaseUrl("http://"), false);
+  assert.equal(isOfficialAnthropicBaseUrl(":::"), false);
+});
+
+test("source no longer uses substring .includes for the official-host check", () => {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const src = fs.readFileSync(
+    path.join(here, "../../open-sse/executors/default.ts"),
+    "utf8"
+  );
+  assert.equal(
+    src.includes('.includes("api.anthropic.com")'),
+    false,
+    "default.ts must not substring-match the official Anthropic host (CodeQL #674)"
+  );
+});


### PR DESCRIPTION
Cherry-pick of the `main` fix (#5129) onto the active release branch.

CodeQL alert **#674** `js/incomplete-url-substring-sanitization` (high) in `open-sse/executors/default.ts`: the official-Anthropic-host check used `baseUrl.includes("api.anthropic.com")`, which a look-alike host (`api.anthropic.com.evil.test`, `evil.test/?x=api.anthropic.com`) would match. Replaced with an exported `isOfficialAnthropicBaseUrl()` helper doing exact parsed-hostname equality.

Tests: `tests/unit/anthropic-official-baseurl-host.test.ts` 4/4 ✅ (on this release base), typecheck:core + eslint clean. Same diff as #5129.