### PR TITLE
fix(api): LAN model-list discovery uses local-first SSRF guard (#6939)

### DIFF
--- a/changelog.d/fixes/6939-lmstudio-models-guard.md
+++ b/changelog.d/fixes/6939-lmstudio-models-guard.md
@@ -1,0 +1,1 @@
+- fix(api): model-list discovery for LAN-local OpenAI-compatible providers (e.g. LM Studio) now uses the same local-first SSRF guard as the connection test, instead of the stricter guard that always blocked LAN hosts (#6939)

--- a/src/app/api/providers/[id]/models/route.ts
+++ b/src/app/api/providers/[id]/models/route.ts
@@ -21,7 +21,10 @@ import {
   getSafeOutboundFetchErrorStatus,
   safeOutboundFetch,
 } from "@/shared/network/safeOutboundFetch";
-import { getProviderOutboundGuard } from "@/shared/network/outboundUrlGuard";
+import {
+  getProviderOutboundGuard,
+  getProviderValidationGuard,
+} from "@/shared/network/outboundUrlGuard";
 import { sanitizeErrorMessage } from "@omniroute/open-sse/utils/error";
 import { getStaticQoderModels } from "@omniroute/open-sse/services/qoderCli.ts";
 import { deriveConfigFromRegistryModelsUrl } from "./discoveryConfig";
@@ -635,7 +638,11 @@ export async function GET(
         try {
           const response = await safeOutboundFetch(modelsUrl, {
             ...SAFE_OUTBOUND_FETCH_PRESETS.modelsProbe,
-            guard: getProviderOutboundGuard(),
+            // #6939: model-list discovery for local/OpenAI-compatible providers (e.g. LM
+            // Studio on a LAN host) must use the same guard tier as the test-connection path
+            // (getProviderValidationGuard — respects the local-first default) rather than the
+            // stricter outbound guard, which never allows LAN hosts by default.
+            guard: getProviderValidationGuard(),
             proxyConfig: proxy,
             method: "GET",
             headers: isNamedOpenAIStyleProvider(provider)

--- a/tests/unit/provider-models-route-lan-guard.test.ts
+++ b/tests/unit/provider-models-route-lan-guard.test.ts
@@ -1,0 +1,143 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// #6939 — model-list fetch for a LAN-local OpenAI-compatible provider (e.g. LM Studio on
+// 192.168.x.x) was rejected by the SSRF guard even though the connection test for the same
+// host succeeds, under the default (local-first) settings. Root cause: the models route used
+// getProviderOutboundGuard() (only "none" | "public-only", never consults the local-first
+// default) instead of getProviderValidationGuard() (used by the test-connection path, which
+// resolves to "block-metadata" — allow LAN, still block cloud-metadata/link-local — when
+// local-first is ON, which is the default).
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-lan-guard-models-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const providersDb = await import("../../src/lib/db/providers.ts");
+const providerModelsRoute = await import("../../src/app/api/providers/[id]/models/route.ts");
+const outboundUrlGuard = await import("../../src/shared/network/outboundUrlGuard.ts");
+
+const originalFetch = globalThis.fetch;
+const originalAllowPrivateProviderUrls = process.env.OMNIROUTE_ALLOW_PRIVATE_PROVIDER_URLS;
+const originalAllowLocalProviderUrls = process.env.OMNIROUTE_ALLOW_LOCAL_PROVIDER_URLS;
+
+async function resetStorage() {
+  globalThis.fetch = originalFetch;
+  if (originalAllowPrivateProviderUrls === undefined) {
+    delete process.env.OMNIROUTE_ALLOW_PRIVATE_PROVIDER_URLS;
+  } else {
+    process.env.OMNIROUTE_ALLOW_PRIVATE_PROVIDER_URLS = originalAllowPrivateProviderUrls;
+  }
+  if (originalAllowLocalProviderUrls === undefined) {
+    delete process.env.OMNIROUTE_ALLOW_LOCAL_PROVIDER_URLS;
+  } else {
+    process.env.OMNIROUTE_ALLOW_LOCAL_PROVIDER_URLS = originalAllowLocalProviderUrls;
+  }
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+async function seedConnection(provider: string, overrides: Record<string, unknown> = {}) {
+  return providersDb.createProviderConnection({
+    provider,
+    authType: (overrides.authType as string) || "apikey",
+    name: (overrides.name as string) || `${provider}-${Math.random().toString(16).slice(2, 8)}`,
+    apiKey: overrides.apiKey as string | undefined,
+    accessToken: overrides.accessToken as string | undefined,
+    isActive: (overrides.isActive as boolean) ?? true,
+    testStatus: (overrides.testStatus as string) || "active",
+    providerSpecificData: (overrides.providerSpecificData as Record<string, unknown>) || {},
+  });
+}
+
+async function callRoute(connectionId: string, search = "") {
+  return providerModelsRoute.GET(
+    new Request(`http://localhost/api/providers/${connectionId}/models${search}`),
+    { params: { id: connectionId } }
+  );
+}
+
+test.beforeEach(async () => {
+  await resetStorage();
+});
+
+test.after(async () => {
+  globalThis.fetch = originalFetch;
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("#6939: getProviderOutboundGuard() and getProviderValidationGuard() agree for LAN hosts under the default local-first setting", () => {
+  // Default settings: OMNIROUTE_ALLOW_LOCAL_PROVIDER_URLS unset (ON by default),
+  // OMNIROUTE_ALLOW_PRIVATE_PROVIDER_URLS unset (OFF by default).
+  delete process.env.OMNIROUTE_ALLOW_LOCAL_PROVIDER_URLS;
+  delete process.env.OMNIROUTE_ALLOW_PRIVATE_PROVIDER_URLS;
+
+  const validationGuard = outboundUrlGuard.getProviderValidationGuard();
+  assert.equal(validationGuard, "block-metadata");
+
+  // The models route must resolve a guard for LAN-local model discovery that is at least as
+  // permissive as the validation (test-connection) guard — "public-only" would reject LAN.
+  assert.notEqual(
+    validationGuard,
+    "public-only",
+    "sanity: validation guard should allow LAN under the local-first default"
+  );
+});
+
+test("#6939: LM Studio (LAN host, local OpenAI-compatible provider) model-list fetch is not SSRF-blocked under default settings", async () => {
+  delete process.env.OMNIROUTE_ALLOW_LOCAL_PROVIDER_URLS;
+  delete process.env.OMNIROUTE_ALLOW_PRIVATE_PROVIDER_URLS;
+
+  const connection = await seedConnection("lm-studio", {
+    providerSpecificData: { baseUrl: "http://192.168.1.50:1234/v1" },
+  });
+
+  let fetchCalled = false;
+  globalThis.fetch = async () => {
+    fetchCalled = true;
+    return Response.json({ data: [{ id: "llama-3-8b-instruct" }] });
+  };
+
+  const response = await callRoute(connection.id);
+  const body = (await response.json()) as Record<string, unknown>;
+
+  // RED before the fix: the guard blocked the LAN host before the fetch mock ever ran,
+  // surfacing a 400 "Blocked private or local provider URL" — even though the equivalent
+  // test-connection call for the same host succeeds under the same default settings.
+  assert.ok(
+    fetchCalled,
+    `expected the LAN model-list fetch to reach the network layer, got status=${response.status} body=${JSON.stringify(body)}`
+  );
+  assert.notEqual(response.status, 400);
+  assert.ok(
+    !String(body?.error || "").includes(outboundUrlGuard.PROVIDER_URL_BLOCKED_MESSAGE),
+    `LAN host must not be SSRF-blocked by default: ${JSON.stringify(body)}`
+  );
+});
+
+test("#6939: LAN model-list fetch is still blocked when the local-first default is explicitly disabled", async () => {
+  delete process.env.OMNIROUTE_ALLOW_PRIVATE_PROVIDER_URLS;
+  process.env.OMNIROUTE_ALLOW_LOCAL_PROVIDER_URLS = "false";
+
+  const connection = await seedConnection("lm-studio", {
+    providerSpecificData: { baseUrl: "http://192.168.1.50:1234/v1" },
+  });
+
+  let fetchCalled = false;
+  globalThis.fetch = async () => {
+    fetchCalled = true;
+    return Response.json({ data: [{ id: "llama-3-8b-instruct" }] });
+  };
+
+  const response = await callRoute(connection.id);
+  const body = (await response.json()) as Record<string, unknown>;
+
+  assert.equal(fetchCalled, false, "guard should block before the network layer is reached");
+  assert.equal(response.status, 400);
+  assert.equal(body.error, outboundUrlGuard.PROVIDER_URL_BLOCKED_MESSAGE);
+});

--- a/tests/unit/provider-models-route.test.ts
+++ b/tests/unit/provider-models-route.test.ts
@@ -154,8 +154,12 @@ test("provider models route rejects OpenAI-compatible providers without a base U
   });
 });
 
-test("provider models route blocks private OpenAI-compatible base URLs", async () => {
+// #6939: model-list discovery must match the test-connection guard tier (local-first ON by
+// default allows LAN/loopback hosts) — see provider-models-route-lan-guard.test.ts for the
+// disabled-default (still-blocked) counterpart.
+test("provider models route allows private/LAN OpenAI-compatible base URLs under the local-first default (#6939)", async () => {
   delete process.env.OMNIROUTE_ALLOW_PRIVATE_PROVIDER_URLS;
+  delete process.env.OMNIROUTE_ALLOW_LOCAL_PROVIDER_URLS;
 
   const connection = await seedConnection("openai-compatible-private", {
     apiKey: "sk-openai-compatible",
@@ -172,11 +176,8 @@ test("provider models route blocks private OpenAI-compatible base URLs", async (
 
   const response = await callRoute(connection.id);
 
-  assert.equal(response.status, 400);
-  assert.deepEqual(await response.json(), {
-    error: "Blocked private or local provider URL",
-  });
-  assert.equal(called, false);
+  assert.equal(response.status, 200);
+  assert.equal(called, true);
 });
 
 test("provider models route returns auth failures from OpenAI-compatible upstreams", async () => {


### PR DESCRIPTION
Closes #6939

## Root cause
Guard asymmetry: the **test-connection** path uses `getProviderValidationGuard()` (resolves to `block-metadata` under the local-first default → allows LAN/private hosts), but the **model-list fetch** (`src/app/api/providers/[id]/models/route.ts:638`) used `getProviderOutboundGuard()`, which only returns `none | public-only` and never consults `areLocalProviderUrlsAllowed()`. So a LAN LM Studio host (`http://192.168.x.x:1234`) passed the connection test but its `/v1/models` fetch was rejected with `PROVIDER_URL_BLOCKED_MESSAGE`. Introduced by the SSRF-guard split (#5066).

## Fix
Switch the models-route fetch to `getProviderValidationGuard()`, matching the test-connection tier. Cloud-metadata/link-local stay blocked unconditionally in both tiers.

## Regression test (Hard Rule #18)
`tests/unit/provider-models-route-lan-guard.test.ts` — RED before fix (LAN host 400 'Blocked private or local provider URL'), GREEN after (reaches network, 200). Includes the disabled-default counterpart (still blocked when `OMNIROUTE_ALLOW_LOCAL_PROVIDER_URLS=false`). Existing `provider-models-route.test.ts` aligned to the corrected contract (LAN now allowed under default).

## Gates
typecheck:core clean · eslint (suppressions) 0 errors · changelog-integrity OK · repro 3/3 + existing suite 59/59 green.