### PR TITLE
refactor(translator): extract pure message helpers from openai-to-kiro (852→751)

### DIFF
--- a/open-sse/translator/request/openai-to-kiro.ts
+++ b/open-sse/translator/request/openai-to-kiro.ts
@@ -5,6 +5,11 @@
 import { register } from "../registry.ts";
 import { FORMATS } from "../formats.ts";
 import { v4 as uuidv4, v5 as uuidv5 } from "uuid";
+import {
+  parseToolInput,
+  normalizeKiroToolSchema,
+  serializeToolResultContent,
+} from "./openai-to-kiro/messageHelpers.ts";
 
 /**
  * Anthropic's direct-provider `[1m]` context-1m beta suffix. Kiro is AWS
@@ -23,116 +28,8 @@ export const KIRO_UNSUPPORTED_CONTEXT_1M_MESSAGE =
  */
 export function hasUnsupportedKiroContextSuffix(model: unknown): boolean {
   return (
-    typeof model === "string" &&
-    model.toLowerCase().includes(KIRO_UNSUPPORTED_CONTEXT_1M_SUFFIX)
+    typeof model === "string" && model.toLowerCase().includes(KIRO_UNSUPPORTED_CONTEXT_1M_SUFFIX)
   );
-}
-
-function parseToolInput(value: unknown) {
-  if (value && typeof value === "object" && !Array.isArray(value)) {
-    return value;
-  }
-  if (typeof value !== "string") {
-    return {};
-  }
-
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return {};
-  }
-
-  try {
-    const parsed = JSON.parse(trimmed);
-    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
-  } catch {
-    return {};
-  }
-}
-
-/**
- * Recursively sanitize JSON Schema for Kiro API.
- * Kiro returns 400 "Improperly formed request" if:
- * - `required` is an empty array []
- * - `additionalProperties` is present anywhere
- */
-function normalizeKiroToolSchema(schema: unknown): Record<string, unknown> {
-  if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
-    return { type: "object", properties: {} };
-  }
-
-  const result: Record<string, unknown> = {};
-  const src = schema as Record<string, unknown>;
-
-  for (const [key, value] of Object.entries(src)) {
-    // Skip empty required arrays — Kiro rejects them
-    if (key === "required" && Array.isArray(value) && value.length === 0) {
-      continue;
-    }
-    // Skip additionalProperties — Kiro doesn't support it
-    if (key === "additionalProperties") {
-      continue;
-    }
-    // Recursively process nested objects
-    if (
-      key === "properties" &&
-      typeof value === "object" &&
-      value !== null &&
-      !Array.isArray(value)
-    ) {
-      const sanitizedProps: Record<string, unknown> = {};
-      for (const [propName, propValue] of Object.entries(value as Record<string, unknown>)) {
-        sanitizedProps[propName] = normalizeKiroToolSchema(propValue);
-      }
-      result[key] = sanitizedProps;
-    } else if (typeof value === "object" && value !== null && !Array.isArray(value)) {
-      result[key] = normalizeKiroToolSchema(value);
-    } else if (Array.isArray(value)) {
-      result[key] = value.map((item) =>
-        typeof item === "object" && item !== null && !Array.isArray(item)
-          ? normalizeKiroToolSchema(item)
-          : item
-      );
-    } else {
-      result[key] = value;
-    }
-  }
-
-  return result;
-}
-
-function serializeToolResultContent(content: unknown): string {
-  if (typeof content === "string") {
-    return content || "(no output)";
-  }
-  if (!Array.isArray(content)) {
-    if (content !== null && content !== undefined) {
-      try {
-        return JSON.stringify(content);
-      } catch {
-        return "(no output)";
-      }
-    }
-    return "(no output)";
-  }
-  const parts: string[] = [];
-  for (const block of content as Array<Record<string, unknown>>) {
-    if (!block || typeof block !== "object") continue;
-    if (block.type === "text" && typeof block.text === "string") {
-      if (block.text) parts.push(block.text);
-    } else if (block.type === "image" || block.type === "image_url") {
-      const src = block.source as Record<string, unknown> | undefined;
-      const mediaType = src?.media_type ?? block.media_type ?? "image";
-      parts.push(`[image: ${mediaType}]`);
-    } else {
-      try {
-        const str = JSON.stringify(block);
-        if (str && str !== "{}") parts.push(str);
-      } catch {
-        // skip unserializable block
-      }
-    }
-  }
-  return parts.join("\n") || "(no output)";
 }
 
 /**
@@ -806,9 +703,7 @@ export function buildKiroPayload(model, body, stream, credentials) {
   // compressContext runs). This keeps conversationId stable even when compression alters content.
   // Priority 2: Deterministic hash from first user message in translated history (fallback).
   const preCompressionBody = credentials?._preCompressionBody as
-    | Record<string, unknown>
-    | null
-    | undefined;
+    Record<string, unknown> | null | undefined;
   const preCompressionMessages = Array.isArray(preCompressionBody?.messages)
     ? preCompressionBody.messages
     : null;

--- a/open-sse/translator/request/openai-to-kiro/messageHelpers.ts
+++ b/open-sse/translator/request/openai-to-kiro/messageHelpers.ts
@@ -1,0 +1,109 @@
+// Pure message/tool helpers for the OpenAI -> Kiro request translator.
+// Extracted verbatim from openai-to-kiro.ts (no host imports).
+
+export function parseToolInput(value: unknown) {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return value;
+  }
+  if (typeof value !== "string") {
+    return {};
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return {};
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Recursively sanitize JSON Schema for Kiro API.
+ * Kiro returns 400 "Improperly formed request" if:
+ * - `required` is an empty array []
+ * - `additionalProperties` is present anywhere
+ */
+export function normalizeKiroToolSchema(schema: unknown): Record<string, unknown> {
+  if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
+    return { type: "object", properties: {} };
+  }
+
+  const result: Record<string, unknown> = {};
+  const src = schema as Record<string, unknown>;
+
+  for (const [key, value] of Object.entries(src)) {
+    // Skip empty required arrays — Kiro rejects them
+    if (key === "required" && Array.isArray(value) && value.length === 0) {
+      continue;
+    }
+    // Skip additionalProperties — Kiro doesn't support it
+    if (key === "additionalProperties") {
+      continue;
+    }
+    // Recursively process nested objects
+    if (
+      key === "properties" &&
+      typeof value === "object" &&
+      value !== null &&
+      !Array.isArray(value)
+    ) {
+      const sanitizedProps: Record<string, unknown> = {};
+      for (const [propName, propValue] of Object.entries(value as Record<string, unknown>)) {
+        sanitizedProps[propName] = normalizeKiroToolSchema(propValue);
+      }
+      result[key] = sanitizedProps;
+    } else if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+      result[key] = normalizeKiroToolSchema(value);
+    } else if (Array.isArray(value)) {
+      result[key] = value.map((item) =>
+        typeof item === "object" && item !== null && !Array.isArray(item)
+          ? normalizeKiroToolSchema(item)
+          : item
+      );
+    } else {
+      result[key] = value;
+    }
+  }
+
+  return result;
+}
+
+export function serializeToolResultContent(content: unknown): string {
+  if (typeof content === "string") {
+    return content || "(no output)";
+  }
+  if (!Array.isArray(content)) {
+    if (content !== null && content !== undefined) {
+      try {
+        return JSON.stringify(content);
+      } catch {
+        return "(no output)";
+      }
+    }
+    return "(no output)";
+  }
+  const parts: string[] = [];
+  for (const block of content as Array<Record<string, unknown>>) {
+    if (!block || typeof block !== "object") continue;
+    if (block.type === "text" && typeof block.text === "string") {
+      if (block.text) parts.push(block.text);
+    } else if (block.type === "image" || block.type === "image_url") {
+      const src = block.source as Record<string, unknown> | undefined;
+      const mediaType = src?.media_type ?? block.media_type ?? "image";
+      parts.push(`[image: ${mediaType}]`);
+    } else {
+      try {
+        const str = JSON.stringify(block);
+        if (str && str !== "{}") parts.push(str);
+      } catch {
+        // skip unserializable block
+      }
+    }
+  }
+  return parts.join("\n") || "(no output)";
+}

--- a/tests/unit/openai-to-kiro-helpers-split.test.ts
+++ b/tests/unit/openai-to-kiro-helpers-split.test.ts
@@ -1,0 +1,44 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+// Split-guard for the openai-to-kiro message-helper extraction.
+// The pure tool/message helpers (parseToolInput / normalizeKiroToolSchema /
+// serializeToolResultContent) live in the leaf `openai-to-kiro/messageHelpers.ts`;
+// the host imports them back for convertMessages. They were module-private, so the
+// public export set is unchanged (no re-export needed).
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REQ = join(HERE, "../../open-sse/translator/request");
+const HOST = join(REQ, "openai-to-kiro.ts");
+const LEAF = join(REQ, "openai-to-kiro/messageHelpers.ts");
+
+test("leaf hosts the pure helpers and does not import the host", () => {
+  const src = readFileSync(LEAF, "utf8");
+  for (const sym of ["parseToolInput", "normalizeKiroToolSchema", "serializeToolResultContent"]) {
+    assert.match(src, new RegExp(`export function ${sym}\\b`));
+  }
+  assert.doesNotMatch(src, /from "\.\.\/openai-to-kiro\.ts"/);
+});
+
+test("host imports the helpers back from the leaf", () => {
+  const src = readFileSync(HOST, "utf8");
+  assert.match(src, /from "\.\/openai-to-kiro\/messageHelpers\.ts"/);
+  // buildKiroPayload stays exported on the host module.
+  assert.match(src, /export function buildKiroPayload\(/);
+});
+
+test("normalizeKiroToolSchema strips empty required arrays and additionalProperties", async () => {
+  const { normalizeKiroToolSchema } =
+    await import("../../open-sse/translator/request/openai-to-kiro/messageHelpers.ts");
+  const out = normalizeKiroToolSchema({
+    type: "object",
+    required: [],
+    additionalProperties: false,
+    properties: { a: { type: "string" } },
+  });
+  assert.equal("required" in out, false);
+  assert.equal("additionalProperties" in out, false);
+  assert.deepEqual(out.properties, { a: { type: "string" } });
+});


### PR DESCRIPTION
## O quê

Campanha god-files (Bloco **H1**). Extrai os helpers puros de tool/mensagem de `open-sse/translator/request/openai-to-kiro.ts` para um leaf irmão.

- **Leaf** `openai-to-kiro/messageHelpers.ts`: `parseToolInput`, `normalizeKiroToolSchema` (sanitiza JSON Schema p/ Kiro), `serializeToolResultContent`. **Zero imports** (100% puros).
- **Host**: importa os 3 de volta (usados só por `convertMessages`). Eram module-private → export-set público inalterado (sem re-export). `buildKiroPayload` permanece exportado no host.

## Por quê

- Host **852 → 751 LOC** (arquivo estava no teto do baseline 853).
- **Zero mudança de comportamento**: corpos byte-idênticos (multiset 99/99), leaf sem imports (sem ciclo).

## Validação

- `typecheck:core` ✅ · `check:cycles` ✅ · `check:file-size` ✅ (meus arquivos) · eslint/prettier ✅
- Testes consumidores verdes: translator-openai-to-kiro (33), translator-ai-sdk-image-parts (3)
- **Split-guard novo** `openai-to-kiro-helpers-split.test.ts` (3) — fixa leaf/host-import/anti-ciclo + caracteriza normalizeKiroToolSchema