### PR TITLE
feat(cli): show version number in startup banner

### DIFF
--- a/bin/cli/commands/serve.mjs
+++ b/bin/cli/commands/serve.mjs
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { platform, totalmem } from "node:os";
@@ -16,6 +16,7 @@ import {
 import { resolveTlsOptions } from "../../../scripts/dev/tls-options.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const _pkg = JSON.parse(readFileSync(join(__dirname, "..", "..", "..", "package.json"), "utf8"));
 
 // URL scheme for the "OmniRoute is running" banner — flipped to https when
 // opt-in TLS (#5242) is active. Process-scoped: one `serve` run = one scheme.
@@ -48,11 +49,13 @@ export function registerServe(program) {
     .option("--no-tray", t("serve.no_tray") || "Disable system tray icon")
     .option(
       "--tls-cert <path>",
-      t("serve.tls_cert") || "Path to a TLS certificate (PEM) to serve HTTPS (also OMNIROUTE_TLS_CERT)"
+      t("serve.tls_cert") ||
+        "Path to a TLS certificate (PEM) to serve HTTPS (also OMNIROUTE_TLS_CERT)"
     )
     .option(
       "--tls-key <path>",
-      t("serve.tls_key") || "Path to the TLS private key (PEM) to serve HTTPS (also OMNIROUTE_TLS_KEY)"
+      t("serve.tls_key") ||
+        "Path to the TLS private key (PEM) to serve HTTPS (also OMNIROUTE_TLS_KEY)"
     )
     .action(async (opts) => {
       await runServe(opts);
@@ -78,6 +81,7 @@ export async function runServe(opts = {}) {
   | |__| | | | | | | | | | | | \\ \\ (_) | |_| | ||  __/
    \\____/|_| |_| |_|_| |_|_|_|  \\_\\___/ \\__,_|\\__\\___|
 \x1b[0m`);
+  console.log(`\x1b[2m  v${_pkg.version}\x1b[0m\n`);
 
   const nodeSupport = getNodeRuntimeSupport();
   if (!nodeSupport.nodeCompatible) {
@@ -366,9 +370,7 @@ async function maybeStartTray(port, apiPort, supervisor) {
   } catch (err) {
     // tray is optional — do not fail the server, but surface why it failed so
     // "--tray shows nothing" is diagnosable instead of silent (#4605).
-    process.stderr.write(
-      `[omniroute][tray] failed to start: ${err?.message ?? String(err)}\n`
-    );
+    process.stderr.write(`[omniroute][tray] failed to start: ${err?.message ?? String(err)}\n`);
   }
 }
 


### PR DESCRIPTION
## Summary

- Adds dim `v<version>` line immediately below the ASCII art logo in `omniroute serve`
- Reads version via `readFileSync` + `JSON.parse` (same pattern as `bin/cli/program.mjs`)
- No new dependency

## Before

```
   OmniRoute ASCII art

  ⏳ Starting server...
```

## After

```
   OmniRoute ASCII art

  v3.8.42

  ⏳ Starting server...
```

## Why

Users debugging routing issues or filing bug reports need to know what version is running without leaving the terminal to run `omniroute --version`. Consistent with `wrangler`, `docker`, `node` — all show version in their startup output.

Resolves #5749.

## Test plan

- [ ] `node bin/omniroute.mjs serve` — confirm `v3.8.42` (dimmed) appears between logo and `⏳ Starting server...`
- [ ] `omniroute --version` still works (unaffected path)
- [ ] `omniroute serve --daemon` — version still shown before daemonizing