### PR TITLE
chore: remove unused sse logger helpers

### DIFF
--- a/src/sse/utils/logger.ts
+++ b/src/sse/utils/logger.ts
@@ -4,7 +4,7 @@
  *
  * Migrated from direct console logging to structured Pino logging.
  */
-import { createLogger, logger as rootLogger } from "@/shared/utils/logger";
+import { createLogger } from "@/shared/utils/logger";
 
 const log = createLogger("sse");
 
@@ -26,18 +26,6 @@ export function error(tag: string, message: string, data?: unknown) {
 
 export function request(method: string, path: string, extra?: unknown) {
   log.info({ tag: "HTTP", method, path, ...spreadData(extra) }, `📥 ${method} ${path}`);
-}
-
-export function response(status: number, duration: number, extra?: unknown) {
-  const level = status < 400 ? "info" : "error";
-  log[level](
-    { tag: "HTTP", status, duration, ...spreadData(extra) },
-    `📤 ${status} (${duration}ms)`
-  );
-}
-
-export function stream(event: string, data?: unknown) {
-  log.debug({ tag: "STREAM", event, ...spreadData(data) }, `🌊 ${event}`);
 }
 
 // Helper to spread data into structured fields

--- a/tests/unit/formatting-public-surface.test.ts
+++ b/tests/unit/formatting-public-surface.test.ts
@@ -18,5 +18,8 @@ test("formatting utilities public surface excludes removed display helpers", () 
 test("sse logger wrapper no longer re-exports formatting maskKey", () => {
   assert.equal(Object.hasOwn(sseLogger, "maskKey"), false);
   assert.equal(typeof sseLogger.debug, "function");
+  assert.equal(typeof sseLogger.info, "function");
   assert.equal(typeof sseLogger.warn, "function");
+  assert.equal(typeof sseLogger.error, "function");
+  assert.equal(typeof sseLogger.request, "function");
 });


### PR DESCRIPTION
## Summary

- Removed unused `response` and `stream` helper exports from the legacy `src/sse` logger wrapper.
- Dropped the now-unused `rootLogger` import from that wrapper.
- Updated public-surface coverage for the remaining logger helper exports.
- Left the dead-code baseline unchanged; the final ratchet remains deferred.

## Validation

```
$ node --import tsx/esm --test tests/unit/formatting-public-surface.test.ts
# tests 2
# pass 2
# fail 0
```

```
$ node scripts/check/check-dead-code.mjs --quiet
DEAD_EXPORTS=198
DEAD_FILES=94
DEAD_TOTAL=292
[dead-code] OK — 292 símbolos mortos (baseline 310)
```

```
$ GITHUB_BASE_REF=release/v3.8.41 GITHUB_BASE_SHA=upstream/release/v3.8.41 node scripts/check/check-pr-test-policy.mjs
Result: PASS
```

```
$ npm run check:fabricated-docs
✓ No fabricated API/env/CLI/hook/file references found.
```