### PR TITLE
fix(services): 9Router embed route + pre-spawn port probe (#6205)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🔧 Bug Fixes
 
 - **fix(api):** relay worker now binds the SSRF guard to a stable `const` name so minified standalone (Docker) builds resolve it ([#6149](https://github.com/diegosouzapw/OmniRoute/issues/6149)) — the Vercel/Deno relay generators embedded the shared `resolveRelayTarget` guard as a bare `${fn.toString()}` declaration while the worker body called the hardcoded literal name; SWC minification mangled the source function's name, so the deployed worker defined `<mangled>` but still called `resolveRelayTarget` → `ReferenceError`. Both templates now emit `const resolveRelayTarget = ${fn.toString()};` (the const name is a template literal, immune to minification). Regression guard: `tests/unit/relay-minified-fn-6149.test.ts` (4). (thanks @SeaXen)
+- **fix(services):** 9Router embed panel no longer 404s (optional catch-all route) and the supervisor probes the port before spawning to avoid raw EADDRINUSE ([#6205](https://github.com/diegosouzapw/OmniRoute/issues/6205)). Regression guards: `tests/unit/ninerouter-embed-port-6205.test.ts`, `tests/unit/services/ServiceSupervisor.test.ts`. (thanks @jonlwheat2-gif)
 
 ### ⚡ Performance & Infrastructure
 

--- a/src/app/(dashboard)/dashboard/providers/services/[name]/embed/[[...path]]/route.ts
+++ b/src/app/(dashboard)/dashboard/providers/services/[name]/embed/[[...path]]/route.ts
@@ -1,7 +1,11 @@
 /**
  * Reverse-proxy handler for embedded service UIs.
  *
- * Route: /dashboard/providers/services/[name]/embed/[...path]
+ * Route: /dashboard/providers/services/[name]/embed/[[...path]]
+ *
+ * Optional catch-all ([[...path]]) so the segment-less prefix
+ * `/embed/` (the panel root — #6205) also matches; a required catch-all
+ * ([...path]) does not match a zero-segment path and falls through to 404.
  *
  * Thin wrapper — all proxy logic lives in @/lib/services/reverseProxy.ts.
  *
@@ -17,11 +21,12 @@ import { proxyRequest } from "@/lib/services/reverseProxy";
 
 export const dynamic = "force-dynamic";
 
-type RouteParams = { name: string; path: string[] };
+// Optional catch-all: `path` is `undefined` for the segment-less `/embed/` root.
+type RouteParams = { name: string; path?: string[] };
 
 async function handleProxy(request: Request, params: RouteParams): Promise<Response> {
   const { name, path } = params;
-  return proxyRequest(request, path, {
+  return proxyRequest(request, path ?? [], {
     name,
     publicPrefix: `/dashboard/providers/services/${name}/embed`,
     htmlRewrite: true,

--- a/src/lib/services/ServiceSupervisor.ts
+++ b/src/lib/services/ServiceSupervisor.ts
@@ -7,6 +7,7 @@ import { sanitizeErrorMessage } from "@omniroute/open-sse/utils/error";
 import { getServiceRow, updateServiceField, setToolStatus } from "@/lib/db/versionManager";
 import { RingBuffer } from "./ringBuffer";
 import { HealthChecker } from "./healthCheck";
+import { decidePreSpawn, probeBeforeSpawn } from "./portProbe";
 import type { ServiceConfig, ServiceState, ServiceStatus, LogLine, HealthState } from "./types";
 
 const CRASH_FAST_THRESHOLD_MS = 5_000;
@@ -60,6 +61,32 @@ export class ServiceSupervisor extends EventEmitter {
 
       this.setState("starting");
       this.lastError = null;
+
+      // Pre-spawn probe (#6205): avoid a raw EADDRINUSE crash when a prior
+      // instance is still holding the port. A healthy instance is adopted; a
+      // held-but-unhealthy port surfaces a clear error instead of a stack.
+      // Opt-in per ServiceConfig so the default spawn path is unchanged.
+      if (this.config.probeBeforeSpawn) {
+        const probe = await probeBeforeSpawn(this.config.healthUrl(), this.config.port);
+        const decision = decidePreSpawn(probe, this.config.port);
+
+        if (decision.action === "adopt") {
+          // Something healthy already serves this port — treat it as running
+          // rather than spawning a duplicate that would die with EADDRINUSE.
+          this.checker.start();
+          this.startedAt = new Date().toISOString();
+          this.setState("running");
+          await setToolStatus(this.config.tool, "running");
+          return this.getStatus();
+        }
+
+        if (decision.action === "error") {
+          this.lastError = sanitizeErrorMessage(decision.message);
+          this.setState("error");
+          await setToolStatus(this.config.tool, "error", undefined, this.lastError);
+          return this.getStatus();
+        }
+      }
 
       const { command, args, env, cwd } = this.config.spawnArgs();
 

--- a/src/lib/services/bootstrap.ts
+++ b/src/lib/services/bootstrap.ts
@@ -105,6 +105,10 @@ export async function bootstrapEmbeddedServices(): Promise<void> {
       healthIntervalMs: cfg.healthIntervalMs,
       stopTimeoutMs: cfg.stopTimeoutMs,
       logsBufferBytes: cfg.logsBufferBytes,
+      // #6205: embedded services bind a fixed port — probe before spawning so
+      // an orphaned prior instance yields adopt/clear-error instead of a raw
+      // EADDRINUSE crash.
+      probeBeforeSpawn: true,
     });
 
     registerSupervisor(supervisor);

--- a/src/lib/services/embedPath.ts
+++ b/src/lib/services/embedPath.ts
@@ -1,0 +1,19 @@
+/**
+ * Pure helpers for the embedded-service reverse proxy path handling.
+ *
+ * Kept dependency-free so the behavior can be unit-tested without pulling in
+ * the registry / DB / htmlRewriter that `reverseProxy.ts` imports.
+ */
+
+/**
+ * Map the `[[...path]]` catch-all segments to an upstream request path.
+ *
+ * The segment-less panel root (`/embed/`, matched only because the route is an
+ * OPTIONAL catch-all — #6205) yields an empty segment array, which must map to
+ * `"/"` so the embedded service serves its index page instead of `/undefined`.
+ *
+ * @param pathSegments The catch-all segments, e.g. `["ui", "index.html"]` or `[]`.
+ */
+export function toUpstreamPath(pathSegments: string[]): string {
+  return pathSegments.length > 0 ? "/" + pathSegments.join("/") : "/";
+}

--- a/src/lib/services/portProbe.ts
+++ b/src/lib/services/portProbe.ts
@@ -1,0 +1,104 @@
+/**
+ * Pre-spawn port/health probe for embedded services (#6205).
+ *
+ * Before the supervisor spawns a service child, it probes the service's port
+ * and health endpoint. This turns two failure modes into graceful outcomes
+ * instead of a raw `EADDRINUSE` stack trace crashing the child:
+ *
+ *   - A healthy prior instance is already answering  → ADOPT it (skip spawn).
+ *   - The port is held but nothing healthy answers    → surface a CLEAR error.
+ *   - The port is free                                → SPAWN normally.
+ *
+ * `decidePreSpawn` is a pure function so the decision logic is unit-testable
+ * without binding a real port or spawning a process.
+ */
+
+import { createConnection } from "node:net";
+
+/** Result of probing the service before spawning. */
+export interface PreSpawnProbe {
+  /** true when the service's healthUrl answered with a 2xx. */
+  healthy: boolean;
+  /** true when something is already listening on the service's port. */
+  portInUse: boolean;
+}
+
+/** Outcome of the pre-spawn decision. */
+export type PreSpawnDecision =
+  | { action: "spawn" }
+  | { action: "adopt" }
+  | { action: "error"; message: string };
+
+const HEALTH_PROBE_TIMEOUT_MS = 3_000;
+const PORT_PROBE_TIMEOUT_MS = 1_000;
+
+/**
+ * Decide what to do before spawning, given a probe of the port + health.
+ *
+ * Pure — no I/O — so it can be exhaustively unit-tested.
+ */
+export function decidePreSpawn(probe: PreSpawnProbe, port: number): PreSpawnDecision {
+  // A healthy instance is already serving on the port — adopt it rather than
+  // spawn a duplicate that would immediately die with EADDRINUSE.
+  if (probe.healthy) {
+    return { action: "adopt" };
+  }
+  // Port is held but nothing healthy answers: an orphaned or unrelated process
+  // is squatting on it. Surface a clear, actionable error instead of letting
+  // the child crash with a raw EADDRINUSE stack.
+  if (probe.portInUse) {
+    return {
+      action: "error",
+      message:
+        `Port ${port} is already in use but the service did not respond to a health ` +
+        `check. An orphaned previous instance or an unrelated process may be holding ` +
+        `the port — stop it (or free the port) and try starting the service again.`,
+    };
+  }
+  // Port is free and nothing is answering — safe to spawn.
+  return { action: "spawn" };
+}
+
+/** TCP connect check: resolves true when something accepts a connection. */
+function isPortInUse(port: number, timeoutMs: number): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    const socket = createConnection({ host: "127.0.0.1", port }, () => {
+      socket.destroy();
+      resolve(true);
+    });
+    socket.setTimeout(timeoutMs);
+    socket.on("error", () => resolve(false));
+    socket.on("timeout", () => {
+      socket.destroy();
+      resolve(false);
+    });
+  });
+}
+
+/** Health check: resolves true when healthUrl answers with a 2xx. */
+async function isHealthy(healthUrl: string, timeoutMs: number): Promise<boolean> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(healthUrl, { signal: controller.signal });
+    return res.ok;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/**
+ * Probe the service's port + health endpoint before spawning.
+ *
+ * @param healthUrl The service's health endpoint URL.
+ * @param port      The service's registered port.
+ */
+export async function probeBeforeSpawn(healthUrl: string, port: number): Promise<PreSpawnProbe> {
+  const [healthy, portInUse] = await Promise.all([
+    isHealthy(healthUrl, HEALTH_PROBE_TIMEOUT_MS),
+    isPortInUse(port, PORT_PROBE_TIMEOUT_MS),
+  ]);
+  return { healthy, portInUse };
+}

--- a/src/lib/services/reverseProxy.ts
+++ b/src/lib/services/reverseProxy.ts
@@ -21,6 +21,7 @@
 import { getSupervisor } from "@/lib/services/registry";
 import { getOrCreateApiKey } from "@/lib/services/apiKey";
 import { rewriteHtml } from "@/lib/services/htmlRewriter";
+import { toUpstreamPath } from "@/lib/services/embedPath";
 import { createErrorResponse } from "@/lib/api/errorResponse";
 import { sanitizeErrorMessage } from "@omniroute/open-sse/utils/error";
 
@@ -90,7 +91,7 @@ export interface ReverseProxyConfig {
  * security-conflicting headers stripped.
  *
  * @param request      The incoming Next.js route Request.
- * @param pathSegments The `[...path]` catch-all segments, e.g. `["ui", "index.html"]`.
+ * @param pathSegments The `[[...path]]` catch-all segments, e.g. `["ui", "index.html"]` or `[]`.
  * @param config       Proxy configuration (service name + public prefix).
  */
 export async function proxyRequest(
@@ -114,7 +115,7 @@ export async function proxyRequest(
   }
 
   const incomingUrl = new URL(request.url);
-  const upstreamPath = pathSegments.length > 0 ? "/" + pathSegments.join("/") : "/";
+  const upstreamPath = toUpstreamPath(pathSegments);
   const upstreamUrl = `http://127.0.0.1:${port}${upstreamPath}${incomingUrl.search}`;
 
   // Build forwarded headers: strip hop-by-hop AND sensitive client headers.

--- a/src/lib/services/types.ts
+++ b/src/lib/services/types.ts
@@ -13,6 +13,14 @@ export interface ServiceConfig {
   healthIntervalMs: number;
   stopTimeoutMs: number;
   logsBufferBytes: number;
+  /**
+   * When true (#6205), the supervisor probes the port + health endpoint before
+   * spawning: a healthy prior instance is adopted, a held-but-unhealthy port
+   * yields a clear error instead of a raw EADDRINUSE stack. Opt-in so the
+   * default spawn path (and existing supervisor tests) stays byte-identical —
+   * enabled for services that bind a fixed port (e.g. 9router).
+   */
+  probeBeforeSpawn?: boolean;
 }
 
 export type ServiceState =

--- a/tests/unit/ninerouter-embed-port-6205.test.ts
+++ b/tests/unit/ninerouter-embed-port-6205.test.ts
@@ -1,0 +1,100 @@
+/**
+ * #6205 — 9Router embedded service: embed-panel 404 + pre-spawn EADDRINUSE.
+ *
+ * SUB-BUG A — the embed panel root (`/embed/`, zero segments after `embed/`)
+ * 404s because the proxy route was a REQUIRED catch-all `[...path]`, which does
+ * not match a segment-less path. Fix: OPTIONAL catch-all `[[...path]]` so the
+ * root matches, and `reverseProxy.toUpstreamPath([])` maps the empty segment
+ * array to `"/"`.
+ *
+ * SUB-BUG B — `ServiceSupervisor.start()` spawned the child with no pre-flight
+ * port/health probe, so an orphaned prior instance holding the port made the
+ * child die with a raw EADDRINUSE stack. Fix: `decidePreSpawn()` — adopt a
+ * healthy instance, surface a clear error for a held-but-unhealthy port.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+import { toUpstreamPath } from "../../src/lib/services/embedPath.ts";
+import { decidePreSpawn } from "../../src/lib/services/portProbe.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "../..");
+
+// ─── SUB-BUG A: optional catch-all route + empty-segment mapping ──────────────
+
+describe("#6205 A — embed panel root no longer 404s", () => {
+  it("the proxy route folder is an OPTIONAL catch-all ([[...path]])", () => {
+    const optional = path.join(
+      repoRoot,
+      "src/app/(dashboard)/dashboard/providers/services/[name]/embed/[[...path]]/route.ts"
+    );
+    const required = path.join(
+      repoRoot,
+      "src/app/(dashboard)/dashboard/providers/services/[name]/embed/[...path]/route.ts"
+    );
+    assert.ok(existsSync(optional), "optional catch-all [[...path]]/route.ts must exist");
+    assert.ok(
+      !existsSync(required),
+      "required catch-all [...path]/route.ts must be gone (it cannot match /embed/)"
+    );
+  });
+
+  it("maps the segment-less embed root ([]) to upstream '/'", () => {
+    // The embed frame links to `/dashboard/providers/services/9router/embed/`,
+    // i.e. zero segments after `embed/`. With the optional catch-all matching,
+    // Next hands the route an empty segment array — which must map to "/".
+    assert.equal(toUpstreamPath([]), "/");
+  });
+
+  it("still maps nested segments to their upstream path", () => {
+    assert.equal(toUpstreamPath(["ui", "index.html"]), "/ui/index.html");
+    assert.equal(toUpstreamPath(["api", "models"]), "/api/models");
+  });
+
+  it("derives an empty segment array from the embed frame's constructed path", () => {
+    // Mirrors what Next's catch-all does: strip the prefix, split remaining.
+    const framePath = "/dashboard/providers/services/9router/embed/";
+    const prefix = "/dashboard/providers/services/9router/embed/";
+    const rest = framePath.slice(prefix.length); // ""
+    const segments = rest.split("/").filter(Boolean); // []
+    assert.deepEqual(segments, []);
+    assert.equal(toUpstreamPath(segments), "/");
+  });
+});
+
+// ─── SUB-BUG B: pre-spawn port/health decision ───────────────────────────────
+
+describe("#6205 B — pre-spawn port probe avoids raw EADDRINUSE", () => {
+  it("adopts a healthy existing instance (no spawn)", () => {
+    const decision = decidePreSpawn({ healthy: true, portInUse: true }, 20130);
+    assert.equal(decision.action, "adopt");
+  });
+
+  it("returns a clear error object (not a throw) when the port is held but unhealthy", () => {
+    let decision;
+    assert.doesNotThrow(() => {
+      decision = decidePreSpawn({ healthy: false, portInUse: true }, 20130);
+    }, "decision must be returned, never thrown");
+    assert.equal(decision.action, "error");
+    assert.match(decision.message, /already in use/i);
+    assert.match(decision.message, /20130/, "error should name the port");
+    // The clear message must not be a raw EADDRINUSE stack trace.
+    assert.ok(!decision.message.includes("at /"), "must not leak a stack trace");
+  });
+
+  it("spawns when the port is free", () => {
+    const decision = decidePreSpawn({ healthy: false, portInUse: false }, 20130);
+    assert.equal(decision.action, "spawn");
+  });
+
+  it("adopts a healthy instance even if the TCP probe missed it", () => {
+    // Health is authoritative: a 2xx means a real instance is serving.
+    const decision = decidePreSpawn({ healthy: true, portInUse: false }, 20130);
+    assert.equal(decision.action, "adopt");
+  });
+});

--- a/tests/unit/services/ServiceSupervisor.test.ts
+++ b/tests/unit/services/ServiceSupervisor.test.ts
@@ -36,6 +36,10 @@ db.prepare(
   `INSERT OR IGNORE INTO version_manager (tool, status, port, auto_start, auto_update, provider_expose)
    VALUES ('test-lock', 'stopped', 29997, 0, 0, 0)`
 ).run();
+db.prepare(
+  `INSERT OR IGNORE INTO version_manager (tool, status, port, auto_start, auto_update, provider_expose)
+   VALUES ('test-adopt', 'stopped', 29996, 0, 0, 0)`
+).run();
 
 const { ServiceSupervisor } = await import("../../../src/lib/services/ServiceSupervisor.ts");
 
@@ -201,6 +205,27 @@ test("does NOT auto-restart on crash", async () => {
       `supervisor should not auto-restart: state was "${status.state}"`
     );
   } finally {
+    healthServer.close();
+  }
+});
+
+// #6205: when probeBeforeSpawn is enabled and a healthy instance already serves
+// the port, the supervisor ADOPTS it (marks running, no child spawned) instead
+// of spawning a duplicate that would die with EADDRINUSE.
+test("#6205: probeBeforeSpawn adopts a healthy existing instance (no spawn)", async () => {
+  const healthServer = startHealthServer(29996);
+  const cfg = { ...tickConfig("test-adopt", 29996), probeBeforeSpawn: true };
+  const sup = new ServiceSupervisor(cfg);
+
+  try {
+    const status = await sup.start();
+    assert.equal(status.state, "running", "adopted instance is marked running");
+    assert.equal(status.pid, null, "no child process is spawned when adopting");
+    // No child means no captured stdout ticks.
+    await new Promise((r) => setTimeout(r, 300));
+    assert.equal(sup.getRingBuffer().snapshot().length, 0, "no logs — nothing was spawned");
+  } finally {
+    await sup.stop();
     healthServer.close();
   }
 });

--- a/tests/unit/services/embed-proxy.test.ts
+++ b/tests/unit/services/embed-proxy.test.ts
@@ -2,7 +2,7 @@
  * T-07 — embed proxy route handler tests.
  *
  * Tests GET/POST/PUT/PATCH/DELETE handlers in
- * /dashboard/providers/services/[name]/embed/[...path]/route.ts.
+ * /dashboard/providers/services/[name]/embed/[[...path]]/route.ts.
  *
  * Uses registerSupervisor to inject fake supervisors (ESM live bindings
  * can't be reassigned, so direct module patching is not possible).
@@ -21,7 +21,7 @@ import {
   DELETE,
   HEAD,
   OPTIONS,
-} from "../../../src/app/(dashboard)/dashboard/providers/services/[name]/embed/[...path]/route.ts";
+} from "../../../src/app/(dashboard)/dashboard/providers/services/[name]/embed/[[...path]]/route.ts";
 
 const originalFetch = globalThis.fetch;
 


### PR DESCRIPTION
Closes #6205

Two confirmed sub-bugs: (1) embed panel 404 — folder renamed `[...path]`→`[[...path]]` (optional catch-all) so the segment-less `/embed/` root matches; (2) EADDRINUSE — supervisor probes the port before spawning (adopt healthy instance / clear error). TDD (Hard Rule #18), 8 new tests + existing 20 intact. Ignored: better-sqlite3 (reporter self-corrected, non-fatal) and 503 (needs-info).