### PR TITLE
fix(docker): approve better-sqlite3 install scripts before rebuild

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,8 @@ ENV NPM_CONFIG_LEGACY_PEER_DEPS=true
 # --ignore-scripts blocks broad dependency install/postinstall hooks, closing
 # the supply-chain attack surface where a transitive dep can run arbitrary code
 # at install time. better-sqlite3 still needs a native binding for the target
-# platform, so rebuild and smoke-test only that known runtime dependency below.
+# platform, so approve its install script and rebuild it, then smoke-test only
+# that known runtime dependency below.
 #
 # We REQUIRE a committed package-lock.json so resolved dependency versions
 # are reproducible.
@@ -57,6 +58,7 @@ RUN test -f package-lock.json \
   || (echo "package-lock.json is required for reproducible Docker builds" >&2 && exit 1)
 RUN --mount=type=cache,id=npm-cache,target=/root/.npm \
   npm ci --no-audit --no-fund --legacy-peer-deps --ignore-scripts \
+  && npm install-scripts approve better-sqlite3 \
   && npm rebuild better-sqlite3 \
   && node -e "require('better-sqlite3')(':memory:').close()"
 


### PR DESCRIPTION
npm 12 (shipped by npm@latest in node:24-trixie-slim) blocks install scripts via the allowScripts allowlist. rebuilt dependencies successfully was being silently skipped because the package was not approved, so the native binding was never compiled and the smoke test failed with 'Could not locate the bindings file'.

Approve better-sqlite3 explicitly in the builder stage before rebuild so the native module is built inside the Docker image.

## Summary

- Describe the user-facing or operational change.

## Related Issues

- Closes #
- Related to #

## Validation

- [ ] `npm run lint`
- [ ] `npm run test:unit`
- [ ] `npm run test:coverage`
- [ ] Coverage is still `>= 60%` for statements, lines, functions, and branches
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below

## Tests Added Or Updated

- List every changed or added automated test file.
- If no production code changed, state that here.

## Coverage Notes

- If this PR changes `src/`, `open-sse/`, `electron/`, or `bin/`, explain which tests cover the change.
- If coverage moved down in any touched file, explain why and what follow-up task will recover it.

## Reviewer Notes

- Call out any risky areas, migrations, feature flags, or manual validation that reviewers should know about.