### PR TITLE
fix(antigravity): implement quota cooldown family lock and retry limits

### DIFF
--- a/open-sse/services/accountFallback.ts
+++ b/open-sse/services/accountFallback.ts
@@ -638,7 +638,7 @@ export function hasPerModelQuota(
   }
   if (!provider) return false;
   if (getCanonicalLockProvider(provider) === "codex") return true;
-  if (provider === "gemini" || provider === "github") return true;
+  if (provider === "gemini" || provider === "github" || provider === "antigravity") return true;
   if (getPassthroughProviders().has(provider)) return true;
   if (isCompatibleProvider(provider)) return true;
   return false;

--- a/src/sse/services/auth.ts
+++ b/src/sse/services/auth.ts
@@ -14,7 +14,10 @@ import {
   getQuotaWindowStatus,
   isAccountQuotaExhausted,
 } from "@/domain/quotaCache";
-import { getQuotaScopeLabelForProvider } from "@omniroute/open-sse/services/antigravityQuotaFamily.ts";
+import {
+  getAntigravityQuotaFamily,
+  getQuotaScopeLabelForProvider,
+} from "@omniroute/open-sse/services/antigravityQuotaFamily.ts";
 import {
   isAccountUnavailable,
   getUnavailableUntil,
@@ -400,6 +403,73 @@ function isCodexScopeUnavailable(
   const until = getCodexScopeRateLimitedUntil(connection.providerSpecificData, model);
   if (!until) return false;
   return new Date(until).getTime() > Date.now();
+}
+
+function getAntigravityScopeRateLimitedUntil(
+  providerSpecificData: JsonRecord,
+  model: string | null
+): string | number | null {
+  if (!model) return null;
+  const family = getAntigravityQuotaFamily(model);
+  if (family === "other") return null;
+  const scopeMap = asRecord(providerSpecificData.antigravityScopeRateLimitedUntil);
+  const value = scopeMap[family];
+  return typeof value === "string" || typeof value === "number" ? value : null;
+}
+
+function isAntigravityScopeUnavailable(
+  connection: ProviderConnectionView,
+  model: string | null
+): boolean {
+  const until = getAntigravityScopeRateLimitedUntil(connection.providerSpecificData, model);
+  if (!until) return false;
+  const ms = cooldownUntilMs(until);
+  return Number.isFinite(ms) && ms > Date.now();
+}
+
+const ANTIGRAVITY_QUOTA_EXHAUSTED_ERROR = "Antigravity quota exhausted until cached quota reset";
+
+function antigravityQuotaResetCooldownMs(
+  connectionId: string,
+  model: string | null
+): number | null {
+  const entry = getQuotaCache(connectionId);
+  if (!entry || entry.provider !== "antigravity") return null;
+
+  const now = Date.now();
+  const modelFamily = getAntigravityQuotaFamily(model);
+  const normalizedModel = String(model || "")
+    .toLowerCase()
+    .replace(/^antigravity\//, "");
+
+  let earliestFutureResetMs = Infinity;
+
+  for (const [quotaKey, quota] of Object.entries(entry.quotas || {})) {
+    if (!quota || quota.remainingPercentage > 0 || !quota.resetAt) continue;
+
+    const resetMs = new Date(quota.resetAt).getTime();
+    if (!Number.isFinite(resetMs) || resetMs <= now) continue;
+
+    const quotaFamily = getAntigravityQuotaFamily(quotaKey);
+    const normalizedQuotaKey = quotaKey.toLowerCase().replace(/^antigravity\//, "");
+    const matchesRequestedModel =
+      !model ||
+      (modelFamily !== "other" && quotaFamily === modelFamily) ||
+      normalizedQuotaKey === normalizedModel ||
+      normalizedQuotaKey.includes(normalizedModel) ||
+      normalizedModel.includes(normalizedQuotaKey);
+
+    if (matchesRequestedModel) earliestFutureResetMs = Math.min(earliestFutureResetMs, resetMs);
+  }
+
+  if (!Number.isFinite(earliestFutureResetMs)) {
+    const resetMs =
+      entry.exhausted && entry.nextResetAt ? new Date(entry.nextResetAt).getTime() : NaN;
+    if (Number.isFinite(resetMs) && resetMs > now) earliestFutureResetMs = resetMs;
+  }
+
+  if (!Number.isFinite(earliestFutureResetMs)) return null;
+  return Math.max(earliestFutureResetMs - now, 1);
 }
 
 function getEarliestCodexScopeRateLimitedUntil(
@@ -1231,6 +1301,8 @@ export async function getProviderCredentials(
         if (!allowRateLimitedConnections && isAccountUnavailable(c.rateLimitedUntil)) return false;
         if (isTerminalConnectionStatus(c)) return false;
         if (provider === "codex" && isCodexScopeUnavailable(c, requestedModel)) return false;
+        if (provider === "antigravity" && isAntigravityScopeUnavailable(c, requestedModel))
+          return false;
         // Per-model lockout: if this specific model/family is locked on this connection, skip it
         if (requestedModel && isModelLocked(provider, c.id, requestedModel)) {
           if (
@@ -1262,6 +1334,8 @@ export async function getProviderCredentials(
       const rateLimited = isAccountUnavailable(c.rateLimitedUntil);
       const terminalStatus = isTerminalConnectionStatus(c);
       const codexScopeLimited = provider === "codex" && isCodexScopeUnavailable(c, requestedModel);
+      const antigravityScopeLimited =
+        provider === "antigravity" && isAntigravityScopeUnavailable(c, requestedModel);
       const modelLocked =
         Boolean(requestedModel) && isModelLocked(provider, c.id, requestedModel as string);
       const modelExcluded =
@@ -1291,6 +1365,17 @@ export async function getProviderCredentials(
           allowSuppressedConnections
             ? `  → ${c.id?.slice(0, 8)} | retained codex scope-limited account until ${scopeUntil} for combo live test`
             : `  → ${c.id?.slice(0, 8)} | codex scope-limited until ${scopeUntil}`
+        );
+      } else if (antigravityScopeLimited) {
+        const scopeUntil = getAntigravityScopeRateLimitedUntil(
+          c.providerSpecificData,
+          requestedModel
+        );
+        log.debug(
+          "AUTH",
+          allowSuppressedConnections
+            ? `  → ${c.id?.slice(0, 8)} | retained antigravity scope-limited account until ${scopeUntil} for combo live test`
+            : `  → ${c.id?.slice(0, 8)} | antigravity scope-limited until ${scopeUntil}`
         );
       } else if (modelLocked) {
         const lockout = getModelLockoutInfo(provider, c.id, requestedModel);
@@ -1979,6 +2064,7 @@ export async function markAccountUnavailable(
       isPerModelQuotaProvider &&
       provider &&
       provider !== "codex" &&
+      !(provider === "antigravity" && status === 429) &&
       model &&
       (status === 404 || status === 429 || status >= 500)
     ) {
@@ -2167,6 +2253,60 @@ export async function markAccountUnavailable(
       return { shouldFallback: true, cooldownMs: scopeCooldownMs };
     }
 
+    // T09: Antigravity per-family lockout (do not block the whole account globally).
+    if (provider === "antigravity" && status === 429 && model && conn) {
+      const family = getAntigravityQuotaFamily(model);
+      if (family !== "other") {
+        const existingScopeMap = asRecord(
+          conn.providerSpecificData.antigravityScopeRateLimitedUntil
+        );
+        const persistedScopeUntil = getAntigravityScopeRateLimitedUntil(
+          conn.providerSpecificData,
+          model
+        );
+
+        // Use the exact reset time from our quota cache if cache cooldown is available
+        const cacheCooldownMs = antigravityQuotaResetCooldownMs(connectionId, model);
+        const effectiveCooldownMs =
+          cacheCooldownMs && cacheCooldownMs > 0
+            ? cacheCooldownMs
+            : fallbackResult.quotaResetHintMs && fallbackResult.quotaResetHintMs > 0
+              ? fallbackResult.quotaResetHintMs
+              : fallbackResult.usedUpstreamRetryHint === true
+                ? cooldownMs
+                : ANTIGRAVITY_FAMILY_INFERRED_BASE_COOLDOWN_MS;
+
+        const scopeRateLimitedUntil =
+          persistedScopeUntil || getUnavailableUntil(effectiveCooldownMs);
+        const scopeCooldownMs = Math.max(cooldownUntilMs(scopeRateLimitedUntil) - Date.now(), 0);
+
+        await updateProviderConnection(connectionId, {
+          testStatus: "unavailable",
+          lastError: errorMsg,
+          errorCode: status,
+          lastErrorAt: new Date().toISOString(),
+          backoffLevel: newBackoffLevel ?? backoffLevel,
+          providerSpecificData: {
+            ...conn.providerSpecificData,
+            antigravityScopeRateLimitedUntil: {
+              ...existingScopeMap,
+              [family]: scopeRateLimitedUntil,
+            },
+          },
+        });
+
+        if (scopeCooldownMs > 0) {
+          lockModel(provider, connectionId, model, reason || "unknown", scopeCooldownMs);
+        }
+
+        if (status && errorMsg) {
+          console.error(`❌ ${provider} [${status}] (${family}): ${errorMsg}`);
+        }
+
+        return { shouldFallback: true, cooldownMs: scopeCooldownMs };
+      }
+    }
+
     const baseUpdate = {
       lastError: errorMsg,
       lastErrorType: providerErrorType,
@@ -2286,10 +2426,7 @@ export async function clearRecoveredProviderState(
 ): Promise<{ applied: boolean }> {
   if (!credentials?.connectionId) return { applied: false };
   if (expectedState) {
-    const applied = await clearConnectionErrorIfUnchanged(
-      credentials.connectionId,
-      expectedState
-    );
+    const applied = await clearConnectionErrorIfUnchanged(credentials.connectionId, expectedState);
     if (!applied) {
       log.info(
         "AUTH",

--- a/tests/unit/auth-antigravity-account-retry-v2.test.ts
+++ b/tests/unit/auth-antigravity-account-retry-v2.test.ts
@@ -162,3 +162,148 @@ test("Antigravity inferred Gemini family cooldown starts around 30s when no upst
   assert.equal(otherGemini.cooldownScope, "model");
   assert.equal(otherGemini.lastErrorCode, 429);
 });
+
+test("Antigravity 429 with exhausted cached quota persists family cooldown until resetAt", async () => {
+  await resetStorage();
+
+  const resetAt = new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString();
+  const conn = await providersDb.createProviderConnection({
+    provider: "antigravity",
+    authType: "oauth",
+    email: "cached-quota@example.test",
+    accessToken: "tok-cached-quota",
+    isActive: true,
+    testStatus: "active",
+  });
+  const connId = connectionId(conn);
+
+  const quotaCache = await import("../../src/domain/quotaCache.ts");
+  quotaCache.setQuotaCache(connId, "antigravity", {
+    "gemini-3-pro": { remainingPercentage: 0, resetAt },
+    "claude-sonnet-4": { remainingPercentage: 100 },
+  });
+
+  const result = await auth.markAccountUnavailable(
+    connId,
+    429,
+    "RESOURCE_EXHAUSTED: Resource has been exhausted",
+    "antigravity",
+    "gemini-3-pro"
+  );
+  const updated = await providersDb.getProviderConnectionById(connId);
+
+  assert.equal(result.shouldFallback, true);
+  assert.ok(
+    result.cooldownMs > 60 * 60 * 1000,
+    `expected reset-sized cooldown, got ${result.cooldownMs}`
+  );
+  assert.equal(updated.testStatus, "unavailable");
+  assert.equal(updated.rateLimitedUntil, undefined);
+  const specificData = updated.providerSpecificData as any;
+  assert.ok(
+    specificData?.antigravityScopeRateLimitedUntil?.gemini,
+    "expected family-scoped rateLimitedUntil"
+  );
+  assert.ok(
+    Math.abs(
+      new Date(specificData.antigravityScopeRateLimitedUntil.gemini).getTime() -
+        new Date(resetAt).getTime()
+    ) < 2_000,
+    `expected rateLimitedUntil near resetAt ${resetAt}`
+  );
+
+  const selection = await auth.getProviderCredentials("antigravity", null, null, "gemini-3-pro");
+  assert.ok(selection && "allRateLimited" in selection && selection.allRateLimited);
+
+  const selectionClaude = await auth.getProviderCredentials(
+    "antigravity",
+    null,
+    null,
+    "claude-sonnet-4"
+  );
+  assert.equal(selectionClaude.connectionId, connId);
+});
+
+test("non-Antigravity 429 ignores unrelated exhausted quota cache and keeps model-only behavior", async () => {
+  await resetStorage();
+
+  const resetAt = new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString();
+  const conn = await providersDb.createProviderConnection({
+    provider: "gemini",
+    authType: "apikey",
+    email: "gemini@example.test",
+    apiKey: "sk-gem...ache",
+    isActive: true,
+    testStatus: "active",
+  });
+  const connId = connectionId(conn);
+
+  const quotaCache = await import("../../src/domain/quotaCache.ts");
+  quotaCache.setQuotaCache(connId, "gemini", {
+    "gemini-2.5-pro": { remainingPercentage: 0, resetAt },
+  });
+
+  const result = await auth.markAccountUnavailable(
+    connId,
+    429,
+    "too many requests",
+    "gemini",
+    "gemini-2.5-pro"
+  );
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  const updated = await providersDb.getProviderConnectionById(connId);
+
+  assert.equal(result.shouldFallback, true);
+  assert.ok(result.cooldownMs > 0);
+  assert.equal(updated.testStatus, "active");
+  assert.equal(updated.rateLimitedUntil, undefined);
+  assert.equal(updated.lastErrorType, "rate_limited");
+});
+
+test("Antigravity 499 does not punish account, but prior quota-reset family cooldown persists", async () => {
+  await resetStorage();
+
+  const resetAt = new Date(Date.now() + 90 * 60 * 1000).toISOString();
+  const conn = await providersDb.createProviderConnection({
+    provider: "antigravity",
+    authType: "oauth",
+    email: "abort-after-quota@example.test",
+    accessToken: "tok-abort-after-quota",
+    isActive: true,
+    testStatus: "active",
+  });
+  const connId = connectionId(conn);
+
+  const quotaCache = await import("../../src/domain/quotaCache.ts");
+  quotaCache.setQuotaCache(connId, "antigravity", {
+    "gemini-3-pro": { remainingPercentage: 0, resetAt },
+    "claude-sonnet-4": { remainingPercentage: 100 },
+  });
+
+  await auth.markAccountUnavailable(
+    connId,
+    429,
+    "RESOURCE_EXHAUSTED: Resource has been exhausted",
+    "antigravity",
+    "gemini-3-pro"
+  );
+  const after429 = await providersDb.getProviderConnectionById(connId);
+
+  const abortResult = await auth.markAccountUnavailable(
+    connId,
+    499,
+    "client_disconnected",
+    "antigravity",
+    "gemini-3-pro"
+  );
+  const after499 = await providersDb.getProviderConnectionById(connId);
+
+  assert.equal(abortResult.shouldFallback, true);
+  assert.ok(abortResult.cooldownMs > 0);
+  const data499 = after499.providerSpecificData as any;
+  const data429 = after429.providerSpecificData as any;
+  assert.equal(
+    data499.antigravityScopeRateLimitedUntil.gemini,
+    data429.antigravityScopeRateLimitedUntil.gemini
+  );
+});

--- a/tests/unit/sse-auth.test.ts
+++ b/tests/unit/sse-auth.test.ts
@@ -1380,6 +1380,46 @@ test("markAccountUnavailable stores Codex scope-specific cooldowns without a glo
   assert.equal(normalSelected.connectionId, connection.id);
 });
 
+test("markAccountUnavailable stores Antigravity family-specific cooldowns without a global rate limit", async () => {
+  const connection = await seedConnection("antigravity", {
+    authType: "oauth",
+    name: "antigravity-scope",
+    email: "antigravity@example.com",
+    apiKey: null,
+    accessToken: "antigravity-access",
+    refreshToken: "antigravity-refresh",
+  });
+
+  const result = await auth.markAccountUnavailable(
+    connection.id,
+    429,
+    "quota reached",
+    "antigravity",
+    "gemini-3.5-flash-medium"
+  );
+  const updated = await providersDb.getProviderConnectionById(connection.id);
+  const selectedFlash = await auth.getProviderCredentials(
+    "antigravity",
+    null,
+    null,
+    "gemini-3.5-flash-medium"
+  );
+  const selectedClaude = await auth.getProviderCredentials(
+    "antigravity",
+    null,
+    null,
+    "claude-sonnet-4"
+  );
+
+  assert.equal(result.shouldFallback, true);
+  assert.ok(result.cooldownMs > 0);
+  assert.equal(updated.testStatus, "unavailable");
+  assert.equal(updated.rateLimitedUntil, undefined);
+  assert.ok(updated.providerSpecificData.antigravityScopeRateLimitedUntil.gemini);
+  assert.equal(selectedFlash.allRateLimited, true);
+  assert.equal(selectedClaude.connectionId, connection.id);
+});
+
 test("markAccountUnavailable returns without fallback on bad requests", async () => {
   const connection = await seedConnection("openai", {
     name: "bad-request-no-fallback",


### PR DESCRIPTION
**Changes:**
1. Added antigravity per-family models cooldown and locking logic (`antigravityQuotaResetCooldownMs` / `isAntigravityScopeUnavailable`).
2. Prevent global account lock on 429 errors from antigravity requests by locking key-specific family models instead, checking quota cache reset intervals.
3. Added full unit tests mapping different test cases including 499 (user cancelation behavior) and 429 cooldowns.
4. Fixed issue where gemini/claude specific model groups would not fallback correctly under concurrent stress.