### PR TITLE
fix(cli): correct rootDir resolution in doctor.mjs on Windows (#5844)

### DIFF
--- a/bin/cli/commands/doctor.mjs
+++ b/bin/cli/commands/doctor.mjs
@@ -3,7 +3,7 @@ import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { createDecipheriv, scryptSync } from "node:crypto";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { resolveDataDir, resolveStoragePath } from "../data-dir.mjs";
 import { printHeading } from "../io.mjs";
 import { t } from "../i18n.mjs";
@@ -397,7 +397,7 @@ async function checkServerLiveness(options = {}) {
 export async function collectDoctorChecks(context = {}, options = {}) {
   const rootDir =
     context.rootDir ||
-    path.resolve(path.dirname(new URL(import.meta.url).pathname), "..", "..", "..");
+    path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
   const dataDir = resolveDataDir();
   const dbPath = resolveStoragePath(dataDir);
 

--- a/tests/unit/cli-doctor-rooturl-windows-5844.test.ts
+++ b/tests/unit/cli-doctor-rooturl-windows-5844.test.ts
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Regression test for #5844: on Windows, `bin/cli/commands/doctor.mjs` used to
+// resolve its `rootDir` via `new URL(import.meta.url).pathname`, which keeps the
+// leading drive-letter slash from a `file:///C:/...` URL (e.g. `/C:/Users/...`).
+// Feeding that string into `path.resolve()` on win32 does NOT strip the leading
+// slash the way `fileURLToPath` does, so the resolved rootDir ends up malformed
+// (effectively doubling/mismatching the drive segment), breaking every doctor
+// check that depends on rootDir (DB migrations, native binary probe, etc).
+//
+// `fileURLToPath` handles the platform-specific URL -> path conversion correctly
+// (stripping the extra leading slash on win32), which is why the fix in PR #5845
+// switched `doctor.mjs` to use it instead of `new URL(...).pathname`.
+//
+// fileURLToPath() throws when parsing a Windows-style file URL on a POSIX host,
+// so we can't call it directly here to prove the "after" behavior cross-platform.
+// Instead we assert two things that together lock the regression:
+//   1. The OLD pattern (`new URL(u).pathname`) demonstrably produces the buggy
+//      `/C:/...` prefix for a synthetic Windows file URL — proving why it was wrong.
+//   2. The current source of doctor.mjs uses `fileURLToPath(import.meta.url)` and
+//      does NOT use the old `new URL(import.meta.url).pathname` pattern anymore.
+
+test("old `new URL(...).pathname` pattern produces the buggy /C: prefix on a Windows file URL", () => {
+  const windowsFileUrl = "file:///C:/Users/x/node_modules/omniroute/bin/cli/commands/doctor.mjs";
+  const buggyPathname = new URL(windowsFileUrl).pathname;
+
+  // This is the defect: the pathname keeps the leading slash before the drive
+  // letter, so `path.resolve(path.dirname(buggyPathname), ...)` on win32 would
+  // treat `/C:/Users/...` as a POSIX-relative-looking segment instead of the
+  // real Windows path `C:\Users\...`, producing a malformed rootDir.
+  assert.equal(buggyPathname.startsWith("/C:"), true);
+  assert.equal(buggyPathname, "/C:/Users/x/node_modules/omniroute/bin/cli/commands/doctor.mjs");
+});
+
+test("fileURLToPath does not keep the leading-slash drive-letter defect on the current platform", () => {
+  // On any platform, fileURLToPath never yields a path starting with "/C:" for a
+  // same-platform URL — it fully normalizes drive letters (win32) or leaves POSIX
+  // paths untouched (posix), unlike the raw `.pathname` accessor used by the bug.
+  const here = fileURLToPath(import.meta.url);
+  assert.equal(here.startsWith("/C:"), false);
+});
+
+test("doctor.mjs source uses fileURLToPath(import.meta.url) and not the buggy new URL(...).pathname pattern", () => {
+  const doctorSource = fs.readFileSync(
+    path.resolve("bin/cli/commands/doctor.mjs"),
+    "utf8"
+  );
+
+  assert.match(
+    doctorSource,
+    /fileURLToPath\(import\.meta\.url\)/,
+    "doctor.mjs must resolve rootDir via fileURLToPath(import.meta.url)"
+  );
+
+  assert.doesNotMatch(
+    doctorSource,
+    /new URL\(import\.meta\.url\)\.pathname/,
+    "doctor.mjs must not regress to the buggy new URL(import.meta.url).pathname pattern"
+  );
+});


### PR DESCRIPTION
## Summary

`omniroute doctor` falsely reports `Native binary: better-sqlite3 native binary was not found` on Windows when OmniRoute is installed globally, even though the binary is present and the `Database` check successfully loads `better-sqlite3`.

## Root cause

`bin/cli/commands/doctor.mjs:398-400` resolved `rootDir` via:

```js
const rootDir =
  context.rootDir ||
  path.resolve(path.dirname(new URL(import.meta.url).pathname), "..", "..", "..");
```

On Node v18+ ESM, `new URL(import.meta.url).pathname` returns the Windows path prefixed with a leading slash, e.g.:

```
/C:/Users/Aris/AppData/Local/nvm/v24.17.0/node_modules/omniroute/bin/cli/commands/doctor.mjs
```

`path.dirname()` preserves the leading slash; `path.resolve()` then interprets it as the start of an absolute path and concatenates against the current drive, producing a non-existent location:

```
C:\C:\Users\Aris\AppData\Local\nvm\v24.17.0\node_modules\omniroute
```

`fs.existsSync()` returns `false` for both candidate locations (`<rootDir>/app/node_modules/...` and `<rootDir>/node_modules/...`), and `checkNativeBinary()` falls into the "not found" warning branch. The functional `require('better-sqlite3')` test passes, so the `Database` check is fine — only the candidate-lookup heuristic is broken.

This is the same class of bug as #5006 / #5028 and PR #5089, which addressed `fileURLToPath(import.meta.url)` / runtime-anchor handling for packaged installs.

## Fix

Replace `new URL(import.meta.url).pathname` with `fileURLToPath(import.meta.url)`. `fileURLToPath` is already used elsewhere in the repo (e.g. line 311 of this same file uses `pathToFileURL(...)` to re-encode paths that were originally produced by `path.join`, which masks the artifact). Adding it to the import and routing `import.meta.url` through it yields a clean Windows-native absolute path before `path.dirname`/`path.resolve` see it.

```diff
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
…
   const rootDir =
     context.rootDir ||
-    path.resolve(path.dirname(new URL(import.meta.url).pathname), "..", "..", "..");
+    path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
```

## Repro

```bash
# Windows + Node v24 + global npm install:
$ omniroute doctor
…
WARN  Native binary: better-sqlite3 native binary was not found      ← wrong
OK    Database: SQLite quick_check passed and migrations look current ← binary loaded fine
…
```

Standalone repro (no OmniRoute install needed; just point at your install):

```js
const path = require("path");
const fs = require("fs");
const { fileURLToPath } = require("url");

// Mirror doctor.mjs:398-400
const doctorMjsUrl = new URL(
  "file:///C:/Users/Aris/AppData/Local/nvm/v24.17.0/node_modules/omniroute/bin/cli/commands/doctor.mjs"
);

// BEFORE (current main):
//   path.resolve(path.dirname(doctorMjsUrl.pathname), "..", "..", "..")
//   → "C:\C:\Users\..." (broken)

// AFTER (this PR):
//   path.resolve(path.dirname(fileURLToPath(doctorMjsUrl)), "..", "..", "..")
//   → "C:\Users\..." (correct)

const rootDir = path.resolve(path.dirname(fileURLToPath(doctorMjsUrl)), "..", "..", "..");
console.log("rootDir:", rootDir);
const binary = path.join(rootDir, "node_modules", "better-sqlite3", "build", "Release", "better_sqlite3.node");
console.log("binary exists:", fs.existsSync(binary));
```

Functional verification that the binary is fine:

```bash
node -e "const Database = require('better-sqlite3'); \
  const db = new Database(':memory:'); \
  db.exec('CREATE TABLE t(x)'); \
  db.prepare('INSERT INTO t VALUES (?)').run(42); \
  console.log(db.prepare('SELECT x FROM t').get());"
# → { x: 42 }
```

## Impact

- Low functional impact: the binary and database work; only the doctor warning is wrong.
- High signal-noise impact: real failures (ABI mismatch, missing binary, native-binary incompatibility — see `native-binary-compat.mjs`) become harder to triage because users (correctly) start ignoring the warning.

## Reproduction confirmed on

- OmniRoute 3.8.42 (global npm install)
- Node v24.17.0
- better-sqlite3 12.11.1
- Windows 11, win32 x64
- git-bash / MSYS and PowerShell 5.1 — both shells reproduce

Fixes #5844