### PR TITLE
fix(quality): anchor cognitive-complexity parse on the cognitive section (#7009)

### DIFF
--- a/scripts/quality/validate-release-green.mjs
+++ b/scripts/quality/validate-release-green.mjs
@@ -126,7 +126,20 @@ export function parseEslintJson(out) {
 
 /** Pull the cognitive-complexity violation count from the gate's output. */
 export function parseCognitiveCount(out) {
-  const m = String(out || "").match(/(\d+)\s+(?:function\(s\) exceed|violações|violations)/i);
+  const s = String(out || "");
+  // The combined `check:complexity-ratchets` walk prints BOTH the cyclomatic and
+  // cognitive sections in one ESLint pass. Each section reports `NNN violações`
+  // (or `NNN function(s) exceed`), so a naive /(\d+)\s+violações/ match grabs the
+  // cyclomatic total (e.g. 2056) instead of the cognitive one (e.g. 890) whenever
+  // the cyclomatic block is emitted first. That produced a phantom +1166 cognitive
+  // drift (#7009). Anchor strictly on the cognitive section: prefer the explicit
+  // `cognitiveComplexity=NNN` print line, then the `[cognitive-complexity]`-tagged
+  // line. Never fall through to the bare `violações`/`violations` pattern.
+  const explicit = /cognitiveComplexity=(\d+)/.exec(s);
+  if (explicit) return Number(explicit[1]);
+  const m = s.match(
+    /\[cognitive-complexity\][^\n]*?(\d+)\s+(?:function\(s\) exceed|viola[çc]õ?es|violations)/i
+  );
   return m ? Number(m[1]) : null;
 }
 

--- a/scripts/quality/validate-release-green.mjs
+++ b/scripts/quality/validate-release-green.mjs
@@ -138,7 +138,7 @@ export function parseCognitiveCount(out) {
   const explicit = /cognitiveComplexity=(\d+)/.exec(s);
   if (explicit) return Number(explicit[1]);
   const m = s.match(
-    /\[cognitive-complexity\][^\n]*?(\d+)\s+(?:function\(s\) exceed|viola[çc]õ?es|violations)/i
+    /\[cognitive-complexity\][^\n]*?(\d+)\s+(?:function\(s\) exceed|viola[çc][õo]?es|violations)/i
   );
   return m ? Number(m[1]) : null;
 }

--- a/tests/unit/validate-release-green.test.ts
+++ b/tests/unit/validate-release-green.test.ts
@@ -297,3 +297,7 @@ test("extractCiGates: the REAL ci.yml yields the base-reds that leaked in v3.8.4
   }
   assert.ok(ids.size >= 20, "the real gate set is substantial (>= 20 static gates)");
 });
+
+test("parseCognitiveCount matches unaccented Portuguese 'violacoes'", () => {
+  assert.equal(parseCognitiveCount("[cognitive-complexity] 812 violacoes > baseline 797"), 812);
+});

--- a/tests/unit/validate-release-green.test.ts
+++ b/tests/unit/validate-release-green.test.ts
@@ -42,6 +42,18 @@ test("parseCognitiveCount reads the gate's count (en + pt)", () => {
   assert.equal(parseCognitiveCount("no number"), null);
 });
 
+test("parseCognitiveCount ignores the cyclomatic section in combined ratchet output (#7009)", () => {
+  // The shared ESLint walk emits the cyclomatic block (2056) BEFORE the cognitive
+  // block (890). A loose /(\d+)\s+violações/ match previously grabbed 2056 and faked
+  // a +1166 cognitive drift. The parser must return the cognitive count (890).
+  const combined =
+    "[complexity] OK — 2056 violações (baseline 2056)\n" +
+    "cognitiveComplexity=890\n" +
+    "[cognitive-complexity] 890 function(s) exceed the cognitive-complexity threshold (15).\n" +
+    "[cognitive-complexity] OK — 890 violações (baseline 890)";
+  assert.equal(parseCognitiveCount(combined), 890);
+});
+
 test("isDrift flags only growth past the committed baseline (down-direction ratchets)", () => {
   assert.equal(isDrift(3900, 3867), true); // grew → drift
   assert.equal(isDrift(3867, 3867), false); // equal → ok


### PR DESCRIPTION
## Summary
`scripts/quality/validate-release-green.mjs` reports a phantom **+1166 cognitive-complexity drift** on every pre-flight.

Root cause: `parseCognitiveCount()` used a loose regex `/(\d+)\s+(?:function\(s\) exceed|violações|violations)/i`. The combined `check:complexity-ratchets` ESLint walk prints **both** the cyclomatic block (e.g. `2056 violações`) **and** the cognitive block (e.g. `890 violações`) in one pass; when the cyclomatic section is emitted first, the unanchored match grabs `2056` and feeds it into the cognitive ratchet (baseline `890`) → `+1166 drift`. The standalone `check-cognitive-complexity.mjs` correctly reports `890`, confirming the parser is at fault.

## Fix
Anchor strictly on the cognitive section:
- prefer the explicit `cognitiveComplexity=NNN` print line, then
- the `[cognitive-complexity]`-tagged line.
Never fall through to the bare `violações`/`violations` pattern.

## Test
Added a regression test that feeds the real combined output (cyclomatic `2056` block first, cognitive `890` block second) and asserts the parser returns `890`. This fails on the old regex and passes on the fix.

Drift is non-blocking, so this is a reporting/correctness fix (not a release gate change).

fixes #7009
