### PR TITLE
fix(mcp): auto-recover stale streamable HTTP sessions on initialize

### DIFF
--- a/open-sse/mcp-server/httpTransport.ts
+++ b/open-sse/mcp-server/httpTransport.ts
@@ -173,6 +173,27 @@ async function handleStreamableRequest(request: Request): Promise<Response> {
       // terminated/unknown, the server MUST respond with HTTP 404 Not Found so the
       // client re-initializes. A 400 here is non-recoverable for spec-compliant
       // clients (they only re-init on 404). See issue #5169.
+      //
+      // Auto-recovery: if the client sends an initialize request with a stale session
+      // id (e.g. after a server restart or idle eviction), treat it as a fresh
+      // initialization rather than hard-failing with 404. This avoids requiring users
+      // to manually restart their MCP client after every server restart.
+      if (await isInitializeRequest(request)) {
+        const newSession = createStreamableSession();
+        try {
+          const response = await withMcpHttpAuthContext(request, () =>
+            newSession.transport.handleRequest(request)
+          );
+          return withSessionHeader(response, newSession.sessionId);
+        } catch (err) {
+          closeStreamableSession(newSession.sessionId);
+          console.error("[MCP] Streamable HTTP error during stale-session recovery:", err);
+          return new Response(JSON.stringify({ error: "MCP transport error" }), {
+            status: 500,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+      }
       return errorResponse("Not Found: Unknown Mcp-Session-Id header", -32000, 404);
     }
 

--- a/tests/unit/mcp-session-sweep.test.ts
+++ b/tests/unit/mcp-session-sweep.test.ts
@@ -347,3 +347,76 @@ test("handleMcpStreamableHTTP keeps 400 for a missing session id (non-initialize
   // only the *present-but-unknown* case changed to 404. This must NOT regress.
   assert.equal(res.status, 400);
 });
+
+test("handleMcpStreamableHTTP auto-recovers when stale session id is sent with initialize", async () => {
+  mod.shutdownMcpHttp();
+
+  const initReq = new Request("http://localhost/api/mcp/stream", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      method: "initialize",
+      id: 1,
+      params: {
+        protocolVersion: "2025-03-26",
+        capabilities: {},
+        clientInfo: { name: "test-client", version: "1.0.0" },
+      },
+    }),
+  });
+
+  const firstRes = await mod.handleMcpStreamableHTTP(initReq);
+  const staleSessionId = firstRes.headers.get("mcp-session-id");
+  if (!staleSessionId) {
+    mod.shutdownMcpHttp();
+    return;
+  }
+
+  mod.shutdownMcpHttp();
+  assert.equal(mod.isMcpHttpActive(), false);
+
+  const reinitReq = new Request("http://localhost/api/mcp/stream", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+      "mcp-session-id": staleSessionId,
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      method: "initialize",
+      id: 2,
+      params: {
+        protocolVersion: "2025-03-26",
+        capabilities: {},
+        clientInfo: { name: "test-client", version: "1.0.0" },
+      },
+    }),
+  });
+
+  const recoveryRes = await mod.handleMcpStreamableHTTP(reinitReq);
+
+  assert.notEqual(
+    recoveryRes.status,
+    404,
+    "Stale session + initialize must NOT return 404 — server should auto-recover"
+  );
+  assert.ok(
+    recoveryRes.status >= 200 && recoveryRes.status < 300,
+    `Expected 2xx response on auto-recovery, got ${recoveryRes.status}`
+  );
+
+  const newSessionId = recoveryRes.headers.get("mcp-session-id");
+  assert.ok(newSessionId, "Server must issue a new mcp-session-id on auto-recovery");
+  assert.equal(
+    mod.isMcpHttpActive(),
+    true,
+    "Server must have an active session after auto-recovery"
+  );
+
+  mod.shutdownMcpHttp();
+});


### PR DESCRIPTION
## Summary
Fix stale MCP Streamable HTTP session handling: when a client re-sends an `initialize` request carrying a stale `mcp-session-id` (after server restart or 5-minute idle eviction), the server now auto-creates a fresh session instead of returning 404.

Non-initialize requests with unknown session IDs still return 404 (preserving the MCP spec guidance for spec-compliant clients).

## Problem
- Sessions live only in-memory (`_streamableSessions` Map).
- Server restart / hot-reload / idle sweep (5 min) drops all sessions.
- MCP clients (e.g. opencode, other tools) often retain the old `mcp-session-id` header.
- Result: `{"error":{"code":-32000,"message":"Not Found: Unknown Mcp-Session-Id header"}}` (HTTP 404) on every subsequent call until client is manually restarted.

## Solution
In `handleStreamableRequest()`:
- If `mcp-session-id` header is present but session is unknown, **and** the body is an `initialize` request → treat as fresh init, create new session via `createStreamableSession()`, return new `mcp-session-id`.
- Non-initialize requests with unknown IDs continue to return 404 (as before).

Added unit test covering the recovery path (stale ID + initialize → 2xx + new session ID).

## Testing
- `node --import tsx/esm --test tests/unit/mcp-session-sweep.test.ts` → 27 pass, 0 fail (includes new test)
- Manual Node script verification:
  - First initialize → 200 + session ID
  - After `shutdownMcpHttp()` (simulates restart) → re-init with stale ID → 200 + *different* new session ID
  - Unknown non-initialize still → 404
- Coverage gate passed repo thresholds (pre-existing unrelated test failure in webdav path/space test noted separately).

## Notes
- This is a pragmatic recovery for real-world clients; spec-compliant clients that see 404 on unknown session are expected to re-initialize, but many do not immediately.
- The recovery path only triggers on `initialize` method, avoiding any change to normal request handling.

Refs: MCP Streamable HTTP session management (2025-03-26 / 2025-11-25), issue #5169 context in code comments.