### PR TITLE
chore: remove unused audit action type

### DIFF
--- a/src/lib/audit/highLevelActions.ts
+++ b/src/lib/audit/highLevelActions.ts
@@ -50,8 +50,6 @@ export const HIGH_LEVEL_ACTIONS = [
   "quota.store.driver_changed",
 ] as const;
 
-export type HighLevelAction = (typeof HIGH_LEVEL_ACTIONS)[number];
-
 const SET: ReadonlySet<string> = new Set<string>(HIGH_LEVEL_ACTIONS);
 
 export function isHighLevelAction(action: string): boolean {

--- a/tests/unit/audit-high-level-actions.test.ts
+++ b/tests/unit/audit-high-level-actions.test.ts
@@ -5,6 +5,13 @@ import { HIGH_LEVEL_ACTIONS, isHighLevelAction } from "../../src/lib/audit/highL
 
 const ALL = HIGH_LEVEL_ACTIONS as readonly string[];
 
+test("high-level actions module exposes runtime allowlist helpers", async () => {
+  const mod = await import("../../src/lib/audit/highLevelActions");
+
+  assert.equal(Array.isArray(mod.HIGH_LEVEL_ACTIONS), true);
+  assert.equal(typeof mod.isHighLevelAction, "function");
+});
+
 // B/G3: allowlist aligned with logAuditEvent emitters (27 after batch_updated).
 test("HIGH_LEVEL_ACTIONS has exactly 27 entries", () => {
   assert.equal(ALL.length, 27);


### PR DESCRIPTION
## Summary

- Removed the unused `HighLevelAction` type export from the audit high-level action allowlist module.
- Kept the runtime allowlist and `isHighLevelAction` helper used by compliance/activity code.
- Added focused coverage for the remaining runtime export surface.
- Left the dead-code baseline unchanged; the final ratchet remains deferred.

## Validation

```
$ node --import tsx/esm --test tests/unit/audit-high-level-actions.test.ts
# tests 12
# pass 12
# fail 0
```

```
$ node scripts/check/check-dead-code.mjs --quiet
DEAD_EXPORTS=199
DEAD_FILES=94
DEAD_TOTAL=293
[dead-code] OK — 293 símbolos mortos (baseline 310)
```

```
$ GITHUB_BASE_REF=release/v3.8.41 GITHUB_BASE_SHA=upstream/release/v3.8.41 node scripts/check/check-pr-test-policy.mjs
Result: PASS
```

```
$ npm run check:fabricated-docs
✓ No fabricated API/env/CLI/hook/file references found.
```