### PR TITLE
fix: frame non-streaming JSON chat responses

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -9,6 +9,7 @@ import { applyClientUsageBuffer } from "./chatCore/clientUsageBuffer.ts";
 import { buildPostCallGuardrailContext } from "./chatCore/postCallGuardrailContext.ts";
 import { storeSemanticCacheResponse } from "./chatCore/semanticCacheStore.ts";
 import { buildNonStreamingResponseHeaders } from "./chatCore/nonStreamingResponseHeaders.ts";
+import { buildNonStreamingJsonResponse } from "./chatCore/nonStreamingJsonResponse.ts";
 import { maybeConvertJsonBodyToSse } from "./chatCore/jsonBodyToSse.ts";
 import { assembleStreamingResponseHeaders } from "./chatCore/streamingResponseHeaders.ts";
 import { storeStreamingSemanticCacheResponse } from "./chatCore/streamingSemanticCacheStore.ts";
@@ -3897,9 +3898,7 @@ export async function handleChatCore({
     if (echoModel) echoModelInObject(translatedResponse, echoModel);
     return {
       success: true,
-      response: new Response(JSON.stringify(translatedResponse), {
-        headers: responseHeaders,
-      }),
+      response: buildNonStreamingJsonResponse(translatedResponse, responseHeaders),
     };
   }
 

--- a/open-sse/handlers/chatCore/nonStreamingJsonResponse.ts
+++ b/open-sse/handlers/chatCore/nonStreamingJsonResponse.ts
@@ -1,0 +1,16 @@
+/**
+ * Build the final non-streaming JSON response body once and publish an accurate
+ * Content-Length for downstream HTTP clients and buffering proxies.
+ */
+export function buildNonStreamingJsonResponse(
+  body: unknown,
+  headers: Record<string, string>
+): Response {
+  const payload = JSON.stringify(body);
+  return new Response(payload, {
+    headers: {
+      ...headers,
+      "Content-Length": String(Buffer.byteLength(payload)),
+    },
+  });
+}

--- a/tests/unit/chatcore-nonstreaming-json-response.test.ts
+++ b/tests/unit/chatcore-nonstreaming-json-response.test.ts
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { buildNonStreamingJsonResponse } from "../../open-sse/handlers/chatCore/nonStreamingJsonResponse";
+
+test("buildNonStreamingJsonResponse sets content-length for the serialized JSON body", async () => {
+  const response = buildNonStreamingJsonResponse(
+    {
+      id: "chatcmpl-test",
+      choices: [{ message: { role: "assistant", content: "hello" } }],
+    },
+    {
+      "Content-Type": "application/json",
+      "X-OmniRoute-Cache": "MISS",
+    }
+  );
+
+  const text = await response.text();
+  assert.equal(response.headers.get("Content-Type"), "application/json");
+  assert.equal(response.headers.get("X-OmniRoute-Cache"), "MISS");
+  assert.equal(response.headers.get("Content-Length"), String(Buffer.byteLength(text)));
+});


### PR DESCRIPTION
## Summary

- Emit an accurate `Content-Length` for non-streaming JSON chat responses after OmniRoute re-serializes the translated response body.
- Keep the response payload unchanged by serializing it once and using the same byte length for framing.

## Root Cause

OmniRoute was rebuilding successful non-streaming chat responses with `JSON.stringify(...)` but returned them without explicit response-length framing. Direct local fetch clients can usually finish by reading the chunked EOF, but downstream clients behind buffering proxies or tunnels can keep waiting for body completion after OmniRoute has already produced and logged the successful response.

## Safety

This does not change upstream request format, provider translation, stream selection, response JSON fields, reasoning/content handling, or any text-tag parsing.
## Validation

- `npm run check:file-size`
- `node --import tsx/esm --test tests/unit/chatcore-nonstreaming-json-response.test.ts`
- `node --import tsx/esm --import ./open-sse/utils/setupPolyfill.ts --test tests/unit/chatcore-translation-paths.test.ts --test-name-pattern "streaming responses"`
- `npm run typecheck:core`
- Manual non-streaming replay with a production build and local database confirmed the downstream response includes a `Content-Length` matching the JSON body length.
