### PR TITLE
chore: remove unused encryption config validator

### DIFF
--- a/src/lib/db/encryption.ts
+++ b/src/lib/db/encryption.ts
@@ -242,40 +242,6 @@ export function decryptConnectionFields<T extends ConnectionFields | null | unde
 }
 
 /**
- * Validate encryption configuration at startup.
- * Returns { valid: true } or { valid: false, error: string } with actionable guidance.
- */
-export function validateEncryptionConfig(): { valid: boolean; error?: string } {
-  const secret = process.env.STORAGE_ENCRYPTION_KEY;
-
-  // No key set — passthrough mode is fine
-  if (!secret) return { valid: true };
-
-  if (typeof secret !== "string" || secret.trim().length === 0) {
-    return {
-      valid: false,
-      error:
-        "STORAGE_ENCRYPTION_KEY is set but empty. " +
-        "Either remove it (passthrough mode) or set a valid key: openssl rand -base64 32",
-    };
-  }
-
-  // Try deriving a key to verify it works
-  try {
-    scryptSync(secret, STATIC_SALT, KEY_LENGTH);
-    return { valid: true };
-  } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
-    return {
-      valid: false,
-      error:
-        `STORAGE_ENCRYPTION_KEY is invalid (${message}). ` +
-        `Generate a valid key with: openssl rand -base64 32`,
-    };
-  }
-}
-
-/**
  * Specifically tests a ciphertext against the legacy key. If it succeeds, it
  * re-encrypts the decrypted value with the canonical static key.
  * Used exclusively by the startup migration script.

--- a/tests/unit/db-encryption.test.ts
+++ b/tests/unit/db-encryption.test.ts
@@ -39,6 +39,7 @@ test("encryption stays in passthrough mode when no storage key is configured", a
   assert.equal(encryption.encrypt(""), "");
   assert.equal(encryption.decrypt(null), null);
   assert.equal(encryption.decrypt(undefined), undefined);
+  assert.equal("validateEncryptionConfig" in encryption, false);
 });
 
 test("encrypt/decrypt round-trip uses the expected serialized format", async () => {


### PR DESCRIPTION
## Summary

- Removed the unused `validateEncryptionConfig` export from `src/lib/db/encryption.ts`.
- Kept the active encryption/decryption helpers and connection-field helpers unchanged.
- Extended the DB encryption unit test to assert the removed validator is no longer part of the public surface.
- Left the dead-code baseline unchanged; the final ratchet remains deferred.

## Validation

```
$ node --import tsx/esm --test tests/unit/db-encryption.test.ts
# tests 6
# pass 6
# fail 0
```

```
$ node scripts/check/check-dead-code.mjs --quiet
DEAD_EXPORTS=215
DEAD_FILES=94
DEAD_TOTAL=309
[dead-code] OK — 309 símbolos mortos (baseline 310)
```

```
$ GITHUB_BASE_REF=release/v3.8.41 GITHUB_BASE_SHA=upstream/release/v3.8.41 node scripts/check/check-pr-test-policy.mjs
Changed production files: 1
Changed automated test files: 1
Result: PASS
```

```
$ npm run check:fabricated-docs
✓ No fabricated API/env/CLI/hook/file references found.
```
