### PR TITLE
chore: remove unused embedding cache export

### DIFF
--- a/src/lib/memory/embedding/index.ts
+++ b/src/lib/memory/embedding/index.ts
@@ -15,16 +15,10 @@ import type {
 import { embedRemote } from "./remote";
 import { embedStatic } from "./staticPotion";
 import { embedTransformers } from "./transformersLocal";
-import {
-  buildCacheKey,
-  get as cacheGet,
-  set as cacheSet,
-  invalidate as cacheInvalidate,
-} from "./cache";
+import { buildCacheKey, get as cacheGet, set as cacheSet } from "./cache";
 
 const STATIC_MODEL = process.env.MEMORY_STATIC_MODEL || "minishlab/potion-base-8M";
-const TRANSFORMERS_MODEL =
-  process.env.MEMORY_TRANSFORMERS_MODEL || "Xenova/all-MiniLM-L6-v2";
+const TRANSFORMERS_MODEL = process.env.MEMORY_TRANSFORMERS_MODEL || "Xenova/all-MiniLM-L6-v2";
 
 /** Build an EmbeddingResolution for "no source available" cases. */
 function noSource(reason: string): EmbeddingResolution {
@@ -184,12 +178,7 @@ export async function embed(
     };
   }
 
-  const cacheKey = buildCacheKey(
-    resolution.source,
-    resolution.model,
-    resolution.dimensions,
-    text
-  );
+  const cacheKey = buildCacheKey(resolution.source, resolution.model, resolution.dimensions, text);
 
   const cached = cacheGet(cacheKey);
   if (cached) {
@@ -289,12 +278,4 @@ export async function listEmbeddingProviders(): Promise<EmbeddingProviderListing
   }
 
   return result;
-}
-
-/**
- * Drop the in-memory embedding cache.
- * Called when settings (model/source) change.
- */
-export function invalidateEmbeddingCache(): void {
-  cacheInvalidate();
 }

--- a/tests/unit/memory-embedding-resolve.test.ts
+++ b/tests/unit/memory-embedding-resolve.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { resolveEmbeddingSource } from "../../src/lib/memory/embedding/index";
+const embeddingPublicApi = await import("../../src/lib/memory/embedding/index");
 import type { MemorySettingsExtended } from "../../src/shared/schemas/memory";
 
 function makeSettings(overrides: Partial<MemorySettingsExtended> = {}): MemorySettingsExtended {
@@ -17,6 +18,10 @@ function makeSettings(overrides: Partial<MemorySettingsExtended> = {}): MemorySe
 }
 
 describe("resolveEmbeddingSource", () => {
+  it("public surface excludes unused cache invalidation wrapper", () => {
+    assert.equal("invalidateEmbeddingCache" in embeddingPublicApi, false);
+  });
+
   it("auto + no key + no static + no transformers => source null", () => {
     const res = resolveEmbeddingSource(makeSettings({ embeddingSource: "auto" }));
     assert.strictEqual(res.source, null);
@@ -28,39 +33,47 @@ describe("resolveEmbeddingSource", () => {
   });
 
   it("auto + embeddingProviderModel set to openai/... => source remote", () => {
-    const res = resolveEmbeddingSource(makeSettings({
-      embeddingSource: "auto",
-      embeddingProviderModel: "openai/text-embedding-3-small",
-    }));
+    const res = resolveEmbeddingSource(
+      makeSettings({
+        embeddingSource: "auto",
+        embeddingProviderModel: "openai/text-embedding-3-small",
+      })
+    );
     assert.strictEqual(res.source, "remote");
     assert.strictEqual(res.model, "openai/text-embedding-3-small");
   });
 
   it("auto + no model + staticEnabled=true => source static", () => {
-    const res = resolveEmbeddingSource(makeSettings({
-      embeddingSource: "auto",
-      embeddingProviderModel: null,
-      staticEnabled: true,
-    }));
+    const res = resolveEmbeddingSource(
+      makeSettings({
+        embeddingSource: "auto",
+        embeddingProviderModel: null,
+        staticEnabled: true,
+      })
+    );
     assert.strictEqual(res.source, "static");
     assert.ok(res.model !== null);
   });
 
   it("auto + no model + staticEnabled=false + transformersEnabled=true => source transformers", () => {
-    const res = resolveEmbeddingSource(makeSettings({
-      embeddingSource: "auto",
-      embeddingProviderModel: null,
-      staticEnabled: false,
-      transformersEnabled: true,
-    }));
+    const res = resolveEmbeddingSource(
+      makeSettings({
+        embeddingSource: "auto",
+        embeddingProviderModel: null,
+        staticEnabled: false,
+        transformersEnabled: true,
+      })
+    );
     assert.strictEqual(res.source, "transformers");
   });
 
   it("explicit 'remote' + no model => source null with no_key reason", () => {
-    const res = resolveEmbeddingSource(makeSettings({
-      embeddingSource: "remote",
-      embeddingProviderModel: null,
-    }));
+    const res = resolveEmbeddingSource(
+      makeSettings({
+        embeddingSource: "remote",
+        embeddingProviderModel: null,
+      })
+    );
     assert.strictEqual(res.source, null);
     // The reason must reference the missing key, not just be non-empty.
     assert.ok(
@@ -70,43 +83,53 @@ describe("resolveEmbeddingSource", () => {
   });
 
   it("explicit 'remote' + model set => source remote (no fallback)", () => {
-    const res = resolveEmbeddingSource(makeSettings({
-      embeddingSource: "remote",
-      embeddingProviderModel: "openai/text-embedding-3-small",
-    }));
+    const res = resolveEmbeddingSource(
+      makeSettings({
+        embeddingSource: "remote",
+        embeddingProviderModel: "openai/text-embedding-3-small",
+      })
+    );
     assert.strictEqual(res.source, "remote");
     assert.strictEqual(res.model, "openai/text-embedding-3-small");
   });
 
   it("explicit 'static' + staticEnabled=true => source static", () => {
-    const res = resolveEmbeddingSource(makeSettings({
-      embeddingSource: "static",
-      staticEnabled: true,
-    }));
+    const res = resolveEmbeddingSource(
+      makeSettings({
+        embeddingSource: "static",
+        staticEnabled: true,
+      })
+    );
     assert.strictEqual(res.source, "static");
   });
 
   it("explicit 'static' + staticEnabled=false => source null", () => {
-    const res = resolveEmbeddingSource(makeSettings({
-      embeddingSource: "static",
-      staticEnabled: false,
-    }));
+    const res = resolveEmbeddingSource(
+      makeSettings({
+        embeddingSource: "static",
+        staticEnabled: false,
+      })
+    );
     assert.strictEqual(res.source, null);
   });
 
   it("explicit 'transformers' + transformersEnabled=true => source transformers", () => {
-    const res = resolveEmbeddingSource(makeSettings({
-      embeddingSource: "transformers",
-      transformersEnabled: true,
-    }));
+    const res = resolveEmbeddingSource(
+      makeSettings({
+        embeddingSource: "transformers",
+        transformersEnabled: true,
+      })
+    );
     assert.strictEqual(res.source, "transformers");
   });
 
   it("explicit 'transformers' + transformersEnabled=false => source null", () => {
-    const res = resolveEmbeddingSource(makeSettings({
-      embeddingSource: "transformers",
-      transformersEnabled: false,
-    }));
+    const res = resolveEmbeddingSource(
+      makeSettings({
+        embeddingSource: "transformers",
+        transformersEnabled: false,
+      })
+    );
     assert.strictEqual(res.source, null);
   });
 
@@ -121,11 +144,16 @@ describe("resolveEmbeddingSource", () => {
   });
 
   it("signature contains source:model:dim components", () => {
-    const res = resolveEmbeddingSource(makeSettings({
-      embeddingSource: "static",
-      staticEnabled: true,
-    }));
-    assert.ok(res.signature.includes("static"), `signature should contain 'static': ${res.signature}`);
+    const res = resolveEmbeddingSource(
+      makeSettings({
+        embeddingSource: "static",
+        staticEnabled: true,
+      })
+    );
+    assert.ok(
+      res.signature.includes("static"),
+      `signature should contain 'static': ${res.signature}`
+    );
     assert.ok(res.signature.includes(":"), "signature should contain colons");
   });
 


### PR DESCRIPTION
## Summary

- Removed the unused `invalidateEmbeddingCache` wrapper export from the memory embedding index.
- Kept the active `embed`, `resolveEmbeddingSource`, and `listEmbeddingProviders` APIs intact.
- Added a public-surface assertion to the memory embedding resolve test.
- Left the dead-code baseline unchanged; the final ratchet remains deferred.

## Validation

```
$ node --import tsx/esm --test tests/unit/memory-embedding-resolve.test.ts
# tests 15
# pass 15
# fail 0
```

```
$ node scripts/check/check-dead-code.mjs --quiet
DEAD_EXPORTS=215
DEAD_FILES=94
DEAD_TOTAL=309
[dead-code] OK — 309 símbolos mortos (baseline 310)
```

```
$ GITHUB_BASE_REF=release/v3.8.41 GITHUB_BASE_SHA=upstream/release/v3.8.41 node scripts/check/check-pr-test-policy.mjs
Changed production files: 1
Changed automated test files: 1
Result: PASS
```

```
$ npm run check:fabricated-docs
✓ No fabricated API/env/CLI/hook/file references found.
```
