### PR TITLE
fix(api): guard shared API client against non-JSON error responses

### DIFF
--- a/src/shared/utils/api.ts
+++ b/src/shared/utils/api.ts
@@ -96,10 +96,10 @@ export function getErrorMessage(
 }
 
 async function handleResponse(response: Response) {
-  const data = await response.json();
+  const data = await parseResponseBody(response);
 
   if (!response.ok) {
-    const error: any = new Error(data.error || "An error occurred");
+    const error: any = new Error(getErrorMessage(data, response.status, "An error occurred"));
     error.status = response.status;
     error.data = data;
     throw error;

--- a/tests/unit/shared-api-utils.test.ts
+++ b/tests/unit/shared-api-utils.test.ts
@@ -109,3 +109,22 @@ test("shared api utils throw enriched errors for non-OK responses", async () => 
     }
   );
 });
+
+test("shared api utils throw a clean error for non-JSON non-OK responses", async () => {
+  globalThis.fetch = async () =>
+    new Response("Bad Gateway", {
+      status: 502,
+      headers: { "Content-Type": "text/plain" },
+    });
+
+  await assert.rejects(
+    () => get("http://localhost/get"),
+    (error) => {
+      assert.ok(!(error instanceof SyntaxError), "must not be a raw JSON parse SyntaxError");
+      assert.match((error as any).message, /Bad Gateway/);
+      assert.equal((error as any).status, 502);
+      assert.equal((error as any).data, "Bad Gateway");
+      return true;
+    }
+  );
+});


### PR DESCRIPTION
## Summary

- The internal `handleResponse()` in `src/shared/utils/api.ts` (used by the exported `get`/`post`/`put`/`del`/default `api`) still called `response.json()` raw, so a non-JSON error body (e.g. a `502 text/plain` response) crashed with a `SyntaxError` instead of surfacing a clean error to callers.
- The already-fixed OAuth call sites (`OAuthModal.tsx` / `oauthBlobSubmit.ts`) already use the `parseResponseBody`/`getErrorMessage` helpers defined in the same file — `handleResponse()` was the one remaining raw-`.json()` call site.
- Fix: `handleResponse()` now reuses `parseResponseBody`/`getErrorMessage`, so any non-JSON non-OK response degrades to a clean `Error` (with `.status`/`.data`) instead of throwing a raw `SyntaxError`.

Thanks to [@Delcado19](https://github.com/Delcado19) for the original implementation.

## Test plan

- [x] TDD: added a failing test to `tests/unit/shared-api-utils.test.ts` mocking `fetch` to return a non-JSON `502 text/plain` response; confirmed it failed with a raw `SyntaxError` on unpatched code, then confirmed it passes after the fix.
- [x] `node --import tsx/esm --test tests/unit/shared-api-utils.test.ts` — 3/3 passing
- [x] `npm run typecheck:core` — clean
- [x] `npm run check:cycles` — no cycles
