### PR TITLE
fix(registry): flag cline-pass/minimax-m3 as multimodal (supportsVision) — unblocks LEDGER-4 base-red

### DIFF
--- a/open-sse/config/providers/registry/clinepass/index.ts
+++ b/open-sse/config/providers/registry/clinepass/index.ts
@@ -34,7 +34,7 @@ export const clinepassProvider: RegistryEntry = {
     },
     { id: "cline-pass/mimo-v2.5", name: "MiMo-V2.5 (ClinePass)" },
     { id: "cline-pass/mimo-v2.5-pro", name: "MiMo-V2.5-Pro (ClinePass)" },
-    { id: "cline-pass/minimax-m3", name: "MiniMax M3 (ClinePass)" },
+    { id: "cline-pass/minimax-m3", name: "MiniMax M3 (ClinePass)", supportsVision: true },
     { id: "cline-pass/qwen3.7-max", name: "Qwen3.7 Max (ClinePass)" },
     { id: "cline-pass/qwen3.7-plus", name: "Qwen3.7 Plus (ClinePass)" },
   ],


### PR DESCRIPTION
## O quê

O provider `cline-pass` tinha a entry `cline-pass/minimax-m3` **sem `supportsVision`**, quebrando o teste de consistência **LEDGER-4** (`tests/unit/review-reviews-v3814-fixes.test.ts`): *all minimax-m3 registry entries set supportsVision (matches lite.ts)* — minimax-m3 é multimodal.

Todas as outras entries minimax-m3 (trae, bazaarlink, cline, ollama-cloud, ...) já setam `supportsVision: true`.

## Por quê

Este era um **base-red na `release/v3.8.44`** herdado por **todas** as PRs abertas (forçava merge com `--admin`). Corrigindo, a CI volta a ficar verde no shard Unit 2/2.

## Validação (Hard Rule #18)

Bug fix validado pelo **teste existente falhando→passando** (LEDGER-4): antes acusava `these minimax-m3 entries miss supportsVision: cline-pass/minimax-m3`, agora passa. `typecheck:core` ✅ · eslint/prettier ✅. Fix cirúrgico (1 campo).