### PR TITLE
fix(cli): raise dev server Node heap limit to 8GB to prevent OOM

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   },
   "homepage": "https://omniroute.online",
   "scripts": {
-    "dev": "node scripts/dev/run-next.mjs dev",
+    "dev": "node --max-old-space-size=8192 scripts/dev/run-next.mjs dev",
     "prebuild:docs": "node scripts/docs/gen-openapi-module.mjs",
     "gen:provider-reference": "node --import tsx scripts/docs/gen-provider-reference.ts",
     "bench:compression": "node --import tsx scripts/compression/benchmark.ts",

--- a/tests/unit/dev-script-heap-limit.test.ts
+++ b/tests/unit/dev-script-heap-limit.test.ts
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// The dev server runs Next's bundler in-process via `node scripts/dev/run-next.mjs`.
+// `--max-old-space-size` can only be set at process startup (not from inside the
+// running process), so the heap ceiling has to live on the `node` invocation in
+// the `dev` npm script. Without it, the dev bundler runs on V8's ~4GB default and
+// OOMs while compiling heavy dashboard routes (e.g. /dashboard/providers, which
+// pulls monaco / recharts / @lobehub/icons / xyflow / mermaid). The unit test
+// suite already runs with 8192; the dev server must match.
+const here = path.dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(fs.readFileSync(path.resolve(here, "../../package.json"), "utf8"));
+
+test("dev script raises the Node heap limit (matches the test suite's 8192)", () => {
+  const dev = pkg.scripts?.dev ?? "";
+  assert.match(
+    dev,
+    /node\s+--max-old-space-size=8192\b/,
+    `dev script must launch node with --max-old-space-size=8192; got: ${dev}`
+  );
+  // Guard ordering: the flag must precede the script path so node (not the script)
+  // receives it.
+  const flagIdx = dev.indexOf("--max-old-space-size");
+  const scriptIdx = dev.indexOf("run-next.mjs");
+  assert.ok(scriptIdx !== -1, "dev script must still launch run-next.mjs");
+  assert.ok(
+    flagIdx !== -1 && flagIdx < scriptIdx,
+    "the heap flag must come before run-next.mjs so node receives it"
+  );
+});


### PR DESCRIPTION
## Summary

`npm run dev` crashes the dev server with a V8 OOM while compiling heavy dashboard
routes (reproduced by opening `/dashboard/providers`):

```
FATAL ERROR: Ineffective mark-compacts near heap limit
Allocation failed - JavaScript heap out of memory
```

Root cause: the dev server runs Next's bundler **in-process** via
`node scripts/dev/run-next.mjs`, and that `node` invocation had no
`--max-old-space-size`, so it ran on V8's ~4GB default. `--max-old-space-size`
can only be set at process startup, so it must live on the `node` command in the
`dev` npm script. The unit-test scripts already use `--max-old-space-size=8192`;
the dev server was the one heavy entry point left on the default.

Measured footprint (Node 26, this repo): ~2.1GB baseline (app + background daemons
+ DB) **+ ~1.8GB to dev-compile `/dashboard/providers`** alone (it pulls monaco,
recharts, `@lobehub/icons`, xyflow, and mermaid) ≈ 4GB → hits the default ceiling
→ OOM. Navigating more routes + HMR pushes it higher.

Fix: launch the dev server with `--max-old-space-size=8192`, matching the test
suite.

## Validation

- [x] `npm run lint` — clean on changed files (new test passes; `scripts/**` is eslint-ignored)
- [x] `npm run test:unit` — new regression test passes (`tests/unit/dev-script-heap-limit.test.ts` → 1/1)
- [ ] `npm run test:coverage` — run on CI; no coverage-gated production code changed
- [x] Coverage `>= 60%` — only `package.json` + a test changed (no `src/ | open-sse/ | electron/ | bin/`), gate unaffected
- [ ] SonarQube PR analysis green (CI)

End-to-end validation:
- Started `npm run dev` and confirmed the spawned process runs as
  `node --max-old-space-size=8192 scripts/dev/run-next.mjs dev`.
- With the 8GB ceiling, opening `/dashboard/providers` and hammering its APIs
  keeps the server stable (RSS ~5-6GB, reclaimed by GC); no OOM.
- Investigated for an app-level leak first: endpoints plateau on sustained load
  (`/api/settings`, `/api/auth/status`) and RSS drops between runs, so the OOM is
  dev-compilation memory, not a leak. Raising the heap is the correct fix.

## Tests Added Or Updated

- `tests/unit/dev-script-heap-limit.test.ts` (new) — asserts the `dev` npm script
  launches `node` with `--max-old-space-size=8192`, before the `run-next.mjs` path
  so node (not the script) receives the flag.

## Coverage Notes

- No production code under `src/`, `open-sse/`, `electron/`, or `bin/` changed —
  the only change is the `dev` script in `package.json`. The per-directory coverage
  gate does not apply.

## Reviewer Notes

- Scope limited to `dev`. `start` (production custom server) is intentionally left
  unchanged: it runs no on-demand route compilation, and production deploys use
  `run-standalone.mjs`, which already sets the heap ceiling.
- `8192` matches the value already hardcoded across the `test*` scripts, so this is
  consistent with existing repo convention rather than a new tunable.
