### PR TITLE
fix(antigravity): enforce model-scoped quota fallback

### DIFF
--- a/open-sse/services/accountFallback.ts
+++ b/open-sse/services/accountFallback.ts
@@ -638,7 +638,7 @@ export function hasPerModelQuota(
   }
   if (!provider) return false;
   if (getCanonicalLockProvider(provider) === "codex") return true;
-  if (provider === "gemini" || provider === "github") return true;
+  if (provider === "gemini" || provider === "github" || provider === "antigravity") return true;
   if (getPassthroughProviders().has(provider)) return true;
   if (isCompatibleProvider(provider)) return true;
   return false;

--- a/src/sse/services/auth.ts
+++ b/src/sse/services/auth.ts
@@ -1390,7 +1390,15 @@ export async function getProviderCredentials(
     });
 
     if (availableConnections.length === 0) {
-      const cooldownStates: CooldownInspectionState[] = connections.map((connection) => {
+      // Request-level exclusions are retry bookkeeping, not provider cooldowns.
+      // Do not let a just-failed/excluded account determine the provider-level
+      // all-rate-limited retry-after; only inspect accounts that remain relevant
+      // for this selection attempt.
+      const cooldownInspectionConnections = connections.filter(
+        (connection) => !excludedConnectionIds.has(connection.id)
+      );
+
+      const cooldownStates: CooldownInspectionState[] = cooldownInspectionConnections.map((connection) => {
         const connectionCooldownMs = parseFutureDateMs(connection.rateLimitedUntil);
         const codexScopeCooldownMs =
           provider === "codex"
@@ -1464,8 +1472,8 @@ export async function getProviderCredentials(
         log.warn(
           "AUTH",
           allBlockedByModelCooldown
-            ? `${provider} | all ${connections.length} active accounts cooling down for model ${requestedModel} (${formatRetryAfter(earliest)}) | lastErrorCode=${earliestConn?.errorCode}, lastError=${earliestConn?.lastError?.slice(0, 50)}`
-            : `${provider} | all ${connections.length} active accounts rate limited (${formatRetryAfter(earliest)}) | lastErrorCode=${earliestConn?.errorCode}, lastError=${earliestConn?.lastError?.slice(0, 50)}`
+            ? `${provider} | all ${cooldownInspectionConnections.length}/${connections.length} non-excluded active accounts cooling down for model ${requestedModel} (${formatRetryAfter(earliest)}) | excluded=${excludedConnectionIds.size} | lastErrorCode=${earliestConn?.errorCode}, lastError=${earliestConn?.lastError?.slice(0, 50)}`
+            : `${provider} | all ${cooldownInspectionConnections.length}/${connections.length} non-excluded active accounts rate limited (${formatRetryAfter(earliest)}) | excluded=${excludedConnectionIds.size} | lastErrorCode=${earliestConn?.errorCode}, lastError=${earliestConn?.lastError?.slice(0, 50)}`
         );
         return {
           allRateLimited: true,
@@ -2350,7 +2358,6 @@ export async function markAccountUnavailable(
         const scopeCooldownMs = Math.max(cooldownUntilMs(scopeRateLimitedUntil) - Date.now(), 0);
 
         await updateProviderConnection(connectionId, {
-          testStatus: "unavailable",
           lastError: errorMsg,
           errorCode: status,
           lastErrorAt: new Date().toISOString(),

--- a/src/sse/services/auth.ts
+++ b/src/sse/services/auth.ts
@@ -127,6 +127,7 @@ interface CooldownInspectionState {
   connection: ProviderConnectionView;
   connectionCooldownMs: number | null;
   codexScopeCooldownMs: number | null;
+  antigravityScopeCooldownMs: number | null;
   retryableModelCooldownMs: number | null;
 }
 
@@ -1397,6 +1398,12 @@ export async function getProviderCredentials(
                 getCodexScopeRateLimitedUntil(connection.providerSpecificData, requestedModel)
               )
             : null;
+        const antigravityScopeCooldownMs =
+          provider === "antigravity"
+            ? parseFutureDateMs(
+                getAntigravityScopeRateLimitedUntil(connection.providerSpecificData, requestedModel)
+              )
+            : null;
         const modelLockout = requestedModel
           ? getModelLockoutInfo(provider, connection.id, requestedModel)
           : null;
@@ -1411,6 +1418,7 @@ export async function getProviderCredentials(
           connection,
           connectionCooldownMs,
           codexScopeCooldownMs,
+          antigravityScopeCooldownMs,
           retryableModelCooldownMs,
         };
       });
@@ -1424,6 +1432,9 @@ export async function getProviderCredentials(
           if (state.codexScopeCooldownMs !== null) {
             candidates.push({ ms: state.codexScopeCooldownMs, connection: state.connection });
           }
+          if (state.antigravityScopeCooldownMs !== null) {
+            candidates.push({ ms: state.antigravityScopeCooldownMs, connection: state.connection });
+          }
           if (state.retryableModelCooldownMs !== null) {
             candidates.push({ ms: state.retryableModelCooldownMs, connection: state.connection });
           }
@@ -1436,7 +1447,9 @@ export async function getProviderCredentials(
         cooldownStates.length > 0 &&
         cooldownStates.every((state) => {
           const hasModelSpecificCooldown =
-            state.codexScopeCooldownMs !== null || state.retryableModelCooldownMs !== null;
+            state.codexScopeCooldownMs !== null ||
+            state.antigravityScopeCooldownMs !== null ||
+            state.retryableModelCooldownMs !== null;
           return hasModelSpecificCooldown && state.connectionCooldownMs === null;
         });
 

--- a/src/sse/services/auth.ts
+++ b/src/sse/services/auth.ts
@@ -14,7 +14,10 @@ import {
   getQuotaWindowStatus,
   isQuotaExhaustedForRequest,
 } from "@/domain/quotaCache";
-import { getQuotaScopeLabelForProvider } from "@omniroute/open-sse/services/antigravityQuotaFamily.ts";
+import {
+  getAntigravityQuotaFamily,
+  getQuotaScopeLabelForProvider,
+} from "@omniroute/open-sse/services/antigravityQuotaFamily.ts";
 import {
   isAccountUnavailable,
   getUnavailableUntil,
@@ -400,6 +403,73 @@ function isCodexScopeUnavailable(
   const until = getCodexScopeRateLimitedUntil(connection.providerSpecificData, model);
   if (!until) return false;
   return new Date(until).getTime() > Date.now();
+}
+
+function getAntigravityScopeRateLimitedUntil(
+  providerSpecificData: JsonRecord,
+  model: string | null
+): string | number | null {
+  if (!model) return null;
+  const family = getAntigravityQuotaFamily(model);
+  if (family === "other") return null;
+  const scopeMap = asRecord(providerSpecificData.antigravityScopeRateLimitedUntil);
+  const value = scopeMap[family];
+  return typeof value === "string" || typeof value === "number" ? value : null;
+}
+
+function isAntigravityScopeUnavailable(
+  connection: ProviderConnectionView,
+  model: string | null
+): boolean {
+  const until = getAntigravityScopeRateLimitedUntil(connection.providerSpecificData, model);
+  if (!until) return false;
+  const ms = cooldownUntilMs(until);
+  return Number.isFinite(ms) && ms > Date.now();
+}
+
+const ANTIGRAVITY_QUOTA_EXHAUSTED_ERROR = "Antigravity quota exhausted until cached quota reset";
+
+function antigravityQuotaResetCooldownMs(
+  connectionId: string,
+  model: string | null
+): number | null {
+  const entry = getQuotaCache(connectionId);
+  if (!entry || entry.provider !== "antigravity") return null;
+
+  const now = Date.now();
+  const modelFamily = getAntigravityQuotaFamily(model);
+  const normalizedModel = String(model || "")
+    .toLowerCase()
+    .replace(/^antigravity\//, "");
+
+  let earliestFutureResetMs = Infinity;
+
+  for (const [quotaKey, quota] of Object.entries(entry.quotas || {})) {
+    if (!quota || quota.remainingPercentage > 0 || !quota.resetAt) continue;
+
+    const resetMs = new Date(quota.resetAt).getTime();
+    if (!Number.isFinite(resetMs) || resetMs <= now) continue;
+
+    const quotaFamily = getAntigravityQuotaFamily(quotaKey);
+    const normalizedQuotaKey = quotaKey.toLowerCase().replace(/^antigravity\//, "");
+    const matchesRequestedModel =
+      !model ||
+      (modelFamily !== "other" && quotaFamily === modelFamily) ||
+      normalizedQuotaKey === normalizedModel ||
+      normalizedQuotaKey.includes(normalizedModel) ||
+      normalizedModel.includes(normalizedQuotaKey);
+
+    if (matchesRequestedModel) earliestFutureResetMs = Math.min(earliestFutureResetMs, resetMs);
+  }
+
+  if (!Number.isFinite(earliestFutureResetMs)) {
+    const resetMs =
+      entry.exhausted && entry.nextResetAt ? new Date(entry.nextResetAt).getTime() : NaN;
+    if (Number.isFinite(resetMs) && resetMs > now) earliestFutureResetMs = resetMs;
+  }
+
+  if (!Number.isFinite(earliestFutureResetMs)) return null;
+  return Math.max(earliestFutureResetMs - now, 1);
 }
 
 function getEarliestCodexScopeRateLimitedUntil(
@@ -1231,6 +1301,8 @@ export async function getProviderCredentials(
         if (!allowRateLimitedConnections && isAccountUnavailable(c.rateLimitedUntil)) return false;
         if (isTerminalConnectionStatus(c)) return false;
         if (provider === "codex" && isCodexScopeUnavailable(c, requestedModel)) return false;
+        if (provider === "antigravity" && isAntigravityScopeUnavailable(c, requestedModel))
+          return false;
         // Per-model lockout: if this specific model/family is locked on this connection, skip it
         if (requestedModel && isModelLocked(provider, c.id, requestedModel)) {
           if (
@@ -1262,6 +1334,8 @@ export async function getProviderCredentials(
       const rateLimited = isAccountUnavailable(c.rateLimitedUntil);
       const terminalStatus = isTerminalConnectionStatus(c);
       const codexScopeLimited = provider === "codex" && isCodexScopeUnavailable(c, requestedModel);
+      const antigravityScopeLimited =
+        provider === "antigravity" && isAntigravityScopeUnavailable(c, requestedModel);
       const modelLocked =
         Boolean(requestedModel) && isModelLocked(provider, c.id, requestedModel as string);
       const modelExcluded =
@@ -1291,6 +1365,17 @@ export async function getProviderCredentials(
           allowSuppressedConnections
             ? `  → ${c.id?.slice(0, 8)} | retained codex scope-limited account until ${scopeUntil} for combo live test`
             : `  → ${c.id?.slice(0, 8)} | codex scope-limited until ${scopeUntil}`
+        );
+      } else if (antigravityScopeLimited) {
+        const scopeUntil = getAntigravityScopeRateLimitedUntil(
+          c.providerSpecificData,
+          requestedModel
+        );
+        log.debug(
+          "AUTH",
+          allowSuppressedConnections
+            ? `  → ${c.id?.slice(0, 8)} | retained antigravity scope-limited account until ${scopeUntil} for combo live test`
+            : `  → ${c.id?.slice(0, 8)} | antigravity scope-limited until ${scopeUntil}`
         );
       } else if (modelLocked) {
         const lockout = getModelLockoutInfo(provider, c.id, requestedModel);
@@ -1983,6 +2068,7 @@ export async function markAccountUnavailable(
       isPerModelQuotaProvider &&
       provider &&
       provider !== "codex" &&
+      !(provider === "antigravity" && status === 429) &&
       model &&
       (status === 404 || status === 429 || status >= 500)
     ) {
@@ -2189,6 +2275,60 @@ export async function markAccountUnavailable(
       }
 
       return { shouldFallback: true, cooldownMs: scopeCooldownMs };
+    }
+
+    // T09: Antigravity per-family lockout (do not block the whole account globally).
+    if (provider === "antigravity" && status === 429 && model && conn) {
+      const family = getAntigravityQuotaFamily(model);
+      if (family !== "other") {
+        const existingScopeMap = asRecord(
+          conn.providerSpecificData.antigravityScopeRateLimitedUntil
+        );
+        const persistedScopeUntil = getAntigravityScopeRateLimitedUntil(
+          conn.providerSpecificData,
+          model
+        );
+
+        // Use the exact reset time from our quota cache if cache cooldown is available
+        const cacheCooldownMs = antigravityQuotaResetCooldownMs(connectionId, model);
+        const effectiveCooldownMs =
+          cacheCooldownMs && cacheCooldownMs > 0
+            ? cacheCooldownMs
+            : fallbackResult.quotaResetHintMs && fallbackResult.quotaResetHintMs > 0
+              ? fallbackResult.quotaResetHintMs
+              : fallbackResult.usedUpstreamRetryHint === true
+                ? cooldownMs
+                : ANTIGRAVITY_FAMILY_INFERRED_BASE_COOLDOWN_MS;
+
+        const scopeRateLimitedUntil =
+          persistedScopeUntil || getUnavailableUntil(effectiveCooldownMs);
+        const scopeCooldownMs = Math.max(cooldownUntilMs(scopeRateLimitedUntil) - Date.now(), 0);
+
+        await updateProviderConnection(connectionId, {
+          testStatus: "unavailable",
+          lastError: errorMsg,
+          errorCode: status,
+          lastErrorAt: new Date().toISOString(),
+          backoffLevel: newBackoffLevel ?? backoffLevel,
+          providerSpecificData: {
+            ...conn.providerSpecificData,
+            antigravityScopeRateLimitedUntil: {
+              ...existingScopeMap,
+              [family]: scopeRateLimitedUntil,
+            },
+          },
+        });
+
+        if (scopeCooldownMs > 0) {
+          lockModel(provider, connectionId, model, reason || "unknown", scopeCooldownMs);
+        }
+
+        if (status && errorMsg) {
+          console.error(`❌ ${provider} [${status}] (${family}): ${errorMsg}`);
+        }
+
+        return { shouldFallback: true, cooldownMs: scopeCooldownMs };
+      }
     }
 
     const baseUpdate = {

--- a/src/sse/services/auth.ts
+++ b/src/sse/services/auth.ts
@@ -12,7 +12,6 @@ import {
   DEFAULT_QUOTA_THRESHOLD_PERCENT,
   getQuotaCache,
   getQuotaWindowStatus,
-  isQuotaExhaustedForRequest,
 } from "@/domain/quotaCache";
 import {
   getAntigravityQuotaFamily,
@@ -430,47 +429,97 @@ function isAntigravityScopeUnavailable(
 
 const ANTIGRAVITY_QUOTA_EXHAUSTED_ERROR = "Antigravity quota exhausted until cached quota reset";
 
+function isAntigravityQuotaKeyForModel(quotaKey: string, model: string | null): boolean {
+  if (!model) return true;
+
+  const modelFamily = getAntigravityQuotaFamily(model);
+  const quotaFamily = getAntigravityQuotaFamily(quotaKey);
+  const normalizedModel = String(model).toLowerCase().replace(/^antigravity\//, "");
+  const normalizedQuotaKey = quotaKey.toLowerCase().replace(/^antigravity\//, "");
+
+  return (
+    (modelFamily !== "other" && quotaFamily === modelFamily) ||
+    normalizedQuotaKey === normalizedModel ||
+    normalizedQuotaKey.includes(normalizedModel) ||
+    normalizedModel.includes(normalizedQuotaKey)
+  );
+}
+
+function getAntigravityQuotaExhaustion(
+  connectionId: string,
+  model: string | null
+): { exhausted: boolean; resetAt: string | null } {
+  const entry = getQuotaCache(connectionId);
+  if (!entry || entry.provider !== "antigravity") return { exhausted: false, resetAt: null };
+
+  const now = Date.now();
+  let sawMatchingQuota = false;
+  let exhaustedMatchingQuota = false;
+  let earliestFutureResetMs = Infinity;
+
+  for (const [quotaKey, quota] of Object.entries(entry.quotas || {})) {
+    if (!quota || !isAntigravityQuotaKeyForModel(quotaKey, model)) continue;
+    sawMatchingQuota = true;
+    if (quota.remainingPercentage > 0) continue;
+
+    exhaustedMatchingQuota = true;
+    const resetMs = quota.resetAt ? new Date(quota.resetAt).getTime() : NaN;
+    if (Number.isFinite(resetMs) && resetMs > now) {
+      earliestFutureResetMs = Math.min(earliestFutureResetMs, resetMs);
+    }
+  }
+
+  if (sawMatchingQuota) {
+    return {
+      exhausted: exhaustedMatchingQuota,
+      resetAt: Number.isFinite(earliestFutureResetMs)
+        ? new Date(earliestFutureResetMs).toISOString()
+        : null,
+    };
+  }
+
+  if (entry.exhausted) {
+    const resetMs = entry.nextResetAt ? new Date(entry.nextResetAt).getTime() : NaN;
+    if (Number.isFinite(resetMs) && resetMs <= now) return { exhausted: false, resetAt: null };
+    return {
+      exhausted: true,
+      resetAt: Number.isFinite(resetMs) && resetMs > now ? new Date(resetMs).toISOString() : null,
+    };
+  }
+
+  return { exhausted: false, resetAt: null };
+}
+
+function isConnectionQuotaExhaustedForModel(
+  provider: string,
+  connectionId: string,
+  model: string | null
+): boolean {
+  if (provider === "antigravity") {
+    return getAntigravityQuotaExhaustion(connectionId, model).exhausted;
+  }
+
+  const entry = getQuotaCache(connectionId);
+  if (!entry || !entry.exhausted) return false;
+
+  const now = Date.now();
+  const resetMs = entry.nextResetAt ? new Date(entry.nextResetAt).getTime() : NaN;
+  if (Number.isFinite(resetMs) && resetMs <= now) return false;
+
+  const age = now - entry.fetchedAt;
+  if (!entry.nextResetAt && age > 5 * 60 * 1000) return false;
+
+  return true;
+}
+
 function antigravityQuotaResetCooldownMs(
   connectionId: string,
   model: string | null
 ): number | null {
-  const entry = getQuotaCache(connectionId);
-  if (!entry || entry.provider !== "antigravity") return null;
-
-  const now = Date.now();
-  const modelFamily = getAntigravityQuotaFamily(model);
-  const normalizedModel = String(model || "")
-    .toLowerCase()
-    .replace(/^antigravity\//, "");
-
-  let earliestFutureResetMs = Infinity;
-
-  for (const [quotaKey, quota] of Object.entries(entry.quotas || {})) {
-    if (!quota || quota.remainingPercentage > 0 || !quota.resetAt) continue;
-
-    const resetMs = new Date(quota.resetAt).getTime();
-    if (!Number.isFinite(resetMs) || resetMs <= now) continue;
-
-    const quotaFamily = getAntigravityQuotaFamily(quotaKey);
-    const normalizedQuotaKey = quotaKey.toLowerCase().replace(/^antigravity\//, "");
-    const matchesRequestedModel =
-      !model ||
-      (modelFamily !== "other" && quotaFamily === modelFamily) ||
-      normalizedQuotaKey === normalizedModel ||
-      normalizedQuotaKey.includes(normalizedModel) ||
-      normalizedModel.includes(normalizedQuotaKey);
-
-    if (matchesRequestedModel) earliestFutureResetMs = Math.min(earliestFutureResetMs, resetMs);
-  }
-
-  if (!Number.isFinite(earliestFutureResetMs)) {
-    const resetMs =
-      entry.exhausted && entry.nextResetAt ? new Date(entry.nextResetAt).getTime() : NaN;
-    if (Number.isFinite(resetMs) && resetMs > now) earliestFutureResetMs = resetMs;
-  }
-
-  if (!Number.isFinite(earliestFutureResetMs)) return null;
-  return Math.max(earliestFutureResetMs - now, 1);
+  const exhaustion = getAntigravityQuotaExhaustion(connectionId, model);
+  if (!exhaustion.exhausted || !exhaustion.resetAt) return null;
+  const resetMs = new Date(exhaustion.resetAt).getTime();
+  return Number.isFinite(resetMs) && resetMs > Date.now() ? Math.max(resetMs - Date.now(), 1) : null;
 }
 
 function getEarliestCodexScopeRateLimitedUntil(
@@ -729,7 +778,7 @@ function getP2CConnectionScore(
   requestedModel: string | null = null
 ): { score: number; quotaHeadroomPercent: number | null } {
   const quotaBlocked = evaluateQuotaLimitPolicy(provider, connection, requestedModel).blocked;
-  const quotaExhausted = isQuotaExhaustedForRequest(connection.id, provider, requestedModel);
+  const quotaExhausted = isConnectionQuotaExhaustedForModel(provider, connection.id, requestedModel);
   const quotaHeadroomPercent = getConnectionQuotaHeadroomPercent(
     provider,
     connection,
@@ -1301,9 +1350,14 @@ export async function getProviderCredentials(
       if (!allowSuppressedConnections) {
         if (!allowRateLimitedConnections && isAccountUnavailable(c.rateLimitedUntil)) return false;
         if (isTerminalConnectionStatus(c)) return false;
-        if (provider === "codex" && isCodexScopeUnavailable(c, requestedModel)) return false;
-        if (provider === "antigravity" && isAntigravityScopeUnavailable(c, requestedModel))
+        if (provider === "codex" && isCodexScopeUnavailable(c, requestedModel)) {
+          modelLockedCount += 1;
           return false;
+        }
+        if (provider === "antigravity" && isAntigravityScopeUnavailable(c, requestedModel)) {
+          familyLockedCount += 1;
+          return false;
+        }
         // Per-model lockout: if this specific model/family is locked on this connection, skip it
         if (requestedModel && isModelLocked(provider, c.id, requestedModel)) {
           if (
@@ -1545,10 +1599,10 @@ export async function getProviderCredentials(
 
     // Quota-aware: filter out accounts with exhausted quota for the requested scope.
     const withQuota = policyEligibleConnections.filter(
-      (c) => !isQuotaExhaustedForRequest(c.id, provider, requestedModel)
+      (c) => !isConnectionQuotaExhaustedForModel(provider, c.id, requestedModel)
     );
     const exhaustedQuota = policyEligibleConnections.filter((c) =>
-      isQuotaExhaustedForRequest(c.id, provider, requestedModel)
+      isConnectionQuotaExhaustedForModel(provider, c.id, requestedModel)
     );
 
     if (exhaustedQuota.length > 0) {
@@ -1562,6 +1616,9 @@ export async function getProviderCredentials(
       // All remaining eligible accounts are exhausted
       const earliestResetAt = getEarliestFutureDate(
         exhaustedQuota.map((c) => {
+          if (provider === "antigravity") {
+            return getAntigravityQuotaExhaustion(c.id, requestedModel).resetAt;
+          }
           const entry = getQuotaCache(c.id);
           return entry?.nextResetAt || null;
         })
@@ -2023,7 +2080,17 @@ export async function markAccountUnavailable(
     const existingCooldownMs = conn?.rateLimitedUntil
       ? cooldownUntilMs(conn.rateLimitedUntil)
       : NaN;
-    if (Number.isFinite(existingCooldownMs) && existingCooldownMs > Date.now()) {
+    const shouldBypassGlobalDuplicateGuardForAntigravityFamily429 =
+      provider === "antigravity" &&
+      status === 429 &&
+      Boolean(model) &&
+      getAntigravityQuotaFamily(model) !== "other" &&
+      Boolean(conn);
+    if (
+      Number.isFinite(existingCooldownMs) &&
+      existingCooldownMs > Date.now() &&
+      !shouldBypassGlobalDuplicateGuardForAntigravityFamily429
+    ) {
       log.info(
         "AUTH",
         `${connectionId.slice(0, 8)} already marked unavailable (until ${conn?.rateLimitedUntil}), skipping duplicate mark`

--- a/src/sse/services/auth.ts
+++ b/src/sse/services/auth.ts
@@ -2044,6 +2044,24 @@ export async function markAccountUnavailable(
       }
     }
 
+    // T09: Antigravity scope-aware lockout guard.
+    if (provider === "antigravity" && model) {
+      const scopeRateLimitedUntil = getAntigravityScopeRateLimitedUntil(
+        conn?.providerSpecificData || {},
+        model
+      );
+      if (scopeRateLimitedUntil && cooldownUntilMs(scopeRateLimitedUntil) > Date.now()) {
+        log.info(
+          "AUTH",
+          `${connectionId.slice(0, 8)} already scope-limited for family of ${model} (until ${scopeRateLimitedUntil}), skipping duplicate mark`
+        );
+        return {
+          shouldFallback: true,
+          cooldownMs: cooldownUntilMs(scopeRateLimitedUntil) - Date.now(),
+        };
+      }
+    }
+
     const effectiveProviderProfile =
       providerProfile || (provider ? await getRuntimeProviderProfile(provider) : null);
     // #4530 follow-up: the combo.ts lockout sites forward the admin-configured
@@ -2261,7 +2279,15 @@ export async function markAccountUnavailable(
       const scope = getCodexModelScope(model);
       const existingScopeMap = asRecord(conn.providerSpecificData.codexScopeRateLimitedUntil);
       const persistedScopeUntil = getCodexScopeRateLimitedUntil(conn.providerSpecificData, model);
-      const scopeRateLimitedUntil = persistedScopeUntil || getUnavailableUntil(cooldownMs);
+      const newScopeUntil = getUnavailableUntil(cooldownMs);
+
+      const scopeRateLimitedUntil =
+        persistedScopeUntil &&
+        new Date(persistedScopeUntil).getTime() > Date.now() &&
+        new Date(persistedScopeUntil).getTime() > new Date(newScopeUntil).getTime()
+          ? persistedScopeUntil
+          : newScopeUntil;
+
       const scopeCooldownMs = Math.max(new Date(scopeRateLimitedUntil).getTime() - Date.now(), 0);
 
       await updateProviderConnection(connectionId, {
@@ -2313,8 +2339,14 @@ export async function markAccountUnavailable(
                 ? cooldownMs
                 : ANTIGRAVITY_FAMILY_INFERRED_BASE_COOLDOWN_MS;
 
+        const newScopeUntil = getUnavailableUntil(effectiveCooldownMs);
         const scopeRateLimitedUntil =
-          persistedScopeUntil || getUnavailableUntil(effectiveCooldownMs);
+          persistedScopeUntil &&
+          cooldownUntilMs(persistedScopeUntil) > Date.now() &&
+          cooldownUntilMs(persistedScopeUntil) > cooldownUntilMs(newScopeUntil)
+            ? persistedScopeUntil
+            : newScopeUntil;
+
         const scopeCooldownMs = Math.max(cooldownUntilMs(scopeRateLimitedUntil) - Date.now(), 0);
 
         await updateProviderConnection(connectionId, {

--- a/tests/unit/auth-antigravity-account-retry-v2.test.ts
+++ b/tests/unit/auth-antigravity-account-retry-v2.test.ts
@@ -272,6 +272,100 @@ test("Antigravity all-rate-limited retry-after ignores request-level excluded ac
   assert.notEqual(connectionId(nonExcluded), connectionId(excluded));
 });
 
+test("Antigravity quota-aware selection skips exhausted requested Gemini model only", async () => {
+  await resetStorage();
+
+  const resetAt = new Date(Date.now() + 90 * 60 * 1000).toISOString();
+  const exhausted = await providersDb.createProviderConnection({
+    provider: "antigravity",
+    authType: "oauth",
+    email: "gemini-exhausted@example.test",
+    accessToken: "tok-gemini-exhausted",
+    isActive: true,
+    testStatus: "active",
+    priority: 1,
+  });
+  const healthy = await providersDb.createProviderConnection({
+    provider: "antigravity",
+    authType: "oauth",
+    email: "gemini-healthy@example.test",
+    accessToken: "tok-gemini-healthy",
+    isActive: true,
+    testStatus: "active",
+    priority: 2,
+  });
+
+  const exhaustedId = connectionId(exhausted);
+  const healthyId = connectionId(healthy);
+  const quotaCache = await import("../../src/domain/quotaCache.ts");
+  quotaCache.setQuotaCache(exhaustedId, "antigravity", {
+    "gemini-3.5-flash-medium": { remainingPercentage: 0, resetAt },
+    "claude-sonnet-4": { remainingPercentage: 100 },
+  });
+  quotaCache.setQuotaCache(healthyId, "antigravity", {
+    "gemini-3.5-flash-medium": { remainingPercentage: 100, resetAt },
+    "claude-sonnet-4": { remainingPercentage: 100 },
+  });
+
+  const selectedGemini = await auth.getProviderCredentials(
+    "antigravity",
+    null,
+    null,
+    "gemini-3.5-flash-medium"
+  );
+  assert.ok(selectedGemini);
+  assert.equal(selectedGemini.connectionId, healthyId);
+
+  const selectedClaude = await auth.getProviderCredentials(
+    "antigravity",
+    null,
+    [exhaustedId],
+    "claude-sonnet-4"
+  );
+  assert.ok(selectedClaude);
+  assert.equal(selectedClaude.connectionId, exhaustedId);
+});
+
+test("Antigravity 429 writes family cooldown even when generic rateLimitedUntil already exists", async () => {
+  await resetStorage();
+
+  const conn = await providersDb.createProviderConnection({
+    provider: "antigravity",
+    authType: "oauth",
+    email: "generic-cooling@example.test",
+    accessToken: "tok-generic-cooling",
+    isActive: true,
+    testStatus: "active",
+    rateLimitedUntil: String(Date.now() + 10 * 60 * 1000),
+  });
+  const connId = connectionId(conn);
+
+  const result = await auth.markAccountUnavailable(
+    connId,
+    429,
+    "RESOURCE_EXHAUSTED: Resource has been exhausted",
+    "antigravity",
+    "gemini-3.5-flash-medium"
+  );
+  const updated = await providersDb.getProviderConnectionById(connId);
+  const data = updated.providerSpecificData as any;
+
+  assert.equal(result.shouldFallback, true);
+  assert.ok(
+    data?.antigravityScopeRateLimitedUntil?.gemini,
+    "expected family cooldown to be persisted despite existing global cooldown"
+  );
+  assert.equal(updated.testStatus, "active");
+
+  const selectedGemini = await auth.getProviderCredentials(
+    "antigravity",
+    null,
+    null,
+    "gemini-3.5-flash-medium"
+  );
+  assert.ok(selectedGemini && "allRateLimited" in selectedGemini && selectedGemini.allRateLimited);
+});
+
 test("non-Antigravity 429 ignores unrelated exhausted quota cache and keeps model-only behavior", async () => {
   await resetStorage();
 

--- a/tests/unit/auth-antigravity-account-retry-v2.test.ts
+++ b/tests/unit/auth-antigravity-account-retry-v2.test.ts
@@ -197,7 +197,7 @@ test("Antigravity 429 with exhausted cached quota persists family cooldown until
     result.cooldownMs > 60 * 60 * 1000,
     `expected reset-sized cooldown, got ${result.cooldownMs}`
   );
-  assert.equal(updated.testStatus, "unavailable");
+  assert.equal(updated.testStatus, "active");
   assert.equal(updated.rateLimitedUntil, undefined);
   const specificData = updated.providerSpecificData as any;
   assert.ok(
@@ -222,6 +222,54 @@ test("Antigravity 429 with exhausted cached quota persists family cooldown until
     "claude-sonnet-4"
   );
   assert.equal(selectionClaude.connectionId, connId);
+});
+
+test("Antigravity all-rate-limited retry-after ignores request-level excluded accounts", async () => {
+  await resetStorage();
+
+  const soon = new Date(Date.now() + 30_000).toISOString();
+  const later = new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString();
+
+  const excluded = await providersDb.createProviderConnection({
+    provider: "antigravity",
+    authType: "oauth",
+    email: "excluded-cooling@example.test",
+    accessToken: "tok-excluded-cooling",
+    isActive: true,
+    testStatus: "active",
+    providerSpecificData: {
+      antigravityScopeRateLimitedUntil: { gemini: soon },
+    },
+  });
+  const nonExcluded = await providersDb.createProviderConnection({
+    provider: "antigravity",
+    authType: "oauth",
+    email: "non-excluded-cooling@example.test",
+    accessToken: "tok-non-excluded-cooling",
+    isActive: true,
+    testStatus: "active",
+    providerSpecificData: {
+      antigravityScopeRateLimitedUntil: { gemini: later },
+    },
+  });
+
+  const selection = await auth.getProviderCredentials(
+    "antigravity",
+    null,
+    null,
+    "gemini-3-pro",
+    { excludeConnectionIds: [connectionId(excluded)] }
+  );
+
+  assert.ok(selection && "allRateLimited" in selection && selection.allRateLimited);
+  assert.equal(selection.cooldownScope, "model");
+  assert.equal(selection.cooldownModel, "gemini-3-pro");
+  assert.ok(selection.retryAfter, "expected retryAfter from non-excluded cooling account");
+  assert.ok(
+    Math.abs(new Date(selection.retryAfter).getTime() - new Date(later).getTime()) < 2_000,
+    `expected retryAfter near non-excluded cooldown ${later}, got ${selection.retryAfter}`
+  );
+  assert.notEqual(connectionId(nonExcluded), connectionId(excluded));
 });
 
 test("non-Antigravity 429 ignores unrelated exhausted quota cache and keeps model-only behavior", async () => {

--- a/tests/unit/auth-antigravity-account-retry-v2.test.ts
+++ b/tests/unit/auth-antigravity-account-retry-v2.test.ts
@@ -162,3 +162,148 @@ test("Antigravity inferred Gemini family cooldown starts around 30s when no upst
   assert.equal(otherGemini.cooldownScope, "model");
   assert.equal(otherGemini.lastErrorCode, 429);
 });
+
+test("Antigravity 429 with exhausted cached quota persists family cooldown until resetAt", async () => {
+  await resetStorage();
+
+  const resetAt = new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString();
+  const conn = await providersDb.createProviderConnection({
+    provider: "antigravity",
+    authType: "oauth",
+    email: "cached-quota@example.test",
+    accessToken: "tok-cached-quota",
+    isActive: true,
+    testStatus: "active",
+  });
+  const connId = connectionId(conn);
+
+  const quotaCache = await import("../../src/domain/quotaCache.ts");
+  quotaCache.setQuotaCache(connId, "antigravity", {
+    "gemini-3-pro": { remainingPercentage: 0, resetAt },
+    "claude-sonnet-4": { remainingPercentage: 100 },
+  });
+
+  const result = await auth.markAccountUnavailable(
+    connId,
+    429,
+    "RESOURCE_EXHAUSTED: Resource has been exhausted",
+    "antigravity",
+    "gemini-3-pro"
+  );
+  const updated = await providersDb.getProviderConnectionById(connId);
+
+  assert.equal(result.shouldFallback, true);
+  assert.ok(
+    result.cooldownMs > 60 * 60 * 1000,
+    `expected reset-sized cooldown, got ${result.cooldownMs}`
+  );
+  assert.equal(updated.testStatus, "unavailable");
+  assert.equal(updated.rateLimitedUntil, undefined);
+  const specificData = updated.providerSpecificData as any;
+  assert.ok(
+    specificData?.antigravityScopeRateLimitedUntil?.gemini,
+    "expected family-scoped rateLimitedUntil"
+  );
+  assert.ok(
+    Math.abs(
+      new Date(specificData.antigravityScopeRateLimitedUntil.gemini).getTime() -
+        new Date(resetAt).getTime()
+    ) < 2_000,
+    `expected rateLimitedUntil near resetAt ${resetAt}`
+  );
+
+  const selection = await auth.getProviderCredentials("antigravity", null, null, "gemini-3-pro");
+  assert.ok(selection && "allRateLimited" in selection && selection.allRateLimited);
+
+  const selectionClaude = await auth.getProviderCredentials(
+    "antigravity",
+    null,
+    null,
+    "claude-sonnet-4"
+  );
+  assert.equal(selectionClaude.connectionId, connId);
+});
+
+test("non-Antigravity 429 ignores unrelated exhausted quota cache and keeps model-only behavior", async () => {
+  await resetStorage();
+
+  const resetAt = new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString();
+  const conn = await providersDb.createProviderConnection({
+    provider: "gemini",
+    authType: "apikey",
+    email: "gemini@example.test",
+    apiKey: "sk-gem...ache",
+    isActive: true,
+    testStatus: "active",
+  });
+  const connId = connectionId(conn);
+
+  const quotaCache = await import("../../src/domain/quotaCache.ts");
+  quotaCache.setQuotaCache(connId, "gemini", {
+    "gemini-2.5-pro": { remainingPercentage: 0, resetAt },
+  });
+
+  const result = await auth.markAccountUnavailable(
+    connId,
+    429,
+    "too many requests",
+    "gemini",
+    "gemini-2.5-pro"
+  );
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  const updated = await providersDb.getProviderConnectionById(connId);
+
+  assert.equal(result.shouldFallback, true);
+  assert.ok(result.cooldownMs > 0);
+  assert.equal(updated.testStatus, "active");
+  assert.equal(updated.rateLimitedUntil, undefined);
+  assert.equal(updated.lastErrorType, "rate_limited");
+});
+
+test("Antigravity 499 does not punish account, but prior quota-reset family cooldown persists", async () => {
+  await resetStorage();
+
+  const resetAt = new Date(Date.now() + 90 * 60 * 1000).toISOString();
+  const conn = await providersDb.createProviderConnection({
+    provider: "antigravity",
+    authType: "oauth",
+    email: "abort-after-quota@example.test",
+    accessToken: "tok-abort-after-quota",
+    isActive: true,
+    testStatus: "active",
+  });
+  const connId = connectionId(conn);
+
+  const quotaCache = await import("../../src/domain/quotaCache.ts");
+  quotaCache.setQuotaCache(connId, "antigravity", {
+    "gemini-3-pro": { remainingPercentage: 0, resetAt },
+    "claude-sonnet-4": { remainingPercentage: 100 },
+  });
+
+  await auth.markAccountUnavailable(
+    connId,
+    429,
+    "RESOURCE_EXHAUSTED: Resource has been exhausted",
+    "antigravity",
+    "gemini-3-pro"
+  );
+  const after429 = await providersDb.getProviderConnectionById(connId);
+
+  const abortResult = await auth.markAccountUnavailable(
+    connId,
+    499,
+    "client_disconnected",
+    "antigravity",
+    "gemini-3-pro"
+  );
+  const after499 = await providersDb.getProviderConnectionById(connId);
+
+  assert.equal(abortResult.shouldFallback, true);
+  assert.ok(abortResult.cooldownMs > 0);
+  const data499 = after499.providerSpecificData as any;
+  const data429 = after429.providerSpecificData as any;
+  assert.equal(
+    data499.antigravityScopeRateLimitedUntil.gemini,
+    data429.antigravityScopeRateLimitedUntil.gemini
+  );
+});

--- a/tests/unit/sse-auth.test.ts
+++ b/tests/unit/sse-auth.test.ts
@@ -1413,7 +1413,7 @@ test("markAccountUnavailable stores Antigravity family-specific cooldowns withou
 
   assert.equal(result.shouldFallback, true);
   assert.ok(result.cooldownMs > 0);
-  assert.equal(updated.testStatus, "unavailable");
+  assert.equal(updated.testStatus, "active");
   assert.equal(updated.rateLimitedUntil, undefined);
   assert.ok(updated.providerSpecificData.antigravityScopeRateLimitedUntil.gemini);
   assert.equal(selectedFlash.allRateLimited, true);

--- a/tests/unit/sse-auth.test.ts
+++ b/tests/unit/sse-auth.test.ts
@@ -1380,6 +1380,46 @@ test("markAccountUnavailable stores Codex scope-specific cooldowns without a glo
   assert.equal(normalSelected.connectionId, connection.id);
 });
 
+test("markAccountUnavailable stores Antigravity family-specific cooldowns without a global rate limit", async () => {
+  const connection = await seedConnection("antigravity", {
+    authType: "oauth",
+    name: "antigravity-scope",
+    email: "antigravity@example.com",
+    apiKey: null,
+    accessToken: "antigravity-access",
+    refreshToken: "antigravity-refresh",
+  });
+
+  const result = await auth.markAccountUnavailable(
+    connection.id,
+    429,
+    "quota reached",
+    "antigravity",
+    "gemini-3.5-flash-medium"
+  );
+  const updated = await providersDb.getProviderConnectionById(connection.id);
+  const selectedFlash = await auth.getProviderCredentials(
+    "antigravity",
+    null,
+    null,
+    "gemini-3.5-flash-medium"
+  );
+  const selectedClaude = await auth.getProviderCredentials(
+    "antigravity",
+    null,
+    null,
+    "claude-sonnet-4"
+  );
+
+  assert.equal(result.shouldFallback, true);
+  assert.ok(result.cooldownMs > 0);
+  assert.equal(updated.testStatus, "unavailable");
+  assert.equal(updated.rateLimitedUntil, undefined);
+  assert.ok(updated.providerSpecificData.antigravityScopeRateLimitedUntil.gemini);
+  assert.equal(selectedFlash.allRateLimited, true);
+  assert.equal(selectedClaude.connectionId, connection.id);
+});
+
 test("markAccountUnavailable returns without fallback on bad requests", async () => {
   const connection = await seedConnection("openai", {
     name: "bad-request-no-fallback",


### PR DESCRIPTION
## Summary

Fixes Antigravity/Gemini quota fallback behavior so exhausted Gemini-family quota does not cause repeated selection of the same Antigravity account across requests.

## Root cause

- Antigravity quota state was evaluated too broadly at account level in selection paths, so a Gemini-exhausted account could remain eligible if other model families still had quota.
- Antigravity 429 handling could be suppressed by an existing generic unavailable guard before persisting the family-scoped Gemini cooldown.
- Request-level fallback exclusions were mixed with provider-level cooldown aggregation, causing misleading retry-after/all-rate-limited decisions.
- Diagnostics under-counted persisted Antigravity family locks (`familyLocked=0`) even when a persisted scope cooldown existed.

## Changes

- Add Antigravity family/model-scoped quota exhaustion checks for selection and quota-aware filtering.
- Persist Antigravity family cooldowns for Gemini/Claude families while keeping the account active for the other family.
- Preserve immediate request fallback exclusions without treating them as provider-level cooldowns.
- Keep Antigravity family 429 from marking the whole account `unavailable`.
- Count persisted Antigravity family cooldowns in `familyLocked` diagnostics.
- Add regression tests for family 429 scoping, duplicate guard bypass, request exclusions, and model-scoped quota exhaustion.

## Verification

- Clean PR worktree targeted suites: `77/77` passed:
  - `tests/unit/auth-antigravity-account-retry-v2.test.ts`
  - `tests/unit/antigravity-429-quota-cooldown.test.ts`
  - `tests/unit/sse-auth.test.ts`
- Production standalone build was created on FriendsHost and deployed to FriendsHost and ubsrvagent.
- Live verification on ubsrvagent after deployment: a real Antigravity 429 fell back to another account and the exhausted account was not selected again in the checked window; logs showed `quota-aware: 4 with quota, skipping 1 exhausted`.
