### PR TITLE
chore: remove unused shared logger default export

### DIFF
--- a/src/shared/utils/logger.ts
+++ b/src/shared/utils/logger.ts
@@ -171,5 +171,3 @@ export const logger = buildLogger();
 export function createLogger(module: string) {
   return logger.child({ module });
 }
-
-export default logger;

--- a/tests/unit/logger-redaction-wiring.test.ts
+++ b/tests/unit/logger-redaction-wiring.test.ts
@@ -12,7 +12,8 @@ process.env.APP_LOG_TO_FILE = "true";
 process.env.APP_LOG_FILE_PATH = logFile;
 process.env.APP_LOG_LEVEL = "debug";
 
-const { createLogger } = await import("../../src/shared/utils/logger.ts");
+const loggerModule = await import("../../src/shared/utils/logger.ts");
+const { createLogger } = loggerModule;
 
 /** Poll the (worker-thread-written) log file until the predicate holds or timeout. */
 async function readLogWhen(
@@ -38,10 +39,18 @@ test("logger redacts a Bearer secret in a free-form message and an error stack (
   log.error({ err }, "request failed");
 
   const contents = await readLogWhen(
-    (c) => c.includes("[REDACTED]") && !c.includes("sk-superSecretKey") && !c.includes("sk-anotherSecret")
+    (c) =>
+      c.includes("[REDACTED]") &&
+      !c.includes("sk-superSecretKey") &&
+      !c.includes("sk-anotherSecret")
   );
 
   assert.match(contents, /\[REDACTED\]/, "redaction marker must appear in the log output");
   assert.doesNotMatch(contents, /sk-superSecretKey/, "message secret must be redacted");
   assert.doesNotMatch(contents, /sk-anotherSecret/, "error-stack secret must be redacted");
+});
+
+test("shared logger module exposes named logger helpers", () => {
+  assert.equal(typeof loggerModule.logger.info, "function");
+  assert.equal(typeof loggerModule.createLogger, "function");
 });


### PR DESCRIPTION
## Summary

- Removed the unused default export from the shared Pino logger module.
- Kept the named `logger` and `createLogger` exports used throughout the app.
- Added focused coverage for the named logger helper surface.
- Left the dead-code baseline unchanged; the final ratchet remains deferred.

## Validation

```
$ node --import tsx/esm --test tests/unit/logger-redaction-wiring.test.ts
# tests 2
# pass 2
# fail 0
```

```
$ node scripts/check/check-dead-code.mjs --quiet
DEAD_EXPORTS=199
DEAD_FILES=94
DEAD_TOTAL=293
[dead-code] OK — 293 símbolos mortos (baseline 310)
```

```
$ GITHUB_BASE_REF=release/v3.8.41 GITHUB_BASE_SHA=upstream/release/v3.8.41 node scripts/check/check-pr-test-policy.mjs
Result: PASS
```

```
$ npm run check:fabricated-docs
✓ No fabricated API/env/CLI/hook/file references found.
```