### PR TITLE
Preserve prompt-format thinking tags in generic streaming paths

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -3602,7 +3602,7 @@ export async function handleChatCore({
     }
     // Sanitize response for OpenAI SDK compatibility
     // Strips non-standard fields (x_groq, usage_breakdown, service_tier, etc.)
-    // Extracts <think> and <thinking> tags into reasoning_content
+    // Preserves provider-native reasoning fields without inferring reasoning from prompt text
     // Source format determines output shape. If we are outputting OpenAI shape or pseudo-OpenAI shape, sanitize.
     if (clientResponseFormat === FORMATS.OPENAI_RESPONSES) {
       translatedResponse = sanitizeResponsesApiResponse(translatedResponse);

--- a/open-sse/handlers/responseSanitizer.ts
+++ b/open-sse/handlers/responseSanitizer.ts
@@ -1,7 +1,4 @@
-import {
-  copyOpenAICompatibleReasoningFields,
-  getReadableReasoningValue,
-} from "../utils/reasoningFields.ts";
+import { copyOpenAICompatibleReasoningFields } from "../utils/reasoningFields.ts";
 import { normalizeOpenAICompatibleFinishReason } from "../utils/finishReason.ts";
 
 /**
@@ -10,7 +7,7 @@ import { normalizeOpenAICompatibleFinishReason } from "../utils/finishReason.ts"
  * Fixes Issues:
  * 1. Strips non-standard fields (x_groq, usage_breakdown, service_tier) that
  *    break OpenAI Python SDK v1.83+ Pydantic validation (returns str instead of object)
- * 2. Extracts <think> tags from thinking models into reasoning_content
+ * 2. Preserves provider-native reasoning fields without inferring them from prompt text
  * 3. Normalizes response id, object, and usage fields
  * 4. Converts developer role → system for non-OpenAI providers
  */
@@ -458,7 +455,7 @@ function sanitizeChoice(choice: unknown, defaultIndex: number): JsonRecord {
 }
 
 /**
- * Sanitize a message object, extracting <think> tags if present.
+ * Sanitize a message object without inferring protocol reasoning from prompt text.
  */
 function sanitizeMessage(msg: unknown): unknown {
   const msgRecord = toRecord(msg);
@@ -470,18 +467,13 @@ function sanitizeMessage(msg: unknown): unknown {
   if (msgRecord.role) sanitized.role = msgRecord.role;
   if (msgRecord.refusal !== undefined) sanitized.refusal = msgRecord.refusal;
 
-  // Handle content — extract <think> tags
+  // Handle content. Prompt-formatted tags such as <thinking> or <content> are
+  // ordinary assistant text unless the provider also sends explicit reasoning
+  // fields. Do not infer reasoning from generated text in the generic sanitizer;
+  // provider-specific translators that explicitly rely on inline thinking tags
+  // keep their own parsing before this layer.
   if (typeof msgRecord.content === "string") {
-    const { content, thinking } = extractThinkingFromContent(
-      stripInternalToolEnvelopeText(msgRecord.content)
-    );
-    sanitized.content = collapseExcessiveNewlines(content);
-
-    // Set reasoning_content from prompt-format tags only when the provider did
-    // not also return a native OpenAI-compatible reasoning field.
-    if (thinking && !getReadableReasoningValue(msgRecord)) {
-      sanitized.reasoning_content = thinking;
-    }
+    sanitized.content = collapseExcessiveNewlines(stripInternalToolEnvelopeText(msgRecord.content));
   } else if (msgRecord.content !== undefined) {
     sanitized.content = msgRecord.content;
   }

--- a/open-sse/services/contextManager.ts
+++ b/open-sse/services/contextManager.ts
@@ -147,7 +147,7 @@ export function resolveComboContextLimit(options: {
  * Operates in 3 layers of increasing aggressiveness:
  *
  * Layer 1: Trim tool_result messages (truncate long outputs)
- * Layer 2: Compress thinking blocks (remove from history, keep last)
+ * Layer 2: Compress structured thinking blocks (remove from history, keep last)
  * Layer 3: Aggressive purification (drop old messages until fitting)
  *
  * @param {object} body - Request body with messages[]
@@ -194,7 +194,7 @@ export function compressContext(
     };
   }
 
-  // Layer 2: Compress thinking blocks (remove from non-last assistant messages)
+  // Layer 2: Compress structured thinking blocks (remove from non-last assistant messages)
   messages = compressThinking(messages);
   currentTokens = estimateTokens(JSON.stringify(messages));
   stats.layers.push({ name: "compress_thinking", tokens: currentTokens });
@@ -249,7 +249,7 @@ function trimToolMessages(messages: Record<string, unknown>[], maxChars: number)
   });
 }
 
-// ─── Layer 2: Compress Thinking Blocks ──────────────────────────────────────
+// ─── Layer 2: Compress Structured Thinking Blocks ───────────────────────────
 
 function compressThinking(messages: Record<string, unknown>[]) {
   // Find last assistant message index
@@ -272,28 +272,6 @@ function compressThinking(messages: Record<string, unknown>[]) {
         return { ...msg, content: "[thinking compressed]" };
       }
       return { ...msg, content: filtered };
-    }
-
-    // Remove thinking XML tags from string content
-    if (typeof msg.content === "string") {
-      let cleaned = msg.content;
-      for (const [start, end] of [
-        ["<thinking>", "</thinking>"],
-        ["<antThinking>", "</antThinking>"],
-      ]) {
-        while (true) {
-          const s = cleaned.indexOf(start);
-          if (s === -1) break;
-          const e = cleaned.indexOf(end, s + start.length);
-          if (e === -1) {
-            cleaned = cleaned.slice(0, s);
-            break;
-          }
-          cleaned = cleaned.slice(0, s) + cleaned.slice(e + end.length);
-        }
-      }
-      cleaned = cleaned.trim();
-      return { ...msg, content: cleaned || "[thinking compressed]" };
     }
 
     return msg;

--- a/open-sse/transformer/responsesTransformer.ts
+++ b/open-sse/transformer/responsesTransformer.ts
@@ -91,7 +91,6 @@ export function createResponsesApiTransformStream(logger = null, keepaliveInterv
     reasoningBuf: "",
     reasoningPartAdded: false,
     reasoningDone: false,
-    inThinking: false,
     funcArgsBuf: {},
     funcNames: {},
     funcCallIds: {},
@@ -443,42 +442,17 @@ export function createResponsesApiTransformStream(logger = null, keepaliveInterv
             emitReasoningDelta(controller, delta.reasoning_content);
           }
 
-          // Handle text content (may contain <think> tags)
+          // Handle text content
           if (delta.content) {
             // Close reasoning if it was opened via native reasoning_content
             // and is still open, before emitting message content. Without this
             // the reasoning item is never closed and the message reuses the
             // reasoning output_index, producing a protocol-invalid stream.
-            // Guard on !inThinking: reasoning opened via <think> tags is closed by
-            // its matching </think> below — force-closing it here would snapshot a
-            // partial buffer (dense output records the item at close time). (#4848 + #4906)
-            if (state.reasoningId && !state.reasoningDone && !state.inThinking) {
+            if (state.reasoningId && !state.reasoningDone) {
               closeReasoning(controller);
             }
 
             let content = delta.content;
-
-            if (content.includes("<think>")) {
-              state.inThinking = true;
-              content = content.replaceAll("<think>", "");
-              startReasoning(controller, idx);
-            }
-
-            if (content.includes("</think>")) {
-              const parts = content.split("</think>");
-              const thinkPart = parts[0];
-              const textPart = parts.slice(1).join("</think>");
-
-              if (thinkPart) emitReasoningDelta(controller, thinkPart);
-              closeReasoning(controller);
-              state.inThinking = false;
-              content = textPart;
-            }
-
-            if (state.inThinking && content) {
-              emitReasoningDelta(controller, content);
-              continue;
-            }
 
             // Regular text content
             if (content) {

--- a/open-sse/translator/index.ts
+++ b/open-sse/translator/index.ts
@@ -289,8 +289,7 @@ export function translateRequest(
     // requested upstream; generic/implicit-cache OpenAI providers stay stripped.
     result = filterToOpenAIFormat(result, {
       preserveCacheControl:
-        options?.preserveCacheControl === true &&
-        providerHonorsOpenAIFormatCacheControl(provider),
+        options?.preserveCacheControl === true && providerHonorsOpenAIFormatCacheControl(provider),
       // #4849 regression guard: keep client reasoning_content for replay providers.
       preserveReasoningContent: isReasoner,
     });
@@ -586,7 +585,6 @@ export function initState(sourceFormat) {
       reasoningBuf: "",
       reasoningPartAdded: false,
       reasoningDone: false,
-      inThinking: false,
       funcArgsBuf: {},
       funcNames: {},
       funcCallIds: {},

--- a/open-sse/translator/response/gemini-to-openai.ts
+++ b/open-sse/translator/response/gemini-to-openai.ts
@@ -46,6 +46,11 @@ type GeminiFunctionCallPart = {
   };
 };
 
+type GeminiToOpenAIResponseOptions = {
+  parseTextualReasoningTags: boolean;
+  unwrapResponseEnvelope?: boolean;
+};
+
 const REASONING_TAG_OPEN_REGEX =
   /<(think|thinking|thought|internal_thought)(?=\s|>|\r?\n)(?:\s[^>]*)?(?:>|\r?\n)/i;
 const REASONING_TAG_OPEN_PREFIXES = ["<think", "<thinking", "<thought", "<internal_thought"];
@@ -289,15 +294,17 @@ function emitFunctionCallPart(
   });
 }
 
-// Convert Gemini response chunk to OpenAI format
-export function geminiToOpenAIResponse(chunk, state) {
+function geminiLikeToOpenAIResponse(chunk, state, options: GeminiToOpenAIResponseOptions) {
   if (!chunk) return null;
 
-  // Handle Antigravity wrapper
-  const response = chunk.response || chunk;
+  const response =
+    options.unwrapResponseEnvelope && chunk && typeof chunk === "object" && "response" in chunk
+      ? chunk.response
+      : chunk;
   if (!response) return null;
 
   const results = [];
+  const parseTextualReasoningTags = options.parseTextualReasoningTags;
   const candidate = response.candidates?.[0];
 
   if (!candidate) {
@@ -438,16 +445,18 @@ export function geminiToOpenAIResponse(chunk, state) {
         }
 
         if (hasFunctionCall) {
-          // Flush any still-open textual reasoning wrapper as reasoning_content BEFORE
-          // the tool call. A signed native functionCall arriving while a `<thinking>`
-          // (etc.) tag opened in an earlier chunk is still buffered must not silently
-          // drop that buffered reasoning — flushOpenTextualReasoning emits it and clears
-          // the active-tag/content buffers. (LEDGER-4 / #3821-review)
-          flushOpenTextualReasoning(state, results);
-          // Also drop any partial open-tag fragment buffered at a chunk boundary
-          // (flushOpenTextualReasoning early-returns when only this is set), matching the
-          // pre-fix branch which cleared all three buffers. (#3821-review convergence)
-          state.textualReasoningTagBuffer = undefined;
+          if (parseTextualReasoningTags) {
+            // Flush any still-open textual reasoning wrapper as reasoning_content BEFORE
+            // the tool call. A signed native functionCall arriving while a `<thinking>`
+            // (etc.) tag opened in an earlier chunk is still buffered must not silently
+            // drop that buffered reasoning — flushOpenTextualReasoning emits it and clears
+            // the active-tag/content buffers. (LEDGER-4 / #3821-review)
+            flushOpenTextualReasoning(state, results);
+            // Also drop any partial open-tag fragment buffered at a chunk boundary
+            // (flushOpenTextualReasoning early-returns when only this is set), matching the
+            // pre-fix branch which cleared all three buffers. (#3821-review convergence)
+            state.textualReasoningTagBuffer = undefined;
+          }
           emitFunctionCallPart(part, state, results);
         }
         continue;
@@ -459,7 +468,9 @@ export function geminiToOpenAIResponse(chunk, state) {
       // back to a structured OpenAI tool call so clients/tools do not see it as
       // assistant prose.
       if (part.text !== undefined && part.text !== "") {
-        const afterReasoning = consumeTextualReasoningTags(part.text, state, results);
+        const afterReasoning = parseTextualReasoningTags
+          ? consumeTextualReasoningTags(part.text, state, results)
+          : part.text;
         if (!afterReasoning) continue;
 
         let accumulated = (state.textualToolCallBuffer || "") + afterReasoning;
@@ -746,7 +757,19 @@ export function geminiToOpenAIResponse(chunk, state) {
   return results.length > 0 ? results : null;
 }
 
+// Convert Gemini response chunk to OpenAI format.
+export function geminiToOpenAIResponse(chunk, state) {
+  return geminiLikeToOpenAIResponse(chunk, state, { parseTextualReasoningTags: true });
+}
+
+// Convert Antigravity/Agy Gemini-shaped response chunks to OpenAI format.
+export function antigravityToOpenAIResponse(chunk, state) {
+  return geminiLikeToOpenAIResponse(chunk, state, {
+    parseTextualReasoningTags: false,
+    unwrapResponseEnvelope: true,
+  });
+}
+
 // Register
 register(FORMATS.GEMINI, FORMATS.OPENAI, null, geminiToOpenAIResponse);
-register(FORMATS.GEMINI_CLI, FORMATS.OPENAI, null, geminiToOpenAIResponse);
-register(FORMATS.ANTIGRAVITY, FORMATS.OPENAI, null, geminiToOpenAIResponse);
+register(FORMATS.ANTIGRAVITY, FORMATS.OPENAI, null, antigravityToOpenAIResponse);

--- a/open-sse/translator/response/kiro-to-openai.ts
+++ b/open-sse/translator/response/kiro-to-openai.ts
@@ -92,7 +92,6 @@ export function convertKiroToOpenAI(chunk, state) {
     const content = data.reasoningContentEvent?.content || data.content || "";
     if (!content) return null;
 
-    // Convert to thinking block format (Claude-style)
     const openaiChunk = {
       id: state.responseId,
       object: "chat.completion.chunk",
@@ -103,7 +102,7 @@ export function convertKiroToOpenAI(chunk, state) {
           index: 0,
           delta: {
             ...(state.chunkIndex === 0 ? { role: "assistant" } : {}),
-            content: `<thinking>${content}</thinking>`,
+            reasoning_content: content,
           },
           finish_reason: null,
         },

--- a/open-sse/translator/response/openai-responses.ts
+++ b/open-sse/translator/response/openai-responses.ts
@@ -128,35 +128,11 @@ export function openaiToOpenAIResponsesResponse(chunk, state) {
     // Close reasoning if it was opened via native reasoning_content and is
     // still open, before emitting message content. Otherwise the reasoning
     // item is never closed and the message reuses its output_index.
-    // Guard on !inThinking: reasoning opened via <think> tags is closed by its
-    // matching </think> below — force-closing it here would snapshot a partial
-    // buffer (dense output records the item at close time). (#4848 + #4906)
-    if (state.reasoningId && !state.reasoningDone && !state.inThinking) {
+    if (state.reasoningId && !state.reasoningDone) {
       closeReasoning(state, emit);
     }
 
-    let content = delta.content;
-
-    if (content.includes("<think>")) {
-      state.inThinking = true;
-      content = content.replaceAll("<think>", "");
-      startReasoning(state, emit, idx);
-    }
-
-    if (content.includes("</think>")) {
-      const parts = content.split("</think>");
-      const thinkPart = parts[0];
-      const textPart = parts.slice(1).join("</think>");
-      if (thinkPart) emitReasoningDelta(state, emit, thinkPart);
-      closeReasoning(state, emit);
-      state.inThinking = false;
-      content = textPart;
-    }
-
-    if (state.inThinking && content) {
-      emitReasoningDelta(state, emit, content);
-      return events;
-    }
+    const content = delta.content;
 
     if (content) {
       // Use a distinct output_index for the message when reasoning was

--- a/tests/unit/context-manager.test.ts
+++ b/tests/unit/context-manager.test.ts
@@ -122,6 +122,41 @@ test("compressContext: Layer 2 — compresses thinking in old messages", () => {
   }
 });
 
+test("compressContext: Layer 2 preserves prompt-format thinking tags in text content", () => {
+  const taggedContent = "<thinking>visible prompt-format text</thinking><content>answer</content>";
+  const body = {
+    model: "test",
+    messages: [
+      { role: "user", content: "q1" },
+      { role: "assistant", content: taggedContent },
+      { role: "user", content: "q2" },
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "structured thinking ".repeat(5000) },
+          { type: "text", text: "answer2" },
+        ],
+      },
+      { role: "user", content: "q3" },
+      { role: "assistant", content: "latest answer" },
+    ],
+  };
+
+  const result = compressContext(body, { maxTokens: 3000, reserveTokens: 0 });
+  assert.equal(result.compressed, true);
+  const layers = result.stats.layers as Array<{ name: string }>;
+  assert.ok(layers.some((layer) => layer.name === "compress_thinking"));
+  assert.equal(
+    layers.some((layer) => layer.name === "purify_history"),
+    false
+  );
+
+  const firstAssistant = (
+    result.body as { messages: Array<{ role?: unknown; content?: unknown }> }
+  ).messages.find((message) => message.role === "assistant" && typeof message.content === "string");
+  assert.equal(firstAssistant?.content, taggedContent);
+});
+
 test("compressContext: Layer 3 — drops old messages to fit", () => {
   const messages = [
     { role: "system", content: "You are helpful" },

--- a/tests/unit/response-sanitizer.test.ts
+++ b/tests/unit/response-sanitizer.test.ts
@@ -65,7 +65,7 @@ test("sanitizeOpenAIResponse strips non-standard fields and preserves required t
   });
 });
 
-test("sanitizeOpenAIResponse extracts thinking, collapses newlines, preserves reasoning_content with tool_calls, and preserves tool calls", () => {
+test("sanitizeOpenAIResponse preserves prompt-format tags as content and preserves tool calls", () => {
   const sanitized = sanitizeOpenAIResponse({
     id: "chatcmpl_test",
     model: "gpt-4.1",
@@ -85,13 +85,16 @@ test("sanitizeOpenAIResponse extracts thinking, collapses newlines, preserves re
 
   assert.equal((sanitized as any).choices[0].index, 2);
   assert.equal((sanitized as any).choices[0].finish_reason, "tool_calls");
-  (assert as any).equal((sanitized as any).choices[0].message.content, "Hello\n\nworld");
-  assert.equal((sanitized as any).choices[0].message.reasoning_content, "internal chain");
+  (assert as any).equal(
+    (sanitized as any).choices[0].message.content,
+    "Hello\n\n<think>internal chain</think>\n\nworld"
+  );
+  assert.equal((sanitized as any).choices[0].message.reasoning_content, undefined);
   (assert as any).deepEqual((sanitized as any).choices[0].message.tool_calls, [{ id: "call_1" }]);
   assert.deepEqual((sanitized as any).choices[0].message.function_call, { name: "legacy" });
 });
 
-test("sanitizeOpenAIResponse extracts unclosed reasoning wrappers into reasoning_content", () => {
+test("sanitizeOpenAIResponse preserves unclosed prompt-format wrappers as content", () => {
   const sanitized = sanitizeOpenAIResponse({
     model: "gpt-4.1",
     choices: [
@@ -104,11 +107,11 @@ test("sanitizeOpenAIResponse extracts unclosed reasoning wrappers into reasoning
     ],
   });
 
-  assert.equal((sanitized as any).choices[0].message.content, "");
-  assert.equal((sanitized as any).choices[0].message.reasoning_content, "internal planning");
+  assert.equal((sanitized as any).choices[0].message.content, "§54§ <thought\ninternal planning");
+  assert.equal((sanitized as any).choices[0].message.reasoning_content, undefined);
 });
 
-test("sanitizeOpenAIResponse preserves native reasoning_content when no visible content remains", () => {
+test("sanitizeOpenAIResponse preserves native reasoning_content without stripping content tags", () => {
   const sanitized = sanitizeOpenAIResponse({
     model: "gpt-4.1",
     choices: [
@@ -122,7 +125,7 @@ test("sanitizeOpenAIResponse preserves native reasoning_content when no visible 
     ],
   });
 
-  assert.equal(((sanitized as any).choices[0].message as any).content, "");
+  assert.equal(((sanitized as any).choices[0].message as any).content, "<think>discard me</think>");
   assert.equal((sanitized as any).choices[0].message.reasoning_content, "provider reasoning");
 });
 
@@ -246,7 +249,10 @@ test("sanitizeOpenAIResponse preserves OpenRouter native reasoning and signature
   assert.deepEqual((sanitized as any).choices[0].message.reasoning_details, [
     { type: "reasoning.encrypted", data: "sig" },
   ]);
-  assert.equal((sanitized as any).choices[0].message.content, "<content>Visible answer</content>");
+  assert.equal(
+    (sanitized as any).choices[0].message.content,
+    "<thinking>tag-derived</thinking><content>Visible answer</content>"
+  );
 });
 
 test("sanitizeOpenAIResponse keeps reasoning_details-derived reasoning_content for reasoning-only messages", () => {
@@ -436,6 +442,26 @@ test("sanitizeStreamingChunk keeps only safe chunk fields and preserves readable
     },
     system_fingerprint: "fp_123",
   });
+});
+
+test("sanitizeStreamingChunk preserves prompt-format tags in content deltas", () => {
+  const sanitized = sanitizeStreamingChunk({
+    choices: [
+      {
+        index: 0,
+        delta: {
+          content: "<thinking>\n[metacognition]\n</thinking><content>answer</content>",
+        },
+        finish_reason: null,
+      },
+    ],
+  });
+
+  assert.equal(
+    (sanitized as any).choices[0].delta.content,
+    "<thinking>\n[metacognition]\n</thinking><content>answer</content>"
+  );
+  assert.equal((sanitized as any).choices[0].delta.reasoning_content, undefined);
 });
 
 test("sanitizeStreamingChunk converts reasoning_details arrays in deltas", () => {

--- a/tests/unit/responses-transformer.test.ts
+++ b/tests/unit/responses-transformer.test.ts
@@ -83,7 +83,7 @@ test("createResponsesApiTransformStream converts plain chat deltas into Response
   assert.equal(doneMarker.data, "[DONE]");
 });
 
-test("createResponsesApiTransformStream converts think tags into reasoning summaries", async () => {
+test("createResponsesApiTransformStream preserves prompt-format think tags as text", async () => {
   const output = await runTransformStream([
     'data: {"choices":[{"index":0,"delta":{"content":"<think>plan"}}]}\n\n',
     'data: {"choices":[{"index":0,"delta":{"content":"ning</think>answer"}}]}\n\n',
@@ -98,14 +98,9 @@ test("createResponsesApiTransformStream converts think tags into reasoning summa
     events.find((event) => event.event === "response.completed").data
   ).response;
 
-  assert.deepEqual(reasoningDeltas, ["plan", "ning"]);
-  assert.deepEqual(completed.output[0], {
-    id: completed.output[0].id,
-    type: "reasoning",
-    summary: [{ type: "summary_text", text: "planning" }],
-  });
-  assert.deepEqual(completed.output[1].content, [
-    { type: "output_text", annotations: [], logprobs: [], text: "answer" },
+  assert.deepEqual(reasoningDeltas, []);
+  assert.deepEqual(completed.output[0].content, [
+    { type: "output_text", annotations: [], logprobs: [], text: "<think>planning</think>answer" },
   ]);
 });
 

--- a/tests/unit/translator-resp-gemini-to-openai.test.ts
+++ b/tests/unit/translator-resp-gemini-to-openai.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-const { geminiToOpenAIResponse } =
+const { antigravityToOpenAIResponse, geminiToOpenAIResponse } =
   await import("../../open-sse/translator/response/gemini-to-openai.ts");
 const { translateNonStreamingResponse } =
   await import("../../open-sse/handlers/responseTranslator.ts");
@@ -423,6 +423,77 @@ test("Gemini stream: routes textual reasoning tags to reasoning_content before t
     .delta.tool_calls[0];
   assert.equal(toolCall.id, "call_grep");
   assert.equal(result.at(-1).choices[0].finish_reason, "tool_calls");
+});
+
+test("Antigravity/Agy stream: prompt-format thinking tags remain content before tool calls", () => {
+  const state = createStreamingState();
+  const result = antigravityToOpenAIResponse(
+    {
+      response: {
+        responseId: "resp-agy-prompt-tags",
+        modelVersion: "claude-opus-4-6-thinking",
+        candidates: [
+          {
+            content: {
+              parts: [
+                { text: "<thinking>prompt-required section</thinking><content>answer</content>" },
+                {
+                  functionCall: {
+                    id: "call_lookup",
+                    name: "lookup",
+                    args: { query: "status" },
+                  },
+                },
+              ],
+            },
+            finishReason: "STOP",
+          },
+        ],
+      },
+    },
+    state
+  );
+
+  const content = result.map((event: any) => event.choices?.[0]?.delta?.content || "").join("");
+  assert.equal(content, "<thinking>prompt-required section</thinking><content>answer</content>");
+  assert.equal(
+    result.some((event: any) => event.choices?.[0]?.delta?.reasoning_content),
+    false
+  );
+  const toolCall = result.find((event: any) => event.choices?.[0]?.delta?.tool_calls)?.choices[0]
+    .delta.tool_calls[0];
+  assert.equal(toolCall.id, "call_lookup");
+});
+
+test("Antigravity/Agy stream: native Gemini thought parts still become reasoning_content", () => {
+  const state = createStreamingState();
+  const result = antigravityToOpenAIResponse(
+    {
+      response: {
+        responseId: "resp-agy-native-thought",
+        modelVersion: "gemini-3.5-flash-low",
+        candidates: [
+          {
+            content: {
+              parts: [{ thought: true, text: "native thought" }, { text: "visible answer" }],
+            },
+            finishReason: "STOP",
+          },
+        ],
+      },
+    },
+    state
+  );
+
+  assert.equal(
+    result.find((event: any) => event.choices?.[0]?.delta?.reasoning_content)?.choices[0].delta
+      .reasoning_content,
+    "native thought"
+  );
+  assert.equal(
+    result.find((event: any) => event.choices?.[0]?.delta?.content)?.choices[0].delta.content,
+    "visible answer"
+  );
 });
 
 test("Gemini stream: keeps textual reasoning hidden across split chunks", () => {
@@ -1174,7 +1245,10 @@ test("Gemini stream: open textual reasoning is flushed before a signed native to
     "buffered textual reasoning must be flushed, not dropped, when a tool call arrives"
   );
   assert.equal(r2[toolIdx]?.choices[0].delta.tool_calls[0].id, "call-flush-1");
-  assert.ok(reasoningIdx >= 0 && toolIdx > reasoningIdx, "reasoning is emitted before the tool call");
+  assert.ok(
+    reasoningIdx >= 0 && toolIdx > reasoningIdx,
+    "reasoning is emitted before the tool call"
+  );
 });
 
 // #3821-review LEDGER-15 — a reasoning-only chunk interrupting a partially-buffered

--- a/tests/unit/translator-resp-kiro-to-openai.test.ts
+++ b/tests/unit/translator-resp-kiro-to-openai.test.ts
@@ -26,13 +26,14 @@ test("Kiro -> OpenAI: subsequent assistantResponseEvent omits role", () => {
   assert.equal(result.choices[0].delta.content, "lo");
 });
 
-test("Kiro -> OpenAI: reasoningContentEvent is wrapped as thinking tags", () => {
+test("Kiro -> OpenAI: reasoningContentEvent emits native reasoning_content", () => {
   const result = convertKiroToOpenAI(
     'event:reasoningContentEvent\ndata:{"content":"Need to inspect first"}\n\n',
     {}
   );
 
-  assert.equal(result.choices[0].delta.content, "<thinking>Need to inspect first</thinking>");
+  assert.equal(result.choices[0].delta.reasoning_content, "Need to inspect first");
+  assert.equal(result.choices[0].delta.content, undefined);
 });
 
 test("Kiro -> OpenAI: toolUseEvent becomes OpenAI tool_calls", () => {

--- a/tests/unit/translator-resp-openai-responses.test.ts
+++ b/tests/unit/translator-resp-openai-responses.test.ts
@@ -112,7 +112,7 @@ test("OpenAI -> Responses: flush on null closes text content and emits response.
   assert.ok(events.some((event) => event.event === "response.completed"));
 });
 
-test("OpenAI -> Responses: <think> tags become reasoning events and normal text still streams", () => {
+test("OpenAI -> Responses: prompt-format <think> tags remain text", () => {
   const events = collectEvents([
     {
       id: "chatcmpl-3",
@@ -130,13 +130,13 @@ test("OpenAI -> Responses: <think> tags become reasoning events and normal text 
   assert.ok(
     events.some(
       (event) =>
-        event.event === "response.reasoning_summary_text.delta" && event.data.delta === "Plan it"
+        event.event === "response.output_text.delta" &&
+        event.data.delta === "<think>Plan it</think>Done."
     )
   );
-  assert.ok(
-    events.some(
-      (event) => event.event === "response.output_text.delta" && event.data.delta === "Done."
-    )
+  assert.equal(
+    events.some((event) => event.event === "response.reasoning_summary_text.delta"),
+    false
   );
 });
 


### PR DESCRIPTION
## Summary

This splits the prompt-tag boundary fix out from #5197 as a focused PR against `release/v3.8.39`.

The intended boundary is:

- provider/protocol-native reasoning stays reasoning (`reasoning_content`, `reasoning`, `reasoning_details`, Gemini `thought` parts, Kiro reasoning events, etc.)
- provider-specific inline-thinking paths that explicitly rely on textual markers continue to parse those markers in their own translators/executors
- generic OpenAI-compatible sanitization and generic OpenAI -> Responses conversion do not infer protocol reasoning from ordinary `delta.content` / `message.content` text containing `<think>` or `<thinking>` tags

This avoids rewriting upstream content when prompts intentionally ask the model to output XML-like sections such as `<thinking>` / `<content>`, which improves compatibility with clients that parse those sections themselves.

## Changes

- Stop `sanitizeOpenAIResponse()` / `sanitizeStreamingChunk()` from extracting `<think>` / `<thinking>` / `<thought>` blocks from generic message content.
- Keep native OpenAI-compatible reasoning fields untouched and client-readable.
- Stop generic Chat Completions -> Responses conversion from treating `<think>` in `delta.content` as Responses reasoning events.
- Keep Gemini textual reasoning handling in the Gemini response translator, where that path already depends on textual reasoning markers.
- Route Antigravity/Agy through a separate response translator entry point that does not infer reasoning from prompt-format text tags, while still mapping native Gemini `thought` parts to `delta.reasoning_content`.
- Remove the legacy Gemini CLI -> OpenAI response registration from this translator path; that channel is no longer maintained upstream.
- Convert Kiro `reasoningContentEvent` directly to `delta.reasoning_content` instead of wrapping it as `<thinking>...</thinking>` and relying on a generic downstream parser.
- Preserve string `<thinking>...</thinking>` prompt-format content during context compression; only structured `type: "thinking"` blocks are compressed.

## Validation

- `node --import tsx --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test tests/unit/translator-resp-gemini-to-openai.test.ts tests/unit/response-sanitizer.test.ts tests/unit/responses-transformer.test.ts tests/unit/translator-resp-openai-responses.test.ts tests/unit/translator-resp-kiro-to-openai.test.ts tests/unit/context-manager.test.ts tests/unit/kiroThinking.test.ts tests/unit/stream-utils.test.ts`