### PR TITLE
fix(ui): prevent silent overwrite of existing API key connections on …

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/[id]/ProviderDetailPageClient.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/ProviderDetailPageClient.tsx
@@ -709,6 +709,7 @@ export default function ProviderDetailPageClient() {
         isCommandCode={isCommandCode}
         isUpstreamProxyProvider={isUpstreamProxyProvider}
         subscriptionRisk={subscriptionRisk}
+        existingConnectionCount={connections.length}
         showRiskNoticeModal={showRiskNoticeModal}
         handleConfirmRiskNotice={handleConfirmRiskNotice}
         handleCancelRiskNotice={handleCancelRiskNotice}

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/ProviderModalsPanel.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/ProviderModalsPanel.tsx
@@ -49,6 +49,7 @@ interface ProviderModalsPanelProps {
   isCommandCode: boolean;
   isUpstreamProxyProvider: boolean;
   subscriptionRisk: boolean;
+  existingConnectionCount?: number;
   // Risk notice
   showRiskNoticeModal: boolean;
   handleConfirmRiskNotice: () => void;
@@ -145,6 +146,7 @@ export default function ProviderModalsPanel({
   isCcCompatible,
   isUpstreamProxyProvider,
   subscriptionRisk,
+  existingConnectionCount,
   showRiskNoticeModal,
   handleConfirmRiskNotice,
   handleCancelRiskNotice,
@@ -278,6 +280,7 @@ export default function ProviderModalsPanel({
           provider={providerId}
           providerName={providerInfo.name}
           initialBaseUrl={siliconFlowInitialBaseUrl}
+          existingConnectionCount={existingConnectionCount}
           isCompatible={isCompatible}
           isAnthropic={isAnthropicProtocolCompatible}
           isCcCompatible={isCcCompatible}

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/modals/AddApiKeyModal.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/modals/AddApiKeyModal.tsx
@@ -35,6 +35,7 @@ export interface AddApiKeyModalProps {
   provider?: string;
   providerName?: string;
   initialBaseUrl?: string;
+  existingConnectionCount?: number;
   isCompatible?: boolean;
   isAnthropic?: boolean;
   isCcCompatible?: boolean;
@@ -57,6 +58,7 @@ export default function AddApiKeyModal({
   provider,
   providerName,
   initialBaseUrl,
+  existingConnectionCount = 0,
   isCompatible,
   isAnthropic,
   isCcCompatible,
@@ -88,6 +90,15 @@ export default function AddApiKeyModal({
   const providerDisplayName = providerName || provider || "";
   const apiKeyOptional =
     providerAllowsOptionalApiKey(provider) || Boolean(isNoAuthWebSessionCredential);
+  // Compute a unique default name based on existing connections to prevent
+  // the backend name-based upsert from overwriting an existing connection.
+  // First connection defaults to "main" (backward compatible); subsequent ones
+  // get a numeric suffix ("main-2", "main-3", …).
+  const computeDefaultName = (): string => {
+    const count = existingConnectionCount ?? 0;
+    return count === 0 ? "main" : `main-${count + 1}`;
+  };
+
   const commandCodeAuthPhaseLabel = commandCodeAuthState
     ? {
         idle: "Ready",
@@ -100,8 +111,9 @@ export default function AddApiKeyModal({
         error: "Connection failed",
       }[commandCodeAuthState.phase]
     : null;
+  const defaultName = computeDefaultName();
   const [formData, setFormData] = useState({
-    name: "main", // #5421: required field; default resists autofill garbage (was "" → "wiw")
+    name: defaultName,
     apiKey: "",
     tokenSecret: "", // #5446 — Modal Token Secret (joined with apiKey as id:secret)
     defaultModel: "",
@@ -134,11 +146,33 @@ export default function AddApiKeyModal({
     const wasOpen = wasOpenRef.current;
     wasOpenRef.current = isOpen;
     if (!isOpen || wasOpen) return;
-    setFormData((current) => ({
-      ...current,
+    // Reset form to defaults on open — including a unique name so a second
+    // API key for the same provider doesn't trigger the backend name-based
+    // upsert and silently overwrite the first connection.
+    setFormData({
+      name: computeDefaultName(),
+      apiKey: "",
+      tokenSecret: "",
+      defaultModel: "",
+      priority: 1,
       baseUrl: initialBaseUrl || defaultBaseUrl,
-    }));
-  }, [defaultBaseUrl, initialBaseUrl, isOpen]);
+      cx: "",
+      region: showsRegion ? defaultRegion : "",
+      apiRegion: "international",
+      validationModelId: defaultValidationModelIdForProvider(provider),
+      routingTags: "",
+      excludedModels: "",
+      customUserAgent: "",
+      accountId: "",
+      consoleApiKey: "",
+      ...EMPTY_QUOTA_SCRAPING_FIELDS,
+      ccCompatibleContext1m: false,
+      ccCompatibleRedactThinking: false,
+      ccCompatibleSummarizeThinking: false,
+      passthroughModels: false,
+      importFreeModelsOnly: false,
+    });
+  }, [defaultBaseUrl, initialBaseUrl, isOpen, showsRegion, defaultRegion, provider]);
   const bulkSupported = supportsBulkApiKey(provider);
   const [mode, setMode] = useState<"single" | "bulk">("single");
   const [bulkText, setBulkText] = useState("");


### PR DESCRIPTION
When adding a second API key for the same provider, the backend uses a name-based upsert. Since all new connections defaulted to the name "main", the second key would silently overwrite the first one with no warning to the user.

Changes:
- Add existingConnectionCount prop threaded from ProviderDetailPageClient through ProviderModalsPanel into AddApiKeyModal
- Compute a unique default connection name based on existing count to prevent name collision: first connection defaults to "main" (backward compatible), subsequent ones get a numeric suffix ("main-2", "main-3", ...)
- Properly reset entire form state on modal open (not just baseUrl) to avoid stale field values leaking across opens

Fixes silent data loss when managing multiple API keys for the same provider.

## Summary

- Describe the user-facing or operational change.

## Related Issues

- Closes #
- Related to #

## Validation

- [x] `npm run lint`
- [x] `npm run test:unit`
- [x] `npm run test:coverage`
- [x] Coverage is still `>= 60%` for statements, lines, functions, and branches
- [x] SonarQube PR analysis is green or any remaining issues are explicitly documented below

## Tests Added Or Updated

- List every changed or added automated test file.
- If no production code changed, state that here.

## Coverage Notes

- If this PR changes `src/`, `open-sse/`, `electron/`, or `bin/`, explain which tests cover the change.
- If coverage moved down in any touched file, explain why and what follow-up task will recover it.

## Reviewer Notes

- Call out any risky areas, migrations, feature flags, or manual validation that reviewers should know about.