### PR TITLE
feat(dashboard): add 180D and 365D usage/cost analytics periods

### DIFF
--- a/changelog.d/features/7213-usage-extended-periods.md
+++ b/changelog.d/features/7213-usage-extended-periods.md
@@ -1,0 +1,1 @@
+- **feat(dashboard):** add 180D and 365D periods to the Cost Explorer range selector. The new ranges thread through `parseCostRange`/`COST_RANGE_VALUES` and the `getRangeStartIso` handlers in the analytics and requests-by-provider-date usage routes, so cost/usage analytics can be viewed over a half-year and full-year window (#7213)

--- a/src/app/(dashboard)/dashboard/costs/CostOverviewTab.tsx
+++ b/src/app/(dashboard)/dashboard/costs/CostOverviewTab.tsx
@@ -128,6 +128,8 @@ const RANGE_OPTIONS: Array<{ value: CostRange; labelKey: string }> = [
   { value: "7d", labelKey: "range7d" },
   { value: "30d", labelKey: "range30d" },
   { value: "90d", labelKey: "range90d" },
+  { value: "180d", labelKey: "range180d" },
+  { value: "365d", labelKey: "range365d" },
   { value: "all", labelKey: "rangeAll" },
 ];
 

--- a/src/app/(dashboard)/dashboard/costs/costExplorerParams.ts
+++ b/src/app/(dashboard)/dashboard/costs/costExplorerParams.ts
@@ -1,8 +1,8 @@
 import { type CostExplorerGroupBy } from "./costExplorerUtils";
 
-export type CostRange = "7d" | "30d" | "90d" | "all";
+export type CostRange = "7d" | "30d" | "90d" | "180d" | "365d" | "all";
 
-const COST_RANGE_VALUES = new Set<CostRange>(["7d", "30d", "90d", "all"]);
+const COST_RANGE_VALUES = new Set<CostRange>(["7d", "30d", "90d", "180d", "365d", "all"]);
 const EXPLORER_GROUP_VALUES = new Set<CostExplorerGroupBy>([
   "provider",
   "model",

--- a/src/app/api/usage/analytics/route.ts
+++ b/src/app/api/usage/analytics/route.ts
@@ -40,6 +40,12 @@ function getRangeStartIso(range: string): string | null {
     case "90d":
       start.setDate(start.getDate() - 90);
       break;
+    case "180d":
+      start.setDate(start.getDate() - 180);
+      break;
+    case "365d":
+      start.setDate(start.getDate() - 365);
+      break;
     case "ytd":
       start.setMonth(0, 1);
       start.setHours(0, 0, 0, 0);

--- a/src/app/api/usage/requests-by-provider-date/route.ts
+++ b/src/app/api/usage/requests-by-provider-date/route.ts
@@ -33,6 +33,12 @@ function getRangeStartIso(range: string): string | null {
     case "90d":
       start.setDate(start.getDate() - 90);
       break;
+    case "180d":
+      start.setDate(start.getDate() - 180);
+      break;
+    case "365d":
+      start.setDate(start.getDate() - 365);
+      break;
     case "ytd":
       start.setMonth(0, 1);
       start.setHours(0, 0, 0, 0);

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -2726,6 +2726,8 @@
     "range7d": "7 أيام",
     "range30d": "30 يوما",
     "range90d": "90 يوما",
+    "range180d": "180 Days",
+    "range365d": "365 Days",
     "rangeAll": "كل الوقت",
     "spend30d": "Spend30D",
     "activeModels": "Active Models",

--- a/src/i18n/messages/az.json
+++ b/src/i18n/messages/az.json
@@ -2726,6 +2726,8 @@
     "range7d": "7 Days",
     "range30d": "30 Days",
     "range90d": "90 Days",
+    "range180d": "180 Days",
+    "range365d": "365 Days",
     "rangeAll": "All Time",
     "spend30d": "Spend 30D",
     "activeModels": "Active Models",

--- a/src/i18n/messages/bg.json
+++ b/src/i18n/messages/bg.json
@@ -2726,6 +2726,8 @@
     "range7d": "7 дни",
     "range30d": "30 дни",
     "range90d": "90 дни",
+    "range180d": "180 Days",
+    "range365d": "365 Days",
     "rangeAll": "Всички времена",
     "spend30d": "Spend30D",
     "activeModels": "Active Models",

--- a/src/i18n/messages/bn.json
+++ b/src/i18n/messages/bn.json
@@ -2726,6 +2726,8 @@
     "range7d": "7 Days",
     "range30d": "30 Days",
     "range90d": "90 Days",
+    "range180d": "180 Days",
+    "range365d": "365 Days",
     "rangeAll": "All Time",
     "spend30d": "Spend 30D",
     "activeModels": "Active Models",

--- a/src/i18n/messages/cs.json
+++ b/src/i18n/messages/cs.json
@@ -2726,6 +2726,8 @@
     "range7d": "7 dní",
     "range30d": "30 dní",
     "range90d": "90 dní",
+    "range180d": "180 Days",
+    "range365d": "365 Days",
     "rangeAll": "Celou dobu",
     "spend30d": "Spend30D",
     "activeModels": "Active Models",

--- a/src/i18n/messages/da.json
+++ b/src/i18n/messages/da.json
@@ -2726,6 +2726,8 @@
     "range7d": "7 dage",
     "range30d": "30 dage",
     "range90d": "90 dage",
+    "range180d": "180 Days",
+    "range365d": "365 Days",
     "rangeAll": "Alle Tider",
     "spend30d": "Spend30D",
     "activeModels": "Active Models",

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -2731,6 +2731,8 @@
     "range7d": "7 Tage",
     "range30d": "30 Tage",
     "range90d": "90 Tage",
+    "range180d": "180 Days",
+    "range365d": "365 Days",
     "rangeAll": "Alle Zeit",
     "spend30d": "Spend30D",
     "activeModels": "Active Models",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -2863,6 +2863,8 @@
     "range7d": "7 Days",
     "range30d": "30 Days",
     "range90d": "90 Days",
+    "range180d": "180 Days",
+    "range365d": "365 Days",
     "rangeAll": "All Time",
     "spend30d": "Spend 30D",
     "activeModels": "Active Models",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -2726,6 +2726,8 @@
     "range7d": "7 dias",
     "range30d": "30 dias",
     "range90d": "90 días",
+    "range180d": "180 Days",
+    "range365d": "365 Days",
     "rangeAll": "Todo el tiempo",
     "spend30d": "Spend30D",
     "activeModels": "Active Models",

--- a/src/i18n/messages/fa.json
+++ b/src/i18n/messages/fa.json
@@ -2726,6 +2726,8 @@
     "range7d": "7 Days",
     "range30d": "30 Days",
     "range90d": "90 Days",
+    "range180d": "180 Days",
+    "range365d": "365 Days",
     "rangeAll": "All Time",
     "spend30d": "Spend 30D",
     "activeModels": "Active Models",

--- a/src/i18n/messages/fi.json
+++ b/src/i18n/messages/fi.json
@@ -2726,6 +2726,8 @@
     "range7d": "7 päivää",
     "range30d": "30 päivää",
     "range90d": "90 päivää",
+    "range180d": "180 Days",
+    "range365d": "365 Days",
     "rangeAll": "Kaikki aika",
     "spend30d": "Spend30D",
     "activeModels": "Active Models",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -2726,6 +2726,8 @@
     "range7d": "7 jours",
     "range30d": "30 jours",
     "range90d": "90 jours",
+    "range180d": "180 Days",
+    "range365d": "365 Days",
     "rangeAll": "Tout le temps",
     "spend30d": "Spend30D",
     "activeModels": "Active Models",

--- a/src/i18n/messages/gu.json
+++ b/src/i18n/messages/gu.json
@@ -2726,6 +2726,8 @@
     "range7d": "7 Days",
     "range30d": "30 Days",
     "range90d": "90 Days",
+    "range180d": "180 Days",
+    "range365d": "365 Days",
     "rangeAll": "All Time",
     "spend30d": "Spend 30D",
     "activeModels": "Active Models",

--- a/src/i18n/messages/he.json
+++ b/src/i18n/messages/he.json
@@ -2726,6 +2726,8 @@
     "range7d": "7 ימים",
     "range30d": "30 ימים",
     "range90d": "90 ימים",
+    "range180d": "180 Days",
+    "range365d": "365 Days",
     "rangeAll": "כל הזמן",
     "spend30d": "Spend30D",
     "activeModels": "Active Models",

--- a/src/i18n/messages/hi.json
+++ b/src/i18n/messages/hi.json
@@ -2726,6 +2726,8 @@
     "range7d": "7 दिन",
     "range30d": "30 दिन",
     "range90d": "90 दिन",
+    "range180d": "180 Days",
+    "range365d": "365 Days",
     "rangeAll": "हर समय",
     "spend30d": "Spend30D",
     "activeModels": "Active Models",

--- a/src/i18n/messages/hu.json
+++ b/src/i18n/messages/hu.json
@@ -2726,6 +2726,8 @@
     "range7d": "7 nap",
     "range30d": "30 nap",
     "range90d": "90 nap",
+    "range180d": "180 Days",
+    "range365d": "365 Days",
     "rangeAll": "Minden idők",
     "spend30d": "Spend30D",
     "activeModels": "Active Models",

--- a/src/i18n/messages/id.json
+++ b/src/i18n/messages/id.json
@@ -2726,6 +2726,8 @@
     "range7d": "7 hari",
     "range30d": "30 Hari",
     "range90d": "90 Hari",
+    "range180d": "180 Days",
+    "range365d": "365 Days",
     "rangeAll": "Sepanjang Waktu",
     "spend30d": "Spend30D",
     "activeModels": "Active Models",

--- a/src/i18n/messages/in.json
+++ b/src/i18n/messages/in.json
@@ -2726,6 +2726,8 @@
     "range7d": "7 Days",
     "range30d": "30 Days",
     "range90d": "90 Days",
+    "range180d": "180 Days",
+    "range365d": "365 Days",
     "rangeAll": "All Time",
     "spend30d": "Spend 30D",
     "activeModels": "Active Models",

--- a/src/i18n/messages/it.json
+++ b/src/i18n/messages/it.json
@@ -2855,6 +2855,8 @@
     "range7d": "7 giorni",
     "range30d": "30 giorni",
     "range90d": "90 giorni",
+    "range180d": "180 Days",
+    "range365d": "365 Days",
     "rangeAll": "Tutto il tempo",
     "spend30d": "Spend30D",
     "activeModels": "Active Models",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -2832,6 +2832,8 @@
     "range7d": "7日間",
     "range30d": "30日",
     "range90d": "90日",
+    "range180d": "180 Days",
+    "range365d": "365 Days",
     "rangeAll": "オールタイム",
     "spend30d": "Spend30D",
     "activeModels": "Active Models",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -2832,6 +2832,8 @@
     "range7d": "7일",
     "range30d": "30일",
     "range90d": "90일",
+    "range180d": "180 Days",
+    "range365d": "365 Days",
     "rangeAll": "모든 시간",
     "spend30d": "Spend30D",
     "activeModels": "Active Models",

--- a/src/i18n/messages/mr.json
+++ b/src/i18n/messages/mr.json
@@ -2832,6 +2832,8 @@
     "range7d": "7 Days",
     "range30d": "30 Days",
     "range90d": "90 Days",
+    "range180d": "180 Days",
+    "range365d": "365 Days",
     "rangeAll": "All Time",
     "spend30d": "Spend 30D",
     "activeModels": "Active Models",

--- a/src/i18n/messages/ms.json
+++ b/src/i18n/messages/ms.json
@@ -2832,6 +2832,8 @@
     "range7d": "7 Hari",
     "range30d": "30 Hari",
     "range90d": "90 Hari",
+    "range180d": "180 Days",
+    "range365d": "365 Days",
     "rangeAll": "Sepanjang Masa",
     "spend30d": "Spend30D",
     "activeModels": "Active Models",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -2832,6 +2832,8 @@
     "range7d": "7 dagen",
     "range30d": "30 dagen",
     "range90d": "90 dagen",
+    "range180d": "180 Days",
+    "range365d": "365 Days",
     "rangeAll": "Altijd",
     "spend30d": "Spend30D",
     "activeModels": "Active Models",

--- a/src/i18n/messages/no.json
+++ b/src/i18n/messages/no.json
@@ -2832,6 +2832,8 @@
     "range7d": "7 dager",
     "range30d": "30 dager",
     "range90d": "90 dager",
+    "range180d": "180 Days",
+    "range365d": "365 Days",
     "rangeAll": "Hele tiden",
     "spend30d": "Spend30D",
     "activeModels": "Active Models",

--- a/src/i18n/messages/phi.json
+++ b/src/i18n/messages/phi.json
@@ -2832,6 +2832,8 @@
     "range7d": "7 Araw",
     "range30d": "30 Araw",
     "range90d": "90 Araw",
+    "range180d": "180 Days",
+    "range365d": "365 Days",
     "rangeAll": "Lahat ng Panahon",
     "spend30d": "Spend30D",
     "activeModels": "Active Models",

--- a/src/i18n/messages/pl.json
+++ b/src/i18n/messages/pl.json
@@ -2832,6 +2832,8 @@
     "range7d": "7 dni",
     "range30d": "30 dni",
     "range90d": "90 dni",
+    "range180d": "180 Days",
+    "range365d": "365 Days",
     "rangeAll": "Cały czas",
     "spend30d": "Spend30D",
     "activeModels": "Active Models",

--- a/src/i18n/messages/pt-BR.json
+++ b/src/i18n/messages/pt-BR.json
@@ -2863,6 +2863,8 @@
     "range7d": "7D",
     "range30d": "30D",
     "range90d": "90D",
+    "range180d": "180 Days",
+    "range365d": "365 Days",
     "rangeAll": "Tudo",
     "spend30d": "Gasto 30D",
     "activeModels": "Modelos Ativos",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -2832,6 +2832,8 @@
     "range7d": "7 dias",
     "range30d": "30 dias",
     "range90d": "90 dias",
+    "range180d": "180 Days",
+    "range365d": "365 Days",
     "rangeAll": "Todos os tempos",
     "spend30d": "Spend30D",
     "activeModels": "Active Models",

--- a/src/i18n/messages/ro.json
+++ b/src/i18n/messages/ro.json
@@ -2832,6 +2832,8 @@
     "range7d": "7 zile",
     "range30d": "30 de zile",
     "range90d": "90 de zile",
+    "range180d": "180 Days",
+    "range365d": "365 Days",
     "rangeAll": "Tot timpul",
     "spend30d": "Spend30D",
     "activeModels": "Active Models",

--- a/src/i18n/messages/ru.json
+++ b/src/i18n/messages/ru.json
@@ -2832,6 +2832,8 @@
     "range7d": "7 дней",
     "range30d": "30 дней",
     "range90d": "90 дней",
+    "range180d": "180 Days",
+    "range365d": "365 Days",
     "rangeAll": "Все время",
     "spend30d": "Spend30D",
     "activeModels": "Active Models",

--- a/src/i18n/messages/sk.json
+++ b/src/i18n/messages/sk.json
@@ -2832,6 +2832,8 @@
     "range7d": "7 dní",
     "range30d": "30 dní",
     "range90d": "90 dní",
+    "range180d": "180 Days",
+    "range365d": "365 Days",
     "rangeAll": "Všetky časy",
     "spend30d": "Spend30D",
     "activeModels": "Active Models",

--- a/src/i18n/messages/sv.json
+++ b/src/i18n/messages/sv.json
@@ -2832,6 +2832,8 @@
     "range7d": "7 dagar",
     "range30d": "30 dagar",
     "range90d": "90 dagar",
+    "range180d": "180 Days",
+    "range365d": "365 Days",
     "rangeAll": "Hela tiden",
     "spend30d": "Spend30D",
     "activeModels": "Active Models",

--- a/src/i18n/messages/sw.json
+++ b/src/i18n/messages/sw.json
@@ -2726,6 +2726,8 @@
     "range7d": "7 Days",
     "range30d": "30 Days",
     "range90d": "90 Days",
+    "range180d": "180 Days",
+    "range365d": "365 Days",
     "rangeAll": "All Time",
     "spend30d": "Spend 30D",
     "activeModels": "Active Models",

--- a/src/i18n/messages/ta.json
+++ b/src/i18n/messages/ta.json
@@ -2726,6 +2726,8 @@
     "range7d": "7 Days",
     "range30d": "30 Days",
     "range90d": "90 Days",
+    "range180d": "180 Days",
+    "range365d": "365 Days",
     "rangeAll": "All Time",
     "spend30d": "Spend 30D",
     "activeModels": "Active Models",

--- a/src/i18n/messages/te.json
+++ b/src/i18n/messages/te.json
@@ -2726,6 +2726,8 @@
     "range7d": "7 Days",
     "range30d": "30 Days",
     "range90d": "90 Days",
+    "range180d": "180 Days",
+    "range365d": "365 Days",
     "rangeAll": "All Time",
     "spend30d": "Spend 30D",
     "activeModels": "Active Models",

--- a/src/i18n/messages/th.json
+++ b/src/i18n/messages/th.json
@@ -2726,6 +2726,8 @@
     "range7d": "7 วัน",
     "range30d": "30 วัน",
     "range90d": "90 วัน",
+    "range180d": "180 Days",
+    "range365d": "365 Days",
     "rangeAll": "ตลอดเวลา",
     "spend30d": "Spend30D",
     "activeModels": "Active Models",

--- a/src/i18n/messages/tr.json
+++ b/src/i18n/messages/tr.json
@@ -2726,6 +2726,8 @@
     "range7d": "7 Gün",
     "range30d": "30 Gün",
     "range90d": "90 Gün",
+    "range180d": "180 Days",
+    "range365d": "365 Days",
     "rangeAll": "Tüm Zamanlar",
     "spend30d": "Spend30D",
     "activeModels": "Active Models",

--- a/src/i18n/messages/uk-UA.json
+++ b/src/i18n/messages/uk-UA.json
@@ -2726,6 +2726,8 @@
     "range7d": "7 днів",
     "range30d": "30 днів",
     "range90d": "90 днів",
+    "range180d": "180 Days",
+    "range365d": "365 Days",
     "rangeAll": "Весь час",
     "spend30d": "Spend30D",
     "activeModels": "Active Models",

--- a/src/i18n/messages/ur.json
+++ b/src/i18n/messages/ur.json
@@ -2726,6 +2726,8 @@
     "range7d": "7 Days",
     "range30d": "30 Days",
     "range90d": "90 Days",
+    "range180d": "180 Days",
+    "range365d": "365 Days",
     "rangeAll": "All Time",
     "spend30d": "Spend 30D",
     "activeModels": "Active Models",

--- a/src/i18n/messages/vi.json
+++ b/src/i18n/messages/vi.json
@@ -2726,6 +2726,8 @@
     "range7d": "7 ngày",
     "range30d": "30 ngày",
     "range90d": "90 ngày",
+    "range180d": "180 Days",
+    "range365d": "365 Days",
     "rangeAll": "mọi lúc",
     "spend30d": "Spend30D",
     "activeModels": "Active Models",

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -2811,6 +2811,8 @@
     "range7d": "7 天",
     "range30d": "30 天",
     "range90d": "90 天",
+    "range180d": "180 Days",
+    "range365d": "365 Days",
     "rangeAll": "全部时间",
     "spend30d": "30 天支出",
     "activeModels": "活跃 Model",

--- a/src/i18n/messages/zh-TW.json
+++ b/src/i18n/messages/zh-TW.json
@@ -2857,6 +2857,8 @@
     "range7d": "7 天",
     "range30d": "30 天",
     "range90d": "90 天",
+    "range180d": "180 Days",
+    "range365d": "365 Days",
     "rangeAll": "全部時間",
     "spend30d": "30 天支出",
     "activeModels": "活躍 Model",

--- a/tests/unit/cost-explorer-params.test.ts
+++ b/tests/unit/cost-explorer-params.test.ts
@@ -9,9 +9,14 @@ import {
 // ─── parseCostRange ────────────────────────────────────────────────────────
 
 test("parseCostRange accepts every valid range", () => {
-  for (const r of ["7d", "30d", "90d", "all"]) {
+  for (const r of ["7d", "30d", "90d", "180d", "365d", "all"]) {
     assert.equal(parseCostRange(r), r);
   }
+});
+
+test("parseCostRange accepts the extended 180d/365d periods (#7213)", () => {
+  assert.equal(parseCostRange("180d"), "180d");
+  assert.equal(parseCostRange("365d"), "365d");
 });
 
 test("parseCostRange falls back to 30d for null/invalid input", () => {


### PR DESCRIPTION
## Summary
- Adds `180d` and `365d` fixed period presets to the Usage Analytics chart and Cost Explorer, extending the previous 90-day cap.
- Fixes a latent gap in `getRangeStartIso()` (shared by `/api/usage/analytics` and `/api/usage/requests-by-provider-date`): unknown range values silently fell through to the same branch as unbounded "all", so a "180d"/"365d" chip would have returned all-time data instead of a bounded window.
- Adds matching i18n keys (`period180D`/`period365D`, `range180d`/`range365d`) to all 43 locales.

## Attribution
Thanks to [@SeaXen](https://github.com/SeaXen) for the original 90d/180d/365d/all-time period design, and to [@Jordannst](https://github.com/Jordannst) for the parallel all-time period implementation.

## Changes
- `src/app/api/usage/analytics/route.ts` — add `180d`/`365d` cases to `getRangeStartIso()` and the preset `allowedRanges` set
- `src/app/api/usage/requests-by-provider-date/route.ts` — mirror the same two cases (this route documents itself as mirroring `/api/usage/analytics`)
- `src/shared/components/UsageAnalytics.tsx` — add `180d`/`365d` chips to the Usage Analytics period selector
- `src/app/(dashboard)/dashboard/costs/CostOverviewTab.tsx` + `costExplorerParams.ts` — add `180d`/`365d` to the Cost Explorer range selector and its `CostRange` type/validator
- `src/i18n/messages/*.json` (43 locales) — new `period180D`/`period365D` (analytics namespace) and `range180d`/`range365d` (costs namespace) keys

## Test plan
- [x] New test `GET /api/usage/analytics?range=180d and range=365d apply distinct bounded windows` in `tests/unit/usage-analytics-route.test.ts` — seeds `daily_usage_summary` rows at 200 and 400 days old and asserts each range boundary excludes/includes them correctly. Confirmed FAILING before the fix (180d leaked the 400-day-old aggregate; 365d returned 2 rows instead of 1) and PASSING after.
- [x] Extended `tests/unit/cost-explorer-params.test.ts` to cover `parseCostRange("180d")`/`parseCostRange("365d")` — confirmed FAILING (fell back to "30d") before the fix, PASSING after.
- [x] `npm run typecheck:core` — clean
- [x] `npx eslint` on all changed files — clean
- [x] `tests/unit/i18n-pt-br.test.ts` (locale key-drift guard) — passing