### PR TITLE
feat(agy): support Google Cloud project ID settings

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/[id]/components/modals/EditConnectionModal.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/modals/EditConnectionModal.tsx
@@ -165,7 +165,9 @@ export default function EditConnectionModal({
   const isCodex = provider === "codex";
   const isClaude = provider === "claude";
   const isAntigravity = provider === "antigravity";
-  const supportsGoogleProjectId = isAntigravity;
+  const isAgy = provider === "agy";
+  const isAntigravityFamily = isAntigravity || isAgy;
+  const supportsGoogleProjectId = isAntigravityFamily;
   const localProviderMetadata = getLocalProviderMetadata(provider);
   const isLocalSelfHostedProvider = !!localProviderMetadata;
   const isGooglePse = provider === "google-pse-search";
@@ -534,7 +536,7 @@ export default function EditConnectionModal({
           updates.providerSpecificData.projectId = trimmedCloudCodeProjectId || null;
         }
       }
-      if (isAntigravity) {
+      if (isAntigravityFamily) {
         updates.providerSpecificData = {
           ...(connection.providerSpecificData || {}),
           ...(updates.providerSpecificData || {}),
@@ -687,7 +689,7 @@ export default function EditConnectionModal({
         />
         {supportsGoogleProjectId && (
           <div className="flex flex-col gap-4 rounded-lg border border-border/50 bg-surface/20 p-4">
-            {isAntigravity && (
+            {isAntigravityFamily && (
               <Select
                 label={t("antigravityClientProfileLabel")}
                 value={formData.antigravityClientProfile}

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/modals/EditConnectionModal.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/modals/EditConnectionModal.tsx
@@ -164,10 +164,7 @@ export default function EditConnectionModal({
   const setOpenRouterPreset = openRouterPreset.setValue;
   const isCodex = provider === "codex";
   const isClaude = provider === "claude";
-  const isAntigravity = provider === "antigravity";
-  const isAgy = provider === "agy";
-  const isAntigravityFamily = isAntigravity || isAgy;
-  const supportsGoogleProjectId = isAntigravityFamily;
+  const isAntigravityFamily = provider === "antigravity" || provider === "agy";
   const localProviderMetadata = getLocalProviderMetadata(provider);
   const isLocalSelfHostedProvider = !!localProviderMetadata;
   const isGooglePse = provider === "google-pse-search";
@@ -433,7 +430,7 @@ export default function EditConnectionModal({
         overrides.maxConcurrent = Number(formData.rateLimitMaxConcurrent);
       updates.rateLimitOverrides = Object.keys(overrides).length > 0 ? overrides : null;
 
-      if (supportsGoogleProjectId) {
+      if (isAntigravityFamily) {
         updates.projectId = trimmedCloudCodeProjectId || null;
       }
 
@@ -507,7 +504,7 @@ export default function EditConnectionModal({
           defaultRegion,
           isGlm,
           isCloudflare,
-          supportsGoogleProjectId,
+          isAntigravityFamily,
           trimmedCloudCodeProjectId,
           isGooglePse,
           isCcCompatible,
@@ -532,7 +529,7 @@ export default function EditConnectionModal({
           updates.providerSpecificData.openaiStoreEnabled =
             formData.codexOpenaiStoreEnabled === true;
         }
-        if (supportsGoogleProjectId) {
+        if (isAntigravityFamily) {
           updates.providerSpecificData.projectId = trimmedCloudCodeProjectId || null;
         }
       }
@@ -687,22 +684,20 @@ export default function EditConnectionModal({
           t={t}
           editMode
         />
-        {supportsGoogleProjectId && (
+        {isAntigravityFamily && (
           <div className="flex flex-col gap-4 rounded-lg border border-border/50 bg-surface/20 p-4">
-            {isAntigravityFamily && (
-              <Select
-                label={t("antigravityClientProfileLabel")}
-                value={formData.antigravityClientProfile}
-                options={ANTIGRAVITY_CLIENT_PROFILE_OPTIONS.map((option) => ({
-                  value: option.value,
-                  label: t(option.labelKey),
-                }))}
-                onChange={(e) =>
-                  setFormData({ ...formData, antigravityClientProfile: e.target.value })
-                }
-                hint={t("antigravityClientProfileHint")}
-              />
-            )}
+            <Select
+              label={t("antigravityClientProfileLabel")}
+              value={formData.antigravityClientProfile}
+              options={ANTIGRAVITY_CLIENT_PROFILE_OPTIONS.map((option) => ({
+                value: option.value,
+                label: t(option.labelKey),
+              }))}
+              onChange={(e) =>
+                setFormData({ ...formData, antigravityClientProfile: e.target.value })
+              }
+              hint={t("antigravityClientProfileHint")}
+            />
             <Input
               label={t("antigravityProjectIdLabel")}
               value={formData.cloudCodeProjectId}

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/modals/connectionProviderSpecificData.ts
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/modals/connectionProviderSpecificData.ts
@@ -89,7 +89,7 @@ export function assignEditApiKeyProviderSpecificData(options: {
   defaultRegion: string;
   isGlm: boolean;
   isCloudflare: boolean;
-  supportsGoogleProjectId: boolean;
+  isAntigravityFamily: boolean;
   trimmedCloudCodeProjectId: string;
   isGooglePse: boolean;
   isCcCompatible: boolean;
@@ -116,7 +116,7 @@ export function assignEditApiKeyProviderSpecificData(options: {
   else if (o.isCloudflare && o.formData.accountId.trim()) {
     o.target.accountId = o.formData.accountId.trim();
   }
-  if (o.supportsGoogleProjectId) o.target.projectId = o.trimmedCloudCodeProjectId || null;
+  if (o.isAntigravityFamily) o.target.projectId = o.trimmedCloudCodeProjectId || null;
   if (o.isCcCompatible) {
     o.target.requestDefaults = mergeCcCompatibleRequestDefaults(
       o.target.requestDefaults,

--- a/tests/unit/agy-projectid-ui.test.ts
+++ b/tests/unit/agy-projectid-ui.test.ts
@@ -7,25 +7,17 @@ const modalPath =
 const source = readFileSync(modalPath, "utf8");
 
 describe("agy Project ID UI support", () => {
-  it("declares isAgy from provider", () => {
+  it("declares a single Antigravity-family provider gate", () => {
     assert.ok(
-      source.includes('const isAgy = provider === "agy"'),
-      "isAgy must be declared via provider === 'agy'"
+      source.includes(
+        'const isAntigravityFamily = provider === "antigravity" || provider === "agy";'
+      ),
+      "isAntigravityFamily must include antigravity and agy without a separate Google Project ID gate"
     );
   });
 
-  it("declares isAntigravityFamily = isAntigravity || isAgy", () => {
-    assert.ok(
-      source.includes("const isAntigravityFamily = isAntigravity || isAgy;"),
-      "isAntigravityFamily must combine antigravity and agy"
-    );
-  });
-
-  it("uses isAntigravityFamily as the Google Project ID gate", () => {
-    assert.ok(
-      /const supportsGoogleProjectId = isAntigravityFamily;/.test(source),
-      "supportsGoogleProjectId must be gated by isAntigravityFamily"
-    );
+  it("does not keep the old supportsGoogleProjectId alias", () => {
+    assert.equal(source.includes("supportsGoogleProjectId"), false);
   });
 
   it("uses antigravityProjectIdLabel for Antigravity-family providers", () => {
@@ -37,7 +29,8 @@ describe("agy Project ID UI support", () => {
 
   it("uses isAntigravityFamily for antigravityClientProfile UI", () => {
     assert.ok(
-      source.includes("{isAntigravityFamily && (\n              <Select"),
+      source.includes("{isAntigravityFamily && (\n          <div") &&
+        source.includes('label={t("antigravityClientProfileLabel")}'),
       "client profile Select must render for isAntigravityFamily"
     );
   });

--- a/tests/unit/agy-projectid-ui.test.ts
+++ b/tests/unit/agy-projectid-ui.test.ts
@@ -1,0 +1,51 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { readFileSync } from "node:fs";
+
+const modalPath =
+  "src/app/(dashboard)/dashboard/providers/[id]/components/modals/EditConnectionModal.tsx";
+const source = readFileSync(modalPath, "utf8");
+
+describe("agy Project ID UI support", () => {
+  it("declares isAgy from provider", () => {
+    assert.ok(
+      source.includes('const isAgy = provider === "agy"'),
+      "isAgy must be declared via provider === 'agy'"
+    );
+  });
+
+  it("declares isAntigravityFamily = isAntigravity || isAgy", () => {
+    assert.ok(
+      source.includes("const isAntigravityFamily = isAntigravity || isAgy;"),
+      "isAntigravityFamily must combine antigravity and agy"
+    );
+  });
+
+  it("uses isAntigravityFamily as the Google Project ID gate", () => {
+    assert.ok(
+      /const supportsGoogleProjectId = isAntigravityFamily;/.test(source),
+      "supportsGoogleProjectId must be gated by isAntigravityFamily"
+    );
+  });
+
+  it("uses antigravityProjectIdLabel for Antigravity-family providers", () => {
+    assert.ok(
+      source.includes('label={t("antigravityProjectIdLabel")}'),
+      "projectId label must use Antigravity-family copy"
+    );
+  });
+
+  it("uses isAntigravityFamily for antigravityClientProfile UI", () => {
+    assert.ok(
+      source.includes("{isAntigravityFamily && (\n              <Select"),
+      "client profile Select must render for isAntigravityFamily"
+    );
+  });
+
+  it("uses isAntigravityFamily for client profile save", () => {
+    assert.ok(
+      source.includes("if (isAntigravityFamily) {"),
+      "client profile save must use isAntigravityFamily"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds Google Cloud Project ID settings support for the standalone `agy` provider.

`agy` already uses the Antigravity execution path:

- provider format: `antigravity`
- executor: `AntigravityExecutor`
- existing executor-side Project ID resolution already reads `projectId` / `providerSpecificData.projectId`

This PR keeps the current standalone `agy` provider behavior consistent with the Antigravity settings UI by treating `agy` and `antigravity` as one Antigravity-family group for Project ID and client profile settings.

## Changes

- Adds an Antigravity-family provider gate:

  ```ts
  provider === "antigravity" || provider === "agy"
  ```

- Shows the existing Antigravity Project ID field for `agy`.
- Persists Project ID for `agy` to:
  - top-level `projectId`
  - `providerSpecificData.projectId`
- Persists the existing Antigravity `clientProfile` setting for `agy`.
- Removes the redundant `supportsGoogleProjectId` alias now that `gemini-cli` is gone and the remaining Google Cloud Code settings path is Antigravity-family only.
- Adds a regression test covering the `agy` Project ID UI gate.

## Context

Antigravity Project ID support was originally added in #2227. Since `agy` is currently a standalone provider that uses the Antigravity executor path, it should expose the same Project ID/client profile settings needed by that executor.

This PR does not change provider registration, routing, OAuth, account import, or model catalogs. It only makes the existing `agy` settings UI consistent with the executor behavior.

## Tests

Ran:

```bash
node --test tests/unit/agy-projectid-ui.test.ts
```

```bash
npx eslint --no-error-on-unmatched-pattern \
  'src/app/(dashboard)/dashboard/providers/[id]/components/modals/EditConnectionModal.tsx' \
  'src/app/(dashboard)/dashboard/providers/[id]/components/modals/connectionProviderSpecificData.ts' \
  'tests/unit/agy-projectid-ui.test.ts'
```

```bash
npm run typecheck:core
```

Also passed local git hooks during commit/push:

- docs sync
- `check:any-budget:t11`
- `check:tracked-artifacts`

Not run locally:

- `npm test`
- `npm run test:coverage`
- `npm run build`

## Pull Request Checklist

- [x] Focused regression test added/updated
- [x] Linting passes for changed files
- [x] Typecheck passes for core project
- [x] No hardcoded secrets or fallback credentials
- [x] No new public upstream credentials
- [x] No shell command changes
- [x] No API error response changes
- [x] No route guard changes
- [ ] Full `npm test` not run locally
- [ ] Full `npm run test:coverage` not run locally
- [ ] Full `npm run build` not run locally
- [ ] CHANGELOG not updated; small dashboard consistency fix
- [ ] Documentation not updated; no user-facing workflow change beyond exposing the existing setting for `agy`
