### PR TITLE
chore(duplication): share machine id fallback

### DIFF
--- a/src/shared/utils/machineId.ts
+++ b/src/shared/utils/machineId.ts
@@ -91,6 +91,33 @@ function getMachineIdRaw(): string {
   return "unknown-machine";
 }
 
+async function getRandomMachineFallbackId() {
+  try {
+    const cryptoFallback = await import("crypto");
+    return cryptoFallback.randomUUID();
+  } catch {
+    if (typeof globalThis !== "undefined" && globalThis.crypto && globalThis.crypto.randomUUID) {
+      return globalThis.crypto.randomUUID();
+    }
+    return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, function (c) {
+      let r = 0;
+      if (
+        typeof globalThis !== "undefined" &&
+        globalThis.crypto &&
+        globalThis.crypto.getRandomValues
+      ) {
+        const arr = new Uint8Array(1);
+        globalThis.crypto.getRandomValues(arr);
+        r = arr[0] % 16;
+      } else {
+        r = (Date.now() % 16) | 0;
+      }
+      const v = c === "x" ? r : (r & 0x3) | 0x8;
+      return v.toString(16);
+    });
+  }
+}
+
 /**
  * Get consistent machine ID using native registry/OS query with salt
  * This ensures the same physical machine gets the same ID across runs
@@ -113,30 +140,7 @@ export async function getConsistentMachineId(salt = null) {
   } catch (error) {
     console.log("Error getting machine ID:", error);
     // Fallback to random ID if node-machine-id fails
-    try {
-      const cryptoFallback = await import("crypto");
-      return cryptoFallback.randomUUID();
-    } catch {
-      if (typeof globalThis !== "undefined" && globalThis.crypto && globalThis.crypto.randomUUID) {
-        return globalThis.crypto.randomUUID();
-      }
-      return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, function (c) {
-        let r = 0;
-        if (
-          typeof globalThis !== "undefined" &&
-          globalThis.crypto &&
-          globalThis.crypto.getRandomValues
-        ) {
-          const arr = new Uint8Array(1);
-          globalThis.crypto.getRandomValues(arr);
-          r = arr[0] % 16;
-        } else {
-          r = (Date.now() % 16) | 0;
-        }
-        const v = c === "x" ? r : (r & 0x3) | 0x8;
-        return v.toString(16);
-      });
-    }
+    return getRandomMachineFallbackId();
   }
 }
 
@@ -150,30 +154,7 @@ export async function getRawMachineId() {
   } catch (error) {
     console.log("Error getting raw machine ID:", error);
     // Fallback to random ID if node-machine-id fails
-    try {
-      const cryptoFallback = await import("crypto");
-      return cryptoFallback.randomUUID();
-    } catch {
-      if (typeof globalThis !== "undefined" && globalThis.crypto && globalThis.crypto.randomUUID) {
-        return globalThis.crypto.randomUUID();
-      }
-      return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, function (c) {
-        let r = 0;
-        if (
-          typeof globalThis !== "undefined" &&
-          globalThis.crypto &&
-          globalThis.crypto.getRandomValues
-        ) {
-          const arr = new Uint8Array(1);
-          globalThis.crypto.getRandomValues(arr);
-          r = arr[0] % 16;
-        } else {
-          r = (Date.now() % 16) | 0;
-        }
-        const v = c === "x" ? r : (r & 0x3) | 0x8;
-        return v.toString(16);
-      });
-    }
+    return getRandomMachineFallbackId();
   }
 }
 


### PR DESCRIPTION
## Summary
- Extract the duplicated random machine-id fallback into a private helper in `machineId.ts`.
- Reuse the helper from both `getConsistentMachineId()` and `getRawMachineId()` fallback paths.
- Keep the public machine-id module surface unchanged.

## Duplication impact
- `npm run check:duplication` passes at 5.01% duplicated code against the 5.72% baseline.
- No metrics or duplication baseline files changed.

## Tests
- `node --import tsx/esm --test tests/unit/machine-id.test.ts`
- `npx eslint src/shared/utils/machineId.ts tests/unit/machine-id.test.ts`
- `npm run check:duplication`
- `npm run check:pr-test-policy` (skips locally because it is not running in a pull request context)
- `npm run typecheck:core` (fails on the release branch because `safe-regex` and `@toon-format/toon` modules are not installed/resolvable)
