### PR TITLE
fix(cc-compatible): send SSE accept for streamed requests

### DIFF
--- a/open-sse/services/claudeCodeCompatible.ts
+++ b/open-sse/services/claudeCodeCompatible.ts
@@ -175,13 +175,12 @@ export function buildClaudeCodeCompatibleHeaders(
   sessionId?: string | null,
   options: { redactThinking?: boolean } = {}
 ): Record<string, string> {
-  void stream;
   // These headers intentionally mirror Claude Code's wire image closely.
   // For CC-compatible relays, passing the upstream's client-gating checks is
   // more important than forwarding arbitrary caller-specific header shapes.
   return {
     "Content-Type": "application/json",
-    Accept: "application/json",
+    Accept: stream ? "text/event-stream" : "application/json",
     Authorization: `Bearer ${apiKey}`,
     "anthropic-version": CLAUDE_CODE_COMPATIBLE_ANTHROPIC_VERSION,
     "anthropic-beta": resolveClaudeCodeCompatibleAnthropicBeta({

--- a/tests/unit/cc-compatible-provider.test.ts
+++ b/tests/unit/cc-compatible-provider.test.ts
@@ -452,7 +452,7 @@ test("DefaultExecutor uses CC-compatible path and headers", () => {
   assert.equal(headers.Authorization, "Bearer sk-test");
   assert.equal(headers["x-api-key"], undefined);
   assert.equal(headers["X-Claude-Code-Session-Id"], "session-3");
-  assert.equal(headers.Accept, "application/json");
+  assert.equal(headers.Accept, "text/event-stream");
 });
 
 test("validateProviderApiKey uses CC skeleton request after /models fallback", async () => {
@@ -493,7 +493,7 @@ test("validateProviderApiKey uses CC skeleton request after /models fallback", a
   assert.equal(calls[1].body.stream, true);
   assert.equal(calls[1].headers.Authorization, "Bearer sk-test");
   assert.equal(calls[1].headers["x-api-key"], undefined);
-  assert.equal(calls[1].headers.Accept, "application/json");
+  assert.equal(calls[1].headers.Accept, "text/event-stream");
 });
 
 test("handleChatCore forces SSE upstream for CC compatible providers while returning JSON to non-stream clients", async () => {
@@ -571,7 +571,7 @@ test("handleChatCore forces SSE upstream for CC compatible providers while retur
 
   assert.equal(result.success, true);
   assert.equal(calls.length, 1);
-  assert.equal(calls[0].headers.Accept, "application/json");
+  assert.equal(calls[0].headers.Accept, "text/event-stream");
   assert.equal(calls[0].body.stream, true);
   assert.equal(calls[0].body.stream_options, undefined);
   assert.equal(JSON.stringify(calls[0].body).includes('"cache_control"'), false);

--- a/tests/unit/chatcore-translation-paths.test.ts
+++ b/tests/unit/chatcore-translation-paths.test.ts
@@ -499,7 +499,9 @@ test("chatCore keeps Responses-native Codex payloads in native passthrough mode"
 
   assert.equal(result.success, true);
   assert.match(call.url, /\/responses$/);
-  assert.deepEqual(call.body.input, [{ type: "message", role: "user", content: [{ type: "input_text", text: "ship it" }] }]);
+  assert.deepEqual(call.body.input, [
+    { type: "message", role: "user", content: [{ type: "input_text", text: "ship it" }] },
+  ]);
   assert.equal(call.body.instructions, "custom system prompt");
   assert.equal(call.body.store, false);
   assert.deepEqual(call.body.metadata, { source: "codex-client" });
@@ -671,7 +673,7 @@ test("chatCore builds Claude Code-compatible upstream requests for CC providers"
   });
 
   assert.equal(result.success, true);
-  assert.equal(call.headers.Accept ?? call.headers.accept, "application/json");
+  assert.equal(call.headers.Accept ?? call.headers.accept, "text/event-stream");
   assert.equal(call.body.stream, true);
   assert.equal(call.body.context_management, undefined);
   assert.equal(call.body.system.length, 1);

--- a/tests/unit/chatcore-translation-paths.test.ts
+++ b/tests/unit/chatcore-translation-paths.test.ts
@@ -674,8 +674,7 @@ test("chatCore builds Claude Code-compatible upstream requests for CC providers"
 
   assert.equal(result.success, true);
   assert.equal(call.headers.Accept ?? call.headers.accept, "text/event-stream");
-  assert.equal(call.body.stream, true);
-  assert.equal(call.body.context_management, undefined);
+  assert.deepEqual([call.body.stream, call.body.context_management], [true, undefined]);
   assert.equal(call.body.system.length, 1);
   assert.match(call.body.system[0].text, /Claude Agent SDK/);
   assert.equal(typeof call.body.metadata.user_id, "string");

--- a/tests/unit/claude-code-compatible-helpers.test.ts
+++ b/tests/unit/claude-code-compatible-helpers.test.ts
@@ -47,7 +47,7 @@ test("buildClaudeCodeCompatibleHeaders emits bearer auth headers and session id"
   const streamHeaders = buildClaudeCodeCompatibleHeaders("sk-demo", true, "session-123");
   const jsonHeaders = buildClaudeCodeCompatibleHeaders("sk-demo", false);
 
-  assert.equal(streamHeaders.Accept, "application/json");
+  assert.equal(streamHeaders.Accept, "text/event-stream");
   assert.equal(streamHeaders.Authorization, "Bearer sk-demo");
   assert.equal(streamHeaders["x-api-key"], undefined);
   assert.equal(streamHeaders["X-Claude-Code-Session-Id"], "session-123");

--- a/tests/unit/executor-default-base.test.ts
+++ b/tests/unit/executor-default-base.test.ts
@@ -587,7 +587,7 @@ test("DefaultExecutor.buildHeaders rotates extra API keys and builds Claude Code
   assert.equal(ccHeaders["x-api-key"], undefined);
   assert.equal(ccHeaders["anthropic-version"], CLAUDE_CODE_COMPATIBLE_ANTHROPIC_VERSION);
   assert.equal(ccHeaders["X-Claude-Code-Session-Id"], "session-1");
-  assert.equal(ccHeaders.Accept, "application/json");
+  assert.equal(ccHeaders.Accept, "text/event-stream");
   assert.equal(ccJsonHeaders.Accept, "application/json");
 });
 

--- a/tests/unit/provider-request-failure-pipeline.test.ts
+++ b/tests/unit/provider-request-failure-pipeline.test.ts
@@ -485,7 +485,7 @@ test("CC-compatible providerRequest log keeps request beta headers and summarize
   assert.ok(providerRequest, "providerRequest must be present on CC-compatible success");
   assert.equal(providerRequest.headers["cf-ray"], undefined);
   assert.equal(providerRequest.headers.server, undefined);
-  assert.equal(providerRequest.headers.Accept, "application/json");
+  assert.equal(providerRequest.headers.Accept, "text/event-stream");
   assert.match(providerRequest.headers["anthropic-beta"], new RegExp(CONTEXT_1M_BETA_HEADER));
   assert.match(
     providerRequest.headers["anthropic-beta"],


### PR DESCRIPTION
## Summary

- Send `Accept: text/event-stream` from the Claude Code-compatible header builder when the upstream request is streamed.
- Keep `Accept: application/json` for explicit non-streaming CC helper calls.
- Update CC helper, executor, provider validation, and non-streaming aggregation regression tests to lock the streamed upstream header shape.

## Root Cause

CC-compatible chat requests intentionally force the upstream body to `stream: true` so OmniRoute can aggregate the upstream stream back into a JSON response for non-streaming downstream clients. The CC header builder still ignored the `stream` argument and always sent `Accept: application/json`, which could make some CC-compatible relays choose JSON/buffered behavior despite the streamed body. That mismatch can leave downstream non-streaming clients waiting for aggregation to complete even though the upstream work has succeeded.

## Validation

- `node --import tsx/esm --test tests/unit/claude-code-compatible-helpers.test.ts tests/unit/provider-service.test.ts`
- `node --import tsx/esm --test tests/unit/executor-default-base.test.ts`
- `node --import tsx/esm --test tests/unit/cc-compatible-provider.test.ts`
- `npx prettier --write open-sse/services/claudeCodeCompatible.ts tests/unit/claude-code-compatible-helpers.test.ts tests/unit/executor-default-base.test.ts tests/unit/cc-compatible-provider.test.ts`
- `npx eslint open-sse/services/claudeCodeCompatible.ts tests/unit/claude-code-compatible-helpers.test.ts tests/unit/executor-default-base.test.ts tests/unit/cc-compatible-provider.test.ts` (warnings only in existing test `any` allowances)
- `npm run typecheck:core`
- `npm run build`
- `git diff --check`

## Live Validation

Tested against a local production server using the existing SQLite data directory and the `anthropic-compatible-cc-sp-anthropic` connection:

- Non-streaming downstream request to `sp-anthropic/claude-sonnet-4-6` with ~56.8k prompt tokens returned `200` JSON in ~4.0s.
- Non-streaming downstream request to `sp-anthropic/claude-sonnet-4-6` with ~52.2k prompt tokens returned `200` JSON in ~10.0s through the upstream-SSE aggregation path.
- Non-streaming downstream request to `sp-anthropic/claude-sonnet-4-6` with ~69.5k prompt tokens returned `200` JSON in ~9.8s through the upstream-SSE aggregation path.
- Streaming downstream request to `sp-anthropic/claude-sonnet-4-6` returned `text/event-stream`, delivered the first chunk in ~2.0s, emitted 21 SSE data events, and ended with `[DONE]`.
- Non-streaming downstream request to `sp-anthropic/claude-sonnet-4-6` with high effort and a larger output budget returned both aggregated `reasoning_content` and final `content` in JSON.
- A SillyTavern-style non-streaming request to `sp-anthropic/claude-sonnet-4-6` with ~157.6k prompt tokens and 3440 output tokens completed with status `200` and persisted in call logs.
- A SillyTavern-style non-streaming request to `sp-anthropic/claude-opus-4-7` with ~158.0k prompt tokens and 7781 output tokens completed with status `200` and persisted in call logs.

`sp-anthropic/claude-haiku-4-5-20251001` currently returns an upstream 400 risk/fingerprint rejection even for a tiny probe, and `sp-anthropic/claude-haiku-4-5` currently returns an upstream 503 no-channel error. Those haiku failures happen before OmniRoute aggregation and are not treated as failures of this fix.
