### PR TITLE
chore: remove unused cloud agent input types

### DIFF
--- a/src/lib/cloudAgent/types.ts
+++ b/src/lib/cloudAgent/types.ts
@@ -88,6 +88,3 @@ export const UpdateCloudAgentTaskSchema = z.object({
   action: z.enum(["approve", "reject", "cancel", "message"]),
   message: z.string().optional(),
 });
-
-export type CreateCloudAgentTaskInput = z.infer<typeof CreateCloudAgentTaskSchema>;
-export type UpdateCloudAgentTaskInput = z.infer<typeof UpdateCloudAgentTaskSchema>;


### PR DESCRIPTION
## Summary

- Removed the unused `CreateCloudAgentTaskInput` and `UpdateCloudAgentTaskInput` type exports from the cloud-agent type module.
- Kept the runtime Zod schemas exported and added a public-surface assertion for the schema exports.
- Left the dead-code baseline unchanged; the final ratchet remains deferred.

## Validation

```
$ node --import tsx/esm --test tests/unit/cloudAgent-types.test.ts
# tests 17
# pass 17
# fail 0
```

```
$ node scripts/check/check-dead-code.mjs --quiet
DEAD_EXPORTS=204
DEAD_FILES=94
DEAD_TOTAL=298
[dead-code] OK — 298 símbolos mortos (baseline 310)
```

```
$ GITHUB_BASE_REF=release/v3.8.41 GITHUB_BASE_SHA=upstream/release/v3.8.41 node scripts/check/check-pr-test-policy.mjs
Result: PASS
```

```
$ npm run check:fabricated-docs
✓ No fabricated API/env/CLI/hook/file references found.
```