### PR TITLE
chore: remove unused api key format helpers

### DIFF
--- a/src/shared/utils/apiKey.ts
+++ b/src/shared/utils/apiKey.ts
@@ -90,29 +90,3 @@ export function parseApiKey(
 
   return null;
 }
-
-/**
- * Verify API key CRC (only for new format)
- * @param {string} apiKey
- * @returns {boolean}
- */
-export function verifyApiKeyCrc(apiKey: string): boolean {
-  const parsed = parseApiKey(apiKey);
-  if (!parsed) return false;
-
-  // Old format doesn't have CRC, always valid if parsed
-  if (!parsed.isNewFormat) return true;
-
-  // New format already verified in parseApiKey
-  return true;
-}
-
-/**
- * Check if API key is new format (contains machineId)
- * @param {string} apiKey
- * @returns {boolean}
- */
-export function isNewFormatKey(apiKey: string): boolean {
-  const parsed = parseApiKey(apiKey);
-  return parsed?.isNewFormat === true;
-}

--- a/tests/unit/api-key-utils-public-surface.test.ts
+++ b/tests/unit/api-key-utils-public-surface.test.ts
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+process.env.API_KEY_SECRET = "test-api-key-utils-secret";
+
+const apiKeyUtils = await import("../../src/shared/utils/apiKey.ts");
+
+test("api key utility public surface keeps generation and parsing only", () => {
+  const machineId = "testmachine";
+  const { key, keyId } = apiKeyUtils.generateApiKeyWithMachine(machineId);
+
+  assert.equal(typeof key, "string");
+  assert.equal(typeof keyId, "string");
+  assert.match(key, new RegExp(`^sk-${machineId}-${keyId}-[a-f0-9]{8}$`));
+  assert.deepEqual(apiKeyUtils.parseApiKey(key), {
+    machineId,
+    keyId,
+    isNewFormat: true,
+  });
+  assert.deepEqual(apiKeyUtils.parseApiKey("sk-legacykey"), {
+    machineId: null,
+    keyId: "legacykey",
+    isNewFormat: false,
+  });
+  assert.equal(apiKeyUtils.parseApiKey("not-a-key"), null);
+
+  assert.equal("verifyApiKeyCrc" in apiKeyUtils, false);
+  assert.equal("isNewFormatKey" in apiKeyUtils, false);
+});


### PR DESCRIPTION
## Summary

- Removed the unused `verifyApiKeyCrc` and `isNewFormatKey` exports from `src/shared/utils/apiKey.ts`.
- Kept API key generation and parsing behavior unchanged.
- Added focused public-surface coverage for the remaining API key utility exports.
- Left the dead-code baseline unchanged; the final ratchet remains deferred.

## Validation

```
$ node --import tsx/esm --test tests/unit/api-key-utils-public-surface.test.ts tests/unit/api-key-regeneration.test.ts
# tests 3
# pass 3
# fail 0
```

```
$ node scripts/check/check-dead-code.mjs --quiet
DEAD_EXPORTS=214
DEAD_FILES=94
DEAD_TOTAL=308
[dead-code] OK — 308 símbolos mortos (baseline 310)
```

```
$ GITHUB_BASE_REF=release/v3.8.41 GITHUB_BASE_SHA=upstream/release/v3.8.41 node scripts/check/check-pr-test-policy.mjs
Changed production files: 1
Changed automated test files: 1
Result: PASS
```

```
$ npm run check:fabricated-docs
✓ No fabricated API/env/CLI/hook/file references found.
```
