### PR TITLE
chore: remove unused search validator wrapper

### DIFF
--- a/src/lib/providers/validation/searchProviders.ts
+++ b/src/lib/providers/validation/searchProviders.ts
@@ -6,21 +6,6 @@ import { getProviderOutboundGuard } from "@/shared/network/outboundUrlGuard";
 import { withCustomUserAgent } from "./headers";
 import { toValidationErrorResult, validationWrite } from "./transport";
 
-export async function validateGenericProvider(
-  baseUrl: string,
-  apiKey: string,
-  providerSpecificData: any = {},
-  provider: string,
-  isLocal: boolean = false
-) {
-  const config = SEARCH_VALIDATOR_CONFIGS[provider];
-  if (!config) {
-    return { valid: false, error: "Validator not found", unsupported: true };
-  }
-  const { url, init } = config(apiKey, providerSpecificData);
-  return validateSearchProvider(url, init, providerSpecificData, isLocal);
-}
-
 export async function validateSearchProvider(
   url: string,
   init: RequestInit,

--- a/tests/unit/validation-search-embedding-split.test.ts
+++ b/tests/unit/validation-search-embedding-split.test.ts
@@ -12,10 +12,13 @@ const HOST = await import("../../src/lib/providers/validation.ts");
 
 test("searchProviders exposes the search validators + the per-provider config map", () => {
   assert.equal(typeof (search as Record<string, unknown>).validateSearchProvider, "function");
-  assert.equal(typeof (search as Record<string, unknown>).validateGenericProvider, "function");
+  assert.equal("validateGenericProvider" in search, false);
   const cfg = (search as Record<string, Record<string, unknown>>).SEARCH_VALIDATOR_CONFIGS;
   assert.ok(cfg && typeof cfg === "object");
-  assert.ok(Object.keys(cfg).length > 0, "SEARCH_VALIDATOR_CONFIGS must carry the provider configs");
+  assert.ok(
+    Object.keys(cfg).length > 0,
+    "SEARCH_VALIDATOR_CONFIGS must carry the provider configs"
+  );
 });
 
 test("embeddingProviders exposes clarifai + embedding + rerank validators", () => {


### PR DESCRIPTION
## Summary

- Removed the unused `validateGenericProvider` wrapper export from `src/lib/providers/validation/searchProviders.ts`.
- Kept the active `validateSearchProvider` helper and `SEARCH_VALIDATOR_CONFIGS` map unchanged for the host dispatcher.
- Updated the search/embedding split test to assert the smaller public surface.
- Left the dead-code baseline unchanged; the final ratchet remains deferred.

## Validation

```
$ node --import tsx/esm --test tests/unit/validation-search-embedding-split.test.ts
# tests 3
# pass 3
# fail 0
```

```
$ node --import tsx/esm --test tests/unit/provider-validation-specialty.test.ts
# tests 115
# pass 115
# fail 0
```

```
$ node scripts/check/check-dead-code.mjs --quiet
DEAD_EXPORTS=215
DEAD_FILES=94
DEAD_TOTAL=309
[dead-code] OK — 309 símbolos mortos (baseline 310)
```

```
$ GITHUB_BASE_REF=release/v3.8.41 GITHUB_BASE_SHA=upstream/release/v3.8.41 node scripts/check/check-pr-test-policy.mjs
Changed production files: 1
Changed automated test files: 1
Result: PASS
```

```
$ npm run check:fabricated-docs
✓ No fabricated API/env/CLI/hook/file references found.
```
