### PR TITLE
test(dashboard): realign #6145 onboarding-href guard to #6166 helper refactor

### DIFF
--- a/tests/unit/onboarding-wizard-details-link-6145.test.ts
+++ b/tests/unit/onboarding-wizard-details-link-6145.test.ts
@@ -9,6 +9,13 @@ import { dirname, join } from "node:path";
 // `/dashboard/providers/[id]` route expects), NOT `connection.provider` (the
 // provider slug/type). The old code produced `/dashboard/providers/<provider-slug>`
 // which 404s for openai-compatible / anthropic-compatible providers.
+//
+// #6166 refactored the inline `href={`/dashboard/providers/${connection.id}`}`
+// literal into the tested `buildProviderDetailsHref(connection)` helper (its
+// id-based routing + null-safety is guarded behaviorally in
+// `provider-onboarding-href.test.ts`). This guard now tracks that refactor: the
+// wizard must delegate to the helper and must NOT reintroduce a raw
+// `connection.provider` URL.
 
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(here, "..", "..");
@@ -20,11 +27,11 @@ const wizard = readFileSync(
   "utf8"
 );
 
-test("#6145: provider-details link routes by connection.id (matches the [id] route)", () => {
+test("#6145: provider-details link routes through buildProviderDetailsHref (id-based helper)", () => {
   assert.match(
     wizard,
-    /href=\{`\/dashboard\/providers\/\$\{connection\.id\}`\}/,
-    "the details link must build the URL from connection.id"
+    /buildProviderDetailsHref\(connection\)/,
+    "the details link must be built by the tested buildProviderDetailsHref helper (routes by connection.id)"
   );
 });
 


### PR DESCRIPTION
## Problem

The `#6145` regression guard (`tests/unit/onboarding-wizard-details-link-6145.test.ts`) is a **source-text guard** that asserted the wizard contained the inline literal `href={\`/dashboard/providers/\${connection.id}\`}`.

`#6166` (already merged to `release/v3.8.45`) refactored that inline literal into the tested `buildProviderDetailsHref(connection)` helper. The brittle literal-match guard therefore went **red on the release tip** — and on the Unit Tests fast-path of **every open PR** rebased onto the tip.

## Fix (test-only, surgical)

Realign the `#6145` guard to assert the wizard **delegates to `buildProviderDetailsHref(connection)`** and still does **not** reintroduce a raw `connection.provider` URL. The behavioral contract (route by `connection.id`, percent-encode, null-safety) remains fully guarded by `provider-onboarding-href.test.ts` (added by #6166).

## Validation (Hard Rule #18)

- Before: `✖ #6145: provider-details link routes by connection.id` fails on clean `origin/release/v3.8.45`.
- After: all 6 tests green (2 guard + 4 helper behavioral). Unblocks the fast-path unit job on the open feature-PR queue.