### PR TITLE
fix(translator): preserve Gemini thought parts as reasoning_content on the OpenAI bridge

### DIFF
--- a/changelog.d/fixes/7206-preserve-reasoning-openai-bridge.md
+++ b/changelog.d/fixes/7206-preserve-reasoning-openai-bridge.md
@@ -1,0 +1,1 @@
+- **fix(translator):** preserve Gemini thinking-mode `thought:true` parts as `reasoning_content` instead of leaking them into visible assistant text on the OpenAI request bridge. (thanks @warelik)

--- a/open-sse/translator/request/gemini-to-openai.ts
+++ b/open-sse/translator/request/gemini-to-openai.ts
@@ -47,7 +47,7 @@ export function geminiToOpenAIRequest(model, body, stream) {
   // Convert contents to messages
   if (body.contents && Array.isArray(body.contents)) {
     for (const content of splitCoLocatedFunctionResponses(body.contents)) {
-      const converted = convertGeminiContent(content);
+      const converted = convertGeminiContentWithReasoning(content);
       if (converted) {
         result.messages.push(converted);
       }
@@ -178,6 +178,50 @@ function convertGeminiContent(content) {
   }
 
   return null;
+}
+
+// Gemini marks thinking-mode output with `part.thought === true` on the model's own
+// `parts` array (no separate field on the content itself). Left alone,
+// convertGeminiContent() treats a thought part exactly like a visible text part —
+// merging the model's internal reasoning into the message's regular `content`, which
+// both leaks the private reasoning to whatever the OpenAI pivot forwards to next and
+// prevents Reasoning Replay Cache (docs/routing/REASONING_REPLAY.md) from ever seeing
+// it as `reasoning_content`. Split thought parts out first and re-attach the joined
+// text as `reasoning_content` on the resulting message instead.
+function convertGeminiContentWithReasoning(content) {
+  if (!content || !Array.isArray(content.parts)) {
+    return convertGeminiContent(content);
+  }
+
+  let reasoningContent = "";
+  const visibleParts = [];
+  for (const part of content.parts) {
+    if (part && part.thought === true) {
+      if (typeof part.text === "string") reasoningContent += part.text;
+    } else {
+      visibleParts.push(part);
+    }
+  }
+
+  if (!reasoningContent) {
+    return convertGeminiContent(content);
+  }
+
+  const converted = convertGeminiContent({ ...content, parts: visibleParts });
+
+  if (converted && converted.role !== "tool") {
+    return { ...converted, reasoning_content: reasoningContent };
+  }
+
+  if (!converted) {
+    const role = content.role === "user" ? "user" : "assistant";
+    return { role, reasoning_content: reasoningContent };
+  }
+
+  // A `tool` message (functionResponse) can't carry reasoning_content — fall back to
+  // returning it unchanged rather than fabricating a field the tool-message schema
+  // doesn't expect.
+  return converted;
 }
 
 // Extract text from Gemini content

--- a/tests/unit/translator-gemini-to-openai.test.ts
+++ b/tests/unit/translator-gemini-to-openai.test.ts
@@ -93,6 +93,55 @@ test("Gemini -> OpenAI converts model parts into assistant text and tool calls",
   assert.match(result.messages[0].tool_calls[0].id, /^call_/);
 });
 
+test("Gemini -> OpenAI maps a thought:true part to reasoning_content instead of leaking it into visible text", () => {
+  const result = geminiToOpenAIRequest(
+    "gpt-4o",
+    {
+      contents: [
+        {
+          role: "model",
+          parts: [
+            { thought: true, text: "internal reasoning" },
+            { text: "final answer" },
+          ],
+        },
+      ],
+    },
+    false
+  );
+
+  assert.equal(result.messages.length, 1);
+  const assistant = result.messages[0];
+  assert.equal(assistant.role, "assistant");
+  assert.equal(assistant.reasoning_content, "internal reasoning");
+  // The visible content must not contain the thought text.
+  const visibleText =
+    typeof assistant.content === "string"
+      ? assistant.content
+      : JSON.stringify(assistant.content);
+  assert.doesNotMatch(visibleText, /internal reasoning/);
+  assert.match(visibleText, /final answer/);
+});
+
+test("Gemini -> OpenAI: a thought-only content still produces a message carrying reasoning_content", () => {
+  const result = geminiToOpenAIRequest(
+    "gpt-4o",
+    {
+      contents: [
+        {
+          role: "model",
+          parts: [{ thought: true, text: "only reasoning, no visible answer yet" }],
+        },
+      ],
+    },
+    false
+  );
+
+  assert.equal(result.messages.length, 1);
+  assert.equal(result.messages[0].role, "assistant");
+  assert.equal(result.messages[0].reasoning_content, "only reasoning, no visible answer yet");
+});
+
 test("Gemini -> OpenAI converts function responses into tool messages", () => {
   const result = geminiToOpenAIRequest(
     "gpt-4o",


### PR DESCRIPTION
## Summary

- `geminiToOpenAIRequest()` treated a Gemini thinking-mode `part.thought === true` exactly like a visible text part, merging the model's internal reasoning straight into the message's regular `content`.
- This leaked private reasoning into whatever the OpenAI pivot forwarded downstream, and hid it from Reasoning Replay Cache, which only ever inspects `reasoning_content`.
- Added `convertGeminiContentWithReasoning()`: splits `thought: true` parts out before delegating to the existing `convertGeminiContent()`, then re-attaches the joined thought text as `reasoning_content` on the resulting message (tool/`functionResponse` messages are left untouched, since that schema has no such field).

## Attribution

Thanks to [@warelik](https://github.com/warelik) for the original implementation.

## Changes

- `open-sse/translator/request/gemini-to-openai.ts` — new `convertGeminiContentWithReasoning()` wrapper, wired into the contents-to-messages loop.
- `tests/unit/translator-gemini-to-openai.test.ts` — 2 new regression tests.

## Test plan

- `node --import tsx/esm --test tests/unit/translator-gemini-to-openai.test.ts` — 2 new tests fail before the fix (thought text leaks into visible content, no `reasoning_content`), pass after.
- `node --import tsx/esm --test tests/unit/gemini-to-openai-function-response.test.ts tests/unit/translator-resp-gemini-to-openai.test.ts` — no regression (35/35 pass).
- `npm run typecheck:core` — clean.
- `npx eslint open-sse/translator/request/gemini-to-openai.ts tests/unit/translator-gemini-to-openai.test.ts` — clean.