### PR TITLE
chore(cursor): add Grok 4.5 effort/fast model IDs

### DIFF
--- a/changelog.d/features/6774-cursor-grok-4-5-effort-fast.md
+++ b/changelog.d/features/6774-cursor-grok-4-5-effort-fast.md
@@ -1,0 +1,1 @@
+- **chore(cursor): add Grok 4.5 effort/fast model IDs** (#6774 — thanks @andrewmunsell).

--- a/open-sse/config/providers/registry/cursor/index.ts
+++ b/open-sse/config/providers/registry/cursor/index.ts
@@ -106,6 +106,13 @@ export const cursorProvider: RegistryEntry = {
     //
     { id: "grok-4.3", name: "Grok 4.3" },
     //
+    { id: "grok-4.5-medium", name: "Grok 4.5 Medium" },
+    { id: "grok-4.5-fast-medium", name: "Grok 4.5 Fast Medium" },
+    { id: "grok-4.5-high", name: "Grok 4.5 High" },
+    { id: "grok-4.5-fast-high", name: "Grok 4.5 Fast High" },
+    { id: "grok-4.5-xhigh", name: "Grok 4.5 XHigh" },
+    { id: "grok-4.5-fast-xhigh", name: "Grok 4.5 Fast XHigh" },
+    //
     { id: "kimi-k2.5", name: "Kimi K2.5" },
   ],
 };

--- a/tests/unit/cursor-agent-models.test.ts
+++ b/tests/unit/cursor-agent-models.test.ts
@@ -39,4 +39,9 @@ test("humanizeCursorModelId pretty-prints common patterns", () => {
   assert.equal(humanizeCursorModelId("kimi-k2.5"), "Kimi K2.5");
   assert.equal(humanizeCursorModelId("gemini-3.1-pro"), "Gemini 3.1 Pro");
   assert.equal(humanizeCursorModelId("claude-4-sonnet-thinking"), "Claude 4 Sonnet Thinking");
+  // Grok 4.5 uses infix -fast- (unlike GPT's trailing -fast)
+  assert.equal(humanizeCursorModelId("grok-4.5-medium"), "Grok 4.5 Medium");
+  assert.equal(humanizeCursorModelId("grok-4.5-fast-medium"), "Grok 4.5 Fast Medium");
+  assert.equal(humanizeCursorModelId("grok-4.5-xhigh"), "Grok 4.5 XHigh");
+  assert.equal(humanizeCursorModelId("grok-4.5-fast-xhigh"), "Grok 4.5 Fast XHigh");
 });


### PR DESCRIPTION
## Summary

- Adds Grok 4.5 medium, high, xhigh (and fast variants) to the Cursor model manifest

## Validation

- [x] `npm run lint`
- [x] Manually ran `npm run dev` and used the Grok 4.5 models
