### PR TITLE
refactor(executors): extract pure stream formatters from deepseek-web (1147→1108)

### DIFF
--- a/open-sse/executors/deepseek-web.ts
+++ b/open-sse/executors/deepseek-web.ts
@@ -7,6 +7,13 @@ import {
   buildToolConversationPrompt,
 } from "../translator/deepseekWebTools.ts";
 import { sanitizeErrorMessage } from "../utils/error.ts";
+import {
+  isThinkingModel,
+  isSearchModel,
+  formatStreamContent,
+  appendSearchCitations,
+  type DeepSeekSearchResult,
+} from "./deepseek-web/stream-format.ts";
 
 export const DEEPSEEK_WEB_BASE = "https://chat.deepseek.com";
 const DEEPSEEK_API_BASE = `${DEEPSEEK_WEB_BASE}/api`;
@@ -143,46 +150,6 @@ async function solvePow(challenge: PowChallenge): Promise<string> {
 }
 
 // ── SSE Transform (DeepSeek → OpenAI) ───────────────────────────────────
-
-function isThinkingModel(model: string): boolean {
-  const m = model.toLowerCase();
-  return m.includes("think") || m.includes("r1") || m.includes("reason");
-}
-
-function isSearchModel(model: string): boolean {
-  const m = model.toLowerCase();
-  return m.includes("search") || m.includes("fold");
-}
-
-function cleanDeepSeekToken(text: string): string {
-  return text.replace(/FINISHED/g, "").replace(/^(SEARCH|WEB_SEARCH|SEARCHING)\s*/i, "");
-}
-
-function formatStreamContent(raw: string, model: string): string {
-  let text = cleanDeepSeekToken(raw);
-  if (!isSearchModel(model)) return text;
-  if (model.toLowerCase().includes("search-silent")) {
-    return text.replace(/\[citation:(\d+)\]/g, "");
-  }
-  return text.replace(/\[citation:(\d+)\]/g, "[$1]");
-}
-
-interface DeepSeekSearchResult {
-  cite_index?: number;
-  title?: string;
-  url?: string;
-}
-
-function appendSearchCitations(searchResults: DeepSeekSearchResult[], model: string): string {
-  if (searchResults.length === 0 || model.toLowerCase().includes("search-silent")) {
-    return "";
-  }
-  return searchResults
-    .filter((r) => r.cite_index)
-    .sort((a, b) => (a.cite_index || 0) - (b.cite_index || 0))
-    .map((r) => `[${r.cite_index}]: [${r.title}](${r.url})`)
-    .join("\n");
-}
 
 function transformSSE(deepseekStream: ReadableStream, model: string): ReadableStream {
   const encoder = new TextEncoder();

--- a/open-sse/executors/deepseek-web/stream-format.ts
+++ b/open-sse/executors/deepseek-web/stream-format.ts
@@ -1,0 +1,44 @@
+// Pure DeepSeek stream content/citation formatting. Verbatim from deepseek-web.ts.
+
+export function isThinkingModel(model: string): boolean {
+  const m = model.toLowerCase();
+  return m.includes("think") || m.includes("r1") || m.includes("reason");
+}
+
+export function isSearchModel(model: string): boolean {
+  const m = model.toLowerCase();
+  return m.includes("search") || m.includes("fold");
+}
+
+export function cleanDeepSeekToken(text: string): string {
+  return text.replace(/FINISHED/g, "").replace(/^(SEARCH|WEB_SEARCH|SEARCHING)\s*/i, "");
+}
+
+export function formatStreamContent(raw: string, model: string): string {
+  let text = cleanDeepSeekToken(raw);
+  if (!isSearchModel(model)) return text;
+  if (model.toLowerCase().includes("search-silent")) {
+    return text.replace(/\[citation:(\d+)\]/g, "");
+  }
+  return text.replace(/\[citation:(\d+)\]/g, "[$1]");
+}
+
+export interface DeepSeekSearchResult {
+  cite_index?: number;
+  title?: string;
+  url?: string;
+}
+
+export function appendSearchCitations(
+  searchResults: DeepSeekSearchResult[],
+  model: string
+): string {
+  if (searchResults.length === 0 || model.toLowerCase().includes("search-silent")) {
+    return "";
+  }
+  return searchResults
+    .filter((r) => r.cite_index)
+    .sort((a, b) => (a.cite_index || 0) - (b.cite_index || 0))
+    .map((r) => `[${r.cite_index}]: [${r.title}](${r.url})`)
+    .join("\n");
+}

--- a/tests/unit/deepseek-web-executor-split.test.ts
+++ b/tests/unit/deepseek-web-executor-split.test.ts
@@ -1,0 +1,34 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+// Split-guard for the deepseek-web executor stream-format extraction.
+// The pure content/citation formatters live in deepseek-web/stream-format.ts
+// (module-private; host imports them into transformSSE/collectSSEContent).
+const HERE = dirname(fileURLToPath(import.meta.url));
+const EXE = join(HERE, "../../open-sse/executors");
+const HOST = join(EXE, "deepseek-web.ts");
+const LEAF = join(EXE, "deepseek-web/stream-format.ts");
+
+test("leaf hosts the formatters and does not import the host", () => {
+  const src = readFileSync(LEAF, "utf8");
+  for (const sym of ["formatStreamContent", "appendSearchCitations", "isThinkingModel"]) {
+    assert.match(src, new RegExp(`export function ${sym}\\b`));
+  }
+  assert.doesNotMatch(src, /from "\.\.\/deepseek-web\.ts"/);
+});
+
+test("host imports the formatters back from the leaf", () => {
+  const host = readFileSync(HOST, "utf8");
+  assert.match(host, /from "\.\/deepseek-web\/stream-format\.ts"/);
+});
+
+test("formatStreamContent + model classifiers behave", async () => {
+  const { isThinkingModel, isSearchModel, formatStreamContent } =
+    await import("../../open-sse/executors/deepseek-web/stream-format.ts");
+  assert.equal(typeof isThinkingModel("deepseek-reasoner"), "boolean");
+  assert.equal(typeof isSearchModel("deepseek-search"), "boolean");
+  assert.equal(typeof formatStreamContent("hi", "deepseek-chat"), "string");
+});


### PR DESCRIPTION
## O quê

Campanha god-files (Bloco **H3**, executores). Extrai os formatters puros de conteúdo/citação de `deepseek-web.ts` p/ o leaf `deepseek-web/stream-format.ts`:

- `isThinkingModel`, `isSearchModel`, `cleanDeepSeekToken`, `formatStreamContent`, `DeepSeekSearchResult`, `appendSearchCitations`.

Host importa os 5 que usa de volta (em `transformSSE`/`collectSSEContent`; `cleanDeepSeekToken` fica interno ao leaf). PoW/auth/token-cache/dispatch HTTP intactos.

## Por quê

- Host **1147 → 1108 LOC**.
- **Zero mudança de comportamento**: corpos byte-idênticos (verbatim 34/34), leaf sem imports (sem ciclo), module-private (sem re-export).

## Validação

- `typecheck:core` ✅ · `check:cycles` ✅ · `check:file-size` ✅ · eslint (0 errors) / prettier ✅
- Testes consumidores verdes: deepseek-web (35), deepseek-web-rolling-window-2942 (5), deepseek-web-tools-execute (3)
- **Split-guard novo** `deepseek-web-executor-split.test.ts` (3)