### PR TITLE
[codex] Keep mode-pack weights consistent in auto fallback ranking

### DIFF
--- a/open-sse/services/combo/autoConfig.ts
+++ b/open-sse/services/combo/autoConfig.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_WEIGHTS, type ScoringWeights } from "../autoCombo/scoring.ts";
+import { getModePack } from "../autoCombo/modePacks.ts";
 import { isRecord } from "./comboData.ts";
 import { resolveResetWindowConfig, resolveSlaRoutingPolicy } from "./quotaScoring.ts";
 import type { ComboLike, ResolvedComboTarget } from "./types.ts";
@@ -34,7 +35,7 @@ export function parseAutoConfig(combo: ComboLike, eligibleTargets: ResolvedCombo
     ? autoConfigSource.candidatePool
     : [...new Set(eligibleTargets.map((target) => target.provider))];
 
-  const weights =
+  const configuredWeights =
     autoConfigSource.weights && typeof autoConfigSource.weights === "object"
       ? (autoConfigSource.weights as ScoringWeights)
       : DEFAULT_WEIGHTS;
@@ -46,6 +47,7 @@ export function parseAutoConfig(combo: ComboLike, eligibleTargets: ResolvedCombo
     : undefined;
   const modePack =
     typeof autoConfigSource.modePack === "string" ? autoConfigSource.modePack : undefined;
+  const weights = modePack ? getModePack(modePack) || configuredWeights : configuredWeights;
   const resetWindowConfig = resolveResetWindowConfig(autoConfigSource);
   const slaPolicy = resolveSlaRoutingPolicy(autoConfigSource);
 

--- a/tests/unit/combo-auto-config-split.test.ts
+++ b/tests/unit/combo-auto-config-split.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 
 import { parseAutoConfig } from "@omniroute/open-sse/services/combo/autoConfig.ts";
 import { DEFAULT_WEIGHTS } from "@omniroute/open-sse/services/autoCombo/scoring.ts";
+import { MODE_PACKS } from "@omniroute/open-sse/services/autoCombo/modePacks.ts";
 
 // Split guard for Block J Task 2: parseAutoConfig was extracted verbatim from
 // handleComboChat's inline auto-strategy config block. These assertions pin the
@@ -60,6 +61,22 @@ test("explicit candidatePool, weights, exploration and budget are honored", () =
   assert.equal(cfg.explorationRate, 0.3);
   assert.equal(cfg.budgetCap, 5);
   assert.equal(cfg.modePack, "coding");
+});
+
+test("valid modePack overrides configured weights for fallback scoring", () => {
+  const cfg = parseAutoConfig(
+    {
+      name: "c",
+      autoConfig: {
+        weights: { ...DEFAULT_WEIGHTS, latencyInv: 0 },
+        modePack: "ship-fast",
+      },
+    } as never,
+    []
+  );
+
+  assert.equal(cfg.modePack, "ship-fast");
+  assert.equal(cfg.weights, MODE_PACKS["ship-fast"]);
 });
 
 test("config.auto is preferred over top-level config", () => {


### PR DESCRIPTION
## Summary
- resolve valid auto-combo `modePack` values in the shared config parser
- use the same effective weights for initial provider selection and scored fallback ordering
- add focused precedence coverage for `ship-fast`

## Why
`selectAutoProvider()` already applies `modePack`, while `scoreAutoTargets()` previously received raw/default weights. This could select a fast provider then rank fallbacks with a different policy.

## Validation
- `node --import tsx/esm --test tests/unit/combo-auto-config-split.test.ts`
- `npx --yes --package prettier prettier --check open-sse/services/combo/autoConfig.ts tests/unit/combo-auto-config-split.test.ts`
- commit hooks: explicit-any budget and tracked-artifact checks