### PR TITLE
fix(api): raise provider apiKey cap for cookie-based web providers (#6715)

### DIFF
--- a/src/shared/validation/schemas/provider.ts
+++ b/src/shared/validation/schemas/provider.ts
@@ -41,10 +41,21 @@ const providerNodeIconUrlSchema = z
   })
   .optional();
 
+// #6715: the `apiKey` field is reused as the raw `Cookie:` header value for
+// cookie-based web providers (Gemini Business, Copilot M365, ChatGPT Web,
+// Claude Web, …). Real multi-cookie session headers (many `__Secure-*` entries,
+// large session tokens) legitimately exceed the old 10,000-char cap, so saving
+// a cookie that the provider's own `validate` check (validateProviderApiKeySchema,
+// uncapped) had already accepted failed with HTTP 400 "Too big …<=10000". Raised
+// to a still-bounded ceiling — well under the 10 MB default request-body limit and
+// the unconstrained SQLite TEXT column — so garbage input is still rejected.
+// Same fix shape as #6562 (priority cap raised to 100_000).
+export const MAX_PROVIDER_CREDENTIAL_LENGTH = 100_000;
+
 export const createProviderSchema = z
   .object({
     provider: z.string().min(1).max(100),
-    apiKey: z.string().max(10000).optional(),
+    apiKey: z.string().max(MAX_PROVIDER_CREDENTIAL_LENGTH).optional(),
     name: z.string().min(1).max(200),
     priority: z.number().int().min(1).max(100).optional(),
     globalPriority: z.number().int().min(1).max(100).nullable().optional(),
@@ -91,7 +102,7 @@ export const bulkCreateProviderSchema = z
       .array(
         z.object({
           name: z.string().min(1).max(200),
-          apiKey: z.string().min(1).max(10000),
+          apiKey: z.string().min(1).max(MAX_PROVIDER_CREDENTIAL_LENGTH),
           // Per-key account id — required for cloudflare-ai (enforced in superRefine below).
           accountId: z.string().min(1).max(200).optional(),
         })
@@ -304,7 +315,7 @@ export const updateProviderConnectionSchema = z
     globalPriority: z.union([z.coerce.number().int().min(1).max(100_000), z.null()]).optional(),
     defaultModel: z.union([z.string().max(200), z.null()]).optional(),
     isActive: z.boolean().optional(),
-    apiKey: z.string().max(10000).optional(),
+    apiKey: z.string().max(MAX_PROVIDER_CREDENTIAL_LENGTH).optional(),
     testStatus: z.string().max(50).optional(),
     lastError: z.union([z.string(), z.null()]).optional(),
     lastErrorAt: z.union([z.string(), z.null()]).optional(),

--- a/tests/unit/provider-apikey-cap-6715.test.ts
+++ b/tests/unit/provider-apikey-cap-6715.test.ts
@@ -1,0 +1,65 @@
+// Regression guard for #6715 — the provider connection `apiKey` field was
+// hard-capped at 10,000 chars in the Zod save schemas:
+//   src/shared/validation/schemas/provider.ts
+//     createProviderSchema            (add connection)
+//     bulkCreateProviderSchema        (bulk import)
+//     updateProviderConnectionSchema  (edit connection)
+//
+// That `apiKey` field is reused as the raw `Cookie:` header value for cookie-
+// based web providers (Gemini Business, Copilot M365, ChatGPT Web, Claude Web,
+// …). Real multi-cookie session headers (many `__Secure-*` entries, large
+// session tokens) legitimately exceed 10,000 chars. The provider's own
+// `validate` schema (validateProviderApiKeySchema) has NO cap, so the cookie
+// validated as OK — then `save` rejected it with HTTP 400
+// "Too big: expected string to have <=10000 characters".
+//
+// Fix: raise the ceiling to MAX_PROVIDER_CREDENTIAL_LENGTH (100_000) — still a
+// sane anti-abuse bound (well under the 10 MB default request-body limit and
+// unconstrained SQLite TEXT storage), just wide enough for real cookie headers.
+// Same fix shape as #6562 (priority cap raised to 100_000).
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { createProviderSchema, bulkCreateProviderSchema, updateProviderConnectionSchema } =
+  await import("../../src/shared/validation/schemas.ts");
+
+// A realistic large cookie-header value: > 10_000 chars, < the new 100_000 cap.
+const LARGE_COOKIE = "__Secure-session=" + "a".repeat(20_000);
+// Beyond the new ceiling — must still be rejected (anti-abuse bound preserved).
+const OVERSIZE_COOKIE = "x".repeat(100_001);
+
+test("createProviderSchema accepts a >10000-char cookie apiKey (#6715)", () => {
+  const result = createProviderSchema.safeParse({
+    provider: "gemini-business",
+    name: "Gemini Business (cookie)",
+    apiKey: LARGE_COOKIE,
+  });
+  assert.equal(result.success, true, JSON.stringify(result.error?.issues));
+});
+
+test("bulkCreateProviderSchema accepts a >10000-char cookie apiKey (#6715)", () => {
+  const result = bulkCreateProviderSchema.safeParse({
+    provider: "gemini-business",
+    entries: [{ name: "cookie-1", apiKey: LARGE_COOKIE }],
+  });
+  assert.equal(result.success, true, JSON.stringify(result.error?.issues));
+});
+
+test("updateProviderConnectionSchema accepts a >10000-char cookie apiKey (#6715)", () => {
+  const result = updateProviderConnectionSchema.safeParse({ apiKey: LARGE_COOKIE });
+  assert.equal(result.success, true, JSON.stringify(result.error?.issues));
+});
+
+test("createProviderSchema still rejects an oversize apiKey past the new ceiling (control)", () => {
+  const result = createProviderSchema.safeParse({
+    provider: "gemini-business",
+    name: "too big",
+    apiKey: OVERSIZE_COOKIE,
+  });
+  assert.equal(result.success, false);
+});
+
+test("updateProviderConnectionSchema still rejects an oversize apiKey past the new ceiling (control)", () => {
+  const result = updateProviderConnectionSchema.safeParse({ apiKey: OVERSIZE_COOKIE });
+  assert.equal(result.success, false);
+});


### PR DESCRIPTION
## Problem

The provider connection `apiKey` field is hard-capped at 10,000 characters in the Zod
save schemas. That field is reused as the raw `Cookie:` header value for cookie-based web
providers (Gemini Business, Copilot M365, ChatGPT Web, Claude Web, …), whose legitimate
multi-cookie session headers (many `__Secure-*` entries, large session tokens) can exceed
10,000 chars.

Repro (reported via the support mesh):

1. Obtain a valid session cookie for a cookie-based provider.
2. The provider's own **validate** check reports the cookie as OK.
3. On **save**, the request is rejected with HTTP 400:
   ```
   Too big: expected string to have <=10000 characters
   ```

## Root cause

`src/shared/validation/schemas/provider.ts` caps `apiKey` at `max(10000)` in the three
save schemas, while the **validate** schema does not cap it at all — so a cookie validates
fine and then fails on save:

| Schema | `apiKey` cap | Path |
| --- | --- | --- |
| `validateProviderApiKeySchema` | none (`z.string().trim().optional()`) | validate → passes |
| `createProviderSchema` | `max(10000)` | add connection → **400** |
| `bulkCreateProviderSchema` | `max(10000)` | bulk import → **400** |
| `updateProviderConnectionSchema` | `max(10000)` | edit connection → **400** |

## Fix

Introduce `MAX_PROVIDER_CREDENTIAL_LENGTH = 100_000` and use it for all three `apiKey`
caps. The ceiling is still bounded (garbage input is rejected) but wide enough for real
cookie headers:

- Well under the default request-body limit (10 MB — `src/shared/constants/bodySize.ts`).
- The `api_key` column is SQLite `TEXT`, which has no practical length constraint.

This mirrors the existing #6562 fix, where the `priority` cap was raised from `max(100)`
to `max(100_000)` for exactly the same "schema cap rejects a legitimate value" class of bug.

```diff
+export const MAX_PROVIDER_CREDENTIAL_LENGTH = 100_000;
 ...
-    apiKey: z.string().max(10000).optional(),          // createProviderSchema
+    apiKey: z.string().max(MAX_PROVIDER_CREDENTIAL_LENGTH).optional(),
-          apiKey: z.string().min(1).max(10000),         // bulkCreateProviderSchema
+          apiKey: z.string().min(1).max(MAX_PROVIDER_CREDENTIAL_LENGTH),
-    apiKey: z.string().max(10000).optional(),          // updateProviderConnectionSchema
+    apiKey: z.string().max(MAX_PROVIDER_CREDENTIAL_LENGTH).optional(),
```

## Verification

New regression test `tests/unit/provider-apikey-cap-6715.test.ts` — asserts a 20,000-char
cookie is accepted by all three save schemas, and that a value past the new ceiling is
still rejected (anti-abuse bound preserved).

Before the fix (reproduces the reported error):

```
$ node --import tsx/esm --test tests/unit/provider-apikey-cap-6715.test.ts
not ok 1 - createProviderSchema accepts a >10000-char cookie apiKey (#6715)
    [{"code":"too_big","maximum":10000, ... "message":"Too big: expected string to have <=10000 characters"}]
not ok 2 - bulkCreateProviderSchema accepts a >10000-char cookie apiKey (#6715)
not ok 3 - updateProviderConnectionSchema accepts a >10000-char cookie apiKey (#6715)
# tests 5 | # pass 2 | # fail 3
```

After the fix:

```
$ node --import tsx/esm --test tests/unit/provider-apikey-cap-6715.test.ts
# tests 5 | # pass 5 | # fail 0

$ node --import tsx/esm --test tests/unit/provider-route-schemas.test.ts \
    tests/unit/modular-schemas.test.ts tests/unit/codex-connection-edit-6562.test.ts
# tests 9 | # pass 9 | # fail 0

$ npx eslint --suppressions-location config/quality/eslint-suppressions.json \
    src/shared/validation/schemas/provider.ts tests/unit/provider-apikey-cap-6715.test.ts
# exit 0

$ npm run typecheck:core
# no new errors on the changed file (2 pre-existing `Cannot find module 'omniglyph'`
# errors in stats.ts / omniglyphAdapter.ts are an unrelated local-env issue — those
# files are untouched by this change)
```

## Diff summary

- `src/shared/validation/schemas/provider.ts` — add `MAX_PROVIDER_CREDENTIAL_LENGTH` and
  use it for the 3 `apiKey` caps (create / bulk / update).
- `tests/unit/provider-apikey-cap-6715.test.ts` — new regression test.

Closes #6715.

Thanks for the thorough report — the file/line references and the validate-vs-save
distinction made the root cause unambiguous.
