### PR TITLE
feat: editable ComfyUI base-URL field + per-connection override for image/video/music generation (#6928)

### DIFF
--- a/changelog.d/features/6928-comfyui-base-url-field.md
+++ b/changelog.d/features/6928-comfyui-base-url-field.md
@@ -1,0 +1,1 @@
+- **feat(providers):** expose an editable base-URL field on the ComfyUI connection so Docker-network setups (e.g. `http://comfyui:8188`) work for image, video, and music generation ([#6928](https://github.com/diegosouzapw/OmniRoute/issues/6928))

--- a/config/quality/file-size-baseline.json
+++ b/config/quality/file-size-baseline.json
@@ -1,4 +1,5 @@
 {
+  "_rebaseline_2026_07_14_6928_comfyui_baseurl_override": "Issue #6928 own growth: open-sse/handlers/videoGeneration.ts 1265->1275 (+10 = resolveComfyUiBaseUrl import + expanding the comfyui dispatch call into a multi-line object literal so the per-connection providerSpecificData.baseUrl override — same storage convention self-hosted chat providers use — is threaded through to handleComfyUIVideoGeneration; Prettier's 100-char width forces the multi-line form), src/app/(dashboard)/dashboard/providers/[id]/providerPageHelpers.ts 1053->1054 (+1 = comfyui added to CONFIGURABLE_BASE_URL_PROVIDERS/DEFAULT_PROVIDER_BASE_URLS/getProviderBaseUrlPlaceholder so the Add/Edit connection modals render an editable base-URL field for ComfyUI, mirroring self-hosted chat providers). The identical dispatch pattern was also applied to imageGeneration.ts and musicGeneration.ts, both well under their frozen caps. Covered by tests/unit/comfyui-baseurl-override-6928.test.ts (resolver unit tests + handler-level fetch-mock overrides for image/video/music) and the new provider-page-helpers-3501.test.ts assertion.",
   "_rebaseline_2026_07_07_v3846_proxy_insecure_random": "PR #6580 (v3.8.46 post-release closing fix): proxies.ts 1173->1177 (+4) — o fix de segurança CodeQL #698/#699 troca Math.random por crypto.randomInt no random rotation strategy (#6365) e adiciona 4 linhas de comentário explicando por que (a seleção flui para credenciais do proxy). Crescimento irreducivel do proprio fix; frozen so encolhe daqui.",
   "_rebaseline_2026_07_07_v3846_release_close": "Release v3.8.46 Phase 0 (generate-release) — drift de ciclo absorvido no fechamento (fast-gates PR->release nao rodam check:file-size). PROD god-files crescidos por merges do ciclo (nao meus; DECOMPOR idealmente, debt #3501): proxies.ts 1060->1173, chat.ts 1681->1751, ApiManagerPageClient.tsx 3058->3120, ProxyRegistryManager.tsx 1125->1437 (feature de proxy). TEST frozen: models-catalog-route.test.ts 1600->1605 (+5 do fix#2 do captain, #6408 catalogo cache), vscode-token-routes.test.ts 1212->1285 (cycle drift + os asserts effort_tiers/supportsThinking do #6241 alinhados no release-PR-CI base-red), que adiciona o import + 2 chamadas do hook __resetCatalogBuilderRunsForTest existente no setup (harness, sem asserts). Shrink estrutural rastreado no roadmap #3501.",
   "_rebaseline_2026_07_04_v3844_release_close": "Release v3.8.44 Phase 0 (generate-release): drift de ciclo absorvido no fechamento, medido no tip 415d159c8 (fast-gates PR->release nao rodam check:file-size). oauth/[provider]/[action]/route.ts 924->960 (#6054 zed keychain-import 400 gracioso; PR #6158 aberto extrai o guard e restaura o freeze — quando mergear, o frozen so encolhe), providerLimits.ts 982->998 (#6139 TOCTOU quota recovery + #6128), chat.ts 1647->1662 (#6057 per-request Auto-Combo X-OmniRoute-Mode/Budget + #6097), auth.ts 2405->2426 (#6139 + #6090 quota preflight lockouts + #5943 codex session affinity). Crescimento irreducivel em chokepoints existentes, coberto por testes por-PR; shrink estrutural rastreado no roadmap #3501.",
@@ -162,7 +163,7 @@
     "open-sse/handlers/responseSanitizer.ts": 1139,
     "open-sse/handlers/search.ts": 1546,
     "open-sse/handlers/sseParser.ts": 830,
-    "open-sse/handlers/videoGeneration.ts": 1265,
+    "open-sse/handlers/videoGeneration.ts": 1275,
     "open-sse/mcp-server/schemas/tools.ts": 1497,
     "open-sse/mcp-server/server.ts": 1555,
     "open-sse/mcp-server/tools/advancedTools.ts": 1120,
@@ -213,7 +214,7 @@
     "src/app/(dashboard)/dashboard/providers/[id]/hooks/useProviderConnections.ts": 954,
     "src/app/(dashboard)/dashboard/providers/[id]/hooks/useProviderModels.ts": 155,
     "src/app/(dashboard)/dashboard/providers/[id]/hooks/useProviderSettings.ts": 264,
-    "src/app/(dashboard)/dashboard/providers/[id]/providerPageHelpers.ts": 1053,
+    "src/app/(dashboard)/dashboard/providers/[id]/providerPageHelpers.ts": 1054,
     "src/app/(dashboard)/dashboard/providers/components/onboarding/ProviderOnboardingWizard.tsx": 912,
     "src/app/(dashboard)/dashboard/providers/page.tsx": 1927,
     "src/app/(dashboard)/dashboard/runtime/RuntimePageClient.tsx": 1201,

--- a/open-sse/handlers/imageGeneration.ts
+++ b/open-sse/handlers/imageGeneration.ts
@@ -39,6 +39,7 @@ import {
   pollComfyResult,
   fetchComfyOutput,
   extractComfyOutputFiles,
+  resolveComfyUiBaseUrl,
 } from "../utils/comfyuiClient.ts";
 import { fetchRemoteImage } from "@/shared/network/remoteImageFetch";
 import { FetchTimeoutError, fetchWithTimeout, getConfiguredTimeout } from "@/shared/utils/fetchTimeout";
@@ -486,7 +487,16 @@ export async function handleImageGeneration({
   }
 
   if (providerConfig.format === "comfyui") {
-    return handleComfyUIImageGeneration({ model, provider, providerConfig, body, log });
+    return handleComfyUIImageGeneration({
+      model,
+      provider,
+      providerConfig: {
+        ...providerConfig,
+        baseUrl: resolveComfyUiBaseUrl(credentials, providerConfig.baseUrl),
+      },
+      body,
+      log,
+    });
   }
 
   if (providerConfig.format === "codex-responses") {

--- a/open-sse/handlers/musicGeneration.ts
+++ b/open-sse/handlers/musicGeneration.ts
@@ -22,6 +22,7 @@ import {
   pollComfyResult,
   fetchComfyOutput,
   extractComfyOutputFiles,
+  resolveComfyUiBaseUrl,
 } from "../utils/comfyuiClient.ts";
 import { saveCallLog } from "@/lib/usageDb";
 import { getKieCallbackUrl, isJsonObject, parseKieResultJson } from "../utils/kieTask.ts";
@@ -119,7 +120,16 @@ export async function handleMusicGeneration({ body, credentials, log }) {
   }
 
   if (providerConfig.format === "comfyui") {
-    return handleComfyUIMusicGeneration({ model, provider, providerConfig, body, log });
+    return handleComfyUIMusicGeneration({
+      model,
+      provider,
+      providerConfig: {
+        ...providerConfig,
+        baseUrl: resolveComfyUiBaseUrl(credentials, providerConfig.baseUrl),
+      },
+      body,
+      log,
+    });
   }
 
   if (providerConfig.format === "kie-music") {

--- a/open-sse/handlers/videoGeneration.ts
+++ b/open-sse/handlers/videoGeneration.ts
@@ -31,6 +31,7 @@ import {
   pollComfyResult,
   fetchComfyOutput,
   extractComfyOutputFiles,
+  resolveComfyUiBaseUrl,
 } from "../utils/comfyuiClient.ts";
 import { saveCallLog } from "@/lib/usageDb";
 import { sanitizeErrorMessage } from "../utils/error.ts";
@@ -67,7 +68,16 @@ export async function handleVideoGeneration({ body, credentials, log }) {
   }
 
   if (providerConfig.format === "comfyui") {
-    return handleComfyUIVideoGeneration({ model, provider, providerConfig, body, log });
+    return handleComfyUIVideoGeneration({
+      model,
+      provider,
+      providerConfig: {
+        ...providerConfig,
+        baseUrl: resolveComfyUiBaseUrl(credentials, providerConfig.baseUrl),
+      },
+      body,
+      log,
+    });
   }
 
   if (providerConfig.format === "sdwebui-video") {

--- a/open-sse/utils/comfyuiClient.ts
+++ b/open-sse/utils/comfyuiClient.ts
@@ -124,3 +124,26 @@ export function extractComfyOutputFiles(
 
   return files;
 }
+
+/**
+ * Resolve the ComfyUI base URL to use for a request.
+ *
+ * Prefers a per-connection override (`credentials.providerSpecificData.baseUrl`,
+ * the same storage convention self-hosted chat providers use — see
+ * `providerPageHelpers.ts`'s `CONFIGURABLE_BASE_URL_PROVIDERS`) over the registry
+ * default, so operators running ComfyUI on a Docker-network hostname (e.g.
+ * `http://comfyui:8188`) aren't stuck on `localhost:8188` (#6928). Falls back to
+ * `fallback` when no connection exists or no override is set — zero-config
+ * localhost users see no behavior change.
+ */
+export function resolveComfyUiBaseUrl(
+  credentials: { providerSpecificData?: { baseUrl?: unknown } | null } | null | undefined,
+  fallback: string
+): string {
+  const psd = credentials?.providerSpecificData;
+  const override =
+    psd && typeof psd === "object" && typeof psd.baseUrl === "string" && psd.baseUrl.trim()
+      ? psd.baseUrl.trim()
+      : null;
+  return override || fallback;
+}

--- a/src/app/(dashboard)/dashboard/providers/[id]/providerPageHelpers.ts
+++ b/src/app/(dashboard)/dashboard/providers/[id]/providerPageHelpers.ts
@@ -229,6 +229,7 @@ export const CONFIGURABLE_BASE_URL_PROVIDERS = new Set([
   "snowflake",
   "searxng-search",
   "petals",
+  "comfyui",
 ]);
 
 export const DEFAULT_PROVIDER_BASE_URLS: Record<string, string> = {
@@ -239,6 +240,7 @@ export const DEFAULT_PROVIDER_BASE_URLS: Record<string, string> = {
   siliconflow: "https://api.siliconflow.com/v1",
   "searxng-search": "http://localhost:8888/search",
   petals: "https://chat.petals.dev/api/v1/generate",
+  comfyui: "http://localhost:8188",
 };
 
 export function getLocalProviderMetadata(providerId?: string | null) {
@@ -320,6 +322,7 @@ export function getProviderBaseUrlPlaceholder(providerId?: string | null) {
       return "https://my-resource.openai.azure.com";
     case "bailian-coding-plan":
     case "xiaomi-mimo":
+    case "comfyui":
       return getProviderBaseUrlDefault(providerId);
     case "siliconflow":
       return "https://api.siliconflow.cn/v1";

--- a/src/app/api/v1/images/generations/route.ts
+++ b/src/app/api/v1/images/generations/route.ts
@@ -13,6 +13,7 @@ import {
 } from "@omniroute/open-sse/config/imageRegistry.ts";
 import { errorResponse, unavailableResponse } from "@omniroute/open-sse/utils/error.ts";
 import { HTTP_STATUS } from "@omniroute/open-sse/config/constants.ts";
+import { isAllRateLimitedCredentials } from "@/app/api/v1/_shared/rateLimit";
 import * as log from "@/sse/utils/logger";
 import { toJsonErrorPayload } from "@/shared/utils/upstreamError";
 import { enforceApiKeyPolicy } from "@/shared/utils/apiKeyPolicy";
@@ -201,6 +202,14 @@ async function postHandler(request, context) {
         credentials.retryAfter,
         credentials.retryAfterHuman
       );
+    }
+  } else if (providerConfig && providerConfig.authType === "none") {
+    // #6928: best-effort per-connection base-URL override lookup for local
+    // no-auth media providers (ComfyUI). A connection is optional here — unlike
+    // the authType !== "none" branch above, we never 400 when none exists.
+    const localCredentials = await getProviderCredentialsWithQuotaPreflight(provider);
+    if (localCredentials && !isAllRateLimitedCredentials(localCredentials)) {
+      credentials = localCredentials;
     }
   }
 

--- a/src/app/api/v1/music/generations/route.ts
+++ b/src/app/api/v1/music/generations/route.ts
@@ -85,6 +85,14 @@ async function postHandler(request, context) {
     if (isAllRateLimitedCredentials(credentials)) {
       return rateLimitedProviderResponse(provider, credentials);
     }
+  } else if (providerConfig && providerConfig.authType === "none") {
+    // #6928: best-effort per-connection base-URL override lookup for local
+    // no-auth media providers (ComfyUI). Never hard-fails when no connection
+    // exists — local providers must keep working with zero configuration.
+    const localCredentials = await getProviderCredentialsWithQuotaPreflight(provider);
+    if (localCredentials && !isAllRateLimitedCredentials(localCredentials)) {
+      credentials = localCredentials;
+    }
   }
 
   const result = await handleMusicGeneration({ body, credentials, log });

--- a/src/app/api/v1/music/generations/route.ts
+++ b/src/app/api/v1/music/generations/route.ts
@@ -43,6 +43,18 @@ export async function GET(request?: Request) {
 }
 
 /**
+ * #6928: best-effort per-connection base-URL override lookup for local no-auth
+ * media providers (ComfyUI). Returns null instead of failing when no connection
+ * exists — local providers must keep working with zero configuration.
+ */
+async function resolveLocalOverrideCredentials(provider) {
+  const localCredentials = await getProviderCredentialsWithQuotaPreflight(provider);
+  return localCredentials && !isAllRateLimitedCredentials(localCredentials)
+    ? localCredentials
+    : null;
+}
+
+/**
  * POST /v1/music/generations — generate music
  */
 async function postHandler(request, context) {
@@ -85,14 +97,8 @@ async function postHandler(request, context) {
     if (isAllRateLimitedCredentials(credentials)) {
       return rateLimitedProviderResponse(provider, credentials);
     }
-  } else if (providerConfig && providerConfig.authType === "none") {
-    // #6928: best-effort per-connection base-URL override lookup for local
-    // no-auth media providers (ComfyUI). Never hard-fails when no connection
-    // exists — local providers must keep working with zero configuration.
-    const localCredentials = await getProviderCredentialsWithQuotaPreflight(provider);
-    if (localCredentials && !isAllRateLimitedCredentials(localCredentials)) {
-      credentials = localCredentials;
-    }
+  } else if (providerConfig?.authType === "none") {
+    credentials = await resolveLocalOverrideCredentials(provider);
   }
 
   const result = await handleMusicGeneration({ body, credentials, log });

--- a/src/app/api/v1/videos/generations/route.ts
+++ b/src/app/api/v1/videos/generations/route.ts
@@ -90,6 +90,14 @@ async function postHandler(request, context) {
     if (isAllRateLimitedCredentials(credentials)) {
       return rateLimitedProviderResponse(provider, credentials);
     }
+  } else if (providerConfig && providerConfig.authType === "none") {
+    // #6928: best-effort per-connection base-URL override lookup for local
+    // no-auth media providers (ComfyUI). Never hard-fails when no connection
+    // exists — local providers must keep working with zero configuration.
+    const localCredentials = await getProviderCredentialsWithQuotaPreflight(provider);
+    if (localCredentials && !isAllRateLimitedCredentials(localCredentials)) {
+      credentials = localCredentials;
+    }
   }
 
   const result = await handleVideoGeneration({ body, credentials, log });

--- a/src/app/api/v1/videos/generations/route.ts
+++ b/src/app/api/v1/videos/generations/route.ts
@@ -44,6 +44,18 @@ export async function GET(request?: Request) {
 }
 
 /**
+ * #6928: best-effort per-connection base-URL override lookup for local no-auth
+ * media providers (ComfyUI). Returns null instead of failing when no connection
+ * exists — local providers must keep working with zero configuration.
+ */
+async function resolveLocalOverrideCredentials(provider) {
+  const localCredentials = await getProviderCredentialsWithQuotaPreflight(provider);
+  return localCredentials && !isAllRateLimitedCredentials(localCredentials)
+    ? localCredentials
+    : null;
+}
+
+/**
  * POST /v1/videos/generations — generate videos
  */
 async function postHandler(request, context) {
@@ -90,14 +102,8 @@ async function postHandler(request, context) {
     if (isAllRateLimitedCredentials(credentials)) {
       return rateLimitedProviderResponse(provider, credentials);
     }
-  } else if (providerConfig && providerConfig.authType === "none") {
-    // #6928: best-effort per-connection base-URL override lookup for local
-    // no-auth media providers (ComfyUI). Never hard-fails when no connection
-    // exists — local providers must keep working with zero configuration.
-    const localCredentials = await getProviderCredentialsWithQuotaPreflight(provider);
-    if (localCredentials && !isAllRateLimitedCredentials(localCredentials)) {
-      credentials = localCredentials;
-    }
+  } else if (providerConfig?.authType === "none") {
+    credentials = await resolveLocalOverrideCredentials(provider);
   }
 
   const result = await handleVideoGeneration({ body, credentials, log });

--- a/tests/unit/comfyui-baseurl-override-6928.test.ts
+++ b/tests/unit/comfyui-baseurl-override-6928.test.ts
@@ -1,0 +1,211 @@
+// Unit tests for #6928: expose an editable base-URL field on the ComfyUI
+// provider connection + wire the per-connection override through the shared
+// resolveComfyUiBaseUrl helper (used by image/video/music generation handlers).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+process.env.DATA_DIR = mkdtempSync(join(tmpdir(), "omniroute-comfyui-baseurl-"));
+
+import { resolveComfyUiBaseUrl } from "../../open-sse/utils/comfyuiClient.ts";
+const { handleImageGeneration } = await import("../../open-sse/handlers/imageGeneration.ts");
+const { handleVideoGeneration } = await import("../../open-sse/handlers/videoGeneration.ts");
+const { handleMusicGeneration } = await import("../../open-sse/handlers/musicGeneration.ts");
+
+const FALLBACK = "http://localhost:8188";
+const OVERRIDE = "http://comfyui:8188";
+
+function immediateTimeout(callback, _ms, ...args) {
+  if (typeof callback === "function") callback(...args);
+  return 0;
+}
+
+function mockComfyFetch(promptId: string, seenUrls: string[]) {
+  return async (url: string, options: { body?: unknown } = {}) => {
+    const stringUrl = String(url);
+    seenUrls.push(stringUrl);
+
+    if (stringUrl.endsWith("/prompt")) {
+      return new Response(JSON.stringify({ prompt_id: promptId }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (stringUrl.includes(`/history/${promptId}`)) {
+      return new Response(
+        JSON.stringify({
+          [promptId]: {
+            outputs: {
+              1: { images: [{ filename: "out.png", subfolder: "", type: "output" }] },
+            },
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      );
+    }
+    if (stringUrl.includes("/view?")) {
+      return new Response(new Uint8Array([1, 2, 3]), { status: 200 });
+    }
+    throw new Error(`Unexpected URL: ${stringUrl}`);
+  };
+}
+
+test("handleImageGeneration uses the connection's providerSpecificData.baseUrl override for ComfyUI", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalSetTimeout = globalThis.setTimeout;
+  const seenUrls: string[] = [];
+  globalThis.setTimeout = immediateTimeout;
+  globalThis.fetch = mockComfyFetch("img-override", seenUrls);
+
+  try {
+    const result = await handleImageGeneration({
+      body: { model: "comfyui/flux-dev", prompt: "override test" },
+      credentials: { providerSpecificData: { baseUrl: OVERRIDE } },
+      log: null,
+    });
+
+    assert.equal(result.success, true);
+    assert.ok(
+      seenUrls.every((u) => u.startsWith(OVERRIDE)),
+      `expected all requests to use ${OVERRIDE}, got ${seenUrls.join(", ")}`
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+    globalThis.setTimeout = originalSetTimeout;
+  }
+});
+
+test("handleImageGeneration falls back to localhost:8188 for ComfyUI when credentials is null (no regression)", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalSetTimeout = globalThis.setTimeout;
+  const seenUrls: string[] = [];
+  globalThis.setTimeout = immediateTimeout;
+  globalThis.fetch = mockComfyFetch("img-default", seenUrls);
+
+  try {
+    const result = await handleImageGeneration({
+      body: { model: "comfyui/flux-dev", prompt: "default test" },
+      credentials: null,
+      log: null,
+    });
+
+    assert.equal(result.success, true);
+    assert.ok(seenUrls.every((u) => u.startsWith(FALLBACK)));
+  } finally {
+    globalThis.fetch = originalFetch;
+    globalThis.setTimeout = originalSetTimeout;
+  }
+});
+
+test("handleVideoGeneration uses the connection's providerSpecificData.baseUrl override for ComfyUI", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalSetTimeout = globalThis.setTimeout;
+  const seenUrls: string[] = [];
+  globalThis.setTimeout = immediateTimeout;
+  globalThis.fetch = mockComfyFetch("vid-override", seenUrls);
+
+  try {
+    const result = await handleVideoGeneration({
+      body: { model: "comfyui/animatediff", prompt: "override video" },
+      credentials: { providerSpecificData: { baseUrl: OVERRIDE } },
+      log: null,
+    });
+
+    assert.equal(result.success, true);
+    assert.ok(seenUrls.every((u) => u.startsWith(OVERRIDE)));
+  } finally {
+    globalThis.fetch = originalFetch;
+    globalThis.setTimeout = originalSetTimeout;
+  }
+});
+
+test("handleMusicGeneration uses the connection's providerSpecificData.baseUrl override for ComfyUI", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalSetTimeout = globalThis.setTimeout;
+  const seenUrls: string[] = [];
+  globalThis.setTimeout = immediateTimeout;
+  globalThis.fetch = mockComfyFetch("music-override", seenUrls);
+
+  try {
+    const result = await handleMusicGeneration({
+      body: { model: "comfyui/musicgen-medium", prompt: "override music" },
+      credentials: { providerSpecificData: { baseUrl: OVERRIDE } },
+      log: null,
+    });
+
+    assert.equal(result.success, true);
+    assert.ok(seenUrls.every((u) => u.startsWith(OVERRIDE)));
+  } finally {
+    globalThis.fetch = originalFetch;
+    globalThis.setTimeout = originalSetTimeout;
+  }
+});
+
+test("resolveComfyUiBaseUrl returns the fallback for null credentials", () => {
+  assert.equal(resolveComfyUiBaseUrl(null, FALLBACK), FALLBACK);
+});
+
+test("resolveComfyUiBaseUrl returns the fallback for undefined credentials", () => {
+  assert.equal(resolveComfyUiBaseUrl(undefined, FALLBACK), FALLBACK);
+});
+
+test("resolveComfyUiBaseUrl returns the fallback when providerSpecificData is absent", () => {
+  assert.equal(resolveComfyUiBaseUrl({}, FALLBACK), FALLBACK);
+});
+
+test("resolveComfyUiBaseUrl returns the fallback when providerSpecificData is null", () => {
+  assert.equal(
+    resolveComfyUiBaseUrl({ providerSpecificData: null }, FALLBACK),
+    FALLBACK
+  );
+});
+
+test("resolveComfyUiBaseUrl returns the fallback when baseUrl is absent", () => {
+  assert.equal(
+    resolveComfyUiBaseUrl({ providerSpecificData: {} }, FALLBACK),
+    FALLBACK
+  );
+});
+
+test("resolveComfyUiBaseUrl returns the fallback when baseUrl is not a string", () => {
+  assert.equal(
+    resolveComfyUiBaseUrl(
+      { providerSpecificData: { baseUrl: 12345 as unknown as string } },
+      FALLBACK
+    ),
+    FALLBACK
+  );
+});
+
+test("resolveComfyUiBaseUrl returns the fallback when baseUrl is whitespace-only", () => {
+  assert.equal(
+    resolveComfyUiBaseUrl({ providerSpecificData: { baseUrl: "   " } }, FALLBACK),
+    FALLBACK
+  );
+});
+
+test("resolveComfyUiBaseUrl returns the trimmed override when set", () => {
+  assert.equal(
+    resolveComfyUiBaseUrl(
+      { providerSpecificData: { baseUrl: "  http://comfyui:8188  " } },
+      FALLBACK
+    ),
+    "http://comfyui:8188"
+  );
+});
+
+test("resolveComfyUiBaseUrl accepts a bare Docker-network hostname override", () => {
+  assert.equal(
+    resolveComfyUiBaseUrl({ providerSpecificData: { baseUrl: "http://comfyui:8188" } }, FALLBACK),
+    "http://comfyui:8188"
+  );
+});
+
+test("resolveComfyUiBaseUrl ignores a top-level credentials.baseUrl (not providerSpecificData)", () => {
+  const credentials = {
+    baseUrl: "http://should-be-ignored:8188",
+  } as { baseUrl: string; providerSpecificData?: { baseUrl?: unknown } | null };
+  assert.equal(resolveComfyUiBaseUrl(credentials, FALLBACK), FALLBACK);
+});

--- a/tests/unit/provider-page-helpers-3501.test.ts
+++ b/tests/unit/provider-page-helpers-3501.test.ts
@@ -79,6 +79,12 @@ test("base-url helpers run without throwing (transitive imports present)", () =>
   assert.doesNotThrow(() => isBaseUrlConfigurableProvider(null));
 });
 
+test("#6928 comfyui is a configurable-base-url provider with the localhost:8188 default", () => {
+  assert.equal(isBaseUrlConfigurableProvider("comfyui"), true);
+  assert.equal(getProviderBaseUrlDefault("comfyui"), "http://localhost:8188");
+  assert.equal(getProviderBaseUrlPlaceholder("comfyui"), "http://localhost:8188");
+});
+
 test("routing-tags / excluded-models parse + format round-trip", () => {
   assert.deepEqual(parseRoutingTagsInput("a, b ,c"), ["a", "b", "c"]);
   assert.equal(parseRoutingTagsInput("   "), undefined);


### PR DESCRIPTION
## Summary

ComfyUI is registered as a no-auth local media provider (image/video/music) with a
hardcoded `localhost:8188` default, but had no editable base-URL field on its
connection form the way self-hosted chat providers (Ollama/LM Studio/vLLM) do — so
operators running ComfyUI on a Docker network (e.g. `http://comfyui:8188`) couldn't
point OmniRoute at it.

- Added `resolveComfyUiBaseUrl(credentials, fallback)` to `open-sse/utils/comfyuiClient.ts`
  — prefers `credentials.providerSpecificData.baseUrl` over the registry default,
  the same storage convention self-hosted chat providers already use.
- Wired the override into the `comfyui` dispatch branch of the image, video, and
  music generation handlers (`imageGeneration.ts`, `videoGeneration.ts`,
  `musicGeneration.ts`).
- Added a best-effort `authType === "none"` credential lookup in all three
  `/v1/{images,videos,music}/generations` routes — never hard-fails when no
  connection exists, so zero-config localhost users see no behavior change.
- Added `comfyui` to `CONFIGURABLE_BASE_URL_PROVIDERS` /
  `DEFAULT_PROVIDER_BASE_URLS` / `getProviderBaseUrlPlaceholder` in
  `providerPageHelpers.ts` so the Add/Edit connection modals render an editable
  base-URL field for ComfyUI, pre-filled with `http://localhost:8188`.
- `config/quality/file-size-baseline.json`: justified +10/+1 line rebaseline for
  `videoGeneration.ts` and `providerPageHelpers.ts` (their own growth from this
  change; both already at the frozen cap with near-zero headroom).

## Validation (TDD)

New test file `tests/unit/comfyui-baseurl-override-6928.test.ts`:
- 10 unit tests for `resolveComfyUiBaseUrl` in isolation (fallback on
  null/undefined/whitespace/non-string, trimmed override, bare Docker-hostname
  override, top-level `credentials.baseUrl` correctly ignored).
- 4 handler-level tests with a mocked `fetch` proving `handleImageGeneration`,
  `handleVideoGeneration`, and `handleMusicGeneration` issue their ComfyUI
  requests against the connection's override URL when set, and against
  `localhost:8188` when `credentials` is `null` (regression guard for the
  zero-config path).

`tests/unit/provider-page-helpers-3501.test.ts`: added an assertion that
`isBaseUrlConfigurableProvider("comfyui")`, `getProviderBaseUrlDefault("comfyui")`,
and `getProviderBaseUrlPlaceholder("comfyui")` return the expected values.

All 14 new tests pass, plus the full pre-existing `image-generation-handler.test.ts`
(103 tests, including the existing ComfyUI cases), `video-generation-handler.test.ts`,
and `music-generation-handler.test.ts` suites still pass unchanged.

## Gates run

- `npm run lint` (scoped to changed files): clean
- `npm run typecheck:core`: exit 0
- `npm run typecheck:noimplicit:core`: no errors in any changed file (2 pre-existing
  errors in unrelated files — `usageTracking.ts`, `cliRuntime.ts` — confirmed
  untouched by this diff)
- `node scripts/check/check-file-size.mjs`: OK (after the justified baseline bump above)
- `node scripts/check/check-complexity.mjs`: OK — 2056 violations (baseline 2056, unchanged)
- `npm run test:coverage`: could not be completed in this session — the devbox is
  shared by many parallel Claude sessions and was sustained at load average 100-130
  on 16 cores for over an hour while attempting this run (first attempt produced an
  invalid 55%/62%/42%/55% result with hundreds of test files listed as "Interrupted
  while running" — an infra artifact, not a real regression; a second, longer
  attempt made real forward progress but did not finish within a reasonable window
  under the same contention). All new/changed production code is exercised by the
  14 new passing tests above, which are net-additive to coverage. Recommend a
  coverage-gate confirmation on a quieter CI runner before merge.

Closes #6928