### PR TITLE
chore(dead-code): remove unused headroom log tail export

### DIFF
--- a/src/lib/headroom/process.ts
+++ b/src/lib/headroom/process.ts
@@ -89,9 +89,7 @@ function safePort(port: unknown): number {
   return Number.isFinite(n) && n > 0 && n < 65536 ? n : DEFAULT_PORT;
 }
 
-export async function startHeadroomProxy(
-  opts: { port?: number } = {}
-): Promise<StartResult> {
+export async function startHeadroomProxy(opts: { port?: number } = {}): Promise<StartResult> {
   const binary = findHeadroomBinary();
   if (!binary) {
     throw new HeadroomError("Headroom CLI not installed", "NOT_INSTALLED");
@@ -125,10 +123,7 @@ export async function startHeadroomProxy(
       if (isPidAlive(child.pid!)) resolve();
       else
         reject(
-          new HeadroomError(
-            "headroom proxy exited during startup — see proxy.log",
-            "EARLY_EXIT"
-          )
+          new HeadroomError("headroom proxy exited during startup — see proxy.log", "EARLY_EXIT")
         );
     }, STARTUP_TIMEOUT_MS);
 
@@ -178,16 +173,5 @@ export function stopHeadroomProxy(): StopResult {
     clearPid();
     const msg = e instanceof Error ? e.message : String(e);
     throw new HeadroomError(`Failed to stop headroom proxy: ${msg}`, "STOP_FAILED");
-  }
-}
-
-export function getHeadroomLogTail(maxLines = 200): string {
-  try {
-    if (!fs.existsSync(LOG_FILE)) return "";
-    const content = fs.readFileSync(LOG_FILE, "utf8");
-    const lines = content.split(/\r?\n/).filter(Boolean);
-    return lines.slice(-maxLines).join("\n");
-  } catch {
-    return "";
   }
 }

--- a/tests/unit/headroom-proxy-lifecycle.test.ts
+++ b/tests/unit/headroom-proxy-lifecycle.test.ts
@@ -6,6 +6,7 @@ import {
   parsePortFromHeadroomUrl,
   buildHeadroomStatus,
 } from "../../src/lib/headroom/detect";
+import { getManagedPid, isPidAlive } from "../../src/lib/headroom/process";
 import { isLocalOnlyPath } from "../../src/server/authz/routeGuard";
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -87,4 +88,10 @@ test("buildHeadroomStatus: nothing installed and proxy unreachable → all false
   assert.equal(status.running, false);
   assert.equal(status.localUrl, true);
   assert.equal(status.canStart, false);
+});
+
+test("process status helpers are safe for absent managed processes", () => {
+  assert.equal(isPidAlive(null), false);
+  assert.equal(isPidAlive(undefined), false);
+  assert.equal(getManagedPid(), null);
 });


### PR DESCRIPTION
## Summary
- Remove the unused `getHeadroomLogTail` export from the local headroom proxy lifecycle module.
- Add a focused lifecycle test assertion for the remaining process status helpers.
- Leave the dead-code ratchet baseline unchanged so this PR remains independent of the cleanup series.

## Validation
- `node --import tsx --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test tests/unit/headroom-proxy-lifecycle.test.ts`
- `npm run check:dead-code -- --quiet`
- `git diff --check`
- Commit/push hooks: docs sync, T11 any-budget, tracked-artifacts
