### PR TITLE
Fix nested Responses output content normalization

### DIFF
--- a/open-sse/services/responsesInputSanitizer.ts
+++ b/open-sse/services/responsesInputSanitizer.ts
@@ -92,6 +92,29 @@ function sanitizeMessageContent(record: JsonRecord): JsonRecord {
   return { ...record, content };
 }
 
+function sanitizeNestedOutputPart(part: unknown): unknown {
+  const record = toRecord(part);
+  if (!record) return part;
+
+  // `output` on replayed items is an input-side container. Its content uses
+  // input content-part types even when the enclosing item originated from an
+  // assistant/tool response. Converting an image placeholder to output_text
+  // here makes Codex reject the request with the inverse 400.
+  if (record.type === "output_text" || record.type === "refusal") {
+    const next: JsonRecord = { ...record, type: "input_text" };
+    if (typeof next.text !== "string") {
+      next.text = typeof record.refusal === "string" ? record.refusal : "";
+    }
+    delete next.annotations;
+    delete next.logprobs;
+    delete next.obfuscation;
+    delete next.refusal;
+    return next;
+  }
+
+  return sanitizeContentPart(part, "user");
+}
+
 function sanitizeOutputContent(record: JsonRecord): JsonRecord {
   if (!Array.isArray(record.output)) return record;
 
@@ -99,8 +122,7 @@ function sanitizeOutputContent(record: JsonRecord): JsonRecord {
   // Responses input. In that shape OpenAI validates `input[n].output[m].type`
   // against output content part types, so legacy Chat-style `image_url` parts
   // must be normalized here too, not only in message.content.
-  const role = record.type === "function_call_output" ? "user" : "assistant";
-  const output = record.output.map((part) => sanitizeContentPart(part, role));
+  const output = record.output.map(sanitizeNestedOutputPart);
   return { ...record, output };
 }
 

--- a/tests/unit/responses-input-sanitizer-name.test.ts
+++ b/tests/unit/responses-input-sanitizer-name.test.ts
@@ -78,7 +78,9 @@ test("normalizes user image_url content parts to input_image", () => {
     {
       type: "message",
       role: "user",
-      content: [{ type: "image_url", image_url: { url: "https://example.com/u.png", detail: "high" } }],
+      content: [
+        { type: "image_url", image_url: { url: "https://example.com/u.png", detail: "high" } },
+      ],
     },
   ];
   const result = sanitizeResponsesInputItems(items) as Array<Record<string, unknown>>;
@@ -111,7 +113,7 @@ test("normalizes assistant image content parts to output_text", () => {
   });
 });
 
-test("normalizes replayed Responses output image parts to output_text", () => {
+test("normalizes replayed Responses output image parts to input_image", () => {
   const items = [
     {
       type: "message",
@@ -123,9 +125,57 @@ test("normalizes replayed Responses output image parts to output_text", () => {
   assert.deepEqual(result[0], {
     type: "message",
     role: "assistant",
-    output: [{ type: "output_text", text: "[Image: https://example.com/output.png]" }],
+    output: [{ type: "input_image", image_url: "https://example.com/output.png" }],
   });
-  assert.equal(JSON.stringify(result).includes('"image_url"'), false);
+  assert.equal(JSON.stringify(result).includes('"type":"image_url"'), false);
+});
+
+test("normalizes nested output_text parts to input_text", () => {
+  const items = [
+    {
+      type: "function_call_output",
+      call_id: "call_2",
+      output: [
+        {
+          type: "output_text",
+          text: "tool result",
+          annotations: [],
+          logprobs: [],
+          obfuscation: "opaque",
+        },
+      ],
+    },
+  ];
+  const result = sanitizeResponsesInputItems(items) as Array<Record<string, unknown>>;
+  assert.deepEqual(result[0], {
+    type: "function_call_output",
+    call_id: "call_2",
+    output: [{ type: "input_text", text: "tool result" }],
+  });
+});
+
+test("normalizes nested refusal parts to input_text", () => {
+  const items = [
+    {
+      type: "function_call_output",
+      call_id: "call_3",
+      output: [
+        {
+          type: "refusal",
+          refusal: "I can't help with that.",
+          annotations: [],
+          logprobs: [],
+          obfuscation: "opaque",
+        },
+      ],
+    },
+  ];
+  const result = sanitizeResponsesInputItems(items) as Array<Record<string, unknown>>;
+  assert.deepEqual(result[0], {
+    type: "function_call_output",
+    call_id: "call_3",
+    output: [{ type: "input_text", text: "I can't help with that." }],
+  });
 });
 
 test("normalizes function_call_output image output parts to input_image", () => {


### PR DESCRIPTION
## Summary

- Normalize nested `output_text` and `refusal` parts in replayed Responses input to `input_text`.
- Preserve nested image content as `input_image`.
- Remove output-only metadata that Codex rejects on replayed input items.

## Root cause

Replayed Responses `output` arrays are input-side containers. Their nested parts must use input content-part types even when the enclosing item originated from assistant or tool output.

## Validation

- `node --import tsx/esm --test tests/unit/responses-input-sanitizer-name.test.ts` (14 passing)
- `npx eslint open-sse/services/responsesInputSanitizer.ts tests/unit/responses-input-sanitizer-name.test.ts`

Split from #7154 at the maintainer's request.