### PR TITLE
fix: agent bridge dns toggle uses POST, not PUT (#7157)

### DIFF
--- a/changelog.d/fixes/7157-agent-bridge-dns-405.md
+++ b/changelog.d/fixes/7157-agent-bridge-dns-405.md
@@ -1,0 +1,1 @@
+- fix(dashboard): Agent Bridge DNS toggle now sends POST (was PUT), fixing HTTP 405 on Start/Stop DNS (#7157)

--- a/src/app/(dashboard)/dashboard/tools/agent-bridge/AgentBridgePageClient.tsx
+++ b/src/app/(dashboard)/dashboard/tools/agent-bridge/AgentBridgePageClient.tsx
@@ -147,7 +147,7 @@ export default function AgentBridgePageClient({
       setActionError(null);
       try {
         const res = await fetch(`/api/tools/agent-bridge/agents/${agentId}/dns`, {
-          method: "PUT",
+          method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ enabled }),
         });

--- a/tests/unit/agent-bridge-dns-toggle-method-7157.test.ts
+++ b/tests/unit/agent-bridge-dns-toggle-method-7157.test.ts
@@ -1,0 +1,24 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const clientPath = path.resolve(
+  __dirname,
+  "../../src/app/(dashboard)/dashboard/tools/agent-bridge/AgentBridgePageClient.tsx"
+);
+const source = readFileSync(clientPath, "utf8");
+
+test("#7157: dns toggle fetch call uses method POST (route.ts only exports POST)", () => {
+  const dnsCallMatch = source.match(
+    /\/api\/tools\/agent-bridge\/agents\/\$\{agentId\}\/dns`,\s*\{\s*method:\s*"([A-Z]+)"/
+  );
+  assert.ok(dnsCallMatch, "expected to find the dns fetch call in AgentBridgePageClient.tsx");
+  assert.equal(
+    dnsCallMatch?.[1],
+    "POST",
+    "dns fetch call must use method: 'POST' to match the route.ts export (issue #7157)"
+  );
+});


### PR DESCRIPTION
Closes #7157

**Root cause**: the Agent Bridge dashboard's "Start DNS" / "Stop DNS" button called `fetch(..., { method: "PUT" })`, but `src/app/api/tools/agent-bridge/agents/[id]/dns/route.ts` only exports `POST`. Next.js App Router auto-returns HTTP 405 for any method without a matching exported handler, so every DNS-enable/disable attempt 405'd before reaching server logic — matching the reporter's screenshot. The route's POST contract is already documented (`docs/frameworks/AGENTBRIDGE.md:490`) and already tested (`tests/unit/agent-bridge-dns-route-validation.test.ts`), so the fix is the single frontend caller, not the route.

The reporter's second point (stale-looking "Certificate not trusted" wording) is a downstream symptom, not a separate bug: the diagnose panel already shows `cert-exists`/`cert-trusted` green — `dns-configured` was red only because DNS was never actually enabled due to the 405. The third ask (auto-detecting the router API key) is an unrelated feature request, out of scope here.

**Regression test**: `tests/unit/agent-bridge-dns-toggle-method-7157.test.ts` — reads `AgentBridgePageClient.tsx` source and asserts the `.../agents/${agentId}/dns` fetch call uses `method: "POST"`. Confirmed RED against unfixed code (`'PUT' !== 'POST'`), GREEN after the fix.

**Gates run**:
- `node --import tsx/esm --test tests/unit/agent-bridge-*.test.ts` — 43/43 pass (full agent-bridge slice, including the pre-existing route-validation suite, untouched)
- `node scripts/check/check-file-size.mjs` — OK
- `node scripts/check/check-complexity.mjs` — OK (baseline unchanged)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (baseline unchanged)
- `node scripts/check/check-changelog-integrity.mjs` — OK
- `npm run typecheck:core` — clean
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json` on both changed files — clean

Plan-file: _tasks/pipeline/bugs/2-implementing/7157-agent-bridge-dns-405.plan.md