### PR TITLE
fix(api): accept rtkConfig.enableRenderers on compression write schema (#6751)

### DIFF
--- a/src/shared/validation/compressionConfigSchemas.ts
+++ b/src/shared/validation/compressionConfigSchemas.ts
@@ -60,6 +60,7 @@ export const rtkConfigSchema = z
     groupingThreshold: z.number().int().min(2).max(100).optional(),
     stripCodeComments: z.boolean().optional(),
     preserveDocstrings: z.boolean().optional(),
+    enableRenderers: z.boolean().optional(),
   })
   .strict();
 

--- a/tests/unit/compression/rtk-grouping-config.test.ts
+++ b/tests/unit/compression/rtk-grouping-config.test.ts
@@ -47,6 +47,16 @@ describe("RTK grouping config persistence (R5)", () => {
     assert.equal(rtkConfigSchema.safeParse({ groupingThreshold: 1 }).success, false);
   });
 
+  it("accepts enableRenderers on the write schema (GET→PUT round-trip parity)", () => {
+    // GET returns enableRenderers, so the strict write schema must accept it too;
+    // otherwise a read→write round-trip of the config 400s. Regression guard.
+    assert.equal(rtkConfigSchema.safeParse({ enableRenderers: true }).success, true);
+    assert.equal(
+      rtkConfigSchema.safeParse({ ...DEFAULT_RTK_CONFIG }).success,
+      true
+    );
+  });
+
   it("preserves enableGrouping / groupingThreshold through a DB round-trip", async () => {
     const settings = await updateCompressionSettings({
       rtkConfig: { ...DEFAULT_RTK_CONFIG, enableGrouping: true, groupingThreshold: 7 },


### PR DESCRIPTION
## Problem
`GET /api/settings/compression` returns `rtkConfig.enableRenderers` (a real RTK config field — `open-sse/services/compression/types.ts:104`, default `false`), but the strict `rtkConfigSchema` omitted it. So a GET→PUT round-trip of the compression config 400s:
```
{ "field": "rtkConfig", "message": "Unrecognized key: \"enableRenderers\"" }
```

Fixes #6751.

## Fix
One line: add `enableRenderers: z.boolean().optional()` to `rtkConfigSchema`.

## Test
Added a schema-acceptance assertion in `tests/unit/compression/rtk-grouping-config.test.ts` (round-trip parity guard). All 3 tests in that file pass:
```
✔ accepts enableGrouping / groupingThreshold on the write schema
✔ accepts enableRenderers on the write schema (GET→PUT round-trip parity)
✔ preserves enableGrouping / groupingThreshold through a DB round-trip
```

Thanks for the great work on OmniRoute!