### PR TITLE
refactor(memory): extract pure scoring/conversion helpers from retrieval.ts (scoring leaf)

### DIFF
--- a/src/lib/memory/retrieval.ts
+++ b/src/lib/memory/retrieval.ts
@@ -1,5 +1,5 @@
 import { getDbInstance } from "../db/core";
-import { Memory, MemoryConfig, MemoryType } from "./types";
+import { Memory, MemoryConfig } from "./types";
 import { MemoryConfigSchema } from "./schemas";
 import { logger } from "../../../open-sse/utils/logger.ts";
 import { sanitizeErrorMessage } from "../../../open-sse/utils/error.ts";
@@ -10,28 +10,10 @@ import { recordMemoryAccess } from "./store";
 import { stats as embeddingCacheStats } from "./embedding/cache";
 import { getQdrantConfig, checkQdrantHealth, searchSemanticMemory } from "./qdrant";
 import type { MemoryEngineStatus } from "@/shared/schemas/memory";
+import { estimateTokens, parseMetadata, rowToMemory, getRelevanceScore } from "./retrieval/scoring";
+import type { MemoryRow } from "./retrieval/scoring";
 
 const log = logger("MEMORY_RETRIEVAL");
-
-interface MemoryRow {
-  id: string;
-  api_key_id?: string;
-  apiKeyId?: string;
-  session_id?: string | null;
-  sessionId?: string | null;
-  type: MemoryType;
-  key?: string | null;
-  content: string;
-  metadata?: string | null;
-  created_at?: string;
-  createdAt?: string;
-  updated_at?: string;
-  updatedAt?: string;
-  expires_at?: string | null;
-  expiresAt?: string | null;
-  access_count?: number | null;
-  last_accessed_at?: string | null;
-}
 
 interface RetrievalOptions extends Partial<MemoryConfig> {
   query?: string;
@@ -65,15 +47,9 @@ export interface RetrievePreviewBundle {
   budgetMaxTokens: number;
 }
 
-// ──────────────── Helpers ────────────────
+export { estimateTokens } from "./retrieval/scoring";
 
-/**
- * Simple token estimation function (roughly 1 token per 4 characters)
- */
-export function estimateTokens(text: string): number {
-  if (!text || typeof text !== "string") return 0;
-  return Math.ceil(text.length / 4);
-}
+// ──────────────── Helpers ────────────────
 
 function hasTable(tableName: string): boolean {
   const db = getDbInstance();
@@ -81,81 +57,6 @@ function hasTable(tableName: string): boolean {
     .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?")
     .get(tableName) as { name?: string } | undefined;
   return row?.name === tableName;
-}
-
-function parseMetadata(raw: unknown): Record<string, unknown> {
-  if (!raw || typeof raw !== "string") return {};
-  try {
-    const parsed = JSON.parse(raw);
-    return typeof parsed === "object" && parsed !== null ? parsed : {};
-  } catch {
-    return {};
-  }
-}
-
-function rowToMemory(row: MemoryRow): Memory {
-  const createdAt = row.created_at || row.createdAt || new Date().toISOString();
-  const updatedAt = row.updated_at || row.updatedAt || createdAt;
-  const expiresAt = row.expires_at ?? row.expiresAt ?? null;
-
-  return {
-    id: String(row.id),
-    apiKeyId: String(row.api_key_id || row.apiKeyId || ""),
-    sessionId: String(row.session_id ?? row.sessionId ?? ""),
-    type: row.type as MemoryType,
-    key: String(row.key || ""),
-    content: String(row.content || ""),
-    metadata: parseMetadata(row.metadata),
-    createdAt: new Date(createdAt),
-    updatedAt: new Date(updatedAt),
-    expiresAt: expiresAt ? new Date(String(expiresAt)) : null,
-    accessCount: typeof row.access_count === "number" ? row.access_count : 0,
-    lastAccessedAt: row.last_accessed_at ? new Date(String(row.last_accessed_at)) : null,
-  };
-}
-
-/**
- * Score a memory against a query using simple string matching (no dynamic RegExp).
- * Uses indexOf() for full-phrase matches and split-token substring checks only,
- * so there is no ReDoS risk — no user input is passed to RegExp().
- */
-function getRelevanceScore(memory: Memory, query: string): number {
-  const normalizedQuery = query.trim().toLowerCase();
-  if (!normalizedQuery) return 0;
-
-  const haystacks = [
-    memory.content.toLowerCase(),
-    memory.key.toLowerCase(),
-    JSON.stringify(memory.metadata).toLowerCase(),
-  ];
-  const tokens = normalizedQuery.split(/\s+/).filter(Boolean);
-
-  let score = 0;
-  for (const haystack of haystacks) {
-    // Full phrase match (safe: literal string, not regex)
-    if (haystack.includes(normalizedQuery)) {
-      score += 20;
-    }
-
-    for (const token of tokens) {
-      if (!token) continue;
-      // Token-level substring count using indexOf loop (no RegExp on user input)
-      if (haystack === memory.key.toLowerCase() && haystack.includes(token)) {
-        score += 6;
-        continue;
-      }
-      // Count occurrences via indexOf loop — avoids new RegExp(token)
-      let pos = 0;
-      let matchCount = 0;
-      while ((pos = haystack.indexOf(token, pos)) !== -1) {
-        matchCount++;
-        pos += token.length;
-      }
-      score += matchCount * 3;
-    }
-  }
-
-  return score;
 }
 
 /**
@@ -263,7 +164,8 @@ async function applyRerank<T extends { memory: Memory; score: number }>(
       top_n: items.length,
     };
 
-    const res = await fetch(RERANK_LOOPBACK_URL, { // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request
+    const res = await fetch(RERANK_LOOPBACK_URL, {
+      // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify(body),
@@ -445,19 +347,13 @@ async function retrieveMemoriesInternal(
               if (qres.ok && qres.results && qres.results.length > 0) {
                 const hitIds = qres.results.map((r) => r.id);
                 const hitMemories = fetchMemoriesByIds(hitIds);
-                const scoreMap = new Map(
-                  qres.results.map((r) => [r.id, r.score])
-                );
+                const scoreMap = new Map(qres.results.map((r) => [r.id, r.score]));
                 let qdrantItems = hitMemories.map((m) => ({
                   memory: m,
                   score: scoreMap.get(m.id) ?? 0,
                   tier: "qdrant" as const,
                 }));
-                if (
-                  settings.rerankEnabled &&
-                  settings.rerankProviderModel &&
-                  config.query
-                ) {
+                if (settings.rerankEnabled && settings.rerankProviderModel && config.query) {
                   qdrantItems = (await applyRerank(
                     qdrantItems,
                     config.query,
@@ -485,9 +381,7 @@ async function retrieveMemoriesInternal(
               }
             } catch (err: unknown) {
               log.warn("memory.retrieval.qdrant.fail", {
-                error: sanitizeErrorMessage(
-                  err instanceof Error ? err.message : String(err)
-                ),
+                error: sanitizeErrorMessage(err instanceof Error ? err.message : String(err)),
               });
               // fall through to sqlite-vec degradation
             }
@@ -581,19 +475,13 @@ async function retrieveMemoriesInternal(
               if (qres.ok && qres.results && qres.results.length > 0) {
                 const hitIds = qres.results.map((r) => r.id);
                 const hitMemories = fetchMemoriesByIds(hitIds);
-                const scoreMap = new Map(
-                  qres.results.map((r) => [r.id, r.score])
-                );
+                const scoreMap = new Map(qres.results.map((r) => [r.id, r.score]));
                 let qdrantItems = hitMemories.map((m) => ({
                   memory: m,
                   score: scoreMap.get(m.id) ?? 0,
                   tier: "qdrant" as const,
                 }));
-                if (
-                  settings.rerankEnabled &&
-                  settings.rerankProviderModel &&
-                  config.query
-                ) {
+                if (settings.rerankEnabled && settings.rerankProviderModel && config.query) {
                   qdrantItems = (await applyRerank(
                     qdrantItems,
                     config.query,
@@ -621,9 +509,7 @@ async function retrieveMemoriesInternal(
               }
             } catch (err: unknown) {
               log.warn("memory.retrieval.qdrant.fail", {
-                error: sanitizeErrorMessage(
-                  err instanceof Error ? err.message : String(err)
-                ),
+                error: sanitizeErrorMessage(err instanceof Error ? err.message : String(err)),
               });
               // fall through to sqlite-vec hybrid RRF
             }
@@ -815,9 +701,7 @@ export async function retrievePreview(
           if (qres.ok && qres.results && qres.results.length > 0) {
             const hitIds = qres.results.map((r) => r.id);
             const hitMemories = fetchMemoriesByIds(hitIds).slice(0, limit);
-            const scoreMap = new Map(
-              qres.results.map((r) => [r.id, r.score])
-            );
+            const scoreMap = new Map(qres.results.map((r) => [r.id, r.score]));
             let items: Array<{
               memory: Memory;
               score: number;
@@ -867,9 +751,7 @@ export async function retrievePreview(
           // with production (so the Playground reflects the same fallback).
           fallbackReason = "Qdrant returned 0 results — falling back to sqlite-vec";
         } catch (err: unknown) {
-          fallbackReason = sanitizeErrorMessage(
-            err instanceof Error ? err.message : String(err)
-          );
+          fallbackReason = sanitizeErrorMessage(err instanceof Error ? err.message : String(err));
           log.warn("memory.preview.qdrant.fail", { error: fallbackReason });
         }
       }
@@ -985,9 +867,7 @@ export async function retrievePreview(
               budgetMaxTokens: maxTokens,
             };
           } catch (err: unknown) {
-            fallbackReason = sanitizeErrorMessage(
-              err instanceof Error ? err.message : String(err)
-            );
+            fallbackReason = sanitizeErrorMessage(err instanceof Error ? err.message : String(err));
             log.warn("memory.preview.vector.fail", { error: fallbackReason });
           }
         } else {

--- a/src/lib/memory/retrieval/scoring.ts
+++ b/src/lib/memory/retrieval/scoring.ts
@@ -1,0 +1,104 @@
+import { Memory, MemoryType } from "../types";
+
+export interface MemoryRow {
+  id: string;
+  api_key_id?: string;
+  apiKeyId?: string;
+  session_id?: string | null;
+  sessionId?: string | null;
+  type: MemoryType;
+  key?: string | null;
+  content: string;
+  metadata?: string | null;
+  created_at?: string;
+  createdAt?: string;
+  updated_at?: string;
+  updatedAt?: string;
+  expires_at?: string | null;
+  expiresAt?: string | null;
+  access_count?: number | null;
+  last_accessed_at?: string | null;
+}
+
+/**
+ * Simple token estimation function (roughly 1 token per 4 characters)
+ */
+export function estimateTokens(text: string): number {
+  if (!text || typeof text !== "string") return 0;
+  return Math.ceil(text.length / 4);
+}
+
+export function parseMetadata(raw: unknown): Record<string, unknown> {
+  if (!raw || typeof raw !== "string") return {};
+  try {
+    const parsed = JSON.parse(raw);
+    return typeof parsed === "object" && parsed !== null ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+export function rowToMemory(row: MemoryRow): Memory {
+  const createdAt = row.created_at || row.createdAt || new Date().toISOString();
+  const updatedAt = row.updated_at || row.updatedAt || createdAt;
+  const expiresAt = row.expires_at ?? row.expiresAt ?? null;
+
+  return {
+    id: String(row.id),
+    apiKeyId: String(row.api_key_id || row.apiKeyId || ""),
+    sessionId: String(row.session_id ?? row.sessionId ?? ""),
+    type: row.type as MemoryType,
+    key: String(row.key || ""),
+    content: String(row.content || ""),
+    metadata: parseMetadata(row.metadata),
+    createdAt: new Date(createdAt),
+    updatedAt: new Date(updatedAt),
+    expiresAt: expiresAt ? new Date(String(expiresAt)) : null,
+    accessCount: typeof row.access_count === "number" ? row.access_count : 0,
+    lastAccessedAt: row.last_accessed_at ? new Date(String(row.last_accessed_at)) : null,
+  };
+}
+
+/**
+ * Score a memory against a query using simple string matching (no dynamic RegExp).
+ * Uses indexOf() for full-phrase matches and split-token substring checks only,
+ * so there is no ReDoS risk — no user input is passed to RegExp().
+ */
+export function getRelevanceScore(memory: Memory, query: string): number {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) return 0;
+
+  const haystacks = [
+    memory.content.toLowerCase(),
+    memory.key.toLowerCase(),
+    JSON.stringify(memory.metadata).toLowerCase(),
+  ];
+  const tokens = normalizedQuery.split(/\s+/).filter(Boolean);
+
+  let score = 0;
+  for (const haystack of haystacks) {
+    // Full phrase match (safe: literal string, not regex)
+    if (haystack.includes(normalizedQuery)) {
+      score += 20;
+    }
+
+    for (const token of tokens) {
+      if (!token) continue;
+      // Token-level substring count using indexOf loop (no RegExp on user input)
+      if (haystack === memory.key.toLowerCase() && haystack.includes(token)) {
+        score += 6;
+        continue;
+      }
+      // Count occurrences via indexOf loop — avoids new RegExp(token)
+      let pos = 0;
+      let matchCount = 0;
+      while ((pos = haystack.indexOf(token, pos)) !== -1) {
+        matchCount++;
+        pos += token.length;
+      }
+      score += matchCount * 3;
+    }
+  }
+
+  return score;
+}

--- a/tests/unit/retrieval-scoring-split.test.ts
+++ b/tests/unit/retrieval-scoring-split.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Characterization + API-surface test: retrieval.ts god-file decomposition.
+ *
+ * The pure, DB-free scoring/conversion helpers (+ the MemoryRow row shape) were
+ * extracted verbatim from src/lib/memory/retrieval.ts into the self-contained
+ * leaf src/lib/memory/retrieval/scoring.ts (imports only ../types — does NOT
+ * import the host, so no cycle). The DB/vector/rerank engine stays in the host.
+ *
+ * Verifies that:
+ *   1. estimateTokens / parseMetadata / rowToMemory / getRelevanceScore behave
+ *      correctly (pure formulas pinned).
+ *   2. The host retrieval.ts still exposes the FULL public API (7 names; the
+ *      public estimateTokens is now re-exported from the leaf).
+ *   3. The scoring leaf exports its pieces directly.
+ *
+ * Pure value assertions — no DB handle is opened.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  estimateTokens,
+  parseMetadata,
+  rowToMemory,
+  getRelevanceScore,
+} from "../../src/lib/memory/retrieval/scoring.ts";
+
+describe("retrieval/scoring — estimateTokens (~1 token / 4 chars)", () => {
+  it("returns 0 for empty / non-string", () => {
+    assert.equal(estimateTokens(""), 0);
+    assert.equal(estimateTokens(undefined as unknown as string), 0);
+  });
+  it("ceils length/4", () => {
+    assert.equal(estimateTokens("abc"), 1); // ceil(3/4)
+    assert.equal(estimateTokens("12345678"), 2); // ceil(8/4)
+    assert.equal(estimateTokens("123456789"), 3); // ceil(9/4)
+  });
+});
+
+describe("retrieval/scoring — parseMetadata", () => {
+  it("returns {} for non-string / blank / invalid JSON", () => {
+    assert.deepEqual(parseMetadata(null), {});
+    assert.deepEqual(parseMetadata(""), {});
+    assert.deepEqual(parseMetadata("not json"), {});
+  });
+  it("parses a JSON object", () => {
+    assert.deepEqual(parseMetadata('{"a":1,"b":"x"}'), { a: 1, b: "x" });
+  });
+});
+
+describe("retrieval/scoring — rowToMemory", () => {
+  const mem = rowToMemory({
+    id: "m1",
+    type: "fact" as never,
+    content: "hello world",
+    metadata: '{"topic":"greeting"}',
+  });
+  it("maps content + parsed metadata + defaults accessCount to 0", () => {
+    assert.equal(mem.content, "hello world");
+    assert.deepEqual(mem.metadata, { topic: "greeting" });
+    assert.equal(mem.accessCount, 0);
+    assert.equal(mem.key, "");
+  });
+});
+
+describe("retrieval/scoring — getRelevanceScore (literal string match, no RegExp)", () => {
+  const mem = rowToMemory({
+    id: "m1",
+    type: "fact" as never,
+    content: "hello world",
+    metadata: '{"topic":"greeting"}',
+  });
+  it("returns 0 for a blank query", () => {
+    assert.equal(getRelevanceScore(mem, ""), 0);
+    assert.equal(getRelevanceScore(mem, "   "), 0);
+  });
+  it("scores +20 for a full-phrase hit and +3 per token occurrence", () => {
+    // content "hello world": phrase +20, 1× "hello" +3 = 23
+    assert.equal(getRelevanceScore(mem, "hello"), 23);
+    // metadata holds "greeting": phrase +20, 1× "greeting" +3 = 23
+    assert.equal(getRelevanceScore(mem, "greeting"), 23);
+  });
+  it("returns 0 when nothing matches", () => {
+    assert.equal(getRelevanceScore(mem, "zzz"), 0);
+  });
+});
+
+// ── host public API surface ──────────────────────────────────────────────────
+
+const host = await import("../../src/lib/memory/retrieval.ts");
+
+describe("retrieval.ts public API surface (7 names)", () => {
+  it("re-exports estimateTokens (now sourced from the leaf) as a function", () => {
+    assert.equal(typeof host.estimateTokens, "function");
+  });
+  it("keeps the three engine entrypoints as functions", () => {
+    assert.equal(typeof host.retrieveMemories, "function");
+    assert.equal(typeof host.retrievePreview, "function");
+    assert.equal(typeof host.engineStatus, "function");
+  });
+});
+
+describe("scoring.ts exports its pieces directly", () => {
+  it("the moved helpers are functions on the leaf", async () => {
+    const s = await import("../../src/lib/memory/retrieval/scoring.ts");
+    for (const fn of ["estimateTokens", "parseMetadata", "rowToMemory", "getRelevanceScore"]) {
+      assert.equal(typeof s[fn], "function", fn);
+    }
+  });
+});


### PR DESCRIPTION
## O quê
`src/lib/memory/retrieval.ts` (**1192** linhas — acima do frozen baseline 1171) é o motor de retrieval (DB + vetor + rerank). Extraí os helpers puros de scoring/conversão (+ o shape `MemoryRow` que compartilham) verbatim para um leaf auto-contido.

| Arquivo | Linhas | Conteúdo |
|---|---|---|
| `retrieval/scoring.ts` | 104 | interface MemoryRow + estimateTokens, parseMetadata, rowToMemory, getRelevanceScore |
| `retrieval.ts` (host) | **1072** (de 1192) | motor DB + vetor + rerank |

## Por que é seguro
- O leaf importa **só** `../types` (Memory/MemoryType), **não importa o host** → `check:cycles` limpo (sem ciclo).
- **Bônus**: o host estava **1192 > frozen 1171** (drift pré-existente); o split traz de volta p/ **1072 < 1171**, consertando a violação latente de file-size.
- `MemoryRow` migrou p/ a leaf e é importado de volta como tipo pelas funções de row do host. `estimateTokens` (público) é **re-exportado** da leaf; os outros 3 eram internos → **API pública inalterada** (7 exports).
- **Verbatim**: leaf 0 linhas divergentes. `typecheck:core` limpo · eslint 0 · prettier limpo.

## Validação
- **38 testes** consumidores existentes seguem **verdes** (rerank 5, hybrid 6, semantic 6, engine-status 9, stats-api 12).
- Novo `tests/unit/retrieval-scoring-split.test.ts` (**11 asserções**) pina estimateTokens (`ceil(len/4)`) + parseMetadata + mapping de rowToMemory + getRelevanceScore (+20 frase / +3 token) + guarda a API.

Campanha god-files (bloco **E5**, base `release/v3.8.43`). Refs #3501.