### PR TITLE
fix(serve): honour HOSTNAME from .env instead of hardcoding 0.0.0.0 (#5134)

### DIFF
--- a/bin/cli/commands/serve.mjs
+++ b/bin/cli/commands/serve.mjs
@@ -136,7 +136,7 @@ export async function runServe(opts = {}) {
     PORT: String(dashboardPort),
     DASHBOARD_PORT: String(dashboardPort),
     API_PORT: String(apiPort),
-    HOSTNAME: "0.0.0.0",
+    HOSTNAME: process.env.HOSTNAME || "0.0.0.0",
     NODE_ENV: "production",
     NODE_OPTIONS: `--max-old-space-size=${memoryLimit}`,
   };

--- a/tests/unit/cli-serve-hostname.test.ts
+++ b/tests/unit/cli-serve-hostname.test.ts
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+/**
+ * Replicate the HOSTNAME resolution from bin/cli/commands/serve.mjs to verify
+ * that the spawned server honours a HOSTNAME provided via env/.env instead of
+ * always hardcoding "0.0.0.0" (#5134). Mirrors the in-file replication pattern
+ * used by cli-serve-port.test.ts (serve.mjs spawns processes, so the logic is
+ * tested in isolation rather than imported).
+ */
+function resolveHostname(envHostname: string | undefined): string {
+  return envHostname || "0.0.0.0";
+}
+
+test("serve hostname: honours HOSTNAME env var when set", () => {
+  assert.equal(resolveHostname("127.0.0.1"), "127.0.0.1");
+});
+
+test("serve hostname: honours a specific bind interface", () => {
+  assert.equal(resolveHostname("192.168.0.15"), "192.168.0.15");
+});
+
+test("serve hostname: falls back to 0.0.0.0 when HOSTNAME is unset", () => {
+  assert.equal(resolveHostname(undefined), "0.0.0.0");
+});
+
+test("serve hostname: falls back to 0.0.0.0 when HOSTNAME is an empty string", () => {
+  assert.equal(resolveHostname(""), "0.0.0.0");
+});


### PR DESCRIPTION
## Summary

Fixes #5134.

`bin/cli/commands/serve.mjs` spreads `...process.env` into the child-process env at line 134 but then immediately overwrites `HOSTNAME` with a hardcoded `"0.0.0.0"` at line 139. Any `HOSTNAME` value set in `~/.omniroute/.env` (which IS documented in `.env.example` and `docs/reference/ENVIRONMENT.md`) was silently discarded at runtime.

## Change

```diff
-    HOSTNAME: "0.0.0.0",
+    HOSTNAME: process.env.HOSTNAME || "0.0.0.0",
```

`dist/server.js` already reads `process.env.HOSTNAME` correctly — only the CLI wrapper was overriding it.

## Impact

Users on VPS / public-facing machines who set `HOSTNAME=127.0.0.1` in their `.env` to bind loopback-only will now get the expected binding instead of `0.0.0.0` on all interfaces.