### PR TITLE
fix(backend): accept mode:"caveman" as alias for "standard" in compression API (#6425)

### DIFF
--- a/open-sse/mcp-server/schemas/tools.ts
+++ b/open-sse/mcp-server/schemas/tools.ts
@@ -1093,11 +1093,11 @@ export const compressionStatusTool: McpToolDefinition<
 export const compressionConfigureInput = z.object({
   enabled: z.boolean().optional(),
   strategy: z
-    .enum(["off", "lite", "standard", "aggressive", "ultra", "rtk", "stacked"])
+    .enum(["off", "lite", "standard", "aggressive", "ultra", "rtk", "stacked", "caveman"])
     .optional()
     .describe("Compression mode"),
   autoTriggerMode: z
-    .enum(["off", "lite", "standard", "aggressive", "ultra", "rtk", "stacked"])
+    .enum(["off", "lite", "standard", "aggressive", "ultra", "rtk", "stacked", "caveman"])
     .optional(),
   maxTokens: z
     .number()

--- a/src/app/api/compression/preview/route.ts
+++ b/src/app/api/compression/preview/route.ts
@@ -32,7 +32,7 @@ export const PreviewRequestSchema = z.object({
     )
     .min(1),
   mode: z
-    .enum(["off", "lite", "standard", "aggressive", "ultra", "rtk", "stacked"])
+    .enum(["off", "lite", "standard", "aggressive", "ultra", "rtk", "stacked", "caveman"])
     .optional()
     .default("stacked"),
   engineId: z.string().optional(),
@@ -185,8 +185,11 @@ export async function POST(req: Request) {
 
   const { messages, mode, engineId, pipeline, config, fidelityGate, fuzzyDedup, riskGate, quantumLock, heatmap: heatmapMode } =
     parsed.data;
+  // "caveman" is a public alias for the internal "standard" mode (standard runs cavemanCompress
+  // per strategySelector.ts). Normalize before dispatch so both names hit the same engine.
+  const normalizedMode = mode === "caveman" ? "standard" : mode;
   const effectiveMode: CompressionMode =
-    engineId || pipeline ? "stacked" : (mode as CompressionMode);
+    engineId || pipeline ? "stacked" : (normalizedMode as CompressionMode);
   const originalText = messagesToText(messages);
   const originalTokens = countTokens(originalText);
 


### PR DESCRIPTION
## Problem

`POST /api/compression/preview` with `{"mode":"caveman"}` returns HTTP 400 `Invalid request` even though "Caveman" is a first-class compression engine advertised in the README + `docs/compression/COMPRESSION_ENGINES.md` and enumerated in the internal `CompressionEngineId` union.

The mismatch is at the API boundary — the Zod enum in `src/app/api/compression/preview/route.ts:35` only accepts:

```ts
mode: z.enum(["off", "lite", "standard", "aggressive", "ultra", "rtk", "stacked"])
```

so any user passing the documented engine name `"caveman"` hits `invalid_value` at request validation, before dispatch.

## Root cause

Schema-vs-docs mismatch at the API surface. The internal engine already exists and is already wired: `open-sse/services/compression/strategySelector.ts:341-367` shows that mode `"standard"` dispatches `cavemanCompress()` — i.e. mode `"standard"` **is** caveman internally:

```ts
if (mode === "standard") {
  // ...
  const compressed = await cavemanCompress(...);
}
```

Same alias at `strategySelector.ts:613` (`if (step === "standard") return { engine: "caveman" };`) and `CompressionEngineId` at `open-sse/services/compression/types.ts:32-41` explicitly includes `"caveman"`. The MCP schemas mirror the same restricted enum at `open-sse/mcp-server/schemas/tools.ts:1096` and `:1100`.

The user-facing `CompressionMode` type has only 7 members (no `"caveman"`), so the fix must (a) widen the API-accepted enum and (b) normalize `"caveman"` → `"standard"` before the cast, so the well-tested internal path is unchanged.

## Fix

1. `src/app/api/compression/preview/route.ts:35` — extend the Zod enum to include `"caveman"`.
2. `src/app/api/compression/preview/route.ts:188-192` — normalize `mode === "caveman"` to `"standard"` before the `CompressionMode` cast, with a comment pointing at `strategySelector.ts` so the alias is discoverable.
3. `open-sse/mcp-server/schemas/tools.ts:1096` and `:1100` — mirror the enum widening for `compression.configure`'s `strategy` and `autoTriggerMode` so the MCP surface accepts the same alias.

No engine logic changes; only the API-facing enum widens. All seven existing modes (`off`, `lite`, `standard`, `aggressive`, `ultra`, `rtk`, `stacked`) remain valid — back-compat preserved.

## Verification

Repro (before this patch):

```bash
curl -sS -X POST http://localhost:20128/api/compression/preview \
  -H 'Content-Type: application/json' \
  -d '{"messages":[{"role":"user","content":"the the the very really just basically"}],"mode":"caveman"}'
# → 400 {"error":"Invalid request","details":[{"code":"invalid_value","path":["mode"], ...}]}
```

After this patch: same request returns 200 and the response's engine breakdown shows the caveman engine ran (identical output to the same request with `mode:"standard"` on the same fluffy-prose fixture, since `"standard"` already dispatches `cavemanCompress`).

## Diff summary

```
 open-sse/mcp-server/schemas/tools.ts     | 4 ++--
 src/app/api/compression/preview/route.ts | 7 +++++--
 2 files changed, 7 insertions(+), 4 deletions(-)
```

Minimal-diff: 2 files, 11 LOC. No refactors, no unrelated changes, no engine logic touched.

## Evidence

Root cause: schema-vs-docs mismatch at the API boundary. (1) `src/app/api/compression/preview/route.ts:34-35` defines mode as `.enum(["off","lite","standard","aggressive","ultra","rtk","stacked"])` — POST `{"mode":"caveman"}` returns 400 invalid_value, matching the issue repro. (2) Internal `CompressionEngineId` at `open-sse/services/compression/types.ts:32-41` explicitly includes `"caveman"`; README + `docs/compression/COMPRESSION_ENGINES.md` + `skills/omni-compression/SKILL.md` all market Caveman as an engine. (3) The alias is already wired internally: `open-sse/services/compression/strategySelector.ts:341-367` shows `if (mode === "standard") { ... cavemanCompress(...) }` — mode `"standard"` IS caveman. Same alias at `strategySelector.ts:613` (`if (step === "standard") return { engine: "caveman" };`). (4) MCP schemas mirror the same restricted enum: `open-sse/mcp-server/schemas/tools.ts:1096` and `:1100`. (5) Type `CompressionMode` at `types.ts:27-28` has only 7 values (no `"caveman"`), so the fix normalizes user-facing `"caveman"` → `"standard"` BEFORE the cast at `route.ts:189`. `tests/unit/compression/types.test.ts:36` asserts internal `CompressionMode` has exactly 7 values — untouched, since this rule concerns the internal type, not the API-facing enum.

Thanks for the great work on OmniRoute.
