### PR TITLE
fix(providers): add MiniMax M3 & Nemotron 3 Ultra to Cline catalog (#3321)

### DIFF
--- a/open-sse/config/providers/registry/cline/index.ts
+++ b/open-sse/config/providers/registry/cline/index.ts
@@ -27,6 +27,14 @@ export const clineProvider: RegistryEntry = {
     { id: "openai/gpt-5.5", name: "GPT-5.5" },
     { id: "deepseek/deepseek-v4-flash", name: "DeepSeek V4 Flash", supportsReasoning: true },
     { id: "deepseek/deepseek-v4-pro", name: "DeepSeek V4 Pro", supportsReasoning: true },
+    // #3321 — free OpenRouter-served models Cline exposes; were missing from the picker.
+    { id: "minimax/minimax-m3", name: "MiniMax M3", contextLength: 1048576, supportsVision: true },
+    {
+      id: "nvidia/nemotron-3-ultra-550b-a55b",
+      name: "Nemotron 3 Ultra 550B",
+      contextLength: 1048576,
+      supportsReasoning: true,
+    },
   ],
   passthroughModels: true,
 };

--- a/tests/unit/cline-catalog-models-3321.test.ts
+++ b/tests/unit/cline-catalog-models-3321.test.ts
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { getModelsByProviderId } from "../../open-sse/config/providerModels.ts";
+
+// #3321 — Cline maps its model catalog through OpenRouter (`modelsProviderId:
+// "openrouter"`) and OmniRoute's Cline provider forwards any id (passthroughModels).
+// The free OpenRouter-served models reporters asked for were missing from the
+// static catalog, so they never showed in the model picker. Verify the verified
+// additions are present with their 1M context windows.
+test("#3321: Cline catalog exposes the verified OpenRouter free additions", () => {
+  const models = getModelsByProviderId("cline");
+  const byId = new Map(models.map((m) => [m.id, m]));
+
+  const minimax = byId.get("minimax/minimax-m3");
+  assert.ok(minimax, "cline must expose minimax/minimax-m3");
+  assert.equal(minimax.contextLength, 1048576);
+
+  const nemotron = byId.get("nvidia/nemotron-3-ultra-550b-a55b");
+  assert.ok(nemotron, "cline must expose nvidia/nemotron-3-ultra-550b-a55b");
+  assert.equal(nemotron.contextLength, 1048576);
+});


### PR DESCRIPTION
Addresses the **missing-models** half of #3321.

## Context
Cline maps its model list through OpenRouter (`modelsProviderId: "openrouter"`) and the OmniRoute Cline provider already forwards any id (`passthroughModels: true`) — but the free OpenRouter-served models reporters asked for were absent from the static catalog, so they never appeared in the model picker.

## Change
Added two **verified** OpenRouter ids to the Cline catalog (both 1M context):
- `minimax/minimax-m3` (MiniMax M3)
- `nvidia/nemotron-3-ultra-550b-a55b` (Nemotron 3 Ultra 550B)

The third requested model (`mimo-2.5`) is **not** included — its exact OpenRouter/Cline slug could not be verified (current OpenRouter lists *MiMo-V2-Flash*, not `mimo-2.5`); the issue comment asks the reporter to confirm the precise id. `passthroughModels` already lets them send it manually meanwhile.

## Out of scope (upstream / already fixed)
- The `[401] Unauthorized … re-authenticate` is generated by `api.cline.bot` (upstream); OmniRoute already builds the `Bearer workos:<token>` header correctly — nothing to fix on our side beyond a token re-auth.
- The macOS CLI-detection half was fixed in v3.8.24 (#3773).

## Test (TDD)
`tests/unit/cline-catalog-models-3321.test.ts` — asserts the Cline catalog exposes both ids with `contextLength: 1048576` (red before the registry change). Registry-models guard test still green.