### PR TITLE
feat: preserve tools/tool_choice for tool-bearing requests through fusion combos (#6771)

### DIFF
--- a/changelog.d/features/6771-fusion-preserve-tools-bypass.md
+++ b/changelog.d/features/6771-fusion-preserve-tools-bypass.md
@@ -1,0 +1,1 @@
+- **feat(sse):** preserve `tools`/`tool_choice` for tool-bearing requests through fusion combos — bypass panel synthesis and route straight to the judge with tools intact (#6771 — thanks @chirag127).

--- a/docs/routing/AUTO-COMBO.md
+++ b/docs/routing/AUTO-COMBO.md
@@ -212,8 +212,15 @@ a single final answer from all panel responses. Ported from upstream `decolua/9r
 
 How it works:
 
-1. **Fan-out** — the prompt is sent to every panel model at once, forced non-streaming
-   with tools stripped (the judge needs complete prose to synthesize).
+0. **Tool-bearing bypass** — a request that carries a non-empty `tools` array with
+   `tool_choice` not explicitly `"none"` skips the panel entirely: it routes directly to
+   a single model (the configured judge, or `panel[0]`) with `tools`/`tool_choice`
+   passed through unmodified. Panel members have no tool access and the judge's
+   synthesis directive discourages tool-call emission, so agentic/tool-calling clients
+   get a real tool-call decision instead of synthesized prose (#6771).
+1. **Fan-out** (non-tool-bearing requests only) — the prompt is sent to every panel
+   model at once, forced non-streaming with tools stripped (the judge needs complete
+   prose to synthesize).
 2. **Quorum-grace collection** — as soon as `minPanel` answers arrive, a short grace
    timer starts for the stragglers, then fusion proceeds with whatever was collected.
    This caps the slowest model's penalty on wall time, bounded by a hard timeout.

--- a/open-sse/services/fusion.ts
+++ b/open-sse/services/fusion.ts
@@ -136,6 +136,18 @@ export function buildJudgePrompt(answers: Array<{ text: string }>): string {
   ].join("\n");
 }
 
+/**
+ * A request is "tool-bearing" when the client supplied tools AND did not
+ * explicitly opt out of tool use this turn (tool_choice: "none" is a valid
+ * way to declare available tools while opting out — that must NOT trigger
+ * the bypass, see issue #6771).
+ */
+export function isToolBearingRequest(body: Body): boolean {
+  const hasTools = Array.isArray(body.tools) && body.tools.length > 0;
+  if (!hasTools) return false;
+  return body.tool_choice !== "none";
+}
+
 type Sentinel = { __timeout?: true; __error?: unknown };
 
 // Resolve a Response (or sentinel) within ms; the loser keeps running but is ignored.
@@ -222,6 +234,12 @@ export type HandleFusionChatOptions = {
  * complete prose to synthesize). The judge call keeps the client's original
  * stream flag + tools, so streaming and downstream tool use still work.
  *
+ * Tool-bearing requests (non-empty `tools` with `tool_choice` not "none")
+ * skip panel synthesis entirely and route straight to a single model (the
+ * configured judge, or panel[0]) with tools/tool_choice intact — panel
+ * members have no tool access and the judge's synthesis directive steers
+ * even a tools-capable judge away from emitting a tool call (#6771).
+ *
  * Speed: quorum-grace collection caps the straggler penalty. Quality: the judge
  * runs the consensus/contradiction/blind-spot analysis before writing.
  *
@@ -260,6 +278,20 @@ export async function handleFusionChat({
     "FUSION",
     `Combo "${comboName ?? ""}" | panel=${panel.length} [${panel.join(", ")}] | judge=${judge} | quorum=${minPanel}`
   );
+
+  // Tool-bearing requests get no value from panel synthesis — panel members
+  // would answer with no tool access (degraded prose), and the judge's
+  // synthesis directive steers it away from emitting a tool call even though
+  // it technically still receives `tools`. Skip straight to a single model
+  // with the full, unmodified body (tools/tool_choice intact) so agentic
+  // clients get a real tool-call decision (#6771).
+  if (isToolBearingRequest(body)) {
+    log.info(
+      "FUSION",
+      `Combo "${comboName ?? ""}" received a tool-bearing request — bypassing panel synthesis, routing directly to ${judge} with tools intact`
+    );
+    return handleSingleModel(body, judge);
+  }
 
   // 1. Fan out to the panel in parallel: non-streaming, tools stripped (we want prose).
   const { tools: _tools, tool_choice: _tc, ...rest } = body;

--- a/tests/unit/combo-fusion-strategy.test.ts
+++ b/tests/unit/combo-fusion-strategy.test.ts
@@ -79,7 +79,6 @@ test("fusion: fans out to the panel then routes a synthesis turn to the judge", 
     body: {
       messages: [{ role: "user", content: "Q" }],
       stream: true,
-      tools: [{ name: "x" }],
     },
     combo: fusionCombo(["p/a", "p/b", "p/c"], { judgeModel: "p/judge" }),
     handleSingleModel,

--- a/tests/unit/fusion-tools-bypass-6771.test.ts
+++ b/tests/unit/fusion-tools-bypass-6771.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Regression guard for #6771 — fusion combos stripping tools/tool_choice for
+ * tool-bearing requests via panel-fan-out-then-judge synthesis.
+ *
+ * Root cause: panel members answer tool-shaped prompts with no tool access
+ * (degraded prose), and the judge's injected synthesis directive ("produce
+ * ONE authoritative final answer" from anonymized panel sources) steers even
+ * a tools-capable judge away from emitting a real tool call.
+ *
+ * Fix: detect a tool-bearing request up front (non-empty `tools`, and
+ * `tool_choice` not explicitly "none") and bypass the panel fan-out +
+ * judge-synthesis path entirely — route the full, unmodified body straight
+ * to a single model (the configured judgeModel, or panel[0]).
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-fusion-6771-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.API_KEY_SECRET = process.env.API_KEY_SECRET || "fusion-6771-test-secret";
+
+const { handleComboChat } = await import("../../open-sse/services/combo.ts");
+
+type Body = Record<string, unknown>;
+
+function jsonResponse(model: string, content: string): Response {
+  const body = JSON.stringify({ model, choices: [{ message: { role: "assistant", content } }] });
+  return new Response(body, { status: 200, headers: { "Content-Type": "application/json" } });
+}
+
+const noop = () => {};
+const log = { info: noop, warn: noop, debug: noop, error: noop };
+
+function fusionCombo(models: string[], extra: Record<string, unknown> = {}) {
+  return {
+    name: "fusion-tools",
+    strategy: "fusion",
+    models: models.map((m) => ({ model: m })),
+    config: extra,
+  };
+}
+
+const TOOLS = [
+  {
+    type: "function",
+    function: { name: "get_weather", description: "Get the weather", parameters: {} },
+  },
+];
+
+test("6771: tool-bearing request bypasses panel fan-out — single call, tools intact, targets configured judge", async () => {
+  const calls: Array<{ model: string; body: Body }> = [];
+  const handleSingleModel = async (b: Body, m: string) => {
+    calls.push({ model: m, body: b });
+    return jsonResponse(m, "tool decision");
+  };
+
+  const requestBody: Body = {
+    messages: [{ role: "user", content: "what's the weather?" }],
+    tools: TOOLS,
+    tool_choice: "auto",
+  };
+
+  const res = await handleComboChat({
+    body: requestBody,
+    combo: fusionCombo(["panel/a", "panel/b"], { judgeModel: "judge/model" }),
+    handleSingleModel,
+    log,
+    settings: {},
+    allCombos: [],
+  });
+
+  // Exactly one call — not once per panel member + once for the judge.
+  assert.equal(calls.length, 1, `expected exactly 1 call, got: ${calls.map((c) => c.model).join(", ")}`);
+  assert.equal(calls[0].model, "judge/model");
+
+  // The forwarded body still contains the original tools/tool_choice unmodified.
+  assert.deepEqual(calls[0].body.tools, TOOLS);
+  assert.equal(calls[0].body.tool_choice, "auto");
+
+  assert.equal(res.status, 200);
+});
+
+test("6771: tool-bearing request with no explicit judgeModel targets panel[0]", async () => {
+  const calls: string[] = [];
+  const handleSingleModel = async (_b: Body, m: string) => {
+    calls.push(m);
+    return jsonResponse(m, "tool decision");
+  };
+
+  await handleComboChat({
+    body: {
+      messages: [{ role: "user", content: "what's the weather?" }],
+      tools: TOOLS,
+    },
+    combo: fusionCombo(["panel/a", "panel/b"]), // no judgeModel — defaults to panel[0]
+    handleSingleModel,
+    log,
+    settings: {},
+    allCombos: [],
+  });
+
+  assert.deepEqual(calls, ["panel/a"]);
+});
+
+test("6771: tools present but tool_choice:\"none\" still goes through normal fan-out+judge path", async () => {
+  const calls: string[] = [];
+  const handleSingleModel = async (_b: Body, m: string) => {
+    calls.push(m);
+    return jsonResponse(m, "prose answer");
+  };
+
+  await handleComboChat({
+    body: {
+      messages: [{ role: "user", content: "hi" }],
+      tools: TOOLS,
+      tool_choice: "none",
+    },
+    combo: fusionCombo(["panel/a", "panel/b"], { judgeModel: "judge/model" }),
+    handleSingleModel,
+    log,
+    settings: {},
+    allCombos: [],
+  });
+
+  // panel.length (2) fan-out calls + 1 judge call = 3.
+  assert.equal(calls.length, 3, `expected 3 calls (fan-out+judge), got: ${calls.join(", ")}`);
+  assert.deepEqual(calls.slice(0, 2).sort(), ["panel/a", "panel/b"]);
+  assert.equal(calls[2], "judge/model");
+});
+
+test("6771: no regression — request without tools still goes through normal fan-out+judge path", async () => {
+  const calls: string[] = [];
+  const handleSingleModel = async (_b: Body, m: string) => {
+    calls.push(m);
+    return jsonResponse(m, "prose answer");
+  };
+
+  await handleComboChat({
+    body: { messages: [{ role: "user", content: "hi" }] },
+    combo: fusionCombo(["panel/a", "panel/b"], { judgeModel: "judge/model" }),
+    handleSingleModel,
+    log,
+    settings: {},
+    allCombos: [],
+  });
+
+  assert.equal(calls.length, 3, `expected 3 calls (fan-out+judge), got: ${calls.join(", ")}`);
+  assert.deepEqual(calls.slice(0, 2).sort(), ["panel/a", "panel/b"]);
+  assert.equal(calls[2], "judge/model");
+});


### PR DESCRIPTION
## Summary

Fusion combos always fan a request out to every panel model in parallel and then hand the panel's synthesized prose to a judge model. Panel members receive no `tools`/`tool_choice` (by design — they need to return plain prose for the judge to synthesize), and the judge's injected synthesis directive ("produce ONE authoritative final answer" from anonymized panel sources) steers even a tools-capable judge away from actually emitting a tool call. Net effect for an agentic/tool-calling client: it gets synthesized prose back instead of a real tool-call decision.

This PR detects a tool-bearing request up front (`tools` non-empty AND `tool_choice` not explicitly `"none"`) and bypasses the panel fan-out + judge-synthesis path entirely for that turn — routing the full, unmodified body straight to a single model (the configured `judgeModel`, or `panel[0]` when unset) via the existing `handleSingleModel`, so `tools`/`tool_choice` reach the model completely untouched.

- `tool_choice: "none"` with `tools` present is correctly treated as "not tool-bearing" (the caller explicitly opted out this turn) — panel synthesis still applies.
- No schema/config changes — behavior-only.
- `docs/routing/AUTO-COMBO.md` fusion section updated to document the bypass.

## How it was validated

TDD — new `tests/unit/fusion-tools-bypass-6771.test.ts`:
- a tool-bearing request calls `handleSingleModel` **exactly once** (not once per panel member + judge), targeting the configured judge with `tools`/`tool_choice` forwarded unmodified
- with no explicit `judgeModel`, the bypass targets `panel[0]`
- `tools` + `tool_choice: "none"` still goes through the normal fan-out+judge path (no accidental over-trigger)
- a request with no `tools` is unaffected (no regression)

Also re-ran the full existing fusion/combo regression suite and confirmed all green: `fusion-judge-model-6455`, `fusion-partial-panel-failure-6454`, `combo-fusion-strategy`, `combo-fusion-config-warn-6455`, `fusion-judge-survivor`, `idempotency-fusion-collision`, `fusion-judge-own-intelligence`, `services/fusion-min-panel-and-failure-detail`, `integration/combo-matrix/fusion`.

One pre-existing test in `combo-fusion-strategy.test.ts` incidentally sent `tools` in its fan-out+judge scenario body — updated to drop that field since a tool-bearing request now legitimately bypasses the panel (the behavior change this PR intentionally introduces), not a masked assertion.

Gates run locally: `npm run lint` (clean), `npm run typecheck:core` (clean), `npm run typecheck:noimplicit:core` (clean on touched files — pre-existing unrelated errors in `combo.ts`/`usageTracking.ts`/`cliRuntime.ts` confirmed identical on `origin/release/v3.8.49`), `node scripts/check/check-file-size.mjs` (OK), `node scripts/check/check-complexity.mjs` (OK, 2056 violations vs baseline 2056), `npm run check:cycles` (OK), `npm run check:docs-sync` (PASS). `npm run test:coverage` (full-repo 60/60/60/60 gate) could not complete locally due to sustained extreme shared-machine contention (load average 70–130 on a 16-core box from ~12+ concurrent sessions running the same gates) — the change is additive-only (one new pure helper + one new early-return branch, both fully exercised by the new dedicated test file) and does not touch any other module, so it should not regress the ratchet; CI will run this authoritatively.

Closes #6771