### PR TITLE
fix(deps): pin transitive esbuild to 0.27.x (avoid 0.28 transform regression) (#5757)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omniroute",
-  "version": "3.8.47",
+  "version": "3.8.48",
   "description": "Unified AI router with 160+ providers, RTK+Caveman compression, auto fallback, MCP/A2A, desktop, PWA, and OpenAI-compatible APIs.",
   "type": "module",
   "bin": {
@@ -372,6 +372,7 @@
     ]
   },
   "overrides": {
+    "esbuild": "^0.27.4",
     "dompurify": "^3.4.11",
     "postcss": "^8.5.14",
     "ip-address": "10.2.0",


### PR DESCRIPTION
## Summary
A fresh `omniroute` install resolves `tsx -> esbuild@0.28.x`, which exposes builds/startup tooling to the upstream esbuild regression (transforms targeting older environments fail with _"Transforming destructuring to the configured target environment (...) is not supported yet"_).

## Fix
Add an npm `overrides` entry pinning the transitive `esbuild` resolution to the `0.27.x` line (known-good), excluding the broken `0.28.x`:
```json
"overrides": {
  "esbuild": "^0.27.4",
  ...
}
```
This matches the documented workaround in the issue (no manual user override required on a fresh install). `^0.27.4` keeps 0.27.x patches while excluding 0.28.x.

## Note
I could not run a full `npm install` in this environment to exercise the build, so this is a config-level band-aid following the issue's recommended fix. CI (which runs the build) is the real gate.

fixes #5757
