### PR TITLE
chore: remove unused kiro social schema

### DIFF
--- a/src/shared/validation/schemas/auth.ts
+++ b/src/shared/validation/schemas/auth.ts
@@ -133,7 +133,10 @@ export const oauthPollSchema = z.object({
 
 /** Import a raw API token (e.g. WINDSURF_API_KEY) without going through the browser OAuth flow. */
 export const oauthImportTokenSchema = z.object({
-  token: z.union([z.string().trim().min(1, "Token is required"), z.record(z.string(), z.unknown())]),
+  token: z.union([
+    z.string().trim().min(1, "Token is required"),
+    z.record(z.string(), z.unknown()),
+  ]),
   connectionId: z.string().optional(),
 });
 
@@ -190,12 +193,6 @@ export const kiroImportSchema = z.object({
   clientSecret: z.string().optional(),
   authMethod: z.string().optional(),
   profileArn: z.string().optional(),
-});
-
-export const kiroSocialExchangeSchema = z.object({
-  code: z.string().trim().min(1, "Code is required"),
-  codeVerifier: z.string().trim().min(1, "Code verifier is required"),
-  provider: z.enum(["google", "github"]),
 });
 
 export const zedImportSchema = z.object({

--- a/tests/unit/oauth-kiro.test.ts
+++ b/tests/unit/oauth-kiro.test.ts
@@ -46,6 +46,11 @@ test("KIRO_CONFIG.socialClientId default matches the public CLI identifier 'kiro
   }
 });
 
+test("auth schemas keep the supported Kiro import schema exported", async () => {
+  const { kiroImportSchema } = await import("../../src/shared/validation/schemas/auth.ts");
+  assert.equal(typeof kiroImportSchema.safeParse, "function");
+});
+
 test("Kiro social-flow routes do not duplicate the AWS auth URL or 'kiro-cli' literal", () => {
   // Catches future refactors that copy a hard-coded URL/identifier back into
   // either route. The string "kiro-cli" may still appear as an env-var name


### PR DESCRIPTION
## Summary

- Removed the unused `kiroSocialExchangeSchema` export from `src/shared/validation/schemas/auth.ts`.
- Kept the supported Kiro import schema exported and covered by the existing Kiro OAuth test file.
- Left the Kiro social device-code route untouched; it uses its own `deviceCode` polling schema.
- Left the dead-code baseline unchanged; the final ratchet remains deferred.

## Validation

```
$ node --import tsx/esm --test tests/unit/oauth-kiro.test.ts
# tests 4
# pass 4
# fail 0
```

```
$ node scripts/check/check-dead-code.mjs --quiet
DEAD_EXPORTS=199
DEAD_FILES=94
DEAD_TOTAL=293
[dead-code] OK — 293 símbolos mortos (baseline 310)
```

```
$ GITHUB_BASE_REF=release/v3.8.41 GITHUB_BASE_SHA=upstream/release/v3.8.41 node scripts/check/check-pr-test-policy.mjs
Result: PASS
```

```
$ npm run check:fabricated-docs
✓ No fabricated API/env/CLI/hook/file references found.
```
