### PR TITLE
feat(providers): add Kenari OpenAI-compatible gateway provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### ✨ New Features
+
+- **providers (Kenari):** add [Kenari](https://kenari.id), an Indonesian OpenAI-compatible AI gateway billed in Rupiah (IDR). One `kn-` API key covers the whole catalog (Claude, GPT, DeepSeek, GLM, Kimi and more); the model list stays live via the public `https://kenari.id/v1/models` catalog (`passthroughModels`). Registered as an aggregator gateway. Regression guard: `tests/unit/kenari-provider-integrity.test.ts`.
+
 ---
 
 ## [3.8.43] — 2026-07-02

--- a/open-sse/config/providers/index.ts
+++ b/open-sse/config/providers/index.ts
@@ -86,6 +86,7 @@ import { klusterProvider } from "./registry/kluster/index.ts";
 import { iflytekProvider } from "./registry/iflytek/index.ts";
 import { crofProvider } from "./registry/crof/index.ts";
 import { moonshotProvider } from "./registry/moonshot/index.ts";
+import { kenariProvider } from "./registry/kenari/index.ts";
 import { bazaarlinkProvider } from "./registry/bazaarlink/index.ts";
 import { perplexityProvider } from "./registry/perplexity/index.ts";
 import { perplexity_webProvider } from "./registry/perplexity/web/index.ts";
@@ -296,6 +297,7 @@ export const REGISTRY: Record<string, RegistryEntry> = {
   nanogpt: nanogptProvider,
   scaleway: scalewayProvider,
   agentrouter: agentrouterProvider,
+  kenari: kenariProvider,
   zai: zaiProvider,
   huggingchat: huggingchatProvider,
   galadriel: galadrielProvider,

--- a/open-sse/config/providers/registry/kenari/index.ts
+++ b/open-sse/config/providers/registry/kenari/index.ts
@@ -1,14 +1,10 @@
-import type { RegistryEntry } from "../../shared.ts";
+import { buildOpenAiCompatibleRegistryEntry } from "../../shared.ts";
 
-export const kenariProvider: RegistryEntry = {
+export const kenariProvider = buildOpenAiCompatibleRegistryEntry({
   id: "kenari",
   alias: "kenari",
-  format: "openai",
-  executor: "default",
   baseUrl: "https://kenari.id/v1/chat/completions",
   modelsUrl: "https://kenari.id/v1/models",
-  authType: "apikey",
-  authHeader: "bearer",
   passthroughModels: true,
   models: [],
-};
+});

--- a/open-sse/config/providers/registry/kenari/index.ts
+++ b/open-sse/config/providers/registry/kenari/index.ts
@@ -1,0 +1,14 @@
+import type { RegistryEntry } from "../../shared.ts";
+
+export const kenariProvider: RegistryEntry = {
+  id: "kenari",
+  alias: "kenari",
+  format: "openai",
+  executor: "default",
+  baseUrl: "https://kenari.id/v1/chat/completions",
+  modelsUrl: "https://kenari.id/v1/models",
+  authType: "apikey",
+  authHeader: "bearer",
+  passthroughModels: true,
+  models: [],
+};

--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -64,6 +64,7 @@ export const AGGREGATOR_PROVIDER_IDS = new Set([
   "laozhang",
   "vercel-ai-gateway",
   "agentrouter",
+  "kenari",
   "glhf",
   "cablyai",
   "thebai",

--- a/src/shared/constants/providers/apikey/gateways.ts
+++ b/src/shared/constants/providers/apikey/gateways.ts
@@ -16,6 +16,20 @@ export const APIKEY_PROVIDERS_GATEWAYS = {
     freeNote: "$200 free credits on signup - multi-model routing gateway",
     apiHint: "Get $200 free credits at https://agentrouter.org/register — no credit card required.",
   },
+  kenari: {
+    id: "kenari",
+    alias: "kenari",
+    name: "Kenari",
+    icon: "router",
+    color: "#B5362A",
+    textIcon: "KN",
+    passthroughModels: true,
+    website: "https://kenari.id",
+    authHint:
+      "Use a kn- API key from the Kenari dashboard in Authorization: Bearer <key>. Fully OpenAI-compatible. API base URL: https://kenari.id/v1.",
+    apiHint:
+      "Kenari is an Indonesian AI gateway billed in Rupiah (IDR): one kn- key covers the whole catalog (Claude, GPT, DeepSeek, GLM, Kimi and more). OpenAI-compatible chat completions at https://kenari.id/v1/chat/completions with a public /v1/models catalog. Docs: https://kenari.id/docs, spec: https://kenari.id/openapi.json.",
+  },
   "command-code": {
     id: "command-code",
     alias: "cmd",

--- a/tests/unit/kenari-provider-integrity.test.ts
+++ b/tests/unit/kenari-provider-integrity.test.ts
@@ -1,0 +1,63 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+
+describe("kenari provider entry in APIKEY_PROVIDERS", () => {
+  it("exists with required fields", async () => {
+    const { APIKEY_PROVIDERS } = await import("../../src/shared/constants/providers.ts");
+    const p = (APIKEY_PROVIDERS as Record<string, Record<string, unknown>>)["kenari"];
+    assert.ok(p, "kenari must exist in APIKEY_PROVIDERS");
+    assert.equal(p.id, "kenari");
+    assert.equal(p.alias, "kenari");
+    assert.equal(p.name, "Kenari");
+    assert.equal(p.icon, "router");
+    assert.equal(p.color, "#B5362A");
+    assert.equal(p.textIcon, "KN");
+    assert.equal(p.website, "https://kenari.id");
+    assert.equal(p.passthroughModels, true);
+  });
+
+  it("includes authHint mentioning the kn- key prefix", async () => {
+    const { APIKEY_PROVIDERS } = await import("../../src/shared/constants/providers.ts");
+    const p = (APIKEY_PROVIDERS as Record<string, { authHint?: string; apiHint?: string }>)[
+      "kenari"
+    ];
+    assert.ok(p.authHint, "kenari must have an authHint field");
+    assert.ok(p.authHint.includes("kn-"), "authHint should mention the kn- key prefix");
+    assert.ok(p.apiHint, "kenari must have an apiHint");
+    assert.ok(p.apiHint.includes("kenari.id"), "apiHint should reference kenari.id");
+  });
+
+  it("is flagged as an aggregator gateway", async () => {
+    const { AGGREGATOR_PROVIDER_IDS } = await import("../../src/shared/constants/providers.ts");
+    assert.ok(AGGREGATOR_PROVIDER_IDS.has("kenari"), "kenari must be in AGGREGATOR_PROVIDER_IDS");
+  });
+
+  it("is registered in the execution registry with a live model catalog", async () => {
+    const { getRegistryEntry } = await import("../../open-sse/config/providerRegistry.ts");
+    const entry = getRegistryEntry("kenari");
+    assert.ok(entry, "kenari must have a registry entry");
+    assert.equal(entry.format, "openai");
+    assert.equal(entry.authType, "apikey");
+    assert.equal(entry.baseUrl, "https://kenari.id/v1/chat/completions");
+    assert.equal(entry.modelsUrl, "https://kenari.id/v1/models");
+    assert.equal(entry.passthroughModels, true, "kenari serves its catalog via /v1/models");
+  });
+
+  it("is resolvable through the static catalog for managed connections", async () => {
+    const { resolveStaticProviderCatalogEntry } =
+      await import("../../src/lib/providers/catalog.ts");
+    const entry = resolveStaticProviderCatalogEntry("kenari");
+    assert.ok(entry, "kenari must resolve through the static provider catalog");
+    assert.equal(entry.category, "apikey", "kenari must be in the apikey category");
+  });
+
+  it("passes isManagedProviderConnectionId check so connections can be created", async () => {
+    const { isManagedProviderConnectionId } = await import("../../src/lib/providers/catalog.ts");
+    assert.equal(isManagedProviderConnectionId("kenari"), true);
+  });
+
+  it("supports bulk API key add (not excluded)", async () => {
+    const { supportsBulkApiKey } = await import("../../src/shared/constants/providers.ts");
+    assert.equal(supportsBulkApiKey("kenari"), true);
+  });
+});

--- a/tests/unit/web-cookie-providers-new.test.ts
+++ b/tests/unit/web-cookie-providers-new.test.ts
@@ -679,8 +679,13 @@ test("Kimi Web: targets www.kimi.com (international)", async () => {
       credentials: { apiKey: "kimi-auth=eyJ.eyJzdWI.signature" },
     });
     assert.ok(result.response instanceof Response);
-    assert.ok(result.url.includes("www.kimi.com"), `got ${result.url}`);
-    assert.ok(!result.url.includes("moonshot.cn"));
+    // Parse the URL and assert on the exact hostname rather than a substring
+    // match — `includes("www.kimi.com")` would also accept a hostile host like
+    // `www.kimi.com.evil.net` or `evil.net/?x=www.kimi.com` (CodeQL
+    // js/incomplete-url-substring-sanitization).
+    const host = new URL(result.url).hostname;
+    assert.equal(host, "www.kimi.com", `got ${result.url}`);
+    assert.notEqual(host, "www.moonshot.cn", `got ${result.url}`);
   } finally {
     restore.restore();
   }


### PR DESCRIPTION
### What

Adds [Kenari](https://kenari.id) as an API-key gateway provider. Kenari is an Indonesian OpenAI-compatible AI gateway billed in Rupiah (IDR): one `kn-` API key covers the whole catalog (Claude, GPT, DeepSeek, GLM, Kimi and more).

### How

Follows the "Adding a New Provider" steps in AGENTS.md; default executor and openai format, so no executor/translator/OAuth changes:

- Runtime registry: `open-sse/config/providers/registry/kenari/index.ts` (`format: "openai"`, `authType: "apikey"`, bearer), wired into `open-sse/config/providers/index.ts`.
- Dashboard metadata: `kenari` entry in `src/shared/constants/providers/apikey/gateways.ts`, added to `AGGREGATOR_PROVIDER_IDS` (it is a multi-model gateway).
- Live model list: `modelsUrl: https://kenari.id/v1/models` (public, no key) + `passthroughModels: true` + `models: []`, per the ModelScope precedent (#5965), so the catalog never goes stale.
- Regression guard: `tests/unit/kenari-provider-integrity.test.ts` (7 tests, modeled on the bazaarlink integrity test).
- CHANGELOG entry under Unreleased.

### Verified

- `tests/unit/kenari-provider-integrity.test.ts`: 7/7 pass; `check-provider-consistency`, registry/catalog guard tests, and `chat-openai-compat-providers` all pass; eslint clean on touched files.
- `https://kenari.id/v1/models` returns the catalog with no auth (24 models); chat completions returns 401 without a key, 200 with a `kn-` key.
- Base URL verifiable against https://kenari.id/docs and https://kenari.id/openapi.json.

Disclosure: I run kenari.id.
