### PR TITLE
fix(compression): surface silently-dropped stacked-pipeline steps and fix inflation-guard misfire (#6479)

### DIFF
--- a/changelog.d/fixes/6479-6479-compression-pipeline.md
+++ b/changelog.d/fixes/6479-6479-compression-pipeline.md
@@ -1,0 +1,1 @@
+- fix(compression): surface silently-dropped stacked-pipeline steps (session-dedup, ccr) and stop the aggregate inflation guard from misfiring on a genuine no-op (#6479, #6480, #6491)

--- a/open-sse/services/compression/pipelineGuards.ts
+++ b/open-sse/services/compression/pipelineGuards.ts
@@ -6,6 +6,8 @@
  * default-off; the inflation guard here is an honest DEFAULT-ON check on the FINAL output.
  */
 
+import type { CompressionResult, CompressionStats } from "./types.ts";
+
 export interface PipelineInflationInput {
   /** The verbatim request body before any engine ran. */
   originalBody: Record<string, unknown>;
@@ -42,4 +44,46 @@ export function guardPipelineInflation(input: PipelineInflationInput): PipelineI
     return { body: input.originalBody, inflated: true };
   }
   return { body: input.compressedBody, inflated: false };
+}
+
+/**
+ * Applies the aggregate inflation guard to a finalized stacked-pipeline `stats` object, honoring
+ * the `compressed` loop-level flag (#6480). If the fully-stacked body did not actually shrink
+ * (its token count is >= the original), discards it and returns the verbatim original — safe by
+ * construction, since the original request body is always a valid payload.
+ *
+ * Only meaningful when some step actually advanced `currentBody` (`compressed === true`). When
+ * no step in the pipeline ever produced/advanced a candidate (e.g. a single no-op engine on an
+ * out-of-charter payload), `currentBody` is still reference-identical to `originalBody`, so
+ * tokens are trivially equal — running the guard in that case would mislabel a genuine no-op as
+ * a "reverted" fallback (`fallbackApplied: true` + a misleading warning) even though nothing was
+ * ever computed to revert.
+ */
+export function applyStackedInflationGuard(
+  originalBody: Record<string, unknown>,
+  currentBody: Record<string, unknown>,
+  compressed: boolean,
+  stats: CompressionStats
+): CompressionResult {
+  if (!compressed) return { body: currentBody, compressed, stats };
+
+  const inflation = guardPipelineInflation({
+    originalBody,
+    compressedBody: currentBody,
+    originalTokens: stats.originalTokens,
+    compressedTokens: stats.compressedTokens,
+  });
+  if (!inflation.inflated) return { body: currentBody, compressed, stats };
+
+  const inflatedTokens = stats.compressedTokens;
+  const warnings = new Set(stats.validationWarnings ?? []);
+  warnings.add(
+    `pipeline-inflation-guard: stacked output (${inflatedTokens} tok) did not shrink input ` +
+      `(${stats.originalTokens} tok); reverted to original`
+  );
+  stats.validationWarnings = Array.from(warnings);
+  stats.fallbackApplied = true;
+  stats.compressedTokens = stats.originalTokens;
+  stats.savingsPercent = 0;
+  return { body: inflation.body, compressed: false, stats };
 }

--- a/open-sse/services/compression/stackedStepCore.ts
+++ b/open-sse/services/compression/stackedStepCore.ts
@@ -62,13 +62,27 @@ export function decideStep(
   return { advance: true };
 }
 
+/**
+ * A dispatched step whose engine found nothing eligible (e.g. session-dedup with no repeated
+ * blocks, ccr below its min-chars threshold) returns `stats: null` instead of throwing or
+ * advancing. Left unrecorded, that step vanishes from the pipeline's telemetry with zero trace —
+ * no `engineBreakdown` entry, no warning, no error (#6479, #6491). Surface it as a validation
+ * warning so operators can tell "engine ran but had nothing to do" apart from "engine never ran".
+ */
+function recordNullStatsStep(acc: StackAccumulator, engineId: string): void {
+  acc.validationWarnings.add(`${engineId}: skipped (no eligible content)`);
+}
+
 /** Folds one engine result into the accumulator (telemetry + breakdown entry). */
 export function mergeStackStep(
   acc: StackAccumulator,
   engineId: string,
   result: CompressionResult
 ): void {
-  if (!result.stats) return;
+  if (!result.stats) {
+    recordNullStatsStep(acc, engineId);
+    return;
+  }
   result.stats.techniquesUsed.forEach((technique) => acc.techniques.add(technique));
   result.stats.rulesApplied?.forEach((rule) => acc.rules.add(rule));
   result.stats.rtkRawOutputPointers?.forEach((pointer) => acc.rtkRawOutputPointers.push(pointer));

--- a/open-sse/services/compression/strategySelector.ts
+++ b/open-sse/services/compression/strategySelector.ts
@@ -13,7 +13,7 @@ import { cavemanCompress } from "./caveman.ts";
 import { compressAggressive } from "./aggressive.ts";
 import { ultraCompress, ultraCompressHeuristic } from "./ultra.ts";
 import { createCompressionStats } from "./stats.ts";
-import { guardPipelineInflation } from "./pipelineGuards.ts";
+import { applyStackedInflationGuard } from "./pipelineGuards.ts";
 import {
   resolvePipelineBreakerConfig,
   canRunEngine,
@@ -762,30 +762,10 @@ function finalizeStackedResult(
     });
   }
 
-  // T02 / H1: honest aggregate inflation guard. If the fully-stacked body did not actually shrink
-  // (its token count is >= the original), discard it and return the verbatim original — safe by
-  // construction, since the original request body is always a valid payload.
-  const inflation = guardPipelineInflation({
-    originalBody,
-    compressedBody: currentBody,
-    originalTokens: stats.originalTokens,
-    compressedTokens: stats.compressedTokens,
-  });
-  if (inflation.inflated) {
-    const inflatedTokens = stats.compressedTokens;
-    const warnings = new Set(stats.validationWarnings ?? []);
-    warnings.add(
-      `pipeline-inflation-guard: stacked output (${inflatedTokens} tok) did not shrink input ` +
-        `(${stats.originalTokens} tok); reverted to original`
-    );
-    stats.validationWarnings = Array.from(warnings);
-    stats.fallbackApplied = true;
-    stats.compressedTokens = stats.originalTokens;
-    stats.savingsPercent = 0;
-    return { body: inflation.body, compressed: false, stats };
-  }
-
-  return { body: currentBody, compressed, stats };
+  // T02 / H1 / #6480: honest aggregate inflation guard, gated on the loop-level `compressed`
+  // flag so a pipeline where nothing ever advanced isn't mislabeled as a reverted fallback.
+  // See `applyStackedInflationGuard` in `pipelineGuards.ts` for the full rationale.
+  return applyStackedInflationGuard(originalBody, currentBody, compressed, stats);
 }
 
 // ── Shared per-step helpers (used by the sync + async stacked loops; keep them in lockstep) ──

--- a/tests/unit/compression-pipeline-inflation-guard.test.ts
+++ b/tests/unit/compression-pipeline-inflation-guard.test.ts
@@ -113,7 +113,11 @@ test("applyStackedCompression reverts to the original body when the pipeline inf
   const body = {
     messages: [{ role: "user", content: "hello world this is a short message" }],
   };
-  const result = applyStackedCompression(body, [INFLATE_ID]);
+  // Pass a step object, not a bare string: `normalizePipelineStep()` only recognizes a fixed
+  // set of built-in bare-string aliases ("standard"/"rtk"/"lite"/"aggressive"/"ultra") and
+  // silently falls back to `{ engine: "caveman" }` for any other string — a bare custom-engine
+  // id here would silently run caveman instead of the registered `inflatingEngine`.
+  const result = applyStackedCompression(body, [{ engine: INFLATE_ID }]);
 
   // The inflating engine produced a bigger body, so the aggregate guard discarded it.
   assert.equal(result.compressed, false);

--- a/tests/unit/compression/repro-6479-6491-null-stats-silent-drop.test.ts
+++ b/tests/unit/compression/repro-6479-6491-null-stats-silent-drop.test.ts
@@ -1,0 +1,103 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { applyStackedCompression } from "../../../open-sse/services/compression/strategySelector.ts";
+
+/**
+ * Regression coverage for #6479 and #6491: a dispatched stacked-pipeline step whose engine
+ * legitimately finds nothing eligible (`session-dedup` with no repeated blocks, `ccr` below its
+ * min-chars threshold) returns `{ stats: null }`. Before the fix, `mergeStackStep()` in
+ * `stackedStepCore.ts` silently dropped that step from the accumulator: no `engineBreakdown`
+ * entry, no `validationWarnings`, no `validationErrors` — zero trace the engine ever ran.
+ *
+ * Both issues report the exact same symptom for two different registered/known engines, so both
+ * are covered here against the shared fix (a `validationWarnings` entry recorded whenever a step
+ * returns `stats: null`).
+ */
+describe("#6479/#6491 — null-stats step no longer silently dropped from the pipeline", () => {
+  it("session-dedup with nothing to dedupe is explained in engineBreakdown or validationWarnings", () => {
+    // Small markdown table, short rows — well under session-dedup's 80-char/3-line
+    // suffix-block threshold, so session-dedup legitimately finds nothing to dedupe.
+    const body = {
+      messages: [
+        {
+          role: "user",
+          content:
+            "| a | b |\n|---|---|\n| 1 | 2 |\n| 1 | 2 |\n| 1 | 2 |\n| 1 | 2 |\n| 1 | 2 |\n| 1 | 2 |",
+        },
+      ],
+    };
+
+    const pipeline = [{ engine: "session-dedup" }, { engine: "rtk" }, { engine: "caveman" }];
+    const result = applyStackedCompression(body, pipeline);
+
+    const engines = result.stats?.engineBreakdown?.map((e) => e.engine) ?? [];
+    const warnings = result.stats?.validationWarnings ?? [];
+    const errors = result.stats?.validationErrors ?? [];
+
+    assert.ok(
+      engines.includes("session-dedup") ||
+        warnings.some((w) => w.includes("session-dedup")) ||
+        errors.some((w) => w.includes("session-dedup")),
+      `session-dedup missing from engineBreakdown (${JSON.stringify(engines)}) with no ` +
+        `explanation in validationWarnings/validationErrors — matches issue #6479's report`
+    );
+    // Specifically: the shared no-op reason must be present.
+    assert.ok(
+      warnings.some((w) => w === "session-dedup: skipped (no eligible content)") ||
+        engines.includes("session-dedup"),
+      `expected an explicit skip reason for session-dedup, got warnings=${JSON.stringify(warnings)}`
+    );
+  });
+
+  it("ccr with no duplicate-eligible block (>=600 chars) is explained, not silently dropped", () => {
+    const body = {
+      messages: [
+        {
+          role: "tool",
+          content: Array.from({ length: 8 }, () => "same noisy tool output line").join("\n"),
+        },
+        {
+          role: "user",
+          content:
+            "Please provide a detailed explanation of the authentication configuration and how it works",
+        },
+      ],
+    };
+
+    const pipeline = [{ engine: "ccr" }];
+    const result = applyStackedCompression(body, pipeline);
+
+    const engines = result.stats?.engineBreakdown?.map((e) => e.engine) ?? [];
+    const warnings = result.stats?.validationWarnings ?? [];
+    const errors = result.stats?.validationErrors ?? [];
+
+    assert.ok(
+      engines.includes("ccr") ||
+        warnings.some((w) => w.includes("ccr")) ||
+        errors.some((w) => w.includes("ccr")),
+      `ccr missing from engineBreakdown (${JSON.stringify(engines)}) with no explanation in ` +
+        `validationWarnings/validationErrors — matches issue #6491's report`
+    );
+    assert.ok(
+      warnings.some((w) => w === "ccr: skipped (no eligible content)") || engines.includes("ccr"),
+      `expected an explicit skip reason for ccr, got warnings=${JSON.stringify(warnings)}`
+    );
+  });
+
+  it("control: ccr with a large duplicate-eligible block (>=600 chars) still runs and advances", () => {
+    const bigBody = {
+      messages: [
+        {
+          role: "tool",
+          content: Array.from({ length: 40 }, () => "same noisy tool output line").join("\n"),
+        },
+        { role: "user", content: "please explain" },
+      ],
+    };
+
+    const result = applyStackedCompression(bigBody, [{ engine: "ccr" }]);
+    const engines = result.stats?.engineBreakdown?.map((e) => e.engine) ?? [];
+    assert.ok(engines.includes("ccr"), `expected 'ccr' in engineBreakdown (control), got ${JSON.stringify(engines)}`);
+  });
+});

--- a/tests/unit/compression/repro-6480-noop-guard-misfire.test.ts
+++ b/tests/unit/compression/repro-6480-noop-guard-misfire.test.ts
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { applyStackedCompression } from "../../../open-sse/services/compression/strategySelector.ts";
+
+/**
+ * Regression coverage for #6480: `finalizeStackedResult` in `strategySelector.ts` used to run
+ * the aggregate `guardPipelineInflation` check unconditionally, even when the loop-level
+ * `compressed` flag was `false` (i.e. no engine in the pipeline ever produced/advanced a
+ * candidate). Since `compressedTokens === originalTokens` trivially holds when nothing ran, the
+ * guard mislabeled a genuine no-op as `fallbackApplied: true` with a misleading
+ * "pipeline-inflation-guard ... reverted to original" warning, even though nothing was ever
+ * computed to revert.
+ */
+test("#6480: session-dedup no-op on out-of-charter single message does not fire the pipeline-inflation-guard", () => {
+  const body = {
+    messages: [
+      {
+        role: "user",
+        content:
+          "This is a single message with no prior session history and no internally " +
+          "repeated content whatsoever, so the session-dedup engine has nothing to do.",
+      },
+    ],
+  };
+
+  const result = applyStackedCompression(body, [{ engine: "session-dedup" }]);
+
+  assert.equal(
+    result.stats?.fallbackApplied,
+    undefined,
+    "expected no fallbackApplied flag on a trivial no-op pipeline (engine never advanced)"
+  );
+  assert.equal(
+    (result.stats?.validationWarnings ?? []).some((w) => w.includes("pipeline-inflation-guard")),
+    false,
+    "expected no misleading pipeline-inflation-guard warning when nothing was ever compressed"
+  );
+});


### PR DESCRIPTION
Closes #6479
Closes #6480
Closes #6491

## Root cause

Two related defects in the stacked compression pipeline (`open-sse/services/compression/strategySelector.ts` + `stackedStepCore.ts` + `pipelineGuards.ts`):

**#6479 / #6491 — silently-dropped null-stats step.** A dispatched step whose engine legitimately finds nothing eligible (`session-dedup` with no repeated blocks, `ccr` below its `DEFAULT_MIN_CHARS` threshold) returns `{ stats: null }`. `mergeStackStep()` in `stackedStepCore.ts` did `if (!result.stats) return;`, silently dropping the step from `engineBreakdown` — no `engineBreakdown` entry, no `validationWarnings`, no `validationErrors`, zero trace the engine ever ran. `rtk`/`caveman` always return a populated stats object even at 0% savings, so they always show up; `session-dedup`/`ccr` (and several other engines following the same `stats: null` no-op convention: `headroom`, `relevance`, `llm`, `llmlingua`, `ionizer`, `readLifecycle`) do not.

Fix: `mergeStackStep()` now records a `"<engine>: skipped (no eligible content)"` validation warning whenever a step returns `stats: null`, in the shared loop — so this covers every engine with this convention, not just the two reported.

**#6480 — inflation-guard misfires on a genuine no-op.** `finalizeStackedResult` ran the aggregate `guardPipelineInflation` check unconditionally, even when the loop-level `compressed` flag stayed `false` (no step in the pipeline ever advanced `currentBody`). Since `compressedTokens === originalTokens` trivially holds when nothing ran, the guard mislabeled a genuine no-op (e.g. `session-dedup` on a single out-of-charter message) as `fallbackApplied: true` with a misleading `"pipeline-inflation-guard: ... reverted to original"` warning, even though nothing was ever computed to revert.

Fix: extracted the guard into `applyStackedInflationGuard()` in `pipelineGuards.ts` (kept `strategySelector.ts` under its frozen file-size budget) and gated it on `compressed === true`.

**Test alignment:** `compression-pipeline-inflation-guard.test.ts`'s wire test passed a bare engine-id string (`[INFLATE_ID]`) to the pipeline. `normalizePipelineStep()` only recognizes a fixed set of built-in string aliases (`"standard"`/`"rtk"`/`"lite"`/`"aggressive"`/`"ultra"`) and silently downgrades any other bare string to `{ engine: "caveman" }` — so the test's custom inflating engine was never actually exercised; the test happened to pass anyway because `caveman` also found nothing to compress on that tiny input, hitting the exact "nothing advanced but tokens are equal" case #6480 is about. Passing a step object (`[{ engine: INFLATE_ID }]`) restores the test's original intent and keeps it green under the #6480 fix.

## Regression tests (TDD, Hard Rule #18)

- `tests/unit/compression/repro-6479-6491-null-stats-silent-drop.test.ts` — RED before the fix (session-dedup/ccr silently absent from `engineBreakdown` with zero explanation), GREEN after.
- `tests/unit/compression/repro-6480-noop-guard-misfire.test.ts` — RED before the fix (`fallbackApplied: true` + misleading warning on a trivial no-op), GREEN after.

RED confirmed by temporarily reverting the production changes (`git checkout -- <files>`) and re-running both new test files; both failed with the exact symptom described in the linked issues. Re-applied the fix and confirmed GREEN.

## Gates run (all green)

- `node scripts/check/check-file-size.mjs` — no violations on touched files (extracted the guard into `pipelineGuards.ts` to keep `strategySelector.ts` under its frozen 1043-line budget; ended at 1017 lines).
- `node scripts/check/check-complexity.mjs` — OK (2050 ≤ baseline 2054, improved).
- `node scripts/check/check-cognitive-complexity.mjs` — OK (885 == baseline 885).
- `node scripts/check/check-changelog-integrity.mjs` — OK.
- `npm run typecheck:core` — clean.
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` — clean.
- Full compression-pipeline test sweep (236 tests across all files referencing `strategySelector`/`stackedStepCore`/`applyStackedCompression`/`pipelineGuards`) — 236/236 pass, including the pre-existing wire test for the inflation guard and the two new regression files.