### PR TITLE
fix(security): enforce API key policy in Codex WS bridge (#6564)

### DIFF
--- a/src/app/api/internal/codex-responses-ws/route.ts
+++ b/src/app/api/internal/codex-responses-ws/route.ts
@@ -9,6 +9,7 @@ import { getProviderCredentialsWithQuotaPreflight } from "@/sse/services/auth";
 import { checkAndRefreshToken } from "@/sse/services/tokenRefresh";
 import { resolveCodexWsModelInfo } from "./modelResolution";
 import { isFeatureFlagEnabled } from "@/shared/utils/featureFlags";
+import { enforceApiKeyPolicy } from "@/shared/utils/apiKeyPolicy";
 import { formatMemoryContext } from "@/lib/memory/injection";
 import { retrieveMemories } from "@/lib/memory/retrieval";
 import {
@@ -289,6 +290,14 @@ function getAuthRequest(body: JsonRecord): Request {
   return new Request(url, { headers: requestHeaders });
 }
 
+function getPolicyRequest(authRequest: Request, apiKey: string | null): Request {
+  if (!apiKey) return authRequest;
+
+  const headers = new Headers(authRequest.headers);
+  headers.set("Authorization", `Bearer ${apiKey}`);
+  return new Request(authRequest.url, { headers });
+}
+
 function jsonError(status: number, code: string, message: string) {
   return NextResponse.json(
     {
@@ -352,17 +361,22 @@ async function prepare(body: JsonRecord) {
 
   const authRequest = getAuthRequest(body);
   const apiKey = extractWsTokenFromRequest(authRequest);
-  const metadata = apiKey ? await getApiKeyMetadata(apiKey).catch(() => null) : null;
-  const allowedConnections =
-    metadata && Array.isArray(metadata.allowedConnections) && metadata.allowedConnections.length > 0
-      ? metadata.allowedConnections
-      : null;
-
   const responseBody = isRecord(body.response) ? body.response : {};
   const requestedModel =
     typeof responseBody.model === "string" && responseBody.model.trim()
       ? responseBody.model.trim()
       : "gpt-5.5";
+
+  const policy = await enforceApiKeyPolicy(getPolicyRequest(authRequest, apiKey), requestedModel);
+  if (policy.rejection) return policy.rejection;
+
+  const metadata =
+    policy.apiKeyInfo || (apiKey ? await getApiKeyMetadata(apiKey).catch(() => null) : null);
+  const allowedConnections =
+    metadata && Array.isArray(metadata.allowedConnections) && metadata.allowedConnections.length > 0
+      ? metadata.allowedConnections
+      : null;
+
   // codex-only bridge: re-resolve bare ChatGPT model ids (the Codex CLI rejects
   // provider-prefixed ids client-side over WebSocket) as codex models.
   const modelInfo = await resolveCodexWsModelInfo(requestedModel, getModelInfo);

--- a/src/app/api/internal/codex-responses-ws/route.ts
+++ b/src/app/api/internal/codex-responses-ws/route.ts
@@ -295,7 +295,7 @@ function getPolicyRequest(authRequest: Request, apiKey: string | null): Request 
 
   const headers = new Headers(authRequest.headers);
   headers.set("Authorization", `Bearer ${apiKey}`);
-  return new Request(authRequest.url, { headers });
+  return new Request(authRequest, { headers });
 }
 
 function jsonError(status: number, code: string, message: string) {
@@ -370,8 +370,7 @@ async function prepare(body: JsonRecord) {
   const policy = await enforceApiKeyPolicy(getPolicyRequest(authRequest, apiKey), requestedModel);
   if (policy.rejection) return policy.rejection;
 
-  const metadata =
-    policy.apiKeyInfo || (apiKey ? await getApiKeyMetadata(apiKey).catch(() => null) : null);
+  const metadata = policy.apiKeyInfo;
   const allowedConnections =
     metadata && Array.isArray(metadata.allowedConnections) && metadata.allowedConnections.length > 0
       ? metadata.allowedConnections

--- a/tests/unit/codex-responses-ws-policy.test.ts
+++ b/tests/unit/codex-responses-ws-policy.test.ts
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-codex-ws-policy-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.API_KEY_SECRET = process.env.API_KEY_SECRET || "codex-ws-policy-test-secret";
+process.env.OMNIROUTE_WS_BRIDGE_SECRET = "bridge-secret";
+
+const coreDb = await import("../../src/lib/db/core.ts");
+const apiKeysDb = await import("../../src/lib/db/apiKeys.ts");
+const { POST } = await import("../../src/app/api/internal/codex-responses-ws/route.ts");
+
+async function resetStorage() {
+  apiKeysDb.resetApiKeyState();
+  coreDb.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+test.beforeEach(async () => {
+  await resetStorage();
+});
+
+test.after(() => {
+  apiKeysDb.resetApiKeyState();
+  coreDb.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("Codex Responses WS prepare enforces API key model/combo policy for query-token auth", async () => {
+  const created = await apiKeysDb.createApiKey("Combo Only", "machine-codex-ws-policy");
+  await apiKeysDb.updateApiKeyPermissions(created.id, {
+    allowedModels: ["combo/model-1.0"],
+    allowedCombos: ["combo/model-1.0"],
+  });
+
+  const response = await POST(
+    new Request("http://omniroute.local/api/internal/codex-responses-ws", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-omniroute-ws-bridge-secret": "bridge-secret",
+      },
+      body: JSON.stringify({
+        action: "prepare",
+        requestUrl: `/v1/responses?api_key=${encodeURIComponent(created.key)}`,
+        headers: {},
+        response: {
+          model: "gpt-5.5",
+          input: [{ role: "user", content: "hello" }],
+        },
+      }),
+    })
+  );
+
+  const body = (await response.json()) as { error?: { message?: string } };
+
+  assert.equal(response.status, 403);
+  assert.match(body.error?.message || "", /gpt-5\.5/);
+  assert.match(body.error?.message || "", /not allowed for this API key/);
+});


### PR DESCRIPTION
## Problem

The Codex Responses WebSocket `prepare` path authenticates the request and checks `allowedConnections`, but it does not run the shared API-key policy gate. As a result, an API key restricted to a combo such as `combo/model-1.0` can still prepare a direct Codex WebSocket request for a raw model like `gpt-5.5` when the key is allowed to use the underlying Codex connection.

That bypasses the same `allowedModels`, `allowedCombos`, and blocked-model restrictions that HTTP `/v1/responses` already enforces.

Closes #6564.

## Root cause

`src/app/api/internal/codex-responses-ws/route.ts` uses `authorizeWebSocketHandshake()` during `action: \"prepare\"`, then reads API-key metadata only to enforce connection allow-lists. It never calls `enforceApiKeyPolicy()` before resolving the requested model and selecting Codex credentials.

The WS bridge also accepts API keys through `?api_key=...`; the shared policy helper expects the key in the request authorization path, so the prepare route needs to normalize the authenticated query-token case before calling the policy gate.

## Fix

Run `enforceApiKeyPolicy()` in the Codex WS `prepare` path before model resolution and credential selection:

- preserve the existing WebSocket authentication flow,
- normalize a query-string API key into an `Authorization: Bearer ...` header for the policy check,
- return the policy rejection directly when the requested model/combo is not allowed,
- reuse `policy.apiKeyInfo` for the existing `allowedConnections` check to avoid an extra metadata lookup in the normal path.

## Tests

Adds `tests/unit/codex-responses-ws-policy.test.ts`, covering a regression where an API key allowed only for `combo/model-1.0` attempts to prepare a Codex WS request with body model `gpt-5.5`. The expected result is now `403` with the standard API-key policy rejection.

Verified the new test fails before the fix by reaching credential selection (`503`), then passes after the fix.

Additional verification run on this branch:

```bash
DISABLE_SQLITE_AUTO_BACKUP=true node --import tsx/esm --import ./open-sse/utils/setupPolyfill.ts --test tests/unit/codex-responses-ws-policy.test.ts tests/unit/codex-responses-ws-memory.test.ts tests/unit/codex-responses-ws-model-resolution.test.ts tests/unit/api-key-policy.test.ts
DISABLE_SQLITE_AUTO_BACKUP=true node --test tests/unit/responses-ws-proxy.test.mjs tests/unit/responses-ws-proxy-headers.test.mjs
DISABLE_SQLITE_AUTO_BACKUP=true node --import tsx/esm --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test tests/unit/executor-codex.test.ts
npm run typecheck:core
npx eslint src/app/api/internal/codex-responses-ws/route.ts tests/unit/codex-responses-ws-policy.test.ts
npx prettier --write src/app/api/internal/codex-responses-ws/route.ts tests/unit/codex-responses-ws-policy.test.ts
git diff --check
```

Pre-push hooks also passed when pushing the branch.

## Risk

Low. The change is scoped to the internal Codex WS prepare route and only rejects requests that violate an already-configured API-key policy. Keys without model/combo restrictions continue through the existing flow, and `allowedConnections` remains enforced after the policy check.