### PR TITLE
chore(duplication): share recharts donut card

### DIFF
--- a/src/shared/components/analytics/rechartsDonuts.tsx
+++ b/src/shared/components/analytics/rechartsDonuts.tsx
@@ -12,6 +12,78 @@ import {
 import { PROVIDER_COLORS } from "./chartColors";
 import { ChartLoadingCard, DarkTooltip, useRecharts } from "./rechartsCore";
 
+function CompactDonutCard({
+  pieData,
+  title,
+  formatter,
+  valueClassName = "text-text-muted",
+  labelClassName = "",
+  getLegendKey,
+  getLegendTitle,
+}) {
+  const recharts = useRecharts();
+
+  if (!recharts) {
+    return <ChartLoadingCard />;
+  }
+
+  const { Cell, PieChart, Pie, Tooltip, ResponsiveContainer } = recharts;
+
+  return (
+    <Card className="p-4 flex-1">
+      <h3 className="text-sm font-semibold text-text-muted uppercase tracking-wider mb-3">
+        {title}
+      </h3>
+      <div className="flex items-center gap-4">
+        <ResponsiveContainer width={120} height={120}>
+          <PieChart>
+            <Pie
+              data={pieData}
+              dataKey="value"
+              nameKey="name"
+              cx="50%"
+              cy="50%"
+              innerRadius={28}
+              outerRadius={55}
+              paddingAngle={1}
+              animationDuration={600}
+            >
+              {pieData.map((entry, i) => (
+                <Cell key={i} fill={entry.fill} stroke="none" />
+              ))}
+            </Pie>
+            <Tooltip content={<DarkTooltip formatter={formatter} />} />
+          </PieChart>
+        </ResponsiveContainer>
+        <div className="flex flex-col gap-1 min-w-0 flex-1">
+          {pieData.map((seg, i) => (
+            <div
+              key={getLegendKey ? getLegendKey(seg, i) : i}
+              className="flex items-center justify-between gap-2 text-xs"
+            >
+              <div className="flex items-center gap-1.5 min-w-0">
+                <span
+                  className="w-2 h-2 rounded-full shrink-0"
+                  style={{ backgroundColor: seg.fill }}
+                />
+                <span
+                  className={`truncate text-text-main ${labelClassName}`.trim()}
+                  title={getLegendTitle?.(seg)}
+                >
+                  {seg.name}
+                </span>
+              </div>
+              <span className={`font-mono font-medium shrink-0 ${valueClassName}`}>
+                {formatter(seg.value)}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </Card>
+  );
+}
+
 // ── AccountDonut (Recharts) ────────────────────────────────────────────────
 
 export function AccountDonut({ byAccount }) {
@@ -38,63 +110,7 @@ export function AccountDonut({ byAccount }) {
     );
   }
 
-  return <AccountDonutBody pieData={pieData} />;
-}
-
-function AccountDonutBody({ pieData }) {
-  const recharts = useRecharts();
-
-  if (!recharts) {
-    return <ChartLoadingCard />;
-  }
-
-  const { Cell, PieChart, Pie, Tooltip, ResponsiveContainer } = recharts;
-
-  return (
-    <Card className="p-4 flex-1">
-      <h3 className="text-sm font-semibold text-text-muted uppercase tracking-wider mb-3">
-        By Account
-      </h3>
-      <div className="flex items-center gap-4">
-        <ResponsiveContainer width={120} height={120}>
-          <PieChart>
-            <Pie
-              data={pieData}
-              dataKey="value"
-              nameKey="name"
-              cx="50%"
-              cy="50%"
-              innerRadius={28}
-              outerRadius={55}
-              paddingAngle={1}
-              animationDuration={600}
-            >
-              {pieData.map((entry, i) => (
-                <Cell key={i} fill={entry.fill} stroke="none" />
-              ))}
-            </Pie>
-            <Tooltip content={<DarkTooltip formatter={fmt} />} />
-          </PieChart>
-        </ResponsiveContainer>
-        <div className="flex flex-col gap-1 min-w-0 flex-1">
-          {pieData.map((seg, i) => (
-            <div key={i} className="flex items-center justify-between gap-2 text-xs">
-              <div className="flex items-center gap-1.5 min-w-0">
-                <span
-                  className="w-2 h-2 rounded-full shrink-0"
-                  style={{ backgroundColor: seg.fill }}
-                />
-                <span className="truncate text-text-main">{seg.name}</span>
-              </div>
-              <span className="font-mono font-medium text-text-muted shrink-0">
-                {fmt(seg.value)}
-              </span>
-            </div>
-          ))}
-        </div>
-      </div>
-    </Card>
-  );
+  return <CompactDonutCard pieData={pieData} title="By Account" formatter={fmt} />;
 }
 
 // ── ApiKeyDonut (Recharts) ─────────────────────────────────────────────────
@@ -124,67 +140,14 @@ export function ApiKeyDonut({ byApiKey }) {
     );
   }
 
-  return <ApiKeyDonutBody pieData={pieData} />;
-}
-
-function ApiKeyDonutBody({ pieData }) {
-  const recharts = useRecharts();
-
-  if (!recharts) {
-    return <ChartLoadingCard />;
-  }
-
-  const { Cell, PieChart, Pie, Tooltip, ResponsiveContainer } = recharts;
-
   return (
-    <Card className="p-4 flex-1">
-      <h3 className="text-sm font-semibold text-text-muted uppercase tracking-wider mb-3">
-        By API Key
-      </h3>
-      <div className="flex items-center gap-4">
-        <ResponsiveContainer width={120} height={120}>
-          <PieChart>
-            <Pie
-              data={pieData}
-              dataKey="value"
-              nameKey="name"
-              cx="50%"
-              cy="50%"
-              innerRadius={28}
-              outerRadius={55}
-              paddingAngle={1}
-              animationDuration={600}
-            >
-              {pieData.map((entry, i) => (
-                <Cell key={i} fill={entry.fill} stroke="none" />
-              ))}
-            </Pie>
-            <Tooltip content={<DarkTooltip formatter={fmt} />} />
-          </PieChart>
-        </ResponsiveContainer>
-        <div className="flex flex-col gap-1 min-w-0 flex-1">
-          {pieData.map((seg, i) => (
-            <div
-              key={`${seg.fullName}-${i}`}
-              className="flex items-center justify-between gap-2 text-xs"
-            >
-              <div className="flex items-center gap-1.5 min-w-0">
-                <span
-                  className="w-2 h-2 rounded-full shrink-0"
-                  style={{ backgroundColor: seg.fill }}
-                />
-                <span className="truncate text-text-main" title={seg.fullName}>
-                  {seg.name}
-                </span>
-              </div>
-              <span className="font-mono font-medium text-text-muted shrink-0">
-                {fmt(seg.value)}
-              </span>
-            </div>
-          ))}
-        </div>
-      </div>
-    </Card>
+    <CompactDonutCard
+      pieData={pieData}
+      title="By API Key"
+      formatter={fmt}
+      getLegendKey={(seg, i) => `${seg.fullName}-${i}`}
+      getLegendTitle={(seg) => seg.fullName}
+    />
   );
 }
 
@@ -218,63 +181,14 @@ export function ProviderCostDonut({ byProvider }) {
     );
   }
 
-  return <ProviderCostDonutBody pieData={pieData} />;
-}
-
-function ProviderCostDonutBody({ pieData }) {
-  const t = useTranslations("analytics");
-  const recharts = useRecharts();
-
-  if (!recharts) {
-    return <ChartLoadingCard />;
-  }
-
-  const { Cell, PieChart, Pie, Tooltip, ResponsiveContainer } = recharts;
-
   return (
-    <Card className="p-4 flex-1">
-      <h3 className="text-sm font-semibold text-text-muted uppercase tracking-wider mb-3">
-        {t("chartCostByProvider")}
-      </h3>
-      <div className="flex items-center gap-4">
-        <ResponsiveContainer width={120} height={120}>
-          <PieChart>
-            <Pie
-              data={pieData}
-              dataKey="value"
-              nameKey="name"
-              cx="50%"
-              cy="50%"
-              innerRadius={28}
-              outerRadius={55}
-              paddingAngle={1}
-              animationDuration={600}
-            >
-              {pieData.map((entry, i) => (
-                <Cell key={i} fill={entry.fill} stroke="none" />
-              ))}
-            </Pie>
-            <Tooltip content={<DarkTooltip formatter={fmtCost} />} />
-          </PieChart>
-        </ResponsiveContainer>
-        <div className="flex flex-col gap-1 min-w-0 flex-1">
-          {pieData.map((seg, i) => (
-            <div key={i} className="flex items-center justify-between gap-2 text-xs">
-              <div className="flex items-center gap-1.5 min-w-0">
-                <span
-                  className="w-2 h-2 rounded-full shrink-0"
-                  style={{ backgroundColor: seg.fill }}
-                />
-                <span className="truncate text-text-main capitalize">{seg.name}</span>
-              </div>
-              <span className="font-mono font-medium text-amber-500 shrink-0">
-                {fmtCost(seg.value)}
-              </span>
-            </div>
-          ))}
-        </div>
-      </div>
-    </Card>
+    <CompactDonutCard
+      pieData={pieData}
+      title={t("chartCostByProvider")}
+      formatter={fmtCost}
+      valueClassName="text-amber-500"
+      labelClassName="capitalize"
+    />
   );
 }
 


### PR DESCRIPTION
## Summary

- Adds a shared local `CompactDonutCard` renderer for the analytics Recharts donut cards.
- Reuses it for account, API-key, and provider-cost donut bodies while preserving titles, tooltip formatters, legend titles/keys, and cost styling.
- Keeps this cleanup scoped to one dashboard analytics component file.

## Duplication impact

- `npm run check:duplication` reports `4.97%` against the unchanged baseline (`5.72%`).
- No metrics/baseline files were changed.

## Tests

- `npx eslint src/shared/components/analytics/rechartsDonuts.tsx` — pass
- `node --import tsx/esm --test tests/integration/integration-wiring.test.ts` — 68 passing, 4 skipped
- `npm run check:duplication` — pass (`4.97%`, baseline `5.72%`)
- `npm run check:pr-test-policy` — skipped locally because there is no pull request context
- Commit/push hooks: docs sync, `check:any-budget:t11`, and tracked-artifacts checks passed

## Known release-branch blocker

- `npm run typecheck:core` is currently blocked on the release branch by missing dependencies unrelated to this change:
  - `open-sse/services/compression/engines/ccr/ccrQuery.ts(9,23): Cannot find module 'safe-regex'`
  - `open-sse/services/compression/engines/headroom/toon.ts(9,60): Cannot find module '@toon-format/toon'`
