### PR TITLE
fix: add static.cloudflareinsights.com to CSP script-src

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,8 +9,8 @@ const distDir = process.env.NEXT_DIST_DIR || ".build/next";
 const projectRoot = dirname(fileURLToPath(import.meta.url));
 const scriptSrc =
   process.env.NODE_ENV === "development"
-    ? "script-src 'self' 'unsafe-inline' 'unsafe-eval' blob:"
-    : "script-src 'self' 'unsafe-inline' 'unsafe-eval' blob:";
+    ? "script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: https://static.cloudflareinsights.com"
+    : "script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: https://static.cloudflareinsights.com";
 const contentSecurityPolicy = [
   "default-src 'self'",
   "base-uri 'self'",


### PR DESCRIPTION
**What**: adds `https://static.cloudflareinsights.com` to both dev/prod `script-src` directives in the Content Security Policy.

**Why**: the CSP was blocking the Cloudflare Web Analytics beacon (`static.cloudflareinsights.com`), causing a CSP violation and analytics failure.

**Scope**: `next.config.mjs` only — one file, +2/-2.

**Note**: `handleToggleSource` was initially part of this PR but had already landed on `release/v3.8.49` via #7200 (#7161), so it was dropped after rebase.