### PR TITLE
fix(bootstrap): filter empty process.env values to prevent Docker env crash loop

### DIFF
--- a/changelog.d/fixes/6828-bootstrap-filter-empty-env.md
+++ b/changelog.d/fixes/6828-bootstrap-filter-empty-env.md
@@ -1,0 +1,1 @@
+- **fix(bootstrap):** filter empty `process.env` values before spawning embedded services so a blank env var no longer crashes the Docker bootstrap in a restart loop (#6828 — thanks @AndrianBalanescu).

--- a/scripts/build/bootstrap-env.mjs
+++ b/scripts/build/bootstrap-env.mjs
@@ -173,7 +173,14 @@ export function bootstrapEnv({ dataDirOverride, quiet = false } = {}) {
   const preferredEnvFiltered = Object.fromEntries(
     Object.entries(preferredEnv).filter(([, v]) => typeof v === "string" && v.length > 0)
   );
-  const merged = { ...persisted, ...preferredEnvFiltered, ...process.env };
+  // Filter empty strings from process.env so that Docker `-e KEY=` (which sets an
+  // empty string) does not override real values persisted in server.env or set
+  // in .env. Only shell/Docker vars that the operator actually set should win.
+  // Mirrors the filtering already applied to preferredEnv above. (fixes #6824)
+  const processEnvFiltered = Object.fromEntries(
+    Object.entries(process.env).filter(([, v]) => typeof v === "string" && v.length > 0)
+  );
+  const merged = { ...persisted, ...preferredEnvFiltered, ...processEnvFiltered };
 
   // ── Auto-generate required secrets ────────────────────────────────────────
   let needsPersist = false;

--- a/tests/unit/bootstrap-env.test.ts
+++ b/tests/unit/bootstrap-env.test.ts
@@ -120,6 +120,30 @@ test("bootstrapEnv fails closed when existing database cannot be inspected", () 
   });
 });
 
+test("bootstrapEnv ignores blank process.env values that would override persisted secrets (#6824)", () => {
+  withTempEnv(({ dataDir }) => {
+    process.env.DATA_DIR = dataDir;
+    fs.mkdirSync(dataDir, { recursive: true });
+
+    // Persisted secrets in server.env
+    fs.writeFileSync(
+      path.join(dataDir, "server.env"),
+      "STORAGE_ENCRYPTION_KEY=persisted-key\nJWT_SECRET=persisted-jwt\n",
+      "utf8"
+    );
+
+    // Simulate Docker `-e STORAGE_ENCRYPTION_KEY=` — sets an empty string
+    process.env.STORAGE_ENCRYPTION_KEY = "";
+    process.env.JWT_SECRET = "";
+
+    const env = bootstrapEnv({ quiet: true });
+
+    // Empty process.env values must NOT override persisted secrets
+    assert.equal(env.STORAGE_ENCRYPTION_KEY, "persisted-key");
+    assert.equal(env.JWT_SECRET, "persisted-jwt");
+  });
+});
+
 test("bootstrapEnv ignores blank dataDirOverride values", () => {
   withTempEnv(({ dataDir }) => {
     process.env.DATA_DIR = dataDir;


### PR DESCRIPTION
## Problem

Fixes #6824

Docker deployments crash-loop on restart because empty secret placeholders (from `.env.example`, passed via `docker -e KEY=`) set empty strings in `process.env`, which override persisted keys in `server.env`.

The `preferredEnv` layer was already filtered (line 173-175 — `preferredEnvFiltered` strips empty strings), but `process.env` was spread **unfiltered** into the merge at line 176:

```js
const merged = { ...persisted, ...preferredEnvFiltered, ...process.env };
```

This means `docker -e STORAGE_ENCRYPTION_KEY=` (empty string) wins over the real key persisted in `server.env`, causing the bootstrap to either auto-generate a new key (breaking encrypted credentials) or crash.

## Fix

Filter `process.env` the same way `preferredEnv` is already filtered — only non-empty string values from the operator should win:

```js
const processEnvFiltered = Object.fromEntries(
  Object.entries(process.env).filter(([, v]) => typeof v === "string" && v.length > 0)
);
const merged = { ...persisted, ...preferredEnvFiltered, ...processEnvFiltered };
```

This is a 3-line change that mirrors the existing filtering pattern exactly.

## Test

Added regression test: `bootstrapEnv ignores blank process.env values that would override persisted secrets (#6824)` — sets `STORAGE_ENCRYPTION_KEY=""` and `JWT_SECRET=""` in `process.env` (simulating Docker `-e KEY=`), writes real values to `server.env`, and asserts the persisted values survive.

```
node --import tsx/esm --test tests/unit/bootstrap-env.test.ts
```

All non-native-binding tests pass (the 2 pre-existing failures require `better-sqlite3` native compilation and are unrelated to this change).

## Checklist

- [x] Tests pass
- [x] Linting passes
- [x] CHANGELOG updated
- [x] No `Co-Authored-By` trailers (Hard Rule #16)
- [x] Production code change includes test in same PR