### PR TITLE
refactor(usage): extract pure formatting helpers from callLogs.ts (format leaf)

### DIFF
--- a/src/lib/usage/callLogs.ts
+++ b/src/lib/usage/callLogs.ts
@@ -20,7 +20,6 @@ import {
   getReasoningTokensOrNull,
 } from "./tokenAccounting";
 import { isNoLog } from "../compliance/noLog";
-import { sanitizePII } from "../piiSanitizer";
 import { protectPayloadForLog, parseStoredPayload } from "../logPayloads";
 import { getCallLogMaxEntries, getCallLogRetentionDays, getCallLogsTableMaxRows } from "../logEnv";
 import { pickDisplayValue } from "@/shared/utils/maskEmail";
@@ -34,6 +33,16 @@ import {
   type CallLogArtifact,
   type CallLogDetailState,
 } from "./callLogArtifacts";
+import {
+  toNumber,
+  toStringOrNull,
+  parseInlineError,
+  normalizeDetailState,
+  sanitizeErrorForLog,
+  toStoredErrorSummary,
+  protectPipelinePayloads,
+  buildRequestSummary,
+} from "./callLogs/format";
 
 type JsonRecord = Record<string, unknown>;
 
@@ -97,126 +106,6 @@ type DeleteResult = {
 };
 
 let logIdCounter = 0;
-
-function asRecord(value: unknown): JsonRecord {
-  return value && typeof value === "object" && !Array.isArray(value) ? (value as JsonRecord) : {};
-}
-
-function toNumber(value: unknown): number {
-  if (typeof value === "number" && Number.isFinite(value)) return value;
-  if (typeof value === "string" && value.trim().length > 0) {
-    const parsed = Number(value);
-    return Number.isFinite(parsed) ? parsed : 0;
-  }
-  return 0;
-}
-
-function toStringOrNull(value: unknown): string | null {
-  return typeof value === "string" && value.trim().length > 0 ? value : null;
-}
-
-function truncateText(value: string, maxLength: number) {
-  return value.length > maxLength ? value.slice(0, maxLength) : value;
-}
-
-function parseInlineError(value: unknown): unknown {
-  if (typeof value !== "string" || value.trim().length === 0) return null;
-  try {
-    return JSON.parse(value);
-  } catch {
-    return value;
-  }
-}
-
-function normalizeDetailState(value: unknown): CallLogDetailState {
-  if (
-    value === "ready" ||
-    value === "missing" ||
-    value === "corrupt" ||
-    value === "legacy-inline"
-  ) {
-    return value;
-  }
-  return "none";
-}
-
-function sanitizeErrorForLog(error: unknown): unknown {
-  if (error === null || error === undefined) return null;
-  if (typeof error === "string") return sanitizePII(error).text;
-  if (error instanceof Error) {
-    return {
-      message: sanitizePII(error.message).text,
-      stack: sanitizePII(error.stack || "").text || undefined,
-      name: error.name,
-    };
-  }
-  return protectPayloadForLog(error);
-}
-
-function toStoredErrorSummary(error: unknown): string | null {
-  const sanitized = sanitizeErrorForLog(error);
-  if (sanitized === null || sanitized === undefined) return null;
-
-  if (typeof sanitized === "string") {
-    return truncateText(sanitized, 4000);
-  }
-
-  try {
-    return truncateText(JSON.stringify(sanitized), 4000);
-  } catch {
-    return truncateText(String(sanitized), 4000);
-  }
-}
-
-function protectPipelinePayloads(payloads: unknown): RequestPipelinePayloads | null {
-  if (!payloads || typeof payloads !== "object") return null;
-
-  const protectedPayloads: RequestPipelinePayloads = {};
-  for (const [key, value] of Object.entries(payloads as JsonRecord)) {
-    if (value === null || value === undefined) continue;
-
-    if (key === "streamChunks" && value && typeof value === "object") {
-      const chunks = value as Record<string, unknown>;
-      const compacted = Object.fromEntries(
-        Object.entries(chunks).filter(
-          ([, chunkValue]) => Array.isArray(chunkValue) && chunkValue.length > 0
-        )
-      );
-      if (Object.keys(compacted).length > 0) {
-        protectedPayloads.streamChunks = protectPayloadForLog(
-          compacted
-        ) as RequestPipelinePayloads["streamChunks"];
-      }
-      continue;
-    }
-
-    protectedPayloads[key as keyof RequestPipelinePayloads] = protectPayloadForLog(value) as never;
-  }
-
-  return Object.keys(protectedPayloads).length > 0 ? protectedPayloads : null;
-}
-
-function buildRequestSummary(requestType: string | null, requestBody: unknown): string | null {
-  if (requestType !== "search") return null;
-
-  const body = asRecord(requestBody);
-  if (Object.keys(body).length === 0) return null;
-
-  const summary: JsonRecord = {};
-  if (typeof body.query === "string" && body.query.trim().length > 0) {
-    summary.query = sanitizePII(body.query).text;
-  }
-
-  const filters = Object.fromEntries(
-    Object.entries(body).filter(([key]) => key !== "query" && key !== "provider")
-  );
-  if (Object.keys(filters).length > 0) {
-    summary.filters = filters;
-  }
-
-  if (Object.keys(summary).length === 0) return null;
-  return JSON.stringify(summary);
-}
 
 function generateLogId() {
   logIdCounter++;

--- a/src/lib/usage/callLogs/format.ts
+++ b/src/lib/usage/callLogs/format.ts
@@ -1,0 +1,129 @@
+import type { RequestPipelinePayloads } from "@omniroute/open-sse/utils/requestLogger.ts";
+import { sanitizePII } from "../../piiSanitizer";
+import { protectPayloadForLog } from "../../logPayloads";
+import type { CallLogDetailState } from "../callLogArtifacts";
+
+type JsonRecord = Record<string, unknown>;
+
+export function asRecord(value: unknown): JsonRecord {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as JsonRecord) : {};
+}
+
+export function toNumber(value: unknown): number {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  return 0;
+}
+
+export function toStringOrNull(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+export function truncateText(value: string, maxLength: number) {
+  return value.length > maxLength ? value.slice(0, maxLength) : value;
+}
+
+export function parseInlineError(value: unknown): unknown {
+  if (typeof value !== "string" || value.trim().length === 0) return null;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+export function normalizeDetailState(value: unknown): CallLogDetailState {
+  if (
+    value === "ready" ||
+    value === "missing" ||
+    value === "corrupt" ||
+    value === "legacy-inline"
+  ) {
+    return value;
+  }
+  return "none";
+}
+
+export function sanitizeErrorForLog(error: unknown): unknown {
+  if (error === null || error === undefined) return null;
+  if (typeof error === "string") return sanitizePII(error).text;
+  if (error instanceof Error) {
+    return {
+      message: sanitizePII(error.message).text,
+      stack: sanitizePII(error.stack || "").text || undefined,
+      name: error.name,
+    };
+  }
+  return protectPayloadForLog(error);
+}
+
+export function toStoredErrorSummary(error: unknown): string | null {
+  const sanitized = sanitizeErrorForLog(error);
+  if (sanitized === null || sanitized === undefined) return null;
+
+  if (typeof sanitized === "string") {
+    return truncateText(sanitized, 4000);
+  }
+
+  try {
+    return truncateText(JSON.stringify(sanitized), 4000);
+  } catch {
+    return truncateText(String(sanitized), 4000);
+  }
+}
+
+export function protectPipelinePayloads(payloads: unknown): RequestPipelinePayloads | null {
+  if (!payloads || typeof payloads !== "object") return null;
+
+  const protectedPayloads: RequestPipelinePayloads = {};
+  for (const [key, value] of Object.entries(payloads as JsonRecord)) {
+    if (value === null || value === undefined) continue;
+
+    if (key === "streamChunks" && value && typeof value === "object") {
+      const chunks = value as Record<string, unknown>;
+      const compacted = Object.fromEntries(
+        Object.entries(chunks).filter(
+          ([, chunkValue]) => Array.isArray(chunkValue) && chunkValue.length > 0
+        )
+      );
+      if (Object.keys(compacted).length > 0) {
+        protectedPayloads.streamChunks = protectPayloadForLog(
+          compacted
+        ) as RequestPipelinePayloads["streamChunks"];
+      }
+      continue;
+    }
+
+    protectedPayloads[key as keyof RequestPipelinePayloads] = protectPayloadForLog(value) as never;
+  }
+
+  return Object.keys(protectedPayloads).length > 0 ? protectedPayloads : null;
+}
+
+export function buildRequestSummary(
+  requestType: string | null,
+  requestBody: unknown
+): string | null {
+  if (requestType !== "search") return null;
+
+  const body = asRecord(requestBody);
+  if (Object.keys(body).length === 0) return null;
+
+  const summary: JsonRecord = {};
+  if (typeof body.query === "string" && body.query.trim().length > 0) {
+    summary.query = sanitizePII(body.query).text;
+  }
+
+  const filters = Object.fromEntries(
+    Object.entries(body).filter(([key]) => key !== "query" && key !== "provider")
+  );
+  if (Object.keys(filters).length > 0) {
+    summary.filters = filters;
+  }
+
+  if (Object.keys(summary).length === 0) return null;
+  return JSON.stringify(summary);
+}

--- a/tests/unit/calllogs-format-split.test.ts
+++ b/tests/unit/calllogs-format-split.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Characterization + API-surface test: callLogs.ts god-file decomposition.
+ *
+ * The 10 pure formatting/sanitization helpers were extracted verbatim from
+ * src/lib/usage/callLogs.ts into the pure leaf src/lib/usage/callLogs/format.ts
+ * (no DB, no fs). The DB CRUD / disk-artifact / rotation code stays in the host.
+ *
+ * Verifies that:
+ *   1. The pure helpers behave correctly (DB-free).
+ *   2. The host callLogs.ts still exposes the FULL public API (10 functions).
+ *   3. The format leaf exports its helpers directly.
+ *
+ * NOTE: helpers that call sanitizePII are exercised with non-PII text, since PII
+ * redaction is opt-in / off by default (Hard Rule #20), so sanitizePII is a
+ * pass-through here — the test pins the formatting logic, not PII behaviour.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  asRecord,
+  toNumber,
+  toStringOrNull,
+  truncateText,
+  parseInlineError,
+  normalizeDetailState,
+  toStoredErrorSummary,
+  buildRequestSummary,
+} from "../../src/lib/usage/callLogs/format.ts";
+
+describe("callLogs/format — coercers", () => {
+  it("asRecord keeps plain objects, rejects arrays/primitives/null", () => {
+    const o = { a: 1 };
+    assert.equal(asRecord(o), o);
+    assert.deepEqual(asRecord([1, 2]), {});
+    assert.deepEqual(asRecord("x"), {});
+    assert.deepEqual(asRecord(null), {});
+  });
+
+  it("toNumber parses finite numbers and numeric strings, else 0", () => {
+    assert.equal(toNumber(5), 5);
+    assert.equal(toNumber("42"), 42);
+    assert.equal(toNumber("  7 "), 7);
+    assert.equal(toNumber("abc"), 0);
+    assert.equal(toNumber(Infinity), 0);
+    assert.equal(toNumber(null), 0);
+  });
+
+  it("toStringOrNull keeps non-blank strings, else null", () => {
+    assert.equal(toStringOrNull("hi"), "hi");
+    assert.equal(toStringOrNull("   "), null);
+    assert.equal(toStringOrNull(5), null);
+  });
+
+  it("truncateText slices only when over the limit", () => {
+    assert.equal(truncateText("hello", 10), "hello");
+    assert.equal(truncateText("hello", 3), "hel");
+  });
+});
+
+describe("callLogs/format — parseInlineError", () => {
+  it("returns null for non-string / blank", () => {
+    assert.equal(parseInlineError(null), null);
+    assert.equal(parseInlineError("  "), null);
+  });
+  it("parses valid JSON, falls back to the raw string on invalid JSON", () => {
+    assert.deepEqual(parseInlineError('{"code":429}'), { code: 429 });
+    assert.equal(parseInlineError("not json"), "not json");
+  });
+});
+
+describe("callLogs/format — normalizeDetailState", () => {
+  it("passes through the four known states", () => {
+    for (const s of ["ready", "missing", "corrupt", "legacy-inline"]) {
+      assert.equal(normalizeDetailState(s), s);
+    }
+  });
+  it("maps anything else to 'none'", () => {
+    assert.equal(normalizeDetailState("bogus"), "none");
+    assert.equal(normalizeDetailState(undefined), "none");
+  });
+});
+
+describe("callLogs/format — toStoredErrorSummary", () => {
+  it("returns null for nullish error", () => {
+    assert.equal(toStoredErrorSummary(null), null);
+    assert.equal(toStoredErrorSummary(undefined), null);
+  });
+  it("stringifies a plain-text error (PII pass-through by default)", () => {
+    assert.equal(toStoredErrorSummary("boom"), "boom");
+  });
+  it("JSON-stringifies an Error object's sanitized shape", () => {
+    const out = toStoredErrorSummary(new Error("kaboom"));
+    assert.equal(typeof out, "string");
+    assert.ok(out.includes("kaboom"));
+    assert.ok(out.includes("message"));
+  });
+});
+
+describe("callLogs/format — buildRequestSummary", () => {
+  it("returns null for non-search request types", () => {
+    assert.equal(buildRequestSummary("chat", { query: "x" }), null);
+    assert.equal(buildRequestSummary(null, { query: "x" }), null);
+  });
+  it("summarizes a search request's query + non-query/provider filters", () => {
+    const out = buildRequestSummary("search", { query: "cats", provider: "p", topK: 5 });
+    assert.equal(typeof out, "string");
+    const parsed = JSON.parse(out);
+    assert.equal(parsed.query, "cats");
+    assert.deepEqual(parsed.filters, { topK: 5 });
+    assert.equal("provider" in (parsed.filters ?? {}), false);
+  });
+  it("returns null when a search request carries no summarizable fields", () => {
+    assert.equal(buildRequestSummary("search", {}), null);
+    assert.equal(buildRequestSummary("search", { provider: "only" }), null);
+  });
+});
+
+// ── host public API surface ──────────────────────────────────────────────────
+
+const host = await import("../../src/lib/usage/callLogs.ts");
+
+describe("callLogs.ts public API surface (10 functions)", () => {
+  const expected = [
+    "cleanupOrphanCallLogFiles",
+    "cleanupOverflowCallLogFiles",
+    "deleteCallLogsBefore",
+    "exportCallLogsSince",
+    "getCallLogById",
+    "getCallLogs",
+    "rotateCallLogs",
+    "saveCallLog",
+    "scheduleCallLogRotation",
+    "trimCallLogsToMaxRows",
+  ];
+  for (const name of expected) {
+    it(`exposes ${name} as a function`, () => {
+      assert.equal(typeof host[name], "function", `${name} must be a function on the host`);
+    });
+  }
+  it("loses no public function in the split", () => {
+    const missing = expected.filter((n) => typeof host[n] !== "function");
+    assert.deepEqual(missing, [], `missing: ${missing.join(", ")}`);
+  });
+});
+
+describe("format.ts exports its helpers directly", () => {
+  it("the moved helpers are functions on the leaf", async () => {
+    const fmt = await import("../../src/lib/usage/callLogs/format.ts");
+    for (const fn of [
+      "asRecord",
+      "toNumber",
+      "sanitizeErrorForLog",
+      "protectPipelinePayloads",
+      "buildRequestSummary",
+    ]) {
+      assert.equal(typeof fmt[fn], "function", fn);
+    }
+  });
+});


### PR DESCRIPTION
## O quê
`src/lib/usage/callLogs.ts` (996 linhas, frozen-baselined) mistura helpers puros de formatação/sanitização de log com CRUD de DB, artefatos em disco e rotação. Extraí os 10 helpers **puros** (sem DB/fs) verbatim para um leaf, deixando todo o código stateful no host.

| Arquivo | Linhas | Conteúdo |
|---|---|---|
| `callLogs/format.ts` | 129 | asRecord/toNumber/toStringOrNull/truncateText/parseInlineError/normalizeDetailState/sanitizeErrorForLog/toStoredErrorSummary/protectPipelinePayloads/buildRequestSummary |
| `callLogs.ts` (host) | **885** (de 996) | CRUD + artefatos + rotação + scheduling |

## Por que é seguro
- **Só helpers puros movidos** (sem DB, sem fs). O `generateLogId` (muta `logIdCounter`) **fica no host**.
- **Sem mudança de API** (os 10 helpers eram internos) → 10 funções públicas inalteradas, sem re-export.
- **Verbatim**: bodies byte-idênticos; o import `sanitizePII` (usado só nos bodies movidos) migrou p/ o leaf; o prettier quebrou a assinatura de `buildRequestSummary` em linhas quando o `export` passou de 100 cols (token-idêntico).
- `typecheck:core` limpo · `check:cycles` OK (319 arquivos) · eslint 0 · prettier limpo.

## Validação
- **46 testes** consumidores existentes seguem **verdes** (call-log-cap 14, pagination 4, file-rotation 5, log-retention 5, startup 1, oom 2, trim-sql 2, db-settings-maintenance 13).
- Novo `tests/unit/calllogs-format-split.test.ts` (**26 asserções**) characteriza os helpers puros (incl. buildRequestSummary search-only + parseInlineError JSON-fallback + normalizeDetailState) + guarda a API de 10 funções.

Campanha god-files (bloco **E4**, base `release/v3.8.43`). Refs #3501.