### PR TITLE
chore: remove unused skills schema types

### DIFF
--- a/src/lib/skills/schemas.ts
+++ b/src/lib/skills/schemas.ts
@@ -41,7 +41,3 @@ export const SkillConfigSchema = z.object({
   timeout: z.number().int().positive().default(30000),
   maxRetries: z.number().int().min(0).default(3),
 });
-
-export type SkillCreateInput = z.infer<typeof SkillCreateInputSchema>;
-export type SkillUpdateInput = z.infer<typeof SkillUpdateInputSchema>;
-export type SkillConfig = z.infer<typeof SkillConfigSchema>;

--- a/tests/unit/skills-schemas.test.ts
+++ b/tests/unit/skills-schemas.test.ts
@@ -1,0 +1,46 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  SkillConfigSchema,
+  SkillCreateInputSchema,
+  SkillSchema,
+  SkillUpdateInputSchema,
+} from "../../src/lib/skills/schemas.ts";
+import { SkillMode } from "../../src/lib/skills/types.ts";
+
+test("skills schema module keeps runtime schemas exported", () => {
+  assert.equal(typeof SkillSchema.safeParse, "function");
+  assert.equal(typeof SkillCreateInputSchema.safeParse, "function");
+  assert.equal(typeof SkillUpdateInputSchema.safeParse, "function");
+  assert.equal(typeof SkillConfigSchema.safeParse, "function");
+});
+
+test("SkillCreateInputSchema accepts a valid custom skill definition", () => {
+  const result = SkillCreateInputSchema.safeParse({
+    name: "memory-search",
+    version: "1.2.3",
+    description: "Search memory entries",
+    schema: {
+      input: { query: "string" },
+      output: { results: "array" },
+    },
+    handler: "export default async function run() {}",
+  });
+
+  assert.equal(result.success, true);
+});
+
+test("SkillConfigSchema applies defaults for execution settings", () => {
+  const result = SkillConfigSchema.safeParse({
+    enabled: true,
+    mode: SkillMode.HYBRID,
+    allowedSkills: ["memory-search"],
+  });
+
+  assert.equal(result.success, true);
+  if (result.success) {
+    assert.equal(result.data.timeout, 30000);
+    assert.equal(result.data.maxRetries, 3);
+  }
+});


### PR DESCRIPTION
## Summary

- Removed unused inferred type exports from `src/lib/skills/schemas.ts`.
- Kept the runtime Skills Zod schemas exported for custom skill and registry consumers.
- Added focused unit coverage for the Skills schema module runtime exports and core validation behavior.
- Left the dead-code baseline unchanged; the final ratchet remains deferred.

## Validation

```
$ node --import tsx/esm --test tests/unit/skills-schemas.test.ts
# tests 3
# pass 3
# fail 0
```

```
$ node scripts/check/check-dead-code.mjs --quiet
DEAD_EXPORTS=197
DEAD_FILES=94
DEAD_TOTAL=291
[dead-code] OK — 291 símbolos mortos (baseline 310)
```

```
$ GITHUB_BASE_REF=release/v3.8.41 GITHUB_BASE_SHA=upstream/release/v3.8.41 node scripts/check/check-pr-test-policy.mjs
Result: PASS
```

```
$ npm run check:fabricated-docs
✓ No fabricated API/env/CLI/hook/file references found.
```
