### PR TITLE
fix(install): pnpm 11 ERR_PNPM_IGNORED_BUILDS — add allowBuilds to pnpm-workspace.yaml

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,31 @@
+packages:
+  - "open-sse"
+allowBuilds:
+  "@parcel/watcher": true
+  "@swc/core": true
+  better-sqlite3: true
+  core-js: true
+  esbuild: true
+  keytar: true
+  koffi: true
+  libxmljs2: true
+  onnxruntime-node: true
+  protobufjs: true
+  sharp: true
+  tls-client-node: true
+  unrs-resolver: true
+onlyBuiltDependencies:
+  - "@parcel/watcher"
+  - "@swc/core"
+  - "better-sqlite3"
+  - "core-js"
+  - "esbuild"
+  - "keytar"
+  - "koffi"
+  - "libxmljs2"
+  - "onnxruntime-node"
+  - "omniroute"
+  - "protobufjs"
+  - "sharp"
+  - "tls-client-node"
+  - "unrs-resolver"

--- a/pnpm.json
+++ b/pnpm.json
@@ -1,0 +1,18 @@
+{
+  "onlyBuiltDependencies": [
+    "@parcel/watcher",
+    "@swc/core",
+    "better-sqlite3",
+    "core-js",
+    "esbuild",
+    "keytar",
+    "koffi",
+    "libxmljs2",
+    "omniroute",
+    "onnxruntime-node",
+    "protobufjs",
+    "sharp",
+    "tls-client-node",
+    "unrs-resolver"
+  ]
+}


### PR DESCRIPTION
## Problem

pnpm 11 introduced strict native-addon build approval. On a fresh clone with pnpm ≥11, `pnpm install` exits with:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: @parcel/watcher, @swc/core, better-sqlite3, ...
```

All native modules skip their build scripts. OmniRoute fails to start with missing bindings (keytar, koffi, onnxruntime-node, sharp, etc.).

## Fix

Two files:
- **pnpm-workspace.yaml** — add `allowBuilds: true` for all 13 affected native packages.
- **pnpm.json** — migrate `onlyBuiltDependencies` from package.json (pnpm 11 no longer reads the `pnpm` key there) per [pnpm settings docs](https://pnpm.io/settings).

## Tested

pnpm 11.9.0, Node 24, Windows 11. Fresh clone installs cleanly in 24s.

Thanks for the great work on OmniRoute!