### PR TITLE
fix(embeddings): forward connection-level proxy to embedding requests

### DIFF
--- a/src/lib/embeddings/service.ts
+++ b/src/lib/embeddings/service.ts
@@ -12,6 +12,8 @@ import * as log from "@/sse/utils/logger";
 import { toJsonErrorPayload } from "@/shared/utils/upstreamError";
 import { getProviderCredentials, clearRecoveredProviderState } from "@/sse/services/auth";
 import { getProviderNodes, getComboByName, getCombos, getDatabaseSettings } from "@/lib/localDb";
+import { resolveProxyForConnection } from "@/lib/db/settings";
+import { runWithProxyContext } from "@omniroute/open-sse/utils/proxyFetch.ts";
 import { handleComboChat } from "@omniroute/open-sse/services/combo.ts";
 import { resolveBareModelToConnectionDefault } from "@omniroute/open-sse/services/model.ts";
 import { findEmbeddingComboDimensionConflict } from "./familyGuard";
@@ -220,20 +222,41 @@ export async function createEmbeddingResponse(
     connectionDefaultModel
   );
 
-  const result = await handleEmbedding({
-    body: effectiveModel !== resolvedModel ? { ...body, model: `${provider}/${effectiveModel}` } : body,
-    // getProviderCredentials returns a richer connection object; handleEmbedding
-    // only reads apiKey/accessToken, both present at runtime. Bridge the wider
-    // selection type to the handler's narrow credential shape.
-    credentials: credentials as { apiKey?: string; accessToken?: string } | null,
-    log,
-    resolvedProvider: providerConfig,
-    resolvedModel: effectiveModel,
-    clientRawRequest: options.clientRawRequest || null,
-    apiKeyId: options.apiKeyId || null,
-    apiKeyName: options.apiKeyName || null,
-    connectionId: options.connectionId || null,
-  });
+  // Resolve the connection-level proxy so the upstream embedding request honors
+  // the same per-connection pinning as chat, image generation, and count_tokens
+  // (#1904-style behavior). Without this, embeddings silently fall back to the
+  // global/env proxy and ignore a connection's pinned proxy. Ported from
+  // upstream decolua/9router#1701.
+  let proxyInfo: Awaited<ReturnType<typeof resolveProxyForConnection>> | null = null;
+  const connectionIdForProxy = (credentials as { connectionId?: string } | null)?.connectionId;
+  if (connectionIdForProxy) {
+    try {
+      proxyInfo = await resolveProxyForConnection(connectionIdForProxy);
+    } catch (err) {
+      log.error("EMBED", `Failed to resolve proxy for connection ${connectionIdForProxy}: ${err}`);
+    }
+  }
+
+  const runEmbedding = () =>
+    handleEmbedding({
+      body:
+        effectiveModel !== resolvedModel ? { ...body, model: `${provider}/${effectiveModel}` } : body,
+      // getProviderCredentials returns a richer connection object; handleEmbedding
+      // only reads apiKey/accessToken, both present at runtime. Bridge the wider
+      // selection type to the handler's narrow credential shape.
+      credentials: credentials as { apiKey?: string; accessToken?: string } | null,
+      log,
+      resolvedProvider: providerConfig,
+      resolvedModel: effectiveModel,
+      clientRawRequest: options.clientRawRequest || null,
+      apiKeyId: options.apiKeyId || null,
+      apiKeyName: options.apiKeyName || null,
+      connectionId: options.connectionId || null,
+    });
+
+  const result = connectionIdForProxy
+    ? await runWithProxyContext(proxyInfo?.proxy || null, runEmbedding)
+    : await runEmbedding();
 
   const responseHeaders = new Headers(result.headers);
 

--- a/tests/unit/embeddings-proxy-forwarding.test.ts
+++ b/tests/unit/embeddings-proxy-forwarding.test.ts
@@ -1,0 +1,110 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import http from "node:http";
+
+// Isolate the DB to a temp dir BEFORE importing any module that opens it.
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-embed-proxy-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const providersDb = await import("../../src/lib/db/providers.ts");
+const settingsDb = await import("../../src/lib/db/settings.ts");
+const { createEmbeddingResponse } = await import("../../src/lib/embeddings/service.ts");
+const { resolveProxyForRequest } = await import("../../open-sse/utils/proxyFetch.ts");
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+async function withHttpServer(handler: http.RequestListener, fn: (baseUrl: string) => Promise<void>) {
+  const server = http.createServer(handler);
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+  try {
+    await fn(`http://127.0.0.1:${(address as { port: number }).port}`);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    });
+  }
+}
+
+test("embeddings forward the connection-level (key) pinned proxy to the upstream fetch", async () => {
+  // T14 Proxy Fast-Fail performs a real TCP reachability check before running
+  // the request inside the proxy context, so the "proxy" must be a real,
+  // reachable local listener (its actual response body is irrelevant here —
+  // the assertion is about which proxy context the upstream fetch observes).
+  await withHttpServer(
+    (_req, res) => {
+      res.writeHead(200);
+      res.end("ok");
+    },
+    async (proxyBaseUrl) => {
+      const proxyUrl = new URL(proxyBaseUrl);
+
+      const connection = await providersDb.createProviderConnection({
+        provider: "mistral",
+        authType: "apikey",
+        name: "Test Mistral Proxy",
+        apiKey: "mistral-test-key",
+      });
+
+      // Pin a proxy at the connection ("key") level — the most specific level,
+      // exactly like a user would configure per-connection in the dashboard.
+      await settingsDb.setProxyForLevel("key", (connection as any).id, {
+        type: "http",
+        host: proxyUrl.hostname,
+        port: Number(proxyUrl.port),
+      });
+
+      let capturedProxySource: string | null = null;
+      let capturedProxyUrl: string | null = null;
+
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = async (input: RequestInfo | URL) => {
+        const targetUrl = typeof input === "string" ? input : (input as URL).toString();
+        const resolved = resolveProxyForRequest(targetUrl);
+        capturedProxySource = resolved.source;
+        capturedProxyUrl = resolved.proxyUrl;
+        return new Response(
+          JSON.stringify({
+            data: [{ object: "embedding", embedding: [0.1, 0.2], index: 0 }],
+            usage: { prompt_tokens: 3, total_tokens: 3 },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        );
+      };
+
+      try {
+        const res = await createEmbeddingResponse({
+          model: "mistral/mistral-embed",
+          input: "hello world",
+        });
+        assert.equal(res.status, 200, "embedding request should succeed");
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+
+      // The upstream fetch must have run inside the AsyncLocalStorage proxy
+      // context carrying the connection's pinned proxy — not "direct" (no
+      // context) and not the env-var proxy fallback.
+      assert.equal(
+        capturedProxySource,
+        "context",
+        `expected the embeddings upstream fetch to run inside a proxy context, got source="${capturedProxySource}"`
+      );
+      assert.ok(
+        capturedProxyUrl && capturedProxyUrl.includes(`${proxyUrl.hostname}:${proxyUrl.port}`),
+        `expected the connection's pinned proxy to be forwarded, got "${capturedProxyUrl}"`
+      );
+    }
+  );
+});


### PR DESCRIPTION
## Summary

- `/v1/embeddings` requests ignored a connection's pinned proxy: chat (`src/sse/handlers/chatHelpers.ts`), image generation (`src/app/api/v1/images/generations/route.ts`), and `count_tokens` all wrap the upstream fetch in `runWithProxyContext(proxyInfo?.proxy || null, ...)`, but `createEmbeddingResponse()` called `handleEmbedding()` directly — so embedding requests silently fell back to the global/env proxy regardless of the connection's configured proxy.
- Resolve the connection's proxy via `resolveProxyForConnection()` (the same helper used by the image-generation route) and wrap the `handleEmbedding()` call in `runWithProxyContext()`, mirroring the existing pattern.

Thanks to [@nic562](https://github.com/nic562) for the original implementation.

## Test plan

- [x] TDD: `tests/unit/embeddings-proxy-forwarding.test.ts` — pins a connection-level proxy (backed by a real local TCP listener, required by the T14 Proxy Fast-Fail reachability check), asserts the embeddings upstream fetch runs inside a `"context"` proxy source matching that connection. Confirmed **red** (`source="direct"`) before the fix, **green** after.
- [x] `node --import tsx/esm --test tests/unit/embeddings-proxy-forwarding.test.ts`
- [x] Existing embeddings suites unaffected: `embeddings-cost-telemetry-headers`, `embeddings-handler`, `embeddings-auth`, `embeddings-combo-dimensions`, `embeddings-combo-family-reject`, `embeddings-gemini-dimensions`, `embeddings-nvidia-input-type` — all pass.
- [x] `npm run typecheck:core`
- [x] `npm run check:cycles`
