### PR TITLE
test(security): fix CodeQL #689 — Kimi Web URL host substring sanitization

### DIFF
--- a/tests/unit/web-cookie-providers-new.test.ts
+++ b/tests/unit/web-cookie-providers-new.test.ts
@@ -679,8 +679,13 @@ test("Kimi Web: targets www.kimi.com (international)", async () => {
       credentials: { apiKey: "kimi-auth=eyJ.eyJzdWI.signature" },
     });
     assert.ok(result.response instanceof Response);
-    assert.ok(result.url.includes("www.kimi.com"), `got ${result.url}`);
-    assert.ok(!result.url.includes("moonshot.cn"));
+    // Parse the URL and assert on the exact hostname rather than a substring
+    // match — `includes("www.kimi.com")` would also accept a hostile host like
+    // `www.kimi.com.evil.net` or `evil.net/?x=www.kimi.com` (CodeQL
+    // js/incomplete-url-substring-sanitization).
+    const host = new URL(result.url).hostname;
+    assert.equal(host, "www.kimi.com", `got ${result.url}`);
+    assert.notEqual(host, "www.moonshot.cn", `got ${result.url}`);
   } finally {
     restore.restore();
   }


### PR DESCRIPTION
## Alerta
Resolve o code-scanning alert [#689](https://github.com/diegosouzapw/OmniRoute/security/code-scanning/689) — `js/incomplete-url-substring-sanitization` (severity: high), em `tests/unit/web-cookie-providers-new.test.ts:682`.

## Causa
A asserção do teste do executor Kimi Web usava:
```ts
assert.ok(result.url.includes("www.kimi.com"), ...)
```
Um substring match numa URL não parseada é bypassável — hosts hostis como `www.kimi.com.evil.net` ou `evil.net/?x=www.kimi.com` também satisfariam o `includes`.

## Correção
Parseia a URL e compara o **hostname exato**:
```ts
const host = new URL(result.url).hostname;
assert.equal(host, "www.kimi.com", ...);
assert.notEqual(host, "www.moonshot.cn", ...);
```
É uma asserção **mais forte** (não só remove o warning do CodeQL) e mantém a intenção original do teste (domínio internacional, não o `moonshot.cn`).

## Validação
`node --import tsx/esm --test tests/unit/web-cookie-providers-new.test.ts` → **38/38 pass**. Sem enfraquecimento de asserts (2 asserts → 3 mais estritos).