### PR TITLE
fix(tests): align t3-web web-session expected metadata with hintKey (#5465)

### DIFF
--- a/tests/unit/web-session-credentials.test.ts
+++ b/tests/unit/web-session-credentials.test.ts
@@ -69,6 +69,8 @@ test("web session credential metadata identifies cookie, token, and no-auth prov
     placeholder: "convex-session-id=abc123...; Cookie: ...",
     acceptsFullCookieHeader: true,
     storageKeys: ["cookie", "convex-session-id", "convexSessionId"],
+    // #5465 — t3.chat ships a step-by-step DevTools copy hint (localStorage + Cookie header).
+    hintKey: "t3ChatWebCookieHint",
   });
 });
 


### PR DESCRIPTION
## Why

The last stale-test base-red on `release/v3.8.43`'s `Unit Tests fast-path (1/2)`.
`src/shared/providers/webSessionCredentials.ts` intentionally carries
`hintKey: "t3ChatWebCookieHint"` for `t3-web` (#5465 — the generic cookie hint reads
circular for t3.chat), but `web-session-credentials.test.ts` still deep-equals against
an object without it, so it fails on the shipped source of truth.

The other stale-test base-reds this branch originally carried (api-manager switch
count, glm-5.1 system-role preservation) and the `modelContextOverrides` db-rules
re-export **already landed on the release** via the #5609 reconciliation
(`077b4bdb7`) and the earlier `localDb.ts:96` re-export — those commits were dropped
here on rebase. This is the one that was missed.

## What

TDD — red reproduced on the tip, green after aligning the `t3-web` expected object to
carry `hintKey: "t3ChatWebCookieHint"`. No behavior change, no test weakening.

## Validation

`node --test tests/unit/web-session-credentials.test.ts` → 4 pass / 0 fail on the
current release tip (077b4bdb7).