### PR TITLE
Normalize safety finish reasons across Gemini and Antigravity

### DIFF
--- a/open-sse/executors/antigravity.ts
+++ b/open-sse/executors/antigravity.ts
@@ -46,6 +46,7 @@ import {
 } from "../services/cloudCodeThinking.ts";
 import { buildGeminiTools } from "../translator/helpers/geminiToolsSanitizer.ts";
 import { DEFAULT_SAFETY_SETTINGS } from "../translator/helpers/geminiHelper.ts";
+import { normalizeOpenAICompatibleFinishReasonString } from "../utils/finishReason.ts";
 import {
   applyAntigravityClientProfileHeaders,
   removeHeaderCaseInsensitive,
@@ -402,10 +403,9 @@ export function processAntigravitySSEPayload(
       }
     }
     if (candidate?.finishReason) {
-      collected.finishReason =
-        candidate.finishReason.toLowerCase() === "stop"
-          ? "stop"
-          : candidate.finishReason.toLowerCase();
+      collected.finishReason = normalizeOpenAICompatibleFinishReasonString(
+        String(candidate.finishReason).toLowerCase()
+      );
     }
     if (parsed?.response?.usageMetadata) {
       const um = parsed.response.usageMetadata;

--- a/open-sse/handlers/responseSanitizer.ts
+++ b/open-sse/handlers/responseSanitizer.ts
@@ -2,6 +2,7 @@ import {
   copyOpenAICompatibleReasoningFields,
   getReadableReasoningValue,
 } from "../utils/reasoningFields.ts";
+import { normalizeOpenAICompatibleFinishReason } from "../utils/finishReason.ts";
 
 /**
  * Response Sanitizer — Normalizes LLM responses to strict OpenAI SDK format.
@@ -437,7 +438,7 @@ function sanitizeChoice(choice: unknown, defaultIndex: number): JsonRecord {
   }
 
   if (choiceRecord?.finish_reason !== undefined) {
-    sanitized.finish_reason = choiceRecord.finish_reason;
+    sanitized.finish_reason = normalizeOpenAICompatibleFinishReason(choiceRecord.finish_reason);
   }
 
   // Sanitize message (non-streaming) or delta (streaming)
@@ -1070,7 +1071,9 @@ export function sanitizeStreamingChunk(parsed: unknown): unknown {
         }
       }
 
-      if (choiceRecord.finish_reason !== undefined) c.finish_reason = choiceRecord.finish_reason;
+      if (choiceRecord.finish_reason !== undefined) {
+        c.finish_reason = normalizeOpenAICompatibleFinishReason(choiceRecord.finish_reason);
+      }
       if (choiceRecord.logprobs !== undefined) c.logprobs = choiceRecord.logprobs;
       return c;
     });

--- a/open-sse/handlers/responseTranslator.ts
+++ b/open-sse/handlers/responseTranslator.ts
@@ -3,6 +3,7 @@ import {
   buildGeminiThoughtSignatureKey,
   storeGeminiThoughtSignature,
 } from "../services/geminiThoughtSignatureStore.ts";
+import { normalizeOpenAICompatibleFinishReasonString } from "../utils/finishReason.ts";
 import { containsTextualToolCallMarker } from "../utils/textualToolCall.ts";
 
 type JsonRecord = Record<string, unknown>;
@@ -423,16 +424,10 @@ export function translateNonStreamingResponse(
                 message.content = "";
               }
 
-              let finishReason = toString(candidate.finishReason, "stop").toLowerCase();
-              if (finishReason === "max_tokens") {
-                finishReason = "length";
-              } else if (
-                finishReason === "safety" ||
-                finishReason === "recitation" ||
-                finishReason === "blocklist"
-              ) {
-                finishReason = "content_filter";
-              } else if (finishReason === "stop" && toolCalls.length > 0) {
+              let finishReason = normalizeOpenAICompatibleFinishReasonString(
+                toString(candidate.finishReason, "stop")
+              );
+              if (finishReason === "stop" && toolCalls.length > 0) {
                 finishReason = "tool_calls";
               }
 

--- a/open-sse/translator/response/gemini-to-openai.ts
+++ b/open-sse/translator/response/gemini-to-openai.ts
@@ -8,6 +8,7 @@ import {
   parseTextualToolCallCandidate,
   containsTextualToolCallMarker,
 } from "../../utils/textualToolCall.ts";
+import { normalizeOpenAICompatibleFinishReasonString } from "../../utils/finishReason.ts";
 
 type GeminiToOpenAIState = {
   functionIndex: number;
@@ -711,20 +712,12 @@ export function geminiToOpenAIResponse(chunk, state) {
       }
     }
 
-    let finishReason = candidate.finishReason.toLowerCase();
+    // normalizeOpenAICompatibleFinishReasonString lowercases, maps max_tokens→length,
+    // and folds Gemini safety reasons (safety/recitation/blocklist/...) → content_filter
+    // so downstream clients can distinguish a blocked completion from a normal stop.
+    let finishReason = normalizeOpenAICompatibleFinishReasonString(candidate.finishReason);
     if (finishReason === "stop" && state.toolCalls.size > 0) {
       finishReason = "tool_calls";
-    } else if (finishReason === "max_tokens") {
-      finishReason = "length";
-    }
-    // Content blocked by Gemini safety filters — pass through as "content_filter"
-    // so downstream clients can distinguish from normal completion.
-    if (
-      finishReason === "safety" ||
-      finishReason === "recitation" ||
-      finishReason === "blocklist"
-    ) {
-      finishReason = "content_filter";
     }
 
     const finalChunk: Record<string, unknown> = {

--- a/open-sse/utils/finishReason.ts
+++ b/open-sse/utils/finishReason.ts
@@ -1,0 +1,35 @@
+const OPENAI_FINISH_REASONS = new Set([
+  "stop",
+  "length",
+  "tool_calls",
+  "content_filter",
+  "function_call",
+]);
+
+const SAFETY_FINISH_REASONS = new Set([
+  "safety",
+  "recitation",
+  "blocklist",
+  "prohibited_content",
+  "content_filtered",
+  "policy_violation",
+]);
+
+export function normalizeOpenAICompatibleFinishReason(value: unknown): unknown {
+  if (typeof value !== "string") return value;
+
+  const normalized = value.toLowerCase();
+  if (OPENAI_FINISH_REASONS.has(normalized)) return normalized;
+  if (normalized === "max_tokens") return "length";
+  if (SAFETY_FINISH_REASONS.has(normalized)) return "content_filter";
+
+  return normalized;
+}
+
+export function normalizeOpenAICompatibleFinishReasonString(
+  value: unknown,
+  fallback = "stop"
+): string {
+  const normalized = normalizeOpenAICompatibleFinishReason(value);
+  return typeof normalized === "string" && normalized ? normalized : fallback;
+}

--- a/open-sse/utils/jsonToSse.ts
+++ b/open-sse/utils/jsonToSse.ts
@@ -13,6 +13,7 @@
  * Returns "" when the text is not a parseable chat-completion object with at
  * least one choice — callers then fall back to the original (error) handling.
  */
+import { normalizeOpenAICompatibleFinishReasonString } from "./finishReason.ts";
 import { getUnsupportedReasoningValue } from "./reasoningFields.ts";
 
 type JsonRecord = Record<string, unknown>;
@@ -112,10 +113,7 @@ export function synthesizeOpenAiSseFromJson(jsonText: string): string {
       emitDelta({ tool_calls: message.tool_calls });
     }
 
-    const finishReason =
-      typeof choice.finish_reason === "string" && choice.finish_reason
-        ? choice.finish_reason
-        : "stop";
+    const finishReason = normalizeOpenAICompatibleFinishReasonString(choice.finish_reason);
     const finalChoice: JsonRecord = { index, delta: {}, finish_reason: finishReason };
     const finalChunk: JsonRecord = { ...base, choices: [finalChoice] };
     if (isRecord(parsed.usage)) finalChunk.usage = parsed.usage;

--- a/tests/unit/antigravity-finish-reason-normalization.test.ts
+++ b/tests/unit/antigravity-finish-reason-normalization.test.ts
@@ -1,0 +1,34 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { AntigravityExecutor } from "../../open-sse/executors/antigravity.ts";
+
+type ChatCompletionPayload = {
+  choices: Array<{
+    message: { content: string };
+    finish_reason: string;
+  }>;
+};
+
+test("AntigravityExecutor.collectStreamToResponse normalizes prohibited content finish reasons", async () => {
+  const executor = new AntigravityExecutor();
+  const response = new Response(
+    'data: {"response":{"candidates":[{"content":{"parts":[{"text":"partial text"}]},"finishReason":"PROHIBITED_CONTENT"}]}}\n\n',
+    {
+      status: 200,
+      headers: { "Content-Type": "text/event-stream" },
+    }
+  );
+
+  const result = await executor.collectStreamToResponse(
+    response,
+    "gemini-2.5-flash",
+    "https://example.com",
+    { Authorization: "Bearer ag-token" },
+    { request: {} }
+  );
+  const payload = (await result.response.json()) as ChatCompletionPayload;
+
+  assert.equal(payload.choices[0].message.content, "partial text");
+  assert.equal(payload.choices[0].finish_reason, "content_filter");
+});

--- a/tests/unit/gemini-finish-reason-normalization.test.ts
+++ b/tests/unit/gemini-finish-reason-normalization.test.ts
@@ -1,0 +1,50 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { geminiToOpenAIResponse } =
+  await import("../../open-sse/translator/response/gemini-to-openai.ts");
+const { translateNonStreamingResponse } =
+  await import("../../open-sse/handlers/responseTranslator.ts");
+const { FORMATS } = await import("../../open-sse/translator/formats.ts");
+
+test("Gemini non-stream: prohibited content finish reason becomes content_filter", () => {
+  const result = translateNonStreamingResponse(
+    {
+      responseId: "resp-prohibited",
+      modelVersion: "gemini-2.5-flash",
+      candidates: [
+        {
+          content: { parts: [{ text: "partial text" }] },
+          finishReason: "PROHIBITED_CONTENT",
+        },
+      ],
+    },
+    FORMATS.GEMINI,
+    FORMATS.OPENAI
+  );
+
+  assert.equal((result as any).choices[0].message.content, "partial text");
+  assert.equal((result as any).choices[0].finish_reason, "content_filter");
+});
+
+test("Gemini stream: prohibited content finish reason becomes content_filter", () => {
+  const result = geminiToOpenAIResponse(
+    {
+      responseId: "resp-prohibited",
+      modelVersion: "gemini-2.5-flash",
+      candidates: [
+        {
+          content: { parts: [{ text: "partial text" }] },
+          finishReason: "PROHIBITED_CONTENT",
+        },
+      ],
+    },
+    { toolCalls: new Map() }
+  );
+
+  assert.equal(result.at(-1).choices[0].finish_reason, "content_filter");
+  assert.equal(
+    result.some((event: any) => event.choices?.[0]?.delta?.content === "partial text"),
+    true
+  );
+});

--- a/tests/unit/json-to-sse-3089.test.ts
+++ b/tests/unit/json-to-sse-3089.test.ts
@@ -155,6 +155,29 @@ describe("synthesizeOpenAiSseFromJson (#3089)", () => {
     assert.equal(toolDelta.tool_calls[0].id, "t1");
   });
 
+  test("normalizes prohibited content finish reasons in synthesized SSE", () => {
+    const sse = synthesizeOpenAiSseFromJson(
+      JSON.stringify({
+        choices: [
+          {
+            message: { role: "assistant", content: "partial text" },
+            finish_reason: "prohibited_content",
+          },
+        ],
+      })
+    );
+    const events = parseDataChunks(sse)
+      .filter((c) => c !== "[DONE]")
+      .map((c) => JSON.parse(c));
+    const finishChunk = events.at(-1);
+
+    assert.equal(finishChunk.choices[0].finish_reason, "content_filter");
+    assert.equal(
+      events.some((event) => event.choices[0].delta.content === "partial text"),
+      true
+    );
+  });
+
   test("returns empty string for non-completion JSON / invalid JSON", () => {
     assert.equal(synthesizeOpenAiSseFromJson('{"error":{"message":"x"}}'), "");
     assert.equal(synthesizeOpenAiSseFromJson("{not json"), "");


### PR DESCRIPTION
## Summary

This PR now carries only the finish-reason normalization half that was split out from the original mixed branch.

It normalizes provider safety/prohibited finish reasons into OpenAI-compatible values so downstream clients do not receive uncommon terminal reasons such as `prohibited_content` directly.

## Changes

- Add a shared finish-reason normalization helper for OpenAI-compatible responses.
- Map Gemini safety-style terminal reasons (`SAFETY`, `RECITATION`, `BLOCKLIST`, `PROHIBITED_CONTENT`) to `content_filter`.
- Apply the same normalization in Antigravity collection and JSON-to-SSE conversion paths.
- Preserve normal finish reasons such as `stop`, `length`, and `tool_calls` without changing their semantics.
- Add focused coverage for Gemini, Antigravity, and JSON-to-SSE finish-reason normalization.

## Out of scope

Prompt-format `<think>` / `<thinking>` content preservation was split into #5216 so this PR stays focused on terminal finish reasons only.

## Validation

- Covered by the focused unit tests added in this PR.
- Current PR checks are running against `release/v3.8.39`.