### PR TITLE
feat(minimax): extract M3 reasoning content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,8 @@
 
 - **providers (CLI profile auto-sync):** opt-in CLI profile auto-sync toggles, including Claude Code auto-sync, so generated CLI profiles can track provider changes automatically. ([#5755](https://github.com/diegosouzapw/OmniRoute/pull/5755) — thanks @diegosouzapw)
 
+- **feat(minimax):** surface MiniMax M3 `<think>` reasoning as `reasoning_content` on OpenAI-format provider tiers. (thanks @zmf963)
+
 ### 🔧 Bug Fixes
 
 - **fix(opencode):** stop fabricating `User-Agent: opencode/local` and `x-opencode-client: cli` headers when the client sends none — the executor-dedup refactor ([#5720](https://github.com/diegosouzapw/OmniRoute/pull/5720)) accidentally re-introduced header fabrication, violating the forward-only contract (inventing opencode-internal values risks upstream rejection). Restored to forward-only: those headers are emitted only when a real client source is present. Regression guard: `tests/unit/opencode-executor.test.ts`. (thanks @diegosouzapw)

--- a/open-sse/handlers/responseSanitizer/reasoning.ts
+++ b/open-sse/handlers/responseSanitizer/reasoning.ts
@@ -129,7 +129,13 @@ export function isTextualReasoningTagNativeRoute(providerId: string, modelId: st
   return (
     /deepseek[-_/]?r1\b/.test(routeId) ||
     /r1[-_/]?distill\b/.test(routeId) ||
-    /(?:^|[/:_-])qwq(?:[/._:-]|$)/.test(routeId)
+    /(?:^|[/:_-])qwq(?:[/._:-]|$)/.test(routeId) ||
+    // 9router#2231: MiniMax M3 leaks raw <think>...</think> into `content` on its
+    // OpenAI-format provider tiers (trae, huggingchat, bazaarlink, ollama-cloud,
+    // opencode, cline, opencode-zen, codebuddy-cn). The direct minimax/minimax-cn
+    // tiers stay on Anthropic's Messages format (targetFormat: "claude") and
+    // already surface reasoning natively, so they are excluded here.
+    (providerId !== "minimax" && providerId !== "minimax-cn" && /minimax[-_]?m3\b/.test(routeId))
   );
 }
 

--- a/tests/unit/responsesanitizer-reasoning-split.test.ts
+++ b/tests/unit/responsesanitizer-reasoning-split.test.ts
@@ -22,8 +22,10 @@ import assert from "node:assert/strict";
 
 import {
   extractThinkingFromContent,
+  isTextualReasoningTagNativeRoute,
   shouldParseTextualReasoningTags,
 } from "../../open-sse/handlers/responseSanitizer/reasoning.ts";
+import { sanitizeOpenAIResponse } from "../../open-sse/handlers/responseSanitizer.ts";
 
 describe("responseSanitizer/reasoning — extractThinkingFromContent", () => {
   it("leaves tag-free content untouched (thinking = null)", () => {
@@ -47,6 +49,84 @@ describe("responseSanitizer/reasoning — shouldParseTextualReasoningTags", () =
   });
   it("returns false when provider/model are missing", () => {
     assert.equal(shouldParseTextualReasoningTags(undefined, undefined), false);
+  });
+});
+
+// ── MiniMax M3 textual reasoning-tag route (9router#2231) ──────────────────────
+//
+// MiniMax M3 leaks raw <think>...</think> into `content` instead of a separate
+// reasoning_content field on the 8 OpenAI-format provider tiers below. The two
+// direct minimax/minimax-cn tiers stay on Anthropic's Messages format
+// (targetFormat: "claude") and already surface reasoning natively — they must
+// stay unaffected.
+describe("responseSanitizer/reasoning — MiniMax M3 textual reasoning-tag route", () => {
+  const affectedRoutes: Array<[string, string]> = [
+    ["trae", "minimax-m3"],
+    ["huggingchat", "minimaxai/minimax-m3"],
+    ["bazaarlink", "minimax-m3"],
+    ["ollama-cloud", "minimax-m3"],
+    ["opencode", "minimax-m3-free"],
+    ["cline", "minimax/minimax-m3"],
+    ["opencode-zen", "minimax-m3"],
+    ["codebuddy-cn", "minimax-m3"],
+  ];
+
+  for (const [provider, model] of affectedRoutes) {
+    it(`isTextualReasoningTagNativeRoute("${provider}", "${model}") === true`, () => {
+      assert.equal(isTextualReasoningTagNativeRoute(provider, model), true);
+    });
+  }
+
+  it("shouldParseTextualReasoningTags is true for a mixed-case MiniMax M3 model id (huggingchat)", () => {
+    assert.equal(shouldParseTextualReasoningTags("huggingchat", "MiniMaxAI/MiniMax-M3"), true);
+  });
+
+  it("extracts <think>...</think> from delta.content into reasoning_content on an affected route", () => {
+    const chunk = {
+      choices: [{ index: 0, delta: { content: "<think>reasoning here</think>final answer" } }],
+    };
+    const sanitized = sanitizeOpenAIResponse(chunk, {
+      parseTextualReasoningTags: shouldParseTextualReasoningTags("trae", "minimax-m3"),
+    }) as { choices: Array<{ delta: { content: string; reasoning_content?: string } }> };
+
+    const delta = sanitized.choices[0].delta;
+    assert.equal(delta.content, "final answer");
+    assert.equal(delta.reasoning_content, "reasoning here");
+  });
+
+  it("leaves <think> tags untouched in content when the route is not tag-native (pre-fix behavior)", () => {
+    const chunk = {
+      choices: [{ index: 0, delta: { content: "<think>reasoning here</think>final answer" } }],
+    };
+    const sanitized = sanitizeOpenAIResponse(chunk, {
+      parseTextualReasoningTags: shouldParseTextualReasoningTags("openai", "gpt-4"),
+    }) as { choices: Array<{ delta: { content: string; reasoning_content?: string } }> };
+
+    const delta = sanitized.choices[0].delta;
+    assert.equal(delta.content, "<think>reasoning here</think>final answer");
+    assert.equal(delta.reasoning_content, undefined);
+  });
+});
+
+describe("responseSanitizer/reasoning — MiniMax M3 fix regression guards", () => {
+  it("direct minimax tier (claude format) stays unaffected", () => {
+    assert.equal(isTextualReasoningTagNativeRoute("minimax", "minimax-m3"), false);
+    assert.equal(shouldParseTextualReasoningTags("minimax", "MiniMax-M3"), false);
+  });
+
+  it("direct minimax-cn tier (claude format) stays unaffected", () => {
+    assert.equal(isTextualReasoningTagNativeRoute("minimax-cn", "minimax-m3"), false);
+    assert.equal(shouldParseTextualReasoningTags("minimax-cn", "MiniMax-M3"), false);
+  });
+
+  it("MiniMax M2.x (non-M3) models on OpenAI-format tiers stay unaffected", () => {
+    assert.equal(isTextualReasoningTagNativeRoute("trae", "minimax-m2.7"), false);
+  });
+
+  it("existing deepseek-r1 / qwq textual-reasoning routes are unaffected", () => {
+    assert.equal(shouldParseTextualReasoningTags("together", "deepseek-ai/DeepSeek-R1"), true);
+    assert.equal(shouldParseTextualReasoningTags("cloudflare-ai", "@cf/qwen/qwq-32b"), true);
+    assert.equal(shouldParseTextualReasoningTags("openrouter", "deepseek/deepseek-v4-pro"), false);
   });
 });
 


### PR DESCRIPTION
Replacement for #5804 replayed cleanly onto release/v3.8.44.\n\nWhat changed:\n- Extracts MiniMax M3 <think> blocks into reasoning_content for OpenAI-format tiers.\n- Keeps visible content split behavior covered by sanitizer tests.\n- Carries the changelog note without the stale branch conflicts.\n\nValidation:\n- npm exec --yes tsx -- --test tests/unit/responsesanitizer-reasoning-split.test.ts\n- npm exec --yes tsx -- --test tests/unit/role-normalizer.test.ts\n- npm run check:docs-sync