### PR TITLE
refactor(db): decompose db/providers.ts god-file into columns/nodes/rate-limit leaves

### DIFF
--- a/src/lib/db/providers.ts
+++ b/src/lib/db/providers.ts
@@ -4,7 +4,6 @@
 
 import { v4 as uuidv4 } from "uuid";
 import { getDbInstance, rowToCamel, cleanNulls } from "./core";
-import { selectProviderNodeForConnection } from "./providerNodeSelect";
 import { backupDbFile } from "./backup";
 import {
   encryptConnectionFields,
@@ -15,6 +14,18 @@ import { invalidateDbCache } from "./readCache";
 import { normalizeProviderSpecificData } from "@/lib/providers/requestDefaults";
 import { bumpProxyConfigGeneration } from "./settings";
 import { webSessionCredentialKey, parseProviderSpecificData } from "./webSessionDedup";
+import {
+  withNullableMaxConcurrent,
+  withNullableQuotaWindowThresholds,
+  withNullableRateLimitOverrides,
+  normalizeBooleanColumn,
+  sanitizeRateLimitOverrides,
+  serializeJsonField,
+  toRecord,
+  sanitizeQuotaWindowThresholds,
+  toStringOrNull,
+  toNumberOrZero,
+} from "./providers/columns";
 
 type JsonRecord = Record<string, unknown>;
 
@@ -26,116 +37,6 @@ interface StatementLike<TRow = unknown> {
 
 interface DbLike {
   prepare: <TRow = unknown>(sql: string) => StatementLike<TRow>;
-}
-
-function withNullableMaxConcurrent(
-  record: JsonRecord,
-  source: JsonRecord | null | undefined
-): JsonRecord {
-  if (!source || !Object.hasOwn(source, "maxConcurrent")) {
-    return record;
-  }
-
-  const sourceMaxConcurrent = source.maxConcurrent;
-  const normalizedMaxConcurrent =
-    typeof sourceMaxConcurrent === "number" || sourceMaxConcurrent === null
-      ? sourceMaxConcurrent
-      : record.maxConcurrent;
-
-  return {
-    ...record,
-    maxConcurrent: normalizedMaxConcurrent,
-  };
-}
-
-// Always surface `quotaWindowThresholds` (possibly null) on the returned
-// object — `cleanNulls` strips null values, but the UI needs to see null so
-// it can distinguish "no overrides on this connection" from "field was
-// never read." Mirrors `withNullableMaxConcurrent`'s contract so create and
-// update return the same shape regardless of whether the source had the key
-// stripped or carried forward.
-function withNullableQuotaWindowThresholds(
-  record: JsonRecord,
-  source: JsonRecord | null | undefined
-): JsonRecord {
-  return {
-    ...record,
-    quotaWindowThresholds: (source?.quotaWindowThresholds ?? null) as Record<string, number> | null,
-  };
-}
-
-// Always surface `rateLimitOverrides` (possibly null) — matches the pattern
-// used by withNullableMaxConcurrent and withNullableQuotaWindowThresholds.
-function withNullableRateLimitOverrides(
-  record: JsonRecord,
-  source: JsonRecord | null | undefined
-): JsonRecord {
-  return {
-    ...record,
-    rateLimitOverrides: (source?.rateLimitOverrides ?? null) as Record<string, number> | null,
-  };
-}
-
-function normalizeBooleanColumn(value: unknown, fallback: boolean): boolean {
-  if (typeof value === "boolean") return value;
-  if (typeof value === "number") return value === 1;
-  if (typeof value === "string") {
-    const normalized = value.trim().toLowerCase();
-    if (normalized === "1" || normalized === "true") return true;
-    if (normalized === "0" || normalized === "false") return false;
-  }
-  return fallback;
-}
-
-// Sanitize the per-connection rate limit overrides map: keep only known
-// fields with valid numeric values. Called once at each write-path boundary.
-function sanitizeRateLimitOverrides(value: unknown): Record<string, number> | null {
-  if (value === null || value === undefined) return null;
-  if (typeof value !== "object" || Array.isArray(value)) return null;
-  const allowedKeys = new Set(["rpm", "tpm", "tpd", "minTime", "maxConcurrent"]);
-  const map: Record<string, number> = {};
-  for (const [key, v] of Object.entries(value as Record<string, unknown>)) {
-    if (!allowedKeys.has(key)) continue;
-    if (typeof v === "number" && Number.isInteger(v) && v >= 0) {
-      map[key] = v;
-    }
-  }
-  return Object.keys(map).length === 0 ? null : map;
-}
-
-// Serialize an already-sanitized map for SQLite TEXT storage.
-function serializeJsonField(value: unknown): string | null {
-  if (value === null || value === undefined) return null;
-  if (typeof value !== "object" || Array.isArray(value)) return null;
-  return JSON.stringify(value);
-}
-
-function toRecord(value: unknown): JsonRecord {
-  return value && typeof value === "object" ? (value as JsonRecord) : {};
-}
-
-// Sanitize the per-window threshold map: keep only 0-100 integer values.
-// Called once at each write-path boundary (createProviderConnection +
-// updateProviderConnection) so both the in-memory return and the persisted
-// row share the same shape. Serialization below trusts this output.
-function sanitizeQuotaWindowThresholds(value: unknown): Record<string, number> | null {
-  if (value === null || value === undefined) return null;
-  if (typeof value !== "object" || Array.isArray(value)) return null;
-  const map: Record<string, number> = {};
-  for (const [key, v] of Object.entries(value as Record<string, unknown>)) {
-    if (typeof v === "number" && Number.isInteger(v) && v >= 0 && v <= 100) {
-      map[key] = v;
-    }
-  }
-  return Object.keys(map).length === 0 ? null : map;
-}
-
-function toStringOrNull(value: unknown): string | null {
-  return typeof value === "string" ? value : null;
-}
-
-function toNumberOrZero(value: unknown): number {
-  return typeof value === "number" ? value : 0;
 }
 
 // ──────────────── Provider Connections ────────────────
@@ -798,309 +699,21 @@ export function autoMigrateLegacyEncryptedConnections(): number {
   return migratedCount;
 }
 
-// ──────────────── Provider Nodes ────────────────
+// ──────────────── Re-exports from leaf modules ────────────────
 
-export async function getProviderNodes(filter: JsonRecord = {}) {
-  const db = getDbInstance() as unknown as DbLike;
-  let sql = "SELECT * FROM provider_nodes";
-  const params: Record<string, unknown> = {};
-
-  if (filter.type) {
-    sql += " WHERE type = @type";
-    params.type = filter.type;
-  }
-
-  return db.prepare(sql).all(params).map(rowToCamel);
-}
-
-export async function getProviderNodeById(id: string) {
-  const db = getDbInstance() as unknown as DbLike;
-  const row = db.prepare("SELECT * FROM provider_nodes WHERE id = ?").get(id);
-  return row ? rowToCamel(row) : null;
-}
-
-// #4421: resolve the provider node for a new connection from either its concrete id
-// (what the dashboard sends, "<type>-<uuid>") OR the bare derived type (what callers
-// using the /api/providers API directly often pass, e.g. "openai-compatible-responses").
-// Falls back to the sole node of that type only when unambiguous; otherwise null (so the
-// caller still surfaces the existing 404).
-export async function resolveProviderNodeForConnection(idOrType: string) {
-  const exact = await getProviderNodeById(idOrType);
-  if (exact) return exact;
-  const all = (await getProviderNodes()) as JsonRecord[];
-  return selectProviderNodeForConnection(idOrType, all);
-}
-
-export async function createProviderNode(data: JsonRecord) {
-  const db = getDbInstance() as unknown as DbLike;
-  const now = new Date().toISOString();
-
-  const customHeadersJson = data.customHeaders ? JSON.stringify(data.customHeaders) : null;
-
-  const node = {
-    id: data.id || uuidv4(),
-    type: data.type,
-    name: data.name,
-    prefix: data.prefix || null,
-    apiType: data.apiType || null,
-    baseUrl: data.baseUrl || null,
-    chatPath: data.chatPath || null,
-    modelsPath: data.modelsPath || null,
-    customHeadersJson,
-    createdAt: now,
-    updatedAt: now,
-  };
-
-  db.prepare(
-    `
-    INSERT INTO provider_nodes (id, type, name, prefix, api_type, base_url, chat_path, models_path, custom_headers_json, created_at, updated_at)
-    VALUES (@id, @type, @name, @prefix, @apiType, @baseUrl, @chatPath, @modelsPath, @customHeadersJson, @createdAt, @updatedAt)
-  `
-  ).run(node);
-
-  backupDbFile("pre-write");
-
-  const result: JsonRecord = { ...node };
-  if (customHeadersJson) {
-    try {
-      result.customHeaders = JSON.parse(customHeadersJson);
-    } catch {
-      result.customHeaders = null;
-    }
-  } else {
-    result.customHeaders = null;
-  }
-  delete result.customHeadersJson;
-  return result;
-}
-
-export async function updateProviderNode(id: string, data: JsonRecord) {
-  const db = getDbInstance() as unknown as DbLike;
-  const existing = db.prepare("SELECT * FROM provider_nodes WHERE id = ?").get(id);
-  if (!existing) return null;
-
-  const merged: JsonRecord = {
-    ...toRecord(rowToCamel(existing)),
-    ...data,
-    updatedAt: new Date().toISOString(),
-  };
-
-  if (data.customHeaders !== undefined) {
-    merged["customHeadersJson"] = data.customHeaders ? JSON.stringify(data.customHeaders) : null;
-  } else {
-    // Partial update that omits customHeaders must PRESERVE the stored value.
-    // rowToCamel surfaces the column under `customHeaders` (suffix stripped),
-    // never `customHeadersJson`, so read the raw stored JSON from `existing`
-    // directly instead of relying on the (absent) merged key — otherwise the
-    // UPDATE would bind null and silently wipe the saved headers.
-    const existingJson = (existing as JsonRecord).custom_headers_json;
-    merged["customHeadersJson"] = typeof existingJson === "string" ? existingJson : null;
-  }
-
-  db.prepare(
-    `
-    UPDATE provider_nodes SET type = @type, name = @name, prefix = @prefix,
-    api_type = @apiType, base_url = @baseUrl, chat_path = @chatPath,
-    models_path = @modelsPath, custom_headers_json = @customHeadersJson, updated_at = @updatedAt
-    WHERE id = @id
-  `
-  ).run({
-    id,
-    type: merged["type"],
-    name: merged["name"],
-    prefix: merged["prefix"] || null,
-    apiType: merged["apiType"] || null,
-    baseUrl: merged["baseUrl"] || null,
-    chatPath: merged["chatPath"] || null,
-    modelsPath: merged["modelsPath"] || null,
-    customHeadersJson: merged["customHeadersJson"] || null,
-    updatedAt: merged["updatedAt"],
-  });
-
-  backupDbFile("pre-write");
-
-  const result: JsonRecord = { ...merged };
-  const storedJson = merged["customHeadersJson"] as string | null;
-  if (storedJson) {
-    try {
-      result.customHeaders = JSON.parse(storedJson);
-    } catch {
-      result.customHeaders = null;
-    }
-  } else {
-    result.customHeaders = null;
-  }
-  delete result.customHeadersJson;
-  return result;
-}
-
-export async function deleteProviderNode(id: string) {
-  const db = getDbInstance() as unknown as DbLike;
-  const existing = db.prepare("SELECT * FROM provider_nodes WHERE id = ?").get(id);
-  if (!existing) return null;
-
-  db.prepare("DELETE FROM provider_nodes WHERE id = ?").run(id);
-  backupDbFile("pre-write");
-  return rowToCamel(existing);
-}
-
-// ──────────────── T05: Rate-Limit DB Persistence ──────────────────────────
-// Allows rate-limit state to survive token refresh without being accidentally
-// cleared. DB column rate_limited_until already exists in schema.
-// Ref: sub2api PR #1218 (fix(openai): prevent rescheduling rate-limited accounts)
-
-/**
- * T05: Persist when a connection is rate-limited, directly in DB.
- * This survives token refresh — OAuth flows must NOT override this field.
- *
- * @param connectionId - The provider_connections.id
- * @param until - Epoch ms when the rate limit expires (null to clear)
- */
-export function setConnectionRateLimitUntil(connectionId: string, until: number | null): void {
-  const db = getDbInstance() as unknown as DbLike;
-  db.prepare(
-    "UPDATE provider_connections SET rate_limited_until = ?, updated_at = ? WHERE id = ?"
-  ).run(until, new Date().toISOString(), connectionId);
-  invalidateDbCache("connections");
-}
-
-/**
- * T05: Check if a connection is currently rate-limited (DB-backed).
- * Use this before account selection to skip transiently rate-limited accounts.
- *
- * @returns true if rate_limited_until is set and in the future
- */
-export function isConnectionRateLimited(connectionId: string): boolean {
-  const db = getDbInstance() as unknown as DbLike;
-  const row = db
-    .prepare("SELECT rate_limited_until FROM provider_connections WHERE id = ?")
-    .get(connectionId) as { rate_limited_until?: number | null } | undefined;
-  if (!row?.rate_limited_until) return false;
-  return Date.now() < row.rate_limited_until;
-}
-
-/**
- * T05: Get all connections for a provider that are currently rate-limited.
- * Returns an array of { id, rateLimitedUntil } for dashboard display.
- */
-export function getRateLimitedConnections(
-  provider: string
-): Array<{ id: string; rateLimitedUntil: number }> {
-  const db = getDbInstance() as unknown as DbLike;
-  const now = Date.now();
-  const rows = db
-    .prepare(
-      "SELECT id, rate_limited_until FROM provider_connections WHERE provider = ? AND rate_limited_until > ?"
-    )
-    .all(provider, now) as Array<{ id: string; rate_limited_until: number }>;
-  return rows.map((r) => ({ id: r.id, rateLimitedUntil: r.rate_limited_until }));
-}
-
-// ──────────────── T13: Stale Quota Display Fix ─────────────────────────────
-// Codex/Claude quotas display stale cumulative usage after the window resets.
-// By comparing resetAt timestamp to now(), we can show 0 when window has passed.
-// Ref: sub2api PR #1171 (fix: quota display shows stale cumulative usage after reset)
-
-/**
- * T13: Get effective quota usage, zeroing it out if the window has already reset.
- *
- * @param used - Stored usage value (tokens used in the window)
- * @param resetAt - ISO-8601 string or epoch ms when the window resets, or null
- * @returns Effective usage: 0 if window expired, original value otherwise
- */
-export function getEffectiveQuotaUsage(
-  used: number,
-  resetAt: string | number | null | undefined
-): number {
-  if (!resetAt) return used;
-  const resetTime = typeof resetAt === "number" ? resetAt : new Date(resetAt).getTime();
-  if (isNaN(resetTime)) return used;
-  // Window has passed — display should show 0 (pending next snapshot)
-  if (Date.now() >= resetTime) return 0;
-  return used;
-}
-
-/**
- * T05: Startup crash-recovery — clear stale transient connection cooldowns.
- *
- * After an unclean crash (SIGKILL, OOM-kill, large-body burst) the normal
- * error-handler paths that would clear/normalise cooldowns never run.
- * A connection's `rate_limited_until` may have been pushed far into the
- * future by exponential back-off.  On next startup that leaves all affected
- * connections excluded by `getProviderCredentials()`, so every request sits
- * in the Bottleneck queue and times out at `maxWaitMs` (120 s default).
- *
- * Safe invariants:
- *  - Only connections with `rate_limited_until IS NOT NULL` are touched.
- *  - Terminal states (`banned`, `expired`, `credits_exhausted`) are skipped —
- *    those require a deliberate credential change or operator reset.
- *  - Past timestamps are also cleared: they are already expired in the lazy
- *    expiry sense, but clearing them resets `backoffLevel` / transient error
- *    fields so the connection gets a clean slate on this fresh process.
- *
- * Must be called once, early in the startup sequence, before any request
- * is handled.  Returns the number of connections that were cleared.
- */
-export function clearStaleCrashCooldowns(): { cleared: number } {
-  const db = getDbInstance() as unknown as DbLike;
-  const now = new Date().toISOString();
-
-  // Fetch all connections that have a rate_limited_until set and are NOT in
-  // a terminal state.  We do the terminal-status filter in JS to reuse the
-  // canonical `TERMINAL_STATUSES` set rather than duplicating the list in SQL.
-  const TERMINAL_STATUSES = new Set(["banned", "expired", "credits_exhausted"]);
-
-  const rows = db
-    .prepare(
-      `SELECT id, test_status FROM provider_connections WHERE rate_limited_until IS NOT NULL`
-    )
-    .all() as Array<{ id: string; test_status: string | null }>;
-
-  const toReset = rows.filter((r) => {
-    const status = (r.test_status || "").trim().toLowerCase();
-    return !TERMINAL_STATUSES.has(status);
-  });
-
-  if (toReset.length === 0) return { cleared: 0 };
-
-  const stmt = db.prepare(
-    `UPDATE provider_connections SET
-       rate_limited_until = NULL,
-       test_status        = 'active',
-       backoff_level      = 0,
-       last_error         = NULL,
-       last_error_at      = NULL,
-       last_error_type    = NULL,
-       last_error_source  = NULL,
-       error_code         = NULL,
-       updated_at         = ?
-     WHERE id = ?`
-  );
-
-  for (const row of toReset) {
-    stmt.run(now, row.id);
-  }
-
-  invalidateDbCache("connections");
-
-  return { cleared: toReset.length };
-}
-
-/**
- * T13: Format a reset countdown as a human-readable string: "2h 35m" or "4m 30s".
- * Returns null if resetAt is in the past or not set.
- */
-export function formatResetCountdown(resetAt: string | number | null | undefined): string | null {
-  if (!resetAt) return null;
-  const resetTime = typeof resetAt === "number" ? resetAt : new Date(resetAt).getTime();
-  if (isNaN(resetTime)) return null;
-  const diffMs = resetTime - Date.now();
-  if (diffMs <= 0) return null;
-  const totalSeconds = Math.floor(diffMs / 1000);
-  const hours = Math.floor(totalSeconds / 3600);
-  const minutes = Math.floor((totalSeconds % 3600) / 60);
-  const seconds = totalSeconds % 60;
-  if (hours > 0) return `${hours}h ${minutes}m`;
-  if (minutes > 0) return `${minutes}m ${seconds}s`;
-  return `${seconds}s`;
-}
+export {
+  getProviderNodes,
+  getProviderNodeById,
+  resolveProviderNodeForConnection,
+  createProviderNode,
+  updateProviderNode,
+  deleteProviderNode,
+} from "./providers/nodes";
+export {
+  setConnectionRateLimitUntil,
+  isConnectionRateLimited,
+  getRateLimitedConnections,
+  getEffectiveQuotaUsage,
+  clearStaleCrashCooldowns,
+  formatResetCountdown,
+} from "./providers/rateLimit";

--- a/src/lib/db/providers/columns.ts
+++ b/src/lib/db/providers/columns.ts
@@ -1,0 +1,116 @@
+/**
+ * db/providers/columns.ts — Pure column-normalizer helpers for provider_connections rows.
+ * No DB access; no imports — JSON/Object/builtins only.
+ */
+
+export type JsonRecord = Record<string, unknown>;
+
+export function withNullableMaxConcurrent(
+  record: JsonRecord,
+  source: JsonRecord | null | undefined
+): JsonRecord {
+  if (!source || !Object.hasOwn(source, "maxConcurrent")) {
+    return record;
+  }
+
+  const sourceMaxConcurrent = source.maxConcurrent;
+  const normalizedMaxConcurrent =
+    typeof sourceMaxConcurrent === "number" || sourceMaxConcurrent === null
+      ? sourceMaxConcurrent
+      : record.maxConcurrent;
+
+  return {
+    ...record,
+    maxConcurrent: normalizedMaxConcurrent,
+  };
+}
+
+// Always surface `quotaWindowThresholds` (possibly null) on the returned
+// object — `cleanNulls` strips null values, but the UI needs to see null so
+// it can distinguish "no overrides on this connection" from "field was
+// never read." Mirrors `withNullableMaxConcurrent`'s contract so create and
+// update return the same shape regardless of whether the source had the key
+// stripped or carried forward.
+export function withNullableQuotaWindowThresholds(
+  record: JsonRecord,
+  source: JsonRecord | null | undefined
+): JsonRecord {
+  return {
+    ...record,
+    quotaWindowThresholds: (source?.quotaWindowThresholds ?? null) as Record<string, number> | null,
+  };
+}
+
+// Always surface `rateLimitOverrides` (possibly null) — matches the pattern
+// used by withNullableMaxConcurrent and withNullableQuotaWindowThresholds.
+export function withNullableRateLimitOverrides(
+  record: JsonRecord,
+  source: JsonRecord | null | undefined
+): JsonRecord {
+  return {
+    ...record,
+    rateLimitOverrides: (source?.rateLimitOverrides ?? null) as Record<string, number> | null,
+  };
+}
+
+export function normalizeBooleanColumn(value: unknown, fallback: boolean): boolean {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") return value === 1;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === "1" || normalized === "true") return true;
+    if (normalized === "0" || normalized === "false") return false;
+  }
+  return fallback;
+}
+
+// Sanitize the per-connection rate limit overrides map: keep only known
+// fields with valid numeric values. Called once at each write-path boundary.
+export function sanitizeRateLimitOverrides(value: unknown): Record<string, number> | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value !== "object" || Array.isArray(value)) return null;
+  const allowedKeys = new Set(["rpm", "tpm", "tpd", "minTime", "maxConcurrent"]);
+  const map: Record<string, number> = {};
+  for (const [key, v] of Object.entries(value as Record<string, unknown>)) {
+    if (!allowedKeys.has(key)) continue;
+    if (typeof v === "number" && Number.isInteger(v) && v >= 0) {
+      map[key] = v;
+    }
+  }
+  return Object.keys(map).length === 0 ? null : map;
+}
+
+// Serialize an already-sanitized map for SQLite TEXT storage.
+export function serializeJsonField(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value !== "object" || Array.isArray(value)) return null;
+  return JSON.stringify(value);
+}
+
+export function toRecord(value: unknown): JsonRecord {
+  return value && typeof value === "object" ? (value as JsonRecord) : {};
+}
+
+// Sanitize the per-window threshold map: keep only 0-100 integer values.
+// Called once at each write-path boundary (createProviderConnection +
+// updateProviderConnection) so both the in-memory return and the persisted
+// row share the same shape. Serialization below trusts this output.
+export function sanitizeQuotaWindowThresholds(value: unknown): Record<string, number> | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value !== "object" || Array.isArray(value)) return null;
+  const map: Record<string, number> = {};
+  for (const [key, v] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof v === "number" && Number.isInteger(v) && v >= 0 && v <= 100) {
+      map[key] = v;
+    }
+  }
+  return Object.keys(map).length === 0 ? null : map;
+}
+
+export function toStringOrNull(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+export function toNumberOrZero(value: unknown): number {
+  return typeof value === "number" ? value : 0;
+}

--- a/src/lib/db/providers/nodes.ts
+++ b/src/lib/db/providers/nodes.ts
@@ -1,0 +1,163 @@
+/**
+ * db/providers/nodes.ts — Provider nodes CRUD.
+ */
+
+import { v4 as uuidv4 } from "uuid";
+import { getDbInstance, rowToCamel } from "../core";
+import { selectProviderNodeForConnection } from "../providerNodeSelect";
+import { backupDbFile } from "../backup";
+import { toRecord, type JsonRecord } from "./columns";
+
+interface StatementLike<TRow = unknown> {
+  all: (...params: unknown[]) => TRow[];
+  get: (...params: unknown[]) => TRow | undefined;
+  run: (...params: unknown[]) => { changes?: number };
+}
+
+interface DbLike {
+  prepare: <TRow = unknown>(sql: string) => StatementLike<TRow>;
+}
+
+export async function getProviderNodes(filter: JsonRecord = {}) {
+  const db = getDbInstance() as unknown as DbLike;
+  let sql = "SELECT * FROM provider_nodes";
+  const params: Record<string, unknown> = {};
+
+  if (filter.type) {
+    sql += " WHERE type = @type";
+    params.type = filter.type;
+  }
+
+  return db.prepare(sql).all(params).map(rowToCamel);
+}
+
+export async function getProviderNodeById(id: string) {
+  const db = getDbInstance() as unknown as DbLike;
+  const row = db.prepare("SELECT * FROM provider_nodes WHERE id = ?").get(id);
+  return row ? rowToCamel(row) : null;
+}
+
+// #4421: resolve the provider node for a new connection from either its concrete id
+// (what the dashboard sends, "<type>-<uuid>") OR the bare derived type (what callers
+// using the /api/providers API directly often pass, e.g. "openai-compatible-responses").
+// Falls back to the sole node of that type only when unambiguous; otherwise null (so the
+// caller still surfaces the existing 404).
+export async function resolveProviderNodeForConnection(idOrType: string) {
+  const exact = await getProviderNodeById(idOrType);
+  if (exact) return exact;
+  const all = (await getProviderNodes()) as JsonRecord[];
+  return selectProviderNodeForConnection(idOrType, all);
+}
+
+export async function createProviderNode(data: JsonRecord) {
+  const db = getDbInstance() as unknown as DbLike;
+  const now = new Date().toISOString();
+
+  const customHeadersJson = data.customHeaders ? JSON.stringify(data.customHeaders) : null;
+
+  const node = {
+    id: data.id || uuidv4(),
+    type: data.type,
+    name: data.name,
+    prefix: data.prefix || null,
+    apiType: data.apiType || null,
+    baseUrl: data.baseUrl || null,
+    chatPath: data.chatPath || null,
+    modelsPath: data.modelsPath || null,
+    customHeadersJson,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  db.prepare(
+    `
+    INSERT INTO provider_nodes (id, type, name, prefix, api_type, base_url, chat_path, models_path, custom_headers_json, created_at, updated_at)
+    VALUES (@id, @type, @name, @prefix, @apiType, @baseUrl, @chatPath, @modelsPath, @customHeadersJson, @createdAt, @updatedAt)
+  `
+  ).run(node);
+
+  backupDbFile("pre-write");
+
+  const result: JsonRecord = { ...node };
+  if (customHeadersJson) {
+    try {
+      result.customHeaders = JSON.parse(customHeadersJson);
+    } catch {
+      result.customHeaders = null;
+    }
+  } else {
+    result.customHeaders = null;
+  }
+  delete result.customHeadersJson;
+  return result;
+}
+
+export async function updateProviderNode(id: string, data: JsonRecord) {
+  const db = getDbInstance() as unknown as DbLike;
+  const existing = db.prepare("SELECT * FROM provider_nodes WHERE id = ?").get(id);
+  if (!existing) return null;
+
+  const merged: JsonRecord = {
+    ...toRecord(rowToCamel(existing)),
+    ...data,
+    updatedAt: new Date().toISOString(),
+  };
+
+  if (data.customHeaders !== undefined) {
+    merged["customHeadersJson"] = data.customHeaders ? JSON.stringify(data.customHeaders) : null;
+  } else {
+    // Partial update that omits customHeaders must PRESERVE the stored value.
+    // rowToCamel surfaces the column under `customHeaders` (suffix stripped),
+    // never `customHeadersJson`, so read the raw stored JSON from `existing`
+    // directly instead of relying on the (absent) merged key — otherwise the
+    // UPDATE would bind null and silently wipe the saved headers.
+    const existingJson = (existing as JsonRecord).custom_headers_json;
+    merged["customHeadersJson"] = typeof existingJson === "string" ? existingJson : null;
+  }
+
+  db.prepare(
+    `
+    UPDATE provider_nodes SET type = @type, name = @name, prefix = @prefix,
+    api_type = @apiType, base_url = @baseUrl, chat_path = @chatPath,
+    models_path = @modelsPath, custom_headers_json = @customHeadersJson, updated_at = @updatedAt
+    WHERE id = @id
+  `
+  ).run({
+    id,
+    type: merged["type"],
+    name: merged["name"],
+    prefix: merged["prefix"] || null,
+    apiType: merged["apiType"] || null,
+    baseUrl: merged["baseUrl"] || null,
+    chatPath: merged["chatPath"] || null,
+    modelsPath: merged["modelsPath"] || null,
+    customHeadersJson: merged["customHeadersJson"] || null,
+    updatedAt: merged["updatedAt"],
+  });
+
+  backupDbFile("pre-write");
+
+  const result: JsonRecord = { ...merged };
+  const storedJson = merged["customHeadersJson"] as string | null;
+  if (storedJson) {
+    try {
+      result.customHeaders = JSON.parse(storedJson);
+    } catch {
+      result.customHeaders = null;
+    }
+  } else {
+    result.customHeaders = null;
+  }
+  delete result.customHeadersJson;
+  return result;
+}
+
+export async function deleteProviderNode(id: string) {
+  const db = getDbInstance() as unknown as DbLike;
+  const existing = db.prepare("SELECT * FROM provider_nodes WHERE id = ?").get(id);
+  if (!existing) return null;
+
+  db.prepare("DELETE FROM provider_nodes WHERE id = ?").run(id);
+  backupDbFile("pre-write");
+  return rowToCamel(existing);
+}

--- a/src/lib/db/providers/rateLimit.ts
+++ b/src/lib/db/providers/rateLimit.ts
@@ -1,0 +1,177 @@
+/**
+ * db/providers/rateLimit.ts — Rate-limit/quota runtime helpers for provider_connections.
+ */
+
+import { getDbInstance } from "../core";
+import { invalidateDbCache } from "../readCache";
+
+interface StatementLike<TRow = unknown> {
+  all: (...params: unknown[]) => TRow[];
+  get: (...params: unknown[]) => TRow | undefined;
+  run: (...params: unknown[]) => { changes?: number };
+}
+
+interface DbLike {
+  prepare: <TRow = unknown>(sql: string) => StatementLike<TRow>;
+}
+
+// ──────────────── T05: Rate-Limit DB Persistence ──────────────────────────
+// Allows rate-limit state to survive token refresh without being accidentally
+// cleared. DB column rate_limited_until already exists in schema.
+// Ref: sub2api PR #1218 (fix(openai): prevent rescheduling rate-limited accounts)
+
+/**
+ * T05: Persist when a connection is rate-limited, directly in DB.
+ * This survives token refresh — OAuth flows must NOT override this field.
+ *
+ * @param connectionId - The provider_connections.id
+ * @param until - Epoch ms when the rate limit expires (null to clear)
+ */
+export function setConnectionRateLimitUntil(connectionId: string, until: number | null): void {
+  const db = getDbInstance() as unknown as DbLike;
+  db.prepare(
+    "UPDATE provider_connections SET rate_limited_until = ?, updated_at = ? WHERE id = ?"
+  ).run(until, new Date().toISOString(), connectionId);
+  invalidateDbCache("connections");
+}
+
+/**
+ * T05: Check if a connection is currently rate-limited (DB-backed).
+ * Use this before account selection to skip transiently rate-limited accounts.
+ *
+ * @returns true if rate_limited_until is set and in the future
+ */
+export function isConnectionRateLimited(connectionId: string): boolean {
+  const db = getDbInstance() as unknown as DbLike;
+  const row = db
+    .prepare("SELECT rate_limited_until FROM provider_connections WHERE id = ?")
+    .get(connectionId) as { rate_limited_until?: number | null } | undefined;
+  if (!row?.rate_limited_until) return false;
+  return Date.now() < row.rate_limited_until;
+}
+
+/**
+ * T05: Get all connections for a provider that are currently rate-limited.
+ * Returns an array of { id, rateLimitedUntil } for dashboard display.
+ */
+export function getRateLimitedConnections(
+  provider: string
+): Array<{ id: string; rateLimitedUntil: number }> {
+  const db = getDbInstance() as unknown as DbLike;
+  const now = Date.now();
+  const rows = db
+    .prepare(
+      "SELECT id, rate_limited_until FROM provider_connections WHERE provider = ? AND rate_limited_until > ?"
+    )
+    .all(provider, now) as Array<{ id: string; rate_limited_until: number }>;
+  return rows.map((r) => ({ id: r.id, rateLimitedUntil: r.rate_limited_until }));
+}
+
+// ──────────────── T13: Stale Quota Display Fix ─────────────────────────────
+// Codex/Claude quotas display stale cumulative usage after the window resets.
+// By comparing resetAt timestamp to now(), we can show 0 when window has passed.
+// Ref: sub2api PR #1171 (fix: quota display shows stale cumulative usage after reset)
+
+/**
+ * T13: Get effective quota usage, zeroing it out if the window has already reset.
+ *
+ * @param used - Stored usage value (tokens used in the window)
+ * @param resetAt - ISO-8601 string or epoch ms when the window resets, or null
+ * @returns Effective usage: 0 if window expired, original value otherwise
+ */
+export function getEffectiveQuotaUsage(
+  used: number,
+  resetAt: string | number | null | undefined
+): number {
+  if (!resetAt) return used;
+  const resetTime = typeof resetAt === "number" ? resetAt : new Date(resetAt).getTime();
+  if (isNaN(resetTime)) return used;
+  // Window has passed — display should show 0 (pending next snapshot)
+  if (Date.now() >= resetTime) return 0;
+  return used;
+}
+
+/**
+ * T05: Startup crash-recovery — clear stale transient connection cooldowns.
+ *
+ * After an unclean crash (SIGKILL, OOM-kill, large-body burst) the normal
+ * error-handler paths that would clear/normalise cooldowns never run.
+ * A connection's `rate_limited_until` may have been pushed far into the
+ * future by exponential back-off.  On next startup that leaves all affected
+ * connections excluded by `getProviderCredentials()`, so every request sits
+ * in the Bottleneck queue and times out at `maxWaitMs` (120 s default).
+ *
+ * Safe invariants:
+ *  - Only connections with `rate_limited_until IS NOT NULL` are touched.
+ *  - Terminal states (`banned`, `expired`, `credits_exhausted`) are skipped —
+ *    those require a deliberate credential change or operator reset.
+ *  - Past timestamps are also cleared: they are already expired in the lazy
+ *    expiry sense, but clearing them resets `backoffLevel` / transient error
+ *    fields so the connection gets a clean slate on this fresh process.
+ *
+ * Must be called once, early in the startup sequence, before any request
+ * is handled.  Returns the number of connections that were cleared.
+ */
+export function clearStaleCrashCooldowns(): { cleared: number } {
+  const db = getDbInstance() as unknown as DbLike;
+  const now = new Date().toISOString();
+
+  // Fetch all connections that have a rate_limited_until set and are NOT in
+  // a terminal state.  We do the terminal-status filter in JS to reuse the
+  // canonical `TERMINAL_STATUSES` set rather than duplicating the list in SQL.
+  const TERMINAL_STATUSES = new Set(["banned", "expired", "credits_exhausted"]);
+
+  const rows = db
+    .prepare(
+      `SELECT id, test_status FROM provider_connections WHERE rate_limited_until IS NOT NULL`
+    )
+    .all() as Array<{ id: string; test_status: string | null }>;
+
+  const toReset = rows.filter((r) => {
+    const status = (r.test_status || "").trim().toLowerCase();
+    return !TERMINAL_STATUSES.has(status);
+  });
+
+  if (toReset.length === 0) return { cleared: 0 };
+
+  const stmt = db.prepare(
+    `UPDATE provider_connections SET
+       rate_limited_until = NULL,
+       test_status        = 'active',
+       backoff_level      = 0,
+       last_error         = NULL,
+       last_error_at      = NULL,
+       last_error_type    = NULL,
+       last_error_source  = NULL,
+       error_code         = NULL,
+       updated_at         = ?
+     WHERE id = ?`
+  );
+
+  for (const row of toReset) {
+    stmt.run(now, row.id);
+  }
+
+  invalidateDbCache("connections");
+
+  return { cleared: toReset.length };
+}
+
+/**
+ * T13: Format a reset countdown as a human-readable string: "2h 35m" or "4m 30s".
+ * Returns null if resetAt is in the past or not set.
+ */
+export function formatResetCountdown(resetAt: string | number | null | undefined): string | null {
+  if (!resetAt) return null;
+  const resetTime = typeof resetAt === "number" ? resetAt : new Date(resetAt).getTime();
+  if (isNaN(resetTime)) return null;
+  const diffMs = resetTime - Date.now();
+  if (diffMs <= 0) return null;
+  const totalSeconds = Math.floor(diffMs / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  if (minutes > 0) return `${minutes}m ${seconds}s`;
+  return `${seconds}s`;
+}

--- a/tests/unit/db-providers-split.test.ts
+++ b/tests/unit/db-providers-split.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Characterization + API-surface test: providers.ts god-file decomposition.
+ *
+ * The host src/lib/db/providers.ts was split into three sibling leaf modules
+ * under src/lib/db/providers/:
+ *   - columns.ts   — 10 pure column-normalizer helpers (DB-free)
+ *   - nodes.ts     — 6 provider-node CRUD functions
+ *   - rateLimit.ts — 6 rate-limit/quota runtime helpers + formatResetCountdown
+ *
+ * This test verifies that:
+ *   1. The pure column helpers in columns.ts behave correctly (DB-free).
+ *   2. The host providers.ts still re-exports the FULL public API surface (23
+ *      symbols) so every existing consumer keeps importing from the same path.
+ *   3. The leaf modules export their own pieces directly.
+ *
+ * Pure typeof/behaviour checks only — no function is invoked against the DB,
+ * so no SQLite handle is opened (no resetDbInstance teardown required).
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+// ── 1. columns.ts — pure helpers behaviour ───────────────────────────────────
+
+import {
+  normalizeBooleanColumn,
+  sanitizeRateLimitOverrides,
+  sanitizeQuotaWindowThresholds,
+  serializeJsonField,
+  toRecord,
+  toStringOrNull,
+  toNumberOrZero,
+} from "../../src/lib/db/providers/columns.ts";
+
+describe("providers/columns — normalizeBooleanColumn", () => {
+  it("passes through real booleans", () => {
+    assert.equal(normalizeBooleanColumn(true, false), true);
+    assert.equal(normalizeBooleanColumn(false, true), false);
+  });
+  it("maps SQLite integer flags (1/0)", () => {
+    assert.equal(normalizeBooleanColumn(1, false), true);
+    assert.equal(normalizeBooleanColumn(0, true), false);
+  });
+  it("parses string flags case-insensitively", () => {
+    assert.equal(normalizeBooleanColumn("True", false), true);
+    assert.equal(normalizeBooleanColumn("0", true), false);
+  });
+  it("returns the fallback for unrecognized values", () => {
+    assert.equal(normalizeBooleanColumn("maybe", true), true);
+    assert.equal(normalizeBooleanColumn(undefined, false), false);
+  });
+});
+
+describe("providers/columns — sanitizeRateLimitOverrides", () => {
+  it("returns null for nullish / non-object / array input", () => {
+    assert.equal(sanitizeRateLimitOverrides(null), null);
+    assert.equal(sanitizeRateLimitOverrides(undefined), null);
+    assert.equal(sanitizeRateLimitOverrides("x"), null);
+    assert.equal(sanitizeRateLimitOverrides([1, 2]), null);
+  });
+  it("keeps only allowed keys with non-negative integers", () => {
+    assert.deepEqual(sanitizeRateLimitOverrides({ rpm: 10, bogus: 5, tpm: -1 }), { rpm: 10 });
+  });
+  it("returns null when nothing valid remains", () => {
+    assert.equal(sanitizeRateLimitOverrides({ rpm: 1.5, nope: 3 }), null);
+  });
+});
+
+describe("providers/columns — sanitizeQuotaWindowThresholds", () => {
+  it("keeps only 0-100 integers", () => {
+    assert.deepEqual(sanitizeQuotaWindowThresholds({ a: 50, b: 120, c: 0 }), { a: 50, c: 0 });
+  });
+  it("returns null when empty", () => {
+    assert.equal(sanitizeQuotaWindowThresholds({ a: 200 }), null);
+  });
+});
+
+describe("providers/columns — small coercers", () => {
+  it("serializeJsonField stringifies objects, null otherwise", () => {
+    assert.equal(serializeJsonField({ a: 1 }), '{"a":1}');
+    assert.equal(serializeJsonField(null), null);
+    assert.equal(serializeJsonField("str"), null);
+  });
+  it("toRecord returns objects as-is, {} otherwise", () => {
+    const o = { x: 1 };
+    assert.equal(toRecord(o), o);
+    assert.deepEqual(toRecord(null), {});
+    assert.deepEqual(toRecord(42), {});
+  });
+  it("toStringOrNull / toNumberOrZero coerce by type", () => {
+    assert.equal(toStringOrNull("hi"), "hi");
+    assert.equal(toStringOrNull(5), null);
+    assert.equal(toNumberOrZero(7), 7);
+    assert.equal(toNumberOrZero("7"), 0);
+  });
+});
+
+// ── 2. providers.ts — full public API surface preserved ──────────────────────
+
+const host = await import("../../src/lib/db/providers.ts");
+
+describe("providers.ts public API surface (23 symbols)", () => {
+  const expected = [
+    // Connection CRUD (kept in host)
+    "getProviderConnections",
+    "getProviderConnectionById",
+    "createProviderConnection",
+    "updateProviderConnection",
+    "deleteProviderConnection",
+    "deleteProviderConnections",
+    "deleteProviderConnectionsByProvider",
+    "reorderProviderConnections",
+    "cleanupProviderConnections",
+    "getDistinctGroups",
+    "autoMigrateLegacyEncryptedConnections",
+    // Provider nodes (re-exported from ./providers/nodes)
+    "getProviderNodes",
+    "getProviderNodeById",
+    "resolveProviderNodeForConnection",
+    "createProviderNode",
+    "updateProviderNode",
+    "deleteProviderNode",
+    // Rate-limit / quota runtime (re-exported from ./providers/rateLimit)
+    "setConnectionRateLimitUntil",
+    "isConnectionRateLimited",
+    "getRateLimitedConnections",
+    "getEffectiveQuotaUsage",
+    "clearStaleCrashCooldowns",
+    "formatResetCountdown",
+  ];
+
+  for (const name of expected) {
+    it(`re-exports ${name} as a function`, () => {
+      assert.equal(typeof host[name], "function", `${name} must be a function on the host module`);
+    });
+  }
+
+  it("exposes exactly the 23 expected callables (no public symbol lost)", () => {
+    const missing = expected.filter((n) => typeof host[n] !== "function");
+    assert.deepEqual(missing, [], `missing public exports: ${missing.join(", ")}`);
+  });
+});
+
+// ── 3. leaf modules export their own pieces ──────────────────────────────────
+
+describe("leaf modules export their slices directly", () => {
+  it("nodes.ts exports the 6 node CRUD functions", async () => {
+    const nodes = await import("../../src/lib/db/providers/nodes.ts");
+    for (const fn of [
+      "getProviderNodes",
+      "getProviderNodeById",
+      "resolveProviderNodeForConnection",
+      "createProviderNode",
+      "updateProviderNode",
+      "deleteProviderNode",
+    ]) {
+      assert.equal(typeof nodes[fn], "function", `nodes.${fn}`);
+    }
+  });
+
+  it("rateLimit.ts exports the 6 runtime helpers", async () => {
+    const rl = await import("../../src/lib/db/providers/rateLimit.ts");
+    for (const fn of [
+      "setConnectionRateLimitUntil",
+      "isConnectionRateLimited",
+      "getRateLimitedConnections",
+      "getEffectiveQuotaUsage",
+      "clearStaleCrashCooldowns",
+      "formatResetCountdown",
+    ]) {
+      assert.equal(typeof rl[fn], "function", `rateLimit.${fn}`);
+    }
+  });
+});


### PR DESCRIPTION
## O quê
`src/lib/db/providers.ts` era um god-file de **1106 linhas** misturando quatro responsabilidades. Extraí as três fatias coesas e **acíclicas** para leaf modules irmãos em `src/lib/db/providers/`, deixando o core acoplado de CRUD de conexões no host.

| Arquivo | Linhas | Conteúdo |
|---|---|---|
| `providers/columns.ts` | 116 | 10 normalizers de coluna **puros** (sem DB) |
| `providers/nodes.ts` | 163 | 6 funções CRUD de `provider_nodes` |
| `providers/rateLimit.ts` | 177 | 6 helpers de rate-limit/quota runtime + `formatResetCountdown` |
| `providers.ts` (host) | **719** (de 1106) | core de CRUD de conexões + re-exports |

## Por que é seguro (behavior-preserving)
- **DAG acíclico mapeado antes**: o core de CRUD de conexões **não chama** nenhuma função de nodes nem de rate-limit (verificado) → host só **re-exporta** os 12 símbolos movidos via `export { ... } from './providers/<leaf>'`.
- **API pública IDÊNTICA**: o export-set continua exatamente os **23 símbolos** (diff before/after vazio).
- **Bodies movidos verbatim** (byte-idêntico); a única edição numa linha movida é o `export` adicionado aos 10 normalizers antes privados.
- **Sem novos ciclos** (`check:cycles` OK, 315 arquivos), `typecheck:core` limpo, eslint 0, prettier limpo.
- `db/providers.ts` sai de over-cap (frozen-baselined) para **719 < 800** — redução de debt de #3501.

## Validação
- **122 testes consumidores** existentes (provider connections/nodes/rate-limit/quota/cooldown) seguem **verdes** (17 arquivos).
- Novo `tests/unit/db-providers-split.test.ts` (**38 asserções**): guarda o barril de re-export (23 símbolos via host) + characteriza os normalizers puros + valida exports diretos das leaves.

```
node --import tsx/esm --test tests/unit/db-providers-split.test.ts   # 38/38
typecheck:core  OK   ·   check:cycles  OK   ·   eslint  0   ·   prettier  clean
```

Parte da campanha de decomposição de god-files (bloco **E3**, base `release/v3.8.43`). Refs #3501.