### PR TITLE
refactor(executors): extract pure EventStream framing from kiro (943→758)

### DIFF
--- a/open-sse/executors/kiro.ts
+++ b/open-sse/executors/kiro.ts
@@ -8,7 +8,12 @@ import {
 import { PROVIDERS } from "../config/constants.ts";
 import { v4 as uuidv4 } from "uuid";
 import { refreshKiroToken } from "../services/tokenRefresh.ts";
-import { splitInlineThinking, flushPendingThinking, type KiroThinkingState } from "./kiroThinking.ts";
+import {
+  splitInlineThinking,
+  flushPendingThinking,
+  type KiroThinkingState,
+} from "./kiroThinking.ts";
+import { ByteQueue, TEXT_ENCODER, parseEventFrame } from "./kiro/eventstream.ts";
 
 type JsonRecord = Record<string, unknown>;
 
@@ -40,97 +45,6 @@ type KiroStreamState = {
   // Inline-thinking splitter state (populated only when thinkingExpected=true).
   thinking?: KiroThinkingState;
 };
-
-type EventFrame = {
-  headers: Record<string, string>;
-  payload: JsonRecord | null;
-};
-
-class ByteQueue {
-  private chunks: Uint8Array[] = [];
-  private headOffset = 0;
-  length = 0;
-
-  push(chunk: Uint8Array) {
-    if (!(chunk instanceof Uint8Array) || chunk.length === 0) return;
-    this.chunks.push(chunk);
-    this.length += chunk.length;
-  }
-
-  peekUint32BE(offset = 0): number | null {
-    if (this.length < offset + 4) return null;
-
-    let value = 0;
-    for (let i = 0; i < 4; i++) {
-      value = (value << 8) | this.byteAt(offset + i);
-    }
-    return value >>> 0;
-  }
-
-  read(length: number): Uint8Array | null {
-    if (length < 0 || this.length < length) return null;
-
-    const output = new Uint8Array(length);
-    let written = 0;
-
-    while (written < length) {
-      const head = this.chunks[0];
-      const available = head.length - this.headOffset;
-      const take = Math.min(available, length - written);
-      output.set(head.subarray(this.headOffset, this.headOffset + take), written);
-      written += take;
-      this.headOffset += take;
-      this.length -= take;
-
-      if (this.headOffset >= head.length) {
-        this.chunks.shift();
-        this.headOffset = 0;
-      }
-    }
-
-    return output;
-  }
-
-  private byteAt(offset: number): number {
-    let remaining = offset;
-    for (let i = 0; i < this.chunks.length; i++) {
-      const chunk = this.chunks[i];
-      const start = i === 0 ? this.headOffset : 0;
-      const available = chunk.length - start;
-      if (remaining < available) {
-        return chunk[start + remaining];
-      }
-      remaining -= available;
-    }
-    return 0;
-  }
-}
-
-// ── CRC32 lookup table (IEEE polynomial, no dependency) ──
-const CRC32_TABLE = new Uint32Array(256);
-const TEXT_ENCODER = new TextEncoder();
-const TEXT_DECODER = new TextDecoder();
-for (let i = 0; i < 256; i++) {
-  let c = i;
-  for (let j = 0; j < 8; j++) {
-    c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
-  }
-  CRC32_TABLE[i] = c >>> 0;
-}
-
-// Full per-frame message-CRC validation is O(frame bytes) and runs for EVERY frame of
-// every Kiro response on the main thread. The transport is TLS-protected and the 8-byte
-// prelude CRC already guards framing, so the full-message CRC is redundant overhead that
-// contributes to the CPU-runaway on large/long generations. Keep it opt-in for debugging.
-const KIRO_VERIFY_FULL_CRC = process.env.KIRO_VERIFY_FULL_CRC === "true";
-
-function crc32(buf: Uint8Array) {
-  let crc = 0xffffffff;
-  for (let i = 0; i < buf.length; i++) {
-    crc = CRC32_TABLE[(crc ^ buf[i]) & 0xff] ^ (crc >>> 8);
-  }
-  return (crc ^ 0xffffffff) >>> 0;
-}
 
 /**
  * Flush buffered tool arguments at finish boundaries.
@@ -354,16 +268,18 @@ export class KiroExecutor extends BaseExecutor {
     // channel.
     const tb = transformedBody as Record<string, unknown>;
     const userContent =
-      (
+      ((
         (
-          (
-            (tb?.conversationState as Record<string, unknown>)
-              ?.currentMessage as Record<string, unknown>
-          )?.userInputMessage as Record<string, unknown>
-        )?.content as string
-      ) || "";
+          (tb?.conversationState as Record<string, unknown>)?.currentMessage as Record<
+            string,
+            unknown
+          >
+        )?.userInputMessage as Record<string, unknown>
+      )?.content as string) || "";
     const thinkingExpected = userContent.includes("<thinking_mode>enabled</thinking_mode>");
-    const transformedResponse = this.transformEventStreamToSSE(response, model, { thinkingExpected });
+    const transformedResponse = this.transformEventStreamToSSE(response, model, {
+      thinkingExpected,
+    });
 
     return { response: transformedResponse, url, headers, transformedBody };
   }
@@ -494,7 +410,10 @@ export class KiroExecutor extends BaseExecutor {
                       choices: [
                         {
                           index: 0,
-                          delta: chunkIndex === 0 ? { role: "assistant", content: text } : { content: text },
+                          delta:
+                            chunkIndex === 0
+                              ? { role: "assistant", content: text }
+                              : { content: text },
                           finish_reason: null,
                         },
                       ],
@@ -840,103 +759,6 @@ export class KiroExecutor extends BaseExecutor {
       log?.error?.("TOKEN", `Kiro refresh error: ${err.message}`);
       return null;
     }
-  }
-}
-
-/**
- * Parse AWS EventStream frame
- */
-function parseEventFrame(data: Uint8Array): EventFrame | null {
-  try {
-    const view = new DataView(data.buffer, data.byteOffset);
-    const totalLength = view.getUint32(0, false);
-    const headersLength = view.getUint32(4, false);
-
-    // ── CRC32 validation ──
-    // Prelude CRC covers bytes [0..7] (totalLength + headersLength)
-    const preludeCRC = view.getUint32(8, false);
-    const computedPreludeCRC = crc32(data.slice(0, 8));
-    if (preludeCRC !== computedPreludeCRC) {
-      console.warn(
-        `[Kiro] Prelude CRC mismatch: expected ${preludeCRC}, got ${computedPreludeCRC} — skipping corrupted frame`
-      );
-      return null;
-    }
-
-    // Message CRC covers bytes [0..totalLength-5] (everything except the CRC itself).
-    // Skipped by default (O(frame bytes) per frame) — the prelude CRC above already
-    // validates framing and the stream is TLS-protected. Enable KIRO_VERIFY_FULL_CRC=true
-    // to restore full validation for debugging corrupted-stream issues.
-    if (KIRO_VERIFY_FULL_CRC) {
-      const messageCRC = view.getUint32(data.length - 4, false);
-      const computedMessageCRC = crc32(data.slice(0, data.length - 4));
-      if (messageCRC !== computedMessageCRC) {
-        console.warn(
-          `[Kiro] Message CRC mismatch: expected ${messageCRC}, got ${computedMessageCRC} — skipping corrupted frame`
-        );
-        return null;
-      }
-    }
-    // Parse headers
-    const headers: Record<string, string> = {};
-    let offset = 12; // After prelude
-    const headerEnd = 12 + headersLength;
-
-    while (offset < headerEnd && offset < data.length) {
-      const nameLen = data[offset];
-      offset++;
-      if (offset + nameLen > data.length) break;
-
-      const name = TEXT_DECODER.decode(data.subarray(offset, offset + nameLen));
-      offset += nameLen;
-
-      const headerType = data[offset];
-      offset++;
-
-      if (headerType === 7) {
-        // String type
-        const valueLen = (data[offset] << 8) | data[offset + 1];
-        offset += 2;
-        if (offset + valueLen > data.length) break;
-
-        const value = TEXT_DECODER.decode(data.subarray(offset, offset + valueLen));
-        offset += valueLen;
-        headers[name] = value;
-      } else {
-        break;
-      }
-    }
-
-    // Parse payload
-    const payloadStart = 12 + headersLength;
-    const payloadEnd = data.length - 4; // Exclude message CRC
-
-    let payload: JsonRecord | null = null;
-    if (payloadEnd > payloadStart) {
-      const payloadStr = TEXT_DECODER.decode(data.subarray(payloadStart, payloadEnd));
-
-      // Skip empty or whitespace-only payloads
-      if (!payloadStr || !payloadStr.trim()) {
-        return { headers, payload: null };
-      }
-
-      try {
-        payload = JSON.parse(payloadStr);
-      } catch (parseError) {
-        const err = parseError instanceof Error ? parseError : new Error(String(parseError));
-        // Log parse error for debugging
-        console.warn(
-          `[Kiro] Failed to parse payload: ${err.message} | payload: ${payloadStr.substring(0, 100)}`
-        );
-        payload = { raw: payloadStr };
-      }
-    }
-
-    return { headers, payload };
-  } catch (err) {
-    const error = err instanceof Error ? err : new Error(String(err));
-    console.warn(`[Kiro] Frame parse error: ${error.message}`);
-    return null;
   }
 }
 

--- a/open-sse/executors/kiro/eventstream.ts
+++ b/open-sse/executors/kiro/eventstream.ts
@@ -1,0 +1,192 @@
+// Pure AWS EventStream binary framing for Kiro (ByteQueue, CRC32, frame parsing).
+// Extracted verbatim from kiro.ts. Self-contained (local JsonRecord, no host imports).
+
+type JsonRecord = Record<string, unknown>;
+
+export type EventFrame = {
+  headers: Record<string, string>;
+  payload: JsonRecord | null;
+};
+
+export class ByteQueue {
+  private chunks: Uint8Array[] = [];
+  private headOffset = 0;
+  length = 0;
+
+  push(chunk: Uint8Array) {
+    if (!(chunk instanceof Uint8Array) || chunk.length === 0) return;
+    this.chunks.push(chunk);
+    this.length += chunk.length;
+  }
+
+  peekUint32BE(offset = 0): number | null {
+    if (this.length < offset + 4) return null;
+
+    let value = 0;
+    for (let i = 0; i < 4; i++) {
+      value = (value << 8) | this.byteAt(offset + i);
+    }
+    return value >>> 0;
+  }
+
+  read(length: number): Uint8Array | null {
+    if (length < 0 || this.length < length) return null;
+
+    const output = new Uint8Array(length);
+    let written = 0;
+
+    while (written < length) {
+      const head = this.chunks[0];
+      const available = head.length - this.headOffset;
+      const take = Math.min(available, length - written);
+      output.set(head.subarray(this.headOffset, this.headOffset + take), written);
+      written += take;
+      this.headOffset += take;
+      this.length -= take;
+
+      if (this.headOffset >= head.length) {
+        this.chunks.shift();
+        this.headOffset = 0;
+      }
+    }
+
+    return output;
+  }
+
+  private byteAt(offset: number): number {
+    let remaining = offset;
+    for (let i = 0; i < this.chunks.length; i++) {
+      const chunk = this.chunks[i];
+      const start = i === 0 ? this.headOffset : 0;
+      const available = chunk.length - start;
+      if (remaining < available) {
+        return chunk[start + remaining];
+      }
+      remaining -= available;
+    }
+    return 0;
+  }
+}
+
+// ── CRC32 lookup table (IEEE polynomial, no dependency) ──
+export const CRC32_TABLE = new Uint32Array(256);
+export const TEXT_ENCODER = new TextEncoder();
+export const TEXT_DECODER = new TextDecoder();
+for (let i = 0; i < 256; i++) {
+  let c = i;
+  for (let j = 0; j < 8; j++) {
+    c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+  }
+  CRC32_TABLE[i] = c >>> 0;
+}
+
+// Full per-frame message-CRC validation is O(frame bytes) and runs for EVERY frame of
+// every Kiro response on the main thread. The transport is TLS-protected and the 8-byte
+// prelude CRC already guards framing, so the full-message CRC is redundant overhead that
+// contributes to the CPU-runaway on large/long generations. Keep it opt-in for debugging.
+export const KIRO_VERIFY_FULL_CRC = process.env.KIRO_VERIFY_FULL_CRC === "true";
+
+export function crc32(buf: Uint8Array) {
+  let crc = 0xffffffff;
+  for (let i = 0; i < buf.length; i++) {
+    crc = CRC32_TABLE[(crc ^ buf[i]) & 0xff] ^ (crc >>> 8);
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+/**
+ * Parse AWS EventStream frame
+ */
+export function parseEventFrame(data: Uint8Array): EventFrame | null {
+  try {
+    const view = new DataView(data.buffer, data.byteOffset);
+    const totalLength = view.getUint32(0, false);
+    const headersLength = view.getUint32(4, false);
+
+    // ── CRC32 validation ──
+    // Prelude CRC covers bytes [0..7] (totalLength + headersLength)
+    const preludeCRC = view.getUint32(8, false);
+    const computedPreludeCRC = crc32(data.slice(0, 8));
+    if (preludeCRC !== computedPreludeCRC) {
+      console.warn(
+        `[Kiro] Prelude CRC mismatch: expected ${preludeCRC}, got ${computedPreludeCRC} — skipping corrupted frame`
+      );
+      return null;
+    }
+
+    // Message CRC covers bytes [0..totalLength-5] (everything except the CRC itself).
+    // Skipped by default (O(frame bytes) per frame) — the prelude CRC above already
+    // validates framing and the stream is TLS-protected. Enable KIRO_VERIFY_FULL_CRC=true
+    // to restore full validation for debugging corrupted-stream issues.
+    if (KIRO_VERIFY_FULL_CRC) {
+      const messageCRC = view.getUint32(data.length - 4, false);
+      const computedMessageCRC = crc32(data.slice(0, data.length - 4));
+      if (messageCRC !== computedMessageCRC) {
+        console.warn(
+          `[Kiro] Message CRC mismatch: expected ${messageCRC}, got ${computedMessageCRC} — skipping corrupted frame`
+        );
+        return null;
+      }
+    }
+    // Parse headers
+    const headers: Record<string, string> = {};
+    let offset = 12; // After prelude
+    const headerEnd = 12 + headersLength;
+
+    while (offset < headerEnd && offset < data.length) {
+      const nameLen = data[offset];
+      offset++;
+      if (offset + nameLen > data.length) break;
+
+      const name = TEXT_DECODER.decode(data.subarray(offset, offset + nameLen));
+      offset += nameLen;
+
+      const headerType = data[offset];
+      offset++;
+
+      if (headerType === 7) {
+        // String type
+        const valueLen = (data[offset] << 8) | data[offset + 1];
+        offset += 2;
+        if (offset + valueLen > data.length) break;
+
+        const value = TEXT_DECODER.decode(data.subarray(offset, offset + valueLen));
+        offset += valueLen;
+        headers[name] = value;
+      } else {
+        break;
+      }
+    }
+
+    // Parse payload
+    const payloadStart = 12 + headersLength;
+    const payloadEnd = data.length - 4; // Exclude message CRC
+
+    let payload: JsonRecord | null = null;
+    if (payloadEnd > payloadStart) {
+      const payloadStr = TEXT_DECODER.decode(data.subarray(payloadStart, payloadEnd));
+
+      // Skip empty or whitespace-only payloads
+      if (!payloadStr || !payloadStr.trim()) {
+        return { headers, payload: null };
+      }
+
+      try {
+        payload = JSON.parse(payloadStr);
+      } catch (parseError) {
+        const err = parseError instanceof Error ? parseError : new Error(String(parseError));
+        // Log parse error for debugging
+        console.warn(
+          `[Kiro] Failed to parse payload: ${err.message} | payload: ${payloadStr.substring(0, 100)}`
+        );
+        payload = { raw: payloadStr };
+      }
+    }
+
+    return { headers, payload };
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    console.warn(`[Kiro] Frame parse error: ${error.message}`);
+    return null;
+  }
+}

--- a/tests/unit/kiro-eventstream-split.test.ts
+++ b/tests/unit/kiro-eventstream-split.test.ts
@@ -1,0 +1,35 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+// Split-guard for the kiro executor EventStream framing extraction.
+// The pure AWS EventStream binary framing (ByteQueue, CRC32, parseEventFrame) lives in
+// kiro/eventstream.ts (self-contained, no host imports). Host imports back what it uses.
+const HERE = dirname(fileURLToPath(import.meta.url));
+const EXE = join(HERE, "../../open-sse/executors");
+const HOST = join(EXE, "kiro.ts");
+const LEAF = join(EXE, "kiro/eventstream.ts");
+
+test("leaf hosts the framing primitives and does not import the host", () => {
+  const src = readFileSync(LEAF, "utf8");
+  assert.match(src, /export class ByteQueue\b/);
+  assert.match(src, /export function crc32\b/);
+  assert.match(src, /export function parseEventFrame\b/);
+  assert.doesNotMatch(src, /from "\.\.\/kiro\.ts"/);
+});
+
+test("host imports the framing primitives back from the leaf", () => {
+  const host = readFileSync(HOST, "utf8");
+  assert.match(host, /from "\.\/kiro\/eventstream\.ts"/);
+});
+
+test("crc32 is deterministic and ByteQueue buffers bytes", async () => {
+  const { crc32, ByteQueue } = await import("../../open-sse/executors/kiro/eventstream.ts");
+  const a = crc32(new Uint8Array([1, 2, 3]));
+  const b = crc32(new Uint8Array([1, 2, 3]));
+  assert.equal(a, b);
+  const q = new ByteQueue();
+  assert.equal(typeof q, "object");
+});


### PR DESCRIPTION
## O quê
Campanha god-files (Bloco **H3**, cauda). Extrai o framing binário puro AWS EventStream (`ByteQueue`, CRC32+`crc32`, `TEXT_ENCODER`/`TEXT_DECODER`, `parseEventFrame`, tipo `EventFrame`) de `kiro.ts` p/ o leaf self-contained `kiro/eventstream.ts` (`JsonRecord` local p/ evitar ciclo). Host importa de volta os 3 que usa; `flushBufferedToolArgs`/`resolveKiroRegion`/`kiroRuntimeHost` (test-imported) permanecem exportados no host.

## Por quê
- Host **943 → 758 LOC**.
- **Zero mudança de comportamento**: verbatim 145/145, leaf sem import do host (sem ciclo). Auth/token-refresh/streaming-state/class intactos.

## Validação
- `typecheck:core` ✅ · `check:cycles` ✅ · `check:file-size` ✅ · eslint/prettier ✅
- Testes consumidores verdes: executor-kiro (9), kiro-tool-args-streaming (7), kiro-iam-region (10)
- **Split-guard novo** (3)