### PR TITLE
fix(combo): advance to next model on 400 'model not supported'

### DIFF
--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -17,7 +17,6 @@ import {
   recordProviderFailure,
   selectLockoutCooldownMs,
 } from "./accountFallback.ts";
-import { RateLimitReason } from "../config/constants.ts";
 import { errorResponse, unavailableResponse } from "../utils/error.ts";
 import {
   recordComboIntent,
@@ -2345,8 +2344,7 @@ export async function handleComboChat({
             fallbackResult.shouldFallback &&
             !isContextOverflow400(errorText) &&
             !isParamValidation400(errorText) &&
-            (fallbackResult.reason === RateLimitReason.MODEL_CAPACITY ||
-              errorText.toLowerCase().includes("context") ||
+            (errorText.toLowerCase().includes("context") ||
               errorText.toLowerCase().includes("prompt") ||
               errorText.toLowerCase().includes("token") ||
               errorText.toLowerCase().includes("malformed") ||

--- a/tests/unit/combo-strategies.test.ts
+++ b/tests/unit/combo-strategies.test.ts
@@ -708,3 +708,39 @@ test("reset-aware strategy scores provider-specific weekly windows when availabl
 
   assert.equal(await selectedConnectionFor(combo), soon);
 });
+
+test("priority combo advances to next model when first returns 400 'model not supported'", async () => {
+  const name = `model-not-supported-${randomUUID()}`;
+  const combo = await combosDb.createCombo({
+    name,
+    strategy: "priority",
+    models: ["openai/gpt-4", "openai/gpt-3.5-turbo"],
+  });
+
+  const calls: string[] = [];
+  const response = await handleComboChat({
+    body: reqBodyTextArray,
+    combo,
+    allCombos: [combo],
+    isModelAvailable: undefined,
+    relayOptions: undefined,
+    signal: undefined,
+    settings: {},
+    log: makeLog(),
+    handleSingleModel: async (_body: unknown, modelStr: string) => {
+      calls.push(modelStr);
+      if (modelStr === "openai/gpt-4") {
+        return Response.json(
+          { error: { message: "requested model is not supported" } },
+          { status: 400 }
+        );
+      }
+      return okResponse(modelStr);
+    },
+  });
+
+  assert.equal(response.status, 200, "combo should advance to second model and return 200");
+  assert.equal(calls.length, 2, "combo should have tried both models");
+  assert.equal(calls[0], "openai/gpt-4", "first model should be tried first");
+  assert.equal(calls[1], "openai/gpt-3.5-turbo", "second model should be tried after 400");
+});


### PR DESCRIPTION
## Problem

When a combo target returns **400** with `"requested model is not supported"`, the combo routing engine stops instead of advancing to the next target. This means a request routed through a combo that hits a provider lacking a specific model gets a hard 400 failure — even though other targets in the combo (different providers) may support that model.

## Root Cause

In `open-sse/services/combo.ts`, the 400 guard condition in `handleComboChat` (priority strategy) included `fallbackResult.reason === RateLimitReason.MODEL_CAPACITY` in its "block fallback" list:

```typescript
if (
  result.status === 400 &&
  fallbackResult.shouldFallback &&
  !isContextOverflow400(errorText) &&
  !isParamValidation400(errorText) &&
  (fallbackResult.reason === RateLimitReason.MODEL_CAPACITY ||  // ← bug
   errorText.toLowerCase().includes("context") ||
   errorText.toLowerCase().includes("prompt") ||
   /* ... more blocking patterns ... */)
) {
  return { ok: false, response: result };  // combo STOPS here
}
```

`checkFallbackError()` correctly classifies "model not supported" as `MODEL_CAPACITY` with `shouldFallback: true` — meaning "yes, try the next target." But the guard condition **blocked** exactly this case, contradicting the comment at line 2106: *"Model access denied: different providers serve different model sets — These should fall through."*

## Fix

**1 line removed** from the guard condition + cleanup of the now-unused `RateLimitReason` import:

```diff
-  (fallbackResult.reason === RateLimitReason.MODEL_CAPACITY ||
-   errorText.toLowerCase().includes("context") ||
+  (errorText.toLowerCase().includes("context") ||
```

`handleRoundRobinCombo` does **not** have this same guard — only one fix location.

## Test

Added test: *"priority combo advances to next model when first returns 400 'model not supported'"*

- Creates 2-model priority combo (`openai/gpt-4` → `openai/gpt-3.5-turbo`)
- First model returns 400 with `{ error: { message: "requested model is not supported" } }`
- Second model returns 200
- Asserts: status=200, both models tried, correct call order

16/16 tests pass on `release/v3.8.40`.