### PR TITLE
fix(chatgpt-web): support GPT-5.5 Pro handoff

### DIFF
--- a/open-sse/config/providers/registry/chatgpt-web/index.ts
+++ b/open-sse/config/providers/registry/chatgpt-web/index.ts
@@ -9,14 +9,15 @@ export const chatgpt_webProvider: RegistryEntry = {
   authType: "apikey",
   authHeader: "cookie",
   models: [
-    { id: "gpt-5.5-pro", name: "GPT-5.5 Pro" }, //pro tier only
-    { id: "gpt-5.5-thinking", name: "GPT-5.5 Thinking" }, //plus, pro tier
-    { id: "gpt-5.5", name: "GPT-5.5 Instant" }, //free, plus, pro tier
-    { id: "gpt-5.4-pro", name: "GPT-5.4 Pro" }, //pro tier only
-    { id: "gpt-5.4-thinking", name: "GPT-5.4 Thinking" }, //plus, pro tier
-    { id: "gpt-5.4-thinking-mini", name: "GPT-5.4 Thinking Mini" }, //free-login only
-    { id: "gpt-5.3", name: "GPT-5.3 Instant" }, //free, free-login, plus, pro tier
-    { id: "gpt-5.3-mini", name: "GPT-5.3 Mini" }, //limit fallback
-    { id: "o3", name: "o3" }, //plus ~ tier
+    { id: "gpt-5-5-pro", name: "GPT-5.5 Pro" }, // pro tier only, standard effort
+    { id: "gpt-5-5-pro-extended", name: "GPT-5.5 Pro Extended" }, // pro tier only, extended effort
+    { id: "gpt-5-5-thinking", name: "GPT-5.5 Thinking" }, // plus, pro tier
+    { id: "gpt-5-5", name: "GPT-5.5 Instant" }, // free, plus, pro tier
+    { id: "gpt-5-4-pro", name: "GPT-5.4 Pro" }, // pro tier only
+    { id: "gpt-5-4-thinking", name: "GPT-5.4 Thinking" }, // plus, pro tier
+    { id: "gpt-5-4-t-mini", name: "GPT-5.4 Thinking Mini" }, // free-login only
+    { id: "gpt-5-3", name: "GPT-5.3 Instant" }, // free, free-login, plus, pro tier
+    { id: "gpt-5-3-mini", name: "GPT-5.3 Mini" }, // limit fallback
+    { id: "o3", name: "o3" }, // plus ~ tier
   ],
 };

--- a/open-sse/executors/chatgpt-web.ts
+++ b/open-sse/executors/chatgpt-web.ts
@@ -41,6 +41,9 @@ const SENTINEL_CR_URL = `${CHATGPT_BASE}/backend-api/sentinel/chat-requirements`
 const CONV_URL = `${CHATGPT_BASE}/backend-api/f/conversation`;
 const USER_LAST_USED_MODEL_CONFIG_URL = `${CHATGPT_BASE}/backend-api/settings/user_last_used_model_config`;
 
+const DEFAULT_PRO_POLL_TIMEOUT_MS = 20 * 60_000;
+const DEFAULT_PRO_POLL_INTERVAL_MS = 4_000;
+
 const CHATGPT_USER_AGENT =
   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:152.0) Gecko/20100101 Firefox/152.0";
 
@@ -81,7 +84,20 @@ function deviceIdFor(cookie: string): string {
 // /backend-api/models on a logged-in account; "gpt-5-4-t-mini" is ChatGPT's
 // abbreviated slug for "GPT-5.4 Thinking Mini".
 const MODEL_MAP: Record<string, string> = {
+  // Current ChatGPT Web slugs (these are what the provider catalog exposes).
+  "gpt-5-5-pro": "gpt-5-5-pro",
+  "gpt-5-5-pro-extended": "gpt-5-5-pro",
+  "gpt-5-5-thinking": "gpt-5-5-thinking",
+  "gpt-5-5": "gpt-5-5",
+  "gpt-5-4-pro": "gpt-5-4-pro",
+  "gpt-5-4-thinking": "gpt-5-4-thinking",
+  "gpt-5-4-t-mini": "gpt-5-4-t-mini",
+  "gpt-5-3": "gpt-5-3",
+  "gpt-5-3-mini": "gpt-5-3-mini",
+
+  // Legacy OmniRoute dot-form aliases kept for direct provider/model callers.
   "gpt-5.5-pro": "gpt-5-5-pro",
+  "gpt-5.5-pro-extended": "gpt-5-5-pro",
   "gpt-5.5-thinking": "gpt-5-5-thinking",
   "gpt-5.5": "gpt-5-5",
   "gpt-5.4-pro": "gpt-5-4-pro",
@@ -91,6 +107,13 @@ const MODEL_MAP: Record<string, string> = {
   "gpt-5.3": "gpt-5-3",
   "gpt-5.3-mini": "gpt-5-3-mini",
   o3: "o3",
+};
+
+const MODEL_FORCED_EFFORT: Record<string, "standard" | "extended"> = {
+  "gpt-5-5-pro": "standard",
+  "gpt-5-5-pro-extended": "extended",
+  "gpt-5.5-pro": "standard",
+  "gpt-5.5-pro-extended": "extended",
 };
 
 /** Set of chatgpt.com slugs that the user_last_used_model_config endpoint
@@ -512,6 +535,36 @@ function resolveThinkingEffort(
   if (top) return top;
   const nested = (b.reasoning as Record<string, unknown> | undefined)?.effort;
   return normalizeThinkingEffort(nested);
+}
+
+interface ResolvedChatGptModel {
+  slug: string;
+  effort: "standard" | "extended" | null;
+  isPro: boolean;
+}
+
+function resolveChatGptModel(
+  model: string,
+  body: unknown,
+  providerSpecificData: Record<string, unknown> | undefined
+): ResolvedChatGptModel {
+  const slug = MODEL_MAP[model] ?? model;
+  const forcedEffort = MODEL_FORCED_EFFORT[model] ?? null;
+  const effort = forcedEffort ?? resolveThinkingEffort(body, providerSpecificData);
+  const isPro = slug === "gpt-5-5-pro";
+  return { slug, effort, isPro };
+}
+
+function configuredProPollTimeoutMs(): number {
+  const raw = Number(process.env.OMNIROUTE_CGPT_WEB_PRO_TIMEOUT_MS);
+  if (!Number.isFinite(raw) || raw <= 0) return DEFAULT_PRO_POLL_TIMEOUT_MS;
+  return Math.floor(raw);
+}
+
+function configuredProPollIntervalMs(): number {
+  const raw = Number(process.env.OMNIROUTE_CGPT_WEB_PRO_POLL_INTERVAL_MS);
+  if (!Number.isFinite(raw) || raw <= 0) return DEFAULT_PRO_POLL_INTERVAL_MS;
+  return Math.floor(raw);
 }
 
 async function setUserThinkingEffort(
@@ -1055,11 +1108,14 @@ function buildConversationBody(
   parsed: ParsedMessages,
   modelSlug: string,
   parentMessageId: string,
-  // When true, send as a regular (non-temporary) chat so the image_gen tool
-  // is available. When false (default), use Temporary Chat to keep chats
-  // out of the user's chatgpt.com history.
-  forImageGen: boolean,
-  continuation: ChatGptImageConversationContext | null = null
+  options: {
+    // Keep text/API calls in Temporary Chat so they do not clutter the user's
+    // chatgpt.com history. Disable Temporary Chat only when ChatGPT needs a
+    // durable image conversation (image generation/editing).
+    persistConversation: boolean;
+    thinkingEffort: "standard" | "extended" | null;
+    continuation?: ChatGptImageConversationContext | null;
+  }
 ): Record<string, unknown> {
   // Critical: do NOT send prior turns as separate `assistant` and `user`
   // messages in the `messages` array. ChatGPT's web API ("action: next")
@@ -1074,6 +1130,8 @@ function buildConversationBody(
   if (parsed.systemMsg.trim()) {
     systemParts.push(parsed.systemMsg.trim());
   }
+  const continuation = options.continuation ?? null;
+
   if (!continuation && parsed.history.length > 0) {
     const formatted = parsed.history
       .map((h) => `${h.role === "assistant" ? "Assistant" : "User"}: ${h.content}`)
@@ -1113,13 +1171,16 @@ function buildConversationBody(
     conversation_id: continuation?.conversationId ?? null,
     parent_message_id: continuation?.parentMessageId ?? parentMessageId,
     timezone_offset_min: -new Date().getTimezoneOffset(),
-    // Temporary Chat is the default. Disable it ONLY when the user is asking
-    // for an image — that lets ChatGPT use its image_gen tool, at the cost of
-    // saving the chat to the user's history. For text-only requests we keep
-    // Temporary Chat on so the user's history stays clean.
-    history_and_training_disabled: !(forImageGen || continuation),
+    // Temporary Chat is the default. Disable it only for image generation /
+    // image edits, where ChatGPT needs durable conversation state for tools.
+    history_and_training_disabled: !options.persistConversation,
     suggestions: [],
     websocket_request_id: randomUUID(),
+    conversation_mode: { kind: "primary_assistant" },
+    supports_buffering: true,
+    force_parallel_switch: "auto",
+    paragen_cot_summary_display_override: "allow",
+    ...(options.thinkingEffort ? { thinking_effort: options.thinkingEffort } : {}),
   };
 }
 
@@ -1161,15 +1222,23 @@ async function* readChatGptSseEvents(
   const decoder = new TextDecoder();
   let buffer = "";
   let dataLines: string[] = [];
+  let eventName: string | null = null;
 
   function flush(): ChatGptStreamEvent | null | "done" {
-    if (dataLines.length === 0) return null;
+    if (dataLines.length === 0) {
+      eventName = null;
+      return null;
+    }
     const payload = dataLines.join("\n");
     dataLines = [];
+    const sseEventName = eventName;
+    eventName = null;
     const trimmed = payload.trim();
     if (!trimmed || trimmed === "[DONE]") return "done";
     try {
-      return JSON.parse(trimmed) as ChatGptStreamEvent;
+      const parsed = JSON.parse(trimmed) as ChatGptStreamEvent;
+      if (sseEventName && !parsed.type) parsed.type = sseEventName;
+      return parsed;
     } catch {
       console.warn("[chatgpt-web] stream event JSON parse failed");
       return null;
@@ -1196,7 +1265,9 @@ async function* readChatGptSseEvents(
           if (parsed) yield parsed;
           continue;
         }
-        if (line.startsWith("data:")) {
+        if (line.startsWith("event:")) {
+          eventName = line.slice(6).trim();
+        } else if (line.startsWith("data:")) {
           dataLines.push(line.slice(5).trimStart());
         }
       }
@@ -1234,6 +1305,8 @@ interface ContentChunk {
    * conversation endpoint for the actual image.
    */
   imageGenAsync?: boolean;
+  /** True when ChatGPT handed the turn off to a long-running worker. */
+  handoff?: boolean;
 }
 
 interface ImagePointerRef {
@@ -1290,6 +1363,7 @@ async function* extractContent(
   // tool (see ContentChunk.imageGenAsync). The actual image arrives later via
   // WebSocket / polling — caller handles that.
   let imageGenAsync = false;
+  let handoff = false;
 
   for await (const event of readChatGptSseEvents(eventStream, signal)) {
     if (event.error) {
@@ -1302,6 +1376,15 @@ async function* extractContent(
     }
 
     if (event.conversation_id) conversationId = event.conversation_id;
+
+    if (event.type === "stream_handoff") {
+      handoff = true;
+      yield {
+        conversationId: conversationId ?? undefined,
+        handoff: true,
+      };
+      continue;
+    }
 
     // Detect image_gen on top-level "server_ste_metadata" events. These don't
     // have a `message` field so the post-message guard would skip them, but
@@ -1407,8 +1490,206 @@ async function* extractContent(
     messageId: currentId ?? undefined,
     imagePointers: imagePointers.size > 0 ? Array.from(imagePointers.values()) : undefined,
     imageGenAsync,
+    handoff,
     done: true,
   };
+}
+
+// ─── Long-running Pro handoff polling ──────────────────────────────────────
+
+interface ChatGptDetailMessage {
+  id?: string;
+  author?: { role?: string };
+  content?: {
+    content_type?: string;
+    parts?: unknown[];
+    text?: string;
+  };
+  status?: string;
+  end_turn?: boolean;
+  create_time?: number;
+  update_time?: number;
+  metadata?: Record<string, unknown>;
+}
+
+interface ChatGptConversationDetail {
+  mapping?: Record<string, { message?: ChatGptDetailMessage | null }>;
+}
+
+interface FinalAssistantAnswer {
+  text: string;
+  messageId?: string;
+  finished: boolean;
+}
+
+function textFromContentPart(part: unknown): string {
+  if (typeof part === "string") return part;
+  if (!part || typeof part !== "object") return "";
+  const obj = part as Record<string, unknown>;
+  for (const key of ["text", "content", "summary"]) {
+    const value = obj[key];
+    if (typeof value === "string") return value;
+  }
+  return "";
+}
+
+function detailMessageText(message: ChatGptDetailMessage): string {
+  const content = message.content;
+  if (!content) return "";
+  if (typeof content.text === "string") return content.text;
+  const parts = content.parts ?? [];
+  return parts.map(textFromContentPart).join("");
+}
+
+function extractFinalAssistantAnswer(
+  detail: ChatGptConversationDetail
+): FinalAssistantAnswer | null {
+  const nodes = Object.values(detail.mapping ?? {});
+  let best: (FinalAssistantAnswer & { sort: number }) | null = null;
+
+  for (const node of nodes) {
+    const message = node.message;
+    if (!message || message.author?.role !== "assistant") continue;
+    if (message.metadata?.is_visually_hidden === true) continue;
+    const contentType = message.content?.content_type ?? "";
+    if (contentType.includes("thought") || contentType.includes("reasoning")) continue;
+
+    const text = detailMessageText(message).trim();
+    if (!text) continue;
+    const finished = message.status === "finished_successfully" && message.end_turn !== false;
+    const sort = message.update_time ?? message.create_time ?? 0;
+    if (
+      !best ||
+      (finished && (!best.finished || sort >= best.sort)) ||
+      (!finished && !best.finished && sort >= best.sort)
+    ) {
+      best = { text, messageId: message.id, finished, sort };
+    }
+  }
+
+  if (!best) return null;
+  return { text: best.text, messageId: best.messageId, finished: best.finished };
+}
+
+function delayWithAbort(ms: number, signal?: AbortSignal | null): Promise<void> {
+  if (ms <= 0) return Promise.resolve();
+  if (signal?.aborted) return Promise.resolve();
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+function decodeUtf8DataUrl(text: string): string {
+  const marker = ";base64,";
+  if (!text.startsWith("data:") || !text.includes(marker)) return text;
+  const base64 = text.slice(text.indexOf(marker) + marker.length);
+  return new TextDecoder().decode(Buffer.from(base64, "base64"));
+}
+
+interface ConversationDetailFetchResult {
+  detail: ChatGptConversationDetail | null;
+  terminal: boolean;
+}
+
+async function fetchConversationDetail(
+  conversationId: string,
+  ctx: ResolverContext
+): Promise<ConversationDetailFetchResult> {
+  const url = `${CHATGPT_BASE}/backend-api/conversation/${encodeURIComponent(conversationId)}`;
+  const headers: Record<string, string> = {
+    ...browserHeaders(),
+    ...oaiHeaders(ctx.sessionId, ctx.deviceId),
+    Accept: "application/json",
+    Authorization: `Bearer ${ctx.accessToken}`,
+    Cookie: buildSessionCookieHeader(ctx.cookie),
+  };
+  if (ctx.accountId) headers["chatgpt-account-id"] = ctx.accountId;
+
+  try {
+    const response = await tlsFetchChatGpt(url, {
+      method: "GET",
+      headers,
+      timeoutMs: 30_000,
+      signal: ctx.signal,
+      // The native tls-client text path can surface UTF-8 JSON as mojibake
+      // (e.g. 👉 becomes ðŸ‘‰). Ask for raw bytes and decode as UTF-8 here so
+      // the final answer appended after Pro stream_handoff preserves Unicode.
+      byteResponse: true,
+    });
+    if (response.status >= 400) {
+      ctx.log?.warn?.(
+        "CGPT-WEB",
+        `conversation poll ${response.status}: ${(response.text || "").slice(0, 300)}`
+      );
+      return { detail: null, terminal: [401, 403, 404].includes(response.status) };
+    }
+    if (!response.text) return { detail: null, terminal: false };
+    return {
+      detail: JSON.parse(decodeUtf8DataUrl(response.text)) as ChatGptConversationDetail,
+      terminal: false,
+    };
+  } catch (err) {
+    ctx.log?.warn?.(
+      "CGPT-WEB",
+      `conversation poll failed: ${err instanceof Error ? err.message : String(err)}`
+    );
+    return { detail: null, terminal: false };
+  }
+}
+
+async function pollForFinalAssistantAnswer(
+  conversationId: string,
+  ctx: ResolverContext
+): Promise<FinalAssistantAnswer | null> {
+  const started = Date.now();
+  const timeoutMs = configuredProPollTimeoutMs();
+  const intervalMs = configuredProPollIntervalMs();
+  let last: FinalAssistantAnswer | null = null;
+  let terminalPollFailure = false;
+
+  while (!ctx.signal?.aborted && Date.now() - started < timeoutMs) {
+    const { detail, terminal } = await fetchConversationDetail(conversationId, ctx);
+    if (detail) {
+      const answer = extractFinalAssistantAnswer(detail);
+      if (answer) {
+        last = answer;
+        if (answer.finished) return answer;
+      }
+    }
+    if (terminal) {
+      terminalPollFailure = true;
+      break;
+    }
+    const remaining = timeoutMs - (Date.now() - started);
+    if (remaining <= 0) break;
+    await delayWithAbort(Math.min(intervalMs, remaining), ctx.signal);
+  }
+
+  if (last) {
+    ctx.log?.warn?.(
+      "CGPT-WEB",
+      terminalPollFailure
+        ? `conversation poll stopped before finished_successfully; returning latest assistant text for ${conversationId}`
+        : `conversation poll timed out before finished_successfully; returning latest assistant text for ${conversationId}`
+    );
+  } else {
+    ctx.log?.warn?.(
+      "CGPT-WEB",
+      terminalPollFailure
+        ? `conversation poll stopped without assistant text for ${conversationId}`
+        : `conversation poll timed out without assistant text for ${conversationId}`
+    );
+  }
+  return last;
 }
 
 // ─── OpenAI SSE format ──────────────────────────────────────────────────────
@@ -1474,6 +1755,11 @@ function buildStreamingResponse(
   // stream finishes without an image_asset_pointer. The executor passes a
   // closure here that knows how to poll the conversation endpoint.
   pollAsyncImage: ((conversationId: string) => Promise<ImagePointerRef[]>) | null,
+  // Optional poller for GPT-5.5 Pro's stream_handoff path. Inline text keeps
+  // streaming as-is; once ChatGPT hands off, we append the final assistant
+  // answer fetched from the conversation detail endpoint. Text requests stay
+  // in Temporary Chat, so these polls should not create sidebar/history items.
+  pollFinalAnswer: ((conversationId: string) => Promise<FinalAssistantAnswer | null>) | null,
   log: { warn?: (tag: string, msg: string) => void } | null,
   signal?: AbortSignal | null
 ): ReadableStream<Uint8Array> {
@@ -1501,11 +1787,79 @@ function buildStreamingResponse(
           let conversationId: string | null = null;
           let imagePointers: ImagePointerRef[] | undefined;
           let imageGenAsync = false;
+          let handoff = false;
+          let emittedText = "";
+          let polledFinalAnswer = "";
           let parentCandidateMessageId: string | null = null;
+
+          const emitTextDelta = (content: string): void => {
+            const cleaned = cleanChatGptText(content);
+            if (!cleaned) return;
+            emittedText += cleaned;
+            controller.enqueue(
+              encoder.encode(
+                sseChunk({
+                  id: cid,
+                  object: "chat.completion.chunk",
+                  created,
+                  model,
+                  system_fingerprint: null,
+                  choices: [
+                    {
+                      index: 0,
+                      delta: { content: cleaned },
+                      finish_reason: null,
+                      logprobs: null,
+                    },
+                  ],
+                })
+              )
+            );
+          };
+
+          const appendFinalAnswer = (text: string): void => {
+            const cleaned = cleanChatGptText(text);
+            const finalTrimmed = cleaned.trim();
+            if (!finalTrimmed) return;
+            const emittedTrimmed = emittedText.trim();
+            if (emittedTrimmed === finalTrimmed || emittedTrimmed.endsWith(finalTrimmed)) return;
+            const prefix = emittedTrimmed && !emittedText.endsWith("\n") ? "\n\n" : "";
+            emitTextDelta(`${prefix}${cleaned}`);
+          };
+
+          // Heartbeat: long async work (Pro polling, WebSocket image-gen,
+          // 2-3 MB image fetch) leaves the SSE quiet and Open WebUI times out
+          // at ~30s (`disconnect: ResponseAborted`). SSE comments and empty
+          // `delta:{}` chunks are both filtered upstream
+          // (`hasValuableContent` in open-sse/utils/streamHelpers.ts), so
+          // heartbeats are zero-width-space content deltas (`"​"`): they pass
+          // the filter and render invisibly.
+          const startHeartbeat = (intervalMs = 5_000): (() => void) => {
+            const heartbeatChunk = sseChunk({
+              id: cid,
+              object: "chat.completion.chunk",
+              created,
+              model,
+              system_fingerprint: null,
+              choices: [{ index: 0, delta: { content: "​" }, finish_reason: null, logprobs: null }],
+            });
+            const timer = setInterval(() => {
+              try {
+                controller.enqueue(encoder.encode(heartbeatChunk));
+              } catch {
+                // Controller may already be closed if the client disconnected
+                // — just stop firing.
+                console.warn("[chatgpt-web] heartbeat enqueue failed - controller closed");
+                clearInterval(timer);
+              }
+            }, intervalMs);
+            return () => clearInterval(timer);
+          };
 
           for await (const chunk of extractContent(eventStream, signal)) {
             if (chunk.conversationId) conversationId = chunk.conversationId;
             if (chunk.messageId) parentCandidateMessageId = chunk.messageId;
+            if (chunk.handoff) handoff = true;
             if (chunk.error) {
               controller.enqueue(
                 encoder.encode(
@@ -1532,67 +1886,36 @@ function buildStreamingResponse(
             if (chunk.done) {
               imagePointers = chunk.imagePointers;
               imageGenAsync = chunk.imageGenAsync ?? false;
+              handoff = handoff || (chunk.handoff ?? false);
               if (chunk.messageId) parentCandidateMessageId = chunk.messageId;
               break;
             }
 
             if (chunk.delta) {
-              const cleaned = cleanChatGptText(chunk.delta);
-              if (cleaned) {
-                controller.enqueue(
-                  encoder.encode(
-                    sseChunk({
-                      id: cid,
-                      object: "chat.completion.chunk",
-                      created,
-                      model,
-                      system_fingerprint: null,
-                      choices: [
-                        {
-                          index: 0,
-                          delta: { content: cleaned },
-                          finish_reason: null,
-                          logprobs: null,
-                        },
-                      ],
-                    })
-                  )
-                );
-              }
+              emitTextDelta(chunk.delta);
             }
+          }
+
+          if (pollFinalAnswer && conversationId && handoff) {
+            const stopHb = startHeartbeat();
+            try {
+              const polled = await pollFinalAnswer(conversationId);
+              if (polled?.text) {
+                polledFinalAnswer = polled.text;
+                if (polled.messageId) parentCandidateMessageId = polled.messageId;
+              }
+            } finally {
+              stopHb();
+            }
+          }
+
+          if (polledFinalAnswer) {
+            appendFinalAnswer(polledFinalAnswer);
           }
 
           // Async image_gen ends the SSE with a "Processing image..."
           // placeholder; poll the conversation endpoint in the background for
           // the final pointer (only when in-stream pointers are empty).
-          // Heartbeat: long async work (WebSocket image-gen, 2-3 MB image
-          // fetch) leaves the SSE quiet and Open WebUI times out at ~30s
-          // (`disconnect: ResponseAborted`). SSE comments and empty `delta:{}`
-          // chunks are both filtered upstream (`hasValuableContent` in
-          // open-sse/utils/streamHelpers.ts), so heartbeats are zero-width-space
-          // content deltas (`"​"`): they pass the filter and render invisibly.
-          const startHeartbeat = (intervalMs = 5_000): (() => void) => {
-            const heartbeatChunk = sseChunk({
-              id: cid,
-              object: "chat.completion.chunk",
-              created,
-              model,
-              system_fingerprint: null,
-              choices: [{ index: 0, delta: { content: "​" }, finish_reason: null, logprobs: null }],
-            });
-            const timer = setInterval(() => {
-              try {
-                controller.enqueue(encoder.encode(heartbeatChunk));
-              } catch {
-                // Controller may already be closed if the client disconnected
-                // — just stop firing.
-                console.warn("[chatgpt-web] heartbeat enqueue failed - controller closed");
-                clearInterval(timer);
-              }
-            }, intervalMs);
-            return () => clearInterval(timer);
-          };
-
           if (
             imageGenAsync &&
             conversationId &&
@@ -1754,6 +2077,7 @@ async function buildNonStreamingResponse(
   currentMsg: string,
   resolver: ImageResolver | null,
   pollAsyncImage: ((conversationId: string) => Promise<ImagePointerRef[]>) | null,
+  pollFinalAnswer: ((conversationId: string) => Promise<FinalAssistantAnswer | null>) | null,
   log: { warn?: (tag: string, msg: string) => void } | null,
   signal?: AbortSignal | null
 ): Promise<Response> {
@@ -1761,11 +2085,13 @@ async function buildNonStreamingResponse(
   let conversationId: string | null = null;
   let imagePointers: ImagePointerRef[] | undefined;
   let imageGenAsync = false;
+  let handoff = false;
   let parentCandidateMessageId: string | null = null;
 
   for await (const chunk of extractContent(eventStream, signal)) {
     if (chunk.conversationId) conversationId = chunk.conversationId;
     if (chunk.messageId) parentCandidateMessageId = chunk.messageId;
+    if (chunk.handoff) handoff = true;
     if (chunk.error) {
       return new Response(
         JSON.stringify({
@@ -1778,10 +2104,19 @@ async function buildNonStreamingResponse(
       fullAnswer = chunk.answer || fullAnswer;
       imagePointers = chunk.imagePointers;
       imageGenAsync = chunk.imageGenAsync ?? false;
+      handoff = handoff || (chunk.handoff ?? false);
       if (chunk.messageId) parentCandidateMessageId = chunk.messageId;
       break;
     }
     if (chunk.answer) fullAnswer = chunk.answer;
+  }
+
+  if (pollFinalAnswer && conversationId && (handoff || !fullAnswer.trim())) {
+    const polled = await pollFinalAnswer(conversationId);
+    if (polled?.text) {
+      fullAnswer = polled.text;
+      if (polled.messageId) parentCandidateMessageId = polled.messageId;
+    }
   }
 
   fullAnswer = cleanChatGptText(fullAnswer);
@@ -2557,18 +2892,16 @@ export class ChatGptWebExecutor extends BaseExecutor {
       log
     );
 
-    // 2a''. Apply thinking_effort preference for thinking-capable models.
-    // Mirrors what chatgpt.com's web UI does when the user toggles the
-    // "Standard"/"Extended" thinking switch — PATCH the user-config endpoint
-    // before issuing the conversation. The conversation request itself has
-    // no `thinking_effort` field; the server reads the stored preference at
-    // routing time. Best-effort: a failed PATCH falls back to whatever the
-    // account's current preference is.
-    const earlyModelSlug = MODEL_MAP[model] ?? model;
-    const requestedEffort = resolveThinkingEffort(body, credentials.providerSpecificData);
-    if (requestedEffort && isThinkingCapableModel(model, earlyModelSlug)) {
+    // 2a''. Resolve model + effort and apply thinking-effort preference for
+    // thinking-capable models. Dedicated thinking models mirror the browser's
+    // user-config PATCH; GPT-5.5 Pro sends the effort with the conversation
+    // body because the Pro standard/extended budget is part of that turn.
+    const resolvedModel = resolveChatGptModel(model, body, credentials.providerSpecificData);
+    const modelSlug = resolvedModel.slug;
+    const requestedEffort = resolvedModel.effort;
+    if (requestedEffort && isThinkingCapableModel(model, modelSlug)) {
       await setUserThinkingEffort(
-        earlyModelSlug,
+        modelSlug,
         requestedEffort,
         tokenEntry.accessToken,
         tokenEntry.accountId,
@@ -2660,13 +2993,13 @@ export class ChatGptWebExecutor extends BaseExecutor {
       };
     }
 
-    // Toggle Temporary Chat off only for image-generation requests, since
-    // Temporary Chat disables the image_gen tool. For plain text turns we
-    // keep Temporary Chat on so the user's chatgpt.com history isn't
-    // polluted with router traffic.
+    // Toggle Temporary Chat off only when ChatGPT needs a durable image
+    // conversation. Text requests, including GPT-5.5 Pro, stay temporary so
+    // they do not show up in the user's chatgpt.com sidebar/history.
     const imageEdit = looksLikeImageEditRequest(parsed);
     const continuation = imageEdit ? parsed.latestImageContext : null;
     const forImageGen = looksLikeImageGenRequest(parsed) || imageEdit;
+    const persistConversation = forImageGen || !!continuation;
     if (forImageGen) {
       log?.debug?.(
         "CGPT-WEB",
@@ -2674,17 +3007,16 @@ export class ChatGptWebExecutor extends BaseExecutor {
           ? "Image edit intent detected — continuing saved image conversation"
           : "Image-gen intent detected — disabling Temporary Chat for this turn"
       );
+    } else if (resolvedModel.isPro) {
+      log?.debug?.("CGPT-WEB", "GPT-5.5 Pro text request — keeping Temporary Chat enabled");
     }
 
     const parentMessageId = continuation?.parentMessageId ?? randomUUID();
-    const modelSlug = MODEL_MAP[model] ?? model;
-    const cgptBody = buildConversationBody(
-      parsed,
-      modelSlug,
-      parentMessageId,
-      forImageGen,
-      continuation
-    );
+    const cgptBody = buildConversationBody(parsed, modelSlug, parentMessageId, {
+      persistConversation,
+      thinkingEffort: requestedEffort,
+      continuation,
+    });
 
     const headers: Record<string, string> = {
       ...browserHeaders(),
@@ -2785,6 +3117,9 @@ export class ChatGptWebExecutor extends BaseExecutor {
     const imageResolver = makeImageResolver(resolverCtx);
     const pollAsyncImage = (conversationId: string) =>
       pollForAsyncImage(conversationId, resolverCtx);
+    const pollFinalAnswer = resolvedModel.isPro
+      ? (conversationId: string) => pollForFinalAssistantAnswer(conversationId, resolverCtx)
+      : null;
 
     // Tool mode buffers (no live streaming) and is gated off the image-gen path.
     const toolMode = hasTools && !forImageGen;
@@ -2798,6 +3133,7 @@ export class ChatGptWebExecutor extends BaseExecutor {
         created,
         imageResolver,
         pollAsyncImage,
+        pollFinalAnswer,
         log,
         signal
       );
@@ -2818,6 +3154,7 @@ export class ChatGptWebExecutor extends BaseExecutor {
         parsed.currentMsg,
         imageResolver,
         pollAsyncImage,
+        pollFinalAnswer,
         log,
         signal
       );

--- a/open-sse/services/chatgptTlsClient.ts
+++ b/open-sse/services/chatgptTlsClient.ts
@@ -14,7 +14,7 @@
 
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { mkdtemp, open, unlink, rmdir, stat } from "node:fs/promises";
+import { mkdtemp, open, unlink, rmdir, stat, readFile } from "node:fs/promises";
 import { randomUUID } from "node:crypto";
 
 let clientPromise: Promise<unknown> | null = null;
@@ -31,6 +31,8 @@ const DEFAULT_TIMEOUT_MS =
 // longer than the configured timeout when the binding is dead.
 const HARD_TIMEOUT_GRACE_MS =
   Number.parseInt(process.env.OMNIROUTE_CHATGPT_TLS_GRACE_MS || "", 10) || 10_000;
+const STREAM_FIRST_BYTE_TIMEOUT_MS =
+  Number.parseInt(process.env.OMNIROUTE_CHATGPT_STREAM_FIRST_BYTE_TIMEOUT_MS || "", 10) || 30_000;
 
 function installExitHook(): void {
   if (exitHookInstalled) return;
@@ -293,7 +295,8 @@ export async function tlsFetchChatGpt(
       requestOptions,
       options.streamEofSymbol,
       options.signal ?? null,
-      (options.timeoutMs ?? DEFAULT_TIMEOUT_MS) + HARD_TIMEOUT_GRACE_MS
+      (options.timeoutMs ?? DEFAULT_TIMEOUT_MS) + HARD_TIMEOUT_GRACE_MS,
+      STREAM_FIRST_BYTE_TIMEOUT_MS
     );
   }
 
@@ -350,7 +353,8 @@ async function tlsFetchStreaming(
   requestOptions: Record<string, unknown>,
   eofSymbol = "[DONE]",
   signal: AbortSignal | null = null,
-  hardTimeoutMs: number = DEFAULT_TIMEOUT_MS + HARD_TIMEOUT_GRACE_MS
+  hardTimeoutMs: number = DEFAULT_TIMEOUT_MS + HARD_TIMEOUT_GRACE_MS,
+  firstByteTimeoutMs: number = STREAM_FIRST_BYTE_TIMEOUT_MS
 ): Promise<TlsFetchResult> {
   const dir = await mkdtemp(join(tmpdir(), "cgpt-stream-"));
   const path = join(dir, `${randomUUID()}.sse`);
@@ -392,16 +396,21 @@ async function tlsFetchStreaming(
   // that race; if the request actually fails before producing any bytes,
   // the timeout falls through to the requestPromise drain below (returning
   // the real upstream status).
-  const ready = await waitForContent(path, 5_000, requestPromise);
+  const ready = await waitForContent(path, firstByteTimeoutMs, requestPromise);
   if (!ready) {
     const r = await requestPromise.catch(
       (e) => ({ status: 502, headers: {}, body: String(e) }) as TlsResponseLike
     );
+    // If the first byte arrived after our first-byte wait but before the
+    // request settled, tls-client-node may have written the full SSE body to
+    // streamOutputPath while leaving r.body empty. Prefer those captured bytes
+    // over misclassifying a successful delayed stream as "empty response body".
+    const fileText = await readTextFileIfExists(path);
     await cleanupTempPath(path);
     return {
       status: r.status,
       headers: toHeaders(r.headers),
-      text: r.body,
+      text: fileText || r.body,
       body: null,
     };
   }
@@ -417,11 +426,12 @@ async function tlsFetchStreaming(
     const r = await requestPromise.catch(
       (e) => ({ status: 502, headers: {}, body: String(e) }) as TlsResponseLike
     );
+    const fileText = await readTextFileIfExists(path);
     await cleanupTempPath(path);
     return {
       status: r.status,
       headers: toHeaders(r.headers),
-      text: r.body,
+      text: r.body || fileText,
       body: null,
     };
   }
@@ -455,6 +465,34 @@ async function cleanupTempPath(path: string): Promise<void> {
   await unlink(path).catch(() => {});
   const dir = path.substring(0, path.lastIndexOf("/"));
   await rmdir(dir).catch(() => {});
+}
+
+async function readTextFileIfExists(path: string): Promise<string> {
+  try {
+    return await readFile(path, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+export async function __tlsFetchStreamingForTesting(
+  client: { request: (url: string, opts: Record<string, unknown>) => Promise<unknown> },
+  url: string,
+  requestOptions: Record<string, unknown>,
+  eofSymbol = "[DONE]",
+  signal: AbortSignal | null = null,
+  hardTimeoutMs: number = DEFAULT_TIMEOUT_MS + HARD_TIMEOUT_GRACE_MS,
+  firstByteTimeoutMs: number = STREAM_FIRST_BYTE_TIMEOUT_MS
+): Promise<TlsFetchResult> {
+  return tlsFetchStreaming(
+    client as { request: (url: string, opts: Record<string, unknown>) => Promise<TlsResponseLike> },
+    url,
+    requestOptions,
+    eofSymbol,
+    signal,
+    hardTimeoutMs,
+    firstByteTimeoutMs
+  );
 }
 
 async function readFirstBytes(path: string, n: number): Promise<string> {

--- a/tests/unit/chatgpt-web.test.ts
+++ b/tests/unit/chatgpt-web.test.ts
@@ -1,20 +1,27 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { writeFile } from "node:fs/promises";
 
 const { ChatGptWebExecutor, __derivePublicBaseUrlForTesting, __resetChatGptWebCachesForTesting } =
   await import("../../open-sse/executors/chatgpt-web.ts");
 const { describeChatGptWebHttpError } =
   await import("../../open-sse/executors/chatgptWebErrors.ts");
 const { getExecutor, hasSpecializedExecutor } = await import("../../open-sse/executors/index.ts");
-const { __setTlsFetchOverrideForTesting, looksLikeSse, TlsClientUnavailableError } =
-  await import("../../open-sse/services/chatgptTlsClient.ts");
+const {
+  __setTlsFetchOverrideForTesting,
+  __tlsFetchStreamingForTesting,
+  looksLikeSse,
+  TlsClientUnavailableError,
+} = await import("../../open-sse/services/chatgptTlsClient.ts");
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
 function mockChatGptStreamText(events) {
   const chunks = [];
   for (const evt of events) {
-    chunks.push(`data: ${JSON.stringify(evt)}\r\n\r\n`);
+    const { __event, ...payload } = evt;
+    if (__event) chunks.push(`event: ${__event}\r\n`);
+    chunks.push(`data: ${JSON.stringify(payload)}\r\n\r\n`);
   }
   chunks.push("data: [DONE]\r\n\r\n");
   return chunks.join("");
@@ -65,6 +72,7 @@ function installMockFetch({
   dpl,
   fileDownload,
   attachmentDownload,
+  conversationDetail,
   signedDownload,
   userConfig,
   onSession,
@@ -81,6 +89,7 @@ function installMockFetch({
     conv: 0,
     fileDownload: 0,
     attachmentDownload: 0,
+    conversationDetail: 0,
     signedDownload: 0,
     userConfig: 0,
     userConfigUrls: [],
@@ -233,6 +242,45 @@ function installMockFetch({
         text: `data:image/png;base64,${tinyPng.toString("base64")}`,
         body: null,
       };
+    }
+
+    // /backend-api/conversation/<id> — detail poll used by GPT-5.5 Pro handoff.
+    {
+      const m1 = u.match(/\/backend-api\/conversation\/([^/?#]+)$/);
+      if (m1) {
+        calls.conversationDetail++;
+        const cfg = Array.isArray(conversationDetail)
+          ? (conversationDetail[
+              Math.min(calls.conversationDetail - 1, conversationDetail.length - 1)
+            ] ?? conversationDetail[conversationDetail.length - 1])
+          : (conversationDetail ?? {
+              status: 200,
+              body: {
+                mapping: {
+                  "msg-final": {
+                    message: {
+                      id: "msg-final",
+                      author: { role: "assistant" },
+                      content: { content_type: "text", parts: ["Final answer from poll."] },
+                      status: "finished_successfully",
+                      end_turn: true,
+                      create_time: 1,
+                      update_time: 1,
+                    },
+                  },
+                },
+              },
+            });
+        const text = typeof cfg.body === "string" ? cfg.body : JSON.stringify(cfg.body || {});
+        return {
+          status: cfg.status,
+          headers: makeHeaders({ "Content-Type": "application/json" }),
+          text: opts.byteResponse
+            ? `data:application/json;base64,${Buffer.from(text, "utf8").toString("base64")}`
+            : text,
+          body: null,
+        };
+      }
     }
 
     // Match only the exact conversation endpoint, not /conversations (plural — warmup).
@@ -743,6 +791,140 @@ test("Streaming: cumulative parts are diffed into non-overlapping deltas", async
   }
 });
 
+test("GPT-5.5 Pro non-streaming: stream_handoff polls conversation detail for final answer", async () => {
+  reset();
+  const m = installMockFetch({
+    conv: {
+      status: 200,
+      events: [
+        {
+          conversation_id: "conv-pro",
+          message: {
+            id: "progress-1",
+            author: { role: "assistant" },
+            content: { content_type: "text", parts: ["Working on it…"] },
+            status: "in_progress",
+          },
+        },
+        { __event: "stream_handoff", conversation_id: "conv-pro" },
+      ],
+    },
+    conversationDetail: {
+      status: 200,
+      body: {
+        mapping: {
+          thought: {
+            message: {
+              id: "thought",
+              author: { role: "assistant" },
+              content: { content_type: "thoughts", parts: ["hidden thinking"] },
+              status: "finished_successfully",
+              end_turn: true,
+              create_time: 1,
+              update_time: 1,
+            },
+          },
+          final: {
+            message: {
+              id: "final",
+              author: { role: "assistant" },
+              content: { content_type: "text", parts: ["👉 Final full Pro answer."] },
+              status: "finished_successfully",
+              end_turn: true,
+              create_time: 2,
+              update_time: 2,
+            },
+          },
+        },
+      },
+    },
+  });
+  try {
+    const executor = new ChatGptWebExecutor();
+    const result = await executor.execute({
+      model: "gpt-5-5-pro-extended",
+      body: { messages: [{ role: "user", content: "hard problem" }] },
+      stream: false,
+      credentials: { apiKey: "cookie-pro-poll" },
+      signal: AbortSignal.timeout(10_000),
+      log: null,
+    });
+
+    const json = await result.response.json();
+    assert.equal(json.choices[0].message.content, "👉 Final full Pro answer.");
+    assert.equal(m.calls.conversationDetail, 1);
+    const convIdx = m.calls.urls.findIndex((u) => u.endsWith("/backend-api/f/conversation"));
+    const sentBody = JSON.parse(m.calls.bodies[convIdx]);
+    assert.equal(sentBody.history_and_training_disabled, true);
+  } finally {
+    m.restore();
+  }
+});
+
+test("GPT-5.5 Pro streaming: preserves interim reasoning and appends final polled answer", async () => {
+  reset();
+  const m = installMockFetch({
+    conv: {
+      status: 200,
+      events: [
+        {
+          conversation_id: "conv-pro-stream",
+          message: {
+            id: "progress-1",
+            author: { role: "assistant" },
+            content: {
+              content_type: "text",
+              parts: ["<thinking>Interim reasoning text</thinking>"],
+            },
+            status: "in_progress",
+          },
+        },
+        { __event: "stream_handoff", conversation_id: "conv-pro-stream" },
+      ],
+    },
+    conversationDetail: {
+      status: 200,
+      body: {
+        mapping: {
+          final: {
+            message: {
+              id: "final-stream",
+              author: { role: "assistant" },
+              content: { content_type: "text", parts: ["👉 Final streamed Pro answer."] },
+              status: "finished_successfully",
+              end_turn: true,
+              create_time: 1,
+              update_time: 1,
+            },
+          },
+        },
+      },
+    },
+  });
+  try {
+    const executor = new ChatGptWebExecutor();
+    const result = await executor.execute({
+      model: "gpt-5-5-pro-extended",
+      body: { messages: [{ role: "user", content: "hard problem" }], stream: true },
+      stream: true,
+      credentials: { apiKey: "cookie-pro-stream" },
+      signal: AbortSignal.timeout(10_000),
+      log: null,
+    });
+
+    const text = await result.response.text();
+    assert.match(text, /<thinking>Interim reasoning text<\/thinking>/);
+    assert.match(text, /👉 Final streamed Pro answer\./);
+    assert.ok(
+      text.indexOf("👉 Final streamed Pro answer.") > text.indexOf("Interim reasoning text"),
+      "final polled answer should be appended after interim reasoning"
+    );
+    assert.equal(m.calls.conversationDetail, 1);
+  } finally {
+    m.restore();
+  }
+});
+
 // ─── Errors ─────────────────────────────────────────────────────────────────
 
 test("Error: 401 on /api/auth/session returns 401 with re-paste hint", async () => {
@@ -1092,30 +1274,34 @@ test("Provider registry: chatgpt-web exposes the current ChatGPT Web model catal
   // Mirrors /backend-api/models for ChatGPT Web. Retired GPT-5/GPT-5.1
   // entries should stay out of this list.
   assert.deepEqual(ids, [
-    "gpt-5.5-pro",
-    "gpt-5.5-thinking",
-    "gpt-5.5",
-    "gpt-5.4-pro",
-    "gpt-5.4-thinking",
-    "gpt-5.4-thinking-mini",
-    "gpt-5.3",
-    "gpt-5.3-mini",
+    "gpt-5-5-pro",
+    "gpt-5-5-pro-extended",
+    "gpt-5-5-thinking",
+    "gpt-5-5",
+    "gpt-5-4-pro",
+    "gpt-5-4-thinking",
+    "gpt-5-4-t-mini",
+    "gpt-5-3",
+    "gpt-5-3-mini",
     "o3",
   ]);
 });
 
-test("Executor MODEL_MAP: dot-form OmniRoute IDs translate to dash-form ChatGPT slugs", async () => {
+test("Executor MODEL_MAP: OmniRoute IDs translate to ChatGPT backend slugs", async () => {
   reset();
   const m = installMockFetch();
   try {
     const cases: Array<[string, string]> = [
+      ["gpt-5-3", "gpt-5-3"],
+      ["gpt-5-5-thinking", "gpt-5-5-thinking"],
+      ["gpt-5-4-t-mini", "gpt-5-4-t-mini"],
+      ["gpt-5-5-pro", "gpt-5-5-pro"],
+      ["gpt-5-5-pro-extended", "gpt-5-5-pro"],
+      ["o3", "o3"],
+      // Legacy dot-form ids are still accepted for direct provider/model callers.
       ["gpt-5.3", "gpt-5-3"],
       ["gpt-5.5-thinking", "gpt-5-5-thinking"],
       ["gpt-5.4-thinking-mini", "gpt-5-4-t-mini"],
-      ["o3", "o3"],
-      // Regression #4665: these advertised catalog ids were missing from
-      // MODEL_MAP and fell through as their dot-form slug verbatim, which the
-      // ChatGPT backend-api silently rejects → served the default Plus model.
       ["gpt-5.5", "gpt-5-5"],
       ["gpt-5.5-pro", "gpt-5-5-pro"],
       ["gpt-5.4-pro", "gpt-5-4-pro"],
@@ -1141,17 +1327,13 @@ test("Executor MODEL_MAP: dot-form OmniRoute IDs translate to dash-form ChatGPT 
   }
 });
 
-test("MODEL_MAP drift guard: every advertised dot-form catalog id resolves to a dash-form backend slug (no verbatim fall-through) (#4665)", async () => {
+test("MODEL_MAP drift guard: every advertised catalog id reaches ChatGPT as a backend slug", async () => {
   reset();
   const { getRegistryEntry } = await import("../../open-sse/config/providerRegistry.ts");
   const ids = (getRegistryEntry("chatgpt-web")?.models || []).map((m) => m.id);
-  // Dot-form ids must never reach the ChatGPT backend verbatim — the backend
-  // only accepts dash-form slugs. (Ids without a dot — e.g. "o3", or any
-  // already-slug-form id — pass through unchanged and are exempt.)
-  const dotFormIds = ids.filter((id) => id.includes("."));
   const m = installMockFetch();
   try {
-    for (const omniId of dotFormIds) {
+    for (const omniId of ids) {
       m.calls.urls.length = 0;
       m.calls.bodies.length = 0;
       const executor = new ChatGptWebExecutor();
@@ -1167,13 +1349,13 @@ test("MODEL_MAP drift guard: every advertised dot-form catalog id resolves to a 
       const body = JSON.parse(m.calls.bodies[convIdx]);
       assert.ok(
         !body.model.includes("."),
-        `${omniId} reached the backend as "${body.model}" (still dot-form) — missing MODEL_MAP entry causes silent model substitution`
+        `${omniId} reached the backend as "${body.model}" (still dot-form)`
       );
-      assert.notEqual(
-        body.model,
-        omniId,
-        `${omniId} fell through MODEL_MAP verbatim — add a dash-form mapping`
-      );
+      if (omniId.endsWith("-extended")) {
+        assert.equal(body.model, "gpt-5-5-pro", `${omniId} should select the base Pro slug`);
+      } else {
+        assert.equal(body.model, omniId, `${omniId} should pass through as its backend slug`);
+      }
     }
   } finally {
     m.restore();
@@ -1181,6 +1363,93 @@ test("MODEL_MAP drift guard: every advertised dot-form catalog id resolves to a 
 });
 
 // ─── thinking_effort PATCH user_last_used_model_config ─────────────────────
+
+test("GPT-5.5 Pro Extended sends base slug with extended effort and Temporary Chat", async () => {
+  reset();
+  const m = installMockFetch();
+  try {
+    const executor = new ChatGptWebExecutor();
+    const result = await executor.execute({
+      model: "gpt-5-5-pro-extended",
+      body: { messages: [{ role: "user", content: "hi" }] },
+      stream: false,
+      credentials: { apiKey: "cookie-pro-extended" },
+      signal: AbortSignal.timeout(10_000),
+      log: null,
+    });
+    assert.equal(result.response.status, 200);
+    const convIdx = m.calls.urls.findIndex((u) => u.endsWith("/backend-api/f/conversation"));
+    const body = JSON.parse(m.calls.bodies[convIdx]);
+    assert.equal(body.model, "gpt-5-5-pro");
+    assert.equal(body.thinking_effort, "extended");
+    assert.equal(body.history_and_training_disabled, true);
+    assert.equal(
+      m.calls.userConfig,
+      0,
+      "Pro effort is sent with the turn, not PATCHed as a thinking-model preference"
+    );
+  } finally {
+    m.restore();
+  }
+});
+
+test("GPT-5.5 Pro standard sends standard effort", async () => {
+  reset();
+  const m = installMockFetch();
+  try {
+    const executor = new ChatGptWebExecutor();
+    await executor.execute({
+      model: "gpt-5-5-pro",
+      body: { messages: [{ role: "user", content: "hi" }] },
+      stream: false,
+      credentials: { apiKey: "cookie-pro-standard" },
+      signal: AbortSignal.timeout(10_000),
+      log: null,
+    });
+    const convIdx = m.calls.urls.findIndex((u) => u.endsWith("/backend-api/f/conversation"));
+    const body = JSON.parse(m.calls.bodies[convIdx]);
+    assert.equal(body.model, "gpt-5-5-pro");
+    assert.equal(body.thinking_effort, "standard");
+    assert.equal(body.history_and_training_disabled, true);
+  } finally {
+    m.restore();
+  }
+});
+
+test("GPT-5.5 Pro store:false keeps Temporary Chat enabled for background utility calls", async () => {
+  reset();
+  const m = installMockFetch();
+  try {
+    const executor = new ChatGptWebExecutor();
+    const result = await executor.execute({
+      model: "gpt-5-5-pro-extended",
+      body: {
+        store: false,
+        messages: [
+          { role: "system", content: "You are a session namer." },
+          { role: "user", content: "Generate a short session name." },
+        ],
+      },
+      stream: false,
+      credentials: { apiKey: "cookie-pro-store-false" },
+      signal: AbortSignal.timeout(10_000),
+      log: null,
+    });
+    assert.equal(result.response.status, 200);
+    const convIdx = m.calls.urls.findIndex((u) => u.endsWith("/backend-api/f/conversation"));
+    const body = JSON.parse(m.calls.bodies[convIdx]);
+    assert.equal(body.model, "gpt-5-5-pro");
+    assert.equal(body.thinking_effort, "extended");
+    assert.equal(body.history_and_training_disabled, true);
+    assert.equal(
+      m.calls.conversationDetail,
+      0,
+      "no final-answer poll is needed when the stream did not hand off"
+    );
+  } finally {
+    m.restore();
+  }
+});
 
 test("thinking_effort: high → PATCH user_last_used_model_config with extended", async () => {
   reset();
@@ -1871,6 +2140,48 @@ test("looksLikeSse: rejects non-SSE bodies that previously passed as 200", () =>
   assert.equal(looksLikeSse(""), false, "empty body");
   assert.equal(looksLikeSse("   \n\n"), false, "whitespace only");
   assert.equal(looksLikeSse("error: rate limit"), false, "non-SSE field name");
+});
+
+test("tls streaming: late first byte is read from streamOutputPath instead of empty body", async () => {
+  const fakeClient = {
+    async request(_url, opts) {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      await writeFile(
+        String(opts.streamOutputPath),
+        mockChatGptStreamText([
+          {
+            conversation_id: "conv-late",
+            message: {
+              id: "msg-late",
+              author: { role: "assistant" },
+              content: { content_type: "text", parts: ["Late title answer"] },
+              status: "finished_successfully",
+            },
+          },
+        ]),
+        "utf8"
+      );
+      return {
+        status: 200,
+        headers: { "content-type": ["text/event-stream"] },
+        body: "",
+      };
+    },
+  };
+
+  const result = await __tlsFetchStreamingForTesting(
+    fakeClient,
+    "https://chatgpt.com/backend-api/f/conversation",
+    { method: "POST" },
+    "[DONE]",
+    null,
+    1_000,
+    5
+  );
+
+  assert.equal(result.status, 200);
+  assert.equal(result.body, null);
+  assert.match(result.text ?? "", /Late title answer/);
 });
 
 // ─── Image generation ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

This PR updates the ChatGPT Web (`chatgpt-web` / `cgpt-web`) executor to support GPT-5.5 Pro's long-running handoff behavior while preserving OmniRoute's existing public model designation style.

Public/provider-facing model IDs remain dot-form:

- `cgpt-web/gpt-5.5-pro` — GPT-5.5 Pro, standard effort
- `cgpt-web/gpt-5.5-pro-extended` — GPT-5.5 Pro, extended effort

ChatGPT's backend still receives the current dash-form upstream slug (`gpt-5-5-pro`). Backend dash-form IDs are also accepted directly as compatibility aliases, but they are not the catalog designation exposed by `cgpt-web`.

Key changes:

- Keep the ChatGPT Web provider catalog in OmniRoute's historical dot-form naming.
- Add new public model `gpt-5.5-pro-extended` for the extended Pro effort mode.
- Route both public Pro IDs to ChatGPT's upstream `gpt-5-5-pro` slug.
- Encode Pro effort by model ID:
  - `gpt-5.5-pro` → `thinking_effort: "standard"`
  - `gpt-5.5-pro-extended` → `thinking_effort: "extended"`
- Send Pro effort on the conversation body instead of PATCHing `user_last_used_model_config`.
- Parse SSE `event:` fields so ChatGPT's `stream_handoff` event is detected.
- Poll `/backend-api/conversation/:conversationId` after a Pro handoff to retrieve the final assistant answer.
- Preserve streamed interim text / reasoning / `<thinking>` deltas, then append the final polled answer after handoff.
- Keep Pro text requests in Temporary Chat (`history_and_training_disabled: true`) so OmniRoute requests do not appear in ChatGPT Web UI history; image generation/editing still disables Temporary Chat because ChatGPT's image tooling requires durable conversation state.
- Decode conversation-detail polling responses from byte/base64 form as UTF-8 to avoid mojibake for emoji and other non-ASCII text.
- Harden ChatGPT TLS streaming when upstream takes longer to emit the first byte:
  - first-byte wait is configurable and defaults to 30s
  - late stream bytes written to `streamOutputPath` are read back instead of incorrectly surfacing an empty 502 response

## Why

ChatGPT Web's Pro model can use a handoff-style response path: the initial SSE stream hands off to a long-running backend worker, with the final answer appearing in the conversation detail endpoint rather than as ordinary SSE deltas.

Before this change:

- `gpt-5.5-pro` had only one public effort mode
- Pro standard/extended effort was not represented as distinct callable models
- `stream_handoff` was not handled
- final Pro answers could be missed or reported as empty/failed
- UTF-8 text from polled final answers could be mojibaked
- delayed first-byte streams could be misclassified as `502 ChatGPT returned empty response body`

## Privacy / history behavior

Text requests, including GPT-5.5 Pro and background utility calls such as title/session naming, are kept in Temporary Chat. They should not create ChatGPT sidebar/history entries.

The only path that still turns Temporary Chat off is image generation/editing, matching the existing behavior needed for ChatGPT's image tools.

## Testing

- `DISABLE_SQLITE_AUTO_BACKUP=true node --max-old-space-size=8192 --import tsx --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test --test-force-exit tests/unit/chatgpt-web.test.ts`
  - 86/86 passing
- `npm run check:provider-consistency`
- `npx prettier --check open-sse/services/chatgptTlsClient.ts open-sse/executors/chatgpt-web.ts open-sse/config/providers/registry/chatgpt-web/index.ts tests/unit/chatgpt-web.test.ts`
- `npx eslint open-sse/services/chatgptTlsClient.ts open-sse/executors/chatgpt-web.ts open-sse/config/providers/registry/chatgpt-web/index.ts tests/unit/chatgpt-web.test.ts`
  - no errors; existing `no-explicit-any` warnings remain in `tests/unit/chatgpt-web.test.ts`
- Docker smoke test locally:
  - `docker compose --profile base up -d --build omniroute-base`
  - `omniroute` healthy on `http://127.0.0.1:20128`
