### PR TITLE
Preserve direct-model combo metadata

### DIFF
--- a/src/app/api/v1/models/catalog.ts
+++ b/src/app/api/v1/models/catalog.ts
@@ -69,6 +69,8 @@ import {
   intersectStringArrays,
   minKnownNumber,
   maybeOmitCatalogModelName,
+  getThinkingCapabilityFields,
+  mergeComboCapabilities,
 } from "./catalogHelpers";
 import {
   qualifyOpenRouterModelId,
@@ -529,32 +531,25 @@ async function buildUnifiedModelsResponseCore(
             ? ["text"]
             : undefined;
 
-      const capabilities: Record<string, boolean> = {};
-      if (typeof synced?.tool_call === "boolean") {
-        capabilities.tool_calling = synced.tool_call;
-      } else if (typeof registryModel?.toolCalling === "boolean") {
-        capabilities.tool_calling = registryModel.toolCalling;
-      } else if (typeof spec?.supportsTools === "boolean") {
-        capabilities.tool_calling = spec.supportsTools;
+      const capabilities: Record<string, boolean | string[]> = {};
+      capabilities.tool_calling = canonical.capabilities.toolCalling;
+      capabilities.reasoning = canonical.capabilities.reasoning;
+      if (typeof canonical.capabilities.vision === "boolean") {
+        capabilities.vision = canonical.capabilities.vision;
       }
-      if (typeof synced?.reasoning === "boolean") {
-        capabilities.reasoning = synced.reasoning;
-      } else if (typeof registryModel?.supportsReasoning === "boolean") {
-        capabilities.reasoning = registryModel.supportsReasoning;
-      } else if (typeof spec?.supportsThinking === "boolean") {
-        capabilities.reasoning = spec.supportsThinking;
+      if (typeof canonical.capabilities.attachment === "boolean") {
+        capabilities.attachment = canonical.capabilities.attachment;
       }
-      if (typeof knownVision === "boolean") capabilities.vision = knownVision;
-      if (typeof synced?.attachment === "boolean") capabilities.attachment = synced.attachment;
-      if (typeof synced?.structured_output === "boolean") {
-        capabilities.structured_output = synced.structured_output;
+      if (typeof canonical.capabilities.structuredOutput === "boolean") {
+        capabilities.structured_output = canonical.capabilities.structuredOutput;
       }
-      if (typeof synced?.temperature === "boolean") capabilities.temperature = synced.temperature;
-      if (typeof synced?.reasoning === "boolean") {
-        capabilities.thinking = synced.reasoning;
-      } else if (typeof spec?.supportsThinking === "boolean") {
-        capabilities.thinking = spec.supportsThinking;
+      if (typeof canonical.capabilities.temperature === "boolean") {
+        capabilities.temperature = canonical.capabilities.temperature;
       }
+      Object.assign(
+        capabilities,
+        getThinkingCapabilityFields(providerId, modelId, canonical.capabilities.supportsThinking)
+      );
 
       return {
         ...(contextLength ? { contextLength } : {}),
@@ -606,22 +601,7 @@ async function buildUnifiedModelsResponseCore(
         ? intersectStringArrays(knownMetadata.map((metadata) => metadata.outputModalities || []))
         : [];
 
-      const capabilities: Record<string, boolean> = {};
-      for (const key of [
-        "tool_calling",
-        "reasoning",
-        "vision",
-        "attachment",
-        "structured_output",
-        "temperature",
-        "thinking",
-      ]) {
-        const values = knownMetadata.map((metadata) => metadata.capabilities[key]);
-        if (values.every((value): value is boolean => typeof value === "boolean")) {
-          const [first] = values;
-          if (values.every((value) => value === first)) capabilities[key] = first;
-        }
-      }
+      const capabilities = mergeComboCapabilities(knownMetadata);
 
       return {
         ...baseMetadata,

--- a/src/app/api/v1/models/catalogHelpers.ts
+++ b/src/app/api/v1/models/catalogHelpers.ts
@@ -3,6 +3,11 @@
 // catalog host shrinks toward the file-size cap without changing behavior — every
 // function body here is byte-identical to its previous in-catalog definition.
 
+import {
+  CANONICAL_EFFORT_VALUES,
+  extendCodexGpt56EffortValues,
+} from "@/shared/reasoning/effortStandardization";
+
 export interface CustomModelEntry {
   id?: string;
   name?: string;
@@ -30,7 +35,7 @@ export type ComboTargetCatalogMetadata = {
   maxOutputTokens?: number;
   inputModalities?: string[];
   outputModalities?: string[];
-  capabilities: Record<string, boolean>;
+  capabilities: Record<string, boolean | string[]>;
 };
 
 export function isPositiveFiniteNumber(value: unknown): value is number {
@@ -73,4 +78,54 @@ export function minKnownNumber(values: Array<number | undefined>): number | unde
   const knownValues = values.filter(isPositiveFiniteNumber);
   if (knownValues.length === 0) return undefined;
   return Math.min(...knownValues);
+}
+
+export function getThinkingCapabilityFields(
+  providerId: string,
+  modelId: string,
+  resolvedThinking?: boolean | null
+): Record<string, boolean | string[]> {
+  const supportsThinking = resolvedThinking;
+  if (typeof supportsThinking !== "boolean") return {};
+  return {
+    thinking: supportsThinking,
+    supportsThinking,
+    ...(supportsThinking
+      ? {
+          effort_tiers: extendCodexGpt56EffortValues(providerId, modelId, CANONICAL_EFFORT_VALUES),
+        }
+      : {}),
+  };
+}
+
+export function mergeComboCapabilities(
+  metadata: ComboTargetCatalogMetadata[]
+): Record<string, boolean | string[]> {
+  const capabilities: Record<string, boolean | string[]> = {};
+  for (const key of [
+    "tool_calling",
+    "reasoning",
+    "vision",
+    "attachment",
+    "structured_output",
+    "temperature",
+    "thinking",
+    "supportsThinking",
+  ]) {
+    const values = metadata.map((entry) => entry.capabilities[key]);
+    if (values.every((value): value is boolean => typeof value === "boolean")) {
+      const [first] = values;
+      if (values.every((value) => value === first)) capabilities[key] = first;
+    }
+  }
+  const effortTiers = metadata.map((entry) => entry.capabilities.effort_tiers);
+  if (
+    effortTiers.every(
+      (value): value is string[] =>
+        Array.isArray(value) && value.every((entry) => typeof entry === "string")
+    )
+  ) {
+    capabilities.effort_tiers = intersectStringArrays(effortTiers);
+  }
+  return capabilities;
 }

--- a/tests/unit/models-catalog-combo-metadata.test.ts
+++ b/tests/unit/models-catalog-combo-metadata.test.ts
@@ -1,0 +1,119 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-combo-metadata-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.API_KEY_SECRET ||= "combo-metadata-test-secret";
+
+const core = await import("../../src/lib/db/core.ts");
+const providersDb = await import("../../src/lib/db/providers.ts");
+const combosDb = await import("../../src/lib/db/combos.ts");
+const catalog = await import("../../src/app/api/v1/models/catalog.ts");
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("single-target combo preserves its direct model metadata", async () => {
+  await providersDb.createProviderConnection({
+    provider: "codex",
+    authType: "oauth",
+    name: "codex-gpt-5.6-single-target-combo",
+    accessToken: "codex-test-token",
+    isActive: true,
+    testStatus: "active",
+    providerSpecificData: {},
+  });
+  await combosDb.createCombo({
+    name: "gpt-5.6-sol-combo",
+    strategy: "auto",
+    models: ["codex/gpt-5.6-sol"],
+  });
+
+  const response = await catalog.getUnifiedModelsResponse(
+    new Request("http://localhost/api/v1/models")
+  );
+  const body = (await response.json()) as { data: Array<Record<string, unknown>> };
+  const direct = body.data.find((item) => item.id === "cx/gpt-5.6-sol");
+  const combo = body.data.find((item) => item.id === "gpt-5.6-sol-combo");
+
+  assert.equal(response.status, 200);
+  assert.ok(direct);
+  assert.ok(combo);
+  for (const field of [
+    "context_length",
+    "max_input_tokens",
+    "max_output_tokens",
+    "input_modalities",
+    "output_modalities",
+    "capabilities",
+  ]) {
+    assert.deepEqual(combo[field], direct[field], field);
+  }
+});
+
+test("single-target combo respects registry reasoning overrides before specs", async () => {
+  await providersDb.createProviderConnection({
+    provider: "command-code",
+    authType: "apikey",
+    name: "command-code-gpt-5.4-mini-combo",
+    apiKey: "command-code-test-key",
+    isActive: true,
+    testStatus: "active",
+    providerSpecificData: {},
+  });
+  await combosDb.createCombo({
+    name: "gpt-5.4-mini-command-code-combo",
+    strategy: "auto",
+    models: ["command-code/gpt-5.4-mini"],
+  });
+
+  const response = await catalog.getUnifiedModelsResponse(
+    new Request("http://localhost/api/v1/models")
+  );
+  const body = (await response.json()) as { data: Array<Record<string, unknown>> };
+  const combo = body.data.find((item) => item.id === "gpt-5.4-mini-command-code-combo");
+
+  assert.equal(response.status, 200);
+  assert.ok(combo);
+  const capabilities = combo.capabilities as Record<string, unknown>;
+  assert.equal(capabilities.reasoning, false);
+  assert.equal(capabilities.thinking, false);
+  assert.equal(capabilities.supportsThinking, false);
+  assert.equal(Object.hasOwn(capabilities, "effort_tiers"), false);
+});
+
+test("single-target combo respects resolved reasoning deny patterns", async () => {
+  await providersDb.createProviderConnection({
+    provider: "antigravity",
+    authType: "oauth",
+    name: "antigravity-gemini-no-thinking-combo",
+    accessToken: "antigravity-test-token",
+    isActive: true,
+    testStatus: "active",
+    providerSpecificData: {},
+  });
+  await combosDb.createCombo({
+    name: "antigravity-gemini-no-thinking-combo",
+    strategy: "auto",
+    models: ["antigravity/gemini-3.1-pro-high"],
+  });
+
+  const response = await catalog.getUnifiedModelsResponse(
+    new Request("http://localhost/api/v1/models")
+  );
+  const body = (await response.json()) as { data: Array<Record<string, unknown>> };
+  const combo = body.data.find((item) => item.id === "antigravity-gemini-no-thinking-combo");
+
+  assert.equal(response.status, 200);
+  assert.ok(combo);
+  const capabilities = combo.capabilities as Record<string, unknown>;
+  assert.equal(capabilities.reasoning, false);
+  assert.equal(capabilities.thinking, false);
+  assert.equal(capabilities.supportsThinking, false);
+  assert.equal(Object.hasOwn(capabilities, "effort_tiers"), false);
+});


### PR DESCRIPTION
## Summary

- Preserve direct-model capability and token metadata when a combo points to a single direct model, including reasoning effort tiers.

## Validation

- [x] `npm run lint`
- [x] `npm run test:unit`
- [x] `npm run test:coverage`
- [x] Coverage is still `>= 60%` for statements, lines, functions, and branches
- [x] SonarQube PR analysis is green or any remaining issues are explicitly documented below

## Tests Added or Updated

- Updated the v1 models catalog combo-metadata test coverage.

## Coverage Notes

- The models catalog combo-derivation path now has unit coverage for preserving direct-model metadata on single-target combos.

## Reviewer Notes

- The new metadata propagation includes reasoning support flags and effort tiers; review the combo aggregation logic for compatibility with existing catalog consumers.
