### PR TITLE
chore: remove unused authz class helpers

### DIFF
--- a/src/server/authz/classify.ts
+++ b/src/server/authz/classify.ts
@@ -3,7 +3,7 @@ import {
   PUBLIC_READONLY_API_ROUTE_PREFIXES,
   PUBLIC_READONLY_METHODS,
 } from "../../shared/constants/publicApiRoutes";
-import type { ClassificationReason, RouteClass, RouteClassification } from "./types";
+import type { ClassificationReason, RouteClassification } from "./types";
 
 const CLIENT_API_ALIAS_PREFIXES: ReadonlyArray<{ alias: string; canonical: string }> = [
   { alias: "/chat/completions", canonical: "/api/v1/chat/completions" },
@@ -138,16 +138,4 @@ function isClassifiedAsPublic(path: string, method: string): boolean {
     return true;
   }
   return matchesReadonlyPublic(path, method);
-}
-
-export function isClientApi(routeClass: RouteClass): boolean {
-  return routeClass === "CLIENT_API";
-}
-
-export function isManagement(routeClass: RouteClass): boolean {
-  return routeClass === "MANAGEMENT";
-}
-
-export function isPublic(routeClass: RouteClass): boolean {
-  return routeClass === "PUBLIC";
 }

--- a/tests/unit/authz/classify.test.ts
+++ b/tests/unit/authz/classify.test.ts
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
+import * as classifyPublicApi from "../../../src/server/authz/classify.ts";
 import { classifyRoute } from "../../../src/server/authz/classify.ts";
 import type { RouteClass } from "../../../src/server/authz/types.ts";
 
@@ -208,4 +209,11 @@ test("classifyRoute treats /api/v1 prefix exactly", () => {
   assert.equal(classifyRoute("/api/v1/x").routeClass, "CLIENT_API");
   assert.equal(classifyRoute("/api/v1betamax").routeClass, "MANAGEMENT");
   assert.equal(classifyRoute("/api/v1beta/models").routeClass, "CLIENT_API");
+});
+
+test("classify module public surface only exposes route classification", () => {
+  assert.equal("classifyRoute" in classifyPublicApi, true);
+  assert.equal("isClientApi" in classifyPublicApi, false);
+  assert.equal("isManagement" in classifyPublicApi, false);
+  assert.equal("isPublic" in classifyPublicApi, false);
 });


### PR DESCRIPTION
## Summary

- Removed the unused `isClientApi`, `isManagement`, and `isPublic` exports from `src/server/authz/classify.ts`.
- Kept `classifyRoute` behavior unchanged for the authz pipeline.
- Added a public-surface assertion to the authz classification unit test.
- Left the dead-code baseline unchanged; the final ratchet remains deferred.

## Validation

```
$ node --import tsx/esm --test tests/unit/authz/classify.test.ts
# tests 45
# pass 45
# fail 0
```

```
$ node scripts/check/check-dead-code.mjs --quiet
DEAD_EXPORTS=213
DEAD_FILES=94
DEAD_TOTAL=307
[dead-code] OK — 307 símbolos mortos (baseline 310)
```

```
$ GITHUB_BASE_REF=release/v3.8.41 GITHUB_BASE_SHA=upstream/release/v3.8.41 node scripts/check/check-pr-test-policy.mjs
Changed production files: 1
Changed automated test files: 1
Result: PASS
```

```
$ npm run check:fabricated-docs
✓ No fabricated API/env/CLI/hook/file references found.
```
