### PR TITLE
chore(release): gate the sync-back push on release-green --quick (WS0.3)

### DIFF
--- a/changelog.d/maintenance/sync-back-green-gate.md
+++ b/changelog.d/maintenance/sync-back-green-gate.md
@@ -1,0 +1,1 @@
+- **Release tooling**: `sync-next-cycle.mjs` now runs `validate-release-green --quick` on the merged tree BEFORE pushing the parallel-cycle sync-back — the one write path to the release branch that had no CI gate; a red merged tree stays local instead of turning the whole PR queue red (`--skip-green-gate` is the documented emergency hatch)

--- a/scripts/release/sync-next-cycle.mjs
+++ b/scripts/release/sync-next-cycle.mjs
@@ -106,6 +106,15 @@ function git(args, opts = {}) {
   return execFileSync("git", args, { encoding: "utf8", maxBuffer: 64 * 1024 * 1024, ...opts }).trim();
 }
 
+// The sync-back is the ONE write path to the release branch with no CI gate — a red
+// merged tree pushed here turns the whole PR queue red (G1, v3.8.49 quality plan WS0.3).
+// Returns the validate-release-green invocation to run before the push, or null when
+// the operator passed --skip-green-gate (emergency hatch: tip reds verified pre-existing).
+export function greenGateArgs(argv) {
+  if (argv.includes("--skip-green-gate")) return null;
+  return ["scripts/quality/validate-release-green.mjs", "--quick"];
+}
+
 function main() {
   const NEXT = process.argv[2];
   if (!/^\d+\.\d+\.\d+$/.test(NEXT || "")) {
@@ -209,6 +218,29 @@ function main() {
   }
 
   git(["commit", "-m", `chore(release): sync main (v${prevVersion} close) into ${BRANCH} — parallel-cycle sync-back`], { cwd: WT });
+
+  // WS0.3 green gate: validate the MERGED tree before it reaches origin. The commit
+  // stays local on failure so the captain can inspect/fix in the sync worktree.
+  const gate = greenGateArgs(process.argv);
+  if (gate) {
+    const nm = path.join(WT, "node_modules");
+    if (!fs.existsSync(nm)) fs.symlinkSync(path.join(ROOT, "node_modules"), nm, "dir");
+    console.log("[sync-next-cycle] release-green --quick on the merged tree (pre-push gate)…");
+    try {
+      execFileSync("node", gate, { cwd: WT, stdio: "inherit", maxBuffer: 64 * 1024 * 1024 });
+    } catch {
+      console.error(
+        `[sync-next-cycle] ABORT: release-green --quick found HARD failures in the merged tree.` +
+          `\n  The sync commit is LOCAL-ONLY in ${WT} — fix the reds there, then re-run this script.` +
+          `\n  Use --skip-green-gate ONLY after verifying the reds pre-exist on origin/${BRANCH}.`
+      );
+      process.exit(1);
+    }
+    fs.rmSync(nm, { force: true });
+  } else {
+    console.warn("[sync-next-cycle] ⚠ --skip-green-gate: pushing WITHOUT release-green validation.");
+  }
+
   git(["push", "origin", BRANCH], { cwd: WT });
 
   const left = git(["rev-list", "--count", `${BRANCH}..origin/main`], { cwd: WT });

--- a/tests/unit/sync-next-cycle.test.ts
+++ b/tests/unit/sync-next-cycle.test.ts
@@ -123,3 +123,31 @@ test("i18n resync also propagates the FINALIZED [prevVersion] section into the m
     "syncs the shipped (finalized) section — without this all 42 mirrors keep it as TBD"
   );
 });
+
+// WS0.3 (v3.8.49 quality plan): the captain's sync-back push is the one write path
+// with NO CI gate — the merged tree must pass release-green --quick BEFORE the push,
+// or the whole PR queue inherits a red tip (G1). --skip-green-gate is the documented
+// emergency escape hatch (pre-existing tip reds verified by hand).
+
+test("greenGateArgs returns the quick release-green command by default", async () => {
+  const { greenGateArgs } = await import("../../scripts/release/sync-next-cycle.mjs");
+  assert.deepEqual(greenGateArgs(["node", "script", "3.8.49"]), [
+    "scripts/quality/validate-release-green.mjs",
+    "--quick",
+  ]);
+});
+
+test("greenGateArgs returns null only with the explicit --skip-green-gate flag", async () => {
+  const { greenGateArgs } = await import("../../scripts/release/sync-next-cycle.mjs");
+  assert.equal(greenGateArgs(["node", "script", "3.8.49", "--skip-green-gate"]), null);
+  assert.notEqual(greenGateArgs(["node", "script", "3.8.49", "--other"]), null);
+});
+
+test("sync-next-cycle gates the push on release-green (source guard)", () => {
+  const src = readFileSync(SCRIPT_PATH, "utf8");
+  const mainIdx = src.indexOf("function main()");
+  const gateCallIdx = src.indexOf("greenGateArgs(process.argv)", mainIdx);
+  const pushIdx = src.indexOf('git(["push", "origin", BRANCH]');
+  assert.ok(gateCallIdx > mainIdx, "main() must call greenGateArgs(process.argv)");
+  assert.ok(pushIdx > gateCallIdx, "the release-green gate must run BEFORE the push");
+});


### PR DESCRIPTION
## Summary

Task **WS0.3** of the v3.8.49 quality/velocity master plan (G1: the captain's sync-back is the one write path to the release branch with NO CI gate — this cycle's tip only stayed green by luck).

- `scripts/release/sync-next-cycle.mjs`: after the merge commit and BEFORE the push, runs `validate-release-green --quick` (fast HARD gates, ~5-8min) on the merged tree, symlinking `node_modules` into the sync worktree for the run. On HARD failure the commit stays LOCAL for inspection and the push is aborted.
- `--skip-green-gate`: documented emergency hatch (only after verifying the reds pre-exist on the branch tip).
- Skill playbook `generate-release/phases/phase-5-next-cycle.md` updated locally to document the new step (file lives outside this repo's git scope).

## Evidence (TDD)

- RED: 3 new tests failed before the implementation (`greenGateArgs` missing + source guard).
- GREEN: 11/11 tests in `tests/unit/sync-next-cycle.test.ts` pass (flag contract + source guard asserting the gate call sits between `main()` and the push).
- Gates: eslint 0 errors · complexity + cognitive OK (baseline 2056/890) · file-size 0 ✗ · mutation-test-coverage no drift.