### PR TITLE
feat(mitm): add Antigravity reasoning-effort overrides

### DIFF
--- a/changelog.d/features/7228-antigravity-reasoning-effort-overrides.md
+++ b/changelog.d/features/7228-antigravity-reasoning-effort-overrides.md
@@ -1,0 +1,1 @@
+- **feat(mitm):** Antigravity MITM model mappings now support an optional per-model reasoning-effort override (Default/None/Low/Medium/High/XHigh) alongside the destination-model remap. (thanks @trfi)

--- a/open-sse/translator/request/antigravity-to-openai.ts
+++ b/open-sse/translator/request/antigravity-to-openai.ts
@@ -2,6 +2,7 @@ import { register } from "../registry.ts";
 import { FORMATS } from "../formats.ts";
 import { adjustMaxTokens } from "../helpers/maxTokensHelper.ts";
 import { fixToolPairs } from "../../services/contextManager.ts";
+import { normalizeEffort } from "@/shared/reasoning/effortStandardization";
 
 type JsonRecord = Record<string, unknown>;
 
@@ -21,6 +22,16 @@ export function antigravityToOpenAIRequest(model, body, stream) {
     stream: stream,
   };
 
+  // Explicit per-alias reasoning-effort override (Antigravity MITM layer only —
+  // `src/mitm/aliasConfig.ts` / `src/mitm/_internal/aliasConfig.cjs`). Set at the same
+  // envelope level as `model` (top-level `body`, sibling of `.request`), so it survives
+  // regardless of which cloudcode envelope shape the caller used. When present it takes
+  // priority over the thinkingConfig-derived value below: an explicit "none" suppresses
+  // reasoning_effort entirely even if Antigravity's own thinkingConfig requested thinking;
+  // any other explicit tier is emitted verbatim instead of the coarse budget-based guess.
+  // Ported from upstream decolua/9router#2584 ("add Antigravity reasoning effort overrides").
+  const effortOverride = normalizeEffort((body as JsonRecord).reasoningEffortOverride);
+
   // Generation config
   if (req.generationConfig) {
     const config = req.generationConfig;
@@ -38,8 +49,8 @@ export function antigravityToOpenAIRequest(model, body, stream) {
       result.top_k = config.topK;
     }
 
-    // Thinking config → reasoning_effort
-    if (config.thinkingConfig) {
+    // Thinking config → reasoning_effort (skipped when an explicit override is present).
+    if (effortOverride === undefined && config.thinkingConfig) {
       const budget = config.thinkingConfig.thinkingBudget || 0;
       if (budget > 0) {
         if (budget <= 2048) {
@@ -51,6 +62,12 @@ export function antigravityToOpenAIRequest(model, body, stream) {
         }
       }
     }
+  }
+
+  if (effortOverride !== undefined && effortOverride !== "none") {
+    result.reasoning_effort = effortOverride;
+  } else if (effortOverride === "none") {
+    delete result.reasoning_effort;
   }
 
   // System instruction

--- a/src/app/(dashboard)/dashboard/cli-code/components/AntigravityToolCard.tsx
+++ b/src/app/(dashboard)/dashboard/cli-code/components/AntigravityToolCard.tsx
@@ -6,6 +6,22 @@ import { MITM_TOOL_HOSTS } from "@/shared/constants/mitmToolHosts";
 import { useTranslations } from "next-intl";
 
 import ProviderIcon from "@/shared/components/ProviderIcon";
+import { CANONICAL_EFFORT_VALUES } from "@/shared/reasoning/effortStandardization";
+
+// Reasoning-effort override per Antigravity model row (ported from upstream
+// decolua/9router#2584). Empty value ("") means "Default" — preserve whatever
+// thinking/effort Antigravity's own request already carries; an explicit tier overrides
+// it end-to-end via `reasoningEffortOverride` (see `open-sse/translator/request/antigravity-to-openai.ts`).
+const REASONING_EFFORT_OPTIONS = ["", ...CANONICAL_EFFORT_VALUES];
+
+/** Read the `{ model?, reasoningEffort? }` entry for an alias, upgrading a legacy plain
+ * string mapping (still possible right after a save that only touched other aliases). */
+function getMappingEntry(mappings: Record<string, unknown>, alias: string) {
+  const raw = mappings[alias];
+  if (typeof raw === "string") return { model: raw };
+  if (raw && typeof raw === "object") return raw as { model?: string; reasoningEffort?: string };
+  return {};
+}
 
 export default function AntigravityToolCard({
   tool,
@@ -204,7 +220,7 @@ export default function AntigravityToolCard({
     if (currentEditingAlias) {
       setModelMappings((prev) => ({
         ...prev,
-        [currentEditingAlias]: model.value,
+        [currentEditingAlias]: { ...getMappingEntry(prev, currentEditingAlias), model: model.value },
       }));
     }
   };
@@ -212,8 +228,17 @@ export default function AntigravityToolCard({
   const handleModelMappingChange = (alias, value) => {
     setModelMappings((prev) => ({
       ...prev,
-      [alias]: value,
+      [alias]: { ...getMappingEntry(prev, alias), model: value },
     }));
+  };
+
+  const handleReasoningEffortChange = (alias, reasoningEffort) => {
+    setModelMappings((prev) => {
+      const entry = { ...getMappingEntry(prev, alias) };
+      if (reasoningEffort) entry.reasoningEffort = reasoningEffort;
+      else delete entry.reasoningEffort;
+      return { ...prev, [alias]: entry };
+    });
   };
 
   const handleSaveMappings = async () => {
@@ -336,39 +361,55 @@ export default function AntigravityToolCard({
                 )}
               </div>
 
-              {(tool.defaultModels || []).map((model) => (
-                <div key={model.alias} className="flex items-center gap-2">
-                  <span className="w-32 shrink-0 text-sm font-semibold text-text-main text-right">
-                    {model.name}
-                  </span>
-                  <span className="material-symbols-outlined text-text-muted text-[14px]">
-                    arrow_forward
-                  </span>
-                  <input
-                    type="text"
-                    value={modelMappings[model.alias] || ""}
-                    onChange={(e) => handleModelMappingChange(model.alias, e.target.value)}
-                    placeholder={t("modelPlaceholder")}
-                    className="flex-1 px-2 py-1.5 bg-surface rounded border border-border text-xs focus:outline-none focus:ring-1 focus:ring-primary/50"
-                  />
-                  <button
-                    onClick={() => openModelSelector(model.alias)}
-                    disabled={!hasActiveProviders}
-                    className={`px-2 py-1.5 rounded border text-xs transition-colors shrink-0 whitespace-nowrap ${hasActiveProviders ? "bg-surface border-border text-text-main hover:border-primary cursor-pointer" : "opacity-50 cursor-not-allowed border-border"}`}
-                  >
-                    {t("select")}
-                  </button>
-                  {modelMappings[model.alias] && (
-                    <button
-                      onClick={() => handleModelMappingChange(model.alias, "")}
-                      className="p-1 text-text-muted hover:text-red-500 rounded transition-colors"
-                      title={t("clear")}
+              {(tool.defaultModels || []).map((model) => {
+                const entry = getMappingEntry(modelMappings, model.alias);
+                return (
+                  <div key={model.alias} className="flex items-center gap-2">
+                    <span className="w-32 shrink-0 text-sm font-semibold text-text-main text-right">
+                      {model.name}
+                    </span>
+                    <span className="material-symbols-outlined text-text-muted text-[14px]">
+                      arrow_forward
+                    </span>
+                    <input
+                      type="text"
+                      value={entry.model || ""}
+                      onChange={(e) => handleModelMappingChange(model.alias, e.target.value)}
+                      placeholder={t("modelPlaceholder")}
+                      className="flex-1 px-2 py-1.5 bg-surface rounded border border-border text-xs focus:outline-none focus:ring-1 focus:ring-primary/50"
+                    />
+                    <select
+                      value={entry.reasoningEffort || ""}
+                      onChange={(e) => handleReasoningEffortChange(model.alias, e.target.value)}
+                      title={t("reasoningEffortHint")}
+                      aria-label={t("reasoningEffort", { model: model.name })}
+                      className="w-28 shrink-0 px-2 py-1.5 bg-surface rounded border border-border text-xs focus:outline-none focus:ring-1 focus:ring-primary/50"
                     >
-                      <span className="material-symbols-outlined text-[14px]">close</span>
+                      {REASONING_EFFORT_OPTIONS.map((tier) => (
+                        <option key={tier || "default"} value={tier}>
+                          {tier ? t(`reasoningEffortTier.${tier}`) : t("reasoningEffortDefault")}
+                        </option>
+                      ))}
+                    </select>
+                    <button
+                      onClick={() => openModelSelector(model.alias)}
+                      disabled={!hasActiveProviders}
+                      className={`px-2 py-1.5 rounded border text-xs transition-colors shrink-0 whitespace-nowrap ${hasActiveProviders ? "bg-surface border-border text-text-main hover:border-primary cursor-pointer" : "opacity-50 cursor-not-allowed border-border"}`}
+                    >
+                      {t("select")}
                     </button>
-                  )}
-                </div>
-              ))}
+                    {(entry.model || entry.reasoningEffort) && (
+                      <button
+                        onClick={() => handleModelMappingChange(model.alias, "")}
+                        className="p-1 text-text-muted hover:text-red-500 rounded transition-colors"
+                        title={t("clear")}
+                      >
+                        <span className="material-symbols-outlined text-[14px]">close</span>
+                      </button>
+                    )}
+                  </div>
+                );
+              })}
 
               <div className="flex items-center gap-2">
                 <Button
@@ -480,7 +521,9 @@ export default function AntigravityToolCard({
         isOpen={modalOpen}
         onClose={() => setModalOpen(false)}
         onSelect={handleModelSelect}
-        selectedModel={currentEditingAlias ? modelMappings[currentEditingAlias] : null}
+        selectedModel={
+          currentEditingAlias ? getMappingEntry(modelMappings, currentEditingAlias).model || null : null
+        }
         activeProviders={activeProviders}
         modelAliases={modelAliases}
         title={t("selectModelForAlias", { alias: currentEditingAlias || "" })}

--- a/src/app/api/cli-tools/antigravity-mitm/alias/route.ts
+++ b/src/app/api/cli-tools/antigravity-mitm/alias/route.ts
@@ -5,6 +5,7 @@ import { requireCliToolsAuth } from "@/lib/api/requireCliToolsAuth";
 import { getMitmAlias, setMitmAliasAll } from "@/models";
 import { cliMitmAliasUpdateSchema } from "@/shared/validation/schemas";
 import { isValidationFailure, validateBody } from "@/shared/validation/helpers";
+import { hasInvalidReasoningEffort, normalizeAliasMappings } from "@/mitm/aliasConfig";
 
 // GET - Get MITM aliases for a tool
 export async function GET(request) {
@@ -15,7 +16,15 @@ export async function GET(request) {
     const { searchParams } = new URL(request.url);
     const toolName = searchParams.get("tool");
     const aliases = await getMitmAlias(toolName || undefined);
-    return NextResponse.json({ aliases });
+    // `getMitmAlias(tool)` returns a flat alias→mapping record we can upgrade in place;
+    // without a `tool` filter it returns one level deeper (`{ [tool]: { [alias]: value } }`),
+    // which is not this shape — only normalize the single-tool response. Upgrades legacy
+    // plain-string mappings (every existing install) into the structured
+    // `{ model?, reasoningEffort? }` shape the UI/consumers expect — no DB migration
+    // required (ported from upstream decolua/9router#2584).
+    return NextResponse.json({
+      aliases: toolName ? normalizeAliasMappings(aliases) : aliases,
+    });
   } catch (error) {
     console.log("Error fetching MITM aliases:", (error as any).message);
     return NextResponse.json({ error: "Failed to fetch aliases" }, { status: 500 });
@@ -49,12 +58,13 @@ export async function PUT(request) {
     }
     const { tool, mappings } = validation.data;
 
-    const filtered: Record<string, string> = {};
-    for (const [alias, model] of Object.entries(mappings)) {
-      if (model && (model as string).trim()) {
-        filtered[alias] = (model as string).trim();
-      }
+    // Reject an unrecognized reasoning-effort value at the API boundary instead of
+    // silently dropping it (ported from upstream decolua/9router#2584).
+    if (hasInvalidReasoningEffort(mappings)) {
+      return NextResponse.json({ error: "Invalid reasoning effort" }, { status: 400 });
     }
+
+    const filtered = normalizeAliasMappings(mappings);
 
     await setMitmAliasAll(tool, filtered);
     return NextResponse.json({ success: true, aliases: filtered });

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -2218,7 +2218,17 @@
     "copilotToolCalling": "استدعاء الأداة",
     "copilotPasteInto": "لصق في:",
     "wireApiChatCompletions": "مكتملات الدردشة (/chat/مكتملات)",
-    "wireApiResponses": "واجهة برمجة تطبيقات الاستجابات (/ الاستجابات)"
+    "wireApiResponses": "واجهة برمجة تطبيقات الاستجابات (/ الاستجابات)",
+    "reasoningEffort": "__MISSING__:Reasoning effort for {model}",
+    "reasoningEffortDefault": "__MISSING__:Default",
+    "reasoningEffortHint": "__MISSING__:Default preserves the reasoning effort sent by the agent",
+    "reasoningEffortTier": {
+      "none": "__MISSING__:None",
+      "low": "__MISSING__:Low",
+      "medium": "__MISSING__:Medium",
+      "high": "__MISSING__:High",
+      "xhigh": "__MISSING__:XHigh"
+    }
   },
   "combos": {
     "title": "المجموعات",

--- a/src/i18n/messages/az.json
+++ b/src/i18n/messages/az.json
@@ -2218,7 +2218,17 @@
     "copilotToolCalling": "Alət çağırışı",
     "copilotPasteInto": "Yapışdırın:",
     "wireApiChatCompletions": "Söhbət Tamamlamaları (/chat/tamamlamalar)",
-    "wireApiResponses": "Responses API (/cavablar)"
+    "wireApiResponses": "Responses API (/cavablar)",
+    "reasoningEffort": "__MISSING__:Reasoning effort for {model}",
+    "reasoningEffortDefault": "__MISSING__:Default",
+    "reasoningEffortHint": "__MISSING__:Default preserves the reasoning effort sent by the agent",
+    "reasoningEffortTier": {
+      "none": "__MISSING__:None",
+      "low": "__MISSING__:Low",
+      "medium": "__MISSING__:Medium",
+      "high": "__MISSING__:High",
+      "xhigh": "__MISSING__:XHigh"
+    }
   },
   "combos": {
     "title": "Combos",

--- a/src/i18n/messages/bg.json
+++ b/src/i18n/messages/bg.json
@@ -2218,7 +2218,17 @@
     "copilotToolCalling": "Извикване на инструмент",
     "copilotPasteInto": "Поставете в:",
     "wireApiChatCompletions": "Завършвания на чат (/chat/completions)",
-    "wireApiResponses": "API за отговори (/отговори)"
+    "wireApiResponses": "API за отговори (/отговори)",
+    "reasoningEffort": "__MISSING__:Reasoning effort for {model}",
+    "reasoningEffortDefault": "__MISSING__:Default",
+    "reasoningEffortHint": "__MISSING__:Default preserves the reasoning effort sent by the agent",
+    "reasoningEffortTier": {
+      "none": "__MISSING__:None",
+      "low": "__MISSING__:Low",
+      "medium": "__MISSING__:Medium",
+      "high": "__MISSING__:High",
+      "xhigh": "__MISSING__:XHigh"
+    }
   },
   "combos": {
     "title": "Комбота",

--- a/src/i18n/messages/bn.json
+++ b/src/i18n/messages/bn.json
@@ -2218,7 +2218,17 @@
     "copilotToolCalling": "টুল কলিং",
     "copilotPasteInto": "এতে পেস্ট করুন:",
     "wireApiChatCompletions": "চ্যাট সমাপ্তি (/চ্যাট/সম্পূর্ণতা)",
-    "wireApiResponses": "প্রতিক্রিয়া API (/প্রতিক্রিয়া)"
+    "wireApiResponses": "প্রতিক্রিয়া API (/প্রতিক্রিয়া)",
+    "reasoningEffort": "__MISSING__:Reasoning effort for {model}",
+    "reasoningEffortDefault": "__MISSING__:Default",
+    "reasoningEffortHint": "__MISSING__:Default preserves the reasoning effort sent by the agent",
+    "reasoningEffortTier": {
+      "none": "__MISSING__:None",
+      "low": "__MISSING__:Low",
+      "medium": "__MISSING__:Medium",
+      "high": "__MISSING__:High",
+      "xhigh": "__MISSING__:XHigh"
+    }
   },
   "combos": {
     "title": "Combos",

--- a/src/i18n/messages/cs.json
+++ b/src/i18n/messages/cs.json
@@ -2218,7 +2218,17 @@
     "copilotToolCalling": "Volání nástroje",
     "copilotPasteInto": "Vložit do:",
     "wireApiChatCompletions": "Dokončení chatu (/chat/completions)",
-    "wireApiResponses": "Responses API (/responses)"
+    "wireApiResponses": "Responses API (/responses)",
+    "reasoningEffort": "__MISSING__:Reasoning effort for {model}",
+    "reasoningEffortDefault": "__MISSING__:Default",
+    "reasoningEffortHint": "__MISSING__:Default preserves the reasoning effort sent by the agent",
+    "reasoningEffortTier": {
+      "none": "__MISSING__:None",
+      "low": "__MISSING__:Low",
+      "medium": "__MISSING__:Medium",
+      "high": "__MISSING__:High",
+      "xhigh": "__MISSING__:XHigh"
+    }
   },
   "combos": {
     "title": "Komba",

--- a/src/i18n/messages/da.json
+++ b/src/i18n/messages/da.json
@@ -2218,7 +2218,17 @@
     "copilotToolCalling": "Værktøjsopkald",
     "copilotPasteInto": "Indsæt i:",
     "wireApiChatCompletions": "Chatafslutninger (/chat/afslutninger)",
-    "wireApiResponses": "Responses API (/responses)"
+    "wireApiResponses": "Responses API (/responses)",
+    "reasoningEffort": "__MISSING__:Reasoning effort for {model}",
+    "reasoningEffortDefault": "__MISSING__:Default",
+    "reasoningEffortHint": "__MISSING__:Default preserves the reasoning effort sent by the agent",
+    "reasoningEffortTier": {
+      "none": "__MISSING__:None",
+      "low": "__MISSING__:Low",
+      "medium": "__MISSING__:Medium",
+      "high": "__MISSING__:High",
+      "xhigh": "__MISSING__:XHigh"
+    }
   },
   "combos": {
     "title": "Combos",

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -2223,7 +2223,17 @@
     "copilotToolCalling": "Werkzeugaufruf",
     "copilotPasteInto": "Einfügen in:",
     "wireApiChatCompletions": "Chat-Abschlüsse (/chat/completions)",
-    "wireApiResponses": "Antwort-API (/responses)"
+    "wireApiResponses": "Antwort-API (/responses)",
+    "reasoningEffort": "__MISSING__:Reasoning effort for {model}",
+    "reasoningEffortDefault": "__MISSING__:Default",
+    "reasoningEffortHint": "__MISSING__:Default preserves the reasoning effort sent by the agent",
+    "reasoningEffortTier": {
+      "none": "__MISSING__:None",
+      "low": "__MISSING__:Low",
+      "medium": "__MISSING__:Medium",
+      "high": "__MISSING__:High",
+      "xhigh": "__MISSING__:XHigh"
+    }
   },
   "combos": {
     "title": "Kombinationen",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -2050,6 +2050,16 @@
     "saveMappings": "Save Mappings",
     "mappingsSaved": "Mappings saved!",
     "failedSaveMappings": "Failed to save mappings",
+    "reasoningEffort": "Reasoning effort for {model}",
+    "reasoningEffortDefault": "Default",
+    "reasoningEffortHint": "Default preserves the reasoning effort sent by the agent",
+    "reasoningEffortTier": {
+      "none": "None",
+      "low": "Low",
+      "medium": "Medium",
+      "high": "High",
+      "xhigh": "XHigh"
+    },
     "howItWorks": "How it works:",
     "antigravityHowWorksDesc": "Antigravity sends requests to Google's endpoint. MITM intercepts and redirects them to OmniRoute.",
     "antigravityStep1": "1. Start MITM to route requests through OmniRoute.",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -2218,7 +2218,17 @@
     "copilotToolCalling": "Llamada de herramientas",
     "copilotPasteInto": "Pegar en:",
     "wireApiChatCompletions": "Finalizaciones de chat (/chat/completions)",
-    "wireApiResponses": "API de respuestas (/respuestas)"
+    "wireApiResponses": "API de respuestas (/respuestas)",
+    "reasoningEffort": "__MISSING__:Reasoning effort for {model}",
+    "reasoningEffortDefault": "__MISSING__:Default",
+    "reasoningEffortHint": "__MISSING__:Default preserves the reasoning effort sent by the agent",
+    "reasoningEffortTier": {
+      "none": "__MISSING__:None",
+      "low": "__MISSING__:Low",
+      "medium": "__MISSING__:Medium",
+      "high": "__MISSING__:High",
+      "xhigh": "__MISSING__:XHigh"
+    }
   },
   "combos": {
     "title": "combos",

--- a/src/i18n/messages/fa.json
+++ b/src/i18n/messages/fa.json
@@ -2218,7 +2218,17 @@
     "copilotToolCalling": "فراخوانی ابزار",
     "copilotPasteInto": "چسباندن در:",
     "wireApiChatCompletions": "تکمیل چت (/chat/completions)",
-    "wireApiResponses": "Responses API (/responses)"
+    "wireApiResponses": "Responses API (/responses)",
+    "reasoningEffort": "__MISSING__:Reasoning effort for {model}",
+    "reasoningEffortDefault": "__MISSING__:Default",
+    "reasoningEffortHint": "__MISSING__:Default preserves the reasoning effort sent by the agent",
+    "reasoningEffortTier": {
+      "none": "__MISSING__:None",
+      "low": "__MISSING__:Low",
+      "medium": "__MISSING__:Medium",
+      "high": "__MISSING__:High",
+      "xhigh": "__MISSING__:XHigh"
+    }
   },
   "combos": {
     "title": "Combos",

--- a/src/i18n/messages/fi.json
+++ b/src/i18n/messages/fi.json
@@ -2218,7 +2218,17 @@
     "copilotToolCalling": "Työkalun kutsuminen",
     "copilotPasteInto": "Liitä kohteeseen:",
     "wireApiChatCompletions": "Keskustelun päättymiset (/chat/completions)",
-    "wireApiResponses": "Responses API (/responses)"
+    "wireApiResponses": "Responses API (/responses)",
+    "reasoningEffort": "__MISSING__:Reasoning effort for {model}",
+    "reasoningEffortDefault": "__MISSING__:Default",
+    "reasoningEffortHint": "__MISSING__:Default preserves the reasoning effort sent by the agent",
+    "reasoningEffortTier": {
+      "none": "__MISSING__:None",
+      "low": "__MISSING__:Low",
+      "medium": "__MISSING__:Medium",
+      "high": "__MISSING__:High",
+      "xhigh": "__MISSING__:XHigh"
+    }
   },
   "combos": {
     "title": "Yhdistelmät",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -2218,7 +2218,17 @@
     "copilotToolCalling": "Appel d'outil",
     "copilotPasteInto": "Coller dans :",
     "wireApiChatCompletions": "Achèvements de chat (/chat/completions)",
-    "wireApiResponses": "API de réponses (/réponses)"
+    "wireApiResponses": "API de réponses (/réponses)",
+    "reasoningEffort": "__MISSING__:Reasoning effort for {model}",
+    "reasoningEffortDefault": "__MISSING__:Default",
+    "reasoningEffortHint": "__MISSING__:Default preserves the reasoning effort sent by the agent",
+    "reasoningEffortTier": {
+      "none": "__MISSING__:None",
+      "low": "__MISSING__:Low",
+      "medium": "__MISSING__:Medium",
+      "high": "__MISSING__:High",
+      "xhigh": "__MISSING__:XHigh"
+    }
   },
   "combos": {
     "title": "Combinaisons",

--- a/src/i18n/messages/gu.json
+++ b/src/i18n/messages/gu.json
@@ -2218,7 +2218,17 @@
     "copilotToolCalling": "ટૂલ કૉલિંગ",
     "copilotPasteInto": "આમાં પેસ્ટ કરો:",
     "wireApiChatCompletions": "ચેટ પૂર્ણતા (/ચેટ/પૂર્ણતા)",
-    "wireApiResponses": "પ્રતિભાવ API (/પ્રતિસાદો)"
+    "wireApiResponses": "પ્રતિભાવ API (/પ્રતિસાદો)",
+    "reasoningEffort": "__MISSING__:Reasoning effort for {model}",
+    "reasoningEffortDefault": "__MISSING__:Default",
+    "reasoningEffortHint": "__MISSING__:Default preserves the reasoning effort sent by the agent",
+    "reasoningEffortTier": {
+      "none": "__MISSING__:None",
+      "low": "__MISSING__:Low",
+      "medium": "__MISSING__:Medium",
+      "high": "__MISSING__:High",
+      "xhigh": "__MISSING__:XHigh"
+    }
   },
   "combos": {
     "title": "Combos",

--- a/src/i18n/messages/he.json
+++ b/src/i18n/messages/he.json
@@ -2218,7 +2218,17 @@
     "copilotToolCalling": "כלי שיחות",
     "copilotPasteInto": "הדבק לתוך:",
     "wireApiChatCompletions": "השלמות של צ'אט (/chat/completions)",
-    "wireApiResponses": "ממשק API של תגובות (/תגובות)"
+    "wireApiResponses": "ממשק API של תגובות (/תגובות)",
+    "reasoningEffort": "__MISSING__:Reasoning effort for {model}",
+    "reasoningEffortDefault": "__MISSING__:Default",
+    "reasoningEffortHint": "__MISSING__:Default preserves the reasoning effort sent by the agent",
+    "reasoningEffortTier": {
+      "none": "__MISSING__:None",
+      "low": "__MISSING__:Low",
+      "medium": "__MISSING__:Medium",
+      "high": "__MISSING__:High",
+      "xhigh": "__MISSING__:XHigh"
+    }
   },
   "combos": {
     "title": "שילובים",

--- a/src/i18n/messages/hi.json
+++ b/src/i18n/messages/hi.json
@@ -2218,7 +2218,17 @@
     "copilotToolCalling": "टूल कॉलिंग",
     "copilotPasteInto": "इसमें चिपकाएँ:",
     "wireApiChatCompletions": "चैट पूर्णताएँ (/चैट/पूर्णियाँ)",
-    "wireApiResponses": "प्रतिक्रियाएँ एपीआई (/प्रतिक्रियाएँ)"
+    "wireApiResponses": "प्रतिक्रियाएँ एपीआई (/प्रतिक्रियाएँ)",
+    "reasoningEffort": "__MISSING__:Reasoning effort for {model}",
+    "reasoningEffortDefault": "__MISSING__:Default",
+    "reasoningEffortHint": "__MISSING__:Default preserves the reasoning effort sent by the agent",
+    "reasoningEffortTier": {
+      "none": "__MISSING__:None",
+      "low": "__MISSING__:Low",
+      "medium": "__MISSING__:Medium",
+      "high": "__MISSING__:High",
+      "xhigh": "__MISSING__:XHigh"
+    }
   },
   "combos": {
     "title": "संयोजन",

--- a/src/i18n/messages/hu.json
+++ b/src/i18n/messages/hu.json
@@ -2218,7 +2218,17 @@
     "copilotToolCalling": "Szerszámhívás",
     "copilotPasteInto": "Beillesztés ide:",
     "wireApiChatCompletions": "Csevegés befejezése (/chat/completions)",
-    "wireApiResponses": "Responses API (/responses)"
+    "wireApiResponses": "Responses API (/responses)",
+    "reasoningEffort": "__MISSING__:Reasoning effort for {model}",
+    "reasoningEffortDefault": "__MISSING__:Default",
+    "reasoningEffortHint": "__MISSING__:Default preserves the reasoning effort sent by the agent",
+    "reasoningEffortTier": {
+      "none": "__MISSING__:None",
+      "low": "__MISSING__:Low",
+      "medium": "__MISSING__:Medium",
+      "high": "__MISSING__:High",
+      "xhigh": "__MISSING__:XHigh"
+    }
   },
   "combos": {
     "title": "Kombók",

--- a/src/i18n/messages/id.json
+++ b/src/i18n/messages/id.json
@@ -2218,7 +2218,17 @@
     "copilotToolCalling": "Panggilan Alat",
     "copilotPasteInto": "Tempel ke:",
     "wireApiChatCompletions": "Penyelesaian Obrolan (/chat/penyelesaian)",
-    "wireApiResponses": "API Respons (/respons)"
+    "wireApiResponses": "API Respons (/respons)",
+    "reasoningEffort": "__MISSING__:Reasoning effort for {model}",
+    "reasoningEffortDefault": "__MISSING__:Default",
+    "reasoningEffortHint": "__MISSING__:Default preserves the reasoning effort sent by the agent",
+    "reasoningEffortTier": {
+      "none": "__MISSING__:None",
+      "low": "__MISSING__:Low",
+      "medium": "__MISSING__:Medium",
+      "high": "__MISSING__:High",
+      "xhigh": "__MISSING__:XHigh"
+    }
   },
   "combos": {
     "title": "kombo",

--- a/src/i18n/messages/in.json
+++ b/src/i18n/messages/in.json
@@ -2218,7 +2218,17 @@
     "copilotToolCalling": "Panggilan Alat",
     "copilotPasteInto": "Tempel ke:",
     "wireApiChatCompletions": "Penyelesaian Obrolan (/chat/penyelesaian)",
-    "wireApiResponses": "API Respons (/respons)"
+    "wireApiResponses": "API Respons (/respons)",
+    "reasoningEffort": "__MISSING__:Reasoning effort for {model}",
+    "reasoningEffortDefault": "__MISSING__:Default",
+    "reasoningEffortHint": "__MISSING__:Default preserves the reasoning effort sent by the agent",
+    "reasoningEffortTier": {
+      "none": "__MISSING__:None",
+      "low": "__MISSING__:Low",
+      "medium": "__MISSING__:Medium",
+      "high": "__MISSING__:High",
+      "xhigh": "__MISSING__:XHigh"
+    }
   },
   "combos": {
     "title": "Combos",

--- a/src/i18n/messages/it.json
+++ b/src/i18n/messages/it.json
@@ -2328,7 +2328,17 @@
     "copilotToolCalling": "Chiamata dello strumento",
     "copilotPasteInto": "Incolla in:",
     "wireApiChatCompletions": "Completamenti chat (/chat/completamenti)",
-    "wireApiResponses": "API delle risposte (/responses)"
+    "wireApiResponses": "API delle risposte (/responses)",
+    "reasoningEffort": "__MISSING__:Reasoning effort for {model}",
+    "reasoningEffortDefault": "__MISSING__:Default",
+    "reasoningEffortHint": "__MISSING__:Default preserves the reasoning effort sent by the agent",
+    "reasoningEffortTier": {
+      "none": "__MISSING__:None",
+      "low": "__MISSING__:Low",
+      "medium": "__MISSING__:Medium",
+      "high": "__MISSING__:High",
+      "xhigh": "__MISSING__:XHigh"
+    }
   },
   "combos": {
     "title": "Combinazioni",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -2320,7 +2320,17 @@
     "copilotToolCalling": "ツール呼び出し",
     "copilotPasteInto": "以下に貼り付けます:",
     "wireApiChatCompletions": "チャットの完了 (/chat/completions)",
-    "wireApiResponses": "レスポンス API (/responses)"
+    "wireApiResponses": "レスポンス API (/responses)",
+    "reasoningEffort": "__MISSING__:Reasoning effort for {model}",
+    "reasoningEffortDefault": "__MISSING__:Default",
+    "reasoningEffortHint": "__MISSING__:Default preserves the reasoning effort sent by the agent",
+    "reasoningEffortTier": {
+      "none": "__MISSING__:None",
+      "low": "__MISSING__:Low",
+      "medium": "__MISSING__:Medium",
+      "high": "__MISSING__:High",
+      "xhigh": "__MISSING__:XHigh"
+    }
   },
   "combos": {
     "title": "コンボ",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -2320,7 +2320,17 @@
     "copilotToolCalling": "도구 호출",
     "copilotPasteInto": "다음 위치에 붙여넣습니다.",
     "wireApiChatCompletions": "채팅 완료(/chat/completions)",
-    "wireApiResponses": "응답 API(/responses)"
+    "wireApiResponses": "응답 API(/responses)",
+    "reasoningEffort": "__MISSING__:Reasoning effort for {model}",
+    "reasoningEffortDefault": "__MISSING__:Default",
+    "reasoningEffortHint": "__MISSING__:Default preserves the reasoning effort sent by the agent",
+    "reasoningEffortTier": {
+      "none": "__MISSING__:None",
+      "low": "__MISSING__:Low",
+      "medium": "__MISSING__:Medium",
+      "high": "__MISSING__:High",
+      "xhigh": "__MISSING__:XHigh"
+    }
   },
   "combos": {
     "title": "콤보",

--- a/src/i18n/messages/mr.json
+++ b/src/i18n/messages/mr.json
@@ -2320,7 +2320,17 @@
     "copilotToolCalling": "टूल कॉलिंग",
     "copilotPasteInto": "यामध्ये पेस्ट करा:",
     "wireApiChatCompletions": "चॅट पूर्णता (/चॅट/पूर्णता)",
-    "wireApiResponses": "प्रतिसाद API (/प्रतिसाद)"
+    "wireApiResponses": "प्रतिसाद API (/प्रतिसाद)",
+    "reasoningEffort": "__MISSING__:Reasoning effort for {model}",
+    "reasoningEffortDefault": "__MISSING__:Default",
+    "reasoningEffortHint": "__MISSING__:Default preserves the reasoning effort sent by the agent",
+    "reasoningEffortTier": {
+      "none": "__MISSING__:None",
+      "low": "__MISSING__:Low",
+      "medium": "__MISSING__:Medium",
+      "high": "__MISSING__:High",
+      "xhigh": "__MISSING__:XHigh"
+    }
   },
   "combos": {
     "title": "Combos",

--- a/src/i18n/messages/ms.json
+++ b/src/i18n/messages/ms.json
@@ -2320,7 +2320,17 @@
     "copilotToolCalling": "Alat Panggilan",
     "copilotPasteInto": "Tampalkan ke dalam:",
     "wireApiChatCompletions": "Selesai Sembang (/sembang/penyelesaian)",
-    "wireApiResponses": "API Respons (/respons)"
+    "wireApiResponses": "API Respons (/respons)",
+    "reasoningEffort": "__MISSING__:Reasoning effort for {model}",
+    "reasoningEffortDefault": "__MISSING__:Default",
+    "reasoningEffortHint": "__MISSING__:Default preserves the reasoning effort sent by the agent",
+    "reasoningEffortTier": {
+      "none": "__MISSING__:None",
+      "low": "__MISSING__:Low",
+      "medium": "__MISSING__:Medium",
+      "high": "__MISSING__:High",
+      "xhigh": "__MISSING__:XHigh"
+    }
   },
   "combos": {
     "title": "Kombo",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -2320,7 +2320,17 @@
     "copilotToolCalling": "Gereedschap bellen",
     "copilotPasteInto": "Plakken in:",
     "wireApiChatCompletions": "Chatvoltooiingen (/chat/voltooiingen)",
-    "wireApiResponses": "Reacties-API (/reacties)"
+    "wireApiResponses": "Reacties-API (/reacties)",
+    "reasoningEffort": "__MISSING__:Reasoning effort for {model}",
+    "reasoningEffortDefault": "__MISSING__:Default",
+    "reasoningEffortHint": "__MISSING__:Default preserves the reasoning effort sent by the agent",
+    "reasoningEffortTier": {
+      "none": "__MISSING__:None",
+      "low": "__MISSING__:Low",
+      "medium": "__MISSING__:Medium",
+      "high": "__MISSING__:High",
+      "xhigh": "__MISSING__:XHigh"
+    }
   },
   "combos": {
     "title": "Combo's",

--- a/src/i18n/messages/no.json
+++ b/src/i18n/messages/no.json
@@ -2320,7 +2320,17 @@
     "copilotToolCalling": "Verktøyanrop",
     "copilotPasteInto": "Lim inn i:",
     "wireApiChatCompletions": "Chatfullføringer (/chat/fullføringer)",
-    "wireApiResponses": "Responses API (/responses)"
+    "wireApiResponses": "Responses API (/responses)",
+    "reasoningEffort": "__MISSING__:Reasoning effort for {model}",
+    "reasoningEffortDefault": "__MISSING__:Default",
+    "reasoningEffortHint": "__MISSING__:Default preserves the reasoning effort sent by the agent",
+    "reasoningEffortTier": {
+      "none": "__MISSING__:None",
+      "low": "__MISSING__:Low",
+      "medium": "__MISSING__:Medium",
+      "high": "__MISSING__:High",
+      "xhigh": "__MISSING__:XHigh"
+    }
   },
   "combos": {
     "title": "Combos",

--- a/src/i18n/messages/phi.json
+++ b/src/i18n/messages/phi.json
@@ -2320,7 +2320,17 @@
     "copilotToolCalling": "Tool Calling",
     "copilotPasteInto": "Idikit sa:",
     "wireApiChatCompletions": "Mga Pagkumpleto ng Chat (/chat/pagkumpleto)",
-    "wireApiResponses": "Responses API (/mga tugon)"
+    "wireApiResponses": "Responses API (/mga tugon)",
+    "reasoningEffort": "__MISSING__:Reasoning effort for {model}",
+    "reasoningEffortDefault": "__MISSING__:Default",
+    "reasoningEffortHint": "__MISSING__:Default preserves the reasoning effort sent by the agent",
+    "reasoningEffortTier": {
+      "none": "__MISSING__:None",
+      "low": "__MISSING__:Low",
+      "medium": "__MISSING__:Medium",
+      "high": "__MISSING__:High",
+      "xhigh": "__MISSING__:XHigh"
+    }
   },
   "combos": {
     "title": "Mga combo",

--- a/src/i18n/messages/pl.json
+++ b/src/i18n/messages/pl.json
@@ -2320,7 +2320,17 @@
     "copilotToolCalling": "Wywołanie narzędzia",
     "copilotPasteInto": "Wklej do:",
     "wireApiChatCompletions": "Zakończenia czatu (/chat/uzupełnienia)",
-    "wireApiResponses": "API odpowiedzi (/response)"
+    "wireApiResponses": "API odpowiedzi (/response)",
+    "reasoningEffort": "__MISSING__:Reasoning effort for {model}",
+    "reasoningEffortDefault": "__MISSING__:Default",
+    "reasoningEffortHint": "__MISSING__:Default preserves the reasoning effort sent by the agent",
+    "reasoningEffortTier": {
+      "none": "__MISSING__:None",
+      "low": "__MISSING__:Low",
+      "medium": "__MISSING__:Medium",
+      "high": "__MISSING__:High",
+      "xhigh": "__MISSING__:XHigh"
+    }
   },
   "combos": {
     "title": "Kombinacje",

--- a/src/i18n/messages/pt-BR.json
+++ b/src/i18n/messages/pt-BR.json
@@ -2332,7 +2332,17 @@
     "copilotToolCalling": "Chamada de ferramenta",
     "copilotPasteInto": "Cole em:",
     "wireApiChatCompletions": "Conclusões de bate-papo (/chat/completions)",
-    "wireApiResponses": "API de respostas (/respostas)"
+    "wireApiResponses": "API de respostas (/respostas)",
+    "reasoningEffort": "__MISSING__:Reasoning effort for {model}",
+    "reasoningEffortDefault": "__MISSING__:Default",
+    "reasoningEffortHint": "__MISSING__:Default preserves the reasoning effort sent by the agent",
+    "reasoningEffortTier": {
+      "none": "__MISSING__:None",
+      "low": "__MISSING__:Low",
+      "medium": "__MISSING__:Medium",
+      "high": "__MISSING__:High",
+      "xhigh": "__MISSING__:XHigh"
+    }
   },
   "combos": {
     "title": "Combos",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -2320,7 +2320,17 @@
     "copilotToolCalling": "Chamada de ferramenta",
     "copilotPasteInto": "Cole em:",
     "wireApiChatCompletions": "Conclusões de bate-papo (/chat/completions)",
-    "wireApiResponses": "API de respostas (/respostas)"
+    "wireApiResponses": "API de respostas (/respostas)",
+    "reasoningEffort": "__MISSING__:Reasoning effort for {model}",
+    "reasoningEffortDefault": "__MISSING__:Default",
+    "reasoningEffortHint": "__MISSING__:Default preserves the reasoning effort sent by the agent",
+    "reasoningEffortTier": {
+      "none": "__MISSING__:None",
+      "low": "__MISSING__:Low",
+      "medium": "__MISSING__:Medium",
+      "high": "__MISSING__:High",
+      "xhigh": "__MISSING__:XHigh"
+    }
   },
   "combos": {
     "title": "Combos",

--- a/src/i18n/messages/ro.json
+++ b/src/i18n/messages/ro.json
@@ -2320,7 +2320,17 @@
     "copilotToolCalling": "Apelarea instrumentului",
     "copilotPasteInto": "Lipiți în:",
     "wireApiChatCompletions": "Finalizări de chat (/chat/completions)",
-    "wireApiResponses": "API-ul Responses (/responses)"
+    "wireApiResponses": "API-ul Responses (/responses)",
+    "reasoningEffort": "__MISSING__:Reasoning effort for {model}",
+    "reasoningEffortDefault": "__MISSING__:Default",
+    "reasoningEffortHint": "__MISSING__:Default preserves the reasoning effort sent by the agent",
+    "reasoningEffortTier": {
+      "none": "__MISSING__:None",
+      "low": "__MISSING__:Low",
+      "medium": "__MISSING__:Medium",
+      "high": "__MISSING__:High",
+      "xhigh": "__MISSING__:XHigh"
+    }
   },
   "combos": {
     "title": "Combo-uri",

--- a/src/i18n/messages/ru.json
+++ b/src/i18n/messages/ru.json
@@ -2320,7 +2320,17 @@
     "copilotToolCalling": "Вызов инструмента",
     "copilotPasteInto": "Вставить в:",
     "wireApiChatCompletions": "Завершения чата (/chat/completions)",
-    "wireApiResponses": "API ответов (/responses)"
+    "wireApiResponses": "API ответов (/responses)",
+    "reasoningEffort": "__MISSING__:Reasoning effort for {model}",
+    "reasoningEffortDefault": "__MISSING__:Default",
+    "reasoningEffortHint": "__MISSING__:Default preserves the reasoning effort sent by the agent",
+    "reasoningEffortTier": {
+      "none": "__MISSING__:None",
+      "low": "__MISSING__:Low",
+      "medium": "__MISSING__:Medium",
+      "high": "__MISSING__:High",
+      "xhigh": "__MISSING__:XHigh"
+    }
   },
   "combos": {
     "title": "Комбо",

--- a/src/i18n/messages/sk.json
+++ b/src/i18n/messages/sk.json
@@ -2320,7 +2320,17 @@
     "copilotToolCalling": "Vyvolanie nástroja",
     "copilotPasteInto": "Vložiť do:",
     "wireApiChatCompletions": "Dokončenia rozhovoru (/chat/completions)",
-    "wireApiResponses": "Responses API (/responses)"
+    "wireApiResponses": "Responses API (/responses)",
+    "reasoningEffort": "__MISSING__:Reasoning effort for {model}",
+    "reasoningEffortDefault": "__MISSING__:Default",
+    "reasoningEffortHint": "__MISSING__:Default preserves the reasoning effort sent by the agent",
+    "reasoningEffortTier": {
+      "none": "__MISSING__:None",
+      "low": "__MISSING__:Low",
+      "medium": "__MISSING__:Medium",
+      "high": "__MISSING__:High",
+      "xhigh": "__MISSING__:XHigh"
+    }
   },
   "combos": {
     "title": "kombá",

--- a/src/i18n/messages/sv.json
+++ b/src/i18n/messages/sv.json
@@ -2320,7 +2320,17 @@
     "copilotToolCalling": "Verktygsanrop",
     "copilotPasteInto": "Klistra in i:",
     "wireApiChatCompletions": "Chattavslut (/chat/kompletteringar)",
-    "wireApiResponses": "Responses API (/responses)"
+    "wireApiResponses": "Responses API (/responses)",
+    "reasoningEffort": "__MISSING__:Reasoning effort for {model}",
+    "reasoningEffortDefault": "__MISSING__:Default",
+    "reasoningEffortHint": "__MISSING__:Default preserves the reasoning effort sent by the agent",
+    "reasoningEffortTier": {
+      "none": "__MISSING__:None",
+      "low": "__MISSING__:Low",
+      "medium": "__MISSING__:Medium",
+      "high": "__MISSING__:High",
+      "xhigh": "__MISSING__:XHigh"
+    }
   },
   "combos": {
     "title": "Combos",

--- a/src/i18n/messages/sw.json
+++ b/src/i18n/messages/sw.json
@@ -2218,7 +2218,17 @@
     "copilotToolCalling": "Kupiga simu kwa zana",
     "copilotPasteInto": "Bandika kwenye:",
     "wireApiChatCompletions": "Kukamilika kwa Gumzo (/kuzungumza/kukamilika)",
-    "wireApiResponses": "API ya majibu (/majibu)"
+    "wireApiResponses": "API ya majibu (/majibu)",
+    "reasoningEffort": "__MISSING__:Reasoning effort for {model}",
+    "reasoningEffortDefault": "__MISSING__:Default",
+    "reasoningEffortHint": "__MISSING__:Default preserves the reasoning effort sent by the agent",
+    "reasoningEffortTier": {
+      "none": "__MISSING__:None",
+      "low": "__MISSING__:Low",
+      "medium": "__MISSING__:Medium",
+      "high": "__MISSING__:High",
+      "xhigh": "__MISSING__:XHigh"
+    }
   },
   "combos": {
     "title": "Combos",

--- a/src/i18n/messages/ta.json
+++ b/src/i18n/messages/ta.json
@@ -2218,7 +2218,17 @@
     "copilotToolCalling": "கருவி அழைப்பு",
     "copilotPasteInto": "இதில் ஒட்டவும்:",
     "wireApiChatCompletions": "அரட்டை நிறைவுகள் (/அரட்டை/நிறைவுகள்)",
-    "wireApiResponses": "பதில்கள் API (/பதில்கள்)"
+    "wireApiResponses": "பதில்கள் API (/பதில்கள்)",
+    "reasoningEffort": "__MISSING__:Reasoning effort for {model}",
+    "reasoningEffortDefault": "__MISSING__:Default",
+    "reasoningEffortHint": "__MISSING__:Default preserves the reasoning effort sent by the agent",
+    "reasoningEffortTier": {
+      "none": "__MISSING__:None",
+      "low": "__MISSING__:Low",
+      "medium": "__MISSING__:Medium",
+      "high": "__MISSING__:High",
+      "xhigh": "__MISSING__:XHigh"
+    }
   },
   "combos": {
     "title": "Combos",

--- a/src/i18n/messages/te.json
+++ b/src/i18n/messages/te.json
@@ -2218,7 +2218,17 @@
     "copilotToolCalling": "టూల్ కాలింగ్",
     "copilotPasteInto": "దీనిలో అతికించండి:",
     "wireApiChatCompletions": "చాట్ పూర్తిలు (/చాట్/పూర్తి)",
-    "wireApiResponses": "ప్రతిస్పందనల API (/స్పందనలు)"
+    "wireApiResponses": "ప్రతిస్పందనల API (/స్పందనలు)",
+    "reasoningEffort": "__MISSING__:Reasoning effort for {model}",
+    "reasoningEffortDefault": "__MISSING__:Default",
+    "reasoningEffortHint": "__MISSING__:Default preserves the reasoning effort sent by the agent",
+    "reasoningEffortTier": {
+      "none": "__MISSING__:None",
+      "low": "__MISSING__:Low",
+      "medium": "__MISSING__:Medium",
+      "high": "__MISSING__:High",
+      "xhigh": "__MISSING__:XHigh"
+    }
   },
   "combos": {
     "title": "Combos",

--- a/src/i18n/messages/th.json
+++ b/src/i18n/messages/th.json
@@ -2218,7 +2218,17 @@
     "copilotToolCalling": "การเรียกเครื่องมือ",
     "copilotPasteInto": "วางลงใน:",
     "wireApiChatCompletions": "เสร็จสิ้นการแชท (/แชท/เสร็จสิ้น)",
-    "wireApiResponses": "API การตอบกลับ (/การตอบกลับ)"
+    "wireApiResponses": "API การตอบกลับ (/การตอบกลับ)",
+    "reasoningEffort": "__MISSING__:Reasoning effort for {model}",
+    "reasoningEffortDefault": "__MISSING__:Default",
+    "reasoningEffortHint": "__MISSING__:Default preserves the reasoning effort sent by the agent",
+    "reasoningEffortTier": {
+      "none": "__MISSING__:None",
+      "low": "__MISSING__:Low",
+      "medium": "__MISSING__:Medium",
+      "high": "__MISSING__:High",
+      "xhigh": "__MISSING__:XHigh"
+    }
   },
   "combos": {
     "title": "คอมโบ",

--- a/src/i18n/messages/tr.json
+++ b/src/i18n/messages/tr.json
@@ -2218,7 +2218,17 @@
     "copilotToolCalling": "Takım Çağırma",
     "copilotPasteInto": "Şuraya yapıştırın:",
     "wireApiChatCompletions": "Sohbet Tamamlamaları (/sohbet/tamamlamalar)",
-    "wireApiResponses": "Yanıtlar API'si (/yanıtlar)"
+    "wireApiResponses": "Yanıtlar API'si (/yanıtlar)",
+    "reasoningEffort": "__MISSING__:Reasoning effort for {model}",
+    "reasoningEffortDefault": "__MISSING__:Default",
+    "reasoningEffortHint": "__MISSING__:Default preserves the reasoning effort sent by the agent",
+    "reasoningEffortTier": {
+      "none": "__MISSING__:None",
+      "low": "__MISSING__:Low",
+      "medium": "__MISSING__:Medium",
+      "high": "__MISSING__:High",
+      "xhigh": "__MISSING__:XHigh"
+    }
   },
   "combos": {
     "title": "Kombolar",

--- a/src/i18n/messages/uk-UA.json
+++ b/src/i18n/messages/uk-UA.json
@@ -2218,7 +2218,17 @@
     "copilotToolCalling": "Виклик інструменту",
     "copilotPasteInto": "Вставити в:",
     "wireApiChatCompletions": "Завершення чату (/chat/completions)",
-    "wireApiResponses": "Responses API (/responses)"
+    "wireApiResponses": "Responses API (/responses)",
+    "reasoningEffort": "__MISSING__:Reasoning effort for {model}",
+    "reasoningEffortDefault": "__MISSING__:Default",
+    "reasoningEffortHint": "__MISSING__:Default preserves the reasoning effort sent by the agent",
+    "reasoningEffortTier": {
+      "none": "__MISSING__:None",
+      "low": "__MISSING__:Low",
+      "medium": "__MISSING__:Medium",
+      "high": "__MISSING__:High",
+      "xhigh": "__MISSING__:XHigh"
+    }
   },
   "combos": {
     "title": "Комбо",

--- a/src/i18n/messages/ur.json
+++ b/src/i18n/messages/ur.json
@@ -2218,7 +2218,17 @@
     "copilotToolCalling": "ٹول کالنگ",
     "copilotPasteInto": "اس میں پیسٹ کریں:",
     "wireApiChatCompletions": "چیٹ کی تکمیل (/چیٹ/کمپلیشنز)",
-    "wireApiResponses": "Responses API (/responses)"
+    "wireApiResponses": "Responses API (/responses)",
+    "reasoningEffort": "__MISSING__:Reasoning effort for {model}",
+    "reasoningEffortDefault": "__MISSING__:Default",
+    "reasoningEffortHint": "__MISSING__:Default preserves the reasoning effort sent by the agent",
+    "reasoningEffortTier": {
+      "none": "__MISSING__:None",
+      "low": "__MISSING__:Low",
+      "medium": "__MISSING__:Medium",
+      "high": "__MISSING__:High",
+      "xhigh": "__MISSING__:XHigh"
+    }
   },
   "combos": {
     "title": "Combos",

--- a/src/i18n/messages/vi.json
+++ b/src/i18n/messages/vi.json
@@ -2218,7 +2218,17 @@
     "copilotToolCalling": "Gọi công cụ",
     "copilotPasteInto": "Dán vào:",
     "wireApiChatCompletions": "Số lần hoàn thành trò chuyện (/chat/hoàn thành)",
-    "wireApiResponses": "API phản hồi (/ phản hồi)"
+    "wireApiResponses": "API phản hồi (/ phản hồi)",
+    "reasoningEffort": "__MISSING__:Reasoning effort for {model}",
+    "reasoningEffortDefault": "__MISSING__:Default",
+    "reasoningEffortHint": "__MISSING__:Default preserves the reasoning effort sent by the agent",
+    "reasoningEffortTier": {
+      "none": "__MISSING__:None",
+      "low": "__MISSING__:Low",
+      "medium": "__MISSING__:Medium",
+      "high": "__MISSING__:High",
+      "xhigh": "__MISSING__:XHigh"
+    }
   },
   "combos": {
     "title": "Combo",

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -2303,7 +2303,17 @@
     "copilotToolCalling": "工具调用",
     "copilotPasteInto": "粘贴到：",
     "wireApiChatCompletions": "聊天完成 (/chat/completions)",
-    "wireApiResponses": "响应 API (/responses)"
+    "wireApiResponses": "响应 API (/responses)",
+    "reasoningEffort": "__MISSING__:Reasoning effort for {model}",
+    "reasoningEffortDefault": "__MISSING__:Default",
+    "reasoningEffortHint": "__MISSING__:Default preserves the reasoning effort sent by the agent",
+    "reasoningEffortTier": {
+      "none": "__MISSING__:None",
+      "low": "__MISSING__:Low",
+      "medium": "__MISSING__:Medium",
+      "high": "__MISSING__:High",
+      "xhigh": "__MISSING__:XHigh"
+    }
   },
   "combos": {
     "title": "组合",

--- a/src/i18n/messages/zh-TW.json
+++ b/src/i18n/messages/zh-TW.json
@@ -2326,7 +2326,17 @@
     "copilotToolCalling": "工具呼叫",
     "copilotPasteInto": "貼上到：",
     "wireApiChatCompletions": "聊天完成 (/chat/completions)",
-    "wireApiResponses": "響應 API (/responses)"
+    "wireApiResponses": "響應 API (/responses)",
+    "reasoningEffort": "__MISSING__:Reasoning effort for {model}",
+    "reasoningEffortDefault": "__MISSING__:Default",
+    "reasoningEffortHint": "__MISSING__:Default preserves the reasoning effort sent by the agent",
+    "reasoningEffortTier": {
+      "none": "__MISSING__:None",
+      "low": "__MISSING__:Low",
+      "medium": "__MISSING__:Medium",
+      "high": "__MISSING__:High",
+      "xhigh": "__MISSING__:XHigh"
+    }
   },
   "combos": {
     "title": "組合",

--- a/src/mitm/_internal/aliasConfig.cjs
+++ b/src/mitm/_internal/aliasConfig.cjs
@@ -1,0 +1,81 @@
+"use strict";
+
+// =========================================================================
+// CJS mirror of `src/mitm/aliasConfig.ts` for the standalone proxy process
+// (server.cjs, spawned by manager.ts — runs as plain CommonJS, cannot import
+// the ESM/TS source tree). Keep the two in sync when the alias-entry shape
+// or the reasoning-effort vocabulary changes.
+//
+// The canonical effort vocabulary mirrors `@/shared/reasoning/effortStandardization.ts`
+// (`CANONICAL_EFFORT_VALUES` + the `extra`/`max` → `xhigh` alias). Ported from upstream
+// decolua/9router#2584 ("add Antigravity reasoning effort overrides").
+// =========================================================================
+
+const CANONICAL_EFFORT_VALUES = ["none", "low", "medium", "high", "xhigh"];
+const EFFORT_TIER_ALIASES = { extra: "xhigh", max: "xhigh" };
+
+function normalizeReasoningEffort(value) {
+  if (typeof value !== "string") return undefined;
+  const lowered = value.trim().toLowerCase();
+  if (!lowered) return undefined;
+  if (Object.prototype.hasOwnProperty.call(EFFORT_TIER_ALIASES, lowered)) {
+    return EFFORT_TIER_ALIASES[lowered];
+  }
+  return CANONICAL_EFFORT_VALUES.includes(lowered) ? lowered : undefined;
+}
+
+function isPlainObject(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeAliasEntry(value) {
+  if (typeof value === "string") {
+    const model = value.trim();
+    return model ? { model } : null;
+  }
+  if (!isPlainObject(value)) return null;
+
+  const model = typeof value.model === "string" ? value.model.trim() : "";
+  const reasoningEffort = normalizeReasoningEffort(value.reasoningEffort);
+  if (!model && !reasoningEffort) return null;
+
+  return {
+    ...(model ? { model } : {}),
+    ...(reasoningEffort ? { reasoningEffort } : {}),
+  };
+}
+
+function normalizeAliasMappings(mappings) {
+  if (!isPlainObject(mappings)) return {};
+  const normalized = {};
+  for (const [alias, value] of Object.entries(mappings)) {
+    if (!alias) continue;
+    const entry = normalizeAliasEntry(value);
+    if (entry) normalized[alias] = entry;
+  }
+  return normalized;
+}
+
+/**
+ * Apply a normalized alias entry onto the raw (still Gemini/cloudcode-shaped) request body
+ * the standalone proxy forwards. Mutates nothing on the input — returns a shallow-cloned
+ * body with `model` swapped (when the override carries one) and `reasoningEffortOverride`
+ * set at the SAME envelope level as `model` (top-level; the antigravity→openai translator
+ * reads it there — see `open-sse/translator/request/antigravity-to-openai.ts`).
+ */
+function applyAntigravityOverride(body, override) {
+  const result = { ...body };
+  if (override && override.model) result.model = override.model;
+  if (override && override.reasoningEffort) {
+    result.reasoningEffortOverride = override.reasoningEffort;
+  }
+  return result;
+}
+
+module.exports = {
+  CANONICAL_EFFORT_VALUES,
+  normalizeReasoningEffort,
+  normalizeAliasEntry,
+  normalizeAliasMappings,
+  applyAntigravityOverride,
+};

--- a/src/mitm/aliasConfig.ts
+++ b/src/mitm/aliasConfig.ts
@@ -1,0 +1,83 @@
+/**
+ * MITM alias-mapping normalization — Antigravity model + reasoning-effort overrides.
+ *
+ * Ported from upstream decolua/9router#2584 ("add Antigravity reasoning effort
+ * overrides"), adapted to OmniRoute's alias storage shape (`src/lib/db/models/mitmAlias.ts`,
+ * `Record<alias, string | MitmAliasEntry>`) and its existing canonical reasoning-effort
+ * vocabulary (`@/shared/reasoning/effortStandardization.ts`) instead of inventing a new one.
+ *
+ * A saved alias entry is either:
+ *   - a legacy plain string  — `"provider/model-id"` (model mapping only, no reasoning
+ *     override; this is the shape every existing install already has on disk), or
+ *   - a structured object    — `{ model?: string, reasoningEffort?: CanonicalEffort }`,
+ *     allowing a reasoning-effort override to be configured independently of (or without)
+ *     a model remap.
+ *
+ * `normalizeAliasMappings` upgrades legacy strings to the structured shape on read, so no
+ * DB migration is required (mirrors upstream's stated backward-compatibility contract).
+ */
+import { normalizeEffort, type CanonicalEffort } from "@/shared/reasoning/effortStandardization";
+
+export interface MitmAliasEntry {
+  model?: string;
+  reasoningEffort?: CanonicalEffort;
+}
+
+export type MitmAliasMappings = Record<string, MitmAliasEntry>;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Normalize a single stored alias value (legacy string or structured entry) into the
+ * canonical `MitmAliasEntry` shape. Returns `null` when the value carries neither a model
+ * nor a valid reasoning-effort override (i.e. it should be dropped from the mapping).
+ */
+export function normalizeAliasEntry(value: unknown): MitmAliasEntry | null {
+  if (typeof value === "string") {
+    const model = value.trim();
+    return model ? { model } : null;
+  }
+  if (!isPlainObject(value)) return null;
+
+  const model = typeof value.model === "string" ? value.model.trim() : "";
+  const reasoningEffort = normalizeEffort(value.reasoningEffort);
+  if (!model && !reasoningEffort) return null;
+
+  return {
+    ...(model ? { model } : {}),
+    ...(reasoningEffort ? { reasoningEffort } : {}),
+  };
+}
+
+/**
+ * Normalize a whole alias→mapping record (as stored under `mitmAlias.antigravity` /
+ * returned by `getMitmAlias()`), upgrading legacy string mappings and dropping empty
+ * entries. Always returns a well-formed object, even for malformed input.
+ */
+export function normalizeAliasMappings(mappings: unknown): MitmAliasMappings {
+  if (!isPlainObject(mappings)) return {};
+  const normalized: MitmAliasMappings = {};
+  for (const [alias, value] of Object.entries(mappings)) {
+    if (!alias) continue;
+    const entry = normalizeAliasEntry(value);
+    if (entry) normalized[alias] = entry;
+  }
+  return normalized;
+}
+
+/**
+ * True when any entry in the (not-yet-normalized) request payload carries a
+ * `reasoningEffort` value that fails to normalize onto the canonical vocabulary — used to
+ * reject the PUT at the API boundary with a 400 instead of silently dropping the override.
+ */
+export function hasInvalidReasoningEffort(mappings: unknown): boolean {
+  if (!isPlainObject(mappings)) return false;
+  return Object.values(mappings).some((value) => {
+    if (!isPlainObject(value)) return false;
+    const raw = value.reasoningEffort;
+    if (raw == null || raw === "") return false;
+    return normalizeEffort(raw) === undefined;
+  });
+}

--- a/src/mitm/server.cjs
+++ b/src/mitm/server.cjs
@@ -136,6 +136,7 @@ function sanitizeErrorMessage(message) {
 const bypassShim = require("./_internal/bypass.cjs");
 const ingestShim = require("./_internal/ingest.cjs");
 const forwardShim = require("./_internal/forwardTarget.cjs");
+const aliasConfigShim = require("./_internal/aliasConfig.cjs");
 
 // Inspector capture (D4 fallback). The standalone proxy intercepts AgentBridge
 // traffic inline (no MitmHandlerBase / agentBridgeHook), so it posts captured
@@ -337,7 +338,13 @@ function getSqliteDb() {
   return null;
 }
 
-function getMappedModel(model) {
+/**
+ * Resolve the stored alias override for a source model: `{ model?, reasoningEffort? }`.
+ * `normalizeAliasMappings` upgrades legacy plain-string mappings (every existing install)
+ * into the structured shape, so both old and new saves resolve consistently. Returns
+ * `null` when there is no override at all for this model (passthrough).
+ */
+function getMappedOverride(model) {
   if (!model) return null;
 
   // Primary: read from SQLite key_value table
@@ -350,7 +357,7 @@ function getMappedModel(model) {
         )
         .get();
       if (row) {
-        const mappings = JSON.parse(row.value);
+        const mappings = aliasConfigShim.normalizeAliasMappings(JSON.parse(row.value));
         return mappings[model] || null;
       }
     }
@@ -362,7 +369,8 @@ function getMappedModel(model) {
   try {
     if (fs.existsSync(DB_FILE)) {
       const db = JSON.parse(fs.readFileSync(DB_FILE, "utf-8"));
-      return db.mitmAlias?.antigravity?.[model] || null;
+      const mappings = aliasConfigShim.normalizeAliasMappings(db.mitmAlias?.antigravity);
+      return mappings[model] || null;
     }
   } catch {
     // Ignore
@@ -451,7 +459,7 @@ function captureToInspector(o) {
   }
 }
 
-async function intercept(req, res, bodyBuffer, mappedModel, sourceModel) {
+async function intercept(req, res, bodyBuffer, override, sourceModel) {
   // C2 — Inject AgentBridge correlation headers per master plan §3.5.
   // The OmniRoute router uses these to distinguish AgentBridge traffic from
   // other inbound clients and to record the originating IDE agent id.
@@ -468,8 +476,15 @@ async function intercept(req, res, bodyBuffer, mappedModel, sourceModel) {
   let captureError;
 
   try {
-    const body = JSON.parse(bodyBuffer.toString());
-    body.model = mappedModel;
+    // `override` is a normalized `{ model?, reasoningEffort? }` alias entry (never null —
+    // the caller already gated on that). `applyAntigravityOverride` swaps `model` when
+    // present and, for a reasoning-effort override, sets `reasoningEffortOverride` at the
+    // same top-level envelope depth so the antigravity→openai translator can read it
+    // ahead of its thinkingConfig-derived guess (ported from upstream #2584).
+    const body = aliasConfigShim.applyAntigravityOverride(
+      JSON.parse(bodyBuffer.toString()),
+      override
+    );
 
     // Gap B — the Antigravity IDE speaks cloudcode (the Gemini payload wrapped
     // under `request`) and expects a cloudcode reply. Forward such envelopes to
@@ -545,7 +560,7 @@ async function intercept(req, res, bodyBuffer, mappedModel, sourceModel) {
       bodyBuffer,
       agentId,
       sourceModel,
-      mappedModel,
+      mappedModel: (override && override.model) || sourceModel,
       status: captureStatus,
       respHeaders,
       respBody,
@@ -587,9 +602,9 @@ const server = https.createServer(sslOptions, async (req, res) => {
     return passthrough(req, res, bodyBuffer);
   }
 
-  const mappedModel = getMappedModel(model);
+  const mappedOverride = getMappedOverride(model);
 
-  if (!mappedModel) {
+  if (!mappedOverride) {
     vlog(1, `[MITM] → PASSTHROUGH (model "${model}" has no MITM alias mapping)`);
     return passthrough(req, res, bodyBuffer);
   }
@@ -598,8 +613,12 @@ const server = https.createServer(sslOptions, async (req, res) => {
   stats.lastInterceptAt = new Date().toISOString();
   writeStats();
 
-  vlog(1, `[MITM] INTERCEPTED ${model} → ${mappedModel}`);
-  return intercept(req, res, bodyBuffer, mappedModel, model);
+  vlog(
+    1,
+    `[MITM] INTERCEPTED ${model} → ${mappedOverride.model || model}` +
+      (mappedOverride.reasoningEffort ? ` (reasoningEffort=${mappedOverride.reasoningEffort})` : "")
+  );
+  return intercept(req, res, bodyBuffer, mappedOverride, model);
 });
 
 // =========================================================================

--- a/src/shared/validation/schemas/cli.ts
+++ b/src/shared/validation/schemas/cli.ts
@@ -24,9 +24,20 @@ export const cliMitmStopSchema = z.object({
   sudoPassword: z.string().optional(),
 });
 
+// A mapping value is either the legacy plain model string, or a structured entry that
+// lets a reasoning-effort override be configured independently of (or without) a model
+// remap. `mitmAliasEntrySchema` is intentionally permissive on `reasoningEffort` (any
+// string) — the canonical-vocabulary check runs at the route boundary via
+// `hasInvalidReasoningEffort` (`@/mitm/aliasConfig`), matching upstream decolua/9router#2584
+// ("validate reasoning values at the API boundary").
+const mitmAliasEntrySchema = z.object({
+  model: z.string().optional(),
+  reasoningEffort: z.string().optional(),
+});
+
 export const cliMitmAliasUpdateSchema = z.object({
   tool: z.string().trim().min(1, "tool and mappings required"),
-  mappings: z.record(z.string(), z.string().optional()),
+  mappings: z.record(z.string(), z.union([z.string(), mitmAliasEntrySchema]).optional()),
 });
 
 export const cliBackupMutationSchema = z

--- a/tests/unit/mitm-alias-config-shim.test.ts
+++ b/tests/unit/mitm-alias-config-shim.test.ts
@@ -1,0 +1,66 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+
+// CJS mirror consumed by the standalone proxy process (server.cjs — cannot import the
+// ESM/TS `src/mitm/aliasConfig.ts`). Ported from upstream decolua/9router#2584 ("add
+// Antigravity reasoning effort overrides"). Keep assertions aligned with
+// `tests/unit/mitm-antigravity-reasoning-effort-override.test.ts` (the TS counterpart).
+const require = createRequire(import.meta.url);
+const {
+  normalizeReasoningEffort,
+  normalizeAliasEntry,
+  normalizeAliasMappings,
+  applyAntigravityOverride,
+} = require("../../src/mitm/_internal/aliasConfig.cjs");
+
+test("normalizeReasoningEffort canonicalizes case and the max/extra UI synonyms", () => {
+  assert.equal(normalizeReasoningEffort(" HIGH "), "high");
+  assert.equal(normalizeReasoningEffort("max"), "xhigh");
+  assert.equal(normalizeReasoningEffort("extra"), "xhigh");
+  assert.equal(normalizeReasoningEffort("extreme"), undefined);
+  assert.equal(normalizeReasoningEffort(42), undefined);
+});
+
+test("normalizeAliasEntry upgrades a legacy string mapping", () => {
+  assert.deepEqual(normalizeAliasEntry("provider/model-id"), { model: "provider/model-id" });
+  assert.equal(normalizeAliasEntry(""), null);
+});
+
+test("normalizeAliasMappings resolves the stored SQLite row shape used by getMappedOverride", () => {
+  const stored = {
+    "gemini-3-flash-agent": "cx/gpt-5.6-sol",
+    "gemini-3-pro-agent": { model: "cx/gpt-5.6-sol", reasoningEffort: "high" },
+    "gemini-3-flash-thinking-agent": { reasoningEffort: "none" },
+  };
+  const normalized = normalizeAliasMappings(stored);
+  assert.deepEqual(normalized["gemini-3-flash-agent"], { model: "cx/gpt-5.6-sol" });
+  assert.deepEqual(normalized["gemini-3-pro-agent"], {
+    model: "cx/gpt-5.6-sol",
+    reasoningEffort: "high",
+  });
+  assert.deepEqual(normalized["gemini-3-flash-thinking-agent"], { reasoningEffort: "none" });
+});
+
+test("applyAntigravityOverride swaps model and sets the top-level reasoningEffortOverride", () => {
+  const body = { model: "gemini-3-flash-agent", request: { contents: [] } };
+  const result = applyAntigravityOverride(body, { model: "cx/gpt-5.6-sol", reasoningEffort: "high" });
+  assert.equal(result.model, "cx/gpt-5.6-sol");
+  assert.equal(result.reasoningEffortOverride, "high");
+  // Original body is untouched (server.cjs still needs it for logging/capture).
+  assert.equal(body.model, "gemini-3-flash-agent");
+  assert.equal("reasoningEffortOverride" in body, false);
+});
+
+test("applyAntigravityOverride applies a reasoning-only override without touching model", () => {
+  const body = { model: "gemini-3-flash-agent", request: { contents: [] } };
+  const result = applyAntigravityOverride(body, { reasoningEffort: "none" });
+  assert.equal(result.model, "gemini-3-flash-agent");
+  assert.equal(result.reasoningEffortOverride, "none");
+});
+
+test("applyAntigravityOverride is a no-op pass-through when override carries neither field", () => {
+  const body = { model: "gemini-3-flash-agent" };
+  const result = applyAntigravityOverride(body, {});
+  assert.deepEqual(result, body);
+});

--- a/tests/unit/mitm-antigravity-reasoning-effort-override.test.ts
+++ b/tests/unit/mitm-antigravity-reasoning-effort-override.test.ts
@@ -1,0 +1,164 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// Ported from upstream decolua/9router#2584 ("add Antigravity reasoning effort
+// overrides"), adapted to OmniRoute's alias storage shape and canonical reasoning-effort
+// vocabulary (`@/shared/reasoning/effortStandardization.ts`).
+const { normalizeAliasEntry, normalizeAliasMappings, hasInvalidReasoningEffort } = await import(
+  "../../src/mitm/aliasConfig.ts"
+);
+const { antigravityToOpenAIRequest } = await import(
+  "../../open-sse/translator/request/antigravity-to-openai.ts"
+);
+
+test("normalizeAliasEntry upgrades a legacy plain-string mapping to { model }", () => {
+  assert.deepEqual(normalizeAliasEntry(" cx/gpt-5.6-sol "), { model: "cx/gpt-5.6-sol" });
+});
+
+test("normalizeAliasEntry drops an empty legacy string", () => {
+  assert.equal(normalizeAliasEntry("   "), null);
+});
+
+test("normalizeAliasEntry keeps a reasoning-only override and canonicalizes its casing", () => {
+  assert.deepEqual(normalizeAliasEntry({ reasoningEffort: " HIGH " }), {
+    reasoningEffort: "high",
+  });
+});
+
+test("normalizeAliasEntry maps the max/extra UI synonyms onto canonical xhigh", () => {
+  assert.deepEqual(normalizeAliasEntry({ model: "p/m", reasoningEffort: "max" }), {
+    model: "p/m",
+    reasoningEffort: "xhigh",
+  });
+});
+
+test("normalizeAliasEntry drops an unrecognized reasoning effort while keeping the model", () => {
+  assert.deepEqual(normalizeAliasEntry({ model: "p/m", reasoningEffort: "extreme" }), {
+    model: "p/m",
+  });
+});
+
+test("normalizeAliasEntry returns null for an entry with neither model nor reasoning effort", () => {
+  assert.equal(normalizeAliasEntry({ reasoningEffort: "" }), null);
+  assert.equal(normalizeAliasEntry({}), null);
+  assert.equal(normalizeAliasEntry(null), null);
+  assert.equal(normalizeAliasEntry(42), null);
+});
+
+test("normalizeAliasMappings upgrades a whole legacy record without a migration", () => {
+  assert.deepEqual(
+    normalizeAliasMappings({
+      "gemini-3-flash-agent": "provider/model-id",
+      "gemini-3-pro-agent": { reasoningEffort: "low" },
+      empty: "",
+    }),
+    {
+      "gemini-3-flash-agent": { model: "provider/model-id" },
+      "gemini-3-pro-agent": { reasoningEffort: "low" },
+    }
+  );
+});
+
+test("normalizeAliasMappings tolerates malformed input", () => {
+  assert.deepEqual(normalizeAliasMappings(null), {});
+  assert.deepEqual(normalizeAliasMappings([1, 2, 3]), {});
+});
+
+test("hasInvalidReasoningEffort flags an unrecognized tier and accepts canonical ones", () => {
+  assert.equal(
+    hasInvalidReasoningEffort({ flash: { model: "p/m", reasoningEffort: "extreme" } }),
+    true
+  );
+  assert.equal(
+    hasInvalidReasoningEffort({ flash: { model: "p/m", reasoningEffort: "xhigh" } }),
+    false
+  );
+  assert.equal(hasInvalidReasoningEffort({ flash: "provider/model-id" }), false);
+  assert.equal(hasInvalidReasoningEffort({ flash: { model: "p/m" } }), false);
+});
+
+// -- Override-resolution: model + requested effort -> effective reasoning_effort ---------
+
+test("antigravity->openai: an explicit reasoningEffortOverride wins over the request's own thinkingConfig", () => {
+  const result = antigravityToOpenAIRequest(
+    "cx/gpt-5.6-sol",
+    {
+      model: "gemini-3-flash-agent",
+      reasoningEffortOverride: "high",
+      request: {
+        contents: [{ role: "user", parts: [{ text: "hi" }] }],
+        generationConfig: { thinkingConfig: { thinkingBudget: 512 } },
+      },
+    },
+    false
+  );
+
+  // thinkingBudget 512 alone would derive "low" (see the budget-tier test below) — the
+  // override must take priority end-to-end.
+  assert.equal(result.reasoning_effort, "high");
+});
+
+test("antigravity->openai: an explicit 'none' override suppresses reasoning_effort even under a thinking request", () => {
+  const result = antigravityToOpenAIRequest(
+    "cx/gpt-5.6-sol",
+    {
+      reasoningEffortOverride: "none",
+      request: {
+        contents: [{ role: "user", parts: [{ text: "hi" }] }],
+        generationConfig: { thinkingConfig: { thinkingBudget: 32000 } },
+      },
+    },
+    false
+  );
+
+  assert.equal("reasoning_effort" in result, false);
+});
+
+test("antigravity->openai: reasoning-only override applies without a model override present", () => {
+  const result = antigravityToOpenAIRequest(
+    "gemini-3-flash-agent",
+    {
+      reasoningEffortOverride: "medium",
+      request: { contents: [{ role: "user", parts: [{ text: "hi" }] }] },
+    },
+    false
+  );
+
+  assert.equal(result.model, "gemini-3-flash-agent");
+  assert.equal(result.reasoning_effort, "medium");
+});
+
+test("antigravity->openai: no override falls back to the pre-existing thinkingConfig-derived tiers", () => {
+  const low = antigravityToOpenAIRequest(
+    "gpt-4o",
+    { request: { generationConfig: { thinkingConfig: { thinkingBudget: 512 } } } },
+    false
+  );
+  const medium = antigravityToOpenAIRequest(
+    "gpt-4o",
+    { request: { generationConfig: { thinkingConfig: { thinkingBudget: 3000 } } } },
+    false
+  );
+  const high = antigravityToOpenAIRequest(
+    "gpt-4o",
+    { request: { generationConfig: { thinkingConfig: { thinkingBudget: 32000 } } } },
+    false
+  );
+
+  assert.equal(low.reasoning_effort, "low");
+  assert.equal(medium.reasoning_effort, "medium");
+  assert.equal(high.reasoning_effort, "high");
+});
+
+test("antigravity->openai: an unrecognized override value is ignored (falls back to derived behavior)", () => {
+  const result = antigravityToOpenAIRequest(
+    "gpt-4o",
+    {
+      reasoningEffortOverride: "extreme",
+      request: { generationConfig: { thinkingConfig: { thinkingBudget: 512 } } },
+    },
+    false
+  );
+
+  assert.equal(result.reasoning_effort, "low");
+});


### PR DESCRIPTION
## Summary
- Antigravity MITM alias entries now support an optional reasoning-effort override alongside the existing destination-model mapping (`{ model?, reasoningEffort? }`); legacy plain-string mappings still normalize to `{ model }` with no DB migration required.
- The standalone Antigravity proxy forwards the chosen tier as a top-level `reasoningEffortOverride`; the antigravity→openai translator honors it ahead of its `thinkingConfig`-derived guess, and an explicit "none" suppresses `reasoning_effort` even when Antigravity's own request asked for thinking.
- The Antigravity tool card now exposes a per-model reasoning-effort selector (Default/None/Low/Medium/High/XHigh) next to the model-mapping input, reusing OmniRoute's existing canonical 5-tier reasoning vocabulary instead of introducing a new one.

## Attribution
Thanks to [@trfi](https://github.com/trfi) for the original implementation.

## Changes
- `src/mitm/aliasConfig.ts` (new) + `src/mitm/_internal/aliasConfig.cjs` (new, CJS mirror for the standalone proxy process): normalize/validate alias entries and reasoning-effort values.
- `src/mitm/server.cjs`: `getMappedModel` → `getMappedOverride`; `intercept()` applies the override (model swap + `reasoningEffortOverride`) via the new shim.
- `open-sse/translator/request/antigravity-to-openai.ts`: honor an explicit `reasoningEffortOverride` ahead of the thinkingConfig-derived tier.
- `src/app/api/cli-tools/antigravity-mitm/alias/route.ts` + `src/shared/validation/schemas/cli.ts`: accept the structured mapping shape, validate reasoning-effort values at the API boundary.
- `src/app/(dashboard)/dashboard/cli-code/components/AntigravityToolCard.tsx`: per-model reasoning-effort selector.
- i18n: new `cliTools.reasoningEffort*` keys in `en.json` + placeholder entries in all other locales.

## Test plan
- [x] TDD: `tests/unit/mitm-antigravity-reasoning-effort-override.test.ts` (14 cases) and `tests/unit/mitm-alias-config-shim.test.ts` (6 cases) — confirmed failing against the pre-change translator (override ignored: `low !== high`, `none` did not suppress `reasoning_effort`, reasoning-only override was a no-op) and passing after the fix.
- [x] `npm run typecheck:core` — clean.
- [x] `npx eslint` on all changed files — clean (the one pre-existing `AntigravityToolCard.tsx` `react-hooks/exhaustive-deps` warning was confirmed present on the unmodified base file, not introduced by this change).
- [x] Existing `tests/unit/translator-antigravity-to-openai.test.ts` (9 cases) and `tests/unit/antigravity-orphan-toolresult-6026.test.ts` (3 cases) still pass — no regression.