### PR TITLE
fix(chatgpt-web): restore dot-form Pro model ids

### DIFF
--- a/open-sse/config/providers/registry/chatgpt-web/index.ts
+++ b/open-sse/config/providers/registry/chatgpt-web/index.ts
@@ -9,15 +9,15 @@ export const chatgpt_webProvider: RegistryEntry = {
   authType: "apikey",
   authHeader: "cookie",
   models: [
-    { id: "gpt-5-5-pro", name: "GPT-5.5 Pro" }, // pro tier only, standard effort
-    { id: "gpt-5-5-pro-extended", name: "GPT-5.5 Pro Extended" }, // pro tier only, extended effort
-    { id: "gpt-5-5-thinking", name: "GPT-5.5 Thinking" }, // plus, pro tier
-    { id: "gpt-5-5", name: "GPT-5.5 Instant" }, // free, plus, pro tier
-    { id: "gpt-5-4-pro", name: "GPT-5.4 Pro" }, // pro tier only
-    { id: "gpt-5-4-thinking", name: "GPT-5.4 Thinking" }, // plus, pro tier
-    { id: "gpt-5-4-t-mini", name: "GPT-5.4 Thinking Mini" }, // free-login only
-    { id: "gpt-5-3", name: "GPT-5.3 Instant" }, // free, free-login, plus, pro tier
-    { id: "gpt-5-3-mini", name: "GPT-5.3 Mini" }, // limit fallback
+    { id: "gpt-5.5-pro", name: "GPT-5.5 Pro" }, // pro tier only, standard effort
+    { id: "gpt-5.5-pro-extended", name: "GPT-5.5 Pro Extended" }, // pro tier only, extended effort
+    { id: "gpt-5.5-thinking", name: "GPT-5.5 Thinking" }, // plus, pro tier
+    { id: "gpt-5.5", name: "GPT-5.5 Instant" }, // free, plus, pro tier
+    { id: "gpt-5.4-pro", name: "GPT-5.4 Pro" }, // pro tier only
+    { id: "gpt-5.4-thinking", name: "GPT-5.4 Thinking" }, // plus, pro tier
+    { id: "gpt-5.4-thinking-mini", name: "GPT-5.4 Thinking Mini" }, // free-login only
+    { id: "gpt-5.3", name: "GPT-5.3 Instant" }, // free, free-login, plus, pro tier
+    { id: "gpt-5.3-mini", name: "GPT-5.3 Mini" }, // limit fallback
     { id: "o3", name: "o3" }, // plus ~ tier
   ],
 };

--- a/open-sse/executors/chatgpt-web.ts
+++ b/open-sse/executors/chatgpt-web.ts
@@ -79,13 +79,13 @@ function deviceIdFor(cookie: string): string {
   return id;
 }
 
-// OmniRoute model ID → ChatGPT internal slug. OmniRoute uses dot-form IDs
-// (e.g. "gpt-5.3-instant"), ChatGPT's web routes use dash-form
-// (e.g. "gpt-5-3-instant"). The slug catalog comes from
-// /backend-api/models on a logged-in account; "gpt-5-4-t-mini" is ChatGPT's
-// abbreviated slug for "GPT-5.4 Thinking Mini".
+// OmniRoute model ID → ChatGPT internal slug. The public ChatGPT Web catalog
+// keeps OmniRoute's historical dot-form IDs (e.g. "gpt-5.5-pro"), while
+// ChatGPT's backend routes use dash-form slugs (e.g. "gpt-5-5-pro"). The slug
+// catalog comes from /backend-api/models on a logged-in account;
+// "gpt-5-4-t-mini" is ChatGPT's abbreviated slug for "GPT-5.4 Thinking Mini".
 const MODEL_MAP: Record<string, string> = {
-  // Current ChatGPT Web slugs (these are what the provider catalog exposes).
+  // ChatGPT backend slugs are also accepted directly for power users / tests.
   "gpt-5-5-pro": "gpt-5-5-pro",
   "gpt-5-5-pro-extended": "gpt-5-5-pro",
   "gpt-5-5-thinking": "gpt-5-5-thinking",
@@ -96,7 +96,7 @@ const MODEL_MAP: Record<string, string> = {
   "gpt-5-3": "gpt-5-3",
   "gpt-5-3-mini": "gpt-5-3-mini",
 
-  // Legacy OmniRoute dot-form aliases kept for direct provider/model callers.
+  // Public OmniRoute dot-form ids exposed by the provider catalog.
   "gpt-5.5-pro": "gpt-5-5-pro",
   "gpt-5.5-pro-extended": "gpt-5-5-pro",
   "gpt-5.5-thinking": "gpt-5-5-thinking",

--- a/tests/unit/chatgpt-web.test.ts
+++ b/tests/unit/chatgpt-web.test.ts
@@ -842,7 +842,7 @@ test("GPT-5.5 Pro non-streaming: stream_handoff polls conversation detail for fi
   try {
     const executor = new ChatGptWebExecutor();
     const result = await executor.execute({
-      model: "gpt-5-5-pro-extended",
+      model: "gpt-5.5-pro-extended",
       body: { messages: [{ role: "user", content: "hard problem" }] },
       stream: false,
       credentials: { apiKey: "cookie-pro-poll" },
@@ -904,7 +904,7 @@ test("GPT-5.5 Pro streaming: preserves interim reasoning and appends final polle
   try {
     const executor = new ChatGptWebExecutor();
     const result = await executor.execute({
-      model: "gpt-5-5-pro-extended",
+      model: "gpt-5.5-pro-extended",
       body: { messages: [{ role: "user", content: "hard problem" }], stream: true },
       stream: true,
       credentials: { apiKey: "cookie-pro-stream" },
@@ -1271,18 +1271,19 @@ test("Provider registry: chatgpt-web exposes the current ChatGPT Web model catal
   assert.equal(entry.authHeader, "cookie");
 
   const ids = (entry.models || []).map((m) => m.id);
-  // Mirrors /backend-api/models for ChatGPT Web. Retired GPT-5/GPT-5.1
-  // entries should stay out of this list.
+  // Public OmniRoute ids stay in historical dot form even though ChatGPT's
+  // backend routes use dash-form slugs. Retired GPT-5/GPT-5.1 entries should
+  // stay out of this list.
   assert.deepEqual(ids, [
-    "gpt-5-5-pro",
-    "gpt-5-5-pro-extended",
-    "gpt-5-5-thinking",
-    "gpt-5-5",
-    "gpt-5-4-pro",
-    "gpt-5-4-thinking",
-    "gpt-5-4-t-mini",
-    "gpt-5-3",
-    "gpt-5-3-mini",
+    "gpt-5.5-pro",
+    "gpt-5.5-pro-extended",
+    "gpt-5.5-thinking",
+    "gpt-5.5",
+    "gpt-5.4-pro",
+    "gpt-5.4-thinking",
+    "gpt-5.4-thinking-mini",
+    "gpt-5.3",
+    "gpt-5.3-mini",
     "o3",
   ]);
 });
@@ -1292,19 +1293,21 @@ test("Executor MODEL_MAP: OmniRoute IDs translate to ChatGPT backend slugs", asy
   const m = installMockFetch();
   try {
     const cases: Array<[string, string]> = [
-      ["gpt-5-3", "gpt-5-3"],
-      ["gpt-5-5-thinking", "gpt-5-5-thinking"],
-      ["gpt-5-4-t-mini", "gpt-5-4-t-mini"],
-      ["gpt-5-5-pro", "gpt-5-5-pro"],
-      ["gpt-5-5-pro-extended", "gpt-5-5-pro"],
-      ["o3", "o3"],
-      // Legacy dot-form ids are still accepted for direct provider/model callers.
+      // Public catalog ids.
       ["gpt-5.3", "gpt-5-3"],
       ["gpt-5.5-thinking", "gpt-5-5-thinking"],
       ["gpt-5.4-thinking-mini", "gpt-5-4-t-mini"],
       ["gpt-5.5", "gpt-5-5"],
       ["gpt-5.5-pro", "gpt-5-5-pro"],
+      ["gpt-5.5-pro-extended", "gpt-5-5-pro"],
       ["gpt-5.4-pro", "gpt-5-4-pro"],
+      ["o3", "o3"],
+      // Backend dash-form slugs are still accepted for direct provider/model callers.
+      ["gpt-5-3", "gpt-5-3"],
+      ["gpt-5-5-thinking", "gpt-5-5-thinking"],
+      ["gpt-5-4-t-mini", "gpt-5-4-t-mini"],
+      ["gpt-5-5-pro", "gpt-5-5-pro"],
+      ["gpt-5-5-pro-extended", "gpt-5-5-pro"],
     ];
     for (const [omniId, expectedSlug] of cases) {
       m.calls.urls.length = 0;
@@ -1331,6 +1334,18 @@ test("MODEL_MAP drift guard: every advertised catalog id reaches ChatGPT as a ba
   reset();
   const { getRegistryEntry } = await import("../../open-sse/config/providerRegistry.ts");
   const ids = (getRegistryEntry("chatgpt-web")?.models || []).map((m) => m.id);
+  const expectedSlugById: Record<string, string> = {
+    "gpt-5.5-pro": "gpt-5-5-pro",
+    "gpt-5.5-pro-extended": "gpt-5-5-pro",
+    "gpt-5.5-thinking": "gpt-5-5-thinking",
+    "gpt-5.5": "gpt-5-5",
+    "gpt-5.4-pro": "gpt-5-4-pro",
+    "gpt-5.4-thinking": "gpt-5-4-thinking",
+    "gpt-5.4-thinking-mini": "gpt-5-4-t-mini",
+    "gpt-5.3": "gpt-5-3",
+    "gpt-5.3-mini": "gpt-5-3-mini",
+    o3: "o3",
+  };
   const m = installMockFetch();
   try {
     for (const omniId of ids) {
@@ -1351,11 +1366,7 @@ test("MODEL_MAP drift guard: every advertised catalog id reaches ChatGPT as a ba
         !body.model.includes("."),
         `${omniId} reached the backend as "${body.model}" (still dot-form)`
       );
-      if (omniId.endsWith("-extended")) {
-        assert.equal(body.model, "gpt-5-5-pro", `${omniId} should select the base Pro slug`);
-      } else {
-        assert.equal(body.model, omniId, `${omniId} should pass through as its backend slug`);
-      }
+      assert.equal(body.model, expectedSlugById[omniId], `${omniId} should map to backend slug`);
     }
   } finally {
     m.restore();
@@ -1370,7 +1381,7 @@ test("GPT-5.5 Pro Extended sends base slug with extended effort and Temporary Ch
   try {
     const executor = new ChatGptWebExecutor();
     const result = await executor.execute({
-      model: "gpt-5-5-pro-extended",
+      model: "gpt-5.5-pro-extended",
       body: { messages: [{ role: "user", content: "hi" }] },
       stream: false,
       credentials: { apiKey: "cookie-pro-extended" },
@@ -1399,7 +1410,7 @@ test("GPT-5.5 Pro standard sends standard effort", async () => {
   try {
     const executor = new ChatGptWebExecutor();
     await executor.execute({
-      model: "gpt-5-5-pro",
+      model: "gpt-5.5-pro",
       body: { messages: [{ role: "user", content: "hi" }] },
       stream: false,
       credentials: { apiKey: "cookie-pro-standard" },
@@ -1422,7 +1433,7 @@ test("GPT-5.5 Pro store:false keeps Temporary Chat enabled for background utilit
   try {
     const executor = new ChatGptWebExecutor();
     const result = await executor.execute({
-      model: "gpt-5-5-pro-extended",
+      model: "gpt-5.5-pro-extended",
       body: {
         store: false,
         messages: [


### PR DESCRIPTION
## Summary

Follow-up to #5536. This restores the public ChatGPT Web model designation to OmniRoute's existing dot-form IDs while keeping the new GPT-5.5 Pro Extended mode.

Provider-facing IDs are now:

- `cgpt-web/gpt-5.5-pro`
- `cgpt-web/gpt-5.5-pro-extended`

ChatGPT's backend still receives the required dash-form upstream slug (`gpt-5-5-pro`). Backend dash-form IDs remain accepted directly as compatibility aliases, but they are no longer the model IDs advertised by the `cgpt-web` catalog.

## Details

- Restores `open-sse/config/providers/registry/chatgpt-web` to dot-form public IDs.
- Keeps `gpt-5.5-pro-extended` as the new public extended-effort model.
- Updates ChatGPT Web model-map comments/tests to distinguish public dot-form IDs from backend dash-form slugs.
- Keeps the #5536 behavior:
  - Pro effort is sent as `thinking_effort` in the conversation body.
  - `stream_handoff` is handled and final answers are polled from conversation detail.
  - Pro text/API calls stay in Temporary Chat (`history_and_training_disabled: true`).

## Testing

- `DISABLE_SQLITE_AUTO_BACKUP=true node --max-old-space-size=8192 --import tsx --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test --test-force-exit tests/unit/chatgpt-web.test.ts`
  - 86/86 passing
- `npm run check:provider-consistency`
- `npx prettier --check open-sse/services/chatgptTlsClient.ts open-sse/executors/chatgpt-web.ts open-sse/config/providers/registry/chatgpt-web/index.ts tests/unit/chatgpt-web.test.ts`
- `npx eslint open-sse/services/chatgptTlsClient.ts open-sse/executors/chatgpt-web.ts open-sse/config/providers/registry/chatgpt-web/index.ts tests/unit/chatgpt-web.test.ts`
  - no errors; existing `no-explicit-any` warnings remain in `tests/unit/chatgpt-web.test.ts`
