### PR TITLE
fix(providers): drop retired chatgpt-web/codex models (gpt-5.2, gpt-4.5)

### DIFF
--- a/docs/guides/USER_GUIDE.md
+++ b/docs/guides/USER_GUIDE.md
@@ -35,29 +35,28 @@ Complete guide for configuring providers, creating combos, integrating CLI tools
 
 ## 💰 Pricing at a Glance
 
-| Tier                | Provider          | Cost        | Quota Reset      | Best For             |
-| ------------------- | ----------------- | ----------- | ---------------- | -------------------- |
-| **💳 SUBSCRIPTION** | Claude Code (Pro) | $20/mo      | 5h + weekly      | Already subscribed   |
-|                     | Codex (Plus/Pro)  | $20-200/mo  | 5h + weekly      | OpenAI users         |
-|                     | GitHub Copilot    | $10-19/mo   | Monthly          | GitHub users         |
-| **🔑 API KEY**      | DeepSeek          | Pay per use | None             | Cheap reasoning      |
-|                     | Groq              | Pay per use | None             | Ultra-fast inference |
-|                     | xAI (Grok)        | Pay per use | None             | Grok 4 reasoning     |
-|                     | Mistral           | Pay per use | None             | EU-hosted models     |
-|                     | Perplexity        | Pay per use | None             | Search-augmented     |
-|                     | Together AI       | Pay per use | None             | Open-source models   |
-|                     | Fireworks AI      | Pay per use | None             | Fast FLUX images     |
-|                     | Cerebras          | Pay per use | None             | Wafer-scale speed    |
-|                     | Cohere            | Pay per use | None             | Command R+ RAG       |
-|                     | NVIDIA NIM        | Pay per use | None             | Enterprise models    |
-|                     | Baidu Qianfan     | Pay per use | None             | ERNIE models         |
-| **💰 CHEAP**        | GLM-4.7           | $0.6/1M     | Daily 10AM       | Budget backup        |
-|                     | MiniMax M2.1      | $0.2/1M     | 5-hour rolling   | Cheapest option      |
-|                     | Kimi K2           | $9/mo flat  | 10M tokens/mo    | Predictable cost     |
-| **🆓 FREE**         | Qoder             | $0          | Unlimited        | 8 models free        |
-|                     | Qwen              | $0          | Unlimited        | 3 models free        |
-|                     | Kiro              | $0          | ~50 credits/mo   | Claude free          |
-
+| Tier                | Provider          | Cost        | Quota Reset    | Best For             |
+| ------------------- | ----------------- | ----------- | -------------- | -------------------- |
+| **💳 SUBSCRIPTION** | Claude Code (Pro) | $20/mo      | 5h + weekly    | Already subscribed   |
+|                     | Codex (Plus/Pro)  | $20-200/mo  | 5h + weekly    | OpenAI users         |
+|                     | GitHub Copilot    | $10-19/mo   | Monthly        | GitHub users         |
+| **🔑 API KEY**      | DeepSeek          | Pay per use | None           | Cheap reasoning      |
+|                     | Groq              | Pay per use | None           | Ultra-fast inference |
+|                     | xAI (Grok)        | Pay per use | None           | Grok 4 reasoning     |
+|                     | Mistral           | Pay per use | None           | EU-hosted models     |
+|                     | Perplexity        | Pay per use | None           | Search-augmented     |
+|                     | Together AI       | Pay per use | None           | Open-source models   |
+|                     | Fireworks AI      | Pay per use | None           | Fast FLUX images     |
+|                     | Cerebras          | Pay per use | None           | Wafer-scale speed    |
+|                     | Cohere            | Pay per use | None           | Command R+ RAG       |
+|                     | NVIDIA NIM        | Pay per use | None           | Enterprise models    |
+|                     | Baidu Qianfan     | Pay per use | None           | ERNIE models         |
+| **💰 CHEAP**        | GLM-4.7           | $0.6/1M     | Daily 10AM     | Budget backup        |
+|                     | MiniMax M2.1      | $0.2/1M     | 5-hour rolling | Cheapest option      |
+|                     | Kimi K2           | $9/mo flat  | 10M tokens/mo  | Predictable cost     |
+| **🆓 FREE**         | Qoder             | $0          | Unlimited      | 8 models free        |
+|                     | Qwen              | $0          | Unlimited      | 3 models free        |
+|                     | Kiro              | $0          | ~50 credits/mo | Claude free          |
 
 ---
 
@@ -158,7 +157,6 @@ Models:
   cx/gpt-5.3-codex
   cx/gpt-5.3-codex-spark
 ```
-
 
 #### GitHub Copilot
 
@@ -570,8 +568,7 @@ For the full environment variable reference, see the [README](../README.md).
 
 **Claude Code (`cc/`)** — Pro/Max OAuth: `cc/claude-opus-4-8`, `cc/claude-opus-4-7`, `cc/claude-opus-4-6`, `cc/claude-opus-4-5-20251101`, `cc/claude-sonnet-4-6`, `cc/claude-sonnet-4-5-20250929`, `cc/claude-haiku-4-5-20251001`
 
-**Codex (`cx/`)** — Plus/Pro OAuth: `cx/gpt-5.5` (+ effort tiers: `gpt-5.5-xhigh`, `gpt-5.5-high`, `gpt-5.5-medium`, `gpt-5.5-low`), `cx/gpt-5.4`, `cx/gpt-5.4-mini`, `cx/gpt-5.3-codex`, `cx/gpt-5.3-codex-spark`, `cx/gpt-5.2`
-
+**Codex (`cx/`)** — Plus/Pro OAuth: `cx/gpt-5.5` (+ effort tiers: `gpt-5.5-xhigh`, `gpt-5.5-high`, `gpt-5.5-medium`, `gpt-5.5-low`), `cx/gpt-5.4`, `cx/gpt-5.4-mini`, `cx/gpt-5.3-codex`, `cx/gpt-5.3-codex-spark`
 
 **GitHub Copilot (`gh/`)** — OAuth: `gh/gpt-5.5`, `gh/gpt-5.4`, `gh/gpt-5.4-mini`, `gh/gpt-5-mini`, `gh/gpt-5.3-codex`, `gh/claude-opus-4.7`, `gh/claude-opus-4.6`, `gh/claude-opus-4-5-20251101`, `gh/claude-sonnet-4.6`, `gh/claude-sonnet-4.5`, `gh/claude-haiku-4.5`, `gh/gemini-3.1-pro-preview`, `gh/gemini-3-flash-preview`, `gh/oswe-vscode-prime`
 

--- a/open-sse/config/providers/registry/chatgpt-web/index.ts
+++ b/open-sse/config/providers/registry/chatgpt-web/index.ts
@@ -17,10 +17,6 @@ export const chatgpt_webProvider: RegistryEntry = {
     { id: "gpt-5.4-thinking-mini", name: "GPT-5.4 Thinking Mini" }, //free-login only
     { id: "gpt-5.3", name: "GPT-5.3 Instant" }, //free, free-login, plus, pro tier
     { id: "gpt-5.3-mini", name: "GPT-5.3 Mini" }, //limit fallback
-    { id: "gpt-5.2-pro", name: "GPT-5.2 Pro" }, //pro tier only
-    { id: "gpt-5.2-thinking", name: "GPT-5.2 Thinking" }, //plus ~ tier
-    { id: "gpt-5.2-instant", name: "GPT-5.2 Instant" }, //plus ~ tier
     { id: "o3", name: "o3" }, //plus ~ tier
-    { id: "gpt-4-5", name: "GPT-4.5" }, //pro tier only
   ],
 };

--- a/open-sse/config/providers/registry/codex/index.ts
+++ b/open-sse/config/providers/registry/codex/index.ts
@@ -97,6 +97,5 @@ export const codexProvider: RegistryEntry = {
       supportsReasoning: true,
       supportsXHighEffort: true,
     },
-    { id: "gpt-5.2", name: "GPT 5.2" },
   ],
 };

--- a/open-sse/executors/chatgpt-web.ts
+++ b/open-sse/executors/chatgpt-web.ts
@@ -79,22 +79,15 @@ function deviceIdFor(cookie: string): string {
 // /backend-api/models on a logged-in account; "gpt-5-4-t-mini" is ChatGPT's
 // abbreviated slug for "GPT-5.4 Thinking Mini".
 const MODEL_MAP: Record<string, string> = {
-  "gpt-5.3-instant": "gpt-5-3-instant",
-  "gpt-5.3": "gpt-5-3",
-  "gpt-5.3-mini": "gpt-5-3-mini",
   "gpt-5.5-pro": "gpt-5-5-pro",
   "gpt-5.5-thinking": "gpt-5-5-thinking",
   "gpt-5.5": "gpt-5-5",
   "gpt-5.4-pro": "gpt-5-4-pro",
   "gpt-5.4-thinking": "gpt-5-4-thinking",
   "gpt-5.4-thinking-mini": "gpt-5-4-t-mini",
-  "gpt-5.2-pro": "gpt-5-2-pro",
-  "gpt-5.2-instant": "gpt-5-2-instant",
-  "gpt-5.2": "gpt-5-2",
-  "gpt-5.2-thinking": "gpt-5-2-thinking",
-  "gpt-5.1": "gpt-5-1",
-  "gpt-5": "gpt-5",
-  "gpt-5-mini": "gpt-5-mini",
+  "gpt-5.3-instant": "gpt-5-3-instant",
+  "gpt-5.3": "gpt-5-3",
+  "gpt-5.3-mini": "gpt-5-3-mini",
   o3: "o3",
 };
 

--- a/open-sse/executors/codex.ts
+++ b/open-sse/executors/codex.ts
@@ -607,7 +607,6 @@ function normalizeServiceTierValue(value: unknown): string | undefined {
  */
 const MAX_EFFORT_BY_MODEL: Record<string, EffortLevel> = {
   "gpt-5.3-codex": "xhigh",
-  "gpt-5.2-codex": "xhigh",
   "gpt-5.1-codex-max": "xhigh",
   "gpt-5-mini": "high",
   "gpt-5.1-mini": "high",

--- a/src/app/(dashboard)/dashboard/cli-code/components/CodexToolCard.tsx
+++ b/src/app/(dashboard)/dashboard/cli-code/components/CodexToolCard.tsx
@@ -33,9 +33,7 @@ export default function CodexToolCard({
     "gpt-5.5",
     "gpt-5.3-codex",
     "gpt-5.4",
-    "gpt-5.2-codex",
     "gpt-5.1-codex-max",
-    "gpt-5.2",
     "gpt-5.1-codex-mini",
   ];
   const [modelMappings, setModelMappings] = useState<Record<string, string>>({});

--- a/tests/unit/chatgpt-web.test.ts
+++ b/tests/unit/chatgpt-web.test.ts
@@ -3,9 +3,8 @@ import assert from "node:assert/strict";
 
 const { ChatGptWebExecutor, __derivePublicBaseUrlForTesting, __resetChatGptWebCachesForTesting } =
   await import("../../open-sse/executors/chatgpt-web.ts");
-const { describeChatGptWebHttpError } = await import(
-  "../../open-sse/executors/chatgptWebErrors.ts"
-);
+const { describeChatGptWebHttpError } =
+  await import("../../open-sse/executors/chatgptWebErrors.ts");
 const { getExecutor, hasSpecializedExecutor } = await import("../../open-sse/executors/index.ts");
 const { __setTlsFetchOverrideForTesting, looksLikeSse, TlsClientUnavailableError } =
   await import("../../open-sse/services/chatgptTlsClient.ts");
@@ -1101,11 +1100,7 @@ test("Provider registry: chatgpt-web exposes the current ChatGPT Web model catal
     "gpt-5.4-thinking-mini",
     "gpt-5.3",
     "gpt-5.3-mini",
-    "gpt-5.2-pro",
-    "gpt-5.2-thinking",
-    "gpt-5.2-instant",
     "o3",
-    "gpt-4-5",
   ]);
 });
 
@@ -1117,7 +1112,6 @@ test("Executor MODEL_MAP: dot-form OmniRoute IDs translate to dash-form ChatGPT 
       ["gpt-5.3", "gpt-5-3"],
       ["gpt-5.5-thinking", "gpt-5-5-thinking"],
       ["gpt-5.4-thinking-mini", "gpt-5-4-t-mini"],
-      ["gpt-5.2-thinking", "gpt-5-2-thinking"],
       ["o3", "o3"],
       // Regression #4665: these advertised catalog ids were missing from
       // MODEL_MAP and fell through as their dot-form slug verbatim, which the
@@ -1125,7 +1119,6 @@ test("Executor MODEL_MAP: dot-form OmniRoute IDs translate to dash-form ChatGPT 
       ["gpt-5.5", "gpt-5-5"],
       ["gpt-5.5-pro", "gpt-5-5-pro"],
       ["gpt-5.4-pro", "gpt-5-4-pro"],
-      ["gpt-5.2-pro", "gpt-5-2-pro"],
     ];
     for (const [omniId, expectedSlug] of cases) {
       m.calls.urls.length = 0;
@@ -1153,8 +1146,8 @@ test("MODEL_MAP drift guard: every advertised dot-form catalog id resolves to a 
   const { getRegistryEntry } = await import("../../open-sse/config/providerRegistry.ts");
   const ids = (getRegistryEntry("chatgpt-web")?.models || []).map((m) => m.id);
   // Dot-form ids must never reach the ChatGPT backend verbatim — the backend
-  // only accepts dash-form slugs. (Ids that are already dash-form, e.g.
-  // "gpt-4-5", legitimately pass through unchanged and are exempt.)
+  // only accepts dash-form slugs. (Ids without a dot — e.g. "o3", or any
+  // already-slug-form id — pass through unchanged and are exempt.)
   const dotFormIds = ids.filter((id) => id.includes("."));
   const m = installMockFetch();
   try {
@@ -1174,12 +1167,12 @@ test("MODEL_MAP drift guard: every advertised dot-form catalog id resolves to a 
       const body = JSON.parse(m.calls.bodies[convIdx]);
       assert.ok(
         !body.model.includes("."),
-        `${omniId} reached the backend as "${body.model}" (still dot-form) — missing MODEL_MAP entry causes silent model substitution`,
+        `${omniId} reached the backend as "${body.model}" (still dot-form) — missing MODEL_MAP entry causes silent model substitution`
       );
       assert.notEqual(
         body.model,
         omniId,
-        `${omniId} fell through MODEL_MAP verbatim — add a dash-form mapping`,
+        `${omniId} fell through MODEL_MAP verbatim — add a dash-form mapping`
       );
     }
   } finally {
@@ -1339,7 +1332,7 @@ test("thinking_effort: nested body.reasoning.effort=high → extended", async ()
   try {
     const executor = new ChatGptWebExecutor();
     await executor.execute({
-      model: "gpt-5.2-thinking",
+      model: "gpt-5.5-thinking",
       body: {
         messages: [{ role: "user", content: "hi" }],
         reasoning: { effort: "high" },
@@ -1350,7 +1343,7 @@ test("thinking_effort: nested body.reasoning.effort=high → extended", async ()
       log: null,
     });
     assert.equal(m.calls.userConfig, 1);
-    assert.match(m.calls.userConfigUrls[0], /model_slug=gpt-5-2-thinking/);
+    assert.match(m.calls.userConfigUrls[0], /model_slug=gpt-5-5-thinking/);
     assert.match(m.calls.userConfigUrls[0], /thinking_effort=extended/);
   } finally {
     m.restore();

--- a/tests/unit/t19-codex-responses-empty-content.test.ts
+++ b/tests/unit/t19-codex-responses-empty-content.test.ts
@@ -9,7 +9,7 @@ test("T19: picks the last non-empty message content from Responses output", () =
   const responseBody = {
     object: "response",
     id: "resp_t19",
-    model: "gpt-5.2-codex",
+    model: "gpt-5.3-codex",
     created_at: 1710000000,
     output: [
       {
@@ -41,7 +41,7 @@ test("T19: falls back to last message block when all message texts are empty", (
   const responseBody = {
     object: "response",
     id: "resp_t19_empty",
-    model: "gpt-5.2-codex",
+    model: "gpt-5.3-codex",
     created_at: 1710000001,
     output: [
       {


### PR DESCRIPTION
## Summary

OpenAI retired GPT‑5.2 (and GPT‑4.5) from the direct **ChatGPT‑web** and **Codex**
surfaces. Remove the dead models from those two providers so OmniRoute stops
advertising / routing models that no longer exist there.

**Scoped on purpose to chatgpt-web + codex.** Third‑party proxies that still
expose these ids (cursor / windsurf / devin‑cli / freeaiapikey / opencode‑zen /
kie / trae) and the generic `openai` catalog in `open-sse/config/providers/shared.ts`
are **left untouched** — those models remain reachable there, and shared.ts is
referenced widely.

## Changes

- **chatgpt-web registry** (`registry/chatgpt-web/index.ts`): drop `gpt-5.2-pro`,
  `gpt-5.2-thinking`, `gpt-5.2-instant`, and `gpt-4.5` (the live ChatGPT‑web
  catalog is 5.5 / 5.4 / 5.3 / o3 — confirmed against the product UI)
- **chatgpt-web slug map** (`executors/chatgpt-web.ts`): drop `gpt-5.2*`, plus
  `gpt-5`, `gpt-5-mini`, `gpt-5.1` (none are in the chatgpt-web catalog)
- **codex registry** (`registry/codex/index.ts`): drop `gpt-5.2`
- **codex executor** (`executors/codex.ts`): drop `gpt-5.2-codex` from
  `MAX_EFFORT_BY_MODEL` — unlisted models already default to `xhigh`, so behavior
  is unchanged
- **UI** (`CodexToolCard.tsx`): drop `gpt-5.2-codex` / `gpt-5.2` from the codex
  model suggestion list (default selection was already `gpt-5.5`)
- **docs** (`docs/guides/USER_GUIDE.md`): drop `cx/gpt-5.2` from the Codex list
- **tests**: swap retired sample models to current ones — `t19` `gpt-5.2-codex`
  → `gpt-5.3-codex`; `chatgpt-web` `gpt-5.2-thinking` → `gpt-5.5-thinking` (incl.
  the dash‑form slug assertion) — and refresh a stale comment example
  (`gpt-4-5` → `o3`)

## Related Issues
- Related to #<add if applicable>

## Validation
- [x] `npm run test:unit` (touched suites): chatgpt-web 80/80, t19 2/2,
  codex-connection 3/3, codex-effort-alias-priority 6/6, codex-gpt55-effort-routing 4/4,
  codex-base-url 2/2 — all green
- [x] `check-docs-sync` + `check-env-doc-sync` PASS (llm.txt / CHANGELOG carry no
  retired models)
- [x] pre-commit hooks (lint-staged/prettier, any-budget, tracked-artifacts) PASS
- [ ] full `npm run test:coverage` on CI

## Tests Added Or Updated
- `tests/unit/chatgpt-web.test.ts`, `tests/unit/t19-codex-responses-empty-content.test.ts`
  updated to current model ids (no behavioral assertions on the removed models).

## Coverage Notes
- No new logic; declarative catalog/map/UI entries + matching test ids only.

## Reviewer Notes
- registry ↔ slug map ↔ effort table stay consistent: every **live** chatgpt-web
  model (5.5/5.4/5.3 + o3) still has its slug mapping; only retired ids were removed.
- `docs/i18n/**` mirrors are **not** hand-edited — they are regenerated from the
  English source by the translation pipeline (`npm run i18n:run`, hash‑incremental),
  and `check-docs-sync` only gates `llm.txt` + `CHANGELOG`, both already clean.
- The `openai` provider keeps `gpt-5.2`/`gpt-5.2-codex` in `shared.ts` intentionally
  (used elsewhere); this PR does not touch it.
