### PR TITLE
feat(providers): add Agnes AI native provider support

### DIFF
--- a/open-sse/config/providers/index.ts
+++ b/open-sse/config/providers/index.ts
@@ -116,6 +116,7 @@ import { gitlawbProvider } from "./registry/gitlawb/index.ts";
 import { liquidProvider } from "./registry/liquid/index.ts";
 import { deepinfraProvider } from "./registry/deepinfra/index.ts";
 import { agyProvider } from "./registry/agy/index.ts";
+import { agnesProvider } from "./registry/agnes/index.ts";
 import { udioProvider } from "./registry/udio/index.ts";
 import { longcatProvider } from "./registry/longcat/index.ts";
 import { vertex_partnerProvider } from "./registry/vertex/partner/index.ts";
@@ -302,6 +303,7 @@ export const REGISTRY: Record<string, RegistryEntry> = {
   liquid: liquidProvider,
   deepinfra: deepinfraProvider,
   agy: agyProvider,
+  agnes: agnesProvider,
   udio: udioProvider,
   longcat: longcatProvider,
   "vertex-partner": vertex_partnerProvider,

--- a/open-sse/config/providers/registry/agnes/index.ts
+++ b/open-sse/config/providers/registry/agnes/index.ts
@@ -1,0 +1,26 @@
+import type { RegistryEntry } from "../../shared.ts";
+import { buildOpenAiCompatibleRegistryEntry } from "../../shared.ts";
+
+export const agnesProvider: RegistryEntry = buildOpenAiCompatibleRegistryEntry({
+  id: "agnes",
+  baseUrl: "https://apihub.agnes-ai.com/v1/chat/completions",
+  models: [
+    {
+      id: "agnes-2.0-flash",
+      name: "Agnes 2.0 Flash",
+      contextLength: 524288,
+      maxOutputTokens: 65536,
+      supportsReasoning: true,
+      supportsVision: true,
+      toolCalling: true,
+      interleavedField: "reasoning_content",
+    },
+    {
+      id: "agnes-1.5-flash",
+      name: "Agnes 1.5 Flash",
+      contextLength: 262144,
+      maxOutputTokens: 65536,
+      supportsVision: true,
+    },
+  ],
+});

--- a/src/shared/constants/providers/apikey/regional.ts
+++ b/src/shared/constants/providers/apikey/regional.ts
@@ -369,4 +369,16 @@ export const APIKEY_PROVIDERS_REGIONAL = {
     passthroughModels: true,
     authHint: "Get API key at api.hcnsec.cn",
   },
+  agnes: {
+    id: "agnes",
+    alias: "agnes",
+    name: "Agnes AI",
+    icon: "auto_awesome",
+    color: "#10B981",
+    textIcon: "AG",
+    website: "https://agnes-ai.com",
+    hasFree: true,
+    freeNote: "Permanently free API - no credit card required.",
+    authHint: "Get API key at agnes-ai.com",
+  },
 };

--- a/tests/unit/agnes-provider.test.ts
+++ b/tests/unit/agnes-provider.test.ts
@@ -1,0 +1,70 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { APIKEY_PROVIDERS } = await import("../../src/shared/constants/providers.ts");
+const { REGISTRY: providerRegistry } = await import("../../open-sse/config/providerRegistry.ts");
+
+const AGNES_CHAT_URL = "https://apihub.agnes-ai.com/v1/chat/completions";
+
+test("agnes is registered as an API-key provider with complete metadata", () => {
+  const entry = APIKEY_PROVIDERS.agnes;
+  assert.ok(entry, "APIKEY_PROVIDERS.agnes must be defined");
+  assert.equal(entry.id, "agnes");
+  assert.equal(entry.alias, "agnes");
+  assert.equal(entry.name, "Agnes AI");
+  assert.equal(entry.icon, "auto_awesome");
+  assert.equal(entry.color, "#10B981");
+  assert.equal(entry.textIcon, "AG");
+  assert.equal(entry.website, "https://agnes-ai.com");
+  assert.equal(entry.hasFree, true);
+  assert.ok(entry.freeNote, "freeNote must be defined");
+  assert.ok(entry.authHint, "authHint must be defined");
+});
+
+test("agnes registry entry uses OpenAI format with bearer API-key auth", () => {
+  const entry = providerRegistry.agnes;
+  assert.ok(entry, "providerRegistry.agnes must be defined");
+  assert.equal(entry.id, "agnes");
+  assert.equal(entry.format, "openai");
+  assert.equal(entry.executor, "default");
+  assert.equal(entry.authType, "apikey");
+  assert.equal(entry.authHeader, "bearer");
+  assert.equal(entry.baseUrl, AGNES_CHAT_URL);
+});
+
+test("agnes ships two models with correct capabilities", () => {
+  const entry = providerRegistry.agnes;
+  assert.equal(entry.models.length, 2, "must have 2 models");
+
+  const flash2 = entry.models.find((m) => m.id === "agnes-2.0-flash");
+  assert.ok(flash2, "agnes-2.0-flash must be defined");
+  assert.equal(flash2.contextLength, 524288);
+  assert.equal(flash2.maxOutputTokens, 65536);
+  assert.equal(flash2.supportsReasoning, true);
+  assert.equal(flash2.supportsVision, true);
+  assert.equal(flash2.toolCalling, true);
+  assert.equal(flash2.interleavedField, "reasoning_content");
+
+  const flash15 = entry.models.find((m) => m.id === "agnes-1.5-flash");
+  assert.ok(flash15, "agnes-1.5-flash must be defined");
+  assert.equal(flash15.contextLength, 262144);
+  assert.equal(flash15.maxOutputTokens, 65536);
+  assert.equal(flash15.supportsVision, true);
+  assert.equal(flash15.supportsReasoning, undefined, "1.5-flash has no thinking mode");
+  assert.equal(flash15.toolCalling, undefined, "1.5-flash has no documented tool calling");
+});
+
+test("agnes has no collision with zenmux-free sapiens-ai prefixed models", (t) => {
+  const zenmux = providerRegistry["zenmux-free"];
+  if (!zenmux) {
+    t.skip("zenmux-free not registered in this environment");
+    return;
+  }
+  const agnesInZenmux = zenmux.models.filter((m) => m.id.includes("agnes"));
+  for (const m of agnesInZenmux) {
+    assert.ok(
+      m.id.startsWith("sapiens-ai/"),
+      `zenmux agnes model ${m.id} must use sapiens-ai/ prefix to avoid collision`
+    );
+  }
+});


### PR DESCRIPTION
## Summary

Add built-in provider registry entry for Agnes AI (agnes-ai.com), a permanently free OpenAI-compatible API by Sapiens AI.

### Models

| Model | Context | Output | Thinking | Vision | Tools |
|-------|---------|--------|----------|--------|-------|
| agnes-2.0-flash | 256K | 64K | reasoning_content | image_url | tools |
| agnes-1.5-flash | 256K | 64K | -- | image_url | -- |

### Why include this provider?

- Permanently free (announced 2026-06-01, no credit card required)
- OpenAI-compatible standard /v1/chat/completions endpoint
- 20 RPM free tier, useful as zero-cost fallback in combo routing
- agnes-2.0-flash supports thinking mode with reasoning_content response format (DeepSeek-compatible), registered with interleavedField for proper reasoning replay

### Specs source

Verified against MODEL_CATALOG.md v2026.06.28 (github.com/AgnesAI-Labs/AgnesAI-Models/blob/main/MODEL_CATALOG.md) and live API testing at apihub.agnes-ai.com/v1 (2026-07-13).

### Testing

Verified agnes-2.0-flash thinking mode returns reasoning_content with empty content at default max_tokens. Setting supportsReasoning: true enables the reasoning token buffer for proper content promotion.

Fixes #5580