### PR TITLE
fix(dashboard): size the web-session cookie modal to fit on 1080p (#6265)

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/[id]/components/modals/AddApiKeyModal.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/modals/AddApiKeyModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useState, useEffect, useRef } from "react";
 import { useTranslations } from "next-intl";
-import { Button, Badge, Input, Modal, Toggle } from "@/shared/components";
+import { Button, Badge, Input, Modal, Toggle, TALL_MODAL_PROPS } from "@/shared/components";
 import {
   providerAllowsOptionalApiKey,
   supportsBulkApiKey,
@@ -445,7 +445,7 @@ export default function AddApiKeyModal({
       title={getAddCredentialModalTitle(t, providerDisplayName, webSessionCredential)}
       onClose={onClose}
       size="lg"
-      bodyClassName="p-6 max-h-[85vh] overflow-y-auto"
+      {...TALL_MODAL_PROPS}
     >
       <div className="flex flex-col gap-4">
         {webProviderHostLink && (

--- a/src/shared/components/Modal.tsx
+++ b/src/shared/components/Modal.tsx
@@ -4,6 +4,14 @@ import { useEffect, useRef, useId } from "react";
 import { cn } from "@/shared/utils/cn";
 import Button from "./Button";
 
+// #6265 — preset for content-heavy modals: caps height on the OUTERMOST dialog
+// wrapper only (single scroll owner) and keeps the inner body plain (no
+// independent max-h/overflow), avoiding a double height cap that clips content.
+export const TALL_MODAL_PROPS = {
+  className: "max-h-[90vh] overflow-y-auto",
+  bodyClassName: "p-6",
+};
+
 interface ModalProps {
   isOpen: boolean;
   onClose: () => void;

--- a/src/shared/components/index.tsx
+++ b/src/shared/components/index.tsx
@@ -6,7 +6,7 @@ export { default as Checkbox } from "./Checkbox";
 export { default as Textarea } from "./Textarea";
 export { default as Card } from "./Card";
 export { default as Collapsible } from "./Collapsible";
-export { default as Modal, ConfirmModal } from "./Modal";
+export { default as Modal, ConfirmModal, TALL_MODAL_PROPS } from "./Modal";
 export { default as Loading, Spinner, PageLoading, Skeleton, CardSkeleton } from "./Loading";
 export { default as Avatar } from "./Avatar";
 export { default as Badge } from "./Badge";

--- a/tests/unit/ui/web-session-cookie-modal-size-6265.test.tsx
+++ b/tests/unit/ui/web-session-cookie-modal-size-6265.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+// Issue #6265 — the "Add session cookie" modal (AddApiKeyModal, shared by every
+// `-web` cookie provider) was undersized on a 1920x1080 viewport: users had to
+// scroll *inside* the modal to reach Save, and the top of the cookie helper text
+// was clipped. Root cause: the height cap (`max-h-*` + `overflow-y-auto`) lived on
+// the INNER body div only, while the OUTERMOST dialog wrapper had no height bound
+// at all — so the whole box (header + body) could grow taller than the viewport
+// and get clipped by the centering flexbox, independent of the inner scrollbar.
+//
+// Fix: move the single height cap to the outermost dialog wrapper (`role="dialog"`)
+// and stop giving the inner body container its own independent `max-h-`/`overflow`
+// cap, so there is exactly one scroll owner for the whole modal.
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+const { default: AddApiKeyModal } =
+  await import("../../../src/app/(dashboard)/dashboard/providers/[id]/components/modals/AddApiKeyModal");
+
+const containers: Array<{ root: ReturnType<typeof createRoot>; el: HTMLDivElement }> = [];
+
+function render(props: Record<string, unknown>) {
+  const el = document.createElement("div");
+  document.body.appendChild(el);
+  const root = createRoot(el);
+  act(() => {
+    root.render(
+      <AddApiKeyModal
+        isOpen
+        onSave={async () => undefined}
+        onClose={() => {}}
+        {...(props as any)}
+      />
+    );
+  });
+  containers.push({ root, el });
+  return el;
+}
+
+afterEach(() => {
+  for (const { root, el } of containers.splice(0)) {
+    act(() => root.unmount());
+    el.remove();
+  }
+});
+
+describe("AddApiKeyModal — cookie modal sizing (#6265)", () => {
+  it("caps height on the OUTERMOST dialog wrapper, not on an inner body div", () => {
+    // chatgpt-web is a `kind: "cookie"` web-session provider — same shared modal
+    // path lmarena/claude-web/gemini-web/kimi-web/z-ai all go through.
+    const el = render({ provider: "chatgpt-web", providerName: "ChatGPT (Web)" });
+
+    const dialog = el.querySelector<HTMLElement>('[role="dialog"]');
+    expect(dialog).toBeTruthy();
+
+    // The outermost wrapper must be the single owner of the height cap + scroll.
+    expect(dialog!.className).toMatch(/max-h-\[90vh\]/);
+    expect(dialog!.className).toMatch(/overflow-y-auto/);
+
+    // The body container (last child of the dialog — header is first, no footer
+    // prop is used by AddApiKeyModal) must NOT carry its own independent max-h/
+    // overflow cap — otherwise the outer cap and the inner cap fight (double cap),
+    // clipping content before the outer 90vh bound ever kicks in.
+    const bodyDiv = dialog!.children[dialog!.children.length - 1] as HTMLElement;
+    expect(bodyDiv).toBeTruthy();
+    expect(bodyDiv.className).not.toMatch(/max-h-/);
+    expect(bodyDiv.className).not.toMatch(/overflow-y-auto/);
+
+    // Sanity: the cookie helper text and Save button are both present in the DOM
+    // (this modal renders the full guide + form Save/Cancel inline in the body).
+    expect(el.textContent).toContain("How to get the session credential");
+    const saveBtn = Array.from(el.querySelectorAll("button")).find(
+      (b) => b.textContent?.trim() === "save"
+    );
+    expect(saveBtn).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Closes #6265

## Root cause (verified, not the literal theory from the issue)

The issue's author theorized a "double `max-h` cap" between an outer dialog wrapper and an inner form container. Reading the actual code (`src/shared/components/Modal.tsx` + `AddApiKeyModal.tsx`), there was only **one** explicit cap — but it was on the **wrong** element: the inner body `<div>` (`bodyClassName="p-6 max-h-[85vh] overflow-y-auto"`), while the **outermost** dialog wrapper (`role="dialog"`, the actual header+body box) had **no height bound at all**. Because that outer box is centered by a plain flex container with no scroll of its own, once header+body together grew taller than the viewport, the box got clipped by the centering flexbox — independent of the inner scrollbar — which produces exactly the reported symptoms: clipped top content and having to scroll inside the modal to reach Save.

## Fix

Added a small reusable preset, `TALL_MODAL_PROPS`, exported from `src/shared/components/Modal.tsx` (re-exported via the `@/shared/components` barrel):

```ts
export const TALL_MODAL_PROPS = {
  className: "max-h-[90vh] overflow-y-auto", // outermost dialog wrapper
  bodyClassName: "p-6",                       // inner body — no independent cap
};
```

`AddApiKeyModal` (the modal opened from a provider card's Import/Connect action, shared by every `-web` cookie provider — lmarena, chatgpt-web, claude-web, gemini-web, kimi-web, z-ai, etc.) now spreads `{...TALL_MODAL_PROPS}` instead of its own ad-hoc `bodyClassName` override, so there is exactly one height cap, on the outermost wrapper, and no independent cap on the inner content.

Frozen-file note: `AddApiKeyModal.tsx` is at its file-size-baseline cap (960/961 lines). To land the fix without growing it, the new preset lives in `Modal.tsx` (not frozen) and is added to `AddApiKeyModal.tsx`'s **existing** single-line import from `@/shared/components` plus a 1-line JSX spread replacing the old 1-line `bodyClassName` override — net zero line change in the frozen file. Verified: `node scripts/check/check-file-size.mjs` exits 0.

## TDD evidence (RED → GREEN)

New regression guard: `tests/unit/ui/web-session-cookie-modal-size-6265.test.tsx`

- **RED** (before the fix): asserted the `role="dialog"` wrapper carries `max-h-[90vh]` + `overflow-y-auto` and the body div carries neither on its own — failed against the pre-fix code (`AssertionError: expected 'relative w-full bg-surface...' to match /max-h-\[90vh\]/`).
- **GREEN** (after the fix): same assertions pass; also verified the cookie helper text and Save button are both present in the DOM.

```
npx vitest run tests/unit/ui/web-session-cookie-modal-size-6265.test.tsx
# Test Files  1 passed (1)
# Tests  1 passed (1)
```

Also re-ran the existing sibling suites to confirm no regression:
```
npx vitest run tests/unit/ui/add-api-key-modal-free-models.test.tsx \
  tests/unit/ui/add-api-key-modal-unsupported-save-5565.test.tsx \
  tests/unit/ui/add-api-key-modal-validation-error-5088.test.tsx \
  tests/unit/ui/edit-connection-modal-free-models.test.tsx
# Test Files  4 passed (4) / Tests  14 passed (14)
```

## Gates run locally (all green)

- `node scripts/check/check-file-size.mjs` → exit 0
- `node scripts/check/check-complexity.mjs` → `OK — 2052 violações (baseline 2052)`
- `npm run typecheck:core` → clean
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` → clean
- `npx prettier --check <changed files>` → clean

## Files changed

- `src/shared/components/Modal.tsx` — new `TALL_MODAL_PROPS` preset
- `src/shared/components/index.tsx` — re-export
- `src/app/(dashboard)/dashboard/providers/[id]/components/modals/AddApiKeyModal.tsx` — consume the preset instead of its own ad-hoc `bodyClassName`
- `tests/unit/ui/web-session-cookie-modal-size-6265.test.tsx` — new regression guard
- `CHANGELOG.md` — bullet under `## [3.8.47] — TBD` → `### 🐛 Bug Fixes`