### PR TITLE
fix(combo): restore sessionless per-conversation model stickiness (#3825)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ _In development — bullets added per PR; finalized at release._
 ### 🔧 Bug Fixes
 
 - **command-code:** omit `max_tokens` when the client omits it so the upstream applies the model's native default, fixing `400 "expected <=200000"` on `/alpha/generate` for high-cap models; an explicit oversized client value is clamped to the 200k endpoint ceiling (#5221 — thanks @adivekar-utexas)
+- **combo:** restore per-conversation model stickiness for sessionless clients (Codex CLI, Claude Code, and most OpenAI-compatible tools that send no session id). #3399 gated the server-side context-cache pin on a client session id, so these clients re-ran the routing strategy every turn → upstream prompt-cache misses → cold high-reasoning starts and intermittent `504`/throughput collapse under concurrency. Combos now derive a stable per-conversation fingerprint and re-pin by default (no `context_cache_protection` toggle required), restoring the pre-#3399 behavior. Turn 1 still runs the strategy, so cross-conversation load spreading is unchanged; only turns 2+ of the same conversation stick. The with-session-id pin and universal-handoff paths are untouched (#3825 — thanks @bypanghu, @jpsn123, @xz-dev)
 
 ---
 

--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -2078,12 +2078,14 @@ export async function handleComboChat({
               fallbackCount,
             });
 
-            // Context cache pinning: record model usage for session-based pinning
-            // (independent of universal handoff — always fires when context_cache_protection is on)
-            // #3825: write under the SAME effectiveSessionId used by the read site so a
-            // sessionless conversation re-pins to this model on its next turn.
+            // Context cache pinning: record model usage for session-based pinning.
+            // #3825: write under the SAME effectiveSessionId the read site
+            // (resolveContextCachePin) computes so a sessionless conversation re-pins to this
+            // model on its next turn. effectiveSessionId carries the scoping: it is the derived
+            // fingerprint for sessionless clients (default-on stickiness, the #3825 fix), the
+            // real session id only when context_cache_protection is on, and null otherwise — so
+            // this write fires for exactly the cases the read site (resolveContextCachePin) pins.
             if (
-              combo.context_cache_protection &&
               effectiveSessionId &&
               !(body as Record<string, unknown>)?.[SKIP_UNIVERSAL_HANDOFF_FLAG]
             ) {

--- a/open-sse/services/combo/comboSetup.ts
+++ b/open-sse/services/combo/comboSetup.ts
@@ -47,8 +47,9 @@ export interface ComboSetup {
  *
  * #3825: when the client sends no session id (most OpenAI-compatible clients), fall back to a
  * stable conversation fingerprint derived from the body so the combo still re-pins across
- * turns. ONLY engaged when context_cache_protection is truthy — when off, behaviour is
- * unchanged (combos rotate as before, no pin read/write, no <omniModel> tag).
+ * turns. This per-conversation stickiness is the DEFAULT (restoring the pre-#3399 <omniModel>-tag
+ * contract) and no longer requires context_cache_protection — turn 1 still runs the strategy
+ * (so different conversations spread across models); only turns 2+ re-pin within a conversation.
  *
  * Extracted from phaseComboSetup to keep that function under the complexity ceiling and to
  * further the combo god-file decomposition.
@@ -58,12 +59,22 @@ function resolveContextCachePin(ctx: ComboContext): {
   pinnedModel: string | null;
 } {
   const { combo, relayOptions, log } = ctx;
-  const effectiveSessionId: string | null = combo.context_cache_protection
-    ? (relayOptions?.sessionId ?? deriveComboSessionKey(ctx.body))
-    : null;
+  // #3825: restore per-conversation stickiness for SESSIONLESS clients (most
+  // OpenAI-compatible tools — Codex CLI, Claude Code) that lost it in #3399. The fix is
+  // intentionally scoped to the sessionless path: when no client session id is present we
+  // derive a stable conversation fingerprint (deriveComboSessionKey) and engage the pin by
+  // DEFAULT — context_cache_protection is no longer required. When a real session id IS
+  // present the prior behavior is unchanged (pin stays opt-in via context_cache_protection;
+  // universal handoff owns session_model_history), so the with-sessionId pin/handoff paths
+  // are untouched. Turn 1 always runs the strategy, so cross-conversation spreading holds;
+  // only turns 2+ of one conversation re-pin to the model turn 1 picked.
+  const effectiveSessionId: string | null = relayOptions?.sessionId
+    ? combo.context_cache_protection
+      ? relayOptions.sessionId
+      : null
+    : deriveComboSessionKey(ctx.body);
   let pinnedModel: string | null = null;
   if (
-    combo.context_cache_protection &&
     effectiveSessionId &&
     !(ctx.body as Record<string, unknown>)?.[SKIP_UNIVERSAL_HANDOFF_FLAG]
   ) {

--- a/tests/unit/combo-sessionless-pin-3825.test.ts
+++ b/tests/unit/combo-sessionless-pin-3825.test.ts
@@ -11,7 +11,10 @@ import path from "node:path";
 // strategy (round-robin rotated) → upstream prompt-cache misses, cold high-reasoning
 // starts, intermittent 504s. The fix derives a stable per-conversation key from the
 // request body when no session id is present, so a combo re-pins to the same model
-// across turns of the same conversation — but ONLY when context_cache_protection is on.
+// across turns of the same conversation. This per-conversation stickiness is now the
+// DEFAULT (restoring the pre-#3399 <omniModel>-tag contract) — it no longer requires
+// context_cache_protection to be on. Turn 1 always runs the strategy, so different
+// conversations still spread across models; only turns 2+ re-pin within a conversation.
 
 const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-combo-pin-3825-"));
 const ORIGINAL_DATA_DIR = process.env.DATA_DIR;
@@ -131,14 +134,16 @@ test("context_cache_protection ON + NO sessionId: combo re-pins to the same mode
   );
 });
 
-test("context_cache_protection OFF + NO sessionId: no pin, strategy re-runs each turn, no <omniModel> tag (#3825 scope guard)", async () => {
+test("context_cache_protection OFF + NO sessionId: sessionless pin engages by DEFAULT, no <omniModel> tag (#3825)", async () => {
   const calls: string[] = [];
   const forwardedContents: string[] = [];
   // Identical priority+failover setup as the positive case, but with the toggle OFF.
+  // #3825: per-conversation stickiness is now the default and must engage even with the
+  // toggle off — this replaces the former scope-guard that asserted toggle-off rotation.
   const combo = {
     name: "unprotected-priority",
     strategy: "priority",
-    // context_cache_protection intentionally omitted (falsy) — #3399 behavior preserved.
+    // context_cache_protection intentionally omitted (falsy) — must still re-pin.
     models: ["model-a", "model-b"],
     config: { maxRetries: 0 },
   };
@@ -170,15 +175,77 @@ test("context_cache_protection OFF + NO sessionId: no pin, strategy re-runs each
     await waitForBackgroundWork();
   }
 
-  // Toggle OFF → no pin is recorded or read → turn 2 re-runs priority from the top,
-  // re-trying model-a before falling through to model-b → [a, b, a, b].
+  // Toggle OFF → turn 1 records model-b (the model that actually succeeded); turn 2 reads
+  // that pin via the derived sessionless key and dispatches model-b DIRECTLY, skipping
+  // model-a → [a, b, b]. This is the v3.8.14 per-conversation stickiness, now default-on.
   assert.deepEqual(
     calls,
-    ["model-a", "model-b", "model-a", "model-b"],
-    "with protection OFF the combo must re-run strategy each turn (no sessionless pin)"
+    ["model-a", "model-b", "model-b"],
+    "with the toggle OFF the combo must STILL re-pin to turn 1's model (sessionless stickiness is default)"
   );
   assert.ok(
     forwardedContents.every((c) => !c.includes("<omniModel>")),
     "no <omniModel> tag may be injected into the forwarded body (#454/#3399)"
+  );
+});
+
+test("two DIFFERENT sessionless conversations pin independently — no global pin bleed (#3825 spreading guard)", async () => {
+  // Locks the cross-conversation-spreading invariant: conversation A pinning to model-b
+  // must NOT leak into conversation B, which has a different first message and must start
+  // fresh from the strategy on its own turn 1. If the pin were global (not per-conversation),
+  // B's first call would jump straight to model-b — this guard fails in that case.
+  const combo = {
+    name: "isolation-priority",
+    strategy: "priority",
+    models: ["model-a", "model-b"],
+    config: { maxRetries: 0 },
+  };
+
+  const makeHandler = (calls: string[]) => async (_body: any, modelStr: string) => {
+    calls.push(modelStr);
+    if (modelStr === "model-a") {
+      return okResponse({ choices: [{ message: { content: "" } }] }); // empty → fall through
+    }
+    return okResponse({ choices: [{ message: { content: "fallback ok" } }] });
+  };
+
+  const bodyA = { messages: [{ role: "user", content: "Conversation A: optimize the parser." }] };
+  const bodyB = { messages: [{ role: "user", content: "Conversation B: write integration tests." }] };
+
+  // Drive conversation A twice so it records + re-pins to model-b.
+  const callsA: string[] = [];
+  for (let turn = 0; turn < 2; turn += 1) {
+    const r = await handleComboChat({
+      body: bodyA,
+      combo,
+      handleSingleModel: makeHandler(callsA) as any,
+      isModelAvailable: async () => true,
+      log: createLog(),
+      settings: null,
+      relayOptions: null as any,
+      allCombos: null,
+    });
+    assert.equal(r.ok, true);
+    await waitForBackgroundWork();
+  }
+  assert.deepEqual(callsA, ["model-a", "model-b", "model-b"], "A must pin to model-b on turn 2");
+
+  // Conversation B's FIRST turn must start fresh at model-a (A's pin must not bleed in).
+  const callsB: string[] = [];
+  const rB = await handleComboChat({
+    body: bodyB,
+    combo,
+    handleSingleModel: makeHandler(callsB) as any,
+    isModelAvailable: async () => true,
+    log: createLog(),
+    settings: null,
+    relayOptions: null as any,
+    allCombos: null,
+  });
+  assert.equal(rB.ok, true);
+  assert.deepEqual(
+    callsB,
+    ["model-a", "model-b"],
+    "conversation B must run the strategy from the top (no bleed from A's pin)"
   );
 });


### PR DESCRIPTION
Closes #3825 (partial — addresses the combo-stickiness regression for sessionless clients; the broader concurrency report is tracked separately if it recurs after this lands).

## Root cause (measured, not assumed)

A diagnostic load harness proved OmniRoute's **request-dispatch CPU is not the bottleneck**: ~5.8ms sync work/req, ceiling ~170 TPS, **no event-loop collapse** from C=1→C=20. The affinity `sha256` fingerprint the reporter suspected is 0.017ms (negligible) and predates v3.8.14.

The regression is **behavioral**, from **#3399 (v3.8.16)**: it replaced the always-on `<omniModel>`-tag per-conversation pin with a server-side pin **gated on a client session id**. Clients that send no session id (Codex CLI, Claude Code — logs fall back to `input:sha256:`) lost per-conversation stickiness → every turn re-runs the strategy (RR rotates, Weighted re-samples) → upstream prompt-cache misses → cold high-reasoning Codex starts (60–95s in the reporters' logs) → with few accounts + concurrency the pool saturates and throughput collapses. Rollback to v3.8.14 restores it because the tag-pin never required a session id.

## The fix (scoped to the sessionless path)

`comboSetup.ts` — when there is **no** client session id, derive a stable conversation fingerprint (`deriveComboSessionKey`) and engage the context-cache pin **by default** (no `context_cache_protection` toggle required). When a real session id **is** present, behavior is unchanged (pin stays opt-in; universal handoff continues to own `session_model_history`). `combo.ts` — the pin write mirrors the same scoping.

**Why this can't break load spreading:** turn 1 always runs the strategy, so cross-conversation distribution is decided on turn 1 and untouched; only turns 2+ of one conversation re-pin.

## Validation (A/B, before vs after, against the real code path)

| Scenario | BEFORE | AFTER |
|---|---|---|
| 1 conversation, 6 turns | rotates (bug) | **sticks** |
| 200 distinct conversations (spreading) | 100/59/41 | **101/62/37 — preserved** |
| 30 conversations × 4 turns | 3/30 stick | **30/30 stick, 3 models** |

## Tests

- `combo-sessionless-pin-3825.test.ts`: updated the scope-guard to assert default-on sessionless stickiness (`[a,b,b]`), added a **cross-conversation isolation guard** (no global pin bleed). TDD fail-before proven (2 new assertions fail on the old code).
- Green: sessionless-pin 3/3, combo-context-relay 11/0, combo-routing-engine 81/0, context-relay integration 5/5, projection 7/0, combo-context 4/0, services-branch 7/7, quota-concurrency 8/0.

Note: `check:complexity` shows 1981 > 1980, a **pre-existing base-red on the release tip** (reproduces without this change) — not introduced here.