### PR TITLE
[codex] fix post-merge CI regressions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ COPY package*.json ./
 # Workspace package manifests MUST be present before `npm ci` so npm materializes
 # the workspace and installs its *workspace-only* deps (e.g. safe-regex,
 # @toon-format/toon — declared in open-sse/package.json, not hoisted to root).
-# Without this, `npm ci` skips them and `npm run build` fails with "Module not
+# Without this, `npm ci` skips them and the application build fails with "Module not
 # found" (root cause of the v3.8.39 Docker build break). workspaces = ["open-sse"].
 COPY open-sse/package.json ./open-sse/package.json
 COPY scripts/build/postinstall.mjs ./scripts/build/postinstall.mjs

--- a/src/app/api/providers/health-autopilot/actions/route.ts
+++ b/src/app/api/providers/health-autopilot/actions/route.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 
 import { requireManagementAuth } from "@/lib/api/requireManagementAuth";
 import { executeProviderHealthAutopilotAction } from "@/lib/monitoring/providerHealthAutopilot";
+import { validateBrowserMutationOrigin } from "@/server/origin/publicOrigin";
 import { validateBody } from "@/shared/validation/helpers";
 
 const actionSchema = z.object({
@@ -27,6 +28,11 @@ const actionSchema = z.object({
 export async function POST(request: Request) {
   const authError = await requireManagementAuth(request);
   if (authError) return authError;
+
+  const originVerdict = validateBrowserMutationOrigin(request);
+  if (!originVerdict.ok) {
+    return NextResponse.json({ error: { message: "Invalid request origin" } }, { status: 403 });
+  }
 
   try {
     let rawBody: unknown;


### PR DESCRIPTION
## Summary

Follow-up after #5315 landed to fix two CI/security regressions that were already visible in the merged run.

## What changed

- Rewords an early Dockerfile comment so `tests/unit/dockerfile-build-heap-4076.test.ts` matches the real `npm run build` step instead of a pre-`NODE_OPTIONS` comment.
- Adds `validateBrowserMutationOrigin()` to `POST /api/providers/health-autopilot/actions` so cross-site browser mutations are rejected before autopilot actions run.

## Validation

- `node --import tsx/esm --test tests/unit/dockerfile-build-heap-4076.test.ts`
- `node --import tsx/esm --test tests/unit/provider-health-autopilot.test.ts`
- `npx eslint src/app/api/providers/health-autopilot/actions/route.ts`