### PR TITLE
fix(providers): openai-family inference no longer hijacks cataloged gpt-oss-* models (#5852)

### DIFF
--- a/open-sse/services/model.ts
+++ b/open-sse/services/model.ts
@@ -546,8 +546,15 @@ async function resolveModelByProviderInference(modelId: string, extendedContext:
     };
   }
 
-  // Fallback for newly released OpenAI-family model IDs that may not be in the local catalog yet.
-  if (/^gpt-/i.test(modelId) || /^o1/i.test(modelId) || /^o3/i.test(modelId)) {
+  // Fallback for newly released OpenAI-family model IDs that may not be in the local
+  // catalog yet. This must only fire when NO known provider catalogs the model id —
+  // otherwise it hijacks cataloged open-weight models like "gpt-oss-120b" (served by
+  // fireworks/cerebras/scaleway/byteplus) into provider "openai", which does not carry
+  // them (#5852).
+  if (
+    providers.length === 0 &&
+    (/^gpt-/i.test(modelId) || /^o1/i.test(modelId) || /^o3/i.test(modelId))
+  ) {
     return {
       provider: "openai",
       model: modelId,

--- a/tests/unit/gptoss-provider-inference-5852.test.ts
+++ b/tests/unit/gptoss-provider-inference-5852.test.ts
@@ -1,0 +1,52 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { getModelInfoCore } from "../../open-sse/services/model.ts";
+
+// Bug #5852: resolveModelByProviderInference() in open-sse/services/model.ts had an
+// unconditional `/^gpt-/i` heuristic that fired for ANY model id starting with
+// "gpt-", hijacking open-weight models cataloged under other providers (e.g.
+// "gpt-oss-120b", served by fireworks/cerebras/scaleway/byteplus) into
+// provider "openai", which does not carry them — producing a 404 with no
+// fallback for bare (non-combo) requests.
+//
+// Fix: the fallback must only apply when there are ZERO known catalog
+// candidates for the model id (providers.length === 0).
+
+const KNOWN_GPT_OSS_120B_PROVIDERS = new Set(["fireworks", "cerebras", "scaleway", "byteplus"]);
+
+test("gpt-oss-120b resolves into its cataloged open-weight providers, not openai (#5852)", async () => {
+  const info = await getModelInfoCore("gpt-oss-120b", null);
+
+  assert.notEqual(
+    info.provider,
+    "openai",
+    "gpt-oss-120b must not be hijacked into the openai-family fallback"
+  );
+
+  // Multiple providers catalog this open-weight model id, so the resolver correctly
+  // reports it as ambiguous (asking the caller to disambiguate with a provider/model
+  // prefix) instead of silently defaulting to openai (which doesn't carry it → 404).
+  assert.equal(info.errorType, "ambiguous_model");
+  assert.ok(Array.isArray(info.candidateProviders) && info.candidateProviders.length > 0);
+  assert.ok(
+    info.candidateProviders.some((p: string) => KNOWN_GPT_OSS_120B_PROVIDERS.has(p)),
+    `expected at least one candidate from ${[...KNOWN_GPT_OSS_120B_PROVIDERS].join(
+      ", "
+    )}, got ${JSON.stringify(info.candidateProviders)}`
+  );
+  assert.ok(
+    !info.candidateProviders.includes("openai"),
+    "openai must not be listed as a candidate for gpt-oss-120b"
+  );
+});
+
+test("regression guard: a genuinely-uncataloged openai-family id still falls back to openai (#5852)", async () => {
+  const info = await getModelInfoCore("gpt-5.9-imaginary-unreleased", null);
+
+  assert.equal(
+    info.provider,
+    "openai",
+    "uncataloged gpt-* ids with zero known candidates must still fall back to openai"
+  );
+});


### PR DESCRIPTION
Closes #5852.

resolveModelByProviderInference() in open-sse/services/model.ts applied an unconditional openai-family fallback (/^gpt-/i, /^o1/i, /^o3/i) that hijacked cataloged open-weight models like gpt-oss-120b (served by fireworks/cerebras/scaleway/byteplus/sambanova/heroku) into provider "openai", which doesn't carry them — producing a 404 with no fallback for bare (non-combo) requests.

Fix: gate the fallback on `providers.length === 0` so it only fires when no cataloged provider serves the model id.

Test: tests/unit/gptoss-provider-inference-5852.test.ts (TDD — reproduced RED against unfixed code, GREEN after the fix). Also reran the full model-inference test suite (fireworks-model-id-prefix, model-combo-mappings, model-resolver, model-cross-proxy-compat, model-alias-provider-resolution, codex-gpt55-*, t28-model-catalog-updates, plan3-p0, services-branch-hardening) — 126/126 passing. typecheck:core and eslint on changed files both clean.