### PR TITLE
fix(compression): lazy-load typescript in RTK codeStripper (#7096)

### DIFF
--- a/open-sse/services/compression/engines/rtk/codeStripper.ts
+++ b/open-sse/services/compression/engines/rtk/codeStripper.ts
@@ -1,4 +1,22 @@
-import ts from "typescript";
+import { createRequire } from "module";
+
+// `typescript` is a devDependency. Requiring it at module top-level (the old
+// code did `import ts from "typescript"`) crashed every Compression Context
+// page after a production-lean deploy (`npm prune --omit=dev`) removed it.
+// Lazily resolve it on first use and gracefully skip TS-aware comment
+// stripping when it is unavailable — compression still works, just less
+// aggressively on code blocks. (OmniRoute issue #7096)
+let _tsModule: typeof import("typescript") | null | undefined;
+function getTsModule(): typeof import("typescript") | null {
+  if (_tsModule !== undefined) return _tsModule;
+  try {
+    const require = createRequire(import.meta.url);
+    _tsModule = require("typescript");
+  } catch {
+    _tsModule = null;
+  }
+  return _tsModule;
+}
 
 export type CodeLanguage =
   | "javascript"
@@ -60,6 +78,13 @@ export function detectCodeLanguage(text: string): CodeLanguage {
  * JSX expression-container comments are never corrupted.
  */
 function stripJsTsComments(text: string, preserveDocstrings: boolean): string {
+  const ts = getTsModule();
+  if (!ts) {
+    // typescript devDependency not installed (e.g. `npm prune --omit=dev`).
+    // Skip TS-aware comment stripping; the caller still applies empty-line /
+    // whitespace collapsing, so compression keeps working on the plain path.
+    return text;
+  }
   const source = ts.createSourceFile(
     "snippet.tsx",
     text,

--- a/tests/unit/rtk-codeStripper-typescript-prune-7096.test.ts
+++ b/tests/unit/rtk-codeStripper-typescript-prune-7096.test.ts
@@ -1,0 +1,34 @@
+// Issue #7096 — RTK codeStripper must not require the `typescript` devDependency at
+// module load. After `npm prune --omit=dev`, typescript is gone; the stripper must
+// degrade gracefully (skip TS-aware comment stripping) instead of throwing
+// "Cannot find module 'typescript'". The lazy loader is exercised here on the
+// happy path (typescript present in dev/build) and the function is asserted to
+// stay callable and JSX-safe.
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { stripCode } = await import(
+  "../../open-sse/services/compression/engines/rtk/codeStripper.ts"
+);
+
+test("#7096 TS-aware comment stripping works when typescript is available", () => {
+  const input = "// leading\nconst x = 1; // trailing\nfunction f() { return 2; }";
+  const out = stripCode(input, "javascript", { removeComments: true });
+  assert.ok(!out.text.includes("// leading"), "leading comment stripped");
+  assert.ok(!out.text.includes("// trailing"), "trailing comment stripped");
+  assert.ok(out.text.includes("const x = 1"), "code preserved");
+});
+
+test("#7096 JSX is left intact (no corruption of expression comments)", () => {
+  const input = "const el = <div>{/* c */ 1}</div>;";
+  const out = stripCode(input, "typescript", { removeComments: true });
+  assert.ok(out.text.includes("<div>"), "JSX preserved");
+});
+
+test("#7096 stripCode stays callable and does not throw", () => {
+  assert.doesNotThrow(() =>
+    stripCode("/* block */ const y = 2;", "typescript", { removeComments: true })
+  );
+  const out = stripCode("/* block */ const y = 2;", "typescript", { removeComments: true });
+  assert.ok(typeof out.text === "string");
+});


### PR DESCRIPTION
## Summary
`open-sse/services/compression/engines/rtk/codeStripper.ts` did `import ts from "typescript"` at module top-level, but `typescript` is only a **devDependency**. After a production-lean deploy (`npm run build && npm prune --omit=dev`), the package is removed and every Compression Context page (Lite, Aggressive, Ultra, CCR) fails to load with "typescript module not found".

This PR converts the top-level import into a lazy `createRequire(import.meta.url)` + `require("typescript")` resolved on first use, wrapped in try/catch. When `typescript` is absent (pruned), the stripper gracefully skips TS-aware comment stripping and returns the text unchanged — the caller still applies empty-line/whitespace collapsing, so compression keeps working, just less aggressively on code blocks. When present (dev/build), behavior is unchanged.

## Test plan
- New regression test `tests/unit/rtk-codeStripper-typescript-prune-7096.test.ts` (node:test) asserts: comments are stripped when typescript is available, JSX is left intact, and `stripCode` never throws.

Closes #7096
