### PR TITLE
fix(usage): register ollama-cloud in USAGE_FETCHER_PROVIDERS (#7026)

### DIFF
--- a/open-sse/services/usage.ts
+++ b/open-sse/services/usage.ts
@@ -533,6 +533,7 @@ export const USAGE_FETCHER_PROVIDERS = [
   "deepseek",
   "opencode",
   "opencode-zen",
+  "ollama-cloud",
   "xiaomi-mimo",
   "xai",
   "vertex",

--- a/tests/unit/usage-families-split.test.ts
+++ b/tests/unit/usage-families-split.test.ts
@@ -60,3 +60,15 @@ test("host dispatcher + USAGE_FETCHER_PROVIDERS still cover the moved families",
     assert.ok(providers.includes(p), `${p} must remain a usage-fetcher provider`);
   }
 });
+
+// #7026 — `ollama-cloud` has a `case` in the dispatcher (getOllamaCloudUsage) but
+// was missing from the USAGE_FETCHER_PROVIDERS registration list, so the generic
+// quota fetcher never attempted to fetch its usage. The list must stay in sync
+// with the switch.
+test("host USAGE_FETCHER_PROVIDERS registers ollama-cloud (#7026)", () => {
+  const providers = (HOST as Record<string, unknown>).USAGE_FETCHER_PROVIDERS as readonly string[];
+  assert.ok(
+    providers.includes("ollama-cloud"),
+    "ollama-cloud has a usage dispatcher case but was missing from the registration list"
+  );
+});


### PR DESCRIPTION
## Problem (#7026)

`ollama-cloud` has a usage dispatcher case in `open-sse/services/usage.ts` (`case "ollama-cloud": return await getOllamaCloudUsage(...)`), but it was **missing from the `USAGE_FETCHER_PROVIDERS` registration list**. `genericQuotaFetcher.ts` consults that list to decide which providers to attempt usage fetching for, so ollama-cloud usage was silently never fetched — breaking the "single source of truth" between the dispatcher switch and the registration list (the exact drift the list's own comment warns about: *"If you add a new provider to the switch, add it here too."*).

## Root cause

In `open-sse/services/usage.ts`, `USAGE_FETCHER_PROVIDERS` enumerated every provider with a dispatcher case **except** `ollama-cloud`. The fetcher (`getOllamaCloudUsage`) and the `case` both exist; only the registration entry was omitted.

## Fix

Added `"ollama-cloud"` to `USAGE_FETCHER_PROVIDERS` (placed next to its `opencode`/`opencode-zen` siblings, since both families live in `opencodeOllamaUsage.ts`). This re-enables usage fetching for ollama-cloud connections that provide a cookie, with no behavior change for any other provider.

## Test

Extended `tests/unit/usage-families-split.test.ts` with a `#7026` case asserting `USAGE_FETCHER_PROVIDERS` includes `"ollama-cloud"`. It fails on unpatched `main` (the entry is absent) and passes after the fix, guarding against future list/switch drift.

Fixes #7026.
