### PR TITLE
fix(startup): normalize non-Error rejections from DB init before rethrow (#6560)

### DIFF
--- a/src/instrumentation-node.ts
+++ b/src/instrumentation-node.ts
@@ -21,6 +21,20 @@ function toHex(bytes: Uint8Array): string {
 }
 
 /**
+ * Normalize an unknown `catch` value into a real `Error` instance.
+ *
+ * Some lower-level drivers (native SQLite bindings, WASM adapters) reject
+ * with a bare string instead of an `Error`. If that raw value escapes to a
+ * caller that assumes an `Error` shape (e.g. assigns `.message`), it throws
+ * `TypeError: Cannot create property 'message' on string '...'` — a much
+ * more confusing crash than the original failure. Normalizing at the catch
+ * site guarantees every downstream consumer gets a real `Error`.
+ */
+export function normalizeStartupError(err: unknown): Error {
+  return err instanceof Error ? err : new Error(String(err));
+}
+
+/**
  * Rename a Node process title so OmniRoute is identifiable in `ps`/`htop`
  * instead of the generic Next.js standalone server name.
  *
@@ -271,7 +285,14 @@ export async function registerNodejs(): Promise<void> {
     console.warn("[COMPLIANCE] Could not initialize audit log:", msg);
   }
 
-  await import("@/lib/db/core").then(({ ensureDbInitialized }) => ensureDbInitialized());
+  try {
+    const { ensureDbInitialized } = await import("@/lib/db/core");
+    await ensureDbInitialized();
+  } catch (err: unknown) {
+    const normalized = normalizeStartupError(err);
+    console.error("[STARTUP] Database initialization failed:", normalized.message);
+    throw normalized;
+  }
 
   // Storage-configured scheduled VACUUM (#4437): registers the timer from
   // Settings > System & Storage and persists lastVacuumAt for the UI.

--- a/tests/unit/instrumentation-startup-error-normalization-6560.test.ts
+++ b/tests/unit/instrumentation-startup-error-normalization-6560.test.ts
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { normalizeStartupError } from "../../src/instrumentation-node";
+
+test("normalizeStartupError passes an existing Error instance through unchanged", () => {
+  const original = new Error("Database closed");
+  assert.equal(normalizeStartupError(original), original);
+});
+
+test("normalizeStartupError wraps a raw string rejection (#6560 repro) into a real Error", () => {
+  const normalized = normalizeStartupError("Database closed");
+  assert.ok(normalized instanceof Error);
+  assert.equal(normalized.message, "Database closed");
+  // Must not throw — this is exactly the crash #6560 reports when downstream
+  // code assumes an Error shape and assigns `.message` on a bare string.
+  assert.doesNotThrow(() => {
+    normalized.message = `${normalized.message} (during startup)`;
+  });
+});
+
+test("normalizeStartupError wraps non-string, non-Error throws (null/number/object)", () => {
+  assert.equal(normalizeStartupError(null).message, "null");
+  assert.equal(normalizeStartupError(undefined).message, "undefined");
+  assert.equal(normalizeStartupError(42).message, "42");
+  assert.equal(normalizeStartupError({ code: "ERR" }).message, "[object Object]");
+});


### PR DESCRIPTION
## Problem

During an update / in-place restart, OmniRoute crashes at instrumentation bootstrap with a **misleading** `TypeError` that hides the real failure:

```
"level":"error","component":"app"
"message":"Cannot create property 'message' on string 'Database closed'"
TypeError: Cannot create property 'message' on string 'Database closed'
    at registerInstrumentation
```

The true underlying condition is a `Database closed` state hit during an update-driven reload (the SQLite handle is being torn down / is not yet reopened when instrumentation runs). But the crash the operator actually sees is the confusing `Cannot create property 'message' on string` — not the real DB error — which makes the failure very hard to diagnose.

## Root cause

`registerNodejs()` in `src/instrumentation-node.ts` awaited the DB-init step with **no** surrounding `try/catch`:

```ts
await import("@/lib/db/core").then(({ ensureDbInitialized }) => ensureDbInitialized());
```

This is the **only** startup step in the entire file that is not defensively wrapped. Every other step — `ensureSecrets`, the stale-cooldown clear (#3625), runtime-settings hydration, the compliance audit init, the vacuum scheduler, embedded-services bootstrap, etc. — already normalizes any thrown value with the same idiom:

```ts
const msg = err instanceof Error ? err.message : String(err);
```

When the underlying SQLite driver rejects with a **bare string** (`'Database closed'`) rather than an `Error`, that raw string propagates uncaught up into Next.js's `registerInstrumentation` caller. That caller assumes an `Error` shape and assigns `err.message = …`, which throws `TypeError: Cannot create property 'message' on string 'Database closed'` — masking the original failure.

## Fix

Two small, surgical changes in `src/instrumentation-node.ts`, matching the try/catch + normalize pattern already used by every other step in the file:

1. Add a tiny exported helper `normalizeStartupError(err: unknown): Error` that returns the value unchanged when it is already an `Error`, otherwise wraps it in `new Error(String(err))`.
2. Wrap the `ensureDbInitialized()` call in a `try/catch` that normalizes any thrown value, logs it (`[STARTUP] Database initialization failed: …`), and **rethrows the normalized `Error`**.

Downstream consumers (including Next's `register()` caller) now always receive a real `Error`, so the confusing `TypeError` can no longer occur and the actual DB failure surfaces in the logs instead. The success path is unchanged.

## Verification

New regression test `tests/unit/instrumentation-startup-error-normalization-6560.test.ts` (3 tests) that reproduces #6560 and locks in the fix:

1. An existing `Error` instance passes through unchanged (identity preserved).
2. A **raw string** rejection (`"Database closed"` — the exact #6560 repro) is wrapped into a real `Error`, and assigning `.message` on the result does **not** throw — this is precisely the crash #6560 reports.
3. Non-string / non-`Error` throws (`null` / `undefined` / number / object) are wrapped with the expected `String()` message.

Commands run locally (Node 22.22.3, Windows 11):

```
# new #6560 regression suite
node --import tsx/esm --test tests/unit/instrumentation-startup-error-normalization-6560.test.ts
# → tests 3 | pass 3 | fail 0

# all instrumentation suites
node --import tsx/esm --test tests/unit/instrumentation*.test.ts
# → tests 8 | pass 8 | fail 0

# lint (repo suppressions applied — same as CI)
npx eslint --suppressions-location config/quality/eslint-suppressions.json \
  src/instrumentation-node.ts \
  tests/unit/instrumentation-startup-error-normalization-6560.test.ts
# → 0 problems (clean)

# typecheck
npm run typecheck:core
# → clean (exit 0)
```

Formatting is enforced by the repo's lint-staged `prettier --write` pre-commit hook, which ran clean on commit (committed files are LF-normalized via `core.autocrlf`).

## Diff summary

| File | Change |
| ---- | ------ |
| `src/instrumentation-node.ts` | Add exported `normalizeStartupError()` helper; wrap `ensureDbInitialized()` in try/catch → normalize → log → rethrow (+22 / −1) |
| `tests/unit/instrumentation-startup-error-normalization-6560.test.ts` | New — 3 regression tests for the normalization helper (+26) |

Total: 2 files changed, 48 insertions(+), 1 deletion(−).

Closes #6560.

Thanks for the great work on OmniRoute!
