### PR TITLE
fix(ci): merge queue tolerates the advisory dast-smoke check

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -41,7 +41,14 @@ queue_rules:
     # is intentionally NOT a condition here: the owner-applied `queue` label IS the
     # approval in this repo's single-maintainer model (see governance header).
     merge_conditions:
-      - "#check-failure=0"
+      # "Zero failures" — EXCEPT the advisory dast-smoke: it is continue-on-error by
+      # design and its GH-hosted CLI build hangs recurrently (drafts #7184/#7221 were
+      # dequeued solely by it). Any OTHER failure still blocks (anti-fail-open kept).
+      - or:
+          - "#check-failure=0"
+          - and:
+              - "#check-failure=1"
+              - check-failure=dast-smoke
       - "#check-pending=0"
       - "#check-success>=1"
       - check-success=Merge integrity (changelog + generated skills)


### PR DESCRIPTION
Fourth live finding: queue draft #7221 ran full CI (25min) and was dequeued by a single failure — `dast-smoke`, the advisory (`continue-on-error`) check whose GH-hosted `Build CLI bundle` step hangs recurrently (24-29min observed; drafts #7184 and #7221 both died on it). The queue's `#check-failure=0` counts advisory checks, so one flaky advisory kills every queue attempt.

Fix: an `or` condition — zero failures, OR exactly one failure and it is `dast-smoke`. Any other failure still blocks (anti-fail-open preserved). The dast build hang itself is tracked separately. Config-only; same flow as #7168/#7179/#7216/#7220.