### PR TITLE
[defer] feat(sidecar): add provider manifest client

### DIFF
--- a/docs/reference/PROVIDER_PLUGIN_MANIFEST.md
+++ b/docs/reference/PROVIDER_PLUGIN_MANIFEST.md
@@ -15,6 +15,10 @@ executor code, OAuth defaults, headers, or process environment state.
 
 The same manifest is available over HTTP at
 `GET /api/v1/provider-plugin-manifest` for sidecars that run out-of-process.
+Code that needs to consume the manifest over HTTP should use
+`open-sse/config/providerPluginManifestClient.ts` instead of hard-coding the
+route. The client resolves `OMNIROUTE_PROVIDER_MANIFEST_URL`, then an explicit
+base URL, then the local OmniRoute API default.
 
 OmniRoute advertises that URL to Bifrost and CLIProxyAPI via the
 `X-OmniRoute-Provider-Manifest-Url` request header. Set

--- a/open-sse/config/providerPluginManifestClient.ts
+++ b/open-sse/config/providerPluginManifestClient.ts
@@ -1,0 +1,87 @@
+import type {
+  ProviderPluginManifest,
+  ProviderPluginManifestEntry,
+} from "./providerPluginManifest.ts";
+
+export const PROVIDER_PLUGIN_MANIFEST_PATH = "/api/v1/provider-plugin-manifest";
+export const PROVIDER_PLUGIN_MANIFEST_ENV = "OMNIROUTE_PROVIDER_MANIFEST_URL";
+
+export interface ProviderPluginManifestClientOptions {
+  baseUrl?: string | null;
+  manifestUrl?: string | null;
+  fetchImpl?: typeof fetch;
+  signal?: AbortSignal | null;
+}
+
+function trimTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, "");
+}
+
+export function resolveProviderPluginManifestUrl(
+  options: Pick<ProviderPluginManifestClientOptions, "baseUrl" | "manifestUrl"> = {},
+): string {
+  const explicitUrl = options.manifestUrl?.trim();
+  if (explicitUrl) return explicitUrl;
+
+  const envUrl = process.env[PROVIDER_PLUGIN_MANIFEST_ENV]?.trim();
+  if (envUrl) return envUrl;
+
+  const baseUrl = options.baseUrl?.trim();
+  if (baseUrl) {
+    return `${trimTrailingSlash(baseUrl)}${PROVIDER_PLUGIN_MANIFEST_PATH}`;
+  }
+
+  const host = process.env.HOST || "127.0.0.1";
+  const port = process.env.PORT || process.env.DASHBOARD_PORT || process.env.API_PORT || "20128";
+  const protocol = process.env.OMNIROUTE_PUBLIC_PROTOCOL || "http";
+  return `${protocol}://${host}:${port}${PROVIDER_PLUGIN_MANIFEST_PATH}`;
+}
+
+export async function fetchProviderPluginManifest(
+  options: ProviderPluginManifestClientOptions = {},
+): Promise<ProviderPluginManifest> {
+  const fetcher = options.fetchImpl ?? fetch;
+  const url = resolveProviderPluginManifestUrl(options);
+  const response = await fetcher(url, {
+    headers: { Accept: "application/json" },
+    signal: options.signal ?? undefined,
+  });
+
+  if (!response.ok) {
+    throw new Error(`Provider plugin manifest request failed: HTTP ${response.status}`);
+  }
+
+  const manifest = (await response.json()) as ProviderPluginManifest;
+  if (manifest.schemaVersion !== 1 || !Array.isArray(manifest.providers)) {
+    throw new Error("Provider plugin manifest response is not schemaVersion 1");
+  }
+
+  return manifest;
+}
+
+export function getProviderPluginManifestEntryForModelFromManifest(
+  manifest: ProviderPluginManifest,
+  model: string | undefined,
+): ProviderPluginManifestEntry | null {
+  if (!model) return null;
+
+  const providerPrefix = model.includes("/") ? model.split("/", 1)[0] : "";
+  if (providerPrefix) {
+    const prefixed = manifest.providers.find(
+      (provider) => provider.id === providerPrefix || provider.alias === providerPrefix,
+    );
+    if (prefixed) return prefixed;
+  }
+
+  return manifest.providers.find((provider) =>
+    provider.models.some((candidate) => candidate.id === model),
+  ) ?? null;
+}
+
+export async function fetchProviderPluginManifestEntryForModel(
+  model: string | undefined,
+  options: ProviderPluginManifestClientOptions = {},
+): Promise<ProviderPluginManifestEntry | null> {
+  const manifest = await fetchProviderPluginManifest(options);
+  return getProviderPluginManifestEntryForModelFromManifest(manifest, model);
+}

--- a/open-sse/config/providerPluginManifestClient.ts
+++ b/open-sse/config/providerPluginManifestClient.ts
@@ -2,9 +2,11 @@ import type {
   ProviderPluginManifest,
   ProviderPluginManifestEntry,
 } from "./providerPluginManifest.ts";
-
-export const PROVIDER_PLUGIN_MANIFEST_PATH = "/api/v1/provider-plugin-manifest";
-export const PROVIDER_PLUGIN_MANIFEST_ENV = "OMNIROUTE_PROVIDER_MANIFEST_URL";
+import {
+  PROVIDER_PLUGIN_MANIFEST_ENV,
+  PROVIDER_PLUGIN_MANIFEST_PATH,
+  resolveProviderPluginManifestUrl as resolveProviderPluginManifestUrlFromOrigin,
+} from "./providerPluginManifestUrl.ts";
 
 export interface ProviderPluginManifestClientOptions {
   baseUrl?: string | null;
@@ -13,12 +15,10 @@ export interface ProviderPluginManifestClientOptions {
   signal?: AbortSignal | null;
 }
 
-function trimTrailingSlash(value: string): string {
-  return value.replace(/\/+$/, "");
-}
+export { PROVIDER_PLUGIN_MANIFEST_ENV, PROVIDER_PLUGIN_MANIFEST_PATH };
 
 export function resolveProviderPluginManifestUrl(
-  options: Pick<ProviderPluginManifestClientOptions, "baseUrl" | "manifestUrl"> = {},
+  options: Pick<ProviderPluginManifestClientOptions, "baseUrl" | "manifestUrl"> = {}
 ): string {
   const explicitUrl = options.manifestUrl?.trim();
   if (explicitUrl) return explicitUrl;
@@ -26,19 +26,11 @@ export function resolveProviderPluginManifestUrl(
   const envUrl = process.env[PROVIDER_PLUGIN_MANIFEST_ENV]?.trim();
   if (envUrl) return envUrl;
 
-  const baseUrl = options.baseUrl?.trim();
-  if (baseUrl) {
-    return `${trimTrailingSlash(baseUrl)}${PROVIDER_PLUGIN_MANIFEST_PATH}`;
-  }
-
-  const host = process.env.HOST || "127.0.0.1";
-  const port = process.env.PORT || process.env.DASHBOARD_PORT || process.env.API_PORT || "20128";
-  const protocol = process.env.OMNIROUTE_PUBLIC_PROTOCOL || "http";
-  return `${protocol}://${host}:${port}${PROVIDER_PLUGIN_MANIFEST_PATH}`;
+  return resolveProviderPluginManifestUrlFromOrigin(options.baseUrl);
 }
 
 export async function fetchProviderPluginManifest(
-  options: ProviderPluginManifestClientOptions = {},
+  options: ProviderPluginManifestClientOptions = {}
 ): Promise<ProviderPluginManifest> {
   const fetcher = options.fetchImpl ?? fetch;
   const url = resolveProviderPluginManifestUrl(options);
@@ -61,26 +53,28 @@ export async function fetchProviderPluginManifest(
 
 export function getProviderPluginManifestEntryForModelFromManifest(
   manifest: ProviderPluginManifest,
-  model: string | undefined,
+  model: string | undefined
 ): ProviderPluginManifestEntry | null {
   if (!model) return null;
 
   const providerPrefix = model.includes("/") ? model.split("/", 1)[0] : "";
   if (providerPrefix) {
     const prefixed = manifest.providers.find(
-      (provider) => provider.id === providerPrefix || provider.alias === providerPrefix,
+      (provider) => provider.id === providerPrefix || provider.alias === providerPrefix
     );
     if (prefixed) return prefixed;
   }
 
-  return manifest.providers.find((provider) =>
-    provider.models.some((candidate) => candidate.id === model),
-  ) ?? null;
+  return (
+    manifest.providers.find((provider) =>
+      provider.models.some((candidate) => candidate.id === model)
+    ) ?? null
+  );
 }
 
 export async function fetchProviderPluginManifestEntryForModel(
   model: string | undefined,
-  options: ProviderPluginManifestClientOptions = {},
+  options: ProviderPluginManifestClientOptions = {}
 ): Promise<ProviderPluginManifestEntry | null> {
   const manifest = await fetchProviderPluginManifest(options);
   return getProviderPluginManifestEntryForModelFromManifest(manifest, model);

--- a/open-sse/config/providerPluginManifestClient.ts
+++ b/open-sse/config/providerPluginManifestClient.ts
@@ -15,6 +15,17 @@ export interface ProviderPluginManifestClientOptions {
   signal?: AbortSignal | null;
 }
 
+export interface CachedProviderPluginManifest {
+  etag: string;
+  manifest: ProviderPluginManifest;
+}
+
+export interface ProviderPluginManifestFetchResult {
+  etag?: string;
+  manifest: ProviderPluginManifest;
+  modified: boolean;
+}
+
 export { PROVIDER_PLUGIN_MANIFEST_ENV, PROVIDER_PLUGIN_MANIFEST_PATH };
 
 export function resolveProviderPluginManifestUrl(
@@ -32,12 +43,37 @@ export function resolveProviderPluginManifestUrl(
 export async function fetchProviderPluginManifest(
   options: ProviderPluginManifestClientOptions = {}
 ): Promise<ProviderPluginManifest> {
+  return (await fetchProviderPluginManifestWithCache(options)).manifest;
+}
+
+export async function fetchProviderPluginManifestWithCache(
+  options: ProviderPluginManifestClientOptions & {
+    cachedManifest?: CachedProviderPluginManifest | null;
+  } = {}
+): Promise<ProviderPluginManifestFetchResult> {
   const fetcher = options.fetchImpl ?? fetch;
   const url = resolveProviderPluginManifestUrl(options);
+  const headers: Record<string, string> = { Accept: "application/json" };
+  if (options.cachedManifest?.etag) {
+    headers["If-None-Match"] = options.cachedManifest.etag;
+  }
   const response = await fetcher(url, {
-    headers: { Accept: "application/json" },
+    headers,
     signal: options.signal ?? undefined,
   });
+
+  if (response.status === 304) {
+    if (!options.cachedManifest) {
+      throw new Error(
+        "Provider plugin manifest request returned HTTP 304 without a cached manifest"
+      );
+    }
+    return {
+      manifest: options.cachedManifest.manifest,
+      etag: options.cachedManifest.etag,
+      modified: false,
+    };
+  }
 
   if (!response.ok) {
     throw new Error(`Provider plugin manifest request failed: HTTP ${response.status}`);
@@ -48,7 +84,11 @@ export async function fetchProviderPluginManifest(
     throw new Error("Provider plugin manifest response is not schemaVersion 1");
   }
 
-  return manifest;
+  return {
+    manifest,
+    ...(response.headers.get("ETag") ? { etag: response.headers.get("ETag")! } : {}),
+    modified: true,
+  };
 }
 
 export function getProviderPluginManifestEntryForModelFromManifest(

--- a/open-sse/config/providerPluginManifestUrl.ts
+++ b/open-sse/config/providerPluginManifestUrl.ts
@@ -1,12 +1,13 @@
 export const PROVIDER_PLUGIN_MANIFEST_HEADER = "X-OmniRoute-Provider-Manifest-Url";
 export const PROVIDER_PLUGIN_MANIFEST_PATH = "/api/v1/provider-plugin-manifest";
+export const PROVIDER_PLUGIN_MANIFEST_ENV = "OMNIROUTE_PROVIDER_MANIFEST_URL";
 
 function trimTrailingSlash(value: string): string {
   return value.replace(/\/$/, "");
 }
 
 export function resolveProviderPluginManifestUrl(origin?: string | null): string {
-  const configured = process.env.OMNIROUTE_PROVIDER_MANIFEST_URL?.trim();
+  const configured = process.env[PROVIDER_PLUGIN_MANIFEST_ENV]?.trim();
   if (configured) return configured;
 
   if (origin) {

--- a/tests/unit/provider-plugin-manifest-client.test.ts
+++ b/tests/unit/provider-plugin-manifest-client.test.ts
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  fetchProviderPluginManifest,
+  fetchProviderPluginManifestEntryForModel,
+  getProviderPluginManifestEntryForModelFromManifest,
+  PROVIDER_PLUGIN_MANIFEST_ENV,
+  PROVIDER_PLUGIN_MANIFEST_PATH,
+  resolveProviderPluginManifestUrl,
+} from "../../open-sse/config/providerPluginManifestClient.ts";
+import type { ProviderPluginManifest } from "../../open-sse/config/providerPluginManifest.ts";
+
+const ORIGINAL_ENV = { ...process.env };
+
+function restoreEnv() {
+  process.env = { ...ORIGINAL_ENV };
+}
+
+test.afterEach(() => {
+  restoreEnv();
+});
+
+test("provider plugin manifest client resolves explicit and env URLs first", () => {
+  process.env[PROVIDER_PLUGIN_MANIFEST_ENV] = "http://env.example/manifest";
+
+  assert.equal(
+    resolveProviderPluginManifestUrl({ manifestUrl: "http://explicit.example/manifest" }),
+    "http://explicit.example/manifest",
+  );
+  assert.equal(
+    resolveProviderPluginManifestUrl({ baseUrl: "http://local.example:20128/" }),
+    "http://env.example/manifest",
+  );
+});
+
+test("provider plugin manifest client resolves base and default local URLs", () => {
+  delete process.env[PROVIDER_PLUGIN_MANIFEST_ENV];
+  process.env.HOST = "0.0.0.0";
+  process.env.PORT = "20129";
+
+  assert.equal(
+    resolveProviderPluginManifestUrl({ baseUrl: "http://127.0.0.1:20128/" }),
+    `http://127.0.0.1:20128${PROVIDER_PLUGIN_MANIFEST_PATH}`,
+  );
+  assert.equal(
+    resolveProviderPluginManifestUrl(),
+    `http://0.0.0.0:20129${PROVIDER_PLUGIN_MANIFEST_PATH}`,
+  );
+});
+
+test("provider plugin manifest client fetches and validates schemaVersion 1", async () => {
+  const manifest: ProviderPluginManifest = {
+    schemaVersion: 1,
+    generatedFrom: "open-sse/config/providers",
+    providers: [],
+  };
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  const fetchImpl: typeof fetch = async (url, init) => {
+    calls.push({ url: String(url), init });
+    return new Response(JSON.stringify(manifest), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+
+  const result = await fetchProviderPluginManifest({
+    manifestUrl: "http://sidecar.local/manifest",
+    fetchImpl,
+  });
+
+  assert.deepEqual(result, manifest);
+  assert.equal(calls[0]?.url, "http://sidecar.local/manifest");
+  assert.equal((calls[0]?.init?.headers as Record<string, string>).Accept, "application/json");
+});
+
+test("provider plugin manifest client rejects failed HTTP and malformed responses", async () => {
+  await assert.rejects(
+    fetchProviderPluginManifest({
+      manifestUrl: "http://sidecar.local/manifest",
+      fetchImpl: async () => new Response("nope", { status: 503 }),
+    }),
+    /HTTP 503/,
+  );
+
+  await assert.rejects(
+    fetchProviderPluginManifest({
+      manifestUrl: "http://sidecar.local/manifest",
+      fetchImpl: async () => new Response(JSON.stringify({ providers: [] }), { status: 200 }),
+    }),
+    /schemaVersion 1/,
+  );
+});
+
+test("provider plugin manifest client resolves model entries from fetched manifests", async () => {
+  const manifest: ProviderPluginManifest = {
+    schemaVersion: 1,
+    generatedFrom: "open-sse/config/providers",
+    providers: [
+      {
+        id: "anthropic",
+        alias: "claude",
+        format: "anthropic",
+        executor: "default",
+        auth: { type: "apikey", header: "x-api-key" },
+        endpoints: { baseUrl: "https://api.anthropic.com" },
+        capabilities: ["apikey", "sidecar-candidate"],
+        passthroughModels: false,
+        models: [{ id: "claude-sonnet-4.6", name: "Claude Sonnet 4.6" }],
+        sidecar: { eligible: true, reasons: [] },
+      },
+      {
+        id: "openai",
+        format: "openai",
+        executor: "default",
+        auth: { type: "apikey", header: "Authorization", prefix: "Bearer" },
+        endpoints: { baseUrl: "https://api.openai.com/v1" },
+        capabilities: ["apikey", "sidecar-candidate"],
+        passthroughModels: false,
+        models: [{ id: "gpt-4.1", name: "GPT-4.1" }],
+        sidecar: { eligible: true, reasons: [] },
+      },
+    ],
+  };
+  const fetchImpl: typeof fetch = async () =>
+    new Response(JSON.stringify(manifest), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+
+  assert.equal(
+    getProviderPluginManifestEntryForModelFromManifest(manifest, "openai/gpt-4.1")?.id,
+    "openai",
+  );
+  assert.equal(
+    getProviderPluginManifestEntryForModelFromManifest(manifest, "claude/claude-sonnet-4.6")?.id,
+    "anthropic",
+  );
+  assert.equal(
+    getProviderPluginManifestEntryForModelFromManifest(manifest, "gpt-4.1")?.id,
+    "openai",
+  );
+  assert.equal(
+    await fetchProviderPluginManifestEntryForModel("missing-model", {
+      manifestUrl: "http://sidecar.local/manifest",
+      fetchImpl,
+    }),
+    null,
+  );
+});

--- a/tests/unit/provider-plugin-manifest-client.test.ts
+++ b/tests/unit/provider-plugin-manifest-client.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   fetchProviderPluginManifest,
+  fetchProviderPluginManifestWithCache,
   fetchProviderPluginManifestEntryForModel,
   getProviderPluginManifestEntryForModelFromManifest,
   PROVIDER_PLUGIN_MANIFEST_ENV,
@@ -26,11 +27,11 @@ test("provider plugin manifest client resolves explicit and env URLs first", () 
 
   assert.equal(
     resolveProviderPluginManifestUrl({ manifestUrl: "http://explicit.example/manifest" }),
-    "http://explicit.example/manifest",
+    "http://explicit.example/manifest"
   );
   assert.equal(
     resolveProviderPluginManifestUrl({ baseUrl: "http://local.example:20128/" }),
-    "http://env.example/manifest",
+    "http://env.example/manifest"
   );
 });
 
@@ -41,11 +42,11 @@ test("provider plugin manifest client resolves base and default local URLs", () 
 
   assert.equal(
     resolveProviderPluginManifestUrl({ baseUrl: "http://127.0.0.1:20128/" }),
-    `http://127.0.0.1:20128${PROVIDER_PLUGIN_MANIFEST_PATH}`,
+    `http://127.0.0.1:20128${PROVIDER_PLUGIN_MANIFEST_PATH}`
   );
   assert.equal(
     resolveProviderPluginManifestUrl(),
-    `http://0.0.0.0:20129${PROVIDER_PLUGIN_MANIFEST_PATH}`,
+    `http://0.0.0.0:20129${PROVIDER_PLUGIN_MANIFEST_PATH}`
   );
 });
 
@@ -80,7 +81,7 @@ test("provider plugin manifest client rejects failed HTTP and malformed response
       manifestUrl: "http://sidecar.local/manifest",
       fetchImpl: async () => new Response("nope", { status: 503 }),
     }),
-    /HTTP 503/,
+    /HTTP 503/
   );
 
   await assert.rejects(
@@ -88,7 +89,34 @@ test("provider plugin manifest client rejects failed HTTP and malformed response
       manifestUrl: "http://sidecar.local/manifest",
       fetchImpl: async () => new Response(JSON.stringify({ providers: [] }), { status: 200 }),
     }),
-    /schemaVersion 1/,
+    /schemaVersion 1/
+  );
+});
+
+test("provider plugin manifest client reuses a cached manifest after a conditional 304", async () => {
+  const manifest: ProviderPluginManifest = {
+    schemaVersion: 1,
+    generatedFrom: "open-sse/config/providers",
+    providers: [],
+  };
+  let requestHeaders: HeadersInit | undefined;
+
+  const result = await fetchProviderPluginManifestWithCache({
+    cachedManifest: { etag: '"manifest-v1"', manifest },
+    fetchImpl: async (_url, init) => {
+      requestHeaders = init?.headers;
+      return new Response(null, { status: 304 });
+    },
+  });
+
+  assert.deepEqual(result, { etag: '"manifest-v1"', manifest, modified: false });
+  assert.equal((requestHeaders as Record<string, string>)["If-None-Match"], '"manifest-v1"');
+
+  await assert.rejects(
+    fetchProviderPluginManifestWithCache({
+      fetchImpl: async () => new Response(null, { status: 304 }),
+    }),
+    /304 without a cached manifest/
   );
 });
 
@@ -130,21 +158,21 @@ test("provider plugin manifest client resolves model entries from fetched manife
 
   assert.equal(
     getProviderPluginManifestEntryForModelFromManifest(manifest, "openai/gpt-4.1")?.id,
-    "openai",
+    "openai"
   );
   assert.equal(
     getProviderPluginManifestEntryForModelFromManifest(manifest, "claude/claude-sonnet-4.6")?.id,
-    "anthropic",
+    "anthropic"
   );
   assert.equal(
     getProviderPluginManifestEntryForModelFromManifest(manifest, "gpt-4.1")?.id,
-    "openai",
+    "openai"
   );
   assert.equal(
     await fetchProviderPluginManifestEntryForModel("missing-model", {
       manifestUrl: "http://sidecar.local/manifest",
       fetchImpl,
     }),
-    null,
+    null
   );
 });

--- a/tests/unit/provider-plugin-manifest-url.test.ts
+++ b/tests/unit/provider-plugin-manifest-url.test.ts
@@ -2,38 +2,47 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  PROVIDER_PLUGIN_MANIFEST_ENV,
   PROVIDER_PLUGIN_MANIFEST_HEADER,
   resolveProviderPluginManifestUrl,
   getProviderPluginManifestHeader,
 } from "../../open-sse/config/providerPluginManifestUrl.ts";
+import { resolveProviderPluginManifestUrl as resolveManifestClientUrl } from "../../open-sse/config/providerPluginManifestClient.ts";
 
 test("provider manifest URL uses explicit env override", () => {
-  const previous = process.env.OMNIROUTE_PROVIDER_MANIFEST_URL;
-  process.env.OMNIROUTE_PROVIDER_MANIFEST_URL = "http://sidecar.local/manifest.json";
+  const previous = process.env[PROVIDER_PLUGIN_MANIFEST_ENV];
+  process.env[PROVIDER_PLUGIN_MANIFEST_ENV] = "http://sidecar.local/manifest.json";
   try {
     assert.equal(
       resolveProviderPluginManifestUrl("http://127.0.0.1:20128"),
-      "http://sidecar.local/manifest.json",
+      "http://sidecar.local/manifest.json"
     );
   } finally {
     if (previous === undefined) {
-      delete process.env.OMNIROUTE_PROVIDER_MANIFEST_URL;
+      delete process.env[PROVIDER_PLUGIN_MANIFEST_ENV];
     } else {
-      process.env.OMNIROUTE_PROVIDER_MANIFEST_URL = previous;
+      process.env[PROVIDER_PLUGIN_MANIFEST_ENV] = previous;
     }
   }
+});
+
+test("provider manifest producer and client resolve the same base URL", () => {
+  const origin = "http://127.0.0.1:20128/";
+  assert.equal(
+    resolveManifestClientUrl({ baseUrl: origin }),
+    resolveProviderPluginManifestUrl(origin)
+  );
 });
 
 test("provider manifest URL derives from request origin", () => {
   assert.equal(
     resolveProviderPluginManifestUrl("http://127.0.0.1:20128/"),
-    "http://127.0.0.1:20128/api/v1/provider-plugin-manifest",
+    "http://127.0.0.1:20128/api/v1/provider-plugin-manifest"
   );
 });
 
 test("provider manifest header exposes stable header name", () => {
   assert.deepEqual(getProviderPluginManifestHeader("http://localhost:20128"), {
-    [PROVIDER_PLUGIN_MANIFEST_HEADER]:
-      "http://localhost:20128/api/v1/provider-plugin-manifest",
+    [PROVIDER_PLUGIN_MANIFEST_HEADER]: "http://localhost:20128/api/v1/provider-plugin-manifest",
   });
 });


### PR DESCRIPTION
Adds a typed HTTP client for the existing provider plugin manifest endpoint. The client resolves explicit, environment, base, and local default URLs; validates schemaVersion 1; and resolves entries for provider-prefixed and bare model IDs. This is additive: Bifrost, CLIProxyAPI, and future sidecars can consume provider metadata without importing OmniRoute executor code. Validated with the focused unit test and strict fabricated-docs check.