### PR TITLE
fix(ci): Mergify auto-enqueue rule (queue_conditions alone are eligibility-only)

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -46,6 +46,18 @@ queue_rules:
     merge_method: squash
 
 pull_request_rules:
+  # AUTO-ENQUEUE trigger — queue_conditions alone only define ELIGIBILITY in current
+  # Mergify semantics (without this rule the PR sits at "use @Mergifyio queue",
+  # observed live on PR #7175). The conditions mirror queue_conditions on purpose.
+  - name: queue on owner-applied label
+    conditions:
+      - base~=^release/v\d+\.\d+\.\d+$
+      - label=queue
+      - -draft
+      - -conflict
+    actions:
+      queue:
+        name: release
   - name: clean up the queue label after merge
     conditions:
       - merged


### PR DESCRIPTION
Live finding from the first queue probe (PR #7175, all checks green + `queue` label): the Mergify check reported *"can be added to the merge queue — use @Mergifyio queue"* and never enqueued. In current Mergify semantics, `queue_conditions` define **eligibility only**; auto-enqueue needs an explicit `pull_request_rules` entry with `actions: queue`. This adds that trigger rule, mirroring the same conditions (owner-applied `queue` label on `release/v*`, non-draft, no conflict).

Config-only file (nothing in build/tests/runtime reads it); same flow as #7168.