### PR TITLE
test(ci): make masking self-reference check hermetic

### DIFF
--- a/tests/unit/check-test-masking-selfref-6634.test.ts
+++ b/tests/unit/check-test-masking-selfref-6634.test.ts
@@ -19,7 +19,6 @@
  */
 import test from "node:test";
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
 
 import {
   countTautologies,
@@ -29,15 +28,16 @@ import {
 
 const FILE = "tests/unit/check-test-masking.test.ts";
 
-function git(args: string[]): string {
-  return execFileSync("git", args, { encoding: "utf8" });
-}
-
 test("#6634: check-test-masking.test.ts's own tautology fixtures must not self-flag as weakening", () => {
-  // origin/main predates the #6404 fixtures (countBareTautologies/scanBareTautologies
-  // tests) that legitimately embed tautology-pattern literals as string fixtures.
-  const baseSrc = git(["show", "origin/main:" + FILE]);
-  const headSrc = git(["show", "HEAD:" + FILE]);
+  // Model the pre-#6404 source and the fixture literals added by #6404 directly.
+  // This must be checkout-independent: Actions only fetches the PR base ref, not
+  // origin/main, so reading a remote ref made the unit shard fail before testing
+  // the masking behavior.
+  const baseSrc = "";
+  const headSrc = `
+    const bare = "expect(true).toBe(true);";
+    const equal = "assert.equal(1, 1);";
+  `;
 
   const perFile = [
     {


### PR DESCRIPTION
Remove the check-test-masking regression test's dependency on origin/main, which Actions does not fetch for release PRs. The test now models the relevant pre- and post-fixture source locally while preserving the file-scoped masking assertion.