### PR TITLE
fix(providers): reject chat requests for cloud-agent-only jules provider (#6699)

### DIFF
--- a/changelog.d/fixes/6699-jules-chat-executor-misroute.md
+++ b/changelog.d/fixes/6699-jules-chat-executor-misroute.md
@@ -1,0 +1,1 @@
+- fix(providers): reject chat-completions requests for cloud-agent-only providers like jules instead of silently mis-routing them to OpenAI's endpoint (#6699)

--- a/open-sse/executors/index.ts
+++ b/open-sse/executors/index.ts
@@ -170,8 +170,26 @@ const executors = {
 
 const defaultCache = new Map();
 
+// #6699 — providers that exist ONLY as Cloud Agent task-API entries
+// (CLOUD_AGENT_PROVIDERS / staticModels "Available Models" catalog) and have no
+// chat-completions REGISTRY entry anywhere in open-sse/. Without this guard,
+// getExecutor() silently falls through to DefaultExecutor's
+// `PROVIDERS[provider] || PROVIDERS.openai` fallback, sending the user's real
+// provider key to OpenAI's endpoint (mislabeled as coming from the provider the
+// user actually selected). Starting with just "jules" (the reported case);
+// "devin" and "codex-cloud" share the same structural gap and are left for a
+// follow-up once their own chat-routing behavior is confirmed.
+const CHAT_UNSUPPORTED_CLOUD_AGENT_PROVIDERS = new Set(["jules"]);
+
 export function getExecutor(provider) {
   if (executors[provider]) return executors[provider];
+  if (CHAT_UNSUPPORTED_CLOUD_AGENT_PROVIDERS.has(provider)) {
+    const err = new Error(
+      `Provider "${provider}" is a cloud-agent provider and does not support direct chat completions; use the Cloud Agents task API instead.`
+    );
+    (err as Error & { status?: number }).status = 400;
+    throw err;
+  }
   if (!defaultCache.has(provider)) defaultCache.set(provider, new DefaultExecutor(provider));
   return defaultCache.get(provider);
 }

--- a/tests/unit/probe-6699-jules-executor-misroute.test.ts
+++ b/tests/unit/probe-6699-jules-executor-misroute.test.ts
@@ -1,0 +1,40 @@
+// Probe for issue #6699 -- "Google Jules provider validation rejects a valid API key".
+//
+// A second reporter (MohammadMD1383) supplied screenshots showing that OmniRoute, when
+// actually routing a chat-completion request for a saved "jules" connection, sends the
+// request to https://api.openai.com/v1/chat/completions and surfaces OpenAI's own
+// "Incorrect API key provided ... platform.openai.com" error -- even though the provider
+// is displayed as JULES with target "jules/jules". This probe proves the executor-level
+// root cause directly: getExecutor("jules") has no specialized executor and no REGISTRY
+// entry, so DefaultExecutor's constructor silently falls back to PROVIDERS.openai,
+// making buildUrl() return OpenAI's endpoint for a provider the user believes is Jules.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { getExecutor, hasSpecializedExecutor } from "../../open-sse/executors/index.ts";
+
+test("#6699: jules has no specialized executor (falls through to DefaultExecutor)", () => {
+  assert.equal(hasSpecializedExecutor("jules"), false);
+});
+
+test("#6699: a chat-completion request routed to provider 'jules' must not silently hit OpenAI's endpoint", () => {
+  // Desired behavior: the Jules provider (a cloud-agent, registered only in
+  // CLOUD_AGENT_PROVIDERS/staticModels, never in the chat REGISTRY) must not silently
+  // resolve to OpenAI's chat/completions endpoint when routed through the normal
+  // chat-completions executor path. getExecutor() now throws a clear, sanitized error
+  // for this narrow set of chat-unsupported cloud-agent providers instead of falling
+  // through to DefaultExecutor's `PROVIDERS.openai` fallback (which produced the
+  // "Incorrect API key provided ... platform.openai.com" error the reporter saw for a
+  // genuine Jules key). Before the fix, getExecutor("jules") returned a working
+  // executor whose buildUrl() resolved to OpenAI's endpoint -- this assertion FAILS on
+  // unfixed release/v3.8.49 code because no error is thrown at all.
+  assert.throws(
+    () => getExecutor("jules"),
+    (err) => {
+      assert.match(err.message, /cloud-agent provider/i);
+      assert.match(err.message, /does not support direct chat completions/i);
+      assert.equal(err.status, 400);
+      return true;
+    },
+    "provider 'jules' must raise a clear error instead of silently inheriting OpenAI's base URL/config"
+  );
+});


### PR DESCRIPTION
Closes #6699

## Root cause

A second reporter's screenshots revealed the real bug behind the "Invalid API key" reports for Jules: `open-sse/executors/index.ts::getExecutor()` has no entry for `"jules"`, so it falls through to `DefaultExecutor`, whose constructor does `PROVIDERS["jules"] || PROVIDERS.openai`. Since Jules only exists as a `CLOUD_AGENT_PROVIDERS` / task-API entry (never in the open-sse chat REGISTRY), `PROVIDERS["jules"]` is undefined and the executor silently becomes an OpenAI executor — sending the user's real Jules API key as a Bearer token to `https://api.openai.com/v1/chat/completions`. OpenAI correctly rejects the Jules key with "Incorrect API key provided ... platform.openai.com", which the UI then mislabels as coming from provider JULES.

The original reporter's "Add Connection / Check" validation dialog is unaffected — that path (`validateJulesProvider` / `SPECIALTY_VALIDATORS.jules`) was already confirmed correct in a prior round and is untouched by this fix.

## Fix

`getExecutor()` now recognizes a small, explicit set of chat-unsupported cloud-agent-only providers (starting with just `"jules"`) and throws a clear, sanitized error (`status: 400`, message: "...is a cloud-agent provider and does not support direct chat completions; use the Cloud Agents task API instead.") instead of silently falling through to the OpenAI default. The error is caught by chatCore's existing top-level try/catch and surfaced to the client via `buildErrorBody()`/`formatProviderError()` (no raw stack/message leakage — Hard Rule #12).

Scope kept intentionally narrow per the analysis plan: only `"jules"` is guarded. `devin` (already has its own specialized executor) and `codex-cloud` share the same structural gap but are left for a follow-up once their chat-routing behavior is separately confirmed.

## Regression test

`tests/unit/probe-6699-jules-executor-misroute.test.ts` — reused the TDD probe from `/triage-fix-bugs`'s analysis (proven RED against unfixed release/v3.8.49 code), adjusted the second assertion to match the new guard's actual behavior (throws with the expected message/status) instead of the original "resolves URL" shape. Both assertions are GREEN after the fix.

## Gates run

- `node --import tsx/esm --test tests/unit/probe-6699-jules-executor-misroute.test.ts` — GREEN (2/2)
- `node scripts/check/check-file-size.mjs` — OK
- `node scripts/check/check-complexity.mjs` — OK (2056 violations, unchanged baseline)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (890 violations, unchanged baseline)
- `node scripts/check/check-changelog-integrity.mjs` — OK
- `npm run typecheck:core` — clean
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json open-sse/executors/index.ts tests/unit/probe-6699-jules-executor-misroute.test.ts` — clean
- Full existing executor test suite (36 files covering `getExecutor`/`hasSpecializedExecutor` callers) — 348 + 396/398 passing. The one pre-existing failure (`chatcore-translation-paths.test.ts` — "chatCore times out upstream execution before provider response headers") is an unrelated, load-sensitive `waitFor` timing test on the `openai` provider path (unaffected by this diff — confirmed reproducible in isolation on this heavily-loaded devbox, ~10 concurrent sessions were running the same gate scripts at the time).

Plan-file: `_tasks/pipeline/bugs/2-implementing/6699-bug-google-jules-provider-integration-returns-invalid-api.plan.md`