### PR TITLE
fix(mimocode): route per-account traffic through SOCKS5 proxy dispatchers

### DIFF
--- a/open-sse/executors/mimocode.ts
+++ b/open-sse/executors/mimocode.ts
@@ -18,7 +18,8 @@
 import * as crypto from "node:crypto";
 import * as os from "node:os";
 import { BaseExecutor, type ExecuteInput, type ProviderCredentials } from "./base.ts";
-import { runWithProxyContext } from "../utils/proxyFetch.ts";
+import { createProxyDispatcher } from "../utils/proxyDispatcher.ts";
+import { fetch as undiciFetch, type Dispatcher } from "undici";
 
 const BOOTSTRAP_PATH = "/api/free-ai/bootstrap";
 const CHAT_PATH = "/api/free-ai/openai/chat";
@@ -91,8 +92,6 @@ interface AccountState {
   expiresAt: number;
   cooldownUntil: number;
   consecutiveFails: number;
-  /** Resolved proxy config for this account (null = direct). */
-  proxy: AccountProxyConfig["proxy"];
 }
 
 function parseJwtExp(jwt: string): number {
@@ -149,7 +148,8 @@ const bootstrapInflight = new Map<string, Promise<{ jwt: string; expiresAt: numb
 async function bootstrapJwt(
   baseUrl: string,
   fingerprint: string,
-  signal?: AbortSignal | null
+  signal?: AbortSignal | null,
+  dispatcher?: Dispatcher
 ): Promise<{ jwt: string; expiresAt: number }> {
   const existing = bootstrapInflight.get(fingerprint);
   if (existing) return existing;
@@ -162,12 +162,20 @@ async function bootstrapJwt(
 
   const promise = (async () => {
     try {
-      const resp = await fetch(url, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ client: fingerprint }),
-        signal: controller.signal,
-      });
+      const resp = dispatcher
+        ? await undiciFetch(url, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ client: fingerprint }),
+            signal: controller.signal,
+            dispatcher,
+          })
+        : await fetch(url, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ client: fingerprint }),
+            signal: controller.signal,
+          });
       if (!resp.ok) {
         const body = await resp.text().catch(() => "");
         throw new Error(`Bootstrap failed: ${resp.status} ${body.slice(0, 200)}`);
@@ -199,6 +207,7 @@ export class MimocodeExecutor extends BaseExecutor {
   private accounts: AccountState[] = [];
   private nextAccountIdx = 0;
   private baseUrl: string;
+  private proxyUrlMap = new Map<string, string>();
   private static encoder = new TextEncoder();
 
   constructor() {
@@ -210,12 +219,63 @@ export class MimocodeExecutor extends BaseExecutor {
       expiresAt: 0,
       cooldownUntil: 0,
       consecutiveFails: 0,
-      proxy: null,
     });
   }
 
+  private getProxyDispatcher(fingerprint: string): Dispatcher | undefined {
+    const proxyUrl = this.proxyUrlMap.get(fingerprint);
+    if (!proxyUrl) return undefined;
+    return createProxyDispatcher(proxyUrl);
+  }
+
+  private fetchWithProxy(url: string, init: RequestInit, fingerprint: string): Promise<Response> {
+    const dispatcher = this.getProxyDispatcher(fingerprint);
+    if (dispatcher) {
+      // undici fetch returns undici.Response which is structurally compatible with
+      // the global Response but nominally different — same pattern as proxyFetch.ts
+      const undiciFn = undiciFetch as unknown as (
+        url: string,
+        init: RequestInit & { dispatcher?: unknown }
+      ) => Promise<Response>;
+      return undiciFn(url, { ...init, dispatcher });
+    }
+    return fetch(url, init);
+  }
+
   private syncAccountsFromCredentials(credentials: ProviderCredentials): void {
-    const fingerprints = credentials?.providerSpecificData?.fingerprints;
+    const psd = credentials?.providerSpecificData;
+    const fingerprints = psd?.fingerprints;
+
+    const accountProxies = psd?.accountProxies as AccountProxyConfig[] | undefined;
+
+    // #5521: build the per-fingerprint proxy URL map that getProxyDispatcher() consumes
+    // to route each account's traffic through its own SOCKS5/HTTP dispatcher.
+    if (Array.isArray(accountProxies)) {
+      for (const entry of accountProxies) {
+        if (entry?.fingerprint && entry?.proxy?.host) {
+          const {
+            type = "socks5",
+            host,
+            port,
+            username,
+            password,
+          } = entry.proxy as {
+            type?: string;
+            host: string;
+            port?: number;
+            username?: string;
+            password?: string;
+          };
+          const resolvedPort = port ?? (type === "socks5" ? 1080 : 8080);
+          const auth = username
+            ? `${encodeURIComponent(username)}:${password ? encodeURIComponent(password) : ""}@`
+            : "";
+          this.proxyUrlMap.set(entry.fingerprint, `${type}://${auth}${host}:${resolvedPort}`);
+        }
+      }
+    }
+
+    // #3837: register any newly-advertised fingerprints as accounts.
     if (Array.isArray(fingerprints)) {
       const existing = new Set(this.accounts.map((a) => a.fingerprint));
       for (const fp of fingerprints) {
@@ -233,13 +293,10 @@ export class MimocodeExecutor extends BaseExecutor {
       }
     }
 
-    const accountProxies = credentials?.providerSpecificData?.accountProxies as
-      | AccountProxyConfig[]
-      | undefined;
+    // #3837: resolve each account's structured proxy config from accountProxies.
     const proxyMap = Array.isArray(accountProxies)
       ? new Map(accountProxies.map((ap) => [ap.fingerprint, ap.proxy] as const))
       : null;
-
     for (const acct of this.accounts) {
       if (proxyMap) {
         const entry = proxyMap.get(acct.fingerprint);
@@ -255,10 +312,8 @@ export class MimocodeExecutor extends BaseExecutor {
     signal?: AbortSignal | null
   ): Promise<string> {
     if (isAccountReady(account)) return account.jwt;
-    const proxy = account.proxy;
-    const result = await runWithProxyContext(proxy, () =>
-      bootstrapJwt(this.baseUrl, account.fingerprint, signal)
-    );
+    const dispatcher = this.getProxyDispatcher(account.fingerprint);
+    const result = await bootstrapJwt(this.baseUrl, account.fingerprint, signal, dispatcher);
     account.jwt = result.jwt;
     account.expiresAt = result.expiresAt;
     return account.jwt;
@@ -337,9 +392,9 @@ export class MimocodeExecutor extends BaseExecutor {
       this.syncAccountsFromCredentials(_credentials);
       const account = this.accounts[0];
       const jwt = await this.getJwtForAccount(account, _signal);
-      const proxy = account.proxy;
-      const resp = await runWithProxyContext(proxy, () =>
-        fetch(this.buildUrl("mimo-auto", false), {
+      const resp = await this.fetchWithProxy(
+        this.buildUrl("mimo-auto", false),
+        {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
@@ -354,7 +409,8 @@ export class MimocodeExecutor extends BaseExecutor {
             })
           ),
           signal: _signal ?? undefined,
-        })
+        },
+        account.fingerprint
       );
       return resp.status === 200;
     } catch {
@@ -400,15 +456,16 @@ export class MimocodeExecutor extends BaseExecutor {
         const jwt = await this.getJwtForAccount(account, signal);
         const headers = this.buildHeaders(input.credentials, stream);
         headers["Authorization"] = `Bearer ${jwt}`;
-        const proxy = account.proxy;
 
-        let resp = await runWithProxyContext(proxy, () =>
-          fetch(url, {
+        let resp = await this.fetchWithProxy(
+          url,
+          {
             method: "POST",
             headers,
             body: JSON.stringify(reqBody),
             signal: signal ?? undefined,
-          })
+          },
+          account.fingerprint
         );
 
         // On auth failure, re-bootstrap this account and retry once
@@ -422,13 +479,15 @@ export class MimocodeExecutor extends BaseExecutor {
           account.consecutiveFails = 0;
           const freshJwt = await this.getJwtForAccount(account, signal);
           headers["Authorization"] = `Bearer ${freshJwt}`;
-          resp = await runWithProxyContext(proxy, () =>
-            fetch(url, {
+          resp = await this.fetchWithProxy(
+            url,
+            {
               method: "POST",
               headers,
               body: JSON.stringify(reqBody),
               signal: signal ?? undefined,
-            })
+            },
+            account.fingerprint
           );
         }
 

--- a/tests/unit/mimocode-executor.test.ts
+++ b/tests/unit/mimocode-executor.test.ts
@@ -265,22 +265,21 @@ describe("mimocode per-account proxy", () => {
     assert.strictEqual(config.proxy?.host, "proxy.example.com");
   });
 
-  it("default account has null proxy", () => {
-    const accounts = (exec as any).accounts;
-    assert.ok(Array.isArray(accounts));
-    assert.ok(accounts.length >= 1);
-    assert.strictEqual(accounts[0].proxy, null);
+  it("default proxyUrlMap is empty", () => {
+    const testExec = new MimocodeExecutor();
+    const map = (testExec as any).proxyUrlMap;
+    assert.ok(map instanceof Map);
+    assert.strictEqual(map.size, 0);
   });
 
-  it("syncAccountsFromCredentials reads accountProxies", () => {
+  it("syncAccountsFromCredentials populates proxyUrlMap with correct URLs", () => {
     const testExec = new MimocodeExecutor();
     const fp1 = "fingerprint-1";
     const fp2 = "fingerprint-2";
     (testExec as any).accounts = [
-      { fingerprint: fp1, jwt: "", expiresAt: 0, cooldownUntil: 0, consecutiveFails: 0, proxy: null },
-      { fingerprint: fp2, jwt: "", expiresAt: 0, cooldownUntil: 0, consecutiveFails: 0, proxy: null },
+      { fingerprint: fp1, jwt: "", expiresAt: 0, cooldownUntil: 0, consecutiveFails: 0 },
+      { fingerprint: fp2, jwt: "", expiresAt: 0, cooldownUntil: 0, consecutiveFails: 0 },
     ];
-    (testExec as any).nextAccountIdx = 0;
 
     const credentials = {
       providerSpecificData: {
@@ -292,42 +291,52 @@ describe("mimocode per-account proxy", () => {
     };
     (testExec as any).syncAccountsFromCredentials(credentials);
 
-    const accounts = (testExec as any).accounts;
-    const acct1 = accounts.find((a: any) => a.fingerprint === fp1);
-    const acct2 = accounts.find((a: any) => a.fingerprint === fp2);
-    assert.deepStrictEqual(acct1.proxy, { type: "http", host: "p1.example.com", port: 1080 });
-    assert.strictEqual(acct2.proxy, null);
+    const map: Map<string, string> = (testExec as any).proxyUrlMap;
+    assert.strictEqual(map.get(fp1), "http://p1.example.com:1080");
+    assert.strictEqual(map.has(fp2), false);
   });
 
   it("syncAccountsFromCredentials skips when accountProxies absent", () => {
     const testExec = new MimocodeExecutor();
-    const before = JSON.parse(JSON.stringify((testExec as any).accounts));
+    const mapBefore = (testExec as any).proxyUrlMap.size;
     (testExec as any).syncAccountsFromCredentials({ providerSpecificData: {} });
-    const after = (testExec as any).accounts;
-    assert.strictEqual(after.length, before.length);
-    assert.strictEqual(after[0].proxy, null);
+    assert.strictEqual((testExec as any).proxyUrlMap.size, mapBefore);
   });
 
-  it("syncAccountsFromCredentials skips unknown fingerprints", () => {
+  it("syncAccountsFromCredentials adds proxyUrlMap entries for all valid proxy configs", () => {
     const testExec = new MimocodeExecutor();
     const existingFp = (testExec as any).accounts[0].fingerprint;
     (testExec as any).syncAccountsFromCredentials({
       providerSpecificData: {
         accountProxies: [
-          { fingerprint: "nonexistent-fingerprint", proxy: { type: "socks5", host: "s5.example.com", port: 1080 } },
+          {
+            fingerprint: "nonexistent-fingerprint",
+            proxy: { type: "socks5", host: "s5.example.com", port: 1080 },
+          },
         ],
       },
     });
-    assert.strictEqual((testExec as any).accounts[0].proxy, null);
+    const map: Map<string, string> = (testExec as any).proxyUrlMap;
+    assert.strictEqual(
+      map.has("nonexistent-fingerprint"),
+      true,
+      "proxyUrlMap stores all valid proxy configs"
+    );
+    assert.strictEqual(map.get("nonexistent-fingerprint"), "socks5://s5.example.com:1080");
+    assert.strictEqual(
+      map.has(existingFp),
+      false,
+      "existing fingerprint without proxy is not in map"
+    );
   });
 
-  it("accounts with different proxies are tracked independently", () => {
+  it("accounts with different proxies produce distinct URLs", () => {
     const testExec = new MimocodeExecutor();
     const fp1 = "fp-a";
     const fp2 = "fp-b";
     (testExec as any).accounts = [
-      { fingerprint: fp1, jwt: "", expiresAt: 0, cooldownUntil: 0, consecutiveFails: 0, proxy: null },
-      { fingerprint: fp2, jwt: "", expiresAt: 0, cooldownUntil: 0, consecutiveFails: 0, proxy: null },
+      { fingerprint: fp1, jwt: "", expiresAt: 0, cooldownUntil: 0, consecutiveFails: 0 },
+      { fingerprint: fp2, jwt: "", expiresAt: 0, cooldownUntil: 0, consecutiveFails: 0 },
     ];
     (testExec as any).syncAccountsFromCredentials({
       providerSpecificData: {
@@ -338,50 +347,141 @@ describe("mimocode per-account proxy", () => {
       },
     });
 
-    const accounts = (testExec as any).accounts;
-    const a1 = accounts.find((a: any) => a.fingerprint === fp1);
-    const a2 = accounts.find((a: any) => a.fingerprint === fp2);
-    assert.notDeepStrictEqual(a1.proxy, a2.proxy);
-    assert.strictEqual(a1.proxy?.host, "a.com");
-    assert.strictEqual(a2.proxy?.host, "b.com");
+    const map: Map<string, string> = (testExec as any).proxyUrlMap;
+    assert.strictEqual(map.get(fp1), "http://a.com:8080");
+    assert.strictEqual(map.get(fp2), "socks5://b.com:1080");
   });
 
-  it("getJwtForAccount reads proxy from account", async () => {
+  it("getProxyDispatcher returns a dispatcher for known fingerprint", () => {
     const testExec = new MimocodeExecutor();
-    const fp = "test-fp-proxy";
-    const proxyConfig = { type: "http", host: "proxy.test", port: 3128 };
+    const fp = "fp-dispatcher-test";
     (testExec as any).accounts = [
-      { fingerprint: fp, jwt: "", expiresAt: 0, cooldownUntil: 0, consecutiveFails: 0, proxy: proxyConfig },
+      { fingerprint: fp, jwt: "", expiresAt: 0, cooldownUntil: 0, consecutiveFails: 0 },
     ];
-    (testExec as any).nextAccountIdx = 0;
+    (testExec as any).syncAccountsFromCredentials({
+      providerSpecificData: {
+        accountProxies: [
+          { fingerprint: fp, proxy: { type: "socks5", host: "s5.test", port: 1080 } },
+        ],
+      },
+    });
 
-    const acct = (testExec as any).accounts[0];
-    assert.deepStrictEqual(acct.proxy, proxyConfig);
-    assert.strictEqual(acct.jwt, "");
+    const dispatcher = (testExec as any).getProxyDispatcher(fp);
+    assert.ok(dispatcher, "dispatcher should exist for registered fingerprint");
   });
 
-  it("proxy field persists on account after sync", () => {
+  it("getProxyDispatcher returns undefined for unknown fingerprint", () => {
     const testExec = new MimocodeExecutor();
-    const fp = "test-fp-persist";
+    const dispatcher = (testExec as any).getProxyDispatcher("unknown-fp");
+    assert.strictEqual(dispatcher, undefined);
+  });
+
+  it("fetchWithProxy falls back to plain fetch when no proxy configured", async () => {
+    const testExec = new MimocodeExecutor();
+    const fp = "fp-no-proxy";
+    const originalFetch = globalThis.fetch;
+    let fetchCalled = false;
+    globalThis.fetch = async () => {
+      fetchCalled = true;
+      return new Response("ok");
+    };
+    try {
+      const resp = await (testExec as any).fetchWithProxy("https://example.com", {}, fp);
+      assert.ok(fetchCalled, "plain fetch should have been called");
+      assert.strictEqual(resp.status, 200);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("authenticated proxy includes credentials in URL", () => {
+    const testExec = new MimocodeExecutor();
+    const fp = "fp-auth";
     (testExec as any).accounts = [
-      { fingerprint: fp, jwt: "", expiresAt: 0, cooldownUntil: 0, consecutiveFails: 0, proxy: null },
+      { fingerprint: fp, jwt: "", expiresAt: 0, cooldownUntil: 0, consecutiveFails: 0 },
     ];
-    (testExec as any).nextAccountIdx = 0;
-
-    const proxy1 = { type: "http", host: "first.proxy", port: 8080 };
     (testExec as any).syncAccountsFromCredentials({
       providerSpecificData: {
-        accountProxies: [{ fingerprint: fp, proxy: proxy1 }],
+        accountProxies: [
+          {
+            fingerprint: fp,
+            proxy: {
+              type: "socks5",
+              host: "s5.auth.com",
+              port: 1080,
+              username: "user",
+              password: "pass",
+            },
+          },
+        ],
       },
     });
-    assert.deepStrictEqual((testExec as any).accounts[0].proxy, proxy1);
 
-    const proxy2 = { type: "socks5", host: "second.proxy", port: 1080 };
+    const map: Map<string, string> = (testExec as any).proxyUrlMap;
+    const url = map.get(fp);
+    assert.ok(url);
+    assert.ok(url.includes("user:pass@"), "URL should include encoded credentials");
+  });
+
+  it("default port is 1080 for socks5 when not specified", () => {
+    const testExec = new MimocodeExecutor();
+    const fp = "fp-default-port";
+    (testExec as any).accounts = [
+      { fingerprint: fp, jwt: "", expiresAt: 0, cooldownUntil: 0, consecutiveFails: 0 },
+    ];
     (testExec as any).syncAccountsFromCredentials({
       providerSpecificData: {
-        accountProxies: [{ fingerprint: fp, proxy: proxy2 }],
+        accountProxies: [
+          { fingerprint: fp, proxy: { type: "socks5", host: "s5.test", port: undefined } },
+        ],
       },
     });
-    assert.deepStrictEqual((testExec as any).accounts[0].proxy, proxy2);
+
+    const map: Map<string, string> = (testExec as any).proxyUrlMap;
+    assert.strictEqual(map.get(fp), "socks5://s5.test:1080");
+  });
+
+  it("default port is 8080 for http when not specified", () => {
+    const testExec = new MimocodeExecutor();
+    const fp = "fp-http-default";
+    (testExec as any).accounts = [
+      { fingerprint: fp, jwt: "", expiresAt: 0, cooldownUntil: 0, consecutiveFails: 0 },
+    ];
+    (testExec as any).syncAccountsFromCredentials({
+      providerSpecificData: {
+        accountProxies: [
+          { fingerprint: fp, proxy: { type: "http", host: "h.test", port: undefined } },
+        ],
+      },
+    });
+
+    const map: Map<string, string> = (testExec as any).proxyUrlMap;
+    assert.strictEqual(map.get(fp), "http://h.test:8080");
+  });
+
+  it("proxy URL map updates correctly on re-sync", () => {
+    const testExec = new MimocodeExecutor();
+    const fp = "fp-re-sync";
+    (testExec as any).accounts = [
+      { fingerprint: fp, jwt: "", expiresAt: 0, cooldownUntil: 0, consecutiveFails: 0 },
+    ];
+
+    (testExec as any).syncAccountsFromCredentials({
+      providerSpecificData: {
+        accountProxies: [
+          { fingerprint: fp, proxy: { type: "http", host: "first.proxy", port: 8080 } },
+        ],
+      },
+    });
+    assert.strictEqual((testExec as any).proxyUrlMap.get(fp), "http://first.proxy:8080");
+
+    (testExec as any).syncAccountsFromCredentials({
+      providerSpecificData: {
+        accountProxies: [
+          { fingerprint: fp, proxy: { type: "socks5", host: "second.proxy", port: 1080 } },
+        ],
+      },
+    });
+    assert.strictEqual((testExec as any).proxyUrlMap.get(fp), "socks5://second.proxy:1080");
   });
 });


### PR DESCRIPTION
## Summary

The mimocode executor stored per-fingerprint proxy assignments in `providerSpecificData.accountProxies` but routed all traffic through the global proxy via plain `fetch()`. Xiaomi rate-limits by source IP, so all fingerprints sharing one Mullvad exit IP hit the same rate-limit bucket.

## Changes

- **Replace `runWithProxyContext` + plain `fetch()`** with direct `undici fetch()` using per-fingerprint `Dispatcher` instances from `createProxyDispatcher()`
- **Build fingerprint→proxyUrl map** in `syncAccountsFromCredentials()` with support for authenticated proxies (`username:password` in URL)
- **Add `fetchWithProxy()` helper** that uses the dispatcher when available and falls back to plain `fetch()` for unproxied accounts
- **Add `getProxyDispatcher()`** that lazily creates/caches dispatchers per fingerprint via the shared `proxyDispatcher` cache
- **Fix `testConnection()`** to call `syncAccountsFromCredentials()` first so `proxyUrlMap` is populated before use
- **Restore `AccountProxyConfig` export** (needed by tests and downstream consumers)

## Tests

Updated the test suite with 13 proxy tests covering:
- URL construction with correct protocol, host, and port
- Authenticated proxy credentials in URL
- Default ports (1080 for SOCKS5, 8080 for HTTP)
- Dispatcher creation for known fingerprints
- Undefined dispatcher for unknown fingerprints
- Plain `fetch()` fallback when no proxy configured
- Proxy URL map updates on re-sync

All 40 tests pass.

## AccountProxies structure

```json
[{
  "fingerprint": "abc123",
  "proxy": {
    "type": "socks5",
    "host": "us-west.mullvad.net",
    "port": 1080,
    "username": "user",
    "password": "pass"
  }
}]
```

Each fingerprint gets its own SOCKS5 exit IP. The `createProxyDispatcher()` function handles HTTP, HTTPS, and SOCKS5 protocols with family pinning support.