### PR TITLE
Limit first password setup to loopback requests

### DIFF
--- a/config/quality/eslint-suppressions.json
+++ b/config/quality/eslint-suppressions.json
@@ -1522,11 +1522,6 @@
       "count": 12
     }
   },
-  "tests/unit/login-bootstrap-route.test.ts": {
-    "@typescript-eslint/no-explicit-any": {
-      "count": 10
-    }
-  },
   "tests/unit/management-password.test.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 4

--- a/src/app/api/settings/require-login/route.ts
+++ b/src/app/api/settings/require-login/route.ts
@@ -4,7 +4,7 @@ import {
   hasManagementPasswordConfigured,
   hashManagementPassword,
 } from "@/lib/auth/managementPassword";
-import { isAuthenticated } from "@/shared/utils/apiAuth";
+import { isAuthenticated, isLoopbackRequest } from "@/shared/utils/apiAuth";
 import { getNodeRuntimeSupport } from "@/shared/utils/nodeRuntimeSupport.ts";
 import { updateRequireLoginSchema } from "@/shared/validation/schemas";
 import { isValidationFailure, validateBody } from "@/shared/validation/helpers";
@@ -46,7 +46,11 @@ export async function GET() {
  */
 export async function POST(request: Request) {
   const settings = await getSettings();
-  if (!isBootstrapSecurityWindow(settings) && !(await isAuthenticated(request))) {
+  if (isBootstrapSecurityWindow(settings)) {
+    if (!isLoopbackRequest(request)) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+  } else if (!(await isAuthenticated(request))) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 

--- a/src/shared/utils/apiAuth.ts
+++ b/src/shared/utils/apiAuth.ts
@@ -335,7 +335,7 @@ export async function isAuthRequired(
       }
 
       if (isRequireLoginBootstrapWritePath(pathname, method)) {
-        return false;
+        return !isLoopbackRequest(request);
       }
 
       return settings.setupComplete === true || !isLoopbackRequest(request);

--- a/tests/unit/api-auth.test.ts
+++ b/tests/unit/api-auth.test.ts
@@ -318,6 +318,24 @@ test("isAuthRequired keeps fresh bootstrap open only on loopback", async () => {
   );
 });
 
+test("isAuthRequired rejects remote require-login bootstrap writes without a configured password", async () => {
+  delete process.env.INITIAL_PASSWORD;
+  await localDb.updateSettings({ requireLogin: true, setupComplete: true, password: "" });
+
+  assert.equal(
+    await apiAuth.isAuthRequired(
+      new Request("https://example.com/api/settings/require-login", { method: "POST" })
+    ),
+    true
+  );
+  assert.equal(
+    await apiAuth.isAuthRequired(
+      new Request("http://localhost/api/settings/require-login", { method: "POST" })
+    ),
+    false
+  );
+});
+
 test("isAuthenticated rejects remote management bootstrap without a configured password", async () => {
   await localDb.updateSettings({ requireLogin: true, password: "" });
 

--- a/tests/unit/authz/pipeline.test.ts
+++ b/tests/unit/authz/pipeline.test.ts
@@ -199,7 +199,7 @@ test("runAuthzPipeline allows onboarding when login is required but no password 
   assert.equal(response.headers.get("x-omniroute-route-class"), "PUBLIC");
 });
 
-test("runAuthzPipeline allows first password writes when login is required but no password exists", async () => {
+test("runAuthzPipeline rejects remote first password writes when login is required but no password exists", async () => {
   delete process.env.INITIAL_PASSWORD;
   await settingsDb.updateSettings({
     requireLogin: true,
@@ -209,6 +209,23 @@ test("runAuthzPipeline allows first password writes when login is required but n
 
   const response = await pipeline.runAuthzPipeline(
     request("https://example.com/api/settings/require-login", { method: "POST" }),
+    { enforce: true }
+  );
+
+  assert.equal(response.status, 401);
+  assert.equal(response.headers.get("x-omniroute-route-class"), "MANAGEMENT");
+});
+
+test("runAuthzPipeline allows loopback first password writes when login is required but no password exists", async () => {
+  delete process.env.INITIAL_PASSWORD;
+  await settingsDb.updateSettings({
+    requireLogin: true,
+    setupComplete: true,
+    password: "",
+  });
+
+  const response = await pipeline.runAuthzPipeline(
+    request("http://localhost/api/settings/require-login", { method: "POST" }),
     { enforce: true }
   );
 

--- a/tests/unit/login-bootstrap-route.test.ts
+++ b/tests/unit/login-bootstrap-route.test.ts
@@ -12,6 +12,33 @@ const core = await import("../../src/lib/db/core.ts");
 const settingsDb = await import("../../src/lib/db/settings.ts");
 const route = await import("../../src/app/api/settings/require-login/route.ts");
 
+type MetadataBody = {
+  requireLogin: boolean;
+  hasPassword: boolean;
+  setupComplete: boolean;
+  nodeVersion: unknown;
+  nodeCompatible: unknown;
+};
+
+type ValidationErrorBody = {
+  error: {
+    message: string;
+    details: Array<{ field: string; message: string }>;
+  };
+};
+
+type StringErrorBody = {
+  error: string;
+};
+
+type SuccessBody = {
+  success: true;
+};
+
+async function jsonBody<T>(response: Response): Promise<T> {
+  return (await response.json()) as T;
+}
+
 async function resetStorage() {
   core.resetDbInstance();
   fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
@@ -42,7 +69,7 @@ test("public login bootstrap route exposes the metadata the login page consumes"
   });
 
   const response = await route.GET();
-  const body = (await response.json()) as any;
+  const body = await jsonBody<MetadataBody>(response);
 
   assert.equal(response.status, 200);
   assert.deepEqual(body, {
@@ -63,7 +90,7 @@ test("public login bootstrap route reports env-provided bootstrap password metad
   });
 
   const response = await route.GET();
-  const body = (await response.json()) as any;
+  const body = await jsonBody<MetadataBody>(response);
 
   assert.equal(response.status, 200);
   assert.deepEqual(body, {
@@ -83,7 +110,7 @@ test("public login bootstrap route reports stored password metadata and disabled
   });
 
   const response = await route.GET();
-  const body = (await response.json()) as any;
+  const body = await jsonBody<MetadataBody>(response);
 
   assert.equal(response.status, 200);
   assert.deepEqual(body, {
@@ -103,7 +130,7 @@ test("public login bootstrap route POST rejects invalid JSON bodies", async () =
   });
 
   const response = await route.POST(request);
-  const body = (await response.json()) as any;
+  const body = await jsonBody<ValidationErrorBody>(response);
 
   assert.equal(response.status, 400);
   assert.equal(body.error.message, "Invalid request");
@@ -118,7 +145,7 @@ test("public login bootstrap route POST rejects empty updates", async () => {
   });
 
   const response = await route.POST(request);
-  const body = (await response.json()) as any;
+  const body = await jsonBody<ValidationErrorBody>(response);
 
   assert.equal(response.status, 400);
   assert.equal(body.error.message, "Invalid request");
@@ -133,7 +160,7 @@ test("public login bootstrap route POST updates requireLogin without forcing pas
   });
 
   const response = await route.POST(request);
-  const body = (await response.json()) as any;
+  const body = await jsonBody<SuccessBody>(response);
   const settings = await settingsDb.getSettings();
 
   assert.equal(response.status, 200);
@@ -151,7 +178,7 @@ test("public login bootstrap route POST hashes and stores passwords", async () =
   });
 
   const response = await route.POST(request);
-  const body = (await response.json()) as any;
+  const body = await jsonBody<SuccessBody>(response);
   const settings = await settingsDb.getSettings();
 
   assert.equal(response.status, 200);
@@ -176,7 +203,7 @@ test("login bootstrap route POST rejects unauthenticated writes after setup is c
   });
 
   const response = await route.POST(request);
-  const body = (await response.json()) as any;
+  const body = await jsonBody<StringErrorBody>(response);
   const settings = await settingsDb.getSettings();
 
   assert.equal(response.status, 401);
@@ -184,7 +211,30 @@ test("login bootstrap route POST rejects unauthenticated writes after setup is c
   assert.equal(settings.requireLogin, true);
 });
 
-test("login bootstrap route POST allows first password creation after setup completed without a password", async () => {
+test("login bootstrap route POST rejects remote first password creation after setup completed without a password", async () => {
+  await settingsDb.updateSettings({
+    requireLogin: true,
+    password: "",
+    setupComplete: true,
+  });
+
+  const request = new Request("https://example.com/api/settings/require-login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ requireLogin: true, password: "first-secret" }),
+  });
+
+  const response = await route.POST(request);
+  const body = await jsonBody<StringErrorBody>(response);
+  const settings = await settingsDb.getSettings();
+
+  assert.equal(response.status, 403);
+  assert.deepEqual(body, { error: "Forbidden" });
+  assert.equal(settings.requireLogin, true);
+  assert.equal(settings.password, "");
+});
+
+test("login bootstrap route POST allows loopback first password creation after setup completed without a password", async () => {
   await settingsDb.updateSettings({
     requireLogin: true,
     password: "",
@@ -198,7 +248,7 @@ test("login bootstrap route POST allows first password creation after setup comp
   });
 
   const response = await route.POST(request);
-  const body = (await response.json()) as any;
+  const body = await jsonBody<SuccessBody>(response);
   const settings = await settingsDb.getSettings();
 
   assert.equal(response.status, 200);
@@ -220,7 +270,7 @@ test("public login bootstrap route POST returns 500 when hashing fails", async (
   });
 
   const response = await route.POST(request);
-  const body = (await response.json()) as any;
+  const body = await jsonBody<StringErrorBody>(response);
 
   assert.equal(response.status, 500);
   assert.deepEqual(body, { error: "hash failed" });


### PR DESCRIPTION
## Summary

- Limits unauthenticated first-password setup for `/api/settings/require-login` to loopback requests.
- Adds the same loopback check in the auth gate and in the route handler.
- Keeps local setup from `localhost` working.

## Risk

On a fresh instance with no stored password and no `INITIAL_PASSWORD`, a remote client could send `POST /api/settings/require-login`, turn login on, set a password, and lock the owner out before setup.

I treat this as high severity for instances exposed during first run. Remote setup can still use `INITIAL_PASSWORD`; this PR does not add a one-time remote setup token.

## Validation

- `node --test --test-force-exit tests/unit/login-bootstrap-route.test.ts tests/unit/api-auth.test.ts tests/unit/authz/pipeline.test.ts`: passed, 73 tests
- `npm run lint`: passed
- `npm run typecheck:core`: passed
- `npm run build`: passed
