### PR TITLE
fix: respect HOSTNAME env var in serve.mjs

### DIFF
--- a/bin/cli/commands/serve.mjs
+++ b/bin/cli/commands/serve.mjs
@@ -49,6 +49,7 @@ export async function runServe(opts = {}) {
   const port = parsePort(opts.port ?? process.env.PORT ?? "20128", 20128);
   const apiPort = parsePort(process.env.API_PORT ?? String(port), port);
   const dashboardPort = parsePort(process.env.DASHBOARD_PORT ?? String(port), port);
+  const hostname = process.env.HOSTNAME || "0.0.0.0";
   const noOpen = opts.open === false;
 
   console.log(`
@@ -136,7 +137,7 @@ export async function runServe(opts = {}) {
     PORT: String(dashboardPort),
     DASHBOARD_PORT: String(dashboardPort),
     API_PORT: String(apiPort),
-    HOSTNAME: "0.0.0.0",
+    HOSTNAME: hostname,
     NODE_ENV: "production",
     NODE_OPTIONS: `--max-old-space-size=${memoryLimit}`,
   };


### PR DESCRIPTION
## Bug

`bin/cli/commands/serve.mjs` line 139 hardcodes `HOSTNAME: "0.0.0.0"`, overriding the user's `.env` value.

The spread `...process.env` on line 134 comes BEFORE the hardcoded value, so `HOSTNAME` from `.env` is always silently overridden.

## Impact

Users setting `HOSTNAME=127.0.0.1` in `~/.omniroute/.env` expect loopback binding. Server binds to `0.0.0.0` on all interfaces.

## Reproduce

```bash
echo "HOSTNAME=127.0.0.1" >> ~/.omniroute/.env
omniroute serve --daemon
ss -tlnp | grep 20128
# Shows 0.0.0.0:20128 instead of 127.0.0.1:20128
```

## Fix

```diff
-    HOSTNAME: "0.0.0.0",
+    HOSTNAME: process.env.HOSTNAME || "0.0.0.0",
```

`HOSTNAME` is already documented in `.env.example` and `docs/reference/ENVIRONMENT.md` but was never respected at runtime.

Closes #5134