### PR TITLE
perf: P0 fixes — recharts dynamic imports, DB pagination, quota pools batch loading

### DIFF
--- a/config/quality/file-size-baseline.json
+++ b/config/quality/file-size-baseline.json
@@ -240,7 +240,7 @@
     "src/lib/db/migrationRunner.ts": 1125,
     "src/lib/db/models.ts": 1259,
     "src/lib/db/providers.ts": 1107,
-    "src/lib/db/proxies.ts": 1177,
+    "src/lib/db/proxies.ts": 1205,
     "src/lib/db/settings.ts": 1155,
     "src/lib/db/usageAnalytics.ts": 925,
     "src/lib/evals/evalRunner.ts": 961,
@@ -401,5 +401,6 @@
   "_rebaseline_2026_07_07_6534_chirag": "PR #6534 (@chirag127) own growth: open-sse/services/compression/strategySelector.ts ->1025. Owner-approved rebaseline. Frozen.",
   "_rebaseline_2026_07_08_6556_omniglyph_mode": "PR #6556 (omniglyph engine) own growth: open-sse/services/compression/strategySelector.ts 1025->1043 (+18 at the existing mode-dispatch chokepoints). Two single-mode branches (sync no-op + async resolve via the engine registry, mirroring the rtk single-mode pattern, B-MODE-ENGINE-DECOUPLE) plus the optional providerTransport field threaded through the three options types (gates transport-sensitive engines). The engine itself lives in engines/omniglyphAdapter.ts (<cap); the residual is cohesive dispatch/type wiring not extractable without hiding the dispatch boundary, mirroring the prior compression rebaselines (#5243/#5286/phase4b/#6534). Covered by tests/unit/compression/omniglyph-*.test.ts (22). Structural shrink of this file tracked in #3501.",
   "_rebaseline_2026_07_07_6546_chirag": "PR #6546 (@chirag127) own growth: src/sse/handlers/chatHelpers.ts ->876. Owner-approved rebaseline. Frozen.",
-  "_rebaseline_2026_07_07_6525_chirag_image_guard": "PR #6525 (@chirag127, #6457) own growth: chat.ts ->1778 (reject image-only models on /v1/chat/completions; stacks on #6515). Owner-approved. Frozen."
+  "_rebaseline_2026_07_07_6525_chirag_image_guard": "PR #6525 (@chirag127, #6457) own growth: chat.ts ->1778 (reject image-only models on /v1/chat/completions; stacks on #6515). Owner-approved. Frozen.",
+  "_rebaseline_2026_07_15_perf_p0_fixes_proxies": "PR #7064 (perf/p0-fixes) own growth: src/lib/db/proxies.ts 1177->1205 (+28). e0695076: pagination support (limit, offset params, {items, total} return) — +~28 lines. Irreducible for adding pagination to the proxies endpoint."
 }

--- a/src/app/(dashboard)/dashboard/analytics/ProviderUtilizationTab.tsx
+++ b/src/app/(dashboard)/dashboard/analytics/ProviderUtilizationTab.tsx
@@ -3,16 +3,9 @@
 import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useProviderNodeMap, resolveProviderName } from "@/lib/display/useProviderNodeMap";
-import {
-  CartesianGrid,
-  Legend,
-  Line,
-  LineChart,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from "recharts";
+import dynamic from "next/dynamic";
+
+const ProviderCharts = dynamic(() => import("./components/ProviderCharts"), { ssr: false });
 import Card from "@/shared/components/Card";
 import ProviderIcon from "@/shared/components/ProviderIcon";
 import TimeRangeSelector from "@/shared/components/analytics/TimeRangeSelector";
@@ -309,60 +302,17 @@ export default function ProviderUtilizationTab() {
           </div>
         ) : (
           <div className="flex flex-col gap-5">
-            <div className="h-80 w-full rounded-xl border border-black/5 bg-black/[0.02] px-3 py-4 dark:border-white/5 dark:bg-white/[0.02]">
-              <ResponsiveContainer width="100%" height="100%">
-                <LineChart data={chartData} margin={{ top: 8, right: 16, bottom: 0, left: 0 }}>
-                  <CartesianGrid
-                    stroke="var(--color-border)"
-                    strokeDasharray="3 3"
-                    vertical={false}
-                  />
-                  <XAxis
-                    dataKey="timestamp"
-                    tickFormatter={(value) => formatTimestamp(String(value), range)}
-                    tick={{ fill: "var(--color-text-muted)", fontSize: 12 }}
-                    axisLine={{ stroke: "var(--color-border)" }}
-                    tickLine={{ stroke: "var(--color-border)" }}
-                    minTickGap={24}
-                  />
-                  <YAxis
-                    domain={[0, 100]}
-                    tickFormatter={formatPercent}
-                    tick={{ fill: "var(--color-text-muted)", fontSize: 12 }}
-                    axisLine={{ stroke: "var(--color-border)" }}
-                    tickLine={{ stroke: "var(--color-border)" }}
-                    width={44}
-                  />
-                  <Tooltip
-                    labelFormatter={(value) => formatTooltipTimestamp(String(value), range)}
-                    formatter={(value: number, name: string) => [formatPercent(value), name]}
-                    contentStyle={{
-                      backgroundColor: "var(--color-surface)",
-                      borderColor: "var(--color-border)",
-                      borderRadius: 12,
-                      color: "var(--color-text-main)",
-                      boxShadow: "var(--shadow-soft)",
-                    }}
-                    itemStyle={{ color: "var(--color-text-main)" }}
-                    labelStyle={{ color: "var(--color-text-main)", fontWeight: 600 }}
-                  />
-                  <Legend />
-                  {data?.providers.map((provider) => (
-                    <Line
-                      key={provider}
-                      type="monotone"
-                      dataKey={provider}
-                      name={resolveProviderName(provider, nodeMap)}
-                      stroke={providerColors.get(provider) ?? "var(--color-primary)"}
-                      strokeWidth={2.5}
-                      dot={false}
-                      activeDot={{ r: 4, strokeWidth: 0 }}
-                      connectNulls
-                    />
-                  ))}
-                </LineChart>
-              </ResponsiveContainer>
-            </div>
+            <ProviderCharts
+              chartData={chartData}
+              providers={data?.providers ?? []}
+              providerColors={providerColors}
+              range={range}
+              resolveProviderName={resolveProviderName}
+              nodeMap={nodeMap}
+              formatTimestamp={formatTimestamp}
+              formatPercent={formatPercent}
+              formatTooltipTimestamp={formatTooltipTimestamp}
+            />
 
             <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
               {latestPoints.map((point) => {

--- a/src/app/(dashboard)/dashboard/analytics/components/ProviderCharts.tsx
+++ b/src/app/(dashboard)/dashboard/analytics/components/ProviderCharts.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+interface ProviderChartsProps {
+  chartData: Array<Record<string, unknown>>;
+  providers: string[];
+  providerColors: Map<string, string>;
+  range: string;
+  resolveProviderName: (provider: string, _nodeMap: unknown) => string;
+  nodeMap: unknown;
+  formatTimestamp: (value: string, _range: string) => string;
+  formatPercent: (value: number) => string;
+  formatTooltipTimestamp: (value: string, _range: string) => string;
+}
+
+export default function ProviderCharts({
+  chartData,
+  providers,
+  providerColors,
+  range,
+  resolveProviderName,
+  nodeMap,
+  formatTimestamp,
+  formatPercent,
+  formatTooltipTimestamp,
+}: ProviderChartsProps) {
+  return (
+    <div className="h-80 w-full rounded-xl border border-black/5 bg-black/[0.02] px-3 py-4 dark:border-white/5 dark:bg-white/[0.02]">
+      <ResponsiveContainer width="100%" height="100%">
+        <LineChart data={chartData} margin={{ top: 8, right: 16, bottom: 0, left: 0 }}>
+          <CartesianGrid stroke="var(--color-border)" strokeDasharray="3 3" vertical={false} />
+          <XAxis
+            dataKey="timestamp"
+            tickFormatter={(value) => formatTimestamp(String(value), range)}
+            tick={{ fill: "var(--color-text-muted)", fontSize: 12 }}
+            axisLine={{ stroke: "var(--color-border)" }}
+            tickLine={{ stroke: "var(--color-border)" }}
+            minTickGap={24}
+          />
+          <YAxis
+            domain={[0, 100]}
+            tickFormatter={formatPercent}
+            tick={{ fill: "var(--color-text-muted)", fontSize: 12 }}
+            axisLine={{ stroke: "var(--color-border)" }}
+            tickLine={{ stroke: "var(--color-border)" }}
+            width={44}
+          />
+          <Tooltip
+            labelFormatter={(value) => formatTooltipTimestamp(String(value), range)}
+            formatter={(value: number, name: string) => [formatPercent(value), name]}
+            contentStyle={{
+              backgroundColor: "var(--color-surface)",
+              borderColor: "var(--color-border)",
+              borderRadius: 12,
+              color: "var(--color-text-main)",
+              boxShadow: "var(--shadow-soft)",
+            }}
+            itemStyle={{ color: "var(--color-text-main)" }}
+            labelStyle={{ color: "var(--color-text-main)", fontWeight: 600 }}
+          />
+          <Legend />
+          {providers.map((provider) => (
+            <Line
+              key={provider}
+              type="monotone"
+              dataKey={provider}
+              name={resolveProviderName(provider, nodeMap)}
+              stroke={providerColors.get(provider) ?? "var(--color-primary)"}
+              strokeWidth={2.5}
+              dot={false}
+              activeDot={{ r: 4, strokeWidth: 0 }}
+              connectNulls
+            />
+          ))}
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/costs/CostOverviewTab.tsx
+++ b/src/app/(dashboard)/dashboard/costs/CostOverviewTab.tsx
@@ -1027,7 +1027,7 @@ function CostExplorerCard({
                       <div className="flex flex-col">
                         <span className="font-medium text-text-main">{row.name}</span>
                         {row.detail ? (
-                          <span className="text-xs text-text-muted truncate max-w-[320px]">
+                          <span className="text-xs text-text-muted truncate inline-block max-w-[320px]">
                             {row.detail}
                           </span>
                         ) : null}

--- a/src/app/(dashboard)/dashboard/costs/CostOverviewTab.tsx
+++ b/src/app/(dashboard)/dashboard/costs/CostOverviewTab.tsx
@@ -9,20 +9,20 @@ import {
   getServiceTierDisplayLabel,
   type TranslationFn as CostTranslationFn,
 } from "@/shared/utils/serviceTierLabels";
-import {
-  ResponsiveContainer,
-  PieChart,
-  Pie,
-  Cell,
-  Tooltip,
-  LineChart,
-  Line,
-  XAxis,
-  YAxis,
-  CartesianGrid,
-  BarChart,
-  Bar,
-} from "recharts";
+import dynamic from "next/dynamic";
+
+const CostTrendCard = dynamic(
+  () => import("./components/CostCharts").then((m) => ({ default: m.CostTrendCard })),
+  { ssr: false }
+);
+const ProviderSpendCard = dynamic(
+  () => import("./components/CostCharts").then((m) => ({ default: m.ProviderSpendCard })),
+  { ssr: false }
+);
+const WeeklyPatternCard = dynamic(
+  () => import("./components/CostCharts").then((m) => ({ default: m.WeeklyPatternCard })),
+  { ssr: false }
+);
 
 import {
   buildCostExplorerRows,
@@ -139,17 +139,6 @@ const EXPLORER_GROUP_OPTIONS: Array<{
   { value: "apiKey", labelKey: "groupApiKey" },
   { value: "account", labelKey: "groupAccount" },
   { value: "serviceTier", labelKey: "groupServiceTier" },
-];
-
-const CHART_COLORS = [
-  "#10b981",
-  "#06b6d4",
-  "#f59e0b",
-  "#8b5cf6",
-  "#ef4444",
-  "#14b8a6",
-  "#6366f1",
-  "#ec4899",
 ];
 
 function createCurrencyFormatter(locale: string) {
@@ -1089,191 +1078,6 @@ function CompactMetric({ label, value }: { label: string; value: string }) {
       <p className="text-xs uppercase tracking-wide text-text-muted font-semibold">{label}</p>
       <p className="text-lg font-semibold text-text-main mt-1">{value}</p>
     </div>
-  );
-}
-
-function ProviderSpendCard({
-  title,
-  rows,
-  locale,
-}: {
-  title: string;
-  rows: UsageAnalyticsProviderRow[];
-  locale: string;
-}) {
-  const currencyFormatter = createCurrencyFormatter(locale);
-  const chartRows = rows.slice(0, 6).map((row, index) => ({
-    name: row.provider,
-    value: row.cost,
-    fill: CHART_COLORS[index % CHART_COLORS.length],
-  }));
-
-  return (
-    <Card className="p-5">
-      <h3 className="text-sm font-semibold text-text-muted uppercase tracking-wide mb-4">
-        {title}
-      </h3>
-      <div className="flex flex-col gap-4 md:flex-row md:items-center">
-        <div className="w-full md:w-45 h-45">
-          <ResponsiveContainer width="100%" height="100%">
-            <PieChart>
-              <Pie
-                data={chartRows}
-                dataKey="value"
-                nameKey="name"
-                innerRadius={45}
-                outerRadius={72}
-                paddingAngle={2}
-              >
-                {chartRows.map((entry) => (
-                  <Cell key={entry.name} fill={entry.fill} stroke="none" />
-                ))}
-              </Pie>
-              <Tooltip
-                formatter={(value: number) => currencyFormatter.format(value || 0)}
-                contentStyle={{
-                  background: "var(--surface)",
-                  border: "1px solid rgba(255,255,255,0.1)",
-                  borderRadius: "12px",
-                }}
-              />
-            </PieChart>
-          </ResponsiveContainer>
-        </div>
-        <div className="flex-1 space-y-2">
-          {chartRows.map((row) => (
-            <div key={row.name} className="flex items-center justify-between gap-3 text-sm">
-              <div className="flex items-center gap-2 min-w-0">
-                <span
-                  className="w-2.5 h-2.5 rounded-full shrink-0"
-                  style={{ backgroundColor: row.fill }}
-                />
-                <span className="truncate text-text-main">{row.name}</span>
-              </div>
-              <span className="font-mono text-text-muted">
-                {currencyFormatter.format(row.value)}
-              </span>
-            </div>
-          ))}
-        </div>
-      </div>
-    </Card>
-  );
-}
-
-function CostTrendCard({
-  title,
-  rows,
-  locale,
-}: {
-  title: string;
-  rows: UsageAnalyticsTrendRow[];
-  locale: string;
-}) {
-  const currencyFormatter = createCurrencyFormatter(locale);
-  const chartRows = rows.map((row) => ({
-    date: row.date.slice(5),
-    cost: row.cost || 0,
-  }));
-
-  return (
-    <Card className="p-5">
-      <h3 className="text-sm font-semibold text-text-muted uppercase tracking-wide mb-4">
-        {title}
-      </h3>
-      <div className="h-55">
-        <ResponsiveContainer width="100%" height="100%">
-          <LineChart data={chartRows} margin={{ top: 5, right: 12, left: 0, bottom: 0 }}>
-            <CartesianGrid stroke="rgba(255,255,255,0.06)" vertical={false} />
-            <XAxis
-              dataKey="date"
-              tick={{ fontSize: 10, fill: "var(--text-muted)" }}
-              axisLine={false}
-              tickLine={false}
-              interval={Math.max(Math.floor(chartRows.length / 8), 0)}
-            />
-            <YAxis
-              tick={{ fontSize: 10, fill: "var(--text-muted)" }}
-              axisLine={false}
-              tickLine={false}
-              tickFormatter={(value) => currencyFormatter.format(value).replace(".00", "")}
-              width={48}
-            />
-            <Tooltip
-              formatter={(value: number) => currencyFormatter.format(value || 0)}
-              contentStyle={{
-                background: "var(--surface)",
-                border: "1px solid rgba(255,255,255,0.1)",
-                borderRadius: "12px",
-              }}
-            />
-            <Line
-              type="monotone"
-              dataKey="cost"
-              stroke="#10b981"
-              strokeWidth={2.5}
-              dot={false}
-              activeDot={{ r: 4 }}
-            />
-          </LineChart>
-        </ResponsiveContainer>
-      </div>
-    </Card>
-  );
-}
-
-function WeeklyPatternCard({
-  title,
-  rows,
-  locale,
-}: {
-  title: string;
-  rows: Array<{ day: string; avgTokens: number; totalTokens: number }>;
-  locale: string;
-}) {
-  const chartData = rows.map((row) => ({
-    day: row.day,
-    tokens: row.avgTokens || 0,
-  }));
-
-  return (
-    <Card className="p-5">
-      <h3 className="text-sm font-semibold text-text-muted uppercase tracking-wide mb-4">
-        {title}
-      </h3>
-      <div className="h-40">
-        <ResponsiveContainer width="100%" height="100%">
-          <BarChart data={chartData} margin={{ top: 5, right: 5, left: 0, bottom: 0 }}>
-            <XAxis
-              dataKey="day"
-              tick={{ fontSize: 11, fill: "var(--text-muted)" }}
-              axisLine={false}
-              tickLine={false}
-            />
-            <YAxis
-              tick={{ fontSize: 10, fill: "var(--text-muted)" }}
-              axisLine={false}
-              tickLine={false}
-              tickFormatter={(value) =>
-                new Intl.NumberFormat(locale, { notation: "compact" }).format(Number(value || 0))
-              }
-              width={40}
-            />
-            <Tooltip
-              formatter={(value: number) =>
-                `${new Intl.NumberFormat(locale).format(value || 0)} tokens`
-              }
-              contentStyle={{
-                background: "var(--surface)",
-                border: "1px solid rgba(255,255,255,0.1)",
-                borderRadius: "12px",
-              }}
-            />
-            <Bar dataKey="tokens" fill="#8b5cf6" radius={[4, 4, 0, 0]} />
-          </BarChart>
-        </ResponsiveContainer>
-      </div>
-    </Card>
   );
 }
 

--- a/src/app/(dashboard)/dashboard/costs/components/CostCharts.tsx
+++ b/src/app/(dashboard)/dashboard/costs/components/CostCharts.tsx
@@ -1,0 +1,236 @@
+"use client";
+
+import { Card } from "@/shared/components";
+import {
+  ResponsiveContainer,
+  PieChart,
+  Pie,
+  Cell,
+  Tooltip,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  BarChart,
+  Bar,
+} from "recharts";
+
+const CHART_COLORS = [
+  "#10b981",
+  "#06b6d4",
+  "#f59e0b",
+  "#8b5cf6",
+  "#ef4444",
+  "#14b8a6",
+  "#6366f1",
+  "#ec4899",
+];
+
+function createCurrencyFormatter(locale: string) {
+  return new Intl.NumberFormat(locale, {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+}
+
+interface UsageAnalyticsProviderRow {
+  provider: string;
+  requests: number;
+  totalTokens: number;
+  cost: number;
+}
+
+interface UsageAnalyticsTrendRow {
+  date: string;
+  cost: number;
+}
+
+export function ProviderSpendCard({
+  title,
+  rows,
+  locale,
+}: {
+  title: string;
+  rows: UsageAnalyticsProviderRow[];
+  locale: string;
+}) {
+  const currencyFormatter = createCurrencyFormatter(locale);
+  const chartRows = rows.slice(0, 6).map((row, index) => ({
+    name: row.provider,
+    value: row.cost,
+    fill: CHART_COLORS[index % CHART_COLORS.length],
+  }));
+
+  return (
+    <Card className="p-5">
+      <h3 className="text-sm font-semibold text-text-muted uppercase tracking-wide mb-4">
+        {title}
+      </h3>
+      <div className="flex flex-col gap-4 md:flex-row md:items-center">
+        <div className="w-full md:w-45 h-45">
+          <ResponsiveContainer width="100%" height="100%">
+            <PieChart>
+              <Pie
+                data={chartRows}
+                dataKey="value"
+                nameKey="name"
+                innerRadius={45}
+                outerRadius={72}
+                paddingAngle={2}
+              >
+                {chartRows.map((entry) => (
+                  <Cell key={entry.name} fill={entry.fill} stroke="none" />
+                ))}
+              </Pie>
+              <Tooltip
+                formatter={(value: number) => currencyFormatter.format(value || 0)}
+                contentStyle={{
+                  background: "var(--surface)",
+                  border: "1px solid rgba(255,255,255,0.1)",
+                  borderRadius: "12px",
+                }}
+              />
+            </PieChart>
+          </ResponsiveContainer>
+        </div>
+        <div className="flex-1 space-y-2">
+          {chartRows.map((row) => (
+            <div key={row.name} className="flex items-center justify-between gap-3 text-sm">
+              <div className="flex items-center gap-2">
+                <span
+                  className="w-2.5 h-2.5 rounded-full shrink-0"
+                  style={{ background: row.fill }}
+                />
+                <span className="font-medium truncate max-w-[120px]">{row.name}</span>
+              </div>
+              <span className="text-text-muted shrink-0">
+                {currencyFormatter.format(row.value)}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+export function CostTrendCard({
+  title,
+  rows,
+  locale,
+}: {
+  title: string;
+  rows: UsageAnalyticsTrendRow[];
+  locale: string;
+}) {
+  const currencyFormatter = createCurrencyFormatter(locale);
+  const chartRows = rows.map((row) => ({
+    date: row.date.slice(5),
+    cost: row.cost || 0,
+  }));
+
+  return (
+    <Card className="p-5">
+      <h3 className="text-sm font-semibold text-text-muted uppercase tracking-wide mb-4">
+        {title}
+      </h3>
+      <div className="h-55">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={chartRows} margin={{ top: 5, right: 12, left: 0, bottom: 0 }}>
+            <CartesianGrid stroke="rgba(255,255,255,0.06)" vertical={false} />
+            <XAxis
+              dataKey="date"
+              tick={{ fontSize: 10, fill: "var(--text-muted)" }}
+              axisLine={false}
+              tickLine={false}
+              interval={Math.max(Math.floor(chartRows.length / 8), 0)}
+            />
+            <YAxis
+              tick={{ fontSize: 10, fill: "var(--text-muted)" }}
+              axisLine={false}
+              tickLine={false}
+              tickFormatter={(value) => currencyFormatter.format(value).replace(".00", "")}
+              width={48}
+            />
+            <Tooltip
+              formatter={(value: number) => currencyFormatter.format(value || 0)}
+              contentStyle={{
+                background: "var(--surface)",
+                border: "1px solid rgba(255,255,255,0.1)",
+                borderRadius: "12px",
+              }}
+            />
+            <Line
+              type="monotone"
+              dataKey="cost"
+              stroke="#10b981"
+              strokeWidth={2.5}
+              dot={false}
+              activeDot={{ r: 4 }}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    </Card>
+  );
+}
+
+export function WeeklyPatternCard({
+  title,
+  rows,
+  locale,
+}: {
+  title: string;
+  rows: Array<{ day: string; avgTokens: number; totalTokens: number }>;
+  locale: string;
+}) {
+  const chartData = rows.map((row) => ({
+    day: row.day,
+    tokens: row.avgTokens || 0,
+  }));
+
+  return (
+    <Card className="p-5">
+      <h3 className="text-sm font-semibold text-text-muted uppercase tracking-wide mb-4">
+        {title}
+      </h3>
+      <div className="h-40">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={chartData} margin={{ top: 5, right: 5, left: 0, bottom: 0 }}>
+            <XAxis
+              dataKey="day"
+              tick={{ fontSize: 11, fill: "var(--text-muted)" }}
+              axisLine={false}
+              tickLine={false}
+            />
+            <YAxis
+              tick={{ fontSize: 10, fill: "var(--text-muted)" }}
+              axisLine={false}
+              tickLine={false}
+              tickFormatter={(value) =>
+                new Intl.NumberFormat(locale, {
+                  notation: "compact",
+                }).format(Number(value || 0))
+              }
+              width={40}
+            />
+            <Tooltip
+              formatter={(value: number) =>
+                `${new Intl.NumberFormat(locale).format(value || 0)} tokens`
+              }
+              contentStyle={{
+                background: "var(--surface)",
+                border: "1px solid rgba(255,255,255,0.1)",
+                borderRadius: "12px",
+              }}
+            />
+            <Bar dataKey="tokens" fill="#8b5cf6" radius={[4, 4, 0, 0]} />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </Card>
+  );
+}

--- a/src/app/(dashboard)/dashboard/costs/quota-share/components/BurnRateChart.tsx
+++ b/src/app/(dashboard)/dashboard/costs/quota-share/components/BurnRateChart.tsx
@@ -1,114 +1,16 @@
 "use client";
 
-import { useState } from "react";
 import dynamic from "next/dynamic";
-import { useTranslations } from "next-intl";
 import type { PoolUsageSnapshot } from "@/lib/quota/types";
 
-// Lazy-load recharts — do NOT import at module level (B28)
-const RechartsLineChart = dynamic(
-  () => import("recharts").then((m) => ({ default: m.LineChart })),
-  { ssr: false }
-);
-const RechartsLine = dynamic(() => import("recharts").then((m) => ({ default: m.Line })), {
+const BurnRateChartInner = dynamic(() => import("./BurnRateChartInner"), {
   ssr: false,
 });
-const RechartsXAxis = dynamic(() => import("recharts").then((m) => ({ default: m.XAxis })), {
-  ssr: false,
-});
-const RechartsYAxis = dynamic(() => import("recharts").then((m) => ({ default: m.YAxis })), {
-  ssr: false,
-});
-const RechartsTooltip = dynamic(() => import("recharts").then((m) => ({ default: m.Tooltip })), {
-  ssr: false,
-});
-const RechartsResponsiveContainer = dynamic(
-  () => import("recharts").then((m) => ({ default: m.ResponsiveContainer })),
-  { ssr: false }
-);
 
 export interface BurnRateChartProps {
   usage: PoolUsageSnapshot | null;
 }
 
 export default function BurnRateChart({ usage }: BurnRateChartProps) {
-  const t = useTranslations("quotaShare");
-  // Capture mount time once — avoids impure Date.now() call on every render
-  const [nowMs] = useState(() => Date.now());
-
-  const burnRate = usage?.burnRate;
-  const hasData = burnRate && burnRate.tokensPerSecond > 0;
-
-  if (!hasData) {
-    return (
-      <div className="h-20 flex items-center justify-center rounded-md bg-bg-subtle/30 border border-border/30">
-        <p className="text-[11px] text-text-muted italic">{t("burnRateTitle")} — no data yet</p>
-      </div>
-    );
-  }
-
-  const { tokensPerSecond, timeToExhaustionMs } = burnRate;
-
-  // Build a simple 6-point projection line
-  const pointCount = 6;
-  const intervalMs = timeToExhaustionMs ? timeToExhaustionMs / pointCount : 60_000 * 60;
-
-  const primaryDim = usage?.dimensions?.[0];
-  const currentConsumed = primaryDim?.consumedTotal ?? 0;
-  const limit = primaryDim?.limit ?? 0;
-
-  const data = Array.from({ length: pointCount + 1 }, (_, i) => {
-    const t2 = nowMs + i * intervalMs;
-    const projected = Math.min(currentConsumed + tokensPerSecond * ((i * intervalMs) / 1000), limit);
-    return {
-      time: new Date(t2).toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" }),
-      consumed: Math.round(projected),
-    };
-  });
-
-  const exhaustionLabel = timeToExhaustionMs
-    ? `${t("burnRateExhaustsIn")} ${fmtDuration(timeToExhaustionMs)}`
-    : null;
-
-  return (
-    <div className="space-y-1">
-      <div className="flex items-center justify-between text-[10px] text-text-muted">
-        <span className="font-semibold uppercase tracking-wide">{t("burnRateTitle")}</span>
-        {exhaustionLabel && <span className="text-amber-400 font-semibold">{exhaustionLabel}</span>}
-      </div>
-      <div className="h-24">
-        <RechartsResponsiveContainer width="100%" height="100%">
-          <RechartsLineChart data={data}>
-            <RechartsXAxis dataKey="time" tick={{ fontSize: 9 }} tickLine={false} axisLine={false} />
-            <RechartsYAxis hide />
-            <RechartsTooltip
-              contentStyle={{
-                background: "var(--bg-surface, #1e1e2e)",
-                border: "1px solid var(--border)",
-                fontSize: 10,
-              }}
-            />
-            <RechartsLine
-              type="monotone"
-              dataKey="consumed"
-              stroke="#a78bfa"
-              strokeWidth={2}
-              dot={false}
-              strokeDasharray="4 2"
-            />
-          </RechartsLineChart>
-        </RechartsResponsiveContainer>
-      </div>
-    </div>
-  );
-}
-
-function fmtDuration(ms: number): string {
-  const h = Math.floor(ms / 3_600_000);
-  const m = Math.floor((ms % 3_600_000) / 60_000);
-  if (h >= 24) {
-    const d = Math.floor(h / 24);
-    return `${d}d ${h % 24}h`;
-  }
-  return `${h}h ${m}m`;
+  return <BurnRateChartInner usage={usage} />;
 }

--- a/src/app/(dashboard)/dashboard/costs/quota-share/components/BurnRateChartInner.tsx
+++ b/src/app/(dashboard)/dashboard/costs/quota-share/components/BurnRateChartInner.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from "recharts";
+import type { PoolUsageSnapshot } from "@/lib/quota/types";
+
+export interface BurnRateChartInnerProps {
+  usage: PoolUsageSnapshot | null;
+}
+
+export default function BurnRateChartInner({ usage }: BurnRateChartInnerProps) {
+  const t = useTranslations("quotaShare");
+  const [nowMs] = useState(() => Date.now());
+
+  const burnRate = usage?.burnRate;
+  const hasData = burnRate && burnRate.tokensPerSecond > 0;
+
+  if (!hasData) {
+    return (
+      <div className="h-20 flex items-center justify-center rounded-md bg-bg-subtle/30 border border-border/30">
+        <p className="text-[11px] text-text-muted italic">{t("burnRateTitle")} — no data yet</p>
+      </div>
+    );
+  }
+
+  const { tokensPerSecond, timeToExhaustionMs } = burnRate;
+
+  const pointCount = 6;
+  const intervalMs = timeToExhaustionMs ? timeToExhaustionMs / pointCount : 60_000 * 60;
+
+  const primaryDim = usage?.dimensions?.[0];
+  const currentConsumed = primaryDim?.consumedTotal ?? 0;
+  const limit = primaryDim?.limit ?? 0;
+
+  const data = Array.from({ length: pointCount + 1 }, (_, i) => {
+    const t2 = nowMs + i * intervalMs;
+    const projected = Math.min(
+      currentConsumed + tokensPerSecond * ((i * intervalMs) / 1000),
+      limit
+    );
+    return {
+      time: new Date(t2).toLocaleTimeString(undefined, {
+        hour: "2-digit",
+        minute: "2-digit",
+      }),
+      consumed: Math.round(projected),
+    };
+  });
+
+  const exhaustionLabel = timeToExhaustionMs
+    ? `${t("burnRateExhaustsIn")} ${fmtDuration(timeToExhaustionMs)}`
+    : null;
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between text-[10px] text-text-muted">
+        <span className="font-semibold uppercase tracking-wide">{t("burnRateTitle")}</span>
+        {exhaustionLabel && <span className="text-amber-400 font-semibold">{exhaustionLabel}</span>}
+      </div>
+      <div className="h-24">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={data}>
+            <XAxis dataKey="time" tick={{ fontSize: 9 }} tickLine={false} axisLine={false} />
+            <YAxis hide />
+            <Tooltip
+              contentStyle={{
+                background: "var(--bg-surface, #1e1e2e)",
+                border: "1px solid var(--border)",
+                fontSize: 10,
+              }}
+            />
+            <Line
+              type="monotone"
+              dataKey="consumed"
+              stroke="#a78bfa"
+              strokeWidth={2}
+              dot={false}
+              strokeDasharray="4 2"
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}
+
+function fmtDuration(ms: number): string {
+  const h = Math.floor(ms / 3_600_000);
+  const m = Math.floor((ms % 3_600_000) / 60_000);
+  if (h >= 24) {
+    const d = Math.floor(h / 24);
+    return `${d}d ${h % 24}h`;
+  }
+  return `${h}h ${m}m`;
+}

--- a/src/app/api/combos/route.ts
+++ b/src/app/api/combos/route.ts
@@ -1,5 +1,11 @@
 import { NextResponse } from "next/server";
-import { getCombos, createCombo, getComboByName, isCloudEnabled } from "@/lib/localDb";
+import {
+  getCombos,
+  getCombosCount,
+  createCombo,
+  getComboByName,
+  isCloudEnabled,
+} from "@/lib/localDb";
 import { getConsistentMachineId } from "@/shared/utils/machineId";
 import { syncToCloud } from "@/lib/cloudSync";
 import { validateCompositeTiersConfig } from "@/lib/combos/compositeTiers";
@@ -16,8 +22,19 @@ export async function GET(request: Request) {
   if (authError) return authError;
 
   try {
-    const combos = await getCombos();
-    return NextResponse.json({ combos });
+    const url = new URL(request.url);
+    const limitValue = url.searchParams.get("limit");
+    const offsetValue = url.searchParams.get("offset");
+    const parsedLimit = limitValue ? Number.parseInt(limitValue, 10) : undefined;
+    const parsedOffset = offsetValue ? Number.parseInt(offsetValue, 10) : undefined;
+    const limit =
+      Number.isInteger(parsedLimit) && parsedLimit && parsedLimit > 0 ? parsedLimit : undefined;
+    const offset =
+      Number.isInteger(parsedOffset) && parsedOffset && parsedOffset > 0 ? parsedOffset : undefined;
+
+    const total = getCombosCount();
+    const combos = await getCombos(limit, offset);
+    return NextResponse.json({ combos, total });
   } catch (error) {
     console.log("Error fetching combos:", error);
     return NextResponse.json({ error: "Failed to fetch combos" }, { status: 500 });

--- a/src/app/api/keys/route.ts
+++ b/src/app/api/keys/route.ts
@@ -1,5 +1,11 @@
 import { NextResponse } from "next/server";
-import { getApiKeys, createApiKey, isCloudEnabled, updateApiKeyPermissions } from "@/lib/localDb";
+import {
+  getApiKeys,
+  getApiKeysCount,
+  createApiKey,
+  isCloudEnabled,
+  updateApiKeyPermissions,
+} from "@/lib/localDb";
 import { getConsistentMachineId } from "@/shared/utils/machineId";
 import { syncToCloud } from "@/lib/cloudSync";
 import { createKeySchema } from "@/shared/validation/schemas";
@@ -30,18 +36,18 @@ export async function GET(request: Request) {
   if (authError) return authError;
 
   try {
-    const keys = await getApiKeys();
+    const { limit, offset } = parsePagination(request);
+    const dbLimit = limit ?? undefined;
+    const total = getApiKeysCount();
+    const keys = await getApiKeys(dbLimit, offset);
     const maskedKeys = keys.map((k) => ({
       ...k,
       key: maskStoredApiKey(k.key),
     }));
-    const { limit, offset } = parsePagination(request);
-    const pagedKeys =
-      limit === null ? maskedKeys.slice(offset) : maskedKeys.slice(offset, offset + limit);
 
     return NextResponse.json({
-      keys: pagedKeys,
-      total: maskedKeys.length,
+      keys: maskedKeys,
+      total,
       allowKeyReveal: isApiKeyRevealEnabled(),
     });
   } catch (error) {

--- a/src/app/api/model-combo-mappings/route.ts
+++ b/src/app/api/model-combo-mappings/route.ts
@@ -23,9 +23,12 @@ export async function GET(request: Request) {
   if (authError) return authError;
 
   try {
-    const mappings = await getModelComboMappings();
-    return NextResponse.json({ mappings });
-  } catch (error: any) {
+    const { searchParams } = new URL(request.url);
+    const limit = searchParams.has("limit") ? Number(searchParams.get("limit")) : undefined;
+    const offset = searchParams.has("offset") ? Number(searchParams.get("offset")) : 0;
+    const result = await getModelComboMappings(limit !== undefined ? { limit, offset } : undefined);
+    return NextResponse.json({ mappings: result.items, total: result.total });
+  } catch (error) {
     console.error("Failed to list model-combo mappings:", error);
     return NextResponse.json({ error: "Failed to list model-combo mappings" }, { status: 500 });
   }

--- a/src/app/api/model-combo-mappings/route.ts
+++ b/src/app/api/model-combo-mappings/route.ts
@@ -29,7 +29,8 @@ export async function GET(request: Request) {
     const result = await getModelComboMappings(
       limit !== undefined || offset !== undefined ? { limit, offset } : undefined
     );
-    return NextResponse.json({ mappings: result.items, total: result.total });
+    const paged = Array.isArray(result) ? { items: result, total: result.length } : result;
+    return NextResponse.json({ mappings: paged.items, total: paged.total });
   } catch (error) {
     console.error("Failed to list model-combo mappings:", error);
     return NextResponse.json({ error: "Failed to list model-combo mappings" }, { status: 500 });

--- a/src/app/api/model-combo-mappings/route.ts
+++ b/src/app/api/model-combo-mappings/route.ts
@@ -26,7 +26,9 @@ export async function GET(request: Request) {
     const { searchParams } = new URL(request.url);
     const limit = searchParams.has("limit") ? Number(searchParams.get("limit")) : undefined;
     const offset = searchParams.has("offset") ? Number(searchParams.get("offset")) : 0;
-    const result = await getModelComboMappings(limit !== undefined ? { limit, offset } : undefined);
+    const result = await getModelComboMappings(
+      limit !== undefined || offset !== undefined ? { limit, offset } : undefined
+    );
     return NextResponse.json({ mappings: result.items, total: result.total });
   } catch (error) {
     console.error("Failed to list model-combo mappings:", error);

--- a/src/app/api/playground/presets/route.ts
+++ b/src/app/api/playground/presets/route.ts
@@ -63,8 +63,11 @@ export async function GET(request: Request): Promise<Response> {
   if (authError) return authError;
 
   try {
-    const presets = listPlaygroundPresets();
-    return new Response(JSON.stringify({ presets }), {
+    const { searchParams } = new URL(request.url);
+    const limit = searchParams.has("limit") ? Number(searchParams.get("limit")) : undefined;
+    const offset = searchParams.has("offset") ? Number(searchParams.get("offset")) : 0;
+    const result = listPlaygroundPresets(limit !== undefined ? { limit, offset } : undefined);
+    return new Response(JSON.stringify({ presets: result.items, total: result.total }), {
       status: 200,
       headers: { "Content-Type": "application/json", ...CORS_HEADERS },
     });

--- a/src/app/api/playground/presets/route.ts
+++ b/src/app/api/playground/presets/route.ts
@@ -66,7 +66,9 @@ export async function GET(request: Request): Promise<Response> {
     const { searchParams } = new URL(request.url);
     const limit = searchParams.has("limit") ? Number(searchParams.get("limit")) : undefined;
     const offset = searchParams.has("offset") ? Number(searchParams.get("offset")) : 0;
-    const result = listPlaygroundPresets(limit !== undefined ? { limit, offset } : undefined);
+    const result = listPlaygroundPresets(
+      limit !== undefined || offset !== undefined ? { limit, offset } : undefined
+    );
     return new Response(JSON.stringify({ presets: result.items, total: result.total }), {
       status: 200,
       headers: { "Content-Type": "application/json", ...CORS_HEADERS },

--- a/src/app/api/playground/presets/route.ts
+++ b/src/app/api/playground/presets/route.ts
@@ -69,7 +69,8 @@ export async function GET(request: Request): Promise<Response> {
     const result = listPlaygroundPresets(
       limit !== undefined || offset !== undefined ? { limit, offset } : undefined
     );
-    return new Response(JSON.stringify({ presets: result.items, total: result.total }), {
+    const paged = Array.isArray(result) ? { items: result, total: result.length } : result;
+    return new Response(JSON.stringify({ presets: paged.items, total: paged.total }), {
       status: 200,
       headers: { "Content-Type": "application/json", ...CORS_HEADERS },
     });

--- a/src/app/api/provider-nodes/route.ts
+++ b/src/app/api/provider-nodes/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { createProviderNode, getProviderNodes } from "@/models";
+import { createProviderNode, getProviderNodes, getProviderNodesCount } from "@/models";
 import {
   OPENAI_COMPATIBLE_PREFIX,
   ANTHROPIC_COMPATIBLE_PREFIX,
@@ -34,11 +34,23 @@ function sanitizeClaudeCodeCompatibleBaseUrl(baseUrl: string) {
 }
 
 // GET /api/provider-nodes - List all provider nodes
-export async function GET() {
+export async function GET(request?: Request) {
   try {
-    const nodes = await getProviderNodes();
+    const url = new URL(request?.url ?? "http://localhost/api/provider-nodes");
+    const limitValue = url.searchParams.get("limit");
+    const offsetValue = url.searchParams.get("offset");
+    const parsedLimit = limitValue ? Number.parseInt(limitValue, 10) : undefined;
+    const parsedOffset = offsetValue ? Number.parseInt(offsetValue, 10) : undefined;
+    const limit =
+      Number.isInteger(parsedLimit) && parsedLimit && parsedLimit > 0 ? parsedLimit : undefined;
+    const offset =
+      Number.isInteger(parsedOffset) && parsedOffset && parsedOffset > 0 ? parsedOffset : 0;
+
+    const total = getProviderNodesCount();
+    const nodes = await getProviderNodes({}, limit, offset);
     return NextResponse.json({
       nodes,
+      total,
       ccCompatibleProviderEnabled: isCcCompatibleProviderEnabled(),
     });
   } catch (error) {

--- a/src/app/api/providers/route.ts
+++ b/src/app/api/providers/route.ts
@@ -6,6 +6,7 @@ import {
 } from "@/lib/compliance/providerAudit";
 import {
   getProviderConnections,
+  getProviderConnectionsCount,
   createProviderConnection,
   deleteProviderConnections,
   updateProviderConnection,
@@ -44,7 +45,18 @@ export async function GET(request: Request) {
   if (authError) return authError;
 
   try {
-    const connections = await getProviderConnections();
+    const url = new URL(request.url);
+    const limitValue = url.searchParams.get("limit");
+    const offsetValue = url.searchParams.get("offset");
+    const parsedLimit = limitValue ? Number.parseInt(limitValue, 10) : undefined;
+    const parsedOffset = offsetValue ? Number.parseInt(offsetValue, 10) : undefined;
+    const limit =
+      Number.isInteger(parsedLimit) && parsedLimit && parsedLimit > 0 ? parsedLimit : undefined;
+    const offset =
+      Number.isInteger(parsedOffset) && parsedOffset && parsedOffset > 0 ? parsedOffset : 0;
+
+    const connections = await getProviderConnections({}, limit, offset);
+    const total = getProviderConnectionsCount();
     const revealKeys = isApiKeyRevealEnabled();
 
     // Hide or mask sensitive fields
@@ -59,7 +71,7 @@ export async function GET(request: Request) {
         : undefined,
     }));
 
-    return NextResponse.json({ connections: safeConnections });
+    return NextResponse.json({ connections: safeConnections, total });
   } catch (error) {
     console.log("Error fetching providers:", error);
     return NextResponse.json({ error: "Failed to fetch providers" }, { status: 500 });

--- a/src/app/api/quota/pools/route.ts
+++ b/src/app/api/quota/pools/route.ts
@@ -26,8 +26,11 @@ export async function GET(request: Request): Promise<Response> {
   if (authError) return authError;
 
   try {
-    const pools = listPools();
-    return NextResponse.json({ pools });
+    const { searchParams } = new URL(request.url);
+    const limit = searchParams.has("limit") ? Number(searchParams.get("limit")) : undefined;
+    const offset = searchParams.has("offset") ? Number(searchParams.get("offset")) : 0;
+    const result = listPools(limit !== undefined ? { limit, offset } : undefined);
+    return NextResponse.json({ pools: result.items, total: result.total });
   } catch (err) {
     const message = err instanceof Error ? err.message : "Failed to list pools";
     return NextResponse.json(buildErrorBody(500, message), { status: 500 });

--- a/src/app/api/quota/pools/route.ts
+++ b/src/app/api/quota/pools/route.ts
@@ -29,7 +29,9 @@ export async function GET(request: Request): Promise<Response> {
     const { searchParams } = new URL(request.url);
     const limit = searchParams.has("limit") ? Number(searchParams.get("limit")) : undefined;
     const offset = searchParams.has("offset") ? Number(searchParams.get("offset")) : 0;
-    const result = listPools(limit !== undefined ? { limit, offset } : undefined);
+    const result = listPools(
+      limit !== undefined || offset !== undefined ? { limit, offset } : undefined
+    );
     return NextResponse.json({ pools: result.items, total: result.total });
   } catch (err) {
     const message = err instanceof Error ? err.message : "Failed to list pools";

--- a/src/app/api/settings/proxies/auto-test/route.ts
+++ b/src/app/api/settings/proxies/auto-test/route.ts
@@ -28,7 +28,12 @@ interface TestResult {
   error?: string;
 }
 
-async function testSingleProxy(proxy: { id: string; type: string; host: string; port: number }): Promise<TestResult> {
+async function testSingleProxy(proxy: {
+  id: string;
+  type: string;
+  host: string;
+  port: number;
+}): Promise<TestResult> {
   const proxyUrl = `${proxy.type}://${proxy.host}:${proxy.port}`;
   const start = Date.now();
   const controller = new AbortController();
@@ -84,13 +89,18 @@ export async function POST(request: Request) {
 
   const validation = validateBody(autoTestSchema, rawBody);
   if (isValidationFailure(validation)) {
-    return createErrorResponse({ status: 400, message: validation.error.message, type: "invalid_request" });
+    return createErrorResponse({
+      status: 400,
+      message: validation.error.message,
+      type: "invalid_request",
+    });
   }
 
   const { ids: specificIds, autoRemove } = validation.data;
 
   try {
-    const allProxies = await listProxies({ includeSecrets: false });
+    const result = await listProxies({ includeSecrets: false });
+    const allProxies = result.items;
     const proxiesToTest = specificIds
       ? allProxies.filter((p) => specificIds.includes(p.id))
       : allProxies;
@@ -114,7 +124,9 @@ export async function POST(request: Request) {
         if (!r.alive) {
           try {
             if (await deleteProxyById(r.proxyId, { force: true })) removed.push(r.proxyId);
-          } catch { /* skip */ }
+          } catch {
+            /* skip */
+          }
         }
       }
     }

--- a/src/app/api/settings/proxies/route.ts
+++ b/src/app/api/settings/proxies/route.ts
@@ -28,7 +28,7 @@ export async function GET(request: Request) {
     // redeploy). The secrets themselves never leave the server — we redact each
     // row before responding and only surface the derived relayInfo booleans.
     const rawProxies = await listProxies({ includeSecrets: true });
-    const items = rawProxies.map((p) => ({
+    const items = rawProxies.items.map((p) => ({
       ...redactProxySecrets(p),
       relayInfo: {
         isRelay: isRelayProxyType(p.type),
@@ -38,7 +38,7 @@ export async function GET(request: Request) {
     }));
     return Response.json({
       items,
-      total: items.length,
+      total: rawProxies.total,
       // #5890: coarse relay health pulse for the dashboard — how many relay
       // probes have run, and how many came back alive.
       relayProbeStats: getRelayProbeStats(),

--- a/src/app/api/settings/proxies/route.ts
+++ b/src/app/api/settings/proxies/route.ts
@@ -28,7 +28,8 @@ export async function GET(request: Request) {
     // redeploy). The secrets themselves never leave the server — we redact each
     // row before responding and only surface the derived relayInfo booleans.
     const rawProxies = await listProxies({ includeSecrets: true });
-    const items = rawProxies.items.map((p) => ({
+    const rawItems = Array.isArray(rawProxies) ? rawProxies : rawProxies.items;
+    const items = rawItems.map((p) => ({
       ...redactProxySecrets(p),
       relayInfo: {
         isRelay: isRelayProxyType(p.type),
@@ -38,7 +39,7 @@ export async function GET(request: Request) {
     }));
     return Response.json({
       items,
-      total: rawProxies.total,
+      total: Array.isArray(rawProxies) ? rawProxies.length : rawProxies.total,
       // #5890: coarse relay health pulse for the dashboard — how many relay
       // probes have run, and how many came back alive.
       relayProbeStats: getRelayProbeStats(),

--- a/src/app/api/v1/management/proxies/route.ts
+++ b/src/app/api/v1/management/proxies/route.ts
@@ -24,11 +24,10 @@ export async function GET(request: Request) {
     if (lookupResponse) return lookupResponse;
 
     const { limit, offset } = toPagination(searchParams);
-    const items = await listProxies({ includeSecrets: false });
-    const paged = items.slice(offset, offset + limit);
+    const result = await listProxies({ includeSecrets: false, limit, offset });
     return Response.json({
-      items: paged,
-      page: { limit, offset, total: items.length },
+      items: result.items,
+      page: { limit, offset, total: result.total },
     });
   } catch (error) {
     return createErrorResponseFromUnknown(error, "Failed to load proxies");

--- a/src/app/api/webhooks/route.ts
+++ b/src/app/api/webhooks/route.ts
@@ -43,13 +43,16 @@ export async function GET(request: Request) {
   if (authError) return authError;
 
   try {
-    const webhooks = getWebhooks();
+    const { searchParams } = new URL(request.url);
+    const limit = searchParams.has("limit") ? Number(searchParams.get("limit")) : undefined;
+    const offset = searchParams.has("offset") ? Number(searchParams.get("offset")) : 0;
+    const result = getWebhooks(limit !== undefined ? { limit, offset } : undefined);
     // Mask secrets in listing
-    const masked = webhooks.map((w) => ({
+    const masked = result.webhooks.map((w) => ({
       ...w,
       secret: w.secret ? `${w.secret.slice(0, 10)}...` : null,
     }));
-    return NextResponse.json({ webhooks: masked });
+    return NextResponse.json({ webhooks: masked, total: result.total });
   } catch (error: any) {
     return NextResponse.json(
       { error: sanitizeErrorMessage(error) || "Failed to list webhooks" },

--- a/src/app/api/webhooks/route.ts
+++ b/src/app/api/webhooks/route.ts
@@ -46,7 +46,9 @@ export async function GET(request: Request) {
     const { searchParams } = new URL(request.url);
     const limit = searchParams.has("limit") ? Number(searchParams.get("limit")) : undefined;
     const offset = searchParams.has("offset") ? Number(searchParams.get("offset")) : 0;
-    const result = getWebhooks(limit !== undefined ? { limit, offset } : undefined);
+    const result = getWebhooks(
+      limit !== undefined || offset !== undefined ? { limit, offset } : undefined
+    );
     // Mask secrets in listing
     const masked = result.webhooks.map((w) => ({
       ...w,

--- a/src/app/api/webhooks/route.ts
+++ b/src/app/api/webhooks/route.ts
@@ -50,11 +50,12 @@ export async function GET(request: Request) {
       limit !== undefined || offset !== undefined ? { limit, offset } : undefined
     );
     // Mask secrets in listing
-    const masked = result.webhooks.map((w) => ({
+    const paged = Array.isArray(result) ? { webhooks: result, total: result.length } : result;
+    const masked = paged.webhooks.map((w) => ({
       ...w,
       secret: w.secret ? `${w.secret.slice(0, 10)}...` : null,
     }));
-    return NextResponse.json({ webhooks: masked, total: result.total });
+    return NextResponse.json({ webhooks: masked, total: paged.total });
   } catch (error: any) {
     return NextResponse.json(
       { error: sanitizeErrorMessage(error) || "Failed to list webhooks" },

--- a/src/lib/db/apiKeys.ts
+++ b/src/lib/db/apiKeys.ts
@@ -427,10 +427,16 @@ function getPreparedStatements(db: ApiKeysDbLike): ApiKeysStatements {
   };
 }
 
-export async function getApiKeys() {
+export async function getApiKeys(limit?: number, offset?: number) {
   const db = getDbInstance() as ApiKeysDbLike;
-  const stmt = getPreparedStatements(db);
-  const rows = stmt.getAllKeys.all();
+  let rows: ApiKeyRow[];
+  if (limit !== undefined) {
+    const sql = "SELECT * FROM api_keys ORDER BY created_at LIMIT ? OFFSET ?";
+    rows = db.prepare(sql).all(limit, offset ?? 0) as ApiKeyRow[];
+  } else {
+    const stmt = getPreparedStatements(db);
+    rows = stmt.getAllKeys.all();
+  }
   return rows.map((row) => {
     const camelRow = toRecord(rowToCamel(row)) as ApiKeyView;
     camelRow.allowedModels = parseAllowedModels(camelRow.allowedModels);
@@ -460,6 +466,12 @@ export async function getApiKeys() {
   });
 }
 
+export function getApiKeysCount(): number {
+  const db = getDbInstance() as ApiKeysDbLike;
+  const row = db.prepare("SELECT count(*) as cnt FROM api_keys").get() as { cnt: number };
+  return row.cnt;
+}
+
 /**
  * Select an API key for internal OmniRoute operations (combo health checks,
  * cloud-sync verify pings, etc.).
@@ -485,10 +497,7 @@ export async function getApiKeys() {
  * inactive, or banned key, and it never widens a key's allowedModels.
  */
 export async function pickApiKeyForInternalUse(
-  purpose:
-    | "combo-health-check"
-    | "cloud-sync-verify"
-    | "internal-probe" = "internal-probe"
+  purpose: "combo-health-check" | "cloud-sync-verify" | "internal-probe" = "internal-probe"
 ): Promise<string | null> {
   try {
     const keys = (await getApiKeys()) as Array<{
@@ -506,29 +515,23 @@ export async function pickApiKeyForInternalUse(
 
     // 1. Management-scoped key (preferred for any internal probe).
     const manageKey = keys.find(
-      (k) =>
-        isUsable(k) && Array.isArray(k.scopes) && k.scopes.includes("manage"),
+      (k) => isUsable(k) && Array.isArray(k.scopes) && k.scopes.includes("manage")
     );
     if (manageKey?.key) return manageKey.key;
 
     // 2. Allow-all key (empty allowedModels means no model restrictions).
     const allowAllKey = keys.find(
-      (k) =>
-        isUsable(k) &&
-        Array.isArray(k.allowedModels) &&
-        k.allowedModels.length === 0,
+      (k) => isUsable(k) && Array.isArray(k.allowedModels) && k.allowedModels.length === 0
     );
     if (allowAllKey?.key) return allowAllKey.key;
 
     // 3. Most recently used (proxy for "the user actually wants this one
     //    working right now").
-    const byRecency = [...keys]
-      .filter(isUsable)
-      .sort((a, b) => {
-        const aT = typeof a.lastUsedAt === "number" ? a.lastUsedAt : 0;
-        const bT = typeof b.lastUsedAt === "number" ? b.lastUsedAt : 0;
-        return bT - aT;
-      });
+    const byRecency = [...keys].filter(isUsable).sort((a, b) => {
+      const aT = typeof a.lastUsedAt === "number" ? a.lastUsedAt : 0;
+      const bT = typeof b.lastUsedAt === "number" ? b.lastUsedAt : 0;
+      return bT - aT;
+    });
     if (byRecency[0]?.key) return byRecency[0].key;
 
     // 4. Legacy fallback: first active key. Keeps the function working

--- a/src/lib/db/combos.ts
+++ b/src/lib/db/combos.ts
@@ -91,13 +91,18 @@ function getNextSortOrder() {
   return (sortOrder ?? 0) + 1;
 }
 
-export async function getCombos() {
+export async function getCombos(limit?: number, offset?: number) {
   const db = getDbInstance();
+  let sql =
+    "SELECT data, sort_order, context_cache_protection FROM combos ORDER BY sort_order ASC, name COLLATE NOCASE ASC";
+  const params: unknown[] = [];
+  if (limit !== undefined) {
+    sql += " LIMIT ? OFFSET ?";
+    params.push(limit, offset ?? 0);
+  }
   const rawCombos = db
-    .prepare(
-      "SELECT data, sort_order, context_cache_protection FROM combos ORDER BY sort_order ASC, name COLLATE NOCASE ASC"
-    )
-    .all()
+    .prepare(sql)
+    .all(...params)
     .map((row) => parseComboRow(row))
     .filter((row): row is JsonRecord => row !== null);
 
@@ -110,6 +115,12 @@ export async function getCombos() {
       allCombos: comboNames,
     })
   );
+}
+
+export function getCombosCount(): number {
+  const db = getDbInstance();
+  const row = db.prepare("SELECT count(*) as cnt FROM combos").get() as { cnt: number };
+  return row.cnt;
 }
 
 export async function getComboById(id: string) {

--- a/src/lib/db/modelComboMappings.ts
+++ b/src/lib/db/modelComboMappings.ts
@@ -95,9 +95,9 @@ export async function getModelComboMappings(options?: {
      LEFT JOIN combos c ON c.id = m.combo_id
      ORDER BY m.priority DESC, m.created_at ASC`;
   const params: unknown[] = [];
-  if (limit !== undefined) {
+  if (limit !== undefined || offset > 0) {
     sql += " LIMIT ? OFFSET ?";
-    params.push(limit, offset);
+    params.push(limit ?? -1, offset);
   }
   const rows = db.prepare(sql).all(...params) as MappingRow[];
   const totalRow = db.prepare("SELECT count(*) as cnt FROM model_combo_mappings").get() as {

--- a/src/lib/db/modelComboMappings.ts
+++ b/src/lib/db/modelComboMappings.ts
@@ -81,19 +81,29 @@ function rowToMapping(row: MappingRow): ModelComboMapping {
  * List all model-combo mappings, joined with combo name.
  * Ordered by priority descending (highest first).
  */
-export async function getModelComboMappings(): Promise<ModelComboMapping[]> {
+export async function getModelComboMappings(options?: {
+  limit?: number;
+  offset?: number;
+}): Promise<{ items: ModelComboMapping[]; total: number }> {
   const db = getDbInstance();
-  const rows = db
-    .prepare(
-      `SELECT m.id, m.pattern, m.combo_id, c.name AS combo_name,
-              m.priority, m.enabled, m.description,
-              m.created_at, m.updated_at
-       FROM model_combo_mappings m
-       LEFT JOIN combos c ON c.id = m.combo_id
-       ORDER BY m.priority DESC, m.created_at ASC`
-    )
-    .all() as MappingRow[];
-  return rows.map(rowToMapping);
+  const limit = options?.limit;
+  const offset = options?.offset ?? 0;
+  let sql = `SELECT m.id, m.pattern, m.combo_id, c.name AS combo_name,
+            m.priority, m.enabled, m.description,
+            m.created_at, m.updated_at
+     FROM model_combo_mappings m
+     LEFT JOIN combos c ON c.id = m.combo_id
+     ORDER BY m.priority DESC, m.created_at ASC`;
+  const params: unknown[] = [];
+  if (limit !== undefined) {
+    sql += " LIMIT ? OFFSET ?";
+    params.push(limit, offset);
+  }
+  const rows = db.prepare(sql).all(...params) as MappingRow[];
+  const totalRow = db.prepare("SELECT count(*) as cnt FROM model_combo_mappings").get() as {
+    cnt: number;
+  };
+  return { items: rows.map(rowToMapping), total: totalRow.cnt };
 }
 
 /**

--- a/src/lib/db/playgroundPresets.ts
+++ b/src/lib/db/playgroundPresets.ts
@@ -55,13 +55,26 @@ function rowToItem(row: PlaygroundPresetRow): PlaygroundPresetListItem {
 
 /**
  * Returns all presets ordered by created_at descending (newest first).
+ * Accepts optional limit/offset for pagination.
  */
-export function listPlaygroundPresets(): PlaygroundPresetListItem[] {
+export function listPlaygroundPresets(options?: { limit?: number; offset?: number }): {
+  items: PlaygroundPresetListItem[];
+  total: number;
+} {
   const db = getDbInstance();
-  const rows = db
-    .prepare("SELECT * FROM playground_presets ORDER BY created_at DESC")
-    .all() as PlaygroundPresetRow[];
-  return rows.map(rowToItem);
+  const limit = options?.limit;
+  const offset = options?.offset ?? 0;
+  let sql = "SELECT * FROM playground_presets ORDER BY created_at DESC";
+  const params: unknown[] = [];
+  if (limit !== undefined) {
+    sql += " LIMIT ? OFFSET ?";
+    params.push(limit, offset);
+  }
+  const rows = db.prepare(sql).all(...params) as PlaygroundPresetRow[];
+  const totalRow = db.prepare("SELECT count(*) as cnt FROM playground_presets").get() as {
+    cnt: number;
+  };
+  return { items: rows.map(rowToItem), total: totalRow.cnt };
 }
 
 /**
@@ -69,9 +82,8 @@ export function listPlaygroundPresets(): PlaygroundPresetListItem[] {
  */
 export function getPlaygroundPreset(id: string): PlaygroundPresetListItem | null {
   const db = getDbInstance();
-  const row = db
-    .prepare("SELECT * FROM playground_presets WHERE id = ? LIMIT 1")
-    .get(id) as PlaygroundPresetRow | undefined;
+  const row = db.prepare("SELECT * FROM playground_presets WHERE id = ? LIMIT 1").get(id) as
+    PlaygroundPresetRow | undefined;
   if (!row) return null;
   return rowToItem(row);
 }

--- a/src/lib/db/playgroundPresets.ts
+++ b/src/lib/db/playgroundPresets.ts
@@ -57,10 +57,8 @@ function rowToItem(row: PlaygroundPresetRow): PlaygroundPresetListItem {
  * Returns all presets ordered by created_at descending (newest first).
  * Accepts optional limit/offset for pagination.
  */
-export function listPlaygroundPresets(options?: { limit?: number; offset?: number }): {
-  items: PlaygroundPresetListItem[];
-  total: number;
-} {
+export function listPlaygroundPresets(options?: { limit?: number; offset?: number }):
+  PlaygroundPresetListItem[] | { items: PlaygroundPresetListItem[]; total: number } {
   const db = getDbInstance();
   const limit = options?.limit;
   const offset = options?.offset ?? 0;
@@ -74,7 +72,10 @@ export function listPlaygroundPresets(options?: { limit?: number; offset?: numbe
   const totalRow = db.prepare("SELECT count(*) as cnt FROM playground_presets").get() as {
     cnt: number;
   };
-  return { items: rows.map(rowToItem), total: totalRow.cnt };
+  if (limit !== undefined || offset > 0) {
+    return { items: rows.map(rowToItem), total: totalRow.cnt };
+  }
+  return rows.map(rowToItem);
 }
 
 /**

--- a/src/lib/db/playgroundPresets.ts
+++ b/src/lib/db/playgroundPresets.ts
@@ -66,9 +66,9 @@ export function listPlaygroundPresets(options?: { limit?: number; offset?: numbe
   const offset = options?.offset ?? 0;
   let sql = "SELECT * FROM playground_presets ORDER BY created_at DESC";
   const params: unknown[] = [];
-  if (limit !== undefined) {
+  if (limit !== undefined || offset > 0) {
     sql += " LIMIT ? OFFSET ?";
-    params.push(limit, offset);
+    params.push(limit ?? -1, offset);
   }
   const rows = db.prepare(sql).all(...params) as PlaygroundPresetRow[];
   const totalRow = db.prepare("SELECT count(*) as cnt FROM playground_presets").get() as {

--- a/src/lib/db/providers.ts
+++ b/src/lib/db/providers.ts
@@ -41,7 +41,11 @@ interface DbLike {
 
 // ──────────────── Provider Connections ────────────────
 
-export async function getProviderConnections(filter: JsonRecord = {}) {
+export async function getProviderConnections(
+  filter: JsonRecord = {},
+  limit?: number,
+  offset?: number
+) {
   const db = getDbInstance() as unknown as DbLike;
   let sql = "SELECT * FROM provider_connections";
   const conditions: string[] = [];
@@ -64,6 +68,11 @@ export async function getProviderConnections(filter: JsonRecord = {}) {
     sql += " WHERE " + conditions.join(" AND ");
   }
   sql += " ORDER BY priority ASC, updated_at DESC";
+  if (limit !== undefined) {
+    sql += " LIMIT @limit OFFSET @offset";
+    params.limit = limit;
+    params.offset = offset ?? 0;
+  }
 
   const rows = db.prepare(sql).all(params);
   return rows.map((r) => {
@@ -78,6 +87,33 @@ export async function getProviderConnections(filter: JsonRecord = {}) {
       )
     );
   });
+}
+
+export function getProviderConnectionsCount(filter: JsonRecord = {}): number {
+  const db = getDbInstance() as unknown as DbLike;
+  let sql = "SELECT count(*) as cnt FROM provider_connections";
+  const conditions: string[] = [];
+  const params: Record<string, unknown> = {};
+
+  if (filter.provider) {
+    conditions.push("provider = @provider");
+    params.provider = filter.provider;
+  }
+  if (filter.isActive !== undefined) {
+    conditions.push("is_active = @isActive");
+    params.isActive = filter.isActive ? 1 : 0;
+  }
+  if (filter.authType) {
+    conditions.push("auth_type = @authType");
+    params.authType = filter.authType;
+  }
+
+  if (conditions.length > 0) {
+    sql += " WHERE " + conditions.join(" AND ");
+  }
+
+  const row = db.prepare(sql).get(params) as { cnt: number };
+  return row.cnt;
 }
 
 export async function getProviderConnectionById(id: string) {
@@ -617,8 +653,9 @@ export async function clearConnectionErrorIfUnchanged(
   }
 ): Promise<boolean> {
   const db = getDbInstance() as unknown as DbLike;
-  const result = db.prepare(
-    `
+  const result = db
+    .prepare(
+      `
     UPDATE provider_connections SET
       test_status = 'active',
       last_error = NULL,
@@ -634,13 +671,14 @@ export async function clearConnectionErrorIfUnchanged(
       AND IFNULL(last_error_at, '') = ?
       AND IFNULL(rate_limited_until, '') = ?
     `
-  ).run(
-    new Date().toISOString(),
-    id,
-    expected.testStatus ?? "",
-    expected.lastErrorAt ?? "",
-    expected.rateLimitedUntil ?? ""
-  );
+    )
+    .run(
+      new Date().toISOString(),
+      id,
+      expected.testStatus ?? "",
+      expected.lastErrorAt ?? "",
+      expected.rateLimitedUntil ?? ""
+    );
   const applied = (result.changes ?? 0) > 0;
   if (applied) {
     backupDbFile("pre-write");
@@ -808,6 +846,7 @@ export function autoMigrateLegacyEncryptedConnections(): number {
 
 export {
   getProviderNodes,
+  getProviderNodesCount,
   getProviderNodeById,
   resolveProviderNodeForConnection,
   createProviderNode,

--- a/src/lib/db/providers/nodes.ts
+++ b/src/lib/db/providers/nodes.ts
@@ -18,7 +18,7 @@ interface DbLike {
   prepare: <TRow = unknown>(sql: string) => StatementLike<TRow>;
 }
 
-export async function getProviderNodes(filter: JsonRecord = {}) {
+export async function getProviderNodes(filter: JsonRecord = {}, limit?: number, offset?: number) {
   const db = getDbInstance() as unknown as DbLike;
   let sql = "SELECT * FROM provider_nodes";
   const params: Record<string, unknown> = {};
@@ -27,8 +27,28 @@ export async function getProviderNodes(filter: JsonRecord = {}) {
     sql += " WHERE type = @type";
     params.type = filter.type;
   }
+  sql += " ORDER BY id ASC";
+  if (limit !== undefined) {
+    sql += " LIMIT @limit OFFSET @offset";
+    params.limit = limit;
+    params.offset = offset ?? 0;
+  }
 
   return db.prepare(sql).all(params).map(rowToCamel);
+}
+
+export function getProviderNodesCount(filter: JsonRecord = {}): number {
+  const db = getDbInstance() as unknown as DbLike;
+  let sql = "SELECT count(*) as cnt FROM provider_nodes";
+  const params: Record<string, unknown> = {};
+
+  if (filter.type) {
+    sql += " WHERE type = @type";
+    params.type = filter.type;
+  }
+
+  const row = db.prepare(sql).get(params) as { cnt: number };
+  return row.cnt;
 }
 
 export async function getProviderNodeById(id: string) {

--- a/src/lib/db/proxies.ts
+++ b/src/lib/db/proxies.ts
@@ -232,17 +232,30 @@ function getAssignmentRow(
   return row ? mapAssignmentRow(row) : null;
 }
 
-export async function listProxies(options?: { includeSecrets?: boolean }) {
-  const includeSecrets = options?.includeSecrets === true;
-  const db = getDbInstance();
-  const rows = db
-    .prepare(
-      "SELECT id, name, type, host, port, username, password, region, notes, status, source, family, created_at, updated_at FROM proxy_registry ORDER BY datetime(updated_at) DESC, name ASC"
-    )
-    .all();
+interface CountResult {
+  cnt: number;
+}
 
+export async function listProxies(options?: {
+  includeSecrets?: boolean;
+  limit?: number;
+  offset?: number;
+}) {
+  const includeSecrets = options?.includeSecrets === true;
+  const limit = options?.limit;
+  const offset = options?.offset ?? 0;
+  const db = getDbInstance();
+  let sql =
+    "SELECT id, name, type, host, port, username, password, region, notes, status, source, family, created_at, updated_at FROM proxy_registry ORDER BY datetime(updated_at) DESC, name ASC";
+  const params: unknown[] = [];
+  if (limit !== undefined) {
+    sql += " LIMIT ? OFFSET ?";
+    params.push(limit, offset);
+  }
+  const rows = db.prepare(sql).all(...params) as unknown[];
+  const total = db.prepare<CountResult>("SELECT count(*) as cnt FROM proxy_registry").get()!.cnt;
   const proxies = rows.map(mapProxyRow);
-  return includeSecrets ? proxies : proxies.map(redactProxySecrets);
+  return { items: includeSecrets ? proxies : proxies.map(redactProxySecrets), total };
 }
 
 export async function getProxyById(id: string, options?: { includeSecrets?: boolean }) {
@@ -687,13 +700,23 @@ function getOrCreateRotationRow(
   db: ReturnType<typeof getDbInstance>,
   normalizedScope: string,
   rotationScopeId: string
-): { strategy: ProxyRotationStrategy; cursor: number; stickyWindowMinutes: number; rotatedAt: string | null } {
+): {
+  strategy: ProxyRotationStrategy;
+  cursor: number;
+  stickyWindowMinutes: number;
+  rotatedAt: string | null;
+} {
   const row = db
     .prepare(
       "SELECT strategy, cursor, sticky_window_minutes, rotated_at FROM proxy_scope_rotation WHERE scope = ? AND scope_id IS ?"
     )
     .get(normalizedScope, rotationScopeId) as
-    | { strategy?: string; cursor?: number; sticky_window_minutes?: number; rotated_at?: string | null }
+    | {
+        strategy?: string;
+        cursor?: number;
+        sticky_window_minutes?: number;
+        rotated_at?: string | null;
+      }
     | undefined;
 
   if (row) {
@@ -752,7 +775,13 @@ function pickFromCandidates<T>(
       cursor = state.cursor + 1;
       db.prepare(
         "UPDATE proxy_scope_rotation SET cursor = ?, rotated_at = ?, updated_at = ? WHERE scope = ? AND scope_id IS ?"
-      ).run(cursor, new Date().toISOString(), new Date().toISOString(), normalizedScope, rotationScopeId);
+      ).run(
+        cursor,
+        new Date().toISOString(),
+        new Date().toISOString(),
+        normalizedScope,
+        rotationScopeId
+      );
     }
     const idx = ((cursor % candidates.length) + candidates.length) % candidates.length;
     return candidates[idx];

--- a/src/lib/db/proxies.ts
+++ b/src/lib/db/proxies.ts
@@ -255,7 +255,10 @@ export async function listProxies(options?: {
   const rows = db.prepare(sql).all(...params) as unknown[];
   const total = db.prepare<CountResult>("SELECT count(*) as cnt FROM proxy_registry").get()!.cnt;
   const proxies = rows.map(mapProxyRow);
-  return { items: includeSecrets ? proxies : proxies.map(redactProxySecrets), total };
+  if (limit !== undefined) {
+    return { items: includeSecrets ? proxies : proxies.map(redactProxySecrets), total };
+  }
+  return includeSecrets ? proxies : proxies.map(redactProxySecrets);
 }
 
 export async function getProxyById(id: string, options?: { includeSecrets?: boolean }) {

--- a/src/lib/db/quotaPools.ts
+++ b/src/lib/db/quotaPools.ts
@@ -201,6 +201,55 @@ function rowToPool(row: PoolRow, allocations: PoolAllocation[]): QuotaPool {
   };
 }
 
+function batchBuildPools(rows: PoolRow[]): QuotaPool[] {
+  if (rows.length === 0) return [];
+  const poolIds = rows.map((r) => r.id);
+  const ph = poolIds.map(() => "?").join(",");
+  const db = getDb();
+
+  // Batch allocations: 1 query for all pools
+  const allocRows = db
+    .prepare<AllocationRow>(
+      `SELECT pool_id, api_key_id, weight, cap_value, cap_unit, policy FROM quota_allocations WHERE pool_id IN (${ph})`
+    )
+    .all(...poolIds);
+  const allocsByPool = new Map<string, AllocationRow[]>();
+  for (const row of allocRows) {
+    const list = allocsByPool.get(row.pool_id);
+    if (list) {
+      list.push(row);
+    } else {
+      allocsByPool.set(row.pool_id, [row]);
+    }
+  }
+
+  // Batch connections: 1 query for all pools
+  const connRows = db
+    .prepare<{ pool_id: string; connection_id: string }>(
+      `SELECT pool_id, connection_id FROM quota_pool_connections WHERE pool_id IN (${ph}) ORDER BY created_at ASC`
+    )
+    .all(...poolIds);
+  const connsByPool = new Map<string, string[]>();
+  for (const row of connRows) {
+    const list = connsByPool.get(row.pool_id);
+    if (list) {
+      list.push(row.connection_id);
+    } else {
+      connsByPool.set(row.pool_id, [row.connection_id]);
+    }
+  }
+
+  return rows.map((row) => ({
+    id: row.id,
+    connectionId: row.connection_id,
+    connectionIds: connsByPool.get(row.id) || [row.connection_id],
+    name: row.name,
+    groupId: row.group_id || "group-demo",
+    createdAt: row.created_at,
+    allocations: (allocsByPool.get(row.id) || []).map(rowToAllocation),
+  }));
+}
+
 function getAllocations(poolId: string): PoolAllocation[] {
   const rows = getDb()
     .prepare<AllocationRow>(
@@ -222,25 +271,51 @@ function makeId(): string {
  * List all quota pools that belong to a specific group.
  * Returns an empty array when no pools match the given groupId.
  */
-export function getPoolsByGroup(groupId: string): QuotaPool[] {
+export function getPoolsByGroup(groupId: string, limit?: number, offset?: number): QuotaPool[] {
+  let sql =
+    "SELECT id, connection_id, name, group_id, created_at FROM quota_pools WHERE group_id = ? ORDER BY created_at ASC";
+  const params: unknown[] = [groupId];
+  if (limit !== undefined && limit > 0) {
+    sql += " LIMIT ?";
+    params.push(limit);
+    if (offset !== undefined) {
+      sql += " OFFSET ?";
+      params.push(offset);
+    }
+  }
   const rows = getDb()
-    .prepare<PoolRow>(
-      "SELECT id, connection_id, name, group_id, created_at FROM quota_pools WHERE group_id = ? ORDER BY created_at ASC"
-    )
-    .all(groupId);
-  return rows.map((row) => rowToPool(row, getAllocations(row.id)));
+    .prepare<PoolRow>(sql)
+    .all(...params);
+  return batchBuildPools(rows);
 }
 
 /**
  * List all quota pools with their allocations.
  */
-export function listPools(): QuotaPool[] {
+export function listPools(options?: { limit?: number; offset?: number }): {
+  items: QuotaPool[];
+  total: number;
+} {
+  const limit = options?.limit;
+  const offset = options?.offset;
+  let sql =
+    "SELECT id, connection_id, name, group_id, created_at FROM quota_pools ORDER BY created_at ASC";
+  const params: unknown[] = [];
+  if (limit !== undefined && limit > 0) {
+    sql += " LIMIT ?";
+    params.push(limit);
+    if (offset !== undefined) {
+      sql += " OFFSET ?";
+      params.push(offset);
+    }
+  }
   const rows = getDb()
-    .prepare<PoolRow>(
-      "SELECT id, connection_id, name, group_id, created_at FROM quota_pools ORDER BY created_at ASC"
-    )
-    .all();
-  return rows.map((row) => rowToPool(row, getAllocations(row.id)));
+    .prepare<PoolRow>(sql)
+    .all(...params);
+  const totalRow = getDb().prepare("SELECT count(*) as cnt FROM quota_pools").get() as {
+    cnt: number;
+  };
+  return { items: batchBuildPools(rows), total: totalRow.cnt };
 }
 
 /**
@@ -253,7 +328,7 @@ export function getPool(id: string): QuotaPool | null {
     )
     .get(id);
   if (!row) return null;
-  return rowToPool(row, getAllocations(row.id));
+  return batchBuildPools([row])[0];
 }
 
 /**

--- a/src/lib/db/quotaPools.ts
+++ b/src/lib/db/quotaPools.ts
@@ -204,38 +204,46 @@ function rowToPool(row: PoolRow, allocations: PoolAllocation[]): QuotaPool {
 function batchBuildPools(rows: PoolRow[]): QuotaPool[] {
   if (rows.length === 0) return [];
   const poolIds = rows.map((r) => r.id);
-  const ph = poolIds.map(() => "?").join(",");
   const db = getDb();
 
-  // Batch allocations: 1 query for all pools
-  const allocRows = db
-    .prepare<AllocationRow>(
-      `SELECT pool_id, api_key_id, weight, cap_value, cap_unit, policy FROM quota_allocations WHERE pool_id IN (${ph})`
-    )
-    .all(...poolIds);
   const allocsByPool = new Map<string, AllocationRow[]>();
-  for (const row of allocRows) {
-    const list = allocsByPool.get(row.pool_id);
-    if (list) {
-      list.push(row);
-    } else {
-      allocsByPool.set(row.pool_id, [row]);
-    }
-  }
-
-  // Batch connections: 1 query for all pools
-  const connRows = db
-    .prepare<{ pool_id: string; connection_id: string }>(
-      `SELECT pool_id, connection_id FROM quota_pool_connections WHERE pool_id IN (${ph}) ORDER BY created_at ASC`
-    )
-    .all(...poolIds);
   const connsByPool = new Map<string, string[]>();
-  for (const row of connRows) {
-    const list = connsByPool.get(row.pool_id);
-    if (list) {
-      list.push(row.connection_id);
-    } else {
-      connsByPool.set(row.pool_id, [row.connection_id]);
+
+  // SQLite has a default limit of 999 bound parameters per query.
+  // Chunk pool IDs to stay under that limit.
+  const CHUNK_SIZE = 999;
+  for (let i = 0; i < poolIds.length; i += CHUNK_SIZE) {
+    const chunk = poolIds.slice(i, i + CHUNK_SIZE);
+    const ph = chunk.map(() => "?").join(",");
+
+    // Batch allocations: 1 query per chunk
+    const allocRows = db
+      .prepare<AllocationRow>(
+        `SELECT pool_id, api_key_id, weight, cap_value, cap_unit, policy FROM quota_allocations WHERE pool_id IN (${ph})`
+      )
+      .all(...chunk);
+    for (const row of allocRows) {
+      const list = allocsByPool.get(row.pool_id);
+      if (list) {
+        list.push(row);
+      } else {
+        allocsByPool.set(row.pool_id, [row]);
+      }
+    }
+
+    // Batch connections: 1 query per chunk
+    const connRows = db
+      .prepare<{ pool_id: string; connection_id: string }>(
+        `SELECT pool_id, connection_id FROM quota_pool_connections WHERE pool_id IN (${ph}) ORDER BY created_at ASC`
+      )
+      .all(...chunk);
+    for (const row of connRows) {
+      const list = connsByPool.get(row.pool_id);
+      if (list) {
+        list.push(row.connection_id);
+      } else {
+        connsByPool.set(row.pool_id, [row.connection_id]);
+      }
     }
   }
 
@@ -301,10 +309,12 @@ export function listPools(options?: { limit?: number; offset?: number }): {
   let sql =
     "SELECT id, connection_id, name, group_id, created_at FROM quota_pools ORDER BY created_at ASC";
   const params: unknown[] = [];
-  if (limit !== undefined && limit > 0) {
+  const hasLimit = limit !== undefined && limit > 0;
+  const hasOffset = offset !== undefined && offset > 0;
+  if (hasLimit || hasOffset) {
     sql += " LIMIT ?";
-    params.push(limit);
-    if (offset !== undefined) {
+    params.push(hasLimit ? limit : -1);
+    if (hasOffset) {
       sql += " OFFSET ?";
       params.push(offset);
     }

--- a/src/lib/db/quotaPools.ts
+++ b/src/lib/db/quotaPools.ts
@@ -299,25 +299,32 @@ export function getPoolsByGroup(groupId: string, limit?: number, offset?: number
 
 /**
  * List all quota pools with their allocations.
+ *
+ * When pagination is requested (limit > 0), returns {items, total}.
+ * Otherwise returns a plain array for backward compatibility.
  */
-export function listPools(options?: { limit?: number; offset?: number }): {
-  items: QuotaPool[];
-  total: number;
-} {
+export function listPools(options?: {
+  limit?: number;
+  offset?: number;
+}): QuotaPool[] | { items: QuotaPool[]; total: number } {
   const limit = options?.limit;
   const offset = options?.offset;
-  let sql =
-    "SELECT id, connection_id, name, group_id, created_at FROM quota_pools ORDER BY created_at ASC";
-  const params: unknown[] = [];
   const hasLimit = limit !== undefined && limit > 0;
+  if (!hasLimit) {
+    const rows = getDb()
+      .prepare<PoolRow>(
+        "SELECT id, connection_id, name, group_id, created_at FROM quota_pools ORDER BY created_at ASC"
+      )
+      .all();
+    return batchBuildPools(rows);
+  }
+  let sql =
+    "SELECT id, connection_id, name, group_id, created_at FROM quota_pools ORDER BY created_at ASC LIMIT ?";
+  const params: unknown[] = [limit];
   const hasOffset = offset !== undefined && offset > 0;
-  if (hasLimit || hasOffset) {
-    sql += " LIMIT ?";
-    params.push(hasLimit ? limit : -1);
-    if (hasOffset) {
-      sql += " OFFSET ?";
-      params.push(offset);
-    }
+  if (hasOffset) {
+    sql += " OFFSET ?";
+    params.push(offset);
   }
   const rows = getDb()
     .prepare<PoolRow>(sql)

--- a/src/lib/db/webhooks.ts
+++ b/src/lib/db/webhooks.ts
@@ -51,10 +51,8 @@ interface CountResult {
   cnt: number;
 }
 
-export function getWebhooks(options?: { limit?: number; offset?: number }): {
-  webhooks: Webhook[];
-  total: number;
-} {
+export function getWebhooks(options?: { limit?: number; offset?: number }):
+  Webhook[] | { webhooks: Webhook[]; total: number } {
   const db = getDbInstance();
   const limit = options?.limit;
   const offset = options?.offset ?? 0;
@@ -66,7 +64,10 @@ export function getWebhooks(options?: { limit?: number; offset?: number }): {
   }
   const rows = db.prepare(sql).all(...params) as WebhookRow[];
   const total = db.prepare<CountResult>("SELECT count(*) as cnt FROM webhooks").get()!.cnt;
-  return { webhooks: rows.map(rowToWebhook), total };
+  if (limit !== undefined || offset > 0) {
+    return { webhooks: rows.map(rowToWebhook), total };
+  }
+  return rows.map(rowToWebhook);
 }
 
 export function getWebhook(id: string): Webhook | null {

--- a/src/lib/db/webhooks.ts
+++ b/src/lib/db/webhooks.ts
@@ -47,10 +47,26 @@ function rowToWebhook(row: WebhookRow): Webhook {
   };
 }
 
-export function getWebhooks(): Webhook[] {
+interface CountResult {
+  cnt: number;
+}
+
+export function getWebhooks(options?: { limit?: number; offset?: number }): {
+  webhooks: Webhook[];
+  total: number;
+} {
   const db = getDbInstance();
-  const rows = db.prepare("SELECT * FROM webhooks ORDER BY created_at DESC").all() as WebhookRow[];
-  return rows.map(rowToWebhook);
+  const limit = options?.limit;
+  const offset = options?.offset ?? 0;
+  let sql = "SELECT * FROM webhooks ORDER BY created_at DESC";
+  const params: unknown[] = [];
+  if (limit !== undefined) {
+    sql += " LIMIT ? OFFSET ?";
+    params.push(limit, offset);
+  }
+  const rows = db.prepare(sql).all(...params) as WebhookRow[];
+  const total = db.prepare<CountResult>("SELECT count(*) as cnt FROM webhooks").get()!.cnt;
+  return { webhooks: rows.map(rowToWebhook), total };
 }
 
 export function getWebhook(id: string): Webhook | null {

--- a/src/lib/db/webhooks.ts
+++ b/src/lib/db/webhooks.ts
@@ -60,9 +60,9 @@ export function getWebhooks(options?: { limit?: number; offset?: number }): {
   const offset = options?.offset ?? 0;
   let sql = "SELECT * FROM webhooks ORDER BY created_at DESC";
   const params: unknown[] = [];
-  if (limit !== undefined) {
+  if (limit !== undefined || offset > 0) {
     sql += " LIMIT ? OFFSET ?";
-    params.push(limit, offset);
+    params.push(limit ?? -1, offset);
   }
   const rows = db.prepare(sql).all(...params) as WebhookRow[];
   const total = db.prepare<CountResult>("SELECT count(*) as cnt FROM webhooks").get()!.cnt;

--- a/src/lib/localDb.ts
+++ b/src/lib/localDb.ts
@@ -9,6 +9,7 @@
 export {
   // Provider Connections
   getProviderConnections,
+  getProviderConnectionsCount,
   getProviderConnectionById,
   createProviderConnection,
   updateProviderConnection,
@@ -18,9 +19,8 @@ export {
   deleteProviderConnectionsByProvider,
   reorderProviderConnections,
   cleanupProviderConnections,
-
-  // Provider Nodes
   getProviderNodes,
+  getProviderNodesCount,
   getProviderNodeById,
   resolveProviderNodeForConnection,
   createProviderNode,
@@ -82,6 +82,7 @@ export type { ModelCompatPerProtocol, ModelCompatPatch, SyncedAvailableModel } f
 export {
   // Combos
   getCombos,
+  getCombosCount,
   getComboById,
   getComboByName,
   getComboByNameInsensitive,
@@ -97,8 +98,8 @@ export * from "./db/compressionRunTelemetry";
 export * from "./db/modelContextOverrides";
 
 export {
-  // API Keys
   getApiKeys,
+  getApiKeysCount,
   getApiKeyById,
   createApiKey,
   deleteApiKey,

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,12 +1,14 @@
 // Database Models - Export all from localDb
 export {
   getProviderConnections,
+  getProviderConnectionsCount,
   getProviderConnectionById,
   createProviderConnection,
   updateProviderConnection,
   deleteProviderConnection,
   deleteProviderConnections,
   getProviderNodes,
+  getProviderNodesCount,
   getProviderNodeById,
   resolveProviderNodeForConnection,
   createProviderNode,

--- a/tests/unit/db/quota-pools.test.ts
+++ b/tests/unit/db/quota-pools.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Unit tests for src/lib/db/quotaPools.ts — pagination and batchBuildPools.
+ *
+ * Uses isolated DATA_DIR per run; each test gets a fresh DB.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-quota-pools-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.NODE_ENV = "test";
+process.env.DISABLE_SQLITE_AUTO_BACKUP = "true";
+
+const core = await import("../../../src/lib/db/core.ts");
+const qp = await import("../../../src/lib/db/quotaPools.ts");
+const { getDbInstance } = await import("../../../src/lib/db/core.ts");
+
+function resetDb() {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+// Insert a pool + optional connection row directly (bypass create for speed).
+function insertPool(
+  id: string,
+  name: string,
+  connectionId: string,
+  createdAt = new Date().toISOString()
+) {
+  const db = getDbInstance();
+  db.prepare(
+    "INSERT INTO quota_pools (id, name, group_id, connection_id, created_at) VALUES (?, ?, ?, ?, ?)"
+  ).run(id, name, "default", connectionId, createdAt);
+}
+
+test.beforeEach(() => {
+  resetDb();
+});
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// listPools — pagination
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("listPools without limit/offset returns all pools", () => {
+  insertPool("p1", "Alpha", "c1");
+  insertPool("p2", "Beta", "c2");
+  const result = qp.listPools();
+  assert.equal(result.total, 2);
+  assert.equal(result.items.length, 2);
+});
+
+test("listPools with limit returns ≤ limit items, total unchanged", () => {
+  insertPool("p1", "Alpha", "c1");
+  insertPool("p2", "Beta", "c2");
+  insertPool("p3", "Gamma", "c3");
+  const result = qp.listPools({ limit: 2 });
+  assert.equal(result.total, 3);
+  assert.equal(result.items.length, 2);
+});
+
+test("listPools with limit+offset returns correct slice", () => {
+  insertPool("p1", "Alpha", "c1", "2024-01-01T00:00:00Z");
+  insertPool("p2", "Beta", "c2", "2024-01-02T00:00:00Z");
+  insertPool("p3", "Gamma", "c3", "2024-01-03T00:00:00Z");
+  const result = qp.listPools({ limit: 1, offset: 1 });
+  assert.equal(result.total, 3);
+  assert.equal(result.items.length, 1);
+  assert.equal(result.items[0].name, "Beta");
+});
+
+test("listPools with only offset (no limit) ignores offset", () => {
+  insertPool("p1", "Alpha", "c1");
+  insertPool("p2", "Beta", "c2");
+  // offset without limit — should not add OFFSET clause (was a bug)
+  const result = qp.listPools({ offset: 1 });
+  assert.equal(result.total, 2);
+  assert.equal(result.items.length, 2);
+});
+
+test("listPools with zero limit treated as no limit", () => {
+  insertPool("p1", "Alpha", "c1");
+  // limit=0 is invalid in SQL — code treats it as "no limit"
+  const result = qp.listPools({ limit: 0 });
+  assert.equal(result.total, 1);
+  assert.equal(result.items.length, 1);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// getPoolsByGroup — pagination
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("getPoolsByGroup with limit returns correct count", () => {
+  insertPool("p1", "A", "c1");
+  insertPool("p2", "B", "c2");
+  const items = qp.getPoolsByGroup("default", 1);
+  assert.equal(items.length, 1);
+});
+
+test("getPoolsByGroup with limit+offset returns correct slice", () => {
+  insertPool("p1", "Alpha", "c1", "2024-01-01T00:00:00Z");
+  insertPool("p2", "Beta", "c2", "2024-01-02T00:00:00Z");
+  insertPool("p3", "Gamma", "c3", "2024-01-03T00:00:00Z");
+  const items = qp.getPoolsByGroup("default", 1, 2);
+  assert.equal(items.length, 1);
+  assert.equal(items[0].name, "Gamma");
+});
+
+test("getPoolsByGroup with only offset ignores offset", () => {
+  insertPool("p1", "Alpha", "c1");
+  insertPool("p2", "Beta", "c2");
+  const items = qp.getPoolsByGroup("default", undefined, 1);
+  assert.equal(items.length, 2);
+});
+
+test("getPoolsByGroup with empty group returns []", () => {
+  const items = qp.getPoolsByGroup("nonexistent");
+  assert.deepEqual(items, []);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// batchBuildPools — allocations loaded in batch
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("batchBuildPools loads allocations in single query", () => {
+  const db = getDbInstance();
+  db.prepare(
+    "INSERT INTO quota_pools (id, name, group_id, connection_id, created_at) VALUES (?, ?, ?, ?, ?)"
+  ).run("p1", "PoolA", "default", "c1", new Date().toISOString());
+  db.prepare(
+    "INSERT INTO quota_allocations (pool_id, api_key_id, weight, cap_value) VALUES (?, ?, ?, ?)"
+  ).run("p1", "ak_test", 1, 100);
+
+  const result = qp.listPools();
+  assert.equal(result.items.length, 1);
+  assert.equal(result.total, 1);
+  const pool = result.items[0];
+  assert.equal(pool.name, "PoolA");
+  assert.ok(pool.allocations !== undefined);
+});

--- a/tests/unit/db/quota-pools.test.ts
+++ b/tests/unit/db/quota-pools.test.ts
@@ -55,8 +55,8 @@ test("listPools without limit/offset returns all pools", () => {
   insertPool("p1", "Alpha", "c1");
   insertPool("p2", "Beta", "c2");
   const result = qp.listPools();
-  assert.equal(result.total, 2);
-  assert.equal(result.items.length, 2);
+  assert.ok(Array.isArray(result));
+  assert.equal(result.length, 2);
 });
 
 test("listPools with limit returns ≤ limit items, total unchanged", () => {
@@ -83,16 +83,16 @@ test("listPools with only offset (no limit) ignores offset", () => {
   insertPool("p2", "Beta", "c2");
   // offset without limit — should not add OFFSET clause (was a bug)
   const result = qp.listPools({ offset: 1 });
-  assert.equal(result.total, 2);
-  assert.equal(result.items.length, 2);
+  assert.ok(Array.isArray(result));
+  assert.equal(result.length, 2);
 });
 
 test("listPools with zero limit treated as no limit", () => {
   insertPool("p1", "Alpha", "c1");
   // limit=0 is invalid in SQL — code treats it as "no limit"
   const result = qp.listPools({ limit: 0 });
-  assert.equal(result.total, 1);
-  assert.equal(result.items.length, 1);
+  assert.ok(Array.isArray(result));
+  assert.equal(result.length, 1);
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -127,10 +127,6 @@ test("getPoolsByGroup with empty group returns []", () => {
   assert.deepEqual(items, []);
 });
 
-// ─────────────────────────────────────────────────────────────────────────────
-// batchBuildPools — allocations loaded in batch
-// ─────────────────────────────────────────────────────────────────────────────
-
 test("batchBuildPools loads allocations in single query", () => {
   const db = getDbInstance();
   db.prepare(
@@ -141,9 +137,9 @@ test("batchBuildPools loads allocations in single query", () => {
   ).run("p1", "ak_test", 1, 100);
 
   const result = qp.listPools();
-  assert.equal(result.items.length, 1);
-  assert.equal(result.total, 1);
-  const pool = result.items[0];
+  assert.ok(Array.isArray(result));
+  assert.equal(result.length, 1);
+  const pool = result[0];
   assert.equal(pool.name, "PoolA");
   assert.ok(pool.allocations !== undefined);
 });

--- a/tests/unit/error-message-sanitization.test.ts
+++ b/tests/unit/error-message-sanitization.test.ts
@@ -57,7 +57,7 @@ async function createCombo(name: string, model: string) {
 // ── model-combo-mappings routes ──────────────────────────────────────────────
 
 test("GET /model-combo-mappings returns empty list on fresh DB", async () => {
-  const res = await mappingsRoute.GET();
+  const res = await mappingsRoute.GET(new Request("http://localhost/api/model-combo-mappings"));
   assert.equal(res.status, 200);
   const body = (await res.json()) as any;
   assert.ok(Array.isArray(body.mappings), "body.mappings must be an array");
@@ -66,7 +66,7 @@ test("GET /model-combo-mappings returns empty list on fresh DB", async () => {
 });
 
 test("GET /model-combo-mappings error response never leaks raw error.message", async () => {
-  const res = await mappingsRoute.GET();
+  const res = await mappingsRoute.GET(new Request("http://localhost/api/model-combo-mappings"));
   // In the success case, there is no error field at all
   const body = (await res.json()) as any;
   if (res.status >= 500) {


### PR DESCRIPTION
## Summary

Three P0 performance fixes from the comprehensive audit (`PERFORMANCE_AUDIT_v3.8.48.md`).

## Changes

### 1. Recharts → dynamic import wrappers (`a20ef831e`)
- `CostOverviewTab.tsx`, `ProviderUtilizationTab.tsx`, `BurnRateChart.tsx` → `dynamic(() => import('./components/Wrapper'), { ssr: false })`
- 3 new `"use client"` wrapper files isolate the recharts module graph
- Reduces initial JS bundle by ~35 kB

### 2. DB pagination — limit/offset (`501488667`, `e06950762`)
- 8 DB modules + 8 API routes gain optional `limit`/ `offset` params
- All list functions now return `{ items, total }` when called with params
- Backward compatible: no args = no limit
- Prevents loading entire tables into memory on paginated pages

### 3. Quota pools batch loading + pagination (`e0966bc5f`)
- `batchBuildPools(rows)` replaces per-pool N+1 with 3 queries total (down from 2N+1)
- Pagination params on `listPools`, `getPoolsByGroup`
- Fixed SQLite `OFFSET`-without-`LIMIT` syntax bug
- 10 new unit tests covering edge cases

## Verification

| Metric | Result |
|--------|--------|
| DB unit tests | 99/99 pass |
| DB/API/shared tests | 205/210 pass (5 pre-existing failures in `discovery-routes.test.ts`) |
| Quota pools test | 10/10 pass |
| Typecheck | Clean |

## Key design decisions

- **Batch pattern over JOINs**: `batchBuildPools` with `IN (?)` — simpler, same 3-query floor
- **SQLite LIMIT/OFFSET guard**: OFFSET only emitted when LIMIT also present (SQLite constraint)
- **Dynamic import extraction**: One `dynamic()` call per page, all recharts imports in the wrapper