### PR TITLE
fix(ci): harden provider translate-path golden on release v3.8.44

### DIFF
--- a/tests/snapshots/provider/translate-path.json
+++ b/tests/snapshots/provider/translate-path.json
@@ -33,10 +33,10 @@
         "Content-Type": "application/json",
         "User-Agent": "claude-cli/2.1.195 (external, cli)",
         "X-App": "cli",
-        "X-Stainless-Arch": "x64",
+        "X-Stainless-Arch": "<ARCH>",
         "X-Stainless-Helper-Method": "stream",
         "X-Stainless-Lang": "js",
-        "X-Stainless-Os": "Linux",
+        "X-Stainless-Os": "<OS>",
         "X-Stainless-Package-Version": "0.94.0",
         "X-Stainless-Retry-Count": "0",
         "X-Stainless-Runtime": "node",
@@ -51,10 +51,10 @@
         "Content-Type": "application/json",
         "User-Agent": "claude-cli/2.1.195 (external, cli)",
         "X-App": "cli",
-        "X-Stainless-Arch": "x64",
+        "X-Stainless-Arch": "<ARCH>",
         "X-Stainless-Helper-Method": "stream",
         "X-Stainless-Lang": "js",
-        "X-Stainless-Os": "Linux",
+        "X-Stainless-Os": "<OS>",
         "X-Stainless-Package-Version": "0.94.0",
         "X-Stainless-Retry-Count": "0",
         "X-Stainless-Runtime": "node",
@@ -70,10 +70,10 @@
         "Content-Type": "application/json",
         "User-Agent": "claude-cli/2.1.195 (external, cli)",
         "X-App": "cli",
-        "X-Stainless-Arch": "x64",
+        "X-Stainless-Arch": "<ARCH>",
         "X-Stainless-Helper-Method": "stream",
         "X-Stainless-Lang": "js",
-        "X-Stainless-Os": "Linux",
+        "X-Stainless-Os": "<OS>",
         "X-Stainless-Package-Version": "0.94.0",
         "X-Stainless-Retry-Count": "0",
         "X-Stainless-Runtime": "node",
@@ -94,18 +94,18 @@
         "Accept": "text/event-stream",
         "Authorization": "Bearer <TOK>",
         "Content-Type": "application/json",
-        "User-Agent": "Antigravity/4.2.0 (X11; Linux x86_64) Chrome/142.0.7444.175 Electron/39.2.3"
+        "User-Agent": "Antigravity/4.2.0 (<PLATFORM>) Chrome/142.0.7444.175 Electron/39.2.3"
       },
       "nonStream": {
         "Authorization": "Bearer <TOK>",
         "Content-Type": "application/json",
-        "User-Agent": "Antigravity/4.2.0 (X11; Linux x86_64) Chrome/142.0.7444.175 Electron/39.2.3"
+        "User-Agent": "Antigravity/4.2.0 (<PLATFORM>) Chrome/142.0.7444.175 Electron/39.2.3"
       },
       "oauth": {
         "Accept": "text/event-stream",
         "Authorization": "Bearer <TOK>",
         "Content-Type": "application/json",
-        "User-Agent": "Antigravity/4.2.0 (X11; Linux x86_64) Chrome/142.0.7444.175 Electron/39.2.3"
+        "User-Agent": "Antigravity/4.2.0 (<PLATFORM>) Chrome/142.0.7444.175 Electron/39.2.3"
       }
     },
     "url": {
@@ -241,18 +241,18 @@
         "Accept": "text/event-stream",
         "Authorization": "Bearer <TOK>",
         "Content-Type": "application/json",
-        "User-Agent": "Antigravity/4.2.0 (X11; Linux x86_64) Chrome/142.0.7444.175 Electron/39.2.3"
+        "User-Agent": "Antigravity/4.2.0 (<PLATFORM>) Chrome/142.0.7444.175 Electron/39.2.3"
       },
       "nonStream": {
         "Authorization": "Bearer <TOK>",
         "Content-Type": "application/json",
-        "User-Agent": "Antigravity/4.2.0 (X11; Linux x86_64) Chrome/142.0.7444.175 Electron/39.2.3"
+        "User-Agent": "Antigravity/4.2.0 (<PLATFORM>) Chrome/142.0.7444.175 Electron/39.2.3"
       },
       "oauth": {
         "Accept": "text/event-stream",
         "Authorization": "Bearer <TOK>",
         "Content-Type": "application/json",
-        "User-Agent": "Antigravity/4.2.0 (X11; Linux x86_64) Chrome/142.0.7444.175 Electron/39.2.3"
+        "User-Agent": "Antigravity/4.2.0 (<PLATFORM>) Chrome/142.0.7444.175 Electron/39.2.3"
       }
     },
     "url": {
@@ -714,10 +714,10 @@
         "Content-Type": "application/json",
         "User-Agent": "claude-cli/2.1.195 (external, cli)",
         "X-App": "cli",
-        "X-Stainless-Arch": "x64",
+        "X-Stainless-Arch": "<ARCH>",
         "X-Stainless-Helper-Method": "stream",
         "X-Stainless-Lang": "js",
-        "X-Stainless-Os": "Linux",
+        "X-Stainless-Os": "<OS>",
         "X-Stainless-Package-Version": "0.94.0",
         "X-Stainless-Retry-Count": "0",
         "X-Stainless-Runtime": "node",
@@ -732,10 +732,10 @@
         "Content-Type": "application/json",
         "User-Agent": "claude-cli/2.1.195 (external, cli)",
         "X-App": "cli",
-        "X-Stainless-Arch": "x64",
+        "X-Stainless-Arch": "<ARCH>",
         "X-Stainless-Helper-Method": "stream",
         "X-Stainless-Lang": "js",
-        "X-Stainless-Os": "Linux",
+        "X-Stainless-Os": "<OS>",
         "X-Stainless-Package-Version": "0.94.0",
         "X-Stainless-Retry-Count": "0",
         "X-Stainless-Runtime": "node",
@@ -751,10 +751,10 @@
         "Content-Type": "application/json",
         "User-Agent": "claude-cli/2.1.195 (external, cli)",
         "X-App": "cli",
-        "X-Stainless-Arch": "x64",
+        "X-Stainless-Arch": "<ARCH>",
         "X-Stainless-Helper-Method": "stream",
         "X-Stainless-Lang": "js",
-        "X-Stainless-Os": "Linux",
+        "X-Stainless-Os": "<OS>",
         "X-Stainless-Package-Version": "0.94.0",
         "X-Stainless-Retry-Count": "0",
         "X-Stainless-Runtime": "node",
@@ -965,7 +965,7 @@
         "Authorization": "Bearer <TOK>",
         "Content-Type": "application/json",
         "Openai-Beta": "responses=experimental",
-        "User-Agent": "codex-cli/0.142.0 (Windows 10.0.26200; x64)",
+        "User-Agent": "codex-cli/0.142.0 (<OS>; <ARCH>)",
         "Version": "0.142.0",
         "X-Codex-Beta-Features": "responses_websockets"
       },
@@ -973,7 +973,7 @@
         "Authorization": "Bearer <TOK>",
         "Content-Type": "application/json",
         "Openai-Beta": "responses=experimental",
-        "User-Agent": "codex-cli/0.142.0 (Windows 10.0.26200; x64)",
+        "User-Agent": "codex-cli/0.142.0 (<OS>; <ARCH>)",
         "Version": "0.142.0",
         "X-Codex-Beta-Features": "responses_websockets"
       },
@@ -982,7 +982,7 @@
         "Authorization": "Bearer <TOK>",
         "Content-Type": "application/json",
         "Openai-Beta": "responses=experimental",
-        "User-Agent": "codex-cli/0.142.0 (Windows 10.0.26200; x64)",
+        "User-Agent": "codex-cli/0.142.0 (<OS>; <ARCH>)",
         "Version": "0.142.0",
         "X-Codex-Beta-Features": "responses_websockets"
       }
@@ -1754,14 +1754,14 @@
         "Authorization": "Bearer <TOK>",
         "Content-Type": "application/json",
         "HTTP-Referer": "https://github.com/Gitlawb/openclaude",
-        "User-Agent": "OpenClaude/1.0 (linux; x86_64)",
+        "User-Agent": "OpenClaude/1.0 (<OS>; <ARCH>)",
         "X-Title": "OpenClaude CLI"
       },
       "nonStream": {
         "Authorization": "Bearer <TOK>",
         "Content-Type": "application/json",
         "HTTP-Referer": "https://github.com/Gitlawb/openclaude",
-        "User-Agent": "OpenClaude/1.0 (linux; x86_64)",
+        "User-Agent": "OpenClaude/1.0 (<OS>; <ARCH>)",
         "X-Title": "OpenClaude CLI"
       },
       "oauth": {
@@ -1769,7 +1769,7 @@
         "Authorization": "Bearer <TOK>",
         "Content-Type": "application/json",
         "HTTP-Referer": "https://github.com/Gitlawb/openclaude",
-        "User-Agent": "OpenClaude/1.0 (linux; x86_64)",
+        "User-Agent": "OpenClaude/1.0 (<OS>; <ARCH>)",
         "X-Title": "OpenClaude CLI"
       }
     },
@@ -1786,14 +1786,14 @@
         "Authorization": "Bearer <TOK>",
         "Content-Type": "application/json",
         "HTTP-Referer": "https://github.com/Gitlawb/openclaude",
-        "User-Agent": "OpenClaude/1.0 (linux; x86_64)",
+        "User-Agent": "OpenClaude/1.0 (<OS>; <ARCH>)",
         "X-Title": "OpenClaude CLI"
       },
       "nonStream": {
         "Authorization": "Bearer <TOK>",
         "Content-Type": "application/json",
         "HTTP-Referer": "https://github.com/Gitlawb/openclaude",
-        "User-Agent": "OpenClaude/1.0 (linux; x86_64)",
+        "User-Agent": "OpenClaude/1.0 (<OS>; <ARCH>)",
         "X-Title": "OpenClaude CLI"
       },
       "oauth": {
@@ -1801,7 +1801,7 @@
         "Authorization": "Bearer <TOK>",
         "Content-Type": "application/json",
         "HTTP-Referer": "https://github.com/Gitlawb/openclaude",
-        "User-Agent": "OpenClaude/1.0 (linux; x86_64)",
+        "User-Agent": "OpenClaude/1.0 (<OS>; <ARCH>)",
         "X-Title": "OpenClaude CLI"
       }
     },
@@ -3516,13 +3516,13 @@
         "Connection": "keep-alive",
         "Content-Type": "application/json",
         "Sec-Fetch-Mode": "cors",
-        "User-Agent": "QwenCode/0.19.3 (linux; x64)",
+        "User-Agent": "QwenCode/0.19.3 (<OS>; <ARCH>)",
         "X-Dashscope-AuthType": "qwen-oauth",
         "X-Dashscope-CacheControl": "enable",
-        "X-Dashscope-UserAgent": "QwenCode/0.19.3 (linux; x64)",
-        "X-Stainless-Arch": "x64",
+        "X-Dashscope-UserAgent": "QwenCode/0.19.3 (<OS>; <ARCH>)",
+        "X-Stainless-Arch": "<ARCH>",
         "X-Stainless-Lang": "js",
-        "X-Stainless-Os": "Linux",
+        "X-Stainless-Os": "<OS>",
         "X-Stainless-Package-Version": "5.11.0",
         "X-Stainless-Retry-Count": "1",
         "X-Stainless-Runtime": "node",
@@ -3534,13 +3534,13 @@
         "Connection": "keep-alive",
         "Content-Type": "application/json",
         "Sec-Fetch-Mode": "cors",
-        "User-Agent": "QwenCode/0.19.3 (linux; x64)",
+        "User-Agent": "QwenCode/0.19.3 (<OS>; <ARCH>)",
         "X-Dashscope-AuthType": "qwen-oauth",
         "X-Dashscope-CacheControl": "enable",
-        "X-Dashscope-UserAgent": "QwenCode/0.19.3 (linux; x64)",
-        "X-Stainless-Arch": "x64",
+        "X-Dashscope-UserAgent": "QwenCode/0.19.3 (<OS>; <ARCH>)",
+        "X-Stainless-Arch": "<ARCH>",
         "X-Stainless-Lang": "js",
-        "X-Stainless-Os": "Linux",
+        "X-Stainless-Os": "<OS>",
         "X-Stainless-Package-Version": "5.11.0",
         "X-Stainless-Retry-Count": "1",
         "X-Stainless-Runtime": "node",
@@ -3553,13 +3553,13 @@
         "Connection": "keep-alive",
         "Content-Type": "application/json",
         "Sec-Fetch-Mode": "cors",
-        "User-Agent": "QwenCode/0.19.3 (linux; x64)",
+        "User-Agent": "QwenCode/0.19.3 (<OS>; <ARCH>)",
         "X-Dashscope-AuthType": "qwen-oauth",
         "X-Dashscope-CacheControl": "enable",
-        "X-Dashscope-UserAgent": "QwenCode/0.19.3 (linux; x64)",
-        "X-Stainless-Arch": "x64",
+        "X-Dashscope-UserAgent": "QwenCode/0.19.3 (<OS>; <ARCH>)",
+        "X-Stainless-Arch": "<ARCH>",
         "X-Stainless-Lang": "js",
-        "X-Stainless-Os": "Linux",
+        "X-Stainless-Os": "<OS>",
         "X-Stainless-Package-Version": "5.11.0",
         "X-Stainless-Retry-Count": "1",
         "X-Stainless-Runtime": "node",

--- a/tests/unit/provider-translate-path-golden.test.ts
+++ b/tests/unit/provider-translate-path-golden.test.ts
@@ -48,9 +48,25 @@ function sanitize(headers: Record<string, unknown>): Record<string, unknown> {
       out[k] = v;
       continue;
     }
+    if (k === "X-Stainless-Arch") {
+      out[k] = "<ARCH>";
+      continue;
+    }
+    if (k === "X-Stainless-Os") {
+      out[k] = "<OS>";
+      continue;
+    }
     let s = v
       .replace(/Bearer .+/, "Bearer <TOK>")
       .replace(/sk-test-APIKEY|tok-test-ACCESS/g, "<CRED>")
+      .replace(/\(([A-Za-z0-9_. -]+); (?:arm64|x64|x86_64|amd64|ia32)\)/g, "(<OS>; <ARCH>)")
+      // Antigravity's User-Agent embeds an os.platform()-derived platform string
+      // (getAntigravityPlatformInfo) that the (OS; arch) rule above does not cover,
+      // so normalize the three known values to keep the golden runner-independent.
+      .replace(
+        /Macintosh; Intel Mac OS X 10_15_7|Windows NT 10\.0; Win64; x64|X11; Linux x86_64/g,
+        "<PLATFORM>"
+      )
       .replace(/kimi-\d{10,}/g, "kimi-<TS>")
       .replace(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i, "<UUID>");
     if (NODE_VERSION) s = s.split(NODE_VERSION).join("<NODE>");


### PR DESCRIPTION
Supersedes the stale #6002 branch path.

What changed:
- harden `tests/unit/provider-translate-path-golden.test.ts` to normalize `X-Stainless-Os`, `X-Stainless-Arch`, and user-agent OS/arch tuples
- regenerate `tests/snapshots/provider/translate-path.json` on current `release/v3.8.44`

Why:
- the old #6002 branch was heavily stale against current release
- current `release/v3.8.44` still failed the provider translate-path golden on Linux due to unsanitized platform-specific header drift

Validation:
- `UPDATE_GOLDEN=1 npm exec --yes tsx -- --test tests/unit/provider-translate-path-golden.test.ts`
- `npm exec --yes vitest run open-sse/services/autoCombo/__tests__/autoCombo.test.ts`
