### PR TITLE
refactor(sse): decompose handleComboChat auto-strategy region (Block J Task 2 — parseAutoConfig + resolveAutoStrategyOrder)

### DIFF
--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -19,12 +19,7 @@ import {
 } from "./accountFallback.ts";
 import { errorResponse, unavailableResponse } from "../utils/error.ts";
 import { buildTargetTimeoutRunner } from "./combo/targetTimeoutRunner.ts";
-import {
-  recordComboIntent,
-  recordComboRequest,
-  recordComboShadowRequest,
-  getComboMetrics,
-} from "./comboMetrics.ts";
+import { recordComboRequest, recordComboShadowRequest, getComboMetrics } from "./comboMetrics.ts";
 import {
   resolveComboConfig,
   getDefaultComboConfig,
@@ -56,14 +51,10 @@ import { phaseComboSetup } from "./combo/comboSetup.ts";
 import { checkCredentialGate, logCredentialSkip } from "./credentialGate.ts";
 import { emit } from "../../src/lib/events/eventBus";
 import { notifyWebhookEvent } from "../../src/lib/webhookDispatcher";
-import { classifyWithConfig } from "./intentClassifier.ts";
-import { selectProvider as selectAutoProvider } from "./autoCombo/engine.ts";
-import { selectWithStrategy } from "./autoCombo/routerStrategy.ts";
 import { parseAutoPrefix } from "./autoCombo/autoPrefix.ts";
-import { parseAutoConfig } from "./combo/autoConfig.ts";
+import { resolveAutoStrategyOrder } from "./combo/resolveAutoStrategy.ts";
 import { handlePipelineCombo, buildPipelineResponse } from "./autoCombo/pipelineRouter.ts";
 import { type ProviderCandidate } from "./autoCombo/scoring.ts";
-import { supportsToolCalling } from "./modelCapabilities.ts";
 import { estimateTokens } from "./contextManager.ts";
 import { getSessionConnection } from "./sessionManager.ts";
 import { applySessionStickiness, recordStickyBinding } from "./combo/sessionStickiness.ts";
@@ -76,8 +67,6 @@ import {
 import { acquireQuotaShareConcurrencySlot } from "./combo/quotaShareConcurrency.ts";
 import { orderTargetsByEvalScores } from "./evalRouting.ts";
 import { generateRoutingHints } from "./manifestAdapter";
-import type { RoutingHint } from "./manifestAdapter";
-import { buildComplexityRoutingHint } from "./autoCombo/complexityRouter";
 import type { CompressionMode } from "./compression/types.ts";
 import { getProviderConnections } from "../../src/lib/db/providers";
 import {
@@ -142,7 +131,7 @@ import {
 } from "./combo/comboPredicates.ts";
 import { applyComboTargetExhaustion } from "./combo/targetExhaustion.ts";
 import { executeRuntimeUnitCombo } from "./combo/runtimeUnits.ts";
-import { dedupeTargetsByExecutionKey, isRecord } from "./combo/comboData.ts";
+import { isRecord } from "./combo/comboData.ts";
 import {
   expandProviderWildcardsInCombo,
   expandProviderWildcardsInCollection,
@@ -155,7 +144,6 @@ import {
 } from "./combo/targetSorters.ts";
 import {
   filterTargetsByRequestCompatibility,
-  getModelContextLimitForModelString,
   resolveComboRuntimeUnits,
   resolveComboTargets,
   resolveWeightedTargets,
@@ -167,9 +155,6 @@ import {
   setCandidateQuotaSoftPenalty,
   _registerExecutionCandidates,
   _unregisterExecutionCandidates,
-  extractPromptForIntent,
-  mapIntentToTaskType,
-  getIntentConfig,
   applyRequestTagRouting,
   scoreAutoTargets,
   expandAutoComboCandidatePool,
@@ -1062,220 +1047,20 @@ export async function handleComboChat({
   // the fallback order, never override the router's primary choice.
   let autoUsedExplicitRouter = false;
   if (strategy === "auto") {
-    const requestHasTools = Array.isArray(body?.tools) && body.tools.length > 0;
-    let eligibleTargets = [...orderedTargets];
-
-    if (requestHasTools) {
-      const filtered = eligibleTargets.filter((target) => supportsToolCalling(target.modelStr));
-      if (filtered.length > 0) {
-        eligibleTargets = filtered;
-      } else {
-        log.warn(
-          "COMBO",
-          "Auto strategy: all candidates filtered by tool-calling policy, falling back to full pool"
-        );
-      }
-    }
-
-    // Context-window pre-filter (#1808)
-    // Estimate input tokens once; exclude candidates whose known context limit is too small.
-    // Uses the same 4-chars-per-token heuristic as contextManager.ts::compressContext().
-    // Null/unknown limits are treated as "include" to avoid incorrectly dropping valid targets.
-    const requestMessages = body.messages;
-    const estimatedInputTokens = estimateTokens(
-      typeof requestMessages === "string" ||
-        (requestMessages !== null && typeof requestMessages === "object")
-        ? requestMessages
-        : []
-    );
-    if (estimatedInputTokens > 0) {
-      const filteredByContext = eligibleTargets.filter((target) => {
-        const limit = getModelContextLimitForModelString(target.modelStr);
-        if (limit === null || limit === undefined) return true; // unknown — include to be safe
-        return limit >= estimatedInputTokens;
-      });
-      if (filteredByContext.length > 0) {
-        log.debug?.(
-          "COMBO",
-          `Auto strategy: context-window filter kept ${filteredByContext.length}/${eligibleTargets.length} candidates (est. ${estimatedInputTokens} tokens)`
-        );
-        eligibleTargets = filteredByContext;
-      } else {
-        log.warn(
-          "COMBO",
-          `Auto strategy: all candidates filtered by context-window policy (est. ${estimatedInputTokens} tokens), falling back to full pool`
-        );
-        // eligibleTargets intentionally unchanged — same fallback contract as tool-calling filter
-      }
-
-      eligibleTargets = await expandAutoComboCandidatePool(eligibleTargets, combo);
-    }
-
-    const prompt = extractPromptForIntent(body);
-    const systemPrompt =
-      typeof combo?.system_message === "string" ? combo.system_message : undefined;
-    const intentConfig = getIntentConfig(settings, combo);
-    const intent = classifyWithConfig(prompt, intentConfig, systemPrompt);
-    recordComboIntent(combo.name, intent);
-    const taskType = mapIntentToTaskType(intent);
-
-    const {
-      routingStrategy,
-      candidatePool,
-      weights,
-      explorationRate,
-      budgetCap,
-      modePack,
-      resetWindowConfig,
-      slaPolicy,
-    } = parseAutoConfig(combo, eligibleTargets);
-
-    let lastKnownGoodProvider: string | undefined;
-    try {
-      const { getLKGP } = await import("../../src/lib/localDb");
-      const lkgp = await getLKGP(combo.name, combo.id || combo.name);
-      if (lkgp) lastKnownGoodProvider = lkgp.provider;
-    } catch (err) {
-      log.warn("COMBO", "Failed to retrieve Last Known Good Provider. This is non-fatal.", { err });
-    }
-
-    const autoCandidateResilienceSettings =
-      relayOptions?.bypassProviderQuotaPolicy === true
-        ? {
-            ...resilienceSettings,
-            quotaPreflight: {
-              ...resilienceSettings.quotaPreflight,
-              enabled: false,
-            },
-          }
-        : resilienceSettings;
-    const candidates = await buildAutoCandidates(
-      eligibleTargets,
-      combo.name,
-      relayOptions?.sessionId,
-      resetWindowConfig,
-      autoCandidateResilienceSettings
-    );
-    const routableCandidates = candidates.filter(
-      (candidate) => candidate.quotaCutoffBlocked !== true
-    );
-    const quotaBlockedCount = candidates.length - routableCandidates.length;
-    if (quotaBlockedCount > 0) {
-      log.info(
-        "COMBO",
-        `Auto strategy: quota cutoff skipped ${quotaBlockedCount}/${candidates.length} account candidates`
-      );
-    }
-    // G2: Register candidates so chatCore can mark quotaSoftPenalty via setCandidateQuotaSoftPenalty.
-    _registerExecutionCandidates(routableCandidates);
-    if (candidates.length > 0 && routableCandidates.length === 0) {
-      return unavailableResponse(
-        429,
-        "All auto strategy candidates are below configured quota cutoffs"
-      );
-    }
-    if (routableCandidates.length > 0) {
-      let selectedProvider: string | null = null;
-      let selectedModel: string | null = null;
-      let selectionReason = "";
-
-      if (routingStrategy !== "rules") {
-        try {
-          const decision = selectWithStrategy(
-            routableCandidates,
-            {
-              taskType,
-              requestHasTools,
-              lastKnownGoodProvider,
-              estimatedInputTokens,
-              sla: slaPolicy,
-            },
-            routingStrategy
-          );
-          selectedProvider = decision.provider;
-          selectedModel = decision.model;
-          selectionReason = decision.reason;
-          autoUsedExplicitRouter = true;
-        } catch (err) {
-          log.warn(
-            "COMBO",
-            `Auto strategy '${routingStrategy}' failed (${err?.message || "unknown"}), falling back to rules`
-          );
-        }
-      }
-
-      if (!selectedProvider || !selectedModel) {
-        const selection = selectAutoProvider(
-          {
-            id: combo.id || combo.name,
-            name: combo.name,
-            type: "auto",
-            candidatePool,
-            weights,
-            modePack,
-            budgetCap,
-            explorationRate,
-          },
-          routableCandidates,
-          taskType
-        );
-        selectedProvider = selection.provider;
-        selectedModel = selection.model;
-        selectionReason = `score=${selection.score.toFixed(3)}${selection.isExploration ? " (exploration)" : ""}`;
-      }
-
-      // Complexity-aware routing (2026, opt-in): classify the request's
-      // difficulty and feed a tier hint into scoring so tierAffinity /
-      // specificityMatch favor candidates whose tier matches the request.
-      const autoManifestHint: RoutingHint | null =
-        config.complexityAwareRouting === true
-          ? buildComplexityRoutingHint(
-              eligibleTargets.filter((t) => t.kind === "model"),
-              body,
-              log
-            )
-          : null;
-
-      const scoredTargets = scoreAutoTargets(
-        eligibleTargets,
-        routableCandidates,
-        taskType,
-        weights,
-        autoManifestHint
-      );
-      const rankedTargets = scoredTargets.map((entry) => entry.target);
-      const selectedTarget =
-        scoredTargets.find((entry) => {
-          const parsed = parseModel(entry.target.modelStr);
-          const modelId = parsed.model || entry.target.modelStr;
-          return entry.target.provider === selectedProvider && modelId === selectedModel;
-        })?.target ||
-        rankedTargets[0] ||
-        eligibleTargets[0];
-      if (!selectedTarget) {
-        return unavailableResponse(
-          429,
-          "No auto strategy targets remained after quota cutoff filtering"
-        );
-      }
-
-      // Keep eligibleTargets as the last-resort fallback tail: dedupe drops the
-      // routable ranked ones (and, when the cutoff is OFF, makes this identical to
-      // the pre-cutoff behavior), but a quota-blocked target still survives as a
-      // final fallback instead of vanishing — the hard cutoff only de-prioritizes.
-      orderedTargets = dedupeTargetsByExecutionKey(
-        [selectedTarget, ...rankedTargets, ...eligibleTargets].filter(
-          (entry): entry is ResolvedComboTarget => entry !== undefined && entry !== null
-        )
-      );
-
-      log.info(
-        "COMBO",
-        `Auto selection: ${selectedTarget?.modelStr || `${selectedProvider}/${selectedModel}`} | intent=${intent} task=${taskType} | strategy=${routingStrategy} | ${selectionReason}`
-      );
-    } else {
-      log.warn("COMBO", "Auto strategy has no candidates, keeping default ordering");
-    }
+    const autoResult = await resolveAutoStrategyOrder({
+      orderedTargets,
+      body,
+      combo,
+      settings,
+      config,
+      relayOptions,
+      resilienceSettings,
+      log,
+      buildAutoCandidates,
+    });
+    if ("earlyResponse" in autoResult) return autoResult.earlyResponse;
+    orderedTargets = autoResult.orderedTargets;
+    autoUsedExplicitRouter = autoResult.autoUsedExplicitRouter;
   } else if (strategy === "lkgp") {
     try {
       const { getLKGP } = await import("../../src/lib/localDb");

--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -60,12 +60,9 @@ import { classifyWithConfig } from "./intentClassifier.ts";
 import { selectProvider as selectAutoProvider } from "./autoCombo/engine.ts";
 import { selectWithStrategy } from "./autoCombo/routerStrategy.ts";
 import { parseAutoPrefix } from "./autoCombo/autoPrefix.ts";
+import { parseAutoConfig } from "./combo/autoConfig.ts";
 import { handlePipelineCombo, buildPipelineResponse } from "./autoCombo/pipelineRouter.ts";
-import {
-  DEFAULT_WEIGHTS,
-  type ProviderCandidate,
-  type ScoringWeights,
-} from "./autoCombo/scoring.ts";
+import { type ProviderCandidate } from "./autoCombo/scoring.ts";
 import { supportsToolCalling } from "./modelCapabilities.ts";
 import { estimateTokens } from "./contextManager.ts";
 import { getSessionConnection } from "./sessionManager.ts";
@@ -179,7 +176,6 @@ import {
 } from "./combo/autoStrategy.ts";
 import {
   resolveResetWindowConfig,
-  resolveSlaRoutingPolicy,
   calculateResetWindowAffinity,
   type ResetWindowConfig,
 } from "./combo/quotaScoring.ts";
@@ -1123,41 +1119,16 @@ export async function handleComboChat({
     recordComboIntent(combo.name, intent);
     const taskType = mapIntentToTaskType(intent);
 
-    const rawAutoConfigSource =
-      combo?.autoConfig ||
-      (isRecord(combo?.config?.auto) ? combo.config.auto : null) ||
-      combo?.config ||
-      {};
-    const autoConfigSource: Record<string, unknown> = isRecord(rawAutoConfigSource)
-      ? rawAutoConfigSource
-      : {};
-    const routingStrategy =
-      typeof autoConfigSource.routerStrategy === "string"
-        ? autoConfigSource.routerStrategy
-        : typeof autoConfigSource.routingStrategy === "string"
-          ? autoConfigSource.routingStrategy
-          : typeof autoConfigSource.strategyName === "string"
-            ? autoConfigSource.strategyName
-            : "rules";
-
-    const candidatePool = Array.isArray(autoConfigSource.candidatePool)
-      ? autoConfigSource.candidatePool
-      : [...new Set(eligibleTargets.map((target) => target.provider))];
-
-    const weights =
-      autoConfigSource.weights && typeof autoConfigSource.weights === "object"
-        ? (autoConfigSource.weights as ScoringWeights)
-        : DEFAULT_WEIGHTS;
-    const explorationRate = Number.isFinite(Number(autoConfigSource.explorationRate))
-      ? Number(autoConfigSource.explorationRate)
-      : 0.05;
-    const budgetCap = Number.isFinite(Number(autoConfigSource.budgetCap))
-      ? Number(autoConfigSource.budgetCap)
-      : undefined;
-    const modePack =
-      typeof autoConfigSource.modePack === "string" ? autoConfigSource.modePack : undefined;
-    const resetWindowConfig = resolveResetWindowConfig(autoConfigSource);
-    const slaPolicy = resolveSlaRoutingPolicy(autoConfigSource);
+    const {
+      routingStrategy,
+      candidatePool,
+      weights,
+      explorationRate,
+      budgetCap,
+      modePack,
+      resetWindowConfig,
+      slaPolicy,
+    } = parseAutoConfig(combo, eligibleTargets);
 
     let lastKnownGoodProvider: string | undefined;
     try {

--- a/open-sse/services/combo/autoConfig.ts
+++ b/open-sse/services/combo/autoConfig.ts
@@ -1,0 +1,62 @@
+import { DEFAULT_WEIGHTS, type ScoringWeights } from "../autoCombo/scoring.ts";
+import { isRecord } from "./comboData.ts";
+import { resolveResetWindowConfig, resolveSlaRoutingPolicy } from "./quotaScoring.ts";
+import type { ComboLike, ResolvedComboTarget } from "./types.ts";
+
+/**
+ * Resolve the auto-strategy routing configuration for a combo.
+ *
+ * Pure function of `(combo, eligibleTargets)`: derives the router strategy name,
+ * candidate provider pool, scoring weights, exploration rate, budget cap, mode
+ * pack, reset-window config and SLA policy from the combo's `autoConfig`/`config`.
+ * No side effects, no early returns — extracted verbatim from `handleComboChat`
+ * so its behavior is byte-identical to the previous inline block.
+ */
+export function parseAutoConfig(combo: ComboLike, eligibleTargets: ResolvedComboTarget[]) {
+  const rawAutoConfigSource =
+    combo?.autoConfig ||
+    (isRecord(combo?.config?.auto) ? combo.config.auto : null) ||
+    combo?.config ||
+    {};
+  const autoConfigSource: Record<string, unknown> = isRecord(rawAutoConfigSource)
+    ? rawAutoConfigSource
+    : {};
+  const routingStrategy =
+    typeof autoConfigSource.routerStrategy === "string"
+      ? autoConfigSource.routerStrategy
+      : typeof autoConfigSource.routingStrategy === "string"
+        ? autoConfigSource.routingStrategy
+        : typeof autoConfigSource.strategyName === "string"
+          ? autoConfigSource.strategyName
+          : "rules";
+
+  const candidatePool = Array.isArray(autoConfigSource.candidatePool)
+    ? autoConfigSource.candidatePool
+    : [...new Set(eligibleTargets.map((target) => target.provider))];
+
+  const weights =
+    autoConfigSource.weights && typeof autoConfigSource.weights === "object"
+      ? (autoConfigSource.weights as ScoringWeights)
+      : DEFAULT_WEIGHTS;
+  const explorationRate = Number.isFinite(Number(autoConfigSource.explorationRate))
+    ? Number(autoConfigSource.explorationRate)
+    : 0.05;
+  const budgetCap = Number.isFinite(Number(autoConfigSource.budgetCap))
+    ? Number(autoConfigSource.budgetCap)
+    : undefined;
+  const modePack =
+    typeof autoConfigSource.modePack === "string" ? autoConfigSource.modePack : undefined;
+  const resetWindowConfig = resolveResetWindowConfig(autoConfigSource);
+  const slaPolicy = resolveSlaRoutingPolicy(autoConfigSource);
+
+  return {
+    routingStrategy,
+    candidatePool,
+    weights,
+    explorationRate,
+    budgetCap,
+    modePack,
+    resetWindowConfig,
+    slaPolicy,
+  };
+}

--- a/open-sse/services/combo/resolveAutoStrategy.ts
+++ b/open-sse/services/combo/resolveAutoStrategy.ts
@@ -1,0 +1,306 @@
+import { unavailableResponse } from "../../utils/error.ts";
+import { selectProvider as selectAutoProvider } from "../autoCombo/engine.ts";
+import { selectWithStrategy } from "../autoCombo/routerStrategy.ts";
+import { buildComplexityRoutingHint } from "../autoCombo/complexityRouter";
+import { recordComboIntent } from "../comboMetrics.ts";
+import { estimateTokens } from "../contextManager.ts";
+import { classifyWithConfig } from "../intentClassifier.ts";
+import type { RoutingHint } from "../manifestAdapter";
+import { parseModel } from "../model.ts";
+import { supportsToolCalling } from "../modelCapabilities.ts";
+import type { ResilienceSettings } from "../../../src/lib/resilience/settings";
+import { parseAutoConfig } from "./autoConfig.ts";
+import { dedupeTargetsByExecutionKey } from "./comboData.ts";
+import { getModelContextLimitForModelString } from "./comboStructure.ts";
+import type { ResetWindowConfig } from "./quotaScoring.ts";
+import {
+  _registerExecutionCandidates,
+  expandAutoComboCandidatePool,
+  extractPromptForIntent,
+  getIntentConfig,
+  mapIntentToTaskType,
+  scoreAutoTargets,
+} from "./autoStrategy.ts";
+import type {
+  AutoProviderCandidate,
+  ComboLike,
+  ComboLogger,
+  ResolvedComboTarget,
+} from "./types.ts";
+
+/**
+ * Dependency-injected `buildAutoCandidates` — it lives in `combo.ts` (the host of
+ * this leaf), so importing it directly would create an import cycle. Passing it
+ * through `deps` keeps this module acyclic (same pattern as `buildTargetTimeoutRunner`).
+ */
+type BuildAutoCandidates = (
+  targets: ResolvedComboTarget[],
+  comboName: string,
+  sessionId?: string | null,
+  resetWindowConfig?: ResetWindowConfig,
+  resilienceSettings?: ResilienceSettings | null
+) => Promise<AutoProviderCandidate[]>;
+
+export interface ResolveAutoStrategyDeps {
+  orderedTargets: ResolvedComboTarget[];
+  body: Record<string, unknown>;
+  combo: ComboLike;
+  settings: Record<string, unknown> | null | undefined;
+  config: { complexityAwareRouting?: boolean };
+  relayOptions?: { bypassProviderQuotaPolicy?: boolean; sessionId?: string | null } | null;
+  resilienceSettings: ResilienceSettings;
+  log: ComboLogger;
+  buildAutoCandidates: BuildAutoCandidates;
+}
+
+export type ResolveAutoStrategyResult =
+  | { earlyResponse: Response }
+  | { orderedTargets: ResolvedComboTarget[]; autoUsedExplicitRouter: boolean };
+
+/**
+ * Resolve target ordering for the `auto` combo strategy.
+ *
+ * Extracted verbatim from `handleComboChat`'s `if (strategy === "auto")` branch:
+ * tool-calling + context-window pre-filters, intent classification, candidate
+ * building (quota cutoff), explicit-router vs rules selection, complexity-aware
+ * scoring and final dedup ordering. Behavior is byte-identical to the previous
+ * inline block; the two `return unavailableResponse(...)` exits become
+ * `{ earlyResponse }` so the host can decide to return them, and the mutated
+ * `orderedTargets` / `autoUsedExplicitRouter` are returned instead of closed over.
+ */
+export async function resolveAutoStrategyOrder(
+  deps: ResolveAutoStrategyDeps
+): Promise<ResolveAutoStrategyResult> {
+  const {
+    body,
+    combo,
+    settings,
+    config,
+    relayOptions,
+    resilienceSettings,
+    log,
+    buildAutoCandidates,
+  } = deps;
+  let orderedTargets = deps.orderedTargets;
+  let autoUsedExplicitRouter = false;
+
+  const requestHasTools = Array.isArray(body?.tools) && body.tools.length > 0;
+  let eligibleTargets = [...orderedTargets];
+
+  if (requestHasTools) {
+    const filtered = eligibleTargets.filter((target) => supportsToolCalling(target.modelStr));
+    if (filtered.length > 0) {
+      eligibleTargets = filtered;
+    } else {
+      log.warn(
+        "COMBO",
+        "Auto strategy: all candidates filtered by tool-calling policy, falling back to full pool"
+      );
+    }
+  }
+
+  // Context-window pre-filter (#1808)
+  // Estimate input tokens once; exclude candidates whose known context limit is too small.
+  // Uses the same 4-chars-per-token heuristic as contextManager.ts::compressContext().
+  // Null/unknown limits are treated as "include" to avoid incorrectly dropping valid targets.
+  const requestMessages = body.messages;
+  const estimatedInputTokens = estimateTokens(
+    typeof requestMessages === "string" ||
+      (requestMessages !== null && typeof requestMessages === "object")
+      ? requestMessages
+      : []
+  );
+  if (estimatedInputTokens > 0) {
+    const filteredByContext = eligibleTargets.filter((target) => {
+      const limit = getModelContextLimitForModelString(target.modelStr);
+      if (limit === null || limit === undefined) return true; // unknown — include to be safe
+      return limit >= estimatedInputTokens;
+    });
+    if (filteredByContext.length > 0) {
+      log.debug?.(
+        "COMBO",
+        `Auto strategy: context-window filter kept ${filteredByContext.length}/${eligibleTargets.length} candidates (est. ${estimatedInputTokens} tokens)`
+      );
+      eligibleTargets = filteredByContext;
+    } else {
+      log.warn(
+        "COMBO",
+        `Auto strategy: all candidates filtered by context-window policy (est. ${estimatedInputTokens} tokens), falling back to full pool`
+      );
+      // eligibleTargets intentionally unchanged — same fallback contract as tool-calling filter
+    }
+
+    eligibleTargets = await expandAutoComboCandidatePool(eligibleTargets, combo);
+  }
+
+  const prompt = extractPromptForIntent(body);
+  const systemPrompt = typeof combo?.system_message === "string" ? combo.system_message : undefined;
+  const intentConfig = getIntentConfig(settings, combo);
+  const intent = classifyWithConfig(prompt, intentConfig, systemPrompt);
+  recordComboIntent(combo.name, intent);
+  const taskType = mapIntentToTaskType(intent);
+
+  const {
+    routingStrategy,
+    candidatePool,
+    weights,
+    explorationRate,
+    budgetCap,
+    modePack,
+    resetWindowConfig,
+    slaPolicy,
+  } = parseAutoConfig(combo, eligibleTargets);
+
+  let lastKnownGoodProvider: string | undefined;
+  try {
+    const { getLKGP } = await import("../../../src/lib/localDb");
+    const lkgp = await getLKGP(combo.name, combo.id || combo.name);
+    if (lkgp) lastKnownGoodProvider = lkgp.provider;
+  } catch (err) {
+    log.warn("COMBO", "Failed to retrieve Last Known Good Provider. This is non-fatal.", { err });
+  }
+
+  const autoCandidateResilienceSettings =
+    relayOptions?.bypassProviderQuotaPolicy === true
+      ? {
+          ...resilienceSettings,
+          quotaPreflight: {
+            ...resilienceSettings.quotaPreflight,
+            enabled: false,
+          },
+        }
+      : resilienceSettings;
+  const candidates = await buildAutoCandidates(
+    eligibleTargets,
+    combo.name,
+    relayOptions?.sessionId,
+    resetWindowConfig,
+    autoCandidateResilienceSettings
+  );
+  const routableCandidates = candidates.filter(
+    (candidate) => candidate.quotaCutoffBlocked !== true
+  );
+  const quotaBlockedCount = candidates.length - routableCandidates.length;
+  if (quotaBlockedCount > 0) {
+    log.info(
+      "COMBO",
+      `Auto strategy: quota cutoff skipped ${quotaBlockedCount}/${candidates.length} account candidates`
+    );
+  }
+  // G2: Register candidates so chatCore can mark quotaSoftPenalty via setCandidateQuotaSoftPenalty.
+  _registerExecutionCandidates(routableCandidates);
+  if (candidates.length > 0 && routableCandidates.length === 0) {
+    return {
+      earlyResponse: unavailableResponse(
+        429,
+        "All auto strategy candidates are below configured quota cutoffs"
+      ),
+    };
+  }
+  if (routableCandidates.length > 0) {
+    let selectedProvider: string | null = null;
+    let selectedModel: string | null = null;
+    let selectionReason = "";
+
+    if (routingStrategy !== "rules") {
+      try {
+        const decision = selectWithStrategy(
+          routableCandidates,
+          {
+            taskType,
+            requestHasTools,
+            lastKnownGoodProvider,
+            estimatedInputTokens,
+            sla: slaPolicy,
+          },
+          routingStrategy
+        );
+        selectedProvider = decision.provider;
+        selectedModel = decision.model;
+        selectionReason = decision.reason;
+        autoUsedExplicitRouter = true;
+      } catch (err) {
+        log.warn(
+          "COMBO",
+          `Auto strategy '${routingStrategy}' failed (${err?.message || "unknown"}), falling back to rules`
+        );
+      }
+    }
+
+    if (!selectedProvider || !selectedModel) {
+      const selection = selectAutoProvider(
+        {
+          id: combo.id || combo.name,
+          name: combo.name,
+          type: "auto",
+          candidatePool,
+          weights,
+          modePack,
+          budgetCap,
+          explorationRate,
+        },
+        routableCandidates,
+        taskType
+      );
+      selectedProvider = selection.provider;
+      selectedModel = selection.model;
+      selectionReason = `score=${selection.score.toFixed(3)}${selection.isExploration ? " (exploration)" : ""}`;
+    }
+
+    // Complexity-aware routing (2026, opt-in): classify the request's
+    // difficulty and feed a tier hint into scoring so tierAffinity /
+    // specificityMatch favor candidates whose tier matches the request.
+    const autoManifestHint: RoutingHint | null =
+      config.complexityAwareRouting === true
+        ? buildComplexityRoutingHint(
+            eligibleTargets.filter((t) => t.kind === "model"),
+            body,
+            log
+          )
+        : null;
+
+    const scoredTargets = scoreAutoTargets(
+      eligibleTargets,
+      routableCandidates,
+      taskType,
+      weights,
+      autoManifestHint
+    );
+    const rankedTargets = scoredTargets.map((entry) => entry.target);
+    const selectedTarget =
+      scoredTargets.find((entry) => {
+        const parsed = parseModel(entry.target.modelStr);
+        const modelId = parsed.model || entry.target.modelStr;
+        return entry.target.provider === selectedProvider && modelId === selectedModel;
+      })?.target ||
+      rankedTargets[0] ||
+      eligibleTargets[0];
+    if (!selectedTarget) {
+      return {
+        earlyResponse: unavailableResponse(
+          429,
+          "No auto strategy targets remained after quota cutoff filtering"
+        ),
+      };
+    }
+
+    // Keep eligibleTargets as the last-resort fallback tail: dedupe drops the
+    // routable ranked ones (and, when the cutoff is OFF, makes this identical to
+    // the pre-cutoff behavior), but a quota-blocked target still survives as a
+    // final fallback instead of vanishing — the hard cutoff only de-prioritizes.
+    orderedTargets = dedupeTargetsByExecutionKey(
+      [selectedTarget, ...rankedTargets, ...eligibleTargets].filter(
+        (entry): entry is ResolvedComboTarget => entry !== undefined && entry !== null
+      )
+    );
+
+    log.info(
+      "COMBO",
+      `Auto selection: ${selectedTarget?.modelStr || `${selectedProvider}/${selectedModel}`} | intent=${intent} task=${taskType} | strategy=${routingStrategy} | ${selectionReason}`
+    );
+  } else {
+    log.warn("COMBO", "Auto strategy has no candidates, keeping default ordering");
+  }
+
+  return { orderedTargets, autoUsedExplicitRouter };
+}

--- a/tests/unit/api-key-provider-quota-bypass-scope.test.ts
+++ b/tests/unit/api-key-provider-quota-bypass-scope.test.ts
@@ -27,7 +27,12 @@ test("chat handler maps API key provider quota bypass scope to auth bypass optio
 });
 
 test("auto combo disables hard provider quota cutoffs when relay requests bypass", () => {
-  const source = fs.readFileSync(path.join(repoRoot, "open-sse/services/combo.ts"), "utf8");
+  // The auto-strategy bypass logic was extracted verbatim from combo.ts into the
+  // resolveAutoStrategy leaf (Block J Task 2); the source scan follows the code.
+  const source = fs.readFileSync(
+    path.join(repoRoot, "open-sse/services/combo/resolveAutoStrategy.ts"),
+    "utf8"
+  );
 
   assert.match(source, /relayOptions\?\.bypassProviderQuotaPolicy === true/);
   assert.match(source, /quotaPreflight:[\s\S]*enabled: false/);

--- a/tests/unit/combo-auto-config-split.test.ts
+++ b/tests/unit/combo-auto-config-split.test.ts
@@ -1,0 +1,79 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { parseAutoConfig } from "@omniroute/open-sse/services/combo/autoConfig.ts";
+import { DEFAULT_WEIGHTS } from "@omniroute/open-sse/services/autoCombo/scoring.ts";
+
+// Split guard for Block J Task 2: parseAutoConfig was extracted verbatim from
+// handleComboChat's inline auto-strategy config block. These assertions pin the
+// pure derivation so the extraction stays behavior-identical.
+
+const target = (provider: string, modelStr: string) =>
+  ({ provider, modelStr, executionKey: `${provider}>${modelStr}` }) as never;
+
+test("defaults: rules strategy, provider-derived pool, default weights", () => {
+  const cfg = parseAutoConfig({ name: "c", config: {} } as never, [
+    target("openai", "gpt-4o"),
+    target("anthropic", "claude-3"),
+    target("openai", "gpt-4o-mini"),
+  ]);
+  assert.equal(cfg.routingStrategy, "rules");
+  assert.deepEqual(cfg.candidatePool, ["openai", "anthropic"]);
+  assert.equal(cfg.weights, DEFAULT_WEIGHTS);
+  assert.equal(cfg.explorationRate, 0.05);
+  assert.equal(cfg.budgetCap, undefined);
+  assert.equal(cfg.modePack, undefined);
+});
+
+test("routerStrategy takes precedence over routingStrategy/strategyName", () => {
+  const cfg = parseAutoConfig(
+    {
+      name: "c",
+      autoConfig: {
+        routerStrategy: "lkgp",
+        routingStrategy: "cost",
+        strategyName: "p2c",
+      },
+    } as never,
+    []
+  );
+  assert.equal(cfg.routingStrategy, "lkgp");
+});
+
+test("explicit candidatePool, weights, exploration and budget are honored", () => {
+  const customWeights = { latency: 1 } as never;
+  const cfg = parseAutoConfig(
+    {
+      name: "c",
+      autoConfig: {
+        candidatePool: ["glm", "openai"],
+        weights: customWeights,
+        explorationRate: 0.3,
+        budgetCap: 5,
+        modePack: "coding",
+      },
+    } as never,
+    [target("ignored", "x")]
+  );
+  assert.deepEqual(cfg.candidatePool, ["glm", "openai"]);
+  assert.equal(cfg.weights, customWeights);
+  assert.equal(cfg.explorationRate, 0.3);
+  assert.equal(cfg.budgetCap, 5);
+  assert.equal(cfg.modePack, "coding");
+});
+
+test("config.auto is preferred over top-level config", () => {
+  const cfg = parseAutoConfig(
+    { name: "c", config: { auto: { routerStrategy: "cost" }, routerStrategy: "rules" } } as never,
+    []
+  );
+  assert.equal(cfg.routingStrategy, "cost");
+});
+
+test("non-finite explorationRate falls back to 0.05", () => {
+  const cfg = parseAutoConfig(
+    { name: "c", autoConfig: { explorationRate: "not-a-number" } } as never,
+    []
+  );
+  assert.equal(cfg.explorationRate, 0.05);
+});

--- a/tests/unit/combo-resolve-auto-strategy-split.test.ts
+++ b/tests/unit/combo-resolve-auto-strategy-split.test.ts
@@ -1,0 +1,88 @@
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+
+import { resolveAutoStrategyOrder } from "@omniroute/open-sse/services/combo/resolveAutoStrategy.ts";
+import { resetDbInstance } from "@/lib/db/core.ts";
+
+// resolveAutoStrategyOrder loads the LKGP via the DB singleton (dynamic import);
+// release the handle so the node:test runner does not hang on teardown (learning #3).
+after(() => {
+  resetDbInstance();
+});
+
+// Split guard for Block J Task 2 (coupled slice): the `if (strategy === "auto")`
+// branch of handleComboChat was extracted verbatim into resolveAutoStrategyOrder,
+// with `buildAutoCandidates` injected (it lives in combo.ts, so a direct import
+// would cycle). These tests pin the DI contract and the two control-flow exits
+// that the host now forwards: an early 429 Response, and the default-ordering
+// pass-through. The routable-selection path is covered end-to-end by the 60
+// consumer tests (router-strategies / auto-combo-engine / combo-strategy-fallbacks).
+
+const noopLog = {
+  info() {},
+  warn() {},
+  error() {},
+  debug() {},
+} as never;
+
+const target = (provider: string, modelStr: string): never =>
+  ({
+    kind: "model",
+    stepId: "s1",
+    executionKey: `${provider}>${modelStr}`,
+    modelStr,
+    provider,
+    providerId: null,
+    connectionId: null,
+    weight: 1,
+    label: null,
+  }) as never;
+
+const baseDeps = (buildAutoCandidates: never) =>
+  ({
+    orderedTargets: [target("openai", "gpt-4o"), target("anthropic", "claude-3")],
+    body: { messages: [{ role: "user", content: "hi" }] },
+    combo: { id: "c1", name: "autoc", config: {} },
+    settings: null,
+    config: {},
+    relayOptions: null,
+    resilienceSettings: { quotaPreflight: { enabled: false } },
+    log: noopLog,
+    buildAutoCandidates,
+  }) as never;
+
+test("exports resolveAutoStrategyOrder", () => {
+  assert.equal(typeof resolveAutoStrategyOrder, "function");
+});
+
+test("no candidates -> keeps default ordering, no explicit router", async () => {
+  const build = (async () => []) as never;
+  const result = await resolveAutoStrategyOrder(baseDeps(build));
+  assert.ok(!("earlyResponse" in result));
+  if ("orderedTargets" in result) {
+    assert.equal(result.autoUsedExplicitRouter, false);
+    // default ordering preserved (both original targets survive)
+    assert.equal(result.orderedTargets.length, 2);
+    assert.equal(result.orderedTargets[0].provider, "openai");
+  }
+});
+
+test("all candidates quota-cutoff-blocked -> early 429 Response", async () => {
+  const build = (async () => [
+    {
+      kind: "model",
+      stepId: "s1",
+      executionKey: "openai>gpt-4o",
+      modelStr: "gpt-4o",
+      provider: "openai",
+      model: "gpt-4o",
+      quotaCutoffBlocked: true,
+    },
+  ]) as never;
+  const result = await resolveAutoStrategyOrder(baseDeps(build));
+  assert.ok("earlyResponse" in result);
+  if ("earlyResponse" in result) {
+    assert.ok(result.earlyResponse instanceof Response);
+    assert.equal(result.earlyResponse.status, 429);
+  }
+});


### PR DESCRIPTION
## Block J Task 2 — decompose the `handleComboChat` auto-strategy region

Two cohesive extractions out of the `combo.ts` god-file (**3309 → 3065 LOC**), both narrowing the auto-strategy region of `handleComboChat`:

### 1. `combo/autoConfig.ts::parseAutoConfig` (pure slice)
Verbatim extraction of the auto-strategy **config-resolution** block — a *pure* function of `(combo, eligibleTargets)` (routingStrategy / candidatePool / weights / explorationRate / budgetCap / modePack / resetWindowConfig / slaPolicy). No side effects, no early returns → **byte-identical** (multiset code-line diff = empty).

### 2. `combo/resolveAutoStrategy.ts::resolveAutoStrategyOrder` (coupled slice)
The ~215-line `if (strategy === "auto")` branch. This is a control-flow region (mutates `orderedTargets` + `autoUsedExplicitRouter`, early-returns 429, side-effect `_registerExecutionCandidates`), so it is **not** a pure move:
- the two `return unavailableResponse(...)` exits become `{ earlyResponse }` (host forwards them);
- the mutated locals are returned instead of closed over;
- **every other logic line is verbatim** — semantic diff = only those wrappers + the deeper `getLKGP` import path.
- `buildAutoCandidates` lives in `combo.ts`, so it is **injected via deps** to keep the leaf acyclic (same DI pattern as `buildTargetTimeoutRunner`) — which also makes the branch independently unit-testable.

### Evidence
- `typecheck:core` + `check:cycles` clean; dead host imports removed; `check:file-size` (combo.ts shrink-only) OK.
- **60/60** consumer tests cover the routable path end-to-end (router-strategies / auto-combo-engine / combo-strategy-fallbacks / scoring-clamp / candidate-expansion / hidden-models).
- New split guards: `combo-auto-config-split.test.ts` (5) + `combo-resolve-auto-strategy-split.test.ts` (3, DI contract + early-429 + default-ordering exits).
- Per Block-J protocol the coupled slice also gets a **VPS deploy-canary** (build-env now unblocked); result appended below.

### Test plan
```
npm run typecheck:core && npm run check:cycles
node --import tsx/esm --test tests/unit/combo-auto-config-split.test.ts tests/unit/combo-resolve-auto-strategy-split.test.ts
node --import tsx/esm --test tests/unit/router-strategies.test.ts tests/unit/auto-combo-engine.test.ts tests/unit/combo-strategy-fallbacks.test.ts
```