### PR TITLE
fix(nvidia): expand NIM chat model catalog

### DIFF
--- a/changelog.d/fixes/7247-nvidia-nim-catalog.md
+++ b/changelog.d/fixes/7247-nvidia-nim-catalog.md
@@ -1,0 +1,1 @@
+- **fix(nvidia):** expand NIM chat model catalog with newly-observed models. (thanks @spacesky-cell)

--- a/open-sse/config/providers/registry/nvidia/index.ts
+++ b/open-sse/config/providers/registry/nvidia/index.ts
@@ -39,5 +39,93 @@ export const nvidiaProvider: RegistryEntry = {
     { id: "openai/gpt-oss-20b", name: "GPT OSS 20B", toolCalling: false },
     { id: "nvidia/nemotron-3-super-120b-a12b", name: "Nemotron 3 Super 120B A12B" },
     { id: "nvidia/nemotron-3-ultra-550b-a55b", name: "Nemotron 3 Ultra 550B" },
+    // Port of decolua/9router#2373 ("fix(nvidia): expand NIM chat model catalog"):
+    // additional live-catalog models observed to serve /v1/chat/completions.
+    // `minimaxai/minimax-m3` from that PR is intentionally NOT re-added — it stays
+    // excluded per the #3329 guard (nvidia-minimax-m3-removed-3329.test.ts).
+    // Non-chat entries from the same PR (nvidia/gliner-pii — NER tagger, not a chat
+    // model; google/diffusiongemma-26b-a4b-it — diffusion model) are dropped for the
+    // same reason: this registry only models the /v1/chat/completions surface.
+    { id: "abacusai/dracarys-llama-3.1-70b-instruct", name: "Dracarys Llama 3.1 70B Instruct" },
+    { id: "google/gemma-2-2b-it", name: "Gemma 2 2B IT" },
+    { id: "google/gemma-3n-e2b-it", name: "Gemma 3n E2B IT" },
+    { id: "meta/llama-3.1-8b-instruct", name: "Llama 3.1 8B Instruct" },
+    {
+      id: "meta/llama-3.2-11b-vision-instruct",
+      name: "Llama 3.2 11B Vision Instruct",
+      supportsVision: true,
+    },
+    { id: "meta/llama-3.2-1b-instruct", name: "Llama 3.2 1B Instruct" },
+    { id: "meta/llama-3.2-3b-instruct", name: "Llama 3.2 3B Instruct" },
+    {
+      id: "meta/llama-3.2-90b-vision-instruct",
+      name: "Llama 3.2 90B Vision Instruct",
+      supportsVision: true,
+    },
+    { id: "meta/llama-4-maverick-17b-128e-instruct", name: "Llama 4 Maverick 17B 128E Instruct" },
+    { id: "meta/llama-guard-4-12b", name: "Llama Guard 4 12B" },
+    { id: "mistralai/ministral-14b-instruct-2512", name: "Ministral 14B Instruct 2512" },
+    { id: "mistralai/mistral-medium-3.5-128b", name: "Mistral Medium 3.5 128B" },
+    { id: "mistralai/mistral-nemotron", name: "Mistral Nemotron" },
+    { id: "mistralai/mixtral-8x7b-instruct-v0.1", name: "Mixtral 8x7B Instruct v0.1" },
+    {
+      id: "nvidia/ising-calibration-1-35b-a3b",
+      name: "Ising Calibration 1 35B A3B",
+      supportsReasoning: true,
+    },
+    {
+      id: "nvidia/llama-3.1-nemoguard-8b-content-safety",
+      name: "Llama 3.1 Nemoguard 8B Content Safety",
+    },
+    {
+      id: "nvidia/llama-3.1-nemoguard-8b-topic-control",
+      name: "Llama 3.1 Nemoguard 8B Topic Control",
+    },
+    { id: "nvidia/llama-3.1-nemotron-nano-8b-v1", name: "Llama 3.1 Nemotron Nano 8B v1" },
+    {
+      id: "nvidia/llama-3.1-nemotron-nano-vl-8b-v1",
+      name: "Llama 3.1 Nemotron Nano VL 8B v1",
+      supportsVision: true,
+    },
+    {
+      id: "nvidia/llama-3.1-nemotron-safety-guard-8b-v3",
+      name: "Llama 3.1 Nemotron Safety Guard 8B v3",
+    },
+    { id: "nvidia/llama-3.3-nemotron-super-49b-v1", name: "Llama 3.3 Nemotron Super 49B v1" },
+    { id: "nvidia/llama-3.3-nemotron-super-49b-v1.5", name: "Llama 3.3 Nemotron Super 49B v1.5" },
+    { id: "nvidia/nemotron-3-content-safety", name: "Nemotron 3 Content Safety" },
+    {
+      id: "nvidia/nemotron-3-nano-30b-a3b",
+      name: "Nemotron 3 Nano 30B A3B",
+      supportsReasoning: true,
+    },
+    {
+      id: "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
+      name: "Nemotron 3 Nano Omni 30B A3B Reasoning",
+      supportsReasoning: true,
+      supportsVision: true,
+    },
+    { id: "nvidia/nemotron-3.5-content-safety", name: "Nemotron 3.5 Content Safety" },
+    { id: "nvidia/nemotron-mini-4b-instruct", name: "Nemotron Mini 4B Instruct" },
+    {
+      id: "nvidia/nemotron-nano-12b-v2-vl",
+      name: "Nemotron Nano 12B v2 VL",
+      supportsReasoning: true,
+      supportsVision: true,
+    },
+    {
+      id: "nvidia/nvidia-nemotron-nano-9b-v2",
+      name: "NVIDIA Nemotron Nano 9B v2",
+      supportsReasoning: true,
+    },
+    { id: "nvidia/riva-translate-4b-instruct-v1.1", name: "Riva Translate 4B Instruct v1.1" },
+    {
+      id: "qwen/qwen3-next-80b-a3b-instruct",
+      name: "Qwen3 Next 80B A3B Instruct",
+      supportsReasoning: true,
+    },
+    { id: "sarvamai/sarvam-m", name: "Sarvam M" },
+    { id: "stockmark/stockmark-2-100b-instruct", name: "Stockmark 2 100B Instruct" },
+    { id: "upstage/solar-10.7b-instruct", name: "Solar 10.7B Instruct" },
   ],
 };

--- a/tests/unit/nvidia-nim-catalog-expansion-2373.test.ts
+++ b/tests/unit/nvidia-nim-catalog-expansion-2373.test.ts
@@ -1,0 +1,81 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { nvidiaProvider } from "../../open-sse/config/providers/registry/nvidia/index.ts";
+
+// Port of decolua/9router#2373 ("fix(nvidia): expand NIM chat model catalog"). Upstream's
+// PR also added a per-model `thinkingFormat`/`kind` capability shape in a legacy
+// open-sse/providers/capabilities.js file that has no equivalent in OmniRoute — reasoning
+// translation here is per-PROVIDER (open-sse/translator/paramSupport.ts,
+// executors/default.ts, both gated on `this.provider === "nvidia"`), not per-model, so
+// only the catalog (RegistryModel.supportsReasoning/supportsVision) needed porting.
+// Embedding/ASR/TTS entries from the same upstream PR are already covered by
+// open-sse/config/embeddingRegistry.ts and audioRegistry.ts, so they are not duplicated
+// here. `minimaxai/minimax-m3` is intentionally excluded — see the #3329 guard
+// (nvidia-minimax-m3-removed-3329.test.ts).
+const modelIds = new Set(nvidiaProvider.models.map((m) => m.id));
+
+test("#2373: NVIDIA NIM registry gains the newly-observed chat-completions models", () => {
+  for (const id of [
+    "abacusai/dracarys-llama-3.1-70b-instruct",
+    "google/gemma-2-2b-it",
+    "google/gemma-3n-e2b-it",
+    "meta/llama-3.1-8b-instruct",
+    "meta/llama-3.2-11b-vision-instruct",
+    "meta/llama-4-maverick-17b-128e-instruct",
+    "meta/llama-guard-4-12b",
+    "mistralai/ministral-14b-instruct-2512",
+    "mistralai/mistral-medium-3.5-128b",
+    "mistralai/mistral-nemotron",
+    "mistralai/mixtral-8x7b-instruct-v0.1",
+    "nvidia/ising-calibration-1-35b-a3b",
+    "nvidia/llama-3.1-nemoguard-8b-content-safety",
+    "nvidia/llama-3.3-nemotron-super-49b-v1.5",
+    "nvidia/nemotron-3-nano-30b-a3b",
+    "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
+    "nvidia/nemotron-nano-12b-v2-vl",
+    "nvidia/nvidia-nemotron-nano-9b-v2",
+    "qwen/qwen3-next-80b-a3b-instruct",
+    "sarvamai/sarvam-m",
+    "stockmark/stockmark-2-100b-instruct",
+    "upstage/solar-10.7b-instruct",
+  ]) {
+    assert.ok(modelIds.has(id), `expected nvidia registry to include ${id}`);
+  }
+});
+
+test("#2373: reasoning-capable NVIDIA-hosted models are flagged supportsReasoning", () => {
+  const reasoningIds = [
+    "nvidia/ising-calibration-1-35b-a3b",
+    "nvidia/nemotron-3-nano-30b-a3b",
+    "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
+    "nvidia/nemotron-nano-12b-v2-vl",
+    "nvidia/nvidia-nemotron-nano-9b-v2",
+    "qwen/qwen3-next-80b-a3b-instruct",
+  ];
+  for (const id of reasoningIds) {
+    const model = nvidiaProvider.models.find((m) => m.id === id);
+    assert.ok(model, `model ${id} must exist`);
+    assert.equal(model?.supportsReasoning, true, `${id} must be supportsReasoning: true`);
+  }
+});
+
+test("#2373/#3329: minimaxai/minimax-m3 stays excluded from the nvidia tier", () => {
+  assert.ok(
+    !modelIds.has("minimaxai/minimax-m3"),
+    "minimaxai/minimax-m3 must not be re-added to the nvidia registry (404 upstream, #3329)"
+  );
+  // sanity: the working sibling stays listed
+  assert.ok(modelIds.has("minimaxai/minimax-m2.7"), "minimaxai/minimax-m2.7 stays available");
+});
+
+test("#2373: non-chat model kinds (NER/diffusion) from the upstream PR are not ported into the chat registry", () => {
+  assert.ok(
+    !modelIds.has("nvidia/gliner-pii"),
+    "nvidia/gliner-pii is an NER/PII tagger, not a chat-completions model"
+  );
+  assert.ok(
+    !modelIds.has("google/diffusiongemma-26b-a4b-it"),
+    "google/diffusiongemma-26b-a4b-it is a diffusion model, not a chat-completions model"
+  );
+});


### PR DESCRIPTION
## Summary
- Adds newly-observed NVIDIA NIM chat-completions models to the registry (Llama 3.x/4 family, Mistral variants, Nemotron/Nemoguard safety+reasoning models, Qwen3-Next, Sarvam/Stockmark/Upstage) with `supportsReasoning`/`supportsVision` flags where applicable.
- `minimaxai/minimax-m3` is intentionally **not** re-added — it stays excluded per the existing #3329 regression guard (still 404s for most callers).
- Drops two non-chat entries from the source sweep (an NER/PII tagger and a diffusion model) — this registry only models the `/v1/chat/completions` surface; NVIDIA's embedding/ASR/TTS models are already covered separately in `embeddingRegistry.ts`/`audioRegistry.ts`.

## Attribution
Thanks to [@spacesky-cell](https://github.com/spacesky-cell) for the original implementation.

## Changes
- `open-sse/config/providers/registry/nvidia/index.ts` (catalog expansion)
- `tests/unit/nvidia-nim-catalog-expansion-2373.test.ts` (new)

## Test plan
- [x] targeted unit test (new, fails before / passes after — confirmed the new model ids are absent from `git show release/v3.8.49`)
- [x] existing NVIDIA regression suite still green (nvidia-minimax-m3-removed-3329, nvidia-nim-registry-6108, nvidia-nim-validator, nvidia-validation-model-3116, nvidia-validation-bypass-proxy-3226, nvidia-minimax-thinking-strip, nvidia-passthrough-models-6773 — 20/20 passing)
- [x] npm run typecheck:core
- [x] eslint on changed files
- [x] npm run check:provider-consistency