### PR TITLE
chore: remove unused v1 search response schema

### DIFF
--- a/src/shared/validation/schemas/apiV1.ts
+++ b/src/shared/validation/schemas/apiV1.ts
@@ -231,42 +231,6 @@ export const searchResultSchema = z.object({
   provider_raw: z.record(z.string(), z.unknown()).nullable().optional(),
 });
 
-export const v1SearchResponseSchema = z.object({
-  id: z.string(),
-  provider: z.string(),
-  query: z.string(),
-  results: z.array(searchResultSchema),
-  cached: z.boolean(),
-  answer: z
-    .object({
-      source: z.enum(["none", "provider", "internal"]).optional(),
-      text: z.string().nullable().optional(),
-      model: z.string().nullable().optional(),
-    })
-    .nullable()
-    .optional(),
-  usage: z.object({
-    queries_used: z.number().int().min(0),
-    search_cost_usd: z.number().min(0),
-    llm_tokens: z.number().int().min(0).optional(),
-  }),
-  metrics: z.object({
-    response_time_ms: z.number().int().min(0),
-    upstream_latency_ms: z.number().int().min(0).optional(),
-    gateway_latency_ms: z.number().int().min(0).optional(),
-    total_results_available: z.number().int().nullable(),
-  }),
-  errors: z
-    .array(
-      z.object({
-        provider: z.string(),
-        code: z.string(),
-        message: z.string(),
-      })
-    )
-    .optional(),
-});
-
 export const v1BatchCreateSchema = z.object({
   input_file_id: z.string().min(1),
   endpoint: z.enum(SUPPORTED_BATCH_ENDPOINTS),

--- a/tests/unit/search-registry.test.ts
+++ b/tests/unit/search-registry.test.ts
@@ -338,6 +338,13 @@ test("SEARCH_CACHE_DEFAULT_TTL_MS is positive", () => {
 
 // ─── Validation Schema Tests ────────────────────────────────
 
+test("shared validation exports the v1 search request schema", async () => {
+  const schemas = await import("../../src/shared/validation/schemas.ts");
+
+  assert.equal("v1SearchSchema" in schemas, true);
+  assert.equal(typeof schemas.v1SearchSchema.safeParse, "function");
+});
+
 test("v1SearchSchema validates correct input", async () => {
   const { v1SearchSchema } = await import("../../src/shared/validation/schemas.ts");
 


### PR DESCRIPTION
## Summary

- Removed the unused `v1SearchResponseSchema` export from the shared API v1 validation schemas.
- Kept the search request schema and search result schema in place.
- Added a focused assertion that the shared validation surface still exports `v1SearchSchema`.
- Left the dead-code baseline unchanged; the final ratchet remains deferred.

## Validation

```
$ node --import tsx/esm --test tests/unit/search-registry.test.ts
# tests 45
# pass 45
# fail 0
```

```
$ node scripts/check/check-dead-code.mjs --quiet
DEAD_EXPORTS=200
DEAD_FILES=94
DEAD_TOTAL=294
[dead-code] OK — 294 símbolos mortos (baseline 310)
```

```
$ GITHUB_BASE_REF=release/v3.8.41 GITHUB_BASE_SHA=upstream/release/v3.8.41 node scripts/check/check-pr-test-policy.mjs
Result: PASS
```

```
$ npm run check:fabricated-docs
✓ No fabricated API/env/CLI/hook/file references found.
```