### PR TITLE
[dup] fix(providers): drop image_generation for gpt-5.3-codex-spark (#6651)

### DIFF
--- a/open-sse/executors/codex.ts
+++ b/open-sse/executors/codex.ts
@@ -49,6 +49,18 @@ import { isCodexFreePlan, normalizeCodexTools } from "./codex/tools.ts";
 // Re-exported for external importers (tests + provider services).
 export { isCodexFreePlan, normalizeCodexTools } from "./codex/tools.ts";
 
+// #6651: `gpt-5.3-codex-spark` rejects the server-side `image_generation` hosted tool
+// upstream (HTTP 400) regardless of plan, yet the Codex Desktop app / CLI injects it into
+// every Responses request. Drop it for the spark scope as well as for free-plan accounts
+// (#2980), so paid accounts routing to spark don't fail upstream. `getCodexModelScope`
+// matches reasoning-suffixed variants (e.g. `gpt-5.3-codex-spark:high`) too.
+export function shouldDropCodexImageGeneration(
+  providerSpecificData: unknown,
+  model: string | null | undefined
+): boolean {
+  return isCodexFreePlan(providerSpecificData) || getCodexModelScope(model) === "spark";
+}
+
 // ─── wreq-js lazy loader ───────────────────────────────────────────────────
 // wreq-js is a Rust-native module that requires platform-specific .node binaries.
 // Loading it eagerly crashes the server when the binary is missing (pnpm, Docker
@@ -1129,7 +1141,10 @@ export class CodexExecutor extends BaseExecutor {
     // Cursor may include custom tools (e.g. ApplyPatch) that work locally but are
     // invalid upstream, and translation bugs can leave orphaned/empty tool_choice names.
     normalizeCodexTools(body, {
-      dropImageGeneration: isCodexFreePlan(credentials?.providerSpecificData),
+      dropImageGeneration: shouldDropCodexImageGeneration(
+        credentials?.providerSpecificData,
+        typeof body.model === "string" ? body.model : model
+      ),
       preserveCustomTools: nativeCodexPassthrough,
     });
 

--- a/tests/unit/codex-spark-image-generation-6651.test.ts
+++ b/tests/unit/codex-spark-image-generation-6651.test.ts
@@ -1,0 +1,53 @@
+/**
+ * #6651 — `gpt-5.3-codex-spark` rejects the server-side `image_generation` hosted tool
+ * upstream (HTTP 400) regardless of plan, but the Codex Desktop app / CLI injects it into
+ * every Responses request. OmniRoute previously dropped `image_generation` only for
+ * free-plan accounts (#2980), so a PAID account routing to spark still forwarded it and the
+ * request failed upstream. `shouldDropCodexImageGeneration` must also drop it for the spark
+ * scope. These tests also guard the free-plan behavior so #2980 does not regress.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { shouldDropCodexImageGeneration, normalizeCodexTools } = await import(
+  "../../open-sse/executors/codex.ts"
+);
+
+const FREE = { workspacePlanType: "free" };
+const PAID = { workspacePlanType: "team" };
+
+test("shouldDropCodexImageGeneration: spark model drops image_generation on a paid plan (#6651)", () => {
+  assert.equal(shouldDropCodexImageGeneration(PAID, "gpt-5.3-codex-spark"), true);
+  // reasoning-suffixed spark variant (e.g. gpt-5.3-codex-spark:high) still counts as spark
+  assert.equal(shouldDropCodexImageGeneration(PAID, "gpt-5.3-codex-spark:high"), true);
+});
+
+test("shouldDropCodexImageGeneration: free plan still drops it for non-spark models (#2980 guard)", () => {
+  assert.equal(shouldDropCodexImageGeneration(FREE, "gpt-5.3-codex"), true);
+  assert.equal(shouldDropCodexImageGeneration(FREE, undefined), true);
+});
+
+test("shouldDropCodexImageGeneration: paid plan + non-spark model preserves image_generation", () => {
+  assert.equal(shouldDropCodexImageGeneration(PAID, "gpt-5.3-codex"), false);
+  assert.equal(shouldDropCodexImageGeneration(undefined, "gpt-5.3-codex"), false);
+});
+
+test("normalizeCodexTools drops image_generation for a paid spark request end-to-end (#6651)", () => {
+  const body: Record<string, unknown> = {
+    model: "gpt-5.3-codex-spark",
+    tools: [
+      { type: "image_generation", output_format: "png" },
+      { type: "function", name: "foo", parameters: { type: "object" } },
+    ],
+  };
+  normalizeCodexTools(body, {
+    dropImageGeneration: shouldDropCodexImageGeneration(PAID, body.model as string),
+  });
+  const tools = body.tools as Array<{ type?: string }>;
+  assert.equal(
+    tools.some((t) => t.type === "image_generation"),
+    false,
+    "image_generation must be dropped for a paid spark request"
+  );
+  assert.equal(tools.length, 1, "the function tool must survive");
+});


### PR DESCRIPTION
## Problem

Codex Desktop (and the Codex CLI) inject the Responses hosted tool `image_generation` into every request. On the native Codex Responses passthrough path, OmniRoute preserves that hosted tool unless the account is detected as a **free plan**.

`gpt-5.3-codex-spark` rejects `image_generation` upstream, so a **paid** account routing to spark fails with an upstream **HTTP 400** — the tool is forwarded even though spark can never run it.

## Root cause

`normalizeCodexTools()` drops `image_generation` only when its `dropImageGeneration` option is `true`, and the Codex executor derived that flag solely from the plan type:

```ts
// open-sse/executors/codex.ts
normalizeCodexTools(body, {
  dropImageGeneration: isCodexFreePlan(credentials?.providerSpecificData),
  preserveCustomTools: nativeCodexPassthrough,
});
```

`image_generation` is a member of `CODEX_HOSTED_TOOL_TYPES` and is preserved for any non-free plan (`open-sse/executors/codex/tools.ts`). Spark's per-model incompatibility was never considered here — spark is only special-cased for quota/rate-limit scope in `open-sse/config/codexQuotaScopes.ts`.

## Fix

Gate `dropImageGeneration` on the **spark scope** as well as the free plan, via a small, testable predicate co-located with the other Codex tool-gating helpers:

```ts
export function shouldDropCodexImageGeneration(
  providerSpecificData: unknown,
  model: string | null | undefined
): boolean {
  return isCodexFreePlan(providerSpecificData) || getCodexModelScope(model) === "spark";
}
```

`getCodexModelScope()` already recognizes `gpt-5.3-codex-spark` (and reasoning-suffixed variants like `gpt-5.3-codex-spark:high`) as scope `"spark"`, so the fix reuses existing spark detection rather than re-implementing it. The `#2980` free-plan behavior is unchanged; only the additional spark condition is new.

Minimal surface: 1 production file (`open-sse/executors/codex.ts`, +16/-1) plus a new unit test. No change to `normalizeCodexTools()` itself — only how the executor derives the flag.

## Verification

TDD — the test fails on the unfixed tree and passes after the fix.

```
$ node --import tsx/esm --test tests/unit/codex-spark-image-generation-6651.test.ts
# before fix:  # tests 4  # pass 0  # fail 4
# after fix:   # tests 4  # pass 4  # fail 0
```

Neighboring Codex suites remain green:

```
$ node --import tsx/esm --test \
    tests/unit/codex-free-plan-image-generation.test.ts \
    tests/unit/codex-tools-split.test.ts \
    tests/unit/executor-codex.test.ts
# tests 46  # pass 46  # fail 0
```

Lint clean on changed files:

```
$ npx eslint --suppressions-location config/quality/eslint-suppressions.json \
    open-sse/executors/codex.ts tests/unit/codex-spark-image-generation-6651.test.ts
# (no output — 0 errors, 0 warnings)
```

`npm run typecheck:core` reports only two pre-existing errors in unrelated `omniglyph` compression files (optional module not installed locally); `codex.ts` type-checks clean.

## Diff summary

- `open-sse/executors/codex.ts` — add `shouldDropCodexImageGeneration()` predicate; use it at the `normalizeCodexTools()` call site instead of `isCodexFreePlan()` alone.
- `tests/unit/codex-spark-image-generation-6651.test.ts` — new regression test (spark-paid drop, free-plan #2980 guard, paid non-spark preserve, end-to-end `normalizeCodexTools`).

Closes #6651.

Thanks for the great work on OmniRoute!
