### PR TITLE
fix(config): externalize ws for copilot-m365-web executor (closes #6062)

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -214,6 +214,13 @@ const nextConfig = {
     "tough-cookie",
     "@ngrok/ngrok",
     "@huggingface/transformers",
+    // copilot-m365-web.ts imports 'ws' as a client-side WebSocket. When bundled,
+    // ws cannot resolve its 'bufferutil' native addon (frame masking) and throws
+    // TypeError: b.mask is not a function on the first outgoing frame, causing
+    // every chat request to time out at the stream-readiness watchdog. (#6062)
+    "ws",
+    "bufferutil",
+    "utf-8-validate",
     "child_process",
     "fs",
     "path",

--- a/tests/unit/next-config.test.ts
+++ b/tests/unit/next-config.test.ts
@@ -37,6 +37,15 @@ test("next config exposes standalone build settings and canonical rewrites", asy
     "fumadocs-ui",
     "fumadocs-core",
   ]);
+  // #6062: `ws` and its native masking helpers must stay external so the
+  // copilot-m365-web executor keeps a working WebSocket masking path at runtime
+  // (bundling ws breaks `bufferutil` → `TypeError: b.mask is not a function`).
+  for (const pkg of ["ws", "bufferutil", "utf-8-validate"]) {
+    assert.ok(
+      nextConfig.serverExternalPackages.includes(pkg),
+      `expected serverExternalPackages to externalize "${pkg}" (#6062)`
+    );
+  }
   assert.equal(headers[0].source, "/:path*");
   assert.match(securityHeaders["Content-Security-Policy"], /default-src 'self'/);
   assert.match(securityHeaders["Content-Security-Policy"], /frame-ancestors 'none'/);


### PR DESCRIPTION
Re-lands the #6098 fix (which merged to the wrong base, main, and was reverted) onto **release/v3.8.44**.

Externalize `ws` / `bufferutil` / `utf-8-validate` in `serverExternalPackages` so the copilot-m365-web WebSocket masking path works at runtime (bundling ws → `TypeError: b.mask is not a function` → 80s chat timeout). Regression guard in `next-config.test.ts`.

Original author: @anki1kr (#6098). Closes #6062.