### PR TITLE
fix(docker): copy head-response-guard.cjs into the standalone bundle (boot crash)

### DIFF
--- a/scripts/build/assembleStandalone.mjs
+++ b/scripts/build/assembleStandalone.mjs
@@ -140,6 +140,13 @@ const EXTRA_MODULE_ENTRIES = [
     dest: ["http-method-guard.cjs"],
   },
   {
+    // #6608 added this import to standalone-server-ws.mjs; without the copy
+    // the Docker image crashes at boot with ERR_MODULE_NOT_FOUND.
+    label: "HEAD response guard (server-ws.mjs dependency)",
+    src: ["scripts", "dev", "head-response-guard.cjs"],
+    dest: ["head-response-guard.cjs"],
+  },
+  {
     label: "responses-ws-proxy (server-ws.mjs dependency)",
     src: ["scripts", "dev", "responses-ws-proxy.mjs"],
     dest: ["responses-ws-proxy.mjs"],

--- a/tests/unit/standalone-server-ws-deps-copied.test.ts
+++ b/tests/unit/standalone-server-ws-deps-copied.test.ts
@@ -1,0 +1,48 @@
+/**
+ * tests/unit/standalone-server-ws-deps-copied.test.ts
+ *
+ * Bug: #6608 added `import headResponseGuard from "./head-response-guard.cjs"`
+ * to scripts/dev/standalone-server-ws.mjs but did NOT add a copy entry to
+ * scripts/build/assembleStandalone.mjs. The standalone Docker image then
+ * crashed at boot: ERR_MODULE_NOT_FOUND /app/head-response-guard.cjs.
+ *
+ * Guard: every RELATIVE import in standalone-server-ws.mjs must have a
+ * matching copy entry in assembleStandalone.mjs, so a future sibling module
+ * cannot silently break the container again.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = join(import.meta.dirname, "../..");
+const serverWsSrc = readFileSync(join(ROOT, "scripts/dev/standalone-server-ws.mjs"), "utf8");
+const assembleSrc = readFileSync(join(ROOT, "scripts/build/assembleStandalone.mjs"), "utf8");
+
+/** All relative same-dir imports of standalone-server-ws.mjs (./foo.mjs|cjs). */
+function relativeImports(src: string): string[] {
+  const out: string[] = [];
+  const re = /from\s+["']\.\/([\w./-]+\.(?:mjs|cjs))["']/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(src)) !== null) out.push(m[1]);
+  return [...new Set(out)];
+}
+
+test("standalone-server-ws.mjs has relative imports to verify", () => {
+  const imports = relativeImports(serverWsSrc);
+  assert.ok(imports.length > 0, "expected at least one relative import (sanity)");
+  assert.ok(
+    imports.includes("head-response-guard.cjs"),
+    "expected the #6608 head-response-guard.cjs import (sanity)"
+  );
+});
+
+test("every relative import of standalone-server-ws.mjs is copied by assembleStandalone", () => {
+  const missing = relativeImports(serverWsSrc).filter((f) => !assembleSrc.includes(f));
+  assert.deepEqual(
+    missing,
+    [],
+    `assembleStandalone.mjs must copy these server-ws.mjs dependencies: ${missing.join(", ")}`
+  );
+});


### PR DESCRIPTION
## Problem

The standalone Docker image (targets `runner-base` / `runner-web` / `runner-cli`) crashes at boot:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/app/head-response-guard.cjs' imported from /app/server-ws.mjs
```

#6608 ("close HEAD requests immediately instead of hanging", #6400) added

```js
import headResponseGuard from "./head-response-guard.cjs";
```

to `scripts/dev/standalone-server-ws.mjs`, but did not add a copy entry to `scripts/build/assembleStandalone.mjs`. That script copies each `server-ws.mjs` sibling dependency into the standalone bundle individually (peer-stamp.mjs, http-method-guard.cjs, responses-ws-proxy.mjs, webdav-handler.mjs, tls-options.mjs) — so the new module never lands in the image and the container restart-loops.

## Fix

- Add the missing copy entry for `head-response-guard.cjs` to `assembleStandalone.mjs`.
- Regression test `tests/unit/standalone-server-ws-deps-copied.test.ts` extracts **all** relative imports of `standalone-server-ws.mjs` and asserts each one has a copy entry — so any future sibling module added to server-ws without a copy entry fails CI instead of breaking the container at boot.

## Validation (TDD, Hard Rule #18)

- Test written first, failed with: `assembleStandalone.mjs must copy these server-ws.mjs dependencies: head-response-guard.cjs`; passes after the fix.
- Rebuilt the Docker image (`--target runner-cli`) from this branch and verified `/app/head-response-guard.cjs` and `/app/server-ws.mjs` are present; the previous `ERR_MODULE_NOT_FOUND` boot crash is gone.
