### PR TITLE
fix(responses): keep shell tool caller-side

### DIFF
--- a/open-sse/translator/request/openai-responses.ts
+++ b/open-sse/translator/request/openai-responses.ts
@@ -804,9 +804,6 @@ export function openaiToOpenAIResponsesRequest(
       if (tool.type === "function") {
         const fn = toRecord(tool.function);
         const name = toString(fn.name);
-        if (name === "shell") {
-          return { type: "local_shell" };
-        }
         return {
           type: "function",
           name,
@@ -827,11 +824,7 @@ export function openaiToOpenAIResponsesRequest(
       const tc = toRecord(root.tool_choice);
       if (tc.type === "function" && tc.function) {
         const fn = toRecord(tc.function);
-        if (toString(fn.name) === "shell") {
-          result.tool_choice = { type: "local_shell" };
-        } else {
-          result.tool_choice = { type: "function", name: fn.name };
-        }
+        result.tool_choice = { type: "function", name: fn.name };
       } else {
         result.tool_choice = root.tool_choice;
       }

--- a/tests/unit/translator-openai-responses-req.test.ts
+++ b/tests/unit/translator-openai-responses-req.test.ts
@@ -229,7 +229,11 @@ test("Responses -> Chat strips safety_identifier (LobeHub #2770)", () => {
     null
   ) as Record<string, unknown>;
 
-  assert.equal(result.safety_identifier, undefined, "safety_identifier must be stripped before forwarding to Chat Completions");
+  assert.equal(
+    result.safety_identifier,
+    undefined,
+    "safety_identifier must be stripped before forwarding to Chat Completions"
+  );
   assert.ok(Array.isArray(result.messages), "translation must still produce messages");
 });
 
@@ -247,7 +251,11 @@ test("Responses -> Chat strips client_metadata (Mistral 422 fix)", () => {
     null
   ) as Record<string, unknown>;
 
-  assert.equal(result.client_metadata, undefined, "client_metadata must be stripped before forwarding to Chat Completions");
+  assert.equal(
+    result.client_metadata,
+    undefined,
+    "client_metadata must be stripped before forwarding to Chat Completions"
+  );
   assert.ok(Array.isArray(result.messages), "translation must still produce messages");
   assert.equal((result.messages as unknown[]).length, 1, "user message must be preserved");
 });
@@ -890,9 +898,6 @@ test("Responses -> Chat: image_generation is stripped from output tools array (i
 // --- Codex CLI: local_shell built-in should be mapped to a function tool ---
 
 test("Responses -> Chat: local_shell does not throw", () => {
-  // Recent Codex CLI releases inject local_shell as a Responses API built-in.
-  // Non-OpenAI upstreams do not support this tool type directly, so OmniRoute
-  // must translate it instead of rejecting the request with 400.
   assert.doesNotThrow(() =>
     openaiResponsesToOpenAIRequest(
       "gpt-4o",
@@ -941,7 +946,7 @@ test("Responses -> Chat: local_shell tool_choice maps to shell function choice",
   assert.deepEqual(result.tool_choice, { type: "function", function: { name: "shell" } });
 });
 
-test("Chat -> Responses: shell function maps back to local_shell", () => {
+test("Chat -> Responses: shell function stays caller-side and does not leak local_shell", () => {
   const result = openaiToOpenAIResponsesRequest(
     "gpt-4o",
     {
@@ -962,8 +967,11 @@ test("Chat -> Responses: shell function maps back to local_shell", () => {
     null
   ) as Record<string, unknown>;
 
-  assert.deepEqual(result.tools, [{ type: "local_shell" }]);
-  assert.deepEqual(result.tool_choice, { type: "local_shell" });
+  assert.equal((result.tools as any[])[0].type, "function");
+  assert.equal((result.tools as any[])[0].name, "shell");
+  assert.equal((result.tools as any[])[0].description, "Run a shell command");
+  assert.deepEqual((result.tools as any[])[0].parameters, { type: "object" });
+  assert.deepEqual(result.tool_choice, { type: "function", name: "shell" });
 });
 
 // --- Issue #2893: orphaned tool results from empty/missing call_id ---
@@ -1038,9 +1046,7 @@ test("Responses -> Chat: a valid function_call/output pair is preserved (issue #
   ) as Record<string, unknown>;
 
   const messages = result.messages as any[];
-  const assistant = messages.find(
-    (m) => m.role === "assistant" && Array.isArray(m.tool_calls)
-  );
+  const assistant = messages.find((m) => m.role === "assistant" && Array.isArray(m.tool_calls));
   assert.ok(assistant, "assistant message with tool_calls must be present");
   assert.equal(assistant.tool_calls[0].id, "c1");
   const toolMsg = messages.find((m) => m.role === "tool");

--- a/tests/unit/translator-openai-responses-req.test.ts
+++ b/tests/unit/translator-openai-responses-req.test.ts
@@ -977,10 +977,6 @@ test("Chat -> Responses: shell function stays caller-side and does not leak loca
 // --- Issue #2893: orphaned tool results from empty/missing call_id ---
 
 test("Responses -> Chat: function_call with empty call_id is dropped together with its output (issue #2893)", () => {
-  // Codex can emit a function_call without a usable call_id; its
-  // function_call_output then becomes an orphan tool message that the upstream
-  // rejects ("role 'tool' must be a response to a preceding message with
-  // 'tool_calls'"). Both must be dropped.
   const result = openaiResponsesToOpenAIRequest(
     "gpt-4o",
     {
@@ -995,13 +991,11 @@ test("Responses -> Chat: function_call with empty call_id is dropped together wi
   ) as Record<string, unknown>;
 
   const messages = result.messages as any[];
-  // No orphan tool message.
   assert.equal(
     messages.some((m) => m.role === "tool"),
     false,
     "tool result with empty tool_call_id must be dropped"
   );
-  // No dangling assistant tool_call with an empty id.
   const danglingEmptyId = messages.some(
     (m) =>
       m.role === "assistant" &&


### PR DESCRIPTION
## Summary
- fix #5251 by keeping Chat `shell` tools as caller-side Responses function tools
- stop translating `shell` tool declarations/tool_choice into hosted `local_shell`, which strict upstream Responses APIs reject
- keep inbound Responses `local_shell` compatibility by still mapping it to Chat `shell` functions

## Validation
- RED: targeted translator test failed with `actual: [{ type: local_shell }]` before the fix
- `node --max-old-space-size=8192 --import tsx --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test tests/unit/translator-openai-responses-req.test.ts`
- `node scripts/check/check-file-size.mjs`

Fixes #5251