### PR TITLE
fix(translator): guard against empty Claude messages from all-system OpenAI requests

### DIFF
--- a/open-sse/translator/request/openai-to-claude.ts
+++ b/open-sse/translator/request/openai-to-claude.ts
@@ -557,6 +557,17 @@ export function openaiToClaudeRequest(model, body, stream) {
     result._toolNameMap = toolNameMap;
   }
 
+  // Empty-messages guard. Claude's Messages API rejects an empty `messages`
+  // array with `400 messages: at least one message is required`. This happens
+  // when the incoming OpenAI request carried only `system`/`developer` turns
+  // (e.g. an all-system compaction or title-generation request from a client
+  // like OpenCode): those are hoisted into `result.system` above, leaving
+  // `messages` empty. Synthesize a minimal user turn so the request stays
+  // valid — the system instructions still drive the response. (#5245)
+  if (result.messages.length === 0) {
+    result.messages.push({ role: "user", content: [{ type: "text", text: "." }] });
+  }
+
   return result;
 }
 

--- a/tests/unit/openai-to-claude-empty-messages-5245.test.ts
+++ b/tests/unit/openai-to-claude-empty-messages-5245.test.ts
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { openaiToClaudeRequest } =
+  await import("../../open-sse/translator/request/openai-to-claude.ts");
+
+// Regression: an all-system OpenAI request (e.g. an all-system compaction or
+// title-generation turn from a client like OpenCode) hoists every
+// system/developer message into Claude's top-level `system` field, leaving the
+// `messages` array empty. Claude's Messages API then rejects the request with
+// `400 messages: at least one message is required`. The converter must
+// synthesize a minimal user turn so the request stays valid. (#5245)
+
+test("openaiToClaudeRequest: all-system input never yields an empty messages array", () => {
+  const result = openaiToClaudeRequest(
+    "claude-sonnet-4-6",
+    {
+      messages: [
+        { role: "system", content: "You summarize." },
+        { role: "system", content: "Summarize the conversation so far." },
+      ],
+    },
+    false
+  );
+
+  // system content is hoisted to the top-level `system` field …
+  assert.ok(result.system, "system content should be hoisted to result.system");
+  // … but `messages` must not be empty (would 400 upstream).
+  assert.ok(Array.isArray(result.messages));
+  assert.equal(result.messages.length, 1);
+  assert.equal(result.messages[0].role, "user");
+  // content block must be non-empty text (Anthropic rejects empty text blocks).
+  const block = result.messages[0].content[0];
+  assert.equal(block.type, "text");
+  assert.ok(typeof block.text === "string" && block.text.length > 0);
+});
+
+test("openaiToClaudeRequest: developer-only input also gets a synthesized user turn", () => {
+  const result = openaiToClaudeRequest(
+    "claude-sonnet-4-6",
+    { messages: [{ role: "developer", content: "Follow these rules." }] },
+    false
+  );
+  assert.equal(result.messages.length, 1);
+  assert.equal(result.messages[0].role, "user");
+});
+
+test("openaiToClaudeRequest: normal system+user request is unaffected by the guard", () => {
+  const result = openaiToClaudeRequest(
+    "claude-sonnet-4-6",
+    {
+      messages: [
+        { role: "system", content: "You summarize." },
+        { role: "user", content: "Summarize: hello world" },
+      ],
+    },
+    false
+  );
+  // Exactly the real user turn — no synthesized placeholder appended.
+  assert.equal(result.messages.length, 1);
+  assert.equal(result.messages[0].role, "user");
+  const text = JSON.stringify(result.messages[0].content);
+  assert.ok(text.includes("hello world"));
+});


### PR DESCRIPTION
## Problem

When an incoming **OpenAI-format** request to a Claude model carries **only `system`/`developer` turns** (e.g. an all-system compaction or title-generation request — OpenCode emits these), `openaiToClaudeRequest` hoists every system/developer message into Claude's top-level `system` field and filters them out of `messages`. With no non-system turn left, `messages` is `[]`, and Claude's Messages API rejects the request:

```
[400]: messages: at least one message is required
```

This breaks the client turn (in OpenCode it surfaces as a mid-task `stream error` that drops the conversation).

### Repro

```bash
# 400 — all-system input:
curl -s http://localhost:20128/v1/chat/completions \
  -H "authorization: Bearer $KEY" -H "content-type: application/json" \
  -d '{"model":"cc/claude-sonnet-4-6","max_tokens":16,"messages":[
       {"role":"system","content":"You summarize."},
       {"role":"system","content":"Summarize the conversation."}]}'
# -> {"message":"[400]: messages: at least one message is required",...}

# 200 — same with a user turn (control): works.
```

## Fix

Add an empty-`messages` guard at the end of `openaiToClaudeRequest`: if the converted Claude `messages` array is empty after the system hoist, synthesize a minimal `user` turn so the request stays valid. The system instructions still drive the response. The guard only fires when `messages` would otherwise be empty, so non-empty requests are completely unaffected (no regression).

## Tests

`tests/unit/openai-to-claude-empty-messages-5245.test.ts` — covers all-system, developer-only, and the normal system+user control case. Full existing `translator-openai-to-claude` suite stays green (19/19).

Reported in #5245 (this is the empty-messages 400 noted there; it is independent of the `</think>` marker discussion in that thread). Happy to relink to a dedicated tracking issue if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
