### PR TITLE
fix(sse): set includeServerSideToolInvocations on Antigravity tool cloak decoys (#6914)

### DIFF
--- a/changelog.d/fixes/6914-antigravity-server-side-tool-invocations.md
+++ b/changelog.d/fixes/6914-antigravity-server-side-tool-invocations.md
@@ -1,0 +1,1 @@
+- fix(sse): set includeServerSideToolInvocations on Antigravity tool cloak decoys (#6914)

--- a/open-sse/config/toolCloaking.ts
+++ b/open-sse/config/toolCloaking.ts
@@ -174,6 +174,18 @@ export function cloakAntigravityToolPayload<T extends JsonRecord>(
         ...preservedTools,
         { functionDeclarations: [...cloakedDeclarations, ...decoys] },
       ];
+
+      // The decoy tools mimic real Antigravity IDE built-in agent tools (search_web,
+      // browser_subagent, read_url_content, generate_image), whose names match the
+      // server-side "Built-in tools" categories Gemini 3's Cloud Code backend
+      // recognizes. A genuine Antigravity client always pairs those declarations with
+      // this opt-in flag; without it, mixing them with custom function declarations
+      // gets rejected upstream (#6914).
+      const existingToolConfig = asRecord(nextRequest.toolConfig) ?? {};
+      nextRequest.toolConfig = {
+        ...existingToolConfig,
+        includeServerSideToolInvocations: true,
+      };
       changed = true;
     }
   }

--- a/tests/unit/antigravity-tool-cloak-server-side-invocations.test.ts
+++ b/tests/unit/antigravity-tool-cloak-server-side-invocations.test.ts
@@ -1,0 +1,61 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { openaiToAntigravityRequest } from "../../open-sse/translator/request/openai-to-gemini.ts";
+import { cloakAntigravityToolPayload } from "../../open-sse/config/toolCloaking.ts";
+
+test("Antigravity payload sets include_server_side_tool_invocations when built-in-shaped decoy tools are injected (#6914)", () => {
+  const body = {
+    model: "gemini-pro-agent",
+    messages: [{ role: "user", content: "list files in the repo" }],
+    tools: [
+      {
+        type: "function",
+        function: {
+          name: "bash",
+          description: "run a shell command",
+          parameters: { type: "object", properties: { cmd: { type: "string" } } },
+        },
+      },
+    ],
+  };
+  const envelope = openaiToAntigravityRequest("gemini-pro-agent", body, false, {
+    projectId: "test-project",
+  });
+  const { body: cloaked } = cloakAntigravityToolPayload(envelope as Record<string, unknown>);
+  const serialized = JSON.stringify(cloaked);
+  const BUILTIN_SHAPED_DECOY_NAMES = [
+    "search_web",
+    "browser_subagent",
+    "read_url_content",
+    "generate_image",
+  ];
+  const injectedBuiltinShapedDecoys = BUILTIN_SHAPED_DECOY_NAMES.filter((name) =>
+    serialized.includes(`"${name}"`)
+  );
+  const hasOptInFlag =
+    serialized.includes("include_server_side_tool_invocations") ||
+    serialized.includes("includeServerSideToolInvocations");
+
+  assert.notDeepEqual(injectedBuiltinShapedDecoys, [], "expected decoy tools to be injected");
+  assert.equal(
+    hasOptInFlag,
+    true,
+    "expected the includeServerSideToolInvocations opt-in flag to be set alongside decoy tools"
+  );
+});
+
+test("Antigravity payload does not set the opt-in flag when no decoys are injected", () => {
+  const body = {
+    model: "gemini-pro-agent",
+    messages: [{ role: "user", content: "hello" }],
+  };
+  const envelope = openaiToAntigravityRequest("gemini-pro-agent", body, false, {
+    projectId: "test-project",
+  });
+  const { body: cloaked } = cloakAntigravityToolPayload(envelope as Record<string, unknown>);
+  const serialized = JSON.stringify(cloaked);
+  const hasOptInFlag =
+    serialized.includes("include_server_side_tool_invocations") ||
+    serialized.includes("includeServerSideToolInvocations");
+  assert.equal(hasOptInFlag, false, "flag should not be set when no tools/decoys are present");
+});


### PR DESCRIPTION
Closes #6914

## Root cause

`cloakAntigravityToolPayload()` (`open-sse/config/toolCloaking.ts`) unconditionally pads every Antigravity/agy tool-calling request with decoy `functionDeclarations` mimicking Antigravity's built-in server-side agent tools (`search_web`, `browser_subagent`, `read_url_content`, `generate_image`) — names that match the 'Built-in tools' categories Gemini 3's Cloud Code backend recognizes (web search, browsing, URL fetch, image generation). The cloak never sets the companion `toolConfig.includeServerSideToolInvocations` flag a real Antigravity client sends alongside those declarations. Google's backend requires this opt-in whenever built-in tool categories are combined with custom function declarations in the same request, so every Antigravity tool-calling request (any model, Gemini or Claude via the same envelope) fails upstream. Confirmed distinct from #6685 (unrelated, size-correlated, field-less 400).

## Fix

In `cloakAntigravityToolPayload`, when decoy tools are injected (the `cloakedDeclarations.length > 0` branch), also set `request.toolConfig.includeServerSideToolInvocations = true`. Verified the Claude-via-Antigravity path (`isClaude` branch in `openai-to-gemini.ts`) only strips `thinkingConfig`, never touches `toolConfig` — the flag passes through unaffected for Claude models on this backend.

## Regression test (TDD, Hard Rule #18)

New file `tests/unit/antigravity-tool-cloak-server-side-invocations.test.ts`:
- RED (before fix): `AssertionError: expected the includeServerSideToolInvocations opt-in flag to be set alongside decoy tools — false !== true`
- GREEN (after fix): both assertions (decoys present + opt-in flag present) pass; second test confirms the flag is NOT set when no tools/decoys are involved (no regression for plain-chat requests).

Command:
```
node --import tsx/esm --test tests/unit/antigravity-tool-cloak-server-side-invocations.test.ts
```

Existing Antigravity cloak regression suite re-run clean (no round-trip regression):
```
node --import tsx/esm --test tests/unit/provider-request-capture-toolname-antigravity-4181.test.ts tests/unit/antigravity-tool-cloaking.test.ts
```
7/7 pass.

## Gates run (all green)

- `node scripts/check/check-file-size.mjs` — no violation on touched files (1 pre-existing unrelated violation on `ProxyRegistryManager.tsx`, not touched by this PR)
- `node scripts/check/check-complexity.mjs` — OK (2056, baseline 2056, no regression)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (890, baseline 890, no regression)
- `node scripts/check/check-changelog-integrity.mjs` — OK
- `npm run typecheck:core` — clean
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json open-sse/config/toolCloaking.ts tests/unit/antigravity-tool-cloak-server-side-invocations.test.ts` — clean

## Note on live validation

Per Hard Rule #18 the fix is validated via TDD (option 1, preferred) with a failing→passing regression test proving the exact request-shape defect. A live VPS/real-Antigravity-account validation of Google's upstream 400 was not performed (requires OAuth credentials not available in this environment) — the plan-file flags this as a nice-to-have follow-up, not a blocker, since TDD already satisfies the hard rule.