### PR TITLE
fix(translator): preserve thinking.budget_tokens: 0 in Claude->Gemini (#6813)

### DIFF
--- a/open-sse/translator/request/claude-to-gemini.ts
+++ b/open-sse/translator/request/claude-to-gemini.ts
@@ -188,7 +188,9 @@ export function claudeToGeminiRequest(model, body, stream, credentials = null) {
   // Priority: thinking.budget_tokens (Claude native) > output_config.effort (Claude Code).
   if (model.startsWith("gemma-4")) {
     // gemma-4 models returns - 400: Thinking budget is not supported for this model
-  } else if (body.thinking?.type === "enabled" && body.thinking.budget_tokens) {
+  } else if (body.thinking?.type === "enabled" && body.thinking.budget_tokens !== undefined) {
+    // #6813: a truthy check here dropped `budget_tokens: 0` (dynamic thinking).
+    // `undefined` (no budget specified) still falls through to the effort branch.
     result.generationConfig.thinkingConfig = {
       thinkingBudget: body.thinking.budget_tokens,
       includeThoughts: true,

--- a/tests/unit/claude-to-gemini-budget-tokens-zero-6813.test.ts
+++ b/tests/unit/claude-to-gemini-budget-tokens-zero-6813.test.ts
@@ -1,0 +1,42 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { claudeToGeminiRequest } = await import(
+  "../../open-sse/translator/request/claude-to-gemini.ts"
+);
+
+// Regression for #6813 — the Claude→Gemini thinking transform used a truthy
+// check (`body.thinking.budget_tokens`) that silently dropped `budget_tokens: 0`
+// (dynamic thinking). The value must be preserved as `thinkingBudget: 0`.
+
+test("Claude -> Gemini preserves thinking.budget_tokens: 0 (dynamic thinking) (#6813)", () => {
+  const result = claudeToGeminiRequest(
+    "gemini-2.5-pro",
+    {
+      messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      thinking: { type: "enabled", budget_tokens: 0 },
+    },
+    false
+  );
+
+  assert.deepEqual(result.generationConfig.thinkingConfig, {
+    thinkingBudget: 0,
+    includeThoughts: true,
+  });
+});
+
+test("Claude -> Gemini prefers a positive thinking.budget_tokens over budget 0 semantics", () => {
+  const result = claudeToGeminiRequest(
+    "gemini-2.5-pro",
+    {
+      messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      thinking: { type: "enabled", budget_tokens: 8192 },
+    },
+    false
+  );
+
+  assert.deepEqual(result.generationConfig.thinkingConfig, {
+    thinkingBudget: 8192,
+    includeThoughts: true,
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #6813 — the Claude→Gemini translator silently dropped `thinking.budget_tokens: 0` (dynamic thinking) because the guard used a truthy check.

## Root cause
`open-sse/translator/request/claude-to-gemini.ts`:
```ts
} else if (body.thinking?.type === "enabled" && body.thinking.budget_tokens) {
```
`budget_tokens: 0` is falsy, so the branch was skipped and `thinkingConfig` was never emitted — the request reached Gemini with no thinking config at all. The OpenAI→Claude thinking fitter (`openai-to-claude/thinkingBudget.ts`) already *preserves* `budget_tokens: 0`, so the value arrives intact; it was only lost at the Gemini edge.

## Fix
Guard on `!== undefined` instead of truthiness, so `budget_tokens: 0` maps to `thinkingConfig: { thinkingBudget: 0, includeThoughts: true }` (Gemini's dynamic-thinking signal). `undefined` (no budget) still falls through to the `output_config.effort` branch, so existing behavior is unchanged.

## Test plan
- `tests/unit/claude-to-gemini-budget-tokens-zero-6813.test.ts`: asserts `thinking: { type: "enabled", budget_tokens: 0 }` produces `thinkingConfig: { thinkingBudget: 0, includeThoughts: true }`, and a positive budget still maps through.
