### PR TITLE
fix(resilience): per-window is_exhausted + quota preflight for priority combos (#5923)

### DIFF
--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -48,7 +48,6 @@ import { fetchCodexQuota } from "./codexQuotaFetcher.ts";
 import {
   evaluateQuotaCutoff,
   getQuotaFetcher,
-  type PreflightQuotaThresholds,
   type QuotaInfo,
 } from "./quotaPreflight.ts";
 import * as semaphore from "./rateLimitSemaphore.ts";
@@ -196,6 +195,10 @@ import {
   type PreScreenResult,
 } from "./combo/quotaStrategies.ts";
 import {
+  buildAutoQuotaThresholds,
+  resolveQuotaExhaustionCutoffForTarget,
+} from "./combo/quotaExhaustionCutoff.ts";
+import {
   classifyTask,
   getConversationCacheKey,
   isTaskRoutingStrategy,
@@ -255,55 +258,6 @@ function getBootstrapLatencyMs(modelId: string): number {
 function clampPercent(value: number): number {
   if (!Number.isFinite(value)) return 100;
   return Math.max(0, Math.min(100, value));
-}
-
-function asThresholdMap(value: unknown): Record<string, number> {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
-  const result: Record<string, number> = {};
-  for (const [key, raw] of Object.entries(value as Record<string, unknown>)) {
-    const numeric = Number(raw);
-    if (key && Number.isFinite(numeric)) result[key] = numeric;
-  }
-  return result;
-}
-
-function quotaWindowLookupNames(provider: string, windowName: string): string[] {
-  const names = [windowName];
-  const lower = windowName.toLowerCase();
-  if (lower !== windowName) names.push(lower);
-  if (provider === "codex") {
-    if (lower.includes("session") || lower === "5h" || lower === "five_hour") names.push("session");
-    if (lower.includes("weekly") || lower === "7d" || lower === "seven_day") names.push("weekly");
-    if (lower.includes("monthly") || lower === "30d") names.push("monthly");
-  }
-  return [...new Set(names)];
-}
-
-function buildAutoQuotaThresholds(
-  provider: string,
-  connection: Record<string, unknown> | undefined,
-  resilienceSettings: ResilienceSettings | null | undefined
-): PreflightQuotaThresholds {
-  const quotaPreflight = (resilienceSettings ?? resolveResilienceSettings(null))?.quotaPreflight;
-  const defaultThresholdPercent = quotaPreflight?.defaultThresholdPercent ?? 2;
-  const warnThresholdPercent = quotaPreflight?.warnThresholdPercent ?? 20;
-  const providerWindowMap = asThresholdMap(quotaPreflight?.providerWindowDefaults?.[provider]);
-  const perConnectionWindowOverrides = asThresholdMap(connection?.quotaWindowThresholds);
-
-  return {
-    resolveMinRemainingPercent: (windowName: string | null): number => {
-      if (windowName !== null) {
-        for (const lookupWindowName of quotaWindowLookupNames(provider, windowName)) {
-          const override = perConnectionWindowOverrides[lookupWindowName];
-          if (typeof override === "number") return override;
-          const providerDefault = providerWindowMap[lookupWindowName];
-          if (typeof providerDefault === "number") return providerDefault;
-        }
-      }
-      return defaultThresholdPercent;
-    },
-    resolveWarnRemainingPercent: () => warnThresholdPercent,
-  };
 }
 
 function quotaRemainingPercentFromQuota(quota: unknown): number {
@@ -1638,6 +1592,12 @@ export async function handleComboChat({
         )
       : new Map<string, PreScreenResult>();
 
+  // #5923 (Finding #4) — reset-window config for the shared per-target quota-
+  // exhaustion cutoff below. The "auto" strategy already applies its own cutoff
+  // via buildAutoCandidates/routableCandidates, so this only affects the other
+  // 16 strategies (priority, weighted, etc.) that funnel through executeTarget.
+  const quotaCutoffResetWindowConfig = resolveResetWindowConfig(config as Record<string, unknown>);
+
   if (orderedTargets.length === 0) {
     return comboModelNotFoundResponse("Combo has no executable targets");
   }
@@ -1788,6 +1748,33 @@ export async function handleComboChat({
           log.info("COMBO", `Skipping ${modelStr} — model locked by resilience (cooldown active)`);
           if (i > 0) fallbackCount++;
           return null;
+        }
+
+        // #5923 (Finding #4) — honor the same opt-in quota-exhaustion cutoff the
+        // "auto" strategy already applies (buildAutoCandidates), for every other
+        // strategy (priority, weighted, etc.). Strictly scoped per (provider,
+        // connectionId): a 0%-remaining connection is skipped here, but sibling
+        // connections/models on the same provider are untouched — the provider
+        // circuit breaker is never touched by this check. The "auto" strategy is
+        // excluded to avoid a redundant duplicate fetch — it already filtered its
+        // candidate pool via `routableCandidates` before reaching this loop.
+        if (strategy !== "auto" && provider && target.connectionId) {
+          const quotaCutoff = await resolveQuotaExhaustionCutoffForTarget(
+            provider,
+            target.connectionId,
+            resilienceSettings,
+            quotaCutoffResetWindowConfig,
+            combo.name,
+            log
+          );
+          if (quotaCutoff.blocked) {
+            log.info(
+              "COMBO",
+              `Skipping ${modelStr} — quota exhaustion cutoff (${quotaCutoff.reason || "quota_exhausted"})`
+            );
+            if (i > 0) fallbackCount++;
+            return null;
+          }
         }
 
         // Pre-screen snapshot is NOT used as a permanent skip — availability

--- a/open-sse/services/combo/quotaExhaustionCutoff.ts
+++ b/open-sse/services/combo/quotaExhaustionCutoff.ts
@@ -1,0 +1,140 @@
+/**
+ * Quota-exhaustion cutoff helpers for combo routing.
+ *
+ * Home of the opt-in per-(provider, connection, window) quota-exhaustion cutoff
+ * shared by the "auto" strategy candidate builder (`buildAutoQuotaThresholds`,
+ * consumed by combo.ts::buildAutoCandidates) and the per-target eligibility loop
+ * (`resolveQuotaExhaustionCutoffForTarget`, consumed by combo.ts::handleComboChat
+ * for every non-auto strategy). Extracted from combo.ts (#5923 Finding #4) to
+ * keep the god-file under its frozen size cap; behavior is byte-identical.
+ *
+ * Pure leaf: this module never imports from the combo barrel. Threshold math and
+ * cutoff evaluation are delegated to ./quotaPreflight.ts; the reset-aware quota
+ * fetch/cache is delegated to ./quotaStrategies.ts.
+ */
+
+import {
+  evaluateQuotaCutoff,
+  getQuotaFetcher,
+  type PreflightQuotaThresholds,
+  type QuotaInfo,
+} from "../quotaPreflight.ts";
+import { getProviderConnectionById } from "../../../src/lib/db/providers";
+import {
+  resolveResilienceSettings,
+  type ResilienceSettings,
+} from "../../../src/lib/resilience/settings";
+import { fetchResetAwareQuotaWithCache } from "./quotaStrategies.ts";
+import type { ResetWindowConfig } from "./quotaScoring.ts";
+
+function asThresholdMap(value: unknown): Record<string, number> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  const result: Record<string, number> = {};
+  for (const [key, raw] of Object.entries(value as Record<string, unknown>)) {
+    const numeric = Number(raw);
+    if (key && Number.isFinite(numeric)) result[key] = numeric;
+  }
+  return result;
+}
+
+function quotaWindowLookupNames(provider: string, windowName: string): string[] {
+  const names = [windowName];
+  const lower = windowName.toLowerCase();
+  if (lower !== windowName) names.push(lower);
+  if (provider === "codex") {
+    if (lower.includes("session") || lower === "5h" || lower === "five_hour") names.push("session");
+    if (lower.includes("weekly") || lower === "7d" || lower === "seven_day") names.push("weekly");
+    if (lower.includes("monthly") || lower === "30d") names.push("monthly");
+  }
+  return [...new Set(names)];
+}
+
+export function buildAutoQuotaThresholds(
+  provider: string,
+  connection: Record<string, unknown> | undefined,
+  resilienceSettings: ResilienceSettings | null | undefined
+): PreflightQuotaThresholds {
+  const quotaPreflight = (resilienceSettings ?? resolveResilienceSettings(null))?.quotaPreflight;
+  const defaultThresholdPercent = quotaPreflight?.defaultThresholdPercent ?? 2;
+  const warnThresholdPercent = quotaPreflight?.warnThresholdPercent ?? 20;
+  const providerWindowMap = asThresholdMap(quotaPreflight?.providerWindowDefaults?.[provider]);
+  const perConnectionWindowOverrides = asThresholdMap(connection?.quotaWindowThresholds);
+
+  return {
+    resolveMinRemainingPercent: (windowName: string | null): number => {
+      if (windowName !== null) {
+        for (const lookupWindowName of quotaWindowLookupNames(provider, windowName)) {
+          const override = perConnectionWindowOverrides[lookupWindowName];
+          if (typeof override === "number") return override;
+          const providerDefault = providerWindowMap[lookupWindowName];
+          if (typeof providerDefault === "number") return providerDefault;
+        }
+      }
+      return defaultThresholdPercent;
+    },
+    resolveWarnRemainingPercent: () => warnThresholdPercent,
+  };
+}
+
+/**
+ * #5923 (Finding #4) — Shared quota-exhaustion cutoff predicate, scoped strictly
+ * per (provider, connectionId, model window). Extracted from the inline logic
+ * that `buildAutoCandidates` has always used (fetch via the SAME
+ * `fetchResetAwareQuotaWithCache` cache, evaluate via the SAME pure
+ * `evaluateQuotaCutoff` + `buildAutoQuotaThresholds`), so priority/weighted/etc.
+ * strategies honor the operator's configured quota cutoff instead of only the
+ * "auto" strategy.
+ *
+ * Gated behind the SAME opt-in setting as the auto-strategy cutoff
+ * (`resilienceSettings.quotaPreflight.enabled`) — when that setting is off this
+ * is a no-op, exactly like the auto path. Never touches the provider circuit
+ * breaker; a blocked result only means "skip this one connection", leaving
+ * every sibling connection/model for the same provider fully eligible.
+ */
+export async function resolveQuotaExhaustionCutoffForTarget(
+  provider: string,
+  connectionId: string | undefined,
+  resilienceSettings: ResilienceSettings | null | undefined,
+  resetWindowConfig: ResetWindowConfig,
+  comboName: string,
+  log: { debug?: (...args: unknown[]) => void; warn?: (...args: unknown[]) => void }
+): Promise<{ blocked: boolean; reason?: string }> {
+  const quotaCutoffEnabled =
+    (resilienceSettings ?? resolveResilienceSettings(null))?.quotaPreflight?.enabled === true;
+  if (!quotaCutoffEnabled || !provider || !connectionId) return { blocked: false };
+
+  const fetcher = getQuotaFetcher(provider);
+  if (!fetcher) return { blocked: false };
+
+  let connection: Record<string, unknown> | undefined;
+  try {
+    connection = (await getProviderConnectionById(connectionId)) as
+      | Record<string, unknown>
+      | undefined;
+  } catch {
+    connection = undefined;
+  }
+
+  try {
+    const quota = await fetchResetAwareQuotaWithCache({
+      provider,
+      connectionId,
+      connection,
+      fetcher,
+      config: resetWindowConfig,
+      log,
+      comboName,
+    });
+    const cutoffDecision = evaluateQuotaCutoff(
+      quota as QuotaInfo | null,
+      buildAutoQuotaThresholds(provider, connection, resilienceSettings)
+    );
+    if (!cutoffDecision.proceed) {
+      return { blocked: true, reason: cutoffDecision.reason || "quota_exhausted" };
+    }
+  } catch {
+    // Fail-open: never block routing because the preflight fetch itself errored.
+    return { blocked: false };
+  }
+  return { blocked: false };
+}

--- a/src/domain/quotaCache.ts
+++ b/src/domain/quotaCache.ts
@@ -250,15 +250,20 @@ export function setQuotaCache(
             }
           : null,
       });
+      // #5923 (Finding #5) — is_exhausted must reflect THIS window's own remaining
+      // percentage, not the connection-wide AND-across-all-windows aggregate
+      // (`entry.exhausted`). A connection with one 0% window and other non-zero
+      // windows previously never flagged that window's row as exhausted.
+      const windowExhausted = remainingPercentage <= 0;
       // #4438 — only persist on the first observation or a real change.
-      if (!quotaSnapshotChanged(prior, windowKey, remainingPercentage, entry.exhausted)) continue;
+      if (!quotaSnapshotChanged(prior, windowKey, remainingPercentage, windowExhausted)) continue;
       try {
         saveQuotaSnapshot({
           provider,
           connection_id: connectionId,
           window_key: windowKey,
           remaining_percentage: remainingPercentage,
-          is_exhausted: entry.exhausted ? 1 : 0,
+          is_exhausted: windowExhausted ? 1 : 0,
           next_reset_at: quotaInfo.resetAt ?? null,
           window_duration_ms: entry.windowDurationMs ?? null,
           raw_data: null,

--- a/tests/unit/combo-priority-quota-exhaustion-cutoff-5923.test.ts
+++ b/tests/unit/combo-priority-quota-exhaustion-cutoff-5923.test.ts
@@ -1,0 +1,183 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+/**
+ * #5923 (Finding #4) — the quota-exhaustion preflight cutoff only ran for
+ * strategy === "auto" (buildAutoCandidates / routableCandidates in combo.ts).
+ * Priority/weighted/etc. strategies funneled through the shared executeTarget
+ * per-target loop, which only checked the provider circuit breaker + model
+ * lockout — never a per-(provider, connection) quota-exhaustion cutoff. A 0%-
+ * remaining connection stayed eligible as the lead leg until it reactively
+ * 429'd.
+ *
+ * Regression guard: with the quota-exhaustion opt-in enabled
+ * (`resilienceSettings.quotaPreflight.enabled = true`), a "priority" combo
+ * whose first-listed connection is at 0% remaining must skip straight to the
+ * sibling connection of the SAME provider — never dispatching to the
+ * exhausted connection. This must stay strictly per-connection: it must NOT
+ * touch the provider circuit breaker (both connections belong to the same
+ * provider, and the healthy one must remain fully eligible).
+ */
+const TEST_DATA_DIR = fs.mkdtempSync(
+  path.join(os.tmpdir(), "omniroute-quota-cutoff-priority-5923-")
+);
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const dbCore = await import("../../src/lib/db/core.ts");
+const { handleComboChat } = await import("../../open-sse/services/combo.ts");
+const { registerQuotaFetcher } = await import("../../open-sse/services/quotaPreflight.ts");
+const { getCircuitBreaker } = await import("../../src/shared/utils/circuitBreaker.ts");
+
+test.after(() => {
+  dbCore.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+function makeLog() {
+  return {
+    info() {},
+    warn() {},
+    debug() {},
+    error() {},
+  };
+}
+
+function okResponse(model: string) {
+  return Response.json({ choices: [{ message: { role: "assistant", content: model } }] });
+}
+
+const PROVIDER = "openai";
+const EXHAUSTED_CONNECTION_ID = "conn-exhausted-5923";
+const HEALTHY_CONNECTION_ID = "conn-healthy-5923";
+
+test("#5923 priority combo skips a 0%-remaining lead connection but keeps the sibling connection eligible", async () => {
+  registerQuotaFetcher(PROVIDER, async (connectionId: string) => {
+    if (connectionId === EXHAUSTED_CONNECTION_ID) {
+      return { used: 100, total: 100, percentUsed: 1 };
+    }
+    return { used: 5, total: 100, percentUsed: 0.05 };
+  });
+
+  const combo = {
+    name: `priority-quota-cutoff-5923-${Date.now()}`,
+    strategy: "priority",
+    models: [
+      {
+        kind: "model",
+        provider: PROVIDER,
+        providerId: PROVIDER,
+        model: "gpt-4o-mini",
+        connectionId: EXHAUSTED_CONNECTION_ID,
+        id: "step-a",
+      },
+      {
+        kind: "model",
+        provider: PROVIDER,
+        providerId: PROVIDER,
+        model: "gpt-4o-mini",
+        connectionId: HEALTHY_CONNECTION_ID,
+        id: "step-b",
+      },
+    ],
+  };
+
+  const calls: Array<string | null> = [];
+  const response = await handleComboChat({
+    body: { model: combo.name, messages: [{ role: "user", content: "hi" }] },
+    combo,
+    allCombos: [combo],
+    isModelAvailable: undefined,
+    relayOptions: undefined,
+    signal: undefined,
+    settings: {
+      resilienceSettings: {
+        quotaPreflight: {
+          enabled: true,
+          defaultThresholdPercent: 2,
+          warnThresholdPercent: 20,
+        },
+      },
+    },
+    log: makeLog(),
+    handleSingleModel: async (
+      _body: unknown,
+      modelStr: string,
+      target?: { connectionId?: string | null }
+    ) => {
+      calls.push(target?.connectionId ?? null);
+      return okResponse(modelStr);
+    },
+  } as Parameters<typeof handleComboChat>[0]);
+
+  assert.equal(response.status, 200);
+  assert.ok(calls.length > 0, "expected at least one dispatched target");
+  assert.equal(
+    calls[0],
+    HEALTHY_CONNECTION_ID,
+    "the 0%-remaining lead connection must be skipped; the sibling connection must be dispatched instead"
+  );
+  assert.ok(
+    !calls.includes(EXHAUSTED_CONNECTION_ID),
+    "the exhausted connection must never be dispatched to"
+  );
+
+  // Strictly per-connection — the provider circuit breaker must stay CLOSED.
+  // Only one connection was skipped; the provider itself never failed.
+  assert.equal(
+    getCircuitBreaker(PROVIDER).getStatus().state,
+    "CLOSED",
+    "quota-exhaustion cutoff must never trip the whole-provider circuit breaker"
+  );
+});
+
+test("#5923 priority combo does NOT skip a 0%-remaining connection when the cutoff setting is disabled (default)", async () => {
+  const provider = "openai";
+  const exhaustedConnectionId = "conn-exhausted-disabled-5923";
+  registerQuotaFetcher(provider, async () => ({ used: 100, total: 100, percentUsed: 1 }));
+
+  const combo = {
+    name: `priority-quota-cutoff-disabled-5923-${Date.now()}`,
+    strategy: "priority",
+    models: [
+      {
+        kind: "model",
+        provider,
+        providerId: provider,
+        model: "gpt-4o-mini",
+        connectionId: exhaustedConnectionId,
+        id: "step-a",
+      },
+    ],
+  };
+
+  const calls: Array<string | null> = [];
+  const response = await handleComboChat({
+    body: { model: combo.name, messages: [{ role: "user", content: "hi" }] },
+    combo,
+    allCombos: [combo],
+    isModelAvailable: undefined,
+    relayOptions: undefined,
+    signal: undefined,
+    // No resilienceSettings override → quotaPreflight.enabled defaults to false (opt-in).
+    settings: {},
+    log: makeLog(),
+    handleSingleModel: async (
+      _body: unknown,
+      modelStr: string,
+      target?: { connectionId?: string | null }
+    ) => {
+      calls.push(target?.connectionId ?? null);
+      return okResponse(modelStr);
+    },
+  } as Parameters<typeof handleComboChat>[0]);
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(
+    calls,
+    [exhaustedConnectionId],
+    "with the cutoff setting OFF (default), the exhausted connection must still be dispatched to (unchanged auto-off behavior)"
+  );
+});

--- a/tests/unit/quota-cache-is-exhausted-per-window-5923.test.ts
+++ b/tests/unit/quota-cache-is-exhausted-per-window-5923.test.ts
@@ -1,0 +1,59 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+/**
+ * #5923 (Finding #5) — `is_exhausted` on `quota_snapshots` rows was written from
+ * the connection-wide aggregate (`entries.every(q => q.remainingPercentage <= 0)`
+ * in `isExhausted()`), not from the specific window being persisted.
+ *
+ * A connection with one window at 0% and another window at 50% never got its
+ * 0%-window row flagged `is_exhausted=1`, because the AND-across-all-windows
+ * aggregate was false (the 50% window kept it false). The reporter observed
+ * ~360 of 274k snapshot rows ever set `is_exhausted=1` in production.
+ *
+ * Regression guard: `setQuotaCache` must persist `is_exhausted` per-window
+ * (`remainingPercentage <= 0` for THAT window), independent of sibling windows
+ * on the same connection.
+ */
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omni-quota-per-window-5923-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const coreDb = await import("../../src/lib/db/core.ts");
+const quotaSnapshotsDb = await import("../../src/lib/db/quotaSnapshots.ts");
+const quotaCache = await import("../../src/domain/quotaCache.ts");
+
+test.after(() => {
+  coreDb.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("#5923 setQuotaCache writes is_exhausted per-window, not the connection-wide AND aggregate", () => {
+  const connectionId = "conn-per-window-5923";
+
+  quotaCache.setQuotaCache(connectionId, "anthropic", {
+    session: { remainingPercentage: 0, resetAt: null },
+    weekly: { remainingPercentage: 50, resetAt: null },
+  });
+
+  const snapshots = quotaSnapshotsDb.getLatestQuotaSnapshotsForConnection(connectionId);
+
+  const sessionRow = snapshots.find((s: any) => (s.windowKey ?? s.window_key) === "session");
+  const weeklyRow = snapshots.find((s: any) => (s.windowKey ?? s.window_key) === "weekly");
+
+  assert.ok(sessionRow, "expected a persisted row for the session window");
+  assert.ok(weeklyRow, "expected a persisted row for the weekly window");
+
+  assert.equal(
+    (sessionRow as any).isExhausted ?? (sessionRow as any).is_exhausted,
+    1,
+    "the 0%-remaining session window must be flagged is_exhausted=1"
+  );
+  assert.equal(
+    (weeklyRow as any).isExhausted ?? (weeklyRow as any).is_exhausted,
+    0,
+    "the 50%-remaining weekly window must NOT be flagged is_exhausted (sibling window is exhausted, but this one isn't)"
+  );
+});


### PR DESCRIPTION
Addresses #5923 findings #4 and #5 (per-connection/per-model scoped; does not touch the provider breaker). Findings #1/#2/#6 need reporter data; #3 refuted during triage.

## Finding #5 — `is_exhausted` written per-connection instead of per-window

`src/domain/quotaCache.ts::setQuotaCache()` persisted `is_exhausted` on every `quota_snapshots` row using the connection-wide AND-across-all-windows aggregate (`isExhausted()`), instead of that specific window's own remaining percentage. A connection with one 0% window and another non-zero window never got its 0% window's row flagged exhausted — the reporter observed ~360 of 274k rows ever set `is_exhausted=1` in production.

Fix: each persisted row now derives `is_exhausted` from `remainingPercentage <= 0` for THAT window, independent of sibling windows. The connection-level `isExhausted()` aggregate (used by `isAccountQuotaExhausted`/cache TTL logic) is unchanged.

## Finding #4 — quota-exhaustion preflight only ran for strategy === "auto"

`open-sse/services/combo.ts::buildAutoCandidates` applies a remaining-quota cutoff (`evaluateQuotaCutoff` + `buildAutoQuotaThresholds`, gated by `resilienceSettings.quotaPreflight.enabled`), but it was only invoked from the `strategy === "auto"` branch. Priority/weighted/etc. strategies funnel through the shared `executeTarget` per-target loop, which only checks the provider circuit breaker + model lockout — a 0%-remaining connection stayed eligible as the lead leg until it reactively 429'd.

Fix: extracted the existing fetch+evaluate flow into `resolveQuotaExhaustionCutoffForTarget()` (reuses the same `fetchResetAwareQuotaWithCache`, `evaluateQuotaCutoff`, `buildAutoQuotaThresholds` — same threshold, no new logic invented) and applied it in `executeTarget`, skipped for `"auto"` (which already has its own gate to avoid a duplicate fetch). Strictly per-(provider, connectionId): skipping one exhausted connection never ejects sibling connections/models of the same provider, and the provider circuit breaker is never touched.

## Tests (TDD — RED confirmed on pre-fix code, GREEN after)

- `tests/unit/quota-cache-is-exhausted-per-window-5923.test.ts` — sets a connection with a 0% window and a 50% window, asserts only the 0% window's persisted row is flagged `is_exhausted=1`.
- `tests/unit/combo-priority-quota-exhaustion-cutoff-5923.test.ts` — priority combo with two connections of the same provider (one 0% remaining, one healthy) and the cutoff enabled: the exhausted connection is skipped, the healthy sibling is dispatched to, and the provider circuit breaker stays `CLOSED`. A second test confirms the cutoff is a no-op when the opt-in setting is off (default), preserving existing behavior.

## Validation run

- `node --import tsx/esm --test` on both new files + existing combo/quota suites (`combo-strategies`, `combo-strategy-fallbacks`, `combo-quota-soft-penalty`, `quota-preflight`, `quota-cache-hydrate-5015`, `combo/combo-exhausted-skip`, `combo-prescreen`, `combo-account-allowlist-3266`, `db-quota-snapshots`, `auto-combo-engine`, `auto-combo-scoring-clamp`, `autocombo-unification`) — all green, no regressions.
- `npm run test:vitest` — 238/238 passed.
- `npm run typecheck:core` — clean.
- `npx eslint` on changed files — 0 errors (pre-existing-style `no-explicit-any` warnings only, in test files).
- `npm run check:any-budget:t11` — PASS.

## Test plan

- [x] Failing-then-passing TDD tests for both findings (see above)
- [x] Both `node:test` and `vitest` runners green
- [x] typecheck + lint clean