### PR TITLE
fix: extend turbopack ignoreIssue suppression to compression module (#7051)

### DIFF
--- a/changelog.d/fixes/7051-turbopack-compression-ignoreissue.md
+++ b/changelog.d/fixes/7051-turbopack-compression-ignoreissue.md
@@ -1,0 +1,1 @@
+- fix(build): extend the Turbopack `ignoreIssue` suppression to `open-sse/services/compression/**`, matching the `getModuleDir()` dynamic-path fs pattern already suppressed for `src/lib/agentSkills/**` in #6582, eliminating the remaining 610 "Overly broad patterns" warnings (#7051)

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -128,9 +128,23 @@ const nextConfig = {
     // expected diagnostic — suppress it here rather than fight the analyzer,
     // mirroring the isNextIntlExtractorDynamicImportWarning precedent below
     // for the webpack path. (#6582)
+    // open-sse/services/compression/ruleLoader.ts and
+    // .../engines/rtk/filterLoader.ts both define an identical
+    // getModuleDir() helper that walks up directories via
+    // path.resolve(anchor) + fs.existsSync(...) in a loop with a
+    // non-literal argument — the same dynamic-path fs access pattern as
+    // the agentSkills case above, but not covered by that narrower
+    // allowlist glob, so the "Overly broad patterns..." warning kept
+    // firing (610 times, once per entry point transitively importing the
+    // compression module). Same known-benign, bounded fs access;
+    // suppressed here rather than fought. (#7051, follow-up to #6582)
     ignoreIssue: [
       {
         path: "**/src/lib/agentSkills/**",
+        description: /Overly broad patterns can lead to build performance issues/,
+      },
+      {
+        path: "**/open-sse/services/compression/**",
         description: /Overly broad patterns can lead to build performance issues/,
       },
     ],

--- a/tests/unit/next-config.test.ts
+++ b/tests/unit/next-config.test.ts
@@ -288,6 +288,30 @@ test("turbopack.ignoreIssue suppresses the agentSkills over-bundling warning (#6
   assert.match(String(agentSkillsRule.description), /Overly broad patterns/);
 });
 
+test("turbopack.ignoreIssue suppresses the compression module over-bundling warning (#7051)", async () => {
+  // open-sse/services/compression/ruleLoader.ts and
+  // .../engines/rtk/filterLoader.ts both define an identical getModuleDir()
+  // helper that walks up directories via path.resolve(anchor) +
+  // fs.existsSync(...) in a loop with a non-literal argument — the same
+  // class of dynamic-path fs access that #6582 suppressed for
+  // src/lib/agentSkills/**, but that narrow allowlist glob didn't cover this
+  // module, so the warning kept firing (610 times) for every entry point
+  // transitively importing the compression module. This guards the config
+  // shape so the suppression rule isn't silently dropped in a future edit.
+  const { default: nextConfig } = await loadNextConfig("ignore-issue-compression");
+  const rules = nextConfig.turbopack?.ignoreIssue;
+
+  assert.ok(Array.isArray(rules), "expected turbopack.ignoreIssue to be an array");
+  const compressionRule = rules.find((rule) =>
+    String(rule.path).includes("open-sse/services/compression")
+  );
+  assert.ok(
+    compressionRule,
+    "expected an ignoreIssue rule targeting open-sse/services/compression/**"
+  );
+  assert.match(String(compressionRule.description), /Overly broad patterns/);
+});
+
 test("optimizePackageImports excludes the internal @omniroute/open-sse workspace (build-OOM guard)", async () => {
   // Regression guard: adding the internal `@omniroute/open-sse` workspace to
   // optimizePackageImports makes Next.js resolve its entire barrel at build


### PR DESCRIPTION
Closes #7051

## Root cause
The #6582 fix added a `turbopack.ignoreIssue` rule in `next.config.mjs` that suppresses the Turbopack "Overly broad patterns..." diagnostic, but scoped its `path` glob only to `**/src/lib/agentSkills/**`. `open-sse/services/compression/ruleLoader.ts` and `open-sse/services/compression/engines/rtk/filterLoader.ts` both define an identical `getModuleDir()` helper that walks up directories via `path.resolve(anchor)` + `fs.existsSync(...)` in a loop with a non-literal argument — the same class of dynamic-path fs access that trips Turbopack's file-tracing analyzer — but that path wasn't covered by the existing suppression, so the warning kept firing (610 times, once per entry point transitively importing the compression module).

## Fix
Added a second `ignoreIssue` entry in `next.config.mjs` scoped to `**/open-sse/services/compression/**`, mirroring the existing agentSkills entry (same description regex, same known-benign/bounded-fs-access rationale).

## Test
TDD per Hard Rule #18: extended `tests/unit/next-config.test.ts` with a new test asserting an `ignoreIssue` rule whose path glob matches `open-sse/services/compression` and whose description matches `/Overly broad patterns/`.

- Confirmed RED against the unfixed config (`AssertionError: expected an ignoreIssue rule targeting open-sse/services/compression/**`).
- Confirmed GREEN after the fix: `node --import tsx/esm --test tests/unit/next-config.test.ts` → 8/8 passing.

## Gates run
- `node scripts/check/check-file-size.mjs` — OK
- `node scripts/check/check-complexity.mjs` — OK (baseline unchanged)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (baseline unchanged)
- `node scripts/check/check-changelog-integrity.mjs` — OK
- `npm run typecheck:core` — clean, exit 0
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json next.config.mjs tests/unit/next-config.test.ts` — clean
- `node --import tsx/esm --test tests/unit/next-config.test.ts` — 8/8 passing

Plan-file: `_tasks/pipeline/bugs/2-implementing/7051-turbopack-610-warnings.plan.md`