### PR TITLE
fix(cli): rename process title to omniroute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,8 @@
 
 - **Security hardening follow-ups (v3.8.15):** the `auth_token` cookie now sets an explicit 30-day `maxAge` so sessions persist as intended (Seg3); the management bootstrap warns at boot when `INITIAL_PASSWORD` is left at the insecure `CHANGEME` default (Seg2); VS Code path-token endpoints (`/api/v1/vscode/raw/[token]`) emit a once-per-process security warning since the API key travels in the URL and can leak via logs/proxies (Seg4); the system version route resolves the real global install path via `npm root -g` instead of a hardcoded `/app` (Bug3); and auto-update mode detection segment-matches `node_modules` instead of substring-matching, eliminating false "global install" positives (Bug1).
 
+- **fix(cli):** rename the Node process title to `omniroute` so it shows correctly in ps/htop. (thanks @waguriagentic)
+
 ### 📝 Maintenance
 
 ---

--- a/src/instrumentation-node.ts
+++ b/src/instrumentation-node.ts
@@ -20,6 +20,21 @@ function toHex(bytes: Uint8Array): string {
   return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
 }
 
+/**
+ * Rename a Node process title so OmniRoute is identifiable in `ps`/`htop`
+ * instead of the generic Next.js standalone server name.
+ *
+ * Only rewrites titles that start with "next-server", preserving any
+ * trailing suffix (e.g. " (v16.2.9)"). Every other title — including one
+ * that has already been renamed, or one that merely contains
+ * "next-server" elsewhere — passes through unchanged. Empty/undefined-safe.
+ */
+export function renameProcessTitle(currentTitle: string): string {
+  if (!currentTitle) return currentTitle;
+  if (!currentTitle.startsWith("next-server")) return currentTitle;
+  return `omniroute${currentTitle.slice("next-server".length)}`;
+}
+
 function isBackgroundServicesDisabled(): boolean {
   const raw = process.env.OMNIROUTE_DISABLE_BACKGROUND_SERVICES;
   if (!raw) return false;
@@ -69,6 +84,10 @@ async function ensureSecrets(): Promise<void> {
 }
 
 export async function registerNodejs(): Promise<void> {
+  // Rename the process title so OmniRoute is identifiable in ps/htop instead
+  // of the generic "next-server" standalone server name.
+  process.title = renameProcessTitle(process.title);
+
   // Initialize proxy fetch patch FIRST (before any HTTP requests)
   await import("@omniroute/open-sse/index.ts");
   console.log("[STARTUP] Global fetch proxy patch initialized");

--- a/tests/unit/instrumentation-process-title.test.ts
+++ b/tests/unit/instrumentation-process-title.test.ts
@@ -1,0 +1,30 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { renameProcessTitle } from "../../src/instrumentation-node";
+
+test("renameProcessTitle renames a bare 'next-server' title to 'omniroute'", () => {
+  assert.equal(renameProcessTitle("next-server"), "omniroute");
+});
+
+test("renameProcessTitle preserves a version suffix after 'next-server'", () => {
+  assert.equal(renameProcessTitle("next-server (v16.2.9)"), "omniroute (v16.2.9)");
+});
+
+test("renameProcessTitle passes through titles that do not start with 'next-server' unchanged", () => {
+  assert.equal(renameProcessTitle("node"), "node");
+  assert.equal(renameProcessTitle("some-other-process"), "some-other-process");
+  assert.equal(renameProcessTitle("my-next-server-thing"), "my-next-server-thing");
+});
+
+test("renameProcessTitle is idempotent when called again on an already-renamed title", () => {
+  const once = renameProcessTitle("next-server (v16.2.9)");
+  const twice = renameProcessTitle(once);
+  assert.equal(once, "omniroute (v16.2.9)");
+  assert.equal(twice, "omniroute (v16.2.9)");
+});
+
+test("renameProcessTitle is empty/undefined safe", () => {
+  assert.equal(renameProcessTitle(""), "");
+  // @ts-expect-error - exercising runtime safety for a possibly-undefined process.title
+  assert.equal(renameProcessTitle(undefined), undefined);
+});


### PR DESCRIPTION
## Summary

- The running Node process previously showed up in `ps`/`htop` under the generic Next.js standalone name `next-server`, making it hard to identify the OmniRoute process among other Node processes on a host.
- Added a pure, well-tested helper `renameProcessTitle(currentTitle)` in `src/instrumentation-node.ts` that renames only a title starting with `next-server` to `omniroute` (the `package.json` `name`), preserving any trailing suffix (e.g. a version string like ` (v16.2.9)`) and passing every other title through unchanged. Empty/undefined-safe.
- Wired it in near the top of `registerNodejs()`: `process.title = renameProcessTitle(process.title)`.
- Backend-only; no i18n surface.

## Attribution

Ported from an upstream fork's process-title rename idea, adapted to OmniRoute's naming (`omniroute` instead of the fork's own name) and re-implemented as a pure, independently-tested helper in the Node-runtime instrumentation entry point rather than a bare `instrumentation.js`. (thanks @waguriagentic)

## Testing

- New `tests/unit/instrumentation-process-title.test.ts` (TDD): rename case, version-suffix preservation, pass-through for non-matching/already-renamed titles, idempotence, and empty/undefined safety.
- Before: test failed with `SyntaxError: ... does not provide an export named 'renameProcessTitle'` (helper did not exist).
- After: `node --import tsx/esm --test tests/unit/instrumentation-process-title.test.ts` → 5/5 passing.
- `npx eslint src/instrumentation-node.ts tests/unit/instrumentation-process-title.test.ts` → clean.
- `npm run typecheck:core` → clean (exit 0).