### PR TITLE
test(quota): guard Claude-Code identity version lockstep (Phase 2)

### DIFF
--- a/tests/unit/claude-identity-version-sync.test.ts
+++ b/tests/unit/claude-identity-version-sync.test.ts
@@ -1,0 +1,56 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// Claude-Code identity version is hand-bumped in lockstep across several modules
+// (2.1.158 → .187 → .195 …). A silent partial bump makes one surface advertise a stale
+// `claude-cli/<version>` and can break Anthropic identity gating. This guard fails on drift.
+// (quota-share-hardening Phase 2 — gaps v3.8.42.)
+const claudeIdentity = await import("../../open-sse/executors/claudeIdentity.ts");
+const ccBridge = await import("../../open-sse/services/ccBridgeTransforms.ts");
+const claudeCompat = await import("../../open-sse/services/claudeCodeCompatible.ts");
+const anthropicHeaders = await import("../../open-sse/config/anthropicHeaders.ts");
+const glmProvider = await import("../../open-sse/config/glmProvider.ts");
+
+const CANONICAL = claudeIdentity.CLAUDE_CODE_VERSION;
+
+// "claude-cli/2.1.195 (external, sdk-cli)" → "2.1.195". String ops only — never a RegExp over
+// the value, per the project's anti-ReDoS contract.
+function versionFromUserAgent(userAgent: string): string {
+  const afterSlash = userAgent.split("claude-cli/")[1] ?? "";
+  return afterSlash.split(" ")[0];
+}
+
+test("canonical claude-cli version constant is a sane semver value", () => {
+  assert.match(CANONICAL, /^\d+\.\d+\.\d+$/);
+});
+
+test("all Claude-Code identity version constants are in lockstep", () => {
+  assert.equal(
+    ccBridge.DEFAULT_CLAUDE_CODE_VERSION,
+    CANONICAL,
+    "ccBridgeTransforms.DEFAULT_CLAUDE_CODE_VERSION drifted from claudeIdentity.CLAUDE_CODE_VERSION"
+  );
+  assert.equal(
+    claudeCompat.CLAUDE_CODE_COMPATIBLE_VERSION,
+    CANONICAL,
+    "claudeCodeCompatible.CLAUDE_CODE_COMPATIBLE_VERSION drifted from the canonical version"
+  );
+  assert.equal(
+    anthropicHeaders.CLAUDE_CLI_VERSION,
+    CANONICAL,
+    "anthropicHeaders.CLAUDE_CLI_VERSION drifted from the canonical version"
+  );
+});
+
+test("all claude-cli User-Agent strings embed the canonical version", () => {
+  assert.equal(
+    versionFromUserAgent(claudeCompat.CLAUDE_CODE_COMPATIBLE_USER_AGENT),
+    CANONICAL,
+    "claudeCodeCompatible.CLAUDE_CODE_COMPATIBLE_USER_AGENT embeds a stale version"
+  );
+  assert.equal(
+    versionFromUserAgent(glmProvider.GLM_CLAUDE_CODE_USER_AGENT),
+    CANONICAL,
+    "glmProvider.GLM_CLAUDE_CODE_USER_AGENT embeds a stale version"
+  );
+});


### PR DESCRIPTION
## Onda 0 — gaps v3.8.42 (quota-share Phase 2)

Fecha o **Phase 2** do `gaps/quota/quota-share-hardening-followups.md`: um guard test de regressão para o drift silencioso da versão `claude-cli`.

### Contexto

A versão de identidade do Claude-Code é bumpada **manualmente em lockstep** (`2.1.158 → .187 → .195`) em 5 arquivos / 6 constantes:

- `open-sse/executors/claudeIdentity.ts` (`CLAUDE_CODE_VERSION`) — canônica
- `open-sse/services/ccBridgeTransforms.ts` (`DEFAULT_CLAUDE_CODE_VERSION`)
- `open-sse/services/claudeCodeCompatible.ts` (`CLAUDE_CODE_COMPATIBLE_VERSION` + UA)
- `open-sse/config/anthropicHeaders.ts` (`CLAUDE_CLI_VERSION`)
- `open-sse/config/glmProvider.ts` (`GLM_CLAUDE_CODE_USER_AGENT`)

Sem guard, um bump parcial deixa um provider anunciando `claude-cli/<versão-stale>`, podendo quebrar o gating de identidade da Anthropic.

### O teste

`tests/unit/claude-identity-version-sync.test.ts` importa cada módulo e asserta que **todos** batem com a versão canônica (constantes + as duas strings de User-Agent, parseadas por string-ops — anti-ReDoS). Qualquer drift futuro falha a suíte.

### Validação

- `node --import tsx/esm --test`: **3 testes, 0 falha**.
- `npx eslint`: **0 erros**.
- Test-only: sem mudança de código de produção (pr-test-policy satisfeito).