### PR TITLE
chore(duplication): share node sqlite adapter

### DIFF
--- a/src/lib/db/adapters/driverFactory.ts
+++ b/src/lib/db/adapters/driverFactory.ts
@@ -1,8 +1,10 @@
-// src/lib/db/adapters/driverFactory.ts
-import fs from "node:fs";
 import { createRequire } from "node:module";
 import { createBetterSqliteAdapter } from "./betterSqliteAdapter";
-import type { SqliteAdapter, PreparedStatement, RunResult } from "./types";
+import {
+  createNodeSqliteAdapterFromDatabase,
+  type NodeSqliteDatabaseLike,
+} from "./nodeSqliteShared";
+import type { SqliteAdapter } from "./types";
 
 const _require = createRequire(import.meta.url);
 
@@ -15,138 +17,6 @@ function getSqlJsCache(): Map<string, SqliteAdapter> {
     globalThis.__omnirouteSqlJsAdapters = new Map();
   }
   return globalThis.__omnirouteSqlJsAdapters;
-}
-
-function buildNodeAdapterSync(
-  db: {
-    prepare(sql: string): {
-      run(...p: unknown[]): { changes: number | bigint; lastInsertRowid: number | bigint };
-      get(...p: unknown[]): unknown;
-      all(...p: unknown[]): unknown[];
-    };
-    exec(sql: string): void;
-    close(): void;
-  },
-  filePath: string
-): SqliteAdapter {
-  let _isOpen = true;
-  const MAX_STMT_CACHE_SIZE = 200;
-  interface CachedStatement {
-    stmt: ReturnType<typeof db.prepare>;
-    sql: string;
-  }
-  const stmtCache = new Map<string, CachedStatement>();
-
-  function getCached(sql: string) {
-    let entry = stmtCache.get(sql);
-    if (entry) {
-      stmtCache.delete(sql);
-      stmtCache.set(sql, entry);
-    } else {
-      const stmt = db.prepare(sql);
-      if (stmtCache.size >= MAX_STMT_CACHE_SIZE) {
-        const oldestKey = stmtCache.keys().next().value;
-        if (oldestKey !== undefined) {
-          const oldest = stmtCache.get(oldestKey);
-          if (oldest?.stmt && "finalize" in oldest.stmt) {
-            try { (oldest.stmt as any).finalize(); } catch {}
-          }
-          stmtCache.delete(oldestKey);
-        }
-      }
-      entry = { stmt, sql };
-      stmtCache.set(sql, entry);
-    }
-    return entry.stmt;
-  }
-
-  function runSp<T>(fn: (...args: unknown[]) => T, ...args: unknown[]): T {
-    const sp = `sp_${Math.random().toString(36).slice(2)}`;
-    db.exec(`SAVEPOINT "${sp}"`);
-    try {
-      const r = fn(...args);
-      db.exec(`RELEASE "${sp}"`);
-      return r;
-    } catch (e) {
-      try {
-        db.exec(`ROLLBACK TO "${sp}"`);
-        db.exec(`RELEASE "${sp}"`);
-      } catch {}
-      throw e;
-    }
-  }
-
-  return {
-    driver: "node:sqlite",
-    get open() {
-      return _isOpen;
-    },
-    get name() {
-      return filePath;
-    },
-    prepare(sql: string): PreparedStatement {
-      const stmt = getCached(sql);
-      return {
-        run(...params: unknown[]): RunResult {
-          const r = stmt.run(...params);
-          return {
-            changes: Number(r.changes ?? 0),
-            lastInsertRowid: Number(r.lastInsertRowid ?? 0),
-          };
-        },
-        get(...params: unknown[]): unknown {
-          return stmt.get(...params);
-        },
-        all(...params: unknown[]): unknown[] {
-          return stmt.all(...params);
-        },
-      };
-    },
-    exec(sql: string): void {
-      db.exec(sql);
-    },
-    pragma(pragmaStr: string, options?: { simple?: boolean }): unknown {
-      if (options?.simple) {
-        const row = db.prepare(`PRAGMA ${pragmaStr}`).get() as Record<string, unknown> | undefined;
-        if (!row) return null;
-        return Object.values(row)[0] ?? null;
-      }
-      return db.prepare(`PRAGMA ${pragmaStr}`).all();
-    },
-    transaction<T>(fn: (...args: unknown[]) => T): (...args: unknown[]) => T {
-      return (...args: unknown[]) => runSp(fn, ...args);
-    },
-    immediate(fn: () => void): void {
-      runSp(() => fn());
-    },
-    async backup(destination: string): Promise<void> {
-      try {
-        db.exec("PRAGMA wal_checkpoint(TRUNCATE)");
-      } catch {}
-      fs.copyFileSync(filePath, destination);
-    },
-    checkpoint(mode = "TRUNCATE"): void {
-      try {
-        db.exec(`PRAGMA wal_checkpoint(${mode})`);
-      } catch {}
-    },
-    close(): void {
-      try {
-        for (const entry of stmtCache.values()) {
-          if (entry.stmt && "finalize" in entry.stmt) {
-            try { (entry.stmt as any).finalize(); } catch {}
-          }
-        }
-        stmtCache.clear();
-        db.close();
-      } finally {
-        _isOpen = false;
-      }
-    },
-    get raw() {
-      return db;
-    },
-  };
 }
 
 /** Tenta abrir com better-sqlite3 e node:sqlite sincronamente. Retorna null se ambos falharem. */
@@ -173,10 +43,10 @@ export function tryOpenSync(
     if (maj > 22 || (maj === 22 && min >= 5)) {
       try {
         const { DatabaseSync } = _require("node:sqlite") as {
-          DatabaseSync: new (p: string) => Parameters<typeof buildNodeAdapterSync>[0];
+          DatabaseSync: new (p: string) => NodeSqliteDatabaseLike;
         };
         const db = new DatabaseSync(filePath);
-        return buildNodeAdapterSync(db, filePath);
+        return createNodeSqliteAdapterFromDatabase(db, filePath);
       } catch {
         // continua
       }

--- a/src/lib/db/adapters/nodeSqliteAdapter.ts
+++ b/src/lib/db/adapters/nodeSqliteAdapter.ts
@@ -1,6 +1,8 @@
-// src/lib/db/adapters/nodeSqliteAdapter.ts
-import fs from "node:fs";
-import type { SqliteAdapter, PreparedStatement, RunResult } from "./types";
+import type { SqliteAdapter } from "./types";
+import {
+  createNodeSqliteAdapterFromDatabase,
+  type NodeSqliteDatabaseLike,
+} from "./nodeSqliteShared";
 
 const CHECKPOINT_INTERVAL_MS = 60_000;
 
@@ -21,64 +23,10 @@ export async function createNodeSqliteAdapter(filePath: string): Promise<SqliteA
   } as typeof process.emit;
 
   const { DatabaseSync } = (await import("node:sqlite" as never)) as {
-    DatabaseSync: new (path: string) => {
-      prepare(sql: string): {
-        run(...p: unknown[]): { changes: number | bigint; lastInsertRowid: number | bigint };
-        get(...p: unknown[]): unknown;
-        all(...p: unknown[]): unknown[];
-      };
-      exec(sql: string): void;
-      close(): void;
-    };
+    DatabaseSync: new (path: string) => NodeSqliteDatabaseLike;
   };
 
   const db = new DatabaseSync(filePath);
-
-  const MAX_STMT_CACHE_SIZE = 200;
-  interface CachedStatement {
-    stmt: ReturnType<typeof db.prepare>;
-    sql: string;
-  }
-  const stmtCache = new Map<string, CachedStatement>();
-
-  function getCached(sql: string) {
-    let entry = stmtCache.get(sql);
-    if (entry) {
-      stmtCache.delete(sql);
-      stmtCache.set(sql, entry);
-    } else {
-      const stmt = db.prepare(sql);
-      if (stmtCache.size >= MAX_STMT_CACHE_SIZE) {
-        const oldestKey = stmtCache.keys().next().value;
-        if (oldestKey !== undefined) {
-          const oldest = stmtCache.get(oldestKey);
-          if (oldest?.stmt && "finalize" in oldest.stmt) {
-            try { (oldest.stmt as any).finalize(); } catch {}
-          }
-          stmtCache.delete(oldestKey);
-        }
-      }
-      entry = { stmt, sql };
-      stmtCache.set(sql, entry);
-    }
-    return entry.stmt;
-  }
-
-  function runSavepoint<T>(fn: (...args: unknown[]) => T, ...args: unknown[]): T {
-    const sp = `sp_${Math.random().toString(36).slice(2)}`;
-    db.exec(`SAVEPOINT "${sp}"`);
-    try {
-      const result = fn(...args);
-      db.exec(`RELEASE "${sp}"`);
-      return result;
-    } catch (err) {
-      try {
-        db.exec(`ROLLBACK TO "${sp}"`);
-        db.exec(`RELEASE "${sp}"`);
-      } catch {}
-      throw err;
-    }
-  }
 
   const checkpointTimer = setInterval(() => {
     try {
@@ -87,108 +35,26 @@ export async function createNodeSqliteAdapter(filePath: string): Promise<SqliteA
   }, CHECKPOINT_INTERVAL_MS);
   (checkpointTimer as unknown as NodeJS.Timeout).unref?.();
 
-  let _isOpen = true;
-
   function gracefulClose() {
     clearInterval(checkpointTimer as unknown as NodeJS.Timeout);
     try {
       db.exec("PRAGMA wal_checkpoint(TRUNCATE)");
     } catch {}
-    try {
-      for (const entry of stmtCache.values()) {
-        if (entry.stmt && "finalize" in entry.stmt) {
-          try { (entry.stmt as any).finalize(); } catch {}
-        }
-      }
-      stmtCache.clear();
-    } catch {}
-    try {
-      db.close();
-    } catch {}
-    _isOpen = false;
   }
 
-  process.once("beforeExit", gracefulClose);
+  const adapter = createNodeSqliteAdapterFromDatabase(db, filePath, gracefulClose);
+
+  process.once("beforeExit", () => {
+    adapter.close();
+  });
   process.once("SIGINT", () => {
-    gracefulClose();
+    adapter.close();
     process.exit(0);
   });
   process.once("SIGTERM", () => {
-    gracefulClose();
+    adapter.close();
     process.exit(0);
   });
 
-  return {
-    driver: "node:sqlite",
-
-    get open() {
-      return _isOpen;
-    },
-
-    get name() {
-      return filePath;
-    },
-
-    prepare(sql: string): PreparedStatement {
-      const stmt = getCached(sql);
-      return {
-        run(...params: unknown[]): RunResult {
-          const r = stmt.run(...params);
-          return {
-            changes: Number(r.changes ?? 0),
-            lastInsertRowid: Number(r.lastInsertRowid ?? 0),
-          };
-        },
-        get(...params: unknown[]): unknown {
-          return stmt.get(...params);
-        },
-        all(...params: unknown[]): unknown[] {
-          return stmt.all(...params);
-        },
-      };
-    },
-
-    exec(sql: string): void {
-      db.exec(sql);
-    },
-
-    pragma(pragmaStr: string, options?: { simple?: boolean }): unknown {
-      const sql = `PRAGMA ${pragmaStr}`;
-      if (options?.simple) {
-        const row = db.prepare(sql).get() as Record<string, unknown> | undefined;
-        if (!row) return null;
-        return Object.values(row)[0] ?? null;
-      }
-      return db.prepare(sql).all();
-    },
-
-    transaction<T>(fn: (...args: unknown[]) => T): (...args: unknown[]) => T {
-      return (...args: unknown[]) => runSavepoint(fn, ...args);
-    },
-
-    immediate(fn: () => void): void {
-      runSavepoint(() => fn());
-    },
-
-    async backup(destination: string): Promise<void> {
-      try {
-        db.exec("PRAGMA wal_checkpoint(TRUNCATE)");
-      } catch {}
-      fs.copyFileSync(filePath, destination);
-    },
-
-    checkpoint(mode = "TRUNCATE"): void {
-      try {
-        db.exec(`PRAGMA wal_checkpoint(${mode})`);
-      } catch {}
-    },
-
-    close(): void {
-      gracefulClose();
-    },
-
-    get raw() {
-      return db;
-    },
-  };
+  return adapter;
 }

--- a/src/lib/db/adapters/nodeSqliteShared.ts
+++ b/src/lib/db/adapters/nodeSqliteShared.ts
@@ -1,0 +1,148 @@
+import fs from "node:fs";
+import type { PreparedStatement, RunResult, SqliteAdapter } from "./types";
+
+export interface NodeSqliteDatabaseLike {
+  prepare(sql: string): {
+    run(...p: unknown[]): { changes: number | bigint; lastInsertRowid: number | bigint };
+    get(...p: unknown[]): unknown;
+    all(...p: unknown[]): unknown[];
+  };
+  exec(sql: string): void;
+  close(): void;
+}
+
+const MAX_STMT_CACHE_SIZE = 200;
+
+export function createNodeSqliteAdapterFromDatabase(
+  db: NodeSqliteDatabaseLike,
+  filePath: string,
+  onClose?: () => void
+): SqliteAdapter {
+  let _isOpen = true;
+  type NodeSqliteStatement = ReturnType<NodeSqliteDatabaseLike["prepare"]>;
+  interface CachedStatement {
+    stmt: NodeSqliteStatement;
+  }
+  const stmtCache = new Map<string, CachedStatement>();
+
+  function finalizeStatement(stmt: NodeSqliteStatement | undefined) {
+    if (stmt && "finalize" in stmt) {
+      try {
+        (stmt as NodeSqliteStatement & { finalize: () => void }).finalize();
+      } catch {}
+    }
+  }
+
+  function getCached(sql: string) {
+    let entry = stmtCache.get(sql);
+    if (entry) {
+      stmtCache.delete(sql);
+      stmtCache.set(sql, entry);
+    } else {
+      const stmt = db.prepare(sql);
+      if (stmtCache.size >= MAX_STMT_CACHE_SIZE) {
+        const oldestKey = stmtCache.keys().next().value;
+        if (oldestKey !== undefined) {
+          finalizeStatement(stmtCache.get(oldestKey)?.stmt);
+          stmtCache.delete(oldestKey);
+        }
+      }
+      entry = { stmt };
+      stmtCache.set(sql, entry);
+    }
+    return entry.stmt;
+  }
+
+  function runSavepoint<T>(fn: (...args: unknown[]) => T, ...args: unknown[]): T {
+    const sp = `sp_${Math.random().toString(36).slice(2)}`;
+    db.exec(`SAVEPOINT "${sp}"`);
+    try {
+      const result = fn(...args);
+      db.exec(`RELEASE "${sp}"`);
+      return result;
+    } catch (err) {
+      try {
+        db.exec(`ROLLBACK TO "${sp}"`);
+        db.exec(`RELEASE "${sp}"`);
+      } catch {}
+      throw err;
+    }
+  }
+
+  function close() {
+    try {
+      onClose?.();
+    } catch {}
+    try {
+      for (const entry of stmtCache.values()) {
+        finalizeStatement(entry.stmt);
+      }
+      stmtCache.clear();
+    } catch {}
+    try {
+      db.close();
+    } catch {}
+    _isOpen = false;
+  }
+
+  return {
+    driver: "node:sqlite",
+    get open() {
+      return _isOpen;
+    },
+    get name() {
+      return filePath;
+    },
+    prepare(sql: string): PreparedStatement {
+      const stmt = getCached(sql);
+      return {
+        run(...params: unknown[]): RunResult {
+          const r = stmt.run(...params);
+          return {
+            changes: Number(r.changes ?? 0),
+            lastInsertRowid: Number(r.lastInsertRowid ?? 0),
+          };
+        },
+        get(...params: unknown[]): unknown {
+          return stmt.get(...params);
+        },
+        all(...params: unknown[]): unknown[] {
+          return stmt.all(...params);
+        },
+      };
+    },
+    exec(sql: string): void {
+      db.exec(sql);
+    },
+    pragma(pragmaStr: string, options?: { simple?: boolean }): unknown {
+      const sql = `PRAGMA ${pragmaStr}`;
+      if (options?.simple) {
+        const row = db.prepare(sql).get() as Record<string, unknown> | undefined;
+        if (!row) return null;
+        return Object.values(row)[0] ?? null;
+      }
+      return db.prepare(sql).all();
+    },
+    transaction<T>(fn: (...args: unknown[]) => T): (...args: unknown[]) => T {
+      return (...args: unknown[]) => runSavepoint(fn, ...args);
+    },
+    immediate(fn: () => void): void {
+      runSavepoint(() => fn());
+    },
+    async backup(destination: string): Promise<void> {
+      try {
+        db.exec("PRAGMA wal_checkpoint(TRUNCATE)");
+      } catch {}
+      fs.copyFileSync(filePath, destination);
+    },
+    checkpoint(mode = "TRUNCATE"): void {
+      try {
+        db.exec(`PRAGMA wal_checkpoint(${mode})`);
+      } catch {}
+    },
+    close,
+    get raw() {
+      return db;
+    },
+  };
+}

--- a/tests/unit/db-adapters/nodeSqliteShared.test.ts
+++ b/tests/unit/db-adapters/nodeSqliteShared.test.ts
@@ -1,0 +1,100 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { createNodeSqliteAdapterFromDatabase } from "../../../src/lib/db/adapters/nodeSqliteShared.ts";
+
+type Row = Record<string, unknown>;
+
+class FakeStatement {
+  finalized = false;
+
+  constructor(
+    private readonly sql: string,
+    private readonly rows: Row[] = []
+  ) {}
+
+  run(..._params: unknown[]) {
+    return { changes: 1n, lastInsertRowid: 7n };
+  }
+
+  get(..._params: unknown[]) {
+    if (this.sql.startsWith("PRAGMA")) {
+      return { journal_mode: "wal" };
+    }
+    return this.rows[0];
+  }
+
+  all(..._params: unknown[]) {
+    if (this.sql.startsWith("PRAGMA")) {
+      return [{ journal_mode: "wal" }];
+    }
+    return this.rows;
+  }
+
+  finalize() {
+    this.finalized = true;
+  }
+}
+
+class FakeDb {
+  closed = false;
+  execCalls: string[] = [];
+  statements: FakeStatement[] = [];
+
+  prepare(sql: string) {
+    const statement = new FakeStatement(sql, [{ value: "ok" }]);
+    this.statements.push(statement);
+    return statement;
+  }
+
+  exec(sql: string) {
+    this.execCalls.push(sql);
+  }
+
+  close() {
+    this.closed = true;
+  }
+}
+
+test("createNodeSqliteAdapterFromDatabase wraps node:sqlite statements", () => {
+  const db = new FakeDb();
+  const adapter = createNodeSqliteAdapterFromDatabase(db, ":memory:");
+
+  const insert = adapter.prepare("INSERT INTO t VALUES (?)").run("ok");
+  assert.deepEqual(insert, { changes: 1, lastInsertRowid: 7 });
+
+  const row = adapter.prepare("SELECT value FROM t").get() as Row;
+  assert.equal(row.value, "ok");
+
+  assert.equal(adapter.pragma("journal_mode", { simple: true }), "wal");
+  assert.deepEqual(adapter.pragma("journal_mode"), [{ journal_mode: "wal" }]);
+});
+
+test("createNodeSqliteAdapterFromDatabase uses savepoints for transactions", () => {
+  const db = new FakeDb();
+  const adapter = createNodeSqliteAdapterFromDatabase(db, ":memory:");
+
+  const run = adapter.transaction((value: string) => value.toUpperCase());
+  assert.equal(run("ok"), "OK");
+  assert.equal(db.execCalls[0].startsWith("SAVEPOINT "), true);
+  assert.equal(db.execCalls[1].startsWith("RELEASE "), true);
+});
+
+test("createNodeSqliteAdapterFromDatabase finalizes cached statements on close", () => {
+  const db = new FakeDb();
+  let closedHookCalls = 0;
+  const adapter = createNodeSqliteAdapterFromDatabase(db, ":memory:", () => {
+    closedHookCalls++;
+  });
+
+  adapter.prepare("SELECT 1").get();
+  adapter.close();
+
+  assert.equal(closedHookCalls, 1);
+  assert.equal(db.closed, true);
+  assert.equal(adapter.open, false);
+  assert.equal(
+    db.statements.every((statement) => statement.finalized),
+    true
+  );
+});


### PR DESCRIPTION
## Summary
- Extract the duplicated node:sqlite adapter wrapper into `src/lib/db/adapters/nodeSqliteShared.ts`.
- Reuse it from both the resilient sync driver factory and the async node:sqlite adapter.
- Keep async node:sqlite import, checkpoint timer, and process signal cleanup in `nodeSqliteAdapter.ts`; the shared builder only owns adapter mechanics.

## Duplication impact
- `npm run check:duplication` passes at 5% duplicated code against the 5.72% baseline.
- No metrics or duplication baseline files changed.

## Tests
- `node --import tsx/esm --test tests/unit/db-adapters/nodeSqliteShared.test.ts`
- `node --import tsx/esm --test tests/unit/db-adapters/driverFactory.test.ts tests/unit/db-import-resilient-driver-3025.test.ts`
- `npx eslint src/lib/db/adapters/nodeSqliteShared.ts src/lib/db/adapters/driverFactory.ts src/lib/db/adapters/nodeSqliteAdapter.ts tests/unit/db-adapters/nodeSqliteShared.test.ts`
- `npm run check:duplication`
- `npm run check:pr-test-policy` (skips locally because it is not running in a pull request context)
- `npm run typecheck:core` (fails on the release branch because `safe-regex` and `@toon-format/toon` modules are not installed/resolvable)
