### PR TITLE
chore: remove unused formatting helper exports

### DIFF
--- a/src/shared/utils/formatting.ts
+++ b/src/shared/utils/formatting.ts
@@ -39,21 +39,6 @@ export function formatDuration(ms: number | null | undefined) {
 }
 
 /**
- * Format an ISO date to a full date+time string (pt-BR locale).
- * @param {string} iso - ISO 8601 date string
- * @returns {string}
- */
-export function formatDateTime(iso: string | null | undefined) {
-  try {
-    if (!iso) return "-";
-    const d = new Date(iso);
-    return d.toLocaleDateString("pt-BR") + ", " + d.toLocaleTimeString("en-US", { hour12: false });
-  } catch {
-    return iso;
-  }
-}
-
-/**
  * Mask a string by showing only start and end characters.
  * @param {string} value - Value to mask
  * @param {number} start - Number of characters to show at start (default: 2)
@@ -112,16 +97,6 @@ export function formatApiKeyLabel(
 }
 
 /**
- * Mask a sensitive key for log output.
- * @param {string} key - API key or token to mask
- * @returns {string}
- */
-export function maskKey(key: string | null | undefined) {
-  if (!key || key.length < 8) return "***";
-  return `${key.slice(0, 4)}...${key.slice(-4)}`;
-}
-
-/**
  * Format large numbers with K/M/B suffixes.
  * @param {number} n - Number to format
  * @returns {string}
@@ -157,55 +132,6 @@ export function formatCost(usd: number | null | undefined): string {
 }
 
 export const fmtCost = formatCost;
-
-/**
- * Format a USD cost for display using abbreviated K/M/B/T suffixes.
- * Sub-cent values show additional precision.
- *   - Values >= 1T are shown as $X.XT
- *   - Values >= 1B are shown as $X.XB
- *   - Values >= 1M are shown as $X.XM
- *   - Values >= 1K are shown as $X.XK
- *   - Otherwise shown as $X.XX
- * @param {number} usd - Cost in USD
- * @returns {string}
- */
-export function formatCostAbbreviated(usd: number | null | undefined): string {
-  const value = Number(usd || 0);
-  if (!Number.isFinite(value) || value === 0) return "$0";
-  const abs = Math.abs(value);
-  if (abs < 0.01) {
-    if (value < 0) {
-      return `-$${Math.abs(value).toFixed(6)}`;
-    }
-    return `$${value.toFixed(6)}`;
-  }
-  let divisor: number, suffix: string;
-  if (abs >= 1_000_000_000_000) {
-    divisor = 1_000_000_000_000;
-    suffix = "T";
-  } else if (abs >= 1_000_000_000) {
-    divisor = 1_000_000_000;
-    suffix = "B";
-  } else if (abs >= 1_000_000) {
-    divisor = 1_000_000;
-    suffix = "M";
-  } else if (abs >= 1_000) {
-    divisor = 1_000;
-    suffix = "K";
-  } else {
-    if (value < 0) {
-      return `-$${Math.abs(value).toFixed(2)}`;
-    }
-    return `$${value.toFixed(2)}`;
-  }
-  const abbreviated = abs / divisor;
-  let formatted = abbreviated.toFixed(1);
-  if (formatted.includes(".")) {
-    formatted = formatted.replace(/\.?0+$/, "");
-  }
-  const sign = value < 0 ? "-" : "";
-  return `${sign}$${formatted}${suffix}`;
-}
 
 /**
  * Truncate a URL for compact display.

--- a/src/sse/utils/logger.ts
+++ b/src/sse/utils/logger.ts
@@ -40,9 +40,6 @@ export function stream(event: string, data?: unknown) {
   log.debug({ tag: "STREAM", event, ...spreadData(data) }, `🌊 ${event}`);
 }
 
-// Mask sensitive data (kept for backward compat; prefer shared maskKey)
-export { maskKey } from "@/shared/utils/formatting";
-
 // Helper to spread data into structured fields
 function spreadData(data: unknown): Record<string, unknown> {
   if (!data) return {};

--- a/tests/unit/formatting-public-surface.test.ts
+++ b/tests/unit/formatting-public-surface.test.ts
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const formatting = await import("../../src/shared/utils/formatting.ts");
+const sseLogger = await import("../../src/sse/utils/logger.ts");
+
+test("formatting utilities public surface excludes removed display helpers", () => {
+  assert.equal(Object.hasOwn(formatting, "formatDateTime"), false);
+  assert.equal(Object.hasOwn(formatting, "maskKey"), false);
+  assert.equal(Object.hasOwn(formatting, "formatCostAbbreviated"), false);
+
+  assert.equal(formatting.formatTime("2026-06-29T12:34:56Z").length, 8);
+  assert.equal(formatting.formatDuration(1250), "1.3s");
+  assert.equal(formatting.maskSegment("abcdef", 2, 2), "ab***ef");
+  assert.equal(formatting.formatCost(0.0123), "$0.0123");
+});
+
+test("sse logger wrapper no longer re-exports formatting maskKey", () => {
+  assert.equal(Object.hasOwn(sseLogger, "maskKey"), false);
+  assert.equal(typeof sseLogger.debug, "function");
+  assert.equal(typeof sseLogger.warn, "function");
+});


### PR DESCRIPTION
## Summary

- Removed unused shared formatting exports: `formatDateTime`, `maskKey`, and `formatCostAbbreviated`.
- Removed the stale `maskKey` re-export from the `src/sse/utils/logger.ts` wrapper; the open-sse logger keeps its own logger-specific `maskKey` helper.
- Added a focused public-surface unit test for the supported formatting helpers and SSE logger wrapper.
- Left `config/quality/quality-baseline.json` unchanged; the dead-code ratchet update is deferred to the final baseline PR.

## Validation

```text
$ node --import tsx/esm --test tests/unit/formatting-public-surface.test.ts tests/unit/sse-shim-contract.test.ts tests/unit/pricing-constants-split.test.ts
# tests 9
# pass 9
# fail 0
```

```text
$ node scripts/check/check-dead-code.mjs --quiet
DEAD_EXPORTS=248
DEAD_FILES=94
DEAD_TOTAL=342
[dead-code] OK — 342 símbolos mortos (baseline 346)
```

```text
$ GITHUB_BASE_REF=main GITHUB_BASE_SHA=upstream/main node scripts/check/check-pr-test-policy.mjs
Changed production files: 2
Changed automated test files: 1
Result: PASS
```

```text
$ git push -u origin dev/dead-code-formatting-cleanup-6
[t11:any-budget] PASS - explicit any budget respected.
[tracked-artifacts] OK — no forbidden artifacts tracked by git
```
