### PR TITLE
fix(dashboard): stop false Token Expired badge for auto-refreshed OAuth (#5836)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@
 
 ### 🔧 Bug Fixes
 
+- **dashboard (token badge):** the red "Token Expired" connection badge no longer flashes for OAuth refresh-capable providers (Antigravity/Gemini) whose access token merely lapsed but is auto-refreshed — it now shows only when the connection is terminally expired (`testStatus === "expired"`). Continuation of #5326. Regression guard: `tests/unit/ui/connection-row-token-badge-5836.test.tsx`. ([#5836](https://github.com/diegosouzapw/OmniRoute/issues/5836))
+
 - **db (auto backup toggle):** full pre-write SQLite backups now honor the persisted `backup.autoBackupEnabled` dashboard setting — previously only the `DISABLE_SQLITE_AUTO_BACKUP` env var was checked, so disabling auto-backup in the UI had no effect and ~70MB pre-write snapshots kept firing. Manual and pre-restore backups still always run. Regression guard: `tests/unit/db-backup-autobackup-setting-5871.test.ts`. ([#5871](https://github.com/diegosouzapw/OmniRoute/issues/5871))
 
 - **providers (auto/ routing for custom providers):** custom OpenAI-/Anthropic-compatible providers (dynamic `*-compatible-*` connection IDs) are no longer excluded from `auto/` routing — the Auto-Combo virtual factory previously skipped any connection whose provider was absent from the static registry. It now falls back to the connection's `defaultModel`. Regression guard: `tests/unit/auto-custom-provider-5873.test.ts`. ([#5873](https://github.com/diegosouzapw/OmniRoute/issues/5873))

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/ConnectionRow.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/ConnectionRow.tsx
@@ -541,15 +541,21 @@ export default function ConnectionRow({
               {statusPresentation.statusLabel}
             </Badge>
             {/* T12: Token expiry status indicator (state-driven, no Date.now in render) */}
+            {/* #5836: the red "Token Expired" badge is TERMINAL-only — for OAuth
+               refresh-capable providers (Antigravity/Gemini) the access token lapses
+               ~hourly but is auto-refreshed, so a lapsed token alone must not paint
+               red. Gate it on testStatus === "expired" (continuation of #5326). */}
             {tokenMinsLeft !== null &&
               (tokenMinsLeft < 0 ? (
-                <span
-                  className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded text-xs font-medium bg-red-500/15 text-red-500"
-                  title={t("tokenExpiredTitle", { date: effectiveExpiresAt })}
-                >
-                  <span className="material-symbols-outlined text-[11px]">error</span>
-                  {t("tokenExpiredBadge")}
-                </span>
+                connection.testStatus === "expired" ? (
+                  <span
+                    className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded text-xs font-medium bg-red-500/15 text-red-500"
+                    title={t("tokenExpiredTitle", { date: effectiveExpiresAt })}
+                  >
+                    <span className="material-symbols-outlined text-[11px]">error</span>
+                    {t("tokenExpiredBadge")}
+                  </span>
+                ) : null
               ) : tokenMinsLeft < 30 ? (
                 <span
                   className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded text-xs font-medium bg-amber-500/15 text-amber-500"

--- a/tests/unit/ui/connection-row-token-badge-5836.test.tsx
+++ b/tests/unit/ui/connection-row-token-badge-5836.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+/**
+ * Regression guard for #5836 — the red "Token Expired" connection badge must
+ * NOT flash for OAuth refresh-capable providers (Antigravity/Gemini) whose
+ * access token merely lapsed but is auto-refreshed. It should render ONLY when
+ * the connection is terminally expired (testStatus === "expired").
+ * Continuation of #5326.
+ */
+import React from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+import ConnectionRow, {
+  type ConnectionRowConnection,
+} from "@/app/(dashboard)/dashboard/providers/[id]/components/ConnectionRow";
+
+const cleanupCallbacks: Array<() => void> = [];
+
+function makeContainer(): HTMLElement {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  cleanupCallbacks.push(() => container.remove());
+  return container;
+}
+
+const baseProps = {
+  isOAuth: true,
+  isFirst: true,
+  isLast: true,
+  onMoveUp: () => {},
+  onMoveDown: () => {},
+  onToggleActive: () => {},
+  onToggleRateLimit: () => {},
+  onRetest: () => {},
+  onEdit: () => {},
+  onDelete: () => {},
+};
+
+function renderRow(connection: ConnectionRowConnection): HTMLElement {
+  const container = makeContainer();
+  const root = createRoot(container);
+  cleanupCallbacks.push(() => act(() => root.unmount()));
+  act(() => {
+    root.render(React.createElement(ConnectionRow, { ...baseProps, connection } as never));
+  });
+  return container;
+}
+
+const PAST = new Date(Date.now() - 60 * 60 * 1000).toISOString(); // 1h ago
+
+describe("ConnectionRow token expiry badge (#5836)", () => {
+  beforeEach(() => {
+    (
+      globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterEach(() => {
+    while (cleanupCallbacks.length) cleanupCallbacks.pop()!();
+  });
+
+  it("does NOT render the red Token Expired badge for a healthy OAuth connection whose access token merely lapsed", () => {
+    const container = renderRow({
+      id: "c1",
+      provider: "antigravity",
+      testStatus: "active",
+      isActive: true,
+      tokenExpiresAt: PAST,
+      priority: 1,
+    } as ConnectionRowConnection);
+    expect(container.textContent).not.toContain("tokenExpiredBadge");
+  });
+
+  it("renders the red Token Expired badge when the connection is terminally expired", () => {
+    const container = renderRow({
+      id: "c2",
+      provider: "antigravity",
+      testStatus: "expired",
+      isActive: true,
+      tokenExpiresAt: PAST,
+      errorCode: "no_refresh_token",
+      priority: 1,
+    } as ConnectionRowConnection);
+    expect(container.textContent).toContain("tokenExpiredBadge");
+  });
+});


### PR DESCRIPTION
Closes #5836

## Problem
The red "Token Expired" badge in `ConnectionRow` rendered whenever `tokenMinsLeft < 0` (access token past `tokenExpiresAt`/`expiresAt`). For OAuth refresh-capable providers (Antigravity/Gemini) the access token expires ~hourly but is auto-refreshed, so the badge flashed red on healthy connections. #5326 only handled the genuine terminal case.

## Fix
Gate the red badge on `connection.testStatus === "expired"` (terminal). A merely-lapsed token on an active connection now paints nothing red; the amber "expires soon" (<30m) indicator is unchanged. No refresh logic touched — display-only.

## Validation (TDD, Hard Rule #18)
`tests/unit/ui/connection-row-token-badge-5836.test.tsx`:
- OAuth + past token + `testStatus:"active"` → NO red badge (was failing before fix)
- `testStatus:"expired"` → red badge renders

Both pass. `typecheck:core` shows only pre-existing `open-sse/executors/base.ts` base-red (unrelated); ESLint clean on the changed file.