### PR TITLE
fix: omniroute dashboard respects PORT env when --port is omitted (#7049)

### DIFF
--- a/bin/cli/commands/dashboard.mjs
+++ b/bin/cli/commands/dashboard.mjs
@@ -1,17 +1,22 @@
 import { execFile } from "node:child_process";
 import { t } from "../i18n.mjs";
 
+function parsePort(value, fallback) {
+  const parsed = parseInt(String(value), 10);
+  return Number.isFinite(parsed) && parsed > 0 && parsed <= 65535 ? parsed : fallback;
+}
+
 export function registerDashboard(program) {
   program
     .command("dashboard")
     .description(t("dashboard.description"))
     .option("--url", t("dashboard.urlOnly"))
-    .option("--port <port>", "Port the server is running on", "20128")
+    .option("--port <port>", "Port the server is running on")
     .option("--tui", t("dashboard.tui") || "Open interactive TUI dashboard (terminal UI)")
     .action(async (opts, cmd) => {
       if (opts.tui) {
         const globalOpts = cmd.optsWithGlobals();
-        const port = opts.port ? parseInt(String(opts.port), 10) : 20128;
+        const port = parsePort(opts.port ?? process.env.PORT ?? "20128", 20128);
         const baseUrl = globalOpts.baseUrl ?? `http://localhost:${port}`;
         const apiKey = globalOpts.apiKey ?? null;
         const { startInteractiveTui } = await import("../tui/Dashboard.jsx");
@@ -24,7 +29,7 @@ export function registerDashboard(program) {
 }
 
 export async function runDashboardCommand(opts = {}) {
-  const port = opts.port ? parseInt(String(opts.port), 10) : 20128;
+  const port = parsePort(opts.port ?? process.env.PORT ?? "20128", 20128);
   const dashboardUrl = `http://localhost:${port}`;
 
   if (opts.url) {

--- a/changelog.d/fixes/7049-dashboard-port-env-fallback.md
+++ b/changelog.d/fixes/7049-dashboard-port-env-fallback.md
@@ -1,0 +1,1 @@
+- **fix(cli):** `omniroute dashboard` (no `--port` flag) now respects `PORT` from the environment instead of always opening `localhost:20128`, matching `serve`/`launch` precedence (`--port` > `PORT` env > `20128` default) (#7049 — thanks @kaon0388v1).

--- a/tests/unit/cli-dashboard-port.test.ts
+++ b/tests/unit/cli-dashboard-port.test.ts
@@ -1,0 +1,75 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+/**
+ * Replicate the parsePort + port resolution logic from bin/cli/commands/dashboard.mjs
+ * to verify that PORT env var is respected when --port is not passed (mirrors
+ * tests/unit/cli-serve-port.test.ts's convention for serve.mjs).
+ */
+function parsePort(value: string | undefined, fallback: number): number {
+  const parsed = parseInt(String(value), 10);
+  return Number.isFinite(parsed) && parsed > 0 && parsed <= 65535 ? parsed : fallback;
+}
+
+function resolvePort(optsPort: string | undefined, envPort: string | undefined): number {
+  return parsePort(optsPort ?? envPort ?? "20128", 20128);
+}
+
+test("dashboard port: uses --port flag when explicitly provided, overriding env", () => {
+  const port = resolvePort("3000", "9999");
+  assert.equal(port, 3000);
+});
+
+test("dashboard port: falls back to PORT env var when --port is not provided", () => {
+  const port = resolvePort(undefined, "20129");
+  assert.equal(port, 20129);
+});
+
+test("dashboard port: falls back to 20128 when neither --port nor PORT env var is set", () => {
+  const port = resolvePort(undefined, undefined);
+  assert.equal(port, 20128);
+});
+
+test("dashboard port: invalid --port (non-numeric) falls back to 20128", () => {
+  const port = resolvePort("abc", undefined);
+  assert.equal(port, 20128);
+});
+
+test("dashboard port: --port 0 (out of range) falls back to 20128", () => {
+  const port = resolvePort("0", undefined);
+  assert.equal(port, 20128);
+});
+
+test("dashboard port: --port 70000 (out of range) falls back to 20128", () => {
+  const port = resolvePort("70000", undefined);
+  assert.equal(port, 20128);
+});
+
+test("dashboard URL generation: http://localhost:<port> built correctly for a custom port", () => {
+  const port = resolvePort(undefined, "31337");
+  assert.equal(`http://localhost:${port}`, "http://localhost:31337");
+});
+
+test("dashboard command: --port option has no Commander default", async () => {
+  const fs = await import("node:fs");
+  const path = await import("node:path");
+  const dashboardSource = fs.readFileSync(
+    path.resolve(import.meta.dirname, "../../bin/cli/commands/dashboard.mjs"),
+    "utf-8",
+  );
+  // Ensure the option does NOT carry a baked-in Commander default (third arg).
+  assert.match(
+    dashboardSource,
+    /\.option\("--port <port>",\s*"Port the server is running on"\)/,
+  );
+});
+
+test("dashboard command: source references process.env.PORT (env-fallback regression guard)", async () => {
+  const fs = await import("node:fs");
+  const path = await import("node:path");
+  const dashboardSource = fs.readFileSync(
+    path.resolve(import.meta.dirname, "../../bin/cli/commands/dashboard.mjs"),
+    "utf-8",
+  );
+  assert.match(dashboardSource, /process\.env\.PORT/);
+});


### PR DESCRIPTION
## Summary
- `omniroute dashboard` (no `--port` flag) previously ignored `process.env.PORT` and always opened `http://localhost:20128`, unlike `serve`/`launch` which already resolve `opts.port ?? process.env.PORT ?? 20128`.
- Root cause: the Commander `--port` option carried a baked-in default value `"20128"`, so `opts.port` was never `undefined` at the action handler, silently defeating any `opts.port ?? process.env.PORT` fallback — plus both call sites (`registerDashboard`'s `--tui` branch and `runDashboardCommand()`) duplicated a `opts.port ? parseInt(...) : 20128` ternary that never consulted the env var.
- Fix: removed the Commander-level default (mirroring `serve.mjs`) and applied the same `opts.port ?? process.env.PORT ?? "20128"` precedence, validated through a `parsePort` helper (rejects non-numeric / out-of-range values, mirroring `serve.mjs`'s pattern) in both call sites.
- Precedence, matching `serve`/`launch`: explicit `--port` flag > `process.env.PORT` > `20128` default.

## Validation
TDD: new test file `tests/unit/cli-dashboard-port.test.ts` (9 tests) written first against the buggy code (source-text assertions on the Commander option shape and `process.env.PORT` usage failed as expected), then the fix was applied and the suite went green.

```
node --import tsx/esm --test tests/unit/cli-dashboard-port.test.ts tests/unit/cli-serve-port.test.ts tests/unit/cli-tui.test.ts
# 36 pass, 0 fail (includes the pre-existing cli-tui.test.ts "--tui flag" regression test, unmodified and still passing)
```

Manual CLI check against the real binary:
```
PORT=20129 node bin/omniroute.mjs dashboard --url    # -> http://localhost:20129 (was :20128 before the fix)
node bin/omniroute.mjs dashboard --port 3000 --url   # -> http://localhost:3000 (explicit flag still wins)
node bin/omniroute.mjs dashboard --url               # -> http://localhost:20128 (default unchanged, no PORT set)
```

Scoped gates run green:
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json tests/unit/cli-dashboard-port.test.ts` — clean (note: `bin/**` is globally excluded from ESLint scope by `eslint.config.mjs`, so `dashboard.mjs` itself isn't linted)
- `npm run typecheck:core` — clean
- `npm run typecheck:noimplicit:core` — pre-existing errors only, confirmed unrelated to this change (zero diff vs `origin/release/v3.8.49` on the affected files)
- `node scripts/check/check-file-size.mjs` — clean
- `node scripts/check/check-complexity.mjs` — clean (ratchet holds at baseline)
- `npm run check:cycles` — clean
- `npm run check:docs-sync` — clean

Note: the full-repo `npm run lint` and `npm run test:coverage` could not complete in this session due to extreme, verified environment contention (load average 90–140 on a 16-core box from many concurrent parallel sessions, plus the filesystem at 97% capacity) — both independently confirmable via `uptime`/`df -h`, unrelated to this change's scope. CI will run these cleanly.

Closes #7049