### PR TITLE
extracted CorrelationId observability changes from #5275

### DIFF
--- a/open-sse/utils/progressTracker.ts
+++ b/open-sse/utils/progressTracker.ts
@@ -90,6 +90,10 @@ export function createProgressTransform({
           }
         }
       },
+
+      cancel() {
+        clearInterval(intervalId);
+      },
     },
     { highWaterMark: 16384 },
     { highWaterMark: 16384 }

--- a/open-sse/utils/requestLogger.ts
+++ b/open-sse/utils/requestLogger.ts
@@ -270,7 +270,8 @@ function makeStreamChunkMethods(options: RequestLoggerOptions, captureChunks: bo
   const append = (arr: string[], bytes: { value: number; truncated: boolean }, chunk: string) => {
     if (!captureChunks) return;
     push();
-    appendBoundedChunk(arr, bytes, chunk, maxBytes, maxItems);
+    const ts = new Date().toISOString().slice(11, 23);
+    appendBoundedChunk(arr, bytes, `[${ts}] ${chunk}`, maxBytes, maxItems);
   };
 
   return {

--- a/open-sse/utils/sseHeartbeat.ts
+++ b/open-sse/utils/sseHeartbeat.ts
@@ -111,5 +111,9 @@ export function createSseHeartbeatTransform({
     flush() {
       stop();
     },
+
+    cancel() {
+      stop();
+    },
   });
 }

--- a/open-sse/utils/streamPayloadCollector.ts
+++ b/open-sse/utils/streamPayloadCollector.ts
@@ -3,6 +3,7 @@ import { FORMATS } from "../translator/formats.ts";
 
 type StructuredSSEEvent = {
   index: number;
+  timestamp?: string;
   event?: string;
   data: unknown;
 };
@@ -660,6 +661,7 @@ export function createStructuredSSECollector(options: CollectorOptions = {}) {
 
       const event: StructuredSSEEvent = {
         index: events.length + droppedEvents,
+        timestamp: new Date().toISOString(),
         data: cloneLogPayload(payload),
       };
 

--- a/src/app/api/usage/call-logs/route.ts
+++ b/src/app/api/usage/call-logs/route.ts
@@ -131,7 +131,6 @@ export async function GET(request: Request) {
     if (searchParams.get("combo")) filter.combo = searchParams.get("combo");
     if (searchParams.get("search")) filter.search = searchParams.get("search");
     if (searchParams.get("correlationId")) filter.correlationId = searchParams.get("correlationId");
-    if (searchParams.get("groupByCorrelationId")) filter.groupByCorrelationId = true;
     if (searchParams.get("limit")) filter.limit = parseInt(searchParams.get("limit"));
     if (searchParams.get("offset")) filter.offset = parseInt(searchParams.get("offset"));
 

--- a/src/app/api/usage/call-logs/route.ts
+++ b/src/app/api/usage/call-logs/route.ts
@@ -63,6 +63,7 @@ export function buildCallLogListRows({
       apiKeyName: null,
       comboName: null,
       error: null,
+      correlationId: detail.correlationId || null,
       active: true,
     });
   }
@@ -96,6 +97,7 @@ export function buildCallLogListRows({
       apiKeyName: null,
       comboName: null,
       error: detail.error || null,
+      correlationId: detail.correlationId || null,
       active: false,
       completed: true,
       completedAt: completedAt ? new Date(completedAt).toISOString() : null,
@@ -104,9 +106,12 @@ export function buildCallLogListRows({
   }
 
   return [...activeEntries, ...completedEntries, ...logs].sort((a, b) => {
-    const timestampDelta = rowTimestampMs(b) - rowTimestampMs(a);
-    if (timestampDelta !== 0) return timestampDelta;
-    return rowPriority(a) - rowPriority(b);
+    // Active requests always on top
+    const pa = rowPriority(a);
+    const pb = rowPriority(b);
+    if (pa !== pb) return pa - pb;
+    // Within same priority, newest first
+    return rowTimestampMs(b) - rowTimestampMs(a);
   });
 }
 
@@ -125,19 +130,29 @@ export async function GET(request: Request) {
     if (searchParams.get("apiKey")) filter.apiKey = searchParams.get("apiKey");
     if (searchParams.get("combo")) filter.combo = searchParams.get("combo");
     if (searchParams.get("search")) filter.search = searchParams.get("search");
+    if (searchParams.get("correlationId")) filter.correlationId = searchParams.get("correlationId");
+    if (searchParams.get("groupByCorrelationId")) filter.groupByCorrelationId = true;
     if (searchParams.get("limit")) filter.limit = parseInt(searchParams.get("limit"));
     if (searchParams.get("offset")) filter.offset = parseInt(searchParams.get("offset"));
 
     const [logs, connections] = await Promise.all([getCallLogs(filter), getProviderConnections()]);
 
-    return NextResponse.json(
-      buildCallLogListRows({
-        logs,
-        connections,
-        pendingDetails: getPendingById().values(),
-        completedDetails: getCompletedDetails().values(),
-      })
-    );
+    const rows = buildCallLogListRows({
+      logs,
+      connections,
+      pendingDetails: getPendingById().values(),
+      completedDetails: getCompletedDetails().values(),
+    });
+
+    // When correlationId filter is set, also filter in-memory entries
+    // (active + completed) that don't match — getCallLogs already filters
+    // the DB rows but activeEntries/completedEntries bypass it.
+    if (filter.correlationId) {
+      const cid = filter.correlationId;
+      return NextResponse.json(rows.filter((r: any) => r.correlationId === cid));
+    }
+
+    return NextResponse.json(rows);
   } catch (error) {
     console.error("[API ERROR] /api/usage/call-logs failed:", error);
     return NextResponse.json({ error: "Failed to fetch call logs" }, { status: 500 });

--- a/src/lib/db/core.ts
+++ b/src/lib/db/core.ts
@@ -346,6 +346,7 @@ const SCHEMA_SQL = `
   );
   CREATE INDEX IF NOT EXISTS idx_cl_timestamp ON call_logs(timestamp);
   CREATE INDEX IF NOT EXISTS idx_cl_status ON call_logs(status);
+  CREATE INDEX IF NOT EXISTS idx_cl_correlation_id ON call_logs(correlation_id);
 
   CREATE TABLE IF NOT EXISTS proxy_logs (
     id TEXT PRIMARY KEY,

--- a/src/lib/db/core.ts
+++ b/src/lib/db/core.ts
@@ -346,7 +346,6 @@ const SCHEMA_SQL = `
   );
   CREATE INDEX IF NOT EXISTS idx_cl_timestamp ON call_logs(timestamp);
   CREATE INDEX IF NOT EXISTS idx_cl_status ON call_logs(status);
-  CREATE INDEX IF NOT EXISTS idx_cl_correlation_id ON call_logs(correlation_id);
 
   CREATE TABLE IF NOT EXISTS proxy_logs (
     id TEXT PRIMARY KEY,

--- a/src/lib/db/migrations/103_call_logs_correlation_id.sql
+++ b/src/lib/db/migrations/103_call_logs_correlation_id.sql
@@ -1,0 +1,2 @@
+ALTER TABLE call_logs ADD COLUMN correlation_id TEXT;
+CREATE INDEX IF NOT EXISTS idx_cl_correlation_id ON call_logs(correlation_id);

--- a/src/lib/db/migrations/103_call_logs_correlation_id.sql
+++ b/src/lib/db/migrations/103_call_logs_correlation_id.sql
@@ -1,2 +1,0 @@
-ALTER TABLE call_logs ADD COLUMN correlation_id TEXT;
-CREATE INDEX IF NOT EXISTS idx_cl_correlation_id ON call_logs(correlation_id);

--- a/src/lib/tokenHealthCheck.ts
+++ b/src/lib/tokenHealthCheck.ts
@@ -353,7 +353,8 @@ export async function checkConnection(conn) {
     //   - transient cooldown state (unavailable) owned by the request path
     const refreshCapableNeedsReauth =
       supportsTokenRefresh(conn.provider) &&
-      (!conn.testStatus || conn.testStatus === "active");
+      (!conn.testStatus || conn.testStatus === "active") &&
+      !(conn.apiKey && conn.apiKey.length > 0); // API-key-only connections don't need refresh tokens
     if (refreshCapableNeedsReauth) {
       const now = new Date().toISOString();
       await updateProviderConnection(conn.id, {

--- a/src/shared/components/RequestLoggerDetail.tsx
+++ b/src/shared/components/RequestLoggerDetail.tsx
@@ -243,7 +243,7 @@ export default function RequestLoggerDetail({
   const requestJson = detail?.requestBody ? toPrettyJson(detail.requestBody) : null;
   const responseJson = detail?.responseBody ? toPrettyJson(detail.responseBody) : null;
   const streamChunks = (() => {
-    if (!detail?.pipelinePayloads?.streamChunks) return null;
+    if (!debugEnabled || !detail?.pipelinePayloads?.streamChunks) return null;
     let chunks: StreamChunks = detail.pipelinePayloads.streamChunks;
     if (typeof chunks === "string") {
       try {

--- a/src/shared/components/RequestLoggerDetail.tsx
+++ b/src/shared/components/RequestLoggerDetail.tsx
@@ -176,6 +176,8 @@ export default function RequestLoggerDetail({
   onCopy,
   onPrevious,
   onNext,
+  relatedLogs = [],
+  onSelectRelated,
 }) {
   // Close on Escape key
   useEffect(() => {
@@ -202,11 +204,12 @@ export default function RequestLoggerDetail({
     if (iso == null) return "\u2014";
     try {
       const d = new Date(iso);
+      if (!Number.isFinite(d.getTime())) return "\u2014";
       return (
         d.toLocaleDateString("pt-BR") + ", " + d.toLocaleTimeString("en-US", { hour12: false })
       );
     } catch {
-      return iso;
+      return "\u2014";
     }
   };
 
@@ -239,32 +242,17 @@ export default function RequestLoggerDetail({
     : [];
   const requestJson = detail?.requestBody ? toPrettyJson(detail.requestBody) : null;
   const responseJson = detail?.responseBody ? toPrettyJson(detail.responseBody) : null;
-  const streamChunksText = (() => {
-    if (!debugEnabled || !detail?.pipelinePayloads?.streamChunks) return null;
+  const streamChunks = (() => {
+    if (!detail?.pipelinePayloads?.streamChunks) return null;
     let chunks: StreamChunks = detail.pipelinePayloads.streamChunks;
-
     if (typeof chunks === "string") {
       try {
-        const parsed = JSON.parse(chunks);
-        chunks = parsed;
+        chunks = JSON.parse(chunks);
       } catch {
-        return chunks;
+        return null;
       }
     }
-
-    if (chunks && typeof chunks === "object") {
-      try {
-        return Object.entries(chunks)
-          .map(([stage, arr]) => {
-            const joined = Array.isArray(arr) ? arr.join("") : String(arr);
-            return `--- ${stage} ---\n${joined}`;
-          })
-          .join("\n\n");
-      } catch {
-        return toPrettyJson(chunks);
-      }
-    }
-
+    if (chunks && typeof chunks === "object") return chunks;
     return null;
   })();
   const detailIssue =
@@ -346,6 +334,14 @@ export default function RequestLoggerDetail({
                 {log.id}
               </span>
             )}
+            {log.correlationId && (
+              <span
+                className="text-[10px] text-text-muted/50 font-mono self-center ml-2 px-1.5 py-0.5 rounded bg-bg-subtle border border-border/40 select-all"
+                title="Correlation ID"
+              >
+                cid: {log.correlationId}
+              </span>
+            )}
           </div>
           <div className="flex items-center gap-1">
             <button
@@ -421,7 +417,23 @@ export default function RequestLoggerDetail({
             >
               <div>
                 <div className="text-[10px] text-text-muted uppercase tracking-wider mb-1">
-                  Completed Time
+                  Started At
+                </div>
+                <div className="text-sm font-medium">
+                  {(() => {
+                    try {
+                      const ts = new Date(log.timestamp).getTime();
+                      if (!Number.isFinite(ts)) return "\u2014";
+                      return formatDate(new Date(ts - (log.duration || 0)).toISOString());
+                    } catch {
+                      return "\u2014";
+                    }
+                  })()}
+                </div>
+              </div>
+              <div>
+                <div className="text-[10px] text-text-muted uppercase tracking-wider mb-1">
+                  Ended At
                 </div>
                 <div className="text-sm font-medium">{formatDate(log.timestamp)}</div>
               </div>
@@ -597,6 +609,62 @@ export default function RequestLoggerDetail({
             </div>
           )}
 
+          {/* Related Requests (same correlation ID) */}
+          {relatedLogs.length > 1 && (
+            <div className="p-4 rounded-xl bg-bg-subtle border border-border">
+              <div className="text-[10px] text-text-muted uppercase tracking-wider mb-2 font-bold">
+                Related Requests ({relatedLogs.length})
+              </div>
+              <div className="flex flex-col gap-1">
+                {[...relatedLogs]
+                  .sort((a, b) => {
+                    const aStart = new Date(a.timestamp).getTime() - (a.duration || 0);
+                    const bStart = new Date(b.timestamp).getTime() - (b.duration || 0);
+                    return aStart - bStart;
+                  })
+                  .map((r) => {
+                    const rStatusStyle = r.active ? null : getStatusStyle(r.status);
+                    const isCurrent = r.id === log.id;
+                    const startTime = new Date(new Date(r.timestamp).getTime() - (r.duration || 0));
+                    return (
+                      <button
+                        key={r.id}
+                        onClick={() => !isCurrent && onSelectRelated?.(r)}
+                        disabled={isCurrent}
+                        className={`flex items-center gap-2 px-2 py-1.5 rounded text-left text-xs transition-colors ${
+                          isCurrent
+                            ? "bg-primary/10 border border-primary/30 cursor-default"
+                            : "hover:bg-bg-hover cursor-pointer"
+                        }`}
+                      >
+                        <span
+                          className="inline-block px-1.5 py-0.5 rounded text-[9px] font-bold min-w-[28px] text-center"
+                          style={
+                            rStatusStyle
+                              ? { backgroundColor: rStatusStyle.bg, color: rStatusStyle.text }
+                              : { backgroundColor: "#374151", color: "#fff" }
+                          }
+                        >
+                          {r.status || "..."}
+                        </span>
+                        <span className="font-mono text-text-muted">{r.id}</span>
+                        <span className="text-text-muted">{r.model}</span>
+                        <span className="text-text-muted text-[10px]">
+                          {startTime.toLocaleTimeString("en-US", { hour12: false })}
+                        </span>
+                        <span className="text-text-muted ml-auto">
+                          {formatDuration(r.duration)}
+                        </span>
+                        {isCurrent && (
+                          <span className="text-[9px] text-primary font-bold ml-1">current</span>
+                        )}
+                      </button>
+                    );
+                  })}
+              </div>
+            </div>
+          )}
+
           {detailIssue && (
             <div className="p-4 rounded-xl bg-amber-500/10 border border-amber-500/30">
               <div className="text-[10px] text-amber-700 dark:text-amber-400 uppercase tracking-wider mb-1 font-bold">
@@ -612,13 +680,62 @@ export default function RequestLoggerDetail({
             </div>
           ) : (
             <>
-              {streamChunksText && (
+              {streamChunks && streamChunks.provider && (
                 <StreamSection
-                  title="Event Stream (Debug)"
-                  json={streamChunksText}
-                  onCopy={() => onCopy(streamChunksText)}
+                  title="Provider Event Stream"
+                  json={
+                    Array.isArray(streamChunks.provider)
+                      ? streamChunks.provider.join("")
+                      : String(streamChunks.provider)
+                  }
+                  onCopy={() =>
+                    onCopy(
+                      Array.isArray(streamChunks.provider)
+                        ? streamChunks.provider.join("")
+                        : String(streamChunks.provider)
+                    )
+                  }
                 />
               )}
+
+              {streamChunks && streamChunks.client && (
+                <StreamSection
+                  title="Client Event Stream"
+                  json={
+                    Array.isArray(streamChunks.client)
+                      ? streamChunks.client.join("")
+                      : String(streamChunks.client)
+                  }
+                  onCopy={() =>
+                    onCopy(
+                      Array.isArray(streamChunks.client)
+                        ? streamChunks.client.join("")
+                        : String(streamChunks.client)
+                    )
+                  }
+                />
+              )}
+
+              {streamChunks &&
+                streamChunks.openai &&
+                !streamChunks.provider &&
+                !streamChunks.client && (
+                  <StreamSection
+                    title="Event Stream"
+                    json={
+                      Array.isArray(streamChunks.openai)
+                        ? streamChunks.openai.join("")
+                        : String(streamChunks.openai)
+                    }
+                    onCopy={() =>
+                      onCopy(
+                        Array.isArray(streamChunks.openai)
+                          ? streamChunks.openai.join("")
+                          : String(streamChunks.openai)
+                      )
+                    }
+                  />
+                )}
 
               {payloadSections.length > 0 &&
                 payloadSections.map((section) => (

--- a/src/shared/components/RequestLoggerV2.tsx
+++ b/src/shared/components/RequestLoggerV2.tsx
@@ -139,7 +139,36 @@ const RequestLoggerV2 = forwardRef<RequestLoggerV2Handle, { initialSelectedId?: 
     const [selectedApiKey, setSelectedApiKey] = useState("");
     const [sortBy, setSortBy] = useState("newest");
     const [selectedLog, setSelectedLog] = useState(null);
+    const [correlationIdFilter, setCorrelationIdFilter] = useState("");
     const [detailLoading, setDetailLoading] = useState(false);
+
+    // Column sort toggle: clicking a column header toggles asc/desc
+    const columnSortMap = {
+      status: { desc: "status_desc", asc: "status_asc" },
+      model: { desc: "model_desc", asc: "model_asc" },
+      tokens: { desc: "tokens_desc", asc: "tokens_asc" },
+      tps: { desc: "tps_desc", asc: "tps_asc" },
+      duration: { desc: "duration_desc", asc: "duration_asc" },
+      time: { desc: "newest", asc: "oldest" },
+    };
+    const toggleSort = useCallback((column: string) => {
+      const mapping = columnSortMap[column as keyof typeof columnSortMap];
+      if (!mapping) return;
+      setSortBy((prev) => {
+        if (prev === mapping.desc) return mapping.asc;
+        return mapping.desc;
+      });
+    }, []);
+    const getSortIndicator = useCallback(
+      (column: string) => {
+        const mapping = columnSortMap[column as keyof typeof columnSortMap];
+        if (!mapping) return "";
+        if (sortBy === mapping.desc) return " ↓";
+        if (sortBy === mapping.asc) return " ↑";
+        return "";
+      },
+      [sortBy]
+    );
     const [detailData, setDetailData] = useState(null);
     const [detailLoggingEnabled, setDetailLoggingEnabled] = useState(false);
     const [detailLoggingLoading, setDetailLoggingLoading] = useState(false);
@@ -222,6 +251,7 @@ const RequestLoggerV2 = forwardRef<RequestLoggerV2Handle, { initialSelectedId?: 
           if (selectedProvider) params.set("provider", selectedProvider);
           if (selectedAccount) params.set("account", selectedAccount);
           if (selectedApiKey) params.set("apiKey", selectedApiKey);
+          if (correlationIdFilter) params.set("correlationId", correlationIdFilter);
           params.set("limit", String(limit));
 
           const res = await fetch(`/api/usage/call-logs?${params}`);
@@ -251,6 +281,7 @@ const RequestLoggerV2 = forwardRef<RequestLoggerV2Handle, { initialSelectedId?: 
         selectedAccount,
         selectedProvider,
         selectedApiKey,
+        correlationIdFilter,
         limit,
       ]
     );
@@ -437,6 +468,34 @@ const RequestLoggerV2 = forwardRef<RequestLoggerV2Handle, { initialSelectedId?: 
       return arr;
     }, [filteredLogs, sortBy]);
 
+    // Group by correlationId: mark retries as children so they render indented
+    // under the first request in each group. Compute group health:
+    //   "healed"  — at least one failure followed by a success
+    //   "failed"  — all attempts failed
+    //   null      — single request or all succeeded
+    const groupedLogs = useMemo(() => {
+      const cidGroups = new Map();
+      for (const log of sortedLogs) {
+        const cid = log.correlationId;
+        if (cid) {
+          if (!cidGroups.has(cid)) cidGroups.set(cid, []);
+          cidGroups.get(cid).push(log);
+        }
+      }
+      return sortedLogs.map((log) => {
+        const cid = log.correlationId;
+        if (!cid) return { ...log, isRetry: false, groupSize: 1, groupStatus: null };
+        const group = cidGroups.get(cid);
+        if (!group || group.length <= 1)
+          return { ...log, isRetry: false, groupSize: 1, groupStatus: null };
+        const isFirst = group[0].id === log.id;
+        const hasFailure = group.some((g) => g.status >= 400 || g.active);
+        const hasSuccess = group.some((g) => g.status >= 200 && g.status < 300);
+        const groupStatus = hasFailure && hasSuccess ? "healed" : hasFailure ? "failed" : null;
+        return { ...log, isRetry: !isFirst, groupSize: group.length, groupStatus };
+      });
+    }, [sortedLogs]);
+
     // Fetch log detail from the persisted call-log endpoint. If a deep-linked
     // request is still being finalized, keep the modal open and poll this same
     // endpoint until the row appears.
@@ -598,6 +657,50 @@ const RequestLoggerV2 = forwardRef<RequestLoggerV2Handle, { initialSelectedId?: 
       };
     }, [selectedLog?.id, detailData?.detailState, selectedLog?.active, fetchLogs]);
 
+    // Poll for related logs (same correlationId) while the detail modal is open.
+    // This ensures newly completed retries appear without closing the modal.
+    useEffect(() => {
+      const cid = selectedLog?.correlationId;
+      if (!selectedLog?.id || !cid) return;
+      let cancelled = false;
+      const interval = setInterval(async () => {
+        if (document.visibilityState !== "visible") return;
+        try {
+          const res = await fetch(`/api/usage/call-logs?correlationId=${encodeURIComponent(cid)}`, {
+            cache: "no-store",
+          });
+          if (cancelled || !res.ok) return;
+          const cidLogs = await res.json();
+          if (!Array.isArray(cidLogs) || cidLogs.length === 0) return;
+          setLogs((prev) => {
+            const ids = new Set(cidLogs.map((l: any) => l.id));
+            let changed = false;
+            const merged = prev.map((l: any) => {
+              const updated = cidLogs.find((c: any) => c.id === l.id);
+              if (updated) {
+                changed = true;
+                return { ...l, ...updated };
+              }
+              return l;
+            });
+            for (const cl of cidLogs) {
+              if (!merged.some((m: any) => m.id === cl.id)) {
+                merged.push(cl);
+                changed = true;
+              }
+            }
+            return changed ? merged : prev;
+          });
+        } catch {
+          /* poll failed — non-critical */
+        }
+      }, 3000);
+      return () => {
+        cancelled = true;
+        clearInterval(interval);
+      };
+    }, [selectedLog?.id, selectedLog?.correlationId]);
+
     const currentLogIndex = useMemo(() => {
       if (!selectedLog) return -1;
       return sortedLogsForNav.findIndex((l) => l.id === selectedLog.id);
@@ -685,13 +788,14 @@ const RequestLoggerV2 = forwardRef<RequestLoggerV2Handle, { initialSelectedId?: 
     );
 
     // Stats (memoized to avoid re-computation on every render)
-    const { totalCount, okCount, errorCount, comboCount, apiKeyCount } = useMemo(
+    const { totalCount, okCount, errorCount, comboCount, apiKeyCount, runningCount } = useMemo(
       () => ({
         totalCount: filteredLogs.length,
         okCount: filteredLogs.filter((l) => l.status >= 200 && l.status < 300).length,
         errorCount: filteredLogs.filter((l) => l.status >= 400).length,
         comboCount: logs.filter((l) => l.comboName).length,
         apiKeyCount: uniqueApiKeys.length,
+        runningCount: filteredLogs.filter((l) => l.active === true).length,
       }),
       [filteredLogs, logs, uniqueApiKeys]
     );
@@ -746,6 +850,20 @@ const RequestLoggerV2 = forwardRef<RequestLoggerV2Handle, { initialSelectedId?: 
               value={search}
               onChange={(e) => setSearch(e.target.value)}
               className="w-full pl-10 pr-4 py-2 rounded-lg bg-bg-subtle border border-border text-sm text-text-primary placeholder:text-text-muted focus:outline-none focus:border-primary"
+            />
+          </div>
+
+          {/* Correlation ID Filter */}
+          <div className="min-w-[180px] relative">
+            <span className="material-symbols-outlined absolute left-3 top-1/2 -translate-y-1/2 text-text-muted text-[16px]">
+              tag
+            </span>
+            <input
+              type="text"
+              placeholder="Correlation ID"
+              value={correlationIdFilter}
+              onChange={(e) => setCorrelationIdFilter(e.target.value)}
+              className="w-full pl-9 pr-3 py-2 rounded-lg bg-bg-subtle border border-border text-sm text-text-primary font-mono placeholder:text-text-muted focus:outline-none focus:border-primary"
             />
           </div>
 
@@ -818,6 +936,11 @@ const RequestLoggerV2 = forwardRef<RequestLoggerV2Handle, { initialSelectedId?: 
             <span className="px-2 py-1 rounded bg-bg-subtle border border-border font-mono">
               {totalCount} {t("total")}
             </span>
+            {runningCount > 0 && (
+              <span className="px-2 py-1 rounded bg-amber-500/10 text-amber-700 dark:text-amber-400 font-mono">
+                {runningCount} running
+              </span>
+            )}
             <span className="px-2 py-1 rounded bg-emerald-500/10 text-emerald-700 dark:text-emerald-400 font-mono">
               {okCount} {t("ok")}
             </span>
@@ -1000,7 +1123,13 @@ const RequestLoggerV2 = forwardRef<RequestLoggerV2Handle, { initialSelectedId?: 
                 <thead className={LOG_TABLE_HEAD_CLASS} style={LOG_TABLE_HEADER_BG_STYLE}>
                   <tr className={LOG_TABLE_ROW_CLASS} style={LOG_TABLE_HEADER_BG_STYLE}>
                     {visibleColumns.status && (
-                      <th className={LOG_TABLE_HEADER_CELL_CLASS}>{t("columns.status")}</th>
+                      <th
+                        className={`${LOG_TABLE_HEADER_CELL_CLASS} cursor-pointer select-none`}
+                        onClick={() => toggleSort("status")}
+                      >
+                        {t("columns.status")}
+                        {getSortIndicator("status")}
+                      </th>
                     )}
                     {visibleColumns.cacheSource && (
                       <th className={LOG_TABLE_HEADER_CELL_CLASS}>{t("columns.cacheSource")}</th>
@@ -1027,21 +1156,45 @@ const RequestLoggerV2 = forwardRef<RequestLoggerV2Handle, { initialSelectedId?: 
                       <th className={LOG_TABLE_HEADER_CELL_CLASS}>{t("columns.combo")}</th>
                     )}
                     {visibleColumns.tokens && (
-                      <th className={LOG_TABLE_HEADER_CELL_RIGHT_CLASS}>{t("columns.tokens")}</th>
+                      <th
+                        className={`${LOG_TABLE_HEADER_CELL_RIGHT_CLASS} cursor-pointer select-none`}
+                        onClick={() => toggleSort("tokens")}
+                      >
+                        {t("columns.tokens")}
+                        {getSortIndicator("tokens")}
+                      </th>
                     )}
                     {visibleColumns.tps && (
-                      <th className={LOG_TABLE_HEADER_CELL_RIGHT_CLASS}>{t("columns.tps")}</th>
+                      <th
+                        className={`${LOG_TABLE_HEADER_CELL_RIGHT_CLASS} cursor-pointer select-none`}
+                        onClick={() => toggleSort("tps")}
+                      >
+                        {t("columns.tps")}
+                        {getSortIndicator("tps")}
+                      </th>
                     )}
                     {visibleColumns.duration && (
-                      <th className={LOG_TABLE_HEADER_CELL_RIGHT_CLASS}>{t("columns.duration")}</th>
+                      <th
+                        className={`${LOG_TABLE_HEADER_CELL_RIGHT_CLASS} cursor-pointer select-none`}
+                        onClick={() => toggleSort("duration")}
+                      >
+                        {t("columns.duration")}
+                        {getSortIndicator("duration")}
+                      </th>
                     )}
                     {visibleColumns.time && (
-                      <th className={LOG_TABLE_HEADER_CELL_RIGHT_CLASS}>{t("columns.time")}</th>
+                      <th
+                        className={`${LOG_TABLE_HEADER_CELL_RIGHT_CLASS} cursor-pointer select-none`}
+                        onClick={() => toggleSort("time")}
+                      >
+                        {t("columns.time")}
+                        {getSortIndicator("time")}
+                      </th>
                     )}
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-border/30">
-                  {sortedLogs.map((log) => {
+                  {groupedLogs.map((log) => {
                     const isActive = log.active === true;
                     const statusStyle = isActive ? null : getStatusStyle(log.status);
                     const protocolKey = isActive ? null : log.sourceFormat || log.provider;
@@ -1064,7 +1217,10 @@ const RequestLoggerV2 = forwardRef<RequestLoggerV2Handle, { initialSelectedId?: 
                       <tr
                         key={log.id}
                         onClick={() => openDetail(log)}
-                        className={`cursor-pointer hover:bg-sky-500/10 dark:hover:bg-sky-400/10 transition-colors ${isError ? "bg-red-500/5" : ""}`}
+                        className={`cursor-pointer hover:bg-sky-500/10 dark:hover:bg-sky-400/10 transition-colors ${isError ? "bg-red-500/5" : ""} ${log.isRetry ? "border-l-2 border-l-amber-500/50" : ""}`}
+                        style={
+                          log.isRetry ? { backgroundColor: "rgba(245,158,11,0.03)" } : undefined
+                        }
                       >
                         {visibleColumns.status && (
                           <td className="px-3 py-2">
@@ -1076,11 +1232,41 @@ const RequestLoggerV2 = forwardRef<RequestLoggerV2Handle, { initialSelectedId?: 
                                 <span className="inline-block h-3 w-3 rounded-full border-2 border-amber-500 border-t-transparent animate-spin" />
                               </span>
                             ) : (
-                              <span
-                                className="inline-block px-2 py-0.5 rounded text-[10px] font-bold min-w-[36px] text-center"
-                                style={{ backgroundColor: statusStyle.bg, color: statusStyle.text }}
-                              >
-                                {log.status || "..."}
+                              <span className="inline-flex items-center gap-1">
+                                <span
+                                  className="inline-block px-2 py-0.5 rounded text-[10px] font-bold min-w-[36px] text-center"
+                                  style={{
+                                    backgroundColor: statusStyle.bg,
+                                    color: statusStyle.text,
+                                  }}
+                                >
+                                  {log.status || "..."}
+                                </span>
+                                {log.groupStatus === "healed" &&
+                                  !log.isRetry &&
+                                  log.status >= 400 && (
+                                    <span
+                                      className="text-emerald-500 text-[11px]"
+                                      title="Recovered by retry"
+                                    >
+                                      ✓
+                                    </span>
+                                  )}
+                                {log.isRetry && (
+                                  <button
+                                    className="inline-flex items-center text-amber-500 hover:text-amber-400 text-[11px] ml-0.5"
+                                    title="Go to parent request"
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      const parent = groupedLogs.find(
+                                        (g) => g.correlationId === log.correlationId && !g.isRetry
+                                      );
+                                      if (parent) openDetail(parent);
+                                    }}
+                                  >
+                                    ↳
+                                  </button>
+                                )}
                               </span>
                             )}
                           </td>
@@ -1103,7 +1289,49 @@ const RequestLoggerV2 = forwardRef<RequestLoggerV2Handle, { initialSelectedId?: 
                         )}
                         {visibleColumns.model && (
                           <td className="px-3 py-2 font-medium text-primary font-mono text-[11px]">
-                            {log.model}
+                            <div className="flex items-center gap-1.5">
+                              <span>{log.model}</span>
+                              {log.groupStatus === "healed" && !log.isRetry && (
+                                <span
+                                  className="inline-flex items-center gap-0.5 px-1 py-0 rounded text-[8px] font-bold bg-emerald-500/15 text-emerald-600 dark:text-emerald-400 border border-emerald-500/25"
+                                  title={`Failed, recovered after ${log.groupSize - 1} retry`}
+                                >
+                                  healed
+                                </span>
+                              )}
+                              {log.groupStatus === "failed" && !log.isRetry && (
+                                <span
+                                  className="inline-flex items-center gap-0.5 px-1 py-0 rounded text-[8px] font-bold bg-red-500/15 text-red-600 dark:text-red-400 border border-red-500/25"
+                                  title={`All ${log.groupSize} attempts failed`}
+                                >
+                                  failed
+                                </span>
+                              )}
+                            </div>
+                            {log.correlationId && !log.isRetry && log.groupSize > 1 && (
+                              <div
+                                className="text-[9px] text-text-muted font-normal truncate max-w-[120px]"
+                                title={log.correlationId}
+                              >
+                                {log.correlationId.slice(0, 12)}… · {log.groupSize} attempts
+                              </div>
+                            )}
+                            {log.correlationId && !log.isRetry && log.groupSize <= 1 && (
+                              <div
+                                className="text-[9px] text-text-muted font-normal truncate max-w-[120px]"
+                                title={log.correlationId}
+                              >
+                                {log.correlationId.slice(0, 12)}…
+                              </div>
+                            )}
+                            {log.correlationId && log.isRetry && (
+                              <div
+                                className="text-[9px] text-amber-500/70 font-normal truncate max-w-[120px]"
+                                title={log.correlationId}
+                              >
+                                {log.correlationId.slice(0, 12)}…
+                              </div>
+                            )}
                           </td>
                         )}
                         {visibleColumns.requestedModel && (
@@ -1303,6 +1531,15 @@ const RequestLoggerV2 = forwardRef<RequestLoggerV2Handle, { initialSelectedId?: 
             onCopy={copyToClipboard}
             onPrevious={handlePrev}
             onNext={handleNext}
+            relatedLogs={
+              selectedLog.correlationId
+                ? groupedLogs.filter((l) => l.correlationId === selectedLog.correlationId)
+                : []
+            }
+            onSelectRelated={(r) => {
+              closeDetail();
+              openDetail(r);
+            }}
           />
         )}
       </div>

--- a/tests/integration/active-request-completion.test.ts
+++ b/tests/integration/active-request-completion.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 
 const API_KEY = process.env.OMNIROUTE_API_KEY;
 const BASE_URL = process.env.OMNIROUTE_URL || "http://localhost:20128";
-const MODEL = process.env.TEST_GEMINI_MODEL || "default";
+const MODEL = "default";
 
 const skip = !API_KEY ? "OMNIROUTE_API_KEY not set — skipping live test" : undefined;
 
@@ -54,7 +54,14 @@ async function readSSEStream(response: Response, onChunk?: (chunk: string) => vo
 }
 
 test("live request returns streamChunks", { skip }, async () => {
-  console.log("[TEST] BASE_URL=", BASE_URL, "OMNIROUTE_URL=", process.env.OMNIROUTE_URL, "API_KEY set=", !!API_KEY);
+  console.log(
+    "[TEST] BASE_URL=",
+    BASE_URL,
+    "OMNIROUTE_URL=",
+    process.env.OMNIROUTE_URL,
+    "API_KEY set=",
+    !!API_KEY
+  );
 
   const messages = [
     { role: "system", content: "Execute the user prompt and provide a detailed explanation." },
@@ -106,9 +113,10 @@ test("live request returns streamChunks", { skip }, async () => {
         );
         if (activeRequestResponse.ok) {
           let activeRequest = await activeRequestResponse.json();
-          if (activeRequest.active &&
-              Array.isArray(activeRequest.pipelinePayloads.streamChunks.provider) &&
-              activeRequest.pipelinePayloads.streamChunks.provider.length > 0
+          if (
+            activeRequest.active &&
+            Array.isArray(activeRequest.pipelinePayloads.streamChunks.provider) &&
+            activeRequest.pipelinePayloads.streamChunks.provider.length > 0
           ) {
             console.log("Stream chunks:", activeRequest.pipelinePayloads.streamChunks.provider);
             sawLogChunksWhileStreaming = true;
@@ -140,9 +148,13 @@ test("live request returns streamChunks", { skip }, async () => {
     let finishedRequest = await logDetailResponse.json();
 
     assert.equal(finishedRequest.id, requestId, "log detail id should match request id");
-    assert.equal(finishedRequest.active, false, "request should be marked as inactive after completion");
+    assert.equal(
+      finishedRequest.active,
+      false,
+      "request should be marked as inactive after completion"
+    );
 
-    assert.ok(Array.isArray(finishedRequest.pipelinePayloads.streamChunks.provider) );
+    assert.ok(Array.isArray(finishedRequest.pipelinePayloads.streamChunks.provider));
     assert.ok(Array.isArray(finishedRequest.pipelinePayloads.streamChunks.client));
 
     assert.ok(finishedRequest.pipelinePayloads.streamChunks.provider.length > 0);

--- a/tests/integration/historical-tool-call-leak.test.ts
+++ b/tests/integration/historical-tool-call-leak.test.ts
@@ -8,7 +8,6 @@
  * Uses same env vars as tests/manual/gemini.http:
  *   OMNIROUTE_URL             — base URL (default http://localhost:20128)
  *   OMNIROUTE_API_KEY         — API key for auth
- *   TEST_GEMINI_MODEL         — model override (default gemini/gemma-4-31b-it)
  *   TEST_THINKING_GEMINI_MODEL — thinking model override, skipped if unset
  */
 
@@ -17,7 +16,7 @@ import assert from "node:assert/strict";
 
 const API_KEY = process.env.OMNIROUTE_API_KEY;
 const BASE_URL = process.env.OMNIROUTE_URL || "http://localhost:20128";
-const MODEL = process.env.TEST_GEMINI_MODEL || "gemini/gemma-4-31b-it";
+const MODEL = "default";
 const THINKING_MODEL = process.env.TEST_THINKING_GEMINI_MODEL || "gemini/gemini-2.5-flash";
 const NUM_HISTORICAL_ROUNDS = 15;
 

--- a/tests/integration/live-gemini-nonstream.test.ts
+++ b/tests/integration/live-gemini-nonstream.test.ts
@@ -1,8 +1,9 @@
 /**
- * tests/integration/live-gemini-workload.test.ts
+ * tests/integration/live-gemini-nonstream.test.ts
  *
- * Streaming live Gemini workload test. Reuses shared generators from
- * liveGeminiShared.ts. For non-streaming, see live-gemini-nonstream.test.ts.
+ * Non-streaming variant of live-gemini-workload.test.ts.
+ * Reuses the same CASE_BUILDERS payload generators but sends stream: false.
+ * Validates that non-streaming responses return content and complete without errors.
  */
 import test from "node:test";
 import assert from "node:assert/strict";
@@ -21,22 +22,19 @@ test.before(async () => {
   await ensureTestEnvironment();
 });
 
-// --------------------------------------------------------------------------
-// Concurrent load — 5 parallel threads × 15 iterations
-// --------------------------------------------------------------------------
+// ── Non-streaming concurrent load — 5 parallel threads × 5 iterations ──
 
-test("[26] concurrent load — 2 threads × 2 iterations", { skip }, async () => {
-  const THREAD_COUNT = 2;
+test("[00] non-streaming: concurrent load — 5 threads × 2 iterations", { skip }, async () => {
+  const THREAD_COUNT = 5;
   const SET_COUNT = 2;
   const TOTAL_REQUESTS = THREAD_COUNT * SET_COUNT;
 
   console.log(
-    `\n  Concurrent load: ${THREAD_COUNT} threads × ${SET_COUNT} iterations = ${TOTAL_REQUESTS} requests`
+    `\n  Non-streaming concurrent: ${THREAD_COUNT} threads × ${SET_COUNT} iterations = ${TOTAL_REQUESTS} requests`
   );
 
   const start = performance.now();
 
-  // Shared state for parallel-request detection across threads
   const requestWindows: { cid: string; start: number; end: number }[] = [];
   let parallelViolation: string | null = null;
 
@@ -51,16 +49,15 @@ test("[26] concurrent load — 2 threads × 2 iterations", { skip }, async () =>
           correlationId: string;
         }[] = [];
         for (let set = 1; set <= SET_COUNT; set++) {
-          if (parallelViolation) break; // another thread detected a violation
+          if (parallelViolation) break;
 
           const idx = randomInt(0, CASE_BUILDERS.length - 1);
           const tc = CASE_BUILDERS[idx];
-          const label = `t${threadIdx + 1}-i${set}: ${tc.name}`;
+          const label = `ns-t${threadIdx + 1}-i${set}: ${tc.name}`;
           const requestStart = Date.now();
-          const r = await sendAndValidate(label, tc.build);
+          const r = await sendAndValidate(label, tc.build, false);
           const requestEnd = Date.now();
 
-          // Check for parallel requests with the same correlationId
           const cid = r.correlationId;
           const myWindow = { cid, start: requestStart, end: requestEnd };
           const siblings = requestWindows.filter((w) => w.cid === cid);
@@ -102,7 +99,7 @@ test("[26] concurrent load — 2 threads × 2 iterations", { skip }, async () =>
       : 0;
 
   console.log(
-    `\n  Concurrent summary: ${fulfilled.length}/${THREAD_COUNT} threads completed | ` +
+    `\n  Non-streaming concurrent summary: ${fulfilled.length}/${THREAD_COUNT} threads completed | ` +
       `${allResults.length}/${TOTAL_REQUESTS} requests succeeded | ` +
       `${Math.round(totalDuration)}ms wall clock | ` +
       `${avgDuration}ms avg per request | ` +
@@ -129,16 +126,23 @@ test("[26] concurrent load — 2 threads × 2 iterations", { skip }, async () =>
     `expected ${TOTAL_REQUESTS} total requests, got ${allResults.length}`
   );
   assert.ok(!parallelViolation, parallelViolation);
+
+  // Verify all correlation IDs are unique
+  const cids = allResults.map((r) => r.correlationId);
+  const uniqueCids = new Set(cids);
+  assert.equal(
+    uniqueCids.size,
+    cids.length,
+    `expected ${cids.length} unique CIDs, got ${uniqueCids.size}`
+  );
 });
 
-// --------------------------------------------------------------------------
-// Single-thread sequential — 1 thread × 5 iterations
-// --------------------------------------------------------------------------
+// ── Non-streaming sequential test ───────────────────────────────────────
 
-test("[27] single-thread sequential — 1 thread × 5 iterations", { skip }, async () => {
+test("[01] non-streaming: sequential — 1 thread × 5 iterations", { skip }, async () => {
   const SET_COUNT = 5;
 
-  console.log(`\n  Single-thread sequential: 1 thread × ${SET_COUNT} iterations`);
+  console.log(`\n  Non-streaming sequential: 1 thread × ${SET_COUNT} iterations`);
 
   const start = performance.now();
   const results: {
@@ -152,10 +156,10 @@ test("[27] single-thread sequential — 1 thread × 5 iterations", { skip }, asy
   for (let i = 1; i <= SET_COUNT; i++) {
     const idx = randomInt(0, CASE_BUILDERS.length - 1);
     const tc = CASE_BUILDERS[idx];
-    const label = `seq-i${i}: ${tc.name}`;
+    const label = `ns-i${i}: ${tc.name}`;
     try {
       if (i > 1) await new Promise((r) => setTimeout(r, DELAY_BETWEEN_REQUESTS_MS));
-      const r = await sendAndValidate(label, tc.build);
+      const r = await sendAndValidate(label, tc.build, false);
       results.push(r);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
@@ -172,33 +176,32 @@ test("[27] single-thread sequential — 1 thread × 5 iterations", { skip }, asy
       : 0;
 
   console.log(
-    `\n  Sequential summary: ${results.length}/${SET_COUNT} succeeded | ` +
+    `\n  Non-streaming summary: ${results.length}/${SET_COUNT} succeeded | ` +
       `${Math.round(totalDuration)}ms wall clock | ` +
       `${avgDuration}ms avg per request | ` +
       `${totalTokens} total tokens`
   );
 
-  // Verify no duplicate correlation IDs (no retries created parallel entries)
   const cids = results.map((r) => r.correlationId);
   const uniqueCids = new Set(cids);
   assert.equal(
     uniqueCids.size,
     cids.length,
-    `expected ${cids.length} unique correlation IDs, got ${uniqueCids.size} — duplicates detected`
+    `expected ${cids.length} unique CIDs, got ${uniqueCids.size}`
   );
   assert.equal(results.length, SET_COUNT, `expected ${SET_COUNT} results, got ${results.length}`);
 });
 
-// ── Streaming-specific tests ────────────────────────────────────────────
+// ── Non-streaming: all payloads return content ──────────────────────────
 
-test("[28] streaming: all payloads return content", { skip }, async () => {
+test("[02] non-streaming: all payloads return content", { skip }, async () => {
   const failures: string[] = [];
 
   for (let i = 0; i < CASE_BUILDERS.length; i++) {
     const tc = CASE_BUILDERS[i];
-    const label = `stream-${String(i + 1).padStart(2, "0")}: ${tc.name}`;
+    const label = `ns-${String(i + 1).padStart(2, "0")}: ${tc.name}`;
     try {
-      const r = await sendAndValidate(label, tc.build);
+      const r = await sendAndValidate(label, tc.build, false);
       if (r.contentLength === 0) {
         failures.push(`${tc.name}: 0 bytes content`);
       }
@@ -211,24 +214,26 @@ test("[28] streaming: all payloads return content", { skip }, async () => {
   }
 
   if (failures.length > 0) {
-    console.log(`\n  Streaming failures (${failures.length}):`);
+    console.log(`\n  Non-streaming failures (${failures.length}):`);
     for (const f of failures) console.log(`    ${f}`);
   }
 
   assert.equal(
     failures.length,
     0,
-    `${failures.length}/${CASE_BUILDERS.length} streaming payloads failed`
+    `${failures.length}/${CASE_BUILDERS.length} non-streaming payloads failed`
   );
 });
 
-test("[29] streaming: correlation IDs are unique per request", { skip }, async () => {
+// ── Non-streaming: correlation IDs are unique ───────────────────────────
+
+test("[03] non-streaming: correlation IDs are unique per request", { skip }, async () => {
   const cids: string[] = [];
   const count = 5;
 
   for (let i = 0; i < count; i++) {
     const tc = CASE_BUILDERS[i % CASE_BUILDERS.length];
-    const r = await sendAndValidate(`cid-${i + 1}: ${tc.name}`, tc.build);
+    const r = await sendAndValidate(`ns-cid-${i + 1}: ${tc.name}`, tc.build, false);
     cids.push(r.correlationId);
   }
 

--- a/tests/integration/live-gemini.test.ts
+++ b/tests/integration/live-gemini.test.ts
@@ -1,0 +1,188 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { ensureTestEnvironment, MODEL, BASE_URL, API_KEY } from "./liveGeminiShared.ts";
+
+const DIRECT_MODEL = process.env.TEST_GEMINI_DIRECT_MODEL || "gemini/gemini-2.0-flash";
+
+const skip = !API_KEY ? "OMNIROUTE_API_KEY not set — skipping live test" : undefined;
+
+test.before(async () => {
+  await ensureTestEnvironment();
+});
+
+async function readSSEStream(response: Response): Promise<{
+  fullContent: string;
+  finishReason: string;
+  model: string;
+  totalTokens: number;
+}> {
+  const reader = response.body!.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let fullContent = "";
+  let finishReason = "unknown";
+  let model = "";
+  let totalTokens = 0;
+  let chunkCount = 0;
+  let sampleLines: string[] = [];
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split("\n");
+    buffer = lines.pop() || "";
+
+    for (const line of lines) {
+      if (!line.startsWith("data: ")) continue;
+      chunkCount++;
+      const data = line.slice(6).trim();
+      if (data === "[DONE]") continue;
+
+      try {
+        const parsed = JSON.parse(data) as Record<string, unknown>;
+        const choice = ((parsed.choices ?? []) as Array<Record<string, unknown>>)[0];
+        if (choice) {
+          const delta = choice.delta as Record<string, unknown> | undefined;
+          if (delta?.content) {
+            fullContent += delta.content as string;
+          } else if (delta?.reasoning_content) {
+            fullContent += delta.reasoning_content as string;
+          }
+          if (choice.finish_reason) finishReason = choice.finish_reason as string;
+        }
+        if (!model) {
+          if (parsed.model) {
+            model = parsed.model as string;
+          } else if (choice?.model) {
+            model = choice.model as string;
+          }
+        }
+        const usage = parsed.usage as Record<string, number> | undefined;
+        if (usage) {
+          totalTokens =
+            usage.total_tokens ?? (usage.prompt_tokens ?? 0) + (usage.completion_tokens ?? 0);
+        }
+      } catch {
+        // skip malformed chunks
+      }
+
+      if (sampleLines.length < 3) {
+        sampleLines.push(data.slice(0, 200));
+      }
+    }
+  }
+
+  console.log(
+    `[SSE] total raw chunks: ${chunkCount}, content length: ${fullContent.length}, finish: ${finishReason}, model: ${model}, tokens: ${totalTokens}`
+  );
+  if (sampleLines.length > 0) {
+    console.log(`[SSE] sample lines: ${JSON.stringify(sampleLines)}`);
+  }
+
+  return { fullContent, finishReason, model, totalTokens };
+}
+
+test("live Gemini — single hello-world request via combo 'default'", { skip }, async (t) => {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 120_000);
+
+  try {
+    console.log(`[TEST] Sending request with model=${MODEL} to ${BASE_URL}/v1/chat/completions`);
+    const response = await fetch(`${BASE_URL}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${API_KEY}`,
+      },
+      body: JSON.stringify({
+        model: MODEL,
+        messages: [{ role: "user", content: "Say 'Hello world' and nothing else." }],
+        stream: true,
+        max_tokens: 50,
+        temperature: 0,
+      }),
+      signal: controller.signal,
+    });
+    clearTimeout(timeout);
+
+    console.log(`[TEST] Response status: ${response.status}`);
+    if (!response.ok) {
+      const body = await response.text().catch(() => "unknown");
+      console.log(`[TEST] Response body: ${body}`);
+    }
+
+    assert.equal(response.status, 200, "Expected HTTP 200 from combo request");
+
+    const { fullContent, finishReason, model, totalTokens } = await readSSEStream(response);
+
+    assert.ok(fullContent.length > 0, "response should have content");
+    assert.ok(
+      finishReason === "stop" || finishReason === "length",
+      `expected stop/length finish, got ${finishReason}`
+    );
+    assert.ok(totalTokens > 0, `should have non-zero token count, got ${totalTokens}`);
+    assert.ok(
+      model.toLowerCase().includes("gemini") || model.toLowerCase().includes("gemma"),
+      `response model "${model}" should be a Gemini/Gemma model`
+    );
+    console.log(
+      `[TEST] OK: model=${model}, finish=${finishReason}, tokens=${totalTokens}, content=${fullContent.length} chars`
+    );
+  } catch (err) {
+    clearTimeout(timeout);
+    throw err;
+  }
+});
+
+test("live Gemini — direct model request (skip combo)", { skip }, async (t) => {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 120_000);
+
+  try {
+    console.log(`[TEST] Direct model request with model=${DIRECT_MODEL}`);
+    const response = await fetch(`${BASE_URL}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${API_KEY}`,
+      },
+      body: JSON.stringify({
+        model: DIRECT_MODEL,
+        messages: [{ role: "user", content: "Say 'Hello world' and nothing else." }],
+        stream: true,
+        max_tokens: 50,
+        temperature: 0,
+      }),
+      signal: controller.signal,
+    });
+    clearTimeout(timeout);
+
+    console.log(`[TEST] Direct response status: ${response.status}`);
+    if (!response.ok) {
+      const body = await response.text().catch(() => "unknown");
+      console.log(`[TEST] Direct response body: ${body}`);
+    }
+
+    assert.equal(response.status, 200, "Expected HTTP 200 for direct model");
+
+    const { fullContent, finishReason, model, totalTokens } = await readSSEStream(response);
+
+    assert.ok(fullContent.length > 0, "response should have content");
+    assert.ok(
+      finishReason === "stop" || finishReason === "length",
+      `expected stop/length finish, got ${finishReason}`
+    );
+    assert.ok(totalTokens > 0, `should have non-zero token count, got ${totalTokens}`);
+    assert.ok(
+      model.toLowerCase().includes("gemini") || model.toLowerCase().includes("gemma"),
+      `response model "${model}" should be a Gemini/Gemma model`
+    );
+    console.log(`[TEST] Direct OK: model=${model}, finish=${finishReason}, tokens=${totalTokens}`);
+  } catch (err) {
+    clearTimeout(timeout);
+    throw err;
+  }
+});

--- a/tests/integration/liveGeminiShared.ts
+++ b/tests/integration/liveGeminiShared.ts
@@ -1,0 +1,1108 @@
+/**
+ * tests/integration/liveGeminiShared.ts
+ *
+ * Shared utilities for live Gemini workload tests (streaming + non-streaming).
+ * Import from here to reuse payload generators without duplicating code.
+ */
+import assert from "node:assert/strict";
+
+export const API_KEY = process.env.OMNIROUTE_API_KEY;
+export const BASE_URL = process.env.OMNIROUTE_URL || "http://localhost:3000";
+export const MODEL = "default";
+const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
+export const DELAY_BETWEEN_REQUESTS_MS = Number(process.env.TEST_DELAY_MS) || 5000;
+
+export const skip = !API_KEY ? "OMNIROUTE_API_KEY not set — skipping live test" : undefined;
+
+// --------------------------------------------------------------------------
+// Test Environment Setup — ensures gemini provider + "default" combo exist
+// --------------------------------------------------------------------------
+
+const DEFAULT_COMBO_CONFIG = {
+  name: "default",
+  strategy: "auto",
+  models: [
+    { model: "gemini/gemma-4-31b-it", providerId: "gemini" },
+    { model: "gemini/gemma-4-26b-a4b-it", providerId: "gemini" },
+  ],
+  config: {
+    maxRetries: 3,
+    retryDelayMs: 500,
+    maxComboDepth: 3,
+    trackMetrics: true,
+    failoverBeforeRetry: true,
+    maxSetRetries: 3,
+    candidatePool: ["gemini"],
+    targetTimeoutMs: 300_000,
+    streamPreBuffer: { enabled: false, mode: "tokens", threshold: 100 },
+  },
+};
+
+async function apiFetch(path: string, options: RequestInit = {}): Promise<Response> {
+  return fetch(`${BASE_URL}${path}`, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${API_KEY}`,
+      "Content-Type": "application/json",
+      ...(options.headers || {}),
+    },
+  });
+}
+
+async function ensureGeminiProvider(): Promise<boolean> {
+  try {
+    const res = await apiFetch("/api/providers");
+    if (!res.ok) return false;
+    const data = await res.json();
+    const connections = data.connections || data;
+    const geminiActive = Array.isArray(connections)
+      ? connections.find(
+          (c: any) => c.provider === "gemini" && c.isActive && c.testStatus !== "expired"
+        )
+      : null;
+
+    if (geminiActive) {
+      console.log(`  [setup] gemini provider active (id=${geminiActive.id.slice(0, 8)}…)`);
+      return true;
+    }
+
+    // Check if gemini exists but is expired — try to reactivate via DB
+    const geminiExpired = Array.isArray(connections)
+      ? connections.find((c: any) => c.provider === "gemini" && c.isActive)
+      : null;
+
+    if (geminiExpired) {
+      console.log(
+        `  [setup] gemini provider expired (id=${geminiExpired.id.slice(0, 8)}…), reactivating via DB...`
+      );
+      // The health check marks API-key connections as expired because it expects
+      // OAuth refresh tokens. Force test_status=active via direct DB update.
+      try {
+        const { getDbInstance } = await import("../../src/lib/db/core.ts");
+        const db = getDbInstance();
+        db.prepare(
+          "UPDATE provider_connections SET test_status = 'active', error_code = NULL, last_error = NULL WHERE id = ?"
+        ).run(geminiExpired.id);
+        console.log(`  [setup] Reactivated gemini connection ${geminiExpired.id.slice(0, 8)}…`);
+        return true;
+      } catch (dbErr) {
+        console.warn(`  [setup] DB reactivation failed: ${dbErr}`);
+      }
+    }
+
+    // No gemini connection at all — create one with GEMINI_API_KEY
+    if (!GEMINI_API_KEY) {
+      console.warn("  [setup] No active gemini connection and GEMINI_API_KEY not set — skipping");
+      return false;
+    }
+
+    console.log(`  [setup] Creating gemini provider with GEMINI_API_KEY...`);
+    const createRes = await apiFetch("/api/providers", {
+      method: "POST",
+      body: JSON.stringify({
+        provider: "gemini",
+        apiKey: GEMINI_API_KEY,
+        name: "gemini-test",
+        testStatus: "active",
+        healthCheckInterval: 999999999,
+      }),
+    });
+    if (!createRes.ok) {
+      const err = await createRes.text();
+      console.warn(`  [setup] Failed to create gemini provider: ${createRes.status} ${err}`);
+      return false;
+    }
+
+    const created = await createRes.json();
+    const connId = created?.connection?.id;
+    if (connId) {
+      // Force test_status=active via direct DB — the health check will otherwise
+      // mark it expired immediately because there's no OAuth refresh token.
+      try {
+        const { getDbInstance } = await import("../../src/lib/db/core.ts");
+        const db = getDbInstance();
+        db.prepare(
+          "UPDATE provider_connections SET test_status = 'active', error_code = NULL, last_error = NULL WHERE id = ?"
+        ).run(connId);
+        console.log(`  [setup] gemini provider created and activated (id=${connId.slice(0, 8)}…)`);
+      } catch (dbErr) {
+        console.warn(`  [setup] DB activation failed: ${dbErr}`);
+        console.log(`  [setup] gemini provider created (id=${connId?.slice(0, 8)}…)`);
+      }
+    }
+    return true;
+  } catch (err) {
+    console.warn(`  [setup] Could not check/create gemini provider: ${err}`);
+    return false;
+  }
+}
+
+async function ensureDefaultCombo(): Promise<void> {
+  try {
+    const res = await apiFetch("/api/combos");
+    if (!res.ok) return;
+    const data = await res.json();
+    const combos = data.combos || data;
+    const existing = Array.isArray(combos) ? combos.find((c: any) => c.name === "default") : null;
+
+    if (existing) {
+      console.log(
+        `  [setup] "default" combo exists (strategy=${existing.strategy}, models=${existing.models?.length})`
+      );
+      return;
+    }
+
+    console.log(`  [setup] Creating "default" combo with gemma-4 models...`);
+    const createRes = await apiFetch("/api/combos", {
+      method: "POST",
+      body: JSON.stringify(DEFAULT_COMBO_CONFIG),
+    });
+    if (createRes.ok) {
+      console.log(`  [setup] "default" combo created successfully`);
+    } else {
+      const err = await createRes.text();
+      console.warn(`  [setup] Failed to create "default" combo: ${createRes.status} ${err}`);
+    }
+  } catch (err) {
+    console.warn(`  [setup] Could not check/create combo: ${err}`);
+  }
+}
+
+export async function ensureTestEnvironment(): Promise<void> {
+  if (!API_KEY) return;
+  console.log(`\n  [setup] Ensuring test environment...`);
+  await ensureGeminiProvider();
+  await ensureDefaultCombo();
+}
+
+// --------------------------------------------------------------------------
+// Test Data Generator
+// --------------------------------------------------------------------------
+export type Message = { role: string; content: string };
+
+export function pick<T>(arr: T[]): T {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+export function randomInt(min: number, max: number): number {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+export const SYSTEM_PROMPTS = [
+  "You are a helpful coding assistant. Respond concisely and accurately.",
+  "You are a senior software engineer reviewing code. Be thorough and critical.",
+  "You are a data scientist analyzing complex datasets. Explain your reasoning step by step.",
+  "You are a technical writer creating documentation. Be clear and well-structured.",
+  "You are a DevOps engineer debugging infrastructure issues. Think about root causes.",
+  "You are a security auditor reviewing code for vulnerabilities. Be meticulous.",
+  "You are an AI researcher explaining concepts. Use analogies and examples.",
+  "You are a product manager evaluating technical proposals. Consider trade-offs.",
+];
+
+export const USER_PROMPTS = [
+  "Write a function that implements a trie data structure with insert, search, and startsWith methods.",
+  "Explain the difference between REST and GraphQL, with pros and cons of each.",
+  "Debug this code and explain what's wrong: function sum(a,b){return a+b} console.log(sum(1,2,3))",
+  "Write a SQL query to find the top 5 most common words in a articles table across all articles.",
+  "Compare and contrast Docker vs Podman for container orchestration.",
+  "Explain how HTTP/2 multiplexing works and why it improves performance.",
+  "Write a Python decorator that caches function results with a TTL.",
+  "What are the trade-offs between microservices and monoliths? When would you choose each?",
+  "Design a rate limiter algorithm. Compare token bucket vs sliding window.",
+  "Explain the CAP theorem and how it applies to distributed databases.",
+  "Write a React custom hook for WebSocket connections with auto-reconnect.",
+  "How does garbage collection work in V8 JavaScript engine?",
+  "Compare SQLite vs PostgreSQL for a production web application.",
+  "Write a bash script that monitors CPU and memory usage and alerts when thresholds are exceeded.",
+  "Explain zero-trust networking principles and how to implement them.",
+  "Write a TypeScript type-safe event emitter class.",
+  "How does TLS 1.3 handshake work? Compare with TLS 1.2.",
+  "Design a URL shortening service. Cover the database schema, API design, and scaling considerations.",
+  "Explain the event loop in Node.js with specific examples of microtasks vs macrotasks.",
+  "Write a regex to validate email addresses and explain the trade-offs.",
+  "Compare Kafka vs RabbitMQ for event-driven architectures.",
+  "How would you implement feature flags in a distributed system?",
+  "Write an implementation of Promise.all() with timeout support.",
+  "Explain the actor model and how it compares to traditional threading.",
+  "Design a caching strategy for a read-heavy API serving 10k requests/second.",
+];
+
+export const CODE_BLOCKS = [
+  `\`\`\`python
+def quicksort(arr):
+    if len(arr) <= 1:
+        return arr
+    pivot = arr[len(arr) // 2]
+    left = [x for x in arr if x < pivot]
+    middle = [x for x in arr if x == pivot]
+    right = [x for x in arr if x > pivot]
+    return quicksort(left) + middle + quicksort(right)
+\`\`\``,
+  `\`\`\`javascript
+const pipeline = (initial, ...fns) =>
+  fns.reduce((acc, fn) => fn(acc), initial);
+
+const result = pipeline(
+  5,
+  x => x * 2,
+  x => x + 1,
+  x => x ** 2
+);
+\`\`\``,
+  `\`\`\`typescript
+interface Task<T> {
+  id: string;
+  priority: number;
+  execute: () => Promise<T>;
+  timeout: number;
+}
+
+class TaskQueue<T> {
+  private queue: Task<T>[] = [];
+  private running = false;
+
+  async enqueue(task: Task<T>): Promise<T> {
+    return new Promise((resolve, reject) => {
+      this.queue.push({
+        ...task,
+        execute: () => task.execute().then(resolve).catch(reject),
+      });
+      if (!this.running) this.processNext();
+    });
+  }
+
+  private async processNext(): Promise<void> {
+    this.running = true;
+    const sorted = this.queue.sort((a, b) => b.priority - a.priority);
+    const task = sorted.shift();
+    if (task) {
+      const result = await task.execute();
+      this.processNext();
+    } else {
+      this.running = false;
+    }
+  }
+}
+\`\`\``,
+  `\`\`\`sql
+WITH word_freq AS (
+  SELECT
+    UNNEST(STRING_TO_ARRAY(LOWER(content), ' ')) AS word,
+    COUNT(*) AS cnt
+  FROM articles
+  WHERE content IS NOT NULL
+  GROUP BY word
+)
+SELECT word, cnt
+FROM word_freq
+WHERE LENGTH(word) > 3
+ORDER BY cnt DESC
+LIMIT 20;
+\`\`\``,
+  `\`\`\`yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-config
+  namespace: production
+data:
+  database.url: "postgresql://db.internal:5432/app"
+  redis.host: "redis-cluster.internal"
+  redis.port: "6379"
+  log.level: "info"
+  feature.flags: '{"darkMode":true,"betaApi":false,"newDashboard":true}'
+\`\`\``,
+];
+
+export const LONG_DOCUMENTS = [
+  `In distributed systems theory, the CAP theorem states that it is impossible for a distributed data store to simultaneously provide more than two out of the following three guarantees: Consistency (every read receives the most recent write or an error), Availability (every request receives a non-error response, without the guarantee that it contains the most recent write), and Partition Tolerance (the system continues to operate despite an arbitrary number of messages being dropped or delayed by the network between nodes). This fundamental trade-off was first articulated by Eric Brewer in 2000 and later formally proven as a theorem by Seth Gilbert and Nancy Lynch in 2002.
+
+  The practical implication of CAP is that when a network partition occurs, system designers must choose between consistency and availability. Traditional ACID-compliant databases like PostgreSQL typically choose consistency (CP), while many NoSQL systems like Cassandra choose availability (AP). However, modern systems increasingly recognize that CAP is not binary — techniques like conflict-free replicated data types (CRDTs), consensus algorithms like Raft, and hybrid approaches allow systems to achieve different trade-offs at different levels.
+
+  In practice, most production systems aim for "PA/EL" (Partition-Aware / Eventually-Literate) or use compensatory transactions to handle inconsistencies. The PACELC extension further refines CAP by noting that even when the network is functioning normally (no partition), there's still a trade-off between latency and consistency. Systems like Amazon DynamoDB and Google Spanner represent different points on this continuum, with Spanner using TrueTime to achieve external consistency at higher latency, while DynamoDB prioritizes availability and partition tolerance with weaker consistency models.`,
+
+  `Concurrency models represent fundamentally different approaches to managing multiple computations that overlap in time. The traditional threading model, used extensively in languages like Java and C++, relies on shared memory with explicit locking mechanisms (mutexes, semaphores, read-write locks) to coordinate access to shared state. This model is well-understood but notoriously difficult to get right — deadlocks, race conditions, and priority inversion are common bugs that can be extremely subtle.
+
+  The actor model, popularized by Erlang and later adopted by Akka, Dapr, and Orleans, takes a different approach: each actor is an independent computation unit with its own private state, communicating exclusively through asynchronous message passing. Actors can create other actors, send messages, and change their behavior for the next message they receive. This model eliminates shared-state concurrency issues entirely, since actors never share memory — they only share messages. The trade-off is that certain patterns (like distributed transactions) become more complex to implement.
+
+  Software Transactional Memory (STM) offers another paradigm, borrowing from database transactions to manage memory accesses. Clojure's STM, for instance, uses multiversion concurrency control (MVCC) to provide optimistic concurrency — transactions proceed in isolation and are committed atomically, with automatic retry on conflicts. STM can be more ergonomic than explicit locking, but performance overhead and the challenge of handling side effects within transactions remain concerns.
+
+  The structured concurrency model, recently gaining traction through Kotlin coroutines, Java virtual threads, and Swift's async/await, organizes concurrent operations into a hierarchy where each operation's lifetime is scoped to its enclosing block. This ensures proper cleanup, simplifies error propagation, and prevents resource leaks. Go's goroutines follow a similar philosophy with channels providing CSP-style communication (Communicating Sequential Processes), where processes communicate by sending values through typed channels rather than through shared memory.
+
+  For I/O-bound workloads, event-driven models (Node.js, Python asyncio, C# async/await) use an event loop to multiplex concurrent operations onto a single thread, avoiding context-switching overhead. This works well when the workload is primarily waiting on I/O, but CPU-bound work can block the event loop and degrade responsiveness. The modern trend is toward hybrid approaches that combine the scalability of event-driven models with the flexibility of thread pools for CPU-intensive work.`,
+
+  `Event sourcing is an architectural pattern where state changes are stored as an immutable sequence of events, rather than as the current state. Instead of updating a row in a database when a user changes their email address, you append an "EmailChanged" event to an event store. The current state is derived by replaying all events for that entity. This fundamental shift in thinking has profound implications for system design, traceability, and temporal queries.
+
+  The primary advantages of event sourcing include: complete audit trail (every state change is recorded with full context), temporal querying (you can reconstruct state at any point in time), event-driven architecture fit (events can be published to downstream consumers naturally), and the ability to create multiple different views (projections) from the same event stream. Command Query Responsibility Segregation (CQRS) is a natural companion pattern, where write operations use the event store and read operations use pre-computed projections optimized for specific query patterns.
+
+  However, event sourcing introduces significant complexity: event schema evolution must be carefully managed (events are permanent), the event store becomes a critical piece of infrastructure requiring careful backup and disaster recovery, and read models can be eventually consistent with the write model, potentially serving stale data. Common implementation patterns using PostgreSQL as an event store include the "outbox pattern" with transactional outbox tables, and using JSONB columns for flexible event payloads while maintaining indexed metadata columns for efficient querying.
+
+  Tools like Kafka (for event streaming), Debezium (for change data capture), and Axon Framework (for Java-based CQRS/ES) provide infrastructure to implement these patterns. The decision to adopt event sourcing should be driven by concrete requirements for audit trails, temporal queries, or complex event-driven workflows — it adds significant complexity that may not be justified for simpler CRUD applications.`,
+];
+
+export const AGENTIC_TASKS = [
+  "I need to build a microservice that processes webhook events. Let's start with the requirements. First, what should I consider when designing the webhook ingestion endpoint?",
+  "Let me show you what I have so far for the task queue system. Actually, first let me reconsider the requirements — we need to handle priorities and timeouts.",
+  "I'm working on refactoring the authentication module. Looking at the current code, I see we're using JWT with refresh tokens. But we also need API key auth for service-to-service communication.",
+  "Before we write any code, let me think about the data model. We have users, organizations, projects, and teams. Users can belong to multiple organizations and each project belongs to one organization.",
+  "Let me walk through the deployment pipeline. We build with Docker, push to GHCR, deploy to Kubernetes. But we're seeing issues with rolling updates — sometimes the old pods serve requests after the new ones are ready.",
+  "I just realized there's a security concern. We're exposing internal service names in error messages returned to the client. Let me check all the error handling paths.",
+  "OK I've been thinking about the caching strategy more. We need multi-layer caching: Redis for API responses, CDN for static assets, and browser caching for images. But invalidation is tricky — what happens when a user updates their avatar?",
+  "Let me trace through the payment flow end to end. User submits payment → we create a pending transaction → call Stripe → handle webhook → update order status → send confirmation email. Each step has failure modes.",
+];
+
+// --------------------------------------------------------------------------
+// Generator helpers
+// --------------------------------------------------------------------------
+
+export function genSystemMessage(): Message {
+  return { role: "system", content: pick(SYSTEM_PROMPTS) };
+}
+
+export function genUserMessage(): Message {
+  return { role: "user", content: pick(USER_PROMPTS) };
+}
+
+export function genCodeReviewMessage(): Message {
+  return {
+    role: "user",
+    content: `Review this code and suggest improvements:\n${pick(CODE_BLOCKS)}\n\nFocus on: performance, readability, edge cases.`,
+  };
+}
+
+export function genLongDocMessage(): Message {
+  return {
+    role: "user",
+    content: `Please summarize the following text and extract 5 key insights:\n\n${pick(LONG_DOCUMENTS)}`,
+  };
+}
+
+export function genAgenticTaskMessage(): Message {
+  return { role: "user", content: pick(AGENTIC_TASKS) };
+}
+
+export function genMultiTurnConversation(turns: number): Message[] {
+  const messages: Message[] = [];
+
+  if (Math.random() > 0.3) {
+    messages.push({ role: "system", content: pick(SYSTEM_PROMPTS) });
+  }
+
+  const topics = [
+    "building a real-time chat application with WebSockets",
+    "designing a distributed task queue",
+    "implementing OAuth 2.0 from scratch",
+    "optimizing database query performance at scale",
+    "creating a monitoring and alerting system",
+    "building a feature flag system with gradual rollout",
+    "designing an API gateway with rate limiting",
+    "implementing event-driven microservices",
+  ];
+
+  const topic = pick(topics);
+
+  const assistantReplies = [
+    `Great question about ${topic}. Let me break this down systematically and consider the key design decisions involved. First, we need to understand the core requirements and constraints. The main challenges here are around scalability, reliability, and maintainability.\n\nLet me start with the architecture: I'd recommend a layered approach. At the foundation, we need a solid data model. Then we build the business logic layer, followed by the API layer. For ${topic}, we should consider using established patterns like the repository pattern for data access and the strategy pattern for algorithm selection.\n\nHere's a concrete example of how I'd structure this:\n\n1. First, define clear interfaces and contracts\n2. Implement the core logic with dependency injection\n3. Add observability (metrics, logging, tracing)\n4. Write comprehensive tests\n5. Add performance optimizations iteratively`,
+    `Building on what we discussed about ${topic}, I want to dive deeper into the implementation details. There are several important design patterns that apply here.\n\nThe key insight is that we need to separate concerns properly. Let me illustrate with a specific scenario:\n\nConsider how data flows through the system. We receive input, process it through a pipeline, and produce output. Each stage of the pipeline should be independently testable and replaceable.\n\nSome common pitfalls to avoid:\n- Tight coupling between components\n- Neglecting error handling and edge cases\n- Premature optimization without profiling\n- Ignoring security implications\n\nInstead, focus on:\n- Clean interfaces between modules\n- Comprehensive error handling with meaningful messages\n- Performance baselines before optimization\n- Security review as part of the design process`,
+    `Let me reconsider my approach to ${topic}. After thinking about it more carefully, I realize there are some important nuances I should address.\n\nThe initial approach I suggested works for small to medium scale, but for production systems we need to consider:\n\n1. **Resilience**: What happens when dependencies fail? Circuit breakers, retries with exponential backoff, graceful degradation.\n2. **Observability**: How do we know the system is working correctly? Distributed tracing, structured logging, metrics with dashboards.\n3. **Operational complexity**: How do we deploy, monitor, and debug this in production?\n\nLet me revise the architecture to address these concerns...`,
+  ];
+
+  const followUps = [
+    `That's helpful. Now let me think about the specific implementation. How would you handle error cases where ${topic} encounters a failure mid-operation? Should we use compensating transactions or rollback?`,
+    `I see. Building on that, what about monitoring and observability for ${topic}? What metrics should we track and what alerting thresholds make sense?`,
+    `Interesting points. Going deeper — how would we test ${topic}? Integration tests? E2E tests? Property-based testing? What's the testing strategy?`,
+    `That makes sense. Now considering the deployment aspect — how would we roll out ${topic} incrementally? Feature flags? Blue-green deployment? Canary releases?`,
+    `One more thing — for ${topic}, how do we handle data consistency across services? Eventual consistency? Saga pattern? Two-phase commit?`,
+    `Let me think about the security implications of ${topic}. What are the threat models we should consider? Authentication, authorization, data encryption, audit logging?`,
+    `Good. Now about performance — what's the bottleneck in ${topic}? Database queries? Network calls? CPU-bound computation? How do we profile and optimize?`,
+  ];
+
+  messages.push({
+    role: "user",
+    content: `I need help with ${topic}. Can you walk me through the design and implementation?`,
+  });
+
+  const numTurns = Math.min(turns, 6);
+
+  for (let i = 0; i < numTurns; i++) {
+    messages.push({ role: "assistant", content: pick(assistantReplies) });
+    messages.push({ role: "user", content: pick(followUps) });
+  }
+
+  return messages;
+}
+
+export function genCodeConversation(): Message[] {
+  return [
+    {
+      role: "system",
+      content: "You are a senior developer reviewing production code. Be thorough.",
+    },
+    {
+      role: "user",
+      content: `I have this code that's causing performance issues in production. Can you help me optimize it?\n\n${pick(CODE_BLOCKS)}\n\nThe function is called about 10,000 times per second and we're seeing GC pressure.`,
+    },
+    {
+      role: "assistant",
+      content:
+        "Let me analyze the code for performance issues. I can see several opportunities for optimization:\n\n1. **Allocation pressure**: The code creates intermediate objects on every call. We should reuse buffers or use object pooling.\n2. **Algorithmic complexity**: The current approach is O(n²) but we can make it O(n log n) with a better data structure.\n3. **GC overhead**: Frequent allocations trigger GC pauses.\n\nLet me provide an optimized version that addresses these issues.",
+    },
+    {
+      role: "user",
+      content:
+        "Thanks, that helped a lot. Now, I also need to add error handling. What patterns do you recommend for this kind of batch processing? Should I use the Result pattern, exceptions, or something else?",
+    },
+    {
+      role: "assistant",
+      content:
+        "For batch processing, I recommend a combination approach:\n\nUse a Result/Either type for expected failures (validation errors, not-found cases) and exceptions for unexpected failures (network errors, bugs). This gives you typed error handling for business logic while keeping unexpected errors visible.\n\nHere's a pattern I use:\n\n```typescript\ntype Result<T, E = Error> = { ok: true; value: T } | { ok: false; error: E };\n\nasync function processBatch(items: Item[]): Promise<Result<Processed[], BatchError>> {\n  const results: Processed[] = [];\n  for (const item of items) {\n    try {\n      const processed = await processItem(item);\n      results.push(processed);\n    } catch (err) {\n      return { ok: false, error: new BatchError(item.id, err) };\n    }\n  }\n  return { ok: true, value: results };\n}\n```\n\nThis way callers can pattern-match on the result without try/catch everywhere.",
+    },
+    {
+      role: "user",
+      content:
+        "That pattern looks clean. One more question — how should I test the batch processor? I want good coverage but the tests are slow because of the async operations.",
+    },
+  ];
+}
+
+// --------------------------------------------------------------------------
+// SSE Stream Reader
+// --------------------------------------------------------------------------
+
+interface StreamResult {
+  fullContent: string;
+  finishReason: string;
+  totalTokens: number;
+}
+
+export async function readSSEStream(response: Response): Promise<StreamResult> {
+  const reader = response.body!.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let fullContent = "";
+  let finishReason = "unknown";
+  let totalTokens = 0;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split("\n");
+    buffer = lines.pop() || "";
+
+    for (const line of lines) {
+      if (!line.startsWith("data: ")) continue;
+      const data = line.slice(6).trim();
+      if (data === "[DONE]") continue;
+
+      try {
+        const parsed = JSON.parse(data) as Record<string, unknown>;
+        const choice = ((parsed?.choices ?? []) as Array<Record<string, unknown>>)[0];
+        if (choice) {
+          const delta = choice.delta as Record<string, unknown> | undefined;
+          if (delta?.content) fullContent += delta.content as string;
+          if (choice.finish_reason) finishReason = choice.finish_reason as string;
+        }
+        const usage = parsed.usage as Record<string, number> | undefined;
+        if (usage) {
+          totalTokens =
+            usage.total_tokens ?? (usage.prompt_tokens ?? 0) + (usage.completion_tokens ?? 0);
+        }
+      } catch {
+        // skip malformed chunks
+      }
+    }
+  }
+
+  return { fullContent, finishReason, totalTokens };
+}
+
+// --------------------------------------------------------------------------
+// Shared helper
+// --------------------------------------------------------------------------
+
+export async function sendAndValidate(
+  tcName: string,
+  buildMessages: () => Message[],
+  stream = true
+): Promise<{
+  status: number;
+  duration: number;
+  tokens: number;
+  contentLength: number;
+  correlationId: string;
+}> {
+  const MAX_RETRIES = 3;
+  const RETRY_DELAY_MS = 10_000;
+
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    const messages = buildMessages();
+
+    const controller = new AbortController();
+    const requestTimeoutMs = Number(process.env.TEST_REQUEST_TIMEOUT_MS) || 600_000;
+    const timeout = setTimeout(() => controller.abort(), requestTimeoutMs);
+    const start = performance.now();
+
+    try {
+      const response = await fetch(`${BASE_URL}/v1/chat/completions`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${API_KEY}`,
+        },
+        body: JSON.stringify({
+          model: MODEL,
+          messages,
+          stream,
+          max_tokens: 4096,
+          temperature: 0.3,
+        }),
+        signal: controller.signal,
+      });
+
+      const duration = performance.now() - start;
+      clearTimeout(timeout);
+
+      const correlationId = response.headers.get("x-correlation-id") || "?";
+      let content = "";
+      let finishReason = "unknown";
+      let totalTokens = 0;
+
+      if (stream) {
+        const streamResult = await readSSEStream(response);
+        content = streamResult.fullContent;
+        finishReason = streamResult.finishReason;
+        totalTokens = streamResult.totalTokens;
+      } else {
+        const json = await response.json().catch(() => ({}));
+        const choice = json?.choices?.[0];
+        content = choice?.message?.content || "";
+        finishReason = choice?.finish_reason || "unknown";
+        totalTokens = json?.usage?.total_tokens || 0;
+      }
+
+      const msPerToken = totalTokens > 0 ? (duration / totalTokens).toFixed(1) : "?";
+
+      console.log(
+        `  ${tcName.padEnd(45)} ` +
+          `HTTP ${response.status} | ` +
+          `${Math.round(duration).toString().padStart(5)}ms | ` +
+          `${String(messages.length).padStart(2)} msgs | ` +
+          `${String(totalTokens).padStart(5)} tok | ` +
+          `${msPerToken.padStart(4)} ms/tok | ` +
+          `finish: ${finishReason} | ` +
+          `response: ${content.length} chars | ` +
+          `cid: ${correlationId}`
+      );
+
+      if (response.status === 200) {
+        if (content.length > 0) {
+          assert.ok(
+            finishReason === "stop" || finishReason === "length",
+            `expected stop/length finish, got ${finishReason}`
+          );
+        } else {
+          assert.fail(`  ${tcName.padEnd(45)} WARNING: empty content returned`);
+        }
+      } else if ((response.status === 503 || response.status === 429) && attempt < MAX_RETRIES) {
+        console.log(
+          `  ${tcName.padEnd(45)} RETRY ${attempt}/${MAX_RETRIES} after ${response.status} (waiting ${RETRY_DELAY_MS / 1000}s)`
+        );
+        await new Promise((r) => setTimeout(r, RETRY_DELAY_MS));
+        continue;
+      } else {
+        const errorBody = await response.text().catch(() => "unknown");
+        assert.fail(`HTTP ${response.status}: ${errorBody}`);
+      }
+
+      return {
+        status: response.status,
+        duration,
+        tokens: totalTokens,
+        contentLength: content.length,
+        correlationId,
+      };
+    } catch (err) {
+      clearTimeout(timeout);
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      if ((errorMessage.includes("503") || errorMessage.includes("429")) && attempt < MAX_RETRIES) {
+        console.log(
+          `  ${tcName.padEnd(45)} RETRY ${attempt}/${MAX_RETRIES} after error (waiting ${RETRY_DELAY_MS / 1000}s)`
+        );
+        await new Promise((r) => setTimeout(r, RETRY_DELAY_MS));
+        continue;
+      }
+      console.log(`  ${tcName.padEnd(45)} FAILED: ${errorMessage}`);
+      throw err;
+    }
+  }
+  throw new Error("Max retries exceeded");
+}
+
+// --------------------------------------------------------------------------
+// CASE_BUILDERS: 25 named payload generators (shared by streaming + non-streaming)
+// --------------------------------------------------------------------------
+
+export const CASE_BUILDERS = [
+  { name: "basic coding question", build: (): Message[] => [genSystemMessage(), genUserMessage()] },
+  {
+    name: "code review request",
+    build: (): Message[] => [genSystemMessage(), genCodeReviewMessage()],
+  },
+  {
+    name: "long document analysis",
+    build: (): Message[] => [genSystemMessage(), genLongDocMessage()],
+  },
+  { name: "direct question no system", build: (): Message[] => [genUserMessage()] },
+  {
+    name: "agentic planning task",
+    build: (): Message[] => [genSystemMessage(), genAgenticTaskMessage()],
+  },
+  { name: "agentic 3-turn conversation", build: (): Message[] => genMultiTurnConversation(3) },
+  { name: "agentic 5-turn conversation", build: (): Message[] => genMultiTurnConversation(5) },
+  { name: "agentic 2-turn conversation", build: (): Message[] => genMultiTurnConversation(2) },
+  { name: "agentic 4-turn conversation", build: (): Message[] => genMultiTurnConversation(4) },
+  { name: "agentic 6-turn conversation", build: (): Message[] => genMultiTurnConversation(6) },
+  { name: "code conversation with review", build: (): Message[] => genCodeConversation() },
+  {
+    name: "code review with long doc",
+    build: (): Message[] => [
+      genSystemMessage(),
+      genLongDocMessage(),
+      {
+        role: "user",
+        content: `Now let's apply this to actual code. Optimize this:\n${pick(CODE_BLOCKS)}`,
+      },
+    ],
+  },
+  {
+    name: "multi-part coding task",
+    build: (): Message[] => [
+      genSystemMessage(),
+      {
+        role: "user",
+        content: `First, let me understand the problem. I need to build a webhook processor.\n\n${pick(CODE_BLOCKS)}\n\nActually, let me also consider the monitoring aspects after the initial implementation.`,
+      },
+      {
+        role: "assistant",
+        content:
+          "Let me outline the architecture for a robust webhook processor. The key components are:\n\n1. **Ingestion endpoint**: Validates signatures, deduplicates, queues\n2. **Processing pipeline**: Routes to handlers based on event type\n3. **Retry logic**: Exponential backoff with dead letter queue\n4. **Monitoring**: Metrics for throughput, latency, error rates\n\nHere's a detailed design...",
+      },
+      {
+        role: "user",
+        content:
+          "Great breakdown. Now let's focus on the retry logic specifically. I need it to handle different error types differently: 4xx should not retry, 5xx should retry up to 3 times, and network errors should retry up to 5 times with shorter intervals.",
+      },
+    ],
+  },
+  {
+    name: "debugging session simulation",
+    build: (): Message[] => [
+      genSystemMessage(),
+      {
+        role: "user",
+        content: `I'm seeing this error in production and I can't figure out the root cause:\n\n\`\`\`\nError: EMFILE: too many open files\n    at FSReqCallback.open (node:fs:249)\n    at Object.openSync (node:fs:466)\n    at Object.readFileSync (node:fs:355)\n\`\`\`\n\nThis happens intermittently under load. The service processes file uploads.`,
+      },
+      {
+        role: "assistant",
+        content:
+          "The EMFILE error occurs when a process exceeds the file descriptor limit. Let me help you debug this systematically:\n\n1. **Check the current limit**: `ulimit -n` shows the soft limit\n2. **Find descriptor leaks**: Use `lsof -p <PID>` to list open files\n3. **Common causes**:\n   - Streams not properly closed after processing\n   - Database connections not returned to pool\n   - File handles held by garbage collector\n\nMost likely you're opening file streams in your upload handler without properly closing them in all code paths (especially error paths).",
+      },
+      {
+        role: "user",
+        content:
+          "You're right, I found it! We were using `fs.readFileSync` in a middleware but not catching errors — on validation failures the file handle was leaking. What's the best pattern to prevent this?",
+      },
+      {
+        role: "assistant",
+        content:
+          "Great find! Here's the recommended pattern:\n\n```typescript\nimport { open, readFile, unlink } from 'fs/promises';\n\nasync function processUpload(path: string) {\n  let file;\n  try {\n    file = await open(path, 'r');\n    const data = await readFile(file);\n    // validate and process\n  } finally {\n    await file?.close().catch(() => {});\n    await unlink(path).catch(() => {}); // cleanup temp file\n  }\n}\n```\n\nKey principles:\n- Always use `finally` for cleanup\n- Prefer async file operations\n- Use the file handle API (open → use → close) rather than one-shot methods for long-lived operations\n- Add file descriptor monitoring in production",
+      },
+      {
+        role: "user",
+        content:
+          "Perfect, that's very clear. Now let me also think about monitoring — what metrics should we expose around file descriptors to catch this early next time?",
+      },
+    ],
+  },
+  {
+    name: "architecture discussion with trade-offs",
+    build: (): Message[] => [
+      genSystemMessage(),
+      genLongDocMessage(),
+      {
+        role: "assistant",
+        content:
+          "Based on the document, I can extract the following key insights about distributed systems design...\n\n1. **CAP theorem trade-offs** need careful evaluation based on your specific use case\n2. **Consensus algorithms** like Raft provide strong consistency but at latency cost\n3. **Event-driven architectures** offer scalability but require careful handling of eventual consistency\n4. **CQRS + Event Sourcing** gives flexibility but adds operational complexity\n5. **Monitoring and observability** are critical in distributed systems",
+      },
+      {
+        role: "user",
+        content:
+          "Given these insights, how would you architect a payment processing system that needs both strong consistency (for balances) and high availability (for the API)? This seems like the classic CAP dilemma applied to fintech.",
+      },
+    ],
+  },
+  {
+    name: "JSON-heavy structured data prompt",
+    build: (): Message[] => [
+      genSystemMessage(),
+      {
+        role: "user",
+        content: `Here's a JSON payload from our API. Transform it into a different structure and explain your changes:\n\n${JSON.stringify(
+          {
+            event: "order.created",
+            timestamp: new Date().toISOString(),
+            data: {
+              orderId: `ord_${randomInt(100000, 999999)}`,
+              customer: {
+                id: `cus_${randomInt(10000, 99999)}`,
+                tier: ["basic", "premium", "enterprise"][randomInt(0, 2)],
+              },
+              items: Array.from({ length: randomInt(3, 8) }, (_, i) => ({
+                sku: `SKU-${String(i + 1).padStart(4, "0")}`,
+                name: pick([
+                  "Widget Pro",
+                  "Deluxe Gadget",
+                  "Basic Tool",
+                  "Premium Service",
+                  "Add-on Pack",
+                ]),
+                quantity: randomInt(1, 5),
+                price: parseFloat((Math.random() * 200 + 5).toFixed(2)),
+              })),
+              total: 0,
+              shipping: {
+                method: pick(["standard", "express", "overnight"]),
+                address: {
+                  street: "123 Main St",
+                  city: "San Francisco",
+                  state: "CA",
+                  zip: "94105",
+                },
+              },
+              payment: { method: pick(["card", "wallet", "invoice"]), status: "pending" },
+            },
+          },
+          null,
+          2
+        )}`,
+      },
+    ],
+  },
+  {
+    name: "markdown formatting prompt",
+    build: (): Message[] => [
+      genSystemMessage(),
+      {
+        role: "user",
+        content: `# Architecture Review Request
+
+## Project Overview
+We are building a **real-time collaboration platform** similar to Google Docs but for code editing.
+
+## Requirements
+1. Real-time sync using **CRDTs** (not OT)
+2. **Multi-cursor** support with presence awareness
+3. **Offline-first** with conflict resolution
+4. **Plugin system** for extensions
+
+## Questions
+1. What's the best CRDT implementation for this use case?
+2. How do we handle **large documents** (100k+ lines)?
+3. What's the **performance budget** for sync operations?
+
+## Current Stack
+| Component | Technology | Status |
+|-----------|------------|--------|
+| Frontend | React + Monaco Editor | POC done |
+| Sync Layer | Yjs | POC done |
+| Backend | Node.js + WebSockets | In progress |
+| Storage | PostgreSQL | Planned |
+| Auth | OAuth 2.0 + JWT | Done |
+
+Please provide a detailed analysis with code examples.`,
+      },
+    ],
+  },
+  {
+    name: "multi-part instructions with constraints",
+    build: (): Message[] => [
+      genSystemMessage(),
+      {
+        role: "user",
+        content: `I need you to solve this problem with specific constraints:
+
+PROBLEM: Design a rate-limited API proxy that:
+1. Routes requests to different backends based on path prefix
+2. Enforces per-tenant rate limits (100 req/s per tenant)
+3. Caches responses with configurable TTL
+4. Logs all requests with timing data
+
+CONSTRAINTS:
+- Must handle 50k req/s peak
+- P99 latency must stay under 50ms
+- No single point of failure
+- Must support gradual rollout
+
+Please provide:
+1. Architecture diagram (ASCII art)
+2. Data structures
+3. Key algorithms
+4. Trade-offs`,
+      },
+    ],
+  },
+  {
+    name: "debugging with stack trace",
+    build: (): Message[] => [
+      genSystemMessage(),
+      {
+        role: "user",
+        content: `I'm getting this error in production. Help me debug it:\n\n\`\`\`\nTypeError: Cannot read properties of undefined (reading 'map')\n    at transformResponse (/app/src/services/transformer.ts:142:23)\n    at processResponse (/app/src/middleware/response.ts:89:14)\n    at processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at async handleRequest (/app/src/router/index.ts:234:18)\n    at async Server.handle (/app/src/server.ts:56:22)\n\`\`\`\n\nThe relevant code at line 142:\n\`\`\`typescript\nconst transformed = response.data.items.map(item => ({\n  id: item.id,\n  name: item.attributes.name,\n  price: item.attributes.price,\n}));\n\`\`\`\n\nI think the issue is that \`response.data.items\` is sometimes undefined. What's the best way to handle this? Should I validate the response shape, use optional chaining, or something else?`,
+      },
+    ],
+  },
+  {
+    name: "comparative analysis request",
+    build: (): Message[] => [
+      genSystemMessage(),
+      {
+        role: "user",
+        content: `Compare these three approaches to handling async operations in JavaScript/TypeScript. For each, provide:\n1. A concrete code example\n2. Error handling strategy\n3. Performance characteristics\n4. When to use it\n\n**Approach 1: Callbacks**\n**Approach 2: Promises with async/await**\n**Approach 3: Observables (RxJS)**\n\nI'm specifically interested in:\n- How cancellation works in each\n- Memory implications for long-lived operations\n- Composability (combining multiple async operations)`,
+      },
+    ],
+  },
+  {
+    name: "very long single user message",
+    build: (): Message[] => [
+      genSystemMessage(),
+      {
+        role: "user",
+        content: `I need a comprehensive analysis of the following topics. Please address each one in detail:\n\n${LONG_DOCUMENTS.join("\n\n---\n\n")}\n\nFor each section above, please:\n1. Summarize the key points\n2. Identify any logical gaps or missing information\n3. Suggest practical applications\n4. List follow-up questions that would deepen understanding`,
+      },
+    ],
+  },
+  {
+    name: "system prompt + multi-part code task",
+    build: (): Message[] => [
+      {
+        role: "system",
+        content:
+          "You are a strict code reviewer. Always point out potential bugs, security issues, and performance problems. Use specific line references.",
+      },
+      {
+        role: "user",
+        content: `Review this React component for production readiness:\n\n${pick(CODE_BLOCKS)}\n\n${pick(CODE_BLOCKS)}`,
+      },
+    ],
+  },
+  {
+    name: "conversation with long assistant responses",
+    build: (): Message[] => [
+      genSystemMessage(),
+      {
+        role: "user",
+        content:
+          "Explain how modern CPU architectures handle branch prediction and speculative execution, including the security implications.",
+      },
+      {
+        role: "assistant",
+        content: `Modern CPU branch prediction is a fascinating and complex topic with significant security implications.
+
+**How Branch Prediction Works**
+
+Modern processors use deep pipelines (14-20 stages in modern x86 CPUs). To keep these pipelines full, they need to predict which way branches will go before the condition is actually evaluated. Processors maintain several structures:
+
+1. **Branch Target Buffer (BTB)**: Caches the target address of recently executed branches. When a branch instruction is decoded, the BTB predicts the target.
+
+2. **Branch History Table (BHT) / Pattern History Table (PHT)**: Tracks the recent outcomes of branches (taken/not taken) using 2-bit saturating counters. A branch that was taken twice in a row is likely to be taken again.
+
+3. **Return Stack Buffer (RSB)**: A hardware stack that predicts return addresses for CALL/RET instructions. Since returns are indirect (the address depends on the call site), the RSB provides much better accuracy than the BTB for returns.
+
+4. **Tournament Predictors**: Modern CPUs combine multiple prediction strategies (e.g., local predictor per branch, global predictor that considers branch history) and select the best performer. The Intel Pentium M's "Hybrid Predictor" and later "Perceptron Predictors" in some designs are examples.
+
+**Speculative Execution**
+
+Once a prediction is made, the CPU speculatively executes instructions along the predicted path before the branch condition is resolved. This includes:
+- Computing addresses and loading data into cache
+- Executing arithmetic operations
+- Even writing to architectural state (though these are retired only if the prediction was correct)
+
+If the prediction was wrong, the CPU must:
+1. Flush the pipeline (discard all speculatively executed instructions)
+2. Restore the architectural state to the checkpoint before the branch
+3. Fetch from the correct path
+
+The performance penalty for a misprediction is roughly 10-20 cycles on modern CPUs — hence the massive investment in accurate prediction.
+
+**Security Implications: Spectre and Meltdown**
+
+The problem is that speculative execution leaves side-effect traces in microarchitectural state, particularly the cache. Here's how Spectre Variant 1 (Bounds Check Bypass) works:
+
+\`\`\`c
+if (x < array1->length) {
+    // Speculatively executed even when x is out of bounds
+    value = array2[array1[x] * 4096];  // Cache-timing side channel
+}
+\`\`\`
+
+By training the branch predictor to predict the bounds check will pass, an attacker can cause speculative access to arbitrary memory. The value read affects which cache line of array2 is loaded, which can be detected through timing measurements.
+
+Mitigations include:
+- **LFENCE serialization**: Insert serializing instructions after bounds checks (heavy overhead)
+- **Retpolines**: Replace indirect branches with returns to confuse the BTB
+- **Indirect Branch Restricted Speculation (IBRS)**: Hardware-level mitigation in newer CPUs
+- **Single Thread Indirect Branch Predictor (STIBP)**: Prevents cross-hyperthread predictor interference
+
+Meltdown (CVE-2018-3615) is a related but distinct attack where the CPU speculatively executes instructions after a fault (not a branch misprediction), allowing access to kernel memory from user space. This affects primarily Intel and some ARM cores.
+
+**Modern Defenses**
+
+Starting with Intel's "Security First" architecture (Ice Lake and later), hardware mitigations include:
+- **Predictor tagging by privilege level**: Branch predictors are tagged with the CPL, preventing user-mode training from affecting kernel predictions
+- **Hardware-enforced bounds checking**: Some instructions can be marked to prevent speculation past them
+- **Mitigation-less performance**: Newer generations have reduced the performance impact of software mitigations from 30%+ to 2-5%`,
+      },
+      {
+        role: "user",
+        content: `That's a great overview. Now, zooming in on one specific aspect: how do Return Stack Buffer (RSB) and CALL/RET prediction work at the microarchitectural level? Specifically, how does the CPU handle:
+
+1. Deeply nested function calls (e.g., recursive functions with 100+ levels)
+2. Indirect function calls through function pointers
+3. Return-oriented programming (ROP) exploits and how CET/Shadow Stack mitigates them
+
+Also, can you explain the "RSB underflow" issue when switching between privilege levels?`,
+      },
+      {
+        role: "assistant",
+        content: `Excellent questions. Let me dive deep into each area.
+
+**RSB Microarchitecture**
+
+The Return Stack Buffer is a specialized predictor implemented as a circular buffer (typically 16-48 entries in modern CPUs). Each CALL instruction pushes the return address onto this hardware stack. Each RET instruction pops the top entry and uses it as the predicted target.
+
+The key insight is that the RSB is a true stack — it naturally handles nested calls correctly, unlike the BTB which would confuse RET instructions that can have many different targets depending on context.
+
+1. **Deeply Nested Calls (100+ levels)**:
+
+When the nesting depth exceeds the RSB size:
+- The bottom entries are simply overwritten (circular buffer behavior)
+- On return beyond the RSB depth, the CPU experiences an **RSB underflow** — there's no valid prediction available
+- The fallback mechanism varies by microarchitecture:
+  - Intel Sandy Bridge and earlier: falls back to BTB prediction for RETs (poor accuracy)
+  - Intel Haswell and later: uses a "return predictor" that's actually a secondary BTB trained on RET behavior
+  - AMD Zen: uses a hybrid approach with a deeper RSB-like structure
+
+2. **Indirect Calls Through Function Pointers**:
+
+Modern CPUs handle indirect calls and returns quite differently:
+- **Indirect calls** (CALL [rax]): predicted using the BTB, which stores mapping from the indirect call instruction address to the recently used target(s).
+- **Indirect jumps** (JMP [rax]): same BTB mechanism
+- **RET instructions**: predicted via RSB exclusively
+
+3. **Return-Oriented Programming and CET**:
+
+ROP works precisely because of how RSB prediction functions:
+- The attacker finds small instruction sequences ("gadgets") ending in RET in existing code
+- By overflowing the stack or corrupting the return address, the attacker chains these gadgets
+
+**Control-flow Enforcement Technology (CET)**:
+
+Intel CET provides two complementary protections:
+
+a) **Shadow Stack (SHSTK)**: A separate, hardware-protected stack that shadows the return addresses pushed by CALL instructions. On RET, the CPU compares the return address from the regular stack with the shadow stack — any mismatch triggers a hardware exception.
+
+b) **Indirect Branch Tracking (IBT)**: For indirect CALL and JMP instructions, the target must begin with an ENDBRANCH instruction. This prevents JOP/COP attacks.
+
+**RSB Underflow Between Privilege Levels**:
+
+When switching from a higher privilege level (kernel) to a lower one (user):
+1. The CPU executes a SYSRET or IRET instruction
+2. The RSB had entries from kernel-mode CALL instructions
+3. These entries predict return addresses *within the kernel*
+4. In user mode, the RSB may predict kernel addresses — speculatively executing kernel code from user space!
+
+The mitigation (kernel RSB stuffing) involves executing 32 fake CALL instructions after transitioning to user mode, pushing and popping to overwrite the RSB entries with harmless addresses.`,
+      },
+      {
+        role: "user",
+        content:
+          "Fascinating. One last question on this topic — how do AMD and ARM implementations compare to Intel's here? I'm particularly interested in ARM's PAC (Pointer Authentication) and how it differs from CET's shadow stack approach.",
+      },
+    ],
+  },
+  {
+    name: "mixed content types in conversation",
+    build: (): Message[] => [
+      genSystemMessage(),
+      {
+        role: "user",
+        content: `I need to process this data and then answer questions about it. First, here's the data:\n\n## System Configuration\n${JSON.stringify(
+          {
+            environment: "production",
+            region: pick(["us-east-1", "eu-west-1", "ap-southeast-1"]),
+            services: [
+              { name: "api-gateway", replicas: 3, memory: "512Mi", cpu: "250m" },
+              { name: "user-service", replicas: 5, memory: "1Gi", cpu: "500m" },
+              { name: "payment-service", replicas: 2, memory: "2Gi", cpu: "1" },
+              { name: "notification-service", replicas: 2, memory: "256Mi", cpu: "100m" },
+            ],
+            databases: [
+              { name: "postgres-primary", type: "PostgreSQL", version: "16", storage: "500Gi" },
+              { name: "redis-cache", type: "Redis", version: "7", storage: "50Gi" },
+              { name: "clickhouse-analytics", type: "ClickHouse", version: "24", storage: "2Ti" },
+            ],
+            monitoring: {
+              prometheus: { retention: "30d", storage: "200Gi" },
+              grafana: { plugins: ["prometheus", "elasticsearch", "cloudwatch"] },
+              alertmanager: { slack: true, pagerduty: true, email: true },
+            },
+          },
+          null,
+          2
+        )}\n\nHere's a SQL query that aggregates the deployment data:\n\n${pick(CODE_BLOCKS)}`,
+      },
+      {
+        role: "assistant",
+        content:
+          "I've analyzed your deployment configuration. Here are my observations:\n\n**Resource Allocation Analysis:**\n- Your API gateway has reasonable resource allocation for typical traffic patterns\n- The payment service has significant CPU allocation which suggests CPU-bound processing\n- Notification service appears under-provisioned if you handle high throughput\n\n**Potential Issues:**\n1. Single PostgreSQL primary is a single point of failure — consider read replicas\n2. No connection pooling configuration visible — pgbouncer recommended\n3. ClickHouse storage seems high — verify your data retention policies\n\n**Recommendations:**\n1. Add pod disruption budgets for production services\n2. Configure horizontal pod autoscaling with appropriate metrics\n3. Consider separating batch workloads onto spot instances",
+      },
+      {
+        role: "user",
+        content: `Great analysis. Now, let me give you some additional context and ask specific questions:\n\n1. We're seeing increased latency in the payment service during peak hours. The CPU usage goes to 80%+ and response times spike from 200ms to 2s. What should we investigate first?\n\n2. For the notification service, we're planning to scale from 2 to 10 replicas ahead of a Black Friday event. Besides increasing replicas, what else should we prepare?\n\n3. Looking at the SQL query in the config — that's actually a migration script that's running slowly. It takes 45 minutes on the primary. How would you optimize it without significant refactoring?`,
+      },
+      {
+        role: "assistant",
+        content:
+          "Let me address each question:\n\n**1. Payment Service Latency**\n\nThe 2s spike at 80% CPU suggests CPU contention. Common causes:\n- Cryptography operations — consider caching\n- JSON serialization — use streaming\n- Synchronous database calls — verify connection pool settings\n\n**2. Black Friday Scaling for Notifications**\n\n- Pre-warm connection pools\n- Queue-based architecture with SQS/RabbitMQ\n- Rate limiting downstream API calls\n- Degrade gracefully with priority levels\n- Load test at 2x expected load\n\n**3. Slow Migration Query**\n\nBatch processing:\n```sql\nDO $$\nDECLARE\n  batch_size CONSTANT INTEGER := 10000;\nBEGIN\n  FOR i IN 0..(SELECT CEIL(COUNT(*)/batch_size) FROM target_table) LOOP\n    UPDATE target_table\n    SET processed = true\n    WHERE ctid IN (\n      SELECT ctid FROM target_table\n      WHERE processed IS false\n      LIMIT batch_size\n    );\n    COMMIT;\n    PERFORM pg_sleep(0.1);\n  END LOOP;\nEND $$;\n```",
+      },
+      {
+        role: "user",
+        content:
+          "The batching approach for the migration seems most practical. One concern though — the migration also needs to backfill a new column based on data from a JOIN with another table that has 5M rows.",
+      },
+    ],
+  },
+  {
+    name: "long context with repeated patterns",
+    build: (): Message[] => [
+      genSystemMessage(),
+      ...Array.from({ length: 5 }, () => [
+        {
+          role: "user",
+          content: `Consider this scenario in a microservices architecture: ${pick(AGENTIC_TASKS)}`,
+        },
+        {
+          role: "assistant",
+          content: `Here's my analysis of this scenario. The key considerations are scalability, fault tolerance, and operational complexity. Let me break this down...\n\n1. **Architecture**: We need to consider the overall system design and how components interact\n2. **Data flow**: Understanding how data moves through the system is critical\n3. **Failure modes**: Each component can fail in different ways\n4. **Monitoring**: We need observability at every layer\n\nThe recommended approach depends on your specific constraints around latency, throughput, and consistency requirements.`,
+        },
+      ]).flat(),
+      {
+        role: "user",
+        content:
+          "Now, given all the scenarios above, what common patterns do you see? Are there any cross-cutting concerns that appear in multiple scenarios?",
+      },
+    ],
+  },
+];

--- a/tests/unit/apikey-connection-health-check.test.ts
+++ b/tests/unit/apikey-connection-health-check.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Regression test: API-key-only connections must not be falsely expired.
+ *
+ * Bug: tokenHealthCheck.checkConnection() marked API-key-only connections
+ * (e.g. gemini with just an API key, no OAuth refresh token) as
+ * testStatus="expired" because it expected OAuth refresh tokens for any
+ * provider in the supportsTokenRefresh set.
+ *
+ * Fix: connections that have an apiKey configured are skipped during OAuth
+ * token validation, since they don't require refresh tokens.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+process.env.NODE_ENV = "test";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-apikey-health-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const providersDb = await import("../../src/lib/db/providers.ts");
+const { checkConnection } = await import("../../src/lib/tokenHealthCheck.ts");
+
+async function resetStorage() {
+  core.resetDbInstance();
+  for (let attempt = 0; attempt < 10; attempt++) {
+    try {
+      if (fs.existsSync(TEST_DATA_DIR)) {
+        fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+      }
+      break;
+    } catch (error: any) {
+      if ((error?.code === "EBUSY" || error?.code === "EPERM") && attempt < 9) {
+        await new Promise((resolve) => setTimeout(resolve, 50 * (attempt + 1)));
+      } else {
+        throw error;
+      }
+    }
+  }
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+test.after(async () => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("API-key-only gemini connection is NOT marked expired by health check", async () => {
+  await resetStorage();
+
+  // Create a gemini connection with an API key but no refresh token
+  const conn = await providersDb.createProviderConnection({
+    provider: "gemini",
+    name: "gemini-apikey-test",
+    apiKey: "AIzaSyTest1234567890abcdefghijklmnop",
+    isActive: true,
+    testStatus: "active",
+    healthCheckInterval: 60,
+    // No refreshToken — this is an API-key-only connection
+  });
+
+  assert.equal(conn.testStatus, "active", "precondition: connection starts as active");
+
+  // Run the health check
+  await checkConnection(conn);
+
+  // Re-read from DB
+  const updated = await providersDb.getProviderConnectionById(conn.id);
+
+  assert.equal(
+    updated?.testStatus,
+    "active",
+    "API-key-only connection should remain active — not be marked expired"
+  );
+  assert.notEqual(
+    updated?.errorCode,
+    "no_refresh_token",
+    "API-key-only connection should not get no_refresh_token error"
+  );
+});
+
+test("gemini connection WITHOUT apiKey AND WITHOUT refreshToken IS marked expired", async () => {
+  await resetStorage();
+
+  // Create a gemini OAuth connection that lost its refresh token
+  const conn = await providersDb.createProviderConnection({
+    provider: "gemini",
+    name: "gemini-oauth-no-refresh",
+    accessToken: "ya29.expired-token",
+    isActive: true,
+    testStatus: "active",
+    healthCheckInterval: 60,
+    // No apiKey, no refreshToken — this is a broken OAuth connection
+  });
+
+  assert.equal(conn.testStatus, "active", "precondition: connection starts as active");
+
+  // Run the health check
+  await checkConnection(conn);
+
+  // Re-read from DB
+  const updated = await providersDb.getProviderConnectionById(conn.id);
+
+  assert.equal(
+    updated?.testStatus,
+    "expired",
+    "OAuth connection without refresh token should be marked expired"
+  );
+  assert.equal(
+    updated?.errorCode,
+    "no_refresh_token",
+    "OAuth connection should get no_refresh_token error code"
+  );
+});
+
+test("API-key-only antigravity connection is NOT marked expired by health check", async () => {
+  await resetStorage();
+
+  // antigravity also supports token refresh — verify the fix applies to all providers
+  const conn = await providersDb.createProviderConnection({
+    provider: "antigravity",
+    name: "agy-apikey-test",
+    apiKey: "sk-ant-test1234567890",
+    isActive: true,
+    testStatus: "active",
+    healthCheckInterval: 60,
+  });
+
+  await checkConnection(conn);
+
+  const updated = await providersDb.getProviderConnectionById(conn.id);
+
+  assert.equal(
+    updated?.testStatus,
+    "active",
+    "antigravity API-key-only connection should remain active"
+  );
+});
+
+test("connection with both apiKey and refreshToken: refresh path is tried", async () => {
+  await resetStorage();
+
+  // Edge case: connection has both an API key and a refresh token
+  // The health check tries the refresh token path first.
+  // With a stale/invalid refresh token, the connection gets marked expired
+  // even though an API key exists — the refresh path takes precedence.
+  const conn = await providersDb.createProviderConnection({
+    provider: "gemini",
+    name: "gemini-dual-auth",
+    apiKey: "AIzaSyTest1234567890abcdefghijklmnop",
+    refreshToken: "1//old-refresh-token",
+    accessToken: "ya29.expired-token",
+    isActive: true,
+    testStatus: "active",
+    healthCheckInterval: 60,
+  });
+
+  await checkConnection(conn);
+
+  const updated = await providersDb.getProviderConnectionById(conn.id);
+
+  // The refresh token path is tried first. Since the refresh token is invalid,
+  // the connection gets marked expired. This is expected — the operator should
+  // either remove the stale refresh token or re-authenticate.
+  assert.equal(
+    updated?.testStatus,
+    "expired",
+    "dual-auth connection with stale refresh token should be expired (refresh path takes precedence)"
+  );
+});

--- a/tests/unit/call-logs-correlation-sort.test.ts
+++ b/tests/unit/call-logs-correlation-sort.test.ts
@@ -1,0 +1,130 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// Pure-function coverage for buildCallLogListRows (src/app/api/usage/call-logs/route.ts):
+// - merges active/completed in-memory entries with persisted DB rows
+// - sorts by priority (active > completed > persisted) then newest-first
+// - carries correlationId through so the GET handler can filter on it
+import { buildCallLogListRows } from "../../src/app/api/usage/call-logs/route.ts";
+
+test("buildCallLogListRows: active requests sort before completed and persisted rows", () => {
+  const now = 1_000_000;
+  const rows = buildCallLogListRows({
+    logs: [
+      {
+        id: "persisted-1",
+        timestamp: new Date(now - 5_000).toISOString(),
+        correlationId: "corr-a",
+      },
+    ],
+    connections: [],
+    pendingDetails: [
+      {
+        id: "active-1",
+        startedAt: now - 1_000,
+        provider: "openai",
+        model: "gpt-4o",
+        connectionId: "conn-1",
+        correlationId: "corr-a",
+      },
+    ],
+    completedDetails: [
+      {
+        id: "completed-1",
+        startedAt: now - 3_000,
+        completedAt: now - 2_000,
+        provider: "anthropic",
+        model: "claude",
+        connectionId: "conn-2",
+        correlationId: "corr-b",
+      },
+    ],
+    now,
+  });
+
+  assert.equal(rows.length, 3);
+  // active (priority 0) first, then completed (priority 1), then persisted (priority 2)
+  assert.equal(rows[0].id, "active-1");
+  assert.equal(rows[0].active, true);
+  assert.equal(rows[1].id, "completed-1");
+  assert.equal(rows[1].completed, true);
+  assert.equal(rows[2].id, "persisted-1");
+});
+
+test("buildCallLogListRows: within the same priority, newest timestamp sorts first", () => {
+  const now = 2_000_000;
+  const rows = buildCallLogListRows({
+    logs: [
+      { id: "old", timestamp: new Date(now - 10_000).toISOString() },
+      { id: "new", timestamp: new Date(now - 1_000).toISOString() },
+    ],
+    connections: [],
+    pendingDetails: [],
+    completedDetails: [],
+    now,
+  });
+
+  assert.deepEqual(
+    rows.map((r: any) => r.id),
+    ["new", "old"]
+  );
+});
+
+test("buildCallLogListRows: in-memory entries carry correlationId for downstream filtering", () => {
+  const now = 3_000_000;
+  const rows = buildCallLogListRows({
+    logs: [],
+    connections: [],
+    pendingDetails: [
+      {
+        id: "active-cid",
+        startedAt: now - 500,
+        provider: "openai",
+        model: "gpt-4o",
+        connectionId: "conn-1",
+        correlationId: "corr-xyz",
+      },
+    ],
+    completedDetails: [
+      {
+        id: "completed-no-cid",
+        startedAt: now - 4_000,
+        completedAt: now - 3_000,
+        provider: "anthropic",
+        model: "claude",
+        connectionId: "conn-2",
+      },
+    ],
+    now,
+  });
+
+  const active = rows.find((r: any) => r.id === "active-cid");
+  const completed = rows.find((r: any) => r.id === "completed-no-cid");
+  assert.equal(active?.correlationId, "corr-xyz");
+  assert.equal(completed?.correlationId, null);
+});
+
+test("buildCallLogListRows: dedupes completed in-memory entries already persisted to the DB", () => {
+  const now = 4_000_000;
+  const rows = buildCallLogListRows({
+    logs: [{ id: "dup-1", timestamp: new Date(now - 1_000).toISOString() }],
+    connections: [],
+    pendingDetails: [],
+    completedDetails: [
+      {
+        id: "dup-1",
+        startedAt: now - 3_000,
+        completedAt: now - 2_000,
+        provider: "openai",
+        model: "gpt-4o",
+        connectionId: "conn-1",
+      },
+    ],
+    now,
+  });
+
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].id, "dup-1");
+  // persisted row wins (no `completed` flag)
+  assert.equal(rows[0].completed, undefined);
+});


### PR DESCRIPTION
extracted CorrelationId observability changes from #5275 

# User-facing / Operational Changes (vs `upstream/release/v3.8.43`)

## Request Logger — Correlation ID tracking & filtering

- Every request now carries a `correlationId` (same as the `X-Correlation-Id` response header) through the call-logs API.
  - Active, completed, and persisted log entries all include it.
- Added a new `?correlationId=` query parameter to `/api/usage/call-logs`.
  - Filter logs by correlation ID to trace a single request across retries.
- Fixed call-log sorting.
  - Active requests are always shown first.
  - Remaining entries are sorted newest-first.
  - Previously, ordering could become inverted when timestamps differed.

---

## Request Logger UI improvements

- Added sortable table columns for:
  - Status
  - Model
  - Tokens
  - TPS
  - Duration
  - Time

  Click a column header to toggle ascending/descending order.

- Added a Correlation ID filter to the logs toolbar.

- Added retry grouping.
  - Requests sharing the same correlation ID are grouped together.
  - The first attempt is rendered normally.
  - Retries are indented and display:
    - **Healed** — a failed attempt eventually succeeded.
    - **Failed** — all retry attempts failed.

- Added a **Related Logs** section to the request detail modal.
  - Shows other requests with the same correlation ID.
  - Supports navigation between related requests.

- The detail modal now always displays per-stage stream chunks:
  - Provider
  - Client
  - OpenAI

  Previously this information was only available when `debugEnabled` was enabled.

- Improved date formatting.
  - Uses an `isFinite` guard.
  - Gracefully falls back to `—` for invalid dates.

---

## Stream transform memory leak fixes

- `progressTracker` and `sseHeartbeat` transforms now implement `cancel()`.
  - Heartbeat intervals are cleared when a stream is cancelled before completion.
  - Previously, cancelled streams could leave timers running.

- Stream chunk logging now includes timestamps in the format:

  ```text
  [HH:MM:SS.mmm]
  ```

- Stream payload collector events now include an ISO 8601 `timestamp` field.

---

## Health check

### API-key-only connections no longer falsely expire

- `tokenHealthCheck.ts` previously marked API-key-only connections (for example Gemini providers using only an API key) as:

  ```text
  testStatus: "expired"
  ```

  because it expected OAuth refresh tokens.

- Connections that have an `apiKey` configured are now skipped during OAuth token validation, since they do not require refresh tokens.

---

## Gemini integration tests

### Self-contained test environment

- Added `ensureTestEnvironment()`.
  - Automatically creates a Gemini provider from `GEMINI_API_KEY` if no active connection exists.
  - Automatically creates the default combo (Auto strategy):
    - `gemma-4-31b-it`
    - `gemma-4-26b-a4b-it`
  - Integration tests are now fully reproducible without manual setup.

- Removed the `TEST_GEMINI_MODEL` environment variable.
  - All tests now target the `"default"` combo.

- Added retry handling for transient provider failures.
  - 3 retry attempts
  - 10-second backoff
  - Retries on HTTP `429` and `503`