### PR TITLE
fix(qoder): decouple shared job token exchange abort

### DIFF
--- a/open-sse/services/qoderCli.ts
+++ b/open-sse/services/qoderCli.ts
@@ -488,7 +488,7 @@ export async function resolveQoderJobToken(
 
   let pending = qoderJobTokenPending.get(trimmed);
   if (!pending) {
-    pending = exchangeQoderJobToken(trimmed, options).finally(() => {
+    pending = exchangeQoderJobToken(trimmed, { fetchImpl: options.fetchImpl }).finally(() => {
       qoderJobTokenPending.delete(trimmed);
     });
     qoderJobTokenPending.set(trimmed, pending);

--- a/tests/unit/qoder-jobtoken-exchange-4683.test.ts
+++ b/tests/unit/qoder-jobtoken-exchange-4683.test.ts
@@ -104,6 +104,45 @@ test("#4683 resolveQoderJobToken coalesces concurrent pt-* exchanges", async () 
   __clearQoderJobTokenCache();
 });
 
+test("#4683 resolveQoderJobToken does not let the first caller abort poison shared waiters", async () => {
+  __clearQoderJobTokenCache();
+  let fetchCount = 0;
+  let releaseExchange: (() => void) | undefined;
+  let markExchangeStarted: (() => void) | undefined;
+  const exchangeStarted = new Promise<void>((resolveStarted) => {
+    markExchangeStarted = resolveStarted;
+  });
+  const firstCaller = new AbortController();
+  const fetchImpl = async (_url: string, init?: Record<string, unknown>) => {
+    fetchCount += 1;
+    markExchangeStarted?.();
+    await new Promise<void>((resolve, reject) => {
+      releaseExchange = resolve;
+      const signal = init?.signal as AbortSignal | undefined;
+      signal?.addEventListener("abort", () => reject(signal.reason ?? new Error("aborted")), {
+        once: true,
+      });
+    });
+    return jsonResponse({ job_token: "jt-unpoisoned", expires_in: 86400 });
+  };
+
+  const first = resolveQoderJobToken("pt-abort-shared", {
+    fetchImpl,
+    now: 1_000,
+    signal: firstCaller.signal,
+  }).catch((error: unknown) => error);
+  await exchangeStarted;
+  const second = resolveQoderJobToken("pt-abort-shared", { fetchImpl, now: 1_000 });
+
+  firstCaller.abort(new Error("caller went away"));
+  releaseExchange?.();
+
+  assert.equal(await second, "jt-unpoisoned");
+  assert.equal(fetchCount, 1, "the unaffected waiter must share the original exchange");
+  await first;
+  __clearQoderJobTokenCache();
+});
+
 test("#4683 resolveQoderJobToken passes a jt-* through without exchanging", async () => {
   __clearQoderJobTokenCache();
   let fetchCount = 0;


### PR DESCRIPTION
## Summary
- add a regression test for concurrent Qoder PAT job-token waiters when the first caller aborts
- keep the shared PAT -> jt-* exchange independent from any one caller AbortSignal
- preserve exchange coalescing and fetch injection for tests

## Verification
- npm exec -- node --import tsx --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test tests/unit/qoder-jobtoken-exchange-4683.test.ts tests/unit/qoder-cli.test.ts tests/unit/qoder-executor.test.ts tests/unit/qoder-unwrap-error-envelope.test.ts
- npm run check:file-size
- npx eslint open-sse/services/qoderCli.ts tests/unit/qoder-jobtoken-exchange-4683.test.ts (exits 0; existing no-explicit-any warnings remain in qoderCli.ts lines 569 and 659)