### PR TITLE
fix(responses): map mid-conversation system turns to developer role (#6954)

### DIFF
--- a/open-sse/translator/request/openai-responses/toResponses.ts
+++ b/open-sse/translator/request/openai-responses/toResponses.ts
@@ -58,6 +58,13 @@ function buildResponsesTextParts(content: unknown): unknown[] {
   if (Array.isArray(content)) {
     const parts: unknown[] = [];
     for (const partValue of content) {
+      // A bare string inside the content array is a real text instruction
+      // (e.g. a harness-injected system reminder), not a structured part.
+      // Silently dropping it lost the instruction (#6954 follow-up).
+      if (typeof partValue === "string") {
+        parts.push({ type: "input_text", text: partValue });
+        continue;
+      }
       const part = toRecord(partValue);
       if (part.type === "text" || typeof part.text === "string") {
         parts.push({ type: "input_text", text: toString(part.text) });

--- a/open-sse/translator/request/openai-responses/toResponses.ts
+++ b/open-sse/translator/request/openai-responses/toResponses.ts
@@ -49,6 +49,25 @@ function mapChatResponseFormatToResponsesText(body: JsonRecord, result: JsonReco
   result.text = { ...existingText, format };
 }
 
+// Convert a Chat-Completions content block (string or text-part array) into the
+// Responses API `input_text` part array used by message input items.
+function buildResponsesTextParts(content: unknown): unknown[] {
+  if (typeof content === "string") {
+    return [{ type: "input_text", text: content }];
+  }
+  if (Array.isArray(content)) {
+    const parts: unknown[] = [];
+    for (const partValue of content) {
+      const part = toRecord(partValue);
+      if (part.type === "text" || typeof part.text === "string") {
+        parts.push({ type: "input_text", text: toString(part.text) });
+      }
+    }
+    return parts.length > 0 ? parts : [{ type: "input_text", text: "" }];
+  }
+  return [{ type: "input_text", text: "" }];
+}
+
 export function openaiToOpenAIResponsesRequest(
   model: unknown,
   body: unknown,
@@ -83,7 +102,18 @@ export function openaiToOpenAIResponsesRequest(
       if (!hasSystemMessage) {
         result.instructions = typeof msg.content === "string" ? msg.content : "";
         hasSystemMessage = true;
+        continue;
       }
+      // Mid-conversation system/developer turns (e.g. harness-injected reminders
+      // from Claude Code) must survive as developer-role input items. The
+      // Responses API supports the `developer` role for exactly this; mapping
+      // them to `assistant` misattributes harness instructions as model output,
+      // and silently dropping them loses them entirely (#6954).
+      input.push({
+        type: "message",
+        role: "developer",
+        content: buildResponsesTextParts(msg.content),
+      });
       continue;
     }
 

--- a/tests/unit/openai-responses-request-split.test.ts
+++ b/tests/unit/openai-responses-request-split.test.ts
@@ -54,3 +54,47 @@ test("both directions are callable via the host module", async () => {
   ) as Record<string, unknown>;
   assert.ok(Array.isArray(out.input));
 });
+
+test("mid-conversation system turns are preserved as developer-role input items (#6954)", async () => {
+  const mod = await import("../../open-sse/translator/request/openai-responses.ts");
+  const out = mod.openaiToOpenAIResponsesRequest(
+    "gpt-5.5",
+    {
+      messages: [
+        { role: "system", content: "You are a helpful assistant." },
+        { role: "user", content: "Hello" },
+        { role: "system", content: "Available agent types: claude, claude-code-guide" },
+        { role: "assistant", content: "Hi there!" },
+        { role: "system", content: "Reminder: stay concise." },
+      ],
+    },
+    true,
+    null
+  ) as Record<string, unknown>;
+
+  // The FIRST system turn becomes `instructions`.
+  assert.equal(out.instructions, "You are a helpful assistant.");
+
+  const input = out.input as Array<Record<string, unknown>>;
+
+  // Mid-conversation system turns must survive as developer-role input items —
+  // not dropped, and never misattributed as assistant (#6954).
+  const developerItems = input.filter((i) => i.role === "developer");
+  assert.equal(developerItems.length, 2, "two mid-conversation system turns should become developer items");
+  assert.deepEqual(
+    (developerItems[0].content as Array<Record<string, unknown>>).map((c) => c.text),
+    ["Available agent types: claude, claude-code-guide"]
+  );
+  assert.deepEqual(
+    (developerItems[1].content as Array<Record<string, unknown>>).map((c) => c.text),
+    ["Reminder: stay concise."]
+  );
+
+  // No harness-injected system content should appear as assistant prose.
+  const assistantText = input
+    .filter((i) => i.role === "assistant")
+    .map((i) => JSON.stringify(i.content))
+    .join(" ");
+  assert.ok(!assistantText.includes("Available agent types"));
+  assert.ok(!assistantText.includes("Reminder: stay concise."));
+});

--- a/tests/unit/openai-responses-request-split.test.ts
+++ b/tests/unit/openai-responses-request-split.test.ts
@@ -98,3 +98,26 @@ test("mid-conversation system turns are preserved as developer-role input items 
   assert.ok(!assistantText.includes("Available agent types"));
   assert.ok(!assistantText.includes("Reminder: stay concise."));
 });
+
+test("mid-conversation system content as an array with a bare string survives (#6954 follow-up)", async () => {
+  const mod = await import("../../open-sse/translator/request/openai-responses.ts");
+  const out = mod.openaiToOpenAIResponsesRequest(
+    "gpt-5.5",
+    {
+      messages: [
+        { role: "system", content: "Base instructions." },
+        { role: "user", content: "Hi" },
+        { role: "system", content: ["Remember to be concise."] },
+      ],
+    },
+    true,
+    null
+  ) as Record<string, unknown>;
+  const input = out.input as Array<Record<string, unknown>>;
+  const devItems = input.filter((i) => i.role === "developer");
+  assert.equal(devItems.length, 1, "array-form system turn should become a developer item");
+  assert.deepEqual(
+    (devItems[0].content as Array<Record<string, unknown>>).map((c) => c.text),
+    ["Remember to be concise."]
+  );
+});


### PR DESCRIPTION
## Problem (#6954)

When translating an Anthropic/OpenAI **Messages**-format request to the OpenAI **Responses** API (`openaiToOpenAIResponsesRequest` in `open-sse/translator/request/openai-responses/toResponses.ts`), the first `role: "system"` (or `role: "developer"`) message is extracted into `instructions`, but **every subsequent mid-conversation system turn is silently dropped** (`continue`).

Clients such as Claude Code v2.1.207 inject harness reminders as mid-stream `role: "system"` turns. Dropping them loses harness instructions entirely; mapping them to `assistant` (as older revisions did) misattributes harness-authored content as model output. The correct target is the Responses API `developer` role, which exists for exactly this purpose.

## Root cause

In `toResponses.ts`, the system/developer branch only handled the first message:

```ts
if (role === "system" || role === "developer") {
  if (!hasSystemMessage) {
    result.instructions = typeof msg.content === "string" ? msg.content : "";
    hasSystemMessage = true;
  }
  continue; // <- subsequent system/developer turns dropped
}
```

## Fix

After the first system turn (which still becomes `instructions`), subsequent `system`/`developer` turns are now emitted as `developer`-role message input items, preserving their content:

```ts
input.push({
  type: "message",
  role: "developer",
  content: buildResponsesTextParts(msg.content),
});
```

A small `buildResponsesTextParts` helper converts a string or text-part array into the Responses `input_text` part shape. The downstream Codex executor's `convertSystemToDeveloperRole` already converts any residual `system` items in-place, so emitting `developer` directly is compatible.

## Test

Added `mid-conversation system turns are preserved as developer-role input items (#6954)` to `tests/unit/openai-responses-request-split.test.ts`:

- A request with `[system, user, system, assistant, system]` history.
- Asserts the first system becomes `instructions`.
- Asserts exactly two `developer`-role input items are produced with the correct text.
- Asserts no harness content leaks into `assistant` prose.

The case passes on the patched code and would fail (zero developer items / dropped content) on the unpatched `main`.

Fixes #6954.
