### PR TITLE
fix(tests+providers): env-dependent tests exposed by GH-hosted runners (#6634 selfref shallow checkout + yuanbao live-network 401)

### DIFF
--- a/changelog.d/fixes/yuanbao-cookie-validation.md
+++ b/changelog.d/fixes/yuanbao-cookie-validation.md
@@ -1,0 +1,1 @@
+- **Providers**: yuanbao-web no longer forwards a foreign single cookie pair upstream — `buildYuanbaoCookie` only trusts `hy_user`/`hy_token` extractions the input explicitly names, so a missing session token now fails fast with the local 401 guidance instead of a live Tencent round-trip

--- a/changelog.d/maintenance/selfref-6634-shallow.md
+++ b/changelog.d/maintenance/selfref-6634-shallow.md
@@ -1,0 +1,1 @@
+- **Tests**: the #6634 self-reference test now fetches `origin/main` on demand and skips cleanly when the ref is unreachable — it failed as a false positive on shallow/single-ref checkouts (GitHub-hosted runners)

--- a/open-sse/executors/yuanbao-web.ts
+++ b/open-sse/executors/yuanbao-web.ts
@@ -106,8 +106,13 @@ function buildPrompt(messages: Array<Record<string, unknown>>): string {
 /** Build the `hy_source=web; hy_user=...; hy_token=...` cookie from the pasted header. */
 function buildYuanbaoCookie(rawApiKey: string): { cookie: string; hasToken: boolean } {
   const raw = stripCookieInputPrefix(rawApiKey || "");
-  const hyUser = extractCookieValue(raw, "hy_user");
-  const hyToken = extractCookieValue(raw, "hy_token");
+  // Guard the extractCookieValue bare-value fallback: for input that is a single
+  // FOREIGN pair (e.g. "some_other=abc") the helper returns the whole string, which
+  // used to fool this validation into forwarding garbage upstream (the request only
+  // failed when Tencent replied 401 — a live-network dependency). Yuanbao needs the
+  // two distinct cookies, so only trust an extraction the input explicitly names.
+  const hyUser = raw.includes("hy_user=") ? extractCookieValue(raw, "hy_user") : null;
+  const hyToken = raw.includes("hy_token=") ? extractCookieValue(raw, "hy_token") : null;
 
   if (hyUser && hyToken) {
     return { cookie: `hy_source=web; hy_user=${hyUser}; hy_token=${hyToken}`, hasToken: true };

--- a/tests/unit/check-test-masking-selfref-6634.test.ts
+++ b/tests/unit/check-test-masking-selfref-6634.test.ts
@@ -33,10 +33,23 @@ function git(args: string[]): string {
   return execFileSync("git", args, { encoding: "utf8" });
 }
 
-test("#6634: check-test-masking.test.ts's own tautology fixtures must not self-flag as weakening", () => {
+test("#6634: check-test-masking.test.ts's own tautology fixtures must not self-flag as weakening", (t) => {
   // origin/main predates the #6404 fixtures (countBareTautologies/scanBareTautologies
   // tests) that legitimately embed tautology-pattern literals as string fixtures.
-  const baseSrc = git(["show", "origin/main:" + FILE]);
+  // Shallow/single-ref checkouts (GitHub-hosted runners) have no origin/main —
+  // fetch it on demand; skip (never fail) when the ref is unreachable offline.
+  let baseSrc: string;
+  try {
+    baseSrc = git(["show", "origin/main:" + FILE]);
+  } catch {
+    try {
+      git(["fetch", "--depth=1", "origin", "main"]);
+      baseSrc = git(["show", "origin/main:" + FILE]);
+    } catch {
+      t.skip("origin/main unavailable (shallow checkout, offline) — nothing to compare against");
+      return;
+    }
+  }
   const headSrc = git(["show", "HEAD:" + FILE]);
 
   const perFile = [

--- a/tests/unit/providers-yuanbao-web.test.ts
+++ b/tests/unit/providers-yuanbao-web.test.ts
@@ -71,6 +71,13 @@ async function readStreamText(res: Response): Promise<string> {
 }
 
 test("missing hy_token cookie returns a 401 auth error", async () => {
+  // Hermetic: the 401 must come from the executor's own cookie validation, never
+  // from the real upstream — on GitHub-hosted runners the Tencent endpoint is
+  // unreachable and a live call turns this into a 71s 502 false-negative.
+  const original = globalThis.fetch;
+  globalThis.fetch = (async () => {
+    throw new Error("network disabled in this test — executor must reject before fetching");
+  }) as typeof fetch;
   const exec = new YuanbaoWebExecutor();
   const { response } = await exec.execute({
     model: "deepseek-v3",
@@ -84,6 +91,7 @@ test("missing hy_token cookie returns a 401 auth error", async () => {
   assert.match(body.error.message, /hy_user|hy_token|session cookie/);
   // Never leak stack traces.
   assert.ok(!body.error.message.includes("at /"));
+  globalThis.fetch = original;
 });
 
 test("streaming request translates think/text events into OpenAI chunks", async () => {


### PR DESCRIPTION
## Problem
`tests/unit/check-test-masking-selfref-6634.test.ts` runs `git show origin/main:<file>` unconditionally. On the .113 self-hosted runners the persistent checkout carries all refs, so it always worked; on GitHub-hosted runners (`USE_VPS_RUNNER=false` fallback, flipped 2026-07-14 to drain the queue) the checkout is shallow/single-ref → `fatal: invalid object name 'origin/main'` → the unit shard fails on **every** PR (observed on #7092, #7109, #7127 — the only base test that shells out to git with an origin ref).

## Fix
Fetch `origin/main --depth=1` on demand when the ref is missing; `t.skip()` (never fail) when it is unreachable (offline). When the ref exists, behavior is byte-identical.

## Validation (Hard Rule #18)
- RED reproduced: shallow `git clone --depth=1 --single-branch` → old test fails with the exact CI error.
- GREEN: same shallow clone with the patch → 1 skip, 0 fail; full-ref checkout → real compare runs and passes.