### PR TITLE
fix(db): allowlist modelContextOverrides as intentionally-internal (#5798 release-green)

### DIFF
--- a/scripts/check/check-db-rules.mjs
+++ b/scripts/check/check-db-rules.mjs
@@ -56,6 +56,7 @@ export const INTENTIONALLY_INTERNAL = new Set([
   "healthCheck", // db-internal: importado por db/core.ts (runDbHealthCheck)
   "jsonMigration", // intentionally-internal: src/app/api/settings/import-json/route.ts
   "migrationRunner", // db-internal: importado por db/core.ts (runMigrations ao inicializar o DB)
+  "modelContextOverrides", // intentionally-internal (#5798): 2 callers em src/lib/ (contextWindowResolver.ts, modelCapabilities.ts) via import direto "@/lib/db/modelContextOverrides" — Feature 5004, consumido fora de db/ por design (Rule #2)
   "notion", // intentionally-internal: settings/notion API route + open-sse/mcp-server/tools/notionTools.ts
   "obsidian", // intentionally-internal: src/lib/obsidianSync.ts + settings/obsidian route + MCP obsidianTools.ts
   "optimizationSettings", // db-internal: imported by db/core.ts for SQLite PRAGMA application helpers that require the live adapter

--- a/tests/unit/check-db-rules-classification.test.ts
+++ b/tests/unit/check-db-rules-classification.test.ts
@@ -121,7 +121,7 @@ test("INTENTIONALLY_INTERNAL is exported from check-db-rules.mjs", () => {
   assert.ok(INTENTIONALLY_INTERNAL.size > 0, "INTENTIONALLY_INTERNAL must not be empty");
 });
 
-test("INTENTIONALLY_INTERNAL contains the expected 33 audited modules", () => {
+test("INTENTIONALLY_INTERNAL contains the expected 34 audited modules", () => {
   const expected = [
     "_rowTypes",
     "accessTokens",
@@ -140,6 +140,7 @@ test("INTENTIONALLY_INTERNAL contains the expected 33 audited modules", () => {
     "healthCheck",
     "jsonMigration",
     "migrationRunner",
+    "modelContextOverrides",
     "notion",
     "obsidian",
     "optimizationSettings",


### PR DESCRIPTION
Addresses one of the HARD failures in the release-green bot issue #5798.

## Problem
`check:db-rules` HARD-failed on `release/v3.8.43`: `src/lib/db/modelContextOverrides.ts` was neither re-exported by `localDb.ts` nor in the `INTENTIONALLY_INTERNAL` allowlist, but it IS imported directly from `src/lib/` (`contextWindowResolver.ts` + `modelCapabilities.ts`, Feature 5004).

## Fix
That direct-import-from-`src/lib/` pattern is the established convention (Rule #2 — never barrel-import from `localDb.ts`), and `modelContextOverrides` already has a sibling direct-consumer (`contextWindowResolver.ts:7`). So the correct, convention-matching fix is the **allowlist entry** (with a justification comment referencing #5798), not a re-export. The classification regression test is updated (33→34 audited modules; exact-contents assertion).

## Validation
- `node scripts/check/check-db-rules.mjs` → `OK (94 módulos db/, 60 re-exportados, 34 intencionalmente-internos)`, exit 0.
- `tests/unit/check-db-rules-classification.test.ts` + `check-db-rules.test.ts` green (incl. the "no NEW unexported db module" + "every allowlist entry has a real importer" guards).
- `typecheck:core` clean. No production source touched.

⚠️ Held from merge while `release-freeze` is active (Rule #21). Ready + green.