### PR TITLE
fix(cli): use defaultMode in compression REST fallback + render objects in table output (#6571)

### DIFF
--- a/bin/cli/commands/compression.mjs
+++ b/bin/cli/commands/compression.mjs
@@ -24,7 +24,9 @@ async function restCompressionStatus() {
   const combosBody = combosRes.ok ? await combosRes.json() : { combos: [] };
   const analytics = analyticsRes && analyticsRes.ok ? await analyticsRes.json() : null;
   return {
-    engine: settings.engine ?? null,
+    // The settings payload exposes the active mode as `defaultMode`, not `engine`
+    // (matches the MCP handler's `strategy: settings.defaultMode`) — #6571.
+    engine: settings.defaultMode ?? null,
     settings,
     combos: combosBody.combos ?? combosBody,
     analytics,
@@ -43,9 +45,15 @@ async function restCompressionConfigure(config) {
 }
 
 async function restSetEngine(name) {
+  const engine = normalizeEngine(name);
+  // The settings API persists the active mode as `defaultMode`, not `engine`
+  // (an unknown `engine` key is silently ignored). Mirror the MCP handler's
+  // caveman → "standard" translation; every other id passes through — #6571.
+  const body = { defaultMode: engine === "caveman" ? "standard" : engine };
+  if (engine === "off") body.enabled = false;
   const res = await apiFetch("/api/settings/compression", {
     method: "PUT",
-    body: { engine: normalizeEngine(name) },
+    body,
   });
   if (!res.ok) {
     process.stderr.write(`Error: ${res.status}\n`);

--- a/bin/cli/output.mjs
+++ b/bin/cli/output.mjs
@@ -37,6 +37,8 @@ function inferSchema(sample) {
 function formatCell(v, col) {
   if (v == null) return "";
   if (col.formatter) return col.formatter(v);
+  // Nested objects/arrays would otherwise stringify to "[object Object]" (#6571).
+  if (typeof v === "object") return JSON.stringify(v);
   return String(v);
 }
 

--- a/tests/unit/cli-compression-commands.test.ts
+++ b/tests/unit/cli-compression-commands.test.ts
@@ -246,5 +246,8 @@ test("compression engine set falls back to PUT /api/settings/compression on MCP 
   const restCall = calls.find((c) => c.url.includes("/api/settings/compression"));
   assert.ok(restCall, "should fall back to PUT /api/settings/compression");
   assert.equal(restCall?.method, "PUT");
-  assert.equal(restCall?.body?.engine, "rtk");
+  // The settings API persists the active mode as `defaultMode`, not the ignored
+  // `engine` key (#6571).
+  assert.equal(restCall?.body?.defaultMode, "rtk");
+  assert.equal(restCall?.body?.engine, undefined);
 });

--- a/tests/unit/compression-cli-rest-fallback-6571.test.ts
+++ b/tests/unit/compression-cli-rest-fallback-6571.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Regression tests for #6571 — compression CLI REST fallback field mismatch
+ * and [object Object] table rendering.
+ *
+ * Bug 1: the REST fallbacks in bin/cli/commands/compression.mjs read/write a
+ *        nonexistent `engine` field, while GET/PUT /api/settings/compression
+ *        uses `defaultMode`. So `engine get` always reports "(default)" and
+ *        `engine set` silently no-ops.
+ * Bug 2: formatCell() in bin/cli/output.mjs renders object-valued cells as the
+ *        literal string "[object Object]" instead of readable JSON.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+type FetchOpts = { method?: string; body?: string };
+
+function makeResp(data: unknown, status = 200) {
+  const obj = {
+    ok: status < 400,
+    status,
+    exitCode: status < 400 ? 0 : 1,
+    json: () => Promise.resolve(data),
+    text: () => Promise.resolve(JSON.stringify(data)),
+    headers: new Headers(),
+  };
+  obj.json = obj.json.bind(obj);
+  obj.text = obj.text.bind(obj);
+  return obj;
+}
+
+async function captureStdout(fn: () => Promise<void> | void): Promise<string> {
+  const chunks: string[] = [];
+  const orig = process.stdout.write.bind(process.stdout);
+  process.stdout.write = (c: string | Uint8Array) => {
+    chunks.push(typeof c === "string" ? c : c.toString());
+    return true;
+  };
+  try {
+    await fn();
+  } finally {
+    process.stdout.write = orig;
+  }
+  return chunks.join("");
+}
+
+function makeCmd(output = "json") {
+  return { optsWithGlobals: () => ({ output, quiet: output !== "table" }) };
+}
+
+// ─── Bug 1a: `compression status` REST fallback reads `defaultMode` ───────────
+test("#6571 restCompressionStatus reads defaultMode (not the nonexistent engine field)", async () => {
+  const origFetch = globalThis.fetch;
+  const mock = (url: string | URL, _opts?: FetchOpts) => {
+    const u = String(url);
+    if (u.includes("/api/mcp/tools/call")) return Promise.resolve(makeResp({}, 404)); // force REST fallback
+    if (u.includes("/api/settings/compression"))
+      return Promise.resolve(makeResp({ enabled: true, defaultMode: "stacked" }));
+    if (u.includes("/api/context/combos")) return Promise.resolve(makeResp({ combos: [] }));
+    if (u.includes("/api/context/analytics")) return Promise.resolve(makeResp(null, 404));
+    return Promise.resolve(makeResp({}));
+  };
+  globalThis.fetch = mock as unknown as typeof fetch;
+
+  const { runCompressionStatus } = await import("../../bin/cli/commands/compression.mjs");
+  const out = await captureStdout(() => runCompressionStatus({}, makeCmd()));
+
+  globalThis.fetch = origFetch;
+  const parsed = JSON.parse(out);
+  // Before the fix `engine` was `settings.engine ?? null` → always null.
+  assert.equal(parsed.engine, "stacked", `expected engine "stacked", got: ${out}`);
+});
+
+// ─── Bug 1b: `compression engine set` REST fallback PUTs `defaultMode` ────────
+test("#6571 restSetEngine PUTs defaultMode, not the ignored engine field", async () => {
+  let putBody: Record<string, unknown> | null = null;
+  const origFetch = globalThis.fetch;
+  const mock = (url: string | URL, opts?: FetchOpts) => {
+    const u = String(url);
+    if (u.includes("/api/mcp/tools/call")) return Promise.resolve(makeResp({}, 404));
+    if (u.includes("/api/settings/compression")) {
+      if (opts?.method === "PUT" && opts?.body) putBody = JSON.parse(opts.body);
+      return Promise.resolve(makeResp({ success: true }));
+    }
+    return Promise.resolve(makeResp({}));
+  };
+  globalThis.fetch = mock as unknown as typeof fetch;
+
+  const { runCompressionEngineSet } = await import("../../bin/cli/commands/compression.mjs");
+  await captureStdout(() => runCompressionEngineSet("stacked", {}, makeCmd()));
+
+  globalThis.fetch = origFetch;
+  assert.ok(putBody, "expected a PUT to /api/settings/compression");
+  assert.equal(putBody!.defaultMode, "stacked", "PUT body must carry defaultMode");
+  assert.equal(putBody!.engine, undefined, "PUT body must not carry the ignored engine field");
+});
+
+// ─── Bug 1b: caveman → "standard" translation parity with the MCP handler ────
+test("#6571 restSetEngine translates caveman → standard (defaultMode)", async () => {
+  let putBody: Record<string, unknown> | null = null;
+  const origFetch = globalThis.fetch;
+  const mock = (url: string | URL, opts?: FetchOpts) => {
+    const u = String(url);
+    if (u.includes("/api/mcp/tools/call")) return Promise.resolve(makeResp({}, 404));
+    if (u.includes("/api/settings/compression")) {
+      if (opts?.method === "PUT" && opts?.body) putBody = JSON.parse(opts.body);
+      return Promise.resolve(makeResp({ success: true }));
+    }
+    return Promise.resolve(makeResp({}));
+  };
+  globalThis.fetch = mock as unknown as typeof fetch;
+
+  const { runCompressionEngineSet } = await import("../../bin/cli/commands/compression.mjs");
+  await captureStdout(() => runCompressionEngineSet("caveman", {}, makeCmd()));
+
+  globalThis.fetch = origFetch;
+  assert.ok(putBody, "expected a PUT to /api/settings/compression");
+  assert.equal(putBody!.defaultMode, "standard", "caveman must map to defaultMode=standard");
+});
+
+// ─── Bug 2: formatCell renders objects as JSON, not "[object Object]" ─────────
+test("#6571 table output renders nested objects as JSON, not [object Object]", async () => {
+  const { emit } = await import("../../bin/cli/output.mjs");
+  const schema = [
+    { key: "name", header: "Name" },
+    { key: "settings", header: "Settings" },
+  ];
+  const out = await captureStdout(() =>
+    emit(
+      [{ name: "compression", settings: { enabled: true, defaultMode: "stacked" } }],
+      { output: "table" },
+      schema
+    )
+  );
+  assert.ok(!out.includes("[object Object]"), `object cell must not render as [object Object], got: ${out}`);
+  assert.ok(out.includes("stacked"), `object cell should show its content, got: ${out}`);
+});


### PR DESCRIPTION
## Problem

Two related bugs in the `omniroute compression` CLI, both on the **REST fallback
path** (`mcpCall()`'s `404`/`501` branch in `bin/cli/commands/compression.mjs`),
which runs on installs where `/api/mcp/tools/call` isn't mounted:

1. **`engine`/`defaultMode` field mismatch (silent no-op).** The REST fallbacks
   read and write a field called `engine`, but the settings payload from
   `GET`/`PUT /api/settings/compression` has never had an `engine` field — the
   canonical field is `defaultMode`. Result:
   - `compression engine get` always printed `(default)` even with a real mode
     (e.g. `stacked`) active, because `restCompressionStatus()` returned
     `engine: settings.engine ?? null` → always `null`.
   - `compression engine set <x>` silently no-op'd, because `restSetEngine()`
     PUT `{ engine: … }`, an unknown key the server ignores.
2. **`[object Object]` in table output.** `formatCell()` in `bin/cli/output.mjs`
   had no branch for object/array values, so nested fields (e.g. `compression
   status`'s `settings`/`combos`/`analytics`) rendered as the literal string
   `[object Object]` in default table output.

## Root cause

The CLI REST fallbacks were written against a field name (`engine`) that the
settings API never used. The MCP tool handlers already translate correctly —
`handleCompressionStatus` reports `strategy: settings.defaultMode` and
`handleSetCompressionEngine` writes `updates.defaultMode = args.engine ===
"caveman" ? "standard" : args.engine` — but the REST fallbacks never mirrored
that mapping. Separately, `formatCell()` fell through to `String(v)` for
objects, which yields `"[object Object]"`.

## Fix

- `restCompressionStatus()` now returns `engine: settings.defaultMode ?? null`,
  matching what `GET /api/settings/compression` and the MCP handler report.
- `restSetEngine()` now PUTs `{ defaultMode }` (with the same `caveman →
  "standard"` translation the MCP handler performs; `off` also clears
  `enabled`), so `engine set` actually persists.
- `formatCell()` now renders object/array values as `JSON.stringify(v)` instead
  of `[object Object]`.

Scope is surgical: `restCompressionConfigure` and the MCP tool path were left
untouched (out of scope for this issue).

## Verification

TDD — new regression test `tests/unit/compression-cli-rest-fallback-6571.test.ts`
reproduces both bugs (4 assertions), plus the pre-existing REST-fallback test
was updated to assert the corrected `defaultMode` contract.

```text
# BEFORE the fix (on the new test):
$ node --import tsx/esm --test tests/unit/compression-cli-rest-fallback-6571.test.ts
# tests 4  # pass 0  # fail 4

# AFTER the fix:
$ node --import tsx/esm --test tests/unit/compression-cli-rest-fallback-6571.test.ts
# tests 4  # pass 4  # fail 0

# Neighbouring suites (compression CLI + output rendering), all green:
$ node --import tsx/esm --test \
    tests/unit/cli-compression-commands.test.ts \
    tests/unit/cli-output.test.ts \
    tests/unit/cli-output-render-table.test.ts \
    tests/unit/compression-cli-rest-fallback-6571.test.ts
# tests 28  # pass 28  # fail 0

# ESLint (changed files): 0 errors
# typecheck:core: only the pre-existing `Cannot find module 'omniglyph'` errors
#   in open-sse/services/compression/{stats,omniglyphAdapter}.ts (untouched here).
```

## Diff summary

- `bin/cli/commands/compression.mjs` — REST fallback reads/writes `defaultMode`.
- `bin/cli/output.mjs` — `formatCell()` renders objects as JSON.
- `tests/unit/compression-cli-rest-fallback-6571.test.ts` — new regression test.
- `tests/unit/cli-compression-commands.test.ts` — updated fallback assertion to
  the corrected `defaultMode` contract.

Closes #6571.

Thanks for the precise, code-referenced report — it made the fix a one-shot.
