### PR TITLE
feat(sse): add native xAI Grok Imagine video generation provider

### DIFF
--- a/changelog.d/features/7238-xai-grok-imagine-video.md
+++ b/changelog.d/features/7238-xai-grok-imagine-video.md
@@ -1,0 +1,1 @@
+- **feat(sse):** add native xAI Grok Imagine video generation provider — `xai/grok-imagine-video` on `/v1/videos/generations` using your own xAI key, instead of only via the kie proxy market. (thanks @anndev-69)

--- a/open-sse/config/videoRegistry.ts
+++ b/open-sse/config/videoRegistry.ts
@@ -205,6 +205,19 @@ export const VIDEO_PROVIDERS: Record<string, VideoProvider> = {
     format: "dashscope-video",
     models: [{ id: "wan2.7-t2v", name: "Wan 2.7 T2V" }],
   },
+
+  xai: {
+    id: "xai",
+    // xAI Grok Imagine async video-generation API. Reuses the stored xai
+    // provider Bearer apiKey (same credential the image-generation "xai"
+    // entry in imageRegistry.ts already uses) — no separate credential flow.
+    baseUrl: "https://api.x.ai/v1/videos",
+    statusUrl: "https://api.x.ai/v1/videos",
+    authType: "apikey",
+    authHeader: "bearer",
+    format: "xai-video",
+    models: [{ id: "grok-imagine-video", name: "Grok Imagine Video" }],
+  },
 };
 
 /**

--- a/open-sse/handlers/videoGeneration.ts
+++ b/open-sse/handlers/videoGeneration.ts
@@ -1,24 +1,17 @@
 /**
  * Video Generation Handler
  *
- * Handles POST /v1/videos/generations requests.
- * Proxies to upstream video generation providers.
- *
- * Supported provider formats:
- * - ComfyUI: submit AnimateDiff/SVD workflow → poll → fetch video
- * - SD WebUI: POST to AnimateDiff extension endpoint
- *
- * Response format (OpenAI-like):
- * {
- *   "created": 1234567890,
- *   "data": [{ "b64_json": "...", "format": "mp4" }]
- * }
+ * Handles POST /v1/videos/generations requests. Proxies to upstream video
+ * generation providers (ComfyUI AnimateDiff/SVD, SD WebUI AnimateDiff, and
+ * more — see the per-format handlers below). Response format (OpenAI-like):
+ * { "created": 1234567890, "data": [{ "b64_json": "...", "format": "mp4" }] }
  */
 
 import { getVideoProvider, parseVideoModel } from "../config/videoRegistry.ts";
 import { kieExecutor } from "../executors/kie.ts";
 import { vertexGenerateVideo } from "../executors/vertexMedia.ts";
 import { handleGoogleFlowVideoGeneration } from "./videoGeneration/googleFlowHandler.ts";
+import { handleXaiVideoGeneration } from "./videoGeneration/xaiGrokImagineHandler.ts";
 import { getExecutor } from "../executors/index.ts";
 import { isJsonObject, parseKieResultJson } from "../utils/kieTask.ts";
 import {
@@ -265,144 +258,6 @@ async function handleDashscopeVideoGeneration({
       success: false,
       status: 504,
       error: `DashScope task ${taskId} timed out (status: ${lastStatus})`,
-    };
-  } catch (err: unknown) {
-    return {
-      success: false,
-      status: isJsonObject(err) && Number.isFinite(Number(err.status)) ? Number(err.status) : 502,
-      error: sanitizeErrorMessage(err) || "Video provider error",
-    };
-  }
-}
-
-/**
- * xAI Grok Imagine video generation: create async job → poll → MP4.
- * Reuses the stored xai provider Bearer apiKey (same credential the
- * image-generation "xai" entry in imageRegistry.ts already uses) — no
- * separate credential flow. Mirrors the DashScope create+poll shape above,
- * adapted to xAI's request_id / status ("pending"|"processing"|"done"|"failed")
- * job shape (https://docs.x.ai/developers/rest-api-reference/inference/videos).
- */
-async function handleXaiVideoGeneration({
-  model,
-  provider,
-  providerConfig,
-  body,
-  credentials,
-  log,
-}: {
-  model: string;
-  provider: string;
-  providerConfig: { baseUrl: string; statusUrl?: string };
-  body: Record<string, unknown> & {
-    prompt?: unknown;
-    image?: unknown;
-    duration?: unknown;
-    aspect_ratio?: unknown;
-    resolution?: unknown;
-    timeout_ms?: unknown;
-    poll_interval_ms?: unknown;
-  };
-  credentials?: { apiKey?: string; accessToken?: string } | null;
-  log?: {
-    info: (scope: string, message: string) => void;
-    error: (scope: string, message: string) => void;
-  } | null;
-}) {
-  const startTime = Date.now();
-  const timeoutMs = Number(body.timeout_ms) > 0 ? Number(body.timeout_ms) : 300000;
-  const pollIntervalMs = Number(body.poll_interval_ms) > 0 ? Number(body.poll_interval_ms) : 2500;
-  const token = credentials?.apiKey || credentials?.accessToken;
-  const baseUrl = providerConfig.baseUrl.replace(/\/$/, "");
-  const statusUrl = (providerConfig.statusUrl || baseUrl).replace(/\/$/, "");
-  const prompt = typeof body.prompt === "string" ? body.prompt : String(body.prompt ?? "");
-
-  if (!token) {
-    return { success: false, status: 401, error: "xAI API key is required" };
-  }
-
-  const payload: Record<string, unknown> = { model, prompt };
-  if (typeof body.image === "string") payload.image = body.image;
-  if (body.duration != null) payload.duration = Number(body.duration);
-  if (typeof body.aspect_ratio === "string") payload.aspect_ratio = body.aspect_ratio;
-  if (typeof body.resolution === "string") payload.resolution = body.resolution;
-
-  if (log) {
-    log.info("VIDEO", `${provider}/${model} (xai-video) | prompt: "${prompt.slice(0, 60)}..."`);
-  }
-
-  try {
-    // Step 1: create async job
-    const createRes = await fetch(`${baseUrl}/generations`, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${token}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(payload),
-    });
-    const createData = await createRes.json().catch(() => ({}));
-    const requestId = createData?.request_id;
-    if (!requestId) {
-      const errorMessage =
-        createData?.error?.message ||
-        createData?.message ||
-        "xAI video generation did not return request_id";
-      if (log) {
-        log.error("VIDEO", `xAI createJob failed: ${JSON.stringify(createData)}`);
-      }
-      return { success: false, status: 502, error: String(errorMessage) };
-    }
-
-    // Step 2: poll statusUrl/{request_id} until terminal
-    const deadline = startTime + timeoutMs;
-    let lastStatus = "pending";
-    while (Date.now() < deadline) {
-      await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
-      const pollRes = await fetch(`${statusUrl}/${requestId}`, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      const pollData = await pollRes.json().catch(() => ({}));
-      lastStatus = pollData?.status || "pending";
-
-      if (lastStatus === "done") {
-        const videoUrl = pollData?.video?.url;
-        if (!videoUrl) {
-          return {
-            success: false,
-            status: 502,
-            error: "xAI video job done but no video.url",
-          };
-        }
-        saveCallLog({
-          method: "POST",
-          path: "/v1/videos/generations",
-          status: 200,
-          model: `${provider}/${model}`,
-          provider,
-          duration: Date.now() - startTime,
-          responseBody: { videos_count: 1 },
-        }).catch(() => {});
-        return {
-          success: true,
-          data: {
-            created: Math.floor(Date.now() / 1000),
-            data: [{ url: videoUrl, format: "mp4" }],
-          },
-        };
-      }
-
-      if (lastStatus === "failed") {
-        const errorMessage = pollData?.error || "xAI video job failed";
-        return { success: false, status: 502, error: String(errorMessage) };
-      }
-      // pending / processing → keep polling
-    }
-
-    return {
-      success: false,
-      status: 504,
-      error: `xAI video job ${requestId} timed out (status: ${lastStatus})`,
     };
   } catch (err: unknown) {
     return {

--- a/open-sse/handlers/videoGeneration.ts
+++ b/open-sse/handlers/videoGeneration.ts
@@ -112,6 +112,10 @@ export async function handleVideoGeneration({ body, credentials, log }) {
     });
   }
 
+  if (providerConfig.format === "xai-video") {
+    return handleXaiVideoGeneration({ model, provider, providerConfig, body, credentials, log });
+  }
+
   return {
     success: false,
     status: 400,
@@ -261,6 +265,144 @@ async function handleDashscopeVideoGeneration({
       success: false,
       status: 504,
       error: `DashScope task ${taskId} timed out (status: ${lastStatus})`,
+    };
+  } catch (err: unknown) {
+    return {
+      success: false,
+      status: isJsonObject(err) && Number.isFinite(Number(err.status)) ? Number(err.status) : 502,
+      error: sanitizeErrorMessage(err) || "Video provider error",
+    };
+  }
+}
+
+/**
+ * xAI Grok Imagine video generation: create async job → poll → MP4.
+ * Reuses the stored xai provider Bearer apiKey (same credential the
+ * image-generation "xai" entry in imageRegistry.ts already uses) — no
+ * separate credential flow. Mirrors the DashScope create+poll shape above,
+ * adapted to xAI's request_id / status ("pending"|"processing"|"done"|"failed")
+ * job shape (https://docs.x.ai/developers/rest-api-reference/inference/videos).
+ */
+async function handleXaiVideoGeneration({
+  model,
+  provider,
+  providerConfig,
+  body,
+  credentials,
+  log,
+}: {
+  model: string;
+  provider: string;
+  providerConfig: { baseUrl: string; statusUrl?: string };
+  body: Record<string, unknown> & {
+    prompt?: unknown;
+    image?: unknown;
+    duration?: unknown;
+    aspect_ratio?: unknown;
+    resolution?: unknown;
+    timeout_ms?: unknown;
+    poll_interval_ms?: unknown;
+  };
+  credentials?: { apiKey?: string; accessToken?: string } | null;
+  log?: {
+    info: (scope: string, message: string) => void;
+    error: (scope: string, message: string) => void;
+  } | null;
+}) {
+  const startTime = Date.now();
+  const timeoutMs = Number(body.timeout_ms) > 0 ? Number(body.timeout_ms) : 300000;
+  const pollIntervalMs = Number(body.poll_interval_ms) > 0 ? Number(body.poll_interval_ms) : 2500;
+  const token = credentials?.apiKey || credentials?.accessToken;
+  const baseUrl = providerConfig.baseUrl.replace(/\/$/, "");
+  const statusUrl = (providerConfig.statusUrl || baseUrl).replace(/\/$/, "");
+  const prompt = typeof body.prompt === "string" ? body.prompt : String(body.prompt ?? "");
+
+  if (!token) {
+    return { success: false, status: 401, error: "xAI API key is required" };
+  }
+
+  const payload: Record<string, unknown> = { model, prompt };
+  if (typeof body.image === "string") payload.image = body.image;
+  if (body.duration != null) payload.duration = Number(body.duration);
+  if (typeof body.aspect_ratio === "string") payload.aspect_ratio = body.aspect_ratio;
+  if (typeof body.resolution === "string") payload.resolution = body.resolution;
+
+  if (log) {
+    log.info("VIDEO", `${provider}/${model} (xai-video) | prompt: "${prompt.slice(0, 60)}..."`);
+  }
+
+  try {
+    // Step 1: create async job
+    const createRes = await fetch(`${baseUrl}/generations`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    });
+    const createData = await createRes.json().catch(() => ({}));
+    const requestId = createData?.request_id;
+    if (!requestId) {
+      const errorMessage =
+        createData?.error?.message ||
+        createData?.message ||
+        "xAI video generation did not return request_id";
+      if (log) {
+        log.error("VIDEO", `xAI createJob failed: ${JSON.stringify(createData)}`);
+      }
+      return { success: false, status: 502, error: String(errorMessage) };
+    }
+
+    // Step 2: poll statusUrl/{request_id} until terminal
+    const deadline = startTime + timeoutMs;
+    let lastStatus = "pending";
+    while (Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+      const pollRes = await fetch(`${statusUrl}/${requestId}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const pollData = await pollRes.json().catch(() => ({}));
+      lastStatus = pollData?.status || "pending";
+
+      if (lastStatus === "done") {
+        const videoUrl = pollData?.video?.url;
+        if (!videoUrl) {
+          return {
+            success: false,
+            status: 502,
+            error: "xAI video job done but no video.url",
+          };
+        }
+        saveCallLog({
+          method: "POST",
+          path: "/v1/videos/generations",
+          status: 200,
+          model: `${provider}/${model}`,
+          provider,
+          duration: Date.now() - startTime,
+          responseBody: { videos_count: 1 },
+        }).catch(() => {});
+        return {
+          success: true,
+          data: {
+            created: Math.floor(Date.now() / 1000),
+            data: [{ url: videoUrl, format: "mp4" }],
+          },
+        };
+      }
+
+      if (lastStatus === "failed") {
+        const errorMessage = pollData?.error || "xAI video job failed";
+        return { success: false, status: 502, error: String(errorMessage) };
+      }
+      // pending / processing → keep polling
+    }
+
+    return {
+      success: false,
+      status: 504,
+      error: `xAI video job ${requestId} timed out (status: ${lastStatus})`,
     };
   } catch (err: unknown) {
     return {

--- a/open-sse/handlers/videoGeneration/xaiGrokImagineHandler.ts
+++ b/open-sse/handlers/videoGeneration/xaiGrokImagineHandler.ts
@@ -1,0 +1,148 @@
+/**
+ * xAI Grok Imagine video generation: create async job → poll → MP4.
+ * Reuses the stored xai provider Bearer apiKey (same credential the
+ * image-generation "xai" entry in imageRegistry.ts already uses) — no
+ * separate credential flow. Mirrors the DashScope create+poll shape in
+ * videoGeneration.ts, adapted to xAI's request_id / status
+ * ("pending"|"processing"|"done"|"failed") job shape
+ * (https://docs.x.ai/developers/rest-api-reference/inference/videos).
+ */
+
+import { isJsonObject } from "../../utils/kieTask.ts";
+import { saveCallLog } from "@/lib/usageDb";
+import { sanitizeErrorMessage } from "../../utils/error.ts";
+
+interface XaiVideoBody {
+  prompt?: unknown;
+  image?: unknown;
+  duration?: unknown;
+  aspect_ratio?: unknown;
+  resolution?: unknown;
+  timeout_ms?: unknown;
+  poll_interval_ms?: unknown;
+  [key: string]: unknown;
+}
+
+interface XaiVideoLog {
+  info: (scope: string, message: string) => void;
+  error: (scope: string, message: string) => void;
+}
+
+export async function handleXaiVideoGeneration({
+  model,
+  provider,
+  providerConfig,
+  body,
+  credentials,
+  log,
+}: {
+  model: string;
+  provider: string;
+  providerConfig: { baseUrl: string; statusUrl?: string };
+  body: XaiVideoBody;
+  credentials?: { apiKey?: string; accessToken?: string } | null;
+  log?: XaiVideoLog | null;
+}) {
+  const startTime = Date.now();
+  const timeoutMs = Number(body.timeout_ms) > 0 ? Number(body.timeout_ms) : 300000;
+  const pollIntervalMs = Number(body.poll_interval_ms) > 0 ? Number(body.poll_interval_ms) : 2500;
+  const token = credentials?.apiKey || credentials?.accessToken;
+  const baseUrl = providerConfig.baseUrl.replace(/\/$/, "");
+  const statusUrl = (providerConfig.statusUrl || baseUrl).replace(/\/$/, "");
+  const prompt = typeof body.prompt === "string" ? body.prompt : String(body.prompt ?? "");
+
+  if (!token) {
+    return { success: false, status: 401, error: "xAI API key is required" };
+  }
+
+  const payload: Record<string, unknown> = { model, prompt };
+  if (typeof body.image === "string") payload.image = body.image;
+  if (body.duration != null) payload.duration = Number(body.duration);
+  if (typeof body.aspect_ratio === "string") payload.aspect_ratio = body.aspect_ratio;
+  if (typeof body.resolution === "string") payload.resolution = body.resolution;
+
+  if (log) {
+    log.info("VIDEO", `${provider}/${model} (xai-video) | prompt: "${prompt.slice(0, 60)}..."`);
+  }
+
+  try {
+    // Step 1: create async job
+    const createRes = await fetch(`${baseUrl}/generations`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    });
+    const createData = await createRes.json().catch(() => ({}));
+    const requestId = createData?.request_id;
+    if (!requestId) {
+      const errorMessage =
+        createData?.error?.message ||
+        createData?.message ||
+        "xAI video generation did not return request_id";
+      if (log) {
+        log.error("VIDEO", `xAI createJob failed: ${JSON.stringify(createData)}`);
+      }
+      return { success: false, status: 502, error: String(errorMessage) };
+    }
+
+    // Step 2: poll statusUrl/{request_id} until terminal
+    const deadline = startTime + timeoutMs;
+    let lastStatus = "pending";
+    while (Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+      const pollRes = await fetch(`${statusUrl}/${requestId}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const pollData = await pollRes.json().catch(() => ({}));
+      lastStatus = pollData?.status || "pending";
+
+      if (lastStatus === "done") {
+        const videoUrl = pollData?.video?.url;
+        if (!videoUrl) {
+          return {
+            success: false,
+            status: 502,
+            error: "xAI video job done but no video.url",
+          };
+        }
+        saveCallLog({
+          method: "POST",
+          path: "/v1/videos/generations",
+          status: 200,
+          model: `${provider}/${model}`,
+          provider,
+          duration: Date.now() - startTime,
+          responseBody: { videos_count: 1 },
+        }).catch(() => {});
+        return {
+          success: true,
+          data: {
+            created: Math.floor(Date.now() / 1000),
+            data: [{ url: videoUrl, format: "mp4" }],
+          },
+        };
+      }
+
+      if (lastStatus === "failed") {
+        const errorMessage = pollData?.error || "xAI video job failed";
+        return { success: false, status: 502, error: String(errorMessage) };
+      }
+      // pending / processing → keep polling
+    }
+
+    return {
+      success: false,
+      status: 504,
+      error: `xAI video job ${requestId} timed out (status: ${lastStatus})`,
+    };
+  } catch (err: unknown) {
+    return {
+      success: false,
+      status: isJsonObject(err) && Number.isFinite(Number(err.status)) ? Number(err.status) : 502,
+      error: sanitizeErrorMessage(err) || "Video provider error",
+    };
+  }
+}

--- a/open-sse/handlers/videoGeneration/xaiGrokImagineHandler.ts
+++ b/open-sse/handlers/videoGeneration/xaiGrokImagineHandler.ts
@@ -28,6 +28,155 @@ interface XaiVideoLog {
   error: (scope: string, message: string) => void;
 }
 
+/** Map the OmniRoute video body onto xAI's create-job payload. */
+function buildXaiVideoPayload(model: string, prompt: string, body: XaiVideoBody) {
+  const payload: Record<string, unknown> = { model, prompt };
+  if (typeof body.image === "string") payload.image = body.image;
+  if (body.duration != null) payload.duration = Number(body.duration);
+  if (typeof body.aspect_ratio === "string") payload.aspect_ratio = body.aspect_ratio;
+  if (typeof body.resolution === "string") payload.resolution = body.resolution;
+  return payload;
+}
+
+/** POST the create-job request; resolves to the request_id or a ready error message. */
+async function createXaiVideoJob({
+  baseUrl,
+  token,
+  payload,
+  log,
+}: {
+  baseUrl: string;
+  token: string;
+  payload: Record<string, unknown>;
+  log?: XaiVideoLog | null;
+}): Promise<{ requestId?: string; error?: string }> {
+  const createRes = await fetch(`${baseUrl}/generations`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+  const createData = await createRes.json().catch(() => ({}));
+  const requestId = createData?.request_id;
+  if (requestId) return { requestId: String(requestId) };
+
+  const errorMessage =
+    createData?.error?.message ||
+    createData?.message ||
+    "xAI video generation did not return request_id";
+  if (log) {
+    log.error("VIDEO", `xAI createJob failed: ${JSON.stringify(createData)}`);
+  }
+  return { error: String(errorMessage) };
+}
+
+type XaiPollOutcome =
+  | { terminal: "done"; videoUrl?: string }
+  | { terminal: "failed"; error?: unknown }
+  | { terminal: "timeout"; lastStatus: string };
+
+/**
+ * Poll statusUrl/{request_id} until a terminal status or the deadline.
+ * Date.now() is read only in the loop condition, so the caller keeps full
+ * control over the timeout budget it computed from its own startTime.
+ */
+async function pollXaiVideoJob({
+  statusUrl,
+  requestId,
+  token,
+  deadline,
+  pollIntervalMs,
+}: {
+  statusUrl: string;
+  requestId: string;
+  token: string;
+  deadline: number;
+  pollIntervalMs: number;
+}): Promise<XaiPollOutcome> {
+  let lastStatus = "pending";
+  while (Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+    const pollRes = await fetch(`${statusUrl}/${requestId}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const pollData = await pollRes.json().catch(() => ({}));
+    lastStatus = pollData?.status || "pending";
+
+    if (lastStatus === "done") return { terminal: "done", videoUrl: pollData?.video?.url };
+    if (lastStatus === "failed") return { terminal: "failed", error: pollData?.error };
+    // pending / processing → keep polling
+  }
+  return { terminal: "timeout", lastStatus };
+}
+
+/** Resolve the request knobs (timeouts, credential, endpoints, prompt) from the call. */
+function resolveXaiVideoOptions(
+  body: XaiVideoBody,
+  providerConfig: { baseUrl: string; statusUrl?: string },
+  credentials?: { apiKey?: string; accessToken?: string } | null
+) {
+  const baseUrl = providerConfig.baseUrl.replace(/\/$/, "");
+  return {
+    timeoutMs: Number(body.timeout_ms) > 0 ? Number(body.timeout_ms) : 300000,
+    pollIntervalMs: Number(body.poll_interval_ms) > 0 ? Number(body.poll_interval_ms) : 2500,
+    token: credentials?.apiKey || credentials?.accessToken,
+    baseUrl,
+    statusUrl: (providerConfig.statusUrl || baseUrl).replace(/\/$/, ""),
+    prompt: typeof body.prompt === "string" ? body.prompt : String(body.prompt ?? ""),
+  };
+}
+
+/** Map a terminal poll outcome onto the OpenAI-like video response (or an error). */
+function buildXaiVideoResponse({
+  outcome,
+  requestId,
+  provider,
+  model,
+  startTime,
+}: {
+  outcome: XaiPollOutcome;
+  requestId: string;
+  provider: string;
+  model: string;
+  startTime: number;
+}) {
+  if (outcome.terminal === "failed") {
+    return { success: false, status: 502, error: String(outcome.error || "xAI video job failed") };
+  }
+
+  if (outcome.terminal === "timeout") {
+    return {
+      success: false,
+      status: 504,
+      error: `xAI video job ${requestId} timed out (status: ${outcome.lastStatus})`,
+    };
+  }
+
+  if (!outcome.videoUrl) {
+    return { success: false, status: 502, error: "xAI video job done but no video.url" };
+  }
+
+  saveCallLog({
+    method: "POST",
+    path: "/v1/videos/generations",
+    status: 200,
+    model: `${provider}/${model}`,
+    provider,
+    duration: Date.now() - startTime,
+    responseBody: { videos_count: 1 },
+  }).catch(() => {});
+
+  return {
+    success: true,
+    data: {
+      created: Math.floor(Date.now() / 1000),
+      data: [{ url: outcome.videoUrl, format: "mp4" }],
+    },
+  };
+}
+
 export async function handleXaiVideoGeneration({
   model,
   provider,
@@ -44,100 +193,46 @@ export async function handleXaiVideoGeneration({
   log?: XaiVideoLog | null;
 }) {
   const startTime = Date.now();
-  const timeoutMs = Number(body.timeout_ms) > 0 ? Number(body.timeout_ms) : 300000;
-  const pollIntervalMs = Number(body.poll_interval_ms) > 0 ? Number(body.poll_interval_ms) : 2500;
-  const token = credentials?.apiKey || credentials?.accessToken;
-  const baseUrl = providerConfig.baseUrl.replace(/\/$/, "");
-  const statusUrl = (providerConfig.statusUrl || baseUrl).replace(/\/$/, "");
-  const prompt = typeof body.prompt === "string" ? body.prompt : String(body.prompt ?? "");
+  const { timeoutMs, pollIntervalMs, token, baseUrl, statusUrl, prompt } = resolveXaiVideoOptions(
+    body,
+    providerConfig,
+    credentials
+  );
 
   if (!token) {
     return { success: false, status: 401, error: "xAI API key is required" };
   }
-
-  const payload: Record<string, unknown> = { model, prompt };
-  if (typeof body.image === "string") payload.image = body.image;
-  if (body.duration != null) payload.duration = Number(body.duration);
-  if (typeof body.aspect_ratio === "string") payload.aspect_ratio = body.aspect_ratio;
-  if (typeof body.resolution === "string") payload.resolution = body.resolution;
 
   if (log) {
     log.info("VIDEO", `${provider}/${model} (xai-video) | prompt: "${prompt.slice(0, 60)}..."`);
   }
 
   try {
-    // Step 1: create async job
-    const createRes = await fetch(`${baseUrl}/generations`, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${token}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(payload),
+    const created = await createXaiVideoJob({
+      baseUrl,
+      token,
+      payload: buildXaiVideoPayload(model, prompt, body),
+      log,
     });
-    const createData = await createRes.json().catch(() => ({}));
-    const requestId = createData?.request_id;
-    if (!requestId) {
-      const errorMessage =
-        createData?.error?.message ||
-        createData?.message ||
-        "xAI video generation did not return request_id";
-      if (log) {
-        log.error("VIDEO", `xAI createJob failed: ${JSON.stringify(createData)}`);
-      }
-      return { success: false, status: 502, error: String(errorMessage) };
+    if (!created.requestId) {
+      return { success: false, status: 502, error: created.error };
     }
 
-    // Step 2: poll statusUrl/{request_id} until terminal
-    const deadline = startTime + timeoutMs;
-    let lastStatus = "pending";
-    while (Date.now() < deadline) {
-      await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
-      const pollRes = await fetch(`${statusUrl}/${requestId}`, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      const pollData = await pollRes.json().catch(() => ({}));
-      lastStatus = pollData?.status || "pending";
+    const outcome = await pollXaiVideoJob({
+      statusUrl,
+      requestId: created.requestId,
+      token,
+      deadline: startTime + timeoutMs,
+      pollIntervalMs,
+    });
 
-      if (lastStatus === "done") {
-        const videoUrl = pollData?.video?.url;
-        if (!videoUrl) {
-          return {
-            success: false,
-            status: 502,
-            error: "xAI video job done but no video.url",
-          };
-        }
-        saveCallLog({
-          method: "POST",
-          path: "/v1/videos/generations",
-          status: 200,
-          model: `${provider}/${model}`,
-          provider,
-          duration: Date.now() - startTime,
-          responseBody: { videos_count: 1 },
-        }).catch(() => {});
-        return {
-          success: true,
-          data: {
-            created: Math.floor(Date.now() / 1000),
-            data: [{ url: videoUrl, format: "mp4" }],
-          },
-        };
-      }
-
-      if (lastStatus === "failed") {
-        const errorMessage = pollData?.error || "xAI video job failed";
-        return { success: false, status: 502, error: String(errorMessage) };
-      }
-      // pending / processing → keep polling
-    }
-
-    return {
-      success: false,
-      status: 504,
-      error: `xAI video job ${requestId} timed out (status: ${lastStatus})`,
-    };
+    return buildXaiVideoResponse({
+      outcome,
+      requestId: created.requestId,
+      provider,
+      model,
+      startTime,
+    });
   } catch (err: unknown) {
     return {
       success: false,

--- a/tests/unit/video-xai-grok-imagine.test.ts
+++ b/tests/unit/video-xai-grok-imagine.test.ts
@@ -1,0 +1,236 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+process.env.DATA_DIR = mkdtempSync(join(tmpdir(), "omniroute-video-xai-"));
+
+const { handleVideoGeneration } = await import("../../open-sse/handlers/videoGeneration.ts");
+const { VIDEO_PROVIDERS } = await import("../../open-sse/config/videoRegistry.ts");
+
+// Makes poll-interval waits resolve instantly so tests don't sleep.
+function immediateTimeout(callback, _ms, ...args) {
+  if (typeof callback === "function") callback(...args);
+  return 0;
+}
+
+const CREATE_URL = "https://api.x.ai/v1/videos/generations";
+const POLL_URL_PREFIX = "https://api.x.ai/v1/videos/";
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+test("VIDEO_PROVIDERS exposes the xai grok-imagine-video entry", () => {
+  assert.ok(VIDEO_PROVIDERS.xai, "xai video provider is registered");
+  assert.equal(VIDEO_PROVIDERS.xai.format, "xai-video");
+  assert.ok(
+    VIDEO_PROVIDERS.xai.models.some((m) => m.id === "grok-imagine-video"),
+    "grok-imagine-video is listed"
+  );
+});
+
+test("handleVideoGeneration creates + polls an xAI Grok Imagine video job and returns mp4 URL", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalSetTimeout = globalThis.setTimeout;
+  let createRequest;
+  let pollRequestCount = 0;
+
+  globalThis.setTimeout = immediateTimeout;
+  globalThis.fetch = async (url, options = {}) => {
+    const stringUrl = String(url);
+
+    if (stringUrl === CREATE_URL) {
+      createRequest = {
+        url: stringUrl,
+        headers: options.headers,
+        body: JSON.parse(String(options.body || "{}")),
+      };
+      return jsonResponse({ request_id: "xai-req-1", status: "pending" });
+    }
+
+    if (stringUrl === `${POLL_URL_PREFIX}xai-req-1`) {
+      pollRequestCount += 1;
+      if (pollRequestCount === 1) {
+        return jsonResponse({ request_id: "xai-req-1", status: "processing", progress: 40 });
+      }
+      return jsonResponse({
+        request_id: "xai-req-1",
+        status: "done",
+        progress: 100,
+        video: { url: "https://videos.x.ai/xai-req-1.mp4" },
+      });
+    }
+
+    throw new Error(`Unexpected URL: ${stringUrl}`);
+  };
+
+  try {
+    const result = await handleVideoGeneration({
+      body: {
+        model: "xai/grok-imagine-video",
+        prompt: "a cinematic tracking shot through a neon city at night",
+        duration: 6,
+      },
+      credentials: { apiKey: "xai-key" },
+      log: null,
+    });
+
+    // Create request shape
+    assert.equal(createRequest.headers["Authorization"], "Bearer xai-key");
+    assert.equal(createRequest.body.model, "grok-imagine-video");
+    assert.equal(
+      createRequest.body.prompt,
+      "a cinematic tracking shot through a neon city at night"
+    );
+    assert.equal(createRequest.body.duration, 6);
+
+    // Polled at least once past "processing" before terminal "done"
+    assert.ok(pollRequestCount >= 2);
+
+    // Response shape
+    assert.equal(result.success, true);
+    assert.equal(result.data.data[0].url, "https://videos.x.ai/xai-req-1.mp4");
+    assert.equal(result.data.data[0].format, "mp4");
+  } finally {
+    globalThis.fetch = originalFetch;
+    globalThis.setTimeout = originalSetTimeout;
+  }
+});
+
+test("handleVideoGeneration rejects xAI video requests without credentials", async () => {
+  const result = await handleVideoGeneration({
+    body: { model: "xai/grok-imagine-video", prompt: "x" },
+    credentials: null,
+    log: null,
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.status, 401);
+  assert.match(result.error, /xAI API key is required/);
+});
+
+test("handleVideoGeneration surfaces a 502 when xAI returns no request_id", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () =>
+    jsonResponse({ error: { message: "Invalid API key" } }, 401);
+
+  try {
+    const result = await handleVideoGeneration({
+      body: { model: "xai/grok-imagine-video", prompt: "x" },
+      credentials: { apiKey: "bad-key" },
+      log: null,
+    });
+
+    assert.equal(result.success, false);
+    assert.equal(result.status, 502);
+    assert.equal(result.error, "Invalid API key");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("handleVideoGeneration returns 502 when the xAI job status is failed", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalSetTimeout = globalThis.setTimeout;
+  globalThis.setTimeout = immediateTimeout;
+
+  globalThis.fetch = async (url) => {
+    const stringUrl = String(url);
+    if (stringUrl === CREATE_URL) {
+      return jsonResponse({ request_id: "xai-fail", status: "pending" });
+    }
+    if (stringUrl === `${POLL_URL_PREFIX}xai-fail`) {
+      return jsonResponse({
+        request_id: "xai-fail",
+        status: "failed",
+        error: "content policy violation",
+      });
+    }
+    throw new Error(`Unexpected URL: ${stringUrl}`);
+  };
+
+  try {
+    const result = await handleVideoGeneration({
+      body: { model: "xai/grok-imagine-video", prompt: "x" },
+      credentials: { apiKey: "xai-key" },
+      log: null,
+    });
+
+    assert.equal(result.success, false);
+    assert.equal(result.status, 502);
+    assert.equal(result.error, "content policy violation");
+  } finally {
+    globalThis.fetch = originalFetch;
+    globalThis.setTimeout = originalSetTimeout;
+  }
+});
+
+test("handleVideoGeneration returns 504 when the xAI job never completes", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalSetTimeout = globalThis.setTimeout;
+  const originalNow = Date.now;
+  globalThis.setTimeout = immediateTimeout;
+
+  let nowCalls = 0;
+  Date.now = () => {
+    nowCalls += 1;
+    return nowCalls === 1 ? 1000 : nowCalls === 2 ? 2000 : 1_000_000;
+  };
+
+  globalThis.fetch = async (url) => {
+    const stringUrl = String(url);
+    if (stringUrl === CREATE_URL) {
+      return jsonResponse({ request_id: "xai-stuck", status: "pending" });
+    }
+    if (stringUrl === `${POLL_URL_PREFIX}xai-stuck`) {
+      return jsonResponse({ request_id: "xai-stuck", status: "processing", progress: 10 });
+    }
+    throw new Error(`Unexpected URL: ${stringUrl}`);
+  };
+
+  try {
+    const result = await handleVideoGeneration({
+      body: {
+        model: "xai/grok-imagine-video",
+        prompt: "x",
+        timeout_ms: 5000,
+        poll_interval_ms: 100,
+      },
+      credentials: { apiKey: "xai-key" },
+      log: null,
+    });
+
+    assert.equal(result.success, false);
+    assert.equal(result.status, 504);
+    assert.match(result.error, /timed out/);
+  } finally {
+    globalThis.fetch = originalFetch;
+    globalThis.setTimeout = originalSetTimeout;
+    Date.now = originalNow;
+  }
+});
+
+test("handleVideoGeneration never leaks a stack trace in xAI video error responses", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => {
+    throw new Error("connect ECONNREFUSED 127.0.0.1:443\n    at TCPConnectWrap.afterConnect");
+  };
+
+  try {
+    const result = await handleVideoGeneration({
+      body: { model: "xai/grok-imagine-video", prompt: "x" },
+      credentials: { apiKey: "xai-key" },
+      log: null,
+    });
+
+    assert.equal(result.success, false);
+    assert.ok(!String(result.error).includes("at TCPConnectWrap"));
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
## Summary

- Registers `xai` as a first-class **video** provider so `xai/grok-imagine-video` works on `POST /v1/videos/generations` against the user's own xAI key.
- Previously Grok Imagine video was only reachable indirectly through the **kie** proxy market (`kie`'s `grok-imagine/text-to-video` models), which needs a separate kie.ai account and bills through kie. This talks to `api.x.ai/v1/videos` directly.
- Reuses the stored `xai` Bearer apiKey that the existing image-generation `xai` entry in `imageRegistry.ts` already uses — **no new credential flow, no new OAuth**.

## Attribution

Thanks to [@anndev-69](https://github.com/anndev-69) for the original implementation.

## Changes

- `open-sse/config/videoRegistry.ts` — new `xai` entry (`format: "xai-video"`, `baseUrl: https://api.x.ai/v1/videos`, model `grok-imagine-video`).
- `open-sse/handlers/videoGeneration.ts` — new `handleXaiVideoGeneration` create+poll handler wired into the existing format dispatch. Mirrors the DashScope create+poll shape, adapted to xAI's `request_id` / `status` (`pending`|`processing`|`done`|`failed`) job model. Errors route through `sanitizeErrorMessage()`.
- `tests/unit/video-xai-grok-imagine.test.ts` — 7 new unit tests (mocked `fetch`, no live xAI calls).

## Scope notes

This is a **deliberately narrow port** of the upstream change, scoped to OmniRoute's existing media architecture. Explicitly **not** ported:

- **`/v1/videos/edits` + `/v1/videos/extensions` routes** — OmniRoute's video surface is a single `POST /v1/videos/generations` endpoint across all 10 existing provider formats. Adding two xAI-only public routes would be provider-specific public API surface inconsistent with every other video provider; better proposed separately as a cross-provider surface.
- **`GET /v1/videos/{request_id}` polling route** — OmniRoute's handler contract is synchronous-to-the-client (create + poll internally, return the finished URL), same as DashScope/Runway/Haiper/Leonardo. A client-driven polling surface would be a new contract for the whole subsystem, not an xAI detail.
- **CLI surface** — no equivalent media-generation CLI surface exists in OmniRoute's `bin/`; nothing to extend.

## Test plan

- [x] targeted unit test (new, fails before / passes after)
- [x] `npm run typecheck:core` — clean
- [x] `npx eslint` on changed files — clean (the 1 remaining `no-explicit-any` in `videoGeneration.ts:472` is pre-existing on the base branch and already in `config/quality/eslint-suppressions.json`)

Failing-before (provider unregistered → `400 Unsupported video format`):

```
✖ handleVideoGeneration rejects xAI video requests without credentials    400 !== 401
✖ handleVideoGeneration surfaces a 502 when xAI returns no request_id     400 !== 502
✖ handleVideoGeneration returns 502 when the xAI job status is failed     400 !== 502
✖ handleVideoGeneration returns 504 when the xAI job never completes      400 !== 504
```

Passing-after:

```
✔ VIDEO_PROVIDERS exposes the xai grok-imagine-video entry
✔ handleVideoGeneration creates + polls an xAI Grok Imagine video job and returns mp4 URL
✔ handleVideoGeneration rejects xAI video requests without credentials
✔ handleVideoGeneration surfaces a 502 when xAI returns no request_id
✔ handleVideoGeneration returns 502 when the xAI job status is failed
✔ handleVideoGeneration returns 504 when the xAI job never completes
✔ handleVideoGeneration never leaks a stack trace in xAI video error responses
ℹ tests 7  ℹ pass 7  ℹ fail 0
```

## Honest limitation

The xAI `/v1/videos` wire shape follows the public docs (`request_id` / `status` / `video.url`). It is unit-tested against a mocked upstream, not a live xAI account — whether a given key carries Grok Imagine video quota is controlled by xAI and surfaces as the upstream error verbatim.
