### PR TITLE
fix(sidebar): drop orphan settings accent color (unblocks typecheck:core)

### DIFF
--- a/src/shared/constants/sidebarVisibility.ts
+++ b/src/shared/constants/sidebarVisibility.ts
@@ -155,7 +155,6 @@ export const SIDEBAR_ICON_ACCENTS: Partial<Record<HideableSidebarItemId, string>
   media: "#D946EF",
   batch: "#14B8A6",
   "batch-files": "#38BDF8",
-  settings: "#94A3B8",
   "settings-general": "#64748B",
   "settings-appearance": "#D946EF",
   "settings-ai": "#A78BFA",


### PR DESCRIPTION
## Problem

`npm run typecheck:core` is **red on the release tip**:

```
src/shared/constants/sidebarVisibility.ts(158,3): error TS2353:
  Object literal may only specify known properties, and 'settings' does not
  exist in type 'Partial<Record<HideableSidebarItemId, string>>'.
```

`SIDEBAR_ICON_ACCENTS` maps icon accent colors per **hideable item id**, but
`settings` is not one — only `settings-general`, `settings-appearance`, … and
`context-settings` exist, and there is no item with `id: "settings"`. The
accent was therefore unreachable. Introduced by #3812 (colored menu icons).

This is a whole-program typecheck red that can block the next release.

## Fix

Remove the single orphan `settings: "#94A3B8"` line. No behavior change (the
key matched no item). `npm run typecheck:core` → **rc=0** (verified).

## Validation

- `npm run typecheck:core` — clean (was 1 error, now 0).
- No runtime/test impact: the key was unreachable, so nothing rendered with it.

Surfaced while validating salvage PR #5141 (its touched files typecheck clean;
this red is pre-existing and unrelated).