### PR TITLE
chore(dead-code): remove unused prompt cache control helper

### DIFF
--- a/src/lib/promptCache/index.ts
+++ b/src/lib/promptCache/index.ts
@@ -1,1 +1,1 @@
-export { analyzePrefix, shouldInjectCacheControl, generatePromptCacheKey } from "./prefixAnalyzer";
+export { analyzePrefix, generatePromptCacheKey } from "./prefixAnalyzer";

--- a/src/lib/promptCache/prefixAnalyzer.ts
+++ b/src/lib/promptCache/prefixAnalyzer.ts
@@ -72,10 +72,6 @@ export function analyzePrefix(messages: Message[]): PrefixAnalysis {
   };
 }
 
-export function shouldInjectCacheControl(analysis: PrefixAnalysis, minTokens = 1024): boolean {
-  return analysis.prefixTokens >= minTokens && analysis.confidence >= 0.7;
-}
-
 export function generatePromptCacheKey(messages: Message[]): string {
   const analysis = analyzePrefix(messages);
   if (analysis.prefixHash) {

--- a/tests/unit/prompt-cache-prefix-analyzer.test.ts
+++ b/tests/unit/prompt-cache-prefix-analyzer.test.ts
@@ -1,0 +1,30 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { analyzePrefix, generatePromptCacheKey } from "../../src/lib/promptCache";
+
+describe("prompt cache prefix analyzer", () => {
+  it("captures stable system prefixes and derives a cache key", () => {
+    const messages = [
+      { role: "system", content: "You are helpful." },
+      { role: "user", content: "Hello" },
+    ];
+
+    const analysis = analyzePrefix(messages);
+
+    assert.equal(analysis.prefixEndIdx, 0);
+    assert.equal(analysis.prefixType, "system_only");
+    assert.equal(analysis.confidence, 0.9);
+    assert.ok(analysis.prefixTokens > 0);
+    assert.match(generatePromptCacheKey(messages), /^omni-[a-f0-9]{32}$/);
+  });
+
+  it("keeps the legacy empty-content key when there is no prefix", () => {
+    const messages = [{ role: "user", content: "Hello" }];
+
+    const analysis = analyzePrefix(messages);
+
+    assert.equal(analysis.prefixEndIdx, -1);
+    assert.equal(generatePromptCacheKey(messages), "omni-e3b0c44298fc1c149afbf4c8996fb924");
+  });
+});


### PR DESCRIPTION
## Summary
- Remove the unused `shouldInjectCacheControl` prompt-cache helper and its barrel re-export.
- Add focused coverage for the remaining prefix analysis/cache-key helpers.
- Leave `metrics.deadExports.value` unchanged so this PR stays independent from the rest of the dead-code cleanup series.

## Validation
- `node --import tsx --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test tests/unit/prompt-cache-prefix-analyzer.test.ts`
- `npm run check:dead-code -- --quiet`
- `git diff --check`
- Commit/push hooks: docs sync, T11 any-budget, tracked-artifacts
