### PR TITLE
chore: remove unused models.dev context export

### DIFF
--- a/src/lib/modelsDevSync.ts
+++ b/src/lib/modelsDevSync.ts
@@ -922,12 +922,3 @@ export async function initModelsDevSync(): Promise<void> {
   const interval = settings.modelsDevSyncInterval as number | undefined;
   startPeriodicSync(interval);
 }
-
-/**
- * Get context window limit for a specific model from synced capabilities.
- * Returns null if not available.
- */
-export function getModelContextLimit(provider: string, modelId: string): number | null {
-  const caps = getSyncedCapabilities(provider, modelId);
-  return caps[provider]?.[modelId]?.limit_context ?? null;
-}

--- a/tests/unit/modelsDevSync-extended.test.ts
+++ b/tests/unit/modelsDevSync-extended.test.ts
@@ -274,8 +274,7 @@ test("modelsDev capabilities helpers create the table, persist rows, filter by p
   assert.equal(allCaps.anthropic["claude-sonnet-4-20250514"].attachment, true);
   assert.deepEqual(Object.keys(openaiOnly), ["openai"]);
   assert.equal(openaiOnly.openai["gpt-4o"].limit_context, 128000);
-  assert.equal(modelsDev.getModelContextLimit("openai", "gpt-4o"), 128000);
-  assert.equal(modelsDev.getModelContextLimit("openai", "missing"), null);
+  assert.equal("getModelContextLimit" in modelsDev, false);
 
   modelsDev.clearModelsDevCapabilities();
   assert.deepEqual(modelsDev.getSyncedCapabilities(), {});


### PR DESCRIPTION
## Summary

- Removed the unused `getModelContextLimit` export from `src/lib/modelsDevSync.ts`.
- Kept the canonical context-limit API in `src/lib/modelCapabilities.ts` unchanged.
- Updated the models.dev unit coverage to assert the old convenience export is no longer part of the public surface.
- Left the dead-code baseline unchanged; the final ratchet remains deferred.

## Validation

```
$ node --import tsx/esm --test tests/unit/modelsDevSync-extended.test.ts
# tests 13
# pass 13
# fail 0
```

```
$ node scripts/check/check-dead-code.mjs --quiet
DEAD_EXPORTS=215
DEAD_FILES=94
DEAD_TOTAL=309
[dead-code] OK — 309 símbolos mortos (baseline 310)
```

```
$ GITHUB_BASE_REF=release/v3.8.41 GITHUB_BASE_SHA=upstream/release/v3.8.41 node scripts/check/check-pr-test-policy.mjs
Changed production files: 1
Changed automated test files: 1
Result: PASS
```

```
$ npm run check:fabricated-docs
✓ No fabricated API/env/CLI/hook/file references found.
```
