### PR TITLE
fix(checks): normalize route paths on windows

### DIFF
--- a/scripts/check/check-route-guard-membership.ts
+++ b/scripts/check/check-route-guard-membership.ts
@@ -68,6 +68,7 @@ export const KNOWN_UNCLASSIFIED: Record<string, string> = {};
  */
 export function routeFileToApiPath(routeFile: string): string {
   return routeFile
+    .replace(/\\/g, "/")
     .replace(/^src\/app/, "")
     .replace(/\/route\.ts$/, "")
     .replace(/\[([^\]]+)\]/g, "_$1_");

--- a/tests/unit/check-route-guard-membership.test.ts
+++ b/tests/unit/check-route-guard-membership.test.ts
@@ -39,6 +39,17 @@ test("routeFileToApiPath resolves dynamic [param] segments to a concrete placeho
   );
 });
 
+test("routeFileToApiPath normalizes Windows backslash separators before stripping prefixes", () => {
+  // On Windows, node:path join() yields backslash-separated paths; without the
+  // leading `.replace(/\\/g, "/")` the `^src\/app` strip never matches and the
+  // route-guard gate produces wrong API paths (false negatives that miss
+  // RCE-capable spawn routes). See PR #5613.
+  assert.equal(
+    routeFileToApiPath("src\\app\\api\\services\\9router\\install\\route.ts"),
+    "/api/services/9router/install"
+  );
+});
+
 test("no unclassified routes when every spawn-capable route is local-only", () => {
   const routes = [
     "/api/mcp/tools",


### PR DESCRIPTION
## Scope

Fixes `scripts/check/check-route-guard-membership.ts` on Windows by normalizing route file paths to POSIX separators before converting Next.js `route.ts` files to `/api/...` paths.

Without this, Windows paths like `src\app\api\services\cliproxy\status\route.ts` are passed through as filesystem paths and fail `isLocalOnlyPath()`, even though `/api/services/` is already correctly classified as local-only.

## Validation

- `node --import tsx scripts/check/check-route-guard-membership.ts`
- `bun scripts/check/check-route-guard-membership.ts`
- push hooks: `check:any-budget:t11`, `check:tracked-artifacts`, docs sync
