### PR TITLE
fix(gemini): preserve chat file_data PDFs

### DIFF
--- a/open-sse/translator/helpers/geminiHelper.ts
+++ b/open-sse/translator/helpers/geminiHelper.ts
@@ -175,9 +175,25 @@ export function convertOpenAIContentToParts(content: unknown): JsonRecord[] {
         //    so PDFs sent as `input_file` reach Gemini instead of being silently dropped (#2515).
         const file = toRecord(rec.file);
         const doc = toRecord(rec.document);
-        const rawDataStr = rec.data || rec.file_data || file?.data || doc?.data;
+        const rawDataStr =
+          rec.data ||
+          rec.file_data ||
+          rec.fileData ||
+          file?.data ||
+          file?.file_data ||
+          file?.fileData ||
+          doc?.data ||
+          doc?.file_data ||
+          doc?.fileData;
         const mimeTypeFallback =
-          rec.mime_type || rec.media_type || file?.mime_type || doc?.mime_type || "application/pdf";
+          rec.mime_type ||
+          rec.mimeType ||
+          rec.media_type ||
+          file?.mime_type ||
+          file?.mimeType ||
+          doc?.mime_type ||
+          doc?.mimeType ||
+          "application/pdf";
         if (typeof rawDataStr === "string" && !rawDataStr.startsWith("http")) {
           const rawData = rawDataStr.replace(/^data:[a-zA-Z0-9/+-]+;base64,/, "");
           parts.push({

--- a/tests/unit/gemini-chat-file-data-pdf.test.ts
+++ b/tests/unit/gemini-chat-file-data-pdf.test.ts
@@ -23,8 +23,8 @@ test("convertOpenAIContentToParts handles OpenAI chat file.file_data PDFs", () =
     },
   ]) as InlineDataPart[];
 
-  const inline = parts.find((part) => part.inlineData);
-  assert.ok(inline?.inlineData, "file.file_data must produce an inlineData part");
-  assert.equal(inline.inlineData.data, "JVBERi0xLjcKJ");
-  assert.equal(inline.inlineData.mimeType, "application/pdf");
+  const inlineData = parts.find((part) => part.inlineData)?.inlineData;
+  assert.ok(inlineData, "file.file_data must produce an inlineData part");
+  assert.equal(inlineData.data, "JVBERi0xLjcKJ");
+  assert.equal(inlineData.mimeType, "application/pdf");
 });

--- a/tests/unit/gemini-chat-file-data-pdf.test.ts
+++ b/tests/unit/gemini-chat-file-data-pdf.test.ts
@@ -1,0 +1,30 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { convertOpenAIContentToParts } =
+  await import("../../open-sse/translator/helpers/geminiHelper.ts");
+
+type InlineDataPart = {
+  inlineData?: {
+    mimeType?: string;
+    data?: string;
+  };
+};
+
+test("convertOpenAIContentToParts handles OpenAI chat file.file_data PDFs", () => {
+  const parts = convertOpenAIContentToParts([
+    { type: "text", text: "Return OCR" },
+    {
+      type: "file",
+      file: {
+        filename: "invoice.pdf",
+        file_data: "data:application/pdf;base64,JVBERi0xLjcKJ",
+      },
+    },
+  ]) as InlineDataPart[];
+
+  const inline = parts.find((part) => part.inlineData);
+  assert.ok(inline?.inlineData, "file.file_data must produce an inlineData part");
+  assert.equal(inline.inlineData.data, "JVBERi0xLjcKJ");
+  assert.equal(inline.inlineData.mimeType, "application/pdf");
+});


### PR DESCRIPTION
## Summary
- Preserve nested OpenAI chat `file.file_data` PDF payloads when translating to Gemini parts
- Accept camelCase and snake_case data/mime aliases for nested file and document content
- Add a focused regression test for the OpenAI chat PDF shape

## Tests
- `DISABLE_SQLITE_AUTO_BACKUP=true node --max-old-space-size=8192 --import tsx/esm --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test tests/unit/gemini-chat-file-data-pdf.test.ts tests/unit/translator-openai-to-gemini.test.ts`
- Commit hook: Prettier, ESLint, docs sync, `check:any-budget:t11`, `check:tracked-artifacts`

## Not run
- `npm run test:unit`
- `npm run test:coverage`