### PR TITLE
chore: remove unused skillssh skill type

### DIFF
--- a/src/lib/skills/skillssh.ts
+++ b/src/lib/skills/skillssh.ts
@@ -18,7 +18,6 @@ export const SkillsShSearchResponseSchema = z.object({
   duration_ms: z.number().optional(),
 });
 
-export type SkillsShSkill = z.infer<typeof SkillsShSkillSchema>;
 export type SkillsShSearchResponse = z.infer<typeof SkillsShSearchResponseSchema>;
 
 const SKILLSSH_BASE_URL = "https://skills.sh/api";

--- a/tests/unit/skills-skillssh.test.ts
+++ b/tests/unit/skills-skillssh.test.ts
@@ -47,6 +47,11 @@ test.after(() => {
 
 // ── Zod schema validation tests ──
 
+test("skills.sh module keeps runtime schemas exported", () => {
+  assert.equal(typeof SkillsShSkillSchema.safeParse, "function");
+  assert.equal(typeof SkillsShSearchResponseSchema.safeParse, "function");
+});
+
 test("SkillsShSkillSchema parses a valid skill object", () => {
   const result = SkillsShSkillSchema.parse({
     id: "supabase/agent-skills/supabase-postgres",


### PR DESCRIPTION
## Summary

- Removed the unused `SkillsShSkill` type-only export from `src/lib/skills/skillssh.ts`.
- Kept the runtime Skills.sh Zod schemas and the consumed `SkillsShSearchResponse` return type unchanged.
- Added focused coverage that asserts the Skills.sh runtime schemas remain exported.
- Left the dead-code baseline unchanged; the final ratchet remains deferred.

## Validation

```
$ node --import tsx/esm --test tests/unit/skills-skillssh.test.ts
# tests 15
# pass 15
# fail 0
```

```
$ node scripts/check/check-dead-code.mjs --quiet
DEAD_EXPORTS=199
DEAD_FILES=94
DEAD_TOTAL=293
[dead-code] OK — 293 símbolos mortos (baseline 310)
```

```
$ GITHUB_BASE_REF=release/v3.8.41 GITHUB_BASE_SHA=upstream/release/v3.8.41 node scripts/check/check-pr-test-policy.mjs
Result: PASS
```

```
$ npm run check:fabricated-docs
✓ No fabricated API/env/CLI/hook/file references found.
```
