### PR TITLE
feat(6922): effort-tier aliases for glm-5.2 & mimo-v2.5 on opencode-go

### DIFF
--- a/open-sse/config/providers/registry/opencode/go/index.ts
+++ b/open-sse/config/providers/registry/opencode/go/index.ts
@@ -17,14 +17,22 @@ export const opencode_goProvider: RegistryEntry = {
     // glm-5.2 is now advertised and Kimi chat traffic must route through
     // `kimi-k2.7-code` (the live API rejects the plain `kimi-k2.7` alias for
     // `/chat/completions`, even though the docs config example uses it).
-    { id: "glm-5.2", name: "GLM-5.2" },
+    // GLM-5.2 — base model + effort-tier aliases (#6922).
+    // OpencodeExecutor rewrites the alias to the canonical id and injects
+    // reasoning_effort, mirroring the deepseek-v4-pro-* pattern.
+    { id: "glm-5.2", name: "GLM-5.2", supportsReasoning: true },
+    { id: "glm-5.2-high", name: "GLM-5.2 (high effort)", supportsReasoning: true },
+    { id: "glm-5.2-max", name: "GLM-5.2 (max effort)", supportsReasoning: true },
     { id: "glm-5.1", name: "GLM-5.1" },
     { id: "glm-5", name: "GLM-5" },
     { id: "kimi-k2.7-code", name: "Kimi K2.7 Code" },
     { id: "kimi-k2.6", name: "Kimi K2.6" },
     { id: "kimi-k2.5", name: "Kimi K2.5" },
-    { id: "mimo-v2.5-pro", name: "MiMo-V2.5-Pro" },
-    { id: "mimo-v2.5", name: "MiMo-V2.5" },
+    // MiMo-V2.5 — base model + effort-tier aliases (#6922).
+    { id: "mimo-v2.5-pro", name: "MiMo-V2.5-Pro", supportsReasoning: true },
+    { id: "mimo-v2.5", name: "MiMo-V2.5", supportsReasoning: true },
+    { id: "mimo-v2.5-high", name: "MiMo-V2.5 (high effort)", supportsReasoning: true },
+    { id: "mimo-v2.5-max", name: "MiMo-V2.5 (max effort)", supportsReasoning: true },
     // #3110: MiniMax M3 via OpenCode Go tier
     {
       id: "minimax-m3",

--- a/open-sse/executors/opencode.ts
+++ b/open-sse/executors/opencode.ts
@@ -61,7 +61,7 @@ const EFFORT_TIERS: Record<string, readonly string[]> = {
  *      "glm-5.2-high"         → { baseModel: "glm-5.2", effort: "high" }
  * Returns null if the model doesn't match any known effort-tier pattern.
  */
-function parseEffortLevel(model: string): { baseModel: string; effort: string } | null {
+export function parseEffortLevel(model: string): { baseModel: string; effort: string } | null {
   const m = String(model || "");
   for (const [baseModel, levels] of Object.entries(EFFORT_TIERS)) {
     for (const level of levels) {

--- a/open-sse/executors/opencode.ts
+++ b/open-sse/executors/opencode.ts
@@ -40,17 +40,37 @@ const OPENCODE_COOLDOWN_MAX_MS = 60_000;
 const EFFORT_LEVELS = ["low", "medium", "high", "max"] as const;
 
 /**
- * Parse a DeepSeek V4 Pro model string with an effort-level suffix.
- * e.g. "deepseek-v4-pro-low" → { baseModel: "deepseek-v4-pro", effort: "low" }
- * Returns null if the model doesn't match the pattern.
+ * Models on opencode-go that support effort-tier aliases. Each entry maps the
+ * canonical base id to the set of effort suffixes the upstream supports.
+ *
+ * - deepseek-v4-pro: all four tiers (low/medium/high/max)
+ * - glm-5.2: high/max only (Z.AI maps these through the reasoning plane;
+ *   low/medium are not supported on the OpenAI transport)
+ * - mimo-v2.5: high/max only (same reasoning; Xiaomi MiMo does not document
+ *   low/medium effort tiers)
  */
-function parseDeepSeekEffortLevel(model: string): { baseModel: string; effort: string } | null {
+const EFFORT_TIERS: Record<string, readonly string[]> = {
+  "deepseek-v4-pro": EFFORT_LEVELS,
+  "glm-5.2": ["high", "max"],
+  "mimo-v2.5": ["high", "max"],
+};
+
+/**
+ * Parse a model string with an effort-level suffix.
+ * e.g. "deepseek-v4-pro-low" → { baseModel: "deepseek-v4-pro", effort: "low" }
+ *      "glm-5.2-high"         → { baseModel: "glm-5.2", effort: "high" }
+ * Returns null if the model doesn't match any known effort-tier pattern.
+ */
+function parseEffortLevel(model: string): { baseModel: string; effort: string } | null {
   const m = String(model || "");
-  const matchedLevel = EFFORT_LEVELS.find((level) => m.endsWith(`-${level}`));
-  if (!matchedLevel) return null;
-  const baseModel = m.slice(0, -matchedLevel.length - 1);
-  if (baseModel.toLowerCase() !== "deepseek-v4-pro") return null;
-  return { baseModel: "deepseek-v4-pro", effort: matchedLevel };
+  for (const [baseModel, levels] of Object.entries(EFFORT_TIERS)) {
+    for (const level of levels) {
+      if (m === `${baseModel}-${level}`) {
+        return { baseModel, effort: level };
+      }
+    }
+  }
+  return null;
 }
 
 export class OpencodeExecutor extends BaseExecutor {
@@ -315,7 +335,7 @@ export class OpencodeExecutor extends BaseExecutor {
     }
     if (modifiedBody && typeof modifiedBody === "object" && !Array.isArray(modifiedBody)) {
       const mb = modifiedBody as Record<string, unknown>;
-      const parsed = parseDeepSeekEffortLevel(model);
+      const parsed = parseEffortLevel(model);
       if (parsed) {
         mb.model = parsed.baseModel;
         if (mb.reasoning_effort === undefined) {

--- a/tests/unit/opencode-go-effort-aliases-6922.test.ts
+++ b/tests/unit/opencode-go-effort-aliases-6922.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Issue #6922 — Effort-tier aliases for glm-5.2 and mimo-v2.5 on opencode-go.
+ *
+ * The OpencodeExecutor must:
+ *  1. Rewrite effort-alias model ids to their canonical base id
+ *  2. Inject `reasoning_effort` if not already set
+ *
+ * Previously only deepseek-v4-pro had aliases. Now glm-5.2 and mimo-v2.5
+ * also have high/max tiers.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// Re-create the parseEffortLevel logic to test independently.
+// (The function is module-private in opencode.ts, so we mirror the EFFORT_TIERS
+//  table here and verify the registry has matching entries.)
+
+import { readFileSync } from "node:fs";
+
+const registryContent = readFileSync(
+  "open-sse/config/providers/registry/opencode/go/index.ts",
+  "utf8"
+);
+
+const executorContent = readFileSync("open-sse/executors/opencode.ts", "utf8");
+
+test("#6922: registry has glm-5.2-high alias", () => {
+  assert.ok(
+    registryContent.includes('"glm-5.2-high"'),
+    "opencode-go registry must declare glm-5.2-high"
+  );
+});
+
+test("#6922: registry has glm-5.2-max alias", () => {
+  assert.ok(
+    registryContent.includes('"glm-5.2-max"'),
+    "opencode-go registry must declare glm-5.2-max"
+  );
+});
+
+test("#6922: registry has mimo-v2.5-high alias", () => {
+  assert.ok(
+    registryContent.includes('"mimo-v2.5-high"'),
+    "opencode-go registry must declare mimo-v2.5-high"
+  );
+});
+
+test("#6922: registry has mimo-v2.5-max alias", () => {
+  assert.ok(
+    registryContent.includes('"mimo-v2.5-max"'),
+    "opencode-go registry must declare mimo-v2.5-max"
+  );
+});
+
+test("#6922: executor has generalized parseEffortLevel (not deepseek-only)", () => {
+  assert.ok(
+    executorContent.includes("parseEffortLevel"),
+    "OpencodeExecutor must use generalized parseEffortLevel"
+  );
+  assert.ok(
+    !executorContent.includes("parseDeepSeekEffortLevel"),
+    "Old deepseek-only function name must be removed"
+  );
+});
+
+test("#6922: EFFORT_TIERS table includes glm-5.2 and mimo-v2.5", () => {
+  assert.ok(executorContent.includes('"glm-5.2"'), "EFFORT_TIERS must include glm-5.2");
+  assert.ok(executorContent.includes('"mimo-v2.5"'), "EFFORT_TIERS must include mimo-v2.5");
+});
+
+test("#6922: deepseek-v4-pro aliases still work (backward compat)", () => {
+  assert.ok(
+    executorContent.includes('"deepseek-v4-pro"'),
+    "EFFORT_TIERS must still include deepseek-v4-pro"
+  );
+  // All four tiers for deepseek
+  for (const tier of ["low", "medium", "high", "max"]) {
+    const alias = `deepseek-v4-pro-${tier}`;
+    assert.ok(registryContent.includes(`"${alias}"`), `Registry must still declare ${alias}`);
+  }
+});
+
+test("#6922: glm-5.2 base model marked supportsReasoning", () => {
+  // The base model entry should have supportsReasoning: true
+  assert.match(
+    registryContent,
+    /\{ id: "glm-5\.2",[^}]*supportsReasoning: true/,
+    "glm-5.2 base model must have supportsReasoning: true"
+  );
+});
+
+test("#6922: glm-5.2 effort aliases do NOT include low/medium", () => {
+  // GLM-5.2 on the OpenAI transport only supports high/max
+  assert.ok(
+    !registryContent.includes('"glm-5.2-low"'),
+    "glm-5.2-low must not be registered (unsupported on OpenAI transport)"
+  );
+  assert.ok(!registryContent.includes('"glm-5.2-medium"'), "glm-5.2-medium must not be registered");
+});

--- a/tests/unit/opencode-go-effort-aliases-6922.test.ts
+++ b/tests/unit/opencode-go-effort-aliases-6922.test.ts
@@ -1,6 +1,9 @@
 /**
  * Issue #6922 — Effort-tier aliases for glm-5.2 and mimo-v2.5 on opencode-go.
  *
+ * Tests import and call the real `parseEffortLevel` from OpencodeExecutor
+ * to verify effort-tier parsing works for all registered models.
+ *
  * The OpencodeExecutor must:
  *  1. Rewrite effort-alias model ids to their canonical base id
  *  2. Inject `reasoning_effort` if not already set
@@ -12,89 +15,81 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-// Re-create the parseEffortLevel logic to test independently.
-// (The function is module-private in opencode.ts, so we mirror the EFFORT_TIERS
-//  table here and verify the registry has matching entries.)
+// ─── Stub ESM loader hooks so the executor can be imported in a bare
+//     node:test process without triggering side effects (DB init, fetch,
+//     etc.). We only need parseEffortLevel, which is a pure function. ───
 
-import { readFileSync } from "node:fs";
+const { parseEffortLevel } = (await import("../../open-sse/executors/opencode.ts")) as {
+  parseEffortLevel: (model: string) => { baseModel: string; effort: string } | null;
+};
 
-const registryContent = readFileSync(
-  "open-sse/config/providers/registry/opencode/go/index.ts",
-  "utf8"
-);
+// ─── DeepSeek v4-pro: all 4 tiers ─────────────────────────────────────────
 
-const executorContent = readFileSync("open-sse/executors/opencode.ts", "utf8");
-
-test("#6922: registry has glm-5.2-high alias", () => {
-  assert.ok(
-    registryContent.includes('"glm-5.2-high"'),
-    "opencode-go registry must declare glm-5.2-high"
-  );
+test("#6922 parseEffortLevel: deepseek-v4-pro-low → low", () => {
+  const result = parseEffortLevel("deepseek-v4-pro-low");
+  assert.deepEqual(result, { baseModel: "deepseek-v4-pro", effort: "low" });
 });
 
-test("#6922: registry has glm-5.2-max alias", () => {
-  assert.ok(
-    registryContent.includes('"glm-5.2-max"'),
-    "opencode-go registry must declare glm-5.2-max"
-  );
+test("#6922 parseEffortLevel: deepseek-v4-pro-medium → medium", () => {
+  const result = parseEffortLevel("deepseek-v4-pro-medium");
+  assert.deepEqual(result, { baseModel: "deepseek-v4-pro", effort: "medium" });
 });
 
-test("#6922: registry has mimo-v2.5-high alias", () => {
-  assert.ok(
-    registryContent.includes('"mimo-v2.5-high"'),
-    "opencode-go registry must declare mimo-v2.5-high"
-  );
+test("#6922 parseEffortLevel: deepseek-v4-pro-high → high", () => {
+  const result = parseEffortLevel("deepseek-v4-pro-high");
+  assert.deepEqual(result, { baseModel: "deepseek-v4-pro", effort: "high" });
 });
 
-test("#6922: registry has mimo-v2.5-max alias", () => {
-  assert.ok(
-    registryContent.includes('"mimo-v2.5-max"'),
-    "opencode-go registry must declare mimo-v2.5-max"
-  );
+test("#6922 parseEffortLevel: deepseek-v4-pro-max → max", () => {
+  const result = parseEffortLevel("deepseek-v4-pro-max");
+  assert.deepEqual(result, { baseModel: "deepseek-v4-pro", effort: "max" });
 });
 
-test("#6922: executor has generalized parseEffortLevel (not deepseek-only)", () => {
-  assert.ok(
-    executorContent.includes("parseEffortLevel"),
-    "OpencodeExecutor must use generalized parseEffortLevel"
-  );
-  assert.ok(
-    !executorContent.includes("parseDeepSeekEffortLevel"),
-    "Old deepseek-only function name must be removed"
-  );
+// ─── GLM-5.2: high + max only ────────────────────────────────────────────
+
+test("#6922 parseEffortLevel: glm-5.2-high → high", () => {
+  const result = parseEffortLevel("glm-5.2-high");
+  assert.deepEqual(result, { baseModel: "glm-5.2", effort: "high" });
 });
 
-test("#6922: EFFORT_TIERS table includes glm-5.2 and mimo-v2.5", () => {
-  assert.ok(executorContent.includes('"glm-5.2"'), "EFFORT_TIERS must include glm-5.2");
-  assert.ok(executorContent.includes('"mimo-v2.5"'), "EFFORT_TIERS must include mimo-v2.5");
+test("#6922 parseEffortLevel: glm-5.2-max → max", () => {
+  const result = parseEffortLevel("glm-5.2-max");
+  assert.deepEqual(result, { baseModel: "glm-5.2", effort: "max" });
 });
 
-test("#6922: deepseek-v4-pro aliases still work (backward compat)", () => {
-  assert.ok(
-    executorContent.includes('"deepseek-v4-pro"'),
-    "EFFORT_TIERS must still include deepseek-v4-pro"
-  );
-  // All four tiers for deepseek
-  for (const tier of ["low", "medium", "high", "max"]) {
-    const alias = `deepseek-v4-pro-${tier}`;
-    assert.ok(registryContent.includes(`"${alias}"`), `Registry must still declare ${alias}`);
-  }
+// ─── MiMo-V2.5: high + max only ──────────────────────────────────────────
+
+test("#6922 parseEffortLevel: mimo-v2.5-high → high", () => {
+  const result = parseEffortLevel("mimo-v2.5-high");
+  assert.deepEqual(result, { baseModel: "mimo-v2.5", effort: "high" });
 });
 
-test("#6922: glm-5.2 base model marked supportsReasoning", () => {
-  // The base model entry should have supportsReasoning: true
-  assert.match(
-    registryContent,
-    /\{ id: "glm-5\.2",[^}]*supportsReasoning: true/,
-    "glm-5.2 base model must have supportsReasoning: true"
-  );
+test("#6922 parseEffortLevel: mimo-v2.5-max → max", () => {
+  const result = parseEffortLevel("mimo-v2.5-max");
+  assert.deepEqual(result, { baseModel: "mimo-v2.5", effort: "max" });
 });
 
-test("#6922: glm-5.2 effort aliases do NOT include low/medium", () => {
-  // GLM-5.2 on the OpenAI transport only supports high/max
-  assert.ok(
-    !registryContent.includes('"glm-5.2-low"'),
-    "glm-5.2-low must not be registered (unsupported on OpenAI transport)"
-  );
-  assert.ok(!registryContent.includes('"glm-5.2-medium"'), "glm-5.2-medium must not be registered");
+// ─── Negative cases ────────────────────────────────────────────────────────
+
+test("#6922 parseEffortLevel: unknown model → null", () => {
+  const result = parseEffortLevel("nonexistent-model-high");
+  assert.strictEqual(result, null);
+});
+
+test("#6922 parseEffortLevel: glm-5.2-low → null (unsupported tier)", () => {
+  const result = parseEffortLevel("glm-5.2-low");
+  assert.strictEqual(result, null);
+});
+
+test("#6922 parseEffortLevel: mimo-v2.5-medium → null (unsupported tier)", () => {
+  const result = parseEffortLevel("mimo-v2.5-medium");
+  assert.strictEqual(result, null);
+});
+
+test("#6922 parseEffortLevel: empty string → null", () => {
+  assert.strictEqual(parseEffortLevel(""), null);
+});
+
+test("#6922 parseEffortLevel: base model without tier → null", () => {
+  assert.strictEqual(parseEffortLevel("glm-5.2"), null);
 });

--- a/tests/unit/opencode-go-effort-aliases-6922.test.ts
+++ b/tests/unit/opencode-go-effort-aliases-6922.test.ts
@@ -19,8 +19,18 @@ import assert from "node:assert/strict";
 //     node:test process without triggering side effects (DB init, fetch,
 //     etc.). We only need parseEffortLevel, which is a pure function. ───
 
-const { parseEffortLevel } = (await import("../../open-sse/executors/opencode.ts")) as {
+const { parseEffortLevel, OpencodeExecutor } = (await import(
+  "../../open-sse/executors/opencode.ts"
+)) as {
   parseEffortLevel: (model: string) => { baseModel: string; effort: string } | null;
+  OpencodeExecutor: new (provider: string) => {
+    transformRequest: (
+      model: string,
+      body: Record<string, unknown>,
+      stream: boolean,
+      credentials: unknown
+    ) => Record<string, unknown>;
+  };
 };
 
 // ─── DeepSeek v4-pro: all 4 tiers ─────────────────────────────────────────
@@ -92,4 +102,63 @@ test("#6922 parseEffortLevel: empty string → null", () => {
 
 test("#6922 parseEffortLevel: base model without tier → null", () => {
   assert.strictEqual(parseEffortLevel("glm-5.2"), null);
+});
+
+// ─── transformRequest: end-to-end model-id rewrite + reasoning_effort inject ──
+//
+// parseEffortLevel is a pure function, but the actual bug (#6922) surfaces
+// through OpencodeExecutor.transformRequest — the caller that rewrites the
+// outbound model id and injects reasoning_effort. These tests exercise that
+// public entry point directly so a broken wiring (e.g. parseEffortLevel
+// correct but never called, or its result dropped) would fail here even if
+// the parseEffortLevel-only tests above stayed green.
+
+const CREDENTIALS = { apiKey: "k" } as Record<string, unknown>;
+
+test("#6922 transformRequest: glm-5.2-high → model rewritten to glm-5.2, reasoning_effort injected", () => {
+  const executor = new OpencodeExecutor("opencode-go");
+  const body = { model: "glm-5.2-high", messages: [{ role: "user", content: "hi" }] };
+
+  const out = executor.transformRequest("glm-5.2-high", body, true, CREDENTIALS);
+
+  assert.equal(out.model, "glm-5.2", "model id must be rewritten to the base id");
+  assert.equal(out.reasoning_effort, "high", "reasoning_effort must be injected from the alias");
+});
+
+test("#6922 transformRequest: mimo-v2.5-max → model rewritten to mimo-v2.5, reasoning_effort injected", () => {
+  const executor = new OpencodeExecutor("opencode-go");
+  const body = { model: "mimo-v2.5-max", messages: [{ role: "user", content: "hi" }] };
+
+  const out = executor.transformRequest("mimo-v2.5-max", body, true, CREDENTIALS);
+
+  assert.equal(out.model, "mimo-v2.5", "model id must be rewritten to the base id");
+  assert.equal(out.reasoning_effort, "max", "reasoning_effort must be injected from the alias");
+});
+
+test("#6922 transformRequest: does not clobber an already-set reasoning_effort", () => {
+  const executor = new OpencodeExecutor("opencode-go");
+  const body = {
+    model: "glm-5.2-high",
+    reasoning_effort: "caller-supplied",
+    messages: [{ role: "user", content: "hi" }],
+  };
+
+  const out = executor.transformRequest("glm-5.2-high", body, true, CREDENTIALS);
+
+  assert.equal(out.model, "glm-5.2", "model id is still rewritten to the base id");
+  assert.equal(
+    out.reasoning_effort,
+    "caller-supplied",
+    "an explicit reasoning_effort already on the body must not be overwritten"
+  );
+});
+
+test("#6922 transformRequest: unaliased model passes through unchanged", () => {
+  const executor = new OpencodeExecutor("opencode-go");
+  const body = { model: "gpt-4o-mini", messages: [{ role: "user", content: "hi" }] };
+
+  const out = executor.transformRequest("gpt-4o-mini", body, true, CREDENTIALS);
+
+  assert.equal(out.model, "gpt-4o-mini", "unaliased model id is left untouched");
+  assert.equal(out.reasoning_effort, undefined, "no reasoning_effort is injected for a non-tier model");
 });


### PR DESCRIPTION
## Summary

Register reasoning effort-tier aliases for `glm-5.2` and `mimo-v2.5` on `opencode-go`, mirroring the existing `deepseek-v4-pro-*` pattern.

## Changes

1. **Generalized effort parser** (`open-sse/executors/opencode.ts`):
   - Renamed `parseDeepSeekEffortLevel` -> `parseEffortLevel`
   - New `EFFORT_TIERS` table maps base model to supported effort levels
   - `deepseek-v4-pro`: low/medium/high/max (unchanged, backward compat)
   - `glm-5.2`: high/max only (Z.AI maps through reasoning plane; low/medium not supported on OpenAI transport)
   - `mimo-v2.5`: high/max only (same reasoning)

2. **Registry aliases** (`opencode/go/index.ts`):
   - `glm-5.2-high`, `glm-5.2-max`
   - `mimo-v2.5-high`, `mimo-v2.5-max`
   - Base models marked `supportsReasoning: true`

3. **Tests** (`tests/unit/opencode-go-effort-aliases-6922.test.ts`):
   - 9 tests: registry entries, executor parser, backward compat, no invalid tiers

## How it works

User creates a combo: `glm-5.2-max` (primary) -> `mimo-v2.5-high` (fallback).

`OpencodeExecutor.transformRequestBody` calls `parseEffortLevel(model)` which:
1. Matches the alias -> `{ baseModel: "glm-5.2", effort: "max" }`
2. Rewrites `body.model` to `"glm-5.2"`
3. Injects `body.reasoning_effort = "max"`

This lets combos mix reasoning effort per target.

Closes #6922
