### PR TITLE
ci(vps): VPS_ALWAYS_ON — keep the dedicated CI host up across releases

### DIFF
--- a/scripts/vps/release-runner-down.sh
+++ b/scripts/vps/release-runner-down.sh
@@ -10,6 +10,17 @@ VM_ID="${VM_ID:-113}"
 REPO="${REPO:-diegosouzapw/OmniRoute}"
 SSH="ssh -o BatchMode=yes -o ConnectTimeout=8"
 
+# 0) Always-on mode. When the repo var VPS_ALWAYS_ON=true, the VM 113 is a DEDICATED,
+# 24/7 CI host (32c/24GB, exclusive to this project) — the day-to-day quality.yml PRs
+# (PR→release/**) route to it too, not just release CI. In that mode the release MUST NOT
+# tear the VM down or flip USE_VPS_RUNNER off, or every subsequent PR would fall back to
+# ubuntu-latest until the next release. Teardown/flag-off is the LEGACY on-demand-per-release
+# model only. (Set/unset with: gh variable set VPS_ALWAYS_ON --body true|false.)
+if [ "$(gh variable get VPS_ALWAYS_ON --repo "$REPO" 2>/dev/null)" = "true" ]; then
+  echo "[release-runner] VPS_ALWAYS_ON=true — dedicated 24/7 host; leaving VM $VM_ID up and USE_VPS_RUNNER=true."
+  exit 0
+fi
+
 # 1) Volta o CI para ubuntu-latest ANTES de derrubar a VM (evita jobs presos).
 echo "[release-runner] USE_VPS_RUNNER=false (CI volta ao GitHub-hosted)."
 gh variable set USE_VPS_RUNNER --repo "$REPO" --body "false" >/dev/null 2>&1 || true


### PR DESCRIPTION
Companion to #6691. The .113 VM (32c/24GB, dedicated + 24/7) now serves the day-to-day `quality.yml` PRs, so `release-runner-down.sh` must NOT tear it down / flip `USE_VPS_RUNNER=false` at the end of a release (that's the legacy on-demand model). Gated on the new `VPS_ALWAYS_ON` repo var (set to `true`); when unset/false the old per-release up/down behavior is unchanged. Runner isolation (job-completed cleanup hook restoring the trust-store) is configured on the VM; 5 runners online.