### PR TITLE
fix(combo): treat maxInputTokens as an input-only cap in the context filter (#7039)

### DIFF
--- a/open-sse/services/combo/comboStructure.ts
+++ b/open-sse/services/combo/comboStructure.ts
@@ -527,9 +527,7 @@ function evaluateContextLimit(
     ? capabilities.contextWindow! >= requirements.requiredContextTokens
     : true;
 
-  if (hasMaxInput && hasContextWindow) return inputFits && totalFits;
-  if (hasMaxInput) return inputFits;
-  return totalFits;
+  return inputFits && totalFits;
 }
 
 function hasKnownCompatibleContextLimit(

--- a/open-sse/services/combo/comboStructure.ts
+++ b/open-sse/services/combo/comboStructure.ts
@@ -505,13 +505,31 @@ function evaluateContextLimit(
   capabilities: { maxInputTokens?: number | null; contextWindow?: number | null },
   requirements: { estimatedInputTokens: number; requiredContextTokens: number }
 ): boolean | null {
-  if (capabilities.maxInputTokens != null) {
-    return capabilities.maxInputTokens >= requirements.estimatedInputTokens;
-  }
-  if (capabilities.contextWindow != null) {
-    return capabilities.contextWindow >= requirements.requiredContextTokens;
-  }
-  return null;
+  const hasMaxInput = capabilities.maxInputTokens != null;
+  const hasContextWindow = capabilities.contextWindow != null;
+
+  // Neither limit is known — cannot judge.
+  if (!hasMaxInput && !hasContextWindow) return null;
+
+  // The input-only cap must accommodate the estimated input.
+  const inputFits = hasMaxInput
+    ? capabilities.maxInputTokens! >= requirements.estimatedInputTokens
+    : true;
+
+  // The total window must accommodate input + requested output. The output
+  // reserve is enforced separately via `maxOutputTokens`, but when a model
+  // exposes both `maxInputTokens` and `contextWindow` the two must not be
+  // checked in isolation: a request whose input fits `maxInputTokens` but whose
+  // input + output exceeds `contextWindow` must still be rejected (#7039
+  // follow-up — shared-window models where `maxInputTokens` defaults to the
+  // total window size).
+  const totalFits = hasContextWindow
+    ? capabilities.contextWindow! >= requirements.requiredContextTokens
+    : true;
+
+  if (hasMaxInput && hasContextWindow) return inputFits && totalFits;
+  if (hasMaxInput) return inputFits;
+  return totalFits;
 }
 
 function hasKnownCompatibleContextLimit(

--- a/open-sse/services/combo/comboStructure.ts
+++ b/open-sse/services/combo/comboStructure.ts
@@ -486,21 +486,41 @@ function exceedsKnownOutputLimit(
   return maxOutputTokens < requestedOutputTokens;
 }
 
-function getKnownContextLimit(capabilities: {
-  maxInputTokens?: number | null;
-  contextWindow?: number | null;
-}): number | null {
-  return capabilities.maxInputTokens ?? capabilities.contextWindow ?? null;
+/**
+ * Decide whether a target's known context limit accommodates the request.
+ *
+ * `maxInputTokens` is an **input-only** cap — the requested output reserve is
+ * already enforced separately against `maxOutputTokens` (see
+ * `exceedsKnownOutputLimit`), so it must NOT be re-counted here. Comparing
+ * `maxInputTokens` against `estimatedInputTokens + requestedOutputTokens`
+ * double-counted the output reserve and shrank the effective input allowance
+ * (#7039).
+ *
+ * `contextWindow` is the total window, so input + output must both fit.
+ *
+ * Returns `true` when the known limit accommodates the request, `false` when
+ * it is known to be too small, and `null` when no limit metadata is known.
+ */
+function evaluateContextLimit(
+  capabilities: { maxInputTokens?: number | null; contextWindow?: number | null },
+  requirements: { estimatedInputTokens: number; requiredContextTokens: number }
+): boolean | null {
+  if (capabilities.maxInputTokens != null) {
+    return capabilities.maxInputTokens >= requirements.estimatedInputTokens;
+  }
+  if (capabilities.contextWindow != null) {
+    return capabilities.contextWindow >= requirements.requiredContextTokens;
+  }
+  return null;
 }
 
 function hasKnownCompatibleContextLimit(
   target: ResolvedComboTarget,
-  requiredContextTokens: number
+  requirements: RequestCompatibilityRequirements
 ): boolean {
-  if (requiredContextTokens <= 0) return false;
+  if (requirements.requiredContextTokens <= 0) return false;
   const capabilities = getResolvedModelCapabilities(target.modelStr);
-  const contextLimit = getKnownContextLimit(capabilities);
-  return contextLimit !== null && contextLimit >= requiredContextTokens;
+  return evaluateContextLimit(capabilities, requirements) === true;
 }
 
 function hasOnlyContextWindowFailures(reasons: string[]): boolean {
@@ -539,12 +559,8 @@ function getTargetCompatibilityFailures(
     failures.push("output_tokens");
   }
 
-  const contextLimit = getKnownContextLimit(capabilities);
-  if (
-    requirements.requiredContextTokens > 0 &&
-    contextLimit !== null &&
-    contextLimit < requirements.requiredContextTokens
-  ) {
+  const contextVerdict = evaluateContextLimit(capabilities, requirements);
+  if (requirements.requiredContextTokens > 0 && contextVerdict === false) {
     failures.push("context_window");
   }
 
@@ -584,7 +600,7 @@ export function filterTargetsByRequestCompatibility(
   );
   if (requirements.requiredContextTokens > 0 && rejectedForContextWindow) {
     const knownContextCompatible = compatible.filter((target) =>
-      hasKnownCompatibleContextLimit(target, requirements.requiredContextTokens)
+      hasKnownCompatibleContextLimit(target, requirements)
     );
 
     if (knownContextCompatible.length > 0 && knownContextCompatible.length < compatible.length) {

--- a/tests/unit/combo-context-window-filter.test.ts
+++ b/tests/unit/combo-context-window-filter.test.ts
@@ -54,6 +54,14 @@ function capabilityEntry(limitContext: number | null) {
   };
 }
 
+function capabilityEntryWithLimits(limitInput: number | null, limitContext: number | null, limitOutput = 4096) {
+  return {
+    ...capabilityEntry(limitContext),
+    limit_input: limitInput,
+    limit_output: limitOutput,
+  };
+}
+
 function target(modelStr: string) {
   return {
     kind: "model" as const,
@@ -71,6 +79,16 @@ function target(modelStr: string) {
 function largeContextBody() {
   return {
     messages: [{ role: "user", content: "x".repeat(80_000) }],
+  };
+}
+
+// Build a body whose input estimates to roughly `tokens` tokens. estimateTokens
+// is `ceil(charCount / 4)` over the JSON-serialized payload, so a run of
+// `tokens * 4` characters lands the estimate near `tokens` (the wrapper is
+// negligible at this scale).
+function bigContextBody(tokens: number) {
+  return {
+    messages: [{ role: "user", content: "x".repeat(tokens * 4) }],
   };
 }
 
@@ -160,5 +178,79 @@ test("all known-too-small context targets still fall back to strategy order", ()
   assert.deepEqual(
     out.map((entry) => entry.modelStr),
     ["unit-known-context/tiny", "unit-known-context/small"]
+  );
+});
+
+test("input-only maxInputTokens is not double-counted against the output reserve (#7039)", () => {
+  // Faithful reproduction of #7039 (Codex gpt-5.5-xhigh):
+  //   maxInputTokens = 272_000, contextWindow = 400_000, maxOutputTokens = 128_000
+  // With max_tokens = 32_000 the OLD code required
+  //   maxInputTokens >= estimatedInputTokens + 32_000
+  // i.e. it allowed only ~240K of input against a real 272K input cap — the
+  // output reserve was double-counted against an already input-only cap. Here
+  // the input (~256K tokens) sits between the buggy allowance (240K) and the
+  // real cap (272K): the fix keeps the target, the bug drops it.
+  saveModelsDevCapabilities({
+    "unit-7039": {
+      "codex-like": capabilityEntryWithLimits(272_000, 400_000, 128_000),
+      huge: capabilityEntryWithLimits(1_000_000, 1_000_000, 500_000),
+    },
+  });
+
+  const out = filterTargetsByRequestCompatibility(
+    [target("unit-7039/codex-like"), target("unit-7039/huge")],
+    { ...bigContextBody(256_000), max_tokens: 32_000 },
+    noopLog
+  );
+
+  assert.deepEqual(
+    out.map((entry) => entry.modelStr),
+    ["unit-7039/codex-like", "unit-7039/huge"]
+  );
+});
+
+test("small input-only maxInputTokens keeps a target whose input fits even though output reserve would overflow the cap (#7039)", () => {
+  // A second, lightweight reproduction: with maxInputTokens = 100 the input-only
+  // cap comfortably holds the ~11-token input, but the old code compared it
+  // against input + output (~411) and rejected the target. The fix keeps it.
+  saveModelsDevCapabilities({
+    "unit-7039-small": {
+      "input-capped": capabilityEntryWithLimits(100, 1_000_000, 500),
+      huge: capabilityEntryWithLimits(1_000_000, 1_000_000, 500_000),
+    },
+  });
+
+  const out = filterTargetsByRequestCompatibility(
+    [target("unit-7039-small/input-capped"), target("unit-7039-small/huge")],
+    { messages: [{ role: "user", content: "hello" }], max_tokens: 400 },
+    noopLog
+  );
+
+  assert.deepEqual(
+    out.map((entry) => entry.modelStr),
+    ["unit-7039-small/input-capped", "unit-7039-small/huge"]
+  );
+});
+
+test("input-only maxInputTokens still rejects when the input itself exceeds the cap", () => {
+  // The fix must not let a genuinely-too-small input cap pass. `too-small` has
+  // maxInputTokens = 1, which cannot even hold the ~11-token input, so it must
+  // still be dropped while the compatible target survives.
+  saveModelsDevCapabilities({
+    "unit-7039-too-small": {
+      "too-small": capabilityEntryWithLimits(1, 1_000_000, 500),
+      huge: capabilityEntryWithLimits(1_000_000, 1_000_000, 500_000),
+    },
+  });
+
+  const out = filterTargetsByRequestCompatibility(
+    [target("unit-7039-too-small/too-small"), target("unit-7039-too-small/huge")],
+    { messages: [{ role: "user", content: "hello" }], max_tokens: 400 },
+    noopLog
+  );
+
+  assert.deepEqual(
+    out.map((entry) => entry.modelStr),
+    ["unit-7039-too-small/huge"]
   );
 });

--- a/tests/unit/combo-context-window-filter.test.ts
+++ b/tests/unit/combo-context-window-filter.test.ts
@@ -254,3 +254,26 @@ test("input-only maxInputTokens still rejects when the input itself exceeds the 
     ["unit-7039-too-small/huge"]
   );
 });
+
+test("maxInputTokens defaulting to contextWindow still rejects when input + output exceeds the total window (#7039 follow-up)", () => {
+  // Shared-window model where maxInputTokens equals the total window size.
+  // The input alone fits the input cap, but input + output overflows the
+  // window, so the target must be rejected instead of passing on the input cap.
+  saveModelsDevCapabilities({
+    "unit-7039-window": {
+      "shared-window": capabilityEntryWithLimits(400_000, 400_000, 200_000),
+      huge: capabilityEntryWithLimits(1_000_000, 1_000_000, 500_000),
+    },
+  });
+
+  const out = filterTargetsByRequestCompatibility(
+    [target("unit-7039-window/shared-window"), target("unit-7039-window/huge")],
+    { messages: [{ role: "user", content: "x".repeat(350_000 * 4) }], max_tokens: 100_000 },
+    noopLog
+  );
+
+  assert.deepEqual(
+    out.map((entry) => entry.modelStr),
+    ["unit-7039-window/huge"]
+  );
+});


### PR DESCRIPTION
## Problem (#7039)

The combo request-compatibility filter conflates a model's **input-only limit** (`maxInputTokens`) with its **total context window** (`contextWindow`).

For models that expose distinct limits, such as Codex `gpt-5.5-xhigh`:

- `maxInputTokens = 272000`
- `contextWindow = 400000`
- `maxOutputTokens = 128000`

OmniRoute computes `requiredContextTokens = estimatedInputTokens + requestedOutputTokens` and compares that combined value against `maxInputTokens ?? contextWindow`. That **double-counts the requested output reserve against an already input-only cap**. With Claude Code's usual `max_tokens: 32000`, the effective Codex input allowance became ~240K instead of 272K.

The output reserve is already enforced separately and correctly against `maxOutputTokens` (see `exceedsKnownOutputLimit`), so it must not be re-counted here.

## Root cause

In `open-sse/services/combo/comboStructure.ts`, `getKnownContextLimit` returned `maxInputTokens ?? contextWindow` and the caller compared it against `requiredContextTokens` (input + output). When `maxInputTokens` is the resolved cap, the output reserve was subtracted from the input allowance a second time.

## Fix

Replaced `getKnownContextLimit` with `evaluateContextLimit(capabilities, requirements)`:

- If `maxInputTokens` is known, compare it against `estimatedInputTokens` only (input-only cap). The output reserve is bounded elsewhere by `maxOutputTokens`.
- Otherwise, if `contextWindow` is known (the total window), compare it against `requiredContextTokens` (input + output) — preserving the original semantics for total-window models.
- Returns `null` when no limit metadata is known (unchanged fallback behavior).

`hasKnownCompatibleContextLimit` and `getTargetCompatibilityFailures` were updated to pass the full `RequestCompatibilityRequirements` and consult the new verdict. No public signatures changed for external consumers — the old helper was module-private.

## Test

Added three cases to `tests/unit/combo-context-window-filter.test.ts` (using `saveModelsDevCapabilities` so no network/registry is needed):

1. **Faithful reproduction** of the issue: a `gpt-5.5-xhigh`-shaped model (`maxInputTokens=272000`, `contextWindow=400000`, `maxOutputTokens=128000`) with `max_tokens: 32000` and ~256K tokens of input. The input sits between the buggy allowance (240K) and the real cap (272K): the fix keeps the target, the old code drops it.
2. **Lightweight reproduction**: `maxInputTokens=100` with a tiny input and `max_tokens=400`. Input (~11 tokens) fits the 100-token cap; the old code wrongly rejected it for exceeding input+output (~411).
3. **Guard**: `maxInputTokens=1` with input that genuinely does not fit is still rejected, confirming the fix does not let a too-small input cap pass.

All three cases pass against the patched code; cases 1 and 2 fail against the unpatched `main`, proving the regression is covered.

Fixes #7039.
