### PR TITLE
chore: remove unused runtime test helper exports

### DIFF
--- a/src/lib/config/runtimeSettings.ts
+++ b/src/lib/config/runtimeSettings.ts
@@ -477,7 +477,9 @@ export async function applyRuntimeSettings(
 
   if (force || hasChanged(currentSnapshot.usageTokenBuffer, previousSnapshot.usageTokenBuffer)) {
     const newBuffer =
-      typeof currentSnapshot.usageTokenBuffer === "number" ? currentSnapshot.usageTokenBuffer : null;
+      typeof currentSnapshot.usageTokenBuffer === "number"
+        ? currentSnapshot.usageTokenBuffer
+        : null;
     await applyUsageTrackingSection(newBuffer);
     markChanged("usageTracking");
   }
@@ -531,17 +533,16 @@ export async function applyRuntimeSettings(
     markChanged("authzBypass");
   }
 
-  if (force || hasChanged(currentSnapshot.customBannedSignals, previousSnapshot.customBannedSignals)) {
+  if (
+    force ||
+    hasChanged(currentSnapshot.customBannedSignals, previousSnapshot.customBannedSignals)
+  ) {
     setCustomBannedSignals(currentSnapshot.customBannedSignals);
     markChanged("bannedSignals");
   }
 
   lastAppliedSnapshot = currentSnapshot;
   return changes;
-}
-
-export function getLastAppliedRuntimeSettingsSnapshotForTests() {
-  return lastAppliedSnapshot;
 }
 
 export function resetRuntimeSettingsStateForTests() {

--- a/src/shared/services/loginShellPath.ts
+++ b/src/shared/services/loginShellPath.ts
@@ -85,8 +85,3 @@ export function getCachedLoginShellPath(): string | null {
   if (cached === undefined) cached = getLoginShellPath();
   return cached;
 }
-
-/** Test-only: clear the module-level cache so a test can re-stub the runner. */
-export function __resetLoginShellPathCacheForTesting(value?: string | null): void {
-  cached = value;
-}

--- a/tests/unit/config-hot-reload.test.ts
+++ b/tests/unit/config-hot-reload.test.ts
@@ -11,8 +11,8 @@ process.env.OMNIROUTE_CONFIG_HOT_RELOAD_MS = "100";
 const core = await import("../../src/lib/db/core.ts");
 const settingsDb = await import("../../src/lib/db/settings.ts");
 const { getDbInstance } = core;
-const { applyRuntimeSettings, resetRuntimeSettingsStateForTests } =
-  await import("../../src/lib/config/runtimeSettings.ts");
+const runtimeSettings = await import("../../src/lib/config/runtimeSettings.ts");
+const { applyRuntimeSettings, resetRuntimeSettingsStateForTests } = runtimeSettings;
 const { startRuntimeConfigHotReload, stopRuntimeConfigHotReloadForTests } =
   await import("../../src/lib/config/hotReload.ts");
 const { getCliCompatProviders } = await import("../../open-sse/config/cliFingerprints.ts");
@@ -64,6 +64,16 @@ test.beforeEach(async () => {
 
 test.after(async () => {
   await resetStorage();
+});
+
+test("runtime settings public surface excludes removed snapshot inspection helper", () => {
+  assert.equal(
+    Object.hasOwn(runtimeSettings, "getLastAppliedRuntimeSettingsSnapshotForTests"),
+    false
+  );
+  assert.equal(typeof runtimeSettings.applyRuntimeSettings, "function");
+  assert.equal(typeof runtimeSettings.getAuthzBypassSnapshot, "function");
+  assert.equal(typeof runtimeSettings.resetRuntimeSettingsStateForTests, "function");
 });
 
 test("updateSettings applies runtime settings incrementally without restart", async () => {

--- a/tests/unit/login-shell-path-3321.test.ts
+++ b/tests/unit/login-shell-path-3321.test.ts
@@ -1,15 +1,23 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
+  getCachedLoginShellPath,
   getLoginShellPath,
   mergeShellPath,
   parseShellPathOutput,
 } from "../../src/shared/services/loginShellPath.ts";
+import * as loginShellPath from "../../src/shared/services/loginShellPath.ts";
 
 // Regression guards for #3321: macOS GUI/Electron apps don't inherit the login-shell PATH,
 // so Homebrew/nvm/volta CLIs were reported "not installed". We recover the real PATH from
 // the login shell and merge it into the lookup env. The pure helpers are tested here with
 // an injected shell runner (no macOS / no real shell needed).
+
+test("login shell path public surface excludes removed cache reset helper", () => {
+  assert.equal(Object.hasOwn(loginShellPath, "__resetLoginShellPathCacheForTesting"), false);
+  assert.equal(typeof getCachedLoginShellPath, "function");
+  assert.equal(typeof getLoginShellPath, "function");
+});
 
 test("mergeShellPath unions and de-dupes, keeping base entries first", () => {
   assert.equal(


### PR DESCRIPTION
## Summary

- Removed the unused `getLastAppliedRuntimeSettingsSnapshotForTests` runtime-settings export.
- Removed the unused `__resetLoginShellPathCacheForTesting` login-shell path cache reset export.
- Updated the nearby runtime hot-reload and login-shell path tests to lock the supported public surfaces.
- Left `config/quality/quality-baseline.json` unchanged; the dead-code ratchet update is deferred to the final baseline PR.

## Validation

```text
$ node --import tsx/esm --test tests/unit/login-shell-path-3321.test.ts tests/unit/config-hot-reload.test.ts
# tests 12
# pass 12
# fail 0
```

```text
$ node scripts/check/check-dead-code.mjs --quiet
DEAD_EXPORTS=249
DEAD_FILES=94
DEAD_TOTAL=343
[dead-code] OK — 343 símbolos mortos (baseline 346)
```

```text
$ GITHUB_BASE_REF=main GITHUB_BASE_SHA=upstream/main node scripts/check/check-pr-test-policy.mjs
Changed production files: 2
Changed automated test files: 2
Result: PASS
```

```text
$ git push -u origin dev/dead-code-runtime-test-helper-cleanup-7
[t11:any-budget] PASS - explicit any budget respected.
[tracked-artifacts] OK — no forbidden artifacts tracked by git
```
