### PR TITLE
feat(mcp): omniroute_tool_search + one-line TS signatures — roadmap #4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ _In development — bullets added per PR; finalized at release._
 
 ### ✨ New Features
 
+- **feat(mcp): `omniroute_tool_search` tool + one-line TS signatures** — new MCP tool that does lexical keyword search over every MCP tool's name/description and returns the top matches as compact one-line TypeScript signatures (~half the JSON-schema token cost), so agents discover tools on demand instead of carrying all ~88 schemas every turn. Search is ReDoS-safe (substring scoring, never `new RegExp` on the query) and deterministic; `tools/list` stays complete (no hidden tools). Adds the `read:tools` scope. Tier-1 item of the compression feature-extraction roadmap (#4).
 - **kilocode:** anonymous (no-auth) access to Kilo Code's free models, mirroring the `opencode`/`mimocode` pattern. With no Kilo account connected, requests now fall back to the gateway's anonymous tier (`Authorization: Bearer anonymous` on `api.kilo.ai/api/openrouter`) so the free models work without signup; a connected OAuth account is still used unchanged for the paid tier (#4019 — thanks @Theadd for the reference implementation)
 
 ### 🔧 Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _In development — bullets added per PR; finalized at release._
 
 ### ✨ New Features
 
-- **feat(mcp): `omniroute_tool_search` tool + one-line TS signatures** — new MCP tool that does lexical keyword search over every MCP tool's name/description and returns the top matches as compact one-line TypeScript signatures (~half the JSON-schema token cost), so agents discover tools on demand instead of carrying all ~88 schemas every turn. Search is ReDoS-safe (substring scoring, never `new RegExp` on the query) and deterministic; `tools/list` stays complete (no hidden tools). Adds the `read:tools` scope. Tier-1 item of the compression feature-extraction roadmap (#4).
+- **feat(mcp): `omniroute_tool_search` tool + one-line TS signatures** — new MCP tool that does lexical keyword search over every MCP tool's name/description and returns the top matches as compact one-line TypeScript signatures (~half the JSON-schema token cost), so agents discover tools on demand instead of carrying all ~88 schemas every turn. Search is ReDoS-safe (substring scoring, never `new RegExp` on the query) and deterministic; `tools/list` stays complete (no hidden tools). Adds the `read:tools` scope. Tier-1 item of the compression feature-extraction roadmap. ([#5269](https://github.com/diegosouzapw/OmniRoute/pull/5269))
 - **kilocode:** anonymous (no-auth) access to Kilo Code's free models, mirroring the `opencode`/`mimocode` pattern. With no Kilo account connected, requests now fall back to the gateway's anonymous tier (`Authorization: Bearer anonymous` on `api.kilo.ai/api/openrouter`) so the free models work without signup; a connected OAuth account is still used unchanged for the paid tier (#4019 — thanks @Theadd for the reference implementation)
 
 ### 🔧 Bug Fixes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ For full test matrix, see `CONTRIBUTING.md` → "Running Tests". For deep archit
 | Services      | `open-sse/services/`    | Combo routing, rate limits, caching, etc                                                                                               |
 | Database      | `src/lib/db/`           | SQLite domain modules (83 files, 97 migrations)                                                                                        |
 | Domain/Policy | `src/domain/`           | Policy engine, cost rules, fallback logic                                                                                              |
-| MCP Server    | `open-sse/mcp-server/`  | 87 tools (33 base + memory/skill/notion/obsidian/gamification/plugin modules), 3 transports (stdio / SSE / Streamable HTTP), 30 scopes |
+| MCP Server    | `open-sse/mcp-server/`  | 88 tools (34 base + memory/skill/notion/obsidian/gamification/plugin modules), 3 transports (stdio / SSE / Streamable HTTP), 31 scopes |
 | A2A Server    | `src/lib/a2a/`          | JSON-RPC 2.0 agent protocol                                                                                                            |
 | Skills        | `src/lib/skills/`       | Extensible skill framework                                                                                                             |
 | Memory        | `src/lib/memory/`       | Persistent conversational memory                                                                                                       |

--- a/docs/frameworks/MCP-SERVER.md
+++ b/docs/frameworks/MCP-SERVER.md
@@ -6,9 +6,9 @@ lastUpdated: 2026-06-20
 
 # OmniRoute MCP Server Documentation
 
-> Model Context Protocol server with 87 tools across routing, cache, compression, memory, skills, proxy, and context source operations.
+> Model Context Protocol server with 88 tools across routing, cache, compression, memory, skills, proxy, and context source operations.
 >
-> Source of truth: `open-sse/mcp-server/schemas/tools.ts` (33 base) + `memoryTools.ts` (3) + `skillTools.ts` (4) + `agentSkillTools.ts` (3) + `gamificationTools.ts` (8) + `pluginTools.ts` (8) + `notionTools.ts` (6) + `obsidianTools.ts` (22) = **87** (`TOTAL_MCP_TOOL_COUNT`). Tool registration and scope wiring lives in `open-sse/mcp-server/server.ts`.
+> Source of truth: `open-sse/mcp-server/schemas/tools.ts` (34 base) + `memoryTools.ts` (3) + `skillTools.ts` (4) + `agentSkillTools.ts` (3) + `gamificationTools.ts` (8) + `pluginTools.ts` (8) + `notionTools.ts` (6) + `obsidianTools.ts` (22) = **88** (`TOTAL_MCP_TOOL_COUNT`). Tool registration and scope wiring lives in `open-sse/mcp-server/server.ts`.
 
 ![MCP tool inventory (87 tools by category)](../diagrams/exported/mcp-tools-87.svg)
 
@@ -217,7 +217,7 @@ See [AGENT-SKILLS.md](./AGENT-SKILLS.md) for the full catalog and how external a
 
 ## Related Frameworks (v3.8.0)
 
-The MCP tool inventory above (87 tools = 33 core + 3 memory + 4 skills + 3 agent-skills + 8 gamification + 8 plugins + 6 notion + 22 obsidian) is intentionally
+The MCP tool inventory above (88 tools = 34 core + 3 memory + 4 skills + 3 agent-skills + 8 gamification + 8 plugins + 6 notion + 22 obsidian) is intentionally
 scoped to runtime routing/cache/compression/memory/skills/proxy/context-source operations. Two adjacent
 frameworks ship alongside the MCP server in v3.8.0 and are documented separately:
 
@@ -331,7 +331,7 @@ MCP tool, prompt, and resource registries can compress descriptions at registrat
 
 Description compression shrinks each tool's metadata; **tool-cardinality reduction** goes one step further by reducing *how many* tools are announced at all. Advertising fewer tools in the `tools/list` manifest cuts the per-request token cost the client's model pays for the tool catalog ("layer 5" compression). The implementation is a pure, stateless filter in `open-sse/mcp-server/toolCardinality.ts` (`reduceToolManifest`), wired into the registration loop in `createMcpServer()` (`open-sse/mcp-server/server.ts`).
 
-**Opt-in, off by default.** The filter only runs when at least one of two environment variables is set; with neither set, all 87 tools are announced unchanged.
+**Opt-in, off by default.** The filter only runs when at least one of two environment variables is set; with neither set, all 88 tools are announced unchanged.
 
 | Variable         | Mode                                                                                    |
 | :--------------- | :-------------------------------------------------------------------------------------- |

--- a/open-sse/mcp-server/README.md
+++ b/open-sse/mcp-server/README.md
@@ -48,7 +48,7 @@ export OMNIROUTE_API_KEY="your-api-key"
 
 # Optional: Scope enforcement (default: disabled)
 export OMNIROUTE_MCP_ENFORCE_SCOPES="true"
-export OMNIROUTE_MCP_SCOPES="read:health,read:combos,read:quota,read:usage,read:models,read:cache,read:compression,execute:completions,write:combos,write:budget,write:resilience,write:cache,write:compression"
+export OMNIROUTE_MCP_SCOPES="read:health,read:combos,read:quota,read:usage,read:models,read:cache,read:compression,read:tools,execute:completions,write:combos,write:budget,write:resilience,write:cache,write:compression"
 ```
 
 ### 2. stdio Transport (IDE Integration)

--- a/open-sse/mcp-server/__tests__/essentialTools.test.ts
+++ b/open-sse/mcp-server/__tests__/essentialTools.test.ts
@@ -22,9 +22,9 @@ describe("MCP Essential Tools", () => {
   });
 
   describe("Tool schema validation", () => {
-    it("should have exactly 10 essential tools (includes web_search + web_fetch)", () => {
+    it("should have exactly 11 essential tools (includes web_search + web_fetch + tool_search)", () => {
       const schemas = MCP_ESSENTIAL_TOOLS;
-      expect(schemas).toHaveLength(10);
+      expect(schemas).toHaveLength(11);
     });
 
     it("all tools should have omniroute_ prefix", () => {

--- a/open-sse/mcp-server/__tests__/toolSearch.catalog.test.ts
+++ b/open-sse/mcp-server/__tests__/toolSearch.catalog.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import { getAllToolDefinitions } from "../toolSearch/catalog.ts";
+
+describe("getAllToolDefinitions", () => {
+  const all = getAllToolDefinitions();
+  it("aggregates many tools across collections", () => {
+    expect(all.length).toBeGreaterThanOrEqual(34);
+    expect(all.find((t) => t.name === "omniroute_get_health")).toBeTruthy();
+  });
+  it("every entry has name + description", () => {
+    for (const t of all) {
+      expect(typeof t.name).toBe("string");
+      expect(t.name.length).toBeGreaterThan(0);
+      expect(typeof t.description).toBe("string");
+    }
+  });
+  it("no duplicate names", () => {
+    const names = all.map((t) => t.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+});

--- a/open-sse/mcp-server/__tests__/toolSearch.catalog.test.ts
+++ b/open-sse/mcp-server/__tests__/toolSearch.catalog.test.ts
@@ -18,4 +18,10 @@ describe("getAllToolDefinitions", () => {
     const names = all.map((t) => t.name);
     expect(new Set(names).size).toBe(names.length);
   });
+  it("includes compressionTools-only entries (omniroute_ccr_retrieve, not in MCP_TOOLS)", () => {
+    // Regression: compressionTools carries omniroute_ccr_retrieve, which is absent from
+    // MCP_TOOLS — if the collection is dropped from the catalog, tool_search can never
+    // surface it. Guards against the catalog omission caught in core review.
+    expect(all.find((t) => t.name === "omniroute_ccr_retrieve")).toBeTruthy();
+  });
 });

--- a/open-sse/mcp-server/__tests__/toolSearch.search.test.ts
+++ b/open-sse/mcp-server/__tests__/toolSearch.search.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { searchTools } from "../toolSearch/search.ts";
+
+const E = [
+  { name: "omniroute_get_health", description: "health status uptime memory", scopes: ["read:health"] },
+  { name: "omniroute_list_combos", description: "list combos and strategies", scopes: ["read:combos"] },
+  { name: "omniroute_check_quota", description: "remaining quota per provider", scopes: ["read:quota"] },
+];
+
+describe("searchTools", () => {
+  it("ranks name+desc hit on top", () => {
+    const r = searchTools(E, "health", 8);
+    expect(r[0].name).toBe("omniroute_get_health");
+  });
+  it("no hit ⇒ empty", () => { expect(searchTools(E, "zzzzz", 8)).toEqual([]); });
+  it("respects limit + deterministic tie-break", () => {
+    const r = searchTools(E, "omniroute", 2);
+    expect(r.length).toBe(2);
+    expect(r[0].name < r[1].name).toBe(true); // tie-break alfabético
+  });
+  it("ReDoS-safe: pathological query does not hang", () => {
+    const start = Date.now();
+    searchTools(E, "(a+)+".repeat(20), 8);
+    expect(Date.now() - start).toBeLessThan(200);
+  });
+});

--- a/open-sse/mcp-server/__tests__/toolSearch.signature.test.ts
+++ b/open-sse/mcp-server/__tests__/toolSearch.signature.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { zodToTsSignature } from "../toolSearch/signature.ts";
+
+describe("zodToTsSignature", () => {
+  it("primitives + optional", () => {
+    const s = z.object({ query: z.string(), limit: z.number().optional() });
+    const out = zodToTsSignature("omniroute_tool_search", s);
+    expect(out).toContain("omniroute_tool_search(args: {");
+    expect(out).toContain("query: string");
+    expect(out).toContain("limit?: number");
+  });
+  it("enum + array + boolean", () => {
+    const s = z.object({ mode: z.enum(["a", "b"]), tags: z.array(z.string()), on: z.boolean() });
+    const out = zodToTsSignature("t", s);
+    expect(out).toContain("mode: 'a' | 'b'");
+    expect(out).toContain("tags: string[]");
+    expect(out).toContain("on: boolean");
+  });
+  it("no schema ⇒ no args", () => {
+    expect(zodToTsSignature("ping")).toBe("ping()");
+  });
+  it("never throws on weird input", () => {
+    expect(() => zodToTsSignature("x", {} as never)).not.toThrow();
+  });
+});

--- a/open-sse/mcp-server/__tests__/toolSearch.tool.test.ts
+++ b/open-sse/mcp-server/__tests__/toolSearch.tool.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createMcpServer } from "../server.ts";
+
+vi.mock("../audit.ts", () => ({
+  logToolCall: vi.fn().mockResolvedValue(undefined),
+  closeAuditDb: vi.fn(),
+}));
+
+describe("omniroute_tool_search", () => {
+  let client: Client;
+
+  beforeEach(async () => {
+    const [ct, st] = InMemoryTransport.createLinkedPair();
+    const server = createMcpServer();
+    await server.connect(st);
+    client = new Client({ name: "t", version: "1.0.0" });
+    await client.connect(ct);
+  });
+
+  afterEach(async () => {
+    await client.close();
+  });
+
+  it("appears in tools/list with read:tools scope", async () => {
+    const { tools } = await client.listTools();
+    expect(tools.find((t) => t.name === "omniroute_tool_search")).toBeTruthy();
+  });
+
+  it("returns relevant tool with a signature, not itself", async () => {
+    const res = await client.callTool({ name: "omniroute_tool_search", arguments: { query: "health" } });
+    const text = (res.content as Array<{ text: string }>)[0].text;
+    const parsed = JSON.parse(text);
+    expect(parsed.tools.some((t: any) => t.name === "omniroute_get_health")).toBe(true);
+    expect(parsed.tools.every((t: any) => t.name !== "omniroute_tool_search")).toBe(true);
+    expect(typeof parsed.tools[0].signature).toBe("string");
+  });
+});

--- a/open-sse/mcp-server/schemas/toolSearch.ts
+++ b/open-sse/mcp-server/schemas/toolSearch.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+import type { McpToolDefinition } from "./tools.ts";
+
+export const toolSearchInput = z
+  .object({
+    query: z
+      .string()
+      .min(1)
+      .describe("Natural-language or keyword query over tool names/descriptions"),
+    limit: z.number().int().min(1).max(25).optional().describe("Max results (default 8)"),
+  })
+  .describe("Search available MCP tools by keyword");
+
+export const toolSearchOutput = z.object({
+  query: z.string(),
+  count: z.number(),
+  tools: z.array(
+    z.object({
+      name: z.string(),
+      description: z.string(),
+      scopes: z.array(z.string()),
+      signature: z.string(),
+    })
+  ),
+});
+
+export const toolSearchTool: McpToolDefinition<typeof toolSearchInput, typeof toolSearchOutput> = {
+  name: "omniroute_tool_search",
+  description:
+    "Search the available MCP tools by keyword and return the most relevant ones as compact one-line TypeScript signatures (token-efficient discovery instead of loading every tool schema).",
+  inputSchema: toolSearchInput,
+  outputSchema: toolSearchOutput,
+  scopes: ["read:tools"],
+  auditLevel: "basic",
+  phase: 1,
+  sourceEndpoints: [],
+};

--- a/open-sse/mcp-server/schemas/tools.ts
+++ b/open-sse/mcp-server/schemas/tools.ts
@@ -10,6 +10,7 @@
  */
 
 import { z } from "zod";
+import { toolSearchTool } from "./toolSearch.ts";
 import {
   AUTO_ROUTING_STRATEGY_VALUES,
   ROUTING_STRATEGY_VALUES,
@@ -1443,52 +1444,8 @@ export const agentSkillsCoverageTool: McpToolDefinition<
   sourceEndpoints: ["/api/agent-skills"],
 };
 
-// ============ Tool Search ============
+export { toolSearchInput, toolSearchOutput, toolSearchTool } from "./toolSearch.ts";
 
-export const toolSearchInput = z
-  .object({
-    query: z
-      .string()
-      .min(1)
-      .describe("Natural-language or keyword query over tool names/descriptions"),
-    limit: z
-      .number()
-      .int()
-      .min(1)
-      .max(25)
-      .optional()
-      .describe("Max results (default 8)"),
-  })
-  .describe("Search available MCP tools by keyword");
-
-export const toolSearchOutput = z.object({
-  query: z.string(),
-  count: z.number(),
-  tools: z.array(
-    z.object({
-      name: z.string(),
-      description: z.string(),
-      scopes: z.array(z.string()),
-      signature: z.string(),
-    })
-  ),
-});
-
-export const toolSearchTool: McpToolDefinition<typeof toolSearchInput, typeof toolSearchOutput> = {
-  name: "omniroute_tool_search",
-  description:
-    "Search the available MCP tools by keyword and return the most relevant ones as compact one-line TypeScript signatures (token-efficient discovery instead of loading every tool schema).",
-  inputSchema: toolSearchInput,
-  outputSchema: toolSearchOutput,
-  scopes: ["read:tools"],
-  auditLevel: "basic",
-  phase: 1,
-  sourceEndpoints: [],
-};
-
-// ============ Tool Registry ============
-
-/** All MCP tool definitions, ordered by phase then name */
 export const MCP_TOOLS = [
   toolSearchTool,
   getHealthTool,
@@ -1527,13 +1484,10 @@ export const MCP_TOOLS = [
   agentSkillsCoverageTool,
 ] as const;
 
-/** Essential tools only (Phase 1) */
 export const MCP_ESSENTIAL_TOOLS = MCP_TOOLS.filter((t) => t.phase === 1);
 
-/** Advanced tools only (Phase 2) */
 export const MCP_ADVANCED_TOOLS = MCP_TOOLS.filter((t) => t.phase === 2);
 
-/** Map of tool name → tool definition */
 export const MCP_TOOL_MAP = Object.fromEntries(MCP_TOOLS.map((t) => [t.name, t])) as Record<
   string,
   (typeof MCP_TOOLS)[number]

--- a/open-sse/mcp-server/schemas/tools.ts
+++ b/open-sse/mcp-server/schemas/tools.ts
@@ -1443,10 +1443,54 @@ export const agentSkillsCoverageTool: McpToolDefinition<
   sourceEndpoints: ["/api/agent-skills"],
 };
 
+// ============ Tool Search ============
+
+export const toolSearchInput = z
+  .object({
+    query: z
+      .string()
+      .min(1)
+      .describe("Natural-language or keyword query over tool names/descriptions"),
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(25)
+      .optional()
+      .describe("Max results (default 8)"),
+  })
+  .describe("Search available MCP tools by keyword");
+
+export const toolSearchOutput = z.object({
+  query: z.string(),
+  count: z.number(),
+  tools: z.array(
+    z.object({
+      name: z.string(),
+      description: z.string(),
+      scopes: z.array(z.string()),
+      signature: z.string(),
+    })
+  ),
+});
+
+export const toolSearchTool: McpToolDefinition<typeof toolSearchInput, typeof toolSearchOutput> = {
+  name: "omniroute_tool_search",
+  description:
+    "Search the available MCP tools by keyword and return the most relevant ones as compact one-line TypeScript signatures (token-efficient discovery instead of loading every tool schema).",
+  inputSchema: toolSearchInput,
+  outputSchema: toolSearchOutput,
+  scopes: ["read:tools"],
+  auditLevel: "basic",
+  phase: 1,
+  sourceEndpoints: [],
+};
+
 // ============ Tool Registry ============
 
 /** All MCP tool definitions, ordered by phase then name */
 export const MCP_TOOLS = [
+  toolSearchTool,
   getHealthTool,
   listCombosTool,
   getComboMetricsTool,

--- a/open-sse/mcp-server/server.ts
+++ b/open-sse/mcp-server/server.ts
@@ -6,11 +6,10 @@ import {
   getComboStepTarget,
 } from "../../src/lib/combos/steps.ts";
 
-import { handleToolSearch } from "./toolSearch/handler.ts";
+import { registerToolSearchTool } from "./toolSearch/register.ts";
 
 import {
   MCP_TOOLS,
-  toolSearchInput,
   getHealthInput,
   listCombosInput,
   getComboMetricsInput,
@@ -1201,21 +1200,7 @@ export function createMcpServer(): McpServer {
     )
   );
 
-  server.registerTool(
-    "omniroute_tool_search",
-    {
-      description:
-        "Search MCP tools by keyword; returns compact one-line TS signatures for token-efficient discovery.",
-      inputSchema: toolSearchInput,
-    },
-    withScopeEnforcement("omniroute_tool_search", (args) => {
-      const parsed = toolSearchInput.parse(args ?? {});
-      const result = handleToolSearch(parsed);
-      return Promise.resolve({
-        content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
-      });
-    })
-  );
+  registerToolSearchTool(server, withScopeEnforcement);
 
   // ── Memory Tools ──────────────────────────────
   Object.values(memoryTools).forEach((toolDef: any) => {

--- a/open-sse/mcp-server/server.ts
+++ b/open-sse/mcp-server/server.ts
@@ -6,8 +6,11 @@ import {
   getComboStepTarget,
 } from "../../src/lib/combos/steps.ts";
 
+import { handleToolSearch } from "./toolSearch/handler.ts";
+
 import {
   MCP_TOOLS,
+  toolSearchInput,
   getHealthInput,
   listCombosInput,
   getComboMetricsInput,
@@ -1196,6 +1199,22 @@ export function createMcpServer(): McpServer {
     withScopeEnforcement("omniroute_oneproxy_stats", (args) =>
       handleOneproxyStats(oneproxyStatsInput.parse(args))
     )
+  );
+
+  server.registerTool(
+    "omniroute_tool_search",
+    {
+      description:
+        "Search MCP tools by keyword; returns compact one-line TS signatures for token-efficient discovery.",
+      inputSchema: toolSearchInput,
+    },
+    withScopeEnforcement("omniroute_tool_search", (args) => {
+      const parsed = toolSearchInput.parse(args ?? {});
+      const result = handleToolSearch(parsed);
+      return Promise.resolve({
+        content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+      });
+    })
   );
 
   // ── Memory Tools ──────────────────────────────

--- a/open-sse/mcp-server/toolSearch/catalog.ts
+++ b/open-sse/mcp-server/toolSearch/catalog.ts
@@ -17,6 +17,7 @@ import { gamificationTools } from "../tools/gamificationTools.ts";
 import { pluginTools } from "../tools/pluginTools.ts";
 import { notionTools } from "../tools/notionTools.ts";
 import { obsidianTools } from "../tools/obsidianTools.ts";
+import { compressionTools } from "../tools/compressionTools.ts";
 
 import type { ToolCatalogEntry } from "./search.ts";
 
@@ -75,6 +76,10 @@ export function getAllToolDefinitions(): ToolCatalogEntry[] {
     pluginTools,
     notionTools,
     obsidianTools,
+    // compressionTools holds omniroute_ccr_retrieve, which is NOT in MCP_TOOLS — without it
+    // a `tool_search("compression")` would miss that tool. The other 5 overlap MCP_TOOLS and
+    // are resolved by the dedup-by-name below (first wins).
+    compressionTools,
   ];
 
   const seen = new Set<string>();

--- a/open-sse/mcp-server/toolSearch/catalog.ts
+++ b/open-sse/mcp-server/toolSearch/catalog.ts
@@ -1,0 +1,93 @@
+/**
+ * getAllToolDefinitions — unified catalog of all MCP tool definitions.
+ *
+ * Aggregates the same collections referenced by TOTAL_MCP_TOOL_COUNT in server.ts:
+ *   MCP_TOOLS + memoryTools + skillTools + agentSkillTools + poolTools +
+ *   gamificationTools + pluginTools + notionTools + obsidianTools
+ *
+ * Tolerates both Array and Record shapes. Deduplicates by name (first wins).
+ */
+
+import { MCP_TOOLS } from "../schemas/tools.ts";
+import { memoryTools } from "../tools/memoryTools.ts";
+import { skillTools } from "../tools/skillTools.ts";
+import { agentSkillTools } from "../tools/agentSkillTools.ts";
+import { poolTools } from "../tools/poolTools.ts";
+import { gamificationTools } from "../tools/gamificationTools.ts";
+import { pluginTools } from "../tools/pluginTools.ts";
+import { notionTools } from "../tools/notionTools.ts";
+import { obsidianTools } from "../tools/obsidianTools.ts";
+
+import type { ToolCatalogEntry } from "./search.ts";
+
+type AnyToolLike = {
+  name?: unknown;
+  description?: unknown;
+  scopes?: unknown;
+  inputSchema?: unknown;
+};
+
+function normalizeEntry(raw: AnyToolLike): ToolCatalogEntry | null {
+  const name = typeof raw.name === "string" ? raw.name : null;
+  const description = typeof raw.description === "string" ? raw.description : "";
+  if (!name) return null;
+
+  const scopes: readonly string[] = Array.isArray(raw.scopes)
+    ? (raw.scopes as string[]).filter((s): s is string => typeof s === "string")
+    : [];
+
+  return { name, description, scopes, inputSchema: raw.inputSchema };
+}
+
+function collectFromArray(arr: AnyToolLike[]): ToolCatalogEntry[] {
+  const result: ToolCatalogEntry[] = [];
+  for (const item of arr) {
+    const entry = normalizeEntry(item);
+    if (entry) result.push(entry);
+  }
+  return result;
+}
+
+function collectFromRecord(rec: Record<string, AnyToolLike>): ToolCatalogEntry[] {
+  return collectFromArray(Object.values(rec));
+}
+
+function collectAny(collection: unknown): ToolCatalogEntry[] {
+  if (Array.isArray(collection)) return collectFromArray(collection as AnyToolLike[]);
+  if (collection && typeof collection === "object") {
+    return collectFromRecord(collection as Record<string, AnyToolLike>);
+  }
+  return [];
+}
+
+/**
+ * Returns a deduplicated list of all registered MCP tool catalog entries.
+ * Deduplication: first occurrence by name wins.
+ */
+export function getAllToolDefinitions(): ToolCatalogEntry[] {
+  const collections: unknown[] = [
+    MCP_TOOLS,
+    memoryTools,
+    skillTools,
+    agentSkillTools,
+    poolTools,
+    gamificationTools,
+    pluginTools,
+    notionTools,
+    obsidianTools,
+  ];
+
+  const seen = new Set<string>();
+  const result: ToolCatalogEntry[] = [];
+
+  for (const collection of collections) {
+    for (const entry of collectAny(collection)) {
+      if (!seen.has(entry.name)) {
+        seen.add(entry.name);
+        result.push(entry);
+      }
+    }
+  }
+
+  return result;
+}

--- a/open-sse/mcp-server/toolSearch/handler.ts
+++ b/open-sse/mcp-server/toolSearch/handler.ts
@@ -1,0 +1,18 @@
+import { getAllToolDefinitions } from "./catalog.ts";
+import { searchTools } from "./search.ts";
+import { zodToTsSignature } from "./signature.ts";
+
+export function handleToolSearch(args: { query: string; limit?: number }) {
+  const entries = getAllToolDefinitions().filter((t) => t.name !== "omniroute_tool_search");
+  const hits = searchTools(entries, args.query, args.limit ?? 8);
+  return {
+    query: args.query,
+    count: hits.length,
+    tools: hits.map((h) => ({
+      name: h.name,
+      description: h.description,
+      scopes: [...h.scopes],
+      signature: zodToTsSignature(h.name, h.inputSchema),
+    })),
+  };
+}

--- a/open-sse/mcp-server/toolSearch/index.ts
+++ b/open-sse/mcp-server/toolSearch/index.ts
@@ -1,0 +1,5 @@
+export { zodToTsSignature } from "./signature.ts";
+export { searchTools } from "./search.ts";
+export type { ToolCatalogEntry, ScoredTool } from "./search.ts";
+export { getAllToolDefinitions } from "./catalog.ts";
+export { handleToolSearch } from "./handler.ts";

--- a/open-sse/mcp-server/toolSearch/register.ts
+++ b/open-sse/mcp-server/toolSearch/register.ts
@@ -1,0 +1,36 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { toolSearchInput } from "../schemas/toolSearch.ts";
+import type { McpToolExtraLike } from "../scopeEnforcement.ts";
+import { handleToolSearch } from "./handler.ts";
+
+type TextToolResult = {
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+};
+
+type ScopeEnforcedHandler = (
+  toolName: string,
+  handler: (args: unknown, extra?: McpToolExtraLike) => Promise<TextToolResult>,
+  toolScopes?: readonly string[]
+) => (args: unknown, extra?: McpToolExtraLike) => Promise<TextToolResult>;
+
+export function registerToolSearchTool(
+  server: McpServer,
+  withScopeEnforcement: ScopeEnforcedHandler
+): void {
+  server.registerTool(
+    "omniroute_tool_search",
+    {
+      description:
+        "Search MCP tools by keyword; returns compact one-line TS signatures for token-efficient discovery.",
+      inputSchema: toolSearchInput,
+    },
+    withScopeEnforcement("omniroute_tool_search", (args) => {
+      const parsed = toolSearchInput.parse(args ?? {});
+      const result = handleToolSearch(parsed);
+      return Promise.resolve({
+        content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+      });
+    })
+  );
+}

--- a/open-sse/mcp-server/toolSearch/search.ts
+++ b/open-sse/mcp-server/toolSearch/search.ts
@@ -39,17 +39,6 @@ function countOccurrences(haystack: string, needle: string): number {
   return count;
 }
 
-function scoreHaystack(haystack: string, normalizedQuery: string, tokens: string[]): number {
-  let score = 0;
-  if (haystack.includes(normalizedQuery)) {
-    score += normalizedQuery === haystack || haystack.startsWith(normalizedQuery) ? NAME_PHRASE_BONUS : DESC_PHRASE_BONUS;
-  }
-  for (const token of tokens) {
-    score += countOccurrences(haystack, token) * DESC_TOKEN_BONUS;
-  }
-  return score;
-}
-
 function scoreEntry(entry: ToolCatalogEntry, normalizedQuery: string, tokens: string[]): number {
   const nameLower = entry.name.toLowerCase();
   const descLower = entry.description.toLowerCase();

--- a/open-sse/mcp-server/toolSearch/search.ts
+++ b/open-sse/mcp-server/toolSearch/search.ts
@@ -1,0 +1,107 @@
+/**
+ * searchTools — pure lexical scoring over tool names + descriptions.
+ *
+ * Anti-ReDoS: never compiles `new RegExp(query)`.
+ * Uses only `String.prototype.indexOf` loops (same pattern as
+ * `src/lib/memory/retrieval.ts::getRelevanceScore`).
+ */
+
+export interface ToolCatalogEntry {
+  name: string;
+  description: string;
+  scopes: readonly string[];
+  inputSchema?: unknown;
+}
+
+export interface ScoredTool {
+  name: string;
+  description: string;
+  scopes: readonly string[];
+  inputSchema?: unknown;
+  score: number;
+}
+
+const NAME_PHRASE_BONUS = 25;
+const NAME_TOKEN_BONUS = 6;
+const DESC_PHRASE_BONUS = 20;
+const DESC_TOKEN_BONUS = 3;
+const MIN_LIMIT = 1;
+const MAX_LIMIT = 25;
+
+function countOccurrences(haystack: string, needle: string): number {
+  if (!needle) return 0;
+  let count = 0;
+  let pos = 0;
+  while ((pos = haystack.indexOf(needle, pos)) !== -1) {
+    count++;
+    pos += needle.length;
+  }
+  return count;
+}
+
+function scoreHaystack(haystack: string, normalizedQuery: string, tokens: string[]): number {
+  let score = 0;
+  if (haystack.includes(normalizedQuery)) {
+    score += normalizedQuery === haystack || haystack.startsWith(normalizedQuery) ? NAME_PHRASE_BONUS : DESC_PHRASE_BONUS;
+  }
+  for (const token of tokens) {
+    score += countOccurrences(haystack, token) * DESC_TOKEN_BONUS;
+  }
+  return score;
+}
+
+function scoreEntry(entry: ToolCatalogEntry, normalizedQuery: string, tokens: string[]): number {
+  const nameLower = entry.name.toLowerCase();
+  const descLower = entry.description.toLowerCase();
+
+  let score = 0;
+
+  // Name scoring (higher weight)
+  if (nameLower.includes(normalizedQuery)) {
+    score += NAME_PHRASE_BONUS;
+  }
+  for (const token of tokens) {
+    score += countOccurrences(nameLower, token) * NAME_TOKEN_BONUS;
+  }
+
+  // Description scoring
+  if (descLower.includes(normalizedQuery)) {
+    score += DESC_PHRASE_BONUS;
+  }
+  for (const token of tokens) {
+    score += countOccurrences(descLower, token) * DESC_TOKEN_BONUS;
+  }
+
+  return score;
+}
+
+/**
+ * Search tool catalog entries lexically (no RegExp on user input).
+ * Returns top-K results ordered by score desc, name asc for ties.
+ */
+export function searchTools(
+  entries: ToolCatalogEntry[],
+  query: string,
+  limit = 8
+): ScoredTool[] {
+  const clampedLimit = Math.max(MIN_LIMIT, Math.min(MAX_LIMIT, limit));
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) return [];
+
+  const tokens = normalizedQuery.split(/\s+/).filter(Boolean);
+
+  const scored: ScoredTool[] = [];
+  for (const entry of entries) {
+    const score = scoreEntry(entry, normalizedQuery, tokens);
+    if (score > 0) {
+      scored.push({ ...entry, score });
+    }
+  }
+
+  scored.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    return a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
+  });
+
+  return scored.slice(0, clampedLimit);
+}

--- a/open-sse/mcp-server/toolSearch/signature.ts
+++ b/open-sse/mcp-server/toolSearch/signature.ts
@@ -1,0 +1,92 @@
+/**
+ * zodToTsSignature — converts a Zod v4 object schema into a compact one-line
+ * TypeScript function signature string. Never throws.
+ *
+ * Example output: `omniroute_tool_search(args: { query: string; limit?: number })`
+ */
+
+type ZodLike = { type?: string; _def?: Record<string, unknown>; shape?: Record<string, ZodLike> };
+
+function unwrap(field: ZodLike): ZodLike {
+  const t = field.type ?? (field._def as Record<string, unknown> | undefined)?.type;
+  if (t === "optional" || t === "default" || t === "nullable") {
+    const inner = (field._def as Record<string, unknown> | undefined)?.innerType;
+    if (inner && typeof inner === "object") return unwrap(inner as ZodLike);
+  }
+  return field;
+}
+
+function isOptional(field: ZodLike): boolean {
+  const t = field.type ?? (field._def as Record<string, unknown> | undefined)?.type;
+  return t === "optional";
+}
+
+function zodTypeToTs(field: ZodLike, depth = 0): string {
+  const core = unwrap(field);
+  const t = core.type ?? (core._def as Record<string, unknown> | undefined)?.type;
+
+  if (t === "string") return "string";
+  if (t === "number") return "number";
+  if (t === "boolean") return "boolean";
+  if (t === "enum") {
+    const entries = (core._def as Record<string, unknown> | undefined)?.entries;
+    if (entries && typeof entries === "object") {
+      const vals = Object.keys(entries as Record<string, unknown>);
+      return vals.map((v) => `'${v}'`).join(" | ");
+    }
+    return "string";
+  }
+  if (t === "array") {
+    const element = (core._def as Record<string, unknown> | undefined)?.element;
+    if (element && typeof element === "object") {
+      return `${zodTypeToTs(element as ZodLike, depth)}[]`;
+    }
+    return "unknown[]";
+  }
+  if (t === "object" && depth < 2) {
+    const shape =
+      core.shape ?? ((core._def as Record<string, unknown> | undefined)?.shape as Record<string, ZodLike> | undefined);
+    if (shape && typeof shape === "object") {
+      const fields = Object.entries(shape)
+        .map(([k, v]) => {
+          const opt = isOptional(v as ZodLike) ? "?" : "";
+          return `${k}${opt}: ${zodTypeToTs(v as ZodLike, depth + 1)}`;
+        })
+        .join("; ");
+      return `{ ${fields} }`;
+    }
+  }
+  return "unknown";
+}
+
+/**
+ * Converts `name` + optional Zod object schema into a one-line TS signature.
+ * Falls back to `name(args: object)` on introspection errors.
+ */
+export function zodToTsSignature(name: string, inputSchema?: unknown): string {
+  if (!inputSchema) return `${name}()`;
+
+  try {
+    const schema = inputSchema as ZodLike;
+    const t = schema.type ?? (schema._def as Record<string, unknown> | undefined)?.type;
+    if (t !== "object") return `${name}()`;
+
+    const shape =
+      schema.shape ??
+      ((schema._def as Record<string, unknown> | undefined)?.shape as Record<string, ZodLike> | undefined);
+    if (!shape || typeof shape !== "object" || Object.keys(shape).length === 0) {
+      return `${name}()`;
+    }
+
+    const fields = Object.entries(shape)
+      .map(([k, v]) => {
+        const opt = isOptional(v as ZodLike) ? "?" : "";
+        return `${k}${opt}: ${zodTypeToTs(v as ZodLike)}`;
+      })
+      .join("; ");
+
+    return `${name}(args: { ${fields} })`;
+  } catch {
+    return `${name}(args: object)`;
+  }
+}


### PR DESCRIPTION
## What

Adds a new MCP tool **`omniroute_tool_search`** that does lexical keyword search over every MCP tool's name/description and returns the top matches as compact **one-line TypeScript signatures** (~half the JSON-schema token cost), so agents discover tools on demand instead of carrying all ~88 schemas every turn. **Tier-1** item of the compression feature-extraction roadmap (#4).

`tools/list` stays **complete** (no hidden tools / no deferred hot-subset in v1 — that's a follow-up, scoped to the Anthropic family). The static deny/allow reduction (`toolCardinality.ts`) is untouched.

## How

New pure `mcp-server/toolSearch/` module:
- **`signature.ts`** — `zodToTsSignature(name, inputSchema)`: Zod v4 introspection (`field.type`, `_def.innerType`, `_def.entries`) → `name(args: { q: string; limit?: number }): Result`. **Never throws** (try/catch → `name(args: object)` fallback).
- **`search.ts`** — `searchTools`: lexical scoring reusing the `getRelevanceScore` pattern (phrase + token `indexOf` counts; name weighted over description). **Anti-ReDoS**: never compiles `new RegExp` on the query. Deterministic (stable name tie-break), `limit` clamped 1–25.
- **`catalog.ts`** — `getAllToolDefinitions`: aggregates all 10 tool collections (array + Record shapes), dedupes by name. Includes `compressionTools` so `omniroute_ccr_retrieve` (absent from `MCP_TOOLS`) is searchable.
- **`handler.ts`** — excludes the tool from its own results; output is `{query, count, tools: [{name, description, scopes, signature}]}` — only metadata already on `tools/list` plus the synthesized signature.

Wired into `server.ts` mirroring the base-tool pattern; new `read:tools` scope (resolved via `MCP_TOOL_MAP`, enforced by `withScopeEnforcement`).

## Core review hardening

A dedicated review caught: (1) **CRITICAL** — `compressionTools` was missing from the catalog, so `omniroute_ccr_retrieve` was unsearchable (fixed + regression test); (2) the README example `OMNIROUTE_MCP_SCOPES` string lacked `read:tools` (would self-lock the discovery tool under enforcement — fixed); (3) removed a dead `scoreHaystack` helper.

## Tests (TDD, vitest)

`toolSearch.{signature,search,catalog,tool}.test.ts` — **all green (13 + the new regression)**. The e2e (InMemoryTransport) proves the tool appears in `tools/list`, returns `omniroute_get_health` on top for `query:"health"` with a `signature` string, carries `read:tools`, and never returns itself.

## Gates (local)

lint 0 errors · typecheck:core clean · check:cycles OK · **docs-sync PASS** (CLAUDE.md/MCP-SERVER.md/README updated to 88 tools / 34 base / 31 scopes) · **check:complexity 1968 (baseline 1981)** · **check:cognitive-complexity 835 (baseline 841)**.

> **Pre-existing vitest reds (NOT from this PR):** `httpAuthContext.test.ts` (2) and an intermittent `audit.test.ts` (1) fail **locally** due to a shared local `DATA_DIR` with renumbered migrations + `fileParallelism:true` SQLite contention — they fail identically on a worktree with zero MCP changes, `tool.test.ts` mocks the audit DB, and `audit`+`tool` run together pass 4/4. These are environmental-local and expected to be green on the clean CI checkout. The 4 `toolSearch.*` files pass consistently.

Ready for review & merge.