### PR TITLE
fix(dashboard): use amber for home update-step warning icon

### DIFF
--- a/src/app/(dashboard)/dashboard/HomePageClient.tsx
+++ b/src/app/(dashboard)/dashboard/HomePageClient.tsx
@@ -842,7 +842,7 @@ export default function HomePageClient({ machineId }: HomePageClientProps) {
                         error
                       </span>
                     ) : (
-                      <span className="material-symbols-outlined text-yellow-500 text-[18px]">
+                      <span className="material-symbols-outlined text-amber-500 text-[18px]">
                         warning
                       </span>
                     )}

--- a/tests/unit/ui/home-update-step-warning-color-amber.test.ts
+++ b/tests/unit/ui/home-update-step-warning-color-amber.test.ts
@@ -1,0 +1,41 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+// Regression guard for the escalated mesh report "Nobody solve this color issue 🤫":
+// the update-step status icon for the `warning` state used a bare `text-yellow-500`
+// (Tailwind #eab308, no dark: variant) while its `done`/`failed` siblings use the
+// vivid `text-green-500` / `text-red-500`. yellow-500 has poor contrast on light
+// backgrounds (~1.9:1, fails WCAG) and is inconsistent with the project's warning
+// convention, which is `amber` everywhere else in this same component (e.g. the
+// `bg-amber-500/10 text-amber-500` badge). The warning icon must use amber, not yellow.
+
+const here = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(
+  resolve(here, "../../../src/app/(dashboard)/dashboard/HomePageClient.tsx"),
+  "utf8"
+);
+
+// Isolate the update-step status-icon block: the `warning` material symbol icon span.
+// Match the className on the span immediately preceding the `warning` glyph.
+const warningIconMatch = source.match(
+  /className="material-symbols-outlined ([^"]*)"[^>]*>\s*warning\s*</
+);
+
+test("update-step warning icon renders with an amber color, not bare yellow", () => {
+  assert.ok(
+    warningIconMatch,
+    "expected to find the update-step `warning` material-symbols icon span in HomePageClient.tsx"
+  );
+  const className = warningIconMatch![1];
+  assert.ok(
+    className.includes("text-amber-500"),
+    `warning icon should use the project's amber warning convention; got: "${className}"`
+  );
+  assert.ok(
+    !className.includes("text-yellow-500"),
+    "warning icon must not use the low-contrast bare `text-yellow-500` (no dark variant, fails WCAG on light backgrounds)"
+  );
+});


### PR DESCRIPTION
## Causa
The update-step status icon for the `warning` state in the home dashboard (`HomePageClient.tsx:845`) used a bare `text-yellow-500` (Tailwind #eab308, no `dark:` variant). It has poor contrast on light backgrounds (~1.9:1, fails WCAG) and is inconsistent with its `done`/`failed` siblings (`text-green-500`/`text-red-500`) and with the project's `amber` warning convention used everywhere else in the same component.

## Fix
Swap `text-yellow-500` → `text-amber-500` for the warning icon (1-line className change). No behavior change beyond color.

## TDD (red → green)
Added `tests/unit/ui/home-update-step-warning-color-amber.test.ts` (source-scan regression guard, this repo's UI-regression pattern). It fails on `text-yellow-500` and passes on `text-amber-500`.

```
✔ update-step warning icon renders with an amber color, not bare yellow
```

- lint: 0 errors
- typecheck:core: clean

## Origin
Reported via the community mesh (WhatsApp World): "Nobody solve this color issue" — a hard-to-read yellow warning icon on the home dashboard.
