### PR TITLE
feat(sidecar): support conditional provider manifest refresh

### DIFF
--- a/docs/reference/PROVIDER_PLUGIN_MANIFEST.md
+++ b/docs/reference/PROVIDER_PLUGIN_MANIFEST.md
@@ -21,6 +21,14 @@ OmniRoute advertises that URL to Bifrost and CLIProxyAPI via the
 `OMNIROUTE_PROVIDER_MANIFEST_URL` when the sidecar needs a public or container
 network URL instead of the local request origin.
 
+## Refreshing the Manifest
+
+The HTTP endpoint returns `Cache-Control: public, max-age=60` and a strong
+`ETag`. A sidecar should retain the last validated manifest and send its ETag
+in `If-None-Match` when refreshing. A `304 Not Modified` response has no body;
+the sidecar keeps its cached manifest. If no validated cached manifest exists,
+the sidecar must issue an unconditional request instead of accepting a `304`.
+
 ## Goal
 
 Move provider metadata toward a plugin contract so the hot request path can

--- a/src/app/api/v1/provider-plugin-manifest/route.ts
+++ b/src/app/api/v1/provider-plugin-manifest/route.ts
@@ -1,9 +1,10 @@
+import { createHash } from "node:crypto";
+
 import { CORS_HEADERS } from "@/shared/utils/cors";
 import { generateProviderPluginManifest } from "@omniroute/open-sse/config/providerPluginManifestRegistry.ts";
 
-const JSON_HEADERS = {
+const CACHE_HEADERS = {
   ...CORS_HEADERS,
-  "Content-Type": "application/json",
   "Cache-Control": "public, max-age=60",
 } as const;
 
@@ -17,8 +18,29 @@ export async function OPTIONS() {
   });
 }
 
-export async function GET() {
-  return new Response(JSON.stringify(generateProviderPluginManifest()), {
-    headers: JSON_HEADERS,
+function createEtag(body: string): string {
+  return `"${createHash("sha256").update(body).digest("base64url")}"`;
+}
+
+function matchesEtag(ifNoneMatch: string | null, etag: string): boolean {
+  return Boolean(
+    ifNoneMatch
+      ?.split(",")
+      .map((value) => value.trim())
+      .some((value) => value === "*" || value === etag)
+  );
+}
+
+export async function GET(request: Request) {
+  const body = JSON.stringify(generateProviderPluginManifest());
+  const etag = createEtag(body);
+  const headers = { ...CACHE_HEADERS, ETag: etag };
+
+  if (matchesEtag(request.headers.get("If-None-Match"), etag)) {
+    return new Response(null, { status: 304, headers });
+  }
+
+  return new Response(body, {
+    headers: { ...headers, "Content-Type": "application/json" },
   });
 }

--- a/src/app/api/v1/provider-plugin-manifest/route.ts
+++ b/src/app/api/v1/provider-plugin-manifest/route.ts
@@ -8,6 +8,9 @@ const CACHE_HEADERS = {
   "Cache-Control": "public, max-age=60",
 } as const;
 
+// The provider registry is module-static; process reloads rebuild this snapshot.
+let cachedPayload: { body: string; etag: string } | null = null;
+
 export async function OPTIONS() {
   return new Response(null, {
     headers: {
@@ -31,9 +34,16 @@ function matchesEtag(ifNoneMatch: string | null, etag: string): boolean {
   );
 }
 
-export async function GET(request: Request) {
+function getManifestPayload(): { body: string; etag: string } {
+  if (cachedPayload) return cachedPayload;
+
   const body = JSON.stringify(generateProviderPluginManifest());
-  const etag = createEtag(body);
+  cachedPayload = { body, etag: createEtag(body) };
+  return cachedPayload;
+}
+
+export async function GET(request: Request) {
+  const { body, etag } = getManifestPayload();
   const headers = { ...CACHE_HEADERS, ETag: etag };
 
   if (matchesEtag(request.headers.get("If-None-Match"), etag)) {

--- a/src/app/api/v1/provider-plugin-manifest/route.ts
+++ b/src/app/api/v1/provider-plugin-manifest/route.ts
@@ -27,7 +27,7 @@ function matchesEtag(ifNoneMatch: string | null, etag: string): boolean {
     ifNoneMatch
       ?.split(",")
       .map((value) => value.trim())
-      .some((value) => value === "*" || value === etag)
+      .some((value) => value === "*" || value === etag || value === `W/${etag}`)
   );
 }
 

--- a/tests/unit/api/v1/provider-plugin-manifest-route.test.ts
+++ b/tests/unit/api/v1/provider-plugin-manifest-route.test.ts
@@ -1,16 +1,34 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { GET } from "../../../../src/app/api/v1/provider-plugin-manifest/route.ts";
+import {
+  GET,
+  OPTIONS,
+} from "../../../../src/app/api/v1/provider-plugin-manifest/route.ts";
 
 test("provider plugin manifest returns a stable ETag with its cache policy", async () => {
   const response = await GET(new Request("http://localhost/api/v1/provider-plugin-manifest"));
+  const body = await response.json();
 
   assert.equal(response.status, 200);
   assert.equal(response.headers.get("Cache-Control"), "public, max-age=60");
   assert.match(response.headers.get("ETag") ?? "", /^"[A-Za-z0-9_-]+"$/);
   assert.equal(response.headers.get("Content-Type"), "application/json");
-  assert.equal((await response.json()).schemaVersion, 1);
+  assert.equal(body.schemaVersion, 1);
+  assert.equal(body.generatedFrom, "open-sse/config/providers");
+  assert.ok(body.providers.length > 100);
+  assert.ok(body.providers.some((provider: { id: string }) => provider.id === "openai"));
+
+  const serialized = JSON.stringify(body);
+  assert.equal(serialized.includes("clientSecret"), false);
+});
+
+test("provider plugin manifest route handles CORS preflight", async () => {
+  const response = await OPTIONS();
+
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get("Access-Control-Allow-Methods"), "GET, OPTIONS");
+  assert.equal(response.headers.get("Access-Control-Allow-Headers"), "*");
 });
 
 test("provider plugin manifest supports conditional sidecar refreshes", async () => {

--- a/tests/unit/api/v1/provider-plugin-manifest-route.test.ts
+++ b/tests/unit/api/v1/provider-plugin-manifest-route.test.ts
@@ -1,30 +1,29 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import {
-  GET,
-  OPTIONS,
-} from "../../../../src/app/api/v1/provider-plugin-manifest/route.ts";
+import { GET } from "../../../../src/app/api/v1/provider-plugin-manifest/route.ts";
 
-test("provider plugin manifest route returns JSON-safe manifest", async () => {
-  const response = await GET();
-  const body = await response.json();
+test("provider plugin manifest returns a stable ETag with its cache policy", async () => {
+  const response = await GET(new Request("http://localhost/api/v1/provider-plugin-manifest"));
 
   assert.equal(response.status, 200);
+  assert.equal(response.headers.get("Cache-Control"), "public, max-age=60");
+  assert.match(response.headers.get("ETag") ?? "", /^"[A-Za-z0-9_-]+"$/);
   assert.equal(response.headers.get("Content-Type"), "application/json");
-  assert.equal(body.schemaVersion, 1);
-  assert.equal(body.generatedFrom, "open-sse/config/providers");
-  assert.ok(body.providers.length > 100);
-  assert.ok(body.providers.some((provider: { id: string }) => provider.id === "openai"));
-
-  const serialized = JSON.stringify(body);
-  assert.equal(serialized.includes("clientSecret"), false);
+  assert.equal((await response.json()).schemaVersion, 1);
 });
 
-test("provider plugin manifest route handles CORS preflight", async () => {
-  const response = await OPTIONS();
+test("provider plugin manifest supports conditional sidecar refreshes", async () => {
+  const initial = await GET(new Request("http://localhost/api/v1/provider-plugin-manifest"));
+  const etag = initial.headers.get("ETag");
 
-  assert.equal(response.status, 200);
-  assert.equal(response.headers.get("Access-Control-Allow-Methods"), "GET, OPTIONS");
-  assert.equal(response.headers.get("Access-Control-Allow-Headers"), "*");
+  const response = await GET(
+    new Request("http://localhost/api/v1/provider-plugin-manifest", {
+      headers: { "If-None-Match": etag ?? "" },
+    })
+  );
+
+  assert.equal(response.status, 304);
+  assert.equal(response.headers.get("ETag"), etag);
+  assert.equal(await response.text(), "");
 });

--- a/tests/unit/api/v1/provider-plugin-manifest-route.test.ts
+++ b/tests/unit/api/v1/provider-plugin-manifest-route.test.ts
@@ -27,3 +27,16 @@ test("provider plugin manifest supports conditional sidecar refreshes", async ()
   assert.equal(response.headers.get("ETag"), etag);
   assert.equal(await response.text(), "");
 });
+
+test("provider plugin manifest accepts weak conditional validators", async () => {
+  const initial = await GET(new Request("http://localhost/api/v1/provider-plugin-manifest"));
+  const etag = initial.headers.get("ETag");
+
+  const response = await GET(
+    new Request("http://localhost/api/v1/provider-plugin-manifest", {
+      headers: { "If-None-Match": `W/${etag}` },
+    })
+  );
+
+  assert.equal(response.status, 304);
+});


### PR DESCRIPTION
Add strong ETags and If-None-Match handling to the provider plugin manifest endpoint. Bifrost and CLIProxyAPI sidecars can now refresh the contract without repeatedly transferring the full provider registry when it has not changed.