### PR TITLE
fix(providers): classify cloudflare-ai daily neuron exhaustion as quota_exhausted

### DIFF
--- a/open-sse/config/providerErrorRules.ts
+++ b/open-sse/config/providerErrorRules.ts
@@ -104,6 +104,35 @@ function buildOpencodeRules(): ProviderErrorRule[] {
   ];
 }
 
+// ─── Cloudflare Workers AI ────────────────────────────────────────────────
+// Free tier = 10,000 Neurons/day, shared across the WHOLE account
+// (docs/reference/FREE_TIERS.md; official: developers.cloudflare.com/
+// workers-ai/platform/errors/). The exhaustion body doesn't match any
+// QUOTA_PATTERNS keyword (src/shared/utils/classify429.ts) so it falls
+// through to rate_limit and gets retried every ~60s against a budget that
+// only resets at UTC midnight.
+//
+// Scope note: `scope: "connection"` (not "provider") for the same reason as
+// Opencode above — the neuron budget is per-account, and a single OmniRoute
+// connection maps to one Cloudflare account. Multiple connections under the
+// same provider name would mean multiple accounts, each with its own budget.
+function buildCloudflareAiRules(): ProviderErrorRule[] {
+  return [
+    {
+      id: "cloudflare-ai-daily-neuron-allocation",
+      match: ({ status, body }) => {
+        if (status !== 429) return null;
+        const text = JSON.stringify(body ?? "").toLowerCase();
+        if (!text.includes("daily free allocation")) return null;
+        // No cooldownMs: recordModelLockoutFailure already sets
+        // quota_exhausted without one to "next UTC midnight" — exactly this
+        // budget's real reset semantics.
+        return { reason: "quota_exhausted", scope: "connection" };
+      },
+    },
+  ];
+}
+
 // ─── Minimax ────────────────────────────────────────────────────────────────
 // Minimax returns per-model quota info via custom headers. The body is generic
 // "rate limit exceeded" so we MUST read the headers. Other models on the same
@@ -141,6 +170,7 @@ export const providerRuleRegistry = new Map<string, ProviderErrorRule[]>([
   ["opencode-cli", buildOpencodeRules()],
   ["minimax", buildMinimaxRules()],
   ["minimax-passthrough", buildMinimaxRules()],
+  ["cloudflare-ai", buildCloudflareAiRules()],
 ]);
 
 /**
@@ -194,7 +224,9 @@ export function getProviderErrorRuleMatch(
  */
 export function parseResetCountdownMs(text: string): number | null {
   if (typeof text !== "string" || text.length === 0) return null;
-  const match = text.match(/resets?\s+in\s+(\d+)\s+(day|days|hour|hours|minute|minutes|second|seconds)\b/);
+  const match = text.match(
+    /resets?\s+in\s+(\d+)\s+(day|days|hour|hours|minute|minutes|second|seconds)\b/
+  );
   if (!match) return null;
   const n = Number(match[1]);
   if (!Number.isFinite(n) || n <= 0) return null;

--- a/src/shared/utils/classify429.ts
+++ b/src/shared/utils/classify429.ts
@@ -53,6 +53,15 @@ const QUOTA_PATTERNS: ReadonlyArray<RegExp> = [
   /individual quota reached/i,
   /enable overages/i,
   /INSUFFICIENT_G1_CREDITS_BALANCE/i,
+
+  // Cloudflare Workers AI daily neuron budget exhaustion ("you have used up
+  // your daily free allocation of 10,000 neurons, please upgrade to
+  // Cloudflare's Workers Paid plan..."). No "quota"/"limit"/"exceed"/"credit"
+  // substring, so none of the patterns above match it. This is the primary
+  // provider-specific rule in providerErrorRules.ts (scope: "connection");
+  // this entry is defense-in-depth for classify429FromError callers that
+  // bypass provider rule matching.
+  /daily free allocation/i,
 ];
 
 /**

--- a/tests/unit/provider-error-rules.test.ts
+++ b/tests/unit/provider-error-rules.test.ts
@@ -83,6 +83,50 @@ test("S2b: provider error rules match canonical-cased plain header records", asy
   assert.equal(minimaxMatch.scope, "model");
 });
 
+test("S2c: Cloudflare Workers AI daily neuron exhaustion → QUOTA_EXHAUSTED with connection scope", async () => {
+  // Cloudflare's free tier is a 10,000-Neurons/day budget shared across the
+  // WHOLE account. The exhaustion body doesn't contain "quota"/"limit"/
+  // "exceed"/"credit" so it would otherwise fall through to the default
+  // RATE_LIMIT_EXCEEDED and get retried every ~60s against a budget that
+  // only resets at UTC midnight.
+  const { getProviderErrorRuleMatch } = await import("../../open-sse/config/providerErrorRules.ts");
+
+  const match = getProviderErrorRuleMatch(
+    "cloudflare-ai",
+    429,
+    {},
+    {
+      errors: [
+        {
+          message:
+            "AiError: AiError: you have used up your daily free allocation of 10,000 neurons, please upgrade to Cloudflare's Workers Paid plan if you would like to continue usage.",
+          code: 4006,
+        },
+      ],
+      success: false,
+    }
+  );
+  assert.ok(match, "cloudflare-ai must have a rule matching the daily neuron allocation body");
+  assert.equal(match.reason, "quota_exhausted");
+  assert.equal(
+    match.scope,
+    "connection",
+    "Cloudflare's neuron budget is account-wide, so the lock must scope to the connection, not a single model"
+  );
+
+  // A 429 without the exhaustion wording (a real transient rate-limit) must
+  // NOT match — this rule is specific to the daily-allocation body.
+  const noMatch = getProviderErrorRuleMatch(
+    "cloudflare-ai",
+    429,
+    {},
+    {
+      errors: [{ message: "Too many requests, please retry shortly.", code: 3040 }],
+    }
+  );
+  assert.equal(noMatch, null, "a generic 429 without the exhaustion wording must not match");
+});
+
 test("S3: Regression — provider with no rules falls back to global ERROR_RULES unchanged", () => {
   // A provider not in the registry (e.g. "unknown-vendor") must NOT cause
   // classifyError to crash or return a different result. It must behave


### PR DESCRIPTION
Fixes #6980

## Summary
- Registers a `cloudflare-ai` provider rule in `providerErrorRules.ts` matching the daily neuron-allocation exhaustion body, scoped `"connection"` (account-wide budget — same reasoning as the existing `opencode` rules).
- Adds `/daily free allocation/i` to `QUOTA_PATTERNS` in `classify429.ts` as defense-in-depth for the `classify429FromError` path.
- Adds a unit test (`S2c`) to `tests/unit/provider-error-rules.test.ts` following the existing `S1`/`S2b` pattern: matches the exhaustion body → `quota_exhausted`/`scope:"connection"`; a generic 429 without the exhaustion wording → no match.

## Why
Cloudflare Workers AI's free-tier exhaustion body doesn't contain "quota"/"limit" (after "daily")/"exceed"/"credit"/"plan limit", so it currently falls through to the default `rate_limit` classification and gets retried on the short ~60s cooldown against a budget that only resets at UTC midnight. `reason==="quota_exhausted"` without an explicit `cooldownMs` already resolves to "next UTC midnight" via `recordModelLockoutFailure` (`accountFallback.ts:553-556`), so this rule just needs to reach that path — no new cooldown logic required.

## Test plan
- [x] `node --import tsx/esm --test tests/unit/provider-error-rules.test.ts` — 6/6 pass (including new `S2c`)
- [x] `eslint` — clean
- [x] `prettier --check` — clean
- [x] Pre-commit hooks (docs-sync, t11 any-budget, tracked-artifacts) — pass

## Prior art
Same bug class as #1767→#1772→#2100 (origin of `classify429.ts`). `providerErrorRules.ts` already establishes this exact pattern for `opencode`/`minimax`.