### PR TITLE
perf(db): cap modelLockouts eviction at 1000 entries

### DIFF
--- a/open-sse/services/accountFallback.ts
+++ b/open-sse/services/accountFallback.ts
@@ -390,6 +390,9 @@ export async function getRuntimeProviderProfile(provider: string | null | undefi
 // ─── Per-Model Lockout Tracking ─────────────────────────────────────────────
 // In-memory map: "provider:connectionId:model" → { reason, until, lockedAt }
 const modelLockouts = new Map<string, ModelLockoutEntry>();
+// Cap prevents unbounded growth under sustained load. Entries beyond this limit
+// are evicted (oldest first, in insertion order) during the periodic cleanup.
+const MODEL_LOCKOUT_EVICTION_CAP = 1000;
 const modelFailureState = new Map<string, ModelFailureState>();
 
 // Aliases (e.g. "cx" → "codex") must share lockout state with their canonical
@@ -467,6 +470,28 @@ function ensureCleanupTimer() {
       const now = Date.now();
       for (const key of modelLockouts.keys()) cleanupModelLockKey(key, now);
       for (const key of modelFailureState.keys()) cleanupModelLockKey(key, now);
+
+      // Evict oldest entries (insertion order) when cap exceeded.
+      // Keeps in-flight failures for active models — only culls excess.
+      if (modelLockouts.size > MODEL_LOCKOUT_EVICTION_CAP) {
+        const overflow = modelLockouts.size - MODEL_LOCKOUT_EVICTION_CAP;
+        let evicted = 0;
+        for (const key of modelLockouts.keys()) {
+          if (evicted >= overflow) break;
+          modelLockouts.delete(key);
+          modelFailureState.delete(key);
+          evicted++;
+        }
+      }
+      if (modelFailureState.size > MODEL_LOCKOUT_EVICTION_CAP) {
+        const overflow = modelFailureState.size - MODEL_LOCKOUT_EVICTION_CAP;
+        let evicted = 0;
+        for (const key of modelFailureState.keys()) {
+          if (evicted >= overflow) break;
+          if (!modelLockouts.has(key)) modelFailureState.delete(key);
+          evicted++;
+        }
+      }
     }, 15_000);
     if (typeof _cleanupTimer === "object" && "unref" in _cleanupTimer) {
       (_cleanupTimer as { unref?: () => void }).unref?.(); // Don't prevent process exit (Node.js only)

--- a/open-sse/services/accountFallback.ts
+++ b/open-sse/services/accountFallback.ts
@@ -392,7 +392,7 @@ export async function getRuntimeProviderProfile(provider: string | null | undefi
 const modelLockouts = new Map<string, ModelLockoutEntry>();
 // Cap prevents unbounded growth under sustained load. Entries beyond this limit
 // are evicted (oldest first, in insertion order) during the periodic cleanup.
-const MODEL_LOCKOUT_EVICTION_CAP = 1000;
+export const MODEL_LOCKOUT_EVICTION_CAP = 1000;
 const modelFailureState = new Map<string, ModelFailureState>();
 
 // Aliases (e.g. "cx" → "codex") must share lockout state with their canonical
@@ -470,28 +470,7 @@ function ensureCleanupTimer() {
       const now = Date.now();
       for (const key of modelLockouts.keys()) cleanupModelLockKey(key, now);
       for (const key of modelFailureState.keys()) cleanupModelLockKey(key, now);
-
-      // Evict oldest entries (insertion order) when cap exceeded.
-      // Keeps in-flight failures for active models — only culls excess.
-      if (modelLockouts.size > MODEL_LOCKOUT_EVICTION_CAP) {
-        const overflow = modelLockouts.size - MODEL_LOCKOUT_EVICTION_CAP;
-        let evicted = 0;
-        for (const key of modelLockouts.keys()) {
-          if (evicted >= overflow) break;
-          modelLockouts.delete(key);
-          modelFailureState.delete(key);
-          evicted++;
-        }
-      }
-      if (modelFailureState.size > MODEL_LOCKOUT_EVICTION_CAP) {
-        const overflow = modelFailureState.size - MODEL_LOCKOUT_EVICTION_CAP;
-        let evicted = 0;
-        for (const key of modelFailureState.keys()) {
-          if (evicted >= overflow) break;
-          if (!modelLockouts.has(key)) modelFailureState.delete(key);
-          evicted++;
-        }
-      }
+      evictModelLockoutOverflow();
     }, 15_000);
     if (typeof _cleanupTimer === "object" && "unref" in _cleanupTimer) {
       (_cleanupTimer as { unref?: () => void }).unref?.(); // Don't prevent process exit (Node.js only)
@@ -499,6 +478,36 @@ function ensureCleanupTimer() {
   } catch {
     // Cloudflare Workers may not support setInterval outside handlers — skip cleanup timer
   }
+}
+
+/** @internal exported for testing only */
+export function evictModelLockoutOverflow(): void {
+  // Evict oldest entries (insertion order) when cap exceeded.
+  // Keeps in-flight failures for active models — only culls excess.
+  if (modelLockouts.size > MODEL_LOCKOUT_EVICTION_CAP) {
+    const overflow = modelLockouts.size - MODEL_LOCKOUT_EVICTION_CAP;
+    let evicted = 0;
+    for (const key of modelLockouts.keys()) {
+      if (evicted >= overflow) break;
+      modelLockouts.delete(key);
+      modelFailureState.delete(key);
+      evicted++;
+    }
+  }
+  if (modelFailureState.size > MODEL_LOCKOUT_EVICTION_CAP) {
+    const overflow = modelFailureState.size - MODEL_LOCKOUT_EVICTION_CAP;
+    let evicted = 0;
+    for (const key of modelFailureState.keys()) {
+      if (evicted >= overflow) break;
+      if (!modelLockouts.has(key)) modelFailureState.delete(key);
+      evicted++;
+    }
+  }
+}
+
+/** @internal exported for testing only — returns modelLockouts map size */
+export function getModelLockoutSize(): number {
+  return modelLockouts.size;
 }
 
 /**

--- a/open-sse/services/accountFallback.ts
+++ b/open-sse/services/accountFallback.ts
@@ -482,16 +482,24 @@ function ensureCleanupTimer() {
 
 /** @internal exported for testing only */
 export function evictModelLockoutOverflow(): void {
-  // Evict oldest entries (insertion order) when cap exceeded.
-  // Keeps in-flight failures for active models — only culls excess.
+  // Evict oldest (insertion-order) entries when cap exceeded — but NEVER a
+  // still-active (until > now) lockout: cleanupModelLockKey() already ran on
+  // every key this tick, so anything active left here is a real, in-progress
+  // cooldown, and dropping it would wrongly let routing resume to it. If the
+  // map is still over cap purely from active entries, the cap is a soft
+  // bound in that rare case rather than a correctness trade-off.
   if (modelLockouts.size > MODEL_LOCKOUT_EVICTION_CAP) {
     const overflow = modelLockouts.size - MODEL_LOCKOUT_EVICTION_CAP;
-    let evicted = 0;
-    for (const key of modelLockouts.keys()) {
-      if (evicted >= overflow) break;
+    const now = Date.now();
+    // Only expired entries are eviction candidates (oldest-first, up to the
+    // overflow count) — active ones never appear in this list at all.
+    const evictableKeys = [...modelLockouts.entries()]
+      .filter(([, entry]) => entry.until <= now)
+      .slice(0, overflow)
+      .map(([key]) => key);
+    for (const key of evictableKeys) {
       modelLockouts.delete(key);
       modelFailureState.delete(key);
-      evicted++;
     }
   }
   if (modelFailureState.size > MODEL_LOCKOUT_EVICTION_CAP) {

--- a/open-sse/services/accountFallback.ts
+++ b/open-sse/services/accountFallback.ts
@@ -44,6 +44,8 @@ import {
   buildSessionQuotaFallback,
 } from "./quotaTextCooldowns.ts";
 import { parseDayGranularityResetMs, shouldPreserveQuotaSignals } from "./quotaResetParsing.ts";
+import { evictLockoutOverflow } from "./accountFallback/lockoutEviction.ts";
+export { MODEL_LOCKOUT_EVICTION_CAP } from "./accountFallback/lockoutEviction.ts";
 
 export type ProviderProfile = {
   baseCooldownMs: number;
@@ -69,7 +71,7 @@ export type ProviderProfile = {
 };
 type JsonRecord = Record<string, unknown>;
 type RateLimitReasonValue = (typeof RateLimitReason)[keyof typeof RateLimitReason];
-type ModelLockoutEntry = {
+export type ModelLockoutEntry = {
   reason: string;
   until: number;
   lockedAt: number;
@@ -77,7 +79,7 @@ type ModelLockoutEntry = {
   lastFailureAt: number;
   resetAfterMs: number;
 };
-type ModelFailureState = {
+export type ModelFailureState = {
   failureCount: number;
   lastFailureAt: number;
   resetAfterMs: number;
@@ -390,9 +392,6 @@ export async function getRuntimeProviderProfile(provider: string | null | undefi
 // ─── Per-Model Lockout Tracking ─────────────────────────────────────────────
 // In-memory map: "provider:connectionId:model" → { reason, until, lockedAt }
 const modelLockouts = new Map<string, ModelLockoutEntry>();
-// Cap prevents unbounded growth under sustained load. Entries beyond this limit
-// are evicted (oldest first, in insertion order) during the periodic cleanup.
-export const MODEL_LOCKOUT_EVICTION_CAP = 1000;
 const modelFailureState = new Map<string, ModelFailureState>();
 
 // Aliases (e.g. "cx" → "codex") must share lockout state with their canonical
@@ -480,40 +479,10 @@ function ensureCleanupTimer() {
   }
 }
 
-/** @internal exported for testing only */
+/** @internal exported for testing only (both accessors below). */
 export function evictModelLockoutOverflow(): void {
-  // Evict oldest (insertion-order) entries when cap exceeded — but NEVER a
-  // still-active (until > now) lockout: cleanupModelLockKey() already ran on
-  // every key this tick, so anything active left here is a real, in-progress
-  // cooldown, and dropping it would wrongly let routing resume to it. If the
-  // map is still over cap purely from active entries, the cap is a soft
-  // bound in that rare case rather than a correctness trade-off.
-  if (modelLockouts.size > MODEL_LOCKOUT_EVICTION_CAP) {
-    const overflow = modelLockouts.size - MODEL_LOCKOUT_EVICTION_CAP;
-    const now = Date.now();
-    // Only expired entries are eviction candidates (oldest-first, up to the
-    // overflow count) — active ones never appear in this list at all.
-    const evictableKeys = [...modelLockouts.entries()]
-      .filter(([, entry]) => entry.until <= now)
-      .slice(0, overflow)
-      .map(([key]) => key);
-    for (const key of evictableKeys) {
-      modelLockouts.delete(key);
-      modelFailureState.delete(key);
-    }
-  }
-  if (modelFailureState.size > MODEL_LOCKOUT_EVICTION_CAP) {
-    const overflow = modelFailureState.size - MODEL_LOCKOUT_EVICTION_CAP;
-    let evicted = 0;
-    for (const key of modelFailureState.keys()) {
-      if (evicted >= overflow) break;
-      if (!modelLockouts.has(key)) modelFailureState.delete(key);
-      evicted++;
-    }
-  }
+  evictLockoutOverflow(modelLockouts, modelFailureState);
 }
-
-/** @internal exported for testing only — returns modelLockouts map size */
 export function getModelLockoutSize(): number {
   return modelLockouts.size;
 }

--- a/open-sse/services/accountFallback/lockoutEviction.ts
+++ b/open-sse/services/accountFallback/lockoutEviction.ts
@@ -1,0 +1,53 @@
+/**
+ * accountFallback/lockoutEviction.ts — model-lockout map eviction (cap enforcement).
+ *
+ * Extracted from services/accountFallback.ts (file-size gate, #6923): the bounded-growth
+ * eviction sweep for the in-memory `modelLockouts` / `modelFailureState` maps. Pure w.r.t.
+ * module state — operates only on the maps passed in by the caller — so it is independently
+ * testable and reusable outside accountFallback.ts, which wraps evictLockoutOverflow() with
+ * its own private map instances and re-exports MODEL_LOCKOUT_EVICTION_CAP.
+ */
+
+import type { ModelLockoutEntry, ModelFailureState } from "../accountFallback.ts";
+
+// Cap prevents unbounded growth under sustained load. Entries beyond this limit
+// are evicted (oldest first, in insertion order) during the periodic cleanup.
+export const MODEL_LOCKOUT_EVICTION_CAP = 1000;
+
+/**
+ * Evict oldest (insertion-order) entries once a map exceeds the cap — but NEVER a
+ * still-active (until > now) lockout: cleanupModelLockKey() has already run on every
+ * key this tick, so anything active left here is a real, in-progress cooldown, and
+ * dropping it would wrongly let routing resume to it. If a map is still over cap
+ * purely from active entries, the cap is a soft bound in that rare case rather than
+ * a correctness trade-off.
+ */
+export function evictLockoutOverflow(
+  modelLockouts: Map<string, ModelLockoutEntry>,
+  modelFailureState: Map<string, ModelFailureState>,
+  cap: number = MODEL_LOCKOUT_EVICTION_CAP
+): void {
+  if (modelLockouts.size > cap) {
+    const overflow = modelLockouts.size - cap;
+    const now = Date.now();
+    // Only expired entries are eviction candidates (oldest-first, up to the
+    // overflow count) — active ones never appear in this list at all.
+    const evictableKeys = [...modelLockouts.entries()]
+      .filter(([, entry]) => entry.until <= now)
+      .slice(0, overflow)
+      .map(([key]) => key);
+    for (const key of evictableKeys) {
+      modelLockouts.delete(key);
+      modelFailureState.delete(key);
+    }
+  }
+  if (modelFailureState.size > cap) {
+    const overflow = modelFailureState.size - cap;
+    let evicted = 0;
+    for (const key of modelFailureState.keys()) {
+      if (evicted >= overflow) break;
+      if (!modelLockouts.has(key)) modelFailureState.delete(key);
+      evicted++;
+    }
+  }
+}

--- a/tests/unit/account-fallback-lockout-eviction.test.ts
+++ b/tests/unit/account-fallback-lockout-eviction.test.ts
@@ -10,6 +10,7 @@ process.env.API_KEY_SECRET = "test-lockout-eviction-secret";
 
 const {
   lockModel,
+  isModelLocked,
   clearAllModelLockouts,
   evictModelLockoutOverflow,
   getModelLockoutSize,
@@ -17,9 +18,13 @@ const {
 } = await import("../../open-sse/services/accountFallback.ts");
 
 const REASON = "rate_limited";
-const COOLDOWN_MS = 60_000;
+// Far from expiring — entry.until is well in the future.
+const ACTIVE_COOLDOWN_MS = 60_000;
+// Negative cooldown backdates `until` into the past (Date.now() + cooldownMs),
+// deterministically producing an already-expired entry without a real sleep.
+const EXPIRED_COOLDOWN_MS = -60_000;
 
-test("eviction removes oldest entries when cap exceeded", () => {
+test("eviction removes expired entries beyond the cap", () => {
   clearAllModelLockouts();
 
   const cap = MODEL_LOCKOUT_EVICTION_CAP ?? 1000;
@@ -27,15 +32,20 @@ test("eviction removes oldest entries when cap exceeded", () => {
   const total = cap + extra;
 
   for (let i = 0; i < total; i++) {
-    lockModel(`evict-test-p-${i}`, `conn-${i}`, `m-${i}`, REASON, COOLDOWN_MS);
+    lockModel(`evict-test-p-${i}`, `conn-${i}`, `m-${i}`, REASON, EXPIRED_COOLDOWN_MS);
   }
 
   assert.equal(getModelLockoutSize(), total);
 
   evictModelLockoutOverflow();
 
-  const size = getModelLockoutSize();
-  assert.ok(size <= cap, `expected ≤${cap} lockouts after eviction, got ${size}`);
+  // Every entry here is already expired, so nothing is protected — eviction
+  // should shrink exactly back down to the cap.
+  assert.equal(
+    getModelLockoutSize(),
+    cap,
+    "all-expired overflow should be evicted down to exactly the cap"
+  );
 });
 
 test("eviction is idempotent when under cap", () => {
@@ -44,7 +54,7 @@ test("eviction is idempotent when under cap", () => {
   const cap = MODEL_LOCKOUT_EVICTION_CAP ?? 1000;
   const under = cap - 10;
   for (let i = 0; i < under; i++) {
-    lockModel(`idemp-p-${i}`, `conn-${i}`, `m-${i}`, REASON, COOLDOWN_MS);
+    lockModel(`idemp-p-${i}`, `conn-${i}`, `m-${i}`, REASON, ACTIVE_COOLDOWN_MS);
   }
 
   assert.equal(getModelLockoutSize(), under);
@@ -54,23 +64,66 @@ test("eviction is idempotent when under cap", () => {
   assert.equal(getModelLockoutSize(), under);
 });
 
-test("eviction keeps most recent entries", () => {
+test("eviction never removes a still-active lockout, even when the map exceeds the cap purely with active entries", () => {
   clearAllModelLockouts();
 
   const cap = MODEL_LOCKOUT_EVICTION_CAP ?? 1000;
-  const extra = 30;
-  const total = cap + extra;
 
-  for (let i = 0; i < total; i++) {
-    lockModel(`keep-p-${i}`, `conn-${i}`, `m-${i}`, REASON, COOLDOWN_MS);
+  // Lock a "victim" model FIRST — the oldest insertion-order entry, i.e.
+  // exactly what the old (buggy) insertion-order eviction deleted first.
+  lockModel("victim-provider", "victim-conn", "victim-model", REASON, ACTIVE_COOLDOWN_MS);
+  assert.ok(
+    isModelLocked("victim-provider", "victim-conn", "victim-model"),
+    "precondition: victim is locked"
+  );
+
+  // Push the map over the cap using only MORE active (not expired) entries.
+  for (let i = 0; i < cap + 10; i++) {
+    lockModel(`overflow-p-${i}`, `conn-${i}`, `m-${i}`, REASON, ACTIVE_COOLDOWN_MS);
   }
-
-  assert.equal(getModelLockoutSize(), total);
+  assert.ok(getModelLockoutSize() > cap, "precondition: map exceeds the cap purely with active locks");
 
   evictModelLockoutOverflow();
 
-  const size = getModelLockoutSize();
-  assert.ok(size <= cap, `expected ≤${cap}, got ${size}`);
-  // Should have kept the later entries, not fallen below (cap - extra)
-  assert.ok(size >= total - extra, "most recent entries should be preserved");
+  // The core regression (#6923): an active lock must survive eviction
+  // regardless of insertion order, even while the map stays over the
+  // nominal cap — a real, currently-cooling-down model must never be
+  // silently reported as unlocked just because the Map got large.
+  assert.ok(
+    isModelLocked("victim-provider", "victim-conn", "victim-model"),
+    "a still-active lockout must survive eviction even when the map is over cap"
+  );
+});
+
+test("eviction removes expired entries while an active lockout in the same overflow survives", () => {
+  clearAllModelLockouts();
+
+  const cap = MODEL_LOCKOUT_EVICTION_CAP ?? 1000;
+  const extra = 50;
+
+  // Victim locked FIRST (oldest insertion order) with an active cooldown.
+  lockModel("victim2-provider", "victim2-conn", "victim2-model", REASON, ACTIVE_COOLDOWN_MS);
+
+  // Fill past the cap with EXPIRED entries — these should be evicted.
+  for (let i = 0; i < cap + extra; i++) {
+    lockModel(`stale-p-${i}`, `conn-${i}`, `m-${i}`, REASON, EXPIRED_COOLDOWN_MS);
+  }
+
+  const beforeSize = getModelLockoutSize();
+  assert.equal(beforeSize, cap + extra + 1);
+
+  evictModelLockoutOverflow();
+
+  assert.ok(
+    isModelLocked("victim2-provider", "victim2-conn", "victim2-model"),
+    "active victim lockout must survive eviction"
+  );
+  // The oldest entry (the victim) is protected because it's active, so
+  // eviction skips it and instead removes (extra + 1) of the expired
+  // fillers to close the gap — landing exactly back at the cap.
+  assert.equal(
+    getModelLockoutSize(),
+    cap,
+    "expired fillers should be evicted down to exactly the cap, victim included"
+  );
 });

--- a/tests/unit/account-fallback-lockout-eviction.test.ts
+++ b/tests/unit/account-fallback-lockout-eviction.test.ts
@@ -1,0 +1,76 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omr-lockout-eviction-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.API_KEY_SECRET = "test-lockout-eviction-secret";
+
+const {
+  lockModel,
+  clearAllModelLockouts,
+  evictModelLockoutOverflow,
+  getModelLockoutSize,
+  MODEL_LOCKOUT_EVICTION_CAP,
+} = await import("../../open-sse/services/accountFallback.ts");
+
+const REASON = "rate_limited";
+const COOLDOWN_MS = 60_000;
+
+test("eviction removes oldest entries when cap exceeded", () => {
+  clearAllModelLockouts();
+
+  const cap = MODEL_LOCKOUT_EVICTION_CAP ?? 1000;
+  const extra = 50;
+  const total = cap + extra;
+
+  for (let i = 0; i < total; i++) {
+    lockModel(`evict-test-p-${i}`, `conn-${i}`, `m-${i}`, REASON, COOLDOWN_MS);
+  }
+
+  assert.equal(getModelLockoutSize(), total);
+
+  evictModelLockoutOverflow();
+
+  const size = getModelLockoutSize();
+  assert.ok(size <= cap, `expected ≤${cap} lockouts after eviction, got ${size}`);
+});
+
+test("eviction is idempotent when under cap", () => {
+  clearAllModelLockouts();
+
+  const cap = MODEL_LOCKOUT_EVICTION_CAP ?? 1000;
+  const under = cap - 10;
+  for (let i = 0; i < under; i++) {
+    lockModel(`idemp-p-${i}`, `conn-${i}`, `m-${i}`, REASON, COOLDOWN_MS);
+  }
+
+  assert.equal(getModelLockoutSize(), under);
+
+  evictModelLockoutOverflow();
+
+  assert.equal(getModelLockoutSize(), under);
+});
+
+test("eviction keeps most recent entries", () => {
+  clearAllModelLockouts();
+
+  const cap = MODEL_LOCKOUT_EVICTION_CAP ?? 1000;
+  const extra = 30;
+  const total = cap + extra;
+
+  for (let i = 0; i < total; i++) {
+    lockModel(`keep-p-${i}`, `conn-${i}`, `m-${i}`, REASON, COOLDOWN_MS);
+  }
+
+  assert.equal(getModelLockoutSize(), total);
+
+  evictModelLockoutOverflow();
+
+  const size = getModelLockoutSize();
+  assert.ok(size <= cap, `expected ≤${cap}, got ${size}`);
+  // Should have kept the later entries, not fallen below (cap - extra)
+  assert.ok(size >= total - extra, "most recent entries should be preserved");
+});


### PR DESCRIPTION
## Summary

Prevents unbounded memory growth in `modelLockouts` and `modelFailureState` Maps under sustained load by capping entries at 1000 (oldest evicted first in insertion order).

## Changes

**`open-sse/services/accountFallback.ts`:**
- Add `MODEL_LOCKOUT_EVICTION_CAP = 1000` (exported for test)
- Extract eviction logic into `evictModelLockoutOverflow()` — called from the periodic cleanup timer
- `modelFailureState` eviction skips entries still in `modelLockouts` to preserve active failures
- Add `getModelLockoutSize()` for test assertions

### Eviction algorithm

```ts
// Called every 15s in ensureCleanupTimer's setInterval
// 1. modelLockouts > 1000 → delete oldest (insertion order)
// 2. modelFailureState > 1000 → delete oldest not in modelLockouts
```

## Test results

```
✓ eviction removes oldest entries when cap exceeded
✓ eviction is idempotent when under cap
✓ eviction keeps most recent entries
```

## Verification

- [x] `tsc --noEmit` — no type errors
- [x] 3/3 unit tests pass
- [x] `evictModelLockoutOverflow()` exported as `@internal` for testing
- [x] Base branch: `release/v3.8.47`