### PR TITLE
fix(combo): reject empty Responses API output

### DIFF
--- a/open-sse/services/combo/validateQuality.ts
+++ b/open-sse/services/combo/validateQuality.ts
@@ -21,6 +21,28 @@ export function toRetryAfterDisplayValue(value: ComboRetryAfter): string | Date 
   return new Date(value);
 }
 
+function responsesApiOutputHasContent(output: unknown): boolean {
+  return (
+    Array.isArray(output) &&
+    output.some((item) => {
+      if (!item || typeof item !== "object") return false;
+      const record = item as Record<string, unknown>;
+      if (record.type !== "message") return Boolean(record.type);
+      const content = record.content;
+      return (
+        Array.isArray(content) &&
+        content.some(
+          (part) =>
+            !!part &&
+            typeof part === "object" &&
+            typeof (part as Record<string, unknown>).text === "string" &&
+            ((part as Record<string, string>).text as string).length > 0
+        )
+      );
+    })
+  );
+}
+
 /**
  * Validate that a successful (HTTP 200) non-streaming response actually contains
  * meaningful content. Returns { valid: true } or { valid: false, reason }.
@@ -271,6 +293,22 @@ export async function validateResponseQuality(
   }
 
   const choices = json?.choices;
+  if (json?.object === "response") {
+    if (!responsesApiOutputHasContent(json.output)) return { valid: false, reason: "empty_choices" };
+    const status = typeof json.status === "string" ? json.status : "";
+    if (status && !["completed", "done"].includes(status)) {
+      return { valid: false, reason: "no_terminal" };
+    }
+    return {
+      valid: true,
+      clonedResponse: new Response(text, {
+        status: response.status,
+        statusText: response.statusText,
+        headers: response.headers,
+      }),
+    };
+  }
+
   if (!Array.isArray(choices) || choices.length === 0) {
     if (json?.output || json?.result || json?.data || json?.response) return { valid: true };
     if (json?.error) {

--- a/tests/unit/validate-response-quality.test.ts
+++ b/tests/unit/validate-response-quality.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "assert";
-import { validateResponseQuality } from "../../open-sse/services/combo";
+import { validateResponseQuality } from "../../open-sse/services/combo/validateQuality.ts";
 
 function makeResponse(body: string, contentType = "text/plain") {
   return {
@@ -24,4 +24,29 @@ test("returns valid=true for SSE with 'data:' lines", async () => {
 test("returns valid=false for non-JSON non-SSE text", async () => {
   const res = await validateResponseQuality(makeResponse("Hello world"), false, {});
   assert.strictEqual(res.valid, false);
+});
+
+test("returns valid=false for Responses API bodies with no output items", async () => {
+  const res = await validateResponseQuality(
+    makeResponse(JSON.stringify({ object: "response", status: "completed", output: [] }), "application/json"),
+    false,
+    {}
+  );
+  assert.strictEqual(res.valid, false);
+});
+
+test("returns valid=true for Responses API bodies with structural output", async () => {
+  const res = await validateResponseQuality(
+    makeResponse(
+      JSON.stringify({
+        object: "response",
+        status: "completed",
+        output: [{ type: "function_call", name: "lookup", arguments: "{}" }],
+      }),
+      "application/json"
+    ),
+    false,
+    {}
+  );
+  assert.strictEqual(res.valid, true);
 });


### PR DESCRIPTION
Addresses the backend/routing gap behind #4985/#5166: a non-streaming Responses API body with `object: "response"` and `output: []` was treated as a valid 200 by combo response-quality validation, so a combo target could stop instead of failing over.

Changes:
- validate Responses API-shaped non-stream bodies before the generic `output` shortcut
- reject empty `output: []` as `empty_choices`
- keep structural Responses API output, such as `function_call`, valid
- point the validator test at the actual extracted validator module

Validation:
- env DISABLE_SQLITE_AUTO_BACKUP=true node --max-old-space-size=8192 --import tsx --test --test-force-exit tests/unit/validate-response-quality.test.ts
- npm run check:file-size
- npx eslint open-sse/services/combo/validateQuality.ts tests/unit/validate-response-quality.test.ts