### PR TITLE
chore: remove unused memory schema types

### DIFF
--- a/src/lib/memory/__tests__/schemas.test.ts
+++ b/src/lib/memory/__tests__/schemas.test.ts
@@ -24,6 +24,12 @@ describe("Memory Schemas", () => {
     metadata: { updatedAt: new Date() },
   };
 
+  test("exports runtime schemas", () => {
+    expect(typeof MemoryConfigSchema.safeParse).toBe("function");
+    expect(typeof MemoryCreateInputSchema.safeParse).toBe("function");
+    expect(typeof MemoryUpdateInputSchema.safeParse).toBe("function");
+  });
+
   test("MemoryConfigSchema validation", () => {
     expect(MemoryConfigSchema.parse(validConfig)).toBeDefined();
     const invalidConfig = { ...validConfig, maxTokens: -1 };
@@ -38,7 +44,7 @@ describe("Memory Schemas", () => {
 
   test("MemoryUpdateInputSchema validation", () => {
     expect(MemoryUpdateInputSchema.parse(validUpdateInput)).toBeDefined();
-    const invalidUpdate = { key: "test" };
+    const invalidUpdate = { key: "" };
     expect(() => MemoryUpdateInputSchema.parse(invalidUpdate)).toThrow();
   });
 });

--- a/src/lib/memory/schemas.ts
+++ b/src/lib/memory/schemas.ts
@@ -37,10 +37,3 @@ export const MemoryUpdateInputSchema = z
     metadata: z.record(z.string(), z.unknown()).optional(),
   })
   .strict();
-
-/**
- * Exported schema types for TypeScript references
- */
-export type MemoryConfig = z.infer<typeof MemoryConfigSchema>;
-export type MemoryCreateInput = z.infer<typeof MemoryCreateInputSchema>;
-export type MemoryUpdateInput = z.infer<typeof MemoryUpdateInputSchema>;


### PR DESCRIPTION
## Summary

- Removed unused inferred type exports from `src/lib/memory/schemas.ts` while keeping the runtime Zod schemas exported.
- Added focused coverage that asserts the memory schema module still exposes its runtime schemas.
- Corrected the update-schema invalid fixture from `{ key: "test" }` to `{ key: "" }`, matching the schema's partial-update behavior.
- Left the dead-code baseline unchanged; the final ratchet remains deferred.

## Validation

```
$ npx vitest run src/lib/memory/__tests__/schemas.test.ts
# Test Files  1 passed (1)
# Tests  4 passed (4)
```

```
$ node scripts/check/check-dead-code.mjs --quiet
DEAD_EXPORTS=197
DEAD_FILES=94
DEAD_TOTAL=291
[dead-code] OK — 291 símbolos mortos (baseline 310)
```

```
$ GITHUB_BASE_REF=release/v3.8.41 GITHUB_BASE_SHA=upstream/release/v3.8.41 node scripts/check/check-pr-test-policy.mjs
Result: PASS
```

```
$ npm run check:fabricated-docs
✓ No fabricated API/env/CLI/hook/file references found.
```
