### PR TITLE
docs: fix pnpm global native-build install command (#5554)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@
 
 ### 🔧 Bug Fixes
 
+- **docs (pnpm global install):** replaced the unsupported `pnpm approve-builds -g` step with the install-time `pnpm add -g omniroute@latest --allow-build=better-sqlite3` flag across README + Setup Guide (and i18n mirrors), fixing native-build approval for pnpm v11 global installs. ([#5554](https://github.com/diegosouzapw/OmniRoute/issues/5554))
+
 - **dashboard (token badge):** the red "Token Expired" connection badge no longer flashes for OAuth refresh-capable providers (Antigravity/Gemini) whose access token merely lapsed but is auto-refreshed — it now shows only when the connection is terminally expired (`testStatus === "expired"`). Continuation of #5326. Regression guard: `tests/unit/ui/connection-row-token-badge-5836.test.tsx`. ([#5836](https://github.com/diegosouzapw/OmniRoute/issues/5836))
 
 - **db (auto backup toggle):** full pre-write SQLite backups now honor the persisted `backup.autoBackupEnabled` dashboard setting — previously only the `DISABLE_SQLITE_AUTO_BACKUP` env var was checked, so disabling auto-backup in the UI had no effect and ~70MB pre-write snapshots kept firing. Manual and pre-restore backups still always run. Regression guard: `tests/unit/db-backup-autobackup-setting-5871.test.ts`. ([#5871](https://github.com/diegosouzapw/OmniRoute/issues/5871))

--- a/README.md
+++ b/README.md
@@ -705,7 +705,7 @@ PORT=20128 npm run dev
 **📦 pnpm**
 
 ```bash
-pnpm install -g omniroute && pnpm approve-builds -g && omniroute
+pnpm add -g omniroute@latest --allow-build=better-sqlite3 --allow-build=@swc/core && omniroute
 ```
 
 **🐧 Arch Linux (AUR)**

--- a/docs/guides/SETUP_GUIDE.md
+++ b/docs/guides/SETUP_GUIDE.md
@@ -34,12 +34,11 @@ Dashboard opens at `http://localhost:20128` and API base URL is `http://localhos
 ### pnpm
 
 ```bash
-pnpm install -g omniroute
-pnpm approve-builds -g   # Select all packages → approve
+pnpm add -g omniroute@latest --allow-build=better-sqlite3 --allow-build=@swc/core
 omniroute
 ```
 
-> **pnpm users:** `pnpm approve-builds -g` is required to enable native build scripts for `better-sqlite3` and `@swc/core`.
+> **pnpm users:** the `--allow-build` flag is required to enable native build scripts for `better-sqlite3` and `@swc/core`. The `pnpm approve-builds -g` command is not supported for global installs on pnpm v11.
 
 ### Arch Linux (AUR)
 

--- a/docs/i18n/ar/README.md
+++ b/docs/i18n/ar/README.md
@@ -756,11 +756,10 @@ npm install -g omniroute
 omniroute
 ```
 
-> **pnpm users:** Run `pnpm approve-builds -g` after install to enable native build scripts required by `better-sqlite3` and `@swc/core`:
+> **pnpm users:** Pass `--allow-build` at install time to enable native build scripts required by `better-sqlite3` and `@swc/core` (the `approve-builds -g` command is not supported for global installs on pnpm v11):
 >
 > ```bash
-> pnpm install -g omniroute
-> pnpm approve-builds -g   # Select all packages → approve
+> pnpm add -g omniroute@latest --allow-build=better-sqlite3 --allow-build=@swc/core
 > omniroute
 > ```
 

--- a/docs/i18n/az/README.md
+++ b/docs/i18n/az/README.md
@@ -757,11 +757,10 @@ npm install -g omniroute
 omniroute
 ```
 
-> **pnpm users:** Run `pnpm approve-builds -g` after install to enable native build scripts required by `better-sqlite3` and `@swc/core`:
+> **pnpm users:** Pass `--allow-build` at install time to enable native build scripts required by `better-sqlite3` and `@swc/core` (the `approve-builds -g` command is not supported for global installs on pnpm v11):
 >
 > ```bash
-> pnpm install -g omniroute
-> pnpm approve-builds -g   # Select all packages → approve
+> pnpm add -g omniroute@latest --allow-build=better-sqlite3 --allow-build=@swc/core
 > omniroute
 > ```
 

--- a/docs/i18n/bg/README.md
+++ b/docs/i18n/bg/README.md
@@ -756,11 +756,10 @@ npm install -g omniroute
 omniroute
 ```
 
-> **pnpm users:** Run `pnpm approve-builds -g` after install to enable native build scripts required by `better-sqlite3` and `@swc/core`:
+> **pnpm users:** Pass `--allow-build` at install time to enable native build scripts required by `better-sqlite3` and `@swc/core` (the `approve-builds -g` command is not supported for global installs on pnpm v11):
 >
 > ```bash
-> pnpm install -g omniroute
-> pnpm approve-builds -g   # Select all packages → approve
+> pnpm add -g omniroute@latest --allow-build=better-sqlite3 --allow-build=@swc/core
 > omniroute
 > ```
 

--- a/docs/i18n/bn/README.md
+++ b/docs/i18n/bn/README.md
@@ -756,11 +756,10 @@ npm install -g omniroute
 omniroute
 ```
 
-> **pnpm users:** Run `pnpm approve-builds -g` after install to enable native build scripts required by `better-sqlite3` and `@swc/core`:
+> **pnpm users:** Pass `--allow-build` at install time to enable native build scripts required by `better-sqlite3` and `@swc/core` (the `approve-builds -g` command is not supported for global installs on pnpm v11):
 >
 > ```bash
-> pnpm install -g omniroute
-> pnpm approve-builds -g   # Select all packages → approve
+> pnpm add -g omniroute@latest --allow-build=better-sqlite3 --allow-build=@swc/core
 > omniroute
 > ```
 

--- a/docs/i18n/cs/README.md
+++ b/docs/i18n/cs/README.md
@@ -756,11 +756,10 @@ npm install -g omniroute
 omniroute
 ```
 
-> **pnpm users:** Run `pnpm approve-builds -g` after install to enable native build scripts required by `better-sqlite3` and `@swc/core`:
+> **pnpm users:** Pass `--allow-build` at install time to enable native build scripts required by `better-sqlite3` and `@swc/core` (the `approve-builds -g` command is not supported for global installs on pnpm v11):
 >
 > ```bash
-> pnpm install -g omniroute
-> pnpm approve-builds -g   # Select all packages → approve
+> pnpm add -g omniroute@latest --allow-build=better-sqlite3 --allow-build=@swc/core
 > omniroute
 > ```
 

--- a/docs/i18n/da/README.md
+++ b/docs/i18n/da/README.md
@@ -756,11 +756,10 @@ npm install -g omniroute
 omniroute
 ```
 
-> **pnpm users:** Run `pnpm approve-builds -g` after install to enable native build scripts required by `better-sqlite3` and `@swc/core`:
+> **pnpm users:** Pass `--allow-build` at install time to enable native build scripts required by `better-sqlite3` and `@swc/core` (the `approve-builds -g` command is not supported for global installs on pnpm v11):
 >
 > ```bash
-> pnpm install -g omniroute
-> pnpm approve-builds -g   # Select all packages → approve
+> pnpm add -g omniroute@latest --allow-build=better-sqlite3 --allow-build=@swc/core
 > omniroute
 > ```
 

--- a/docs/i18n/de/README.md
+++ b/docs/i18n/de/README.md
@@ -756,11 +756,10 @@ npm install -g omniroute
 omniroute
 ```
 
-> **pnpm users:** Run `pnpm approve-builds -g` after install to enable native build scripts required by `better-sqlite3` and `@swc/core`:
+> **pnpm users:** Pass `--allow-build` at install time to enable native build scripts required by `better-sqlite3` and `@swc/core` (the `approve-builds -g` command is not supported for global installs on pnpm v11):
 >
 > ```bash
-> pnpm install -g omniroute
-> pnpm approve-builds -g   # Select all packages → approve
+> pnpm add -g omniroute@latest --allow-build=better-sqlite3 --allow-build=@swc/core
 > omniroute
 > ```
 

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -756,11 +756,10 @@ npm install -g omniroute
 omniroute
 ```
 
-> **pnpm users:** Run `pnpm approve-builds -g` after install to enable native build scripts required by `better-sqlite3` and `@swc/core`:
+> **pnpm users:** Pass `--allow-build` at install time to enable native build scripts required by `better-sqlite3` and `@swc/core` (the `approve-builds -g` command is not supported for global installs on pnpm v11):
 >
 > ```bash
-> pnpm install -g omniroute
-> pnpm approve-builds -g   # Select all packages → approve
+> pnpm add -g omniroute@latest --allow-build=better-sqlite3 --allow-build=@swc/core
 > omniroute
 > ```
 

--- a/docs/i18n/fa/README.md
+++ b/docs/i18n/fa/README.md
@@ -756,11 +756,10 @@ npm install -g omniroute
 omniroute
 ```
 
-> **pnpm users:** Run `pnpm approve-builds -g` after install to enable native build scripts required by `better-sqlite3` and `@swc/core`:
+> **pnpm users:** Pass `--allow-build` at install time to enable native build scripts required by `better-sqlite3` and `@swc/core` (the `approve-builds -g` command is not supported for global installs on pnpm v11):
 >
 > ```bash
-> pnpm install -g omniroute
-> pnpm approve-builds -g   # Select all packages → approve
+> pnpm add -g omniroute@latest --allow-build=better-sqlite3 --allow-build=@swc/core
 > omniroute
 > ```
 

--- a/docs/i18n/fi/README.md
+++ b/docs/i18n/fi/README.md
@@ -756,11 +756,10 @@ npm install -g omniroute
 omniroute
 ```
 
-> **pnpm users:** Run `pnpm approve-builds -g` after install to enable native build scripts required by `better-sqlite3` and `@swc/core`:
+> **pnpm users:** Pass `--allow-build` at install time to enable native build scripts required by `better-sqlite3` and `@swc/core` (the `approve-builds -g` command is not supported for global installs on pnpm v11):
 >
 > ```bash
-> pnpm install -g omniroute
-> pnpm approve-builds -g   # Select all packages → approve
+> pnpm add -g omniroute@latest --allow-build=better-sqlite3 --allow-build=@swc/core
 > omniroute
 > ```
 

--- a/docs/i18n/fr/README.md
+++ b/docs/i18n/fr/README.md
@@ -756,11 +756,10 @@ npm install -g omniroute
 omniroute
 ```
 
-> **pnpm users:** Run `pnpm approve-builds -g` after install to enable native build scripts required by `better-sqlite3` and `@swc/core`:
+> **pnpm users:** Pass `--allow-build` at install time to enable native build scripts required by `better-sqlite3` and `@swc/core` (the `approve-builds -g` command is not supported for global installs on pnpm v11):
 >
 > ```bash
-> pnpm install -g omniroute
-> pnpm approve-builds -g   # Select all packages → approve
+> pnpm add -g omniroute@latest --allow-build=better-sqlite3 --allow-build=@swc/core
 > omniroute
 > ```
 

--- a/docs/i18n/gu/README.md
+++ b/docs/i18n/gu/README.md
@@ -756,11 +756,10 @@ npm install -g omniroute
 omniroute
 ```
 
-> **pnpm users:** Run `pnpm approve-builds -g` after install to enable native build scripts required by `better-sqlite3` and `@swc/core`:
+> **pnpm users:** Pass `--allow-build` at install time to enable native build scripts required by `better-sqlite3` and `@swc/core` (the `approve-builds -g` command is not supported for global installs on pnpm v11):
 >
 > ```bash
-> pnpm install -g omniroute
-> pnpm approve-builds -g   # Select all packages → approve
+> pnpm add -g omniroute@latest --allow-build=better-sqlite3 --allow-build=@swc/core
 > omniroute
 > ```
 

--- a/docs/i18n/he/README.md
+++ b/docs/i18n/he/README.md
@@ -756,11 +756,10 @@ npm install -g omniroute
 omniroute
 ```
 
-> **pnpm users:** Run `pnpm approve-builds -g` after install to enable native build scripts required by `better-sqlite3` and `@swc/core`:
+> **pnpm users:** Pass `--allow-build` at install time to enable native build scripts required by `better-sqlite3` and `@swc/core` (the `approve-builds -g` command is not supported for global installs on pnpm v11):
 >
 > ```bash
-> pnpm install -g omniroute
-> pnpm approve-builds -g   # Select all packages → approve
+> pnpm add -g omniroute@latest --allow-build=better-sqlite3 --allow-build=@swc/core
 > omniroute
 > ```
 

--- a/docs/i18n/hi/README.md
+++ b/docs/i18n/hi/README.md
@@ -756,11 +756,10 @@ npm install -g omniroute
 omniroute
 ```
 
-> **pnpm users:** Run `pnpm approve-builds -g` after install to enable native build scripts required by `better-sqlite3` and `@swc/core`:
+> **pnpm users:** Pass `--allow-build` at install time to enable native build scripts required by `better-sqlite3` and `@swc/core` (the `approve-builds -g` command is not supported for global installs on pnpm v11):
 >
 > ```bash
-> pnpm install -g omniroute
-> pnpm approve-builds -g   # Select all packages → approve
+> pnpm add -g omniroute@latest --allow-build=better-sqlite3 --allow-build=@swc/core
 > omniroute
 > ```
 

--- a/docs/i18n/hu/README.md
+++ b/docs/i18n/hu/README.md
@@ -756,11 +756,10 @@ npm install -g omniroute
 omniroute
 ```
 
-> **pnpm users:** Run `pnpm approve-builds -g` after install to enable native build scripts required by `better-sqlite3` and `@swc/core`:
+> **pnpm users:** Pass `--allow-build` at install time to enable native build scripts required by `better-sqlite3` and `@swc/core` (the `approve-builds -g` command is not supported for global installs on pnpm v11):
 >
 > ```bash
-> pnpm install -g omniroute
-> pnpm approve-builds -g   # Select all packages → approve
+> pnpm add -g omniroute@latest --allow-build=better-sqlite3 --allow-build=@swc/core
 > omniroute
 > ```
 

--- a/docs/i18n/id/README.md
+++ b/docs/i18n/id/README.md
@@ -754,11 +754,10 @@ npm install -g omniroute
 omniroute
 ```
 
-> **pengguna pnpm:** Jalankan `pnpm approve-builds -g` setelah instalasi untuk mengaktifkan skrip build asli yang diperlukan oleh `better-sqlite3` dan `@swc/core`:
+> **pengguna pnpm:** Pass `--allow-build` at install time to enable native build scripts required by `better-sqlite3` and `@swc/core` (the `approve-builds -g` command is not supported for global installs on pnpm v11):
 >
 > ```bash
-> pnpm install -g omniroute
-> pnpm approve-builds -g   # Pilih semua paket → approve
+> pnpm add -g omniroute@latest --allow-build=better-sqlite3 --allow-build=@swc/core
 > omniroute
 > ```
 

--- a/docs/i18n/in/README.md
+++ b/docs/i18n/in/README.md
@@ -755,11 +755,10 @@ npm install -g omniroute
 omniroute
 ```
 
-> **pnpm users:** Run `pnpm approve-builds -g` after install to enable native build scripts required by `better-sqlite3` and `@swc/core`:
+> **pnpm users:** Pass `--allow-build` at install time to enable native build scripts required by `better-sqlite3` and `@swc/core` (the `approve-builds -g` command is not supported for global installs on pnpm v11):
 >
 > ```bash
-> pnpm install -g omniroute
-> pnpm approve-builds -g   # Select all packages → approve
+> pnpm add -g omniroute@latest --allow-build=better-sqlite3 --allow-build=@swc/core
 > omniroute
 > ```
 

--- a/docs/i18n/it/README.md
+++ b/docs/i18n/it/README.md
@@ -756,11 +756,10 @@ npm install -g omniroute
 omniroute
 ```
 
-> **pnpm users:** Run `pnpm approve-builds -g` after install to enable native build scripts required by `better-sqlite3` and `@swc/core`:
+> **pnpm users:** Pass `--allow-build` at install time to enable native build scripts required by `better-sqlite3` and `@swc/core` (the `approve-builds -g` command is not supported for global installs on pnpm v11):
 >
 > ```bash
-> pnpm install -g omniroute
-> pnpm approve-builds -g   # Select all packages → approve
+> pnpm add -g omniroute@latest --allow-build=better-sqlite3 --allow-build=@swc/core
 > omniroute
 > ```
 

--- a/docs/i18n/ja/README.md
+++ b/docs/i18n/ja/README.md
@@ -756,11 +756,10 @@ npm install -g omniroute
 omniroute
 ```
 
-> **pnpm users:** Run `pnpm approve-builds -g` after install to enable native build scripts required by `better-sqlite3` and `@swc/core`:
+> **pnpm users:** Pass `--allow-build` at install time to enable native build scripts required by `better-sqlite3` and `@swc/core` (the `approve-builds -g` command is not supported for global installs on pnpm v11):
 >
 > ```bash
-> pnpm install -g omniroute
-> pnpm approve-builds -g   # Select all packages → approve
+> pnpm add -g omniroute@latest --allow-build=better-sqlite3 --allow-build=@swc/core
 > omniroute
 > ```
 

--- a/docs/i18n/ko/README.md
+++ b/docs/i18n/ko/README.md
@@ -756,11 +756,10 @@ npm install -g omniroute
 omniroute
 ```
 
-> **pnpm users:** Run `pnpm approve-builds -g` after install to enable native build scripts required by `better-sqlite3` and `@swc/core`:
+> **pnpm users:** Pass `--allow-build` at install time to enable native build scripts required by `better-sqlite3` and `@swc/core` (the `approve-builds -g` command is not supported for global installs on pnpm v11):
 >
 > ```bash
-> pnpm install -g omniroute
-> pnpm approve-builds -g   # Select all packages → approve
+> pnpm add -g omniroute@latest --allow-build=better-sqlite3 --allow-build=@swc/core
 > omniroute
 > ```
 

--- a/docs/i18n/mr/README.md
+++ b/docs/i18n/mr/README.md
@@ -756,11 +756,10 @@ npm install -g omniroute
 omniroute
 ```
 
-> **pnpm users:** Run `pnpm approve-builds -g` after install to enable native build scripts required by `better-sqlite3` and `@swc/core`:
+> **pnpm users:** Pass `--allow-build` at install time to enable native build scripts required by `better-sqlite3` and `@swc/core` (the `approve-builds -g` command is not supported for global installs on pnpm v11):
 >
 > ```bash
-> pnpm install -g omniroute
-> pnpm approve-builds -g   # Select all packages → approve
+> pnpm add -g omniroute@latest --allow-build=better-sqlite3 --allow-build=@swc/core
 > omniroute
 > ```
 

--- a/docs/i18n/ms/README.md
+++ b/docs/i18n/ms/README.md
@@ -756,11 +756,10 @@ npm install -g omniroute
 omniroute
 ```
 
-> **pnpm users:** Run `pnpm approve-builds -g` after install to enable native build scripts required by `better-sqlite3` and `@swc/core`:
+> **pnpm users:** Pass `--allow-build` at install time to enable native build scripts required by `better-sqlite3` and `@swc/core` (the `approve-builds -g` command is not supported for global installs on pnpm v11):
 >
 > ```bash
-> pnpm install -g omniroute
-> pnpm approve-builds -g   # Select all packages → approve
+> pnpm add -g omniroute@latest --allow-build=better-sqlite3 --allow-build=@swc/core
 > omniroute
 > ```
 

--- a/docs/i18n/nl/README.md
+++ b/docs/i18n/nl/README.md
@@ -756,11 +756,10 @@ npm install -g omniroute
 omniroute
 ```
 
-> **pnpm users:** Run `pnpm approve-builds -g` after install to enable native build scripts required by `better-sqlite3` and `@swc/core`:
+> **pnpm users:** Pass `--allow-build` at install time to enable native build scripts required by `better-sqlite3` and `@swc/core` (the `approve-builds -g` command is not supported for global installs on pnpm v11):
 >
 > ```bash
-> pnpm install -g omniroute
-> pnpm approve-builds -g   # Select all packages → approve
+> pnpm add -g omniroute@latest --allow-build=better-sqlite3 --allow-build=@swc/core
 > omniroute
 > ```
 

--- a/docs/i18n/no/README.md
+++ b/docs/i18n/no/README.md
@@ -756,11 +756,10 @@ npm install -g omniroute
 omniroute
 ```
 
-> **pnpm users:** Run `pnpm approve-builds -g` after install to enable native build scripts required by `better-sqlite3` and `@swc/core`:
+> **pnpm users:** Pass `--allow-build` at install time to enable native build scripts required by `better-sqlite3` and `@swc/core` (the `approve-builds -g` command is not supported for global installs on pnpm v11):
 >
 > ```bash
-> pnpm install -g omniroute
-> pnpm approve-builds -g   # Select all packages → approve
+> pnpm add -g omniroute@latest --allow-build=better-sqlite3 --allow-build=@swc/core
 > omniroute
 > ```
 

--- a/docs/i18n/phi/README.md
+++ b/docs/i18n/phi/README.md
@@ -756,11 +756,10 @@ npm install -g omniroute
 omniroute
 ```
 
-> **pnpm users:** Run `pnpm approve-builds -g` after install to enable native build scripts required by `better-sqlite3` and `@swc/core`:
+> **pnpm users:** Pass `--allow-build` at install time to enable native build scripts required by `better-sqlite3` and `@swc/core` (the `approve-builds -g` command is not supported for global installs on pnpm v11):
 >
 > ```bash
-> pnpm install -g omniroute
-> pnpm approve-builds -g   # Select all packages → approve
+> pnpm add -g omniroute@latest --allow-build=better-sqlite3 --allow-build=@swc/core
 > omniroute
 > ```
 

--- a/docs/i18n/pl/README.md
+++ b/docs/i18n/pl/README.md
@@ -756,11 +756,10 @@ npm install -g omniroute
 omniroute
 ```
 
-> **pnpm users:** Run `pnpm approve-builds -g` after install to enable native build scripts required by `better-sqlite3` and `@swc/core`:
+> **pnpm users:** Pass `--allow-build` at install time to enable native build scripts required by `better-sqlite3` and `@swc/core` (the `approve-builds -g` command is not supported for global installs on pnpm v11):
 >
 > ```bash
-> pnpm install -g omniroute
-> pnpm approve-builds -g   # Select all packages → approve
+> pnpm add -g omniroute@latest --allow-build=better-sqlite3 --allow-build=@swc/core
 > omniroute
 > ```
 

--- a/docs/i18n/pt-BR/README.md
+++ b/docs/i18n/pt-BR/README.md
@@ -756,11 +756,10 @@ npm install -g omniroute
 omniroute
 ```
 
-> **pnpm users:** Run `pnpm approve-builds -g` after install to enable native build scripts required by `better-sqlite3` and `@swc/core`:
+> **pnpm users:** Pass `--allow-build` at install time to enable native build scripts required by `better-sqlite3` and `@swc/core` (the `approve-builds -g` command is not supported for global installs on pnpm v11):
 >
 > ```bash
-> pnpm install -g omniroute
-> pnpm approve-builds -g   # Select all packages → approve
+> pnpm add -g omniroute@latest --allow-build=better-sqlite3 --allow-build=@swc/core
 > omniroute
 > ```
 

--- a/docs/i18n/pt/README.md
+++ b/docs/i18n/pt/README.md
@@ -756,11 +756,10 @@ npm install -g omniroute
 omniroute
 ```
 
-> **pnpm users:** Run `pnpm approve-builds -g` after install to enable native build scripts required by `better-sqlite3` and `@swc/core`:
+> **pnpm users:** Pass `--allow-build` at install time to enable native build scripts required by `better-sqlite3` and `@swc/core` (the `approve-builds -g` command is not supported for global installs on pnpm v11):
 >
 > ```bash
-> pnpm install -g omniroute
-> pnpm approve-builds -g   # Select all packages → approve
+> pnpm add -g omniroute@latest --allow-build=better-sqlite3 --allow-build=@swc/core
 > omniroute
 > ```
 

--- a/docs/i18n/ro/README.md
+++ b/docs/i18n/ro/README.md
@@ -756,11 +756,10 @@ npm install -g omniroute
 omniroute
 ```
 
-> **pnpm users:** Run `pnpm approve-builds -g` after install to enable native build scripts required by `better-sqlite3` and `@swc/core`:
+> **pnpm users:** Pass `--allow-build` at install time to enable native build scripts required by `better-sqlite3` and `@swc/core` (the `approve-builds -g` command is not supported for global installs on pnpm v11):
 >
 > ```bash
-> pnpm install -g omniroute
-> pnpm approve-builds -g   # Select all packages → approve
+> pnpm add -g omniroute@latest --allow-build=better-sqlite3 --allow-build=@swc/core
 > omniroute
 > ```
 

--- a/docs/i18n/ru/README.md
+++ b/docs/i18n/ru/README.md
@@ -756,11 +756,10 @@ npm install -g omniroute
 omniroute
 ```
 
-> **pnpm users:** Run `pnpm approve-builds -g` after install to enable native build scripts required by `better-sqlite3` and `@swc/core`:
+> **pnpm users:** Pass `--allow-build` at install time to enable native build scripts required by `better-sqlite3` and `@swc/core` (the `approve-builds -g` command is not supported for global installs on pnpm v11):
 >
 > ```bash
-> pnpm install -g omniroute
-> pnpm approve-builds -g   # Select all packages → approve
+> pnpm add -g omniroute@latest --allow-build=better-sqlite3 --allow-build=@swc/core
 > omniroute
 > ```
 

--- a/docs/i18n/sk/README.md
+++ b/docs/i18n/sk/README.md
@@ -756,11 +756,10 @@ npm install -g omniroute
 omniroute
 ```
 
-> **pnpm users:** Run `pnpm approve-builds -g` after install to enable native build scripts required by `better-sqlite3` and `@swc/core`:
+> **pnpm users:** Pass `--allow-build` at install time to enable native build scripts required by `better-sqlite3` and `@swc/core` (the `approve-builds -g` command is not supported for global installs on pnpm v11):
 >
 > ```bash
-> pnpm install -g omniroute
-> pnpm approve-builds -g   # Select all packages → approve
+> pnpm add -g omniroute@latest --allow-build=better-sqlite3 --allow-build=@swc/core
 > omniroute
 > ```
 

--- a/docs/i18n/sv/README.md
+++ b/docs/i18n/sv/README.md
@@ -756,11 +756,10 @@ npm install -g omniroute
 omniroute
 ```
 
-> **pnpm users:** Run `pnpm approve-builds -g` after install to enable native build scripts required by `better-sqlite3` and `@swc/core`:
+> **pnpm users:** Pass `--allow-build` at install time to enable native build scripts required by `better-sqlite3` and `@swc/core` (the `approve-builds -g` command is not supported for global installs on pnpm v11):
 >
 > ```bash
-> pnpm install -g omniroute
-> pnpm approve-builds -g   # Select all packages → approve
+> pnpm add -g omniroute@latest --allow-build=better-sqlite3 --allow-build=@swc/core
 > omniroute
 > ```
 

--- a/docs/i18n/sw/README.md
+++ b/docs/i18n/sw/README.md
@@ -756,11 +756,10 @@ npm install -g omniroute
 omniroute
 ```
 
-> **pnpm users:** Run `pnpm approve-builds -g` after install to enable native build scripts required by `better-sqlite3` and `@swc/core`:
+> **pnpm users:** Pass `--allow-build` at install time to enable native build scripts required by `better-sqlite3` and `@swc/core` (the `approve-builds -g` command is not supported for global installs on pnpm v11):
 >
 > ```bash
-> pnpm install -g omniroute
-> pnpm approve-builds -g   # Select all packages → approve
+> pnpm add -g omniroute@latest --allow-build=better-sqlite3 --allow-build=@swc/core
 > omniroute
 > ```
 

--- a/docs/i18n/ta/README.md
+++ b/docs/i18n/ta/README.md
@@ -756,11 +756,10 @@ npm install -g omniroute
 omniroute
 ```
 
-> **pnpm users:** Run `pnpm approve-builds -g` after install to enable native build scripts required by `better-sqlite3` and `@swc/core`:
+> **pnpm users:** Pass `--allow-build` at install time to enable native build scripts required by `better-sqlite3` and `@swc/core` (the `approve-builds -g` command is not supported for global installs on pnpm v11):
 >
 > ```bash
-> pnpm install -g omniroute
-> pnpm approve-builds -g   # Select all packages → approve
+> pnpm add -g omniroute@latest --allow-build=better-sqlite3 --allow-build=@swc/core
 > omniroute
 > ```
 

--- a/docs/i18n/te/README.md
+++ b/docs/i18n/te/README.md
@@ -756,11 +756,10 @@ npm install -g omniroute
 omniroute
 ```
 
-> **pnpm users:** Run `pnpm approve-builds -g` after install to enable native build scripts required by `better-sqlite3` and `@swc/core`:
+> **pnpm users:** Pass `--allow-build` at install time to enable native build scripts required by `better-sqlite3` and `@swc/core` (the `approve-builds -g` command is not supported for global installs on pnpm v11):
 >
 > ```bash
-> pnpm install -g omniroute
-> pnpm approve-builds -g   # Select all packages → approve
+> pnpm add -g omniroute@latest --allow-build=better-sqlite3 --allow-build=@swc/core
 > omniroute
 > ```
 

--- a/docs/i18n/th/README.md
+++ b/docs/i18n/th/README.md
@@ -756,11 +756,10 @@ npm install -g omniroute
 omniroute
 ```
 
-> **pnpm users:** Run `pnpm approve-builds -g` after install to enable native build scripts required by `better-sqlite3` and `@swc/core`:
+> **pnpm users:** Pass `--allow-build` at install time to enable native build scripts required by `better-sqlite3` and `@swc/core` (the `approve-builds -g` command is not supported for global installs on pnpm v11):
 >
 > ```bash
-> pnpm install -g omniroute
-> pnpm approve-builds -g   # Select all packages → approve
+> pnpm add -g omniroute@latest --allow-build=better-sqlite3 --allow-build=@swc/core
 > omniroute
 > ```
 

--- a/docs/i18n/tr/README.md
+++ b/docs/i18n/tr/README.md
@@ -756,11 +756,10 @@ npm install -g omniroute
 omniroute
 ```
 
-> **pnpm users:** Run `pnpm approve-builds -g` after install to enable native build scripts required by `better-sqlite3` and `@swc/core`:
+> **pnpm users:** Pass `--allow-build` at install time to enable native build scripts required by `better-sqlite3` and `@swc/core` (the `approve-builds -g` command is not supported for global installs on pnpm v11):
 >
 > ```bash
-> pnpm install -g omniroute
-> pnpm approve-builds -g   # Select all packages → approve
+> pnpm add -g omniroute@latest --allow-build=better-sqlite3 --allow-build=@swc/core
 > omniroute
 > ```
 

--- a/docs/i18n/uk-UA/README.md
+++ b/docs/i18n/uk-UA/README.md
@@ -756,11 +756,10 @@ npm install -g omniroute
 omniroute
 ```
 
-> **pnpm users:** Run `pnpm approve-builds -g` after install to enable native build scripts required by `better-sqlite3` and `@swc/core`:
+> **pnpm users:** Pass `--allow-build` at install time to enable native build scripts required by `better-sqlite3` and `@swc/core` (the `approve-builds -g` command is not supported for global installs on pnpm v11):
 >
 > ```bash
-> pnpm install -g omniroute
-> pnpm approve-builds -g   # Select all packages → approve
+> pnpm add -g omniroute@latest --allow-build=better-sqlite3 --allow-build=@swc/core
 > omniroute
 > ```
 

--- a/docs/i18n/ur/README.md
+++ b/docs/i18n/ur/README.md
@@ -756,11 +756,10 @@ npm install -g omniroute
 omniroute
 ```
 
-> **pnpm users:** Run `pnpm approve-builds -g` after install to enable native build scripts required by `better-sqlite3` and `@swc/core`:
+> **pnpm users:** Pass `--allow-build` at install time to enable native build scripts required by `better-sqlite3` and `@swc/core` (the `approve-builds -g` command is not supported for global installs on pnpm v11):
 >
 > ```bash
-> pnpm install -g omniroute
-> pnpm approve-builds -g   # Select all packages → approve
+> pnpm add -g omniroute@latest --allow-build=better-sqlite3 --allow-build=@swc/core
 > omniroute
 > ```
 

--- a/docs/i18n/vi/README.md
+++ b/docs/i18n/vi/README.md
@@ -756,11 +756,10 @@ npm install -g omniroute
 omniroute
 ```
 
-> **pnpm users:** Run `pnpm approve-builds -g` after install to enable native build scripts required by `better-sqlite3` and `@swc/core`:
+> **pnpm users:** Pass `--allow-build` at install time to enable native build scripts required by `better-sqlite3` and `@swc/core` (the `approve-builds -g` command is not supported for global installs on pnpm v11):
 >
 > ```bash
-> pnpm install -g omniroute
-> pnpm approve-builds -g   # Select all packages → approve
+> pnpm add -g omniroute@latest --allow-build=better-sqlite3 --allow-build=@swc/core
 > omniroute
 > ```
 

--- a/docs/i18n/zh-CN/README.md
+++ b/docs/i18n/zh-CN/README.md
@@ -632,7 +632,7 @@ PORT=20128 npm run dev
 **📦 pnpm**
 
 ```bash
-pnpm install -g omniroute && pnpm approve-builds -g && omniroute
+pnpm add -g omniroute@latest --allow-build=better-sqlite3 --allow-build=@swc/core && omniroute
 ```
 
 **🐧 Arch Linux（AUR）**

--- a/docs/i18n/zh-TW/README.md
+++ b/docs/i18n/zh-TW/README.md
@@ -626,7 +626,7 @@ PORT=20128 npm run dev
 **📦 pnpm**
 
 ```bash
-pnpm install -g omniroute && pnpm approve-builds -g && omniroute
+pnpm add -g omniroute@latest --allow-build=better-sqlite3 --allow-build=@swc/core && omniroute
 ```
 
 **🐧 Arch Linux（AUR）**


### PR DESCRIPTION
Closes #5554 (part 1: docs). Parts 2/3 (store corruption recovery, better-sqlite3 prebuilds) tracked separately as config/enhancement.

## What
Replaced the unsupported `pnpm approve-builds -g` step (not supported for global installs on pnpm v11 — global packages are isolated) with the install-time flag `pnpm add -g omniroute@latest --allow-build=better-sqlite3 --allow-build=@swc/core`.

## Where
- README.md (pnpm one-liner)
- docs/guides/SETUP_GUIDE.md (pnpm block + callout)
- 42 i18n README mirrors (docs/i18n/*/README.md), keeping each language's bold label

## Validation
- Verified `pnpm --version` = 11.5.1 and `pnpm add --help` exposes `--allow-build`.
- `npm run check:docs-sync` → PASS.
- Historical CHANGELOG #520 i18n entries left untouched (frozen release history).