### PR TITLE
fix(proxy): coalesce fast-fail health probes

### DIFF
--- a/src/lib/proxyHealth.ts
+++ b/src/lib/proxyHealth.ts
@@ -24,6 +24,10 @@ interface ProxyHealthEntry {
 
 // In-memory cache: proxyUrl → health entry
 const proxyHealthCache = new Map<string, ProxyHealthEntry>();
+const proxyHealthInflight = new Map<string, Promise<boolean>>();
+
+type TcpCheck = (host: string, port: number, timeoutMs: number) => Promise<boolean>;
+let tcpCheckImpl: TcpCheck = tcpCheck;
 
 /**
  * T14: Perform a fast TCP check to see if a proxy host:port is reachable.
@@ -69,9 +73,24 @@ export async function isProxyReachable(
     return false;
   }
 
-  const healthy = await tcpCheck(host, port, timeoutMs);
-  proxyHealthCache.set(proxyUrl, { healthy, checkedAt: Date.now(), ttlMs: cacheTtlMs });
-  return healthy;
+  const existingProbe = proxyHealthInflight.get(proxyUrl);
+  if (existingProbe) {
+    return existingProbe;
+  }
+
+  const probe = tcpCheckImpl(host, port, timeoutMs).then((healthy) => {
+    proxyHealthCache.set(proxyUrl, { healthy, checkedAt: Date.now(), ttlMs: cacheTtlMs });
+    return healthy;
+  });
+
+  proxyHealthInflight.set(proxyUrl, probe);
+  try {
+    return await probe;
+  } finally {
+    if (proxyHealthInflight.get(proxyUrl) === probe) {
+      proxyHealthInflight.delete(proxyUrl);
+    }
+  }
 }
 
 /**
@@ -90,6 +109,7 @@ export function getCachedProxyHealth(proxyUrl: string): boolean | null {
  */
 export function invalidateProxyHealth(proxyUrl: string): void {
   proxyHealthCache.delete(proxyUrl);
+  proxyHealthInflight.delete(proxyUrl);
 }
 
 /**
@@ -138,4 +158,8 @@ function tcpCheck(host: string, port: number, timeoutMs: number): Promise<boolea
       resolve(false);
     });
   });
+}
+
+export function __setProxyHealthTcpCheckForTesting(check: TcpCheck | null): void {
+  tcpCheckImpl = check ?? tcpCheck;
 }

--- a/tests/unit/t14-proxy-fast-fail.test.ts
+++ b/tests/unit/t14-proxy-fast-fail.test.ts
@@ -5,6 +5,7 @@ import {
   isProxyReachable,
   getCachedProxyHealth,
   invalidateProxyHealth,
+  __setProxyHealthTcpCheckForTesting,
 } from "../../src/lib/proxyHealth.ts";
 import { runWithProxyContext } from "../../open-sse/utils/proxyFetch.ts";
 
@@ -15,6 +16,37 @@ test("T14: isProxyReachable caches unreachable proxy result", async () => {
   const healthy = await isProxyReachable(proxyUrl, 120, 2_000);
   assert.equal(healthy, false);
   assert.equal(getCachedProxyHealth(proxyUrl), false);
+});
+
+test("#5109: concurrent proxy reachability checks share one TCP probe", async () => {
+  const proxyUrl = "http://127.0.0.1:1080";
+  invalidateProxyHealth(proxyUrl);
+
+  let probeCount = 0;
+  let releaseProbe!: (healthy: boolean) => void;
+  const probeStarted = new Promise<void>((resolve) => {
+    __setProxyHealthTcpCheckForTesting(async () => {
+      probeCount += 1;
+      resolve();
+      return new Promise<boolean>((resolveProbe) => {
+        releaseProbe = resolveProbe;
+      });
+    });
+  });
+
+  try {
+    const checks = Array.from({ length: 50 }, () => isProxyReachable(proxyUrl, 120, 2_000));
+
+    await probeStarted;
+    assert.equal(probeCount, 1, "concurrent requests must not fan out TCP health probes");
+
+    releaseProbe(true);
+    assert.deepEqual(await Promise.all(checks), Array.from({ length: 50 }, () => true));
+    assert.equal(getCachedProxyHealth(proxyUrl), true);
+  } finally {
+    __setProxyHealthTcpCheckForTesting(null);
+    invalidateProxyHealth(proxyUrl);
+  }
 });
 
 test("T14: runWithProxyContext fast-fails when proxy is unreachable", async () => {
@@ -28,7 +60,7 @@ test("T14: runWithProxyContext fast-fails when proxy is unreachable", async () =
         executed = true;
         return "ok";
       }),
-    (err) => (err as any).code === "PROXY_UNREACHABLE"
+    (err) => (err as { code?: string })?.code === "PROXY_UNREACHABLE"
   );
 
   assert.equal(executed, false);


### PR DESCRIPTION
## Summary
- Fixes #5109 by coalescing concurrent proxy fast-fail TCP health checks per proxy URL.
- Preserves the existing completed-result health cache while preventing concurrency bursts from opening one TCP probe per request.
- Adds a regression test covering 50 simultaneous reachability checks sharing a single probe.

## Validation
- `node --max-old-space-size=8192 --import tsx --test --test-force-exit tests/unit/t14-proxy-fast-fail.test.ts tests/unit/proxy-health-ipv6.test.ts tests/unit/proxy-fetch.test.ts tests/unit/socks-handshake-timeout-5109.test.ts` -> 17/17 pass
- `npx eslint src/lib/proxyHealth.ts tests/unit/t14-proxy-fast-fail.test.ts` -> pass
- `npm run check:file-size` -> pass
- `git diff --check` -> pass
