### PR TITLE
fix(providers): classify 404 as MODEL_NOT_FOUND to stop retry storm (#6827)

### DIFF
--- a/changelog.d/fixes/6829-classify-404-model-not-found.md
+++ b/changelog.d/fixes/6829-classify-404-model-not-found.md
@@ -1,0 +1,1 @@
+- **fix(providers):** classify upstream `404` responses as `MODEL_NOT_FOUND` (model lockout) instead of a retryable provider error, stopping the retry storm when a single model is missing (#6829 — thanks @AndrianBalanescu).

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -3306,6 +3306,16 @@ export async function handleChatCore({
           console.warn(
             `[provider] Node ${errorConnectionId} project routing error (${statusCode}) — not banning`
           );
+        } else if (errorType === PROVIDER_ERROR_TYPES.MODEL_NOT_FOUND) {
+          // 404 — model/endpoint does not exist upstream. Lock the model so the
+          // retry/backoff loop stops hammering the dead endpoint (which would
+          // otherwise degenerate into a 429 rate-limit storm). Connection stays
+          // active since only the specific model is unavailable. (#6827)
+          const notFoundCooldownMs = COOLDOWN_MS.notFound;
+          lockModel(provider, errorConnectionId, currentModel, "model_not_found", notFoundCooldownMs);
+          console.warn(
+            `[provider] Node ${errorConnectionId} model not found (${statusCode}) for ${currentModel} - locking model for ${Math.ceil(notFoundCooldownMs / 1000)}s (connection stays active)`
+          );
         }
       } catch {
         // Best-effort state update; request flow should continue with fallback handling.

--- a/open-sse/services/errorClassifier.ts
+++ b/open-sse/services/errorClassifier.ts
@@ -76,6 +76,7 @@ export const PROVIDER_ERROR_TYPES = {
   CONTEXT_OVERFLOW: "context_overflow",
   OAUTH_INVALID_TOKEN: "oauth_invalid_token",
   EMPTY_CONTENT: "empty_content",
+  MODEL_NOT_FOUND: "model_not_found",
 };
 
 export const CONTEXT_OVERFLOW_SIGNALS = [
@@ -142,6 +143,15 @@ export function classifyProviderError(
       return PROVIDER_ERROR_TYPES.QUOTA_EXHAUSTED;
     }
     return PROVIDER_ERROR_TYPES.RATE_LIMITED;
+  }
+
+  // 404 — model or endpoint not found. Without classification the error
+  // falls through to `return null`, so no cooldown/lockout is applied and the
+  // retry/backoff loop keeps hammering the dead endpoint until the upstream
+  // rate-limits it (404 + 429 storm). Classify as MODEL_NOT_FOUND so the model
+  // gets locked via the cooldown layer and retries stop. (#6827)
+  if (statusCode === 404) {
+    return PROVIDER_ERROR_TYPES.MODEL_NOT_FOUND;
   }
 
   if (statusCode === 401) {

--- a/tests/unit/error-classifier.test.ts
+++ b/tests/unit/error-classifier.test.ts
@@ -120,3 +120,22 @@ test("classifyProviderError: OAuth provider 429 with daily quota signal => QUOTA
   );
   assert.equal(result, PROVIDER_ERROR_TYPES.QUOTA_EXHAUSTED);
 });
+
+// #6827 — 404 must be classified as MODEL_NOT_FOUND, not fall through to null.
+// Without this, no cooldown/lockout is applied and the retry loop keeps hitting
+// the dead endpoint until the upstream rate-limits it (404 + 429 storm).
+test("classifyProviderError: 404 => MODEL_NOT_FOUND", () => {
+  const result = classifyProviderError(404, {
+    error: { message: "model v0-1.5-md not found" },
+  });
+  assert.equal(result, PROVIDER_ERROR_TYPES.MODEL_NOT_FOUND);
+});
+
+test("classifyProviderError: 404 with provider => MODEL_NOT_FOUND", () => {
+  const result = classifyProviderError(
+    404,
+    { error: { message: "Not Found" } },
+    "v0-vercel"
+  );
+  assert.equal(result, PROVIDER_ERROR_TYPES.MODEL_NOT_FOUND);
+});


### PR DESCRIPTION
## Summary

Fixes #6827

`classifyProviderError` had no branch for HTTP 404 — it fell through to `return null`, meaning no cooldown or model lockout was applied. The retry/backoff loop kept hammering the dead endpoint until the upstream (or proxy) rate-limited it, producing the **404 + 429 storm** users saw even with rate-limit "Protected" enabled.

## Root cause

`open-sse/services/errorClassifier.ts` has dedicated branches for 429, 401, 402, 403, 500+, and 400 (context overflow) — but **no branch for 404**. A 404 returns `null`, which skips all the connection-state persistence in `chatCore.ts` (lines 3191–3304). Meanwhile `isModelUnavailableError(404, ...)` returns `true` and tries a family fallback, but when no sibling model exists or the fallback also fails, the error is returned without locking the model — and the routing layer retries the same request, looping until 429.

## Fix

1. **`errorClassifier.ts`** — add `MODEL_NOT_FOUND: "model_not_found"` to `PROVIDER_ERROR_TYPES` and a 404 branch to `classifyProviderError` that returns `MODEL_NOT_FOUND`.
2. **`chatCore.ts`** — handle `MODEL_NOT_FOUND` in the error-type switch: lock the model via `lockModel()` for `COOLDOWN_MS.notFound` (2 minutes, already defined in `errorConfig.ts`). Connection stays active since only the specific model/endpoint is unavailable — not a provider-wide ban.
3. **`error-classifier.test.ts`** — 2 regression tests asserting 404 returns `MODEL_NOT_FOUND` (with and without a provider argument).

## Behavior after fix

| Before | After |
|--------|-------|
| 404 → `null` → no lockout → retry storm → 429 | 404 → `MODEL_NOT_FOUND` → model locked 2min → retries stop |

The model family fallback (`isModelUnavailableError`) still runs for 404s — it sits earlier in the error handler and is independent of `classifyProviderError`. This change ensures that when the fallback path exhausts, the model is locked so the combo/router layer does not keep retrying.

## Testing

```
node --import tsx/esm --test tests/unit/error-classifier.test.ts
# 16 pass, 0 fail (14 existing + 2 new)

node --import tsx/esm --test tests/unit/services-branch-hardening.test.ts
# 7 pass, 0 fail
```

## Files changed

- `open-sse/services/errorClassifier.ts` — added `MODEL_NOT_FOUND` type + 404 branch
- `open-sse/handlers/chatCore.ts` — added `MODEL_NOT_FOUND` handler (lock model, keep connection active)
- `tests/unit/error-classifier.test.ts` — 2 regression tests
- `CHANGELOG.md` — entry under Unreleased