### PR TITLE
fix(api): accept enableRenderers in RTK compression config schema (#6703)

### DIFF
--- a/src/shared/validation/compressionConfigSchemas.ts
+++ b/src/shared/validation/compressionConfigSchemas.ts
@@ -61,6 +61,7 @@ export const rtkConfigSchema = z
     groupingThreshold: z.number().int().min(2).max(100).optional(),
     stripCodeComments: z.boolean().optional(),
     preserveDocstrings: z.boolean().optional(),
+    enableRenderers: z.boolean().optional(),
   })
   .strict();
 

--- a/tests/unit/rtk-enable-renderers-6703.test.ts
+++ b/tests/unit/rtk-enable-renderers-6703.test.ts
@@ -1,0 +1,41 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  rtkConfigSchema,
+  compressionSettingsUpdateSchema,
+} from "../../src/shared/validation/compressionConfigSchemas.ts";
+import { DEFAULT_RTK_CONFIG } from "../../open-sse/services/compression/types.ts";
+
+// Regression for #6703: rtkConfigSchema uses Zod .strict() but was missing the
+// `enableRenderers` field that DEFAULT_RTK_CONFIG (and the RTK engine's own
+// configSchema) already define. The frontend reads DEFAULT_RTK_CONFIG (which
+// carries enableRenderers), sends the full object back on save, and .strict()
+// rejects the unknown key → HTTP 400 "Unrecognized key: enableRenderers".
+// This broke PUT /api/settings/compression, POST /api/context/rtk/test, and
+// PUT /api/context/rtk/config.
+
+describe("RTK config schema — enableRenderers (#6703)", () => {
+  it("accepts enableRenderers on the strict rtkConfigSchema", () => {
+    assert.equal(rtkConfigSchema.safeParse({ enableRenderers: false }).success, true);
+    assert.equal(rtkConfigSchema.safeParse({ enableRenderers: true }).success, true);
+  });
+
+  it("accepts the full DEFAULT_RTK_CONFIG without stripping fields", () => {
+    const result = rtkConfigSchema.safeParse(DEFAULT_RTK_CONFIG);
+    assert.equal(result.success, true, JSON.stringify(result.error?.issues));
+    assert.equal(result.data.enableRenderers, false);
+  });
+
+  it("rejects a genuinely unknown key (strict mode still enforced)", () => {
+    assert.equal(rtkConfigSchema.safeParse({ totallyBogusKey: true }).success, false);
+  });
+
+  it("accepts rtkConfig with enableRenderers through the settings-update schema", () => {
+    // Mirrors the PUT /api/settings/compression payload from the bug report.
+    const result = compressionSettingsUpdateSchema.safeParse({
+      rtkConfig: { ...DEFAULT_RTK_CONFIG, enableRenderers: false },
+    });
+    assert.equal(result.success, true, JSON.stringify(result.error?.issues));
+  });
+});


### PR DESCRIPTION
## Problem

Saving compression settings in the Dashboard (or calling the RTK config/test APIs)
fails with an HTTP 400 validation error:

```json
{"error":{"message":"Invalid request","details":[{"field":"rtkConfig","message":"Unrecognized key: \"enableRenderers\""}]}}
```

This blocks:

- `PUT /api/settings/compression` (Dashboard "Save")
- `POST /api/context/rtk/test`
- `PUT /api/context/rtk/config`

## Root cause

`rtkConfigSchema` in `src/shared/validation/compressionConfigSchemas.ts` is declared
with Zod `.strict()`, but it was missing the `enableRenderers` field — even though that
field is part of the RTK config everywhere else:

- `open-sse/services/compression/types.ts` → `DEFAULT_RTK_CONFIG` has `enableRenderers: false` ✅
- `open-sse/services/compression/engines/rtk/configSchema.ts` → `RTK_SCHEMA` has `enableRenderers` ✅
- `src/shared/validation/compressionConfigSchemas.ts` → `rtkConfigSchema` **missing** ❌

The flow that triggers it:

1. The frontend reads settings and gets `enableRenderers: false` from `DEFAULT_RTK_CONFIG`.
2. The user changes any compression setting and clicks Save.
3. The frontend echoes the full config back — including `enableRenderers`.
4. `.strict()` sees the unknown key and rejects the whole request with 400.

## Fix

Add `enableRenderers: z.boolean().optional()` to `rtkConfigSchema`, right after
`preserveDocstrings` — mirroring the type in `DEFAULT_RTK_CONFIG` / `RTK_SCHEMA`.
`.strict()` is preserved, so genuinely unknown keys are still rejected.

```diff
     stripCodeComments: z.boolean().optional(),
     preserveDocstrings: z.boolean().optional(),
+    enableRenderers: z.boolean().optional(),
   })
   .strict();
```

## Verification

New regression test `tests/unit/rtk-enable-renderers-6703.test.ts`.

Before the fix (reproduces the reported error):

```
$ node --import tsx/esm --test tests/unit/rtk-enable-renderers-6703.test.ts
not ok 1 - accepts enableRenderers on the strict rtkConfigSchema
    [{"code":"unrecognized_keys","keys":["enableRenderers"], ... "message":"Unrecognized key: \"enableRenderers\""}]
not ok 4 - accepts rtkConfig with enableRenderers through the settings-update schema
# tests 4 | # pass 1 | # fail 3
```

After the fix:

```
$ node --import tsx/esm --test tests/unit/rtk-enable-renderers-6703.test.ts
# tests 4 | # pass 4 | # fail 0

$ npx eslint --suppressions-location config/quality/eslint-suppressions.json \
    src/shared/validation/compressionConfigSchemas.ts tests/unit/rtk-enable-renderers-6703.test.ts
# exit 0

$ npm run typecheck:core
# no new errors on the changed file (2 pre-existing `Cannot find module 'omniglyph'`
# errors in stats.ts / omniglyphAdapter.ts are an unrelated local-env issue — those
# files are untouched by this change)
```

The test also asserts `.strict()` still rejects a genuinely unknown key, so the anti-typo
guard is unchanged.

## Diff summary

- `src/shared/validation/compressionConfigSchemas.ts` — add `enableRenderers` (+1 line)
- `tests/unit/rtk-enable-renderers-6703.test.ts` — new regression test (+41 lines)

Closes #6703.

Thanks for the precise root-cause report — the field-by-field comparison made this a one-line fix.
