### PR TITLE
fix(providers): AgentRouter model import applies Claude Code wire image to /v1/models (#7016)

### DIFF
--- a/src/app/api/providers/[id]/models/discovery/providerModelsConfig.ts
+++ b/src/app/api/providers/[id]/models/discovery/providerModelsConfig.ts
@@ -148,11 +148,14 @@ export const PROVIDER_MODELS_CONFIG: Record<string, ProviderModelsConfigEntry> =
       const out: Record<string, string> = { ...wire };
       // Keep AgentRouter's own x-api-key auth scheme (#6056); the CC helper
       // adds a Bearer Authorization we must not send.
-      delete out.Authorization;
+      for (const key of Object.keys(out)) {
+        if (key.toLowerCase() === "authorization") delete out[key];
+      }
       if (token) out["x-api-key"] = token;
       return out;
     },
-    parseResponse: (data: any) => data?.data || data?.models || [],
+    parseResponse: (data: any) =>
+      Array.isArray(data) ? data : (data?.data || data?.models || []),
   },
   openai: {
     url: "https://api.openai.com/v1/models",

--- a/src/app/api/providers/[id]/models/discovery/providerModelsConfig.ts
+++ b/src/app/api/providers/[id]/models/discovery/providerModelsConfig.ts
@@ -4,6 +4,7 @@ import { parseGeminiModelsList } from "@/lib/providerModels/geminiModelsParser";
 import { filterClinepassModels } from "@omniroute/open-sse/services/clinepassModels.ts";
 import { normalizeOpenAiLikeModelsResponse } from "./normalizers";
 import { extractKimiJwt } from "@/lib/providers/webCookieAuth";
+import { buildClaudeCodeCompatibleHeaders } from "@omniroute/open-sse/services/claudeCodeCompatible.ts";
 
 export type ProviderModelsConfigEntry = {
   url: string;
@@ -132,6 +133,26 @@ export const PROVIDER_MODELS_CONFIG: Record<string, ProviderModelsConfigEntry> =
     authPrefix: "Bearer ",
     body: {},
     parseResponse: (data) => data.models || [],
+  },
+  // #7016: AgentRouter rejects /v1/models unless the request carries the same
+  // Claude Code wire image the chat path uses (it adopts the dynamic CC wire
+  // image while keeping its own x-api-key auth — see #6056). Without these
+  // headers the gateway WAF 4xx's the request and model import silently falls
+  // back to the local catalog ("API unavailable — using local catalog").
+  agentrouter: {
+    url: "https://agentrouter.org/v1/models",
+    method: "GET",
+    headers: { "Content-Type": "application/json" },
+    buildHeaders: (token: string) => {
+      const wire = buildClaudeCodeCompatibleHeaders(token, false, undefined, {});
+      const out: Record<string, string> = { ...wire };
+      // Keep AgentRouter's own x-api-key auth scheme (#6056); the CC helper
+      // adds a Bearer Authorization we must not send.
+      delete out.Authorization;
+      if (token) out["x-api-key"] = token;
+      return out;
+    },
+    parseResponse: (data: any) => data?.data || data?.models || [],
   },
   openai: {
     url: "https://api.openai.com/v1/models",

--- a/tests/unit/agentrouter-models-discovery-7016.test.ts
+++ b/tests/unit/agentrouter-models-discovery-7016.test.ts
@@ -1,0 +1,60 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { PROVIDER_MODELS_CONFIG } from "../../src/app/api/providers/[id]/models/discovery/providerModelsConfig.ts";
+import { CLAUDE_CODE_COMPATIBLE_USER_AGENT } from "../../open-sse/services/claudeCodeCompatible.ts";
+
+// Regression guard for #7016 — AgentRouter's "Import from /models" must hit the
+// live /v1/models endpoint. Previously the provider had no PROVIDER_MODELS_CONFIG
+// entry, so model discovery fell through to the local catalog and import reported
+// "API unavailable — using local catalog". The live request must also carry the
+// Claude Code wire image (the same one the chat path uses) or the gateway WAF
+// rejects it; AgentRouter keeps its own x-api-key auth (#6056).
+
+test("agentrouter has a live /v1/models discovery config", () => {
+  const cfg = PROVIDER_MODELS_CONFIG.agentrouter;
+  assert.ok(cfg, "expected an agentrouter entry in PROVIDER_MODELS_CONFIG");
+  assert.equal(cfg.method, "GET");
+  assert.equal(cfg.url, "https://agentrouter.org/v1/models");
+  assert.equal(typeof cfg.buildHeaders, "function");
+  assert.equal(typeof cfg.parseResponse, "function");
+});
+
+test("agentrouter discovery headers carry the Claude Code wire image + x-api-key", () => {
+  const cfg = PROVIDER_MODELS_CONFIG.agentrouter;
+  const headers = cfg.buildHeaders!("sk-agentrouter");
+
+  // CC wire-image markers (mirrors the chat path — see agentrouter-cc-wire-image.test.ts).
+  assert.equal(headers["User-Agent"], CLAUDE_CODE_COMPATIBLE_USER_AGENT);
+  assert.equal(headers["x-app"], "cli");
+  assert.equal(headers["anthropic-dangerous-direct-browser-access"], "true");
+  assert.ok(headers["anthropic-beta"], "expected the CC anthropic-beta header");
+  assert.ok(headers["X-Stainless-Package-Version"], "expected CC X-Stainless anchors");
+
+  // CRUX: AgentRouter keeps its OWN x-api-key auth (NOT the CC Bearer).
+  assert.equal(headers["x-api-key"], "sk-agentrouter");
+  assert.equal(headers["Authorization"], undefined);
+});
+
+test("agentrouter discovery parseResponse maps an OpenAI-style model list", () => {
+  const cfg = PROVIDER_MODELS_CONFIG.agentrouter;
+  const models = cfg.parseResponse!({
+    object: "list",
+    data: [
+      { id: "claude-opus-4-6", object: "model", owned_by: "anthropic" },
+      { id: "glm-5.1", object: "model", owned_by: "zhipu" },
+    ],
+  });
+  assert.deepEqual(
+    models,
+    [
+      { id: "claude-opus-4-6", object: "model", owned_by: "anthropic" },
+      { id: "glm-5.1", object: "model", owned_by: "zhipu" },
+    ]
+  );
+
+  // Tolerant of the alternate `models` envelope shape too.
+  assert.deepEqual(cfg.parseResponse!({ models: [{ id: "deepseek-v3.2" }] }), [
+    { id: "deepseek-v3.2" },
+  ]);
+});

--- a/tests/unit/agentrouter-models-discovery-7016.test.ts
+++ b/tests/unit/agentrouter-models-discovery-7016.test.ts
@@ -58,3 +58,17 @@ test("agentrouter discovery parseResponse maps an OpenAI-style model list", () =
     { id: "deepseek-v3.2" },
   ]);
 });
+
+test("agentrouter discovery headers leak no Authorization variant (case-insensitive)", () => {
+  const cfg = PROVIDER_MODELS_CONFIG.agentrouter;
+  const headers = cfg.buildHeaders!("sk-agentrouter");
+  const hasAuthVariant = Object.keys(headers).some((k) => k.toLowerCase() === "authorization");
+  assert.equal(hasAuthVariant, false, "no Authorization/authorization header must survive");
+});
+
+test("agentrouter parseResponse handles a bare array response (#7016)", () => {
+  const cfg = PROVIDER_MODELS_CONFIG.agentrouter;
+  assert.deepEqual(cfg.parseResponse!([{ id: "claude-sonnet-4-6" }]), [
+    { id: "claude-sonnet-4-6" },
+  ]);
+});


### PR DESCRIPTION
## Summary
Fixes #7016 — "Import from /models" on the AgentRouter provider fails and silently falls back to the local catalog (`API unavailable — using local catalog`).

## Root cause
AgentRouter's `/v1/models` endpoint is gated by the same Claude Code "wire image" the **chat** path already sends (AgentRouter adopts the dynamic CC wire image while keeping its own `x-api-key` auth — see #6056). The model-discovery path had **no** `PROVIDER_MODELS_CONFIG` entry for `agentrouter`, so discovery fell through to the local catalog and never attempted a live fetch. Even if it had, the generic fallback would have sent a plain `Bearer`/empty request that the gateway WAF rejects.

## Fix
- Add an `agentrouter` entry to `PROVIDER_MODELS_CONFIG` whose `buildHeaders` reuses `buildClaudeCodeCompatibleHeaders` (the exact source-of-truth CC wire image) and swaps the CC `Bearer` auth for AgentRouter's own `x-api-key` — identical to how `buildProviderHeaders` handles `usesCcWireImage` providers on the chat path.
- `parseResponse` tolerates both the OpenAI-style `{ data: [...] }` and `{ models: [...] }` envelopes.

If the live fetch still fails (bad key, WAF), the existing `buildDiscoveryErrorFallbackResponse` path keeps returning the local catalog — no regression / no 5xx.

## Test plan
- `tests/unit/agentrouter-models-discovery-7016.test.ts`: asserts the entry exists (GET, correct URL), that `buildHeaders` emits the CC wire image + `x-api-key` (no `Authorization`), and that `parseResponse` maps the OpenAI-style list.
