### PR TITLE
chore: remove unused qdrant schema types

### DIFF
--- a/src/shared/schemas/qdrant.ts
+++ b/src/shared/schemas/qdrant.ts
@@ -37,8 +37,3 @@ export const QdrantHealthResultSchema = z.object({
   latencyMs: z.number(),
   error: z.string().optional(),
 });
-
-export type QdrantSettings = z.infer<typeof QdrantSettingsSchema>;
-export type QdrantSettingsUpdate = z.infer<typeof QdrantSettingsUpdateSchema>;
-export type QdrantSearch = z.infer<typeof QdrantSearchSchema>;
-export type QdrantHealthResult = z.infer<typeof QdrantHealthResultSchema>;

--- a/tests/unit/qdrant-schemas.test.ts
+++ b/tests/unit/qdrant-schemas.test.ts
@@ -1,0 +1,35 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  QdrantHealthResultSchema,
+  QdrantSearchSchema,
+  QdrantSettingsSchema,
+  QdrantSettingsUpdateSchema,
+} from "../../src/shared/schemas/qdrant.ts";
+
+test("qdrant schema module keeps runtime request and response schemas exported", () => {
+  assert.equal(typeof QdrantSettingsSchema.safeParse, "function");
+  assert.equal(typeof QdrantSettingsUpdateSchema.safeParse, "function");
+  assert.equal(typeof QdrantSearchSchema.safeParse, "function");
+  assert.equal(typeof QdrantHealthResultSchema.safeParse, "function");
+});
+
+test("QdrantSettingsUpdateSchema validates partial updates", () => {
+  const result = QdrantSettingsUpdateSchema.safeParse({
+    enabled: true,
+    host: "qdrant.local",
+    port: 6334,
+  });
+
+  assert.equal(result.success, true);
+});
+
+test("QdrantSearchSchema applies the default topK", () => {
+  const result = QdrantSearchSchema.safeParse({ query: "semantic search" });
+
+  assert.equal(result.success, true);
+  if (result.success) {
+    assert.equal(result.data.topK, 5);
+  }
+});


### PR DESCRIPTION
## Summary

- Removed unused type-only exports from `src/shared/schemas/qdrant.ts`.
- Kept the runtime Qdrant request/response Zod schemas exported for route consumers.
- Added focused Qdrant schema coverage in a separate test file to avoid coupling with other cleanup PRs.
- Left the dead-code baseline unchanged; the final ratchet remains deferred.

## Validation

```
$ node --import tsx/esm --test tests/unit/qdrant-schemas.test.ts
# tests 3
# pass 3
# fail 0
```

```
$ node scripts/check/check-dead-code.mjs --quiet
DEAD_EXPORTS=196
DEAD_FILES=94
DEAD_TOTAL=290
[dead-code] OK — 290 símbolos mortos (baseline 310)
```

```
$ GITHUB_BASE_REF=release/v3.8.41 GITHUB_BASE_SHA=upstream/release/v3.8.41 node scripts/check/check-pr-test-policy.mjs
Result: PASS
```

```
$ npm run check:fabricated-docs
✓ No fabricated API/env/CLI/hook/file references found.
```
