### PR TITLE
chore: remove unused qdrant schema aliases

### DIFF
--- a/src/shared/schemas/qdrant.ts
+++ b/src/shared/schemas/qdrant.ts
@@ -37,8 +37,3 @@ export const QdrantHealthResultSchema = z.object({
   latencyMs: z.number(),
   error: z.string().optional(),
 });
-
-export type QdrantSettings = z.infer<typeof QdrantSettingsSchema>;
-export type QdrantSettingsUpdate = z.infer<typeof QdrantSettingsUpdateSchema>;
-export type QdrantSearch = z.infer<typeof QdrantSearchSchema>;
-export type QdrantHealthResult = z.infer<typeof QdrantHealthResultSchema>;

--- a/tests/unit/memory-schemas-roundtrip.test.ts
+++ b/tests/unit/memory-schemas-roundtrip.test.ts
@@ -325,6 +325,7 @@ test("QdrantSettingsSchema: accepts valid settings with defaults applied", () =>
   if (result.success) {
     assert.equal(result.data.port, 6333, "Default port should be 6333");
     assert.equal(result.data.collection, "omniroute_memory", "Default collection");
+    assert.equal(result.data.quantization, "none", "Default quantization should be none");
     assert.equal(result.data.hasApiKey, false, "Default hasApiKey should be false");
     assert.equal(result.data.apiKeyMasked, null, "Default apiKeyMasked should be null");
   }


### PR DESCRIPTION
## Summary

- Removed unused inferred type aliases from `src/shared/schemas/qdrant.ts` while keeping all runtime Zod schemas intact.
- Tightened the existing memory/Qdrant schema roundtrip test to assert the default quantization value.
- Left `metrics.deadExports.value` unchanged; the final ratchet remains deferred.

## Validation

```bash
$ node --import tsx/esm --test tests/unit/memory-schemas-roundtrip.test.ts
# tests 34
# pass 34
# fail 0
```

```bash
$ node scripts/check/check-dead-code.mjs --quiet
DEAD_EXPORTS=196
DEAD_FILES=94
DEAD_TOTAL=290
[dead-code] OK — 290 símbolos mortos (baseline 310)
```

```bash
$ GITHUB_BASE_REF=release/v3.8.41 GITHUB_BASE_SHA=upstream/release/v3.8.41 node scripts/check/check-pr-test-policy.mjs
Result: PASS
```

```bash
$ npm run check:fabricated-docs
✓ No fabricated API/env/CLI/hook/file references found.
```
