### PR TITLE
test(ci): collect orphaned executor tests (move to top-level)

### DIFF
--- a/tests/unit/executor-firecrawl-fetch.test.ts
+++ b/tests/unit/executor-firecrawl-fetch.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-const { firecrawlFetch } = await import("../../../open-sse/executors/firecrawl-fetch.ts");
+const { firecrawlFetch } = await import("../../open-sse/executors/firecrawl-fetch.ts");
 
 // ── #2253 (decolua/9router): self-hosted Firecrawl support ────────────────────
 // FIRECRAWL_BASE_URL lets operators point the executor at a self-hosted instance.

--- a/tests/unit/executor-xai.test.ts
+++ b/tests/unit/executor-xai.test.ts
@@ -1,9 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { XaiExecutor } from "../../../open-sse/executors/xai.ts";
-import { getExecutor, hasSpecializedExecutor } from "../../../open-sse/executors/index.ts";
-import { xaiProvider } from "../../../open-sse/config/providers/registry/xai/index.ts";
+import { XaiExecutor } from "../../open-sse/executors/xai.ts";
+import { getExecutor, hasSpecializedExecutor } from "../../open-sse/executors/index.ts";
+import { xaiProvider } from "../../open-sse/config/providers/registry/xai/index.ts";
 
 // Real xai catalog ids (open-sse/config/providers/registry/xai/index.ts):
 //   grok-4.3                          — plain, reasoning-capable


### PR DESCRIPTION
Fixes the `check:test-discovery` base-red on `release/v3.8.44`: `tests/unit/executors/{firecrawl-fetch,xai-executor}.test.ts` (added by #5793/#5800) sat in a `tests/unit/executors/` subdir that **no runner glob collects** (`tests/unit/*.test.ts` is top-level-only; the subdir brace-list omits `executors`) — so they **never ran**. Moved to the established top-level `executor-*.test.ts` convention → collected by `tests/unit/*.test.ts`. Both pass 10/10; `check:test-discovery` → OK.

> Scope reduced: the i18n-keys and complexity-baseline base-reds this PR originally also fixed were **independently resolved on the tip by the parallel #6021 session** — dropped here to avoid conflict (verified: en.json already has the keys, complexity already rebaselined to 2007).