### PR TITLE
fix(cli): default dev bundler to Turbopack (16.2.x panic no longer reproduces)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -111,13 +111,19 @@ PORT=20128
 # Used by: src/app/api/v1/relay/chat/completions/route.ts
 # RELAY_IP_PER_MINUTE=30
 
-# Bundler selection for `npm run dev`. Set to 1 to opt into Turbopack.
-# Default is 0 (webpack) because Turbopack 16.2.x panics on the OmniRoute
-# module graph with "internal error: entered unreachable code: there must be
-# a path to a root" (turbopack-core/module_graph/mod.rs:662). Same bug class
-# the production Docker build worked around in PR #4052. Webpack starts
-# slower but compiles cleanly. Re-enable once upstream Turbopack ships a fix.
-OMNIROUTE_USE_TURBOPACK=0
+# Bundler selection for `npm run dev`. Set to 0 to fall back to webpack.
+# Default is 1 (Turbopack). PR #4092 had forced webpack because earlier
+# Turbopack 16.2.x panicked on the OmniRoute module graph with "internal error:
+# entered unreachable code: there must be a path to a root"
+# (turbopack-core/module_graph/mod.rs:662). That panic no longer reproduces on
+# the pinned Next 16.2.9 — verified across a broad cold-compile sweep (36
+# dashboard routes + open-sse-heavy API routes incl. /api/v1/chat/completions,
+# /api/v1/models, /api/mcp) and repeated HMR rebuilds: zero panics. Turbopack
+# also keeps dev memory far lower on the edit→rebuild loop (HMR rebuild RSS stays
+# ~flat vs webpack's monotonic growth), which mitigates the dev-server OOM on
+# this 60+ route app. The production build still uses webpack (build pipeline is
+# unaffected by this dev-only flag).
+OMNIROUTE_USE_TURBOPACK=1
 
 # Skip the SQLite integrity health check on startup (faster boot on large DBs).
 # Used by: src/lib/db/core.ts, src/lib/db/healthCheck.ts. Set to 1 to skip.


### PR DESCRIPTION
## Summary

Re-enable Turbopack as the default `npm run dev` bundler by flipping
`OMNIROUTE_USE_TURBOPACK` from `0` to `1` in `.env.example`.

PR #4092 had forced webpack because earlier Turbopack 16.2.x panicked while
building the OmniRoute module graph:

```
internal error: entered unreachable code: there must be a path to a root
  (turbopack-core/module_graph/mod.rs:662)
```

On the pinned **Next 16.2.9** that panic no longer reproduces. This also aligns
`.env.example` with `docs/reference/ENVIRONMENT.md`, which already documented the
default as `1` (the example was stale at `0`).

Why this matters beyond the panic: Turbopack keeps dev-server memory far lower on
the edit→rebuild loop. The webpack dev server retains every compiled route and
grows monotonically (~200MB/route, never reclaimed), which OOMs the dev heap on
this 60+ route app after navigating/editing for a while. Turbopack's HMR rebuilds
stay ~flat, mitigating that.

## Related Issues

- Related to #<add issue number if one is filed>
- Reverts the dev-only workaround from #4092 (its root cause is resolved upstream).

## Validation

Real-environment test (Hard Rule #18 — config default, no unit test applies):

- **Cold-compile sweep, Turbopack on Next 16.2.9** — 36 dashboard routes + the
  open-sse-heavy API routes (`/api/v1/chat/completions`, `/api/v1/models`,
  `/api/mcp`, `/api/providers`, `/api/monitoring/health`, `/api/provider-models`):
  **0 panics, 0 compile errors**.
- **HMR rebuild loop** — edited `app/(dashboard)/dashboard/providers/page.tsx` 6×
  with the route loaded, forcing incremental module-graph rebuilds: **0 panics**,
  RSS ~flat (3522→3624MB across 6 rebuilds).
- **Memory comparison (16-route cold compile):** webpack ~203MB/route vs Turbopack
  ~136MB/route; HMR rebuilds are ~flat under Turbopack vs accumulating under webpack.

Checklist:
- [x] `npm run lint` — n/a to `.env.example`; no code changed
- [x] `node scripts/check/check-env-doc-sync.mjs` — ✓ env/docs contract in sync
- [ ] `npm run test:unit` / `test:coverage` — no production code changed (config default only)
- [ ] SonarQube PR analysis green (CI)

## Tests Added Or Updated

- None. This PR changes a single `.env.example` default (not `src/`, `open-sse/`,
  `electron/`, or `bin/`). Validation is the documented real-environment test above.

## Coverage Notes

- No application code changed; coverage gate is unaffected.

## Reviewer Notes

- **Dev-only.** The flag is read in `scripts/dev/run-next.mjs` for `npm run dev`.
  The production build (`build-next-isolated.mjs`) is webpack and is not changed by
  this flag, so PR #4052's separate production-build concern is out of scope here.
- **Reversible per-operator:** anyone hitting a Turbopack-specific issue can set
  `OMNIROUTE_USE_TURBOPACK=0` to fall back to webpack.
- Testing was broad but not literally exhaustive across every route/edit pattern;
  it covered the route classes most likely to have tripped the original module-graph
  panic (heavy open-sse API routes) plus the HMR path.
