### PR TITLE
test(cli): deflake setup-claude.test.ts — stop console/report stdout interleaving (#5959)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ _TBD_
 
 ### 📝 Maintenance
 
+- **test (deflake `setup-claude`):** `tests/unit/cli/setup-claude.test.ts` failed ~50% of runs with `Unable to deserialize cloned data due to invalid or unsupported version` at file teardown (all subtests passed), randomly reddening `Unit Tests fast-path (2/2)` / `Fast Quality Gates` across the PR→release queue. Root cause: `node --test` streams each file's report to the parent as V8-serialized frames on fd 1 (stdout), and the CLI helper under test (`syncClaudeProfilesFromModels`) prints progress via `console.log` — that stdout output interleaved with the serialized frames and corrupted the stream. The test now silences the stdout-writing `console` methods for the file's duration (no assertion inspects stdout), making it deterministic (15/15 green locally). ([#5959](https://github.com/diegosouzapw/OmniRoute/issues/5959))
+
 - **API validation:** add a `validatedJsonBody(request, schema)` helper in `src/shared/validation/helpers.ts` that fuses JSON body parsing and Zod validation into a single call, returning either the type-narrowed data or a ready-to-return 400 `NextResponse` with the standard error envelope. Salvaged from the closed refactor PR #5075 (Tier 1 portable helper) with a focused 6-case regression test. Co-authored-by: KooshaPari <KooshaPari@users.noreply.github.com>
 
 ---

--- a/tests/unit/cli/setup-claude.test.ts
+++ b/tests/unit/cli/setup-claude.test.ts
@@ -1,4 +1,4 @@
-import { test } from "node:test";
+import { test, before, after } from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs/promises";
 import os from "node:os";
@@ -9,6 +9,27 @@ import {
 } from "../../../bin/cli/commands/setup-claude.mjs";
 import { buildClaudeEnv, resolveLaunchTarget } from "../../../bin/cli/commands/launch.mjs";
 import { categoriseModel } from "../../../bin/cli/commands/setup-codex.mjs";
+
+// #5959 — deflake: `node --test` runs each file in a child process that streams
+// its report back to the parent as V8-serialized frames on fd 1 (stdout). The CLI
+// helpers under test (`syncClaudeProfilesFromModels`) print progress via
+// `console.log`, and that stdout output interleaves with the serialized frames,
+// corrupting the stream — the parent then throws
+// "Unable to deserialize cloned data due to invalid or unsupported version" at
+// file teardown ~50% of runs (all subtests pass; only the file errors). No test
+// here asserts on stdout, so silence the stdout-writing console methods for the
+// duration of this file. Restored in `after` for good hygiene.
+const _console = { log: console.log, info: console.info, warn: console.warn };
+before(() => {
+  console.log = () => {};
+  console.info = () => {};
+  console.warn = () => {};
+});
+after(() => {
+  console.log = _console.log;
+  console.info = _console.info;
+  console.warn = _console.warn;
+});
 
 // ── setup-claude profile generation ──────────────────────────────────────────
 


### PR DESCRIPTION
Closes #5959.

## Root cause
`node --test` runs each test file in a child process that streams its report to the parent as **V8-serialized frames on fd 1 (stdout)**. `syncClaudeProfilesFromModels` (exercised by two tests) prints progress via `console.log` — that stdout output interleaves with the serialized frames and intermittently corrupts the stream. The parent then throws `Unable to deserialize cloned data due to invalid or unsupported version` at file teardown (**all subtests pass**; only the file errors), reddening `Unit Tests fast-path (2/2)` / `Fast Quality Gates` at random across the PR→release queue.

## Fix
No test asserts on stdout, so silence `console.log/info/warn` for the file's duration (restored in `after`). Test-only; no production change.

## Proof (TDD / deflake)
- Before: ~6/10 runs fail on the pristine base (matches the issue's ~50%).
- After: **15/15 green** locally; 12/12 subtests pass, lint + prettier clean.