### PR TITLE
fix(providers): honor max_token capability override in reasoning buffer clamp (#6524)

### DIFF
--- a/changelog.d/fixes/6524-6524-reasoning-buffer-clamp.md
+++ b/changelog.d/fixes/6524-6524-reasoning-buffer-clamp.md
@@ -1,0 +1,1 @@
+- fix(providers): honor the `max_token` capability override in the reasoning-token-buffer output cap (#6524)

--- a/src/lib/modelCapabilities.ts
+++ b/src/lib/modelCapabilities.ts
@@ -341,8 +341,33 @@ function resolveVisionCapability(
   return null;
 }
 
+/**
+ * Issue #6524: an operator-set `max_token` capability override (see
+ * `src/lib/db/modelCapabilityOverrides.ts`) is the manual escape hatch for a
+ * wrong/stale synced `limit_output` value (e.g. a provider's models.dev catalog
+ * row reporting `limit_output` equal to `limit_context`). It already won over the
+ * synced value in `getResolvedModelCapabilities().maxOutputTokens` — this helper
+ * makes `getExplicitModelOutputCap()` (used by the reasoning-token-buffer clamp)
+ * consult the same override so both read paths agree.
+ */
+function getMaxTokenCapabilityOverride(resolved: {
+  provider: string | null;
+  model: string | null;
+  rawModel: string | null;
+}): number | null {
+  return (
+    getModelCapabilityOverride(resolved.provider, resolved.model, "max_token") ??
+    (resolved.rawModel && resolved.rawModel !== resolved.model
+      ? getModelCapabilityOverride(resolved.provider, resolved.rawModel, "max_token")
+      : null)
+  );
+}
+
 export function getExplicitModelOutputCap(input: CapabilityInput): number | null {
   const resolved = resolveCapabilityInput(input);
+  const maxTokenOverride = getMaxTokenCapabilityOverride(resolved);
+  if (maxTokenOverride !== null) return maxTokenOverride;
+
   const synced = getSyncedCapabilityForResolved(
     resolved.provider,
     resolved.model,
@@ -402,11 +427,7 @@ export function getResolvedModelCapabilities(input: CapabilityInput): ResolvedMo
     spec?.contextWindow ??
     null;
 
-  const maxTokenOverride =
-    getModelCapabilityOverride(resolved.provider, resolved.model, "max_token") ??
-    (resolved.rawModel && resolved.rawModel !== resolved.model
-      ? getModelCapabilityOverride(resolved.provider, resolved.rawModel, "max_token")
-      : null);
+  const maxTokenOverride = getMaxTokenCapabilityOverride(resolved);
 
   return {
     provider: resolved.provider,

--- a/tests/unit/repro-6524.test.ts
+++ b/tests/unit/repro-6524.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Regression test for issue #6524.
+ *
+ * Reporter observed: for `ollama-cloud/deepseek-v4-flash`, a synced capability row
+ * with `limit_output=1048576` (wrongly equal to `limit_context`, while the real
+ * upstream output cap is `65536`) caused the reasoning-token-buffer heuristic to
+ * expand `max_tokens` 64000 -> 96000, which upstream rejected with
+ * "exceeds model's maximum output tokens (65536)".
+ *
+ * Root cause (confirmed by reading `resolveReasoningBufferedMaxTokens` and its
+ * `getExplicitModelOutputCap` clamp source): the clamp math itself is correct, but
+ * `getExplicitModelOutputCap()` only ever read the unvalidated synced
+ * `limit_output` (or registry/static fallbacks) — it ignored the operator-settable
+ * `max_token` capability override (`src/lib/db/modelCapabilityOverrides.ts`,
+ * `/api/model-capability-overrides`) that `getResolvedModelCapabilities()` already
+ * consulted. That inconsistency meant an operator manually correcting a bad synced
+ * output cap (the existing, already-shipped remediation path for wrong catalog
+ * data) had no effect on the reasoning buffer, which kept inflating past the real
+ * cap regardless.
+ *
+ * Fix: `getExplicitModelOutputCap()` now checks the same `max_token` override
+ * before falling back to synced/registry/static data, via a helper shared with
+ * `getResolvedModelCapabilities()`.
+ */
+import assert from "node:assert/strict";
+import test from "node:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-repro-6524-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const { saveModelsDevCapabilities, clearModelsDevCapabilities } = await import(
+  "../../src/lib/modelsDevSync.ts"
+);
+const { setModelCapabilityOverride, removeModelCapabilityOverride } = await import(
+  "../../src/lib/db/modelCapabilityOverrides.ts"
+);
+const { resolveReasoningBufferedMaxTokens } = await import(
+  "../../open-sse/services/reasoningTokenBuffer.ts"
+);
+
+const PROVIDER = "ollama-cloud";
+const MODEL = "deepseek-v4-flash";
+const TARGET = `${PROVIDER}/${MODEL}`;
+const REAL_UPSTREAM_OUTPUT_CAP = 65536; // per reporter's boundary test table
+
+function capabilityEntry(limitContext: unknown, overrides: Record<string, unknown> = {}) {
+  return {
+    reasoning: false,
+    tool_call: true,
+    attachment: false,
+    temperature: true,
+    structured_output: true,
+    limit: { context: limitContext, output: limitContext },
+    ...overrides,
+  };
+}
+
+test.before(() => {
+  clearModelsDevCapabilities();
+  // Mirrors the exact production row from the issue: limit_context and limit_output
+  // both wrongly synced to 1048576 for ollama-cloud/deepseek-v4-flash, while the real
+  // upstream output cap (per the reporter's boundary test) is 65536.
+  saveModelsDevCapabilities({
+    [PROVIDER]: {
+      [MODEL]: capabilityEntry(1048576, { reasoning: true, limit_output: 1048576 }),
+    },
+  });
+});
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("#6524: with only the (wrong) synced catalog data, the buffer still inflates past the real cap", () => {
+  // Documents the known, out-of-scope limitation: nothing in our codebase can
+  // psychically know the real upstream cap before an operator (or a future
+  // self-healing mechanism) supplies a correction. This is the reported symptom's
+  // starting state, not something this fix promises to eliminate on first contact.
+  const result = resolveReasoningBufferedMaxTokens(TARGET, 64000);
+  assert.equal(result, 96000);
+});
+
+test("#6524: an operator-set max_token override now clamps the reasoning buffer to the real cap", () => {
+  assert.ok(
+    setModelCapabilityOverride(TARGET, "max_token", REAL_UPSTREAM_OUTPUT_CAP),
+    "expected the max_token override to be written"
+  );
+  try {
+    const result = resolveReasoningBufferedMaxTokens(TARGET, 64000);
+    assert.ok(
+      result === null || result <= REAL_UPSTREAM_OUTPUT_CAP,
+      `expected max_tokens to stay <= ${REAL_UPSTREAM_OUTPUT_CAP}, got ${result} ` +
+        `(reproduces reported 64000 -> 96000 inflation, upstream then 400s)`
+    );
+  } finally {
+    removeModelCapabilityOverride(TARGET, "max_token");
+  }
+});


### PR DESCRIPTION
Closes #6524

## Root cause

`resolveReasoningBufferedMaxTokens()` (`open-sse/services/reasoningTokenBuffer.ts`) clamps the reasoning-token buffer to a ceiling from `getExplicitModelOutputCap()`. That clamp math is correct, but `getExplicitModelOutputCap()` only ever read the unvalidated synced `limit_output` (falling through to registry/static-spec data) — it never consulted the operator-settable `max_token` capability override (`model_capability_overrides` table, `/api/model-capability-overrides`) that `getResolvedModelCapabilities().maxOutputTokens` already honored.

Reporter's exact production case: `ollama-cloud/deepseek-v4-flash`'s synced catalog row reports `limit_output=1048576` (wrongly equal to `limit_context`), while the real upstream cap (confirmed by the reporter's boundary test) is `65536`. With only that bad synced data, the reasoning buffer inflates `max_tokens` `64000 -> 96000`, and upstream rejects with `exceeds model's maximum output tokens (65536)`.

Since nothing in OmniRoute derives the real per-model output cap from the external models.dev catalog data itself, the actionable fix is to let the *existing*, already-shipped manual-override escape hatch (built for exactly this class of bad catalog data) actually take effect for the reasoning buffer too — which it silently didn't before this PR.

## Fix

Extracted the override lookup (`getModelCapabilityOverride(..., "max_token")`, with the raw-model-id fallback) into a shared `getMaxTokenCapabilityOverride()` helper in `src/lib/modelCapabilities.ts`, and made `getExplicitModelOutputCap()` consult it first, before falling back to synced/registry/static data — exactly the precedence `getResolvedModelCapabilities()` already used. Both read paths now agree.

## Regression test

`tests/unit/repro-6524.test.ts` (new file):
1. **RED (confirmed on unfixed code)**: with only the wrong synced catalog data for `ollama-cloud/deepseek-v4-flash` (`limit_output=1048576`), setting a `max_token` override of `65536` and calling `resolveReasoningBufferedMaxTokens(..., 64000)` still returned `96000` — the override had no effect.
2. **GREEN (with the fix)**: the same call now returns `<= 65536`, honoring the override.
3. A companion assertion documents the known, out-of-scope limitation that stays unchanged by this PR: with *no* override set, the raw wrong synced data alone still produces `96000` (nothing in our code can correct external catalog data without an operator or a future self-healing signal — see issue follow-up #3, left for a separate PR).

## Gates run (all green)

- `node scripts/check/check-file-size.mjs` — OK (no files touched are frozen/near-cap)
- `node scripts/check/check-complexity.mjs` — OK, 2050 violations vs baseline 2054 (net improvement, no new violations)
- `node scripts/check/check-cognitive-complexity.mjs` — OK, 885 violations vs baseline 885 (no regression)
- `node scripts/check/check-changelog-integrity.mjs` — OK
- `npm run typecheck:core` — clean, exit 0
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json src/lib/modelCapabilities.ts tests/unit/repro-6524.test.ts` — clean, exit 0
- Existing related tests (`model-output-cap-synced-fallthrough-6714`, `model-capability-overrides`, `reasoning-token-buffer-6274`, `model-capabilities-registry`) + the new `repro-6524` test: 16/16 passing, 0 failures

## Changelog

`changelog.d/fixes/6524-6524-reasoning-buffer-clamp.md`