### PR TITLE
fix(codex): preserve encrypted reasoning without fake summaries

### DIFF
--- a/open-sse/utils/passthroughTailProcessor.ts
+++ b/open-sse/utils/passthroughTailProcessor.ts
@@ -37,7 +37,6 @@ export type PassthroughTailProcessorContext = {
   appendPassthroughReasoning: (value: string) => void;
   getResponsesReasoningKey: (payload: Record<string, unknown>) => string | null;
   markResponsesReasoningSummarySeen: (key: string) => void;
-  ensureVisibleResponsesReasoningSummary: (payload: Record<string, unknown>) => boolean;
   emitSyntheticResponsesReasoningSummary: (payload: Record<string, unknown>) => void;
   passthroughResponsesOutputItems: unknown[];
   passthroughResponsesPendingFunctionCalls: Map<string, JsonRecord>;
@@ -136,12 +135,8 @@ function handleResponsesTailPayload(
     }
   }
   if (parsed.type === "response.output_item.done" && parsed.item) {
-    const reasoningSummaryInjected = context.ensureVisibleResponsesReasoningSummary(parsed);
     context.emitSyntheticResponsesReasoningSummary(parsed);
     pushUniqueResponsesOutputItems(context.passthroughResponsesOutputItems, [parsed.item]);
-    if (reasoningSummaryInjected) {
-      output = `data: ${JSON.stringify(parsed)}\n\n`;
-    }
     const item = asRecord(parsed.item);
     if (item.type === "function_call") {
       const pendingKey = getFunctionCallPendingKey(item);

--- a/open-sse/utils/stream.ts
+++ b/open-sse/utils/stream.ts
@@ -1021,34 +1021,6 @@ export function createSSEStream(options: StreamOptions = {}) {
       : "";
   };
 
-  const ensureVisibleResponsesReasoningSummary = (payload: Record<string, unknown>): boolean => {
-    const item =
-      payload.item && typeof payload.item === "object" && !Array.isArray(payload.item)
-        ? (payload.item as Record<string, unknown>)
-        : null;
-    if (!item || item.type !== "reasoning") {
-      return false;
-    }
-
-    if (getResponsesReasoningSummaryText(item)) {
-      return false;
-    }
-
-    const hasEncryptedReasoning =
-      typeof item.encrypted_content === "string" && item.encrypted_content.length > 0;
-    if (!hasEncryptedReasoning) {
-      return false;
-    }
-
-    item.summary = [
-      {
-        type: "summary_text",
-        text: "Codex is reasoning, but the upstream Responses API exposed this reasoning block only as encrypted state. OmniRoute cannot recover the private reasoning text.",
-      },
-    ];
-    return true;
-  };
-
   const emitSyntheticResponsesReasoningSummary = (
     controller: TransformStreamDefaultController,
     payload: Record<string, unknown>
@@ -1061,7 +1033,6 @@ export function createSSEStream(options: StreamOptions = {}) {
       return;
     }
 
-    ensureVisibleResponsesReasoningSummary(payload);
     const visibleSummary = getResponsesReasoningSummaryText(item);
 
     if (!visibleSummary) {
@@ -1485,13 +1456,8 @@ export function createSSEStream(options: StreamOptions = {}) {
                   // response.completed snapshot can be backfilled when upstream
                   // returns an empty `output` (happens with store: false).
                   if (parsed.type === "response.output_item.done" && parsed.item) {
-                    const reasoningSummaryInjected = ensureVisibleResponsesReasoningSummary(parsed);
                     emitSyntheticResponsesReasoningSummary(controller, parsed);
                     pushUniqueResponsesOutputItems(passthroughResponsesOutputItems, [parsed.item]);
-                    if (reasoningSummaryInjected) {
-                      output = `data: ${JSON.stringify(parsed)}\n\n`;
-                      injectedUsage = true;
-                    }
                     if (parsed.item?.type === "function_call") {
                       const pendingKey =
                         typeof parsed.item.id === "string"
@@ -2181,7 +2147,6 @@ export function createSSEStream(options: StreamOptions = {}) {
               markResponsesReasoningSummarySeen: (key: string) => {
                 passthroughResponsesReasoningSummarySeen.add(key);
               },
-              ensureVisibleResponsesReasoningSummary,
               emitSyntheticResponsesReasoningSummary: (payload: Record<string, unknown>) =>
                 emitSyntheticResponsesReasoningSummary(controller, payload),
               passthroughResponsesOutputItems,

--- a/tests/unit/stream-utilities.test.ts
+++ b/tests/unit/stream-utilities.test.ts
@@ -133,7 +133,7 @@ test("createPassthroughStreamWithLogger synthesizes reasoning summary events fro
   assert.match(result, /event: response\.output_item\.done/);
 });
 
-test("createPassthroughStreamWithLogger shows a placeholder for encrypted reasoning items", async () => {
+test("createPassthroughStreamWithLogger preserves encrypted reasoning without a fake summary", async () => {
   const transform = createPassthroughStreamWithLogger(
     "codex",
     null,
@@ -169,9 +169,10 @@ test("createPassthroughStreamWithLogger shows a placeholder for encrypted reason
     result += decoder.decode(value);
   }
 
-  assert.match(result, /event: response\.reasoning_summary_text\.delta/);
-  assert.match(result, /Codex is reasoning/);
-  assert.match(result, /"summary":\[\{"type":"summary_text","text":"Codex is reasoning/);
+  assert.doesNotMatch(result, /response\.reasoning_summary/);
+  assert.doesNotMatch(result, /Codex is reasoning/);
+  assert.match(result, /"encrypted_content":"enc_opaque_state"/);
+  assert.doesNotMatch(result, /"summary":/);
   assert.match(result, /event: response\.output_item\.done/);
 });
 


### PR DESCRIPTION
## What changed

- Preserve Codex reasoning output items that contain only `encrypted_content`.
- Stop synthesizing fake reasoning-summary events and placeholder summary text for those items.
- Keep genuine reasoning-summary events unchanged when an upstream summary is present.

## Why

Encrypted reasoning state is opaque continuation data. Turning it into a fabricated summary mutates the upstream response and can break consumers that need the original `encrypted_content` for subsequent Codex requests.

## Scope

This PR is based directly on `release/v3.8.49` and contains only the patch from `JxnLexn/OmniRoute:dev/fix-codex_encypted_reasoning` relative to its original parent. No changes from `JxnLexn/OmniRoute:main` are included.

## Validation

- `node --import tsx/esm --test tests/unit/stream-utilities.test.ts` (8/8 passed)
- `npm run typecheck:core`
- Stable patch ID matches the original fix commit (`f8ebe8d23`).
