### PR TITLE
ci: unblock test jobs from the Build gate (start at minute 0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -616,7 +616,13 @@ jobs:
     name: Unit Tests (${{ matrix.shard }}/8)
     runs-on: ubuntu-latest
     timeout-minutes: 25
-    needs: build
+    # needs: changes (not build) — this job never downloads the next-build artifact;
+    # gating it on Build only serialized ~20min of wall-clock for nothing. Jobs that
+    # DO consume the artifact (e2e, package-artifact, electron-package-smoke) keep
+    # needs: build. The `if` mirrors Build's own skip condition so docs-only PRs
+    # still skip the suite.
+    needs: changes
+    if: ${{ github.event_name != 'pull_request' || (needs.changes.outputs.code == 'true' && github.event.pull_request.draft == false) }}
     strategy:
       fail-fast: false
       matrix:
@@ -664,7 +670,9 @@ jobs:
     name: Vitest (MCP / autoCombo / UI components)
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: build
+    # needs: changes (not build) — no artifact consumed; see test-unit note.
+    needs: changes
+    if: ${{ github.event_name != 'pull_request' || (needs.changes.outputs.code == 'true' && github.event.pull_request.draft == false) }}
     env:
       JWT_SECRET: ci-test-secret-with-sufficient-length-for-validation
       API_KEY_SECRET: ci-test-api-key-secret-long
@@ -952,7 +960,9 @@ jobs:
     name: Integration Tests (${{ matrix.shard }}/2)
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: build
+    # needs: changes (not build) — no artifact consumed; see test-unit note.
+    needs: changes
+    if: ${{ github.event_name != 'pull_request' || (needs.changes.outputs.code == 'true' && github.event.pull_request.draft == false) }}
     strategy:
       fail-fast: false
       matrix:
@@ -979,7 +989,9 @@ jobs:
   test-security:
     name: Security Tests
     runs-on: ubuntu-latest
-    needs: build
+    # needs: changes (not build) — no artifact consumed; see test-unit note.
+    needs: changes
+    if: ${{ github.event_name != 'pull_request' || (needs.changes.outputs.code == 'true' && github.event.pull_request.draft == false) }}
     env:
       JWT_SECRET: ci-test-secret-with-sufficient-length-for-validation
       API_KEY_SECRET: ci-test-api-key-secret-long


### PR DESCRIPTION
## O que muda

`test-unit ×8`, `test-vitest`, `test-integration ×2` e `test-security` tinham `needs: build` mas **nunca baixam o artifact `next-build`** — a dependência só serializava ~20min de Build na frente de todo run de teste.

Trocados para `needs: changes` com o **mesmo** skip condition do Build (`github.event_name != 'pull_request' || (code == 'true' && !draft)`) — PRs docs-only e drafts continuam pulando a suíte.

Quem consome o artifact de verdade **mantém** `needs: build` intacto: `test-e2e ×9`, `package-artifact`, `electron-package-smoke`.

## Efeito

Cadeia `test-unit → test-coverage → quality-gate → sonarqube` passa a rodar **em paralelo** com o Build:

| | Antes | Depois |
|---|---|---|
| Caminho crítico | build (~20min) **+** testes (~10min) + coverage/gates | **max**(build, testes) + coverage/gates |
| Ganho | — | **~15-20min por run** |

Sem minutos extras de runner — são os mesmos jobs, começando mais cedo. Trade-off assumido: se o Build quebrar, os testes rodam mesmo assim (antes eram poupados); no fluxo de release o Build quase nunca é o que quebra, e a fila/wall-clock é o problema real.

## Validação

- YAML parseado + `needs`/`if` de todos os jobs conferidos programaticamente
- `test-coverage` (needs: test-unit) e `ci-summary` inalterados — herdam o novo timing naturalmente