### PR TITLE
ci(build): switch Next.js production build to Turbopack (1.9x faster)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -519,14 +519,21 @@ jobs:
           cache: npm
       - uses: ./.github/actions/npm-ci-retry
       - run: npm run check:node-runtime
-      - name: Cache Next.js build cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
-        with:
-          path: .build/next/cache
-          key: nextjs-${{ runner.os }}-node-${{ env.CI_NODE_VERSION }}-${{ hashFiles('package-lock.json') }}-${{ hashFiles('src/**/*', 'open-sse/**/*', 'db/**/*', 'next.config.mjs', 'tsconfig*.json', 'postcss.config.*', 'tailwind.config.*') }}
-          restore-keys: |
-            nextjs-${{ runner.os }}-node-${{ env.CI_NODE_VERSION }}-${{ hashFiles('package-lock.json') }}-
+      # NOTE: the webpack `.build/next/cache` actions/cache step was removed with the
+      # Turbopack switch below — Turbopack does not read/write the webpack cache dir
+      # (its persistent FS cache is still experimental and intentionally NOT enabled),
+      # so restoring the old ~0.5 GB webpack cache would only waste download time.
+      # Rolling back to webpack = revert this commit (cache step comes back with it).
+      #
+      # Turbopack production build (Next 16, stable): benchmarked 1.9× faster than the
+      # webpack pass (9min0s vs 17min15s on a 32-core box; multi-core Rust vs webpack's
+      # single-threaded compile). Standalone output smoke-validated (server boots,
+      # /api/monitoring/health 200). Downstream jobs (e2e ×9, package-artifact,
+      # electron-package-smoke) consume this artifact, so a green run here validates
+      # the Turbopack artifact end-to-end.
       - run: npm run build
+        env:
+          OMNIROUTE_USE_TURBOPACK: "1"
       - name: Archive Next.js build for downstream jobs
         # Use tar so the archive preserves paths relative to CWD (.build/next/...).
         # upload-artifact path-stripping is ambiguous when exclude patterns are used;


### PR DESCRIPTION
## O que muda

Troca o bundler do job **Build** do CI de webpack para **Turbopack** (estável no Next 16), via `OMNIROUTE_USE_TURBOPACK=1` — a chave já existia em `scripts/build/build-next-isolated.mjs` e o `next.config.mjs` já espelha os `resolveAlias` no bloco `turbopack`. Nenhuma mudança de código de produção; só o env do CI.

Remove no mesmo commit o `actions/cache` do `.build/next/cache` (cache do webpack): o Turbopack não lê/escreve esse dir (o FS cache persistente dele é experimental e ficou **desligado** de propósito), então restaurar ~0,5 GB por run seria download desperdiçado. Rollback = revert deste commit (o cache volta junto).

## Benchmark (mesma árvore, máquina 32-core)

| Bundler | Tempo |
|---|---|
| webpack (atual) | 1035s (17min15s) |
| **Turbopack** | **539s (9min0s)** — **1,92×** |

O ganho vem do compile multi-core em Rust vs o passe single-thread do webpack (nosso gargalo medido).

## Validação já feita

- Standalone montado completo (`assembleStandalone` sincronizou healthcheck, public, playwright-core, sqlite-vec)
- Smoke do artefato: `standalone/server.js` sobe, `/api/monitoring/health` **200**, dashboard **307** (redirect login esperado)
- 428 warnings de build = classe benigna "overly broad file pattern" (análise estática de `fs` dinâmico; coberto em runtime por `outputFileTracingIncludes`)

## O que este PR valida

Os jobs downstream consomem o artifact deste build: **e2e ×9, package-artifact (build:cli + pack), electron-package-smoke**. CI verde aqui = artefato Turbopack validado end-to-end.

## Fora de escopo (propositalmente)

- `nightly-compat.yml` e `npm-publish.yml` continuam no webpack até este PR provar o Turbopack no CI completo
- Turbopack persistent FS cache (`turbopackFileSystemCacheForBuild`, Next 16.3 preview) — reportes de prerender não-determinístico com cache cross-build; ficamos fora até estabilizar