### PR TITLE
fix: include proxyId when testing a saved registry proxy (#7080)

### DIFF
--- a/changelog.d/fixes/7080-proxy-test-connection-saved-proxyid.md
+++ b/changelog.d/fixes/7080-proxy-test-connection-saved-proxyid.md
@@ -1,0 +1,1 @@
+- fix(dashboard): include proxyId when testing a saved registry proxy so SOCKS5/auth credentials are loaded (#7080)

--- a/src/shared/components/ProxyConfigModal.tsx
+++ b/src/shared/components/ProxyConfigModal.tsx
@@ -463,6 +463,7 @@ export default function ProxyConfigModal({
         username?: string;
         password?: string;
       } | null = null;
+      let testProxyId: string | null = null;
 
       if (mode === "saved") {
         if (!selectedProxyId) {
@@ -481,6 +482,7 @@ export default function ProxyConfigModal({
           host: found.host || "",
           port: String(found.port || 8080),
         };
+        testProxyId = selectedProxyId;
       } else {
         if (!String(host || "").trim()) {
           setTesting(false);
@@ -498,7 +500,7 @@ export default function ProxyConfigModal({
       const res = await fetch("/api/settings/proxy/test", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ proxy }),
+        body: JSON.stringify(testProxyId ? { proxy, proxyId: testProxyId } : { proxy }),
       });
       const data = await res.json().catch(() => ({}));
       if (!res.ok) {

--- a/tests/unit/shared/components/ProxyConfigModal.test.tsx
+++ b/tests/unit/shared/components/ProxyConfigModal.test.tsx
@@ -389,3 +389,66 @@ describe("ProxyConfigModal custom registry saves", () => {
     ).toBe(false);
   });
 });
+
+describe("ProxyConfigModal test connection (saved proxy)", () => {
+  beforeEach(() => {
+    (
+      globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    fetchCalls = [];
+  });
+
+  afterEach(() => {
+    while (cleanupCallbacks.length > 0) {
+      cleanupCallbacks.pop()?.();
+    }
+    document.body.innerHTML = "";
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("includes proxyId when testing a saved SOCKS5 registry proxy so the server can load its stored credentials", async () => {
+    installFetchMock((url, init) => {
+      const method = String(init?.method || "GET").toUpperCase();
+      if (method === "GET" && url === "/api/settings/proxies") {
+        return {
+          body: {
+            items: [
+              {
+                id: "socks5-1",
+                name: "Geonode SOCKS5",
+                type: "socks5",
+                host: "proxy.geonode.io",
+                port: 12000,
+                username: "***",
+                password: "***",
+                source: "manual",
+              },
+            ],
+            total: 1,
+            socks5Enabled: true,
+          },
+        };
+      }
+      if (url.startsWith("/api/settings/proxies/assignments?") && url.includes("scope=provider")) {
+        return {
+          body: { items: [{ proxyId: "socks5-1", scope: "provider", scopeId: "claude" }], total: 1 },
+        };
+      }
+      if (method === "POST" && url === "/api/settings/proxy/test") {
+        return { body: { success: true, publicIp: "1.2.3.4", latencyMs: 500 } };
+      }
+      return defaultProxyConfigResponses(url) || { status: 404, body: {} };
+    });
+
+    const { container } = await renderProxyConfigModal();
+    await clickButton(container, "testConnection");
+    await waitForCall((call) => call.method === "POST" && call.url === "/api/settings/proxy/test");
+
+    const testCall = fetchCalls.find(
+      (call) => call.method === "POST" && call.url === "/api/settings/proxy/test"
+    );
+    expect(testCall).toBeTruthy();
+    expect(testCall?.body?.proxyId).toBe("socks5-1");
+  }, 20000);
+});


### PR DESCRIPTION
Closes #7080

## Root cause
`ProxyConfigModal.tsx::handleTest()` builds the POST body for `/api/settings/proxy/test` from local `savedProxies` state when `mode === "saved"` (the default mode, and the mode used when picking an existing proxy from the registry dropdown, e.g. a SOCKS5 proxy assigned to a provider scope). That body only carried `{ type, host, port }` — never the top-level `proxyId`. The server route (`src/app/api/settings/proxy/test/route.ts`) only loads the real, non-redacted stored credentials (`username`/`password`) from the DB when `proxyId` is present in the body. Without it, the SOCKS5 dispatcher connects with no auth, and a proxy requiring user/pass auth immediately rejects the handshake ("no accepted authentication type"), even though the same proxy works fine for live traffic (where `proxyId` is resolved through the assignment, not through this test-connection path).

## Fix
`handleTest()` now includes `proxyId: selectedProxyId` at the top level of the POST body when `mode === "saved"`. The `custom` mode branch (which already sends `username`/`password` directly, no DB-backed proxy involved) is untouched. No server-side changes — `route.ts` already reads `body.proxyId` correctly once it is sent.

## Regression test
`tests/unit/shared/components/ProxyConfigModal.test.tsx` — new describe block `ProxyConfigModal test connection (saved proxy)`: simulates a saved SOCKS5 registry proxy assigned to a provider scope, clicks "Test connection", asserts the POST body to `/api/settings/proxy/test` includes `proxyId`.

- RED (pre-fix, confirmed in this worktree): `AssertionError: expected undefined to be 'socks5-1'`
- GREEN (post-fix): all 4 tests in the file pass (`npx vitest run tests/unit/shared/components/ProxyConfigModal.test.tsx`)

## Gates run
- `node scripts/check/check-file-size.mjs` — OK
- `node scripts/check/check-complexity.mjs` — OK (2056 violations, matches baseline)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (890 violations, matches baseline)
- `node scripts/check/check-changelog-integrity.mjs` — OK
- `npm run typecheck:core` — clean (exit 0)
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json` on the touched files — clean
- Existing related tests (`tests/unit/proxy-types-socks5-runtime-3508.test.ts`, `tests/unit/relay-test-result-awareness.test.ts`, `tests/unit/proxy-relay-test-error-5716.test.ts`) — pass

Plan-file: `_tasks/pipeline/bugs/2-implementing/7080-socks5-test-connection-false-negative.plan.md`