### PR TITLE
chore: remove unused quota schema types

### DIFF
--- a/src/shared/schemas/quota.ts
+++ b/src/shared/schemas/quota.ts
@@ -4,12 +4,10 @@ import { PoolAllocationSchema, QuotaDimensionSchema } from "@/lib/quota/dimensio
 export const GroupCreateSchema = z.object({
   name: z.string().min(1).max(120),
 });
-export type GroupCreate = z.infer<typeof GroupCreateSchema>;
 
 export const GroupRenameSchema = z.object({
   name: z.string().min(1).max(120),
 });
-export type GroupRename = z.infer<typeof GroupRenameSchema>;
 
 export const PoolCreateSchema = z
   .object({
@@ -26,7 +24,6 @@ export const PoolCreateSchema = z
     },
     { message: "primary connectionId must be one of connectionIds" }
   );
-export type PoolCreate = z.infer<typeof PoolCreateSchema>;
 
 export const PoolUpdateSchema = z.object({
   name: z.string().min(1).max(120).optional(),
@@ -35,18 +32,15 @@ export const PoolUpdateSchema = z.object({
   groupId: z.string().optional(),
   connectionIds: z.array(z.string().min(1)).min(1).optional(),
 });
-export type PoolUpdate = z.infer<typeof PoolUpdateSchema>;
 
 export const PlanUpsertSchema = z.object({
   dimensions: z.array(QuotaDimensionSchema).min(1),
 });
-export type PlanUpsert = z.infer<typeof PlanUpsertSchema>;
 
 export const QuotaStoreSettingsSchema = z.object({
   driver: z.enum(["sqlite", "redis"]),
   redisUrl: z.string().url().nullable().optional(),
 });
-export type QuotaStoreSettings = z.infer<typeof QuotaStoreSettingsSchema>;
 
 export const QuotaPreviewQuerySchema = z.object({
   apiKeyId: z.string().min(1),
@@ -55,7 +49,6 @@ export const QuotaPreviewQuerySchema = z.object({
   estimatedUsd: z.coerce.number().nonnegative().optional(),
   estimatedRequests: z.coerce.number().int().nonnegative().optional(),
 });
-export type QuotaPreviewQuery = z.infer<typeof QuotaPreviewQuerySchema>;
 
 export const AuditLogQuerySchema = z.object({
   action: z.string().optional(),
@@ -66,4 +59,3 @@ export const AuditLogQuerySchema = z.object({
   limit: z.coerce.number().int().min(1).max(500).default(50),
   offset: z.coerce.number().int().min(0).max(10_000).default(0),
 });
-export type AuditLogQuery = z.infer<typeof AuditLogQuerySchema>;

--- a/tests/unit/quota-schemas.test.ts
+++ b/tests/unit/quota-schemas.test.ts
@@ -20,6 +20,7 @@ test("PoolCreateSchema defaults allocations to []", () => {
   const r = PoolCreateSchema.safeParse({ connectionId: "c", name: "Pool" });
   assert.ok(r.success);
   assert.deepEqual(r.data?.allocations, []);
+  assert.equal(r.data?.connectionId, "c");
 });
 
 test("PoolCreateSchema rejects empty name", () => {


### PR DESCRIPTION
## Summary

- Removed unused inferred type aliases from `src/shared/schemas/quota.ts` while keeping all runtime Zod schemas intact.
- Tightened the existing quota schema test to assert the parsed `connectionId` value alongside default allocations.
- Left `metrics.deadExports.value` unchanged; the final ratchet remains deferred.

## Validation

```bash
$ node --import tsx/esm --test tests/unit/quota-schemas.test.ts
# tests 27
# pass 27
# fail 0
```

```bash
$ node scripts/check/check-dead-code.mjs --quiet
DEAD_EXPORTS=192
DEAD_FILES=94
DEAD_TOTAL=286
[dead-code] OK — 286 símbolos mortos (baseline 310)
```

```bash
$ GITHUB_BASE_REF=release/v3.8.41 GITHUB_BASE_SHA=upstream/release/v3.8.41 node scripts/check/check-pr-test-policy.mjs
Result: PASS
```

```bash
$ npm run check:fabricated-docs
✓ No fabricated API/env/CLI/hook/file references found.
```
