### PR TITLE
chore: remove unused memory schema types

### DIFF
--- a/src/shared/schemas/memory.ts
+++ b/src/shared/schemas/memory.ts
@@ -68,9 +68,9 @@ export const EmbeddingProviderListingSchema = z.object({
           id: z.string(), // `provider/model`
           name: z.string(),
           dimensions: z.number().nullable(),
-        }),
+        })
       ),
-    }),
+    })
   ),
 });
 
@@ -123,7 +123,7 @@ export const RetrievePreviewResultSchema = z.object({
       tier: z.enum(["fts5", "vector", "hybrid-rrf", "qdrant"]),
       vecScore: z.number().nullable(),
       ftsScore: z.number().nullable(),
-    }),
+    })
   ),
   resolution: z.object({
     embeddingSource: z.enum(["remote", "static", "transformers"]).nullable(),
@@ -138,10 +138,5 @@ export const RetrievePreviewResultSchema = z.object({
 });
 
 export type MemorySettingsExtended = z.infer<typeof MemorySettingsExtendedSchema>;
-export type MemoryUpdatePut = z.infer<typeof MemoryUpdatePutSchema>;
-export type RetrievePreview = z.infer<typeof RetrievePreviewSchema>;
-export type MemoryReindex = z.infer<typeof MemoryReindexSchema>;
-export type MemorySummarize = z.infer<typeof MemorySummarizeSchema>;
-export type EmbeddingProviderListings = z.infer<typeof EmbeddingProviderListingSchema>;
 export type MemoryEngineStatus = z.infer<typeof MemoryEngineStatusSchema>;
 export type RetrievePreviewResult = z.infer<typeof RetrievePreviewResultSchema>;

--- a/tests/unit/memory-schemas-roundtrip.test.ts
+++ b/tests/unit/memory-schemas-roundtrip.test.ts
@@ -19,6 +19,17 @@ import {
   QdrantHealthResultSchema,
 } from "../../src/shared/schemas/qdrant.ts";
 
+test("memory schema module keeps the runtime request/response schemas exported", () => {
+  assert.equal(typeof MemorySettingsExtendedSchema.safeParse, "function");
+  assert.equal(typeof MemoryUpdatePutSchema.safeParse, "function");
+  assert.equal(typeof RetrievePreviewSchema.safeParse, "function");
+  assert.equal(typeof MemoryReindexSchema.safeParse, "function");
+  assert.equal(typeof MemorySummarizeSchema.safeParse, "function");
+  assert.equal(typeof EmbeddingProviderListingSchema.safeParse, "function");
+  assert.equal(typeof MemoryEngineStatusSchema.safeParse, "function");
+  assert.equal(typeof RetrievePreviewResultSchema.safeParse, "function");
+});
+
 // ---------------------------------------------------------------------------
 // 1. MemorySettingsExtendedSchema
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Removed unused type-only exports from `src/shared/schemas/memory.ts` for memory update, retrieve preview, reindex, summarize, and embedding provider listing payloads.
- Kept the runtime Zod schemas exported for route and UI consumers.
- Added focused coverage that asserts the memory schema module continues to expose the runtime request/response schemas.
- Left the dead-code baseline unchanged; the final ratchet remains deferred.

## Validation

```
$ node --import tsx/esm --test tests/unit/memory-schemas-roundtrip.test.ts
# tests 35
# pass 35
# fail 0
```

```
$ node scripts/check/check-dead-code.mjs --quiet
DEAD_EXPORTS=195
DEAD_FILES=94
DEAD_TOTAL=289
[dead-code] OK — 289 símbolos mortos (baseline 310)
```

```
$ GITHUB_BASE_REF=release/v3.8.41 GITHUB_BASE_SHA=upstream/release/v3.8.41 node scripts/check/check-pr-test-policy.mjs
Result: PASS
```

```
$ npm run check:fabricated-docs
✓ No fabricated API/env/CLI/hook/file references found.
```
