### PR TITLE
feat(ci): Windows leg for Electron prepare smoke (WS1.5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -611,10 +611,19 @@ jobs:
       - run: npm run check:pack-artifact
 
   electron-package-smoke:
-    name: Electron Package Smoke
-    runs-on: ubuntu-latest
-    timeout-minutes: 25
+    name: Electron Package Smoke (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     needs: build
+    # WS1.5 (v3.8.49 plan): the Electron rebuild/spawn path previously executed for
+    # the FIRST time on the release tag — the v3.8.48 Windows bug (npx.cmd spawned
+    # without shell, CVE-2024-27980 behavior change) could only surface at release.
+    # windows-latest runs prepare:bundle (the ABI rebuild + spawn plan) per release
+    # PR; ubuntu keeps the full pack + headless smoke.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     env:
       JWT_SECRET: ci-build-secret-with-sufficient-length-for-validation
       CSC_IDENTITY_AUTO_DISCOVERY: "false"
@@ -640,9 +649,15 @@ jobs:
         working-directory: electron
         run: npm install --no-audit --no-fund
       - name: Pack Electron app
+        if: runner.os == 'Linux'
         working-directory: electron
         run: npm run pack
+      - name: Prepare Electron standalone (Windows ABI rebuild + spawn path)
+        if: runner.os == 'Windows'
+        working-directory: electron
+        run: npm run prepare:bundle
       - name: Smoke packaged Electron app
+        if: runner.os == 'Linux'
         env:
           ELECTRON_SMOKE_TIMEOUT_MS: 60000
         run: xvfb-run -a npm run electron:smoke:packaged

--- a/changelog.d/maintenance/electron-win-prepare-smoke.md
+++ b/changelog.d/maintenance/electron-win-prepare-smoke.md
@@ -1,0 +1,1 @@
+- **CI**: the Electron Package Smoke job now runs a Windows leg that executes `prepare:bundle` (the native ABI rebuild + spawn plan) per release PR — the v3.8.48 Windows bug (`npx.cmd` spawned without shell) could previously only surface on the release tag, its first-ever execution


### PR DESCRIPTION
## Summary

Task **WS1.5 (=T3)** of the v3.8.49 quality/velocity master plan — closes **G12**: the Electron native-rebuild/spawn path only executed on `push: tags`, so its first-ever real execution was release day (exactly how the v3.8.48 Windows bug — `npx.cmd` spawned without `shell`, Node's CVE-2024-27980 behavior — reached the tag).

- `electron-package-smoke` becomes a 2-leg matrix:
  - **ubuntu-latest** (unchanged): full `npm run pack` + headless packaged-app smoke.
  - **windows-latest** (new): `npm run prepare:bundle` only — the ABI rebuild + spawn plan (`prepare-electron-standalone.mjs` + `electronRebuildPlan.mjs` from #7055), i.e. the exact code path that broke, now exercised per release PR (~5-8min, no electron-builder toolchain).
- `fail-fast: false` so one leg's failure still reports the other.

Workflow-only change; YAML parse validated. The Windows leg's first run happens on this PR's own CI? No — this repo's full gate runs on PR→main, so first execution is the next release PR (or a workflow_dispatch); noted for expectations.