### PR TITLE
fix(compression): split RTK config schema

### DIFF
--- a/open-sse/services/compression/engines/rtk/configSchema.ts
+++ b/open-sse/services/compression/engines/rtk/configSchema.ts
@@ -1,0 +1,117 @@
+import { DEFAULT_RTK_CONFIG } from "../../types.ts";
+import type { EngineConfigField, EngineValidationResult } from "../types.ts";
+
+export const RTK_SCHEMA: EngineConfigField[] = [
+  {
+    key: "intensity",
+    type: "select",
+    label: "Intensity",
+    defaultValue: DEFAULT_RTK_CONFIG.intensity,
+    options: [
+      { value: "minimal", label: "minimal" },
+      { value: "standard", label: "standard" },
+      { value: "aggressive", label: "aggressive" },
+    ],
+  },
+  {
+    key: "applyToToolResults",
+    type: "boolean",
+    label: "Apply to tool results",
+    defaultValue: DEFAULT_RTK_CONFIG.applyToToolResults,
+  },
+  {
+    key: "applyToAssistantMessages",
+    type: "boolean",
+    label: "Apply to assistant messages",
+    defaultValue: DEFAULT_RTK_CONFIG.applyToAssistantMessages,
+  },
+  {
+    key: "applyToCodeBlocks",
+    type: "boolean",
+    label: "Apply to code blocks",
+    defaultValue: DEFAULT_RTK_CONFIG.applyToCodeBlocks,
+  },
+  {
+    key: "maxLinesPerResult",
+    type: "number",
+    label: "Max lines per result",
+    defaultValue: DEFAULT_RTK_CONFIG.maxLinesPerResult,
+    min: 0,
+    max: 5000,
+  },
+  {
+    key: "maxCharsPerResult",
+    type: "number",
+    label: "Max chars per result",
+    defaultValue: DEFAULT_RTK_CONFIG.maxCharsPerResult,
+    min: 0,
+    max: 500000,
+  },
+  {
+    key: "deduplicateThreshold",
+    type: "number",
+    label: "Deduplicate threshold",
+    defaultValue: DEFAULT_RTK_CONFIG.deduplicateThreshold,
+    min: 2,
+    max: 100,
+  },
+  {
+    key: "rawOutputRetention",
+    type: "select",
+    label: "Raw output retention",
+    defaultValue: DEFAULT_RTK_CONFIG.rawOutputRetention,
+    options: [
+      { value: "never", label: "never" },
+      { value: "failures", label: "failures" },
+      { value: "always", label: "always" },
+    ],
+  },
+  {
+    key: "enableRenderers",
+    type: "boolean",
+    label: "Semantic renderers",
+    defaultValue: DEFAULT_RTK_CONFIG.enableRenderers,
+  },
+];
+
+export function validateRtkEngineConfig(config: Record<string, unknown>): EngineValidationResult {
+  const errors: string[] = [];
+  if (
+    config.intensity !== undefined &&
+    config.intensity !== "minimal" &&
+    config.intensity !== "standard" &&
+    config.intensity !== "aggressive"
+  ) {
+    errors.push("intensity must be minimal, standard, or aggressive");
+  }
+  for (const key of [
+    "enabled",
+    "applyToToolResults",
+    "applyToAssistantMessages",
+    "applyToCodeBlocks",
+  ]) {
+    if (config[key] !== undefined && typeof config[key] !== "boolean") {
+      errors.push(`${key} must be a boolean`);
+    }
+  }
+  for (const key of ["maxLinesPerResult", "maxCharsPerResult", "deduplicateThreshold"]) {
+    if (config[key] !== undefined && (typeof config[key] !== "number" || config[key] < 0)) {
+      errors.push(`${key} must be a non-negative number`);
+    }
+  }
+  if (config.enabledFilters !== undefined && !Array.isArray(config.enabledFilters)) {
+    errors.push("enabledFilters must be an array");
+  }
+  if (config.disabledFilters !== undefined && !Array.isArray(config.disabledFilters)) {
+    errors.push("disabledFilters must be an array");
+  }
+  if (
+    config.rawOutputRetention !== undefined &&
+    config.rawOutputRetention !== "never" &&
+    config.rawOutputRetention !== "failures" &&
+    config.rawOutputRetention !== "always"
+  ) {
+    errors.push("rawOutputRetention must be never, failures, or always");
+  }
+  return { valid: errors.length === 0, errors };
+}

--- a/open-sse/services/compression/engines/rtk/index.ts
+++ b/open-sse/services/compression/engines/rtk/index.ts
@@ -1,7 +1,8 @@
 import { createCompressionStats, estimateCompressionTokens } from "../../stats.ts";
 import { DEFAULT_RTK_CONFIG, type CompressionResult, type RtkConfig } from "../../types.ts";
-import type { CompressionEngine, EngineConfigField, EngineValidationResult } from "../types.ts";
+import type { CompressionEngine } from "../types.ts";
 import { detectCommandType } from "./commandDetector.ts";
+import { RTK_SCHEMA, validateRtkEngineConfig } from "./configSchema.ts";
 import { deduplicateRepeatedLines } from "./deduplicator.ts";
 import { groupSimilarLines } from "./grouper.ts";
 import { matchRtkFilter } from "./filterLoader.ts";
@@ -61,121 +62,6 @@ function resolveToolMeta(
     return { command: meta.command, skipFilters: false };
   }
   return { command: null, skipFilters: true };
-}
-
-const RTK_SCHEMA: EngineConfigField[] = [
-  {
-    key: "intensity",
-    type: "select",
-    label: "Intensity",
-    defaultValue: DEFAULT_RTK_CONFIG.intensity,
-    options: [
-      { value: "minimal", label: "minimal" },
-      { value: "standard", label: "standard" },
-      { value: "aggressive", label: "aggressive" },
-    ],
-  },
-  {
-    key: "applyToToolResults",
-    type: "boolean",
-    label: "Apply to tool results",
-    defaultValue: DEFAULT_RTK_CONFIG.applyToToolResults,
-  },
-  {
-    key: "applyToAssistantMessages",
-    type: "boolean",
-    label: "Apply to assistant messages",
-    defaultValue: DEFAULT_RTK_CONFIG.applyToAssistantMessages,
-  },
-  {
-    key: "applyToCodeBlocks",
-    type: "boolean",
-    label: "Apply to code blocks",
-    defaultValue: DEFAULT_RTK_CONFIG.applyToCodeBlocks,
-  },
-  {
-    key: "maxLinesPerResult",
-    type: "number",
-    label: "Max lines per result",
-    defaultValue: DEFAULT_RTK_CONFIG.maxLinesPerResult,
-    min: 0,
-    max: 5000,
-  },
-  {
-    key: "maxCharsPerResult",
-    type: "number",
-    label: "Max chars per result",
-    defaultValue: DEFAULT_RTK_CONFIG.maxCharsPerResult,
-    min: 0,
-    max: 500000,
-  },
-  {
-    key: "deduplicateThreshold",
-    type: "number",
-    label: "Deduplicate threshold",
-    defaultValue: DEFAULT_RTK_CONFIG.deduplicateThreshold,
-    min: 2,
-    max: 100,
-  },
-  {
-    key: "rawOutputRetention",
-    type: "select",
-    label: "Raw output retention",
-    defaultValue: DEFAULT_RTK_CONFIG.rawOutputRetention,
-    options: [
-      { value: "never", label: "never" },
-      { value: "failures", label: "failures" },
-      { value: "always", label: "always" },
-    ],
-  },
-  {
-    key: "enableRenderers",
-    type: "boolean",
-    label: "Semantic renderers",
-    defaultValue: DEFAULT_RTK_CONFIG.enableRenderers,
-  },
-];
-
-function validateRtkEngineConfig(config: Record<string, unknown>): EngineValidationResult {
-  const errors: string[] = [];
-  if (
-    config.intensity !== undefined &&
-    config.intensity !== "minimal" &&
-    config.intensity !== "standard" &&
-    config.intensity !== "aggressive"
-  ) {
-    errors.push("intensity must be minimal, standard, or aggressive");
-  }
-  for (const key of [
-    "enabled",
-    "applyToToolResults",
-    "applyToAssistantMessages",
-    "applyToCodeBlocks",
-  ]) {
-    if (config[key] !== undefined && typeof config[key] !== "boolean") {
-      errors.push(`${key} must be a boolean`);
-    }
-  }
-  for (const key of ["maxLinesPerResult", "maxCharsPerResult", "deduplicateThreshold"]) {
-    if (config[key] !== undefined && (typeof config[key] !== "number" || config[key] < 0)) {
-      errors.push(`${key} must be a non-negative number`);
-    }
-  }
-  if (config.enabledFilters !== undefined && !Array.isArray(config.enabledFilters)) {
-    errors.push("enabledFilters must be an array");
-  }
-  if (config.disabledFilters !== undefined && !Array.isArray(config.disabledFilters)) {
-    errors.push("disabledFilters must be an array");
-  }
-  if (
-    config.rawOutputRetention !== undefined &&
-    config.rawOutputRetention !== "never" &&
-    config.rawOutputRetention !== "failures" &&
-    config.rawOutputRetention !== "always"
-  ) {
-    errors.push("rawOutputRetention must be never, failures, or always");
-  }
-  return { valid: errors.length === 0, errors };
 }
 
 export interface RtkProcessResult {


### PR DESCRIPTION
Unblocks #5268 Fast Quality by moving the RTK engine schema + validator into a sibling module.

Why:
- Fast Quality failed on file-size: open-sse/services/compression/engines/rtk/index.ts 821 > cap 800.
- This keeps behavior intact and reduces index.ts to 706 lines.

Validation:
- npm run check:file-size
- env DISABLE_SQLITE_AUTO_BACKUP=true node --max-old-space-size=8192 --import tsx --test --test-force-exit tests/unit/compression/rtk-render-gitdiff.test.ts tests/unit/compression/rtk-render-table.test.ts tests/unit/compression/rtk-render-testgreen.test.ts tests/unit/compression/rtk-renderers-integration.test.ts (11/11 pass)
- npx eslint open-sse/services/compression/engines/rtk/index.ts open-sse/services/compression/engines/rtk/configSchema.ts
