### PR TITLE
chore(ci): Trivy advisory scan ignores unfixed CVEs (Security-tab noise)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -344,6 +344,15 @@ jobs:
 
       # Visibility scan: reports HIGH + CRITICAL into the SARIF (Security tab) but
       # never blocks (exit-code 0). The blocking gate below narrows to CRITICAL.
+      #
+      # ignore-unfixed mirrors the blocking gate: the Security tab must surface only
+      # ACTIONABLE vulnerabilities — ones with a published fix we can pull by rebuilding
+      # on a patched base or bumping the dep. Without it the advisory upload floods the
+      # tab with unfixable base-image OS CVEs (Debian trixie packages with no upstream
+      # patch yet, overwhelmingly local-only and not reachable from the proxy request
+      # surface), which is noise an operator cannot act on. trivyignores points at the
+      # repo-root .trivyignore so accepted-risk fixable CVEs have one auditable home.
+      # See docs/security/SUPPLY_CHAIN.md.
       - name: Trivy image scan (SARIF, advisory)
         if: needs.prepare.outputs.version != 'main'
         continue-on-error: true
@@ -353,6 +362,8 @@ jobs:
           format: sarif
           output: trivy-results.sarif
           severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          trivyignores: .trivyignore
           exit-code: "0"
 
       # BLOCKING gate (v3.8.27 cycle-end): fail the release on a CRITICAL CVE in the

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,22 @@
+# .trivyignore — accepted-risk suppressions for the container image scan
+#
+# Policy (see docs/security/SUPPLY_CHAIN.md):
+#   - The Trivy steps in .github/workflows/docker-publish.yml run with
+#     `ignore-unfixed: true`, so vulnerabilities WITHOUT a published fix are
+#     already excluded from both the blocking CRITICAL gate and the advisory
+#     Security-tab upload. You do NOT need an entry here for an unfixable
+#     base-image OS CVE — it will not be reported.
+#   - This file is the single auditable home for the rare case where a *fixable*
+#     CVE must be temporarily accepted (e.g. the upstream fix is not yet in the
+#     pinned base tag, or the affected package/binary is provably unreachable
+#     from the proxy request surface and rebuilding now is not justified).
+#
+# Format — one CVE id per line, each with a justification comment and, where
+# possible, an expiry, e.g.:
+#   # CVE-XXXX-YYYY — <why accepted>; revisit on next base-image bump (YYYY-MM-DD)
+#   CVE-XXXX-YYYY
+#
+# Keep this list SHORT and reviewed every release. Prefer fixing (rebuild on a
+# patched base / bump the dep) over suppressing. Stale entries are debt.
+#
+# (No accepted-risk suppressions at present — ignore-unfixed covers the noise.)


### PR DESCRIPTION
Continuação do hardening de container (#5228/#5229). Ataca a causa do **painel de code-scanning com 155 alertas**: são 100% Trivy (scan da imagem), e o passo *advisory* despejava todo HIGH/CRITICAL na aba Security **sem `ignore-unfixed`** — ~150 eram CVEs de base-image Debian trixie **sem patch upstream**, em sua maioria local-only e não-alcançáveis pela superfície de request. Ruído puro que o operador não tem como corrigir.

## Mudança
- `ignore-unfixed: true` no passo advisory do Trivy (`docker-publish.yml`) → aba Security passa a mostrar só vulnerabilidades **acionáveis/fixáveis**, espelhando o gate bloqueante de CRITICAL que já usa essa flag.
- Novo `.trivyignore` na raiz documentando a política de risco-aceito (sem supressões no momento — `ignore-unfixed` cobre o ruído).

## Efeito
Vale no **próximo build de imagem de release** (Trivy só roda em build de tag, não em push de main). No re-scan da imagem endurecida (#5228) os CVEs corrigidos somem do SARIF e o GitHub auto-resolve os alertas; os sem-fix deixam de ser reportados.

Os 155 alertas atuais serão dispensados em massa via API (won't fix, container-scan não-alcançável) para limpar a aba imediatamente.

Cherry-pick para `release/v3.8.40` em PR separado.