### PR TITLE
test(ci): wire antigravity-quota-family under test:vitest (fix test-discovery orphan)

### DIFF
--- a/scripts/check/check-test-discovery.mjs
+++ b/scripts/check/check-test-discovery.mjs
@@ -67,6 +67,12 @@ export const COLLECTORS = [
   // vitest.mcp.config.ts — test:vitest
   { glob: "open-sse/mcp-server/__tests__/**/*.test.ts", sources: ["vitest.mcp.config.ts"] },
   { glob: "open-sse/services/autoCombo/__tests__/**/*.test.ts", sources: ["vitest.mcp.config.ts"] },
+  // Single-file include: the rest of open-sse/services/__tests__/ are frozen orphans
+  // (empty/dormant stubs); only this one is wired to run under test:vitest.
+  {
+    glob: "open-sse/services/__tests__/antigravity-quota-family.test.ts",
+    sources: ["vitest.mcp.config.ts"],
+  },
   { glob: "tests/unit/autoCombo/**/*.test.ts", sources: ["vitest.mcp.config.ts"] },
   { glob: "tests/unit/encryption.spec.ts", sources: ["vitest.mcp.config.ts"] },
   { glob: "src/shared/components/**/*.test.tsx", sources: ["vitest.mcp.config.ts"] },

--- a/vitest.mcp.config.ts
+++ b/vitest.mcp.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     include: [
       "open-sse/mcp-server/__tests__/**/*.test.ts",
       "open-sse/services/autoCombo/__tests__/**/*.test.ts",
+      "open-sse/services/__tests__/antigravity-quota-family.test.ts",
       "tests/unit/autoCombo/**/*.test.ts",
       "tests/unit/encryption.spec.ts",
       "src/shared/components/**/*.test.tsx",


### PR DESCRIPTION
## Problema

`open-sse/services/__tests__/antigravity-quota-family.test.ts` (introduzido pelo #5180) ficou **órfão**: nenhum runner ativo o coletava → `check:test-discovery` **vermelho na base** `release/v3.8.39` (`[órfão NOVO]`), travando o gate em toda PR. (Vitest test; o `vitest.config.ts` o incluiria mas é config morta — `test:vitest` roda o `vitest.mcp.config.ts`, que não o tinha.)

## Fix (religar pra RODAR, não congelar — espírito do #5145)

- `vitest.mcp.config.ts` — adiciona o arquivo específico ao `include` (`test:vitest` agora o roda).
- `scripts/check/check-test-discovery.mjs` — collector correspondente (single-file).

**Só o antigravity**, não o diretório: os outros 7 testes em `open-sse/services/__tests__/` são stubs vazios ("No test suite found") e ficam como dívida congelada no baseline — religar o dir inteiro ligaria 5 testes quebrados.

## Validação

- `npm run check:test-discovery` → **OK — 2510 arquivos, 18 collectors, 60 órfãos congelados** (antes: 1 órfão NOVO → fail).
- `antigravity-quota-family.test.ts` sob `vitest.mcp.config.ts` → **5/5 passed** (agora roda de verdade).
- Diff = 2 arquivos de config. Zero mudança de produção.

Base-red isolado em PR própria conforme o padrão (#5145).