### PR TITLE
fix(6975): show embedding models in combo builder picker

### DIFF
--- a/src/lib/combos/builderOptions.ts
+++ b/src/lib/combos/builderOptions.ts
@@ -155,9 +155,19 @@ function toStringArray(value: unknown): string[] | undefined {
   return normalized.length > 0 ? normalized : undefined;
 }
 
-function isChatCapable(supportedEndpoints: string[] | undefined): boolean {
+/**
+ * Determine whether a model should appear in the combo builder picker.
+ *
+ * Issue #6975: models whose only endpoint is "embedding" were silently filtered
+ * out, making it impossible to build embedding combos from the UI.  The combo
+ * runtime already supports embedding steps (see `dimensions` override in
+ * `createComboSchema`), so we accept both "chat" and "embedding" endpoints.
+ * Models with no endpoint metadata default to visible (preserves prior behavior
+ * for built-in/legacy models).
+ */
+export function isComboSelectable(supportedEndpoints: string[] | undefined): boolean {
   if (!supportedEndpoints || supportedEndpoints.length === 0) return true;
-  return supportedEndpoints.includes("chat");
+  return supportedEndpoints.includes("chat") || supportedEndpoints.includes("embedding");
 }
 
 function getSourcePriority(source: BuilderModelSource): number {
@@ -305,7 +315,7 @@ function addModelOption(
   const modelId = toStringOrNull(input.id);
   if (!modelId) return;
   if (getModelIsHidden(providerId, modelId)) return;
-  if (!isChatCapable(input.supportedEndpoints)) return;
+  if (!isComboSelectable(input.supportedEndpoints)) return;
 
   const nextSourcePriority = getSourcePriority(input.source);
   const existing = modelMap.get(modelId);
@@ -554,9 +564,8 @@ export async function getComboBuilderOptions(): Promise<ComboBuilderOptionsPaylo
       customModels
     );
 
-    const normalizedConnections = expandConnectionOptions(providerConnections).sort(
-      compareConnections
-    );
+    const normalizedConnections =
+      expandConnectionOptions(providerConnections).sort(compareConnections);
 
     const activeConnectionCount = normalizedConnections.filter(
       (connection) => connection.isActive

--- a/tests/unit/combo-builder-embedding-models-6975.test.ts
+++ b/tests/unit/combo-builder-embedding-models-6975.test.ts
@@ -9,7 +9,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { isComboSelectable } from "../../src/lib/combos/builderOptions.ts";
+import { isComboSelectable } from "../../src/lib/combos/builderOptions";
 
 test("#6975: embedding-only endpoints are selectable", () => {
   assert.equal(isComboSelectable(["embedding"]), true);

--- a/tests/unit/combo-builder-embedding-models-6975.test.ts
+++ b/tests/unit/combo-builder-embedding-models-6975.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Issue #6975 — Embedding-only models were silently filtered out of the combo
+ * builder picker because `isChatCapable` only accepted the "chat" endpoint.
+ *
+ * The fix renames it to `isComboSelectable` and also accepts "embedding",
+ * since the combo runtime already supports embedding combos (see `dimensions`
+ * override in `createComboSchema`).
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { isComboSelectable } from "../../src/lib/combos/builderOptions.ts";
+
+test("#6975: embedding-only endpoints are selectable", () => {
+  assert.equal(isComboSelectable(["embedding"]), true);
+});
+
+test("#6975: chat-only endpoints are selectable (no regression)", () => {
+  assert.equal(isComboSelectable(["chat"]), true);
+});
+
+test("#6975: combined chat+embedding endpoints are selectable", () => {
+  assert.equal(isComboSelectable(["chat", "embedding"]), true);
+});
+
+test("#6975: empty/undefined endpoints default to selectable (backward compat)", () => {
+  assert.equal(isComboSelectable([]), true);
+  assert.equal(isComboSelectable(undefined), true);
+});
+
+test("#6975: non-chat non-embedding endpoints are NOT selectable", () => {
+  assert.equal(isComboSelectable(["image_generation"]), false);
+  assert.equal(isComboSelectable(["audio_transcription"]), false);
+  assert.equal(isComboSelectable(["moderation"]), false);
+});
+
+test("#6975: mixed embedding + other (non-chat) is selectable", () => {
+  assert.equal(isComboSelectable(["embedding", "image_generation"]), true);
+});


### PR DESCRIPTION
## Problem
Issue #6975

The combo builder model picker silently filtered out embedding-only models (e.g. `text-embedding-3-small`). The `isChatCapable` function in `builderOptions.ts` only accepted models whose `supportedEndpoints` array included `"chat"`, rejecting everything else.

This made it impossible to build embedding combos from the UI, even though the combo runtime fully supports them (the `dimensions` override in `createComboSchema` is specifically designed for embedding combos).

## Fix
- Renamed `isChatCapable` → `isComboSelectable`
- Broadened the check to accept `"chat"` OR `"embedding"`
- Exported the function for direct unit testing

## Tests (6/6 pass)
```
✓ embedding-only endpoints are selectable
✓ chat-only endpoints are selectable (no regression)
✓ combined chat+embedding endpoints are selectable
✓ empty/undefined endpoints default to selectable (backward compat)
✓ non-chat non-embedding endpoints are NOT selectable
✓ mixed embedding + other (non-chat) is selectable
```

## Quality gates
- ESLint: 0 errors
- check:any-budget:t11: PASS
- check:file-size: PASS