### PR TITLE
chore: remove unused codex auth input type

### DIFF
--- a/src/lib/oauth/utils/codexAuthImport.ts
+++ b/src/lib/oauth/utils/codexAuthImport.ts
@@ -56,18 +56,6 @@ function extractCodexAccountId(
 
 // ──── Public types ────────────────────────────────────────────────────────────
 
-export interface CodexAuthFileInput {
-  auth_mode?: unknown;
-  OPENAI_API_KEY?: unknown;
-  tokens?: {
-    id_token?: unknown;
-    access_token?: unknown;
-    refresh_token?: unknown;
-    account_id?: unknown;
-  };
-  last_refresh?: unknown;
-}
-
 export interface ParsedCodexAuth {
   idToken: string;
   accessToken: string;

--- a/tests/unit/token-refresh-race-comprehensive.test.ts
+++ b/tests/unit/token-refresh-race-comprehensive.test.ts
@@ -87,6 +87,13 @@ test("Fix C reverted: codexAuthImport does NOT refresh tokens on import (avoids 
   );
 });
 
+test("codexAuthImport public surface keeps only consumed auth import types", async () => {
+  const src = await read("src/lib/oauth/utils/codexAuthImport.ts");
+  assert.doesNotMatch(src, /export interface CodexAuthFileInput\b/);
+  assert.match(src, /export interface ParsedCodexAuth\b/);
+  assert.match(src, /export interface CreateConnectionOptions\b/);
+});
+
 test("Fix D: staleness fallback returns absolute expiresAt, not raw expiresIn", async () => {
   const src = await read("open-sse/services/tokenRefresh.ts");
   // Locate the actual return statement, not the JSDoc mention.


### PR DESCRIPTION
## Summary

- Removed the unused `CodexAuthFileInput` interface export from `src/lib/oauth/utils/codexAuthImport.ts`.
- Kept the consumed Codex auth import types and runtime helpers unchanged.
- Added focused source-surface coverage in the existing token-refresh race regression test.
- Left the dead-code baseline unchanged; the final ratchet remains deferred.

## Validation

```
$ node --import tsx/esm --test tests/unit/token-refresh-race-comprehensive.test.ts
# tests 15
# pass 15
# fail 0
```

```
$ node scripts/check/check-dead-code.mjs --quiet
DEAD_EXPORTS=199
DEAD_FILES=94
DEAD_TOTAL=293
[dead-code] OK — 293 símbolos mortos (baseline 310)
```

```
$ GITHUB_BASE_REF=release/v3.8.41 GITHUB_BASE_SHA=upstream/release/v3.8.41 node scripts/check/check-pr-test-policy.mjs
Result: PASS
```

```
$ npm run check:fabricated-docs
✓ No fabricated API/env/CLI/hook/file references found.
```
