### PR TITLE
fix(providers): honor a provider-level proxy assigned to no-auth providers (#6272)

### DIFF
--- a/changelog.d/fixes/6272-6272-mimo-proxy.md
+++ b/changelog.d/fixes/6272-6272-mimo-proxy.md
@@ -1,0 +1,1 @@
+- fix(providers): honor a provider-level proxy assigned to no-auth providers like MiMoCode Free (#6272)

--- a/src/lib/db/settings.ts
+++ b/src/lib/db/settings.ts
@@ -11,6 +11,7 @@ import { getComboModelProvider as getComboEntryProvider } from "@/lib/combos/ste
 import { requestBodyLimitMbFromEnv } from "@/shared/constants/bodySize";
 import { DEFAULT_RESPONSES_PREVIOUS_RESPONSE_ID_MODE } from "@/shared/constants/responsesPreviousResponseId";
 import { type JsonRecord, toRecord } from "./settings/shared";
+import { resolveNoAuthSharedProviderProxy } from "./settings/noAuthProxyFallback";
 
 type ProxyValue = JsonRecord | string | null;
 type ProxyResolutionResult = {
@@ -558,6 +559,19 @@ export async function resolveProxyForConnection(connectionId: string, apiKeyId?:
       };
       cacheProxyResolution(cacheKey, startGeneration, startRegistryGeneration, result);
       return result;
+    }
+  }
+
+  // Step 8.5 (#6272): no-auth providers (mimocode, opencode, ...) share a single
+  // synthetic connectionId that never matches a `provider_connections` row, so
+  // `connectionRecord` above is null and Steps 5-8 (which require it) never run for
+  // them — a provider-level proxy assigned to a no-auth provider was silently
+  // ignored. Best-effort fallback: scan the known no-auth provider ids directly.
+  if (!connectionRecord) {
+    const noAuthFallback = await resolveNoAuthSharedProviderProxy(config.providers);
+    if (noAuthFallback) {
+      cacheProxyResolution(cacheKey, startGeneration, startRegistryGeneration, noAuthFallback);
+      return noAuthFallback;
     }
   }
 

--- a/src/lib/db/settings/noAuthProxyFallback.ts
+++ b/src/lib/db/settings/noAuthProxyFallback.ts
@@ -1,0 +1,65 @@
+/**
+ * db/settings/noAuthProxyFallback.ts
+ *
+ * #6272 — no-auth providers (mimocode, opencode, ...) are dispatched with a single
+ * hardcoded, provider-agnostic connectionId ("noauth" — SYNTHETIC_NOAUTH_CONNECTION_ID
+ * in src/sse/services/auth.ts). No `provider_connections` row ever has id="noauth", so
+ * `resolveProxyForConnection()` in ../settings.ts can never populate `connectionRecord`
+ * for these providers, and its provider-level proxy lookup (Steps 6/8) only runs when
+ * `connectionRecord` is present — a proxy assigned via Settings -> Providers -> mimocode
+ * (or any other no-auth provider) was therefore silently unreachable.
+ *
+ * This is a best-effort fallback invoked only when `connectionRecord` could not be
+ * found: it scans the known no-auth provider ids for a configured provider-level
+ * proxy (registry first, then legacy `proxyConfig.providers`) and returns the first
+ * match. It intentionally does not try to disambiguate which no-auth provider issued
+ * the request (the shared connectionId carries no such information) — in practice at
+ * most one no-auth provider has a provider-level proxy assigned at a time.
+ */
+import { NOAUTH_PROVIDERS } from "@/shared/constants/providers";
+import { resolveProxyForScopeFromRegistry } from "../proxies";
+import type { JsonRecord } from "./shared";
+
+type ProxyValue = JsonRecord | string | null;
+export type NoAuthProxyResolutionResult = {
+  proxy: ProxyValue;
+  level: string;
+  levelId: string | null;
+  source?: string;
+};
+type LegacyProviderProxyMap = Record<string, ProxyValue> | undefined | null;
+
+// Mirrors settings.ts's withFamilyDefault: legacy proxyConfig entries predate the
+// IPv6-only `family` directive, so default it to "auto" when missing.
+function withFamilyDefault(value: ProxyValue): ProxyValue {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    const record = value as JsonRecord;
+    if (typeof record.family === "string") return record;
+    return { ...record, family: "auto" };
+  }
+  return value;
+}
+
+async function resolveOneNoAuthProviderProxy(
+  providerId: string,
+  legacyProviders: LegacyProviderProxyMap
+): Promise<NoAuthProxyResolutionResult | null> {
+  const registryProvider = await resolveProxyForScopeFromRegistry("provider", providerId);
+  if (registryProvider?.proxy) return registryProvider as NoAuthProxyResolutionResult;
+
+  const legacyProxy = legacyProviders?.[providerId];
+  if (legacyProxy) {
+    return { proxy: withFamilyDefault(legacyProxy), level: "provider", levelId: providerId };
+  }
+  return null;
+}
+
+export async function resolveNoAuthSharedProviderProxy(
+  legacyProviders: LegacyProviderProxyMap
+): Promise<NoAuthProxyResolutionResult | null> {
+  for (const providerId of Object.keys(NOAUTH_PROVIDERS)) {
+    const resolved = await resolveOneNoAuthProviderProxy(providerId, legacyProviders);
+    if (resolved) return resolved;
+  }
+  return null;
+}

--- a/tests/unit/proxy-noauth-provider-6272.test.ts
+++ b/tests/unit/proxy-noauth-provider-6272.test.ts
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-6272-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+const ORIGINAL_INITIAL_PASSWORD = process.env.INITIAL_PASSWORD;
+delete process.env.INITIAL_PASSWORD;
+
+const core = await import("../../src/lib/db/core.ts");
+const settingsDb = await import("../../src/lib/db/settings.ts");
+
+test.after(async () => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  if (ORIGINAL_INITIAL_PASSWORD === undefined) delete process.env.INITIAL_PASSWORD;
+  else process.env.INITIAL_PASSWORD = ORIGINAL_INITIAL_PASSWORD;
+});
+
+test("#6272: resolveProxyForConnection('noauth', ...) honors a provider-level proxy assigned to 'mimocode'", async () => {
+  core.getDbInstance();
+  const proxy = { type: "http", host: "127.0.0.1", port: 8888 };
+
+  // Reporter's second symptom: "same thing happen when i set the proxy directly
+  // in the provider menu" -> assign a provider-scoped proxy to the mimocode
+  // provider id, the way Settings -> Providers -> mimocode would persist it.
+  await settingsDb.setProxyForLevel("provider", "mimocode", proxy);
+
+  const resolved = await settingsDb.resolveProxyForConnection("noauth", undefined);
+
+  assert.equal(
+    resolved?.proxy?.host,
+    "127.0.0.1",
+    `expected the mimocode provider-level proxy to be honored, got level=${resolved?.level} proxy=${JSON.stringify(resolved?.proxy)}`
+  );
+  assert.equal(resolved?.level, "provider");
+  assert.equal(resolved?.levelId, "mimocode");
+});
+
+test("control: resolveProxyForConnection('noauth', ...) still honors the GLOBAL proxy when no no-auth provider proxy is set", async () => {
+  core.getDbInstance();
+  await settingsDb.deleteProxyForLevel("provider", "mimocode");
+  const proxy = { type: "http", host: "10.0.0.1", port: 9999 };
+  await settingsDb.setProxyForLevel("global", null, proxy);
+
+  const resolved = await settingsDb.resolveProxyForConnection("noauth", undefined);
+  assert.equal(resolved?.proxy?.host, "10.0.0.1");
+  assert.equal(resolved?.level, "global");
+});


### PR DESCRIPTION
Closes #6272

## Root cause

No-auth providers (mimocode, opencode, ...) are always dispatched with a single hardcoded, provider-agnostic connectionId of `"noauth"` (`SYNTHETIC_NOAUTH_CONNECTION_ID` in `src/sse/services/auth.ts`), shared across ALL no-auth providers. Since no `provider_connections` row in the database ever has `id = "noauth"`, `resolveProxyForConnection()` (`src/lib/db/settings.ts`) can never populate `connectionRecord`, and its provider-level proxy lookup (Steps 6/8) only runs when `connectionRecord` is present. A proxy assigned specifically to `"mimocode"` in Settings -> Providers -> mimocode was therefore silently ignored — this reproduces the reporter's second symptom ("same thing happen when i set the proxy directly in the provider menu").

The Global Proxy toggle is unaffected by this bug: its lookup (Steps 9-10) does not depend on `connectionRecord`, so it already resolves correctly for the synthetic `"noauth"` connection id (verified by a control test in the same file).

## Fix

Adds a best-effort fallback in a new module, `src/lib/db/settings/noAuthProxyFallback.ts`: when `connectionRecord` could not be resolved (the case for every no-auth provider), scan the known no-auth provider ids for a configured provider-level proxy (registry first, then legacy `proxyConfig.providers`) before falling through to the global/direct steps. It intentionally does not try to disambiguate which no-auth provider issued the request — the shared connectionId carries no such information — so it applies when at most one no-auth provider has a provider-level proxy assigned, which is the reported scenario.

## Regression test (TDD, Hard Rule #18)

`tests/unit/proxy-noauth-provider-6272.test.ts`:
- RED on unfixed code: assigning a provider-level proxy to `"mimocode"` then calling `resolveProxyForConnection("noauth", undefined)` resolved to `level=direct, proxy=null`.
- GREEN after the fix: resolves to the configured proxy (`level=provider, levelId=mimocode`).
- Control case: the global-proxy fallback path is unaffected.

## Gates run (all green)

- `node scripts/check/check-file-size.mjs` — OK
- `node scripts/check/check-complexity.mjs` — OK (2050 violations vs baseline 2054, no regression)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (885 vs baseline 885, no regression)
- `node scripts/check/check-changelog-integrity.mjs` — OK
- `npm run typecheck:core` — clean
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` — exit 0
- Existing proxy-resolution test suite (11 files covering `resolveProxyForConnection`/provider proxies/registry/settings): all green, no regressions — `resolve-proxy-family`, `db-proxies-crud`, `proxy-registry`, `fixes-p1`, `proxy-pool-rotation-6365`, `proxy-resolution-status-filter`, `db-settings-split`, `db-settings-extended`, `db-settings-crud`, `db-proxies-split`, `proxy-assigned-unavailable-6246`