### PR TITLE
docs(i18n): add Traditional Chinese (zh-TW) README and update zh-CN to latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@
 </div>
 
 <div align="center">
-<b>🌐 Available in 40+ languages</b>
-<table>
+ <b>🌐 Available in 41+ languages</b>
+ <table>
   <tr>
     <td align="center"><a href="README.md">🇺🇸</a></td>
     <td align="center"><a href="docs/i18n/pt-BR/README.md">🇧🇷</a></td>
@@ -76,6 +76,7 @@
     <td align="center"><a href="docs/i18n/it/README.md">🇮🇹</a></td>
     <td align="center"><a href="docs/i18n/ru/README.md">🇷🇺</a></td>
     <td align="center"><a href="docs/i18n/zh-CN/README.md">🇨🇳</a></td>
+    <td align="center"><a href="docs/i18n/zh-TW/README.md">🇹🇼</a></td>
     <td align="center"><a href="docs/i18n/de/README.md">🇩🇪</a></td>
     <td align="center"><a href="docs/i18n/ja/README.md">🇯🇵</a></td>
     <td align="center"><a href="docs/i18n/ko/README.md">🇰🇷</a></td>

--- a/docs/i18n/README.md
+++ b/docs/i18n/README.md
@@ -43,4 +43,5 @@ Translations of documentation into 40 languages. Code blocks remain in English.
 - 🇺🇦 **Українська** (`uk-UA`): [Docs Root](./uk-UA/README.md)
 - 🇵🇰 **اردو** (`ur`): [Docs Root](./ur/README.md)
 - 🇻🇳 **Tiếng Việt** (`vi`): [Docs Root](./vi/README.md)
+- 🇹🇼 **中文 (繁體)** (`zh-TW`): [Docs Root](./zh-TW/README.md)
 - 🇨🇳 **中文 (简体)** (`zh-CN`): [Docs Root](./zh-CN/README.md)

--- a/docs/i18n/zh-CN/README.md
+++ b/docs/i18n/zh-CN/README.md
@@ -1,2376 +1,563 @@
-# 🚀 OmniRoute — The Free AI Gateway (中文 (简体))
+# 🚀 OmniRoute — 免费 AI 网关
 
-🌐 **Languages:** 🇺🇸 [English](../../../README.md) · 🇸🇦 [ar](../ar/README.md) · 🇧🇬 [bg](../bg/README.md) · 🇧🇩 [bn](../bn/README.md) · 🇨🇿 [cs](../cs/README.md) · 🇩🇰 [da](../da/README.md) · 🇩🇪 [de](../de/README.md) · 🇪🇸 [es](../es/README.md) · 🇮🇷 [fa](../fa/README.md) · 🇫🇮 [fi](../fi/README.md) · 🇫🇷 [fr](../fr/README.md) · 🇮🇳 [gu](../gu/README.md) · 🇮🇱 [he](../he/README.md) · 🇮🇳 [hi](../hi/README.md) · 🇭🇺 [hu](../hu/README.md) · 🇮🇩 [id](../id/README.md) · 🇮🇹 [it](../it/README.md) · 🇯🇵 [ja](../ja/README.md) · 🇰🇷 [ko](../ko/README.md) · 🇮🇳 [mr](../mr/README.md) · 🇲🇾 [ms](../ms/README.md) · 🇳🇱 [nl](../nl/README.md) · 🇳🇴 [no](../no/README.md) · 🇵🇭 [phi](../phi/README.md) · 🇵🇱 [pl](../pl/README.md) · 🇵🇹 [pt](../pt/README.md) · 🇧🇷 [pt-BR](../pt-BR/README.md) · 🇷🇴 [ro](../ro/README.md) · 🇷🇺 [ru](../ru/README.md) · 🇸🇰 [sk](../sk/README.md) · 🇸🇪 [sv](../sv/README.md) · 🇰🇪 [sw](../sw/README.md) · 🇮🇳 [ta](../ta/README.md) · 🇮🇳 [te](../te/README.md) · 🇹🇭 [th](../th/README.md) · 🇹🇷 [tr](../tr/README.md) · 🇺🇦 [uk-UA](../uk-UA/README.md) · 🇵🇰 [ur](../ur/README.md) · 🇻🇳 [vi](../vi/README.md) · 🇨🇳 [zh-CN](../zh-CN/README.md)
-
----
-
-### Never stop coding. Smart routing to **FREE & low-cost AI models** with automatic fallback.
-
-_Your universal API proxy — one endpoint, 100+ providers, zero downtime. Now with **MCP Server (25 tools)**, **A2A Protocol**, **Memory/Skills Systems** & **Electron Desktop App**._
-
-**Chat Completions • Embeddings • Image Generation • Video • Music • Audio • Reranking • **Web Search** • MCP Server • A2A Protocol • 100% TypeScript**
+🌐 **语言:** 🇺🇸 [English](../../../README.md) · 🇸🇦 [ar](../ar/README.md) · 🇧🇬 [bg](../bg/README.md) · 🇧🇩 [bn](../bn/README.md) · 🇨🇿 [cs](../cs/README.md) · 🇩🇰 [da](../da/README.md) · 🇩🇪 [de](../de/README.md) · 🇪🇸 [es](../es/README.md) · 🇮🇷 [fa](../fa/README.md) · 🇫🇮 [fi](../fi/README.md) · 🇫🇷 [fr](../fr/README.md) · 🇮🇳 [gu](../gu/README.md) · 🇮🇱 [he](../he/README.md) · 🇮🇳 [hi](../hi/README.md) · 🇭🇺 [hu](../hu/README.md) · 🇮🇩 [id](../id/README.md) · 🇮🇹 [it](../it/README.md) · 🇯🇵 [ja](../ja/README.md) · 🇰🇷 [ko](../ko/README.md) · 🇮🇳 [mr](../mr/README.md) · 🇲🇾 [ms](../ms/README.md) · 🇳🇱 [nl](../nl/README.md) · 🇳🇴 [no](../no/README.md) · 🇵🇭 [phi](../phi/README.md) · 🇵🇱 [pl](../pl/README.md) · 🇵🇹 [pt](../pt/README.md) · 🇧🇷 [pt-BR](../pt-BR/README.md) · 🇷🇴 [ro](../ro/README.md) · 🇷🇺 [ru](../ru/README.md) · 🇸🇰 [sk](../sk/README.md) · 🇸🇪 [sv](../sv/README.md) · 🇰🇪 [sw](../sw/README.md) · 🇮🇳 [ta](../ta/README.md) · 🇮🇳 [te](../te/README.md) · 🇹🇭 [th](../th/README.md) · 🇹🇷 [tr](../tr/README.md) · 🇺🇦 [uk-UA](../uk-UA/README.md) · 🇵🇰 [ur](../ur/README.md) · 🇻🇳 [vi](../vi/README.md) · 🇨🇳 [zh-CN](../zh-CN/README.md) · 🇹🇼 [zh-TW](../zh-TW/README.md)
 
 ---
+
+<div align="center">
+
+<img src="../../screenshots/MainOmniRoute.png" alt="OmniRoute 仪表板" width="820"/>
+
+<br/>
+
+# 🚀 OmniRoute — 免费 AI 网关
+
+### 永远不要停止开发。通过一个端点，将每个 AI 工具连接到 **231 个供应商** — **50+ 免费**。
+
+**将 Claude Code、Codex、Cursor、Cline、Copilot 和 Antigravity 连接到免费的 Claude / GPT / Gemini。自动故障转移。**
+
+**RTK + Caveman 压缩可节省 15–95% 的 Token。永远不会达到限制。**
+
+**~1.6B 有记录的免费 Token/月** — 首月通过注册奖励最高可达 **~2.1B** — 聚合所有免费层的配额，再加上永久免费、无上限的供应商，而上述压缩进一步延长每一分 Token。([统计方法 →](docs/reference/FREE_TIERS.md#tldr--how-much-free-inference-does-omniroute-actually-aggregate))
+
+[![231 AI Providers](https://img.shields.io/badge/231-AI_Providers-6C5CE7?style=for-the-badge)](#-231-ai-providers--50-free)
+[![50+ Free](https://img.shields.io/badge/50%2B-Free_Tiers-00B894?style=for-the-badge)](#-231-ai-providers--50-free)
+[![1.6B Free Tokens/mo](https://img.shields.io/badge/1.6B-Free_Tokens%2Fmo-00B894?style=for-the-badge)](docs/reference/FREE_TIERS.md)
+[![Token Savings](https://img.shields.io/badge/up_to_95%25-Token_Savings-E17055?style=for-the-badge)](#%EF%B8%8F-save-1595-tokens--automatically)
+[![17 Strategies](https://img.shields.io/badge/17-Routing_Strategies-0984E3?style=for-the-badge)](#-combos--the-flagship)
+[![$0 to start](https://img.shields.io/badge/%240-To_Start-FDCB6E?style=for-the-badge&logoColor=black)](#-quick-start)
+
+### 💬 加入社区
+
+[![Discord](https://img.shields.io/badge/Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/EkzRkpzKYt)
+[![Telegram](https://img.shields.io/badge/Telegram-26A5E4?style=for-the-badge&logo=telegram&logoColor=white)](https://t.me/omnirouteOficial)
+[![WhatsApp Global](https://img.shields.io/badge/WhatsApp_Global-25D366?style=for-the-badge&logo=whatsapp&logoColor=white)](https://chat.whatsapp.com/JI7cDQ1GyaiDHhVBpLxf8b?mode=gi_t)
+[![WhatsApp Brasil](https://img.shields.io/badge/WhatsApp_Brasil-25D366?style=for-the-badge&logo=whatsapp&logoColor=white)](https://chat.whatsapp.com/BTGJXIyjeNIIgExvTMGGhI)
+
+**问题、供应商技巧、路线图和支持 → [Discord](https://discord.gg/EkzRkpzKYt) · [Telegram](https://t.me/omnirouteOficial) · WhatsApp [🌍 全球](https://chat.whatsapp.com/JI7cDQ1GyaiDHhVBpLxf8b?mode=gi_t) / [🇧🇷 巴西](https://chat.whatsapp.com/BTGJXIyjeNIIgExvTMGGhI)**
+
+<a href="https://trendshift.io/repositories/23589" target="_blank"><img src="https://trendshift.io/api/badge/repositories/23589" alt="diegosouzapw%2FOmniRoute | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+
+[![npm](https://img.shields.io/npm/v/omniroute?logo=npm&style=flat-square)](https://www.npmjs.com/package/omniroute)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square)](LICENSE)
+[![Node](https://img.shields.io/badge/node-%E2%89%A522.0.0-brightgreen?style=flat-square)](package.json)
+[![Stars](https://img.shields.io/github/stars/diegosouzapw/OmniRoute?style=social)](https://github.com/diegosouzapw/OmniRoute)
 
 <div align="center">
 
 [![npm version](https://img.shields.io/npm/v/omniroute?color=cb3837&logo=npm)](https://www.npmjs.com/package/omniroute)
+![NPM Monthly](https://img.shields.io/npm/dm/omniroute?label=npm/month&color=cb3837&logo=npm)
 [![Docker Hub](https://img.shields.io/docker/v/diegosouzapw/omniroute?label=Docker%20Hub&logo=docker&color=2496ED)](https://hub.docker.com/r/diegosouzapw/omniroute)
-
-![NPM Downloads](https://img.shields.io/npm/dw/omniroute?label=npm%20down%20week&color=red)
-![NPM Downloads](https://img.shields.io/npm/dm/omniroute?label=npm%20down%20month&color=red)
-
-![NPM Downloads](https://img.shields.io/npm/d18m/omniroute?label=npm%20down%20year&color=red)
-![Docker Pulls](https://img.shields.io/docker/pulls/diegosouzapw/omniroute)
-![GitHub Downloads (all assets, all releases)](https://img.shields.io/github/downloads/diegosouzapw/omniroute/total?style=flat&label=eletron%20donwloads&color=blue)
-
-[![stars](https://custom-icon-badges.demolab.com/github/stars/diegosouzapw/OmniRoute?logo=star&style=flat)](https://github.com/diegosouzapw/OmniRoute/stargazers)
-[![open issues](https://custom-icon-badges.demolab.com/github/issues-raw/diegosouzapw/OmniRoute?logo=issue)](https://github.com/diegosouzapw/OmniRoute/issues)
-[![license](https://custom-icon-badges.demolab.com/github/license/diegosouzapw/OmniRoute?logo=law)](https://github.com/diegosouzapw/OmniRoute/blob/main/LICENSE)
-[![last commit](https://custom-icon-badges.demolab.com/github/last-commit/diegosouzapw/OmniRoute?logo=history&logoColor=white)](https://github.com/diegosouzapw/OmniRoute/commits/main)
-[![total contributions](https://custom-icon-badges.demolab.com/badge/dynamic/json?logo=graph&logoColor=fff&color=blue&label=total%20contributions&query=%24.totalContributions&url=https%3A%2F%2Fstreak-stats.demolab.com%2F%3Fuser%3Ddiegosouzapw%26type%3Djson)](https://github.com/diegosouzapw)
-[![code size](https://custom-icon-badges.demolab.com/github/languages/code-size/diegosouzapw/OmniRoute?logo=file-code&logoColor=white)](https://github.com/diegosouzapw/OmniRoute)
-[![pr closed](https://custom-icon-badges.demolab.com/github/issues-pr-closed/diegosouzapw/OmniRoute?color=purple&logo=git-pull-request&logoColor=white)](https://github.com/diegosouzapw/OmniRoute/pulls?q=is%3Apr+is%3Aclosed)
-[![tag](https://custom-icon-badges.demolab.com/github/v/tag/diegosouzapw/OmniRoute?logo=tag&logoColor=white)](https://github.com/diegosouzapw/OmniRoute/tags)
-[![github streak](https://custom-icon-badges.demolab.com/badge/dynamic/json?logo=fire&logoColor=fff&color=orange&label=github%20streak&query=%24.currentStreak.length&suffix=%20days&url=https%3A%2F%2Fstreak-stats.demolab.com%2F%3Fuser%3Ddiegosouzapw%26type%3Djson)](https://github.com/diegosouzapw)
-[![followers](https://custom-icon-badges.demolab.com/github/followers/diegosouzapw?logo=person-add)](https://github.com/diegosouzapw?tab=followers)
-[![fork](https://custom-icon-badges.demolab.com/github/forks/diegosouzapw/OmniRoute?logo=fork)](https://github.com/diegosouzapw/OmniRoute/network/members)
-[![watch](https://custom-icon-badges.demolab.com/github/watchers/diegosouzapw/OmniRoute?logo=eye)](https://github.com/diegosouzapw/OmniRoute/watchers)
-
-[![License](https://img.shields.io/github/license/diegosouzapw/OmniRoute)](https://github.com/diegosouzapw/OmniRoute/blob/main/LICENSE)
+![Docker Pulls](https://img.shields.io/docker/pulls/diegosouzapw/omniroute?label=docker%20pulls&logo=docker&color=2496ED)
+![Electron Downloads](https://img.shields.io/github/downloads/diegosouzapw/omniroute/total?style=flat&label=electron%20downloads&logo=electron&color=47848F)
 [![Website](https://img.shields.io/badge/Website-omniroute.online-blue?logo=google-chrome&logoColor=white)](https://omniroute.online)
-[![WhatsApp](https://img.shields.io/badge/WhatsApp-Community-25D366?logo=whatsapp&logoColor=white)](https://chat.whatsapp.com/JI7cDQ1GyaiDHhVBpLxf8b?mode=gi_t)
-
-[🌐 Website](https://omniroute.online) • [🚀 Quick Start](#-quick-start) • [💡 Features](#-key-features) • [📖 Docs](#-documentation) • [💰 Pricing](#-pricing-at-a-glance) • [💬 WhatsApp](https://chat.whatsapp.com/JI7cDQ1GyaiDHhVBpLxf8b?mode=gi_t)
 
 </div>
 
-🌐 **Available in:** 🇺🇸 [English](README.md) | 🇧🇷 [Português (Brasil)](docs/i18n/pt-BR/README.md) | 🇪🇸 [Español](docs/i18n/es/README.md) | 🇫🇷 [Français](docs/i18n/fr/README.md) | 🇮🇹 [Italiano](docs/i18n/it/README.md) | 🇷🇺 [Русский](docs/i18n/ru/README.md) | 🇨🇳 [中文 (简体)](docs/i18n/zh-CN/README.md) | 🇩🇪 [Deutsch](docs/i18n/de/README.md) | 🇮🇳 [हिन्दी](docs/i18n/in/README.md) | 🇹🇭 [ไทย](docs/i18n/th/README.md) | 🇺🇦 [Українська](docs/i18n/uk-UA/README.md) | 🇸🇦 [العربية](docs/i18n/ar/README.md) | 🇯🇵 [日本語](docs/i18n/ja/README.md) | 🇻🇳 [Tiếng Việt](docs/i18n/vi/README.md) | 🇧🇬 [Български](docs/i18n/bg/README.md) | 🇩🇰 [Dansk](docs/i18n/da/README.md) | 🇫🇮 [Suomi](docs/i18n/fi/README.md) | 🇮🇱 [עברית](docs/i18n/he/README.md) | 🇭🇺 [Magyar](docs/i18n/hu/README.md) | 🇮🇩 [Bahasa Indonesia](docs/i18n/id/README.md) | 🇰🇷 [한국어](docs/i18n/ko/README.md) | 🇲🇾 [Bahasa Melayu](docs/i18n/ms/README.md) | 🇳🇱 [Nederlands](docs/i18n/nl/README.md) | 🇳🇴 [Norsk](docs/i18n/no/README.md) | 🇵🇹 [Português (Portugal)](docs/i18n/pt/README.md) | 🇷🇴 [Română](docs/i18n/ro/README.md) | 🇵🇱 [Polski](docs/i18n/pl/README.md) | 🇸🇰 [Slovenčina](docs/i18n/sk/README.md) | 🇸🇪 [Svenska](docs/i18n/sv/README.md) | 🇵🇭 [Filipino](docs/i18n/phi/README.md) | 🇨🇿 [Čeština](docs/i18n/cs/README.md)
+[**🚀 快速开始**](#-quick-start) • [**🎯 组合策略**](#-combos--the-flagship) • [**🌐 供应商**](#-231-ai-providers--50-free) • [**🔌 CLI 与 MCP**](#-full-cli--a2a--mcp) • [**🗜️ 压缩**](#%EF%B8%8F-save-1595-tokens--automatically) • [**🌍 网站**](https://omniroute.online)
 
----
-
-## 🖼️ Main Dashboard
+[💥 承诺](#-the-promise) • [🤔 为什么](#-why-omniroute) • [🏆 优势](#-what-sets-omniroute-apart) • [🤖 兼容 CLI](#-compatible-clis--coding-agents) • [🖥️ 运行平台](#%EF%B8%8F-where-omniroute-runs--anywhere) • [🔒 隐私](#-private--local-first) • [🎬 实际演示](#-omniroute-in-action) • [📚 探索更多](#-explore-more) • [📧 支持](#-support--community)
 
 <div align="center">
-  <img src="./docs/screenshots/MainOmniRoute.png" alt="OmniRoute Dashboard" width="800"/>
+<b>🌐 支持 41+ 种语言</b>
+<table>
+  <tr>
+    <td align="center"><a href="README.md">🇺🇸</a></td>
+    <td align="center"><a href="docs/i18n/pt-BR/README.md">🇧🇷</a></td>
+    <td align="center"><a href="docs/i18n/es/README.md">🇪🇸</a></td>
+    <td align="center"><a href="docs/i18n/fr/README.md">🇫🇷</a></td>
+    <td align="center"><a href="docs/i18n/it/README.md">🇮🇹</a></td>
+    <td align="center"><a href="docs/i18n/ru/README.md">🇷🇺</a></td>
+    <td align="center"><a href="docs/i18n/zh-CN/README.md">🇨🇳</a></td>
+    <td align="center"><a href="docs/i18n/zh-TW/README.md">🇹🇼</a></td>
+    <td align="center"><a href="docs/i18n/de/README.md">🇩🇪</a></td>
+    <td align="center"><a href="docs/i18n/ja/README.md">🇯🇵</a></td>
+    <td align="center"><a href="docs/i18n/ko/README.md">🇰🇷</a></td>
+  </tr>
+  <tr>
+    <td align="center"><a href="docs/i18n/th/README.md">🇹🇭</a></td>
+    <td align="center"><a href="docs/i18n/vi/README.md">🇻🇳</a></td>
+    <td align="center"><a href="docs/i18n/id/README.md">🇮🇩</a></td>
+    <td align="center"><a href="docs/i18n/ms/README.md">🇲🇾</a></td>
+    <td align="center"><a href="docs/i18n/phi/README.md">🇵🇭</a></td>
+    <td align="center"><a href="docs/i18n/ar/README.md">🇸🇦</a></td>
+    <td align="center"><a href="docs/i18n/he/README.md">🇮🇱</a></td>
+    <td align="center"><a href="docs/i18n/az/README.md">🇦🇿</a></td>
+    <td align="center"><a href="docs/i18n/uk-UA/README.md">🇺🇦</a></td>
+    <td align="center"><a href="docs/i18n/pl/README.md">🇵🇱</a></td>
+    <td align="center"><a href="docs/i18n/cs/README.md">🇨🇿</a></td>
+  </tr>
+  <tr>
+    <td align="center"><a href="docs/i18n/nl/README.md">🇳🇱</a></td>
+    <td align="center"><a href="docs/i18n/bg/README.md">🇧🇬</a></td>
+    <td align="center"><a href="docs/i18n/da/README.md">🇩🇰</a></td>
+    <td align="center"><a href="docs/i18n/fi/README.md">🇫🇮</a></td>
+    <td align="center"><a href="docs/i18n/no/README.md">🇳🇴</a></td>
+    <td align="center"><a href="docs/i18n/sv/README.md">🇸🇪</a></td>
+    <td align="center"><a href="docs/i18n/hu/README.md">🇭🇺</a></td>
+    <td align="center"><a href="docs/i18n/ro/README.md">🇷🇴</a></td>
+    <td align="center"><a href="docs/i18n/sk/README.md">🇸🇰</a></td>
+    <td align="center"><a href="docs/i18n/pt/README.md">🇵🇹</a></td>
+    <td align="center"></td>
+  </tr>
+</table>
 </div>
 
----
+# 💰 ~1.6B 免费 Token/月
 
-## 📸 Dashboard Preview
+> 手动堆叠免费层很痛苦 — 数十个 SDK、数十个速率限制，且不清楚自己到底有多少配额。OmniRoute 将 **40+ 供应商池 / 500+ 模型**的**有记录**免费层聚合为一个真实数字，并在仪表板上实时展示 (`/dashboard/free-tiers`)。
 
-<details>
-<summary><b>Click to see dashboard screenshots</b></summary>
+- **~1.6B 免费 Token/月**（稳定） — 首月通过注册奖励最高可达 **~2.1B**。
+- **池去重，诚实** — 每个共享免费池只计算**一次**，因此标题不会被速率限制上限所夸大。
+- **加上不可计数的** — 永久免费、无 Token 上限的供应商（SiliconFlow、Z.AI GLM-Flash、Kilo、OpenCode Zen…）以及 **$10 OpenRouter 充值**可解锁 **+24M/月**。
+- **按模型细分**，当月**已用/剩余**实时显示，以及每个供应商的透明**条款标志**。
 
-| Page           | Screenshot                                        |
-| -------------- | ------------------------------------------------- |
-| **Providers**  | ![Providers](docs/screenshots/01-providers.png)   |
-| **Combos**     | ![Combos](docs/screenshots/02-combos.png)         |
-| **Analytics**  | ![Analytics](docs/screenshots/03-analytics.png)   |
-| **Health**     | ![Health](docs/screenshots/04-health.png)         |
-| **Translator** | ![Translator](docs/screenshots/05-translator.png) |
-| **Settings**   | ![Settings](docs/screenshots/06-settings.png)     |
-| **CLI Tools**  | ![CLI Tools](docs/screenshots/07-cli-tools.png)   |
-| **Usage Logs** | ![Usage](docs/screenshots/08-usage.png)           |
-| **Endpoints**  | ![Endpoints](docs/screenshots/09-endpoint.png)    |
+![Free-Tier Budget card (preview mockup)](docs/screenshots/free-tier-budget-card.svg)
 
-</details>
+> 预览模型 — 实际截图将在 `/dashboard/free-tiers` 页面验证后上线。完整方法（池去重、信用层级、供应商条款）：**[docs/reference/FREE_TIERS.md](docs/reference/FREE_TIERS.md)**。
 
----
+# 💥 承诺
 
-### 🤖 Free AI Provider for your favorite coding agents
+> 一个端点。**231 个供应商。** 永远不要停止构建 — 让 OmniRoute 选择最便宜且有效的方案。
 
-_Connect any AI-powered IDE or CLI tool through OmniRoute — free API gateway for unlimited coding._
+<table>
+  <tr>
+    <td width="33%" valign="top"><b>🚫 永远不会达到限制</b><br/><sub>跨 231 个供应商毫秒级自动故障转移。配额用尽？下一个供应商立即接管 — 零停机。</sub></td>
+    <td width="33%" valign="top"><b>💸 节省高达 95% 的 Token</b><br/><sub>RTK + Caveman 堆叠压缩可削减 15–95% 的合格 Token（工具密集型会话平均约 89%）。</sub></td>
+    <td width="33%" valign="top"><b>🆓 零成本开始</b><br/><sub>50+ 供应商提供免费层，11 个永久免费（Kiro、Qoder、Pollinations、LongCat…）。无需信用卡。</sub></td>
+  </tr>
+  <tr>
+    <td width="33%" valign="top"><b>🔌 每个工具都兼容</b><br/><sub>16+ 编码代理 — Claude Code、Codex、Cursor、Cline、Copilot、Antigravity — 通过一个配置即可使用。</sub></td>
+    <td width="33%" valign="top"><b>🧩 一个端点</b><br/><sub>OpenAI ↔ Claude ↔ Gemini ↔ Responses API 转换。将任何工具指向 <code>/v1</code> 即可使用。</sub></td>
+    <td width="33%" valign="top"><b>🛡️ 生产级别</b><br/><sub>断路器、TLS 隐身、MCP（87 工具）、A2A、记忆、护栏、评估。14,965 个测试。</sub></td>
+  </tr>
+</table>
 
-  <table>
-    <tr>
-      <td align="center" width="110">
-        <a href="https://github.com/openclaw/openclaw">
-          <img src="./public/providers/openclaw.png" alt="OpenClaw" width="48"/><br/>
-          <b>OpenClaw</b>
-        </a><br/>
-        <sub>⭐ 205K</sub>
-      </td>
-      <td align="center" width="110">
-        <a href="https://github.com/HKUDS/nanobot">
-          <img src="./public/providers/nanobot.png" alt="NanoBot" width="48"/><br/>
-          <b>NanoBot</b>
-        </a><br/>
-        <sub>⭐ 20.9K</sub>
-      </td>
-      <td align="center" width="110">
-        <a href="https://github.com/sipeed/picoclaw">
-          <img src="./public/providers/picoclaw.jpg" alt="PicoClaw" width="48"/><br/>
-          <b>PicoClaw</b>
-        </a><br/>
-        <sub>⭐ 14.6K</sub>
-      </td>
-      <td align="center" width="110">
-        <a href="https://github.com/zeroclaw-labs/zeroclaw">
-          <img src="./public/providers/zeroclaw.png" alt="ZeroClaw" width="48"/><br/>
-          <b>ZeroClaw</b>
-        </a><br/>
-        <sub>⭐ 9.9K</sub>
-      </td>
-      <td align="center" width="110">
-        <a href="https://github.com/nearai/ironclaw">
-          <img src="./public/providers/ironclaw.png" alt="IronClaw" width="48"/><br/>
-          <b>IronClaw</b>
-        </a><br/>
-        <sub>⭐ 2.1K</sub>
-      </td>
-    </tr>
-    <tr>
-      <td align="center" width="110">
-        <a href="https://github.com/anomalyco/opencode">
-          <img src="./public/providers/opencode.svg" alt="OpenCode" width="48"/><br/>
-          <b>OpenCode</b>
-        </a><br/>
-        <sub>⭐ 106K</sub>
-      </td>
-      <td align="center" width="110">
-        <a href="https://github.com/openai/codex">
-          <img src="./public/providers/codex.svg" alt="Codex CLI" width="48"/><br/>
-          <b>Codex CLI</b>
-        </a><br/>
-        <sub>⭐ 60.8K</sub>
-      </td>
-      <td align="center" width="110">
-        <a href="https://github.com/anthropics/claude-code">
-          <img src="./public/providers/claude.svg" alt="Claude Code" width="48"/><br/>
-          <b>Claude Code</b>
-        </a><br/>
-        <sub>⭐ 67.3K</sub>
-      </td>
-      <td align="center" width="110">
-        <a href="https://github.com/google-gemini/gemini-cli">
-          <img src="./public/providers/gemini-cli.svg" alt="Gemini CLI" width="48"/><br/>
-          <b>Gemini CLI</b>
-        </a><br/>
-        <sub>⭐ 94.7K</sub>
-      </td>
-      <td align="center" width="110">
-        <a href="https://github.com/Kilo-Org/kilocode">
-          <img src="./public/providers/kilocode.svg" alt="Kilo Code" width="48"/><br/>
-          <b>Kilo Code</b>
-        </a><br/>
-        <sub>⭐ 15.5K</sub>
-      </td>
-    </tr>
-  </table>
+# 🤔 为什么选择 OmniRoute？
 
-<sub>📡 All agents connect via <code>http://localhost:20128/v1</code> or <code>http://cloud.omniroute.online/v1</code> — one config, unlimited models and quota</sub>
+> 告别管理 10 个仪表板、失效的 API 密钥和意外账单的烦恼。
 
----
+| ❌ 日常痛点 | ✅ OmniRoute 的解决方案 |
+|---|---|
+| 📉 订阅配额每月用不完就浪费 | **最大化订阅** — 追踪配额，在重置前用尽每个 Token |
+| 🛑 速率限制中断编码 | **4 层自动故障转移** — 订阅 → API → 廉价 → 免费，毫秒级切换 |
+| 🔥 工具输出消耗大量 Token | **RTK + Caveman 压缩** — 每次请求节省 15–95% 合格 Token |
+| 💸 昂贵的 API（每个供应商 $20–50/月） | **成本优化路由** — 自动路由到最便宜的可行模型 |
+| 🧰 每个 AI 工具需要不同的设置 | **一个端点，所有工具，一个仪表板** |
+| 🌍 所在国家/地区封锁 AI | **3 层代理** + TLS 指纹隐身 — 从任何地方使用 AI |
 
-## 🤔 Why OmniRoute?
+```
+┌──────────────────────────────────────────────────────────┐
+│        Your IDE / CLI  (Claude Code, Cursor, Cline…)       │
+└─────────────────────────┬──────────────────────────────────┘
+                          │ http://localhost:20128/v1
+                          ▼
+┌──────────────────────────────────────────────────────────┐
+│                  OmniRoute — Smart Router                  │
+│  RTK + Caveman compression · 17 routing strategies         │
+│  Circuit breakers · TLS stealth · MCP · A2A · Guardrails   │
+└─────────────────────────┬──────────────────────────────────┘
+        ┌─────────────┬────┴────────┬─────────────┐
+        ▼ Tier 1      ▼ Tier 2      ▼ Tier 3       ▼ Tier 4
+   SUBSCRIPTION     API KEY        CHEAP          FREE
+   Claude Code,     DeepSeek,      GLM $0.5,      Kiro, Qoder,
+   Codex, Copilot   Groq, xAI      MiniMax $0.2   Pollinations
+   quota out? ───▶  budget hit? ─▶ budget hit? ─▶ always on
+```
 
-**Stop wasting money and hitting limits:**
+# 🎯 Combo — 旗舰功能
 
-- <img src="https://img.shields.io/badge/✗-e74c3c?style=flat-square" height="16"/> Subscription quota expires unused every month
-- <img src="https://img.shields.io/badge/✗-e74c3c?style=flat-square" height="16"/> Rate limits stop you mid-coding
-- <img src="https://img.shields.io/badge/✗-e74c3c?style=flat-square" height="16"/> Expensive APIs ($20-50/month per provider)
-- <img src="https://img.shields.io/badge/✗-e74c3c?style=flat-square" height="16"/> Manual switching between providers
+> **Combo** 是 OmniRoute **自动**路由的模型链。配额用尽、供应商失败或成本飙升 — Combo 自动滑动到下一个模型。**这就是 OmniRoute 不可中断的原因。** 🛡️
 
-**OmniRoute solves this:**
+### ⚡ 零配置 — 只需使用 `auto`
 
-- ✅ **Maximize subscriptions** - Track quota, use every bit before reset
-- ✅ **Auto fallback** - Subscription → API Key → Cheap → Free, zero downtime
-- ✅ **Multi-account** - Round-robin between accounts per provider
-- ✅ **Universal** - Works with Claude Code, Codex, Gemini CLI, Cursor, Cline, OpenClaw, any CLI tool
+无需创建 Combo。将模型设置为 `auto`（或变体），OmniRoute 会根据您连接的供应商实时评分构建虚拟 Combo：
 
----
+| 模型 ID | 优化目标 |
+|---|---|
+| `auto` | 🎯 平衡默认（LKGP — 沿用上次好的供应商） |
+| `auto/coding` | 🧑‍💻 代码生成优先质量权重 |
+| `auto/fast` | ⚡ 最低延迟优先 |
+| `auto/cheap` | 💰 每 Token 最低价优先 |
+| `auto/offline` | 🔋 最多配额/速率限制余量优先 |
+| `auto/smart` | 🔭 质量优先 + 10% 探索以发现更好模型 |
 
-## 📧 Support
+### 🔀 或自行构建 — 17 种路由策略
 
-> 💬 **Join our community!** [WhatsApp Group](https://chat.whatsapp.com/JI7cDQ1GyaiDHhVBpLxf8b?mode=gi_t) — Get help, share tips, and stay updated.
+| 目标 | 策略 / Combo |
+|---|---|
+| 🥇 先用完订阅再付费 | `priority` / `fill-first` |
+| ⚖️ 跨账户分散负载 | `round-robin` · `weighted` · `p2c` · `least-used` |
+| 💸 始终选最便宜的可行模型 | `cost-optimized` · `auto/cheap` |
+| 🧠 模型间移交长上下文 | `context-relay` · `context-optimized` |
+| 🎲 随机/隐私路由 | `random` · `strict-random` |
+| 🧬 分发到专家组 + 裁判合成 | `fusion` |
+| 📊 按剩余配额余量路由 | `reset-window` · `headroom` |
+| 🤖 智能路由 | `auto`（9 因素评分）· `lkgp` · `reset-aware` |
 
-- **Website**: [omniroute.online](https://omniroute.online)
-- **GitHub**: [github.com/diegosouzapw/OmniRoute](https://github.com/diegosouzapw/OmniRoute)
-- **Issues**: [github.com/diegosouzapw/OmniRoute/issues](https://github.com/diegosouzapw/OmniRoute/issues)
-- **WhatsApp**: [Community Group](https://chat.whatsapp.com/JI7cDQ1GyaiDHhVBpLxf8b?mode=gi_t)
-- **Contributing**: See [CONTRIBUTING.md](CONTRIBUTING.md), open a PR, or pick a `good first issue`
+### 🧱 内置弹性（3 个独立层）
 
-### 🐛 Reporting a Bug?
+| 层 | 范围 | 作用 |
+|---|---|---|
+| 🔌 **断路器** | 整个供应商 | 停止重复调用上游失败的供应商；自动探测恢复 |
+| 💤 **连接冷却** | 一个账户/密钥 | 跳过速率受限的密钥，其他密钥继续提供服务 |
+| 🎯 **模型锁定** | 供应商 + 模型 | 仅隔离配额受限的模型，不影响整个连接 |
 
-When opening an issue, please run the system-info command and attach the generated file:
+```
+Combo: "always-on"                         Strategy: priority
+  1. cc/claude-opus-4-7   ← subscription (use it fully)
+  2. cx/gpt-5.5           ← second subscription
+  3. glm/glm-5.1          ← cheap backup ($0.5/1M)
+  4. kr/claude-sonnet-4.5 ← FREE, unlimited (never fails)
+Result: 4 layers of fallback = zero downtime
+```
+
+# 🏆 OmniRoute 的独特优势
+
+| 功能 | OmniRoute | 其他路由器 |
+|---|---|---|
+| 🌐 供应商数量 | **231** | 20–100 |
+| 🆓 免费供应商 | **50+（11 个永久免费）** | 1–5 |
+| 🔀 路由策略 | **17 种**（优先级、加权、成本优化、上下文中继、融合…） | 1–3 |
+| 🗜️ Token 压缩 | **RTK + Caveman 堆叠（15–95%）** | 无 / 20–40% |
+| 🧰 内置 MCP 服务器 | **87 个工具、3 种传输、30 个范围** | 少有 |
+| 🤝 A2A 代理协议 | **6 项技能、JSON-RPC 2.0** | 无 |
+| 🧠 记忆（FTS5 + 向量） | **支持** | 少有 |
+| 🛡️ 护栏（PII、注入、视觉） | **支持** | 少有 |
+| ☁️ 云代理 | **Codex、Devin、Jules** | 无 |
+| 🥷 TLS 指纹隐身 | **JA3/JA4 通过 wreq-js** | 无 |
+| 🖥️ 多平台 | **Web · 桌面 · Termux · PWA** | 仅 Web |
+| 🌍 国际化 | **42 种语言环境** | 0–4 |
+
+# ✨ 新功能
+
+> **v3.8.20 → v3.8.38** 重点更新。完整记录见 [`CHANGELOG.md`](CHANGELOG.md)。
+
+- **⚖️ Quota-Share 路由** — 按可用配额跨账户分配负载的专用 Combo 策略
+- **🤖 一键 CLI/代理设置** — 专用的 `setup-*` 命令配置每个编码工具通过 OmniRoute 路由
+- **🛰️ 远程模式** — 通过范围访问令牌从任何机器驱动远程 OmniRoute
+- **🧭 更智能的自动路由** — OpenRouter 风格 Combo、Fusion 策略、任务感知路由
+- **🗜️ 可插拔压缩** — **9 个可组合引擎**的异步流水线
+- **🕵️ 透明 MITM 解密（TPROXY）** — 捕获并转换忽略代理环境变量的 CLI 流量
+- **💸 全方位成本遥测** — 每个端点上的 `X-OmniRoute-*` 成本/使用量标头
+- **🧠 可控记忆** — 可选 int8 向量量化
+- **🛡️ 安全** — 所有 LLM 路由的提示注入防护
+- **🤝 更多供应商和代理** — Cursor Cloud Agent、CodeBuddy CN、新网关
+- **⚡ 本地性能与基础设施** — 一键本地 Redis 启动器、Cloudflare Workers 中继
+
+# 🤖 兼容的 CLI 和编码代理
+
+> 一个配置 — `http://localhost:20128/v1` — 每个 AI IDE 或 CLI 都可以在免费和低成本模型上运行。
+
+Claude Code · Codex CLI · Gemini CLI · Cursor · Copilot · Continue · OpenCode · Kilo Code · Cline · Antigravity · Windsurf · AMP · Hermes · Qwen CLI · Roo · 任何兼容 OpenAI 的工具
+
+# 🌐 231 个 AI 供应商 — 50+ 免费
+
+> 最完整的开源路由器目录：**231 个供应商**、**50+ 具有免费层**、**11 个永久免费**。
+
+### 🆓 永久免费 — $0，无需信用卡
+
+AgentRouter · Qoder AI · Pollinations · LongCat · Cloudflare AI · Gemini CLI · NVIDIA NIM · Cerebras
+
+# 🖥️ OmniRoute 的运行平台 — 无处不在
+
+> 相同的应用，您的机器，您的规则。从全局 npm 安装到通过 Termux **在手机上**运行。
+
+| 平台 | 安装方式 | 亮点 |
+|---|---|---|
+| 📦 **npm（全局）** | `npm install -g omniroute` | 一条命令，任何操作系统 |
+| 🐳 **Docker** | `docker run … diegosouzapw/omniroute` | 多架构 AMD64 + ARM64 |
+| 🖥️ **桌面（Electron）** | `npm run electron:build` | Windows / macOS / Linux |
+| 💪 **ARM** | 原生 `arm64` | Raspberry Pi、Apple Silicon |
+| 📱 **Android（Termux）** | `pkg install nodejs-lts && npx -y omniroute` | 在手机上运行 |
+| 📲 **PWA** | "添加到主屏幕" | 全屏、离线 |
+| 🧩 **OpenCode 插件** | `@omniroute/opencode-provider` | 原生 OpenCode 集成 |
+| 🛠️ **从源码构建** | `npm install && npm run dev` | 参与开发 |
+
+# 🔒 私有与本地优先
+
+> 您的密钥、您的机器、您的数据。OmniRoute 是**本地代理** — 从不向外部报告。
+
+- 🏠 **100% 在您的硬件上运行** — npm、Docker、桌面或手机
+- 🔐 **凭证静态加密** — API 密钥和 OAuth 令牌使用 **AES-256-GCM** 加密
+- 🚫 **默认零遥测** — 您的提示仅发送给您选择的供应商
+- 🛡️ **强化网关** — API 密钥范围限制、IP 过滤、速率限制、提示注入防护
+- 📜 **MIT 许可且完全开源** — 审计每一行代码，永久自托管
+
+# 🔌 完整 CLI + A2A 和 MCP
+
+> OmniRoute 不仅仅是服务器 — 它拥有 **60+ 命令**的**完整命令行控制台**，以及开放的代理协议，AI 代理可以**自行**驱动 OmniRoute。
+
+### ⌨️ 真正的 CLI（不仅仅是 `start`）
 
 ```bash
-npm run system-info
+omniroute               # 启动网关 + 仪表板（端口 20128）
+omniroute chat          # 交互式 TUI 聊天客户端
+omniroute setup         # 引导式首次运行向导
+omniroute doctor        # 诊断供应商、端口、原生依赖
 ```
 
-This generates a `system-info.txt` with your Node.js version, OmniRoute version, OS details, installed CLI tools (qoder, gemini, claude, codex, antigravity, droid, etc.), Docker/PM2 status, and system packages — everything we need to reproduce your issue quickly. Attach the file directly to your GitHub issue.
+### 🛰️ 远程模式 — 在此处运行 CLI，OmniRoute 在 VPS 上
 
----
-
-## 🔄 How It Works
-
-```
-┌─────────────┐
-│  Your CLI   │  (Claude Code, Codex, Gemini CLI, OpenClaw, Cursor, Cline...)
-│   Tool      │
-└──────┬──────┘
-       │ http://localhost:20128/v1
-       ↓
-┌─────────────────────────────────────────┐
-│           OmniRoute (Smart Router)        │
-│  • Format translation (OpenAI ↔ Claude) │
-│  • Quota tracking + Embeddings + Images │
-│  • Auto token refresh                   │
-└──────┬──────────────────────────────────┘
-       │
-       ├─→ [Tier 1: SUBSCRIPTION] Claude Code, Codex, Gemini CLI
-       │   ↓ quota exhausted
-       ├─→ [Tier 2: API KEY] DeepSeek, Groq, xAI, Mistral, NVIDIA NIM, etc.
-       │   ↓ budget limit
-       ├─→ [Tier 3: CHEAP] GLM ($0.6/1M), MiniMax ($0.2/1M)
-       │   ↓ budget limit
-       └─→ [Tier 4: FREE] Qoder, Qwen, Kiro (unlimited)
-
-Result: Never stop coding, minimal cost
+```bash
+omniroute connect 192.168.0.15            # 密码 → 范围令牌
+omniroute models list                     # 在远程服务器上运行
+omniroute configure codex                 # 选择远程模型
+omniroute tokens create --name ci --scope read
+omniroute contexts use default            # 切换回本地
 ```
 
----
-
-## 🎯 What OmniRoute Solves — 30 Real Pain Points & Use Cases
-
-> **Every developer using AI tools faces these problems daily.** OmniRoute was built to solve them all — from cost overruns to regional blocks, from broken OAuth flows to protocol operations and enterprise observability.
-
-<details>
-<summary><b>💸 1. "I pay for an expensive subscription but still get interrupted by limits"</b></summary>
-
-Developers pay $20–200/month for Claude Pro, Codex Pro, or GitHub Copilot. Even paying, quota has a ceiling — 5h of usage, weekly limits, or per-minute rate limits. Mid-coding session, the provider stops responding and the developer loses flow and productivity.
-
-**How OmniRoute solves it:**
-
-- **Smart 4-Tier Fallback** — If subscription quota runs out, automatically redirects to API Key → Cheap → Free with zero manual intervention
-- **Provider Limits Tracking** — Cached quota snapshots refresh on a server-side schedule (default `PROVIDER_LIMITS_SYNC_INTERVAL_MINUTES=70`) with manual refresh available in the UI
-- **Multi-Account Support** — Multiple accounts per provider with auto round-robin — when one runs out, switches to the next
-- **Custom Combos** — Customizable fallback chains with 13 balancing strategies (priority, weighted, fill-first, round-robin, P2C, random, least-used, cost-optimized, strict-random, auto, lkgp, context-optimized, **context-relay**)
-- **Structured Combo Builder** — Build combos step-by-step with explicit provider + model + account selection, including repeated providers and fixed-account targets
-- **Quota-Aware P2C** — Power-of-two account selection now factors quota headroom, backoff, recent errors, and consecutive use
-- **Codex Business Quotas** — Business/Team workspace quota monitoring directly in the dashboard
-
-</details>
-
-<details>
-<summary><b>🔌 2. "I need to use multiple providers but each has a different API"</b></summary>
-
-OpenAI uses one format, Claude (Anthropic) uses another, Gemini yet another. If a dev wants to test models from different providers or fallback between them, they need to reconfigure SDKs, change endpoints, deal with incompatible formats. Custom providers (FriendLI, NIM) have non-standard model endpoints.
-
-**How OmniRoute solves it:**
-
-- **Unified Endpoint** — A single `http://localhost:20128/v1` serves as proxy for all 100+ providers
-- **Format Translation** — Automatic and transparent: OpenAI ↔ Claude ↔ Gemini ↔ Responses API
-- **Response Sanitization** — Strips non-standard fields (`x_groq`, `usage_breakdown`, `service_tier`) that break OpenAI SDK v1.83+
-- **Role Normalization** — Converts `developer` → `system` for non-OpenAI providers; `system` → `user` for GLM/ERNIE
-- **Think Tag Extraction** — Extracts `<think>` blocks from models like DeepSeek R1 into standardized `reasoning_content`
-- **Structured Output for Gemini** — `json_schema` → `responseMimeType`/`responseSchema` automatic conversion
-- **`stream` defaults to `false`** — Aligns with OpenAI spec, avoiding unexpected SSE in Python/Rust/Go SDKs
-
-</details>
-
-<details>
-<summary><b>🌐 3. "My AI provider blocks my region/country"</b></summary>
-
-Providers like OpenAI/Codex block access from certain geographic regions. Users get errors like `unsupported_country_region_territory` during OAuth and API connections. This is especially frustrating for developers from developing countries.
-
-**How OmniRoute solves it:**
-
-- **3-Level Proxy Config** — Configurable proxy at 3 levels: global (all traffic), per-provider (one provider only), and per-connection/key
-- **Color-Coded Proxy Badges** — Visual indicators: 🟢 global proxy, 🟡 provider proxy, 🔵 connection proxy, always showing the IP
-- **OAuth Token Exchange Through Proxy** — OAuth flow also goes through the proxy, solving `unsupported_country_region_territory`
-- **Connection Tests via Proxy** — Connection tests use the configured proxy (no more direct bypass)
-- **SOCKS5 Support** — Full SOCKS5 proxy support for outbound routing
-- **TLS Fingerprint Spoofing** — Browser-like TLS fingerprint via `wreq-js` to bypass bot detection
-- **🔏 CLI Fingerprint Matching** — Reorders headers and body fields to match native CLI binary signatures, drastically reducing account flagging risk. The proxy IP is preserved — you get both stealth **and** IP masking simultaneously
-
-</details>
-
-<details>
-<summary><b>🆓 4. "I want to use AI for coding but I have no money"</b></summary>
-
-Not everyone can pay $20–200/month for AI subscriptions. Students, devs from emerging countries, hobbyists, and freelancers need access to quality models at zero cost.
-
-**How OmniRoute solves it:**
-
-- **Free Tier Providers Built-in** — Native support for 100% free providers: Qoder (5 unlimited models via OAuth: kimi-k2-thinking, qwen3-coder-plus, deepseek-r1, minimax-m2, kimi-k2), Qwen (4 unlimited models: qwen3-coder-plus, qwen3-coder-flash, qwen3-coder-next, vision-model), Kiro (Claude + AWS Builder ID for free), Gemini CLI (180K tokens/month free)
-- **Ollama Cloud** — Cloud-hosted Ollama models at `api.ollama.com` with free "Light usage" tier; use `ollamacloud/<model>` prefix
-- **Free-Only Combos** — Chain `gc/gemini-3-flash → if/kimi-k2-thinking → qw/qwen3-coder-plus` = $0/month with zero downtime
-- **NVIDIA NIM Free Access** — ~40 RPM dev-forever free access to 70+ models at build.nvidia.com (transitioning from credits to pure rate limits)
-- **Cost Optimized Strategy** — Routing strategy that automatically chooses the cheapest available provider
-
-</details>
-
-<details>
-<summary><b>🔒 5. "I need to protect my AI gateway from unauthorized access"</b></summary>
-
-When exposing an AI gateway to the network (LAN, VPS, Docker), anyone with the address can consume the developer's tokens/quota. Without protection, APIs are vulnerable to misuse, prompt injection, and abuse.
-
-**How OmniRoute solves it:**
-
-- **API Key Management** — Generation, rotation, and scoping per provider with a dedicated `/dashboard/api-manager` page
-- **Model-Level Permissions** — Restrict API keys to specific models (`openai/*`, wildcard patterns), with Allow All/Restrict toggle
-- **API Endpoint Protection** — Require a key for `/v1/models` and block specific providers from the listing
-- **Auth Guard + CSRF Protection** — All dashboard routes protected with `withAuth` middleware + CSRF tokens
-- **Rate Limiter** — Per-IP rate limiting with configurable windows
-- **IP Filtering** — Allowlist/blocklist for access control
-- **Prompt Injection Guard** — Sanitization against malicious prompt patterns
-- **AES-256-GCM Encryption** — Credentials encrypted at rest
-
-</details>
-
-<details>
-<summary><b>🛑 6. "My provider went down and I lost my coding flow"</b></summary>
-
-AI providers can become unstable, return 5xx errors, or hit temporary rate limits. If a dev depends on a single provider, they're interrupted. Without circuit breakers, repeated retries can crash the application.
-
-**How OmniRoute solves it:**
-
-- **Request Queue & Pacing** — Per-connection request buckets smooth bursts before they hit upstream rate caps
-- **Connection Cooldown** — A single connection cools down after retryable failures with optional upstream `Retry-After` hints and exponential backoff
-- **Provider Circuit Breaker** — The provider only trips after fallback is exhausted and the provider request still fails with provider-wide transient errors; connection-scoped `429` rate limits stay in Connection Cooldown
-- **Wait For Cooldown** — The server can wait for the earliest connection cooldown to expire and retry the same client request automatically
-- **Anti-Thundering Herd** — Mutex + semaphore protection against concurrent retry storms
-- **Combo Fallback Chains** — If the primary provider fails, automatically falls through the chain with no intervention
-- **Health Dashboard** — Uptime monitoring, provider circuit breaker states, cooldowns, cache stats, p50/p95/p99 latency
-
-</details>
-
-<details>
-<summary><b>🔧 7. "Configuring each AI tool is tedious and repetitive"</b></summary>
-
-Developers use Cursor, Claude Code, Codex CLI, OpenClaw, Gemini CLI, Kilo Code... Each tool needs a different config (API endpoint, key, model). Reconfiguring when switching providers or models is a waste of time.
-
-**How OmniRoute solves it:**
-
-- **CLI Tools Dashboard** — Dedicated page with one-click setup for Claude Code, Codex CLI, OpenClaw, Kilo Code, Antigravity, Cline
-- **GitHub Copilot Config Generator** — Generates `chatLanguageModels.json` for VS Code with bulk model selection
-- **Onboarding Wizard** — Guided 4-step setup for first-time users
-- **One endpoint, all models** — Configure `http://localhost:20128/v1` once, access 100+ providers
-
-</details>
-
-<details>
-<summary><b>🔑 8. "Managing OAuth tokens from multiple providers is hell"</b></summary>
-
-Claude Code, Codex, Gemini CLI, Copilot — all use OAuth 2.0 with expiring tokens. Developers need to re-authenticate constantly, deal with `client_secret is missing`, `redirect_uri_mismatch`, and failures on remote servers. OAuth on LAN/VPS is particularly problematic.
-
-**How OmniRoute solves it:**
-
-- **Auto Token Refresh** — OAuth tokens refresh in background before expiration
-- **OAuth 2.0 (PKCE) Built-in** — Automatic flow for Claude Code, Codex, Gemini CLI, Copilot, Kiro, Qwen, Qoder
-- **Multi-Account OAuth** — Multiple accounts per provider via JWT/ID token extraction
-- **OAuth LAN/Remote Fix** — Private IP detection for `redirect_uri` + manual URL mode for remote servers
-- **OAuth Behind Nginx** — Uses `window.location.origin` for reverse proxy compatibility
-- **Remote OAuth Guide** — Step-by-step guide for Google Cloud credentials on VPS/Docker
-
-</details>
-
-<details>
-<summary><b>📊 9. "I don't know how much I'm spending or where"</b></summary>
-
-Developers use multiple paid providers but have no unified view of spending. Each provider has its own billing dashboard, but there's no consolidated view. Unexpected costs can pile up.
-
-**How OmniRoute solves it:**
-
-- **Cost Analytics Dashboard** — Per-token cost tracking and budget management per provider
-- **Budget Limits per Tier** — Spending ceiling per tier that triggers automatic fallback
-- **Per-Model Pricing Configuration** — Configurable prices per model
-- **Usage Statistics Per API Key** — Request count and last-used timestamp per key
-- **Analytics Dashboard** — Stat cards, model usage chart, provider table with success rates and latency
-
-</details>
-
-<details>
-<summary><b>🐛 10. "I can't diagnose errors and problems in AI calls"</b></summary>
-
-When a call fails, the dev doesn't know if it was a rate limit, expired token, wrong format, or provider error. Fragmented logs across different terminals. Without observability, debugging is trial-and-error.
-
-**How OmniRoute solves it:**
-
-- **Unified Logs Dashboard** — 4 tabs: Request Logs, Proxy Logs, Audit Logs, Console
-- **Console Log Viewer** — Real-time terminal-style viewer with color-coded levels, auto-scroll, search, filter
-- **SQLite Summary Logs** — Request and proxy log indexes stay queryable across restarts without loading large payload blobs into SQLite
-- **Translator Playground** — 4 debugging modes: Playground (format translation), Chat Tester (round-trip), Test Bench (batch), Live Monitor (real-time)
-- **Request Telemetry** — p50/p95/p99 latency + X-Request-Id tracing
-- **File-Based Detail Artifacts** — App logs rotate by size, retention days, and archive count; detailed request/response payloads live in `DATA_DIR/call_logs/` and rotate independently of SQLite summaries
-- **System Info Report** — `npm run system-info` generates `system-info.txt` with your full environment (Node version, OmniRoute version, OS, CLI tools, Docker/PM2 status). Attach it when reporting issues for instant triage.
-
-</details>
-
-<details>
-<summary><b>🏗️ 11. "Deploying and maintaining the gateway is complex"</b></summary>
-
-Installing, configuring, and maintaining an AI proxy across different environments (local, VPS, Docker, cloud) is labor-intensive. Problems like hardcoded paths, `EACCES` on directories, port conflicts, and cross-platform builds add friction.
-
-**How OmniRoute solves it:**
-
-- **npm global install** — `npm install -g omniroute && omniroute` — done
-- **Docker Multi-Platform** — AMD64 + ARM64 native (Apple Silicon, AWS Graviton, Raspberry Pi)
-- **Docker Compose Profiles** — `base` (no CLI tools) and `cli` (with Claude Code, Codex, OpenClaw)
-- **Electron Desktop App** — Native app for Windows/macOS/Linux with system tray, auto-start, offline mode
-- **Split-Port Mode** — API and Dashboard on separate ports for advanced scenarios (reverse proxy, container networking)
-- **Cloud Sync** — Config synchronization across devices via Cloudflare Workers
-- **DB Backups** — Automatic backup, restore, export and import of all settings, with `DISABLE_SQLITE_AUTO_BACKUP` for externally managed backups
-
-</details>
-
-<details>
-<summary><b>🌍 12. "The interface is English-only and my team doesn't speak English"</b></summary>
-
-Teams in non-English-speaking countries, especially in Latin America, Asia, and Europe, struggle with English-only interfaces. Language barriers reduce adoption and increase configuration errors.
-
-**How OmniRoute solves it:**
-
-- **Dashboard i18n — 30 Languages** — All 500+ keys translated including Arabic, Bulgarian, Danish, German, Spanish, Finnish, French, Hebrew, Hindi, Hungarian, Indonesian, Italian, Japanese, Korean, Malay, Dutch, Norwegian, Polish, Portuguese (PT/BR), Romanian, Russian, Slovak, Swedish, Thai, Ukrainian, Vietnamese, Chinese, Filipino, English
-- **RTL Support** — Right-to-left support for Arabic and Hebrew
-- **Multi-Language READMEs** — 30 complete documentation translations
-- **Language Selector** — Globe icon in header for real-time switching
-
-</details>
-
-<details>
-<summary><b>🔄 13. "I need more than chat — I need embeddings, images, audio"</b></summary>
-
-AI isn't just chat completion. Devs need to generate images, transcribe audio, create embeddings for RAG, rerank documents, and moderate content. Each API has a different endpoint and format.
-
-**How OmniRoute solves it:**
-
-- **Embeddings** — `/v1/embeddings` with 6 providers and 9+ models
-- **Image Generation** — `/v1/images/generations` with 10 providers and 20+ models (OpenAI, xAI, Together, Fireworks, Nebius, Hyperbolic, NanoBanana, Antigravity, SD WebUI, ComfyUI)
-- **Text-to-Video** — `/v1/videos/generations` — ComfyUI (AnimateDiff, SVD) and SD WebUI
-- **Text-to-Music** — `/v1/music/generations` — ComfyUI (Stable Audio Open, MusicGen)
-- **Audio Transcription** — `/v1/audio/transcriptions` — Whisper + Nvidia NIM, HuggingFace, Qwen3
-- **Text-to-Speech** — `/v1/audio/speech` — ElevenLabs, Nvidia NIM, HuggingFace, Coqui, Tortoise, Qwen3, **Inworld**, **Cartesia**, **PlayHT**, + existing providers
-- **Moderations** — `/v1/moderations` — Content safety checks
-- **Reranking** — `/v1/rerank` — Document relevance reranking
-- **Responses API** — Full `/v1/responses` support for Codex
-
-</details>
-
-<details>
-<summary><b>🧪 14. "I have no way to test and compare quality across models"</b></summary>
-
-Developers want to know which model is best for their use case — code, translation, reasoning — but comparing manually is slow. No integrated eval tools exist.
-
-**How OmniRoute solves it:**
-
-- **LLM Evaluations** — Golden set testing with 10 pre-loaded cases covering greetings, math, geography, code generation, JSON compliance, translation, markdown, safety refusal
-- **4 Match Strategies** — `exact`, `contains`, `regex`, `custom` (JS function)
-- **Translator Playground Test Bench** — Batch testing with multiple inputs and expected outputs, cross-provider comparison
-- **Chat Tester** — Full round-trip with visual response rendering
-- **Live Monitor** — Real-time stream of all requests flowing through the proxy
-
-</details>
-
-<details>
-<summary><b>📈 15. "I need to scale without losing performance"</b></summary>
-
-As request volume grows, without caching the same questions generate duplicate costs. Without idempotency, duplicate requests waste processing. Per-provider rate limits must be respected.
-
-**How OmniRoute solves it:**
-
-- **Semantic Cache** — Two-tier cache (signature + semantic) reduces cost and latency
-- **Request Idempotency** — 5s deduplication window for identical requests
-- **Rate Limit Detection** — Per-provider RPM, min gap, and max concurrent tracking
-- **Request Queue & Pacing** — Configurable queue, pacing, and concurrency defaults in Settings → Resilience
-- **API Key Validation Cache** — 3-tier cache for production performance
-- **Health Dashboard with Telemetry** — p50/p95/p99 latency, cache stats, uptime
-
-</details>
-
-<details>
-<summary><b>🤖 16. "I want to control model behavior globally"</b></summary>
-
-Developers who want all responses in a specific language, with a specific tone, or want to limit reasoning tokens. Configuring this in every tool/request is impractical.
-
-**How OmniRoute solves it:**
-
-- **System Prompt Injection** — Global prompt applied to all requests
-- **Thinking Budget Validation** — Reasoning token allocation control per request (passthrough, auto, custom, adaptive)
-- **9 Routing Strategies** — Global strategies that determine how requests are distributed
-- **Wildcard Router** — `provider/*` patterns route dynamically to any provider
-- **Combo Enable/Disable Toggle** — Toggle combos directly from the dashboard
-- **Manual Combo Ordering** — Drag combo cards by handle and persist the order in SQLite
-- **Provider Toggle** — Enable/disable all connections for a provider with one click
-- **Blocked Providers** — Exclude specific providers from `/v1/models` listing
-
-</details>
-
-<details>
-<summary><b>🧰 17. "I need MCP tools as first-class product capabilities"</b></summary>
-
-Many AI gateways expose MCP only as a hidden implementation detail. Teams need a visible, manageable operation layer.
-
-**How OmniRoute solves it:**
-
-- MCP appears in the dashboard navigation and endpoint protocol tab
-- Dedicated MCP management page with process, tools, scopes, and audit
-- Built-in quick-start for `omniroute --mcp` and client onboarding
-
-</details>
-
-<details>
-<summary><b>🧠 18. "I need A2A orchestration with sync + stream task paths"</b></summary>
-
-Agent workflows need both direct replies and long-running streamed execution with lifecycle control.
-
-**How OmniRoute solves it:**
-
-- A2A JSON-RPC endpoint (`POST /a2a`) with `message/send` and `message/stream`
-- SSE streaming with terminal state propagation
-- Task lifecycle APIs for `tasks/get` and `tasks/cancel`
-
-</details>
-
-<details>
-<summary><b>🛰️ 19. "I need real MCP process health, not guessed status"</b></summary>
-
-Operational teams need to know if MCP is actually alive, not just whether an API is reachable.
-
-**How OmniRoute solves it:**
-
-- Runtime heartbeat file with PID, timestamps, transport, tool count, and scope mode
-- MCP status API combining heartbeat + recent activity
-- UI status cards for process/uptime/heartbeat freshness
-
-</details>
-
-<details>
-<summary><b>📋 20. "I need auditable MCP tool execution"</b></summary>
-
-When tools mutate config or trigger ops actions, teams need forensic traceability.
-
-**How OmniRoute solves it:**
-
-- SQLite-backed audit logging for MCP tool calls
-- Filters by tool, success/failure, API key, and pagination
-- Dashboard audit table + stats endpoints for automation
-
-</details>
-
-<details>
-<summary><b>🔐 21. "I need scoped MCP permissions per integration"</b></summary>
-
-Different clients should have least-privilege access to tool categories.
-
-**How OmniRoute solves it:**
-
-- 10 granular MCP scopes for controlled tool access
-- Scope enforcement and visibility in MCP management UI
-- Safe default posture for operational tooling
-
-</details>
-
-<details>
-<summary><b>⚙️ 22. "I need operational controls without redeploying"</b></summary>
-
-Teams need quick runtime changes during incidents or cost events.
-
-**How OmniRoute solves it:**
-
-- Switch combo activation directly from MCP dashboard
-- Tune queue, cooldown, breaker, and wait settings from the dedicated Resilience page
-- Review live provider breaker state from the Health dashboard
-
-</details>
-
-<details>
-<summary><b>🔄 23. "I need live A2A task lifecycle visibility and cancellation"</b></summary>
-
-Without lifecycle visibility, task incidents become hard to triage.
-
-**How OmniRoute solves it:**
-
-- Task listing/filtering by state/skill with pagination
-- Drill-down on task metadata, events, and artifacts
-- Task cancellation endpoint and UI action with confirmation
-
-</details>
-
-<details>
-<summary><b>🌊 24. "I need active stream metrics for A2A load"</b></summary>
-
-Streaming workflows require operational insight into concurrency and live connections.
-
-**How OmniRoute solves it:**
-
-- Active stream counters integrated into A2A status
-- Last task timestamp and per-state counts
-- A2A dashboard cards for real-time ops monitoring
-
-</details>
-
-<details>
-<summary><b>🪪 25. "I need standard agent discovery for clients"</b></summary>
-
-External clients and orchestrators need machine-readable metadata for onboarding.
-
-**How OmniRoute solves it:**
-
-- Agent Card exposed at `/.well-known/agent.json`
-- Capabilities and skills shown in management UI
-- A2A status API includes discovery metadata for automation
-
-</details>
-
-<details>
-<summary><b>🧭 26. "I need protocol discoverability in the product UX"</b></summary>
-
-If users cannot discover protocol surfaces, adoption and support quality drop.
-
-**How OmniRoute solves it:**
-
-- Consolidated **Endpoints** page with tabs for Proxy, MCP, A2A, and API Endpoints
-- Inline service status toggles (Online/Offline) for MCP and A2A
-- Links from overview to dedicated management tabs
-
-</details>
-
-<details>
-<summary><b>🧪 27. "I need end-to-end protocol validation with real clients"</b></summary>
-
-Mock tests are not enough to validate protocol compatibility before release.
-
-**How OmniRoute solves it:**
-
-- E2E suite that boots app and uses real MCP SDK client transport
-- A2A client tests for discovery, send, stream, get, and cancel flows
-- Cross-check assertions against MCP audit and A2A tasks APIs
-
-</details>
-
-<details>
-<summary><b>📡 28. "I need unified observability across all interfaces"</b></summary>
-
-Splitting observability by protocol creates blind spots and longer MTTR.
-
-**How OmniRoute solves it:**
-
-- Unified dashboards/logs/analytics in one product
-- Health + audit + request telemetry across OpenAI, MCP, and A2A layers
-- Operational APIs for status and automation
-
-</details>
-
-<details>
-<summary><b>💼 29. "I need one runtime for proxy + tools + agent orchestration"</b></summary>
-
-Running many separate services increases operational cost and failure modes.
-
-**How OmniRoute solves it:**
-
-- OpenAI-compatible proxy, MCP server, and A2A server in one stack
-- Shared auth, resilience, data store, and observability
-- Consistent policy model across all interaction surfaces
-
-</details>
-
-<details>
-<summary><b>🚀 30. "I need to ship agentic workflows without glue-code sprawl"</b></summary>
-
-Teams lose velocity when stitching multiple ad-hoc services and scripts.
-
-**How OmniRoute solves it:**
-
-- Unified endpoint strategy for clients and agents
-- Built-in protocol management UIs and smoke validation paths
-- Production-ready foundations (security, logging, resilience, backup)
-
-</details>
-
-<details>
-<summary><b>📚 31. "My long sessions crash with 'context_length_exceeded' limits"</b></summary>
-
-During deep debugging, long histories with tool results quickly exceed provider token windows, causing failed requests and orphaned context.
-
-**How OmniRoute solves it:**
-
-- **Proactive Context Compression** — Evaluates token budgets before the request hits upstream and proactively prunes old conversation history with a smart binary-search mechanism.
-- **Structural Integrity Guards** — Automatically tracks explicit `tool_use` definitions and ensures that if a tool input is truncated, its corresponding `tool_result` is also safely removed, preventing API validation errors.
-- **Multi-Layer Dropping** — Progressively drops system messages, regular messages, and finally enforces strict length limits without breaking conversational logic.
-
-</details>
-
-### Example Playbooks (Integrated Use Cases)
-
-**Playbook A: Maximize paid subscription + cheap backup**
-
-```txt
-Combo: "maximize-claude"
-  1. cc/claude-opus-4-7
-  2. glm/glm-4.7
-  3. if/kimi-k2-thinking
-
-Monthly cost: $20 + small backup spend
-Outcome: higher quality, near-zero interruption
-```
-
-**Playbook B: Zero-cost coding stack**
-
-```txt
-Combo: "free-forever"
-  1. gc/gemini-3-flash
-  2. if/kimi-k2-thinking
-  3. qw/qwen3-coder-plus
-
-Monthly cost: $0
-Outcome: stable free coding workflow
-```
-
-**Playbook C: 24/7 always-on fallback chain**
-
-```txt
-Combo: "always-on"
-  1. cc/claude-opus-4-7
-  2. cx/gpt-5.2-codex
-  3. glm/glm-4.7
-  4. minimax/MiniMax-M2.1
-  5. if/kimi-k2-thinking
-
-Outcome: deep fallback depth for deadline-critical workloads
-```
-
-**Playbook D: Agent ops with MCP + A2A**
-
-```txt
-1) Start MCP transport (`omniroute --mcp`) for tool-driven operations
-2) Run A2A tasks via `message/send` and `message/stream`
-3) Observe via /dashboard/endpoint (MCP and A2A tabs)
-4) Toggle services via inline status controls
-```
-
----
-
-## 🆓 Start Free — Zero Configuration Cost
-
-> Setup AI coding in minutes at **$0/month**. Connect these free accounts and use the built-in **Free Stack** combo.
-
-| Step | Action                                             | Providers Unlocked                                                 |
-| ---- | -------------------------------------------------- | ------------------------------------------------------------------ |
-| 1    | Connect **Kiro** (AWS Builder ID OAuth)            | Claude Sonnet 4.5, Haiku 4.5 — **unlimited**                       |
-| 2    | Connect **Qoder** (Google OAuth)                   | kimi-k2-thinking, qwen3-coder-plus, deepseek-r1... — **unlimited** |
-| 3    | Connect **Qwen** (Device Code)                     | qwen3-coder-plus, qwen3-coder-flash... — **unlimited**             |
-| 4    | Connect **Gemini CLI** (Google OAuth)              | gemini-3-flash, gemini-2.5-pro — **180K/mo free**                  |
-| 5    | `/dashboard/combos` → **Free Stack ($0)** template | Round-robin all free providers automatically                       |
-
-**Point any IDE/CLI to:** `http://localhost:20128/v1` · API Key: `any-string` · Done.
-
-> **Optional extra coverage (also free):** Groq API key (30 RPM free), NVIDIA NIM (40 RPM free, 70+ models), Cerebras (1M tok/day), LongCat API key (50M tokens/day!), Cloudflare Workers AI (10K Neurons/day, 50+ models).
-
-## 快速开始
-
-### 1) Install and run
+### 🤝 连接代理 — 代理自行控制 OmniRoute
+
+| 协议 | 端点 | 用途 |
+|---|---|---|
+| 🧰 **MCP（stdio）** | `omniroute --mcp` | 接入 Claude Desktop、Cursor 等 MCP 客户端 |
+| 🌊 **MCP（HTTP）** | `http://localhost:20128/api/mcp/stream` | 远程 MCP — **87 个工具** |
+| 📡 **MCP（SSE）** | `http://localhost:20128/api/mcp/sse` | 流式 MCP 传输 |
+| 🤝 **A2A** | `http://localhost:20128/.well-known/agent.json` | 代理间通信，JSON-RPC 2.0 |
+
+# 🗜️ 自动节省 15–95% 的 Token
+
+> **为什么用很多 Token 而不用少量 Token？** 每个请求**透明地**通过 OmniRoute 的压缩流水线 — 无需更改客户端。
+
+### 🧱 9 引擎堆栈
+
+| # | 引擎 | 作用 |
+|---|---|---|
+| 1 | **Session-Dedup** | 删除跨轮次重复的内容 |
+| 2 | **CCR** | 将大块内容归档到检索标记后，按需获取 |
+| 3 | **RTK** | 智能工具结果过滤、去重和截断 |
+| 4 | **Headroom** | 同构 JSON 数组的无损表格压缩（~30%+） |
+| 5 | **Caveman** | 基于规则的文章压缩（~65–75%） |
+| 6 | **LLMLingua-2** | 通过 MobileBERT ONNX 进行 ML 语义剪枝 |
+| 7 | **Lite** | 空白字符和图片 URL 修剪 |
+| 8 | **Aggressive** | 摘要 + 逐步淘汰旧轮次 |
+| 9 | **Ultra** | 启发式 Token 剪枝 + 可选小模型层 |
+
+### 🎛️ 一键预设
+
+| 模式 | 节省比例 | 最佳用途 |
+|---|---|---|
+| 🪶 **Lite** | ~15% | 始终开启的安全默认 |
+| 🪨 **Standard（Caveman）** | ~30% | 日常编码 |
+| ⚡ **Aggressive** | ~50% | 长时间工具密集型会话 |
+| 🔥 **Ultra** | ~75% | 最大节省 |
+| 🧰 **RTK** | 60–90% | Shell/测试/构建/Git 输出 |
+| 🔗 **堆叠（RTK → Caveman）** | **78–95%** | 混合提示 + 工具日志 |
+
+# ⚡ 快速开始
+
+**1) 安装并运行**
 
 ```bash
 npm install -g omniroute
 omniroute
 ```
 
-> **pnpm users:** Run `pnpm approve-builds -g` after install to enable native build scripts required by `better-sqlite3` and `@swc/core`:
->
-> ```bash
-> pnpm install -g omniroute
-> pnpm approve-builds -g   # Select all packages → approve
-> omniroute
-> ```
+仪表板：`http://localhost:20128` · API：`http://localhost:20128/v1`
 
-Dashboard opens at `http://localhost:20128` and API base URL is `http://localhost:20128/v1`.
+**2) 连接免费供应商（无需注册）**
 
-#### Arch Linux (AUR)
+仪表板 → **Providers** → 连接 **Kiro AI** 或 **OpenCode Free** → 完成。
 
-Arch Linux users can install the [AUR package](https://aur.archlinux.org/packages/omniroute-bin), which installs OmniRoute and provides a systemd user service:
-
-```bash
-yay -S omniroute-bin
-systemctl --user enable --now omniroute.service
-```
-
-| Command                 | Description                                                 |
-| ----------------------- | ----------------------------------------------------------- |
-| `omniroute`             | Start server (`PORT=20128`, API and dashboard on same port) |
-| `omniroute --port 3000` | Set canonical/API port to 3000                              |
-| `omniroute --mcp`       | Start MCP server (stdio transport)                          |
-| `omniroute --no-open`   | Don't auto-open browser                                     |
-| `omniroute --help`      | Show help                                                   |
-
-Optional split-port mode:
-
-```bash
-PORT=20128 DASHBOARD_PORT=20129 omniroute
-# API:       http://localhost:20128/v1
-# Dashboard: http://localhost:20129
-```
-
-### 2) Uninstalling
-
-When you no longer need OmniRoute, we provide two quick scripts for a clean removal:
-
-| Command                  | Action                                                                              |
-| ------------------------ | ----------------------------------------------------------------------------------- |
-| `npm run uninstall`      | Removes the system app but **keeps your DB and configurations** in `~/.omniroute`.  |
-| `npm run uninstall:full` | Removes the app AND permanently **erases all configurations, keys, and databases**. |
-
-> Note: To run these commands, navigate to the OmniRoute project folder (if you cloned it) and run them. Alternatively, if globally installed, you can simply run `npm uninstall -g omniroute`.
-
-### Long-Running Streaming Timeouts
-
-For most deployments, you only need:
-
-| Variable                 | Default                       | Purpose                                                                                                                                      |
-| ------------------------ | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| `REQUEST_TIMEOUT_MS`     | `600000`                      | Shared baseline for upstream response-start timeout, hidden Undici timeouts, TLS fingerprint requests, and API bridge request/proxy timeouts |
-| `STREAM_IDLE_TIMEOUT_MS` | inherits `REQUEST_TIMEOUT_MS` | Maximum gap between streaming chunks before OmniRoute aborts the SSE stream                                                                  |
-
-Backward compatibility is preserved: existing `FETCH_TIMEOUT_MS`, `API_BRIDGE_PROXY_TIMEOUT_MS`, and other per-layer timeout vars still work and override the shared baseline.
-
-For Claude Code-compatible upstreams (`anthropic-compatible-cc-*`), OmniRoute also derives the outbound `X-Stainless-Timeout` header from the resolved fetch timeout so provider-side read timeouts stay aligned with your env configuration.
-
-For third-party Claude Code-compatible reverse proxies, OmniRoute keeps the default
-`anthropic-beta` set conservative and, when `Client Cache Control` is left on `Auto`,
-only forwards client-provided `cache_control` markers. If the request does not include
-`cache_control`, OmniRoute does not inject bridge-owned markers.
-
-Advanced overrides are available if you need finer control:
-
-| Variable                                 | Default                                    | Purpose                                                              |
-| ---------------------------------------- | ------------------------------------------ | -------------------------------------------------------------------- |
-| `FETCH_TIMEOUT_MS`                       | inherits `REQUEST_TIMEOUT_MS`              | Upstream response-start timeout used until response headers arrive   |
-| `FETCH_HEADERS_TIMEOUT_MS`               | inherits `FETCH_TIMEOUT_MS`                | Undici time limit for receiving upstream response headers            |
-| `FETCH_BODY_TIMEOUT_MS`                  | inherits `FETCH_TIMEOUT_MS`                | Undici time limit between upstream body chunks (`0` disables it)     |
-| `FETCH_CONNECT_TIMEOUT_MS`               | `30000`                                    | Undici TCP connect timeout                                           |
-| `FETCH_KEEPALIVE_TIMEOUT_MS`             | `4000`                                     | Undici idle keep-alive socket timeout                                |
-| `TLS_CLIENT_TIMEOUT_MS`                  | inherits `FETCH_TIMEOUT_MS`                | Timeout for TLS fingerprint requests made through `wreq-js`          |
-| `API_BRIDGE_PROXY_TIMEOUT_MS`            | inherits `REQUEST_TIMEOUT_MS` or `600000`  | Timeout for `/v1` proxy forwarding from API port to dashboard port   |
-| `API_BRIDGE_SERVER_REQUEST_TIMEOUT_MS`   | `max(API_BRIDGE_PROXY_TIMEOUT_MS, 300000)` | Incoming request timeout on the API bridge server                    |
-| `API_BRIDGE_SERVER_HEADERS_TIMEOUT_MS`   | `60000`                                    | Incoming header timeout on the API bridge server                     |
-| `API_BRIDGE_SERVER_KEEPALIVE_TIMEOUT_MS` | `5000`                                     | Keep-alive timeout on the API bridge server                          |
-| `API_BRIDGE_SERVER_SOCKET_TIMEOUT_MS`    | `0`                                        | Socket inactivity timeout on the API bridge server (`0` disables it) |
-
-For streaming requests, `FETCH_TIMEOUT_MS` only covers connection setup / waiting for the first upstream response. Once the stream is active, OmniRoute will only abort on an actual stall (`STREAM_IDLE_TIMEOUT_MS`) or Undici body inactivity (`FETCH_BODY_TIMEOUT_MS`).
-
-If you run OmniRoute behind Nginx, Caddy, Cloudflare, or another reverse proxy, make sure the proxy
-timeouts are also higher than your OmniRoute stream/fetch timeouts.
-
-### 2) Connect providers and create your API key
-
-1. Open Dashboard → `Providers` and connect at least one provider (OAuth or API key).
-2. Open Dashboard → `Endpoints` and create an API key.
-3. (Optional) Open Dashboard → `Combos` and set your fallback chain.
-
-### 3) Point your coding tool to OmniRoute
+**3) 配置您的编码工具**
 
 ```txt
 Base URL: http://localhost:20128/v1
-API Key:  [copy from Endpoint page]
-Model:    if/kimi-k2-thinking (or any provider/model prefix)
+API Key:  [从仪表板 → Endpoints 复制]
+Model:    auto
 ```
 
-Works with Claude Code, Codex CLI, Gemini CLI, Cursor, Cline, OpenClaw, OpenCode, and OpenAI-compatible SDKs.
-
-### 4) Enable and validate protocols (v2.0)
-
-**MCP (for tool-driven operations):**
+**4) 验证是否正常工作**
 
 ```bash
-omniroute --mcp
+curl http://localhost:20128/v1/models -H "Authorization: Bearer ***"
 ```
 
-Then connect your MCP client over `stdio` and test tools like:
+### 📦 更多安装方式
 
-- `omniroute_get_health`
-- `omniroute_list_combos`
-
-**A2A (for agent-to-agent workflows):**
-
+**🐳 Docker**
 ```bash
-curl http://localhost:20128/.well-known/agent.json
+docker run -d --name omniroute --restart unless-stopped -p 20128:20128 -v omniroute-data:/app/data diegosouzapw/omniroute:latest
 ```
 
+**🛠️ 从源码构建**
 ```bash
-curl -X POST http://localhost:20128/a2a \
-  -H 'content-type: application/json' \
-  -d '{"jsonrpc":"2.0","id":"quickstart","method":"message/send","params":{"skill":"quota-management","messages":[{"role":"user","content":"Give me a short quota summary."}]}}'
+cp .env.example .env && npm install
+PORT=20128 npm run dev
 ```
 
-### 5) Validate everything end-to-end (recommended)
-
+**📦 pnpm**
 ```bash
-npm run test:protocols:e2e
+pnpm install -g omniroute && pnpm approve-builds -g && omniroute
 ```
 
-This suite validates real MCP and A2A client flows against a running app.
-
-### Alternative: run from source
-
+**🐧 Arch Linux（AUR）**
 ```bash
-cp .env.example .env
-npm install
-PORT=20128 DASHBOARD_PORT=20129 NEXT_PUBLIC_BASE_URL=http://localhost:20129 npm run dev
+yay -S omniroute-bin && systemctl --user enable --now omniroute.service
 ```
+
+# 🎬 OmniRoute 实际演示
+
+视频：🇧🇷 Português · 🇺🇸 English · 🇷🇺 Русский
+
+# 📚 探索更多
 
 <details>
-<summary><b>Void Linux (`xbps-src` template)</b></summary>
-
-For Void Linux users, you can build a native package using `xbps-src`. Save this block as `srcpkgs/omniroute/template`:
-
-```bash
-# Template file for 'omniroute'
-pkgname=omniroute
-version=3.4.1
-revision=1
-hostmakedepends="nodejs python3 make"
-depends="openssl"
-short_desc="Universal AI gateway with smart routing for multiple LLM providers"
-maintainer="zenobit <zenobit@disroot.org>"
-license="MIT"
-homepage="https://github.com/diegosouzapw/OmniRoute"
-distfiles="https://github.com/diegosouzapw/OmniRoute/archive/refs/tags/v${version}.tar.gz"
-checksum=009400afee90a9f32599d8fe734145cfd84098140b7287990183dde45ae2245b
-system_accounts="_omniroute"
-omniroute_homedir="/var/lib/omniroute"
-export NODE_ENV=production
-export npm_config_engine_strict=false
-export npm_config_loglevel=error
-export npm_config_fund=false
-export npm_config_audit=false
-
-do_build() {
-	# Determine target CPU arch for node-gyp
-	local _gyp_arch
-	case "$XBPS_TARGET_MACHINE" in
-		aarch64*) _gyp_arch=arm64 ;;
-		armv7*|armv6*) _gyp_arch=arm ;;
-		i686*) _gyp_arch=ia32 ;;
-		*) _gyp_arch=x64 ;;
-	esac
-
-	# 1) Install all deps – skip scripts (no network in do_build, native modules
-	#    compiled separately below; better-sqlite3 is serverExternalPackage so
-	#    Next.js does not execute it during next build)
-	NODE_ENV=development npm ci --ignore-scripts
-
-	# 2) Build the Next.js standalone bundle
-	npm run build
-
-	# 3) Copy static assets into standalone
-	cp -r .next/static .next/standalone/.next/static
-	[ -d public ] && cp -r public .next/standalone/public || true
-
-	# 4) Compile better-sqlite3 native binding for the target architecture.
-	#    Use node-gyp directly so CC/CXX from xbps-src cross-toolchain are used
-	#    without npm altering them.
-	local _node_gyp=/usr/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js
-	(cd node_modules/better-sqlite3 && node "$_node_gyp" rebuild --arch="$_gyp_arch")
-
-	# 5) Place the compiled binding into the standalone bundle
-	local _bs3_release=.next/standalone/node_modules/better-sqlite3/build/Release
-	mkdir -p "$_bs3_release"
-	cp node_modules/better-sqlite3/build/Release/better_sqlite3.node "$_bs3_release/"
-
-	# 6) Remove arch-specific sharp bundles – upstream sets images.unoptimized=true
-	#    so sharp is not used at runtime; x64 .so files would break aarch64 strip
-	rm -rf .next/standalone/node_modules/@img
-
-	# 7) Copy pino runtime deps omitted by Next.js static analysis:
-	#    pino-abstract-transport – required by pino's worker thread
-	#    split2 – dep of pino-abstract-transport
-	#    process-warning – dep of pino itself
-	for _mod in pino-abstract-transport split2 process-warning; do
-		cp -r "node_modules/$_mod" .next/standalone/node_modules/
-	done
-}
-
-do_check() {
-	npm run test:unit
-}
-
-do_install() {
-	vmkdir usr/lib/omniroute/.next
-
-	vcopy .next/standalone/. usr/lib/omniroute/.next/standalone
-
-	# Prevent removal of empty Next.js app router dirs by the post-install hook
-	for _d in \
-		.next/standalone/.next/server/app/dashboard \
-		.next/standalone/.next/server/app/dashboard/settings \
-		.next/standalone/.next/server/app/dashboard/providers; do
-		touch "${DESTDIR}/usr/lib/omniroute/${_d}/.keep"
-	done
-
-	cat > "${WRKDIR}/omniroute" <<'EOF'
-#!/bin/sh
-export PORT="${PORT:-20128}"
-export DATA_DIR="${DATA_DIR:-${XDG_DATA_HOME:-${HOME}/.local/share}/omniroute}"
-export APP_LOG_TO_FILE="${APP_LOG_TO_FILE:-false}"
-mkdir -p "${DATA_DIR}"
-exec node /usr/lib/omniroute/.next/standalone/server.js "$@"
-EOF
-	vbin "${WRKDIR}/omniroute"
-}
-
-post_install() {
-	vlicense LICENSE
-}
-```
-
-</details>
-
----
-
-## 🐳 Docker
-
-OmniRoute is available as a public Docker image on [Docker Hub](https://hub.docker.com/r/diegosouzapw/omniroute).
-
-**Quick run:**
-
-```bash
-docker run -d \
-  --name omniroute \
-  --restart unless-stopped \
-  --stop-timeout 40 \
-  -p 20128:20128 \
-  -v omniroute-data:/app/data \
-  diegosouzapw/omniroute:latest
-```
-
-**With environment file:**
-
-```bash
-# Copy and edit .env first
-cp .env.example .env
-
-docker run -d \
-  --name omniroute \
-  --restart unless-stopped \
-  --stop-timeout 40 \
-  --env-file .env \
-  -p 20128:20128 \
-  -v omniroute-data:/app/data \
-  diegosouzapw/omniroute:latest
-```
-
-**Using Docker Compose:**
-
-```bash
-# Base profile (no CLI tools)
-docker compose --profile base up -d
-
-# CLI profile (Claude Code, Codex, OpenClaw built-in)
-docker compose --profile cli up -d
-```
-
-Dashboard support for Docker deployments now includes a one-click **Cloudflare Quick Tunnel** on `Dashboard → Endpoints`. The first enable downloads `cloudflared` only when needed, starts a temporary tunnel to your current `/v1` endpoint, and shows the generated `https://*.trycloudflare.com/v1` URL directly below your normal public URL.
-
-Notes:
-
-- Quick Tunnel URLs are temporary and change after every restart.
-- Quick Tunnels are not auto-restored after an OmniRoute or container restart. Re-enable them from the dashboard when needed.
-- Managed install currently supports Linux, macOS, and Windows on `x64` / `arm64`.
-- Managed Quick Tunnels default to HTTP/2 transport to avoid noisy QUIC UDP buffer warnings in constrained container environments. Set `CLOUDFLARED_PROTOCOL=quic` or `auto` if you want a different transport.
-- Docker images bundle system CA roots and pass them to managed `cloudflared`, which avoids TLS trust failures when the tunnel bootstraps inside the container.
-- SQLite runs in WAL mode. `docker stop` should be allowed to finish so OmniRoute can checkpoint the latest changes back into `storage.sqlite`.
-- The bundled Compose files already set a 40s stop grace period. If you run the image directly, keep `--stop-timeout 40` (or similar) so manual stops do not cut off shutdown cleanup.
-- Set `CLOUDFLARED_BIN=/absolute/path/to/cloudflared` if you want OmniRoute to use an existing binary instead of downloading one.
-
-**Using Docker Compose with Caddy (HTTPS Auto-TLS):**
-
-OmniRoute can be securely exposed using Caddy's automatic SSL provisioning. Ensure your domain's DNS A record points to your server's IP.
-
-```yaml
-services:
-  omniroute:
-    image: diegosouzapw/omniroute:latest
-    container_name: omniroute
-    restart: unless-stopped
-    volumes:
-      - omniroute-data:/app/data
-    environment:
-      - PORT=20128
-      - NEXT_PUBLIC_BASE_URL=https://your-domain.com
-
-  caddy:
-    image: caddy:latest
-    container_name: caddy
-    restart: unless-stopped
-    ports:
-      - "80:80"
-      - "443:443"
-    command: caddy reverse-proxy --from https://your-domain.com --to http://omniroute:20128
-
-volumes:
-  omniroute-data:
-```
-
-| Image                    | Tag      | Size   | Description           |
-| ------------------------ | -------- | ------ | --------------------- |
-| `diegosouzapw/omniroute` | `latest` | ~250MB | Latest stable release |
-| `diegosouzapw/omniroute` | `3.6.2`  | ~250MB | Current version       |
-
----
-
-## 🖥️ Desktop App — Offline & Always-On
-
-> 🆕 **NEW!** OmniRoute is now available as a **native desktop application** for Windows, macOS, and Linux.
-
-Run OmniRoute as a standalone desktop app — no terminal, no browser, no internet required for local models. The Electron-based app includes:
-
-- 🖥️ **Native Window** — Dedicated app window with system tray integration
-- 🔄 **Auto-Start** — Launch OmniRoute on system login
-- 🔔 **Native Notifications** — Get alerts for quota exhaustion or provider issues
-- ⚡ **One-Click Install** — NSIS (Windows), DMG (macOS), AppImage (Linux)
-- 🌐 **Offline Mode** — Works fully offline with bundled server
-
-### 快速开始
-
-```bash
-# Development mode
-npm run electron:dev
-
-# Build for your platform
-npm run electron:build         # Current platform
-npm run electron:build:win     # Windows (.exe)
-npm run electron:build:mac     # macOS (.dmg) — x64 & arm64
-npm run electron:build:linux   # Linux (.AppImage)
-```
-
-### System Tray
-
-When minimized, OmniRoute lives in your system tray with quick actions:
-
-- Open dashboard
-- Change server port
-- Quit application
-
-📖 Full documentation: [`electron/README.md`](electron/README.md)
-
----
-
-## 💰 Pricing at a Glance
-
-| Tier                | Provider                    | Cost                      | Quota Reset      | Best For                          |
-| ------------------- | --------------------------- | ------------------------- | ---------------- | --------------------------------- |
-| **💳 SUBSCRIPTION** | Claude Code (Pro)           | $20/mo                    | 5h + weekly      | Already subscribed                |
-|                     | Codex (Plus/Pro)            | $20-200/mo                | 5h + weekly      | OpenAI users                      |
-|                     | Gemini CLI                  | **FREE**                  | 180K/mo + 1K/day | Everyone!                         |
-|                     | GitHub Copilot              | $10-19/mo                 | Monthly          | GitHub users                      |
-| **🔑 API KEY**      | NVIDIA NIM                  | **FREE** (dev forever)    | ~40 RPM          | 70+ open models                   |
-|                     | Cerebras                    | **FREE** (1M tok/day)     | 60K TPM / 30 RPM | World's fastest                   |
-|                     | Groq                        | **FREE** (30 RPM)         | 14.4K RPD        | Ultra-fast Llama/Gemma            |
-|                     | DeepSeek V3.2               | $0.27/$1.10 per 1M        | None             | Best price/quality reasoning      |
-|                     | xAI Grok-4 Fast             | **$0.20/$0.50 per 1M** 🆕 | None             | Fastest + tool calling, ultralow  |
-|                     | xAI Grok-4 (standard)       | $0.20/$1.50 per 1M 🆕     | None             | Reasoning flagship from xAI       |
-|                     | Mistral                     | Free trial + paid         | Rate limited     | European AI                       |
-|                     | OpenRouter                  | Pay-per-use               | None             | 100+ models aggr.                 |
-| **💰 CHEAP**        | GLM-5 (via Z.AI) 🆕         | $0.5/1M                   | Daily 10AM       | 128K output, newest flagship      |
-|                     | GLM-4.7                     | $0.6/1M                   | Daily 10AM       | Budget backup                     |
-|                     | MiniMax M2.5 🆕             | $0.3/1M input             | 5-hour rolling   | Reasoning + agentic tasks         |
-|                     | MiniMax M2.1                | $0.2/1M                   | 5-hour rolling   | Cheapest option                   |
-|                     | Kimi K2.5 (Moonshot API) 🆕 | Pay-per-use               | None             | Direct Moonshot API access        |
-|                     | Kimi K2                     | $9/mo flat                | 10M tokens/mo    | Predictable cost                  |
-| **🆓 FREE**         | Qoder                       | **$0**                    | Unlimited        | 5 models unlimited                |
-|                     | Qwen                        | **$0**                    | Unlimited        | 4 models unlimited                |
-|                     | Kiro                        | **$0**                    | Unlimited        | Claude Sonnet/Haiku (AWS Builder) |
-|                     | LongCat Flash-Lite 🆕       | **$0** (50M tok/day 🔥)   | 1 RPS            | Largest free quota on Earth       |
-|                     | Pollinations AI 🆕          | **$0** (no key needed)    | 1 req/15s        | GPT-5, Claude, DeepSeek, Llama 4  |
-|                     | Cloudflare Workers AI 🆕    | **$0** (10K Neurons/day)  | ~150 resp/day    | 50+ models, global edge           |
-|                     | Scaleway AI 🆕              | **$0** (1M tokens total)  | Rate limited     | EU/GDPR, Qwen3 235B, Llama 70B    |
-
-> 🆕 **New models added (Mar 2026):** Grok-4 Fast family at $0.20/$0.50/M (benchmarked at 1143ms — 30% faster than Gemini 2.5 Flash), GLM-5 via Z.AI with 128K output, MiniMax M2.5 reasoning, DeepSeek V3.2 updated pricing, Kimi K2.5 via Moonshot direct API.
-
-**💡 $0 Combo Stack — The Complete Free Setup:**
-
-```
-# 🆓 Ultimate Free Stack 2026 — 11 Providers, $0 Forever
-Kiro (kr/)             → Claude Sonnet/Haiku UNLIMITED
-Qoder (if/)            → kimi-k2-thinking, qwen3-coder-plus, deepseek-r1 UNLIMITED
-LongCat Lite (lc/)     → LongCat-Flash-Lite — 50M tokens/day 🔥
-Pollinations (pol/)    → GPT-5, Claude, DeepSeek, Llama 4 — no key needed
-Qwen (qw/)             → qwen3-coder-plus, qwen3-coder-flash, qwen3-coder-next UNLIMITED
-Gemini (gemini/)       → Gemini 2.5 Flash — 1,500 req/day free API key
-Cloudflare AI (cf/)    → Llama 70B, Gemma 3, Mistral — 10K Neurons/day
-Scaleway (scw/)        → Qwen3 235B, Llama 70B — 1M free tokens (EU)
-Groq (groq/)           → Llama/Gemma ultra-fast — 14.4K req/day
-NVIDIA NIM (nvidia/)   → 70+ open models — 40 RPM forever
-Cerebras (cerebras/)   → Llama/Qwen world-fastest — 1M tok/day
-```
-
-**Zero cost. Never stops coding.** Configure this as one OmniRoute combo and all fallbacks happen automatically — no manual switching ever.
-
----
-
----
-
-## 🆓 Free Models — What You Actually Get
-
-> All models below are **100% free with zero credit card required**. OmniRoute auto-routes between them when one quota runs out — combine them all for an unbreakable $0 combo.
-
-### 🔵 CLAUDE MODELS (via Kiro — AWS Builder ID)
-
-| Model               | Prefix | Limit         | Rate Limit            |
-| ------------------- | ------ | ------------- | --------------------- |
-| `claude-sonnet-4.5` | `kr/`  | **Unlimited** | No reported daily cap |
-| `claude-haiku-4.5`  | `kr/`  | **Unlimited** | No reported daily cap |
-| `claude-opus-4.6`   | `kr/`  | **Unlimited** | Latest Opus via Kiro  |
-
-### 🟢 QODER MODELS (Free PAT via qodercli)
-
-| Model              | Prefix | Limit         | Rate Limit      |
-| ------------------ | ------ | ------------- | --------------- |
-| `kimi-k2-thinking` | `if/`  | **Unlimited** | No reported cap |
-| `qwen3-coder-plus` | `if/`  | **Unlimited** | No reported cap |
-| `deepseek-r1`      | `if/`  | **Unlimited** | No reported cap |
-| `minimax-m2.1`     | `if/`  | **Unlimited** | No reported cap |
-| `kimi-k2`          | `if/`  | **Unlimited** | No reported cap |
-
-> Recommended connection method: **Personal Access Token + `qodercli`**. Browser OAuth is
-> experimental and disabled by default unless `QODER_OAUTH_*` environment variables are configured.
-
-### 🟡 QWEN MODELS (Device Code Auth)
-
-| Model               | Prefix | Limit         | Rate Limit          |
-| ------------------- | ------ | ------------- | ------------------- |
-| `qwen3-coder-plus`  | `qw/`  | **Unlimited** | No reported cap     |
-| `qwen3-coder-flash` | `qw/`  | **Unlimited** | No reported cap     |
-| `qwen3-coder-next`  | `qw/`  | **Unlimited** | No reported cap     |
-| `vision-model`      | `qw/`  | **Unlimited** | Multimodal (images) |
-
-### 🟣 GEMINI CLI (Google OAuth)
-
-| Model                    | Prefix | Limit                       | Rate Limit    |
-| ------------------------ | ------ | --------------------------- | ------------- |
-| `gemini-3-flash-preview` | `gc/`  | **180K tok/month** + 1K/day | Monthly reset |
-| `gemini-2.5-pro`         | `gc/`  | 180K/month (shared pool)    | High quality  |
-
-### ⚫ NVIDIA NIM (Free API Key — build.nvidia.com)
-
-| Tier       | Daily Limit  | Rate Limit  | Notes                                                  |
-| ---------- | ------------ | ----------- | ------------------------------------------------------ |
-| Free (Dev) | No token cap | **~40 RPM** | 70+ models; transitioning to pure rate limits mid-2025 |
-
-Popular free models: `moonshotai/kimi-k2.5` (Kimi K2.5), `z-ai/glm4.7` (GLM 4.7), `deepseek-ai/deepseek-v3.2` (DeepSeek V3.2), `nvidia/llama-3.3-70b-instruct`, `deepseek/deepseek-r1`
-
-### ⚪ CEREBRAS (Free API Key — inference.cerebras.ai)
-
-| Tier | Daily Limit       | Rate Limit       | Notes                                       |
-| ---- | ----------------- | ---------------- | ------------------------------------------- |
-| Free | **1M tokens/day** | 60K TPM / 30 RPM | World's fastest LLM inference; resets daily |
-
-Available free: `llama-3.3-70b`, `llama-3.1-8b`, `deepseek-r1-distill-llama-70b`
-
-### 🔴 GROQ (Free API Key — console.groq.com)
-
-| Tier | Daily Limit   | Rate Limit       | Notes                                     |
-| ---- | ------------- | ---------------- | ----------------------------------------- |
-| Free | **14.4K RPD** | 30 RPM per model | No credit card; 429 on limit, not charged |
-
-Available free: `llama-3.3-70b-versatile`, `gemma2-9b-it`, `mixtral-8x7b`, `whisper-large-v3`
-
-### 🔴 LONGCAT AI (Free API Key — longcat.chat) 🆕
-
-| Model                         | Prefix | Daily Free Quota  | Notes                   |
-| ----------------------------- | ------ | ----------------- | ----------------------- |
-| `LongCat-Flash-Lite`          | `lc/`  | **50M tokens** 💥 | Largest free quota ever |
-| `LongCat-Flash-Chat`          | `lc/`  | 500K tokens       | Multi-turn chat         |
-| `LongCat-Flash-Thinking`      | `lc/`  | 500K tokens       | Reasoning / CoT         |
-| `LongCat-Flash-Thinking-2601` | `lc/`  | 500K tokens       | Jan 2026 version        |
-| `LongCat-Flash-Omni-2603`     | `lc/`  | 500K tokens       | Multimodal              |
-
-> 100% free while in public beta. Sign up at [longcat.chat](https://longcat.chat) with email or phone. Resets daily 00:00 UTC.
-
-### 🟢 POLLINATIONS AI (No API Key Required) 🆕
-
-| Model      | Prefix | Rate Limit | Provider Behind    |
-| ---------- | ------ | ---------- | ------------------ |
-| `openai`   | `pol/` | 1 req/15s  | GPT-5              |
-| `claude`   | `pol/` | 1 req/15s  | Anthropic Claude   |
-| `gemini`   | `pol/` | 1 req/15s  | Google Gemini      |
-| `deepseek` | `pol/` | 1 req/15s  | DeepSeek V3        |
-| `llama`    | `pol/` | 1 req/15s  | Meta Llama 4 Scout |
-| `mistral`  | `pol/` | 1 req/15s  | Mistral AI         |
-
-> ✨ **Zero friction:** No signup, no API key. Add the Pollinations provider with an empty key field and it works immediately.
-
-### 🟠 CLOUDFLARE WORKERS AI (Free API Key — cloudflare.com) 🆕
-
-| Tier | Daily Neurons | Equivalent Usage                        | Notes                   |
-| ---- | ------------- | --------------------------------------- | ----------------------- |
-| Free | **10,000**    | ~150 LLM resp / 500s audio / 15K embeds | Global edge, 50+ models |
-
-Popular free models: `@cf/meta/llama-3.3-70b-instruct`, `@cf/google/gemma-3-12b-it`, `@cf/openai/whisper-large-v3-turbo` (free audio!), `@cf/qwen/qwen2.5-coder-15b-instruct`
-
-> Requires API Token + Account ID from [dash.cloudflare.com](https://dash.cloudflare.com). Store Account ID in provider settings.
-
-### 🟣 SCALEWAY AI (1M Free Tokens — scaleway.com) 🆕
-
-| Tier | Free Quota    | Location     | Notes                               |
-| ---- | ------------- | ------------ | ----------------------------------- |
-| Free | **1M tokens** | 🇫🇷 Paris, EU | No credit card needed within limits |
-
-Available free: `qwen3-235b-a22b-instruct-2507` (Qwen3 235B!), `llama-3.1-70b-instruct`, `mistral-small-3.2-24b-instruct-2506`, `deepseek-v3-0324`
-
-> EU/GDPR compliant. Get API key at [console.scaleway.com](https://console.scaleway.com).
-
-> **💡 The Ultimate Free Stack (11 Providers, $0 Forever):**
->
-> ```
-> Kiro (kr/)             → Claude Sonnet/Haiku UNLIMITED
-> Qoder (if/)            → kimi-k2-thinking, qwen3-coder-plus, deepseek-r1 UNLIMITED
-> LongCat Lite (lc/)     → LongCat-Flash-Lite — 50M tokens/day 🔥
-> Pollinations (pol/)    → GPT-5, Claude, DeepSeek, Llama 4 — no key needed
-> Qwen (qw/)             → qwen3-coder models UNLIMITED
-> Gemini (gemini/)       → Gemini 2.5 Flash — 1,500 req/day free
-> Cloudflare AI (cf/)    → 50+ models — 10K Neurons/day
-> Scaleway (scw/)        → Qwen3 235B, Llama 70B — 1M free tokens (EU)
-> Groq (groq/)           → Llama/Gemma — 14.4K req/day ultra-fast
-> NVIDIA NIM (nvidia/)   → 70+ open models — 40 RPM forever
-> Cerebras (cerebras/)   → Llama/Qwen world-fastest — 1M tok/day
-> ```
-
-## 🎙️ Free Transcription Combo
-
-> Transcribe any audio/video for **$0** — Deepgram leads with $200 free, AssemblyAI $50 fallback, Groq Whisper as unlimited emergency backup.
-
-| Provider          | Free Credits           | Best Model                                   | Rate Limit                   |
-| ----------------- | ---------------------- | -------------------------------------------- | ---------------------------- |
-| 🟢 **Deepgram**   | **$200 free** (signup) | `nova-3` — best accuracy, 30+ languages      | No RPM limit on free credits |
-| 🔵 **AssemblyAI** | **$50 free** (signup)  | `universal-3-pro` — chapters, sentiment, PII | No RPM limit on free credits |
-| 🔴 **Groq**       | **Free forever**       | `whisper-large-v3` — OpenAI Whisper          | 30 RPM (rate limited)        |
-
-**Suggested combo in `/dashboard/combos`:**
-
-```
-Name: free-transcription
-Strategy: Priority
-Nodes:
-  [1] deepgram/nova-3          → uses $200 free first
-  [2] assemblyai/universal-3-pro → fallback when Deepgram credits run out
-  [3] groq/whisper-large-v3    → free forever, emergency fallback
-```
-
-Then in `/dashboard/media` → **Transcription** tab: upload any audio or video file → select your combo endpoint → get transcription in supported formats.
-
-## 💡 Key Features
-
-OmniRoute v3.6 is built as an operational platform, not just a relay proxy.
-
-### 🆕 New — v3.6.x Highlights (Apr 2026)
-
-| Feature                            | What It Does                                                                                                                                      |
-| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 🌐 **V1 WebSocket Bridge**         | OpenAI-compatible WebSocket traffic upgraded and proxied via `/v1/ws` — full streaming over WS with session auth (API key or session cookie)      |
-| 🔑 **Sync Tokens & Config Bundle** | Issue/revoke sync tokens for config sync endpoints. Config bundles versioned with ETag for bandwidth-efficient polling                            |
-| 🧠 **GLM Thinking (glmt) Preset**  | GLM Thinking registered first-class: 65 536 max tokens, 24 576 thinking budget, 900s timeout, usage sync & pricing — Claude-compatible API        |
-| 🔢 **Hybrid Token Counting**       | Uses provider-side `/messages/count_tokens` when available; falls back to estimation — accurate usage tracking without guessing                   |
-| 🌱 **Model Alias Auto-Seed**       | 30+ cross-proxy dialect aliases normalised at startup — no more routing mismatches                                                                |
-| 🛡️ **Safe Outbound Fetch**         | All provider validation and model discovery go through a guarded fetch layer blocking private/local URLs with retry, timeout, and SSRF protection |
-| ⏳ **Wait For Cooldown**           | Server-side chat retries when every candidate connection is cooling down; configurable `enabled`, `maxRetries`, and `maxRetryWaitSec`             |
-| 🔍 **Runtime Env Validation**      | Startup validates all env vars with Zod schemas — clear errors for missing secrets, invalid URLs, or wrong types                                  |
-| 📋 **Compliance Audit Expansion**  | Structured audit logs with pagination, request context, auth events, provider CRUD events, and SSRF-blocked validation logging                    |
-| 🔐 **TPS Log Metric**              | Log details modal shows Tokens Per Second (TPS) — quick performance at-a-glance for every request                                                 |
-| 🗑️ **Uninstall / Full Uninstall**  | `npm run uninstall` keeps data, `npm run uninstall:full` removes everything — clean removal for all install methods                               |
-| 🔧 **OAuth Env Repair**            | One-click "Repair env" action for OAuth providers restores missing env vars and fixes broken auth state                                           |
-| 🔒 **Graceful Electron Shutdown**  | Electron `before-quit` shuts down Next.js gracefully, preventing SQLite WAL database locks on desktop close                                       |
-| 👁️ **Model Visibility Toggle**     | Per-model visibility toggle (👁 icon) with search filter and active-count badge (`N/M active`) on provider pages                                  |
-| 📧 **Email Privacy Masking**       | OAuth account emails masked (`di*****@g****.com`), full address visible on hover                                                                  |
-| 🔗 **Context Relay Strategy**      | Combo strategy preserving session continuity via structured handoff summaries when accounts rotate mid-conversation                               |
-| 🛡️ **Proxy Hardening**             | Token health check, API key validation, and undici dispatcher all honor proxy config                                                              |
-| ⚠️ **Node.js 24 Login Warning**    | Login page proactively detects incompatible Node.js versions and shows a clear warning banner                                                     |
-| 📎 **Gemini PDF Attachments**      | PDF attachments correctly routed to Gemini via `inline_data` and generic base64 detection                                                         |
-| 🔒 **CodeQL Security Hardening**   | Resolved SSRF, insecure randomness, polynomial ReDoS, and incomplete URL sanitization alerts                                                      |
-
-### 🆕 New — ClawRouter-Inspired Improvements (Mar 2026)
-
-| Feature                              | What It Does                                                                                |
-| ------------------------------------ | ------------------------------------------------------------------------------------------- |
-| ⚡ **Grok-4 Fast Family**            | xAI models at $0.20/$0.50/M — benchmarked 1143ms (30% faster than Gemini 2.5 Flash)         |
-| 🧠 **GLM-5 via Z.AI**                | 128K output context, $0.5/1M — newest flagship from the GLM family                          |
-| 🔮 **MiniMax M2.5**                  | Reasoning + agentic tasks at $0.30/1M — significant upgrade from M2.1                       |
-| 🎯 **toolCalling Flag per Model**    | Per-model `toolCalling: true/false` in registry — AutoCombo skips non-tool-capable models   |
-| 🌍 **Multilingual Intent Detection** | PT/ZH/ES/AR keywords in AutoCombo scoring — better model selection for non-English content  |
-| 📊 **Benchmark-Driven Fallbacks**    | Real p95 latency from live requests feeds combo scoring — AutoCombo learns from actual data |
-| 🔁 **Request Deduplication**         | Content-hash based dedup window — multi-agent safe, prevents duplicate charges              |
-| 🔌 **Pluggable RouterStrategy**      | Extensible `RouterStrategy` interface — add custom routing logic as plugins                 |
-
-### 🚀 Previous v2.0.9+ — Playground, CLI Fingerprints & ACP
-
-| Feature                                    | What It Does                                                                                                                                                                                                                            |
-| ------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 🎮 **Model Playground**                    | Dashboard page to test any model directly — provider/model/endpoint selectors, Monaco Editor, streaming, abort, timing                                                                                                                  |
-| 🔏 **CLI Fingerprint Matching**            | Per-provider header/body ordering to match native CLI signatures — toggle per provider in Settings > Security. **Your proxy IP is preserved**                                                                                           |
-| 🤝 **ACP Support (Agent Client Protocol)** | CLI agent discovery (Codex, Claude, Goose, Gemini CLI, OpenClaw + 9 more), process spawner, `/api/acp/agents` endpoint                                                                                                                  |
-| 🤖 **ACP Agents Dashboard**                | Debug › Agents page — grid of 14 agents with install status, version, custom agent form for any CLI tool. **OpenCode** users get a "Download opencode.json" button that auto-generates a ready-to-use config with all available models. |
-| 🔧 **Custom Model `apiFormat` Routing**    | Custom models with `apiFormat: "responses"` now correctly route to the Responses API translator                                                                                                                                         |
-| 🏢 **Codex Workspace Isolation**           | Multiple Codex workspaces per email — OAuth correctly separates connections by workspace ID                                                                                                                                             |
-| 🔄 **Electron Auto-Update**                | Desktop app checks for updates + auto-install on restart                                                                                                                                                                                |
-
-### 🤖 Agent & Protocol Operations (v2.0)
-
-| Feature                               | What It Does                                                                                                                           |
-| ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| 🔧 **MCP Server (25 tools)**          | IDE/agent tools via 3 transports: stdio, SSE (`/api/mcp/sse`), Streamable HTTP (`/api/mcp/stream`). 18 core + 3 memory + 4 skill tools |
-| 🤝 **A2A Server (JSON-RPC + SSE)**    | Agent-to-agent task execution with sync and streaming flows                                                                            |
-| 🧭 **Consolidated Endpoints Page**    | Tabbed management page with Endpoint Proxy, MCP, A2A, and API Endpoints tabs                                                           |
-| 🎚️ **Service Enable/Disable Toggles** | ON/OFF switches for MCP and A2A with settings persistence (default: OFF)                                                               |
-| 🛰️ **MCP Runtime Heartbeat**          | Real process status (pid, uptime, heartbeat age, transport, scope mode)                                                                |
-| 📋 **MCP Audit Trail**                | Filterable audit logs with success/failure and key attribution                                                                         |
-| 🔐 **MCP Scope Enforcement**          | 10 granular scope permissions for controlled tool access                                                                               |
-| 📡 **A2A Task Lifecycle Management**  | List/filter tasks, inspect events/artifacts, cancel running tasks                                                                      |
-| 📋 **Agent Card Discovery**           | `/.well-known/agent.json` for client auto-discovery                                                                                    |
-| 🧪 **Protocol E2E Test Harness**      | Real MCP SDK + A2A client flows in `test:protocols:e2e`                                                                                |
-| ⚙️ **Operational Controls**           | Switch combos, tune resilience settings, and review breaker state from dedicated Health and Settings surfaces                          |
-
-### 🧠 Routing & Intelligence
-
-| Feature                            | What It Does                                                             |
-| ---------------------------------- | ------------------------------------------------------------------------ |
-| 🎯 **Smart 4-Tier Fallback**       | Auto-route: Subscription → API Key → Cheap → Free                        |
-| 📊 **Real-Time Quota Tracking**    | Live token count + reset countdown per provider                          |
-| 🔄 **Format Translation**          | OpenAI ↔ Claude ↔ Gemini ↔ Responses with schema-safe conversions        |
-| 👥 **Multi-Account Support**       | Multiple accounts per provider with intelligent selection                |
-| 🔄 **Auto Token Refresh**          | OAuth tokens refresh automatically with retry                            |
-| 🎨 **Custom Combos**               | 13 balancing strategies + fallback chain control                         |
-| 🔗 **Context Relay**               | Session continuity handoffs when account rotation happens mid-session    |
-| 🌐 **Wildcard Router**             | `provider/*` dynamic routing                                             |
-| 🧠 **Thinking Budget Controls**    | Passthrough, auto, custom, and adaptive reasoning limits                 |
-| 🔀 **Model Aliases**               | Built-in + custom model aliasing and migration safety                    |
-| ⚡ **Background Degradation**      | Route low-priority background tasks to cheaper models                    |
-| 🧪 **Task-Aware Smart Routing**    | Auto-select model by content type (coding/vision/analysis/summarization) |
-| 🔄 **A2A Agent Workflows**         | Deterministic FSM orchestrator for stateful multi-step agent executions  |
-| 🔀 **Adaptive Routing**            | Dynamic strategy override based on token volume and prompt complexity    |
-| 🎲 **Provider Diversity**          | Shannon entropy scoring balancing auto-combo traffic distribution        |
-| 💬 **System Prompt Injection**     | Global behavior controls applied consistently                            |
-| 📄 **Responses API Compatibility** | Full `/v1/responses` support for Codex and advanced agentic workflows    |
-
-### 🎵 Multi-Modal APIs
-
-| Feature                    | What It Does                                                                                                                                                               |
-| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 🖼️ **Image Generation**    | `/v1/images/generations` with cloud and local backends                                                                                                                     |
-| 📐 **Embeddings**          | `/v1/embeddings` for search and RAG pipelines                                                                                                                              |
-| 🎤 **Audio Transcription** | `/v1/audio/transcriptions` — 7 providers (Deepgram Nova 3, AssemblyAI, Groq Whisper, HuggingFace, ElevenLabs, OpenAI, Azure), auto-language detection, MP4/MP3/WAV support |
-| 🔊 **Text-to-Speech**      | `/v1/audio/speech` — 10 providers (ElevenLabs, OpenAI, Deepgram, Cartesia, PlayHT, HuggingFace, Nvidia NIM, Inworld, Coqui, Tortoise) with correct error messages          |
-| 🎬 **Video Generation**    | `/v1/videos/generations` (ComfyUI + SD WebUI workflows)                                                                                                                    |
-| 🎵 **Music Generation**    | `/v1/music/generations` (ComfyUI workflows)                                                                                                                                |
-| 🛡️ **Moderations**         | `/v1/moderations` safety checks                                                                                                                                            |
-| 🔀 **Reranking**           | `/v1/rerank` for relevance scoring                                                                                                                                         |
-| 🔍 **Web Search** 🆕       | `/v1/search` — 5 providers (Serper, Brave, Perplexity, Exa, Tavily), 6,500+ free/month, auto-failover, cache                                                               |
-
-### 🛡️ Resilience, Security & Governance
-
-| Feature                             | What It Does                                                                                            |
-| ----------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| 🔌 **Provider Circuit Breakers**    | Provider-wide trip/recover after fallback exhaustion with configurable thresholds                       |
-| 🔒 **Daily Quota Lock** 🆕          | Detects exhaustion signals and locks routing for the specific model until midnight                      |
-| 🎯 **Endpoint-Aware Models**        | Custom models declare supported endpoints + API format                                                  |
-| 🛡️ **Anti-Thundering Herd**         | Mutex + semaphore protections on retry/rate events                                                      |
-| 🧠 **Semantic + Signature Cache**   | Cost/latency reduction with two cache layers                                                            |
-| ⚡ **Request Idempotency**          | Duplicate protection window                                                                             |
-| 🔒 **TLS Fingerprint Spoofing**     | Browser-like TLS fingerprint — **reduces bot detection and account flagging**                           |
-| 🔏 **CLI Fingerprint Matching**     | Matches native CLI request signatures — **reduces ban risk while preserving proxy IP**                  |
-| 🌐 **IP Filtering**                 | Allowlist/blocklist control for exposed deployments                                                     |
-| 🚦 **Request Queue & Pacing**       | Configurable per-connection request buckets for RPM, spacing, concurrency, and max wait                 |
-| 📉 **Graceful Degradation**         | Multi-layer capability fallbacks protecting core gateway operations                                     |
-| 📜 **Config Audit Trail**           | Diff-based change tracking preventing operational drift with simple rollbacks                           |
-| ⏳ **Provider Health Sync**         | Proactive token expiration monitoring triggering alerts before authorization failures                   |
-| ❄️ **Connection Cooldown**          | Retryable 408/429/5xx failures cool down a single connection with optional upstream hints               |
-| 🚪 **Auto-Disable Banned Accounts** | Permanently blocked token accounts can be disabled automatically                                        |
-| 🔑 **API Key Management + Scoping** | Secure key issuance/rotation and model/provider controls                                                |
-| 👁️ **Scoped API Key Reveal** 🆕     | Opt-in recovery of API keys via `ALLOW_API_KEY_REVEAL`                                                  |
-| 🛡️ **Protected `/models`**          | Optional auth gating and provider hiding for model catalog                                              |
-| 🛡️ **Safe Outbound Fetch** 🆕       | Guarded fetch for provider calls — blocks private/local URLs, retries, SSRF protection                  |
-| ⏳ **Wait For Cooldown** 🆕         | Auto-retry chat after connection cooldowns; configurable `enabled`, `maxRetries`, and `maxRetryWaitSec` |
-| 🔍 **Runtime Env Validation** 🆕    | Zod-based env schema validation at startup with actionable error messages                               |
-| 📋 **Compliance Audit v2** 🆕       | Pagination, request context, auth events, provider CRUD, and SSRF-blocked logging                       |
-
-### 📊 Observability & Analytics
-
-| Feature                          | What It Does                                          |
-| -------------------------------- | ----------------------------------------------------- |
-| 📝 **Request + Proxy Logging**   | Full request/response and proxy logging               |
-| 📉 **Streamed Detailed Logs**    | Reconstructs SSE payload streams cleanly into the UI  |
-| 🏷️ **Real-Time Model Badges** 🆕 | Live model status and daily quota countdown timers    |
-| 📋 **Unified Logs Dashboard**    | Request, proxy, audit, and console views in one page  |
-| 🔍 **Request Telemetry**         | p50/p95/p99 latency and request tracing               |
-| 🏥 **Health Dashboard**          | Uptime, breaker states, lockouts, cache stats         |
-| 💰 **Cost Tracking**             | Budget controls and per-model pricing visibility      |
-| 📈 **Analytics Visualizations**  | Model/provider usage insights and trend views         |
-| 🧪 **Evaluation Framework**      | Golden set testing with configurable match strategies |
-| 📡 **Live Diagnostics** 🆕       | Semantic cache bypass for accurate combo live testing |
-| 🔐 **TPS Log Metric** 🆕         | Tokens Per Second badge in log details modal          |
-
-### ☁️ Deployment & Platform
-
-| Feature                        | What It Does                                                          |
-| ------------------------------ | --------------------------------------------------------------------- |
-| 🌐 **Deploy Anywhere**         | Localhost, VPS, Docker, Cloud environments                            |
-| 🚇 **Cloudflare Tunnel** 🆕    | One-click Quick Tunnel integration from the dashboard                 |
-| 🔑 **API Key Model Filtering** | Native /v1/models response filtered via assigned Bearer context roles |
-| ⚡ **Smart Cache Bypass**      | Configurable TTL heuristics and forced refetch controls               |
-| 🔄 **Backup/Restore**          | Export/import and disaster recovery flows                             |
-| 🧙 **Onboarding Wizard**       | First-run guided setup                                                |
-| 🔧 **CLI Tools Dashboard**     | One-click setup for popular coding tools                              |
-| 🎮 **Model Playground**        | Test any provider/model/endpoint from the dashboard                   |
-| 🔏 **CLI Fingerprint Toggle**  | Per-provider fingerprint matching in Settings > Security              |
-| 🌐 **i18n (30 languages)**     | Full dashboard + docs language support with RTL coverage              |
-| 🧹 **Clear All Models**        | One-click model list clearing in provider details                     |
-| 👁️ **Sidebar Controls** 🆕     | Hide components and integrations from Appearance Settings             |
-| 📋 **Issue Templates**         | Standardized GitHub templates for bugs and features                   |
-| 📂 **Custom Data Directory**   | `DATA_DIR` override for storage location                              |
-| 🌐 **V1 WebSocket Bridge** 🆕  | OpenAI-compatible WebSocket traffic proxied via `/v1/ws`              |
-| 🔑 **Sync Tokens & Bundle** 🆕 | Config sync tokens + versioned bundle endpoint with ETag support      |
-
-### Feature Deep Dive
-
-#### Smart fallback with practical cost control
-
-```txt
-Combo: "my-coding-stack"
-  1. cc/claude-opus-4-7
-  2. nvidia/llama-3.3-70b
-  3. glm/glm-4.7
-  4. if/kimi-k2-thinking
-```
-
-When quota, rate, or health fails, OmniRoute automatically moves to the next candidate without manual switching.
-
-#### Protocol management that is visible and operable
-
-- MCP + A2A are discoverable in UI and docs (not hidden)
-- Protocol status APIs expose live operational data (`/api/mcp/*`, `/api/a2a/*`)
-- Dashboards include actions for day-2 ops (combo toggles, breaker resets, task cancellation)
-
-#### Translator + validation workflow
-
-The Translator area includes:
-
-- **Playground**: request transformation checks
-- **Chat Tester**: full request/response round-trip
-- **Test Bench**: multiple cases in one run
-- **Live Monitor**: real-time traffic view
-
-Plus protocol validation with real clients via `npm run test:protocols:e2e`.
-
-> 📖 **[MCP Server README](open-sse/mcp-server/README.md)** — Tool reference, IDE configs, and client examples
->
-> 📖 **[A2A Server README](src/lib/a2a/README.md)** — Skills, JSON-RPC methods, streaming, and task lifecycle
-
-## 🧪 Evaluations (Evals)
-
-OmniRoute includes a built-in evaluation framework to test LLM response quality against a golden set. Access it via **Analytics → Evals** in the dashboard.
-
-### Built-in Golden Set
-
-The pre-loaded "OmniRoute Golden Set" contains test cases for:
-
-- Greetings, math, geography, code generation
-- JSON format compliance, translation, markdown generation
-- Safety refusal (harmful content), counting, boolean logic
-
-### Evaluation Strategies
-
-| Strategy   | Description                                      | Example                          |
-| ---------- | ------------------------------------------------ | -------------------------------- |
-| `exact`    | Output must match exactly                        | `"4"`                            |
-| `contains` | Output must contain substring (case-insensitive) | `"Paris"`                        |
-| `regex`    | Output must match regex pattern                  | `"1.*2.*3"`                      |
-| `custom`   | Custom JS function returns true/false            | `(output) => output.length > 10` |
-
----
-
-## 📖 Setup Guide
-
-### Protocol Setup (MCP + A2A)
-
-<details>
-<summary><b>🧩 MCP Setup (Model Context Protocol)</b></summary>
-
-Start MCP transport in stdio mode:
-
-```bash
-omniroute --mcp
-```
-
-Recommended validation flow:
-
-1. Connect your MCP client over stdio.
-2. Run `omniroute_get_health`.
-3. Run `omniroute_list_combos`.
-4. Open `/dashboard/mcp` to confirm heartbeat, activity, and audit.
-
-Useful APIs for automation:
-
-- `GET /api/mcp/status`
-- `GET /api/mcp/tools`
-- `GET /api/mcp/audit`
-- `GET /api/mcp/audit/stats`
+<summary><b>💰 价格一览与 $0 免费堆栈</b></summary>
+
+| 层级 | 示例 | 成本 |
+|---|---|---|
+| 💳 **订阅** | Claude Code Pro / Codex / Copilot | $10–200/月 |
+| 🔑 **API 密钥（免费层）** | NVIDIA NIM、Cerebras、Groq | **免费** |
+| 💰 **廉价** | GLM-5 $0.5/1M · MiniMax M2.5 $0.3/1M | 几分钱 |
+| 🆓 **永久免费** | Kiro、Qoder、Qwen、Pollinations、LongCat | **$0** |
+
+**$0 免费堆栈：**
+
+| 供应商 | 免费模型 | 配额 |
+|---|---|---|
+| **Kiro** | Claude Sonnet 4.5、Haiku 4.5、Opus 4.6 | 50 积分/月 |
+| **Qoder** | kimi-k2-thinking、qwen3-coder-plus、deepseek-r1 | ♾️ 无限 |
+| **Qwen** | qwen3-coder-plus/flash/next | ♾️ 无限 |
+| **Pollinations** | GPT-5、Claude、Gemini、DeepSeek、Llama 4 | 无需密钥 |
+| **LongCat** | LongCat-Flash-Lite | 5 千万 Token/天 |
+| **Cloudflare AI** | 50+ 模型 | 1 万神经元/天 |
+| **NVIDIA NIM** | 129 个模型 | ~40 RPM |
+| **Cerebras** | Qwen3 235B、GPT-OSS 120B | 1M Token/天 |
 
 </details>
 
 <details>
-<summary><b>🤝 A2A Setup (Agent2Agent)</b></summary>
+<summary><b>🎯 用例 — 现成 Combo 剧本</b></summary>
 
-Discover the agent:
-
-```bash
-curl http://localhost:20128/.well-known/agent.json
+**$0 永久免费：**
+```
+1. kr/claude-sonnet-4.5   (Kiro — ~50 积分/月)
+2. if/kimi-k2-thinking    (Qoder — 无限)
+3. pol/gpt-5              (Pollinations — 无需密钥)
+4. lc/longcat-flash-lite  (5 千万 Token/天 备用)
+压缩：aggressive (~50%) · 成本：$0/月
 ```
 
-Send a task:
-
-```bash
-curl -X POST http://localhost:20128/a2a \
-  -H 'content-type: application/json' \
-  -d '{"jsonrpc":"2.0","id":"setup-a2a","method":"message/send","params":{"skill":"quota-management","messages":[{"role":"user","content":"Summarize quota status."}]}}'
-```
-
-Manage lifecycle:
-
-- `GET /api/a2a/status`
-- `GET /api/a2a/tasks`
-- `GET /api/a2a/tasks/:id`
-- `POST /api/a2a/tasks/:id/cancel`
-
-Operational UI:
-
-- `/dashboard/a2a` for task/state/stream observability and smoke actions
-
+**24/7 无中断：** 串联 2 个订阅 → 廉价 → 免费，5 层故障转移。
+**被封锁地区：** 免费供应商 + 全局/每供应商代理 → 从任何国家访问 AI。
+**最大节省：** 订阅 + 廉价备用 + `ultra` 压缩 (~75%) → 重度用户每月节省 ~$150–300。
 </details>
 
 <details>
-<summary><b>🧪 End-to-end protocol validation</b></summary>
+<summary><b>🌍 绕过地理封锁 — 3 层代理 + 隐身</b></summary>
 
-Validate both protocols with real clients:
+在被封锁的地区？OmniRoute 的 **3 层代理**（全局/每供应商/每连接）代理 API 请求、OAuth 流程、连接测试、Token 刷新和模型同步。
 
-```bash
-npm run test:protocols:e2e
-```
-
-This verifies:
-
-- MCP SDK client connect/list/call
-- A2A discovery/send/stream/get/cancel
-- Cross-check data in MCP audit and A2A task management APIs
-
+- **协议：** HTTP/HTTPS、SOCKS5、认证代理
+- **🆓 1proxy 市场** — 数百个免费验证代理、质量评分、自动轮换
+- **反检测** — TLS 指纹欺骗、CLI 指纹匹配、代理 IP 保持
 </details>
 
 <details>
-<summary><b>💳 Subscription Providers</b></summary>
+<summary><b>✨ 完整功能列表</b></summary>
 
-### Claude Code (Pro/Max)
-
-```bash
-Dashboard → Providers → Connect Claude Code
-→ OAuth login → Auto token refresh
-→ 5-hour + weekly quota tracking
-
-Models:
-  cc/claude-opus-4-7
-  cc/claude-sonnet-4-5-20250929
-  cc/claude-haiku-4-5-20251001
-```
-
-**Pro Tip:** Use Opus for complex tasks, Sonnet for speed. OmniRoute tracks quota per model!
-
-### OpenAI Codex (Plus/Pro)
-
-```bash
-Dashboard → Providers → Connect Codex
-→ OAuth login (port 1455)
-→ 5-hour + weekly reset
-
-Models:
-  cx/gpt-5.2-codex
-  cx/gpt-5.1-codex-max
-```
-
-#### Codex Account Limit Management (5h + Weekly)
-
-Each Codex account now has policy toggles in `Dashboard -> Providers`:
-
-- `5h` (ON/OFF): enforce the 5-hour window threshold policy.
-- `Weekly` (ON/OFF): enforce the weekly window threshold policy.
-- Threshold behavior: when an enabled window reaches >=90% usage, that account is skipped.
-- Rotation behavior: OmniRoute routes to the next eligible Codex account automatically.
-- Reset behavior: when the provider `resetAt` time passes, the account becomes eligible again automatically.
-
-Scenarios:
-
-- `5h ON` + `Weekly ON`: account is skipped when either window reaches threshold.
-- `5h OFF` + `Weekly ON`: only weekly usage can block the account.
-- `5h ON` + `Weekly OFF`: only 5-hour usage can block the account.
-- `resetAt` passed: account re-enters rotation automatically (no manual re-enable).
-
-### Gemini CLI (FREE 180K/month!)
-
-```bash
-Dashboard → Providers → Connect Gemini CLI
-→ Google OAuth
-→ 180K completions/month + 1K/day
-
-Models:
-  gc/gemini-3-flash-preview
-  gc/gemini-2.5-pro
-```
-
-**Best Value:** Huge free tier! Use this before paid tiers.
-
-### GitHub Copilot
-
-```bash
-Dashboard → Providers → Connect GitHub
-→ OAuth via GitHub
-→ Monthly reset (1st of month)
-
-Models:
-  gh/gpt-5
-  gh/claude-4.5-sonnet
-  gh/gemini-3.1-pro-preview
-```
-
+**路由：** 15 种策略 · 任务感知智能路由 · 思考预算控制 · 通配符路由
+**兼容性：** OpenAI ↔ Claude ↔ Gemini ↔ Responses API · 自动 OAuth 刷新
+**协议：** MCP（87 工具）· A2A（JSON-RPC 2.0）· ACP · 云代理
+**质量与运维：** 内置 Evals · 护栏 · 健康仪表板 · 遥测 · Webhooks
 </details>
 
 <details>
-<summary><b>🔑 API Key Providers</b></summary>
+<summary><b>📖 设置、环境变量与 FAQ</b></summary>
 
-### NVIDIA NIM (FREE developer access — 70+ models)
+| 环境变量 | 默认值 | 用途 |
+|---|---|---|
+| `PORT` | `20128` | API + 仪表板端口 |
+| `REQUIRE_API_KEY` | `false` | 是否需要 API 密钥 |
+| `DATA_DIR` | `~/.omniroute` | 数据库和配置存储 |
 
-1. Sign up: [build.nvidia.com](https://build.nvidia.com)
-2. Get free API key (1000 inference credits included)
-3. Dashboard → Add Provider → NVIDIA NIM:
-   - API Key: `nvapi-your-key`
-
-**Models:** `nvidia/llama-3.3-70b-instruct`, `nvidia/mistral-7b-instruct`, and 50+ more
-
-**Pro Tip:** OpenAI-compatible API — works seamlessly with OmniRoute's format translation!
-
-### DeepSeek
-
-1. Sign up: [platform.deepseek.com](https://platform.deepseek.com)
-2. Get API key
-3. Dashboard → Add Provider → DeepSeek
-
-**Models:** `deepseek/deepseek-chat`, `deepseek/deepseek-coder`
-
-### Groq (Free Tier Available!)
-
-1. Sign up: [console.groq.com](https://console.groq.com)
-2. Get API key (free tier included)
-3. Dashboard → Add Provider → Groq
-
-**Models:** `groq/llama-3.3-70b`, `groq/mixtral-8x7b`
-
-**Pro Tip:** Ultra-fast inference — best for real-time coding!
-
-### OpenRouter (100+ Models)
-
-1. Sign up: [openrouter.ai](https://openrouter.ai)
-2. Get API key
-3. Dashboard → Add Provider → OpenRouter
-
-**Models:** Access 100+ models from all major providers through a single API key.
-
-**Dashboard behavior:** OpenRouter models are managed from **Available Models**. Manual add, import, and auto-sync all update the same list.
-
+**OmniRoute 会向我收费吗？** 不会 — 它是免费的开源软件，运行在您的机器上。
+**免费供应商真的无限吗？** 基本上是的 — 在 Combo 中堆叠多个免费供应商。
+**压缩会损害质量吗？** 不会 — 它只压缩**输入**。
+**在被封锁 AI 的地区能用吗？** 可以 — 3 层代理可覆盖所有 231 个供应商。
 </details>
 
 <details>
-<summary><b>💰 Cheap Providers (Backup)</b></summary>
+<summary><b>🐛 故障排除</b></summary>
 
-### GLM-4.7 (Daily reset, $0.6/1M)
-
-1. Sign up: [Zhipu AI](https://open.bigmodel.cn/)
-2. Get API key from Coding Plan
-3. Dashboard → Add API Key:
-   - Provider: `glm`
-   - API Key: `your-key`
-
-**Use:** `glm/glm-4.7`
-
-**Pro Tip:** Coding Plan offers 3× quota at 1/7 cost! Reset daily 10:00 AM.
-
-### MiniMax M2.1 (5h reset, $0.20/1M)
-
-1. Sign up: [MiniMax](https://www.minimax.io/)
-2. Get API key
-3. Dashboard → Add API Key
-
-**Use:** `minimax/MiniMax-M2.1`
-
-**Pro Tip:** Cheapest option for long context (1M tokens)!
-
-### Kimi K2 ($9/month flat)
-
-1. Subscribe: [Moonshot AI](https://platform.moonshot.ai/)
-2. Get API key
-3. Dashboard → Add API Key
-
-**Use:** `kimi/kimi-latest`
-
-**Pro Tip:** Fixed $9/month for 10M tokens = $0.90/1M effective cost!
-
+| 问题 | 快速修复 |
+|---|---|
+| "Language model did not provide messages" | 供应商配额用尽 → 使用 Combo 故障转移 |
+| 速率限制（429） | 添加故障转移供应商 |
+| OAuth Token 过期 | 自动刷新；如果卡住，重新认证 |
+| `unsupported_country_region_territory` | 在设置中配置代理 |
+| Docker SQLite 锁定 | 使用 `--stop-timeout 40` |
+| Node 运行时错误 | 使用 Node >=22.0.0 <23 或 >=24.0.0 <27 |
 </details>
 
 <details>
-<summary><b>🆓 FREE Providers (Emergency Backup)</b></summary>
+<summary><b>📸 仪表板截图</b></summary>
 
-### Qoder (5 FREE models via OAuth)
-
-```bash
-Dashboard → Connect Qoder
-→ Qoder OAuth login
-→ Unlimited usage
-
-Models:
-  if/kimi-k2-thinking
-  if/qwen3-coder-plus
-  if/glm-4.7
-  if/minimax-m2
-  if/deepseek-r1
-```
-
-### Qwen (4 FREE models via Device Code)
-
-```bash
-Dashboard → Connect Qwen
-→ Device code authorization
-→ Unlimited usage
-
-Models:
-  qw/qwen3-coder-plus
-  qw/qwen3-coder-flash
-```
-
-### Kiro (Claude FREE)
-
-```bash
-Dashboard → Connect Kiro
-→ AWS Builder ID or Google/GitHub
-→ Unlimited usage
-
-Models:
-  kr/claude-sonnet-4.5
-  kr/claude-haiku-4.5
-```
-
+| 页面 | 截图 | 页面 | 截图 |
+|---|---|---|---|
+| Providers | ![Providers](docs/screenshots/01-providers.png) | Combos | ![Combos](docs/screenshots/02-combos.png) |
+| Analytics | ![Analytics](docs/screenshots/03-analytics.png) | Health | ![Health](docs/screenshots/04-health.png) |
+| Translator | ![Translator](docs/screenshots/05-translator.png) | Settings | ![Settings](docs/screenshots/06-settings.png) |
+| CLI Tools | ![CLI Tools](docs/screenshots/07-cli-tools.png) | Usage Logs | ![Usage](docs/screenshots/08-usage.png) |
 </details>
 
-<details>
-<summary><b>🎨 Create Combos</b></summary>
+# 📧 支持与社区
 
-### Example 1: Maximize Subscription → Cheap Backup
+- 🌍 **网站**：[omniroute.online](https://omniroute.online)
+- 🐙 **GitHub**：[github.com/diegosouzapw/OmniRoute](https://github.com/diegosouzapw/OmniRoute)
+- 🐛 **Issues**：报告 Bug（请附上 `npm run system-info` 输出）
+- 🤝 **贡献**：参见 CONTRIBUTING.md 或选择 `good first issue`
 
-```
-Dashboard → Combos → Create New
+## 🛠️ 技术栈
 
-Name: premium-coding
-Models:
-  1. cc/claude-opus-4-7 (Subscription primary)
-  2. glm/glm-4.7 (Cheap backup, $0.6/1M)
-  3. minimax/MiniMax-M2.1 (Cheapest fallback, $0.20/1M)
+- **运行时**：Node.js 22.x 或 24.x LTS
+- **语言**：TypeScript 6.0 — **100% TypeScript**
+- **框架**：Next.js 16 + React 19 + Tailwind CSS 4
+- **数据库**：better-sqlite3 (SQLite) + LowDB
+- **架构**：Zod
+- **协议**：MCP (stdio/HTTP) + A2A v0.3
+- **认证**：OAuth 2.0 (PKCE) + JWT + API 密钥
+- **测试**：**14,965 个测试用例**，覆盖 517 个文件
+- **平台**：桌面 (Electron)、Android (Termux)、PWA
 
-Use in CLI: premium-coding
-```
+## 📖 文档
 
-### Example 2: Free-Only (Zero Cost)
+**入门指南：** 用户指南 · 设置指南 · CLI 工具 · 远程模式 · 快速开始
+**运维与部署：** Docker · Podman · VM · Fly.io · Termux · PWA
+**功能与架构：** 架构 · 压缩 · 弹性 · Auto-Combo · 代理
+**协议与 API：** API 参考 · OpenAPI 规范 · MCP 服务器 · A2A 服务器
+**项目与质量：** 贡献 · 更新日志 · 安全 · 国际化指南
 
-```
-Name: free-combo
-Models:
-  1. gc/gemini-3-flash-preview (180K free/month)
-  2. if/kimi-k2-thinking (unlimited)
-  3. qw/qwen3-coder-plus (unlimited)
+## ⭐ 顶级贡献者
 
-Cost: $0 forever!
-```
+OmniRoute 由充满激情的开源社区塑造。**感谢你们。**
 
-</details>
-
-<details>
-<summary><b>🔧 CLI Integration</b></summary>
-
-### Cursor IDE
-
-```
-Settings → Models → Advanced:
-  OpenAI API Base URL: http://localhost:20128/v1
-  OpenAI API Key: [from OmniRoute dashboard]
-  Model: cc/claude-opus-4-7
-```
-
-### Claude Code
-
-Use the **CLI Tools** page in the dashboard for one-click configuration, or edit `~/.claude/settings.json` manually.
-
-### Codex CLI
-
-```bash
-export OPENAI_BASE_URL="http://localhost:20128"
-export OPENAI_API_KEY="your-omniroute-api-key"
-
-codex "your prompt"
-```
-
-### OpenClaw
-
-**Option 1 — Dashboard (recommended):**
-
-```
-Dashboard → CLI Tools → OpenClaw → Select Model → Apply
-```
-
-**Option 2 — Manual:** Edit `~/.openclaw/openclaw.json`:
-
-```json
-{
-  "models": {
-    "providers": {
-      "omniroute": {
-        "baseUrl": "http://127.0.0.1:20128/v1",
-        "apiKey": "sk_omniroute",
-        "api": "openai-completions"
-      }
-    }
-  }
-}
-```
-
-> **Note:** OpenClaw only works with local OmniRoute. Use `127.0.0.1` instead of `localhost` to avoid IPv6 resolution issues.
-
-### Cline / Continue / RooCode
-
-```
-Settings → API Configuration:
-  Provider: OpenAI Compatible
-  Base URL: http://localhost:20128/v1
-  API Key: [from OmniRoute dashboard]
-  Model: if/kimi-k2-thinking
-```
-
-### OpenCode
-
-**Step 1:** Add OmniRoute as a custom provider:
-
-```bash
-opencode
-/connect
-# Select "Other" → Enter ID: "omniroute" → Enter your OmniRoute API key
-```
-
-**Step 2:** Create/edit `opencode.json` in your project root:
-
-```json
-{
-  "$schema": "https://opencode.ai/config.json",
-  "provider": {
-    "omniroute": {
-      "npm": "@ai-sdk/openai-compatible",
-      "name": "OmniRoute",
-      "options": {
-        "baseURL": "http://localhost:20128/v1"
-      },
-      "models": {
-        "cc/claude-sonnet-4-20250514": { "name": "Claude Sonnet 4" },
-        "gg/gemini-2.5-pro": { "name": "Gemini 2.5 Pro" },
-        "if/kimi-k2-thinking": { "name": "Kimi K2 (Free)" }
-      }
-    }
-  }
-}
-```
-
-**Step 3:** Select the model in OpenCode:
-
-```bash
-/models
-# Select any OmniRoute model from the list
-```
-
-> **Tip:** Add any model available in your OmniRoute `/v1/models` endpoint to the `models` section. Use the format `provider/model-id` from your OmniRoute dashboard.
-
-</details>
-
----
-
-## 故障排除
-
-<details>
-<summary><b>Click to expand troubleshooting guide</b></summary>
-
-**"Language model did not provide messages"**
-
-- Provider quota exhausted → Check dashboard quota tracker
-- Solution: Use combo fallback or switch to cheaper tier
-
-**Rate limiting**
-
-- Subscription quota out → Fallback to GLM/MiniMax
-- Add combo: `cc/claude-opus-4-7 → glm/glm-4.7 → if/kimi-k2-thinking`
-
-**OAuth token expired**
-
-- Auto-refreshed by OmniRoute
-- If issues persist: Dashboard → Provider → Reconnect
-
-**High costs**
-
-- Check usage stats in Dashboard → Costs
-- Switch primary model to GLM/MiniMax
-- Use free tier (Gemini CLI, Qoder) for non-critical tasks
-
-**Dashboard/API ports are wrong**
-
-- `PORT` is the canonical base port (and API port by default)
-- `API_PORT` overrides only OpenAI-compatible API listener
-- `DASHBOARD_PORT` overrides only dashboard/Next.js listener
-- Set `NEXT_PUBLIC_BASE_URL` to your dashboard/public URL (for OAuth callbacks)
-
-**Cloud sync errors**
-
-- Verify `BASE_URL` points to your running instance
-- Verify `CLOUD_URL` points to your expected cloud endpoint
-- Keep `NEXT_PUBLIC_*` values aligned with server-side values
-
-**First login not working**
-
-- Check `INITIAL_PASSWORD` in `.env`
-- If unset, fallback password is `123456`
-
-**No request logs**
-
-- `call_logs` in SQLite stores summary metadata for the Request Logs table and analytics views
-- Detailed request/response payloads are written to `DATA_DIR/call_logs/` as one JSON artifact per request
-- Enable pipeline capture from Dashboard → Logs → Request Logs if you need detailed per-stage payloads
-- `Export Logs` reads the artifact files on demand, while `Export All` includes the `call_logs/` directory alongside `storage.sqlite`
-- Set `APP_LOG_TO_FILE=true` if you also want application console logs in `logs/application/app.log`
-- Adjust `APP_LOG_MAX_FILE_SIZE`, `APP_LOG_RETENTION_DAYS`, `APP_LOG_MAX_FILES`, and `CALL_LOG_MAX_ENTRIES` as needed
-
-**Connection test shows "Invalid" for OpenAI-compatible providers**
-
-- Many providers don't expose a `/models` endpoint
-- OmniRoute v1.0.6+ includes fallback validation via chat completions
-- Ensure base URL includes `/v1` suffix
-
-### 🔐 OAuth on a Remote Server
-
-<a name="oauth-on-a-remote-server"></a>
-<a name="oauth-em-servidor-remoto"></a>
-
-> **⚠️ Important for users running OmniRoute on a VPS, Docker, or any remote server**
-
-#### Why does Antigravity / Gemini CLI OAuth fail on remote servers?
-
-The **Antigravity** and **Gemini CLI** providers use **Google OAuth 2.0**. Google requires the `redirect_uri` in the OAuth flow to exactly match one of the pre-registered URIs in the app's Google Cloud Console.
-
-The OAuth credentials bundled in OmniRoute are registered **for `localhost` only**. When you access OmniRoute on a remote server (e.g. `https://omniroute.myserver.com`), Google rejects the authentication with:
-
-```
-Error 400: redirect_uri_mismatch
-```
-
-#### Solution: Configure your own OAuth credentials
-
-You need to create an **OAuth 2.0 Client ID** in Google Cloud Console with your server's URI.
-
-#### Step-by-step
-
-**1. Open Google Cloud Console**
-
-Go to: [https://console.cloud.google.com/apis/credentials](https://console.cloud.google.com/apis/credentials)
-
-**2. Create a new OAuth 2.0 Client ID**
-
-- Click **"+ Create Credentials"** → **"OAuth client ID"**
-- Application type: **"Web application"**
-- Name: anything you like (e.g. `OmniRoute Remote`)
-
-**3. Add Authorized Redirect URIs**
-
-In the **"Authorized redirect URIs"** field, add:
-
-```
-https://your-server.com/callback
-```
-
-> Replace `your-server.com` with your server's domain or IP (include the port if needed, e.g. `http://45.33.32.156:20128/callback`).
-
-**4. Save and copy the credentials**
-
-After creating, Google will show the **Client ID** and **Client Secret**.
-
-**5. Set environment variables**
-
-In your `.env` (or Docker environment variables):
-
-```bash
-# For Antigravity:
-ANTIGRAVITY_OAUTH_CLIENT_ID=your-client-id.apps.googleusercontent.com
-ANTIGRAVITY_OAUTH_CLIENT_SECRET=GOCSPX-your-secret
-
-# For Gemini CLI:
-GEMINI_OAUTH_CLIENT_ID=your-client-id.apps.googleusercontent.com
-GEMINI_OAUTH_CLIENT_SECRET=GOCSPX-your-secret
-GEMINI_CLI_OAUTH_CLIENT_SECRET=GOCSPX-your-secret
-```
-
-**6. Restart OmniRoute**
-
-```bash
-# npm:
-npm run dev
-
-# Docker:
-docker restart omniroute
-```
-
-**7. Try connecting again**
-
-Dashboard → Providers → Antigravity (or Gemini CLI) → OAuth
-
-Google will now redirect correctly to `https://your-server.com/callback`.
-
----
-
-#### Temporary workaround (without custom credentials)
-
-If you don't want to set up your own credentials right now, you can still use the **manual URL flow**:
-
-1. OmniRoute opens the Google authorization URL
-2. After authorizing, Google tries to redirect to `localhost` (which fails on the remote server)
-3. **Copy the full URL** from your browser's address bar (even if the page doesn't load)
-4. Paste that URL into the field shown in the OmniRoute connection modal
-5. Click **"Connect"**
-
-> This works because the authorization code in the URL is valid regardless of whether the redirect page loaded.
-
----
-
-<details>
-<summary><b>🇧🇷 Versão em Português</b></summary>
-
-#### Por que o OAuth do Antigravity / Gemini CLI falha em servidores remotos?
-
-Os provedores **Antigravity** e **Gemini CLI** usam **Google OAuth 2.0** para autenticação. O Google exige que a `redirect_uri` usada no fluxo OAuth seja **exatamente** uma das URIs pré-cadastradas no Google Cloud Console do aplicativo.
-
-As credenciais OAuth embutidas no OmniRoute estão cadastradas **apenas para `localhost`**. Quando você acessa o OmniRoute em um servidor remoto (ex: `https://omniroute.meuservidor.com`), o Google rejeita a autenticação com:
-
-```
-Error 400: redirect_uri_mismatch
-```
-
-#### Solução: Configure suas próprias credenciais OAuth
-
-Você precisa criar um **OAuth 2.0 Client ID** no Google Cloud Console com a URI do seu servidor.
-
-#### Passo a passo
-
-**1. Acesse o Google Cloud Console**
-
-Abra: [https://console.cloud.google.com/apis/credentials](https://console.cloud.google.com/apis/credentials)
-
-**2. Crie um novo OAuth 2.0 Client ID**
-
-- Clique em **"+ Create Credentials"** → **"OAuth client ID"**
-- Tipo de aplicativo: **"Web application"**
-- Nome: escolha qualquer nome (ex: `OmniRoute Remote`)
-
-**3. Adicione as Authorized Redirect URIs**
-
-No campo **"Authorized redirect URIs"**, adicione:
-
-```
-https://seu-servidor.com/callback
-```
-
-> Substitua `seu-servidor.com` pelo domínio ou IP do seu servidor (inclua a porta se necessário, ex: `http://45.33.32.156:20128/callback`).
-
-**4. Salve e copie as credenciais**
-
-Após criar, o Google mostrará o **Client ID** e o **Client Secret**.
-
-**5. Configure as variáveis de ambiente**
-
-No seu `.env` (ou nas variáveis de ambiente do Docker):
-
-```bash
-# Para Antigravity:
-ANTIGRAVITY_OAUTH_CLIENT_ID=seu-client-id.apps.googleusercontent.com
-ANTIGRAVITY_OAUTH_CLIENT_SECRET=GOCSPX-seu-secret
-
-# Para Gemini CLI:
-GEMINI_OAUTH_CLIENT_ID=seu-client-id.apps.googleusercontent.com
-GEMINI_OAUTH_CLIENT_SECRET=GOCSPX-seu-secret
-GEMINI_CLI_OAUTH_CLIENT_SECRET=GOCSPX-seu-secret
-```
-
-**6. Reinicie o OmniRoute**
-
-```bash
-# Se usando npm:
-npm run dev
-
-# Se usando Docker:
-docker restart omniroute
-```
-
-**7. Tente conectar novamente**
-
-Dashboard → Providers → Antigravity (ou Gemini CLI) → OAuth
-
-Agora o Google redirecionará corretamente para `https://seu-servidor.com/callback` e a autenticação funcionará.
-
----
-
-#### Workaround temporário (sem configurar credenciais próprias)
-
-Se não quiser criar credenciais próprias agora, ainda é possível usar o fluxo **manual de URL**:
-
-1. O OmniRoute abrirá a URL de autorização do Google
-2. Após você autorizar, o Google tentará redirecionar para `localhost` (que falha no servidor remoto)
-3. **Copie a URL completa** da barra de endereço do seu browser (mesmo que a página não carregue)
-4. Cole essa URL no campo que aparece no modal de conexão do OmniRoute
-5. Clique em **"Connect"**
-
-> Este workaround funciona porque o código de autorização na URL é válido independente do redirect ter carregado ou não.
-
-</details>
-
----
-
-</details>
-
-## 🛠️ Tech Stack
-
-<details>
-<summary><b>Click to expand tech stack details</b></summary>
-
-- **Runtime**: Node.js 18–22 LTS (⚠️ Node.js 24+ is **not supported** — `better-sqlite3` native binaries are incompatible)
-- **Language**: TypeScript 5.9 — **100% TypeScript** across `src/` and `open-sse/` (zero `any` in core modules since v2.0)
-- **Framework**: Next.js 16 + React 19 + Tailwind CSS 4
-- **Database**: better-sqlite3 (SQLite) + LowDB (JSON legacy) — domain state, proxy logs, MCP audit, routing decisions, memory, skills
-- **Schemas**: Zod (MCP tool I/O validation, API contracts)
-- **Protocols**: MCP (stdio/HTTP) + A2A v0.3 (JSON-RPC 2.0 + SSE)
-- **Streaming**: Server-Sent Events (SSE)
-- **Auth**: OAuth 2.0 (PKCE) + JWT + API Keys + MCP Scoped Authorization
-- **Testing**: Node.js test runner + Vitest (900+ tests including unit, integration, E2E)
-- **CI/CD**: GitHub Actions (auto npm publish + Docker Hub on release)
-- **Website**: [omniroute.online](https://omniroute.online)
-- **Package**: [npmjs.com/package/omniroute](https://www.npmjs.com/package/omniroute)
-- **Docker**: [hub.docker.com/r/diegosouzapw/omniroute](https://hub.docker.com/r/diegosouzapw/omniroute)
-- **Resilience**: Circuit breaker, exponential backoff, anti-thundering herd, TLS spoofing, auto-combo self-healing
-
-</details>
-
----
-
-## 文档
-
-| Document                                                              | Description                                         |
-| --------------------------------------------------------------------- | --------------------------------------------------- |
-| [User Guide](docs/guides/USER_GUIDE.md)                               | Providers, combos, CLI integration, deployment      |
-| [API Reference](docs/reference/API_REFERENCE.md)                      | All endpoints with examples                         |
-| [MCP Server](open-sse/mcp-server/README.md)                           | 25 MCP tools, IDE configs, Python/TS/Go clients     |
-| [A2A Server](src/lib/a2a/README.md)                                   | JSON-RPC 2.0 protocol, skills, streaming, task mgmt |
-| [Auto-Combo Engine](docs/routing/AUTO-COMBO.md)                       | 6-factor scoring, mode packs, self-healing          |
-| [Context Relay](docs/features/context-relay.md)                       | Session handoff strategy for account rotation       |
-| [Troubleshooting](docs/guides/TROUBLESHOOTING.md)                     | Common problems and solutions                       |
-| [Architecture](docs/architecture/ARCHITECTURE.md)                     | System architecture and internals                   |
-| [Codebase Documentation](docs/architecture/CODEBASE_DOCUMENTATION.md) | Beginner-friendly codebase walkthrough              |
-| [Uninstall Guide](docs/guides/UNINSTALL.md)                           | Clean removal for all install methods               |
-| [Environment Config](docs/reference/ENVIRONMENT.md)                   | Complete `.env` variables and references            |
-| [Contributing](CONTRIBUTING.md)                                       | Development setup and guidelines                    |
-| [OpenAPI Spec](docs/reference/openapi.yaml)                           | OpenAPI 3.0 specification                           |
-| [Security Policy](SECURITY.md)                                        | Vulnerability reporting and security practices      |
-| [VM Deployment](docs/ops/VM_DEPLOYMENT_GUIDE.md)                      | Complete guide: VM + nginx + Cloudflare setup       |
-| [Features Gallery](docs/guides/FEATURES.md)                           | Visual dashboard tour with screenshots              |
-| [Release Checklist](docs/ops/RELEASE_CHECKLIST.md)                    | Pre-release validation steps                        |
-
----
-
-## 🗺️ Roadmap
-
-OmniRoute has **218+ features planned** across multiple development phases. Here are the key areas:
-
-| Category                      | Planned Features | Highlights                                                                                            |
-| ----------------------------- | ---------------- | ----------------------------------------------------------------------------------------------------- |
-| 🧠 **Routing & Intelligence** | 25+              | Lowest-latency routing, tag-based routing, quota preflight, quota-aware P2C, step-based combo routing |
-| 🔒 **Security & Compliance**  | 20+              | SSRF hardening, credential cloaking, rate-limit per endpoint, management key scoping                  |
-| 📊 **Observability**          | 15+              | OpenTelemetry integration, real-time quota monitoring, combo target health, cost tracking per model   |
-| 🔄 **Provider Integrations**  | 20+              | Dynamic model registry, connection cooldowns, multi-account Codex, Copilot quota parsing              |
-| ⚡ **Performance**            | 15+              | Dual cache layer, prompt cache, response cache, streaming keepalive, batch API                        |
-| 🌐 **Ecosystem**              | 10+              | WebSocket API, config hot-reload, distributed config store, commercial mode                           |
-
-### 🔜 Coming Soon
-
-- 🔗 **OpenCode Integration** — Native provider support for the OpenCode AI coding IDE
-- 🔗 **TRAE Integration** — Full support for the TRAE AI development framework
-- 📦 **Batch API** — Asynchronous batch processing for bulk requests
-- 🎯 **Tag-Based Routing** — Route requests based on custom tags and metadata
-- 💰 **Lowest-Cost Strategy** — Automatically select the cheapest available provider
-
-> 📝 Full feature specifications available in [`docs/new-features/`](docs/new-features/) (217 detailed specs)
-
----
-
-## 👥 Contributors
+## 👥 贡献者
 
 [![Contributors](https://contrib.rocks/image?repo=diegosouzapw/OmniRoute&max=100&columns=20&anon=1)](https://github.com/diegosouzapw/OmniRoute/graphs/contributors)
 
-### How to Contribute
+### 如何贡献
+1. Fork 仓库
+2. 创建功能分支
+3. 提交更改
+4. 推送到分支
+5. 创建 Pull Request
 
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
+## 🙏 致谢
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed guidelines.
+OmniRoute 建立在巨人的肩膀上。每个子系统都受到先行的开源项目的启发。
 
-### Releasing a New Version
+**渊源：** 9router · CLIProxyAPI · LiteLLM
+**压缩：** Caveman · RTK · Headroom · LLMLingua · Ponytail
+**记忆：** Mem0 · Letta
+**模型数据：** models.dev · React Flow · Langfuse
 
-```bash
-# Create a release — npm publish happens automatically
-gh release create v2.0.0 --title "v2.0.0" --generate-notes
-```
+## 📄 许可证
 
----
-
-## 📊 Star History
-
-<a href="https://www.star-history.com/?repos=diegosouzapw%2Fomniroute&type=date&legend=top-left">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=diegosouzapw/omniroute&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=diegosouzapw/omniroute&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=diegosouzapw/omniroute&type=date&legend=top-left" />
- </picture>
-</a>
-
-## 🌍 StarMapper
-
-<a href="https://starmapper.bruniaux.com/diegosouzapw/omniroute">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://starmapper.bruniaux.com/api/map-image/diegosouzapw/omniroute?theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://starmapper.bruniaux.com/api/map-image/diegosouzapw/omniroute?theme=light" />
-    <img alt="StarMapper" src="https://starmapper.bruniaux.com/api/map-image/diegosouzapw/omniroute" />
-  </picture>
-</a>
-
-## 🙏 Acknowledgments
-
-Special thanks to **[CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI)** — the original Go implementation that inspired this JavaScript port.
+MIT 许可证 — 详情见 LICENSE 文件。
 
 ---
 
-## 许可证
-
-MIT License - see [LICENSE](LICENSE) for details.
-
----
-
-<div align="center">
-  <sub>Built with ❤️ for developers who code 24/7</sub>
-  <br/>
-  <sub><a href="https://omniroute.online">omniroute.online</a></sub>
-</div>
-<!-- GitHub Discussions enabled for community Q&A -->
+**[⬆ 返回顶部](#-omniroute)** · 为开源 AI 社区用心构建。

--- a/docs/i18n/zh-TW/README.md
+++ b/docs/i18n/zh-TW/README.md
@@ -1,0 +1,868 @@
+# 🚀 OmniRoute — 免費 AI 閘道器
+
+🌐 **語言:** 🇺🇸 [English](../../../README.md) · 🇸🇦 [ar](../ar/README.md) · 🇧🇬 [bg](../bg/README.md) · 🇧🇩 [bn](../bn/README.md) · 🇨🇿 [cs](../cs/README.md) · 🇩🇰 [da](../da/README.md) · 🇩🇪 [de](../de/README.md) · 🇪🇸 [es](../es/README.md) · 🇮🇷 [fa](../fa/README.md) · 🇫🇮 [fi](../fi/README.md) · 🇫🇷 [fr](../fr/README.md) · 🇮🇳 [gu](../gu/README.md) · 🇮🇱 [he](../he/README.md) · 🇮🇳 [hi](../hi/README.md) · 🇭🇺 [hu](../hu/README.md) · 🇮🇩 [id](../id/README.md) · 🇮🇹 [it](../it/README.md) · 🇯🇵 [ja](../ja/README.md) · 🇰🇷 [ko](../ko/README.md) · 🇮🇳 [mr](../mr/README.md) · 🇲🇾 [ms](../ms/README.md) · 🇳🇱 [nl](../nl/README.md) · 🇳🇴 [no](../no/README.md) · 🇵🇭 [phi](../phi/README.md) · 🇵🇱 [pl](../pl/README.md) · 🇵🇹 [pt](../pt/README.md) · 🇧🇷 [pt-BR](../pt-BR/README.md) · 🇷🇴 [ro](../ro/README.md) · 🇷🇺 [ru](../ru/README.md) · 🇸🇰 [sk](../sk/README.md) · 🇸🇪 [sv](../sv/README.md) · 🇰🇪 [sw](../sw/README.md) · 🇮🇳 [ta](../ta/README.md) · 🇮🇳 [te](../te/README.md) · 🇹🇭 [th](../th/README.md) · 🇹🇷 [tr](../tr/README.md) · 🇺🇦 [uk-UA](../uk-UA/README.md) · 🇵🇰 [ur](../ur/README.md) · 🇻🇳 [vi](../vi/README.md) · 🇨🇳 [zh-CN](../zh-CN/README.md) · 🇹🇼 [zh-TW](../zh-TW/README.md)
+
+---
+
+<div align="center">
+
+<img src="../../screenshots/MainOmniRoute.png" alt="OmniRoute 儀表板" width="820"/>
+
+<br/>
+
+# 🚀 OmniRoute — 免費 AI 閘道器
+
+### 永遠不要停止開發。透過一個端點，將每個 AI 工具連接到 **231 個供應商** — **50+ 免費**。
+
+**將 Claude Code、Codex、Cursor、Cline、Copilot 和 Antigravity 連接到免費的 Claude / GPT / Gemini。自動備援。**
+
+**RTK + Caveman 壓縮可節省 15–95% 的 Token。永遠不會達到限制。**
+
+**每月約 16 億個免費 Token** — 加上註冊獎勵，首月可達 **約 21 億** — 匯集自各個免費方案，再加上壓縮技術進一步放大。
+
+[![231 個 AI 供應商](https://img.shields.io/badge/231-AI_Providers-6C5CE7?style=for-the-badge)](#-231-ai-providers--50-free)
+[![50+ 免費](https://img.shields.io/badge/50%2B-Free_Tiers-00B894?style=for-the-badge)](#-231-ai-providers--50-free)
+[![16 億免費 Token/月](https://img.shields.io/badge/1.6B-Free_Tokens%2Fmo-00B894?style=for-the-badge)](docs/reference/FREE_TIERS.md)
+[![節省高達 95% Token](https://img.shields.io/badge/up_to_95%25-Token_Savings-E17055?style=for-the-badge)](#%EF%B8%8F-save-1595-tokens--automatically)
+[![17 種路由策略](https://img.shields.io/badge/17-Routing_Strategies-0984E3?style=for-the-badge)](#-combos--the-flagship)
+[![從 $0 開始](https://img.shields.io/badge/%240-To_Start-FDCB6E?style=for-the-badge&logoColor=black)](#-quick-start)
+
+<br/>
+
+### 💬 加入社群
+
+[![Discord](https://img.shields.io/badge/Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/EkzRkpzKYt)
+[![Telegram](https://img.shields.io/badge/Telegram-26A5E4?style=for-the-badge&logo=telegram&logoColor=white)](https://t.me/omnirouteOficial)
+[![WhatsApp Global](https://img.shields.io/badge/WhatsApp_Global-25D366?style=for-the-badge&logo=whatsapp&logoColor=white)](https://chat.whatsapp.com/JI7cDQ1GyaiDHhVBpLxf8b?mode=gi_t)
+[![WhatsApp Brasil](https://img.shields.io/badge/WhatsApp_Brasil-25D366?style=for-the-badge&logo=whatsapp&logoColor=white)](https://chat.whatsapp.com/BTGJXIyjeNIIgExvTMGGhI)
+
+**問題、供應商訣竅、路線圖與支援 → [Discord](https://discord.gg/EkzRkpzKYt) · [Telegram](https://t.me/omnirouteOficial) · WhatsApp [🌍 全球](https://chat.whatsapp.com/JI7cDQ1GyaiDHhVBpLxf8b?mode=gi_t) / [🇧🇷 巴西](https://chat.whatsapp.com/BTGJXIyjeNIIgExvTMGGhI)**
+
+<br/>
+
+<a href="https://trendshift.io/repositories/23589" target="_blank"><img src="https://trendshift.io/api/badge/repositories/23589" alt="diegosouzapw%2FOmniRoute | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+
+[![npm](https://img.shields.io/npm/v/omniroute?logo=npm&style=flat-square)](https://www.npmjs.com/package/omniroute)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square)](LICENSE)
+[![Node](https://img.shields.io/badge/node-%E2%89%A522.0.0-brightgreen?style=flat-square)](package.json)
+[![Stars](https://img.shields.io/github/stars/diegosouzapw/OmniRoute?style=social)](https://github.com/diegosouzapw/OmniRoute)
+
+<div align="center">
+
+[![npm version](https://img.shields.io/npm/v/omniroute?color=cb3837&logo=npm)](https://www.npmjs.com/package/omniroute)
+![NPM Monthly](https://img.shields.io/npm/dm/omniroute?label=npm/month&color=cb3837&logo=npm)
+[![Docker Hub](https://img.shields.io/docker/v/diegosouzapw/omniroute?label=Docker%20Hub&logo=docker&color=2496ED)](https://hub.docker.com/r/diegosouzapw/omniroute)
+![Docker Pulls](https://img.shields.io/docker/pulls/diegosouzapw/omniroute?label=docker%20pulls&logo=docker&color=2496ED)
+![Electron Downloads](https://img.shields.io/github/downloads/diegosouzapw/omniroute/total?style=flat&label=electron%20downloads&logo=electron&color=47848F)
+[![Website](https://img.shields.io/badge/Website-omniroute.online-blue?logo=google-chrome&logoColor=white)](https://omniroute.online)
+
+</div>
+
+<br/>
+
+[**🚀 快速開始**](#-quick-start) • [**🎯 組合策略**](#-combos--the-flagship) • [**🌐 供應商**](#-231-ai-providers--50-free) • [**🔌 CLI 與 MCP**](#-full-cli--a2a--mcp) • [**🗜️ 壓縮**](#%EF%B8%8F-save-1595-tokens--automatically) • [**🌍 網站**](https://omniroute.online)
+
+[💥 承諾](#-the-promise) • [🤔 為何選擇](#-why-omniroute) • [🏆 與眾不同](#-what-sets-omniroute-apart) • [🤖 相容工具](#-compatible-clis--coding-agents) • [🖥️ 執行環境](#%EF%B8%8F-where-omniroute-runs--anywhere) • [🔒 隱私](#-private--local-first) • [🎬 實際展示](#-omniroute-in-action) • [📚 探索更多](#-explore-more) • [📧 支援](#-support--community)
+
+</div>
+
+<div align="center">
+<b>🌐 提供 41+ 種語言</b>
+<table>
+  <tr>
+    <td align="center"><a href="../../README.md">🇺🇸</a></td>
+    <td align="center"><a href="../pt-BR/README.md">🇧🇷</a></td>
+    <td align="center"><a href="../es/README.md">🇪🇸</a></td>
+    <td align="center"><a href="../fr/README.md">🇫🇷</a></td>
+    <td align="center"><a href="../it/README.md">🇮🇹</a></td>
+    <td align="center"><a href="../ru/README.md">🇷🇺</a></td>
+    <td align="center"><a href="../zh-CN/README.md">🇨🇳</a></td>
+    <td align="center"><a href="../zh-TW/README.md">🇹🇼</a></td>
+    <td align="center"><a href="../de/README.md">🇩🇪</a></td>
+    <td align="center"><a href="../ja/README.md">🇯🇵</a></td>
+    <td align="center"><a href="../ko/README.md">🇰🇷</a></td>
+  </tr>
+  <tr>
+    <td align="center"><a href="../th/README.md">🇹🇭</a></td>
+    <td align="center"><a href="../vi/README.md">🇻🇳</a></td>
+    <td align="center"><a href="../id/README.md">🇮🇩</a></td>
+    <td align="center"><a href="../ms/README.md">🇲🇾</a></td>
+    <td align="center"><a href="../phi/README.md">🇵🇭</a></td>
+    <td align="center"><a href="../ar/README.md">🇸🇦</a></td>
+    <td align="center"><a href="../he/README.md">🇮🇱</a></td>
+    <td align="center"><a href="../az/README.md">🇦🇿</a></td>
+    <td align="center"><a href="../uk-UA/README.md">🇺🇦</a></td>
+    <td align="center"><a href="../pl/README.md">🇵🇱</a></td>
+    <td align="center"><a href="../cs/README.md">🇨🇿</a></td>
+  </tr>
+  <tr>
+    <td align="center"><a href="../nl/README.md">🇳🇱</a></td>
+    <td align="center"><a href="../bg/README.md">🇧🇬</a></td>
+    <td align="center"><a href="../da/README.md">🇩🇰</a></td>
+    <td align="center"><a href="../fi/README.md">🇫🇮</a></td>
+    <td align="center"><a href="../no/README.md">🇳🇴</a></td>
+    <td align="center"><a href="../sv/README.md">🇸🇪</a></td>
+    <td align="center"><a href="../hu/README.md">🇭🇺</a></td>
+    <td align="center"><a href="../ro/README.md">🇷🇴</a></td>
+    <td align="center"><a href="../sk/README.md">🇸🇰</a></td>
+    <td align="center"><a href="../pt/README.md">🇵🇹</a></td>
+    <td align="center"></td>
+  </tr>
+</table>
+</div>
+
+<br/>
+
+<div align="center">
+
+# 💰 每月約 16 億個免費 Token
+
+</div>
+
+> 手動疊加免費方案很痛苦 — 幾十個 SDK、幾十個速率限制，而且你根本不知道自己實際上還剩多少配額。OmniRoute 匯總了 **40+ 供應商池 / 500+ 模型** 的免費方案，在儀表板上即時顯示真實數字。
+
+- **每月約 16 億個免費 Token**（穩定）— 加上註冊獎勵，首月可達 **約 21 億**
+- **去重計算、誠實透明** — 我們對每個共享免費池**只計算一次**
+- **加上無法精確計算的部分** — 永久免費、無 Token 上限的供應商
+- **逐模型細項**、**當月即時已用/剩餘**，以及每個供應商的透明條款標記
+
+<br/>
+
+<div align="center">
+
+# 💥 承諾
+
+</div>
+
+> 一個端點。**231 個供應商。** 永遠不要停止開發 — 讓 OmniRoute 自動挑選最便宜的可用選項。
+
+| | | |
+|---|---|---|
+| **🚫 永不達標**<br/>毫秒級自動備援，跨越 231 個供應商。配額用完？下一個供應商立即接手 — 零停機。 | **💸 節省高達 95% Token**<br/>RTK + Caveman 疊加壓縮，可減少 15–95% 的 Token（工具密集型工作階段平均約 89%）。 | **🆓 從 $0 開始**<br/>50+ 供應商提供免費方案，11 個**永久免費**（Kiro、Qoder、Pollinations、LongCat...）。無需信用卡。 |
+| **🔌 每個工具都適用**<br/>16+ 程式碼代理 — Claude Code、Codex、Cursor、Cline、Copilot、Antigravity — 只需一個設定檔。 | **🧩 一個端點**<br/>OpenAI ↔ Claude ↔ Gemini ↔ Responses API 自動轉譯。將任何工具指向 `/v1` 即可使用。 | **🛡️ 生產級別**<br/>斷路器、TLS 隱匿、MCP（87 個工具）、A2A、記憶體、護欄、評估。14,965 項測試。 |
+
+<br/>
+
+<div align="center">
+
+# 🤔 為何選擇 OmniRoute？
+
+</div>
+
+> 告別十個儀表板、失效的 API 金鑰和意外的帳單。
+
+| ❌ 日常痛點 | ✅ OmniRoute 如何解決 |
+|---|---|
+| 📉 訂閱配額每月未用完就歸零 | **最大化訂閱** — 追蹤配額，在重置前用完每個 Token |
+| 🛑 速率限制中斷你的開發 | **4 層自動備援** — 訂閱 → API → 便宜 → 免費，毫秒級切換 |
+| 🔥 工具輸出（`git diff`、`grep`、日誌）浪費 Token | **RTK + Caveman 壓縮** — 每次請求節省 15–95% Token |
+| 💸 昂貴的 API（每個供應商每月 $20–50） | **成本優化路由** — 自動路由到最便宜的可行模型 |
+| 🧰 每個 AI 工具都需要自己的設定 | **一個端點、所有工具、一個儀表板** |
+| 🌍 AI 在你所在的國家被封鎖 | **3 層代理** + TLS 指紋隱匿 — 從任何地方使用 AI |
+
+<div align="center">
+
+```
+┌──────────────────────────────────────────────────────────┐
+│           你的 IDE / CLI（Claude Code、Cursor、Cline…）     │
+└─────────────────────────┬──────────────────────────────────┘
+                          │ http://localhost:20128/v1
+                          ▼
+┌──────────────────────────────────────────────────────────┐
+│                  OmniRoute — 智慧路由器                     │
+│  RTK + Caveman 壓縮 · 17 種路由策略                        │
+│  斷路器 · TLS 隱匿 · MCP · A2A · 護欄                      │
+└─────────────────────────┬──────────────────────────────────┘
+        ┌─────────────┬────┴────────┬─────────────┐
+        ▼ 第 1 層     ▼ 第 2 層     ▼ 第 3 層      ▼ 第 4 層
+       訂閱制          API 金鑰      便宜方案        免費方案
+   Claude Code,      DeepSeek,      GLM $0.5,      Kiro, Qoder,
+   Codex, Copilot    Groq, xAI      MiniMax $0.2   Pollinations
+   配額用完？───▶ 預算超標？───▶ 預算超標？───▶ 永遠可用
+```
+
+</div>
+
+<br/>
+
+<div align="center">
+
+# 🎯 組合策略 — 旗艦功能
+
+</div>
+
+> **組合（Combo）** 是一串模型的鏈條，OmniRoute 會**自動**在它們之間路由。配額用完、供應商故障或成本飆升 — 組合會無聲地切換到下一個模型。**這就是 OmniRoute 牢不可破的原因。** 🛡️
+
+### ⚡ 零設定 — 只要用 `auto`
+
+無需建立組合。將模型設為 `auto`（或變體），OmniRoute 就會根據你連接的供應商即時建立虛擬組合：
+
+| 模型 ID | 最佳化目標 |
+|---|---|
+| `auto` | 🎯 平衡預設（LKGP — 停留在上次良好的供應商） |
+| `auto/coding` | 🧑‍💻 品質優先，適用於程式碼生成 |
+| `auto/fast` | ⚡ 最低延遲優先 |
+| `auto/cheap` | 💰 每個 Token 最便宜優先 |
+| `auto/offline` | 🔋 最多配額/速率限制餘裕優先 |
+| `auto/smart` | 🔭 品質優先 + 10% 探索以發現更好的模型 |
+
+### 🔀 或自行建立 — 17 種路由策略
+
+| 目標 | 策略 / 組合 |
+|---|---|
+| 🥇 先用完訂閱再付費 | `priority` / `fill-first` |
+| ⚖️ 在多個帳號間分散負載 | `round-robin` · `weighted` · `p2c` · `least-used` |
+| 💸 永遠選最便宜的可行模型 | `cost-optimized` · `auto/cheap` |
+| 🧠 在模型之間交接長上下文 | `context-relay` · `context-optimized` |
+| 🎲 隨機/隱私路由 | `random` · `strict-random` |
+| 🧬 分散到多個模型再綜合評判 | `fusion` |
+| 📊 依剩餘配額餘裕路由 | `reset-window` · `headroom` |
+| 🤖 讓它智慧化 | `auto`（9 因子評分）· `lkgp` · `reset-aware` |
+
+### 🧱 內建三層彈性
+
+| 層級 | 範圍 | 功能 |
+|---|---|---|
+| 🔌 **斷路器** | 整個供應商 | 停止對上游故障的供應商發送請求；自動探測恢復 |
+| 💤 **連線冷卻** | 一個帳號/金鑰 | 跳過受限的金鑰，同時其他金鑰繼續服務 |
+| 🎯 **模型鎖定** | 供應商 + 模型 | 只隔離配額受限的單一模型，不影響整個連線 |
+
+```
+組合："always-on"                         策略：priority
+  1. cc/claude-opus-4-7   ← 訂閱（充分使用）
+  2. cx/gpt-5.5           ← 第二個訂閱
+  3. glm/glm-5.1          ← 便宜備援（$0.5/1M）
+  4. kr/claude-sonnet-4.5 ← 免費、無限制（永不故障）
+結果：4 層備援 = 零停機
+```
+
+<br/>
+
+<div align="center">
+
+# 🏆 OmniRoute 與眾不同之處
+
+</div>
+
+| 功能 | OmniRoute | 其他路由器 |
+|---|---|---|
+| 🌐 供應商 | **231** | 20–100 |
+| 🆓 免費供應商 | **50+（11 個永久免費）** | 1–5 |
+| 🔀 路由策略 | **17 種** | 1–3 |
+| 🗜️ Token 壓縮 | **RTK + Caveman 疊加（15–95%）** | 無/20–40% |
+| 🧰 內建 MCP 伺服器 | **87 個工具、3 種傳輸、30 個範圍** | 少見 |
+| 🤝 A2A 代理協定 | **6 項技能、JSON-RPC 2.0** | 無 |
+| 🧠 記憶體（FTS5 + 向量） | **有** | 少見 |
+| 🛡️ 護欄（PII、注入、視覺） | **有** | 少見 |
+| ☁️ 雲端代理 | **Codex、Devin、Jules** | 無 |
+| 🥷 TLS 指紋隱匿 | **JA3/JA4 via wreq-js** | 無 |
+| 🖥️ 多平台 | **網頁 · 桌面 · Termux · PWA** | 僅網頁 |
+| 🌍 國際化 | **42 種語言** | 0–4 |
+
+<br/>
+
+<div align="center">
+
+# ✨ 最新消息
+
+</div>
+
+> **v3.8.20 → v3.8.38** 的精選更新。完整紀錄在 [`CHANGELOG.md`](CHANGELOG.md)。
+
+- **⚖️ 配額共享路由** — 依可用配額在帳號間分散負載的專用組合策略
+- **🤖 一鍵 CLI/代理設定** — `setup-*` 命令為每個編碼工具設定 OmniRoute 路由
+- **🛰️ 遠端模式** — 從任何機器使用範圍存取 Token 驅動遠端 OmniRoute
+- **🧭 更智慧的自動路由** — OpenRouter 風格的組合、Fusion 策略、任務感知路由
+- **🗜️ 可插拔壓縮** — **9 個可組合引擎**的非同步管道
+- **🕵️ 透明 MITM 解密（TPROXY）** — 擷取並轉譯忽略代理環境變數的 CLI 流量
+- **💸 無處不在的成本遙測** — 每個端點都有 `X-OmniRoute-*` 成本/用量標頭
+- **🧠 你可控制的記憶體** — 可選的 int8 向量量化
+- **🛡️ 安全性** — 所有 LLM 路由的提示注入防護
+- **🤝 更多供應商與代理** — Cursor Cloud Agent、CodeBuddy CN、新閘道器
+- **⚡ 本地效能與基礎設施** — 一鍵啟動本地 Redis、Cloudflare Workers 中繼
+
+<br/>
+
+<div align="center">
+
+# 🤖 相容的 CLI 與編碼代理
+
+</div>
+
+> 一個設定檔 — `http://localhost:20128/v1` — **每個** AI IDE 或 CLI 都能在免費與低成本模型上執行。
+
+<div align="center">
+<table>
+  <tr>
+    <td align="center" width="120"><a href="https://github.com/anthropics/claude-code"><img src="../../public/providers/claude.svg" width="52" alt="Claude Code"/><br/><b>Claude Code</b></a></td>
+    <td align="center" width="120"><a href="https://github.com/openai/codex"><img src="../../public/providers/codex.svg" width="52" alt="Codex CLI"/><br/><b>Codex CLI</b></a></td>
+    <td align="center" width="120"><a href="https://github.com/google-gemini/gemini-cli"><img src="../../public/providers/gemini-cli.svg" width="52" alt="Gemini CLI"/><br/><b>Gemini CLI</b></a></td>
+    <td align="center" width="120"><img src="../../public/providers/cursor.png" width="52" alt="Cursor"/><br/><b>Cursor</b></td>
+    <td align="center" width="120"><img src="../../public/providers/copilot.png" width="52" alt="Copilot"/><br/><b>Copilot</b></td>
+    <td align="center" width="120"><img src="../../public/providers/continue.png" width="52" alt="Continue"/><br/><b>Continue</b></td>
+  </tr>
+  <tr>
+    <td align="center" width="120"><a href="https://github.com/anomalyco/opencode"><img src="../../public/providers/opencode.svg" width="52" alt="OpenCode"/><br/><b>OpenCode</b></a></td>
+    <td align="center" width="120"><a href="https://github.com/Kilo-Org/kilocode"><img src="../../public/providers/kilocode.svg" width="52" alt="Kilo Code"/><br/><b>Kilo Code</b></a></td>
+    <td align="center" width="120"><img src="../../public/providers/droid.svg" width="52" alt="Droid"/><br/><b>Droid</b></td>
+    <td align="center" width="120"><img src="../../public/providers/openclaw.png" width="52" alt="OpenClaw"/><br/><b>OpenClaw</b></td>
+    <td align="center" width="120"><img src="../../public/providers/kiro.svg" width="52" alt="Kiro"/><br/><b>Kiro</b></td>
+    <td align="center" width="120"><img src="../../public/providers/command-code.svg" width="52" alt="Command Code"/><br/><b>Command</b></td>
+  </tr>
+</table>
+</div>
+
+<div align="center">
+<b>＋也相容於</b> · Cline · Antigravity · Windsurf · AMP · Hermes · Qwen CLI · Roo · Continue · <b>任何 OpenAI 相容工具</b>
+</div>
+
+<br/>
+
+<div align="center">
+
+# 🌐 231 個 AI 供應商 — 50+ 免費
+
+</div>
+
+> 最完整的開源路由器目錄：**231 個供應商**、**50+ 有免費方案**、**11 個永久免費**。
+
+<div align="center">
+
+### 🆓 永久免費 — $0，無需信用卡
+
+<table>
+  <tr>
+    <td align="center" width="150"><img src="https://img.shields.io/badge/AgentRouter-FF6600?style=flat-square" alt="AgentRouter"/><br/><sub>GPT-5, Claude, Gemini<br/>$100 免費額度</sub></td>
+    <td align="center" width="150"><img src="https://img.shields.io/badge/Qoder_AI-6366F1?style=flat-square" alt="Qoder AI"/><br/><sub>Kimi-K2, DeepSeek-R1<br/>無限制免費</sub></td>
+    <td align="center" width="150"><img src="https://img.shields.io/badge/Pollinations-10B981?style=flat-square" alt="Pollinations"/><br/><sub>GPT-5, Claude, Llama 4<br/>無需金鑰</sub></td>
+    <td align="center" width="150"><img src="https://img.shields.io/badge/LongCat-FF7A00?style=flat-square" alt="LongCat"/><br/><sub>Flash-Lite<br/>每天 5000 萬 Token 🔥</sub></td>
+  </tr>
+  <tr>
+    <td align="center" width="150"><img src="https://img.shields.io/badge/Cloudflare_AI-F38020?style=flat-square&logo=cloudflare&logoColor=white" alt="Cloudflare AI"/><br/><sub>50+ 模型<br/>每天 1 萬神經元</sub></td>
+    <td align="center" width="150"><img src="https://img.shields.io/badge/Gemini_CLI-8E75B2?style=flat-square&logo=googlegemini&logoColor=white" alt="Gemini CLI"/><br/><sub>gemini-3-flash<br/>每月 18 萬免費</sub></td>
+    <td align="center" width="150"><img src="https://img.shields.io/badge/NVIDIA_NIM-76B900?style=flat-square&logo=nvidia&logoColor=white" alt="NVIDIA NIM"/><br/><sub>129 個模型<br/>每分鐘約 40 次免費</sub></td>
+    <td align="center" width="150"><img src="https://img.shields.io/badge/Cerebras-F15A29?style=flat-square" alt="Cerebras"/><br/><sub>Qwen3 235B<br/>每天 100 萬 Token</sub></td>
+  </tr>
+</table>
+
+</div>
+
+<br/>
+
+<div align="center">
+
+# 🖥️ OmniRoute 執行環境 — 隨處可用
+
+</div>
+
+> 同一個應用程式、你的機器、你的規則。從全域 npm 安裝到**你的手機**（透過 Termux）。
+
+| 平台 | 安裝方式 | 亮點 |
+|---|---|---|
+| 📦 **npm（全域）** | `npm install -g omniroute` | 一條命令，任何作業系統 |
+| 🐳 **Docker** | `docker run … diegosouzapw/omniroute` | 多架構 **AMD64 + ARM64** |
+| 🖥️ **桌面（Electron）** | `npm run electron:build` | 原生視窗 + 系統匣 — **Windows / macOS / Linux** |
+| 💪 **ARM** | 原生 `arm64` | Raspberry Pi、ARM 伺服器、Apple Silicon |
+| 📱 **Android（Termux）** | `pkg install nodejs-lts && npx -y omniroute` | **在你的手機上**執行，24/7，無需 Root |
+| 📲 **PWA** | 「新增至主畫面」 | 全螢幕、離線、可從瀏覽器安裝 |
+| 🧩 **OpenCode 插件** | `@omniroute/opencode-provider` | 原生 OpenCode 整合 |
+| 🛠️ **原始碼** | `npm install && npm run dev` | 自行修改、貢獻 |
+
+<br/>
+
+<div align="center">
+
+# 🔒 私密且本地優先
+
+</div>
+
+> 你的金鑰、你的機器、你的資料。OmniRoute 是一個**本地代理** — 它永遠不會回傳資料。
+
+- 🏠 **100% 在你的硬體上執行** — npm、Docker、桌面或手機。請求路徑中沒有 OmniRoute 雲端。
+- 🔐 **憑證靜態加密** — API 金鑰和 OAuth Token 以 **AES-256-GCM** 加密保存。
+- 🚫 **預設零遙測** — 你的提示只會送到你選擇的供應商，不會送往其他地方。
+- 🛡️ **強化閘道** — API 金鑰範圍限制、IP 過濾、速率限制、提示注入防護。
+- 📜 **MIT 授權且完全開源** — 審計每一行程式碼，永遠可以自架。
+
+<br/>
+
+<div align="center">
+
+# 🔌 完整 CLI + A2A 與 MCP
+
+</div>
+
+> OmniRoute 不僅僅是一個伺服器 — 它是一個**完整的命令列駕駛艙**，擁有 **60+ 命令**，加上開放的代理協定，讓 AI 代理可以**自行**驅動 OmniRoute。
+
+### ⌨️ 真正的 CLI（不只是 `start`）
+
+```bash
+omniroute               # 提供閘道 + 儀表板服務（通訊埠 20128）
+omniroute chat          # 交談式 TUI 聊天客戶端
+omniroute setup         # 引導式首次執行精靈
+omniroute doctor        # 診斷供應商、通訊埠、原生相依性
+```
+
+### 🛰️ 遠端模式 — 在本地執行 CLI，OmniRoute 在 VPS 上
+
+OmniRoute 在伺服器上？用**相同的 CLI** 從你的筆電驅動它。使用範圍存取 Token 登入一次；之後每個命令都會指向遠端。
+
+```bash
+omniroute connect 192.168.0.15            # 密碼 → 範圍 Token，儲存為一個環境
+omniroute models list                     # 對遠端伺服器執行
+omniroute configure codex                 # 選擇遠端模型，寫入本地 Codex 設定檔
+omniroute tokens create --name ci --scope read   # 為其他機器建立更窄的 Token
+omniroute contexts use default            # 切換回本地伺服器
+```
+
+### 🤝 連接代理 — 它就能控制 OmniRoute 本身
+
+將 OmniRoute 暴露於 **MCP** 或 **A2A**，任何有能力的代理就能取得整個閘道的控制權 — 路由、供應商、組合、快取、壓縮、記憶體 — 自主運作。
+
+| 協定 | 端點 | 用途 |
+|---|---|---|
+| 🧰 **MCP（stdio）** | `omniroute --mcp` | 接入 Claude Desktop、Cursor、任何 MCP 客戶端 |
+| 🌊 **MCP（HTTP）** | `http://localhost:20128/api/mcp/stream` | 遠端 MCP — **87 個工具**、30 個範圍、完整審計軌跡 |
+| 📡 **MCP（SSE）** | `http://localhost:20128/api/mcp/sse` | 串流 MCP 傳輸 |
+| 🤝 **A2A** | `http://localhost:20128/.well-known/agent.json` | 代理間通訊，**JSON-RPC 2.0** + SSE、6 項技能 |
+
+```bash
+# 透過 MCP 將完整的 OmniRoute 工具集提供給 Claude Code：
+claude mcp add-server omniroute --type http --url http://localhost:20128/api/mcp/stream
+```
+
+<br/>
+
+<div align="center">
+
+# 🗜️ 自動節省 15–95% Token
+
+</div>
+
+> **Token 夠用就好，何必浪費？** 每個請求都會**透明地**通過 OmniRoute 的壓縮管道 — 無需修改客戶端。現在是一個**9 個可組合引擎**的堆疊，按順序執行，並可依路由組合混合搭配。
+
+### 🧱 9 引擎堆疊
+
+引擎按管道順序執行；每個引擎可獨立開關，並可依組合設定：
+
+| # | 引擎 | 功能 |
+|---|---|---|
+| 1 | **Session-Dedup** | 刪除跨輪重複的內容（內容定址、跨輪） |
+| 2 | **CCR** | 將大型區塊歸檔到檢索標記後，按需提取 |
+| 3 | **RTK** | 智慧工具結果過濾、去重與截斷（命令感知） |
+| 4 | **Headroom** | 同質 JSON 陣列的無損表格壓縮（約 30%+） |
+| 5 | **Caveman** | 基於規則的文句壓縮（輸出約 65–75%） |
+| 6 | **LLMLingua-2** | 透過 MobileBERT ONNX 進行 ML 語義修剪 — 程式碼安全、非同步 |
+| 7 | **Lite** | 空白字元 + 圖片 URL 修剪（低延遲基準） |
+| 8 | **Aggressive** | 摘要 + 舊輪次漸進式老化 |
+| 9 | **Ultra** | 啟發式 Token 修剪，可選小型模型（SLM）層 |
+
+### 🎛️ 一鍵預設
+
+| 模式 | 節省幅度 | 最佳用途 |
+|---|---|---|
+| 🪶 **Lite** | 約 15% | 永遠開啟的安全預設 |
+| 🪨 **Standard（Caveman）** | 約 30% | 日常編碼 |
+| ⚡ **Aggressive** | 約 50% | 長時間工具密集型工作階段 |
+| 🔥 **Ultra** | 約 75% | 最大節省 |
+| 🧰 **RTK** | 60–90% | Shell/測試/建置/Git 輸出 |
+| 🔗 **疊加（RTK → Caveman）** | **78–95%** | 混合提示 + 工具日誌 |
+
+<br/>
+
+<div align="center">
+
+# ⚡ 快速開始
+
+</div>
+
+**1) 安裝並執行**
+
+```bash
+npm install -g omniroute
+omniroute
+```
+
+儀表板在 `http://localhost:20128` · API 在 `http://localhost:20128/v1`。
+
+**2) 連接免費供應商（無需註冊）**
+
+儀表板 → **Providers** → 連接 **Kiro AI**（免費 Claude，每個帳號每月約 50 點）或 **OpenCode Free**（無需驗證）→ 完成。
+
+**3) 指向你的編碼工具**
+
+```txt
+Base URL: http://localhost:20128/v1
+API Key:  [從儀表板 → Endpoints 複製]
+Model:    auto（零設定智慧路由 — 或任何供應商/模型）
+```
+
+**4) 驗證是否正常運作**
+
+```bash
+curl http://localhost:20128/v1/models -H "Authorization: Bearer ***"
+```
+
+如果一切正常，你應該會看到已連接的模型列表。🎉
+
+<br/>
+
+## 📦 更多安裝方式
+
+**🐳 Docker**
+```bash
+docker run -d --name omniroute --restart unless-stopped --stop-timeout 40 \
+  -p 20128:20128 -v omniroute-data:/app/data diegosouzapw/omniroute:latest
+```
+
+**🛠️ 從原始碼**
+```bash
+cp .env.example .env && npm install
+PORT=20128 npm run dev
+```
+
+**📦 pnpm**
+```bash
+pnpm install -g omniroute && pnpm approve-builds -g && omniroute
+```
+
+**🐧 Arch Linux（AUR）**
+```bash
+yay -S omniroute-bin && systemctl --user enable --now omniroute.service
+```
+
+<br/>
+
+<div align="center">
+
+# 🎬 OmniRoute 實際展示
+
+</div>
+
+<div align="center">
+<table>
+  <tr>
+    <td align="center" width="280">
+      <a href="https://www.youtube.com/watch?v=Rxdc36yUyOQ"><img src="https://img.youtube.com/vi/Rxdc36yUyOQ/maxresdefault.jpg" alt="葡萄牙語指南" width="260"/></a><br/>
+      <b>🇧🇷 Português</b><br/><sub>完整指南</sub>
+    </td>
+    <td align="center" width="280">
+      <a href="https://www.youtube.com/watch?v=CMzyOiUyEVc"><img src="https://img.youtube.com/vi/CMzyOiUyEVc/maxresdefault.jpg" alt="English Guide" width="260"/></a><br/>
+      <b>🇺🇸 English</b><br/><sub>Complete walkthrough</sub>
+    </td>
+    <td align="center" width="280">
+      <a href="https://www.youtube.com/watch?v=il_5Ii6v4-Y"><img src="https://img.youtube.com/vi/il_5Ii6v4-Y/maxresdefault.jpg" alt="俄語指南" width="260"/></a><br/>
+      <b>🇷🇺 Русский</b><br/><sub>Полное руководство</sub>
+    </td>
+  </tr>
+</table>
+</div>
+
+<br/>
+
+<div align="center">
+
+# 📚 探索更多
+
+</div>
+
+<details>
+<summary><b>💰 價格一覽與 $0 免費堆疊</b></summary>
+
+<br/>
+
+| 層級 | 範例 | 費用 |
+|---|---|---|
+| 💳 **訂閱制** | Claude Code Pro / Codex / Copilot | $10–200/月 |
+| 🔑 **API 金鑰（免費方案）** | NVIDIA NIM、Cerebras、Groq | **免費** |
+| 💰 **便宜方案** | GLM-5 $0.5/1M · MiniMax M2.5 $0.3/1M | 極低 |
+| 🆓 **永久免費** | Kiro、Qoder、Qwen、Pollinations、LongCat | **$0** |
+
+**$0 免費堆疊 — 組合成一個牢不可破的組合：**
+
+| 供應商 | 字首 | 免費模型 | 配額 |
+|---|---|---|---|
+| **Kiro** | `kr/` | Claude Sonnet 4.5、Haiku 4.5、Opus 4.6 | 每月 50 點 |
+| **Qoder** | `if/` | kimi-k2-thinking、qwen3-coder-plus、deepseek-r1 | ♾️ 無限制 |
+| **Qwen** | `qw/` | qwen3-coder-plus/flash/next | ♾️ 無限制 |
+| **Pollinations** | `pol/` | GPT-5、Claude、Gemini、DeepSeek、Llama 4 | 無需金鑰 |
+| **LongCat** | `lc/` | LongCat-Flash-Lite | 每天 5000 萬 Token 🔥 |
+| **Cloudflare AI** | `cf/` | 50+ 模型 | 每天 1 萬神經元 |
+| **NVIDIA NIM** | `nvidia/` | 129 個模型 | 每分鐘約 40 次 |
+| **Cerebras** | `cerebras/` | Qwen3 235B、GPT-OSS 120B | 每天 100 萬 Token |
+
+</details>
+
+<details>
+<summary><b>🎯 使用案例 — 現成組合策略</b></summary>
+
+<br/>
+
+**永久免費：**
+```
+1. kr/claude-sonnet-4.5   (Kiro — 每月約 50 點)
+2. if/kimi-k2-thinking    (Qoder — 無限制)
+3. pol/gpt-5              (Pollinations — 無需金鑰)
+4. lc/longcat-flash-lite  (每天 5000 萬 Token 備援)
+壓縮：aggressive（約 50%）→ 免費配額翻倍 · 費用：$0/月
+```
+
+**24/7 不中斷：** 串聯 2 個訂閱 → 便宜方案 → 免費方案，共 5 層備援。
+**被封鎖地區：** 免費供應商 + 全域/每供應商代理 → 從任何國家存取 AI。
+**最大節省：** 訂閱 + 便宜備援 + `ultra` 壓縮（約 75%）→ 重度使用者每月約省 $150–300。
+
+</details>
+
+<details>
+<summary><b>🌍 繞過地理封鎖 — 3 層代理 + 隱匿</b></summary>
+
+<br/>
+
+在被封鎖的地區？OmniRoute 的 **3 層代理**（全域/每供應商/每連線）代理 API 請求、OAuth 流程、連線測試、Token 刷新和模型同步。
+
+- **協定：** HTTP/HTTPS、SOCKS5、認證代理
+- **🆓 1proxy 市集** — 數百個經過驗證的免費代理、品質評分、自動輪換
+- **反偵測：** TLS 指紋偽裝（`wreq-js`）、CLI 指紋比對、代理 IP 保留
+
+</details>
+
+<details>
+<summary><b>✨ 完整功能列表</b></summary>
+
+<br/>
+
+**路由：** 15 種策略 · 任務感知智慧路由 · 思考預算控制 · 萬用字元路由 · 系統提示注入。
+**相容性：** OpenAI ↔ Claude ↔ Gemini ↔ Responses API · 自動 OAuth 刷新（PKCE、8 個供應商）· 多帳號輪詢 · Batch + Files API · 即時 OpenAPI 3.0。
+**協定：** MCP（87 個工具、3 種傳輸、30 個範圍）· A2A（JSON-RPC 2.0、SSE、6 項技能）· ACP · 雲端代理（Codex、Devin、Jules）。
+**插件：** 自訂插件市集 · 安裝/啟用/停用 · Notion + Obsidian 知識庫整合。
+**品質與維運：** 內建 **Evals**（金標準集）· 護欄（PII、注入、視覺）· 健康儀表板 · p50/p95/p99 遙測 · Webhooks · 合規審計。
+**AI 代理技能：** 可直接載入的 Markdown 清單 — 將任何代理指向 `skills/*/SKILL.md`。提供 43 項技能。
+
+</details>
+
+<details>
+<summary><b>📖 設定、環境變數與常見問題</b></summary>
+
+<br/>
+
+| 環境變數 | 預設值 | 用途 |
+|---|---|---|
+| `PORT` | `20128` | API + 儀表板通訊埠 |
+| `REQUIRE_API_KEY` | `false` | 要求所有請求提供 API 金鑰 |
+| `DATA_DIR` | `~/.omniroute` | 資料庫與設定儲存位置 |
+
+**OmniRoute 會向我收費嗎？** 不會 — 它是免費、開源的軟體，執行在你的機器上。你只直接付費給付費供應商。OmniRoute 沒有計費系統。
+**免費供應商真的無限制嗎？** 大多如此 — Qoder、Pollinations、LongCat 和 Cloudflare 免費且無帳號信用上限。在組合中堆疊多個免費供應商，自動備援讓你能以 $0 持續使用。
+**壓縮會影響品質嗎？** 不會 — 它只壓縮**輸入**；程式碼、URL、JSON 始終受到保護。
+**在 AI 被封鎖的地方能運作嗎？** 可以 — 3 層代理 + 1proxy 市集可觸及全部 231 個供應商。
+
+</details>
+
+<details>
+<summary><b>🐛 故障排除</b></summary>
+
+<br/>
+
+| 問題 | 快速解決方案 |
+|---|---|
+| 「Language model did not provide messages」 | 供應商配額耗盡 → 使用組合備援 |
+| 速率限制（429） | 加入備援供應商 |
+| OAuth Token 過期 | 自動刷新；若卡住，在供應商頁面刪除並重新認證 |
+| `unsupported_country_region_territory` | 在設定 → Proxy 中設定代理 |
+| Docker SQLite 鎖定 | 使用 `--stop-timeout 40` 確保乾淨的 WAL 檢查點 |
+| Node 執行時期錯誤 | 使用 Node `>=22.0.0 <23` 或 `>=24.0.0 <27` |
+
+</details>
+
+<details>
+<summary><b>📸 儀表板截圖</b></summary>
+
+<br/>
+
+| 頁面 | 截圖 | 頁面 | 截圖 |
+|---|---|---|---|
+| Providers | ![Providers](docs/screenshots/01-providers.png) | Combos | ![Combos](docs/screenshots/02-combos.png) |
+| Analytics | ![Analytics](docs/screenshots/03-analytics.png) | Health | ![Health](docs/screenshots/04-health.png) |
+| Translator | ![Translator](docs/screenshots/05-translator.png) | Settings | ![Settings](docs/screenshots/06-settings.png) |
+| CLI Tools | ![CLI Tools](docs/screenshots/07-cli-tools.png) | Usage Logs | ![Usage](docs/screenshots/08-usage.png) |
+
+</details>
+
+<br/>
+
+<div align="center">
+
+# 📧 支援與社群
+
+</div>
+
+> 💬 **與社群聊天** — Discord、Telegram 和 WhatsApp 連結在 [本 README 頂部](#-join-the-community)。
+
+- 🌍 **網站**：[omniroute.online](https://omniroute.online)
+- 🐙 **GitHub**：[github.com/diegosouzapw/OmniRoute](https://github.com/diegosouzapw/OmniRoute)
+- 🐛 **問題回報**：[回報錯誤](https://github.com/diegosouzapw/OmniRoute/issues)（請附上 `npm run system-info` 輸出）
+- 🤝 **貢獻**：詳細指南請見 [CONTRIBUTING.md](CONTRIBUTING.md)
+
+</div>
+
+---
+
+<br/>
+
+<div align="center">
+
+## 🛠️ 技術堆疊
+
+</div>
+
+- **執行時期**：Node.js 22.x 或 24.x LTS（建議 24 LTS）
+- **語言**：TypeScript 6.0 — `src/` 和 `open-sse/` **100% TypeScript**（自 v2.0 起核心模組零 `any`）
+- **框架**：Next.js 16 + React 19 + Tailwind CSS 4
+- **資料庫**：better-sqlite3（SQLite）+ LowDB（JSON 舊版）
+- **Schema**：Zod（MCP 工具 I/O 驗證、API 合約）
+- **協定**：MCP（stdio/HTTP）+ A2A v0.3（JSON-RPC 2.0 + SSE）
+- **串流**：Server-Sent Events（SSE）+ WebSocket 橋接（`/v1/ws`）
+- **認證**：OAuth 2.0（PKCE）+ JWT + API 金鑰 + MCP 範圍授權
+- **測試**：Node.js 測試執行器 + Vitest（**14,965 個測試案例**，涵蓋 517 個檔案）
+- **平台**：桌面（Electron）、Android（Termux）、PWA（任何瀏覽器）
+- **CI/CD**：GitHub Actions（發布時自動發佈 npm + Docker Hub）
+
+<div align="center">
+
+<br/>
+
+## 📖 文件
+
+</div>
+
+### 📘 入門指南
+
+| 文件 | 說明 |
+|---|---|
+| [使用者指南](docs/guides/USER_GUIDE.md) | 供應商、組合、CLI 整合、部署 |
+| [設定指南](docs/guides/SETUP_GUIDE.md) | 完整安裝方法、CLI 工具設定、協定設定 |
+| [CLI 工具指南](docs/reference/CLI-TOOLS.md) | 每個工具的設定方式 |
+| [遠端模式](docs/guides/REMOTE-MODE.md) | 從筆電 CLI 驅動遠端 OmniRoute |
+| [快速開始](README.md#-quick-start) | 3 步驟安裝 → 連接 → 設定 |
+
+### 🔧 維運與部署
+
+| 文件 | 說明 |
+|---|---|
+| [Docker 指南](docs/guides/DOCKER_GUIDE.md) | Docker 執行、Compose 設定檔、Caddy HTTPS |
+| [VM 部署](docs/ops/VM_DEPLOYMENT_GUIDE.md) | 完整指南：VM + nginx + Cloudflare 設定 |
+| [Termux 指南](docs/guides/TERMUX_GUIDE.md) | 在 Android 上透過 Termux 執行 OmniRoute |
+| [環境設定](docs/reference/ENVIRONMENT.md) | 完整的 `.env` 變數與參考 |
+
+### 🧠 功能與架構
+
+| 文件 | 說明 |
+|---|---|
+| [架構](docs/architecture/ARCHITECTURE.md) | 系統架構、資料流程與內部原理 |
+| [壓縮指南](docs/compression/COMPRESSION_GUIDE.md) | 7 種壓縮選項 |
+| [彈性指南](docs/architecture/RESILIENCE_GUIDE.md) | 斷路器、冷卻、佇列 |
+| [自動組合引擎](docs/routing/AUTO-COMBO.md) | 9 因子評分、模式套件、自我修復 |
+| [免費方案](docs/reference/FREE_TIERS.md) | 25+ 免費 API 供應商目錄 |
+
+### 🤖 協定與 API
+
+| 文件 | 說明 |
+|---|---|
+| [API 參考](docs/reference/API_REFERENCE.md) | 所有端點與範例 |
+| [MCP 伺服器](docs/frameworks/MCP-SERVER.md) | 87 個 MCP 工具、IDE 設定 |
+| [A2A 伺服器](docs/frameworks/A2A-SERVER.md) | A2A 代理卡片、任務、技能 |
+
+### 📋 專案與品質
+
+| 文件 | 說明 |
+|---|---|
+| [貢獻指南](CONTRIBUTING.md) | 開發設定與指引 |
+| [更新紀錄](CHANGELOG.md) | 完整版本歷史 |
+| [安全政策](SECURITY.md) | 漏洞回報與安全實務 |
+
+<br/>
+
+<div align="center">
+
+# ⭐ 頂級貢獻者
+
+</div>
+
+> OmniRoute 由充滿熱情的開源社群塑造。這些人做出了卓越貢獻，直接影響了專案的品質、穩定性和影響力。**謝謝你們。**
+
+感謝所有貢獻者 — 每個 PR、每個測試案例、每個 i18n 翻譯檔案都很重要。開源是由像他們這樣的人建立的。
+
+</div>
+
+---
+
+<br/>
+
+<div align="center">
+
+## 👥 貢獻者
+
+</div>
+
+[![Contributors](https://contrib.rocks/image?repo=diegosouzapw/OmniRoute&max=100&columns=20&anon=1)](https://github.com/diegosouzapw/OmniRoute/graphs/contributors)
+
+### 如何貢獻
+
+1. Fork 此儲存庫
+2. 建立你的功能分支（`git checkout -b feature/amazing-feature`）
+3. 提交你的變更（`git commit -m 'Add amazing feature'`）
+4. 推送到分支（`git push origin feature/amazing-feature`）
+5. 開啟 Pull Request
+
+詳細指引請見 [CONTRIBUTING.md](CONTRIBUTING.md)。
+
+<br/>
+
+<div align="center">
+
+## 🙏 致謝
+
+</div>
+
+OmniRoute 站在巨人的肩膀上。每個子系統都是受到先行者的開源專案啟發。
+
+> ⭐ 以下為 2026 年 6 月的星星數 — 去給這些專案一顆星吧。
+
+### 🧬 源起與閘道
+
+| 專案 | ⭐ | 啟發 |
+|---|---|---|
+| **[9router](https://github.com/decolua/9router)** · decolua | 17.9k | 本 fork 的原始專案 |
+| **[CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI)** · router-for-me | 37.8k | 啟發此 JS/TS 移植的 Go 實作 |
+| **[LiteLLM](https://github.com/BerriAI/litellm)** · BerriAI | 50.8k | 公開定價資料集與供應商標準化模型 |
+
+### 🗜️ 上下文與 Token 壓縮 — 引擎
+
+| 專案 | ⭐ | 啟發 |
+|---|---|---|
+| **[Caveman](https://github.com/JuliusBrussee/caveman)** · JuliusBrussee | 74.5k | 「Token 夠用就好」哲學 |
+| **[RTK](https://github.com/rtk-ai/rtk)** · rtk-ai | 63.6k | 高效能命令輸出壓縮 |
+| **[Headroom](https://github.com/chopratejas/headroom)** · chopratejas | 33.6k | 可逆上下文壓縮 |
+| **[LLMLingua](https://github.com/microsoft/LLMLingua)** · Microsoft | 6.3k | 提示壓縮研究 |
+| **[Ponytail](https://github.com/DietrichGebert/ponytail)** · DietrichGebert | 51.4k | 「懶惰資深開發者」YAGNI 編碼技能 |
+
+### 🧠 記憶體與 RAG
+
+| 專案 | ⭐ | 啟發 |
+|---|---|---|
+| **[Mem0](https://github.com/mem0ai/mem0)** · mem0ai | 58.9k | 通用記憶層 |
+| **[Letta (MemGPT)](https://github.com/letta-ai/letta)** · letta-ai | 23.4k | 有狀態代理與分層記憶 |
+
+### 📄 授權
+
+MIT License — 詳見 [LICENSE](LICENSE)。
+
+---
+
+<div align="center">
+
+**[⬆ 回到頂部](#-omniroute)** · 用 ❤️ 為開源 AI 社群打造。
+
+<sub>OmniRoute v3.8.38 · Node ≥22.0.0 · MIT License · <a href="https://omniroute.online">omniroute.online</a></sub>
+
+</div>

--- a/docs/i18n/zh-TW/README.md
+++ b/docs/i18n/zh-TW/README.md
@@ -22,7 +22,7 @@
 
 [![231 個 AI 供應商](https://img.shields.io/badge/231-AI_Providers-6C5CE7?style=for-the-badge)](#-231-ai-providers--50-free)
 [![50+ 免費](https://img.shields.io/badge/50%2B-Free_Tiers-00B894?style=for-the-badge)](#-231-ai-providers--50-free)
-[![16 億免費 Token/月](https://img.shields.io/badge/1.6B-Free_Tokens%2Fmo-00B894?style=for-the-badge)](docs/reference/FREE_TIERS.md)
+[![16 億免費 Token/月](https://img.shields.io/badge/1.6B-Free_Tokens%2Fmo-00B894?style=for-the-badge)](../../reference/FREE_TIERS.md)
 [![節省高達 95% Token](https://img.shields.io/badge/up_to_95%25-Token_Savings-E17055?style=for-the-badge)](#%EF%B8%8F-save-1595-tokens--automatically)
 [![17 種路由策略](https://img.shields.io/badge/17-Routing_Strategies-0984E3?style=for-the-badge)](#-combos--the-flagship)
 [![從 $0 開始](https://img.shields.io/badge/%240-To_Start-FDCB6E?style=for-the-badge&logoColor=black)](#-quick-start)

--- a/docs/i18n/zh-TW/README.md
+++ b/docs/i18n/zh-TW/README.md
@@ -70,7 +70,7 @@
 <b>🌐 提供 41+ 種語言</b>
 <table>
   <tr>
-    <td align="center"><a href="../../README.md">🇺🇸</a></td>
+    <td align="center"><a href="../../../README.md">🇺🇸</a></td>
     <td align="center"><a href="../pt-BR/README.md">🇧🇷</a></td>
     <td align="center"><a href="../es/README.md">🇪🇸</a></td>
     <td align="center"><a href="../fr/README.md">🇫🇷</a></td>


### PR DESCRIPTION
## Summary

This PR adds **Traditional Chinese (zh-TW)** documentation and updates the existing **Simplified Chinese (zh-CN)** README to match the current English v3.8.38 version.

### Changes

| File | Action | Description |
|------|--------|-------------|
| `docs/i18n/zh-TW/README.md` | **New** | Full Traditional Chinese translation of current README (868 lines) |
| `docs/i18n/zh-CN/README.md` | **Updated** | Replaced outdated version with current README translation (563 lines) |
| `docs/i18n/README.md` | **Updated** | Added zh-TW to language index |
| `README.md` | **Updated** | Added zh-TW (🇹🇼) to language selector table (now 41+ languages) |

### Notes
- All code blocks, URLs, badges, and image paths preserved identical to English version
- zh-TW uses Taiwanese Traditional Chinese terminology (閘道器, 供應商, 備援, 儀表板)
- zh-CN uses Simplified Chinese terminology (网关, 供应商, 故障转移, 仪表板)