### PR TITLE
refactor(db): extract static migration data tables from migrationRunner.ts (constants leaf)

### DIFF
--- a/src/lib/db/migrationRunner.ts
+++ b/src/lib/db/migrationRunner.ts
@@ -19,6 +19,14 @@ import path from "path";
 import { fileURLToPath } from "url";
 import type { SqliteAdapter } from "./adapters/types";
 import { DEFAULT_DATABASE_SETTINGS } from "@/types/databaseSettings";
+import {
+  RENAMED_MIGRATION_COMPATIBILITY,
+  LEGACY_VERSION_SLOT_MIGRATIONS,
+  SUPERSEDED_DUPLICATE_MIGRATIONS,
+  PHYSICAL_SCHEMA_SENTINELS,
+  INITIAL_SCHEMA_SENTINELS,
+  OPTIONAL_FTS5_MIGRATION_VERSIONS,
+} from "./migrationRunner/constants";
 
 const isNodeTestRunnerChild = typeof process.env.NODE_TEST_CONTEXT === "string";
 
@@ -130,114 +138,6 @@ function resolveMaxPendingMigrations(): number {
   return DEFAULT_MAX_PENDING_MIGRATIONS_ON_EXISTING_DB;
 }
 
-const RENAMED_MIGRATION_COMPATIBILITY = [
-  {
-    fromVersion: "022",
-    fromName: "call_logs_summary_storage",
-    toVersion: "025",
-    toName: "call_logs_summary_storage",
-  },
-  {
-    fromVersion: "028",
-    fromName: "provider_connection_max_concurrent",
-    toVersion: "029",
-    toName: "provider_connection_max_concurrent",
-  },
-  {
-    fromVersion: "028",
-    fromName: "compression_settings",
-    toVersion: "034",
-    toName: "compression_settings",
-  },
-  {
-    fromVersion: "032",
-    fromName: "create_reasoning_cache",
-    toVersion: "033",
-    toName: "create_reasoning_cache",
-  },
-  {
-    fromVersion: "032",
-    fromName: "compression_analytics",
-    toVersion: "038",
-    toName: "compression_analytics",
-  },
-  {
-    fromVersion: "033",
-    fromName: "compression_cache_stats",
-    toVersion: "039",
-    toName: "compression_cache_stats",
-  },
-  {
-    fromVersion: "041",
-    fromName: "session_account_affinity",
-    toVersion: "050",
-    toName: "session_account_affinity",
-  },
-  {
-    fromVersion: "051",
-    fromName: "usage_history_service_tier",
-    toVersion: "054",
-    toName: "usage_history_service_tier",
-  },
-  {
-    fromVersion: "052",
-    fromName: "manifest_routing",
-    toVersion: "059",
-    toName: "manifest_routing",
-  },
-  {
-    fromVersion: "056",
-    fromName: "manifest_routing",
-    toVersion: "059",
-    toName: "manifest_routing",
-  },
-] as const;
-
-const LEGACY_VERSION_SLOT_MIGRATIONS = [
-  { version: "028", name: "evals_tables" },
-  { version: "029", name: "webhooks_templates" },
-  { version: "030", name: "mcp_scopes_api_keys" },
-  { version: "031", name: "api_keys_expires" },
-  { version: "032", name: "detailed_logs_warnings" },
-  { version: "033", name: "provider_connections_block_extra_usage" },
-  { version: "033", name: "add_batch_id_to_call_logs" },
-  { version: "046", name: "remove_status_from_files" },
-  { version: "051", name: "remove_status_from_files" },
-] as const;
-
-const SUPERSEDED_DUPLICATE_MIGRATIONS = [
-  {
-    version: "041",
-    name: "session_account_affinity",
-    supersededByVersion: "050",
-    supersededByName: "session_account_affinity",
-  },
-] as const;
-
-const PHYSICAL_SCHEMA_SENTINELS = [
-  { version: "028", tableName: "batches", description: "batches table" },
-  { version: "024", tableName: "sync_tokens", description: "sync_tokens table" },
-  { version: "022", tableName: "memory_fts", description: "memory_fts virtual table" },
-  { version: "019", tableName: "context_handoffs", description: "context_handoffs table" },
-  {
-    version: "064",
-    tableName: "session_model_history",
-    description: "session_model_history table",
-  },
-  { version: "017", tableName: "version_manager", description: "version_manager table" },
-  { version: "016", tableName: "skill_executions", description: "skill_executions table" },
-  { version: "015", tableName: "memories", description: "memories table" },
-  { version: "013", tableName: "quota_snapshots", description: "quota_snapshots table" },
-  { version: "011", tableName: "webhooks", description: "webhooks table" },
-  { version: "010", tableName: "model_combo_mappings", description: "model_combo_mappings table" },
-  { version: "008", tableName: "registered_keys", description: "registered_keys table" },
-  { version: "006", tableName: "request_detail_logs", description: "request_detail_logs table" },
-  { version: "004", tableName: "proxy_registry", description: "proxy_registry table" },
-  { version: "002", tableName: "mcp_tool_audit", description: "mcp_tool_audit table" },
-] as const;
-
-const INITIAL_SCHEMA_SENTINELS = ["provider_connections", "combos", "call_logs"] as const;
-const OPTIONAL_FTS5_MIGRATION_VERSIONS = new Set(["022", "023"]);
 const fts5SupportCache = new WeakMap<SqliteAdapter, boolean>();
 
 /**
@@ -735,8 +635,7 @@ function reconcileRenumberedMigrations(
     const legacyRow = db
       .prepare("SELECT version, name FROM _omniroute_migrations WHERE version = ? AND name = ?")
       .get(compatibility.fromVersion, compatibility.fromName) as
-      | { version: string; name: string }
-      | undefined;
+      { version: string; name: string } | undefined;
     if (!legacyRow) {
       continue;
     }

--- a/src/lib/db/migrationRunner/constants.ts
+++ b/src/lib/db/migrationRunner/constants.ts
@@ -1,0 +1,118 @@
+/**
+ * db/migrationRunner/constants.ts — Static migration-compatibility data tables.
+ *
+ * Pure data (no imports, no DB, no behaviour) extracted verbatim from
+ * migrationRunner.ts: the renamed/legacy/superseded migration maps and the
+ * physical/initial schema sentinels used by the reconciliation, dedup, and
+ * already-applied detection paths. Kept separate so the orchestrator host
+ * file holds logic, not data tables.
+ */
+
+export const RENAMED_MIGRATION_COMPATIBILITY = [
+  {
+    fromVersion: "022",
+    fromName: "call_logs_summary_storage",
+    toVersion: "025",
+    toName: "call_logs_summary_storage",
+  },
+  {
+    fromVersion: "028",
+    fromName: "provider_connection_max_concurrent",
+    toVersion: "029",
+    toName: "provider_connection_max_concurrent",
+  },
+  {
+    fromVersion: "028",
+    fromName: "compression_settings",
+    toVersion: "034",
+    toName: "compression_settings",
+  },
+  {
+    fromVersion: "032",
+    fromName: "create_reasoning_cache",
+    toVersion: "033",
+    toName: "create_reasoning_cache",
+  },
+  {
+    fromVersion: "032",
+    fromName: "compression_analytics",
+    toVersion: "038",
+    toName: "compression_analytics",
+  },
+  {
+    fromVersion: "033",
+    fromName: "compression_cache_stats",
+    toVersion: "039",
+    toName: "compression_cache_stats",
+  },
+  {
+    fromVersion: "041",
+    fromName: "session_account_affinity",
+    toVersion: "050",
+    toName: "session_account_affinity",
+  },
+  {
+    fromVersion: "051",
+    fromName: "usage_history_service_tier",
+    toVersion: "054",
+    toName: "usage_history_service_tier",
+  },
+  {
+    fromVersion: "052",
+    fromName: "manifest_routing",
+    toVersion: "059",
+    toName: "manifest_routing",
+  },
+  {
+    fromVersion: "056",
+    fromName: "manifest_routing",
+    toVersion: "059",
+    toName: "manifest_routing",
+  },
+] as const;
+
+export const LEGACY_VERSION_SLOT_MIGRATIONS = [
+  { version: "028", name: "evals_tables" },
+  { version: "029", name: "webhooks_templates" },
+  { version: "030", name: "mcp_scopes_api_keys" },
+  { version: "031", name: "api_keys_expires" },
+  { version: "032", name: "detailed_logs_warnings" },
+  { version: "033", name: "provider_connections_block_extra_usage" },
+  { version: "033", name: "add_batch_id_to_call_logs" },
+  { version: "046", name: "remove_status_from_files" },
+  { version: "051", name: "remove_status_from_files" },
+] as const;
+
+export const SUPERSEDED_DUPLICATE_MIGRATIONS = [
+  {
+    version: "041",
+    name: "session_account_affinity",
+    supersededByVersion: "050",
+    supersededByName: "session_account_affinity",
+  },
+] as const;
+
+export const PHYSICAL_SCHEMA_SENTINELS = [
+  { version: "028", tableName: "batches", description: "batches table" },
+  { version: "024", tableName: "sync_tokens", description: "sync_tokens table" },
+  { version: "022", tableName: "memory_fts", description: "memory_fts virtual table" },
+  { version: "019", tableName: "context_handoffs", description: "context_handoffs table" },
+  {
+    version: "064",
+    tableName: "session_model_history",
+    description: "session_model_history table",
+  },
+  { version: "017", tableName: "version_manager", description: "version_manager table" },
+  { version: "016", tableName: "skill_executions", description: "skill_executions table" },
+  { version: "015", tableName: "memories", description: "memories table" },
+  { version: "013", tableName: "quota_snapshots", description: "quota_snapshots table" },
+  { version: "011", tableName: "webhooks", description: "webhooks table" },
+  { version: "010", tableName: "model_combo_mappings", description: "model_combo_mappings table" },
+  { version: "008", tableName: "registered_keys", description: "registered_keys table" },
+  { version: "006", tableName: "request_detail_logs", description: "request_detail_logs table" },
+  { version: "004", tableName: "proxy_registry", description: "proxy_registry table" },
+  { version: "002", tableName: "mcp_tool_audit", description: "mcp_tool_audit table" },
+] as const;
+
+export const INITIAL_SCHEMA_SENTINELS = ["provider_connections", "combos", "call_logs"] as const;
+export const OPTIONAL_FTS5_MIGRATION_VERSIONS = new Set(["022", "023"]);

--- a/tests/unit/db-migrationrunner-constants-split.test.ts
+++ b/tests/unit/db-migrationrunner-constants-split.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Characterization / snapshot test: migrationRunner.ts god-file decomposition.
+ *
+ * The static migration-compatibility data tables were extracted verbatim from
+ * src/lib/db/migrationRunner.ts into the pure-data leaf
+ * src/lib/db/migrationRunner/constants.ts (no imports, no DB, no behaviour).
+ *
+ * These tables drive the reconciliation / dedup / already-applied detection
+ * paths in runMigrations(). The existing db-migration-runner.test.ts proves the
+ * BEHAVIOUR is unchanged; this test PINS THE DATA so a bad move (a dropped row,
+ * a transposed version, a corrupted sentinel) is caught immediately — the data
+ * is the thing the move could silently break.
+ *
+ * Pure value assertions — no DB handle is opened.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  RENAMED_MIGRATION_COMPATIBILITY,
+  LEGACY_VERSION_SLOT_MIGRATIONS,
+  SUPERSEDED_DUPLICATE_MIGRATIONS,
+  PHYSICAL_SCHEMA_SENTINELS,
+  INITIAL_SCHEMA_SENTINELS,
+  OPTIONAL_FTS5_MIGRATION_VERSIONS,
+} from "../../src/lib/db/migrationRunner/constants.ts";
+
+// ── small tables — full snapshot ─────────────────────────────────────────────
+
+describe("migrationRunner/constants — exact small-table snapshots", () => {
+  it("LEGACY_VERSION_SLOT_MIGRATIONS is the 9-entry list, in order", () => {
+    assert.deepEqual(
+      LEGACY_VERSION_SLOT_MIGRATIONS.map((m) => `${m.version}:${m.name}`),
+      [
+        "028:evals_tables",
+        "029:webhooks_templates",
+        "030:mcp_scopes_api_keys",
+        "031:api_keys_expires",
+        "032:detailed_logs_warnings",
+        "033:provider_connections_block_extra_usage",
+        "033:add_batch_id_to_call_logs",
+        "046:remove_status_from_files",
+        "051:remove_status_from_files",
+      ]
+    );
+  });
+
+  it("SUPERSEDED_DUPLICATE_MIGRATIONS is the single 041→050 session_account_affinity entry", () => {
+    assert.deepEqual(SUPERSEDED_DUPLICATE_MIGRATIONS, [
+      {
+        version: "041",
+        name: "session_account_affinity",
+        supersededByVersion: "050",
+        supersededByName: "session_account_affinity",
+      },
+    ]);
+  });
+
+  it("INITIAL_SCHEMA_SENTINELS pins the three baseline tables", () => {
+    assert.deepEqual(INITIAL_SCHEMA_SENTINELS, ["provider_connections", "combos", "call_logs"]);
+  });
+
+  it("OPTIONAL_FTS5_MIGRATION_VERSIONS is exactly {022, 023}", () => {
+    assert.ok(OPTIONAL_FTS5_MIGRATION_VERSIONS instanceof Set);
+    assert.deepEqual([...OPTIONAL_FTS5_MIGRATION_VERSIONS].sort(), ["022", "023"]);
+  });
+});
+
+// ── large tables — count + shape + spot-checks (corruption guard) ─────────────
+
+describe("migrationRunner/constants — large-table integrity", () => {
+  it("RENAMED_MIGRATION_COMPATIBILITY has 10 well-formed entries", () => {
+    assert.equal(RENAMED_MIGRATION_COMPATIBILITY.length, 10);
+    for (const e of RENAMED_MIGRATION_COMPATIBILITY) {
+      assert.equal(typeof e.fromVersion, "string");
+      assert.equal(typeof e.fromName, "string");
+      assert.equal(typeof e.toVersion, "string");
+      assert.equal(typeof e.toName, "string");
+    }
+  });
+
+  it("RENAMED_MIGRATION_COMPATIBILITY spot-checks the boundary renames", () => {
+    const first = RENAMED_MIGRATION_COMPATIBILITY[0];
+    assert.deepEqual(first, {
+      fromVersion: "022",
+      fromName: "call_logs_summary_storage",
+      toVersion: "025",
+      toName: "call_logs_summary_storage",
+    });
+    // both manifest_routing collisions (052→059 and 056→059) must survive
+    const manifest = RENAMED_MIGRATION_COMPATIBILITY.filter((e) => e.toName === "manifest_routing");
+    assert.deepEqual(manifest.map((e) => e.fromVersion).sort(), ["052", "056"]);
+  });
+
+  it("PHYSICAL_SCHEMA_SENTINELS has 15 well-formed entries incl. the newest 064", () => {
+    assert.equal(PHYSICAL_SCHEMA_SENTINELS.length, 15);
+    for (const e of PHYSICAL_SCHEMA_SENTINELS) {
+      assert.equal(typeof e.version, "string");
+      assert.equal(typeof e.tableName, "string");
+      assert.equal(typeof e.description, "string");
+    }
+    const byVersion = Object.fromEntries(
+      PHYSICAL_SCHEMA_SENTINELS.map((e) => [e.version, e.tableName])
+    );
+    assert.equal(byVersion["064"], "session_model_history");
+    assert.equal(byVersion["002"], "mcp_tool_audit");
+    assert.equal(byVersion["028"], "batches");
+  });
+});


### PR DESCRIPTION
## O quê
`src/lib/db/migrationRunner.ts` (1124 linhas, frozen-baselined em 1125) é o orquestrador de migrações que roda no **startup** — módulo crítico. Como **fatia conservadora de zero-risco-comportamental** (escolha do operador: *caracterizar antes, split conservador*), extraí as **6 tabelas de DADOS estáticos** (verbatim) para um leaf puro, deixando o orquestrador inteiro + todos os helpers que rodam SQL no host.

| Arquivo | Linhas | Conteúdo |
|---|---|---|
| `migrationRunner/constants.ts` | 118 | RENAMED/LEGACY/SUPERSEDED migration maps + PHYSICAL/INITIAL schema sentinels + OPTIONAL_FTS5 set |
| `migrationRunner.ts` (host) | **1023** (de 1124) | orquestrador + helpers SQL + `fts5SupportCache` (WeakMap runtime) |

## Por que é seguro
- **Só dados puros movidos** (sem imports, sem DB, sem comportamento). O `fts5SupportCache` (WeakMap mutável de runtime) **fica no host**.
- **Sem mudança de API** (esses consts eram internos ao módulo).
- **Verbatim**: dados extraídos via `sed` byte-idênticos (verificado). Únicas edições no host: o import do leaf + 1 colapso do prettier numa união de tipo pré-existente de 2→1 linha (token-idêntico, confirmado por typecheck).
- `typecheck:core` limpo · `check:cycles` OK (313 arquivos) · eslint 0 · prettier limpo.

## Validação (caracterizar-antes)
- **Comportamento preservado**: os **37 testes** existentes de migração seguem verdes — `db-migration-runner` (26: apply-in-order, skip-applied, getMigrationStatus, no-op, invalid-names) + `no-migration-collisions` (2) + `weak-rng-fixes` (4) + `check-db-rules-classification` (5). Eles exercitam reconciliation/dedup/already-applied, que **consomem** estes consts.
- **Dados pinados**: novo `tests/unit/db-migrationrunner-constants-split.test.ts` (**7 testes**) — snapshot exato das tabelas pequenas + count/shape/spot-check das grandes (RENAMED 10 entries incl. ambas colisões manifest_routing 052/056→059; PHYSICAL 15 incl. 064 session_model_history). Uma linha derrubada/trocada falha imediatamente.

Campanha god-files (bloco **E3**, base `release/v3.8.43`). Refs #3501.