### PR TITLE
fix: zai-web connection-test cookie probe now honors the configured proxy (#7058)

### DIFF
--- a/changelog.d/fixes/7058-zai-web-proxy-connection-test.md
+++ b/changelog.d/fixes/7058-zai-web-proxy-connection-test.md
@@ -1,0 +1,1 @@
+- fix(providers): web-cookie connection-test/cookie-validation probe (zai-web and every other registry-entry web-cookie provider) now honors the configured HTTP/SOCKS proxy — the `/models` probe routed through `directHttpsRequest`'s hardcoded native-fetch bypass, silently skipping proxy resolution even though the executor's actual chat traffic already respected it (#7058)

--- a/src/lib/providers/validation.ts
+++ b/src/lib/providers/validation.ts
@@ -155,7 +155,7 @@ export async function validateWebCookieProvider({
     const baseUrl = normalizeBaseUrl(entry.baseUrl || "");
     const testUrl = `${baseUrl}/models`;
 
-    const res = await directHttpsRequest(
+    const res = await validationRead(
       testUrl,
       {
         method: "GET",
@@ -164,7 +164,7 @@ export async function validateWebCookieProvider({
           Cookie: cookie,
         },
       },
-      10_000
+      isLocalProvider(provider)
     );
 
     if (res.status === 401 || res.status === 403) {

--- a/tests/unit/provider-validation-web-cookie-auth007.test.ts
+++ b/tests/unit/provider-validation-web-cookie-auth007.test.ts
@@ -1,15 +1,18 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-// The validator probes the provider's /models endpoint via safeOutboundFetch →
-// fetchWithTimeout, which binds globalThis.fetch at MODULE LOAD time. The mock MUST be
-// installed BEFORE importing validation.ts — a late reassignment (inside a test) is
-// ignored and the validator hits the real network instead. (That made the 401/403
-// assertions pass only by coincidence — live chatgpt.com returns 401/403 — while the
-// 200 case failed.) A mutable `nextResponse` lets each test vary the probe result, and
-// `fetchCalls` proves the mocked probe ran rather than the live network.
+// The validator probes the provider's /models endpoint via validationRead → safeOutboundFetch
+// → fetchWithTimeout, which reads `globalThis.fetch` dynamically at CALL time (#7058 — routed
+// through the proxy-aware patched fetch instead of a bypassing directHttpsRequest). Importing
+// validation.ts pulls in the proxy-patch module, which installs its own `globalThis.fetch`
+// exactly once at import time — so the mock must be (re)installed AFTER the import, not before,
+// or the patch silently clobbers it. A mutable `nextResponse` lets each test vary the probe
+// result, and `fetchCalls` proves the mocked probe ran rather than the live network.
 let nextResponse: { status: number; body: string } = { status: 200, body: "{}" };
 let fetchCalls = 0;
+
+const { validateWebCookieProvider } = await import("../../src/lib/providers/validation.ts");
+
 globalThis.fetch = (async () => {
   fetchCalls++;
   return new Response(nextResponse.body, {
@@ -17,8 +20,6 @@ globalThis.fetch = (async () => {
     headers: { "content-type": "application/json" },
   });
 }) as typeof fetch;
-
-const { validateWebCookieProvider } = await import("../../src/lib/providers/validation.ts");
 
 function mockFetch(status: number, body: string) {
   nextResponse = { status, body };

--- a/tests/unit/web-cookie-validation-proxy-7058.test.ts
+++ b/tests/unit/web-cookie-validation-proxy-7058.test.ts
@@ -1,0 +1,98 @@
+// Regression test for #7058 — zai-web (and every other entry-bearing web-cookie
+// provider) never honored a configured HTTP/SOCKS proxy during connection-test /
+// cookie validation.
+//
+// Root cause: validateWebCookieProvider() probed `${baseUrl}/models` via
+// directHttpsRequest(), which hardcodes `bypassProxyPatch: true` — forcing
+// safeOutboundFetch to use the pre-patch native fetch and skip proxy-context/
+// env-var resolution entirely. That bypass was introduced in #3226 as a narrow,
+// documented exception for a single NVIDIA NIM workaround
+// (see tests/unit/proxy-bypass-scope-guard-3226.test.ts) but validateWebCookieProvider
+// adopted it as its default transport from inception (#4023), silently extending the
+// bypass to every web-cookie provider with a registry entry (zai-web among them).
+//
+// This test proves the cookie-validation probe reaches a local forward proxy
+// (via a real CONNECT tunnel — the same mechanism undici uses for both HTTP and
+// HTTPS targets) when one is configured via HTTP_PROXY, exactly like the
+// specialty web-cookie validators (chatgpt-web, grok-web, ...) already do via
+// validationRead/validationWrite.
+import test from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import net from "node:net";
+
+const { validateWebCookieProvider } = await import("../../src/lib/providers/validation.ts");
+const { REGISTRY } = await import("../../open-sse/config/providerRegistry.ts");
+const { clearDispatcherCache } = await import("../../open-sse/utils/proxyDispatcher.ts");
+
+const zaiWebEntry = REGISTRY["zai-web"] as { baseUrl?: string } | undefined;
+const ORIGINAL_BASE_URL = zaiWebEntry?.baseUrl;
+const ORIGINAL_HTTP_PROXY = process.env.HTTP_PROXY;
+
+test.after(() => {
+  if (zaiWebEntry && ORIGINAL_BASE_URL !== undefined) {
+    zaiWebEntry.baseUrl = ORIGINAL_BASE_URL;
+  }
+  if (ORIGINAL_HTTP_PROXY === undefined) {
+    delete process.env.HTTP_PROXY;
+  } else {
+    process.env.HTTP_PROXY = ORIGINAL_HTTP_PROXY;
+  }
+  clearDispatcherCache();
+});
+
+test("zai-web cookie validation routes through the configured HTTP_PROXY (#7058)", async () => {
+  assert.ok(zaiWebEntry, "zai-web must have a providerRegistry entry for this test to be meaningful");
+
+  // Stand-in for chat.z.ai's /models probe target.
+  const target = http.createServer((_req, res) => {
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end("{}");
+  });
+  await new Promise<void>((resolve) => target.listen(0, () => resolve()));
+  const targetPort = (target.address() as net.AddressInfo).port;
+
+  // Minimal forward proxy that only speaks CONNECT (like a real corporate proxy) and
+  // always tunnels to the local target above, regardless of the requested host — this
+  // lets the "upstream" host be a non-resolvable placeholder without any real DNS
+  // dependency, while still proving the request actually reached the proxy.
+  let sawConnect = false;
+  const proxy = http.createServer((_req, res) => {
+    res.writeHead(501);
+    res.end("CONNECT only");
+  });
+  proxy.on("connect", (_req, socket) => {
+    sawConnect = true;
+    const upstream = net.connect(targetPort, "127.0.0.1", () => {
+      socket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+      upstream.pipe(socket);
+      socket.pipe(upstream);
+    });
+    upstream.on("error", () => socket.destroy());
+    socket.on("error", () => upstream.destroy());
+  });
+  await new Promise<void>((resolve) => proxy.listen(0, () => resolve()));
+  const proxyPort = (proxy.address() as net.AddressInfo).port;
+
+  // A non-local-looking hostname: isLocalAddress()/resolveProxyForRequest() force a
+  // direct connection for any 127.*/localhost/LAN target, which would defeat this test.
+  zaiWebEntry!.baseUrl = "http://zai-web-validation-probe-7058.invalid";
+  process.env.HTTP_PROXY = `http://127.0.0.1:${proxyPort}`;
+  clearDispatcherCache();
+
+  try {
+    const result = await validateWebCookieProvider({ provider: "zai-web", apiKey: "token=fake" });
+
+    assert.equal(
+      sawConnect,
+      true,
+      "BUG #7058: zai-web cookie validation never reached the configured HTTP_PROXY " +
+        "(bypassProxyPatch:true unconditionally uses the native, unpatched fetch)"
+    );
+    assert.equal(result.valid, true, `expected a valid session, got ${JSON.stringify(result)}`);
+  } finally {
+    target.close();
+    proxy.close();
+    clearDispatcherCache();
+  }
+});


### PR DESCRIPTION
Closes #7058

## Root cause

`validateWebCookieProvider()` (src/lib/providers/validation.ts) probes `${baseUrl}/models` to validate a web-cookie provider's session. For zai-web (and every other web-cookie provider that has a `providerRegistry` entry but no specialty validator), that probe went through `directHttpsRequest()`, which hardcodes `bypassProxyPatch: true` — forcing `safeOutboundFetch` to use the pre-patch native fetch (`getOriginalFetch()`) and skip proxy-context/env-var resolution entirely.

That bypass was introduced in #3226 as a narrow, documented exception for a single NVIDIA NIM 504 workaround, but `validateWebCookieProvider` adopted it as its default transport from its own inception (#4023), silently extending the exception to every web-cookie provider lacking a specialty validator. Providers that DO have a specialty validator (chatgpt-web, grok-web, deepseek-web, qwen-web, …) already use `validationRead`/`validationWrite`, which correctly respect the resolved connection proxy — exactly the asymmetry the reporter observed ("other providers do support proxy").

## Fix

Swap `directHttpsRequest(...)` for `validationRead(testUrl, init, isLocalProvider(provider))` inside `validateWebCookieProvider()` — the same proxy-aware transport the specialty web-cookie validators already use. `directHttpsRequest` itself is untouched and still used by the NVIDIA NIM validator (its one documented exception).

## Regression test

`tests/unit/web-cookie-validation-proxy-7058.test.ts` — spins up a local HTTP target plus a local forward proxy that only speaks CONNECT (matching how `undici`'s `ProxyAgent` tunnels both HTTP and HTTPS traffic), points zai-web's registry `baseUrl` at a non-local-looking placeholder host, sets `HTTP_PROXY`, and asserts the cookie probe actually reaches the proxy.

- RED (pre-fix): `AssertionError: BUG #7058: zai-web cookie validation never reached the configured HTTP_PROXY ... false !== true`
- GREEN (post-fix): passes, `sawConnect === true`.

`tests/unit/provider-validation-web-cookie-auth007.test.ts` needed a small, line-neutral-in-intent update: it mocked `globalThis.fetch` *before* importing `validation.ts`, relying on the (accidental, previously-undocumented) fact that `directHttpsRequest`'s native-fetch bypass hit the live network anyway. Now that the probe correctly uses the proxy-aware patched fetch, the mock must be installed *after* the import (matching the pattern in `web-cookie-validation-fallback.test.ts`) — otherwise the proxy-patch module's own `globalThis.fetch` assignment clobbers the test mock. Reordered + updated the comment; all 5 assertions in that file are otherwise unchanged and still pass.

## Gates run

- `node --import tsx/esm --test tests/unit/web-cookie-validation-proxy-7058.test.ts` — new regression test, RED→GREEN as above
- `node --import tsx/esm --test tests/unit/provider-validation-web-cookie-auth007.test.ts tests/unit/web-cookie-validation-fallback.test.ts tests/unit/proxy-bypass-scope-guard-3226.test.ts tests/unit/web-cookie-auth.test.ts tests/unit/web-cookie-providers-new.test.ts tests/unit/qwen-web-cookie-validation-3958.test.ts tests/unit/executor-web-cookie-sweep.test.ts` — 102/102 pass
- `node scripts/check/check-file-size.mjs` — OK
- `node scripts/check/check-complexity.mjs` — OK (2056 violations, baseline unchanged)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (890 violations, baseline unchanged)
- `node scripts/check/check-changelog-integrity.mjs` — OK
- `npm run typecheck:core` — clean
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json src/lib/providers/validation.ts tests/unit/web-cookie-validation-proxy-7058.test.ts tests/unit/provider-validation-web-cookie-auth007.test.ts` — clean

Plan-file: `_tasks/pipeline/bugs/2-implementing/7058-zai-web-proxy-not-used-in-connection-test.plan.md`