### PR TITLE
fix(dashboard): null-guard EditConnectionModal base-URL override — fixes provider-detail crash (#6147)

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/[id]/components/modals/EditConnectionModal.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/modals/EditConnectionModal.tsx
@@ -159,10 +159,10 @@ export default function EditConnectionModal({
   // providerSpecificData.baseUrl.
   const isConfigurableBaseUrl = isBaseUrlConfigurableProvider(provider);
   const isBaseUrlOverrideEligible =
-    connection.authType !== "oauth" && isBaseUrlOverrideEligibleProvider(provider);
+    connection?.authType !== "oauth" && isBaseUrlOverrideEligibleProvider(provider);
   const [showBaseUrlOverride, setShowBaseUrlOverride] = useState(
     () =>
-      typeof connection.providerSpecificData?.baseUrl === "string" &&
+      typeof connection?.providerSpecificData?.baseUrl === "string" &&
       connection.providerSpecificData.baseUrl.trim().length > 0
   );
   const usesBaseUrl =


### PR DESCRIPTION
## Bug (production, found on VPS homologation)

Entering **any** provider-detail page (`/dashboard/providers/[id]`) showed **"Failed to load providers"**. Console:
```
TypeError: Cannot read properties of null (reading 'authType')
  at .../providers/[id]/page-….js
```

## Root cause

The #6147 base-URL-override wiring (PR #6253) added, in `EditConnectionModal.tsx`:
```ts
connection.authType !== "oauth"                    // ← .authType on null
connection.providerSpecificData?.baseUrl            // ← connection. also unguarded
```
But `EditConnectionModal` is **mounted standalone with `connection=null`** (hidden until opened — there's a #3501 regression test for exactly this: `connModals.test.tsx` → "mounts standalone when connection=null"). The const/useState body runs on every render regardless of `isOpen`, so the null connection threw on entry; the page error boundary rendered "Failed to load providers".

## Fix

Optional-chain both reads: `connection?.authType` / `connection?.providerSpecificData?.baseUrl` (the third access is short-circuit-protected).

## Validation (Hard Rule #18 — TDD)

- Before: `connModals.test.tsx` "mounts standalone when connection=null" **FAILS** with the exact production error (reproduced).
- After: **9/9 green**; `routing-settings-ux-6147.test.ts` still 6/6 (feature intact); typecheck clean.
- Also live-reproduced + will re-verify on the VPS after redeploy.