### PR TITLE
chore: remove unused playground row type

### DIFF
--- a/src/shared/schemas/playground.ts
+++ b/src/shared/schemas/playground.ts
@@ -11,7 +11,6 @@ export const PlaygroundPresetRowSchema = z.object({
   params_json: z.string(), // JSON serializado (parsed na rota)
   created_at: z.string().datetime(),
 });
-export type PlaygroundPresetRow = z.infer<typeof PlaygroundPresetRowSchema>;
 
 /** Body de POST /api/playground/presets. */
 export const PlaygroundPresetCreateSchema = z.object({

--- a/tests/unit/playground-schemas.test.ts
+++ b/tests/unit/playground-schemas.test.ts
@@ -30,6 +30,7 @@ test("PlaygroundPresetRowSchema: valid row parses correctly", () => {
     assert.equal(result.data.id, row.id);
     assert.equal(result.data.name, row.name);
     assert.equal(result.data.system, "You are helpful.");
+    assert.equal(result.data.params_json, row.params_json);
   }
 });
 


### PR DESCRIPTION
## Summary

- Removed the unused `PlaygroundPresetRow` type alias while keeping the runtime `PlaygroundPresetRowSchema` intact.
- Tightened the existing playground schema test to assert the row schema preserves `params_json`.
- Left `metrics.deadExports.value` unchanged; the final ratchet remains deferred.

## Validation

```bash
$ node --import tsx/esm --test tests/unit/playground-schemas.test.ts
# tests 23
# pass 23
# fail 0
```

```bash
$ node scripts/check/check-dead-code.mjs --quiet
DEAD_EXPORTS=199
DEAD_FILES=94
DEAD_TOTAL=293
[dead-code] OK — 293 símbolos mortos (baseline 310)
```

```bash
$ GITHUB_BASE_REF=release/v3.8.41 GITHUB_BASE_SHA=upstream/release/v3.8.41 node scripts/check/check-pr-test-policy.mjs
Result: PASS
```

```bash
$ npm run check:fabricated-docs
✓ No fabricated API/env/CLI/hook/file references found.
```
