### PR TITLE
fix(registry): update grok-cli model context lengths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@
 
 - fix(providers): GitLab Duo executor now emulates OpenAI tool_calls (#6051)
 
+- **grok-cli (context-aware routing filtered out larger requests):** the `grok-cli` registry declared a 128k `contextLength` for `grok-build` and `grok-composer-2.5-fast`, below their real Grok CLI capacities, so OmniRoute's context-aware routing dropped these models for larger prompts. Updated to match the actual `/context` values — `grok-build` → 256000 (xAI-published 256k window) and `grok-composer-2.5-fast` → 200000. Registry-only; no runtime logic change. ([#5913](https://github.com/diegosouzapw/OmniRoute/pull/5913) — thanks @Chewji9875)
+
 ### 📝 Maintenance
 
 - **ci (env-doc base-red):** document `BIFROST_PORT` in `.env.example` + `docs/reference/ENVIRONMENT.md`. The Bifrost embedded-service merge referenced `process.env.BIFROST_PORT` (`src/lib/services/bootstrap.ts`, default `8080`) without documenting it, so `check:env-doc-sync` failed on the release tip — reddening the `Fast Quality Gates` job for **every** open PR→release regardless of its content. Docs-only; no runtime change.

--- a/open-sse/config/providers/registry/grok-cli/index.ts
+++ b/open-sse/config/providers/registry/grok-cli/index.ts
@@ -14,13 +14,13 @@ export const grok_cliProvider: RegistryEntry = {
     {
       id: "grok-build",
       name: "Grok Build",
-      contextLength: 128000,
+      contextLength: 256000,
       unsupportedParams: ["presencePenalty", "frequencyPenalty", "logprobs", "topLogprobs"],
     },
     {
       id: "grok-composer-2.5-fast",
       name: "Grok Composer 2.5 Fast",
-      contextLength: 128000,
+      contextLength: 200000,
       unsupportedParams: ["presencePenalty", "frequencyPenalty", "logprobs", "topLogprobs"],
     },
   ],


### PR DESCRIPTION
This pull request increases the maximum context length for two Grok CLI provider models in the `grok_cliProvider` registry entry. These changes allow the models to handle larger input contexts.

Model configuration updates:

* Increased the `contextLength` for the `grok-build` model from 128,000 to 256,000 tokens in `open-sse/config/providers/registry/grok-cli/index.ts`.
* Increased the `contextLength` for the `grok-composer-2.5-fast` model from 128,000 to 200,000 tokens in `open-sse/config/providers/registry/grok-cli/index.ts`.Update grok-cli registry context lengths to match the actual Grok CLI /context values:\n\n- grok-build: 128000 → 256000\n- grok-composer-2.5-fast: 128000 → 200000\n\n## Why\nOmniRoute's context-aware routing was filtering out grok-build for larger requests because the registry value was too low.\n\n## Notes\n- No runtime logic changes; this is a registry-only fix.\n- Based on .