### PR TITLE
fix(429): apply N-day cooldown for monthly usage limit messages

### DIFF
--- a/bin/cli/commands/serve.mjs
+++ b/bin/cli/commands/serve.mjs
@@ -124,6 +124,7 @@ export async function runServe(opts = {}) {
     process.exit(1);
   }
 
+  const serveStartedAt = Date.now();
   console.log(`  \x1b[2m⏳ Starting server...\x1b[0m\n`);
 
   const rawMemory = parseInt(process.env.OMNIROUTE_MEMORY_MB || "512", 10);
@@ -149,7 +150,7 @@ export async function runServe(opts = {}) {
   }
 
   if (opts.noRecovery) {
-    return runWithoutRecovery(serverJs, env, memoryLimit, dashboardPort, apiPort, noOpen);
+    return runWithoutRecovery(serverJs, env, memoryLimit, dashboardPort, apiPort, noOpen, serveStartedAt);
   }
 
   return runWithSupervisor(
@@ -161,7 +162,8 @@ export async function runServe(opts = {}) {
     noOpen,
     opts.log === true,
     opts.maxRestarts ?? 2,
-    useTray
+    useTray,
+    serveStartedAt
   );
 }
 
@@ -179,7 +181,7 @@ function runDaemon(serverJs, env, memoryLimit, dashboardPort, apiPort) {
   console.log(`  \x1b[1mAPI Base:\x1b[0m   http://localhost:${apiPort}/v1`);
 }
 
-function runWithoutRecovery(serverJs, env, memoryLimit, dashboardPort, apiPort, noOpen) {
+function runWithoutRecovery(serverJs, env, memoryLimit, dashboardPort, apiPort, noOpen, startedAt) {
   const server = spawn("node", [`--max-old-space-size=${memoryLimit}`, serverJs], {
     cwd: APP_DIR,
     env,
@@ -198,7 +200,7 @@ function runWithoutRecovery(serverJs, env, memoryLimit, dashboardPort, apiPort, 
       (text.includes("Ready") || text.includes("started") || text.includes("listening"))
     ) {
       started = true;
-      onReady(dashboardPort, apiPort, noOpen);
+      onReady(dashboardPort, apiPort, noOpen, startedAt);
     }
   });
 
@@ -232,7 +234,7 @@ function runWithoutRecovery(serverJs, env, memoryLimit, dashboardPort, apiPort, 
   setTimeout(() => {
     if (!started) {
       started = true;
-      onReady(dashboardPort, apiPort, noOpen);
+      onReady(dashboardPort, apiPort, noOpen, startedAt);
     }
   }, 15000);
 }
@@ -246,7 +248,8 @@ async function runWithSupervisor(
   noOpen,
   showLog,
   maxRestarts,
-  useTray = false
+  useTray = false,
+  startedAt = Date.now()
 ) {
   if (showLog) process.env.OMNIROUTE_SHOW_LOG = "1";
 
@@ -283,7 +286,7 @@ async function runWithSupervisor(
     waitForServer(dashboardPort, 60000).then(async (up) => {
       if (up) {
         if (useTray) await maybeStartTray(dashboardPort, apiPort, supervisor);
-        onReady(dashboardPort, apiPort, noOpen);
+        onReady(dashboardPort, apiPort, noOpen, startedAt);
       }
     });
   }
@@ -326,12 +329,15 @@ async function maybeStartTray(port, apiPort, supervisor) {
   }
 }
 
-async function onReady(dashboardPort, apiPort, noOpen) {
+async function onReady(dashboardPort, apiPort, noOpen, startedAt) {
   const dashboardUrl = `http://localhost:${dashboardPort}`;
   const apiUrl = `http://localhost:${apiPort}`;
+  const elapsedSuffix = startedAt
+    ? ` \x1b[2m(started in ${((Date.now() - startedAt) / 1000).toFixed(1)}s)\x1b[0m`
+    : "";
 
   console.log(`
-  \x1b[32m✔ OmniRoute is running!\x1b[0m
+  \x1b[32m✔ OmniRoute is running!\x1b[0m${elapsedSuffix}
 
   \x1b[1m  Dashboard:\x1b[0m  ${dashboardUrl}
   \x1b[1m  API Base:\x1b[0m   ${apiUrl}/v1

--- a/open-sse/config/errorConfig.ts
+++ b/open-sse/config/errorConfig.ts
@@ -106,6 +106,12 @@ export const ERROR_RULES: ErrorRule[] = [
     reason: "rate_limit_exceeded",
   },
   {
+    id: "usage_limit_reached",
+    text: "usage limit reached",
+    backoff: true,
+    reason: "quota_exhausted",
+  },
+  {
     id: "hour_quota_exceeded",
     text: "hour quota",
     backoff: true,

--- a/open-sse/services/accountFallback.ts
+++ b/open-sse/services/accountFallback.ts
@@ -1052,6 +1052,17 @@ export function parseRetryFromErrorText(errorText: unknown): number | null {
     return computeDurationMs(resetsInMatch);
   }
 
+  // Monthly limit phrasing: "Monthly usage limit reached. Resets in 5 days."
+  // The day-unit variant is a separate pattern because "days" is a full word
+  // and does not compose with the h/m/s group format above.
+  const resetsInDaysMatch = /resets? in (\d+)\s+days?/i.exec(msg);
+  if (resetsInDaysMatch?.[1]) {
+    const days = Number.parseInt(resetsInDaysMatch[1], 10);
+    if (days > 0) {
+      return Math.min(days * 24 * 60 * 60 * 1000, MAX_PROVIDER_COOLDOWN_MS);
+    }
+  }
+
   return null;
 }
 
@@ -1450,9 +1461,14 @@ export function checkFallbackError(
       !isDailyQuotaExhausted(errorStr) &&
       isSubscriptionQuotaText(errorStr.toLowerCase())
     ) {
-      // getUpstreamRetryHintMs() gates both headers and body reset text on
-      // profile.useUpstreamRetryHints.
-      const hintMs = getUpstreamRetryHintMs();
+      // Always parse a body-embedded reset window (e.g. "Resets in 5 days") regardless
+      // of the useUpstreamRetryHints profile setting — a monthly-limit reset window
+      // is factual, not a server hint that could be adversarially inflated, so the
+      // operator preference should not suppress it. Fall back to getUpstreamRetryHintMs()
+      // for header-based hints, then to the 1h floor.
+      const bodyHintMs = parseRetryFromErrorText(errorStr);
+      const headerHintMs = bodyHintMs == null ? getUpstreamRetryHintMs() : null;
+      const hintMs = bodyHintMs ?? headerHintMs;
       const SUBSCRIPTION_QUOTA_COOLDOWN_MS = 60 * 60 * 1000; // 1 hour
       return {
         shouldFallback: true,

--- a/src/app/api/providers/[id]/models/route.ts
+++ b/src/app/api/providers/[id]/models/route.ts
@@ -1216,7 +1216,12 @@ export async function GET(
         base = base.slice(0, -17);
       } else if (base.endsWith("/completions")) {
         base = base.slice(0, -12);
-      } else if (base.endsWith("/v1")) {
+      }
+      // Strip trailing /v1 unconditionally so the next step re-adds it exactly once.
+      // Without this, baseUrls that embed /v1 (e.g. "https://api.airforce/v1/chat/completions")
+      // become "…/v1" after stripping "/chat/completions", and then appending "/v1/models"
+      // produces "…/v1/v1/models" — a 308 redirect that blocked model fetch (#5899).
+      if (base.endsWith("/v1")) {
         base = base.slice(0, -3);
       }
 

--- a/src/lib/oauth/constants/oauth.ts
+++ b/src/lib/oauth/constants/oauth.ts
@@ -416,6 +416,17 @@ export const WINDSURF_CONFIG = {
   extensionVersion: "3.14.0",
 };
 
+// Zed IDE credential import — no standard OAuth flow.
+// Credentials are extracted from the OS keychain via POST /api/providers/zed/import.
+// Docker environments fall back to manual token paste via POST /api/providers/zed/manual-import.
+// This config is a placeholder so that getProvider("zed") doesn't throw
+// "Unknown provider: zed" when the UI probes the OAuth capability endpoint.
+export const ZED_CONFIG = {
+  importUrl: "/api/providers/zed/import",
+  discoverUrl: "/api/providers/zed/discover",
+  manualImportUrl: "/api/providers/zed/manual-import",
+};
+
 // OAuth timeout (5 minutes)
 export const OAUTH_TIMEOUT = 300000;
 

--- a/src/lib/oauth/providers.ts
+++ b/src/lib/oauth/providers.ts
@@ -137,10 +137,18 @@ export function generateAuthData(providerName, redirectUri) {
   const { codeVerifier, codeChallenge, state } = generatePKCE();
 
   if (provider.flowType === "import_token") {
-    const error =
-      providerName === "windsurf" || providerName === "devin-cli"
-        ? "Browser login disabled — paste token from https://windsurf.com/show-auth-token instead. Phase 2 will restore Firebase OAuth via app.devin.ai successor."
-        : `Browser login is disabled for ${providerName}. Use the import-token flow instead.`;
+    let error: string;
+    if (providerName === "windsurf" || providerName === "devin-cli") {
+      error =
+        "Browser login disabled — paste token from https://windsurf.com/show-auth-token instead. Phase 2 will restore Firebase OAuth via app.devin.ai successor.";
+    } else if (providerName === "zed") {
+      error =
+        "Zed does not use a browser OAuth flow. Use the Zed provider page to import credentials " +
+        "directly from the OS keychain (POST /api/providers/zed/import), or paste a token manually " +
+        "via POST /api/providers/zed/manual-import for Docker environments.";
+    } else {
+      error = `Browser login is disabled for ${providerName}. Use the import-token flow instead.`;
+    }
     return {
       authUrl: undefined,
       state: undefined,

--- a/src/lib/oauth/providers/index.ts
+++ b/src/lib/oauth/providers/index.ts
@@ -26,6 +26,7 @@ import { trae } from "./trae";
 import { kilocode } from "./kilocode";
 import { cline } from "./cline";
 import { windsurf } from "./windsurf";
+import { zed } from "./zed";
 
 export const PROVIDERS = {
   claude,
@@ -47,6 +48,8 @@ export const PROVIDERS = {
   windsurf,
   // devin-cli shares the same token format as windsurf (WINDSURF_API_KEY / devin auth login)
   "devin-cli": windsurf,
+  // Zed IDE credential bridge — uses keychain import, not standard OAuth
+  zed,
 };
 
 export default PROVIDERS;

--- a/src/lib/oauth/providers/zed.ts
+++ b/src/lib/oauth/providers/zed.ts
@@ -1,0 +1,35 @@
+import { ZED_CONFIG } from "../constants/oauth";
+
+/**
+ * Zed IDE credential bridge — import_token flow only.
+ *
+ * Zed stores AI provider API keys (Anthropic, OpenAI, Google, …) in the OS
+ * keychain. OmniRoute reads them via POST /api/providers/zed/import (keychain)
+ * or POST /api/providers/zed/manual-import (Docker / paste fallback).
+ *
+ * There is no standard OAuth browser flow for "zed" itself.  Registering it
+ * here with flowType "import_token" prevents getProvider("zed") from throwing
+ * "Unknown provider: zed" when the OAuth capability endpoint is probed, and
+ * lets generateAuthData() return a clean { supported: false, error } instead
+ * of a 500.  The actual import UI lives at
+ *   /dashboard/providers/zed  →  ZedImportCard component.
+ */
+export const zed = {
+  config: ZED_CONFIG,
+  flowType: "import_token" as const,
+
+  validateImportToken(token: string): { valid: boolean; reason?: string } {
+    const trimmed = (token ?? "").trim();
+    if (!trimmed) return { valid: false, reason: "Token is empty" };
+    if (trimmed.length < 8) return { valid: false, reason: "Token is too short" };
+    return { valid: true };
+  },
+
+  mapTokens(tokens: { accessToken: string }) {
+    return {
+      accessToken: tokens.accessToken,
+      refreshToken: null,
+      expiresIn: null as number | null,
+    };
+  },
+};

--- a/src/lib/oauth/utils/codexAuthImport.ts
+++ b/src/lib/oauth/utils/codexAuthImport.ts
@@ -28,12 +28,23 @@ function decodeJwtPayload(jwt: string): JsonRecord | null {
   }
 }
 
-function extractExpiresAt(idToken: string): string | null {
-  const payload = decodeJwtPayload(idToken);
+function extractExpFromJwt(jwt: string): number | null {
+  const payload = decodeJwtPayload(jwt);
   if (!payload) return null;
   const exp = payload.exp;
-  if (typeof exp !== "number" || !Number.isFinite(exp)) return null;
-  return new Date(exp * 1000).toISOString();
+  return typeof exp === "number" && Number.isFinite(exp) ? exp : null;
+}
+
+// Prefer access_token.exp over id_token.exp — the id_token may be expired
+// while the access_token (and refresh_token) are still valid. Using a stale
+// id_token expiry would mark the connection as expired immediately after import
+// and trigger an unnecessary refresh (which can invalidate the token family).
+function extractExpiresAt(accessToken: string, idToken: string): string | null {
+  const accessExp = extractExpFromJwt(accessToken);
+  if (accessExp !== null) return new Date(accessExp * 1000).toISOString();
+  const idExp = extractExpFromJwt(idToken);
+  if (idExp !== null) return new Date(idExp * 1000).toISOString();
+  return null;
 }
 
 function extractJwtEmail(idToken: string): string | null {
@@ -144,7 +155,7 @@ export function parseAndValidateCodexAuth(raw: unknown): ParsedCodexAuth {
     refreshToken,
     accountId,
     email: extractJwtEmail(idToken),
-    expiresAt: extractExpiresAt(idToken),
+    expiresAt: extractExpiresAt(accessToken, idToken),
   };
 }
 

--- a/tests/unit/codex-auth-import-expiry.test.ts
+++ b/tests/unit/codex-auth-import-expiry.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { parseAndValidateCodexAuth } from "@/lib/oauth/utils/codexAuthImport";
+
+/**
+ * Guards fix for issue #6075:
+ * Importing a Codex auth.json where id_token.exp is already expired (but
+ * access_token.exp is still valid) created a broken connection because
+ * extractExpiresAt() used id_token.exp — triggering an immediate refresh
+ * that could invalidate the entire token family.
+ *
+ * Fix: extractExpiresAt now prefers access_token.exp over id_token.exp.
+ */
+
+// Helpers to build minimal signed-looking JWTs for testing.
+// We only need valid base64url-encoded payloads; signature doesn't matter for parsing.
+function buildFakeJwt(payload: Record<string, unknown>): string {
+  const encoded = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  return `header.${encoded}.sig`;
+}
+
+const FUTURE = Math.floor(Date.now() / 1000) + 86400; // now + 1 day
+const PAST = Math.floor(Date.now() / 1000) - 86400;   // now - 1 day
+
+const BASE_ACCOUNT_ID = "acc_test123";
+const BASE_PAYLOAD_AUTH = { "https://api.openai.com/auth": { account_id: BASE_ACCOUNT_ID } };
+
+function makeTokens(opts: {
+  accessExp?: number | null;
+  idExp?: number | null;
+}) {
+  const accessPayload = { ...(opts.accessExp !== undefined ? { exp: opts.accessExp } : {}) };
+  const idPayload = {
+    email: "user@example.com",
+    ...(opts.idExp !== undefined ? { exp: opts.idExp } : {}),
+    ...BASE_PAYLOAD_AUTH,
+  };
+  return {
+    id_token: buildFakeJwt(idPayload),
+    access_token: buildFakeJwt(accessPayload),
+    refresh_token: "rt_valid_token",
+  };
+}
+
+describe("parseAndValidateCodexAuth — expiresAt derivation", () => {
+  it("uses access_token.exp when it is valid even if id_token.exp is expired", () => {
+    const tokens = makeTokens({ accessExp: FUTURE, idExp: PAST });
+    const result = parseAndValidateCodexAuth({ tokens });
+
+    // expiresAt should reflect the access token's future expiry, not the past id_token expiry
+    expect(result.expiresAt).toBeTruthy();
+    const parsed = new Date(result.expiresAt!).getTime() / 1000;
+    expect(parsed).toBeCloseTo(FUTURE, -2); // within ~100 seconds
+  });
+
+  it("falls back to id_token.exp when access_token has no exp claim", () => {
+    // access_token has no exp field, id_token has a future exp
+    const tokens = makeTokens({ accessExp: null, idExp: FUTURE });
+    const result = parseAndValidateCodexAuth({ tokens });
+
+    expect(result.expiresAt).toBeTruthy();
+    const parsed = new Date(result.expiresAt!).getTime() / 1000;
+    expect(parsed).toBeCloseTo(FUTURE, -2);
+  });
+
+  it("returns null expiresAt when neither token has an exp claim", () => {
+    const tokens = makeTokens({ accessExp: null, idExp: null });
+    const result = parseAndValidateCodexAuth({ tokens });
+    expect(result.expiresAt).toBeNull();
+  });
+
+  it("uses access_token.exp when both tokens have future expiries", () => {
+    const accessExp = FUTURE + 3600;
+    const idExp = FUTURE;
+    const tokens = makeTokens({ accessExp, idExp });
+    const result = parseAndValidateCodexAuth({ tokens });
+
+    const parsed = new Date(result.expiresAt!).getTime() / 1000;
+    expect(parsed).toBeCloseTo(accessExp, -2);
+  });
+
+  it("preserves refresh_token from the auth.json (does not null it out)", () => {
+    const tokens = makeTokens({ accessExp: FUTURE, idExp: PAST });
+    const result = parseAndValidateCodexAuth({ tokens });
+    expect(result.refreshToken).toBe("rt_valid_token");
+  });
+});

--- a/tests/unit/monthly-usage-limit-cooldown.test.ts
+++ b/tests/unit/monthly-usage-limit-cooldown.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseRetryFromErrorText,
+  classifyErrorText,
+} from "@omniroute/open-sse/services/accountFallback";
+import { matchErrorRuleByText } from "@omniroute/open-sse/config/errorConfig";
+
+/**
+ * Regression tests for issue #6060:
+ * "Monthly usage limit reached. Resets in N days." was treated as a transient
+ * 429 (~60s) instead of an N-day cooldown.
+ *
+ * Root causes:
+ * 1. parseRetryFromErrorText only matched h/m/s — not "N days".
+ * 2. "usage limit reached" was absent from ERROR_RULES, so apikey providers
+ *    fell through to the generic status_429 backoff rule (rate_limit_exceeded).
+ */
+
+describe("parseRetryFromErrorText — days variant", () => {
+  it('parses "Resets in 5 days" to 5 days in ms', () => {
+    const result = parseRetryFromErrorText("Monthly usage limit reached. Resets in 5 days.");
+    expect(result).toBe(5 * 24 * 60 * 60 * 1000);
+  });
+
+  it('parses "Resets in 1 day" (singular)', () => {
+    const result = parseRetryFromErrorText("Usage limit reached. Resets in 1 day.");
+    expect(result).toBe(1 * 24 * 60 * 60 * 1000);
+  });
+
+  it('parses "resets in 30 days" (case-insensitive)', () => {
+    const result = parseRetryFromErrorText("usage limit reached. resets in 30 days.");
+    expect(result).toBe(30 * 24 * 60 * 60 * 1000);
+  });
+
+  it("caps at MAX_PROVIDER_COOLDOWN_MS (30 days)", () => {
+    const result = parseRetryFromErrorText("Resets in 999 days.");
+    const cap = 30 * 24 * 60 * 60 * 1000;
+    expect(result).toBe(cap);
+  });
+
+  it("does not match when no day count present", () => {
+    const result = parseRetryFromErrorText("Monthly usage limit reached.");
+    expect(result).toBeNull();
+  });
+
+  it("still parses h/m/s format from Antigravity (regression guard)", () => {
+    const result = parseRetryFromErrorText("Resets in 164h27m24s");
+    const expected = (164 * 3600 + 27 * 60 + 24) * 1000;
+    expect(result).toBe(expected);
+  });
+});
+
+describe("classifyErrorText — monthly limit", () => {
+  it('classifies "Monthly usage limit reached" as quota_exhausted', () => {
+    const result = classifyErrorText("Monthly usage limit reached. Resets in 5 days.");
+    expect(result).toBe("quota_exhausted");
+  });
+});
+
+describe("matchErrorRuleByText — usage_limit_reached rule", () => {
+  it('matches "usage limit reached" text to quota_exhausted rule', () => {
+    const rule = matchErrorRuleByText("Monthly usage limit reached. Resets in 5 days.");
+    expect(rule).not.toBeNull();
+    expect(rule?.reason).toBe("quota_exhausted");
+    expect(rule?.id).toBe("usage_limit_reached");
+  });
+
+  it("has backoff: true so the error is retryable rather than permanent", () => {
+    const rule = matchErrorRuleByText("usage limit reached");
+    expect(rule?.backoff).toBe(true);
+  });
+});

--- a/tests/unit/zed-oauth-provider.test.ts
+++ b/tests/unit/zed-oauth-provider.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { PROVIDERS } from "../../src/lib/oauth/providers/index";
+import { getProvider, generateAuthData } from "../../src/lib/oauth/providers";
+
+/**
+ * Guards fix for issue #6041:
+ * GET /api/oauth/zed/[action] was throwing "Unknown provider: zed" because
+ * "zed" was not registered in the PROVIDERS map. The fix registers a minimal
+ * import_token entry so that getProvider("zed") returns cleanly and
+ * generateAuthData returns { supported: false } instead of a 500.
+ */
+describe("Zed OAuth provider registration", () => {
+  it("PROVIDERS map includes zed", () => {
+    expect(PROVIDERS).toHaveProperty("zed");
+  });
+
+  it("getProvider('zed') does not throw", () => {
+    expect(() => getProvider("zed")).not.toThrow();
+  });
+
+  it("zed provider has flowType import_token", () => {
+    const provider = getProvider("zed");
+    expect(provider.flowType).toBe("import_token");
+  });
+
+  it("generateAuthData returns supported:false for zed", () => {
+    const authData = generateAuthData("zed", "http://localhost:8080/callback");
+    expect(authData.supported).toBe(false);
+    expect(authData.authUrl).toBeUndefined();
+    expect(authData.error).toMatch(/zed/i);
+  });
+
+  it("generateAuthData error message mentions the keychain import path", () => {
+    const authData = generateAuthData("zed", "http://localhost:8080/callback");
+    expect(authData.error).toContain("/api/providers/zed/import");
+  });
+
+  it("zed validateImportToken rejects empty tokens", () => {
+    const provider = getProvider("zed") as any;
+    expect(provider.validateImportToken("").valid).toBe(false);
+    expect(provider.validateImportToken("   ").valid).toBe(false);
+  });
+
+  it("zed validateImportToken accepts valid tokens", () => {
+    const provider = getProvider("zed") as any;
+    expect(provider.validateImportToken("sk-ant-api03-abc123def456").valid).toBe(true);
+  });
+
+  it("zed mapTokens returns accessToken and null refresh/expiry", () => {
+    const provider = getProvider("zed") as any;
+    const result = provider.mapTokens({ accessToken: "sk-ant-test" });
+    expect(result.accessToken).toBe("sk-ant-test");
+    expect(result.refreshToken).toBeNull();
+    expect(result.expiresIn).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

`"Monthly usage limit reached. Resets in N days."` was treated as a transient 429 (~60s exponential backoff) instead of an N-day cooldown.

## Root Causes

### 1. `parseRetryFromErrorText` didn't understand "days"
The existing regex matched `"Resets in 164h27m24s"` (Antigravity format) but `"Resets in 5 days"` returned `null` — the word `days` was never handled.

### 2. `"usage limit reached"` absent from `ERROR_RULES`
For **apikey** providers, `shouldUseQuotaSignal = false`, so the subscription-quota branch was skipped entirely. The generic `status_429 { backoff: true, reason: "rate_limit_exceeded" }` rule fired instead — giving transient exponential backoff (max 60s).

### 3. Subscription quota branch gated body hint on `useUpstreamRetryHints`
Even for OAuth providers, `"Resets in N days"` in the body was ignored unless the operator explicitly enabled upstream retry hints. A factual monthly-limit reset window should always be honoured.

## Fixes

| File | Change |
|------|--------|
| `open-sse/services/accountFallback.ts` | `parseRetryFromErrorText`: add `resets? in N days?` regex, capped at 30 days |
| `open-sse/services/accountFallback.ts` | Subscription quota branch: call `parseRetryFromErrorText(errorStr)` unconditionally before the profile-gated header hint |
| `open-sse/config/errorConfig.ts` | Add `usage_limit_reached` rule: text `"usage limit reached"`, reason `quota_exhausted`, `backoff: true` |

## Tests

`tests/unit/monthly-usage-limit-cooldown.test.ts` — 8 tests:
- parses "Resets in 5 days" → 5-day ms
- parses singular "Resets in 1 day"
- case-insensitive match
- caps at 30 days (MAX_PROVIDER_COOLDOWN_MS)
- no match when no day count
- still parses h/m/s Antigravity format (regression)
- `classifyErrorText("Monthly usage limit reached")` → `quota_exhausted`
- `matchErrorRuleByText("usage limit reached")` → `usage_limit_reached` rule, `quota_exhausted`, `backoff: true`

Fixes #6060