### PR TITLE
feat: add Type filter and easiest-first sort to Free Provider Rankings (#6915)

### DIFF
--- a/changelog.d/features/6915-free-rankings-auth-type-filter.md
+++ b/changelog.d/features/6915-free-rankings-auth-type-filter.md
@@ -1,0 +1,1 @@
+- **feat(dashboard):** add a Type filter (No Signup / OAuth Login / API Key) and an "Easiest first" sort toggle to Free Provider Rankings, so zero-setup NOAUTH providers can be surfaced without eyeballing the Type column. (#6915)

--- a/src/app/(dashboard)/dashboard/free-provider-rankings/page.tsx
+++ b/src/app/(dashboard)/dashboard/free-provider-rankings/page.tsx
@@ -1,8 +1,13 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { useTranslations } from "next-intl";
 import { Card } from "@/shared/components";
+import {
+  filterRankingsByAuthType,
+  sortRankingsAuthTypeFirst,
+  type ProviderAuthType,
+} from "@/lib/freeProviderRankingsAuthType";
 
 interface ProviderModelScore {
   modelId: string;
@@ -19,7 +24,7 @@ interface FreeProviderRanking {
   icon: string;
   color: string;
   textIcon?: string;
-  category: "noauth" | "oauth" | "apikey";
+  category: ProviderAuthType;
   topModel: ProviderModelScore | null;
   averageScore: number;
   modelCount: number;
@@ -54,6 +59,13 @@ const CATEGORY_OPTIONS = [
   { value: "debugging", labelKey: "categoryDebugging" },
 ];
 
+const TYPE_OPTIONS: Array<{ value: ProviderAuthType | ""; labelKey: string }> = [
+  { value: "", labelKey: "typeAll" },
+  { value: "noauth", labelKey: "typeNoauth" },
+  { value: "oauth", labelKey: "typeOauth" },
+  { value: "apikey", labelKey: "typeApikey" },
+];
+
 export default function FreeProviderRankingsPage() {
   const t = useTranslations("freeProviderRankingsPage");
   const [rankings, setRankings] = useState<FreeProviderRanking[]>([]);
@@ -62,6 +74,8 @@ export default function FreeProviderRankingsPage() {
   const [filter, setFilter] = useState<string>("");
   const [configuredOnly, setConfiguredOnly] = useState(false);
   const [availableOnly, setAvailableOnly] = useState(false);
+  const [typeFilter, setTypeFilter] = useState<ProviderAuthType | "">("");
+  const [groupByType, setGroupByType] = useState(false);
 
   const fetchRankings = useCallback(
     async (category?: string, opts?: { configuredOnly?: boolean; availableOnly?: boolean }) => {
@@ -92,6 +106,13 @@ export default function FreeProviderRankingsPage() {
   useEffect(() => {
     fetchRankings(filter || undefined, { configuredOnly, availableOnly });
   }, [filter, configuredOnly, availableOnly, fetchRankings]);
+
+  // Client-side Type filter + "group by type" sort (#6915) — purely derived
+  // from the already-fetched `rankings`, never trigger a refetch.
+  const displayedRankings = useMemo(() => {
+    const filtered = filterRankingsByAuthType(rankings, typeFilter);
+    return groupByType ? sortRankingsAuthTypeFirst(filtered) : filtered;
+  }, [rankings, typeFilter, groupByType]);
 
   return (
     <div className="flex flex-col gap-6">
@@ -147,6 +168,37 @@ export default function FreeProviderRankingsPage() {
         </button>
       </div>
 
+      {/* Type filter chips + "group by type" sort (#6915) */}
+      <div className="flex items-center gap-2 flex-wrap">
+        {TYPE_OPTIONS.map((opt) => (
+          <button
+            key={opt.value || "all"}
+            onClick={() => setTypeFilter(opt.value)}
+            aria-pressed={typeFilter === opt.value}
+            className={`px-4 py-2 text-sm font-medium rounded-lg border transition-colors ${
+              typeFilter === opt.value
+                ? "bg-violet-500 border-violet-500 text-white"
+                : "border-border text-text-muted hover:text-text-main hover:border-violet-500/50"
+            }`}
+          >
+            {t(opt.labelKey)}
+          </button>
+        ))}
+        <button
+          onClick={() => setGroupByType((v) => !v)}
+          aria-pressed={groupByType}
+          title={t("sortTypeFirstHelp")}
+          className={`px-4 py-2 text-sm font-medium rounded-lg border transition-colors ${
+            groupByType
+              ? "bg-emerald-500 border-emerald-500 text-white"
+              : "border-border text-text-muted hover:text-text-main hover:border-emerald-500/50"
+          }`}
+        >
+          {t("sortTypeFirst")}
+        </button>
+      </div>
+      <p className="text-xs text-text-muted">{t("typeLegend")}</p>
+
       {error && <div className="p-3 rounded-lg bg-red-500/10 text-red-400 text-sm">{error}</div>}
 
       {loading ? (
@@ -156,9 +208,9 @@ export default function FreeProviderRankingsPage() {
       ) : (
         <>
           {/* Top 3 Podium */}
-          {rankings.length >= 3 && (
+          {displayedRankings.length >= 3 && (
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-              {rankings.slice(0, 3).map((provider, idx) => (
+              {displayedRankings.slice(0, 3).map((provider, idx) => (
                 <Card key={provider.id} className="relative overflow-hidden">
                   <div
                     className={`absolute top-0 left-0 right-0 h-1 ${
@@ -202,7 +254,7 @@ export default function FreeProviderRankingsPage() {
           )}
 
           {/* Full List */}
-          {rankings.length > 0 && (
+          {displayedRankings.length > 0 && (
             <Card>
               <div className="overflow-x-auto">
                 <table className="w-full">
@@ -214,11 +266,13 @@ export default function FreeProviderRankingsPage() {
                       <th className="pb-3 font-medium text-right">{t("colScore")}</th>
                       <th className="pb-3 font-medium text-right">{t("colAvgScore")}</th>
                       <th className="pb-3 font-medium text-right">{t("colModels")}</th>
-                      <th className="pb-3 font-medium text-right">{t("colType")}</th>
+                      <th className="pb-3 font-medium text-right" title={t("typeLegend")}>
+                        {t("colType")}
+                      </th>
                     </tr>
                   </thead>
                   <tbody>
-                    {rankings.map((provider, idx) => (
+                    {displayedRankings.map((provider, idx) => (
                       <tr key={provider.id} className="border-b border-border/50 last:border-b-0">
                         <td className="py-3 text-text-muted font-mono">{idx + 1}</td>
                         <td className="py-3">
@@ -271,7 +325,7 @@ export default function FreeProviderRankingsPage() {
             </Card>
           )}
 
-          {rankings.length === 0 && !error && (
+          {displayedRankings.length === 0 && !error && (
             <Card>
               <div className="text-center py-12 text-text-muted">{t("emptyState")}</div>
             </Card>

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -7614,5 +7614,14 @@
     "enabled": "Enabled",
     "disabled": "Disabled",
     "hooks": "Hooks"
+  },
+  "freeProviderRankingsPage": {
+    "typeAll": "__MISSING__:All Types",
+    "typeNoauth": "__MISSING__:No Signup",
+    "typeOauth": "__MISSING__:OAuth Login",
+    "typeApikey": "__MISSING__:API Key",
+    "sortTypeFirst": "__MISSING__:Easiest first",
+    "sortTypeFirstHelp": "__MISSING__:Group by signup effort (No Signup → OAuth Login → API Key), keeping quality order within each group",
+    "typeLegend": "__MISSING__:No Signup = zero setup · OAuth Login = sign in with your own account · API Key = bring your own key or that provider's free tier"
   }
 }

--- a/src/i18n/messages/az.json
+++ b/src/i18n/messages/az.json
@@ -7614,5 +7614,14 @@
     "enabled": "Enabled",
     "disabled": "Disabled",
     "hooks": "Hooks"
+  },
+  "freeProviderRankingsPage": {
+    "typeAll": "__MISSING__:All Types",
+    "typeNoauth": "__MISSING__:No Signup",
+    "typeOauth": "__MISSING__:OAuth Login",
+    "typeApikey": "__MISSING__:API Key",
+    "sortTypeFirst": "__MISSING__:Easiest first",
+    "sortTypeFirstHelp": "__MISSING__:Group by signup effort (No Signup → OAuth Login → API Key), keeping quality order within each group",
+    "typeLegend": "__MISSING__:No Signup = zero setup · OAuth Login = sign in with your own account · API Key = bring your own key or that provider's free tier"
   }
 }

--- a/src/i18n/messages/bg.json
+++ b/src/i18n/messages/bg.json
@@ -7614,5 +7614,14 @@
     "enabled": "Enabled",
     "disabled": "Disabled",
     "hooks": "Hooks"
+  },
+  "freeProviderRankingsPage": {
+    "typeAll": "__MISSING__:All Types",
+    "typeNoauth": "__MISSING__:No Signup",
+    "typeOauth": "__MISSING__:OAuth Login",
+    "typeApikey": "__MISSING__:API Key",
+    "sortTypeFirst": "__MISSING__:Easiest first",
+    "sortTypeFirstHelp": "__MISSING__:Group by signup effort (No Signup → OAuth Login → API Key), keeping quality order within each group",
+    "typeLegend": "__MISSING__:No Signup = zero setup · OAuth Login = sign in with your own account · API Key = bring your own key or that provider's free tier"
   }
 }

--- a/src/i18n/messages/bn.json
+++ b/src/i18n/messages/bn.json
@@ -7614,5 +7614,14 @@
     "enabled": "Enabled",
     "disabled": "Disabled",
     "hooks": "Hooks"
+  },
+  "freeProviderRankingsPage": {
+    "typeAll": "__MISSING__:All Types",
+    "typeNoauth": "__MISSING__:No Signup",
+    "typeOauth": "__MISSING__:OAuth Login",
+    "typeApikey": "__MISSING__:API Key",
+    "sortTypeFirst": "__MISSING__:Easiest first",
+    "sortTypeFirstHelp": "__MISSING__:Group by signup effort (No Signup → OAuth Login → API Key), keeping quality order within each group",
+    "typeLegend": "__MISSING__:No Signup = zero setup · OAuth Login = sign in with your own account · API Key = bring your own key or that provider's free tier"
   }
 }

--- a/src/i18n/messages/cs.json
+++ b/src/i18n/messages/cs.json
@@ -7614,5 +7614,14 @@
     "enabled": "Enabled",
     "disabled": "Disabled",
     "hooks": "Hooks"
+  },
+  "freeProviderRankingsPage": {
+    "typeAll": "__MISSING__:All Types",
+    "typeNoauth": "__MISSING__:No Signup",
+    "typeOauth": "__MISSING__:OAuth Login",
+    "typeApikey": "__MISSING__:API Key",
+    "sortTypeFirst": "__MISSING__:Easiest first",
+    "sortTypeFirstHelp": "__MISSING__:Group by signup effort (No Signup → OAuth Login → API Key), keeping quality order within each group",
+    "typeLegend": "__MISSING__:No Signup = zero setup · OAuth Login = sign in with your own account · API Key = bring your own key or that provider's free tier"
   }
 }

--- a/src/i18n/messages/da.json
+++ b/src/i18n/messages/da.json
@@ -7614,5 +7614,14 @@
     "enabled": "Enabled",
     "disabled": "Disabled",
     "hooks": "Hooks"
+  },
+  "freeProviderRankingsPage": {
+    "typeAll": "__MISSING__:All Types",
+    "typeNoauth": "__MISSING__:No Signup",
+    "typeOauth": "__MISSING__:OAuth Login",
+    "typeApikey": "__MISSING__:API Key",
+    "sortTypeFirst": "__MISSING__:Easiest first",
+    "sortTypeFirstHelp": "__MISSING__:Group by signup effort (No Signup → OAuth Login → API Key), keeping quality order within each group",
+    "typeLegend": "__MISSING__:No Signup = zero setup · OAuth Login = sign in with your own account · API Key = bring your own key or that provider's free tier"
   }
 }

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -7632,5 +7632,14 @@
     "enabled": "Enabled",
     "disabled": "Disabled",
     "hooks": "Hooks"
+  },
+  "freeProviderRankingsPage": {
+    "typeAll": "__MISSING__:All Types",
+    "typeNoauth": "__MISSING__:No Signup",
+    "typeOauth": "__MISSING__:OAuth Login",
+    "typeApikey": "__MISSING__:API Key",
+    "sortTypeFirst": "__MISSING__:Easiest first",
+    "sortTypeFirstHelp": "__MISSING__:Group by signup effort (No Signup → OAuth Login → API Key), keeping quality order within each group",
+    "typeLegend": "__MISSING__:No Signup = zero setup · OAuth Login = sign in with your own account · API Key = bring your own key or that provider's free tier"
   }
 }

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -9162,7 +9162,14 @@
     "configuredOnly": "Configured Only",
     "configuredOnlyHint": "Show only providers with active connections",
     "noConfiguredProviders": "No configured providers found. Add a provider connection first.",
-    "colConfigured": "Status"
+    "colConfigured": "Status",
+    "typeAll": "All Types",
+    "typeNoauth": "No Signup",
+    "typeOauth": "OAuth Login",
+    "typeApikey": "API Key",
+    "sortTypeFirst": "Easiest first",
+    "sortTypeFirstHelp": "Group by signup effort (No Signup → OAuth Login → API Key), keeping quality order within each group",
+    "typeLegend": "No Signup = zero setup · OAuth Login = sign in with your own account · API Key = bring your own key or that provider's free tier"
   },
   "discovery": {
     "title": "Provider Discovery",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -7614,5 +7614,14 @@
     "enabled": "Enabled",
     "disabled": "Disabled",
     "hooks": "Hooks"
+  },
+  "freeProviderRankingsPage": {
+    "typeAll": "__MISSING__:All Types",
+    "typeNoauth": "__MISSING__:No Signup",
+    "typeOauth": "__MISSING__:OAuth Login",
+    "typeApikey": "__MISSING__:API Key",
+    "sortTypeFirst": "__MISSING__:Easiest first",
+    "sortTypeFirstHelp": "__MISSING__:Group by signup effort (No Signup → OAuth Login → API Key), keeping quality order within each group",
+    "typeLegend": "__MISSING__:No Signup = zero setup · OAuth Login = sign in with your own account · API Key = bring your own key or that provider's free tier"
   }
 }

--- a/src/i18n/messages/fa.json
+++ b/src/i18n/messages/fa.json
@@ -7614,5 +7614,14 @@
     "enabled": "Enabled",
     "disabled": "Disabled",
     "hooks": "Hooks"
+  },
+  "freeProviderRankingsPage": {
+    "typeAll": "__MISSING__:All Types",
+    "typeNoauth": "__MISSING__:No Signup",
+    "typeOauth": "__MISSING__:OAuth Login",
+    "typeApikey": "__MISSING__:API Key",
+    "sortTypeFirst": "__MISSING__:Easiest first",
+    "sortTypeFirstHelp": "__MISSING__:Group by signup effort (No Signup → OAuth Login → API Key), keeping quality order within each group",
+    "typeLegend": "__MISSING__:No Signup = zero setup · OAuth Login = sign in with your own account · API Key = bring your own key or that provider's free tier"
   }
 }

--- a/src/i18n/messages/fi.json
+++ b/src/i18n/messages/fi.json
@@ -7614,5 +7614,14 @@
     "enabled": "Enabled",
     "disabled": "Disabled",
     "hooks": "Hooks"
+  },
+  "freeProviderRankingsPage": {
+    "typeAll": "__MISSING__:All Types",
+    "typeNoauth": "__MISSING__:No Signup",
+    "typeOauth": "__MISSING__:OAuth Login",
+    "typeApikey": "__MISSING__:API Key",
+    "sortTypeFirst": "__MISSING__:Easiest first",
+    "sortTypeFirstHelp": "__MISSING__:Group by signup effort (No Signup → OAuth Login → API Key), keeping quality order within each group",
+    "typeLegend": "__MISSING__:No Signup = zero setup · OAuth Login = sign in with your own account · API Key = bring your own key or that provider's free tier"
   }
 }

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -7614,5 +7614,14 @@
     "enabled": "Enabled",
     "disabled": "Disabled",
     "hooks": "Hooks"
+  },
+  "freeProviderRankingsPage": {
+    "typeAll": "__MISSING__:All Types",
+    "typeNoauth": "__MISSING__:No Signup",
+    "typeOauth": "__MISSING__:OAuth Login",
+    "typeApikey": "__MISSING__:API Key",
+    "sortTypeFirst": "__MISSING__:Easiest first",
+    "sortTypeFirstHelp": "__MISSING__:Group by signup effort (No Signup → OAuth Login → API Key), keeping quality order within each group",
+    "typeLegend": "__MISSING__:No Signup = zero setup · OAuth Login = sign in with your own account · API Key = bring your own key or that provider's free tier"
   }
 }

--- a/src/i18n/messages/gu.json
+++ b/src/i18n/messages/gu.json
@@ -7614,5 +7614,14 @@
     "enabled": "Enabled",
     "disabled": "Disabled",
     "hooks": "Hooks"
+  },
+  "freeProviderRankingsPage": {
+    "typeAll": "__MISSING__:All Types",
+    "typeNoauth": "__MISSING__:No Signup",
+    "typeOauth": "__MISSING__:OAuth Login",
+    "typeApikey": "__MISSING__:API Key",
+    "sortTypeFirst": "__MISSING__:Easiest first",
+    "sortTypeFirstHelp": "__MISSING__:Group by signup effort (No Signup → OAuth Login → API Key), keeping quality order within each group",
+    "typeLegend": "__MISSING__:No Signup = zero setup · OAuth Login = sign in with your own account · API Key = bring your own key or that provider's free tier"
   }
 }

--- a/src/i18n/messages/he.json
+++ b/src/i18n/messages/he.json
@@ -7614,5 +7614,14 @@
     "enabled": "Enabled",
     "disabled": "Disabled",
     "hooks": "Hooks"
+  },
+  "freeProviderRankingsPage": {
+    "typeAll": "__MISSING__:All Types",
+    "typeNoauth": "__MISSING__:No Signup",
+    "typeOauth": "__MISSING__:OAuth Login",
+    "typeApikey": "__MISSING__:API Key",
+    "sortTypeFirst": "__MISSING__:Easiest first",
+    "sortTypeFirstHelp": "__MISSING__:Group by signup effort (No Signup → OAuth Login → API Key), keeping quality order within each group",
+    "typeLegend": "__MISSING__:No Signup = zero setup · OAuth Login = sign in with your own account · API Key = bring your own key or that provider's free tier"
   }
 }

--- a/src/i18n/messages/hi.json
+++ b/src/i18n/messages/hi.json
@@ -7614,5 +7614,14 @@
     "enabled": "Enabled",
     "disabled": "Disabled",
     "hooks": "Hooks"
+  },
+  "freeProviderRankingsPage": {
+    "typeAll": "__MISSING__:All Types",
+    "typeNoauth": "__MISSING__:No Signup",
+    "typeOauth": "__MISSING__:OAuth Login",
+    "typeApikey": "__MISSING__:API Key",
+    "sortTypeFirst": "__MISSING__:Easiest first",
+    "sortTypeFirstHelp": "__MISSING__:Group by signup effort (No Signup → OAuth Login → API Key), keeping quality order within each group",
+    "typeLegend": "__MISSING__:No Signup = zero setup · OAuth Login = sign in with your own account · API Key = bring your own key or that provider's free tier"
   }
 }

--- a/src/i18n/messages/hu.json
+++ b/src/i18n/messages/hu.json
@@ -7614,5 +7614,14 @@
     "enabled": "Enabled",
     "disabled": "Disabled",
     "hooks": "Hooks"
+  },
+  "freeProviderRankingsPage": {
+    "typeAll": "__MISSING__:All Types",
+    "typeNoauth": "__MISSING__:No Signup",
+    "typeOauth": "__MISSING__:OAuth Login",
+    "typeApikey": "__MISSING__:API Key",
+    "sortTypeFirst": "__MISSING__:Easiest first",
+    "sortTypeFirstHelp": "__MISSING__:Group by signup effort (No Signup → OAuth Login → API Key), keeping quality order within each group",
+    "typeLegend": "__MISSING__:No Signup = zero setup · OAuth Login = sign in with your own account · API Key = bring your own key or that provider's free tier"
   }
 }

--- a/src/i18n/messages/id.json
+++ b/src/i18n/messages/id.json
@@ -7614,5 +7614,14 @@
     "enabled": "Enabled",
     "disabled": "Disabled",
     "hooks": "Hooks"
+  },
+  "freeProviderRankingsPage": {
+    "typeAll": "__MISSING__:All Types",
+    "typeNoauth": "__MISSING__:No Signup",
+    "typeOauth": "__MISSING__:OAuth Login",
+    "typeApikey": "__MISSING__:API Key",
+    "sortTypeFirst": "__MISSING__:Easiest first",
+    "sortTypeFirstHelp": "__MISSING__:Group by signup effort (No Signup → OAuth Login → API Key), keeping quality order within each group",
+    "typeLegend": "__MISSING__:No Signup = zero setup · OAuth Login = sign in with your own account · API Key = bring your own key or that provider's free tier"
   }
 }

--- a/src/i18n/messages/in.json
+++ b/src/i18n/messages/in.json
@@ -7614,5 +7614,14 @@
     "enabled": "Enabled",
     "disabled": "Disabled",
     "hooks": "Hooks"
+  },
+  "freeProviderRankingsPage": {
+    "typeAll": "__MISSING__:All Types",
+    "typeNoauth": "__MISSING__:No Signup",
+    "typeOauth": "__MISSING__:OAuth Login",
+    "typeApikey": "__MISSING__:API Key",
+    "sortTypeFirst": "__MISSING__:Easiest first",
+    "sortTypeFirstHelp": "__MISSING__:Group by signup effort (No Signup → OAuth Login → API Key), keeping quality order within each group",
+    "typeLegend": "__MISSING__:No Signup = zero setup · OAuth Login = sign in with your own account · API Key = bring your own key or that provider's free tier"
   }
 }

--- a/src/i18n/messages/it.json
+++ b/src/i18n/messages/it.json
@@ -9036,7 +9036,14 @@
     "colScore": "__MISSING__:Score",
     "colAvgScore": "__MISSING__:Avg Score",
     "colModels": "__MISSING__:Models",
-    "colType": "__MISSING__:Type"
+    "colType": "__MISSING__:Type",
+    "typeAll": "__MISSING__:All Types",
+    "typeNoauth": "__MISSING__:No Signup",
+    "typeOauth": "__MISSING__:OAuth Login",
+    "typeApikey": "__MISSING__:API Key",
+    "sortTypeFirst": "__MISSING__:Easiest first",
+    "sortTypeFirstHelp": "__MISSING__:Group by signup effort (No Signup → OAuth Login → API Key), keeping quality order within each group",
+    "typeLegend": "__MISSING__:No Signup = zero setup · OAuth Login = sign in with your own account · API Key = bring your own key or that provider's free tier"
   },
   "disabled": "Disabilitato",
   "discovery": {

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -8938,6 +8938,13 @@
     "colScore": "__MISSING__:Score",
     "colAvgScore": "__MISSING__:Avg Score",
     "colModels": "__MISSING__:Models",
-    "colType": "__MISSING__:Type"
+    "colType": "__MISSING__:Type",
+    "typeAll": "__MISSING__:All Types",
+    "typeNoauth": "__MISSING__:No Signup",
+    "typeOauth": "__MISSING__:OAuth Login",
+    "typeApikey": "__MISSING__:API Key",
+    "sortTypeFirst": "__MISSING__:Easiest first",
+    "sortTypeFirstHelp": "__MISSING__:Group by signup effort (No Signup → OAuth Login → API Key), keeping quality order within each group",
+    "typeLegend": "__MISSING__:No Signup = zero setup · OAuth Login = sign in with your own account · API Key = bring your own key or that provider's free tier"
   }
 }

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -8938,6 +8938,13 @@
     "colScore": "__MISSING__:Score",
     "colAvgScore": "__MISSING__:Avg Score",
     "colModels": "__MISSING__:Models",
-    "colType": "__MISSING__:Type"
+    "colType": "__MISSING__:Type",
+    "typeAll": "__MISSING__:All Types",
+    "typeNoauth": "__MISSING__:No Signup",
+    "typeOauth": "__MISSING__:OAuth Login",
+    "typeApikey": "__MISSING__:API Key",
+    "sortTypeFirst": "__MISSING__:Easiest first",
+    "sortTypeFirstHelp": "__MISSING__:Group by signup effort (No Signup → OAuth Login → API Key), keeping quality order within each group",
+    "typeLegend": "__MISSING__:No Signup = zero setup · OAuth Login = sign in with your own account · API Key = bring your own key or that provider's free tier"
   }
 }

--- a/src/i18n/messages/mr.json
+++ b/src/i18n/messages/mr.json
@@ -8938,6 +8938,13 @@
     "colScore": "__MISSING__:Score",
     "colAvgScore": "__MISSING__:Avg Score",
     "colModels": "__MISSING__:Models",
-    "colType": "__MISSING__:Type"
+    "colType": "__MISSING__:Type",
+    "typeAll": "__MISSING__:All Types",
+    "typeNoauth": "__MISSING__:No Signup",
+    "typeOauth": "__MISSING__:OAuth Login",
+    "typeApikey": "__MISSING__:API Key",
+    "sortTypeFirst": "__MISSING__:Easiest first",
+    "sortTypeFirstHelp": "__MISSING__:Group by signup effort (No Signup → OAuth Login → API Key), keeping quality order within each group",
+    "typeLegend": "__MISSING__:No Signup = zero setup · OAuth Login = sign in with your own account · API Key = bring your own key or that provider's free tier"
   }
 }

--- a/src/i18n/messages/ms.json
+++ b/src/i18n/messages/ms.json
@@ -8938,6 +8938,13 @@
     "colScore": "__MISSING__:Score",
     "colAvgScore": "__MISSING__:Avg Score",
     "colModels": "__MISSING__:Models",
-    "colType": "__MISSING__:Type"
+    "colType": "__MISSING__:Type",
+    "typeAll": "__MISSING__:All Types",
+    "typeNoauth": "__MISSING__:No Signup",
+    "typeOauth": "__MISSING__:OAuth Login",
+    "typeApikey": "__MISSING__:API Key",
+    "sortTypeFirst": "__MISSING__:Easiest first",
+    "sortTypeFirstHelp": "__MISSING__:Group by signup effort (No Signup → OAuth Login → API Key), keeping quality order within each group",
+    "typeLegend": "__MISSING__:No Signup = zero setup · OAuth Login = sign in with your own account · API Key = bring your own key or that provider's free tier"
   }
 }

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -8938,6 +8938,13 @@
     "colScore": "__MISSING__:Score",
     "colAvgScore": "__MISSING__:Avg Score",
     "colModels": "__MISSING__:Models",
-    "colType": "__MISSING__:Type"
+    "colType": "__MISSING__:Type",
+    "typeAll": "__MISSING__:All Types",
+    "typeNoauth": "__MISSING__:No Signup",
+    "typeOauth": "__MISSING__:OAuth Login",
+    "typeApikey": "__MISSING__:API Key",
+    "sortTypeFirst": "__MISSING__:Easiest first",
+    "sortTypeFirstHelp": "__MISSING__:Group by signup effort (No Signup → OAuth Login → API Key), keeping quality order within each group",
+    "typeLegend": "__MISSING__:No Signup = zero setup · OAuth Login = sign in with your own account · API Key = bring your own key or that provider's free tier"
   }
 }

--- a/src/i18n/messages/no.json
+++ b/src/i18n/messages/no.json
@@ -8938,6 +8938,13 @@
     "colScore": "__MISSING__:Score",
     "colAvgScore": "__MISSING__:Avg Score",
     "colModels": "__MISSING__:Models",
-    "colType": "__MISSING__:Type"
+    "colType": "__MISSING__:Type",
+    "typeAll": "__MISSING__:All Types",
+    "typeNoauth": "__MISSING__:No Signup",
+    "typeOauth": "__MISSING__:OAuth Login",
+    "typeApikey": "__MISSING__:API Key",
+    "sortTypeFirst": "__MISSING__:Easiest first",
+    "sortTypeFirstHelp": "__MISSING__:Group by signup effort (No Signup → OAuth Login → API Key), keeping quality order within each group",
+    "typeLegend": "__MISSING__:No Signup = zero setup · OAuth Login = sign in with your own account · API Key = bring your own key or that provider's free tier"
   }
 }

--- a/src/i18n/messages/phi.json
+++ b/src/i18n/messages/phi.json
@@ -8938,6 +8938,13 @@
     "colScore": "__MISSING__:Score",
     "colAvgScore": "__MISSING__:Avg Score",
     "colModels": "__MISSING__:Models",
-    "colType": "__MISSING__:Type"
+    "colType": "__MISSING__:Type",
+    "typeAll": "__MISSING__:All Types",
+    "typeNoauth": "__MISSING__:No Signup",
+    "typeOauth": "__MISSING__:OAuth Login",
+    "typeApikey": "__MISSING__:API Key",
+    "sortTypeFirst": "__MISSING__:Easiest first",
+    "sortTypeFirstHelp": "__MISSING__:Group by signup effort (No Signup → OAuth Login → API Key), keeping quality order within each group",
+    "typeLegend": "__MISSING__:No Signup = zero setup · OAuth Login = sign in with your own account · API Key = bring your own key or that provider's free tier"
   }
 }

--- a/src/i18n/messages/pl.json
+++ b/src/i18n/messages/pl.json
@@ -8938,6 +8938,13 @@
     "colScore": "__MISSING__:Score",
     "colAvgScore": "__MISSING__:Avg Score",
     "colModels": "__MISSING__:Models",
-    "colType": "__MISSING__:Type"
+    "colType": "__MISSING__:Type",
+    "typeAll": "__MISSING__:All Types",
+    "typeNoauth": "__MISSING__:No Signup",
+    "typeOauth": "__MISSING__:OAuth Login",
+    "typeApikey": "__MISSING__:API Key",
+    "sortTypeFirst": "__MISSING__:Easiest first",
+    "sortTypeFirstHelp": "__MISSING__:Group by signup effort (No Signup → OAuth Login → API Key), keeping quality order within each group",
+    "typeLegend": "__MISSING__:No Signup = zero setup · OAuth Login = sign in with your own account · API Key = bring your own key or that provider's free tier"
   }
 }

--- a/src/i18n/messages/pt-BR.json
+++ b/src/i18n/messages/pt-BR.json
@@ -9162,7 +9162,14 @@
     "configuredOnly": "Somente configurados",
     "configuredOnlyHint": "Mostrar apenas provedores com conexões ativas",
     "noConfiguredProviders": "Nenhum provedor configurado encontrado. Adicione uma conexão de provedor primeiro.",
-    "colConfigured": "Status"
+    "colConfigured": "Status",
+    "typeAll": "__MISSING__:All Types",
+    "typeNoauth": "__MISSING__:No Signup",
+    "typeOauth": "__MISSING__:OAuth Login",
+    "typeApikey": "__MISSING__:API Key",
+    "sortTypeFirst": "__MISSING__:Easiest first",
+    "sortTypeFirstHelp": "__MISSING__:Group by signup effort (No Signup → OAuth Login → API Key), keeping quality order within each group",
+    "typeLegend": "__MISSING__:No Signup = zero setup · OAuth Login = sign in with your own account · API Key = bring your own key or that provider's free tier"
   },
   "discovery": {
     "title": "Descoberta de provedores",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -8938,6 +8938,13 @@
     "colScore": "__MISSING__:Score",
     "colAvgScore": "__MISSING__:Avg Score",
     "colModels": "__MISSING__:Models",
-    "colType": "__MISSING__:Type"
+    "colType": "__MISSING__:Type",
+    "typeAll": "__MISSING__:All Types",
+    "typeNoauth": "__MISSING__:No Signup",
+    "typeOauth": "__MISSING__:OAuth Login",
+    "typeApikey": "__MISSING__:API Key",
+    "sortTypeFirst": "__MISSING__:Easiest first",
+    "sortTypeFirstHelp": "__MISSING__:Group by signup effort (No Signup → OAuth Login → API Key), keeping quality order within each group",
+    "typeLegend": "__MISSING__:No Signup = zero setup · OAuth Login = sign in with your own account · API Key = bring your own key or that provider's free tier"
   }
 }

--- a/src/i18n/messages/ro.json
+++ b/src/i18n/messages/ro.json
@@ -8938,6 +8938,13 @@
     "colScore": "__MISSING__:Score",
     "colAvgScore": "__MISSING__:Avg Score",
     "colModels": "__MISSING__:Models",
-    "colType": "__MISSING__:Type"
+    "colType": "__MISSING__:Type",
+    "typeAll": "__MISSING__:All Types",
+    "typeNoauth": "__MISSING__:No Signup",
+    "typeOauth": "__MISSING__:OAuth Login",
+    "typeApikey": "__MISSING__:API Key",
+    "sortTypeFirst": "__MISSING__:Easiest first",
+    "sortTypeFirstHelp": "__MISSING__:Group by signup effort (No Signup → OAuth Login → API Key), keeping quality order within each group",
+    "typeLegend": "__MISSING__:No Signup = zero setup · OAuth Login = sign in with your own account · API Key = bring your own key or that provider's free tier"
   }
 }

--- a/src/i18n/messages/ru.json
+++ b/src/i18n/messages/ru.json
@@ -8938,6 +8938,13 @@
     "colScore": "__MISSING__:Score",
     "colAvgScore": "__MISSING__:Avg Score",
     "colModels": "__MISSING__:Models",
-    "colType": "__MISSING__:Type"
+    "colType": "__MISSING__:Type",
+    "typeAll": "__MISSING__:All Types",
+    "typeNoauth": "__MISSING__:No Signup",
+    "typeOauth": "__MISSING__:OAuth Login",
+    "typeApikey": "__MISSING__:API Key",
+    "sortTypeFirst": "__MISSING__:Easiest first",
+    "sortTypeFirstHelp": "__MISSING__:Group by signup effort (No Signup → OAuth Login → API Key), keeping quality order within each group",
+    "typeLegend": "__MISSING__:No Signup = zero setup · OAuth Login = sign in with your own account · API Key = bring your own key or that provider's free tier"
   }
 }

--- a/src/i18n/messages/sk.json
+++ b/src/i18n/messages/sk.json
@@ -8938,6 +8938,13 @@
     "colScore": "__MISSING__:Score",
     "colAvgScore": "__MISSING__:Avg Score",
     "colModels": "__MISSING__:Models",
-    "colType": "__MISSING__:Type"
+    "colType": "__MISSING__:Type",
+    "typeAll": "__MISSING__:All Types",
+    "typeNoauth": "__MISSING__:No Signup",
+    "typeOauth": "__MISSING__:OAuth Login",
+    "typeApikey": "__MISSING__:API Key",
+    "sortTypeFirst": "__MISSING__:Easiest first",
+    "sortTypeFirstHelp": "__MISSING__:Group by signup effort (No Signup → OAuth Login → API Key), keeping quality order within each group",
+    "typeLegend": "__MISSING__:No Signup = zero setup · OAuth Login = sign in with your own account · API Key = bring your own key or that provider's free tier"
   }
 }

--- a/src/i18n/messages/sv.json
+++ b/src/i18n/messages/sv.json
@@ -8938,6 +8938,13 @@
     "colScore": "__MISSING__:Score",
     "colAvgScore": "__MISSING__:Avg Score",
     "colModels": "__MISSING__:Models",
-    "colType": "__MISSING__:Type"
+    "colType": "__MISSING__:Type",
+    "typeAll": "__MISSING__:All Types",
+    "typeNoauth": "__MISSING__:No Signup",
+    "typeOauth": "__MISSING__:OAuth Login",
+    "typeApikey": "__MISSING__:API Key",
+    "sortTypeFirst": "__MISSING__:Easiest first",
+    "sortTypeFirstHelp": "__MISSING__:Group by signup effort (No Signup → OAuth Login → API Key), keeping quality order within each group",
+    "typeLegend": "__MISSING__:No Signup = zero setup · OAuth Login = sign in with your own account · API Key = bring your own key or that provider's free tier"
   }
 }

--- a/src/i18n/messages/sw.json
+++ b/src/i18n/messages/sw.json
@@ -7614,5 +7614,14 @@
     "enabled": "Enabled",
     "disabled": "Disabled",
     "hooks": "Hooks"
+  },
+  "freeProviderRankingsPage": {
+    "typeAll": "__MISSING__:All Types",
+    "typeNoauth": "__MISSING__:No Signup",
+    "typeOauth": "__MISSING__:OAuth Login",
+    "typeApikey": "__MISSING__:API Key",
+    "sortTypeFirst": "__MISSING__:Easiest first",
+    "sortTypeFirstHelp": "__MISSING__:Group by signup effort (No Signup → OAuth Login → API Key), keeping quality order within each group",
+    "typeLegend": "__MISSING__:No Signup = zero setup · OAuth Login = sign in with your own account · API Key = bring your own key or that provider's free tier"
   }
 }

--- a/src/i18n/messages/ta.json
+++ b/src/i18n/messages/ta.json
@@ -7614,5 +7614,14 @@
     "enabled": "Enabled",
     "disabled": "Disabled",
     "hooks": "Hooks"
+  },
+  "freeProviderRankingsPage": {
+    "typeAll": "__MISSING__:All Types",
+    "typeNoauth": "__MISSING__:No Signup",
+    "typeOauth": "__MISSING__:OAuth Login",
+    "typeApikey": "__MISSING__:API Key",
+    "sortTypeFirst": "__MISSING__:Easiest first",
+    "sortTypeFirstHelp": "__MISSING__:Group by signup effort (No Signup → OAuth Login → API Key), keeping quality order within each group",
+    "typeLegend": "__MISSING__:No Signup = zero setup · OAuth Login = sign in with your own account · API Key = bring your own key or that provider's free tier"
   }
 }

--- a/src/i18n/messages/te.json
+++ b/src/i18n/messages/te.json
@@ -7614,5 +7614,14 @@
     "enabled": "Enabled",
     "disabled": "Disabled",
     "hooks": "Hooks"
+  },
+  "freeProviderRankingsPage": {
+    "typeAll": "__MISSING__:All Types",
+    "typeNoauth": "__MISSING__:No Signup",
+    "typeOauth": "__MISSING__:OAuth Login",
+    "typeApikey": "__MISSING__:API Key",
+    "sortTypeFirst": "__MISSING__:Easiest first",
+    "sortTypeFirstHelp": "__MISSING__:Group by signup effort (No Signup → OAuth Login → API Key), keeping quality order within each group",
+    "typeLegend": "__MISSING__:No Signup = zero setup · OAuth Login = sign in with your own account · API Key = bring your own key or that provider's free tier"
   }
 }

--- a/src/i18n/messages/th.json
+++ b/src/i18n/messages/th.json
@@ -7614,5 +7614,14 @@
     "enabled": "Enabled",
     "disabled": "Disabled",
     "hooks": "Hooks"
+  },
+  "freeProviderRankingsPage": {
+    "typeAll": "__MISSING__:All Types",
+    "typeNoauth": "__MISSING__:No Signup",
+    "typeOauth": "__MISSING__:OAuth Login",
+    "typeApikey": "__MISSING__:API Key",
+    "sortTypeFirst": "__MISSING__:Easiest first",
+    "sortTypeFirstHelp": "__MISSING__:Group by signup effort (No Signup → OAuth Login → API Key), keeping quality order within each group",
+    "typeLegend": "__MISSING__:No Signup = zero setup · OAuth Login = sign in with your own account · API Key = bring your own key or that provider's free tier"
   }
 }

--- a/src/i18n/messages/tr.json
+++ b/src/i18n/messages/tr.json
@@ -7614,5 +7614,14 @@
     "enabled": "Enabled",
     "disabled": "Disabled",
     "hooks": "Hooks"
+  },
+  "freeProviderRankingsPage": {
+    "typeAll": "__MISSING__:All Types",
+    "typeNoauth": "__MISSING__:No Signup",
+    "typeOauth": "__MISSING__:OAuth Login",
+    "typeApikey": "__MISSING__:API Key",
+    "sortTypeFirst": "__MISSING__:Easiest first",
+    "sortTypeFirstHelp": "__MISSING__:Group by signup effort (No Signup → OAuth Login → API Key), keeping quality order within each group",
+    "typeLegend": "__MISSING__:No Signup = zero setup · OAuth Login = sign in with your own account · API Key = bring your own key or that provider's free tier"
   }
 }

--- a/src/i18n/messages/uk-UA.json
+++ b/src/i18n/messages/uk-UA.json
@@ -7614,5 +7614,14 @@
     "enabled": "Enabled",
     "disabled": "Disabled",
     "hooks": "Hooks"
+  },
+  "freeProviderRankingsPage": {
+    "typeAll": "__MISSING__:All Types",
+    "typeNoauth": "__MISSING__:No Signup",
+    "typeOauth": "__MISSING__:OAuth Login",
+    "typeApikey": "__MISSING__:API Key",
+    "sortTypeFirst": "__MISSING__:Easiest first",
+    "sortTypeFirstHelp": "__MISSING__:Group by signup effort (No Signup → OAuth Login → API Key), keeping quality order within each group",
+    "typeLegend": "__MISSING__:No Signup = zero setup · OAuth Login = sign in with your own account · API Key = bring your own key or that provider's free tier"
   }
 }

--- a/src/i18n/messages/ur.json
+++ b/src/i18n/messages/ur.json
@@ -7614,5 +7614,14 @@
     "enabled": "Enabled",
     "disabled": "Disabled",
     "hooks": "Hooks"
+  },
+  "freeProviderRankingsPage": {
+    "typeAll": "__MISSING__:All Types",
+    "typeNoauth": "__MISSING__:No Signup",
+    "typeOauth": "__MISSING__:OAuth Login",
+    "typeApikey": "__MISSING__:API Key",
+    "sortTypeFirst": "__MISSING__:Easiest first",
+    "sortTypeFirstHelp": "__MISSING__:Group by signup effort (No Signup → OAuth Login → API Key), keeping quality order within each group",
+    "typeLegend": "__MISSING__:No Signup = zero setup · OAuth Login = sign in with your own account · API Key = bring your own key or that provider's free tier"
   }
 }

--- a/src/i18n/messages/vi.json
+++ b/src/i18n/messages/vi.json
@@ -7614,5 +7614,14 @@
     "enabled": "Enabled",
     "disabled": "Disabled",
     "hooks": "Hooks"
+  },
+  "freeProviderRankingsPage": {
+    "typeAll": "__MISSING__:All Types",
+    "typeNoauth": "__MISSING__:No Signup",
+    "typeOauth": "__MISSING__:OAuth Login",
+    "typeApikey": "__MISSING__:API Key",
+    "sortTypeFirst": "__MISSING__:Easiest first",
+    "sortTypeFirstHelp": "__MISSING__:Group by signup effort (No Signup → OAuth Login → API Key), keeping quality order within each group",
+    "typeLegend": "__MISSING__:No Signup = zero setup · OAuth Login = sign in with your own account · API Key = bring your own key or that provider's free tier"
   }
 }

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -8685,5 +8685,14 @@
     "regenerateRunning": "正在重新生成技能…",
     "regenerateSuccess": "技能成功重生。",
     "regenerateError": "无法重新生成技能。"
+  },
+  "freeProviderRankingsPage": {
+    "typeAll": "__MISSING__:All Types",
+    "typeNoauth": "__MISSING__:No Signup",
+    "typeOauth": "__MISSING__:OAuth Login",
+    "typeApikey": "__MISSING__:API Key",
+    "sortTypeFirst": "__MISSING__:Easiest first",
+    "sortTypeFirstHelp": "__MISSING__:Group by signup effort (No Signup → OAuth Login → API Key), keeping quality order within each group",
+    "typeLegend": "__MISSING__:No Signup = zero setup · OAuth Login = sign in with your own account · API Key = bring your own key or that provider's free tier"
   }
 }

--- a/src/i18n/messages/zh-TW.json
+++ b/src/i18n/messages/zh-TW.json
@@ -9047,7 +9047,14 @@
     "configuredOnly": "__MISSING__:Configured Only",
     "configuredOnlyHint": "__MISSING__:Show only providers with active connections",
     "noConfiguredProviders": "__MISSING__:No configured providers found. Add a provider connection first.",
-    "colConfigured": "__MISSING__:Status"
+    "colConfigured": "__MISSING__:Status",
+    "typeAll": "__MISSING__:All Types",
+    "typeNoauth": "__MISSING__:No Signup",
+    "typeOauth": "__MISSING__:OAuth Login",
+    "typeApikey": "__MISSING__:API Key",
+    "sortTypeFirst": "__MISSING__:Easiest first",
+    "sortTypeFirstHelp": "__MISSING__:Group by signup effort (No Signup → OAuth Login → API Key), keeping quality order within each group",
+    "typeLegend": "__MISSING__:No Signup = zero setup · OAuth Login = sign in with your own account · API Key = bring your own key or that provider's free tier"
   },
   "discovery": {
     "title": "__MISSING__:Provider Discovery",

--- a/src/lib/freeProviderRankings.ts
+++ b/src/lib/freeProviderRankings.ts
@@ -13,6 +13,16 @@ import { REGISTRY } from "@omniroute/open-sse/config/providerRegistry";
 import { listModelIntelligence } from "./db/modelIntelligence";
 import { getProviderConnections } from "./db/providers";
 import { getCustomModels } from "./db/models";
+import type { ProviderAuthType } from "./freeProviderRankingsAuthType";
+
+// Re-exported for backward-compat / same-module ergonomics (#6915) — the
+// actual implementations live in `freeProviderRankingsAuthType.ts` (DB-free,
+// safe to import from "use client" pages; see that file's header comment).
+export type { ProviderAuthType } from "./freeProviderRankingsAuthType";
+export {
+  filterRankingsByAuthType,
+  sortRankingsAuthTypeFirst,
+} from "./freeProviderRankingsAuthType";
 
 export interface ProviderModelScore {
   modelId: string;
@@ -29,7 +39,7 @@ export interface FreeProviderRanking {
   icon: string;
   color: string;
   textIcon?: string;
-  category: "noauth" | "oauth" | "apikey";
+  category: ProviderAuthType;
   topModel: ProviderModelScore | null;
   averageScore: number;
   modelCount: number;
@@ -45,7 +55,7 @@ function getFreeProviders() {
     icon: string;
     color: string;
     textIcon?: string;
-    category: "noauth" | "oauth" | "apikey";
+    category: ProviderAuthType;
   }> = [];
 
   // No-auth providers are always free

--- a/src/lib/freeProviderRankings.ts
+++ b/src/lib/freeProviderRankings.ts
@@ -382,7 +382,11 @@ export async function computeFreeProviderRankings(
   // limit slice, so `limit` counts providers that survive the filter.
   let filtered = rankings;
   if (opts.configuredOnly || opts.availableOnly) {
-    const connections = (await getProviderConnections({ isActive: true })) as ConnectionState[];
+    // `getProviderConnections` returns a loose JsonRecord[]; ConnectionState is a
+    // structural subset of it, so TS needs the explicit `unknown` hop (TS2352).
+    const connections = (await getProviderConnections({
+      isActive: true,
+    })) as unknown as ConnectionState[];
     filtered = filterFreeProviderRankings(rankings, connections, opts);
   }
 

--- a/src/lib/freeProviderRankingsAuthType.ts
+++ b/src/lib/freeProviderRankingsAuthType.ts
@@ -1,0 +1,46 @@
+/**
+ * freeProviderRankingsAuthType.ts — Pure Type-filter/sort helpers for the Free
+ * Provider Rankings page (#6915).
+ *
+ * Deliberately split out of `freeProviderRankings.ts`: that module imports
+ * DB-touching code (`./db/modelIntelligence`, `./db/providers`,
+ * `./db/models`) at module scope, so importing a runtime value from it
+ * (rather than only types) would pull server-only DB wiring into the
+ * "use client" page's bundle. This module has zero imports beyond a shared
+ * type, so it is safe to import from client components.
+ */
+
+import type { FreeProviderRanking } from "./freeProviderRankings";
+
+export type ProviderAuthType = "noauth" | "oauth" | "apikey";
+
+const AUTH_TYPE_ORDER: Record<ProviderAuthType, number> = {
+  noauth: 0,
+  oauth: 1,
+  apikey: 2,
+};
+
+/**
+ * Pure filter: keep only rankings whose `category` (auth type) matches `type`.
+ * `type` falsy/omitted returns the input unchanged (#6915 — "All" filter state).
+ */
+export function filterRankingsByAuthType(
+  rankings: FreeProviderRanking[],
+  type?: ProviderAuthType | ""
+): FreeProviderRanking[] {
+  if (!type) return rankings;
+  return rankings.filter((r) => r.category === type);
+}
+
+/**
+ * Pure stable sort: group NOAUTH first, then OAUTH, then APIKEY. Relies on
+ * `Array.prototype.sort` being stable (guaranteed ES2019+, our Node engine
+ * range is >=22), so the existing score-descending order from
+ * `computeFreeProviderRankings` is preserved *within* each auth-type group
+ * (#6915 — "least effort" and "best quality" compose instead of fighting).
+ */
+export function sortRankingsAuthTypeFirst(
+  rankings: FreeProviderRanking[]
+): FreeProviderRanking[] {
+  return [...rankings].sort((a, b) => AUTH_TYPE_ORDER[a.category] - AUTH_TYPE_ORDER[b.category]);
+}

--- a/tests/unit/free-provider-rankings-page-authtype-6915.test.tsx
+++ b/tests/unit/free-provider-rankings-page-authtype-6915.test.tsx
@@ -1,0 +1,208 @@
+// @vitest-environment jsdom
+/**
+ * #6915 — Sort/filter Free Provider Rankings by auth Type: page-level tests.
+ *
+ * Mirrors tests/unit/dashboard/batch/list-regression.test.tsx: mock
+ * next-intl's useTranslations to return the key, mock `fetch` to return a
+ * fixed 3-provider payload spanning all three auth types, mount the real
+ * page component, and prove the Type filter chips + "group by type" toggle
+ * actually narrow/reorder the rendered `<table>` rows.
+ */
+
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+// Return a STABLE `t` function identity across renders (real next-intl memoizes
+// this internally). The page's `fetchRankings` useCallback depends on `t`, which
+// is itself a dependency of the data-fetch useEffect — a mock that returns a
+// fresh closure per call would give `t` a new identity every render, causing
+// the effect to re-fire (and refetch) on every render, an infinite loop that
+// only exists in this mock, not in production with real next-intl.
+const stableT = (key: string) => key;
+vi.mock("next-intl", () => ({
+  useTranslations: () => stableT,
+}));
+
+// ── Import component after mocks ──────────────────────────────────────────────
+
+const { default: FreeProviderRankingsPage } = await import(
+  "../../src/app/(dashboard)/dashboard/free-provider-rankings/page"
+);
+
+// ── Fixture data ──────────────────────────────────────────────────────────────
+
+function makeRanking(overrides: Partial<{
+  id: string;
+  name: string;
+  category: "noauth" | "oauth" | "apikey";
+  averageScore: number;
+}> = {}) {
+  return {
+    id: overrides.id ?? "provider-noauth",
+    name: overrides.name ?? "Provider NoAuth",
+    icon: "",
+    color: "#123456",
+    textIcon: undefined,
+    category: overrides.category ?? "noauth",
+    topModel: {
+      modelId: "model-1",
+      modelName: "Model One",
+      score: 0.8,
+      eloRaw: 1500,
+      confidence: "high",
+      category: "default",
+    },
+    averageScore: overrides.averageScore ?? 0.75,
+    modelCount: 1,
+  };
+}
+
+const FIXTURE_RANKINGS = [
+  makeRanking({ id: "p-apikey", name: "APIKey Provider", category: "apikey", averageScore: 0.9 }),
+  makeRanking({ id: "p-oauth", name: "OAuth Provider", category: "oauth", averageScore: 0.85 }),
+  makeRanking({ id: "p-noauth", name: "NoAuth Provider", category: "noauth", averageScore: 0.7 }),
+];
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const containers: Array<{ root: ReturnType<typeof createRoot>; el: HTMLDivElement }> = [];
+
+function makeDiv() {
+  const el = document.createElement("div");
+  document.body.appendChild(el);
+  return el;
+}
+
+function render(jsx: React.ReactElement) {
+  const el = makeDiv();
+  const root = createRoot(el);
+  act(() => {
+    root.render(jsx);
+  });
+  containers.push({ root, el });
+  return el;
+}
+
+/**
+ * Poll until the "loading" placeholder text is gone (fetch resolved + state
+ * committed) or `maxAttempts` is exhausted. Deliberately outside `act()` — the
+ * mount/click that triggered the async work already ran inside its own sync
+ * `act()`; nesting an async `act()` around this wait hangs indefinitely under
+ * React 19 + jsdom in this repo's test environment.
+ */
+async function waitForNotLoading(el: HTMLDivElement, maxAttempts = 40) {
+  for (let i = 0; i < maxAttempts && el.textContent?.includes("loading"); i++) {
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+}
+
+async function renderPageWithFixture() {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ rankings: FIXTURE_RANKINGS }),
+    })
+  );
+  const el = render(<FreeProviderRankingsPage />);
+  await waitForNotLoading(el);
+  return el;
+}
+
+function clickButtonByText(el: HTMLDivElement, text: string) {
+  const btn = Array.from(el.querySelectorAll("button")).find((b) => b.textContent === text);
+  expect(btn).not.toBeUndefined();
+  act(() => {
+    btn!.click();
+  });
+}
+
+function tableRowNames(el: HTMLDivElement): string[] {
+  const rows = Array.from(el.querySelectorAll("tbody tr"));
+  return rows.map((r) => r.querySelector("span.font-medium")?.textContent ?? "");
+}
+
+// ── Lifecycle ─────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => ({ rankings: [] }) }));
+});
+
+afterEach(() => {
+  for (const { root, el } of containers.splice(0)) {
+    act(() => root.unmount());
+    el.remove();
+  }
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("FreeProviderRankingsPage — Type filter + group-by-type sort (#6915)", () => {
+  it("renders all three providers before any Type filter is applied", async () => {
+    const el = await renderPageWithFixture();
+    expect(tableRowNames(el)).toEqual(
+      expect.arrayContaining(["APIKey Provider", "OAuth Provider", "NoAuth Provider"])
+    );
+  }, 15000);
+
+  it("clicking the NOAUTH filter chip narrows the rendered rows to only NOAUTH-typed providers", async () => {
+    const el = await renderPageWithFixture();
+    clickButtonByText(el, "typeNoauth");
+    const names = tableRowNames(el);
+    expect(names).toEqual(["NoAuth Provider"]);
+  }, 15000);
+
+  it("clicking the OAUTH filter chip narrows the rendered rows to only OAUTH-typed providers", async () => {
+    const el = await renderPageWithFixture();
+    clickButtonByText(el, "typeOauth");
+    expect(tableRowNames(el)).toEqual(["OAuth Provider"]);
+  }, 15000);
+
+  it("clicking 'All Types' after a filter restores every row", async () => {
+    const el = await renderPageWithFixture();
+    clickButtonByText(el, "typeApikey");
+    expect(tableRowNames(el)).toEqual(["APIKey Provider"]);
+    clickButtonByText(el, "typeAll");
+    expect(tableRowNames(el)).toEqual(
+      expect.arrayContaining(["APIKey Provider", "OAuth Provider", "NoAuth Provider"])
+    );
+  }, 15000);
+
+  it("toggling 'group by type' re-orders rendered rows to NOAUTH-first", async () => {
+    const el = await renderPageWithFixture();
+    // Fixture order is APIKey, OAuth, NoAuth (by score) — ungrouped preserves that.
+    expect(tableRowNames(el)).toEqual(["APIKey Provider", "OAuth Provider", "NoAuth Provider"]);
+
+    clickButtonByText(el, "sortTypeFirst");
+    expect(tableRowNames(el)).toEqual(["NoAuth Provider", "OAuth Provider", "APIKey Provider"]);
+  }, 15000);
+
+  it("existing configuredOnly/availableOnly toggles remain independently functional alongside the new Type filter", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ rankings: FIXTURE_RANKINGS }) });
+    vi.stubGlobal("fetch", fetchMock);
+    const el = await renderPageWithFixture();
+    vi.stubGlobal("fetch", fetchMock);
+
+    // Apply the new Type filter (client-side only — no refetch expected for this).
+    clickButtonByText(el, "typeNoauth");
+    expect(tableRowNames(el)).toEqual(["NoAuth Provider"]);
+
+    const callsBeforeToggle = fetchMock.mock.calls.length;
+
+    // Toggle the pre-existing "configured only" control — it still triggers its own refetch.
+    clickButtonByText(el, "filterConfiguredOnly");
+    await waitForNotLoading(el);
+
+    expect(fetchMock.mock.calls.length).toBeGreaterThan(callsBeforeToggle);
+    const lastUrl = fetchMock.mock.calls[fetchMock.mock.calls.length - 1][0] as string;
+    expect(lastUrl).toContain("configuredOnly=1");
+
+    // The Type filter (client-side) should still be applied to the (still-fixture) rows.
+    expect(tableRowNames(el)).toEqual(["NoAuth Provider"]);
+  }, 15000);
+});

--- a/tests/unit/freeProviderRankings-authtype-6915.test.ts
+++ b/tests/unit/freeProviderRankings-authtype-6915.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Unit tests for #6915 — Sort/filter Free Provider Rankings by auth Type.
+ *
+ * Targets the PURE helpers `filterRankingsByAuthType` + `sortRankingsAuthTypeFirst`
+ * (no DB, no I/O) so the new filter/sort logic is exercised in isolation, mirroring
+ * `tests/unit/freeProviderRankings-filters.test.ts`.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  filterRankingsByAuthType,
+  sortRankingsAuthTypeFirst,
+  type FreeProviderRanking,
+  type ProviderAuthType,
+} from "../../src/lib/freeProviderRankings.ts";
+
+function ranking(id: string, category: ProviderAuthType, score: number): FreeProviderRanking {
+  return {
+    id,
+    name: id,
+    icon: "",
+    color: "#000",
+    category,
+    topModel: null,
+    averageScore: score,
+    modelCount: 1,
+  };
+}
+
+// ──────────────── filterRankingsByAuthType ────────────────
+
+test("filterRankingsByAuthType: 'noauth' keeps only NOAUTH rows", () => {
+  const rows = [
+    ranking("a", "noauth", 0.9),
+    ranking("b", "oauth", 0.8),
+    ranking("c", "apikey", 0.7),
+    ranking("d", "noauth", 0.6),
+  ];
+  const result = filterRankingsByAuthType(rows, "noauth");
+  assert.deepEqual(
+    result.map((r) => r.id),
+    ["a", "d"]
+  );
+});
+
+test("filterRankingsByAuthType: 'oauth' keeps only OAUTH rows", () => {
+  const rows = [ranking("a", "noauth", 0.9), ranking("b", "oauth", 0.8)];
+  const result = filterRankingsByAuthType(rows, "oauth");
+  assert.deepEqual(
+    result.map((r) => r.id),
+    ["b"]
+  );
+});
+
+test("filterRankingsByAuthType: 'apikey' keeps only APIKEY rows", () => {
+  const rows = [ranking("a", "apikey", 0.9), ranking("b", "oauth", 0.8)];
+  const result = filterRankingsByAuthType(rows, "apikey");
+  assert.deepEqual(
+    result.map((r) => r.id),
+    ["a"]
+  );
+});
+
+test("filterRankingsByAuthType: empty-string type returns input unchanged (identity — 'All')", () => {
+  const rows = [ranking("a", "noauth", 0.9), ranking("b", "oauth", 0.8)];
+  const result = filterRankingsByAuthType(rows, "");
+  assert.equal(result, rows);
+});
+
+test("filterRankingsByAuthType: undefined type returns input unchanged (identity — 'All')", () => {
+  const rows = [ranking("a", "noauth", 0.9), ranking("b", "oauth", 0.8)];
+  const result = filterRankingsByAuthType(rows);
+  assert.equal(result, rows);
+});
+
+// ──────────────── sortRankingsAuthTypeFirst ────────────────
+
+test("sortRankingsAuthTypeFirst: groups NOAUTH < OAUTH < APIKEY", () => {
+  const rows = [
+    ranking("apikey-1", "apikey", 0.95),
+    ranking("oauth-1", "oauth", 0.9),
+    ranking("noauth-1", "noauth", 0.5),
+  ];
+  const result = sortRankingsAuthTypeFirst(rows);
+  assert.deepEqual(
+    result.map((r) => r.category),
+    ["noauth", "oauth", "apikey"]
+  );
+});
+
+test("sortRankingsAuthTypeFirst: preserves relative (score) order within each group (stable-sort proof)", () => {
+  // Input already sorted by score across mixed types (simulating computeFreeProviderRankings output).
+  const rows = [
+    ranking("apikey-best", "apikey", 0.95),
+    ranking("oauth-best", "oauth", 0.9),
+    ranking("noauth-best", "noauth", 0.85),
+    ranking("apikey-worst", "apikey", 0.8),
+    ranking("oauth-worst", "oauth", 0.6),
+    ranking("noauth-worst", "noauth", 0.4),
+  ];
+  const result = sortRankingsAuthTypeFirst(rows);
+  assert.deepEqual(
+    result.map((r) => r.id),
+    ["noauth-best", "noauth-worst", "oauth-best", "oauth-worst", "apikey-best", "apikey-worst"]
+  );
+});
+
+test("sortRankingsAuthTypeFirst: does not mutate the input array", () => {
+  const rows = [ranking("apikey-1", "apikey", 0.95), ranking("noauth-1", "noauth", 0.5)];
+  const original = [...rows];
+  sortRankingsAuthTypeFirst(rows);
+  assert.deepEqual(rows, original);
+});
+
+test("sortRankingsAuthTypeFirst: empty input returns empty output", () => {
+  assert.deepEqual(sortRankingsAuthTypeFirst([]), []);
+});

--- a/tests/unit/ui/free-provider-rankings-page-authtype-6915.test.tsx
+++ b/tests/unit/ui/free-provider-rankings-page-authtype-6915.test.tsx
@@ -29,7 +29,7 @@ vi.mock("next-intl", () => ({
 // ── Import component after mocks ──────────────────────────────────────────────
 
 const { default: FreeProviderRankingsPage } = await import(
-  "../../src/app/(dashboard)/dashboard/free-provider-rankings/page"
+  "@/app/(dashboard)/dashboard/free-provider-rankings/page"
 );
 
 // ── Fixture data ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Adds a Type filter (All / No Signup / OAuth Login / API Key) and an "Easiest first" sort toggle to `/dashboard/free-provider-rankings`, so zero-setup NOAUTH providers can be surfaced without eyeballing the Type column (fixes the "top-ranked rows required a key/login" confusion from discussion #6746).
- Type filter and sort are purely client-side over the already-fetched rankings — no API/backend change. The existing `configuredOnly`/`availableOnly` toggles and the podium continue to work and compose with the new filter.
- Pure filter/sort logic (`filterRankingsByAuthType`, `sortRankingsAuthTypeFirst`) was extracted into a **new** `src/lib/freeProviderRankingsAuthType.ts` module rather than added to `freeProviderRankings.ts` directly: that existing module imports DB-touching code (`./db/modelIntelligence`, `./db/providers`, `./db/models`) at module scope, so importing a runtime value from it into the `"use client"` page would have pulled server-only DB wiring (fs/path/better-sqlite3) into the client bundle. `freeProviderRankings.ts` re-exports both functions for API/test parity with the original plan.
- Type column now has a legend/tooltip explaining NOAUTH/OAUTH/APIKEY effort levels.
- i18n keys added to `en.json` and synced to all 42 locale mirrors with the existing `__MISSING__:` placeholder convention (surgical addition — only the 7 new keys, not a full re-sync of pre-existing unrelated missing keys).

## Validation
- TDD: `tests/unit/freeProviderRankings-authtype-6915.test.ts` (Node native `node:test`) — 9/9 passing, proves `filterRankingsByAuthType` and `sortRankingsAuthTypeFirst` in isolation (filter by each type, identity on empty/undefined, stable-sort grouping, no-mutation).
  ```
  node --import tsx/esm --test tests/unit/freeProviderRankings-authtype-6915.test.ts
  # tests 9, pass 9, fail 0
  ```
- `tests/unit/free-provider-rankings-page-authtype-6915.test.tsx` (Vitest + jsdom, mounts the real page component) — 6/6 passing, proves the Type filter chips narrow the rendered `<table>` rows, "group by type" re-orders them NOAUTH-first, and the pre-existing `configuredOnly` toggle still triggers its own refetch while the client-side Type filter stays applied.
  ```
  npx vitest run --config vitest.config.ts tests/unit/free-provider-rankings-page-authtype-6915.test.tsx
  # Test Files 1 passed, Tests 6 passed
  ```

## Gates run
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` — clean
- `npm run typecheck:core` — clean
- `npm run typecheck:noimplicit:core` — clean on touched files (pre-existing unrelated errors in `open-sse/services/combo.ts`, `open-sse/utils/usageTracking.ts`, `src/shared/services/cliRuntime.ts` confirmed present on `origin/release/v3.8.49` via `git show`, untouched by this PR)
- `node scripts/check/check-file-size.mjs` — OK, no violations
- `node scripts/check/check-complexity.mjs` — **2056 violations (baseline 2056)**, net-zero: `FreeProviderRankingsPage` already exceeded `max-lines-per-function` before this PR (measured 218 lines on `origin/release/v3.8.49`); this PR grows the same already-violating function, not a new one, so the total violation count is unchanged
- `node scripts/check/check-docs-sync.mjs` — PASS
- `npm run i18n:check-ui-coverage` — **pre-existing failure, unrelated to this PR**: measured directly against `origin/release/v3.8.49`, the vast majority of locales are already ~75.6% translated (well under the 80% threshold) before this PR; adding 7 new `__MISSING__:`-placeholder keys (same convention as every other untranslated key already in these files) moves that to ~75.5% — a ~0.1pp shift from enlarging the denominator, not a regression this PR introduces or can fix (would require an actual translation pass across 42 locales, out of scope for this feature)
- `npm run test:coverage` (full repo suite): attempted twice but could not complete within a practical time budget on this shared devbox, which was under extreme unrelated contention during this session (`load average` ~121 on a 16-core box from other concurrent sessions/PRs). The new test files are small and fully isolated (pure functions + one page-level UI test); they add coverage rather than reduce it. Recommend CI (uncontended) confirm the 60/60/60/60 gate; happy to follow up if it flags anything.

Closes #6915