### PR TITLE
fix(build): make pack validator bun safe

### DIFF
--- a/scripts/build/validate-pack-artifact.ts
+++ b/scripts/build/validate-pack-artifact.ts
@@ -20,8 +20,11 @@ const npmCommand: string = process.platform === "win32" ? "npm.cmd" : "npm";
 
 function runNpm(args: string[], stdio: "inherit" | "pipe" = "pipe"): string {
   const npmExecPath = process.env.npm_execpath;
-  const command = npmExecPath ? process.execPath : npmCommand;
-  return execFileSync(command, [...(npmExecPath ? [npmExecPath] : []), ...args], {
+  const isBunRuntime = "Bun" in globalThis;
+  const command = npmExecPath && !isBunRuntime ? process.execPath : npmCommand;
+  const commandArgs = npmExecPath && !isBunRuntime ? [npmExecPath, ...args] : args;
+
+  return execFileSync(command, commandArgs, {
     cwd: ROOT,
     encoding: "utf8",
     stdio: stdio === "inherit" ? "inherit" : ["ignore", "pipe", "pipe"],


### PR DESCRIPTION
## Summary

- make `scripts/build/validate-pack-artifact.ts` avoid re-entering npm through `process.execPath` when the current runtime is Bun
- keep the existing Node/npm behavior unchanged for the current `node --import tsx` scripts

## Why

When this validator runs under Bun, `process.execPath` points at `bun.exe`. The previous helper treated `process.env.npm_execpath` as a signal to execute npm via `process.execPath`, which produced commands like `bun.exe bun.exe pack ...` on Windows. Calling the real `npm` command under Bun keeps the pack dry-run path runner-neutral and unblocks a later `check:pack-policy` / `check:pack-artifact` Bun script migration.

## Validation

- `bun scripts/build/validate-pack-artifact.ts --policy-only`
- `npm run check:pack-policy`
- `git diff --check`