### PR TITLE
fix(providers): correct LongCat free tier — GA LongCat-2.0, one-time 10M (KYC)

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ Result: 4 layers of fallback = zero downtime
     <td align="center" width="150"><img src="https://img.shields.io/badge/AgentRouter-FF6600?style=flat-square" alt="AgentRouter"/><br/><sub>GPT-5, Claude, Gemini<br/>$100 free credits</sub></td>
     <td align="center" width="150"><img src="https://img.shields.io/badge/Qoder_AI-6366F1?style=flat-square" alt="Qoder AI"/><br/><sub>Kimi-K2, DeepSeek-R1<br/>Unlimited FREE</sub></td>
     <td align="center" width="150"><img src="https://img.shields.io/badge/Pollinations-10B981?style=flat-square" alt="Pollinations"/><br/><sub>GPT-5, Claude, Llama 4<br/>No key needed</sub></td>
-    <td align="center" width="150"><img src="https://img.shields.io/badge/LongCat-FF7A00?style=flat-square" alt="LongCat"/><br/><sub>Flash-Lite<br/>50M tokens/day 🔥</sub></td>
+    <td align="center" width="150"><img src="https://img.shields.io/badge/LongCat-FF7A00?style=flat-square" alt="LongCat"/><br/><sub>LongCat-2.0<br/>10M tokens one-time (KYC) 🔑</sub></td>
   </tr>
   <tr>
     <td align="center" width="150"><img src="https://img.shields.io/badge/Cloudflare_AI-F38020?style=flat-square&logo=cloudflare&logoColor=white" alt="Cloudflare AI"/><br/><sub>50+ models<br/>10K neurons/day</sub></td>
@@ -726,7 +726,7 @@ podman compose --profile base up -d
 | **Qoder**         | `if/`       | kimi-k2-thinking, qwen3-coder-plus, deepseek-r1 | ♾️ Unlimited      |
 | **Qwen**          | `qw/`       | qwen3-coder-plus/flash/next                     | ♾️ Unlimited      |
 | **Pollinations**  | `pol/`      | GPT-5, Claude, Gemini, DeepSeek, Llama 4        | No key needed     |
-| **LongCat**       | `lc/`       | LongCat-Flash-Lite                              | 50M tokens/day 🔥 |
+| **LongCat**       | `lc/`       | LongCat-2.0                                     | 10M one-time (KYC) |
 | **Cloudflare AI** | `cf/`       | 50+ models                                      | 10K neurons/day   |
 | **NVIDIA NIM**    | `nvidia/`   | 129 models                                      | ~40 RPM           |
 | **Cerebras**      | `cerebras/` | Qwen3 235B, GPT-OSS 120B                        | 1M tok/day        |
@@ -748,7 +748,7 @@ podman compose --profile base up -d
 1. kr/claude-sonnet-4.5   (Kiro — ~50 credits/mo per acct)
 2. if/kimi-k2-thinking    (Qoder — unlimited)
 3. pol/gpt-5              (Pollinations — no key)
-4. lc/longcat-flash-lite  (50M tok/day backup)
+4. lc/LongCat-2.0         (10M one-time backup, KYC)
 Compression: aggressive (~50%) → double your free quota · Cost: $0/mo
 ```
 

--- a/docs/getting-started/FREE-TIERS-GUIDE.md
+++ b/docs/getting-started/FREE-TIERS-GUIDE.md
@@ -23,7 +23,7 @@ These providers are **always free** with no limits:
 | **Kiro AI** | Claude Sonnet 4.5, Haiku 4.5, Opus 4.6 | 50 credits/month | No auth needed |
 | **OpenCode Free** | GPT-4o, Claude, Gemini | Unlimited | No auth needed |
 | **Pollinations** | GPT-5, Claude, Gemini, DeepSeek, Llama 4 | No key needed | No auth needed |
-| **LongCat** | LongCat-Flash-Lite | 50M tokens/day | No auth needed |
+| **LongCat** | LongCat-2.0 | 10M tokens (one-time) | API key + KYC |
 | **Cloudflare AI** | 50+ models | 10K neurons/day | No auth needed |
 | **Qwen** | Qwen3-coder-plus/flash/next | Unlimited | No auth needed |
 | **Qoder** | Kimi-K2, DeepSeek-R1, Qwen3-coder | Unlimited | No auth needed |
@@ -66,7 +66,7 @@ Connect these 4 providers for **unlimited free AI**:
 1. **Kiro AI** — 50 credits/month (Claude models)
 2. **OpenCode Free** — Unlimited (GPT models)
 3. **Pollinations** — No key needed (multiple models)
-4. **LongCat** — 50M tokens/day (backup)
+4. **LongCat** — 10M tokens one-time (backup, requires KYC)
 
 Then use `model: "auto"` and OmniRoute will:
 - Try Kiro first (best quality)
@@ -98,7 +98,7 @@ Browse the list and select one of these free providers:
 - **Kiro AI** — Free Claude models
 - **OpenCode Free** — Free GPT models
 - **Pollinations** — Free GPT-5, Claude, Gemini
-- **LongCat** — 50M tokens/day free
+- **LongCat** — 10M tokens free (one-time, requires KYC)
 - **Cloudflare AI** — 50+ models, 10K neurons/day
 
 ### Step 5: Click Connect
@@ -136,10 +136,10 @@ Connect 3-4 free providers for the best experience.
 
 ### LongCat
 
-- **Models**: LongCat-Flash-Lite
-- **Quota**: 50M tokens/day
-- **Auth**: No auth needed
-- **Best for**: High-volume usage
+- **Models**: LongCat-2.0
+- **Quota**: 10M tokens, one-time grant on signup (not recurring daily/monthly)
+- **Auth**: API key + KYC verification required to unlock the free grant
+- **Best for**: A one-off free allowance; pay-as-you-go beyond it
 
 ### Cloudflare AI
 
@@ -222,7 +222,7 @@ Let's calculate how much free AI you can get:
 | Kiro AI | ~1.7 credits | 50 credits |
 | OpenCode Free | Unlimited | Unlimited |
 | Pollinations | Unlimited | Unlimited |
-| LongCat | 50M tokens | 1.5B tokens |
+| LongCat | — (one-time) | 10M tokens (one-time, KYC) |
 | Cloudflare AI | 10K neurons | 300K neurons |
 | NVIDIA NIM | ~40 RPM | ~1.7M requests |
 | Cerebras | 1M tokens | 30M tokens |

--- a/docs/getting-started/PROVIDERS-GUIDE.md
+++ b/docs/getting-started/PROVIDERS-GUIDE.md
@@ -29,7 +29,7 @@ Think of a provider like a **phone carrier**. Just as you need a phone carrier t
    - **Kiro AI** — Free Claude models (no auth needed)
    - **OpenCode Free** — Free GPT models (no auth needed)
    - **Pollinations** — Free GPT-5, Claude, Gemini (no key needed)
-   - **LongCat** — 50M tokens/day free
+   - **LongCat** — 10M tokens free (one-time grant, requires account + KYC)
    - **Cloudflare AI** — 50+ models, 10K neurons/day
 4. Click **Connect**
 5. Done! You now have free AI access.
@@ -69,7 +69,7 @@ These providers offer **free access** with no credit card:
 | **Kiro AI**       | 50 credits/month | Claude Sonnet 4.5, Haiku 4.5, Opus 4.6   | No auth needed |
 | **OpenCode Free** | Unlimited        | GPT-4o, Claude, Gemini                   | No auth needed |
 | **Pollinations**  | No key needed    | GPT-5, Claude, Gemini, DeepSeek, Llama 4 | No auth needed |
-| **LongCat**       | 50M tokens/day   | LongCat-Flash-Lite                       | No auth needed |
+| **LongCat**       | 10M one-time     | LongCat-2.0                              | API key + KYC  |
 | **Cloudflare AI** | 10K neurons/day  | 50+ models                               | No auth needed |
 | **NVIDIA NIM**    | ~40 RPM          | 129 models                               | API key needed |
 | **Cerebras**      | 1M tokens/day    | Qwen3 235B, GPT-OSS 120B                 | API key needed |

--- a/docs/reference/FREE_TIERS.md
+++ b/docs/reference/FREE_TIERS.md
@@ -25,7 +25,7 @@ lastUpdated: 2026-06-28
 
 > **Why this dropped from the previous ~1.94B.** The 2026-06-17 refresh is an honesty correction, not a loss: `gemini` is now pool-deduped (was inflated by counting each Flash variant separately, 462M → 60M), `cloudflare-ai` corrected to its real 10k-Neurons/day (122M → 30M), `doubao` reclassified as a one-time signup credit (not recurring), and shut-down tiers removed (`github-models` closed to new signups, `chutes`/`phind`/`kluster`/`glhf` discontinued). Partly offset by `llm7` (correct 5M/day → 150M) and new free providers (Kilo, OpenCode Zen, Z.AI GLM-Flash).
 
-Biggest **documented** contributors: `mistral` 1.00B, `llm7` 150M, `longcat` 150M (LongCat-2.0), `groq` 117M, `gemini` 60M, `cerebras` 30M, `cloudflare-ai` 30M, `sambanova` 30M.
+Biggest **documented** contributors: `mistral` 1.00B, `llm7` 150M, `groq` 117M, `gemini` 60M, `cerebras` 30M, `cloudflare-ai` 30M, `sambanova` 30M. (`longcat` is excluded — its 10M LongCat-2.0 grant is a one-time, KYC-gated signup credit, not a recurring monthly budget.)
 
 > ⚠️ The theoretical ceiling (~10B) is inflated by rate-limit-only providers with **no published token cap** (`tencent`, `siliconflow`, `nvidia`, `baidu`, `glm-cn`, `sparkdesk`) whose figures would be `RPM/TPM × 24/7 × 30d` — a theoretical maximum no single account will sustain. They are **excluded** from the defensible number (shown in the "permanently free, no cap" row instead). This is the same inflation that makes competitors' multi-billion claims unreliable.
 
@@ -38,7 +38,7 @@ A 50-agent web-research pass (official docs + last-7-days news, adversarially ve
 - **Removed / no free tier (2026):** `chutes` (free tier ended 2026-03), `phind` (company shut down 2026-01), `kluster` (sunset 2026-06-09 → MITO), `glhf` (beta ended), `gitlawb` + `gitlawb-gmi` (MiMo free revoked 2026-05-24, Nemotron promo ended 2026-06 — re-verified 2026-06-18), `aimlapi` (free tier paused — re-verified 2026-06-18), `yi` (Yi-Light retired, pay-as-you-go — re-verified 2026-06-18), `theoldllm` / `featherless-ai` (no current free tier). `iflytek` / `sparkdesk` stay listed but carry a ToS-caution note (Spark Lite is free; the ToS restricts proxy/relay use).
 - **GitHub Models** — closed to **new** customers on 2026-06-16; existing accounts keep API/playground access, so it stays in the catalog with a note (not removed).
 - **Gemini** — `2.0 Flash` / `2.0 Flash-Lite` shut down 2026-06-01 and `2.5 Pro` left the free tier (2026-04); free tier is now **Flash-family only** (2.5/3/3.1/3.5 Flash + Gemma). The catalog now **pools** the Flash family (was inflated by counting each variant separately: 462M → 60M).
-- **Corrected numbers:** `cloudflare-ai` 122M → **30M** (real 10k-Neurons/day), `doubao` reclassified as a one-time signup credit (not recurring), `llm7` 4M → **150M** (documented 5M tokens/day), `together` "-Free" endpoints discontinued → only the **$25** signup credit remains, `longcat` retired 6 legacy models → **LongCat-2.0-Preview** only.
+- **Corrected numbers:** `cloudflare-ai` 122M → **30M** (real 10k-Neurons/day), `doubao` reclassified as a one-time signup credit (not recurring), `llm7` 4M → **150M** (documented 5M tokens/day), `together` "-Free" endpoints discontinued → only the **$25** signup credit remains, `longcat` Preview ended + Flash models retired → **LongCat-2.0** only, reclassified as a one-time **10M**-token signup credit (KYC-gated, not recurring).
 - **New free providers discovered:** ⭐ **Kilo Code** (`kilo-gateway` — rotating "Auto Free" set: NVIDIA Nemotron 3 family, StepFun, Poolside, Nex-N2-Pro), ⭐ **OpenCode Zen** (`opencode-zen` — 6 rotating free coding models), ⭐ **Z.AI / Zhipu** (`glm-cn` — GLM-4-Flash / 4.5-Flash / 4.7-Flash permanently free + 20M signup bonus), and `arcee-ai` Trinity Large Preview.
 - **New honest tiers** (see Methodology): a _permanently-free-but-uncapped_ category (real recurring access, no token cap to count) and a _deposit-unlock boost_ (OpenRouter $10 → +24M/mo), both surfaced **separately** so they never inflate the headline.
 
@@ -177,7 +177,7 @@ A 50-agent web-research pass (official docs + last-7-days news, adversarially ve
 |---|---|---|---|---|---|
 | `mistral` | recurring | ~1.00B | — | caution | 5 |
 | `llm7` | recurring | ~150M | — | caution | 4 |
-| `longcat` | recurring | ~150M | — | caution | 1 |
+| `longcat` | one-time | — | 10M | caution | 1 |
 | `gemini` | recurring | ~60M | — | caution | 6 |
 | `cerebras` | recurring | ~30M | — | caution | 2 |
 | `cloudflare-ai` | recurring | ~30M | — | caution | 6 |
@@ -297,7 +297,7 @@ A 50-agent web-research pass (official docs + last-7-days news, adversarially ve
 - **`kiro`** — Catalog shipped freeNote "(none)" — but Kiro has a documented, perpetual free tier of 50 credits/month. The free tier existed since Kiro's public launch (pricing formalized ~October 2025). This is a …
 - **`kluster`** — The $5 free credits on signup appears to still match. However, there is evidence of an additional permanent free tier (post-credit) with undocumented limits, which may represent an improvement over t…
 - **`llm7`** — Rate limits have increased from the shipped freeNote (20 RPM / 100 req/hr → 40 RPM / 200 req/hr). The "no signup required" claim is now outdated — a free token from token.llm7.io is now required (tho…
-- **`longcat`** — Significant change from shipped freeNote of "(none)": the platform actively provides 5M free tokens/day on a recurring daily basis to all API users during the public beta.
+- **`longcat`** — The public preview/beta ended and the Flash models were retired; only the GA `LongCat-2.0` remains. The free tier is a **one-time 10M-token grant** unlocked after account signup + **KYC verification** — it does **not** reset daily or monthly. Beyond the grant it is pay-as-you-go.
 - **`mistral`** — The shipped freeNote ("Free Experiment tier: rate-limited access to all models") is directionally correct but understated. Current reality adds specific documented limits: 2 RPM, 500K TPM, 1B tokens/…
 - **`monsterapi`** — The shipped freeNote says "Free credits for decentralized GPU inference" which is partially accurate — there are one-time trial credits on signup. However, the recurring free tier has 0 credits/month…
 - **`morph`** — The shipped freeNote mentions "250K credits/month" which matches the current credit allocation; however, the more significant constraint is 200 requests/month which was not captured in the original c…

--- a/docs/reference/PROVIDER_REFERENCE.md
+++ b/docs/reference/PROVIDER_REFERENCE.md
@@ -1,14 +1,14 @@
 ---
 title: "Provider Reference"
-version: 3.8.40
-lastUpdated: 2026-06-29
+version: 3.8.42
+lastUpdated: 2026-06-30
 ---
 
 # Provider Reference
 
 > **Auto-generated** from `src/shared/constants/providers.ts` — do not edit by hand.
 > Regenerate with: `npm run gen:provider-reference`
-> **Last generated:** 2026-06-29
+> **Last generated:** 2026-06-30
 
 Total providers: **237**. See category breakdown below.
 
@@ -175,7 +175,7 @@ Use the dashboard at `/dashboard/providers` to enable, configure, and test each 
 | `liquid` | `liquid` | Liquid AI | API key | [link](https://liquid.ai) | Get API key at liquid.ai |
 | `llamagate` | `llamagate` | LlamaGate | API key | [link](https://llamagate.ai) | — |
 | `llm7` | `llm7` | LLM7.io | API key | [link](https://llm7.io) | No signup required - 2 req/s, 20 RPM, 100 req/hr free tier |
-| `longcat` | `lc` | LongCat AI | API key | [link](https://longcat.chat/platform/docs) | Free: 5M tokens/day on LongCat-2.0-Preview (Flash models retired 2026-05-29); up to 120M/day via feedback. |
+| `longcat` | `lc` | LongCat AI | API key | [link](https://longcat.chat/platform/docs) | Free: one-time 10M-token grant after account signup + KYC verification (LongCat-2.0). One-time only — not a recurring daily/monthly allowance. |
 | `maritalk` | `maritalk` | Maritalk | API key | [link](https://www.maritaca.ai) | — |
 | `meta-llama` | `meta` | Meta Llama API | API key | [link](https://llama.developer.meta.com) | — |
 | `minimax` | `minimax` | Minimax Coding | API key, video | [link](https://www.minimax.io) | — |

--- a/open-sse/config/freeModelCatalog.data.ts
+++ b/open-sse/config/freeModelCatalog.data.ts
@@ -241,7 +241,7 @@ export const FREE_MODEL_BUDGETS: FreeModelBudget[] = [
   { provider: "llm7", modelId: "gpt-4.1-nano-2025-04-14", displayName: "GPT-4.1 nano (LLM7)", monthlyTokens: 0, creditTokens: 0, freeType: "recurring-daily", poolKey: "llm7-free", tos: "caution" },
   { provider: "llm7", modelId: "deepseek-r1-0528", displayName: "DeepSeek R1 (LLM7)", monthlyTokens: 0, creditTokens: 0, freeType: "recurring-daily", poolKey: "llm7-free", tos: "caution" },
   { provider: "llm7", modelId: "qwen2.5-coder-32b-instruct", displayName: "Qwen2.5 Coder 32B (LLM7)", monthlyTokens: 0, creditTokens: 0, freeType: "recurring-daily", poolKey: "llm7-free", tos: "caution" },
-  { provider: "longcat", modelId: "longcat-2.0-preview", displayName: "LongCat-2.0-Preview", monthlyTokens: 150000000, creditTokens: 0, freeType: "recurring-daily", poolKey: "longcat-free", tos: "caution" },
+  { provider: "longcat", modelId: "LongCat-2.0", displayName: "LongCat-2.0", monthlyTokens: 0, creditTokens: 10000000, freeType: "one-time-initial", poolKey: "longcat-free", tos: "caution" },
   { provider: "mistral", modelId: "mistral-large-latest", displayName: "Mistral Large 3", monthlyTokens: 1000000000, creditTokens: 0, freeType: "recurring-monthly", poolKey: "mistral", tos: "caution" },
   { provider: "mistral", modelId: "mistral-medium-3-5", displayName: "Mistral Medium 3.5", monthlyTokens: 1000000000, creditTokens: 0, freeType: "recurring-monthly", poolKey: "mistral", tos: "caution" },
   { provider: "mistral", modelId: "mistral-small-latest", displayName: "Mistral Small 4", monthlyTokens: 1000000000, creditTokens: 0, freeType: "recurring-monthly", poolKey: "mistral", tos: "caution" },

--- a/open-sse/config/freeTierCatalog.ts
+++ b/open-sse/config/freeTierCatalog.ts
@@ -13,7 +13,6 @@ export type TosVerdict = "ok" | "caution" | "ambiguous" | "avoid" | "unknown";
 
 export const FREE_TIER_BUDGETS: Record<string, number> = {
   mistral: 1_000_000_000,
-  longcat: 150_000_000,
   "cloudflare-ai": 122_000_000,
   gemini: 60_000_000,
   doubao: 60_000_000,

--- a/open-sse/config/providers/registry/longcat/index.ts
+++ b/open-sse/config/providers/registry/longcat/index.ts
@@ -9,12 +9,15 @@ export const longcatProvider: RegistryEntry = {
   authType: "apikey",
   authHeader: "Authorization",
   authPrefix: "Bearer",
-  // Sweep 2026-06-19: the LongCat-Flash-* line was officially retired 2026-05-29; the
-  // current docs (longcat.chat/platform/docs) expose only LongCat-2.0-Preview.
+  // Sweep 2026-06-30: the LongCat-Flash-* line was retired 2026-05-29 and the Preview
+  // ended; current docs (longcat.chat/platform/docs) expose only the GA LongCat-2.0
+  // (1M context, 128K max output). Free tier is a ONE-TIME 10M-token grant unlocked
+  // after account signup + KYC verification — NOT a recurring daily/monthly allowance.
+  // Beyond the free quota it is pay-as-you-go (see providerCostData).
   models: [
     {
-      id: "LongCat-2.0-Preview",
-      name: "LongCat 2.0 Preview (10M tok/day 🆓)",
+      id: "LongCat-2.0",
+      name: "LongCat 2.0 (10M tok free 🆓)",
       contextLength: 1048576,
     },
   ],

--- a/open-sse/services/__tests__/tierResolver.test.ts
+++ b/open-sse/services/__tests__/tierResolver.test.ts
@@ -44,7 +44,7 @@ describe("TierResolver", () => {
     });
 
     it("classifies LongCat as free", () => {
-      const result = classifyTier("longcat", "flash-lite");
+      const result = classifyTier("longcat", "LongCat-2.0");
       assert.equal(result.tier, PROVIDER_TIER.FREE);
       assert.equal(result.hasFreeTier, true);
     });

--- a/open-sse/services/providerCostData.ts
+++ b/open-sse/services/providerCostData.ts
@@ -26,11 +26,11 @@ export const KNOWN_MODEL_PRICING: Record<string, ModelPricing> = {
   "grok-4-fast": { inputCostPer1M: 0.2, outputCostPer1M: 0.5, isFree: false },
   "kimi-k2-thinking": { inputCostPer1M: 0, outputCostPer1M: 0, isFree: true },
   "qwen3-coder-plus": { inputCostPer1M: 0, outputCostPer1M: 0, isFree: true },
-  "longcat-flash-lite": {
-    inputCostPer1M: 0,
-    outputCostPer1M: 0,
+  "longcat-2.0": {
+    inputCostPer1M: 0.75,
+    outputCostPer1M: 2.95,
     isFree: true,
-    freeQuotaLimit: 50000000,
+    freeQuotaLimit: 10000000,
   },
 };
 

--- a/src/lib/providers/validation.ts
+++ b/src/lib/providers/validation.ts
@@ -421,7 +421,7 @@ export async function validateProviderApiKey({ provider, apiKey, providerSpecifi
             method: "POST",
             headers: buildBearerHeaders(apiKey, providerSpecificData),
             body: JSON.stringify({
-              model: "longcat",
+              model: "LongCat-2.0",
               messages: [{ role: "user", content: "test" }],
               max_tokens: 1,
             }),

--- a/src/shared/constants/providers/apikey/regional.ts
+++ b/src/shared/constants/providers/apikey/regional.ts
@@ -138,7 +138,7 @@ export const APIKEY_PROVIDERS_REGIONAL = {
     website: "https://longcat.chat/platform/docs",
     hasFree: true,
     freeNote:
-      "Free: 5M tokens/day on LongCat-2.0-Preview (Flash models retired 2026-05-29); up to 120M/day via feedback.",
+      "Free: one-time 10M-token grant after account signup + KYC verification (LongCat-2.0). One-time only — not a recurring daily/monthly allowance.",
   },
   moonshot: {
     id: "moonshot",

--- a/tests/unit/free-tier-catalog.test.ts
+++ b/tests/unit/free-tier-catalog.test.ts
@@ -12,9 +12,11 @@ test("FREE_TIER_BUDGETS holds positive integer monthly-token budgets", () => {
     assert.ok(Number.isInteger(tokens) && tokens > 0, `${id} must be a positive integer`);
   }
   assert.equal(FREE_TIER_BUDGETS.mistral, 1_000_000_000);
-  assert.equal(FREE_TIER_BUDGETS.longcat, 150_000_000);
   assert.equal(FREE_TIER_BUDGETS["cloudflare-ai"], 122_000_000);
   assert.equal(FREE_TIER_BUDGETS.cerebras, 30_000_000);
+  // LongCat is excluded from this recurring-monthly catalog: its free tier is a
+  // one-time 10M-token signup grant (not recurring), so it must not appear here.
+  assert.equal(FREE_TIER_BUDGETS.longcat, undefined);
 });
 
 test("FREE_TIER_TOS marks proxy-prohibited providers as avoid", () => {
@@ -25,16 +27,16 @@ test("FREE_TIER_TOS marks proxy-prohibited providers as avoid", () => {
 
 test("computeFreeTierTotals sums the documented budgets", () => {
   const t = computeFreeTierTotals();
-  assert.equal(t.providerCount, 22);
-  assert.ok(t.documentedMonthlyTokens >= 1_500_000_000);
-  assert.ok(t.documentedMonthlyTokens <= 1_600_000_000);
+  assert.equal(t.providerCount, 21);
+  assert.ok(t.documentedMonthlyTokens >= 1_350_000_000);
+  assert.ok(t.documentedMonthlyTokens <= 1_450_000_000);
   assert.equal(typeof t.headline, "string");
-  assert.match(t.headline, /1\.5/);
+  assert.match(t.headline, /1\.3/);
 });
 
 test("computeFreeTierTotals can exclude ToS-avoid providers", () => {
   const all = computeFreeTierTotals();
   const clean = computeFreeTierTotals({ excludeTosAvoid: true });
   assert.equal(all.documentedMonthlyTokens - clean.documentedMonthlyTokens, 25_000);
-  assert.equal(clean.providerCount, 21);
+  assert.equal(clean.providerCount, 20);
 });


### PR DESCRIPTION
## Summary

LongCat's public preview ended and the `LongCat-Flash-*` line was retired (2026-05-29). The API now exposes only the GA **`LongCat-2.0`** (1M context, 128K max output), and the free tier is a **one-time 10M-token grant** unlocked after **account signup + KYC verification** — it does **not** reset daily or monthly. The catalog still advertised the retired preview/Flash models and a recurring "150M / 5M-per-day" budget, so this corrects every reference and aligns cost/free-tier accounting to reality.

Verified against the live docs (longcat.chat/platform/docs → only `LongCat-2.0`) and the operator's account (10M one-time, KYC-gated).

## Config / code

- **registry/longcat**: model `LongCat-2.0-Preview` → `LongCat-2.0`; name + comment now state the one-time 10M (KYC) grant and pay-as-you-go beyond it.
- **freeModelCatalog**: `longcat-2.0-preview` (150M, `recurring-daily`) → `LongCat-2.0` (10M via `creditTokens`, `freeType: one-time-initial`).
- **freeTierCatalog**: dropped `longcat` from the recurring-monthly budget map — one-time signup credits are excluded by that catalog's own rule.
- **regional.ts** `freeNote`: one-time 10M after signup + KYC, not a recurring allowance.
- **providerCostData**: `longcat-flash-lite` → `longcat-2.0` (pay-as-you-go 0.75 / 2.95 per 1M, 10M free quota).
- **validation** probe model `longcat` → `LongCat-2.0`.

## Tests

- **free-tier-catalog**: `longcat` now absent from `FREE_TIER_BUDGETS`; `providerCount` 22→21 (clean 21→20); documented total recomputed (~1.39B).
- **tierResolver**: sample model `flash-lite` → `LongCat-2.0`.

## Docs

- `README`, `PROVIDERS-GUIDE`, `FREE-TIERS-GUIDE`, `FREE_TIERS`: "50M/day Flash-Lite" → "one-time 10M LongCat-2.0 (KYC)"; "No auth needed" → "API key + KYC".
- Regenerated `PROVIDER_REFERENCE.md` (picks up the new freeNote).
- i18n mirrors will be regenerated by the translation pipeline; the budget-card SVG is a follow-up.

## Validation

- `npm run typecheck:core` — clean
- changed-file lint — 0 errors
- `npm run check:docs-sync` — PASS
- Unit: `free-tier-catalog`, `free-model-catalog`, `tierResolver` green
