### PR TITLE
fix(github): keep Copilot access-token sessions active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🔧 Bug Fixes
 
+- **fix(github):** keep Copilot access-token sessions active. GitHub Copilot device-flow accounts can hold a GitHub access token plus a short-lived Copilot token **without** a refresh token; the proactive health check treated that as terminal `no_refresh_token` and marked the connection expired minutes after login. The health check now keeps those sessions active, clears stale `no_refresh_token` state, and refreshes the Copilot sub-token when needed. Regression guard: `tests/unit/token-health-no-refresh-token-expired-5326.test.ts`. Extracted from [#5863](https://github.com/diegosouzapw/OmniRoute/pull/5863) by [@Witroch4](https://github.com/Witroch4).
+
 - **fix(kiro):** bound the Claude model-id dash→dot normalization to a 1–2 digit minor so date-suffixed ids (e.g. claude-opus-4-20250514) are no longer corrupted. (thanks @voravitl)
 
 - **fix(usage):** preserve (bounded) tool definitions in request logs even when the request body is truncated, so the request-details view can still show available tools. (thanks @noir017)

--- a/src/lib/tokenHealthCheck.ts
+++ b/src/lib/tokenHealthCheck.ts
@@ -76,6 +76,35 @@ function getEffectiveTokenExpiryMs(conn: any): number {
   return Number.isFinite(expiryMs) ? expiryMs : 0;
 }
 
+const TOKEN_EXPIRY_BUFFER = 5 * 60 * 1000; // 5 minutes
+
+function getCopilotTokenExpiryMs(expiresAt: unknown): number {
+  if (typeof expiresAt === "number" && Number.isFinite(expiresAt)) {
+    return expiresAt < 1e12 ? expiresAt * 1000 : expiresAt;
+  }
+  if (typeof expiresAt === "string" && expiresAt.trim()) {
+    const parsed = new Date(expiresAt).getTime();
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  return 0;
+}
+
+function isGitHubAccessTokenOnlyConnection(conn: any): boolean {
+  return (
+    String(conn?.provider || "").toLowerCase() === "github" &&
+    typeof conn?.accessToken === "string" &&
+    conn.accessToken.trim().length > 0
+  );
+}
+
+function canClearGitHubNoRefreshTokenState(conn: any): boolean {
+  return (
+    !conn?.testStatus ||
+    conn.testStatus === "active" ||
+    (conn.testStatus === "expired" && conn.errorCode === "no_refresh_token")
+  );
+}
+
 // ── Refresh circuit breaker ───────────────────────────────────────────────
 // A refresh that returns null (network blip, dead proxy, unclassified error)
 // leaves the connection active, so the next 60s sweep retries immediately —
@@ -248,8 +277,7 @@ export function clearHealthCheckLogCache() {
 
 declare global {
   var __omnirouteTokenHC:
-    | { initialized: boolean; interval: ReturnType<typeof setInterval> | null }
-    | undefined;
+    { initialized: boolean; interval: ReturnType<typeof setInterval> | null } | undefined;
 }
 
 function getHCState() {
@@ -342,6 +370,86 @@ export async function checkConnection(conn) {
   if (intervalMin <= 0) return;
   if (!conn.isActive) return;
   if (!conn.refreshToken || typeof conn.refreshToken !== "string") {
+    if (isGitHubAccessTokenOnlyConnection(conn)) {
+      const now = new Date().toISOString();
+      const providerSpecificData = conn.providerSpecificData || {};
+      const hasCopilotToken =
+        typeof providerSpecificData.copilotToken === "string" &&
+        providerSpecificData.copilotToken.trim().length > 0;
+      const copilotExpiresAtMs = getCopilotTokenExpiryMs(
+        providerSpecificData.copilotTokenExpiresAt
+      );
+      const copilotAboutToExpire =
+        !hasCopilotToken ||
+        !copilotExpiresAtMs ||
+        copilotExpiresAtMs - Date.now() < TOKEN_EXPIRY_BUFFER;
+
+      let refreshedProviderSpecificData: Record<string, unknown> | null = null;
+      if (copilotAboutToExpire) {
+        const hideLogs = await shouldHideLogs();
+        const proxyResolution = await resolveProxyForConnection(conn.id);
+        const proxyConfig = extractResolvedProxyConfig(proxyResolution);
+        const healthCheckLog = {
+          info: (tag: string, msg: string) => {
+            if (!hideLogs) console.log(LOG_PREFIX, `[${tag}]`, msg);
+          },
+          warn: (tag: string, msg: string) => {
+            if (!hideLogs) console.warn(LOG_PREFIX, `[${tag}]`, msg);
+          },
+          error: (tag: string, msg: string, extra?: Record<string, unknown>) => {
+            if (!hideLogs) console.error(LOG_PREFIX, `[${tag}]`, msg, extra || "");
+          },
+        };
+
+        const copilotResult = await refreshCopilotToken(
+          conn.accessToken,
+          healthCheckLog,
+          proxyConfig
+        );
+        if (copilotResult?.token) {
+          refreshedProviderSpecificData = {
+            ...providerSpecificData,
+            copilotToken: copilotResult.token,
+            copilotTokenExpiresAt: copilotResult.expiresAt,
+          };
+        }
+      }
+
+      if (canClearGitHubNoRefreshTokenState(conn)) {
+        await updateProviderConnection(conn.id, {
+          lastHealthCheckAt: now,
+          testStatus: "active",
+          lastError:
+            copilotAboutToExpire && !refreshedProviderSpecificData
+              ? "Health check: Copilot token refresh failed"
+              : null,
+          lastErrorAt: copilotAboutToExpire && !refreshedProviderSpecificData ? now : null,
+          lastErrorType:
+            copilotAboutToExpire && !refreshedProviderSpecificData ? "token_refresh_failed" : null,
+          lastErrorSource: copilotAboutToExpire && !refreshedProviderSpecificData ? "oauth" : null,
+          errorCode:
+            copilotAboutToExpire && !refreshedProviderSpecificData ? "refresh_failed" : null,
+          expiredRetryCount: null,
+          expiredRetryAt: null,
+          ...(refreshedProviderSpecificData
+            ? { providerSpecificData: refreshedProviderSpecificData }
+            : {}),
+        });
+      } else {
+        await updateProviderConnection(conn.id, {
+          lastHealthCheckAt: now,
+          ...(refreshedProviderSpecificData
+            ? { providerSpecificData: refreshedProviderSpecificData }
+            : {}),
+        });
+      }
+
+      log(
+        `${LOG_PREFIX} ${conn.provider}/${getConnectionLogLabel(conn)} has no refresh token but has a GitHub access token; keeping connection active`
+      );
+      return;
+    }
+
     // #5326: a refresh-CAPABLE provider (e.g. antigravity/gemini) with no usable
     // refresh token can never self-heal via the sweep — it genuinely needs re-auth.
     // Silently skipping here left the row at testStatus="active" while the dashboard
@@ -402,7 +510,6 @@ export async function checkConnection(conn) {
   // Prefer expiry-driven refresh when the provider returns a concrete expiry timestamp.
   // Rotating-token providers such as Codex should not be refreshed on a fixed hourly
   // cadence while the access token is still valid for days.
-  const TOKEN_EXPIRY_BUFFER = 5 * 60 * 1000; // 5 minutes
   const tokenExpiresAt = getEffectiveTokenExpiryMs(conn);
   const hasKnownExpiry = tokenExpiresAt > 0;
   const isAboutToExpire = hasKnownExpiry && tokenExpiresAt - Date.now() < TOKEN_EXPIRY_BUFFER;

--- a/tests/unit/token-health-no-refresh-token-expired-5326.test.ts
+++ b/tests/unit/token-health-no-refresh-token-expired-5326.test.ts
@@ -21,8 +21,12 @@ async function resetStorage() {
         fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
       }
       break;
-    } catch (error: any) {
-      if ((error?.code === "EBUSY" || error?.code === "EPERM") && attempt < 9) {
+    } catch (error: unknown) {
+      const code =
+        error && typeof error === "object" && "code" in error
+          ? (error as { code?: unknown }).code
+          : null;
+      if ((code === "EBUSY" || code === "EPERM") && attempt < 9) {
         await new Promise((resolve) => setTimeout(resolve, 50 * (attempt + 1)));
       } else {
         throw error;
@@ -30,6 +34,11 @@ async function resetStorage() {
     }
   }
   fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+function getCreatedConnectionId(connection: { id?: unknown }): string {
+  assert.equal(typeof connection.id, "string");
+  return connection.id;
 }
 
 test.after(async () => {
@@ -58,7 +67,7 @@ test("checkConnection marks refresh-capable provider with no refresh token as ex
 
   await tokenHealthCheck.checkConnection(connection);
 
-  const updated = await providersDb.getProviderConnectionById((connection as any).id);
+  const updated = await providersDb.getProviderConnectionById(getCreatedConnectionId(connection));
   assert.equal(updated?.testStatus, "expired");
   assert.equal(updated?.errorCode, "no_refresh_token");
   assert.ok(updated?.lastHealthCheckAt);
@@ -85,7 +94,7 @@ test("checkConnection leaves a connection WITH a refresh token untouched (#5326)
 
   await tokenHealthCheck.checkConnection(connection);
 
-  const updated = await providersDb.getProviderConnectionById((connection as any).id);
+  const updated = await providersDb.getProviderConnectionById(getCreatedConnectionId(connection));
   assert.equal(updated?.testStatus, "active");
   assert.notEqual(updated?.errorCode, "no_refresh_token");
 });
@@ -108,7 +117,60 @@ test("checkConnection leaves a non-refresh provider with no refresh token untouc
 
   await tokenHealthCheck.checkConnection(connection);
 
-  const updated = await providersDb.getProviderConnectionById((connection as any).id);
+  const updated = await providersDb.getProviderConnectionById(getCreatedConnectionId(connection));
   assert.equal(updated?.testStatus, "active");
   assert.notEqual(updated?.errorCode, "no_refresh_token");
+});
+
+test("checkConnection keeps GitHub Copilot access-token-only connections active", async () => {
+  await resetStorage();
+
+  const connection = await providersDb.createProviderConnection({
+    provider: "github",
+    authType: "oauth",
+    name: "GitHub Access Token Account",
+    accessToken: "github-access-token",
+    refreshToken: null,
+    providerSpecificData: {
+      copilotToken: "copilot-token",
+      copilotTokenExpiresAt: Math.floor((Date.now() + 60 * 60 * 1000) / 1000),
+    },
+    testStatus: "active",
+    isActive: true,
+  });
+
+  await tokenHealthCheck.checkConnection(connection);
+
+  const updated = await providersDb.getProviderConnectionById(getCreatedConnectionId(connection));
+  assert.equal(updated?.testStatus, "active");
+  assert.notEqual(updated?.errorCode, "no_refresh_token");
+  assert.ok(updated?.lastHealthCheckAt);
+});
+
+test("checkConnection clears stale no_refresh_token state for usable GitHub Copilot connections", async () => {
+  await resetStorage();
+
+  const connection = await providersDb.createProviderConnection({
+    provider: "github",
+    authType: "oauth",
+    name: "GitHub False Expired Account",
+    accessToken: "github-access-token",
+    refreshToken: null,
+    providerSpecificData: {
+      copilotToken: "copilot-token",
+      copilotTokenExpiresAt: Math.floor((Date.now() + 60 * 60 * 1000) / 1000),
+    },
+    testStatus: "expired",
+    errorCode: "no_refresh_token",
+    lastError: "No refresh token available — re-authenticate this account.",
+    isActive: true,
+  });
+
+  await tokenHealthCheck.checkConnection(connection);
+
+  const updated = await providersDb.getProviderConnectionById(getCreatedConnectionId(connection));
+  assert.equal(updated?.testStatus, "active");
+  assert.equal(updated?.errorCode ?? null, null);
+  assert.equal(updated?.lastError ?? null, null);
+  assert.ok(updated?.lastHealthCheckAt);
 });


### PR DESCRIPTION
## Summary

Extraction of commit `68095d479` from #5863 (by @Witroch4), rebased onto `release/v3.8.43`. Authorship preserved via `git cherry-pick -x`.

GitHub Copilot device-flow accounts can hold a GitHub access token plus a short-lived Copilot token **without** a refresh token. The proactive token health check treated that as terminal `no_refresh_token` and marked the connection expired minutes after login. This change keeps those sessions active, clears stale `no_refresh_token` state, and refreshes the Copilot sub-token when needed.

One small conflict in `src/lib/tokenHealthCheck.ts` was resolved preserving both intents: the release branch's API-key-only guard on `refreshCapableNeedsReauth` (`!(conn.apiKey && conn.apiKey.length > 0)`) is kept alongside the new Copilot access-token handling.

## Validation (Hard Rule #18)

- `node --test` (tsx): `tests/unit/token-health-no-refresh-token-expired-5326.test.ts`, `tests/unit/token-health-check.test.ts`, `tests/unit/token-health-check-circuit-breaker.test.ts`, `tests/unit/token-refresh-service.test.ts` — **59/59 pass, 0 fail**.
- `npm run typecheck:core` — clean apart from the 2 pre-existing base-red errors in `open-sse/executors/base.ts` (untouched).
- `npx eslint` on changed files — clean.

Extracted from #5863 — full credit to @Witroch4.