### PR TITLE
fix(security): avoid rendering error stacks

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -40,7 +40,6 @@ export default function Error({ error, reset }: ErrorProps) {
           aria-label="Error details"
         >
           {error.message}
-          {error.stack && `\n\n${error.stack}`}
         </pre>
       )}
       <div className="flex gap-3">

--- a/tests/unit/error-boundary-stack.test.ts
+++ b/tests/unit/error-boundary-stack.test.ts
@@ -1,0 +1,12 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const repoRoot = join(import.meta.dirname, "../..");
+
+test("app error boundary does not render stack traces", async () => {
+  const source = await readFile(join(repoRoot, "src/app/error.tsx"), "utf8");
+
+  assert.doesNotMatch(source, /error\.stack/);
+});


### PR DESCRIPTION
## Summary

- stop rendering `error.stack` in the app-level Next.js error boundary
- add a unit guard so the boundary does not reintroduce direct stack rendering
- keep the existing development-only `error.message` debug surface and production-safe digest display

## Why

The open PRs are currently blocked by the repository-wide CodeQL quality ratchet for `js/stack-trace-exposure`. I do not have permission to read the exact code-scanning alert location through the GitHub API, so I audited likely stack/error response surfaces locally. The direct `error.stack` render in `src/app/error.tsx` is the clearest client-visible stack exposure pattern and is inconsistent with `global-error.tsx`, which only renders `error.message` in development.

## Validation

- `node --test --test-force-exit tests/unit/error-boundary-stack.test.ts`
- `npm run check:error-helper`
- `git diff --check`

Note: the full repo `test:unit` harness requires installed dependencies in this worktree (`tsx`); CI runs after dependency installation.