### PR TITLE
feat(db): include xp_audit_log in automatic retention/prune (#6801)

### DIFF
--- a/changelog.d/features/6801-xp-audit-log-retention.md
+++ b/changelog.d/features/6801-xp-audit-log-retention.md
@@ -1,0 +1,1 @@
+- feat(db): include `xp_audit_log` in the automatic retention/prune cycle, with a configurable `retention.xpAuditLog` setting (#6801)

--- a/src/app/(dashboard)/dashboard/settings/components/SystemStorageTab.tsx
+++ b/src/app/(dashboard)/dashboard/settings/components/SystemStorageTab.tsx
@@ -910,6 +910,7 @@ export default function SystemStorageTab() {
       ["callLogs", t("retentionCallLogs"), 30],
       ["usageHistory", t("retentionUsageHistory"), 30],
       ["memoryEntries", t("retentionMemoryEntries"), 30],
+      ["xpAuditLog", t("retentionXpAuditLog"), 30],
     ];
 
     return (

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -5949,6 +5949,7 @@
     "retentionCallLogs": "Call Logs (days)",
     "retentionUsageHistory": "Usage History (days)",
     "retentionMemoryEntries": "Memory Entries (days)",
+    "retentionXpAuditLog": "XP Audit Log (days)",
     "saveRetentionSettings": "Save retention settings",
     "storageAutoVacuumMode": "Auto Vacuum Mode",
     "storageScheduledVacuum": "Scheduled Vacuum",

--- a/src/i18n/messages/pt-BR.json
+++ b/src/i18n/messages/pt-BR.json
@@ -5911,6 +5911,7 @@
     "retentionCallLogs": "Registros de chamadas (dias)",
     "retentionUsageHistory": "Histórico de uso (dias)",
     "retentionMemoryEntries": "Entradas de memória (dias)",
+    "retentionXpAuditLog": "Log de Auditoria de XP (dias)",
     "saveRetentionSettings": "__MISSING__:Save retention settings",
     "storageAutoVacuumMode": "Modo de vácuo automático",
     "storageScheduledVacuum": "Vácuo programado",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -5810,6 +5810,7 @@
     "retentionCallLogs": "Registros de chamadas (dias)",
     "retentionUsageHistory": "Histórico de uso (dias)",
     "retentionMemoryEntries": "Entradas de memória (dias)",
+    "retentionXpAuditLog": "Log de Auditoria de XP (dias)",
     "saveRetentionSettings": "__MISSING__:Save retention settings",
     "storageAutoVacuumMode": "Modo de vácuo automático",
     "storageScheduledVacuum": "Vácuo programado",

--- a/src/lib/db/cleanup.ts
+++ b/src/lib/db/cleanup.ts
@@ -245,6 +245,36 @@ export async function cleanupMemoryEntries(): Promise<CleanupResult> {
 }
 
 /**
+ * Clean up old xp_audit_log based on retention settings.
+ */
+export async function cleanupXpAuditLog(): Promise<CleanupResult> {
+  const db = getDbInstance();
+  const retention = getRetentionSettings();
+
+  const retentionDays = retention.xpAuditLog;
+  const cutoffDate = new Date();
+  cutoffDate.setDate(cutoffDate.getDate() - retentionDays);
+  const cutoffISO = cutoffDate.toISOString();
+
+  const result: CleanupResult = { deleted: 0, errors: 0 };
+
+  try {
+    const stmt = db.prepare("DELETE FROM xp_audit_log WHERE created_at < ?");
+    const runResult = stmt.run(cutoffISO);
+    result.deleted = runResult.changes;
+
+    console.log(
+      `[Cleanup] Deleted ${result.deleted} xp_audit_log older than ${retentionDays} days`
+    );
+  } catch (err: unknown) {
+    console.error("[Cleanup] Error cleaning xp_audit_log:", err);
+    result.errors++;
+  }
+
+  return result;
+}
+
+/**
  * Run all cleanup functions if auto-cleanup is enabled.
  */
 export async function runAutoCleanup(): Promise<{
@@ -270,6 +300,7 @@ export async function runAutoCleanup(): Promise<{
     mcpAudit: await cleanupMcpAudit(),
     a2aEvents: await cleanupA2aEvents(),
     memoryEntries: await cleanupMemoryEntries(),
+    xpAuditLog: await cleanupXpAuditLog(),
     proxyLogs: await cleanupProxyLogs(),
   };
 

--- a/src/lib/db/databaseSettings.ts
+++ b/src/lib/db/databaseSettings.ts
@@ -49,6 +49,7 @@ const LEGACY_FLAT_KEYS: {
     callLogs: ["callLogs"],
     usageHistory: ["usageHistory"],
     memoryEntries: ["memoryEntries"],
+    xpAuditLog: ["xpAuditLog"],
     autoCleanupEnabled: ["autoCleanupEnabled"],
   },
   aggregation: {

--- a/src/shared/validation/settingsSchemas.ts
+++ b/src/shared/validation/settingsSchemas.ts
@@ -379,6 +379,7 @@ export const databaseSettingsSchema = z
       callLogs: z.number().int().min(1).max(3650),
       usageHistory: z.number().int().min(1).max(3650),
       memoryEntries: z.number().int().min(1).max(3650),
+      xpAuditLog: z.number().int().min(1).max(365),
       autoCleanupEnabled: z.boolean(),
     }),
 

--- a/src/types/databaseSettings.ts
+++ b/src/types/databaseSettings.ts
@@ -46,6 +46,7 @@ export interface DatabaseSettings {
     callLogs: number;
     usageHistory: number;
     memoryEntries: number;
+    xpAuditLog: number;
     autoCleanupEnabled: boolean;
   };
 
@@ -106,6 +107,7 @@ export const DEFAULT_DATABASE_SETTINGS: Omit<DatabaseSettings, "location" | "sta
     callLogs: 30,
     usageHistory: 30,
     memoryEntries: 30,
+    xpAuditLog: 30,
     autoCleanupEnabled: true,
   },
   aggregation: {

--- a/tests/unit/db-cleanup-xp-audit-log.test.ts
+++ b/tests/unit/db-cleanup-xp-audit-log.test.ts
@@ -1,0 +1,122 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-xp-audit-cleanup-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.DISABLE_SQLITE_AUTO_BACKUP = "true";
+
+const core = await import("../../src/lib/db/core.ts");
+const databaseSettings = await import("../../src/lib/db/databaseSettings.ts");
+const databaseSettingsRoute = await import("../../src/app/api/settings/database/route.ts");
+const cleanup = await import("../../src/lib/db/cleanup.ts");
+
+type CountRow = {
+  count: number;
+};
+
+function resetStorage() {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+function makeJsonRequest(method: string, body?: unknown): Request {
+  return new Request("http://localhost/api/settings/database", {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+function insertXpAuditLogRow(createdAt: string) {
+  const db = core.getDbInstance();
+  db.prepare(
+    `INSERT INTO xp_audit_log (api_key_id, action, xp_earned, metadata, created_at)
+     VALUES (?, ?, ?, ?, ?)`
+  ).run("test-api-key", "test-action", 10, null, createdAt);
+}
+
+function countXpAuditLogRows(): number {
+  const db = core.getDbInstance();
+  const row = db.prepare("SELECT COUNT(*) AS count FROM xp_audit_log").get() as CountRow;
+  return row.count;
+}
+
+test.beforeEach(() => {
+  resetStorage();
+});
+
+test.after(() => {
+  resetStorage();
+});
+
+test("cleanupXpAuditLog deletes rows older than the retention window and keeps recent rows", async () => {
+  const oldCreatedAt = new Date(Date.now() - 40 * 24 * 60 * 60 * 1000).toISOString();
+  const recentCreatedAt = new Date().toISOString();
+
+  insertXpAuditLogRow(oldCreatedAt);
+  insertXpAuditLogRow(recentCreatedAt);
+
+  const result = await cleanup.cleanupXpAuditLog();
+
+  assert.equal(result.errors, 0);
+  assert.equal(result.deleted, 1);
+  assert.equal(countXpAuditLogRows(), 1);
+});
+
+test("runAutoCleanup includes an xpAuditLog result with numeric deleted/errors fields", async () => {
+  const oldCreatedAt = new Date(Date.now() - 40 * 24 * 60 * 60 * 1000).toISOString();
+  insertXpAuditLogRow(oldCreatedAt);
+
+  const result = await cleanup.runAutoCleanup();
+
+  assert.ok(result.results.xpAuditLog);
+  assert.equal(typeof result.results.xpAuditLog.deleted, "number");
+  assert.equal(typeof result.results.xpAuditLog.errors, "number");
+  assert.equal(result.results.xpAuditLog.deleted, 1);
+  assert.equal(countXpAuditLogRows(), 0);
+});
+
+test("cleanupXpAuditLog honors a configurable retention.xpAuditLog value", async () => {
+  const tenDaysAgo = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
+  insertXpAuditLogRow(tenDaysAgo);
+
+  const current = databaseSettings.getUserDatabaseSettings();
+  databaseSettings.updateDatabaseSettings({
+    retention: { ...current.retention, xpAuditLog: 15 },
+  });
+
+  let result = await cleanup.cleanupXpAuditLog();
+  assert.equal(result.deleted, 0);
+  assert.equal(countXpAuditLogRows(), 1);
+
+  databaseSettings.updateDatabaseSettings({
+    retention: { ...databaseSettings.getUserDatabaseSettings().retention, xpAuditLog: 5 },
+  });
+
+  result = await cleanup.cleanupXpAuditLog();
+  assert.equal(result.deleted, 1);
+  assert.equal(countXpAuditLogRows(), 0);
+});
+
+test("PATCH /api/settings/database round-trips retention.xpAuditLog without stripping it", async () => {
+  const current = databaseSettings.getUserDatabaseSettings();
+  const response = await databaseSettingsRoute.PATCH(
+    makeJsonRequest("PATCH", {
+      retention: { ...current.retention, xpAuditLog: 45 },
+    }) as never
+  );
+  const body = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.equal(body.retention.xpAuditLog, 45);
+
+  const getResponse = await databaseSettingsRoute.GET(makeJsonRequest("GET") as never);
+  const getBody = await getResponse.json();
+
+  assert.equal(getResponse.status, 200);
+  assert.equal(getBody.retention.xpAuditLog, 45);
+});


### PR DESCRIPTION
`xp_audit_log` had no cleanup path anywhere — neither `runAutoCleanup()` in `src/lib/db/cleanup.ts` nor the separate compliance `cleanupExpiredLogs()` pipeline referenced it, so the table grew unbounded.

## What changed
- New `cleanupXpAuditLog()` in `src/lib/db/cleanup.ts`, mirroring the existing `cleanupMemoryEntries()`/`cleanupMcpAudit()` pattern, wired into `runAutoCleanup()`.
- New configurable `retention.xpAuditLog` setting (default 30 days) across the type, the DB settings module, the legacy-flat-key map and the Settings → System Storage UI (en/pt).
- **Zod schema updated too** (`src/shared/validation/settingsSchemas.ts`): without this, `PATCH /api/settings/database` would silently strip `retention.xpAuditLog` from the request body, making the configurable retention non-functional.

## Validation (Hard Rule #18 — TDD)
`tests/unit/db-cleanup-xp-audit-log.test.ts` — 4/4 passing:
- deletes rows older than the retention window and keeps recent rows
- `runAutoCleanup` includes an `xpAuditLog` result with numeric deleted/errors
- honors a configurable `retention.xpAuditLog` value
- `PATCH /api/settings/database` round-trips `retention.xpAuditLog` without stripping it

Gates green: scoped eslint, `typecheck:core`, `check-file-size`.

Closes #6801