### PR TITLE
feat(providers): add Yuanbao (web) cookie-session provider (#6196)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### ✨ New Features
+
+- **feat(providers):** add **Yuanbao (web)** as a cookie-session provider ([#6196](https://github.com/diegosouzapw/OmniRoute/issues/6196)) — `yuanbao-web` (Tencent Yuanbao, `yuanbao.tencent.com`) with cookie-only auth (`hy_user`/`hy_token` + public agent id), SSE→OpenAI translation incl. `reasoning_content`, exposing DeepSeek V3/R1 + Hunyuan / Hunyuan-T1. Regression guard: `tests/unit/providers-yuanbao-web.test.ts`. `together-web` was **deferred** (no verifiable web-session endpoint — needs a captured request) and `huggingchat-web` **dropped** (the existing `huggingchat` already is a web-cookie provider). (thanks @chirag127)
+
 ### 🐛 Bug Fixes
 
 - **chatcore (tools): stop the default 128-tool cap from silently dropping opencode's `task`/MCP tools.** opencode (used as an MCP/agent host) sends a large tool list; when it exceeds the speculative `MAX_TOOLS_LIMIT` (128) default, `truncateToolList` did a blind `tools.slice(0, 128)`, dropping every tool past index 128 — including opencode's built-in `task` tool (subagent launch) and many MCP tools, so models routed through OmniRoute could no longer spawn subagents or reach part of their tools. The cap exists to avoid upstream `400`s for providers with real hard limits (e.g. grok-cli 200), so it is kept for those: detection of the opencode client (`isOpencodeClient` — any `x-opencode-*` header, or `opencode` in the user-agent) now only bypasses the **speculative 128 default**, never a known provider ceiling. Precedence is explicit — a proactive/detected provider limit always truncates (even for opencode); otherwise opencode forwards its full tool list; otherwise the unchanged 128 default applies to every other client. Refactors `getEffectiveToolLimit` into `getKnownToolLimit(provider) ?? DEFAULT_LIMIT` (byte-identical for existing callers) and fixes a cosmetic debug-log that reported the truncated count instead of the original. Regression guard: `tests/unit/tool-limit-detector.test.ts`.

--- a/open-sse/config/providers/index.ts
+++ b/open-sse/config/providers/index.ts
@@ -134,6 +134,7 @@ import { agentrouterProvider } from "./registry/agentrouter/index.ts";
 import { zaiProvider } from "./registry/zai/index.ts";
 import { waferProvider } from "./registry/wafer/index.ts";
 import { huggingchatProvider } from "./registry/huggingchat/index.ts";
+import { yuanbao_webProvider } from "./registry/yuanbao-web/index.ts";
 import { galadrielProvider } from "./registry/galadriel/index.ts";
 import { qianfanProvider } from "./registry/qianfan/index.ts";
 import { meta_llamaProvider } from "./registry/meta-llama/index.ts";
@@ -314,6 +315,7 @@ export const REGISTRY: Record<string, RegistryEntry> = {
   agentrouter: agentrouterProvider,
   zai: zaiProvider,
   huggingchat: huggingchatProvider,
+  "yuanbao-web": yuanbao_webProvider,
   galadriel: galadrielProvider,
   qianfan: qianfanProvider,
   "meta-llama": meta_llamaProvider,

--- a/open-sse/config/providers/registry/yuanbao-web/index.ts
+++ b/open-sse/config/providers/registry/yuanbao-web/index.ts
@@ -1,0 +1,37 @@
+import type { RegistryEntry } from "../../shared.ts";
+
+export const yuanbao_webProvider: RegistryEntry = {
+  id: "yuanbao-web",
+  alias: "ybw",
+  format: "openai",
+  executor: "yuanbao-web",
+  baseUrl: "https://yuanbao.tencent.com/api/chat",
+  authType: "apikey",
+  authHeader: "cookie",
+  models: [
+    { id: "deepseek-v3", name: "DeepSeek V3 (via Yuanbao)", toolCalling: false },
+    {
+      id: "deepseek-r1",
+      name: "DeepSeek R1 (via Yuanbao)",
+      supportsReasoning: true,
+    },
+    { id: "hunyuan", name: "Hunyuan (via Yuanbao)" },
+    {
+      id: "hunyuan-t1",
+      name: "Hunyuan T1 (via Yuanbao)",
+      supportsReasoning: true,
+    },
+    { id: "deepseek-v3-search", name: "DeepSeek V3 + Web Search (via Yuanbao)" },
+    {
+      id: "deepseek-r1-search",
+      name: "DeepSeek R1 + Web Search (via Yuanbao)",
+      supportsReasoning: true,
+    },
+    { id: "hunyuan-search", name: "Hunyuan + Web Search (via Yuanbao)" },
+    {
+      id: "hunyuan-t1-search",
+      name: "Hunyuan T1 + Web Search (via Yuanbao)",
+      supportsReasoning: true,
+    },
+  ],
+};

--- a/open-sse/executors/index.ts
+++ b/open-sse/executors/index.ts
@@ -41,6 +41,7 @@ import { T3ChatWebExecutor } from "./t3-chat-web.ts";
 import { ClaudeWebExecutor } from "./claude-web.ts";
 import { InnerAiExecutor } from "./inner-ai.ts";
 import { HuggingChatExecutor } from "./huggingchat.ts";
+import { YuanbaoWebExecutor } from "./yuanbao-web.ts";
 import { PoeWebExecutor } from "./poe-web.ts";
 import { VeniceWebExecutor } from "./venice-web.ts";
 import { V0VercelWebExecutor } from "./v0-vercel-web.ts";
@@ -129,6 +130,8 @@ const executors = {
   "in-ai": new InnerAiExecutor(), // Alias
   huggingchat: new HuggingChatExecutor(),
   hc: new HuggingChatExecutor(), // Alias
+  "yuanbao-web": new YuanbaoWebExecutor(),
+  ybw: new YuanbaoWebExecutor(), // Alias
   "poe-web": new PoeWebExecutor(),
   poe: new PoeWebExecutor(), // Alias
   "venice-web": new VeniceWebExecutor(),
@@ -212,6 +215,7 @@ export { ClaudeWebExecutor } from "./claude-web.ts";
 export { DeepSeekWebExecutor } from "./deepseek-web.ts";
 export { DeepSeekWebWithAutoRefreshExecutor } from "./deepseek-web-with-auto-refresh.ts";
 export { AdaptaWebExecutor } from "./adapta-web.ts";
+export { YuanbaoWebExecutor } from "./yuanbao-web.ts";
 export { T3ChatWebExecutor } from "./t3-chat-web.ts";
 export { InnerAiExecutor } from "./inner-ai.ts";
 export { QwenWebExecutor } from "./qwen-web.ts";

--- a/open-sse/executors/yuanbao-web.ts
+++ b/open-sse/executors/yuanbao-web.ts
@@ -1,0 +1,504 @@
+/**
+ * YuanbaoWebExecutor — Tencent Yuanbao (yuanbao.tencent.com) Web Provider
+ *
+ * Routes chat requests through the Tencent Yuanbao consumer web session.
+ * Requires the `hy_user` + `hy_token` cookies from a logged-in
+ * yuanbao.tencent.com browser session (paste the full Cookie header).
+ *
+ * API flow (verified against the reverse-engineered references below):
+ *   1. POST /api/user/agent/conversation/create  { agentId } -> { id }  (conversationId)
+ *   2. POST /api/chat/{conversationId}           (JSON body) -> SSE stream
+ *
+ * Streaming format (SSE, `data: {json}` lines):
+ *   - { type: "think", content: "..." }   -- reasoning tokens (DeepSeek-R1 / Hunyuan-T1)
+ *   - { type: "text",  msg: "..." }       -- answer tokens
+ *   - { ..., stopReason: "..." }          -- terminal marker
+ *
+ * References (endpoint/payload/session shape lifted + cross-checked):
+ *   - juzeon/yuanbao-chat2api (Rust)      — cookie-only auth: hy_user + hy_token + agentId
+ *   - chenwr727/yuanbao-free-api (Python) — endpoints, body shape, model map
+ */
+import {
+  BaseExecutor,
+  mergeAbortSignals,
+  mergeUpstreamExtraHeaders,
+  type ExecuteInput,
+} from "./base.ts";
+import { FETCH_TIMEOUT_MS } from "../config/constants.ts";
+import { buildErrorBody, sanitizeErrorMessage } from "../utils/error.ts";
+import { extractCookieValue, stripCookieInputPrefix } from "@/lib/providers/webCookieAuth";
+
+const YUANBAO_BASE = "https://yuanbao.tencent.com";
+const CREATE_URL = `${YUANBAO_BASE}/api/user/agent/conversation/create`;
+const CHAT_URL = `${YUANBAO_BASE}/api/chat`;
+
+// Public default DeepSeek agent id used by the Yuanbao web app. Not a secret —
+// it is the shared consumer agent every logged-in session addresses by default.
+const DEFAULT_AGENT_ID = "naQivTmsDa";
+
+const USER_AGENT =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " +
+  "(KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36";
+
+const DEFAULT_MODEL = "deepseek-v3";
+
+// OmniRoute model id -> Yuanbao internal chatModelId + optional supportFunctions.
+const MODEL_MAP: Record<string, { chatModelId: string; supportFunctions?: string[] }> = {
+  "deepseek-v3": { chatModelId: "deep_seek_v3" },
+  "deepseek-r1": { chatModelId: "deep_seek" },
+  "deepseek-v3-search": {
+    chatModelId: "deep_seek_v3",
+    supportFunctions: ["supportInternetSearch"],
+  },
+  "deepseek-r1-search": {
+    chatModelId: "deep_seek",
+    supportFunctions: ["supportInternetSearch"],
+  },
+  hunyuan: { chatModelId: "hunyuan_gpt_175B_0404" },
+  "hunyuan-t1": { chatModelId: "hunyuan_t1" },
+  "hunyuan-search": {
+    chatModelId: "hunyuan_gpt_175B_0404",
+    supportFunctions: ["supportInternetSearch"],
+  },
+  "hunyuan-t1-search": {
+    chatModelId: "hunyuan_t1",
+    supportFunctions: ["supportInternetSearch"],
+  },
+};
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function isEncryptedCredentialBlob(value: unknown): boolean {
+  return typeof value === "string" && value.trim().startsWith("enc:v1:");
+}
+
+function extractText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return String(content ?? "");
+  return content
+    .map((part: unknown) => {
+      if (!part || typeof part !== "object") return "";
+      const item = part as Record<string, unknown>;
+      if ((item.type === "text" || item.type === "input_text") && typeof item.text === "string") {
+        return item.text;
+      }
+      return "";
+    })
+    .filter((p: string) => p.length > 0)
+    .join("\n");
+}
+
+/** Flatten OpenAI messages into the single-prompt shape Yuanbao expects. */
+function buildPrompt(messages: Array<Record<string, unknown>>): string {
+  const parts: Array<{ role: string; content: string }> = [];
+  for (const msg of messages) {
+    const role = String(msg.role || "user");
+    const text = extractText(msg.content).trim();
+    if (!text) continue;
+    parts.push({ role, content: text });
+  }
+  if (parts.length === 0) return "";
+  if (parts.length === 1) return parts[0].content;
+  // Multi-turn: label each turn (matches the reference chat2api formatting).
+  return parts.map((p) => `#[${p.role.trim()}]\n${p.content}`).join("\n\n");
+}
+
+/** Build the `hy_source=web; hy_user=...; hy_token=...` cookie from the pasted header. */
+function buildYuanbaoCookie(rawApiKey: string): { cookie: string; hasToken: boolean } {
+  const raw = stripCookieInputPrefix(rawApiKey || "");
+  const hyUser = extractCookieValue(raw, "hy_user");
+  const hyToken = extractCookieValue(raw, "hy_token");
+
+  if (hyUser && hyToken) {
+    return { cookie: `hy_source=web; hy_user=${hyUser}; hy_token=${hyToken}`, hasToken: true };
+  }
+
+  // Fall back to forwarding whatever the user pasted (may already be a full
+  // Cookie header). Only usable if it plausibly carries the session token.
+  const hasToken = raw.includes("hy_token=");
+  return { cookie: raw, hasToken };
+}
+
+function estimateTokens(text: string): number {
+  return Math.max(1, Math.ceil((text || "").length / 4));
+}
+
+async function readUpstreamErrorDetails(response: Response): Promise<{
+  message: string | null;
+  details: unknown;
+}> {
+  const contentType = response.headers.get("content-type") || "";
+  const text = await response.text().catch(() => "");
+  if (!text) return { message: null, details: null };
+
+  if (contentType.includes("json")) {
+    try {
+      const parsed = JSON.parse(text) as Record<string, unknown>;
+      const message =
+        typeof parsed.message === "string"
+          ? parsed.message
+          : typeof parsed.error === "string"
+            ? parsed.error
+            : null;
+      return { message: message ? sanitizeErrorMessage(message) : null, details: parsed };
+    } catch {
+      // fall through
+    }
+  }
+  return { message: sanitizeErrorMessage(text), details: { body: text } };
+}
+
+// ── Executor ────────────────────────────────────────────────────────────────
+
+export class YuanbaoWebExecutor extends BaseExecutor {
+  constructor() {
+    super("yuanbao-web", { id: "yuanbao-web", baseUrl: CHAT_URL });
+  }
+
+  private errorResponse(status: number, message: string, url: string, details?: unknown) {
+    return {
+      response: new Response(JSON.stringify(buildErrorBody(status, message, details)), {
+        status,
+        headers: { "Content-Type": "application/json" },
+      }),
+      url,
+      headers: {},
+      transformedBody: undefined,
+    };
+  }
+
+  async execute(input: ExecuteInput): Promise<{
+    response: Response;
+    url: string;
+    headers: Record<string, string>;
+    transformedBody: unknown;
+  }> {
+    const { model, body, stream, credentials, signal, log, upstreamExtraHeaders } = input;
+    const messages = (body as Record<string, unknown>).messages as
+      | Array<Record<string, unknown>>
+      | undefined;
+
+    if (!messages || !Array.isArray(messages) || messages.length === 0) {
+      return this.errorResponse(400, "Missing or empty messages array", CHAT_URL);
+    }
+
+    if (isEncryptedCredentialBlob(credentials.apiKey)) {
+      return this.errorResponse(
+        401,
+        "Yuanbao credentials are encrypted but STORAGE_ENCRYPTION_KEY is not loaded. " +
+          "Restore the encryption key or re-save the Yuanbao cookie.",
+        CREATE_URL
+      );
+    }
+
+    const { cookie, hasToken } = buildYuanbaoCookie(credentials.apiKey || "");
+    if (!hasToken) {
+      return this.errorResponse(
+        401,
+        "Yuanbao requires a session cookie. Log in to yuanbao.tencent.com, open " +
+          "DevTools > Application > Cookies, and paste the full Cookie header " +
+          "(it must contain hy_user and hy_token).",
+        CREATE_URL
+      );
+    }
+
+    const resolvedModel = model && MODEL_MAP[model] ? model : DEFAULT_MODEL;
+    const modelSpec = MODEL_MAP[resolvedModel];
+    const prompt = buildPrompt(messages);
+    if (!prompt.trim()) {
+      return this.errorResponse(400, "Empty prompt after processing messages", CHAT_URL);
+    }
+
+    const baseHeaders: Record<string, string> = {
+      Cookie: cookie,
+      "User-Agent": USER_AGENT,
+      Origin: YUANBAO_BASE,
+      Referer: `${YUANBAO_BASE}/chat/${DEFAULT_AGENT_ID}`,
+      "X-Agentid": DEFAULT_AGENT_ID,
+    };
+
+    const timeoutSignal = AbortSignal.timeout(FETCH_TIMEOUT_MS);
+    const combinedSignal = signal ? mergeAbortSignals(signal, timeoutSignal) : timeoutSignal;
+
+    // ── Step 1: create conversation ─────────────────────────────────────────
+    let conversationId: string;
+    try {
+      const createRes = await fetch(CREATE_URL, {
+        method: "POST",
+        headers: { ...baseHeaders, "Content-Type": "application/json" },
+        body: JSON.stringify({ agentId: DEFAULT_AGENT_ID }),
+        signal: combinedSignal,
+      });
+
+      if (!createRes.ok) {
+        const status = createRes.status;
+        const upstreamError = await readUpstreamErrorDetails(createRes);
+        let message = `Yuanbao conversation creation failed (HTTP ${status})`;
+        if (status === 401 || status === 403) {
+          message =
+            "Yuanbao auth failed — your hy_user/hy_token cookies may be missing or expired. " +
+            "Log in to yuanbao.tencent.com and re-paste your Cookie header.";
+        } else if (status === 429) {
+          message = "Yuanbao rate limited. Wait a moment and retry.";
+        }
+        if (upstreamError.message) message = `${message}: ${upstreamError.message}`;
+        return this.errorResponse(status, message, CREATE_URL, upstreamError.details);
+      }
+
+      const createData = (await createRes.json()) as Record<string, unknown>;
+      conversationId = String(createData.id || "");
+      if (!conversationId) {
+        return this.errorResponse(
+          502,
+          "Yuanbao did not return a conversation id",
+          CREATE_URL
+        );
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log?.error?.("YUANBAO-WEB", `Conversation creation failed: ${message}`);
+      return this.errorResponse(
+        502,
+        `Yuanbao connection failed: ${sanitizeErrorMessage(message)}`,
+        CREATE_URL
+      );
+    }
+
+    // ── Step 2: send message ────────────────────────────────────────────────
+    const messageUrl = `${CHAT_URL}/${conversationId}`;
+    const chatBody: Record<string, unknown> = {
+      model: "gpt_175B_0404",
+      prompt,
+      plugin: "Adaptive",
+      displayPrompt: prompt,
+      displayPromptType: 1,
+      options: {
+        imageIntention: {
+          needIntentionModel: true,
+          backendUpdateFlag: 2,
+          intentionStatus: true,
+        },
+      },
+      multimedia: [],
+      agentId: DEFAULT_AGENT_ID,
+      supportHint: 1,
+      version: "v2",
+      chatModelId: modelSpec.chatModelId,
+    };
+    if (modelSpec.supportFunctions) chatBody.supportFunctions = modelSpec.supportFunctions;
+
+    const chatHeaders: Record<string, string> = {
+      ...baseHeaders,
+      "Content-Type": "application/json",
+      Accept: "text/event-stream",
+    };
+    mergeUpstreamExtraHeaders(chatHeaders, upstreamExtraHeaders);
+
+    let upstreamResponse: Response;
+    try {
+      upstreamResponse = await fetch(messageUrl, {
+        method: "POST",
+        headers: chatHeaders,
+        body: JSON.stringify(chatBody),
+        signal: combinedSignal,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log?.error?.("YUANBAO-WEB", `Message send failed: ${message}`);
+      return this.errorResponse(
+        502,
+        `Yuanbao connection failed: ${sanitizeErrorMessage(message)}`,
+        messageUrl
+      );
+    }
+
+    if (!upstreamResponse.ok) {
+      const status = upstreamResponse.status;
+      const upstreamError = await readUpstreamErrorDetails(upstreamResponse);
+      let message = `Yuanbao returned HTTP ${status}`;
+      if (status === 401 || status === 403) {
+        message = "Yuanbao auth failed — session cookie may be expired.";
+      } else if (status === 429) {
+        message = "Yuanbao rate limited. Wait a moment and retry.";
+      }
+      if (upstreamError.message) message = `${message}: ${upstreamError.message}`;
+      return this.errorResponse(status, message, messageUrl, upstreamError.details);
+    }
+
+    if (!upstreamResponse.body) {
+      return this.errorResponse(502, "Yuanbao returned empty response body", messageUrl);
+    }
+
+    // ── Step 3: translate SSE → OpenAI ──────────────────────────────────────
+    const id = `chatcmpl-yuanbao-${crypto.randomUUID().slice(0, 12)}`;
+    const created = Math.floor(Date.now() / 1000);
+
+    if (stream) {
+      return {
+        response: new Response(
+          transformYuanbaoStream(upstreamResponse.body, resolvedModel, id, created, signal, log),
+          {
+            status: 200,
+            headers: {
+              "Content-Type": "text/event-stream",
+              "Cache-Control": "no-cache",
+              "X-Accel-Buffering": "no",
+            },
+          }
+        ),
+        url: messageUrl,
+        headers: chatHeaders,
+        transformedBody: chatBody,
+      };
+    }
+
+    const { content, reasoning } = await collectYuanbaoResponse(upstreamResponse.body, signal);
+    const completionTokens = estimateTokens(content + reasoning);
+    const messagePayload: Record<string, unknown> = { role: "assistant", content };
+    if (reasoning) messagePayload.reasoning_content = reasoning;
+
+    return {
+      response: new Response(
+        JSON.stringify({
+          id,
+          object: "chat.completion",
+          created,
+          model: resolvedModel,
+          choices: [{ index: 0, message: messagePayload, finish_reason: "stop" }],
+          usage: {
+            prompt_tokens: estimateTokens(prompt),
+            completion_tokens: completionTokens,
+            total_tokens: estimateTokens(prompt) + completionTokens,
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      ),
+      url: messageUrl,
+      headers: chatHeaders,
+      transformedBody: chatBody,
+    };
+  }
+}
+
+// ── SSE translation helpers ───────────────────────────────────────────────────
+
+interface YuanbaoEvent {
+  type?: string;
+  content?: string;
+  msg?: string;
+  stopReason?: string;
+}
+
+function parseYuanbaoDataLine(line: string): YuanbaoEvent | null {
+  if (!line.startsWith("data: ")) return null;
+  const payload = line.slice(6).trim();
+  if (!payload || payload === "[DONE]" || !payload.startsWith("{")) return null;
+  try {
+    return JSON.parse(payload) as YuanbaoEvent;
+  } catch {
+    return null;
+  }
+}
+
+function transformYuanbaoStream(
+  upstream: ReadableStream<Uint8Array>,
+  model: string,
+  id: string,
+  created: number,
+  signal: AbortSignal | null | undefined,
+  log?: ExecuteInput["log"]
+): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
+  let roleEmitted = false;
+
+  return new ReadableStream({
+    async start(controller) {
+      const reader = upstream.getReader();
+      let buffer = "";
+
+      const emit = (delta: object, finish?: string | null) => {
+        controller.enqueue(
+          encoder.encode(
+            `data: ${JSON.stringify({
+              id,
+              object: "chat.completion.chunk",
+              created,
+              model,
+              choices: [{ index: 0, delta, finish_reason: finish ?? null }],
+            })}\n\n`
+          )
+        );
+      };
+
+      const ensureRole = () => {
+        if (!roleEmitted) {
+          roleEmitted = true;
+          emit({ role: "assistant", content: "" });
+        }
+      };
+
+      try {
+        while (true) {
+          if (signal?.aborted) break;
+          const { done, value } = await reader.read();
+          if (done) break;
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split("\n");
+          buffer = lines.pop() ?? "";
+          for (const line of lines) {
+            const event = parseYuanbaoDataLine(line);
+            if (!event) continue;
+            if (event.type === "think" && event.content) {
+              ensureRole();
+              emit({ reasoning_content: event.content });
+            } else if (event.type === "text" && typeof event.msg === "string" && event.msg) {
+              ensureRole();
+              emit({ content: event.msg });
+            }
+          }
+        }
+      } catch (err) {
+        log?.error?.("YUANBAO-WEB", `Stream error: ${err}`);
+      } finally {
+        ensureRole();
+        emit({}, "stop");
+        controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+        controller.close();
+        reader.releaseLock();
+      }
+    },
+  });
+}
+
+async function collectYuanbaoResponse(
+  upstream: ReadableStream<Uint8Array>,
+  signal: AbortSignal | null | undefined
+): Promise<{ content: string; reasoning: string }> {
+  const decoder = new TextDecoder();
+  const reader = upstream.getReader();
+  let buffer = "";
+  let content = "";
+  let reasoning = "";
+
+  try {
+    while (true) {
+      if (signal?.aborted) break;
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+      for (const line of lines) {
+        const event = parseYuanbaoDataLine(line);
+        if (!event) continue;
+        if (event.type === "think" && event.content) reasoning += event.content;
+        else if (event.type === "text" && typeof event.msg === "string") content += event.msg;
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  return { content, reasoning };
+}

--- a/src/shared/constants/providers/web-cookie.ts
+++ b/src/shared/constants/providers/web-cookie.ts
@@ -185,6 +185,21 @@ export const WEB_COOKIE_PROVIDERS = {
       "Paste the full Cookie header from lmarena.ai (DevTools → Network → request → Cookie). The session is now split across arena-auth-prod-v1.0, .1, … — copy the whole header. Optional — works with free tier for basic comparisons.",
     riskNoticeVariant: "webCookie",
   },
+  "yuanbao-web": {
+    id: "yuanbao-web",
+    alias: "ybw",
+    name: "Tencent Yuanbao (Free)",
+    icon: "auto_awesome",
+    color: "#0052D9",
+    textIcon: "YB",
+    website: "https://yuanbao.tencent.com",
+    hasFree: true,
+    freeNote:
+      "Free consumer web session — DeepSeek V3/R1 and Hunyuan / Hunyuan-T1, optional web search. No subscription required. Rate limits apply.",
+    authHint:
+      "Log in to yuanbao.tencent.com, then paste the full Cookie header (DevTools → Network → any /api request → Request Headers → Cookie). It must contain hy_user and hy_token.",
+    riskNoticeVariant: "webCookie",
+  },
   huggingchat: {
     id: "huggingchat",
     // "hc" belongs to the hackclub provider; huggingchat uses its own id as alias.

--- a/src/shared/providers/webSessionCredentials.ts
+++ b/src/shared/providers/webSessionCredentials.ts
@@ -141,6 +141,13 @@ export const WEB_SESSION_CREDENTIAL_REQUIREMENTS = {
     acceptsFullCookieHeader: true,
     storageKeys: ["cookie", "hf-chat"],
   },
+  "yuanbao-web": {
+    kind: "cookie",
+    credentialName: "full Cookie header (hy_user + hy_token)",
+    placeholder: "hy_user=...; hy_token=... (full Cookie header from yuanbao.tencent.com)",
+    acceptsFullCookieHeader: true,
+    storageKeys: ["cookie", "hy_user", "hy_token"],
+  },
   "poe-web": {
     kind: "cookie",
     credentialName: "p-b",

--- a/tests/snapshots/provider/translate-path.json
+++ b/tests/snapshots/provider/translate-path.json
@@ -4402,6 +4402,29 @@
       "stream": "https://api.lingyiwanwu.com/v1/chat/completions"
     }
   },
+  "yuanbao-web": {
+    "format": "openai",
+    "headers": {
+      "apiKey": {
+        "Accept": "text/event-stream",
+        "Authorization": "Bearer <TOK>",
+        "Content-Type": "application/json"
+      },
+      "nonStream": {
+        "Authorization": "Bearer <TOK>",
+        "Content-Type": "application/json"
+      },
+      "oauth": {
+        "Accept": "text/event-stream",
+        "Authorization": "Bearer <TOK>",
+        "Content-Type": "application/json"
+      }
+    },
+    "url": {
+      "nonStream": "https://yuanbao.tencent.com/api/chat",
+      "stream": "https://yuanbao.tencent.com/api/chat"
+    }
+  },
   "zai": {
     "format": "claude",
     "headers": {

--- a/tests/unit/providers-yuanbao-web.test.ts
+++ b/tests/unit/providers-yuanbao-web.test.ts
@@ -1,0 +1,201 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { ExecuteInput } from "../../open-sse/executors/base.ts";
+
+const { REGISTRY } = await import("../../open-sse/config/providerRegistry.ts");
+const providers = await import("../../src/shared/constants/providers.ts");
+const { getExecutor, hasSpecializedExecutor } = await import("../../open-sse/executors/index.ts");
+const { YuanbaoWebExecutor } = await import("../../open-sse/executors/yuanbao-web.ts");
+
+type Dict = Record<string, unknown>;
+const registry = REGISTRY as unknown as Record<string, Dict>;
+const catalog = providers.WEB_COOKIE_PROVIDERS as unknown as Record<string, Dict>;
+const creds = (apiKey: string) => ({ apiKey }) as unknown as ExecuteInput["credentials"];
+
+// ── Registry wiring ───────────────────────────────────────────────────────────
+
+test("yuanbao-web is registered as a cookie-auth provider in the registry", () => {
+  const entry = registry["yuanbao-web"];
+  assert.ok(entry, "yuanbao-web missing from REGISTRY");
+  assert.equal(entry.id, "yuanbao-web");
+  assert.equal(entry.alias, "ybw");
+  assert.equal(entry.executor, "yuanbao-web");
+  assert.equal(entry.format, "openai");
+  assert.equal(entry.authHeader, "cookie");
+  assert.equal(entry.baseUrl, "https://yuanbao.tencent.com/api/chat");
+  const models = entry.models as Array<{ id: string }>;
+  assert.ok(Array.isArray(models) && models.length > 0);
+  const ids = models.map((m) => m.id);
+  assert.ok(ids.includes("deepseek-v3"));
+  assert.ok(ids.includes("hunyuan-t1"));
+});
+
+test("yuanbao-web appears in the web-cookie catalog with a cookie authHint", () => {
+  const entry = catalog["yuanbao-web"];
+  assert.ok(entry, "yuanbao-web missing from WEB_COOKIE_PROVIDERS");
+  assert.equal(entry.id, "yuanbao-web");
+  assert.equal(entry.riskNoticeVariant, "webCookie");
+  assert.match(String(entry.authHint), /hy_token/);
+  assert.match(String(entry.website), /yuanbao\.tencent\.com/);
+});
+
+test("YuanbaoWebExecutor is wired under id and alias", () => {
+  assert.ok(hasSpecializedExecutor("yuanbao-web"));
+  assert.ok(hasSpecializedExecutor("ybw"));
+  assert.ok(getExecutor("yuanbao-web") instanceof YuanbaoWebExecutor);
+  assert.ok(getExecutor("ybw") instanceof YuanbaoWebExecutor);
+});
+
+// ── Behavioral: SSE → OpenAI translation (mocked upstream) ─────────────────────
+
+function makeSSEBody(lines: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const line of lines) controller.enqueue(encoder.encode(line));
+      controller.close();
+    },
+  });
+}
+
+async function readStreamText(res: Response): Promise<string> {
+  const reader = res.body!.getReader();
+  const decoder = new TextDecoder();
+  let out = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    out += decoder.decode(value, { stream: true });
+  }
+  return out;
+}
+
+test("missing hy_token cookie returns a 401 auth error", async () => {
+  const exec = new YuanbaoWebExecutor();
+  const { response } = await exec.execute({
+    model: "deepseek-v3",
+    body: { messages: [{ role: "user", content: "hi" }] },
+    stream: false,
+    credentials: creds("some_unrelated_cookie=abc"),
+    signal: null,
+  });
+  assert.equal(response.status, 401);
+  const body = (await response.json()) as { error: { message: string } };
+  assert.match(body.error.message, /hy_user|hy_token|session cookie/);
+  // Never leak stack traces.
+  assert.ok(!body.error.message.includes("at /"));
+});
+
+test("streaming request translates think/text events into OpenAI chunks", async () => {
+  const original = globalThis.fetch;
+  const calls: string[] = [];
+  globalThis.fetch = (async (url: string | URL | Request) => {
+    calls.push(String(url));
+    if (String(url).includes("/conversation/create")) {
+      return new Response(JSON.stringify({ id: "conv-123" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    return new Response(
+      makeSSEBody([
+        'data: {"type":"think","content":"reasoning..."}\n',
+        'data: {"type":"text","msg":"Hello"}\n',
+        'data: {"type":"text","msg":" world"}\n',
+        'data: {"stopReason":"stop"}\n',
+      ]),
+      { status: 200, headers: { "Content-Type": "text/event-stream" } }
+    );
+  }) as typeof fetch;
+
+  try {
+    const exec = new YuanbaoWebExecutor();
+    const { response, url } = await exec.execute({
+      model: "deepseek-r1",
+      body: { messages: [{ role: "user", content: "hi" }] },
+      stream: true,
+      credentials: creds("hy_source=web; hy_user=u1; hy_token=t1"),
+      signal: null,
+    });
+    assert.equal(response.status, 200);
+    assert.match(url, /\/api\/chat\/conv-123$/);
+    assert.ok(calls[0].includes("/conversation/create"));
+
+    const text = await readStreamText(response);
+    assert.match(text, /"reasoning_content":"reasoning\.\.\."/);
+    assert.match(text, /"content":"Hello"/);
+    assert.match(text, /"content":" world"/);
+    assert.match(text, /"finish_reason":"stop"/);
+    assert.match(text, /data: \[DONE\]/);
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+test("non-streaming request collects content and reasoning", async () => {
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (url: string | URL | Request) => {
+    if (String(url).includes("/conversation/create")) {
+      return new Response(JSON.stringify({ id: "conv-9" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    return new Response(
+      makeSSEBody([
+        'data: {"type":"think","content":"think-part"}\n',
+        'data: {"type":"text","msg":"Answer"}\n',
+        'data: {"stopReason":"stop"}\n',
+      ]),
+      { status: 200, headers: { "Content-Type": "text/event-stream" } }
+    );
+  }) as typeof fetch;
+
+  try {
+    const exec = new YuanbaoWebExecutor();
+    const { response } = await exec.execute({
+      model: "hunyuan-t1",
+      body: { messages: [{ role: "user", content: "q" }] },
+      stream: false,
+      credentials: creds("hy_source=web; hy_user=u1; hy_token=t1"),
+      signal: null,
+    });
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as {
+      object: string;
+      model: string;
+      choices: Array<{ message: { content: string; reasoning_content?: string } }>;
+    };
+    assert.equal(body.object, "chat.completion");
+    assert.equal(body.choices[0].message.content, "Answer");
+    assert.equal(body.choices[0].message.reasoning_content, "think-part");
+    assert.equal(body.model, "hunyuan-t1");
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+test("upstream 401 on conversation create surfaces an auth error (no stack leak)", async () => {
+  const original = globalThis.fetch;
+  globalThis.fetch = (async () =>
+    new Response(JSON.stringify({ message: "unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    })) as typeof fetch;
+
+  try {
+    const exec = new YuanbaoWebExecutor();
+    const { response } = await exec.execute({
+      model: "deepseek-v3",
+      body: { messages: [{ role: "user", content: "hi" }] },
+      stream: false,
+      credentials: creds("hy_source=web; hy_user=u1; hy_token=t1"),
+      signal: null,
+    });
+    assert.equal(response.status, 401);
+    const body = (await response.json()) as { error: { message: string } };
+    assert.ok(!body.error.message.includes("at /"));
+  } finally {
+    globalThis.fetch = original;
+  }
+});


### PR DESCRIPTION
- **feat(providers):** add **Yuanbao (web)** as a cookie-session provider ([#6196](https://github.com/diegosouzapw/OmniRoute/issues/6196)) — `yuanbao-web` (Tencent Yuanbao, `yuanbao.tencent.com`) with cookie-only auth (`hy_user`/`hy_token` + public agent id), SSE→OpenAI translation incl. `reasoning_content`, exposing DeepSeek V3/R1 + Hunyuan / Hunyuan-T1. Regression guard: `tests/unit/providers-yuanbao-web.test.ts`. `together-web` was **deferred** (no verifiable web-session endpoint — needs a captured request) and `huggingchat-web` **dropped** (the existing `huggingchat` already is a web-cookie provider). (thanks @chirag127)


Closes #6196