### PR TITLE
chore: drop unused validation schema exports

### DIFF
--- a/src/shared/schemas/searchTools.ts
+++ b/src/shared/schemas/searchTools.ts
@@ -37,5 +37,3 @@ export const ScrapeResultSchema = z.object({
   screenshot_url: z.string().nullable(),
 });
 export type ScrapeResult = z.infer<typeof ScrapeResultSchema>;
-
-export const SearchProviderCatalogResponseSchemaFull = SearchProviderCatalogResponseSchema;

--- a/src/shared/validation/settingsSchemas.ts
+++ b/src/shared/validation/settingsSchemas.ts
@@ -407,10 +407,3 @@ export const databaseSettingsSchema = z
     // Skip location and stats as they're read-only
   })
   .strict();
-
-export type DatabaseSettingsSchema = z.infer<typeof databaseSettingsSchema>;
-
-export const featureFlagUpdateSchema = z.object({
-  key: z.string().min(1),
-  value: z.string().optional(),
-});

--- a/tests/unit/feature-flags-settings.test.ts
+++ b/tests/unit/feature-flags-settings.test.ts
@@ -418,3 +418,12 @@ describe("featureFlagUpdateSchema validation", () => {
     );
   });
 });
+
+describe("settings schema public surface", () => {
+  it("uses databaseSettingsSchema as the canonical database settings export", async () => {
+    const settingsSchemas = await import("../../src/shared/validation/settingsSchemas.ts");
+    assert.equal("DatabaseSettingsSchema" in settingsSchemas, false);
+    assert.equal("featureFlagUpdateSchema" in settingsSchemas, false);
+    assert.equal(typeof settingsSchemas.databaseSettingsSchema.safeParse, "function");
+  });
+});

--- a/tests/unit/search-tools-schemas.test.ts
+++ b/tests/unit/search-tools-schemas.test.ts
@@ -4,6 +4,7 @@ import { ZodError } from "zod";
 
 const { SearchProviderCatalogItemSchema, SearchProviderCatalogResponseSchema, ScrapeResultSchema } =
   await import("../../src/shared/schemas/searchTools.ts");
+const searchToolsModule = await import("../../src/shared/schemas/searchTools.ts");
 
 // ── SearchProviderCatalogItemSchema ───────────────────────────────────────────
 
@@ -158,6 +159,11 @@ test("SearchProviderCatalogResponseSchema: empty providers array is valid", () =
 test("SearchProviderCatalogResponseSchema: invalid — providers not array", () => {
   const result = SearchProviderCatalogResponseSchema.safeParse({ providers: "not-array" });
   assert.ok(!result.success, "non-array providers should fail");
+});
+
+test("SearchProviderCatalogResponseSchemaFull alias is not exported", () => {
+  assert.equal("SearchProviderCatalogResponseSchemaFull" in searchToolsModule, false);
+  assert.equal(typeof searchToolsModule.SearchProviderCatalogResponseSchema.safeParse, "function");
 });
 
 // ── ScrapeResultSchema ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Removed the unused `SearchProviderCatalogResponseSchemaFull` alias; callers and tests already use `SearchProviderCatalogResponseSchema` directly.
- Removed unused `DatabaseSettingsSchema` and `featureFlagUpdateSchema` exports from `settingsSchemas.ts`; the database route and feature-flag route use their canonical/local schemas.
- Left `metrics.deadExports.value` unchanged so this cleanup PR is independent of the final baseline ratchet PR.

## Tests changed

- `tests/unit/search-tools-schemas.test.ts`
- `tests/unit/feature-flags-settings.test.ts`

## Validation

```text
$ node --import tsx/esm --test tests/unit/search-tools-schemas.test.ts tests/unit/feature-flags-settings.test.ts
# tests 63
# pass 63
# fail 0
```

```text
$ node scripts/check/check-dead-code.mjs --quiet
DEAD_EXPORTS=248
DEAD_FILES=94
DEAD_TOTAL=342
[dead-code] OK — 342 símbolos mortos (baseline 346)
```

```text
$ GITHUB_BASE_REF=main GITHUB_BASE_SHA=upstream/main node scripts/check/check-pr-test-policy.mjs
Changed production files: 2
Changed automated test files: 2
Result: PASS
```

Pre-commit / pre-push hooks also passed: Prettier, ESLint fix, docs sync, explicit-any budget, tracked-artifacts.
