### PR TITLE
chore: remove unused static constant exports

### DIFF
--- a/src/shared/constants/colors.ts
+++ b/src/shared/constants/colors.ts
@@ -129,21 +129,6 @@ export function getProxyStatusStyle(status) {
 }
 
 /**
- * Get default fallback for a provider color lookup.
- * @param {string} provider - Provider key
- * @returns {{ bg: string, text: string, label: string }}
- */
-export function getProviderColor(provider) {
-  return (
-    PROVIDER_COLORS[provider] || {
-      bg: "#374151",
-      text: "#fff",
-      label: (provider || "-").toUpperCase(),
-    }
-  );
-}
-
-/**
  * Get default fallback for a protocol color lookup.
  * @param {string} protocol - Protocol key
  * @param {string} fallbackProvider - Provider key to use as a secondary protocol key

--- a/src/shared/constants/config.ts
+++ b/src/shared/constants/config.ts
@@ -1,21 +1,5 @@
 export { APP_CONFIG, THEME_CONFIG } from "./appConfig";
 
-// Subscription
-export const SUBSCRIPTION_CONFIG = {
-  price: 1.0,
-  currency: "USD",
-  interval: "month",
-  planName: "Pro Plan",
-};
-
-// API endpoints
-export const API_ENDPOINTS = {
-  users: "/api/users",
-  providers: "/api/providers",
-  payments: "/api/payments",
-  auth: "/api/auth",
-};
-
 // Provider API endpoints (for display only)
 export const PROVIDER_ENDPOINTS = {
   agentrouter: "https://agentrouter.org/v1/chat/completions",

--- a/src/shared/constants/pricing.ts
+++ b/src/shared/constants/pricing.ts
@@ -8,14 +8,6 @@ export { DEFAULT_PRICING } from "./pricing/default-pricing";
 // Shared pricing constants to reduce duplication
 
 type ProviderPricingTable = Record<string, Record<string, unknown>>;
-type PricingRow = {
-  input: number;
-  output: number;
-  cached?: number;
-  reasoning?: number;
-  cache_creation?: number;
-};
-type TokenUsage = Record<string, number | undefined>;
 
 /**
  * Get pricing for a specific provider and model
@@ -46,51 +38,3 @@ export function getDefaultPricing() {
 }
 
 export { formatCost } from "../utils/formatting";
-
-/**
- * Calculate cost from tokens and pricing
- * @param {object} tokens - Token counts
- * @param {object} pricing - Pricing object
- * @returns {number} Cost in dollars
- */
-export function calculateCostFromTokens(
-  tokens: TokenUsage | null | undefined,
-  pricing: PricingRow | null | undefined
-): number {
-  if (!tokens || !pricing) return 0;
-
-  let cost = 0;
-
-  // Input tokens (non-cached)
-  const inputTokens = tokens.prompt_tokens || tokens.input_tokens || 0;
-  const cachedTokens = tokens.cached_tokens || tokens.cache_read_input_tokens || 0;
-  const nonCachedInput = Math.max(0, inputTokens - cachedTokens);
-
-  cost += nonCachedInput * (pricing.input / 1000000);
-
-  // Cached tokens
-  if (cachedTokens > 0) {
-    const cachedRate = pricing.cached || pricing.input; // Fallback to input rate
-    cost += cachedTokens * (cachedRate / 1000000);
-  }
-
-  // Output tokens
-  const outputTokens = tokens.completion_tokens || tokens.output_tokens || 0;
-  cost += outputTokens * (pricing.output / 1000000);
-
-  // Reasoning tokens
-  const reasoningTokens = tokens.reasoning_tokens || 0;
-  if (reasoningTokens > 0) {
-    const reasoningRate = pricing.reasoning || pricing.output; // Fallback to output rate
-    cost += reasoningTokens * (reasoningRate / 1000000);
-  }
-
-  // Cache creation tokens
-  const cacheCreationTokens = tokens.cache_creation_input_tokens || 0;
-  if (cacheCreationTokens > 0) {
-    const cacheCreationRate = pricing.cache_creation || pricing.input; // Fallback to input rate
-    cost += cacheCreationTokens * (cacheCreationRate / 1000000);
-  }
-
-  return cost;
-}

--- a/tests/unit/pricing-constants-split.test.ts
+++ b/tests/unit/pricing-constants-split.test.ts
@@ -1,21 +1,17 @@
 // Characterization of the pricing.ts split (god-file decomposition): the host became a barrel that
 // re-exports DEFAULT_PRICING (now merged from 4 semantic family files that import shared tier consts)
-// and keeps the 3 helper functions. Pure-data move → behavior identical. Locks: public surface, the
+// and keeps the helper functions. Pure-data move → behavior identical. Locks: public surface, the
 // spread-merge integrity, and that lookups/cost math resolve unchanged.
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
 const P = await import("../../src/shared/constants/pricing.ts");
 
-test("barrel still exports DEFAULT_PRICING + the 3 helpers", () => {
-  for (const name of [
-    "DEFAULT_PRICING",
-    "getPricingForModel",
-    "getDefaultPricing",
-    "calculateCostFromTokens",
-  ]) {
+test("barrel still exports DEFAULT_PRICING + supported helpers", () => {
+  for (const name of ["DEFAULT_PRICING", "getPricingForModel", "getDefaultPricing"]) {
     assert.ok(name in P, `missing export: ${name}`);
   }
+  assert.equal(Object.hasOwn(P, "calculateCostFromTokens"), false);
 });
 
 test("DEFAULT_PRICING merges the 4 family files; families partition all entries", async () => {
@@ -49,8 +45,7 @@ test("shared tier consts feed the parts (a known model resolves to a shared rate
   assert.equal(typeof (pricing as { input?: number }).input, "number");
 });
 
-test("calculateCostFromTokens stays callable and numeric", () => {
-  const fn = (P as Record<string, (...a: unknown[]) => unknown>).calculateCostFromTokens;
-  const out = fn("openai", "gpt-4o", { prompt_tokens: 1000, completion_tokens: 1000 });
-  assert.equal(typeof out, "number");
+test("formatCost remains re-exported from the pricing barrel", () => {
+  const fn = (P as Record<string, (value: number) => string>).formatCost;
+  assert.equal(fn(0.0123), "$0.0123");
 });

--- a/tests/unit/static-constants-public-surface.test.ts
+++ b/tests/unit/static-constants-public-surface.test.ts
@@ -1,0 +1,27 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const config = await import("../../src/shared/constants/config.ts");
+const colors = await import("../../src/shared/constants/colors.ts");
+const pricing = await import("../../src/shared/constants/pricing.ts");
+
+test("config constants public surface excludes removed app endpoint placeholders", () => {
+  assert.equal(Object.hasOwn(config, "SUBSCRIPTION_CONFIG"), false);
+  assert.equal(Object.hasOwn(config, "API_ENDPOINTS"), false);
+  assert.ok(config.PROVIDER_ENDPOINTS.openai);
+  assert.ok(config.APP_CONFIG.name);
+});
+
+test("colors public surface excludes removed provider-color wrapper", () => {
+  assert.equal(Object.hasOwn(colors, "getProviderColor"), false);
+  assert.ok(colors.PROVIDER_COLORS.codex);
+  assert.equal(colors.getProtocolColor("openai-chat", "openai").label, "OpenAI-Chat");
+  assert.equal(colors.getProxyStatusStyle("success").bg, "#059669");
+});
+
+test("pricing public surface excludes removed token-cost helper", () => {
+  assert.equal(Object.hasOwn(pricing, "calculateCostFromTokens"), false);
+  assert.equal(typeof pricing.getPricingForModel, "function");
+  assert.equal(typeof pricing.getDefaultPricing, "function");
+  assert.equal(typeof pricing.formatCost, "function");
+});


### PR DESCRIPTION
## Summary

- Removed unused static app endpoint placeholders: `SUBSCRIPTION_CONFIG` and `API_ENDPOINTS` from `src/shared/constants/config.ts`.
- Removed the unused pricing helper export `calculateCostFromTokens`; active cost calculation uses the backend cost calculator path.
- Removed the unused `getProviderColor` wrapper while keeping the shared color maps and status/protocol helpers.
- Added/updated unit coverage for the supported public surfaces of config, pricing, and color constants.
- Left `config/quality/quality-baseline.json` unchanged; the dead-code ratchet update is deferred to the final baseline PR.

## Validation

```text
$ node --import tsx/esm --test tests/unit/pricing-constants-split.test.ts tests/unit/static-constants-public-surface.test.ts tests/unit/dgrid-provider.test.ts tests/unit/zenmux-provider.test.ts tests/unit/crof-provider.test.ts tests/unit/openai-style-providers-4239-4155-3841.test.ts
# tests 41
# pass 41
# fail 0
```

```text
$ node scripts/check/check-dead-code.mjs --quiet
DEAD_EXPORTS=247
DEAD_FILES=94
DEAD_TOTAL=341
[dead-code] OK — 341 símbolos mortos (baseline 346)
```

```text
$ GITHUB_BASE_REF=main GITHUB_BASE_SHA=upstream/main node scripts/check/check-pr-test-policy.mjs
Changed production files: 3
Changed automated test files: 2
Result: PASS
```

```text
$ git push -u origin dev/dead-code-static-data-cleanup-5
[t11:any-budget] PASS - explicit any budget respected.
[tracked-artifacts] OK — no forbidden artifacts tracked by git
```
