### PR TITLE
feat(ci): Trunk Flaky Tests upload on the fast-path vitest job (per-PR volume)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -226,7 +226,18 @@ jobs:
           node-version: ${{ env.CI_NODE_VERSION }}
           cache: npm
       - run: npm ci
-      - run: npm run test:vitest
+      # WS5.2/5.3: JUnit feeds Trunk Flaky Tests — the fast-path runs on EVERY PR,
+      # which is where flaky-detection volume actually comes from (ci.yml's heavy
+      # jobs only run on the release PR). Advisory upload, own-origin only.
+      - run: npm run test:vitest -- --reporter=default --reporter=junit --outputFile.junit=trunk-junit/vitest-fastpath.xml
+      - name: Upload test results to Trunk (advisory)
+        if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+        continue-on-error: true
+        uses: trunk-io/analytics-uploader@385f1ccdf345b4532dc4b6c665dd432b702b8e28 # v2.1.2
+        with:
+          junit-paths: trunk-junit/**/*.xml
+          org-slug: omniroute
+          token: ${{ secrets.TRUNK_TOKEN }}
 
   fast-unit:
     name: Unit Tests fast-path (${{ matrix.shard }}/4)

--- a/changelog.d/maintenance/trunk-upload-fastpath.md
+++ b/changelog.d/maintenance/trunk-upload-fastpath.md
@@ -1,0 +1,1 @@
+- **CI**: the fast-path Vitest job (every PR) now also emits JUnit and uploads to Trunk Flaky Tests — the heavy-gate uploads alone (release PR only) would never accumulate flaky-detection volume


### PR DESCRIPTION
Follow-up to #7175: the Trunk uploads were wired only into `ci.yml` (heavy gate — runs on the release PR), so the Flaky Tests dashboard would never accumulate per-PR volume. This adds the same JUnit + SHA-pinned advisory upload to the `quality.yml` **fast-path Vitest** job, which runs on every PR — that's where flake detection actually feeds from.

Same guards as #7175: `continue-on-error` (never blocks), own-origin only (forks have no `TRUNK_TOKEN`).