### PR TITLE
chore(duplication): share batch response formatter

### DIFF
--- a/src/app/api/v1/batches/[id]/cancel/route.ts
+++ b/src/app/api/v1/batches/[id]/cancel/route.ts
@@ -2,37 +2,7 @@ import { CORS_HEADERS, handleCorsOptions } from "@/shared/utils/cors";
 import { getBatch, updateBatch } from "@/lib/localDb";
 import { NextResponse } from "next/server";
 import { getApiKeyRequestScope } from "@/app/api/v1/_helpers/apiKeyScope";
-
-function formatBatchResponse(batch: any) {
-  return {
-    id: batch.id,
-    object: "batch",
-    endpoint: batch.endpoint,
-    errors: batch.errors || null,
-    input_file_id: batch.inputFileId,
-    completion_window: batch.completionWindow,
-    status: batch.status,
-    output_file_id: batch.outputFileId || null,
-    error_file_id: batch.errorFileId || null,
-    created_at: batch.createdAt,
-    in_progress_at: batch.inProgressAt || null,
-    expires_at: batch.expiresAt || null,
-    finalizing_at: batch.finalizingAt || null,
-    completed_at: batch.completedAt || null,
-    failed_at: batch.failedAt || null,
-    expired_at: batch.expiredAt || null,
-    cancelling_at: batch.cancellingAt || null,
-    cancelled_at: batch.cancelledAt || null,
-    request_counts: {
-      total: batch.requestCountsTotal || 0,
-      completed: batch.requestCountsCompleted || 0,
-      failed: batch.requestCountsFailed || 0,
-    },
-    metadata: batch.metadata || null,
-    model: batch.model || null,
-    usage: batch.usage || null,
-  };
-}
+import { formatBatchResponse } from "../../formatBatchResponse";
 
 export async function OPTIONS() {
   return handleCorsOptions();

--- a/src/app/api/v1/batches/[id]/route.ts
+++ b/src/app/api/v1/batches/[id]/route.ts
@@ -2,37 +2,7 @@ import { CORS_HEADERS, handleCorsOptions } from "@/shared/utils/cors";
 import { getBatch, deleteBatch } from "@/lib/localDb";
 import { NextResponse } from "next/server";
 import { getApiKeyRequestScope } from "@/app/api/v1/_helpers/apiKeyScope";
-
-function formatBatchResponse(batch: any) {
-  return {
-    id: batch.id,
-    object: "batch",
-    endpoint: batch.endpoint,
-    errors: batch.errors || null,
-    input_file_id: batch.inputFileId,
-    completion_window: batch.completionWindow,
-    status: batch.status,
-    output_file_id: batch.outputFileId || null,
-    error_file_id: batch.errorFileId || null,
-    created_at: batch.createdAt,
-    in_progress_at: batch.inProgressAt || null,
-    expires_at: batch.expiresAt || null,
-    finalizing_at: batch.finalizingAt || null,
-    completed_at: batch.completedAt || null,
-    failed_at: batch.failedAt || null,
-    expired_at: batch.expiredAt || null,
-    cancelling_at: batch.cancellingAt || null,
-    cancelled_at: batch.cancelledAt || null,
-    request_counts: {
-      total: batch.requestCountsTotal || 0,
-      completed: batch.requestCountsCompleted || 0,
-      failed: batch.requestCountsFailed || 0,
-    },
-    metadata: batch.metadata || null,
-    model: batch.model || null,
-    usage: batch.usage || null,
-  };
-}
+import { formatBatchResponse } from "../formatBatchResponse";
 
 export async function OPTIONS() {
   return handleCorsOptions();

--- a/src/app/api/v1/batches/formatBatchResponse.ts
+++ b/src/app/api/v1/batches/formatBatchResponse.ts
@@ -1,0 +1,30 @@
+export function formatBatchResponse(batch: any) {
+  return {
+    id: batch.id,
+    object: "batch",
+    endpoint: batch.endpoint,
+    errors: batch.errors || null,
+    input_file_id: batch.inputFileId,
+    completion_window: batch.completionWindow,
+    status: batch.status,
+    output_file_id: batch.outputFileId || null,
+    error_file_id: batch.errorFileId || null,
+    created_at: batch.createdAt,
+    in_progress_at: batch.inProgressAt || null,
+    expires_at: batch.expiresAt || null,
+    finalizing_at: batch.finalizingAt || null,
+    completed_at: batch.completedAt || null,
+    failed_at: batch.failedAt || null,
+    expired_at: batch.expiredAt || null,
+    cancelling_at: batch.cancellingAt || null,
+    cancelled_at: batch.cancelledAt || null,
+    request_counts: {
+      total: batch.requestCountsTotal || 0,
+      completed: batch.requestCountsCompleted || 0,
+      failed: batch.requestCountsFailed || 0,
+    },
+    metadata: batch.metadata || null,
+    model: batch.model || null,
+    usage: batch.usage || null,
+  };
+}

--- a/src/app/api/v1/batches/route.ts
+++ b/src/app/api/v1/batches/route.ts
@@ -3,37 +3,7 @@ import { createBatch, getFile, listBatches, countBatches } from "@/lib/localDb";
 import { v1BatchCreateSchema } from "@/shared/validation/schemas";
 import { NextResponse } from "next/server";
 import { getApiKeyRequestScope } from "@/app/api/v1/_helpers/apiKeyScope";
-
-function formatBatchResponse(batch: any) {
-  return {
-    id: batch.id,
-    object: "batch",
-    endpoint: batch.endpoint,
-    errors: batch.errors || null,
-    input_file_id: batch.inputFileId,
-    completion_window: batch.completionWindow,
-    status: batch.status,
-    output_file_id: batch.outputFileId || null,
-    error_file_id: batch.errorFileId || null,
-    created_at: batch.createdAt,
-    in_progress_at: batch.inProgressAt || null,
-    expires_at: batch.expiresAt || null,
-    finalizing_at: batch.finalizingAt || null,
-    completed_at: batch.completedAt || null,
-    failed_at: batch.failedAt || null,
-    expired_at: batch.expiredAt || null,
-    cancelling_at: batch.cancellingAt || null,
-    cancelled_at: batch.cancelledAt || null,
-    request_counts: {
-      total: batch.requestCountsTotal || 0,
-      completed: batch.requestCountsCompleted || 0,
-      failed: batch.requestCountsFailed || 0,
-    },
-    metadata: batch.metadata || null,
-    model: batch.model || null,
-    usage: batch.usage || null,
-  };
-}
+import { formatBatchResponse } from "./formatBatchResponse";
 
 export async function OPTIONS() {
   return handleCorsOptions();


### PR DESCRIPTION
## Summary

- Adds a shared `formatBatchResponse` helper for the v1 batches API response shape.
- Reuses it from list, by-id, and cancel batch routes.
- Leaves route auth/scope checks, status handling, and error responses unchanged.

## Duplication impact

- `npm run check:duplication` reports `5%` against the unchanged baseline (`5.72%`).
- No metrics/baseline files were changed.

## Tests

- `npx eslint src/app/api/v1/batches/formatBatchResponse.ts src/app/api/v1/batches/route.ts 'src/app/api/v1/batches/[id]/route.ts' 'src/app/api/v1/batches/[id]/cancel/route.ts'` — pass
- `node --import tsx/esm --test tests/unit/batch_api.test.ts` — 22 passing
- `npm run check:duplication` — pass (`5%`, baseline `5.72%`)
- `npm run check:pr-test-policy` — skipped locally because there is no pull request context
- Commit/push hooks: docs sync, `check:any-budget:t11`, and tracked-artifacts checks passed

## Known release-branch blocker

- `npm run typecheck:core` is currently blocked on the release branch by missing dependencies unrelated to this change:
  - `open-sse/services/compression/engines/ccr/ccrQuery.ts(9,23): Cannot find module 'safe-regex'`
  - `open-sse/services/compression/engines/headroom/toon.ts(9,60): Cannot find module '@toon-format/toon'`
