### PR TITLE
fix(test): use lightweight health probe for batch e2e

### DIFF
--- a/tests/integration/batch-e2e-rate-limit.test.ts
+++ b/tests/integration/batch-e2e-rate-limit.test.ts
@@ -175,7 +175,7 @@ async function waitForServer(baseUrl: string, proc: ReturnType<typeof createServ
       );
     }
     try {
-      const resp = await fetch(`${baseUrl}/api/monitoring/health`, {
+      const resp = await fetch(`${baseUrl}/api/health/ping`, {
         signal: AbortSignal.timeout(5_000),
       });
       if (resp.ok) return;
@@ -205,6 +205,18 @@ async function stopProcess(child: ReturnType<typeof spawn>) {
   if (!exited && !child.killed) {
     child.kill("SIGKILL");
     await new Promise<void>((resolve) => child.once("exit", () => resolve()));
+  }
+}
+
+async function removeDirWithRetry(dir: string) {
+  for (let attempt = 0; attempt < 5; attempt++) {
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      if (attempt === 4) throw error;
+      await sleep(250);
+    }
   }
 }
 
@@ -248,7 +260,7 @@ test.after(async () => {
     await relay.stop();
   } catch {}
   if (fs.existsSync(TEST_DATA_DIR)) {
-    fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+    await removeDirWithRetry(TEST_DATA_DIR);
   }
 });
 


### PR DESCRIPTION
## Summary

- switch the batch rate-limit E2E readiness probe from `/api/monitoring/health` to the lightweight `/api/health/ping` endpoint
- add retrying cleanup for the test temp directory so local Windows runs do not fail on transient file locks

## Why

The Integration Tests (2/2) shard on the Bun PRs timed out waiting for the server even though Next was responding. The captured logs showed repeated `GET /api/monitoring/health 404` responses until the test timed out. `/api/health/ping` already exists as the lightweight liveness probe and is the correct readiness endpoint for this test harness.

## Validation

- `node --import tsx --import ./tests/_setup/isolateDataDir.ts --test --test-force-exit --test-concurrency=1 tests/integration/batch-e2e-rate-limit.test.ts`
- `git diff --check`