### PR TITLE
fix(sse): route the public OpenAI GPT-5.6 family through the Responses API

### DIFF
--- a/changelog.d/fixes/7242-openai-gpt56-responses-routing.md
+++ b/changelog.d/fixes/7242-openai-gpt56-responses-routing.md
@@ -1,0 +1,1 @@
+- **fix(sse):** route the public OpenAI GPT-5.6 family (`gpt-5.6`, `-sol`, `-terra`, `-luna`) through the Responses API — Chat Completions rejects GPT-5.6 requests that combine function tools with an active `reasoning_effort`. (thanks @Jordannst)

--- a/open-sse/config/providers/shared.ts
+++ b/open-sse/config/providers/shared.ts
@@ -285,7 +285,16 @@ export const GPT_5_5_CODEX_CAPABILITIES = {
 } as const;
 
 // Public OpenAI API limits. These differ from the Codex OAuth catalog limits below.
+// Upstream port (decolua/9router#2547, closes #2540): OpenAI's Chat Completions
+// endpoint rejects GPT-5.6 requests that combine function tools with an active
+// reasoning_effort ("Function tools with reasoning_effort are not supported for
+// <model> in /v1/chat/completions. Please use /v1/responses instead."). Tag the
+// whole public GPT-5.6 family with the existing generic targetFormat override
+// (the same mechanism already routes gpt-5.5-pro / gpt-5.4-pro, #5842) so both
+// the outbound URL (DefaultExecutor.buildUrl) and the body translation
+// (chatCore's resolveChatCoreTargetFormat) go through api.openai.com/v1/responses.
 export const GPT_5_6_API_CAPABILITIES = {
+  targetFormat: "openai-responses",
   toolCalling: true,
   supportsReasoning: true,
   supportsVision: true,

--- a/tests/unit/openai-gpt56-responses-routing.test.ts
+++ b/tests/unit/openai-gpt56-responses-routing.test.ts
@@ -1,0 +1,45 @@
+/**
+ * OpenAI API-key GPT-5.6 family must route through the native Responses API
+ * (/v1/responses), not Chat Completions (/v1/chat/completions).
+ *
+ * Port of 9router#2547 (closes 9router#2540): OpenAI rejects Chat Completions
+ * requests that combine function tools with an active `reasoning_effort` for
+ * the GPT-5.6 family with HTTP 400 ("Function tools with reasoning_effort are
+ * not supported for <model> in /v1/chat/completions. Please use /v1/responses
+ * instead."). OmniRoute already has a generic model-specific `targetFormat`
+ * override (used today for gpt-5.5-pro / gpt-5.4-pro, #5842) that routes the
+ * request body translation AND the executor's outbound URL to
+ * api.openai.com/v1/responses — the GPT-5.6 family registry entries were
+ * simply missing the tag.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { getModelTargetFormat } from "../../open-sse/config/providerModels.ts";
+import { DefaultExecutor } from "../../open-sse/executors/default.ts";
+
+test("getModelTargetFormat routes the public OpenAI GPT-5.6 family through Responses", () => {
+  for (const modelId of ["gpt-5.6", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]) {
+    assert.equal(
+      getModelTargetFormat("openai", modelId),
+      "openai-responses",
+      `${modelId} must target openai-responses`
+    );
+  }
+});
+
+test("GPT-5.4 (non-5.6) stays on Chat Completions", () => {
+  assert.equal(getModelTargetFormat("openai", "gpt-5.4"), null);
+});
+
+test("DefaultExecutor builds the /v1/responses URL for gpt-5.6-sol", () => {
+  const executor = new DefaultExecutor("openai");
+  const url = executor.buildUrl("gpt-5.6-sol", true, 0, null);
+  assert.equal(url, "https://api.openai.com/v1/responses");
+});
+
+test("DefaultExecutor keeps /v1/chat/completions for gpt-5.4", () => {
+  const executor = new DefaultExecutor("openai");
+  const url = executor.buildUrl("gpt-5.4", true, 0, null);
+  assert.equal(url, "https://api.openai.com/v1/chat/completions");
+});


### PR DESCRIPTION
## Summary

- OpenAI's Chat Completions endpoint rejects GPT-5.6 requests that combine function tools with an active `reasoning_effort` — `400 "Function tools with reasoning_effort are not supported for <model> in /v1/chat/completions. Please use /v1/responses instead."` Any agentic client hitting `openai/gpt-5.6-sol` with tools + reasoning got the 400 and burned a combo fallback attempt.
- Root cause: the `openai` (API-key) registry entries for `gpt-5.6` / `-sol` / `-terra` / `-luna` were missing the per-model `targetFormat` tag, so every request went to `/v1/chat/completions`.
- Fix reuses the mechanism OmniRoute already has: the per-model `targetFormat: "openai-responses"` override that already routes `gpt-5.5-pro` / `gpt-5.4-pro` (#5842). It drives BOTH the outbound URL (`DefaultExecutor.buildUrl` → `api.openai.com/v1/responses`) and the body translation (`resolveChatCoreTargetFormat` → `openai-responses`). No new transport table or routing branch needed.

## Attribution

Thanks to [@Jordannst](https://github.com/Jordannst) for the original implementation.

## Changes

- `open-sse/config/providers/shared.ts` — add `targetFormat: "openai-responses"` to `GPT_5_6_API_CAPABILITIES` (consumed only by the 4 public OpenAI GPT-5.6 catalog entries). Scoped to the public OpenAI API catalog; the `codex` provider has its own Responses transport and is untouched.
- `tests/unit/openai-gpt56-responses-routing.test.ts` — new regression test.

## Test plan

- [x] targeted unit test (new, fails before / passes after)

  Before (on `release/v3.8.49`):

  ```
  ✖ getModelTargetFormat routes the public OpenAI GPT-5.6 family through Responses
    AssertionError: gpt-5.6 must target openai-responses
    + actual: null   - expected: 'openai-responses'
  ✖ DefaultExecutor builds the /v1/responses URL for gpt-5.6-sol
    + actual: 'https://api.openai.com/v1/chat/completions'
    - expected: 'https://api.openai.com/v1/responses'
  ```

  After: `ℹ tests 4 / ℹ pass 4 / ℹ fail 0`

- [x] `npm run typecheck:core` — clean
- [x] `npx eslint` on changed files — clean (exit 0)

Negative coverage included: `gpt-5.4` still resolves to `null` / `/v1/chat/completions`.

---

## ⚠️ Reviewer note — competing approach in flight

Another in-flight change targets the **same root cause** (GPT-5.6 + tools + reasoning) with the **opposite strategy**, and the two should not land together without a decision:

- **This PR** *preserves* the client's `reasoning_effort` by routing the request to the Responses API.
- **The other approach** (`tests/unit/gpt5-tools-reasoning-guard.test.ts`, currently uncommitted WIP) *drops* the client's reasoning when tools are present.

They are mutually exclusive in intent: one keeps reasoning by changing the endpoint, the other silently discards it. Worth picking one deliberately rather than merging both.

FWIW that WIP test currently does not import — it pulls `stripGpt5ReasoningWhenTools` from `open-sse/services/gpt5SamplingGuard.ts`, which does not export that symbol.
