### PR TITLE
fix(mcp): de-duplicate TOTAL_MCP_TOOL_COUNT by tool name (#6854)

### DIFF
--- a/changelog.d/fixes/6854-6854-mcp-toolcount.md
+++ b/changelog.d/fixes/6854-6854-mcp-toolcount.md
@@ -1,0 +1,1 @@
+- fix(mcp): de-duplicate `TOTAL_MCP_TOOL_COUNT` by tool name instead of double-counting collections (#6854)

--- a/open-sse/mcp-server/server.ts
+++ b/open-sse/mcp-server/server.ts
@@ -37,6 +37,7 @@ import {
   oneproxyStatsInput,
 } from "./schemas/tools.ts";
 import { startMcpHeartbeat } from "./runtimeHeartbeat.ts";
+import { countUniqueMcpTools } from "./toolCount.ts";
 import { z } from "zod";
 import { closeAuditDb, logToolCall } from "./audit.ts";
 import {
@@ -98,17 +99,18 @@ const MCP_ALLOWED_SCOPES = new Set(
     .map((s) => s.trim())
     .filter(Boolean)
 );
-const TOTAL_MCP_TOOL_COUNT =
-  MCP_TOOLS.length +
-  Object.keys(memoryTools).length +
-  Object.keys(skillTools).length +
-  Object.keys(agentSkillTools).length +
-  Object.keys(githubSkillTools).length +
-  Object.keys(poolTools).length +
-  gamificationTools.length +
-  pluginTools.length +
-  notionTools.length +
-  obsidianTools.length;
+const TOTAL_MCP_TOOL_COUNT = countUniqueMcpTools({
+  MCP_TOOLS,
+  memoryTools,
+  skillTools,
+  agentSkillTools,
+  githubSkillTools,
+  poolTools,
+  gamificationTools,
+  pluginTools,
+  notionTools,
+  obsidianTools,
+});
 
 type JsonRecord = Record<string, unknown>;
 

--- a/open-sse/mcp-server/toolCount.ts
+++ b/open-sse/mcp-server/toolCount.ts
@@ -1,0 +1,36 @@
+/**
+ * countUniqueMcpTools — de-duplicated MCP tool count.
+ *
+ * The various tool collections registered by the MCP server (array-shaped, e.g.
+ * `MCP_TOOLS`, and record-shaped, e.g. `memoryTools`) are not guaranteed disjoint by
+ * tool `name` — some tools (e.g. the agent-skills trio) are intentionally defined in
+ * both an array collection and a record collection for registration purposes. Summing
+ * `collection.length` / `Object.keys(collection).length` across all sources therefore
+ * double-counts any name that appears in more than one source.
+ *
+ * This helper unions every collection's tool names into a `Set` and returns the size
+ * of that set, so the reported tool count always reflects distinct, user-visible tool
+ * names regardless of how many internal collections a given tool happens to appear in.
+ */
+
+type NamedTool = { name: string };
+type ToolCollection = readonly NamedTool[] | Readonly<Record<string, NamedTool>>;
+
+function collectionNames(collection: ToolCollection): string[] {
+  const items: NamedTool[] = Array.isArray(collection)
+    ? collection
+    : Object.values(collection as Record<string, NamedTool>);
+  return items.map((item) => item.name);
+}
+
+export function countUniqueMcpTools(
+  collectionsByLabel: Readonly<Record<string, ToolCollection>>
+): number {
+  const uniqueNames = new Set<string>();
+  for (const collection of Object.values(collectionsByLabel)) {
+    for (const name of collectionNames(collection)) {
+      uniqueNames.add(name);
+    }
+  }
+  return uniqueNames.size;
+}

--- a/tests/unit/mcp-tool-count-dedup-6854.test.ts
+++ b/tests/unit/mcp-tool-count-dedup-6854.test.ts
@@ -1,0 +1,83 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// Regression for #6854: TOTAL_MCP_TOOL_COUNT (open-sse/mcp-server/server.ts) was a
+// plain additive sum across all registered tool collections. Three tools
+// (omniroute_agent_skills_list/get/coverage) are intentionally defined in BOTH
+// MCP_TOOLS (open-sse/mcp-server/schemas/tools.ts) and agentSkillTools
+// (open-sse/mcp-server/tools/agentSkillTools.ts), so the additive sum reported 99
+// while only 96 distinct tool names actually exist. countUniqueMcpTools
+// (open-sse/mcp-server/toolCount.ts) fixes this by unioning tool names into a Set
+// before counting, so a tool present in multiple collections is only counted once.
+
+const { countUniqueMcpTools } = await import("../../open-sse/mcp-server/toolCount.ts");
+const { MCP_TOOLS } = await import("../../open-sse/mcp-server/schemas/tools.ts");
+const { memoryTools } = await import("../../open-sse/mcp-server/tools/memoryTools.ts");
+const { skillTools } = await import("../../open-sse/mcp-server/tools/skillTools.ts");
+const { agentSkillTools } = await import("../../open-sse/mcp-server/tools/agentSkillTools.ts");
+const { githubSkillTools } = await import("../../open-sse/mcp-server/tools/githubSkillTools.ts");
+const { poolTools } = await import("../../open-sse/mcp-server/tools/poolTools.ts");
+const { gamificationTools } = await import("../../open-sse/mcp-server/tools/gamificationTools.ts");
+const { pluginTools } = await import("../../open-sse/mcp-server/tools/pluginTools.ts");
+const { notionTools } = await import("../../open-sse/mcp-server/tools/notionTools.ts");
+const { obsidianTools } = await import("../../open-sse/mcp-server/tools/obsidianTools.ts");
+
+type NamedTool = { name: string };
+
+function namesOf(collection: readonly NamedTool[] | Record<string, NamedTool>): string[] {
+  return Array.isArray(collection)
+    ? collection.map((t) => t.name)
+    : Object.values(collection).map((t) => t.name);
+}
+
+test("#6854: countUniqueMcpTools de-duplicates tools registered in multiple collections", () => {
+  // The agent-skills trio is intentionally present in both MCP_TOOLS and agentSkillTools.
+  const mcpToolsNames = namesOf(MCP_TOOLS as unknown as NamedTool[]);
+  const agentSkillNames = namesOf(agentSkillTools as unknown as Record<string, NamedTool>);
+  const overlap = mcpToolsNames.filter((n) => agentSkillNames.includes(n));
+  assert.ok(
+    overlap.length > 0,
+    "expected MCP_TOOLS and agentSkillTools to still share the agent-skills tool names " +
+      "(if this fails because the overlap was removed instead, this test's premise no " +
+      "longer applies and it should be revisited)"
+  );
+
+  const collections = {
+    MCP_TOOLS: MCP_TOOLS as unknown as NamedTool[],
+    memoryTools: memoryTools as unknown as Record<string, NamedTool>,
+    skillTools: skillTools as unknown as Record<string, NamedTool>,
+    agentSkillTools: agentSkillTools as unknown as Record<string, NamedTool>,
+    githubSkillTools: githubSkillTools as unknown as Record<string, NamedTool>,
+    poolTools: poolTools as unknown as Record<string, NamedTool>,
+    gamificationTools: gamificationTools as unknown as NamedTool[],
+    pluginTools: pluginTools as unknown as NamedTool[],
+    notionTools: notionTools as unknown as NamedTool[],
+    obsidianTools: obsidianTools as unknown as NamedTool[],
+  };
+
+  const total = countUniqueMcpTools(collections);
+
+  // Independently compute the "true" unique count by unioning every collection's
+  // tool names into a Set — this must equal countUniqueMcpTools's own result AND
+  // must be strictly less than the naive additive sum whenever there is overlap.
+  const uniqueNames = new Set<string>();
+  for (const collection of Object.values(collections)) {
+    for (const name of namesOf(collection)) uniqueNames.add(name);
+  }
+
+  const naiveAdditiveSum = Object.values(collections).reduce(
+    (sum, collection) => sum + namesOf(collection).length,
+    0
+  );
+
+  assert.equal(total, uniqueNames.size, "countUniqueMcpTools must equal the unique-name count");
+  assert.equal(
+    total,
+    naiveAdditiveSum - overlap.length,
+    "unique count must be exactly the additive sum minus the double-counted overlap"
+  );
+  assert.ok(
+    total < naiveAdditiveSum,
+    "unique count must be strictly less than the naive additive sum given a known overlap"
+  );
+});


### PR DESCRIPTION
Closes #6854

## Root cause
`TOTAL_MCP_TOOL_COUNT` in `open-sse/mcp-server/server.ts` (lines ~101-111) summed the sizes of 10 tool collections additively. The agent-skills trio (`omniroute_agent_skills_list`, `omniroute_agent_skills_get`, `omniroute_agent_skills_coverage`) is intentionally defined in **both** `MCP_TOOLS` (`open-sse/mcp-server/schemas/tools.ts`) and `agentSkillTools` (`open-sse/mcp-server/tools/agentSkillTools.ts`) — a second, independent implementation of the same tool surface. The additive formula counted each of those 3 tools twice, reporting 99 instead of the actual 96 unique tool names.

## Fix
Replaced the additive sum with `countUniqueMcpTools()` (new `open-sse/mcp-server/toolCount.ts`), which unions every collection's tool `name`s into a `Set` before counting — any tool present in more than one collection is counted once, and this self-corrects for any future duplicate additions.

## TDD (Hard Rule #18)
- **RED**: reproduced the exact runtime formula from `server.ts` before the fix — `TOTAL_MCP_TOOL_COUNT = 99`, unique names `= 96`, diff `= 3` (matches the issue exactly).
- **Fix applied.**
- **GREEN**: same computation via `countUniqueMcpTools()` now returns `96`. New regression test `tests/unit/mcp-tool-count-dedup-6854.test.ts` asserts the dedup result equals the independently-computed unique-name count and is strictly less than the naive additive sum given the known agent-skills overlap. Passes: `1 pass, 0 fail`.

## Gates run (all green)
- `node scripts/check/check-file-size.mjs` — OK
- `node scripts/check/check-complexity.mjs` — OK (2050 violations vs baseline 2054, no regression)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (885 violations vs baseline 885, no regression)
- `node scripts/check/check-changelog-integrity.mjs` — pre-existing base-red drift only (7 bullets missing vs origin tip, unrelated to this change; branch tip == origin/release/v3.8.47 tip, CHANGELOG.md untouched by this PR — fragment-based instead)
- `npm run typecheck:core` — clean
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` — clean, exit 0
- Existing tests exercising the touched collections (`tests/unit/mcp-server-entry.test.ts`, `tests/unit/mcp-tool-collections-shape.test.ts`) — 19/19 pass

## Scope
Minimal — only `server.ts`'s `TOTAL_MCP_TOOL_COUNT` computation changed, plus the new dedup helper and its test. No drive-by refactors. The secondary doc-count-drift the reporter also flagged (docs say 94, missing `githubSkillTools` from the doc formula) is out of scope for this fix — it is documentation reconciliation, not the double-count defect.