### PR TITLE
feat(services): promote Bifrost to embedded/supervised service (#5670)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - **feat(providers):** add optional client-identity header profiles for compatible nodes — preset User-Agent/fingerprint headers (e.g. matching a known CLI) merged into the existing customHeaders field.
 - **feat(xai):** surface Grok usage on the quota dashboard via local usage-history aggregation. (thanks @DevEstacion)
 - **feat(services):** add **Mux** (`coder/mux`) as a managed embedded service — install/start/stop/restart/logs lifecycle + dashboard tab, loopback-only API, `127.0.0.1`-bound with the auth token passed via env (never argv). Ported from upstream 9router#1802. (thanks @Ansh7473)
+- **feat(services):** promote **Bifrost** (`@maximhq/bifrost`) to a supervised embedded service ([#5670](https://github.com/diegosouzapw/OmniRoute/issues/5670)) — full install/start/stop/restart/update/status/auto-start lifecycle + dashboard tab, loopback-only API (hard rule #17). When a supervised Bifrost is running and `BIFROST_BASE_URL` is unset, the relay route auto-selects it as the routing backend (`getBifrostRoutingConfig()`); an explicit `BIFROST_BASE_URL` always takes precedence.
 
 ### 🔧 Bug Fixes
 

--- a/docs/frameworks/EMBEDDED-SERVICES.md
+++ b/docs/frameworks/EMBEDDED-SERVICES.md
@@ -1,13 +1,13 @@
 ---
 title: "Embedded Services"
-description: "Reference for 9Router, CLIProxyAPI, and Mux"
+description: "Reference for 9Router, CLIProxyAPI, Mux, and Bifrost"
 ---
 
 # Embedded Services
 
 > **Version:** v3.8.44
 > **Last updated:** 2026-07-03
-> **Audience:** Engineers adding, maintaining, or debugging embedded services (9Router, CLIProxyAPI, Mux).
+> **Audience:** Engineers adding, maintaining, or debugging embedded services (9Router, CLIProxyAPI, Mux, Bifrost).
 
 Embedded services are locally-installed process sidecar tools that OmniRoute installs, supervises, and
 exposes as first-class routing targets. Unlike external providers (which are reached over the internet
@@ -32,19 +32,20 @@ via API keys), embedded services run on the same machine as OmniRoute and commun
 
 ### Why embedded services?
 
-Three services are embedded as of v3.8.44:
+Four services are embedded as of v3.8.44:
 
 | Service         | npm package                                    | Default port | Purpose                                                                                                          |
 | --------------- | ----------------------------------------------- | :----------: | ------------------------------------------------------------------------------------------------------------------ |
 | **9Router**     | `9router`                                      |    20130     | AI router that OmniRoute can use as a sub-provider. Models exposed as `9router/{sub}/{model}`                     |
 | **CLIProxyAPI** | `@anthropic/cli-proxy` (via `cliproxy` binary) |     auto     | Local proxy adapter for Anthropic CLI auth flows. Provides fallback routing when OAuth tokens expire              |
 | **Mux**         | `mux` (headless `mux server`)                  |     8322     | Local agent-orchestration daemon (coder/mux). Lifecycle-managed only — not a routing target (no LLM proxying).   |
+| **Bifrost**     | `@maximhq/bifrost`                             |    8080      | Go AI-gateway relay backend. When running, auto-selected by the relay route (`/v1/relay/`)                       |
 
-All three follow the same supervisory model:
+All four follow the same supervisory model:
 
 - OmniRoute installs them under `DATA_DIR/services/{name}/` (isolated from OmniRoute's own `package.json`)
 - OmniRoute spawns and monitors them as child processes
-- OmniRoute injects an ephemeral API key into the child's environment and rotates it without downtime
+- OmniRoute injects an ephemeral API key into the child's environment and rotates it without downtime (where applicable)
 - All management routes (`/api/services/*`) are **LOCAL_ONLY** — accessible only from loopback (hard rule #17)
 
 ### Key decisions (from design plan)
@@ -445,7 +446,7 @@ config) and `status` includes fewer fields.
 | `POST` | `/api/services/cliproxy/auto-start` | Toggle auto-start                    |
 
 The shared `GET /api/services/{name}/logs` endpoint (see §4.1) works for all
-three services using the `[name]` dynamic segment.
+four services using the `[name]` dynamic segment.
 
 ---
 
@@ -466,6 +467,30 @@ there is no dedicated rotation endpoint yet). Mux is lifecycle-managed only: unl
 | `POST` | `/api/services/mux/update`     | Update to newer npm version          |
 | `GET`  | `/api/services/mux/status`     | Live + DB status                     |
 | `POST` | `/api/services/mux/auto-start` | Toggle auto-start                    |
+
+---
+
+### 4.4 Bifrost endpoints (7 routes)
+
+Bifrost is a Go AI-gateway relay backend (`@maximhq/bifrost`). It uses the same
+endpoint shape as CLIProxyAPI (no `rotate-key` — Bifrost manages its own provider
+keys in `config.json` under its `-app-dir`).
+
+| Method | Path                               | Description                                            |
+| ------ | ---------------------------------- | ------------------------------------------------------ |
+| `POST` | `/api/services/bifrost/install`    | Install Bifrost from npm (`@maximhq/bifrost`)          |
+| `POST` | `/api/services/bifrost/start`      | Start Bifrost on port 8080 (default)                   |
+| `POST` | `/api/services/bifrost/stop`       | Stop Bifrost                                           |
+| `POST` | `/api/services/bifrost/restart`    | Restart Bifrost                                        |
+| `POST` | `/api/services/bifrost/update`     | Update to newer version                                |
+| `GET`  | `/api/services/bifrost/status`     | Live + DB status                                       |
+| `POST` | `/api/services/bifrost/auto-start` | Toggle auto-start                                      |
+| `GET`  | `/api/services/bifrost/logs`       | SSE log tail (via shared `[name]/logs` dynamic route)  |
+
+**Routing wiring:** When `BIFROST_BASE_URL` is unset and the supervised Bifrost
+instance is running, `getBifrostRoutingConfig()` (in `routingBackend.ts`) automatically
+uses `http://127.0.0.1:{port}` as the relay base URL. Explicit `BIFROST_BASE_URL` env
+always takes precedence.
 
 ---
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -3604,6 +3604,116 @@ paths:
         "400":
           description: Invalid request body
 
+  /api/services/bifrost/install:
+    post:
+      tags: [Embedded Services]
+      summary: Install Bifrost
+      description: >-
+        Installs the `@maximhq/bifrost` npm package under DATA_DIR/services/bifrost/.
+        The package downloads the Go binary on first run. Accepts an optional `version`
+        field (semver or `latest`). **LOCAL_ONLY** — loopback only.
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                version:
+                  type: string
+                  default: latest
+      responses:
+        "200":
+          description: Installation result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  installedVersion:
+                    type: string
+                  installPath:
+                    type: string
+                  durationMs:
+                    type: number
+
+  /api/services/bifrost/start:
+    post:
+      tags: [Embedded Services]
+      summary: Start Bifrost
+      description: Starts the supervised Bifrost process. **LOCAL_ONLY** — loopback only.
+      responses:
+        "200":
+          description: Service status after start
+        "409":
+          description: Bifrost is not installed
+
+  /api/services/bifrost/stop:
+    post:
+      tags: [Embedded Services]
+      summary: Stop Bifrost
+      description: Stops the supervised Bifrost process. **LOCAL_ONLY** — loopback only.
+      responses:
+        "200":
+          description: Service status after stop
+
+  /api/services/bifrost/restart:
+    post:
+      tags: [Embedded Services]
+      summary: Restart Bifrost
+      description: Restarts the supervised Bifrost process. **LOCAL_ONLY** — loopback only.
+      responses:
+        "200":
+          description: Service status after restart
+        "409":
+          description: Bifrost is not installed
+
+  /api/services/bifrost/update:
+    post:
+      tags: [Embedded Services]
+      summary: Update Bifrost
+      description: >-
+        Updates Bifrost to the latest npm version. Stops the running process,
+        installs the new version, and restarts if it was previously running.
+        **LOCAL_ONLY** — loopback only.
+      responses:
+        "200":
+          description: Update result
+
+  /api/services/bifrost/status:
+    get:
+      tags: [Embedded Services]
+      summary: Get Bifrost status
+      description: Returns live and DB status for the supervised Bifrost service. **LOCAL_ONLY** — loopback only.
+      responses:
+        "200":
+          description: Bifrost service status
+
+  /api/services/bifrost/auto-start:
+    post:
+      tags: [Embedded Services]
+      summary: Toggle Bifrost auto-start
+      description: >-
+        When enabled, Bifrost starts automatically on the next OmniRoute boot.
+        **LOCAL_ONLY** — loopback only.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [enabled]
+              properties:
+                enabled:
+                  type: boolean
+      responses:
+        "204":
+          description: Auto-start flag updated
+        "400":
+          description: Invalid request body
+
   /api/services/{name}/logs:
     get:
       tags: [Embedded Services]

--- a/src/app/(dashboard)/dashboard/providers/services/page.tsx
+++ b/src/app/(dashboard)/dashboard/providers/services/page.tsx
@@ -5,13 +5,15 @@ import { cn } from "@/shared/utils/cn";
 import { CliproxyServiceTab } from "./tabs/CliproxyServiceTab";
 import { NinerouterServiceTab } from "./tabs/NinerouterServiceTab";
 import { MuxServiceTab } from "./tabs/MuxServiceTab";
+import { BifrostServiceTab } from "./tabs/BifrostServiceTab";
 
-type Tab = "cliproxy" | "9router" | "mux";
+type Tab = "cliproxy" | "9router" | "mux" | "bifrost";
 
 const TABS: { id: Tab; label: string; icon: string }[] = [
   { id: "cliproxy", label: "CLIProxyAPI", icon: "swap_horiz" },
   { id: "9router", label: "9Router", icon: "route" },
   { id: "mux", label: "Mux", icon: "hub" },
+  { id: "bifrost", label: "Bifrost", icon: "bolt" },
 ];
 
 export default function ServicesPage() {
@@ -28,8 +30,8 @@ export default function ServicesPage() {
       <header>
         <h1 className="text-xl font-semibold text-text-primary">Embedded Services</h1>
         <p className="text-sm text-text-muted mt-1">
-          External engines managed on demand — CLIProxyAPI, 9Router, and Mux. Accessible on loopback
-          only.
+          External engines managed on demand — CLIProxyAPI, 9Router, Mux, and Bifrost. Accessible on
+          loopback only.
         </p>
       </header>
 
@@ -59,6 +61,7 @@ export default function ServicesPage() {
         {active === "cliproxy" && <CliproxyServiceTab />}
         {active === "9router" && <NinerouterServiceTab />}
         {active === "mux" && <MuxServiceTab />}
+        {active === "bifrost" && <BifrostServiceTab />}
       </div>
     </div>
   );

--- a/src/app/(dashboard)/dashboard/providers/services/tabs/BifrostServiceTab.tsx
+++ b/src/app/(dashboard)/dashboard/providers/services/tabs/BifrostServiceTab.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { ServiceStatusCard } from "../components/ServiceStatusCard";
+import { ServiceLifecycleButtons } from "../components/ServiceLifecycleButtons";
+import { ServiceLogsPanel } from "../components/ServiceLogsPanel";
+import { AutoStartToggle } from "../components/AutoStartToggle";
+
+const NAME = "bifrost";
+
+export function BifrostServiceTab() {
+  return (
+    <div className="space-y-4">
+      <ServiceStatusCard name={NAME} />
+      <ServiceLifecycleButtons name={NAME} />
+      <AutoStartToggle
+        name={NAME}
+        description="Launch Bifrost automatically when OmniRoute starts"
+      />
+      <ServiceLogsPanel name={NAME} />
+    </div>
+  );
+}

--- a/src/app/api/services/[name]/logs/route.ts
+++ b/src/app/api/services/[name]/logs/route.ts
@@ -41,6 +41,10 @@ async function getOrInitNamedSupervisor(name: string) {
     const { getOrInitSupervisor } = await import("../../mux/_lib");
     return getOrInitSupervisor();
   }
+  if (name === "bifrost") {
+    const { getOrInitSupervisor } = await import("../../bifrost/_lib");
+    return getOrInitSupervisor();
+  }
 
   return null;
 }

--- a/src/app/api/services/bifrost/_lib.ts
+++ b/src/app/api/services/bifrost/_lib.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared helpers for /api/services/bifrost/* route handlers.
+ * Creates a supervisor on demand if bootstrap hasn't registered one yet.
+ */
+
+import { getSupervisor, registerSupervisor } from "@/lib/services/registry";
+import { ServiceSupervisor } from "@/lib/services/ServiceSupervisor";
+import { resolveSpawnArgs, BIFROST_DEFAULT_PORT } from "@/lib/services/installers/bifrost";
+
+const TOOL = "bifrost";
+const PORT = parseInt(process.env.BIFROST_PORT ?? String(BIFROST_DEFAULT_PORT), 10);
+
+export async function getOrInitSupervisor(): Promise<ServiceSupervisor> {
+  const existing = getSupervisor(TOOL);
+  if (existing) return existing;
+
+  const sup = new ServiceSupervisor({
+    tool: TOOL,
+    port: PORT,
+    spawnArgs: () => resolveSpawnArgs(PORT),
+    healthUrl: () => `http://127.0.0.1:${PORT}/v1/models`,
+    healthIntervalMs: 5_000,
+    stopTimeoutMs: 15_000,
+    logsBufferBytes: 5_242_880,
+  });
+
+  registerSupervisor(sup);
+  return sup;
+}

--- a/src/app/api/services/bifrost/auto-start/route.ts
+++ b/src/app/api/services/bifrost/auto-start/route.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+import { updateServiceField } from "@/lib/db/versionManager";
+import { createErrorResponse } from "@/lib/api/errorResponse";
+import { sanitizeErrorMessage } from "@omniroute/open-sse/utils/error";
+
+const BodySchema = z.object({ enabled: z.boolean() });
+
+export async function POST(request: Request): Promise<Response> {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return createErrorResponse({ status: 400, message: "Invalid JSON body" });
+  }
+
+  const parsed = BodySchema.safeParse(body);
+  if (!parsed.success) {
+    return createErrorResponse({ status: 400, message: parsed.error.message });
+  }
+
+  try {
+    await updateServiceField("bifrost", "autoStart", parsed.data.enabled);
+    return new Response(null, { status: 204 });
+  } catch (err) {
+    const msg = sanitizeErrorMessage(err instanceof Error ? err.message : String(err));
+    return createErrorResponse({ status: 500, message: msg });
+  }
+}

--- a/src/app/api/services/bifrost/install/route.ts
+++ b/src/app/api/services/bifrost/install/route.ts
@@ -1,0 +1,6 @@
+import { install } from "@/lib/services/installers/bifrost";
+import { handleServiceInstall } from "@/app/api/services/_shared/installRoute";
+
+export async function POST(request: Request): Promise<Response> {
+  return handleServiceInstall(request, install);
+}

--- a/src/app/api/services/bifrost/restart/route.ts
+++ b/src/app/api/services/bifrost/restart/route.ts
@@ -1,0 +1,22 @@
+import { getServiceRow } from "@/lib/db/versionManager";
+import { getOrInitSupervisor } from "../_lib";
+import { createErrorResponse } from "@/lib/api/errorResponse";
+import { sanitizeErrorMessage } from "@omniroute/open-sse/utils/error";
+
+const TOOL = "bifrost";
+
+export async function POST(): Promise<Response> {
+  try {
+    const row = await getServiceRow(TOOL);
+    if (!row || row.status === "not_installed") {
+      return createErrorResponse({ status: 409, message: "Bifrost não está instalado." });
+    }
+
+    const sup = await getOrInitSupervisor();
+    const status = await sup.restart();
+    return Response.json(status);
+  } catch (err) {
+    const msg = sanitizeErrorMessage(err instanceof Error ? err.message : String(err));
+    return createErrorResponse({ status: 503, message: msg });
+  }
+}

--- a/src/app/api/services/bifrost/start/route.ts
+++ b/src/app/api/services/bifrost/start/route.ts
@@ -1,0 +1,22 @@
+import { getServiceRow } from "@/lib/db/versionManager";
+import { getOrInitSupervisor } from "../_lib";
+import { createErrorResponse } from "@/lib/api/errorResponse";
+import { sanitizeErrorMessage } from "@omniroute/open-sse/utils/error";
+
+const TOOL = "bifrost";
+
+export async function POST(): Promise<Response> {
+  try {
+    const row = await getServiceRow(TOOL);
+    if (!row || row.status === "not_installed") {
+      return createErrorResponse({ status: 409, message: "Bifrost não está instalado." });
+    }
+
+    const sup = await getOrInitSupervisor();
+    const status = await sup.start();
+    return Response.json(status);
+  } catch (err) {
+    const msg = sanitizeErrorMessage(err instanceof Error ? err.message : String(err));
+    return createErrorResponse({ status: 503, message: msg });
+  }
+}

--- a/src/app/api/services/bifrost/status/route.ts
+++ b/src/app/api/services/bifrost/status/route.ts
@@ -1,0 +1,39 @@
+import { getSupervisor } from "@/lib/services/registry";
+import { getServiceRow } from "@/lib/db/versionManager";
+import {
+  getInstalledVersion,
+  getLatestVersion,
+  BIFROST_DEFAULT_PORT,
+} from "@/lib/services/installers/bifrost";
+import { createErrorResponse } from "@/lib/api/errorResponse";
+import { sanitizeErrorMessage } from "@omniroute/open-sse/utils/error";
+
+const TOOL = "bifrost";
+
+export async function GET(): Promise<Response> {
+  try {
+    const sup = getSupervisor(TOOL);
+    const row = await getServiceRow(TOOL);
+
+    const liveStatus = sup?.getStatus() ?? null;
+    const installedVersion = await getInstalledVersion();
+    const latestVersion = await getLatestVersion();
+
+    return Response.json({
+      tool: TOOL,
+      state: liveStatus?.state ?? row?.status ?? "unknown",
+      pid: liveStatus?.pid ?? null,
+      port: liveStatus?.port ?? row?.port ?? BIFROST_DEFAULT_PORT,
+      health: liveStatus?.health ?? "unknown",
+      startedAt: liveStatus?.startedAt ?? null,
+      lastError: liveStatus?.lastError ?? row?.errorMessage ?? null,
+      installedVersion: installedVersion ?? row?.installedVersion ?? null,
+      latestVersion,
+      updateAvailable: !!installedVersion && !!latestVersion && installedVersion !== latestVersion,
+      autoStart: row?.autoStart ?? false,
+    });
+  } catch (err) {
+    const msg = sanitizeErrorMessage(err instanceof Error ? err.message : String(err));
+    return createErrorResponse({ status: 500, message: msg });
+  }
+}

--- a/src/app/api/services/bifrost/stop/route.ts
+++ b/src/app/api/services/bifrost/stop/route.ts
@@ -1,0 +1,19 @@
+import { getSupervisor } from "@/lib/services/registry";
+import { createErrorResponse } from "@/lib/api/errorResponse";
+import { sanitizeErrorMessage } from "@omniroute/open-sse/utils/error";
+
+const TOOL = "bifrost";
+
+export async function POST(): Promise<Response> {
+  try {
+    const sup = getSupervisor(TOOL);
+    if (!sup) {
+      return Response.json({ tool: TOOL, state: "stopped" });
+    }
+    const status = await sup.stop();
+    return Response.json(status);
+  } catch (err) {
+    const msg = sanitizeErrorMessage(err instanceof Error ? err.message : String(err));
+    return createErrorResponse({ status: 500, message: msg });
+  }
+}

--- a/src/app/api/services/bifrost/update/route.ts
+++ b/src/app/api/services/bifrost/update/route.ts
@@ -1,0 +1,45 @@
+import { getSupervisor } from "@/lib/services/registry";
+import { getOrInitSupervisor } from "../_lib";
+import {
+  getInstalledVersion,
+  getLatestVersion,
+  update as downloadUpdate,
+} from "@/lib/services/installers/bifrost";
+import { createErrorResponse } from "@/lib/api/errorResponse";
+import { sanitizeErrorMessage } from "@omniroute/open-sse/utils/error";
+
+export async function POST(): Promise<Response> {
+  try {
+    const [installed, latest] = await Promise.all([getInstalledVersion(), getLatestVersion()]);
+
+    if (installed && latest && installed === latest) {
+      return Response.json({ updated: false, installedVersion: installed, latestVersion: latest });
+    }
+
+    const sup = getSupervisor("bifrost");
+    const wasRunning = sup?.getStatus().state === "running";
+
+    if (wasRunning && sup) {
+      await sup.stop();
+    }
+
+    const result = await downloadUpdate();
+
+    if (wasRunning) {
+      const freshSup = await getOrInitSupervisor();
+      await freshSup.start().catch((err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.warn("[Services] Could not restart bifrost after update:", msg);
+      });
+    }
+
+    return Response.json({
+      updated: true,
+      oldVersion: installed ?? null,
+      newVersion: result.installedVersion,
+    });
+  } catch (err) {
+    const msg = sanitizeErrorMessage(err instanceof Error ? err.message : String(err));
+    return createErrorResponse({ status: 500, message: msg });
+  }
+}

--- a/src/app/api/v1/relay/chat/completions/routingBackend.ts
+++ b/src/app/api/v1/relay/chat/completions/routingBackend.ts
@@ -1,3 +1,5 @@
+import { getSupervisor } from "@/lib/services/registry";
+
 export type RelayRoutingBackend = "ts" | "bifrost" | "auto";
 
 const VALID_BACKENDS = new Set<RelayRoutingBackend>(["ts", "bifrost", "auto"]);
@@ -26,11 +28,22 @@ export function getBifrostRoutingConfig(
   env: NodeJS.ProcessEnv = process.env
 ): BifrostRoutingConfig | null {
   const baseUrl = env.BIFROST_BASE_URL?.replace(/\/$/, "");
-  if (!baseUrl) return null;
+
+  // §4b: if BIFROST_BASE_URL is unset, check if supervised instance is running
+  let resolvedBaseUrl = baseUrl;
+  if (!resolvedBaseUrl) {
+    const sup = getSupervisor("bifrost");
+    if (sup?.getStatus().state === "running") {
+      resolvedBaseUrl = `http://127.0.0.1:${sup.getStatus().port}`;
+    }
+  }
+
+  if (!resolvedBaseUrl) return null;
+
   const timeoutMs = Number.parseInt(env.BIFROST_TIMEOUT_MS || "", 10);
 
   return {
-    baseUrl,
+    baseUrl: resolvedBaseUrl,
     apiKey: env.BIFROST_API_KEY || env.OMNIROUTE_BIFROST_KEY || undefined,
     timeoutMs: Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : 30000,
     streamingEnabled: env.BIFROST_STREAMING_ENABLED !== "0",

--- a/src/lib/db/migrations/115_bifrost_service.sql
+++ b/src/lib/db/migrations/115_bifrost_service.sql
@@ -1,0 +1,9 @@
+-- Migration 115: Seed version_manager row for Bifrost embedded service
+--
+-- Bifrost (npm @maximhq/bifrost) is promoted from env-only relay sidecar
+-- to a first-class supervised service (v3.8.43).
+-- The row is seeded with status='not_installed' so the bootstrap loop
+-- skips it until the user installs via /api/services/bifrost/install.
+
+INSERT OR IGNORE INTO version_manager (tool, status, port, auto_start, auto_update, provider_expose)
+VALUES ('bifrost', 'not_installed', 8080, 0, 1, 1);

--- a/src/lib/services/bootstrap.ts
+++ b/src/lib/services/bootstrap.ts
@@ -8,6 +8,10 @@ import {
   CLIPROXY_DEFAULT_PORT,
 } from "./installers/cliproxy";
 import { resolveSpawnArgs as muxSpawnArgs, MUX_DEFAULT_PORT } from "./installers/mux";
+import {
+  resolveSpawnArgs as bifrostSpawnArgs,
+  BIFROST_DEFAULT_PORT,
+} from "./installers/bifrost";
 import { getOrCreateApiKey } from "./apiKey";
 import { scheduleServiceModelSync, stopServiceModelSync } from "./modelSync";
 import type { ServiceStatus } from "./types";
@@ -15,6 +19,7 @@ import type { ServiceStatus } from "./types";
 const NINEROUTER_PORT = parseInt(process.env.NINEROUTER_PORT ?? "20130", 10);
 const CLIPROXY_PORT = parseInt(process.env.CLIPROXYAPI_PORT ?? String(CLIPROXY_DEFAULT_PORT), 10);
 const MUX_PORT = parseInt(process.env.MUX_SERVICE_PORT ?? String(MUX_DEFAULT_PORT), 10);
+const BIFROST_PORT = parseInt(process.env.BIFROST_PORT ?? String(BIFROST_DEFAULT_PORT), 10);
 
 type ServiceEntry = {
   tool: string;
@@ -54,6 +59,15 @@ const SERVICES: ServiceEntry[] = [
     logsBufferBytes: 5_242_880,
     needsApiKey: true,
   },
+  {
+    tool: "bifrost",
+    port: BIFROST_PORT,
+    healthPath: "/v1/models",
+    healthIntervalMs: 5_000,
+    stopTimeoutMs: 15_000,
+    logsBufferBytes: 5_242_880,
+    needsApiKey: false,
+  },
 ];
 
 function buildSpawnArgsFactory(
@@ -65,6 +79,9 @@ function buildSpawnArgsFactory(
   }
   if (cfg.tool === "mux") {
     return () => muxSpawnArgs(apiKey, cfg.port);
+  }
+  if (cfg.tool === "bifrost") {
+    return () => bifrostSpawnArgs(cfg.port);
   }
   return () => cliproxySpawnArgs(cfg.port);
 }

--- a/src/lib/services/installers/bifrost.ts
+++ b/src/lib/services/installers/bifrost.ts
@@ -1,0 +1,145 @@
+import fs from "node:fs";
+import path from "node:path";
+import { DATA_DIR } from "@/lib/db/core";
+import { upsertVersionManagerTool } from "@/lib/db/versionManager";
+import { runNpm, InstallError } from "./utils";
+
+export const BIFROST_PACKAGE = "@maximhq/bifrost";
+export const BIFROST_DEFAULT_PORT = 8080;
+export const BIFROST_INSTALL_DIR = path.join(DATA_DIR, "services", "bifrost");
+
+export interface InstallResult {
+  installedVersion: string;
+  installPath: string;
+  durationMs: number;
+}
+
+export interface SpawnArgs {
+  command: string;
+  args: string[];
+  env: NodeJS.ProcessEnv;
+  cwd: string;
+}
+
+// In-memory latest-version cache, 1h TTL
+let latestVersionCache: { value: string; expiresAt: number } | null = null;
+const VERSION_CACHE_TTL_MS = 3_600_000;
+
+function getInstalledPkgPath(): string {
+  return path.join(BIFROST_INSTALL_DIR, "node_modules", "@maximhq", "bifrost", "package.json");
+}
+
+function getBinPath(): string {
+  return path.join(BIFROST_INSTALL_DIR, "node_modules", "@maximhq", "bifrost", "bin.js");
+}
+
+function getInstalledVersionSync(): string | null {
+  try {
+    const raw = fs.readFileSync(getInstalledPkgPath(), "utf8");
+    const parsed = JSON.parse(raw) as { version?: string };
+    return typeof parsed.version === "string" ? parsed.version : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function getInstalledVersion(): Promise<string | null> {
+  return getInstalledVersionSync();
+}
+
+export async function getLatestVersion(): Promise<string | null> {
+  if (latestVersionCache && latestVersionCache.expiresAt > Date.now()) {
+    return latestVersionCache.value;
+  }
+  try {
+    const { stdout } = await runNpm(["view", BIFROST_PACKAGE, "version"], { timeoutMs: 30_000 });
+    const version = stdout.trim();
+    if (version) {
+      latestVersionCache = { value: version, expiresAt: Date.now() + VERSION_CACHE_TTL_MS };
+    }
+    return version || null;
+  } catch {
+    return null;
+  }
+}
+
+export async function install(version = "latest"): Promise<InstallResult> {
+  const startMs = Date.now();
+
+  // Create install dir + minimal package.json (idempotent)
+  fs.mkdirSync(BIFROST_INSTALL_DIR, { recursive: true });
+  const hostPkgPath = path.join(BIFROST_INSTALL_DIR, "package.json");
+  if (!fs.existsSync(hostPkgPath)) {
+    fs.writeFileSync(
+      hostPkgPath,
+      JSON.stringify(
+        { name: "omniroute-bifrost-host", version: "0.0.0", private: true, dependencies: {} },
+        null,
+        2
+      ),
+      "utf8"
+    );
+  }
+
+  await runNpm(
+    ["install", `${BIFROST_PACKAGE}@${version}`, "--omit=dev", "--no-audit", "--no-fund"],
+    // `--prefix` via `prefix` (→ npm_config_prefix env) so paths with spaces survive Windows shell
+    { cwd: BIFROST_INSTALL_DIR, prefix: BIFROST_INSTALL_DIR }
+  );
+
+  const installedVersion = await getInstalledVersion();
+  if (!installedVersion) {
+    throw new InstallError(
+      "Could not read installed version from node_modules/@maximhq/bifrost/package.json",
+      "Bifrost instalado mas versão não pôde ser lida.",
+      500
+    );
+  }
+
+  await upsertVersionManagerTool({
+    tool: "bifrost",
+    installedVersion,
+    binaryPath: getBinPath(),
+    status: "stopped",
+    port: BIFROST_DEFAULT_PORT,
+  });
+
+  // Invalidate cache so next getLatestVersion() re-fetches
+  latestVersionCache = null;
+
+  return {
+    installedVersion,
+    installPath: BIFROST_INSTALL_DIR,
+    durationMs: Date.now() - startMs,
+  };
+}
+
+export async function update(): Promise<InstallResult> {
+  return install("latest");
+}
+
+export function resolveSpawnArgs(port: number): SpawnArgs {
+  const binPath = getBinPath();
+  // Pin transport version to the installed npm version for reproducibility (spec §2b)
+  const transportVersion = getInstalledVersionSync() ?? "latest";
+
+  return {
+    command: process.execPath,
+    args: [
+      binPath,
+      "-port",
+      String(port),
+      "-host",
+      "127.0.0.1",
+      "-app-dir",
+      BIFROST_INSTALL_DIR,
+      "-log-level",
+      "warn",
+    ],
+    env: {
+      ...process.env,
+      BIFROST_TRANSPORT_VERSION: transportVersion,
+    },
+    cwd: BIFROST_INSTALL_DIR,
+  };
+}

--- a/tests/integration/services/full-lifecycle.int.test.ts
+++ b/tests/integration/services/full-lifecycle.int.test.ts
@@ -13,8 +13,10 @@
  * Prerequisites when running for real:
  *   - npm is in PATH
  *   - Network access to registry.npmjs.org
- *   - Ports 20130 (9router) and 8317 (cliproxy) are available
+ *   - Ports 20130 (9router), 8317 (cliproxy), and 8080 (bifrost) are available
  *   - DATA_DIR is writable
+ *   - Bifrost lazily downloads its Go binary from downloads.getmaxim.ai on first
+ *     start, so the bifrost block additionally needs network access to that host.
  */
 
 import { describe, it } from "node:test";
@@ -241,6 +243,86 @@ describe("cliproxy — full lifecycle (opt-in, RUN_SERVICES_INT=1)", () => {
   it("STEP 5: status returns stopped after stop", async (t) => {
     if (maybeSkip(t)) return;
     const final = await waitForState("/api/services/cliproxy/status", "stopped", 15_000);
+    assert.equal((final as Record<string, unknown>).state, "stopped");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// bifrost lifecycle
+// ---------------------------------------------------------------------------
+
+describe("bifrost — full lifecycle (opt-in, RUN_SERVICES_INT=1)", () => {
+  it("STEP 1: install bifrost (latest)", async (t) => {
+    if (maybeSkip(t)) return;
+    const { status, body } = await apiPost("/api/services/bifrost/install", {
+      version: "latest",
+    });
+    assert.ok(
+      status === 200,
+      `Expected 200 from install, got ${status}: ${JSON.stringify(body).slice(0, 300)}`
+    );
+    const b = body as Record<string, unknown>;
+    assert.ok(b.ok === true, "install response must have ok:true");
+    assert.ok(
+      typeof b.installedVersion === "string",
+      "install response must have installedVersion"
+    );
+    assert.ok(typeof b.durationMs === "number", "install response must have durationMs");
+  });
+
+  it("STEP 2: verify status is stopped after install", async (t) => {
+    if (maybeSkip(t)) return;
+    const { status, body } = await apiGet("/api/services/bifrost/status");
+    assert.equal(status, 200);
+    const b = body as Record<string, unknown>;
+    assert.equal(b.state, "stopped", `Expected stopped state after install, got: ${b.state}`);
+    assert.ok(
+      typeof b.installedVersion === "string",
+      "installedVersion should be set after install"
+    );
+  });
+
+  it("STEP 3: start bifrost", async (t) => {
+    if (maybeSkip(t)) return;
+    const { status, body } = await apiPost("/api/services/bifrost/start");
+    assert.ok(
+      status === 200,
+      `Expected 200 from start, got ${status}: ${JSON.stringify(body).slice(0, 300)}`
+    );
+    const b = body as Record<string, unknown>;
+    assert.ok(
+      ["starting", "running"].includes(b.state as string),
+      `Expected starting or running, got: ${b.state}`
+    );
+  });
+
+  it("STEP 4: wait for bifrost to become healthy (≤60s — Go binary download on first start)", async (t) => {
+    if (maybeSkip(t)) return;
+    // First start lazily downloads the Go binary, so allow a longer window than
+    // the 9router/cliproxy blocks (30s). Confirms open question §2b/§6 (Windows +
+    // headless boot) against a real download.
+    const finalStatus = await waitForState("/api/services/bifrost/status", "running", 60_000);
+    const b = finalStatus as Record<string, unknown>;
+    assert.equal(b.state, "running");
+    assert.equal(b.health, "healthy");
+    assert.ok(typeof b.pid === "number", "pid must be a number when running");
+    assert.equal(b.port, 8080, "bifrost must report its default port 8080");
+  });
+
+  it("STEP 5: stop bifrost", async (t) => {
+    if (maybeSkip(t)) return;
+    const { status, body } = await apiPost("/api/services/bifrost/stop");
+    assert.equal(status, 200);
+    const b = body as Record<string, unknown>;
+    assert.ok(
+      ["stopping", "stopped"].includes(b.state as string),
+      `Expected stopping or stopped, got: ${b.state}`
+    );
+  });
+
+  it("STEP 6: status returns stopped after stop", async (t) => {
+    if (maybeSkip(t)) return;
+    const final = await waitForState("/api/services/bifrost/status", "stopped", 15_000);
     assert.equal((final as Record<string, unknown>).state, "stopped");
   });
 });

--- a/tests/integration/services/route-guard-services.int.test.ts
+++ b/tests/integration/services/route-guard-services.int.test.ts
@@ -52,6 +52,18 @@ describe("isLocalOnlyPath — /api/services/* and /dashboard/providers/services/
     assert.equal(isLocalOnlyPath("/api/services/cliproxy/status"), true);
   });
 
+  it("returns true for /api/services/bifrost/start", () => {
+    assert.equal(isLocalOnlyPath("/api/services/bifrost/start"), true);
+  });
+
+  it("returns true for /api/services/bifrost/install", () => {
+    assert.equal(isLocalOnlyPath("/api/services/bifrost/install"), true);
+  });
+
+  it("returns true for /api/services/bifrost/status", () => {
+    assert.equal(isLocalOnlyPath("/api/services/bifrost/status"), true);
+  });
+
   it("returns true for /api/services/ (root prefix)", () => {
     assert.equal(isLocalOnlyPath("/api/services/"), true);
   });
@@ -109,6 +121,10 @@ describe("isLocalOnlyBypassableByManageScope — /api/services/* is NOT bypassab
 
   it("returns false for /api/services/cliproxy/install", () => {
     assert.equal(isLocalOnlyBypassableByManageScope("/api/services/cliproxy/install"), false);
+  });
+
+  it("returns false for /api/services/bifrost/install (spawn-capable)", () => {
+    assert.equal(isLocalOnlyBypassableByManageScope("/api/services/bifrost/install"), false);
   });
 });
 

--- a/tests/unit/services/bifrost-route-guard.test.ts
+++ b/tests/unit/services/bifrost-route-guard.test.ts
@@ -1,0 +1,27 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { isLocalOnlyPath } from "../../../src/server/authz/routeGuard.ts";
+
+test("isLocalOnlyPath: /api/services/bifrost/start is local-only", () => {
+  assert.equal(isLocalOnlyPath("/api/services/bifrost/start"), true);
+});
+
+test("isLocalOnlyPath: /api/services/bifrost/install is local-only", () => {
+  assert.equal(isLocalOnlyPath("/api/services/bifrost/install"), true);
+});
+
+test("isLocalOnlyPath: /api/services/bifrost/status is local-only", () => {
+  assert.equal(isLocalOnlyPath("/api/services/bifrost/status"), true);
+});
+
+test("isLocalOnlyPath: /api/services/bifrost/stop is local-only", () => {
+  assert.equal(isLocalOnlyPath("/api/services/bifrost/stop"), true);
+});
+
+test("isLocalOnlyPath: /api/services/bifrost/auto-start is local-only", () => {
+  assert.equal(isLocalOnlyPath("/api/services/bifrost/auto-start"), true);
+});
+
+test("isLocalOnlyPath: /api/services/bifrost/logs is local-only", () => {
+  assert.equal(isLocalOnlyPath("/api/services/bifrost/logs"), true);
+});

--- a/tests/unit/services/bifrost-routing-backend.test.ts
+++ b/tests/unit/services/bifrost-routing-backend.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Unit tests for §4b routing-layer wiring:
+ * getBifrostRoutingConfig uses supervised instance port when BIFROST_BASE_URL is unset.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerSupervisor, unregisterSupervisor } from "../../../src/lib/services/registry.ts";
+import { ServiceSupervisor } from "../../../src/lib/services/ServiceSupervisor.ts";
+import { getBifrostRoutingConfig } from "../../../src/app/api/v1/relay/chat/completions/routingBackend.ts";
+
+test("getBifrostRoutingConfig: returns null when BIFROST_BASE_URL unset and no supervised service", () => {
+  const result = getBifrostRoutingConfig({} as NodeJS.ProcessEnv);
+  assert.equal(result, null);
+});
+
+test("getBifrostRoutingConfig: uses BIFROST_BASE_URL when set (explicit env wins)", () => {
+  const result = getBifrostRoutingConfig({
+    BIFROST_BASE_URL: "http://localhost:9999",
+  } as NodeJS.ProcessEnv);
+  assert.ok(result !== null);
+  assert.equal(result?.baseUrl, "http://localhost:9999");
+});
+
+test("getBifrostRoutingConfig: uses supervised port when BIFROST_BASE_URL unset and bifrost running", () => {
+  // Register a stub supervisor whose getStatus() reports running on port 8080
+  const stub = {
+    getStatus: () => ({
+      tool: "bifrost",
+      state: "running" as const,
+      port: 8080,
+      health: "healthy" as const,
+      pid: 1234,
+      startedAt: new Date().toISOString(),
+      lastError: null,
+    }),
+  } as unknown as ServiceSupervisor;
+
+  registerSupervisor(stub);
+
+  try {
+    const result = getBifrostRoutingConfig({} as NodeJS.ProcessEnv);
+    assert.ok(result !== null, "should return config when supervised instance is running");
+    assert.equal(result?.baseUrl, "http://127.0.0.1:8080");
+    assert.equal(result?.enabled, true);
+  } finally {
+    unregisterSupervisor("bifrost");
+  }
+});
+
+test("getBifrostRoutingConfig: explicit BIFROST_BASE_URL overrides supervised port", () => {
+  const stub = {
+    getStatus: () => ({
+      tool: "bifrost",
+      state: "running" as const,
+      port: 8080,
+      health: "healthy" as const,
+      pid: 1234,
+      startedAt: new Date().toISOString(),
+      lastError: null,
+    }),
+  } as unknown as ServiceSupervisor;
+
+  registerSupervisor(stub);
+
+  try {
+    const result = getBifrostRoutingConfig({
+      BIFROST_BASE_URL: "http://remote-host:9999",
+    } as NodeJS.ProcessEnv);
+    assert.ok(result !== null);
+    // Explicit env wins
+    assert.equal(result?.baseUrl, "http://remote-host:9999");
+  } finally {
+    unregisterSupervisor("bifrost");
+  }
+});
+
+test("getBifrostRoutingConfig: stopped supervised instance does NOT provide baseUrl", () => {
+  const stub = {
+    getStatus: () => ({
+      tool: "bifrost",
+      state: "stopped" as const,
+      port: 8080,
+      health: "unknown" as const,
+      pid: null,
+      startedAt: null,
+      lastError: null,
+    }),
+  } as unknown as ServiceSupervisor;
+
+  registerSupervisor(stub);
+
+  try {
+    const result = getBifrostRoutingConfig({} as NodeJS.ProcessEnv);
+    assert.equal(result, null, "stopped supervisor should not yield a baseUrl");
+  } finally {
+    unregisterSupervisor("bifrost");
+  }
+});

--- a/tests/unit/services/installers/bifrost.test.ts
+++ b/tests/unit/services/installers/bifrost.test.ts
@@ -1,0 +1,152 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execSync } from "node:child_process";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-bifrost-installer-"));
+const FAKE_BIN_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-bifrost-fake-bin-"));
+
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.NODE_ENV = "test";
+process.env.DISABLE_SQLITE_AUTO_BACKUP = "true";
+
+const originalPath = process.env.PATH ?? "";
+process.env.PATH = `${FAKE_BIN_DIR}:${originalPath}`;
+
+const INSTALL_DIR = path.join(TEST_DATA_DIR, "services", "bifrost");
+const fakeNpmScript = `#!/bin/sh
+set -e
+CMD="$1"
+shift
+if [ "$CMD" = "install" ]; then
+  PREFIX=""
+  while [ $# -gt 0 ]; do
+    if [ "$1" = "--prefix" ]; then PREFIX="$2"; shift 2; else shift; fi
+  done
+  if [ -z "$PREFIX" ]; then PREFIX="$npm_config_prefix"; fi
+  PKG_DIR="$PREFIX/node_modules/@maximhq/bifrost"
+  mkdir -p "$PKG_DIR"
+  echo '{"name":"@maximhq/bifrost","version":"1.6.3"}' > "$PKG_DIR/package.json"
+  touch "$PKG_DIR/bin.js"
+  exit 0
+fi
+if [ "$CMD" = "view" ]; then
+  echo "1.6.3"
+  exit 0
+fi
+exit 0
+`;
+const fakeNpmPath = path.join(FAKE_BIN_DIR, "npm");
+fs.writeFileSync(fakeNpmPath, fakeNpmScript, { mode: 0o755 });
+
+execSync("which npm", { env: process.env });
+
+// DB bootstrap (must be before bifrost import due to db/core eager init)
+const core = await import("../../../../src/lib/db/core.ts");
+const db = core.getDbInstance();
+db.prepare(
+  `INSERT OR IGNORE INTO version_manager (tool, status, port, auto_start, auto_update, provider_expose)
+   VALUES ('bifrost', 'not_installed', 8080, 0, 1, 1)`
+).run();
+
+const {
+  install,
+  update,
+  getInstalledVersion,
+  getLatestVersion,
+  resolveSpawnArgs,
+  BIFROST_DEFAULT_PORT,
+  BIFROST_INSTALL_DIR,
+} = await import("../../../../src/lib/services/installers/bifrost.ts");
+
+test.after(() => {
+  process.env.PATH = originalPath;
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  fs.rmSync(FAKE_BIN_DIR, { recursive: true, force: true });
+});
+
+test("BIFROST_DEFAULT_PORT is 8080", () => {
+  assert.equal(BIFROST_DEFAULT_PORT, 8080);
+});
+
+test("install creates host package.json structure", async () => {
+  const result = await install("1.6.3");
+
+  const hostPkg = path.join(BIFROST_INSTALL_DIR, "package.json");
+  assert.ok(fs.existsSync(hostPkg), "host package.json should exist");
+  const parsedHost = JSON.parse(fs.readFileSync(hostPkg, "utf8")) as {
+    name: string;
+    private: boolean;
+  };
+  assert.equal(parsedHost.name, "omniroute-bifrost-host");
+  assert.ok(parsedHost.private);
+
+  assert.equal(result.installedVersion, "1.6.3");
+  assert.equal(result.installPath, BIFROST_INSTALL_DIR);
+  assert.ok(result.durationMs >= 0);
+});
+
+test("getInstalledVersion reads from node_modules/@maximhq/bifrost/package.json", async () => {
+  const ver = await getInstalledVersion();
+  assert.equal(ver, "1.6.3", "should read version from installed package");
+});
+
+test("update calls npm install with latest (idempotent)", async () => {
+  const result = await update();
+  assert.equal(result.installedVersion, "1.6.3");
+});
+
+test("getLatestVersion returns version string from npm view", async () => {
+  const ver = await getLatestVersion();
+  assert.equal(ver, "1.6.3");
+});
+
+test("resolveSpawnArgs shape: command is node, bin.js path, Go single-dash flags", () => {
+  const args = resolveSpawnArgs(8080);
+
+  assert.equal(args.command, process.execPath, "command must be current node binary");
+  assert.ok(args.args[0]?.includes("bin.js"), "args[0] should point to bin.js");
+
+  // Go-style single-dash flags
+  const portIdx = args.args.indexOf("-port");
+  assert.ok(portIdx !== -1, "must have -port flag");
+  assert.equal(args.args[portIdx + 1], "8080");
+
+  const hostIdx = args.args.indexOf("-host");
+  assert.ok(hostIdx !== -1, "must have -host flag");
+  assert.equal(args.args[hostIdx + 1], "127.0.0.1");
+
+  const appDirIdx = args.args.indexOf("-app-dir");
+  assert.ok(appDirIdx !== -1, "must have -app-dir flag");
+  assert.ok(args.args[appDirIdx + 1]?.includes("bifrost"), "-app-dir must point into bifrost dir");
+
+  const logLevelIdx = args.args.indexOf("-log-level");
+  assert.ok(logLevelIdx !== -1, "must have -log-level flag");
+  assert.equal(args.args[logLevelIdx + 1], "warn");
+
+  // BIFROST_TRANSPORT_VERSION must be set in env
+  assert.ok(
+    typeof args.env.BIFROST_TRANSPORT_VERSION === "string" &&
+      args.env.BIFROST_TRANSPORT_VERSION.length > 0,
+    "BIFROST_TRANSPORT_VERSION must be set in env"
+  );
+});
+
+test("resolveSpawnArgs with different port passes correct -port value", () => {
+  const args = resolveSpawnArgs(9090);
+  const portIdx = args.args.indexOf("-port");
+  assert.ok(portIdx !== -1);
+  assert.equal(args.args[portIdx + 1], "9090");
+});
+
+test("INSTALL_DIR constant points into DATA_DIR/services/bifrost", () => {
+  assert.ok(BIFROST_INSTALL_DIR.includes("bifrost"), "install dir must include 'bifrost'");
+  assert.ok(
+    BIFROST_INSTALL_DIR.startsWith(TEST_DATA_DIR),
+    "install dir must be under TEST_DATA_DIR"
+  );
+  assert.equal(INSTALL_DIR, BIFROST_INSTALL_DIR);
+});


### PR DESCRIPTION
## What

Promotes **Bifrost** (`@maximhq/bifrost` — the Go AI-gateway) from an **env-only relay sidecar** to a **first-class embedded/supervised service**, using the exact same model already shipped for `cliproxy` and `9router`: installer → supervisor → lifecycle APIs → dashboard tab → health/auto-start/logs/version row → local-only route guard.

This implements **item #2 of #5670**. The broader `RouterBackend` contract (items #1, #3–#5) and the native hot-path migration stay out of scope. The existing env-configured relay path (`/v1/relay/.../bifrost`, `OMNIROUTE_RELAY_BACKEND=bifrost`) is **kept unchanged** as a compatibility layer.

## Implementation (8 steps, mapped to the design spec)

1. **Installer** `src/lib/services/installers/bifrost.ts` — npm-style (mirrors `ninerouter.ts`, since `@maximhq/bifrost` is a thin wrapper that lazily downloads the Go binary): `install`/`update`/`getInstalledVersion`/`getLatestVersion` (1h cache) + `resolveSpawnArgs(port)` (Go single-dash flags `-port/-host 127.0.0.1/-app-dir/-log-level warn`, pinned `BIFROST_TRANSPORT_VERSION`). `needsApiKey=false`.
2. **Bootstrap** `src/lib/services/bootstrap.ts` — `SERVICES[]` entry (`healthPath: /v1/models`, 5s health interval, 15s stop timeout, 5 MiB log ring) + `buildSpawnArgsFactory` branch.
3. **Migration** `113_bifrost_service.sql` — seeds the `version_manager` row (`not_installed`, port 8080, `auto_update=1`, `provider_expose=1`).
4. **API** `src/app/api/services/bifrost/` — `_lib.ts` + 7 lifecycle routes (`install/start/stop/restart/update/status/auto-start`), verbatim from `cliproxy`, all errors via `createErrorResponse`/`sanitizeErrorMessage`.
5. **Shared logs** `[name]/logs/route.ts` — `bifrost` branch.
6. **Route guard** — no code change (`/api/services/` is already `LOCAL_ONLY`); a unit test asserts `isLocalOnlyPath("/api/services/bifrost/*") === true`.
7. **Dashboard** `BifrostServiceTab.tsx` + registration in the services `page.tsx` shell (Tab type + `TABS[]` + render block).
8. **Docs + tests** — `EMBEDDED-SERVICES.md` (§1 table + §4.3 endpoint table) + `openapi.yaml` (7 paths); unit tests + gated integration lifecycle.

**Relay auto-wiring:** when `BIFROST_BASE_URL` is unset **and** the supervised instance is `running`, `getBifrostRoutingConfig()` defaults the relay base URL to `http://127.0.0.1:{port}`. Explicit `BIFROST_BASE_URL` always wins.

## Tests

- **Unit (19, all green):** installer version-pattern + spawn-args shape (8), route-guard classification (6), §4b routing-backend defaulting incl. env-precedence + stopped cases (5).
- **Integration:** full bifrost lifecycle added to `full-lifecycle.int.test.ts`, gated by `RUN_SERVICES_INT=1` (does **not** run or download the Go binary in the default suite).
- Local gates green for the feature: `typecheck:core`, `lint` (0 errors), `check:cycles`, `test:unit` + `test:vitest` (no feature-attributable failures).

## ⚠️ Merge gate — VPS live-test required (Hard Rule #18 / spec §7)

The **actual Go-binary install → start → health** path can only be validated live (it downloads a per-platform binary from `downloads.getmaxim.ai` on first start). Per Hard Rule #18, this **must not be merged on "worked locally" alone** — run the gated integration harness on the VPS and record the result before merge:

```
RUN_SERVICES_INT=1 node --import tsx/esm --test tests/integration/services/full-lifecycle.int.test.ts
```

Open questions to close during that run: Windows binary download; headless boot with an empty `-app-dir`.

## Out of scope

`RouterBackend` unification, CLIProxyAPI ecosystem parity, and the hot-path migration (#5670 items #1, #3–#5).

---

Part of #5670.
