### PR TITLE
fix(gitlab): emulate tool calls

### DIFF
--- a/open-sse/executors/gitlab.ts
+++ b/open-sse/executors/gitlab.ts
@@ -10,6 +10,7 @@ import {
 } from "./base.ts";
 import { FETCH_TIMEOUT_MS } from "../config/constants.ts";
 import { getAccessToken } from "../services/tokenRefresh.ts";
+import { buildToolModeResponse } from "./chatgptWebTools.ts";
 import {
   buildGitLabDirectGatewayUrl,
   buildGitLabOAuthEndpoints,
@@ -19,6 +20,7 @@ import {
   resolveGitLabOAuthBaseUrl,
   type GitLabDirectAccessDetails,
 } from "@/lib/oauth/gitlab";
+import { prepareToolMessages } from "../translator/webTools.ts";
 
 type OpenAIMessage = {
   role?: string;
@@ -335,7 +337,12 @@ export class GitlabExecutor extends BaseExecutor {
     _stream: boolean,
     credentials: ExecuteInput["credentials"]
   ): Record<string, unknown> {
-    const prompt = buildPrompt(body.messages as OpenAIMessage[] | undefined);
+    const messages = body.messages as OpenAIMessage[] | undefined;
+    const { effectiveMessages } = prepareToolMessages(
+      body,
+      messages as Array<{ role: string; content: unknown }>
+    );
+    const prompt = buildPrompt(effectiveMessages);
     const providerData =
       credentials?.providerSpecificData && typeof credentials.providerSpecificData === "object"
         ? credentials.providerSpecificData
@@ -572,9 +579,13 @@ export class GitlabExecutor extends BaseExecutor {
   }
 
   async execute(input: ExecuteInput) {
-    const prompt = buildPrompt(
-      (input.body as Record<string, unknown>)?.messages as OpenAIMessage[]
+    const bodyObj = (input.body as Record<string, unknown>) || {};
+    const messages = bodyObj.messages as OpenAIMessage[] | undefined;
+    const { hasTools, requestedTools } = prepareToolMessages(
+      bodyObj,
+      messages as Array<{ role: string; content: unknown }>
     );
+    const prompt = buildPrompt(messages);
     if (!prompt) {
       return {
         response: toOpenAIError(400, "GitLab Duo requires at least one user message"),
@@ -684,6 +695,27 @@ export class GitlabExecutor extends BaseExecutor {
     const resolvedModel = resolveResponseModel(payload, input.model);
     const responseId = `chatcmpl-gitlab-${randomUUID()}`;
     const created = Math.floor(Date.now() / 1000);
+
+    if (hasTools) {
+      const toolAwareResponse = await buildToolModeResponse(
+        buildJsonCompletion(content, resolvedModel, responseId, created),
+        requestedTools,
+        input.stream,
+        {
+          cid: responseId,
+          created,
+          model: resolvedModel,
+          idSeed: "gitlab",
+        }
+      );
+      return {
+        response: toolAwareResponse,
+        url: activeTarget.url,
+        headers: requestHeaders,
+        transformedBody,
+      };
+    }
+
     const response = input.stream
       ? buildStreamingResponse(content, resolvedModel, responseId, created)
       : buildJsonCompletion(content, resolvedModel, responseId, created);

--- a/tests/unit/executor-gitlab.test.ts
+++ b/tests/unit/executor-gitlab.test.ts
@@ -114,6 +114,101 @@ test("GitlabExecutor synthesizes SSE responses from non-streaming upstream compl
   }
 });
 
+test("GitlabExecutor parses tool calls from buffered completions", async () => {
+  const executor = new GitlabExecutor();
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = async () =>
+    jsonResponse({
+      model: { name: "code-gecko" },
+      choices: [
+        {
+          text: '<tool>{"name":"run_tests","arguments":{"path":"src/app.py"}}</tool>',
+          finish_reason: "stop",
+        },
+      ],
+    });
+
+  try {
+    const result = await executor.execute({
+      model: "gitlab-duo-code-suggestions",
+      body: {
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "run_tests",
+              description: "Run the test suite",
+              parameters: {
+                type: "object",
+                properties: {
+                  path: { type: "string" },
+                },
+              },
+            },
+          },
+        ],
+        messages: [{ role: "user", content: "Run the tests" }],
+      },
+      stream: false,
+      credentials: { apiKey: "glpat-test" },
+      signal: AbortSignal.timeout(10_000),
+      log: null,
+    });
+
+    const body = (await result.response.json()) as any;
+    assert.equal(body.choices[0].message.role, "assistant");
+    assert.equal(body.choices[0].message.content, null);
+    assert.equal(body.choices[0].finish_reason, "tool_calls");
+    assert.equal(body.choices[0].message.tool_calls[0].function.name, "run_tests");
+    assert.match(body.choices[0].message.tool_calls[0].function.arguments, /"path":"src\/app\.py"/);
+    assert.match(
+      String(result.transformedBody.current_file.content_above_cursor),
+      /You can call tools\./
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("GitlabExecutor streams tool calls as terminal SSE chunks", async () => {
+  const executor = new GitlabExecutor();
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = async () =>
+    jsonResponse({
+      model: { name: "code-gecko" },
+      choices: [
+        {
+          text: '<tool>{"name":"run_tests","arguments":{"path":"src/app.py"}}</tool>',
+          finish_reason: "stop",
+        },
+      ],
+    });
+
+  try {
+    const result = await executor.execute({
+      model: "gitlab-duo-code-suggestions",
+      body: {
+        tools: [{ type: "function", function: { name: "run_tests" } }],
+        messages: [{ role: "user", content: "Run the tests" }],
+      },
+      stream: true,
+      credentials: { apiKey: "glpat-test" },
+      signal: AbortSignal.timeout(10_000),
+      log: null,
+    });
+
+    assert.equal(result.response.headers.get("Content-Type"), "text/event-stream");
+    const text = await result.response.text();
+    assert.match(text, /"tool_calls"/);
+    assert.match(text, /"finish_reason":"tool_calls"/);
+    assert.match(text, /"name":"run_tests"/);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("GitlabExecutor maps upstream auth failures to OpenAI-style errors", async () => {
   const executor = new GitlabExecutor();
   const originalFetch = globalThis.fetch;


### PR DESCRIPTION
Adds tool-call emulation to the GitLab Duo executor by reusing the shared web-tool prompt/result helpers. This lets tool-enabled requests round-trip OpenAI tool_calls in both JSON and SSE responses, matching the provider behavior used by other web executors.\n\nVerification:\n- npm exec --yes tsx -- --test tests/unit/executor-gitlab.test.ts\n