### PR TITLE
fix: label audio/embeddings/image compatible providers by kind on ProviderCard (#6936)

### DIFF
--- a/changelog.d/fixes/6936-providercard-audio-badge.md
+++ b/changelog.d/fixes/6936-providercard-audio-badge.md
@@ -1,0 +1,1 @@
+- fix(dashboard): label audio/embeddings/image compatible providers by kind instead of "Chat" on ProviderCard (#6936)

--- a/src/app/(dashboard)/dashboard/providers/components/ProviderCard.tsx
+++ b/src/app/(dashboard)/dashboard/providers/components/ProviderCard.tsx
@@ -42,6 +42,15 @@ const KIND_LABEL: Record<string, string> = {
   music: "Music",
 };
 
+/** Maps a compatible-provider `apiType` to its `KIND_LABEL` key (#6936: non-chat
+ * apiTypes — audio/embeddings/image — were falling through to the "Chat" badge). */
+const COMPATIBLE_API_TYPE_KIND: Record<string, string> = {
+  "audio-transcriptions": "stt",
+  "audio-speech": "tts",
+  "images-generations": "image",
+  embeddings: "embedding",
+};
+
 interface ProviderCardProps {
   providerId: string;
   provider: {
@@ -319,7 +328,10 @@ export default function ProviderCard({
                 ))}
                 {isCompatible && (
                   <Badge variant="default" size="sm">
-                    {provider.apiType === "responses" ? t("responses") : t("chat")}
+                    {provider.apiType === "responses"
+                      ? t("responses")
+                      : (KIND_LABEL[COMPATIBLE_API_TYPE_KIND[provider.apiType ?? ""] ?? ""] ??
+                        t("chat"))}
                   </Badge>
                 )}
                 {isCcCompatible && (

--- a/src/app/(dashboard)/dashboard/providers/components/__tests__/providerCardAudioBadge.test.tsx
+++ b/src/app/(dashboard)/dashboard/providers/components/__tests__/providerCardAudioBadge.test.tsx
@@ -1,0 +1,94 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+import { act } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import ProviderCard from "../ProviderCard";
+
+vi.mock("next-intl", () => ({ useTranslations: () => (k: string) => k }));
+vi.mock("@/shared/components/ProviderTestSlideOver", () => ({ default: () => null }));
+vi.mock("@/shared/components/ProviderIcon", () => ({ default: () => null }));
+
+describe("ProviderCard — #6936 audio-transcriptions provider badge", () => {
+  let container: HTMLDivElement | null = null;
+
+  afterEach(() => {
+    if (container) {
+      document.body.removeChild(container);
+      container = null;
+    }
+  });
+
+  it("does NOT label an audio-transcriptions compatible node as Chat", () => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    act(() => {
+      root.render(
+        <ProviderCard
+          providerId="openai-compatible-speaches-stt"
+          provider={{
+            id: "openai-compatible-speaches-stt",
+            name: "Speaches-stt",
+            apiType: "audio-transcriptions",
+            serviceKinds: [],
+          }}
+          stats={{ total: 1, connected: 1, error: 0, warning: 0 }}
+          authType="apikey"
+          onToggle={() => {}}
+        />
+      );
+    });
+    const text = (container.textContent || "").toLowerCase();
+    expect(text).not.toContain("chat");
+    expect(text).toContain("stt");
+  });
+
+  it("labels an audio-speech compatible node as TTS", () => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    act(() => {
+      root.render(
+        <ProviderCard
+          providerId="openai-compatible-speaches-tts"
+          provider={{
+            id: "openai-compatible-speaches-tts",
+            name: "Speaches-tts",
+            apiType: "audio-speech",
+            serviceKinds: [],
+          }}
+          stats={{ total: 1, connected: 1, error: 0, warning: 0 }}
+          authType="apikey"
+          onToggle={() => {}}
+        />
+      );
+    });
+    const text = (container.textContent || "").toLowerCase();
+    expect(text).not.toContain("chat");
+    expect(text).toContain("tts");
+  });
+
+  it("still labels a plain chat compatible node as Chat", () => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    act(() => {
+      root.render(
+        <ProviderCard
+          providerId="openai-compatible-plain"
+          provider={{
+            id: "openai-compatible-plain",
+            name: "Plain-chat",
+            apiType: "chat",
+            serviceKinds: [],
+          }}
+          stats={{ total: 1, connected: 1, error: 0, warning: 0 }}
+          authType="apikey"
+          onToggle={() => {}}
+        />
+      );
+    });
+    const text = (container.textContent || "").toLowerCase();
+    expect(text).toContain("chat");
+  });
+});


### PR DESCRIPTION
Closes #6936

## Root cause
`ProviderCard.tsx`'s compatibility badge used a binary `apiType` ternary:
```tsx
{provider.apiType === "responses" ? t("responses") : t("chat")}
```
Every non-`responses` `apiType` — `audio-transcriptions`, `audio-speech`, `images-generations`, `embeddings` — fell through to `t("chat")`. A locally-hosted `speaches` TTS/STT server added as an OpenAI-compatible provider (`apiType: "audio-transcriptions"`) was shown as "Chat" instead of "STT". Pure UI-label defect — `apiType` was already plumbed correctly end-to-end (`providerPageUtils.ts`), no routing logic touched.

## Fix
Added a `COMPATIBLE_API_TYPE_KIND` map from `apiType` to the existing `KIND_LABEL` key space (`stt`/`tts`/`image`/`embedding`), reusing the labels already used for `serviceKinds` chips elsewhere in the same component — no new i18n keys needed.

## Regression test (TDD, Hard Rule #18)
`src/app/(dashboard)/dashboard/providers/components/__tests__/providerCardAudioBadge.test.tsx` — renders the real `ProviderCard` for `audio-transcriptions`/`audio-speech`/`chat` compatible nodes.

- RED (before fix, on unfixed `ProviderCard.tsx`): `AssertionError: expected 'speaches-sttchatconnected...' not to contain 'chat'`
- GREEN (after fix): `Test Files 1 passed (1) / Tests 3 passed (3)`

Command: `npx vitest run "src/app/(dashboard)/dashboard/providers/components/__tests__/providerCardAudioBadge.test.tsx"`

## Gates run green
- `node scripts/check/check-file-size.mjs` — clean (1 pre-existing unrelated violation in `ProxyRegistryManager.tsx`, not touched by this PR)
- `node scripts/check/check-complexity.mjs` — OK (baseline unchanged: 2056)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (baseline unchanged: 890)
- `node scripts/check/check-changelog-integrity.mjs` — OK
- `npm run typecheck:core` — clean
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` — clean
- Sibling tests (`tests/unit/providers-page-utils.test.ts`, `tests/unit/card-hover-visible.test.ts`, `tests/unit/repro-6557-noauth-connection-disable-ignored.test.ts`) — 28/28 pass

## Scope note
Reporter's issue had no Steps/Expected/Actual. The confirmed and fixed defect is the badge label. Whether audio models are also mis-*routed* as chat end-to-end was not proven and is out of scope for this fix.