### PR TITLE
chore(ci): pass sonar.projectVersion to the SonarQube scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -889,12 +889,28 @@ jobs:
           else
             echo "SonarQube scan skipped because SONAR_TOKEN or SONAR_HOST_URL is not configured." >> "$GITHUB_STEP_SUMMARY"
           fi
+      - name: Read project version
+        if: ${{ github.event_name == 'pull_request' && env.SONAR_TOKEN != '' && env.SONAR_HOST_URL != '' }}
+        id: pkg
+        run: |
+          VERSION="$(node -p "require('./package.json').version")"
+          # Harden against output injection: only accept a plain semver-ish string.
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid package.json version: $VERSION" >&2; exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
       - name: SonarQube Scan
         if: ${{ github.event_name == 'pull_request' && env.SONAR_TOKEN != '' && env.SONAR_HOST_URL != '' }}
         uses: SonarSource/sonarqube-scan-action@v8
         env:
           SONAR_TOKEN: ${{ env.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ env.SONAR_HOST_URL }}
+        with:
+          # sonar.projectVersion advances the "previous_version" new-code baseline at
+          # each release; without it the baseline never moves (it stays pinned to the
+          # analysis where the version last changed) and legacy issues pile up as
+          # "new code" in the quality gate.
+          args: -Dsonar.projectVersion=${{ steps.pkg.outputs.version }}
 
   coverage-pr-comment:
     name: PR Coverage Comment


### PR DESCRIPTION
## Why

SonarCloud's quality gate for this project uses the `previous_version` new-code baseline. That baseline only advances when an analysis reports a **changed** `sonar.projectVersion` — and the CI scan never set it, so the baseline stayed pinned at 2026-05-06 and an entire release cycle's worth of legacy issues piled into "new code" (253 bugs → `new_reliability_rating = E`).

Diagnosed during the 2026-07-02 SonarCloud cleanup: manual rescans of `main` confirmed the effective period was `previous_version @ 2026-05-06` regardless of server-side settings; only a version change moves it.

## What

- New `Read project version` step in the `sonarqube` job: reads `package.json` version, validates it against a strict semver pattern (guards $GITHUB_OUTPUT injection), exports it as a step output.
- Passes `-Dsonar.projectVersion=<version>` to `SonarSource/sonarqube-scan-action@v8`.

Result: each release bump automatically advances the Sonar new-code baseline — legacy stays grandfathered, the gate only judges the current cycle.

## Validation

CI-only change (no production code). The step conditions mirror the existing scan step (`pull_request` + secrets present), so behavior is a no-op until `SONAR_TOKEN`/`SONAR_HOST_URL` are configured.