### PR TITLE
feat(api): add Vary: Accept-Encoding to token-authenticated /v1* responses (#6737)

### DIFF
--- a/changelog.d/features/6737-vary-accept-encoding.md
+++ b/changelog.d/features/6737-vary-accept-encoding.md
@@ -1,0 +1,1 @@
+- **feat(api):** add `Vary: Accept-Encoding` to token-authenticated `/v1*`/`/v1beta*` responses so downstream caches distinguish compressed vs uncompressed variants (RFC 9110 §12.5.5). (thanks @chirag127)

--- a/docs/security/CORS.md
+++ b/docs/security/CORS.md
@@ -23,7 +23,11 @@ in this order:
 
 1. **`CORS_ALLOW_ALL=true`** (or the legacy `CORS_ORIGIN=*`) → echo the caller's
    `Origin` back (or `*` when there is no `Origin` header), with `Vary: Origin`
-   so caches stay correct.
+   so caches stay correct. The same `applyCorsHeaders()` chokepoint also appends
+   `Vary: Accept-Encoding` to every 2xx-with-body response on the token-authenticated
+   `/v1*`/`/v1beta*` surface (`relaxForTokenAuth`, RFC 9110 §12.5.5, issue #6737), so
+   downstream/shared caches can correctly distinguish compressed vs uncompressed
+   variants.
 2. Otherwise, the request `Origin` is normalized (lower-cased, trailing slash
    stripped) and matched against the **merged allowlist**:
    - env **`CORS_ALLOWED_ORIGINS`** — comma-separated list, and

--- a/src/server/cors/origins.ts
+++ b/src/server/cors/origins.ts
@@ -138,6 +138,11 @@ export function getCorsStatus(): CorsStatus {
  * is returned when there is no `Origin` header. This is NEVER paired with
  * `Access-Control-Allow-Credentials` (these routes are not cookie-authed), so
  * the echo/wildcard stays safe.
+ *
+ * On that same `relaxForTokenAuth` surface, also appends `Vary: Accept-Encoding`
+ * to every response with a body (RFC 9110 §12.5.5, issue #6737) — Next's built-in
+ * compression middleware only appends it conditionally, so shared caches can't
+ * otherwise reliably tell compressed vs uncompressed variants apart.
  */
 export function applyCorsHeaders(
   response: Response,
@@ -152,6 +157,16 @@ export function applyCorsHeaders(
   if (allowed !== null) {
     response.headers.set("Access-Control-Allow-Origin", allowed);
     response.headers.append("Vary", "Origin");
+  }
+  // RFC 9110 §12.5.5 (issue #6737): the token-authenticated /v1*/v1beta* surface
+  // (relaxForTokenAuth) negotiates content-encoding via Next's built-in
+  // compression middleware, which only appends `Vary: Accept-Encoding`
+  // conditionally (after its own content-type/threshold filter) — so shared
+  // caches (CDNs/proxies) can't reliably tell compressed vs uncompressed variants
+  // apart. Stamp it explicitly here, at the same chokepoint that already appends
+  // `Vary: Origin`, on every relaxed-CORS response with a body.
+  if (relaxForTokenAuth && response.status !== 204) {
+    response.headers.append("Vary", "Accept-Encoding");
   }
   response.headers.set("Access-Control-Allow-Methods", STANDARD_ALLOW_METHODS);
   response.headers.set("Access-Control-Allow-Headers", STANDARD_ALLOW_HEADERS);

--- a/tests/unit/cors/origins.test.ts
+++ b/tests/unit/cors/origins.test.ts
@@ -174,6 +174,51 @@ describe("cors/origins.applyCorsHeaders", () => {
     assert.match(res.headers.get("Vary") || "", /Origin/);
   });
 
+  it("CLIENT_API: appends Vary: Accept-Encoding on a 2xx relaxForTokenAuth response (#6737)", () => {
+    const res = NextResponse.json({ ok: true });
+    const req = new Request("https://server.example.com/api/v1/models");
+    applyCorsHeaders(res, req, true);
+    assert.match(res.headers.get("Vary") || "", /Accept-Encoding/);
+  });
+
+  it("CLIENT_API: combines with Vary: Origin into a single comma-joined header (#6737)", () => {
+    process.env.CORS_ALLOWED_ORIGINS = "https://app.example.com";
+    const res = NextResponse.json({ ok: true });
+    const req = new Request("https://server.example.com/api/v1/models", {
+      headers: { Origin: "https://app.example.com" },
+    });
+    applyCorsHeaders(res, req, true);
+    const varyValues = res.headers.getSetCookie ? res.headers.get("Vary") : res.headers.get("Vary");
+    assert.equal(varyValues, "Origin, Accept-Encoding");
+    assert.equal([...res.headers.entries()].filter(([k]) => k.toLowerCase() === "vary").length, 1);
+  });
+
+  it("MANAGEMENT: does not append Vary: Accept-Encoding (relax off) (#6737)", () => {
+    const res = NextResponse.json({ ok: true });
+    const req = new Request("https://server.example.com/api/keys");
+    applyCorsHeaders(res, req);
+    assert.doesNotMatch(res.headers.get("Vary") || "", /Accept-Encoding/);
+    applyCorsHeaders(res, req, false);
+    assert.doesNotMatch(res.headers.get("Vary") || "", /Accept-Encoding/);
+  });
+
+  it("204 response: does not append Vary: Accept-Encoding even with relaxForTokenAuth (#6737)", () => {
+    const res = new NextResponse(null, { status: 204 });
+    const req = new Request("https://server.example.com/api/v1/models", {
+      method: "OPTIONS",
+    });
+    applyCorsHeaders(res, req, true);
+    assert.doesNotMatch(res.headers.get("Vary") || "", /Accept-Encoding/);
+  });
+
+  it("CLIENT_API: appends Vary: Accept-Encoding even without an Origin header (#6737)", () => {
+    const res = NextResponse.json({ ok: true });
+    const req = new Request("https://server.example.com/api/v1/models");
+    applyCorsHeaders(res, req, true);
+    assert.equal(res.headers.get("Access-Control-Allow-Origin"), "*");
+    assert.match(res.headers.get("Vary") || "", /Accept-Encoding/);
+  });
+
   it("reflects requested headers from Access-Control-Request-Headers preflight", () => {
     process.env.CORS_ALLOWED_ORIGINS = "https://app.example.com";
     const res = NextResponse.json({ ok: true });


### PR DESCRIPTION
## Summary

Adds an explicit `Vary: Accept-Encoding` header to token-authenticated `/v1*`/`/v1beta*` responses (RFC 9110 §12.5.5), so downstream/shared caches (CDNs, reverse proxies) can correctly distinguish compressed vs uncompressed variants.

Next.js's built-in compression middleware (`compress: true`) only appends `Vary: Accept-Encoding` conditionally — after its own content-type/threshold filter passes — so it is not guaranteed across every 2xx `/v1/*` response shape. This extends `applyCorsHeaders()` (`src/server/cors/origins.ts`), the existing chokepoint that already appends `Vary: Origin` for CORS on every branch of the authz pipeline, to also append `Vary: Accept-Encoding` whenever `relaxForTokenAuth` is true (the exact CLIENT_API `/v1*`/`/v1beta*` + public-readonly surface the issue targets), skipping bodiless `204` responses where `Vary` is meaningless.

Uses `Headers.append()` (not `.set()`) so it comma-joins cleanly with any existing `Vary: Origin` into a single `Vary: Origin, Accept-Encoding` header, matching the existing pattern.

## Changes
- `src/server/cors/origins.ts` — append `Vary: Accept-Encoding` in `applyCorsHeaders()` when `relaxForTokenAuth` and status is not `204`
- `tests/unit/cors/origins.test.ts` — 5 new test cases covering the relaxed/non-relaxed, combined-header, 204, and no-Origin-header scenarios
- `docs/security/CORS.md` — documents the new behavior alongside the existing `Vary: Origin` mention
- `changelog.d/features/6737-vary-accept-encoding.md` — changelog fragment

## Validation (TDD)
Wrote failing tests first (asserted `Vary` included `Accept-Encoding`), confirmed red, then implemented the header append and confirmed green:

```
node --import tsx/esm --test tests/unit/cors/origins.test.ts
```
25/25 passing, including the 5 new cases:
- `CLIENT_API: appends Vary: Accept-Encoding on a 2xx relaxForTokenAuth response (#6737)`
- `CLIENT_API: combines with Vary: Origin into a single comma-joined header (#6737)`
- `MANAGEMENT: does not append Vary: Accept-Encoding (relax off) (#6737)`
- `204 response: does not append Vary: Accept-Encoding even with relaxForTokenAuth (#6737)`
- `CLIENT_API: appends Vary: Accept-Encoding even without an Origin header (#6737)`

Also ran green locally: `npm run typecheck:core`, `npm run typecheck:noimplicit:core` (pre-existing unrelated errors confirmed against base — not introduced here), `node scripts/check/check-file-size.mjs`, `node scripts/check/check-complexity.mjs` (matches baseline), `npm run check:cycles`, `npm run check:docs-sync`, scoped `eslint` on changed files (clean), and the pre-commit hook (lint-staged + docs-sync + any-budget + tracked-artifacts) passed on commit. Full-repo `npm run lint` / `npm run test:coverage` were still running under heavy concurrent load from multiple parallel sessions on this box at hand-off — CI will confirm those; flagging for the owner to double-check if desired.

Closes #6737