### PR TITLE
test(cli): deflake cli-setup-opencode.test.ts — silence console (#5959-class landmine)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### 🔧 Bug Fixes
 
 - **tests(cli):** stabilize `setup-claude.test.ts` (#5959) — the dry-run path printed a multi-byte "──" heading to the test child's stdout, corrupting the node:test runner's V8-serialized event stream in ~50% of runs ("Unable to deserialize cloned data due to invalid or unsupported version") and randomly failing the PR→release queue. `syncClaudeProfilesFromModels` now accepts an injectable `log` sink (CLI default unchanged: `console.log`); the test injects a collector and gains assertions on the dry-run report. Validated 0/30 failures post-fix vs 5/10 on the pristine base.
+- **tests(cli):** deflake `cli-setup-opencode.test.ts` preemptively — same #5959 class: the command under test prints multi-byte "✔"/"✖" CLI glyphs to the test child's stdout, which can corrupt the node:test V8 report stream. Console silenced for the file (pattern of #6019/#6021); no test asserts on stdout. 0/20 failures, stdout clean.
 - **tests(ci):** collect the orphaned `tests/unit/executors/` directory (created by #5800 outside every runner glob — its 2 test files never ran anywhere). Added `executors` to the unit-runner brace globs (package.json, ci.yml shards, quality.yml TIA, test-impact map, test-discovery gate); both files pass (10/10).
 
 ### 📝 Maintenance

--- a/tests/unit/cli-setup-opencode.test.ts
+++ b/tests/unit/cli-setup-opencode.test.ts
@@ -40,12 +40,27 @@ function readConfig() {
   return JSON.parse(fs.readFileSync(path.join(CONFIG_DIR, "opencode.json"), "utf8"));
 }
 
+// #5959-class deflake: the command under test prints CLI progress with multi-byte
+// glyphs (printInfo/printSuccess "✔"/printError "✖" via console.log). Under the
+// node:test runner those stdout writes interleave with the child's V8-serialized
+// report frames and can corrupt the stream ("Unable to deserialize cloned data
+// due to invalid or unsupported version"). No test here asserts on stdout, so
+// silence the stdout-writing console methods for the duration of this file
+// (same pattern as tests/unit/cli/setup-claude.test.ts, #6019/#6021).
+const _console = { log: console.log, info: console.info, warn: console.warn };
+
 describe("omniroute setup opencode", () => {
   before(() => {
+    console.log = () => {};
+    console.info = () => {};
+    console.warn = () => {};
     makeFakePluginDist();
   });
 
   after(() => {
+    console.log = _console.log;
+    console.info = _console.info;
+    console.warn = _console.warn;
     try {
       fs.rmSync(FIXTURE_ROOT, { recursive: true, force: true });
     } catch {
@@ -72,7 +87,11 @@ describe("omniroute setup opencode", () => {
     const [modulePath, options] = cfg.plugin[0];
     assert.equal(modulePath, "./plugins/omniroute/dist/index.js");
     assert.equal(options.providerId, "omniroute");
-    assert.equal(options.baseURL, "http://10.0.0.5:20128", "--base-url flag must reach the registered entry");
+    assert.equal(
+      options.baseURL,
+      "http://10.0.0.5:20128",
+      "--base-url flag must reach the registered entry"
+    );
   });
 
   it("is idempotent: re-running updates the entry in place instead of duplicating it", async () => {
@@ -85,10 +104,15 @@ describe("omniroute setup opencode", () => {
 
     const cfg = readConfig();
     const omniEntries = cfg.plugin.filter(
-      (p: unknown) => Array.isArray(p) && (p[1] as { providerId?: string })?.providerId === "omniroute"
+      (p: unknown) =>
+        Array.isArray(p) && (p[1] as { providerId?: string })?.providerId === "omniroute"
     );
     assert.equal(omniEntries.length, 1, "re-run must not duplicate the entry");
-    assert.equal(omniEntries[0][1].baseURL, "http://10.0.0.9:20128", "re-run updates baseURL in place");
+    assert.equal(
+      omniEntries[0][1].baseURL,
+      "http://10.0.0.9:20128",
+      "re-run updates baseURL in place"
+    );
   });
 
   it("removes the legacy opencode-omniroute-auth entry (#3711) and preserves unrelated plugins", async () => {


### PR DESCRIPTION
Follow-up to #6021/#6019 — removes the last known #5959-class landmine.

## Why

`runSetupOpenCodeCommand` prints CLI progress with multi-byte glyphs via `console.log`: `printSuccess "✔"` fires in the happy-path tests, and `printError "✖ @omniroute/opencode-plugin dist/ not built…"` fires in test 4 (the dist-missing path). Under the node:test runner those child-stdout writes interleave with the V8-serialized report frames and can corrupt the stream — the exact mechanism isolated empirically for #5959 (`──` heading, 10/20 failures with the unicode line alone). This file's `✖` line was already visible entangled in red CI runs of the queue.

## Fix

Silence `console.log/info/warn` for the duration of the file (restored in `after()`) — the same pattern #6019 landed for `setup-claude.test.ts`. No test in this file asserts on stdout; test 4 asserts the `exitCode: 1` contract, which is untouched.

## Validation (Hard Rule #18)

- **Pre-fix (RED)**: the `✖`/`✔` unicode lines reach the child's stdout on every run (grep-able in the runner output).
- **Post-fix (GREEN)**: stdout contains zero CLI unicode lines; 4/4 tests green; **0/20 failures** across 20 consecutive runs; prettier + typecheck:core clean.

Test-only change (one test file + CHANGELOG bullet).