### PR TITLE
chore(dead-code): remove unused gamification streak exports

### DIFF
--- a/src/lib/gamification/streaks.ts
+++ b/src/lib/gamification/streaks.ts
@@ -162,33 +162,3 @@ export async function updateStreak(apiKeyId: string): Promise<number> {
 
   return newStreak;
 }
-
-/**
- * Check if a streak is still active (last activity within the last 2 days).
- * Does not modify any data.
- *
- * @param apiKeyId - The API key identifier
- * @returns true if the streak is still alive
- */
-export async function isStreakActive(apiKeyId: string): Promise<boolean> {
-  const streak = await getStreak(apiKeyId);
-  if (!streak.lastActiveDate) return false;
-
-  const last = new Date(streak.lastActiveDate + "T00:00:00Z").getTime();
-  const now = Date.now();
-  const daysSince = Math.floor((now - last) / MS_PER_DAY);
-
-  return daysSince <= 1; // Today or yesterday
-}
-
-/**
- * Reset streak data for an API key (admin/testing use).
- *
- * @param apiKeyId - The API key identifier
- */
-export async function resetStreak(apiKeyId: string): Promise<void> {
-  if (isBuildPhase || isCloud) return;
-
-  const db = getDbInstance() as unknown as DbLike;
-  db.prepare("DELETE FROM key_value WHERE namespace = ? AND key = ?").run(NAMESPACE, apiKeyId);
-}

--- a/tests/unit/gamification/streaks.test.ts
+++ b/tests/unit/gamification/streaks.test.ts
@@ -22,5 +22,15 @@ describe("Streak Tracker", () => {
       const second = await updateStreak("test-user-2");
       assert.equal(first, second);
     });
+
+    it("stores date metadata when starting a streak", async () => {
+      await updateStreak("test-user-3");
+
+      const streak = await getStreak("test-user-3");
+      assert.equal(streak.currentStreak, 1);
+      assert.equal(streak.longestStreak, 1);
+      assert.match(streak.lastActiveDate, /^\d{4}-\d{2}-\d{2}$/);
+      assert.equal(streak.streakStartDate, streak.lastActiveDate);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Remove the unused `isStreakActive` and `resetStreak` exports from the gamification streak tracker.
- Add a focused streak metadata assertion to keep the remaining public streak API characterized.
- Leave the dead-code ratchet baseline unchanged so this PR stays independent of the rest of the cleanup series.

## Validation
- `node --import tsx --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test tests/unit/gamification/streaks.test.ts`
- `npm run check:dead-code -- --quiet`
- Commit/push hooks: docs sync, T11 any-budget, tracked-artifacts

## Note
- `npm run typecheck:core` currently fails on this checkout because `safe-regex` and `@toon-format/toon` are missing from the installed dependency graph; the reported errors are outside this PR's changed files.
