### PR TITLE
fix(dashboard): implement missing handleToggleSource on Free Pool tab (#7161)

### DIFF
--- a/changelog.d/fixes/7161-free-pool-handletogglesource.md
+++ b/changelog.d/fixes/7161-free-pool-handletogglesource.md
@@ -1,0 +1,1 @@
+- fix(dashboard): implement missing `handleToggleSource` callback on the Free Pool tab so the page no longer crashes with a `ReferenceError` (#7161)

--- a/src/app/(dashboard)/dashboard/settings/components/proxy/FreePoolTab.tsx
+++ b/src/app/(dashboard)/dashboard/settings/components/proxy/FreePoolTab.tsx
@@ -139,6 +139,16 @@ export default function FreePoolTab() {
     });
   };
 
+  const handleToggleSource = (source: SourceId) => {
+    setDisabledSources((prev) => {
+      const next = new Set(prev);
+      if (next.has(source)) next.delete(source);
+      else next.add(source);
+      saveDisabledSources(next);
+      return next;
+    });
+  };
+
   const handleToggleSelect = (id: string) => {
     setSelected((prev) => {
       const next = new Set(prev);

--- a/tests/unit/free-pool-tab.test.tsx
+++ b/tests/unit/free-pool-tab.test.tsx
@@ -91,13 +91,13 @@ afterEach(() => {
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe("FreePoolTab source toggles", () => {
-  it("renders a toggle group with exactly 3 buttons", async () => {
+  it("renders a toggle group with exactly 4 buttons", async () => {
     const el = renderTab();
     await waitForCondition(() => el.querySelector("[role='group']") !== null);
     const bar = el.querySelector("[role='group']")!;
     expect(bar).toBeTruthy();
     const buttons = bar.querySelectorAll("button");
-    expect(buttons.length).toBe(3);
+    expect(buttons.length).toBe(4);
   });
 
   it("all toggles start enabled (aria-pressed=true)", async () => {
@@ -160,7 +160,7 @@ describe("FreePoolTab source toggles", () => {
     expect(stored).toContain("1proxy");
   });
 
-  it("button labels are 1proxy, Proxifly, IPLocate", async () => {
+  it("button labels are 1proxy, Proxifly, IPLocate, Webshare", async () => {
     const el = renderTab();
     await waitForCondition(() => el.querySelector("[role='group']") !== null);
     const texts = Array.from(el.querySelector("[role='group']")!.querySelectorAll("button")).map(
@@ -169,6 +169,7 @@ describe("FreePoolTab source toggles", () => {
     expect(texts).toContain("1proxy");
     expect(texts).toContain("Proxifly");
     expect(texts).toContain("IPLocate");
+    expect(texts).toContain("Webshare");
   });
 });
 


### PR DESCRIPTION
Closes #7161

## Root cause
`FreePoolTab.tsx` wires `<SourceToggleBar onToggle={handleToggleSource} />`, but `handleToggleSource` was never implemented — it was dropped during the #6909 refactor that added the per-source toggle bar. Since this is a bare identifier evaluated at render time, React threw `ReferenceError: handleToggleSource is not defined` on every render of the page, surfacing as the reported 500 (proxy-pool page).

## Fix
Implemented `handleToggleSource(source: SourceId)` in `FreePoolTab.tsx`: toggles the source id in/out of the `disabledSources` Set via `setDisabledSources`, and persists the selection with the already-imported `saveDisabledSources` helper (mirroring the existing `loadDisabledSources` hydration on mount).

## Regression test (Hard Rule #18 — TDD)
`tests/unit/free-pool-tab.test.tsx` reproduces the bug: before the fix, all 13 tests failed with the exact `ReferenceError: handleToggleSource is not defined`. After the fix, the toggle-bar tests pass and the crash is gone.

Two stale assertions in the same file were updated to match the current 4-source list (`1proxy`, `Proxifly`, `IPLocate`, `Webshare` — Webshare was added after this test file was last touched, pre-dating this bug): the button-count assertion (3 → 4) and the button-labels assertion (added Webshare).

Note: 3 pre-existing failures remain in this file, unrelated to the ReferenceError and out of scope for this fix — they were previously masked by the crash:
- `displays stats when available` / `shows 'No proxies found' message` — the test's `next-intl` mock returns raw translation keys, and the assertions expect literal English text; a cosmetic mismatch unrelated to this bug.
- `renders the per-source errors...` (#5595) — `handleSync` only surfaces `data.errors` when `!res.ok`, but the real `/api/settings/free-proxies/sync` route always returns `200` with per-source errors nested under `results`, so the error box never renders. This is a distinct, pre-existing gap in the #5595 frontend wiring.

This test file is not currently wired into any CI-run vitest script (`test:vitest` targets `vitest.mcp.config.ts` only; `test:vitest:ui` scopes to `tests/unit/ui/`), so none of this was previously caught by CI. Flagging as a follow-up rather than expanding this fix's scope.

## Gates run
- `node scripts/check/check-file-size.mjs` — OK
- `node scripts/check/check-complexity.mjs` — OK (2056/2056 baseline)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (890/890 baseline)
- `node scripts/check/check-changelog-integrity.mjs` — OK
- `npm run typecheck:core` — clean
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json` on both changed files — clean
- `npx vitest run tests/unit/free-pool-tab.test.tsx` — 10/13 pass (RED→GREEN for the ReferenceError-caused failures; 3 pre-existing unrelated failures noted above)
- `node --import tsx/esm --test tests/unit/design-grid-background.test.ts` (references FreePoolTab.tsx) — 19/19 pass

Plan-file: `_tasks/pipeline/bugs/2-implementing/7161-free-pool-tab-handletogglesource-undefined.plan.md`