### PR TITLE
fix: restore mobile grid-cols-1 fallback on quota page card grid (#7072)

### DIFF
--- a/changelog.d/fixes/7072-quota-card-grid-mobile.md
+++ b/changelog.d/fixes/7072-quota-card-grid-mobile.md
@@ -1,0 +1,1 @@
+- fix(dashboard): restore mobile single-column fallback on the Provider Quota page card grid, fixing clipped labels/buttons on phone-width viewports (#7072)

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/QuotaCardGrid.tsx
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/QuotaCardGrid.tsx
@@ -56,7 +56,7 @@ export default function QuotaCardGrid({
               ({conns.length} account{conns.length !== 1 ? "s" : ""})
             </span>
           </h3>
-          <div className="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-4 gap-3">
+          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 gap-3">
             {conns.map((conn) => (
               <QuotaCard
                 key={conn.id}

--- a/tests/unit/quota-card-grid-horizontal-layout.test.ts
+++ b/tests/unit/quota-card-grid-horizontal-layout.test.ts
@@ -6,8 +6,11 @@
 // the shipped JSX structure and grouping logic directly:
 //  1. Grouping still produces one header per distinct provider with the
 //     correct account count ("N account(s)").
-//  2. The per-group card grid starts multi-column (`grid-cols-2`), not
-//     single-column, so cards fill horizontal space sooner.
+//  2. The per-group card grid keeps a single-column mobile fallback
+//     (`grid-cols-1`) below the `sm:` breakpoint (restored by #7072 after
+//     PR #6815 dropped it and clipped labels on phone-width viewports),
+//     while still going multi-column (`sm:grid-cols-2`) from `sm:` up so
+//     cards fill horizontal space sooner on larger screens.
 //  3. Provider groups themselves flow into multiple columns on wide screens
 //     (`columns-*`) instead of an unconditional vertical `flex flex-col`
 //     stack.
@@ -104,14 +107,14 @@ test("QuotaCardGrid (#3520) — outer container flows groups into multiple colum
   assert.notEqual(outerClassName, "flex flex-col gap-6");
 });
 
-test("QuotaCardGrid (#3520) — per-group card grid starts multi-column (grid-cols-2), not single-column", () => {
+test("QuotaCardGrid (#3520/#7072) — per-group card grid keeps a mobile grid-cols-1 fallback and goes multi-column from sm: up", () => {
   const classNames = extractDivClassNames(COMPONENT_PATH);
   const cardGridClassName = classNames.find(
     (c) => /\bgrid\b/.test(c) && /grid-cols-/.test(c)
   );
   assert.ok(cardGridClassName, "expected to find the per-group card grid's className");
-  assert.match(cardGridClassName!, /\bgrid-cols-2\b/);
-  assert.doesNotMatch(cardGridClassName!, /\bgrid-cols-1\b/);
+  assert.match(cardGridClassName!, /\bgrid-cols-1\b/);
+  assert.match(cardGridClassName!, /\bsm:grid-cols-2\b/);
 });
 
 test("QuotaCardGrid (#3520) — early-returns null when there are no connections", () => {

--- a/tests/unit/quota-card-grid-mobile-7072.test.ts
+++ b/tests/unit/quota-card-grid-mobile-7072.test.ts
@@ -1,0 +1,79 @@
+// #7072 — Provider Quota page card grid clipped on mobile.
+//
+// PR #6815 changed QuotaCardGrid.tsx's per-group card grid from
+// `grid-cols-1 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4` to
+// `grid-cols-2 md:grid-cols-3 xl:grid-cols-4`, dropping the mobile (<768px)
+// single-column fallback that every other card-grid in the dashboard still
+// has (ProviderQuotaWidget.tsx, EvalsTab.tsx, MediaPageClient.tsx,
+// SystemStorageTab.tsx). Forcing 2 columns even on phone widths squeezes
+// each QuotaCard, and since QuotaCard's outer Card uses `overflow-hidden`,
+// the overflowing button/label text is clipped instead of wrapping.
+//
+// This regression guard parses QuotaCardGrid.tsx's JSX via the TypeScript
+// compiler API and asserts the per-group card grid's className restores an
+// unprefixed `grid-cols-1` mobile fallback, while keeping the #6815 density
+// gains (grid-cols-2 at `sm:` and up).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import ts from "typescript";
+
+const COMPONENT_PATH = path.resolve(
+  import.meta.dirname,
+  "../../src/app/(dashboard)/dashboard/usage/components/ProviderLimits/QuotaCardGrid.tsx"
+);
+
+function extractDivClassNames(sourcePath: string): string[] {
+  const sourceText = fs.readFileSync(sourcePath, "utf8");
+  const sourceFile = ts.createSourceFile(
+    sourcePath,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX
+  );
+  const classNames: string[] = [];
+
+  function visit(node: ts.Node) {
+    if (ts.isJsxOpeningElement(node) || ts.isJsxSelfClosingElement(node)) {
+      const tagName = node.tagName.getText(sourceFile);
+      if (tagName === "div") {
+        for (const attr of node.attributes.properties) {
+          if (ts.isJsxAttribute(attr) && attr.name.getText(sourceFile) === "className") {
+            const init = attr.initializer;
+            if (init && ts.isStringLiteral(init)) {
+              classNames.push(init.text);
+            } else if (
+              init &&
+              ts.isJsxExpression(init) &&
+              init.expression &&
+              ts.isStringLiteral(init.expression)
+            ) {
+              classNames.push(init.expression.text);
+            }
+          }
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+  visit(sourceFile);
+  return classNames;
+}
+
+test("QuotaCardGrid (#7072) — per-group card grid keeps a single-column mobile fallback", () => {
+  const classNames = extractDivClassNames(COMPONENT_PATH);
+  const cardGridClassName = classNames.find((c) => /\bgrid\b/.test(c) && /grid-cols-/.test(c));
+  assert.ok(cardGridClassName, "expected to find the per-group card grid's className");
+
+  const tokens = cardGridClassName!.split(/\s+/);
+  const unprefixedGridCols = tokens.find((t) => /^grid-cols-\d+$/.test(t));
+  assert.equal(
+    unprefixedGridCols,
+    "grid-cols-1",
+    `expected unprefixed grid-cols-1 (mobile fallback), got className="${cardGridClassName}"`
+  );
+  assert.match(cardGridClassName!, /\bsm:grid-cols-2\b/, "expected sm:grid-cols-2 to be preserved");
+});


### PR DESCRIPTION
Closes #7072

Root cause: PR #6815 changed `QuotaCardGrid.tsx`'s per-group card grid from `grid-cols-1 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4` to `grid-cols-2 md:grid-cols-3 xl:grid-cols-4`, dropping the mobile (<768px) single-column fallback that every other card-grid in the dashboard still has. Forcing 2 columns even on phone widths squeezes each QuotaCard, and since QuotaCard's outer Card uses `overflow-hidden`, the overflowing button/label text is clipped instead of wrapping — matching the reporter's screenshot.

Fix: restore `grid-cols-1` as the unprefixed mobile fallback, moving the #6815 2-column density gain to the `sm:` breakpoint (`grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 gap-3`).

TDD: added `tests/unit/quota-card-grid-mobile-7072.test.ts`, confirmed RED against the current release tip (asserted unprefixed grid-cols-1, got grid-cols-2), then GREEN after the fix. Updated the existing #3520 regression test in `tests/unit/quota-card-grid-horizontal-layout.test.ts` which previously asserted `doesNotMatch(/grid-cols-1/)` — it now asserts the mobile fallback is present alongside `sm:grid-cols-2`.

Gates run (all green): file-size, cyclomatic complexity, cognitive complexity, changelog-integrity, `npm run typecheck:core`, `npx eslint --suppressions-location config/quality/eslint-suppressions.json` on changed files, and the full existing test file for the touched component (`quota-deactivate-toggle.test.ts` + both grid test files) — 10/10 passing.

Plan-file: _tasks/pipeline/bugs/2-implementing/7072-quota-page-card-grid-clipped-on-mobile.plan.md