### PR TITLE
test: refresh ionizer branch release expectations

### DIFF
--- a/tests/unit/check-db-rules-classification.test.ts
+++ b/tests/unit/check-db-rules-classification.test.ts
@@ -121,7 +121,7 @@ test("INTENTIONALLY_INTERNAL is exported from check-db-rules.mjs", () => {
   assert.ok(INTENTIONALLY_INTERNAL.size > 0, "INTENTIONALLY_INTERNAL must not be empty");
 });
 
-test("INTENTIONALLY_INTERNAL contains the expected 32 audited modules", () => {
+test("INTENTIONALLY_INTERNAL contains the expected 33 audited modules", () => {
   const expected = [
     "_rowTypes",
     "accessTokens",
@@ -155,6 +155,7 @@ test("INTENTIONALLY_INTERNAL contains the expected 32 audited modules", () => {
     "stats",
     "tierConfig",
     "vacuumScheduler",
+    "webSessionDedup",
   ];
   for (const mod of expected) {
     assert.ok(

--- a/tests/unit/quota-plan-registry.test.ts
+++ b/tests/unit/quota-plan-registry.test.ts
@@ -64,8 +64,8 @@ test("getKnownPlan('') returns null", () => {
   assert.equal(getKnownPlan(""), null);
 });
 
-test("knownProviders() returns exactly 10 entries", () => {
-  assert.equal(knownProviders().length, 10);
+test("knownProviders() returns exactly 11 entries", () => {
+  assert.equal(knownProviders().length, 11);
 });
 
 test("knownProviders() includes the full registry set", () => {
@@ -81,6 +81,7 @@ test("knownProviders() includes the full registry set", () => {
     "kimi-coding",
     "xiaomi-mimo",
     "alibaba",
+    "grok-cli",
   ]) {
     assert.ok(list.includes(p), `missing ${p}`);
   }

--- a/tests/unit/sidebar-icon-accents-3812.test.ts
+++ b/tests/unit/sidebar-icon-accents-3812.test.ts
@@ -16,7 +16,7 @@ import {
 
 test("#3812 returns the curated accent for a mapped sidebar item", () => {
   assert.equal(getSidebarIconAccent("home"), SIDEBAR_ICON_ACCENTS.home);
-  assert.equal(getSidebarIconAccent("settings"), SIDEBAR_ICON_ACCENTS.settings);
+  assert.equal(getSidebarIconAccent("settings-general"), SIDEBAR_ICON_ACCENTS["settings-general"]);
 });
 
 test("#3812 falls back to a valid hex accent for an unmapped id", () => {


### PR DESCRIPTION
## Summary
- merge current release/v3.8.38 into feat/compression-ionizer so quality baselines are current
- refresh stale unit expectations for INTENTIONALLY_INTERNAL, quota providers, and sidebar accent IDs

## Validation
- npm run check:complexity
- npm run quality:scan:fast
- node --max-old-space-size=8192 --import tsx --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test --test-force-exit tests/unit/check-db-rules-classification.test.ts tests/unit/quota-plan-registry.test.ts tests/unit/sidebar-icon-accents-3812.test.ts
