### PR TITLE
fix: default app log path resolves under process.cwd() instead of DATA_DIR

### DIFF
--- a/src/lib/logEnv.ts
+++ b/src/lib/logEnv.ts
@@ -1,6 +1,9 @@
 import path from "path";
 
-const DEFAULT_APP_LOG_RETENTION_DAYS = 7;
+// DATA_DIR is the project root for local installs or ~/.omniroute/ for global CLI.
+// Fall back to cwd so existing setups don't break silently.
+const appRoot = process.env.DATA_DIR || process.cwd();
+const DEFAULT_APP_LOG_PATH = path.join(appRoot, "logs", "application", "app.log");
 const DEFAULT_CALL_LOG_RETENTION_DAYS = 7;
 const DEFAULT_APP_LOG_MAX_SIZE = 50 * 1024 * 1024;
 const DEFAULT_APP_LOG_MAX_FILES = 20;
@@ -8,7 +11,7 @@ const DEFAULT_CALL_LOG_MAX_ENTRIES = 10000;
 const DEFAULT_CALL_LOGS_TABLE_MAX_ROWS = 100000;
 const DEFAULT_CALL_LOG_PIPELINE_MAX_SIZE_KB = 512;
 const DEFAULT_PROXY_LOGS_TABLE_MAX_ROWS = 100000;
-const DEFAULT_APP_LOG_PATH = path.join(process.cwd(), "logs", "application", "app.log");
+
 
 function parsePositiveInt(value: string | undefined, fallback: number): number {
   if (!value) return fallback;


### PR DESCRIPTION
**Fixes #6197**

The default application log path resolved relative to `process.cwd()`, but `.env.example` documents it as relative to `DATA_DIR` / project root. For the globally-installed CLI these are different directories, and because file logging is best-effort (it swallows write errors), the result was no log file and no error.

**Change:**
- Use `process.env.DATA_DIR || process.cwd()` as the base directory so the default path honors DATA_DIR when set, falling back to cwd for local dev.
- `src/lib/logEnv.ts:11` ? `path.join(DATA_DIR || cwd, "logs", "application", "app.log")`