### PR TITLE
chore: remove unused event bus exports

### DIFF
--- a/src/lib/events/eventBus.ts
+++ b/src/lib/events/eventBus.ts
@@ -138,53 +138,6 @@ export function onAny(listener: (event: DashboardEventName, payload: unknown) =>
 }
 
 /**
- * Remove a specific listener.
- */
-export function off<E extends DashboardEventName>(
-  event: E,
-  listener: DashboardEventListener<E>
-): void {
-  getBusState()
-    .listeners.get(event)
-    ?.delete(listener as Function);
-}
-
-/**
- * Remove all listeners for an event.
- */
-export function removeAllListeners(event?: DashboardEventName): void {
-  const state = getBusState();
-  if (event) {
-    state.listeners.delete(event);
-  } else {
-    state.listeners.clear();
-    state.wildcardListeners.clear();
-  }
-}
-
-/**
- * Get bus stats for monitoring.
- */
-export function getBusStats(): {
-  totalListeners: number;
-  eventsWithListeners: number;
-  totalEmitted: number;
-  historySize: number;
-} {
-  const state = getBusState();
-  let totalListeners = state.wildcardListeners.size;
-  for (const set of state.listeners.values()) {
-    totalListeners += set.size;
-  }
-  return {
-    totalListeners,
-    eventsWithListeners: state.listeners.size,
-    totalEmitted: state.emitCount,
-    historySize: state.history.length,
-  };
-}
-
-/**
  * Initialize event bus (idempotent).
  */
 export function initEventBus(): void {

--- a/tests/unit/event-bus.test.ts
+++ b/tests/unit/event-bus.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { beforeEach, describe, it } from "node:test";
+
+import {
+  emit,
+  getEventHistory,
+  on,
+  onAny,
+  type HistoryEntry,
+} from "../../src/lib/events/eventBus.ts";
+
+const eventBusPublicApi = await import("../../src/lib/events/eventBus.ts");
+
+const requestStartedPayload = {
+  id: "req-1",
+  model: "gpt-test",
+  provider: "openai",
+  timestamp: 123,
+};
+
+describe("eventBus", () => {
+  beforeEach(() => {
+    globalThis.__omnirouteEventBus = undefined;
+  });
+
+  it("public surface excludes unused listener management helpers", () => {
+    assert.equal("off" in eventBusPublicApi, false);
+    assert.equal("removeAllListeners" in eventBusPublicApi, false);
+    assert.equal("getBusStats" in eventBusPublicApi, false);
+  });
+
+  it("emits to specific and wildcard listeners until unsubscribed", () => {
+    const received: (typeof requestStartedPayload)[] = [];
+    const wildcardEvents: string[] = [];
+
+    const unsubscribe = on("request.started", (payload) => {
+      received.push(payload);
+    });
+    const unsubscribeAny = onAny((event) => {
+      wildcardEvents.push(event);
+    });
+
+    emit("request.started", requestStartedPayload);
+    unsubscribe();
+    unsubscribeAny();
+    emit("request.started", { ...requestStartedPayload, id: "req-2" });
+
+    assert.deepEqual(received, [requestStartedPayload]);
+    assert.deepEqual(wildcardEvents, ["request.started"]);
+  });
+
+  it("keeps recent event history for late subscribers", () => {
+    emit("request.started", requestStartedPayload);
+
+    const history: HistoryEntry[] = getEventHistory(undefined, 1);
+
+    assert.equal(history.length, 1);
+    assert.equal(history[0]?.event, "request.started");
+    assert.deepEqual(history[0]?.payload, requestStartedPayload);
+  });
+});

--- a/tests/unit/event-bus.test.ts
+++ b/tests/unit/event-bus.test.ts
@@ -9,7 +9,7 @@ import {
   type HistoryEntry,
 } from "../../src/lib/events/eventBus.ts";
 
-const eventBusPublicApi = await import("../../src/lib/events/eventBus.ts");
+import * as eventBusPublicApi from "../../src/lib/events/eventBus.ts";
 
 const requestStartedPayload = {
   id: "req-1",


### PR DESCRIPTION
## Summary

- Removed unused event-bus exports: `off`, `removeAllListeners`, and `getBusStats`.
- Kept the active `on` unsubscribe callback, wildcard subscriptions, event emission, and history APIs intact.
- Added a focused event-bus unit test for the remaining public surface and dispatch behavior.
- Left `config/quality/quality-baseline.json` unchanged; the dead-code ratchet update is deferred to the final baseline PR.

## Validation

```text
$ node --import tsx/esm --test tests/unit/event-bus.test.ts
# tests 3
# pass 3
# fail 0
```

```text
$ node scripts/check/check-dead-code.mjs --quiet
DEAD_EXPORTS=248
DEAD_FILES=94
DEAD_TOTAL=342
[dead-code] OK — 342 símbolos mortos (baseline 346)
```

```text
$ GITHUB_BASE_REF=release/v3.8.41 GITHUB_BASE_SHA=upstream/release/v3.8.41 node scripts/check/check-pr-test-policy.mjs
Changed production files: 1
Changed automated test files: 1
Result: PASS
```

```text
$ git commit -m "chore: remove unused event bus exports"
[docs-sync] PASS - documentation version sync is consistent.
[t11:any-budget] PASS - explicit any budget respected.
[tracked-artifacts] OK — no forbidden artifacts tracked by git
```

```text
$ git push -u origin dev/dead-code-event-bus-cleanup-11
[t11:any-budget] PASS - explicit any budget respected.
[tracked-artifacts] OK — no forbidden artifacts tracked by git
```