### PR TITLE
fix(build): keep ioredis out of the client/CLI bundle (dast-smoke regression)

### DIFF
--- a/src/server/authz/routeGuard.ts
+++ b/src/server/authz/routeGuard.ts
@@ -22,6 +22,7 @@
  */
 
 import { getAuthzBypassSnapshot } from "@/lib/config/runtimeSettings";
+import { SPAWN_CAPABLE_PREFIXES } from "@/shared/constants/spawnCapablePrefixes";
 
 const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
 
@@ -59,31 +60,13 @@ export const LOCAL_ONLY_API_PATTERNS: ReadonlyArray<RegExp> = [
   /^\/api\/providers\/[^/]+\/login\/?$/,
 ];
 
-/**
- * Compile-time deny-list: route prefixes that can spawn arbitrary local
- * subprocesses on behalf of the caller. These MUST NEVER appear in the
- * manage-scope bypass list — regardless of DB state — because reaching them
- * from non-loopback would re-introduce the GHSA-fhh6-4qxv-rpqj surface that
- * the LOCAL_ONLY tier exists to close.
- *
- * Enforced at two layers:
- *   1. zod schema (`settingsSchemas.ts`): rejects `PATCH /api/settings` with
- *      error code `BYPASS_PREFIX_NOT_ALLOWED` if any entry in
- *      `localOnlyManageScopeBypassPrefixes` falls inside this set.
- *   2. runtime (`isLocalOnlyBypassableByManageScope` below): even if a
- *      malformed DB row somehow claims a spawn-capable path is bypassable,
- *      the policy still refuses to honour it.
- */
-export const SPAWN_CAPABLE_PREFIXES: ReadonlyArray<string> = [
-  "/api/cli-tools/runtime/",
-  "/api/services/", // T-10: can run npm install + spawn node processes
-  "/api/tools/agent-bridge/", // start/stop MITM server + DNS edits (Hard Rules #15 + #17)
-  "/api/tools/traffic-inspector/", // http-proxy listener + system proxy (Hard Rules #15 + #17)
-  "/api/plugins/", // plugins: load/execute via worker_threads + child_process (Hard Rules #15 + #17)
-  "/api/local/", // T-12: 1-click local service launchers (Redis today) — must never be whitelistable via manage-scope bypass (Hard Rules #15 + #17)
-  "/api/headroom/start", // spawns headroom-ai python CLI — must never be bypassable (Hard Rules #15 + #17)
-  "/api/headroom/stop", // kills tracked PID — must never be bypassable (Hard Rules #15 + #17)
-];
+// `SPAWN_CAPABLE_PREFIXES` (the spawn-capable deny-list) now lives in the
+// server-free leaf module `@/shared/constants/spawnCapablePrefixes` so that
+// client-reachable validation schemas can import it without pulling this module's
+// server runtime (runtimeSettings → localDb → ioredis) into the browser bundle.
+// Imported above for the runtime check in `isLocalOnlyBypassableByManageScope`;
+// re-exported here so existing `@/server/authz/routeGuard` importers keep working.
+export { SPAWN_CAPABLE_PREFIXES };
 
 /**
  * Compile-time default of the manage-scope bypass list. Kept as an exported

--- a/src/shared/constants/spawnCapablePrefixes.ts
+++ b/src/shared/constants/spawnCapablePrefixes.ts
@@ -1,0 +1,35 @@
+/**
+ * Compile-time deny-list: route prefixes whose handlers can spawn arbitrary local
+ * subprocesses (npm install, node, MITM server, python CLIs) on behalf of the
+ * caller. These MUST NEVER appear in the manage-scope bypass list — regardless of
+ * DB state — because reaching them from non-loopback would re-introduce the
+ * GHSA-fhh6-4qxv-rpqj surface that the LOCAL_ONLY tier exists to close.
+ *
+ * Enforced at two layers:
+ *   1. zod schema (`settingsSchemas.ts`): rejects `PATCH /api/settings` with error
+ *      code `BYPASS_PREFIX_NOT_ALLOWED` if any entry in
+ *      `localOnlyManageScopeBypassPrefixes` falls inside this set.
+ *   2. runtime (`isLocalOnlyBypassableByManageScope` in `routeGuard.ts`): even if a
+ *      malformed DB row claims a spawn-capable path is bypassable, the policy refuses.
+ *
+ * 🔒 This constant lives in `@/shared/constants` — a server-free leaf module — and
+ * NOT in `@/server/authz/routeGuard`, on purpose. `settingsSchemas.ts` is reachable
+ * from client components (dashboard onboarding wizard → validation barrel), and
+ * importing it from `routeGuard.ts` dragged routeGuard's server runtime
+ * (runtimeSettings → localDb → apiKeys → rateLimiter → ioredis) into the browser
+ * bundle, breaking the Next CLI/client webpack build with
+ * `Module not found: Can't resolve 'dns'/'net'`. Keeping the value here lets both the
+ * client-safe schema and the server routeGuard import it with no server coupling.
+ * Regression guard: `tests/unit/authz/spawn-capable-prefixes-client-safe.test.ts`.
+ * Hard Rules #15 + #17.
+ */
+export const SPAWN_CAPABLE_PREFIXES: ReadonlyArray<string> = [
+  "/api/cli-tools/runtime/",
+  "/api/services/", // T-10: can run npm install + spawn node processes
+  "/api/tools/agent-bridge/", // start/stop MITM server + DNS edits (Hard Rules #15 + #17)
+  "/api/tools/traffic-inspector/", // http-proxy listener + system proxy (Hard Rules #15 + #17)
+  "/api/plugins/", // plugins: load/execute via worker_threads + child_process (Hard Rules #15 + #17)
+  "/api/local/", // T-12: 1-click local service launchers (Redis today) — must never be whitelistable via manage-scope bypass (Hard Rules #15 + #17)
+  "/api/headroom/start", // spawns headroom-ai python CLI — must never be bypassable (Hard Rules #15 + #17)
+  "/api/headroom/stop", // kills tracked PID — must never be bypassable (Hard Rules #15 + #17)
+];

--- a/src/shared/validation/settingsSchemas.ts
+++ b/src/shared/validation/settingsSchemas.ts
@@ -12,7 +12,10 @@ import { HIDEABLE_SIDEBAR_GROUP_IDS } from "@/shared/constants/sidebarGroupVisib
 import { HIDEABLE_SIDEBAR_ITEM_IDS, SIDEBAR_SECTIONS } from "@/shared/constants/sidebarVisibility";
 import { ACCOUNT_FALLBACK_STRATEGY_VALUES } from "@/shared/constants/routingStrategies";
 import { RESPONSES_PREVIOUS_RESPONSE_ID_MODES } from "@/shared/constants/responsesPreviousResponseId";
-import { SPAWN_CAPABLE_PREFIXES } from "@/server/authz/routeGuard";
+// Import from the server-free constants leaf, NOT from `@/server/authz/routeGuard`:
+// this schema is reachable from client components (dashboard onboarding wizard), and
+// routeGuard drags in server runtime (→ ioredis) that breaks the client/CLI build.
+import { SPAWN_CAPABLE_PREFIXES } from "@/shared/constants/spawnCapablePrefixes";
 
 const signatureCacheModeValues = ["enabled", "bypass", "bypass-strict"] as const;
 

--- a/tests/unit/authz/spawn-capable-prefixes-client-safe.test.ts
+++ b/tests/unit/authz/spawn-capable-prefixes-client-safe.test.ts
@@ -1,0 +1,89 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { SPAWN_CAPABLE_PREFIXES } from "@/shared/constants/spawnCapablePrefixes";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+const VALIDATION_DIR = join(ROOT, "src/shared/validation");
+
+function walkTsFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...walkTsFiles(full));
+    else if (/\.tsx?$/.test(entry) && !/\.test\.tsx?$/.test(entry)) out.push(full);
+  }
+  return out;
+}
+
+/**
+ * Returns the VALUE-import specifiers in `src` (i.e. imports that survive to the
+ * runtime bundle). `import type …` is excluded — it is erased by the compiler/SWC and
+ * never creates a webpack bundle edge, so it cannot leak a Node-only dep into a
+ * client bundle.
+ */
+function valueImportSpecifiers(src: string): string[] {
+  const specs: string[] = [];
+  // import [type] [<clause> from] "<spec>"  — `[^"';]*?` spans multi-line clauses.
+  const re = /\bimport\s+(type\s+)?(?:[^"';]*?\bfrom\s*)?["']([^"']+)["']/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(src))) {
+    if (m[1]) continue; // `import type …` — erased, not a runtime edge
+    specs.push(m[2]);
+  }
+  return specs;
+}
+
+// Regression guard for the dast-smoke "Build CLI bundle" failure:
+//   Module not found: Can't resolve 'dns' / 'net'  (./node_modules/ioredis/...)
+// Root cause: `settingsSchemas.ts` VALUE-imported SPAWN_CAPABLE_PREFIXES from
+// `@/server/authz/routeGuard`, whose server runtime (runtimeSettings → localDb →
+// apiKeys → rateLimiter → ioredis) then got dragged into the client/CLI webpack bundle
+// via the dashboard onboarding wizard → validation barrel chain. Validation schemas are
+// client-reachable and MUST depend only on zod + `@/shared` leaves — never on the
+// server (`@/server/…`) or server-side lib (`@/lib/…`, which reaches the DB/ioredis).
+const FORBIDDEN_VALUE_ROOTS = ["@/server/", "@/lib/"];
+
+test("validation schemas must not VALUE-import from server-side roots (client/CLI build safety)", () => {
+  const offenders: string[] = [];
+  for (const file of walkTsFiles(VALIDATION_DIR)) {
+    const rel = file.slice(ROOT.length + 1);
+    for (const spec of valueImportSpecifiers(readFileSync(file, "utf8"))) {
+      if (FORBIDDEN_VALUE_ROOTS.some((root) => spec.startsWith(root))) {
+        offenders.push(`${rel} → ${spec}`);
+      }
+    }
+  }
+  assert.deepEqual(
+    offenders,
+    [],
+    "Client-reachable validation schemas VALUE-import server-side modules, which drags the " +
+      "server runtime (→ ioredis) into the browser/CLI bundle and breaks the Next build with " +
+      `"Can't resolve 'dns'/'net'". Move the needed value to a server-free @/shared/constants ` +
+      `leaf (see src/shared/constants/spawnCapablePrefixes.ts). Offenders:\n  ${offenders.join("\n  ")}`
+  );
+});
+
+test("SPAWN_CAPABLE_PREFIXES is defined in the server-free constants leaf with the expected entries", () => {
+  assert.ok(Array.isArray(SPAWN_CAPABLE_PREFIXES));
+  // The full deny-list survived the extraction out of routeGuard.ts (Hard Rules #15/#17).
+  for (const prefix of [
+    "/api/cli-tools/runtime/",
+    "/api/services/",
+    "/api/tools/agent-bridge/",
+    "/api/tools/traffic-inspector/",
+    "/api/plugins/",
+    "/api/local/",
+    "/api/headroom/start",
+    "/api/headroom/stop",
+  ]) {
+    assert.ok(
+      SPAWN_CAPABLE_PREFIXES.includes(prefix),
+      `SPAWN_CAPABLE_PREFIXES lost the spawn-capable prefix "${prefix}" during extraction`
+    );
+  }
+  assert.equal(SPAWN_CAPABLE_PREFIXES.length, 8);
+});


### PR DESCRIPTION
## Fix the `dast-smoke` "Build CLI bundle" regression (ioredis → client bundle)

### Symptom
Every fresh PR into `release/v3.8.42` failed the `dast-smoke` job's **Build CLI bundle** step (and would break the real CLI/client build) with:

```
Module not found: Can't resolve 'dns'
Module not found: Can't resolve 'net'
./node_modules/ioredis/built/cluster/...
```

It was **not** PR-specific: PRs touching only a test file (#5514) and only `.npmrc`/docs (#5506) both hit the identical error — a shared base regression.

### Root cause
A **client component** transitively bundled `ioredis` (a Node-only package). Webpack import trace:

```
ProviderOnboardingWizard.tsx  (client)
  → providerOnboardingApi.ts → @/shared/validation/schemas → settingsSchemas.ts
  → @/server/authz/routeGuard   ← settingsSchemas VALUE-imported SPAWN_CAPABLE_PREFIXES here
  → runtimeSettings → localDb → apiKeys → rateLimiter → ioredis
```

`settingsSchemas.ts` is a **client-reachable validation schema** that value-imported the `SPAWN_CAPABLE_PREFIXES` constant from `@/server/authz/routeGuard`. routeGuard's top-level `import … runtimeSettings` drags the whole server runtime — down to `ioredis` — into the browser bundle, where `dns`/`net` don't resolve.

### Fix
Extract the pure `SPAWN_CAPABLE_PREFIXES` deny-list into a **server-free leaf**, `src/shared/constants/spawnCapablePrefixes.ts`:
- `settingsSchemas.ts` imports it from there (no more `@/server/*` edge).
- `routeGuard.ts` imports **and re-exports** it (back-compat for `localEndpoints.ts`, the authz-inventory route, and the existing authz tests).

No runtime behavior changes — same constant, same enforcement at both layers (zod schema + `isLocalOnlyBypassableByManageScope`).

### Validation (TDD — Hard Rule #18)
- New regression guard `tests/unit/authz/spawn-capable-prefixes-client-safe.test.ts`: asserts no validation schema **value-imports** from `@/server/` or `@/lib/` (type-only imports, erased by SWC, are correctly ignored) + the deny-list survived extraction (8 entries). **Proven red→green**: reverting the import makes it fail; the fix makes it pass.
- A static import-graph reachability check confirms `ProviderOnboardingWizard.tsx` no longer reaches `ioredis` (the other BFS hits — `batch/page.tsx` etc. — are `import type`/SWC-elided types, not real bundle edges).
- `npm run typecheck:core` clean · `npm run check:cycles` clean (new module is a leaf) · existing `routeGuard.test.ts` (29) + `route-guard-local-prefix.test.ts` (5) green.

Closes the dast-smoke base regression that forced #5506 to merge with `--admin`.
