### PR TITLE
fix: preserve relayAuth for pool-referenced relay proxies (#5716)

### DIFF
--- a/changelog.d/fixes/5716-proxy-pool-relayauth-dropped.md
+++ b/changelog.d/fixes/5716-proxy-pool-relayauth-dropped.md
@@ -1,0 +1,1 @@
+- fix(providers): preserve relayAuth for vercel/deno/cloudflare relay proxies referenced by-id from the no-auth-provider Proxy Pool dropdown (#5716)

--- a/open-sse/executors/mimocode.ts
+++ b/open-sse/executors/mimocode.ts
@@ -90,6 +90,7 @@ export interface AccountProxyConfig {
     port: number;
     username?: string;
     password?: string;
+    relayAuth?: string;
   } | null;
 }
 

--- a/open-sse/executors/opencode.ts
+++ b/open-sse/executors/opencode.ts
@@ -21,6 +21,7 @@ export interface OpencodeAccountProxyConfig {
     port: number;
     username?: string;
     password?: string;
+    relayAuth?: string;
   } | null;
 }
 

--- a/src/sse/services/noAuthProxyResolution.ts
+++ b/src/sse/services/noAuthProxyResolution.ts
@@ -1,4 +1,5 @@
 import { getProxyById } from "@/lib/db/proxies";
+import { isRelayProxyType, extractRelayAuth } from "@/lib/db/proxies/mappers";
 
 /**
  * #5217 (Gap 1) — Per-account proxy resolution for no-auth providers
@@ -29,6 +30,7 @@ export interface ResolvedAccountProxy {
   port: number;
   username?: string;
   password?: string;
+  relayAuth?: string;
 }
 
 export interface AccountProxyEntry {
@@ -43,6 +45,7 @@ interface ProxyRegistryRecordLike {
   port?: number | string;
   username?: string | null;
   password?: string | null;
+  notes?: string | null;
 }
 
 /** Async lookup of a proxy registry record by id (null when absent). */
@@ -53,12 +56,17 @@ function normalizeRecord(rec: ProxyRegistryRecordLike | Partial<ResolvedAccountP
   if (!host) return null;
   const username = typeof rec.username === "string" ? rec.username : "";
   const password = typeof rec.password === "string" ? rec.password : "";
+  const type = typeof rec.type === "string" && rec.type ? rec.type : "socks5";
+  const relayAuth = isRelayProxyType(type)
+    ? extractRelayAuth((rec as ProxyRegistryRecordLike).notes)
+    : undefined;
   const resolved: ResolvedAccountProxy = {
-    type: typeof rec.type === "string" && rec.type ? rec.type : "socks5",
+    type,
     host,
     port: Number(rec.port) || 0,
     ...(username ? { username } : {}),
     ...(password ? { password } : {}),
+    ...(relayAuth ? { relayAuth } : {}),
   };
   return resolved;
 }

--- a/tests/unit/noAuthProxyResolution.relayAuth.test.ts
+++ b/tests/unit/noAuthProxyResolution.relayAuth.test.ts
@@ -1,0 +1,49 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { resolveAccountProxies } from "../../src/sse/services/noAuthProxyResolution.ts";
+
+test("resolveAccountProxies preserves relayAuth for relay-type (vercel/deno/cloudflare) pool proxies", async () => {
+  const fakeVercelProxyRow = {
+    id: "proxy-1",
+    type: "vercel",
+    host: "my-relay-abc123.vercel.app",
+    port: 443,
+    username: null,
+    password: null,
+    notes: JSON.stringify({ relayAuth: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef" }),
+  };
+
+  const resolved = await resolveAccountProxies(
+    [{ fingerprint: "acct-1", proxyId: "proxy-1" }],
+    async (id) => (id === "proxy-1" ? fakeVercelProxyRow : null)
+  );
+
+  const proxy = resolved[0].proxy as unknown as { type?: string; relayAuth?: string };
+  assert.equal(proxy?.type, "vercel");
+  assert.equal(
+    proxy?.relayAuth,
+    "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+    "relayAuth must survive resolveAccountProxies() for relay-type (vercel/deno/cloudflare) proxies"
+  );
+});
+
+test("resolveAccountProxies leaves relayAuth absent for plain non-relay (socks5/http) pool proxies", async () => {
+  const fakeSocksProxyRow = {
+    id: "proxy-2",
+    type: "socks5",
+    host: "1.2.3.4",
+    port: 1080,
+    username: "u",
+    password: "p",
+    notes: JSON.stringify({ relayAuth: "should-not-leak-onto-non-relay-types" }),
+  };
+
+  const resolved = await resolveAccountProxies(
+    [{ fingerprint: "acct-2", proxyId: "proxy-2" }],
+    async (id) => (id === "proxy-2" ? fakeSocksProxyRow : null)
+  );
+
+  const proxy = resolved[0].proxy as unknown as { type?: string; relayAuth?: string };
+  assert.equal(proxy?.type, "socks5");
+  assert.equal(proxy?.relayAuth, undefined);
+});


### PR DESCRIPTION
Closes #5716

## Root cause

Relay-type (vercel/deno/cloudflare) proxies referenced by-id from a no-auth account's
Proxy Pool dropdown (OpenCode Free / MiMoCode) are resolved through
`resolveAccountProxies()`/`normalizeRecord()` in
`src/sse/services/noAuthProxyResolution.ts`, which only copied
`{type, host, port, username, password}` and never extracted `relayAuth` from the
proxy's `notes` blob — so `relayAuth` was unconditionally `undefined` for this
resolution path, and `proxyFetch.ts`'s `if (!vc.relayAuth) throw` fired on every
request, on every redeploy. This is a distinct root cause from the
STORAGE_ENCRYPTION_KEY-rotation hypothesis discussed in-thread; it specifically
affects relay-type proxies assigned via the no-auth-provider Proxy Pool dropdown, not
the global/provider/account/combo scope-assignment path (which already called
`extractRelayAuth()` correctly via `toRegistryProxyResolution()`).

## Fix

- `normalizeRecord()` in `src/sse/services/noAuthProxyResolution.ts` now calls
  `isRelayProxyType()` / `extractRelayAuth()` (already used by the scope-based path)
  and includes `relayAuth` on the resolved proxy when present.
- Added `relayAuth?: string` to `ResolvedAccountProxy` and `notes?: string | null` to
  `ProxyRegistryRecordLike`.
- Added `relayAuth?: string` to `OpencodeAccountProxyConfig['proxy']` and
  `AccountProxyConfig['proxy']` (mimocode) so the field type-checks through to
  `runWithProxyContext()`.

## Regression test

`tests/unit/noAuthProxyResolution.relayAuth.test.ts` — reproduces the exact repro from
triage (RED before the fix: `relayAuth` resolved as `undefined` for a vercel-type pool
proxy row with `notes: {relayAuth: "..."}`) and asserts the fix (GREEN), plus a
non-regression case confirming non-relay (socks5) proxies never gain a `relayAuth`
field.

```
node --import tsx/esm --test tests/unit/noAuthProxyResolution.relayAuth.test.ts
# before fix: 1 pass / 1 fail (relayAuth undefined)
# after fix:  2 pass / 0 fail
```

## Gates run

- `node scripts/check/check-file-size.mjs` — OK
- `node scripts/check/check-complexity.mjs` — OK (2056 violations, baseline 2056, unchanged)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (890 violations, baseline 890, unchanged)
- `node scripts/check/check-changelog-integrity.mjs` — OK
- `npm run typecheck:core` — clean, exit 0
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` — clean, exit 0
- Existing opencode/mimocode executor tests (`tests/unit/mimocode-executor.test.ts`,
  `tests/unit/opencode-proxy-rotation-4954.test.ts`, `tests/unit/opencode-executor.test.ts`)
  — 99/99 pass, no regression in account-proxy rotation behavior.

Plan-file: `_tasks/pipeline/bugs/2-implementing/5716-proxy-pool-not-working.plan.md`