### PR TITLE
test(dashboard): repoint sidebar quota-share placement scan to sections.ts (fix base-red from D1 #5683)

### DIFF
--- a/tests/unit/sidebar-quota-share-placement.test.ts
+++ b/tests/unit/sidebar-quota-share-placement.test.ts
@@ -8,6 +8,10 @@
  *
  * Pattern mirrors: tests/unit/quota-groups-ui.test.ts (readFileSync style)
  *
+ * Source location: the nav-item id definitions live in
+ * `src/shared/constants/sidebarVisibility/sections.ts` (extracted from the
+ * former monolithic `sidebarVisibility.ts` in the D1 god-file split, #5683).
+ *
  * Node.js native test runner — no DOM setup required.
  */
 
@@ -19,7 +23,7 @@ import { fileURLToPath } from "node:url";
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 
-const SIDEBAR_PATH = join(ROOT, "src/shared/constants/sidebarVisibility.ts");
+const SIDEBAR_PATH = join(ROOT, "src/shared/constants/sidebarVisibility/sections.ts");
 
 const src = readFileSync(SIDEBAR_PATH, "utf8");
 


### PR DESCRIPTION
## Problema
O split de god-file do **D1 (#5683)** moveu as definições de `id:` dos itens de navegação de `src/shared/constants/sidebarVisibility.ts` para o leaf extraído `src/shared/constants/sidebarVisibility/sections.ts`. O teste source-scan `tests/unit/sidebar-quota-share-placement.test.ts` continuava lendo o caminho do monólito antigo → encontrava **0 ocorrências** de `id: "costs-quota-share"` → **base-red** na `release/v3.8.43`.

## Fix (test-only, cirúrgico)
- Reaponta `SIDEBAR_PATH` para `sections.ts`, onde os ids vivem agora.
- Atualiza o comentário do cabeçalho documentando a nova localização (anti comment-rot).

Nenhuma mudança em código de produção.

## Validação (TDD — Hard Rule #18)
- **Antes:** `✖ exactly one occurrence of costs-quota-share — found 0` (vermelho).
- **Depois:** `✔ 4/4` (verde) — as quatro asserções de posicionamento (quota-share após quota, mesmo array, distante de costs-budget, exatamente uma ocorrência) seguem válidas contra `sections.ts`.
- Suíte sidebar completa (15 arquivos, **104 testes**) → **104/104 verdes**, confirmando que este era o único teste quebrado pelo D1.

```
node --import tsx/esm --test tests/unit/sidebar-quota-share-placement.test.ts
# ✔ pass 4 / fail 0
```