### PR TITLE
chore(ci): pr-evidence FAIL output tells you to push (edited body does not re-run)

### DIFF
--- a/scripts/check/check-pr-evidence.mjs
+++ b/scripts/check/check-pr-evidence.mjs
@@ -231,7 +231,16 @@ if (isMain) {
   } else if (result === "pass") {
     reportLines.push("Result: PASS", "", reason);
   } else {
-    reportLines.push("Result: FAIL", "", reason);
+    reportLines.push(
+      "Result: FAIL",
+      "",
+      reason,
+      "",
+      "> ℹ️ Editing the PR body to add the evidence does NOT re-run this gate — `ci.yml` " +
+        "does not listen to the `edited` event. Add the `## Evidence` block, then **push a " +
+        "commit** (or re-run this job) to re-validate. For releases, put the Evidence block in " +
+        "the body BEFORE the first push (see the generate-release skill, Phase 0)."
+    );
   }
 
   const report = buildReport(reportLines);

--- a/tests/unit/check-pr-evidence.test.ts
+++ b/tests/unit/check-pr-evidence.test.ts
@@ -1,0 +1,55 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const mod = await import("../../scripts/check/check-pr-evidence.mjs");
+const { evaluatePrBody } = mod;
+const SCRIPT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../scripts/check/check-pr-evidence.mjs"
+);
+
+function run(body) {
+  try {
+    const out = execFileSync("node", [SCRIPT], {
+      encoding: "utf8",
+      env: { ...process.env, PR_BODY: body },
+    });
+    return { code: 0, out };
+  } catch (err) {
+    return { code: err.status ?? 1, out: `${err.stdout || ""}${err.stderr || ""}` };
+  }
+}
+
+test("evaluatePrBody: no outcome claim → pass (no evidence required)", () => {
+  const r = evaluatePrBody("Adds a helper module.");
+  assert.equal(r.result, "pass");
+  assert.match(r.reason, /no evidence required/i);
+});
+
+test("evaluatePrBody: outcome claim + evidence block → pass", () => {
+  const r = evaluatePrBody("Tests pass.\n\n## Evidence\n```\ntests 20 / pass 20 / fail 0\n```");
+  assert.equal(r.result, "pass");
+});
+
+test("evaluatePrBody: outcome claim without evidence → fail", () => {
+  const r = evaluatePrBody("All 20 tests pass and 0 errors.");
+  assert.equal(r.result, "fail");
+});
+
+test("the FAIL report explains that editing the body does not re-run the gate (push instead)", () => {
+  const { code, out } = run("All 20 tests pass and 0 errors."); // claim, no evidence
+  assert.equal(code, 1, "gate fails on a claim with no evidence");
+  assert.match(out, /Result: FAIL/);
+  assert.match(out, /does NOT re-run this gate/);
+  assert.match(out, /push a commit/i);
+});
+
+test("the hint does NOT appear when the gate passes", () => {
+  const { code, out } = run("Tests pass.\n\n## Evidence\n```\ntests 20 / pass 20 / fail 0\n```");
+  assert.equal(code, 0);
+  assert.match(out, /Result: PASS/);
+  assert.doesNotMatch(out, /does NOT re-run this gate/);
+});


### PR DESCRIPTION
## What
The `check:pr-evidence` FAIL report now tells you that **editing the PR body does not re-run the gate** — `ci.yml` ignores the `edited` event, so you must push a commit (or re-run the job) after adding the `## Evidence` block. The hint prints at the exact place someone sees the red check.

## Why (decision on the v3.8.43 "item #4")
The release retro flagged the `edited` gap (I hit it: edited the release-PR body to add Evidence, the gate stayed red, needed another push). I evaluated building a workflow that re-runs pr-evidence on `edited` and **decided against it**:
- **pr-evidence is not a required check** — no ruleset gates it; the v3.8.43 release PR merged `UNSTABLE` (not `BLOCKED`) with pr-evidence red. So the gap is **cosmetic**, not a merge blocker.
- A dedicated `edited`-triggered workflow runs on every title/body edit (noise) and changes check topology for a non-blocking, already-mitigated case (the generate-release skill now puts the Evidence block in the body **before** the first push). Over-engineering.

This one-line hint captures the lesson at the point of pain for anyone who still hits it — zero topology risk.

## Evidence
```text
node --test tests/unit/check-pr-evidence.test.ts   → tests 5 / pass 5 / fail 0
prettier --check                                    → clean
FAIL case (claim, no evidence)  → prints "Result: FAIL" + the push hint
PASS case (has Evidence block)  → prints "Result: PASS", no hint
```
