### PR TITLE
ci(quality): shard unit fast-path 2→4 (halves the heaviest job)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -130,15 +130,17 @@ jobs:
       - run: npm run test:vitest
 
   fast-unit:
-    name: Unit Tests fast-path (${{ matrix.shard }}/2)
+    name: Unit Tests fast-path (${{ matrix.shard }}/4)
     # Dynamic runner — see fast-gates (own-origin + flag; fork/unset → ubuntu-latest).
-    # This is the heaviest fast-path job (~9min on ubuntu-latest); the 32-core VPS
-    # cuts it to ~2-3min when the flag is on.
+    # This is the heaviest fast-path job; 4-way sharding (was 2) halves the critical
+    # path again (~8.5min → ~4.5min on ubuntu-latest; ~2min on the 8-slot runner box).
+    # Node's native --test-shard=N/total takes any denominator — only this matrix and
+    # the TEST_SHARD env below encode the shard count.
     runs-on: ${{ (vars.USE_VPS_RUNNER == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)) && fromJSON('["self-hosted","omni-release"]') || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2]
+        shard: [1, 2, 3, 4]
     env:
       JWT_SECRET: ci-lint-secret-with-sufficient-length-for-validation
       API_KEY_SECRET: ci-lint-api-key-secret-long
@@ -157,7 +159,7 @@ jobs:
       # silenciosamente não rodavam no fast path) e o setupPolyfill não era importado.
       - run: npm run test:unit:ci:shard
         env:
-          TEST_SHARD: ${{ matrix.shard }}/2
+          TEST_SHARD: ${{ matrix.shard }}/4
 
   # ── Pacote 4 (plano mestre testes+CI, aprovado 2026-07-04) ─────────────────────────
   # No-new-warnings por PR via ESLint bulk suppressions nativo (>=9.24). O baseline


### PR DESCRIPTION
## Summary

The \`fast-unit\` job is the critical path of every PR run (~8.5min measured on the last 3 green runs). Node's native \`--test-shard=N/total\` accepts any denominator, so this bumps the matrix from 2 to 4 shards:

- \`ubuntu-latest\` (fork PRs): ~8.5min → ~4.5min wall per run
- self-hosted pool (own-origin, 8 slots since today): ~4min → ~2min

## Context

Part of the merge-storm throughput work (2026-07-09): with ~10 PRs queued into \`release/v3.8.47\`, the unit-shard wall time dominates every CI round-trip. Only the matrix and the \`TEST_SHARD\` env encode the shard count — \`test:unit:ci:shard\` passes it straight to \`--test-shard\`.

## Validation

- \`--test-shard=3/4\` executed locally against a test subset — runner accepts the 4-denominator and runs the sharded subset green.
- No test-file changes; pure CI matrix change (workflow-only, no production code → no new tests per PR rule).