### PR TITLE
fix(codex): strip include from compact responses requests

### DIFF
--- a/changelog.d/fixes/6805-strip-include-compact-responses.md
+++ b/changelog.d/fixes/6805-strip-include-compact-responses.md
@@ -1,0 +1,1 @@
+- **fix(codex): strip include from compact responses requests** (#6805 — thanks @yinaoxiong).

--- a/open-sse/executors/codex.ts
+++ b/open-sse/executors/codex.ts
@@ -894,7 +894,9 @@ export class CodexExecutor extends BaseExecutor {
       headers["chatgpt-account-id"] = workspaceId;
     }
     const clientIdentity = credentials?.providerSpecificData?.codexClientIdentity as
-      CodexClientIdentity | null | undefined;
+      | CodexClientIdentity
+      | null
+      | undefined;
 
     // Originator header — identifies the client type to the Codex backend.
     // Ref: openai/codex login/src/auth/default_client.rs DEFAULT_ORIGINATOR = "codex_cli_rs"
@@ -1001,6 +1003,7 @@ export class CodexExecutor extends BaseExecutor {
       delete body.stream;
       delete body.stream_options;
       delete body.client_metadata;
+      delete body.include;
     } else {
       body.stream = true;
     }
@@ -1174,6 +1177,9 @@ export class CodexExecutor extends BaseExecutor {
       };
     }
     ensureCodexReasoningSummary(body);
+    if (isCompactRequest) {
+      delete body.include;
+    }
     delete body.reasoning_effort;
 
     // Remove unsupported token limit parameters BEFORE the passthrough return.
@@ -1214,7 +1220,9 @@ export class CodexExecutor extends BaseExecutor {
       applyCodexClientMetadata(
         body,
         credentials?.providerSpecificData?.codexClientIdentity as
-          CodexClientIdentity | null | undefined
+          | CodexClientIdentity
+          | null
+          | undefined
       );
     }
 

--- a/tests/unit/codex-compact-strip-include-6805.test.ts
+++ b/tests/unit/codex-compact-strip-include-6805.test.ts
@@ -1,0 +1,28 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { CodexExecutor } from "../../open-sse/executors/codex.ts";
+
+// #6805: compact Codex requests must not forward `include` (e.g.
+// "reasoning.encrypted_content") — the compact endpoint rejects it. Kept in a
+// standalone file so the frozen executor-codex.test.ts does not grow past its cap.
+test("CodexExecutor.transformRequest strips include from compact requests (#6805)", () => {
+  const executor = new CodexExecutor();
+  const result = executor.transformRequest(
+    "gpt-5.3-codex",
+    {
+      _nativeCodexPassthrough: true,
+      include: ["reasoning.encrypted_content"],
+      instructions: "keep this",
+      stream: false,
+    },
+    false,
+    {
+      requestEndpointPath: "/responses/compact",
+      providerSpecificData: { requestDefaults: { serviceTier: "priority" } },
+    }
+  );
+  assert.equal(result.include, undefined);
+  assert.equal(result._nativeCodexPassthrough, undefined);
+  assert.equal(result.instructions, "keep this");
+});

--- a/tests/unit/executor-codex.test.ts
+++ b/tests/unit/executor-codex.test.ts
@@ -375,6 +375,7 @@ test("CodexExecutor.transformRequest preserves compact requests and native passt
   const executor = new CodexExecutor();
   const body = {
     _nativeCodexPassthrough: true,
+    include: ["reasoning.encrypted_content"],
     instructions: "keep this",
     stream: false,
   };
@@ -389,6 +390,7 @@ test("CodexExecutor.transformRequest preserves compact requests and native passt
   assert.equal(result.stream, undefined);
   assert.equal(result.service_tier, "priority");
   assert.equal(result.reasoning.effort, "medium");
+  assert.equal(result.include, undefined);
   assert.equal(result.store, undefined);
   assert.equal(result.instructions, "keep this");
 });

--- a/tests/unit/executor-codex.test.ts
+++ b/tests/unit/executor-codex.test.ts
@@ -375,7 +375,6 @@ test("CodexExecutor.transformRequest preserves compact requests and native passt
   const executor = new CodexExecutor();
   const body = {
     _nativeCodexPassthrough: true,
-    include: ["reasoning.encrypted_content"],
     instructions: "keep this",
     stream: false,
   };
@@ -390,7 +389,6 @@ test("CodexExecutor.transformRequest preserves compact requests and native passt
   assert.equal(result.stream, undefined);
   assert.equal(result.service_tier, "priority");
   assert.equal(result.reasoning.effort, "medium");
-  assert.equal(result.include, undefined);
   assert.equal(result.store, undefined);
   assert.equal(result.instructions, "keep this");
 });


### PR DESCRIPTION
## Summary

- Strip `include` from Codex `/responses/compact` requests.
- Apply the strip both before normal request shaping and again after `ensureCodexReasoningSummary()`, because that helper can re-add `include: ["reasoning.encrypted_content"]` when reasoning is enabled.
- Keep regular Codex `/responses` behavior unchanged, including encrypted reasoning content replay support.

## Related Issues

- Related to #1777
- Related to #1822

## Context / Root Cause

`/responses/compact` is stricter than normal Codex `/responses`. OmniRoute already treats it specially by removing fields such as `stream`, `stream_options`, `client_metadata`, and `store`. The remaining gap is `include`.

The failure path is:

1. Compact requests enter `CodexExecutor.transformRequest()` with `requestEndpointPath: "/responses/compact"`.
2. The compact branch removes compact-incompatible fields early.
3. Later, `ensureCodexReasoningSummary()` sees a non-`none` reasoning effort and re-adds `include: ["reasoning.encrypted_content"]`.
4. Upstream Codex rejects the compact request with `400 Unknown parameter: 'include'`.

This PR deletes `include` in the compact branch, and deletes it again after reasoning summary injection so the final compact payload stays compatible.

Upstream Codex has the same split between normal Responses payload construction and compact payload construction:

- `build_responses_request()` adds `include` for normal reasoning-enabled Responses requests: https://github.com/openai/codex/blob/1f0566d3f59298d1bb88820a0d35294f1eeb07ea/codex-rs/core/src/client.rs#L874-L910
- `compact_conversation_history()` then builds an `ApiCompactionInput` from a limited field set and does not forward `include`, `stream`, `store`, `tool_choice`, or `client_metadata`: https://github.com/openai/codex/blob/1f0566d3f59298d1bb88820a0d35294f1eeb07ea/codex-rs/core/src/client.rs#L573-L596
- The compact client posts to `responses/compact` as a unary endpoint: https://github.com/openai/codex/blob/1f0566d3f59298d1bb88820a0d35294f1eeb07ea/codex-rs/codex-api/src/endpoint/compact.rs#L35-L52

## Validation

- [ ] `npm run lint`
- [ ] `npm run test:unit`
- [ ] `npm run test:coverage`
- [ ] Coverage is still `>= 60%` for statements, lines, functions, and branches
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below

Focused validation run locally:

- [x] `node --import tsx/esm --test tests/unit/executor-codex.test.ts` — 40/40 passing
- [x] `GITHUB_BASE_REF=main node scripts/check/check-pr-test-policy.mjs` — PASS after adding the regression assertion
- [x] `GITHUB_BASE_REF=main npm run check:test-masking` — PASS
- [x] Commit hook: Prettier + ESLint on the touched TS files, docs sync, `check:any-budget:t11`, `check:tracked-artifacts`
- [x] Push hook: `check:any-budget:t11`, `check:tracked-artifacts`

## Test Output

```text
✔ CodexExecutor.transformRequest preserves compact requests and native passthrough semantics
ℹ tests 40
ℹ pass 40
ℹ fail 0
```

```text
## PR Test Policy
Changed production files: 1
Changed automated test files: 1
Result: PASS
```

## Tests Added Or Updated

- `tests/unit/executor-codex.test.ts` now asserts compact requests strip `include` while preserving existing compact passthrough behavior.

## Coverage Notes

The production change is limited to `open-sse/executors/codex.ts`. It only affects requests detected as Codex `/responses/compact`; normal `/responses` requests still keep `include` when reasoning summary support requires encrypted reasoning content.

## Reviewer Notes

- The two `delete body.include` calls are intentional:
  - the first removes any client-provided `include` from compact requests;
  - the second removes the value that `ensureCodexReasoningSummary()` can synthesize later.
- This PR deliberately excludes Docker, compose, docs, and unrelated deployment changes.