### PR TITLE
chore: remove unused batch provider type

### DIFF
--- a/src/lib/batches/types.ts
+++ b/src/lib/batches/types.ts
@@ -71,10 +71,8 @@ export interface RetryPlan {
 // ── Provider catalog (D16 / D17) ─────────────────────────────────────────────
 
 export const BATCH_SUPPORTED_PROVIDERS = ["openai", "anthropic", "gemini"] as const;
-export type BatchProvider = (typeof BATCH_SUPPORTED_PROVIDERS)[number];
 
 // ── Re-exports ───────────────────────────────────────────────────────────────
 
 export type { SupportedBatchEndpoint };
 export { SUPPORTED_BATCH_ENDPOINTS };
-

--- a/tests/unit/lib/batches/schemas.test.ts
+++ b/tests/unit/lib/batches/schemas.test.ts
@@ -3,6 +3,11 @@ import assert from "node:assert/strict";
 
 const { wizardDestinationSchema, wizardCsvMappingSchema, csvToJsonlInputSchema } =
   await import("../../../../src/lib/batches/schemas.ts");
+const { BATCH_SUPPORTED_PROVIDERS } = await import("../../../../src/lib/batches/types.ts");
+
+test("batch types module keeps the supported providers catalog exported", () => {
+  assert.deepEqual(BATCH_SUPPORTED_PROVIDERS, ["openai", "anthropic", "gemini"]);
+});
 
 // ── wizardDestinationSchema ──────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Removed the unused `BatchProvider` type-only export from `src/lib/batches/types.ts`.
- Kept the runtime `BATCH_SUPPORTED_PROVIDERS` catalog and batch endpoint re-exports unchanged.
- Added focused coverage that asserts the batch provider catalog remains exported for schema/UI consumers.
- Left the dead-code baseline unchanged; the final ratchet remains deferred.

## Validation

```
$ node --import tsx/esm --test tests/unit/lib/batches/schemas.test.ts
# tests 10
# pass 10
# fail 0
```

```
$ node scripts/check/check-dead-code.mjs --quiet
DEAD_EXPORTS=199
DEAD_FILES=94
DEAD_TOTAL=293
[dead-code] OK — 293 símbolos mortos (baseline 310)
```

```
$ GITHUB_BASE_REF=release/v3.8.41 GITHUB_BASE_SHA=upstream/release/v3.8.41 node scripts/check/check-pr-test-policy.mjs
Result: PASS
```

```
$ npm run check:fabricated-docs
✓ No fabricated API/env/CLI/hook/file references found.
```
