### PR TITLE
fix(api): validate chat completion scalars before provider lookup (#6412)

### DIFF
--- a/src/shared/schemas/validation.ts
+++ b/src/shared/schemas/validation.ts
@@ -128,6 +128,23 @@ export const chatCompletionSchema = z.object({
   top_p: z.number().min(0).max(1).optional(),
 });
 
+// Scalar-only variant (#6412) — validates just the OpenAI-typed scalars
+// (temperature / max_tokens / top_p / stream) so invalid values are rejected
+// with a clear 400 at the API boundary instead of being forwarded to a
+// provider (which then either 400s upstream or, worse, produces a 404 "no
+// active credentials" after routing has already begun). Model/messages have
+// their own downstream handling per #5907 (relaxed) and the inline empty-
+// messages guard (#5110) — keeping them out of this schema preserves that
+// contract while still catching type/range errors early.
+export const chatCompletionScalarSchema = z
+  .object({
+    stream: z.boolean().optional(),
+    temperature: z.number().min(0).max(2).optional(),
+    max_tokens: z.number().int().min(1).optional(),
+    top_p: z.number().min(0).max(1).optional(),
+  })
+  .passthrough();
+
 // ─── Helper ───────────────────────────────────────────────────────
 
 /**

--- a/src/sse/handlers/chat.ts
+++ b/src/sse/handlers/chat.ts
@@ -92,6 +92,7 @@ import { RequestTelemetry, recordTelemetry } from "../../shared/utils/requestTel
 import { generateRequestId } from "../../shared/utils/requestId";
 import { logAuditEvent } from "../../lib/compliance/index";
 import { enforceApiKeyPolicy } from "../../shared/utils/apiKeyPolicy";
+import { chatCompletionScalarSchema } from "@/shared/schemas/validation";
 import { hasProviderQuotaBypassScope } from "../../shared/constants/apiKeyPolicyScopes";
 import { cloneLogPayload } from "@/lib/logPayloads";
 import { handleInternalUsageCommand } from "@/lib/usage/internalUsageCommand";
@@ -243,6 +244,22 @@ export async function handleChat(
   ) {
     log.warn("CHAT", "Rejecting request with empty messages array");
     return errorResponse(HTTP_STATUS.BAD_REQUEST, "messages: at least one message is required");
+  }
+
+  // Scalar-parameter validation (#6412). Reject bad `temperature` / `max_tokens`
+  // / `top_p` / `stream` at the API boundary — otherwise a body like
+  // `{ max_tokens: "not-a-number" }` sails through parsing + the empty-messages
+  // guard and only fails deep inside provider credential resolution as an
+  // unrelated 404 "No active credentials". Model/messages stay out of the
+  // schema so #5907's relaxed handling and the inline empty-messages guard
+  // above keep owning them. Responses-API bodies (which don't use `messages`)
+  // pass through untouched — passthrough() preserves unknown fields.
+  const scalarCheck = chatCompletionScalarSchema.safeParse(body);
+  if (!scalarCheck.success) {
+    const issue = scalarCheck.error.issues[0];
+    const path = issue.path.join(".") || "request";
+    log.warn("CHAT", `Rejecting request with invalid scalar: ${path}: ${issue.message}`);
+    return errorResponse(HTTP_STATUS.BAD_REQUEST, `${path}: ${issue.message}`);
   }
 
   // buildClientRawRequest already deep-clones the body, so pass `body` directly — the

--- a/tests/unit/chat-scalar-validation-6412.test.ts
+++ b/tests/unit/chat-scalar-validation-6412.test.ts
@@ -1,0 +1,99 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// #6412: invalid chat-completion scalars (temperature out of range, max_tokens
+// as a string, stream="yes", negative top_p) used to sail through the API
+// boundary — the `/v1/chat/completions` route only ran the prompt-injection
+// guard, then handleChat only validated JSON-parse + empty-messages. Bad
+// scalars first surfaced deep in provider credential resolution as an
+// unrelated 404 "No active credentials for provider: <x>", confusing users.
+//
+// Fix: `chatCompletionScalarSchema` (a `.passthrough()` variant of
+// `chatCompletionSchema` that keeps only the scalar validators) is applied at
+// the top of `handleChat`, right after the empty-messages guard, before any
+// policy / provider lookup. This test pins the schema's shape so a future edit
+// can't quietly relax it.
+
+const { chatCompletionScalarSchema } = await import("../../src/shared/schemas/validation.ts");
+
+test("#6412 rejects string max_tokens", () => {
+  const result = chatCompletionScalarSchema.safeParse({
+    model: "openrouter/deepseek/deepseek-r1:free",
+    messages: [{ role: "user", content: "hi" }],
+    max_tokens: "not-a-number",
+  });
+  assert.equal(result.success, false);
+  if (!result.success) {
+    assert.equal(result.error.issues[0].path[0], "max_tokens");
+  }
+});
+
+test("#6412 rejects out-of-range temperature", () => {
+  const result = chatCompletionScalarSchema.safeParse({
+    model: "openrouter/deepseek/deepseek-r1:free",
+    messages: [{ role: "user", content: "hi" }],
+    temperature: 99,
+  });
+  assert.equal(result.success, false);
+  if (!result.success) {
+    assert.equal(result.error.issues[0].path[0], "temperature");
+  }
+});
+
+test("#6412 rejects non-boolean stream", () => {
+  const result = chatCompletionScalarSchema.safeParse({
+    model: "openrouter/deepseek/deepseek-r1:free",
+    messages: [{ role: "user", content: "hi" }],
+    stream: "yes",
+  });
+  assert.equal(result.success, false);
+  if (!result.success) {
+    assert.equal(result.error.issues[0].path[0], "stream");
+  }
+});
+
+test("#6412 rejects negative top_p", () => {
+  const result = chatCompletionScalarSchema.safeParse({
+    model: "openrouter/deepseek/deepseek-r1:free",
+    messages: [{ role: "user", content: "hi" }],
+    top_p: -5,
+  });
+  assert.equal(result.success, false);
+  if (!result.success) {
+    assert.equal(result.error.issues[0].path[0], "top_p");
+  }
+});
+
+test("#6412 accepts a valid scalar body", () => {
+  const result = chatCompletionScalarSchema.safeParse({
+    model: "openrouter/deepseek/deepseek-r1:free",
+    messages: [{ role: "user", content: "hi" }],
+    temperature: 0.7,
+    max_tokens: 128,
+    top_p: 0.9,
+    stream: false,
+  });
+  assert.equal(result.success, true);
+});
+
+test("#6412 passthrough preserves unknown fields (e.g. Responses-API `input`, `reasoning_effort`)", () => {
+  const result = chatCompletionScalarSchema.safeParse({
+    input: [{ role: "user", content: "hi" }], // Responses API — no `messages`
+    reasoning_effort: "high",
+    custom_provider_ext: { foo: "bar" },
+  });
+  assert.equal(result.success, true);
+  if (result.success) {
+    assert.deepEqual((result.data as any).input, [{ role: "user", content: "hi" }]);
+    assert.equal((result.data as any).reasoning_effort, "high");
+    assert.deepEqual((result.data as any).custom_provider_ext, { foo: "bar" });
+  }
+});
+
+test("#6412 omitted scalars are fine (no forced defaults)", () => {
+  const result = chatCompletionScalarSchema.safeParse({
+    model: "openrouter/deepseek/deepseek-r1:free",
+    messages: [{ role: "user", content: "hi" }],
+  });
+  assert.equal(result.success, true);
+});


### PR DESCRIPTION
## Problem

Invalid chat-completion scalar parameters sail through OmniRoute's API boundary and only fail deep inside provider credential resolution as an unrelated 404 `"No active credentials for provider: openrouter"` (`src/sse/handlers/chatHelpers.ts:628-629`). A body like `{ "max_tokens": "not-a-number" }`, `{ "temperature": 99 }`, `{ "stream": "yes" }`, or `{ "top_p": -5 }` should be rejected with a clear 400 at the boundary — instead the request runs past `resolveChatRequestBody` (`src/sse/handlers/chat.ts:227`), past the `#5110` empty-messages guard (`src/sse/handlers/chat.ts:240-246`), past API-key policy (`chat.ts:331`), past guardrails, and finally trips a routing-layer error that is confusing and provider-specific.

The `/v1/chat/completions` POST route (`src/app/api/v1/chat/completions/route.ts:40-112`) itself does zero Zod validation — only the prompt-injection guard runs before forwarding to `handleChat`.

## Root cause

A `chatCompletionSchema` **already exists** at `src/shared/schemas/validation.ts:115-129` with exactly the validators this issue needs — `temperature: z.number().min(0).max(2)`, `max_tokens: z.number().int().min(1)`, `top_p: z.number().min(0).max(1)`, `stream: z.boolean()`. `grep` across `src/`, `open-sse/`, and `tests/` finds **zero call sites**. It is dead code.

`handleChat` (`src/sse/handlers/chat.ts:214-843`) validates only:
- (a) JSON parse via `resolveChatRequestBody` (line 227)
- (b) empty `messages` array inline (line 240-246 — the `#5110` fix)

Everything else is forwarded to provider routing without type/range checks.

## Fix

Two-line change plus a scalar-only schema variant:

1. **`src/shared/schemas/validation.ts`** — export `chatCompletionScalarSchema`, a `.passthrough()` variant that keeps only the four scalar validators (temperature / max_tokens / top_p / stream). Model/messages stay out so the relaxed handling from `#5907` and the inline empty-messages guard from `#5110` continue to own them. `.passthrough()` preserves unknown fields, so Responses-API bodies (which use `input`, not `messages`) and any provider-specific extras (`reasoning_effort`, custom keys) pass through untouched.

2. **`src/sse/handlers/chat.ts`** — import the new schema and `safeParse` the body immediately after the empty-messages guard (line 247). On failure, extract the first issue's path + message and return `errorResponse(HTTP_STATUS.BAD_REQUEST, "<path>: <zod message>")`.

Because the gate lives inside `handleChat`, it also covers `/v1/relay/chat/completions`, `/v1/providers/[provider]/chat/completions`, and the vscode variants that route through the same handler — single-point fix.

## Verification

Four repro curls that previously produced `404 "No active credentials..."` now return a clean `400`:

```bash
# Before: 404 "No active credentials for provider: openrouter"
# After:  400 "max_tokens: Expected number, received string"
curl -s -X POST http://localhost:20128/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{"model":"openrouter/deepseek/deepseek-r1:free","messages":[{"role":"user","content":"hi"}],"max_tokens":"not-a-number"}'

# Before: 404 (same). After: 400 "temperature: Number must be less than or equal to 2"
curl -s -X POST http://localhost:20128/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{"model":"openrouter/deepseek/deepseek-r1:free","messages":[{"role":"user","content":"hi"}],"temperature":99}'

# Before: 404. After: 400 "stream: Expected boolean, received string"
curl -s -X POST http://localhost:20128/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{"model":"openrouter/deepseek/deepseek-r1:free","messages":[{"role":"user","content":"hi"}],"stream":"yes"}'

# Before: 404. After: 400 "top_p: Number must be greater than or equal to 0"
curl -s -X POST http://localhost:20128/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{"model":"openrouter/deepseek/deepseek-r1:free","messages":[{"role":"user","content":"hi"}],"top_p":-5}'
```

Automated verification (7 tests, all passing):

```
$ node --import tsx/esm --test tests/unit/chat-scalar-validation-6412.test.ts
✔ #6412 rejects string max_tokens
✔ #6412 rejects out-of-range temperature
✔ #6412 rejects non-boolean stream
✔ #6412 rejects negative top_p
✔ #6412 accepts a valid scalar body
✔ #6412 passthrough preserves unknown fields (e.g. Responses-API `input`, `reasoning_effort`)
✔ #6412 omitted scalars are fine (no forced defaults)
ℹ tests 7 / pass 7 / fail 0
```

The passthrough test pins the `#5907` relaxed-body contract: Responses-API bodies (no `messages`, uses `input`) and requests with `reasoning_effort` or provider-specific extras are unaffected.

## Diff summary

3 files changed, 133 insertions(+):

- `src/shared/schemas/validation.ts` (+17) — new `chatCompletionScalarSchema` export
- `src/sse/handlers/chat.ts` (+17) — import + 12-line validation gate
- `tests/unit/chat-scalar-validation-6412.test.ts` (+99) — 7 regression tests

Same class of minimal-diff as `#6402` (which added the inline empty-messages check right above this new gate); this generalizes to the four scalar validators.

Thanks for the great work on OmniRoute.
