### PR TITLE
chore: remove unused playground row type

### DIFF
--- a/src/shared/schemas/playground.ts
+++ b/src/shared/schemas/playground.ts
@@ -11,7 +11,6 @@ export const PlaygroundPresetRowSchema = z.object({
   params_json: z.string(), // JSON serializado (parsed na rota)
   created_at: z.string().datetime(),
 });
-export type PlaygroundPresetRow = z.infer<typeof PlaygroundPresetRowSchema>;
 
 /** Body de POST /api/playground/presets. */
 export const PlaygroundPresetCreateSchema = z.object({

--- a/tests/unit/playground-schemas.test.ts
+++ b/tests/unit/playground-schemas.test.ts
@@ -12,6 +12,16 @@ const {
   StreamMetricsSchema,
 } = await import("../../src/shared/schemas/playground.ts");
 
+test("playground schema module keeps runtime schemas exported", () => {
+  assert.equal(typeof PlaygroundPresetRowSchema.safeParse, "function");
+  assert.equal(typeof PlaygroundPresetCreateSchema.safeParse, "function");
+  assert.equal(typeof PlaygroundPresetUpdateSchema.safeParse, "function");
+  assert.equal(typeof PlaygroundPresetListItemSchema.safeParse, "function");
+  assert.equal(typeof ToolDefinitionSchema.safeParse, "function");
+  assert.equal(typeof StructuredOutputSchema.safeParse, "function");
+  assert.equal(typeof StreamMetricsSchema.safeParse, "function");
+});
+
 // ── PlaygroundPresetRowSchema ──────────────────────────────────────────────────
 
 test("PlaygroundPresetRowSchema: valid row parses correctly", () => {


### PR DESCRIPTION
## Summary

- Removed the unused `PlaygroundPresetRow` type-only export from `src/shared/schemas/playground.ts`.
- Kept the runtime playground Zod schemas and still-used inferred types exported.
- Added focused coverage that asserts the playground schema module continues to expose its runtime schemas.
- Left the dead-code baseline unchanged; the final ratchet remains deferred.

## Validation

```
$ node --import tsx/esm --test tests/unit/playground-schemas.test.ts
# tests 24
# pass 24
# fail 0
```

```
$ node scripts/check/check-dead-code.mjs --quiet
DEAD_EXPORTS=199
DEAD_FILES=94
DEAD_TOTAL=293
[dead-code] OK — 293 símbolos mortos (baseline 310)
```

```
$ GITHUB_BASE_REF=release/v3.8.41 GITHUB_BASE_SHA=upstream/release/v3.8.41 node scripts/check/check-pr-test-policy.mjs
Result: PASS
```

```
$ npm run check:fabricated-docs
✓ No fabricated API/env/CLI/hook/file references found.
```
