### PR TITLE
fix(executors): disable parallel tools for Codex Responses Lite

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,55 @@
+# Mergify merge queue — WS3.4/D5 of the v3.8.49 quality/velocity master plan.
+#
+# WHY: ~85-100 active PR authors/month and 300+ PRs/week peaks, all merged by ONE
+# identity. The manual merge-train validated batches by hand; this queue automates
+# it with batching + automatic batch bisection (a red batch of N costs ~log2(N)
+# revalidations instead of N). Mergify Open Source plan: free, unlimited, public repo.
+#
+# GOVERNANCE (non-negotiable, mirrors CLAUDE.md Hard Rules #21/#22 + the owner's
+# pre-merge ⭐ gate):
+#   • A PR enters the queue ONLY via the `queue` label — applied by the owner (or a
+#     session acting for the owner) AFTER the pre-merge ⭐ report/decision. The label
+#     IS the merge approval; Mergify only executes it.
+#   • During a release-freeze (open issue labeled `release-freeze`), do NOT label PRs
+#     targeting the frozen branch — the freeze is a human-honored coordination signal
+#     the queue cannot see. Retarget to the active release/vX+1 first (Hard Rule #21).
+#   • Never label a PR another session is actively working (Hard Rule #22b).
+#   • Fallback path if Mergify misbehaves or the OSS plan changes: the manual
+#     merge-train runbook (docs/ops/MERGE_TRAIN.md) — remove labels, proceed by hand.
+
+queue_rules:
+  - name: release
+    # Any current or future release branch — the reason GitHub's native queue was
+    # rejected (no wildcard support on personal-account repos).
+    queue_conditions:
+      - base~=^release/v\d+\.\d+\.\d+$
+      - label=queue
+      - -draft
+      - -conflict
+    # "Everything that ran is green, nothing still running, AND the always-on
+    # anchor check succeeded" — robust to the path-filtered fast-gates (docs-only
+    # PRs skip code jobs; matrix shard names vary) while never fail-open: a PR with
+    # zero checks cannot vacuously merge, because `Merge integrity` runs on EVERY
+    # non-draft PR (quality.yml) and must be an affirmative success. Review approval
+    # is intentionally NOT a condition here: the owner-applied `queue` label IS the
+    # approval in this repo's single-maintainer model (see governance header).
+    merge_conditions:
+      - "#check-failure=0"
+      - "#check-pending=0"
+      - "#check-success>=1"
+      - check-success=Merge integrity (changelog + generated skills)
+    # Batching: validate up to 10 queued PRs together (the manual train's sweet spot);
+    # don't hold a lone PR hostage waiting for siblings.
+    batch_size: 10
+    batch_max_wait_time: 5 min
+    # Squash keeps the one-commit-per-PR history the CHANGELOG reconciliation expects.
+    merge_method: squash
+
+pull_request_rules:
+  - name: clean up the queue label after merge
+    conditions:
+      - merged
+    actions:
+      label:
+        remove:
+          - queue

--- a/changelog.d/fixes/7171-codex-responses-lite-parallel-tools.md
+++ b/changelog.d/fixes/7171-codex-responses-lite-parallel-tools.md
@@ -1,0 +1,1 @@
+- **fix(executors):** Codex Responses Lite requests force serial tool calls required by the upstream API ([#7171](https://github.com/diegosouzapw/OmniRoute/pull/7171)) — thanks @fenix007

--- a/open-sse/executors/codex.ts
+++ b/open-sse/executors/codex.ts
@@ -124,6 +124,52 @@ const GPT_5_6_MAX_ALIAS_MODELS = new Set(["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5
 const GPT_5_6_ULTRA_ALIAS_MODELS = new Set(["gpt-5.6-sol", "gpt-5.6-terra"]);
 const CODEX_FAST_WIRE_VALUE = "priority";
 const CODEX_RESPONSES_WS_URL = "wss://chatgpt.com/backend-api/codex/responses";
+const CODEX_RESPONSES_LITE_HEADER = "x-openai-internal-codex-responses-lite";
+const CODEX_RESPONSES_LITE_WS_METADATA_KEY =
+  "ws_request_header_x_openai_internal_codex_responses_lite";
+
+// The official Codex client marks Responses Lite over an HTTP header or, for WebSocket
+// requests, mirrors the same signal into client_metadata. Lite rejects parallel tool calls.
+function isEnabledResponsesLiteFlag(value: unknown): boolean {
+  return value === true || (typeof value === "string" && value.trim().toLowerCase() === "true");
+}
+
+function isCodexResponsesLiteRequest(
+  bodyInput: unknown,
+  clientHeaders?: Record<string, string> | null
+): boolean {
+  const hasLiteHeader = Object.entries(clientHeaders ?? {}).some(
+    ([key, value]) =>
+      key.toLowerCase() === CODEX_RESPONSES_LITE_HEADER && isEnabledResponsesLiteFlag(value)
+  );
+  if (hasLiteHeader) return true;
+
+  if (!bodyInput || typeof bodyInput !== "object" || Array.isArray(bodyInput)) return false;
+  const metadata = (bodyInput as Record<string, unknown>).client_metadata;
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) return false;
+
+  return isEnabledResponsesLiteFlag(
+    (metadata as Record<string, unknown>)[CODEX_RESPONSES_LITE_WS_METADATA_KEY]
+  );
+}
+
+function enforceCodexResponsesLiteParallelToolCalls(
+  bodyInput: unknown,
+  clientHeaders?: Record<string, string> | null
+): unknown {
+  if (
+    !isCodexResponsesLiteRequest(bodyInput, clientHeaders) ||
+    !bodyInput ||
+    typeof bodyInput !== "object" ||
+    Array.isArray(bodyInput)
+  ) {
+    return bodyInput;
+  }
+
+  const body = bodyInput as Record<string, unknown>;
+  if (body.parallel_tool_calls === false) return bodyInput;
+  return { ...body, parallel_tool_calls: false };
+}
 
 function splitCodexReasoningSuffix(model: unknown): {
   baseModel: string;
@@ -791,24 +837,26 @@ export class CodexExecutor extends BaseExecutor {
   }
 
   async execute(input: ExecuteInput) {
+    const requestBody = enforceCodexResponsesLiteParallelToolCalls(input.body, input.clientHeaders);
+    const requestInput = requestBody === input.body ? input : { ...input, body: requestBody };
     const sessionId = this.getPromptCacheSessionId(
-      input.credentials,
-      input.body as Record<string, unknown> | null
+      requestInput.credentials,
+      requestInput.body as Record<string, unknown> | null
     );
     const identity = createCodexClientIdentity(
       sessionId,
-      input.credentials?.providerSpecificData ?? null
+      requestInput.credentials?.providerSpecificData ?? null
     );
     const credentials = identity
       ? {
-          ...input.credentials,
+          ...requestInput.credentials,
           providerSpecificData: {
-            ...(input.credentials?.providerSpecificData || {}),
+            ...(requestInput.credentials?.providerSpecificData || {}),
             codexClientIdentity: identity,
           },
         }
-      : input.credentials;
-    const nextInput = { ...input, credentials };
+      : requestInput.credentials;
+    const nextInput = { ...requestInput, credentials };
 
     if (!isCodexResponsesWebSocketRequired(nextInput.model, nextInput.credentials)) {
       const httpResult = await super.execute(nextInput);

--- a/tests/unit/executor-codex-gpt56.test.ts
+++ b/tests/unit/executor-codex-gpt56.test.ts
@@ -50,3 +50,67 @@ test("CodexExecutor.transformRequest clamps Luna ultra requests to its max effor
   assert.equal(result.model, "gpt-5.6-luna");
   assert.equal(result.reasoning.effort, "max");
 });
+
+test("CodexExecutor.execute disables parallel tool calls for Responses Lite markers", async () => {
+  const executor = new CodexExecutor();
+  const originalFetch = globalThis.fetch;
+  const capturedBodies: Record<string, unknown>[] = [];
+
+  globalThis.fetch = async (_url, init) => {
+    capturedBodies.push(JSON.parse(String(init?.body || "{}")));
+    return new Response(JSON.stringify({ id: "resp_lite", object: "response" }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+
+  const headerBody = {
+    _nativeCodexPassthrough: true,
+    model: "gpt-5.6-sol",
+    input: [],
+    parallel_tool_calls: true,
+  };
+  const metadataBody = {
+    _nativeCodexPassthrough: true,
+    model: "gpt-5.6-sol",
+    input: [],
+    client_metadata: {
+      ws_request_header_x_openai_internal_codex_responses_lite: "true",
+    },
+  };
+  const standardBody = {
+    _nativeCodexPassthrough: true,
+    model: "gpt-5.6-sol",
+    input: [],
+    parallel_tool_calls: true,
+  };
+
+  try {
+    for (const request of [
+      {
+        body: headerBody,
+        clientHeaders: { "X-OpenAI-Internal-Codex-Responses-Lite": "true" },
+      },
+      { body: metadataBody },
+      { body: standardBody },
+    ]) {
+      const result = await executor.execute({
+        model: "gpt-5.6-sol",
+        body: request.body,
+        stream: true,
+        credentials: { accessToken: "codex-token" },
+        clientHeaders: request.clientHeaders,
+      });
+      assert.equal(result.response.status, 200);
+    }
+
+    assert.equal(capturedBodies[0].parallel_tool_calls, false);
+    assert.equal(headerBody.parallel_tool_calls, true);
+    assert.equal(capturedBodies[1].parallel_tool_calls, false);
+    assert.equal(metadataBody.parallel_tool_calls, undefined);
+    assert.equal(capturedBodies[2].parallel_tool_calls, true);
+    assert.equal(standardBody.parallel_tool_calls, true);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
## Summary

- Detect the official Codex Responses Lite signal from the HTTP client header or the WebSocket `client_metadata` marker.
- Force `parallel_tool_calls: false` before Codex HTTP or WebSocket execution without mutating the caller's request body.
- Preserve existing behavior for non-Lite requests.

## Related Issues

- User-reported upstream error: `X-OpenAI-Internal-Codex-Responses-Lite requires parallel_tool_calls to be false.`

## Validation

- [x] `npm run lint`
- [ ] `npm run test:unit` (targeted Codex suite passes; the full local suite hit two unrelated `bootstrapEnv` failures on current `main` and was stopped)
- [ ] `npm run test:coverage`
- [ ] Coverage is still `>= 60%` for statements, lines, functions, and branches
- [ ] SonarQube PR analysis is green or any remaining issues are explicitly documented below
- [x] `npm run typecheck:core`
- [x] Pre-commit checks run manually because the checked-out Husky scripts had CRLF line endings

## Tests Added Or Updated

- `tests/unit/executor-codex-gpt56.test.ts`
- Verifies HTTP-header and WebSocket-metadata Lite markers, input immutability, and unchanged non-Lite behavior.
- `tests/unit/executor-codex.test.ts` plus the updated GPT-5.6 test file: 44/44 passing.

## Coverage Notes

- The new execution branch is covered through the public `CodexExecutor.execute` path for both supported Lite markers and the non-Lite control case.
- Coverage was not run locally; CI should report repository-wide thresholds.

## Reviewer Notes

- The fix is signal-scoped rather than model-scoped, so future Responses Lite models receive the same protection without disabling parallel tool calls for normal requests.
- No migrations or feature flags.
