### PR TITLE
fix(providers): honor explicit thinking.budget_tokens 0 in openai->gemini transform (#6813)

### DIFF
--- a/open-sse/translator/request/openai-to-gemini.ts
+++ b/open-sse/translator/request/openai-to-gemini.ts
@@ -211,11 +211,15 @@ function openaiToGeminiBase(
     };
   }
   // 2. Claude format: thinking (type: enabled, budget_tokens)
+  // Use an explicit numeric check (not truthy) so an explicit `budget_tokens: 0` — the
+  // natural way to disable thinking — is honored as thinkingBudget 0 instead of being
+  // dropped and falling through to the default injection below (#6813). A zero budget
+  // yields no thoughts, so includeThoughts is only set for a non-zero budget.
   const thinking = body.thinking as { type?: string; budget_tokens?: number } | undefined;
-  if (thinking?.type === "enabled" && thinking.budget_tokens) {
+  if (thinking?.type === "enabled" && typeof thinking.budget_tokens === "number") {
     result.generationConfig.thinkingConfig = {
       thinkingBudget: thinking.budget_tokens,
-      includeThoughts: true,
+      includeThoughts: thinking.budget_tokens !== 0,
     };
   }
 

--- a/tests/unit/gemini-thinking-budget-zero-6813.test.ts
+++ b/tests/unit/gemini-thinking-budget-zero-6813.test.ts
@@ -1,0 +1,50 @@
+/**
+ * #6813 (defect 1) — the openai->gemini transform forwards the Claude-style
+ * `thinking.budget_tokens` into `generationConfig.thinkingConfig.thinkingBudget`, but the
+ * presence check was truthy (`&& thinking.budget_tokens`). An explicit `budget_tokens: 0`
+ * (the natural "disable thinking" request) is falsy, so it was dropped and the request fell
+ * through to the default thinkingConfig injection — the model thought despite an explicit
+ * request for zero. A `budget_tokens: 0` must be honored as thinkingBudget: 0.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { openaiToGeminiRequest } = await import(
+  "../../open-sse/translator/request/openai-to-gemini.ts"
+);
+
+test("thinking.budget_tokens: 0 is honored as thinkingBudget 0 (not dropped) (#6813)", () => {
+  const result = openaiToGeminiRequest(
+    "gemini-2.5-flash",
+    {
+      messages: [{ role: "user", content: "hi" }],
+      thinking: { type: "enabled", budget_tokens: 0 },
+    },
+    false
+  ) as { generationConfig: { thinkingConfig?: { thinkingBudget: number; includeThoughts: boolean } } };
+
+  assert.equal(
+    result.generationConfig.thinkingConfig?.thinkingBudget,
+    0,
+    "explicit budget_tokens: 0 must map to thinkingBudget: 0"
+  );
+  assert.equal(
+    result.generationConfig.thinkingConfig?.includeThoughts,
+    false,
+    "with a zero budget there are no thoughts to include"
+  );
+});
+
+test("thinking.budget_tokens: positive value still maps through with includeThoughts true (#6813 no-regression)", () => {
+  const result = openaiToGeminiRequest(
+    "gemini-2.5-flash",
+    {
+      messages: [{ role: "user", content: "hi" }],
+      thinking: { type: "enabled", budget_tokens: 2048 },
+    },
+    false
+  ) as { generationConfig: { thinkingConfig?: { thinkingBudget: number; includeThoughts: boolean } } };
+
+  assert.equal(result.generationConfig.thinkingConfig?.thinkingBudget, 2048);
+  assert.equal(result.generationConfig.thinkingConfig?.includeThoughts, true);
+});


### PR DESCRIPTION
## Scope

Issue #6813 reports **two** related defects in the openai→gemini request transform. This PR fixes **defect 1** (the `budget_tokens: 0` falsy drop) with a surgical, fully test-covered change. **Defect 2** (the unconditional default `thinkingConfig` injection) is intentionally left out — see *Why defect 2 is not included* below — so this PR is scoped to the clear correctness bug and does not silently change the think-by-default behavior. Not tagged `Closes` for that reason.

## Problem

`thinking: { type: "enabled", budget_tokens: 0 }` — the natural way to ask a Gemini model for **no** thinking — was silently dropped, so the model reasoned anyway (issue reporter measured ~958 reasoning tokens on a request that explicitly asked for zero, while `budget_tokens: 1` correctly produced 0). AI Studio honors `thinkingConfig.thinkingBudget: 0` directly, so the drop was in OmniRoute's transform, not the provider.

## Root cause

`openaiToGeminiBase()` in `open-sse/translator/request/openai-to-gemini.ts` gated the Claude-format thinking mapping on a **truthy** check:

```ts
if (thinking?.type === "enabled" && thinking.budget_tokens) {   // 0 is falsy → dropped
  result.generationConfig.thinkingConfig = {
    thinkingBudget: thinking.budget_tokens,
    includeThoughts: true,
  };
}
```

`budget_tokens: 0` is falsy, so the block was skipped and the request fell through to the default `thinkingConfig` injection lower down (a large budget), making the model think despite the explicit zero.

## Fix

Use an explicit numeric check so `0` passes through, and only mark `includeThoughts` for a non-zero budget (a zero budget produces no thoughts; a `-1` dynamic budget still does):

```ts
if (thinking?.type === "enabled" && typeof thinking.budget_tokens === "number") {
  result.generationConfig.thinkingConfig = {
    thinkingBudget: thinking.budget_tokens,
    includeThoughts: thinking.budget_tokens !== 0,
  };
}
```

Behavior is unchanged for every non-zero `budget_tokens` (still maps through with `includeThoughts: true`); only the previously-dropped `0` now yields `thinkingBudget: 0`.

## Why defect 2 is not included

Defect 2 asks to stop injecting a default `thinkingConfig` when the request carries no reasoning knob. That injection was added deliberately (#4170) so `includeThoughts: true` routes Gemini's reasoning into `reasoning_content` instead of leaking it into visible content — removing it risks reintroducing that leak, and defaulting the lane to "no thinking" changes answer quality/cost semantics for every caller. That is a product/design decision for a maintainer, not a safe autonomous change, so it is left out of this PR. Note that fixing defect 1 already removes the specific symptom where a `budget_tokens: 0` request triggered the default injection.

## Verification

TDD — the new test fails on the unfixed tree and passes after the fix:

```
$ node --import tsx/esm --test tests/unit/gemini-thinking-budget-zero-6813.test.ts
# before fix:  # tests 2  # pass 1  # fail 1   (budget_tokens:0 case fails)
# after fix:   # tests 2  # pass 2  # fail 0
```

No regression across the Gemini translator suites:

```
$ node --import tsx/esm --test \
    tests/unit/translator-openai-to-gemini.test.ts \
    tests/unit/translator-openai-to-gemini-sse.test.ts \
    tests/unit/openai-to-gemini-helpers-split.test.ts
# tests 59  # pass 59  # fail 0
```

Lint clean on changed files:

```
$ npx eslint --suppressions-location config/quality/eslint-suppressions.json \
    open-sse/translator/request/openai-to-gemini.ts tests/unit/gemini-thinking-budget-zero-6813.test.ts
# (no output — 0 errors, 0 warnings)
```

`npm run typecheck:core` reports only two pre-existing errors in unrelated `omniglyph` compression files (optional module not installed locally); the translator type-checks clean.

## Diff summary

- `open-sse/translator/request/openai-to-gemini.ts` — explicit numeric presence check for `thinking.budget_tokens`; `includeThoughts` gated on non-zero budget (+6/-2).
- `tests/unit/gemini-thinking-budget-zero-6813.test.ts` — new regression test (budget 0 honored as thinkingBudget 0; positive budget unchanged).

Addresses defect 1 of #6813.

Thanks for the great work on OmniRoute!
