### PR TITLE
chore: remove unused command-code auth cleanup export

### DIFF
--- a/src/lib/db/commandCodeAuth.ts
+++ b/src/lib/db/commandCodeAuth.ts
@@ -207,14 +207,3 @@ export function consumeCommandCodeAuthSecret(
     };
   })() as ConsumedCommandCodeAuthSecret | null;
 }
-
-export function cleanupExpiredCommandCodeAuthSessions(now = nowIso()): number {
-  const result = db()
-    .prepare(
-      `UPDATE command_code_auth_sessions
-       SET status = 'expired', updated_at = ?
-       WHERE status IN ('pending', 'received') AND expires_at <= ?`
-    )
-    .run(now, now);
-  return result.changes ?? 0;
-}

--- a/tests/unit/db-command-code-auth.test.ts
+++ b/tests/unit/db-command-code-auth.test.ts
@@ -1,0 +1,66 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omni-command-code-auth-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const coreDb = await import("../../src/lib/db/core.ts");
+const commandCodeAuthDb = await import("../../src/lib/db/commandCodeAuth.ts");
+
+async function resetStorage() {
+  coreDb.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+test.beforeEach(async () => {
+  await resetStorage();
+});
+
+test.after(() => {
+  coreDb.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("status lookup expires stale pending command-code auth sessions", () => {
+  const stateHash = commandCodeAuthDb.hashCommandCodeAuthState("expired-state");
+  const session = commandCodeAuthDb.createPendingCommandCodeAuthSession({
+    stateHash,
+    expiresAt: "2026-01-01T00:00:00.000Z",
+  });
+
+  assert.equal(session.status, "pending");
+
+  const status = commandCodeAuthDb.getCommandCodeAuthSessionSafeStatus(stateHash);
+
+  assert.equal(status?.status, "expired");
+  assert.equal(status?.stateHash, stateHash);
+});
+
+test("consume returns the received api key once and marks the session applied", () => {
+  const stateHash = commandCodeAuthDb.hashCommandCodeAuthState("received-state");
+  commandCodeAuthDb.createPendingCommandCodeAuthSession({
+    stateHash,
+    expiresAt: "2999-01-01T00:00:00.000Z",
+  });
+
+  const received = commandCodeAuthDb.markCommandCodeAuthSessionReceived({
+    stateHash,
+    apiKey: "sk-test-command-code",
+    metadata: { userId: "user-1", userName: "Test User" },
+  });
+
+  assert.equal(received?.status, "received");
+  assert.equal(received?.metadata?.userId, "user-1");
+
+  const consumed = commandCodeAuthDb.consumeCommandCodeAuthSecret(stateHash);
+
+  assert.equal(consumed?.apiKey, "sk-test-command-code");
+  assert.equal(consumed?.status, "applied");
+
+  assert.equal(commandCodeAuthDb.consumeCommandCodeAuthSecret(stateHash), null);
+  assert.equal(commandCodeAuthDb.getCommandCodeAuthSessionSafeStatus(stateHash)?.status, "applied");
+});


### PR DESCRIPTION
## Summary

- Removed the unused `cleanupExpiredCommandCodeAuthSessions` export from the command-code auth DB module.
- Added focused coverage for the remaining public command-code auth expiry and consume/apply behavior.
- Left the dead-code baseline unchanged; the final ratchet remains deferred.

## Validation

```
$ node --import tsx/esm --test tests/unit/db-command-code-auth.test.ts
# tests 2
# pass 2
# fail 0
```

```
$ node scripts/check/check-dead-code.mjs --quiet
DEAD_EXPORTS=205
DEAD_FILES=94
DEAD_TOTAL=299
[dead-code] OK — 299 símbolos mortos (baseline 310)
```

```
$ GITHUB_BASE_REF=release/v3.8.41 GITHUB_BASE_SHA=upstream/release/v3.8.41 node scripts/check/check-pr-test-policy.mjs
Result: PASS
```

```
$ npm run check:fabricated-docs
✓ No fabricated API/env/CLI/hook/file references found.
```