### PR TITLE
fix: wire modelAliases fetch into HermesAgentToolCard (#7151)

### DIFF
--- a/changelog.d/fixes/7151-hermes-agent-model-aliases.md
+++ b/changelog.d/fixes/7151-hermes-agent-model-aliases.md
@@ -1,0 +1,1 @@
+- fix(dashboard): wire modelAliases fetch into HermesAgentToolCard so OpenRouter and other passthrough providers appear in the Hermes Agent role picker (#7151)

--- a/src/app/(dashboard)/dashboard/cli-code/components/HermesAgentToolCard.tsx
+++ b/src/app/(dashboard)/dashboard/cli-code/components/HermesAgentToolCard.tsx
@@ -47,6 +47,10 @@ export default function HermesAgentToolCard({
   const [previewYaml, setPreviewYaml] = useState<string | null>(null);
   const [isPreviewLoading, setIsPreviewLoading] = useState(false);
   const [firstSetupAt, setFirstSetupAt] = useState<string | null>(null);
+  // Model aliases drive the passthrough provider groups (OpenRouter, Requesty,
+  // DGrid, AgentRouter, Charm Hyper, ...) in ModelSelectModal — without them,
+  // those providers never surface in the Hermes Agent role picker (#7151).
+  const [modelAliases, setModelAliases] = useState({});
 
   // Track whether we have already seeded from batchStatus on this expand
   const seededFromBatchRef = useRef(false);
@@ -109,7 +113,18 @@ export default function HermesAgentToolCard({
       });
     }
     loadCurrentConfig();
+    fetchModelAliases();
   }, [isExpanded, batchStatus, loadCurrentConfig]);
+
+  const fetchModelAliases = async () => {
+    try {
+      const res = await fetch("/api/models/alias");
+      const data = await res.json();
+      if (res.ok) setModelAliases(data.aliases || {});
+    } catch (error) {
+      console.warn("Error fetching model aliases:", error);
+    }
+  };
 
   const setRoleSelection = (roleId: string, model: string, provider = "OmniRoute") => {
     setSelections((prev) => ({ ...prev, [roleId]: { model, provider } }));
@@ -522,6 +537,7 @@ export default function HermesAgentToolCard({
         showCombos={true}
         activeProviders={activeProviders}
         alwaysIncludeProviders={HERMES_AGENT_ZERO_CONFIG_PROVIDERS}
+        modelAliases={modelAliases}
       />
     </Card>
   );

--- a/tests/unit/ui/HermesAgentToolCard-model-aliases.test.tsx
+++ b/tests/unit/ui/HermesAgentToolCard-model-aliases.test.tsx
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+// Regression probe for issue #7151: OpenRouter (and every other
+// `passthroughModels` provider — requesty, dgrid, agentrouter, charm-hyper,
+// etc.) never appears in the Hermes Agent role model picker.
+//
+// Root cause: <ModelSelectModal> derives a passthrough provider's model list
+// from the `modelAliases` prop (ModelSelectModal.tsx groupedModels →
+// buildPassthroughAliasModels(modelAliases, providerId)). When `modelAliases`
+// is `{}` (the component default), that helper returns `[]` and the provider
+// group is skipped entirely — see modelSelectModalHelpers.ts. Every sibling
+// CLI tool card (Codex, Claude, Cline, Kilo, Droid, OpenClaw, Antigravity)
+// fetches `/api/models/alias` and passes the result through, but
+// HermesAgentToolCard never does, so OpenRouter's managed-available-model
+// aliases (synced automatically after the connection is tested — see
+// syncManagedAvailableModelAliases in src/lib/providerModels/managedAvailableModels.ts)
+// are invisible to it.
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CARD_PATH = resolve(
+  __dirname,
+  "../../../src/app/(dashboard)/dashboard/cli-code/components/HermesAgentToolCard.tsx"
+);
+
+describe("HermesAgentToolCard model alias wiring (#7151)", () => {
+  const source = readFileSync(CARD_PATH, "utf8");
+
+  it("declares modelAliases state", () => {
+    expect(source).toMatch(/const \[modelAliases, setModelAliases\] = useState\(\{\}\)/);
+  });
+
+  it("fetches /api/models/alias when expanded", () => {
+    expect(source).toContain('fetch("/api/models/alias")');
+  });
+
+  it("passes modelAliases prop to ModelSelectModal", () => {
+    // Regression guard: this prop is what unlocks passthrough provider groups
+    // (OpenRouter, Requesty, DGrid, AgentRouter, Charm Hyper, ...) in the
+    // Hermes Agent role picker. Without it, OpenRouter is silently absent
+    // from the "Select" modal for every role (Default, Delegation, ...).
+    expect(source).toMatch(/modelAliases=\{modelAliases\}/);
+  });
+});


### PR DESCRIPTION
Closes #7151

Root cause: HermesAgentToolCard.tsx (unlike every sibling CLI-tool card — Kilo, Claude, Codex, Cline, Droid, OpenClaw, Antigravity) never fetched `/api/models/alias` nor passed a `modelAliases` prop into `<ModelSelectModal>`. OpenRouter (and every other `passthroughModels` aggregator — Requesty, DGrid, AgentRouter, Charm Hyper, etc.) builds its model list in the picker purely from that prop (`buildPassthroughAliasModels`), so with an empty map the whole provider group was silently skipped — OpenRouter never showed up in the Hermes Agent role picker even after the connection was configured and tested.

Fix: add `modelAliases` state, fetch `/api/models/alias` on expand (mirroring AntigravityToolCard's proven pattern), and pass `modelAliases={modelAliases}` into `<ModelSelectModal>`. Additive-only, no behavior change for non-passthrough providers.

Regression test: `tests/unit/ui/HermesAgentToolCard-model-aliases.test.tsx` (from the analysis plan-file) — confirmed RED (3/3 failing) against the unfixed code, GREEN (3/3 passing) after the fix.

Gates run:
- `npx vitest run tests/unit/ui/HermesAgentToolCard-model-aliases.test.tsx` — GREEN (3/3)
- Existing HermesAgentToolCard-related tests (ToolDetailClient, hermes-agent-opencode-free, hermes-agent-config-loop) — all pass, no regressions
- `npx vitest run tests/unit/ui/` full suite — 871/873 passing; the 2 failures (ProxyRegistryManager-tdz-render, playView) are pre-existing timeout flakes unrelated to this change, not touching HermesAgentToolCard
- `npm run typecheck:core` — clean
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json` on changed files — clean
- `node scripts/check/check-file-size.mjs` — OK
- `node scripts/check/check-complexity.mjs` — OK (2056 violations, at baseline)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (890 violations, at baseline)
- `node scripts/check/check-changelog-integrity.mjs` — OK

Plan-file: _tasks/pipeline/bugs/2-implementing/7151-hermes-agent-missing-model-aliases-wiring.plan.md