### PR TITLE
chore: remove unused domain helper exports

### DIFF
--- a/src/lib/combos/builderDraft.ts
+++ b/src/lib/combos/builderDraft.ts
@@ -49,13 +49,6 @@ export function parseQualifiedModel(
   };
 }
 
-export function getComboDraftTarget(entry: unknown): string | null {
-  if (typeof entry === "string") return toTrimmedString(entry);
-  if (!isRecord(entry)) return null;
-  if (entry.kind === "combo-ref") return toTrimmedString(entry.comboName);
-  return toTrimmedString(entry.model);
-}
-
 export function buildPrecisionComboModelStep({
   providerId,
   modelId,

--- a/src/lib/combos/steps.ts
+++ b/src/lib/combos/steps.ts
@@ -142,14 +142,6 @@ function shouldTreatAsComboRef(
   return comboNames.has(target) || target === toTrimmedString(options.comboName);
 }
 
-export function isComboRefStep(value: unknown): value is ComboRefStep {
-  return isRecord(value) && value.kind === "combo-ref" && !!toTrimmedString(value.comboName);
-}
-
-export function isComboModelStep(value: unknown): value is ComboModelStep {
-  return isRecord(value) && value.kind === "model" && !!toTrimmedString(value.model);
-}
-
 export function getComboStepWeight(value: unknown): number {
   if (typeof value === "string") return 0;
   if (!isRecord(value)) return 0;

--- a/src/lib/providers/catalog.ts
+++ b/src/lib/providers/catalog.ts
@@ -173,16 +173,6 @@ export function getStaticProviderCatalogGroup(
   return STATIC_PROVIDER_CATALOG_GROUPS[category];
 }
 
-export function getStaticProviderCategories(providerId: string): StaticProviderCatalogCategory[] {
-  const categories: StaticProviderCatalogCategory[] = [];
-  for (const category of STATIC_PROVIDER_CATALOG_RESOLUTION_ORDER) {
-    if (STATIC_PROVIDER_CATALOG_GROUPS[category].providers[providerId]) {
-      categories.push(category);
-    }
-  }
-  return categories;
-}
-
 export function resolveStaticProviderCatalogEntry(
   providerId: string
 ): ResolvedStaticProviderCatalogEntry | null {

--- a/tests/unit/combo-builder-draft.test.ts
+++ b/tests/unit/combo-builder-draft.test.ts
@@ -3,6 +3,12 @@ import assert from "node:assert/strict";
 
 const builderDraft = await import("../../src/lib/combos/builderDraft.ts");
 
+test("combo builder draft public surface excludes removed target accessor", () => {
+  assert.equal(Object.hasOwn(builderDraft, "getComboDraftTarget"), false);
+  assert.equal(typeof builderDraft.buildPrecisionComboModelStep, "function");
+  assert.equal(typeof builderDraft.buildManualComboModelStep, "function");
+});
+
 test("parseQualifiedModel keeps provider prefix and the full tail model id", () => {
   assert.deepEqual(builderDraft.parseQualifiedModel("openrouter/openai/gpt-5.4"), {
     providerId: "openrouter",

--- a/tests/unit/combo-custom-provider-resolution.test.ts
+++ b/tests/unit/combo-custom-provider-resolution.test.ts
@@ -29,6 +29,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import * as comboSteps from "../../src/lib/combos/steps.ts";
 import { getComboModelString } from "../../src/lib/combos/steps.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -37,6 +38,13 @@ const MODEL_SERVICE_SRC = path.resolve(__dirname, "../../src/sse/services/model.
 // ── 1. Reproduce the exact model string from the bug screenshot ───────────────
 
 const FAKE_UUID_NODE_ID = "openai-compatible-responses-d302c75f-f133-48d3-afa1-066e594e0d29";
+
+test("combo step public surface excludes removed type-guard helpers", () => {
+  assert.equal(Object.hasOwn(comboSteps, "isComboRefStep"), false);
+  assert.equal(Object.hasOwn(comboSteps, "isComboModelStep"), false);
+  assert.equal(typeof comboSteps.getComboModelString, "function");
+  assert.equal(typeof comboSteps.getComboStepWeight, "function");
+});
 
 test("#2778 getComboModelString with UUID-prefixed providerId assembles the UUID-prefixed model string", () => {
   // This is what a combo step looks like when the UI stores the internal node id as
@@ -151,7 +159,10 @@ test("#2778 matching logic: node with prefix=flymux and id=UUID-id still matches
 });
 
 test("custom provider auth lookup search pool maps alias prefixes to internal provider ids", async () => {
-  const authSrc = fs.readFileSync(path.resolve(__dirname, "../../src/sse/services/auth.ts"), "utf8");
+  const authSrc = fs.readFileSync(
+    path.resolve(__dirname, "../../src/sse/services/auth.ts"),
+    "utf8"
+  );
 
   assert.match(
     authSrc,

--- a/tests/unit/providers-free-tier-filter.test.ts
+++ b/tests/unit/providers-free-tier-filter.test.ts
@@ -6,6 +6,7 @@ import {
   type ProviderCatalogMetadata,
   type StaticProviderCatalogCategory,
 } from "@/lib/providers/catalog";
+import * as providerCatalog from "@/lib/providers/catalog";
 
 const CATALOG_CATEGORIES = [
   "no-auth",
@@ -88,6 +89,12 @@ function countByCategory(entries: ProviderFilterEntry[]) {
     cloudAgent: filterByCategory(entries, "cloud-agent").length,
   };
 }
+
+test("provider catalog public surface excludes removed categories helper", () => {
+  assert.equal(Object.hasOwn(providerCatalog, "getStaticProviderCategories"), false);
+  assert.equal(typeof providerCatalog.getStaticProviderCatalogGroup, "function");
+  assert.equal(typeof providerCatalog.resolveStaticProviderCatalogEntry, "function");
+});
 
 test('filterByCategory("free") returns every hasFree provider across native categories', () => {
   const entries = buildCatalogEntries();


### PR DESCRIPTION
## Summary

- Removed unused combo helper exports: `isComboRefStep`, `isComboModelStep`, and `getComboDraftTarget`.
- Removed unused `getStaticProviderCategories` while keeping the catalog group and entry-resolution helpers used by UI/tests.
- Added public-surface regression assertions for the touched combo/provider modules so the production cleanup satisfies the PR Test Policy.
- Left `config/quality/quality-baseline.json` unchanged versus `upstream/main`; the dead-code ratchet update is intentionally deferred to the final baseline PR.

## Validation

```text
$ node --import tsx/esm --test tests/unit/combo-builder-draft.test.ts tests/unit/combo-custom-provider-resolution.test.ts tests/unit/providers-free-tier-filter.test.ts tests/unit/bazaarlink-provider-integrity.test.ts tests/unit/autocombo-unification.test.ts tests/integration/combo-matrix/cost-and-context.test.ts
# tests 38
# pass 38
# fail 0
```

```text
$ node scripts/check/check-dead-code.mjs --quiet
DEAD_EXPORTS=247
DEAD_FILES=94
DEAD_TOTAL=341
[dead-code] OK — 341 símbolos mortos (baseline 346)
```

```text
$ GITHUB_BASE_REF=main GITHUB_BASE_SHA=upstream/main node scripts/check/check-pr-test-policy.mjs
Changed production files: 3
Changed automated test files: 3
Result: PASS
```

```text
$ git push --force-with-lease origin dev/dead-code-domain-helper-cleanup-4
[t11:any-budget] PASS - explicit any budget respected.
[tracked-artifacts] OK — no forbidden artifacts tracked by git
```

## Note

The combo integration test logged a non-fatal compression warning because this checkout is missing the optional workspace dependency `safe-regex`; the tested combo/provider assertions passed.
