### PR TITLE
fix(routing): recognize Kimi token-limit 400 as context overflow for combo fallback (#6637)

### DIFF
--- a/changelog.d/fixes/6637-6637-combo-kimi-fallback.md
+++ b/changelog.d/fixes/6637-6637-combo-kimi-fallback.md
@@ -1,0 +1,1 @@
+- fix(routing): recognize Kimi-style "exceeded model token limit" 400 as context overflow so combo fallback continues to the next target (#6637)

--- a/open-sse/services/accountFallback.ts
+++ b/open-sse/services/accountFallback.ts
@@ -189,7 +189,10 @@ export const OAUTH_INVALID_TOKEN_SIGNALS = [
 // Context overflow patterns — the prompt exceeds the model's maximum context length.
 // Different providers phrase this differently. Used to decide whether a 400 error
 // should trigger combo fallback (a different model may have a larger context window).
-const CONTEXT_OVERFLOW_PATTERNS = [
+// Exported so combo.ts's isContextOverflow400() guard (open-sse/services/combo.ts)
+// can reuse this single source of truth instead of maintaining its own,
+// independently-drifting pattern list (see issue #6637).
+export const CONTEXT_OVERFLOW_PATTERNS = [
   /\binput is too long\b/i,
   /\binput too long\b/i,
   /\bcontext.*(too long|exceeded|overflow|limit)/i,

--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -8,6 +8,7 @@
 import {
   checkFallbackError,
   classifyLockoutReason,
+  CONTEXT_OVERFLOW_PATTERNS,
   decayModelFailureCount,
   formatRetryAfter,
   getModelLockoutInfo,
@@ -663,7 +664,12 @@ export function isContextOverflow400(errorText) {
   return (
     /\bcontext.*(?:length_exceeded|too long|overflow|exceeded|window|limit)\b/i.test(errorText) ||
     /exceeds.*context/i.test(errorText) ||
-    /your input exceeds/i.test(errorText)
+    /your input exceeds/i.test(errorText) ||
+    // Reuse accountFallback.ts's CONTEXT_OVERFLOW_PATTERNS (single source of truth)
+    // so wording like Kimi's "exceeded model token limit" — which never says the
+    // literal word "context" — is still recognized as an overflow/fallback-worthy
+    // 400 instead of halting the whole combo (issue #6637).
+    CONTEXT_OVERFLOW_PATTERNS.some((p) => p.test(errorText))
   );
 }
 /** @param {string} errorText */

--- a/tests/unit/repro-6637-kimi-token-limit.test.ts
+++ b/tests/unit/repro-6637-kimi-token-limit.test.ts
@@ -1,0 +1,41 @@
+// Repro probe for issue #6637: combo stops fallback after Kimi total token-limit 400.
+//
+// Observed provider response (Kimi, verbatim from the issue report):
+//   "Invalid request: Your request exceeded model token limit: 262144 (requested: 308458)"
+//
+// combo.ts's #2101 guard (handleComboChat) treats a 400 as a combo-halting
+// "body-specific" error UNLESS isContextOverflow400() or isParamValidation400()
+// recognizes it as a context/param overflow that should fall through to the next
+// combo target. Kimi's exact wording ("... exceeded model token limit ...") does
+// NOT contain the literal word "context", so isContextOverflow400() misses it even
+// though accountFallback.ts's OWN CONTEXT_OVERFLOW_PATTERNS (used one layer below,
+// to decide fallbackResult.shouldFallback) explicitly matches `/\btoken limit\b/i`
+// and `/\bmax.*token/i`. The two classifiers disagree, and the stricter one wins,
+// so the combo halts instead of trying the next (larger-context) target.
+import assert from "node:assert/strict";
+import test from "node:test";
+import { isContextOverflow400, isParamValidation400 } from "../../open-sse/services/combo.ts";
+
+const KIMI_ERROR_TEXT =
+  "Invalid request: Your request exceeded model token limit: 262144 (requested: 308458)";
+
+test("#6637: Kimi's 'exceeded model token limit' 400 must be classified as context/token overflow (not body-specific)", () => {
+  // This is the exact predicate combo.ts checks before deciding to abort the
+  // whole combo instead of falling through to the next target (combo.ts ~L2038-2049):
+  //   if (status === 400 && fallbackResult.shouldFallback &&
+  //       !isContextOverflow400(errorText) && !isParamValidation400(errorText) && ...)
+  //     -> "stopping combo"
+  //
+  // For the fallback to proceed to the next target, at least one of these must be true.
+  const isRecognizedAsOverflow = isContextOverflow400(KIMI_ERROR_TEXT) || isParamValidation400(KIMI_ERROR_TEXT);
+
+  assert.equal(
+    isRecognizedAsOverflow,
+    true,
+    `Expected Kimi's "exceeded model token limit" 400 to be classified as context/token ` +
+      `overflow so combo fallback continues to the next target, but neither ` +
+      `isContextOverflow400() nor isParamValidation400() matched it. This causes ` +
+      `handleComboChat's #2101 guard to treat it as a body-specific error and halt the ` +
+      `whole combo (bug #6637).`
+  );
+});


### PR DESCRIPTION
Closes #6637

## Root cause

`open-sse/services/combo.ts`'s `handleComboChat()` has a "#2101" guard (added by #4519) that hard-stops the whole combo on a 400 unless the error text is recognized by `isContextOverflow400()` or `isParamValidation400()` (combo.ts). `isContextOverflow400()` required the literal word "context" in the message. Kimi's exact 400 body ("Your request exceeded model token limit: 262144 (requested: 308458)") never says "context", so the guard misclassified it as a body-specific error and halted the whole combo instead of trying the next (larger-context) target.

One layer below, `accountFallback.ts`'s `CONTEXT_OVERFLOW_PATTERNS` (used inside `checkFallbackError()` to compute `fallbackResult.shouldFallback`) already matches this wording (`/\btoken limit\b/i`, `/\bmax.*token/i`) and correctly says the request is fallback-worthy. The two independently-maintained regex classifiers disagreed, and the stricter one (combo.ts's) won — causing the "400 Bad Request with body-specific error detected... skipping fallback to other targets" halt.

## Fix

Export `CONTEXT_OVERFLOW_PATTERNS` from `accountFallback.ts` and reuse it inside `combo.ts`'s `isContextOverflow400()`, so both layers share a single source of truth instead of drifting independently.

## Regression test (TDD, Hard Rule #18)

`tests/unit/repro-6637-kimi-token-limit.test.ts` — asserts `isContextOverflow400(KIMI_ERROR_TEXT) || isParamValidation400(KIMI_ERROR_TEXT)` is `true`.

- RED on unfixed code: `false !== true` (assertion failure)
- GREEN after the fix: test passes

Existing regression coverage for the original #4519 guard (`tests/unit/combo-param-validation-fallback-4519.test.ts`, 5 tests) still passes unmodified, including the negative case proving a genuinely body-specific 400 ("Invalid JSON: unexpected token at position 12") is still NOT misclassified as overflow.

## Gates run (all green)

- `node scripts/check/check-file-size.mjs` — no ✗ on touched files
- `node scripts/check/check-complexity.mjs` — OK (2050 violations vs baseline 2054)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (885 violations vs baseline 885, unchanged)
- `node scripts/check/check-changelog-integrity.mjs` — OK
- `npm run typecheck:core` — clean (exit 0)
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json open-sse/services/combo.ts open-sse/services/accountFallback.ts tests/unit/repro-6637-kimi-token-limit.test.ts` — clean (exit 0)
- `node --import tsx/esm --test tests/unit/repro-6637-kimi-token-limit.test.ts` — 1/1 pass
- `node --import tsx/esm --test tests/unit/combo-param-validation-fallback-4519.test.ts` — 5/5 pass (no regression)

## Scope

Touches only `open-sse/services/accountFallback.ts` (export the existing pattern list) and `open-sse/services/combo.ts` (reuse it in `isContextOverflow400()`), plus the new regression test and changelog fragment. No drive-by refactors.