### PR TITLE
chore: remove unused sse model legacy helpers

### DIFF
--- a/src/sse/services/model.ts
+++ b/src/sse/services/model.ts
@@ -8,12 +8,7 @@ import {
   getCustomModels,
 } from "@/lib/localDb";
 import { getCachedSettings } from "@/lib/localDb";
-import { getComboStepTarget } from "@/lib/combos/steps";
-import {
-  parseModel,
-  resolveModelAliasFromMap,
-  getModelInfoCore,
-} from "@omniroute/open-sse/services/model.ts";
+import { parseModel, getModelInfoCore } from "@omniroute/open-sse/services/model.ts";
 import { REGISTRY } from "@omniroute/open-sse/config/providerRegistry.ts";
 
 export { parseModel };
@@ -65,14 +60,6 @@ async function getCombinedModelAliases(): Promise<Record<string, unknown>> {
 
   // Settings-based aliases win over DB-namespace aliases on key collision
   return { ...dbAliases, ...settingsAliases };
-}
-
-/**
- * Resolve model alias from localDb
- */
-export async function resolveModelAlias(alias) {
-  const aliases = await getModelAliases();
-  return resolveModelAliasFromMap(alias, aliases);
 }
 
 /**
@@ -264,16 +251,4 @@ export async function getComboForModel(modelStr) {
   }
 
   return null;
-}
-
-/**
- * Legacy: get combo models as string array
- * @returns {Promise<string[]|null>}
- */
-export async function getComboModels(modelStr) {
-  const combo = await getCombo(modelStr);
-  if (!combo) return null;
-  return (combo.models || [])
-    .map((entry) => getComboStepTarget(entry))
-    .filter((entry): entry is string => typeof entry === "string" && entry.length > 0);
 }

--- a/tests/unit/sse-shim-contract.test.ts
+++ b/tests/unit/sse-shim-contract.test.ts
@@ -46,6 +46,14 @@ test("src/sse model shim keeps parseModel behavior aligned with open-sse core", 
   }
 });
 
+test("src/sse model shim exposes the active model helper surface", async () => {
+  const srcModel = await import("../../src/sse/services/model.ts");
+
+  for (const helper of ["parseModel", "getModelInfo", "getCombo", "getComboForModel"]) {
+    assert.equal(typeof srcModel[helper], "function", `${helper} should stay exported`);
+  }
+});
+
 test("src/sse service wrappers delegate to open-sse and shared infrastructure", () => {
   const tokenRefreshSource = readProjectFile("src/sse/services/tokenRefresh.ts");
   const modelSource = readProjectFile("src/sse/services/model.ts");


### PR DESCRIPTION
## Summary

- Removed unused legacy helper exports from the `src/sse` model shim (`resolveModelAlias`, `getComboModels`).
- Kept the active shim surface used by routes (`parseModel`, `getModelInfo`, `getCombo`, `getComboForModel`).
- Added a shim contract assertion for the remaining active model helper exports.
- Left the dead-code baseline unchanged; the final ratchet remains deferred.

## Validation

```
$ node --import tsx/esm --test tests/unit/sse-shim-contract.test.ts
# tests 4
# pass 4
# fail 0
```

```
$ node scripts/check/check-dead-code.mjs --quiet
DEAD_EXPORTS=198
DEAD_FILES=94
DEAD_TOTAL=292
[dead-code] OK — 292 símbolos mortos (baseline 310)
```

```
$ GITHUB_BASE_REF=release/v3.8.41 GITHUB_BASE_SHA=upstream/release/v3.8.41 node scripts/check/check-pr-test-policy.mjs
Result: PASS
```

```
$ npm run check:fabricated-docs
✓ No fabricated API/env/CLI/hook/file references found.
```