### PR TITLE
fix(providers): restore codex auto-routing for unprefixed gpt-5.5 (#5887)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 
 ### 🔧 Bug Fixes
 
+- **providers (codex image auto-routing regression):** an unprefixed `gpt-5.5` request from a codex-only setup (no OpenAI connection) now correctly infers the `codex` provider again — the OpenAI static-catalog short-circuit in `resolveModelByProviderInference` was preempting the codex-preference block, so `gpt-5.5` (added to the OpenAI catalog) stopped auto-routing to Codex image generation. Users with an active OpenAI connection are unaffected (OpenAI stays default). Regression guard: `tests/unit/codex-gpt55-routing-5887.test.ts`. ([#5887](https://github.com/diegosouzapw/OmniRoute/issues/5887))
 - **api (proxy header hygiene):** upstream `x-middleware-*` control headers (emitted by providers hosted behind Next.js, e.g. synthetic.new) are now stripped from proxied responses instead of forwarded verbatim — forwarding `x-middleware-rewrite` made Next 16 throw `NextResponse.rewrite() was used in a app route handler` and return 500 despite a successful upstream call. Applies to both streaming and JSON paths. Regression guard: `tests/unit/middleware-header-strip-5849.test.ts`. ([#5849](https://github.com/diegosouzapw/OmniRoute/issues/5849))
 
 - **docs (pnpm global install):** replaced the unsupported `pnpm approve-builds -g` step with the install-time `pnpm add -g omniroute@latest --allow-build=better-sqlite3` flag across README + Setup Guide (and i18n mirrors), fixing native-build approval for pnpm v11 global installs. ([#5554](https://github.com/diegosouzapw/OmniRoute/issues/5554))

--- a/open-sse/services/model.ts
+++ b/open-sse/services/model.ts
@@ -127,7 +127,13 @@ const CODEX_PREFERRED_UNPREFIXED_MODELS = new Set([
   "gpt-5.5-medium",
   "gpt-5.5-low",
 ]);
-const CODEX_PREFERRED_UNPREFIXED_MODEL_ALIASES = new Map([["gpt-5.5", "gpt-5.5-medium"]]);
+// Intentionally empty: an unprefixed codex-preferred model keeps its BARE id when
+// inferred to codex. #2877 established that baking a `-medium` effort suffix silently
+// overrides a client `reasoning.effort` (the Codex executor reads the suffix as an
+// explicit modelEffort). This map was dormant while bare `gpt-5.5` hit the OpenAI
+// short-circuit; #5887 makes the codex block reachable for bare `gpt-5.5`, so the
+// `gpt-5.5 → gpt-5.5-medium` entry is removed to preserve #2877's bare-id contract.
+const CODEX_PREFERRED_UNPREFIXED_MODEL_ALIASES = new Map<string, string>([]);
 export const CODEX_NATIVE_UNPREFIXED_MODELS = new Set(["codex-auto-review"]);
 
 interface ProviderConnectionLike {
@@ -511,17 +517,11 @@ async function resolveModelByProviderInference(modelId: string, extendedContext:
     getPreferClaudeCodeForUnprefixedClaudeModels(),
   ]);
 
-  // Preserve historical behavior: OpenAI stays default when model exists there.
-  // Connection availability must not make unprefixed OpenAI models resolve to a
-  // different provider; callers can still force Codex with an explicit prefix.
-  if (providers.includes("openai")) {
-    return {
-      provider: "openai",
-      model: modelId,
-      extendedContext,
-    };
-  }
-
+  // Codex-only setups must keep auto-routing codex-preferred unprefixed models
+  // (e.g. `gpt-5.5`) to codex even after those ids were added to the OpenAI
+  // static catalog (#5887). This block is guarded by `!activeProviders.has("openai")`,
+  // so it must run BEFORE the OpenAI short-circuit below; users WITH an active
+  // OpenAI connection still fall through to the OpenAI default.
   if (
     activeProviders?.has("codex") &&
     !activeProviders.has("openai") &&
@@ -531,6 +531,17 @@ async function resolveModelByProviderInference(modelId: string, extendedContext:
     return {
       provider: "codex",
       model: resolveInferredProviderModel("codex", modelId),
+      extendedContext,
+    };
+  }
+
+  // Preserve historical behavior: OpenAI stays default when model exists there.
+  // Connection availability must not make unprefixed OpenAI models resolve to a
+  // different provider; callers can still force Codex with an explicit prefix.
+  if (providers.includes("openai")) {
+    return {
+      provider: "openai",
+      model: modelId,
       extendedContext,
     };
   }

--- a/tests/unit/codex-gpt55-routing-5887.test.ts
+++ b/tests/unit/codex-gpt55-routing-5887.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Issue #5887 — regression: an unprefixed `gpt-5.5` request from a codex-only
+ * setup (no OpenAI connection) stopped auto-routing to the `codex` provider.
+ *
+ * Root cause: `gpt-5.5` was added to the OpenAI static catalog
+ * (`open-sse/config/providers/registry/openai/index.ts`), so the
+ * `if (providers.includes("openai"))` short-circuit in
+ * `resolveModelByProviderInference` (open-sse/services/model.ts) started
+ * firing BEFORE the codex-preference block — making that block unreachable for
+ * `gpt-5.5`. Result: a codex-only user (no OpenAI connection) had `gpt-5.5`
+ * routed to `openai`, and Codex-only hosted image generation failed.
+ *
+ * Fix: move the codex-preference block ahead of the OpenAI short-circuit. It is
+ * guarded by `!activeProviders.has("openai")`, so users WITH an active OpenAI
+ * connection keep OpenAI as the default (behavior preserved).
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-gpt55-5887-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const providersDb = await import("../../src/lib/db/providers.ts");
+const { getModelInfoCore } = await import("../../open-sse/services/model.ts");
+
+let openaiConnectionId: number | string | undefined;
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+// (a) Codex active, OpenAI NOT active → bare gpt-5.5 must infer codex.
+//     FAILS before the fix (OpenAI static-catalog short-circuit wins).
+test("#5887(a) codex-only setup infers codex for unprefixed gpt-5.5", async () => {
+  await providersDb.createProviderConnection({
+    provider: "codex",
+    authType: "oauth",
+    email: "codex@example.com",
+    providerSpecificData: { workspaceId: "ws-1" },
+  });
+
+  const info = await getModelInfoCore("gpt-5.5", null);
+  assert.equal(info.provider, "codex", "gpt-5.5 must infer codex when only codex is active");
+  // #2877: the bare id must be preserved — no `-medium` effort suffix baked in.
+  assert.equal(info.model, "gpt-5.5", "codex inference keeps the bare gpt-5.5 id");
+});
+
+// (b) OpenAI active → OpenAI stays the default for gpt-5.5 (behavior preserved).
+test("#5887(b) active OpenAI connection keeps gpt-5.5 on openai", async () => {
+  const conn = await providersDb.createProviderConnection({
+    provider: "openai",
+    authType: "apikey",
+    apiKey: "sk-test",
+  });
+  openaiConnectionId = (conn as { id?: number | string })?.id;
+
+  const info = await getModelInfoCore("gpt-5.5", null);
+  assert.equal(info.provider, "openai", "OpenAI stays default when openai is active");
+  assert.equal(info.model, "gpt-5.5");
+});
+
+// (c) Non-regression: a normal OpenAI model still routes to openai.
+test("#5887(c) gpt-4o routes to openai with openai active", async () => {
+  assert.ok(openaiConnectionId !== undefined, "openai connection created in (b)");
+  const info = await getModelInfoCore("gpt-4o", null);
+  assert.equal(info.provider, "openai");
+});


### PR DESCRIPTION
Closes #5887

## Root cause
In `open-sse/services/model.ts` `resolveModelByProviderInference()`, the OpenAI static-catalog short-circuit (`if (providers.includes("openai")) return { provider: "openai" }`) ran BEFORE the codex-preference block. Since `gpt-5.5` is now in the OpenAI static catalog, the codex block became unreachable for it — so a codex-only user (no OpenAI connection) had `gpt-5.5` routed to `openai` and Codex-only hosted image generation failed.

## Fix
Moved the codex-preference block ahead of the OpenAI short-circuit. It is guarded by `!activeProviders.has("openai")`, so users WITH an active OpenAI connection still fall through to the OpenAI default (behavior preserved).

Additionally emptied the dormant `CODEX_PREFERRED_UNPREFIXED_MODEL_ALIASES` (`gpt-5.5 → gpt-5.5-medium`) map: bare `gpt-5.5` never reached the codex block before this change, so the alias was never applied; now that the block is reachable, applying it would bake a `-medium` effort suffix and reintroduce #2877 (silently overriding a client `reasoning.effort`). Emptying it preserves #2877's bare-id contract and changes no pre-existing behavior.

## Validation (TDD — Hard Rule #18)
Regression guard `tests/unit/codex-gpt55-routing-5887.test.ts`:
- (a) codex active, OpenAI not active → `gpt-5.5` infers `codex` (bare id) — **fails before the fix**
- (b) OpenAI active → `gpt-5.5` stays `openai`
- (c) `gpt-4o` with OpenAI active → `openai`

All model/chat unit suites green (887 tests). Existing #2877 guard (`codex-gpt55-effort-routing.test.ts`) still passes. `typecheck:core` shows only the 2 pre-existing `open-sse/executors/base.ts` errors (present on `release/v3.8.43`). ESLint clean.