### PR TITLE
fix: treat terminal stream cancels as complete

### DIFF
--- a/open-sse/utils/streamHandler.ts
+++ b/open-sse/utils/streamHandler.ts
@@ -219,6 +219,7 @@ export function createStreamController({
   const abortController = new AbortController();
   const startTime = Date.now();
   let disconnected = false;
+  let clientTerminalSeen = false;
   let pendingRequestCleared = false;
   let cleanupClientAbortSignal: (() => void) | null = null;
 
@@ -274,6 +275,10 @@ export function createStreamController({
     // Call when client disconnects
     handleDisconnect: (reason = "client_closed") => {
       if (disconnected) return;
+      if (clientTerminalSeen) {
+        controller.handleComplete();
+        return;
+      }
       disconnected = true;
       cleanupClientAbortListener();
 
@@ -295,6 +300,10 @@ export function createStreamController({
       cleanupClientAbortListener();
 
       logStream("complete");
+    },
+
+    markClientTerminalSeen: () => {
+      clientTerminalSeen = true;
     },
 
     // Call on error
@@ -461,6 +470,9 @@ export function createDisconnectAwareStream(transformStream, streamController) {
       terminalTail,
       streamController.clientResponseFormat
     );
+    if (clientTerminalSeen) {
+      streamController.markClientTerminalSeen?.();
+    }
   };
 
   return new ReadableStream(
@@ -523,7 +535,11 @@ export function createDisconnectAwareStream(transformStream, streamController) {
       },
 
       async cancel(reason) {
-        streamController.handleDisconnect(reason || "cancelled");
+        if (clientTerminalSeen) {
+          streamController.handleComplete();
+        } else {
+          streamController.handleDisconnect(reason || "cancelled");
+        }
         await Promise.allSettled([reader.cancel(reason), writer.abort(reason)]);
       },
     },

--- a/tests/unit/stream-handler.test.ts
+++ b/tests/unit/stream-handler.test.ts
@@ -98,6 +98,75 @@ test("createDisconnectAwareStream treats errors after OpenAI DONE as successful 
   assert.doesNotMatch(text, /terminated/);
 });
 
+test("createDisconnectAwareStream treats cancel after OpenAI DONE as successful completion", async () => {
+  let disconnectHandled = false;
+  const transformStream = {
+    readable: new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+      },
+    }),
+    writable: {
+      getWriter() {
+        return {
+          abort() {},
+        };
+      },
+    },
+  };
+
+  const stream = createDisconnectAwareStream(
+    transformStream,
+    createStreamController({
+      onDisconnect() {
+        disconnectHandled = true;
+      },
+    })
+  );
+  const reader = stream.getReader();
+  const first = await reader.read();
+  assert.equal(decoder.decode(first.value), "data: [DONE]\n\n");
+  await reader.cancel("request_signal_aborted");
+
+  assert.equal(disconnectHandled, false);
+});
+
+test("createDisconnectAwareStream treats cancel after Responses completed as successful completion", async () => {
+  let disconnectHandled = false;
+  const transformStream = {
+    readable: new ReadableStream({
+      start(controller) {
+        controller.enqueue(
+          encoder.encode('event: response.completed\ndata: {"type":"response.completed"}\n\n')
+        );
+      },
+    }),
+    writable: {
+      getWriter() {
+        return {
+          abort() {},
+        };
+      },
+    },
+  };
+
+  const stream = createDisconnectAwareStream(
+    transformStream,
+    createStreamController({
+      clientResponseFormat: FORMATS.OPENAI_RESPONSES,
+      onDisconnect() {
+        disconnectHandled = true;
+      },
+    })
+  );
+  const reader = stream.getReader();
+  const first = await reader.read();
+  assert.match(decoder.decode(first.value), /response\.completed/);
+  await reader.cancel("request_signal_aborted");
+
+  assert.equal(disconnectHandled, false);
+});
+
 test("createDisconnectAwareStream: Gemini 503 high-demand error becomes SSE error chunk with message preserved", async () => {
   const geminiMsg =
     "[503]: This model is currently experiencing high demand. Spikes in demand are usually temporary. Please try again later.";


### PR DESCRIPTION
## Summary

Fixes late stream-cancel classification after the downstream client has already received a terminal SSE marker.

## Root Cause

When a client closed the stream immediately after receiving `data: [DONE]` or `response.completed`, the disconnect-aware wrapper could still route the downstream cancel through the client-disconnect path. That finalized the request as a 499 even though the stream had already reached a successful terminal marker.

## Changes

- Track when the client-visible stream has emitted a terminal SSE marker.
- Treat downstream cancel/disconnect after that marker as normal completion instead of `client_disconnected`.
- Add unit coverage for OpenAI Chat Completions `[DONE]` and OpenAI Responses `response.completed` terminal cancels.

## Validation

- `node --import tsx/esm --test tests/unit/stream-handler.test.ts`
- pre-commit/lint-staged checks: Prettier, ESLint, docs sync, explicit-any budget, tracked artifact check
- pre-push checks: explicit-any budget, tracked artifact check
