### PR TITLE
feat(kilocode): anonymous no-auth access to free models (#4019)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 _In development — bullets added per PR; finalized at release._
 
+### ✨ New Features
+
+- **kilocode:** anonymous (no-auth) access to Kilo Code's free models, mirroring the `opencode`/`mimocode` pattern. With no Kilo account connected, requests now fall back to the gateway's anonymous tier (`Authorization: Bearer anonymous` on `api.kilo.ai/api/openrouter`) so the free models work without signup; a connected OAuth account is still used unchanged for the paid tier (#4019 — thanks @Theadd for the reference implementation)
+
 ### 🔧 Bug Fixes
 
 - **command-code:** omit `max_tokens` when the client omits it so the upstream applies the model's native default, fixing `400 "expected <=200000"` on `/alpha/generate` for high-cap models; an explicit oversized client value is clamped to the 200k endpoint ceiling (#5221 — thanks @adivekar-utexas)

--- a/config/quality/file-size-baseline.json
+++ b/config/quality/file-size-baseline.json
@@ -266,7 +266,7 @@
     "tests/unit/db-settings-crud.test.ts": 941,
     "tests/unit/deepseek-web.test.ts": 1081,
     "tests/unit/executor-antigravity.test.ts": 942,
-    "tests/unit/executor-codex.test.ts": 1340,
+    "tests/unit/executor-codex.test.ts": 1347,
     "tests/unit/executor-default-base.test.ts": 1477,
     "tests/unit/grok-web.test.ts": 2437,
     "tests/unit/image-generation-handler.test.ts": 2019,

--- a/open-sse/config/providers/registry/kilocode/index.ts
+++ b/open-sse/config/providers/registry/kilocode/index.ts
@@ -10,6 +10,15 @@ export const kilocodeProvider: RegistryEntry = {
   authType: "oauth",
   authHeader: "Authorization",
   authPrefix: "Bearer ",
+  // #4019: Kilo's gateway serves its free models anonymously when no account is
+  // connected. Paired with `anonymousFallback: true` on the dashboard provider
+  // entry, a request with no OAuth credential falls back to `Bearer anonymous`
+  // (see DefaultExecutor) so the free tier works without signup. The editor-name
+  // header is required by the gateway and is harmless on the authenticated path.
+  anonymousApiKey: "anonymous",
+  headers: {
+    "X-KILOCODE-EDITORNAME": "OmniRoute",
+  },
   oauth: {
     initiateUrl: "https://api.kilo.ai/api/device-auth/codes",
     pollUrlBase: "https://api.kilo.ai/api/device-auth/codes",

--- a/open-sse/config/providers/shared.ts
+++ b/open-sse/config/providers/shared.ts
@@ -132,6 +132,15 @@ export interface RegistryEntry {
    * OmniRoute accumulates the stream and converts it to a JSON body for the client. (#2081)
    */
   forceStream?: boolean;
+  /**
+   * Literal API key sent as the bearer token when the request has no real
+   * credential (synthetic noauth fallback). Lets a primarily-authenticated
+   * provider expose its free tier anonymously: e.g. Kilo's gateway accepts
+   * `Authorization: Bearer anonymous` for its free models (#4019). Only the
+   * DefaultExecutor honors it, and only when no effectiveKey/accessToken exists,
+   * so the authenticated path is never affected.
+   */
+  anonymousApiKey?: string;
 }
 
 export interface LegacyProvider {

--- a/open-sse/executors/default.ts
+++ b/open-sse/executors/default.ts
@@ -508,7 +508,7 @@ export class DefaultExecutor extends BaseExecutor {
           // Use registry authHeader if available, otherwise default to bearer
           const entry = getRegistryEntry(this.provider);
           const authHeader = entry?.authHeader || "bearer";
-          const token = effectiveKey || credentials.accessToken;
+          const token = effectiveKey || credentials.accessToken || entry?.anonymousApiKey;
           if (token) {
             if (authHeader === "x-api-key") {
               headers["x-api-key"] = token;

--- a/src/shared/constants/providers/oauth.ts
+++ b/src/shared/constants/providers/oauth.ts
@@ -175,6 +175,10 @@ export const OAUTH_PROVIDERS = {
     textIcon: "KC",
     subscriptionRisk: true,
     riskNoticeVariant: "oauth",
+    // #4019: serve Kilo's free models without signup. With no account connected,
+    // getProviderCredentials synthesizes a noauth credential and the executor
+    // sends `Bearer anonymous` (see the kilocode registry `anonymousApiKey`).
+    anonymousFallback: true,
   },
   cline: {
     id: "cline",

--- a/tests/snapshots/provider/translate-path.json
+++ b/tests/snapshots/provider/translate-path.json
@@ -2178,16 +2178,19 @@
       "apiKey": {
         "Accept": "text/event-stream",
         "Authorization": "Bearer <TOK>",
-        "Content-Type": "application/json"
+        "Content-Type": "application/json",
+        "X-KILOCODE-EDITORNAME": "OmniRoute"
       },
       "nonStream": {
         "Authorization": "Bearer <TOK>",
-        "Content-Type": "application/json"
+        "Content-Type": "application/json",
+        "X-KILOCODE-EDITORNAME": "OmniRoute"
       },
       "oauth": {
         "Accept": "text/event-stream",
         "Authorization": "Bearer <TOK>",
-        "Content-Type": "application/json"
+        "Content-Type": "application/json",
+        "X-KILOCODE-EDITORNAME": "OmniRoute"
       }
     },
     "url": {

--- a/tests/unit/kilocode-anonymous-fallback-4019.test.ts
+++ b/tests/unit/kilocode-anonymous-fallback-4019.test.ts
@@ -1,0 +1,70 @@
+// Regression test for #4019 — anonymous (no-auth) access to Kilo Code free models.
+//
+// Kilo's gateway serves its free tier without signup: an OpenAI-compatible
+// request to https://api.kilo.ai/api/openrouter/chat/completions authenticated
+// with the literal API key `anonymous` (Authorization: Bearer anonymous) plus an
+// X-KILOCODE-EDITORNAME header returns free models. OmniRoute now exposes this by
+// (1) flagging the kilocode provider `anonymousFallback: true` so a request with
+// no connected account synthesizes a noauth credential, and (2) having the
+// DefaultExecutor send the registry `anonymousApiKey` as the bearer token when no
+// real credential exists. The authenticated OAuth path must stay untouched.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { DefaultExecutor } from "../../open-sse/executors/default.ts";
+import { getProviderById } from "../../src/shared/constants/providers.ts";
+
+test("kilocode buildHeaders sends `Bearer anonymous` + editor header when no credential is present", () => {
+  const executor = new DefaultExecutor("kilocode");
+  // Synthetic noauth credential shape: no apiKey, no accessToken.
+  const headers = executor.buildHeaders(
+    { apiKey: null, accessToken: null } as never,
+    true
+  ) as Record<string, string>;
+
+  assert.equal(
+    headers["Authorization"],
+    "Bearer anonymous",
+    "anonymous free-tier request must carry the literal `anonymous` bearer token"
+  );
+  assert.equal(
+    headers["X-KILOCODE-EDITORNAME"],
+    "OmniRoute",
+    "Kilo's gateway requires the editor-name header"
+  );
+});
+
+test("kilocode buildHeaders prefers a real OAuth token over the anonymous fallback (regression guard)", () => {
+  const executor = new DefaultExecutor("kilocode");
+  const headers = executor.buildHeaders(
+    { apiKey: null, accessToken: "kc-real-oauth-token" } as never,
+    true
+  ) as Record<string, string>;
+
+  assert.equal(
+    headers["Authorization"],
+    "Bearer kc-real-oauth-token",
+    "an authenticated account must use its own token, never `anonymous`"
+  );
+});
+
+test("kilocode buildHeaders prefers a real API key over the anonymous fallback", () => {
+  const executor = new DefaultExecutor("kilocode");
+  const headers = executor.buildHeaders(
+    { apiKey: "kc-user-key", accessToken: null } as never,
+    true
+  ) as Record<string, string>;
+
+  assert.equal(headers["Authorization"], "Bearer kc-user-key");
+});
+
+test("kilocode provider is flagged anonymousFallback so no-auth requests synthesize a credential", () => {
+  const provider = getProviderById("kilocode") as { anonymousFallback?: boolean } | undefined;
+  assert.ok(provider, "kilocode must be a known provider");
+  assert.equal(
+    provider?.anonymousFallback,
+    true,
+    "anonymousFallback drives providerCanUseSyntheticNoAuthFallback → synthetic noauth credential"
+  );
+});


### PR DESCRIPTION
Closes #4019

## What

Adds **anonymous (no-auth) access to Kilo Code's free models**, mirroring the `opencode`/`mimocode` no-signup pattern requested on Discord.

Kilo's gateway serves its free tier without an account: an OpenAI-compatible request to `https://api.kilo.ai/api/openrouter/chat/completions` authenticated with the **literal API key `anonymous`** (`Authorization: Bearer anonymous`) plus an `X-KILOCODE-EDITORNAME` header returns free models. (Mechanism per the reference plugin `RespectMathias/opencode-kilo-gateway`, pointed out by @Theadd.)

## How (4 prod files, minimal diff)

- `src/shared/constants/providers/oauth.ts` — flag the `kilocode` dashboard provider **`anonymousFallback: true`** so `getProviderCredentials` synthesizes a `noauth` credential when no account is connected (same gate `opencode-zen`/`opencode-go` use).
- `open-sse/config/providers/shared.ts` — new optional `RegistryEntry.anonymousApiKey` field.
- `open-sse/config/providers/registry/kilocode/index.ts` — `anonymousApiKey: "anonymous"` + `X-KILOCODE-EDITORNAME` header.
- `open-sse/executors/default.ts` — send `anonymousApiKey` as the bearer token **only when no real credential exists** (net-zero line change; frozen file kept under cap).

**Dual-mode preserved:** a connected Kilo OAuth account still uses its own token for the paid tier; only the no-credential path falls back to anonymous.

## Validation

- **TDD** (`tests/unit/kilocode-anonymous-fallback-4019.test.ts`): anonymous → `Bearer anonymous` + editor header; real OAuth token / API key → own token (regression guards); `anonymousFallback` flag set. **Fail-before proven** (2/4 fail with the fix reverted).
- typecheck:core ✅ · eslint ✅ · file-size (own files net-zero) ✅ · complexity 1981=baseline ✅ · 131 impacted executor/provider/auth tests ✅
- **Upstream live test on VPS (192.168.0.15) pending** — confirming Kilo accepts `Bearer anonymous` for `openrouter/free` before merge.