### PR TITLE
fix: gate Claude adaptive thinking defaults

### DIFF
--- a/open-sse/executors/base.ts
+++ b/open-sse/executors/base.ts
@@ -1057,8 +1057,11 @@ export class BaseExecutor {
             delete tb.thinking;
             delete tb.context_management;
             appliedThinking = "off";
-          } else if (!effThinking && !headerEffort) {
-            // Default CC logic when no override headers are present
+          } else if (!effThinking && !headerEffort && isClaudeCodeClient) {
+            // Default Claude Code logic when no override headers are present.
+            // Generic OpenAI-compatible clients that route through native Claude OAuth
+            // must opt in with x-omniroute-thinking; force-injecting adaptive thinking
+            // leaks non-standard reasoning replay fields back into those clients.
             const isHaiku = typeof tb.model === "string" && tb.model.includes("haiku");
             // #5312 RC-B: honor the operator's proxy-level Thinking-Budget mode.
             // `auto` means "strip — let the provider decide", so suppress the default

--- a/tests/unit/context-editing-executor-injection.test.ts
+++ b/tests/unit/context-editing-executor-injection.test.ts
@@ -35,6 +35,60 @@ function toolUseEdits(body: Record<string, unknown> | undefined) {
   return (cm?.edits ?? []).filter((e) => e?.type === CLEAR_TOOL_USES_STRATEGY);
 }
 
+test("#5312: generic Claude OAuth clients do not get implicit adaptive thinking", async () => {
+  const { bodies, restore } = mockFetchCapture();
+  try {
+    await new DefaultExecutor("claude").execute({
+      model: "claude-opus-4-8",
+      body: {
+        model: "claude-opus-4-8",
+        messages: [{ role: "user", content: "hi" }],
+        max_tokens: 1,
+      },
+      stream: false,
+      credentials: { accessToken: "sk-ant-oat-generic-client-token" },
+      clientHeaders: {
+        "user-agent": "Cursor/1.0",
+      },
+      contextEditing: { enabled: false },
+    });
+  } finally {
+    restore();
+  }
+
+  assert.equal(bodies[0]?.thinking, undefined);
+  assert.equal(bodies[0]?.output_config, undefined);
+  assert.equal(bodies[0]?.context_management, undefined);
+});
+
+test("#5312: generic Claude OAuth clients can opt in to adaptive thinking", async () => {
+  const { bodies, restore } = mockFetchCapture();
+  try {
+    await new DefaultExecutor("claude").execute({
+      model: "claude-opus-4-8",
+      body: {
+        model: "claude-opus-4-8",
+        messages: [{ role: "user", content: "hi" }],
+        max_tokens: 1,
+      },
+      stream: false,
+      credentials: { accessToken: "sk-ant-oat-generic-client-token" },
+      clientHeaders: {
+        "user-agent": "Cursor/1.0",
+        "x-omniroute-thinking": "adaptive",
+      },
+      contextEditing: { enabled: false },
+    });
+  } finally {
+    restore();
+  }
+
+  assert.deepEqual(bodies[0]?.thinking, { type: "adaptive" });
+  assert.deepEqual(bodies[0]?.context_management, {
+    edits: [{ type: CLEAR_THINKING_STRATEGY, keep: "all" }],
+  });
+});
+
 test("Context Editing: enabled → genuine claude request gets clear_tool_uses with defaults", async () => {
   const { bodies, restore } = mockFetchCapture();
   try {


### PR DESCRIPTION
## Summary
- stop force-injecting Claude adaptive thinking/output_config for generic native Claude OAuth clients
- keep explicit `x-omniroute-thinking: adaptive` opt-in behavior
- preserve the existing Claude Code CLI default adaptive-thinking path

Closes #5312.

## Test plan
- `DISABLE_SQLITE_AUTO_BACKUP=true node --max-old-space-size=8192 --import tsx --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test --test-force-exit tests/unit/context-editing-executor-injection.test.ts`

Note: I also attempted a related Claude translator/beta slice, but this local environment exited with status 1 and no stderr/stdout for those files, so I did not use it as evidence.