### PR TITLE
fix(antigravity): collect native part.functionCall into tool calls (#7037)

### DIFF
--- a/open-sse/executors/antigravity/sseCollect.ts
+++ b/open-sse/executors/antigravity/sseCollect.ts
@@ -108,7 +108,11 @@ export function processAntigravitySSEPayload(
         }
       }
     }
-    if (candidate?.finishReason) {
+    // Preserve a tool-call finish reason: once a native `part.functionCall`
+    // (or textual tool call) has populated `toolCalls`, the candidate's own
+    // finish reason (often STOP) must not clobber it (#7037 — a tool-only
+    // response would otherwise report STOP and lose its tool-call signal).
+    if (candidate?.finishReason && collected.toolCalls.length === 0) {
       collected.finishReason = normalizeOpenAICompatibleFinishReasonString(
         String(candidate.finishReason).toLowerCase()
       );

--- a/open-sse/executors/antigravity/sseCollect.ts
+++ b/open-sse/executors/antigravity/sseCollect.ts
@@ -96,6 +96,16 @@ export function processAntigravitySSEPayload(
             collected.textContent += part.text;
           }
         }
+        // Native Gemini function calls. Non-streaming responses (and some
+        // streaming ones) carry the tool call as `part.functionCall` rather than
+        // the textual `[Tool call: ...]` markdown. Without this, a tool-only
+        // response produced empty content and a 502 Provider error (#7037).
+        if (part.functionCall && typeof part.functionCall.name === "string") {
+          addAntigravityTextualToolCall(collected, {
+            name: part.functionCall.name,
+            args: part.functionCall.args ?? {},
+          });
+        }
       }
     }
     if (candidate?.finishReason) {

--- a/tests/unit/executor-agy.test.ts
+++ b/tests/unit/executor-agy.test.ts
@@ -75,3 +75,88 @@ test("processAntigravitySSEPayload ignores [DONE] and malformed payloads without
   processAntigravitySSEPayload("{not json", collected);
   assert.equal(collected.textContent, "");
 });
+
+// #7037 — non-streaming (and tool-only) responses carry the tool call as a native
+// `part.functionCall` with no `part.text`. It must produce a tool call instead of
+// empty content (which previously surfaced as a 502 "Provider returned empty content").
+test("processAntigravitySSEPayload converts native part.functionCall into a tool call (#7037)", () => {
+  const collected = emptyCollected();
+  processAntigravitySSEPayload(
+    JSON.stringify({
+      response: {
+        candidates: [
+          {
+            content: {
+              parts: [{ functionCall: { name: "get_weather", args: { city: "Paris" } } }],
+            },
+            finishReason: "STOP",
+          },
+        ],
+        usageMetadata: { promptTokenCount: 12, candidatesTokenCount: 932, totalTokenCount: 944 },
+      },
+    }),
+    collected
+  );
+
+  assert.equal(collected.textContent, "");
+  assert.equal(collected.toolCalls.length, 1);
+  assert.equal(collected.toolCalls[0].type, "function");
+  assert.equal(collected.toolCalls[0].function.name, "get_weather");
+  assert.deepEqual(JSON.parse(collected.toolCalls[0].function.arguments), { city: "Paris" });
+  assert.equal(collected.finishReason, "tool_calls");
+  assert.ok(collected.usage !== null, "usage metadata should still be collected");
+});
+
+test("processAntigravitySSEPayload handles a mixed text + functionCall response (#7037)", () => {
+  const collected = emptyCollected();
+  processAntigravitySSEPayload(
+    JSON.stringify({
+      response: {
+        candidates: [
+          {
+            content: {
+              parts: [
+                { text: "Let me check." },
+                { functionCall: { name: "get_weather", args: { city: "Paris" } } },
+              ],
+            },
+          },
+        ],
+      },
+    }),
+    collected
+  );
+
+  assert.equal(collected.textContent, "Let me check.");
+  assert.equal(collected.toolCalls.length, 1);
+  assert.equal(collected.toolCalls[0].function.name, "get_weather");
+});
+
+// #7037 — before the fix, a function-call-only payload yielded no text and no
+// tool call, so the non-streaming path returned empty content. Guard that the
+// textual-tool-call path is unaffected.
+test("processAntigravitySSEPayload still parses textual [Tool call:] when present", () => {
+  const collected = emptyCollected();
+  processAntigravitySSEPayload(
+    JSON.stringify({
+      response: {
+        candidates: [
+          {
+            content: {
+              parts: [
+                {
+                  text: "[Tool call: get_weather]\nArguments: {\"city\":\"Paris\"}",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    }),
+    collected
+  );
+
+  assert.equal(collected.toolCalls.length, 1);
+  assert.equal(collected.toolCalls[0].function.name, "get_weather");
+  assert.deepEqual(JSON.parse(collected.toolCalls[0].function.arguments), { city: "Paris" });
+});


### PR DESCRIPTION
## Problem (#7037)

Non-streaming Anthropic `/v1/messages` requests against Antigravity Gemini models return `502 Provider returned empty content` whenever the upstream response consists **only** of a native Gemini `part.functionCall` (no `part.text`). The identical body with `stream: true` succeeds and returns a valid `tool_use` block.

On single-credential setups the corrupted empty response is recorded as a per-model failure and cascades into `429 model_cooldown`.

## Root cause

In `open-sse/executors/antigravity/sseCollect.ts`, `processAntigravitySSEPayload` accumulates only `part.text` parts (and the textual `[Tool call: ...]` markdown shape via `parseAntigravityTextualToolCall`). A native `part.functionCall` was never collected, so a tool-only response left both `collected.textContent` and `collected.toolCalls` empty. Downstream assembly (`antigravity.ts`) then produced `{ role: "assistant", content: "" }`, which the gateway rejects as empty content.

Streaming worked because Antigravity emits the tool call as textual `[Tool call: ...]` markdown in that path; non-streaming emits a structured `part.functionCall`, which the collector silently dropped.

## Fix

In the parts loop, also handle `part.functionCall`: when present with a string `name`, feed it through the existing `addAntigravityTextualToolCall` helper (the same one the textual path uses), so it produces the identical OpenAI `tool_calls` element (`id`/`index`/`type:"function"`/`function:{name,arguments}`). `finishReason` is set to `tool_calls`, matching the textual path. This makes the non-streaming path emit `tool_calls` exactly like the streaming path, and the existing OpenAI→Anthropic `tool_use` translation (already proven by streaming) carries it through.

Text/usage/`remainingCredits` handling is unchanged. The textual-tool-call path is untouched.

## Test

Added three cases to `tests/unit/executor-agy.test.ts` (pure, no network):

1. **#7037 reproduction** — `part.functionCall` only → `toolCalls` populated with the right `name`/parsed `arguments`, `textContent` empty, `finishReason = tool_calls`, usage still collected. (Fails on unpatched `main`.)
2. **Mixed** — `part.text` + `part.functionCall` → both the text and the tool call are collected.
3. **Guard** — textual `[Tool call: ...]` still parses into a tool call (no regression to the existing path).

All three pass against the patched code; case 1 fails against `main`, proving the regression is covered.

Fixes #7037.
