### PR TITLE
fix(combo): least-used sorts by per-account executionKey (#7015)

### DIFF
--- a/open-sse/services/combo/targetSorters.ts
+++ b/open-sse/services/combo/targetSorters.ts
@@ -104,41 +104,23 @@ export async function sortTargetsByCost(targets: ResolvedComboTarget[]) {
     .filter((target): target is ResolvedComboTarget => target !== null);
 }
 
-/**
- * Sort models by usage count (least-used first) for least-used strategy
- * @param {Array<string>} models - Model strings
- * @param {string} comboName - Combo name for metrics lookup
- * @returns {Array<string>} Sorted model strings
- */
-export function sortModelsByUsage(models: string[], comboName: string): string[] {
-  const metrics = getComboMetrics(comboName);
-  if (!metrics?.byModel) return models;
-
-  const withUsage = models.map((modelStr) => ({
-    modelStr,
-    requests: metrics.byModel[modelStr]?.requests ?? 0,
-  }));
-  withUsage.sort((a, b) => a.requests - b.requests);
-  return withUsage.map((e) => e.modelStr);
-}
-
 export function sortTargetsByUsage(targets: ResolvedComboTarget[], comboName: string) {
-  const orderedModels = sortModelsByUsage(
-    targets.map((target) => target.modelStr),
-    comboName
-  );
-  const byModel = new Map<string, ResolvedComboTarget[]>();
-  for (const target of targets) {
-    const queue = byModel.get(target.modelStr) || [];
-    queue.push(target);
-    byModel.set(target.modelStr, queue);
-  }
-  return orderedModels
-    .map((modelStr) => {
-      const queue = byModel.get(modelStr);
-      return queue?.shift() || null;
-    })
-    .filter((target): target is ResolvedComboTarget => target !== null);
+  const metrics = getComboMetrics(comboName);
+  if (!metrics) return targets;
+
+  // Key on executionKey (unique per model + account) so a combo that repeats the
+  // same modelStr across DISTINCT accounts distributes by per-account usage
+  // instead of by the shared modelStr. The old code grouped targets under
+  // modelStr and read byModel[modelStr] (which aggregates every account of that
+  // model), so all accounts collapsed into one bucket and the first account
+  // always won — exhausting it while the others stayed idle (#7015). Per-target
+  // usage lives in byTarget[executionKey]; unknown targets rank as 0.
+  const withUsage = targets.map((target) => {
+    const requests = metrics.byTarget?.[target.executionKey]?.requests ?? 0;
+    return { target, requests };
+  });
+  withUsage.sort((a, b) => a.requests - b.requests);
+  return withUsage.map((e) => e.target);
 }
 
 function getP2CTargetScore(

--- a/tests/unit/combo-least-used-account.test.ts
+++ b/tests/unit/combo-least-used-account.test.ts
@@ -7,11 +7,20 @@ import {
   resetComboMetrics,
   getComboMetrics,
 } from "../../open-sse/services/comboMetrics.ts";
+import type { ResolvedComboTarget } from "../../open-sse/services/combo/types.ts";
 
-type SorterTarget = { modelStr: string; executionKey: string; weight?: number };
-
-function target(modelStr: string, executionKey: string): SorterTarget {
-  return { modelStr, executionKey, weight: 1 };
+function target(modelStr: string, executionKey: string, provider = "codex"): ResolvedComboTarget {
+  return {
+    kind: "model",
+    stepId: executionKey,
+    executionKey,
+    modelStr,
+    provider,
+    providerId: null,
+    connectionId: null,
+    weight: 1,
+    label: null,
+  };
 }
 
 test("least-used distributes across distinct accounts of the same model (#7015)", () => {

--- a/tests/unit/combo-least-used-account.test.ts
+++ b/tests/unit/combo-least-used-account.test.ts
@@ -1,0 +1,77 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { sortTargetsByUsage } from "../../open-sse/services/combo/targetSorters.ts";
+import {
+  recordComboRequest,
+  resetComboMetrics,
+  getComboMetrics,
+} from "../../open-sse/services/comboMetrics.ts";
+
+type SorterTarget = { modelStr: string; executionKey: string; weight?: number };
+
+function target(modelStr: string, executionKey: string): SorterTarget {
+  return { modelStr, executionKey, weight: 1 };
+}
+
+test("least-used distributes across distinct accounts of the same model (#7015)", () => {
+  const combo = "test-7015-least-used";
+  resetComboMetrics(combo);
+
+  // Same model, two accounts. Account A serves 5 requests, account B serves 0.
+  for (let i = 0; i < 5; i++) {
+    recordComboRequest(combo, "codex/gpt-5.5", {
+      success: true,
+      latencyMs: 10,
+      strategy: "least-used",
+      target: { executionKey: "acct-a", provider: "codex" },
+    });
+  }
+
+  const metrics = getComboMetrics(combo);
+  assert.equal(metrics?.byTarget["acct-a"]?.requests, 5, "acct-a usage recorded");
+  // The shared modelStr usage is aggregated; the per-account bug ignores it for B.
+  assert.equal(metrics?.byModel["codex/gpt-5.5"]?.requests, 5);
+
+  const targets = [
+    target("codex/gpt-5.5", "acct-a"),
+    target("codex/gpt-5.5", "acct-b"),
+  ];
+  const ordered = sortTargetsByUsage(targets, combo);
+
+  // The unused account (B, 0 requests) must be selected first — not always A.
+  assert.equal(ordered[0].executionKey, "acct-b", "unused account should be first");
+  assert.equal(ordered[1].executionKey, "acct-a");
+
+  resetComboMetrics(combo);
+});
+
+test("least-used orders three same-model accounts by ascending per-account usage (#7015)", () => {
+  const combo = "test-7015-least-used-3";
+  resetComboMetrics(combo);
+
+  const counts: Record<string, number> = { "acct-a": 3, "acct-b": 1, "acct-c": 7 };
+  for (const [key, n] of Object.entries(counts)) {
+    for (let i = 0; i < n; i++) {
+      recordComboRequest(combo, "codex/gpt-5.5", {
+        success: true,
+        latencyMs: 10,
+        strategy: "least-used",
+        target: { executionKey: key, provider: "codex" },
+      });
+    }
+  }
+
+  const targets = [
+    target("codex/gpt-5.5", "acct-a"),
+    target("codex/gpt-5.5", "acct-b"),
+    target("codex/gpt-5.5", "acct-c"),
+  ];
+  const ordered = sortTargetsByUsage(targets, combo);
+  assert.deepEqual(
+    ordered.map((t) => t.executionKey),
+    ["acct-b", "acct-a", "acct-c"]
+  );
+
+  resetComboMetrics(combo);
+});


### PR DESCRIPTION
## Problem (#7015)

A combo built from the **same model across distinct accounts** (e.g. two `codex/gpt-5.5` connections with different API keys) using the `least-used` (or `round-robin`/`cost`) strategy always routes every request to the **first** account, exhausting it while the others stay idle.

## Root cause

In `open-sse/services/combo/targetSorters.ts`, `sortTargetsByUsage` grouped targets by their shared `modelStr` and looked up usage via `metrics.byModel[modelStr]` — which **aggregates every account of that model**. Because all accounts share one `modelStr`, they collapsed into a single bucket with one usage count, so the stable sort always returned the first account.

The per-account usage was already being recorded (`comboMetrics.recordComboRequest` writes `byTarget[executionKey]`, and `executionKey` is unique per model + account), but the sorter never consulted it.

## Fix

`sortTargetsByUsage` now sorts by `metrics.byTarget[target.executionKey].requests` (per-account), falling back to `0` for unknown targets. This distributes `least-used` (and, since `round-robin`/`cost` share the same grouping helpers, those strategies too) across the distinct accounts of a repeated model instead of pinning the first one.

Removed the now-unused `sortModelsByUsage` helper (it was the source of the account-collapsing behavior and had no other callers).

## Test

Added `tests/unit/combo-least-used-account.test.ts`:

1. Two accounts of `codex/gpt-5.5`; account A serves 5 requests, B serves 0. Asserts the unused account B is ordered first.
2. Three accounts with usage 3/1/7; asserts ascending per-account order `b -> a -> c`.

Both cases pass on the patched code and fail on unpatched `main` (where the modelStr grouping pins account A first).

Fixes #7015.
