### PR TITLE
fix(sse): apply commentary-phase drop filter in TRANSLATE mode (#6952)

### DIFF
--- a/changelog.d/fixes/6952-commentary-translate-mode.md
+++ b/changelog.d/fixes/6952-commentary-translate-mode.md
@@ -1,0 +1,1 @@
+- fix(sse): drop internal commentary-phase Responses output in TRANSLATE-mode streams, not just PASSTHROUGH — codex/Responses-upstream routes translated into another client format (e.g. Claude Code) no longer leak duplicate prose and narrated tool-call arguments into the client text channel (#6952)

--- a/open-sse/utils/responsesCommentaryDrop.ts
+++ b/open-sse/utils/responsesCommentaryDrop.ts
@@ -10,6 +10,7 @@
 // config/quality/file-size-baseline.json) so the #6561 fix (clearing the
 // buffered `event:` line alongside every drop) does not grow that file.
 import { isResponsesCommentaryMessageItem } from "../handlers/responseSanitizer.ts";
+import { FORMATS } from "../translator/formats.ts";
 
 type JsonRecord = Record<string, unknown>;
 
@@ -95,4 +96,15 @@ export function shouldDropResponsesCommentaryEvent(
       commentaryIndexes
     )
   );
+}
+
+// #6952 — TRANSLATE-mode chunk loop was missing this filter (only PASSTHROUGH
+// had it wired), so commentary-phase text leaked into the client. Own Sets +
+// the `targetFormat` gate, closed over so stream.ts (frozen) stays a one-liner.
+export function createTranslateCommentaryFilter(targetFormat: string | undefined) {
+  const commentaryItemIds = new Set<string>();
+  const commentaryIndexes = new Set<number>();
+  const applies = targetFormat === FORMATS.OPENAI_RESPONSES;
+  return (parsed: JsonRecord): boolean =>
+    applies && shouldDropResponsesCommentaryEvent(parsed, commentaryItemIds, commentaryIndexes);
 }

--- a/open-sse/utils/stream.ts
+++ b/open-sse/utils/stream.ts
@@ -31,7 +31,10 @@ import {
   sanitizeStreamingChunk,
 } from "../handlers/responseSanitizer.ts";
 import { isFeatureFlagEnabled } from "@/shared/utils/featureFlags";
-import { shouldDropResponsesCommentaryEvent } from "./responsesCommentaryDrop.ts";
+import {
+  shouldDropResponsesCommentaryEvent,
+  createTranslateCommentaryFilter,
+} from "./responsesCommentaryDrop.ts";
 import { buildErrorBody } from "./error.ts";
 import { parseTextualToolCallCandidate, isValidToolCallHeaderPrefix } from "./textualToolCall.ts";
 import { recordToolLatency } from "../services/toolLatencyTracker.ts";
@@ -707,6 +710,7 @@ export function createSSEStream(options: StreamOptions = {}) {
   // item id + output_index here and drop every matching follow-up event.
   const passthroughResponsesCommentaryItemIds = new Set<string>();
   const passthroughResponsesCommentaryIndexes = new Set<number>();
+  const dropCommentary = createTranslateCommentaryFilter(targetFormat);
   // #5786 — highest Responses-API `sequence_number` already forwarded on this stream.
   // The Responses API guarantees a strictly increasing sequence_number, so any event at
   // or below this watermark is an upstream reconnect/retry replay and must be dropped —
@@ -1931,6 +1935,8 @@ export function createSSEStream(options: StreamOptions = {}) {
           ) {
             continue;
           }
+
+          if (shouldDropResponsesCommentary && dropCommentary(parsed as JsonRecord)) continue;
 
           providerPayloadCollector.push(parsed);
 

--- a/tests/unit/repro-6952-commentary.test.ts
+++ b/tests/unit/repro-6952-commentary.test.ts
@@ -1,0 +1,257 @@
+/**
+ * TDD repro for #6952: commentary-phase output leaks in TRANSLATE mode.
+ *
+ * Background: #6199/#6561 added a stateful commentary-phase filter
+ * (`shouldDropResponsesCommentaryEvent`) but wired it only into
+ * `createSSEStream`'s PASSTHROUGH branch. The TRANSLATE-mode branch (an
+ * openai-responses upstream translated into another client format, e.g.
+ * codex routes streaming into Claude Code) called `translateResponse()` on
+ * every raw chunk without checking `phase`, so `phase: "commentary"`
+ * scratchpad text — duplicate prose and narrated tool-call arguments — leaked
+ * into the client-visible text block, right alongside the real final answer
+ * and the real function_call.
+ *
+ * This test drives `createSSEStream({ mode: "translate", targetFormat:
+ * "openai-responses", sourceFormat: "claude" })` with a realistic upstream
+ * sequence: a commentary item (duplicate prose + narrated tool-call JSON),
+ * a real final-answer item, and a real function_call — then asserts the
+ * translated Claude-shaped SSE stream contains the final prose exactly once,
+ * never the commentary text, and still carries the real tool call.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-commentary-6952-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+const core = await import("../../src/lib/db/core.ts");
+
+const { createSSEStream } = await import("../../open-sse/utils/stream.ts");
+
+const textEncoder = new TextEncoder();
+
+async function readTransformed(chunks: string[], options: object): Promise<string> {
+  const source = new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(textEncoder.encode(chunk));
+      }
+      controller.close();
+    },
+  });
+  return new Response(source.pipeThrough(createSSEStream(options))).text();
+}
+
+test.after(() => {
+  core.resetDbInstance();
+  if (fs.existsSync(TEST_DATA_DIR)) {
+    fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  }
+});
+
+const COMMENTARY_TEXT = "narrating the tool call before actually making it";
+const COMMENTARY_ARGS_JSON = '{"path":"/etc/passwd","reason":"scratchpad narration"}';
+const FINAL_TEXT = "Here is the final answer for the user.";
+const TOOL_NAME = "read_file";
+const TOOL_ARGS_JSON = '{"path":"/tmp/real.txt"}';
+
+function sse(event: object): string {
+  return `data: ${JSON.stringify(event)}\n\n`;
+}
+
+// Upstream openai-responses sequence: commentary item (prose + narrated tool
+// args) -> real final-answer item -> real function_call.
+function buildResponsesStream(): string[] {
+  return [
+    sse({ type: "response.created", response: { id: "resp_6952", output: [] } }),
+    // --- commentary item (internal scratchpad, must never reach the client) ---
+    sse({
+      type: "response.output_item.added",
+      output_index: 0,
+      item: {
+        id: "msg_commentary",
+        type: "message",
+        role: "assistant",
+        phase: "commentary",
+        content: [],
+      },
+    }),
+    sse({
+      type: "response.output_text.delta",
+      output_index: 0,
+      item_id: "msg_commentary",
+      content_index: 0,
+      delta: COMMENTARY_TEXT,
+    }),
+    sse({
+      type: "response.output_text.delta",
+      output_index: 0,
+      item_id: "msg_commentary",
+      content_index: 0,
+      delta: COMMENTARY_ARGS_JSON,
+    }),
+    sse({
+      type: "response.output_text.done",
+      output_index: 0,
+      item_id: "msg_commentary",
+      content_index: 0,
+      text: COMMENTARY_TEXT + COMMENTARY_ARGS_JSON,
+    }),
+    sse({
+      type: "response.output_item.done",
+      output_index: 0,
+      item: {
+        id: "msg_commentary",
+        type: "message",
+        role: "assistant",
+        phase: "commentary",
+        content: [{ type: "output_text", text: COMMENTARY_TEXT + COMMENTARY_ARGS_JSON }],
+      },
+    }),
+    // --- real final-answer item (must always be forwarded, exactly once) ---
+    sse({
+      type: "response.output_item.added",
+      output_index: 1,
+      item: {
+        id: "msg_final",
+        type: "message",
+        role: "assistant",
+        phase: "final",
+        content: [],
+      },
+    }),
+    sse({
+      type: "response.output_text.delta",
+      output_index: 1,
+      item_id: "msg_final",
+      content_index: 0,
+      delta: FINAL_TEXT,
+    }),
+    sse({
+      type: "response.output_text.done",
+      output_index: 1,
+      item_id: "msg_final",
+      content_index: 0,
+      text: FINAL_TEXT,
+    }),
+    sse({
+      type: "response.output_item.done",
+      output_index: 1,
+      item: {
+        id: "msg_final",
+        type: "message",
+        role: "assistant",
+        phase: "final",
+        content: [{ type: "output_text", text: FINAL_TEXT }],
+      },
+    }),
+    // --- real function_call (must always be forwarded) ---
+    sse({
+      type: "response.output_item.added",
+      output_index: 2,
+      item: {
+        id: "fc_real",
+        type: "function_call",
+        call_id: "call_real_1",
+        name: TOOL_NAME,
+        arguments: "",
+      },
+    }),
+    sse({
+      type: "response.function_call_arguments.delta",
+      output_index: 2,
+      item_id: "fc_real",
+      delta: TOOL_ARGS_JSON,
+    }),
+    sse({
+      type: "response.output_item.done",
+      output_index: 2,
+      item: {
+        id: "fc_real",
+        type: "function_call",
+        call_id: "call_real_1",
+        name: TOOL_NAME,
+        arguments: TOOL_ARGS_JSON,
+      },
+    }),
+    sse({
+      type: "response.completed",
+      response: {
+        id: "resp_6952",
+        output: [
+          {
+            id: "msg_final",
+            type: "message",
+            role: "assistant",
+            phase: "final",
+            content: [{ type: "output_text", text: FINAL_TEXT }],
+          },
+          {
+            id: "fc_real",
+            type: "function_call",
+            call_id: "call_real_1",
+            name: TOOL_NAME,
+            arguments: TOOL_ARGS_JSON,
+          },
+        ],
+        usage: { input_tokens: 10, output_tokens: 20 },
+      },
+    }),
+  ];
+}
+
+const TRANSLATE_RESPONSES_TO_CLAUDE_OPTIONS = {
+  mode: "translate",
+  targetFormat: "openai-responses",
+  sourceFormat: "claude",
+  provider: "openai",
+};
+
+test("TRANSLATE mode drops commentary-phase text before translateResponse (#6952)", async () => {
+  const output = await readTransformed(buildResponsesStream(), {
+    ...TRANSLATE_RESPONSES_TO_CLAUDE_OPTIONS,
+    dropResponsesCommentary: true,
+  });
+
+  assert.ok(
+    !output.includes(COMMENTARY_TEXT),
+    "commentary-phase prose must not reach the translated client stream"
+  );
+  assert.ok(
+    !output.includes(COMMENTARY_ARGS_JSON),
+    "commentary-phase narrated tool-call JSON must not reach the translated client stream"
+  );
+
+  // The final prose must appear exactly once — not once from commentary
+  // duplication and once from the real final item.
+  const finalTextOccurrences = output.split(FINAL_TEXT).length - 1;
+  assert.equal(
+    finalTextOccurrences,
+    1,
+    `expected prose exactly once in the translated stream, got ${finalTextOccurrences}`
+  );
+
+  // The real tool call must still be forwarded (arguments are JSON-escaped inside
+  // an `input_json_delta` SSE frame, so match on the unescaped path fragment).
+  assert.ok(
+    output.includes("/tmp/real.txt"),
+    "the real function_call arguments must be forwarded"
+  );
+  assert.ok(output.includes(TOOL_NAME), "the real function_call name must be forwarded");
+});
+
+test("TRANSLATE mode passes commentary through when dropping is disabled (gate/regression) (#6952)", async () => {
+  const output = await readTransformed(buildResponsesStream(), {
+    ...TRANSLATE_RESPONSES_TO_CLAUDE_OPTIONS,
+    dropResponsesCommentary: false,
+  });
+
+  assert.ok(
+    output.includes(COMMENTARY_TEXT),
+    "with the flag disabled, commentary text must still pass through untouched"
+  );
+  assert.ok(output.includes(FINAL_TEXT), "the final answer text must still be forwarded");
+});


### PR DESCRIPTION
Closes #6952

## Root cause
The #6199/#6561 commentary-phase filter (`shouldDropResponsesCommentaryEvent`, `open-sse/utils/responsesCommentaryDrop.ts`) is wired only into `createSSEStream`'s PASSTHROUGH branch (`open-sse/utils/stream.ts`). The TRANSLATE-mode loop (openai-responses upstream translated into another client format, e.g. codex routes streaming into Claude Code) calls `translateResponse()` on every raw chunk with no `phase` check, so internal commentary-phase scratchpad text — duplicate prose and narrated tool-call arguments — leaks into the client-visible content channel.

## Fix
Extends the same stateful filter into the TRANSLATE-mode chunk loop via a small factory, `createTranslateCommentaryFilter(targetFormat)`, that owns its own item/index `Set`s (independent from the PASSTHROUGH Sets) and gates on `targetFormat === "openai-responses"`. The wiring in `stream.ts` (a frozen file per `config/quality/file-size-baseline.json`) stays a single guarded line; the logic itself lives in `responsesCommentaryDrop.ts` (not frozen).

## Evidence (TDD, Hard Rule #18)
`tests/unit/repro-6952-commentary.test.ts` drives `createSSEStream({ mode: "translate", targetFormat: "openai-responses", sourceFormat: "claude" })` with a realistic upstream sequence: a commentary item (duplicate prose + narrated tool-call JSON), a real final-answer item, and a real function_call.

- Against `origin/release/v3.8.47` (pre-fix): **FAILED** — `AssertionError: commentary-phase prose must not reach the translated client stream`
- Against the fix: **PASSED** (2/2 — drop-enabled and the flag-off gate/regression control)

## Gates run
- `npm run typecheck:core` — clean
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json open-sse/utils/stream.ts open-sse/utils/responsesCommentaryDrop.ts tests/unit/repro-6952-commentary.test.ts` — clean
- `node scripts/check/check-file-size.mjs` — `stream.ts` stays within its frozen cap (2792); the 2 remaining violations reported (`ProxyRegistryManager.tsx`, `tokenHealthCheck.ts`) are pre-existing base-red, confirmed unaffected via `git show origin/release/v3.8.47:<path> | wc -l`
- `node scripts/check/check-complexity.mjs` — OK (2056/2056, no regression)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (890/890, no regression)
- `node scripts/check/check-changelog-integrity.mjs` — OK
- Related suites green: `tests/unit/responses-commentary-event-frame-6561.test.ts`, `tests/unit/responses-commentary-passthrough-6199.test.ts`, `tests/unit/stream-utils.test.ts` (56/56 total)

Note: `tests/unit/stream-utils.test.ts` is a frozen test file with only 1 line of headroom under its cap, so the plan's optional "regression in stream-utils.test.ts" was not practical to add there without extraction beyond this fix's scope — the new `repro-6952-commentary.test.ts` already covers TRANSLATE Responses→Claude with the drop-flag on/off gate.