### PR TITLE
fix(system): route in-app auto-update npm calls through the win32 shell helper (#5542)

### DIFF
--- a/src/app/api/system/version/route.ts
+++ b/src/app/api/system/version/route.ts
@@ -19,6 +19,10 @@ import {
 import { NEWS_JSON_URL, parseActiveNewsPayload } from "@/shared/utils/releaseNotes";
 import { isNewer, resolveLatestVersion } from "@/lib/system/versionCheck";
 import { resolveGlobalOmniroutePath } from "@/lib/system/globalPackagePath";
+// #5542 — On Windows npm is `npm.cmd`; Node ≥24 refuses to execFile a `.cmd` without
+// a shell (nodejs/node#52554 → "spawn npm ENOENT"). buildNpmExecOptions enables the
+// shell on win32 only; SERVICE_VERSION_PATTERN keeps the shell-joined version safe.
+import { buildNpmExecOptions, SERVICE_VERSION_PATTERN } from "@/lib/services/installers/utils";
 
 const execFileAsync = promisify(execFile);
 
@@ -208,10 +212,11 @@ export async function POST(req: NextRequest) {
             status: "running",
             message: "Installing dependencies...",
           });
-          await execFileAsync("npm", ["install", "--legacy-peer-deps"], {
-            timeout: 300_000,
-            cwd: PROJECT_ROOT,
-          });
+          await execFileAsync(
+            "npm",
+            ["install", "--legacy-peer-deps"],
+            buildNpmExecOptions(process.platform, { cwd: PROJECT_ROOT, timeoutMs: 300_000 })
+          );
           send({ step: "rebuild", status: "done", message: "Dependencies installed" });
 
           try {
@@ -228,10 +233,11 @@ export async function POST(req: NextRequest) {
             status: "running",
             message: "Building application...",
           });
-          await execFileAsync("npm", ["run", "build"], {
-            timeout: 600_000,
-            cwd: PROJECT_ROOT,
-          });
+          await execFileAsync(
+            "npm",
+            ["run", "build"],
+            buildNpmExecOptions(process.platform, { cwd: PROJECT_ROOT, timeoutMs: 600_000 })
+          );
           send({ step: "rebuild", status: "done", message: "Build complete" });
 
           send({ step: "restart", status: "running", message: "Restarting service..." });
@@ -286,14 +292,19 @@ export async function POST(req: NextRequest) {
 
       try {
         // Step 1: Install
+        // #5542 — buildNpmExecOptions enables the shell on win32 (npm.cmd), which
+        // shell-joins argv, so the version spec must be metacharacter-free before it
+        // reaches the command line (Hard Rule #13).
+        if (!SERVICE_VERSION_PATTERN.test(latest)) {
+          send({ step: "install", status: "error", message: "Invalid version format" });
+          controller.close();
+          return;
+        }
         send({ step: "install", status: "running", message: `Installing omniroute@${latest}...` });
           await execFileAsync(
             "npm",
             ["install", "-g", `omniroute@${latest}`, "--ignore-scripts", "--legacy-peer-deps"],
-            {
-              timeout: 300000,
-              cwd: PROJECT_ROOT,
-            }
+            buildNpmExecOptions(process.platform, { cwd: PROJECT_ROOT, timeoutMs: 300_000 })
           );
         send({ step: "install", status: "done", message: `Installed omniroute@${latest}` });
 
@@ -307,10 +318,7 @@ export async function POST(req: NextRequest) {
         await execFileAsync(
           "npm",
           ["rebuild", "better-sqlite3"],
-          {
-            cwd: omniPath,
-            timeout: 120000,
-          }
+          buildNpmExecOptions(process.platform, { cwd: omniPath, timeoutMs: 120_000 })
         );
         send({ step: "rebuild", status: "done", message: "Native modules rebuilt" });
 

--- a/src/lib/system/versionCheck.ts
+++ b/src/lib/system/versionCheck.ts
@@ -19,6 +19,7 @@
 import { execFile } from "child_process";
 import { promisify } from "util";
 import { createLogger } from "@/shared/utils/logger";
+import { buildNpmExecOptions } from "@/lib/services/installers/utils";
 
 const execFileAsync = promisify(execFile);
 const log = createLogger("system/versionCheck");
@@ -71,9 +72,13 @@ export function isNewer(latest: string | null | undefined, current: string): boo
 /** Latest published version via the `npm` CLI (fast when npm is on PATH, e.g. source installs). */
 export async function getLatestVersionFromNpmCli(): Promise<string | null> {
   try {
-    const { stdout } = await execFileAsync("npm", ["info", "omniroute", "version", "--json"], {
-      timeout: LOOKUP_TIMEOUT_MS,
-    });
+    // #5542 — win32 npm is npm.cmd; execFile without a shell throws "spawn npm ENOENT"
+    // on Node ≥24 (nodejs/node#52554). buildNpmExecOptions enables the shell on win32.
+    const { stdout } = await execFileAsync(
+      "npm",
+      ["info", "omniroute", "version", "--json"],
+      buildNpmExecOptions(process.platform, { timeoutMs: LOOKUP_TIMEOUT_MS })
+    );
     const parsed = JSON.parse(String(stdout).trim());
     return typeof parsed === "string" && parsed ? parsed : null;
   } catch {

--- a/tests/unit/autoupdate-npm-win32-5542.test.ts
+++ b/tests/unit/autoupdate-npm-win32-5542.test.ts
@@ -1,0 +1,57 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+// #5542 — On Windows, npm is `npm.cmd`; Node ≥24 refuses to execFile a `.cmd`
+// without a shell (nodejs/node#52554), so the in-app auto-update flow threw
+// "spawn npm ENOENT" for the version lookup, dependency install, global install,
+// and native rebuild. Those npm calls now go through buildNpmExecOptions (the
+// same win32-shell helper the embedded-services installer uses, fix #5379).
+const { buildNpmExecOptions, SERVICE_VERSION_PATTERN } = await import(
+  "../../src/lib/services/installers/utils.ts"
+);
+
+test("#5542 npm exec options enable the shell on win32 (resolves npm.cmd → no ENOENT)", () => {
+  const win = buildNpmExecOptions("win32", { cwd: "/x", timeoutMs: 1000 });
+  assert.equal(win.shell, true, "win32 must enable the shell so npm.cmd resolves");
+  assert.equal(win.timeout, 1000);
+  assert.equal(win.cwd, "/x");
+
+  const linux = buildNpmExecOptions("linux", { cwd: "/x", timeoutMs: 1000 });
+  assert.notEqual(linux.shell, true, "non-win32 must not enable the shell");
+});
+
+test("#5542 the update version spec is validated before it is shell-joined (Hard Rule #13)", () => {
+  assert.ok(SERVICE_VERSION_PATTERN.test("3.8.43"));
+  assert.ok(SERVICE_VERSION_PATTERN.test("3.8.43-beta.1"));
+  assert.ok(!SERVICE_VERSION_PATTERN.test("1.0.0; rm -rf /"));
+  assert.ok(!SERVICE_VERSION_PATTERN.test("$(whoami)"));
+  assert.ok(!SERVICE_VERSION_PATTERN.test("1.0 && curl evil"));
+});
+
+test("#5542 the auto-update npm call sites route through buildNpmExecOptions", () => {
+  const routeSrc = fs.readFileSync(
+    new URL("../../src/app/api/system/version/route.ts", import.meta.url),
+    "utf8"
+  );
+  const checkSrc = fs.readFileSync(
+    new URL("../../src/lib/system/versionCheck.ts", import.meta.url),
+    "utf8"
+  );
+  assert.ok(routeSrc.includes("buildNpmExecOptions"), "version route must use the win32-shell helper");
+  assert.ok(checkSrc.includes("buildNpmExecOptions"), "versionCheck must use the win32-shell helper");
+  // The global install spec must be guarded before it reaches the shell.
+  assert.ok(
+    routeSrc.includes("SERVICE_VERSION_PATTERN.test(latest)"),
+    "version route must validate the version spec before shell-joining it"
+  );
+  // Every npm invocation in the route must pass buildNpmExecOptions (not a bare
+  // inline options object that would lack the win32 shell).
+  const npmCalls = routeSrc.match(/execFileAsync\(\s*\n?\s*"npm",/g) || [];
+  const npmViaHelper = routeSrc.match(/"npm",[\s\S]{0,120}?buildNpmExecOptions\(/g) || [];
+  assert.equal(
+    npmViaHelper.length,
+    npmCalls.length,
+    `all ${npmCalls.length} npm calls must route through buildNpmExecOptions`
+  );
+});


### PR DESCRIPTION
Closes #5542.

## Problem
The in-app auto-update flow (`POST /api/system/version`) and its version lookup called `execFileAsync("npm", …)` **directly**. On Windows `npm` is `npm.cmd`, and Node ≥24 refuses to `execFile` a `.cmd` without a shell (nodejs/node#52554), so the update threw **`spawn npm ENOENT`** — the exact error in the issue. Affected calls: `versionCheck.getLatestVersionFromNpmCli` (`npm info`), the dependency install, the global install (`npm install -g omniroute@…`), and the native rebuild.

## Fix
Route every npm call through **`buildNpmExecOptions`** — the same win32-shell helper the embedded-services installer already uses (fix #5379, tested by `runNpm-shell-5379.test.ts`): it sets `shell: true` on win32 only so `npm.cmd` resolves, and is a no-op on Linux/macOS. The global-install version spec is validated with **`SERVICE_VERSION_PATTERN`** before it is shell-joined (Hard Rule #13 — enabling the shell means argv is shell-interpreted).

This is **not** the pnpm/npx substitution the issue proposed — that is the wrong direction for an `npm install -g` flow already solved elsewhere in-repo.

## Validation (Hard Rule #18)
- `tests/unit/autoupdate-npm-win32-5542.test.ts`: win32 → `shell:true` / non-win32 → no shell; version pattern accepts semver + rejects shell-injection specs; source-guard that all npm call sites route through `buildNpmExecOptions` + the version guard is present.
- `typecheck:core` clean. (Windows-runtime behavior itself is covered by the already-tested helper; #5543 "crash on startup" was triaged NOT-A-BUG — no `process.exit` in the update path.)

No CHANGELOG bullet — reconciled at release time (per operator).