### PR TITLE
fix(compression): enable caveman engine when selected as stacked step (#6464)

### DIFF
--- a/open-sse/services/compression/engines/cavemanAdapter.ts
+++ b/open-sse/services/compression/engines/cavemanAdapter.ts
@@ -289,7 +289,11 @@ export const cavemanEngine: CompressionEngine = {
   },
   apply(body, options) {
     const adapter = adaptBodyForCompression(body);
+    // Selecting caveman as a stacked step runs it regardless of the per-engine
+    // cavemanConfig.enabled flag (B-MODE-ENGINE-DECOUPLE). Later spreads still
+    // win, so an explicit `stepConfig.enabled === false` opts out.
     const cavemanConfig = {
+      enabled: true,
       ...(options?.config?.cavemanConfig ?? {}),
       ...(options?.stepConfig ?? {}),
       ...(options?.config?.languageConfig?.enabled

--- a/tests/unit/compression/caveman-engine-enable.test.ts
+++ b/tests/unit/compression/caveman-engine-enable.test.ts
@@ -1,0 +1,50 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { cavemanEngine } from "../../../open-sse/services/compression/engines/cavemanAdapter.ts";
+
+describe("caveman engine — stacked-step enable (regression #6464)", () => {
+  it("compresses when invoked as a stacked step without explicit enabled flag", () => {
+    // Reproduces the failure from #6464: /api/compression/preview with
+    // mode=stacked routes through cavemanEngine.apply with
+    // stepConfig={intensity:'full'} and no cavemanConfig — the engine used to
+    // fall through to DEFAULT_CAVEMAN_CONFIG.enabled=false and short-circuit,
+    // returning bytes-identical output. Selection as a stacked step is the
+    // enable signal (B-MODE-ENGINE-DECOUPLE), same pattern as the RTK adapter
+    // and the mode='standard' strategy path.
+    const body = {
+      messages: [
+        {
+          role: "user",
+          content: "really important context please carefully. ".repeat(20),
+        },
+      ],
+    };
+    const result = cavemanEngine.apply(body as any, {
+      stepConfig: { intensity: "full" } as any,
+    });
+    assert.equal(result.compressed, true);
+    assert.ok(
+      result.stats.compressedTokens < result.stats.originalTokens,
+      `Expected compressedTokens (${result.stats.compressedTokens}) < originalTokens (${result.stats.originalTokens})`
+    );
+    assert.ok(
+      result.stats.rulesApplied && result.stats.rulesApplied.length > 0,
+      "Expected at least one rule applied"
+    );
+  });
+
+  it("still honors explicit stepConfig.enabled === false opt-out", () => {
+    const body = {
+      messages: [
+        {
+          role: "user",
+          content: "really important context please carefully. ".repeat(20),
+        },
+      ],
+    };
+    const result = cavemanEngine.apply(body as any, {
+      stepConfig: { intensity: "full", enabled: false } as any,
+    });
+    assert.equal(result.compressed, false);
+  });
+});


### PR DESCRIPTION
## Problem

`POST /api/compression/preview` with `mode: "stacked"` returns `tokensSaved: 0` and `engineBreakdown` reports the caveman engine at 0% savings even when the request body contains obvious caveman-rule targets (filler adverbs, polite framing, emphasis) and per-engine settings show `caveman.enabled: true`, `level: "lite"`, `compressRoles: ["user"]`, `minMessageLength: 50` — all satisfied by the reproduction body.

Quoted failing response from the issue:

```json
"engineBreakdown": [
  { "engine": "caveman", "originalTokens": 2803, "compressedTokens": 2803, "savingsPercent": 0 }
]
```

The `compressed` string is byte-identical to the input. RTK in the same pipeline works — only caveman is inert.

## Root cause

The `cavemanEngine.apply` adapter at `open-sse/services/compression/engines/cavemanAdapter.ts:290-315` builds a `cavemanConfig` from `options.config.cavemanConfig` (undefined for the stacked-step path) and `options.stepConfig` (`{ intensity: "full" }` from `buildStepOptions` at `strategySelector.ts:683-696`). Neither contributes an `enabled` field.

`cavemanCompress` at `open-sse/services/compression/caveman.ts:449-465` then spreads over `DEFAULT_CAVEMAN_CONFIG`:

```ts
const config: CavemanConfig = { ...DEFAULT_CAVEMAN_CONFIG, ...options };
// ...
if (!config.enabled) {
  return emptyResult();
}
```

`DEFAULT_CAVEMAN_CONFIG.enabled` is `false` at `open-sse/services/compression/types.ts:325`, so the enable-gate short-circuits before any rule runs.

The other two invocation paths already handle this the same way we're proposing here:

- `strategySelector.ts:358-361` (mode=`"standard"`) explicitly sets `enabled: true` with the comment `Selecting the "standard" mode runs caveman regardless of the per-engine cavemanConfig.enabled flag (B-MODE-ENGINE-DECOUPLE)`.
- `open-sse/services/compression/engines/rtk/index.ts:530-535` uses the same "selection is the enable signal" pattern for the RTK stacked adapter.

The caveman stacked adapter is the outlier.

## Fix

Prepend `enabled: true` as the first spread key in the constructed `cavemanConfig` inside `cavemanEngine.apply`. Callers may still opt out via an explicit `stepConfig.enabled === false` — later spreads win, so behavior is unchanged for the explicit-off case. A short B-MODE-ENGINE-DECOUPLE comment matches the wording used at the other two invocation sites.

## Verification

New unit test at `tests/unit/compression/caveman-engine-enable.test.ts` reproduces the failure and asserts the fix:

1. `cavemanEngine.apply(body, { stepConfig: { intensity: "full" } })` on a body with 20 repetitions of `"really important context please carefully. "` — asserts `result.compressed === true`, `compressedTokens < originalTokens`, and `rulesApplied.length > 0`. Without the fix this test fails because caveman returns the empty result.
2. `stepConfig.enabled === false` — asserts the opt-out still short-circuits to `compressed: false`, so consumers that explicitly disable a step keep working.

Run: `node --import tsx/esm --test tests/unit/compression/caveman-engine-enable.test.ts`

Result: 2 passing.

## Diff summary

```
 open-sse/services/compression/engines/cavemanAdapter.ts | +8
 tests/unit/compression/caveman-engine-enable.test.ts    | +46 (new file)
 2 files changed, 54 insertions(+)
```

No refactors, no default-config changes (flipping `DEFAULT_CAVEMAN_CONFIG.enabled` would break every consumer that treats it as an opt-in gate for mode=`"caveman"` via cavemanConfig). Minimum surface to bring the stacked adapter in line with the two peer invocation paths.

Thanks for the great work on OmniRoute.
