### PR TITLE
fix(mimocode): route per-account traffic through SOCKS5 proxy dispatchers

### DIFF
--- a/open-sse/executors/mimocode.ts
+++ b/open-sse/executors/mimocode.ts
@@ -1,0 +1,537 @@
+/**
+ * MiMoCode Executor — Free-tier Xiaomi MiMo models via bootstrap JWT auth.
+ *
+ * Implements the auth flow from the official MiMo-Code repository:
+ *   https://github.com/XiaomiMiMo/MiMo-Code/blob/main/packages/opencode/src/plugin/mimo-free.ts
+ *
+ *   1. Generate device fingerprint from hostname + OS + arch + CPU + username
+ *   2. POST /api/free-ai/bootstrap with fingerprint → JWT
+ *   3. Use JWT as Bearer token for chat requests
+ *   4. Custom endpoint: /api/free-ai/openai/chat (not /v1/chat/completions)
+ *   5. Custom header: X-Mimo-Source: mimocode-cli-free
+ *
+ * Only the "mimo-auto" model is supported (1M context, 128K output).
+ * Supports multiple accounts: N fingerprints → N JWTs → round-robin with cooldown.
+ * On 429, account enters cooldown (exponential backoff). On 401/403, JWT is re-bootstrapped.
+ */
+
+import * as crypto from "node:crypto";
+import * as os from "node:os";
+import { BaseExecutor, type ExecuteInput, type ProviderCredentials } from "./base.ts";
+import { createProxyDispatcher } from "../utils/proxyDispatcher.ts";
+import { fetch as undiciFetch, type Dispatcher } from "undici";
+
+const BOOTSTRAP_PATH = "/api/free-ai/bootstrap";
+const CHAT_PATH = "/api/free-ai/openai/chat";
+const JWT_REFRESH_BUFFER_MS = 5 * 60 * 1000;
+const BOOTSTRAP_TIMEOUT_MS = 15_000;
+const COOLDOWN_BASE_MS = 5_000;
+const COOLDOWN_MAX_MS = 60_000;
+
+const MIMO_SOURCE = "mimocode-cli-free";
+
+/**
+ * Anti-abuse gate marker required by the Xiaomi free endpoint.
+ *
+ * `/api/free-ai/openai/chat` returns `403 "Illegal access"` unless the request body
+ * contains a recognized MiMoCode prompt signature as a substring inside a `system`-role
+ * message (verified empirically — headers, fingerprint, and JWT are not what is checked).
+ * This is the canonical MiMoCode agent opener the official CLI sends, and it is on the
+ * upstream allowlist. We inject it as a leading system message so user requests pass the
+ * gate. The string MUST stay byte-for-byte identical — the check is case-sensitive and
+ * truncations are rejected.
+ */
+export const MIMO_SYSTEM_MARKER =
+  "You are MiMoCode, an interactive CLI tool that helps users with software engineering tasks.";
+
+/**
+ * Ensure the outgoing body carries the MiMoCode anti-abuse marker in a system message.
+ * Idempotent: if any system message already contains the marker, the body is returned
+ * unchanged. Bodies without a `messages` array are left untouched.
+ */
+function injectSystemMarker(body: Record<string, unknown>): Record<string, unknown> {
+  const messages = body.messages;
+  if (!Array.isArray(messages)) return body;
+
+  const hasMarker = messages.some(
+    (m) =>
+      m != null &&
+      typeof m === "object" &&
+      (m as { role?: unknown }).role === "system" &&
+      typeof (m as { content?: unknown }).content === "string" &&
+      (m as { content: string }).content.includes(MIMO_SYSTEM_MARKER)
+  );
+  if (hasMarker) return body;
+
+  return { ...body, messages: [{ role: "system", content: MIMO_SYSTEM_MARKER }, ...messages] };
+}
+
+const USER_AGENTS = [
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+  "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+];
+
+// ── Account State ──────────────────────────────────────────────────────────
+
+/** Per-account proxy configuration, passed through providerSpecificData.accountProxies. */
+export interface AccountProxyConfig {
+  fingerprint: string;
+  proxy: {
+    type: string;
+    host: string;
+    port: number;
+    username?: string;
+    password?: string;
+  } | null;
+}
+
+interface AccountState {
+  fingerprint: string;
+  jwt: string;
+  expiresAt: number;
+  cooldownUntil: number;
+  consecutiveFails: number;
+}
+
+function parseJwtExp(jwt: string): number {
+  try {
+    const parts = jwt.split(".");
+    if (parts.length < 2) return Date.now() + 50 * 60 * 1000;
+    const payload = JSON.parse(Buffer.from(parts[1], "base64url").toString());
+    return (payload.exp ?? Math.floor(Date.now() / 1000) + 3000) * 1000;
+  } catch {
+    return Date.now() + 50 * 60 * 1000;
+  }
+}
+
+function isAccountReady(account: AccountState): boolean {
+  if (account.cooldownUntil > Date.now()) return false;
+  if (account.jwt && account.expiresAt - Date.now() > JWT_REFRESH_BUFFER_MS) return true;
+  return false;
+}
+
+// ── Fingerprint Generation ─────────────────────────────────────────────────
+
+function getCpuModel(): string {
+  try {
+    const cpus = os.cpus();
+    if (cpus.length > 0 && cpus[0].model) return cpus[0].model.trim();
+  } catch {
+    /* ignore */
+  }
+  return "unknown-cpu";
+}
+
+export function generateFingerprint(seed?: string): string {
+  if (seed) return crypto.createHash("sha256").update(seed).digest("hex");
+  const hostname = os.hostname();
+  const platform = os.platform();
+  const arch = os.arch();
+  const cpu = getCpuModel();
+  let username = "unknown-user";
+  try {
+    username = os.userInfo().username;
+  } catch {
+    /* ignore */
+  }
+  return crypto
+    .createHash("sha256")
+    .update(`${hostname}|${platform}|${arch}|${cpu}|${username}`)
+    .digest("hex");
+}
+
+// ── Bootstrap ──────────────────────────────────────────────────────────────
+
+const bootstrapInflight = new Map<string, Promise<{ jwt: string; expiresAt: number }>>();
+
+async function bootstrapJwt(
+  baseUrl: string,
+  fingerprint: string,
+  signal?: AbortSignal | null,
+  dispatcher?: Dispatcher
+): Promise<{ jwt: string; expiresAt: number }> {
+  const existing = bootstrapInflight.get(fingerprint);
+  if (existing) return existing;
+
+  const url = `${baseUrl}${BOOTSTRAP_PATH}`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), BOOTSTRAP_TIMEOUT_MS);
+  const onSignal = signal ? () => controller.abort(signal.reason) : null;
+  if (signal && onSignal) signal.addEventListener("abort", onSignal, { once: true });
+
+  const promise = (async () => {
+    try {
+      const resp = dispatcher
+        ? await undiciFetch(url, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ client: fingerprint }),
+            signal: controller.signal,
+            dispatcher,
+          })
+        : await fetch(url, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ client: fingerprint }),
+            signal: controller.signal,
+          });
+      if (!resp.ok) {
+        const body = await resp.text().catch(() => "");
+        throw new Error(`Bootstrap failed: ${resp.status} ${body.slice(0, 200)}`);
+      }
+      const data = (await resp.json()) as { jwt?: string };
+      if (!data.jwt) throw new Error("Bootstrap response missing jwt field");
+      return { jwt: data.jwt, expiresAt: parseJwtExp(data.jwt) };
+    } finally {
+      clearTimeout(timer);
+      if (signal && onSignal) signal.removeEventListener("abort", onSignal);
+      bootstrapInflight.delete(fingerprint);
+    }
+  })();
+
+  bootstrapInflight.set(fingerprint, promise);
+  return promise;
+}
+
+// ── Model Rewriting ────────────────────────────────────────────────────────
+
+function rewriteModelName(model: string): string {
+  const idx = model.lastIndexOf("/");
+  return idx >= 0 ? model.slice(idx + 1) : model;
+}
+
+// ── Executor ───────────────────────────────────────────────────────────────
+
+export class MimocodeExecutor extends BaseExecutor {
+  private accounts: AccountState[] = [];
+  private nextAccountIdx = 0;
+  private baseUrl: string;
+  private proxyUrlMap = new Map<string, string>();
+  private static encoder = new TextEncoder();
+
+  constructor() {
+    super("mimocode", { format: "openai" });
+    this.baseUrl = this.getBaseUrls()[0] || "https://api.xiaomimimo.com";
+    this.accounts.push({
+      fingerprint: generateFingerprint(),
+      jwt: "",
+      expiresAt: 0,
+      cooldownUntil: 0,
+      consecutiveFails: 0,
+    });
+  }
+
+  private getProxyDispatcher(fingerprint: string): Dispatcher | undefined {
+    const proxyUrl = this.proxyUrlMap.get(fingerprint);
+    if (!proxyUrl) return undefined;
+    return createProxyDispatcher(proxyUrl);
+  }
+
+  private fetchWithProxy(url: string, init: RequestInit, fingerprint: string): Promise<Response> {
+    const dispatcher = this.getProxyDispatcher(fingerprint);
+    if (dispatcher) {
+      // undici fetch returns undici.Response which is structurally compatible with
+      // the global Response but nominally different — same pattern as proxyFetch.ts
+      const undiciFn = undiciFetch as unknown as (
+        url: string,
+        init: RequestInit & { dispatcher?: unknown }
+      ) => Promise<Response>;
+      return undiciFn(url, { ...init, dispatcher });
+    }
+    return fetch(url, init);
+  }
+
+  private syncAccountsFromCredentials(credentials: ProviderCredentials): void {
+    const psd = credentials?.providerSpecificData;
+    const fingerprints = psd?.fingerprints;
+
+    const accountProxies = psd?.accountProxies;
+    if (Array.isArray(accountProxies)) {
+      for (const entry of accountProxies) {
+        if (entry?.fingerprint && entry?.proxy?.host) {
+          const {
+            type = "socks5",
+            host,
+            port,
+            username,
+            password,
+          } = entry.proxy as {
+            type?: string;
+            host: string;
+            port?: number;
+            username?: string;
+            password?: string;
+          };
+          const resolvedPort = port ?? (type === "socks5" ? 1080 : 8080);
+          const auth = username
+            ? `${encodeURIComponent(username)}:${password ? encodeURIComponent(password) : ""}@`
+            : "";
+          this.proxyUrlMap.set(entry.fingerprint, `${type}://${auth}${host}:${resolvedPort}`);
+        }
+      }
+    }
+
+    if (!Array.isArray(fingerprints)) return;
+    const existing = new Set(this.accounts.map((a) => a.fingerprint));
+    for (const fp of fingerprints) {
+      if (typeof fp === "string" && !existing.has(fp)) {
+        this.accounts.push({
+          fingerprint: fp,
+          jwt: "",
+          expiresAt: 0,
+          cooldownUntil: 0,
+          consecutiveFails: 0,
+        });
+        existing.add(fp);
+      }
+    }
+  }
+
+  private async getJwtForAccount(
+    account: AccountState,
+    signal?: AbortSignal | null
+  ): Promise<string> {
+    if (isAccountReady(account)) return account.jwt;
+    const dispatcher = this.getProxyDispatcher(account.fingerprint);
+    const result = await bootstrapJwt(this.baseUrl, account.fingerprint, signal, dispatcher);
+    account.jwt = result.jwt;
+    account.expiresAt = result.expiresAt;
+    return account.jwt;
+  }
+
+  private pickAccount(): AccountState {
+    for (let i = 0; i < this.accounts.length; i++) {
+      const idx = (this.nextAccountIdx + i) % this.accounts.length;
+      const acct = this.accounts[idx];
+      if (isAccountReady(acct)) {
+        this.nextAccountIdx = (idx + 1) % this.accounts.length;
+        return acct;
+      }
+    }
+    const fallbackIdx = this.nextAccountIdx % this.accounts.length;
+    this.nextAccountIdx = (this.nextAccountIdx + 1) % this.accounts.length;
+    return this.accounts[fallbackIdx];
+  }
+
+  private markCooldown(account: AccountState): void {
+    account.consecutiveFails++;
+    const backoff = Math.min(
+      COOLDOWN_BASE_MS * Math.pow(2, account.consecutiveFails - 1),
+      COOLDOWN_MAX_MS
+    );
+    account.cooldownUntil = Date.now() + backoff + Math.random() * 1000;
+  }
+
+  private markSuccess(account: AccountState): void {
+    account.consecutiveFails = 0;
+  }
+
+  buildUrl(
+    _model: string,
+    _stream: boolean,
+    _urlIndex = 0,
+    _credentials?: ProviderCredentials | null
+  ): string {
+    return `${this.baseUrl.replace(/\/$/, "")}${CHAT_PATH}`;
+  }
+
+  buildHeaders(
+    _credentials: ProviderCredentials,
+    stream = true,
+    _clientHeaders?: Record<string, string> | null,
+    _model?: string
+  ): Record<string, string> {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      "X-Mimo-Source": MIMO_SOURCE,
+      "User-Agent": USER_AGENTS[Math.floor(Math.random() * USER_AGENTS.length)],
+    };
+    if (stream) headers["Accept"] = "text/event-stream, application/json";
+    return headers;
+  }
+
+  transformRequest(
+    model: string,
+    body: unknown,
+    _stream: boolean,
+    _credentials?: ProviderCredentials | null
+  ): unknown {
+    if (typeof body === "object" && body !== null) {
+      const withModel = { ...(body as Record<string, unknown>), model: rewriteModelName(model) };
+      return injectSystemMarker(withModel);
+    }
+    return body;
+  }
+
+  async testConnection(
+    _credentials: ProviderCredentials,
+    _signal?: AbortSignal | null,
+    log?: ExecuteInput["log"]
+  ): Promise<boolean> {
+    try {
+      this.syncAccountsFromCredentials(_credentials);
+      const account = this.accounts[0];
+      const jwt = await this.getJwtForAccount(account, _signal);
+      const resp = await this.fetchWithProxy(
+        this.buildUrl("mimo-auto", false),
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${jwt}`,
+            "X-Mimo-Source": MIMO_SOURCE,
+          },
+          body: JSON.stringify(
+            injectSystemMarker({
+              model: "mimo-auto",
+              messages: [{ role: "user", content: "ping" }],
+              stream: false,
+            })
+          ),
+          signal: _signal ?? undefined,
+        },
+        account.fingerprint
+      );
+      return resp.status === 200;
+    } catch {
+      log?.warn?.("MIMOCODE", "testConnection network error");
+      return false;
+    }
+  }
+
+  async execute(input: ExecuteInput): Promise<{
+    response: Response;
+    url: string;
+    headers: Record<string, string>;
+    transformedBody: unknown;
+  }> {
+    const { model, stream, body, signal, log } = input;
+    const encoder = MimocodeExecutor.encoder;
+
+    if (signal?.aborted) {
+      return {
+        response: new Response(
+          encoder.encode(
+            JSON.stringify({
+              error: { message: "Request aborted", type: "abort", code: "ABORTED" },
+            })
+          ),
+          { status: 499, headers: { "Content-Type": "application/json" } }
+        ),
+        url: this.buildUrl(model, stream),
+        headers: this.buildHeaders(input.credentials, stream),
+        transformedBody: body,
+      };
+    }
+
+    const url = this.buildUrl(model, stream);
+    const reqBody = this.transformRequest(model, body, stream, input.credentials);
+
+    this.syncAccountsFromCredentials(input.credentials);
+
+    // Try each account, skip cooldown ones
+    for (let attempt = 0; attempt < this.accounts.length; attempt++) {
+      const account = this.pickAccount();
+      try {
+        const jwt = await this.getJwtForAccount(account, signal);
+        const headers = this.buildHeaders(input.credentials, stream);
+        headers["Authorization"] = `Bearer ${jwt}`;
+
+        let resp = await this.fetchWithProxy(
+          url,
+          {
+            method: "POST",
+            headers,
+            body: JSON.stringify(reqBody),
+            signal: signal ?? undefined,
+          },
+          account.fingerprint
+        );
+
+        // On auth failure, re-bootstrap this account and retry once
+        if (resp.status === 401 || resp.status === 403) {
+          log?.warn?.(
+            "MIMOCODE",
+            `Auth failed (${resp.status}) on account ${account.fingerprint.slice(0, 8)}…`
+          );
+          account.jwt = "";
+          account.expiresAt = 0;
+          account.consecutiveFails = 0;
+          const freshJwt = await this.getJwtForAccount(account, signal);
+          headers["Authorization"] = `Bearer ${freshJwt}`;
+          resp = await this.fetchWithProxy(
+            url,
+            {
+              method: "POST",
+              headers,
+              body: JSON.stringify(reqBody),
+              signal: signal ?? undefined,
+            },
+            account.fingerprint
+          );
+        }
+
+        if (resp.status === 429) {
+          this.markCooldown(account);
+          log?.warn?.(
+            "MIMOCODE",
+            `Rate limited on account ${account.fingerprint.slice(0, 8)}, trying next…`
+          );
+          continue;
+        }
+
+        this.markSuccess(account);
+        const respHeaders: Record<string, string> = {};
+        resp.headers.forEach((v, k) => {
+          respHeaders[k] = v;
+        });
+        return {
+          response: resp as unknown as Response,
+          url,
+          headers: respHeaders,
+          transformedBody: reqBody,
+        };
+      } catch (err) {
+        this.markCooldown(account);
+        if (attempt === this.accounts.length - 1) {
+          const msg = err instanceof Error ? err.message : String(err);
+          log?.error?.("MIMOCODE", `Executor error: ${msg}`);
+          return {
+            response: new Response(
+              encoder.encode(
+                JSON.stringify({
+                  error: { message: msg, type: "upstream_error", code: "EXECUTOR_ERROR" },
+                })
+              ),
+              { status: 502, headers: { "Content-Type": "application/json" } }
+            ),
+            url,
+            headers: this.buildHeaders(input.credentials, stream),
+            transformedBody: body,
+          };
+        }
+      }
+    }
+
+    return {
+      response: new Response(
+        encoder.encode(
+          JSON.stringify({
+            error: {
+              message: "All accounts exhausted",
+              type: "upstream_error",
+              code: "NO_ACCOUNTS",
+            },
+          })
+        ),
+        { status: 502, headers: { "Content-Type": "application/json" } }
+      ),
+      url,
+      headers: this.buildHeaders(input.credentials, stream),
+      transformedBody: body,
+    };
+  }
+}
+
+export default MimocodeExecutor;

--- a/tests/unit/mimocode-executor.test.ts
+++ b/tests/unit/mimocode-executor.test.ts
@@ -1,0 +1,487 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import {
+  MimocodeExecutor,
+  generateFingerprint,
+  MIMO_SYSTEM_MARKER,
+  type AccountProxyConfig,
+} from "../../open-sse/executors/mimocode.ts";
+
+const executor = new MimocodeExecutor();
+
+describe("MimocodeExecutor", () => {
+  it("generateFingerprint returns a 64-char hex string", () => {
+    const fp = generateFingerprint();
+    assert.match(fp, /^[0-9a-f]{64}$/);
+  });
+
+  it("generateFingerprint is deterministic", () => {
+    assert.strictEqual(generateFingerprint(), generateFingerprint());
+  });
+
+  it("generateFingerprint with seed is deterministic", () => {
+    assert.strictEqual(generateFingerprint("seed-a"), generateFingerprint("seed-a"));
+  });
+
+  it("generateFingerprint with different seeds differs", () => {
+    assert.notStrictEqual(generateFingerprint("seed-a"), generateFingerprint("seed-b"));
+  });
+
+  it("buildUrl returns the free-ai chat endpoint", () => {
+    const url = executor.buildUrl("mimo-auto", false);
+    assert.ok(url.includes("/api/free-ai/openai/chat"));
+    assert.ok(url.startsWith("https://"));
+  });
+
+  it("buildHeaders includes X-Mimo-Source and Content-Type", () => {
+    const headers = (executor as any).buildHeaders({}, true);
+    assert.strictEqual(headers["Content-Type"], "application/json");
+    assert.strictEqual(headers["X-Mimo-Source"], "mimocode-cli-free");
+  });
+
+  it("buildHeaders includes Accept for streaming", () => {
+    const headers = (executor as any).buildHeaders({}, true);
+    assert.ok(headers["Accept"]?.includes("text/event-stream"));
+  });
+
+  it("buildHeaders omits Accept for non-streaming", () => {
+    const headers = (executor as any).buildHeaders({}, false);
+    assert.ok(!headers["Accept"]?.includes("text/event-stream"));
+  });
+
+  it("transformRequest strips model prefix", () => {
+    const result = (executor as any).transformRequest(
+      "mcode/mimo-auto",
+      { model: "mcode/mimo-auto", messages: [{ role: "user", content: "hi" }] },
+      false
+    );
+    assert.strictEqual(result.model, "mimo-auto");
+  });
+
+  it("transformRequest passes model through when no prefix", () => {
+    const result = (executor as any).transformRequest(
+      "mimo-auto",
+      { model: "mimo-auto", messages: [{ role: "user", content: "hi" }] },
+      false
+    );
+    assert.strictEqual(result.model, "mimo-auto");
+  });
+
+  // The Xiaomi free endpoint rejects requests with `403 "Illegal access"` unless the
+  // body contains a recognized MiMoCode prompt signature inside a `system`-role message.
+  // The executor must inject that marker so user requests pass the upstream anti-abuse gate.
+  it("transformRequest injects a MiMoCode system marker when none is present", () => {
+    const result = (executor as any).transformRequest(
+      "mcode/mimo-auto",
+      { model: "mcode/mimo-auto", messages: [{ role: "user", content: "write a haiku" }] },
+      true
+    );
+    assert.ok(Array.isArray(result.messages));
+    const first = result.messages[0];
+    assert.strictEqual(first.role, "system");
+    assert.ok(
+      typeof first.content === "string" && first.content.includes(MIMO_SYSTEM_MARKER),
+      "first message must be a system message containing the MiMoCode marker"
+    );
+  });
+
+  it("transformRequest preserves the original user message after injection", () => {
+    const result = (executor as any).transformRequest(
+      "mcode/mimo-auto",
+      { model: "mcode/mimo-auto", messages: [{ role: "user", content: "write a haiku" }] },
+      true
+    );
+    const userMsg = result.messages.find((m: any) => m.role === "user");
+    assert.ok(userMsg);
+    assert.strictEqual(userMsg.content, "write a haiku");
+  });
+
+  it("transformRequest preserves a caller-provided system prompt alongside the marker", () => {
+    const result = (executor as any).transformRequest(
+      "mcode/mimo-auto",
+      {
+        model: "mcode/mimo-auto",
+        messages: [
+          { role: "system", content: "You are a pirate." },
+          { role: "user", content: "hi" },
+        ],
+      },
+      true
+    );
+    const systemContents = result.messages
+      .filter((m: any) => m.role === "system")
+      .map((m: any) => m.content)
+      .join("\n");
+    assert.ok(systemContents.includes(MIMO_SYSTEM_MARKER), "marker present");
+    assert.ok(systemContents.includes("You are a pirate."), "caller system prompt preserved");
+  });
+
+  it("transformRequest does not duplicate the marker when already present", () => {
+    const result = (executor as any).transformRequest(
+      "mcode/mimo-auto",
+      {
+        model: "mcode/mimo-auto",
+        messages: [
+          { role: "system", content: `${MIMO_SYSTEM_MARKER}\nExtra context.` },
+          { role: "user", content: "hi" },
+        ],
+      },
+      true
+    );
+    const count = result.messages.filter(
+      (m: any) =>
+        m.role === "system" &&
+        typeof m.content === "string" &&
+        m.content.includes(MIMO_SYSTEM_MARKER)
+    ).length;
+    assert.strictEqual(count, 1, "marker should not be duplicated");
+  });
+
+  it("transformRequest leaves a body without a messages array untouched", () => {
+    const result = (executor as any).transformRequest(
+      "mcode/mimo-auto",
+      { model: "mcode/mimo-auto", prompt: "legacy" },
+      true
+    );
+    assert.strictEqual((result as any).messages, undefined);
+    assert.strictEqual((result as any).model, "mimo-auto");
+  });
+
+  it("returns 499 on pre-aborted signal", async () => {
+    const controller = new AbortController();
+    controller.abort(new Error("cancelled"));
+
+    const result = await executor.execute({
+      model: "mimo-auto",
+      body: { messages: [{ role: "user", content: "hi" }], stream: false },
+      stream: false,
+      signal: controller.signal,
+      credentials: {},
+      log: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
+    });
+
+    assert.strictEqual((result as any).response.status, 499);
+  });
+
+  it("is registered in executor index", async () => {
+    const { getExecutor } = await import("../../open-sse/executors/index.ts");
+    const exec = getExecutor("mimocode");
+    assert.ok(exec instanceof MimocodeExecutor);
+  });
+
+  it("mcode alias works", async () => {
+    const { getExecutor } = await import("../../open-sse/executors/index.ts");
+    const exec = getExecutor("mcode");
+    assert.ok(exec instanceof MimocodeExecutor);
+  });
+});
+
+describe("mimocode multi-account", () => {
+  it("executor has at least one account", () => {
+    const accounts = (executor as any).accounts;
+    assert.ok(Array.isArray(accounts));
+    assert.ok(accounts.length >= 1);
+  });
+
+  it("each account has required fields", () => {
+    const accounts = (executor as any).accounts;
+    for (const acct of accounts) {
+      assert.ok(typeof acct.fingerprint === "string");
+      assert.ok(typeof acct.jwt === "string");
+      assert.ok(typeof acct.expiresAt === "number");
+      assert.ok(typeof acct.cooldownUntil === "number");
+      assert.ok(typeof acct.consecutiveFails === "number");
+    }
+  });
+
+  it("pickAccount returns an account", () => {
+    const acct = (executor as any).pickAccount();
+    assert.ok(acct);
+    assert.ok(typeof acct.fingerprint === "string");
+  });
+
+  it("markCooldown increases consecutiveFails and sets cooldownUntil", () => {
+    const acct = (executor as any).accounts[0];
+    const before = acct.consecutiveFails;
+    (executor as any).markCooldown(acct);
+    assert.strictEqual(acct.consecutiveFails, before + 1);
+    assert.ok(acct.cooldownUntil > Date.now());
+  });
+
+  it("markSuccess resets consecutiveFails", () => {
+    const acct = (executor as any).accounts[0];
+    acct.consecutiveFails = 5;
+    (executor as any).markSuccess(acct);
+    assert.strictEqual(acct.consecutiveFails, 0);
+  });
+});
+
+describe("mimocode provider registration", () => {
+  it("provider is registered in NOAUTH_PROVIDERS", async () => {
+    const { NOAUTH_PROVIDERS } = await import("../../src/shared/constants/providers.ts");
+    const provider = (NOAUTH_PROVIDERS as Record<string, any>)["mimocode"];
+    assert.ok(provider);
+    assert.strictEqual(provider.id, "mimocode");
+    assert.strictEqual(provider.alias, "mcode");
+    assert.strictEqual(provider.noAuth, true);
+    assert.strictEqual(provider.hasFree, true);
+  });
+
+  it("provider has correct service kinds", async () => {
+    const { NOAUTH_PROVIDERS } = await import("../../src/shared/constants/providers.ts");
+    const provider = (NOAUTH_PROVIDERS as Record<string, any>)["mimocode"];
+    assert.ok(provider.serviceKinds?.includes("llm"));
+  });
+});
+
+describe("mimocode providerRegistry entry", () => {
+  it("registry entry exists with correct executor", async () => {
+    const { getRegistryEntry } = await import("../../open-sse/config/providerRegistry.ts");
+    const entry = getRegistryEntry("mimocode");
+    assert.ok(entry);
+    assert.strictEqual(entry.executor, "mimocode");
+    assert.strictEqual(entry.format, "openai");
+    assert.strictEqual(entry.authType, "none");
+  });
+
+  it("registry entry has mimo-auto model", async () => {
+    const { getRegistryEntry } = await import("../../open-sse/config/providerRegistry.ts");
+    const entry = getRegistryEntry("mimocode");
+    const models = entry.models as Array<{ id: string }>;
+    const mimoAuto = models.find((m) => m.id === "mimo-auto");
+    assert.ok(mimoAuto);
+  });
+});
+
+describe("mimocode per-account proxy", () => {
+  const exec = new MimocodeExecutor();
+
+  it("AccountProxyConfig type has required fields", () => {
+    const config: AccountProxyConfig = {
+      fingerprint: "abc123",
+      proxy: { type: "http", host: "proxy.example.com", port: 8080 },
+    };
+    assert.strictEqual(config.fingerprint, "abc123");
+    assert.strictEqual(config.proxy?.host, "proxy.example.com");
+  });
+
+  it("default proxyUrlMap is empty", () => {
+    const testExec = new MimocodeExecutor();
+    const map = (testExec as any).proxyUrlMap;
+    assert.ok(map instanceof Map);
+    assert.strictEqual(map.size, 0);
+  });
+
+  it("syncAccountsFromCredentials populates proxyUrlMap with correct URLs", () => {
+    const testExec = new MimocodeExecutor();
+    const fp1 = "fingerprint-1";
+    const fp2 = "fingerprint-2";
+    (testExec as any).accounts = [
+      { fingerprint: fp1, jwt: "", expiresAt: 0, cooldownUntil: 0, consecutiveFails: 0 },
+      { fingerprint: fp2, jwt: "", expiresAt: 0, cooldownUntil: 0, consecutiveFails: 0 },
+    ];
+
+    const credentials = {
+      providerSpecificData: {
+        accountProxies: [
+          { fingerprint: fp1, proxy: { type: "http", host: "p1.example.com", port: 1080 } },
+          { fingerprint: fp2, proxy: null },
+        ],
+      },
+    };
+    (testExec as any).syncAccountsFromCredentials(credentials);
+
+    const map: Map<string, string> = (testExec as any).proxyUrlMap;
+    assert.strictEqual(map.get(fp1), "http://p1.example.com:1080");
+    assert.strictEqual(map.has(fp2), false);
+  });
+
+  it("syncAccountsFromCredentials skips when accountProxies absent", () => {
+    const testExec = new MimocodeExecutor();
+    const mapBefore = (testExec as any).proxyUrlMap.size;
+    (testExec as any).syncAccountsFromCredentials({ providerSpecificData: {} });
+    assert.strictEqual((testExec as any).proxyUrlMap.size, mapBefore);
+  });
+
+  it("syncAccountsFromCredentials adds proxyUrlMap entries for all valid proxy configs", () => {
+    const testExec = new MimocodeExecutor();
+    const existingFp = (testExec as any).accounts[0].fingerprint;
+    (testExec as any).syncAccountsFromCredentials({
+      providerSpecificData: {
+        accountProxies: [
+          {
+            fingerprint: "nonexistent-fingerprint",
+            proxy: { type: "socks5", host: "s5.example.com", port: 1080 },
+          },
+        ],
+      },
+    });
+    const map: Map<string, string> = (testExec as any).proxyUrlMap;
+    assert.strictEqual(
+      map.has("nonexistent-fingerprint"),
+      true,
+      "proxyUrlMap stores all valid proxy configs"
+    );
+    assert.strictEqual(map.get("nonexistent-fingerprint"), "socks5://s5.example.com:1080");
+    assert.strictEqual(
+      map.has(existingFp),
+      false,
+      "existing fingerprint without proxy is not in map"
+    );
+  });
+
+  it("accounts with different proxies produce distinct URLs", () => {
+    const testExec = new MimocodeExecutor();
+    const fp1 = "fp-a";
+    const fp2 = "fp-b";
+    (testExec as any).accounts = [
+      { fingerprint: fp1, jwt: "", expiresAt: 0, cooldownUntil: 0, consecutiveFails: 0 },
+      { fingerprint: fp2, jwt: "", expiresAt: 0, cooldownUntil: 0, consecutiveFails: 0 },
+    ];
+    (testExec as any).syncAccountsFromCredentials({
+      providerSpecificData: {
+        accountProxies: [
+          { fingerprint: fp1, proxy: { type: "http", host: "a.com", port: 8080 } },
+          { fingerprint: fp2, proxy: { type: "socks5", host: "b.com", port: 1080 } },
+        ],
+      },
+    });
+
+    const map: Map<string, string> = (testExec as any).proxyUrlMap;
+    assert.strictEqual(map.get(fp1), "http://a.com:8080");
+    assert.strictEqual(map.get(fp2), "socks5://b.com:1080");
+  });
+
+  it("getProxyDispatcher returns a dispatcher for known fingerprint", () => {
+    const testExec = new MimocodeExecutor();
+    const fp = "fp-dispatcher-test";
+    (testExec as any).accounts = [
+      { fingerprint: fp, jwt: "", expiresAt: 0, cooldownUntil: 0, consecutiveFails: 0 },
+    ];
+    (testExec as any).syncAccountsFromCredentials({
+      providerSpecificData: {
+        accountProxies: [
+          { fingerprint: fp, proxy: { type: "socks5", host: "s5.test", port: 1080 } },
+        ],
+      },
+    });
+
+    const dispatcher = (testExec as any).getProxyDispatcher(fp);
+    assert.ok(dispatcher, "dispatcher should exist for registered fingerprint");
+  });
+
+  it("getProxyDispatcher returns undefined for unknown fingerprint", () => {
+    const testExec = new MimocodeExecutor();
+    const dispatcher = (testExec as any).getProxyDispatcher("unknown-fp");
+    assert.strictEqual(dispatcher, undefined);
+  });
+
+  it("fetchWithProxy falls back to plain fetch when no proxy configured", async () => {
+    const testExec = new MimocodeExecutor();
+    const fp = "fp-no-proxy";
+    const originalFetch = globalThis.fetch;
+    let fetchCalled = false;
+    globalThis.fetch = async () => {
+      fetchCalled = true;
+      return new Response("ok");
+    };
+    try {
+      const resp = await (testExec as any).fetchWithProxy("https://example.com", {}, fp);
+      assert.ok(fetchCalled, "plain fetch should have been called");
+      assert.strictEqual(resp.status, 200);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("authenticated proxy includes credentials in URL", () => {
+    const testExec = new MimocodeExecutor();
+    const fp = "fp-auth";
+    (testExec as any).accounts = [
+      { fingerprint: fp, jwt: "", expiresAt: 0, cooldownUntil: 0, consecutiveFails: 0 },
+    ];
+    (testExec as any).syncAccountsFromCredentials({
+      providerSpecificData: {
+        accountProxies: [
+          {
+            fingerprint: fp,
+            proxy: {
+              type: "socks5",
+              host: "s5.auth.com",
+              port: 1080,
+              username: "user",
+              password: "pass",
+            },
+          },
+        ],
+      },
+    });
+
+    const map: Map<string, string> = (testExec as any).proxyUrlMap;
+    const url = map.get(fp);
+    assert.ok(url);
+    assert.ok(url.includes("user:pass@"), "URL should include encoded credentials");
+  });
+
+  it("default port is 1080 for socks5 when not specified", () => {
+    const testExec = new MimocodeExecutor();
+    const fp = "fp-default-port";
+    (testExec as any).accounts = [
+      { fingerprint: fp, jwt: "", expiresAt: 0, cooldownUntil: 0, consecutiveFails: 0 },
+    ];
+    (testExec as any).syncAccountsFromCredentials({
+      providerSpecificData: {
+        accountProxies: [
+          { fingerprint: fp, proxy: { type: "socks5", host: "s5.test", port: undefined } },
+        ],
+      },
+    });
+
+    const map: Map<string, string> = (testExec as any).proxyUrlMap;
+    assert.strictEqual(map.get(fp), "socks5://s5.test:1080");
+  });
+
+  it("default port is 8080 for http when not specified", () => {
+    const testExec = new MimocodeExecutor();
+    const fp = "fp-http-default";
+    (testExec as any).accounts = [
+      { fingerprint: fp, jwt: "", expiresAt: 0, cooldownUntil: 0, consecutiveFails: 0 },
+    ];
+    (testExec as any).syncAccountsFromCredentials({
+      providerSpecificData: {
+        accountProxies: [
+          { fingerprint: fp, proxy: { type: "http", host: "h.test", port: undefined } },
+        ],
+      },
+    });
+
+    const map: Map<string, string> = (testExec as any).proxyUrlMap;
+    assert.strictEqual(map.get(fp), "http://h.test:8080");
+  });
+
+  it("proxy URL map updates correctly on re-sync", () => {
+    const testExec = new MimocodeExecutor();
+    const fp = "fp-re-sync";
+    (testExec as any).accounts = [
+      { fingerprint: fp, jwt: "", expiresAt: 0, cooldownUntil: 0, consecutiveFails: 0 },
+    ];
+
+    (testExec as any).syncAccountsFromCredentials({
+      providerSpecificData: {
+        accountProxies: [
+          { fingerprint: fp, proxy: { type: "http", host: "first.proxy", port: 8080 } },
+        ],
+      },
+    });
+    assert.strictEqual((testExec as any).proxyUrlMap.get(fp), "http://first.proxy:8080");
+
+    (testExec as any).syncAccountsFromCredentials({
+      providerSpecificData: {
+        accountProxies: [
+          { fingerprint: fp, proxy: { type: "socks5", host: "second.proxy", port: 1080 } },
+        ],
+      },
+    });
+    assert.strictEqual((testExec as any).proxyUrlMap.get(fp), "socks5://second.proxy:1080");
+  });
+});


### PR DESCRIPTION
## Summary

The mimocode executor stored per-fingerprint proxy assignments in `providerSpecificData.accountProxies` but routed all traffic through the global proxy via plain `fetch()`. Xiaomi rate-limits by source IP, so all 10 fingerprints sharing one Mullvad exit IP hit the same rate-limit bucket.

## Changes

- Replace `runWithProxyContext` + plain `fetch()` with direct `undici fetch()` using per-fingerprint `Dispatcher` instances from `createProxyDispatcher()`
- Build fingerprint→proxyUrl map in `syncAccountsFromCredentials()` with support for authenticated proxies (username:password in URL)
- Add `fetchWithProxy()` helper that uses the dispatcher when available and falls back to plain `fetch()` for unproxied accounts
- Add `getProxyDispatcher()` that lazily creates/caches dispatchers per fingerprint via the shared `proxyDispatcher` cache
- Fix `testConnection()` to call `syncAccountsFromCredentials()` first so `proxyUrlMap` is populated before use
- Restore `AccountProxyConfig` export (needed by tests and consumers)
- Update test suite: 13 proxy tests covering URL construction, auth credentials, default ports, dispatcher creation, and fallback behavior

## Background

The mimocode executor (Xiaomi MiMo free-tier via bootstrap JWT auth) uses 10 device fingerprints, each assigned a dedicated Mullvad SOCKS5 proxy in `providerSpecificData.accountProxies`. However, the executor was using plain `fetch()` for all requests — meaning all 10 fingerprints shared a single Mullvad exit IP. Xiaomi tightened anti-abuse detection after June 22, causing 100% failure rate (400 errors: "Detected high-frequency non-compliant requests") because all fingerprints appeared to come from the same source.

This fix routes each fingerprint's bootstrap JWT and chat requests through its assigned SOCKS5 proxy, giving each fingerprint a unique exit IP.