### PR TITLE
refactor(dashboard): T11 — consolidate duplicate compression controls onto the single-source panel

### DIFF
--- a/src/app/(dashboard)/dashboard/settings/components/CompressionSettingsTab.tsx
+++ b/src/app/(dashboard)/dashboard/settings/components/CompressionSettingsTab.tsx
@@ -416,38 +416,20 @@ export default function CompressionSettingsTab() {
           config.defaultMode !== "lite" &&
           config.cavemanConfig && (
             <div className="space-y-3 pt-4 border-t border-border/30">
-              <div className="flex items-center justify-between">
-                <div>
-                  <h4 className="text-sm font-medium text-text-main">
-                    {t("compressionCavemanConfig")}
-                  </h4>
-                  <p className="text-xs text-text-muted mt-0.5">
-                    {t("compressionCavemanConfigDesc")}
-                  </p>
-                </div>
-                <button
-                  onClick={() =>
-                    save({
-                      cavemanConfig: {
-                        ...config.cavemanConfig!,
-                        enabled: !config.cavemanConfig!.enabled,
-                      },
-                    })
-                  }
-                  className={`relative w-10 h-5 rounded-full transition-colors ${
-                    config.cavemanConfig.enabled ? "bg-green-500" : "bg-border"
-                  }`}
-                >
-                  <span
-                    className={`absolute top-0.5 w-4 h-4 rounded-full bg-white transition-transform ${
-                      config.cavemanConfig.enabled ? "left-5" : "left-0.5"
-                    }`}
-                  />
-                </button>
+              {/* Engine on/off is owned by the single-source panel (/dashboard/context/settings):
+                  the panel's `engines.caveman.enabled` is authoritative (planResolution.ts). This tab
+                  keeps only the advanced caveman tuning the panel does not expose. */}
+              <div data-testid="caveman-panel-note">
+                <h4 className="text-sm font-medium text-text-main">
+                  {t("compressionCavemanConfig")}
+                </h4>
+                <p className="text-xs text-text-muted mt-0.5">
+                  {t("compressionCavemanConfigDesc")} {t("compressionCavemanPanelHint")}{" "}
+                  <code className="text-text-muted">/dashboard/context/settings</code>
+                </p>
               </div>
 
-              {config.cavemanConfig.enabled && (
-                <>
+              <>
                   <div className="space-y-2">
                     <p className="text-sm text-text-muted">{t("compressionRoles")}</p>
                     <div className="flex flex-wrap gap-2">
@@ -534,8 +516,7 @@ export default function CompressionSettingsTab() {
                       className="w-full min-h-[80px] px-3 py-2 text-sm rounded-lg border border-border bg-surface text-text-main font-mono resize-y"
                     />
                   </div>
-                </>
-              )}
+              </>
             </div>
           )}
 

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -5637,6 +5637,7 @@
     "compressionPreserveSystem": "Preserve System Prompt",
     "compressionCavemanConfig": "Caveman Engine Configuration",
     "compressionCavemanConfigDesc": "Fine-tune the rule-based compression engine",
+    "compressionCavemanPanelHint": "Its on/off and level are set in the panel:",
     "compressionRoles": "Compress Message Roles",
     "compressionRoleUser": "User",
     "compressionRoleAssistant": "Assistant",

--- a/tests/unit/compression-settings-tab-consolidation.test.tsx
+++ b/tests/unit/compression-settings-tab-consolidation.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import React from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// next-intl → echo the key so we can assert on stable identifiers.
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+vi.mock("@/shared/components", () => ({
+  Card: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <div data-testid="card" className={className}>
+      {children}
+    </div>
+  ),
+  Button: ({ children, onClick }: { children?: React.ReactNode; onClick?: () => void }) => (
+    <button onClick={onClick}>{children}</button>
+  ),
+}));
+
+const CONFIG = {
+  enabled: true,
+  defaultMode: "standard",
+  autoTriggerTokens: 0,
+  cacheMinutes: 5,
+  preserveSystemPrompt: true,
+  comboOverrides: {},
+  cavemanConfig: {
+    enabled: true,
+    compressRoles: ["user"],
+    skipRules: [],
+    minMessageLength: 50,
+    preservePatterns: [],
+    intensity: "full",
+  },
+  cavemanOutputMode: { enabled: false, intensity: "full", autoClarity: true },
+  rtkConfig: { enabled: true, intensity: "standard" },
+};
+
+let container: HTMLDivElement;
+let root: ReturnType<typeof createRoot> | undefined;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  vi.stubGlobal(
+    "fetch",
+    vi.fn((url: string) => {
+      const u = String(url);
+      if (u.includes("/api/settings/compression")) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(CONFIG) });
+      }
+      if (u.includes("/api/compression/rules")) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ rules: [] }) });
+      }
+      return Promise.resolve({ ok: false, json: () => Promise.resolve(null) });
+    })
+  );
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  root = undefined;
+  container.remove();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+async function renderTab() {
+  const { default: CompressionSettingsTab } = await import(
+    "@/app/(dashboard)/dashboard/settings/components/CompressionSettingsTab"
+  );
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<CompressionSettingsTab />);
+  });
+  // Drain the on-mount fetch → json → setState microtask chain.
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+describe("CompressionSettingsTab — compression controls consolidation (T11)", () => {
+  it("renders the read-only TokenSaver summary that links to the unified panel", async () => {
+    await renderTab();
+    const hrefs = Array.from(container.querySelectorAll("a")).map((a) => a.getAttribute("href"));
+    expect(hrefs).toContain("/dashboard/context/settings");
+    expect(container.textContent).toContain("tokenSaverTitle");
+  });
+
+  it("does not render a duplicate caveman engine on/off toggle (panel owns on/off)", async () => {
+    await renderTab();
+    const note = container.querySelector('[data-testid="caveman-panel-note"]');
+    expect(note).not.toBeNull();
+    // The note points users to the single-source panel...
+    expect(note?.textContent).toContain("/dashboard/context/settings");
+    // ...and the caveman header no longer carries its own enable toggle button.
+    expect(note?.querySelector("button")).toBeNull();
+  });
+
+  it("keeps the advanced caveman tuning the panel does not expose", async () => {
+    await renderTab();
+    expect(container.textContent).toContain("compressionRoleUser");
+    expect(container.textContent).toContain("compressionSkipRules");
+    expect(container.textContent).toContain("compressionPreservePatterns");
+  });
+});


### PR DESCRIPTION
## Onda 1 — gaps v3.8.42 (T11: consolidate duplicate compression controls)

Fecha o **T11** do `gaps/compress/T11-consolidate-duplicate-compression-controls.md`.

### Re-auditoria

A maior parte do T11 **já estava entregue**: `CompressionTokenSaverCard` já é um summary read-only que linka ao painel; o **toggle RTK, os níveis caveman e o on/off do cavemanOutput** já tinham sido movidos para o painel único (comentários "set in the panel" no código). Restava **uma duplicata real**: o toggle `cavemanConfig.enabled` no tab de settings.

### Mudança

O backend usa `engines.caveman.enabled` do painel como autoritativo quando configurado (`planResolution.ts`, path `enginesExplicit`). O toggle do tab era uma **segunda superfície de escrita** que podia divergir. Removido (substituído por uma nota apontando ao painel), no **mesmo padrão já usado no cavemanOutput**. A config avançada que o painel **não** expõe (compress-roles, min-length, skip-rules, preserve-patterns) é preservada.

- god-file `CompressionSettingsTab.tsx`: **−19 linhas líquidas** (encolheu).
- Sem regressão de i18n (a nota usa o mesmo padrão de texto inline já presente no cavemanOutput).

### Validação

- `npx vitest run` em `tests/unit/compression-settings-tab-consolidation.test.tsx`: **3 testes, 0 falha** (guard real: sem a mudança, falha).
- `npm run typecheck:core`: **verde**.
- `npx eslint`: **0 erros**.

### Sub-itens restantes (cosméticos, não-bloqueantes)

- Confirmar `EngineConfigPage` write-path (painel já é a superfície).
- Verificar reorder do `COMPRESSION_CONTEXT_GROUP` (Task 12, cosmético).