### PR TITLE
refactor(db): extract compat/aliases/mitm helpers from db/models.ts into leaf modules (BLOCO E3)

### DIFF
--- a/src/lib/db/models.ts
+++ b/src/lib/db/models.ts
@@ -1,358 +1,44 @@
 /**
- * db/models.js — Model aliases, MITM aliases, and custom models.
+ * db/models.ts — Custom models, synced available models, and model-flag queries.
+ * Compat overrides, model aliases, and MITM aliases have moved to sub-modules under
+ * models/; this file re-exports their public APIs for backward compatibility.
  */
 
 import { getDbInstance } from "./core";
 import { backupDbFile } from "./backup";
+import { type JsonRecord, asRecord, toNonEmptyString, getKeyValue } from "./models/shared";
 import {
+  readCompatList,
+  writeCompatList,
+  deepMergeCompatByProtocol,
+  compatByProtocolHasEntries,
+  isCompatProtocolKey,
+  sanitizeUpstreamHeadersMap,
+  removeModelCompatOverride,
+  type CompatByProtocolMap,
+  type ModelCompatProtocolKey,
+  type ModelCompatOverride,
+  type ModelCompatPerProtocol,
+} from "./models/compat";
+
+export {
+  sanitizeUpstreamHeadersMap,
+  getModelCompatOverrides,
+  mergeModelCompatOverride,
+  removeModelCompatOverride,
   MODEL_COMPAT_PROTOCOL_KEYS,
   type ModelCompatProtocolKey,
-} from "@/shared/constants/modelCompat";
-import { isForbiddenUpstreamHeaderName } from "@/shared/constants/upstreamHeaders";
-
-type JsonRecord = Record<string, unknown>;
-
-/** Built-in / alias models: tool-call + developer-role flags without a full custom row */
-const MODEL_COMPAT_NAMESPACE = "modelCompatOverrides";
-
-export { MODEL_COMPAT_PROTOCOL_KEYS, type ModelCompatProtocolKey };
-
-export type ModelCompatPerProtocol = {
-  normalizeToolCallId?: boolean;
-  preserveOpenAIDeveloperRole?: boolean;
-  /** Merged into upstream HTTP requests for this model (after default auth headers). */
-  upstreamHeaders?: Record<string, string>;
-};
-
-type CompatByProtocolMap = Partial<Record<ModelCompatProtocolKey, ModelCompatPerProtocol>>;
-
-function isCompatProtocolKey(p: string): p is ModelCompatProtocolKey {
-  return (MODEL_COMPAT_PROTOCOL_KEYS as readonly string[]).includes(p);
-}
-
-const UPSTREAM_HEADERS_MAX = 16;
-const UPSTREAM_HEADER_NAME_MAX = 128;
-const UPSTREAM_HEADER_VALUE_MAX = 4096;
-
-function isValidUpstreamHeaderName(k: string): boolean {
-  if (!k || k.length > UPSTREAM_HEADER_NAME_MAX) return false;
-  if (isForbiddenUpstreamHeaderName(k)) return false;
-  if (/[\r\n\0]/.test(k)) return false;
-  if (/\s/.test(k)) return false;
-  if (k.includes(":")) return false;
-  return true;
-}
-
-/** Sanitize user-provided upstream header map (used when persisting and when reading for requests). */
-export function sanitizeUpstreamHeadersMap(
-  raw: Record<string, unknown> | null | undefined
-): Record<string, string> {
-  const out: Record<string, string> = {};
-  if (!raw || typeof raw !== "object") return out;
-  for (const [k0, v0] of Object.entries(raw)) {
-    const k = String(k0).trim();
-    if (!k || !isValidUpstreamHeaderName(k)) {
-      continue;
-    }
-    const v =
-      typeof v0 === "string"
-        ? v0.trim().slice(0, UPSTREAM_HEADER_VALUE_MAX)
-        : String(v0 ?? "")
-            .trim()
-            .slice(0, UPSTREAM_HEADER_VALUE_MAX);
-    if (v.includes("\r") || v.includes("\n")) continue;
-    out[k] = v;
-    if (Object.keys(out).length >= UPSTREAM_HEADERS_MAX) break;
-  }
-  return out;
-}
-
-function deepMergeCompatByProtocol(
-  prev: CompatByProtocolMap | undefined,
-  patch: Partial<Record<ModelCompatProtocolKey, Partial<ModelCompatPerProtocol>>>
-): CompatByProtocolMap {
-  const out: CompatByProtocolMap = { ...(prev || {}) };
-  for (const key of Object.keys(patch) as ModelCompatProtocolKey[]) {
-    if (!isCompatProtocolKey(key)) continue;
-    const deltas = patch[key];
-    if (!deltas || typeof deltas !== "object") continue;
-    const hasDelta =
-      Object.prototype.hasOwnProperty.call(deltas, "normalizeToolCallId") ||
-      Object.prototype.hasOwnProperty.call(deltas, "preserveOpenAIDeveloperRole") ||
-      Object.prototype.hasOwnProperty.call(deltas, "upstreamHeaders");
-    if (!hasDelta) continue;
-    const cur: ModelCompatPerProtocol = { ...(out[key] || {}) };
-    if ("normalizeToolCallId" in deltas) {
-      cur.normalizeToolCallId = Boolean(deltas.normalizeToolCallId);
-    }
-    if ("preserveOpenAIDeveloperRole" in deltas) {
-      cur.preserveOpenAIDeveloperRole = Boolean(deltas.preserveOpenAIDeveloperRole);
-    }
-    if ("upstreamHeaders" in deltas) {
-      const uh = deltas.upstreamHeaders;
-      if (uh === undefined) {
-        /* skip */
-      } else {
-        const s = sanitizeUpstreamHeadersMap(uh as Record<string, unknown>);
-        if (Object.keys(s).length === 0) delete cur.upstreamHeaders;
-        else cur.upstreamHeaders = s;
-      }
-    }
-    if (Object.keys(cur).length === 0) delete out[key];
-    else out[key] = cur;
-  }
-  return out;
-}
-
-export type ModelCompatOverride = {
-  id: string;
-  normalizeToolCallId?: boolean;
-  preserveOpenAIDeveloperRole?: boolean;
-  compatByProtocol?: CompatByProtocolMap;
-  upstreamHeaders?: Record<string, string>;
-  isHidden?: boolean;
-  /**
-   * #3782 — distinct "deleted" marker, separate from {@link isHidden}.
-   *
-   * `isHidden` is set by the EYE/visibility toggle and must be PRESERVED across a
-   * re-sync (the model stays listed-but-hidden). `isDeleted` is set by the trash/
-   * DELETE route and means "drop this id on every re-import" (#3199). Keeping the
-   * two flags distinct is what lets {@link replaceSyncedAvailableModelsForConnection}
-   * preserve eye-hidden models while still dropping deleted ones.
-   */
-  isDeleted?: boolean;
-};
-
-function readCompatList(providerId: string): ModelCompatOverride[] {
-  const db = getDbInstance();
-  const row = db
-    .prepare("SELECT value FROM key_value WHERE namespace = ? AND key = ?")
-    .get(MODEL_COMPAT_NAMESPACE, providerId);
-  const value = getKeyValue(row).value;
-  if (!value) return [];
-  try {
-    const parsed = JSON.parse(value);
-    return Array.isArray(parsed) ? parsed : [];
-  } catch {
-    return [];
-  }
-}
-
-function writeCompatList(providerId: string, list: ModelCompatOverride[]) {
-  const db = getDbInstance();
-  if (list.length === 0) {
-    db.prepare("DELETE FROM key_value WHERE namespace = ? AND key = ?").run(
-      MODEL_COMPAT_NAMESPACE,
-      providerId
-    );
-  } else {
-    db.prepare("INSERT OR REPLACE INTO key_value (namespace, key, value) VALUES (?, ?, ?)").run(
-      MODEL_COMPAT_NAMESPACE,
-      providerId,
-      JSON.stringify(list)
-    );
-  }
-  backupDbFile("pre-write");
-}
-
-export function getModelCompatOverrides(providerId: string): ModelCompatOverride[] {
-  return readCompatList(providerId);
-}
-
-export type ModelCompatPatch = {
-  normalizeToolCallId?: boolean;
-  preserveOpenAIDeveloperRole?: boolean | null;
-  compatByProtocol?: CompatByProtocolMap;
-  /** Replace top-level extra headers for override-only rows; omit to leave unchanged. */
-  upstreamHeaders?: Record<string, string> | null;
-  isHidden?: boolean | null;
-  /** #3782 — distinct delete marker; set by the DELETE route, never by the eye toggle. */
-  isDeleted?: boolean | null;
-};
-
-function compatByProtocolHasEntries(map: CompatByProtocolMap | undefined): boolean {
-  if (!map || typeof map !== "object") return false;
-  return Object.keys(map).some((k) => {
-    const v = map[k as ModelCompatProtocolKey];
-    return v && typeof v === "object" && Object.keys(v).length > 0;
-  });
-}
-
-export function mergeModelCompatOverride(
-  providerId: string,
-  modelId: string,
-  patch: ModelCompatPatch
-) {
-  const list = readCompatList(providerId);
-  const idx = list.findIndex((e) => e.id === modelId);
-  const prev = idx >= 0 ? { ...list[idx] } : { id: modelId };
-  const next: ModelCompatOverride = { ...prev, id: modelId };
-  if ("normalizeToolCallId" in patch) {
-    if (patch.normalizeToolCallId) next.normalizeToolCallId = true;
-    else delete next.normalizeToolCallId;
-  }
-  if ("preserveOpenAIDeveloperRole" in patch) {
-    if (patch.preserveOpenAIDeveloperRole === null) {
-      delete next.preserveOpenAIDeveloperRole; // unset: revert to default (undefined at read time)
-    } else {
-      next.preserveOpenAIDeveloperRole = Boolean(patch.preserveOpenAIDeveloperRole);
-    }
-  }
-  if (patch.compatByProtocol && Object.keys(patch.compatByProtocol).length > 0) {
-    const merged = deepMergeCompatByProtocol(next.compatByProtocol, patch.compatByProtocol);
-    if (compatByProtocolHasEntries(merged)) next.compatByProtocol = merged;
-    else delete next.compatByProtocol;
-  }
-  if ("upstreamHeaders" in patch) {
-    if (patch.upstreamHeaders === null) {
-      delete next.upstreamHeaders;
-    } else if (patch.upstreamHeaders && typeof patch.upstreamHeaders === "object") {
-      const s = sanitizeUpstreamHeadersMap(patch.upstreamHeaders as Record<string, unknown>);
-      if (Object.keys(s).length === 0) delete next.upstreamHeaders;
-      else next.upstreamHeaders = s;
-    }
-  }
-  const filtered = list.filter((e) => e.id !== modelId);
-  const hasPreserveFlag = Object.prototype.hasOwnProperty.call(next, "preserveOpenAIDeveloperRole");
-  const hasTopUpstream = next.upstreamHeaders && Object.keys(next.upstreamHeaders).length > 0;
-  if ("isHidden" in patch) {
-    if (patch.isHidden === null) {
-      delete next.isHidden;
-    } else {
-      next.isHidden = Boolean(patch.isHidden);
-    }
-  }
-  if ("isDeleted" in patch) {
-    if (patch.isDeleted === null || patch.isDeleted === false) {
-      delete next.isDeleted;
-    } else {
-      next.isDeleted = Boolean(patch.isDeleted);
-    }
-  }
-  const hasHiddenFlag = Object.prototype.hasOwnProperty.call(next, "isHidden");
-  const hasDeletedFlag = Object.prototype.hasOwnProperty.call(next, "isDeleted");
-  if (
-    next.normalizeToolCallId ||
-    hasPreserveFlag ||
-    hasHiddenFlag ||
-    hasDeletedFlag ||
-    compatByProtocolHasEntries(next.compatByProtocol) ||
-    hasTopUpstream
-  ) {
-    filtered.push(next);
-  }
-  writeCompatList(providerId, filtered);
-}
-
-export function removeModelCompatOverride(providerId: string, modelId: string) {
-  const list = readCompatList(providerId);
-  const filtered = list.filter((e) => e.id !== modelId);
-  if (filtered.length === list.length) return;
-  writeCompatList(providerId, filtered);
-}
-
-function asRecord(value: unknown): JsonRecord {
-  return value && typeof value === "object" && !Array.isArray(value) ? (value as JsonRecord) : {};
-}
-
-function toNonEmptyString(value: unknown): string | null {
-  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
-}
-
-function getKeyValue(row: unknown): { key: string | null; value: string | null } {
-  const record = asRecord(row);
-  return {
-    key: typeof record.key === "string" ? record.key : null,
-    value: typeof record.value === "string" ? record.value : null,
-  };
-}
-
-// ──────────────── Model Aliases ────────────────
-
-export async function getModelAliases() {
-  const db = getDbInstance();
-  const rows = db
-    .prepare("SELECT key, value FROM key_value WHERE namespace = 'modelAliases'")
-    .all();
-  const result: Record<string, unknown> = {};
-  for (const row of rows) {
-    const { key, value } = getKeyValue(row);
-    if (!key || value === null) continue;
-    result[key] = JSON.parse(value);
-  }
-  return result;
-}
-
-export async function setModelAlias(alias: string, model: unknown) {
-  const db = getDbInstance();
-  db.prepare(
-    "INSERT OR REPLACE INTO key_value (namespace, key, value) VALUES ('modelAliases', ?, ?)"
-  ).run(alias, JSON.stringify(model));
-  backupDbFile("pre-write");
-}
-
-export async function deleteModelAlias(alias: string) {
-  const db = getDbInstance();
-  db.prepare("DELETE FROM key_value WHERE namespace = 'modelAliases' AND key = ?").run(alias);
-  backupDbFile("pre-write");
-}
-
-/**
- * Cascade-delete every model-alias row that resolves to the given provider.
- *
- * Managed/imported aliases are stored as `key = <alias>`, `value = "<providerId>/<model>"`
- * (e.g. `setModelAlias("x-fast", "providerX/fast-model")`). When a custom provider is
- * removed, its connections and node are deleted but these alias rows are left behind,
- * which then block re-importing the same provider ("already exists" / no new models) — see
- * #1409. This removes every alias whose stored value begins with `<providerId>/`, so a
- * fresh import is unblocked.
- *
- * Only string values starting with the exact `"<providerId>/"` prefix match, so unrelated
- * providers and user-facing settings aliases (whose value is the bare alias, not a
- * `<providerId>/<model>` string) are left untouched.
- *
- * @returns the list of alias keys that were removed.
- */
-export async function deleteModelAliasesForProvider(providerId: string): Promise<string[]> {
-  const prefix = `${providerId}/`;
-  const aliases = await getModelAliases();
-  const removed: string[] = [];
-  for (const [alias, value] of Object.entries(aliases)) {
-    if (typeof value !== "string" || !value.startsWith(prefix)) continue;
-    await deleteModelAlias(alias);
-    removed.push(alias);
-  }
-  return removed;
-}
-
-// ──────────────── MITM Alias ────────────────
-
-export async function getMitmAlias(toolName?: string) {
-  const db = getDbInstance();
-  if (toolName) {
-    const row = db
-      .prepare("SELECT value FROM key_value WHERE namespace = 'mitmAlias' AND key = ?")
-      .get(toolName);
-    const value = getKeyValue(row).value;
-    return value ? JSON.parse(value) : {};
-  }
-  const rows = db.prepare("SELECT key, value FROM key_value WHERE namespace = 'mitmAlias'").all();
-  const result: Record<string, unknown> = {};
-  for (const row of rows) {
-    const { key, value } = getKeyValue(row);
-    if (!key || value === null) continue;
-    result[key] = JSON.parse(value);
-  }
-  return result;
-}
-
-export async function setMitmAliasAll(toolName: string, mappings: unknown) {
-  const db = getDbInstance();
-  db.prepare(
-    "INSERT OR REPLACE INTO key_value (namespace, key, value) VALUES ('mitmAlias', ?, ?)"
-  ).run(toolName, JSON.stringify(mappings || {}));
-  backupDbFile("pre-write");
-}
+  type ModelCompatPerProtocol,
+  type ModelCompatOverride,
+  type ModelCompatPatch,
+} from "./models/compat";
+export {
+  getModelAliases,
+  setModelAlias,
+  deleteModelAlias,
+  deleteModelAliasesForProvider,
+} from "./models/aliases";
+export { getMitmAlias, setMitmAliasAll } from "./models/mitmAlias";
 
 // ──────────────── Custom Models ────────────────
 

--- a/src/lib/db/models/aliases.ts
+++ b/src/lib/db/models/aliases.ts
@@ -1,0 +1,61 @@
+/** db/models/aliases.ts — model alias CRUD (modelAliases namespace). */
+
+import { getDbInstance } from "../core";
+import { backupDbFile } from "../backup";
+import { getKeyValue } from "./shared";
+
+export async function getModelAliases() {
+  const db = getDbInstance();
+  const rows = db
+    .prepare("SELECT key, value FROM key_value WHERE namespace = 'modelAliases'")
+    .all();
+  const result: Record<string, unknown> = {};
+  for (const row of rows) {
+    const { key, value } = getKeyValue(row);
+    if (!key || value === null) continue;
+    result[key] = JSON.parse(value);
+  }
+  return result;
+}
+
+export async function setModelAlias(alias: string, model: unknown) {
+  const db = getDbInstance();
+  db.prepare(
+    "INSERT OR REPLACE INTO key_value (namespace, key, value) VALUES ('modelAliases', ?, ?)"
+  ).run(alias, JSON.stringify(model));
+  backupDbFile("pre-write");
+}
+
+export async function deleteModelAlias(alias: string) {
+  const db = getDbInstance();
+  db.prepare("DELETE FROM key_value WHERE namespace = 'modelAliases' AND key = ?").run(alias);
+  backupDbFile("pre-write");
+}
+
+/**
+ * Cascade-delete every model-alias row that resolves to the given provider.
+ *
+ * Managed/imported aliases are stored as `key = <alias>`, `value = "<providerId>/<model>"`
+ * (e.g. `setModelAlias("x-fast", "providerX/fast-model")`). When a custom provider is
+ * removed, its connections and node are deleted but these alias rows are left behind,
+ * which then block re-importing the same provider ("already exists" / no new models) — see
+ * #1409. This removes every alias whose stored value begins with `<providerId>/`, so a
+ * fresh import is unblocked.
+ *
+ * Only string values starting with the exact `"<providerId>/"` prefix match, so unrelated
+ * providers and user-facing settings aliases (whose value is the bare alias, not a
+ * `<providerId>/<model>` string) are left untouched.
+ *
+ * @returns the list of alias keys that were removed.
+ */
+export async function deleteModelAliasesForProvider(providerId: string): Promise<string[]> {
+  const prefix = `${providerId}/`;
+  const aliases = await getModelAliases();
+  const removed: string[] = [];
+  for (const [alias, value] of Object.entries(aliases)) {
+    if (typeof value !== "string" || !value.startsWith(prefix)) continue;
+    await deleteModelAlias(alias);
+    removed.push(alias);
+  }
+  return removed;
+}

--- a/src/lib/db/models/compat.ts
+++ b/src/lib/db/models/compat.ts
@@ -1,0 +1,249 @@
+/** db/models/compat.ts — model-compat overrides (normalizeToolCallId, per-protocol flags, upstream headers). */
+
+import { getDbInstance } from "../core";
+import { backupDbFile } from "../backup";
+import {
+  MODEL_COMPAT_PROTOCOL_KEYS,
+  type ModelCompatProtocolKey,
+} from "@/shared/constants/modelCompat";
+import { isForbiddenUpstreamHeaderName } from "@/shared/constants/upstreamHeaders";
+import { getKeyValue } from "./shared";
+
+/** Built-in / alias models: tool-call + developer-role flags without a full custom row */
+const MODEL_COMPAT_NAMESPACE = "modelCompatOverrides";
+
+export { MODEL_COMPAT_PROTOCOL_KEYS, type ModelCompatProtocolKey };
+
+export type ModelCompatPerProtocol = {
+  normalizeToolCallId?: boolean;
+  preserveOpenAIDeveloperRole?: boolean;
+  /** Merged into upstream HTTP requests for this model (after default auth headers). */
+  upstreamHeaders?: Record<string, string>;
+};
+
+export type CompatByProtocolMap = Partial<Record<ModelCompatProtocolKey, ModelCompatPerProtocol>>;
+
+export function isCompatProtocolKey(p: string): p is ModelCompatProtocolKey {
+  return (MODEL_COMPAT_PROTOCOL_KEYS as readonly string[]).includes(p);
+}
+
+const UPSTREAM_HEADERS_MAX = 16;
+const UPSTREAM_HEADER_NAME_MAX = 128;
+const UPSTREAM_HEADER_VALUE_MAX = 4096;
+
+function isValidUpstreamHeaderName(k: string): boolean {
+  if (!k || k.length > UPSTREAM_HEADER_NAME_MAX) return false;
+  if (isForbiddenUpstreamHeaderName(k)) return false;
+  if (/[\r\n\0]/.test(k)) return false;
+  if (/\s/.test(k)) return false;
+  if (k.includes(":")) return false;
+  return true;
+}
+
+/** Sanitize user-provided upstream header map (used when persisting and when reading for requests). */
+export function sanitizeUpstreamHeadersMap(
+  raw: Record<string, unknown> | null | undefined
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!raw || typeof raw !== "object") return out;
+  for (const [k0, v0] of Object.entries(raw)) {
+    const k = String(k0).trim();
+    if (!k || !isValidUpstreamHeaderName(k)) {
+      continue;
+    }
+    const v =
+      typeof v0 === "string"
+        ? v0.trim().slice(0, UPSTREAM_HEADER_VALUE_MAX)
+        : String(v0 ?? "")
+            .trim()
+            .slice(0, UPSTREAM_HEADER_VALUE_MAX);
+    if (v.includes("\r") || v.includes("\n")) continue;
+    out[k] = v;
+    if (Object.keys(out).length >= UPSTREAM_HEADERS_MAX) break;
+  }
+  return out;
+}
+
+export function deepMergeCompatByProtocol(
+  prev: CompatByProtocolMap | undefined,
+  patch: Partial<Record<ModelCompatProtocolKey, Partial<ModelCompatPerProtocol>>>
+): CompatByProtocolMap {
+  const out: CompatByProtocolMap = { ...(prev || {}) };
+  for (const key of Object.keys(patch) as ModelCompatProtocolKey[]) {
+    if (!isCompatProtocolKey(key)) continue;
+    const deltas = patch[key];
+    if (!deltas || typeof deltas !== "object") continue;
+    const hasDelta =
+      Object.prototype.hasOwnProperty.call(deltas, "normalizeToolCallId") ||
+      Object.prototype.hasOwnProperty.call(deltas, "preserveOpenAIDeveloperRole") ||
+      Object.prototype.hasOwnProperty.call(deltas, "upstreamHeaders");
+    if (!hasDelta) continue;
+    const cur: ModelCompatPerProtocol = { ...(out[key] || {}) };
+    if ("normalizeToolCallId" in deltas) {
+      cur.normalizeToolCallId = Boolean(deltas.normalizeToolCallId);
+    }
+    if ("preserveOpenAIDeveloperRole" in deltas) {
+      cur.preserveOpenAIDeveloperRole = Boolean(deltas.preserveOpenAIDeveloperRole);
+    }
+    if ("upstreamHeaders" in deltas) {
+      const uh = deltas.upstreamHeaders;
+      if (uh === undefined) {
+        /* skip */
+      } else {
+        const s = sanitizeUpstreamHeadersMap(uh as Record<string, unknown>);
+        if (Object.keys(s).length === 0) delete cur.upstreamHeaders;
+        else cur.upstreamHeaders = s;
+      }
+    }
+    if (Object.keys(cur).length === 0) delete out[key];
+    else out[key] = cur;
+  }
+  return out;
+}
+
+export type ModelCompatOverride = {
+  id: string;
+  normalizeToolCallId?: boolean;
+  preserveOpenAIDeveloperRole?: boolean;
+  compatByProtocol?: CompatByProtocolMap;
+  upstreamHeaders?: Record<string, string>;
+  isHidden?: boolean;
+  /**
+   * #3782 — distinct "deleted" marker, separate from {@link isHidden}.
+   *
+   * `isHidden` is set by the EYE/visibility toggle and must be PRESERVED across a
+   * re-sync (the model stays listed-but-hidden). `isDeleted` is set by the trash/
+   * DELETE route and means "drop this id on every re-import" (#3199). Keeping the
+   * two flags distinct is what lets {@link replaceSyncedAvailableModelsForConnection}
+   * preserve eye-hidden models while still dropping deleted ones.
+   */
+  isDeleted?: boolean;
+};
+
+export function readCompatList(providerId: string): ModelCompatOverride[] {
+  const db = getDbInstance();
+  const row = db
+    .prepare("SELECT value FROM key_value WHERE namespace = ? AND key = ?")
+    .get(MODEL_COMPAT_NAMESPACE, providerId);
+  const value = getKeyValue(row).value;
+  if (!value) return [];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+export function writeCompatList(providerId: string, list: ModelCompatOverride[]) {
+  const db = getDbInstance();
+  if (list.length === 0) {
+    db.prepare("DELETE FROM key_value WHERE namespace = ? AND key = ?").run(
+      MODEL_COMPAT_NAMESPACE,
+      providerId
+    );
+  } else {
+    db.prepare("INSERT OR REPLACE INTO key_value (namespace, key, value) VALUES (?, ?, ?)").run(
+      MODEL_COMPAT_NAMESPACE,
+      providerId,
+      JSON.stringify(list)
+    );
+  }
+  backupDbFile("pre-write");
+}
+
+export function getModelCompatOverrides(providerId: string): ModelCompatOverride[] {
+  return readCompatList(providerId);
+}
+
+export type ModelCompatPatch = {
+  normalizeToolCallId?: boolean;
+  preserveOpenAIDeveloperRole?: boolean | null;
+  compatByProtocol?: CompatByProtocolMap;
+  /** Replace top-level extra headers for override-only rows; omit to leave unchanged. */
+  upstreamHeaders?: Record<string, string> | null;
+  isHidden?: boolean | null;
+  /** #3782 — distinct delete marker; set by the DELETE route, never by the eye toggle. */
+  isDeleted?: boolean | null;
+};
+
+export function compatByProtocolHasEntries(map: CompatByProtocolMap | undefined): boolean {
+  if (!map || typeof map !== "object") return false;
+  return Object.keys(map).some((k) => {
+    const v = map[k as ModelCompatProtocolKey];
+    return v && typeof v === "object" && Object.keys(v).length > 0;
+  });
+}
+
+export function mergeModelCompatOverride(
+  providerId: string,
+  modelId: string,
+  patch: ModelCompatPatch
+) {
+  const list = readCompatList(providerId);
+  const idx = list.findIndex((e) => e.id === modelId);
+  const prev = idx >= 0 ? { ...list[idx] } : { id: modelId };
+  const next: ModelCompatOverride = { ...prev, id: modelId };
+  if ("normalizeToolCallId" in patch) {
+    if (patch.normalizeToolCallId) next.normalizeToolCallId = true;
+    else delete next.normalizeToolCallId;
+  }
+  if ("preserveOpenAIDeveloperRole" in patch) {
+    if (patch.preserveOpenAIDeveloperRole === null) {
+      delete next.preserveOpenAIDeveloperRole; // unset: revert to default (undefined at read time)
+    } else {
+      next.preserveOpenAIDeveloperRole = Boolean(patch.preserveOpenAIDeveloperRole);
+    }
+  }
+  if (patch.compatByProtocol && Object.keys(patch.compatByProtocol).length > 0) {
+    const merged = deepMergeCompatByProtocol(next.compatByProtocol, patch.compatByProtocol);
+    if (compatByProtocolHasEntries(merged)) next.compatByProtocol = merged;
+    else delete next.compatByProtocol;
+  }
+  if ("upstreamHeaders" in patch) {
+    if (patch.upstreamHeaders === null) {
+      delete next.upstreamHeaders;
+    } else if (patch.upstreamHeaders && typeof patch.upstreamHeaders === "object") {
+      const s = sanitizeUpstreamHeadersMap(patch.upstreamHeaders as Record<string, unknown>);
+      if (Object.keys(s).length === 0) delete next.upstreamHeaders;
+      else next.upstreamHeaders = s;
+    }
+  }
+  const filtered = list.filter((e) => e.id !== modelId);
+  const hasPreserveFlag = Object.prototype.hasOwnProperty.call(next, "preserveOpenAIDeveloperRole");
+  const hasTopUpstream = next.upstreamHeaders && Object.keys(next.upstreamHeaders).length > 0;
+  if ("isHidden" in patch) {
+    if (patch.isHidden === null) {
+      delete next.isHidden;
+    } else {
+      next.isHidden = Boolean(patch.isHidden);
+    }
+  }
+  if ("isDeleted" in patch) {
+    if (patch.isDeleted === null || patch.isDeleted === false) {
+      delete next.isDeleted;
+    } else {
+      next.isDeleted = Boolean(patch.isDeleted);
+    }
+  }
+  const hasHiddenFlag = Object.prototype.hasOwnProperty.call(next, "isHidden");
+  const hasDeletedFlag = Object.prototype.hasOwnProperty.call(next, "isDeleted");
+  if (
+    next.normalizeToolCallId ||
+    hasPreserveFlag ||
+    hasHiddenFlag ||
+    hasDeletedFlag ||
+    compatByProtocolHasEntries(next.compatByProtocol) ||
+    hasTopUpstream
+  ) {
+    filtered.push(next);
+  }
+  writeCompatList(providerId, filtered);
+}
+
+export function removeModelCompatOverride(providerId: string, modelId: string) {
+  const list = readCompatList(providerId);
+  const filtered = list.filter((e) => e.id !== modelId);
+  if (filtered.length === list.length) return;
+  writeCompatList(providerId, filtered);
+}

--- a/src/lib/db/models/mitmAlias.ts
+++ b/src/lib/db/models/mitmAlias.ts
@@ -1,0 +1,32 @@
+/** db/models/mitmAlias.ts — MITM alias CRUD (mitmAlias namespace). */
+
+import { getDbInstance } from "../core";
+import { backupDbFile } from "../backup";
+import { getKeyValue } from "./shared";
+
+export async function getMitmAlias(toolName?: string) {
+  const db = getDbInstance();
+  if (toolName) {
+    const row = db
+      .prepare("SELECT value FROM key_value WHERE namespace = 'mitmAlias' AND key = ?")
+      .get(toolName);
+    const value = getKeyValue(row).value;
+    return value ? JSON.parse(value) : {};
+  }
+  const rows = db.prepare("SELECT key, value FROM key_value WHERE namespace = 'mitmAlias'").all();
+  const result: Record<string, unknown> = {};
+  for (const row of rows) {
+    const { key, value } = getKeyValue(row);
+    if (!key || value === null) continue;
+    result[key] = JSON.parse(value);
+  }
+  return result;
+}
+
+export async function setMitmAliasAll(toolName: string, mappings: unknown) {
+  const db = getDbInstance();
+  db.prepare(
+    "INSERT OR REPLACE INTO key_value (namespace, key, value) VALUES ('mitmAlias', ?, ?)"
+  ).run(toolName, JSON.stringify(mappings || {}));
+  backupDbFile("pre-write");
+}

--- a/src/lib/db/models/shared.ts
+++ b/src/lib/db/models/shared.ts
@@ -1,0 +1,19 @@
+/** db/models/shared.ts — foundational JSON-record helpers shared across model sub-modules. */
+
+export type JsonRecord = Record<string, unknown>;
+
+export function asRecord(value: unknown): JsonRecord {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as JsonRecord) : {};
+}
+
+export function toNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+export function getKeyValue(row: unknown): { key: string | null; value: string | null } {
+  const record = asRecord(row);
+  return {
+    key: typeof record.key === "string" ? record.key : null,
+    value: typeof record.value === "string" ? record.value : null,
+  };
+}

--- a/tests/unit/db-models-split.test.ts
+++ b/tests/unit/db-models-split.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Characterization tests for the db/models god-file decomposition (BLOCO E3).
+ * The compat-overrides, model-alias, MITM-alias and shared helpers were lifted out
+ * of src/lib/db/models.ts verbatim into cohesive leaf modules under db/models/.
+ * These tests pin the behavior of the pure extracted helpers AND guard that the
+ * host module still re-exports the full public API consumed across the codebase.
+ *
+ * (Behavioral DB-backed coverage of the moved CRUD/alias paths lives in the
+ * existing db-models-crud / db-models-extended / db-model-aliases-cascade suites.)
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { asRecord, toNonEmptyString, getKeyValue } from "../../src/lib/db/models/shared.ts";
+import {
+  sanitizeUpstreamHeadersMap,
+  isCompatProtocolKey,
+  deepMergeCompatByProtocol,
+  compatByProtocolHasEntries,
+} from "../../src/lib/db/models/compat.ts";
+
+test("shared: asRecord only unwraps plain objects", () => {
+  assert.deepEqual(asRecord({ a: 1 }), { a: 1 });
+  assert.deepEqual(asRecord(null), {});
+  assert.deepEqual(asRecord([1, 2]), {});
+  assert.deepEqual(asRecord("x"), {});
+});
+
+test("shared: toNonEmptyString trims and rejects blanks", () => {
+  assert.equal(toNonEmptyString("  hi "), "hi");
+  assert.equal(toNonEmptyString("   "), null);
+  assert.equal(toNonEmptyString(""), null);
+  assert.equal(toNonEmptyString(5), null);
+});
+
+test("shared: getKeyValue reads key/value strings only", () => {
+  assert.deepEqual(getKeyValue({ key: "k", value: "v" }), { key: "k", value: "v" });
+  assert.deepEqual(getKeyValue({ key: 1, value: null }), { key: null, value: null });
+  assert.deepEqual(getKeyValue(undefined), { key: null, value: null });
+});
+
+test("compat: sanitizeUpstreamHeadersMap enforces structural validity", () => {
+  assert.deepEqual(sanitizeUpstreamHeadersMap({ "X-Api-Key": "abc" }), { "X-Api-Key": "abc" });
+  // names with whitespace or colon are dropped
+  assert.deepEqual(sanitizeUpstreamHeadersMap({ "Bad Name": "v" }), {});
+  assert.deepEqual(sanitizeUpstreamHeadersMap({ "bad:name": "v" }), {});
+  // CRLF in value is rejected
+  assert.deepEqual(sanitizeUpstreamHeadersMap({ "X-H": "a\r\nb" }), {});
+  // null / non-object => empty
+  assert.deepEqual(sanitizeUpstreamHeadersMap(null), {});
+  // cap at 16 entries
+  const many: Record<string, string> = {};
+  for (let i = 0; i < 40; i++) many[`H-${i}`] = "v";
+  assert.equal(Object.keys(sanitizeUpstreamHeadersMap(many)).length, 16);
+});
+
+test("compat: isCompatProtocolKey recognizes known protocol keys only", () => {
+  assert.equal(isCompatProtocolKey("openai"), true);
+  assert.equal(isCompatProtocolKey("definitely-not-a-protocol"), false);
+});
+
+test("compat: deepMergeCompatByProtocol + compatByProtocolHasEntries", () => {
+  const merged = deepMergeCompatByProtocol(undefined, {
+    openai: { normalizeToolCallId: true },
+  });
+  assert.equal(merged.openai?.normalizeToolCallId, true);
+  assert.equal(compatByProtocolHasEntries(merged), true);
+  assert.equal(compatByProtocolHasEntries(undefined), false);
+  assert.equal(compatByProtocolHasEntries({}), false);
+  // a later patch deep-merges without clobbering prior fields
+  const merged2 = deepMergeCompatByProtocol(merged, {
+    openai: { preserveOpenAIDeveloperRole: false },
+  });
+  assert.equal(merged2.openai?.normalizeToolCallId, true);
+  assert.equal(merged2.openai?.preserveOpenAIDeveloperRole, false);
+});
+
+test("host db/models.ts preserves its full public API after the split", async () => {
+  const host = (await import("../../src/lib/db/models.ts")) as Record<string, unknown>;
+  // re-exported from leaves
+  for (const name of [
+    "sanitizeUpstreamHeadersMap",
+    "getModelCompatOverrides",
+    "mergeModelCompatOverride",
+    "removeModelCompatOverride",
+    "MODEL_COMPAT_PROTOCOL_KEYS",
+    "getModelAliases",
+    "setModelAlias",
+    "deleteModelAlias",
+    "deleteModelAliasesForProvider",
+    "getMitmAlias",
+    "setMitmAliasAll",
+  ]) {
+    assert.ok(host[name] !== undefined, `db/models must still export ${name}`);
+  }
+  // kept in host (custom / synced / flags)
+  for (const name of [
+    "getCustomModels",
+    "getAllCustomModels",
+    "addCustomModel",
+    "replaceCustomModels",
+    "removeCustomModel",
+    "updateCustomModel",
+    "getSyncedAvailableModels",
+    "getAllSyncedAvailableModels",
+    "replaceSyncedAvailableModelsForConnection",
+    "getModelNormalizeToolCallId",
+    "getModelPreserveOpenAIDeveloperRole",
+    "getModelIsHidden",
+    "getHiddenModelsByProvider",
+    "getModelIsDeleted",
+    "setModelIsHidden",
+    "getModelUpstreamExtraHeaders",
+  ]) {
+    assert.equal(typeof host[name], "function", `db/models must still export ${name}`);
+  }
+});


### PR DESCRIPTION
## BLOCO E3 — `db/models.ts` god-file decomposition (campanha SDD quality & god-files)

Fatia **segura, sem ciclos e behavior-preserving** do god-file `src/lib/db/models.ts` (1250 LOC), que misturava 6 concerns. As três fronteiras limpamente separáveis + os helpers `key_value` compartilhados foram extraídos **verbatim** para `src/lib/db/models/`; o **trio acoplado custom/synced/flags fica no host** (separá-lo limpo é follow-up).

`db/models.ts`: **1250 → 936 LOC** (frozen baseline 1259; já era frozen-satisfeito → redução de dívida, não gate-required).

### Leaves criados
| Arquivo | LOC | Conteúdo |
|---|---|---|
| `models/shared.ts` | 19 | `asRecord` / `toNonEmptyString` / `getKeyValue` + `JsonRecord` |
| `models/compat.ts` | 249 | model-compat overrides + `sanitizeUpstreamHeadersMap` |
| `models/aliases.ts` | 61 | model-alias CRUD + cascade-delete (#1409) |
| `models/mitmAlias.ts` | 32 | MITM alias get/set |

### Por que o trio custom/synced/flags fica no host
Acoplamento real (não-quebrável sem ciclo nesta fatia): `flags→getCustomModelRow`, `flags→readCompatList`, `custom→removeModelCompatOverride`, `synced→getModelIsDeleted`, `setModelIsHidden→updateCustomModel`. Parar no core acoplado é a decisão correta (anti split-por-split). DAG das extrações é **acíclico** (`check:cycles` ✓).

### API pública preservada (verificado)
Diff do **conjunto de símbolos exportados** de `@/lib/db/models` antes vs depois = **vazio**. O host re-exporta todos os símbolos movidos (`sanitizeUpstreamHeadersMap`, `getModelCompatOverrides`, `mergeModelCompatOverride`, `removeModelCompatOverride`, `MODEL_COMPAT_PROTOCOL_KEYS`, aliases, mitm + tipos). Nenhum dos ~29 arquivos de teste / `localDb` consumidores muda.

### Testes
- **Novo** `tests/unit/db-models-split.test.ts` (7 testes): caracterização dos helpers puros extraídos + guarda do export-surface completo do host.
- **77 testes** existentes de consumidores verdes (`db-models-crud`/`db-models-extended`/`db-model-aliases-cascade` + `model-alias-route`/`model-sync-route`/`managed-model-import`/`managed-available-models`/`model-metadata-registry`/`noauth-imported-models-3200`/`custom-model-target-format`).

### Validação local (re-rodada na auditoria, não só pelo subagente)
`typecheck:core` ✓ · `check:cycles` (308 arquivos, 0 ciclos) ✓ · 77 testes consumidores ✓ · 7 testes novos ✓ · ESLint ✓ · Prettier ✓ · `check:file-size` (host 936 < frozen 1259; sem novas violações) ✓.

> Não-mergear até liberação do dono (no-merge-meddling). Sem `release-freeze` ativo na abertura. Extração mecânica feita por subagente e **auditada** (export-set idêntico + verbatim line-check + gates re-rodados).
