### PR TITLE
refactor(api): extract unified-catalog helpers into cohesive leaf modules (BLOCO E2)

### DIFF
--- a/src/app/api/v1/models/catalog.ts
+++ b/src/app/api/v1/models/catalog.ts
@@ -1,6 +1,5 @@
 import { PROVIDER_MODELS, PROVIDER_ID_TO_ALIAS } from "@/shared/constants/models";
-import { AI_PROVIDERS, NOAUTH_PROVIDERS } from "@/shared/constants/providers";
-import { isVisionModelId } from "@/shared/constants/visionModels";
+import { NOAUTH_PROVIDERS } from "@/shared/constants/providers";
 import {
   getProviderConnections,
   getCombos,
@@ -40,7 +39,6 @@ import {
 } from "@/lib/modelMetadataRegistry";
 import { getSyncedCapability } from "@/lib/modelsDevSync";
 import { getModelSpec } from "@/shared/constants/modelSpecs";
-import { isAuthRequired, isDashboardSessionAuthenticated } from "@/shared/utils/apiAuth";
 import {
   isModelCatalogNamesEnabled,
   getModelsCatalogPrefixMode,
@@ -56,297 +54,33 @@ import { parseModel } from "@omniroute/open-sse/services/model";
 import { getTokenLimit } from "@omniroute/open-sse/services/contextManager";
 import { extractApiKey } from "@/sse/services/auth";
 import type { ComboModelStep } from "@/lib/combos/steps";
+import {
+  type CustomModelEntry,
+  type ComboCatalogTarget,
+  type ComboTargetCatalogMetadata,
+  isPositiveFiniteNumber,
+  parseJsonStringArray,
+  intersectStringArrays,
+  minKnownNumber,
+  maybeOmitCatalogModelName,
+} from "./catalogHelpers";
+import {
+  qualifyOpenRouterModelId,
+  normalizeOpenRouterModalities,
+  getOpenRouterModelType,
+  isOpenRouterFreeModel,
+  getOpenRouterDisplayName,
+} from "./catalogOpenrouter";
+import { getVisionCapabilityFields, getCustomVisionCapabilityFields } from "./catalogVision";
+import { FALLBACK_ALIAS_TO_PROVIDER, buildAliasMaps } from "./catalogProviderMaps";
+import { getModelCatalogAuthRejection, isCodexModelCatalogClient } from "./catalogRequest";
 
-interface CustomModelEntry {
-  id?: string;
-  name?: string;
-  source?: string;
-  apiFormat?: string;
-  supportedEndpoints?: string[];
-  inputTokenLimit?: number;
-  isHidden?: boolean;
-  // User-set "vision-capable" flag (persisted by addCustomModel / replaceCustomModels
-  // in src/lib/db/models.ts). Surfaced into `/v1/models` via
-  // getCustomVisionCapabilityFields so user-added vision models appear with
-  // `capabilities.vision: true` even when their id does not match the
-  // conservative isVisionModelId heuristic.
-  supportsVision?: boolean;
-}
-
-const FALLBACK_ALIAS_TO_PROVIDER = {
-  ag: "antigravity",
-  cc: "claude",
-  cl: "cline",
-  cu: "cursor",
-  cx: "codex",
-  gh: "github",
-  kc: "kilocode",
-  kmc: "kimi-coding",
-  kr: "kiro",
-  qw: "qwen",
-};
-
-type ComboCatalogTarget = {
-  modelStr?: string;
-  provider?: string | null;
-};
-
-type ComboTargetCatalogMetadata = {
-  contextLength?: number;
-  maxInputTokens?: number;
-  maxOutputTokens?: number;
-  inputModalities?: string[];
-  outputModalities?: string[];
-  capabilities: Record<string, boolean>;
-};
-
-function isPositiveFiniteNumber(value: unknown): value is number {
-  return typeof value === "number" && Number.isFinite(value) && value > 0;
-}
-
-function parseJsonStringArray(value: unknown): string[] {
-  if (typeof value !== "string" || value.trim().length === 0) return [];
-  try {
-    const parsed = JSON.parse(value);
-    return Array.isArray(parsed)
-      ? parsed.filter((entry): entry is string => typeof entry === "string" && entry.length > 0)
-      : [];
-  } catch {
-    return [];
-  }
-}
-
-function maybeOmitCatalogModelName<T extends Record<string, unknown>>(
-  model: T,
-  includeNames: boolean
-): T | Omit<T, "name"> {
-  if (includeNames || !Object.prototype.hasOwnProperty.call(model, "name")) return model;
-
-  const { name: omittedName, ...nextModel } = model;
-  void omittedName;
-  return nextModel;
-}
-
-function intersectStringArrays(arrays: string[][]): string[] {
-  if (arrays.length === 0 || arrays.some((values) => values.length === 0)) return [];
-  const [first, ...rest] = arrays;
-  return first.filter((value, index) => {
-    if (first.indexOf(value) !== index) return false;
-    return rest.every((values) => values.includes(value));
-  });
-}
-
-function minKnownNumber(values: Array<number | undefined>): number | undefined {
-  const knownValues = values.filter(isPositiveFiniteNumber);
-  if (knownValues.length === 0) return undefined;
-  return Math.min(...knownValues);
-}
-
-// Vision detection is centralized in `@/shared/constants/visionModels` (#4072) so
-// this listing path, the routing fallback, and lite compression share one verdict.
-// Re-exported for callers/tests that imported it from here.
-export { isVisionModelId };
-
-function getVisionCapabilityFields(modelId: string) {
-  if (!isVisionModelId(modelId)) return null;
-  return {
-    capabilities: { vision: true },
-    input_modalities: ["text", "image"],
-    output_modalities: ["text"],
-  };
-}
-
-/**
- * Vision-capability fields for a user-added custom chat model. Honours an
- * explicit `supportsVision` flag on the saved entry (the dashboard "vision-
- * capable" toggle) IN ADDITION TO the conservative id-based heuristic used by
- * built-in models. Without this, a user who registered e.g. `my-vision-llm`
- * and ticked vision saw no `capabilities.vision` in `/v1/models`, so the LLM
- * selector and downstream routing treated the model as text-only.
- *
- * Port of upstream decolua/9router 5e5e78d3. Conservative: an explicit
- * `supportsVision === false` wins so users can downgrade a mis-classified
- * model (same anti-FP discipline as #4071 / #4072).
- */
-export function getCustomVisionCapabilityFields(
-  entry: { supportsVision?: boolean } | null | undefined,
-  ...candidateIds: Array<string | null | undefined>
-): { capabilities: { vision: true }; input_modalities: string[]; output_modalities: string[] } | null {
-  if (entry && entry.supportsVision === false) return null;
-  if (entry && entry.supportsVision === true) {
-    return {
-      capabilities: { vision: true },
-      input_modalities: ["text", "image"],
-      output_modalities: ["text"],
-    };
-  }
-  for (const id of candidateIds) {
-    if (typeof id === "string" && id) {
-      const fields = getVisionCapabilityFields(id);
-      if (fields) return fields;
-    }
-  }
-  return null;
-}
-
-function qualifyOpenRouterModelId(modelId: string): string {
-  return modelId.startsWith("openrouter/") ? modelId : `openrouter/${modelId}`;
-}
-
-function normalizeOpenRouterModalities(value: unknown): string[] {
-  return Array.isArray(value)
-    ? value.filter((entry): entry is string => typeof entry === "string" && entry.length > 0)
-    : [];
-}
-
-function getOpenRouterModelType(inputModalities: string[], outputModalities: string[]) {
-  if (outputModalities.includes("image")) return "image";
-  if (outputModalities.includes("audio")) return "audio";
-  if (outputModalities.includes("video")) return "video";
-  if (outputModalities.includes("embedding")) return "embedding";
-  return "chat";
-}
-
-function isZeroPrice(value: unknown) {
-  if (typeof value === "number") return value === 0;
-  if (typeof value !== "string") return false;
-  const parsed = Number(value);
-  return Number.isFinite(parsed) && parsed === 0;
-}
-
-function isOpenRouterFreeModel(model: {
-  id?: string;
-  pricing?: { prompt?: string; completion?: string };
-}) {
-  if (typeof model.id === "string" && model.id.endsWith(":free")) return true;
-  return isZeroPrice(model.pricing?.prompt) && isZeroPrice(model.pricing?.completion);
-}
-
-function getOpenRouterDisplayName(model: {
-  id?: string;
-  name?: string;
-  pricing?: { prompt?: string; completion?: string };
-}) {
-  const name = model.name || model.id || "OpenRouter model";
-  return isOpenRouterFreeModel(model) && !/\bgr[aá]tis\b/i.test(name) ? `${name} (Grátis)` : name;
-}
-
-async function validateCatalogApiKey(apiKey: string): Promise<boolean> {
-  const { validateApiKey } = await import("@/lib/db/apiKeys");
-  return validateApiKey(apiKey);
-}
-
-async function getModelCatalogAuthRejection(
-  request: Request,
-  settings: Record<string, any>,
-  headers: Record<string, string>
-): Promise<Response | null> {
-  if (settings.requireAuthForModels !== true || !(await isAuthRequired(request))) return null;
-
-  const apiKey = extractApiKey(request);
-  if (apiKey) {
-    if (await validateCatalogApiKey(apiKey)) return null;
-    return Response.json(
-      {
-        error: {
-          message: "Invalid API key",
-          type: "invalid_api_key",
-          code: "invalid_api_key",
-        },
-      },
-      {
-        status: 401,
-        headers,
-      }
-    );
-  }
-
-  if (await isDashboardSessionAuthenticated(request)) return null;
-
-  return Response.json(
-    {
-      error: {
-        message: "Authentication required",
-        type: "invalid_api_key",
-        code: "invalid_api_key",
-      },
-    },
-    {
-      status: 401,
-      headers,
-    }
-  );
-}
-
-function buildAliasMaps() {
-  const aliasToProviderId: Record<string, string> = {};
-  const providerIdToAlias: Record<string, string> = {};
-
-  // Canonical source for ID/alias pairs used across dashboard/provider config.
-  for (const provider of Object.values(AI_PROVIDERS)) {
-    const providerId = provider?.id;
-    const alias = provider?.alias || providerId;
-    if (!providerId) continue;
-    aliasToProviderId[providerId] = providerId;
-    aliasToProviderId[alias] = providerId;
-    if (!providerIdToAlias[providerId]) {
-      providerIdToAlias[providerId] = alias;
-    }
-  }
-
-  for (const [left, right] of Object.entries(PROVIDER_ID_TO_ALIAS)) {
-    // Handle both possible directions:
-    // - providerId -> alias
-    // - alias -> providerId
-    if (PROVIDER_MODELS[left]) {
-      aliasToProviderId[left] = aliasToProviderId[left] || right;
-      continue;
-    }
-    if (PROVIDER_MODELS[right]) {
-      aliasToProviderId[right] = aliasToProviderId[right] || left;
-      continue;
-    }
-    aliasToProviderId[right] = aliasToProviderId[right] || left;
-  }
-
-  for (const alias of Object.keys(PROVIDER_MODELS)) {
-    if (!aliasToProviderId[alias]) {
-      aliasToProviderId[alias] = alias;
-    }
-  }
-
-  for (const [alias, providerId] of Object.entries(aliasToProviderId)) {
-    if (!providerIdToAlias[providerId]) {
-      providerIdToAlias[providerId] = alias;
-    }
-  }
-
-  // Safety net for environments where alias maps are partially loaded during
-  // module initialization/circular imports.
-  for (const [alias, providerId] of Object.entries(FALLBACK_ALIAS_TO_PROVIDER)) {
-    if (!aliasToProviderId[alias]) aliasToProviderId[alias] = providerId;
-    if (!aliasToProviderId[providerId]) aliasToProviderId[providerId] = providerId;
-    if (!providerIdToAlias[providerId]) providerIdToAlias[providerId] = alias;
-  }
-
-  return { aliasToProviderId, providerIdToAlias };
-}
-
-/**
- * Detect the Codex CLI's model-catalog refresh client. Codex sends an `originator` header
- * of `codex_exec` (codex exec) / `codex_cli_rs` (interactive TUI) — see openai/codex
- * login/src/auth/default_client.rs DEFAULT_ORIGINATOR — and a matching `codex_*`
- * User-Agent on its `GET /v1/models?client_version=...` catalog refresh. We only augment
- * the response shape for these clients so every other OpenAI consumer keeps the
- * byte-identical `{object,data}` payload.
- */
-function isCodexModelCatalogClient(request: Request): boolean {
-  const headers = request.headers;
-  const originator = headers.get("originator")?.toLowerCase() ?? "";
-  if (originator.startsWith("codex")) return true;
-  const userAgent = headers.get("user-agent")?.toLowerCase() ?? "";
-  return userAgent.startsWith("codex");
-}
+// Public API of this module is preserved after the catalog helper extraction:
+// `isVisionModelId` (vision-detection-consistency.test.ts) and
+// `getCustomVisionCapabilityFields` (llm-selector-custom-vision-models.test.ts)
+// are still importable from here.
+export { isVisionModelId } from "@/shared/constants/visionModels";
+export { getCustomVisionCapabilityFields };
 
 /**
  * Build unified OpenAI-compatible model catalog response.

--- a/src/app/api/v1/models/catalogHelpers.ts
+++ b/src/app/api/v1/models/catalogHelpers.ts
@@ -1,0 +1,76 @@
+// Pure, dependency-free helpers + shared types for the unified model catalog
+// (`getUnifiedModelsResponse` in ./catalog.ts). Extracted as a cohesive leaf so the
+// catalog host shrinks toward the file-size cap without changing behavior — every
+// function body here is byte-identical to its previous in-catalog definition.
+
+export interface CustomModelEntry {
+  id?: string;
+  name?: string;
+  source?: string;
+  apiFormat?: string;
+  supportedEndpoints?: string[];
+  inputTokenLimit?: number;
+  isHidden?: boolean;
+  // User-set "vision-capable" flag (persisted by addCustomModel / replaceCustomModels
+  // in src/lib/db/models.ts). Surfaced into `/v1/models` via
+  // getCustomVisionCapabilityFields so user-added vision models appear with
+  // `capabilities.vision: true` even when their id does not match the
+  // conservative isVisionModelId heuristic.
+  supportsVision?: boolean;
+}
+
+export type ComboCatalogTarget = {
+  modelStr?: string;
+  provider?: string | null;
+};
+
+export type ComboTargetCatalogMetadata = {
+  contextLength?: number;
+  maxInputTokens?: number;
+  maxOutputTokens?: number;
+  inputModalities?: string[];
+  outputModalities?: string[];
+  capabilities: Record<string, boolean>;
+};
+
+export function isPositiveFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0;
+}
+
+export function parseJsonStringArray(value: unknown): string[] {
+  if (typeof value !== "string" || value.trim().length === 0) return [];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed)
+      ? parsed.filter((entry): entry is string => typeof entry === "string" && entry.length > 0)
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+export function maybeOmitCatalogModelName<T extends Record<string, unknown>>(
+  model: T,
+  includeNames: boolean
+): T | Omit<T, "name"> {
+  if (includeNames || !Object.prototype.hasOwnProperty.call(model, "name")) return model;
+
+  const { name: omittedName, ...nextModel } = model;
+  void omittedName;
+  return nextModel;
+}
+
+export function intersectStringArrays(arrays: string[][]): string[] {
+  if (arrays.length === 0 || arrays.some((values) => values.length === 0)) return [];
+  const [first, ...rest] = arrays;
+  return first.filter((value, index) => {
+    if (first.indexOf(value) !== index) return false;
+    return rest.every((values) => values.includes(value));
+  });
+}
+
+export function minKnownNumber(values: Array<number | undefined>): number | undefined {
+  const knownValues = values.filter(isPositiveFiniteNumber);
+  if (knownValues.length === 0) return undefined;
+  return Math.min(...knownValues);
+}

--- a/src/app/api/v1/models/catalogOpenrouter.ts
+++ b/src/app/api/v1/models/catalogOpenrouter.ts
@@ -1,0 +1,46 @@
+// OpenRouter-specific catalog normalization helpers. Extracted verbatim from
+// ./catalog.ts as a cohesive leaf — id qualification, modality normalization,
+// model-type inference, and the free-model / display-name heuristics that shape
+// OpenRouter entries in `getUnifiedModelsResponse`.
+
+export function qualifyOpenRouterModelId(modelId: string): string {
+  return modelId.startsWith("openrouter/") ? modelId : `openrouter/${modelId}`;
+}
+
+export function normalizeOpenRouterModalities(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string" && entry.length > 0)
+    : [];
+}
+
+export function getOpenRouterModelType(inputModalities: string[], outputModalities: string[]) {
+  if (outputModalities.includes("image")) return "image";
+  if (outputModalities.includes("audio")) return "audio";
+  if (outputModalities.includes("video")) return "video";
+  if (outputModalities.includes("embedding")) return "embedding";
+  return "chat";
+}
+
+export function isZeroPrice(value: unknown) {
+  if (typeof value === "number") return value === 0;
+  if (typeof value !== "string") return false;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed === 0;
+}
+
+export function isOpenRouterFreeModel(model: {
+  id?: string;
+  pricing?: { prompt?: string; completion?: string };
+}) {
+  if (typeof model.id === "string" && model.id.endsWith(":free")) return true;
+  return isZeroPrice(model.pricing?.prompt) && isZeroPrice(model.pricing?.completion);
+}
+
+export function getOpenRouterDisplayName(model: {
+  id?: string;
+  name?: string;
+  pricing?: { prompt?: string; completion?: string };
+}) {
+  const name = model.name || model.id || "OpenRouter model";
+  return isOpenRouterFreeModel(model) && !/\bgr[aá]tis\b/i.test(name) ? `${name} (Grátis)` : name;
+}

--- a/src/app/api/v1/models/catalogProviderMaps.ts
+++ b/src/app/api/v1/models/catalogProviderMaps.ts
@@ -1,0 +1,72 @@
+import { PROVIDER_MODELS, PROVIDER_ID_TO_ALIAS } from "@/shared/constants/models";
+import { AI_PROVIDERS } from "@/shared/constants/providers";
+
+// Alias <-> providerId resolution maps for the unified model catalog. Extracted
+// verbatim from ./catalog.ts. `FALLBACK_ALIAS_TO_PROVIDER` is also consumed directly by
+// the catalog host's `resolveCanonicalProviderId`, so it is exported alongside the builder.
+export const FALLBACK_ALIAS_TO_PROVIDER = {
+  ag: "antigravity",
+  cc: "claude",
+  cl: "cline",
+  cu: "cursor",
+  cx: "codex",
+  gh: "github",
+  kc: "kilocode",
+  kmc: "kimi-coding",
+  kr: "kiro",
+  qw: "qwen",
+};
+
+export function buildAliasMaps() {
+  const aliasToProviderId: Record<string, string> = {};
+  const providerIdToAlias: Record<string, string> = {};
+
+  // Canonical source for ID/alias pairs used across dashboard/provider config.
+  for (const provider of Object.values(AI_PROVIDERS)) {
+    const providerId = provider?.id;
+    const alias = provider?.alias || providerId;
+    if (!providerId) continue;
+    aliasToProviderId[providerId] = providerId;
+    aliasToProviderId[alias] = providerId;
+    if (!providerIdToAlias[providerId]) {
+      providerIdToAlias[providerId] = alias;
+    }
+  }
+
+  for (const [left, right] of Object.entries(PROVIDER_ID_TO_ALIAS)) {
+    // Handle both possible directions:
+    // - providerId -> alias
+    // - alias -> providerId
+    if (PROVIDER_MODELS[left]) {
+      aliasToProviderId[left] = aliasToProviderId[left] || right;
+      continue;
+    }
+    if (PROVIDER_MODELS[right]) {
+      aliasToProviderId[right] = aliasToProviderId[right] || left;
+      continue;
+    }
+    aliasToProviderId[right] = aliasToProviderId[right] || left;
+  }
+
+  for (const alias of Object.keys(PROVIDER_MODELS)) {
+    if (!aliasToProviderId[alias]) {
+      aliasToProviderId[alias] = alias;
+    }
+  }
+
+  for (const [alias, providerId] of Object.entries(aliasToProviderId)) {
+    if (!providerIdToAlias[providerId]) {
+      providerIdToAlias[providerId] = alias;
+    }
+  }
+
+  // Safety net for environments where alias maps are partially loaded during
+  // module initialization/circular imports.
+  for (const [alias, providerId] of Object.entries(FALLBACK_ALIAS_TO_PROVIDER)) {
+    if (!aliasToProviderId[alias]) aliasToProviderId[alias] = providerId;
+    if (!aliasToProviderId[providerId]) aliasToProviderId[providerId] = providerId;
+    if (!providerIdToAlias[providerId]) providerIdToAlias[providerId] = alias;
+  }
+
+  return { aliasToProviderId, providerIdToAlias };
+}

--- a/src/app/api/v1/models/catalogRequest.ts
+++ b/src/app/api/v1/models/catalogRequest.ts
@@ -1,0 +1,68 @@
+import { isAuthRequired, isDashboardSessionAuthenticated } from "@/shared/utils/apiAuth";
+import { extractApiKey } from "@/sse/services/auth";
+
+// Request-scoped catalog helpers: API-key auth gating for `/v1/models` and Codex
+// CLI client detection. Extracted verbatim from ./catalog.ts.
+
+async function validateCatalogApiKey(apiKey: string): Promise<boolean> {
+  const { validateApiKey } = await import("@/lib/db/apiKeys");
+  return validateApiKey(apiKey);
+}
+
+export async function getModelCatalogAuthRejection(
+  request: Request,
+  settings: Record<string, any>,
+  headers: Record<string, string>
+): Promise<Response | null> {
+  if (settings.requireAuthForModels !== true || !(await isAuthRequired(request))) return null;
+
+  const apiKey = extractApiKey(request);
+  if (apiKey) {
+    if (await validateCatalogApiKey(apiKey)) return null;
+    return Response.json(
+      {
+        error: {
+          message: "Invalid API key",
+          type: "invalid_api_key",
+          code: "invalid_api_key",
+        },
+      },
+      {
+        status: 401,
+        headers,
+      }
+    );
+  }
+
+  if (await isDashboardSessionAuthenticated(request)) return null;
+
+  return Response.json(
+    {
+      error: {
+        message: "Authentication required",
+        type: "invalid_api_key",
+        code: "invalid_api_key",
+      },
+    },
+    {
+      status: 401,
+      headers,
+    }
+  );
+}
+
+/**
+ * Detect the Codex CLI's model-catalog refresh client. Codex sends an `originator` header
+ * of `codex_exec` (codex exec) / `codex_cli_rs` (interactive TUI) — see openai/codex
+ * login/src/auth/default_client.rs DEFAULT_ORIGINATOR — and a matching `codex_*`
+ * User-Agent on its `GET /v1/models?client_version=...` catalog refresh. We only augment
+ * the response shape for these clients so every other OpenAI consumer keeps the
+ * byte-identical `{object,data}` payload.
+ */
+export function isCodexModelCatalogClient(request: Request): boolean {
+  const headers = request.headers;
+  const originator = headers.get("originator")?.toLowerCase() ?? "";
+  if (originator.startsWith("codex")) return true;
+  const userAgent = headers.get("user-agent")?.toLowerCase() ?? "";
+  return userAgent.startsWith("codex");
+}

--- a/src/app/api/v1/models/catalogVision.ts
+++ b/src/app/api/v1/models/catalogVision.ts
@@ -1,0 +1,53 @@
+import { isVisionModelId } from "@/shared/constants/visionModels";
+
+// Vision-capability fields for catalog entries. Extracted verbatim from ./catalog.ts.
+// Vision detection is centralized in `@/shared/constants/visionModels` (#4072) so this
+// listing path, the routing fallback, and lite compression share one verdict.
+// Re-exported (here and from ./catalog.ts) for callers/tests that imported it from there.
+export { isVisionModelId };
+
+export function getVisionCapabilityFields(modelId: string) {
+  if (!isVisionModelId(modelId)) return null;
+  return {
+    capabilities: { vision: true },
+    input_modalities: ["text", "image"],
+    output_modalities: ["text"],
+  };
+}
+
+/**
+ * Vision-capability fields for a user-added custom chat model. Honours an
+ * explicit `supportsVision` flag on the saved entry (the dashboard "vision-
+ * capable" toggle) IN ADDITION TO the conservative id-based heuristic used by
+ * built-in models. Without this, a user who registered e.g. `my-vision-llm`
+ * and ticked vision saw no `capabilities.vision` in `/v1/models`, so the LLM
+ * selector and downstream routing treated the model as text-only.
+ *
+ * Port of upstream decolua/9router 5e5e78d3. Conservative: an explicit
+ * `supportsVision === false` wins so users can downgrade a mis-classified
+ * model (same anti-FP discipline as #4071 / #4072).
+ */
+export function getCustomVisionCapabilityFields(
+  entry: { supportsVision?: boolean } | null | undefined,
+  ...candidateIds: Array<string | null | undefined>
+): {
+  capabilities: { vision: true };
+  input_modalities: string[];
+  output_modalities: string[];
+} | null {
+  if (entry && entry.supportsVision === false) return null;
+  if (entry && entry.supportsVision === true) {
+    return {
+      capabilities: { vision: true },
+      input_modalities: ["text", "image"],
+      output_modalities: ["text"],
+    };
+  }
+  for (const id of candidateIds) {
+    if (typeof id === "string" && id) {
+      const fields = getVisionCapabilityFields(id);
+      if (fields) return fields;
+    }
+  }
+  return null;
+}

--- a/tests/unit/catalog-helpers-extraction.test.ts
+++ b/tests/unit/catalog-helpers-extraction.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Characterization tests for the catalog helper extraction (BLOCO E2 of the
+ * god-files campaign). The pure, dependency-free helpers and the request/vision/
+ * provider-map helpers were lifted out of `src/app/api/v1/models/catalog.ts`
+ * verbatim into cohesive leaf modules so the catalog host shrinks toward the
+ * file-size cap. These tests pin the behavior of each extracted helper AND guard
+ * the host module's preserved public API (re-exports relied on by other tests).
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  isPositiveFiniteNumber,
+  parseJsonStringArray,
+  intersectStringArrays,
+  minKnownNumber,
+  maybeOmitCatalogModelName,
+} from "../../src/app/api/v1/models/catalogHelpers.ts";
+import {
+  qualifyOpenRouterModelId,
+  normalizeOpenRouterModalities,
+  getOpenRouterModelType,
+  isZeroPrice,
+  isOpenRouterFreeModel,
+  getOpenRouterDisplayName,
+} from "../../src/app/api/v1/models/catalogOpenrouter.ts";
+import {
+  isVisionModelId,
+  getVisionCapabilityFields,
+  getCustomVisionCapabilityFields,
+} from "../../src/app/api/v1/models/catalogVision.ts";
+import {
+  FALLBACK_ALIAS_TO_PROVIDER,
+  buildAliasMaps,
+} from "../../src/app/api/v1/models/catalogProviderMaps.ts";
+import { isCodexModelCatalogClient } from "../../src/app/api/v1/models/catalogRequest.ts";
+
+test("catalogHelpers: isPositiveFiniteNumber", () => {
+  assert.equal(isPositiveFiniteNumber(1), true);
+  assert.equal(isPositiveFiniteNumber(0), false);
+  assert.equal(isPositiveFiniteNumber(-1), false);
+  assert.equal(isPositiveFiniteNumber(Number.NaN), false);
+  assert.equal(isPositiveFiniteNumber(Infinity), false);
+  assert.equal(isPositiveFiniteNumber("5"), false);
+  assert.equal(isPositiveFiniteNumber(undefined), false);
+});
+
+test("catalogHelpers: parseJsonStringArray keeps only non-empty strings", () => {
+  assert.deepEqual(parseJsonStringArray('["a","b"]'), ["a", "b"]);
+  assert.deepEqual(parseJsonStringArray('["a", 1, "", "c"]'), ["a", "c"]);
+  assert.deepEqual(parseJsonStringArray("not json"), []);
+  assert.deepEqual(parseJsonStringArray(""), []);
+  assert.deepEqual(parseJsonStringArray('{"x":1}'), []);
+  assert.deepEqual(parseJsonStringArray(null), []);
+});
+
+test("catalogHelpers: intersectStringArrays (dedup + common)", () => {
+  assert.deepEqual(
+    intersectStringArrays([
+      ["a", "b", "c"],
+      ["b", "c", "d"],
+    ]),
+    ["b", "c"]
+  );
+  assert.deepEqual(
+    intersectStringArrays([
+      ["a", "a", "b"],
+      ["a", "b"],
+    ]),
+    ["a", "b"]
+  );
+  assert.deepEqual(intersectStringArrays([]), []);
+  assert.deepEqual(intersectStringArrays([["a"], []]), []);
+});
+
+test("catalogHelpers: minKnownNumber ignores non-positive/unknown", () => {
+  assert.equal(minKnownNumber([3, 1, 2]), 1);
+  assert.equal(minKnownNumber([undefined, 0, -5, 7]), 7);
+  assert.equal(minKnownNumber([undefined, undefined]), undefined);
+  assert.equal(minKnownNumber([]), undefined);
+});
+
+test("catalogHelpers: maybeOmitCatalogModelName drops name only when excluding", () => {
+  const model = { id: "x", name: "X" };
+  assert.deepEqual(maybeOmitCatalogModelName(model, true), { id: "x", name: "X" });
+  assert.deepEqual(maybeOmitCatalogModelName(model, false), { id: "x" });
+  // No `name` key -> returned unchanged regardless of flag.
+  assert.deepEqual(maybeOmitCatalogModelName({ id: "y" }, false), { id: "y" });
+});
+
+test("catalogOpenrouter: qualify + modality normalization + type", () => {
+  assert.equal(qualifyOpenRouterModelId("foo/bar"), "openrouter/foo/bar");
+  assert.equal(qualifyOpenRouterModelId("openrouter/foo"), "openrouter/foo");
+  assert.deepEqual(normalizeOpenRouterModalities(["text", 1, "", "image"]), ["text", "image"]);
+  assert.deepEqual(normalizeOpenRouterModalities("nope"), []);
+  assert.equal(getOpenRouterModelType(["text"], ["image"]), "image");
+  assert.equal(getOpenRouterModelType(["text"], ["audio"]), "audio");
+  assert.equal(getOpenRouterModelType(["text"], ["embedding"]), "embedding");
+  assert.equal(getOpenRouterModelType(["text"], ["text"]), "chat");
+});
+
+test("catalogOpenrouter: free-model detection + display name", () => {
+  assert.equal(isZeroPrice(0), true);
+  assert.equal(isZeroPrice("0"), true);
+  assert.equal(isZeroPrice("0.5"), false);
+  assert.equal(isZeroPrice("x"), false);
+  assert.equal(isOpenRouterFreeModel({ id: "z/model:free" }), true);
+  assert.equal(
+    isOpenRouterFreeModel({ id: "z/model", pricing: { prompt: "0", completion: "0" } }),
+    true
+  );
+  assert.equal(
+    isOpenRouterFreeModel({ id: "z/model", pricing: { prompt: "0.1", completion: "0" } }),
+    false
+  );
+  assert.equal(getOpenRouterDisplayName({ id: "z/m", name: "Some Model" }), "Some Model");
+  assert.equal(
+    getOpenRouterDisplayName({ id: "z/m:free", name: "Free Model" }),
+    "Free Model (Grátis)"
+  );
+  // Already labelled "grátis" is not double-tagged.
+  assert.equal(
+    getOpenRouterDisplayName({ id: "z/m:free", name: "Modelo Grátis" }),
+    "Modelo Grátis"
+  );
+});
+
+test("catalogVision: re-exports isVisionModelId and derives capability fields", () => {
+  assert.equal(typeof isVisionModelId, "function");
+  // id-based heuristic
+  const visionFields = getVisionCapabilityFields("gpt-4o");
+  assert.ok(visionFields, "gpt-4o must be detected as vision-capable");
+  assert.equal(visionFields?.capabilities.vision, true);
+  assert.equal(getVisionCapabilityFields("kimi-k2"), null);
+});
+
+test("catalogVision: getCustomVisionCapabilityFields honours explicit flag", () => {
+  // explicit true wins
+  assert.equal(
+    getCustomVisionCapabilityFields({ supportsVision: true }, "x")?.capabilities.vision,
+    true
+  );
+  // explicit false wins even for a vision-looking id
+  assert.equal(getCustomVisionCapabilityFields({ supportsVision: false }, "gpt-4o"), null);
+  // no flag -> falls back to id heuristic
+  assert.equal(getCustomVisionCapabilityFields(null, "gpt-4o")?.capabilities.vision, true);
+  assert.equal(getCustomVisionCapabilityFields(null, "kimi-k2"), null);
+});
+
+test("catalogProviderMaps: buildAliasMaps seeds the fallback aliases", () => {
+  const { aliasToProviderId, providerIdToAlias } = buildAliasMaps();
+  assert.equal(typeof aliasToProviderId, "object");
+  assert.equal(typeof providerIdToAlias, "object");
+  // Fallback entries are always present even if upstream maps loaded partially.
+  for (const [alias, providerId] of Object.entries(FALLBACK_ALIAS_TO_PROVIDER)) {
+    assert.equal(aliasToProviderId[alias], providerId, `alias ${alias} -> ${providerId}`);
+  }
+  assert.equal(aliasToProviderId["cx"], "codex");
+  assert.equal(aliasToProviderId["kr"], "kiro");
+});
+
+test("catalogRequest: isCodexModelCatalogClient detects codex originator/user-agent", () => {
+  const byOriginator = new Request("https://x/v1/models", {
+    headers: { originator: "codex_cli_rs" },
+  });
+  assert.equal(isCodexModelCatalogClient(byOriginator), true);
+  const byUserAgent = new Request("https://x/v1/models", {
+    headers: { "user-agent": "codex_exec/0.137" },
+  });
+  assert.equal(isCodexModelCatalogClient(byUserAgent), true);
+  const other = new Request("https://x/v1/models", {
+    headers: { "user-agent": "curl/8.0" },
+  });
+  assert.equal(isCodexModelCatalogClient(other), false);
+});
+
+test("host catalog.ts preserves its public API after the extraction", async () => {
+  const host = (await import("../../src/app/api/v1/models/catalog.ts")) as Record<string, unknown>;
+  assert.equal(typeof host.getUnifiedModelsResponse, "function", "getUnifiedModelsResponse export");
+  assert.equal(
+    typeof host.getCustomVisionCapabilityFields,
+    "function",
+    "getCustomVisionCapabilityFields re-export (llm-selector-custom-vision-models.test.ts)"
+  );
+  assert.equal(
+    typeof host.isVisionModelId,
+    "function",
+    "isVisionModelId re-export (vision-detection-consistency.test.ts)"
+  );
+});


### PR DESCRIPTION
## BLOCO E2 — `models/catalog.ts` god-file decomposition (campanha SDD quality & god-files)

Fatia **segura e behavior-preserving** do god-file `src/app/api/v1/models/catalog.ts` (1611 LOC). As funções/consts **module-level puras/standalone** foram extraídas **verbatim** para 5 leaves coesos; o host fica com o orquestrador `getUnifiedModelsResponse` (cujas closures internas NÃO foram tocadas — isso seria um ctx-rewrite de risco, deferido).

`catalog.ts`: **1611 → 1345 LOC** (frozen baseline 1615; já era frozen-satisfeito → isto é redução de dívida, não gate-required).

### Leaves criados (todos < 800 LOC)
| Arquivo | Conteúdo |
|---|---|
| `catalogHelpers.ts` (76) | helpers numéricos/array/shape puros + tipos compartilhados (`CustomModelEntry`, `ComboCatalogTarget`, `ComboTargetCatalogMetadata`) |
| `catalogOpenrouter.ts` (46) | id/modality/free-model/display-name do OpenRouter |
| `catalogVision.ts` (52) | derivação de campos de vision (+ re-export de `isVisionModelId`) |
| `catalogProviderMaps.ts` (72) | mapas alias↔providerId (`buildAliasMaps` + `FALLBACK_ALIAS_TO_PROVIDER`) |
| `catalogRequest.ts` (68) | auth gating do `/v1/models` + detecção do client Codex CLI |

### API pública preservada
O host re-exporta `getUnifiedModelsResponse` (9 rotas de produção), `getCustomVisionCapabilityFields` (`llm-selector-custom-vision-models.test.ts`) e `isVisionModelId` (`vision-detection-consistency.test.ts`). Nenhum consumidor muda.

### Testes
- **Novo** `tests/unit/catalog-helpers-extraction.test.ts` (12 testes): caracterização de cada helper extraído + guarda da API pública re-exportada.
- Suíte de caracterização existente do catalog/vision (50 testes) verde — prova de behavior-preservation.

### Validação local
`typecheck:core` ✓ · 50 testes catalog/vision ✓ · 12 testes novos ✓ · `integration-wiring` (72, 0 fail) ✓ · `check:cycles` ✓ · ESLint ✓ · Prettier ✓.

`check:file-size` reporta apenas **base-red herdada** (`open-sse/executors/huggingchat.ts` 813 + 3 test files) — **0 diff vs `release/v3.8.43`**, nenhuma causada por este PR; meus arquivos (host 1345, leaves 46–76) estão todos abaixo do cap/frozen.

> Não-mergear até liberação do dono (no-merge-meddling). Sem `release-freeze` ativo no momento da abertura.
