### PR TITLE
chore: remove unused agent skills schema types

### DIFF
--- a/src/lib/agentSkills/schemas.ts
+++ b/src/lib/agentSkills/schemas.ts
@@ -34,8 +34,3 @@ export const GenerateBodySchema = z.object({
   prune: z.boolean().default(false),
   onlyIds: z.array(z.string()).optional(),
 });
-
-export type AgentSkillT = z.infer<typeof AgentSkillSchema>;
-export type SkillCoverageT = z.infer<typeof SkillCoverageSchema>;
-export type ListQueryT = z.infer<typeof ListQuerySchema>;
-export type GenerateBodyT = z.infer<typeof GenerateBodySchema>;

--- a/tests/unit/agentSkills-schemas.test.ts
+++ b/tests/unit/agentSkills-schemas.test.ts
@@ -4,6 +4,20 @@ import assert from "node:assert/strict";
 const { AgentSkillSchema, SkillCoverageSchema, ListQuerySchema, GenerateBodySchema } =
   await import("../../src/lib/agentSkills/schemas.ts");
 
+test("agent skills schemas module exposes runtime validators", async () => {
+  const schemas = await import("../../src/lib/agentSkills/schemas.ts");
+
+  for (const key of [
+    "AgentSkillSchema",
+    "GenerateBodySchema",
+    "ListQuerySchema",
+    "SkillCategorySchema",
+    "SkillCoverageSchema",
+  ]) {
+    assert.equal(typeof schemas[key].safeParse, "function", `${key} should stay exported`);
+  }
+});
+
 // ─── AgentSkillSchema ─────────────────────────────────────────────────────────
 
 test("AgentSkillSchema — valid api skill parses successfully", () => {
@@ -105,7 +119,15 @@ test("AgentSkillSchema — optional fields absent parses successfully", () => {
 
 test("AgentSkillSchema — .parse throws on invalid input", () => {
   assert.throws(() => {
-    AgentSkillSchema.parse({ id: "bad id", name: "", description: "", category: "api", area: "x", rawUrl: "x", githubUrl: "x" });
+    AgentSkillSchema.parse({
+      id: "bad id",
+      name: "",
+      description: "",
+      category: "api",
+      area: "x",
+      rawUrl: "x",
+      githubUrl: "x",
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

- Removed unused inferred type exports from the agent-skills schema module.
- Kept the runtime Zod validators used by the agent-skills routes.
- Added focused coverage for the remaining runtime schema export surface.
- Left the dead-code baseline unchanged; the final ratchet remains deferred.

## Validation

```
$ node --import tsx/esm --test tests/unit/agentSkills-schemas.test.ts
# tests 21
# pass 21
# fail 0
```

```
$ node scripts/check/check-dead-code.mjs --quiet
DEAD_EXPORTS=196
DEAD_FILES=94
DEAD_TOTAL=290
[dead-code] OK — 290 símbolos mortos (baseline 310)
```

```
$ GITHUB_BASE_REF=release/v3.8.41 GITHUB_BASE_SHA=upstream/release/v3.8.41 node scripts/check/check-pr-test-policy.mjs
Result: PASS
```

```
$ npm run check:fabricated-docs
✓ No fabricated API/env/CLI/hook/file references found.
```