### PR TITLE
chore: remove unused notion client type

### DIFF
--- a/src/lib/notion/api.ts
+++ b/src/lib/notion/api.ts
@@ -245,5 +245,3 @@ export function createNotionClient(apiKey: string) {
 
   return client;
 }
-
-export type NotionClient = ReturnType<typeof createNotionClient>;

--- a/tests/unit/notion-api.test.ts
+++ b/tests/unit/notion-api.test.ts
@@ -45,6 +45,14 @@ test("NotionTimeoutError has correct name", () => {
 test("createNotionClient returns object with expected methods", async () => {
   const { createNotionClient } = await import("../../src/lib/notion/api.ts");
   const client = createNotionClient("test-token");
+  assert.deepEqual(Object.keys(client), [
+    "searchPagesAndDatabases",
+    "getPage",
+    "listBlockChildren",
+    "queryDatabase",
+    "getDatabase",
+    "appendBlocks",
+  ]);
   assert.equal(typeof client.searchPagesAndDatabases, "function");
   assert.equal(typeof client.getPage, "function");
   assert.equal(typeof client.listBlockChildren, "function");


### PR DESCRIPTION
## Summary

- Removed the unused `NotionClient` type export from the Notion API client module.
- Tightened the existing Notion client test to assert the runtime client method shape directly.
- Left `metrics.deadExports.value` unchanged; the final ratchet remains deferred.

## Validation

```bash
$ node --import tsx/esm --test tests/unit/notion-api.test.ts
# tests 7
# pass 7
# fail 0
```

```bash
$ node scripts/check/check-dead-code.mjs --quiet
DEAD_EXPORTS=199
DEAD_FILES=94
DEAD_TOTAL=293
[dead-code] OK — 293 símbolos mortos (baseline 310)
```

```bash
$ GITHUB_BASE_REF=release/v3.8.41 GITHUB_BASE_SHA=upstream/release/v3.8.41 node scripts/check/check-pr-test-policy.mjs
Result: PASS
```

```bash
$ npm run check:fabricated-docs
✓ No fabricated API/env/CLI/hook/file references found.
```
