### PR TITLE
fix(dashboard): resolve broken Card import breaking next build (base-red from #6061)

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/[id]/components/CoolingConnectionsPanel.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/CoolingConnectionsPanel.tsx
@@ -4,7 +4,7 @@
  * CoolingConnectionsPanel — Dashboard readout of connections currently in a
  * persisted 429 cooldown. Sourced from `useProviderConnections().connections`
  * filtered on `rateLimitedUntil`. Live human-readable countdown via the
- * existing `formatResetCountdown` helper re-exported by `@/lib/localDb`.
+ * client-safe `formatResetCountdown` helper in `@/shared/utils/formatting`.
  *
  * Why this exists: Fix A (per-account 429 cascade not persisting) writes the
  * cooldown to `provider_connections.rate_limited_until` so the cascade
@@ -22,7 +22,7 @@
  */
 
 import { useEffect, useState } from "react";
-import { formatResetCountdown } from "@/lib/localDb";
+import { formatResetCountdown } from "@/shared/utils/formatting";
 import type { ConnectionRowConnection } from "./ConnectionRow";
 
 export interface CoolingConnectionsPanelProps {

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/CoolingConnectionsPanel.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/CoolingConnectionsPanel.tsx
@@ -22,7 +22,6 @@
  */
 
 import { useEffect, useState } from "react";
-import { Card } from "@/components/ui/card";
 import { formatResetCountdown } from "@/lib/localDb";
 import type { ConnectionRowConnection } from "./ConnectionRow";
 
@@ -36,9 +35,7 @@ function isCoolingNow(connection: ConnectionRowConnection, now: number): boolean
   return Number.isFinite(until) && until > now;
 }
 
-export default function CoolingConnectionsPanel(
-  props: CoolingConnectionsPanelProps,
-) {
+export default function CoolingConnectionsPanel(props: CoolingConnectionsPanelProps) {
   const { connections } = props;
   // Tick once per second so the human-readable countdown updates.
   const [now, setNow] = useState<number>(() => Date.now());
@@ -51,9 +48,9 @@ export default function CoolingConnectionsPanel(
   if (cooling.length === 0) return null;
 
   return (
-    <Card
+    <div
       data-testid="cooling-connections-panel"
-      className="mb-4 border-amber-500/40 bg-amber-500/5 p-4"
+      className="mb-4 rounded-card border border-amber-500/40 bg-amber-500/5 p-4 shadow-sm"
     >
       <div className="mb-2 flex items-center gap-2">
         <span
@@ -65,15 +62,17 @@ export default function CoolingConnectionsPanel(
         </h3>
       </div>
       <p className="mb-3 text-xs text-muted-foreground">
-        These connections returned a 429 (rate-limit) on their last request.
-        OmniRoute will skip them until the timer expires — no manual disable
-        required.
+        These connections returned a 429 (rate-limit) on their last request. OmniRoute will skip
+        them until the timer expires — no manual disable required.
       </p>
       <ul className="space-y-1">
         {cooling.map((c) => {
           const until = c.rateLimitedUntil!;
           const label =
-            c.displayName || c.name || c.email || (c.id ? `connection ${c.id.slice(0, 8)}` : "connection");
+            c.displayName ||
+            c.name ||
+            c.email ||
+            (c.id ? `connection ${c.id.slice(0, 8)}` : "connection");
           return (
             <li
               key={c.id ?? label}
@@ -90,6 +89,6 @@ export default function CoolingConnectionsPanel(
           );
         })}
       </ul>
-    </Card>
+    </div>
   );
 }

--- a/src/lib/db/providers/rateLimit.ts
+++ b/src/lib/db/providers/rateLimit.ts
@@ -190,21 +190,9 @@ export function clearStaleCrashCooldowns(): { cleared: number } {
   return { cleared: toReset.length };
 }
 
-/**
- * T13: Format a reset countdown as a human-readable string: "2h 35m" or "4m 30s".
- * Returns null if resetAt is in the past or not set.
- */
-export function formatResetCountdown(resetAt: string | number | null | undefined): string | null {
-  if (!resetAt) return null;
-  const resetTime = typeof resetAt === "number" ? resetAt : new Date(resetAt).getTime();
-  if (isNaN(resetTime)) return null;
-  const diffMs = resetTime - Date.now();
-  if (diffMs <= 0) return null;
-  const totalSeconds = Math.floor(diffMs / 1000);
-  const hours = Math.floor(totalSeconds / 3600);
-  const minutes = Math.floor((totalSeconds % 3600) / 60);
-  const seconds = totalSeconds % 60;
-  if (hours > 0) return `${hours}h ${minutes}m`;
-  if (minutes > 0) return `${minutes}m ${seconds}s`;
-  return `${seconds}s`;
-}
+// T13: Format a reset countdown as a human-readable string ("2h 35m" / "4m 30s").
+// The implementation lives in the client-safe formatting utils so client
+// components (e.g. CoolingConnectionsPanel) can import it without pulling this
+// server-only DB module (better-sqlite3/ioredis) into the browser bundle.
+// Re-exported here for existing server-side callers and the db/providers barrel.
+export { formatResetCountdown } from "@/shared/utils/formatting";

--- a/src/shared/utils/formatting.ts
+++ b/src/shared/utils/formatting.ts
@@ -157,3 +157,27 @@ export function truncateUrl(url: string | null | undefined, max = 50) {
 export function safePercentage(value: unknown): number | undefined {
   return typeof value === "number" && isFinite(value) ? value : undefined;
 }
+
+/**
+ * Format a reset countdown as a human-readable string: "2h 35m" or "4m 30s".
+ * Returns null if resetAt is in the past or not set.
+ *
+ * Lives here (client-safe utils) — not in db/providers/rateLimit — so client
+ * components can render a cooldown countdown without dragging the server-only
+ * DB barrel (better-sqlite3/ioredis → node:net) into the browser bundle.
+ * `rateLimit.ts` re-exports this for its server callers.
+ */
+export function formatResetCountdown(resetAt: string | number | null | undefined): string | null {
+  if (!resetAt) return null;
+  const resetTime = typeof resetAt === "number" ? resetAt : new Date(resetAt).getTime();
+  if (isNaN(resetTime)) return null;
+  const diffMs = resetTime - Date.now();
+  if (diffMs <= 0) return null;
+  const totalSeconds = Math.floor(diffMs / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  if (minutes > 0) return `${minutes}m ${seconds}s`;
+  return `${seconds}s`;
+}

--- a/tests/unit/format-reset-countdown.test.ts
+++ b/tests/unit/format-reset-countdown.test.ts
@@ -1,0 +1,38 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { formatResetCountdown } from "@/shared/utils/formatting";
+
+// Guards both the pure formatting behavior and the client-safe home of this
+// helper: it MUST live in @/shared/utils/formatting (not db/providers/rateLimit)
+// so client components can import it without pulling the server-only DB barrel
+// (better-sqlite3/ioredis → node:net) into the browser bundle. See PR #6155.
+
+test("returns null for missing / past / invalid reset times", () => {
+  assert.equal(formatResetCountdown(null), null);
+  assert.equal(formatResetCountdown(undefined), null);
+  assert.equal(formatResetCountdown(0), null);
+  assert.equal(formatResetCountdown("not-a-date"), null);
+  assert.equal(formatResetCountdown(Date.now() - 60_000), null);
+});
+
+test("formats seconds-only remaining", () => {
+  const out = formatResetCountdown(Date.now() + 30_000);
+  assert.match(out ?? "", /^\d+s$/);
+});
+
+test("formats minutes + seconds", () => {
+  const out = formatResetCountdown(Date.now() + 5 * 60_000 + 30_000);
+  assert.match(out ?? "", /^\d+m \d+s$/);
+});
+
+test("formats hours + minutes", () => {
+  const out = formatResetCountdown(Date.now() + 2 * 3_600_000 + 35 * 60_000);
+  assert.match(out ?? "", /^\d+h \d+m$/);
+  assert.ok((out ?? "").startsWith("2h"));
+});
+
+test("accepts an ISO string as well as an epoch number", () => {
+  const iso = new Date(Date.now() + 90_000).toISOString();
+  assert.match(formatResetCountdown(iso) ?? "", /^(1m \d+s|\d+s)$/);
+});

--- a/tests/unit/ui/CoolingConnectionsPanel.test.tsx
+++ b/tests/unit/ui/CoolingConnectionsPanel.test.tsx
@@ -11,9 +11,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // component here fails at module-load if that broken import ever comes back,
 // so this test fails-without-the-fix.
 
-// `formatResetCountdown` lives in db/providers/rateLimit.ts and is re-exported by
-// localDb; stub it so the countdown text is deterministic and no DB is touched.
-vi.mock("@/lib/localDb", () => ({
+// `formatResetCountdown` lives in the client-safe `@/shared/utils/formatting`
+// module (imported directly by the panel — never via the server-only localDb
+// barrel, which would drag ioredis/node:net into the browser bundle). Stub it so
+// the countdown text is deterministic.
+vi.mock("@/shared/utils/formatting", () => ({
   formatResetCountdown: (v: string | number | null | undefined) => (v == null ? null : "in 5m"),
 }));
 

--- a/tests/unit/ui/CoolingConnectionsPanel.test.tsx
+++ b/tests/unit/ui/CoolingConnectionsPanel.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+import React from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Regression guard for the base-red introduced by #6061: CoolingConnectionsPanel
+// imported `Card` from a non-existent `@/components/ui/card`, which passed the
+// PR→release fast-gates (they don't run `next build`) but broke `next build`
+// with `Module not found: Can't resolve '@/components/ui/card'`. Importing the
+// component here fails at module-load if that broken import ever comes back,
+// so this test fails-without-the-fix.
+
+// `formatResetCountdown` lives in db/providers/rateLimit.ts and is re-exported by
+// localDb; stub it so the countdown text is deterministic and no DB is touched.
+vi.mock("@/lib/localDb", () => ({
+  formatResetCountdown: (v: string | number | null | undefined) => (v == null ? null : "in 5m"),
+}));
+
+const cleanupCallbacks: Array<() => void> = [];
+
+function makeContainer(): HTMLElement {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  cleanupCallbacks.push(() => container.remove());
+  return container;
+}
+
+const PANEL_PATH = "@/app/(dashboard)/dashboard/providers/[id]/components/CoolingConnectionsPanel";
+
+describe("CoolingConnectionsPanel", () => {
+  beforeEach(() => {
+    (
+      globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterEach(() => {
+    while (cleanupCallbacks.length > 0) cleanupCallbacks.pop()?.();
+    document.body.innerHTML = "";
+  });
+
+  it("module loads and exports a default component (guards the import path)", async () => {
+    const mod = await import(PANEL_PATH);
+    expect(typeof mod.default).toBe("function");
+  });
+
+  it("renders the panel with a countdown for a cooling connection", async () => {
+    const { default: CoolingConnectionsPanel } = await import(PANEL_PATH);
+    const container = makeContainer();
+    const root = createRoot(container);
+    const future = new Date(Date.now() + 5 * 60_000).toISOString();
+    await act(async () => {
+      root.render(
+        React.createElement(CoolingConnectionsPanel, {
+          connections: [{ id: "conn-abc12345", displayName: "My Key", rateLimitedUntil: future }],
+        })
+      );
+    });
+    const panel = container.querySelector("[data-testid='cooling-connections-panel']");
+    expect(panel).toBeTruthy();
+    expect(container.querySelector("[data-testid='cooling-countdown']")?.textContent).toContain(
+      "in 5m"
+    );
+    expect(panel?.textContent).toContain("My Key");
+  });
+
+  it("renders nothing when no connection is cooling", async () => {
+    const { default: CoolingConnectionsPanel } = await import(PANEL_PATH);
+    const container = makeContainer();
+    const root = createRoot(container);
+    const past = new Date(Date.now() - 60_000).toISOString();
+    await act(async () => {
+      root.render(
+        React.createElement(CoolingConnectionsPanel, {
+          connections: [{ id: "conn-old", displayName: "Expired", rateLimitedUntil: past }],
+        })
+      );
+    });
+    expect(container.querySelector("[data-testid='cooling-connections-panel']")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem — release-blocking base-red

`next build` on `release/v3.8.44` (tip `415d159c8`) **fails to compile**:

```
./src/app/(dashboard)/dashboard/providers/[id]/components/CoolingConnectionsPanel.tsx
Module not found: Can't resolve '@/components/ui/card'
> Build failed because of webpack errors
```

`CoolingConnectionsPanel` (introduced by #6061, `e9d83e7c3`) imports `Card` from `@/components/ui/card` — a **shadcn-style path that does not exist in this repo** (there is no `src/components/ui/`; the repo's card lives at `@/shared/components/Card`). It is the only `@/components/ui/*` reference in the whole tree.

It slipped in because the **PR→release fast-gates do not run `next build`** (only the release PR → `main` does), so the broken import wasn't caught at merge time. This would blow up the next `/generate-release`.

## Fix

- The `<Card>` here was only a **styled container**, so replace it with a `<div>` carrying the equivalent Tailwind classes (border/bg/padding + `rounded-card shadow-sm` to keep the card look). Faithful drop-in — no behavior change.
- Normalize the file **CRLF → LF** (it shipped with CRLF, off the repo's LF/prettier standard).

## Validation (Rule #18 — TDD)

New `tests/unit/ui/CoolingConnectionsPanel.test.tsx` (vitest/jsdom):

- **Fails without the fix** — reverting to the #6061 component (`<Card>` used) makes all 3 tests fail with `Failed to resolve import "@/components/ui/card"` (Vite mirrors webpack's resolution).
- **Passes with the fix** — 3/3: import-path guard + renders-countdown + empty-state.
- `npm run typecheck:core` clean; prettier clean.
- Build validated green as part of the antigravity #6114 VPS bundle (base-red gone).

Regression guard lives in `tests/unit/ui/` so `test:vitest:ui` picks it up.