### PR TITLE
fix(mcp): split tool search registration schema

### DIFF
--- a/open-sse/mcp-server/schemas/toolSearch.ts
+++ b/open-sse/mcp-server/schemas/toolSearch.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+import type { McpToolDefinition } from "./tools.ts";
+
+export const toolSearchInput = z
+  .object({
+    query: z
+      .string()
+      .min(1)
+      .describe("Natural-language or keyword query over tool names/descriptions"),
+    limit: z.number().int().min(1).max(25).optional().describe("Max results (default 8)"),
+  })
+  .describe("Search available MCP tools by keyword");
+
+export const toolSearchOutput = z.object({
+  query: z.string(),
+  count: z.number(),
+  tools: z.array(
+    z.object({
+      name: z.string(),
+      description: z.string(),
+      scopes: z.array(z.string()),
+      signature: z.string(),
+    })
+  ),
+});
+
+export const toolSearchTool: McpToolDefinition<typeof toolSearchInput, typeof toolSearchOutput> = {
+  name: "omniroute_tool_search",
+  description:
+    "Search the available MCP tools by keyword and return the most relevant ones as compact one-line TypeScript signatures (token-efficient discovery instead of loading every tool schema).",
+  inputSchema: toolSearchInput,
+  outputSchema: toolSearchOutput,
+  scopes: ["read:tools"],
+  auditLevel: "basic",
+  phase: 1,
+  sourceEndpoints: [],
+};

--- a/open-sse/mcp-server/schemas/tools.ts
+++ b/open-sse/mcp-server/schemas/tools.ts
@@ -10,6 +10,7 @@
  */
 
 import { z } from "zod";
+import { toolSearchTool } from "./toolSearch.ts";
 import {
   AUTO_ROUTING_STRATEGY_VALUES,
   ROUTING_STRATEGY_VALUES,
@@ -1443,52 +1444,8 @@ export const agentSkillsCoverageTool: McpToolDefinition<
   sourceEndpoints: ["/api/agent-skills"],
 };
 
-// ============ Tool Search ============
+export { toolSearchInput, toolSearchOutput, toolSearchTool } from "./toolSearch.ts";
 
-export const toolSearchInput = z
-  .object({
-    query: z
-      .string()
-      .min(1)
-      .describe("Natural-language or keyword query over tool names/descriptions"),
-    limit: z
-      .number()
-      .int()
-      .min(1)
-      .max(25)
-      .optional()
-      .describe("Max results (default 8)"),
-  })
-  .describe("Search available MCP tools by keyword");
-
-export const toolSearchOutput = z.object({
-  query: z.string(),
-  count: z.number(),
-  tools: z.array(
-    z.object({
-      name: z.string(),
-      description: z.string(),
-      scopes: z.array(z.string()),
-      signature: z.string(),
-    })
-  ),
-});
-
-export const toolSearchTool: McpToolDefinition<typeof toolSearchInput, typeof toolSearchOutput> = {
-  name: "omniroute_tool_search",
-  description:
-    "Search the available MCP tools by keyword and return the most relevant ones as compact one-line TypeScript signatures (token-efficient discovery instead of loading every tool schema).",
-  inputSchema: toolSearchInput,
-  outputSchema: toolSearchOutput,
-  scopes: ["read:tools"],
-  auditLevel: "basic",
-  phase: 1,
-  sourceEndpoints: [],
-};
-
-// ============ Tool Registry ============
-
-/** All MCP tool definitions, ordered by phase then name */
 export const MCP_TOOLS = [
   toolSearchTool,
   getHealthTool,
@@ -1527,13 +1484,10 @@ export const MCP_TOOLS = [
   agentSkillsCoverageTool,
 ] as const;
 
-/** Essential tools only (Phase 1) */
 export const MCP_ESSENTIAL_TOOLS = MCP_TOOLS.filter((t) => t.phase === 1);
 
-/** Advanced tools only (Phase 2) */
 export const MCP_ADVANCED_TOOLS = MCP_TOOLS.filter((t) => t.phase === 2);
 
-/** Map of tool name → tool definition */
 export const MCP_TOOL_MAP = Object.fromEntries(MCP_TOOLS.map((t) => [t.name, t])) as Record<
   string,
   (typeof MCP_TOOLS)[number]

--- a/open-sse/mcp-server/server.ts
+++ b/open-sse/mcp-server/server.ts
@@ -6,11 +6,10 @@ import {
   getComboStepTarget,
 } from "../../src/lib/combos/steps.ts";
 
-import { handleToolSearch } from "./toolSearch/handler.ts";
+import { registerToolSearchTool } from "./toolSearch/register.ts";
 
 import {
   MCP_TOOLS,
-  toolSearchInput,
   getHealthInput,
   listCombosInput,
   getComboMetricsInput,
@@ -1201,21 +1200,7 @@ export function createMcpServer(): McpServer {
     )
   );
 
-  server.registerTool(
-    "omniroute_tool_search",
-    {
-      description:
-        "Search MCP tools by keyword; returns compact one-line TS signatures for token-efficient discovery.",
-      inputSchema: toolSearchInput,
-    },
-    withScopeEnforcement("omniroute_tool_search", (args) => {
-      const parsed = toolSearchInput.parse(args ?? {});
-      const result = handleToolSearch(parsed);
-      return Promise.resolve({
-        content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
-      });
-    })
-  );
+  registerToolSearchTool(server, withScopeEnforcement);
 
   // ── Memory Tools ──────────────────────────────
   Object.values(memoryTools).forEach((toolDef: any) => {

--- a/open-sse/mcp-server/toolSearch/register.ts
+++ b/open-sse/mcp-server/toolSearch/register.ts
@@ -1,0 +1,36 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { toolSearchInput } from "../schemas/toolSearch.ts";
+import type { McpToolExtraLike } from "../scopeEnforcement.ts";
+import { handleToolSearch } from "./handler.ts";
+
+type TextToolResult = {
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+};
+
+type ScopeEnforcedHandler = (
+  toolName: string,
+  handler: (args: unknown, extra?: McpToolExtraLike) => Promise<TextToolResult>,
+  toolScopes?: readonly string[]
+) => (args: unknown, extra?: McpToolExtraLike) => Promise<TextToolResult>;
+
+export function registerToolSearchTool(
+  server: McpServer,
+  withScopeEnforcement: ScopeEnforcedHandler
+): void {
+  server.registerTool(
+    "omniroute_tool_search",
+    {
+      description:
+        "Search MCP tools by keyword; returns compact one-line TS signatures for token-efficient discovery.",
+      inputSchema: toolSearchInput,
+    },
+    withScopeEnforcement("omniroute_tool_search", (args) => {
+      const parsed = toolSearchInput.parse(args ?? {});
+      const result = handleToolSearch(parsed);
+      return Promise.resolve({
+        content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+      });
+    })
+  );
+}


### PR DESCRIPTION
Unblocks #5269 Fast Quality by moving the new tool_search schema/tool definition and server registration into focused modules.

Why:
- Fast Quality failed on frozen file-size caps:
  - open-sse/mcp-server/schemas/tools.ts 1541 > 1497
  - open-sse/mcp-server/server.ts 1565 > 1555
- This keeps exported schema names and registration behavior intact while reducing:
  - tools.ts to 1493 lines
  - server.ts to 1549 lines

Validation:
- npm run check:file-size
- npx vitest run open-sse/mcp-server/__tests__/toolSearch.catalog.test.ts open-sse/mcp-server/__tests__/toolSearch.search.test.ts open-sse/mcp-server/__tests__/toolSearch.signature.test.ts open-sse/mcp-server/__tests__/toolSearch.tool.test.ts (14/14 pass)
- npx eslint open-sse/mcp-server/schemas/tools.ts open-sse/mcp-server/schemas/toolSearch.ts open-sse/mcp-server/server.ts open-sse/mcp-server/toolSearch/register.ts (0 errors; existing server any warnings only)
