### PR TITLE
fix(providers): ensure DeepSeek Web SSE emits [DONE] after FINISHED

### DIFF
--- a/changelog.d/fixes/6791-deepseek-web-done-after-finished.md
+++ b/changelog.d/fixes/6791-deepseek-web-done-after-finished.md
@@ -1,0 +1,1 @@
+- **fix(providers): ensure DeepSeek Web SSE emits [DONE] after FINISHED** (#6791 — thanks @Pitchfork-and-Torch).

--- a/open-sse/executors/deepseek-web-done-terminator.ts
+++ b/open-sse/executors/deepseek-web-done-terminator.ts
@@ -1,0 +1,68 @@
+// ── DeepSeek Web SSE "done terminator" helpers ──────────────────────────
+//
+// Extracted from deepseek-web.ts (frozen line-count) so the drain/guard
+// state machine used to close the OpenAI-compatible SSE after DeepSeek's
+// `response/status=FINISHED` event can grow without touching the frozen
+// file. See #6777: upstreams that leave the HTTP body open hang OpenAI SDK
+// clients that wait for `data: [DONE]` after `finish_reason: stop`.
+
+/** How long to wait after DeepSeek `response/status=FINISHED` for trailing
+ * search_results before closing the OpenAI-compatible SSE. */
+export const DEEPSEEK_FINISHED_DRAIN_MS = 750;
+
+/** Wraps a stream-finishing callback so it runs at most once and never
+ * throws past a controller that the client already cancelled/closed. */
+export function createFinishOnceGuard(finish: () => void): {
+  finishOnce: () => void;
+  hasFinished: () => boolean;
+} {
+  let streamFinished = false;
+  return {
+    finishOnce: () => {
+      if (streamFinished) return;
+      streamFinished = true;
+      try {
+        finish();
+      } catch {
+        // Controller may already be closed if the client cancelled.
+      }
+    },
+    hasFinished: () => streamFinished,
+  };
+}
+
+/** Schedules `finishStream` after a short drain window following
+ * `response/status=FINISHED`, so late `search_results` payloads still get
+ * captured, while guaranteeing the stream always closes even if the
+ * upstream body stays open past that window. */
+export function createFinishedDrainScheduler(
+  finishStream: () => void,
+  drainMs: number = DEEPSEEK_FINISHED_DRAIN_MS
+): {
+  scheduleFinishAfterDrain: () => void;
+  clearFinishedDrain: () => void;
+  isDrainPending: () => boolean;
+} {
+  let finishedDrainTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const clearFinishedDrain = () => {
+    if (finishedDrainTimer) {
+      clearTimeout(finishedDrainTimer);
+      finishedDrainTimer = null;
+    }
+  };
+
+  const scheduleFinishAfterDrain = () => {
+    clearFinishedDrain();
+    finishedDrainTimer = setTimeout(() => {
+      finishedDrainTimer = null;
+      finishStream();
+    }, drainMs);
+  };
+
+  return {
+    scheduleFinishAfterDrain,
+    clearFinishedDrain,
+    isDrainPending: () => finishedDrainTimer !== null,
+  };
+}

--- a/open-sse/executors/deepseek-web.ts
+++ b/open-sse/executors/deepseek-web.ts
@@ -160,6 +160,12 @@ async function solvePow(challenge: PowChallenge): Promise<string> {
 
 // ── SSE Transform (DeepSeek → OpenAI) ───────────────────────────────────
 
+/** How long to wait after DeepSeek `response/status=FINISHED` for trailing
+ * search_results before closing the OpenAI-compatible SSE. Without this,
+ * upstreams that leave the HTTP body open hang OpenAI SDK clients that wait
+ * for `data: [DONE]` after `finish_reason: stop` (#6777). */
+const DEEPSEEK_FINISHED_DRAIN_MS = 750;
+
 function transformSSE(deepseekStream: ReadableStream, model: string): ReadableStream {
   const encoder = new TextEncoder();
   const decoder = new TextDecoder();
@@ -176,6 +182,8 @@ function transformSSE(deepseekStream: ReadableStream, model: string): ReadableSt
       async start(controller) {
         const reader = deepseekStream.getReader();
         let buffer = "";
+        let streamFinished = false;
+        let finishedDrainTimer: ReturnType<typeof setTimeout> | null = null;
 
         const emit = (obj: object) => {
           controller.enqueue(encoder.encode(`data: ${JSON.stringify(obj)}\n\n`));
@@ -198,16 +206,40 @@ function transformSSE(deepseekStream: ReadableStream, model: string): ReadableSt
           }
         };
 
-        const finishStream = () => {
-          const citations = appendSearchCitations(searchResults, streamModel);
-          if (citations) {
-            ensureRole();
-            chunk({ content: `\n\n${citations}` });
+        const clearFinishedDrain = () => {
+          if (finishedDrainTimer) {
+            clearTimeout(finishedDrainTimer);
+            finishedDrainTimer = null;
           }
-          ensureRole();
-          chunk({}, "stop");
-          controller.enqueue(encoder.encode("data: [DONE]\n\n"));
-          controller.close();
+        };
+
+        const finishStream = () => {
+          if (streamFinished) return;
+          streamFinished = true;
+          clearFinishedDrain();
+          try {
+            const citations = appendSearchCitations(searchResults, streamModel);
+            if (citations) {
+              ensureRole();
+              chunk({ content: `\n\n${citations}` });
+            }
+            ensureRole();
+            chunk({}, "stop");
+            // OpenAI-compatible clients (SDK, OpenCode) hang without this terminator.
+            controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+            controller.close();
+          } catch {
+            // Controller may already be closed if the client cancelled.
+          }
+        };
+
+        /** After FINISHED, allow a short window for trailing search_results, then close. */
+        const scheduleFinishAfterDrain = () => {
+          clearFinishedDrain();
+          finishedDrainTimer = setTimeout(() => {
+            finishedDrainTimer = null;
+            finishStream();
+          }, DEEPSEEK_FINISHED_DRAIN_MS);
         };
 
         const sendByPath = (raw: string) => {
@@ -324,18 +356,34 @@ function transformSSE(deepseekStream: ReadableStream, model: string): ReadableSt
                 }
               }
 
-              // Do not close on FINISHED — DeepSeek may still send search_results afterward.
+              // Do not close *immediately* on FINISHED — DeepSeek may still send
+              // search_results afterward. Schedule a short drain, then always emit
+              // stop + [DONE] so clients do not hang if the upstream body stays open.
               if (p === "response/status" && v === "FINISHED") {
+                scheduleFinishAfterDrain();
                 continue;
+              }
+
+              // Any other post-FINISHED payload extends the drain window so we
+              // still capture late search_results before closing.
+              if (finishedDrainTimer) {
+                scheduleFinishAfterDrain();
               }
             }
           }
         } catch (err) {
-          controller.error(err);
+          clearFinishedDrain();
+          if (!streamFinished) {
+            controller.error(err);
+          }
           return;
         }
 
         finishStream();
+      },
+      cancel() {
+        // Best-effort: cancel upstream reader if the client aborts mid-stream.
+        // finishStream is not required here — the controller is already cancelled.
       },
     },
     { highWaterMark: 16384 }

--- a/open-sse/executors/deepseek-web.ts
+++ b/open-sse/executors/deepseek-web.ts
@@ -14,6 +14,10 @@ import {
   appendSearchCitations,
   type DeepSeekSearchResult,
 } from "./deepseek-web/stream-format.ts";
+import {
+  createFinishOnceGuard,
+  createFinishedDrainScheduler,
+} from "./deepseek-web-done-terminator.ts";
 
 export const DEEPSEEK_WEB_BASE = "https://chat.deepseek.com";
 const DEEPSEEK_API_BASE = `${DEEPSEEK_WEB_BASE}/api`;
@@ -160,12 +164,6 @@ async function solvePow(challenge: PowChallenge): Promise<string> {
 
 // ── SSE Transform (DeepSeek → OpenAI) ───────────────────────────────────
 
-/** How long to wait after DeepSeek `response/status=FINISHED` for trailing
- * search_results before closing the OpenAI-compatible SSE. Without this,
- * upstreams that leave the HTTP body open hang OpenAI SDK clients that wait
- * for `data: [DONE]` after `finish_reason: stop` (#6777). */
-const DEEPSEEK_FINISHED_DRAIN_MS = 750;
-
 function transformSSE(deepseekStream: ReadableStream, model: string): ReadableStream {
   const encoder = new TextEncoder();
   const decoder = new TextDecoder();
@@ -182,8 +180,6 @@ function transformSSE(deepseekStream: ReadableStream, model: string): ReadableSt
       async start(controller) {
         const reader = deepseekStream.getReader();
         let buffer = "";
-        let streamFinished = false;
-        let finishedDrainTimer: ReturnType<typeof setTimeout> | null = null;
 
         const emit = (obj: object) => {
           controller.enqueue(encoder.encode(`data: ${JSON.stringify(obj)}\n\n`));
@@ -206,41 +202,24 @@ function transformSSE(deepseekStream: ReadableStream, model: string): ReadableSt
           }
         };
 
-        const clearFinishedDrain = () => {
-          if (finishedDrainTimer) {
-            clearTimeout(finishedDrainTimer);
-            finishedDrainTimer = null;
-          }
-        };
-
-        const finishStream = () => {
-          if (streamFinished) return;
-          streamFinished = true;
-          clearFinishedDrain();
-          try {
-            const citations = appendSearchCitations(searchResults, streamModel);
-            if (citations) {
-              ensureRole();
-              chunk({ content: `\n\n${citations}` });
-            }
+        const { finishOnce: finishStream, hasFinished } = createFinishOnceGuard(() => {
+          const citations = appendSearchCitations(searchResults, streamModel);
+          if (citations) {
             ensureRole();
-            chunk({}, "stop");
-            // OpenAI-compatible clients (SDK, OpenCode) hang without this terminator.
-            controller.enqueue(encoder.encode("data: [DONE]\n\n"));
-            controller.close();
-          } catch {
-            // Controller may already be closed if the client cancelled.
+            chunk({ content: `\n\n${citations}` });
           }
-        };
+          ensureRole();
+          chunk({}, "stop");
+          // OpenAI-compatible clients (SDK, OpenCode) hang without this terminator.
+          controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+          controller.close();
+        });
 
-        /** After FINISHED, allow a short window for trailing search_results, then close. */
-        const scheduleFinishAfterDrain = () => {
-          clearFinishedDrain();
-          finishedDrainTimer = setTimeout(() => {
-            finishedDrainTimer = null;
-            finishStream();
-          }, DEEPSEEK_FINISHED_DRAIN_MS);
-        };
+        // Do not close *immediately* on FINISHED — DeepSeek may still send
+        // search_results afterward. Drain briefly, then always emit
+        // stop + [DONE] so clients do not hang if the upstream body stays open.
+        const { scheduleFinishAfterDrain, clearFinishedDrain, isDrainPending } =
+          createFinishedDrainScheduler(finishStream);
 
         const sendByPath = (raw: string) => {
           const text = formatStreamContent(raw, streamModel);
@@ -356,9 +335,6 @@ function transformSSE(deepseekStream: ReadableStream, model: string): ReadableSt
                 }
               }
 
-              // Do not close *immediately* on FINISHED — DeepSeek may still send
-              // search_results afterward. Schedule a short drain, then always emit
-              // stop + [DONE] so clients do not hang if the upstream body stays open.
               if (p === "response/status" && v === "FINISHED") {
                 scheduleFinishAfterDrain();
                 continue;
@@ -366,14 +342,14 @@ function transformSSE(deepseekStream: ReadableStream, model: string): ReadableSt
 
               // Any other post-FINISHED payload extends the drain window so we
               // still capture late search_results before closing.
-              if (finishedDrainTimer) {
+              if (isDrainPending()) {
                 scheduleFinishAfterDrain();
               }
             }
           }
         } catch (err) {
           clearFinishedDrain();
-          if (!streamFinished) {
+          if (!hasFinished()) {
             controller.error(err);
           }
           return;


### PR DESCRIPTION
## Summary

Fixes #6777.

`ds-web/*` streams can synthesize `finish_reason: "stop"` while the upstream HTTP body stays open after `response/status: FINISHED` (DeepSeek may still send search_results, then idle). OpenAI SDK / OpenCode clients hang waiting for the mandatory SSE terminator:

```text
data: [DONE]
```

## Change

In `open-sse/executors/deepseek-web.ts` `transformSSE`:

1. **Idempotent `finishStream`** — stop + `[DONE]` + close only once; safe if drain timer and reader-done race.
2. **Drain window after `FINISHED`** — do not close immediately (preserve trailing `search_results`); schedule close after **750ms**, resetting the timer if more events arrive during the window.
3. **Always close** when the upstream reader ends (existing path), still ensuring `[DONE]`.

This keeps search citation capture while guaranteeing clients that require `[DONE]` do not hang.

## Test plan

- [ ] Streamed `POST /v1/chat/completions` with `model: ds-web/deepseek-v4-pro` (or equivalent) ends with a `finish_reason: stop` chunk **and** a following `data: [DONE]` line
- [ ] OpenAI SDK / OpenCode multi-turn no longer hang after first reply
- [ ] Search-enabled DeepSeek models still append citations when `search_results` arrive shortly after FINISHED
- [ ] Non-stream requests unchanged

## Notes

- Focused on the DeepSeek Web OpenAI transform path (where the hang was reported).
- Live credentials required for full e2e; logic is local to the SSE transformer.
