### PR TITLE
refactor(sse): extract applyStrategyOrdering leaf from handleComboChat (Block J Task 3)

### DIFF
--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -53,20 +53,16 @@ import { emit } from "../../src/lib/events/eventBus";
 import { notifyWebhookEvent } from "../../src/lib/webhookDispatcher";
 import { parseAutoPrefix } from "./autoCombo/autoPrefix.ts";
 import { resolveAutoStrategyOrder } from "./combo/resolveAutoStrategy.ts";
+import { applyStrategyOrdering } from "./combo/applyStrategyOrdering.ts";
 import { handlePipelineCombo, buildPipelineResponse } from "./autoCombo/pipelineRouter.ts";
 import { type ProviderCandidate } from "./autoCombo/scoring.ts";
 import { estimateTokens } from "./contextManager.ts";
 import { getSessionConnection } from "./sessionManager.ts";
 import { applySessionStickiness, recordStickyBinding } from "./combo/sessionStickiness.ts";
 import { selectQuotaShareTarget } from "./combo/quotaShareStrategy.ts";
-import {
-  resolveMaxConcurrentByConnection,
-  makeConnectionConcurrencyResolver,
-  lookupPositiveCap,
-} from "./combo/concurrencyCaps.ts";
+import { makeConnectionConcurrencyResolver, lookupPositiveCap } from "./combo/concurrencyCaps.ts";
 import { acquireQuotaShareConcurrencySlot } from "./combo/quotaShareConcurrency.ts";
 import { orderTargetsByEvalScores } from "./evalRouting.ts";
-import { generateRoutingHints } from "./manifestAdapter";
 import type { CompressionMode } from "./compression/types.ts";
 import { getProviderConnections } from "../../src/lib/db/providers";
 import {
@@ -138,17 +134,11 @@ import {
 } from "./combo/providerWildcard.ts";
 import { resolveShadowTargets, scheduleShadowRouting } from "./combo/shadowRouting.ts";
 import {
-  sortTargetsByCost,
-  sortTargetsByUsage,
-  orderTargetsByPowerOfTwoChoices,
-} from "./combo/targetSorters.ts";
-import {
   filterTargetsByRequestCompatibility,
   resolveComboRuntimeUnits,
   resolveComboTargets,
   resolveWeightedTargets,
   resolveWeightedStepGroups,
-  sortTargetsByContextSize,
 } from "./combo/comboStructure.ts";
 import {
   QUOTA_SOFT_DEPRIORITIZE_FACTOR,
@@ -167,9 +157,6 @@ import {
 import {
   fetchResetAwareQuotaWithCache,
   preScreenTargets,
-  orderTargetsByResetAwareQuota,
-  orderTargetsByResetWindow,
-  orderTargetsByHeadroom,
   type PreScreenResult,
 } from "./combo/quotaStrategies.ts";
 import {
@@ -1061,183 +1048,14 @@ export async function handleComboChat({
     if ("earlyResponse" in autoResult) return autoResult.earlyResponse;
     orderedTargets = autoResult.orderedTargets;
     autoUsedExplicitRouter = autoResult.autoUsedExplicitRouter;
-  } else if (strategy === "lkgp") {
-    try {
-      const { getLKGP } = await import("../../src/lib/localDb");
-      const lkgpProvider = await getLKGP(combo.name, combo.id || combo.name);
-
-      if (lkgpProvider) {
-        const lkgpRecord = lkgpProvider;
-        const providerName = lkgpRecord.provider;
-        const connId = lkgpRecord.connectionId;
-
-        let lkgpIndex = -1;
-        if (connId) {
-          lkgpIndex = orderedTargets.findIndex(
-            (target) => target.provider === providerName && target.connectionId === connId
-          );
-        }
-        if (lkgpIndex < 0) {
-          lkgpIndex = orderedTargets.findIndex(
-            (target) =>
-              target.provider === providerName ||
-              // Issue #2359: Defensive guard. The `target.modelStr` type
-              // annotation is `string`, but malformed combo entries (e.g.,
-              // local-provider rows whose `modelStr` failed to resolve when
-              // the executor catalogue was being rebuilt) have leaked
-              // through and surfaced as `e.startsWith is not a function`
-              // 500s on combo test/dispatch. The fast path stays
-              // unchanged for the common case; this only avoids the
-              // crash when the field is unexpectedly non-string.
-              (typeof target.modelStr === "string" &&
-                target.modelStr.startsWith(`${providerName}/`))
-          );
-        }
-
-        if (lkgpIndex > 0) {
-          const [lkgpTarget] = orderedTargets.splice(lkgpIndex, 1);
-          orderedTargets.unshift(lkgpTarget);
-          log.info(
-            "COMBO",
-            `[LKGP] Prioritizing last known good provider ${providerName}${connId ? ` (account ${connId})` : ""} for combo "${combo.name}"`
-          );
-        } else if (lkgpIndex === 0) {
-          log.debug?.(
-            "COMBO",
-            `[LKGP] Last known good provider ${providerName}${connId ? ` (account ${connId})` : ""} already first for combo "${combo.name}"`
-          );
-        }
-      }
-    } catch (err) {
-      log.warn("COMBO", "Failed to retrieve Last Known Good Provider. This is non-fatal.", { err });
-    }
-  } else if (strategy === "strict-random") {
-    const selectedExecutionKey = await getNextFromDeck(
-      `combo:${combo.name}`,
-      orderedTargets.map((target) => target.executionKey)
-    );
-    const selectedTarget =
-      orderedTargets.find((target) => target.executionKey === selectedExecutionKey) || null;
-    // #3959: shuffle the fallback remainder too. Previously `rest` kept fixed
-    // priority order, so after a failing deck pick the chain always fell through
-    // to the same top-priority model — a persistently-failing model was retried
-    // on essentially every request and fallback load never spread across peers.
-    const rest = fisherYatesShuffle(
-      orderedTargets.filter((target) => target.executionKey !== selectedExecutionKey)
-    );
-    orderedTargets = [selectedTarget, ...rest].filter(
-      (target): target is ResolvedComboTarget => target !== null
-    );
-    log.info(
-      "COMBO",
-      `Strict-random deck: ${selectedExecutionKey} selected (${orderedTargets.length} targets)`
-    );
-  } else if (strategy === "random") {
-    orderedTargets = fisherYatesShuffle([...orderedTargets]);
-    log.info("COMBO", `Random shuffle: ${orderedTargets.length} targets`);
-  } else if (strategy === "fill-first") {
-    log.info(
-      "COMBO",
-      `Fill-first ordering: preserving priority order (${orderedTargets.length} targets)`
-    );
-  } else if (strategy === "p2c") {
-    orderedTargets = orderTargetsByPowerOfTwoChoices(orderedTargets, combo.name);
-    log.info("COMBO", `Power-of-two-choices ordering: selected ${orderedTargets[0]?.modelStr}`);
-  } else if (strategy === "least-used") {
-    orderedTargets = sortTargetsByUsage(orderedTargets, combo.name);
-    log.info("COMBO", `Least-used ordering: ${orderedTargets[0]?.modelStr} has fewest requests`);
-  } else if (strategy === "cost-optimized") {
-    orderedTargets = await sortTargetsByCost(orderedTargets);
-    if (config.manifestRouting === true) {
-      try {
-        const manifestHint = generateRoutingHints(
-          orderedTargets.filter((t) => t.kind === "model"),
-          {
-            messages: Array.isArray(body?.messages)
-              ? (body.messages as Array<{ role?: string; content?: string | unknown }>)
-              : [],
-            tools: Array.isArray(body?.tools)
-              ? (body.tools as Array<{
-                  function?: { name: string; description?: string; parameters?: unknown };
-                }>)
-              : undefined,
-            model: typeof body?.model === "string" ? body.model : undefined,
-          }
-        );
-        if (manifestHint.strategyModifier === "require-premium") {
-          const eligible = orderedTargets.filter(
-            (t) =>
-              t.kind !== "model" ||
-              manifestHint.eligibleTargets.some(
-                (e) => e.provider === t.provider && e.modelStr === t.modelStr
-              )
-          );
-          if (eligible.length > 0) orderedTargets = eligible;
-        }
-        log.debug?.(
-          {
-            strategyModifier: manifestHint.strategyModifier,
-            specificityLevel: manifestHint.specificityLevel,
-            score: manifestHint.specificity.score,
-          },
-          "manifest routing applied"
-        );
-      } catch (err) {
-        log.warn({ err }, "manifest routing failed, falling back to standard strategy");
-      }
-    }
-    log.info("COMBO", `Cost-optimized ordering: cheapest first (${orderedTargets[0]?.modelStr})`);
-  } else if (strategy === "reset-aware") {
-    orderedTargets = await orderTargetsByResetAwareQuota(
-      orderedTargets,
-      combo.name,
+  } else {
+    orderedTargets = await applyStrategyOrdering(strategy, orderedTargets, {
+      combo,
       config,
+      body,
       log,
-      apiKeyAllowedConnections
-    );
-    log.info(
-      "COMBO",
-      `Reset-aware ordering: ${orderedTargets[0]?.modelStr}${orderedTargets[0]?.connectionId ? ` (${orderedTargets[0].connectionId})` : ""} first`
-    );
-  } else if (strategy === "reset-window") {
-    orderedTargets = await orderTargetsByResetWindow(
-      orderedTargets,
-      combo.name,
-      config,
-      log,
-      apiKeyAllowedConnections
-    );
-    log.info(
-      "COMBO",
-      `Reset-window ordering: ${orderedTargets[0]?.modelStr}${orderedTargets[0]?.connectionId ? ` (${orderedTargets[0].connectionId})` : ""} first`
-    );
-  } else if (strategy === "context-optimized") {
-    orderedTargets = sortTargetsByContextSize(orderedTargets);
-    log.info("COMBO", `Context-optimized ordering: largest first (${orderedTargets[0]?.modelStr})`);
-  } else if (strategy === "headroom") {
-    orderedTargets = await orderTargetsByHeadroom(
-      orderedTargets,
-      combo.name,
-      log,
-      apiKeyAllowedConnections
-    );
-    log.info(
-      "COMBO",
-      `Headroom ordering: ${orderedTargets[0]?.modelStr}${orderedTargets[0]?.connectionId ? ` (${orderedTargets[0].connectionId})` : ""} has most free capacity`
-    );
-  } else if (strategy === "quota-share") {
-    // Internal quota-share combos (qtSd/): delegate to the dedicated module (DRR +
-    // P2C in-flight + per-model bucket gating + per-connection concurrency gating).
-    const qsModel =
-      typeof body?.model === "string" ? body.model : (orderedTargets[0]?.modelStr ?? "");
-    const qsMaxConcurrent = await resolveMaxConcurrentByConnection(orderedTargets);
-    orderedTargets = selectQuotaShareTarget(orderedTargets, combo.name, qsModel, Date.now(), {
-      maxConcurrentByConnection: qsMaxConcurrent,
-    }).orderedTargets;
-    log.info(
-      "COMBO",
-      `Quota-share ordering: ${orderedTargets[0]?.modelStr}${orderedTargets[0]?.connectionId ? ` (${orderedTargets[0].connectionId})` : ""} selected (DRR+P2C)`
-    );
+      apiKeyAllowedConnections,
+    });
   }
   const _sticky = await applySessionStickiness(
     orderedTargets,

--- a/open-sse/services/combo/applyStrategyOrdering.ts
+++ b/open-sse/services/combo/applyStrategyOrdering.ts
@@ -1,0 +1,226 @@
+import { fisherYatesShuffle, getNextFromDeck } from "../../../src/shared/utils/shuffleDeck";
+import { generateRoutingHints } from "../manifestAdapter";
+import { resolveMaxConcurrentByConnection } from "./concurrencyCaps.ts";
+import { sortTargetsByContextSize } from "./comboStructure.ts";
+import { selectQuotaShareTarget } from "./quotaShareStrategy.ts";
+import {
+  orderTargetsByHeadroom,
+  orderTargetsByResetAwareQuota,
+  orderTargetsByResetWindow,
+} from "./quotaStrategies.ts";
+import {
+  orderTargetsByPowerOfTwoChoices,
+  sortTargetsByCost,
+  sortTargetsByUsage,
+} from "./targetSorters.ts";
+import type { ComboLike, ComboLogger, ResolvedComboTarget } from "./types.ts";
+
+export interface ApplyStrategyOrderingDeps {
+  combo: ComboLike;
+  config: Record<string, unknown>;
+  body: Record<string, unknown>;
+  log: ComboLogger;
+  apiKeyAllowedConnections: string[] | null;
+}
+
+/**
+ * Apply the target-ordering step for every non-`auto` combo strategy.
+ *
+ * Extracted verbatim from the `else if (strategy === ...)` chain in
+ * handleComboChat (lkgp / strict-random / random / fill-first / p2c /
+ * least-used / cost-optimized / reset-aware / reset-window / context-optimized /
+ * headroom / quota-share). Each branch only reorders `orderedTargets` — no early
+ * returns, no other mutable state — so the extraction returns the reordered list.
+ * An unknown strategy falls through with the input order unchanged, matching the
+ * previous inline behavior (the chain had no trailing `else`). The `auto` strategy
+ * is handled separately by `resolveAutoStrategyOrder` and never reaches here.
+ */
+export async function applyStrategyOrdering(
+  strategy: string,
+  initialOrderedTargets: ResolvedComboTarget[],
+  deps: ApplyStrategyOrderingDeps
+): Promise<ResolvedComboTarget[]> {
+  const { combo, config, body, log, apiKeyAllowedConnections } = deps;
+  let orderedTargets = initialOrderedTargets;
+
+  if (strategy === "lkgp") {
+    try {
+      const { getLKGP } = await import("../../../src/lib/localDb");
+      const lkgpProvider = await getLKGP(combo.name, combo.id || combo.name);
+
+      if (lkgpProvider) {
+        const lkgpRecord = lkgpProvider;
+        const providerName = lkgpRecord.provider;
+        const connId = lkgpRecord.connectionId;
+
+        let lkgpIndex = -1;
+        if (connId) {
+          lkgpIndex = orderedTargets.findIndex(
+            (target) => target.provider === providerName && target.connectionId === connId
+          );
+        }
+        if (lkgpIndex < 0) {
+          lkgpIndex = orderedTargets.findIndex(
+            (target) =>
+              target.provider === providerName ||
+              // Issue #2359: Defensive guard. The `target.modelStr` type
+              // annotation is `string`, but malformed combo entries (e.g.,
+              // local-provider rows whose `modelStr` failed to resolve when
+              // the executor catalogue was being rebuilt) have leaked
+              // through and surfaced as `e.startsWith is not a function`
+              // 500s on combo test/dispatch. The fast path stays
+              // unchanged for the common case; this only avoids the
+              // crash when the field is unexpectedly non-string.
+              (typeof target.modelStr === "string" &&
+                target.modelStr.startsWith(`${providerName}/`))
+          );
+        }
+
+        if (lkgpIndex > 0) {
+          const [lkgpTarget] = orderedTargets.splice(lkgpIndex, 1);
+          orderedTargets.unshift(lkgpTarget);
+          log.info(
+            "COMBO",
+            `[LKGP] Prioritizing last known good provider ${providerName}${connId ? ` (account ${connId})` : ""} for combo "${combo.name}"`
+          );
+        } else if (lkgpIndex === 0) {
+          log.debug?.(
+            "COMBO",
+            `[LKGP] Last known good provider ${providerName}${connId ? ` (account ${connId})` : ""} already first for combo "${combo.name}"`
+          );
+        }
+      }
+    } catch (err) {
+      log.warn("COMBO", "Failed to retrieve Last Known Good Provider. This is non-fatal.", { err });
+    }
+  } else if (strategy === "strict-random") {
+    const selectedExecutionKey = await getNextFromDeck(
+      `combo:${combo.name}`,
+      orderedTargets.map((target) => target.executionKey)
+    );
+    const selectedTarget =
+      orderedTargets.find((target) => target.executionKey === selectedExecutionKey) || null;
+    // #3959: shuffle the fallback remainder too. Previously `rest` kept fixed
+    // priority order, so after a failing deck pick the chain always fell through
+    // to the same top-priority model — a persistently-failing model was retried
+    // on essentially every request and fallback load never spread across peers.
+    const rest = fisherYatesShuffle(
+      orderedTargets.filter((target) => target.executionKey !== selectedExecutionKey)
+    );
+    orderedTargets = [selectedTarget, ...rest].filter(
+      (target): target is ResolvedComboTarget => target !== null
+    );
+    log.info(
+      "COMBO",
+      `Strict-random deck: ${selectedExecutionKey} selected (${orderedTargets.length} targets)`
+    );
+  } else if (strategy === "random") {
+    orderedTargets = fisherYatesShuffle([...orderedTargets]);
+    log.info("COMBO", `Random shuffle: ${orderedTargets.length} targets`);
+  } else if (strategy === "fill-first") {
+    log.info(
+      "COMBO",
+      `Fill-first ordering: preserving priority order (${orderedTargets.length} targets)`
+    );
+  } else if (strategy === "p2c") {
+    orderedTargets = orderTargetsByPowerOfTwoChoices(orderedTargets, combo.name);
+    log.info("COMBO", `Power-of-two-choices ordering: selected ${orderedTargets[0]?.modelStr}`);
+  } else if (strategy === "least-used") {
+    orderedTargets = sortTargetsByUsage(orderedTargets, combo.name);
+    log.info("COMBO", `Least-used ordering: ${orderedTargets[0]?.modelStr} has fewest requests`);
+  } else if (strategy === "cost-optimized") {
+    orderedTargets = await sortTargetsByCost(orderedTargets);
+    if (config.manifestRouting === true) {
+      try {
+        const manifestHint = generateRoutingHints(
+          orderedTargets.filter((t) => t.kind === "model"),
+          {
+            messages: Array.isArray(body?.messages)
+              ? (body.messages as Array<{ role?: string; content?: string | unknown }>)
+              : [],
+            tools: Array.isArray(body?.tools)
+              ? (body.tools as Array<{
+                  function?: { name: string; description?: string; parameters?: unknown };
+                }>)
+              : undefined,
+            model: typeof body?.model === "string" ? body.model : undefined,
+          }
+        );
+        if (manifestHint.strategyModifier === "require-premium") {
+          const eligible = orderedTargets.filter(
+            (t) =>
+              t.kind !== "model" ||
+              manifestHint.eligibleTargets.some(
+                (e) => e.provider === t.provider && e.modelStr === t.modelStr
+              )
+          );
+          if (eligible.length > 0) orderedTargets = eligible;
+        }
+        log.debug?.(
+          {
+            strategyModifier: manifestHint.strategyModifier,
+            specificityLevel: manifestHint.specificityLevel,
+            score: manifestHint.specificity.score,
+          },
+          "manifest routing applied"
+        );
+      } catch (err) {
+        log.warn({ err }, "manifest routing failed, falling back to standard strategy");
+      }
+    }
+    log.info("COMBO", `Cost-optimized ordering: cheapest first (${orderedTargets[0]?.modelStr})`);
+  } else if (strategy === "reset-aware") {
+    orderedTargets = await orderTargetsByResetAwareQuota(
+      orderedTargets,
+      combo.name,
+      config,
+      log,
+      apiKeyAllowedConnections
+    );
+    log.info(
+      "COMBO",
+      `Reset-aware ordering: ${orderedTargets[0]?.modelStr}${orderedTargets[0]?.connectionId ? ` (${orderedTargets[0].connectionId})` : ""} first`
+    );
+  } else if (strategy === "reset-window") {
+    orderedTargets = await orderTargetsByResetWindow(
+      orderedTargets,
+      combo.name,
+      config,
+      log,
+      apiKeyAllowedConnections
+    );
+    log.info(
+      "COMBO",
+      `Reset-window ordering: ${orderedTargets[0]?.modelStr}${orderedTargets[0]?.connectionId ? ` (${orderedTargets[0].connectionId})` : ""} first`
+    );
+  } else if (strategy === "context-optimized") {
+    orderedTargets = sortTargetsByContextSize(orderedTargets);
+    log.info("COMBO", `Context-optimized ordering: largest first (${orderedTargets[0]?.modelStr})`);
+  } else if (strategy === "headroom") {
+    orderedTargets = await orderTargetsByHeadroom(
+      orderedTargets,
+      combo.name,
+      log,
+      apiKeyAllowedConnections
+    );
+    log.info(
+      "COMBO",
+      `Headroom ordering: ${orderedTargets[0]?.modelStr}${orderedTargets[0]?.connectionId ? ` (${orderedTargets[0].connectionId})` : ""} has most free capacity`
+    );
+  } else if (strategy === "quota-share") {
+    // Internal quota-share combos (qtSd/): delegate to the dedicated module (DRR +
+    // P2C in-flight + per-model bucket gating + per-connection concurrency gating).
+    const qsModel =
+      typeof body?.model === "string" ? body.model : (orderedTargets[0]?.modelStr ?? "");
+    const qsMaxConcurrent = await resolveMaxConcurrentByConnection(orderedTargets);
+    orderedTargets = selectQuotaShareTarget(orderedTargets, combo.name, qsModel, Date.now(), {
+      maxConcurrentByConnection: qsMaxConcurrent,
+    }).orderedTargets;
+    log.info(
+      "COMBO",
+      `Quota-share ordering: ${orderedTargets[0]?.modelStr}${orderedTargets[0]?.connectionId ? ` (${orderedTargets[0].connectionId})` : ""} selected (DRR+P2C)`
+    );
+  }
+
+  return orderedTargets;
+}

--- a/scripts/check/check-known-symbols.ts
+++ b/scripts/check/check-known-symbols.ts
@@ -473,7 +473,16 @@ async function main(): Promise<void> {
     ...(strategiesMod.ROUTING_STRATEGY_VALUES as readonly string[]),
     ...(strategiesMod.INTERNAL_ROUTING_STRATEGY_VALUES as readonly string[]),
   ];
-  const comboSource = readFileSync(resolvePath(REPO_ROOT, "open-sse/services/combo.ts"), "utf8");
+  // The combo dispatch was decomposed (Block J): the `strategy === "..."` branches
+  // now live across combo.ts + its strategy-ordering leaves, so scan all of them.
+  const comboDispatchFiles = [
+    "open-sse/services/combo.ts",
+    "open-sse/services/combo/applyStrategyOrdering.ts",
+    "open-sse/services/combo/resolveAutoStrategy.ts",
+  ];
+  const comboSource = comboDispatchFiles
+    .map((rel) => readFileSync(resolvePath(REPO_ROOT, rel), "utf8"))
+    .join("\n");
   const handled = extractHandledStrategies(comboSource);
 
   // Stale-enforcement (6A.3): IMPLICIT_DEFAULT_STRATEGIES is a suppression allowlist —

--- a/tests/unit/combo-apply-strategy-ordering-split.test.ts
+++ b/tests/unit/combo-apply-strategy-ordering-split.test.ts
@@ -1,0 +1,72 @@
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+
+import { applyStrategyOrdering } from "@omniroute/open-sse/services/combo/applyStrategyOrdering.ts";
+import { resetDbInstance } from "@/lib/db/core.ts";
+
+// Split guard for Block J Task 3: the non-`auto` strategy-ordering chain
+// (lkgp / strict-random / random / fill-first / p2c / ... / quota-share) was
+// extracted verbatim into applyStrategyOrdering. These tests pin the exits that
+// need no DB/deck state (random / fill-first / unknown); the DB-backed branches
+// (lkgp, reset-*, quota-share) are covered end-to-end by the 47 consumer tests
+// (router-strategies / combo-strategy-fallbacks / rr-session-stickiness).
+
+after(() => {
+  // some branches (lkgp/quota-share) may touch the DB singleton; release handles.
+  resetDbInstance();
+});
+
+const noopLog = { info() {}, warn() {}, error() {}, debug() {} } as never;
+
+const target = (provider: string, modelStr: string): never =>
+  ({
+    kind: "model",
+    stepId: "s1",
+    executionKey: `${provider}>${modelStr}`,
+    modelStr,
+    provider,
+    providerId: null,
+    connectionId: null,
+    weight: 1,
+    label: null,
+  }) as never;
+
+const deps = () =>
+  ({
+    combo: { id: "c1", name: "c1", config: {} },
+    config: {},
+    body: { messages: [] },
+    log: noopLog,
+    apiKeyAllowedConnections: null,
+  }) as never;
+
+const keys = (arr: Array<{ executionKey: string }>) => arr.map((t) => t.executionKey).sort();
+
+test("exports applyStrategyOrdering", () => {
+  assert.equal(typeof applyStrategyOrdering, "function");
+});
+
+test("unknown strategy -> input order unchanged (same reference contents)", async () => {
+  const input = [target("openai", "gpt-4o"), target("anthropic", "claude-3")];
+  const out = await applyStrategyOrdering("no-such-strategy", input, deps());
+  assert.deepEqual(
+    out.map((t: { executionKey: string }) => t.executionKey),
+    ["openai>gpt-4o", "anthropic>claude-3"]
+  );
+});
+
+test("fill-first -> preserves priority order", async () => {
+  const input = [target("a", "m1"), target("b", "m2"), target("c", "m3")];
+  const out = await applyStrategyOrdering("fill-first", input, deps());
+  assert.deepEqual(
+    out.map((t: { executionKey: string }) => t.executionKey),
+    ["a>m1", "b>m2", "c>m3"]
+  );
+});
+
+test("random -> same multiset of targets (a permutation)", async () => {
+  const input = [target("a", "m1"), target("b", "m2"), target("c", "m3")];
+  const out = await applyStrategyOrdering("random", input, deps());
+  assert.equal(out.length, 3);
+  assert.deepEqual(keys(out), keys(input));
+});

--- a/tests/unit/combo-target-defensive-modelstr.test.ts
+++ b/tests/unit/combo-target-defensive-modelstr.test.ts
@@ -14,16 +14,22 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const COMBO_SRC = path.resolve(__dirname, "../../open-sse/services/combo.ts");
+// The LKGP fallback (and every non-auto strategy ordering) was extracted verbatim
+// from combo.ts into the applyStrategyOrdering leaf (Block J Task 3); the guard
+// scans follow the code to the leaf that now owns the `target.modelStr` usages.
+const STRATEGY_SRC = path.resolve(
+  __dirname,
+  "../../open-sse/services/combo/applyStrategyOrdering.ts"
+);
 const TEST_ROUTE_SRC = path.resolve(__dirname, "../../src/app/api/combos/test/route.ts");
 
-test("#2359 combo.ts LKGP findIndex guards modelStr against non-string", () => {
-  const src = fs.readFileSync(COMBO_SRC, "utf8");
+test("#2359 LKGP findIndex guards modelStr against non-string", () => {
+  const src = fs.readFileSync(STRATEGY_SRC, "utf8");
   // The findIndex on orderedTargets must check `typeof target.modelStr === "string"`
   // before calling .startsWith. Anchor on the LKGP fallback branch.
   assert.ok(
     /typeof target\.modelStr === "string"[\s\S]{0,80}target\.modelStr\.startsWith/.test(src),
-    "LKGP fallback in combo.ts must type-check target.modelStr before calling .startsWith"
+    "LKGP fallback must type-check target.modelStr before calling .startsWith"
   );
 });
 
@@ -41,8 +47,8 @@ test("#2359 combo test route falls back instead of throwing on missing modelStr"
   );
 });
 
-test("#2359 combo.ts has no remaining unguarded target.modelStr.<method> usages", () => {
-  const src = fs.readFileSync(COMBO_SRC, "utf8");
+test("#2359 strategy ordering has no remaining unguarded target.modelStr.<method> usages", () => {
+  const src = fs.readFileSync(STRATEGY_SRC, "utf8");
   // Strip the line that contains the guard so the regex below only catches
   // direct, unguarded method calls.
   const stripped = src.replace(/typeof target\.modelStr === "string"[^\n]*\n[^\n]*/g, "");


### PR DESCRIPTION
## Block J Task 3 — extract the non-auto strategy-ordering chain

Follows #6049 (parseAutoConfig + resolveAutoStrategyOrder). Extracts the ~177-line `else if (strategy === ...)` chain covering **every non-auto combo strategy** (lkgp / strict-random / random / fill-first / p2c / least-used / cost-optimized / reset-aware / reset-window / context-optimized / headroom / quota-share) into `open-sse/services/combo/applyStrategyOrdering.ts`.

Each branch only reorders `orderedTargets` — no early returns, no other mutable state — so this is a clean verbatim move returning the reordered list. The host replaces the chain with `else { orderedTargets = await applyStrategyOrdering(strategy, orderedTargets, deps); }`. An unknown strategy falls through with the input order unchanged (matching the previous no-trailing-`else` behavior).

### Why it's safe
- **Semantic verbatim**: diff vs the original chain = only the leading `if` (was `} else if`), the trailing `return` and the deeper `getLKGP` import path — no logic line changed.
- **No cycle / no DI**: none of the 13 strategy helpers live in `combo.ts` (unlike the auto branch's `buildAutoCandidates`), so the leaf imports them directly.
- `typecheck:core` + `check:cycles` clean; 9 dead host imports removed (`targetSorters` block emptied); `check:file-size` (combo.ts shrink-only) OK.
- **combo.ts 3065 → 2883 LOC** (3309 → 2883 across Task 2+3).
- 47/47 consumer tests (router-strategies / combo-strategy-fallbacks / rr-session-stickiness / tag-routing) cover the DB-backed branches end-to-end; new `tests/unit/combo-apply-strategy-ordering-split.test.ts` pins random / fill-first / unknown exits.

### Test plan
```
npm run typecheck:core && npm run check:cycles
node --import tsx/esm --test tests/unit/combo-apply-strategy-ordering-split.test.ts
node --import tsx/esm --test tests/unit/router-strategies.test.ts tests/unit/combo-strategy-fallbacks.test.ts
```