### PR TITLE
fix(translator): suppress </think> close marker for clients that render it verbatim (#5245)

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -73,6 +73,7 @@ import {
   withBodyTimeout,
 } from "../utils/stream.ts";
 import { ensureStreamReadiness } from "../utils/streamReadiness.ts";
+import { shouldSuppressThinkCloseMarker } from "../utils/thinkCloseMarker.ts";
 import { resolveStreamReadinessTimeout } from "../utils/streamReadinessPolicy.ts";
 import { createStreamController } from "../utils/streamHandler.ts";
 import * as streamFailure from "../utils/streamFailureFinalization.ts";
@@ -4188,7 +4189,10 @@ export async function handleChatCore({
       onStreamComplete,
       apiKeyInfo,
       handleStreamFailure,
-      copilotCompatibleReasoning
+      copilotCompatibleReasoning,
+      // Suppress the `</think>` close marker for clients that render it verbatim
+      // (e.g. OpenCode); preserved for Claude Code / Cursor and unknown clients (#5245).
+      shouldSuppressThinkCloseMarker(streamUserAgent)
     );
   } else {
     log?.debug?.("STREAM", `Standard passthrough mode`);

--- a/open-sse/translator/response/claude-to-openai.ts
+++ b/open-sse/translator/response/claude-to-openai.ts
@@ -81,7 +81,11 @@ export function claudeToOpenAIResponse(chunk, state) {
         // immediately before the assistant reply begins — but NOT in tool-use streams
         // where no text_delta ever arrives (#5123).
         if (state.pendingThinkClose) {
-          results.push(createChunk(state, { content: "</think>" }));
+          // Suppressed for clients that render the marker verbatim (#5245);
+          // still clear the flag so it never re-fires later in the stream.
+          if (!state.suppressThinkClose) {
+            results.push(createChunk(state, { content: "</think>" }));
+          }
           state.pendingThinkClose = false;
         }
         results.push(createChunk(state, { content: delta.text }));
@@ -195,7 +199,10 @@ export function claudeToOpenAIResponse(chunk, state) {
         // responses that had no text_delta (edge case: thinking-only with
         // immediate stop) still receive the marker here.
         if (state.pendingThinkClose && state.toolCalls.size === 0) {
-          results.push(createChunk(state, { content: "</think>" }));
+          // Suppressed for clients that render the marker verbatim (#5245).
+          if (!state.suppressThinkClose) {
+            results.push(createChunk(state, { content: "</think>" }));
+          }
           state.pendingThinkClose = false;
         }
         state.finishReason = convertStopReason(chunk.delta.stop_reason);

--- a/open-sse/utils/stream.ts
+++ b/open-sse/utils/stream.ts
@@ -117,6 +117,8 @@ type StreamOptions = {
   sourceFormat?: string;
   clientResponseFormat?: string | null;
   copilotCompatibleReasoning?: boolean;
+  /** Suppress the `</think>` close marker for clients that render it verbatim (#5245). */
+  suppressThinkClose?: boolean;
   provider?: string | null;
   reqLogger?: StreamLogger | null;
   toolNameMap?: unknown;
@@ -135,6 +137,8 @@ type TranslateState = ReturnType<typeof initState> & {
   usage?: unknown;
   finishReason?: unknown;
   copilotCompatibleReasoning?: boolean;
+  /** Suppress the `</think>` close marker for clients that render it verbatim (#5245). */
+  suppressThinkClose?: boolean;
   /** Accumulated message content for call log response body */
   accumulatedContent?: string;
   upstreamError?: {
@@ -607,6 +611,7 @@ export function createSSEStream(options: StreamOptions = {}) {
     sourceFormat,
     clientResponseFormat = null,
     copilotCompatibleReasoning = false,
+    suppressThinkClose = false,
     provider = null,
     reqLogger = null,
     toolNameMap = null,
@@ -660,6 +665,7 @@ export function createSSEStream(options: StreamOptions = {}) {
           toolNameMap,
           signatureNamespace,
           copilotCompatibleReasoning,
+          suppressThinkClose,
           accumulatedContent: "",
         }
       : null;
@@ -2636,7 +2642,8 @@ export function createSSETransformStreamWithLogger(
   onComplete: ((payload: StreamCompletePayload) => void) | null = null,
   apiKeyInfo: unknown = null,
   onFailure: ((payload: StreamFailurePayload) => void | Promise<void>) | null = null,
-  copilotCompatibleReasoning = false
+  copilotCompatibleReasoning = false,
+  suppressThinkClose = false
 ) {
   return createSSEStream({
     mode: STREAM_MODE.TRANSLATE,
@@ -2652,6 +2659,7 @@ export function createSSETransformStreamWithLogger(
     onComplete,
     onFailure,
     copilotCompatibleReasoning,
+    suppressThinkClose,
   });
 }
 

--- a/open-sse/utils/thinkCloseMarker.ts
+++ b/open-sse/utils/thinkCloseMarker.ts
@@ -1,0 +1,32 @@
+/**
+ * `</think>` close-marker client policy.
+ *
+ * When OmniRoute translates a Claude-native streamed response to OpenAI Chat
+ * Completions shape (`claude-to-openai.ts`), it emits a single `</think>`
+ * close marker as `delta.content` so clients that scan content for the marker
+ * (Claude Code, Cursor) can split reasoning from the final answer — see #4633.
+ *
+ * Some OpenAI-compatible consumers do NOT parse that marker and render it
+ * verbatim, so a bare `</think>` leaks into the visible reply (#5245). OpenCode
+ * is one such client.
+ *
+ * Policy is conservative and opt-OUT by allowlist: the marker stays ON by
+ * default (preserving #4633 for Claude Code / Cursor and any unrecognized
+ * client), and is suppressed ONLY for known clients that render it literally.
+ * Detection is by inbound `User-Agent`.
+ */
+
+// Lowercased User-Agent substrings of clients that render the textual
+// `</think>` marker verbatim and therefore want it suppressed.
+const SUPPRESS_THINK_CLOSE_UA_MARKERS = ["opencode"];
+
+/**
+ * Whether the streamed `</think>` close marker should be suppressed for the
+ * given inbound client. Returns false (emit the marker) for unknown clients and
+ * for Claude Code / Cursor, so #4633 is never regressed.
+ */
+export function shouldSuppressThinkCloseMarker(userAgent: string | null | undefined): boolean {
+  if (!userAgent || typeof userAgent !== "string") return false;
+  const ua = userAgent.toLowerCase();
+  return SUPPRESS_THINK_CLOSE_UA_MARKERS.some((marker) => ua.includes(marker));
+}

--- a/tests/unit/think-close-marker-suppress-5245.test.ts
+++ b/tests/unit/think-close-marker-suppress-5245.test.ts
@@ -1,0 +1,94 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { claudeToOpenAIResponse } =
+  await import("../../open-sse/translator/response/claude-to-openai.ts");
+const { shouldSuppressThinkCloseMarker } = await import("../../open-sse/utils/thinkCloseMarker.ts");
+
+// #5245: when translating a Claude-native stream to OpenAI shape,
+// claude-to-openai.ts emits a textual `</think>` close marker (by design, for
+// Claude Code / Cursor — #4633). Clients that render it verbatim (OpenCode)
+// want it suppressed. `state.suppressThinkClose` gates the emission; default
+// (unset/false) preserves the #4633 behaviour.
+
+function newState(extra: Record<string, unknown> = {}) {
+  return { toolCalls: new Map(), toolNameMap: new Map(), ...extra } as Record<string, unknown>;
+}
+
+// Drive a thinking-then-text stream and collect every emitted chunk.
+function runThinkThenText(state: Record<string, unknown>) {
+  const out: unknown[] = [];
+  const push = (r: unknown) => {
+    if (Array.isArray(r)) out.push(...r);
+    else if (r) out.push(r);
+  };
+  push(claudeToOpenAIResponse({ type: "message_start", message: { id: "m1" } }, state));
+  push(
+    claudeToOpenAIResponse(
+      { type: "content_block_start", index: 0, content_block: { type: "thinking" } },
+      state
+    )
+  );
+  push(
+    claudeToOpenAIResponse(
+      {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "thinking_delta", thinking: "plan" },
+      },
+      state
+    )
+  );
+  push(claudeToOpenAIResponse({ type: "content_block_stop", index: 0 }, state));
+  push(
+    claudeToOpenAIResponse(
+      { type: "content_block_start", index: 1, content_block: { type: "text" } },
+      state
+    )
+  );
+  push(
+    claudeToOpenAIResponse(
+      { type: "content_block_delta", index: 1, delta: { type: "text_delta", text: "169" } },
+      state
+    )
+  );
+  return out;
+}
+
+function contentChunks(chunks: unknown[]): string[] {
+  return chunks
+    .map(
+      (c) =>
+        (c as { choices?: Array<{ delta?: { content?: unknown } }> })?.choices?.[0]?.delta?.content
+    )
+    .filter((v): v is string => typeof v === "string");
+}
+
+// ── shouldSuppressThinkCloseMarker ───────────────────────────────────────────
+
+test("shouldSuppressThinkCloseMarker: suppresses for OpenCode, preserves CC/Cursor/unknown", () => {
+  assert.equal(shouldSuppressThinkCloseMarker("opencode/1.17.11"), true);
+  assert.equal(shouldSuppressThinkCloseMarker("OpenCode/2.0"), true);
+  assert.equal(shouldSuppressThinkCloseMarker("claude-code/1.0"), false);
+  assert.equal(shouldSuppressThinkCloseMarker("cursor-agent/0.5"), false);
+  assert.equal(shouldSuppressThinkCloseMarker("some-other-client/1.0"), false);
+  assert.equal(shouldSuppressThinkCloseMarker(""), false);
+  assert.equal(shouldSuppressThinkCloseMarker(null), false);
+  assert.equal(shouldSuppressThinkCloseMarker(undefined), false);
+});
+
+// ── translator gating ────────────────────────────────────────────────────────
+
+test("claude-to-openai: default emits the </think> marker before the first text (#4633 preserved)", () => {
+  const contents = contentChunks(runThinkThenText(newState()));
+  assert.ok(contents.includes("</think>"), "marker must be emitted by default");
+  assert.ok(contents.includes("169"), "real text still emitted");
+  // marker comes before the real text
+  assert.ok(contents.indexOf("</think>") < contents.indexOf("169"));
+});
+
+test("claude-to-openai: suppressThinkClose drops the </think> marker but keeps the text (#5245)", () => {
+  const contents = contentChunks(runThinkThenText(newState({ suppressThinkClose: true })));
+  assert.ok(!contents.includes("</think>"), "marker must be suppressed");
+  assert.ok(contents.includes("169"), "real text still emitted");
+});


### PR DESCRIPTION
Follow-up to #5245. Resolves the `</think>` marker leak you triaged — confirmed **path #1** (the request hits `/v1/chat/completions`, `claude-to-openai.ts` emits the #4633 marker) because OpenCode uses the openai-compatible SDK even for `cc/`/`claude/` models, as detailed in the issue thread.

## Approach — conservative, no #4633 regression

Allowlist-based **opt-out**, not a blanket suppression:

- The marker stays **ON by default** — Claude Code, Cursor, and **any unrecognized client** keep the exact #4633 behaviour.
- It is suppressed **only** for known clients that render the marker verbatim, detected by inbound `User-Agent`. Currently just OpenCode (`opencode/…`); the allowlist (`SUPPRESS_THINK_CLOSE_UA_MARKERS`) is trivial to extend.

This is the "targeted suppression for non-CC OpenAI consumers" you described, done as an allowlist so a UA we don't recognize can never lose the marker.

## Wiring

- `open-sse/utils/thinkCloseMarker.ts` — `shouldSuppressThinkCloseMarker(userAgent)` (new).
- `chatCore` computes the flag from the request `User-Agent` and threads it via `createSSETransformStreamWithLogger` → `createSSEStream` into the translator state (mirrors the existing `copilotCompatibleReasoning` plumbing).
- `claude-to-openai.ts` gates **both** marker-emission sites (the deferred flush before the first `text_delta`, and the `message_delta` finish path) on `state.suppressThinkClose`; `pendingThinkClose` is still cleared so it never re-fires.

## Tests

`tests/unit/think-close-marker-suppress-5245.test.ts`:
- helper allowlist (OpenCode → suppress; `claude-code`/`cursor-agent`/unknown/empty → keep);
- **default still emits** `</think>` before the first text (#4633 regression guard);
- `suppressThinkClose` drops the marker but keeps the answer text.

Existing `anthropic-stream-thinking-close-marker` + `translator-resp-claude-to-openai` suites stay green (72/72 across the touched translator/stream tests). Pre-commit (prettier/eslint/any-budget/docs-sync) clean.

Note: detection is by inbound UA, so it auto-fixes OpenCode with no plugin change. If you'd rather gate this on an explicit header (e.g. extending `x-omniroute-strip-reasoning`) or a different signal, happy to adapt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
