### PR TITLE
fix(cli): force NODE_ENV to match dev/start run mode in custom Next server

### DIFF
--- a/scripts/dev/run-next.mjs
+++ b/scripts/dev/run-next.mjs
@@ -56,6 +56,16 @@ for (const [key, value] of Object.entries(mergedEnv)) {
   }
 }
 
+// The mergedEnv copy above pulls NODE_ENV straight from `.env` — and the shipped
+// `.env.example` default is `NODE_ENV=production`. Next's programmatic `next()`
+// entry (unlike the `next` CLI) trusts that value verbatim, so `npm run dev`
+// would boot the dev bundler with NODE_ENV=production. That desyncs Next's
+// webpack CSS pipeline and `src/app/globals.css` reaches webpack's JS parser
+// instead of PostCSS — failing as `Module parse failed: Unexpected character
+// '@'` on the `@import "tailwindcss"` line. Force NODE_ENV to track the run
+// mode, exactly like the `next` CLI does.
+process.env.NODE_ENV = dev ? "development" : "production";
+
 const { dashboardPort } = runtimePorts;
 const hostname = process.env.HOST || "0.0.0.0";
 const useTurbopack = dev && mergedEnv.OMNIROUTE_USE_TURBOPACK === "1";

--- a/tests/unit/run-next-node-env.test.ts
+++ b/tests/unit/run-next-node-env.test.ts
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// run-next.mjs has top-level side effects (bootstrapEnv, native sqlite, server
+// listen) so it cannot be imported in-process. Guard the fix by inspecting the
+// source: the dev/start server MUST force NODE_ENV to match the run mode, after
+// the mergedEnv copy loop (which pulls NODE_ENV=production from .env/.env.example)
+// and before next() is constructed. Otherwise `npm run dev` boots the dev
+// bundler with NODE_ENV=production, which breaks Next's webpack CSS pipeline and
+// fails globals.css with "Unexpected character '@'" on `@import "tailwindcss"`.
+const here = path.dirname(fileURLToPath(import.meta.url));
+const source = fs.readFileSync(path.resolve(here, "../../scripts/dev/run-next.mjs"), "utf8");
+
+// Quote- and whitespace-tolerant so legitimate Prettier/formatting changes
+// don't trip the guard; only a real change to the assignment shape should.
+const NODE_ENV_NORMALIZE =
+  /process\.env\.NODE_ENV\s*=\s*dev\s*\?\s*['"]development['"]\s*:\s*['"]production['"]/;
+
+test("run-next.mjs forces NODE_ENV to track the run mode", () => {
+  assert.match(
+    source,
+    NODE_ENV_NORMALIZE,
+    "expected NODE_ENV to be forced to development in dev mode, production otherwise"
+  );
+});
+
+test("NODE_ENV normalization runs after the merged-env copy and before next()", () => {
+  const copyLoopIdx = source.search(/process\.env\[key\]\s*=\s*value/);
+  const normalizeIdx = source.search(NODE_ENV_NORMALIZE);
+  const nextCallIdx = source.search(/\bnext\s*\(\s*\{/);
+
+  assert.ok(copyLoopIdx !== -1, "expected the mergedEnv copy loop to exist");
+  assert.ok(normalizeIdx !== -1, "expected the NODE_ENV normalization to exist");
+  assert.ok(nextCallIdx !== -1, "expected the next() construction to exist");
+  assert.ok(
+    normalizeIdx > copyLoopIdx,
+    "NODE_ENV must be normalized AFTER the env copy loop (else .env overwrites it)"
+  );
+  assert.ok(normalizeIdx < nextCallIdx, "NODE_ENV must be normalized BEFORE next() reads it");
+});


### PR DESCRIPTION
## Summary
`npm run dev` fails to compile with a Build Error overlay:

```
Module parse failed: Unexpected character '@' (1:0)
./src/app/globals.css
> @import "tailwindcss";
```

Root cause is a `NODE_ENV` mismatch in the custom dev server, **not** Tailwind/PostCSS:

- `scripts/dev/run-next.mjs` copies the environment from `bootstrapEnv()` into
  `process.env`, and the shipped `.env.example` default is `NODE_ENV=production`.
- The programmatic `next()` entry — unlike the `next` CLI — trusts whatever
  `NODE_ENV` is already set; it does **not** normalize it to match the run mode.
- So `npm run dev` boots the dev (webpack) bundler with `NODE_ENV=production`.
  That desyncs Next's App-Router CSS pipeline (the global-CSS handling is gated
  on the prod flag), so `src/app/globals.css` is handed to webpack's JS parser
  instead of PostCSS — failing on the leading `@import "tailwindcss"`.

Plain `next dev --webpack` works because the CLI forces `NODE_ENV=development`
for the dev command and ignores the `.env` value; only the programmatic custom
server is affected.

The fix mirrors the `next` CLI: force `NODE_ENV` to track the run mode
(`dev → development`, `start → production`), applied right after the merged-env
copy loop (so the stale `.env` value can't win) and before `next()` reads it.

## Related Issues
- Related to #<add issue number if one is filed>

## Validation
- [x] `npm run lint` — ESLint clean on the changed files (the new test passes lint; `scripts/**` is intentionally eslint-ignored)
- [x] `npm run test:unit` — new regression test passes (`node --import tsx/esm --test tests/unit/run-next-node-env.test.ts` → 2/2)
- [ ] `npm run test:coverage` — please run on CI; this PR adds no coverage-gated production code (see Coverage Notes)
- [x] Coverage is still `>= 60%` — no `src/ | open-sse/ | electron/ | bin/` code changed (only `scripts/`), so the coverage gate is unaffected
- [ ] SonarQube PR analysis is green (verified on CI)

Manual end-to-end validation (Hard Rule #18, in addition to the unit test):
with `NODE_ENV=production` present in `.env`, `npm run dev` now serves `/` and
`/dashboard` with **HTTP 200** and **zero** `globals.css` parse errors. Without
the fix the same setup reproduces the `Unexpected character '@'` Build Error.

## Tests Added Or Updated
- `tests/unit/run-next-node-env.test.ts` (new) — regression guard. `run-next.mjs`
  has top-level side effects (bootstrap, native sqlite, server listen) and cannot
  be imported in-process, so the test inspects the script source to assert that
  `NODE_ENV` is forced to track the run mode **after** the merged-env copy loop
  and **before** `next()` is constructed.

## Coverage Notes
- No production code under `src/`, `open-sse/`, `electron/`, or `bin/` changed —
  the only production change is one line in `scripts/dev/run-next.mjs`. The
  per-directory coverage gate therefore does not apply to this PR.

## Reviewer Notes
- Behavioral surface is intentionally tiny: one line in `scripts/dev/run-next.mjs`
  plus a regression test. No new modules, no dependency changes.
- `start` mode is explicitly preserved as `production`, so `npm run start`
  (production custom server) is unchanged.
- The shipped `.env.example` keeps `NODE_ENV=production` as the deploy default;
  this fix means a `production` value can no longer leak into the dev bundler.