### PR TITLE
chore: remove unused utility exports

### DIFF
--- a/src/lib/oauth/providers.ts
+++ b/src/lib/oauth/providers.ts
@@ -100,13 +100,6 @@ export function getProvider(name) {
 }
 
 /**
- * Get all provider names
- */
-export function getProviderNames() {
-  return Object.keys(PROVIDERS);
-}
-
-/**
  * Generate auth data for a provider.
  *
  * Returns `{ supported: false, error }` (no `authUrl`) for providers whose

--- a/src/lib/proxyLogger.ts
+++ b/src/lib/proxyLogger.ts
@@ -238,14 +238,3 @@ export function clearProxyLogs() {
     }
   }
 }
-
-// ──────────────── Stats ────────────────
-
-export function getProxyLogStats() {
-  const total = proxyLogs.length;
-  const success = proxyLogs.filter((l) => l.status === "success").length;
-  const error = proxyLogs.filter((l) => l.status === "error").length;
-  const timeout = proxyLogs.filter((l) => l.status === "timeout").length;
-  const direct = proxyLogs.filter((l) => l.level === "direct").length;
-  return { total, success, error, timeout, direct };
-}

--- a/src/lib/quota/sqliteQuotaStore.ts
+++ b/src/lib/quota/sqliteQuotaStore.ts
@@ -15,13 +15,7 @@
  * Part of: Group B — Quota Sharing Engine (plan 22, frente F6).
  */
 
-import {
-  getPool,
-  getBucket,
-  incrementBucket,
-  getPair,
-  sumPoolDimension,
-} from "@/lib/localDb";
+import { getPool, getBucket, incrementBucket, getPair, sumPoolDimension } from "@/lib/localDb";
 import { WINDOW_MS, dimensionKeyToString } from "./dimensions";
 import type { DimensionKey } from "./dimensions";
 import type { QuotaStore, PoolUsageSnapshot } from "./types";
@@ -285,8 +279,4 @@ export function getSqliteQuotaStore(): SqliteQuotaStore {
     _instance = new SqliteQuotaStore();
   }
   return _instance;
-}
-
-export function resetSqliteQuotaStore(): void {
-  _instance = null;
 }

--- a/src/shared/middleware/bodySizeGuard.ts
+++ b/src/shared/middleware/bodySizeGuard.ts
@@ -16,7 +16,6 @@
 import {
   normalizeRequestBodyLimitMb,
   parseRequestBodyLimitBytes,
-  requestBodyLimitBytesToMb,
   requestBodyLimitMbToBytes,
 } from "../constants/bodySize";
 
@@ -39,10 +38,6 @@ const ROUTE_LIMITS: BodySizeRule[] = [
   { prefix: "/api/v1/audio/transcriptions", limit: MAX_BODY_BYTES_AUDIO },
   { prefix: "/api/v1/files", limit: MAX_BODY_BYTES_FILE },
 ];
-
-export function getDefaultRequestBodyLimitMb(): number {
-  return requestBodyLimitBytesToMb(MAX_BODY_BYTES);
-}
 
 export function getConfiguredBodySizeLimitBytes(settings?: Record<string, unknown>): number {
   const configuredMb = normalizeRequestBodyLimitMb(settings?.maxBodySizeMb);

--- a/src/sse/services/streamState.ts
+++ b/src/sse/services/streamState.ts
@@ -216,12 +216,3 @@ export function archiveStream(requestId) {
 export function getActiveStreams() {
   return Array.from(activeStreams.values()).map((t) => t.getSummary());
 }
-
-/**
- * Get recent completed streams.
- * @param {number} [limit=20]
- * @returns {Array<Object>}
- */
-export function getRecentCompletedStreams(limit = 20) {
-  return completedStreams.slice(-limit);
-}

--- a/tests/unit/advanced-fase07-09.test.ts
+++ b/tests/unit/advanced-fase07-09.test.ts
@@ -234,6 +234,13 @@ import {
   getActiveStreams,
   archiveStream,
 } from "../../src/sse/services/streamState.ts";
+import * as streamStateModule from "../../src/sse/services/streamState.ts";
+
+test("stream state public surface excludes removed completed-history accessor", () => {
+  assert.equal(Object.hasOwn(streamStateModule, "getRecentCompletedStreams"), false);
+  assert.equal(typeof streamStateModule.getActiveStreams, "function");
+  assert.equal(typeof streamStateModule.archiveStream, "function");
+});
 
 test("StreamTracker: starts in INITIALIZED state", () => {
   const tracker = new StreamTracker("req-1");

--- a/tests/unit/body-size-guard.test.ts
+++ b/tests/unit/body-size-guard.test.ts
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import * as bodySizeGuard from "../../src/shared/middleware/bodySizeGuard.ts";
 import {
   MAX_BODY_BYTES_AUDIO,
   MAX_BODY_BYTES_FILE,
@@ -7,6 +8,12 @@ import {
   checkBodySize,
 } from "../../src/shared/middleware/bodySizeGuard.ts";
 import { requestBodyLimitMbToBytes } from "../../src/shared/constants/bodySize.ts";
+
+test("body size guard public surface excludes the removed default MB helper", () => {
+  assert.equal(Object.hasOwn(bodySizeGuard, "getDefaultRequestBodyLimitMb"), false);
+  assert.equal(typeof bodySizeGuard.getBodySizeLimit, "function");
+  assert.equal(typeof bodySizeGuard.checkBodySize, "function");
+});
 
 test("body size guard uses maxBodySizeMb from settings for regular API routes", () => {
   assert.equal(
@@ -53,7 +60,10 @@ test("/api/v1/files route guard allows 500 MB file upload", () => {
     method: "POST",
     headers: { "content-length": String(thirtyMb) },
   });
-  assert.equal(checkBodySize(request, getBodySizeLimit("/api/v1/files", { maxBodySizeMb: 10 })), null);
+  assert.equal(
+    checkBodySize(request, getBodySizeLimit("/api/v1/files", { maxBodySizeMb: 10 })),
+    null
+  );
 });
 
 test("/api/v1/files route guard rejects >512 MB file upload", async () => {

--- a/tests/unit/oauth-trae.test.ts
+++ b/tests/unit/oauth-trae.test.ts
@@ -13,6 +13,12 @@ const { getProvider } = oauthHandlers;
 // Registration
 // ---------------------------------------------------------------------------
 
+test("oauth provider helpers public surface excludes removed provider-name list helper", () => {
+  assert.equal(Object.hasOwn(oauthHandlers, "getProviderNames"), false);
+  assert.equal(typeof oauthHandlers.getProvider, "function");
+  assert.equal(typeof oauthHandlers.generateAuthData, "function");
+});
+
 test("PROVIDERS map includes a 'trae' entry", () => {
   assert.ok("trae" in PROVIDERS, "PROVIDERS must contain trae");
 });

--- a/tests/unit/proxy-logs-route.test.ts
+++ b/tests/unit/proxy-logs-route.test.ts
@@ -23,6 +23,13 @@ test.after(() => {
   fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
 });
 
+test("proxy logger public surface excludes removed stats helper", () => {
+  assert.equal(Object.hasOwn(proxyLogger, "getProxyLogStats"), false);
+  assert.equal(typeof proxyLogger.getProxyLogs, "function");
+  assert.equal(typeof proxyLogger.clearProxyLogs, "function");
+  assert.equal(typeof proxyLogger.logProxyEvent, "function");
+});
+
 test("GET /api/usage/proxy-logs returns filtered proxy logs", async () => {
   proxyLogger.logProxyEvent({
     status: "success",

--- a/tests/unit/quota-sqlite-store.test.ts
+++ b/tests/unit/quota-sqlite-store.test.ts
@@ -21,6 +21,7 @@ process.env.DATA_DIR = TEST_DATA_DIR;
 
 const core = await import("../../src/lib/db/core.ts");
 const poolsDb = await import("../../src/lib/db/quotaPools.ts");
+const sqliteQuotaStoreModule = await import("../../src/lib/quota/sqliteQuotaStore.ts");
 
 async function resetStorage() {
   core.resetDbInstance();
@@ -51,6 +52,12 @@ test.after(async () => {
   if (fs.existsSync(TEST_DATA_DIR)) {
     fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
   }
+});
+
+test("sqliteQuotaStore public surface excludes removed singleton reset helper", () => {
+  assert.equal(Object.hasOwn(sqliteQuotaStoreModule, "resetSqliteQuotaStore"), false);
+  assert.equal(typeof sqliteQuotaStoreModule.getSqliteQuotaStore, "function");
+  assert.equal(typeof sqliteQuotaStoreModule.SqliteQuotaStore, "function");
 });
 
 // Helper: make a dimension key
@@ -153,9 +160,7 @@ test("sqliteQuotaStore: 50 concurrent consumes → exact sum (mutex guards)", as
   const COST = 10;
 
   // Fire 50 concurrent consumes
-  await Promise.all(
-    Array.from({ length: N }, () => store.consume("key-concurrent", dim, COST))
-  );
+  await Promise.all(Array.from({ length: N }, () => store.consume("key-concurrent", dim, COST)));
 
   const effective = await store.peek("key-concurrent", dim);
 
@@ -202,7 +207,10 @@ test("sqliteQuotaStore: poolUsageWithDimensions returns correct shape", async ()
   assert.equal(dimSnap.window, "hourly");
   assert.equal(dimSnap.limit, 1000);
   // consumedTotal should be close to 300 + 200 = 500
-  assert.ok(dimSnap.consumedTotal > 490, `consumedTotal should be close to 500, got ${dimSnap.consumedTotal}`);
+  assert.ok(
+    dimSnap.consumedTotal > 490,
+    `consumedTotal should be close to 500, got ${dimSnap.consumedTotal}`
+  );
   assert.equal(dimSnap.perKey.length, 2);
 
   // Validate perKey shapes


### PR DESCRIPTION
## Summary

- Removed five unused utility exports from body-size guard, OAuth providers, proxy logging, quota store, and SSE stream-state modules.
- Kept the live APIs used by routes and tests intact: `getBodySizeLimit`, `checkBodySize`, `getProvider`, `generateAuthData`, `getProxyLogs`, `clearProxyLogs`, `getSqliteQuotaStore`, `getActiveStreams`, and `archiveStream`.
- Added public-surface regression assertions for the touched modules so the production cleanup satisfies the PR Test Policy.
- Left `config/quality/quality-baseline.json` unchanged versus `upstream/main`; the dead-code ratchet update is intentionally deferred to the final baseline PR.

## Validation

```text
$ node --import tsx/esm --test tests/unit/body-size-guard.test.ts tests/unit/oauth-trae.test.ts tests/unit/proxy-logs-route.test.ts tests/unit/quota-sqlite-store.test.ts tests/unit/advanced-fase07-09.test.ts
# tests 59
# pass 59
# fail 0
```

```text
$ node scripts/check/check-dead-code.mjs --quiet
DEAD_EXPORTS=246
DEAD_FILES=94
DEAD_TOTAL=340
[dead-code] OK — 340 símbolos mortos (baseline 346)
```

```text
$ GITHUB_BASE_REF=main GITHUB_BASE_SHA=upstream/main node scripts/check/check-pr-test-policy.mjs
Changed production files: 5
Changed automated test files: 5
Result: PASS
```

```text
$ git push --force-with-lease origin dev/dead-code-utility-cleanup-3
[t11:any-budget] PASS - explicit any budget respected.
[tracked-artifacts] OK — no forbidden artifacts tracked by git
```
