### PR TITLE
chore: remove unused build profile exports

### DIFF
--- a/src/lib/build-profile/featureDisabled.ts
+++ b/src/lib/build-profile/featureDisabled.ts
@@ -21,6 +21,3 @@ export class FeatureDisabledError extends Error {
 export function featureDisabledError(featureName: string): FeatureDisabledError {
   return new FeatureDisabledError(featureName);
 }
-
-export const OMNIROUTE_BUILD_PROFILE: string = process.env.OMNIROUTE_BUILD_PROFILE || "full";
-export const IS_MINIMAL_BUILD: boolean = OMNIROUTE_BUILD_PROFILE === "minimal";

--- a/tests/unit/security/build-profile-stubs.test.ts
+++ b/tests/unit/security/build-profile-stubs.test.ts
@@ -13,6 +13,8 @@ test("featureDisabledError carries the featureName", async () => {
   assert.equal(err.featureName, "my-feature");
   assert.match(err.message, /my-feature/);
   assert.match(err.message, /minimal/);
+  assert.equal("OMNIROUTE_BUILD_PROFILE" in mod, false);
+  assert.equal("IS_MINIMAL_BUILD" in mod, false);
 });
 
 test("install.stub.ts: installCert / uninstallCert throw FeatureDisabledError", async () => {


### PR DESCRIPTION
## Summary

- Removed unused build-profile exports from `src/lib/build-profile/featureDisabled.ts`.
- Kept the `FeatureDisabledError` and `featureDisabledError()` helper used by minimal-build stubs unchanged.
- Extended the build-profile stub test to assert the removed flags are no longer part of the public surface.
- Left the dead-code baseline unchanged; the final ratchet remains deferred.

## Validation

```
$ node --import tsx/esm --test tests/unit/security/build-profile-stubs.test.ts
# tests 5
# pass 5
# fail 0
```

```
$ node scripts/check/check-dead-code.mjs --quiet
DEAD_EXPORTS=215
DEAD_FILES=94
DEAD_TOTAL=309
[dead-code] OK — 309 símbolos mortos (baseline 310)
```

```
$ GITHUB_BASE_REF=release/v3.8.41 GITHUB_BASE_SHA=upstream/release/v3.8.41 node scripts/check/check-pr-test-policy.mjs
Changed production files: 1
Changed automated test files: 1
Result: PASS
```

```
$ npm run check:fabricated-docs
✓ No fabricated API/env/CLI/hook/file references found.
```
