### PR TITLE
fix(sse): apply cliproxyapiModelMapping at CLIProxyAPI dispatch time (#6876)

### DIFF
--- a/changelog.d/fixes/6876-6876-cliproxy-modelmap.md
+++ b/changelog.d/fixes/6876-6876-cliproxy-modelmap.md
@@ -1,0 +1,1 @@
+- fix(sse): apply cliproxyapiModelMapping at CLIProxyAPI dispatch time (#6876)

--- a/open-sse/handlers/chatCore/cliproxyModelMapping.ts
+++ b/open-sse/handlers/chatCore/cliproxyModelMapping.ts
@@ -1,0 +1,69 @@
+/**
+ * CLIProxyAPI model-mapping application (#6876).
+ *
+ * The dashboard persists `cliproxyapiModelMapping` per provider
+ * (`upstream_proxy_config.cliproxyapi_model_mapping`) but nothing at
+ * request-dispatch time ever consulted it — the configured alias was
+ * silently dropped and the original model was forwarded verbatim to
+ * CLIProxyAPI. This module applies the mapping exactly once, at the
+ * executor boundary, so it only affects requests that actually reach
+ * CLIProxyAPI (the `cliproxyapi` passthrough leg and the CLIProxyAPI retry
+ * leg of `fallback` mode) and never the native leg of `fallback` mode.
+ */
+
+type ExecutorInput = {
+  model: string;
+  body: unknown;
+  [key: string]: unknown;
+};
+
+type ExecutorLike = {
+  execute: (input: ExecutorInput) => Promise<unknown>;
+  [key: string]: unknown;
+};
+
+export type CliproxyapiModelMapping = Record<string, unknown> | null | undefined;
+
+function resolveMappedModel(model: string, mapping: CliproxyapiModelMapping): string | null {
+  if (!mapping || typeof mapping !== "object") return null;
+  const mapped = (mapping as Record<string, unknown>)[model];
+  return typeof mapped === "string" && mapped.trim() ? mapped : null;
+}
+
+/**
+ * Rewrites `input.model` (and `input.body.model` when body is a plain
+ * object) to the mapped model, if one is configured for `input.model`.
+ * Returns the original input unchanged when no mapping applies.
+ */
+export function applyCliproxyapiModelMapping(
+  input: ExecutorInput,
+  mapping: CliproxyapiModelMapping
+): ExecutorInput {
+  const mappedModel = resolveMappedModel(input.model, mapping);
+  if (!mappedModel) return input;
+
+  const body =
+    input.body && typeof input.body === "object" && !Array.isArray(input.body)
+      ? { ...(input.body as Record<string, unknown>), model: mappedModel }
+      : input.body;
+
+  return { ...input, model: mappedModel, body };
+}
+
+/**
+ * Wraps an executor so every `execute()` call has the CLIProxyAPI model
+ * mapping applied first. Returns the executor unchanged when no mapping is
+ * configured (empty/absent mapping is a no-op, matching prior behavior).
+ */
+export function wrapExecutorWithCliproxyapiModelMapping<T extends ExecutorLike>(
+  executor: T,
+  mapping: CliproxyapiModelMapping
+): T {
+  if (!mapping || typeof mapping !== "object" || Object.keys(mapping).length === 0) {
+    return executor;
+  }
+  const wrapped = Object.create(executor) as T;
+  wrapped.execute = (input: ExecutorInput) =>
+    executor.execute(applyCliproxyapiModelMapping(input, mapping));
+  return wrapped;
+}

--- a/open-sse/handlers/chatCore/comboContextCache.ts
+++ b/open-sse/handlers/chatCore/comboContextCache.ts
@@ -4,7 +4,14 @@ import { getUpstreamProxyConfig } from "@/lib/localDb";
  * Module-level cache for upstream proxy config (shared across all requests).
  * 10s TTL prevents per-request DB lookups while staying fresh enough for setting changes.
  */
-const _proxyConfigCache = new Map<string, { mode: string; enabled: boolean; ts: number }>();
+type UpstreamProxyConfigCacheEntry = {
+  mode: string;
+  enabled: boolean;
+  cliproxyapiModelMapping: Record<string, unknown> | null;
+  ts: number;
+};
+
+const _proxyConfigCache = new Map<string, UpstreamProxyConfigCacheEntry>();
 const PROXY_CONFIG_CACHE_TTL = 10_000;
 
 /**
@@ -55,9 +62,14 @@ export async function getUpstreamProxyConfigCached(providerId: string) {
   const cached = _proxyConfigCache.get(providerId);
   if (cached && Date.now() - cached.ts < PROXY_CONFIG_CACHE_TTL) return cached;
   const cfg = await getUpstreamProxyConfig(providerId).catch(() => null);
-  const result = cfg
-    ? { mode: cfg.mode, enabled: cfg.enabled, ts: Date.now() }
-    : { mode: "native" as const, enabled: false, ts: Date.now() };
+  const result: UpstreamProxyConfigCacheEntry = cfg
+    ? {
+        mode: cfg.mode,
+        enabled: cfg.enabled,
+        cliproxyapiModelMapping: cfg.cliproxyapiModelMapping ?? null,
+        ts: Date.now(),
+      }
+    : { mode: "native" as const, enabled: false, cliproxyapiModelMapping: null, ts: Date.now() };
   _proxyConfigCache.set(providerId, result);
   return result;
 }

--- a/open-sse/handlers/chatCore/executorProxy.ts
+++ b/open-sse/handlers/chatCore/executorProxy.ts
@@ -13,6 +13,7 @@ import { getExecutor } from "../../executors/index.ts";
 import { isCliproxyapiDeepModeEnabled } from "../../executors/cliproxyapi.ts";
 import { getCachedSettings } from "@/lib/db/readCache";
 import { getUpstreamProxyConfigCached } from "./comboContextCache.ts";
+import { wrapExecutorWithCliproxyapiModelMapping } from "./cliproxyModelMapping.ts";
 
 type LoggerLike =
   | {
@@ -47,12 +48,20 @@ export async function resolveExecutorWithProxy(
 
   if (cfg.mode === "cliproxyapi") {
     log?.info?.("UPSTREAM_PROXY", `${prov} routed through CLIProxyAPI (passthrough)`);
-    return getExecutor("cliproxyapi");
+    return wrapExecutorWithCliproxyapiModelMapping(
+      getExecutor("cliproxyapi"),
+      cfg.cliproxyapiModelMapping
+    );
   }
 
-  // mode === "fallback": try native first, retry via CLIProxyAPI on specific failures
+  // mode === "fallback": try native first, retry via CLIProxyAPI on specific failures.
+  // The model mapping applies only to the CLIProxyAPI retry leg (proxyExec) — the
+  // native leg must keep seeing the original, unmapped model.
   const nativeExec = getExecutor(prov);
-  const proxyExec = getExecutor("cliproxyapi");
+  const proxyExec = wrapExecutorWithCliproxyapiModelMapping(
+    getExecutor("cliproxyapi"),
+    cfg.cliproxyapiModelMapping
+  );
 
   // Read custom fallback codes from settings. Default: 5xx + 429 + network errors.
   let fallbackCodes: number[] = [429, 500, 502, 503, 504];

--- a/tests/unit/cliproxyapi-model-mapping-dispatch.test.ts
+++ b/tests/unit/cliproxyapi-model-mapping-dispatch.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Regression tests for #6876 — `cliproxyapiModelMapping` was persisted by the
+ * dashboard (`upstream_proxy_config.cliproxyapi_model_mapping`) but never
+ * consulted at request-dispatch time: the mapped model never made it onto the
+ * outbound CLIProxyAPI wire request.
+ *
+ * All tests exercise REAL production functions end-to-end:
+ *   - upsertUpstreamProxyConfig (src/lib/db/upstreamProxy.ts)
+ *   - resolveExecutorWithProxy (open-sse/handlers/chatCore/executorProxy.ts)
+ *   - CliproxyapiExecutor.execute (open-sse/executors/cliproxyapi.ts)
+ * `globalThis.fetch` is stubbed only to capture the outbound wire body.
+ */
+
+import { describe, it, before, after, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const testDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "omni-6876-model-mapping-"));
+process.env.DATA_DIR = testDataDir;
+
+const coreDb = await import("../../src/lib/db/core.ts");
+const upstreamProxyDb = await import("../../src/lib/db/upstreamProxy.ts");
+const { resolveExecutorWithProxy } =
+  await import("../../open-sse/handlers/chatCore/executorProxy.ts");
+const { clearUpstreamProxyConfigCache } =
+  await import("../../open-sse/handlers/chatCore/comboContextCache.ts");
+
+before(async () => {
+  await coreDb.ensureDbInitialized();
+});
+
+afterEach(() => {
+  clearUpstreamProxyConfigCache();
+});
+
+after(() => {
+  coreDb.resetDbInstance();
+  if (fs.existsSync(testDataDir)) fs.rmSync(testDataDir, { recursive: true, force: true });
+});
+
+type ExecuteInput = {
+  model: string;
+  body: unknown;
+  stream: boolean;
+  credentials: unknown;
+};
+
+type ExecutorLike = { execute: (input: ExecuteInput) => Promise<unknown> };
+
+async function captureFetchBody(fn: () => Promise<unknown>): Promise<Record<string, unknown>> {
+  let capturedBody: Record<string, unknown> | null = null;
+  const originalFetch = globalThis.fetch;
+  // @ts-expect-error test stub
+  globalThis.fetch = async (_url: string, init: RequestInit) => {
+    capturedBody = JSON.parse(init.body as string);
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+  try {
+    await fn();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+  assert.ok(capturedBody, "executor should have issued a fetch call");
+  return capturedBody as Record<string, unknown>;
+}
+
+describe("#6876 — cliproxyapiModelMapping applied at dispatch", () => {
+  it("forwards the MAPPED model to CLIProxyAPI in cliproxyapi (passthrough) mode", async () => {
+    await upstreamProxyDb.upsertUpstreamProxyConfig({
+      providerId: "anthropic-mapped-passthrough",
+      mode: "cliproxyapi",
+      enabled: true,
+      cliproxyapiModelMapping: { "claude-3-opus": "claude-3-opus-mapped" },
+    });
+
+    const executor = await resolveExecutorWithProxy(
+      "anthropic-mapped-passthrough",
+      undefined,
+      null
+    );
+    assert.equal(
+      (executor as { provider?: string }).provider,
+      "cliproxyapi",
+      "sanity: provider should route through the cliproxyapi executor"
+    );
+
+    const capturedBody = await captureFetchBody(() =>
+      (executor as ExecutorLike).execute({
+        model: "claude-3-opus",
+        body: { model: "claude-3-opus", messages: [{ role: "user", content: "hi" }] },
+        stream: false,
+        credentials: { apiKey: "test-key" },
+      })
+    );
+
+    assert.equal(
+      capturedBody.model,
+      "claude-3-opus-mapped",
+      `expected mapped model "claude-3-opus-mapped" to be forwarded upstream, got unmapped "${capturedBody.model}"`
+    );
+  });
+
+  it("does NOT remap the model when no mapping is configured (no regression)", async () => {
+    await upstreamProxyDb.upsertUpstreamProxyConfig({
+      providerId: "anthropic-no-mapping",
+      mode: "cliproxyapi",
+      enabled: true,
+    });
+
+    const executor = await resolveExecutorWithProxy("anthropic-no-mapping", undefined, null);
+
+    const capturedBody = await captureFetchBody(() =>
+      (executor as ExecutorLike).execute({
+        model: "claude-3-opus",
+        body: { model: "claude-3-opus", messages: [{ role: "user", content: "hi" }] },
+        stream: false,
+        credentials: { apiKey: "test-key" },
+      })
+    );
+
+    assert.equal(capturedBody.model, "claude-3-opus", "unmapped model must pass through unchanged");
+  });
+});


### PR DESCRIPTION
Closes #6876

## Root cause

`cliproxyapiModelMapping` is fully persisted per-provider (`upstream_proxy_config.cliproxyapi_model_mapping`, written by `upsertUpstreamProxyConfig`/read by `GET /api/settings`) but was never consulted at request-dispatch time:

1. `open-sse/handlers/chatCore/comboContextCache.ts::getUpstreamProxyConfigCached` narrowed the cached config to `{ mode, enabled }`, dropping `cliproxyapiModelMapping` before it ever reached the dispatch path.
2. `open-sse/handlers/chatCore/executorProxy.ts::resolveExecutorWithProxy` only branched on `mode`/`enabled` to pick an executor — it never had the mapping to apply, and never applied one.
3. `CliproxyapiExecutor.execute`/`transformRequest` forwarded `input.model` verbatim onto the outbound wire request.

Net effect: a model alias configured in the dashboard for CLIProxyAPI routing was silently ignored — the original (unmapped) model always hit CLIProxyAPI.

## Fix

- `comboContextCache.ts`: stop discarding `cliproxyapiModelMapping` in the cached config shape (both the DB-hit and the `null`-fallback branches).
- New module `open-sse/handlers/chatCore/cliproxyModelMapping.ts`: `applyCliproxyapiModelMapping()` rewrites `input.model` (and `input.body.model` when body is a plain object) per the configured mapping; `wrapExecutorWithCliproxyapiModelMapping()` decorates an executor so every `execute()` call goes through the rewrite (no-op when no mapping is configured — matches prior passthrough behavior).
- `executorProxy.ts`: apply the wrapper to the `cliproxyapi` passthrough executor, and to the CLIProxyAPI retry leg (`proxyExec`) of `fallback` mode only — the native leg (`nativeExec`) is left untouched so mapping never affects the native path.

## Regression test

`tests/unit/cliproxyapi-model-mapping-dispatch.test.ts` (new file), exercising the real production functions end-to-end (`upsertUpstreamProxyConfig`, `resolveExecutorWithProxy`, `CliproxyapiExecutor.execute`), stubbing only `globalThis.fetch` to capture the outbound wire body:

- mapping configured + mode=`cliproxyapi` → mapped model forwarded on the wire — **RED before the fix** (`AssertionError: expected mapped model "claude-3-opus-mapped" ... got unmapped "claude-3-opus"`), **GREEN after**.
- no mapping configured → unmapped model still passes through unchanged (no regression for the common case).

Existing coverage confirmed unaffected: `tests/unit/cliproxyapi-fallback-wiring.test.ts` (12/12 pass) and `tests/unit/chatcore-executor-proxy.test.ts` (9/9 pass).

## Gates run (all green)

- `node scripts/check/check-file-size.mjs`
- `node scripts/check/check-complexity.mjs`
- `node scripts/check/check-cognitive-complexity.mjs`
- `node scripts/check/check-changelog-integrity.mjs`
- `npm run typecheck:core`
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>`
- `node --import tsx/esm --test tests/unit/cliproxyapi-model-mapping-dispatch.test.ts`
- `node --import tsx/esm --test tests/unit/cliproxyapi-fallback-wiring.test.ts`
- `node --import tsx/esm --test tests/unit/chatcore-executor-proxy.test.ts`