### PR TITLE
test(runtime): guard tsx/esm→esbuild transform path on boot (#5757)

### DIFF
--- a/tests/unit/_fixtures/tsx-runtime-modern-syntax.ts
+++ b/tests/unit/_fixtures/tsx-runtime-modern-syntax.ts
@@ -1,0 +1,39 @@
+/**
+ * #5757 guard fixture — NOT a test file (no `.test.` in the name, so the runner
+ * skips it). Exercised by `tests/unit/tsx-runtime-transform-5757.test.ts`.
+ *
+ * It concentrates the modern JS/TS syntax that the published CLI's runtime
+ * `tsx/esm` loader (`bin/omniroute.mjs` → `await import("tsx/esm")`) must
+ * transform through esbuild at startup: object/array destructuring + rest,
+ * object/array spread, class + private fields, optional chaining, nullish
+ * coalescing, logical assignment, async/await and top-level await.
+ *
+ * If a future esbuild (pulled transitively via `tsx`) cannot transform this on a
+ * supported Node runtime, running this file fails — which is the whole point.
+ */
+class Box {
+  value = 41; // public class field
+  #secret = 1; // private field
+
+  bump(): number {
+    this.value += this.#secret;
+    return this.value;
+  }
+}
+
+async function main() {
+  const { a, b, ...rest } = { a: 1, b: 2, c: 3, d: 4 }; // object destructuring + rest
+  const [first, ...tail] = [10, 20, 30]; // array destructuring + rest
+  const merged = { ...rest, first }; // object spread
+  const arr = [...tail, first]; // array spread
+  const bumped = new Box().bump(); // class + private field
+  const maybe: { x?: { y?: number } } = {};
+  const opt = maybe?.x?.y ?? 99; // optional chaining + nullish coalescing
+  let acc = 0;
+  acc ||= bumped; // logical assignment
+  const total = await Promise.resolve(a + b + first + opt + acc); // async/await
+  return { a, b, rest, first, tail, merged, arr, bumped, opt, total };
+}
+
+const result = await main(); // top-level await
+console.log("TSX_TRANSFORM_OK " + JSON.stringify(result));

--- a/tests/unit/tsx-runtime-transform-5757.test.ts
+++ b/tests/unit/tsx-runtime-transform-5757.test.ts
@@ -1,0 +1,80 @@
+/**
+ * #5757 — regression guard for the runtime `tsx/esm` → esbuild transform path.
+ *
+ * Background: `tsx` is a runtime `dependency` (not dev), and the published CLI
+ * registers it at boot (`bin/omniroute.mjs` → `await import("tsx/esm")`) to load
+ * OmniRoute's own `.ts` sources. A fresh `npm install omniroute` therefore pulls
+ * `esbuild` transitively via `tsx`. #5757 worried a broken esbuild could make a
+ * fresh install "build-fragile", and proposed forcing `esbuild@0.27.4`.
+ *
+ * That override is unsafe: `tsx` declares `esbuild@~0.28.0` and `fumadocs-mdx`
+ * (also a runtime dep) declares `esbuild@^0.28.0`; forcing 0.27.x pushes esbuild
+ * below both. So instead of pinning a version, these two tests guard the actual
+ * invariants:
+ *   1. the runtime tsx/esm loader still transforms modern syntax correctly, and
+ *   2. the resolved esbuild stays inside tsx's declared range (so nobody
+ *      reintroduces the out-of-range override this issue proposed).
+ *
+ * Run: node --import tsx/esm --test tests/unit/tsx-runtime-transform-5757.test.ts
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, "..", "..");
+const FIXTURE = join(__dirname, "_fixtures", "tsx-runtime-modern-syntax.ts");
+
+test("#5757: runtime tsx/esm loader transforms modern syntax (esbuild functional guard)", () => {
+  // Exactly the mechanism bin/omniroute.mjs uses. cwd = package root so `tsx`
+  // resolves regardless of where the process is launched from (see #4055).
+  const res = spawnSync(process.execPath, ["--import", "tsx/esm", FIXTURE], {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+    timeout: 60_000,
+  });
+
+  assert.equal(res.status, 0, `tsx/esm failed to run the fixture:\n${res.stderr}`);
+  const line = (res.stdout || "").split("\n").find((l) => l.startsWith("TSX_TRANSFORM_OK"));
+  assert.ok(
+    line,
+    `missing TSX_TRANSFORM_OK marker.\nstdout:\n${res.stdout}\nstderr:\n${res.stderr}`
+  );
+
+  const payload = JSON.parse(line!.slice("TSX_TRANSFORM_OK ".length)) as {
+    rest: Record<string, number>;
+    arr: number[];
+    bumped: number;
+    opt: number;
+    total: number;
+  };
+  assert.equal(payload.bumped, 42); // class field + private field lowering
+  assert.equal(payload.opt, 99); // optional chaining + nullish coalescing
+  assert.equal(payload.total, 154); // destructuring/spread/async/logical-assign
+  assert.deepEqual(payload.rest, { c: 3, d: 4 });
+  assert.deepEqual(payload.arr, [20, 30, 10]);
+});
+
+test("#5757: resolved esbuild stays within tsx's declared range (blocks the out-of-range override)", () => {
+  const tsxPkg = JSON.parse(
+    readFileSync(join(REPO_ROOT, "node_modules", "tsx", "package.json"), "utf8")
+  ) as { dependencies?: Record<string, string> };
+  const esbuildPkg = JSON.parse(
+    readFileSync(join(REPO_ROOT, "node_modules", "esbuild", "package.json"), "utf8")
+  ) as { version: string };
+
+  const declared = tsxPkg.dependencies?.esbuild ?? "";
+  // e.g. "~0.28.0" → base minor "0.28". Self-maintaining: when tsx bumps its
+  // esbuild range, this guard follows it automatically.
+  const baseMinor = declared.replace(/^[~^]/, "").split(".").slice(0, 2).join(".");
+  assert.ok(baseMinor, `could not parse tsx's declared esbuild range: "${declared}"`);
+  assert.ok(
+    esbuildPkg.version.startsWith(baseMinor + "."),
+    `esbuild ${esbuildPkg.version} is outside tsx's declared range "${declared}". ` +
+      `A global esbuild override (such as the esbuild@0.27.4 workaround proposed in #5757) ` +
+      `breaks tsx and fumadocs-mdx (both require esbuild@^0.28) — do not add one.`
+  );
+});


### PR DESCRIPTION
Addresses #5757 — a fresh `npm install omniroute@3.8.42` pulls `esbuild@0.28.1` transitively via `tsx`, and the reporter proposed forcing `esbuild@0.27.4`.

## Why not the proposed override

`overrides: { esbuild: "0.27.4" }` is **unsafe here**:

- `tsx@4.22.4` declares `esbuild@~0.28.0` and **`fumadocs-mdx@15`** (also a runtime `dependency`) declares `esbuild@^0.28.0`. Forcing `0.27.x` pushes esbuild **below both** ranges.
- `esbuild@0.28.1` is currently the **latest** release — there is no fixed `0.28.2` to pin up to.

## Why the failure doesn't reproduce

The quoted error ("Transforming destructuring to the configured target environment is not supported yet") only fires when esbuild lowers to a pre-ES2015 target. In OmniRoute that path can't be reached on a supported runtime:

- `tsconfig target` is **ES2022** (destructuring is native → no lowering).
- Minimum supported Node is **22.2** (`bin/nodeRuntimeSupport.mjs`) — all support destructuring.
- `tsx` targets the **running Node**, not the tsconfig downlevel target (verified empirically: even a hostile `target: es5` tsconfig transforms cleanly via `tsx/esm` on Node 24 with esbuild@0.28.1).

## What this PR adds (a safe guard instead of a version pin)

`tests/unit/tsx-runtime-transform-5757.test.ts` + `tests/unit/_fixtures/tsx-runtime-modern-syntax.ts`:

1. **Functional guard** — spawns the real `node --import tsx/esm` loader (exactly what `bin/omniroute.mjs` registers at boot) on a fixture packed with modern syntax (destructuring/spread, class + private fields, optional chaining, nullish, logical assignment, async + top-level await) and asserts it transforms + runs correctly. Fails loudly if a future esbuild regresses the boot path.
2. **Dependency-shape guard** — asserts the resolved esbuild stays within tsx's *declared* range (self-maintaining: reads tsx's `dependencies.esbuild`), so nobody reintroduces the out-of-range override this issue proposed. Proven to catch `0.27.x`.

No production code changed; no esbuild version pinned.

## Validation

- Both guards pass (`node --import tsx/esm --test …` → 2/2), and both proven to have teeth (dependency guard rejects `0.27.4`/`0.27.7`; functional guard fails on non-zero child status).
- `typecheck:core` clean · lint 0 errors · the `_fixtures/` file is not matched by the `test:unit` glob.

Refs #5757 (kept open pending the reporter's actual error log / exact repro command — see issue comment).