### PR TITLE
test(security): fix CodeQL #689 — Kimi Web URL host substring sanitization (main)

### DIFF
--- a/tests/unit/web-cookie-providers-new.test.ts
+++ b/tests/unit/web-cookie-providers-new.test.ts
@@ -679,8 +679,13 @@ test("Kimi Web: targets www.kimi.com (international)", async () => {
       credentials: { apiKey: "kimi-auth=eyJ.eyJzdWI.signature" },
     });
     assert.ok(result.response instanceof Response);
-    assert.ok(result.url.includes("www.kimi.com"), `got ${result.url}`);
-    assert.ok(!result.url.includes("moonshot.cn"));
+    // Parse the URL and assert on the exact hostname rather than a substring
+    // match — `includes("www.kimi.com")` would also accept a hostile host like
+    // `www.kimi.com.evil.net` or `evil.net/?x=www.kimi.com` (CodeQL
+    // js/incomplete-url-substring-sanitization).
+    const host = new URL(result.url).hostname;
+    assert.equal(host, "www.kimi.com", `got ${result.url}`);
+    assert.notEqual(host, "www.moonshot.cn", `got ${result.url}`);
   } finally {
     restore.restore();
   }


### PR DESCRIPTION
Ports the fix already merged into `release/v3.8.44` (PR #5928) directly to `main`, so code-scanning alert **#689** (`js/incomplete-url-substring-sanitization`) closes on the default branch instead of waiting for the next release→main merge.

## Change
Single test file. Parses the URL and asserts on the exact `hostname` rather than a substring match:

- `includes("www.kimi.com")` also accepts hostile hosts like `www.kimi.com.evil.net` or `evil.net/?x=www.kimi.com`.
- Now: `new URL(result.url).hostname === "www.kimi.com"` (2 asserts → 3 stronger asserts, no weakening).

## Validation
`node --import tsx/esm --test tests/unit/web-cookie-providers-new.test.ts` → **38 pass / 0 fail**.

When `release/v3.8.44` later merges to `main`, both sides carry the identical change, so git auto-resolves with no conflict.