### PR TITLE
docs(readme): document faster/leaner install — skip native build, sql.js fallback (#5550)

### DIFF
--- a/README.md
+++ b/README.md
@@ -666,6 +666,24 @@ podman compose --profile base up -d
 
 📖 [Podman Guide](contrib/podman/README.md) — Quadlet setup, podman-compose, Quadlet.
 
+**⚡ Faster / leaner install (skip the native build)**
+
+The native SQLite engine (`better-sqlite3`) is an **optional** dependency, so a global
+install never blocks on compiling from source: it uses a prebuilt binary when one matches
+your platform/Node, and otherwise falls back transparently to a pure-JS engine
+(`node:sqlite` on Node 22+, else the bundled `sql.js` WASM) — no build tools required.
+
+To skip the post-install native warm-up entirely (CI, headless, or slow machines):
+
+```bash
+OMNIROUTE_SKIP_POSTINSTALL=1 npm install -g omniroute   # CI=1 also skips it
+```
+
+For the fastest installs prefer **pnpm** (content-addressed store + hard links — see above).
+For a dashboard-free, headless runtime use the Docker `base` profile (above) or the
+[Termux guide](docs/guides/TERMUX_GUIDE.md). The CLI and the web dashboard are served by the
+same process on one port, so there is no separate CLI-only package today.
+
 <br/>
 
 <div align="center">


### PR DESCRIPTION
## What & why

Answers the recurring "why is `npm install -g omniroute` slow / is there a CLI-only install" question (#5550) by surfacing options that **already exist** but were buried in `docs/reference/ENVIRONMENT.md`.

Adds a **"⚡ Faster / leaner install"** subsection to the README install methods:

- `better-sqlite3` is an **optional** dependency with a transparent pure-JS fallback (`node:sqlite` on Node 22+, else bundled `sql.js` WASM) — no build tools required, install never blocks on a native compile.
- `OMNIROUTE_SKIP_POSTINSTALL=1` (and `CI=1`) skip the post-install native warm-up.
- pnpm as the fastest install path; Docker `base` profile / Termux for a headless, dashboard-free runtime.

## Scope

Docs-only — no production code touched (`README.md`, +18 lines). Validated: `check-fabricated-docs`, `check:doc-links`, `check-docs-counts-sync` all green.

Refs #5550