### PR TITLE
fix(dashboard): keep onboarding schemas browser-safe

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/components/onboarding/providerOnboardingApi.ts
+++ b/src/app/(dashboard)/dashboard/providers/components/onboarding/providerOnboardingApi.ts
@@ -4,7 +4,7 @@ import {
   createProviderNodeSchema,
   createProviderSchema,
   validateProviderApiKeySchema,
-} from "@/shared/validation/schemas";
+} from "@/shared/validation/schemas/provider";
 
 export type OnboardingConnection = {
   id: string;


### PR DESCRIPTION
## Summary
- avoid importing the full validation schema barrel from the provider onboarding client helper
- import provider onboarding schemas from the provider schema module directly so the browser bundle does not traverse settings/runtime/db/rateLimiter/ioredis

## Validation
- `npx eslint 'src/app/(dashboard)/dashboard/providers/components/onboarding/providerOnboardingApi.ts'`
- attempted `npm run build`; local Windows build exceeded the 10 minute command timeout before returning output

Fixes the CI build failure seen on #5467 where `ProviderOnboardingWizard.tsx` pulled `ioredis` into the client bundle via `@/shared/validation/schemas`.