### PR TITLE
fix(onboarding): use node id (not composite provider slug) for provider details link

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/components/onboarding/ProviderOnboardingWizard.tsx
+++ b/src/app/(dashboard)/dashboard/providers/components/onboarding/ProviderOnboardingWizard.tsx
@@ -260,9 +260,9 @@ function ResultSummary({
         )}
 
         <div className="flex flex-wrap gap-2">
-          {connection?.provider && (
+          {connection?.id && (
             <Link
-              href={`/dashboard/providers/${connection.provider}`}
+              href={`/dashboard/providers/${connection.id}`}
               className="inline-flex items-center justify-center rounded-lg bg-primary px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-primary/90"
             >
               {providerText(t, "onboardingOpenProviderDetails", "Open provider details")}

--- a/tests/unit/onboarding-wizard-details-link-6145.test.ts
+++ b/tests/unit/onboarding-wizard-details-link-6145.test.ts
@@ -1,0 +1,37 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+// Regression guard for #6145: the onboarding success-screen "Open provider
+// details" link must route by `connection.id` (the node id the
+// `/dashboard/providers/[id]` route expects), NOT `connection.provider` (the
+// provider slug/type). The old code produced `/dashboard/providers/<provider-slug>`
+// which 404s for openai-compatible / anthropic-compatible providers.
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(here, "..", "..");
+const wizard = readFileSync(
+  join(
+    repoRoot,
+    "src/app/(dashboard)/dashboard/providers/components/onboarding/ProviderOnboardingWizard.tsx"
+  ),
+  "utf8"
+);
+
+test("#6145: provider-details link routes by connection.id (matches the [id] route)", () => {
+  assert.match(
+    wizard,
+    /href=\{`\/dashboard\/providers\/\$\{connection\.id\}`\}/,
+    "the details link must build the URL from connection.id"
+  );
+});
+
+test("#6145: provider-details link must NOT use connection.provider (404s for compat providers)", () => {
+  assert.doesNotMatch(
+    wizard,
+    /href=\{`\/dashboard\/providers\/\$\{connection\.provider\}`\}/,
+    "connection.provider is the slug/type, not the node id — it 404s"
+  );
+});


### PR DESCRIPTION
## Problem

The 'Open provider details' button on the onboarding wizard success screen 404s for OpenAI-compat / Anthropic-compat providers.

## Repro

1. `/dashboard/providers/new`
2. Complete OpenAI-Compatible wizard (any real endpoint)
3. Click **Open provider details** on success screen
4. → `/dashboard/providers/openai-compatible-chat-<uuid>` → 404

## Root cause

`src/app/(dashboard)/dashboard/providers/components/onboarding/ProviderOnboardingWizard.tsx:265`

For openai-compat / anthropic-compat providers, `connection.provider` is the composite `openai-compatible-chat-<uuid>` slug (see docstring in `src/shared/utils/providerDisplayLabel.ts:3`). The dashboard `[id]` route resolves via `/api/provider-nodes/<id>` and expects the plain node UUID.

## Fix

Use `connection.id` (the provider node UUID) — already used elsewhere in the same file for validation calls (L360, L446, L462).

## Diff

+2 / -2 in one file. No test change: this is a URL-construction bug fixed by swapping the field being interpolated; a route-existence unit test would just assert the string shape, which is exactly the two lines changed.

Fixes #6144

Thanks for the great work on OmniRoute!