### PR TITLE
fix(i18n): translate hardcoded Portuguese dashboard strings to English (#6761, #6768)

### DIFF
--- a/changelog.d/fixes/6769-i18n-translate-pt-dashboard.md
+++ b/changelog.d/fixes/6769-i18n-translate-pt-dashboard.md
@@ -1,0 +1,1 @@
+- **fix(i18n): translate hardcoded Portuguese dashboard strings to English (#6761, #6768)** (#6769 — thanks @chirag127).

--- a/src/app/(dashboard)/dashboard/compression/studio/CompareView.tsx
+++ b/src/app/(dashboard)/dashboard/compression/studio/CompareView.tsx
@@ -115,7 +115,7 @@ export function CompareView({ text }: CompareViewProps) {
       </div>
       <table className="w-full text-xs">
         <thead>
-          <tr className="text-left opacity-60"><th>Engine</th><th>Savings</th><th>Retenção</th><th>Out tok</th><th>Fidelidade</th></tr>
+          <tr className="text-left opacity-60"><th>Engine</th><th>Savings</th><th>Retention</th><th>Out tok</th><th>Fidelity</th></tr>
         </thead>
         <tbody>
           {rows.map((r) => {

--- a/src/app/(dashboard)/dashboard/compression/studio/PlaygroundInput.tsx
+++ b/src/app/(dashboard)/dashboard/compression/studio/PlaygroundInput.tsx
@@ -20,7 +20,7 @@ export function PlaygroundInput({ text, onText, active, onToggleActive, onRun, l
       </label>
       <label className="flex items-center gap-2 text-sm">
         <input type="checkbox" data-testid="risk-toggle" checked={riskGate} onChange={onToggleRisk} />
-        Proteger conteúdo sensível (risk-gate)
+        Protect sensitive content (risk-gate)
       </label>
       <label className="flex items-center gap-1 text-xs">
         <input type="checkbox" data-testid="quantum-toggle" checked={quantumLock} onChange={onToggleQuantum} />

--- a/src/app/(dashboard)/dashboard/context/combos/CompressionHub.tsx
+++ b/src/app/(dashboard)/dashboard/context/combos/CompressionHub.tsx
@@ -248,15 +248,14 @@ export default function CompressionHub() {
         </div>
       </div>
 
-      {/* ── Compressão delegada ao provedor ── */}
+      {/* ── Provider-delegated compression ── */}
       <div className="flex flex-col gap-3">
-        <h2 className="text-sm font-semibold text-text-main">Compressão delegada ao provedor</h2>
+        <h2 className="text-sm font-semibold text-text-main">Provider-delegated compression</h2>
         <div className="flex items-center gap-3 rounded-lg border border-border bg-bg p-4">
           <div className="min-w-0 flex-1">
             <p className="text-sm font-semibold text-text-main">Context Editing (Claude)</p>
             <p className="text-xs text-text-muted">
-              Deixa o próprio provedor limpar blocos antigos de tool-use no servidor, sem reescrever
-              a mensagem.
+              Lets the provider clear old tool-use blocks server-side, without rewriting the message.
             </p>
           </div>
           <Toggle
@@ -270,9 +269,7 @@ export default function CompressionHub() {
         <div className="flex items-start gap-2 rounded-lg border border-amber-500/40 bg-amber-500/5 px-3 py-2 text-xs text-amber-500">
           <span className="material-symbols-outlined text-[16px]">info</span>
           <span>
-            Hoje disponível apenas para Claude (Anthropic). É um modo delegado: o próprio provedor
-            limpa blocos antigos de tool-use no servidor — não reescrevemos a mensagem. Não afeta
-            outros provedores.
+            Currently available for Claude (Anthropic) only. It is a delegated mode: the provider clears old tool-use blocks server-side — we do not rewrite the message. Does not affect other providers.
           </span>
         </div>
       </div>

--- a/src/app/(dashboard)/dashboard/translator/components/advanced/CompressionPreviewAccordion.tsx
+++ b/src/app/(dashboard)/dashboard/translator/components/advanced/CompressionPreviewAccordion.tsx
@@ -176,7 +176,7 @@ function CompressionPreviewContent({ inputContent = "" }: { inputContent?: strin
 
           {compressionResult.techniquesUsed.length > 0 && (
             <div className="text-xs text-text-muted">
-              <span className="font-semibold">{t("techniques") || "Técnicas:"}</span>{" "}
+              <span className="font-semibold">{t("techniques") || "Techniques:"}</span>{" "}
               {compressionResult.techniquesUsed.join(", ")}
             </div>
           )}

--- a/tests/unit/i18n-hardcoded-pt-dashboard-6761.test.ts
+++ b/tests/unit/i18n-hardcoded-pt-dashboard-6761.test.ts
@@ -1,0 +1,44 @@
+// ABOUTME: Guard test — the 4 dashboard files translated in #6761/#6768 must stay free of
+// ABOUTME: hardcoded Portuguese UI strings (regression guard for the i18n cleanup).
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+// Files cleaned of hardcoded Portuguese in #6769 (issues #6761, #6768).
+const FILES = [
+  "src/app/(dashboard)/dashboard/compression/studio/CompareView.tsx",
+  "src/app/(dashboard)/dashboard/compression/studio/PlaygroundInput.tsx",
+  "src/app/(dashboard)/dashboard/context/combos/CompressionHub.tsx",
+  "src/app/(dashboard)/dashboard/translator/components/advanced/CompressionPreviewAccordion.tsx",
+];
+
+// Portuguese-only words that appeared as hardcoded UI copy before the fix.
+// Distinct from English + from shared tech terms, so a hit means real PT regression.
+const PT_MARKERS = [
+  "Retenção",
+  "Fidelidade",
+  "Compressão",
+  "Proteger conteúdo",
+  "delegada ao provedor",
+  "Deixa o próprio provedor",
+  "Hoje disponível apenas",
+  "Técnicas:",
+  "Não afeta",
+  "reescrevemos",
+];
+
+for (const rel of FILES) {
+  test(`no hardcoded Portuguese in ${rel}`, () => {
+    const src = readFileSync(join(repoRoot, rel), "utf8");
+    const hits = PT_MARKERS.filter((m) => src.includes(m));
+    assert.deepEqual(
+      hits,
+      [],
+      `Hardcoded Portuguese found in ${rel}: ${hits.join(", ")} — translate to English or route through t().`
+    );
+  });
+}


### PR DESCRIPTION
## Problem
Four dashboard components ship raw Portuguese literals that render regardless of the EN locale (no `tr()`/`t()` wrapper on the leaked strings).

Fixes #6761 and #6768.

## Changes (7 insertions, 10 deletions across 4 files)
| File | Before | After |
|---|---|---|
| `CompressionHub.tsx` | 'Compressão delegada ao provedor' + Context Editing blurb (2 paragraphs) | 'Provider-delegated compression' + EN blurb |
| `compression/studio/PlaygroundInput.tsx` | 'Proteger conteúdo sensível (risk-gate)' | 'Protect sensitive content (risk-gate)' |
| `compression/studio/CompareView.tsx` | `<th>Retenção</th>` / `<th>Fidelidade</th>` | 'Retention' / 'Fidelity' |
| `translator/…/CompressionPreviewAccordion.tsx` | `t("techniques") || "Técnicas:"` | `t("techniques") || "Techniques:"` |

## Notes
- Pure string swap, no behavior change.
- Matches each file's existing style (these were raw literals, not i18n keys — kept them raw, just English). If you'd prefer them routed through the i18n layer, happy to follow up.
- Other files matched a non-ASCII grep but are legitimate (regexes like `/\bgr[aá]tis\b/`, `tr()` fallbacks) — left untouched.

Thanks for the great work on OmniRoute!