### PR TITLE
chore(bun): run validated ts scripts with bun

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,8 +76,8 @@
   "scripts": {
     "dev": "node --max-old-space-size=8192 scripts/dev/run-next.mjs dev",
     "prebuild:docs": "node scripts/docs/gen-openapi-module.mjs",
-    "gen:provider-reference": "node --import tsx scripts/docs/gen-provider-reference.ts",
-    "bench:compression": "node --import tsx scripts/compression/benchmark.ts",
+    "gen:provider-reference": "bun scripts/docs/gen-provider-reference.ts",
+    "bench:compression": "bun scripts/compression/benchmark.ts",
     "eval:compression": "node --import tsx scripts/compression-eval/index.ts",
     "release:sync-changelog-i18n": "node scripts/release/sync-changelog-i18n.mjs",
     "build": "node scripts/build/build-next-isolated.mjs",


### PR DESCRIPTION
## Scope

This is the smallest CI-safe slice of the Bun migration: only package script entries that are not invoked by current GitHub Actions before Bun is installed.

Changed from `node --import tsx` to `bun`:
- `gen:provider-reference`
- `bench:compression`

## Validation

- `bun run gen:provider-reference`
- `bun run bench:compression`

## Deferred

Left on Node in this PR:
- CI-invoked checks (`check:node-runtime`, `check:compression-budget`, `check:provider-consistency`, `check:known-symbols`) until CI installs Bun first.
- `check:route-guard-membership`: covered separately by #5613 for Windows path normalization first.
- `check:pack-artifact` / `check:pack-policy`: current Windows fresh-checkout validation fails before this PR can prove a runtime-only migration.
- `eval:compression`: requires runtime model/provider arguments and is better migrated with a dedicated invocation contract.