### PR TITLE
fix(antigravity): keep unreported quota fraction unknown

### DIFF
--- a/open-sse/services/usage/antigravity.ts
+++ b/open-sse/services/usage/antigravity.ts
@@ -647,12 +647,12 @@ export async function getAntigravityUsage(
 
       const liveQuota = userQuotaEntries.get(modelKey);
       const quotaSource = liveQuota || quotaInfo;
-      const rawFraction = toNumber(quotaSource.remainingFraction, -1);
+      const rawFraction = toNumber(quotaSource.remainingFraction, Number.NaN);
       const resetAt = parseResetTime(quotaSource.resetTime);
       // Distinguish "upstream did not report remainingFraction" from "remaining is 0%".
       // fetchAvailableModels is a catalog view and can be stale/full; retrieveUserQuota is
       // the source of truth for actual Gemini consumption when it includes the model.
-      const fractionReported = rawFraction >= 0;
+      const fractionReported = Number.isFinite(rawFraction);
       if (!fractionReported) {
         console.warn(
           `[Antigravity] model ${modelKey} returned no remainingFraction — quota unknown`
@@ -662,18 +662,20 @@ export async function getAntigravityUsage(
       // Models with no resetTime AND a reported full fraction are unlimited
       // (e.g. tab-completion models). Unreported fraction is NEVER unlimited.
       const isUnlimited = fractionReported && !resetAt && remainingFraction >= 1;
-      const remainingPercentage = remainingFraction * 100;
       const QUOTA_NORMALIZED_BASE = 1000;
-      const total = QUOTA_NORMALIZED_BASE;
+      const total = fractionReported ? QUOTA_NORMALIZED_BASE : 0;
       const remaining = Math.round(total * remainingFraction);
       const used = isUnlimited ? 0 : Math.max(0, total - remaining);
 
       quotas[modelKey] = applyLocalUsageFallback(
         {
+          // An omitted fraction is unknown, not a 0% sentinel. Keep the reset
+          // timestamp for display, but omit numeric quota fields so cache and
+          // preflight fail open rather than turning uncertainty into exhaustion.
           used,
           total: isUnlimited ? 0 : total,
           resetAt,
-          remainingPercentage: isUnlimited ? 100 : remainingPercentage,
+          ...(fractionReported && { remainingPercentage: isUnlimited ? 100 : remainingFraction * 100 }),
           unlimited: isUnlimited,
           fractionReported,
           quotaSource: liveQuota ? "retrieveUserQuota" : "fetchAvailableModels",

--- a/tests/unit/antigravity-usage-service.test.ts
+++ b/tests/unit/antigravity-usage-service.test.ts
@@ -2,7 +2,7 @@
  * Tests for open-sse/services/usage.ts — Antigravity quota parsing.
  *
  * Verifies that remainingFraction is correctly parsed:
- * - undefined → 0% remaining (exhausted quota)
+ * - undefined → unknown quota (not exhausted)
  * - 0 → 0% remaining (exhausted quota, explicit)
  * - 1.0 → 100% remaining (full quota)
  * - 1.0 without resetTime → unlimited (e.g. tab-completion)
@@ -28,7 +28,7 @@ describe("getUsageForProvider (antigravity in usage.ts)", () => {
     projectId: undefined,
   };
 
-  it("defaults to 0% remaining when remainingFraction is undefined", async () => {
+  it("treats a missing remainingFraction as unknown rather than exhausted", async () => {
     const originalFetch = globalThis.fetch;
     globalThis.fetch = async () =>
       ({
@@ -53,9 +53,10 @@ describe("getUsageForProvider (antigravity in usage.ts)", () => {
       if ("quotas" in result) {
         const quota = result.quotas["gemini-3.5-flash-high"];
         assert.ok(quota, "should have quota for gemini-3.5-flash-high");
-        assert.equal(quota.remainingPercentage, 0, "remaining should be 0%");
+        assert.equal(quota.remainingPercentage, undefined, "unknown quota must not become 0%");
+        assert.equal(quota.fractionReported, false, "missing fraction should be marked unknown");
         assert.equal(quota.unlimited, false, "should not be unlimited");
-        assert.equal(quota.used > 0, true, "used should be > 0 when quota is exhausted");
+        assert.equal(quota.used, 0, "unknown quota must not report usage");
       }
     } finally {
       globalThis.fetch = originalFetch;

--- a/tests/unit/generic-quota-fetcher.test.ts
+++ b/tests/unit/generic-quota-fetcher.test.ts
@@ -114,3 +114,12 @@ test("registerGenericQuotaFetchers registers Claude, GLM, and OpenCode Go via th
   // which would couple this test to chat.ts startup wiring. The skip list
   // semantics are exercised by the source code review.
 });
+
+test("convertUsageToQuotaInfo skips Antigravity quota entries with an unknown fraction", () => {
+  const result = convertUsageToQuotaInfo({
+    quotas: {
+      gemini: { fractionReported: false, resetAt: "2026-05-14T20:00:00Z" },
+    },
+  });
+  assert.equal(result, null);
+});


### PR DESCRIPTION
## Summary
- treat a missing or invalid Antigravity `remainingFraction` as unknown instead of confirmed exhaustion
- keep explicit `remainingFraction: 0` as exhausted
- preserve the upstream reset timestamp while omitting unknown numeric quota fields so preflight fails open

## Scope
This is a minimal, independent patch rebased on current `main`. It intentionally excludes model-scoped/exact-precedence changes, runtime/deployment fixes, configs, workflows, and unrelated files.

## Verification
- targeted unit tests: 18 passed, 0 failed
- `git diff origin/main...HEAD --check`
- changed-file scope verified: one service file and two focused unit-test files

No deployments are included.