### PR TITLE
feat(compression): fuzzy near-duplicate dedup (session-dedup 2nd pass + playground toggle)

### DIFF
--- a/open-sse/services/compression/engines/session-dedup/fuzzy.ts
+++ b/open-sse/services/compression/engines/session-dedup/fuzzy.ts
@@ -1,0 +1,124 @@
+// open-sse/services/compression/engines/session-dedup/fuzzy.ts
+import { storeBlock } from "../ccr/index.ts";
+
+type MessageLike = { role?: string; content?: unknown; [key: string]: unknown };
+
+/** FNV-1a 32-bit hash (deterministic, cheap, no Math.random). */
+function fnv1a(s: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return h >>> 0;
+}
+
+/** Set of k-word shingle hashes (default k=3). Empty when the text has < k words. */
+export function shingles(text: string, k = 3): Set<number> {
+  const words = text.split(/\s+/).filter(Boolean);
+  const out = new Set<number>();
+  if (words.length < k) return out;
+  for (let i = 0; i + k <= words.length; i++) {
+    out.add(fnv1a(words.slice(i, i + k).join(" ")));
+  }
+  return out;
+}
+
+/** Jaccard similarity |a∩b| / |a∪b| (0..1; 0 when both empty). */
+export function jaccard(a: Set<number>, b: Set<number>): number {
+  if (a.size === 0 && b.size === 0) return 0;
+  const [small, large] = a.size <= b.size ? [a, b] : [b, a];
+  let inter = 0;
+  for (const x of small) if (large.has(x)) inter++;
+  const union = a.size + b.size - inter;
+  return union === 0 ? 0 : inter / union;
+}
+
+export interface FuzzyBlock {
+  text: string;
+  index: number;
+}
+export interface NearDuplicate {
+  block: FuzzyBlock;
+  matchedIndex: number;
+  similarity: number;
+}
+
+/**
+ * For each block, find the EARLIER block with the highest Jaccard ≥ minJaccard.
+ * O(n²); returns [] when blocks.length > maxBlocks (fail-safe bound, no blowup).
+ */
+export function findNearDuplicates(
+  blocks: FuzzyBlock[],
+  minJaccard: number,
+  maxBlocks: number,
+  shingleSize = 3
+): NearDuplicate[] {
+  if (blocks.length > maxBlocks) return [];
+  const sets = blocks.map((b) => shingles(b.text, shingleSize));
+  const out: NearDuplicate[] = [];
+  for (let i = 0; i < blocks.length; i++) {
+    let best = -1;
+    let bestSim = 0;
+    for (let j = 0; j < i; j++) {
+      const sim = jaccard(sets[i], sets[j]);
+      if (sim >= minJaccard && sim > bestSim) {
+        bestSim = sim;
+        best = j;
+      }
+    }
+    if (best >= 0) {
+      out.push({ block: blocks[i], matchedIndex: blocks[best].index, similarity: bestSim });
+    }
+  }
+  return out;
+}
+
+export interface FuzzyPassOptions {
+  minJaccard: number;
+  shingleSize: number;
+  maxBlocks: number;
+  minBlockChars: number;
+  principalId?: string;
+}
+export interface FuzzyPassResult {
+  messages: MessageLike[];
+  fuzzyCount: number;
+}
+
+/**
+ * Near-duplicate second pass over WHOLE string-content messages. A later message ≥minJaccard
+ * similar to an earlier one is stored in the CCR store and replaced inline with a recoverable
+ * `[CCR retrieve …]` marker (only when the marker shrinks). FAIL-OPEN: any error → no-op.
+ */
+export function applyFuzzyPass(messages: MessageLike[], opts: FuzzyPassOptions): FuzzyPassResult {
+  try {
+    const blocks: FuzzyBlock[] = [];
+    for (let i = 0; i < messages.length; i++) {
+      const m = messages[i];
+      if (m.role === "system") continue;
+      if (typeof m.content === "string" && m.content.length >= opts.minBlockChars) {
+        blocks.push({ text: m.content, index: i });
+      }
+    }
+    if (blocks.length < 2) return { messages, fuzzyCount: 0 };
+
+    const nearDups = findNearDuplicates(blocks, opts.minJaccard, opts.maxBlocks, opts.shingleSize);
+    if (nearDups.length === 0) return { messages, fuzzyCount: 0 };
+
+    const replacements = new Map<number, string>();
+    for (const nd of nearDups) {
+      const hash = storeBlock(nd.block.text, opts.principalId);
+      const marker = `[CCR retrieve hash=${hash} chars=${nd.block.text.length}]`;
+      if (marker.length < nd.block.text.length) replacements.set(nd.block.index, marker);
+    }
+    if (replacements.size === 0) return { messages, fuzzyCount: 0 };
+
+    const out = messages.map((m, i) =>
+      replacements.has(i) ? { ...m, content: replacements.get(i) } : m
+    );
+    return { messages: out, fuzzyCount: replacements.size };
+  } catch {
+    return { messages, fuzzyCount: 0 };
+  }
+}

--- a/open-sse/services/compression/engines/session-dedup/fuzzy.ts
+++ b/open-sse/services/compression/engines/session-dedup/fuzzy.ts
@@ -3,6 +3,9 @@ import { storeBlock } from "../ccr/index.ts";
 
 type MessageLike = { role?: string; content?: unknown; [key: string]: unknown };
 
+/** Hard cap on blocks compared in the fuzzy O(n²) pass (fail-safe bound). */
+export const MAX_FUZZY_BLOCKS = 200;
+
 /** FNV-1a 32-bit hash (deterministic, cheap, no Math.random). */
 function fnv1a(s: string): number {
   let h = 0x811c9dc5;
@@ -121,4 +124,30 @@ export function applyFuzzyPass(messages: MessageLike[], opts: FuzzyPassOptions):
   } catch {
     return { messages, fuzzyCount: 0 };
   }
+}
+
+/**
+ * Resolve the `fuzzy` step-config (a bare boolean OR `{ enabled, minJaccard?, shingleSize? }`)
+ * and run the near-duplicate pass. Returns the messages unchanged + `fuzzyCount: 0` when disabled.
+ * Keeps the engine's `apply()` thin (config normalization + dispatch live here).
+ */
+export function runFuzzyPass(
+  messages: MessageLike[],
+  stepConfig: Record<string, unknown>,
+  minBlockChars: number,
+  principalId?: string
+): FuzzyPassResult {
+  const raw = stepConfig["fuzzy"] as
+    | boolean
+    | { enabled?: boolean; minJaccard?: number; shingleSize?: number }
+    | undefined;
+  const cfg = typeof raw === "boolean" ? { enabled: raw } : raw;
+  if (!cfg?.enabled) return { messages, fuzzyCount: 0 };
+  return applyFuzzyPass(messages, {
+    minJaccard: typeof cfg.minJaccard === "number" ? cfg.minJaccard : 0.85,
+    shingleSize: typeof cfg.shingleSize === "number" ? cfg.shingleSize : 3,
+    maxBlocks: MAX_FUZZY_BLOCKS,
+    minBlockChars,
+    principalId,
+  });
 }

--- a/open-sse/services/compression/engines/session-dedup/index.ts
+++ b/open-sse/services/compression/engines/session-dedup/index.ts
@@ -261,6 +261,14 @@ const SESSION_DEDUP_SCHEMA: EngineConfigField[] = [
     min: 1,
     max: 100000,
   },
+  {
+    key: "fuzzy",
+    type: "boolean",
+    label: "Fuzzy near-duplicate dedup",
+    description:
+      "Opt-in: replace whole messages ~85%+ similar to an earlier one with a recoverable CCR marker.",
+    defaultValue: false,
+  },
 ];
 
 function validateSessionDedupConfig(config: Record<string, unknown>): EngineValidationResult {
@@ -272,6 +280,15 @@ function validateSessionDedupConfig(config: Record<string, unknown>): EngineVali
     const v = config["minBlockChars"];
     if (typeof v !== "number" || !Number.isFinite(v) || v < 1) {
       errors.push("minBlockChars must be a positive number");
+    }
+  }
+  if (config["fuzzy"] !== undefined) {
+    const f = config["fuzzy"];
+    if (typeof f === "object" && f !== null) {
+      const fe = (f as Record<string, unknown>)["enabled"];
+      if (fe !== undefined && typeof fe !== "boolean") errors.push("fuzzy.enabled must be a boolean");
+    } else if (typeof f !== "boolean") {
+      errors.push("fuzzy must be an object { enabled } or a boolean");
     }
   }
   return { valid: errors.length === 0, errors };

--- a/open-sse/services/compression/engines/session-dedup/index.ts
+++ b/open-sse/services/compression/engines/session-dedup/index.ts
@@ -30,6 +30,7 @@
 
 import crypto from "node:crypto";
 import { createCompressionStats } from "../../stats.ts";
+import { applyFuzzyPass } from "./fuzzy.ts";
 import type {
   CompressionEngine,
   CompressionEngineApplyOptions,
@@ -45,6 +46,8 @@ const ENGINE_ID = "session-dedup";
 const DEFAULT_MIN_BLOCK_CHARS = 80;
 /** Minimum number of lines a block must span to be a dedup candidate. */
 const MIN_BLOCK_LINES = 3;
+/** Hard cap on blocks compared in the fuzzy O(n²) pass (fail-safe bound). */
+const MAX_FUZZY_BLOCKS = 200;
 
 // ─── hash helper (SHA-256 prefix, collision-resistant) ───────────────────────
 
@@ -317,30 +320,39 @@ export const sessionDedupEngine: CompressionEngine = {
     }
 
     const start = performance.now();
-    const { messages: dedupedMessages, dedupCount } = processMessages(
+    const { messages: exactMessages, dedupCount } = processMessages(
       messages as MessageLike[],
       minBlockChars
     );
 
-    if (dedupCount === 0) {
+    const fuzzyCfg = stepConfig["fuzzy"] as
+      | { enabled?: boolean; minJaccard?: number; shingleSize?: number }
+      | undefined;
+    let finalMessages = exactMessages;
+    let fuzzyCount = 0;
+    if (fuzzyCfg?.enabled) {
+      const r = applyFuzzyPass(finalMessages, {
+        minJaccard: typeof fuzzyCfg.minJaccard === "number" ? fuzzyCfg.minJaccard : 0.85,
+        shingleSize: typeof fuzzyCfg.shingleSize === "number" ? fuzzyCfg.shingleSize : 3,
+        maxBlocks: MAX_FUZZY_BLOCKS,
+        minBlockChars,
+        principalId: options?.principalId,
+      });
+      finalMessages = r.messages;
+      fuzzyCount = r.fuzzyCount;
+    }
+
+    if (dedupCount + fuzzyCount === 0) {
       return { body, compressed: false, stats: null };
     }
 
-    const newBody: Record<string, unknown> = {
-      ...body,
-      messages: dedupedMessages,
-    };
-
+    const newBody: Record<string, unknown> = { ...body, messages: finalMessages };
     const durationMs = Math.round(performance.now() - start);
-    const stats = createCompressionStats(
-      body,
-      newBody,
-      "stacked",
-      ["session-dedup"],
-      [`deduplicated-${dedupCount}-blocks`],
-      durationMs
-    );
-
+    const techniques = ["session-dedup"];
+    if (fuzzyCount > 0) techniques.push("fuzzy-dedup");
+    const rules = [`deduplicated-${dedupCount}-blocks`];
+    if (fuzzyCount > 0) rules.push(`fuzzy-${fuzzyCount}-blocks`);
+    const stats = createCompressionStats(body, newBody, "stacked", techniques, rules, durationMs);
     return { body: newBody, compressed: true, stats };
   },
 

--- a/open-sse/services/compression/engines/session-dedup/index.ts
+++ b/open-sse/services/compression/engines/session-dedup/index.ts
@@ -30,7 +30,7 @@
 
 import crypto from "node:crypto";
 import { createCompressionStats } from "../../stats.ts";
-import { applyFuzzyPass } from "./fuzzy.ts";
+import { runFuzzyPass } from "./fuzzy.ts";
 import type {
   CompressionEngine,
   CompressionEngineApplyOptions,
@@ -46,8 +46,6 @@ const ENGINE_ID = "session-dedup";
 const DEFAULT_MIN_BLOCK_CHARS = 80;
 /** Minimum number of lines a block must span to be a dedup candidate. */
 const MIN_BLOCK_LINES = 3;
-/** Hard cap on blocks compared in the fuzzy O(n²) pass (fail-safe bound). */
-const MAX_FUZZY_BLOCKS = 200;
 
 // ─── hash helper (SHA-256 prefix, collision-resistant) ───────────────────────
 
@@ -342,24 +340,12 @@ export const sessionDedupEngine: CompressionEngine = {
       minBlockChars
     );
 
-    const rawFuzzy = stepConfig["fuzzy"] as
-      | boolean
-      | { enabled?: boolean; minJaccard?: number; shingleSize?: number }
-      | undefined;
-    const fuzzyCfg = typeof rawFuzzy === "boolean" ? { enabled: rawFuzzy } : rawFuzzy;
-    let finalMessages = exactMessages;
-    let fuzzyCount = 0;
-    if (fuzzyCfg?.enabled) {
-      const r = applyFuzzyPass(finalMessages, {
-        minJaccard: typeof fuzzyCfg.minJaccard === "number" ? fuzzyCfg.minJaccard : 0.85,
-        shingleSize: typeof fuzzyCfg.shingleSize === "number" ? fuzzyCfg.shingleSize : 3,
-        maxBlocks: MAX_FUZZY_BLOCKS,
-        minBlockChars,
-        principalId: options?.principalId,
-      });
-      finalMessages = r.messages;
-      fuzzyCount = r.fuzzyCount;
-    }
+    const { messages: finalMessages, fuzzyCount } = runFuzzyPass(
+      exactMessages,
+      stepConfig,
+      minBlockChars,
+      options?.principalId
+    );
 
     if (dedupCount + fuzzyCount === 0) {
       return { body, compressed: false, stats: null };

--- a/open-sse/services/compression/engines/session-dedup/index.ts
+++ b/open-sse/services/compression/engines/session-dedup/index.ts
@@ -342,9 +342,11 @@ export const sessionDedupEngine: CompressionEngine = {
       minBlockChars
     );
 
-    const fuzzyCfg = stepConfig["fuzzy"] as
+    const rawFuzzy = stepConfig["fuzzy"] as
+      | boolean
       | { enabled?: boolean; minJaccard?: number; shingleSize?: number }
       | undefined;
+    const fuzzyCfg = typeof rawFuzzy === "boolean" ? { enabled: rawFuzzy } : rawFuzzy;
     let finalMessages = exactMessages;
     let fuzzyCount = 0;
     if (fuzzyCfg?.enabled) {
@@ -367,7 +369,8 @@ export const sessionDedupEngine: CompressionEngine = {
     const durationMs = Math.round(performance.now() - start);
     const techniques = ["session-dedup"];
     if (fuzzyCount > 0) techniques.push("fuzzy-dedup");
-    const rules = [`deduplicated-${dedupCount}-blocks`];
+    const rules: string[] = [];
+    if (dedupCount > 0) rules.push(`deduplicated-${dedupCount}-blocks`);
     if (fuzzyCount > 0) rules.push(`fuzzy-${fuzzyCount}-blocks`);
     const stats = createCompressionStats(body, newBody, "stacked", techniques, rules, durationMs);
     return { body: newBody, compressed: true, stats };

--- a/src/app/(dashboard)/dashboard/compression/studio/PlayView.tsx
+++ b/src/app/(dashboard)/dashboard/compression/studio/PlayView.tsx
@@ -32,17 +32,18 @@ function LaneList({ lanes, onSelect }: { lanes: Lane[]; onSelect: (e: string) =>
 
 export function PlayView({ text, onText, laneEngines = LANE_ENGINES }: PlayViewProps) {
   const [active, setActive] = useState<string[]>(["rtk", "caveman"]);
+  const [fuzzyDedup, setFuzzyDedup] = useState(false);
   const [selectedLane, setSelectedLane] = useState<string | null>(null);
   const [fidelityGate, setFidelityGate] = useState(false);
   const { batch, loading, run } = usePreviewCompression();
   const messages = [{ role: "user", content: text }];
   const toggle = (e: string) => setActive((a) => (a.includes(e) ? a.filter((x) => x !== e) : [...a, e]));
-  const onRun = () => run({ messages, laneEngines: [...laneEngines], activeEngines: orderByStack(active, laneEngines), fidelityGate });
+  const onRun = () => run({ messages, laneEngines: [...laneEngines], activeEngines: orderByStack(active, laneEngines), fidelityGate, fuzzyDedup });
   const activeDiff = resolveActiveDiff(batch, selectedLane);
   return (
     <div className="flex h-full gap-3">
       <div className="w-[260px] shrink-0">
-        <PlaygroundInput text={text} onText={onText} active={active} onToggleActive={toggle} onRun={onRun} loading={loading} fidelityGate={fidelityGate} onToggleFidelity={() => setFidelityGate((v) => !v)} />
+        <PlaygroundInput text={text} onText={onText} active={active} onToggleActive={toggle} onRun={onRun} loading={loading} fidelityGate={fidelityGate} onToggleFidelity={() => setFidelityGate((v) => !v)} fuzzyDedup={fuzzyDedup} onToggleFuzzy={() => setFuzzyDedup((v) => !v)} />
       </div>
       <div className="flex min-w-0 flex-1 flex-col gap-3 overflow-auto">
         {batch?.combined && (

--- a/src/app/(dashboard)/dashboard/compression/studio/PlaygroundInput.tsx
+++ b/src/app/(dashboard)/dashboard/compression/studio/PlaygroundInput.tsx
@@ -1,7 +1,7 @@
 "use client";
 export const LANE_ENGINES = ["session-dedup", "ccr", "lite", "rtk", "headroom", "caveman", "aggressive", "ultra"] as const;
-export interface PlaygroundInputProps { text: string; onText: (t: string) => void; active: string[]; onToggleActive: (engine: string) => void; onRun: () => void; loading: boolean; fidelityGate: boolean; onToggleFidelity: () => void; }
-export function PlaygroundInput({ text, onText, active, onToggleActive, onRun, loading, fidelityGate, onToggleFidelity }: PlaygroundInputProps) {
+export interface PlaygroundInputProps { text: string; onText: (t: string) => void; active: string[]; onToggleActive: (engine: string) => void; onRun: () => void; loading: boolean; fidelityGate: boolean; onToggleFidelity: () => void; fuzzyDedup: boolean; onToggleFuzzy: () => void; }
+export function PlaygroundInput({ text, onText, active, onToggleActive, onRun, loading, fidelityGate, onToggleFidelity, fuzzyDedup, onToggleFuzzy }: PlaygroundInputProps) {
   return (
     <div className="flex flex-col gap-3">
       <textarea data-testid="play-input" className="min-h-[160px] w-full rounded border p-2 font-mono text-xs" value={text} onChange={(e) => onText(e.target.value)} placeholder="Cole prompt / tool-output / contexto..." />
@@ -13,6 +13,10 @@ export function PlaygroundInput({ text, onText, active, onToggleActive, onRun, l
       <label className="flex items-center gap-2 text-sm">
         <input type="checkbox" data-testid="fidelity-toggle" checked={fidelityGate} onChange={onToggleFidelity} />
         Verificar fidelidade (rejeitar camada que corromper)
+      </label>
+      <label className="flex items-center gap-2 text-sm">
+        <input type="checkbox" data-testid="fuzzy-toggle" checked={fuzzyDedup} onChange={onToggleFuzzy} />
+        Fuzzy dedup (near-duplicate → CCR)
       </label>
       <button data-testid="play-run" className="rounded bg-blue-500/30 py-2 font-semibold" onClick={onRun} disabled={loading}>{loading ? "Rodando..." : "▶ Run"}</button>
     </div>

--- a/src/app/api/compression/preview/route.ts
+++ b/src/app/api/compression/preview/route.ts
@@ -38,6 +38,9 @@ export const PreviewRequestSchema = z.object({
   // / checkDiffHunks on FidelityGateConfig) use their conservative defaults until the studio gets
   // a config panel for them.
   fidelityGate: z.object({ enabled: z.boolean() }).optional(),
+  // Playground fuzzy near-duplicate toggle → injects `{ fuzzy: { enabled: true } }` into the
+  // session-dedup step config (see buildStep).
+  fuzzyDedup: z.object({ enabled: z.boolean() }).optional(),
 });
 
 function countTokens(text: string): number {
@@ -53,6 +56,12 @@ function messagesToText(messages: Array<{ role: string; content: unknown }>): st
     .join("\n");
 }
 
+function buildStep(engine: string, fuzzy?: { enabled: boolean }) {
+  return engine === "session-dedup" && fuzzy?.enabled
+    ? { engine, config: { fuzzy: { enabled: true } } }
+    : { engine };
+}
+
 async function dispatchCompression(
   requestBody: Record<string, unknown>,
   opts: {
@@ -61,12 +70,13 @@ async function dispatchCompression(
     effectiveMode: CompressionMode;
     config?: unknown;
     fidelityGate?: { enabled: boolean };
+    fuzzyDedup?: { enabled: boolean };
   }
 ) {
   if (opts.engineId) {
     return applyCompressionAsync(requestBody, "stacked", {
       config: {
-        stackedPipeline: [{ engine: opts.engineId }],
+        stackedPipeline: [buildStep(opts.engineId, opts.fuzzyDedup)],
         ...(opts.fidelityGate ? { fidelityGate: opts.fidelityGate } : {}),
       } as CompressionConfig,
     });
@@ -74,7 +84,7 @@ async function dispatchCompression(
   if (opts.pipeline) {
     return applyCompressionAsync(requestBody, "stacked", {
       config: {
-        stackedPipeline: opts.pipeline.map((engine) => ({ engine })),
+        stackedPipeline: opts.pipeline.map((engine) => buildStep(engine, opts.fuzzyDedup)),
         ...(opts.fidelityGate ? { fidelityGate: opts.fidelityGate } : {}),
       } as CompressionConfig,
     });
@@ -106,7 +116,7 @@ export async function POST(req: Request) {
     );
   }
 
-  const { messages, mode, engineId, pipeline, config, fidelityGate } = parsed.data;
+  const { messages, mode, engineId, pipeline, config, fidelityGate, fuzzyDedup } = parsed.data;
   const effectiveMode: CompressionMode = engineId || pipeline ? "stacked" : (mode as CompressionMode);
   const originalText = messagesToText(messages);
   const originalTokens = countTokens(originalText);
@@ -115,7 +125,7 @@ export async function POST(req: Request) {
     const start = Date.now();
     const requestBody = { messages };
     const result = await dispatchCompression(requestBody as Record<string, unknown>, {
-      engineId, pipeline, effectiveMode, config, fidelityGate,
+      engineId, pipeline, effectiveMode, config, fidelityGate, fuzzyDedup,
     });
     const durationMs = Date.now() - start;
 

--- a/src/hooks/usePreviewCompression.ts
+++ b/src/hooks/usePreviewCompression.ts
@@ -4,7 +4,7 @@ import { previewToRunModel, type CompressionRunModel, type PreviewResponse } fro
 export interface PreviewMessage { role: string; content: unknown; }
 export interface Lane { engine: string; run: CompressionRunModel | null; error: string | null; }
 export interface PreviewBatch { lanes: Lane[]; combined: CompressionRunModel | null; diff: PreviewResponse["diff"] | null; }
-export interface RunPreviewArgs { messages: PreviewMessage[]; laneEngines: string[]; activeEngines: string[]; language?: string; fidelityGate?: boolean; }
+export interface RunPreviewArgs { messages: PreviewMessage[]; laneEngines: string[]; activeEngines: string[]; language?: string; fidelityGate?: boolean; fuzzyDedup?: boolean; }
 async function postPreview(payload: Record<string, unknown>): Promise<PreviewResponse> {
   const res = await fetch("/api/compression/preview", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload) });
   const data = await res.json();
@@ -12,17 +12,21 @@ async function postPreview(payload: Record<string, unknown>): Promise<PreviewRes
   return data as PreviewResponse;
 }
 export async function runPreviewBatch(args: RunPreviewArgs): Promise<PreviewBatch> {
-  const { messages, laneEngines, activeEngines, fidelityGate } = args;
+  const { messages, laneEngines, activeEngines, fidelityGate, fuzzyDedup } = args;
+  const extra = {
+    ...(fidelityGate ? { fidelityGate: { enabled: true } } : {}),
+    ...(fuzzyDedup ? { fuzzyDedup: { enabled: true } } : {}),
+  };
   const lanes: Lane[] = await Promise.all(
     laneEngines.map(async (engine): Promise<Lane> => {
-      try { const res = await postPreview({ messages, engineId: engine, ...(fidelityGate ? { fidelityGate: { enabled: true } } : {}) }); return { engine, run: previewToRunModel(res, engine), error: null }; }
+      try { const res = await postPreview({ messages, engineId: engine, ...extra }); return { engine, run: previewToRunModel(res, engine), error: null }; }
       catch (e) { return { engine, run: null, error: e instanceof Error ? e.message : "error" }; }
     })
   );
   let combined: CompressionRunModel | null = null;
   let diff: PreviewResponse["diff"] | null = null;
   if (activeEngines.length > 0) {
-    try { const res = await postPreview({ messages, pipeline: activeEngines, ...(fidelityGate ? { fidelityGate: { enabled: true } } : {}) }); combined = previewToRunModel(res, activeEngines.join(" → ")); diff = res.diff; }
+    try { const res = await postPreview({ messages, pipeline: activeEngines, ...extra }); combined = previewToRunModel(res, activeEngines.join(" → ")); diff = res.diff; }
     catch { combined = null; }
   }
   return { lanes, combined, diff };

--- a/tests/unit/compression/fuzzyDedup.test.ts
+++ b/tests/unit/compression/fuzzyDedup.test.ts
@@ -1,0 +1,57 @@
+// tests/unit/compression/fuzzyDedup.test.ts
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  shingles, jaccard, findNearDuplicates, applyFuzzyPass,
+} from "../../../open-sse/services/compression/engines/session-dedup/fuzzy.ts";
+import { retrieveBlock, resetCcrStore } from "../../../open-sse/services/compression/engines/ccr/index.ts";
+
+test("shingles: k=3 word windows, deterministic, empty when < k words", () => {
+  assert.equal(shingles("one two", 3).size, 0);
+  const a = shingles("the quick brown fox jumps", 3);
+  assert.equal(a.size, 3); // "the quick brown","quick brown fox","brown fox jumps"
+  assert.deepEqual([...a], [...shingles("the quick brown fox jumps", 3)]); // deterministic
+});
+
+test("jaccard: identical=1, disjoint=0, both-empty=0, partial=ratio", () => {
+  const a = shingles("alpha beta gamma delta", 3);
+  assert.equal(jaccard(a, a), 1);
+  assert.equal(jaccard(a, shingles("zzz yyy xxx www", 3)), 0);
+  assert.equal(jaccard(new Set(), new Set()), 0);
+});
+
+test("findNearDuplicates: a block ≥0.85 similar to an earlier one is flagged; below isn't; maxBlocks bounds", () => {
+  const base = "alpha beta gamma delta epsilon zeta eta theta iota kappa";
+  const near = base + " lambda"; // one extra word → very high jaccard
+  const far = "totally different words here nothing in common with above at all";
+  const blocks = [
+    { text: base, index: 0 },
+    { text: near, index: 1 },
+    { text: far, index: 2 },
+  ];
+  const nd = findNearDuplicates(blocks, 0.85, 200, 3);
+  assert.equal(nd.length, 1);
+  assert.equal(nd[0].block.index, 1);
+  assert.equal(nd[0].matchedIndex, 0);
+  assert.ok(nd[0].similarity >= 0.85);
+  // maxBlocks guard: above the cap → [] (no O(n^2) blowup)
+  assert.deepEqual(findNearDuplicates(blocks, 0.85, 1, 3), []);
+});
+
+test("applyFuzzyPass: near-dup message → CCR marker, recoverable; below threshold untouched; fail-open", async () => {
+  resetCcrStore();
+  const A = "alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu nu xi omicron";
+  const Aprime = A + " pi"; // ≥0.85 similar
+  const messages = [
+    { role: "user", content: A },
+    { role: "user", content: Aprime },
+  ];
+  const out = applyFuzzyPass(messages, { minJaccard: 0.85, shingleSize: 3, maxBlocks: 200, minBlockChars: 10, principalId: "p1" });
+  assert.equal(out.fuzzyCount, 1);
+  const marker = out.messages[1].content as string;
+  assert.match(marker, /^\[CCR retrieve hash=[0-9a-f]{24} chars=\d+\]$/);
+  // recoverable: the hash in the marker resolves to A' verbatim
+  const hash = marker.match(/hash=([0-9a-f]{24})/)![1];
+  assert.equal(retrieveBlock(hash, "p1"), Aprime);
+  assert.equal(out.messages[0].content, A); // first occurrence intact
+});

--- a/tests/unit/compression/previewRouteFuzzy.test.ts
+++ b/tests/unit/compression/previewRouteFuzzy.test.ts
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { join } from "node:path";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+const TEST_DATA_DIR = mkdtempSync(join(tmpdir(), "preview-fuzzy-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.API_KEY_SECRET = process.env.API_KEY_SECRET ?? "test-secret-32-chars-min-aaaaaaaa";
+delete process.env.INITIAL_PASSWORD;
+const core = await import("../../../src/lib/db/core.ts");
+const route = await import("../../../src/app/api/compression/preview/route.ts");
+function makeReq(body: unknown) {
+  return new Request("http://localhost/api/compression/preview", {
+    method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body),
+  });
+}
+test.beforeEach(() => core.resetDbInstance());
+test.after(() => { core.resetDbInstance(); rmSync(TEST_DATA_DIR, { recursive: true, force: true }); });
+
+const A = "alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu nu xi omicron pi rho";
+
+test("fuzzyDedup flag drives the session-dedup lane to produce a CCR marker", async () => {
+  const res = await route.POST(makeReq({
+    messages: [{ role: "user", content: A }, { role: "user", content: A + " sigma" }],
+    engineId: "session-dedup",
+    fuzzyDedup: { enabled: true },
+  }));
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.match(body.compressed, /\[CCR retrieve hash=[0-9a-f]{24}/);
+});
+
+test("malformed fuzzyDedup is rejected (field is in the schema, not stripped)", async () => {
+  const res = await route.POST(makeReq({
+    messages: [{ role: "user", content: "x" }], engineId: "session-dedup", fuzzyDedup: { enabled: "yes" },
+  }));
+  assert.equal(res.status, 400);
+});

--- a/tests/unit/compression/sessionDedupFuzzy.test.ts
+++ b/tests/unit/compression/sessionDedupFuzzy.test.ts
@@ -36,3 +36,10 @@ test("fuzzy enabled but below threshold → untouched", () => {
   const res = sessionDedupEngine.apply(body, { stepConfig: { fuzzy: { enabled: true, minJaccard: 0.85 } }, principalId: "p1" });
   assert.equal(res.compressed, false);
 });
+
+test("config schema advertises the fuzzy toggle + validateConfig accepts a fuzzy block", () => {
+  const schema = sessionDedupEngine.getConfigSchema();
+  assert.ok(schema.some((f) => f.key === "fuzzy"));
+  assert.equal(sessionDedupEngine.validateConfig({ fuzzy: { enabled: true } }).valid, true);
+  assert.equal(sessionDedupEngine.validateConfig({ fuzzy: { enabled: "yes" } }).valid, false);
+});

--- a/tests/unit/compression/sessionDedupFuzzy.test.ts
+++ b/tests/unit/compression/sessionDedupFuzzy.test.ts
@@ -1,0 +1,38 @@
+// tests/unit/compression/sessionDedupFuzzy.test.ts
+import test from "node:test";
+import assert from "node:assert/strict";
+import { sessionDedupEngine } from "../../../open-sse/services/compression/engines/session-dedup/index.ts";
+import { retrieveBlock, resetCcrStore } from "../../../open-sse/services/compression/engines/ccr/index.ts";
+
+const A = "alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu nu xi omicron pi rho";
+const Aprime = A + " sigma"; // ≥0.85 similar, not identical
+
+test("fuzzy enabled: a near-duplicate message becomes a recoverable CCR marker", () => {
+  resetCcrStore();
+  const body = { messages: [{ role: "user", content: A }, { role: "user", content: Aprime }] };
+  const res = sessionDedupEngine.apply(body, { stepConfig: { fuzzy: { enabled: true } }, principalId: "p1" });
+  assert.equal(res.compressed, true);
+  const msgs = (res.body.messages as Array<{ content: string }>);
+  assert.equal(msgs[0].content, A); // first occurrence intact
+  assert.match(msgs[1].content, /^\[CCR retrieve hash=[0-9a-f]{24} chars=\d+\]$/);
+  const hash = msgs[1].content.match(/hash=([0-9a-f]{24})/)![1];
+  assert.equal(retrieveBlock(hash, "p1"), Aprime); // recoverable
+});
+
+test("fuzzy ABSENT: byte-identical legacy (near-dup untouched, only exact dedup runs)", () => {
+  resetCcrStore();
+  const body = { messages: [{ role: "user", content: A }, { role: "user", content: Aprime }] };
+  const res = sessionDedupEngine.apply(body, { stepConfig: {}, principalId: "p1" });
+  // no exact-identical blocks here → no-op
+  assert.equal(res.compressed, false);
+});
+
+test("fuzzy enabled but below threshold → untouched", () => {
+  resetCcrStore();
+  const body = { messages: [
+    { role: "user", content: A },
+    { role: "user", content: "completely unrelated content with no shared three word windows whatsoever here ok" },
+  ] };
+  const res = sessionDedupEngine.apply(body, { stepConfig: { fuzzy: { enabled: true, minJaccard: 0.85 } }, principalId: "p1" });
+  assert.equal(res.compressed, false);
+});

--- a/tests/unit/compression/sessionDedupFuzzy.test.ts
+++ b/tests/unit/compression/sessionDedupFuzzy.test.ts
@@ -43,3 +43,12 @@ test("config schema advertises the fuzzy toggle + validateConfig accepts a fuzzy
   assert.equal(sessionDedupEngine.validateConfig({ fuzzy: { enabled: true } }).valid, true);
   assert.equal(sessionDedupEngine.validateConfig({ fuzzy: { enabled: "yes" } }).valid, false);
 });
+
+test("fuzzy as a bare boolean true also fires (schema advertises type:boolean)", () => {
+  resetCcrStore();
+  const body = { messages: [{ role: "user", content: A }, { role: "user", content: Aprime }] };
+  const res = sessionDedupEngine.apply(body, { stepConfig: { fuzzy: true }, principalId: "p1" });
+  assert.equal(res.compressed, true);
+  const msgs = res.body.messages as Array<{ content: string }>;
+  assert.match(msgs[1].content, /^\[CCR retrieve hash=[0-9a-f]{24} chars=\d+\]$/);
+});

--- a/tests/unit/ui/fuzzyDedupToggle.test.tsx
+++ b/tests/unit/ui/fuzzyDedupToggle.test.tsx
@@ -1,0 +1,22 @@
+// @vitest-environment jsdom
+// tests/unit/ui/fuzzyDedupToggle.test.tsx
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { runPreviewBatch } from "@/hooks/usePreviewCompression";
+beforeEach(() => vi.restoreAllMocks());
+describe("runPreviewBatch fuzzyDedup", () => {
+  it("includes fuzzyDedup:{enabled:true} in every preview payload when on", async () => {
+    const payloads: any[] = [];
+    vi.stubGlobal("fetch", vi.fn(async (_u: string, init: any) => {
+      payloads.push(JSON.parse(init.body));
+      return { ok: true, json: async () => ({
+        original: "o", compressed: "c", originalTokens: 5, compressedTokens: 5, savingsPct: 0,
+        mode: "stacked", durationMs: 1, engineBreakdown: [], diff: [], preservedBlocks: [], ruleRemovals: [],
+      }) } as any;
+    }));
+    await runPreviewBatch({
+      messages: [{ role: "user", content: "x" }], laneEngines: ["session-dedup"], activeEngines: ["session-dedup"], fuzzyDedup: true,
+    });
+    expect(payloads.length).toBe(2);
+    expect(payloads.every((p) => p.fuzzyDedup?.enabled === true)).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

An **opt-in, config-gated near-duplicate second pass** for the `session-dedup` compression engine. After the existing byte-exact pass, when `fuzzy` is enabled, the engine detects whole messages **~85%+ similar** to an *earlier* message (shingle k=3 words + Jaccard ≥0.85) and replaces them with a **recoverable** `[CCR retrieve hash=<24hex> chars=<N>]` marker (the whole block stored in the CCR store). Default **off** → byte-identical to today. Third feature of the compression feature-extraction roadmap (validated on the playground bench, PR #5080; guarded by the fidelity gate, PR #5127).

Spec/plan: `docs/superpowers/{specs,plans}/2026-06-27-compression-fuzzy-dedup*` (gitignored tooling).

## Why

`session-dedup` today dedups only **byte-exact** blocks. Agent loops that re-paste a file/tool-output differing by a single line or a timestamp dedup to **nothing**. The fuzzy pass closes that gap while staying fully reversible via the existing CCR retrieve path (`omniroute_ccr_retrieve`).

## How

- **`engines/session-dedup/fuzzy.ts`** (new, pure): `shingles` (FNV-1a, k-word windows), `jaccard`, `findNearDuplicates` (O(n²) with a hard `MAX_FUZZY_BLOCKS=200` bound → `[]` above the cap), `applyFuzzyPass` (whole-message, system-skipping, replace-only-if-shorter, **fail-open**), and `runFuzzyPass` (config normalization + dispatch — keeps `apply()` under the complexity gate). Deterministic (no `Date.now`/`Math.random`); the only regex is a ReDoS-safe `/\s+/` split.
- **`engines/session-dedup/index.ts`**: a thin 2nd-pass hook after the exact pass; reads `stepConfig.fuzzy` (accepts **both** a bare `true` and `{ enabled, minJaccard?, shingleSize? }`); combined `dedupCount + fuzzyCount` gating; `fuzzy-dedup` technique + `fuzzy-N-blocks` rule in stats; a `fuzzy` config-schema field + validation.
- **`preview/route.ts`**: a `fuzzyDedup:{enabled}` flag that injects `{ fuzzy:{ enabled:true } }` into the **`session-dedup` step only** (`buildStep`), on both the lane (`engineId`) and `pipeline` paths.
- **Playground**: a "Fuzzy dedup (near-duplicate → CCR)" checkbox in the studio Play tab → `usePreviewCompression.runPreviewBatch` propagates `fuzzyDedup:{enabled:true}` to every preview payload.

**Verified functionally end-to-end** (not an inert flag): a preview with two near-duplicate messages + `fuzzyDedup:{enabled:true}` on the `session-dedup` lane returns the 2nd message as `[CCR retrieve hash=… chars=…]`, and `retrieveBlock(hash, principalId)` recovers it verbatim.

## Tests (TDD, both runners)

- Node runner (`tests/unit/compression/`): `fuzzyDedup` (4: shingles/jaccard/findNearDuplicates/applyFuzzyPass + recoverability), `sessionDedupFuzzy` (5: fires/absent-byte-identical/below-threshold/bare-boolean/config-schema), `previewRouteFuzzy` (2: flag→marker / malformed→400).
- Vitest UI (`tests/unit/ui/fuzzyDedupToggle.test.tsx`, 1): toggle → payloads carry `fuzzyDedup:{enabled:true}`.
- Full compression suite **937/937**; typecheck:core / typecheck:noimplicit:core / lint / check:cycles green. `vitest.config.ts` untouched (UI test is `.tsx`).

## CI note — `check:file-size` red is pre-existing DRIFT, not this PR

`check:file-size` flags `src/sse/handlers/chat.ts: 1575 > 1560`. **This PR does not touch `chat.ts`** (the diff is 10 files, all compression) — it is the usual release-branch ratchet drift surfaced by GitHub's merge-with-base, rebaselined at release time. `check:complexity` stays at baseline (the `apply()` growth was offset by extracting `runFuzzyPass`).

Default **off** → the full suite passes unchanged. Ready for review & merge.
