### PR TITLE
fix(zenmux): normalize vendor-prefixed GLM system roles

### DIFF
--- a/open-sse/services/roleNormalizer.ts
+++ b/open-sse/services/roleNormalizer.ts
@@ -57,6 +57,15 @@ const MODELS_WITHOUT_SYSTEM_ROLE = [
   "ernie-", // Baidu ERNIE models
 ];
 
+const PROVIDER_SCOPED_MODELS_WITHOUT_SYSTEM_ROLE: Record<string, RegExp[]> = {
+  // ZenMux exposes Z.AI GLM through OpenAI-compatible model ids such as
+  // "z-ai/glm-5.2". Z.AI rejects compressed histories that start with a
+  // system summary followed by an assistant/tool bundle, while OpenRouter
+  // tolerates the same shape. Treat these vendor-prefixed GLM ids like native
+  // GLM so normalizeSystemRole moves system/developer content into a user turn.
+  zenmux: [/(?:^|\/)glm(?:-|$)/i],
+};
+
 interface MessageContentPart {
   type?: string;
   text?: string;
@@ -88,9 +97,15 @@ function extractTextFromContent(content: unknown): string {
  * Check if a provider+model combo supports the system role.
  */
 function supportsSystemRole(provider: string, model: string): boolean {
-  if (PROVIDERS_WITHOUT_SYSTEM_ROLE.has(provider)) return false;
+  const providerLower = (provider || "").trim().toLowerCase();
+  if (PROVIDERS_WITHOUT_SYSTEM_ROLE.has(providerLower)) return false;
 
   const modelLower = (model || "").toLowerCase();
+
+  for (const pattern of PROVIDER_SCOPED_MODELS_WITHOUT_SYSTEM_ROLE[providerLower] ?? []) {
+    if (pattern.test(modelLower)) return false;
+  }
+
   for (const prefix of MODELS_WITHOUT_SYSTEM_ROLE) {
     if (modelLower.startsWith(prefix)) return false;
   }

--- a/tests/unit/role-normalizer.test.ts
+++ b/tests/unit/role-normalizer.test.ts
@@ -99,6 +99,35 @@ test("normalizeSystemRole inserts a user message when no user exists and drops e
   ]);
 });
 
+test("normalizeSystemRole treats ZenMux z-ai/glm models as GLM even with vendor prefix", () => {
+  const messages = [
+    { role: "system", content: "[Context compressed: earlier messages removed]" },
+    {
+      role: "assistant",
+      content: null,
+      tool_calls: [
+        {
+          id: "call_1",
+          type: "function",
+          function: { name: "read", arguments: "{}" },
+        },
+      ],
+    },
+    { role: "tool", tool_call_id: "call_1", content: "ok" },
+  ];
+
+  const result = normalizeSystemRole(messages, "zenmux", "z-ai/glm-5.2");
+
+  assert.deepEqual(result, [
+    {
+      role: "user",
+      content: "[System Instructions]\n[Context compressed: earlier messages removed]",
+    },
+    messages[1],
+    messages[2],
+  ]);
+});
+
 test("normalizeRoles composes model, developer and system normalization in order", () => {
   const messages = [
     { role: "model", content: "first answer" },


### PR DESCRIPTION
## Summary

- Treat ZenMux `z-ai/glm-*` model ids as GLM models for system-role compatibility.
- Reuse the existing `normalizeSystemRole` path so compressed system/developer context is moved into a user turn before assistant/tool history.
- Add a regression test for the `system -> assistant(tool_calls) -> tool` compressed-history suffix that ZenMux/Z.AI rejects.

## Why

ZenMux exposes Z.AI GLM using vendor-prefixed OpenAI-compatible ids such as `z-ai/glm-5.2`. The existing GLM detection only matched bare `glm-*`/`glm`, so `zenmux/z-ai/glm-5.2` kept system messages. Z.AI rejects compressed histories where a system summary is immediately followed by an assistant/tool bundle with `messages 参数非法`, while OpenRouter tolerates that shape.

## Validation

- ✅ `DISABLE_SQLITE_AUTO_BACKUP=true node --import tsx --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test tests/unit/role-normalizer.test.ts`
- ✅ `npx eslint open-sse/services/roleNormalizer.ts tests/unit/role-normalizer.test.ts`
- ✅ pre-commit / pre-push hooks: docs sync, eslint/prettier, any-budget, tracked-artifacts
- ✅ Live ZenMux probe with a minimal failing shape:
  - `system -> assistant(tool_calls) -> tool`: 400 `messages 参数非法。请检查文档。`
  - normalized `user -> assistant(tool_calls) -> tool`: 200 OK

Note: full `npx tsc --noEmit --pretty false` still fails on existing unrelated test typing errors in the current tree (for example `tests/unit/trae-executor.test.ts` missing `signal`/`upstreamExtraHeaders`, plus multiple pre-existing test cast errors). No new type errors were introduced by this change.
