### PR TITLE
refactor(db): decompose db/proxies.ts god-file into types + mappers leaves

### DIFF
--- a/src/lib/db/proxies.ts
+++ b/src/lib/db/proxies.ts
@@ -6,73 +6,32 @@
 import { randomUUID } from "crypto";
 import { getDbInstance } from "./core";
 import { backupDbFile } from "./backup";
-import { decrypt } from "./encryption";
-
-type JsonRecord = Record<string, unknown>;
-type ProxyScope = "global" | "provider" | "account" | "combo";
-
-interface ProxyRegistryRecord {
-  id: string;
-  name: string;
-  type: string;
-  host: string;
-  port: number;
-  username: string;
-  password: string;
-  region: string | null;
-  notes: string | null;
-  status: string;
-  source: string;
-  family: string;
-  createdAt: string;
-  updatedAt: string;
-}
-
-interface ProxyAssignmentRecord {
-  id: number;
-  proxyId: string;
-  scope: ProxyScope;
-  scopeId: string | null;
-  createdAt: string;
-  updatedAt: string;
-}
-
-interface ProxyPayload {
-  name: string;
-  type: string;
-  host: string;
-  port: number;
-  username?: string;
-  password?: string;
-  region?: string | null;
-  notes?: string | null;
-  status?: string;
-  source?: string;
-  family?: string;
-}
-
-interface ProxyAssignmentPayload {
-  scope: string;
-  scopeId?: string | null;
-}
-
-interface ProxyMutationResult {
-  proxy: ProxyRegistryRecord;
-  assignment: ProxyAssignmentRecord | null;
-}
-
-type LegacyProxyClearStatus = "cleared" | "absent";
-
-interface ProxyTransactionResult extends ProxyMutationResult {
-  legacyClearStatus: LegacyProxyClearStatus;
-}
-
-interface LegacyProxyConfig {
-  global?: unknown;
-  providers?: Record<string, unknown>;
-  combos?: Record<string, unknown>;
-  keys?: Record<string, unknown>;
-}
+import type {
+  JsonRecord,
+  ProxyScope,
+  ProxyRegistryRecord,
+  ProxyAssignmentRecord,
+  ProxyPayload,
+  ProxyAssignmentPayload,
+  ProxyMutationResult,
+  LegacyProxyClearStatus,
+  ProxyTransactionResult,
+  LegacyProxyConfig,
+} from "./proxies/types";
+import {
+  toRecord,
+  mapProxyRow,
+  mapAssignmentRow,
+  isRelayProxyType,
+  extractRelayAuth,
+  toRegistryProxyResolution,
+  normalizeScope,
+  normalizeAssignmentScopeId,
+  toLegacyProxyLevel,
+  coerceProxyPayload,
+  redactProxySecrets,
+} from "./proxies/mappers";
+export { extractRelayAuth, redactProxySecrets } from "./proxies/mappers";
 
 let proxyRegistryGeneration = 0;
 
@@ -82,109 +41,6 @@ function bumpProxyRegistryGeneration() {
 
 export function getProxyRegistryGeneration() {
   return proxyRegistryGeneration;
-}
-
-function toRecord(value: unknown): JsonRecord {
-  return value && typeof value === "object" ? (value as JsonRecord) : {};
-}
-
-function mapProxyRow(row: unknown): ProxyRegistryRecord {
-  const r = toRecord(row);
-  return {
-    id: typeof r.id === "string" ? r.id : "",
-    name: typeof r.name === "string" ? r.name : "",
-    type: typeof r.type === "string" ? r.type : "http",
-    host: typeof r.host === "string" ? r.host : "",
-    port: Number(r.port) || 0,
-    username: typeof r.username === "string" ? r.username : "",
-    password: typeof r.password === "string" ? r.password : "",
-    region: typeof r.region === "string" ? r.region : null,
-    notes: typeof r.notes === "string" ? r.notes : null,
-    status: typeof r.status === "string" ? r.status : "active",
-    source: typeof r.source === "string" ? r.source : "manual",
-    family: typeof r.family === "string" ? r.family : "auto",
-    createdAt: typeof r.created_at === "string" ? r.created_at : "",
-    updatedAt: typeof r.updated_at === "string" ? r.updated_at : "",
-  };
-}
-
-function mapAssignmentRow(row: unknown): ProxyAssignmentRecord {
-  const r = toRecord(row);
-  const scope = (typeof r.scope === "string" ? r.scope : "global") as ProxyScope;
-  const rawScopeId = typeof r.scope_id === "string" ? r.scope_id : null;
-  return {
-    id: Number(r.id) || 0,
-    proxyId: typeof r.proxy_id === "string" ? r.proxy_id : "",
-    scope,
-    scopeId: scope === "global" && rawScopeId === "__global__" ? null : rawScopeId,
-    createdAt: typeof r.created_at === "string" ? r.created_at : "",
-    updatedAt: typeof r.updated_at === "string" ? r.updated_at : "",
-  };
-}
-
-// Edge-relay proxy types. Mirrors RELAY_TYPES in open-sse/utils/proxyDispatcher.
-// Duplicated here (not imported) to keep src/lib/db/ free of open-sse runtime
-// imports; if a third relay backend lands, update BOTH sets.
-const RELAY_PROXY_TYPES = new Set(["vercel", "deno", "cloudflare"]);
-
-function isRelayProxyType(type: unknown): boolean {
-  return typeof type === "string" && RELAY_PROXY_TYPES.has(type);
-}
-
-export function extractRelayAuth(notes: unknown): string | undefined {
-  if (typeof notes !== "string") return undefined;
-  try {
-    const parsed = JSON.parse(notes) as {
-      relayAuth?: string;
-      relayAuthEnc?: string;
-    };
-    // Prefer the encrypted form when both are present (legacy plaintext rows
-    // are still readable until migrated). decrypt() is a no-op when encryption
-    // is disabled, matching the existing convention for webhook secrets.
-    if (parsed.relayAuthEnc) {
-      const dec = decrypt(parsed.relayAuthEnc);
-      if (dec) return dec;
-    }
-    return parsed.relayAuth || undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-function toRegistryProxyResolution(row: unknown, level: ProxyScope, levelId: string | null) {
-  const record = toRecord(row);
-  const relayAuth = isRelayProxyType(record.type) ? extractRelayAuth(record.notes) : undefined;
-  return {
-    proxy: {
-      type: record.type,
-      host: record.host,
-      port: record.port,
-      username: record.username,
-      password: record.password,
-      family: typeof record.family === "string" ? record.family : "auto",
-      ...(relayAuth !== undefined ? { relayAuth } : {}),
-    },
-    level,
-    levelId,
-    source: "registry",
-  };
-}
-
-function normalizeScope(scope: string): ProxyScope {
-  const value = String(scope || "").toLowerCase();
-  if (value === "key") return "account";
-  if (value === "provider") return "provider";
-  if (value === "account") return "account";
-  if (value === "combo") return "combo";
-  return "global";
-}
-
-function normalizeAssignmentScopeId(scope: ProxyScope, scopeId?: string | null) {
-  return scope === "global" ? "__global__" : scopeId || null;
-}
-
-function toLegacyProxyLevel(scope: ProxyScope) {
-  return scope === "account" ? "key" : scope;
 }
 
 // Mutate legacy proxyConfig rows directly so these writes stay inside the same
@@ -354,75 +210,6 @@ function getAssignmentRow(
     )
     .get(normalizedScope, normalizedScopeId);
   return row ? mapAssignmentRow(row) : null;
-}
-
-function coerceProxyPayload(value: unknown, fallbackName: string): ProxyPayload | null {
-  if (!value) return null;
-
-  if (typeof value === "string") {
-    try {
-      const parsed = new URL(value);
-      return {
-        name: fallbackName,
-        type: parsed.protocol.replace(":", "") || "http",
-        host: parsed.hostname,
-        port: Number(parsed.port || (parsed.protocol === "https:" ? "443" : "8080")),
-        username: parsed.username ? decodeURIComponent(parsed.username) : "",
-        password: parsed.password ? decodeURIComponent(parsed.password) : "",
-        status: "active",
-      };
-    } catch {
-      return null;
-    }
-  }
-
-  if (typeof value !== "object" || Array.isArray(value)) return null;
-  const record = toRecord(value);
-  const host = typeof record.host === "string" ? record.host.trim() : "";
-  if (!host) return null;
-  const port = Number(record.port) || 8080;
-
-  return {
-    name: fallbackName,
-    type: typeof record.type === "string" ? record.type : "http",
-    host,
-    port,
-    username: typeof record.username === "string" ? record.username : "",
-    password: typeof record.password === "string" ? record.password : "",
-    status: "active",
-  };
-}
-
-export function redactProxySecrets(proxy: ProxyRegistryRecord): ProxyRegistryRecord {
-  let redactedNotes = proxy.notes;
-  if (isRelayProxyType(proxy.type) && proxy.notes) {
-    try {
-      const parsed = JSON.parse(proxy.notes);
-      if (parsed && typeof parsed === "object") {
-        const next: Record<string, unknown> = { ...parsed };
-        let touched = false;
-        if ("relayAuth" in next) {
-          next.relayAuth = "***";
-          touched = true;
-        }
-        if ("relayAuthEnc" in next) {
-          next.relayAuthEnc = "***";
-          touched = true;
-        }
-        if (touched) {
-          redactedNotes = JSON.stringify(next);
-        }
-      }
-    } catch {
-      // Non-JSON notes pass through unchanged
-    }
-  }
-  return {
-    ...proxy,
-    username: proxy.username ? "***" : "",
-    password: proxy.password ? "***" : "",
-    notes: redactedNotes,
-  };
 }
 
 export async function listProxies(options?: { includeSecrets?: boolean }) {
@@ -760,7 +547,9 @@ export async function resolveProxyForConnectionFromRegistry(connectionId: string
         .get(connection.provider);
       if (providerAssignment) {
         const record = toRecord(providerAssignment);
-        const relayAuth = isRelayProxyType(record.type) ? extractRelayAuth(record.notes) : undefined;
+        const relayAuth = isRelayProxyType(record.type)
+          ? extractRelayAuth(record.notes)
+          : undefined;
         return {
           proxy: {
             type: record.type,
@@ -848,8 +637,7 @@ export async function migrateLegacyProxyConfigToRegistry(options?: { force?: boo
   const db = getDbInstance();
 
   const existingCountRow = db.prepare("SELECT COUNT(*) AS cnt FROM proxy_registry").get() as
-    | { cnt?: number }
-    | undefined;
+    { cnt?: number } | undefined;
   const existingCount = Number(existingCountRow?.cnt || 0);
   if (!force && existingCount > 0) {
     return { migrated: 0, skipped: true, reason: "registry_not_empty" as const };

--- a/src/lib/db/proxies/mappers.ts
+++ b/src/lib/db/proxies/mappers.ts
@@ -1,0 +1,180 @@
+import { decrypt } from "../encryption";
+import type {
+  JsonRecord,
+  ProxyScope,
+  ProxyRegistryRecord,
+  ProxyAssignmentRecord,
+  ProxyPayload,
+} from "./types";
+
+export function toRecord(value: unknown): JsonRecord {
+  return value && typeof value === "object" ? (value as JsonRecord) : {};
+}
+
+export function mapProxyRow(row: unknown): ProxyRegistryRecord {
+  const r = toRecord(row);
+  return {
+    id: typeof r.id === "string" ? r.id : "",
+    name: typeof r.name === "string" ? r.name : "",
+    type: typeof r.type === "string" ? r.type : "http",
+    host: typeof r.host === "string" ? r.host : "",
+    port: Number(r.port) || 0,
+    username: typeof r.username === "string" ? r.username : "",
+    password: typeof r.password === "string" ? r.password : "",
+    region: typeof r.region === "string" ? r.region : null,
+    notes: typeof r.notes === "string" ? r.notes : null,
+    status: typeof r.status === "string" ? r.status : "active",
+    source: typeof r.source === "string" ? r.source : "manual",
+    family: typeof r.family === "string" ? r.family : "auto",
+    createdAt: typeof r.created_at === "string" ? r.created_at : "",
+    updatedAt: typeof r.updated_at === "string" ? r.updated_at : "",
+  };
+}
+
+export function mapAssignmentRow(row: unknown): ProxyAssignmentRecord {
+  const r = toRecord(row);
+  const scope = (typeof r.scope === "string" ? r.scope : "global") as ProxyScope;
+  const rawScopeId = typeof r.scope_id === "string" ? r.scope_id : null;
+  return {
+    id: Number(r.id) || 0,
+    proxyId: typeof r.proxy_id === "string" ? r.proxy_id : "",
+    scope,
+    scopeId: scope === "global" && rawScopeId === "__global__" ? null : rawScopeId,
+    createdAt: typeof r.created_at === "string" ? r.created_at : "",
+    updatedAt: typeof r.updated_at === "string" ? r.updated_at : "",
+  };
+}
+
+// Edge-relay proxy types. Mirrors RELAY_TYPES in open-sse/utils/proxyDispatcher.
+// Duplicated here (not imported) to keep src/lib/db/ free of open-sse runtime
+// imports; if a third relay backend lands, update BOTH sets.
+const RELAY_PROXY_TYPES = new Set(["vercel", "deno", "cloudflare"]);
+
+export function isRelayProxyType(type: unknown): boolean {
+  return typeof type === "string" && RELAY_PROXY_TYPES.has(type);
+}
+
+export function extractRelayAuth(notes: unknown): string | undefined {
+  if (typeof notes !== "string") return undefined;
+  try {
+    const parsed = JSON.parse(notes) as {
+      relayAuth?: string;
+      relayAuthEnc?: string;
+    };
+    // Prefer the encrypted form when both are present (legacy plaintext rows
+    // are still readable until migrated). decrypt() is a no-op when encryption
+    // is disabled, matching the existing convention for webhook secrets.
+    if (parsed.relayAuthEnc) {
+      const dec = decrypt(parsed.relayAuthEnc);
+      if (dec) return dec;
+    }
+    return parsed.relayAuth || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function toRegistryProxyResolution(row: unknown, level: ProxyScope, levelId: string | null) {
+  const record = toRecord(row);
+  const relayAuth = isRelayProxyType(record.type) ? extractRelayAuth(record.notes) : undefined;
+  return {
+    proxy: {
+      type: record.type,
+      host: record.host,
+      port: record.port,
+      username: record.username,
+      password: record.password,
+      family: typeof record.family === "string" ? record.family : "auto",
+      ...(relayAuth !== undefined ? { relayAuth } : {}),
+    },
+    level,
+    levelId,
+    source: "registry",
+  };
+}
+
+export function normalizeScope(scope: string): ProxyScope {
+  const value = String(scope || "").toLowerCase();
+  if (value === "key") return "account";
+  if (value === "provider") return "provider";
+  if (value === "account") return "account";
+  if (value === "combo") return "combo";
+  return "global";
+}
+
+export function normalizeAssignmentScopeId(scope: ProxyScope, scopeId?: string | null) {
+  return scope === "global" ? "__global__" : scopeId || null;
+}
+
+export function toLegacyProxyLevel(scope: ProxyScope) {
+  return scope === "account" ? "key" : scope;
+}
+
+export function coerceProxyPayload(value: unknown, fallbackName: string): ProxyPayload | null {
+  if (!value) return null;
+
+  if (typeof value === "string") {
+    try {
+      const parsed = new URL(value);
+      return {
+        name: fallbackName,
+        type: parsed.protocol.replace(":", "") || "http",
+        host: parsed.hostname,
+        port: Number(parsed.port || (parsed.protocol === "https:" ? "443" : "8080")),
+        username: parsed.username ? decodeURIComponent(parsed.username) : "",
+        password: parsed.password ? decodeURIComponent(parsed.password) : "",
+        status: "active",
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  if (typeof value !== "object" || Array.isArray(value)) return null;
+  const record = toRecord(value);
+  const host = typeof record.host === "string" ? record.host.trim() : "";
+  if (!host) return null;
+  const port = Number(record.port) || 8080;
+
+  return {
+    name: fallbackName,
+    type: typeof record.type === "string" ? record.type : "http",
+    host,
+    port,
+    username: typeof record.username === "string" ? record.username : "",
+    password: typeof record.password === "string" ? record.password : "",
+    status: "active",
+  };
+}
+
+export function redactProxySecrets(proxy: ProxyRegistryRecord): ProxyRegistryRecord {
+  let redactedNotes = proxy.notes;
+  if (isRelayProxyType(proxy.type) && proxy.notes) {
+    try {
+      const parsed = JSON.parse(proxy.notes);
+      if (parsed && typeof parsed === "object") {
+        const next: Record<string, unknown> = { ...parsed };
+        let touched = false;
+        if ("relayAuth" in next) {
+          next.relayAuth = "***";
+          touched = true;
+        }
+        if ("relayAuthEnc" in next) {
+          next.relayAuthEnc = "***";
+          touched = true;
+        }
+        if (touched) {
+          redactedNotes = JSON.stringify(next);
+        }
+      }
+    } catch {
+      // Non-JSON notes pass through unchanged
+    }
+  }
+  return {
+    ...proxy,
+    username: proxy.username ? "***" : "",
+    password: proxy.password ? "***" : "",
+    notes: redactedNotes,
+  };
+}

--- a/src/lib/db/proxies/types.ts
+++ b/src/lib/db/proxies/types.ts
@@ -1,0 +1,65 @@
+export type JsonRecord = Record<string, unknown>;
+export type ProxyScope = "global" | "provider" | "account" | "combo";
+
+export interface ProxyRegistryRecord {
+  id: string;
+  name: string;
+  type: string;
+  host: string;
+  port: number;
+  username: string;
+  password: string;
+  region: string | null;
+  notes: string | null;
+  status: string;
+  source: string;
+  family: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ProxyAssignmentRecord {
+  id: number;
+  proxyId: string;
+  scope: ProxyScope;
+  scopeId: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ProxyPayload {
+  name: string;
+  type: string;
+  host: string;
+  port: number;
+  username?: string;
+  password?: string;
+  region?: string | null;
+  notes?: string | null;
+  status?: string;
+  source?: string;
+  family?: string;
+}
+
+export interface ProxyAssignmentPayload {
+  scope: string;
+  scopeId?: string | null;
+}
+
+export interface ProxyMutationResult {
+  proxy: ProxyRegistryRecord;
+  assignment: ProxyAssignmentRecord | null;
+}
+
+export type LegacyProxyClearStatus = "cleared" | "absent";
+
+export interface ProxyTransactionResult extends ProxyMutationResult {
+  legacyClearStatus: LegacyProxyClearStatus;
+}
+
+export interface LegacyProxyConfig {
+  global?: unknown;
+  providers?: Record<string, unknown>;
+  combos?: Record<string, unknown>;
+  keys?: Record<string, unknown>;
+}

--- a/tests/unit/db-proxies-split.test.ts
+++ b/tests/unit/db-proxies-split.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Characterization + API-surface test: proxies.ts god-file decomposition.
+ *
+ * The host src/lib/db/proxies.ts was split into two sibling leaf modules under
+ * src/lib/db/proxies/:
+ *   - types.ts   — the 10 proxy type/interface declarations
+ *   - mappers.ts — the pure row mappers / scope normalizers / payload coercers
+ *                  (toRecord, mapProxyRow, isRelayProxyType, extractRelayAuth,
+ *                   normalizeScope, toLegacyProxyLevel, coerceProxyPayload,
+ *                   redactProxySecrets, …)
+ *
+ * The tightly-coupled CRUD + assignment + resolution core stays in the host
+ * (resolution calls createProxy/assignProxyToScope, so extracting it would
+ * create an import cycle).
+ *
+ * Verifies that:
+ *   1. The pure mappers behave correctly (DB-free).
+ *   2. The host proxies.ts still re-exports the FULL public API (20 functions).
+ *   3. The mappers leaf exports its pieces directly.
+ *
+ * Pure typeof/behaviour checks only — no DB handle is opened.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+// ── 1. mappers.ts — pure helper behaviour ────────────────────────────────────
+
+import {
+  isRelayProxyType,
+  extractRelayAuth,
+  normalizeScope,
+  normalizeAssignmentScopeId,
+  toLegacyProxyLevel,
+} from "../../src/lib/db/proxies/mappers.ts";
+
+describe("proxies/mappers — isRelayProxyType", () => {
+  it("is true only for relay proxy types", () => {
+    for (const t of ["vercel", "deno", "cloudflare"]) {
+      assert.equal(isRelayProxyType(t), true, t);
+    }
+  });
+  it("is false for non-relay or non-string input", () => {
+    assert.equal(isRelayProxyType("http"), false);
+    assert.equal(isRelayProxyType("socks5"), false);
+    assert.equal(isRelayProxyType(123), false);
+    assert.equal(isRelayProxyType(null), false);
+  });
+});
+
+describe("proxies/mappers — normalizeScope", () => {
+  it("maps the legacy 'key' alias to 'account'", () => {
+    assert.equal(normalizeScope("key"), "account");
+  });
+  it("passes through known scopes (case-insensitive)", () => {
+    assert.equal(normalizeScope("Provider"), "provider");
+    assert.equal(normalizeScope("ACCOUNT"), "account");
+    assert.equal(normalizeScope("combo"), "combo");
+  });
+  it("defaults to 'global' for unknown / empty", () => {
+    assert.equal(normalizeScope("bogus"), "global");
+    assert.equal(normalizeScope(""), "global");
+  });
+});
+
+describe("proxies/mappers — normalizeAssignmentScopeId", () => {
+  it("returns the sentinel for the global scope", () => {
+    assert.equal(normalizeAssignmentScopeId("global", "ignored"), "__global__");
+  });
+  it("returns the scopeId (or null) for other scopes", () => {
+    assert.equal(normalizeAssignmentScopeId("provider", "openai"), "openai");
+    assert.equal(normalizeAssignmentScopeId("account", null), null);
+    assert.equal(normalizeAssignmentScopeId("account", undefined), null);
+  });
+});
+
+describe("proxies/mappers — toLegacyProxyLevel", () => {
+  it("maps 'account' back to the legacy 'key' level", () => {
+    assert.equal(toLegacyProxyLevel("account"), "key");
+  });
+  it("passes through the other scopes unchanged", () => {
+    assert.equal(toLegacyProxyLevel("global"), "global");
+    assert.equal(toLegacyProxyLevel("provider"), "provider");
+    assert.equal(toLegacyProxyLevel("combo"), "combo");
+  });
+});
+
+describe("proxies/mappers — extractRelayAuth", () => {
+  it("returns undefined for non-string input", () => {
+    assert.equal(extractRelayAuth(null), undefined);
+    assert.equal(extractRelayAuth(42), undefined);
+  });
+  it("returns undefined for invalid JSON (try/catch)", () => {
+    assert.equal(extractRelayAuth("not json"), undefined);
+  });
+  it("returns the plaintext relayAuth field when present", () => {
+    assert.equal(extractRelayAuth(JSON.stringify({ relayAuth: "tok-123" })), "tok-123");
+  });
+  it("returns undefined when no relay auth is stored", () => {
+    assert.equal(extractRelayAuth(JSON.stringify({ other: "x" })), undefined);
+  });
+});
+
+// ── 2. proxies.ts — full public API surface preserved ────────────────────────
+
+const host = await import("../../src/lib/db/proxies.ts");
+
+describe("proxies.ts public API surface (20 symbols)", () => {
+  const expected = [
+    "assignProxyToScope",
+    "bulkAssignProxyToScope",
+    "createProxy",
+    "createProxyAndAssign",
+    "deleteProxyById",
+    "extractRelayAuth", // re-export from mappers
+    "getProxyAssignments",
+    "getProxyById",
+    "getProxyHealthStats",
+    "getProxyRegistryGeneration",
+    "getProxyWhereUsed",
+    "listProxies",
+    "migrateLegacyProxyConfigToRegistry",
+    "redactProxySecrets", // re-export from mappers
+    "resolveProxyForConnectionFromRegistry",
+    "resolveProxyForProvider",
+    "resolveProxyForScopeFromRegistry",
+    "updateProxy",
+    "updateProxyAndAssign",
+    "upsertProxy",
+  ];
+
+  for (const name of expected) {
+    it(`re-exports ${name} as a function`, () => {
+      assert.equal(typeof host[name], "function", `${name} must be a function on the host module`);
+    });
+  }
+
+  it("exposes exactly the 20 expected callables (no public symbol lost)", () => {
+    const missing = expected.filter((n) => typeof host[n] !== "function");
+    assert.deepEqual(missing, [], `missing public exports: ${missing.join(", ")}`);
+  });
+});
+
+// ── 3. mappers leaf exports its slice directly ───────────────────────────────
+
+describe("mappers.ts exports its public helpers directly", () => {
+  it("re-exported public mappers are functions on the leaf", async () => {
+    const mappers = await import("../../src/lib/db/proxies/mappers.ts");
+    assert.equal(typeof mappers.extractRelayAuth, "function");
+    assert.equal(typeof mappers.redactProxySecrets, "function");
+    assert.equal(typeof mappers.coerceProxyPayload, "function");
+  });
+});


### PR DESCRIPTION
## O quê
`src/lib/db/proxies.ts` era um god-file de **1059 linhas** (registry + assignments + resolution). Extraí as duas fatias **acíclicas e sem DB** para leaf modules irmãos em `src/lib/db/proxies/`, deixando o core acoplado de CRUD+resolution no host.

| Arquivo | Linhas | Conteúdo |
|---|---|---|
| `proxies/types.ts` | 65 | 10 declarações de type/interface (internas) |
| `proxies/mappers.ts` | 180 | row mappers / scope normalizers / payload coercers **puros** |
| `proxies.ts` (host) | **847** (de 1059) | CRUD + assignment + resolution + re-exports |

## Por que é seguro
- **Resolution não é extraível**: `resolveProxyForProvider`/`migrateLegacyProxyConfigToRegistry`/`bulkAssignProxyToScope` chamam `createProxy`/`assignProxyToScope` do core → extrair criaria **ciclo de import**. Por isso o core fica no host (parada consciente no limite acoplado).
- **API pública IDÊNTICA**: export-set continua os **20** mesmos símbolos (diff before/after vazio); nenhum type era público. Host re-exporta os 2 públicos movidos (`extractRelayAuth`, `redactProxySecrets`).
- **Verbatim**: bodies movidos byte-idênticos;  100% verbatim; mappers code 100% verbatim. Únicas edições no host: imports novos das leaves + re-export + remoção do `import { decrypt }` agora não-usado + 2 reflows de quebra-de-linha do prettier (ternário a 8-indent passa de 1→3 linhas por exceder 100 chars; union `{ cnt?: number }`) — **token-idênticos** (provado por comparação normalizada de whitespace).
- `typecheck:core` limpo, `check:cycles` OK (314 arquivos), eslint 0, prettier limpo.
- `db/proxies.ts` é frozen-baselined (1060) → 847 reduz o debt bem abaixo do congelado.

## Validação
- **69 testes** consumidores (db-proxies-crud/family, proxy-registry, registry-route-handlers, resolution-status-filter, relay-deploy, resolve-family, db-settings-crud) seguem **verdes**.
- Novo `tests/unit/db-proxies-split.test.ts` (**35 asserções**): guarda o barril (20 símbolos via host) + characteriza os mappers puros (isRelayProxyType/normalizeScope/normalizeAssignmentScopeId/toLegacyProxyLevel/extractRelayAuth) + valida exports diretos da leaf.

Campanha god-files (bloco **E3**, base `release/v3.8.43`). Refs #3501.