### PR TITLE
feat: let custom connections opt into prompt-cache capability (#6880)

### DIFF
--- a/changelog.d/features/6880-connection-cache-override.md
+++ b/changelog.d/features/6880-connection-cache-override.md
@@ -1,0 +1,1 @@
+- **feat(providers):** let a custom/openai-compatible connection opt into prompt-cache behavior via a per-connection `cache` capability override, unblocking `prompt_cache_key` injection, the compression cache-aware guard, and `cache_control` passthrough for `openai-compatible-chat-<uuid>`-style connections. (thanks @andrea-kingautomation)

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -233,7 +233,10 @@ import { getProviderCredentials, extractSessionAffinityKey } from "@/sse/service
 import { deleteSessionAccountAffinity } from "@/lib/db/sessionAccountAffinity";
 import { getCacheControlSettings } from "@/lib/cacheControlSettings";
 import { guardrailRegistry } from "@/lib/guardrails";
-import { shouldPreserveCacheControl } from "../utils/cacheControlPolicy.ts";
+import {
+  shouldPreserveCacheControl,
+  resolveConnectionCacheOverride,
+} from "../utils/cacheControlPolicy.ts";
 import { getCachedSettings } from "@/lib/db/readCache";
 import { applyCodexGlobalFastServiceTier } from "@/lib/providers/codexFastTier";
 import { buildUpstreamHeadersForExecute as buildUpstreamHeadersForExecuteFor } from "./chatCore/upstreamExecuteHeaders.ts";
@@ -1180,12 +1183,15 @@ export async function handleChatCore({
       if (compressionHeader) {
         log?.debug?.("COMPRESSION", `x-omniroute-compression header: ${compressionHeader}`);
       }
+      const connectionCacheOverride = resolveConnectionCacheOverride(
+        credentials?.providerSpecificData
+      );
       const modeBeforeOutputTransform = selectCompressionStrategy(
         config,
         compressionComboKey,
         estimatedTokens,
         body as Record<string, unknown>,
-        { provider, targetFormat, model: effectiveModel },
+        { provider, targetFormat, model: effectiveModel, connectionCacheOverride },
         namedCombos,
         compressionHeader
       );
@@ -1284,7 +1290,7 @@ export async function handleChatCore({
         compressionComboKey,
         estimatedTokens,
         compressionInputBody,
-        { provider, targetFormat, model: effectiveModel },
+        { provider, targetFormat, model: effectiveModel, connectionCacheOverride },
         namedCombos,
         compressionHeader,
         {
@@ -1323,7 +1329,7 @@ export async function handleChatCore({
         // #3890: in a caching context, never compress the system prompt (cacheable prefix)
         // even if the operator disabled preserveSystemPrompt — honors the cache-aware flag
         // that selectCompressionStrategy can only partially apply via the mode string.
-        const cacheCtx = { provider, targetFormat, model: effectiveModel };
+        const cacheCtx = { provider, targetFormat, model: effectiveModel, connectionCacheOverride };
         const compressionConfig = resolveCacheAwareConfig(config, compressionInputBody, cacheCtx);
         const result = await applyCompressionAsync(compressionInputBody, mode, {
           model: effectiveModel,
@@ -1455,6 +1461,7 @@ export async function handleChatCore({
               effectiveModel,
               mode,
               stats: result.stats,
+              connectionCacheOverride,
               log,
             });
             log?.info?.(
@@ -1650,6 +1657,7 @@ export async function handleChatCore({
   // Determine if we should preserve client-side cache_control headers
   // Fetch settings from DB to get user preference
   const cacheControlMode = await getCacheControlSettings().catch(() => "auto" as const);
+  const connectionCacheOverride = resolveConnectionCacheOverride(credentials?.providerSpecificData);
   const preserveCacheControl = shouldPreserveCacheControl({
     userAgent,
     isCombo,
@@ -1657,6 +1665,7 @@ export async function handleChatCore({
     targetProvider: provider,
     targetFormat,
     settings: { alwaysPreserveClientCache: cacheControlMode },
+    connectionCacheOverride,
   });
 
   if (preserveCacheControl) {

--- a/open-sse/handlers/chatCore/compressionCacheStats.ts
+++ b/open-sse/handlers/chatCore/compressionCacheStats.ts
@@ -8,6 +8,8 @@
  * affects the request. Behaviour is byte-identical to the previous inline block.
  */
 
+import type { ConnectionCacheOverride } from "../../utils/cacheControlPolicy.ts";
+
 type LoggerLike = { debug?: (...args: unknown[]) => void } | null | undefined;
 
 export function recordCompressionCacheStats(args: {
@@ -17,6 +19,7 @@ export function recordCompressionCacheStats(args: {
   effectiveModel: string | null | undefined;
   mode: string;
   stats: { originalTokens: number; compressedTokens: number };
+  connectionCacheOverride?: ConnectionCacheOverride | null;
   log?: LoggerLike;
 }): void {
   void (async () => {
@@ -27,6 +30,7 @@ export function recordCompressionCacheStats(args: {
         provider: args.provider,
         targetFormat: args.targetFormat,
         model: args.effectiveModel,
+        connectionCacheOverride: args.connectionCacheOverride ?? null,
       });
       const tokensSavedCompression = Math.max(
         0,

--- a/open-sse/handlers/chatCore/upstreamBody.ts
+++ b/open-sse/handlers/chatCore/upstreamBody.ts
@@ -15,12 +15,19 @@ import {
   resolvePayloadRuleProtocols,
 } from "../../services/payloadRules.ts";
 import { getEffectiveToolLimit, getKnownToolLimit } from "../../services/toolLimitDetector.ts";
-import { providerSupportsCaching } from "../../utils/cacheControlPolicy.ts";
+import {
+  providerSupportsCaching,
+  resolveConnectionCacheOverride,
+  type ConnectionCacheOverride,
+} from "../../utils/cacheControlPolicy.ts";
 import { FORMATS } from "../../translator/formats.ts";
 
 type LoggerLike = { debug?: (...args: unknown[]) => void } | null | undefined;
 type Body = Record<string, unknown>;
-type CredentialsLike = { apiKey?: unknown; accessToken?: unknown } | null | undefined;
+type CredentialsLike =
+  | { apiKey?: unknown; accessToken?: unknown; providerSpecificData?: Record<string, unknown> | null }
+  | null
+  | undefined;
 
 function buildAppliedRulesSummary(
   applied: Array<{ type: string; path: string; value?: unknown }>
@@ -100,11 +107,12 @@ function backfillQwenOAuthUser(
 async function injectPromptCacheKey(
   bodyToSend: Body,
   provider: string | null | undefined,
-  targetFormat: string
+  targetFormat: string,
+  connectionCacheOverride: ConnectionCacheOverride | null
 ): Promise<Body> {
   if (
     targetFormat === FORMATS.OPENAI &&
-    providerSupportsCaching(provider) &&
+    providerSupportsCaching(provider, undefined, connectionCacheOverride) &&
     !bodyToSend.prompt_cache_key &&
     Array.isArray(bodyToSend.messages) &&
     !["nvidia", "codex", "xai"].includes(provider)
@@ -162,7 +170,8 @@ export async function prepareUpstreamBody(opts: {
 
   bodyToSend = truncateToolList(bodyToSend, provider, bypassDefaultToolLimit ?? false, log);
   bodyToSend = backfillQwenOAuthUser(bodyToSend, provider, credentials, log);
-  bodyToSend = await injectPromptCacheKey(bodyToSend, provider, targetFormat);
+  const connectionCacheOverride = resolveConnectionCacheOverride(credentials?.providerSpecificData);
+  bodyToSend = await injectPromptCacheKey(bodyToSend, provider, targetFormat, connectionCacheOverride);
 
   return bodyToSend;
 }

--- a/open-sse/services/compression/cachingAware.ts
+++ b/open-sse/services/compression/cachingAware.ts
@@ -6,7 +6,10 @@
  * @exports CachingContext, CacheAwareStrategy, detectCachingContext, getCacheAwareStrategy
  */
 
-import { providerSupportsCaching } from "../../utils/cacheControlPolicy.ts";
+import {
+  providerSupportsCaching,
+  type ConnectionCacheOverride,
+} from "../../utils/cacheControlPolicy.ts";
 
 type JsonRecord = Record<string, unknown>;
 
@@ -14,6 +17,7 @@ export interface CachingDetectionContext {
   provider?: string | null;
   targetFormat?: string | null;
   model?: string | null;
+  connectionCacheOverride?: ConnectionCacheOverride | null;
 }
 
 export interface CachingContext {
@@ -94,7 +98,7 @@ export function detectCachingContext(
     hasCacheControl: hasCacheControl(body),
     provider,
     targetFormat,
-    isCachingProvider: providerSupportsCaching(provider, targetFormat),
+    isCachingProvider: providerSupportsCaching(provider, targetFormat, context.connectionCacheOverride),
   };
 }
 

--- a/open-sse/translator/index.ts
+++ b/open-sse/translator/index.ts
@@ -9,7 +9,10 @@ import {
   prepareClaudeRequest,
 } from "./helpers/claudeHelper.ts";
 import { filterToOpenAIFormat } from "./helpers/openaiHelper.ts";
-import { providerHonorsOpenAIFormatCacheControl } from "../utils/cacheControlPolicy.ts";
+import {
+  providerHonorsOpenAIFormatCacheControl,
+  resolveConnectionCacheOverride,
+} from "../utils/cacheControlPolicy.ts";
 import {
   coerceToolSchemas,
   injectEmptyReasoningContentForToolCalls,
@@ -169,6 +172,9 @@ export function translateRequest(
   let result = body;
   const use9CharId = options?.normalizeToolCallId === true;
   const preserveDeveloperRole = options?.preserveDeveloperRole;
+  const connectionCacheOverride = resolveConnectionCacheOverride(
+    (credentials as { providerSpecificData?: unknown } | null)?.providerSpecificData
+  );
 
   // Phase 2: Apply thinking budget control before normalization
   result = applyThinkingBudget(result);
@@ -229,7 +235,7 @@ export function translateRequest(
           // stripped.
           const preserveCacheControl =
             options?.preserveCacheControl === true &&
-            providerHonorsOpenAIFormatCacheControl(provider);
+            providerHonorsOpenAIFormatCacheControl(provider, connectionCacheOverride);
           const step1Credentials =
             options?.copilotClient || hasTargetHint || preserveCacheControl
               ? {
@@ -296,7 +302,8 @@ export function translateRequest(
     // requested upstream; generic/implicit-cache OpenAI providers stay stripped.
     result = filterToOpenAIFormat(result, {
       preserveCacheControl:
-        options?.preserveCacheControl === true && providerHonorsOpenAIFormatCacheControl(provider),
+        options?.preserveCacheControl === true &&
+        providerHonorsOpenAIFormatCacheControl(provider, connectionCacheOverride),
       // #4849 regression guard: keep client reasoning_content for replay providers.
       preserveReasoningContent: isReasoner,
     });

--- a/open-sse/utils/cacheControlPolicy.ts
+++ b/open-sse/utils/cacheControlPolicy.ts
@@ -124,13 +124,53 @@ const OPENAI_FORMAT_CACHE_CONTROL_PROVIDERS = new Set([
 ]);
 
 /**
+ * Per-connection override for cache behavior, resolved from the connection's
+ * `provider_specific_data.cache` JSON sub-object (see `resolveConnectionCacheOverride`).
+ * Lets an operator opt a custom/openai-compatible connection into prompt-cache
+ * behavior that the hardcoded provider-name sets above can never match (#6880).
+ */
+export interface ConnectionCacheOverride {
+  supportsPromptCaching?: boolean;
+  cacheControlPassthrough?: "strip" | "openai-format" | "claude-format";
+}
+
+/**
+ * Extract and validate a `ConnectionCacheOverride` from a connection's
+ * `providerSpecificData` bag. Returns `null` when absent/malformed so every
+ * call site can safely pass the result straight through.
+ */
+export function resolveConnectionCacheOverride(
+  providerSpecificData: unknown
+): ConnectionCacheOverride | null {
+  if (!providerSpecificData || typeof providerSpecificData !== "object") return null;
+  const cache = (providerSpecificData as Record<string, unknown>).cache;
+  if (!cache || typeof cache !== "object" || Array.isArray(cache)) return null;
+  const record = cache as Record<string, unknown>;
+  const result: ConnectionCacheOverride = {};
+  if (typeof record.supportsPromptCaching === "boolean") {
+    result.supportsPromptCaching = record.supportsPromptCaching;
+  }
+  if (
+    record.cacheControlPassthrough === "strip" ||
+    record.cacheControlPassthrough === "openai-format" ||
+    record.cacheControlPassthrough === "claude-format"
+  ) {
+    result.cacheControlPassthrough = record.cacheControlPassthrough;
+  }
+  return Object.keys(result).length > 0 ? result : null;
+}
+
+/**
  * Whether `cache_control` markers should be PASSED THROUGH the OpenAI-format
  * translation for this provider (vs. stripped). Used to gate the request-side
  * passthrough so generic / implicit-cache OpenAI providers keep getting cleaned.
  */
 export function providerHonorsOpenAIFormatCacheControl(
-  provider: string | null | undefined
+  provider: string | null | undefined,
+  connectionCacheOverride?: ConnectionCacheOverride | null
 ): boolean {
+  if (connectionCacheOverride?.cacheControlPassthrough === "openai-format") return true;
+  if (connectionCacheOverride?.cacheControlPassthrough === "strip") return false;
   if (!provider) return false;
   return OPENAI_FORMAT_CACHE_CONTROL_PROVIDERS.has(provider.toLowerCase());
 }
@@ -159,8 +199,12 @@ export function isClaudeCodeClient(userAgent: string | null | undefined): boolea
  */
 export function providerSupportsCaching(
   provider: string | null | undefined,
-  targetFormat?: string | null
+  targetFormat?: string | null,
+  connectionCacheOverride?: ConnectionCacheOverride | null
 ): boolean {
+  if (typeof connectionCacheOverride?.supportsPromptCaching === "boolean") {
+    return connectionCacheOverride.supportsPromptCaching;
+  }
   if (!provider) return false;
   if (CACHING_PROVIDERS.has(provider.toLowerCase())) return true;
   // All Claude-protocol providers support prompt caching
@@ -195,6 +239,7 @@ export function shouldPreserveCacheControl({
   targetProvider,
   targetFormat,
   settings,
+  connectionCacheOverride,
 }: {
   userAgent: string | null | undefined;
   isCombo: boolean;
@@ -202,6 +247,7 @@ export function shouldPreserveCacheControl({
   targetProvider: string | null | undefined;
   targetFormat?: string | null;
   settings?: CacheControlSettings;
+  connectionCacheOverride?: ConnectionCacheOverride | null;
 }): boolean {
   // User override takes precedence
   if (settings?.alwaysPreserveClientCache === "always") {
@@ -218,7 +264,7 @@ export function shouldPreserveCacheControl({
   }
 
   // Target provider must support caching
-  if (!providerSupportsCaching(targetProvider, targetFormat)) {
+  if (!providerSupportsCaching(targetProvider, targetFormat, connectionCacheOverride)) {
     return false;
   }
 

--- a/src/lib/providers/requestDefaults.ts
+++ b/src/lib/providers/requestDefaults.ts
@@ -129,6 +129,54 @@ export function normalizeRequestDefaults(
   return Object.keys(normalized).length > 0 ? normalized : undefined;
 }
 
+const CACHE_PASSTHROUGH_VALUES = new Set(["strip", "openai-format", "claude-format"]);
+
+// #6880 — per-connection prompt-cache capability override: strip unknown keys / invalid
+// types, drop the sub-object entirely when nothing valid survives.
+export function normalizeCacheOverride(value: unknown): JsonRecord | undefined {
+  const record = asRecord(value);
+  if (Object.keys(record).length === 0) return undefined;
+
+  const normalized: JsonRecord = {};
+  if (typeof record.supportsPromptCaching === "boolean") {
+    normalized.supportsPromptCaching = record.supportsPromptCaching;
+  }
+  if (
+    typeof record.cacheControlPassthrough === "string" &&
+    CACHE_PASSTHROUGH_VALUES.has(record.cacheControlPassthrough)
+  ) {
+    normalized.cacheControlPassthrough = record.cacheControlPassthrough;
+  }
+
+  return Object.keys(normalized).length > 0 ? normalized : undefined;
+}
+
+// #6880 — extracted so normalizeProviderSpecificData() stays under the
+// max-lines-per-function gate: normalizes the two nested-object sub-fields
+// (requestDefaults, cache) in one pass.
+function normalizeNestedSubObjects(
+  provider: string | null | undefined,
+  normalized: JsonRecord
+): void {
+  if ("requestDefaults" in normalized) {
+    const requestDefaults = normalizeRequestDefaults(provider, normalized.requestDefaults);
+    if (requestDefaults) {
+      normalized.requestDefaults = requestDefaults;
+    } else {
+      delete normalized.requestDefaults;
+    }
+  }
+
+  if ("cache" in normalized) {
+    const cache = normalizeCacheOverride(normalized.cache);
+    if (cache) {
+      normalized.cache = cache;
+    } else {
+      delete normalized.cache;
+    }
+  }
+}
+
 export function normalizeProviderSpecificData(
   provider: string | null | undefined,
   value: unknown
@@ -138,14 +186,7 @@ export function normalizeProviderSpecificData(
 
   const normalized: JsonRecord = { ...record };
 
-  if ("requestDefaults" in normalized) {
-    const requestDefaults = normalizeRequestDefaults(provider, normalized.requestDefaults);
-    if (requestDefaults) {
-      normalized.requestDefaults = requestDefaults;
-    } else {
-      delete normalized.requestDefaults;
-    }
-  }
+  normalizeNestedSubObjects(provider, normalized);
 
   if ("openaiStoreEnabled" in normalized && typeof normalized.openaiStoreEnabled !== "boolean") {
     delete normalized.openaiStoreEnabled;

--- a/src/shared/validation/providerSpecificData.ts
+++ b/src/shared/validation/providerSpecificData.ts
@@ -15,6 +15,44 @@ function isHttpUrl(value: string): boolean {
 
 const CODEX_REASONING_EFFORT_VALUES = new Set(["none", "low", "medium", "high", "xhigh", "max"]);
 const REQUEST_DEFAULT_SERVICE_TIER_VALUES = new Set(["default", "priority", "fast", "flex"]);
+const CACHE_PASSTHROUGH_VALUES = new Set(["strip", "openai-format", "claude-format"]);
+
+// #6880 — per-connection prompt-cache capability override, extracted so
+// validateProviderSpecificData() stays under the complexity gate.
+function validateCacheBlock(data: Record<string, unknown>, ctx: z.RefinementCtx): void {
+  const cache = data.cache;
+  if (cache === undefined) return;
+  if (!cache || typeof cache !== "object" || Array.isArray(cache)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "providerSpecificData.cache must be an object",
+      path: ["cache"],
+    });
+    return;
+  }
+  const cacheRecord = cache as Record<string, unknown>;
+  const supportsPromptCaching = cacheRecord.supportsPromptCaching;
+  if (supportsPromptCaching !== undefined && typeof supportsPromptCaching !== "boolean") {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "providerSpecificData.cache.supportsPromptCaching must be a boolean",
+      path: ["cache", "supportsPromptCaching"],
+    });
+  }
+  const cacheControlPassthrough = cacheRecord.cacheControlPassthrough;
+  if (
+    cacheControlPassthrough !== undefined &&
+    (typeof cacheControlPassthrough !== "string" ||
+      !CACHE_PASSTHROUGH_VALUES.has(cacheControlPassthrough))
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message:
+        'providerSpecificData.cache.cacheControlPassthrough must be one of "strip", "openai-format", "claude-format"',
+      path: ["cache", "cacheControlPassthrough"],
+    });
+  }
+}
 
 export function validateProviderSpecificData(
   data: Record<string, unknown> | undefined,
@@ -162,6 +200,8 @@ export function validateProviderSpecificData(
       }
     }
   }
+
+  validateCacheBlock(data, ctx);
 
   const consoleApiKey = data.consoleApiKey;
   if (consoleApiKey !== undefined && consoleApiKey !== null && typeof consoleApiKey !== "string") {

--- a/tests/unit/connection-cache-override-6880.test.ts
+++ b/tests/unit/connection-cache-override-6880.test.ts
@@ -1,0 +1,207 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import type { z } from "zod";
+import {
+  providerSupportsCaching,
+  providerHonorsOpenAIFormatCacheControl,
+  resolveConnectionCacheOverride,
+  shouldPreserveCacheControl,
+} from "../../open-sse/utils/cacheControlPolicy.ts";
+import {
+  detectCachingContext,
+  getCacheAwareStrategy,
+} from "../../open-sse/services/compression/cachingAware.ts";
+import { validateProviderSpecificData } from "../../src/shared/validation/providerSpecificData.ts";
+import { normalizeProviderSpecificData } from "../../src/lib/providers/requestDefaults.ts";
+
+// Regression for #6880: a custom/openai-compatible connection (provider id like
+// `openai-compatible-chat-<uuid>`) can never match the hardcoded CACHING_PROVIDERS /
+// OPENAI_FORMAT_CACHE_CONTROL_PROVIDERS name sets in cacheControlPolicy.ts, so cache
+// behaviors (prompt_cache_key injection, the compression cache-aware guard, and
+// cache_control passthrough) are permanently disabled for that class of connections with
+// no way to opt in. This adds a per-connection `cache` capability override consulted
+// first by the policy functions, defaulting to today's hardcoded-set behavior.
+
+function collectIssues(): { ctx: z.RefinementCtx; issues: Array<{ path: (string | number)[]; message: string }> } {
+  const issues: Array<{ path: (string | number)[]; message: string }> = [];
+  const ctx = {
+    addIssue: (issue: { path?: (string | number)[]; message: string }) => {
+      issues.push({ path: issue.path ?? [], message: issue.message });
+    },
+  } as unknown as z.RefinementCtx;
+  return { ctx, issues };
+}
+
+describe("#6880 resolveConnectionCacheOverride", () => {
+  test("returns null for undefined/non-object/empty cache", () => {
+    assert.equal(resolveConnectionCacheOverride(undefined), null);
+    assert.equal(resolveConnectionCacheOverride(null), null);
+    assert.equal(resolveConnectionCacheOverride("nope"), null);
+    assert.equal(resolveConnectionCacheOverride({}), null);
+    assert.equal(resolveConnectionCacheOverride({ cache: null }), null);
+    assert.equal(resolveConnectionCacheOverride({ cache: [] }), null);
+    assert.equal(resolveConnectionCacheOverride({ cache: {} }), null);
+  });
+
+  test("extracts valid fields and drops invalid/unknown values", () => {
+    const result = resolveConnectionCacheOverride({
+      cache: {
+        supportsPromptCaching: true,
+        cacheControlPassthrough: "openai-format",
+        unknownField: "ignored",
+      },
+    });
+    assert.deepEqual(result, {
+      supportsPromptCaching: true,
+      cacheControlPassthrough: "openai-format",
+    });
+
+    const invalid = resolveConnectionCacheOverride({
+      cache: { supportsPromptCaching: "yes", cacheControlPassthrough: "bogus" },
+    });
+    assert.equal(invalid, null);
+  });
+});
+
+describe("#6880 providerSupportsCaching override", () => {
+  test("unblocks a custom openai-compatible connection when the override opts in", () => {
+    assert.equal(
+      providerSupportsCaching("openai-compatible-chat-abc123", undefined, {
+        supportsPromptCaching: true,
+      }),
+      true
+    );
+  });
+
+  test("no override -> default hardcoded-set behavior is unchanged", () => {
+    assert.equal(providerSupportsCaching("openai-compatible-chat-abc123"), false);
+  });
+
+  test("explicit opt-out overrides the hardcoded set", () => {
+    assert.equal(providerSupportsCaching("claude", undefined, { supportsPromptCaching: false }), false);
+  });
+});
+
+describe("#6880 providerHonorsOpenAIFormatCacheControl override", () => {
+  test("openai-format override enables passthrough for a non-hardcoded provider", () => {
+    assert.equal(
+      providerHonorsOpenAIFormatCacheControl("grok-custom", { cacheControlPassthrough: "openai-format" }),
+      true
+    );
+  });
+
+  test("strip override disables passthrough", () => {
+    assert.equal(
+      providerHonorsOpenAIFormatCacheControl("grok-custom", { cacheControlPassthrough: "strip" }),
+      false
+    );
+  });
+
+  test("no override -> default hardcoded-set behavior is unchanged", () => {
+    assert.equal(providerHonorsOpenAIFormatCacheControl("grok-custom"), false);
+    assert.equal(providerHonorsOpenAIFormatCacheControl("alibaba"), true);
+  });
+});
+
+describe("#6880 shouldPreserveCacheControl override", () => {
+  test("preserves cache_control for a non-hardcoded provider when override opts in", () => {
+    const result = shouldPreserveCacheControl({
+      userAgent: "claude-code/1.0",
+      isCombo: false,
+      targetProvider: "openai-compatible-chat-abc123",
+      targetFormat: "openai",
+      connectionCacheOverride: { supportsPromptCaching: true },
+    });
+    assert.equal(result, true);
+  });
+
+  test("no override -> non-hardcoded provider still not preserved", () => {
+    const result = shouldPreserveCacheControl({
+      userAgent: "claude-code/1.0",
+      isCombo: false,
+      targetProvider: "openai-compatible-chat-abc123",
+      targetFormat: "openai",
+    });
+    assert.equal(result, false);
+  });
+});
+
+describe("#6880 compression cache-aware guard", () => {
+  test("detectCachingContext reports isCachingProvider=true when the override opts in", () => {
+    const ctx = detectCachingContext(
+      { messages: [{ role: "user", content: "hi" }] },
+      {
+        provider: "openai-compatible-chat-xyz",
+        targetFormat: "openai",
+        connectionCacheOverride: { supportsPromptCaching: true },
+      }
+    );
+    assert.equal(ctx.isCachingProvider, true);
+  });
+
+  test("detectCachingContext without override keeps default (non-caching) behavior", () => {
+    const ctx = detectCachingContext(
+      { messages: [{ role: "user", content: "hi" }] },
+      { provider: "openai-compatible-chat-xyz", targetFormat: "openai" }
+    );
+    assert.equal(ctx.isCachingProvider, false);
+  });
+
+  test("getCacheAwareStrategy protects the cacheable prefix for an overridden context", () => {
+    const ctx = detectCachingContext(
+      { messages: [{ role: "user", content: "hi" }] },
+      {
+        provider: "openai-compatible-chat-xyz",
+        targetFormat: "openai",
+        connectionCacheOverride: { supportsPromptCaching: true },
+      }
+    );
+    const strategy = getCacheAwareStrategy("aggressive", ctx);
+    assert.equal(strategy.skipSystemPrompt, true);
+    assert.equal(strategy.deterministicOnly, true);
+  });
+});
+
+describe("#6880 validateProviderSpecificData cache block", () => {
+  test("accepts a well-formed cache block", () => {
+    const { ctx, issues } = collectIssues();
+    validateProviderSpecificData(
+      { cache: { supportsPromptCaching: true, cacheControlPassthrough: "openai-format" } },
+      ctx
+    );
+    assert.deepEqual(issues, []);
+  });
+
+  test("rejects a non-object cache", () => {
+    const { ctx, issues } = collectIssues();
+    validateProviderSpecificData({ cache: "nope" }, ctx);
+    assert.equal(issues.length, 1);
+    assert.deepEqual(issues[0]?.path, ["cache"]);
+  });
+
+  test("rejects an invalid cacheControlPassthrough value", () => {
+    const { ctx, issues } = collectIssues();
+    validateProviderSpecificData({ cache: { cacheControlPassthrough: "bogus" } }, ctx);
+    assert.equal(issues.length, 1);
+    assert.deepEqual(issues[0]?.path, ["cache", "cacheControlPassthrough"]);
+  });
+});
+
+describe("#6880 normalizeProviderSpecificData cache block", () => {
+  test("strips an invalid cache sub-object down to nothing (key deleted)", () => {
+    const normalized = normalizeProviderSpecificData("openai-compatible-chat-xyz", {
+      cache: { supportsPromptCaching: "yes", cacheControlPassthrough: "bogus" },
+    });
+    assert.equal(normalized?.cache, undefined);
+  });
+
+  test("preserves a valid cache sub-object", () => {
+    const normalized = normalizeProviderSpecificData("openai-compatible-chat-xyz", {
+      cache: { supportsPromptCaching: true, cacheControlPassthrough: "openai-format", junk: 1 },
+    });
+    assert.deepEqual(normalized?.cache, {
+      supportsPromptCaching: true,
+      cacheControlPassthrough: "openai-format",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

All prompt-cache handling was gated on the hardcoded provider-name set `CACHING_PROVIDERS` in `open-sse/utils/cacheControlPolicy.ts`. A user-added openai-compatible connection gets a provider id like `openai-compatible-chat-<uuid>`, which can never match that set — permanently disabling three cache behaviors for the entire class of custom/proxy providers, with no way to opt in:

1. `prompt_cache_key` injection (`injectPromptCacheKey`, `chatCore/upstreamBody.ts`)
2. The cache-aware compression guard (`compression/cachingAware.ts`)
3. `cache_control` passthrough (`shouldPreserveCacheControl` / `OPENAI_FORMAT_CACHE_CONTROL_PROVIDERS`)

This adds a per-connection `cache` capability override stored in the connection's existing `provider_specific_data` JSON column (same generic bag already used for `disableCooling`, `openaiStoreEnabled`, `requestDefaults`, etc — **no new DB column/migration**):

```jsonc
{
  "cache": {
    "supportsPromptCaching": true,
    "cacheControlPassthrough": "strip" | "openai-format" | "claude-format"
  }
}
```

`providerSupportsCaching()` and `providerHonorsOpenAIFormatCacheControl()` now consult the override first, then fall back to the hardcoded sets. Default (no override) is byte-identical to today's behavior — no regression for existing setups. An explicit `supportsPromptCaching: false` also works as an opt-out escape hatch.

Threaded the resolved override through the four request-time call sites that gate on these two policy functions: `upstreamBody.ts` (prompt_cache_key injection), `chatCore.ts` (both the `shouldPreserveCacheControl` call and the compression cache-aware chokepoint — `selectCompressionStrategy`, `selectCompressionPlan`, and the `#3890` cacheable-prefix guard), `cachingAware.ts` (`detectCachingContext`), and `translator/index.ts` (both OpenAI-format cache_control passthrough call sites).

Added Zod validation (`validateProviderSpecificData`) and normalization (`normalizeProviderSpecificData`) for the new `cache` sub-object, mirroring the existing `requestDefaults` nested-object pattern.

**Scope note**: the dashboard UI toggle (plan Step 5) and its i18n keys (Step 7) were deferred — `EditConnectionModal.tsx` is frozen at 1278 lines in `config/quality/file-size-baseline.json` with only 3 lines of headroom, not enough for the two new form fields. Per the plan's own escape hatch, operators can set the override today via a direct `PATCH /api/providers/:id` call with `{"providerSpecificData": {"cache": {...}}}` (already accepted — the validation/normalization in this PR covers it); the UI toggle can follow in a small dedicated PR.

Also out of scope (documented, not silently dropped): `detectCachingContext()`'s other two callers — `memorySkillsInjection.ts` (only reads `.hasCacheControl`, unaffected) and QuantumLock's `quantumCachingContext()` helper (niche opt-in engine, not implicated in the reported evidence).

## Validation

- New test file `tests/unit/connection-cache-override-6880.test.ts` (18 tests, TDD): `resolveConnectionCacheOverride` shape validation, `providerSupportsCaching`/`providerHonorsOpenAIFormatCacheControl` override + opt-out + default-unchanged behavior, `shouldPreserveCacheControl` with the override, `detectCachingContext`/`getCacheAwareStrategy` compression-guard protection, and `validateProviderSpecificData`/`normalizeProviderSpecificData` accept/reject/strip behavior for the new `cache` block.
- Regression: `tests/unit/cache-control-policy.test.ts`, `tests/unit/dashscope-cache-control-openai-2069.test.ts`, `tests/unit/compression-cache-guard-3955.test.ts`, `tests/unit/claude-cache-control-passthrough.test.ts` (59 tests) all still pass unmodified — default/no-override behavior is byte-identical.
- `npm run lint` — clean on all changed files.
- `npm run typecheck:core` — clean.
- `npm run typecheck:noimplicit:core` — clean on changed files (pre-existing unrelated errors in `open-sse/services/combo.ts`, `open-sse/utils/usageTracking.ts`, `src/shared/services/cliRuntime.ts` confirmed present on `origin/release/v3.8.49` too — not touched by this PR).
- `node scripts/check/check-complexity.mjs` — initially regressed (`normalizeProviderSpecificData` crossed the 80-line max-lines-per-function cap); fixed by extracting the nested `requestDefaults`/`cache` normalization into a small `normalizeNestedSubObjects()` helper. Final: exact match to baseline (2056 violations == baseline 2056).
- `node scripts/check/check-file-size.mjs` — no violations on touched files.
- `npm run check:cycles` — no cycles.

Closes #6880