### PR TITLE
refactor(sse): extract reasoning-tag detection/extraction from responseSanitizer.ts (reasoning leaf)

### DIFF
--- a/open-sse/handlers/responseSanitizer.ts
+++ b/open-sse/handlers/responseSanitizer.ts
@@ -3,6 +3,14 @@ import {
   getReadableReasoningValue,
 } from "../utils/reasoningFields.ts";
 import { normalizeOpenAICompatibleFinishReason } from "../utils/finishReason.ts";
+import {
+  collapseExcessiveNewlines,
+  extractThinkingFromContent,
+} from "./responseSanitizer/reasoning.ts";
+export {
+  extractThinkingFromContent,
+  shouldParseTextualReasoningTags,
+} from "./responseSanitizer/reasoning.ts";
 
 /**
  * Response Sanitizer — Normalizes LLM responses to strict OpenAI SDK format.
@@ -188,144 +196,6 @@ function containsTextualToolCallContent(content: unknown): boolean {
   return (
     typeof content === "string" &&
     TEXTUAL_TOOL_CALL_HEADER.test(stripInternalToolEnvelopeText(content))
-  );
-}
-
-const REASONING_TAG_NAMES = ["think", "thinking", "thought", "internal_thought"];
-const REASONING_TAG_PATTERN = REASONING_TAG_NAMES.join("|");
-// Matches complete <think>/<thinking>/<thought>/<internal_thought> blocks.
-const THINK_TAG_REGEX = new RegExp(
-  `<(${REASONING_TAG_PATTERN})\\b[^>]*>([\\s\\S]*?)<\\/\\1>`,
-  "gi"
-);
-const REASONING_CLOSE_TAG_REGEX = new RegExp(`</(${REASONING_TAG_PATTERN})>`, "i");
-const REASONING_TAG_FRAGMENT_REGEX = new RegExp(`</?(${REASONING_TAG_PATTERN})\\b[^>]*>`, "gi");
-const CONTENT_OPEN_TAG_REGEX = /<content\b[^>]*>/i;
-// Matches an unclosed reasoning tag at the end of a message. Some providers can
-// emit malformed/open reasoning wrappers (for example "<thought\n...") before a
-// tool call. Treat that tail as reasoning instead of visible assistant text.
-const UNCLOSED_REASONING_TAG_REGEX = new RegExp(
-  `<(${REASONING_TAG_PATTERN})(?:\\s[^>]*)?(?:>|\\r?\\n)([\\s\\S]*)$`,
-  "i"
-);
-
-// #638, #727: Collapse runs of 2+ consecutive newlines into \n\n
-// Tool call responses from thinking models often accumulate excessive newlines
-const EXCESSIVE_NEWLINES = /\n{2,}/g;
-function collapseExcessiveNewlines(text: string): string {
-  return text.replace(EXCESSIVE_NEWLINES, "\n\n");
-}
-
-function cleanReasoningFragment(text: string): string {
-  return text.replace(REASONING_TAG_FRAGMENT_REGEX, "").trim();
-}
-
-function splitClosingOnlyReasoningPrefix(text: string): {
-  content: string;
-  thinking: string | null;
-} | null {
-  const closeMatch = text.match(REASONING_CLOSE_TAG_REGEX);
-  if (!closeMatch || closeMatch.index === undefined || closeMatch.index === 0) return null;
-  const closeIndex = closeMatch.index;
-
-  const suffix = text.slice(closeIndex + closeMatch[0].length);
-  if (!CONTENT_OPEN_TAG_REGEX.test(suffix)) return null;
-
-  const thinking = cleanReasoningFragment(text.slice(0, closeIndex));
-  if (!thinking) return null;
-  return { content: suffix.trim(), thinking };
-}
-
-function movePrefixBeforeContentTagToThinking(cleaned: string, thinkingParts: string[]): string {
-  const contentMatch = cleaned.match(CONTENT_OPEN_TAG_REGEX);
-  if (!contentMatch || contentMatch.index === undefined || contentMatch.index <= 0) return cleaned;
-  const contentIndex = contentMatch.index;
-
-  const prefix = cleanReasoningFragment(cleaned.slice(0, contentIndex));
-  if (prefix) thinkingParts.unshift(prefix);
-  return cleaned.slice(contentIndex);
-}
-
-/**
- * Extract <think> blocks from text content and return separated parts.
- * @returns {{ content: string, thinking: string | null }}
- */
-export function extractThinkingFromContent(text: string): {
-  content: string;
-  thinking: string | null;
-} {
-  if (!text || typeof text !== "string") {
-    return { content: text || "", thinking: null };
-  }
-
-  const thinkingParts: string[] = [];
-  let hasThinkTags = false;
-
-  let cleaned = text.replace(THINK_TAG_REGEX, (_match, _tagName, thinkContent) => {
-    hasThinkTags = true;
-    const trimmed = thinkContent.trim();
-    if (trimmed) {
-      thinkingParts.push(trimmed);
-    }
-    return "";
-  });
-
-  if (!hasThinkTags) {
-    const closingOnly = splitClosingOnlyReasoningPrefix(cleaned);
-    if (closingOnly) {
-      return closingOnly;
-    }
-  }
-
-  const unclosedMatch = cleaned.match(UNCLOSED_REASONING_TAG_REGEX);
-  if (unclosedMatch?.index !== undefined) {
-    hasThinkTags = true;
-    const reasoning = String(unclosedMatch[2] || "").trim();
-    if (reasoning) thinkingParts.push(reasoning);
-    const prefix = cleaned.slice(0, unclosedMatch.index);
-    cleaned = /^(?:\s|§\d+§)*$/.test(prefix) ? "" : prefix;
-  }
-
-  if (!hasThinkTags) {
-    return { content: text, thinking: null };
-  }
-
-  cleaned = movePrefixBeforeContentTagToThinking(cleaned, thinkingParts);
-
-  return {
-    content: cleaned.trim(),
-    thinking: thinkingParts.length > 0 ? thinkingParts.join("\n\n") : null,
-  };
-}
-
-function normalizeReasoningRouteId(value: unknown): string {
-  return typeof value === "string" ? value.toLowerCase() : "";
-}
-
-function isAntigravityReasoningRoute(providerId: string, modelId: string): boolean {
-  return (
-    providerId.includes("antigravity") ||
-    providerId === "agy" ||
-    modelId.includes("antigravity/") ||
-    modelId.startsWith("agy/")
-  );
-}
-
-function isTextualReasoningTagNativeRoute(providerId: string, modelId: string): boolean {
-  const routeId = `${providerId}/${modelId}`;
-  return (
-    /deepseek[-_/]?r1\b/.test(routeId) ||
-    /r1[-_/]?distill\b/.test(routeId) ||
-    /(?:^|[/:_-])qwq(?:[/._:-]|$)/.test(routeId)
-  );
-}
-
-export function shouldParseTextualReasoningTags(provider?: unknown, model?: unknown): boolean {
-  const providerId = normalizeReasoningRouteId(provider);
-  const modelId = normalizeReasoningRouteId(model);
-  return (
-    !isAntigravityReasoningRoute(providerId, modelId) &&
-    isTextualReasoningTagNativeRoute(providerId, modelId)
   );
 }
 

--- a/open-sse/handlers/responseSanitizer/reasoning.ts
+++ b/open-sse/handlers/responseSanitizer/reasoning.ts
@@ -1,0 +1,143 @@
+export const REASONING_TAG_NAMES = ["think", "thinking", "thought", "internal_thought"];
+export const REASONING_TAG_PATTERN = REASONING_TAG_NAMES.join("|");
+// Matches complete <think>/<thinking>/<thought>/<internal_thought> blocks.
+export const THINK_TAG_REGEX = new RegExp(
+  `<(${REASONING_TAG_PATTERN})\\b[^>]*>([\\s\\S]*?)<\\/\\1>`,
+  "gi"
+);
+export const REASONING_CLOSE_TAG_REGEX = new RegExp(`</(${REASONING_TAG_PATTERN})>`, "i");
+export const REASONING_TAG_FRAGMENT_REGEX = new RegExp(
+  `</?(${REASONING_TAG_PATTERN})\\b[^>]*>`,
+  "gi"
+);
+export const CONTENT_OPEN_TAG_REGEX = /<content\b[^>]*>/i;
+// Matches an unclosed reasoning tag at the end of a message. Some providers can
+// emit malformed/open reasoning wrappers (for example "<thought\n...") before a
+// tool call. Treat that tail as reasoning instead of visible assistant text.
+export const UNCLOSED_REASONING_TAG_REGEX = new RegExp(
+  `<(${REASONING_TAG_PATTERN})(?:\\s[^>]*)?(?:>|\\r?\\n)([\\s\\S]*)$`,
+  "i"
+);
+
+// #638, #727: Collapse runs of 2+ consecutive newlines into \n\n
+// Tool call responses from thinking models often accumulate excessive newlines
+export const EXCESSIVE_NEWLINES = /\n{2,}/g;
+export function collapseExcessiveNewlines(text: string): string {
+  return text.replace(EXCESSIVE_NEWLINES, "\n\n");
+}
+
+export function cleanReasoningFragment(text: string): string {
+  return text.replace(REASONING_TAG_FRAGMENT_REGEX, "").trim();
+}
+
+export function splitClosingOnlyReasoningPrefix(text: string): {
+  content: string;
+  thinking: string | null;
+} | null {
+  const closeMatch = text.match(REASONING_CLOSE_TAG_REGEX);
+  if (!closeMatch || closeMatch.index === undefined || closeMatch.index === 0) return null;
+  const closeIndex = closeMatch.index;
+
+  const suffix = text.slice(closeIndex + closeMatch[0].length);
+  if (!CONTENT_OPEN_TAG_REGEX.test(suffix)) return null;
+
+  const thinking = cleanReasoningFragment(text.slice(0, closeIndex));
+  if (!thinking) return null;
+  return { content: suffix.trim(), thinking };
+}
+
+export function movePrefixBeforeContentTagToThinking(
+  cleaned: string,
+  thinkingParts: string[]
+): string {
+  const contentMatch = cleaned.match(CONTENT_OPEN_TAG_REGEX);
+  if (!contentMatch || contentMatch.index === undefined || contentMatch.index <= 0) return cleaned;
+  const contentIndex = contentMatch.index;
+
+  const prefix = cleanReasoningFragment(cleaned.slice(0, contentIndex));
+  if (prefix) thinkingParts.unshift(prefix);
+  return cleaned.slice(contentIndex);
+}
+
+/**
+ * Extract <think> blocks from text content and return separated parts.
+ * @returns {{ content: string, thinking: string | null }}
+ */
+export function extractThinkingFromContent(text: string): {
+  content: string;
+  thinking: string | null;
+} {
+  if (!text || typeof text !== "string") {
+    return { content: text || "", thinking: null };
+  }
+
+  const thinkingParts: string[] = [];
+  let hasThinkTags = false;
+
+  let cleaned = text.replace(THINK_TAG_REGEX, (_match, _tagName, thinkContent) => {
+    hasThinkTags = true;
+    const trimmed = thinkContent.trim();
+    if (trimmed) {
+      thinkingParts.push(trimmed);
+    }
+    return "";
+  });
+
+  if (!hasThinkTags) {
+    const closingOnly = splitClosingOnlyReasoningPrefix(cleaned);
+    if (closingOnly) {
+      return closingOnly;
+    }
+  }
+
+  const unclosedMatch = cleaned.match(UNCLOSED_REASONING_TAG_REGEX);
+  if (unclosedMatch?.index !== undefined) {
+    hasThinkTags = true;
+    const reasoning = String(unclosedMatch[2] || "").trim();
+    if (reasoning) thinkingParts.push(reasoning);
+    const prefix = cleaned.slice(0, unclosedMatch.index);
+    cleaned = /^(?:\s|§\d+§)*$/.test(prefix) ? "" : prefix;
+  }
+
+  if (!hasThinkTags) {
+    return { content: text, thinking: null };
+  }
+
+  cleaned = movePrefixBeforeContentTagToThinking(cleaned, thinkingParts);
+
+  return {
+    content: cleaned.trim(),
+    thinking: thinkingParts.length > 0 ? thinkingParts.join("\n\n") : null,
+  };
+}
+
+export function normalizeReasoningRouteId(value: unknown): string {
+  return typeof value === "string" ? value.toLowerCase() : "";
+}
+
+export function isAntigravityReasoningRoute(providerId: string, modelId: string): boolean {
+  return (
+    providerId.includes("antigravity") ||
+    providerId === "agy" ||
+    modelId.includes("antigravity/") ||
+    modelId.startsWith("agy/")
+  );
+}
+
+export function isTextualReasoningTagNativeRoute(providerId: string, modelId: string): boolean {
+  const routeId = `${providerId}/${modelId}`;
+  return (
+    /deepseek[-_/]?r1\b/.test(routeId) ||
+    /r1[-_/]?distill\b/.test(routeId) ||
+    /(?:^|[/:_-])qwq(?:[/._:-]|$)/.test(routeId)
+  );
+}
+
+export function shouldParseTextualReasoningTags(provider?: unknown, model?: unknown): boolean {
+  const providerId = normalizeReasoningRouteId(provider);
+  const modelId = normalizeReasoningRouteId(model);
+  return (
+    !isAntigravityReasoningRoute(providerId, modelId) &&
+    isTextualReasoningTagNativeRoute(providerId, modelId)
+  );
+}

--- a/tests/unit/responsesanitizer-reasoning-split.test.ts
+++ b/tests/unit/responsesanitizer-reasoning-split.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Characterization + API-surface test: responseSanitizer.ts god-file decomposition.
+ *
+ * The reasoning-tag detection/extraction block (regexes + extraction helpers +
+ * route classification) was extracted verbatim from
+ * open-sse/handlers/responseSanitizer.ts into the ZERO-IMPORT, self-contained
+ * leaf open-sse/handlers/responseSanitizer/reasoning.ts. The response/usage/
+ * streaming sanitization stays in the host.
+ *
+ * Verifies that:
+ *   1. extractThinkingFromContent / shouldParseTextualReasoningTags behave.
+ *   2. The host still exposes the FULL public API (7 names; the two reasoning
+ *      functions are now re-exported from the leaf).
+ *   3. The reasoning leaf exports its public pieces directly.
+ *
+ * Deeper sanitization behaviour is covered by the existing response-sanitizer /
+ * strip-reasoning-header suites; this pins the extraction boundary.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  extractThinkingFromContent,
+  shouldParseTextualReasoningTags,
+} from "../../open-sse/handlers/responseSanitizer/reasoning.ts";
+
+describe("responseSanitizer/reasoning — extractThinkingFromContent", () => {
+  it("leaves tag-free content untouched (thinking = null)", () => {
+    const out = extractThinkingFromContent("just an answer");
+    assert.equal(out.content, "just an answer");
+    assert.equal(out.thinking, null);
+  });
+  it("splits a <think>…</think> prefix into thinking + content", () => {
+    const out = extractThinkingFromContent("<think>reasoning here</think>final answer");
+    assert.ok(out.thinking && out.thinking.includes("reasoning here"), "thinking captured");
+    assert.ok(out.content.includes("final answer"), "content kept");
+    assert.ok(!out.content.includes("<think>"), "think tag stripped from content");
+  });
+});
+
+describe("responseSanitizer/reasoning — shouldParseTextualReasoningTags", () => {
+  it("returns a boolean; false for a generic non-textual-reasoning route", () => {
+    const r = shouldParseTextualReasoningTags("openai", "gpt-4");
+    assert.equal(typeof r, "boolean");
+    assert.equal(r, false);
+  });
+  it("returns false when provider/model are missing", () => {
+    assert.equal(shouldParseTextualReasoningTags(undefined, undefined), false);
+  });
+});
+
+// ── host public API surface ──────────────────────────────────────────────────
+
+const host = await import("../../open-sse/handlers/responseSanitizer.ts");
+
+describe("responseSanitizer.ts public API surface (7 names)", () => {
+  const expectedFns = [
+    "extractThinkingFromContent", // re-exported from leaf
+    "shouldParseTextualReasoningTags", // re-exported from leaf
+    "sanitizeOpenAIResponse",
+    "sanitizeResponsesApiResponse",
+    "sanitizeStreamingChunk",
+  ];
+  for (const name of expectedFns) {
+    it(`exposes ${name} as a function`, () => {
+      assert.equal(typeof host[name], "function", `${name} must be a function on the host`);
+    });
+  }
+  it("keeps the OMIT_STREAMING_CHUNK_MARKER constant", () => {
+    assert.equal(typeof host.OMIT_STREAMING_CHUNK_MARKER, "string");
+  });
+});
+
+describe("reasoning.ts exports its public pieces directly", () => {
+  it("the re-exported reasoning helpers are functions on the leaf", async () => {
+    const r = await import("../../open-sse/handlers/responseSanitizer/reasoning.ts");
+    assert.equal(typeof r.extractThinkingFromContent, "function");
+    assert.equal(typeof r.shouldParseTextualReasoningTags, "function");
+  });
+});


### PR DESCRIPTION
## O quê
`open-sse/handlers/responseSanitizer.ts` (1133 linhas, frozen-baselined) mistura detecção/extração de tags de reasoning com sanitização de response/usage/streaming. Extraí o bloco coeso de reasoning (**zero imports**) verbatim para um leaf auto-contido.

| Arquivo | Linhas | Conteúdo |
|---|---|---|
| `responseSanitizer/reasoning.ts` | 143 | regexes de reasoning + collapseExcessiveNewlines/cleanReasoningFragment/splitClosingOnlyReasoningPrefix/movePrefixBeforeContentTagToThinking/extractThinkingFromContent + route-classification/shouldParseTextualReasoningTags |
| `responseSanitizer.ts` (host) | **1003** (de 1133) | sanitização response/usage/streaming |

## Por que é seguro
- O bloco só chama a si mesmo → o leaf tem **ZERO imports**, não pode importar o host → `check:cycles` limpo (sem ciclo).
- Host importa de volta `collapseExcessiveNewlines` (6 call-sites) + `extractThinkingFromContent`, e **re-exporta** os 2 públicos (extractThinkingFromContent, shouldParseTextualReasoningTags) → **API pública IDÊNTICA** (7 exports).
- **Verbatim**: bodies byte-idênticos; 2 declarações longas (regex  + assinatura de ) reformatadas pelo prettier quando o `export` passou de 100 cols — token-idênticas, typecheck confirma.
- `typecheck:core` limpo · eslint 0 · prettier limpo.

## Validação
- **47 testes** consumidores existentes seguem **verdes** (response-sanitizer 36, strip-reasoning-header 8, textual-toolcall-false-positive 3).
- Novo `tests/unit/responsesanitizer-reasoning-split.test.ts` (**11 asserções**) characteriza extractThinkingFromContent (split de `<think>`) + shouldParseTextualReasoningTags + guarda a API.

Campanha god-files (bloco **E5**, base `release/v3.8.43`). Refs #3501.