### PR TITLE
chore: trim unused exported helpers

### DIFF
--- a/src/shared/constants/cliTools.ts
+++ b/src/shared/constants/cliTools.ts
@@ -815,31 +815,3 @@ export function listCliTools(): CliToolEntry[] {
 export function getCliTool(id: string): CliToolEntry | undefined {
   return CLI_TOOLS[id];
 }
-
-// ─── Provider model mapping helper ───────────────────────────────────────────
-
-// Get all provider models for mapping dropdown
-export const getProviderModelsForMapping = (
-  providers: Array<{
-    id: string;
-    isActive: boolean;
-    testStatus: string;
-    provider: string;
-    name: string;
-    models?: string[];
-  }>
-) => {
-  const result: Array<{ connectionId: string; provider: string; name: string; models: string[] }> =
-    [];
-  providers.forEach((conn) => {
-    if (conn.isActive && (conn.testStatus === "active" || conn.testStatus === "success")) {
-      result.push({
-        connectionId: conn.id,
-        provider: conn.provider,
-        name: conn.name,
-        models: conn.models || [],
-      });
-    }
-  });
-  return result;
-};

--- a/src/shared/utils/a11yAudit.ts
+++ b/src/shared/utils/a11yAudit.ts
@@ -123,26 +123,6 @@ export function getContrastRatio(fgHex, bgHex) {
 }
 
 /**
- * Check WCAG AA contrast compliance between foreground and background colors.
- *
- * @param {string} fgHex - Foreground color (#RRGGBB)
- * @param {string} bgHex - Background color (#RRGGBB)
- * @param {{ largeText?: boolean }} [options={}] - Options
- * @returns {{ ratio: number, aa: boolean, aaa: boolean }}
- */
-export function checkContrast(fgHex, bgHex, options: any = {}) {
-  const ratio = getContrastRatio(fgHex, bgHex);
-  const minAA = options.largeText ? 3 : 4.5;
-  const minAAA = options.largeText ? 4.5 : 7;
-
-  return {
-    ratio: Math.round(ratio * 100) / 100,
-    aa: ratio >= minAA,
-    aaa: ratio >= minAAA,
-  };
-}
-
-/**
  * Generate a summary report from a list of violations.
  *
  * @param {Violation[]} violations

--- a/src/shared/validation/helpers.ts
+++ b/src/shared/validation/helpers.ts
@@ -1,9 +1,5 @@
 import { z } from "zod";
 
-export const loginSchema = z.object({
-  password: z.string().min(1, "Password is required").max(200),
-});
-
 type ValidationErrorDetail = {
   field: string;
   message: string;

--- a/tests/unit/batch-b-final.test.ts
+++ b/tests/unit/batch-b-final.test.ts
@@ -271,6 +271,14 @@ describe("a11yAudit", () => {
     assert.equal(report.total, 0);
   });
 
+  it("should not export the removed contrast compliance wrapper", async () => {
+    const audit = await import("../../src/shared/utils/a11yAudit.ts");
+    assert.equal("checkContrast" in audit, false);
+    assert.equal(typeof audit.getContrastRatio, "function");
+    assert.equal(typeof audit.auditHTML, "function");
+    assert.equal(typeof audit.generateReport, "function");
+  });
+
   it("should export WCAG rules", () => {
     assert.ok(WCAG_RULES.ARIA_LABEL);
     assert.ok(WCAG_RULES.COLOR_CONTRAST);

--- a/tests/unit/cli-tools-schema.test.ts
+++ b/tests/unit/cli-tools-schema.test.ts
@@ -77,3 +77,8 @@ test("getCliTool returns correct tool by id", async () => {
   const missing = getCliTool("nonexistent");
   assert.equal(missing, undefined);
 });
+
+test("CLI tools registry does not export provider model mapping helper", async () => {
+  const registry = await import("../../src/shared/constants/cliTools.ts");
+  assert.equal("getProviderModelsForMapping" in registry, false);
+});

--- a/tests/unit/modular-schemas.test.ts
+++ b/tests/unit/modular-schemas.test.ts
@@ -33,3 +33,10 @@ test("modular schemas: loginSchema validates correctly", () => {
   });
   assert.equal(invalid.success, false);
 });
+
+test("validation helpers only export request-body helper APIs", async () => {
+  const helpers = await import("../../src/shared/validation/helpers.ts");
+  assert.equal("loginSchema" in helpers, false);
+  assert.equal(typeof helpers.validateBody, "function");
+  assert.equal(typeof helpers.isValidationFailure, "function");
+});


### PR DESCRIPTION
## Summary

- Removed the unused `getProviderModelsForMapping` export from the CLI tools registry.
- Removed the unused `checkContrast` wrapper while keeping `getContrastRatio` and the a11y audit/report helpers intact.
- Dropped the duplicate `loginSchema` export from `src/shared/validation/helpers.ts`; the canonical schema remains exported from `src/shared/validation/schemas.ts`.
- Left `metrics.deadExports.value` unchanged so this cleanup PR is independent of the final baseline ratchet PR.

## Tests changed

- `tests/unit/cli-tools-schema.test.ts`
- `tests/unit/batch-b-final.test.ts`
- `tests/unit/modular-schemas.test.ts`

## Validation

```text
$ node --import tsx/esm --test tests/unit/modular-schemas.test.ts tests/unit/cli-tools-schema.test.ts tests/unit/batch-b-final.test.ts
# tests 41
# pass 41
# fail 0
```

```text
$ node scripts/check/check-dead-code.mjs --quiet
DEAD_EXPORTS=248
DEAD_FILES=94
DEAD_TOTAL=342
[dead-code] OK — 342 símbolos mortos (baseline 346)
```

```text
$ GITHUB_BASE_REF=main GITHUB_BASE_SHA=upstream/main node scripts/check/check-pr-test-policy.mjs
Changed production files: 3
Changed automated test files: 3
Result: PASS
```

Pre-commit / pre-push hooks also passed: Prettier, ESLint fix, docs sync, explicit-any budget, tracked-artifacts.
