### PR TITLE
refactor(sse): extract rate-limit header parsing from rateLimitManager.ts (headers leaf)

### DIFF
--- a/open-sse/services/rateLimitManager.ts
+++ b/open-sse/services/rateLimitManager.ts
@@ -18,6 +18,12 @@ import {
   resolveResilienceSettings,
   type RequestQueueSettings,
 } from "../../src/lib/resilience/settings";
+import {
+  STANDARD_HEADERS,
+  ANTHROPIC_HEADERS,
+  parseResetTime,
+  toPlainHeaders,
+} from "./rateLimitManager/headers";
 
 interface LearnedLimitEntry {
   provider: string;
@@ -596,101 +602,6 @@ export async function withRateLimit(provider, connectionId, model, fn, signal = 
     }
     throw err;
   }
-}
-
-// ─── Header Parsing ──────────────────────────────────────────────────────────
-
-/**
- * Standard headers used by most providers (OpenAI, Fireworks, etc.)
- */
-const STANDARD_HEADERS = {
-  limit: "x-ratelimit-limit-requests",
-  remaining: "x-ratelimit-remaining-requests",
-  reset: "x-ratelimit-reset-requests",
-  limitTokens: "x-ratelimit-limit-tokens",
-  remainingTokens: "x-ratelimit-remaining-tokens",
-  resetTokens: "x-ratelimit-reset-tokens",
-  retryAfter: "retry-after",
-  overLimit: "x-ratelimit-over-limit",
-};
-
-/**
- * Anthropic uses custom headers
- */
-const ANTHROPIC_HEADERS = {
-  limit: "anthropic-ratelimit-requests-limit",
-  remaining: "anthropic-ratelimit-requests-remaining",
-  reset: "anthropic-ratelimit-requests-reset",
-  limitTokens: "anthropic-ratelimit-input-tokens-limit",
-  remainingTokens: "anthropic-ratelimit-input-tokens-remaining",
-  resetTokens: "anthropic-ratelimit-input-tokens-reset",
-  retryAfter: "retry-after",
-};
-
-/**
- * Parse a reset time string into milliseconds.
- * Formats: "1s", "1m", "1h", "1ms", "60", ISO date, Unix timestamp
- */
-function parseResetTime(value) {
-  if (!value) return null;
-
-  // Duration strings: "1s", "500ms", "1m30s"
-  const durationMatch = value.match(/^(?:(\d+)h)?(?:(\d+)m(?!s))?(?:(\d+)s)?(?:(\d+)ms)?$/);
-  if (durationMatch) {
-    const [, h, m, s, ms] = durationMatch;
-    return (
-      (parseInt(h || 0) * 3600 + parseInt(m || 0) * 60 + parseInt(s || 0)) * 1000 +
-      parseInt(ms || 0)
-    );
-  }
-
-  // Pure number: assume seconds
-  const num = parseFloat(value);
-  if (!isNaN(num) && num > 0) {
-    // If it looks like a Unix timestamp (> year 2025)
-    if (num > 1700000000) {
-      return Math.max(0, num * 1000 - Date.now());
-    }
-    return num * 1000;
-  }
-
-  // ISO date string
-  try {
-    const date = new Date(value);
-    if (!isNaN(date.getTime())) {
-      return Math.max(0, date.getTime() - Date.now());
-    }
-  } catch {}
-
-  return null;
-}
-
-function toPlainHeaders(headers: unknown): Record<string, string> {
-  if (!headers) return {};
-  const plain: Record<string, string> = {};
-  const obj = headers as Record<string, unknown>;
-  if (typeof obj.forEach === "function") {
-    try {
-      (obj.forEach as (cb: (v: string, k: string) => void) => void)((v: string, k: string) => {
-        plain[k.toLowerCase()] = v;
-      });
-      return plain;
-    } catch {}
-  }
-  if (typeof obj.entries === "function") {
-    try {
-      for (const [k, v] of (obj.entries as () => Iterable<[string, string]>)()) {
-        plain[k.toLowerCase()] = v;
-      }
-      return plain;
-    } catch {}
-  }
-  try {
-    for (const [k, v] of Object.entries(obj)) {
-      plain[k.toLowerCase()] = v == null ? "" : String(v);
-    }
-  } catch {}
-  return plain;
 }
 
 /**

--- a/open-sse/services/rateLimitManager/headers.ts
+++ b/open-sse/services/rateLimitManager/headers.ts
@@ -1,0 +1,94 @@
+// ─── Header Parsing ──────────────────────────────────────────────────────────
+
+/**
+ * Standard headers used by most providers (OpenAI, Fireworks, etc.)
+ */
+export const STANDARD_HEADERS = {
+  limit: "x-ratelimit-limit-requests",
+  remaining: "x-ratelimit-remaining-requests",
+  reset: "x-ratelimit-reset-requests",
+  limitTokens: "x-ratelimit-limit-tokens",
+  remainingTokens: "x-ratelimit-remaining-tokens",
+  resetTokens: "x-ratelimit-reset-tokens",
+  retryAfter: "retry-after",
+  overLimit: "x-ratelimit-over-limit",
+};
+
+/**
+ * Anthropic uses custom headers
+ */
+export const ANTHROPIC_HEADERS = {
+  limit: "anthropic-ratelimit-requests-limit",
+  remaining: "anthropic-ratelimit-requests-remaining",
+  reset: "anthropic-ratelimit-requests-reset",
+  limitTokens: "anthropic-ratelimit-input-tokens-limit",
+  remainingTokens: "anthropic-ratelimit-input-tokens-remaining",
+  resetTokens: "anthropic-ratelimit-input-tokens-reset",
+  retryAfter: "retry-after",
+};
+
+/**
+ * Parse a reset time string into milliseconds.
+ * Formats: "1s", "1m", "1h", "1ms", "60", ISO date, Unix timestamp
+ */
+export function parseResetTime(value) {
+  if (!value) return null;
+
+  // Duration strings: "1s", "500ms", "1m30s"
+  const durationMatch = value.match(/^(?:(\d+)h)?(?:(\d+)m(?!s))?(?:(\d+)s)?(?:(\d+)ms)?$/);
+  if (durationMatch) {
+    const [, h, m, s, ms] = durationMatch;
+    return (
+      (parseInt(h || 0) * 3600 + parseInt(m || 0) * 60 + parseInt(s || 0)) * 1000 +
+      parseInt(ms || 0)
+    );
+  }
+
+  // Pure number: assume seconds
+  const num = parseFloat(value);
+  if (!isNaN(num) && num > 0) {
+    // If it looks like a Unix timestamp (> year 2025)
+    if (num > 1700000000) {
+      return Math.max(0, num * 1000 - Date.now());
+    }
+    return num * 1000;
+  }
+
+  // ISO date string
+  try {
+    const date = new Date(value);
+    if (!isNaN(date.getTime())) {
+      return Math.max(0, date.getTime() - Date.now());
+    }
+  } catch {}
+
+  return null;
+}
+
+export function toPlainHeaders(headers: unknown): Record<string, string> {
+  if (!headers) return {};
+  const plain: Record<string, string> = {};
+  const obj = headers as Record<string, unknown>;
+  if (typeof obj.forEach === "function") {
+    try {
+      (obj.forEach as (cb: (v: string, k: string) => void) => void)((v: string, k: string) => {
+        plain[k.toLowerCase()] = v;
+      });
+      return plain;
+    } catch {}
+  }
+  if (typeof obj.entries === "function") {
+    try {
+      for (const [k, v] of (obj.entries as () => Iterable<[string, string]>)()) {
+        plain[k.toLowerCase()] = v;
+      }
+      return plain;
+    } catch {}
+  }
+  try {
+    for (const [k, v] of Object.entries(obj)) {
+      plain[k.toLowerCase()] = v == null ? "" : String(v);
+    }
+  } catch {}
+  return plain;
+}

--- a/tests/unit/ratelimitmanager-headers-split.test.ts
+++ b/tests/unit/ratelimitmanager-headers-split.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Characterization + API-surface test: rateLimitManager.ts god-file decomposition.
+ *
+ * The pure rate-limit HEADER parsing block (STANDARD_HEADERS, ANTHROPIC_HEADERS,
+ * parseResetTime, toPlainHeaders) was extracted verbatim from
+ * open-sse/services/rateLimitManager.ts into the ZERO-IMPORT, self-contained
+ * leaf open-sse/services/rateLimitManager/headers.ts. The stateful limiter
+ * machinery (Bottleneck, watchdog timers, learned-limits Map) stays in the host.
+ *
+ * Verifies that:
+ *   1. parseResetTime / toPlainHeaders behave correctly (pure, DB/timer-free).
+ *   2. The host rateLimitManager.ts still exposes the FULL public API (17 names).
+ *   3. The headers leaf exports its pieces directly.
+ *
+ * The host import is released in a test.after hook (watchdog timers) so the
+ * native runner does not hang — mirrors the DB-handle teardown discipline.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  STANDARD_HEADERS,
+  ANTHROPIC_HEADERS,
+  parseResetTime,
+  toPlainHeaders,
+} from "../../open-sse/services/rateLimitManager/headers.ts";
+
+// ── 1. pure helpers ──────────────────────────────────────────────────────────
+
+test("rateLimitManager/headers — parseResetTime: nullish → null", () => {
+  assert.equal(parseResetTime(""), null);
+  assert.equal(parseResetTime(null), null);
+  assert.equal(parseResetTime("not-a-duration"), null);
+});
+
+test("rateLimitManager/headers — parseResetTime: duration strings → ms", () => {
+  assert.equal(parseResetTime("30s"), 30_000);
+  assert.equal(parseResetTime("500ms"), 500);
+  assert.equal(parseResetTime("1m30s"), 90_000);
+});
+
+test("rateLimitManager/headers — parseResetTime: bare number → seconds*1000", () => {
+  assert.equal(parseResetTime("5"), 5_000);
+});
+
+test("rateLimitManager/headers — toPlainHeaders normalizes to a string record", () => {
+  const out = toPlainHeaders({ "X-RateLimit-Remaining": "10", "Content-Type": "application/json" });
+  assert.equal(typeof out, "object");
+  assert.ok(out !== null && !Array.isArray(out));
+  // every value is a string
+  for (const v of Object.values(out)) assert.equal(typeof v, "string");
+});
+
+test("rateLimitManager/headers — STANDARD/ANTHROPIC header maps are objects with string fields", () => {
+  assert.equal(typeof STANDARD_HEADERS, "object");
+  assert.equal(typeof ANTHROPIC_HEADERS, "object");
+  assert.equal(typeof STANDARD_HEADERS.overLimit, "string");
+});
+
+// ── 2. host public API surface (17) ──────────────────────────────────────────
+
+const host = await import("../../open-sse/services/rateLimitManager.ts");
+
+test.after(async () => {
+  // release watchdog timers / limiter state so the runner exits cleanly
+  try {
+    await host.__resetRateLimitManagerForTests?.();
+  } catch {
+    /* ignore */
+  }
+  host.stopRateLimitWatchdog?.();
+});
+
+test("rateLimitManager.ts public API surface (17 names)", () => {
+  const expected = [
+    "__flushLearnedLimitsForTests",
+    "__getLimiterStateForTests",
+    "__resetRateLimitManagerForTests",
+    "applyRequestQueueSettings",
+    "disableRateLimitProtection",
+    "enableRateLimitProtection",
+    "getAllRateLimitStatus",
+    "getLearnedLimits",
+    "getRateLimitStatus",
+    "initializeRateLimits",
+    "isRateLimitEnabled",
+    "refreshConnectionRateLimits",
+    "startRateLimitWatchdog",
+    "stopRateLimitWatchdog",
+    "updateFromHeaders",
+    "updateFromResponseBody",
+    "withRateLimit",
+  ];
+  const missing = expected.filter((n) => typeof host[n] !== "function");
+  assert.deepEqual(missing, [], `missing public exports: ${missing.join(", ")}`);
+});
+
+// ── 3. leaf exports its pieces ───────────────────────────────────────────────
+
+test("headers.ts exports its helpers directly", async () => {
+  const h = await import("../../open-sse/services/rateLimitManager/headers.ts");
+  assert.equal(typeof h.parseResetTime, "function");
+  assert.equal(typeof h.toPlainHeaders, "function");
+  assert.equal(typeof h.STANDARD_HEADERS, "object");
+  assert.equal(typeof h.ANTHROPIC_HEADERS, "object");
+});


### PR DESCRIPTION
## O quê
`open-sse/services/rateLimitManager.ts` (1034 linhas, frozen-baselined) é o rate-limiter stateful (Bottleneck, watchdog, Maps). Extraí o bloco puro de parsing de headers (**zero imports**) verbatim p/ um leaf auto-contido.

| Arquivo | Linhas | Conteúdo |
|---|---|---|
| `rateLimitManager/headers.ts` | 94 | STANDARD_HEADERS, ANTHROPIC_HEADERS, parseResetTime, toPlainHeaders |
| `rateLimitManager.ts` (host) | **945** (de 1034) | máquina de limiters + watchdog + learned-limits |

## Por que é seguro
- Os 4 itens são puros (sem state, sem deps externas) → o leaf tem **ZERO imports**, não pode importar o host → `check:cycles` limpo.
- Host importa os 4 de volta (usados em `updateFromHeaders`); eram internos → **API pública inalterada** (17 exports), sem re-export.
- **Verbatim**: leaf 0 linhas divergentes. typecheck limpo · eslint 0 · prettier limpo.

## Validação
- **21 testes** consumidores existentes seguem verdes (rate-limit-manager 7, limiter-lifecycle 4, queue-timeout-msg 2, idle-eviction 6, body-lock 2).
- Novo `tests/unit/ratelimitmanager-headers-split.test.ts` (**7 asserções**) pina parseResetTime (durations/bare-number/nullish) + toPlainHeaders + guarda os 17 públicos (com teardown do watchdog p/ o runner sair limpo).

Campanha god-files (bloco **E5**, base `release/v3.8.43`). Refs #3501.