### PR TITLE
fix: resolve nested combo-ref panel members in fusion strategy (#6764)

### DIFF
--- a/changelog.d/fixes/6764-fusion-combo-ref.md
+++ b/changelog.d/fixes/6764-fusion-combo-ref.md
@@ -1,0 +1,1 @@
+- **fix(routing):** fusion combos no longer silently drop `combo-ref` panel members — a referenced combo is now dispatched as one black-box panel voice instead of being dropped (#6764)

--- a/docs/routing/AUTO-COMBO.md
+++ b/docs/routing/AUTO-COMBO.md
@@ -225,6 +225,11 @@ How it works:
 4. **Graceful degradation** — 0 panel answers → `503`; exactly 1 survivor → that answer
    is returned directly (nothing to fuse); a single-model panel answers directly.
 
+A panel member may also be a `combo-ref` step (`{kind: "combo-ref", comboName: "..."}`) referencing
+another combo — it resolves as **one black-box panel voice** (a full recursive dispatch into the
+referenced combo, not a fan-out of that combo's own targets), with the same depth/cycle protection
+every other combo-ref-consuming strategy already uses (#6764).
+
 ### Configuration
 
 Configured on the combo's `config` blob (no schema migration — it reuses the existing

--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -146,6 +146,7 @@ import {
 } from "./combo/comboPredicates.ts";
 import { applyComboTargetExhaustion } from "./combo/targetExhaustion.ts";
 import { executeRuntimeUnitCombo } from "./combo/runtimeUnits.ts";
+import { extractFusionPanelSpec, buildFusionHandleSingleModel } from "./combo/fusionPanel.ts";
 import { isRecord } from "./combo/comboData.ts";
 import {
   expandProviderWildcardsInCombo,
@@ -818,20 +819,47 @@ export async function handleComboChat({
     );
   }
   if (strategy === "fusion") {
-    const fusionModels = (combo.models || [])
-      .map((m) => {
-        if (typeof m === "string") return m;
-        if (m && typeof m === "object") {
-          const obj = m as Record<string, unknown>;
-          if (typeof obj.model === "string") return obj.model;
-        }
-        return null;
-      })
-      .filter((m): m is string => Boolean(m));
+    const { panel: fusionModels, comboRefUnits } = extractFusionPanelSpec(
+      combo.models || [],
+      combo.name,
+      allCombos
+    );
+    // Untyped like the existing `nestingContext` further down — `nesting` is
+    // already `ComboNestingContext | null` per HandleComboChatOptions, no new
+    // import needed.
+    const fusionNesting = nesting || {
+      depth: 0,
+      maxDepth: clampComboDepth(config.maxComboDepth),
+      visitedComboNames: [combo.name],
+      rootComboName: combo.name,
+      attemptBudget: { count: 0, limit: MAX_GLOBAL_ATTEMPTS },
+    };
+    const fusionHandleSingleModel =
+      comboRefUnits.size > 0
+        ? buildFusionHandleSingleModel({
+            handleSingleModel: handleSingleModelWithTimeout,
+            comboRefUnits,
+            allCombos,
+            nesting: fusionNesting,
+            baseOptions: {
+              body,
+              combo,
+              handleSingleModel,
+              isModelAvailable,
+              log,
+              settings,
+              allCombos,
+              relayOptions,
+              signal,
+              apiKeyAllowedConnections,
+            },
+            runCombo: handleComboChat,
+          })
+        : handleSingleModelWithTimeout;
     return handleFusionChat({
       body,
       models: fusionModels,
-      handleSingleModel: handleSingleModelWithTimeout,
+      handleSingleModel: fusionHandleSingleModel,
       log,
       comboName: combo.name,
       judgeModel,

--- a/open-sse/services/combo/fusionPanel.ts
+++ b/open-sse/services/combo/fusionPanel.ts
@@ -1,0 +1,79 @@
+/**
+ * Fusion panel member extraction — resolves combo.models entries for the
+ * fusion strategy, including nested `combo-ref` steps (#6764).
+ *
+ * A combo-ref panel member is dispatched as ONE black-box panel voice (a full
+ * recursive handleComboChat call for the referenced combo, reusing the same
+ * executeComboRefUnit + cycle/depth guards every other combo-ref-consuming
+ * strategy already uses) — NOT a fan-out of the referenced combo's own
+ * targets. This keeps panel sizing and cost predictable and matches how a
+ * literal `auto/*` string panel member already behaves via the single-
+ * dispatch safety net in src/sse/handlers/chat.ts.
+ */
+import { normalizeComboStep } from "../../../src/lib/combos/steps.ts";
+import { executeComboRefUnit } from "./runtimeUnits.ts";
+import type {
+  ComboCollectionLike,
+  ComboNestingContext,
+  HandleComboChatOptions,
+  HandleSingleModel,
+  ResolvedComboRefTarget,
+} from "./types.ts";
+
+export type FusionPanelSpec = {
+  /** Dispatch keys handed to fusion.ts's `models` — comboName for combo-ref members, plain model string otherwise. */
+  panel: string[];
+  /** comboName -> resolved combo-ref unit, consumed by buildFusionHandleSingleModel. */
+  comboRefUnits: Map<string, ResolvedComboRefTarget>;
+};
+
+export function extractFusionPanelSpec(
+  models: unknown[],
+  comboName: string,
+  allCombos: ComboCollectionLike
+): FusionPanelSpec {
+  const panel: string[] = [];
+  const comboRefUnits = new Map<string, ResolvedComboRefTarget>();
+  models.forEach((entry, index) => {
+    const step = normalizeComboStep(entry, { comboName, index, allCombos });
+    if (!step) return;
+    if (step.kind === "combo-ref") {
+      if (!comboRefUnits.has(step.comboName)) {
+        comboRefUnits.set(step.comboName, {
+          kind: "combo-ref",
+          stepId: step.id,
+          executionKey: step.id,
+          comboName: step.comboName,
+          weight: step.weight,
+          label: step.label ?? null,
+        });
+      }
+      panel.push(step.comboName);
+      return;
+    }
+    panel.push(step.model);
+  });
+  return { panel, comboRefUnits };
+}
+
+export function buildFusionHandleSingleModel(args: {
+  handleSingleModel: HandleSingleModel;
+  comboRefUnits: Map<string, ResolvedComboRefTarget>;
+  allCombos: ComboCollectionLike;
+  nesting: ComboNestingContext;
+  baseOptions: HandleComboChatOptions;
+  runCombo: (options: HandleComboChatOptions) => Promise<Response>;
+}): HandleSingleModel {
+  return (body, modelStr, target) => {
+    const unit = args.comboRefUnits.get(modelStr);
+    if (!unit) return args.handleSingleModel(body, modelStr, target);
+    return executeComboRefUnit({
+      body,
+      unit,
+      allCombos: args.allCombos,
+      runCombo: args.runCombo,
+      baseOptions: args.baseOptions,
+      nesting: args.nesting,
+    });
+  };
+}

--- a/open-sse/services/combo/runtimeUnits.ts
+++ b/open-sse/services/combo/runtimeUnits.ts
@@ -98,7 +98,7 @@ function buildChildNestingContext(args: {
   };
 }
 
-async function executeComboRefUnit(args: {
+export async function executeComboRefUnit(args: {
   body: Record<string, unknown>;
   unit: ResolvedComboRefTarget;
   allCombos: ComboCollectionLike;

--- a/tests/unit/combo-fusion-strategy-comboref-6764.test.ts
+++ b/tests/unit/combo-fusion-strategy-comboref-6764.test.ts
@@ -1,0 +1,190 @@
+/**
+ * #6764 — fusion strategy silently dropped `combo-ref` panel members.
+ *
+ * Every other combo strategy resolves a `{kind:"combo-ref", comboName}` panel
+ * member through the shared execute-mode machinery (see
+ * `open-sse/services/combo/runtimeUnits.ts::executeComboRefUnit`); the fusion
+ * branch in `open-sse/services/combo.ts` only recognized plain `string` or
+ * `{model: string}` entries, so a combo-ref member had neither field and was
+ * filtered out (`.filter(Boolean)`) — no error, no warning. This suite proves
+ * the fix: a combo-ref fusion panel member is dispatched as ONE black-box
+ * panel voice (a recursive `handleComboChat` call into the referenced combo),
+ * not dropped, not fanned out into the referenced combo's own targets.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-combo-fusion-ref-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.API_KEY_SECRET = process.env.API_KEY_SECRET || "combo-fusion-ref-test-secret";
+
+const { handleComboChat } = await import("../../open-sse/services/combo.ts");
+
+const noop = () => {};
+const log = { info: noop, warn: noop, debug: noop, error: noop };
+
+type Body = Record<string, unknown>;
+
+function okResponse(content: string): Response {
+  const body = JSON.stringify({ choices: [{ message: { role: "assistant", content } }] });
+  return new Response(body, { status: 200, headers: { "Content-Type": "application/json" } });
+}
+
+function fusionCombo(models: unknown[], extra: Record<string, unknown> = {}) {
+  return {
+    name: "test-fusion-combo-ref",
+    strategy: "fusion",
+    models,
+    config: extra,
+  };
+}
+
+test("fusion: a combo-ref panel member is dispatched, not silently dropped", async () => {
+  const seen: string[] = [];
+  const handleSingleModel = async (_b: Body, m: string) => {
+    seen.push(m);
+    if (m === "p/judge") return okResponse("FINAL");
+    return okResponse(`ans-${m}`);
+  };
+  const nestedPriority = {
+    name: "nested-priority",
+    strategy: "priority",
+    models: ["openai/nested-a"],
+    config: { maxRetries: 0, retryDelayMs: 0 },
+  };
+  const combo = fusionCombo(
+    [{ kind: "combo-ref", comboName: "nested-priority" }, { model: "p/plain" }],
+    { judgeModel: "p/judge" }
+  );
+
+  const res = await handleComboChat({
+    body: { messages: [{ role: "user", content: "Q" }] },
+    combo,
+    handleSingleModel,
+    log,
+    settings: {},
+    allCombos: [combo, nestedPriority],
+  });
+
+  assert.equal(res.status, 200);
+  // Proves the combo-ref member was actually dispatched (its nested target
+  // model reached handleSingleModel) instead of being silently filtered out.
+  assert.ok(
+    seen.includes("openai/nested-a"),
+    `expected nested combo's target model to be dispatched, saw: ${seen.join(", ")}`
+  );
+  assert.ok(seen.includes("p/plain"), "plain panel member must still dispatch alongside combo-ref");
+});
+
+test("fusion: combo-ref-only panel resolves normally (not a 400 empty-panel error)", async () => {
+  const seen: string[] = [];
+  const handleSingleModel = async (_b: Body, m: string) => {
+    seen.push(m);
+    return okResponse(`ans-${m}`);
+  };
+  const nestedPriority = {
+    name: "solo-nested",
+    strategy: "priority",
+    models: ["openai/solo-target"],
+    config: { maxRetries: 0, retryDelayMs: 0 },
+  };
+  const combo = fusionCombo([{ kind: "combo-ref", comboName: "solo-nested" }]);
+
+  const res = await handleComboChat({
+    body: { messages: [{ role: "user", content: "Q" }] },
+    combo,
+    handleSingleModel,
+    log,
+    settings: {},
+    allCombos: [combo, nestedPriority],
+  });
+
+  assert.notEqual(res.status, 400);
+  assert.ok(seen.includes("openai/solo-target"));
+});
+
+test("fusion: self-referencing combo-ref fails that panel member gracefully, not an infinite loop", async () => {
+  const seen: string[] = [];
+  const handleSingleModel = async (_b: Body, m: string) => {
+    seen.push(m);
+    return okResponse(`ans-${m}`);
+  };
+  const combo = fusionCombo([
+    { kind: "combo-ref", comboName: "test-fusion-combo-ref" },
+    { model: "p/other" },
+  ]);
+
+  const res = await handleComboChat({
+    body: { messages: [{ role: "user", content: "Q" }] },
+    combo,
+    handleSingleModel,
+    log,
+    settings: {},
+    allCombos: [combo],
+  });
+
+  // Overall request still degrades gracefully because "p/other" survives.
+  assert.equal(res.status, 200);
+  assert.ok(seen.includes("p/other"));
+  assert.ok(!seen.includes("test-fusion-combo-ref"));
+});
+
+test("fusion: combo-ref pointing at a nonexistent combo fails only that panel member", async () => {
+  const seen: string[] = [];
+  const handleSingleModel = async (_b: Body, m: string) => {
+    seen.push(m);
+    return okResponse(`ans-${m}`);
+  };
+  const combo = fusionCombo([
+    { kind: "combo-ref", comboName: "does-not-exist" },
+    { model: "p/other" },
+  ]);
+
+  const res = await handleComboChat({
+    body: { messages: [{ role: "user", content: "Q" }] },
+    combo,
+    handleSingleModel,
+    log,
+    settings: {},
+    allCombos: [combo],
+  });
+
+  assert.equal(res.status, 200);
+  assert.ok(seen.includes("p/other"));
+});
+
+test("fusion: mixed plain string / auto-style / combo-ref panel members all dispatch together", async () => {
+  const seen: string[] = [];
+  const handleSingleModel = async (_b: Body, m: string) => {
+    seen.push(m);
+    return okResponse(`ans-${m}`);
+  };
+  const nestedPriority = {
+    name: "mixed-nested",
+    strategy: "priority",
+    models: ["openai/mixed-target"],
+    config: { maxRetries: 0, retryDelayMs: 0 },
+  };
+  const combo = fusionCombo([
+    "auto/best-coding",
+    { model: "p/direct" },
+    { kind: "combo-ref", comboName: "mixed-nested" },
+  ]);
+
+  const res = await handleComboChat({
+    body: { messages: [{ role: "user", content: "Q" }] },
+    combo,
+    handleSingleModel,
+    log,
+    settings: {},
+    allCombos: [combo, nestedPriority],
+  });
+
+  assert.equal(res.status, 200);
+  assert.ok(seen.includes("auto/best-coding"));
+  assert.ok(seen.includes("p/direct"));
+  assert.ok(seen.includes("openai/mixed-target"));
+});


### PR DESCRIPTION
## Summary

Fusion combos silently dropped `{kind:"combo-ref", comboName}` panel members. The dashboard's combo builder already lets you add a "Reference another combo" step to a fusion panel (it's a first-class, Zod-validated combo-step shape used by every other strategy), but fusion's ad-hoc panel-model extraction in `open-sse/services/combo.ts` only recognized plain `string` entries or `{model: string}` objects — a combo-ref step has neither field, so it was filtered out with no error or warning. If it was the only panel member, the request 400'd with an opaque "Fusion combo has no models".

A combo-ref panel member is now dispatched as **one black-box panel voice** — a recursive `handleComboChat` call into the referenced combo, reusing the exact same `executeComboRefUnit` + cycle/depth guards every other combo-ref-consuming strategy (priority/round-robin/random/weighted/etc.) already uses — not a fan-out of the referenced combo's own targets. This keeps panel sizing/cost predictable and mirrors how a literal `auto/*` string panel member already behaves via the single-dispatch safety net.

## Changes

- `open-sse/services/combo/runtimeUnits.ts` — export the already-existing `executeComboRefUnit` (no logic change)
- `open-sse/services/combo/fusionPanel.ts` (new) — `extractFusionPanelSpec()` resolves `combo.models` entries including `combo-ref` steps via the shared `normalizeComboStep`; `buildFusionHandleSingleModel()` wraps `handleSingleModel` to dispatch combo-ref panel members through `executeComboRefUnit`. Kept as a separate module so the frozen `combo.ts` god-file (baseline 3387 lines, ~177 headroom) only grows by the wiring, not the full feature.
- `open-sse/services/combo.ts` — wire the new module into the fusion branch
- `docs/routing/AUTO-COMBO.md` — documents combo-ref panel members under "Fusion Strategy"
- `changelog.d/fixes/6764-fusion-combo-ref.md`

## Test plan (TDD, Hard Rule #18)

New file `tests/unit/combo-fusion-strategy-comboref-6764.test.ts` — written first against the unmodified code and confirmed **failing** (3/5 cases failed: the combo-ref member never reached `handleSingleModel`), then the fix made all 5 pass:

- [x] a combo-ref panel member is dispatched, not silently dropped
- [x] a combo-ref-only panel resolves normally (not the opaque 400)
- [x] a self-referencing combo-ref fails only that panel member gracefully (cycle guard), the rest of the panel still degrades correctly
- [x] a combo-ref pointing at a nonexistent combo fails only that panel member
- [x] a mixed panel (plain string + `auto/*` string + combo-ref) all dispatch together — regression guard

Also re-ran (all green, unchanged behavior): `tests/unit/combo-fusion-strategy.test.ts`, `tests/unit/combo-fusion-config-warn-6455.test.ts`, `tests/unit/fusion-partial-panel-failure-6454.test.ts`, `tests/unit/fusion-judge-model-6455.test.ts`, `tests/unit/fusion-judge-own-intelligence.test.ts`, `tests/unit/fusion-judge-survivor.test.ts`, `tests/unit/combo-strategy-fallbacks.test.ts`, `tests/integration/combo-matrix/fusion.test.ts`.

## Gates run locally

- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` — clean
- `npm run typecheck:core` — clean
- `npm run typecheck:noimplicit:core` — clean
- `node scripts/check/check-file-size.mjs` — OK (no growth on frozen files; new module keeps `combo.ts` within budget)
- `node scripts/check/check-complexity.mjs` — OK, 2056 violations == 2056 baseline (no regression)
- `npm run check:cycles` — no cycles
- `npm run check:docs-sync` — PASS

Note: the repo-wide `npm run test:coverage` (60/60/60/60) gate could not be completed locally in this session due to severe shared-devbox resource exhaustion (multiple parallel sessions running full-suite coverage concurrently drove load average >100 on 16 cores and filled the root filesystem to 100%, independent of this change). CI will run this gate in an isolated runner.

Closes #6764