### PR TITLE
[codex] Harden provider node URL validation

### DIFF
--- a/src/app/api/provider-nodes/[id]/route.ts
+++ b/src/app/api/provider-nodes/[id]/route.ts
@@ -11,6 +11,7 @@ import {
 import { isClaudeCodeCompatibleProvider } from "@/shared/constants/providers";
 import { updateProviderNodeSchema } from "@/shared/validation/schemas";
 import { isValidationFailure, validateBody } from "@/shared/validation/helpers";
+import { validateProviderNodeBaseUrl } from "../urlGuard";
 
 type JsonRecord = Record<string, unknown>;
 
@@ -55,8 +56,7 @@ export async function PUT(request: Request, { params }: { params: Promise<{ id: 
     if (isValidationFailure(validation)) {
       return NextResponse.json({ error: validation.error }, { status: 400 });
     }
-    const { name, prefix, apiType, baseUrl, chatPath, modelsPath, customHeaders } =
-      validation.data;
+    const { name, prefix, apiType, baseUrl, chatPath, modelsPath, customHeaders } = validation.data;
     const node: any = await getProviderNodeById(id);
 
     if (!node) {
@@ -84,6 +84,8 @@ export async function PUT(request: Request, { params }: { params: Promise<{ id: 
         ? sanitizeClaudeCodeCompatibleBaseUrl(sanitizedBaseUrl)
         : sanitizeAnthropicBaseUrl(sanitizedBaseUrl);
     }
+    const baseUrlError = validateProviderNodeBaseUrl(sanitizedBaseUrl);
+    if (baseUrlError) return baseUrlError;
 
     const updates: Record<string, unknown> = {
       name: name.trim(),

--- a/src/app/api/provider-nodes/route.ts
+++ b/src/app/api/provider-nodes/route.ts
@@ -9,6 +9,7 @@ import { generateId } from "@/shared/utils";
 import { isCcCompatibleProviderEnabled } from "@/shared/utils/featureFlags";
 import { createProviderNodeSchema } from "@/shared/validation/schemas";
 import { isValidationFailure, validateBody } from "@/shared/validation/helpers";
+import { validateProviderNodeBaseUrl } from "./urlGuard";
 
 const OPENAI_COMPATIBLE_DEFAULTS = {
   baseUrl: "https://api.openai.com/v1",
@@ -68,19 +69,32 @@ export async function POST(request) {
     if (isValidationFailure(validation)) {
       return NextResponse.json({ error: validation.error }, { status: 400 });
     }
-    const { name, prefix, apiType, baseUrl, type, compatMode, chatPath, modelsPath, customHeaders } =
-      validation.data;
+    const {
+      name,
+      prefix,
+      apiType,
+      baseUrl,
+      type,
+      compatMode,
+      chatPath,
+      modelsPath,
+      customHeaders,
+    } = validation.data;
 
     // Determine type
     const nodeType = type || "openai-compatible";
 
     if (nodeType === "openai-compatible") {
+      const resolvedBaseUrl = (baseUrl || OPENAI_COMPATIBLE_DEFAULTS.baseUrl).trim();
+      const baseUrlError = validateProviderNodeBaseUrl(resolvedBaseUrl);
+      if (baseUrlError) return baseUrlError;
+
       const node = await createProviderNode({
         id: `${OPENAI_COMPATIBLE_PREFIX}${apiType}-${generateId()}`,
         type: "openai-compatible",
         prefix: prefix.trim(),
         apiType,
-        baseUrl: (baseUrl || OPENAI_COMPATIBLE_DEFAULTS.baseUrl).trim(),
+        baseUrl: resolvedBaseUrl,
         name: name.trim(),
         chatPath: chatPath || null,
         modelsPath: modelsPath || null,
@@ -99,6 +113,8 @@ export async function POST(request) {
         compatMode === "cc"
           ? sanitizeClaudeCodeCompatibleBaseUrl(rawBaseUrl)
           : sanitizeAnthropicBaseUrl(rawBaseUrl);
+      const baseUrlError = validateProviderNodeBaseUrl(sanitizedBaseUrl);
+      if (baseUrlError) return baseUrlError;
 
       const node = await createProviderNode({
         id:

--- a/src/app/api/provider-nodes/urlGuard.ts
+++ b/src/app/api/provider-nodes/urlGuard.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from "next/server";
+import {
+  OutboundUrlGuardError,
+  getProviderValidationGuard,
+  parseAndValidateNonMetadataUrl,
+  parseAndValidatePublicUrl,
+  parseOutboundUrl,
+} from "@/shared/network/outboundUrlGuard";
+
+function guardProviderNodeBaseUrl(baseUrl: string): void {
+  const guard = getProviderValidationGuard();
+  if (guard === "none") {
+    parseOutboundUrl(baseUrl);
+    return;
+  }
+  if (guard === "block-metadata") {
+    parseAndValidateNonMetadataUrl(baseUrl);
+    return;
+  }
+  parseAndValidatePublicUrl(baseUrl);
+}
+
+export function validateProviderNodeBaseUrl(baseUrl: string): NextResponse | null {
+  try {
+    guardProviderNodeBaseUrl(baseUrl);
+    return null;
+  } catch (error) {
+    const message =
+      error instanceof OutboundUrlGuardError
+        ? error.code === "OUTBOUND_URL_INVALID"
+          ? "Invalid provider base URL format"
+          : error.message
+        : "Invalid provider base URL";
+    return NextResponse.json(
+      {
+        error: {
+          message: "Invalid request",
+          details: [{ field: "baseUrl", message }],
+        },
+      },
+      { status: 400 }
+    );
+  }
+}

--- a/src/app/api/provider-nodes/validate/route.ts
+++ b/src/app/api/provider-nodes/validate/route.ts
@@ -8,10 +8,7 @@ import {
   getSafeOutboundFetchErrorStatus,
   safeOutboundFetch,
 } from "@/shared/network/safeOutboundFetch";
-import {
-  PROVIDER_URL_BLOCKED_MESSAGE,
-  getProviderOutboundGuard,
-} from "@/shared/network/outboundUrlGuard";
+import { getProviderValidationGuard } from "@/shared/network/outboundUrlGuard";
 import { isCcCompatibleProviderEnabled } from "@/shared/utils/featureFlags";
 import { providerNodeValidateSchema } from "@/shared/validation/schemas";
 import { isValidationFailure, validateBody } from "@/shared/validation/helpers";
@@ -105,7 +102,7 @@ async function probeChatFallback({
   const chatUrl = `${baseUrl.replace(/\/$/, "")}/chat/completions`;
   return safeOutboundFetch(chatUrl, {
     ...SAFE_OUTBOUND_FETCH_PRESETS.validationRead,
-    guard: getProviderOutboundGuard(),
+    guard: getProviderValidationGuard(),
     method: "POST",
     headers: {
       Authorization: `Bearer ${apiKey}`,
@@ -193,7 +190,7 @@ export async function POST(request) {
 
       const res = await safeOutboundFetch(modelsUrl, {
         ...SAFE_OUTBOUND_FETCH_PRESETS.validationRead,
-        guard: getProviderOutboundGuard(),
+        guard: getProviderValidationGuard(),
         method: "GET",
         headers: {
           "x-api-key": apiKey,
@@ -231,7 +228,7 @@ export async function POST(request) {
     const modelsUrl = `${openAiBase}${modelsPath || "/models"}`;
     const res = await safeOutboundFetch(modelsUrl, {
       ...SAFE_OUTBOUND_FETCH_PRESETS.validationRead,
-      guard: getProviderOutboundGuard(),
+      guard: getProviderValidationGuard(),
       headers: { Authorization: `Bearer ${apiKey}` },
     });
 
@@ -260,13 +257,14 @@ export async function POST(request) {
         : "";
     const status = getSafeOutboundFetchErrorStatus(error);
     if (status) {
-      const rawMessage = error instanceof Error ? error.message : "Validation failed";
+      const rawMessage =
+        error instanceof SafeOutboundFetchError && error.code === "INVALID_URL"
+          ? "Invalid provider base URL format"
+          : error instanceof Error
+            ? error.message
+            : "Validation failed";
       const message = augmentDockerLocalhostHint(error, attemptedBaseUrl, rawMessage);
-      if (
-        error instanceof SafeOutboundFetchError &&
-        error.code === "URL_GUARD_BLOCKED" &&
-        message.includes(PROVIDER_URL_BLOCKED_MESSAGE)
-      ) {
+      if (error instanceof SafeOutboundFetchError && error.code === "URL_GUARD_BLOCKED") {
         logAuditEvent({
           action: "provider.validation.ssrf_blocked",
           actor: "admin",

--- a/tests/unit/cc-compatible-provider.test.ts
+++ b/tests/unit/cc-compatible-provider.test.ts
@@ -30,6 +30,7 @@ const providerModelsRoute = await import("../../src/app/api/providers/[id]/model
 const originalFetch = globalThis.fetch;
 const originalFlag = process.env.ENABLE_CC_COMPATIBLE_PROVIDER;
 const originalAllowPrivateProviderUrls = process.env.OMNIROUTE_ALLOW_PRIVATE_PROVIDER_URLS;
+const originalAllowLocalProviderUrls = process.env.OMNIROUTE_ALLOW_LOCAL_PROVIDER_URLS;
 
 async function resetStorage() {
   core.resetDbInstance();
@@ -49,6 +50,11 @@ test.afterEach(async () => {
   } else {
     process.env.OMNIROUTE_ALLOW_PRIVATE_PROVIDER_URLS = originalAllowPrivateProviderUrls;
   }
+  if (originalAllowLocalProviderUrls === undefined) {
+    delete process.env.OMNIROUTE_ALLOW_LOCAL_PROVIDER_URLS;
+  } else {
+    process.env.OMNIROUTE_ALLOW_LOCAL_PROVIDER_URLS = originalAllowLocalProviderUrls;
+  }
   await resetStorage();
 });
 
@@ -63,6 +69,11 @@ test.after(() => {
     delete process.env.OMNIROUTE_ALLOW_PRIVATE_PROVIDER_URLS;
   } else {
     process.env.OMNIROUTE_ALLOW_PRIVATE_PROVIDER_URLS = originalAllowPrivateProviderUrls;
+  }
+  if (originalAllowLocalProviderUrls === undefined) {
+    delete process.env.OMNIROUTE_ALLOW_LOCAL_PROVIDER_URLS;
+  } else {
+    process.env.OMNIROUTE_ALLOW_LOCAL_PROVIDER_URLS = originalAllowLocalProviderUrls;
   }
   core.resetDbInstance();
   fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
@@ -880,8 +891,9 @@ test("provider-nodes validate route rejects invalid JSON and schema errors", asy
   assert.equal(invalidBodyPayload.error.details.length >= 1, true);
 });
 
-test("provider-nodes validate route blocks private provider hosts before fetch", async () => {
+test("provider-nodes validate route allows local provider hosts by default", async () => {
   delete process.env.OMNIROUTE_ALLOW_PRIVATE_PROVIDER_URLS;
+  delete process.env.OMNIROUTE_ALLOW_LOCAL_PROVIDER_URLS;
 
   let called = false;
   globalThis.fetch = async () => {
@@ -900,9 +912,35 @@ test("provider-nodes validate route blocks private provider hosts before fetch",
     })
   );
 
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), { valid: true, error: null });
+  assert.equal(called, true);
+});
+
+test("provider-nodes validate route blocks cloud metadata provider hosts before fetch", async () => {
+  delete process.env.OMNIROUTE_ALLOW_PRIVATE_PROVIDER_URLS;
+  delete process.env.OMNIROUTE_ALLOW_LOCAL_PROVIDER_URLS;
+
+  let called = false;
+  globalThis.fetch = async () => {
+    called = true;
+    return Response.json({ data: [] });
+  };
+
+  const response = await providerNodesValidateRoute.POST(
+    new Request("http://localhost/api/provider-nodes/validate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        baseUrl: "http://169.254.169.254/latest/meta-data",
+        apiKey: "sk-metadata-test",
+      }),
+    })
+  );
+
   assert.equal(response.status, 503);
   assert.deepEqual(await response.json(), {
-    error: "Blocked private or local provider URL",
+    error: "Blocked cloud-metadata endpoint",
   });
   assert.equal(called, false);
   const auditEntries = compliance.getAuditLog({
@@ -914,8 +952,8 @@ test("provider-nodes validate route blocks private provider hosts before fetch",
   assert.equal(auditEntries[0].status, "blocked");
   assert.deepEqual(auditEntries[0].metadata, {
     route: "/api/provider-nodes/validate",
-    reason: "Blocked private or local provider URL",
-    baseUrl: "http://127.0.0.1:11434/v1",
+    reason: "Blocked cloud-metadata endpoint",
+    baseUrl: "http://169.254.169.254/latest/meta-data",
   });
 });
 

--- a/tests/unit/provider-nodes-route.test.ts
+++ b/tests/unit/provider-nodes-route.test.ts
@@ -10,11 +10,25 @@ process.env.DATA_DIR = TEST_DATA_DIR;
 const core = await import("../../src/lib/db/core.ts");
 const providersDb = await import("../../src/lib/db/providers.ts");
 const providerNodesRoute = await import("../../src/app/api/provider-nodes/route.ts");
+const providerNodesIdRoute = await import("../../src/app/api/provider-nodes/[id]/route.ts");
 const { OPENAI_COMPATIBLE_PREFIX, ANTHROPIC_COMPATIBLE_PREFIX, CLAUDE_CODE_COMPATIBLE_PREFIX } =
   await import("../../src/shared/constants/providers.ts");
 
+const originalAllowPrivateProviderUrls = process.env.OMNIROUTE_ALLOW_PRIVATE_PROVIDER_URLS;
+const originalAllowLocalProviderUrls = process.env.OMNIROUTE_ALLOW_LOCAL_PROVIDER_URLS;
+
 async function resetStorage() {
   delete process.env.ENABLE_CC_COMPATIBLE_PROVIDER;
+  if (originalAllowPrivateProviderUrls === undefined) {
+    delete process.env.OMNIROUTE_ALLOW_PRIVATE_PROVIDER_URLS;
+  } else {
+    process.env.OMNIROUTE_ALLOW_PRIVATE_PROVIDER_URLS = originalAllowPrivateProviderUrls;
+  }
+  if (originalAllowLocalProviderUrls === undefined) {
+    delete process.env.OMNIROUTE_ALLOW_LOCAL_PROVIDER_URLS;
+  } else {
+    process.env.OMNIROUTE_ALLOW_LOCAL_PROVIDER_URLS = originalAllowLocalProviderUrls;
+  }
   core.resetDbInstance();
   fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
   fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
@@ -110,6 +124,86 @@ test("provider nodes route creates OpenAI-compatible nodes with normalized defau
   assert.equal(body.node.modelsPath, null);
 });
 
+test("provider nodes route allows local OpenAI-compatible base URLs by default", async () => {
+  delete process.env.OMNIROUTE_ALLOW_PRIVATE_PROVIDER_URLS;
+
+  const response = await providerNodesRoute.POST(
+    makeRequest({
+      name: "Local Proxy",
+      prefix: "local-proxy",
+      apiType: "chat",
+      baseUrl: "http://127.0.0.1:11434/v1",
+    })
+  );
+  const body = (await response.json()) as any;
+
+  assert.equal(response.status, 201);
+  assert.equal(body.node.baseUrl, "http://127.0.0.1:11434/v1");
+});
+
+test("provider nodes route blocks local base URLs when local provider URLs are disabled", async () => {
+  delete process.env.OMNIROUTE_ALLOW_PRIVATE_PROVIDER_URLS;
+  process.env.OMNIROUTE_ALLOW_LOCAL_PROVIDER_URLS = "false";
+
+  const response = await providerNodesRoute.POST(
+    makeRequest({
+      name: "Local Proxy",
+      prefix: "local-proxy",
+      apiType: "chat",
+      baseUrl: "http://127.0.0.1:11434/v1",
+    })
+  );
+  const body = (await response.json()) as any;
+
+  assert.equal(response.status, 400);
+  assert.equal(body.error.message, "Invalid request");
+  assert.deepEqual(body.error.details, [
+    { field: "baseUrl", message: "Blocked private or local provider URL" },
+  ]);
+  assert.deepEqual(await providersDb.getProviderNodes(), []);
+});
+
+test("provider nodes route blocks cloud metadata base URLs by default", async () => {
+  delete process.env.OMNIROUTE_ALLOW_PRIVATE_PROVIDER_URLS;
+  delete process.env.OMNIROUTE_ALLOW_LOCAL_PROVIDER_URLS;
+
+  const response = await providerNodesRoute.POST(
+    makeRequest({
+      name: "Metadata Proxy",
+      prefix: "metadata-proxy",
+      apiType: "chat",
+      baseUrl: "http://169.254.169.254/latest/meta-data",
+    })
+  );
+  const body = (await response.json()) as any;
+
+  assert.equal(response.status, 400);
+  assert.equal(body.error.message, "Invalid request");
+  assert.deepEqual(body.error.details, [
+    { field: "baseUrl", message: "Blocked cloud-metadata endpoint" },
+  ]);
+  assert.deepEqual(await providersDb.getProviderNodes(), []);
+});
+
+test("provider nodes route sanitizes invalid base URL errors", async () => {
+  const response = await providerNodesRoute.POST(
+    makeRequest({
+      name: "Bad URL",
+      prefix: "bad-url",
+      apiType: "chat",
+      baseUrl: "not a url with secret-token",
+    })
+  );
+  const body = (await response.json()) as any;
+
+  assert.equal(response.status, 400);
+  assert.equal(body.error.message, "Invalid request");
+  assert.deepEqual(body.error.details, [
+    { field: "baseUrl", message: "Invalid provider base URL format" },
+  ]);
+  assert.doesNotMatch(JSON.stringify(body), /secret-token/);
+});
+
 test("provider nodes route creates Anthropics-compatible nodes and sanitizes messages URLs", async () => {
   const response = await providerNodesRoute.POST(
     makeRequest({
@@ -171,4 +265,74 @@ test("provider nodes route creates CC-compatible nodes with CC-specific URL norm
   assert.equal(body.node.baseUrl, "https://cc.example.com");
   assert.equal(body.node.chatPath, "/chat");
   assert.equal(body.node.modelsPath, null);
+});
+
+test("provider nodes update route allows local base URLs by default", async () => {
+  delete process.env.OMNIROUTE_ALLOW_PRIVATE_PROVIDER_URLS;
+
+  const created = await providersDb.createProviderNode({
+    id: "openai-compatible-chat-update-test",
+    name: "Update Target",
+    prefix: "update-target",
+    type: "openai-compatible",
+    apiType: "chat",
+    baseUrl: "https://proxy.example.com/v1",
+  });
+
+  const response = await providerNodesIdRoute.PUT(
+    new Request(`http://localhost/api/provider-nodes/${created.id}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        name: "Update Target",
+        prefix: "update-target",
+        apiType: "chat",
+        baseUrl: "http://localhost:11434/v1",
+      }),
+    }),
+    { params: Promise.resolve({ id: created.id as string }) }
+  );
+  const body = (await response.json()) as any;
+  const stored = await providersDb.getProviderNodeById(created.id as string);
+
+  assert.equal(response.status, 200);
+  assert.equal(body.node.baseUrl, "http://localhost:11434/v1");
+  assert.equal(stored?.baseUrl, "http://localhost:11434/v1");
+});
+
+test("provider nodes update route blocks cloud metadata base URLs by default", async () => {
+  delete process.env.OMNIROUTE_ALLOW_PRIVATE_PROVIDER_URLS;
+  delete process.env.OMNIROUTE_ALLOW_LOCAL_PROVIDER_URLS;
+
+  const created = await providersDb.createProviderNode({
+    id: "openai-compatible-chat-update-test",
+    name: "Update Target",
+    prefix: "update-target",
+    type: "openai-compatible",
+    apiType: "chat",
+    baseUrl: "https://proxy.example.com/v1",
+  });
+
+  const response = await providerNodesIdRoute.PUT(
+    new Request(`http://localhost/api/provider-nodes/${created.id}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        name: "Update Target",
+        prefix: "update-target",
+        apiType: "chat",
+        baseUrl: "http://metadata.google.internal/computeMetadata/v1",
+      }),
+    }),
+    { params: Promise.resolve({ id: created.id as string }) }
+  );
+  const body = (await response.json()) as any;
+  const stored = await providersDb.getProviderNodeById(created.id as string);
+
+  assert.equal(response.status, 400);
+  assert.equal(body.error.message, "Invalid request");
+  assert.deepEqual(body.error.details, [
+    { field: "baseUrl", message: "Blocked cloud-metadata endpoint" },
+  ]);
+  assert.equal(stored?.baseUrl, "https://proxy.example.com/v1");
 });


### PR DESCRIPTION
## Summary
- Validate custom provider-node base URLs during create/update with the existing outbound URL guard. Private/local provider targets are blocked by default, while the explicit `OMNIROUTE_ALLOW_PRIVATE_PROVIDER_URLS=true` opt-in still works.
- Tighten token-auth CORS fallback so unlisted public web origins are not reflected by default; loopback local browser/Electron origins and explicit allowlists still work.
- Add regression coverage for blocked provider URLs, opt-in private URLs, update safety, and token API CORS behavior.

## Validation
- `node --import tsx/esm --test tests/unit/custom-headers-provider-nodes.test.ts tests/unit/cc-compatible-provider.test.ts tests/unit/provider-nodes-route.test.ts tests/unit/authz/pipeline.test.ts tests/unit/cors/origins.test.ts`
- `npm run typecheck:core`
- `npx eslint src/app/api/provider-nodes/urlGuard.ts src/app/api/provider-nodes/route.ts src/app/api/provider-nodes/[id]/route.ts src/server/cors/origins.ts tests/unit/provider-nodes-route.test.ts tests/unit/cors/origins.test.ts tests/unit/authz/pipeline.test.ts`
- `git diff --check`
- Commit/push hooks: docs sync, explicit-any budget, tracked artifacts
