### PR TITLE
chore: remove unused semantic cache maintenance exports

### DIFF
--- a/src/lib/semanticCache.ts
+++ b/src/lib/semanticCache.ts
@@ -116,7 +116,13 @@ function getMemoryCache() {
  * @param {string} [apiKeyId] - API key ID for per-key isolation (prevents cross-user cache hits)
  * @returns {string} hex signature
  */
-export function generateSignature(model, conversation, temperature = 0, topP = 1, apiKeyId?: string) {
+export function generateSignature(
+  model,
+  conversation,
+  temperature = 0,
+  topP = 1,
+  apiKeyId?: string
+) {
   const payload = JSON.stringify({
     model,
     messages: normalizeConversation(conversation),
@@ -308,48 +314,6 @@ export function invalidateStale(maxAgeMs: number): number {
   try {
     const db = getDbInstance();
     const cutoff = new Date(Date.now() - maxAgeMs).toISOString();
-    const result = db.prepare("DELETE FROM semantic_cache WHERE created_at < ?").run(cutoff);
-    return result.changes || 0;
-  } catch {
-    return 0;
-  }
-}
-
-// ── Auto-cleanup timer ──
-
-let _cleanupTimer: ReturnType<typeof setInterval> | null = null;
-
-/**
- * Start periodic auto-cleanup of expired entries.
- * @param {number} intervalMs - Cleanup interval (default: 5 minutes)
- */
-export function startAutoCleanup(intervalMs = 300_000): void {
-  stopAutoCleanup();
-  _cleanupTimer = setInterval(() => {
-    const removed = cleanExpiredEntries();
-    if (removed > 0) {
-      console.log(`[SemanticCache] Auto-cleaned ${removed} expired entries`);
-    }
-  }, intervalMs);
-  if (_cleanupTimer && typeof _cleanupTimer === "object" && "unref" in _cleanupTimer) {
-    (_cleanupTimer as { unref?: () => void }).unref?.();
-  }
-}
-
-/**
- * Stop periodic auto-cleanup.
- */
-export function stopAutoCleanup(): void {
-  if (_cleanupTimer) {
-    clearInterval(_cleanupTimer);
-    _cleanupTimer = null;
-  }
-}
-
-export function cleanOldMetrics(retentionDays = 90): number {
-  try {
-    const db = getDbInstance();
-    const cutoff = new Date(Date.now() - retentionDays * 86400000).toISOString();
     const result = db.prepare("DELETE FROM semantic_cache WHERE created_at < ?").run(cutoff);
     return result.changes || 0;
   } catch {

--- a/tests/unit/semantic-cache.test.ts
+++ b/tests/unit/semantic-cache.test.ts
@@ -6,7 +6,15 @@ import {
   isCacheableForWrite,
 } from "../../src/lib/semanticCache.ts";
 
+const semanticCachePublicApi = await import("../../src/lib/semanticCache.ts");
+
 describe("Semantic Cache", () => {
+  it("public surface excludes unused maintenance timer helpers", () => {
+    assert.equal("startAutoCleanup" in semanticCachePublicApi, false);
+    assert.equal("stopAutoCleanup" in semanticCachePublicApi, false);
+    assert.equal("cleanOldMetrics" in semanticCachePublicApi, false);
+  });
+
   describe("generateSignature", () => {
     it("generates consistent signatures for same inputs", () => {
       const messages = [{ role: "user", content: "hello" }];
@@ -77,7 +85,11 @@ describe("Semantic Cache", () => {
       const messages = [{ role: "user", content: "what is 2+2?" }];
       const sigKeyA = generateSignature("gpt-4o", messages, 0, 1, "key-id-alice");
       const sigKeyB = generateSignature("gpt-4o", messages, 0, 1, "key-id-bob");
-      assert.notEqual(sigKeyA, sigKeyB, "different API keys must produce different cache signatures");
+      assert.notEqual(
+        sigKeyA,
+        sigKeyB,
+        "different API keys must produce different cache signatures"
+      );
     });
 
     it("generates consistent signatures for same API key ID (#3740)", () => {


### PR DESCRIPTION
## Summary

- Removed unused semantic-cache maintenance exports: `startAutoCleanup`, `stopAutoCleanup`, and `cleanOldMetrics`.
- Kept the active cache read/write, invalidation, expiration cleanup, clear, and stats APIs intact.
- Added a public-surface assertion to the semantic-cache unit test.
- Left `config/quality/quality-baseline.json` unchanged; the dead-code ratchet update is deferred to the final baseline PR.

## Validation

```text
$ node --import tsx/esm --test tests/unit/semantic-cache.test.ts
# tests 22
# pass 22
# fail 0
```

```text
$ node scripts/check/check-dead-code.mjs --quiet
DEAD_EXPORTS=250
DEAD_FILES=94
DEAD_TOTAL=344
[dead-code] OK — 344 símbolos mortos (baseline 346)
```

```text
$ GITHUB_BASE_REF=release/v3.8.41 GITHUB_BASE_SHA=upstream/release/v3.8.41 node scripts/check/check-pr-test-policy.mjs
Changed production files: 1
Changed automated test files: 1
Result: PASS
```

```text
$ git commit -m "chore: remove unused semantic cache maintenance exports"
[docs-sync] PASS - documentation version sync is consistent.
[t11:any-budget] PASS - explicit any budget respected.
[tracked-artifacts] OK — no forbidden artifacts tracked by git
```

```text
$ git push -u origin dev/dead-code-scheduler-cleanup-10
[t11:any-budget] PASS - explicit any budget respected.
[tracked-artifacts] OK — no forbidden artifacts tracked by git
```