### PR TITLE
fix(opencode-plugin): bump to 0.2.0 + auto-publish on release

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -205,12 +205,55 @@ jobs:
         uses: actions/checkout@v7
         with:
           persist-credentials: false
+          fetch-depth: 0
+          # Full history needed for auto-bump: git diff against previous release tag
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NPM_PUBLISH_NODE_VERSION }}
           registry-url: https://registry.npmjs.org
+
+      - name: Auto-bump plugin version if plugin changed since last release
+        id: bump
+        working-directory: "@omniroute/opencode-plugin"
+        env:
+          CURRENT_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          PKG_NAME=$(node -p "require('./package.json').name")
+
+          # 1) Skip if current version is not yet published (no bump needed)
+          PUBLISHED="$(npm view "${PKG_NAME}@${PKG_VERSION}" version 2>/dev/null || true)"
+          if [ "$PUBLISHED" != "$PKG_VERSION" ]; then
+            echo "✅ ${PKG_NAME}@${PKG_VERSION} is new — no bump needed."
+            echo "bumped=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # 2) Find the previous release tag (exclude the current one)
+          PREV_TAG=$(git tag -l 'v*' --sort=-version:refname \
+            | grep -v "^${CURRENT_TAG}$" | head -1 || echo "")
+          if [ -z "$PREV_TAG" ]; then
+            echo "No previous tag to compare — skipping bump."
+            echo "bumped=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # 3) Check if plugin dir actually changed since that tag
+          if git diff --quiet "$PREV_TAG" -- "@omniroute/opencode-plugin/"; then
+            echo "⏭️ No plugin changes since $PREV_TAG — nothing to publish."
+            echo "bumped=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # 4) Auto-bump patch version
+          npm version patch --no-git-tag-version --allow-same-version
+          NEW_VERSION=$(node -p "require('./package.json').version")
+          echo "bumped=true" >> "$GITHUB_OUTPUT"
+          echo "📦 Auto-bumped ${PKG_NAME} from ${PKG_VERSION} to ${NEW_VERSION}"
 
       - name: Install plugin dependencies
         working-directory: "@omniroute/opencode-plugin"

--- a/@omniroute/opencode-plugin/package.json
+++ b/@omniroute/opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omniroute/opencode-plugin",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "OpenCode plugin for the OmniRoute AI Gateway. Drives dynamic model discovery, /connect auth flow, and multi-instance OmniRoute providers via the official @opencode-ai/plugin contract.",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

The `@omniroute/opencode-plugin` npm package was published once at `0.1.0` on 2026-05-24. All subsequent fixes and features (auto combos, schema fields, debug logging, per-prefix API format, etc.) accumulated in the repo but **never reached npm** because the version was never bumped and the CI skip-check blocks re-publishing the same version.

## Changes

### 1. Bump plugin to `0.2.0` (`@omniroute/opencode-plugin/package.json`)
- `version`: `0.1.0` → `0.2.0`
- This publishes the accumulated fixes since May 24, including the custom combo schema fields fix (`e1a9c6117`) and auto combo features.

### 2. Auto-bump step in `npm-publish.yml`
- Added `fetch-depth: 0` to the `publish-opencode-plugin` job so full tag history is available.
- New step **Auto-bump plugin version** that runs before install/build/test:

| Guard | What it does |
|-------|-------------|
| 1 | Current version already published? → check further. Not published? → publish as-is |
| 2 | `git diff` against previous release tag in `@omniroute/opencode-plugin/` → only bumps if there are actual changes |
| 3 | No changes? → skip publish entirely |
| 4 | Changes detected? → `npm version patch` auto-bumps and proceeds to publish |

## Why this matters

Before this PR, every release silently skipped the plugin because the version was frozen at `0.1.0`. After this PR:
- **Next release**: `0.2.0` is new → published with all accumulated fixes
- **Subsequent releases with plugin changes**: auto-bump patch (`0.2.1`, `0.2.2`, ...) → published
- **Releases without plugin changes**: no bump, no publish (CI minutes saved)