### PR TITLE
chore: remove unused status hex key type

### DIFF
--- a/src/shared/constants/statusColors.ts
+++ b/src/shared/constants/statusColors.ts
@@ -15,5 +15,3 @@ export const STATUS_HEX = {
   error: "#ef4444",
   muted: "#6b7280",
 } as const;
-
-export type StatusHexKey = keyof typeof STATUS_HEX;

--- a/tests/unit/design-grid-background.test.ts
+++ b/tests/unit/design-grid-background.test.ts
@@ -98,6 +98,7 @@ test("Card / Modal / Input / Select adopt the radius scale and border token", ()
 
 test("status colors come from one canonical module", () => {
   const mod = read("../../src/shared/constants/statusColors.ts");
+  assert.match(mod, /export const STATUS_HEX/);
   assert.match(mod, /success:\s*"#22c55e"/);
   assert.match(mod, /warning:\s*"#f59e0b"/);
   assert.match(mod, /error:\s*"#ef4444"/);


### PR DESCRIPTION
## Summary

- Removed the unused `StatusHexKey` type-only export from `src/shared/constants/statusColors.ts`.
- Kept the runtime `STATUS_HEX` status color catalog exported for UI consumers.
- Added focused coverage that asserts the canonical status color module still exports `STATUS_HEX`.
- Left the dead-code baseline unchanged; the final ratchet remains deferred.

## Validation

```
$ node --import tsx/esm --test tests/unit/design-grid-background.test.ts
# tests 19
# pass 19
# fail 0
```

```
$ node scripts/check/check-dead-code.mjs --quiet
DEAD_EXPORTS=199
DEAD_FILES=94
DEAD_TOTAL=293
[dead-code] OK — 293 símbolos mortos (baseline 310)
```

```
$ GITHUB_BASE_REF=release/v3.8.41 GITHUB_BASE_SHA=upstream/release/v3.8.41 node scripts/check/check-pr-test-policy.mjs
Result: PASS
```

```
$ npm run check:fabricated-docs
✓ No fabricated API/env/CLI/hook/file references found.
```
