### PR TITLE
fix(db): preserve healthCheckInterval=0 across create/update

### DIFF
--- a/src/lib/db/providers.ts
+++ b/src/lib/db/providers.ts
@@ -399,6 +399,7 @@ export async function createProviderConnection(data: JsonRecord) {
     "perKeyProxyEnabled",
     "quotaWindowThresholds",
     "rateLimitOverrides",
+    "healthCheckInterval",
   ];
   for (const field of optionalFields) {
     if (data[field] !== undefined && data[field] !== null) {
@@ -491,7 +492,7 @@ function _insertConnectionRow(db: DbLike, conn: JsonRecord) {
     lastErrorSource: conn.lastErrorSource || null,
     backoffLevel: conn.backoffLevel || 0,
     rateLimitedUntil: conn.rateLimitedUntil || null,
-    healthCheckInterval: conn.healthCheckInterval || null,
+    healthCheckInterval: conn.healthCheckInterval ?? null,
     lastHealthCheckAt: conn.lastHealthCheckAt || null,
     lastTested: conn.lastTested || null,
     apiKey: conn.apiKey || null,
@@ -569,7 +570,7 @@ function _updateConnectionRow(db: DbLike, id: string, data: JsonRecord) {
     lastErrorSource: data.lastErrorSource || null,
     backoffLevel: data.backoffLevel || 0,
     rateLimitedUntil: data.rateLimitedUntil || null,
-    healthCheckInterval: data.healthCheckInterval || null,
+    healthCheckInterval: data.healthCheckInterval ?? null,
     lastHealthCheckAt: data.lastHealthCheckAt || null,
     lastTested: data.lastTested || null,
     apiKey: data.apiKey || null,

--- a/tests/unit/provider-connection-healthcheck-interval-zero.test.ts
+++ b/tests/unit/provider-connection-healthcheck-interval-zero.test.ts
@@ -1,0 +1,120 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+process.env.NODE_ENV = "test";
+
+const TEST_DATA_DIR = fs.mkdtempSync(
+  path.join(os.tmpdir(), "omniroute-hci-zero-")
+);
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const providersDb = await import("../../src/lib/db/providers.ts");
+
+async function resetStorage() {
+  core.resetDbInstance();
+  for (let attempt = 0; attempt < 10; attempt++) {
+    try {
+      if (fs.existsSync(TEST_DATA_DIR)) {
+        fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+      }
+      break;
+    } catch (error: any) {
+      if ((error?.code === "EBUSY" || error?.code === "EPERM") && attempt < 9) {
+        await new Promise((resolve) => setTimeout(resolve, 50 * (attempt + 1)));
+      } else {
+        throw error;
+      }
+    }
+  }
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+test.after(async () => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+// Regression: the `_insertConnectionRow` and `_updateConnectionRow` bind helpers
+// used `data.healthCheckInterval || null`, which collapses an explicit `0`
+// ("disable the proactive sweep", see src/lib/tokenHealthCheck.ts:
+// `if (intervalMin <= 0) return;`) to `null`. Once persisted as NULL, reading
+// the row back yields `undefined`/`null`, and the dashboard's
+// `connection.healthCheckInterval ?? 60` fallback renders a misleading `60`
+// instead of the user's chosen `0`. Using `?? null` preserves `0`.
+test("createProviderConnection persists healthCheckInterval=0 (not coerced to null)", async () => {
+  await resetStorage();
+
+  const connection = await providersDb.createProviderConnection({
+    provider: "antigravity",
+    authType: "oauth",
+    name: "Antigravity Disabled HC",
+    email: "hc-zero-create@example.com",
+    accessToken: "access-token",
+    refreshToken: "refresh-token",
+    expiresAt: new Date(Date.now() + 3600 * 1000).toISOString(),
+    tokenExpiresAt: new Date(Date.now() + 3600 * 1000).toISOString(),
+    testStatus: "active",
+    isActive: true,
+    healthCheckInterval: 0,
+  });
+
+  const stored = await providersDb.getProviderConnectionById((connection as any).id);
+  assert.equal(stored?.healthCheckInterval, 0);
+});
+
+test("updateProviderConnection persists healthCheckInterval=0 (not coerced to null)", async () => {
+  await resetStorage();
+
+  const connection = await providersDb.createProviderConnection({
+    provider: "antigravity",
+    authType: "oauth",
+    name: "Antigravity Default HC",
+    email: "hc-zero-update@example.com",
+    accessToken: "access-token",
+    refreshToken: "refresh-token",
+    expiresAt: new Date(Date.now() + 3600 * 1000).toISOString(),
+    tokenExpiresAt: new Date(Date.now() + 3600 * 1000).toISOString(),
+    testStatus: "active",
+    isActive: true,
+    // Start from the default (60). Updating to 0 below must round-trip.
+    healthCheckInterval: 60,
+  });
+
+  await providersDb.updateProviderConnection((connection as any).id, {
+    healthCheckInterval: 0,
+  });
+
+  const stored = await providersDb.getProviderConnectionById((connection as any).id);
+  assert.equal(stored?.healthCheckInterval, 0);
+});
+
+// Sanity: a nonzero value still round-trips (the `||` → `??` change preserves 60
+// because 60 is truthy, and `?? null` also keeps it).
+test("updateProviderConnection still persists a nonzero healthCheckInterval", async () => {
+  await resetStorage();
+
+  const connection = await providersDb.createProviderConnection({
+    provider: "antigravity",
+    authType: "oauth",
+    name: "Antigravity Nonzero HC",
+    email: "hc-nonzero-update@example.com",
+    accessToken: "access-token",
+    refreshToken: "refresh-token",
+    expiresAt: new Date(Date.now() + 3600 * 1000).toISOString(),
+    tokenExpiresAt: new Date(Date.now() + 3600 * 1000).toISOString(),
+    testStatus: "active",
+    isActive: true,
+    healthCheckInterval: 0,
+  });
+
+  await providersDb.updateProviderConnection((connection as any).id, {
+    healthCheckInterval: 60,
+  });
+
+  const stored = await providersDb.getProviderConnectionById((connection as any).id);
+  assert.equal(stored?.healthCheckInterval, 60);
+});


### PR DESCRIPTION
## Summary

- Fix the "Edit connection" **Health check (minutes)** field round-tripping `0` (the documented "disable the proactive sweep" sentinel, per `src/lib/tokenHealthCheck.ts`: `if (intervalMin <= 0) return;`) back to `60` in the UI.
- Two related bugs are repaired:
  - `_insertConnectionRow` / `_updateConnectionRow` bound `healthCheckInterval: x || null`, which coerced an explicit `0` to `NULL` (0 is falsy in JS). Reads then came back `undefined`, and the modal fallback `connection.healthCheckInterval ?? 60` rendered `60`, so the operator could not disable the sweep from the dashboard.
  - `createProviderConnection` builds the row from an `optionalFields` allowlist that never included `healthCheckInterval`, so any caller-supplied value (including `0`) never reached `_insertConnectionRow` and was always persisted as `NULL`.
- Switched `||` to `??` and added `healthCheckInterval` to the `optionalFields` allowlist in `createProviderConnection`.

## Related Issues

- Closes #
- Related to # (operator reports: GitHub Copilot OAuth device-flow connection lacks a refresh_token; the proactive health-check sweep force-marks it `expired` after a few minutes, but the UI cannot disable the per-connection sweep because `0` does not round-trip)

## Validation

- [x] `npm run lint` (0 errors; 6 `no-explicit-any` warnings in the new test file, matching the style of the adjacent OAuth connection DB tests like `tests/unit/oauth-connection-tokenexpiresat-5326.test.ts` and `tests/unit/token-health-no-refresh-token-expired-5326.test.ts`)
- [ ] `npm run test:unit` (not run in full locally; see Validation Notes below)
- [ ] `npm run test:coverage`
- [ ] Coverage is still `>= 60%` for statements, lines, functions, and branches
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below

## Tests Added Or Updated

- New: `tests/unit/provider-connection-healthcheck-interval-zero.test.ts` — three cases:
  - `createProviderConnection` persists `healthCheckInterval=0` (regression: previously stored `NULL`)
  - `updateProviderConnection` switches `60` → `0` and the `0` survives
  - `updateProviderConnection` persists a nonzero value (guard against over-correcting)
- No production behavior changed beyond the `||` → `??` fix and the allowlist addition.

## Coverage Notes

- This PR changes `src/lib/db/providers.ts` (`createProviderConnection` allowlist + two row binders). The new test file directly exercises both the create and update code paths against the real SQLite store, mirroring the patterns in `oauth-connection-tokenexpiresat-5326.test.ts` and `token-health-no-refresh-token-expired-5326.test.ts`.
- Adjacent existing regression suites were run locally and pass (33/33): `provider-connection-apikey-dedup`, `provider-connections-quota-threshold`, `provider-connections-ui-regression`, `oauth-connection-tokenexpiresat-5326`, `token-health-no-refresh-token-expired-5326`, `token-health-check`, plus the new file.
- Full `npm run test:unit` and `npm run test:coverage` were not run locally (long-running suite); CI on this PR will exercise them.

## Reviewer Notes

- The fix removes a silent breakage of the documented `0 = disabled` UI contract; there is no schema migration needed (the column already accepts `0` per `z.coerce.number().int().min(0).optional()` in `src/shared/validation/schemas/provider.ts` and the SQLite column is a plain INTEGER).
- The `??` change is consistent with the existing style in the same file for `maxConcurrent: conn.maxConcurrent ?? null` (line 507 / line 584), which was already treated as the "preserve 0" candidate but only for that one column.
- No feature flags, no migrations, no behavioral change when the caller does not pass `healthCheckInterval` (it stays `NULL` exactly as before).
- Symptom screened live against a wrapper deployment, where setting `health_check_interval=0` (workaround via direct DB write) was already known to silence the false `expired` status; with this fix the dashboard can set it directly.