### PR TITLE
chore: remove unused provider types

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,7 +5,7 @@
  * Import from "@/types" in any file.
  */
 
-export type { ProviderConnection, ProviderNode, ModelCooldownErrorPayload } from "./provider";
+export type { ModelCooldownErrorPayload } from "./provider";
 export type { ApiKey } from "./apiKey";
 export type { Combo, ComboStrategy, ComboNode } from "./combo";
 export type { UsageEntry, UsageStats, ProviderUsageStats, ModelUsageStats, CallLog } from "./usage";

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -1,34 +1,3 @@
-/**
- * Provider connection — a configured cloud AI provider account.
- */
-export interface ProviderConnection {
-  id: string;
-  provider: string;
-  label: string;
-  url: string;
-  apiKey?: string;
-  oauthToken?: string;
-  oauthRefreshToken?: string;
-  oauthExpiresAt?: string;
-  isActive: boolean;
-  priority: number;
-  createdAt: string;
-  updatedAt: string;
-}
-
-/**
- * Provider node — a specific endpoint within a provider.
- */
-export interface ProviderNode {
-  id: string;
-  connectionId: string;
-  provider: string;
-  model: string;
-  baseUrl: string;
-  isActive: boolean;
-  priority: number;
-}
-
 export interface ModelCooldownErrorPayload {
   error: {
     message: string;

--- a/tests/unit/error-message-sanitization.test.ts
+++ b/tests/unit/error-message-sanitization.test.ts
@@ -18,6 +18,9 @@ const mappingsRoute = await import("../../src/app/api/model-combo-mappings/route
 const mappingsIdRoute = await import("../../src/app/api/model-combo-mappings/[id]/route.ts");
 const syncTokens = await import("../../src/lib/sync/tokens.ts");
 
+const repoRoot = path.resolve(import.meta.dirname, "../..");
+const read = (relPath: string) => fs.readFileSync(path.join(repoRoot, relPath), "utf8");
+
 function makeRequest(url: string, options: { method?: string; body?: unknown } = {}) {
   const { method = "GET", body } = options;
   return new Request(url, {
@@ -238,6 +241,13 @@ test("buildErrorBody never exposes stack traces in its message", async () => {
   );
   assert.equal(body.error.message, "Internal error");
   assert.ok(!body.error.message.includes("at /opt"));
+});
+
+test("types barrel keeps the model cooldown payload export only", async () => {
+  const src = await read("src/types/index.ts");
+  assert.match(src, /ModelCooldownErrorPayload/);
+  assert.doesNotMatch(src, /ProviderConnection/);
+  assert.doesNotMatch(src, /ProviderNode/);
 });
 
 // ── sanitizeUpstreamDetails ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Removed unused `ProviderConnection` and `ProviderNode` type exports from `src/types/provider.ts`.
- Trimmed the central `@/types` barrel to keep only the consumed `ModelCooldownErrorPayload` provider export.
- Added focused coverage that asserts the model cooldown payload export remains while stale provider type re-exports are gone.
- Left the dead-code baseline unchanged; the final ratchet remains deferred.

## Validation

```
$ node --import tsx/esm --test tests/unit/error-message-sanitization.test.ts
# tests 31
# pass 31
# fail 0
```

```
$ node scripts/check/check-dead-code.mjs --quiet
DEAD_EXPORTS=198
DEAD_FILES=94
DEAD_TOTAL=292
[dead-code] OK — 292 símbolos mortos (baseline 310)
```

```
$ GITHUB_BASE_REF=release/v3.8.41 GITHUB_BASE_SHA=upstream/release/v3.8.41 node scripts/check/check-pr-test-policy.mjs
Result: PASS
```

```
$ npm run check:fabricated-docs
✓ No fabricated API/env/CLI/hook/file references found.
```
