### PR TITLE
feat(codex): auto-sync profiles after model discovery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -529,8 +529,9 @@ NEXT_PUBLIC_ENABLE_SOCKS5_PROXY=true
 # Allow OmniRoute to write CLI config files (token refresh, etc.).
 # CLI_ALLOW_CONFIG_WRITES=true
 
-# Auto-sync Codex profile files after provider model discovery changes.
-# Writes only ~/.codex/*.config.toml profiles; does not change active/default Codex config.
+# Auto-sync Codex profile files after provider model discovery changes. OPT-IN, default OFF.
+# When enabled, writes only ~/.codex/*.config.toml profiles; never changes the active/default
+# Codex config. Also requires CLI_ALLOW_CONFIG_WRITES (default on). Leave unset to disable.
 # OMNIROUTE_AUTO_SYNC_CODEX_PROFILES=true
 
 # Override binary paths for individual CLI tools.

--- a/.env.example
+++ b/.env.example
@@ -529,6 +529,10 @@ NEXT_PUBLIC_ENABLE_SOCKS5_PROXY=true
 # Allow OmniRoute to write CLI config files (token refresh, etc.).
 # CLI_ALLOW_CONFIG_WRITES=true
 
+# Auto-sync Codex profile files after provider model discovery changes.
+# Writes only ~/.codex/*.config.toml profiles; does not change active/default Codex config.
+# OMNIROUTE_AUTO_SYNC_CODEX_PROFILES=true
+
 # Override binary paths for individual CLI tools.
 # CLI_CLAUDE_BIN=claude
 # CLI_CODEX_BIN=codex

--- a/bin/cli/commands/setup-codex.mjs
+++ b/bin/cli/commands/setup-codex.mjs
@@ -187,6 +187,52 @@ function buildProfileToml(modelId, cfg) {
   return lines.join("\n") + "\n";
 }
 
+export async function syncCodexProfilesFromModels(models, opts = {}) {
+  const codexHome = opts.codexHome || join(os.homedir(), ".codex");
+  const dryRun = Boolean(opts.dryRun);
+  const onlyFilter = opts.only ? opts.only.split(",").map((s) => s.trim()) : null;
+
+  if (!dryRun && !existsSync(codexHome)) {
+    mkdirSync(codexHome, { recursive: true });
+  }
+
+  let written = 0;
+  let skipped = 0;
+  const profiles = [];
+
+  for (const m of models) {
+    const id = typeof m === "string" ? m : (m.id ?? "");
+    if (!id) {
+      skipped++;
+      continue;
+    }
+    if (onlyFilter && !onlyFilter.some((f) => id.includes(f))) {
+      skipped++;
+      continue;
+    }
+
+    const cfg = categoriseModel(id) ?? fallbackCodexProfile(id, m);
+    if (!cfg) {
+      skipped++;
+      continue;
+    }
+
+    const filePath = join(codexHome, `${cfg.name}.config.toml`);
+    const content = buildProfileToml(id, cfg);
+
+    if (dryRun) {
+      console.log(`\n── [dry-run] ${filePath} ──`);
+      console.log(content);
+    } else {
+      writeFileSync(filePath, content, "utf8");
+    }
+    profiles.push({ name: cfg.name, model: id, filePath });
+    written++;
+  }
+
+  return { written, skipped, profiles };
+}
+
 // ── Command ───────────────────────────────────────────────────────────────────
 
 /**
@@ -228,39 +274,17 @@ export async function runSetupCodexCommand(opts = {}) {
 
   printInfo(`Received ${models.length} models from ${baseUrl}`);
 
-  // ── Ensure codex home exists ──────────────────────────────────────────────
-  if (!dryRun && !existsSync(codexHome)) {
-    mkdirSync(codexHome, { recursive: true });
-  }
-
   // ── Generate profiles ─────────────────────────────────────────────────────
-  let written = 0;
-  let skipped = 0;
-
-  for (const m of models) {
-    const id = typeof m === "string" ? m : (m.id ?? "");
-    if (!id) continue;
-    if (onlyFilter && !onlyFilter.some((f) => id.includes(f))) continue;
-
-    const cfg = categoriseModel(id) ?? fallbackCodexProfile(id, m);
-    if (!cfg) continue;
-
-    const filePath = join(codexHome, `${cfg.name}.config.toml`);
-    const content = buildProfileToml(id, cfg);
-
-    if (dryRun) {
-      console.log(`\n── [dry-run] ${filePath} ──`);
-      console.log(content);
-    } else {
-      writeFileSync(filePath, content, "utf8");
-      printSuccess(`  ✓ ${cfg.name}.config.toml  (${id})`);
-    }
-    written++;
-  }
-
-  skipped = models.length - written;
+  const { written, skipped, profiles } = await syncCodexProfilesFromModels(models, {
+    codexHome,
+    dryRun,
+    only: opts.only,
+  });
 
   if (!dryRun) {
+    for (const profile of profiles) {
+      printSuccess(`  ✓ ${profile.name}.config.toml  (${profile.model})`);
+    }
     console.log("");
     printSuccess(`${written} profiles written to ${codexHome}`);
     if (skipped > 0) {

--- a/docs/guides/CODEX-CLI-CONFIGURATION.md
+++ b/docs/guides/CODEX-CLI-CONFIGURATION.md
@@ -243,6 +243,8 @@ omniroute setup-codex --codex-home /path/to/.codex
 
 The command fetches `/v1/models`, uses tuned profiles for known models, falls back to catalog metadata for other compatible text models, and writes `~/.codex/<name>.config.toml` for each. Idempotent — safe to re-run.
 
+When `CLI_ALLOW_CONFIG_WRITES=true`, OmniRoute also auto-syncs these same profile files after a successful provider model discovery/import changes the live catalog. This only writes separate `~/.codex/*.config.toml` profile files; it does not change the active/default `~/.codex/config.toml`, Codex-lb settings, auth, or provider selection. Disable with `OMNIROUTE_AUTO_SYNC_CODEX_PROFILES=false`.
+
 ---
 
 ## Launching Codex with `omniroute launch-codex`

--- a/docs/guides/CODEX-CLI-CONFIGURATION.md
+++ b/docs/guides/CODEX-CLI-CONFIGURATION.md
@@ -243,7 +243,7 @@ omniroute setup-codex --codex-home /path/to/.codex
 
 The command fetches `/v1/models`, uses tuned profiles for known models, falls back to catalog metadata for other compatible text models, and writes `~/.codex/<name>.config.toml` for each. Idempotent — safe to re-run.
 
-When `CLI_ALLOW_CONFIG_WRITES=true`, OmniRoute also auto-syncs these same profile files after a successful provider model discovery/import changes the live catalog. This only writes separate `~/.codex/*.config.toml` profile files; it does not change the active/default `~/.codex/config.toml`, Codex-lb settings, auth, or provider selection. Disable with `OMNIROUTE_AUTO_SYNC_CODEX_PROFILES=false`.
+OmniRoute can also **auto-sync** these same profile files after a successful provider model discovery/import changes the live catalog. This is **opt-in and off by default**: enable it with `OMNIROUTE_AUTO_SYNC_CODEX_PROFILES=true` (it also honors `CLI_ALLOW_CONFIG_WRITES`, on by default). When enabled it only writes separate `~/.codex/*.config.toml` profile files; it never changes the active/default `~/.codex/config.toml`, Codex-lb settings, auth, or provider selection.
 
 ---
 

--- a/src/app/api/providers/[id]/sync-models/route.ts
+++ b/src/app/api/providers/[id]/sync-models/route.ts
@@ -12,6 +12,7 @@ import {
   buildModelSyncInternalHeaders,
   isModelSyncInternalRequest,
 } from "@/shared/services/modelSyncScheduler";
+import { autoSyncCodexProfilesFromLiveCatalog } from "@/lib/cli-helper/codexProfileAutoSync";
 import { GET as getProviderModels } from "../models/route";
 import { sanitizeErrorMessage } from "@omniroute/open-sse/utils/error";
 
@@ -520,6 +521,27 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
     const importedCount = importedChanges.added;
     const updatedCount = importedChanges.updated;
     const shouldLog = modelChanges.total > 0 || customModelChanges.total > 0;
+
+    if (shouldLog) {
+      void autoSyncCodexProfilesFromLiveCatalog(request, `model-sync:${logProvider}`)
+        .then((syncResult) => {
+          if (syncResult.ok) {
+            console.log(
+              `[ModelSync] Codex profile auto-sync wrote ${syncResult.written} profile(s), skipped ${syncResult.skipped} (${logProvider})`
+            );
+          } else {
+            console.log(
+              `[ModelSync] Codex profile auto-sync skipped for ${logProvider}: ${syncResult.reason}`
+            );
+          }
+        })
+        .catch((err) => {
+          console.log(
+            `[ModelSync] Codex profile auto-sync failed for ${logProvider}:`,
+            err?.message || err
+          );
+        });
+    }
 
     if (shouldLog) {
       await saveCallLog({

--- a/src/lib/cli-helper/codexProfileAutoSync.ts
+++ b/src/lib/cli-helper/codexProfileAutoSync.ts
@@ -1,0 +1,76 @@
+import path from "node:path";
+import { ensureCliConfigWriteAllowed, getCliConfigPaths } from "@/shared/services/cliRuntime";
+import { getModelSyncInternalBaseUrl } from "@/shared/services/modelSyncScheduler";
+
+type SyncResult =
+  | {
+      ok: true;
+      written: number;
+      skipped: number;
+      reason: string;
+    }
+  | {
+      ok: false;
+      skipped: true;
+      reason: string;
+    };
+
+function isAutoSyncEnabled() {
+  const raw = String(process.env.OMNIROUTE_AUTO_SYNC_CODEX_PROFILES ?? "true").toLowerCase();
+  return !["0", "false", "no", "off"].includes(raw);
+}
+
+function forwardAuthHeaders(request: Request): Record<string, string> {
+  const headers: Record<string, string> = {};
+  const cookie = request.headers.get("cookie");
+  const authorization = request.headers.get("authorization");
+  if (cookie) headers.cookie = cookie;
+  if (authorization) headers.authorization = authorization;
+  return headers;
+}
+
+export async function autoSyncCodexProfilesFromLiveCatalog(
+  request: Request,
+  reason: string
+): Promise<SyncResult> {
+  if (!isAutoSyncEnabled()) {
+    return { ok: false, skipped: true, reason: "disabled" };
+  }
+
+  const writeGuard = ensureCliConfigWriteAllowed();
+  if (writeGuard) {
+    return { ok: false, skipped: true, reason: writeGuard };
+  }
+
+  const baseUrl = getModelSyncInternalBaseUrl().replace(/\/$/, "");
+  const res = await fetch(`${baseUrl}/v1/models`, {
+    headers: forwardAuthHeaders(request),
+    signal: AbortSignal.timeout(10_000),
+  });
+
+  if (!res.ok) {
+    return { ok: false, skipped: true, reason: `catalog_http_${res.status}` };
+  }
+
+  const body = await res.json();
+  const candidateModels = Array.isArray(body) ? body : body.data || body.models || [];
+  const models = Array.isArray(candidateModels) ? candidateModels : [];
+  const codexPaths = getCliConfigPaths("codex");
+  if (!codexPaths?.config) {
+    return { ok: false, skipped: true, reason: "codex_config_path_unavailable" };
+  }
+  const codexHome = path.dirname(codexPaths.config);
+
+  // Reuse the CLI generator so automatic sync and `omniroute setup-codex`
+  // stay behaviorally identical.
+  // @ts-ignore - bin CLI modules are shipped as ESM JavaScript, without TS declarations.
+  const { syncCodexProfilesFromModels } = await import("../../../bin/cli/commands/setup-codex.mjs");
+  const result = await syncCodexProfilesFromModels(models, { codexHome });
+
+  return {
+    ok: true,
+    written: result.written,
+    skipped: result.skipped,
+    reason,
+  };
+}

--- a/src/lib/cli-helper/codexProfileAutoSync.ts
+++ b/src/lib/cli-helper/codexProfileAutoSync.ts
@@ -16,8 +16,11 @@ type SyncResult =
     };
 
 function isAutoSyncEnabled() {
-  const raw = String(process.env.OMNIROUTE_AUTO_SYNC_CODEX_PROFILES ?? "true").toLowerCase();
-  return !["0", "false", "no", "off"].includes(raw);
+  // Opt-in, default OFF. Auto-writing profile files into ~/.codex is a side effect on the
+  // operator's machine, so it must be explicitly enabled (via env, or a settings/UI toggle
+  // that sets this env at runtime) — never silently on. An unset flag means disabled.
+  const raw = String(process.env.OMNIROUTE_AUTO_SYNC_CODEX_PROFILES ?? "false").toLowerCase();
+  return ["1", "true", "yes", "on"].includes(raw);
 }
 
 function forwardAuthHeaders(request: Request): Record<string, string> {

--- a/tests/unit/cli/setup-codex.test.ts
+++ b/tests/unit/cli/setup-codex.test.ts
@@ -1,8 +1,12 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import {
   fallbackCodexProfile,
   isCodexCompatibleTextModel,
+  syncCodexProfilesFromModels,
 } from "../../../bin/cli/commands/setup-codex.mjs";
 
 test("fallbackCodexProfile creates profiles for compatible live catalog models", () => {
@@ -39,4 +43,39 @@ test("fallbackCodexProfile skips media and non-text models", () => {
     }),
     null
   );
+});
+
+test("syncCodexProfilesFromModels writes compatible profiles and skips media", async () => {
+  const codexHome = await fs.mkdtemp(path.join(os.tmpdir(), "omniroute-codex-profiles-"));
+  try {
+    const result = await syncCodexProfilesFromModels(
+      [
+        {
+          id: "new-provider/future-chat-1",
+          context_length: 250000,
+          output_modalities: ["text"],
+        },
+        {
+          id: "video-provider/seedance",
+          type: "video",
+          output_modalities: ["video"],
+        },
+      ],
+      { codexHome }
+    );
+
+    assert.equal(result.written, 1);
+    assert.equal(result.skipped, 1);
+    const content = await fs.readFile(
+      path.join(codexHome, "new-provider-future-chat-1.config.toml"),
+      "utf8"
+    );
+    assert.match(content, /model\s+= "new-provider\/future-chat-1"/);
+    await assert.rejects(
+      fs.stat(path.join(codexHome, "video-provider-seedance.config.toml")),
+      /ENOENT/
+    );
+  } finally {
+    await fs.rm(codexHome, { recursive: true, force: true });
+  }
 });

--- a/tests/unit/codex-profile-auto-sync-gate.test.ts
+++ b/tests/unit/codex-profile-auto-sync-gate.test.ts
@@ -1,0 +1,80 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { autoSyncCodexProfilesFromLiveCatalog } from "@/lib/cli-helper/codexProfileAutoSync";
+
+// #5737 hardening: the Codex profile auto-sync writes files into the operator's ~/.codex,
+// so it MUST be opt-in (default OFF) and MUST short-circuit before any catalog fetch / file
+// write when either gate is closed. These tests pin the two gates (env opt-in + the existing
+// CLI_ALLOW_CONFIG_WRITES write-guard) so a future change can't silently turn it back on.
+
+const GATE_ENV = ["OMNIROUTE_AUTO_SYNC_CODEX_PROFILES", "CLI_ALLOW_CONFIG_WRITES"] as const;
+
+function snapshotEnv(): Record<string, string | undefined> {
+  const snap: Record<string, string | undefined> = {};
+  for (const k of GATE_ENV) snap[k] = process.env[k];
+  return snap;
+}
+
+function restoreEnv(snap: Record<string, string | undefined>): void {
+  for (const k of GATE_ENV) {
+    if (snap[k] === undefined) delete process.env[k];
+    else process.env[k] = snap[k];
+  }
+}
+
+function mockSyncRequest(): Request {
+  // A local model-sync request; the gate returns before any header is actually forwarded.
+  return new Request("http://127.0.0.1:20128/api/providers/openai/sync-models", { method: "POST" });
+}
+
+test("auto-sync is OFF by default (flag unset) — returns disabled, never fetches or writes", async () => {
+  const snap = snapshotEnv();
+  try {
+    delete process.env.OMNIROUTE_AUTO_SYNC_CODEX_PROFILES;
+    const result = await autoSyncCodexProfilesFromLiveCatalog(mockSyncRequest(), "test:default-off");
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "disabled");
+  } finally {
+    restoreEnv(snap);
+  }
+});
+
+test("explicit OMNIROUTE_AUTO_SYNC_CODEX_PROFILES=false stays disabled", async () => {
+  const snap = snapshotEnv();
+  try {
+    process.env.OMNIROUTE_AUTO_SYNC_CODEX_PROFILES = "false";
+    const result = await autoSyncCodexProfilesFromLiveCatalog(mockSyncRequest(), "test:explicit-false");
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "disabled");
+  } finally {
+    restoreEnv(snap);
+  }
+});
+
+test("non-truthy flag values ('0', 'no', 'off', 'maybe') stay disabled", async () => {
+  const snap = snapshotEnv();
+  try {
+    for (const v of ["0", "no", "off", "maybe", ""]) {
+      process.env.OMNIROUTE_AUTO_SYNC_CODEX_PROFILES = v;
+      const result = await autoSyncCodexProfilesFromLiveCatalog(mockSyncRequest(), `test:${v}`);
+      assert.equal(result.ok, false, `value '${v}' must not enable auto-sync`);
+      assert.equal(result.reason, "disabled", `value '${v}' must report disabled`);
+    }
+  } finally {
+    restoreEnv(snap);
+  }
+});
+
+test("enabled flag but CLI_ALLOW_CONFIG_WRITES=false is blocked by the write-guard (no write)", async () => {
+  const snap = snapshotEnv();
+  try {
+    process.env.OMNIROUTE_AUTO_SYNC_CODEX_PROFILES = "true";
+    process.env.CLI_ALLOW_CONFIG_WRITES = "false";
+    const result = await autoSyncCodexProfilesFromLiveCatalog(mockSyncRequest(), "test:write-guard");
+    assert.equal(result.ok, false);
+    assert.match(result.reason, /CLI config writes are disabled/);
+  } finally {
+    restoreEnv(snap);
+  }
+});


### PR DESCRIPTION
## Summary
- reuse the merged `setup-codex` live-catalog profile generator for automatic profile sync
- run Codex profile sync after provider model discovery/import changes the live model catalog
- keep the sync non-blocking, gated by `CLI_ALLOW_CONFIG_WRITES`, and disableable with `OMNIROUTE_AUTO_SYNC_CODEX_PROFILES=false`
- document that the sync only writes separate `~/.codex/*.config.toml` files and does not change active/default Codex config, Codex-lb, auth, or provider selection

Follows #5707 and builds on #5701.

## Test plan
- `node --test tests\\unit\\cli\\setup-codex.test.ts`
- `git diff --check` (passes; only Windows CRLF warnings)

Note: `npm run typecheck:core` could not run in this checkout because `tsc` is not installed/available.