### PR TITLE
fix(dashboard): neutral badge for unsupported validation + clickable OAuth error links (#5442, #5486)

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/[id]/components/modals/AddApiKeyModal.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/modals/AddApiKeyModal.tsx
@@ -19,6 +19,7 @@ import {
   normalizeAndValidateHttpBaseUrl,
   extractCommandCodeCredentialInput,
   providerText,
+  validationBadgeProps,
   type CommandCodeAuthFlowState,
 } from "../../providerPageHelpers";
 import { getWebSessionCredentialRequirement } from "../../webSessionCredentials";
@@ -202,7 +203,7 @@ export default function AddApiKeyModal({
       });
       const data = await res.json();
       const ok = !!data.valid;
-      setValidationResult(ok ? "success" : "failed");
+      setValidationResult(ok ? "success" : data.unsupported ? "unsupported" : "failed");
       // #5088: surface the detailed reason the backend returns (e.g. a TLS/EACCES
       // environment error for claude-web/chatgpt-web) instead of only a bare
       // "invalid" badge — otherwise the real cause is hidden and users are stuck.
@@ -276,7 +277,7 @@ export default function AddApiKeyModal({
           if (!isValid && data.error) {
             validationError = data.error;
           }
-          setValidationResult(isValid ? "success" : "failed");
+          setValidationResult(isValid ? "success" : isUnsupported ? "unsupported" : "failed");
         } catch {
           setValidationResult("failed");
         } finally {
@@ -674,8 +675,8 @@ export default function AddApiKeyModal({
               />
             )}
             {validationResult && (
-              <Badge variant={validationResult === "success" ? "success" : "error"}>
-                {validationResult === "success" ? t("valid") : t("invalid")}
+              <Badge variant={validationBadgeProps(validationResult).variant}>
+                {t(validationBadgeProps(validationResult).labelKey)}
               </Badge>
             )}
             {saveError && (

--- a/src/app/(dashboard)/dashboard/providers/[id]/providerPageHelpers.ts
+++ b/src/app/(dashboard)/dashboard/providers/[id]/providerPageHelpers.ts
@@ -118,6 +118,22 @@ export function providerText(
   return fallback;
 }
 
+/**
+ * #5442 — Badge variant + i18n label key for an add-credential validation result.
+ * A provider with no live validator returns `unsupported` (Save still succeeds);
+ * previously the modal only had success/failed states, so it rendered a red
+ * "Invalid" badge for those providers even though saving worked (LMArena, PiAPI…).
+ * "unsupported" now maps to a neutral `info` badge ("N/A"), not "Invalid".
+ */
+export function validationBadgeProps(result: string): {
+  variant: "success" | "error" | "info";
+  labelKey: string;
+} {
+  if (result === "success") return { variant: "success", labelKey: "valid" };
+  if (result === "unsupported") return { variant: "info", labelKey: "notApplicable" };
+  return { variant: "error", labelKey: "invalid" };
+}
+
 /** A single model's outcome from a `/api/models/test-all` response. */
 export interface TestAllModelOutcome {
   status: "ok" | "error";

--- a/src/shared/components/LinkifiedText.tsx
+++ b/src/shared/components/LinkifiedText.tsx
@@ -1,0 +1,30 @@
+import { Fragment } from "react";
+import { linkifyText } from "@/shared/utils/linkify";
+
+/**
+ * #5486 — Render a string with any embedded http(s) URLs as clickable links.
+ * Used by the OAuth error step so setup instructions (e.g. GitLab Duo's
+ * "register an OAuth application at https://gitlab.com/-/profile/applications …")
+ * are actionable instead of dead text. Links open in a new tab with a safe rel.
+ */
+export default function LinkifiedText({ text }: { text: string | null | undefined }) {
+  return (
+    <>
+      {linkifyText(text || "").map((seg, i) =>
+        seg.href ? (
+          <a
+            key={i}
+            href={seg.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline break-all"
+          >
+            {seg.text}
+          </a>
+        ) : (
+          <Fragment key={i}>{seg.text}</Fragment>
+        )
+      )}
+    </>
+  );
+}

--- a/src/shared/components/OAuthModal.tsx
+++ b/src/shared/components/OAuthModal.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from "next-intl";
 import Modal from "./Modal";
 import Button from "./Button";
 import Input from "./Input";
+import LinkifiedText from "./LinkifiedText";
 import { useCopyToClipboard } from "@/shared/hooks/useCopyToClipboard";
 import { parseResponseBody, getErrorMessage } from "@/shared/utils/api";
 import { isCredentialBlob, submitCredentialBlob } from "@/shared/components/oauthBlobSubmit";
@@ -948,7 +949,9 @@ export default function OAuthModal({
               <span className="material-symbols-outlined text-3xl text-red-600">error</span>
             </div>
             <h3 className="text-lg font-semibold mb-2">{t("error")}</h3>
-            <p className="text-sm text-red-600 mb-4">{error}</p>
+            <p className="text-sm text-red-600 mb-4">
+              <LinkifiedText text={error} />
+            </p>
             <div className="flex gap-2">
               <Button onClick={startOAuthFlow} variant="secondary" fullWidth>
                 {t("tryAgain")}

--- a/src/shared/utils/linkify.ts
+++ b/src/shared/utils/linkify.ts
@@ -1,0 +1,37 @@
+// #5486 — Split a plain string into text + URL segments so messages that embed a
+// URL (e.g. the GitLab Duo OAuth setup instructions pointing at
+// https://gitlab.com/-/profile/applications) can render clickable links instead of
+// dead red text in the OAuth error step. Pure (no React) so it is unit-testable.
+//
+// The matcher is a single unbounded repetition over a NEGATED character class
+// (`[^\s...]+`) — linear time, no catastrophic backtracking (ReDoS-safe per the
+// bounded-regex rule). A trailing sentence punctuation char is peeled back out of
+// the URL so "…restart." keeps its period as text and the link stays valid.
+
+export type TextSegment = { text: string; href?: string };
+
+const URL_RE = /https?:\/\/[^\s"'<>)]+/g;
+
+export function linkifyText(input: string): TextSegment[] {
+  if (!input) return [];
+  const segments: TextSegment[] = [];
+  let last = 0;
+  let match: RegExpExecArray | null;
+  URL_RE.lastIndex = 0;
+  while ((match = URL_RE.exec(input)) !== null) {
+    if (match.index > last) {
+      segments.push({ text: input.slice(last, match.index) });
+    }
+    let url = match[0];
+    let trailing = "";
+    while (url.length > 0 && /[.,;:!?]$/.test(url)) {
+      trailing = url.slice(-1) + trailing;
+      url = url.slice(0, -1);
+    }
+    segments.push({ text: url, href: url });
+    if (trailing) segments.push({ text: trailing });
+    last = match.index + match[0].length;
+  }
+  if (last < input.length) segments.push({ text: input.slice(last) });
+  return segments;
+}

--- a/tests/unit/oauth-error-linkify-5486.test.ts
+++ b/tests/unit/oauth-error-linkify-5486.test.ts
@@ -1,0 +1,35 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// #5486 — GitLab Duo's OAuth setup error embeds a registration URL
+// (https://gitlab.com/-/profile/applications) but the OAuth error step rendered
+// it as dead red text. linkifyText splits the message so the URL becomes a
+// clickable <a> while the surrounding instructions stay plain text.
+const { linkifyText } = await import("../../src/shared/utils/linkify.ts");
+
+test("#5486 linkifies the GitLab Duo applications URL in the setup error", () => {
+  const msg =
+    "GitLab Duo OAuth is not configured. Register an OAuth application at " +
+    "https://gitlab.com/-/profile/applications with redirect URI " +
+    "http://localhost:20128/callback and scopes then restart.";
+  const segs = linkifyText(msg);
+  const links = segs.filter((s) => s.href);
+  assert.equal(links.length, 2, "both URLs must become links");
+  assert.equal(links[0].href, "https://gitlab.com/-/profile/applications");
+  assert.equal(links[1].href, "http://localhost:20128/callback");
+  // Reassembling the segment texts must reproduce the original message verbatim.
+  assert.equal(segs.map((s) => s.text).join(""), msg);
+});
+
+test("#5486 trailing sentence punctuation is peeled out of the URL", () => {
+  const segs = linkifyText("See https://gitlab.com/-/profile/applications.");
+  const link = segs.find((s) => s.href);
+  assert.equal(link?.href, "https://gitlab.com/-/profile/applications", "period not part of href");
+  assert.equal(segs[segs.length - 1].text, ".", "period kept as trailing text");
+});
+
+test("#5486 plain text with no URL is a single text segment", () => {
+  assert.deepEqual(linkifyText("no links here"), [{ text: "no links here" }]);
+  assert.deepEqual(linkifyText(""), []);
+  assert.deepEqual(linkifyText(null as unknown as string), []);
+});

--- a/tests/unit/validation-badge-unsupported-5442.test.ts
+++ b/tests/unit/validation-badge-unsupported-5442.test.ts
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// #5442 — LMArena (and any provider with no live validator) returns
+// `{ unsupported: true }` from /api/providers/validate; Save still succeeds.
+// The Add-API-Key modal only had success/failed states, so it rendered a red
+// "Invalid" badge for those providers even though the key was saved fine. The
+// "unsupported" result now maps to a neutral info "N/A" badge, not "Invalid".
+const { validationBadgeProps } = await import(
+  "../../src/app/(dashboard)/dashboard/providers/[id]/providerPageHelpers.ts"
+);
+
+test("#5442 unsupported validation → neutral N/A badge, not red Invalid", () => {
+  assert.deepEqual(validationBadgeProps("unsupported"), {
+    variant: "info",
+    labelKey: "notApplicable",
+  });
+});
+
+test("#5442 success and failed badges are unchanged", () => {
+  assert.deepEqual(validationBadgeProps("success"), { variant: "success", labelKey: "valid" });
+  assert.deepEqual(validationBadgeProps("failed"), { variant: "error", labelKey: "invalid" });
+  // Any other/unknown result defaults to the error badge (fail-safe).
+  assert.deepEqual(validationBadgeProps("whatever"), { variant: "error", labelKey: "invalid" });
+});


### PR DESCRIPTION
Closes #5442, closes #5486.

- **#5442 LMArena** — a provider with no live validator returns `{ unsupported: true }` from `/api/providers/validate` and **Save still succeeds**, but the Add-API-Key modal only had `success`/`failed` states, so it rendered a red **"Invalid"** badge every time (confusing — the key was saved fine). An `unsupported` result now maps to a neutral **info "N/A"** badge via the pure leaf `validationBadgeProps()`; both validate handlers map `data.unsupported` to it. (The reporter's `freeKeyAllModels` / cookie-format claims were FALSE and are not touched.)
- **#5486 GitLab Duo** — the OAuth setup error already carries the full instructions (register an app at `https://gitlab.com/-/profile/applications`, redirect URI, scopes, env vars) but the OAuth **error step rendered it as dead red text**. New `LinkifiedText` component (backed by a ReDoS-safe `linkify` util) makes any http(s) URL in an OAuth error **clickable**. The `kilo-duplicate` label was a mistriage (#2013 only added the env vars to `.env.example`; this is a distinct UX gap) and is removed.

## Validation (Hard Rule #18)
- `tests/unit/validation-badge-unsupported-5442.test.ts` — unsupported→info/N-A, success/failed unchanged.
- `tests/unit/oauth-error-linkify-5486.test.ts` — GitLab Duo URL linkified, trailing punctuation peeled, plain text untouched.
- `typecheck:core` clean. Frozen god-files kept within cap (AddApiKeyModal 868/868, OAuthModal 968/969).

No CHANGELOG bullet — reconciled at release time (per operator).