### PR TITLE
feat(provider): add Claude 5 Sonnet to Claude Web provider

### DIFF
--- a/open-sse/config/providers/registry/claude/web/index.ts
+++ b/open-sse/config/providers/registry/claude/web/index.ts
@@ -9,6 +9,7 @@ export const claude_webProvider: RegistryEntry = {
   authType: "apikey",
   authHeader: "cookie",
   models: [
+    { id: "claude-sonnet-5", name: "Claude 5 Sonnet (web)" },
     { id: "claude-sonnet-4-6", name: "Claude 4.6 Sonnet (web)" },
     { id: "claude-haiku-4-5", name: "Claude 4.5 Haiku (web)" },
   ],


### PR DESCRIPTION
## Summary

- Adds Claude 5 Sonnet (`claude-sonnet-5`) to the Claude Web provider model list
- The model ID matches the one already used by the Kiro provider registry, confirming it's the correct Anthropic identifier

## Changes

| File | Change |
|------|--------|
| `open-sse/config/providers/registry/claude/web/index.ts` | Added `{ id: "claude-sonnet-5", name: "Claude 5 Sonnet (web)" }` to the models array |
