### PR TITLE
fix: add nvidia to PROVIDER_TOOL_LIMITS (1536) to prevent tool truncation

### DIFF
--- a/open-sse/services/toolLimitDetector.ts
+++ b/open-sse/services/toolLimitDetector.ts
@@ -6,6 +6,7 @@ const DEFAULT_LIMIT = MAX_TOOLS_LIMIT;
 
 const PROVIDER_TOOL_LIMITS: Record<string, number> = {
   "grok-cli": 200,
+  "nvidia": 1536,
 };
 
 const _detectedLimitsSweep = setInterval(() => {

--- a/tests/unit/tool-limit-detector.test.ts
+++ b/tests/unit/tool-limit-detector.test.ts
@@ -69,6 +69,15 @@ describe("toolLimitDetector", () => {
     assert.strictEqual(getEffectiveToolLimit("grok-cli"), 200);
   });
 
+  it("should return proactive limit for nvidia (1536) without any detection", () => {
+    assert.strictEqual(getEffectiveToolLimit("nvidia"), 1536);
+  });
+
+  it("should not override nvidia proactive limit with reactive detection", () => {
+    setDetectedToolLimit("nvidia", 100);
+    assert.strictEqual(getEffectiveToolLimit("nvidia"), 1536);
+  });
+
   it("should still return default (128) for unknown providers", () => {
     assert.strictEqual(getEffectiveToolLimit("some-new-provider"), 128);
   });


### PR DESCRIPTION
## Problem

NVIDIA NIM API (`nvidia/*` models) silently truncates the tool list to 128 tools (the default `MAX_TOOLS_LIMIT`), because `nvidia` is not in the `PROVIDER_TOOL_LIMITS` map. When a client sends more than 128 tools (common with MCP-heavy setups like OpenCode), any tool beyond index 127 is dropped — including critical tools like `task`, `read`, or high-index MCP tools. The truncation is **silent**: no error is raised and the model simply cannot call the dropped tools, leading to confusing runtime failures.

## Root Cause

`getEffectiveToolLimit("nvidia")` returns `DEFAULT_LIMIT = 128` (from `MAX_TOOLS_LIMIT` in `constants.ts`) because `"nvidia"` is not in `PROVIDER_TOOL_LIMITS`. The existing `truncateToolList()` (gate removed in v3.8.43 via #5563) then slices the tools array to 128, dropping everything beyond index 127.

The 128 default applies to **all** providers except those explicitly listed in `PROVIDER_TOOL_LIMITS` (currently only `grok-cli: 200`).

## Fix

Add `"nvidia": 1536` to `PROVIDER_TOOL_LIMITS` in `toolLimitDetector.ts`.

**Why 1536?** Verified by direct testing against `integrate.api.nvidia.com` that NVIDIA's NIM API accepts up to 1536 tools in a single request. 1536 is the real hard limit — sending 1537+ tools returns a 400 error from NIM.

### `open-sse/services/toolLimitDetector.ts`

```typescript
const PROVIDER_TOOL_LIMITS: Record<string, number> = {
  "grok-cli": 200,
  "nvidia": 1536,   // <-- added
};
```

### `tests/unit/tool-limit-detector.test.ts`

Two new unit tests:
- `should return proactive limit for nvidia (1536) without any detection`
- `should not override nvidia proactive limit with reactive detection`

## Result

With fix: 198 tools → all passed through → model calls tools at any index ✅
Without fix: 198 tools → truncated to 128 → tools at indices 128-197 dropped → runtime failures ❌

## Testing

- **End-to-end verified**: 198 tools sent through OmniRoute to `nvidia/z-ai/glm-5.2` via NIM. Model successfully called `task` tool (index 193), `tool_195_special` (index 195), and `tool_last` (index 197) — all previously dropped by truncation to 128.
- **NIM limit verified**: Direct requests to `integrate.api.nvidia.com` confirm 1536 is the hard ceiling (1537+ returns 400).
- **Unit tests added**: Two tests in `tool-limit-detector.test.ts` mirroring the existing grok-cli test pattern.

## Context

Follows the same pattern as #5563 (grok-cli: 200), which was cherry-picked and integrated into `release/v3.8.43` by @diegosouzapw. The `PROVIDER_TOOL_LIMITS` infrastructure and the removal of the broken `effectiveToolLimit < MAX_TOOLS_LIMIT` gate both shipped in v3.8.43.