### PR TITLE
chore: remove unused request timeout fetch wrapper

### DIFF
--- a/src/shared/utils/requestTimeout.ts
+++ b/src/shared/utils/requestTimeout.ts
@@ -7,46 +7,6 @@
  * @module shared/utils/requestTimeout
  */
 
-interface TimeoutOptions {
-  timeoutMs?: number;
-  label?: string;
-  signal?: AbortSignal;
-}
-
-export async function fetchWithTimeout(url: string, options: RequestInit & TimeoutOptions = {}) {
-  const { timeoutMs = 30000, label = "Request", signal: externalSignal, ...fetchOptions } = options;
-
-  const controller = new AbortController();
-
-  // Merge with external signal if provided
-  if (externalSignal) {
-    externalSignal.addEventListener("abort", () => controller.abort(externalSignal.reason));
-  }
-
-  const timeoutId = setTimeout(() => {
-    controller.abort(new Error(`${label} timed out after ${timeoutMs}ms`));
-  }, timeoutMs);
-
-  try {
-    const response = await fetch(url, {
-      ...fetchOptions,
-      signal: controller.signal,
-    });
-    return response;
-  } catch (error: any) {
-    if (error.name === "AbortError" || controller.signal.aborted) {
-      const timeoutError: any = new Error(`${label} timed out after ${timeoutMs}ms`);
-      timeoutError.name = "TimeoutError";
-      timeoutError.originalUrl = url;
-      timeoutError.timeoutMs = timeoutMs;
-      throw timeoutError;
-    }
-    throw error;
-  } finally {
-    clearTimeout(timeoutId);
-  }
-}
-
 /**
  * Execute any async function with a timeout.
  *

--- a/tests/unit/observability-fase04.test.ts
+++ b/tests/unit/observability-fase04.test.ts
@@ -136,7 +136,14 @@ test("CircuitBreaker: calls onStateChange callback", async () => {
 
 // ─── Request Timeout Tests ───────────────────────────
 
+import * as requestTimeout from "../../src/shared/utils/requestTimeout.ts";
 import { withTimeout, getProviderTimeout } from "../../src/shared/utils/requestTimeout.ts";
+
+test("requestTimeout: public surface excludes removed fetch wrapper", () => {
+  assert.equal(Object.hasOwn(requestTimeout, "fetchWithTimeout"), false);
+  assert.equal(typeof requestTimeout.withTimeout, "function");
+  assert.equal(typeof requestTimeout.getProviderTimeout, "function");
+});
 
 test("requestTimeout: withTimeout resolves before timeout", async () => {
   const result = await withTimeout(async () => "fast", 1000, "test");


### PR DESCRIPTION
## Summary

- Removed the unused `fetchWithTimeout` export from the older `src/shared/utils/requestTimeout.ts` utility.
- Kept the actively used `withTimeout`, `PROVIDER_TIMEOUTS`, and `getProviderTimeout` helpers intact.
- Added a public-surface assertion to the existing observability unit test.
- Left `config/quality/quality-baseline.json` unchanged; the dead-code ratchet update is deferred to the final baseline PR.

## Validation

```text
$ node --import tsx/esm --test tests/unit/observability-fase04.test.ts
# tests 17
# pass 17
# fail 0
```

```text
$ node scripts/check/check-dead-code.mjs --quiet
DEAD_EXPORTS=250
DEAD_FILES=94
DEAD_TOTAL=344
[dead-code] OK — 344 símbolos mortos (baseline 346)
```

```text
$ GITHUB_BASE_REF=main GITHUB_BASE_SHA=upstream/main node scripts/check/check-pr-test-policy.mjs
Changed production files: 1
Changed automated test files: 1
Result: PASS
```

```text
$ git push -u origin dev/dead-code-request-timeout-cleanup-8
[t11:any-budget] PASS - explicit any budget respected.
[tracked-artifacts] OK — no forbidden artifacts tracked by git
```
