### PR TITLE
Preserve non-stream reasoning fields for compatible clients

### DIFF
--- a/open-sse/handlers/responseSanitizer.ts
+++ b/open-sse/handlers/responseSanitizer.ts
@@ -1,4 +1,7 @@
-import { copyOpenAICompatibleReasoningFields } from "../utils/reasoningFields.ts";
+import {
+  copyOpenAICompatibleReasoningFields,
+  getReadableReasoningValue,
+} from "../utils/reasoningFields.ts";
 
 /**
  * Response Sanitizer — Normalizes LLM responses to strict OpenAI SDK format.
@@ -31,12 +34,6 @@ type JsonRecord = Record<string, unknown>;
 
 export const OMIT_STREAMING_CHUNK_MARKER = "__omniroute_omit_streaming_chunk";
 
-const DEEPSEEK_V4_SANITIZER_MODEL_PATTERN = /deepseek[-/]v4/i;
-
-function isDeepSeekV4Model(model: unknown): boolean {
-  return typeof model === "string" && DEEPSEEK_V4_SANITIZER_MODEL_PATTERN.test(model);
-}
-
 function toRecord(value: unknown): JsonRecord | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) return null;
   return value as JsonRecord;
@@ -48,6 +45,13 @@ function toString(value: unknown): string | undefined {
 
 function toNumber(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function deleteOpenAICompatibleReasoningFields(record: JsonRecord): void {
+  delete record.reasoning_content;
+  delete record.reasoning;
+  delete record.reasoning_text;
+  delete record.reasoning_details;
 }
 
 function stripZeroWidthText(value: string): string {
@@ -185,23 +189,6 @@ function containsTextualToolCallContent(content: unknown): boolean {
   );
 }
 
-function hasVisibleMessageContent(content: unknown): boolean {
-  if (typeof content === "string") {
-    return content.trim().length > 0;
-  }
-
-  if (!Array.isArray(content)) return false;
-
-  return content.some((contentPart) => {
-    const part = toRecord(contentPart);
-    if (!part) return false;
-    if (typeof part.text === "string" && part.text.trim().length > 0) return true;
-    if (typeof part.content === "string" && part.content.trim().length > 0) return true;
-    const partType = toString(part.type);
-    return Boolean(partType && partType !== "thinking" && partType !== "reasoning");
-  });
-}
-
 const REASONING_TAG_NAMES = ["think", "thinking", "thought", "internal_thought"];
 const REASONING_TAG_PATTERN = REASONING_TAG_NAMES.join("|");
 // Matches complete <think>/<thinking>/<thought>/<internal_thought> blocks.
@@ -209,6 +196,9 @@ const THINK_TAG_REGEX = new RegExp(
   `<(${REASONING_TAG_PATTERN})\\b[^>]*>([\\s\\S]*?)<\\/\\1>`,
   "gi"
 );
+const REASONING_CLOSE_TAG_REGEX = new RegExp(`</(${REASONING_TAG_PATTERN})>`, "i");
+const REASONING_TAG_FRAGMENT_REGEX = new RegExp(`</?(${REASONING_TAG_PATTERN})\\b[^>]*>`, "gi");
+const CONTENT_OPEN_TAG_REGEX = /<content\b[^>]*>/i;
 // Matches an unclosed reasoning tag at the end of a message. Some providers can
 // emit malformed/open reasoning wrappers (for example "<thought\n...") before a
 // tool call. Treat that tail as reasoning instead of visible assistant text.
@@ -222,6 +212,34 @@ const UNCLOSED_REASONING_TAG_REGEX = new RegExp(
 const EXCESSIVE_NEWLINES = /\n{2,}/g;
 function collapseExcessiveNewlines(text: string): string {
   return text.replace(EXCESSIVE_NEWLINES, "\n\n");
+}
+
+function cleanReasoningFragment(text: string): string {
+  return text.replace(REASONING_TAG_FRAGMENT_REGEX, "").trim();
+}
+
+function splitClosingOnlyReasoningPrefix(text: string): {
+  content: string;
+  thinking: string | null;
+} | null {
+  const closeMatch = text.match(REASONING_CLOSE_TAG_REGEX);
+  if (!closeMatch?.index) return null;
+
+  const suffix = text.slice(closeMatch.index + closeMatch[0].length);
+  if (!CONTENT_OPEN_TAG_REGEX.test(suffix)) return null;
+
+  const thinking = cleanReasoningFragment(text.slice(0, closeMatch.index));
+  if (!thinking) return null;
+  return { content: suffix.trim(), thinking };
+}
+
+function movePrefixBeforeContentTagToThinking(cleaned: string, thinkingParts: string[]): string {
+  const contentMatch = cleaned.match(CONTENT_OPEN_TAG_REGEX);
+  if (!contentMatch?.index || contentMatch.index <= 0) return cleaned;
+
+  const prefix = cleanReasoningFragment(cleaned.slice(0, contentMatch.index));
+  if (prefix) thinkingParts.unshift(prefix);
+  return cleaned.slice(contentMatch.index);
 }
 
 /**
@@ -248,6 +266,13 @@ export function extractThinkingFromContent(text: string): {
     return "";
   });
 
+  if (!hasThinkTags) {
+    const closingOnly = splitClosingOnlyReasoningPrefix(cleaned);
+    if (closingOnly) {
+      return closingOnly;
+    }
+  }
+
   const unclosedMatch = cleaned.match(UNCLOSED_REASONING_TAG_REGEX);
   if (unclosedMatch?.index !== undefined) {
     hasThinkTags = true;
@@ -260,6 +285,8 @@ export function extractThinkingFromContent(text: string): {
   if (!hasThinkTags) {
     return { content: text, thinking: null };
   }
+
+  cleaned = movePrefixBeforeContentTagToThinking(cleaned, thinkingParts);
 
   return {
     content: cleaned.trim(),
@@ -289,7 +316,6 @@ export function sanitizeOpenAIResponse(
 ): unknown {
   const bodyRecord = toRecord(body);
   if (!bodyRecord) return body;
-  const isDeepSeekV4 = isDeepSeekV4Model(bodyRecord.model);
   const stripReasoning = options.stripReasoning === true;
 
   // Build sanitized response with only allowed top-level fields
@@ -304,7 +330,7 @@ export function sanitizeOpenAIResponse(
   // Sanitize choices
   if (Array.isArray(bodyRecord.choices)) {
     sanitized.choices = bodyRecord.choices.map((choice, idx) => {
-      const sanitizedChoice = sanitizeChoice(choice, idx, isDeepSeekV4);
+      const sanitizedChoice = sanitizeChoice(choice, idx);
       const message = toRecord(sanitizedChoice.message);
       if (
         message &&
@@ -314,8 +340,8 @@ export function sanitizeOpenAIResponse(
       ) {
         sanitizedChoice.finish_reason = "tool_calls";
       }
-      if (stripReasoning && message && "reasoning_content" in message) {
-        delete message.reasoning_content;
+      if (stripReasoning && message) {
+        deleteOpenAICompatibleReasoningFields(message);
       }
       return sanitizedChoice;
     });
@@ -397,7 +423,7 @@ export function sanitizeResponsesApiResponse(body: unknown): unknown {
 /**
  * Sanitize a single choice object.
  */
-function sanitizeChoice(choice: unknown, defaultIndex: number, isDeepSeekV4 = false): JsonRecord {
+function sanitizeChoice(choice: unknown, defaultIndex: number): JsonRecord {
   const choiceRecord = toRecord(choice);
   const sanitized: JsonRecord = {
     index: defaultIndex,
@@ -414,7 +440,7 @@ function sanitizeChoice(choice: unknown, defaultIndex: number, isDeepSeekV4 = fa
 
   // Sanitize message (non-streaming) or delta (streaming)
   if (choiceRecord?.message !== undefined) {
-    sanitized.message = sanitizeMessage(choiceRecord.message, isDeepSeekV4);
+    sanitized.message = sanitizeMessage(choiceRecord.message);
   }
   if (choiceRecord?.delta !== undefined) {
     sanitized.delta = sanitizeMessage(choiceRecord.delta);
@@ -431,7 +457,7 @@ function sanitizeChoice(choice: unknown, defaultIndex: number, isDeepSeekV4 = fa
 /**
  * Sanitize a message object, extracting <think> tags if present.
  */
-function sanitizeMessage(msg: unknown, isDeepSeekV4 = false): unknown {
+function sanitizeMessage(msg: unknown): unknown {
   const msgRecord = toRecord(msg);
   if (!msgRecord) return msg;
 
@@ -448,69 +474,16 @@ function sanitizeMessage(msg: unknown, isDeepSeekV4 = false): unknown {
     );
     sanitized.content = collapseExcessiveNewlines(content);
 
-    // Set reasoning_content from <think> tags (if not already set)
-    if (thinking && !msgRecord.reasoning_content) {
+    // Set reasoning_content from prompt-format tags only when the provider did
+    // not also return a native OpenAI-compatible reasoning field.
+    if (thinking && !getReadableReasoningValue(msgRecord)) {
       sanitized.reasoning_content = thinking;
     }
   } else if (msgRecord.content !== undefined) {
     sanitized.content = msgRecord.content;
   }
 
-  // Preserve existing reasoning_content (from providers that natively support it)
-  if (msgRecord.reasoning_content && !sanitized.reasoning_content) {
-    sanitized.reasoning_content = msgRecord.reasoning_content;
-  }
-
-  // Handle 'reasoning' field alias (some providers use this instead of reasoning_content)
-  if (
-    msgRecord.reasoning &&
-    typeof msgRecord.reasoning === "string" &&
-    !sanitized.reasoning_content
-  ) {
-    sanitized.reasoning_content = msgRecord.reasoning;
-  }
-
-  // Handle reasoning_details[] array (StepFun/OpenRouter format)
-  // Structure: [{ type: "reasoning.text", text: "...", format: "unknown", index: 0 }]
-  if (Array.isArray(msgRecord.reasoning_details) && !sanitized.reasoning_content) {
-    const reasoningParts: string[] = [];
-    for (const detail of msgRecord.reasoning_details) {
-      const detailObj = detail && typeof detail === "object" ? (detail as JsonRecord) : null;
-      if (!detailObj) continue;
-      const detailType = typeof detailObj.type === "string" ? detailObj.type : "";
-      const detailText =
-        typeof detailObj.text === "string"
-          ? detailObj.text
-          : typeof detailObj.content === "string"
-            ? detailObj.content
-            : "";
-      if (
-        detailText &&
-        (detailType === "reasoning" ||
-          detailType === "reasoning.text" ||
-          detailType === "thinking" ||
-          detailType === "")
-      ) {
-        reasoningParts.push(detailText);
-      }
-    }
-    if (reasoningParts.length > 0) {
-      sanitized.reasoning_content = reasoningParts.join("");
-    }
-  }
-
-  // Non-streaming responses should not expose both visible content and reasoning_content.
-  // Some clients drop the visible assistant text or render duplicated panels when both fields
-  // are present in the final payload. Keep reasoning_content only for reasoning-only messages.
-  if (
-    sanitized.reasoning_content !== undefined &&
-    hasVisibleMessageContent(sanitized.content) &&
-    !msgRecord.tool_calls &&
-    !msgRecord.function_call &&
-    !isDeepSeekV4
-  ) {
-    delete sanitized.reasoning_content;
-  }
+  copyOpenAICompatibleReasoningFields(msgRecord, sanitized);
 
   const textualToolCall = parseTextualToolCallContent(sanitized.content);
   if (textualToolCall && !msgRecord.tool_calls) {

--- a/open-sse/handlers/responseSanitizer.ts
+++ b/open-sse/handlers/responseSanitizer.ts
@@ -223,23 +223,25 @@ function splitClosingOnlyReasoningPrefix(text: string): {
   thinking: string | null;
 } | null {
   const closeMatch = text.match(REASONING_CLOSE_TAG_REGEX);
-  if (!closeMatch?.index) return null;
+  if (!closeMatch || closeMatch.index === undefined || closeMatch.index === 0) return null;
+  const closeIndex = closeMatch.index;
 
-  const suffix = text.slice(closeMatch.index + closeMatch[0].length);
+  const suffix = text.slice(closeIndex + closeMatch[0].length);
   if (!CONTENT_OPEN_TAG_REGEX.test(suffix)) return null;
 
-  const thinking = cleanReasoningFragment(text.slice(0, closeMatch.index));
+  const thinking = cleanReasoningFragment(text.slice(0, closeIndex));
   if (!thinking) return null;
   return { content: suffix.trim(), thinking };
 }
 
 function movePrefixBeforeContentTagToThinking(cleaned: string, thinkingParts: string[]): string {
   const contentMatch = cleaned.match(CONTENT_OPEN_TAG_REGEX);
-  if (!contentMatch?.index || contentMatch.index <= 0) return cleaned;
+  if (!contentMatch || contentMatch.index === undefined || contentMatch.index <= 0) return cleaned;
+  const contentIndex = contentMatch.index;
 
-  const prefix = cleanReasoningFragment(cleaned.slice(0, contentMatch.index));
+  const prefix = cleanReasoningFragment(cleaned.slice(0, contentIndex));
   if (prefix) thinkingParts.unshift(prefix);
-  return cleaned.slice(contentMatch.index);
+  return cleaned.slice(contentIndex);
 }
 
 /**

--- a/tests/unit/response-sanitizer.test.ts
+++ b/tests/unit/response-sanitizer.test.ts
@@ -39,6 +39,12 @@ test("extractThinkingFromContent does NOT treat <thoughtful> as a reasoning tag"
   assert.equal(parsed.thinking, null);
 });
 
+test("extractThinkingFromContent handles closing-only reasoning before content tag", () => {
+  const parsed = extractThinkingFromContent("planning\n</thinking>\n<content>visible</content>");
+  assert.equal(parsed.content, "<content>visible</content>");
+  assert.equal(parsed.thinking, "planning");
+});
+
 test("sanitizeOpenAIResponse strips non-standard fields and preserves required top-level fields", () => {
   const sanitized = sanitizeOpenAIResponse({
     id: "chatcmpl_existing",
@@ -139,7 +145,7 @@ test("sanitizeOpenAIResponse maps Claude-style usage fields and strips extras", 
   });
 });
 
-test("sanitizeOpenAIResponse strips reasoning_details-derived reasoning_content when visible text exists", () => {
+test("sanitizeOpenAIResponse preserves reasoning_details-derived reasoning_content with visible text", () => {
   const sanitized = sanitizeOpenAIResponse({
     model: "openrouter/model",
     choices: [
@@ -150,14 +156,18 @@ test("sanitizeOpenAIResponse strips reasoning_details-derived reasoning_content 
           reasoning_details: [
             { type: "reasoning.text", text: "first " },
             { type: "thinking", content: "second" },
-            { type: "other", text: "ignored" },
           ],
         },
       },
     ],
   });
 
-  assert.equal((sanitized as any).choices[0].message.reasoning_content, undefined);
+  assert.equal((sanitized as any).choices[0].message.content, "Visible");
+  assert.equal((sanitized as any).choices[0].message.reasoning_content, "first second");
+  assert.deepEqual((sanitized as any).choices[0].message.reasoning_details, [
+    { type: "reasoning.text", text: "first " },
+    { type: "thinking", content: "second" },
+  ]);
 });
 
 test("sanitizeOpenAIResponse preserves DeepSeek V4 reasoning_content with visible text", () => {
@@ -198,7 +208,7 @@ test("sanitizeOpenAIResponse preserves DeepSeek V4 reasoning_details with visibl
   assert.equal((sanitized as any).choices[0].message.reasoning_content, "first second");
 });
 
-test("sanitizeOpenAIResponse still strips non-DeepSeek reasoning_content with visible text", () => {
+test("sanitizeOpenAIResponse preserves non-DeepSeek reasoning_content with visible text", () => {
   const sanitized = sanitizeOpenAIResponse({
     model: "o3-mini",
     choices: [
@@ -212,7 +222,31 @@ test("sanitizeOpenAIResponse still strips non-DeepSeek reasoning_content with vi
     ],
   });
 
+  assert.equal((sanitized as any).choices[0].message.content, "Visible answer");
+  assert.equal((sanitized as any).choices[0].message.reasoning_content, "OpenAI reasoning");
+});
+
+test("sanitizeOpenAIResponse preserves OpenRouter native reasoning and signatures", () => {
+  const sanitized = sanitizeOpenAIResponse({
+    model: "moonshotai/kimi-k2.6",
+    choices: [
+      {
+        message: {
+          role: "assistant",
+          content: "<thinking>tag-derived</thinking><content>Visible answer</content>",
+          reasoning: "provider native reasoning",
+          reasoning_details: [{ type: "reasoning.encrypted", data: "sig" }],
+        },
+      },
+    ],
+  });
+
   assert.equal((sanitized as any).choices[0].message.reasoning_content, undefined);
+  assert.equal((sanitized as any).choices[0].message.reasoning, "provider native reasoning");
+  assert.deepEqual((sanitized as any).choices[0].message.reasoning_details, [
+    { type: "reasoning.encrypted", data: "sig" },
+  ]);
+  assert.equal((sanitized as any).choices[0].message.content, "<content>Visible answer</content>");
 });
 
 test("sanitizeOpenAIResponse keeps reasoning_details-derived reasoning_content for reasoning-only messages", () => {
@@ -535,9 +569,7 @@ test("sanitizeOpenAIResponse preserves reasoning_content when tool_calls are pre
   assert.equal(message.tool_calls[0].id, "call_search_1");
 });
 
-test("sanitizeOpenAIResponse still strips reasoning_content when no tool_calls exist", () => {
-  // When there are no tool_calls, the original behavior should remain:
-  // reasoning_content is stripped to avoid client rendering issues.
+test("sanitizeOpenAIResponse preserves reasoning_content when no tool_calls exist", () => {
   const sanitized = sanitizeOpenAIResponse({
     model: "gpt-4.1",
     choices: [
@@ -553,7 +585,7 @@ test("sanitizeOpenAIResponse still strips reasoning_content when no tool_calls e
 
   const message = (sanitized as any).choices[0].message;
   assert.equal(message.content, "Hello world");
-  assert.equal(message.reasoning_content, undefined);
+  assert.equal(message.reasoning_content, "Some internal reasoning");
 });
 
 test("sanitizeOpenAIResponse preserves reasoning_content when legacy function_call is present", () => {

--- a/tests/unit/strip-reasoning-header.test.ts
+++ b/tests/unit/strip-reasoning-header.test.ts
@@ -7,12 +7,9 @@ import assert from "node:assert/strict";
 // (Firecrawl AI SDK) have JSON parsers that break on this non-standard
 // extension even when there is no visible content, so the default
 // "keep reasoning-only messages" behavior is not sufficient.
-const { isStripReasoningRequested, getHeaderValueCaseInsensitive } = await import(
-  "../../open-sse/handlers/chatCore/headers.ts"
-);
-const { sanitizeOpenAIResponse } = await import(
-  "../../open-sse/handlers/responseSanitizer.ts"
-);
+const { isStripReasoningRequested, getHeaderValueCaseInsensitive } =
+  await import("../../open-sse/handlers/chatCore/headers.ts");
+const { sanitizeOpenAIResponse } = await import("../../open-sse/handlers/responseSanitizer.ts");
 
 test("isStripReasoningRequested is true for truthy header values", () => {
   for (const v of ["true", "1", "yes", "TRUE", "Yes", " true "]) {
@@ -98,7 +95,7 @@ test("stripReasoning=true: reasoning-only message has reasoning_content removed"
   assert.equal("reasoning_content" in out.choices[0].message, false);
 });
 
-test("stripReasoning=true: message with both content and reasoning_content has reasoning stripped", () => {
+test("stripReasoning=true: message with content has all OpenAI-compatible reasoning stripped", () => {
   const out = sanitizeOpenAIResponse(
     {
       id: "chatcmpl-x",
@@ -112,6 +109,9 @@ test("stripReasoning=true: message with both content and reasoning_content has r
             role: "assistant",
             content: "visible answer",
             reasoning_content: "internal",
+            reasoning: "native reasoning",
+            reasoning_text: "copilot reasoning",
+            reasoning_details: [{ type: "reasoning.encrypted", data: "sig" }],
           },
           finish_reason: "stop",
         },
@@ -120,5 +120,8 @@ test("stripReasoning=true: message with both content and reasoning_content has r
     { stripReasoning: true }
   ) as { choices: Array<{ message: Record<string, unknown> }> };
   assert.equal(out.choices[0].message.reasoning_content, undefined);
+  assert.equal(out.choices[0].message.reasoning, undefined);
+  assert.equal(out.choices[0].message.reasoning_text, undefined);
+  assert.equal(out.choices[0].message.reasoning_details, undefined);
   assert.equal(out.choices[0].message.content, "visible answer");
 });


### PR DESCRIPTION
## Summary

Fix non-streaming Chat Completions response sanitization so OpenAI-compatible clients can consume reasoning metadata that they already support.

## Root cause

The non-streaming sanitizer previously collapsed provider reasoning shapes into `reasoning_content`, then removed `reasoning_content` whenever visible assistant content was also present. That made compatible clients such as SillyTavern lose reasoning for successful non-streaming responses from providers that return `reasoning`, `reasoning_content`, or `reasoning_details` alongside normal content.

Some model outputs also use prompt-format tags but omit the opening `<thinking>` tag while still emitting `</thinking><content>...`; those prefixes were left in visible content instead of being surfaced as reasoning.

## Changes

- Preserve OpenAI-compatible reasoning fields in non-streaming messages:
  - `reasoning_content`
  - `reasoning`
  - `reasoning_text`
  - `reasoning_details`
- Keep native `reasoning` / `reasoning_details` instead of forcing them into `reasoning_content` when clients can read them directly.
- Extract closing-only `</thinking><content>` prompt-format reasoning prefixes into `reasoning_content`.
- Keep `x-omniroute-strip-reasoning` as the opt-in escape hatch, now stripping all compatible reasoning fields rather than only `reasoning_content`.
- Add regression coverage for visible-content reasoning preservation, OpenRouter native reasoning/signatures, closing-only thinking tags, and strip-reasoning behavior.

## Validation

- `node --import tsx/esm --test tests/unit/response-sanitizer.test.ts tests/unit/strip-reasoning-header.test.ts`
- `node --import tsx/esm --test tests/unit/response-sanitizer.test.ts tests/unit/strip-reasoning-header.test.ts tests/unit/combo/combo-context.test.ts tests/unit/combo-config.test.ts`
- `npm run typecheck:core`
- `npx eslint open-sse/handlers/responseSanitizer.ts tests/unit/response-sanitizer.test.ts tests/unit/strip-reasoning-header.test.ts` (no errors; existing test-file `any` warnings remain)

Note: full `npm run lint` still fails on repository-wide pre-existing lint errors outside this change.