### PR TITLE
chore: remove unused service registry export

### DIFF
--- a/src/lib/services/registry.ts
+++ b/src/lib/services/registry.ts
@@ -12,10 +12,6 @@ export function getSupervisor(tool: string): ServiceSupervisor | null {
   return supervisors.get(tool) ?? null;
 }
 
-export function listSupervisors(): ServiceSupervisor[] {
-  return Array.from(supervisors.values());
-}
-
 /** Remove a supervisor by tool name. Intended for use in tests. */
 export function unregisterSupervisor(tool: string): void {
   supervisors.delete(tool);

--- a/tests/unit/services/embedWsProxy.test.ts
+++ b/tests/unit/services/embedWsProxy.test.ts
@@ -21,6 +21,7 @@ import {
   unregisterSupervisor,
   getSupervisor,
 } from "../../../src/lib/services/registry.ts";
+const registryPublicApi = await import("../../../src/lib/services/registry.ts");
 import type { ServiceSupervisor } from "../../../src/lib/services/ServiceSupervisor.ts";
 import {
   activeConnections,
@@ -76,6 +77,10 @@ function joined(received: Buffer[]): string {
 // ─── tests ───────────────────────────────────────────────────────────────────
 
 describe("embedWsProxy", () => {
+  it("registry public surface excludes unused supervisor listing helper", () => {
+    assert.equal("listSupervisors" in registryPublicApi, false);
+  });
+
   it("idempotent — initEmbedWsProxy does not bind twice", async () => {
     // Reset the global flag so we can test it from scratch
     const prev = globalThis.__omnirouteEmbedWsStarted;


### PR DESCRIPTION
## Summary

- Removed the unused `listSupervisors` export from the service registry.
- Kept the active `registerSupervisor`, `getSupervisor`, and `unregisterSupervisor` APIs intact.
- Added a public-surface assertion to the existing embed WebSocket proxy registry test.
- Left `config/quality/quality-baseline.json` unchanged; the dead-code ratchet update is deferred to the final baseline PR.

## Validation

```text
$ node --import tsx/esm --test tests/unit/services/embedWsProxy.test.ts
# tests 10
# pass 10
# fail 0
```

```text
$ node scripts/check/check-dead-code.mjs --quiet
DEAD_EXPORTS=250
DEAD_FILES=94
DEAD_TOTAL=344
[dead-code] OK — 344 símbolos mortos (baseline 346)
```

```text
$ GITHUB_BASE_REF=release/v3.8.41 GITHUB_BASE_SHA=upstream/release/v3.8.41 node scripts/check/check-pr-test-policy.mjs
Changed production files: 1
Changed automated test files: 1
Result: PASS
```

```text
$ git commit -m "chore: remove unused service registry export"
[docs-sync] PASS - documentation version sync is consistent.
[t11:any-budget] PASS - explicit any budget respected.
[tracked-artifacts] OK — no forbidden artifacts tracked by git
```

```text
$ git push -u origin dev/dead-code-service-registry-cleanup-13
[t11:any-budget] PASS - explicit any budget respected.
[tracked-artifacts] OK — no forbidden artifacts tracked by git
```