### PR TITLE
feat(providers): add live-validated Microsoft 365 Copilot individual provider [wating autor]

### DIFF
--- a/open-sse/config/providers/index.ts
+++ b/open-sse/config/providers/index.ts
@@ -103,6 +103,7 @@ import { openrouterProvider } from "./registry/openrouter/index.ts";
 import { orcarouterProvider } from "./registry/orcarouter/index.ts";
 import { glhfProvider } from "./registry/glhf/index.ts";
 import { copilot_webProvider } from "./registry/copilot-web/index.ts";
+import { copilot_m365_webProvider } from "./registry/copilot-m365-web/index.ts";
 import { stepfunProvider } from "./registry/stepfun/index.ts";
 import { freemodel_devProvider } from "./registry/freemodel-dev/index.ts";
 import { gitlawb_gmiProvider } from "./registry/gitlawb/gmi/index.ts";
@@ -274,6 +275,7 @@ export const REGISTRY: Record<string, RegistryEntry> = {
   orcarouter: orcarouterProvider,
   glhf: glhfProvider,
   "copilot-web": copilot_webProvider,
+  "copilot-m365-web": copilot_m365_webProvider,
   stepfun: stepfunProvider,
   "freemodel-dev": freemodel_devProvider,
   "gitlawb-gmi": gitlawb_gmiProvider,

--- a/open-sse/config/providers/registry/copilot-m365-web/index.ts
+++ b/open-sse/config/providers/registry/copilot-m365-web/index.ts
@@ -1,0 +1,12 @@
+import type { RegistryEntry } from "../../shared.ts";
+
+export const copilot_m365_webProvider: RegistryEntry = {
+  id: "copilot-m365-web",
+  alias: "m365copilot",
+  format: "openai",
+  executor: "copilot-m365-web",
+  baseUrl: "wss://substrate.office.com/m365Copilot/Chathub",
+  authType: "apikey",
+  authHeader: "cookie",
+  models: [{ id: "copilot-m365", name: "Microsoft 365 Copilot (BizChat)" }],
+};

--- a/open-sse/executors/copilot-m365-connection.ts
+++ b/open-sse/executors/copilot-m365-connection.ts
@@ -24,10 +24,61 @@ export const M365_INDIVIDUAL_DEFAULTS = {
   scenario: "OfficeWebPaidConsumerCopilot",
 } as const;
 
+export const M365_DEFAULT_VARIANTS = [
+  "EnableMcpServerWidgets",
+  "feature.EnableMcpServerWidgets",
+  "feature.EnableLuForChatCIQ",
+  "feature.enableChatCIQPlugin",
+  "EnableRequestPlugins",
+  "feature.EnableSensitivityLabels",
+  "EnableUnsupportedUrlDetector",
+  "feature.IsCustomEngineCopilotEnabled",
+  "feature.bizchatfluxv3",
+  "feature.enablechatpages",
+  "feature.enableCodeCanvas",
+  "feature.turnOnDARecommendation",
+  "feature.IsStreamingModeInChatRequestEnabled",
+  "IncludeSourceAttributionsConcise",
+  "SkipPublishEmptyMessage",
+  "feature.EnableDeduplicatingSourceAttributions",
+  "Enable3PActionProgressMessages",
+  "feature.enableClientWebRtc",
+  "feature.EnableMeetingRecapOfSeriesMeetingWithCiq",
+  "feature.cwcfluxv3fe",
+  "feature.cwcfluxv3fem",
+  "feature.EnableReferencesListCompleteSignal",
+  "feature.StorageMessageSplitDisabled",
+  "feature.EnableCuaTakeControlApi",
+  "SingletonEnvOn",
+  "EnableComposeWidget",
+  "feature.cwcallowedos",
+  "feature.EnableMergingPureDeltas",
+  "feature.disabledisallowedmsgs",
+  "feature.enableCitationsForSynthesisData",
+  "feature.EnableConversationShareApis",
+  "feature.enableGenerateGraphicArtOptionsSet",
+  "cdximagen",
+  "feature.EnableUpdatedUXForConfirmationDialog",
+  "feature.EnableContentApiandDocTypeHtmlInRichAnswers",
+  "cdxgrounding_api_v2_rich_web_answers_reference_bottom_force",
+  "cdxenablerenderforisocomp",
+  "feature.EnableClientFileURLSupportForOfficeWebPaidCopilot",
+  "feature.EnableDesignEditorImageGrounding",
+  "feature.EnableDesignerEditor",
+  "feature.EnableSkipRehydrationForSpeCIdImages",
+  "feature.EnablePersonalizationForMSA",
+  "agt_bizchat_enableRichResponses",
+  "feature.EnableBase64DataInMessageAnnotations",
+  "feature.EnableSkipEmittingMessageOnFlush",
+  "feature.EnableRemoveEmptySourceAttributions",
+  "feature.EnableRemoveStreamingMode",
+] as const;
+
 export interface M365ConnectionParams {
   host: string;
   chathubPath: string; // "<user-oid>@<tenant-id>"
   accessToken: string;
+  variants?: string;
 }
 
 /** A new 32-hex chat session id (== XRoutingParameterSessionKey == clientrequestid). */
@@ -63,7 +114,8 @@ export function resolveConnectionParams(
     };
   }
   const host = (typeof psd.host === "string" && psd.host) || M365_INDIVIDUAL_DEFAULTS.host;
-  return { host, chathubPath, accessToken };
+  const variants = typeof psd.variants === "string" && psd.variants ? psd.variants : undefined;
+  return { host, chathubPath, accessToken, variants };
 }
 
 /**
@@ -80,6 +132,7 @@ export function buildWsUrl(params: M365ConnectionParams): string {
     "X-SessionId": randomUUID(),
     ConversationId: randomUUID(),
     access_token: params.accessToken,
+    variants: params.variants ?? M365_DEFAULT_VARIANTS.join(","),
     source: M365_INDIVIDUAL_DEFAULTS.source,
     product: M365_INDIVIDUAL_DEFAULTS.product,
     agentHost: M365_INDIVIDUAL_DEFAULTS.agentHost,

--- a/open-sse/executors/copilot-m365-frames.ts
+++ b/open-sse/executors/copilot-m365-frames.ts
@@ -40,6 +40,34 @@ export const ALLOWED_MESSAGE_TYPES = [
   "GenerateContentQuery",
 ] as const;
 
+export const M365_DEFAULT_OPTION_SETS = [
+  "search_result_progress_messages_with_search_queries",
+  "update_textdoc_response_after_streaming",
+  "deepleo_networking_timeout_10minutes_canmore",
+  "cwc_flux_image",
+  "cwc_code_interpreter",
+  "cwc_code_interpreter_amsfix",
+  "enable_msa_user",
+  "cwcgptv",
+  "flux_v3_gptv_enable_upload_multi_image_in_turn_wo_ch",
+  "gptvnorm2048",
+  "pdnascan",
+  "cwc_code_interpreter_citation_fix",
+  "code_interpreter_interactive_charts",
+  "cwc_code_interpreter_interactive_charts_inline_image",
+  "code_interpreter_matplotlib_patching",
+  "cwc_fileupload_odb",
+  "update_memory_plugin",
+  "add_custom_instructions",
+  "cwc_flux_v3",
+  "flux_v3_progress_messages",
+  "enable_batch_token_processing",
+  "enable_gg_gpt",
+  "flux_v3_image_gen_enable_non_watermarked_storage",
+  "flux_v3_image_gen_enable_story",
+  "rich_responses",
+] as const;
+
 /** Append the record separator to a JSON-serializable frame. */
 export function encodeFrame(obj: unknown): string {
   return JSON.stringify(obj) + RECORD_SEPARATOR;
@@ -118,7 +146,7 @@ export function buildChatInvocation(opts: ChatInvocationOptions): Record<string,
         source: "officeweb",
         clientCorrelationId: opts.traceId,
         sessionId: opts.sessionId,
-        optionsSets: opts.optionsSets ?? [],
+        optionsSets: opts.optionsSets ?? [...M365_DEFAULT_OPTION_SETS],
         streamingMode: "ConciseWithPadding",
         spokenTextMode: "None",
         options: {},
@@ -180,6 +208,7 @@ export function extractBotText(frame: Record<string, unknown> | null): string | 
     if (!m) continue;
     const author = m.author;
     const text = m.text;
+    if (m.messageType === "Progress" || m.contentType === "EarlyProgress") continue;
     if ((author === "bot" || author === undefined) && typeof text === "string" && text.length > 0) {
       return text;
     }

--- a/open-sse/executors/copilot-m365-web.ts
+++ b/open-sse/executors/copilot-m365-web.ts
@@ -1,5 +1,14 @@
 import WebSocket from "ws";
 import { FETCH_TIMEOUT_MS } from "../config/constants.ts";
+
+// Test seam: the WebSocket constructor is injectable so unit tests can drive the wsChat
+// stream lifecycle (open/message/error/close) with a fake instead of a live `wss://` peer.
+// Defaults to the real `ws` implementation; production never overrides it.
+let WebSocketImpl: typeof WebSocket = WebSocket;
+/** @internal — test-only seam. Pass null to restore the real `ws` implementation. */
+export function __setWebSocketImplForTests(impl: typeof WebSocket | null): void {
+  WebSocketImpl = impl ?? WebSocket;
+}
 import { sanitizeErrorMessage } from "../utils/error.ts";
 import { BaseExecutor, type ExecuteInput } from "./base.ts";
 import {
@@ -85,7 +94,9 @@ export class CopilotM365WebExecutor extends BaseExecutor {
             if (settled) return;
             settled = true;
             cleanup();
-            controller.enqueue(encoder.encode(`data: ${JSON.stringify({ error: { message: reason } })}\n\n`));
+            controller.enqueue(
+              encoder.encode(`data: ${JSON.stringify({ error: { message: reason } })}\n\n`)
+            );
             controller.close();
           };
 
@@ -98,10 +109,12 @@ export class CopilotM365WebExecutor extends BaseExecutor {
 
           try {
             const wsUrlParts = new URL(input.wsUrl);
-            const traceId = wsUrlParts.searchParams.get("clientrequestid") ?? crypto.randomUUID().replace(/-/g, "");
+            const traceId =
+              wsUrlParts.searchParams.get("clientrequestid") ??
+              crypto.randomUUID().replace(/-/g, "");
             const sessionId = wsUrlParts.searchParams.get("X-SessionId") ?? crypto.randomUUID();
 
-            ws = new WebSocket(input.wsUrl, {
+            ws = new WebSocketImpl(input.wsUrl, {
               headers: {
                 Origin: "https://m365.cloud.microsoft",
                 "User-Agent":
@@ -139,7 +152,7 @@ export class CopilotM365WebExecutor extends BaseExecutor {
                   const err = handshakeError(frame);
                   if (err) {
                     clearTimeout(timeout);
-                    abort(`Microsoft 365 Copilot handshake failed: ${err}`);
+                    abort(sanitizeErrorMessage(`Microsoft 365 Copilot handshake failed: ${err}`));
                     return;
                   }
                   handshakeComplete = true;
@@ -166,7 +179,11 @@ export class CopilotM365WebExecutor extends BaseExecutor {
 
             ws.on("error", (err) => {
               clearTimeout(timeout);
-              abort(err instanceof Error ? err.message : "Microsoft 365 Copilot WebSocket error");
+              abort(
+                sanitizeErrorMessage(
+                  err instanceof Error ? err.message : "Microsoft 365 Copilot WebSocket error"
+                )
+              );
             });
 
             ws.on("close", () => {
@@ -175,7 +192,11 @@ export class CopilotM365WebExecutor extends BaseExecutor {
             });
           } catch (err) {
             clearTimeout(timeout);
-            abort(err instanceof Error ? err.message : "Failed to connect to Microsoft 365 Copilot");
+            abort(
+              sanitizeErrorMessage(
+                err instanceof Error ? err.message : "Failed to connect to Microsoft 365 Copilot"
+              )
+            );
           }
         },
       },
@@ -216,7 +237,12 @@ export class CopilotM365WebExecutor extends BaseExecutor {
     const wsUrl = buildWsUrl(connectionParams);
 
     try {
-      const wsStream = await this.wsChat({ wsUrl, prompt, model, signal: input.signal ?? undefined });
+      const wsStream = await this.wsChat({
+        wsUrl,
+        prompt,
+        model,
+        signal: input.signal ?? undefined,
+      });
 
       if (stream) {
         return {

--- a/open-sse/executors/copilot-m365-web.ts
+++ b/open-sse/executors/copilot-m365-web.ts
@@ -1,0 +1,290 @@
+import WebSocket from "ws";
+import { FETCH_TIMEOUT_MS } from "../config/constants.ts";
+import { sanitizeErrorMessage } from "../utils/error.ts";
+import { BaseExecutor, type ExecuteInput } from "./base.ts";
+import {
+  buildPrompt,
+  buildWsUrl,
+  redactWsUrl,
+  resolveConnectionParams,
+} from "./copilot-m365-connection.ts";
+import {
+  buildChatInvocation,
+  encodeFrame,
+  extractBotText,
+  handshakeError,
+  handshakeFrame,
+  incrementalDelta,
+  isCompletionFrame,
+  keepaliveFrame,
+  parseFrame,
+  splitFrames,
+} from "./copilot-m365-frames.ts";
+
+type JsonRecord = Record<string, unknown>;
+
+function sseChunk(model: string, delta: JsonRecord, finishReason: string | null = null): string {
+  return `data: ${JSON.stringify({
+    id: `chatcmpl-copilot-m365-${Date.now()}`,
+    object: "chat.completion.chunk",
+    created: Math.floor(Date.now() / 1000),
+    model,
+    choices: [{ index: 0, delta, finish_reason: finishReason }],
+  })}\n\n`;
+}
+
+function errorResponse(message: string, status = 502): Response {
+  return new Response(JSON.stringify({ error: { message } }), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export class CopilotM365WebExecutor extends BaseExecutor {
+  constructor() {
+    super("copilot-m365-web", { id: "copilot-m365-web", baseUrl: "wss://substrate.office.com" });
+  }
+
+  private async wsChat(input: {
+    wsUrl: string;
+    prompt: string;
+    model: string;
+    signal?: AbortSignal;
+  }): Promise<ReadableStream<Uint8Array>> {
+    return new ReadableStream<Uint8Array>(
+      {
+        start: async (controller) => {
+          const encoder = new TextEncoder();
+          let ws: WebSocket | null = null;
+          let settled = false;
+          let buffer = "";
+          let previousText = "";
+          let handshakeComplete = false;
+
+          const cleanup = () => {
+            if (ws) {
+              try {
+                ws.close();
+              } catch {
+                /* ignore */
+              }
+              ws = null;
+            }
+          };
+
+          const finish = () => {
+            if (settled) return;
+            settled = true;
+            cleanup();
+            controller.enqueue(encoder.encode(sseChunk(input.model, {}, "stop")));
+            controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+            controller.close();
+          };
+
+          const abort = (reason: string) => {
+            if (settled) return;
+            settled = true;
+            cleanup();
+            controller.enqueue(encoder.encode(`data: ${JSON.stringify({ error: { message: reason } })}\n\n`));
+            controller.close();
+          };
+
+          input.signal?.addEventListener("abort", () => abort("Request aborted"), { once: true });
+
+          const timeout = setTimeout(
+            () => abort("Microsoft 365 Copilot WebSocket timeout"),
+            FETCH_TIMEOUT_MS
+          );
+
+          try {
+            const wsUrlParts = new URL(input.wsUrl);
+            const traceId = wsUrlParts.searchParams.get("clientrequestid") ?? crypto.randomUUID().replace(/-/g, "");
+            const sessionId = wsUrlParts.searchParams.get("X-SessionId") ?? crypto.randomUUID();
+
+            ws = new WebSocket(input.wsUrl, {
+              headers: {
+                Origin: "https://m365.cloud.microsoft",
+                "User-Agent":
+                  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36",
+              },
+            });
+
+            const sendChat = () => {
+              ws?.send(keepaliveFrame());
+              ws?.send(
+                encodeFrame(
+                  buildChatInvocation({
+                    text: input.prompt,
+                    traceId,
+                    sessionId,
+                    isStartOfSession: true,
+                  })
+                )
+              );
+            };
+
+            ws.on("open", () => {
+              ws?.send(handshakeFrame());
+            });
+
+            ws.on("message", (data) => {
+              if (settled) return;
+              buffer += data.toString();
+              const split = splitFrames(buffer);
+              buffer = split.rest;
+
+              for (const rawFrame of split.frames) {
+                const frame = parseFrame(rawFrame);
+                if (!handshakeComplete) {
+                  const err = handshakeError(frame);
+                  if (err) {
+                    clearTimeout(timeout);
+                    abort(`Microsoft 365 Copilot handshake failed: ${err}`);
+                    return;
+                  }
+                  handshakeComplete = true;
+                  sendChat();
+                  continue;
+                }
+
+                const text = extractBotText(frame);
+                if (text) {
+                  const delta = incrementalDelta(previousText, text);
+                  previousText = text;
+                  if (delta) {
+                    controller.enqueue(encoder.encode(sseChunk(input.model, { content: delta })));
+                  }
+                }
+
+                if (isCompletionFrame(frame)) {
+                  clearTimeout(timeout);
+                  finish();
+                  return;
+                }
+              }
+            });
+
+            ws.on("error", (err) => {
+              clearTimeout(timeout);
+              abort(err instanceof Error ? err.message : "Microsoft 365 Copilot WebSocket error");
+            });
+
+            ws.on("close", () => {
+              clearTimeout(timeout);
+              finish();
+            });
+          } catch (err) {
+            clearTimeout(timeout);
+            abort(err instanceof Error ? err.message : "Failed to connect to Microsoft 365 Copilot");
+          }
+        },
+      },
+      { highWaterMark: 16384 }
+    );
+  }
+
+  async execute(input: ExecuteInput): Promise<{
+    response: Response;
+    url: string;
+    headers: Record<string, string>;
+    transformedBody: unknown;
+  }> {
+    const body = input.body as JsonRecord | undefined;
+    const model = input.model || (body?.model as string) || "copilot-m365";
+    const stream = input.stream !== false;
+    const prompt = buildPrompt(body).trim();
+
+    if (!prompt) {
+      return {
+        response: errorResponse("No user message provided", 400),
+        url: "wss://substrate.office.com/m365Copilot/Chathub",
+        headers: {},
+        transformedBody: null,
+      };
+    }
+
+    const connectionParams = resolveConnectionParams(input.credentials);
+    if ("error" in connectionParams) {
+      return {
+        response: errorResponse(connectionParams.error, 400),
+        url: "wss://substrate.office.com/m365Copilot/Chathub",
+        headers: {},
+        transformedBody: { model, prompt: prompt.slice(0, 100) },
+      };
+    }
+
+    const wsUrl = buildWsUrl(connectionParams);
+
+    try {
+      const wsStream = await this.wsChat({ wsUrl, prompt, model, signal: input.signal ?? undefined });
+
+      if (stream) {
+        return {
+          response: new Response(wsStream, {
+            headers: {
+              "Content-Type": "text/event-stream",
+              "Cache-Control": "no-cache",
+              Connection: "keep-alive",
+            },
+          }),
+          url: redactWsUrl(wsUrl),
+          headers: {},
+          transformedBody: { model, prompt: prompt.slice(0, 100) },
+        };
+      }
+
+      const reader = wsStream.getReader();
+      const decoder = new TextDecoder();
+      let fullText = "";
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        for (const line of decoder.decode(value, { stream: true }).split("\n")) {
+          if (!line.startsWith("data: ")) continue;
+          const data = line.slice(6).trim();
+          if (!data || data === "[DONE]") continue;
+          try {
+            const parsed = JSON.parse(data);
+            const content = parsed.choices?.[0]?.delta?.content;
+            if (typeof content === "string") fullText += content;
+          } catch {
+            /* skip malformed SSE lines */
+          }
+        }
+      }
+
+      return {
+        response: new Response(
+          JSON.stringify({
+            id: `chatcmpl-copilot-m365-${Date.now()}`,
+            object: "chat.completion",
+            created: Math.floor(Date.now() / 1000),
+            model,
+            choices: [
+              {
+                index: 0,
+                message: { role: "assistant", content: fullText || "(empty response)" },
+                finish_reason: "stop",
+              },
+            ],
+            usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+          }),
+          { headers: { "Content-Type": "application/json" } }
+        ),
+        url: redactWsUrl(wsUrl),
+        headers: {},
+        transformedBody: { model, prompt: prompt.slice(0, 100) },
+      };
+    } catch (err) {
+      const message = sanitizeErrorMessage(
+        err instanceof Error ? err.message : "Microsoft 365 Copilot executor error"
+      );
+      return {
+        response: errorResponse(message),
+        url: redactWsUrl(wsUrl),
+        headers: {},
+        transformedBody: { model, prompt: prompt.slice(0, 100) },
+      };
+    }
+  }
+}

--- a/open-sse/executors/index.ts
+++ b/open-sse/executors/index.ts
@@ -33,6 +33,7 @@ import { DeepSeekWebWithAutoRefreshExecutor } from "./deepseek-web-with-auto-ref
 import { AdaptaWebExecutor } from "./adapta-web.ts";
 import { ClaudeWebWithAutoRefresh } from "./claude-web-with-auto-refresh.ts";
 import { CopilotWebExecutor } from "./copilot-web.ts";
+import { CopilotM365WebExecutor } from "./copilot-m365-web.ts";
 import { VeoAIFreeWebExecutor } from "./veoaifree-web.ts";
 import { DuckDuckGoWebExecutor } from "./duckduckgo-web.ts";
 import { T3ChatWebExecutor } from "./t3-chat-web.ts";
@@ -115,6 +116,7 @@ const executors = {
   "adapta-web": new AdaptaWebExecutor(),
   "adp-web": new AdaptaWebExecutor(), // Alias
   "copilot-web": new CopilotWebExecutor(),
+  "copilot-m365-web": new CopilotM365WebExecutor(),
   copilot: new CopilotWebExecutor(), // Alias
   "veoaifree-web": new VeoAIFreeWebExecutor(),
   "veo-free": new VeoAIFreeWebExecutor(), // Alias
@@ -201,6 +203,7 @@ export { NlpCloudExecutor } from "./nlpcloud.ts";
 export { WindsurfExecutor } from "./windsurf.ts";
 export { DevinCliExecutor } from "./devin-cli.ts";
 export { CopilotWebExecutor } from "./copilot-web.ts";
+export { CopilotM365WebExecutor } from "./copilot-m365-web.ts";
 export { VeoAIFreeWebExecutor } from "./veoaifree-web.ts";
 export { DuckDuckGoWebExecutor } from "./duckduckgo-web.ts";
 export { ClaudeWebExecutor } from "./claude-web.ts";

--- a/src/shared/constants/providers/web-cookie.ts
+++ b/src/shared/constants/providers/web-cookie.ts
@@ -116,6 +116,19 @@ export const WEB_COOKIE_PROVIDERS = {
     subscriptionRisk: true,
     riskNoticeVariant: "webCookie",
   },
+  "copilot-m365-web": {
+    id: "copilot-m365-web",
+    alias: "m365copilot",
+    name: "Microsoft 365 Copilot (BizChat)",
+    icon: "business_center",
+    color: "#0078D4",
+    textIcon: "M365",
+    website: "https://m365.cloud.microsoft/chat",
+    authHint:
+      "Paste the access_token and Chathub path from the Microsoft 365 Copilot WebSocket URL. The path is the '<user-oid>@<tenant-id>' segment before the query string.",
+    subscriptionRisk: true,
+    riskNoticeVariant: "webCookie",
+  },
   "t3-web": {
     id: "t3-web",
     alias: "t3chat",

--- a/src/shared/providers/webSessionCredentials.ts
+++ b/src/shared/providers/webSessionCredentials.ts
@@ -94,6 +94,13 @@ export const WEB_SESSION_CREDENTIAL_REQUIREMENTS = {
     acceptsFullCookieHeader: false,
     storageKeys: ["token", "access_token", "accessToken"],
   },
+  "copilot-m365-web": {
+    kind: "token",
+    credentialName: "access_token + chathubPath",
+    placeholder: "access_token=...; chathubPath=<user-oid>@<tenant-id>",
+    acceptsFullCookieHeader: false,
+    storageKeys: ["token", "access_token", "accessToken", "chathubPath", "userTenant"],
+  },
   "t3-web": {
     kind: "cookie",
     credentialName: "convex-session-id + Cookie header",

--- a/tests/unit/m365-bizchat-frames-4042.test.ts
+++ b/tests/unit/m365-bizchat-frames-4042.test.ts
@@ -29,7 +29,7 @@ const HANDSHAKE_ACK = {}; // SignalR success ack
 const PROGRESS_UPDATE = {
   type: 1,
   target: "update",
-  arguments: [{ messages: [{ messageType: "Progress", author: "bot" }] }],
+  arguments: [{ messages: [{ text: "In progress…", messageType: "Progress", author: "bot" }] }],
 };
 const BOT_UPDATE = {
   type: 1,
@@ -128,6 +128,8 @@ test("buildChatInvocation produces a type:4 chat invocation carrying the user te
   assert.equal(arg.clientCorrelationId, "trace-id");
   assert.equal(arg.sessionId, "session-id");
   assert.equal(arg.isStartOfSession, true);
+  assert.ok(Array.isArray(arg.optionsSets));
+  assert.ok((arg.optionsSets as string[]).includes("rich_responses"));
   assert.ok(Array.isArray(arg.allowedMessageTypes));
   assert.ok((arg.allowedMessageTypes as string[]).includes("Chat"));
   const message = arg.message as Record<string, unknown>;

--- a/tests/unit/m365-connection-4042.test.ts
+++ b/tests/unit/m365-connection-4042.test.ts
@@ -65,6 +65,7 @@ test("buildWsUrl targets the substrate Chathub with the individual-tier query", 
   assert.equal(qs.get("agent"), "web");
   assert.equal(qs.get("scenario"), "OfficeWebPaidConsumerCopilot");
   assert.equal(qs.get("source"), "officeweb");
+  assert.ok(qs.get("variants")?.includes("feature.bizchatfluxv3"));
   assert.equal(qs.get("access_token"), "TOK");
   // chatsessionid == XRoutingParameterSessionKey == clientrequestid (same value)
   const sid = qs.get("chatsessionid");

--- a/tests/unit/m365-executor-sanitize-5287.test.ts
+++ b/tests/unit/m365-executor-sanitize-5287.test.ts
@@ -1,0 +1,54 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  CopilotM365WebExecutor,
+  __setWebSocketImplForTests,
+} from "../../open-sse/executors/copilot-m365-web.ts";
+
+// A fake `ws` instance that emits an `error` carrying a stack-trace-laden message right after
+// construction. This drives the executor's wsChat ReadableStream error path and proves the
+// Rule #12 sanitization (#5287): the raw error/stack must never reach the SSE
+// `data: {error:{message}}` frame.
+class FakeWebSocket {
+  handlers: Record<string, (arg?: unknown) => void> = {};
+  constructor(_url: string, _opts?: unknown) {
+    queueMicrotask(() => {
+      const err = new Error(
+        "ECONNREFUSED 10.0.0.5:443\n    at TLSSocket.onError (/home/app/open-sse/executors/copilot-m365-web.ts:167:14)"
+      );
+      this.handlers["error"]?.(err);
+    });
+  }
+  on(event: string, cb: (arg?: unknown) => void) {
+    this.handlers[event] = cb;
+    return this;
+  }
+  send() {}
+  close() {}
+}
+
+test("#5287 wsChat sanitizes a ws error before emitting it into the SSE stream (Rule #12)", async () => {
+  __setWebSocketImplForTests(FakeWebSocket as never);
+  try {
+    const executor = new CopilotM365WebExecutor();
+    const result = await executor.execute({
+      body: { messages: [{ role: "user", content: "hello" }] },
+      model: "copilot-m365",
+      stream: true,
+      credentials: { apiKey: "opaque-token", providerSpecificData: { chathubPath: "u@t" } },
+    } as never);
+
+    const text = await result.response.text();
+
+    // An SSE error frame is emitted...
+    assert.ok(text.includes('"error"'), `expected an SSE error frame, got: ${text}`);
+    // ...but the raw stack path must be stripped by sanitizeErrorMessage (Rule #12).
+    assert.ok(!text.includes("/home/app/"), `raw stack path leaked into SSE: ${text}`);
+    assert.ok(
+      !/\bat\s+\S+\s+\(\/.+\.ts:\d+/.test(text),
+      `raw stack frame leaked into SSE: ${text}`
+    );
+  } finally {
+    __setWebSocketImplForTests(null);
+  }
+});


### PR DESCRIPTION
## Summary
- Adds a `copilot-m365-web` provider registry entry and specialized executor for Microsoft 365 Copilot BizChat.
- Reuses the landed pure M365 SignalR framing/connection helpers and wires provider credential UI metadata.
- Includes current non-secret BizChat `variants` / `optionsSets` defaults required for live text responses, while redacting all credentials and account-specific values.
- Filters EarlyProgress/Progress messages so only assistant answer text is emitted as OpenAI-compatible SSE deltas.

## Validation
- Live browser validation against `m365.cloud.microsoft/chat` completed on 2026-06-29.
- Credentials, user/tenant path, account identifiers, and location-specific fields: `REDACTED`.
- Observed redacted flow: `wss://substrate.office.com/m365Copilot/Chathub/REDACTED?...access_token=REDACTED`.
- SignalR handshake succeeded; `type:4` chat invocation produced `type:1` updates, `type:2` final item, and `type:3` completion.
- Prompt: `Reply with exactly one word: pong`; response: `pong`.
- Fresh non-browser replay with newly generated IDs succeeded only when current non-secret `variants` and `optionsSets` were included. Empty option flags completed without assistant text.

## Tests
- `npm exec -- tsx --import ./open-sse/utils/setupPolyfill.ts --test tests/unit/m365-connection-4042.test.ts tests/unit/m365-bizchat-frames-4042.test.ts`
- Result: 23/23 passing.

Follow-up to #4400 / #4042.
