### PR TITLE
chore(docker): harden base image against container-scan CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,27 @@
 FROM node:24-trixie-slim AS base
 WORKDIR /app
 
+# `apt-get upgrade` pulls the security-patched versions of the Debian (trixie)
+# base-image packages at build time — clears the subset of container-scan CVEs
+# (perl / util-linux / systemd / ncurses / zlib / tar / sqlite / shadow / pam …)
+# that already have a fix published in trixie. CVEs without an upstream fix yet
+# (local-only TOCTOU, etc.) remain until the distro patches them and the image
+# is rebuilt; none are reachable from the proxy's request surface at runtime.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=shared \
   --mount=type=cache,target=/var/lib/apt/lists,sharing=shared \
   apt-get update \
+  && apt-get upgrade -y \
   && apt-get install -y --no-install-recommends libsecret-1-0 ca-certificates \
   && rm -rf /var/lib/apt/lists/*
+
+# Refresh the globally-installed npm so its *bundled* node_modules (undici, tar)
+# ship the patched versions. These are npm's own internals — not application
+# dependencies (our app already resolves undici@8.5.0 / tar@7.5.16, both fixed) —
+# but the container scanner flags the stale copies under
+# /usr/local/lib/node_modules/npm/node_modules. npm is not invoked at runtime in
+# the runner stages, so this is hygiene, not an exploitable runtime path.
+RUN npm install -g npm@latest \
+  && npm cache clean --force
 
 # ── Builder ────────────────────────────────────────────────────────────────
 FROM base AS builder


### PR DESCRIPTION
Resolve a parcela acionável dos alertas de **container/dependency CVE** do painel de code-scanning (#615–#664), que vivem inteiramente na camada da imagem Docker — nenhum no código-fonte ou nas dependências do app.

## Mudança
No stage `base` do `Dockerfile`:
- `apt-get upgrade -y` → puxa os pacotes Debian (trixie) já corrigidos no momento do build (perl / util-linux / systemd / ncurses / zlib / tar / sqlite / shadow / pam …).
- `npm install -g npm@latest && npm cache clean --force` → refresca o undici/tar **empacotados dentro do npm global** (`/usr/local/lib/node_modules/npm/node_modules`), que o scanner flaga (CVE-2026-12151/11525/9679/6733 e tar CVE-2026-53655).

## Por que é seguro / escopo
- **Nenhum CVE está na árvore de deps do app** — já resolvemos `undici@8.5.0` e `tar@7.5.16` (ambos corrigidos); o scanner só flaga as cópias internas do npm e os pacotes OS da base-image.
- Os binários afetados (npm, perl, mount, tar) **não são alcançáveis pela superfície de request** do proxy em runtime; a maioria dos OS-CVEs é local-only/TOCTOU.
- CVEs **sem fix publicado** no trixie (TOCTOU de mount sem patch, etc.) permanecem até o distro corrigir e a imagem ser rebuildada — `apt-get upgrade` não os resolve por não haver pacote.

## Validação
- `Dockerfile` apenas; nenhum código em `src/`/`open-sse/`/`electron/`/`bin/` → sem requisito de teste unitário (PR rule).
- Build local do daemon Docker indisponível nesta máquina; o job **docker-publish** do CI valida o build completo da imagem no merge.

Os 5 alertas CodeQL do mesmo painel (3× url-substring em arrays `.includes`, 2× ReDoS em fixtures de teste) já foram dispensados como false-positive/used-in-tests.

Cherry-pick para `release/v3.8.40` em PR separado.