### PR TITLE
chore: remove unused codegraph exports

### DIFF
--- a/src/lib/copilot/codegraphKnowledge.ts
+++ b/src/lib/copilot/codegraphKnowledge.ts
@@ -31,27 +31,6 @@ export interface CodeGraphNode {
   visibility?: string;
 }
 
-export interface CodeGraphEdge {
-  id: number;
-  source: string;
-  target: string;
-  kind: string;
-  line?: number;
-  metadata?: Record<string, unknown>;
-}
-
-export interface CodeGraphFile {
-  path: string;
-  language: string;
-  nodeCount: number;
-  modifiedAt: number;
-}
-
-export interface CodeGraphSearchResult {
-  nodes: CodeGraphNode[];
-  total: number;
-}
-
 // ---------------------------------------------------------------------------
 // Database access (lazy loaded)
 // ---------------------------------------------------------------------------
@@ -229,30 +208,6 @@ export function listFiles(language?: string, limit = 50): CodeGraphQueryResult {
     ]);
   }
   return queryDb(`SELECT * FROM files ORDER BY path LIMIT ?`, [limit]);
-}
-
-/**
- * Get impact analysis: find symbols that depend on a given symbol (transitively).
- */
-export function getImpactAnalysis(symbolName: string, depth = 1): CodeGraphQueryResult {
-  if (depth <= 0)
-    return { success: false, data: null, error: "Depth must be >= 1", engine: "none" };
-
-  // Direct callers (depth 1)
-  const directCallers = findCallers(symbolName);
-  if (depth === 1) return directCallers;
-
-  // For depth > 1, we'd need recursive CTE or multiple queries.
-  // For now, just return direct callers with a note.
-  const result = directCallers;
-  return {
-    ...result,
-    data: (result.data as Record<string, unknown>[])?.map((r) => ({
-      ...r,
-      _depth: 1,
-      _note: `Depth > 1 requires multiple queries. Use searchSymbols() + findCallers() iteratively for deeper analysis.`,
-    })),
-  };
 }
 
 /**

--- a/tests/unit/copilot-codegraph-knowledge.test.ts
+++ b/tests/unit/copilot-codegraph-knowledge.test.ts
@@ -1,0 +1,34 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  findCallers,
+  getCodeGraphStats,
+  isCodeGraphAvailable,
+  searchSymbols,
+} from "../../src/lib/copilot/codegraphKnowledge.ts";
+
+test("CodeGraph knowledge helpers fail closed when the index is unavailable", () => {
+  assert.equal(isCodeGraphAvailable(), false);
+
+  assert.deepEqual(searchSymbols("handleChatCore"), {
+    success: false,
+    data: null,
+    error: "CodeGraph DB not found",
+    engine: "none",
+  });
+
+  assert.deepEqual(findCallers("handleChatCore"), {
+    success: false,
+    data: null,
+    error: "CodeGraph DB not found",
+    engine: "none",
+  });
+
+  assert.deepEqual(getCodeGraphStats(), {
+    success: false,
+    data: null,
+    error: "CodeGraph DB not found",
+    engine: "none",
+  });
+});


### PR DESCRIPTION
## Summary

- Removed unused CodeGraph exports from the Copilot knowledge module (`CodeGraphEdge`, `CodeGraphFile`, `CodeGraphSearchResult`, `getImpactAnalysis`).
- Added focused coverage for the CodeGraph helpers' production fallback behavior when no local index is available.
- Left `metrics.deadExports.value` unchanged; the final ratchet remains deferred.

## Validation

```bash
$ node --import tsx/esm --test tests/unit/copilot-codegraph-knowledge.test.ts
# tests 1
# pass 1
# fail 0
```

```bash
$ node scripts/check/check-dead-code.mjs --quiet
DEAD_EXPORTS=197
DEAD_FILES=94
DEAD_TOTAL=291
[dead-code] OK — 291 símbolos mortos (baseline 310)
```

```bash
$ GITHUB_BASE_REF=release/v3.8.41 GITHUB_BASE_SHA=upstream/release/v3.8.41 node scripts/check/check-pr-test-policy.mjs
Result: PASS
```

```bash
$ npm run check:fabricated-docs
✓ No fabricated API/env/CLI/hook/file references found.
```
