### PR TITLE
chore: remove unused webhook delivery detail export

### DIFF
--- a/src/lib/db/webhookDeliveries.ts
+++ b/src/lib/db/webhookDeliveries.ts
@@ -75,12 +75,3 @@ export function getDeliveries(webhookId: string, limit: number): WebhookDelivery
     )
     .all(webhookId, limit) as WebhookDeliverySafe[];
 }
-
-/** Fetch one delivery including `payload_snapshot` — used for opt-in detail view. */
-export function getDeliveryDetail(webhookId: string, deliveryId: number): WebhookDelivery | null {
-  const db = getDbInstance();
-  const row = db
-    .prepare(`SELECT * FROM webhook_deliveries WHERE webhook_id = ? AND id = ? LIMIT 1`)
-    .get(webhookId, deliveryId);
-  return (row as WebhookDelivery | undefined) ?? null;
-}

--- a/tests/unit/webhook-deliveries-db.test.ts
+++ b/tests/unit/webhook-deliveries-db.test.ts
@@ -42,6 +42,7 @@ test("insertDelivery stores a row and getDeliveries returns it", () => {
   assert.equal(rows[0].http_status, 200);
   assert.equal(rows[0].latency_ms, 142);
   assert.equal(rows[0].status, "delivered");
+  assert.equal("payload_snapshot" in rows[0], false);
 });
 
 test("rotation keeps only last 100 deliveries per webhook", () => {


### PR DESCRIPTION
## Summary

- Removed the unused `getDeliveryDetail` export from the webhook delivery DB module.
- Kept the delivery list API on its safe projection and added an assertion that it does not expose `payload_snapshot`.
- Left the dead-code baseline unchanged; the final ratchet remains deferred.

## Validation

```
$ node --import tsx/esm --test tests/unit/webhook-deliveries-db.test.ts
# tests 7
# pass 7
# fail 0
```

```
$ node scripts/check/check-dead-code.mjs --quiet
DEAD_EXPORTS=205
DEAD_FILES=94
DEAD_TOTAL=299
[dead-code] OK — 299 símbolos mortos (baseline 310)
```

```
$ GITHUB_BASE_REF=release/v3.8.41 GITHUB_BASE_SHA=upstream/release/v3.8.41 node scripts/check/check-pr-test-policy.mjs
Result: PASS
```

```
$ npm run check:fabricated-docs
✓ No fabricated API/env/CLI/hook/file references found.
```