### PR TITLE
fix: rename max_completion_tokens to max_tokens for volcengine/DeepSeek (#6912)

### DIFF
--- a/changelog.d/fixes/6912-volcengine-max-tokens-rename.md
+++ b/changelog.d/fixes/6912-volcengine-max-tokens-rename.md
@@ -1,0 +1,1 @@
+- fix(sse): rename client-sent `max_completion_tokens` to `max_tokens` for providers/models that only accept the legacy field (e.g. Volcengine Ark / DeepSeek), mirroring the existing reverse rename from #1961 (#6912)

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -2099,6 +2099,16 @@ export async function handleChatCore({
       delete translatedBody.max_tokens;
       log?.debug?.("PARAMS", `Renamed max_tokens to max_completion_tokens for ${model}`);
     }
+  } else if (translatedBody.max_completion_tokens !== undefined) {
+    // Symmetric case (#6912): some providers/models (e.g. Volcengine Ark /
+    // DeepSeek) only document the legacy `max_tokens` field and silently
+    // ignore an unrecognized `max_completion_tokens`, so a client sending the
+    // newer field alone would have it dropped upstream with no cap applied.
+    if (translatedBody.max_tokens === undefined) {
+      translatedBody.max_tokens = translatedBody.max_completion_tokens;
+    }
+    delete translatedBody.max_completion_tokens;
+    log?.debug?.("PARAMS", `Renamed max_completion_tokens to max_tokens for ${model}`);
   }
 
   // OpenAI's `store` parameter is not supported by most compatible providers and breaks them

--- a/tests/unit/repro-6912-volcengine-max-completion-tokens.test.ts
+++ b/tests/unit/repro-6912-volcengine-max-completion-tokens.test.ts
@@ -1,0 +1,182 @@
+// @ts-nocheck
+// Regression test for #6912: OmniRoute never renamed a client-sent
+// `max_completion_tokens` back to `max_tokens` for providers/models whose
+// registry entry only documents the legacy field (Volcengine Ark / DeepSeek).
+// chatCore.ts already renamed the OTHER direction (max_tokens ->
+// max_completion_tokens for o1/o3/o4/gpt-5.4/5.5, #1961) but had no symmetric
+// case, so `max_completion_tokens` was forwarded byte-for-byte to Volcengine,
+// which silently ignores the unrecognized field and returns an unbounded
+// completion.
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-repro-6912-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const { clearCache } = await import("../../src/lib/semanticCache.ts");
+const { clearIdempotency } = await import("../../src/lib/idempotencyLayer.ts");
+const { clearInflight } = await import("../../open-sse/services/requestDedup.ts");
+const { resetAll: resetAccountSemaphores } = await import(
+  "../../open-sse/services/accountSemaphore.ts"
+);
+const { handleChatCore, clearUpstreamProxyConfigCache } = await import(
+  "../../open-sse/handlers/chatCore.ts"
+);
+const { resetPayloadRulesConfigForTests } = await import("../../open-sse/services/payloadRules.ts");
+
+const originalFetch = globalThis.fetch;
+
+function noopLog() {
+  return {
+    debug() {},
+    info() {},
+    warn() {},
+    error() {},
+  };
+}
+
+function toPlainHeaders(headers) {
+  if (!headers) return {};
+  if (headers instanceof Headers) return Object.fromEntries(headers.entries());
+  return Object.fromEntries(
+    Object.entries(headers).map(([key, value]) => [key, value == null ? "" : String(value)])
+  );
+}
+
+function buildOpenAIResponse(text = "ok") {
+  return new Response(
+    JSON.stringify({
+      id: "chatcmpl-json",
+      object: "chat.completion",
+      model: "DeepSeek-V4-Flash",
+      choices: [
+        {
+          index: 0,
+          message: { role: "assistant", content: text },
+          finish_reason: "stop",
+        },
+      ],
+      usage: { prompt_tokens: 4, completion_tokens: 2, total_tokens: 6 },
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } }
+  );
+}
+
+async function invokeChatCore({ body, provider, model, endpoint = "/v1/chat/completions" }) {
+  const calls: any[] = [];
+
+  globalThis.fetch = async (url, init = {}) => {
+    const headers = toPlainHeaders(init.headers);
+    const captured = {
+      url: String(url),
+      method: init.method || "GET",
+      headers,
+      body: init.body ? JSON.parse(String(init.body)) : null,
+    };
+    calls.push(captured);
+    return buildOpenAIResponse();
+  };
+
+  try {
+    const requestBody = structuredClone(body);
+    const result = await handleChatCore({
+      body: requestBody,
+      modelInfo: { provider, model, extendedContext: false },
+      credentials: { apiKey: "sk-test", providerSpecificData: {} },
+      log: noopLog(),
+      clientRawRequest: {
+        endpoint,
+        body: structuredClone(body),
+        headers: new Headers({ accept: "application/json" }),
+      },
+      connectionId: null,
+      apiKeyInfo: null,
+      userAgent: "unit-test",
+      isCombo: false,
+      comboStrategy: null,
+      onCredentialsRefreshed: null,
+      onRequestSuccess: null,
+    } as any);
+
+    return { result, calls, call: calls.at(-1) };
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+async function resetStorage() {
+  clearUpstreamProxyConfigCache();
+  resetPayloadRulesConfigForTests();
+  clearCache();
+  clearIdempotency();
+  clearInflight();
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+test.afterEach(async () => {
+  globalThis.fetch = originalFetch;
+  resetAccountSemaphores();
+  await resetStorage();
+});
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("#6912: chatCore renames max_completion_tokens to max_tokens for volcengine/DeepSeek-V4-Flash", async () => {
+  const { call } = await invokeChatCore({
+    provider: "volcengine",
+    model: "DeepSeek-V4-Flash",
+    body: {
+      model: "DeepSeek-V4-Flash",
+      messages: [{ role: "user", content: "hi" }],
+      max_completion_tokens: 30,
+      stream: false,
+    },
+  });
+
+  assert.equal(call.body.max_tokens, 30, "expected max_completion_tokens to be normalized to max_tokens for volcengine");
+  assert.equal(call.body.max_completion_tokens, undefined);
+});
+
+test("#6912: chatCore does not clobber an already-present max_tokens", async () => {
+  const { call } = await invokeChatCore({
+    provider: "volcengine",
+    model: "DeepSeek-V4-Flash",
+    body: {
+      model: "DeepSeek-V4-Flash",
+      messages: [{ role: "user", content: "hi" }],
+      max_tokens: 500,
+      max_completion_tokens: 30,
+      stream: false,
+    },
+  });
+
+  assert.equal(call.body.max_tokens, 500, "existing max_tokens must win over max_completion_tokens");
+  assert.equal(call.body.max_completion_tokens, undefined);
+});
+
+test("#6912: chatCore keeps the pre-existing max_tokens->max_completion_tokens direction for o3 (#1961)", async () => {
+  const { call } = await invokeChatCore({
+    provider: "openai",
+    model: "o3",
+    body: {
+      model: "o3",
+      messages: [{ role: "user", content: "hi" }],
+      max_tokens: 99999,
+      stream: false,
+    },
+  });
+
+  // Existing provider-side token-limit clamping (unrelated to #6912) caps the
+  // renamed value; this test only asserts the rename direction is preserved.
+  assert.equal(call.body.max_tokens, undefined);
+  assert.equal(call.body.max_completion_tokens, 16384);
+});


### PR DESCRIPTION
Closes #6912

## Root cause

The reported symptom (`max_completion_tokens:30` ignored, DeepSeek-V4-Flash via Volcengine returns 2826 tokens) is real, but the issue's stated root cause is wrong. `ensureThinkingBudget()` in `open-sse/executors/default.ts` is **not** involved — it is a ClinePass-only floor-raiser that bumps an undersized reasoning budget *up* to avoid empty `finish_reason:"length"` content; it never caps or truncates output for any provider, so it was left untouched.

The actual defect: `chatCore.ts` already renamed `max_tokens` → `max_completion_tokens` for o1/o3/o4/gpt-5.4/5.5 (#1961), but had no symmetric case for the reverse direction. Volcengine Ark / DeepSeek's OpenAI-compatible endpoint only documents `max_tokens` (confirmed against api-docs.deepseek.com and litellm's Volcano provider docs — neither lists `max_completion_tokens`), so a client-sent `max_completion_tokens` was forwarded byte-for-byte and silently dropped upstream, leaving no cap applied.

## Fix

Added the symmetric rename in `open-sse/handlers/chatCore.ts`, right after the existing `max_tokens` → `max_completion_tokens` block: when `supportsMaxTokens({provider, model})` is true and the client sent `max_completion_tokens` without `max_tokens`, copy the value into `max_tokens` and delete `max_completion_tokens` (mirrors the #1961 pattern). If both fields are present, the existing `max_tokens` wins (not clobbered) and `max_completion_tokens` is still stripped.

## Test (TDD, Hard Rule #18)

New permanent regression file `tests/unit/repro-6912-volcengine-max-completion-tokens.test.ts`:
- RED (pre-fix): `expected max_completion_tokens to be normalized to max_tokens for volcengine ... undefined !== 30`
- GREEN (post-fix): all 3 cases pass — new rename direction, "does not clobber an existing max_tokens", and the pre-existing o3 `max_tokens`→`max_completion_tokens` direction (#1961) stays intact.

```
node --import tsx/esm --test tests/unit/repro-6912-volcengine-max-completion-tokens.test.ts
ℹ tests 3
ℹ pass 3
ℹ fail 0
```

Also ran the full sibling suite of the touched area (chatcore-translation-paths, executors-strip-unsupported-params, command-code-maxtokens-negative-5166, chatcore-sanitization, translator-openai-responses-req, translator-openai-to-claude, translator-openai-to-gemini): 214/214 pass. Full `chatcore-*.test.ts` suite: 421/421 pass.

## Gates run green

- `node scripts/check/check-file-size.mjs` — no new violation (1 pre-existing, unrelated: `ProxyRegistryManager.tsx`)
- `node scripts/check/check-complexity.mjs` — OK (2056/2056, unchanged)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (890/890, unchanged)
- `node scripts/check/check-changelog-integrity.mjs` — OK
- `npm run typecheck:core` — clean, exit 0
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json open-sse/handlers/chatCore.ts tests/unit/repro-6912-volcengine-max-completion-tokens.test.ts` — exit 0 (0 errors, 2 pre-existing-style `any` warnings in the new test harness, same pattern as sibling test files)

## Scope note

Per the plan-file, `ensureThinkingBudget()` / the ClinePass gate in `open-sse/executors/default.ts` was intentionally **not** touched — it addresses a different bug class (empty content from undersized ClinePass reasoning budgets) and removing its gate would not have fixed this issue.