### PR TITLE
[codex] Add router backend registry

### DIFF
--- a/src/app/api/services/9router/_lib.ts
+++ b/src/app/api/services/9router/_lib.ts
@@ -7,9 +7,12 @@ import { getSupervisor, registerSupervisor } from "@/lib/services/registry";
 import { ServiceSupervisor } from "@/lib/services/ServiceSupervisor";
 import { resolveSpawnArgs } from "@/lib/services/installers/ninerouter";
 import { getOrCreateApiKey } from "@/lib/services/apiKey";
+import {
+  buildLoopbackUrl,
+  getRouterBackendServiceMetadata,
+} from "@/lib/services/routerBackendService";
 
-const TOOL = "9router";
-const PORT = 20130;
+const SERVICE = getRouterBackendServiceMetadata("9router");
 
 // Module-level in-flight guard. Without this, two concurrent requests that
 // both observe `getSupervisor() === null` and then await getOrCreateApiKey
@@ -18,7 +21,7 @@ const PORT = 20130;
 let initInFlight: Promise<ServiceSupervisor> | null = null;
 
 export async function getOrInitSupervisor(): Promise<ServiceSupervisor> {
-  const existing = getSupervisor(TOOL);
+  const existing = getSupervisor(SERVICE.tool);
   if (existing) return existing;
 
   if (initInFlight) return initInFlight;
@@ -26,16 +29,16 @@ export async function getOrInitSupervisor(): Promise<ServiceSupervisor> {
   initInFlight = (async () => {
     // Double-check after entering the in-flight branch — a competing caller
     // may have completed initialization while we awaited the lock check.
-    const racy = getSupervisor(TOOL);
+    const racy = getSupervisor(SERVICE.tool);
     if (racy) return racy;
 
-    const apiKey = await getOrCreateApiKey(TOOL);
+    const apiKey = await getOrCreateApiKey(SERVICE.tool);
 
     const sup = new ServiceSupervisor({
-      tool: TOOL,
-      port: PORT,
-      spawnArgs: () => resolveSpawnArgs(apiKey, PORT),
-      healthUrl: () => `http://127.0.0.1:${PORT}/api/health`,
+      tool: SERVICE.tool,
+      port: SERVICE.port,
+      spawnArgs: () => resolveSpawnArgs(apiKey, SERVICE.port),
+      healthUrl: () => buildLoopbackUrl(SERVICE.port, SERVICE.healthPath),
       healthIntervalMs: 2_000,
       stopTimeoutMs: 15_000,
       logsBufferBytes: 5_242_880,

--- a/src/app/api/services/9router/models/route.ts
+++ b/src/app/api/services/9router/models/route.ts
@@ -18,9 +18,13 @@ import { getSupervisor } from "@/lib/services/registry";
 import { getOrCreateApiKey } from "@/lib/services/apiKey";
 import { createErrorResponse } from "@/lib/api/errorResponse";
 import { sanitizeErrorMessage } from "@omniroute/open-sse/utils/error";
+import {
+  buildLoopbackUrl,
+  getRouterBackendServiceMetadata,
+} from "@/lib/services/routerBackendService";
 
-const TOOL = "9router";
-const DEFAULT_PORT = parseInt(process.env.NINEROUTER_PORT ?? "20130", 10);
+const SERVICE = getRouterBackendServiceMetadata("9router");
+const TOOL = SERVICE.tool;
 
 export async function GET(request: Request): Promise<Response> {
   try {
@@ -31,8 +35,8 @@ export async function GET(request: Request): Promise<Response> {
       // Determine the running port from the supervisor, falling back to default.
       const sup = getSupervisor(TOOL);
       const status = sup?.getStatus();
-      const port = status?.port ?? DEFAULT_PORT;
-      const baseUrl = `http://127.0.0.1:${port}`;
+      const port = status?.port ?? SERVICE.port;
+      const baseUrl = buildLoopbackUrl(port);
 
       let apiKey: string;
       try {

--- a/src/app/api/services/9router/status/route.ts
+++ b/src/app/api/services/9router/status/route.ts
@@ -5,8 +5,10 @@ import { getOrCreateApiKey, maskApiKey } from "@/lib/services/apiKey";
 import { createErrorResponse } from "@/lib/api/errorResponse";
 import { sanitizeErrorMessage } from "@omniroute/open-sse/utils/error";
 import { logAuditEvent } from "@/lib/compliance/index";
+import { getRouterBackendServiceMetadata } from "@/lib/services/routerBackendService";
 
-const TOOL = "9router";
+const SERVICE = getRouterBackendServiceMetadata("9router");
+const TOOL = SERVICE.tool;
 
 export async function GET(request: Request = new Request("http://localhost/")): Promise<Response> {
   try {
@@ -27,7 +29,7 @@ export async function GET(request: Request = new Request("http://localhost/")): 
       tool: TOOL,
       state: liveStatus?.state ?? row?.status ?? "unknown",
       pid: liveStatus?.pid ?? null,
-      port: liveStatus?.port ?? row?.port ?? 20130,
+      port: liveStatus?.port ?? row?.port ?? SERVICE.port,
       health: liveStatus?.health ?? "unknown",
       startedAt: liveStatus?.startedAt ?? null,
       lastError: liveStatus?.lastError ?? row?.errorMessage ?? null,

--- a/src/app/api/services/cliproxy/_lib.ts
+++ b/src/app/api/services/cliproxy/_lib.ts
@@ -5,20 +5,23 @@
 
 import { getSupervisor, registerSupervisor } from "@/lib/services/registry";
 import { ServiceSupervisor } from "@/lib/services/ServiceSupervisor";
-import { resolveSpawnArgs, CLIPROXY_DEFAULT_PORT } from "@/lib/services/installers/cliproxy";
+import { resolveSpawnArgs } from "@/lib/services/installers/cliproxy";
+import {
+  buildLoopbackUrl,
+  getRouterBackendServiceMetadata,
+} from "@/lib/services/routerBackendService";
 
-const TOOL = "cliproxy";
-const PORT = parseInt(process.env.CLIPROXYAPI_PORT ?? String(CLIPROXY_DEFAULT_PORT), 10);
+const SERVICE = getRouterBackendServiceMetadata("cliproxy");
 
 export async function getOrInitSupervisor(): Promise<ServiceSupervisor> {
-  const existing = getSupervisor(TOOL);
+  const existing = getSupervisor(SERVICE.tool);
   if (existing) return existing;
 
   const sup = new ServiceSupervisor({
-    tool: TOOL,
-    port: PORT,
-    spawnArgs: () => resolveSpawnArgs(PORT),
-    healthUrl: () => `http://127.0.0.1:${PORT}/v1/models`,
+    tool: SERVICE.tool,
+    port: SERVICE.port,
+    spawnArgs: () => resolveSpawnArgs(SERVICE.port),
+    healthUrl: () => buildLoopbackUrl(SERVICE.port, SERVICE.healthPath),
     healthIntervalMs: 5_000,
     stopTimeoutMs: 15_000,
     logsBufferBytes: 5_242_880,

--- a/src/app/api/services/cliproxy/status/route.ts
+++ b/src/app/api/services/cliproxy/status/route.ts
@@ -1,14 +1,12 @@
 import { getSupervisor } from "@/lib/services/registry";
 import { getServiceRow } from "@/lib/db/versionManager";
-import {
-  getInstalledVersion,
-  getLatestVersion,
-  CLIPROXY_DEFAULT_PORT,
-} from "@/lib/services/installers/cliproxy";
+import { getInstalledVersion, getLatestVersion } from "@/lib/services/installers/cliproxy";
 import { createErrorResponse } from "@/lib/api/errorResponse";
 import { sanitizeErrorMessage } from "@omniroute/open-sse/utils/error";
+import { getRouterBackendServiceMetadata } from "@/lib/services/routerBackendService";
 
-const TOOL = "cliproxy";
+const SERVICE = getRouterBackendServiceMetadata("cliproxy");
+const TOOL = SERVICE.tool;
 
 export async function GET(): Promise<Response> {
   try {
@@ -23,7 +21,7 @@ export async function GET(): Promise<Response> {
       tool: TOOL,
       state: liveStatus?.state ?? row?.status ?? "unknown",
       pid: liveStatus?.pid ?? null,
-      port: liveStatus?.port ?? row?.port ?? CLIPROXY_DEFAULT_PORT,
+      port: liveStatus?.port ?? row?.port ?? SERVICE.port,
       health: liveStatus?.health ?? "unknown",
       startedAt: liveStatus?.startedAt ?? null,
       lastError: liveStatus?.lastError ?? row?.errorMessage ?? null,

--- a/src/app/api/v1/relay/chat/completions/routingBackend.ts
+++ b/src/app/api/v1/relay/chat/completions/routingBackend.ts
@@ -1,3 +1,6 @@
+import { getRouterBackend } from "@/domain/routing/routerBackends";
+import type { RouterBackendDefinition } from "@/domain/routing/routerBackends";
+
 export type RelayRoutingBackend = "ts" | "bifrost" | "auto";
 
 const VALID_BACKENDS = new Set<RelayRoutingBackend>(["ts", "bifrost", "auto"]);
@@ -13,7 +16,9 @@ export interface BifrostRoutingConfig {
 export function getBifrostRoutingConfig(
   env: NodeJS.ProcessEnv = process.env
 ): BifrostRoutingConfig | null {
-  const baseUrl = env.BIFROST_BASE_URL?.replace(/\/$/, "");
+  const backend = getRouterBackend("bifrost");
+  const baseUrlEnv = backend?.envBaseUrl ?? "BIFROST_BASE_URL";
+  const baseUrl = env[baseUrlEnv]?.replace(/\/$/, "");
   if (!baseUrl) return null;
   const timeoutMs = Number.parseInt(env.BIFROST_TIMEOUT_MS || "", 10);
 
@@ -24,6 +29,15 @@ export function getBifrostRoutingConfig(
     streamingEnabled: env.BIFROST_STREAMING_ENABLED !== "0",
     enabled: env.BIFROST_ENABLED !== "0",
   };
+}
+
+export function getRelayRouterBackendDefinition(
+  backend: RelayRoutingBackend
+): RouterBackendDefinition | null {
+  if (backend === "auto") {
+    return getRouterBackend("bifrost");
+  }
+  return getRouterBackend(backend);
 }
 
 export function resolveRelayRoutingBackend(

--- a/src/domain/routing/routerBackends.ts
+++ b/src/domain/routing/routerBackends.ts
@@ -1,0 +1,131 @@
+export type RouterBackendId = "ts" | "bifrost" | "cliproxy" | "9router" | "vibeproxy";
+
+export type RouterBackendLifecycle = "in-process" | "external" | "supervised" | "disabled";
+
+export type RouterBackendCapability =
+  | "chat"
+  | "responses"
+  | "streaming"
+  | "tools"
+  | "vision"
+  | "oauth-backed"
+  | "dashboard-embed"
+  | "model-sync"
+  | "native-hot-path";
+
+export interface RouterBackendHealthConfig {
+  path?: string;
+  envBaseUrl?: string;
+}
+
+export interface RouterBackendTelemetryConfig {
+  ttft: boolean;
+  tokensPerSecond: boolean;
+  e2eLatency: boolean;
+  failureRate: boolean;
+  upstreamStatus: boolean;
+  fallbackReason: boolean;
+}
+
+export interface RouterBackendDefinition {
+  id: RouterBackendId;
+  displayName: string;
+  lifecycle: RouterBackendLifecycle;
+  capabilities: readonly RouterBackendCapability[];
+  defaultPort?: number;
+  serviceName?: string;
+  envBaseUrl?: string;
+  health: RouterBackendHealthConfig;
+  telemetry: RouterBackendTelemetryConfig;
+}
+
+const FULL_TELEMETRY: RouterBackendTelemetryConfig = {
+  ttft: true,
+  tokensPerSecond: true,
+  e2eLatency: true,
+  failureRate: true,
+  upstreamStatus: true,
+  fallbackReason: true,
+};
+
+const BASIC_TELEMETRY: RouterBackendTelemetryConfig = {
+  ttft: false,
+  tokensPerSecond: false,
+  e2eLatency: true,
+  failureRate: true,
+  upstreamStatus: true,
+  fallbackReason: true,
+};
+
+export const ROUTER_BACKENDS: readonly RouterBackendDefinition[] = [
+  {
+    id: "ts",
+    displayName: "OmniRoute TypeScript",
+    lifecycle: "in-process",
+    capabilities: ["chat", "responses", "streaming", "tools", "vision"],
+    health: {},
+    telemetry: BASIC_TELEMETRY,
+  },
+  {
+    id: "bifrost",
+    displayName: "Bifrost",
+    lifecycle: "external",
+    capabilities: ["chat", "streaming", "native-hot-path"],
+    envBaseUrl: "BIFROST_BASE_URL",
+    health: { envBaseUrl: "BIFROST_BASE_URL", path: "/health" },
+    telemetry: FULL_TELEMETRY,
+  },
+  {
+    id: "cliproxy",
+    displayName: "CLIProxyAPI",
+    lifecycle: "supervised",
+    capabilities: ["chat", "responses", "streaming", "tools", "oauth-backed", "model-sync"],
+    defaultPort: 8317,
+    serviceName: "cliproxy",
+    health: { path: "/v1/models" },
+    telemetry: FULL_TELEMETRY,
+  },
+  {
+    id: "9router",
+    displayName: "9Router",
+    lifecycle: "supervised",
+    capabilities: ["chat", "streaming", "dashboard-embed", "model-sync"],
+    defaultPort: 20130,
+    serviceName: "9router",
+    health: { path: "/api/health" },
+    telemetry: FULL_TELEMETRY,
+  },
+  {
+    id: "vibeproxy",
+    displayName: "VibeProxy-compatible",
+    lifecycle: "external",
+    capabilities: ["chat", "streaming", "oauth-backed"],
+    envBaseUrl: "VIBEPROXY_BASE_URL",
+    health: { envBaseUrl: "VIBEPROXY_BASE_URL", path: "/v1/models" },
+    telemetry: BASIC_TELEMETRY,
+  },
+] as const;
+
+const BACKENDS_BY_ID = new Map(ROUTER_BACKENDS.map((backend) => [backend.id, backend]));
+
+export function getRouterBackend(id: string): RouterBackendDefinition | null {
+  return BACKENDS_BY_ID.get(id as RouterBackendId) ?? null;
+}
+
+export function listRouterBackends(): readonly RouterBackendDefinition[] {
+  return ROUTER_BACKENDS;
+}
+
+export function backendHasCapability(
+  backend: RouterBackendDefinition,
+  capability: RouterBackendCapability
+): boolean {
+  return backend.capabilities.includes(capability);
+}
+
+export function listRouterBackendsByCapability(
+  capability: RouterBackendCapability
+): RouterBackendDefinition[] {
+  return ROUTER_BACKENDS.filter((backend) => backendHasCapability(backend, capability));
+}
+

--- a/src/domain/routing/routerBackends.ts
+++ b/src/domain/routing/routerBackends.ts
@@ -33,6 +33,7 @@ export interface RouterBackendDefinition {
   lifecycle: RouterBackendLifecycle;
   capabilities: readonly RouterBackendCapability[];
   defaultPort?: number;
+  portEnv?: string;
   serviceName?: string;
   envBaseUrl?: string;
   health: RouterBackendHealthConfig;
@@ -81,6 +82,7 @@ export const ROUTER_BACKENDS: readonly RouterBackendDefinition[] = [
     lifecycle: "supervised",
     capabilities: ["chat", "responses", "streaming", "tools", "oauth-backed", "model-sync"],
     defaultPort: 8317,
+    portEnv: "CLIPROXYAPI_PORT",
     serviceName: "cliproxy",
     health: { path: "/v1/models" },
     telemetry: FULL_TELEMETRY,
@@ -91,6 +93,7 @@ export const ROUTER_BACKENDS: readonly RouterBackendDefinition[] = [
     lifecycle: "supervised",
     capabilities: ["chat", "streaming", "dashboard-embed", "model-sync"],
     defaultPort: 20130,
+    portEnv: "NINEROUTER_PORT",
     serviceName: "9router",
     health: { path: "/api/health" },
     telemetry: FULL_TELEMETRY,
@@ -128,4 +131,3 @@ export function listRouterBackendsByCapability(
 ): RouterBackendDefinition[] {
   return ROUTER_BACKENDS.filter((backend) => backendHasCapability(backend, capability));
 }
-

--- a/src/lib/services/bootstrap.ts
+++ b/src/lib/services/bootstrap.ts
@@ -3,16 +3,11 @@ import { markAllUnavailable } from "@/lib/db/serviceModels";
 import { registerSupervisor, getSupervisor } from "./registry";
 import { ServiceSupervisor } from "./ServiceSupervisor";
 import { resolveSpawnArgs as nineRouterSpawnArgs } from "./installers/ninerouter";
-import {
-  resolveSpawnArgs as cliproxySpawnArgs,
-  CLIPROXY_DEFAULT_PORT,
-} from "./installers/cliproxy";
+import { resolveSpawnArgs as cliproxySpawnArgs } from "./installers/cliproxy";
 import { getOrCreateApiKey } from "./apiKey";
 import { scheduleServiceModelSync, stopServiceModelSync } from "./modelSync";
+import { buildLoopbackUrl, getRouterBackendServiceMetadata } from "./routerBackendService";
 import type { ServiceStatus } from "./types";
-
-const NINEROUTER_PORT = parseInt(process.env.NINEROUTER_PORT ?? "20130", 10);
-const CLIPROXY_PORT = parseInt(process.env.CLIPROXYAPI_PORT ?? String(CLIPROXY_DEFAULT_PORT), 10);
 
 type ServiceEntry = {
   tool: string;
@@ -26,18 +21,14 @@ type ServiceEntry = {
 
 const SERVICES: ServiceEntry[] = [
   {
-    tool: "9router",
-    port: NINEROUTER_PORT,
-    healthPath: "/api/health",
+    ...getRouterBackendServiceMetadata("9router"),
     healthIntervalMs: 2_000,
     stopTimeoutMs: 15_000,
     logsBufferBytes: 5_242_880,
     needsApiKey: true,
   },
   {
-    tool: "cliproxy",
-    port: CLIPROXY_PORT,
-    healthPath: "/v1/models",
+    ...getRouterBackendServiceMetadata("cliproxy"),
     healthIntervalMs: 5_000,
     stopTimeoutMs: 15_000,
     logsBufferBytes: 5_242_880,
@@ -70,7 +61,7 @@ export async function bootstrapEmbeddedServices(): Promise<void> {
       tool: cfg.tool,
       port: cfg.port,
       spawnArgs: buildSpawnArgsFactory(cfg, apiKey),
-      healthUrl: () => `http://127.0.0.1:${cfg.port}${cfg.healthPath}`,
+      healthUrl: () => buildLoopbackUrl(cfg.port, cfg.healthPath),
       healthIntervalMs: cfg.healthIntervalMs,
       stopTimeoutMs: cfg.stopTimeoutMs,
       logsBufferBytes: cfg.logsBufferBytes,
@@ -78,7 +69,7 @@ export async function bootstrapEmbeddedServices(): Promise<void> {
 
     registerSupervisor(supervisor);
 
-    const baseUrl = `http://127.0.0.1:${cfg.port}`;
+    const baseUrl = buildLoopbackUrl(cfg.port);
     supervisor.on("stateChange", (status: ServiceStatus) => {
       if (status.state === "running") {
         scheduleServiceModelSync(cfg.tool, baseUrl, apiKey);

--- a/src/lib/services/routerBackendService.ts
+++ b/src/lib/services/routerBackendService.ts
@@ -1,0 +1,38 @@
+import { getRouterBackend } from "@/domain/routing/routerBackends";
+import type { RouterBackendDefinition, RouterBackendId } from "@/domain/routing/routerBackends";
+
+export interface RouterBackendServiceMetadata {
+  backend: RouterBackendDefinition;
+  tool: string;
+  port: number;
+  healthPath: string;
+}
+
+function parsePort(value: string | undefined, fallback: number): number {
+  const parsed = Number.parseInt(value ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export function getRouterBackendServiceMetadata(
+  id: RouterBackendId,
+  env: NodeJS.ProcessEnv = process.env
+): RouterBackendServiceMetadata {
+  const backend = getRouterBackend(id);
+  if (!backend) {
+    throw new Error(`Unknown router backend: ${id}`);
+  }
+  if (backend.lifecycle !== "supervised" || !backend.serviceName || !backend.defaultPort) {
+    throw new Error(`Router backend is not a supervised service: ${id}`);
+  }
+
+  return {
+    backend,
+    tool: backend.serviceName,
+    port: parsePort(backend.portEnv ? env[backend.portEnv] : undefined, backend.defaultPort),
+    healthPath: backend.health.path ?? "/health",
+  };
+}
+
+export function buildLoopbackUrl(port: number, path = ""): string {
+  return `http://127.0.0.1:${port}${path}`;
+}

--- a/tests/unit/api/v1/relay-routing-backend.test.ts
+++ b/tests/unit/api/v1/relay-routing-backend.test.ts
@@ -2,6 +2,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
   getBifrostRoutingConfig,
+  getRelayRouterBackendDefinition,
   getRoutingFallbackHeader,
   resolveRelayRoutingBackend,
   shouldTryBifrost,
@@ -30,6 +31,12 @@ test("relay routing backend auto-enables bifrost when base URL is configured", (
   assert.equal(config?.streamingEnabled, true);
   assert.equal(config?.enabled, true);
   assert.equal(shouldTryBifrost("auto", config), true);
+});
+
+test("relay routing backend resolves definitions from the router backend registry", () => {
+  assert.equal(getRelayRouterBackendDefinition("ts")?.id, "ts");
+  assert.equal(getRelayRouterBackendDefinition("bifrost")?.id, "bifrost");
+  assert.equal(getRelayRouterBackendDefinition("auto")?.id, "bifrost");
 });
 
 test("relay routing backend honors explicit TS and strict bifrost modes", () => {

--- a/tests/unit/router-backends.test.ts
+++ b/tests/unit/router-backends.test.ts
@@ -1,0 +1,46 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  backendHasCapability,
+  getRouterBackend,
+  listRouterBackends,
+  listRouterBackendsByCapability,
+} from "../../src/domain/routing/routerBackends.ts";
+
+test("router backend registry exposes the current routing backends", () => {
+  const ids = listRouterBackends().map((backend) => backend.id);
+  assert.deepEqual(ids, ["ts", "bifrost", "cliproxy", "9router", "vibeproxy"]);
+});
+
+test("bifrost is represented as a native hot-path backend before supervision lands", () => {
+  const bifrost = getRouterBackend("bifrost");
+  assert.ok(bifrost);
+  assert.equal(bifrost.lifecycle, "external");
+  assert.equal(bifrost.envBaseUrl, "BIFROST_BASE_URL");
+  assert.equal(backendHasCapability(bifrost, "native-hot-path"), true);
+  assert.equal(bifrost.telemetry.ttft, true);
+  assert.equal(bifrost.telemetry.tokensPerSecond, true);
+});
+
+test("supervised service backends carry service names and default ports", () => {
+  const cliproxy = getRouterBackend("cliproxy");
+  const ninerouter = getRouterBackend("9router");
+  assert.ok(cliproxy);
+  assert.ok(ninerouter);
+  assert.equal(cliproxy.lifecycle, "supervised");
+  assert.equal(cliproxy.serviceName, "cliproxy");
+  assert.equal(cliproxy.defaultPort, 8317);
+  assert.equal(ninerouter.lifecycle, "supervised");
+  assert.equal(ninerouter.serviceName, "9router");
+  assert.equal(ninerouter.defaultPort, 20130);
+});
+
+test("capability filtering returns every streaming backend", () => {
+  const streaming = listRouterBackendsByCapability("streaming").map((backend) => backend.id);
+  assert.deepEqual(streaming, ["ts", "bifrost", "cliproxy", "9router", "vibeproxy"]);
+});
+
+test("unknown backend ids resolve to null", () => {
+  assert.equal(getRouterBackend("plano"), null);
+});

--- a/tests/unit/services/routerBackendService.test.ts
+++ b/tests/unit/services/routerBackendService.test.ts
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildLoopbackUrl,
+  getRouterBackendServiceMetadata,
+} from "../../../src/lib/services/routerBackendService.ts";
+
+test("router backend service metadata resolves 9router from registry defaults", () => {
+  const metadata = getRouterBackendServiceMetadata("9router", {});
+
+  assert.equal(metadata.tool, "9router");
+  assert.equal(metadata.port, 20130);
+  assert.equal(metadata.healthPath, "/api/health");
+});
+
+test("router backend service metadata resolves cliproxy port from env", () => {
+  const metadata = getRouterBackendServiceMetadata("cliproxy", {
+    CLIPROXYAPI_PORT: "18317",
+  });
+
+  assert.equal(metadata.tool, "cliproxy");
+  assert.equal(metadata.port, 18317);
+  assert.equal(metadata.healthPath, "/v1/models");
+});
+
+test("router backend service metadata falls back when env port is invalid", () => {
+  const metadata = getRouterBackendServiceMetadata("9router", {
+    NINEROUTER_PORT: "not-a-port",
+  });
+
+  assert.equal(metadata.port, 20130);
+});
+
+test("router backend service metadata rejects non-supervised backends", () => {
+  assert.throws(() => getRouterBackendServiceMetadata("bifrost", {}), /not a supervised service/);
+});
+
+test("buildLoopbackUrl formats service health URLs", () => {
+  assert.equal(buildLoopbackUrl(20130, "/api/health"), "http://127.0.0.1:20130/api/health");
+});


### PR DESCRIPTION
## Summary
- add a typed router backend registry for TS, Bifrost, CLIProxyAPI, 9Router, and VibeProxy-compatible adapters
- model lifecycle, capabilities, health, service identity, default ports, and telemetry support in one domain contract
- add focused unit coverage for backend lookup, supervised service metadata, native hot-path capability, and capability filtering

## Why
Starts #5670 with a low-risk contract layer before wiring heavier runtime changes. This gives the Bifrost supervision and native hot-path migration work a shared registry instead of continuing to special-case every router sidecar.

## Validation
- `node --import tsx --test tests/unit/router-backends.test.ts`
- `node --import tsx --test tests/unit/api/v1/relay-routing-backend.test.ts`
- `npm run typecheck:core`