### PR TITLE
fix(providers): classify Cloudflare neuron 429 as quota_exhausted (#6980)

### DIFF
--- a/open-sse/config/providerErrorRules.ts
+++ b/open-sse/config/providerErrorRules.ts
@@ -130,6 +130,30 @@ function buildMinimaxRules(): ProviderErrorRule[] {
   ];
 }
 
+// ─── Cloudflare Workers AI ───────────────────────────────────────────────
+// Free tier = 10,000 Neurons/day, shared across the WHOLE account
+// (docs/reference/FREE_TIERS.md; official: developers.cloudflare.com/
+// workers-ai/platform/errors/, code 4006). The exhaustion body
+// ("you have used up your daily free allocation of 10,000 neurons, please
+// upgrade to Cloudflare's Workers Paid plan…") doesn't match any QUOTA_PATTERNS
+// keyword, so it fell through to RATE_LIMIT_EXCEEDED (~5s cooldown) and the
+// combo kept retrying every model on the same provider until UTC midnight.
+// Scope "connection": the upstream quota is per-account (same reasoning as the
+// opencode rules — see Issue #2). (OmniRoute issue #6980)
+function buildCloudflareAiRules(): ProviderErrorRule[] {
+  return [
+    {
+      id: "cloudflare-ai-daily-neuron-allocation",
+      match: ({ status, body }) => {
+        if (status !== 429) return null;
+        const text = JSON.stringify(body ?? "").toLowerCase();
+        if (!text.includes("daily free allocation")) return null;
+        return { reason: "quota_exhausted", scope: "connection" };
+      },
+    },
+  ];
+}
+
 /**
  * Global registry. Provider name → ordered list of rules (first match wins).
  * Add new providers here; the matcher in classifyError will pick them up
@@ -141,6 +165,7 @@ export const providerRuleRegistry = new Map<string, ProviderErrorRule[]>([
   ["opencode-cli", buildOpencodeRules()],
   ["minimax", buildMinimaxRules()],
   ["minimax-passthrough", buildMinimaxRules()],
+  ["cloudflare-ai", buildCloudflareAiRules()],
 ]);
 
 /**

--- a/src/shared/utils/classify429.ts
+++ b/src/shared/utils/classify429.ts
@@ -53,6 +53,14 @@ const QUOTA_PATTERNS: ReadonlyArray<RegExp> = [
   /individual quota reached/i,
   /enable overages/i,
   /INSUFFICIENT_G1_CREDITS_BALANCE/i,
+
+  // Cloudflare Workers AI free tier: "you have used up your daily free
+  // allocation of 10,000 neurons" (workers-ai error 4006). It is a daily
+  // account-wide quota, not a rate-limit — misclassification locked the
+  // connection for only ~5s and retried every ~60s against a budget that
+  // only resets at UTC midnight. Defense-in-depth for the classify429FromError
+  // path (the providerErrorRules entry is the primary fix). (OmniRoute #6980)
+  /daily free allocation/i,
 ];
 
 /**

--- a/tests/unit/cloudflare-ai-neuron-quota-6980.test.ts
+++ b/tests/unit/cloudflare-ai-neuron-quota-6980.test.ts
@@ -1,0 +1,38 @@
+// Issue #6980 — Cloudflare Workers AI "daily free allocation" (neuron) 429 must be
+// classified as quota_exhausted (account-wide, resets at UTC midnight), not a transient
+// rate_limit. Covers both the providerErrorRules entry and the classify429 QUOTA_PATTERNS
+// defense-in-depth path.
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { getProviderErrorRuleMatch } = await import(
+  "../../open-sse/config/providerErrorRules.ts"
+);
+const { classify429 } = await import("../../src/shared/utils/classify429.ts");
+
+const CLOUDFLARE_BODY = {
+  errors: [
+    {
+      code: 4006,
+      message:
+        "you have used up your daily free allocation of 10,000 neurons, please upgrade to Cloudflare's Workers Paid plan",
+    },
+  ],
+};
+
+test("#6980 cloudflare-ai 429 with 'daily free allocation' is quota_exhausted (connection scope)", () => {
+  const match = getProviderErrorRuleMatch("cloudflare-ai", 429, {}, CLOUDFLARE_BODY);
+  assert.ok(match, "expected a provider rule match for cloudflare-ai neuron exhaustion");
+  assert.equal(match!.reason, "quota_exhausted");
+  assert.equal(match!.scope, "connection");
+});
+
+test("#6980 cloudflare-ai generic 429 (no allocation wording) does NOT match the quota rule", () => {
+  const match = getProviderErrorRuleMatch("cloudflare-ai", 429, {}, { error: "rate limit exceeded" });
+  assert.equal(match, null, "generic rate-limit 429 must not be classified as quota_exhausted");
+});
+
+test("#6980 classify429 QUOTA_PATTERNS catches cloudflare neuron wording (defense-in-depth)", () => {
+  const kind = classify429({ status: 429, body: CLOUDFLARE_BODY });
+  assert.equal(kind, "quota_exhausted");
+});

--- a/tests/unit/cloudflare-ai-neuron-quota-6980.test.ts
+++ b/tests/unit/cloudflare-ai-neuron-quota-6980.test.ts
@@ -5,10 +5,8 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-const { getProviderErrorRuleMatch } = await import(
-  "../../open-sse/config/providerErrorRules.ts"
-);
-const { classify429 } = await import("../../src/shared/utils/classify429.ts");
+import { getProviderErrorRuleMatch } from "../../open-sse/config/providerErrorRules.ts";
+import { classify429 } from "../../src/shared/utils/classify429.ts";
 
 const CLOUDFLARE_BODY = {
   errors: [


### PR DESCRIPTION
## Summary
Cloudflare Workers AI free-tier exhaustion (429, body: *"you have used up your daily free allocation of 10,000 neurons"*, workers-ai error 4006) was misclassified as a transient `rate_limit`, so the connection was only locked for ~5s and the combo kept retrying every model against a budget that only resets at UTC midnight.

This PR:
- Adds a `cloudflare-ai` provider rule in `open-sse/config/providerErrorRules.ts` scoped `connection` (per-account budget, same reasoning as the existing `opencode` rules) that returns `quota_exhausted` on a 429 whose body mentions "daily free allocation".
- Adds `/daily free allocation/i` to `QUOTA_PATTERNS` in `src/shared/utils/classify429.ts` as defense-in-depth for the `classify429FromError` path.

## Test plan
- New regression test `tests/unit/cloudflare-ai-neuron-quota-6980.test.ts` (node:test) asserts: the rule matches and yields `quota_exhausted`/`connection`, a generic rate-limit 429 does not match, and `classify429` classifies the Cloudflare body as `quota_exhausted`.

Closes #6980
