### PR TITLE
chore(deps): bump omniglyph to ^1.0.2 (security: ReDoS fixes)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "next-intl": "^4.12.0",
         "next-themes": "^0.4.6",
         "node-machine-id": "^1.1.12",
-        "omniglyph": "^1.0.0",
+        "omniglyph": "^1.0.2",
         "open": "^11.0.0",
         "ora": "^9.4.1",
         "parse5": "^8.0.1",
@@ -22298,9 +22298,9 @@
       "license": "MIT"
     },
     "node_modules/omniglyph": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/omniglyph/-/omniglyph-1.0.0.tgz",
-      "integrity": "sha512-Jz48LVU4UOtQ++kad4Pa5bNqJEqa0OfYRR7iJtsLoMgpNmnAqjAnQao/VIsh2anTurC+BLPhCthzmAjIo746iA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/omniglyph/-/omniglyph-1.0.2.tgz",
+      "integrity": "sha512-GGLet99n3HVxOx3WuNPda4B0ETptX9SA8h1fnm/AYSXmvsKXE3mN11Ae2jfX8ldAOA/rVJRXHzPhNkXsRHzMsg==",
       "license": "MIT",
       "dependencies": {
         "gpt-tokenizer": "^3.4.0"

--- a/package.json
+++ b/package.json
@@ -261,7 +261,7 @@
     "next-intl": "^4.12.0",
     "next-themes": "^0.4.6",
     "node-machine-id": "^1.1.12",
-    "omniglyph": "^1.0.0",
+    "omniglyph": "^1.0.2",
     "open": "^11.0.0",
     "ora": "^9.4.1",
     "parse5": "^8.0.1",


### PR DESCRIPTION
## What

Bump `omniglyph` from a lockfile-pinned **1.0.0** to **^1.0.2** (lock refreshed to 1.0.2).

Only two files change — `package.json` (range `^1.0.0` → `^1.0.2`) and `package-lock.json` (the `omniglyph` entry: version/resolved/integrity). The dependency tree is unchanged (`gpt-tokenizer ^3.4.0`).

## Why

The lock pinned `omniglyph@1.0.0`, so `npm ci` was installing the pre-fix build. Upstream **1.0.1/1.0.2 resolved all CodeQL alerts** (16 polynomial-ReDoS rewrites to linear scans, 2 TOCTOU file-read fixes, 1 ASI fix). **No behavior change** to the compression path — 1.0.1/1.0.2 touched only regex hot paths and docs. 1.0.2 is also published with **SLSA provenance** (npm trusted publishing).

## "Always latest 1.x / auto-updatable"

- `^1.0.2` already means *any* future 1.x is eligible — that's the "latest 1.x" declaration at the manifest level.
- The **lockfile stays pinned on purpose** (reproducible, VPS-validated builds — consistent with this repo's Dependabot policy that freezes npm auto-bumps). Truly unpinning to fetch the newest 1.x on every build would break reproducibility and the supply-chain discipline here, so I did **not** do that.
- If you want ongoing *auto-update PRs* for `omniglyph` specifically (opened by Dependabot, still human-merged and VPS-validated), I can follow up with a small `allow` carve-out in `.github/dependabot.yml`. Flagging it as a separate policy decision rather than bundling it here.

## Validation

- `package.json` and `package-lock.json` remain valid JSON.
- Lock `integrity` matches the npm registry for `omniglyph@1.0.2` (`sha512-GGLet99n…`).
- Merge is yours to make; no release-freeze label is currently open.
