### PR TITLE
fix(db): add authType filter support to getProviderConnections

### DIFF
--- a/src/lib/db/providers.ts
+++ b/src/lib/db/providers.ts
@@ -55,6 +55,10 @@ export async function getProviderConnections(filter: JsonRecord = {}) {
     conditions.push("is_active = @isActive");
     params.isActive = filter.isActive ? 1 : 0;
   }
+  if (filter.authType) {
+    conditions.push("auth_type = @authType");
+    params.authType = filter.authType;
+  }
 
   if (conditions.length > 0) {
     sql += " WHERE " + conditions.join(" AND ");

--- a/tests/unit/db-providers-crud.test.ts
+++ b/tests/unit/db-providers-crud.test.ts
@@ -81,6 +81,34 @@ test("createProviderConnection assigns provider-scoped priorities and supports f
   assert.equal(second.isActive, false);
 });
 
+test("getProviderConnections filters by authType", async () => {
+  const apiKeyConnection = await providersDb.createProviderConnection({
+    provider: "openai",
+    authType: "apikey",
+    name: "API Key Connection",
+    apiKey: "sk-apikey",
+  });
+  const oauthConnection = await providersDb.createProviderConnection({
+    provider: "claude",
+    authType: "oauth",
+    email: "oauth@example.com",
+    accessToken: "token-a",
+    refreshToken: "refresh-a",
+  });
+
+  const oauthOnly = await providersDb.getProviderConnections({ authType: "oauth" });
+  const apiKeyOnly = await providersDb.getProviderConnections({ authType: "apikey" });
+
+  assert.deepEqual(
+    oauthOnly.map((connection) => connection.id),
+    [oauthConnection.id]
+  );
+  assert.deepEqual(
+    apiKeyOnly.map((connection) => connection.id),
+    [apiKeyConnection.id]
+  );
+});
+
 test("oauth connections upsert by provider and email instead of duplicating rows", async () => {
   const original = await providersDb.createProviderConnection({
     provider: "claude",


### PR DESCRIPTION
## Problem

`getProviderConnections` accepts a filter object but only processes `provider` and `isActive` keys. The `authType` query param is silently ignored, so callers like `tokenHealthCheck.ts` that pass `{ authType: "oauth" }` still fetch ALL connections and pay decryption cost for every row.

## Change

Added `auth_type = @authType` SQL WHERE clause when `filter.authType` is provided.

## Context

Originally flagged by gemini-code-assist review on PR #6590 — deferred as out-of-scope. Now landing as a standalone fix.

## Verification

`npm run test:unit:serial -- --findRelatedTests src/lib/db/providers.ts` — 18/18 pass.