### PR TITLE
fix(antigravity): strip trailing assistant prefill for Vertex Claude models — relocated to live executor, NEEDS LIVE VALIDATION

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - **fix(api):** `/v1/messages/count_tokens` now counts `tool_use`, `tool_result` and `thinking` content blocks (and array-form `system` prompts) in the local-estimation path, instead of only `text`. Real agentic conversations keep ~95% of their tokens inside tool results; the previous estimate returned near-zero for them, which silently broke Claude Code's auto-compaction (context grew past the window with no compaction until the upstream API rejected the request). The real provider-side count path is unchanged. Regression guard: `tests/unit/messages-count-tokens-route.test.ts`. ([#6221](https://github.com/diegosouzapw/OmniRoute/pull/6221) — thanks @luweiCN)
 
+- **fix(antigravity):** strip a trailing assistant prefill turn for Vertex Claude models to avoid upstream 400s ([#6114](https://github.com/diegosouzapw/OmniRoute/pull/6114)). Regression guard: `tests/unit/antigravity-claude-prefill-strip.test.ts`. (thanks @anki1kr)
+
 ---
 
 ## [3.8.43] — 2026-07-02

--- a/open-sse/executors/antigravity.ts
+++ b/open-sse/executors/antigravity.ts
@@ -480,6 +480,46 @@ function sanitizeAntigravityGeminiRequest(
   return clean;
 }
 
+/**
+ * Ported from decolua/9router#2321 (anki1kr): Vertex AI (used by Antigravity for
+ * Claude-branded models) rejects a conversation ending on an assistant turn —
+ * "This model does not support assistant message prefill" — so the request must
+ * always end on a user turn. Upstream patched `openaiToClaudeRequestForAntigravity`
+ * (dead code here, zero callers — see `open-sse/translator/request/openai-to-claude.ts`);
+ * this relocates the same strip to the LIVE Antigravity dispatch path, where Claude
+ * requests are converted to Gemini `contents` (assistant role is `"model"`, not
+ * `"assistant"`). Mirrors the trailing-strip pop-loop already used for Mistral
+ * (#3396), Copilot (#5802), and the CC-bridge in `claudeCodeCompatible.ts`.
+ *
+ * Scoped strictly to the Claude path by the caller (`isClaude` branch only) — native
+ * Gemini models via Antigravity must be unaffected, since Vertex-Claude is the only
+ * documented rejection surface.
+ *
+ * Guard: never strip `contents` down to empty — an empty `contents` array is itself
+ * an invalid request, so at least one entry (even a lone trailing "model" turn) is
+ * always preserved.
+ */
+function stripTrailingAntigravityAssistantTurn(
+  request: Record<string, unknown>
+): Record<string, unknown> {
+  const contents = request.contents;
+  if (!Array.isArray(contents) || contents.length === 0) {
+    return request;
+  }
+
+  while (
+    contents.length > 1 &&
+    (contents[contents.length - 1] as AntigravityContent)?.role === "model"
+  ) {
+    contents.pop();
+  }
+
+  return request;
+}
+
+// Test-only export so the unit suite can exercise the strip logic directly.
+export const __test_stripTrailingAntigravityAssistantTurn = stripTrailingAntigravityAssistantTurn;
+
 export class AntigravityExecutor extends BaseExecutor {
   constructor() {
     super("antigravity", PROVIDERS.antigravity);
@@ -660,7 +700,7 @@ export class AntigravityExecutor extends BaseExecutor {
     };
 
     const transformedRequest = isClaude
-      ? sanitizeAntigravityGeminiRequest(rawTransformedRequest)
+      ? stripTrailingAntigravityAssistantTurn(sanitizeAntigravityGeminiRequest(rawTransformedRequest))
       : rawTransformedRequest;
 
     // Obfuscate sensitive client names in user content (e.g. "OpenCode", "Cursor")

--- a/tests/unit/antigravity-claude-prefill-strip.test.ts
+++ b/tests/unit/antigravity-claude-prefill-strip.test.ts
@@ -1,0 +1,101 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  AntigravityExecutor,
+  __test_stripTrailingAntigravityAssistantTurn,
+} from "../../open-sse/executors/antigravity.ts";
+
+/**
+ * Ports decolua/9router#2321 (anki1kr): Vertex AI (used by Antigravity for
+ * Claude-branded models) rejects a conversation ending on an assistant turn —
+ * "This model does not support assistant message prefill" — so the request must
+ * always end on a user turn.
+ *
+ * Upstream's diff patched `openaiToClaudeRequestForAntigravity` in
+ * `open-sse/translator/request/openai-to-claude.ts`, which has ZERO callers in
+ * OmniRoute (dead code). The live Antigravity Claude dispatch path converts to
+ * Gemini `contents` (`role: "user"/"model"`) in `AntigravityExecutor.transformRequest`
+ * via `sanitizeAntigravityGeminiRequest` — this test drives THAT function end-to-end.
+ */
+
+async function transform(model: string, contents: Array<Record<string, unknown>>) {
+  const executor = new AntigravityExecutor();
+  const body = {
+    request: {
+      contents,
+      generationConfig: {},
+    },
+  };
+  const result = await executor.transformRequest(model, body, true, {
+    projectId: "project-1",
+  });
+  if (result instanceof Response) throw new Error("Unexpected Response from transformRequest");
+  return (result as Record<string, unknown>).request as Record<string, unknown>;
+}
+
+test("(a) strips a single trailing assistant (model) turn for Claude models", async () => {
+  const request = await transform("antigravity/claude-opus-4-8", [
+    { role: "user", parts: [{ text: "Hello" }] },
+    { role: "model", parts: [{ text: "Hi there" }] }, // prefill to strip
+  ]);
+  const contents = request.contents as Array<{ role: string }>;
+  assert.equal(contents.length, 1);
+  assert.equal(contents.at(-1)?.role, "user");
+});
+
+test("(b) does NOT strip a trailing model turn for non-Claude (native Gemini) models", async () => {
+  const request = await transform("antigravity/gemini-3.1-pro", [
+    { role: "user", parts: [{ text: "Hello" }] },
+    { role: "model", parts: [{ text: "Hi there" }] },
+  ]);
+  const contents = request.contents as Array<{ role: string }>;
+  assert.equal(contents.length, 2);
+  assert.equal(contents.at(-1)?.role, "model", "native Gemini requests via Antigravity are untouched");
+});
+
+test("(c) a Claude conversation already ending on user is unchanged", async () => {
+  const request = await transform("antigravity/claude-opus-4-8", [
+    { role: "user", parts: [{ text: "Hello" }] },
+    { role: "model", parts: [{ text: "Hi" }] },
+    { role: "user", parts: [{ text: "What is 2+2?" }] },
+  ]);
+  const contents = request.contents as Array<{ role: string }>;
+  assert.equal(contents.length, 3);
+  assert.equal(contents.at(-1)?.role, "user");
+});
+
+test("(d) multiple trailing model turns are all stripped", () => {
+  // Under normal executor flow, adjacent same-role turns are merged before this
+  // helper runs — this directly exercises the helper's robustness for an input
+  // that (defensively) still carries multiple consecutive trailing "model" turns.
+  const request = __test_stripTrailingAntigravityAssistantTurn({
+    contents: [
+      { role: "user", parts: [{ text: "Hello" }] },
+      { role: "model", parts: [{ text: "A" }] },
+      { role: "model", parts: [{ text: "B" }] },
+    ],
+  });
+  const contents = request.contents as Array<{ role: string }>;
+  assert.equal(contents.length, 1);
+  assert.equal(contents.at(-1)?.role, "user");
+});
+
+test("(e) never strips contents down to empty", () => {
+  const request = __test_stripTrailingAntigravityAssistantTurn({
+    contents: [{ role: "model", parts: [{ text: "solo prefill" }] }],
+  });
+  const contents = request.contents as Array<{ role: string }>;
+  // A lone trailing "model" turn is preserved rather than emptying `contents`
+  // (an empty contents array is itself an invalid upstream request).
+  assert.equal(contents.length, 1);
+  assert.equal(contents[0].role, "model");
+});
+
+test("empty/missing contents does not throw", () => {
+  const request = __test_stripTrailingAntigravityAssistantTurn({ contents: [] });
+  assert.deepEqual(request.contents, []);
+
+  const request2 = __test_stripTrailingAntigravityAssistantTurn({});
+  assert.equal(request2.contents, undefined);
+});


### PR DESCRIPTION
## Summary

Vertex AI (Cloud Code Assist, used by Antigravity for Claude-branded models) rejects a conversation whose last turn is an assistant message — `"This model does not support assistant message prefill"`. This port strips a trailing assistant turn for Claude models routed through the Antigravity executor so the upstream request always ends on a user turn.

**Relocated from dead code to the live executor path.** The original upstream diff patched `openaiToClaudeRequestForAntigravity` in `open-sse/translator/request/openai-to-claude.ts`, which has **zero callers** in OmniRoute — porting it verbatim would have been inert. The live Antigravity Claude dispatch path is `AntigravityExecutor.transformRequest` (`open-sse/executors/antigravity.ts`), which converts Claude requests to Gemini `contents` (`role: "user"/"model"`) via `sanitizeAntigravityGeminiRequest` and bypasses `BaseExecutor.execute` entirely — so it never ran the 3 existing trailing-assistant guards elsewhere in the codebase (Mistral #3396, Copilot #5802, CC-bridge in `claudeCodeCompatible.ts`). This PR adds a new `stripTrailingAntigravityAssistantTurn` helper mirroring that same pop-loop pattern, wired into the `isClaude` branch only — native Gemini models via Antigravity are unaffected.

## ⚠️ Needs live validation before merge

The upstream diff patched a function with zero callers in OmniRoute; this relocates the fix to the live Antigravity executor path (`antigravity.ts`, Gemini `contents`, `isClaude`). The premise (Vertex/Cloud-Code-Assist rejects a trailing assistant turn) matches 3 in-repo precedents but was NOT empirically confirmed for this exact envelope. TDD covers the strip behavior. **Validate on the VPS with a real Antigravity Claude request carrying a trailing assistant turn before merging** — if Vertex actually accepts prefill here, this would remove a legitimate capability.

## Test plan

- [x] `tests/unit/antigravity-claude-prefill-strip.test.ts` (new, 6 cases) — trailing `role:"model"` strip for Claude models, non-Claude/Gemini untouched, conversation already ending on user unchanged, multiple trailing model turns stripped, never emptied to zero, empty/missing contents no-op. Watched fail → pass.
- [x] `npm run typecheck:core` — clean
- [x] Targeted `eslint` on changed files — clean
- [x] Full `agy-*`/`executor-antigravity` regression suite (75 tests) — all green, no regressions
- [ ] Live VPS validation with a real trailing-assistant-turn request to a Vertex Claude model via Antigravity (see warning above)

Thanks to [@anki1kr](https://github.com/anki1kr) for the original implementation.


---

## 🔬 Live validation runbook (for the validating session)

> **Context:** the unit tests prove the trailing `role:"model"` turn is stripped for Claude models on the Antigravity executor path. They cannot confirm the *premise* — that Vertex/Cloud-Code-Assist actually rejects a trailing assistant turn. This step confirms the premise AND that we're not removing a legitimate capability. Do not merge until PASS.

**Precondition:** a real Antigravity connection with a Claude-branded model.

**Steps (run BOTH — the second guards against removing a real feature):**
1. Deploy this branch (`fix/port-pr-2321-antigravity-prefill-strip`) to the VPS.
2. **Premise check (do this on `origin/release/v3.8.44` WITHOUT this fix first):** send a request whose messages end on an assistant turn to a Claude model via Antigravity:
   ```
   ...,"messages":[{"role":"user","content":"Write a haiku"},{"role":"assistant","content":"Autumn"}]
   ```
   - If it returns `HTTP 400 "does not support assistant message prefill"` → premise CONFIRMED, proceed.
   - If it returns **200** (Vertex accepted the prefill) → **premise is FALSE**: this fix would silently drop a legitimate assistant-prefill capability. **Do not merge** — reconsider or scope the strip more narrowly.
3. **Fix check (with this branch deployed):** send the same trailing-assistant request → must now return **HTTP 200** (the trailing turn is stripped, request accepted).

**PASS:** step 2 without the fix 400s, step 3 with the fix 200s. → merge.
**FAIL:** step 2 without the fix already 200s. → the fix removes real functionality; do not merge.
