### PR TITLE
feat(ci): Codecov patch coverage (informational) + missing lcov reporter fix (WS5.6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -789,6 +789,7 @@ jobs:
             --merge-async \
             --reporter=text-summary \
             --reporter=json-summary \
+            --reporter=lcov \
             --exclude=tests/** \
             --exclude=**/*.test.* \
             --check-coverage \
@@ -810,6 +811,18 @@ jobs:
               > coverage/coverage-report.md
           fi
           cat coverage/coverage-report.md >> "$GITHUB_STEP_SUMMARY"
+      # WS5.6 (D7, v3.8.49 plan): patch coverage on the PR diff via Codecov —
+      # informational during calibration (codecov.yml sets informational: true);
+      # promote to blocking only after ~2 weeks without false blocks. The lcov
+      # reporter above also fixes coverage/lcov.info being silently absent
+      # (if-no-files-found: warn) — Sonar consumes the same file.
+      - name: Upload coverage to Codecov (informational)
+        if: always()
+        uses: codecov/codecov-action@04b047e8bb82a0c002c8312c1c880fbc6a999d45 # v5
+        with:
+          files: coverage/lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
       - name: Upload coverage artifacts
         if: always()
         uses: actions/upload-artifact@v7

--- a/changelog.d/maintenance/codecov-patch-coverage.md
+++ b/changelog.d/maintenance/codecov-patch-coverage.md
@@ -1,0 +1,1 @@
+- **CI**: Codecov patch-coverage on every PR diff (informational during calibration — `codecov.yml` sets nothing blocking; strict-patch/lenient-project philosophy on top of the existing 60% c8 floor + ratchet); the CI coverage job now actually emits `coverage/lcov.info` (the `lcov` reporter was missing, so the artifact silently skipped it — the same file Sonar consumes)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,19 @@
+# Codecov — WS5.6/D7 of the v3.8.49 quality/velocity plan.
+# Philosophy: strict patch, lenient project — the project floor/ratchet already
+# lives in quality-baseline.json + the c8 60% gate; Codecov adds the DIFF view
+# ("new lines in this PR are covered"), which the global ratchet cannot see.
+# INFORMATIONAL during calibration: nothing here blocks a PR. Promote by flipping
+# informational to false after ~2 weeks without false blocks (owner decision).
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        target: 70%
+        informational: true
+comment:
+  layout: "condensed_header, diff"
+  behavior: default
+  require_changes: true


### PR DESCRIPTION
## Summary

Task **WS5.6 (decision D7)** of the v3.8.49 quality/velocity master plan — the owner already created the `CODECOV_TOKEN` secret.

1. **Bug found while wiring**: the CI `c8 report` step never emitted lcov (only text/json summaries) — `coverage/lcov.info` was silently absent from the coverage artifact (`if-no-files-found: warn`), which is the same file the **Sonar** job consumes (likely a remaining cause of Sonar's 0% coverage). `--reporter=lcov` added.
2. **Codecov upload** (action SHA-pinned to v5) after the coverage summary, `fail_ci_if_error: false`.
3. **`codecov.yml`**: strict-patch/lenient-project philosophy — patch target 70% and project status both `informational: true` (D7: nothing blocks during ~2 weeks of calibration; promotion to blocking is an owner flip of one flag). PR comment only when coverage changes.

Closes the gap the global ratchet cannot see: 200 new uncovered lines pass today if the repo average holds — patch coverage looks at the diff.

Workflow/config-only; YAML parse OK.