### PR TITLE
feat(providers): add Astraflow (UCloud) OpenAI-compatible provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### ✨ New Features
 
-_TBD_
+- **feat(providers):** add Astraflow (UCloud) as an OpenAI-compatible (API-key) provider with global and China endpoints. (thanks @ucloudnb666)
 
 ### 🔧 Bug Fixes
 

--- a/open-sse/config/providers/index.ts
+++ b/open-sse/config/providers/index.ts
@@ -91,6 +91,8 @@ import { perplexityProvider } from "./registry/perplexity/index.ts";
 import { perplexity_webProvider } from "./registry/perplexity/web/index.ts";
 import { minimaxProvider } from "./registry/minimax/index.ts";
 import { minimax_cnProvider } from "./registry/minimax/cn/index.ts";
+import { astraflowProvider } from "./registry/astraflow/index.ts";
+import { astraflow_cnProvider } from "./registry/astraflow-cn/index.ts";
 import { haiperProvider } from "./registry/haiper/index.ts";
 import { bytezProvider } from "./registry/bytez/index.ts";
 import { blackboxProvider } from "./registry/blackbox/index.ts";
@@ -262,6 +264,8 @@ export const REGISTRY: Record<string, RegistryEntry> = {
   "perplexity-web": perplexity_webProvider,
   minimax: minimaxProvider,
   "minimax-cn": minimax_cnProvider,
+  astraflow: astraflowProvider,
+  "astraflow-cn": astraflow_cnProvider,
   haiper: haiperProvider,
   bytez: bytezProvider,
   blackbox: blackboxProvider,

--- a/open-sse/config/providers/registry/astraflow-cn/index.ts
+++ b/open-sse/config/providers/registry/astraflow-cn/index.ts
@@ -1,0 +1,16 @@
+import type { RegistryEntry } from "../../shared.ts";
+
+// Astraflow (UCloud) — OpenAI-compatible platform, China endpoint.
+// Base URL is the vendor's inference domain (behind UCloud's edge WAF), not the
+// astraflow.ucloud.cn marketing site — verify at first use if it changes.
+export const astraflow_cnProvider: RegistryEntry = {
+  id: "astraflow-cn",
+  alias: "astraflow-cn",
+  format: "openai",
+  executor: "default",
+  baseUrl: "https://api.modelverse.cn/v1/chat/completions",
+  authType: "apikey",
+  authHeader: "bearer",
+  models: [],
+  passthroughModels: true,
+};

--- a/open-sse/config/providers/registry/astraflow/index.ts
+++ b/open-sse/config/providers/registry/astraflow/index.ts
@@ -1,0 +1,16 @@
+import type { RegistryEntry } from "../../shared.ts";
+
+// Astraflow (UCloud) — OpenAI-compatible platform, global endpoint.
+// Base URL is the vendor's inference domain (behind UCloud's edge WAF), not the
+// astraflow.ucloud-global.com marketing site — verify at first use if it changes.
+export const astraflowProvider: RegistryEntry = {
+  id: "astraflow",
+  alias: "astraflow",
+  format: "openai",
+  executor: "default",
+  baseUrl: "https://api-us-ca.umodelverse.ai/v1/chat/completions",
+  authType: "apikey",
+  authHeader: "bearer",
+  models: [],
+  passthroughModels: true,
+};

--- a/src/shared/constants/config.ts
+++ b/src/shared/constants/config.ts
@@ -13,6 +13,8 @@ export const PROVIDER_ENDPOINTS = {
   "kimi-coding-apikey": "https://api.kimi.com/coding/v1/messages",
   minimax: "https://api.minimax.io/anthropic/v1/messages",
   "minimax-cn": "https://api.minimaxi.com/anthropic/v1/messages",
+  astraflow: "https://api-us-ca.umodelverse.ai/v1/chat/completions",
+  "astraflow-cn": "https://api.modelverse.cn/v1/chat/completions",
   crof: "https://crof.ai/v1/chat/completions",
   zenmux: "https://zenmux.ai/api/v1/chat/completions",
   openadapter: "https://api.openadapter.in/v1/chat/completions",

--- a/src/shared/constants/providers/apikey/gateways.ts
+++ b/src/shared/constants/providers/apikey/gateways.ts
@@ -547,4 +547,32 @@ export const APIKEY_PROVIDERS_GATEWAYS = {
     apiHint:
       "TokenRouter exposes an OpenAI-compatible chat completions endpoint at https://api.tokenrouter.com/v1/chat/completions, plus a working /v1/models catalog. OmniRoute uses the OpenAI protocol.",
   },
+  astraflow: {
+    id: "astraflow",
+    alias: "astraflow",
+    name: "Astraflow",
+    icon: "cloud",
+    color: "#0052D9",
+    textIcon: "AF",
+    passthroughModels: true,
+    website: "https://astraflow.ucloud-global.com",
+    authHint:
+      "Use your Astraflow API key in Authorization: Bearer <key>. Fully OpenAI-compatible — global endpoint.",
+    apiHint:
+      "Astraflow by UCloud exposes an OpenAI-compatible chat completions endpoint at https://api-us-ca.umodelverse.ai/v1/chat/completions. OmniRoute uses the OpenAI protocol.",
+  },
+  "astraflow-cn": {
+    id: "astraflow-cn",
+    alias: "astraflow-cn",
+    name: "Astraflow (China)",
+    icon: "cloud",
+    color: "#0052D9",
+    textIcon: "AFC",
+    passthroughModels: true,
+    website: "https://astraflow.ucloud.cn",
+    authHint:
+      "Use your Astraflow API key in Authorization: Bearer <key>. Fully OpenAI-compatible — China endpoint.",
+    apiHint:
+      "Astraflow by UCloud (China region) exposes an OpenAI-compatible chat completions endpoint at https://api.modelverse.cn/v1/chat/completions. OmniRoute uses the OpenAI protocol.",
+  },
 };

--- a/tests/unit/astraflow-provider.test.ts
+++ b/tests/unit/astraflow-provider.test.ts
@@ -1,0 +1,103 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { APIKEY_PROVIDERS } = await import("../../src/shared/constants/providers.ts");
+const { PROVIDER_ENDPOINTS } = await import("../../src/shared/constants/config.ts");
+const { REGISTRY: providerRegistry } = await import("../../open-sse/config/providerRegistry.ts");
+const { isValidModel } = await import("../../src/shared/constants/models.ts");
+
+const ASTRAFLOW_GLOBAL_URL = "https://api-us-ca.umodelverse.ai/v1/chat/completions";
+const ASTRAFLOW_CN_URL = "https://api.modelverse.cn/v1/chat/completions";
+
+test("Astraflow global + China metadata are registered as API-key providers", () => {
+  const global = APIKEY_PROVIDERS.astraflow;
+  const cn = APIKEY_PROVIDERS["astraflow-cn"];
+
+  assert.ok(global, "APIKEY_PROVIDERS.astraflow must be defined");
+  assert.ok(cn, "APIKEY_PROVIDERS['astraflow-cn'] must be defined");
+
+  assert.equal(global.id, "astraflow");
+  assert.equal(global.alias, "astraflow");
+  assert.equal(global.name, "Astraflow");
+  assert.equal(global.color, "#0052D9");
+  assert.equal(global.website, "https://astraflow.ucloud-global.com");
+  assert.equal(global.passthroughModels, true);
+
+  assert.equal(cn.id, "astraflow-cn");
+  assert.equal(cn.alias, "astraflow-cn");
+  assert.equal(cn.name, "Astraflow (China)");
+  assert.equal(cn.color, "#0052D9");
+  assert.equal(cn.website, "https://astraflow.ucloud.cn");
+  assert.equal(cn.passthroughModels, true);
+});
+
+test("Astraflow display endpoints point at the vendor inference domains", () => {
+  assert.equal(PROVIDER_ENDPOINTS.astraflow, ASTRAFLOW_GLOBAL_URL);
+  assert.equal(PROVIDER_ENDPOINTS["astraflow-cn"], ASTRAFLOW_CN_URL);
+});
+
+test("Astraflow registry entries resolve with OpenAI format + bearer API-key auth", () => {
+  const global = providerRegistry.astraflow;
+  const cn = providerRegistry["astraflow-cn"];
+
+  assert.ok(global, "providerRegistry.astraflow must be defined");
+  assert.ok(cn, "providerRegistry['astraflow-cn'] must be defined");
+
+  for (const entry of [global, cn]) {
+    assert.equal(entry.format, "openai");
+    assert.equal(entry.executor, "default");
+    assert.equal(entry.authType, "apikey");
+    assert.equal(entry.authHeader, "bearer");
+    assert.equal(entry.passthroughModels, true);
+    assert.deepEqual(entry.models, [], "passthrough providers ship an empty seed list");
+  }
+
+  assert.equal(global.id, "astraflow");
+  assert.equal(global.baseUrl, ASTRAFLOW_GLOBAL_URL);
+  assert.equal(cn.id, "astraflow-cn");
+  assert.equal(cn.baseUrl, ASTRAFLOW_CN_URL);
+  assert.notEqual(global.baseUrl, cn.baseUrl, "global and CN endpoints must differ");
+});
+
+test("Astraflow accepts arbitrary catalog models via passthrough", () => {
+  assert.equal(isValidModel("astraflow", "gpt-4o"), true);
+  assert.equal(isValidModel("astraflow", "anthropic/claude-sonnet-4"), true);
+  assert.equal(isValidModel("astraflow-cn", "gpt-4o"), true);
+});
+
+test("Astraflow / astraflow-cn mirror the minimax / minimax-cn global+CN pair structure", () => {
+  const minimax = providerRegistry.minimax;
+  const minimaxCn = providerRegistry["minimax-cn"];
+  const astraflow = providerRegistry.astraflow;
+  const astraflowCn = providerRegistry["astraflow-cn"];
+
+  assert.ok(minimax && minimaxCn, "minimax pair must exist as the reference pattern");
+
+  // Same shape: both pairs expose a global entry and a distinctly-aliased CN entry.
+  assert.equal(minimaxCn.id, "minimax-cn");
+  assert.equal(astraflowCn.id, "astraflow-cn");
+  assert.notEqual(minimax.baseUrl, minimaxCn.baseUrl, "minimax pair uses distinct base URLs");
+  assert.notEqual(
+    astraflow.baseUrl,
+    astraflowCn.baseUrl,
+    "astraflow pair uses distinct base URLs, mirroring minimax/minimax-cn"
+  );
+
+  // Both members of a pair share the same protocol format and auth wiring.
+  assert.equal(minimax.format, minimaxCn.format);
+  assert.equal(minimax.authType, minimaxCn.authType);
+  assert.equal(minimax.authHeader, minimaxCn.authHeader);
+  assert.equal(astraflow.format, astraflowCn.format);
+  assert.equal(astraflow.authType, astraflowCn.authType);
+  assert.equal(astraflow.authHeader, astraflowCn.authHeader);
+
+  // Gateway metadata pairs (APIKEY_PROVIDERS) also mirror the CN-suffix alias convention.
+  const minimaxMeta = APIKEY_PROVIDERS.minimax;
+  const minimaxCnMeta = APIKEY_PROVIDERS["minimax-cn"];
+  const astraflowMeta = APIKEY_PROVIDERS.astraflow;
+  const astraflowCnMeta = APIKEY_PROVIDERS["astraflow-cn"];
+  assert.ok(minimaxMeta && minimaxCnMeta, "minimax gateway metadata pair must exist");
+  assert.equal(minimaxCnMeta.alias, "minimax-cn");
+  assert.equal(astraflowCnMeta.alias, "astraflow-cn");
+  assert.equal(astraflowMeta.alias, "astraflow");
+});


### PR DESCRIPTION
## Summary
- Adds **Astraflow (UCloud)** as an OpenAI-compatible, BYOK API-key provider pair: `astraflow` (global) and `astraflow-cn` (China), following the existing `minimax`/`minimax-cn` global+CN pattern.
- Both entries use `passthroughModels: true` with an empty seed model list (no fixed catalog; matches the vendor's "OpenAI-compatible platform" positioning without hardcoding a specific model count).
- Auth: bearer API key, `format: "openai"`, `executor: "default"`.

## Base URL note
Base URLs are the vendor's inference domains (resolved behind UCloud's own edge WAF, `*.uewaf.com`), not the `astraflow.ucloud-global.com` / `astraflow.ucloud.cn` marketing sites:
- Global: `https://api-us-ca.umodelverse.ai/v1/chat/completions`
- China: `https://api.modelverse.cn/v1/chat/completions`

Both domains resolve via DNS to UCloud WAF infrastructure, which is a strong signal they are legitimate UCloud-operated endpoints. Direct HTTP validation could not be completed from this sandbox (no outbound network egress to arbitrary hosts). **Best-effort — verify at first use.**

## Attribution
Thanks to [@ucloudnb666](https://github.com/ucloudnb666)

## Changes
- `src/shared/constants/providers/apikey/gateways.ts` — `astraflow` + `astraflow-cn` gateway metadata (color `#0052D9`, websites).
- `open-sse/config/providers/registry/astraflow/index.ts` + `open-sse/config/providers/registry/astraflow-cn/index.ts` — registry entries.
- `open-sse/config/providers/index.ts` — wires both entries into the registry map.
- `src/shared/constants/config.ts` — `PROVIDER_ENDPOINTS` display entries for both.
- `CHANGELOG.md` — `[3.8.44]` New Features entry.
- `tests/unit/astraflow-provider.test.ts` — new test file.

## Test plan
- [x] `node --import tsx/esm scripts/check/check-provider-consistency.ts` → OK (173 REGISTRY entries, 245 canonical providers, 0 exceptions)
- [x] `node --import tsx/esm --test tests/unit/astraflow-provider.test.ts` → 5/5 passing
- [x] `npm run typecheck:core` → clean
- [x] `npm run check:cycles` → OK, no cycles