### PR TITLE
chore(duplication): share version manager request parsing

### DIFF
--- a/src/app/api/version-manager/request.ts
+++ b/src/app/api/version-manager/request.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server";
+
+import { requireManagementAuth } from "@/lib/api/requireManagementAuth";
+import { isValidationFailure, validateBody } from "@/shared/validation/helpers";
+import { versionManagerToolSchema } from "@/shared/validation/schemas";
+
+export const VERSION_MANAGER_SUPERVISOR_TOOLS = new Set(["cliproxy", "cliproxyapi"]);
+
+type VersionManagerToolRequest = { ok: true; tool: string } | { ok: false; response: Response };
+
+export function validateVersionManagerToolBody(rawBody: unknown): VersionManagerToolRequest {
+  const validation = validateBody(versionManagerToolSchema, rawBody);
+  if (isValidationFailure(validation)) {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: validation.error }, { status: 400 }),
+    };
+  }
+
+  const { tool } = validation.data;
+
+  if (!VERSION_MANAGER_SUPERVISOR_TOOLS.has(tool)) {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: `Unknown tool: ${tool}` }, { status: 400 }),
+    };
+  }
+
+  return { ok: true, tool };
+}
+
+export async function parseVersionManagerToolRequest(
+  request: Request
+): Promise<VersionManagerToolRequest> {
+  const authError = await requireManagementAuth(request);
+  if (authError) {
+    return { ok: false, response: authError };
+  }
+
+  let rawBody: unknown;
+  try {
+    rawBody = await request.json();
+  } catch {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: "Invalid JSON body" }, { status: 400 }),
+    };
+  }
+
+  return validateVersionManagerToolBody(rawBody);
+}

--- a/src/app/api/version-manager/restart/route.ts
+++ b/src/app/api/version-manager/restart/route.ts
@@ -3,33 +3,14 @@
 import { NextResponse } from "next/server";
 import { getServiceRow } from "@/lib/db/versionManager";
 import { getOrInitSupervisor } from "@/app/api/services/cliproxy/_lib";
-import { versionManagerToolSchema } from "@/shared/validation/schemas";
-import { isValidationFailure, validateBody } from "@/shared/validation/helpers";
-import { requireManagementAuth } from "@/lib/api/requireManagementAuth";
 import { sanitizeErrorMessage } from "@omniroute/open-sse/utils/error";
 
-const SUPERVISOR_TOOLS = new Set(["cliproxy", "cliproxyapi"]);
+import { parseVersionManagerToolRequest } from "../request";
 
 export async function POST(request: Request) {
-  const authError = await requireManagementAuth(request);
-  if (authError) return authError;
-
-  let rawBody;
-  try {
-    rawBody = await request.json();
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
-  }
-
-  const validation = validateBody(versionManagerToolSchema, rawBody);
-  if (isValidationFailure(validation)) {
-    return NextResponse.json({ error: validation.error }, { status: 400 });
-  }
-
-  const { tool } = validation.data;
-
-  if (!SUPERVISOR_TOOLS.has(tool)) {
-    return NextResponse.json({ error: `Unknown tool: ${tool}` }, { status: 400 });
+  const parsed = await parseVersionManagerToolRequest(request);
+  if (!parsed.ok) {
+    return parsed.response;
   }
 
   try {

--- a/src/app/api/version-manager/start/route.ts
+++ b/src/app/api/version-manager/start/route.ts
@@ -3,35 +3,14 @@
 import { NextResponse } from "next/server";
 import { getServiceRow } from "@/lib/db/versionManager";
 import { getOrInitSupervisor } from "@/app/api/services/cliproxy/_lib";
-import { versionManagerToolSchema } from "@/shared/validation/schemas";
-import { isValidationFailure, validateBody } from "@/shared/validation/helpers";
-import { requireManagementAuth } from "@/lib/api/requireManagementAuth";
 import { sanitizeErrorMessage } from "@omniroute/open-sse/utils/error";
 
-// Only "cliproxy" has a supervisor; for other tools the legacy path is not
-// available in this branch, so we return 409 if the tool is not installed.
-const SUPERVISOR_TOOLS = new Set(["cliproxy", "cliproxyapi"]);
+import { parseVersionManagerToolRequest } from "../request";
 
 export async function POST(request: Request) {
-  const authError = await requireManagementAuth(request);
-  if (authError) return authError;
-
-  let rawBody;
-  try {
-    rawBody = await request.json();
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
-  }
-
-  const validation = validateBody(versionManagerToolSchema, rawBody);
-  if (isValidationFailure(validation)) {
-    return NextResponse.json({ error: validation.error }, { status: 400 });
-  }
-
-  const { tool } = validation.data;
-
-  if (!SUPERVISOR_TOOLS.has(tool)) {
-    return NextResponse.json({ error: `Unknown tool: ${tool}` }, { status: 400 });
+  const parsed = await parseVersionManagerToolRequest(request);
+  if (!parsed.ok) {
+    return parsed.response;
   }
 
   try {

--- a/src/app/api/version-manager/stop/route.ts
+++ b/src/app/api/version-manager/stop/route.ts
@@ -2,33 +2,14 @@
 
 import { NextResponse } from "next/server";
 import { getSupervisor } from "@/lib/services/registry";
-import { versionManagerToolSchema } from "@/shared/validation/schemas";
-import { isValidationFailure, validateBody } from "@/shared/validation/helpers";
-import { requireManagementAuth } from "@/lib/api/requireManagementAuth";
 import { sanitizeErrorMessage } from "@omniroute/open-sse/utils/error";
 
-const SUPERVISOR_TOOLS = new Set(["cliproxy", "cliproxyapi"]);
+import { parseVersionManagerToolRequest } from "../request";
 
 export async function POST(request: Request) {
-  const authError = await requireManagementAuth(request);
-  if (authError) return authError;
-
-  let rawBody;
-  try {
-    rawBody = await request.json();
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
-  }
-
-  const validation = validateBody(versionManagerToolSchema, rawBody);
-  if (isValidationFailure(validation)) {
-    return NextResponse.json({ error: validation.error }, { status: 400 });
-  }
-
-  const { tool } = validation.data;
-
-  if (!SUPERVISOR_TOOLS.has(tool)) {
-    return NextResponse.json({ error: `Unknown tool: ${tool}` }, { status: 400 });
+  const parsed = await parseVersionManagerToolRequest(request);
+  if (!parsed.ok) {
+    return parsed.response;
   }
 
   try {

--- a/tests/unit/version-manager-request.test.ts
+++ b/tests/unit/version-manager-request.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { validateVersionManagerToolBody } from "../../src/app/api/version-manager/request.ts";
+
+async function readFailure(result: ReturnType<typeof validateVersionManagerToolBody>) {
+  assert.equal(result.ok, false);
+  if (result.ok) {
+    throw new Error("expected validation failure");
+  }
+
+  return {
+    status: result.response.status,
+    body: await result.response.json(),
+  };
+}
+
+test("validateVersionManagerToolBody accepts cliproxy aliases", () => {
+  assert.deepEqual(validateVersionManagerToolBody({ tool: "cliproxy" }), {
+    ok: true,
+    tool: "cliproxy",
+  });
+  assert.deepEqual(validateVersionManagerToolBody({ tool: "cliproxyapi" }), {
+    ok: true,
+    tool: "cliproxyapi",
+  });
+});
+
+test("validateVersionManagerToolBody rejects unknown tools with the legacy response shape", async () => {
+  const failure = await readFailure(validateVersionManagerToolBody({ tool: "other" }));
+
+  assert.equal(failure.status, 400);
+  assert.deepEqual(failure.body, { error: "Unknown tool: other" });
+});
+
+test("validateVersionManagerToolBody rejects invalid bodies", async () => {
+  const failure = await readFailure(validateVersionManagerToolBody({}));
+
+  assert.equal(failure.status, 400);
+  assert.equal(failure.body.error.message, "Invalid request");
+  assert.deepEqual(failure.body.error.details, [
+    {
+      field: "tool",
+      message: "Invalid input: expected string, received undefined",
+    },
+  ]);
+});


### PR DESCRIPTION
## Summary
- Extract shared version-manager tool request auth, JSON parsing, schema validation, and allowed-tool checks into `src/app/api/version-manager/request.ts`.
- Reuse the parser from the start, restart, and stop route handlers while keeping supervisor-specific behavior in each route.
- Add focused unit coverage for accepted tool aliases, unknown-tool rejection, and schema validation errors.

## Duplication impact
- `npm run check:duplication` passes at 5% duplicated code against the 5.72% baseline.
- No metrics or duplication baseline files changed.

## Tests
- `node --import tsx/esm --test tests/unit/version-manager-request.test.ts`
- `node --import tsx/esm --test tests/unit/version-manager.test.ts`
- `npx eslint src/app/api/version-manager/request.ts src/app/api/version-manager/start/route.ts src/app/api/version-manager/restart/route.ts src/app/api/version-manager/stop/route.ts tests/unit/version-manager-request.test.ts`
- `npm run check:duplication`
- `npm run check:pr-test-policy` (skips locally because it is not running in a pull request context)
- `npm run typecheck:core` (fails on the release branch because `safe-regex` and `@toon-format/toon` modules are not installed/resolvable)
