### PR TITLE
chore: remove unused cloud agent result schemas

### DIFF
--- a/src/lib/cloudAgent/types.ts
+++ b/src/lib/cloudAgent/types.ts
@@ -70,24 +70,6 @@ export const CloudAgentSourceSchema = z.object({
   branch: z.string().optional(),
 });
 
-export const CloudAgentResultSchema = z.object({
-  prUrl: z.string().url().optional(),
-  prNumber: z.number().int().positive().optional(),
-  commitMessage: z.string().optional(),
-  diffUrl: z.string().url().optional(),
-  summary: z.string().optional(),
-  duration: z.number().int().positive().optional(),
-  cost: z.number().positive().optional(),
-});
-
-export const CloudAgentActivitySchema = z.object({
-  id: z.string(),
-  type: z.enum(["plan", "command", "code_change", "message", "error", "completion"]),
-  content: z.string(),
-  timestamp: z.string().datetime(),
-  metadata: z.record(z.string(), z.unknown()).optional(),
-});
-
 export const CloudAgentTaskOptionsSchema = z.object({
   autoCreatePr: z.boolean().optional(),
   planApprovalRequired: z.boolean().optional(),

--- a/tests/unit/cloudAgent-types.test.ts
+++ b/tests/unit/cloudAgent-types.test.ts
@@ -1,10 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-const { CLOUD_AGENT_STATUS, CloudAgentStatusSchema } =
-  await import("../../src/lib/cloudAgent/types.ts");
-const { CreateCloudAgentTaskSchema, UpdateCloudAgentTaskSchema } =
-  await import("../../src/lib/cloudAgent/types.ts");
+const cloudAgentTypes = await import("../../src/lib/cloudAgent/types.ts");
+const { CLOUD_AGENT_STATUS, CloudAgentStatusSchema } = cloudAgentTypes;
+const { CreateCloudAgentTaskSchema, UpdateCloudAgentTaskSchema } = cloudAgentTypes;
 const { isCloudAgentProvider, getAgent, getAvailableAgents } =
   await import("../../src/lib/cloudAgent/registry.ts");
 
@@ -15,6 +14,21 @@ test("CLOUD_AGENT_STATUS has correct values", () => {
   assert.strictEqual(CLOUD_AGENT_STATUS.COMPLETED, "completed");
   assert.strictEqual(CLOUD_AGENT_STATUS.FAILED, "failed");
   assert.strictEqual(CLOUD_AGENT_STATUS.CANCELLED, "cancelled");
+});
+
+test("cloud agent types module exposes the request validation schemas", () => {
+  const expectedRuntimeExports = [
+    "CLOUD_AGENT_STATUS",
+    "CloudAgentSourceSchema",
+    "CloudAgentStatusSchema",
+    "CloudAgentTaskOptionsSchema",
+    "CreateCloudAgentTaskSchema",
+    "UpdateCloudAgentTaskSchema",
+  ];
+
+  for (const key of expectedRuntimeExports) {
+    assert.equal(key in cloudAgentTypes, true, `${key} should stay exported`);
+  }
 });
 
 test("CloudAgentStatusSchema validates valid statuses", () => {


### PR DESCRIPTION
## Summary

- Removed unused `CloudAgentResultSchema` and `CloudAgentActivitySchema` exports from the cloud-agent type module.
- Kept the TypeScript interfaces and request validation schemas used by cloud-agent routes/agents.
- Updated the cloud-agent type test to assert the remaining request validation schema surface.
- Left the dead-code baseline unchanged; the final ratchet remains deferred.

## Validation

```
$ node --import tsx/esm --test tests/unit/cloudAgent-types.test.ts
# tests 17
# pass 17
# fail 0
```

```
$ node scripts/check/check-dead-code.mjs --quiet
DEAD_EXPORTS=198
DEAD_FILES=94
DEAD_TOTAL=292
[dead-code] OK — 292 símbolos mortos (baseline 310)
```

```
$ GITHUB_BASE_REF=release/v3.8.41 GITHUB_BASE_SHA=upstream/release/v3.8.41 node scripts/check/check-pr-test-policy.mjs
Result: PASS
```

```
$ npm run check:fabricated-docs
✓ No fabricated API/env/CLI/hook/file references found.
```