### PR TITLE
feat: add CorrelationId and fix lazy loading [wating autor]

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -220,6 +220,7 @@ const nextConfig = {
     "buffer",
     "util",
     "process",
+    "worker_threads",
   ],
   transpilePackages: ["@omniroute/open-sse", "@lobehub/icons", "fumadocs-ui", "fumadocs-core"],
   allowedDevOrigins: ["localhost", "127.0.0.1", "192.168.0.250"],

--- a/open-sse/handlers/videoGeneration.ts
+++ b/open-sse/handlers/videoGeneration.ts
@@ -342,7 +342,7 @@ async function handleVertexVeoGeneration({ model, body, credentials, log }) {
  * Submits an AnimateDiff or SVD workflow, polls for completion, fetches output video
  */
 async function handleVeoAiFreeVideoGeneration({ model, provider, body, credentials, log }) {
-  const executor = getExecutor(provider);
+  const executor = await getExecutor(provider);
   if (!executor) {
     return { success: false, status: 400, error: `Unknown video provider: ${provider}` };
   }

--- a/open-sse/services/batchProcessor.ts
+++ b/open-sse/services/batchProcessor.ts
@@ -17,7 +17,6 @@ import {
   markBatchItemResult,
   updateBatch,
 } from "@/lib/localDb";
-import { dispatch } from "@/lib/batches/dispatch";
 import type { SupportedBatchEndpoint } from "@/shared/constants/batchEndpoints";
 import { DEFAULT_BATCH_EXPIRATION_SECONDS } from "@/shared/constants/batch";
 
@@ -509,7 +508,9 @@ async function processSingleItemWithRetry(item: BatchRequestItem, apiKey: string
 async function processSingleItem(item: BatchRequestItem, apiKey: string) {
   const body = buildRequestBody(item);
 
-  return await dispatch.dispatchBatchApiRequest({
+  // Lazy import to avoid webpack tracing 7 route handlers during instrumentation compilation.
+  const { dispatch: batchDispatch } = await import("@/lib/batches/dispatch");
+  return await batchDispatch.dispatchBatchApiRequest({
     endpoint: item.url,
     body,
     apiKey,

--- a/open-sse/services/combo/autoStrategy.ts
+++ b/open-sse/services/combo/autoStrategy.ts
@@ -413,6 +413,16 @@ export async function expandAutoComboCandidatePool(
 
   if (Array.isArray(localAutoConfig?.candidatePool) && localAutoConfig.candidatePool.length > 0)
     return eligibleTargets;
+  console.error(
+    "[DEBUG-EXPAND] NO early return! localAutoConfig keys:",
+    Object.keys(localAutoConfig),
+    "candidatePool:",
+    localAutoConfig?.candidatePool,
+    "combo.autoConfig:",
+    combo?.autoConfig,
+    "combo.config?.auto:",
+    (combo?.config as any)?.auto
+  );
 
   try {
     const allConnections = await getProviderConnections({ isActive: true });

--- a/open-sse/services/combo/comboSetup.ts
+++ b/open-sse/services/combo/comboSetup.ts
@@ -69,6 +69,20 @@ function resolveContextCachePin(ctx: ComboContext): {
   ) {
     const pinned = getLastSessionModel(effectiveSessionId, combo.name);
     if (pinned) {
+      // Validate pinned model is within the combo's candidatePool
+      const candidatePool = Array.isArray((combo.config as any)?.candidatePool)
+        ? ((combo.config as any).candidatePool as string[])
+        : null;
+      if (candidatePool && candidatePool.length > 0) {
+        const pinnedProvider = pinned.includes("/") ? pinned.split("/")[0] : "";
+        if (pinnedProvider && !candidatePool.includes(pinnedProvider)) {
+          log.warn(
+            "COMBO",
+            `Context cache: ignoring pinned model=${pinned} — provider "${pinnedProvider}" not in candidatePool [${candidatePool}]`
+          );
+          return { effectiveSessionId, pinnedModel: null };
+        }
+      }
       ctx.body = { ...ctx.body, model: pinned };
       pinnedModel = pinned;
       log.info("COMBO", `[#401] Context cache: pinned model=${pinned} (server-side)`);

--- a/open-sse/services/combo/streamPreBuffer.ts
+++ b/open-sse/services/combo/streamPreBuffer.ts
@@ -1,0 +1,112 @@
+/**
+ * Stream pre-buffer: holds streaming response chunks before sending to client.
+ * If an error occurs before the threshold is met, the combo can retry with
+ * another provider. Once the threshold is met, chunks flush to the client
+ * and no more retries are possible.
+ *
+ * Modes:
+ *   - "time": buffer for N seconds, then flush
+ *   - "tokens": buffer until N tokens are accumulated, then flush
+ */
+
+export type StreamPreBufferConfig = {
+  enabled: boolean;
+  mode: "time" | "tokens";
+  threshold: number;
+};
+
+/**
+ * Reads the stream until the pre-buffer threshold is met.
+ * Returns a new Response with the buffered + remaining stream.
+ * Throws if the stream errors before the threshold.
+ */
+export async function preBufferStream(
+  response: Response,
+  config: StreamPreBufferConfig,
+  log?: { info?: (...args: unknown[]) => void; warn?: (...args: unknown[]) => void }
+): Promise<Response> {
+  if (!config.enabled || !response.body) return response;
+
+  const { mode, threshold } = config;
+  const reader = response.body.getReader();
+  const buffered: Uint8Array[] = [];
+  let totalTokens = 0;
+  const startTime = Date.now();
+  let totalBytes = 0;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffered.push(value);
+      totalBytes += value.length;
+      totalTokens += Math.ceil(value.length / 4); // ~4 chars/token
+
+      const elapsed = Date.now() - startTime;
+      const met =
+        (mode === "time" && elapsed >= threshold * 1000) ||
+        (mode === "tokens" && totalTokens >= threshold);
+
+      if (met) {
+        log?.info?.(
+          "COMBO",
+          `Pre-buffer threshold met (${mode}=${threshold}, actual ${mode === "time" ? elapsed + "ms" : totalTokens + " tokens"}, ${buffered.length} chunks, ${totalBytes} bytes) — releasing to client`
+        );
+        // Threshold met — return a replay response
+        return buildPreBufferResponse(buffered, reader, response);
+      }
+    }
+
+    // Stream ended before threshold — still valid, return what we have
+    log?.warn?.(
+      "COMBO",
+      `Pre-buffer stream ended before threshold (${mode}=${threshold}, actual ${mode === "time" ? Date.now() - startTime + "ms" : totalTokens + " tokens"}) — releasing ${buffered.length} buffered chunks`
+    );
+    return buildPreBufferResponse(buffered, reader, response);
+  } catch (err) {
+    // Stream errored before threshold — combo can retry
+    log?.warn?.(
+      "COMBO",
+      `Pre-buffer stream error before threshold (${mode}=${threshold}): ${err instanceof Error ? err.message : err}`
+    );
+    await reader.cancel(err).catch(() => {});
+    throw err;
+  }
+}
+
+function buildPreBufferResponse(
+  buffered: Uint8Array[],
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  original: Response
+): Response {
+  const prefix = buffered.slice();
+  let idx = 0;
+  const stream = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      if (idx < prefix.length) {
+        controller.enqueue(prefix[idx++]);
+        return;
+      }
+      try {
+        const { done, value } = await reader.read();
+        if (done) {
+          controller.close();
+        } else {
+          controller.enqueue(value);
+        }
+      } catch (err) {
+        controller.error(err);
+      }
+    },
+    cancel(reason) {
+      reader.cancel(reason).catch(() => {});
+    },
+  });
+
+  return new Response(stream, {
+    status: original.status,
+    statusText: original.statusText,
+    headers: original.headers,
+  });
+}

--- a/open-sse/services/combo/targetExhaustion.ts
+++ b/open-sse/services/combo/targetExhaustion.ts
@@ -26,7 +26,10 @@ import type { ComboLogger, ResolvedComboTarget } from "./types.ts";
 
 // Connection-level failure statuses: the provider connection itself is likely bad (upstream
 // unreachable, proxy/gateway error), so remaining same-connection targets are skipped.
-const CONNECTION_LEVEL_ERROR_STATUSES = [408, 500, 502, 503, 504, 524];
+// 502/503/504 are excluded — they often indicate model-specific or transient upstream issues,
+// not a broken connection. Different models on the same connection may still succeed.
+// The provider circuit breaker handles provider-wide outages with the sameProviderNext guard.
+const CONNECTION_LEVEL_ERROR_STATUSES = [408, 524];
 
 // #5085: an "empty content" 502 is the synthetic status chatCore assigns to a provider that
 // answered HTTP 200 with no usable completion (isEmptyContentResponse). The connection is
@@ -112,9 +115,15 @@ export function applyComboTargetExhaustion(
 
 /**
  * #1731v2: connection-level errors (408/5xx, excluding the OmniRoute circuit-open signal) suggest
- * the provider connection itself is bad → skip remaining same-connection (or same-provider, when
- * no connectionId) targets this request. Only runs when the provider was NOT already marked fully
- * exhausted above. Split out to keep applyComboTargetExhaustion under the complexity ceiling.
+ * the provider connection itself is bad → skip remaining same-connection targets this request.
+ * Only runs when the provider was NOT already marked fully exhausted above. Split out to keep
+ * applyComboTargetExhaustion under the complexity ceiling.
+ *
+ * When there is no connectionId (common for combos configured with just model names), we do NOT
+ * mark the entire provider as exhausted — a 503 from one model (e.g. gemma-4-31b-it) does not
+ * mean another model on the same provider (e.g. gemma-4-26b-a4b-it) is also down. The provider
+ * circuit breaker (shouldRecordProviderBreakerFailure) already handles provider-level failure
+ * tracking with the sameProviderNext guard.
  */
 function markConnectionLevelExhaustion(
   target: ResolvedComboTarget,
@@ -141,11 +150,8 @@ function markConnectionLevelExhaustion(
       tag,
       `Provider ${provider} connection ${connId} error (${result.status}) — marking for skip on remaining targets (#1731v2)`
     );
-  } else {
-    sets.exhaustedProviders.add(provider);
-    log.info(
-      tag,
-      `Provider ${provider} connection error (${result.status}) — marking for skip on remaining targets (#1731)`
-    );
   }
+  // When there is no connectionId, do NOT add the provider to exhaustedProviders.
+  // Different models on the same provider may still succeed — let the combo loop
+  // try the next target normally. The provider circuit breaker handles provider-wide outages.
 }

--- a/open-sse/services/combo/types.ts
+++ b/open-sse/services/combo/types.ts
@@ -89,6 +89,7 @@ export type HandleComboChatOptions = {
   signal?: AbortSignal | null;
   apiKeyAllowedConnections?: string[] | null;
   nesting?: ComboNestingContext | null;
+  correlationId?: string | null;
 };
 
 export type HandleRoundRobinOptions = Omit<

--- a/open-sse/services/combo/validateQuality.ts
+++ b/open-sse/services/combo/validateQuality.ts
@@ -99,6 +99,8 @@ export async function validateResponseQuality(
     let hasMessageStart = false;
     let hasContentBlock = false;
     let hasLifecycleEnd = false;
+    let hasRealContent = false;
+    let hasOnlyErrors = true;
     const sseLineNormalizer = createSSEDataLineNormalizer();
     let pendingEventType = "";
 
@@ -143,7 +145,40 @@ export async function validateResponseQuality(
         pendingEventType = "";
 
         if (isKnownNonClaudeStreamPayload(parsed, eventType)) {
+          // Check for Gemini malformed_response — the stream delivered a 200
+          // but the content is unusable (e.g. truncated, garbled, or empty).
+          const fr = (parsed.choices as any[])?.[0]?.finish_reason;
+          if (fr === "malformed_response" || fr === "MALFORMED_RESPONSE") {
+            hasOnlyErrors = true;
+            continue;
+          }
+          hasRealContent = true;
+          hasOnlyErrors = false;
           return true;
+        }
+
+        // Detect error-only streams: the provider returned 200 but the stream
+        // body is an error (e.g. Gemini "server exhausted"). The translator may
+        // wrap this in an OpenAI-format chunk with empty choices + error field.
+        if (parsed.error) {
+          const hasMeaningfulContent = isKnownNonClaudeStreamPayload(parsed, eventType);
+          if (!hasMeaningfulContent) {
+            // Error with no real content — skip this chunk but track it.
+            continue;
+          }
+        }
+
+        // Any other non-error, non-Claude, non-protocol payload counts as real content.
+        // Skip protocol markers ([DONE] is already handled above, but other
+        // non-content fields like bare event IDs shouldn't count either).
+        if (isKnownNonClaudeStreamPayload(parsed, eventType)) {
+          hasRealContent = true;
+          hasOnlyErrors = false;
+          return true;
+        }
+        if (eventType || parsed.id || parsed.object) {
+          hasRealContent = true;
+          hasOnlyErrors = false;
         }
 
         switch (eventType) {
@@ -236,6 +271,25 @@ export async function validateResponseQuality(
             return { valid: false, reason: "streaming empty content block" };
           }
 
+          if (hasOnlyErrors && !hasRealContent) {
+            // Stream contained only error objects (e.g. Gemini "server exhausted")
+            // with no real content — treat as invalid for combo failover.
+            log.warn?.(
+              "COMBO",
+              "Streaming response contained only error objects, no real content — marking as invalid for combo failover"
+            );
+            return { valid: false, reason: "streaming error-only response" };
+          }
+
+          // If stream ended without any recognized content or errors, treat as invalid.
+          if (!hasRealContent && !hasMessageStart) {
+            log.warn?.(
+              "COMBO",
+              `Streaming response ended without any recognized content (hasOnlyErrors=${hasOnlyErrors}) — marking as invalid`
+            );
+            return { valid: false, reason: "streaming no recognized content" };
+          }
+
           // Incomplete lifecycle or non-Claude stream — replay all buffered
           // bytes. The reader is exhausted so the forwarding reader will
           // immediately signal done.
@@ -308,7 +362,8 @@ export async function validateResponseQuality(
 
   const choices = json?.choices;
   if (json?.object === "response") {
-    if (!responsesApiOutputHasContent(json.output)) return { valid: false, reason: "empty_choices" };
+    if (!responsesApiOutputHasContent(json.output))
+      return { valid: false, reason: "empty_choices" };
     const status = typeof json.status === "string" ? json.status : "";
     if (status && !["completed", "done"].includes(status)) {
       return { valid: false, reason: "no_terminal" };
@@ -331,6 +386,11 @@ export async function validateResponseQuality(
         valid: false,
         reason: `upstream error in 200 body: ${err?.message || JSON.stringify(json.error).substring(0, 200)}`,
       };
+    }
+    // Empty JSON body (no choices, no output, no error) — treat as invalid.
+    const topLevelKeys = Object.keys(json).filter((k) => !k.startsWith("_"));
+    if (topLevelKeys.length === 0) {
+      return { valid: false, reason: "empty JSON response body" };
     }
     return { valid: true };
   }

--- a/open-sse/services/comboConfig.ts
+++ b/open-sse/services/comboConfig.ts
@@ -27,6 +27,16 @@ export const PRE_SCREEN_CONCURRENCY = 5;
 export const DEFAULT_COMBO_TARGET_TIMEOUT_MS = 120_000;
 
 /**
+ * Streaming-specific per-target timeout. For streaming requests the combo only
+ * needs to wait for the first headers — once the stream starts, data flows
+ * indefinitely. This timeout catches "provider never responds" without aborting
+ * healthy long-running streams. The timeout is cancelled as soon as
+ * `handleSingleModel` resolves (which happens after `ensureStreamReadiness`
+ * confirms the stream has data).
+ */
+export const STREAMING_TARGET_TIMEOUT_MS = 30_000;
+
+/**
  * Default pre-cascade semaphore queue depth for round-robin combos (#3872). When a
  * combo member's concurrency slot is saturated, this many requests wait in the
  * member's queue before `SEMAPHORE_QUEUE_FULL` triggers a cascade to the next member.
@@ -103,6 +113,15 @@ const DEFAULT_COMBO_CONFIG = {
     qualityWeight: 0.85,
     latencyWeight: 0.15,
     cacheTtlMs: 60000,
+  },
+  // Stream pre-buffer: hold streaming response chunks before sending to client.
+  // If an error occurs before the threshold is met, the combo can retry with
+  // another provider. Once the threshold is met, chunks flush to the client
+  // and no more retries are possible.
+  streamPreBuffer: {
+    enabled: false,
+    mode: "tokens" as "time" | "tokens",
+    threshold: 100, // seconds if mode=time, token count if mode=tokens
   },
 };
 

--- a/open-sse/services/providerCooldownTracker.ts
+++ b/open-sse/services/providerCooldownTracker.ts
@@ -61,27 +61,32 @@ export function cleanupExpiredCooldownEntries(now = Date.now()): void {
 }
 
 /**
- * Build a cooldown key from provider and optional connectionId.
+ * Build a cooldown key from provider, optional connectionId, and optional model.
+ * When modelStr is provided the key is model-scoped (e.g. "gemini:conn:gemma-4-31b-it"),
+ * allowing per-model rate limits (Gemini) to cool down independently.
  */
-function cooldownKey(provider: string, connectionId?: string): string {
-  return connectionId ? `${provider}:${connectionId}` : provider;
+function cooldownKey(provider: string, connectionId?: string, modelStr?: string): string {
+  const base = connectionId ? `${provider}:${connectionId}` : provider;
+  return modelStr ? `${base}@${modelStr}` : base;
 }
 
 /**
- * Record a failure for a provider/connection.
+ * Record a failure for a provider/connection/model.
  *
  * @param provider - Provider ID (e.g. "openai", "anthropic")
  * @param connectionId - Optional connection ID for per-connection tracking
  * @param settings - Resilience settings for cooldown configuration
+ * @param modelStr - Optional model string for per-model cooldown (e.g. "gemma-4-31b-it")
  */
 export function recordProviderCooldown(
   provider: string,
   connectionId: string | undefined,
-  settings?: ResilienceSettings
+  settings?: ResilienceSettings,
+  modelStr?: string
 ): void {
   if (!provider || provider === "unknown") return;
 
-  const key = cooldownKey(provider, connectionId);
+  const key = cooldownKey(provider, connectionId, modelStr);
   const existing = cooldownMap.get(key);
   const now = Date.now();
   const retentionMs = getEntryRetentionMs(settings);
@@ -98,21 +103,23 @@ export function recordProviderCooldown(
 }
 
 /**
- * Check if a provider/connection is currently in cooldown and should be skipped.
+ * Check if a provider/connection/model is currently in cooldown and should be skipped.
  *
  * @param provider - Provider ID
  * @param connectionId - Optional connection ID
  * @param settings - Resilience settings for cooldown configuration
+ * @param modelStr - Optional model string for per-model cooldown check
  * @returns true if the provider should be skipped (still in cooldown)
  */
 export function isProviderInCooldown(
   provider: string,
   connectionId: string | undefined,
-  settings?: ResilienceSettings
+  settings?: ResilienceSettings,
+  modelStr?: string
 ): boolean {
   if (!provider || provider === "unknown") return false;
 
-  const key = cooldownKey(provider, connectionId);
+  const key = cooldownKey(provider, connectionId, modelStr);
   const entry = cooldownMap.get(key);
   if (!entry) return false;
 
@@ -136,17 +143,18 @@ export function isProviderInCooldown(
 }
 
 /**
- * Get the remaining cooldown time for a provider/connection.
+ * Get the remaining cooldown time for a provider/connection/model.
  * Returns 0 if not in cooldown.
  */
 export function getRemainingCooldownMs(
   provider: string,
   connectionId: string | undefined,
-  settings?: ResilienceSettings
+  settings?: ResilienceSettings,
+  modelStr?: string
 ): number {
   if (!provider || provider === "unknown") return 0;
 
-  const key = cooldownKey(provider, connectionId);
+  const key = cooldownKey(provider, connectionId, modelStr);
   const entry = cooldownMap.get(key);
   if (!entry) return 0;
 
@@ -169,13 +177,17 @@ export function getRemainingCooldownMs(
 }
 
 /**
- * Record a successful request for a provider/connection.
+ * Record a successful request for a provider/connection/model.
  * Resets the failure count (but keeps the entry for reference).
  */
-export function recordProviderSuccess(provider: string, connectionId: string | undefined): void {
+export function recordProviderSuccess(
+  provider: string,
+  connectionId: string | undefined,
+  modelStr?: string
+): void {
   if (!provider || provider === "unknown") return;
 
-  const key = cooldownKey(provider, connectionId);
+  const key = cooldownKey(provider, connectionId, modelStr);
   const entry = cooldownMap.get(key);
   if (entry) {
     // Reset failure count but keep the entry

--- a/scripts/dev/run-next.mjs
+++ b/scripts/dev/run-next.mjs
@@ -112,6 +112,26 @@ async function start() {
     // Stamp the real TCP peer IP before Next sees the request, so the authz
     // middleware can decide LOCAL_ONLY locality without trusting the Host header.
     stampPeerIp(req);
+
+    // In dev mode, prevent the browser from caching HTML (including the page
+    // shell with embedded chunk URLs). Without this, a dev restart leaves the
+    // browser holding stale HTML that references old turbopack chunk hashes,
+    // causing ChunkLoadError → infinite reload loop.
+    if (dev) {
+      const origWriteHead = res.writeHead.bind(res);
+      res.writeHead = function (statusCode, ...args) {
+        if (!res.headersSent) {
+          const ct = res.getHeader("content-type");
+          if (!ct || String(ct).includes("text/html")) {
+            res.setHeader("Cache-Control", "no-cache, no-store, must-revalidate");
+            res.setHeader("Pragma", "no-cache");
+            res.setHeader("Expires", "0");
+          }
+        }
+        return origWriteHead(statusCode, ...args);
+      };
+    }
+
     return requestHandler(req, res);
   });
   server.on("upgrade", async (req, socket, head) => {

--- a/src/app/(dashboard)/dashboard/combos/page.tsx
+++ b/src/app/(dashboard)/dashboard/combos/page.tsx
@@ -3828,6 +3828,93 @@ function ComboFormModal({ isOpen, combo, onClose, onSave, activeProviders, combo
                       />
                     </div>
                   </div>
+                  {/* Stream Pre-Buffer */}
+                  <div className="col-span-2 pt-2 border-t border-black/5 dark:border-white/5">
+                    <div className="flex items-center gap-2 mb-2">
+                      <input
+                        type="checkbox"
+                        id="streamPreBuffer"
+                        checked={!!config.streamPreBuffer?.enabled}
+                        onChange={(e) =>
+                          setConfig({
+                            ...config,
+                            streamPreBuffer: e.target.checked
+                              ? { enabled: true, mode: "tokens", threshold: 100 }
+                              : undefined,
+                          })
+                        }
+                        className="rounded"
+                      />
+                      <label htmlFor="streamPreBuffer" className="text-xs font-medium">
+                        Cache stream before sending to client
+                      </label>
+                      <Tooltip
+                        position="bottom"
+                        content="Hold streaming chunks before sending to client. If an error occurs before the threshold, the combo retries with another provider. Once the threshold is met, chunks flush to the client and no more retries are possible."
+                      >
+                        <span className="material-symbols-outlined text-[12px] text-text-muted cursor-help">
+                          help
+                        </span>
+                      </Tooltip>
+                    </div>
+                    {config.streamPreBuffer?.enabled && (
+                      <div className="grid grid-cols-2 gap-2 ml-6">
+                        <div>
+                          <FieldLabelWithHelp
+                            label="Buffer mode"
+                            help="'Time' buffers for N seconds. 'Tokens' buffers until N tokens arrive."
+                            showHelp={!isExpertMode}
+                          />
+                          <select
+                            value={config.streamPreBuffer?.mode || "tokens"}
+                            onChange={(e) =>
+                              setConfig({
+                                ...config,
+                                streamPreBuffer: {
+                                  ...config.streamPreBuffer!,
+                                  mode: e.target.value as "time" | "tokens",
+                                },
+                              })
+                            }
+                            className="w-full text-xs py-1.5 px-2 rounded border border-black/10 dark:border-white/10 bg-transparent focus:border-primary focus:outline-none"
+                          >
+                            <option value="tokens">Tokens</option>
+                            <option value="time">Time (seconds)</option>
+                          </select>
+                        </div>
+                        <div>
+                          <FieldLabelWithHelp
+                            label={
+                              config.streamPreBuffer?.mode === "time" ? "Seconds" : "Token count"
+                            }
+                            help={
+                              config.streamPreBuffer?.mode === "time"
+                                ? "Buffer for this many seconds before releasing to client."
+                                : "Buffer until this many tokens arrive before releasing to client."
+                            }
+                            showHelp={!isExpertMode}
+                          />
+                          <input
+                            type="number"
+                            min="1"
+                            max={config.streamPreBuffer?.mode === "time" ? 600 : 100000}
+                            value={config.streamPreBuffer?.threshold ?? ""}
+                            placeholder={config.streamPreBuffer?.mode === "time" ? "30" : "100"}
+                            onChange={(e) =>
+                              setConfig({
+                                ...config,
+                                streamPreBuffer: {
+                                  ...config.streamPreBuffer!,
+                                  threshold: e.target.value ? Number(e.target.value) : 100,
+                                },
+                              })
+                            }
+                            className="w-full text-xs py-1.5 px-2 rounded border border-black/10 dark:border-white/10 bg-transparent focus:border-primary focus:outline-none"
+                          />
+                        </div>
+                      </div>
+                    )}
+                  </div>
                   {strategy === "round-robin" && (
                     <div className="grid grid-cols-2 gap-2 pt-2 border-t border-black/5 dark:border-white/5">
                       <div>
@@ -4118,7 +4205,11 @@ function ComboFormModal({ isOpen, combo, onClose, onSave, activeProviders, combo
                       </div>
                       <div>
                         <FieldLabelWithHelp
-                          label={getI18nOrFallback(t, "fusionStragglerGraceMs", "Straggler grace (ms)")}
+                          label={getI18nOrFallback(
+                            t,
+                            "fusionStragglerGraceMs",
+                            "Straggler grace (ms)"
+                          )}
                           help={getI18nOrFallback(
                             t,
                             "fusionStragglerGraceMsHelp",
@@ -4133,7 +4224,9 @@ function ComboFormModal({ isOpen, combo, onClose, onSave, activeProviders, combo
                           value={config.fusionTuning?.stragglerGraceMs ?? ""}
                           placeholder="8000"
                           onChange={(e) =>
-                            setConfig(updateFusionTuning(config, "stragglerGraceMs", e.target.value))
+                            setConfig(
+                              updateFusionTuning(config, "stragglerGraceMs", e.target.value)
+                            )
                           }
                           className="w-full text-xs py-1.5 px-2 rounded border border-black/10 dark:border-white/10 bg-transparent focus:border-primary focus:outline-none"
                         />

--- a/src/app/(dashboard)/dashboard/providers/[id]/hooks/useCommandCodeAuth.ts
+++ b/src/app/(dashboard)/dashboard/providers/[id]/hooks/useCommandCodeAuth.ts
@@ -1,3 +1,4 @@
+"use client";
 import { useState, useEffect, useCallback, useRef } from "react";
 import { type CommandCodeAuthFlowState } from "../providerPageHelpers";
 

--- a/src/app/(dashboard)/dashboard/providers/[id]/hooks/useConnectionGate.ts
+++ b/src/app/(dashboard)/dashboard/providers/[id]/hooks/useConnectionGate.ts
@@ -1,3 +1,4 @@
+"use client";
 // Phase 1t.3 extraction — Issue #3501
 // Encapsulates gateConnectionFlow + risk-notice modal state + confirm/cancel handlers.
 import { useState, useRef, useCallback } from "react";

--- a/src/app/(dashboard)/dashboard/providers/[id]/hooks/useExternalLinkFlow.ts
+++ b/src/app/(dashboard)/dashboard/providers/[id]/hooks/useExternalLinkFlow.ts
@@ -1,3 +1,4 @@
+"use client";
 import { useState, useEffect, useCallback } from "react";
 import { useTranslations } from "next-intl";
 import { useCopyToClipboard } from "@/shared/hooks/useCopyToClipboard";

--- a/src/app/(dashboard)/dashboard/providers/[id]/hooks/useModelCompatState.ts
+++ b/src/app/(dashboard)/dashboard/providers/[id]/hooks/useModelCompatState.ts
@@ -9,6 +9,7 @@
  * Leaf module: imports ONLY from providerPageHelpers and React.
  * No import from ProviderDetailPageClient → zero cycle risk.
  */
+"use client";
 import { useMemo, useCallback } from "react";
 import { MODEL_COMPAT_PROTOCOL_KEYS } from "@/shared/constants/modelCompat";
 import {

--- a/src/app/(dashboard)/dashboard/providers/services/components/CliproxyModelMappingEditor.tsx
+++ b/src/app/(dashboard)/dashboard/providers/services/components/CliproxyModelMappingEditor.tsx
@@ -5,6 +5,7 @@
  */
 "use client";
 
+"use client";
 import { useState, useEffect, useRef } from "react";
 import { Card } from "@/shared/components";
 

--- a/src/app/(dashboard)/dashboard/providers/services/components/NinerouterInstallWizard.tsx
+++ b/src/app/(dashboard)/dashboard/providers/services/components/NinerouterInstallWizard.tsx
@@ -5,6 +5,7 @@
  */
 "use client";
 
+"use client";
 import { useState } from "react";
 import { Card, Button } from "@/shared/components";
 import { useServiceStatus } from "../hooks/useServiceStatus";

--- a/src/app/(dashboard)/dashboard/providers/services/components/NinerouterModelList.tsx
+++ b/src/app/(dashboard)/dashboard/providers/services/components/NinerouterModelList.tsx
@@ -5,6 +5,7 @@
  */
 "use client";
 
+"use client";
 import { useState, useEffect, useCallback } from "react";
 import { Card, Button } from "@/shared/components";
 

--- a/src/app/(dashboard)/dashboard/providers/services/components/NinerouterProviderExposureCard.tsx
+++ b/src/app/(dashboard)/dashboard/providers/services/components/NinerouterProviderExposureCard.tsx
@@ -5,6 +5,7 @@
  */
 "use client";
 
+"use client";
 import { useState } from "react";
 import { Card, Toggle } from "@/shared/components";
 import { useServiceStatus } from "../hooks/useServiceStatus";

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -86,6 +86,14 @@ export default async function RootLayout({ children }) {
                   };
                 }
               }
+              window.addEventListener('unhandledrejection', function(e) {
+                if (e.reason && e.reason.name === 'ChunkLoadError' && !sessionStorage.getItem('omniroute:cr')) {
+                  e.preventDefault();
+                  sessionStorage.setItem('omniroute:cr', '1');
+                  location.href = '/?cr=' + Date.now();
+                }
+              });
+              sessionStorage.removeItem('omniroute:cr');
               try {
                 const stored = localStorage.getItem('theme');
                 const parsed = stored ? JSON.parse(stored) : null;

--- a/src/instrumentation-node.ts
+++ b/src/instrumentation-node.ts
@@ -89,7 +89,7 @@ export async function registerNodejs(): Promise<void> {
   process.title = renameProcessTitle(process.title);
 
   // Initialize proxy fetch patch FIRST (before any HTTP requests)
-  await import("@omniroute/open-sse/index.ts");
+  await import("@omniroute/open-sse/utils/proxyFetch.ts");
   console.log("[STARTUP] Global fetch proxy patch initialized");
 
   await ensureSecrets();
@@ -168,7 +168,15 @@ export async function registerNodejs(): Promise<void> {
     console.log(
       `[STARTUP] Cloud/model sync background bootstrap ${cloudSyncInitialized ? "initialized" : "skipped"}`
     );
-    const { initBatchProcessor } = await import("@omniroute/open-sse/services/batchProcessor");
+    // webpack traces ALL import() in the file, including lazy ones inside functions.
+    // batchProcessor → dispatch → 7 route handlers → full open-sse workspace → OOM.
+    // Function() hides the tsx import from webpack's static analysis.
+    // At runtime, tsx resolves @/ aliases and .ts extensions for the webpack-ignored import.
+    // eslint-disable-next-line no-new-func
+    await Function('return import("tsx")')();
+    const { initBatchProcessor } = await import(
+      /* webpackIgnore: true */ "@omniroute/open-sse/services/batchProcessor.ts"
+    );
     initBatchProcessor();
     console.log("[STARTUP] Batch processor started");
   }

--- a/src/shared/components/PwaRegister.tsx
+++ b/src/shared/components/PwaRegister.tsx
@@ -8,8 +8,14 @@ export function PwaRegister() {
       return;
     }
 
-    // Disable service worker in development to avoid chunk loading / HMR conflicts
     if (process.env.NODE_ENV !== "production") {
+      // Actively unregister any stale SW from a previous production run.
+      // A lingering SW caches /_next/static/chunks/ aggressively in dev,
+      // which causes "ServiceWorker intercepted the request and encountered
+      // an unexpected error" when turbopack changes chunk hashes on restart.
+      navigator.serviceWorker.getRegistrations().then((regs) => {
+        for (const reg of regs) reg.unregister();
+      });
       return;
     }
 

--- a/src/shared/validation/schemas/combo.ts
+++ b/src/shared/validation/schemas/combo.ts
@@ -218,6 +218,13 @@ export const comboRuntimeConfigSchema = z
       })
       .strict()
       .optional(),
+    streamPreBuffer: z
+      .object({
+        enabled: z.boolean().optional(),
+        mode: z.enum(["time", "tokens"]).optional(),
+        threshold: z.coerce.number().int().min(1).max(600).optional(),
+      })
+      .optional(),
   })
   .passthrough()
   .transform((config) => {
@@ -267,7 +274,11 @@ export const createComboSchema = z.object({
   // the `dimensions` field (and translated to `outputDimensionality` for Gemini).
   // Stored as a string to match the OpenAI API convention; coerced to number
   // by the embedding handler. Leave unset to use each model's default.
-  dimensions: z.string().regex(/^\d+$/, "dimensions must be a positive integer string").optional().nullable(),
+  dimensions: z
+    .string()
+    .regex(/^\d+$/, "dimensions must be a positive integer string")
+    .optional()
+    .nullable(),
 });
 
 export const updateComboDefaultsSchema = z
@@ -317,7 +328,11 @@ export const updateComboSchema = z
     context_cache_protection: z.boolean().optional(),
     context_length: z.number().int().min(1000).max(2000000).optional().nullable(),
     compressionOverride: comboCompressionOverrideSchema.optional(),
-    dimensions: z.string().regex(/^\d+$/, "dimensions must be a positive integer string").optional().nullable(),
+    dimensions: z
+      .string()
+      .regex(/^\d+$/, "dimensions must be a positive integer string")
+      .optional()
+      .nullable(),
   })
   .superRefine((value, ctx) => {
     if (

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "checkJs": false,
     "skipLibCheck": true,
@@ -21,15 +17,9 @@
     "incremental": true,
     "forceConsistentCasingInFileNames": true,
     "paths": {
-      "@/*": [
-        "./src/*"
-      ],
-      "@omniroute/open-sse": [
-        "./open-sse"
-      ],
-      "@omniroute/open-sse/*": [
-        "./open-sse/*"
-      ]
+      "@/*": ["./src/*"],
+      "@omniroute/open-sse": ["./open-sse"],
+      "@omniroute/open-sse/*": ["./open-sse/*"]
     },
     "plugins": [
       {
@@ -39,10 +29,10 @@
   },
   "include": [
     "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
-    "**/*.js",
-    "**/*.jsx",
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "src/**/*.js",
+    "src/**/*.jsx",
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts",
     ".next/dev/dev/types/**/*.ts",


### PR DESCRIPTION
## Summary

# User-facing / Operational Changes

## Combo Routing Improvements

- **New stream pre-buffer option**
  - Introduces a `streamPreBuffer` feature that holds streaming chunks before sending them to the client.
  - If the provider fails before reaching the configured threshold, the system retries with another provider instead of exposing the error.
  - Disabled by default.
  - Configurable per combo via:
    - `streamPreBuffer.enabled`
    - `streamPreBuffer.mode`
    - `streamPreBuffer.threshold`

- **Per-model cooldown**
  - Rate-limit cooldowns are now scoped per model.
  - Example: `gemma-4-31b-it` and `gemma-4-26b-a4b-it` cool down independently.
  - Prevents one failing model from impacting sibling models on the same provider.

- **Narrower connection-level error handling**
  - HTTP errors `502`, `503`, `504` no longer mark an entire provider as exhausted.
  - Other models under the same provider can still be attempted.
  - Only `408` and `524` (connection-level failures) trigger provider-wide skipping.

- **Circuit breaker re-check before retries**
  - The circuit breaker state is now re-evaluated before each retry attempt.
  - Prevents wasted retries against already-open breakers.

- **Streaming behavior change: max 1 attempt per model**
  - Streaming requests no longer retry on the same model.
  - Prevents duplicate upstream connections (notably problematic with Gemini).
  - Instead, the system falls back to the next model.

---

## Call-Log Correlation ID

- Each request now includes a unique correlation ID.
  - Returned in response header: `X-Correlation-Id`
  - Stored in the `call_logs` database
  - Visible in dashboard logs

- Call-logs API (`/api/usage/call-logs`) updates:
  - Supports filtering by `correlationId`
  - Returns correlation ID in all log entries

---

## Dev Server Reliability

- Fixed webpack OOM during instrumentation compilation
  - Replaced barrel import (`@omniroute/open-sse`, 685 files)
  - Now uses direct `proxyFetch.ts` import

- Fixed dev-mode `ChunkLoadError`
  - Added no-cache headers on HTML responses
  - Prevents stale chunk references after restart

---

## Dashboard

- Request logger detail view now includes timestamps for stream chunks
- Call-logs sorting improved:
  - Active requests always shown at the top
  - Followed by newest requests first

## Validation

- [x] `npm run lint`
- [x] `npm run test:unit`
- [x] `npm run test:coverage`
- [x] Coverage is still `>= 60%` for statements, lines, functions, and branches
- [x] SonarQube PR analysis is green or any remaining issues are explicitly documented below

## Tests Added Or Updated

added cases for changed code