### PR TITLE
fix(providers): include custom compatible providers in auto/ routing (#5873)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@
 
 ### 🔧 Bug Fixes
 
+- **providers (auto/ routing for custom providers):** custom OpenAI-/Anthropic-compatible providers (dynamic `*-compatible-*` connection IDs) are no longer excluded from `auto/` routing — the Auto-Combo virtual factory previously skipped any connection whose provider was absent from the static registry. It now falls back to the connection's `defaultModel`. Regression guard: `tests/unit/auto-custom-provider-5873.test.ts`. ([#5873](https://github.com/diegosouzapw/OmniRoute/issues/5873))
+
 - **middleware (hook sandbox):** operator-authored pre-request hook code now runs inside a hardened Node `vm` sandbox (minimal context, no ambient globals/`process.env`, execution timeout, no `require`) instead of `new Function()` in the main process — closing the Hard Rule #3 / SonarCloud S1523 exposure. Regression guard: `tests/unit/middleware-hook-sandbox-5872.test.ts`. ([#5872](https://github.com/diegosouzapw/OmniRoute/issues/5872))
 
 - **mcp-server (auth forwarding):** the per-caller MCP identity forwarded via `withMcpHttpAuthContext` now wins over the static `OMNIROUTE_API_KEY` env fallback in the internal-fetch helpers (`apiFetch`, `omniRouteFetch`) — previously the env key was spread after the forwarded headers and clobbered the caller's `Authorization`. Regression guard: `open-sse/mcp-server/__tests__/httpAuthContext.test.ts`. ([#5819](https://github.com/diegosouzapw/OmniRoute/issues/5819))

--- a/open-sse/services/autoCombo/virtualFactory.ts
+++ b/open-sse/services/autoCombo/virtualFactory.ts
@@ -240,15 +240,18 @@ export async function createVirtualAutoCombo(
 
   const candidatePool: VirtualAutoComboCandidate[] = [];
   for (const conn of validConnections) {
+    // #5873: custom OpenAI-/Anthropic-compatible providers have dynamic connection
+    // IDs (`*-compatible-*`) that are never keys of the static registry. Do NOT drop
+    // them from `auto/` routing — only fall back to the registry's first model when
+    // the connection has no explicit defaultModel.
     const providerInfo = getProviderRegistry()[conn.provider];
-    if (!providerInfo) continue; // Skip unknown providers
 
     let modelId: string | undefined = conn.defaultModel;
-    if (!modelId) {
+    if (!modelId && providerInfo) {
       const firstModel = providerInfo.models[0];
       modelId = firstModel?.id;
     }
-    if (!modelId) continue; // Skip providers without a model
+    if (!modelId) continue; // Skip providers without a resolvable model
 
     // Skip models that the user has hidden in the dashboard
     const hiddenModels = hiddenModelsMap.get(conn.provider);

--- a/tests/unit/auto-custom-provider-5873.test.ts
+++ b/tests/unit/auto-custom-provider-5873.test.ts
@@ -1,0 +1,66 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// #5873 regression guard: custom OpenAI-/Anthropic-compatible providers have
+// dynamic connection IDs (`*-compatible-*`) that are never keys of the static
+// provider registry. The Auto-Combo virtual factory previously skipped any
+// connection whose provider was absent from the registry, silently excluding
+// every custom provider from `auto/` routing. It must now fall back to the
+// connection's defaultModel instead.
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-auto-custom-5873-"));
+const ORIGINAL_DATA_DIR = process.env.DATA_DIR;
+
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const providersDb = await import("../../src/lib/db/providers.ts");
+const virtualFactory = await import("../../open-sse/services/autoCombo/virtualFactory.ts");
+
+type VirtualComboResult = Awaited<ReturnType<typeof virtualFactory.createVirtualAutoCombo>>;
+
+async function resetStorage() {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+test.beforeEach(async () => {
+  await resetStorage();
+});
+
+test.after(async () => {
+  await resetStorage();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+
+  if (ORIGINAL_DATA_DIR === undefined) {
+    delete process.env.DATA_DIR;
+  } else {
+    process.env.DATA_DIR = ORIGINAL_DATA_DIR;
+  }
+});
+
+test("createVirtualAutoCombo includes custom openai-compatible providers via defaultModel (#5873)", async () => {
+  const customProvider = "openai-compatible-chat-02669115-2545-4896-b003-cb4dac09d441";
+  await providersDb.createProviderConnection({
+    provider: customProvider,
+    authType: "apikey",
+    name: "My Custom LLM",
+    apiKey: "sk-custom-key",
+    defaultModel: "my-custom-model",
+  });
+
+  const combo: VirtualComboResult = await virtualFactory.createVirtualAutoCombo("fast");
+
+  assert.equal(combo.strategy, "auto");
+  const candidate = combo.models.find((model) => model.providerId === customProvider);
+  assert.ok(
+    candidate,
+    "custom openai-compatible providers must not be excluded from auto/ routing"
+  );
+  assert.equal(candidate.model, `${customProvider}/my-custom-model`);
+  assert.ok(combo.autoConfig.candidatePool.includes(customProvider));
+});


### PR DESCRIPTION
Closes #5873

## Root cause
`open-sse/services/autoCombo/virtualFactory.ts` skipped any connection whose provider was absent from the static provider registry (`if (!providerInfo) continue`). Custom OpenAI-/Anthropic-compatible providers have dynamic connection IDs (`openai-compatible-chat-<uuid>`, `anthropic-compatible-<uuid>`, `anthropic-compatible-cc-<uuid>`) that are never keys of the static registry, so they were silently dropped from `auto/` routing.

## Fix
The registry lookup is now an optional fallback source for the model id instead of a gate: use `conn.defaultModel` when present, otherwise fall back to the registry's first model only when `providerInfo` exists. Custom providers with a `defaultModel` are now included.

## Validation (Hard Rule #18 — TDD)
`tests/unit/auto-custom-provider-5873.test.ts` — asserts a custom `openai-compatible-chat-<uuid>` connection appears in the candidate pool. Confirmed fail before the fix, pass after. Existing `virtual-auto-combo.test.ts` (10) stays green.