### PR TITLE
fix(providers): validate v0 Platform API keys via chats endpoint

### DIFF
--- a/src/lib/providers/validation.ts
+++ b/src/lib/providers/validation.ts
@@ -264,6 +264,39 @@ export async function validateProviderApiKey({ provider, apiKey, providerSpecifi
 
   // ── Specialty provider validation ──
   const SPECIALTY_VALIDATORS = {
+    "v0-vercel": async ({ apiKey, providerSpecificData }: any) => {
+      try {
+        const configuredBaseUrl =
+          typeof providerSpecificData?.baseUrl === "string" && providerSpecificData.baseUrl.trim()
+            ? providerSpecificData.baseUrl.trim()
+            : "https://api.v0.dev";
+
+        const root = normalizeBaseUrl(configuredBaseUrl)
+          .replace(/\/v1\/chat\/completions$/, "")
+          .replace(/\/v1$/, "");
+
+        const res = await validationRead(
+          `${root}/v1/chats?limit=1`,
+          {
+            method: "GET",
+            headers: buildBearerHeaders(apiKey, providerSpecificData),
+          },
+          isLocal
+        );
+
+        if (res.ok) {
+          return { valid: true, error: null, method: "v0_platform_chats_list" };
+        }
+
+        if (res.status === 401 || res.status === 403) {
+          return { valid: false, error: "Invalid API key" };
+        }
+
+        return { valid: false, error: `v0 validation failed: ${res.status}` };
+      } catch (error: any) {
+        return toValidationErrorResult(error);
+      }
+    },
     jules: validateJulesProvider,
     qoder: async ({ apiKey, providerSpecificData }: any) => {
       // Bifurcate validation: PAT tokens use Cosy auth against api1.qoder.sh;

--- a/tests/unit/provider-validation-specialty.test.ts
+++ b/tests/unit/provider-validation-specialty.test.ts
@@ -242,6 +242,48 @@ test("embedding and rerank specialty validators surface auth failures for Voyage
   assert.equal(jina.error, "Invalid API key");
 });
 
+test("v0-vercel specialty validator checks the Platform API chats endpoint", async () => {
+  globalThis.fetch = async (url, init = {}) => {
+    assert.equal(String(url), "https://api.v0.dev/v1/chats?limit=1");
+    assert.equal((init.headers as Record<string, string>).Authorization, "Bearer v0-key");
+    return new Response(JSON.stringify({ object: "list", data: [] }), { status: 200 });
+  };
+
+  const result = await validateProviderApiKey({
+    provider: "v0-vercel",
+    apiKey: "v0-key",
+    providerSpecificData: {
+      baseUrl: "https://api.v0.dev/v1/chat/completions",
+    },
+  });
+
+  assert.deepEqual(result, {
+    valid: true,
+    error: null,
+    method: "v0_platform_chats_list",
+  });
+});
+
+test("v0-vercel specialty validator treats auth failures as invalid API key", async () => {
+  globalThis.fetch = async (url, init = {}) => {
+    assert.equal(String(url), "https://api.v0.dev/v1/chats?limit=1");
+    assert.equal((init.headers as Record<string, string>).Authorization, "Bearer bad-v0-key");
+    return new Response(JSON.stringify({ error: { type: "unauthorized_error" } }), {
+      status: 401,
+    });
+  };
+
+  const result = await validateProviderApiKey({
+    provider: "v0-vercel",
+    apiKey: "bad-v0-key",
+    providerSpecificData: {
+      baseUrl: "https://api.v0.dev/v1",
+    },
+  });
+
+  assert.equal(result.error, "Invalid API key");
+});
+
 test("gitlab specialty validator accepts PAT auth on the direct access endpoint", async () => {
   globalThis.fetch = async (url, init = {}) => {
     assert.equal(String(url), "https://gitlab.com/api/v4/code_suggestions/direct_access");
@@ -2783,12 +2825,14 @@ test("huggingface validator accepts a token whoami-v2 recognizes", async () => {
 });
 
 test("huggingface validator treats 401/403 as an invalid token", async () => {
-  globalThis.fetch = async () => new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 });
+  globalThis.fetch = async () =>
+    new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 });
   const unauthorized = await validateProviderApiKey({ provider: "huggingface", apiKey: "hf_bad" });
   assert.equal(unauthorized.valid, false);
   assert.equal(unauthorized.error, "Invalid API key");
 
-  globalThis.fetch = async () => new Response(JSON.stringify({ error: "Forbidden" }), { status: 403 });
+  globalThis.fetch = async () =>
+    new Response(JSON.stringify({ error: "Forbidden" }), { status: 403 });
   const forbidden = await validateProviderApiKey({ provider: "huggingface", apiKey: "hf_bad" });
   assert.equal(forbidden.valid, false);
   assert.equal(forbidden.error, "Invalid API key");
@@ -2800,7 +2844,10 @@ test("huggingface validator does NOT mark a fine-grained token invalid on a non-
   // non-OK status must surface as a transient error, never "Invalid API key".
   globalThis.fetch = async () => new Response("upstream down", { status: 503 });
 
-  const result = await validateProviderApiKey({ provider: "huggingface", apiKey: "hf_finegrained" });
+  const result = await validateProviderApiKey({
+    provider: "huggingface",
+    apiKey: "hf_finegrained",
+  });
 
   assert.equal(result.valid, false);
   assert.notEqual(result.error, "Invalid API key");


### PR DESCRIPTION
## Summary

Adds a dedicated validator for the `v0-vercel` API-key provider.

The validator now checks the v0 Platform API directly with:

`GET https://api.v0.dev/v1/chats?limit=1`

instead of falling through to the generic OpenAI-compatible validation flow.

## Root cause

`v0-vercel` is registered as an API-key provider, but the generic validator treats it as OpenAI-compatible and probes `/models` and `/chat/completions`.

The v0 Platform API uses REST endpoints such as `/v1/chats` and `/v1/chats/:id/messages`, so valid v0 API keys can be reported as:

`Provider validation endpoint not supported`

## Changes

- Add a `v0-vercel` specialty validator.
- Normalize saved/custom base URLs such as:
  - `https://api.v0.dev`
  - `https://api.v0.dev/v1`
  - `https://api.v0.dev/v1/chat/completions`
- Add unit coverage for:
  - successful validation
  - 401 auth failure

## Validation

Targeted provider validation test passed:

```bash
DISABLE_SQLITE_AUTO_BACKUP=true node --max-old-space-size=8192 \
  --import tsx \
  --import ./open-sse/utils/setupPolyfill.ts \
  --import ./tests/_setup/isolateDataDir.ts \
  --test \
  --test-force-exit \
  tests/unit/provider-validation-specialty.test.ts
```

Result:

- 118 tests
- 118 pass
- 0 fail

Full coverage was also attempted locally. Coverage threshold passed at ~80%, but one unrelated environment-sensitive test failed under the full suite while passing in isolation. This PR only changes `v0-vercel` validation and its unit coverage.

Changed test file:

- `tests/unit/provider-validation-specialty.test.ts`

## Note

This PR fixes API-key validation only. It does not implement a full v0 Platform API runtime executor. The existing runtime path may still need a dedicated executor because the v0 Platform API is not OpenAI-compatible.
