### PR TITLE
fix(sse): normalize array user content for Command Code (#5166)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 _In development — bullets added per PR; finalized at release._
 
+### 🔧 Bug Fixes
+
+- **fix(sse): normalize array user-message content in the Command Code executor to prevent upstream 400** — when a client sends a user turn whose `content` is an array of content parts (e.g. `[{type:"text",text:"…"}, …]`), the raw array was forwarded verbatim to the Command Code upstream, which requires `messages[N].content` for the `user` role to be a plain string — resulting in `expected string, received array` / HTTP 400 on DeepSeek V4-Pro and other Command Code models. The user branch of `convertMessages` now calls `normalizeContentText()` (already used by system, assistant, and tool branches) so multi-part user content is joined to a string before dispatch. Partially addresses ([#5166](https://github.com/diegosouzapw/OmniRoute/issues/5166)); the 0-output-token symptom on reasoning-only models is tracked separately.
+
 ---
 
 ## [3.8.38] — 2026-06-27

--- a/open-sse/executors/commandCode.ts
+++ b/open-sse/executors/commandCode.ts
@@ -95,7 +95,7 @@ function convertMessages(messages: unknown): { system: string; messages: unknown
     }
 
     if (role === "user") {
-      out.push({ role: "user", content: message.content ?? "" });
+      out.push({ role: "user", content: normalizeContentText(message.content) });
       continue;
     }
 

--- a/tests/unit/command-code-user-array-5166.test.ts
+++ b/tests/unit/command-code-user-array-5166.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Regression test for #5166 (user-content-array 400 on Command Code / deepseek-v4-pro).
+ *
+ * When a client sends a user message whose `content` is an array of content parts
+ * (e.g. [{type:"text",text:"Hello"},{type:"text",text:"World"}]), the raw array
+ * must NOT reach the Command Code upstream — it requires user content to be a plain
+ * string. The executor must normalise the array to a string before posting.
+ *
+ * NOTE: this file covers ONLY the user-content-array/400 symptom of #5166.
+ * The 0-output-token symptom on mimo-v2.5-pro (reasoning-only models) is tracked
+ * separately and is NOT addressed here.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(
+  path.join(os.tmpdir(), "omniroute-cmd-code-user-array-5166-")
+);
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const { getExecutor } = await import("../../open-sse/executors/index.ts");
+const core = await import("../../src/lib/db/core.ts");
+
+const originalFetch = globalThis.fetch;
+
+function commandCodeStream(lines: unknown[]) {
+  const text = lines.map((l) => JSON.stringify(l)).join("\n") + "\n";
+  return new Response(text, { status: 200, headers: { "Content-Type": "application/x-ndjson" } });
+}
+
+test.after(() => {
+  globalThis.fetch = originalFetch;
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test.afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+// ── helpers ────────────────────────────────────────────────────────────────────
+
+type FetchCall = { url: string; init: Record<string, unknown>; body: Record<string, unknown> };
+
+function captureFetch(response: Response) {
+  const calls: FetchCall[] = [];
+  globalThis.fetch = async (url, init: RequestInit = {}) => {
+    calls.push({ url: String(url), init: init as Record<string, unknown>, body: JSON.parse(String(init.body)) });
+    return response;
+  };
+  return calls;
+}
+
+// ── failing tests (before fix, user content is the raw array) ──────────────
+
+test(
+  "#5166 user message with multi-part array content is flattened to a string (#5166)",
+  async () => {
+    const calls = captureFetch(
+      commandCodeStream([{ type: "text-delta", text: "ok" }, { type: "finish" }])
+    );
+
+    await getExecutor("command-code").execute({
+      model: "deepseek/deepseek-v4-pro",
+      stream: false,
+      credentials: { apiKey: "cc_test_key" },
+      body: {
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "Hello" },
+              { type: "text", text: "World" },
+            ],
+          },
+        ],
+      },
+    });
+
+    const posted = calls[0].body;
+    const userMsg = (posted.params as Record<string, unknown[]>).messages[0] as Record<
+      string,
+      unknown
+    >;
+
+    // Must be a string — never an array — otherwise Command Code's upstream returns 400.
+    assert.equal(
+      typeof userMsg.content,
+      "string",
+      `user message content must be a string, got ${typeof userMsg.content}`
+    );
+    // Joined text parts with "\n"
+    assert.equal(userMsg.content, "Hello\nWorld");
+  }
+);
+
+test(
+  "#5166 user message with single text-part array is flattened to a plain string",
+  async () => {
+    const calls = captureFetch(
+      commandCodeStream([{ type: "text-delta", text: "ok" }, { type: "finish" }])
+    );
+
+    await getExecutor("command-code").execute({
+      model: "deepseek/deepseek-v4-pro",
+      stream: false,
+      credentials: { apiKey: "cc_test_key" },
+      body: {
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "Hi there" }],
+          },
+        ],
+      },
+    });
+
+    const posted = calls[0].body;
+    const userMsg = (posted.params as Record<string, unknown[]>).messages[0] as Record<
+      string,
+      unknown
+    >;
+    assert.equal(typeof userMsg.content, "string");
+    assert.equal(userMsg.content, "Hi there");
+  }
+);
+
+test(
+  "#5166 user message with plain string content passes through unchanged (no regression)",
+  async () => {
+    const calls = captureFetch(
+      commandCodeStream([{ type: "text-delta", text: "ok" }, { type: "finish" }])
+    );
+
+    await getExecutor("command-code").execute({
+      model: "deepseek/deepseek-v4-pro",
+      stream: false,
+      credentials: { apiKey: "cc_test_key" },
+      body: {
+        messages: [
+          {
+            role: "user",
+            content: "Plain string message",
+          },
+        ],
+      },
+    });
+
+    const posted = calls[0].body;
+    const userMsg = (posted.params as Record<string, unknown[]>).messages[0] as Record<
+      string,
+      unknown
+    >;
+    assert.equal(typeof userMsg.content, "string");
+    assert.equal(userMsg.content, "Plain string message");
+  }
+);
+
+test(
+  "#5166 user message with mixed parts (text + image_url) keeps only text parts",
+  async () => {
+    const calls = captureFetch(
+      commandCodeStream([{ type: "text-delta", text: "ok" }, { type: "finish" }])
+    );
+
+    await getExecutor("command-code").execute({
+      model: "deepseek/deepseek-v4-pro",
+      stream: false,
+      credentials: { apiKey: "cc_test_key" },
+      body: {
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "Describe this:" },
+              { type: "image_url", image_url: { url: "https://example.com/img.png" } },
+            ],
+          },
+        ],
+      },
+    });
+
+    const posted = calls[0].body;
+    const userMsg = (posted.params as Record<string, unknown[]>).messages[0] as Record<
+      string,
+      unknown
+    >;
+    assert.equal(typeof userMsg.content, "string");
+    // Only text parts extracted; image_url part is dropped (not a "text" type)
+    assert.equal(userMsg.content, "Describe this:");
+  }
+);


### PR DESCRIPTION
Partially addresses #5166 (the user-content-array / HTTP 400 symptom). The 0-output-token symptom on `mimo-v2.5-pro` (reasoning-only models) is tracked separately and is **NOT** addressed here.

## Root cause

`convertMessages` in `open-sse/executors/commandCode.ts` (line 98) passed `message.content` verbatim for the `user` role:

```ts
out.push({ role: "user", content: message.content ?? "" });
```

When a client (Zoo Code / Command Code IDE, Claude Code multi-part turns) sends a user message whose `content` is an array of content parts (`[{type:"text",text:"…"}, ...]`), the raw array reached the Command Code upstream, which requires `messages[N].content` for the `user` role to be a **plain string** — producing:

```
expected string, received array at params.messages[N].content  →  HTTP 400
```

The `system`, `assistant`, and `tool` branches already called `normalizeContentText()` to flatten arrays. Only the `user` branch skipped it.

## Fix

One-line change: call `normalizeContentText(message.content)` in the `user` branch (same helper already used by every other branch). The helper joins `type==="text"` parts with `"\n"` and passes plain strings through unchanged.

## TDD evidence

New regression test: `tests/unit/command-code-user-array-5166.test.ts` (4 cases):

| test | before fix | after fix |
|------|-----------|-----------|
| multi-part array (`["Hello","World"]`) → `"Hello\nWorld"` | FAIL (`object !== string`) | PASS |
| single text-part array → `"Hi there"` | FAIL | PASS |
| plain string passthrough (no regression) | PASS | PASS |
| mixed parts (text + image_url) → text only | FAIL | PASS |

Full existing test suite (`command-code-executor.test.ts` + `executor-command-code.test.ts`): **17/17 pass**, no regressions.

## Files changed

- `open-sse/executors/commandCode.ts` — 1-line fix in `convertMessages` user branch
- `tests/unit/command-code-user-array-5166.test.ts` — 4 regression tests (new file)
- `CHANGELOG.md` — v3.8.39 Bug Fixes entry