### PR TITLE
chore: remove unused webhook example payload helper

### DIFF
--- a/src/lib/webhooks/eventDescriptions.ts
+++ b/src/lib/webhooks/eventDescriptions.ts
@@ -74,12 +74,3 @@ export const EVENT_DESCRIPTIONS: Record<WebhookEvent, EventDescription> = {
     exampleData: { message: "Test ping from OmniRoute", webhookId: "preview" },
   },
 };
-
-export function buildExamplePayload(event: WebhookEvent): Record<string, unknown> {
-  return {
-    event,
-    webhook_id: "preview",
-    timestamp: new Date().toISOString(),
-    data: EVENT_DESCRIPTIONS[event].exampleData,
-  };
-}

--- a/tests/unit/webhook-event-descriptions.test.ts
+++ b/tests/unit/webhook-event-descriptions.test.ts
@@ -1,0 +1,13 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const webhookEvents = await import("../../src/lib/webhooks/eventDescriptions.ts");
+
+test("webhook event descriptions expose event metadata without the unused payload builder", () => {
+  const descriptions = webhookEvents.EVENT_DESCRIPTIONS;
+
+  assert.ok(descriptions["request.completed"]);
+  assert.equal(descriptions["request.completed"].label, "Request Completed");
+  assert.equal(descriptions["test.ping"].exampleData.webhookId, "preview");
+  assert.equal("buildExamplePayload" in webhookEvents, false);
+});


### PR DESCRIPTION
## Summary

- Removed the unused `buildExamplePayload` export from `src/lib/webhooks/eventDescriptions.ts`.
- Kept the active `EVENT_DESCRIPTIONS` metadata used by Slack, Discord, and Telegram webhook integrations unchanged.
- Added focused coverage for the webhook event-description public surface.
- Left the dead-code baseline unchanged; the final ratchet remains deferred.

## Validation

```
$ node --import tsx/esm --test tests/unit/webhook-event-descriptions.test.ts tests/unit/webhook-slack-dispatcher.test.ts tests/unit/webhook-discord-dispatcher.test.ts tests/unit/webhook-telegram-dispatcher.test.ts
# tests 15
# pass 15
# fail 0
```

```
$ node scripts/check/check-dead-code.mjs --quiet
DEAD_EXPORTS=215
DEAD_FILES=94
DEAD_TOTAL=309
[dead-code] OK — 309 símbolos mortos (baseline 310)
```

```
$ GITHUB_BASE_REF=release/v3.8.41 GITHUB_BASE_SHA=upstream/release/v3.8.41 node scripts/check/check-pr-test-policy.mjs
Changed production files: 1
Changed automated test files: 1
Result: PASS
```

```
$ npm run check:fabricated-docs
✓ No fabricated API/env/CLI/hook/file references found.
```
