### PR TITLE
fix(combo): wire session stickiness into round-robin dispatch (#3825)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ _In development — bullets added per PR; finalized at release._
 ### 🔧 Bug Fixes
 
 - **command-code:** omit `max_tokens` when the client omits it so the upstream applies the model's native default, fixing `400 "expected <=200000"` on `/alpha/generate` for high-cap models; an explicit oversized client value is clamped to the 200k endpoint ceiling (#5221 — thanks @adivekar-utexas)
+- **combo:** wire session stickiness into the round-robin dispatch path. Multi-turn conversations from clients that send no session id (Codex CLI, Claude Code, most OpenAI-compatible tools) were rotated to a different connection on every turn by round-robin combos, busting the upstream prompt-cache → cold high-reasoning starts, intermittent `504`s and throughput collapse under concurrency. The weighted/priority paths already honored per-conversation stickiness; the round-robin handler returned before reaching it. Round-robin now starts the rotation at the conversation's sticky connection (failover to the other targets is preserved), and different conversations still spread across connections — only intra-conversation rotation is removed (#3825 — thanks @bypanghu, @jpsn123, @xz-dev)
 
 ---
 

--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -2849,6 +2849,23 @@ async function handleRoundRobinCombo({
     rrCounters.set(combo.name, counter + 1);
   }
 
+  // #3825: per-conversation session stickiness for round-robin. weighted/priority honor a
+  // sticky connection via applySessionStickiness, but this RR handler returns before that
+  // call — so sessionless RR combos rotated every turn, busting the upstream prompt-cache.
+  // Reuse the SAME mechanism: start the rotation at the conversation's sticky connection
+  // (the loop still falls through to the other targets on failure → failover preserved).
+  const _rrSessionSticky = await applySessionStickiness(
+    filteredTargets,
+    body?.messages as Array<{ role?: string; content?: unknown }>
+  );
+  let rrStartIndex = startIndex;
+  if (_rrSessionSticky.stuck) {
+    const stickyIdx = filteredTargets.findIndex(
+      (t) => t.connectionId === _rrSessionSticky.targets[0]?.connectionId
+    );
+    if (stickyIdx >= 0) rrStartIndex = stickyIdx;
+  }
+
   const clientRequestedStream = body?.stream === true;
   const startTime = Date.now();
   let lastError: string | null = null;
@@ -2867,7 +2884,7 @@ async function handleRoundRobinCombo({
 
   // Try each model starting from the round-robin target
   for (let offset = 0; offset < modelCount; offset++) {
-    const modelIndex = (startIndex + offset) % modelCount;
+    const modelIndex = (rrStartIndex + offset) % modelCount;
     const target = filteredTargets[modelIndex];
     const modelStr = target.modelStr;
     const provider = target.provider;
@@ -3057,6 +3074,12 @@ async function handleRoundRobinCombo({
 
           if (stickyRoundRobinEnabled) {
             recordStickyRoundRobinSuccess(combo.name, target, stickyLimit, filteredTargets);
+          }
+
+          // #3825: (re)record the sticky binding so the next turn re-pins (prompt-cache).
+          if (_rrSessionSticky.messageHash) {
+            const stickyConn = effectiveConnectionId || target.connectionId;
+            if (stickyConn) recordStickyBinding(_rrSessionSticky.messageHash, stickyConn);
           }
 
           if (provider) {

--- a/tests/unit/combo-rr-session-stickiness-3825.test.ts
+++ b/tests/unit/combo-rr-session-stickiness-3825.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Regression for #3825 — round-robin session stickiness.
+ *
+ * sessionStickiness.ts (v3.8.36) keeps a sessionless multi-turn conversation pinned to the
+ * same connection so the upstream prompt-cache stays warm. The weighted/priority dispatch
+ * honors it (via applySessionStickiness at combo.ts:~1587), but handleRoundRobinCombo
+ * returned earlier (combo.ts:~1004) and never engaged it — so ROUND-ROBIN combos rotated on
+ * every turn for clients that send no session id (Codex CLI, Claude Code, most
+ * OpenAI-compatible tools), busting the cache → cold high-reasoning starts, intermittent
+ * 504s and throughput collapse under concurrency (#3825).
+ *
+ * This drives the REAL handleComboChat with a flat round-robin combo and asserts:
+ *  - a single sessionless conversation re-pins to its turn-1 connection (FAILS before the fix:
+ *    the combo rotates A → B → C …);
+ *  - DISTINCT conversations still spread across connections on their first turn (round-robin
+ *    distribution is preserved — only intra-conversation rotation is removed).
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-rr-stick-3825-"));
+const ORIGINAL_DATA_DIR = process.env.DATA_DIR;
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const { handleComboChat } = await import("../../open-sse/services/combo.ts");
+const stick = await import("../../open-sse/services/combo/sessionStickiness.ts");
+const dbCore = await import("../../src/lib/db/core.ts");
+
+function makeLog() {
+  return { info() {}, warn() {}, debug() {}, error() {} };
+}
+
+function rrCombo(name: string) {
+  return {
+    name,
+    strategy: "round-robin",
+    config: { maxRetries: 0 },
+    models: [
+      { kind: "model", provider: "codex", providerId: "codex", model: "m-a", connectionId: "conn-A", id: `${name}-0` },
+      { kind: "model", provider: "codex", providerId: "codex", model: "m-b", connectionId: "conn-B", id: `${name}-1` },
+      { kind: "model", provider: "glm-cn", providerId: "glm-cn", model: "m-c", connectionId: "conn-C", id: `${name}-2` },
+    ],
+  };
+}
+
+async function dispatchConnection(combo: Record<string, unknown>, firstMessage: string): Promise<string> {
+  let conn = "?";
+  await handleComboChat({
+    body: { model: combo.name, messages: [{ role: "user", content: firstMessage }], stream: false },
+    combo,
+    allCombos: [combo],
+    isModelAvailable: async () => true,
+    relayOptions: undefined,
+    signal: undefined,
+    settings: {},
+    log: makeLog(),
+    handleSingleModel: async (
+      _b: unknown,
+      modelStr: string,
+      target?: { connectionId?: string | null }
+    ) => {
+      conn = target?.connectionId ?? "?";
+      return Response.json({ choices: [{ message: { role: "assistant", content: modelStr } }] });
+    },
+  });
+  return conn;
+}
+
+test.beforeEach(() => {
+  stick.clearAllStickyBindings();
+  // Fail-open saturation (unknown → full headroom) so we exercise the stickiness MECHANISM,
+  // not the headroom gate.
+  stick.__setStickinessHeadroomFetcherForTests(async () => undefined);
+});
+
+test.after(() => {
+  stick.__setStickinessHeadroomFetcherForTests(null);
+  dbCore.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  if (ORIGINAL_DATA_DIR === undefined) delete process.env.DATA_DIR;
+  else process.env.DATA_DIR = ORIGINAL_DATA_DIR;
+});
+
+test("round-robin: a sessionless conversation re-pins to its turn-1 connection across turns (#3825)", async () => {
+  const combo = rrCombo("rr-stick");
+  const conns: string[] = [];
+  for (let turn = 0; turn < 5; turn++) {
+    conns.push(await dispatchConnection(combo, "Refactor the streaming handler for combos."));
+  }
+  // Turns 2..5 must all reuse turn 1's connection (sticky). Before the fix RR rotates
+  // (conn-A → conn-B → conn-C → conn-A → …) so this set would have size 3.
+  assert.equal(
+    new Set(conns.slice(1)).size,
+    1,
+    `turns 2..5 must stick to one connection, got: ${conns.join(", ")}`
+  );
+  assert.equal(conns[1], conns[0], "turn 2 must reuse turn 1's connection");
+});
+
+test("round-robin: DISTINCT conversations still spread across connections on turn 1 (#3825 spreading guard)", async () => {
+  const combo = rrCombo("rr-spread");
+  const hist: Record<string, number> = {};
+  for (let i = 0; i < 6; i++) {
+    const conn = await dispatchConnection(combo, `conversation number ${i} — distinct first message`);
+    hist[conn] = (hist[conn] || 0) + 1;
+  }
+  // Round-robin distribution must be preserved across conversations: more than one
+  // connection used (the pin must NOT collapse all conversations onto one connection).
+  assert.ok(
+    Object.keys(hist).length > 1,
+    `distinct conversations must spread across connections, got: ${JSON.stringify(hist)}`
+  );
+});


### PR DESCRIPTION
Closes #3825 (combo-stickiness regression for round-robin). Replaces #5244 (wrong layer — closed).

## Root cause (measured + traced)

A diagnostic load harness first proved OmniRoute's **request-dispatch CPU is not the bottleneck** (~170 req/s ceiling, no event-loop collapse 1→20 concurrent). The regression is **routing/behavioral**:

`sessionStickiness.ts` (shipped **v3.8.36**) keeps a sessionless multi-turn conversation pinned to one connection (by SHA-256 of the first user message, headroom-gated) so the upstream prompt-cache stays warm. The **weighted** and **priority** dispatch paths already honor it via `applySessionStickiness` (combo.ts ~1587). But `handleRoundRobinCombo` **returns earlier** (combo.ts ~1004) and never reaches that call — so **round-robin** combos rotate to a different connection on every turn for clients that send no session id (Codex CLI, Claude Code, most OpenAI-compatible tools). That busts the prompt-cache → cold high-reasoning starts (the reporters' 60–95s codex latencies) → intermittent `504`s and throughput collapse under concurrency.

The reporters tested ≤ v3.8.26, before sessionStickiness existed; their "weighted also fails" was from that era. On current v3.8.40 a probe confirms **weighted already sticks** — only round-robin was still rotating.

## The fix

Wire the existing mechanism into the round-robin handler:
- Before the rotation loop, call `applySessionStickiness`; if a sticky connection is bound to this conversation and present in the current targets, **start the rotation at it** (the loop still falls through to the other targets on failure, so failover is preserved).
- On a successful dispatch, `recordStickyBinding(messageHash, connection)` so the next turn re-pins.

No second mechanism, no new gate — it reuses the same module the weighted/priority paths use (which is why the quota-strategy tests, that already isolate stickiness via `clearAllStickyBindings`, stay green).

## Validation

Probe against the **real** `handleComboChat`:
- round-robin, one sessionless conversation, 6 turns → **all on one connection** (was A→B→C→A…).
- 6 distinct conversations, turn 1 → **spread 2/2/2 across 3 connections** (round-robin distribution preserved).

New integration regression test (`combo-rr-session-stickiness-3825.test.ts`): TDD fail-before proven (the stickiness assertion fails on base, the spreading assertion holds).

Green: combo-rr-session-stickiness 2/0, combo-strategies 15/0, combo-session-stickiness 19/0, combo-routing-engine 81/0, combo-context-relay 11/0, combo-sessionless-pin 2/0, combo/ 40/0. Lint 0 errors. `check:complexity` OK (1981 = baseline, no new violation).