### PR TITLE
fix: omit removed attachments field from Muse Spark Web request (#6935)

### DIFF
--- a/changelog.d/fixes/6935-muse-spark-attachments.md
+++ b/changelog.d/fixes/6935-muse-spark-attachments.md
@@ -1,0 +1,1 @@
+- fix(sse): omit removed `attachments` field from Muse Spark Web (Meta AI) persisted GraphQL query to fix `Unknown type "AttachmentInput"` 502s (#6935)

--- a/open-sse/executors/muse-spark-web.ts
+++ b/open-sse/executors/muse-spark-web.ts
@@ -336,7 +336,11 @@ function buildMetaAiRequestBody(prompt: string, model: string, conversation: Con
     doc_id: META_AI_SEND_MESSAGE_DOC_ID,
     variables: {
       assistantMessageId: crypto.randomUUID(),
-      attachments: null,
+      // `attachments` was removed from Meta's GraphQL schema (the
+      // AttachmentInput type is gone), so sending it — even as null —
+      // makes the server reject the persisted query with
+      // `Unknown type "AttachmentInput"`. Omit it entirely; GraphQL
+      // input fields are nullable-by-omission by default.
       clientLatitude: null,
       clientLongitude: null,
       clientTimezone:

--- a/tests/unit/muse-spark-web-continuation.test.ts
+++ b/tests/unit/muse-spark-web-continuation.test.ts
@@ -323,3 +323,26 @@ test("muse-spark-web: empty latestUserContent (no `user` role) falls back to fre
     globalThis.fetch = original;
   }
 });
+
+test(
+  "muse-spark-web: outgoing variables must NOT declare 'attachments' " +
+    "(AttachmentInput type removed upstream, regression for #6935)",
+  async () => {
+    __resetMuseSparkConversationCacheForTesting();
+    const executor = new MuseSparkWebExecutor();
+    const original = globalThis.fetch;
+    const { fetchFn, captured } = captureFetch(() => metaAiSseResponse("pong"));
+    globalThis.fetch = fetchFn;
+    try {
+      await executor.execute(executeInputs([{ role: "user", content: "hi" }]));
+      const sentVars = (captured[0].body as { variables: Record<string, unknown> }).variables;
+      assert.equal(
+        Object.prototype.hasOwnProperty.call(sentVars, "attachments"),
+        false,
+        "variables must omit 'attachments' entirely — Meta removed AttachmentInput from schema"
+      );
+    } finally {
+      globalThis.fetch = original;
+    }
+  }
+);


### PR DESCRIPTION
Closes #6935

## Root cause

`open-sse/executors/muse-spark-web.ts::buildMetaAiRequestBody` was sending `attachments: null` in the GraphQL `variables` payload for Meta AI's persisted `useEctoSendMessageSubscription` query. Meta removed the `AttachmentInput` type from their live GraphQL schema; because this is a **persisted** query, Meta validates every variable key present against its live schema — sending the `attachments` key at all (even `null`) triggers `Unknown type "AttachmentInput"` and the request 502s. Cookies/auth were never the problem (the request reaches Meta and gets a schema-validation error, not 401/403), despite the issue title mentioning cookies.

This is the exact failure class already fixed once for `rewriteOptions`/`RewriteOptionsInput` (see the existing comment at the same call site) — Meta is incrementally stripping input types from their schema, and `AttachmentInput` is now among the removed types.

## Fix

Omit the `attachments` key entirely from the outgoing `variables` object (GraphQL input fields are nullable-by-omission by default), following the identical pattern already used for `rewriteOptions`.

## Regression test (TDD, Hard Rule #18)

Landed permanently in `tests/unit/muse-spark-web-continuation.test.ts`:
- RED (pre-fix): `AssertionError: true !== false` — the `attachments` key was present in outgoing variables.
- GREEN (post-fix): all 7 tests in the file pass, including the new regression test asserting `attachments` is omitted.

## Gates run green

- `node scripts/check/check-file-size.mjs` — no violation in touched files (one pre-existing unrelated violation on `ProxyRegistryManager.tsx`, not touched by this PR)
- `node scripts/check/check-complexity.mjs` — OK (2056/2056, baseline unchanged)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (890/890, baseline unchanged)
- `node scripts/check/check-changelog-integrity.mjs` — OK
- `npm run typecheck:core` — clean
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json open-sse/executors/muse-spark-web.ts tests/unit/muse-spark-web-continuation.test.ts` — clean
- Sibling muse-spark-web tests (`muse-spark-cookie-copy-5449.test.ts`, `muse-spark-response-parser-split.test.ts`, `executor-web-cookie-sweep.test.ts`) — all 32 pass