### PR TITLE
chore: remove unused settings fallback schema

### DIFF
--- a/src/shared/validation/schemas/settings.ts
+++ b/src/shared/validation/schemas/settings.ts
@@ -1,8 +1,5 @@
 import { z } from "zod";
-import {
-  ACCOUNT_FALLBACK_STRATEGY_VALUES,
-  ROUTING_STRATEGY_VALUES,
-} from "@/shared/constants/routingStrategies";
+import { ROUTING_STRATEGY_VALUES } from "@/shared/constants/routingStrategies";
 import { SUPPORTED_BATCH_ENDPOINTS } from "@/shared/constants/batchEndpoints";
 import { MAX_REQUEST_BODY_LIMIT_MB, MIN_REQUEST_BODY_LIMIT_MB } from "@/shared/constants/bodySize";
 import { COMBO_CONFIG_MODES } from "@/shared/constants/comboConfigMode";
@@ -14,11 +11,6 @@ import {
   isForbiddenCustomHeaderName,
 } from "@/shared/constants/upstreamHeaders";
 import { MAX_TIMER_TIMEOUT_MS } from "@/shared/utils/runtimeTimeouts";
-
-// ──── Settings Schemas ────
-// FASE-01: Removed .passthrough() — only explicitly listed fields are accepted
-
-export const settingsFallbackStrategySchema = z.enum(ACCOUNT_FALLBACK_STRATEGY_VALUES);
 
 // Single source of truth: ../settingsSchemas (the schema the runtime settings route validates
 // against). Re-exported here so this modular barrel stays in exact lockstep — a divergent local

--- a/tests/unit/settings-schema-routing-strategies.test.ts
+++ b/tests/unit/settings-schema-routing-strategies.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { SETTINGS_FALLBACK_STRATEGY_VALUES } from "@/shared/constants/routingStrategies";
 import { updateSettingsSchema as settingsRouteSchema } from "@/shared/validation/settingsSchemas";
+import * as sharedSchemaModule from "@/shared/validation/schemas";
 import { updateSettingsSchema as sharedSettingsSchema } from "@/shared/validation/schemas";
 
 for (const strategy of SETTINGS_FALLBACK_STRATEGY_VALUES) {
@@ -21,6 +22,10 @@ test("settings schemas reject combo-only strategies as account fallback strategi
     assert.equal(settingsRouteSchema.safeParse({ fallbackStrategy: strategy }).success, false);
     assert.equal(sharedSettingsSchema.safeParse({ fallbackStrategy: strategy }).success, false);
   }
+});
+
+test("shared settings schema module omits the unused fallback strategy sub-schema export", () => {
+  assert.equal("settingsFallbackStrategySchema" in sharedSchemaModule, false);
 });
 
 test("settings schemas accept cooldown-aware retry knobs", () => {


### PR DESCRIPTION
## Summary

- Removed the unused `settingsFallbackStrategySchema` export from `src/shared/validation/schemas/settings.ts`.
- Kept the runtime `updateSettingsSchema` fallback-strategy validation unchanged.
- Updated the routing-strategy settings schema test to assert the smaller public surface.
- Left the dead-code baseline unchanged; the final ratchet remains deferred.

## Validation

```
$ node --import tsx/esm --test tests/unit/settings-schema-routing-strategies.test.ts
# tests 27
# pass 27
# fail 0
```

```
$ node scripts/check/check-dead-code.mjs --quiet
DEAD_EXPORTS=215
DEAD_FILES=94
DEAD_TOTAL=309
[dead-code] OK — 309 símbolos mortos (baseline 310)
```

```
$ GITHUB_BASE_REF=release/v3.8.41 GITHUB_BASE_SHA=upstream/release/v3.8.41 node scripts/check/check-pr-test-policy.mjs
Changed production files: 1
Changed automated test files: 1
Result: PASS
```

```
$ npm run check:fabricated-docs
✓ No fabricated API/env/CLI/hook/file references found.
```
