### PR TITLE
chore: remove unused memory schema aliases

### DIFF
--- a/src/shared/schemas/memory.ts
+++ b/src/shared/schemas/memory.ts
@@ -138,10 +138,5 @@ export const RetrievePreviewResultSchema = z.object({
 });
 
 export type MemorySettingsExtended = z.infer<typeof MemorySettingsExtendedSchema>;
-export type MemoryUpdatePut = z.infer<typeof MemoryUpdatePutSchema>;
-export type RetrievePreview = z.infer<typeof RetrievePreviewSchema>;
-export type MemoryReindex = z.infer<typeof MemoryReindexSchema>;
-export type MemorySummarize = z.infer<typeof MemorySummarizeSchema>;
-export type EmbeddingProviderListings = z.infer<typeof EmbeddingProviderListingSchema>;
 export type MemoryEngineStatus = z.infer<typeof MemoryEngineStatusSchema>;
 export type RetrievePreviewResult = z.infer<typeof RetrievePreviewResultSchema>;

--- a/tests/unit/memory-schemas-roundtrip.test.ts
+++ b/tests/unit/memory-schemas-roundtrip.test.ts
@@ -66,6 +66,9 @@ test("MemorySettingsExtendedSchema: rejects invalid embeddingSource value", () =
 test("MemoryUpdatePutSchema: accepts valid partial update (content only)", () => {
   const result = MemoryUpdatePutSchema.safeParse({ content: "updated content" });
   assert.equal(result.success, true, "Should accept partial update with only content");
+  if (result.success) {
+    assert.equal(result.data.content, "updated content");
+  }
 });
 
 test("MemoryUpdatePutSchema: rejects extra field (strict)", () => {


### PR DESCRIPTION
## Summary

- Removed unused inferred type aliases from `src/shared/schemas/memory.ts` while keeping all runtime Zod schemas intact.
- Kept the active exported aliases (`MemorySettingsExtended`, `MemoryEngineStatus`, `RetrievePreviewResult`) that are still imported by runtime/UI code.
- Tightened the existing memory schema roundtrip test to assert parsed update content.
- Left `metrics.deadExports.value` unchanged; the final ratchet remains deferred.

## Validation

```bash
$ node --import tsx/esm --test tests/unit/memory-schemas-roundtrip.test.ts
# tests 34
# pass 34
# fail 0
```

```bash
$ node scripts/check/check-dead-code.mjs --quiet
DEAD_EXPORTS=195
DEAD_FILES=94
DEAD_TOTAL=289
[dead-code] OK — 289 símbolos mortos (baseline 310)
```

```bash
$ GITHUB_BASE_REF=release/v3.8.41 GITHUB_BASE_SHA=upstream/release/v3.8.41 node scripts/check/check-pr-test-policy.mjs
Result: PASS
```

```bash
$ npm run check:fabricated-docs
✓ No fabricated API/env/CLI/hook/file references found.
```
