### PR TITLE
fix(api): return JSON 404 for unknown /api/* paths (#6424)

### DIFF
--- a/src/app/api/[...omnirouteApiCatchAll]/route.ts
+++ b/src/app/api/[...omnirouteApiCatchAll]/route.ts
@@ -1,0 +1,56 @@
+import { CORS_HEADERS } from "@/shared/utils/cors";
+
+/**
+ * Catch-all fallback for /api/* — issue #6424.
+ *
+ * Extends the /v1/* catch-all (#6405) to the whole /api/ tree. Without this
+ * route, unknown paths under /api/context/*, /api/settings/*, /api/admin/*
+ * (etc.) fell through to the Next.js app-router `not-found.tsx`, which
+ * returned the dashboard HTML shell (~463 KB) to CLI/SDK callers instead of a
+ * JSON 404. Combined with the management-auth boundary, this made an
+ * "unknown route" indistinguishable from a "wrong scope" failure.
+ *
+ * Static / dynamic segments under /api/ take precedence over this catch-all
+ * in Next.js App Router matching, so real routes are unaffected.
+ */
+
+function notFoundResponse(request: Request): Response {
+  const url = new URL(request.url);
+  return Response.json(
+    {
+      error: {
+        message: `Unknown API route: ${url.pathname}`,
+        type: "not_found",
+        code: "unknown_route",
+        path: url.pathname,
+      },
+    },
+    {
+      status: 404,
+      headers: { "Content-Type": "application/json", ...CORS_HEADERS },
+    },
+  );
+}
+
+export async function OPTIONS() {
+  return new Response(null, { headers: CORS_HEADERS });
+}
+
+export async function GET(request: Request) {
+  return notFoundResponse(request);
+}
+export async function POST(request: Request) {
+  return notFoundResponse(request);
+}
+export async function PUT(request: Request) {
+  return notFoundResponse(request);
+}
+export async function PATCH(request: Request) {
+  return notFoundResponse(request);
+}
+export async function DELETE(request: Request) {
+  return notFoundResponse(request);
+}
+export async function HEAD(request: Request) {
+  return notFoundResponse(request);
+}

--- a/tests/unit/api/api-catchall-json-404.test.ts
+++ b/tests/unit/api/api-catchall-json-404.test.ts
@@ -1,0 +1,55 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+/**
+ * Regression: issue #6424 — unknown paths under /api/* (outside /api/v1/*)
+ * returned the Next.js dashboard HTML 404 shell instead of JSON. This made
+ * management-auth failures indistinguishable from missing routes, and forced
+ * CLI/SDK callers to parse ~463 KB of HTML.
+ *
+ * Complements the /v1/* catch-all from #6405; asserts the app-router catch-all
+ * under `src/app/api/[...omnirouteApiCatchAll]/route.ts` returns JSON for
+ * every HTTP method.
+ */
+
+const catchAll = await import(
+  "../../../src/app/api/[...omnirouteApiCatchAll]/route.ts"
+);
+
+function makeReq(pathname: string, method = "GET"): Request {
+  return new Request(`http://localhost:20128${pathname}`, { method });
+}
+
+test("/api catchall returns application/json 404 with not_found type on GET", async () => {
+  const res = await catchAll.GET(makeReq("/api/context/rtk/does-not-exist"));
+  assert.equal(res.status, 404);
+  const ct = res.headers.get("content-type") || "";
+  assert.ok(ct.includes("application/json"), `expected JSON content-type, got: ${ct}`);
+  const body = (await res.json()) as {
+    error: { type: string; message: string; code?: string; path?: string };
+  };
+  assert.equal(body.error.type, "not_found");
+  assert.equal(body.error.path, "/api/context/rtk/does-not-exist");
+  assert.match(body.error.message, /Unknown API route/);
+});
+
+test("/api catchall returns JSON 404 on POST / PUT / PATCH / DELETE / HEAD", async () => {
+  for (const method of ["POST", "PUT", "PATCH", "DELETE", "HEAD"] as const) {
+    const res = await (catchAll as Record<string, (r: Request) => Promise<Response>>)[
+      method
+    ](makeReq(`/api/settings/nope/${method.toLowerCase()}`, method));
+    assert.equal(res.status, 404, `${method} status`);
+    assert.ok(
+      (res.headers.get("content-type") || "").includes("application/json"),
+      `${method} content-type`,
+    );
+  }
+});
+
+test("/api catchall OPTIONS preflight returns CORS headers", async () => {
+  const res = await catchAll.OPTIONS();
+  assert.ok(
+    res.headers.get("access-control-allow-methods"),
+    "OPTIONS must expose CORS methods header",
+  );
+});


### PR DESCRIPTION
## Problem

Routes gated by `requireManagementAuth` return HTML 404 (Next.js dashboard shell, ~463 KB) for API-key bearer tokens instead of JSON 401/403. Reporter's affected paths: `/api/context/rtk/filters`, `/api/context/rtk/config`, `/api/context/rtk/test` (issue #6424).

Root cause: same class as #6405 — any unmatched path under `/api/*` falls through to `src/app/not-found.tsx` (dashboard HTML). #6405 fixed this for `/v1/*` only; the rest of `/api/*` was still HTML.

## Fix

Add `src/app/api/[...omnirouteApiCatchAll]/route.ts`, mirroring the `/v1/*` catch-all pattern. Static/dynamic segments under `/api/` still take precedence — real routes unaffected. Combined with the existing `requireManagementAuth` JSON responses, failure surface is now deterministic:

- unknown route      → 404 JSON `{ type: 'not_found' }`
- missing token      → 401 JSON `{ type: 'invalid_request' }`
- valid key, no scope → 403 JSON `{ type: 'invalid_request' }`

## Test

`tests/unit/api/api-catchall-json-404.test.ts` — 3 cases (GET, all methods, OPTIONS CORS). Mirrors the existing `v1-catchall-json-404.test.ts`. All pass.

## Env

OmniRoute 3.8.45, Node 24, Windows 11 x64.

Refs: #6405.

Thanks for the great work on OmniRoute!